### PR TITLE
Add the ROM importer: species data, palettes and sprites

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ the same thing for Generation 1.
 
 > ### Status: early
 >
-> The project skeleton and the ROM import gate exist and are tested. The
-> importer, renderer, overworld, battle system, audio and mod loader do not
+> The import gate and the first half of the importer exist and are tested: a
+> verified cartridge decodes into species data, palettes and every Pokémon
+> sprite. The renderer, overworld, battle system, audio and mod loader do not
 > exist yet. There is nothing playable here today.
 
 ## Getting started
@@ -50,6 +51,37 @@ Matching is by SHA-1, never by filename.
 An unrecognised hash is refused outright rather than imported on a best-effort
 basis: a cartridge whose bank layout has not been characterised produces
 corrupt assets instead of an honest error.
+
+## Importing
+
+Decoding a cartridge into the cache:
+
+```bash
+godot --headless --path . -s res://tools/import_rom.gd
+```
+
+Takes under a second per game. The cache lands in Godot's `user://` directory —
+never inside the project, because it is cartridge-derived data and subject to
+exactly the same rule as the ROM itself. Add `--verify` to run the checks
+without writing anything.
+
+Each import is keyed by game and hash, so two revisions never share a cache.
+What comes out today:
+
+| | |
+|---|---|
+| Species | Names, base stats, types, held items, egg groups, TM/HM flags |
+| Palettes | Normal and shiny, as the cartridge's own 15-bit colours |
+| Sprites | Front and back for all 251 species, plus all 26 Unown forms |
+
+Sprites are stored as colour indices rather than as images, and a palette is
+applied when they are drawn — which is the whole of what being shiny costs.
+
+To look at what was decoded:
+
+```bash
+godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png front
+```
 
 ## Running
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,11 +33,72 @@ The ROM layer is the model for the rest of the engine:
 - `game/rom/rom_registry.gd` — the SHA-1 allowlist.
 - `game/rom/rom_verifier.gd` — size pre-filter, then chunked SHA-1, then
   lookup.
+- `game/rom/rom_file.gd` — a verified dump in memory, plus bank addressing.
+- `game/rom/rom_header.gd` — the cartridge header, for diagnostics only.
 
-Both are `RefCounted` statics with no scene dependencies, so the import gate is
-fully testable headlessly. Keep the engine core the same shape: rules apart
-from content, and randomness injected as an explicit `RandomNumberGenerator`
-rather than pulled from a global, so a whole battle can play out inside a test.
+All of them are `RefCounted` statics with no scene dependencies, so the import
+gate is fully testable headlessly. Keep the engine core the same shape: rules
+apart from content, and randomness injected as an explicit
+`RandomNumberGenerator` rather than pulled from a global, so a whole battle can
+play out inside a test.
+
+The importer under `game/import/` decodes a verified cartridge into a cache:
+
+| | |
+|---|---|
+| `lz_decompressor.gd` | The LZ variant every compressed graphic uses |
+| `tile_codec.gd` | 2bpp tiles to colour indices; pic layout |
+| `text_codec.gd` | The Generation 2 character encoding |
+| `palette.gd` | 15-bit BGR colours |
+| `rom_layout.gd` | Where each table lives, per game |
+| `rom_cache.gd` | The `user://` cache: paths, formats, lifecycle |
+| `rom_importer.gd` | Orchestration, and the layout self-check |
+
+Each decoder takes bytes and returns data — none of them knows what a cartridge
+is, so all of them are testable on a handful of hand-built bytes.
+
+## Offsets, and why they are checked at runtime
+
+`rom_layout.gd` is a table of absolute positions inside each supported dump. An
+offset is a claim about a specific 2 MiB file, and a wrong one does not throw:
+it decodes neighbouring data into something plausible. A palette table that was
+one entire table too far along still produced 251 sprites — the right shapes in
+the wrong colours — and every unit test stayed green.
+
+So every offset ships with a check that would fail if it were wrong, and
+`RomImporter.verify_layout()` runs all of them before a single byte is decoded:
+
+- Species names are read through the text codec and compared against the first
+  and last species, which pins the offset, the stride and the character map at
+  once.
+- Every base stats entry begins with its own Pokédex number, so the whole table
+  self-checks in one pass.
+- Palettes have no self-identifying field, so they are checked structurally: a
+  colour is 15 bits, and no species is drawn in two blacks.
+
+When you add an offset, add its check. "It produced output" is not evidence.
+
+New offsets were found by searching the cartridge for content whose bytes are
+known independently — the encoded string `BULBASAUR`, a species' published base
+stats — and then confirming the *structure* against the
+[pret](https://github.com/pret) disassemblies, which are the reference for how
+these games are laid out. Do not copy an address out of a disassembly and
+assume it applies: those are bank:address pairs for a build of the source, and
+Gold, Silver and Crystal do not agree.
+
+## Seeing that a decode is right
+
+For anything graphical, look at it. `tools/preview_pics.gd` applies a palette to
+the cached indices and writes a PNG:
+
+```bash
+godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png front
+```
+
+A contact sheet of all 251 species is the fastest correctness check the project
+has — a bad decompressor, a wrong tile order, a wrong palette and an off-by-one
+in a pointer table all look obviously wrong, and all of them look fine in a
+manifest.
 
 ## Seeing the UI without pressing Play
 
@@ -80,6 +141,11 @@ so it cannot run under `--headless`.
 - **A `.tscn` root node with no `script =` line fails quietly.** The scene
   loads and every node resolves; it just does nothing. If a screen is inert,
   check the root kept its script line.
+- **JSON has one number type, so everything comes back as a float.** A species
+  number written as `1` reads back as `1.0`, and `read["number"] == 1` is
+  false. Anything loading the cache must coerce with `int()`; there is a test
+  in `test_rom_cache.gd` that pins this down so nobody rediscovers it the hard
+  way.
 - **GDScript lambdas capture by value.** Assigning to a captured local inside a
   `func():` closure updates the copy, not the original — the write silently
   vanishes. Append to an Array/Dictionary, or use a method.

--- a/game/import/lz_decompressor.gd
+++ b/game/import/lz_decompressor.gd
@@ -1,0 +1,170 @@
+class_name Gen2Lz
+extends RefCounted
+
+## The LZ variant Generation 1 and 2 use for every compressed graphic.
+##
+## A stream is a run of commands, terminated by $FF. Each command byte packs a
+## 3-bit opcode and a length; opcode 7 escapes to a long form that borrows two
+## more length bits and a following byte, so a single command can span up to
+## 1024 bytes.
+##
+##   000 literal    copy the next N bytes verbatim
+##   001 iterate    repeat the next byte N times
+##   010 alternate  repeat the next two bytes, alternating, N times
+##   011 zero       N zero bytes
+##   100 repeat     copy N bytes already written, forwards
+##   101 flipped    same, with each byte's bits reversed
+##   110 reversed   same, but reading backwards from the source
+##
+## The three back-references take an offset that is either a one-byte distance
+## back from the write head (high bit set) or a two-byte absolute position from
+## the start of the output (high bit clear). Sources may overlap the bytes being
+## written, which is how the format expresses runs — so the copy has to be
+## byte-at-a-time, not a slice.
+##
+## The bit-reversing opcode exists because these streams encode 2bpp tiles: a
+## mirrored sprite half is the same bytes with their bits flipped.
+
+enum Op {
+	LITERAL,
+	ITERATE,
+	ALTERNATE,
+	ZERO,
+	REPEAT,
+	FLIPPED,
+	REVERSED,
+	LONG,
+}
+
+const TERMINATOR: int = 0xFF
+const MAX_SHORT_LENGTH: int = 32
+const LONG_OFFSET_MASK: int = 0x80
+
+## No Gen 2 graphic decompresses to anything near this. It only bounds the
+## damage when a bad offset points at data that happens to decode forever.
+const MAX_OUTPUT: int = 0x4000
+
+## Set when the last decompression ran off the end of the data, hit an
+## impossible back-reference, or overran [constant MAX_OUTPUT].
+var failed: bool = false
+
+## Bytes of compressed input the last successful decompression consumed,
+## including the terminator.
+var consumed: int = 0
+
+static var _reversed_bits: PackedByteArray = PackedByteArray()
+
+
+## Decompresses the stream starting at [param offset]. Returns the decompressed
+## bytes, or an empty array on failure — check [member failed] to tell that
+## apart from a legitimately empty stream.
+func decompress(data: PackedByteArray, offset: int) -> PackedByteArray:
+	failed = false
+	consumed = 0
+
+	var out: PackedByteArray = PackedByteArray()
+	var pos: int = offset
+	var size: int = data.size()
+
+	while true:
+		if pos < 0 or pos >= size:
+			return _fail()
+
+		var command: int = data[pos]
+		pos += 1
+		if command == TERMINATOR:
+			consumed = pos - offset
+			return out
+
+		var op: int = command >> 5
+		var length: int = (command & 0x1F) + 1
+		if op == Op.LONG:
+			if pos >= size:
+				return _fail()
+			op = (command >> 2) & 0x07
+			length = (((command & 0x03) << 8) | data[pos]) + 1
+			pos += 1
+
+		match op:
+			Op.LITERAL:
+				if pos + length > size:
+					return _fail()
+				out.append_array(data.slice(pos, pos + length))
+				pos += length
+
+			Op.ITERATE:
+				if pos >= size:
+					return _fail()
+				var value: int = data[pos]
+				pos += 1
+				for _i: int in length:
+					out.append(value)
+
+			Op.ALTERNATE:
+				if pos + 2 > size:
+					return _fail()
+				var even: int = data[pos]
+				var odd: int = data[pos + 1]
+				pos += 2
+				for i: int in length:
+					out.append(odd if i & 1 else even)
+
+			Op.ZERO:
+				for _i: int in length:
+					out.append(0)
+
+			_:
+				if pos >= size:
+					return _fail()
+				var source: int = 0
+				var high: int = data[pos]
+				pos += 1
+				if high & LONG_OFFSET_MASK:
+					source = out.size() - (high & 0x7F) - 1
+				else:
+					if pos >= size:
+						return _fail()
+					source = (high << 8) | data[pos]
+					pos += 1
+
+				if source < 0 or source >= out.size():
+					return _fail()
+
+				var table: PackedByteArray = _bit_reversal_table()
+				for i: int in length:
+					var from: int = source - i if op == Op.REVERSED else source + i
+					if from < 0 or from >= out.size():
+						return _fail()
+					out.append(table[out[from]] if op == Op.FLIPPED else out[from])
+
+		if out.size() > MAX_OUTPUT:
+			return _fail()
+
+	return out
+
+
+## Convenience for callers that only care whether it worked.
+static func unpack(data: PackedByteArray, offset: int) -> PackedByteArray:
+	return Gen2Lz.new().decompress(data, offset)
+
+
+func _fail() -> PackedByteArray:
+	failed = true
+	consumed = 0
+	return PackedByteArray()
+
+
+static func _bit_reversal_table() -> PackedByteArray:
+	if not _reversed_bits.is_empty():
+		return _reversed_bits
+
+	var table: PackedByteArray = PackedByteArray()
+	table.resize(256)
+	for value: int in 256:
+		var flipped: int = 0
+		for bit: int in 8:
+			if value & (1 << bit):
+				flipped |= 1 << (7 - bit)
+		table[value] = flipped
+	_reversed_bits = table
+	return _reversed_bits

--- a/game/import/lz_decompressor.gd.uid
+++ b/game/import/lz_decompressor.gd.uid
@@ -1,0 +1,1 @@
+uid://btgu3trvll3ay

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -1,0 +1,61 @@
+class_name Gen2Palette
+extends RefCounted
+
+## Game Boy Color palette entries.
+##
+## A colour is 15 bits packed little-endian as $0BBBBBGG GGGRRRRR — five bits
+## per channel, red in the low bits. The hardware ignores bit 15.
+##
+## A Pokémon's stored palette holds only two colours. The other two are implied:
+## every pic uses index 0 for white and index 3 for black, so only the middle
+## pair varies. Each species stores two such pairs, normal and shiny, which is
+## the whole of what being shiny means to the renderer.
+
+const COLOR_BYTES: int = 2
+## Two colours, normal and shiny.
+const ENTRY_BYTES: int = 8
+const COLORS_PER_PIC: int = 4
+
+
+static func decode_color(data: PackedByteArray, offset: int) -> Color:
+	if offset < 0 or offset + COLOR_BYTES > data.size():
+		return Color.MAGENTA
+	return from_packed(data[offset] | (data[offset + 1] << 8))
+
+
+## The cache stores colours as the cartridge's own 15-bit value rather than as
+## anything wider, so nothing is rounded on the way in and out.
+static func from_packed(packed: int) -> Color:
+	return Color(
+		_expand(packed & 0x1F),
+		_expand((packed >> 5) & 0x1F),
+		_expand((packed >> 10) & 0x1F),
+	)
+
+
+## The four colours a pic is drawn with, in index order.
+static func pic_palette(middle: PackedColorArray) -> PackedColorArray:
+	var out: PackedColorArray = PackedColorArray([Color.WHITE])
+	out.append_array(middle)
+	out.append(Color.BLACK)
+	return out
+
+
+## Reads one species' entry as { normal, shiny }, each a two-colour array.
+static func decode_entry(data: PackedByteArray, offset: int) -> Dictionary:
+	return {
+		"normal": PackedColorArray([
+			decode_color(data, offset),
+			decode_color(data, offset + COLOR_BYTES),
+		]),
+		"shiny": PackedColorArray([
+			decode_color(data, offset + COLOR_BYTES * 2),
+			decode_color(data, offset + COLOR_BYTES * 3),
+		]),
+	}
+
+
+## 5 bits to a float. Scaling by 31 rather than 32 keeps $1F exactly white,
+## which matters because the two implied colours are pure white and black.
+static func _expand(component: int) -> float:
+	return float(component) / 31.0

--- a/game/import/palette.gd.uid
+++ b/game/import/palette.gd.uid
@@ -1,0 +1,1 @@
+uid://bls8bl7rppfnt

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -1,0 +1,120 @@
+class_name RomCache
+extends RefCounted
+
+## Where decoded cartridge data lives between runs.
+##
+## Under [code]user://[/code], never inside the project: the cache is derived
+## from a commercial cartridge, so it must not be committed and must not end up
+## in an export. Keeping it here is the runtime half of the rule the .gitignore
+## and the pre-commit hook enforce at build time.
+##
+## One directory per dump, named by game and hash, so two revisions of the same
+## game never share a cache and a re-import cannot half-overwrite the last one.
+##
+## Pixel data is stored as raw colour indices rather than as images. It is what
+## the renderer wants — palettes are applied per species and per shiny state at
+## draw time — and it avoids a decode round-trip whose exactness would have to
+## be trusted.
+
+const ROOT: String = "user://rom_cache"
+const MANIFEST: String = "manifest.json"
+const SPECIES: String = "species.json"
+const PICS_DIR: String = "pics"
+
+## Bumped whenever the on-disk shape changes. A cache written by an older
+## importer is discarded rather than migrated.
+const FORMAT_VERSION: int = 1
+
+
+static func directory_for(id: StringName, sha1: String) -> String:
+	return "%s/%s_%s" % [ROOT, id, sha1.substr(0, 8)]
+
+
+static func manifest_path(directory: String) -> String:
+	return "%s/%s" % [directory, MANIFEST]
+
+
+static func species_path(directory: String) -> String:
+	return "%s/%s" % [directory, SPECIES]
+
+
+static func pic_path(directory: String, name: String) -> String:
+	return "%s/%s/%s.idx" % [directory, PICS_DIR, name]
+
+
+static func prepare(directory: String) -> bool:
+	return DirAccess.make_dir_recursive_absolute("%s/%s" % [directory, PICS_DIR]) == OK
+
+
+## True when [param directory] holds a complete cache this build can read.
+static func is_usable(directory: String) -> bool:
+	var manifest: Dictionary = read_manifest(directory)
+	if manifest.is_empty():
+		return false
+	return int(manifest.get("format_version", -1)) == FORMAT_VERSION \
+		and bool(manifest.get("complete", false))
+
+
+static func read_manifest(directory: String) -> Dictionary:
+	var value: Variant = read_json(manifest_path(directory))
+	return value if value is Dictionary else {}
+
+
+static func write_json(path: String, value: Variant) -> bool:
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_string(JSON.stringify(value, "\t"))
+	file.close()
+	return true
+
+
+static func read_json(path: String) -> Variant:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return null
+	var text: String = file.get_as_text()
+	file.close()
+	return JSON.parse_string(text)
+
+
+## Index buffers are mostly runs of the same value, so they compress hard —
+## roughly ten to one for a pic atlas.
+static func write_indices(path: String, data: PackedByteArray) -> bool:
+	var file: FileAccess = FileAccess.open_compressed(
+		path, FileAccess.WRITE, FileAccess.COMPRESSION_ZSTD
+	)
+	if file == null:
+		return false
+	file.store_buffer(data)
+	file.close()
+	return true
+
+
+static func read_indices(path: String) -> PackedByteArray:
+	var file: FileAccess = FileAccess.open_compressed(
+		path, FileAccess.READ, FileAccess.COMPRESSION_ZSTD
+	)
+	if file == null:
+		return PackedByteArray()
+	var data: PackedByteArray = file.get_buffer(file.get_length())
+	file.close()
+	return data
+
+
+## Deletes a cache directory and everything below it.
+static func clear(directory: String) -> void:
+	var dir: DirAccess = DirAccess.open(directory)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var name: String = dir.get_next()
+	while name != "":
+		var full: String = "%s/%s" % [directory, name]
+		if dir.current_is_dir():
+			clear(full)
+		else:
+			DirAccess.remove_absolute(full)
+		name = dir.get_next()
+	dir.list_dir_end()
+	DirAccess.remove_absolute(directory)

--- a/game/import/rom_cache.gd.uid
+++ b/game/import/rom_cache.gd.uid
@@ -1,0 +1,1 @@
+uid://bbyfwww6qsgqv

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -1,0 +1,307 @@
+class_name RomImporter
+extends RefCounted
+
+## Decodes a verified cartridge into the cache under [code]user://[/code].
+##
+## The ROM is an asset database, read once and released. Nothing downstream of
+## the cache holds a reference to it, and nothing in the engine reads cartridge
+## bytes at play time.
+##
+## Order of business, and it matters: verify the hash, then verify the layout,
+## then decode. [method verify_layout] exists because an offset table is a claim
+## that can rot — a wrong constant produces plausible-looking garbage rather
+## than an error, and garbage that reaches the cache is indistinguishable from
+## real data later on. Checking a handful of values whose correct answers are
+## known independently turns that class of mistake into an immediate failure.
+
+## Atlas cells are the largest pic of their kind so a renderer can index them
+## arithmetically; smaller pics sit in the top-left of their cell and record
+## their real size.
+const ATLAS_COLUMNS: int = 16
+
+var _lz: Gen2Lz = Gen2Lz.new()
+
+
+## Sanity-checks [RomLayout] against the cartridge before anything is decoded.
+## Returns { ok, message }.
+static func verify_layout(rom: RomFile) -> Dictionary:
+	var layout: Dictionary = RomLayout.for_id(rom.id)
+	if layout.is_empty():
+		return {"ok": false, "message": "No layout for %s." % rom.id}
+
+	var data: PackedByteArray = rom.bytes()
+
+	# The first and last species, decoded through the text codec. Wrong offset,
+	# wrong table or wrong character map all fail here.
+	var first: String = Gen2Text.decode(
+		data, RomLayout.species_name_offset(layout, 1), RomLayout.NAME_LENGTH
+	)
+	if first != "BULBASAUR":
+		return {"ok": false, "message": "Species name table: expected BULBASAUR, read %s." % first}
+
+	var last: String = Gen2Text.decode(
+		data, RomLayout.species_name_offset(layout, RomLayout.SPECIES_COUNT),
+		RomLayout.NAME_LENGTH
+	)
+	if last != "CELEBI":
+		return {"ok": false, "message": "Species name table: expected CELEBI, read %s." % last}
+
+	# Every base stats entry opens with its own Pokédex number, so the whole
+	# table self-checks in one pass — and a stride that is off by any amount
+	# stops matching immediately.
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var stored: int = rom.u8(RomLayout.base_stats_offset(layout, species))
+		if stored != species:
+			return {
+				"ok": false,
+				"message": "Base stats entry %d claims to be %d." % [species, stored],
+			}
+
+	# Palettes have no self-identifying field, so they are checked structurally:
+	# a colour is 15 bits, and no species is drawn in two blacks. An offset that
+	# lands on the wrong table, or a stride that runs past the end of the right
+	# one, breaks one of those. This check exists because a palette table that
+	# was one whole table too far along still decoded — into sprites that were
+	# the correct shapes in the wrong colours, which nothing else would catch.
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var entry: int = RomLayout.palette_offset(layout, species)
+		var packed: Array = []
+		for i: int in Gen2Palette.ENTRY_BYTES / Gen2Palette.COLOR_BYTES:
+			packed.append(rom.u16le(entry + i * Gen2Palette.COLOR_BYTES))
+		for color: int in packed:
+			if color & 0x8000:
+				return {
+					"ok": false,
+					"message": "Palette %d has bit 15 set ($%04X); not colour data." % [
+						species, color,
+					],
+				}
+		if packed.count(0) == packed.size():
+			return {"ok": false, "message": "Palette %d is blank." % species}
+
+	return {"ok": true, "message": "Layout verified."}
+
+
+## Imports [param rom] into its cache directory, replacing whatever was there.
+##
+## [param on_progress] is called as [code](stage, done, total)[/code] if given.
+## Returns { ok, message, directory, species, elapsed_ms }.
+func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
+	var started: int = Time.get_ticks_msec()
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var result: Dictionary = {
+		"ok": false,
+		"message": "",
+		"directory": directory,
+		"species": 0,
+		"elapsed_ms": 0,
+	}
+
+	var layout: Dictionary = RomLayout.for_id(rom.id)
+	var check: Dictionary = verify_layout(rom)
+	if not check["ok"]:
+		result["message"] = check["message"]
+		return result
+
+	# A half-written cache from an interrupted run must not be mistaken for a
+	# good one, so the old directory goes before the new one is built and the
+	# manifest is only marked complete at the very end.
+	RomCache.clear(directory)
+	if not RomCache.prepare(directory):
+		result["message"] = "Could not create %s." % directory
+		return result
+
+	var species: Array = _import_species(rom, layout, on_progress)
+	if species.is_empty():
+		result["message"] = "Decoded no species."
+		return result
+
+	var pics: Dictionary = _import_pics(rom, layout, species, on_progress)
+	if pics.is_empty():
+		result["message"] = "Could not decode pics."
+		return result
+
+	if not RomCache.write_json(RomCache.species_path(directory), species):
+		result["message"] = "Could not write species data."
+		return result
+
+	var manifest: Dictionary = {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": String(rom.id),
+		"sha1": rom.sha1,
+		"species_count": species.size(),
+		"atlases": pics,
+		"complete": true,
+	}
+	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
+		result["message"] = "Could not write manifest."
+		return result
+
+	result["ok"] = true
+	result["species"] = species.size()
+	result["elapsed_ms"] = Time.get_ticks_msec() - started
+	result["message"] = "Imported %d species in %d ms." % [species.size(), result["elapsed_ms"]]
+	return result
+
+
+func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
+	var data: PackedByteArray = rom.bytes()
+	var out: Array = []
+
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var stats: int = RomLayout.base_stats_offset(layout, species)
+		var dimensions: int = rom.u8(stats + RomLayout.OFFSET_PIC_SIZE)
+		var egg_groups: int = rom.u8(stats + RomLayout.OFFSET_EGG_GROUPS)
+		var palette: int = RomLayout.palette_offset(layout, species)
+
+		out.append({
+			"number": species,
+			"name": Gen2Text.decode(
+				data, RomLayout.species_name_offset(layout, species), RomLayout.NAME_LENGTH
+			),
+			"stats": {
+				"hp": rom.u8(stats + RomLayout.STAT_HP),
+				"attack": rom.u8(stats + RomLayout.STAT_ATTACK),
+				"defense": rom.u8(stats + RomLayout.STAT_DEFENSE),
+				"speed": rom.u8(stats + RomLayout.STAT_SPEED),
+				"sp_attack": rom.u8(stats + RomLayout.STAT_SP_ATTACK),
+				"sp_defense": rom.u8(stats + RomLayout.STAT_SP_DEFENSE),
+			},
+			"types": [
+				rom.u8(stats + RomLayout.OFFSET_TYPE1),
+				rom.u8(stats + RomLayout.OFFSET_TYPE2),
+			],
+			"catch_rate": rom.u8(stats + RomLayout.OFFSET_CATCH_RATE),
+			"base_exp": rom.u8(stats + RomLayout.OFFSET_BASE_EXP),
+			"held_items": [
+				rom.u8(stats + RomLayout.OFFSET_ITEM1),
+				rom.u8(stats + RomLayout.OFFSET_ITEM2),
+			],
+			"gender_ratio": rom.u8(stats + RomLayout.OFFSET_GENDER_RATIO),
+			"hatch_cycles": rom.u8(stats + RomLayout.OFFSET_HATCH_CYCLES),
+			"growth_rate": rom.u8(stats + RomLayout.OFFSET_GROWTH_RATE),
+			"egg_groups": [egg_groups >> 4, egg_groups & 0x0F],
+			"tmhm": Array(rom.slice(stats + RomLayout.OFFSET_TMHM, RomLayout.TMHM_BYTES)),
+			"front_tiles": [dimensions & 0x0F, dimensions >> 4],
+			"palette": {
+				"normal": [rom.u16le(palette), rom.u16le(palette + 2)],
+				"shiny": [rom.u16le(palette + 4), rom.u16le(palette + 6)],
+			},
+		})
+
+		if on_progress.is_valid():
+			on_progress.call("species", species, RomLayout.SPECIES_COUNT)
+
+	return out
+
+
+func _import_pics(
+	rom: RomFile, layout: Dictionary, species: Array, on_progress: Callable
+) -> Dictionary:
+	var front: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, RomLayout.SPECIES_COUNT)
+	var back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.SPECIES_COUNT)
+	var unown_front: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, RomLayout.UNOWN_FORMS)
+	var unown_back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.UNOWN_FORMS)
+
+	for entry: Dictionary in species:
+		var number: int = entry["number"]
+		var tiles: Array = entry["front_tiles"]
+		var slot: int = number - 1
+
+		# Unown's main-table entry is a placeholder. Its forms are decoded into
+		# their own atlas, and the species slot gets form A so a caller that
+		# does not know about forms still gets a sprite rather than a hole.
+		var source: int = number
+		if number == RomLayout.UNOWN_SPECIES:
+			for form: int in RomLayout.UNOWN_FORMS:
+				_decode_into(
+					rom, layout, RomLayout.unown_pic_pointer_offset(layout, form, false),
+					tiles[0], tiles[1], unown_front, form
+				)
+				_decode_into(
+					rom, layout, RomLayout.unown_pic_pointer_offset(layout, form, true),
+					RomLayout.BACKPIC_TILES, RomLayout.BACKPIC_TILES, unown_back, form
+				)
+			_decode_into(
+				rom, layout, RomLayout.unown_pic_pointer_offset(layout, 0, false),
+				tiles[0], tiles[1], front, slot
+			)
+			_decode_into(
+				rom, layout, RomLayout.unown_pic_pointer_offset(layout, 0, true),
+				RomLayout.BACKPIC_TILES, RomLayout.BACKPIC_TILES, back, slot
+			)
+		else:
+			_decode_into(
+				rom, layout, RomLayout.pic_pointer_offset(layout, source, false),
+				tiles[0], tiles[1], front, slot
+			)
+			_decode_into(
+				rom, layout, RomLayout.pic_pointer_offset(layout, source, true),
+				RomLayout.BACKPIC_TILES, RomLayout.BACKPIC_TILES, back, slot
+			)
+
+		if on_progress.is_valid():
+			on_progress.call("pics", number, RomLayout.SPECIES_COUNT)
+
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var atlases: Dictionary = {
+		"front": front, "back": back, "unown_front": unown_front, "unown_back": unown_back,
+	}
+	var written: Dictionary = {}
+	for name: String in atlases:
+		var atlas: Dictionary = atlases[name]
+		if not RomCache.write_indices(RomCache.pic_path(directory, name), atlas["pixels"]):
+			return {}
+		written[name] = {
+			"width": atlas["width"],
+			"height": atlas["height"],
+			"cell": atlas["cell"],
+			"columns": ATLAS_COLUMNS,
+			"decoded": atlas["decoded"],
+		}
+	return written
+
+
+func _new_atlas(cell_tiles: int, cells: int) -> Dictionary:
+	var cell: int = cell_tiles * Gen2Tiles.TILE_WIDTH
+	var rows: int = ceili(float(cells) / ATLAS_COLUMNS)
+	var width: int = ATLAS_COLUMNS * cell
+	var height: int = rows * cell
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(width * height)
+	return {
+		"pixels": pixels, "width": width, "height": height, "cell": cell, "decoded": 0,
+	}
+
+
+func _decode_into(
+	rom: RomFile,
+	layout: Dictionary,
+	pointer_offset: int,
+	columns: int,
+	rows: int,
+	atlas: Dictionary,
+	slot: int
+) -> bool:
+	if columns <= 0 or rows <= 0:
+		return false
+
+	var pointer: Dictionary = rom.far_pointer(pointer_offset)
+	var bank: int = RomLayout.fix_pic_bank(layout, pointer["bank"])
+	var start: int = RomFile.linear(bank, pointer["address"])
+	if not rom.in_bounds(start):
+		return false
+
+	var raw: PackedByteArray = _lz.decompress(rom.bytes(), start)
+	if _lz.failed or raw.size() < columns * rows * Gen2Tiles.TILE_BYTES:
+		return false
+
+	var pixels: PackedByteArray = Gen2Tiles.decode_pic(raw, columns, rows)
+	var cell: int = atlas["cell"]
+	Gen2Tiles.blit(
+		pixels, columns * Gen2Tiles.TILE_WIDTH,
+		atlas["pixels"], atlas["width"],
+		(slot % ATLAS_COLUMNS) * cell, (slot / ATLAS_COLUMNS) * cell
+	)
+	atlas["decoded"] = int(atlas["decoded"]) + 1
+	return true

--- a/game/import/rom_importer.gd.uid
+++ b/game/import/rom_importer.gd.uid
@@ -1,0 +1,1 @@
+uid://dcniy2wgbud1y

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1,0 +1,142 @@
+class_name RomLayout
+extends RefCounted
+
+## Where the data lives inside each supported cartridge.
+##
+## Offsets are absolute positions in the 2 MiB dump, not bank:address pairs, so
+## a decoder never has to think about banking. Gold and Silver share a layout;
+## Crystal moved almost everything and is its own table.
+##
+## Every offset here was located in the cartridges themselves — by searching for
+## content whose bytes are known independently (the encoded string "BULBASAUR",
+## Bulbasaur's published base stats) — and then cross-checked against the pret
+## disassemblies for structure. That is why there is no entry for a ROM that is
+## not in [RomRegistry]: an offset table is a claim about a specific dump, and
+## the honest answer for an uncharacterised one is a refusal, not a guess.
+##
+## An offset is only trustworthy alongside the check that proves it: see
+## [method RomImporter.verify_layout], which the importer runs before it decodes
+## anything.
+
+const SPECIES_COUNT: int = 251
+const NAME_LENGTH: int = 10
+const BASE_STATS_SIZE: int = 32
+const PIC_POINTER_SIZE: int = 3
+
+## Unown's entry in the main pic table is a deliberate $FF placeholder: its 26
+## letter forms live in a table of their own.
+const UNOWN_SPECIES: int = 201
+const UNOWN_FORMS: int = 26
+
+## Back pics are always this square. Front pics vary and carry their own size in
+## the base stats.
+const BACKPIC_TILES: int = 6
+## The battle screen's frontpic window, and so the atlas cell size.
+const FRONTPIC_MAX_TILES: int = 7
+
+## Byte positions within a 32-byte base stats entry.
+const STAT_HP: int = 1
+const STAT_ATTACK: int = 2
+const STAT_DEFENSE: int = 3
+const STAT_SPEED: int = 4
+const STAT_SP_ATTACK: int = 5
+const STAT_SP_DEFENSE: int = 6
+const OFFSET_TYPE1: int = 7
+const OFFSET_TYPE2: int = 8
+const OFFSET_CATCH_RATE: int = 9
+const OFFSET_BASE_EXP: int = 10
+const OFFSET_ITEM1: int = 11
+const OFFSET_ITEM2: int = 12
+const OFFSET_GENDER_RATIO: int = 13
+const OFFSET_HATCH_CYCLES: int = 15
+## Packed nibbles: width in the low half, height in the high half, in tiles.
+const OFFSET_PIC_SIZE: int = 17
+const OFFSET_GROWTH_RATE: int = 22
+## Packed nibbles, one egg group per half.
+const OFFSET_EGG_GROUPS: int = 23
+const OFFSET_TMHM: int = 24
+const TMHM_BYTES: int = 8
+
+## Gold and Silver are byte-identical in every table below; only content differs.
+const GOLD_SILVER: Dictionary = {
+	"species_names": 0x1B0B74,
+	"base_stats": 0x51B0B,
+	"pic_pointers": 0x48000,
+	"unown_pic_pointers": 0x7C000,
+	"palettes": 0xAD3D,
+	"move_names": 0x1B1574,
+	"item_names": 0x1B0000,
+	"move_data": 0x41AFE,
+	# Gold and Silver patch three bank numbers and pass the rest through. The
+	# stored value is what the linker assigned before three pic sections were
+	# moved; see FixPicBank in pokegold.
+	"pic_bank_add": 0,
+	"pic_bank_patch": {0x13: 0x1F, 0x14: 0x20, 0x1F: 0x2E},
+}
+
+const CRYSTAL: Dictionary = {
+	"species_names": 0x53384,
+	"base_stats": 0x51424,
+	"pic_pointers": 0x120000,
+	"unown_pic_pointers": 0x124000,
+	"palettes": 0xA8CE,
+	"move_names": 0x1C9F29,
+	"item_names": 0x1C8000,
+	"move_data": 0x41AFB,
+	# Crystal's equivalent table is a contiguous $48-$5F, so the whole remap
+	# collapses to a constant: PICS_FIX in pokecrystal.
+	"pic_bank_add": 0x36,
+	"pic_bank_patch": {},
+}
+
+
+## The layout for a game id, or an empty Dictionary if it is not characterised.
+static func for_id(id: StringName) -> Dictionary:
+	match id:
+		RomRegistry.GOLD, RomRegistry.SILVER:
+			return GOLD_SILVER
+		RomRegistry.CRYSTAL:
+			return CRYSTAL
+	return {}
+
+
+static func is_characterised(id: StringName) -> bool:
+	return not for_id(id).is_empty()
+
+
+## Translates the bank number stored in a pic pointer into the bank the data is
+## really in.
+##
+## The tables were written before the pic sections were shuffled between banks
+## and nobody rebuilt them, so the game repairs each pointer as it loads it.
+## Reproducing that is not optional — the stored numbers are simply wrong.
+static func fix_pic_bank(layout: Dictionary, stored: int) -> int:
+	var patch: Dictionary = layout["pic_bank_patch"]
+	if patch.has(stored):
+		return patch[stored]
+	return stored + int(layout["pic_bank_add"])
+
+
+static func species_name_offset(layout: Dictionary, species: int) -> int:
+	return int(layout["species_names"]) + (species - 1) * NAME_LENGTH
+
+
+static func base_stats_offset(layout: Dictionary, species: int) -> int:
+	return int(layout["base_stats"]) + (species - 1) * BASE_STATS_SIZE
+
+
+## The palette table carries a leading entry before Bulbasaur, so unlike every
+## other table here it is indexed by species number directly.
+static func palette_offset(layout: Dictionary, species: int) -> int:
+	return int(layout["palettes"]) + species * Gen2Palette.ENTRY_BYTES
+
+
+## Pointers come in pairs, front then back.
+static func pic_pointer_offset(layout: Dictionary, species: int, back: bool) -> int:
+	var pair: int = (species - 1) * 2 + (1 if back else 0)
+	return int(layout["pic_pointers"]) + pair * PIC_POINTER_SIZE
+
+
+static func unown_pic_pointer_offset(layout: Dictionary, form: int, back: bool) -> int:
+	var pair: int = form * 2 + (1 if back else 0)
+	return int(layout["unown_pic_pointers"]) + pair * PIC_POINTER_SIZE

--- a/game/import/rom_layout.gd.uid
+++ b/game/import/rom_layout.gd.uid
@@ -1,0 +1,1 @@
+uid://d2knn6unmici3

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -1,0 +1,153 @@
+class_name Gen2Text
+extends RefCounted
+
+## The Generation 2 character encoding, for the international ROMs.
+##
+## One byte per character, terminated by $50, with the alphabet laid out in
+## runs: $80 is "A", $A0 is "a", $F6 is "0". Several codes expand to whole
+## words ($5D is "TRAINER") or name the player at print time ($52); those are
+## kept as bracketed markers so a caller can substitute them, and so nothing is
+## silently lost.
+##
+## The Japanese cartridges reuse most of this range for kana. They are not in
+## [RomRegistry] and this table would decode them into nonsense, which is the
+## same reason the import gate refuses an unknown hash.
+
+const TERMINATOR: int = 0x50
+const SPACE: int = 0x7F
+
+static var _table: Dictionary = {}
+
+
+## Decodes bytes from [param offset] up to a terminator or [param max_length]
+## characters, whichever comes first.
+static func decode(data: PackedByteArray, offset: int, max_length: int) -> String:
+	var out: String = ""
+	for i: int in max_length:
+		var at: int = offset + i
+		if at < 0 or at >= data.size():
+			break
+		var byte: int = data[at]
+		if byte == TERMINATOR:
+			break
+		out += character(byte)
+	return out
+
+
+## A fixed-width field: the game pads names with $50 and reads a known number of
+## bytes, so trailing padding is stripped rather than treated as a terminator
+## mid-string.
+static func decode_fixed(data: PackedByteArray, offset: int, length: int) -> String:
+	return decode(data, offset, length)
+
+
+static func character(byte: int) -> String:
+	var table: Dictionary = _characters()
+	if table.has(byte):
+		return table[byte]
+	# Never silently drop a byte we do not understand: an unrecognised code in a
+	# name means the offset table is wrong, and that should be visible.
+	return "<%02X>" % byte
+
+
+static func _characters() -> Dictionary:
+	if not _table.is_empty():
+		return _table
+
+	var table: Dictionary = {}
+	for i: int in 26:
+		table[0x80 + i] = char("A".unicode_at(0) + i)
+		table[0xA0 + i] = char("a".unicode_at(0) + i)
+	for i: int in 10:
+		table[0xF6 + i] = char("0".unicode_at(0) + i)
+
+	table[SPACE] = " "
+	table[0x9A] = "("
+	table[0x9B] = ")"
+	table[0x9C] = ":"
+	table[0x9D] = ";"
+	table[0x9E] = "["
+	table[0x9F] = "]"
+	table[0xC0] = "Ä"
+	table[0xC1] = "Ö"
+	table[0xC2] = "Ü"
+	table[0xC3] = "ä"
+	table[0xC4] = "ö"
+	table[0xC5] = "ü"
+	table[0xE0] = "'"
+	table[0xE3] = "-"
+	table[0xE6] = "?"
+	table[0xE7] = "!"
+	table[0xE8] = "."
+	table[0xE9] = "&"
+	table[0xEA] = "é"
+	table[0xEB] = "→"
+	table[0xEC] = "▷"
+	table[0xED] = "▶"
+	table[0xEE] = "▼"
+	table[0xEF] = "♂"
+	table[0xF0] = "¥"
+	table[0xF1] = "×"
+	table[0xF2] = "."
+	table[0xF3] = "/"
+	table[0xF4] = ","
+	table[0xF5] = "♀"
+	table[0x6D] = ":"
+	table[0x72] = "“"
+	table[0x73] = "”"
+	table[0x74] = "·"
+	table[0x75] = "…"
+	table[0x79] = "┌"
+	table[0x7A] = "─"
+	table[0x7B] = "┐"
+	table[0x7C] = "│"
+	table[0x7D] = "└"
+	table[0x7E] = "┘"
+
+	# Apostrophe ligatures: one tile each, because the font has no room for a
+	# free-standing apostrophe followed by a letter.
+	table[0xD0] = "'d"
+	table[0xD1] = "'l"
+	table[0xD2] = "'m"
+	table[0xD3] = "'r"
+	table[0xD4] = "'s"
+	table[0xD5] = "'t"
+	table[0xD6] = "'v"
+
+	# Codes that stand for whole words at print time.
+	table[0x24] = "POKé"
+	table[0x4A] = "PKMN"
+	table[0x54] = "POKé"
+	table[0x5B] = "PC"
+	table[0x5C] = "TM"
+	table[0x5D] = "TRAINER"
+	table[0x5E] = "ROCKET"
+	table[0xE1] = "PK"
+	table[0xE2] = "MN"
+
+	# Substituted from RAM when the game prints them.
+	table[0x14] = "<PLAYER>"
+	table[0x38] = "<RED>"
+	table[0x39] = "<GREEN>"
+	table[0x3F] = "<ENEMY>"
+	table[0x49] = "<MOM>"
+	table[0x52] = "<PLAYER>"
+	table[0x53] = "<RIVAL>"
+	table[0x59] = "<TARGET>"
+	table[0x5A] = "<USER>"
+
+	# Line and box control.
+	table[0x16] = "\n"
+	table[0x22] = "\n"
+	table[0x4B] = "\n"
+	table[0x4C] = "\n"
+	table[0x4E] = "\n"
+	table[0x4F] = "\n"
+	table[0x51] = "\n\n"
+	table[0x55] = "\n"
+	table[0x56] = "……"
+	table[0x57] = ""
+	table[0x58] = ""
+
+	_table = table
+	return _table

--- a/game/import/text_codec.gd.uid
+++ b/game/import/text_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://c76jfwkkm8sxp

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -1,0 +1,96 @@
+class_name Gen2Tiles
+extends RefCounted
+
+## Game Boy 2bpp tile data to one-byte-per-pixel colour indices.
+##
+## A tile is 8x8 pixels in 16 bytes: two bytes per row, the first holding the
+## low bit of every pixel in that row and the second the high bit. Bit 7 is the
+## leftmost pixel.
+##
+## Decoding stops at indices 0-3. Turning those into colours needs a palette,
+## which is a separate concern — see [Gen2Palette]. Keeping the two apart is
+## what makes shiny variants free: same pixels, different palette.
+
+const TILE_WIDTH: int = 8
+const TILE_HEIGHT: int = 8
+const TILE_PIXELS: int = 64
+## Bytes of 2bpp data per tile.
+const TILE_BYTES: int = 16
+
+
+## Decodes one tile into [param out] starting at [param out_offset], as 8 rows
+## of 8 indices. [param out] must already be large enough.
+static func decode_tile_into(
+	data: PackedByteArray, offset: int, out: PackedByteArray, out_offset: int
+) -> void:
+	for row: int in TILE_HEIGHT:
+		var low: int = data[offset + row * 2]
+		var high: int = data[offset + row * 2 + 1]
+		for column: int in TILE_WIDTH:
+			var shift: int = 7 - column
+			var index: int = ((low >> shift) & 1) | (((high >> shift) & 1) << 1)
+			out[out_offset + row * TILE_WIDTH + column] = index
+
+
+static func decode_tile(data: PackedByteArray, offset: int) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(TILE_PIXELS)
+	if offset < 0 or offset + TILE_BYTES > data.size():
+		return out
+	decode_tile_into(data, offset, out, 0)
+	return out
+
+
+## Decodes a Pokémon or trainer pic into a row-major index buffer
+## [param columns] * 8 wide and [param rows] * 8 tall.
+##
+## Pics store their tiles column-major — the whole left column top to bottom,
+## then the next — because the game streams them into VRAM a column at a time.
+## Every other tilemap in these games is row-major, so this is the one place
+## that ordering flips.
+##
+## Trailing data is ignored: Crystal's front pics carry the frames of the
+## Pokédex animation after the still image, so a stream is routinely longer
+## than [param columns] * [param rows] tiles.
+static func decode_pic(data: PackedByteArray, columns: int, rows: int) -> PackedByteArray:
+	var width: int = columns * TILE_WIDTH
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(width * rows * TILE_HEIGHT)
+
+	if columns <= 0 or rows <= 0 or data.size() < columns * rows * TILE_BYTES:
+		return out
+
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(TILE_PIXELS)
+
+	for column: int in columns:
+		for row: int in rows:
+			var tile: int = column * rows + row
+			decode_tile_into(data, tile * TILE_BYTES, pixels, 0)
+			for y: int in TILE_HEIGHT:
+				var destination: int = (row * TILE_HEIGHT + y) * width + column * TILE_WIDTH
+				for x: int in TILE_WIDTH:
+					out[destination + x] = pixels[y * TILE_WIDTH + x]
+
+	return out
+
+
+## Copies an index buffer into a larger one. Pics are stored in fixed-size atlas
+## cells so the renderer can index them arithmetically, and a 5x5 pic has to
+## land in a 7x7 cell somewhere.
+static func blit(
+	source: PackedByteArray,
+	source_width: int,
+	destination: PackedByteArray,
+	destination_width: int,
+	at_x: int,
+	at_y: int
+) -> void:
+	if source_width <= 0:
+		return
+	var height: int = source.size() / source_width
+	for y: int in height:
+		var from: int = y * source_width
+		var to: int = (at_y + y) * destination_width + at_x
+		for x: int in source_width:
+			destination[to + x] = source[from + x]

--- a/game/import/tile_codec.gd.uid
+++ b/game/import/tile_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://coiml60cbl25l

--- a/game/rom/rom_file.gd
+++ b/game/rom/rom_file.gd
@@ -1,0 +1,93 @@
+class_name RomFile
+extends RefCounted
+
+## A cartridge dump held in memory for the duration of an import.
+##
+## Node-free like the rest of the ROM layer. [method open_verified] refuses
+## anything [RomVerifier] has not accepted: every offset in [RomLayout] is only
+## meaningful for a characterised dump, so an unverified file must never reach
+## a decoder.
+##
+## Reads are bounds-checked and return zero rather than faulting. Decoders walk
+## data whose length is only known once it has been decoded — a corrupt stream
+## should end up as an honest "that did not decode" instead of an engine error.
+
+## Cartridge banks are 16 KiB; the CPU sees one fixed and one switchable.
+const BANK_SIZE: int = 0x4000
+
+var path: String = ""
+var sha1: String = ""
+var id: StringName = &""
+
+var _bytes: PackedByteArray = PackedByteArray()
+
+
+## Loads a ROM only if it verifies against the registry. Returns null otherwise;
+## call [method RomVerifier.identify] first if you want the reason.
+static func open_verified(rom_path: String) -> RomFile:
+	var info: Dictionary = RomVerifier.identify(rom_path)
+	if info["status"] != RomVerifier.Status.OK:
+		return null
+
+	var file: FileAccess = FileAccess.open(rom_path, FileAccess.READ)
+	if file == null:
+		return null
+
+	var rom := RomFile.new()
+	rom.path = rom_path
+	rom.sha1 = info["sha1"]
+	rom.id = info["id"]
+	rom._bytes = file.get_buffer(file.get_length())
+	file.close()
+	return rom
+
+
+## Wraps bytes that have already been vouched for. For tests and tooling —
+## production paths should go through [method open_verified].
+static func from_bytes(data: PackedByteArray, id: StringName = &"") -> RomFile:
+	var rom := RomFile.new()
+	rom.id = id
+	rom._bytes = data
+	return rom
+
+
+## A bank number and a CPU address as the cartridge sees them, flattened to an
+## offset into the dump. Correct for both the fixed bank ($0000-$3FFF) and the
+## switchable window ($4000-$7FFF): only the low 14 bits of an address carry a
+## position within a bank.
+static func linear(bank: int, address: int) -> int:
+	return bank * BANK_SIZE + (address & 0x3FFF)
+
+
+func size() -> int:
+	return _bytes.size()
+
+
+func bytes() -> PackedByteArray:
+	return _bytes
+
+
+func in_bounds(offset: int, length: int = 1) -> bool:
+	return offset >= 0 and length >= 0 and offset + length <= _bytes.size()
+
+
+func u8(offset: int) -> int:
+	return _bytes[offset] if in_bounds(offset) else 0
+
+
+func u16le(offset: int) -> int:
+	if not in_bounds(offset, 2):
+		return 0
+	return _bytes[offset] | (_bytes[offset + 1] << 8)
+
+
+func slice(offset: int, length: int) -> PackedByteArray:
+	if not in_bounds(offset, length):
+		return PackedByteArray()
+	return _bytes.slice(offset, offset + length)
+
+
+## Reads a three-byte "bank, little-endian address" pointer, the form every
+## far-pointer table in these games uses. Returns { bank, address }.
+func far_pointer(offset: int) -> Dictionary:
+	return {"bank": u8(offset), "address": u16le(offset + 1)}

--- a/game/rom/rom_file.gd.uid
+++ b/game/rom/rom_file.gd.uid
@@ -1,0 +1,1 @@
+uid://c8h8u5e6hrepi

--- a/game/rom/rom_header.gd
+++ b/game/rom/rom_header.gd
@@ -1,0 +1,106 @@
+class_name RomHeader
+extends RefCounted
+
+## The Game Boy cartridge header at $0100-$014F.
+##
+## The import gate identifies a dump by SHA-1, which is stricter than anything
+## in here — this exists so a *diagnostic* can say why a file looked wrong, and
+## so an added registry entry can be sanity-checked against what the cartridge
+## claims about itself. Nothing in the importer branches on these fields.
+
+const TITLE_START: int = 0x134
+const TITLE_END: int = 0x143
+const CGB_FLAG: int = 0x143
+const NEW_LICENSEE: int = 0x144
+const SGB_FLAG: int = 0x146
+const CART_TYPE: int = 0x147
+const ROM_SIZE_CODE: int = 0x148
+const RAM_SIZE_CODE: int = 0x149
+const DESTINATION: int = 0x14A
+const OLD_LICENSEE: int = 0x14B
+const VERSION: int = 0x14C
+const HEADER_CHECKSUM: int = 0x14D
+const GLOBAL_CHECKSUM: int = 0x14E
+
+## $80 runs on both Game Boy and Game Boy Color; $C0 is Color-only. Gold and
+## Silver are $80, Crystal is $C0 — Crystal was the first mainline game that
+## would not boot on a DMG.
+const CGB_COMPATIBLE: int = 0x80
+const CGB_ONLY: int = 0xC0
+
+var title: String = ""
+var cgb_flag: int = 0
+var new_licensee: String = ""
+var sgb_flag: int = 0
+var cart_type: int = 0
+var rom_size_code: int = 0
+var ram_size_code: int = 0
+var destination: int = 0
+var old_licensee: int = 0
+var version: int = 0
+var header_checksum: int = 0
+var global_checksum: int = 0
+
+
+static func parse(rom: RomFile) -> RomHeader:
+	var header := RomHeader.new()
+
+	var raw_title: PackedByteArray = rom.slice(TITLE_START, TITLE_END - TITLE_START)
+	var letters: PackedByteArray = PackedByteArray()
+	for byte: int in raw_title:
+		# The title field is ASCII padded with $00, and later cartridges stole
+		# its last bytes for the manufacturer code and the CGB flag. Stopping at
+		# the first non-printable byte gets the human-readable part.
+		if byte < 0x20 or byte > 0x7E:
+			break
+		letters.append(byte)
+	header.title = letters.get_string_from_ascii()
+
+	header.cgb_flag = rom.u8(CGB_FLAG)
+	header.new_licensee = rom.slice(NEW_LICENSEE, 2).get_string_from_ascii()
+	header.sgb_flag = rom.u8(SGB_FLAG)
+	header.cart_type = rom.u8(CART_TYPE)
+	header.rom_size_code = rom.u8(ROM_SIZE_CODE)
+	header.ram_size_code = rom.u8(RAM_SIZE_CODE)
+	header.destination = rom.u8(DESTINATION)
+	header.old_licensee = rom.u8(OLD_LICENSEE)
+	header.version = rom.u8(VERSION)
+	header.header_checksum = rom.u8(HEADER_CHECKSUM)
+	# The only big-endian field in the header.
+	header.global_checksum = (rom.u8(GLOBAL_CHECKSUM) << 8) | rom.u8(GLOBAL_CHECKSUM + 1)
+	return header
+
+
+## Bytes $0134-$014C folded with x = x - byte - 1. The boot ROM refuses to start
+## a cartridge whose stored value disagrees.
+static func compute_header_checksum(rom: RomFile) -> int:
+	var sum: int = 0
+	for offset: int in range(TITLE_START, HEADER_CHECKSUM):
+		sum = (sum - rom.u8(offset) - 1) & 0xFF
+	return sum
+
+
+## Sum of every byte in the cartridge except the two that store it. Real
+## hardware never checks this, so a patched ROM commonly fails it.
+static func compute_global_checksum(rom: RomFile) -> int:
+	var sum: int = 0
+	var data: PackedByteArray = rom.bytes()
+	for i: int in data.size():
+		if i != GLOBAL_CHECKSUM and i != GLOBAL_CHECKSUM + 1:
+			sum += data[i]
+	return sum & 0xFFFF
+
+
+## Cartridge size the header claims, in bytes: 32 KiB shifted by the code.
+func declared_rom_size() -> int:
+	return 0x8000 << rom_size_code
+
+
+func is_color_game() -> bool:
+	return cgb_flag == CGB_COMPATIBLE or cgb_flag == CGB_ONLY
+
+
+func describe() -> String:
+	return "%s  cgb=$%02X  cart=$%02X  rom=%d KiB  ver=%d" % [
+		title, cgb_flag, cart_type, declared_rom_size() / 1024, version,
+	]

--- a/game/rom/rom_header.gd.uid
+++ b/game/rom/rom_header.gd.uid
@@ -1,0 +1,1 @@
+uid://cbo8e2jmauybm

--- a/project.godot
+++ b/project.godot
@@ -15,14 +15,14 @@ run/main_scene="res://game/main/main.tscn"
 config/features=PackedStringArray("4.8", "GL Compatibility")
 config/icon="res://icon.svg"
 
-[editor_plugins]
-
-enabled=PackedStringArray("res://addons/gut/plugin.cfg")
-
 [display]
 
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/gut/plugin.cfg")
 
 [input_devices]
 

--- a/tests/unit/test_lz_decompressor.gd
+++ b/tests/unit/test_lz_decompressor.gd
@@ -1,0 +1,122 @@
+extends GutTest
+
+## Every command is exercised against a stream built here, so a failure points
+## at one opcode rather than at "graphics are broken". No cartridge is involved.
+
+var _lz: Gen2Lz
+
+
+func before_each() -> void:
+	_lz = Gen2Lz.new()
+
+
+func _stream(bytes: Array) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray(bytes)
+	out.append(Gen2Lz.TERMINATOR)
+	return out
+
+
+func test_literal_copies_verbatim() -> void:
+	# 000 with length 4, then the bytes.
+	var data: PackedByteArray = _stream([0x03, 0xDE, 0xAD, 0xBE, 0xEF])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0xDE, 0xAD, 0xBE, 0xEF]))
+	assert_false(_lz.failed)
+
+
+func test_iterate_repeats_one_byte() -> void:
+	var data: PackedByteArray = _stream([0x20 | 0x04, 0xAB])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0xAB, 0xAB, 0xAB, 0xAB, 0xAB]))
+
+
+func test_alternate_repeats_a_pair() -> void:
+	var data: PackedByteArray = _stream([0x40 | 0x03, 0x11, 0x22])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0x11, 0x22, 0x11, 0x22]))
+
+
+func test_zero_fill_needs_no_operand() -> void:
+	var data: PackedByteArray = _stream([0x60 | 0x02])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0x00, 0x00, 0x00]))
+
+
+func test_repeat_reads_back_with_a_relative_offset() -> void:
+	# Literal "AB", then repeat 2 bytes starting 2 back.
+	var data: PackedByteArray = _stream([0x01, 0x41, 0x42, 0x80 | 0x01, 0x81])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0x41, 0x42, 0x41, 0x42]))
+
+
+func test_repeat_reads_back_with_an_absolute_offset() -> void:
+	# The two-byte form addresses from the start of the output, not the head.
+	var data: PackedByteArray = _stream([0x01, 0x41, 0x42, 0x80 | 0x01, 0x00, 0x00])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0x41, 0x42, 0x41, 0x42]))
+
+
+func test_repeat_may_overlap_the_bytes_it_is_writing() -> void:
+	# Source one byte back, length four: the format's way of spelling a run.
+	var data: PackedByteArray = _stream([0x00, 0x07, 0x80 | 0x03, 0x80])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0x07, 0x07, 0x07, 0x07, 0x07]))
+
+
+func test_flipped_repeat_reverses_each_byte() -> void:
+	var data: PackedByteArray = _stream([0x00, 0b0000_0001, 0xA0 | 0x00, 0x80])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0b0000_0001, 0b1000_0000]))
+
+
+func test_reversed_repeat_walks_backwards() -> void:
+	var data: PackedByteArray = _stream([0x02, 0x01, 0x02, 0x03, 0xC0 | 0x02, 0x80])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray([0x01, 0x02, 0x03, 0x03, 0x02, 0x01]))
+
+
+func test_long_command_borrows_two_length_bits() -> void:
+	# 111 escapes; the opcode moves to bits 4-2 and the length grows to 10 bits.
+	# Here: zero fill, length 0x101 + 1.
+	var command: int = 0xE0 | (Gen2Lz.Op.ZERO << 2) | 0x01
+	var data: PackedByteArray = _stream([command, 0x01])
+	var out: PackedByteArray = _lz.decompress(data, 0)
+	assert_false(_lz.failed)
+	assert_eq(out.size(), 0x102)
+
+
+func test_short_command_length_maxes_at_32() -> void:
+	var data: PackedByteArray = _stream([0x60 | 0x1F])
+	assert_eq(_lz.decompress(data, 0).size(), Gen2Lz.MAX_SHORT_LENGTH)
+
+
+func test_consumed_counts_the_terminator() -> void:
+	var data: PackedByteArray = _stream([0x01, 0x41, 0x42])
+	_lz.decompress(data, 0)
+	assert_eq(_lz.consumed, 4)
+
+
+func test_decoding_can_start_partway_in() -> void:
+	var data: PackedByteArray = PackedByteArray([0xFF, 0xFF, 0x00, 0x77, Gen2Lz.TERMINATOR])
+	assert_eq(_lz.decompress(data, 2), PackedByteArray([0x77]))
+
+
+func test_truncated_stream_fails_rather_than_returning_short() -> void:
+	# Literal claiming four bytes with only two present, and no terminator.
+	var data: PackedByteArray = PackedByteArray([0x03, 0xDE, 0xAD])
+	assert_eq(_lz.decompress(data, 0), PackedByteArray())
+	assert_true(_lz.failed)
+
+
+func test_missing_terminator_fails() -> void:
+	assert_eq(_lz.decompress(PackedByteArray([0x00, 0x41]), 0), PackedByteArray())
+	assert_true(_lz.failed)
+
+
+func test_back_reference_past_the_start_fails() -> void:
+	# Nothing has been written yet, so there is nothing to copy.
+	assert_eq(_lz.decompress(_stream([0x80 | 0x01, 0x80]), 0), PackedByteArray())
+	assert_true(_lz.failed)
+
+
+func test_failure_clears_on_the_next_run() -> void:
+	_lz.decompress(PackedByteArray([0x00]), 0)
+	assert_true(_lz.failed)
+	_lz.decompress(_stream([0x00, 0x01]), 0)
+	assert_false(_lz.failed, "state from a failed run leaked into the next")
+
+
+func test_static_helper_matches_the_instance() -> void:
+	var data: PackedByteArray = _stream([0x01, 0x41, 0x42])
+	assert_eq(Gen2Lz.unpack(data, 0), _lz.decompress(data, 0))

--- a/tests/unit/test_lz_decompressor.gd.uid
+++ b/tests/unit/test_lz_decompressor.gd.uid
@@ -1,0 +1,1 @@
+uid://cajsq2tryg5qp

--- a/tests/unit/test_rom_cache.gd
+++ b/tests/unit/test_rom_cache.gd
@@ -1,0 +1,110 @@
+extends GutTest
+
+## The cache holds cartridge-derived data, so these tests build their own and
+## clean it up. Nothing here reads a ROM.
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"testgame", "0123456789abcdef")
+	RomCache.clear(_directory)
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func test_the_cache_lives_under_user_not_in_the_project() -> void:
+	# It is derived from a commercial cartridge: it must never be committable
+	# or sweepable into an export.
+	assert_true(RomCache.ROOT.begins_with("user://"))
+
+
+func test_a_directory_is_named_by_game_and_hash() -> void:
+	# Two revisions of the same game must not share one.
+	var gold: String = RomCache.directory_for(RomRegistry.GOLD, "aaaaaaaabbbb")
+	var other: String = RomCache.directory_for(RomRegistry.GOLD, "ccccccccdddd")
+	assert_ne(gold, other)
+	assert_true(gold.contains("gold"))
+
+
+func test_prepare_creates_the_tree() -> void:
+	assert_true(RomCache.prepare(_directory))
+	assert_true(DirAccess.dir_exists_absolute("%s/%s" % [_directory, RomCache.PICS_DIR]))
+
+
+func test_json_round_trips() -> void:
+	RomCache.prepare(_directory)
+	var value: Dictionary = {"name": "BULBASAUR", "types": ["GRASS", "POISON"]}
+	assert_true(RomCache.write_json(RomCache.species_path(_directory), value))
+	assert_eq(RomCache.read_json(RomCache.species_path(_directory)), value)
+
+
+func test_numbers_come_back_from_json_as_floats() -> void:
+	# JSON has one number type, so every stat, index and byte read back out of
+	# the cache is a float. Callers must coerce; asserting it here so nobody
+	# rediscovers it by comparing a species number against an int and losing.
+	RomCache.prepare(_directory)
+	var path: String = RomCache.species_path(_directory)
+	RomCache.write_json(path, {"number": 1})
+
+	var read: Dictionary = RomCache.read_json(path)
+	assert_true(read["number"] is float)
+	assert_eq(int(read["number"]), 1)
+
+
+func test_reading_a_missing_file_returns_null() -> void:
+	assert_null(RomCache.read_json("%s/nothing.json" % _directory))
+
+
+func test_index_buffers_round_trip_exactly() -> void:
+	RomCache.prepare(_directory)
+	var pixels: PackedByteArray = PackedByteArray()
+	for i: int in 4096:
+		pixels.append(i % 4)
+
+	var path: String = RomCache.pic_path(_directory, "front")
+	assert_true(RomCache.write_indices(path, pixels))
+	assert_eq(RomCache.read_indices(path), pixels)
+
+
+func test_reading_missing_index_data_yields_an_empty_buffer() -> void:
+	assert_eq(RomCache.read_indices("%s/absent.idx" % _directory), PackedByteArray())
+
+
+func test_a_cache_without_a_manifest_is_not_usable() -> void:
+	RomCache.prepare(_directory)
+	assert_false(RomCache.is_usable(_directory))
+
+
+func test_an_incomplete_cache_is_not_usable() -> void:
+	# An interrupted import must not be mistaken for a finished one.
+	RomCache.prepare(_directory)
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION, "complete": false,
+	})
+	assert_false(RomCache.is_usable(_directory))
+
+
+func test_a_cache_from_another_format_version_is_not_usable() -> void:
+	RomCache.prepare(_directory)
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION - 1, "complete": true,
+	})
+	assert_false(RomCache.is_usable(_directory))
+
+
+func test_a_complete_current_cache_is_usable() -> void:
+	RomCache.prepare(_directory)
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION, "complete": true,
+	})
+	assert_true(RomCache.is_usable(_directory))
+
+
+func test_clear_removes_subdirectories_too() -> void:
+	RomCache.prepare(_directory)
+	RomCache.write_indices(RomCache.pic_path(_directory, "front"), PackedByteArray([1, 2, 3]))
+	RomCache.clear(_directory)
+	assert_false(DirAccess.dir_exists_absolute(_directory))

--- a/tests/unit/test_rom_cache.gd.uid
+++ b/tests/unit/test_rom_cache.gd.uid
@@ -1,0 +1,1 @@
+uid://bbue5nc8xljkn

--- a/tests/unit/test_rom_file.gd
+++ b/tests/unit/test_rom_file.gd
@@ -1,0 +1,149 @@
+extends GutTest
+
+## Addressing and header parsing, on a synthetic cartridge. No real dump is
+## involved — the bytes here are built to exercise the arithmetic, not to
+## resemble a game.
+
+const SCRATCH_DIR: String = "user://test_roms"
+
+var _made: PackedStringArray = []
+
+
+func before_each() -> void:
+	DirAccess.make_dir_recursive_absolute(SCRATCH_DIR)
+	_made = []
+
+
+func after_each() -> void:
+	for path: String in _made:
+		DirAccess.remove_absolute(path)
+
+
+func _blank_cartridge() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	return data
+
+
+func test_reads_are_little_endian() -> void:
+	var rom: RomFile = RomFile.from_bytes(PackedByteArray([0x34, 0x12]))
+	assert_eq(rom.u8(0), 0x34)
+	assert_eq(rom.u16le(0), 0x1234)
+
+
+func test_a_far_pointer_is_bank_then_address() -> void:
+	var rom: RomFile = RomFile.from_bytes(PackedByteArray([0x1E, 0x6C, 0x6D]))
+	assert_eq(rom.far_pointer(0), {"bank": 0x1E, "address": 0x6D6C})
+
+
+func test_reads_past_the_end_return_zero_rather_than_faulting() -> void:
+	# Decoders walk data whose length they only learn by decoding it.
+	var rom: RomFile = RomFile.from_bytes(PackedByteArray([0x01]))
+	assert_eq(rom.u8(99), 0)
+	assert_eq(rom.u16le(0), 0, "a two-byte read needs two bytes")
+	assert_eq(rom.slice(0, 4), PackedByteArray())
+	assert_false(rom.in_bounds(1))
+
+
+func test_negative_offsets_are_out_of_bounds() -> void:
+	var rom: RomFile = RomFile.from_bytes(PackedByteArray([0x01, 0x02]))
+	assert_false(rom.in_bounds(-1))
+	assert_eq(rom.u8(-1), 0)
+
+
+func test_slice_takes_a_length_not_an_end() -> void:
+	var rom: RomFile = RomFile.from_bytes(PackedByteArray([1, 2, 3, 4, 5]))
+	assert_eq(rom.slice(1, 3), PackedByteArray([2, 3, 4]))
+
+
+func test_bank_zero_addresses_are_left_alone() -> void:
+	assert_eq(RomFile.linear(0, 0x0100), 0x0100)
+
+
+func test_the_switchable_window_folds_onto_its_bank() -> void:
+	# $4000-$7FFF is a window: only the low 14 bits give a position in the bank.
+	assert_eq(RomFile.linear(1, 0x4000), 0x4000)
+	assert_eq(RomFile.linear(0x1E, 0x6D6C), 0x7AD6C)
+	assert_eq(RomFile.linear(2, 0x4000), RomFile.linear(2, 0x0000))
+
+
+func test_the_last_bank_of_a_cartridge_still_fits() -> void:
+	var banks: int = RomRegistry.EXPECTED_SIZE / RomFile.BANK_SIZE
+	assert_eq(RomFile.linear(banks - 1, 0x7FFF), RomRegistry.EXPECTED_SIZE - 1)
+
+
+func test_an_unverified_file_is_refused() -> void:
+	var path: String = "%s/not_a_game.gbc" % SCRATCH_DIR
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_buffer(_blank_cartridge())
+	file.close()
+	_made.append(path)
+
+	# Right size, unknown contents: the offset tables would be meaningless.
+	assert_null(RomFile.open_verified(path))
+
+
+func test_a_missing_file_is_refused() -> void:
+	assert_null(RomFile.open_verified("user://definitely_absent.gbc"))
+
+
+func test_header_fields_are_read_from_their_documented_places() -> void:
+	var data: PackedByteArray = _blank_cartridge()
+	var title: String = "POKEMON_GLD"
+	for i: int in title.length():
+		data[RomHeader.TITLE_START + i] = title.unicode_at(i)
+	data[RomHeader.CGB_FLAG] = RomHeader.CGB_COMPATIBLE
+	data[RomHeader.CART_TYPE] = 0x10
+	data[RomHeader.ROM_SIZE_CODE] = 0x06
+	data[RomHeader.VERSION] = 0x01
+
+	var header: RomHeader = RomHeader.parse(RomFile.from_bytes(data))
+	assert_eq(header.title, title)
+	assert_eq(header.cgb_flag, RomHeader.CGB_COMPATIBLE)
+	assert_eq(header.cart_type, 0x10)
+	assert_eq(header.version, 1)
+	assert_eq(header.declared_rom_size(), RomRegistry.EXPECTED_SIZE)
+	assert_true(header.is_color_game())
+
+
+func test_the_title_stops_at_the_first_padding_byte() -> void:
+	# Later cartridges reused the tail of the field, so it is not a plain string.
+	var data: PackedByteArray = _blank_cartridge()
+	for i: int in "PM_CRYSTAL".length():
+		data[RomHeader.TITLE_START + i] = "PM_CRYSTAL".unicode_at(i)
+	data[RomHeader.TITLE_START + 10] = 0x00
+	data[RomHeader.TITLE_START + 11] = 0x42
+
+	assert_eq(RomHeader.parse(RomFile.from_bytes(data)).title, "PM_CRYSTAL")
+
+
+func test_the_global_checksum_is_the_one_big_endian_field() -> void:
+	var data: PackedByteArray = _blank_cartridge()
+	data[RomHeader.GLOBAL_CHECKSUM] = 0x68
+	data[RomHeader.GLOBAL_CHECKSUM + 1] = 0x2D
+	assert_eq(RomHeader.parse(RomFile.from_bytes(data)).global_checksum, 0x682D)
+
+
+func test_the_header_checksum_matches_when_it_is_written_correctly() -> void:
+	var data: PackedByteArray = _blank_cartridge()
+	data[RomHeader.CART_TYPE] = 0x10
+	var rom: RomFile = RomFile.from_bytes(data)
+
+	var computed: int = RomHeader.compute_header_checksum(rom)
+	data[RomHeader.HEADER_CHECKSUM] = computed
+	assert_eq(RomHeader.parse(RomFile.from_bytes(data)).header_checksum, computed)
+
+	# Changing any covered byte must change the result — the boot ROM's check.
+	data[RomHeader.CART_TYPE] = 0x11
+	assert_ne(RomHeader.compute_header_checksum(RomFile.from_bytes(data)), computed)
+
+
+func test_the_global_checksum_excludes_its_own_bytes() -> void:
+	var data: PackedByteArray = _blank_cartridge()
+	data[0x200] = 0x10
+	var without: int = RomHeader.compute_global_checksum(RomFile.from_bytes(data))
+
+	data[RomHeader.GLOBAL_CHECKSUM] = 0xFF
+	data[RomHeader.GLOBAL_CHECKSUM + 1] = 0xFF
+	assert_eq(RomHeader.compute_global_checksum(RomFile.from_bytes(data)), without)
+	assert_eq(without, 0x10)

--- a/tests/unit/test_rom_file.gd.uid
+++ b/tests/unit/test_rom_file.gd.uid
@@ -1,0 +1,1 @@
+uid://b6y2rl1scebc4

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -1,0 +1,104 @@
+extends GutTest
+
+## The offset tables cannot be checked for correctness without a cartridge —
+## that is what [method RomImporter.verify_layout] does at import time. What can
+## be checked here is that they are internally consistent and complete, and that
+## the addressing arithmetic around them is right.
+
+
+func test_every_registry_game_has_a_layout() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		assert_true(RomLayout.is_characterised(id), "%s has no layout" % id)
+
+
+func test_an_unknown_game_has_none() -> void:
+	assert_true(RomLayout.for_id(&"emerald").is_empty())
+
+
+func test_gold_and_silver_share_one_layout() -> void:
+	# Same engine, same build: only the content between the offsets differs.
+	assert_eq(RomLayout.for_id(RomRegistry.GOLD), RomLayout.for_id(RomRegistry.SILVER))
+
+
+func test_crystal_has_its_own() -> void:
+	assert_ne(RomLayout.for_id(RomRegistry.CRYSTAL), RomLayout.for_id(RomRegistry.GOLD))
+
+
+func test_layouts_carry_the_same_keys() -> void:
+	var gold: Array = RomLayout.for_id(RomRegistry.GOLD).keys()
+	var crystal: Array = RomLayout.for_id(RomRegistry.CRYSTAL).keys()
+	gold.sort()
+	crystal.sort()
+	assert_eq(gold, crystal)
+
+
+func test_every_offset_lands_inside_a_cartridge() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		for key: String in layout:
+			if layout[key] is int and key != "pic_bank_add":
+				assert_between(int(layout[key]), 0, RomRegistry.EXPECTED_SIZE - 1, "%s.%s" % [id, key])
+
+
+func test_tables_do_not_run_off_the_end() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		var last_name: int = RomLayout.species_name_offset(layout, RomLayout.SPECIES_COUNT)
+		assert_lt(last_name + RomLayout.NAME_LENGTH, RomRegistry.EXPECTED_SIZE)
+		var last_stats: int = RomLayout.base_stats_offset(layout, RomLayout.SPECIES_COUNT)
+		assert_lt(last_stats + RomLayout.BASE_STATS_SIZE, RomRegistry.EXPECTED_SIZE)
+		var last_pic: int = RomLayout.pic_pointer_offset(layout, RomLayout.SPECIES_COUNT, true)
+		assert_lt(last_pic + RomLayout.PIC_POINTER_SIZE, RomRegistry.EXPECTED_SIZE)
+
+
+func test_species_tables_are_one_based() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	assert_eq(RomLayout.species_name_offset(layout, 1), int(layout["species_names"]))
+	assert_eq(RomLayout.base_stats_offset(layout, 1), int(layout["base_stats"]))
+
+
+func test_the_palette_table_is_indexed_by_species_number() -> void:
+	# Unlike the others: there is an entry before Bulbasaur's.
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	assert_eq(
+		RomLayout.palette_offset(layout, 1),
+		int(layout["palettes"]) + Gen2Palette.ENTRY_BYTES
+	)
+
+
+func test_pic_pointers_come_in_front_back_pairs() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	var front: int = RomLayout.pic_pointer_offset(layout, 2, false)
+	var back: int = RomLayout.pic_pointer_offset(layout, 2, true)
+	assert_eq(back - front, RomLayout.PIC_POINTER_SIZE)
+	assert_eq(front - RomLayout.pic_pointer_offset(layout, 1, false), RomLayout.PIC_POINTER_SIZE * 2)
+
+
+func test_unown_forms_are_zero_based() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	assert_eq(
+		RomLayout.unown_pic_pointer_offset(layout, 0, false),
+		int(layout["unown_pic_pointers"])
+	)
+
+
+func test_crystal_shifts_every_pic_bank_by_a_constant() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.CRYSTAL)
+	assert_eq(RomLayout.fix_pic_bank(layout, 0x12), 0x12 + 0x36)
+	assert_eq(RomLayout.fix_pic_bank(layout, 0x23), 0x23 + 0x36)
+
+
+func test_gold_patches_only_the_three_banks_that_moved() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	assert_eq(RomLayout.fix_pic_bank(layout, 0x13), 0x1F)
+	assert_eq(RomLayout.fix_pic_bank(layout, 0x14), 0x20)
+	assert_eq(RomLayout.fix_pic_bank(layout, 0x1F), 0x2E)
+	assert_eq(RomLayout.fix_pic_bank(layout, 0x1A), 0x1A, "an unpatched bank passes through")
+
+
+func test_a_fixed_bank_still_addresses_inside_the_cartridge() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		for stored: int in range(0x10, 0x40):
+			var bank: int = RomLayout.fix_pic_bank(layout, stored)
+			assert_lt(RomFile.linear(bank, 0x7FFF), RomRegistry.EXPECTED_SIZE)

--- a/tests/unit/test_rom_layout.gd.uid
+++ b/tests/unit/test_rom_layout.gd.uid
@@ -1,0 +1,1 @@
+uid://iainil3qp1vi

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -1,0 +1,67 @@
+extends GutTest
+
+## Synthetic byte strings only. The encoding is a fixed table, so it can be
+## checked without a cartridge — and the importer's own layout check re-tests it
+## against real data by insisting species 1 decodes to BULBASAUR.
+
+
+func _encode(letters: String) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	for i: int in letters.length():
+		out.append(0x80 + letters.unicode_at(i) - "A".unicode_at(0))
+	return out
+
+
+func test_uppercase_run_starts_at_0x80() -> void:
+	assert_eq(Gen2Text.decode(_encode("ABZ"), 0, 10), "ABZ")
+
+
+func test_lowercase_run_starts_at_0xa0() -> void:
+	assert_eq(Gen2Text.decode(PackedByteArray([0xA0, 0xA1, 0xB9]), 0, 10), "abz")
+
+
+func test_digits_run_starts_at_0xf6() -> void:
+	assert_eq(Gen2Text.decode(PackedByteArray([0xF6, 0xF7, 0xFF]), 0, 10), "019")
+
+
+func test_space_and_punctuation() -> void:
+	assert_eq(Gen2Text.decode(PackedByteArray([0x7F, 0xE3, 0xF4, 0xE7]), 0, 10), " -,!")
+
+
+func test_terminator_ends_the_string() -> void:
+	var data: PackedByteArray = PackedByteArray([0x80, Gen2Text.TERMINATOR, 0x81])
+	assert_eq(Gen2Text.decode(data, 0, 10), "A")
+
+
+func test_max_length_is_respected_without_a_terminator() -> void:
+	assert_eq(Gen2Text.decode(_encode("ABCDE"), 0, 3), "ABC")
+
+
+func test_decoding_can_start_partway_in() -> void:
+	assert_eq(Gen2Text.decode(_encode("ABC"), 1, 10), "BC")
+
+
+func test_reading_past_the_end_stops_rather_than_faulting() -> void:
+	assert_eq(Gen2Text.decode(_encode("AB"), 0, 64), "AB")
+	assert_eq(Gen2Text.decode(PackedByteArray(), 0, 8), "")
+
+
+func test_word_codes_expand() -> void:
+	assert_eq(Gen2Text.decode(PackedByteArray([0x5D]), 0, 4), "TRAINER")
+	assert_eq(Gen2Text.decode(PackedByteArray([0xE1, 0xE2]), 0, 4), "PKMN")
+
+
+func test_apostrophe_ligatures_expand_to_two_characters() -> void:
+	# One tile in the font, two letters on screen.
+	assert_eq(Gen2Text.decode(PackedByteArray([0x88, 0xD5]), 0, 4), "I't")
+
+
+func test_unknown_byte_is_visible_rather_than_dropped() -> void:
+	# A silently skipped byte would turn a wrong offset into a plausible name.
+	assert_eq(Gen2Text.decode(PackedByteArray([0x80, 0x01]), 0, 4), "A<01>")
+
+
+func test_a_real_species_name_round_trips() -> void:
+	# The bytes of "MEWTWO@" as they sit in the cartridge.
+	var data: PackedByteArray = PackedByteArray([0x8C, 0x84, 0x96, 0x93, 0x96, 0x8E, 0x50])
+	assert_eq(Gen2Text.decode(data, 0, 10), "MEWTWO")

--- a/tests/unit/test_text_codec.gd.uid
+++ b/tests/unit/test_text_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://dc80tl0iidmqt

--- a/tests/unit/test_tile_codec.gd
+++ b/tests/unit/test_tile_codec.gd
@@ -1,0 +1,93 @@
+extends GutTest
+
+## 2bpp decoding and pic layout, on hand-built tiles.
+
+
+func _solid_tile(index: int) -> PackedByteArray:
+	var low: int = 0xFF if index & 1 else 0x00
+	var high: int = 0xFF if index & 2 else 0x00
+	var out: PackedByteArray = PackedByteArray()
+	for _row: int in Gen2Tiles.TILE_HEIGHT:
+		out.append(low)
+		out.append(high)
+	return out
+
+
+func test_a_tile_is_sixty_four_pixels() -> void:
+	assert_eq(Gen2Tiles.decode_tile(_solid_tile(0), 0).size(), Gen2Tiles.TILE_PIXELS)
+
+
+func test_each_index_round_trips() -> void:
+	for index: int in 4:
+		var pixels: PackedByteArray = Gen2Tiles.decode_tile(_solid_tile(index), 0)
+		for pixel: int in pixels:
+			assert_eq(pixel, index, "solid tile of index %d decoded a %d" % [index, pixel])
+
+
+func test_the_two_bytes_of_a_row_are_low_then_high_bitplane() -> void:
+	var data: PackedByteArray = PackedByteArray()
+	data.append(0b1000_0000)
+	data.append(0b0100_0000)
+	for _i: int in 14:
+		data.append(0x00)
+	var pixels: PackedByteArray = Gen2Tiles.decode_tile(data, 0)
+	assert_eq(pixels[0], 1, "bit 7 of the first byte is the leftmost low bit")
+	assert_eq(pixels[1], 2, "bit 6 of the second byte is the next high bit")
+	assert_eq(pixels[2], 0)
+
+
+func test_bit_seven_is_the_leftmost_pixel() -> void:
+	var data: PackedByteArray = PackedByteArray([0b0000_0001, 0x00])
+	data.resize(Gen2Tiles.TILE_BYTES)
+	assert_eq(Gen2Tiles.decode_tile(data, 0)[7], 1)
+
+
+func test_out_of_range_offset_yields_a_blank_tile() -> void:
+	var pixels: PackedByteArray = Gen2Tiles.decode_tile(PackedByteArray([0x01]), 0)
+	assert_eq(pixels.size(), Gen2Tiles.TILE_PIXELS)
+	assert_eq(pixels.count(0), Gen2Tiles.TILE_PIXELS)
+
+
+func test_pic_tiles_are_stored_column_major() -> void:
+	# Two columns of two tiles. Storage order is top-left, bottom-left,
+	# top-right, bottom-right — down the columns, not across the rows.
+	var data: PackedByteArray = PackedByteArray()
+	for index: int in [1, 2, 3, 1]:
+		data.append_array(_solid_tile(index))
+
+	var pixels: PackedByteArray = Gen2Tiles.decode_pic(data, 2, 2)
+	var width: int = 16
+	assert_eq(pixels.size(), 16 * 16)
+	assert_eq(pixels[0], 1, "top-left")
+	assert_eq(pixels[8], 3, "top-right")
+	assert_eq(pixels[8 * width], 2, "bottom-left")
+	assert_eq(pixels[8 * width + 8], 1, "bottom-right")
+
+
+func test_pic_ignores_trailing_data() -> void:
+	# Crystal's front pics carry Pokédex animation frames after the still image.
+	var data: PackedByteArray = _solid_tile(2)
+	data.append_array(_solid_tile(3))
+	var pixels: PackedByteArray = Gen2Tiles.decode_pic(data, 1, 1)
+	assert_eq(pixels.size(), Gen2Tiles.TILE_PIXELS)
+	assert_eq(pixels.count(2), Gen2Tiles.TILE_PIXELS)
+
+
+func test_pic_with_too_little_data_is_blank_rather_than_partial() -> void:
+	var pixels: PackedByteArray = Gen2Tiles.decode_pic(_solid_tile(3), 2, 2)
+	assert_eq(pixels.size(), 16 * 16)
+	assert_eq(pixels.count(0), 16 * 16)
+
+
+func test_blit_places_a_small_pic_inside_a_cell() -> void:
+	var source: PackedByteArray = PackedByteArray([1, 2, 3, 4])
+	var destination: PackedByteArray = PackedByteArray()
+	destination.resize(16)
+
+	Gen2Tiles.blit(source, 2, destination, 4, 1, 1)
+
+	assert_eq(destination[5], 1)
+	assert_eq(destination[6], 2)
+	assert_eq(destination[9], 3)
+	assert_eq(destination[10], 4)
+	assert_eq(destination[0], 0, "the rest of the cell is untouched")

--- a/tests/unit/test_tile_codec.gd.uid
+++ b/tests/unit/test_tile_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://b5roiix1b8kkn

--- a/tools/import_rom.gd
+++ b/tools/import_rom.gd
@@ -1,0 +1,99 @@
+extends SceneTree
+
+## Imports a cartridge into the user:// cache, headlessly.
+##
+##   Godot --headless --path . -s res://tools/import_rom.gd -- [file-or-dir ...]
+##
+## Defaults to res://roms. Exits 0 only if every candidate imported. Add
+## --verify to stop after the layout check without writing a cache.
+
+const DEFAULT_DIR: String = "res://roms"
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	var verify_only: bool = args.has("--verify")
+
+	var inputs: PackedStringArray = []
+	for arg: String in args:
+		if not arg.begins_with("--"):
+			inputs.append(arg)
+	if inputs.is_empty():
+		inputs = PackedStringArray([DEFAULT_DIR])
+
+	var paths: PackedStringArray = []
+	for raw: String in inputs:
+		var path: String = raw if raw.contains("://") or raw.begins_with("/") else "res://" + raw
+		if DirAccess.dir_exists_absolute(path):
+			paths.append_array(_roms_in(path))
+		else:
+			paths.append(path)
+
+	if paths.is_empty():
+		push_error("No candidate files found.")
+		quit(1)
+		return
+
+	var failures: int = 0
+	for path: String in paths:
+		if not _handle(path, verify_only):
+			failures += 1
+
+	print("\n%d/%d %s." % [
+		paths.size() - failures, paths.size(), "verified" if verify_only else "imported",
+	])
+	quit(1 if failures > 0 else 0)
+
+
+func _handle(path: String, verify_only: bool) -> bool:
+	var identity: Dictionary = RomVerifier.identify(path)
+	if identity["status"] != RomVerifier.Status.OK:
+		print("FAIL  %s\n    %s" % [path.get_file(), identity["message"]])
+		return false
+
+	var rom: RomFile = RomFile.open_verified(path)
+	if rom == null:
+		print("FAIL  %s\n    Could not read the file." % path.get_file())
+		return false
+
+	var header: RomHeader = RomHeader.parse(rom)
+	print("\n%s  %s" % [path.get_file(), identity["message"]])
+	print("    %s" % header.describe())
+	print("    header checksum %s" % (
+		"ok" if header.header_checksum == RomHeader.compute_header_checksum(rom) else "MISMATCH"
+	))
+
+	var check: Dictionary = RomImporter.verify_layout(rom)
+	print("    layout: %s" % check["message"])
+	if not check["ok"]:
+		return false
+	if verify_only:
+		return true
+
+	var importer := RomImporter.new()
+	var result: Dictionary = importer.import_rom(rom, _report)
+	print("    %s" % result["message"])
+	if result["ok"]:
+		print("    cache: %s" % ProjectSettings.globalize_path(result["directory"]))
+	return result["ok"]
+
+
+func _report(stage: String, done: int, total: int) -> void:
+	if done == total:
+		print("    %s: %d/%d" % [stage, done, total])
+
+
+func _roms_in(dir_path: String) -> PackedStringArray:
+	var out: PackedStringArray = []
+	var dir: DirAccess = DirAccess.open(dir_path)
+	if dir == null:
+		return out
+	dir.list_dir_begin()
+	var name: String = dir.get_next()
+	while name != "":
+		if not dir.current_is_dir() and name.get_extension().to_lower() in ["gb", "gbc"]:
+			out.append("%s/%s" % [dir_path, name])
+		name = dir.get_next()
+	dir.list_dir_end()
+	out.sort()
+	return out

--- a/tools/import_rom.gd.uid
+++ b/tools/import_rom.gd.uid
@@ -1,0 +1,1 @@
+uid://y6818wx1gvex

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -1,0 +1,103 @@
+extends SceneTree
+
+## Renders an imported pic atlas to a PNG so it can be looked at.
+##
+##   Godot --headless --path . -s res://tools/preview_pics.gd -- <game> <out.png> [atlas] [--shiny]
+##
+## e.g. gold /tmp/gold_front.png front
+##
+## The cache stores colour indices, not pixels — a palette is applied at draw
+## time so that shiny is free. This applies one and writes the result out, which
+## is the only way to tell a correct decode from a plausible-looking wrong one.
+## Runs headless: it writes an image, it does not open a window.
+
+const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back"]
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	var shiny: bool = args.has("--shiny")
+
+	var positional: PackedStringArray = []
+	for arg: String in args:
+		if not arg.begins_with("--"):
+			positional.append(arg)
+
+	if positional.size() < 2:
+		push_error("Usage: <game> <out.png> [%s] [--shiny]" % "|".join(ATLASES))
+		quit(1)
+		return
+
+	var game: StringName = StringName(positional[0])
+	var out_path: String = positional[1]
+	var atlas_name: String = positional[2] if positional.size() > 2 else "front"
+
+	var directory: String = _find_cache(game)
+	if directory.is_empty():
+		push_error("No cache for %s. Run tools/import_rom.gd first." % game)
+		quit(1)
+		return
+
+	var manifest: Dictionary = RomCache.read_manifest(directory)
+	var atlases: Dictionary = manifest.get("atlases", {})
+	if not atlases.has(atlas_name):
+		push_error("No atlas named %s." % atlas_name)
+		quit(1)
+		return
+
+	var image: Image = _render(directory, manifest, atlases[atlas_name], atlas_name, shiny)
+	if image == null:
+		quit(1)
+		return
+
+	if image.save_png(out_path) != OK:
+		push_error("Could not write %s." % out_path)
+		quit(1)
+		return
+
+	print("%s %s%s -> %s (%dx%d)" % [
+		game, atlas_name, " shiny" if shiny else "", out_path,
+		image.get_width(), image.get_height(),
+	])
+	quit(0)
+
+
+func _find_cache(game: StringName) -> String:
+	var sha1: String = RomRegistry.sha1_for(game)
+	if sha1.is_empty():
+		return ""
+	var directory: String = RomCache.directory_for(game, sha1)
+	return directory if RomCache.is_usable(directory) else ""
+
+
+func _render(
+	directory: String, manifest: Dictionary, atlas: Dictionary, name: String, shiny: bool
+) -> Image:
+	var indices: PackedByteArray = RomCache.read_indices(RomCache.pic_path(directory, name))
+	var width: int = int(atlas["width"])
+	var height: int = int(atlas["height"])
+	if indices.size() != width * height:
+		push_error("%s holds %d bytes, expected %d." % [name, indices.size(), width * height])
+		return null
+
+	var species: Array = RomCache.read_json(RomCache.species_path(directory))
+	var cell: int = int(atlas["cell"])
+	var columns: int = int(atlas["columns"])
+	var key: String = "shiny" if shiny else "normal"
+
+	var image: Image = Image.create_empty(width, height, false, Image.FORMAT_RGBA8)
+	for y: int in height:
+		for x: int in width:
+			var slot: int = (y / cell) * columns + (x / cell)
+			# Unown's atlas is one cell per letter, all of them the same species.
+			var entry: Dictionary = species[
+				RomLayout.UNOWN_SPECIES - 1 if name.begins_with("unown") else mini(slot, species.size() - 1)
+			]
+			var packed: Array = entry["palette"][key]
+			var palette: PackedColorArray = Gen2Palette.pic_palette(PackedColorArray([
+				Gen2Palette.from_packed(int(packed[0])),
+				Gen2Palette.from_packed(int(packed[1])),
+			]))
+			image.set_pixel(x, y, palette[indices[y * width + x]])
+
+	return image

--- a/tools/preview_pics.gd.uid
+++ b/tools/preview_pics.gd.uid
@@ -1,0 +1,1 @@
+uid://dwmcjgd4d5g7x


### PR DESCRIPTION
Decodes a verified cartridge into a cache under `user://`. Species names, base
stats, types, held items, egg groups and TM/HM flags; normal and shiny
palettes; front and back sprites for all 251 species plus the 26 Unown forms.
Under 200 ms per game.

Nothing renders it yet, this is the data layer the renderer will sit on.

## Shape

The decoders take bytes rather than a cartridge, so each is testable on a
handful of hand-built values:

| | |
|---|---|
| `game/import/lz_decompressor.gd` | The Gen 1/2 LZ variant, all seven opcodes |
| `game/import/tile_codec.gd` | 2bpp tiles to colour indices; pic layout |
| `game/import/text_codec.gd` | The Generation 2 character encoding |
| `game/import/palette.gd` | 15-bit BGR colour |
| `game/import/rom_layout.gd` | Where each table lives, per game |
| `game/import/rom_cache.gd` | The `user://` cache: paths, formats, lifecycle |
| `game/import/rom_importer.gd` | Orchestration, and the layout self-check |

Plus `RomFile` (a verified dump in memory, with bank addressing) and
`RomHeader` (diagnostics only, nothing branches on it).

`RomFile.open_verified()` is the only way into the importer, so the hard
refusal on an unknown hash cannot be routed around.

Gold and Silver share one offset table byte for byte; Crystal needs its own
values but not its own code path.

## Two places the cartridge is not what it appears to be

**Pic pointers store bank numbers that were never updated** after the graphics
sections moved between banks. The game repairs each pointer as it loads it, and
so does this: Crystal shifts every bank by a constant, Gold and Silver patch
three specific banks and pass the rest through. Reproducing it is not optional, the stored numbers are simply wrong.

**Crystal's front pics run past their stated size.** The frames of the Pokédex
animation follow the still image. The decoder takes the first *width* ×
*height* tiles and ignores the rest; the animation frames are there for the
taking when something needs them.

Unown also isn't in the main pic table at all, its entry is a deliberate `$FF`
placeholder and its 26 forms live in a table of their own.

## Why offsets are checked at runtime

A wrong offset does not throw. It decodes neighbouring data into something
plausible.

The palette table was one whole table too far along in the first draft, and it
still produced 251 sprites, the right shapes in the wrong colours, while
every unit test stayed green. It was only caught by rendering a contact sheet
and looking at it.

So every offset now ships with a check that would fail if it were wrong, and
`RomImporter.verify_layout()` runs all of them before a single byte is decoded:

- Species names are read back through the text codec and compared against the
  first and last species, pinning offset, stride and character map at once.
- Every base stats entry begins with its own Pokédex number, so the whole table
  self-checks in one pass.
- Palettes have no self-identifying field, so they are checked structurally: a
  colour is 15 bits, and no species is drawn in two blacks.

Offsets were located by searching each cartridge for content whose bytes are
known independently, then confirming the structure against the pret
disassemblies. `docs/CONTRIBUTING.md` documents the method and the rule: when
you add an offset, add its check.

## Caching

Sprites are stored as colour indices, not images, with the palette applied at
draw time, so shiny costs nothing and no image round-trip has to be trusted to
be lossless. Atlases use fixed cells so a renderer can index them
arithmetically.

The cache is cartridge-derived, so it lives under `user://` and falls under the
same rule as the ROM itself: never in the repo, never in an export. Each import
is keyed by game and hash, so two revisions never share one, and the manifest is
only marked complete at the very end so an interrupted run cannot be mistaken
for a finished one.

## Verification

- **93/93 tests passing**, 612 asserts, 0.54s. No test loads a real cartridge,
  synthetic files and hand-built byte streams, so the suite runs anywhere.
- `tools/import_rom.gd` on the three real games: **3/3**, 251 species and 554
  sprites each, no decode failures.
- `tools/preview_pics.gd` contact sheets rendered and eyeballed for Gold and
  Crystal, normal and shiny, fronts and backs, and all 26 Unown forms.

One find worth flagging for anyone reading the cache: Godot's JSON has a single
number type, so every stat and index reads back as a float and `read["number"]
== 1` is false. There's a test pinning that down and a note in the pitfalls
list.

## Not in scope here

Move, item and type tables are located and confirmed in all three ROMs but not
yet decoded. Trainers, maps, dex entries, evolution and learnset chains and
audio are not located yet. `game/main/` is untouched, it still just prints the
allowlist and knows nothing about the importer.