### PR TITLE
Decode moves, items and types in the importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 # ---------------------------------------------------------------------------
 # Bring-your-own-ROM. Nothing derived from a commercial cartridge may ever be
 # committed: not the ROM, not a save, not the extracted asset cache. The
-# pre-commit hook in .githooks/ enforces this too — see docs/CONTRIBUTING.md.
+# pre-commit hook in .githooks/ enforces this too; see docs/CONTRIBUTING.md.
 # ---------------------------------------------------------------------------
 *.gb
 *.gbc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gen2recomp
 
 A native [Godot 4](https://godotengine.org) reimplementation of the Generation 2
-Game Boy Color games — Gold, Silver and Crystal.
+Game Boy Color games: Gold, Silver and Crystal.
 
 **Not an emulator, not a static recompilation, not a disassembly.** The engine
 is written from scratch in GDScript. Your own cartridge dump is used as an
@@ -15,9 +15,9 @@ the same thing for Generation 1.
 > ### Status: early
 >
 > The import gate and the first half of the importer exist and are tested: a
-> verified cartridge decodes into species data, palettes and every Pokémon
-> sprite. The renderer, overworld, battle system, audio and mod loader do not
-> exist yet. There is nothing playable here today.
+> verified cartridge decodes into species data, moves, items, types, palettes
+> and every Pokémon sprite. The renderer, overworld, battle system, audio and
+> mod loader do not exist yet. There is nothing playable here today.
 
 ## Getting started
 
@@ -28,7 +28,7 @@ You need Godot 4.8 or newer. Clone the repo, then enable the commit guard
 git config core.hooksPath .githooks
 ```
 
-Put your cartridge dumps in `roms/` — see [roms/README.md](roms/README.md).
+Put your cartridge dumps in `roms/`; see [roms/README.md](roms/README.md).
 That folder is gitignored and carries a `.gdignore`, so its contents are
 excluded from both commits and builds.
 
@@ -60,7 +60,7 @@ Decoding a cartridge into the cache:
 godot --headless --path . -s res://tools/import_rom.gd
 ```
 
-Takes under a second per game. The cache lands in Godot's `user://` directory —
+Takes under a second per game. The cache lands in Godot's `user://` directory,
 never inside the project, because it is cartridge-derived data and subject to
 exactly the same rule as the ROM itself. Add `--verify` to run the checks
 without writing anything.
@@ -71,16 +71,25 @@ What comes out today:
 | | |
 |---|---|
 | Species | Names, base stats, types, held items, egg groups, TM/HM flags |
+| Moves | Names, power, type, accuracy, PP, effect and its chance |
+| Items | All 255 names, indexed by item number |
+| Types | All 28 names, indexed by type number |
 | Palettes | Normal and shiny, as the cartridge's own 15-bit colours |
 | Sprites | Front and back for all 251 species, plus all 26 Unown forms |
 
 Sprites are stored as colour indices rather than as images, and a palette is
-applied when they are drawn — which is the whole of what being shiny costs.
+applied when they are drawn, which is the whole of what being shiny costs.
 
-To look at what was decoded:
+To look at what was decoded, as a contact sheet of sprites:
 
 ```bash
 godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png front
+```
+
+or as text, for any of `species`, `moves`, `items`, `types` or `all`:
+
+```bash
+godot --headless --path . -s res://tools/dump_tables.gd -- gold moves
 ```
 
 ## Running
@@ -89,7 +98,7 @@ godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png f
 godot --headless --path . --quit-after 30
 ```
 
-Boots the main scene for 30 frames and exits — a quick smoke check.
+Boots the main scene for 30 frames and exits, as a quick smoke check.
 
 ## Tests
 
@@ -100,7 +109,7 @@ Boots the main scene for 30 frames and exits — a quick smoke check.
 godot --headless -s res://addons/gut/gut_cmdln.gd -gdir=res://tests -ginclude_subdirs -gexit
 ```
 
-Exit code `0` means everything passed. Tests never load a real cartridge —
+Exit code `0` means everything passed. Tests never load a real cartridge;
 they use synthetic files and a known SHA-1 vector, so the suite runs anywhere.
 
 ## Layout
@@ -123,7 +132,7 @@ the widest hardware reach. Export presets are not configured yet.
 
 Note that iOS forbids JIT compilation and loading native code at runtime. Mods
 are therefore GDScript interpreted by the shipped VM, never compiled
-extensions — this is why the project is GDScript-first.
+extensions. That is why the project is GDScript-first.
 
 ## Contributing
 
@@ -132,7 +141,7 @@ pitfalls that have cost real time on this project.
 
 **The one rule that matters:** no cartridge-derived data enters this
 repository. Not a ROM, not a `.sav`, not extracted sprites, text, maps or
-audio. Three layers enforce it — `.gitignore`, the pre-commit hook, and tests
+audio. Three layers enforce it: `.gitignore`, the pre-commit hook, and tests
 that never touch a real file. Please do not weaken any of them.
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ godot --headless --path . --quit-after 30
 
 Boots the main scene for 30 frames and exits, as a quick smoke check.
 
+To see an imported sprite on a real screen, open
+`game/render/pic_viewer.tscn` in the editor and press Play. Left and right
+change species, `S` toggles shiny, `B` swaps the front pic for the back one.
+The game is drawn into a 160x144 viewport and scaled up by a whole number, so a
+Game Boy pixel stays square; the interface around it is at the window's own
+resolution.
+
 ## Tests
 
 [GUT](https://github.com/bitwes/Gut) lives in `addons/gut`; configuration is in

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,7 @@ enforce this, and none of them should be weakened:
 
 1. **`.gitignore`** blocks the known extensions, the `roms/` drop folder and
    the runtime cache directories.
-2. **`.githooks/pre-commit`** checks what is actually *staged* — by extension,
+2. **`.githooks/pre-commit`** checks what is actually *staged*: by extension,
    and by size for any blob ≥ 512 KiB outside `addons/` and `assets/`. That
    second check catches a renamed or trimmed dump that no extension rule would
    see. Enable it with `git config core.hooksPath .githooks`; Git does not
@@ -22,7 +22,7 @@ enforce this, and none of them should be weakened:
    on any machine and in CI.
 
 `roms/` additionally carries a `.gdignore`, which makes Godot's resource system
-skip the directory entirely — files there are never imported and never swept
+skip the directory entirely, so files there are never imported and never swept
 into an export. `FileAccess` can still read them during development, which is
 how `tools/verify_rom.gd` works. Do not delete that file.
 
@@ -30,11 +30,11 @@ how `tools/verify_rom.gd` works. Do not delete that file.
 
 The ROM layer is the model for the rest of the engine:
 
-- `game/rom/rom_registry.gd` — the SHA-1 allowlist.
-- `game/rom/rom_verifier.gd` — size pre-filter, then chunked SHA-1, then
+- `game/rom/rom_registry.gd`: the SHA-1 allowlist.
+- `game/rom/rom_verifier.gd`: size pre-filter, then chunked SHA-1, then
   lookup.
-- `game/rom/rom_file.gd` — a verified dump in memory, plus bank addressing.
-- `game/rom/rom_header.gd` — the cartridge header, for diagnostics only.
+- `game/rom/rom_file.gd`: a verified dump in memory, plus bank addressing.
+- `game/rom/rom_header.gd`: the cartridge header, for diagnostics only.
 
 All of them are `RefCounted` statics with no scene dependencies, so the import
 gate is fully testable headlessly. Keep the engine core the same shape: rules
@@ -54,7 +54,7 @@ The importer under `game/import/` decodes a verified cartridge into a cache:
 | `rom_cache.gd` | The `user://` cache: paths, formats, lifecycle |
 | `rom_importer.gd` | Orchestration, and the layout self-check |
 
-Each decoder takes bytes and returns data — none of them knows what a cartridge
+Each decoder takes bytes and returns data; none of them knows what a cartridge
 is, so all of them are testable on a handful of hand-built bytes.
 
 ## Offsets, and why they are checked at runtime
@@ -62,8 +62,8 @@ is, so all of them are testable on a handful of hand-built bytes.
 `rom_layout.gd` is a table of absolute positions inside each supported dump. An
 offset is a claim about a specific 2 MiB file, and a wrong one does not throw:
 it decodes neighbouring data into something plausible. A palette table that was
-one entire table too far along still produced 251 sprites — the right shapes in
-the wrong colours — and every unit test stayed green.
+one entire table too far along still produced 251 sprites (the right shapes in
+the wrong colours) and every unit test stayed green.
 
 So every offset ships with a check that would fail if it were wrong, and
 `RomImporter.verify_layout()` runs all of them before a single byte is decoded:
@@ -75,12 +75,21 @@ So every offset ships with a check that would fail if it were wrong, and
   self-checks in one pass.
 - Palettes have no self-identifying field, so they are checked structurally: a
   colour is 15 bits, and no species is drawn in two blacks.
+- Every move entry opens with its own animation number, which is its move
+  number, so the move table self-checks in one pass exactly like the base
+  stats. Its type byte is range-checked in the same loop, because it indexes
+  the type name table.
+- The move and item names are variable-length, terminated rather than padded,
+  so a start that is one byte out slides every later entry and still reads as
+  words. Both tables are checked at the far end as well as the near one, and
+  the item table also at entry four, where a start that is right but a walk
+  that is not shows up first.
 
 When you add an offset, add its check. "It produced output" is not evidence.
 
 New offsets were found by searching the cartridge for content whose bytes are
-known independently — the encoded string `BULBASAUR`, a species' published base
-stats — and then confirming the *structure* against the
+known independently (the encoded string `BULBASAUR`, a species' published base
+stats), and then confirming the *structure* against the
 [pret](https://github.com/pret) disassemblies, which are the reference for how
 these games are laid out. Do not copy an address out of a disassembly and
 assume it applies: those are bank:address pairs for a build of the source, and
@@ -96,9 +105,21 @@ godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png f
 ```
 
 A contact sheet of all 251 species is the fastest correctness check the project
-has — a bad decompressor, a wrong tile order, a wrong palette and an off-by-one
+has: a bad decompressor, a wrong tile order, a wrong palette and an off-by-one
 in a pointer table all look obviously wrong, and all of them look fine in a
 manifest.
+
+Text decodes get the same treatment from `tools/dump_tables.gd`, which prints a
+cached table rather than drawing it:
+
+```bash
+godot --headless --path . -s res://tools/dump_tables.gd -- gold moves
+```
+
+A name table that has slid by a byte still decodes into words, so reading the
+output is the check. Cross-check a handful of moves against published power,
+accuracy and PP while you are there; the runtime checks pin the ends of a
+table, not what is between them.
 
 ## Seeing the UI without pressing Play
 
@@ -110,8 +131,8 @@ godot --path . -s res://tools/screenshot.gd -- res://game/main/main.tscn /tmp/sh
 
 An optional trailing `<method> <times> [int arg]` drives the scene before
 capturing, so you can photograph a screen mid-interaction rather than only on
-its first frame. This briefly opens a real window — rendering needs a display,
-so it cannot run under `--headless`.
+its first frame. This briefly opens a real window, because rendering needs a
+display, so it cannot run under `--headless`.
 
 ## Pitfalls that cost real time
 
@@ -147,7 +168,7 @@ so it cannot run under `--headless`.
   in `test_rom_cache.gd` that pins this down so nobody rediscovers it the hard
   way.
 - **GDScript lambdas capture by value.** Assigning to a captured local inside a
-  `func():` closure updates the copy, not the original — the write silently
+  `func():` closure updates the copy, not the original, and the write silently
   vanishes. Append to an Array/Dictionary, or use a method.
 - **A closure stored on the signal of an object it captures leaks that
   object.** The cycle is invisible until Godot prints "ObjectDB instances were
@@ -158,17 +179,17 @@ so it cannot run under `--headless`.
 
 ## GDScript conventions
 
-- Tabs for indentation (Godot default — don't reformat to spaces).
+- Tabs for indentation (Godot default; don't reformat to spaces).
 - Static typing everywhere practical: `var health: int = 10`,
   `func heal(amount: int) -> void:`.
 - `snake_case` for variables, functions and files; `PascalCase` for classes and
   nodes.
-- No comments explaining *what* code does — only *why*, for non-obvious
+- No comments explaining *what* code does, only *why*, for non-obvious
   constraints.
 
 ## Scenes
 
-`.tscn` and `.tres` are plain text (format 3) — read and edit them directly
+`.tscn` and `.tres` are plain text (format 3), so read and edit them directly
 like source. Don't hand-invent `uid://` identifiers; Godot regenerates missing
 or invalid ones on load, or omit the `uid` field on `ext_resource` lines and
 let the editor fill it in.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,6 +57,25 @@ The importer under `game/import/` decodes a verified cartridge into a cache:
 Each decoder takes bytes and returns data; none of them knows what a cartridge
 is, so all of them are testable on a handful of hand-built bytes.
 
+Above the cache, `game/data/game_data.gd` reads it back. It is the only thing
+the engine uses to see cartridge content: nothing above it opens a ROM, and
+nothing in it knows what a ROM is. It is also where JSON's single number type is
+coerced back to int, once, rather than at every call site.
+
+The drawing layer is deliberately thin:
+
+| | |
+|---|---|
+| `render/pic_image.gd` | Colour indices plus a palette to an `Image` |
+| `render/gen2_screen.gd` | The 160x144 screen, scaled by a whole number |
+
+`Gen2Screen` renders the game into a `SubViewport` the size of the real
+hardware and blows it up by an integer factor, while the interface around it
+stays at the window's own resolution. This is a `Control` and not a
+project-wide stretch setting on purpose: a stretch would have made the menus
+fuzzy to keep the game sharp, and any non-integer factor resamples an 8x8 tile
+into something that crawls when it moves.
+
 ## Offsets, and why they are checked at runtime
 
 `rom_layout.gd` is a table of absolute positions inside each supported dump. An
@@ -133,6 +152,19 @@ An optional trailing `<method> <times> [int arg]` drives the scene before
 capturing, so you can photograph a screen mid-interaction rather than only on
 its first frame. This briefly opens a real window, because rendering needs a
 display, so it cannot run under `--headless`.
+
+Screens are built so this works on them. `pic_viewer.gd` reacts to keys, but
+every one of those keys is also a plain method (`next_species`, `toggle_shiny`,
+`toggle_back`), so a screen can be photographed in any state without a human at
+the keyboard:
+
+```bash
+godot --path . -s res://tools/screenshot.gd -- res://game/render/pic_viewer.tscn /tmp/shot.png 20 show_species 1 249
+```
+
+Keep that property when you add a screen. A handler that only exists inside an
+input match statement cannot be driven, and a screen that cannot be driven
+cannot be checked without asking someone what they see.
 
 ## Pitfalls that cost real time
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1,0 +1,184 @@
+class_name GameData
+extends RefCounted
+
+## A decoded cartridge, read back out of the cache.
+##
+## The importer's counterpart, and the only way the engine sees cartridge
+## content: nothing downstream of here opens a ROM, and nothing here knows what
+## a ROM is. It is [RefCounted] and scene-free like the layer that wrote it, so
+## a battle or a menu can be exercised in a test with no display.
+##
+## JSON has one number type, so every number in the cache comes back as a float
+## and every comparison against an int quietly fails. Coercion happens here,
+## once, rather than at each of the places that would otherwise have to remember.
+##
+## Index buffers are loaded on first use and kept. A pic atlas is a megabyte or
+## so of indices; reading four of them to draw one sprite would be a waste, and
+## re-reading one per frame would be worse.
+
+var id: StringName = &""
+var sha1: String = ""
+var directory: String = ""
+
+var _species: Array = []
+var _moves: Array = []
+var _items: Array = []
+var _types: Array = []
+var _atlases: Dictionary = {}
+var _indices: Dictionary = {}
+
+
+## Opens the cache for a registry game, or null if it has not been imported.
+static func open(game_id: StringName) -> GameData:
+	var hash: String = RomRegistry.sha1_for(game_id)
+	if hash.is_empty():
+		return null
+	return open_directory(RomCache.directory_for(game_id, hash))
+
+
+## Opens a cache directory, or null if it is missing, incomplete, or was written
+## by an importer whose format this build does not read.
+static func open_directory(path: String) -> GameData:
+	if not RomCache.is_usable(path):
+		return null
+
+	var manifest: Dictionary = RomCache.read_manifest(path)
+	var data := GameData.new()
+	data.directory = path
+	data.id = StringName(manifest.get("game_id", ""))
+	data.sha1 = String(manifest.get("sha1", ""))
+	data._atlases = manifest.get("atlases", {})
+	data._species = data._read_array(RomCache.species_path(path))
+	data._moves = data._read_array(RomCache.moves_path(path))
+	data._items = data._read_array(RomCache.items_path(path))
+	data._types = data._read_array(RomCache.types_path(path))
+	return data
+
+
+## The first registry game with a usable cache, or null if none has been
+## imported. For development views that just want something to draw.
+static func open_any() -> GameData:
+	for game_id: StringName in RomRegistry.ORDER:
+		var data: GameData = open(game_id)
+		if data != null:
+			return data
+	return null
+
+
+func title() -> String:
+	return RomRegistry.title_for(id)
+
+
+func species_count() -> int:
+	return _species.size()
+
+
+## One species by Pokédex number, or an empty Dictionary if there is no such
+## number. Out of range is a question, not a crash: a mod may well ask.
+func species(number: int) -> Dictionary:
+	return _entry(_species, number - 1)
+
+
+func move(number: int) -> Dictionary:
+	return _entry(_moves, number - 1)
+
+
+func item(number: int) -> Dictionary:
+	return _entry(_items, number - 1)
+
+
+func item_name(number: int) -> String:
+	return String(item(number).get("name", ""))
+
+
+## Type names are indexed from zero, unlike everything else here.
+func type_name(number: int) -> String:
+	return String(_entry(_types, number).get("name", ""))
+
+
+## The four colours a species is drawn with, in index order. The cache stores
+## the cartridge's own 15-bit pair; white and black are implied.
+func palette(number: int, shiny: bool = false) -> PackedColorArray:
+	var entry: Dictionary = species(number)
+	if entry.is_empty():
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+
+	var stored: Array = entry["palette"]["shiny" if shiny else "normal"]
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int(stored[0])),
+		Gen2Palette.from_packed(int(stored[1])),
+	]))
+
+
+## Atlas metadata: width, height, cell, columns, decoded.
+func atlas(name: String) -> Dictionary:
+	var value: Variant = _atlases.get(name, {})
+	if not value is Dictionary:
+		return {}
+
+	var out: Dictionary = {}
+	for key: String in value:
+		out[key] = int(value[key])
+	return out
+
+
+## The index buffer for an atlas, read on first use and kept afterwards.
+func atlas_indices(name: String) -> PackedByteArray:
+	if _indices.has(name):
+		return _indices[name]
+
+	var indices: PackedByteArray = RomCache.read_indices(RomCache.pic_path(directory, name))
+	_indices[name] = indices
+	return indices
+
+
+## Where a species sits in its atlas, and how much of that cell it fills.
+##
+## Cells are the size of the largest pic of their kind so a slot can be found by
+## arithmetic; a smaller pic sits in the top-left of its cell and the rest is
+## blank. Returns { atlas, slot, width, height } in pixels, or an empty
+## Dictionary for a species that is not in the cache.
+func species_pic(number: int, back: bool = false) -> Dictionary:
+	var entry: Dictionary = species(number)
+	if entry.is_empty():
+		return {}
+
+	# Unown's main-table slot holds form A. Its other 25 forms are in an atlas
+	# of their own and are asked for by form, not by species.
+	var name: String = "back" if back else "front"
+	var cell: int = int(atlas(name).get("cell", 0))
+	if back:
+		return {"atlas": name, "slot": number - 1, "width": cell, "height": cell}
+
+	var tiles: Array = entry["front_tiles"]
+	return {
+		"atlas": name,
+		"slot": number - 1,
+		"width": int(tiles[0]) * Gen2Tiles.TILE_WIDTH,
+		"height": int(tiles[1]) * Gen2Tiles.TILE_HEIGHT,
+	}
+
+
+## One of Unown's 26 letter forms, which live outside the species tables.
+func unown_pic(form: int, back: bool = false) -> Dictionary:
+	if form < 0 or form >= RomLayout.UNOWN_FORMS:
+		return {}
+
+	var pic: Dictionary = species_pic(RomLayout.UNOWN_SPECIES, back)
+	if pic.is_empty():
+		return {}
+
+	pic["atlas"] = "unown_back" if back else "unown_front"
+	pic["slot"] = form
+	return pic
+
+
+func _read_array(path: String) -> Array:
+	var value: Variant = RomCache.read_json(path)
+	return value if value is Array else []
+
+
+func _entry(rows: Array, index: int) -> Dictionary:
+	if index < 0 or index >= rows.size():
+		return {}
+	return rows[index]

--- a/game/data/game_data.gd.uid
+++ b/game/data/game_data.gd.uid
@@ -1,0 +1,1 @@
+uid://7lcmsmqikdgv

--- a/game/import/lz_decompressor.gd
+++ b/game/import/lz_decompressor.gd
@@ -19,7 +19,7 @@ extends RefCounted
 ## The three back-references take an offset that is either a one-byte distance
 ## back from the write head (high bit set) or a two-byte absolute position from
 ## the start of the output (high bit clear). Sources may overlap the bytes being
-## written, which is how the format expresses runs — so the copy has to be
+## written, which is how the format expresses runs, so the copy has to be
 ## byte-at-a-time, not a slice.
 ##
 ## The bit-reversing opcode exists because these streams encode 2bpp tiles: a
@@ -56,7 +56,7 @@ static var _reversed_bits: PackedByteArray = PackedByteArray()
 
 
 ## Decompresses the stream starting at [param offset]. Returns the decompressed
-## bytes, or an empty array on failure — check [member failed] to tell that
+## bytes, or an empty array on failure; check [member failed] to tell that
 ## apart from a legitimately empty stream.
 func decompress(data: PackedByteArray, offset: int) -> PackedByteArray:
 	failed = false

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 ## Game Boy Color palette entries.
 ##
-## A colour is 15 bits packed little-endian as $0BBBBBGG GGGRRRRR — five bits
+## A colour is 15 bits packed little-endian as $0BBBBBGG GGGRRRRR, five bits
 ## per channel, red in the low bits. The hardware ignores bit 15.
 ##
 ## A Pokémon's stored palette holds only two colours. The other two are implied:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -12,18 +12,21 @@ extends RefCounted
 ## game never share a cache and a re-import cannot half-overwrite the last one.
 ##
 ## Pixel data is stored as raw colour indices rather than as images. It is what
-## the renderer wants — palettes are applied per species and per shiny state at
-## draw time — and it avoids a decode round-trip whose exactness would have to
+## the renderer wants (palettes are applied per species and per shiny state at
+## draw time), and it avoids a decode round-trip whose exactness would have to
 ## be trusted.
 
 const ROOT: String = "user://rom_cache"
 const MANIFEST: String = "manifest.json"
 const SPECIES: String = "species.json"
+const MOVES: String = "moves.json"
+const ITEMS: String = "items.json"
+const TYPES: String = "types.json"
 const PICS_DIR: String = "pics"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 1
+const FORMAT_VERSION: int = 2
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -36,6 +39,18 @@ static func manifest_path(directory: String) -> String:
 
 static func species_path(directory: String) -> String:
 	return "%s/%s" % [directory, SPECIES]
+
+
+static func moves_path(directory: String) -> String:
+	return "%s/%s" % [directory, MOVES]
+
+
+static func items_path(directory: String) -> String:
+	return "%s/%s" % [directory, ITEMS]
+
+
+static func types_path(directory: String) -> String:
+	return "%s/%s" % [directory, TYPES]
 
 
 static func pic_path(directory: String, name: String) -> String:
@@ -78,7 +93,7 @@ static func read_json(path: String) -> Variant:
 	return JSON.parse_string(text)
 
 
-## Index buffers are mostly runs of the same value, so they compress hard —
+## Index buffers are mostly runs of the same value, so they compress hard,
 ## roughly ten to one for a pic atlas.
 static func write_indices(path: String, data: PackedByteArray) -> bool:
 	var file: FileAccess = FileAccess.open_compressed(

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -9,7 +9,7 @@ extends RefCounted
 ##
 ## Order of business, and it matters: verify the hash, then verify the layout,
 ## then decode. [method verify_layout] exists because an offset table is a claim
-## that can rot — a wrong constant produces plausible-looking garbage rather
+## that can rot: a wrong constant produces plausible-looking garbage rather
 ## than an error, and garbage that reaches the cache is indistinguishable from
 ## real data later on. Checking a handful of values whose correct answers are
 ## known independently turns that class of mistake into an immediate failure.
@@ -47,7 +47,7 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 		return {"ok": false, "message": "Species name table: expected CELEBI, read %s." % last}
 
 	# Every base stats entry opens with its own Pokédex number, so the whole
-	# table self-checks in one pass — and a stride that is off by any amount
+	# table self-checks in one pass, and a stride that is off by any amount
 	# stops matching immediately.
 	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
 		var stored: int = rom.u8(RomLayout.base_stats_offset(layout, species))
@@ -61,8 +61,8 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	# a colour is 15 bits, and no species is drawn in two blacks. An offset that
 	# lands on the wrong table, or a stride that runs past the end of the right
 	# one, breaks one of those. This check exists because a palette table that
-	# was one whole table too far along still decoded — into sprites that were
-	# the correct shapes in the wrong colours, which nothing else would catch.
+	# was one whole table too far along still decoded into sprites that were the
+	# correct shapes in the wrong colours, which nothing else would catch.
 	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
 		var entry: int = RomLayout.palette_offset(layout, species)
 		var packed: Array = []
@@ -79,7 +79,70 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 		if packed.count(0) == packed.size():
 			return {"ok": false, "message": "Palette %d is blank." % species}
 
+	# Move and item names are variable-length, so one wrong byte at the start
+	# slides every entry after it and still reads as words. Checking the last
+	# entry of each table catches that; checking only the first would not.
+	var moves: PackedStringArray = Gen2Text.decode_sequence(
+		data, int(layout["move_names"]), RomLayout.MOVE_COUNT, RomLayout.MAX_NAME_LENGTH
+	)
+	if moves.size() != RomLayout.MOVE_COUNT:
+		return {"ok": false, "message": "Move name table ran out after %d." % moves.size()}
+	if moves[0] != "POUND":
+		return {"ok": false, "message": "Move name table: expected POUND, read %s." % moves[0]}
+	if moves[RomLayout.MOVE_COUNT - 1] != "BEAT UP":
+		return {
+			"ok": false,
+			"message": "Move name table: expected BEAT UP, read %s." % moves[
+				RomLayout.MOVE_COUNT - 1
+			],
+		}
+
+	# Every move entry opens with its animation, which is the move's own number,
+	# so the whole table self-checks the way the base stats do. The type byte is
+	# range-checked in the same pass because it indexes the type name table.
+	for move: int in range(1, RomLayout.MOVE_COUNT + 1):
+		var entry: int = RomLayout.move_data_offset(layout, move)
+		var animation: int = rom.u8(entry + RomLayout.MOVE_ANIMATION)
+		if animation != move:
+			return {"ok": false, "message": "Move entry %d claims to be %d." % [move, animation]}
+		var type_number: int = rom.u8(entry + RomLayout.MOVE_TYPE)
+		if type_number >= RomLayout.TYPE_COUNT:
+			return {
+				"ok": false,
+				"message": "Move %d has type $%02X, past the end of the type table." % [
+					move, type_number,
+				],
+			}
+
+	var items: PackedStringArray = Gen2Text.decode_sequence(
+		data, int(layout["item_names"]), RomLayout.ITEM_COUNT, RomLayout.MAX_NAME_LENGTH
+	)
+	if items.size() != RomLayout.ITEM_COUNT:
+		return {"ok": false, "message": "Item name table ran out after %d." % items.size()}
+	if items[0] != "MASTER BALL":
+		return {"ok": false, "message": "Item name table: expected MASTER BALL, read %s." % items[0]}
+	# Four entries in, so a start that is right but a walk that is not still
+	# fails here.
+	if items[3] != "GREAT BALL":
+		return {"ok": false, "message": "Item 4: expected GREAT BALL, read %s." % items[3]}
+
+	# The first and last type, either side of the padding run in the middle.
+	var first_type: String = type_name(rom, layout, 0)
+	if first_type != "NORMAL":
+		return {"ok": false, "message": "Type table: expected NORMAL, read %s." % first_type}
+	var last_type: String = type_name(rom, layout, RomLayout.TYPE_COUNT - 1)
+	if last_type != "DARK":
+		return {"ok": false, "message": "Type table: expected DARK, read %s." % last_type}
+
 	return {"ok": true, "message": "Layout verified."}
+
+
+## Resolves one entry of the type name pointer table.
+static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> String:
+	var table: int = RomLayout.type_name_pointer_offset(layout, type_number)
+	var address: int = rom.u16le(table)
+	var offset: int = RomFile.linear(RomLayout.bank_of(table), address)
+	return Gen2Text.decode(rom.bytes(), offset, RomLayout.MAX_NAME_LENGTH)
 
 
 ## Imports [param rom] into its cache directory, replacing whatever was there.
@@ -94,6 +157,9 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"message": "",
 		"directory": directory,
 		"species": 0,
+		"moves": 0,
+		"items": 0,
+		"types": 0,
 		"elapsed_ms": 0,
 	}
 
@@ -121,8 +187,21 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		result["message"] = "Could not decode pics."
 		return result
 
+	var moves: Array = _import_moves(rom, layout, on_progress)
+	var items: Array = _import_items(rom, layout, on_progress)
+	var types: Array = _import_types(rom, layout, on_progress)
+
 	if not RomCache.write_json(RomCache.species_path(directory), species):
 		result["message"] = "Could not write species data."
+		return result
+	if not RomCache.write_json(RomCache.moves_path(directory), moves):
+		result["message"] = "Could not write move data."
+		return result
+	if not RomCache.write_json(RomCache.items_path(directory), items):
+		result["message"] = "Could not write item data."
+		return result
+	if not RomCache.write_json(RomCache.types_path(directory), types):
+		result["message"] = "Could not write type data."
 		return result
 
 	var manifest: Dictionary = {
@@ -130,6 +209,9 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"game_id": String(rom.id),
 		"sha1": rom.sha1,
 		"species_count": species.size(),
+		"move_count": moves.size(),
+		"item_count": items.size(),
+		"type_count": types.size(),
 		"atlases": pics,
 		"complete": true,
 	}
@@ -139,8 +221,13 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 
 	result["ok"] = true
 	result["species"] = species.size()
+	result["moves"] = moves.size()
+	result["items"] = items.size()
+	result["types"] = types.size()
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
-	result["message"] = "Imported %d species in %d ms." % [species.size(), result["elapsed_ms"]]
+	result["message"] = "Imported %d species, %d moves and %d items in %d ms." % [
+		species.size(), moves.size(), items.size(), result["elapsed_ms"],
+	]
 	return result
 
 
@@ -191,6 +278,58 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 
 		if on_progress.is_valid():
 			on_progress.call("species", species, RomLayout.SPECIES_COUNT)
+
+	return out
+
+
+func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
+	var names: PackedStringArray = Gen2Text.decode_sequence(
+		rom.bytes(), int(layout["move_names"]), RomLayout.MOVE_COUNT, RomLayout.MAX_NAME_LENGTH
+	)
+	var out: Array = []
+
+	for move: int in range(1, RomLayout.MOVE_COUNT + 1):
+		var entry: int = RomLayout.move_data_offset(layout, move)
+		# The animation byte is dropped: it is the move's own number, and it is
+		# already spent proving the table is where the layout says it is.
+		out.append({
+			"number": move,
+			"name": names[move - 1],
+			"effect": rom.u8(entry + RomLayout.MOVE_EFFECT),
+			"power": rom.u8(entry + RomLayout.MOVE_POWER),
+			"type": rom.u8(entry + RomLayout.MOVE_TYPE),
+			"accuracy": rom.u8(entry + RomLayout.MOVE_ACCURACY),
+			"pp": rom.u8(entry + RomLayout.MOVE_PP),
+			"effect_chance": rom.u8(entry + RomLayout.MOVE_EFFECT_CHANCE),
+		})
+
+		if on_progress.is_valid():
+			on_progress.call("moves", move, RomLayout.MOVE_COUNT)
+
+	return out
+
+
+func _import_items(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
+	var names: PackedStringArray = Gen2Text.decode_sequence(
+		rom.bytes(), int(layout["item_names"]), RomLayout.ITEM_COUNT, RomLayout.MAX_NAME_LENGTH
+	)
+	var out: Array = []
+
+	for item: int in range(1, RomLayout.ITEM_COUNT + 1):
+		out.append({"number": item, "name": names[item - 1]})
+		if on_progress.is_valid():
+			on_progress.call("items", item, RomLayout.ITEM_COUNT)
+
+	return out
+
+
+func _import_types(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
+	var out: Array = []
+
+	for type_number: int in RomLayout.TYPE_COUNT:
+		out.append({"number": type_number, "name": type_name(rom, layout, type_number)})
+		if on_progress.is_valid():
+			on_progress.call("types", type_number + 1, RomLayout.TYPE_COUNT)
 
 	return out
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -7,9 +7,9 @@ extends RefCounted
 ## a decoder never has to think about banking. Gold and Silver share a layout;
 ## Crystal moved almost everything and is its own table.
 ##
-## Every offset here was located in the cartridges themselves — by searching for
+## Every offset here was located in the cartridges themselves, by searching for
 ## content whose bytes are known independently (the encoded string "BULBASAUR",
-## Bulbasaur's published base stats) — and then cross-checked against the pret
+## Bulbasaur's published base stats), and then cross-checked against the pret
 ## disassemblies for structure. That is why there is no entry for a ROM that is
 ## not in [RomRegistry]: an offset table is a claim about a specific dump, and
 ## the honest answer for an uncharacterised one is a refusal, not a guess.
@@ -22,6 +22,24 @@ const SPECIES_COUNT: int = 251
 const NAME_LENGTH: int = 10
 const BASE_STATS_SIZE: int = 32
 const PIC_POINTER_SIZE: int = 3
+
+const MOVE_COUNT: int = 251
+const MOVE_DATA_SIZE: int = 7
+
+## Item numbers run from 1 to 255. The last several entries are the unused
+## "TERU-SAMA" slots the cartridges ship with; they are decoded rather than
+## trimmed, so an item number always indexes the table directly.
+const ITEM_COUNT: int = 255
+
+## Type numbers are sparse: $00-$09 are the physical types, $14-$1B the special
+## ones, and the run between is padding that still has a name entry. Reading all
+## 28 keeps the table indexable by type number.
+const TYPE_COUNT: int = 28
+const TYPE_POINTER_SIZE: int = 2
+
+## The longest move and item name in these games is twelve characters. This is
+## the runaway guard for a terminator walk, not a field width.
+const MAX_NAME_LENGTH: int = 16
 
 ## Unown's entry in the main pic table is a deliberate $FF placeholder: its 26
 ## letter forms live in a table of their own.
@@ -57,6 +75,17 @@ const OFFSET_EGG_GROUPS: int = 23
 const OFFSET_TMHM: int = 24
 const TMHM_BYTES: int = 8
 
+## Byte positions within a 7-byte move entry.
+## The animation is the move's own number, which is what makes the table
+## self-checking in the same way the base stats are.
+const MOVE_ANIMATION: int = 0
+const MOVE_EFFECT: int = 1
+const MOVE_POWER: int = 2
+const MOVE_TYPE: int = 3
+const MOVE_ACCURACY: int = 4
+const MOVE_PP: int = 5
+const MOVE_EFFECT_CHANCE: int = 6
+
 ## Gold and Silver are byte-identical in every table below; only content differs.
 const GOLD_SILVER: Dictionary = {
 	"species_names": 0x1B0B74,
@@ -67,6 +96,7 @@ const GOLD_SILVER: Dictionary = {
 	"move_names": 0x1B1574,
 	"item_names": 0x1B0000,
 	"move_data": 0x41AFE,
+	"type_names": 0x509AE,
 	# Gold and Silver patch three bank numbers and pass the rest through. The
 	# stored value is what the linker assigned before three pic sections were
 	# moved; see FixPicBank in pokegold.
@@ -83,6 +113,7 @@ const CRYSTAL: Dictionary = {
 	"move_names": 0x1C9F29,
 	"item_names": 0x1C8000,
 	"move_data": 0x41AFB,
+	"type_names": 0x5097B,
 	# Crystal's equivalent table is a contiguous $48-$5F, so the whole remap
 	# collapses to a constant: PICS_FIX in pokecrystal.
 	"pic_bank_add": 0x36,
@@ -109,7 +140,7 @@ static func is_characterised(id: StringName) -> bool:
 ##
 ## The tables were written before the pic sections were shuffled between banks
 ## and nobody rebuilt them, so the game repairs each pointer as it loads it.
-## Reproducing that is not optional — the stored numbers are simply wrong.
+## Reproducing that is not optional: the stored numbers are simply wrong.
 static func fix_pic_bank(layout: Dictionary, stored: int) -> int:
 	var patch: Dictionary = layout["pic_bank_patch"]
 	if patch.has(stored):
@@ -140,3 +171,21 @@ static func pic_pointer_offset(layout: Dictionary, species: int, back: bool) -> 
 static func unown_pic_pointer_offset(layout: Dictionary, form: int, back: bool) -> int:
 	var pair: int = form * 2 + (1 if back else 0)
 	return int(layout["unown_pic_pointers"]) + pair * PIC_POINTER_SIZE
+
+
+static func move_data_offset(layout: Dictionary, move: int) -> int:
+	return int(layout["move_data"]) + (move - 1) * MOVE_DATA_SIZE
+
+
+## Type names are reached through a pointer table rather than stored inline,
+## because every unused type number points at the same "NORMAL" string. The
+## pointers are two bytes, not three: the strings sit in the table's own bank.
+static func type_name_pointer_offset(layout: Dictionary, type_number: int) -> int:
+	return int(layout["type_names"]) + type_number * TYPE_POINTER_SIZE
+
+
+## The bank a dump offset falls in, for resolving a pointer that carries an
+## address but no bank number of its own.
+static func bank_of(offset: int) -> int:
+	@warning_ignore("integer_division")
+	return offset / RomFile.BANK_SIZE

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -41,6 +41,33 @@ static func decode_fixed(data: PackedByteArray, offset: int, length: int) -> Str
 	return decode(data, offset, length)
 
 
+## Walks [param count] consecutive terminated strings starting at [param offset].
+##
+## The species names are a fixed-width table, but the move and item names are
+## not: each entry ends at its terminator and the next one begins on the very
+## next byte. Nothing announces how long an entry is, so a single wrong byte
+## slides every name after it, which is why the importer checks the last entry
+## of such a table and not only the first.
+##
+## [param max_length] is a runaway guard rather than a field width. Without it, a
+## table read past its own end would scan the remaining megabyte looking for a
+## terminator that is not coming.
+static func decode_sequence(
+	data: PackedByteArray, offset: int, count: int, max_length: int
+) -> PackedStringArray:
+	var out: PackedStringArray = PackedStringArray()
+	var at: int = offset
+	for i: int in count:
+		if at < 0 or at >= data.size():
+			break
+		out.append(decode(data, at, max_length))
+		var end: int = at
+		while end < data.size() and data[end] != TERMINATOR and end - at < max_length:
+			end += 1
+		at = end + 1
+	return out
+
+
 static func character(byte: int) -> String:
 	var table: Dictionary = _characters()
 	if table.has(byte):

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -8,7 +8,7 @@ extends RefCounted
 ## leftmost pixel.
 ##
 ## Decoding stops at indices 0-3. Turning those into colours needs a palette,
-## which is a separate concern — see [Gen2Palette]. Keeping the two apart is
+## which is a separate concern; see [Gen2Palette]. Keeping the two apart is
 ## what makes shiny variants free: same pixels, different palette.
 
 const TILE_WIDTH: int = 8
@@ -44,8 +44,8 @@ static func decode_tile(data: PackedByteArray, offset: int) -> PackedByteArray:
 ## Decodes a Pokémon or trainer pic into a row-major index buffer
 ## [param columns] * 8 wide and [param rows] * 8 tall.
 ##
-## Pics store their tiles column-major — the whole left column top to bottom,
-## then the next — because the game streams them into VRAM a column at a time.
+## Pics store their tiles column-major, the whole left column top to bottom and
+## then the next, because the game streams them into VRAM a column at a time.
 ## Every other tilemap in these games is row-major, so this is the one place
 ## that ordering flips.
 ##

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 	for id: StringName in RomRegistry.ORDER:
 		lines.append("  %-8s %s" % [RomRegistry.title_for(id), RomRegistry.sha1_for(id)])
 
-	print("gen2recomp — supported cartridges:")
+	print("gen2recomp supported cartridges:")
 	print("\n".join(lines))
 
 	_status.text = "No ROM imported\n\nSupported: %s" % ", ".join(_titles())

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -1,0 +1,71 @@
+class_name Gen2Screen
+extends Control
+
+## A Game Boy Color screen: 160x144 pixels, scaled by a whole number to fit.
+##
+## The game does not run at the window's resolution and must not. A GBC pixel
+## has to stay square and stay sharp, so everything the game draws goes into a
+## [SubViewport] the size of the real hardware and that image is blown up by an
+## integer factor. Any other scale resamples an 8x8 tile into something that
+## crawls when it moves.
+##
+## The launcher chrome around it is ordinary Godot UI at the window's own
+## resolution. Keeping the two apart is why this is a [Control] rather than a
+## project-wide stretch setting: menus stay crisp at any window size, and the
+## game stays a Game Boy.
+##
+## Add what the game draws with [method display]; it goes inside the viewport.
+
+const WIDTH: int = 160
+const HEIGHT: int = 144
+
+## Emitted after a resize changes the whole-number factor the screen is drawn
+## at. Nothing in the game should care, but a debug overlay might.
+signal scale_changed(factor: int)
+
+var scale_factor: int = 1
+
+@onready var _container: SubViewportContainer = %Container
+@onready var _viewport: SubViewport = %Viewport
+
+
+func _ready() -> void:
+	# The viewport's size is not set here: a stretching SubViewportContainer
+	# owns it, and it falls out of the container's size divided by the shrink
+	# factor. Writing it directly is refused at runtime.
+	resized.connect(_fit)
+	_fit()
+
+
+## Puts a node inside the screen. Anything added this way is drawn in hardware
+## pixels, so position it in the 160x144 space and nothing else.
+func display(node: Node) -> void:
+	_viewport.add_child(node)
+
+
+## Removes and frees everything currently on screen.
+func clear() -> void:
+	for child: Node in _viewport.get_children():
+		_viewport.remove_child(child)
+		child.queue_free()
+
+
+## The viewport itself, for a caller that needs to read the drawn frame.
+func viewport() -> SubViewport:
+	return _viewport
+
+
+## The largest whole number of window pixels per hardware pixel that still fits.
+func _fit() -> void:
+	var factor: int = maxi(1, mini(int(size.x) / WIDTH, int(size.y) / HEIGHT))
+	var drawn := Vector2(WIDTH * factor, HEIGHT * factor)
+
+	_container.stretch_shrink = factor
+	_container.size = drawn
+	# Centred rather than anchored: a screen that does not divide evenly into
+	# the window leaves a margin, and an uneven one is visible.
+	_container.position = ((size - drawn) * 0.5).floor()
+
+	if factor != scale_factor:
+		scale_factor = factor
+		scale_changed.emit(factor)

--- a/game/render/gen2_screen.gd.uid
+++ b/game/render/gen2_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://ddok4joii22ue

--- a/game/render/gen2_screen.tscn
+++ b/game/render/gen2_screen.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://game/render/gen2_screen.gd" id="1"]
+
+[node name="Gen2Screen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+
+[node name="Container" type="SubViewportContainer" parent="."]
+unique_name_in_owner = true
+texture_filter = 1
+layout_mode = 0
+offset_right = 160.0
+offset_bottom = 144.0
+stretch = true
+
+[node name="Viewport" type="SubViewport" parent="Container"]
+unique_name_in_owner = true
+disable_3d = true
+handle_input_locally = false
+size = Vector2i(160, 144)
+render_target_update_mode = 4

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -1,0 +1,105 @@
+class_name Gen2PicImage
+extends RefCounted
+
+## Colour indices plus a palette to an [Image].
+##
+## The cache stores what the cartridge stores: two bits per pixel, no colour. A
+## palette is chosen here, at draw time, which is why a shiny sprite costs one
+## different [PackedColorArray] and not a second copy of the pixels.
+##
+## The whole image is built as one buffer and handed to
+## [method Image.create_from_data]. Per-pixel [method Image.set_pixel] on a
+## 56x56 sprite is 3136 calls through the binding for something that is a table
+## lookup, and a battle can want several sprites in a frame.
+##
+## Node-free like the layers below it: an [Image] is data, not a scene, so this
+## can be checked in a headless test.
+
+const CHANNELS: int = 4
+
+
+## An image [param width] x [param height] pixels from a row-major index buffer.
+##
+## [param transparent_background] makes index 0 transparent. The hardware has no
+## alpha and draws that index as white, which is right for a battle sprite in
+## its window; it is wrong for a sprite over anything else.
+static func from_indices(
+	indices: PackedByteArray,
+	width: int,
+	height: int,
+	palette: PackedColorArray,
+	transparent_background: bool = false
+) -> Image:
+	if width <= 0 or height <= 0 or indices.size() < width * height:
+		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
+
+	var lookup: PackedByteArray = _lookup(palette, transparent_background)
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(width * height * CHANNELS)
+
+	for i: int in width * height:
+		var at: int = int(indices[i]) * CHANNELS
+		var to: int = i * CHANNELS
+		pixels[to] = lookup[at]
+		pixels[to + 1] = lookup[at + 1]
+		pixels[to + 2] = lookup[at + 2]
+		pixels[to + 3] = lookup[at + 3]
+
+	return Image.create_from_data(width, height, false, Image.FORMAT_RGBA8, pixels)
+
+
+## One cell out of a pic atlas, cropped to the pic's real size.
+##
+## [param pic] is what [method GameData.species_pic] returns: which atlas, which
+## slot, and how much of the cell the sprite actually fills. Cropping matters
+## because a cell is the size of the largest pic of its kind, so a 5x5 sprite
+## carries two rows and columns of blank tiles it should not be positioned by.
+static func from_atlas(
+	indices: PackedByteArray,
+	atlas: Dictionary,
+	pic: Dictionary,
+	palette: PackedColorArray,
+	transparent_background: bool = false
+) -> Image:
+	var cell: int = int(atlas.get("cell", 0))
+	var columns: int = int(atlas.get("columns", 0))
+	var atlas_width: int = int(atlas.get("width", 0))
+	var slot: int = int(pic.get("slot", -1))
+	if cell <= 0 or columns <= 0 or atlas_width <= 0 or slot < 0:
+		return Image.create_empty(1, 1, false, Image.FORMAT_RGBA8)
+
+	var width: int = mini(int(pic.get("width", cell)), cell)
+	var height: int = mini(int(pic.get("height", cell)), cell)
+	if width <= 0 or height <= 0:
+		return Image.create_empty(1, 1, false, Image.FORMAT_RGBA8)
+
+	var left: int = (slot % columns) * cell
+	var top: int = (slot / columns) * cell
+	var cropped: PackedByteArray = PackedByteArray()
+	cropped.resize(width * height)
+
+	for y: int in height:
+		var from: int = (top + y) * atlas_width + left
+		if from + width > indices.size():
+			break
+		for x: int in width:
+			cropped[y * width + x] = indices[from + x]
+
+	return from_indices(cropped, width, height, palette, transparent_background)
+
+
+## The palette flattened to bytes, four per index, so the inner loop is a copy
+## rather than a colour conversion.
+static func _lookup(palette: PackedColorArray, transparent_background: bool) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Palette.COLORS_PER_PIC * CHANNELS)
+
+	for i: int in Gen2Palette.COLORS_PER_PIC:
+		var color: Color = palette[i] if i < palette.size() else Color.MAGENTA
+		var at: int = i * CHANNELS
+		out[at] = int(roundf(color.r * 255.0))
+		out[at + 1] = int(roundf(color.g * 255.0))
+		out[at + 2] = int(roundf(color.b * 255.0))
+		out[at + 3] = 0 if transparent_background and i == 0 else 255
+
+	return out

--- a/game/render/pic_image.gd.uid
+++ b/game/render/pic_image.gd.uid
@@ -1,0 +1,1 @@
+uid://ddtlsn23r8gq8

--- a/game/render/pic_viewer.gd
+++ b/game/render/pic_viewer.gd
@@ -1,0 +1,127 @@
+extends Control
+
+## Development view: one species on a real 160x144 screen.
+##
+## Scaffolding, and deliberately so. It exists to prove the whole path from a
+## cartridge to a lit pixel (cache to indices to palette to viewport to an
+## integer-scaled window) and to make a wrong decode visible without a dev tool
+## writing a PNG. The battle screen will do this properly, with the pic where
+## the hardware puts it and a tile-based font around it.
+##
+## Left/right change species, S toggles shiny, B swaps front for back. Each is
+## also a plain method so `tools/screenshot.gd` can drive it.
+
+## The white the hardware fills a pic window with. Index 0 of every pic is this
+## colour, so a sprite on it looks exactly as it does in the game.
+const BACKGROUND: Color = Color.WHITE
+
+var _data: GameData = null
+var _number: int = 1
+var _shiny: bool = false
+var _back: bool = false
+
+var _pic: TextureRect = null
+
+@onready var _screen: Gen2Screen = %Screen
+@onready var _caption: Label = %Caption
+@onready var _hint: Label = %Hint
+
+
+func _ready() -> void:
+	_data = GameData.open_any()
+	if _data == null:
+		_caption.text = "No cache found"
+		_hint.text = "Run tools/import_rom.gd first."
+		return
+
+	var field := ColorRect.new()
+	field.color = BACKGROUND
+	field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_screen.display(field)
+
+	_pic = TextureRect.new()
+	# Nearest, or the whole point of the integer-scaled viewport is lost on the
+	# last hop.
+	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_screen.display(_pic)
+
+	_refresh()
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if _data == null or not event.is_pressed():
+		return
+
+	var key: InputEventKey = event as InputEventKey
+	if key == null:
+		return
+
+	match key.keycode:
+		KEY_RIGHT:
+			next_species()
+		KEY_LEFT:
+			previous_species()
+		KEY_S:
+			toggle_shiny()
+		KEY_B:
+			toggle_back()
+		_:
+			return
+	accept_event()
+
+
+func next_species() -> void:
+	show_species(_number + 1)
+
+
+func previous_species() -> void:
+	show_species(_number - 1)
+
+
+## Wraps at both ends, so holding an arrow down never lands on a blank screen.
+func show_species(number: int) -> void:
+	if _data == null:
+		return
+	var count: int = _data.species_count()
+	if count <= 0:
+		return
+	_number = wrapi(number, 1, count + 1)
+	_refresh()
+
+
+func toggle_shiny() -> void:
+	_shiny = not _shiny
+	_refresh()
+
+
+func toggle_back() -> void:
+	_back = not _back
+	_refresh()
+
+
+func _refresh() -> void:
+	if _data == null or _pic == null:
+		return
+
+	var entry: Dictionary = _data.species(_number)
+	var pic: Dictionary = _data.species_pic(_number, _back)
+	if entry.is_empty() or pic.is_empty():
+		return
+
+	var atlas: Dictionary = _data.atlas(pic["atlas"])
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), atlas, pic, _data.palette(_number, _shiny)
+	)
+
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = image.get_size()
+	_pic.position = (
+		Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) - Vector2(image.get_size())
+	).floor() * 0.5
+
+	_caption.text = "%s   #%03d %s   %s   %s" % [
+		_data.title(), _number, entry["name"],
+		"back" if _back else "front",
+		"shiny" if _shiny else "normal",
+	]
+	_hint.text = "left/right species    S shiny    B front/back"

--- a/game/render/pic_viewer.gd.uid
+++ b/game/render/pic_viewer.gd.uid
@@ -1,0 +1,1 @@
+uid://dybm4ldef12s2

--- a/game/render/pic_viewer.tscn
+++ b/game/render/pic_viewer.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://game/render/pic_viewer.gd" id="1"]
+[ext_resource type="PackedScene" path="res://game/render/gen2_screen.tscn" id="2"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0.0509804, 0.0745098, 0.164706, 1)
+
+[node name="PicViewer" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+
+[node name="Background" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
+
+[node name="Layout" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 12
+
+[node name="Caption" type="Label" parent="Layout"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 20
+text = "loading"
+horizontal_alignment = 1
+
+[node name="Screen" parent="Layout" instance=ExtResource("2")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Hint" type="Label" parent="Layout"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+theme_override_colors/font_color = Color(0.6, 0.65, 0.75, 1)
+text = ""
+horizontal_alignment = 1

--- a/game/rom/rom_file.gd
+++ b/game/rom/rom_file.gd
@@ -9,7 +9,7 @@ extends RefCounted
 ## a decoder.
 ##
 ## Reads are bounds-checked and return zero rather than faulting. Decoders walk
-## data whose length is only known once it has been decoded — a corrupt stream
+## data whose length is only known once it has been decoded, and a corrupt stream
 ## should end up as an honest "that did not decode" instead of an engine error.
 
 ## Cartridge banks are 16 KiB; the CPU sees one fixed and one switchable.
@@ -42,7 +42,7 @@ static func open_verified(rom_path: String) -> RomFile:
 	return rom
 
 
-## Wraps bytes that have already been vouched for. For tests and tooling —
+## Wraps bytes that have already been vouched for. For tests and tooling;
 ## production paths should go through [method open_verified].
 static func from_bytes(data: PackedByteArray, id: StringName = &"") -> RomFile:
 	var rom := RomFile.new()

--- a/game/rom/rom_header.gd
+++ b/game/rom/rom_header.gd
@@ -4,7 +4,7 @@ extends RefCounted
 ## The Game Boy cartridge header at $0100-$014F.
 ##
 ## The import gate identifies a dump by SHA-1, which is stricter than anything
-## in here — this exists so a *diagnostic* can say why a file looked wrong, and
+## in here. This exists so a *diagnostic* can say why a file looked wrong, and
 ## so an added registry entry can be sanity-checked against what the cartridge
 ## claims about itself. Nothing in the importer branches on these fields.
 
@@ -23,7 +23,7 @@ const HEADER_CHECKSUM: int = 0x14D
 const GLOBAL_CHECKSUM: int = 0x14E
 
 ## $80 runs on both Game Boy and Game Boy Color; $C0 is Color-only. Gold and
-## Silver are $80, Crystal is $C0 — Crystal was the first mainline game that
+## Silver are $80, Crystal is $C0, because Crystal was the first mainline game that
 ## would not boot on a DMG.
 const CGB_COMPATIBLE: int = 0x80
 const CGB_ONLY: int = 0xC0

--- a/game/rom/rom_registry.gd
+++ b/game/rom/rom_registry.gd
@@ -5,13 +5,13 @@ extends RefCounted
 ##
 ## gen2recomp ships no game data. A user supplies their own cartridge dump and
 ## it is matched against this table by SHA-1 before a single byte is read for
-## content. An unknown hash is a hard refusal, never a "try anyway" — a ROM we
+## content. An unknown hash is a hard refusal, never a "try anyway": a ROM we
 ## have not characterised has unknown bank layout, and guessing produces
 ## corrupt assets rather than an honest error.
 ##
 ## Gen 2 is three games. Crystal's two common filenames (the "(UE) (V1.1)" and
 ## "(USA, Europe) (Rev 1)" dumps) are byte-identical, so they collapse to one
-## entry here — matching is by hash, never by filename.
+## entry here: matching is by hash, never by filename.
 
 ## Every Game Boy Color cartridge in this generation is 2 MiB. Used only as a
 ## cheap pre-filter so a wrong file is rejected before we hash it.

--- a/game/rom/rom_verifier.gd
+++ b/game/rom/rom_verifier.gd
@@ -4,7 +4,7 @@ extends RefCounted
 ## Identifies a user-supplied ROM file by SHA-1 against [RomRegistry].
 ##
 ## Pure and node-free so the whole import gate is testable headlessly. Nothing
-## here reads game content — it only answers "is this a cartridge we know?".
+## here reads game content; it only answers "is this a cartridge we know?".
 ## The importer that follows is entitled to assume a verified hash.
 
 enum Status {

--- a/roms/README.md
+++ b/roms/README.md
@@ -19,8 +19,8 @@ Two independent mechanisms:
 - **`.gitignore` + the pre-commit hook** keep them out of the repository. The
   hook checks staged blobs by extension *and* by size, so even a renamed dump
   with no extension is refused.
-- **`.gdignore`** makes Godot's resource system skip this directory entirely —
-  the files are never imported and never swept into an export. That file must
+- **`.gdignore`** makes Godot's resource system skip this directory entirely,
+  so the files are never imported and never swept into an export. That file must
   stay here; deleting it would let a build pick up a cartridge.
 
 ## Checking your files

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -1,0 +1,165 @@
+extends GutTest
+
+## Builds its own cache and reads it back. Nothing here opens a cartridge: the
+## point of the cache is that the engine never needs one, so its reader has to
+## be testable without one too.
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"testgame", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+## A cache with two species, one of each other table, and a 2x2-cell atlas.
+func _write_cache(complete: bool = true) -> void:
+	RomCache.write_json(RomCache.species_path(_directory), [
+		_species(1, "BULBASAUR", 0x1234, 0x5678),
+		_species(2, "IVYSAUR", 0x0C63, 0x1084),
+	])
+	RomCache.write_json(RomCache.moves_path(_directory), [
+		{"number": 1, "name": "POUND", "power": 40, "type": 0, "accuracy": 255, "pp": 35},
+	])
+	RomCache.write_json(RomCache.items_path(_directory), [{"number": 1, "name": "MASTER BALL"}])
+	RomCache.write_json(RomCache.types_path(_directory), [
+		{"number": 0, "name": "NORMAL"}, {"number": 1, "name": "FIGHTING"},
+	])
+	RomCache.write_indices(RomCache.pic_path(_directory, "front"), PackedByteArray([
+		0, 0, 1, 1,
+		0, 0, 1, 1,
+		2, 2, 3, 3,
+		2, 2, 3, 3,
+	]))
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "testgame",
+		"sha1": "0123456789abcdef",
+		"species_count": 2,
+		"atlases": {
+			"front": {"width": 4, "height": 4, "cell": 2, "columns": 2, "decoded": 2},
+			"back": {"width": 4, "height": 4, "cell": 2, "columns": 2, "decoded": 2},
+		},
+		"complete": complete,
+	})
+
+
+func _species(number: int, name: String, normal: int, shiny: int) -> Dictionary:
+	return {
+		"number": number,
+		"name": name,
+		"stats": {"hp": 45, "attack": 49},
+		"types": [0, 3],
+		"front_tiles": [1, 1],
+		"palette": {"normal": [normal, normal], "shiny": [shiny, shiny]},
+	}
+
+
+func test_a_complete_cache_opens() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_not_null(data)
+	assert_eq(data.species_count(), 2)
+
+
+func test_an_incomplete_cache_does_not_open() -> void:
+	# An interrupted import must not be read as if it were a finished one.
+	_write_cache(false)
+	assert_null(GameData.open_directory(_directory))
+
+
+func test_a_missing_cache_does_not_open() -> void:
+	assert_null(GameData.open_directory("user://nothing_here"))
+
+
+func test_numbers_come_back_as_ints_not_floats() -> void:
+	# JSON has one number type. Coercing here, once, is the whole reason this
+	# class exists rather than callers reading the JSON themselves.
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var move: Dictionary = data.move(1)
+	assert_eq(int(move["power"]), 40)
+	assert_true(data.atlas("front")["cell"] is int, "atlas metadata is coerced")
+
+
+func test_lookups_are_by_number_not_position() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(String(data.species(2)["name"]), "IVYSAUR")
+	assert_eq(data.item_name(1), "MASTER BALL")
+	assert_eq(String(data.move(1)["name"]), "POUND")
+
+
+func test_types_are_indexed_from_zero() -> void:
+	# Unlike every other table: NORMAL is type $00.
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.type_name(0), "NORMAL")
+	assert_eq(data.type_name(1), "FIGHTING")
+
+
+func test_an_unknown_number_answers_empty_rather_than_failing() -> void:
+	# A mod may well ask for something that is not there.
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_true(data.species(0).is_empty())
+	assert_true(data.species(999).is_empty())
+	assert_eq(data.item_name(999), "")
+	assert_eq(data.type_name(-1), "")
+
+
+func test_a_palette_is_four_colours_with_white_and_black_implied() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var palette: PackedColorArray = data.palette(1)
+	assert_eq(palette.size(), Gen2Palette.COLORS_PER_PIC)
+	assert_eq(palette[0], Color.WHITE)
+	assert_eq(palette[3], Color.BLACK)
+
+
+func test_shiny_is_a_different_palette_and_the_same_pixels() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_ne(data.palette(1, true), data.palette(1, false))
+
+
+func test_a_species_pic_reports_its_own_size_not_the_cell_size() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var pic: Dictionary = data.species_pic(1)
+	assert_eq(pic["slot"], 0, "slots are zero-based, species numbers are not")
+	assert_eq(pic["width"], Gen2Tiles.TILE_WIDTH, "one tile, not the two-tile cell")
+
+
+func test_back_pics_always_fill_their_cell() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.species_pic(1, true)["width"], 2)
+
+
+func test_unown_forms_come_from_their_own_atlas() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	# There is no Unown in this two-species cache, so the answer is empty
+	# rather than a lie about slot 0 of an atlas that was never written.
+	assert_true(data.unown_pic(0).is_empty())
+
+
+func test_index_buffers_are_read_once_and_kept() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var first: PackedByteArray = data.atlas_indices("front")
+	assert_eq(first.size(), 16)
+	assert_eq(data.atlas_indices("front"), first)
+
+
+func test_an_atlas_that_was_never_written_reads_as_empty() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_true(data.atlas("nothing").is_empty())
+	assert_eq(data.atlas_indices("back"), PackedByteArray())

--- a/tests/unit/test_game_data.gd.uid
+++ b/tests/unit/test_game_data.gd.uid
@@ -1,0 +1,1 @@
+uid://b47fninjjmlt

--- a/tests/unit/test_pic_image.gd
+++ b/tests/unit/test_pic_image.gd
@@ -1,0 +1,113 @@
+extends GutTest
+
+## Hand-built index buffers and palettes. No cache, no cartridge, no display:
+## an Image is data, so the whole of this runs headless.
+
+const RED: Color = Color(1, 0, 0)
+const BLUE: Color = Color(0, 0, 1)
+
+
+func _palette() -> PackedColorArray:
+	return Gen2Palette.pic_palette(PackedColorArray([RED, BLUE]))
+
+
+func test_each_index_becomes_its_palette_colour() -> void:
+	var indices: PackedByteArray = PackedByteArray([0, 1, 2, 3])
+	var image: Image = Gen2PicImage.from_indices(indices, 4, 1, _palette())
+
+	assert_eq(image.get_pixel(0, 0), Color.WHITE)
+	assert_eq(image.get_pixel(1, 0), RED)
+	assert_eq(image.get_pixel(2, 0), BLUE)
+	assert_eq(image.get_pixel(3, 0), Color.BLACK)
+
+
+func test_the_buffer_is_read_row_major() -> void:
+	var indices: PackedByteArray = PackedByteArray([0, 1, 2, 3])
+	var image: Image = Gen2PicImage.from_indices(indices, 2, 2, _palette())
+
+	assert_eq(image.get_size(), Vector2i(2, 2))
+	assert_eq(image.get_pixel(1, 0), RED, "second byte is the top-right pixel")
+	assert_eq(image.get_pixel(0, 1), BLUE, "third byte starts the second row")
+
+
+func test_background_is_opaque_white_by_default() -> void:
+	# What the hardware does: there is no alpha, and index 0 is drawn white.
+	var image: Image = Gen2PicImage.from_indices(PackedByteArray([0]), 1, 1, _palette())
+	assert_eq(image.get_pixel(0, 0).a, 1.0)
+
+
+func test_background_can_be_made_transparent() -> void:
+	var image: Image = Gen2PicImage.from_indices(PackedByteArray([0, 1]), 2, 1, _palette(), true)
+	assert_eq(image.get_pixel(0, 0).a, 0.0)
+	assert_eq(image.get_pixel(1, 0).a, 1.0, "only index 0 is affected")
+
+
+func test_a_short_buffer_yields_a_blank_image_rather_than_faulting() -> void:
+	var image: Image = Gen2PicImage.from_indices(PackedByteArray([1]), 8, 8, _palette())
+	assert_eq(image.get_size(), Vector2i(8, 8))
+
+
+func test_a_zero_sized_image_is_refused() -> void:
+	var image: Image = Gen2PicImage.from_indices(PackedByteArray(), 0, 0, _palette())
+	assert_gt(image.get_width(), 0, "an Image of no size cannot be created at all")
+
+
+func test_a_missing_palette_entry_is_visible_rather_than_black() -> void:
+	# Magenta, for the same reason an unknown text byte prints as its hex: a
+	# palette that did not load should look wrong, not merely dark.
+	var image: Image = Gen2PicImage.from_indices(
+		PackedByteArray([3]), 1, 1, PackedColorArray([Color.WHITE])
+	)
+	assert_eq(image.get_pixel(0, 0), Color.MAGENTA)
+
+
+func _atlas() -> Dictionary:
+	# Four 2x2 cells in a 4x4 buffer, two per row.
+	return {"width": 4, "height": 4, "cell": 2, "columns": 2}
+
+
+func _atlas_indices() -> PackedByteArray:
+	return PackedByteArray([
+		0, 0, 1, 1,
+		0, 0, 1, 1,
+		2, 2, 3, 3,
+		2, 2, 3, 3,
+	])
+
+
+func test_a_slot_is_cut_out_of_the_atlas_by_arithmetic() -> void:
+	var image: Image = Gen2PicImage.from_atlas(
+		_atlas_indices(), _atlas(), {"slot": 3, "width": 2, "height": 2}, _palette()
+	)
+	assert_eq(image.get_size(), Vector2i(2, 2))
+	assert_eq(image.get_pixel(0, 0), Color.BLACK, "slot 3 is the bottom-right cell")
+
+
+func test_slots_run_across_before_down() -> void:
+	var image: Image = Gen2PicImage.from_atlas(
+		_atlas_indices(), _atlas(), {"slot": 1, "width": 2, "height": 2}, _palette()
+	)
+	assert_eq(image.get_pixel(0, 0), RED, "slot 1 is the top-right cell, not the second row")
+
+
+func test_a_pic_smaller_than_its_cell_is_cropped() -> void:
+	# Cells are the size of the largest pic of their kind, so a small sprite
+	# carries blank tiles that must not be positioned by.
+	var image: Image = Gen2PicImage.from_atlas(
+		_atlas_indices(), _atlas(), {"slot": 0, "width": 1, "height": 1}, _palette()
+	)
+	assert_eq(image.get_size(), Vector2i(1, 1))
+
+
+func test_a_pic_cannot_claim_more_than_its_cell() -> void:
+	var image: Image = Gen2PicImage.from_atlas(
+		_atlas_indices(), _atlas(), {"slot": 0, "width": 99, "height": 99}, _palette()
+	)
+	assert_eq(image.get_size(), Vector2i(2, 2))
+
+
+func test_an_unknown_slot_yields_an_image_rather_than_an_error() -> void:
+	var image: Image = Gen2PicImage.from_atlas(
+		_atlas_indices(), _atlas(), {"slot": -1}, _palette()
+	)
+	assert_gt(image.get_width(), 0)

--- a/tests/unit/test_pic_image.gd.uid
+++ b/tests/unit/test_pic_image.gd.uid
@@ -1,0 +1,1 @@
+uid://b0s06wocgc7vn

--- a/tests/unit/test_rom_cache.gd
+++ b/tests/unit/test_rom_cache.gd
@@ -29,6 +29,19 @@ func test_a_directory_is_named_by_game_and_hash() -> void:
 	assert_true(gold.contains("gold"))
 
 
+func test_each_table_gets_its_own_file() -> void:
+	var paths: Array = [
+		RomCache.species_path(_directory),
+		RomCache.moves_path(_directory),
+		RomCache.items_path(_directory),
+		RomCache.types_path(_directory),
+		RomCache.manifest_path(_directory),
+	]
+	for path: String in paths:
+		assert_eq(paths.count(path), 1, "%s is not unique" % path)
+		assert_true(path.begins_with(_directory))
+
+
 func test_prepare_creates_the_tree() -> void:
 	assert_true(RomCache.prepare(_directory))
 	assert_true(DirAccess.dir_exists_absolute("%s/%s" % [_directory, RomCache.PICS_DIR]))

--- a/tests/unit/test_rom_file.gd
+++ b/tests/unit/test_rom_file.gd
@@ -1,7 +1,7 @@
 extends GutTest
 
 ## Addressing and header parsing, on a synthetic cartridge. No real dump is
-## involved — the bytes here are built to exercise the arithmetic, not to
+## involved: the bytes here are built to exercise the arithmetic, not to
 ## resemble a game.
 
 const SCRATCH_DIR: String = "user://test_roms"
@@ -133,7 +133,7 @@ func test_the_header_checksum_matches_when_it_is_written_correctly() -> void:
 	data[RomHeader.HEADER_CHECKSUM] = computed
 	assert_eq(RomHeader.parse(RomFile.from_bytes(data)).header_checksum, computed)
 
-	# Changing any covered byte must change the result — the boot ROM's check.
+	# Changing any covered byte must change the result; that is the boot ROM's check.
 	data[RomHeader.CART_TYPE] = 0x11
 	assert_ne(RomHeader.compute_header_checksum(RomFile.from_bytes(data)), computed)
 

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -1,6 +1,6 @@
 extends GutTest
 
-## The offset tables cannot be checked for correctness without a cartridge —
+## The offset tables cannot be checked for correctness without a cartridge;
 ## that is what [method RomImporter.verify_layout] does at import time. What can
 ## be checked here is that they are internally consistent and complete, and that
 ## the addressing arithmetic around them is right.
@@ -49,12 +49,45 @@ func test_tables_do_not_run_off_the_end() -> void:
 		assert_lt(last_stats + RomLayout.BASE_STATS_SIZE, RomRegistry.EXPECTED_SIZE)
 		var last_pic: int = RomLayout.pic_pointer_offset(layout, RomLayout.SPECIES_COUNT, true)
 		assert_lt(last_pic + RomLayout.PIC_POINTER_SIZE, RomRegistry.EXPECTED_SIZE)
+		var last_move: int = RomLayout.move_data_offset(layout, RomLayout.MOVE_COUNT)
+		assert_lt(last_move + RomLayout.MOVE_DATA_SIZE, RomRegistry.EXPECTED_SIZE)
+		var last_type: int = RomLayout.type_name_pointer_offset(layout, RomLayout.TYPE_COUNT - 1)
+		assert_lt(last_type + RomLayout.TYPE_POINTER_SIZE, RomRegistry.EXPECTED_SIZE)
 
 
 func test_species_tables_are_one_based() -> void:
 	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
 	assert_eq(RomLayout.species_name_offset(layout, 1), int(layout["species_names"]))
 	assert_eq(RomLayout.base_stats_offset(layout, 1), int(layout["base_stats"]))
+
+
+func test_move_data_is_one_based_and_fixed_stride() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	assert_eq(RomLayout.move_data_offset(layout, 1), int(layout["move_data"]))
+	assert_eq(
+		RomLayout.move_data_offset(layout, 3) - RomLayout.move_data_offset(layout, 2),
+		RomLayout.MOVE_DATA_SIZE
+	)
+
+
+func test_the_type_table_is_indexed_by_type_number_from_zero() -> void:
+	# Unlike the species tables: NORMAL is type $00.
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
+	assert_eq(RomLayout.type_name_pointer_offset(layout, 0), int(layout["type_names"]))
+	assert_eq(
+		RomLayout.type_name_pointer_offset(layout, 1) - int(layout["type_names"]),
+		RomLayout.TYPE_POINTER_SIZE
+	)
+
+
+func test_a_type_pointer_resolves_against_its_own_bank() -> void:
+	# The table stores an address and no bank, so the bank comes from where the
+	# table itself sits.
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		var table: int = RomLayout.type_name_pointer_offset(layout, 0)
+		var bank: int = RomLayout.bank_of(table)
+		assert_eq(RomFile.linear(bank, 0x4000 + (table & 0x3FFF)), table)
 
 
 func test_the_palette_table_is_indexed_by_species_number() -> void:

--- a/tests/unit/test_rom_verifier.gd
+++ b/tests/unit/test_rom_verifier.gd
@@ -1,6 +1,6 @@
 extends GutTest
 
-## These tests never touch a real cartridge — the repo has none and must never
+## These tests never touch a real cartridge; the repo has none and must never
 ## gain one. Synthetic files cover the rejection paths, and the accept path is
 ## covered by asserting the registry's own hashes round-trip. Hashing a genuine
 ## ROM is a manual check: `tools/verify_rom.gd` (see README.md).

--- a/tests/unit/test_smoke.gd
+++ b/tests/unit/test_smoke.gd
@@ -28,7 +28,7 @@ func test_every_script_parses() -> void:
 	for root: String in ROOTS:
 		_gd_files(root, scripts)
 
-	assert_gt(scripts.size(), 0, "found no scripts to check — is the walk broken?")
+	assert_gt(scripts.size(), 0, "found no scripts to check; is the walk broken?")
 	for path: String in scripts:
 		assert_not_null(load(path), "failed to load %s" % path)
 

--- a/tests/unit/test_smoke.gd
+++ b/tests/unit/test_smoke.gd
@@ -7,7 +7,7 @@ extends GutTest
 const ROOTS: Array[String] = ["res://game", "res://autoload", "res://tests", "res://tools"]
 
 
-func _gd_files(dir_path: String, out: PackedStringArray) -> void:
+func _files(dir_path: String, extension: String, out: PackedStringArray) -> void:
 	var dir: DirAccess = DirAccess.open(dir_path)
 	if dir == null:
 		return
@@ -16,8 +16,8 @@ func _gd_files(dir_path: String, out: PackedStringArray) -> void:
 	while name != "":
 		var full: String = "%s/%s" % [dir_path, name]
 		if dir.current_is_dir():
-			_gd_files(full, out)
-		elif name.ends_with(".gd"):
+			_files(full, extension, out)
+		elif name.ends_with(extension):
 			out.append(full)
 		name = dir.get_next()
 	dir.list_dir_end()
@@ -26,18 +26,25 @@ func _gd_files(dir_path: String, out: PackedStringArray) -> void:
 func test_every_script_parses() -> void:
 	var scripts: PackedStringArray = []
 	for root: String in ROOTS:
-		_gd_files(root, scripts)
+		_files(root, ".gd", scripts)
 
 	assert_gt(scripts.size(), 0, "found no scripts to check; is the walk broken?")
 	for path: String in scripts:
 		assert_not_null(load(path), "failed to load %s" % path)
 
 
-func test_main_scene_loads_and_keeps_its_script() -> void:
-	var packed: PackedScene = load("res://game/main/main.tscn")
-	assert_not_null(packed)
-	var instance: Node = packed.instantiate()
-	# A .tscn root that lost its `script =` line still loads and resolves every
-	# node; it just does nothing. Cheap to assert, expensive to debug.
-	assert_not_null(instance.get_script(), "main.tscn root lost its script")
-	instance.free()
+func test_every_scene_loads_and_keeps_its_script() -> void:
+	var scenes: PackedStringArray = []
+	_files("res://game", ".tscn", scenes)
+
+	assert_gt(scenes.size(), 0, "found no scenes to check; is the walk broken?")
+	for path: String in scenes:
+		var packed: PackedScene = load(path)
+		assert_not_null(packed, "failed to load %s" % path)
+		if packed == null:
+			continue
+		var instance: Node = packed.instantiate()
+		# A .tscn root that lost its `script =` line still loads and resolves
+		# every node; it just does nothing. Cheap to assert, expensive to debug.
+		assert_not_null(instance.get_script(), "%s root lost its script" % path)
+		instance.free()

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -1,7 +1,7 @@
 extends GutTest
 
 ## Synthetic byte strings only. The encoding is a fixed table, so it can be
-## checked without a cartridge — and the importer's own layout check re-tests it
+## checked without a cartridge, and the importer's own layout check re-tests it
 ## against real data by insisting species 1 decodes to BULBASAUR.
 
 
@@ -59,6 +59,35 @@ func test_apostrophe_ligatures_expand_to_two_characters() -> void:
 func test_unknown_byte_is_visible_rather_than_dropped() -> void:
 	# A silently skipped byte would turn a wrong offset into a plausible name.
 	assert_eq(Gen2Text.decode(PackedByteArray([0x80, 0x01]), 0, 4), "A<01>")
+
+
+func test_a_sequence_walks_past_each_terminator() -> void:
+	var data: PackedByteArray = _encode("AB")
+	data.append(Gen2Text.TERMINATOR)
+	data.append_array(_encode("CD"))
+	data.append(Gen2Text.TERMINATOR)
+	assert_eq(Gen2Text.decode_sequence(data, 0, 2, 8), PackedStringArray(["AB", "CD"]))
+
+
+func test_a_sequence_stops_at_the_end_of_the_data() -> void:
+	# Short is a failure the caller must be able to see: the move and item
+	# tables are variable-length, so a wrong start runs off the end rather than
+	# landing on a boundary.
+	var data: PackedByteArray = _encode("AB")
+	data.append(Gen2Text.TERMINATOR)
+	assert_eq(Gen2Text.decode_sequence(data, 0, 4, 8).size(), 1)
+
+
+func test_a_sequence_gives_up_on_an_entry_with_no_terminator() -> void:
+	# The guard, not a field width: without it this walks the rest of the dump.
+	var result: PackedStringArray = Gen2Text.decode_sequence(_encode("ABCDEFGH"), 0, 2, 3)
+	assert_eq(result[0], "ABC")
+
+
+func test_an_empty_entry_is_kept_rather_than_skipped() -> void:
+	# Dropping it would shift every later name down by one.
+	var data: PackedByteArray = PackedByteArray([Gen2Text.TERMINATOR, 0x80, Gen2Text.TERMINATOR])
+	assert_eq(Gen2Text.decode_sequence(data, 0, 2, 8), PackedStringArray(["", "A"]))
 
 
 func test_a_real_species_name_round_trips() -> void:

--- a/tests/unit/test_tile_codec.gd
+++ b/tests/unit/test_tile_codec.gd
@@ -50,7 +50,7 @@ func test_out_of_range_offset_yields_a_blank_tile() -> void:
 
 func test_pic_tiles_are_stored_column_major() -> void:
 	# Two columns of two tiles. Storage order is top-left, bottom-left,
-	# top-right, bottom-right — down the columns, not across the rows.
+	# top-right, bottom-right, down the columns and not across the rows.
 	var data: PackedByteArray = PackedByteArray()
 	for index: int in [1, 2, 3, 1]:
 		data.append_array(_solid_tile(index))

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -1,0 +1,80 @@
+extends SceneTree
+
+## Prints the decoded text tables out of the cache, headlessly.
+##
+##   Godot --headless --path . -s res://tools/dump_tables.gd -- <game> [table]
+##
+## The written-down counterpart of the contact sheet: a bad offset in a name
+## table produces plausible words rather than an error, so the check is to read
+## the output. <game> is a registry id (gold, silver, crystal); [table] is one of
+## species, moves, items, types, or all.
+
+const TABLES: PackedStringArray = ["species", "moves", "items", "types"]
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.is_empty():
+		print("Usage: dump_tables.gd -- <%s> [%s|all]" % [
+			"|".join(RomRegistry.ORDER), "|".join(TABLES),
+		])
+		quit(1)
+		return
+
+	var id: StringName = StringName(args[0])
+	var wanted: String = args[1] if args.size() > 1 else "all"
+
+	var directory: String = _cache_for(id)
+	if directory.is_empty():
+		push_error("No cache for %s. Run tools/import_rom.gd first." % id)
+		quit(1)
+		return
+
+	print("%s  %s" % [id, ProjectSettings.globalize_path(directory)])
+	for table: String in TABLES:
+		if wanted == "all" or wanted == table:
+			_dump(directory, table)
+	quit(0)
+
+
+## The cache directory is keyed by hash as well as game, so it is found by
+## listing rather than built from an id.
+func _cache_for(id: StringName) -> String:
+	var dir: DirAccess = DirAccess.open(RomCache.ROOT)
+	if dir == null:
+		return ""
+	for name: String in dir.get_directories():
+		if name.begins_with("%s_" % id):
+			return "%s/%s" % [RomCache.ROOT, name]
+	return ""
+
+
+func _dump(directory: String, table: String) -> void:
+	var path: String = "%s/%s.json" % [directory, table]
+	var rows: Variant = RomCache.read_json(path)
+	if not rows is Array:
+		print("\n%s: missing" % table)
+		return
+
+	print("\n%s (%d)" % [table, (rows as Array).size()])
+	for row: Dictionary in rows:
+		print("  %s" % _describe(table, row))
+
+
+func _describe(table: String, row: Dictionary) -> String:
+	var number: int = int(row["number"])
+	var name: String = String(row["name"])
+	match table:
+		"moves":
+			return "%3d  %-13s pow %3d  type %2d  acc %3d  pp %2d  effect %3d/%3d" % [
+				number, name, int(row["power"]), int(row["type"]), int(row["accuracy"]),
+				int(row["pp"]), int(row["effect"]), int(row["effect_chance"]),
+			]
+		"species":
+			var stats: Dictionary = row["stats"]
+			return "%3d  %-11s %3d/%3d/%3d/%3d/%3d/%3d  types %2d %2d" % [
+				number, name, int(stats["hp"]), int(stats["attack"]), int(stats["defense"]),
+				int(stats["speed"]), int(stats["sp_attack"]), int(stats["sp_defense"]),
+				int(row["types"][0]), int(row["types"][1]),
+			]
+	return "%3d  %s" % [number, name]

--- a/tools/dump_tables.gd.uid
+++ b/tools/dump_tables.gd.uid
@@ -1,0 +1,1 @@
+uid://bbe0yux3fheru

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -6,7 +6,7 @@ extends SceneTree
 ##
 ## e.g. gold /tmp/gold_front.png front
 ##
-## The cache stores colour indices, not pixels — a palette is applied at draw
+## The cache stores colour indices, not pixels; a palette is applied at draw
 ## time so that shiny is free. This applies one and writes the result out, which
 ## is the only way to tell a correct decode from a plausible-looking wrong one.
 ## Runs headless: it writes an image, it does not open a window.


### PR DESCRIPTION
Move names and move data, item names and type names were located in all three cartridges but never decoded. They now land in the cache next to the species tables, indexed by their own numbers, and each one ships with the runtime check that proves its offset: the move table self-identifies the way the base stats do, and the two variable-length name tables are checked at the far end as well as the near one.

Type names come through a pointer table rather than sitting inline, because type numbers are sparse and every unused one points at the same string. Move and item names are terminator-separated rather than fixed-width, so the text codec grew a walk for them.

The cache format version is bumped, so an existing cache is discarded and rebuilt rather than read as if it held the new tables.

tools/dump_tables.gd prints a cached table: the text counterpart of the pic contact sheet, and the only way to see that a name table has not slid.