### PR TITLE
Decode the trainer classes: pics, names and palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ the same thing for Generation 1.
 >
 > The import gate and the first half of the importer exist and are tested: a
 > verified cartridge decodes into species data, moves, items, types, palettes,
-> every Pokémon sprite, every trainer pic, the font and the text box borders.
-> Sprites and text draw on a real 160x144 screen. The overworld, battle system, audio and mod loader
-> do not exist yet. There is nothing playable here today.
+> every Pokémon sprite, every trainer pic, the font, the text box borders and
+> the battle HUD. The battle screen draws: two Pokémon, two status panels and a
+> text box on a real 160x144 screen. Nothing happens on it yet, and the
+> overworld, the battle system, audio and the mod loader do not exist. There is
+> nothing playable here today.
 
 ## Getting started
 
@@ -92,6 +94,7 @@ What comes out today:
 | Sprites | Front and back for all 251 species, plus all 26 Unown forms |
 | Font | All 128 glyphs, indexed by character code |
 | Borders | All eight text box frames, six tiles each |
+| Battle HUD | The HP bar, the exp bar, both panel borders and the colours they are drawn in |
 
 Sprites are stored as colour indices rather than as images, and a palette is
 applied when they are drawn, which is the whole of what being shiny costs.
@@ -132,6 +135,12 @@ resolution.
 `game/render/text_viewer.tscn` does the same for text: space advances the box,
 `F` cycles through the eight borders, and `C` shows every glyph in the font at
 once.
+
+`game/battle/battle_screen.tscn` is the battle screen itself: two Pokémon, a
+status panel each and a text box, where the hardware puts them. Left and right
+change which Pokémon are on it, `S` and `D` take health off the player's and the
+enemy's, and the bars change colour as they empty. Nothing else happens: there
+is no battle behind it yet.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ the same thing for Generation 1.
 >
 > The import gate and the first half of the importer exist and are tested: a
 > verified cartridge decodes into species data, moves, items, types, palettes,
-> every Pokémon sprite, the font and the text box borders. Sprites and text draw
-> on a real 160x144 screen. The overworld, battle system, audio and mod loader
+> every Pokémon sprite, every trainer pic, the font and the text box borders.
+> Sprites and text draw on a real 160x144 screen. The overworld, battle system, audio and mod loader
 > do not exist yet. There is nothing playable here today.
 
 ## Getting started
@@ -87,6 +87,7 @@ What comes out today:
 | Moves | Names, power, type, accuracy, PP, effect and its chance |
 | Items | All 255 names, indexed by item number |
 | Types | All 28 names, indexed by type number |
+| Trainers | Every trainer class: name, pic and palette |
 | Palettes | Normal and shiny, as the cartridge's own 15-bit colours |
 | Sprites | Front and back for all 251 species, plus all 26 Unown forms |
 | Font | All 128 glyphs, indexed by character code |
@@ -101,10 +102,12 @@ To look at what was decoded, as a contact sheet of sprites:
 godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png front
 ```
 
-The same tool takes `font` or `frames` in place of an atlas name, which is how
-you check that the glyphs are where the character codes say they are.
+The same tool takes `trainers` for the trainer classes, or `font` or `frames` in
+place of an atlas name, which is how you check that the glyphs are where the
+character codes say they are.
 
-or as text, for any of `species`, `moves`, `items`, `types` or `all`:
+or as text, for any of `species`, `moves`, `items`, `types`, `trainers` or
+`all`:
 
 ```bash
 godot --headless --path . -s res://tools/dump_tables.gd -- gold moves
@@ -120,7 +123,8 @@ Boots the main scene for 30 frames and exits, as a quick smoke check.
 
 To see an imported sprite on a real screen, open
 `game/render/pic_viewer.tscn` in the editor and press Play. Left and right
-change species, `S` toggles shiny, `B` swaps the front pic for the back one.
+change species, `S` toggles shiny, `B` swaps the front pic for the back one, and
+`T` switches to the trainer classes.
 The game is drawn into a 160x144 viewport and scaled up by a whole number, so a
 Game Boy pixel stays square; the interface around it is at the window's own
 resolution.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -71,6 +71,13 @@ The drawing layer is deliberately thin:
 | `render/font.gd` | Character codes to glyph tiles, blitted into a buffer |
 | `render/text_layout.gd` | A string to the lines and pages a box can show |
 | `render/text_box.gd` | The two of them, as a bordered window on the grid |
+| `render/battle_tiles.gd` | The battle's tile page, assembled as the hardware does |
+| `render/battle_hud.gd` | The two status panels, on the tile grid |
+
+`game/battle/battle_screen.gd` is the first screen that is not a development
+view. It draws what it is given and decides nothing: no turn order, no damage,
+no faint. When there is an engine it will hand the screen the same numbers a
+caller hands it today, which is why its setters take plain values.
 
 `Gen2Screen` renders the game into a `SubViewport` the size of the real
 hardware and blows it up by an integer factor, while the interface around it
@@ -126,6 +133,13 @@ So every offset ships with a check that would fail if it were wrong, and
   `Gen2Text` says are there must have ink, and the runs it has no character for
   must be blank. Those runs sit between the alphabets, so an offset out by a
   single tile drags a blank onto "z" and a glyph onto a code that has none.
+- The battle HUD's graphics are checked by the one thing they do that nothing
+  around them does: they count. A bar's fill levels are consecutive tiles, each
+  lighting one more column than the last, so the ink climbs by exactly two
+  pixels a step, and no wrong offset lands on a run like that. The two HUD
+  borders have no progression, so they are checked the way the text box frames
+  are. The four palettes the bars are drawn in are known values, so they are
+  checked against those values.
 - The three trainer tables are checked against each other, because they are
   three views of one numbering and a mistake shows up as them disagreeing. The
   class names pin the ends and the middle of a terminated table the way the move
@@ -223,6 +237,14 @@ box does not depend on how long the capture took to arrive.
 
 ```bash
 godot --path . -s res://tools/screenshot.gd -- res://game/render/text_viewer.tscn /tmp/shot.png 24 finish 1
+```
+
+The battle screen is built the same way, and it is worth photographing in more
+than one state: an HP bar changes colour as it empties, and the rule is about
+how many pixels are lit rather than how many hit points are left.
+
+```bash
+godot --path . -s res://tools/screenshot.gd -- res://game/battle/battle_screen.tscn /tmp/shot.png 24 hurt_player 3
 ```
 
 Keep that property when you add a screen. A handler that only exists inside an

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -126,6 +126,13 @@ So every offset ships with a check that would fail if it were wrong, and
   `Gen2Text` says are there must have ink, and the runs it has no character for
   must be blank. Those runs sit between the alphabets, so an offset out by a
   single tile drags a blank onto "z" and a glyph onto a code that has none.
+- The three trainer tables are checked against each other, because they are
+  three views of one numbering and a mistake shows up as them disagreeing. The
+  class names pin the ends and the middle of a terminated table the way the move
+  names do; the palettes are checked structurally *and* one entry past the end,
+  since the table is the player plus every class and something that is not a
+  palette has to follow it; and the pic pointers have to address the banked
+  window and decompress into a pic of the one size every trainer is drawn at.
 - The eight text box borders have no content to check, so they are checked by
   the shape a border has to have: inset from the top of its tile row, corners
   that carry the pattern of the side they hang from, and no two frames the
@@ -163,6 +170,10 @@ A contact sheet of all 251 species is the fastest correctness check the project
 has: a bad decompressor, a wrong tile order, a wrong palette and an off-by-one
 in a pointer table all look obviously wrong, and all of them look fine in a
 manifest.
+
+`trainers` does the same for the trainer classes, each drawn in its own class
+palette, which is where a palette table that has slid by an entry becomes
+obvious: the pics stay right and the colours move one class along.
 
 The same tool takes `font` or `frames`, which it folds into rows of sixteen
 tiles. That is the shape the charmap describes, so the alphabets, the gaps

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1,0 +1,295 @@
+class_name Gen2BattleScreen
+extends Control
+
+## The battle screen: two Pokémon, two status panels and a text box, at the
+## positions the hardware puts them.
+##
+## This is the first screen that is not a development view. Everything on it
+## already existed a layer down (a pic from an atlas, a panel from the HUD
+## sheets, a box from the font and a border), and what this adds is where each
+## of them goes: the enemy's pic in the top right, the player's back pic below
+## and to the left of it, a panel each, and the standard box along the bottom.
+##
+## It draws what it is given and decides nothing. There is no battle here: no
+## turn order, no damage, no faint. When there is an engine, it will hand this
+## the same numbers a caller hands it now, which is why the setters take plain
+## values rather than a battle state object.
+##
+## The panels are composed into one screen-sized index buffer and drawn over the
+## pics with index 0 transparent, because a panel is a shape on a white field
+## rather than a rectangle: the games draw them into the background layer, where
+## nothing overlaps, and the pics have to show through everything that is not ink.
+
+## Where the two pics sit, in tiles.
+const ENEMY_PIC: Vector2i = Vector2i(12, 0)
+const PLAYER_PIC: Vector2i = Vector2i(2, 6)
+
+## What is on screen before a caller says otherwise: the first battle a player
+## of Gold or Silver is likely to have.
+const DEFAULT_ENEMY: int = 16
+const DEFAULT_PLAYER: int = 155
+const DEFAULT_LEVEL: int = 5
+
+const TILE: int = Gen2Font.TILE
+
+## The white the hardware fills the battle background with.
+const BACKGROUND: Color = Color.WHITE
+
+var _data: GameData = null
+var _hud: Gen2BattleHud = null
+
+var _enemy: int = 1
+var _player: int = 1
+var _enemy_level: int = 5
+var _player_level: int = 5
+var _enemy_hp: int = 0
+var _enemy_max_hp: int = 0
+var _player_hp: int = 0
+var _player_max_hp: int = 0
+var _exp: float = 0.0
+
+var _enemy_pic: TextureRect = null
+var _player_pic: TextureRect = null
+var _panels: TextureRect = null
+var _enemy_bar: TextureRect = null
+var _player_bar: TextureRect = null
+var _exp_bar: TextureRect = null
+var _box: Gen2TextBox = null
+
+@onready var _screen: Gen2Screen = %Screen
+
+
+func _ready() -> void:
+	_data = GameData.open_any()
+	_hud = Gen2BattleHud.from_data(_data)
+	if _hud == null:
+		return
+
+	var field := ColorRect.new()
+	field.color = BACKGROUND
+	field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_screen.display(field)
+
+	_enemy_pic = _new_layer()
+	_player_pic = _new_layer()
+	_panels = _new_layer()
+	_enemy_bar = _new_layer()
+	_player_bar = _new_layer()
+	_exp_bar = _new_layer()
+
+	_box = Gen2TextBox.new()
+	_box.font = _hud.font
+	_screen.display(_box)
+	_box.place_at_bottom()
+
+	show_matchup(DEFAULT_ENEMY, DEFAULT_PLAYER, DEFAULT_LEVEL, DEFAULT_LEVEL)
+	set_exp(0.5)
+	_announce()
+
+
+## True once the cache had everything the screen draws with.
+func is_ready() -> bool:
+	return _hud != null
+
+
+## Puts two Pokémon on the screen at a level each, both at full health.
+func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: int = 5) -> void:
+	_enemy = _wrap_species(enemy)
+	_player = _wrap_species(player)
+	_enemy_level = enemy_level
+	_player_level = player_level
+	_enemy_max_hp = _hp_at_level(_enemy, _enemy_level)
+	_player_max_hp = _hp_at_level(_player, _player_level)
+	_enemy_hp = _enemy_max_hp
+	_player_hp = _player_max_hp
+	_refresh()
+
+
+## Both HP totals, for a caller that has its own numbers.
+func set_hp(enemy: int, enemy_max: int, player: int, player_max: int) -> void:
+	_enemy_hp = enemy
+	_enemy_max_hp = enemy_max
+	_player_hp = player
+	_player_max_hp = player_max
+	_refresh()
+
+
+## How full the exp bar is, from nothing to a level's worth.
+func set_exp(fraction: float) -> void:
+	_exp = clampf(fraction, 0.0, 1.0)
+	_refresh()
+
+
+func show_message(text: String) -> void:
+	if _box != null:
+		_box.show_text(text)
+
+
+## Reveals the rest of the message at once, so a photograph of the screen does
+## not depend on how long the capture took to arrive.
+func finish() -> void:
+	if _box != null:
+		_box.finish()
+
+
+func next_enemy() -> void:
+	show_matchup(_enemy + 1, _player, _enemy_level, _player_level)
+	_announce()
+
+
+func next_player() -> void:
+	show_matchup(_enemy, _player + 1, _enemy_level, _player_level)
+	_announce()
+
+
+## Takes a quarter of the enemy's health off, which is the fastest way to see
+## that a bar and its numbers agree.
+func hurt_enemy() -> void:
+	_enemy_hp = maxi(_enemy_hp - maxi(_enemy_max_hp / 4, 1), 0)
+	_refresh()
+
+
+func hurt_player() -> void:
+	_player_hp = maxi(_player_hp - maxi(_player_max_hp / 4, 1), 0)
+	_refresh()
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if _hud == null or not event.is_pressed():
+		return
+
+	var key: InputEventKey = event as InputEventKey
+	if key == null:
+		return
+
+	match key.keycode:
+		KEY_RIGHT:
+			next_enemy()
+		KEY_LEFT:
+			next_player()
+		KEY_D:
+			hurt_enemy()
+		KEY_S:
+			hurt_player()
+		KEY_SPACE, KEY_ENTER:
+			_box.advance()
+		_:
+			return
+	accept_event()
+
+
+func _new_layer() -> TextureRect:
+	var out := TextureRect.new()
+	# Nearest, or the integer-scaled viewport is undone on the last hop.
+	out.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_screen.display(out)
+	return out
+
+
+func _wrap_species(number: int) -> int:
+	var count: int = _data.species_count() if _data != null else 0
+	return wrapi(number, 1, maxi(count, 1) + 1) if count > 0 else 1
+
+
+## A rough HP total, so the bar and the numbers have something to show. The real
+## formula belongs to the engine that does not exist yet, along with the IVs and
+## the effort values it also reads.
+func _hp_at_level(species: int, level: int) -> int:
+	var entry: Dictionary = _data.species(species)
+	if entry.is_empty():
+		return 1
+	var base: int = int(entry["stats"]["hp"])
+	@warning_ignore("integer_division")
+	return (base * 2 * level) / 100 + level + 10
+
+
+func _refresh() -> void:
+	if _hud == null:
+		return
+
+	_draw_pic(_enemy_pic, _data.species_pic(_enemy), _data.palette(_enemy), ENEMY_PIC)
+	_draw_pic(_player_pic, _data.species_pic(_player, true), _data.palette(_player), PLAYER_PIC)
+	_draw_panels()
+
+
+func _draw_pic(
+	into: TextureRect, pic: Dictionary, palette: PackedColorArray, at: Vector2i
+) -> void:
+	if into == null or pic.is_empty():
+		return
+
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
+	)
+	into.texture = ImageTexture.create_from_image(image)
+	into.size = image.get_size()
+	into.position = Vector2(at.x * TILE, at.y * TILE)
+
+
+## The panels, and then each bar over them in its own colour.
+##
+## The hardware gives every tile of the background its own palette, so a green
+## HP bar sits in a panel of black text without either being a separate thing.
+## Layering is how that is done here, one buffer per palette, which is why the
+## bars are drawn apart from the panels that hold them.
+func _draw_panels() -> void:
+	var panels: PackedByteArray = _new_buffer()
+	_hud.draw_enemy(panels, Gen2Screen.WIDTH, _name_of(_enemy), _enemy_level)
+	_hud.draw_player(
+		panels, Gen2Screen.WIDTH, _name_of(_player), _player_level, _player_hp, _player_max_hp
+	)
+	_show_layer(
+		_panels, panels,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+
+	var enemy: PackedByteArray = _new_buffer()
+	_hud.draw_hp_bar(
+		enemy, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, _enemy_hp, _enemy_max_hp
+	)
+	_show_layer(_enemy_bar, enemy, _hp_palette(_enemy_hp, _enemy_max_hp))
+
+	var player: PackedByteArray = _new_buffer()
+	_hud.draw_hp_bar(
+		player, Gen2Screen.WIDTH, Gen2BattleHud.PLAYER_BAR, _player_hp, _player_max_hp
+	)
+	_show_layer(_player_bar, player, _hp_palette(_player_hp, _player_max_hp))
+
+	var gained: PackedByteArray = _new_buffer()
+	_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, _exp)
+	_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
+
+
+func _new_buffer() -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	return out
+
+
+## Every layer above the pics is drawn with index 0 transparent: a panel is a
+## shape on the background, not a rectangle over it.
+func _show_layer(
+	into: TextureRect, indices: PackedByteArray, palette: PackedColorArray
+) -> void:
+	var image: Image = Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
+	)
+	into.texture = ImageTexture.create_from_image(image)
+	into.size = image.get_size()
+
+
+## An HP bar is green, yellow or red by how much of it is lit rather than by the
+## hit points behind it, which is the rule the games use.
+func _hp_palette(hp: int, max_hp: int) -> PackedColorArray:
+	var lit: int = Gen2BattleHud.bar_pixels(
+		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
+	)
+	return _data.bar_palette(GameData.hp_bar_palette_name(lit))
+
+
+func _name_of(species: int) -> String:
+	return String(_data.species(species).get("name", ""))
+
+
+func _announce() -> void:
+	show_message("Wild %s appeared!" % _name_of(_enemy))

--- a/game/battle/battle_screen.gd.uid
+++ b/game/battle/battle_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://b2wo3hbvnr6vv

--- a/game/battle/battle_screen.tscn
+++ b/game/battle/battle_screen.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://game/battle/battle_screen.gd" id="1"]
+[ext_resource type="PackedScene" path="res://game/render/gen2_screen.tscn" id="2"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0.0509804, 0.0745098, 0.164706, 1)
+
+[node name="BattleScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+
+[node name="Background" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
+
+[node name="Screen" parent="." instance=ExtResource("2")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -27,6 +27,7 @@ var _types: Array = []
 var _trainers: Array = []
 var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
+var _bar_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 
 
@@ -51,6 +52,7 @@ static func open_directory(path: String) -> GameData:
 	data.sha1 = String(manifest.get("sha1", ""))
 	data._atlases = manifest.get("atlases", {})
 	data._tiles = manifest.get("tiles", {})
+	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._items = data._read_array(RomCache.items_path(path))
@@ -112,6 +114,31 @@ func palette(number: int, shiny: bool = false) -> PackedColorArray:
 		Gen2Palette.from_packed(int(stored[0])),
 		Gen2Palette.from_packed(int(stored[1])),
 	]))
+
+
+## One of the battle bars' palettes, by the names in
+## [constant RomLayout.BAR_PALETTE_NAMES]. An unknown name answers with white and
+## black, which draws a bar that is legible and obviously not coloured.
+func bar_palette(name: String) -> PackedColorArray:
+	var stored: Variant = _bar_palettes.get(name, null)
+	if not stored is Array or (stored as Array).size() < 2:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int(stored[0])),
+		Gen2Palette.from_packed(int(stored[1])),
+	]))
+
+
+## Which HP bar palette a bar of [param lit] pixels is drawn in. The colour
+## follows what is drawn rather than the numbers behind it, which is why a bar
+## can turn red on a Pokémon that still has a good few hit points.
+static func hp_bar_palette_name(lit: int) -> String:
+	if lit >= RomLayout.HP_GREEN_PIXELS:
+		return "hp_green"
+	if lit >= RomLayout.HP_YELLOW_PIXELS:
+		return "hp_yellow"
+	return "hp_red"
 
 
 func trainer_count() -> int:

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -24,6 +24,7 @@ var _species: Array = []
 var _moves: Array = []
 var _items: Array = []
 var _types: Array = []
+var _trainers: Array = []
 var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
 var _indices: Dictionary = {}
@@ -54,6 +55,7 @@ static func open_directory(path: String) -> GameData:
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._items = data._read_array(RomCache.items_path(path))
 	data._types = data._read_array(RomCache.types_path(path))
+	data._trainers = data._read_array(RomCache.trainers_path(path))
 	return data
 
 
@@ -110,6 +112,47 @@ func palette(number: int, shiny: bool = false) -> PackedColorArray:
 		Gen2Palette.from_packed(int(stored[0])),
 		Gen2Palette.from_packed(int(stored[1])),
 	]))
+
+
+func trainer_count() -> int:
+	return _trainers.size()
+
+
+## One trainer class by number, counting from Falkner at 1. Class 0 is the
+## player, who is a class in the cartridge's tables and has no pic, so the cache
+## does not carry an entry for them.
+func trainer(number: int) -> Dictionary:
+	return _entry(_trainers, number - 1)
+
+
+func trainer_name(number: int) -> String:
+	return String(trainer(number).get("name", ""))
+
+
+## The four colours a trainer class is drawn with. A class has one palette and
+## no shiny counterpart: only a Pokémon can be shiny.
+func trainer_palette(number: int) -> PackedColorArray:
+	var entry: Dictionary = trainer(number)
+	if entry.is_empty():
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+
+	var stored: Array = entry["palette"]
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int(stored[0])),
+		Gen2Palette.from_packed(int(stored[1])),
+	]))
+
+
+## Where a trainer class sits in the trainer atlas. Every trainer is drawn at the
+## same size, so unlike a species pic this one always fills its cell.
+func trainer_pic(number: int) -> Dictionary:
+	if trainer(number).is_empty():
+		return {}
+
+	var cell: int = int(atlas("trainers").get("cell", 0))
+	if cell <= 0:
+		return {}
+	return {"atlas": "trainers", "slot": number - 1, "width": cell, "height": cell}
 
 
 ## Atlas metadata: width, height, cell, columns, decoded.

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -12,8 +12,11 @@ extends RefCounted
 ## the whole of what being shiny means to the renderer.
 
 const COLOR_BYTES: int = 2
-## Two colours, normal and shiny.
-const ENTRY_BYTES: int = 8
+## The two middle colours a pic is drawn with. A trainer class stores one such
+## pair and nothing else: only a Pokémon can be shiny.
+const PAIR_BYTES: int = COLOR_BYTES * 2
+## A species' entry: two pairs, normal and shiny.
+const ENTRY_BYTES: int = PAIR_BYTES * 2
 const COLORS_PER_PIC: int = 4
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -28,7 +28,7 @@ const TILES_DIR: String = "tiles"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 4
+const FORMAT_VERSION: int = 5
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -63,9 +63,10 @@ static func pic_path(directory: String, name: String) -> String:
 	return "%s/%s/%s.idx" % [directory, PICS_DIR, name]
 
 
-## Fixed tile sheets: the font and the text box borders. Kept apart from the
-## pics because they are addressed by character code rather than by species, and
-## because they are 1bpp, so the two never want the same accessor.
+## Fixed tile sheets: the font, the text box borders and the battle HUD's
+## graphics. Kept apart from the pics because they are addressed by a tile number
+## rather than by species, and because a sheet has no palette of its own, so the
+## two never want the same accessor.
 static func tile_path(directory: String, name: String) -> String:
 	return "%s/%s/%s.idx" % [directory, TILES_DIR, name]
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -22,12 +22,13 @@ const SPECIES: String = "species.json"
 const MOVES: String = "moves.json"
 const ITEMS: String = "items.json"
 const TYPES: String = "types.json"
+const TRAINERS: String = "trainers.json"
 const PICS_DIR: String = "pics"
 const TILES_DIR: String = "tiles"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 3
+const FORMAT_VERSION: int = 4
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -52,6 +53,10 @@ static func items_path(directory: String) -> String:
 
 static func types_path(directory: String) -> String:
 	return "%s/%s" % [directory, TYPES]
+
+
+static func trainers_path(directory: String) -> String:
+	return "%s/%s" % [directory, TRAINERS]
 
 
 static func pic_path(directory: String, name: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -281,6 +281,21 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 
+	# The bar palettes are known values rather than a shape, so they are checked
+	# as the species names are: against what they have to say.
+	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
+		var entry: int = RomLayout.bar_palette_offset(layout, index)
+		var wanted: Array = RomLayout.BAR_PALETTES[index]
+		for colour: int in wanted.size():
+			var read: int = rom.u16le(entry + colour * Gen2Palette.COLOR_BYTES)
+			if read != int(wanted[colour]):
+				return {
+					"ok": false,
+					"message": "Bar palette %s colour %d: expected $%04X, read $%04X." % [
+						RomLayout.BAR_PALETTE_NAMES[index], colour, wanted[colour], read,
+					],
+				}
+
 	var battle_font: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
 		data, int(layout["battle_font"]), RomLayout.BATTLE_FONT_TILES
 	)
@@ -564,6 +579,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"item_count": items.size(),
 		"type_count": types.size(),
 		"trainer_count": trainers.size(),
+		"bar_palettes": _import_bar_palettes(rom, layout),
 		"atlases": pics,
 		"tiles": tiles,
 		"complete": true,
@@ -711,6 +727,18 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 		if on_progress.is_valid():
 			on_progress.call("trainers", trainer_class, count)
 
+	return out
+
+
+## The four colours a battle draws its bars in. Small enough to live in the
+## manifest beside the atlas metadata rather than in a file of its own.
+func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
+		var entry: int = RomLayout.bar_palette_offset(layout, index)
+		out[RomLayout.BAR_PALETTE_NAMES[index]] = [
+			rom.u16le(entry), rom.u16le(entry + Gen2Palette.COLOR_BYTES),
+		]
 	return out
 
 

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -149,6 +149,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not frames["ok"]:
 		return frames
 
+	var battle: Dictionary = verify_battle_graphics(rom, layout)
+	if not battle["ok"]:
+		return battle
+
 	var trainers: Dictionary = verify_trainers(rom, layout)
 	if not trainers["ok"]:
 		return trainers
@@ -263,6 +267,102 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 		seen.append(tiles)
 
 	return {"ok": true, "message": ""}
+
+
+## The battle HUD's graphics, checked by the one thing they do that nothing else
+## in the section does: they count.
+##
+## A bar's fill levels are consecutive tiles, each lighting one more column than
+## the last, so the ink in that run climbs by exactly two pixels a step. Neither
+## bar has a name or a number in the cartridge, but a run that counts up like
+## that is not something a wrong offset lands on. The two HUD borders have
+## neither content nor a progression, so they are checked the way the text box
+## frames are: every tile has ink, and no two tiles are the same.
+static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var data: PackedByteArray = rom.bytes()
+
+	var battle_font: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		data, int(layout["battle_font"]), RomLayout.BATTLE_FONT_TILES
+	)
+	var hp_bar: Dictionary = _verify_bar(
+		battle_font, RomLayout.BATTLE_FONT_TILES, RomLayout.HP_BAR_FIRST_TILE,
+		RomLayout.HP_BAR_LEVELS, "HP bar"
+	)
+	if not hp_bar["ok"]:
+		return hp_bar
+
+	var exp_bar: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		data, int(layout["exp_bar"]), RomLayout.EXP_BAR_TILES
+	)
+	var levels: Dictionary = _verify_bar(
+		exp_bar, RomLayout.EXP_BAR_TILES, 0, RomLayout.EXP_BAR_LEVELS, "exp bar"
+	)
+	if not levels["ok"]:
+		return levels
+
+	for name: String in ["enemy_hud", "player_hud"]:
+		var tiles: int = RomLayout.ENEMY_HUD_TILES if name == "enemy_hud" \
+			else RomLayout.PLAYER_HUD_TILES
+		var strip: PackedByteArray = Gen2Tiles.decode_1bpp_strip(
+			data, int(layout[name]), tiles
+		)
+		var seen: Array = []
+		for tile: int in tiles:
+			var pixels: PackedByteArray = _strip_tile(strip, tiles, tile)
+			if _ink(pixels) == 0:
+				return {"ok": false, "message": "%s tile %d is blank." % [name, tile]}
+			if seen.has(pixels):
+				return {"ok": false, "message": "%s tile %d repeats an earlier one." % [name, tile]}
+			seen.append(pixels)
+
+	return {"ok": true, "message": ""}
+
+
+## One bar's fill levels: consecutive tiles whose ink climbs by a fixed step.
+static func _verify_bar(
+	strip: PackedByteArray, tiles: int, first: int, levels: int, what: String
+) -> Dictionary:
+	if strip.size() != tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT:
+		return {"ok": false, "message": "%s: strip decoded short." % what}
+
+	var previous: int = _ink(_strip_tile(strip, tiles, first))
+	if previous == 0:
+		return {"ok": false, "message": "%s: the empty level has no ink." % what}
+
+	for level: int in range(1, levels):
+		var ink: int = _ink(_strip_tile(strip, tiles, first + level))
+		if ink != previous + RomLayout.BAR_STEP_PIXELS:
+			return {
+				"ok": false,
+				"message": "%s: level %d has %d pixels, expected %d." % [
+					what, level, ink, previous + RomLayout.BAR_STEP_PIXELS,
+				],
+			}
+		previous = ink
+
+	return {"ok": true, "message": ""}
+
+
+## One tile out of a strip, as its own buffer.
+static func _strip_tile(strip: PackedByteArray, tiles: int, tile: int) -> PackedByteArray:
+	var width: int = tiles * Gen2Tiles.TILE_WIDTH
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Tiles.TILE_PIXELS)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			out[row * Gen2Tiles.TILE_WIDTH + column] = strip[
+				row * width + tile * Gen2Tiles.TILE_WIDTH + column
+			]
+	return out
+
+
+## Lit pixels in a decoded tile, whatever colour they are.
+static func _ink(pixels: PackedByteArray) -> int:
+	var out: int = 0
+	for index: int in pixels:
+		if index != 0:
+			out += 1
+	return out
 
 
 ## The three trainer tables, each checked by what is known about it independently.
@@ -614,12 +714,19 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 	return out
 
 
-## Decodes the font and the eight text box borders, each as one strip of tiles.
+## Decodes the fixed tile sheets: the font, the eight text box borders and the
+## battle HUD's graphics, each as one strip of tiles.
 ##
-## Neither is compressed and neither is per-species, so unlike a pic there is
-## nothing to look up: the whole of both is a fixed run of 1bpp tiles. They are
-## kept as strips because both are addressed by character code, and a strip
-## turns that code into a horizontal offset and nothing else.
+## None of them is compressed and none is per-species, so unlike a pic there is
+## nothing to look up: each is a fixed run of tiles at a known place. They are
+## kept as strips because each is addressed by a number, whether a character code
+## or a tile in a bar, and a strip turns that number into a horizontal offset and
+## nothing else.
+##
+## [code]first_code[/code] is the character code a sheet's first tile draws, and
+## is zero for the sheets that are graphics rather than characters. [code]bits[/code]
+## is how the cartridge stores them: the font and the borders are 1bpp, the
+## battle graphics 2bpp.
 func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 	var sheets: Dictionary = {
@@ -627,11 +734,37 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"offset": RomLayout.font_offset(layout),
 			"tiles": RomLayout.FONT_TILES,
 			"first_code": RomLayout.FONT_FIRST_CODE,
+			"bits": 1,
 		},
 		"frames": {
 			"offset": RomLayout.frame_offset(layout, 0),
 			"tiles": RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES,
 			"first_code": RomLayout.FRAME_FIRST_CODE,
+			"bits": 1,
+		},
+		"battle_font": {
+			"offset": int(layout["battle_font"]),
+			"tiles": RomLayout.BATTLE_FONT_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		"enemy_hud": {
+			"offset": int(layout["enemy_hud"]),
+			"tiles": RomLayout.ENEMY_HUD_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"player_hud": {
+			"offset": int(layout["player_hud"]),
+			"tiles": RomLayout.PLAYER_HUD_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"exp_bar": {
+			"offset": int(layout["exp_bar"]),
+			"tiles": RomLayout.EXP_BAR_TILES,
+			"first_code": 0,
+			"bits": 2,
 		},
 	}
 
@@ -640,7 +773,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]
 		var count: int = sheet["tiles"]
-		var indices: PackedByteArray = Gen2Tiles.decode_1bpp_strip(data, sheet["offset"], count)
+		var indices: PackedByteArray = _decode_strip(data, sheet)
 		var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 		if not RomCache.write_indices(RomCache.tile_path(directory, name), indices):
 			return {}
@@ -649,6 +782,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"height": Gen2Tiles.TILE_HEIGHT,
 			"tiles": count,
 			"first_code": sheet["first_code"],
+			"bits": sheet["bits"],
 		}
 
 		done += 1
@@ -656,6 +790,12 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			on_progress.call("tiles", done, sheets.size())
 
 	return written
+
+
+static func _decode_strip(data: PackedByteArray, sheet: Dictionary) -> PackedByteArray:
+	if int(sheet["bits"]) == 1:
+		return Gen2Tiles.decode_1bpp_strip(data, int(sheet["offset"]), int(sheet["tiles"]))
+	return Gen2Tiles.decode_2bpp_strip(data, int(sheet["offset"]), int(sheet["tiles"]))
 
 
 func _import_pics(

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -19,6 +19,13 @@ extends RefCounted
 ## their real size.
 const ATLAS_COLUMNS: int = 16
 
+## Falkner is trainer class 1 in all three games, and the class in the middle is
+## a walk check on a table whose entries are terminated rather than padded. The
+## class that ends the table differs between games and lives in [RomLayout].
+const TRAINER_FIRST_CLASS: String = "LEADER"
+const TRAINER_MIDDLE_CLASS: int = 22
+const TRAINER_MIDDLE_CLASS_NAME: String = "YOUNGSTER"
+
 var _lz: Gen2Lz = Gen2Lz.new()
 
 
@@ -142,6 +149,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not frames["ok"]:
 		return frames
 
+	var trainers: Dictionary = verify_trainers(rom, layout)
+	if not trainers["ok"]:
+		return trainers
+
 	return {"ok": true, "message": "Layout verified."}
 
 
@@ -254,6 +265,119 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"ok": true, "message": ""}
 
 
+## The three trainer tables, each checked by what is known about it independently.
+##
+## They are checked together because they are three views of one numbering, and
+## a mistake in any of them shows up as the three disagreeing: the names say what
+## a class is, the palette table has one entry more than the pic table because
+## the player owns the first one, and the pic table's entries have to decompress
+## into pics of the one size every trainer is drawn at.
+static func verify_trainers(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var count: int = RomLayout.trainer_class_count(layout)
+	var names: PackedStringArray = Gen2Text.decode_sequence(
+		rom.bytes(), int(layout["trainer_class_names"]), count, RomLayout.MAX_NAME_LENGTH
+	)
+	if names.size() != count:
+		return {"ok": false, "message": "Trainer class names ran out after %d." % names.size()}
+	# Falkner opens the table, and the classes are terminated rather than padded,
+	# so the far end is checked as well as the near one. The class in the middle
+	# catches a start that is right and a walk that is not.
+	if names[0] != TRAINER_FIRST_CLASS:
+		return {
+			"ok": false,
+			"message": "Trainer class 1: expected %s, read %s." % [TRAINER_FIRST_CLASS, names[0]],
+		}
+	if names[TRAINER_MIDDLE_CLASS - 1] != TRAINER_MIDDLE_CLASS_NAME:
+		return {
+			"ok": false,
+			"message": "Trainer class %d: expected %s, read %s." % [
+				TRAINER_MIDDLE_CLASS, TRAINER_MIDDLE_CLASS_NAME, names[TRAINER_MIDDLE_CLASS - 1],
+			],
+		}
+	var last_class: String = String(layout["trainer_last_class"])
+	if names[count - 1] != last_class:
+		return {
+			"ok": false,
+			"message": "Trainer class %d: expected %s, read %s." % [
+				count, last_class, names[count - 1],
+			],
+		}
+
+	# Palettes are checked structurally, as the species ones are, and then at one
+	# entry past the end: the table is the player plus every class, so whatever
+	# follows it must not read as a palette. Without that, an offset that slid by
+	# a whole entry would pass every check above it.
+	for trainer_class: int in range(0, count + 1):
+		var check: Dictionary = _trainer_palette_check(rom, layout, trainer_class)
+		if not check["ok"]:
+			return check
+	if _trainer_palette_check(rom, layout, count + 1)["ok"]:
+		return {
+			"ok": false,
+			"message": "Trainer palette table has a %dth entry; it should end at %d." % [
+				count + 2, count + 1,
+			],
+		}
+
+	# Every pointer has to address the switchable window of a bank that exists.
+	# The two ends are decompressed as well, which is what proves the bank repair
+	# is the same one the Pokémon pics need.
+	var lz := Gen2Lz.new()
+	var wanted: int = RomLayout.TRAINER_PIC_TILES * RomLayout.TRAINER_PIC_TILES \
+		* Gen2Tiles.TILE_BYTES
+	for trainer_class: int in range(1, count + 1):
+		var offset: int = RomLayout.trainer_pic_pointer_offset(layout, trainer_class)
+		var pointer: Dictionary = rom.far_pointer(offset)
+		var address: int = int(pointer["address"])
+		if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
+			return {
+				"ok": false,
+				"message": "Trainer pic %d points at $%04X, outside the banked window." % [
+					trainer_class, address,
+				],
+			}
+		var start: int = RomFile.linear(
+			RomLayout.fix_pic_bank(layout, int(pointer["bank"])), address
+		)
+		if not rom.in_bounds(start):
+			return {"ok": false, "message": "Trainer pic %d points past the dump." % trainer_class}
+		if trainer_class != 1 and trainer_class != count:
+			continue
+		var raw: PackedByteArray = lz.decompress(rom.bytes(), start)
+		if lz.failed or raw.size() < wanted:
+			return {
+				"ok": false,
+				"message": "Trainer pic %d decompressed to %d bytes, wanted %d." % [
+					trainer_class, raw.size(), wanted,
+				],
+			}
+
+	return {"ok": true, "message": ""}
+
+
+## One trainer palette entry, checked the way a species' is: fifteen-bit colours,
+## and never two blacks.
+static func _trainer_palette_check(
+	rom: RomFile, layout: Dictionary, trainer_class: int
+) -> Dictionary:
+	var entry: int = RomLayout.trainer_palette_offset(layout, trainer_class)
+	if not rom.in_bounds(entry, Gen2Palette.PAIR_BYTES):
+		return {"ok": false, "message": "Trainer palette %d is past the end." % trainer_class}
+
+	var first: int = rom.u16le(entry)
+	var second: int = rom.u16le(entry + Gen2Palette.COLOR_BYTES)
+	if (first | second) & 0x8000:
+		return {
+			"ok": false,
+			"message": "Trainer palette %d has bit 15 set ($%04X, $%04X)." % [
+				trainer_class, first, second,
+			],
+		}
+	if first == 0 and second == 0:
+		return {"ok": false, "message": "Trainer palette %d is blank." % trainer_class}
+	return {"ok": true, "message": ""}
+
+
 ## Resolves one entry of the type name pointer table.
 static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> String:
 	var table: int = RomLayout.type_name_pointer_offset(layout, type_number)
@@ -277,6 +401,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"moves": 0,
 		"items": 0,
 		"types": 0,
+		"trainers": 0,
 		"elapsed_ms": 0,
 	}
 
@@ -312,6 +437,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	var moves: Array = _import_moves(rom, layout, on_progress)
 	var items: Array = _import_items(rom, layout, on_progress)
 	var types: Array = _import_types(rom, layout, on_progress)
+	var trainers: Array = _import_trainers(rom, layout, on_progress)
 
 	if not RomCache.write_json(RomCache.species_path(directory), species):
 		result["message"] = "Could not write species data."
@@ -325,6 +451,9 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	if not RomCache.write_json(RomCache.types_path(directory), types):
 		result["message"] = "Could not write type data."
 		return result
+	if not RomCache.write_json(RomCache.trainers_path(directory), trainers):
+		result["message"] = "Could not write trainer data."
+		return result
 
 	var manifest: Dictionary = {
 		"format_version": RomCache.FORMAT_VERSION,
@@ -334,6 +463,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"move_count": moves.size(),
 		"item_count": items.size(),
 		"type_count": types.size(),
+		"trainer_count": trainers.size(),
 		"atlases": pics,
 		"tiles": tiles,
 		"complete": true,
@@ -347,9 +477,10 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	result["moves"] = moves.size()
 	result["items"] = items.size()
 	result["types"] = types.size()
+	result["trainers"] = trainers.size()
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
-	result["message"] = "Imported %d species, %d moves and %d items in %d ms." % [
-		species.size(), moves.size(), items.size(), result["elapsed_ms"],
+	result["message"] = "Imported %d species, %d moves, %d items and %d trainer classes in %d ms." % [
+		species.size(), moves.size(), items.size(), trainers.size(), result["elapsed_ms"],
 	]
 	return result
 
@@ -457,6 +588,32 @@ func _import_types(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 	return out
 
 
+## Decodes the trainer classes: a name and the two colours the class is drawn in.
+##
+## A class has one palette and no shiny counterpart, so the pair is stored flat
+## rather than under a key, and the pic is found by class number in the trainer
+## atlas the way a species' is in the front one.
+func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
+	var count: int = RomLayout.trainer_class_count(layout)
+	var names: PackedStringArray = Gen2Text.decode_sequence(
+		rom.bytes(), int(layout["trainer_class_names"]), count, RomLayout.MAX_NAME_LENGTH
+	)
+	var out: Array = []
+
+	for trainer_class: int in range(1, count + 1):
+		var palette: int = RomLayout.trainer_palette_offset(layout, trainer_class)
+		out.append({
+			"number": trainer_class,
+			"name": names[trainer_class - 1],
+			"palette": [rom.u16le(palette), rom.u16le(palette + Gen2Palette.COLOR_BYTES)],
+		})
+
+		if on_progress.is_valid():
+			on_progress.call("trainers", trainer_class, count)
+
+	return out
+
+
 ## Decodes the font and the eight text box borders, each as one strip of tiles.
 ##
 ## Neither is compressed and neither is per-species, so unlike a pic there is
@@ -508,6 +665,8 @@ func _import_pics(
 	var back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.SPECIES_COUNT)
 	var unown_front: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, RomLayout.UNOWN_FORMS)
 	var unown_back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.UNOWN_FORMS)
+	var trainer_classes: int = RomLayout.trainer_class_count(layout)
+	var trainers: Dictionary = _new_atlas(RomLayout.TRAINER_PIC_TILES, trainer_classes)
 
 	for entry: Dictionary in species:
 		var number: int = entry["number"]
@@ -549,9 +708,21 @@ func _import_pics(
 		if on_progress.is_valid():
 			on_progress.call("pics", number, RomLayout.SPECIES_COUNT)
 
+	# Trainer pics share the pointer form and the bank repair, and differ in that
+	# every one of them is the same square and none of them has a back half.
+	for trainer_class: int in range(1, trainer_classes + 1):
+		_decode_into(
+			rom, layout, RomLayout.trainer_pic_pointer_offset(layout, trainer_class),
+			RomLayout.TRAINER_PIC_TILES, RomLayout.TRAINER_PIC_TILES, trainers, trainer_class - 1
+		)
+
+		if on_progress.is_valid():
+			on_progress.call("trainer pics", trainer_class, trainer_classes)
+
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var atlases: Dictionary = {
 		"front": front, "back": back, "unown_front": unown_front, "unown_back": unown_back,
+		"trainers": trainers,
 	}
 	var written: Dictionary = {}
 	for name: String in atlases:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -95,6 +95,26 @@ const ENEMY_HUD_TILES: int = 4
 const PLAYER_HUD_TILES: int = 6
 const EXP_BAR_TILES: int = 9
 
+## The four palettes a battle draws its bars with: the HP bar in green, yellow
+## or red depending on how much is left, and the exp bar in blue. They are two
+## colours each like a species' palette, white and black being implied, and they
+## sit immediately before the species palettes in every game.
+##
+## The names are the cache's keys, and the order is the cartridge's.
+const BAR_PALETTE_NAMES: Array = ["hp_green", "hp_yellow", "hp_red", "exp"]
+
+## What those palettes hold. This is content whose value is known independently,
+## like the first species name, so the check for the offset is the values
+## themselves: every bar shares a light colour and differs in the dark one.
+const BAR_PALETTES: Array = [
+	[0x3F5E, 0x02E0], [0x3F5E, 0x02BF], [0x3F5E, 0x001F], [0x3F5E, 0x7E24],
+]
+
+## An HP bar is green down to half and yellow down to a fifth, measured in lit
+## pixels rather than in hit points: what colours the bar is what is drawn.
+const HP_GREEN_PIXELS: int = 24
+const HP_YELLOW_PIXELS: int = 10
+
 ## The HP bar's fill levels within [constant BATTLE_FONT_TILES], and the exp
 ## bar's within its own strip. Each step lights one more column, which is two
 ## more pixels than the step before, and that progression is what proves the
@@ -164,6 +184,7 @@ const GOLD_SILVER: Dictionary = {
 	"type_names": 0x509AE,
 	"font": 0xF82F2,
 	"frames": 0xF88F2,
+	"bar_palettes": 0xAD2D,
 	"battle_font": 0xF86F2,
 	"enemy_hud": 0xF8BB2,
 	"player_hud": 0xF8BD2,
@@ -192,6 +213,7 @@ const CRYSTAL: Dictionary = {
 	"type_names": 0x5097B,
 	"font": 0xF8200,
 	"frames": 0xF8800,
+	"bar_palettes": 0xA8BE,
 	"battle_font": 0xF8600,
 	"enemy_hud": 0xF8AC0,
 	"player_hud": 0xF8AE0,
@@ -258,6 +280,11 @@ static func pic_pointer_offset(layout: Dictionary, species: int, back: bool) -> 
 static func unown_pic_pointer_offset(layout: Dictionary, form: int, back: bool) -> int:
 	var pair: int = form * 2 + (1 if back else 0)
 	return int(layout["unown_pic_pointers"]) + pair * PIC_POINTER_SIZE
+
+
+## One of the four bar palettes, by its position in [constant BAR_PALETTE_NAMES].
+static func bar_palette_offset(layout: Dictionary, index: int) -> int:
+	return int(layout["bar_palettes"]) + index * Gen2Palette.PAIR_BYTES
 
 
 static func trainer_class_count(layout: Dictionary) -> int:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -83,6 +83,27 @@ const FRAME_VERTICAL: int = 3
 const FRAME_BOTTOM_LEFT: int = 4
 const FRAME_BOTTOM_RIGHT: int = 5
 
+## The battle HUD's own graphics, which sit in the same section as the font and
+## the text box borders and are the rest of what a battle screen draws.
+##
+## [code]battle_font[/code] is 2bpp and carries "HP:", the nine fill levels of
+## the HP bar and the battle screen's odds and ends. The two HUD borders are 1bpp
+## and are the boxes a name and a level sit in, one shape for the enemy's and one
+## for the player's. The exp bar is 2bpp and is seven fill levels and two ends.
+const BATTLE_FONT_TILES: int = 32
+const ENEMY_HUD_TILES: int = 4
+const PLAYER_HUD_TILES: int = 6
+const EXP_BAR_TILES: int = 9
+
+## The HP bar's fill levels within [constant BATTLE_FONT_TILES], and the exp
+## bar's within its own strip. Each step lights one more column, which is two
+## more pixels than the step before, and that progression is what proves the
+## offset: nothing else in the section counts up like this.
+const HP_BAR_FIRST_TILE: int = 2
+const HP_BAR_LEVELS: int = 9
+const EXP_BAR_LEVELS: int = 7
+const BAR_STEP_PIXELS: int = 2
+
 ## Trainer classes are numbered from 1; class 0 is the player, who has a palette
 ## in the table but no pic in it. Crystal added one class to the sixty-six Gold
 ## and Silver have, so the count lives in the layout rather than here.
@@ -143,6 +164,10 @@ const GOLD_SILVER: Dictionary = {
 	"type_names": 0x509AE,
 	"font": 0xF82F2,
 	"frames": 0xF88F2,
+	"battle_font": 0xF86F2,
+	"enemy_hud": 0xF8BB2,
+	"player_hud": 0xF8BD2,
+	"exp_bar": 0xF8C02,
 	"trainer_pic_pointers": 0x80000,
 	"trainer_palettes": 0xB53D,
 	"trainer_class_names": 0x1B0955,
@@ -167,6 +192,10 @@ const CRYSTAL: Dictionary = {
 	"type_names": 0x5097B,
 	"font": 0xF8200,
 	"frames": 0xF8800,
+	"battle_font": 0xF8600,
+	"enemy_hud": 0xF8AC0,
+	"player_hud": 0xF8AE0,
+	"exp_bar": 0xF8B10,
 	"trainer_pic_pointers": 0x128000,
 	"trainer_palettes": 0xB0CE,
 	"trainer_class_names": 0x2C1EF,

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -83,6 +83,13 @@ const FRAME_VERTICAL: int = 3
 const FRAME_BOTTOM_LEFT: int = 4
 const FRAME_BOTTOM_RIGHT: int = 5
 
+## Trainer classes are numbered from 1; class 0 is the player, who has a palette
+## in the table but no pic in it. Crystal added one class to the sixty-six Gold
+## and Silver have, so the count lives in the layout rather than here.
+##
+## Every trainer pic is this square, unlike a Pokémon's front pic.
+const TRAINER_PIC_TILES: int = 7
+
 ## Back pics are always this square. Front pics vary and carry their own size in
 ## the base stats.
 const BACKPIC_TILES: int = 6
@@ -136,6 +143,11 @@ const GOLD_SILVER: Dictionary = {
 	"type_names": 0x509AE,
 	"font": 0xF82F2,
 	"frames": 0xF88F2,
+	"trainer_pic_pointers": 0x80000,
+	"trainer_palettes": 0xB53D,
+	"trainer_class_names": 0x1B0955,
+	"trainer_classes": 66,
+	"trainer_last_class": "ROCKET",
 	# Gold and Silver patch three bank numbers and pass the rest through. The
 	# stored value is what the linker assigned before three pic sections were
 	# moved; see FixPicBank in pokegold.
@@ -155,6 +167,11 @@ const CRYSTAL: Dictionary = {
 	"type_names": 0x5097B,
 	"font": 0xF8200,
 	"frames": 0xF8800,
+	"trainer_pic_pointers": 0x128000,
+	"trainer_palettes": 0xB0CE,
+	"trainer_class_names": 0x2C1EF,
+	"trainer_classes": 67,
+	"trainer_last_class": "MYSTICALMAN",
 	# Crystal's equivalent table is a contiguous $48-$5F, so the whole remap
 	# collapses to a constant: PICS_FIX in pokecrystal.
 	"pic_bank_add": 0x36,
@@ -212,6 +229,24 @@ static func pic_pointer_offset(layout: Dictionary, species: int, back: bool) -> 
 static func unown_pic_pointer_offset(layout: Dictionary, form: int, back: bool) -> int:
 	var pair: int = form * 2 + (1 if back else 0)
 	return int(layout["unown_pic_pointers"]) + pair * PIC_POINTER_SIZE
+
+
+static func trainer_class_count(layout: Dictionary) -> int:
+	return int(layout["trainer_classes"])
+
+
+## Trainer pics have no back half and no size of their own, so unlike the
+## Pokémon table this one is a flat run of three-byte pointers, indexed from the
+## first class rather than from the player.
+static func trainer_pic_pointer_offset(layout: Dictionary, trainer_class: int) -> int:
+	return int(layout["trainer_pic_pointers"]) + (trainer_class - 1) * PIC_POINTER_SIZE
+
+
+## The palette table opens with the player, who is a trainer class with no pic,
+## so it is indexed by class number where the pic table is indexed by class
+## number minus one. The two are one entry out of step on purpose.
+static func trainer_palette_offset(layout: Dictionary, trainer_class: int) -> int:
+	return int(layout["trainer_palettes"]) + trainer_class * Gen2Palette.PAIR_BYTES
 
 
 static func move_data_offset(layout: Dictionary, move: int) -> int:

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -76,6 +76,35 @@ static func decode_1bpp_strip(data: PackedByteArray, offset: int, count: int) ->
 	return out
 
 
+## The same, for tiles stored 2bpp: the battle HUD's graphics, which are four
+## colours where the font is two.
+##
+## Kept as a strip for the same reason the font is. These sheets are addressed by
+## tile number, so one row turns that number into a horizontal offset and nothing
+## else, and a sheet that decoded short leaves a visible hole rather than failing.
+static func decode_2bpp_strip(data: PackedByteArray, offset: int, count: int) -> PackedByteArray:
+	var width: int = count * TILE_WIDTH
+	var out: PackedByteArray = PackedByteArray()
+	if count <= 0:
+		return out
+	out.resize(width * TILE_HEIGHT)
+
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(TILE_PIXELS)
+
+	for tile: int in count:
+		var at: int = offset + tile * TILE_BYTES
+		if at < 0 or at + TILE_BYTES > data.size():
+			break
+		decode_tile_into(data, at, pixels, 0)
+		for row: int in TILE_HEIGHT:
+			var destination: int = row * width + tile * TILE_WIDTH
+			for column: int in TILE_WIDTH:
+				out[destination + column] = pixels[row * TILE_WIDTH + column]
+
+	return out
+
+
 ## Decodes a Pokémon or trainer pic into a row-major index buffer
 ## [param columns] * 8 wide and [param rows] * 8 tall.
 ##

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -1,0 +1,185 @@
+class_name Gen2BattleHud
+extends RefCounted
+
+## The two status panels a battle draws, on the tile grid the hardware uses.
+##
+## Everything here is in tiles, and every position is the one the games use. The
+## enemy's panel hangs from a side on its left at the top of the screen and the
+## player's from a side on its right below the middle, and neither is a box: they
+## are an edge and two corners with the contents printed inside them, which is
+## why they are drawn from the HUD sheets rather than from a text box frame.
+##
+## The panels differ in more than position. The player's carries its Pokémon's
+## HP as numbers and an exp bar along its bottom edge, and its bar closes with
+## the cap that hangs off the other side. The enemy's has neither, because the
+## player is not supposed to know either number.
+##
+## Node-free: it writes indices into a buffer, so a HUD can be drawn and read
+## back in a headless test.
+
+const TILE: int = Gen2Font.TILE
+
+## The HP bar is six tiles of eight pixels; the exp bar is eight.
+const HP_BAR_TILES: int = 6
+const EXP_BAR_TILES: int = 8
+
+## The enemy's panel: name, then level, then the bar and the edge under it.
+const ENEMY_NAME: Vector2i = Vector2i(1, 0)
+const ENEMY_LEVEL: Vector2i = Vector2i(6, 1)
+const ENEMY_BAR: Vector2i = Vector2i(2, 2)
+const ENEMY_EDGE: Vector2i = Vector2i(1, 2)
+
+## The player's, which is the same idea mirrored and two rows taller.
+const PLAYER_NAME: Vector2i = Vector2i(10, 7)
+const PLAYER_LEVEL: Vector2i = Vector2i(14, 8)
+const PLAYER_BAR: Vector2i = Vector2i(10, 9)
+const PLAYER_HP: Vector2i = Vector2i(11, 10)
+const PLAYER_EXP: Vector2i = Vector2i(10, 11)
+const PLAYER_EDGE: Vector2i = Vector2i(18, 10)
+
+## How many tiles of edge run along the bottom of a panel.
+const EDGE_TILES: int = 8
+
+## Both HP numbers are printed three columns wide, right-aligned, with a slash
+## between them.
+const HP_DIGITS: int = 3
+
+var font: Gen2Font = null
+var tiles: Gen2BattleTiles = null
+
+
+## Reads what it draws with out of a cache, or null if any of it is missing.
+static func from_data(data: GameData) -> Gen2BattleHud:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(data)
+	if glyphs == null or page == null:
+		return null
+
+	var out := Gen2BattleHud.new()
+	out.font = glyphs
+	out.tiles = page
+	return out
+
+
+## How much of a bar is lit, in pixels.
+##
+## A Pokémon that is alive never shows an empty bar: the games round down and
+## then put one pixel back, so that fainting is the only thing that empties it.
+static func bar_pixels(current: int, maximum: int, length: int) -> int:
+	if maximum <= 0 or current <= 0:
+		return 0
+	if current >= maximum:
+		return length
+	@warning_ignore("integer_division")
+	var lit: int = current * length / maximum
+	return maxi(lit, 1)
+
+
+## The enemy's panel except for the bar's fill: the name, the level, the "HP:"
+## label, the cap that closes the bar and the edge under it.
+##
+## The fill is drawn separately because it is the one thing on the panel that is
+## not black on white. The hardware gives every tile its own palette; this
+## layers instead, which comes to the same picture and keeps the palette choice
+## where the colour is.
+func draw_enemy(
+	into: PackedByteArray, width: int, name: String, level: int
+) -> void:
+	font.draw_text(name, into, width, ENEMY_NAME.x * TILE, ENEMY_NAME.y * TILE)
+	_draw_level(into, width, ENEMY_LEVEL, level)
+	_draw_bar_frame(into, width, ENEMY_BAR, Gen2BattleTiles.HP_BAR_END)
+
+	# The edge, which starts beside the bar and turns under it.
+	var left: int = ENEMY_EDGE.x * TILE
+	var top: int = ENEMY_EDGE.y * TILE
+	tiles.draw(Gen2BattleTiles.ENEMY_SIDE, into, width, left, top)
+	tiles.draw(Gen2BattleTiles.ENEMY_CORNER, into, width, left, top + TILE)
+	tiles.draw_run(Gen2BattleTiles.HUD_BOTTOM, EDGE_TILES, into, width, left + TILE, top + TILE)
+	tiles.draw(
+		Gen2BattleTiles.ENEMY_BOTTOM_RIGHT, into, width,
+		left + (EDGE_TILES + 1) * TILE, top + TILE
+	)
+
+
+## The player's panel, likewise without its two bars: it carries HP as numbers
+## as well, and an exp bar sunk into its bottom edge.
+func draw_player(
+	into: PackedByteArray, width: int, name: String, level: int, hp: int, max_hp: int
+) -> void:
+	font.draw_text(name, into, width, PLAYER_NAME.x * TILE, PLAYER_NAME.y * TILE)
+	_draw_level(into, width, PLAYER_LEVEL, level)
+	_draw_bar_frame(into, width, PLAYER_BAR, Gen2BattleTiles.HP_BAR_END + 1)
+
+	# Right-aligned in a fixed field, as the games print any number in a panel:
+	# the digits line up and the leading spaces draw nothing.
+	font.draw_text(
+		"%s/%s" % [str(hp).lpad(HP_DIGITS), str(max_hp).lpad(HP_DIGITS)], into, width,
+		PLAYER_HP.x * TILE, PLAYER_HP.y * TILE
+	)
+
+	# The edge, drawn before the exp bar because the bar sits in it: the games
+	# lay the bottom edge down and then print the bar over the middle of it.
+	var right: int = PLAYER_EDGE.x * TILE
+	var top: int = PLAYER_EDGE.y * TILE
+	tiles.draw(Gen2BattleTiles.PLAYER_SIDE, into, width, right, top)
+	tiles.draw(Gen2BattleTiles.PLAYER_BOTTOM_RIGHT, into, width, right, top + TILE)
+	tiles.draw_run(
+		Gen2BattleTiles.HUD_BOTTOM, EDGE_TILES, into, width,
+		right - EDGE_TILES * TILE, top + TILE
+	)
+	tiles.draw(
+		Gen2BattleTiles.PLAYER_BOTTOM_LEFT, into, width,
+		right - (EDGE_TILES + 1) * TILE, top + TILE
+	)
+
+
+## The fill of one HP bar, which is all that is drawn in the bar's own colour.
+func draw_hp_bar(
+	into: PackedByteArray, width: int, at: Vector2i, hp: int, max_hp: int
+) -> void:
+	var lit: int = bar_pixels(hp, max_hp, HP_BAR_TILES * TILE)
+	var left: int = (at.x + 2) * TILE
+	for tile: int in HP_BAR_TILES:
+		var within: int = clampi(lit - tile * TILE, 0, TILE)
+		if within <= 0:
+			continue
+		tiles.draw(
+			Gen2BattleTiles.HP_BAR_EMPTY + within, into, width, left + tile * TILE, at.y * TILE
+		)
+
+
+## The exp bar, whose ends are the HP bar's own tiles and whose partial fills
+## are the only thing its own sheet is for.
+func draw_exp_bar(into: PackedByteArray, width: int, fraction: float) -> void:
+	var length: int = EXP_BAR_TILES * TILE
+	var lit: int = clampi(int(fraction * float(length)), 0, length)
+	var left: int = PLAYER_EXP.x * TILE
+	var top: int = PLAYER_EXP.y * TILE
+
+	for tile: int in EXP_BAR_TILES:
+		var within: int = clampi(lit - tile * TILE, 0, TILE)
+		if within <= 0:
+			continue
+		var number: int = Gen2BattleTiles.HP_BAR_FULL if within >= TILE \
+			else Gen2BattleTiles.EXP_BAR_FIRST_PARTIAL + within - 1
+		tiles.draw(number, into, width, left + tile * TILE, top)
+
+
+## The level symbol and the number, left-aligned after it, which is how a level
+## is written everywhere in these games.
+func _draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> void:
+	tiles.draw(Gen2BattleTiles.LEVEL, into, width, at.x * TILE, at.y * TILE)
+	font.draw_text("%d" % level, into, width, (at.x + 1) * TILE, at.y * TILE)
+
+
+## "HP:", the empty bar and the cap that closes it: everything about a bar that
+## does not depend on how full it is.
+func _draw_bar_frame(into: PackedByteArray, width: int, at: Vector2i, cap: int) -> void:
+	var left: int = at.x * TILE
+	var top: int = at.y * TILE
+	tiles.draw(Gen2BattleTiles.HP_LABEL, into, width, left, top)
+	tiles.draw(Gen2BattleTiles.HP_LABEL + 1, into, width, left + TILE, top)
+	tiles.draw_run(
+		Gen2BattleTiles.HP_BAR_EMPTY, HP_BAR_TILES, into, width, left + 2 * TILE, top
+	)
+	tiles.draw(cap, into, width, left + (2 + HP_BAR_TILES) * TILE, top)

--- a/game/render/battle_hud.gd.uid
+++ b/game/render/battle_hud.gd.uid
@@ -1,0 +1,1 @@
+uid://udl22pyvse7u

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -1,0 +1,115 @@
+class_name Gen2BattleTiles
+extends RefCounted
+
+## The battle screen's tile page, assembled the way the hardware assembles it.
+##
+## A battle loads four sheets into one run of tile numbers, and they overlap on
+## purpose: the battle font is copied in first and the two HUD borders are
+## copied over the middle of it, so thirteen of its tiles are never seen. Rather
+## than trim the sheets and renumber them, this copies them in the same order
+## into one strip and keeps the cartridge's own tile numbers. The result is that
+## the constants below are the numbers the disassembly uses, and a screen built
+## from them can be read against it.
+##
+## Node-free like the rest of the drawing layer: it writes indices into a buffer,
+## so a whole HUD can be laid out and checked with no display.
+
+const TILE: int = Gen2Font.TILE
+
+## The first and last tile numbers the page covers.
+const FIRST_TILE: int = 0x55
+const LAST_TILE: int = 0x78
+
+## Where each sheet is copied to, in the order the battle loads them.
+const EXP_BAR_AT: int = 0x55
+const BATTLE_FONT_AT: int = 0x60
+const ENEMY_HUD_AT: int = 0x6C
+const PLAYER_HUD_AT: int = 0x73
+
+## "HP:", which is two tiles because the colon shares one with the bar's cap.
+const HP_LABEL: int = 0x60
+## The nine fill levels, from empty to eight pixels lit.
+const HP_BAR_EMPTY: int = 0x62
+const HP_BAR_FULL: int = 0x6A
+## The cap that closes a bar. The player's HUD uses the tile after it, which is
+## the same shape hanging off the other side.
+const HP_BAR_END: int = 0x6B
+## The seven partial fills of the exp bar. Its empty and full tiles are the HP
+## bar's own: only the middle of it is drawn from a sheet of its own.
+const EXP_BAR_FIRST_PARTIAL: int = 0x55
+
+## The level symbol, printed before a number.
+const LEVEL: int = 0x6E
+
+## The enemy's HUD hangs from a side on its left; the player's from one on its
+## right. Both close with a bottom edge and two corners.
+const ENEMY_SIDE: int = 0x6D
+const ENEMY_CORNER: int = 0x74
+const ENEMY_BOTTOM_RIGHT: int = 0x78
+const PLAYER_SIDE: int = 0x73
+const PLAYER_BOTTOM_LEFT: int = 0x6F
+const PLAYER_BOTTOM_RIGHT: int = 0x77
+const HUD_BOTTOM: int = 0x76
+
+var _tiles: PackedByteArray = PackedByteArray()
+var _width: int = 0
+
+
+## Builds the page out of a cache, or null if the battle graphics are not in it.
+static func from_data(data: GameData) -> Gen2BattleTiles:
+	if data == null:
+		return null
+
+	var out := Gen2BattleTiles.new()
+	var count: int = LAST_TILE - FIRST_TILE + 1
+	out._width = count * TILE
+	out._tiles.resize(out._width * TILE)
+
+	# In load order, so that where two sheets claim a tile the later one wins,
+	# exactly as it does in video memory.
+	var sheets: Array = [
+		["exp_bar", EXP_BAR_AT], ["battle_font", BATTLE_FONT_AT],
+		["enemy_hud", ENEMY_HUD_AT], ["player_hud", PLAYER_HUD_AT],
+	]
+	var loaded: int = 0
+	for sheet: Array in sheets:
+		var name: String = sheet[0]
+		var meta: Dictionary = data.tile_sheet(name)
+		if meta.is_empty():
+			continue
+		if out._copy(data.tile_indices(name), int(meta.get("width", 0)), int(sheet[1])):
+			loaded += 1
+
+	return out if loaded == sheets.size() else null
+
+
+## One tile of the page, drawn at a pixel position in [param into].
+func draw(tile: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int) -> void:
+	if tile < FIRST_TILE or tile > LAST_TILE:
+		return
+	Gen2Font.blit_slot(_tiles, _width, tile - FIRST_TILE, into, into_width, at_x, at_y)
+
+
+## Draws the same tile across a run of columns, which is what a HUD's bottom
+## edge and an empty bar both are.
+func draw_run(
+	tile: int, count: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int
+) -> void:
+	for i: int in count:
+		draw(tile, into, into_width, at_x + i * TILE, at_y)
+
+
+func _copy(strip: PackedByteArray, strip_width: int, at_tile: int) -> bool:
+	if strip_width <= 0 or strip.size() < strip_width * TILE:
+		return false
+
+	var tiles: int = strip_width / TILE
+	for tile: int in tiles:
+		var to: int = (at_tile - FIRST_TILE + tile) * TILE
+		if to < 0 or to + TILE > _width:
+			continue
+		for y: int in TILE:
+			var from: int = y * strip_width + tile * TILE
+			for x: int in TILE:
+				_tiles[y * _width + to + x] = strip[from + x]
+	return true

--- a/game/render/battle_tiles.gd.uid
+++ b/game/render/battle_tiles.gd.uid
@@ -1,0 +1,1 @@
+uid://dqtsei8dnapt8

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -74,7 +74,7 @@ func draw_code(
 	var slot: int = code - _first_code
 	if slot < 0 or slot >= _glyph_tiles:
 		return
-	_blit(_glyphs, _glyph_width, slot, into, into_width, at_x, at_y)
+	blit_slot(_glyphs, _glyph_width, slot, into, into_width, at_x, at_y)
 
 
 ## Draws a string left to right from [param at_x], advancing eight pixels per
@@ -101,13 +101,16 @@ func draw_frame_code(
 	var slot: int = frame * RomLayout.FRAME_TILES + within
 	if frame < 0 or slot >= _frame_tiles:
 		return
-	_blit(_frames, _frame_width, slot, into, into_width, at_x, at_y)
+	blit_slot(_frames, _frame_width, slot, into, into_width, at_x, at_y)
 
 
 ## Copies one tile out of a strip, clipped to the destination. Clipping rather
 ## than refusing, because a text box that runs off the edge of the screen should
 ## look wrong at the edge and be right everywhere else.
-static func _blit(
+##
+## Public because every sheet in this project is a strip and they all draw from
+## one the same way; [Gen2BattleTiles] is the other caller.
+static func blit_slot(
 	strip: PackedByteArray,
 	strip_width: int,
 	slot: int,

--- a/game/render/pic_viewer.gd
+++ b/game/render/pic_viewer.gd
@@ -8,8 +8,9 @@ extends Control
 ## writing a PNG. The battle screen will do this properly, with the pic where
 ## the hardware puts it and a tile-based font around it.
 ##
-## Left/right change species, S toggles shiny, B swaps front for back. Each is
-## also a plain method so `tools/screenshot.gd` can drive it.
+## Left/right change species, S toggles shiny, B swaps front for back, and T
+## switches to the trainer classes, which have one palette each and no back pic.
+## Each is also a plain method so `tools/screenshot.gd` can drive it.
 
 ## The white the hardware fills a pic window with. Index 0 of every pic is this
 ## colour, so a sprite on it looks exactly as it does in the game.
@@ -19,6 +20,7 @@ var _data: GameData = null
 var _number: int = 1
 var _shiny: bool = false
 var _back: bool = false
+var _trainers: bool = false
 
 var _pic: TextureRect = null
 
@@ -65,6 +67,8 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			toggle_shiny()
 		KEY_B:
 			toggle_back()
+		KEY_T:
+			toggle_trainers()
 		_:
 			return
 	accept_event()
@@ -79,14 +83,23 @@ func previous_species() -> void:
 
 
 ## Wraps at both ends, so holding an arrow down never lands on a blank screen.
+## In trainer mode the number is a class rather than a species; the two count
+## differently and the wrap follows whichever is on screen.
 func show_species(number: int) -> void:
 	if _data == null:
 		return
-	var count: int = _data.species_count()
+	var count: int = _data.trainer_count() if _trainers else _data.species_count()
 	if count <= 0:
 		return
 	_number = wrapi(number, 1, count + 1)
 	_refresh()
+
+
+## The trainer classes use the same viewer because they are the same path: a
+## slot in an atlas and a palette applied at draw time.
+func show_trainer(number: int) -> void:
+	_trainers = true
+	show_species(number)
 
 
 func toggle_shiny() -> void:
@@ -99,8 +112,19 @@ func toggle_back() -> void:
 	_refresh()
 
 
+func toggle_trainers() -> void:
+	_trainers = not _trainers
+	# Class 67 is a species and species 251 is not a class, so the number cannot
+	# survive the switch.
+	show_species(1)
+
+
 func _refresh() -> void:
 	if _data == null or _pic == null:
+		return
+
+	if _trainers:
+		_refresh_trainer()
 		return
 
 	var entry: Dictionary = _data.species(_number)
@@ -113,15 +137,33 @@ func _refresh() -> void:
 		_data.atlas_indices(pic["atlas"]), atlas, pic, _data.palette(_number, _shiny)
 	)
 
-	_pic.texture = ImageTexture.create_from_image(image)
-	_pic.size = image.get_size()
-	_pic.position = (
-		Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) - Vector2(image.get_size())
-	).floor() * 0.5
-
+	_show(image)
 	_caption.text = "%s   #%03d %s   %s   %s" % [
 		_data.title(), _number, entry["name"],
 		"back" if _back else "front",
 		"shiny" if _shiny else "normal",
 	]
-	_hint.text = "left/right species    S shiny    B front/back"
+	_hint.text = "left/right species    S shiny    B front/back    T trainers"
+
+
+func _refresh_trainer() -> void:
+	var pic: Dictionary = _data.trainer_pic(_number)
+	if pic.is_empty():
+		return
+
+	_show(Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.trainer_palette(_number)
+	))
+	_caption.text = "%s   class %02d %s" % [
+		_data.title(), _number, _data.trainer_name(_number),
+	]
+	_hint.text = "left/right class    T back to species"
+
+
+func _show(image: Image) -> void:
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = image.get_size()
+	_pic.position = (
+		Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) - Vector2(image.get_size())
+	).floor() * 0.5

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -1,0 +1,191 @@
+extends GutTest
+
+## The battle screen's tile page and the arithmetic behind its bars.
+##
+## Builds its own cache, like `test_game_data.gd`: nothing here opens a
+## cartridge, because the point of the drawing layer is that it works on
+## indices and a palette and never sees one.
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"battletest", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+## Four sheets, each filled with one index, so which sheet a tile came from can
+## be read off the page.
+func _write_cache(with_sheets: bool = true) -> void:
+	var sheets: Dictionary = {}
+	if with_sheets:
+		var written: Dictionary = {
+			"exp_bar": [RomLayout.EXP_BAR_TILES, 2],
+			"battle_font": [RomLayout.BATTLE_FONT_TILES, 1],
+			"enemy_hud": [RomLayout.ENEMY_HUD_TILES, 2],
+			"player_hud": [RomLayout.PLAYER_HUD_TILES, 3],
+			"font": [RomLayout.FONT_TILES, 3],
+			"frames": [RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES, 3],
+		}
+		for name: String in written:
+			var tiles: int = written[name][0]
+			var value: int = written[name][1]
+			var indices: PackedByteArray = PackedByteArray()
+			indices.resize(tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
+			indices.fill(value)
+			RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
+			sheets[name] = {
+				"width": tiles * Gen2Tiles.TILE_WIDTH,
+				"height": Gen2Tiles.TILE_HEIGHT,
+				"tiles": tiles,
+				"first_code": RomLayout.FONT_FIRST_CODE if name == "font" else 0,
+				"bits": 1,
+			}
+
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "battletest",
+		"sha1": "0123456789abcdef",
+		"tiles": sheets,
+		"bar_palettes": {
+			"hp_green": [0x02E0, 0x02E0],
+			"hp_yellow": [0x02BF, 0x02BF],
+			"hp_red": [0x001F, 0x001F],
+			"exp": [0x7E24, 0x7E24],
+		},
+		"complete": true,
+	})
+
+
+func _data() -> GameData:
+	return GameData.open_directory(_directory)
+
+
+## The index one tile of the page draws, read back out of a buffer.
+func _drawn(page: Gen2BattleTiles, tile: int) -> int:
+	var into: PackedByteArray = PackedByteArray()
+	into.resize(Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
+	page.draw(tile, into, Gen2Tiles.TILE_WIDTH, 0, 0)
+	return into[0]
+
+
+func test_the_page_needs_every_sheet_it_draws_from() -> void:
+	_write_cache(false)
+	assert_null(Gen2BattleTiles.from_data(_data()))
+	assert_null(Gen2BattleHud.from_data(_data()))
+
+
+func test_a_later_sheet_wins_the_tiles_it_lands_on() -> void:
+	# The battle font is copied in first and the HUD borders over the middle of
+	# it, exactly as they are in video memory, so thirteen of its tiles are never
+	# seen. Getting this backwards draws a border where a bar should be.
+	_write_cache()
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(_data())
+	assert_not_null(page)
+	assert_eq(_drawn(page, Gen2BattleTiles.EXP_BAR_AT), 2, "the exp bar keeps its own tiles")
+	assert_eq(_drawn(page, Gen2BattleTiles.HP_BAR_EMPTY), 1, "the bar is the battle font's")
+	assert_eq(_drawn(page, Gen2BattleTiles.ENEMY_HUD_AT), 2, "the enemy border overwrites")
+	assert_eq(_drawn(page, Gen2BattleTiles.PLAYER_HUD_AT), 3, "so does the player's")
+
+
+func test_a_tile_outside_the_page_draws_nothing() -> void:
+	_write_cache()
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(_data())
+	assert_eq(_drawn(page, Gen2BattleTiles.FIRST_TILE - 1), 0)
+	assert_eq(_drawn(page, Gen2BattleTiles.LAST_TILE + 1), 0)
+
+
+func test_a_full_bar_is_full_and_an_empty_one_is_empty() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(20, 20, 48), 48)
+	assert_eq(Gen2BattleHud.bar_pixels(0, 20, 48), 0)
+
+
+func test_a_pokemon_that_is_alive_never_shows_an_empty_bar() -> void:
+	# The games round the bar down and then put a pixel back, so that an empty
+	# bar means fainted and nothing else.
+	assert_eq(Gen2BattleHud.bar_pixels(1, 999, 48), 1)
+
+
+func test_a_bar_is_as_full_as_the_fraction_behind_it() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(10, 20, 48), 24)
+	assert_eq(Gen2BattleHud.bar_pixels(5, 20, 48), 12)
+
+
+func test_a_bar_with_no_maximum_does_not_divide_by_it() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(5, 0, 48), 0)
+
+
+func test_the_bar_colour_follows_what_is_drawn_not_the_hit_points() -> void:
+	# Half a bar is still green, a fifth of it is yellow, and below that it is
+	# red: the rule is about pixels, which is why a bar can turn red on a
+	# Pokémon with hit points left.
+	assert_eq(GameData.hp_bar_palette_name(48), "hp_green")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_GREEN_PIXELS), "hp_green")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_GREEN_PIXELS - 1), "hp_yellow")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_YELLOW_PIXELS), "hp_yellow")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_YELLOW_PIXELS - 1), "hp_red")
+
+
+func test_a_bar_palette_comes_back_as_four_colours() -> void:
+	_write_cache()
+	var data: GameData = _data()
+	var palette: PackedColorArray = data.bar_palette("hp_green")
+	assert_eq(palette.size(), Gen2Palette.COLORS_PER_PIC)
+	assert_eq(palette[0], Color.WHITE)
+	assert_eq(palette[3], Color.BLACK)
+	assert_ne(palette, data.bar_palette("hp_red"))
+
+
+func test_an_unknown_bar_palette_is_legible_rather_than_missing() -> void:
+	_write_cache()
+	assert_eq(_data().bar_palette("nothing"), _data().bar_palette("also nothing"))
+
+
+func test_the_hud_draws_its_panels_where_the_hardware_puts_them() -> void:
+	# The panels sit above and below the pics and must not reach into either.
+	_write_cache()
+	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
+	assert_not_null(hud)
+
+	var screen: PackedByteArray = PackedByteArray()
+	screen.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_enemy(screen, Gen2Screen.WIDTH, "PIDGEY", 5)
+	hud.draw_player(screen, Gen2Screen.WIDTH, "CYNDAQUIL", 5, 18, 18)
+
+	assert_ne(_ink_in_row(screen, Gen2BattleHud.ENEMY_NAME.y), 0, "the enemy's name row")
+	assert_ne(_ink_in_row(screen, Gen2BattleHud.PLAYER_BAR.y), 0, "the player's bar row")
+	assert_eq(_ink_in_row(screen, Gen2TextBox.STANDARD_TOP), 0, "nothing in the text box")
+	assert_eq(_ink_in_row(screen, 5), 0, "nothing between the two panels")
+
+
+func test_the_hp_bar_fill_is_drawn_apart_from_the_panel() -> void:
+	# The fill is the only part of a panel that is not black on white, so it is
+	# a layer of its own and the panel must not draw it.
+	_write_cache()
+	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
+
+	var full: PackedByteArray = PackedByteArray()
+	full.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_hp_bar(full, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, 20, 20)
+
+	var empty: PackedByteArray = PackedByteArray()
+	empty.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_hp_bar(empty, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, 0, 20)
+
+	assert_ne(_ink_in_row(full, Gen2BattleHud.ENEMY_BAR.y), 0)
+	assert_eq(_ink_in_row(empty, Gen2BattleHud.ENEMY_BAR.y), 0, "a fainted bar draws nothing")
+
+
+## Lit pixels in one row of tiles.
+func _ink_in_row(screen: PackedByteArray, row: int) -> int:
+	var out: int = 0
+	for y: int in range(row * Gen2Font.TILE, (row + 1) * Gen2Font.TILE):
+		for x: int in Gen2Screen.WIDTH:
+			if screen[y * Gen2Screen.WIDTH + x] != 0:
+				out += 1
+	return out

--- a/tests/unit/test_battle_hud.gd.uid
+++ b/tests/unit/test_battle_hud.gd.uid
@@ -1,0 +1,1 @@
+uid://bq3yvoe5vomq0

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -30,6 +30,10 @@ func _write_cache(complete: bool = true) -> void:
 	RomCache.write_json(RomCache.types_path(_directory), [
 		{"number": 0, "name": "NORMAL"}, {"number": 1, "name": "FIGHTING"},
 	])
+	RomCache.write_json(RomCache.trainers_path(_directory), [
+		{"number": 1, "name": "LEADER", "palette": [0x1234, 0x5678]},
+		{"number": 2, "name": "YOUNGSTER", "palette": [0x0C63, 0x1084]},
+	])
 	RomCache.write_indices(RomCache.pic_path(_directory, "front"), PackedByteArray([
 		0, 0, 1, 1,
 		0, 0, 1, 1,
@@ -47,6 +51,7 @@ func _write_cache(complete: bool = true) -> void:
 		"atlases": {
 			"front": {"width": 4, "height": 4, "cell": 2, "columns": 2, "decoded": 2},
 			"back": {"width": 4, "height": 4, "cell": 2, "columns": 2, "decoded": 2},
+			"trainers": {"width": 4, "height": 2, "cell": 2, "columns": 2, "decoded": 2},
 		},
 		"tiles": {
 			"font": {"width": 2, "height": 2, "tiles": 1, "first_code": 0x80},
@@ -154,6 +159,42 @@ func test_unown_forms_come_from_their_own_atlas() -> void:
 	# There is no Unown in this two-species cache, so the answer is empty
 	# rather than a lie about slot 0 of an atlas that was never written.
 	assert_true(data.unown_pic(0).is_empty())
+
+
+func test_trainer_classes_are_numbered_from_the_first_class_not_the_player() -> void:
+	# The cartridge's palette table opens with the player, who has no pic. The
+	# cache does not carry that entry, so class 1 is the first row here.
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.trainer_count(), 2)
+	assert_eq(data.trainer_name(1), "LEADER")
+	assert_eq(data.trainer_pic(1)["slot"], 0)
+
+
+func test_a_trainer_palette_has_no_shiny_half() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var palette: PackedColorArray = data.trainer_palette(1)
+	assert_eq(palette.size(), Gen2Palette.COLORS_PER_PIC)
+	assert_eq(palette[0], Color.WHITE)
+	assert_ne(palette, data.trainer_palette(2))
+
+
+func test_a_trainer_pic_always_fills_its_cell() -> void:
+	# Every trainer is drawn at one size, unlike a species front pic.
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var pic: Dictionary = data.trainer_pic(2)
+	assert_eq(pic["width"], 2)
+	assert_eq(pic["height"], 2)
+
+
+func test_an_unknown_trainer_class_answers_empty() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_true(data.trainer(0).is_empty(), "class 0 is the player, who has no entry")
+	assert_true(data.trainer_pic(99).is_empty())
+	assert_eq(data.trainer_name(99), "")
 
 
 func test_index_buffers_are_read_once_and_kept() -> void:

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -1,11 +1,16 @@
 extends GutTest
 
-## The font and border layout checks, against dumps this test builds.
+## The font, border and trainer layout checks, against dumps this test builds.
 ##
 ## No cartridge is opened here. What is being tested is not where the font is,
 ## which only a real dump can settle, but that the checks would notice if it
 ## were somewhere else: the whole value of a runtime check is that it fails, and
 ## a check nobody has ever seen fail is a comment.
+
+## Where the synthetic trainer pics are put: a bank the layout passes through
+## unpatched, so the check sees the same bank repair a real pointer gets.
+const PIC_BANK: int = 0x21
+const PIC_ADDRESS: int = 0x4010
 
 var _layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
 
@@ -159,3 +164,113 @@ func test_eight_identical_borders_mean_it_is_not_the_table() -> void:
 func test_a_dump_too_short_to_hold_the_font_fails_rather_than_reading_past_it() -> void:
 	assert_false(RomImporter.verify_font(_rom(PackedByteArray()), _layout)["ok"])
 	assert_false(RomImporter.verify_frames(_rom(PackedByteArray()), _layout)["ok"])
+
+
+## Names, palettes and pic pointers for every class, all three agreeing.
+func _trainer_dump() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_class_names(data, int(_layout["trainer_class_names"]))
+	_write_trainer_palettes(data, true)
+	_write_trainer_pointers(data)
+	_write(data, RomFile.linear(PIC_BANK, PIC_ADDRESS), _trainer_pic())
+	return data
+
+
+func _write_class_names(data: PackedByteArray, at: int) -> void:
+	var count: int = RomLayout.trainer_class_count(_layout)
+	var cursor: int = at
+	for trainer_class: int in range(1, count + 1):
+		var name: String = "LASS"
+		if trainer_class == 1:
+			name = RomImporter.TRAINER_FIRST_CLASS
+		elif trainer_class == RomImporter.TRAINER_MIDDLE_CLASS:
+			name = RomImporter.TRAINER_MIDDLE_CLASS_NAME
+		elif trainer_class == count:
+			name = String(_layout["trainer_last_class"])
+		var encoded: PackedByteArray = Gen2Text.encode(name)
+		encoded.append(Gen2Text.TERMINATOR)
+		_write(data, cursor, encoded)
+		cursor += encoded.size()
+
+
+## The player's entry plus one per class, and then something that is not a
+## palette, because the table ending where it should is half of what is checked.
+func _write_trainer_palettes(data: PackedByteArray, ends: bool) -> void:
+	var count: int = RomLayout.trainer_class_count(_layout)
+	for trainer_class: int in range(0, count + 2):
+		var at: int = RomLayout.trainer_palette_offset(_layout, trainer_class)
+		var high: int = 0x80 if ends and trainer_class == count + 1 else 0x00
+		_write(data, at, PackedByteArray([0x34, 0x12, 0x78, 0x56 | high]))
+
+
+func _write_trainer_pointers(data: PackedByteArray) -> void:
+	for trainer_class: int in range(1, RomLayout.trainer_class_count(_layout) + 1):
+		_write(
+			data, RomLayout.trainer_pic_pointer_offset(_layout, trainer_class),
+			PackedByteArray([PIC_BANK, PIC_ADDRESS & 0xFF, PIC_ADDRESS >> 8])
+		)
+
+
+## A long-form zero fill of exactly one trainer pic, then the terminator. The
+## pixels do not matter here; the length is what the check reads.
+func _trainer_pic() -> PackedByteArray:
+	var pixels: int = RomLayout.TRAINER_PIC_TILES * RomLayout.TRAINER_PIC_TILES \
+		* Gen2Tiles.TILE_BYTES
+	var length: int = pixels - 1
+	return PackedByteArray([
+		0xE0 | (Gen2Lz.Op.ZERO << 2) | (length >> 8), length & 0xFF, Gen2Lz.TERMINATOR,
+	])
+
+
+func test_a_plausible_trainer_table_verifies() -> void:
+	var result: Dictionary = RomImporter.verify_trainers(_rom(_trainer_dump()), _layout)
+	assert_true(result["ok"], result["message"])
+
+
+func test_class_names_that_slid_by_a_byte_fail() -> void:
+	# The failure the far-end check exists for: the entries are terminated rather
+	# than padded, so a start that is one byte out still reads as words.
+	var data: PackedByteArray = _trainer_dump()
+	_write_class_names(data, int(_layout["trainer_class_names"]) + 1)
+	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
+
+
+func test_a_palette_table_that_does_not_end_where_the_classes_do_fails() -> void:
+	var data: PackedByteArray = _trainer_dump()
+	_write_trainer_palettes(data, false)
+	var result: Dictionary = RomImporter.verify_trainers(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "entry")
+
+
+func test_a_blank_trainer_palette_fails() -> void:
+	var data: PackedByteArray = _trainer_dump()
+	_write(data, RomLayout.trainer_palette_offset(_layout, 3), PackedByteArray([0, 0, 0, 0]))
+	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
+
+
+func test_a_pointer_outside_the_banked_window_fails() -> void:
+	# $0000-$3FFF is the fixed bank, which no pic pointer addresses: a pointer
+	# that lands there means the table is not a pointer table.
+	var data: PackedByteArray = _trainer_dump()
+	_write(
+		data, RomLayout.trainer_pic_pointer_offset(_layout, 5),
+		PackedByteArray([PIC_BANK, 0x00, 0x20])
+	)
+	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
+
+
+func test_a_pic_that_is_short_of_a_full_trainer_fails() -> void:
+	var data: PackedByteArray = _trainer_dump()
+	_write(
+		data, RomFile.linear(PIC_BANK, PIC_ADDRESS),
+		PackedByteArray([0x60 | 0x02, Gen2Lz.TERMINATOR])
+	)
+	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
+
+
+func test_a_dump_with_no_trainers_in_it_fails() -> void:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -285,7 +285,21 @@ func _battle_dump() -> PackedByteArray:
 	_write_bar(data, int(_layout["exp_bar"]), 0, RomLayout.EXP_BAR_LEVELS)
 	_write_hud(data, int(_layout["enemy_hud"]), RomLayout.ENEMY_HUD_TILES)
 	_write_hud(data, int(_layout["player_hud"]), RomLayout.PLAYER_HUD_TILES)
+	_write_bar_palettes(data)
 	return data
+
+
+## The four bar palettes, whose values are the check on where they are.
+func _write_bar_palettes(data: PackedByteArray) -> void:
+	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
+		var at: int = RomLayout.bar_palette_offset(_layout, index)
+		var wanted: Array = RomLayout.BAR_PALETTES[index]
+		for colour: int in wanted.size():
+			var packed: int = int(wanted[colour])
+			_write(
+				data, at + colour * Gen2Palette.COLOR_BYTES,
+				PackedByteArray([packed & 0xFF, packed >> 8])
+			)
 
 
 ## Fill levels as 2bpp tiles, each one two pixels fuller than the last.
@@ -340,6 +354,16 @@ func test_an_exp_bar_that_is_not_there_fails() -> void:
 	for i: int in RomLayout.EXP_BAR_TILES * Gen2Tiles.TILE_BYTES:
 		data[int(_layout["exp_bar"]) + i] = 0
 	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_a_bar_palette_that_is_not_the_colour_it_should_be_fails() -> void:
+	# These are known values rather than a shape, so a wrong offset is caught by
+	# the colours themselves.
+	var data: PackedByteArray = _battle_dump()
+	_write(data, RomLayout.bar_palette_offset(_layout, 2), PackedByteArray([0x00, 0x00]))
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "hp_red")
 
 
 func test_a_blank_hud_tile_fails() -> void:

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -274,3 +274,85 @@ func test_a_dump_with_no_trainers_in_it_fails() -> void:
 	var data: PackedByteArray = PackedByteArray()
 	data.resize(RomRegistry.EXPECTED_SIZE)
 	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
+
+
+## A battle sheet at every offset the layout claims: two bars that count up, and
+## two HUD borders whose tiles all differ.
+func _battle_dump() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_bar(data, int(_layout["battle_font"]), RomLayout.HP_BAR_FIRST_TILE, RomLayout.HP_BAR_LEVELS)
+	_write_bar(data, int(_layout["exp_bar"]), 0, RomLayout.EXP_BAR_LEVELS)
+	_write_hud(data, int(_layout["enemy_hud"]), RomLayout.ENEMY_HUD_TILES)
+	_write_hud(data, int(_layout["player_hud"]), RomLayout.PLAYER_HUD_TILES)
+	return data
+
+
+## Fill levels as 2bpp tiles, each one two pixels fuller than the last.
+func _write_bar(data: PackedByteArray, at: int, first: int, levels: int) -> void:
+	for level: int in levels:
+		_write(
+			data, at + (first + level) * Gen2Tiles.TILE_BYTES,
+			_lit_tile(Gen2Tiles.TILE_WIDTH + level * RomLayout.BAR_STEP_PIXELS)
+		)
+
+
+## A 2bpp tile with [param pixels] lit, filled row by row.
+func _lit_tile(pixels: int) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Tiles.TILE_BYTES)
+	for pixel: int in pixels:
+		@warning_ignore("integer_division")
+		var row: int = pixel / Gen2Tiles.TILE_WIDTH
+		out[row * 2] |= 1 << (7 - pixel % Gen2Tiles.TILE_WIDTH)
+	return out
+
+
+## 1bpp tiles that all have ink and none of which repeats another.
+func _write_hud(data: PackedByteArray, at: int, tiles: int) -> void:
+	for tile: int in tiles:
+		var bytes: PackedByteArray = PackedByteArray()
+		bytes.resize(Gen2Tiles.TILE_1BPP_BYTES)
+		bytes[0] = 0xFF << (7 - tile) & 0xFF
+		bytes[1] = 0x18
+		_write(data, at + tile * Gen2Tiles.TILE_1BPP_BYTES, bytes)
+
+
+func test_battle_graphics_that_count_up_verify() -> void:
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(_battle_dump()), _layout)
+	assert_true(result["ok"], result["message"])
+
+
+func test_a_bar_whose_levels_do_not_climb_fails() -> void:
+	# The check the bars exist for: neither has a name or a number in the
+	# cartridge, and a run of tiles that counts up is what says it is a bar.
+	var data: PackedByteArray = _battle_dump()
+	_write(
+		data,
+		int(_layout["battle_font"]) + (RomLayout.HP_BAR_FIRST_TILE + 4) * Gen2Tiles.TILE_BYTES,
+		_lit_tile(Gen2Tiles.TILE_WIDTH)
+	)
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_an_exp_bar_that_is_not_there_fails() -> void:
+	var data: PackedByteArray = _battle_dump()
+	for i: int in RomLayout.EXP_BAR_TILES * Gen2Tiles.TILE_BYTES:
+		data[int(_layout["exp_bar"]) + i] = 0
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_a_blank_hud_tile_fails() -> void:
+	var data: PackedByteArray = _battle_dump()
+	for row: int in Gen2Tiles.TILE_1BPP_BYTES:
+		data[int(_layout["player_hud"]) + 2 * Gen2Tiles.TILE_1BPP_BYTES + row] = 0
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_hud_tiles_that_repeat_mean_it_is_not_the_border() -> void:
+	var data: PackedByteArray = _battle_dump()
+	_write(
+		data, int(_layout["enemy_hud"]) + Gen2Tiles.TILE_1BPP_BYTES,
+		data.slice(int(_layout["enemy_hud"]), int(_layout["enemy_hud"]) + Gen2Tiles.TILE_1BPP_BYTES)
+	)
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -107,6 +107,49 @@ func test_pic_pointers_come_in_front_back_pairs() -> void:
 	assert_eq(front - RomLayout.pic_pointer_offset(layout, 1, false), RomLayout.PIC_POINTER_SIZE * 2)
 
 
+func test_the_trainer_tables_are_one_entry_out_of_step() -> void:
+	# The palette table opens with the player, who has no pic, so a class reaches
+	# its palette by its own number and its pic by one less.
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		assert_eq(
+			RomLayout.trainer_pic_pointer_offset(layout, 1),
+			int(layout["trainer_pic_pointers"]), "%s pics start at the first class" % id
+		)
+		assert_eq(
+			RomLayout.trainer_palette_offset(layout, 1),
+			int(layout["trainer_palettes"]) + Gen2Palette.PAIR_BYTES,
+			"%s palettes start at the player" % id
+		)
+
+
+func test_a_trainer_palette_is_one_pair_and_a_species_is_two() -> void:
+	# Only a Pokémon can be shiny, so a class stores half of what a species does.
+	assert_eq(Gen2Palette.ENTRY_BYTES, Gen2Palette.PAIR_BYTES * 2)
+
+
+func test_crystal_has_one_trainer_class_more_than_gold() -> void:
+	assert_eq(
+		RomLayout.trainer_class_count(RomLayout.for_id(RomRegistry.CRYSTAL)),
+		RomLayout.trainer_class_count(RomLayout.for_id(RomRegistry.GOLD)) + 1
+	)
+
+
+func test_the_trainer_tables_do_not_run_off_the_end() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		var count: int = RomLayout.trainer_class_count(layout)
+		assert_gt(count, 0, "%s has no trainer classes" % id)
+		assert_lt(
+			RomLayout.trainer_pic_pointer_offset(layout, count) + RomLayout.PIC_POINTER_SIZE,
+			RomRegistry.EXPECTED_SIZE
+		)
+		assert_lt(
+			RomLayout.trainer_palette_offset(layout, count) + Gen2Palette.PAIR_BYTES,
+			RomRegistry.EXPECTED_SIZE
+		)
+
+
 func test_unown_forms_are_zero_based() -> void:
 	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
 	assert_eq(

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -218,6 +218,39 @@ func test_the_font_and_the_frames_do_not_overlap_or_run_off_the_end() -> void:
 		assert_lt(last, RomRegistry.EXPECTED_SIZE)
 
 
+func test_the_battle_graphics_sit_back_to_back_in_the_order_they_are_stored() -> void:
+	# They are one run in the cartridge: the enemy's HUD border, the player's,
+	# then the exp bar. Each offset is a claim about where the one before it ends.
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		assert_eq(
+			int(layout["enemy_hud"]) + RomLayout.ENEMY_HUD_TILES * Gen2Tiles.TILE_1BPP_BYTES,
+			int(layout["player_hud"]), "%s: the player's HUD does not follow the enemy's" % id
+		)
+		assert_eq(
+			int(layout["player_hud"]) + RomLayout.PLAYER_HUD_TILES * Gen2Tiles.TILE_1BPP_BYTES,
+			int(layout["exp_bar"]), "%s: the exp bar does not follow the HUD borders" % id
+		)
+
+
+func test_the_battle_font_follows_the_font_itself() -> void:
+	# Both are in the section the font opens, and the battle sheet is the next
+	# thing in it after the 128 glyphs.
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		assert_eq(
+			RomLayout.font_offset(layout) + RomLayout.FONT_TILES * Gen2Tiles.TILE_1BPP_BYTES,
+			int(layout["battle_font"]), "%s battle font" % id
+		)
+
+
+func test_the_bars_have_a_level_for_every_step_of_their_tiles() -> void:
+	assert_lt(
+		RomLayout.HP_BAR_FIRST_TILE + RomLayout.HP_BAR_LEVELS, RomLayout.BATTLE_FONT_TILES
+	)
+	assert_lt(RomLayout.EXP_BAR_LEVELS, RomLayout.EXP_BAR_TILES)
+
+
 func test_a_fixed_bank_still_addresses_inside_the_cartridge() -> void:
 	for id: StringName in RomRegistry.ORDER:
 		var layout: Dictionary = RomLayout.for_id(id)

--- a/tests/unit/test_tile_codec.gd
+++ b/tests/unit/test_tile_codec.gd
@@ -115,6 +115,26 @@ func test_a_1bpp_strip_that_runs_out_of_data_keeps_its_size() -> void:
 	assert_eq(strip.count(0), strip.size())
 
 
+func test_a_2bpp_strip_keeps_all_four_colours_where_a_1bpp_one_has_two() -> void:
+	# The battle HUD is 2bpp, so its strips carry the middle indices the font
+	# never produces.
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(Gen2Tiles.TILE_BYTES)
+	data[0] = 0xF0
+	data[1] = 0xCC
+	var strip: PackedByteArray = Gen2Tiles.decode_2bpp_strip(data, 0, 1)
+	assert_eq(strip.size(), Gen2Tiles.TILE_PIXELS)
+	assert_eq(strip[0], 3, "both planes set")
+	assert_eq(strip[2], 1, "low plane only")
+	assert_eq(strip[4], 2, "high plane only")
+	assert_eq(strip[6], 0)
+
+
+func test_a_2bpp_strip_that_runs_out_of_data_keeps_its_size() -> void:
+	var strip: PackedByteArray = Gen2Tiles.decode_2bpp_strip(PackedByteArray(), 0, 4)
+	assert_eq(strip.size(), 4 * Gen2Tiles.TILE_PIXELS)
+
+
 func test_blit_places_a_small_pic_inside_a_cell() -> void:
 	var source: PackedByteArray = PackedByteArray([1, 2, 3, 4])
 	var destination: PackedByteArray = PackedByteArray()

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -7,9 +7,9 @@ extends SceneTree
 ## The written-down counterpart of the contact sheet: a bad offset in a name
 ## table produces plausible words rather than an error, so the check is to read
 ## the output. <game> is a registry id (gold, silver, crystal); [table] is one of
-## species, moves, items, types, or all.
+## species, moves, items, types, trainers, or all.
 
-const TABLES: PackedStringArray = ["species", "moves", "items", "types"]
+const TABLES: PackedStringArray = ["species", "moves", "items", "types", "trainers"]
 
 
 func _initialize() -> void:
@@ -69,6 +69,11 @@ func _describe(table: String, row: Dictionary) -> String:
 			return "%3d  %-13s pow %3d  type %2d  acc %3d  pp %2d  effect %3d/%3d" % [
 				number, name, int(row["power"]), int(row["type"]), int(row["accuracy"]),
 				int(row["pp"]), int(row["effect"]), int(row["effect_chance"]),
+			]
+		"trainers":
+			var palette: Array = row["palette"]
+			return "%3d  %-13s $%04X $%04X" % [
+				number, name, int(palette[0]), int(palette[1]),
 			]
 		"species":
 			var stats: Dictionary = row["stats"]

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -17,7 +17,9 @@ extends SceneTree
 ## them and the digits where they can be read at a glance.
 
 const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back", "trainers"]
-const SHEETS: PackedStringArray = ["font", "frames"]
+const SHEETS: PackedStringArray = [
+	"font", "frames", "battle_font", "enemy_hud", "player_hud", "exp_bar",
+]
 
 ## Tiles per row when a strip is folded for viewing.
 const SHEET_COLUMNS: int = 16
@@ -87,8 +89,9 @@ func _find_cache(game: StringName) -> String:
 	return directory if RomCache.is_usable(directory) else ""
 
 
-## A 1bpp strip, folded into rows of [constant SHEET_COLUMNS] tiles. There is no
-## palette to choose: 1bpp graphics are black on white and nothing else.
+## A tile strip, folded into rows of [constant SHEET_COLUMNS] tiles. There is no
+## palette to choose: a sheet has none of its own, so it is drawn in the greys a
+## Game Boy would have shown before a palette was applied.
 func _render_sheet(directory: String, sheet: Dictionary, name: String) -> Image:
 	var indices: PackedByteArray = RomCache.read_indices(RomCache.tile_path(directory, name))
 	var strip_width: int = int(sheet["width"])
@@ -117,7 +120,9 @@ func _render_sheet(directory: String, sheet: Dictionary, name: String) -> Image:
 
 	return Gen2PicImage.from_indices(
 		folded, width, rows * Gen2Tiles.TILE_HEIGHT,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		Gen2Palette.pic_palette(PackedColorArray([
+			Color(0.66, 0.66, 0.66), Color(0.33, 0.33, 0.33),
+		]))
 	)
 
 

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -16,7 +16,7 @@ extends SceneTree
 ## the shape the charmap describes, and it puts the alphabets, the gaps between
 ## them and the digits where they can be read at a glance.
 
-const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back"]
+const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back", "trainers"]
 const SHEETS: PackedStringArray = ["font", "frames"]
 
 ## Tiles per row when a strip is folded for viewing.
@@ -131,24 +131,51 @@ func _render(
 		push_error("%s holds %d bytes, expected %d." % [name, indices.size(), width * height])
 		return null
 
-	var species: Array = RomCache.read_json(RomCache.species_path(directory))
 	var cell: int = int(atlas["cell"])
 	var columns: int = int(atlas["columns"])
-	var key: String = "shiny" if shiny else "normal"
+	var palettes: Array = _palettes(directory, name, shiny)
+	if palettes.is_empty():
+		push_error("No palettes for %s." % name)
+		return null
 
 	var image: Image = Image.create_empty(width, height, false, Image.FORMAT_RGBA8)
 	for y: int in height:
 		for x: int in width:
 			var slot: int = (y / cell) * columns + (x / cell)
-			# Unown's atlas is one cell per letter, all of them the same species.
-			var entry: Dictionary = species[
-				RomLayout.UNOWN_SPECIES - 1 if name.begins_with("unown") else mini(slot, species.size() - 1)
-			]
-			var packed: Array = entry["palette"][key]
-			var palette: PackedColorArray = Gen2Palette.pic_palette(PackedColorArray([
-				Gen2Palette.from_packed(int(packed[0])),
-				Gen2Palette.from_packed(int(packed[1])),
-			]))
+			var palette: PackedColorArray = palettes[mini(slot, palettes.size() - 1)]
 			image.set_pixel(x, y, palette[indices[y * width + x]])
 
 	return image
+
+
+## One palette per cell of an atlas, in slot order.
+##
+## The three kinds of atlas are indexed differently: a species atlas by species,
+## the trainer atlas by class, and Unown's by letter form, all twenty-six of
+## which are the one species and so share its colours.
+func _palettes(directory: String, name: String, shiny: bool) -> Array:
+	var out: Array = []
+
+	if name == "trainers":
+		for entry: Dictionary in RomCache.read_json(RomCache.trainers_path(directory)):
+			out.append(_palette_of(entry["palette"]))
+		return out
+
+	var species: Array = RomCache.read_json(RomCache.species_path(directory))
+	var key: String = "shiny" if shiny else "normal"
+	if name.begins_with("unown"):
+		var unown: Dictionary = species[RomLayout.UNOWN_SPECIES - 1]
+		for form: int in RomLayout.UNOWN_FORMS:
+			out.append(_palette_of(unown["palette"][key]))
+		return out
+
+	for entry: Dictionary in species:
+		out.append(_palette_of(entry["palette"][key]))
+	return out
+
+
+func _palette_of(packed: Array) -> PackedColorArray:
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int(packed[0])),
+		Gen2Palette.from_packed(int(packed[1])),
+	]))


### PR DESCRIPTION
A verified cartridge now decodes every trainer class as well as every species: the pic, the class name and the class palette.

Trainer pics reuse the pointer form and the bank repair the Pokémon pics already need, so they come out of the same decoder into an atlas of their own: one 7x7 cell per class, no back half and no stored size.

The three tables that describe a class are not indexed alike. The palette table opens with the player, who is a trainer class with no pic, so a class reaches its palette by its own number and its pic and name by one less. Crystal has sixty-seven classes to Gold and Silver's sixty-six, so the count lives in the layout beside the offsets rather than in a constant.

Every new offset ships with the check that would fail if it were wrong, and the three tables are checked against each other, since a mistake in any of them shows up as the three disagreeing:

- the class names are pinned at both ends and in the middle, because the entries are terminated rather than padded and a start that is one byte out still reads as words;
- the palettes are checked structurally and one entry past where the table has to stop, so an offset that slid by a whole entry cannot pass;
- every pic pointer has to address the banked window, and the two ends have to decompress into a full 7x7 pic, which is what proves the bank repair is the one the Pokémon pics need.

Also here: `tools/preview_pics.gd` and `tools/dump_tables.gd` take `trainers`, and `T` in the pic viewer switches to the classes (with `show_trainer` as a plain method, so it can be photographed).

The cache format version is bumped, so an existing cache is discarded and re-imported rather than read as if it had trainers in it.

Verified on all three cartridges: 3/3 import, contact sheets for Gold and Crystal eyeballed class by class, class names read back against the pics, and the viewer photographed in trainer mode. GUT: 197/197.