### PR TITLE
Draw the battle screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ the same thing for Generation 1.
 >
 > The import gate and the first half of the importer exist and are tested: a
 > verified cartridge decodes into species data, moves, items, types, palettes,
-> every Pokémon sprite, every trainer pic, the font and the text box borders.
-> Sprites and text draw on a real 160x144 screen. The overworld, battle system, audio and mod loader
-> do not exist yet. There is nothing playable here today.
+> every Pokémon sprite, every trainer pic, the font, the text box borders and
+> the battle HUD. The battle screen draws: two Pokémon, two status panels and a
+> text box on a real 160x144 screen. Nothing happens on it yet, and the
+> overworld, the battle system, audio and the mod loader do not exist. There is
+> nothing playable here today.
 
 ## Getting started
 
@@ -92,6 +94,7 @@ What comes out today:
 | Sprites | Front and back for all 251 species, plus all 26 Unown forms |
 | Font | All 128 glyphs, indexed by character code |
 | Borders | All eight text box frames, six tiles each |
+| Battle HUD | The HP bar, the exp bar, both panel borders and the colours they are drawn in |
 
 Sprites are stored as colour indices rather than as images, and a palette is
 applied when they are drawn, which is the whole of what being shiny costs.
@@ -132,6 +135,12 @@ resolution.
 `game/render/text_viewer.tscn` does the same for text: space advances the box,
 `F` cycles through the eight borders, and `C` shows every glyph in the font at
 once.
+
+`game/battle/battle_screen.tscn` is the battle screen itself: two Pokémon, a
+status panel each and a text box, where the hardware puts them. Left and right
+change which Pokémon are on it, `S` and `D` take health off the player's and the
+enemy's, and the bars change colour as they empty. Nothing else happens: there
+is no battle behind it yet.
 
 ## Tests
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -71,6 +71,13 @@ The drawing layer is deliberately thin:
 | `render/font.gd` | Character codes to glyph tiles, blitted into a buffer |
 | `render/text_layout.gd` | A string to the lines and pages a box can show |
 | `render/text_box.gd` | The two of them, as a bordered window on the grid |
+| `render/battle_tiles.gd` | The battle's tile page, assembled as the hardware does |
+| `render/battle_hud.gd` | The two status panels, on the tile grid |
+
+`game/battle/battle_screen.gd` is the first screen that is not a development
+view. It draws what it is given and decides nothing: no turn order, no damage,
+no faint. When there is an engine it will hand the screen the same numbers a
+caller hands it today, which is why its setters take plain values.
 
 `Gen2Screen` renders the game into a `SubViewport` the size of the real
 hardware and blows it up by an integer factor, while the interface around it
@@ -126,6 +133,13 @@ So every offset ships with a check that would fail if it were wrong, and
   `Gen2Text` says are there must have ink, and the runs it has no character for
   must be blank. Those runs sit between the alphabets, so an offset out by a
   single tile drags a blank onto "z" and a glyph onto a code that has none.
+- The battle HUD's graphics are checked by the one thing they do that nothing
+  around them does: they count. A bar's fill levels are consecutive tiles, each
+  lighting one more column than the last, so the ink climbs by exactly two
+  pixels a step, and no wrong offset lands on a run like that. The two HUD
+  borders have no progression, so they are checked the way the text box frames
+  are. The four palettes the bars are drawn in are known values, so they are
+  checked against those values.
 - The three trainer tables are checked against each other, because they are
   three views of one numbering and a mistake shows up as them disagreeing. The
   class names pin the ends and the middle of a terminated table the way the move
@@ -223,6 +237,14 @@ box does not depend on how long the capture took to arrive.
 
 ```bash
 godot --path . -s res://tools/screenshot.gd -- res://game/render/text_viewer.tscn /tmp/shot.png 24 finish 1
+```
+
+The battle screen is built the same way, and it is worth photographing in more
+than one state: an HP bar changes colour as it empties, and the rule is about
+how many pixels are lit rather than how many hit points are left.
+
+```bash
+godot --path . -s res://tools/screenshot.gd -- res://game/battle/battle_screen.tscn /tmp/shot.png 24 hurt_player 3
 ```
 
 Keep that property when you add a screen. A handler that only exists inside an

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1,0 +1,295 @@
+class_name Gen2BattleScreen
+extends Control
+
+## The battle screen: two Pokémon, two status panels and a text box, at the
+## positions the hardware puts them.
+##
+## This is the first screen that is not a development view. Everything on it
+## already existed a layer down (a pic from an atlas, a panel from the HUD
+## sheets, a box from the font and a border), and what this adds is where each
+## of them goes: the enemy's pic in the top right, the player's back pic below
+## and to the left of it, a panel each, and the standard box along the bottom.
+##
+## It draws what it is given and decides nothing. There is no battle here: no
+## turn order, no damage, no faint. When there is an engine, it will hand this
+## the same numbers a caller hands it now, which is why the setters take plain
+## values rather than a battle state object.
+##
+## The panels are composed into one screen-sized index buffer and drawn over the
+## pics with index 0 transparent, because a panel is a shape on a white field
+## rather than a rectangle: the games draw them into the background layer, where
+## nothing overlaps, and the pics have to show through everything that is not ink.
+
+## Where the two pics sit, in tiles.
+const ENEMY_PIC: Vector2i = Vector2i(12, 0)
+const PLAYER_PIC: Vector2i = Vector2i(2, 6)
+
+## What is on screen before a caller says otherwise: the first battle a player
+## of Gold or Silver is likely to have.
+const DEFAULT_ENEMY: int = 16
+const DEFAULT_PLAYER: int = 155
+const DEFAULT_LEVEL: int = 5
+
+const TILE: int = Gen2Font.TILE
+
+## The white the hardware fills the battle background with.
+const BACKGROUND: Color = Color.WHITE
+
+var _data: GameData = null
+var _hud: Gen2BattleHud = null
+
+var _enemy: int = 1
+var _player: int = 1
+var _enemy_level: int = 5
+var _player_level: int = 5
+var _enemy_hp: int = 0
+var _enemy_max_hp: int = 0
+var _player_hp: int = 0
+var _player_max_hp: int = 0
+var _exp: float = 0.0
+
+var _enemy_pic: TextureRect = null
+var _player_pic: TextureRect = null
+var _panels: TextureRect = null
+var _enemy_bar: TextureRect = null
+var _player_bar: TextureRect = null
+var _exp_bar: TextureRect = null
+var _box: Gen2TextBox = null
+
+@onready var _screen: Gen2Screen = %Screen
+
+
+func _ready() -> void:
+	_data = GameData.open_any()
+	_hud = Gen2BattleHud.from_data(_data)
+	if _hud == null:
+		return
+
+	var field := ColorRect.new()
+	field.color = BACKGROUND
+	field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_screen.display(field)
+
+	_enemy_pic = _new_layer()
+	_player_pic = _new_layer()
+	_panels = _new_layer()
+	_enemy_bar = _new_layer()
+	_player_bar = _new_layer()
+	_exp_bar = _new_layer()
+
+	_box = Gen2TextBox.new()
+	_box.font = _hud.font
+	_screen.display(_box)
+	_box.place_at_bottom()
+
+	show_matchup(DEFAULT_ENEMY, DEFAULT_PLAYER, DEFAULT_LEVEL, DEFAULT_LEVEL)
+	set_exp(0.5)
+	_announce()
+
+
+## True once the cache had everything the screen draws with.
+func is_ready() -> bool:
+	return _hud != null
+
+
+## Puts two Pokémon on the screen at a level each, both at full health.
+func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: int = 5) -> void:
+	_enemy = _wrap_species(enemy)
+	_player = _wrap_species(player)
+	_enemy_level = enemy_level
+	_player_level = player_level
+	_enemy_max_hp = _hp_at_level(_enemy, _enemy_level)
+	_player_max_hp = _hp_at_level(_player, _player_level)
+	_enemy_hp = _enemy_max_hp
+	_player_hp = _player_max_hp
+	_refresh()
+
+
+## Both HP totals, for a caller that has its own numbers.
+func set_hp(enemy: int, enemy_max: int, player: int, player_max: int) -> void:
+	_enemy_hp = enemy
+	_enemy_max_hp = enemy_max
+	_player_hp = player
+	_player_max_hp = player_max
+	_refresh()
+
+
+## How full the exp bar is, from nothing to a level's worth.
+func set_exp(fraction: float) -> void:
+	_exp = clampf(fraction, 0.0, 1.0)
+	_refresh()
+
+
+func show_message(text: String) -> void:
+	if _box != null:
+		_box.show_text(text)
+
+
+## Reveals the rest of the message at once, so a photograph of the screen does
+## not depend on how long the capture took to arrive.
+func finish() -> void:
+	if _box != null:
+		_box.finish()
+
+
+func next_enemy() -> void:
+	show_matchup(_enemy + 1, _player, _enemy_level, _player_level)
+	_announce()
+
+
+func next_player() -> void:
+	show_matchup(_enemy, _player + 1, _enemy_level, _player_level)
+	_announce()
+
+
+## Takes a quarter of the enemy's health off, which is the fastest way to see
+## that a bar and its numbers agree.
+func hurt_enemy() -> void:
+	_enemy_hp = maxi(_enemy_hp - maxi(_enemy_max_hp / 4, 1), 0)
+	_refresh()
+
+
+func hurt_player() -> void:
+	_player_hp = maxi(_player_hp - maxi(_player_max_hp / 4, 1), 0)
+	_refresh()
+
+
+func _unhandled_key_input(event: InputEvent) -> void:
+	if _hud == null or not event.is_pressed():
+		return
+
+	var key: InputEventKey = event as InputEventKey
+	if key == null:
+		return
+
+	match key.keycode:
+		KEY_RIGHT:
+			next_enemy()
+		KEY_LEFT:
+			next_player()
+		KEY_D:
+			hurt_enemy()
+		KEY_S:
+			hurt_player()
+		KEY_SPACE, KEY_ENTER:
+			_box.advance()
+		_:
+			return
+	accept_event()
+
+
+func _new_layer() -> TextureRect:
+	var out := TextureRect.new()
+	# Nearest, or the integer-scaled viewport is undone on the last hop.
+	out.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_screen.display(out)
+	return out
+
+
+func _wrap_species(number: int) -> int:
+	var count: int = _data.species_count() if _data != null else 0
+	return wrapi(number, 1, maxi(count, 1) + 1) if count > 0 else 1
+
+
+## A rough HP total, so the bar and the numbers have something to show. The real
+## formula belongs to the engine that does not exist yet, along with the IVs and
+## the effort values it also reads.
+func _hp_at_level(species: int, level: int) -> int:
+	var entry: Dictionary = _data.species(species)
+	if entry.is_empty():
+		return 1
+	var base: int = int(entry["stats"]["hp"])
+	@warning_ignore("integer_division")
+	return (base * 2 * level) / 100 + level + 10
+
+
+func _refresh() -> void:
+	if _hud == null:
+		return
+
+	_draw_pic(_enemy_pic, _data.species_pic(_enemy), _data.palette(_enemy), ENEMY_PIC)
+	_draw_pic(_player_pic, _data.species_pic(_player, true), _data.palette(_player), PLAYER_PIC)
+	_draw_panels()
+
+
+func _draw_pic(
+	into: TextureRect, pic: Dictionary, palette: PackedColorArray, at: Vector2i
+) -> void:
+	if into == null or pic.is_empty():
+		return
+
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
+	)
+	into.texture = ImageTexture.create_from_image(image)
+	into.size = image.get_size()
+	into.position = Vector2(at.x * TILE, at.y * TILE)
+
+
+## The panels, and then each bar over them in its own colour.
+##
+## The hardware gives every tile of the background its own palette, so a green
+## HP bar sits in a panel of black text without either being a separate thing.
+## Layering is how that is done here, one buffer per palette, which is why the
+## bars are drawn apart from the panels that hold them.
+func _draw_panels() -> void:
+	var panels: PackedByteArray = _new_buffer()
+	_hud.draw_enemy(panels, Gen2Screen.WIDTH, _name_of(_enemy), _enemy_level)
+	_hud.draw_player(
+		panels, Gen2Screen.WIDTH, _name_of(_player), _player_level, _player_hp, _player_max_hp
+	)
+	_show_layer(
+		_panels, panels,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+
+	var enemy: PackedByteArray = _new_buffer()
+	_hud.draw_hp_bar(
+		enemy, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, _enemy_hp, _enemy_max_hp
+	)
+	_show_layer(_enemy_bar, enemy, _hp_palette(_enemy_hp, _enemy_max_hp))
+
+	var player: PackedByteArray = _new_buffer()
+	_hud.draw_hp_bar(
+		player, Gen2Screen.WIDTH, Gen2BattleHud.PLAYER_BAR, _player_hp, _player_max_hp
+	)
+	_show_layer(_player_bar, player, _hp_palette(_player_hp, _player_max_hp))
+
+	var gained: PackedByteArray = _new_buffer()
+	_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, _exp)
+	_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
+
+
+func _new_buffer() -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	return out
+
+
+## Every layer above the pics is drawn with index 0 transparent: a panel is a
+## shape on the background, not a rectangle over it.
+func _show_layer(
+	into: TextureRect, indices: PackedByteArray, palette: PackedColorArray
+) -> void:
+	var image: Image = Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
+	)
+	into.texture = ImageTexture.create_from_image(image)
+	into.size = image.get_size()
+
+
+## An HP bar is green, yellow or red by how much of it is lit rather than by the
+## hit points behind it, which is the rule the games use.
+func _hp_palette(hp: int, max_hp: int) -> PackedColorArray:
+	var lit: int = Gen2BattleHud.bar_pixels(
+		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
+	)
+	return _data.bar_palette(GameData.hp_bar_palette_name(lit))
+
+
+func _name_of(species: int) -> String:
+	return String(_data.species(species).get("name", ""))
+
+
+func _announce() -> void:
+	show_message("Wild %s appeared!" % _name_of(_enemy))

--- a/game/battle/battle_screen.gd.uid
+++ b/game/battle/battle_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://b2wo3hbvnr6vv

--- a/game/battle/battle_screen.tscn
+++ b/game/battle/battle_screen.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://game/battle/battle_screen.gd" id="1"]
+[ext_resource type="PackedScene" path="res://game/render/gen2_screen.tscn" id="2"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bg"]
+bg_color = Color(0.0509804, 0.0745098, 0.164706, 1)
+
+[node name="BattleScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+
+[node name="Background" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_bg")
+
+[node name="Screen" parent="." instance=ExtResource("2")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -27,6 +27,7 @@ var _types: Array = []
 var _trainers: Array = []
 var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
+var _bar_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 
 
@@ -51,6 +52,7 @@ static func open_directory(path: String) -> GameData:
 	data.sha1 = String(manifest.get("sha1", ""))
 	data._atlases = manifest.get("atlases", {})
 	data._tiles = manifest.get("tiles", {})
+	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._items = data._read_array(RomCache.items_path(path))
@@ -112,6 +114,31 @@ func palette(number: int, shiny: bool = false) -> PackedColorArray:
 		Gen2Palette.from_packed(int(stored[0])),
 		Gen2Palette.from_packed(int(stored[1])),
 	]))
+
+
+## One of the battle bars' palettes, by the names in
+## [constant RomLayout.BAR_PALETTE_NAMES]. An unknown name answers with white and
+## black, which draws a bar that is legible and obviously not coloured.
+func bar_palette(name: String) -> PackedColorArray:
+	var stored: Variant = _bar_palettes.get(name, null)
+	if not stored is Array or (stored as Array).size() < 2:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int(stored[0])),
+		Gen2Palette.from_packed(int(stored[1])),
+	]))
+
+
+## Which HP bar palette a bar of [param lit] pixels is drawn in. The colour
+## follows what is drawn rather than the numbers behind it, which is why a bar
+## can turn red on a Pokémon that still has a good few hit points.
+static func hp_bar_palette_name(lit: int) -> String:
+	if lit >= RomLayout.HP_GREEN_PIXELS:
+		return "hp_green"
+	if lit >= RomLayout.HP_YELLOW_PIXELS:
+		return "hp_yellow"
+	return "hp_red"
 
 
 func trainer_count() -> int:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -28,7 +28,7 @@ const TILES_DIR: String = "tiles"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 4
+const FORMAT_VERSION: int = 5
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -63,9 +63,10 @@ static func pic_path(directory: String, name: String) -> String:
 	return "%s/%s/%s.idx" % [directory, PICS_DIR, name]
 
 
-## Fixed tile sheets: the font and the text box borders. Kept apart from the
-## pics because they are addressed by character code rather than by species, and
-## because they are 1bpp, so the two never want the same accessor.
+## Fixed tile sheets: the font, the text box borders and the battle HUD's
+## graphics. Kept apart from the pics because they are addressed by a tile number
+## rather than by species, and because a sheet has no palette of its own, so the
+## two never want the same accessor.
 static func tile_path(directory: String, name: String) -> String:
 	return "%s/%s/%s.idx" % [directory, TILES_DIR, name]
 

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -281,6 +281,21 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 
+	# The bar palettes are known values rather than a shape, so they are checked
+	# as the species names are: against what they have to say.
+	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
+		var entry: int = RomLayout.bar_palette_offset(layout, index)
+		var wanted: Array = RomLayout.BAR_PALETTES[index]
+		for colour: int in wanted.size():
+			var read: int = rom.u16le(entry + colour * Gen2Palette.COLOR_BYTES)
+			if read != int(wanted[colour]):
+				return {
+					"ok": false,
+					"message": "Bar palette %s colour %d: expected $%04X, read $%04X." % [
+						RomLayout.BAR_PALETTE_NAMES[index], colour, wanted[colour], read,
+					],
+				}
+
 	var battle_font: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
 		data, int(layout["battle_font"]), RomLayout.BATTLE_FONT_TILES
 	)
@@ -564,6 +579,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"item_count": items.size(),
 		"type_count": types.size(),
 		"trainer_count": trainers.size(),
+		"bar_palettes": _import_bar_palettes(rom, layout),
 		"atlases": pics,
 		"tiles": tiles,
 		"complete": true,
@@ -711,6 +727,18 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 		if on_progress.is_valid():
 			on_progress.call("trainers", trainer_class, count)
 
+	return out
+
+
+## The four colours a battle draws its bars in. Small enough to live in the
+## manifest beside the atlas metadata rather than in a file of its own.
+func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
+		var entry: int = RomLayout.bar_palette_offset(layout, index)
+		out[RomLayout.BAR_PALETTE_NAMES[index]] = [
+			rom.u16le(entry), rom.u16le(entry + Gen2Palette.COLOR_BYTES),
+		]
 	return out
 
 

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -149,6 +149,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not frames["ok"]:
 		return frames
 
+	var battle: Dictionary = verify_battle_graphics(rom, layout)
+	if not battle["ok"]:
+		return battle
+
 	var trainers: Dictionary = verify_trainers(rom, layout)
 	if not trainers["ok"]:
 		return trainers
@@ -263,6 +267,102 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 		seen.append(tiles)
 
 	return {"ok": true, "message": ""}
+
+
+## The battle HUD's graphics, checked by the one thing they do that nothing else
+## in the section does: they count.
+##
+## A bar's fill levels are consecutive tiles, each lighting one more column than
+## the last, so the ink in that run climbs by exactly two pixels a step. Neither
+## bar has a name or a number in the cartridge, but a run that counts up like
+## that is not something a wrong offset lands on. The two HUD borders have
+## neither content nor a progression, so they are checked the way the text box
+## frames are: every tile has ink, and no two tiles are the same.
+static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var data: PackedByteArray = rom.bytes()
+
+	var battle_font: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		data, int(layout["battle_font"]), RomLayout.BATTLE_FONT_TILES
+	)
+	var hp_bar: Dictionary = _verify_bar(
+		battle_font, RomLayout.BATTLE_FONT_TILES, RomLayout.HP_BAR_FIRST_TILE,
+		RomLayout.HP_BAR_LEVELS, "HP bar"
+	)
+	if not hp_bar["ok"]:
+		return hp_bar
+
+	var exp_bar: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		data, int(layout["exp_bar"]), RomLayout.EXP_BAR_TILES
+	)
+	var levels: Dictionary = _verify_bar(
+		exp_bar, RomLayout.EXP_BAR_TILES, 0, RomLayout.EXP_BAR_LEVELS, "exp bar"
+	)
+	if not levels["ok"]:
+		return levels
+
+	for name: String in ["enemy_hud", "player_hud"]:
+		var tiles: int = RomLayout.ENEMY_HUD_TILES if name == "enemy_hud" \
+			else RomLayout.PLAYER_HUD_TILES
+		var strip: PackedByteArray = Gen2Tiles.decode_1bpp_strip(
+			data, int(layout[name]), tiles
+		)
+		var seen: Array = []
+		for tile: int in tiles:
+			var pixels: PackedByteArray = _strip_tile(strip, tiles, tile)
+			if _ink(pixels) == 0:
+				return {"ok": false, "message": "%s tile %d is blank." % [name, tile]}
+			if seen.has(pixels):
+				return {"ok": false, "message": "%s tile %d repeats an earlier one." % [name, tile]}
+			seen.append(pixels)
+
+	return {"ok": true, "message": ""}
+
+
+## One bar's fill levels: consecutive tiles whose ink climbs by a fixed step.
+static func _verify_bar(
+	strip: PackedByteArray, tiles: int, first: int, levels: int, what: String
+) -> Dictionary:
+	if strip.size() != tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT:
+		return {"ok": false, "message": "%s: strip decoded short." % what}
+
+	var previous: int = _ink(_strip_tile(strip, tiles, first))
+	if previous == 0:
+		return {"ok": false, "message": "%s: the empty level has no ink." % what}
+
+	for level: int in range(1, levels):
+		var ink: int = _ink(_strip_tile(strip, tiles, first + level))
+		if ink != previous + RomLayout.BAR_STEP_PIXELS:
+			return {
+				"ok": false,
+				"message": "%s: level %d has %d pixels, expected %d." % [
+					what, level, ink, previous + RomLayout.BAR_STEP_PIXELS,
+				],
+			}
+		previous = ink
+
+	return {"ok": true, "message": ""}
+
+
+## One tile out of a strip, as its own buffer.
+static func _strip_tile(strip: PackedByteArray, tiles: int, tile: int) -> PackedByteArray:
+	var width: int = tiles * Gen2Tiles.TILE_WIDTH
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Tiles.TILE_PIXELS)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			out[row * Gen2Tiles.TILE_WIDTH + column] = strip[
+				row * width + tile * Gen2Tiles.TILE_WIDTH + column
+			]
+	return out
+
+
+## Lit pixels in a decoded tile, whatever colour they are.
+static func _ink(pixels: PackedByteArray) -> int:
+	var out: int = 0
+	for index: int in pixels:
+		if index != 0:
+			out += 1
+	return out
 
 
 ## The three trainer tables, each checked by what is known about it independently.
@@ -614,12 +714,19 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 	return out
 
 
-## Decodes the font and the eight text box borders, each as one strip of tiles.
+## Decodes the fixed tile sheets: the font, the eight text box borders and the
+## battle HUD's graphics, each as one strip of tiles.
 ##
-## Neither is compressed and neither is per-species, so unlike a pic there is
-## nothing to look up: the whole of both is a fixed run of 1bpp tiles. They are
-## kept as strips because both are addressed by character code, and a strip
-## turns that code into a horizontal offset and nothing else.
+## None of them is compressed and none is per-species, so unlike a pic there is
+## nothing to look up: each is a fixed run of tiles at a known place. They are
+## kept as strips because each is addressed by a number, whether a character code
+## or a tile in a bar, and a strip turns that number into a horizontal offset and
+## nothing else.
+##
+## [code]first_code[/code] is the character code a sheet's first tile draws, and
+## is zero for the sheets that are graphics rather than characters. [code]bits[/code]
+## is how the cartridge stores them: the font and the borders are 1bpp, the
+## battle graphics 2bpp.
 func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 	var sheets: Dictionary = {
@@ -627,11 +734,37 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"offset": RomLayout.font_offset(layout),
 			"tiles": RomLayout.FONT_TILES,
 			"first_code": RomLayout.FONT_FIRST_CODE,
+			"bits": 1,
 		},
 		"frames": {
 			"offset": RomLayout.frame_offset(layout, 0),
 			"tiles": RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES,
 			"first_code": RomLayout.FRAME_FIRST_CODE,
+			"bits": 1,
+		},
+		"battle_font": {
+			"offset": int(layout["battle_font"]),
+			"tiles": RomLayout.BATTLE_FONT_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		"enemy_hud": {
+			"offset": int(layout["enemy_hud"]),
+			"tiles": RomLayout.ENEMY_HUD_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"player_hud": {
+			"offset": int(layout["player_hud"]),
+			"tiles": RomLayout.PLAYER_HUD_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"exp_bar": {
+			"offset": int(layout["exp_bar"]),
+			"tiles": RomLayout.EXP_BAR_TILES,
+			"first_code": 0,
+			"bits": 2,
 		},
 	}
 
@@ -640,7 +773,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]
 		var count: int = sheet["tiles"]
-		var indices: PackedByteArray = Gen2Tiles.decode_1bpp_strip(data, sheet["offset"], count)
+		var indices: PackedByteArray = _decode_strip(data, sheet)
 		var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 		if not RomCache.write_indices(RomCache.tile_path(directory, name), indices):
 			return {}
@@ -649,6 +782,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"height": Gen2Tiles.TILE_HEIGHT,
 			"tiles": count,
 			"first_code": sheet["first_code"],
+			"bits": sheet["bits"],
 		}
 
 		done += 1
@@ -656,6 +790,12 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			on_progress.call("tiles", done, sheets.size())
 
 	return written
+
+
+static func _decode_strip(data: PackedByteArray, sheet: Dictionary) -> PackedByteArray:
+	if int(sheet["bits"]) == 1:
+		return Gen2Tiles.decode_1bpp_strip(data, int(sheet["offset"]), int(sheet["tiles"]))
+	return Gen2Tiles.decode_2bpp_strip(data, int(sheet["offset"]), int(sheet["tiles"]))
 
 
 func _import_pics(

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -95,6 +95,26 @@ const ENEMY_HUD_TILES: int = 4
 const PLAYER_HUD_TILES: int = 6
 const EXP_BAR_TILES: int = 9
 
+## The four palettes a battle draws its bars with: the HP bar in green, yellow
+## or red depending on how much is left, and the exp bar in blue. They are two
+## colours each like a species' palette, white and black being implied, and they
+## sit immediately before the species palettes in every game.
+##
+## The names are the cache's keys, and the order is the cartridge's.
+const BAR_PALETTE_NAMES: Array = ["hp_green", "hp_yellow", "hp_red", "exp"]
+
+## What those palettes hold. This is content whose value is known independently,
+## like the first species name, so the check for the offset is the values
+## themselves: every bar shares a light colour and differs in the dark one.
+const BAR_PALETTES: Array = [
+	[0x3F5E, 0x02E0], [0x3F5E, 0x02BF], [0x3F5E, 0x001F], [0x3F5E, 0x7E24],
+]
+
+## An HP bar is green down to half and yellow down to a fifth, measured in lit
+## pixels rather than in hit points: what colours the bar is what is drawn.
+const HP_GREEN_PIXELS: int = 24
+const HP_YELLOW_PIXELS: int = 10
+
 ## The HP bar's fill levels within [constant BATTLE_FONT_TILES], and the exp
 ## bar's within its own strip. Each step lights one more column, which is two
 ## more pixels than the step before, and that progression is what proves the
@@ -164,6 +184,7 @@ const GOLD_SILVER: Dictionary = {
 	"type_names": 0x509AE,
 	"font": 0xF82F2,
 	"frames": 0xF88F2,
+	"bar_palettes": 0xAD2D,
 	"battle_font": 0xF86F2,
 	"enemy_hud": 0xF8BB2,
 	"player_hud": 0xF8BD2,
@@ -192,6 +213,7 @@ const CRYSTAL: Dictionary = {
 	"type_names": 0x5097B,
 	"font": 0xF8200,
 	"frames": 0xF8800,
+	"bar_palettes": 0xA8BE,
 	"battle_font": 0xF8600,
 	"enemy_hud": 0xF8AC0,
 	"player_hud": 0xF8AE0,
@@ -258,6 +280,11 @@ static func pic_pointer_offset(layout: Dictionary, species: int, back: bool) -> 
 static func unown_pic_pointer_offset(layout: Dictionary, form: int, back: bool) -> int:
 	var pair: int = form * 2 + (1 if back else 0)
 	return int(layout["unown_pic_pointers"]) + pair * PIC_POINTER_SIZE
+
+
+## One of the four bar palettes, by its position in [constant BAR_PALETTE_NAMES].
+static func bar_palette_offset(layout: Dictionary, index: int) -> int:
+	return int(layout["bar_palettes"]) + index * Gen2Palette.PAIR_BYTES
 
 
 static func trainer_class_count(layout: Dictionary) -> int:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -83,6 +83,27 @@ const FRAME_VERTICAL: int = 3
 const FRAME_BOTTOM_LEFT: int = 4
 const FRAME_BOTTOM_RIGHT: int = 5
 
+## The battle HUD's own graphics, which sit in the same section as the font and
+## the text box borders and are the rest of what a battle screen draws.
+##
+## [code]battle_font[/code] is 2bpp and carries "HP:", the nine fill levels of
+## the HP bar and the battle screen's odds and ends. The two HUD borders are 1bpp
+## and are the boxes a name and a level sit in, one shape for the enemy's and one
+## for the player's. The exp bar is 2bpp and is seven fill levels and two ends.
+const BATTLE_FONT_TILES: int = 32
+const ENEMY_HUD_TILES: int = 4
+const PLAYER_HUD_TILES: int = 6
+const EXP_BAR_TILES: int = 9
+
+## The HP bar's fill levels within [constant BATTLE_FONT_TILES], and the exp
+## bar's within its own strip. Each step lights one more column, which is two
+## more pixels than the step before, and that progression is what proves the
+## offset: nothing else in the section counts up like this.
+const HP_BAR_FIRST_TILE: int = 2
+const HP_BAR_LEVELS: int = 9
+const EXP_BAR_LEVELS: int = 7
+const BAR_STEP_PIXELS: int = 2
+
 ## Trainer classes are numbered from 1; class 0 is the player, who has a palette
 ## in the table but no pic in it. Crystal added one class to the sixty-six Gold
 ## and Silver have, so the count lives in the layout rather than here.
@@ -143,6 +164,10 @@ const GOLD_SILVER: Dictionary = {
 	"type_names": 0x509AE,
 	"font": 0xF82F2,
 	"frames": 0xF88F2,
+	"battle_font": 0xF86F2,
+	"enemy_hud": 0xF8BB2,
+	"player_hud": 0xF8BD2,
+	"exp_bar": 0xF8C02,
 	"trainer_pic_pointers": 0x80000,
 	"trainer_palettes": 0xB53D,
 	"trainer_class_names": 0x1B0955,
@@ -167,6 +192,10 @@ const CRYSTAL: Dictionary = {
 	"type_names": 0x5097B,
 	"font": 0xF8200,
 	"frames": 0xF8800,
+	"battle_font": 0xF8600,
+	"enemy_hud": 0xF8AC0,
+	"player_hud": 0xF8AE0,
+	"exp_bar": 0xF8B10,
 	"trainer_pic_pointers": 0x128000,
 	"trainer_palettes": 0xB0CE,
 	"trainer_class_names": 0x2C1EF,

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -76,6 +76,35 @@ static func decode_1bpp_strip(data: PackedByteArray, offset: int, count: int) ->
 	return out
 
 
+## The same, for tiles stored 2bpp: the battle HUD's graphics, which are four
+## colours where the font is two.
+##
+## Kept as a strip for the same reason the font is. These sheets are addressed by
+## tile number, so one row turns that number into a horizontal offset and nothing
+## else, and a sheet that decoded short leaves a visible hole rather than failing.
+static func decode_2bpp_strip(data: PackedByteArray, offset: int, count: int) -> PackedByteArray:
+	var width: int = count * TILE_WIDTH
+	var out: PackedByteArray = PackedByteArray()
+	if count <= 0:
+		return out
+	out.resize(width * TILE_HEIGHT)
+
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(TILE_PIXELS)
+
+	for tile: int in count:
+		var at: int = offset + tile * TILE_BYTES
+		if at < 0 or at + TILE_BYTES > data.size():
+			break
+		decode_tile_into(data, at, pixels, 0)
+		for row: int in TILE_HEIGHT:
+			var destination: int = row * width + tile * TILE_WIDTH
+			for column: int in TILE_WIDTH:
+				out[destination + column] = pixels[row * TILE_WIDTH + column]
+
+	return out
+
+
 ## Decodes a Pokémon or trainer pic into a row-major index buffer
 ## [param columns] * 8 wide and [param rows] * 8 tall.
 ##

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -1,0 +1,185 @@
+class_name Gen2BattleHud
+extends RefCounted
+
+## The two status panels a battle draws, on the tile grid the hardware uses.
+##
+## Everything here is in tiles, and every position is the one the games use. The
+## enemy's panel hangs from a side on its left at the top of the screen and the
+## player's from a side on its right below the middle, and neither is a box: they
+## are an edge and two corners with the contents printed inside them, which is
+## why they are drawn from the HUD sheets rather than from a text box frame.
+##
+## The panels differ in more than position. The player's carries its Pokémon's
+## HP as numbers and an exp bar along its bottom edge, and its bar closes with
+## the cap that hangs off the other side. The enemy's has neither, because the
+## player is not supposed to know either number.
+##
+## Node-free: it writes indices into a buffer, so a HUD can be drawn and read
+## back in a headless test.
+
+const TILE: int = Gen2Font.TILE
+
+## The HP bar is six tiles of eight pixels; the exp bar is eight.
+const HP_BAR_TILES: int = 6
+const EXP_BAR_TILES: int = 8
+
+## The enemy's panel: name, then level, then the bar and the edge under it.
+const ENEMY_NAME: Vector2i = Vector2i(1, 0)
+const ENEMY_LEVEL: Vector2i = Vector2i(6, 1)
+const ENEMY_BAR: Vector2i = Vector2i(2, 2)
+const ENEMY_EDGE: Vector2i = Vector2i(1, 2)
+
+## The player's, which is the same idea mirrored and two rows taller.
+const PLAYER_NAME: Vector2i = Vector2i(10, 7)
+const PLAYER_LEVEL: Vector2i = Vector2i(14, 8)
+const PLAYER_BAR: Vector2i = Vector2i(10, 9)
+const PLAYER_HP: Vector2i = Vector2i(11, 10)
+const PLAYER_EXP: Vector2i = Vector2i(10, 11)
+const PLAYER_EDGE: Vector2i = Vector2i(18, 10)
+
+## How many tiles of edge run along the bottom of a panel.
+const EDGE_TILES: int = 8
+
+## Both HP numbers are printed three columns wide, right-aligned, with a slash
+## between them.
+const HP_DIGITS: int = 3
+
+var font: Gen2Font = null
+var tiles: Gen2BattleTiles = null
+
+
+## Reads what it draws with out of a cache, or null if any of it is missing.
+static func from_data(data: GameData) -> Gen2BattleHud:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(data)
+	if glyphs == null or page == null:
+		return null
+
+	var out := Gen2BattleHud.new()
+	out.font = glyphs
+	out.tiles = page
+	return out
+
+
+## How much of a bar is lit, in pixels.
+##
+## A Pokémon that is alive never shows an empty bar: the games round down and
+## then put one pixel back, so that fainting is the only thing that empties it.
+static func bar_pixels(current: int, maximum: int, length: int) -> int:
+	if maximum <= 0 or current <= 0:
+		return 0
+	if current >= maximum:
+		return length
+	@warning_ignore("integer_division")
+	var lit: int = current * length / maximum
+	return maxi(lit, 1)
+
+
+## The enemy's panel except for the bar's fill: the name, the level, the "HP:"
+## label, the cap that closes the bar and the edge under it.
+##
+## The fill is drawn separately because it is the one thing on the panel that is
+## not black on white. The hardware gives every tile its own palette; this
+## layers instead, which comes to the same picture and keeps the palette choice
+## where the colour is.
+func draw_enemy(
+	into: PackedByteArray, width: int, name: String, level: int
+) -> void:
+	font.draw_text(name, into, width, ENEMY_NAME.x * TILE, ENEMY_NAME.y * TILE)
+	_draw_level(into, width, ENEMY_LEVEL, level)
+	_draw_bar_frame(into, width, ENEMY_BAR, Gen2BattleTiles.HP_BAR_END)
+
+	# The edge, which starts beside the bar and turns under it.
+	var left: int = ENEMY_EDGE.x * TILE
+	var top: int = ENEMY_EDGE.y * TILE
+	tiles.draw(Gen2BattleTiles.ENEMY_SIDE, into, width, left, top)
+	tiles.draw(Gen2BattleTiles.ENEMY_CORNER, into, width, left, top + TILE)
+	tiles.draw_run(Gen2BattleTiles.HUD_BOTTOM, EDGE_TILES, into, width, left + TILE, top + TILE)
+	tiles.draw(
+		Gen2BattleTiles.ENEMY_BOTTOM_RIGHT, into, width,
+		left + (EDGE_TILES + 1) * TILE, top + TILE
+	)
+
+
+## The player's panel, likewise without its two bars: it carries HP as numbers
+## as well, and an exp bar sunk into its bottom edge.
+func draw_player(
+	into: PackedByteArray, width: int, name: String, level: int, hp: int, max_hp: int
+) -> void:
+	font.draw_text(name, into, width, PLAYER_NAME.x * TILE, PLAYER_NAME.y * TILE)
+	_draw_level(into, width, PLAYER_LEVEL, level)
+	_draw_bar_frame(into, width, PLAYER_BAR, Gen2BattleTiles.HP_BAR_END + 1)
+
+	# Right-aligned in a fixed field, as the games print any number in a panel:
+	# the digits line up and the leading spaces draw nothing.
+	font.draw_text(
+		"%s/%s" % [str(hp).lpad(HP_DIGITS), str(max_hp).lpad(HP_DIGITS)], into, width,
+		PLAYER_HP.x * TILE, PLAYER_HP.y * TILE
+	)
+
+	# The edge, drawn before the exp bar because the bar sits in it: the games
+	# lay the bottom edge down and then print the bar over the middle of it.
+	var right: int = PLAYER_EDGE.x * TILE
+	var top: int = PLAYER_EDGE.y * TILE
+	tiles.draw(Gen2BattleTiles.PLAYER_SIDE, into, width, right, top)
+	tiles.draw(Gen2BattleTiles.PLAYER_BOTTOM_RIGHT, into, width, right, top + TILE)
+	tiles.draw_run(
+		Gen2BattleTiles.HUD_BOTTOM, EDGE_TILES, into, width,
+		right - EDGE_TILES * TILE, top + TILE
+	)
+	tiles.draw(
+		Gen2BattleTiles.PLAYER_BOTTOM_LEFT, into, width,
+		right - (EDGE_TILES + 1) * TILE, top + TILE
+	)
+
+
+## The fill of one HP bar, which is all that is drawn in the bar's own colour.
+func draw_hp_bar(
+	into: PackedByteArray, width: int, at: Vector2i, hp: int, max_hp: int
+) -> void:
+	var lit: int = bar_pixels(hp, max_hp, HP_BAR_TILES * TILE)
+	var left: int = (at.x + 2) * TILE
+	for tile: int in HP_BAR_TILES:
+		var within: int = clampi(lit - tile * TILE, 0, TILE)
+		if within <= 0:
+			continue
+		tiles.draw(
+			Gen2BattleTiles.HP_BAR_EMPTY + within, into, width, left + tile * TILE, at.y * TILE
+		)
+
+
+## The exp bar, whose ends are the HP bar's own tiles and whose partial fills
+## are the only thing its own sheet is for.
+func draw_exp_bar(into: PackedByteArray, width: int, fraction: float) -> void:
+	var length: int = EXP_BAR_TILES * TILE
+	var lit: int = clampi(int(fraction * float(length)), 0, length)
+	var left: int = PLAYER_EXP.x * TILE
+	var top: int = PLAYER_EXP.y * TILE
+
+	for tile: int in EXP_BAR_TILES:
+		var within: int = clampi(lit - tile * TILE, 0, TILE)
+		if within <= 0:
+			continue
+		var number: int = Gen2BattleTiles.HP_BAR_FULL if within >= TILE \
+			else Gen2BattleTiles.EXP_BAR_FIRST_PARTIAL + within - 1
+		tiles.draw(number, into, width, left + tile * TILE, top)
+
+
+## The level symbol and the number, left-aligned after it, which is how a level
+## is written everywhere in these games.
+func _draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> void:
+	tiles.draw(Gen2BattleTiles.LEVEL, into, width, at.x * TILE, at.y * TILE)
+	font.draw_text("%d" % level, into, width, (at.x + 1) * TILE, at.y * TILE)
+
+
+## "HP:", the empty bar and the cap that closes it: everything about a bar that
+## does not depend on how full it is.
+func _draw_bar_frame(into: PackedByteArray, width: int, at: Vector2i, cap: int) -> void:
+	var left: int = at.x * TILE
+	var top: int = at.y * TILE
+	tiles.draw(Gen2BattleTiles.HP_LABEL, into, width, left, top)
+	tiles.draw(Gen2BattleTiles.HP_LABEL + 1, into, width, left + TILE, top)
+	tiles.draw_run(
+		Gen2BattleTiles.HP_BAR_EMPTY, HP_BAR_TILES, into, width, left + 2 * TILE, top
+	)
+	tiles.draw(cap, into, width, left + (2 + HP_BAR_TILES) * TILE, top)

--- a/game/render/battle_hud.gd.uid
+++ b/game/render/battle_hud.gd.uid
@@ -1,0 +1,1 @@
+uid://udl22pyvse7u

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -1,0 +1,115 @@
+class_name Gen2BattleTiles
+extends RefCounted
+
+## The battle screen's tile page, assembled the way the hardware assembles it.
+##
+## A battle loads four sheets into one run of tile numbers, and they overlap on
+## purpose: the battle font is copied in first and the two HUD borders are
+## copied over the middle of it, so thirteen of its tiles are never seen. Rather
+## than trim the sheets and renumber them, this copies them in the same order
+## into one strip and keeps the cartridge's own tile numbers. The result is that
+## the constants below are the numbers the disassembly uses, and a screen built
+## from them can be read against it.
+##
+## Node-free like the rest of the drawing layer: it writes indices into a buffer,
+## so a whole HUD can be laid out and checked with no display.
+
+const TILE: int = Gen2Font.TILE
+
+## The first and last tile numbers the page covers.
+const FIRST_TILE: int = 0x55
+const LAST_TILE: int = 0x78
+
+## Where each sheet is copied to, in the order the battle loads them.
+const EXP_BAR_AT: int = 0x55
+const BATTLE_FONT_AT: int = 0x60
+const ENEMY_HUD_AT: int = 0x6C
+const PLAYER_HUD_AT: int = 0x73
+
+## "HP:", which is two tiles because the colon shares one with the bar's cap.
+const HP_LABEL: int = 0x60
+## The nine fill levels, from empty to eight pixels lit.
+const HP_BAR_EMPTY: int = 0x62
+const HP_BAR_FULL: int = 0x6A
+## The cap that closes a bar. The player's HUD uses the tile after it, which is
+## the same shape hanging off the other side.
+const HP_BAR_END: int = 0x6B
+## The seven partial fills of the exp bar. Its empty and full tiles are the HP
+## bar's own: only the middle of it is drawn from a sheet of its own.
+const EXP_BAR_FIRST_PARTIAL: int = 0x55
+
+## The level symbol, printed before a number.
+const LEVEL: int = 0x6E
+
+## The enemy's HUD hangs from a side on its left; the player's from one on its
+## right. Both close with a bottom edge and two corners.
+const ENEMY_SIDE: int = 0x6D
+const ENEMY_CORNER: int = 0x74
+const ENEMY_BOTTOM_RIGHT: int = 0x78
+const PLAYER_SIDE: int = 0x73
+const PLAYER_BOTTOM_LEFT: int = 0x6F
+const PLAYER_BOTTOM_RIGHT: int = 0x77
+const HUD_BOTTOM: int = 0x76
+
+var _tiles: PackedByteArray = PackedByteArray()
+var _width: int = 0
+
+
+## Builds the page out of a cache, or null if the battle graphics are not in it.
+static func from_data(data: GameData) -> Gen2BattleTiles:
+	if data == null:
+		return null
+
+	var out := Gen2BattleTiles.new()
+	var count: int = LAST_TILE - FIRST_TILE + 1
+	out._width = count * TILE
+	out._tiles.resize(out._width * TILE)
+
+	# In load order, so that where two sheets claim a tile the later one wins,
+	# exactly as it does in video memory.
+	var sheets: Array = [
+		["exp_bar", EXP_BAR_AT], ["battle_font", BATTLE_FONT_AT],
+		["enemy_hud", ENEMY_HUD_AT], ["player_hud", PLAYER_HUD_AT],
+	]
+	var loaded: int = 0
+	for sheet: Array in sheets:
+		var name: String = sheet[0]
+		var meta: Dictionary = data.tile_sheet(name)
+		if meta.is_empty():
+			continue
+		if out._copy(data.tile_indices(name), int(meta.get("width", 0)), int(sheet[1])):
+			loaded += 1
+
+	return out if loaded == sheets.size() else null
+
+
+## One tile of the page, drawn at a pixel position in [param into].
+func draw(tile: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int) -> void:
+	if tile < FIRST_TILE or tile > LAST_TILE:
+		return
+	Gen2Font.blit_slot(_tiles, _width, tile - FIRST_TILE, into, into_width, at_x, at_y)
+
+
+## Draws the same tile across a run of columns, which is what a HUD's bottom
+## edge and an empty bar both are.
+func draw_run(
+	tile: int, count: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int
+) -> void:
+	for i: int in count:
+		draw(tile, into, into_width, at_x + i * TILE, at_y)
+
+
+func _copy(strip: PackedByteArray, strip_width: int, at_tile: int) -> bool:
+	if strip_width <= 0 or strip.size() < strip_width * TILE:
+		return false
+
+	var tiles: int = strip_width / TILE
+	for tile: int in tiles:
+		var to: int = (at_tile - FIRST_TILE + tile) * TILE
+		if to < 0 or to + TILE > _width:
+			continue
+		for y: int in TILE:
+			var from: int = y * strip_width + tile * TILE
+			for x: int in TILE:
+				_tiles[y * _width + to + x] = strip[from + x]
+	return true

--- a/game/render/battle_tiles.gd.uid
+++ b/game/render/battle_tiles.gd.uid
@@ -1,0 +1,1 @@
+uid://dqtsei8dnapt8

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -74,7 +74,7 @@ func draw_code(
 	var slot: int = code - _first_code
 	if slot < 0 or slot >= _glyph_tiles:
 		return
-	_blit(_glyphs, _glyph_width, slot, into, into_width, at_x, at_y)
+	blit_slot(_glyphs, _glyph_width, slot, into, into_width, at_x, at_y)
 
 
 ## Draws a string left to right from [param at_x], advancing eight pixels per
@@ -101,13 +101,16 @@ func draw_frame_code(
 	var slot: int = frame * RomLayout.FRAME_TILES + within
 	if frame < 0 or slot >= _frame_tiles:
 		return
-	_blit(_frames, _frame_width, slot, into, into_width, at_x, at_y)
+	blit_slot(_frames, _frame_width, slot, into, into_width, at_x, at_y)
 
 
 ## Copies one tile out of a strip, clipped to the destination. Clipping rather
 ## than refusing, because a text box that runs off the edge of the screen should
 ## look wrong at the edge and be right everywhere else.
-static func _blit(
+##
+## Public because every sheet in this project is a strip and they all draw from
+## one the same way; [Gen2BattleTiles] is the other caller.
+static func blit_slot(
 	strip: PackedByteArray,
 	strip_width: int,
 	slot: int,

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -1,0 +1,191 @@
+extends GutTest
+
+## The battle screen's tile page and the arithmetic behind its bars.
+##
+## Builds its own cache, like `test_game_data.gd`: nothing here opens a
+## cartridge, because the point of the drawing layer is that it works on
+## indices and a palette and never sees one.
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"battletest", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+## Four sheets, each filled with one index, so which sheet a tile came from can
+## be read off the page.
+func _write_cache(with_sheets: bool = true) -> void:
+	var sheets: Dictionary = {}
+	if with_sheets:
+		var written: Dictionary = {
+			"exp_bar": [RomLayout.EXP_BAR_TILES, 2],
+			"battle_font": [RomLayout.BATTLE_FONT_TILES, 1],
+			"enemy_hud": [RomLayout.ENEMY_HUD_TILES, 2],
+			"player_hud": [RomLayout.PLAYER_HUD_TILES, 3],
+			"font": [RomLayout.FONT_TILES, 3],
+			"frames": [RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES, 3],
+		}
+		for name: String in written:
+			var tiles: int = written[name][0]
+			var value: int = written[name][1]
+			var indices: PackedByteArray = PackedByteArray()
+			indices.resize(tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
+			indices.fill(value)
+			RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
+			sheets[name] = {
+				"width": tiles * Gen2Tiles.TILE_WIDTH,
+				"height": Gen2Tiles.TILE_HEIGHT,
+				"tiles": tiles,
+				"first_code": RomLayout.FONT_FIRST_CODE if name == "font" else 0,
+				"bits": 1,
+			}
+
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "battletest",
+		"sha1": "0123456789abcdef",
+		"tiles": sheets,
+		"bar_palettes": {
+			"hp_green": [0x02E0, 0x02E0],
+			"hp_yellow": [0x02BF, 0x02BF],
+			"hp_red": [0x001F, 0x001F],
+			"exp": [0x7E24, 0x7E24],
+		},
+		"complete": true,
+	})
+
+
+func _data() -> GameData:
+	return GameData.open_directory(_directory)
+
+
+## The index one tile of the page draws, read back out of a buffer.
+func _drawn(page: Gen2BattleTiles, tile: int) -> int:
+	var into: PackedByteArray = PackedByteArray()
+	into.resize(Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
+	page.draw(tile, into, Gen2Tiles.TILE_WIDTH, 0, 0)
+	return into[0]
+
+
+func test_the_page_needs_every_sheet_it_draws_from() -> void:
+	_write_cache(false)
+	assert_null(Gen2BattleTiles.from_data(_data()))
+	assert_null(Gen2BattleHud.from_data(_data()))
+
+
+func test_a_later_sheet_wins_the_tiles_it_lands_on() -> void:
+	# The battle font is copied in first and the HUD borders over the middle of
+	# it, exactly as they are in video memory, so thirteen of its tiles are never
+	# seen. Getting this backwards draws a border where a bar should be.
+	_write_cache()
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(_data())
+	assert_not_null(page)
+	assert_eq(_drawn(page, Gen2BattleTiles.EXP_BAR_AT), 2, "the exp bar keeps its own tiles")
+	assert_eq(_drawn(page, Gen2BattleTiles.HP_BAR_EMPTY), 1, "the bar is the battle font's")
+	assert_eq(_drawn(page, Gen2BattleTiles.ENEMY_HUD_AT), 2, "the enemy border overwrites")
+	assert_eq(_drawn(page, Gen2BattleTiles.PLAYER_HUD_AT), 3, "so does the player's")
+
+
+func test_a_tile_outside_the_page_draws_nothing() -> void:
+	_write_cache()
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(_data())
+	assert_eq(_drawn(page, Gen2BattleTiles.FIRST_TILE - 1), 0)
+	assert_eq(_drawn(page, Gen2BattleTiles.LAST_TILE + 1), 0)
+
+
+func test_a_full_bar_is_full_and_an_empty_one_is_empty() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(20, 20, 48), 48)
+	assert_eq(Gen2BattleHud.bar_pixels(0, 20, 48), 0)
+
+
+func test_a_pokemon_that_is_alive_never_shows_an_empty_bar() -> void:
+	# The games round the bar down and then put a pixel back, so that an empty
+	# bar means fainted and nothing else.
+	assert_eq(Gen2BattleHud.bar_pixels(1, 999, 48), 1)
+
+
+func test_a_bar_is_as_full_as_the_fraction_behind_it() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(10, 20, 48), 24)
+	assert_eq(Gen2BattleHud.bar_pixels(5, 20, 48), 12)
+
+
+func test_a_bar_with_no_maximum_does_not_divide_by_it() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(5, 0, 48), 0)
+
+
+func test_the_bar_colour_follows_what_is_drawn_not_the_hit_points() -> void:
+	# Half a bar is still green, a fifth of it is yellow, and below that it is
+	# red: the rule is about pixels, which is why a bar can turn red on a
+	# Pokémon with hit points left.
+	assert_eq(GameData.hp_bar_palette_name(48), "hp_green")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_GREEN_PIXELS), "hp_green")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_GREEN_PIXELS - 1), "hp_yellow")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_YELLOW_PIXELS), "hp_yellow")
+	assert_eq(GameData.hp_bar_palette_name(RomLayout.HP_YELLOW_PIXELS - 1), "hp_red")
+
+
+func test_a_bar_palette_comes_back_as_four_colours() -> void:
+	_write_cache()
+	var data: GameData = _data()
+	var palette: PackedColorArray = data.bar_palette("hp_green")
+	assert_eq(palette.size(), Gen2Palette.COLORS_PER_PIC)
+	assert_eq(palette[0], Color.WHITE)
+	assert_eq(palette[3], Color.BLACK)
+	assert_ne(palette, data.bar_palette("hp_red"))
+
+
+func test_an_unknown_bar_palette_is_legible_rather_than_missing() -> void:
+	_write_cache()
+	assert_eq(_data().bar_palette("nothing"), _data().bar_palette("also nothing"))
+
+
+func test_the_hud_draws_its_panels_where_the_hardware_puts_them() -> void:
+	# The panels sit above and below the pics and must not reach into either.
+	_write_cache()
+	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
+	assert_not_null(hud)
+
+	var screen: PackedByteArray = PackedByteArray()
+	screen.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_enemy(screen, Gen2Screen.WIDTH, "PIDGEY", 5)
+	hud.draw_player(screen, Gen2Screen.WIDTH, "CYNDAQUIL", 5, 18, 18)
+
+	assert_ne(_ink_in_row(screen, Gen2BattleHud.ENEMY_NAME.y), 0, "the enemy's name row")
+	assert_ne(_ink_in_row(screen, Gen2BattleHud.PLAYER_BAR.y), 0, "the player's bar row")
+	assert_eq(_ink_in_row(screen, Gen2TextBox.STANDARD_TOP), 0, "nothing in the text box")
+	assert_eq(_ink_in_row(screen, 5), 0, "nothing between the two panels")
+
+
+func test_the_hp_bar_fill_is_drawn_apart_from_the_panel() -> void:
+	# The fill is the only part of a panel that is not black on white, so it is
+	# a layer of its own and the panel must not draw it.
+	_write_cache()
+	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
+
+	var full: PackedByteArray = PackedByteArray()
+	full.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_hp_bar(full, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, 20, 20)
+
+	var empty: PackedByteArray = PackedByteArray()
+	empty.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_hp_bar(empty, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, 0, 20)
+
+	assert_ne(_ink_in_row(full, Gen2BattleHud.ENEMY_BAR.y), 0)
+	assert_eq(_ink_in_row(empty, Gen2BattleHud.ENEMY_BAR.y), 0, "a fainted bar draws nothing")
+
+
+## Lit pixels in one row of tiles.
+func _ink_in_row(screen: PackedByteArray, row: int) -> int:
+	var out: int = 0
+	for y: int in range(row * Gen2Font.TILE, (row + 1) * Gen2Font.TILE):
+		for x: int in Gen2Screen.WIDTH:
+			if screen[y * Gen2Screen.WIDTH + x] != 0:
+				out += 1
+	return out

--- a/tests/unit/test_battle_hud.gd.uid
+++ b/tests/unit/test_battle_hud.gd.uid
@@ -1,0 +1,1 @@
+uid://bq3yvoe5vomq0

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -285,7 +285,21 @@ func _battle_dump() -> PackedByteArray:
 	_write_bar(data, int(_layout["exp_bar"]), 0, RomLayout.EXP_BAR_LEVELS)
 	_write_hud(data, int(_layout["enemy_hud"]), RomLayout.ENEMY_HUD_TILES)
 	_write_hud(data, int(_layout["player_hud"]), RomLayout.PLAYER_HUD_TILES)
+	_write_bar_palettes(data)
 	return data
+
+
+## The four bar palettes, whose values are the check on where they are.
+func _write_bar_palettes(data: PackedByteArray) -> void:
+	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
+		var at: int = RomLayout.bar_palette_offset(_layout, index)
+		var wanted: Array = RomLayout.BAR_PALETTES[index]
+		for colour: int in wanted.size():
+			var packed: int = int(wanted[colour])
+			_write(
+				data, at + colour * Gen2Palette.COLOR_BYTES,
+				PackedByteArray([packed & 0xFF, packed >> 8])
+			)
 
 
 ## Fill levels as 2bpp tiles, each one two pixels fuller than the last.
@@ -340,6 +354,16 @@ func test_an_exp_bar_that_is_not_there_fails() -> void:
 	for i: int in RomLayout.EXP_BAR_TILES * Gen2Tiles.TILE_BYTES:
 		data[int(_layout["exp_bar"]) + i] = 0
 	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_a_bar_palette_that_is_not_the_colour_it_should_be_fails() -> void:
+	# These are known values rather than a shape, so a wrong offset is caught by
+	# the colours themselves.
+	var data: PackedByteArray = _battle_dump()
+	_write(data, RomLayout.bar_palette_offset(_layout, 2), PackedByteArray([0x00, 0x00]))
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "hp_red")
 
 
 func test_a_blank_hud_tile_fails() -> void:

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -274,3 +274,85 @@ func test_a_dump_with_no_trainers_in_it_fails() -> void:
 	var data: PackedByteArray = PackedByteArray()
 	data.resize(RomRegistry.EXPECTED_SIZE)
 	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
+
+
+## A battle sheet at every offset the layout claims: two bars that count up, and
+## two HUD borders whose tiles all differ.
+func _battle_dump() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_bar(data, int(_layout["battle_font"]), RomLayout.HP_BAR_FIRST_TILE, RomLayout.HP_BAR_LEVELS)
+	_write_bar(data, int(_layout["exp_bar"]), 0, RomLayout.EXP_BAR_LEVELS)
+	_write_hud(data, int(_layout["enemy_hud"]), RomLayout.ENEMY_HUD_TILES)
+	_write_hud(data, int(_layout["player_hud"]), RomLayout.PLAYER_HUD_TILES)
+	return data
+
+
+## Fill levels as 2bpp tiles, each one two pixels fuller than the last.
+func _write_bar(data: PackedByteArray, at: int, first: int, levels: int) -> void:
+	for level: int in levels:
+		_write(
+			data, at + (first + level) * Gen2Tiles.TILE_BYTES,
+			_lit_tile(Gen2Tiles.TILE_WIDTH + level * RomLayout.BAR_STEP_PIXELS)
+		)
+
+
+## A 2bpp tile with [param pixels] lit, filled row by row.
+func _lit_tile(pixels: int) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Tiles.TILE_BYTES)
+	for pixel: int in pixels:
+		@warning_ignore("integer_division")
+		var row: int = pixel / Gen2Tiles.TILE_WIDTH
+		out[row * 2] |= 1 << (7 - pixel % Gen2Tiles.TILE_WIDTH)
+	return out
+
+
+## 1bpp tiles that all have ink and none of which repeats another.
+func _write_hud(data: PackedByteArray, at: int, tiles: int) -> void:
+	for tile: int in tiles:
+		var bytes: PackedByteArray = PackedByteArray()
+		bytes.resize(Gen2Tiles.TILE_1BPP_BYTES)
+		bytes[0] = 0xFF << (7 - tile) & 0xFF
+		bytes[1] = 0x18
+		_write(data, at + tile * Gen2Tiles.TILE_1BPP_BYTES, bytes)
+
+
+func test_battle_graphics_that_count_up_verify() -> void:
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(_battle_dump()), _layout)
+	assert_true(result["ok"], result["message"])
+
+
+func test_a_bar_whose_levels_do_not_climb_fails() -> void:
+	# The check the bars exist for: neither has a name or a number in the
+	# cartridge, and a run of tiles that counts up is what says it is a bar.
+	var data: PackedByteArray = _battle_dump()
+	_write(
+		data,
+		int(_layout["battle_font"]) + (RomLayout.HP_BAR_FIRST_TILE + 4) * Gen2Tiles.TILE_BYTES,
+		_lit_tile(Gen2Tiles.TILE_WIDTH)
+	)
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_an_exp_bar_that_is_not_there_fails() -> void:
+	var data: PackedByteArray = _battle_dump()
+	for i: int in RomLayout.EXP_BAR_TILES * Gen2Tiles.TILE_BYTES:
+		data[int(_layout["exp_bar"]) + i] = 0
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_a_blank_hud_tile_fails() -> void:
+	var data: PackedByteArray = _battle_dump()
+	for row: int in Gen2Tiles.TILE_1BPP_BYTES:
+		data[int(_layout["player_hud"]) + 2 * Gen2Tiles.TILE_1BPP_BYTES + row] = 0
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+func test_hud_tiles_that_repeat_mean_it_is_not_the_border() -> void:
+	var data: PackedByteArray = _battle_dump()
+	_write(
+		data, int(_layout["enemy_hud"]) + Gen2Tiles.TILE_1BPP_BYTES,
+		data.slice(int(_layout["enemy_hud"]), int(_layout["enemy_hud"]) + Gen2Tiles.TILE_1BPP_BYTES)
+	)
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -218,6 +218,39 @@ func test_the_font_and_the_frames_do_not_overlap_or_run_off_the_end() -> void:
 		assert_lt(last, RomRegistry.EXPECTED_SIZE)
 
 
+func test_the_battle_graphics_sit_back_to_back_in_the_order_they_are_stored() -> void:
+	# They are one run in the cartridge: the enemy's HUD border, the player's,
+	# then the exp bar. Each offset is a claim about where the one before it ends.
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		assert_eq(
+			int(layout["enemy_hud"]) + RomLayout.ENEMY_HUD_TILES * Gen2Tiles.TILE_1BPP_BYTES,
+			int(layout["player_hud"]), "%s: the player's HUD does not follow the enemy's" % id
+		)
+		assert_eq(
+			int(layout["player_hud"]) + RomLayout.PLAYER_HUD_TILES * Gen2Tiles.TILE_1BPP_BYTES,
+			int(layout["exp_bar"]), "%s: the exp bar does not follow the HUD borders" % id
+		)
+
+
+func test_the_battle_font_follows_the_font_itself() -> void:
+	# Both are in the section the font opens, and the battle sheet is the next
+	# thing in it after the 128 glyphs.
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		assert_eq(
+			RomLayout.font_offset(layout) + RomLayout.FONT_TILES * Gen2Tiles.TILE_1BPP_BYTES,
+			int(layout["battle_font"]), "%s battle font" % id
+		)
+
+
+func test_the_bars_have_a_level_for_every_step_of_their_tiles() -> void:
+	assert_lt(
+		RomLayout.HP_BAR_FIRST_TILE + RomLayout.HP_BAR_LEVELS, RomLayout.BATTLE_FONT_TILES
+	)
+	assert_lt(RomLayout.EXP_BAR_LEVELS, RomLayout.EXP_BAR_TILES)
+
+
 func test_a_fixed_bank_still_addresses_inside_the_cartridge() -> void:
 	for id: StringName in RomRegistry.ORDER:
 		var layout: Dictionary = RomLayout.for_id(id)

--- a/tests/unit/test_tile_codec.gd
+++ b/tests/unit/test_tile_codec.gd
@@ -115,6 +115,26 @@ func test_a_1bpp_strip_that_runs_out_of_data_keeps_its_size() -> void:
 	assert_eq(strip.count(0), strip.size())
 
 
+func test_a_2bpp_strip_keeps_all_four_colours_where_a_1bpp_one_has_two() -> void:
+	# The battle HUD is 2bpp, so its strips carry the middle indices the font
+	# never produces.
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(Gen2Tiles.TILE_BYTES)
+	data[0] = 0xF0
+	data[1] = 0xCC
+	var strip: PackedByteArray = Gen2Tiles.decode_2bpp_strip(data, 0, 1)
+	assert_eq(strip.size(), Gen2Tiles.TILE_PIXELS)
+	assert_eq(strip[0], 3, "both planes set")
+	assert_eq(strip[2], 1, "low plane only")
+	assert_eq(strip[4], 2, "high plane only")
+	assert_eq(strip[6], 0)
+
+
+func test_a_2bpp_strip_that_runs_out_of_data_keeps_its_size() -> void:
+	var strip: PackedByteArray = Gen2Tiles.decode_2bpp_strip(PackedByteArray(), 0, 4)
+	assert_eq(strip.size(), 4 * Gen2Tiles.TILE_PIXELS)
+
+
 func test_blit_places_a_small_pic_inside_a_cell() -> void:
 	var source: PackedByteArray = PackedByteArray([1, 2, 3, 4])
 	var destination: PackedByteArray = PackedByteArray()

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -17,7 +17,9 @@ extends SceneTree
 ## them and the digits where they can be read at a glance.
 
 const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back", "trainers"]
-const SHEETS: PackedStringArray = ["font", "frames"]
+const SHEETS: PackedStringArray = [
+	"font", "frames", "battle_font", "enemy_hud", "player_hud", "exp_bar",
+]
 
 ## Tiles per row when a strip is folded for viewing.
 const SHEET_COLUMNS: int = 16
@@ -87,8 +89,9 @@ func _find_cache(game: StringName) -> String:
 	return directory if RomCache.is_usable(directory) else ""
 
 
-## A 1bpp strip, folded into rows of [constant SHEET_COLUMNS] tiles. There is no
-## palette to choose: 1bpp graphics are black on white and nothing else.
+## A tile strip, folded into rows of [constant SHEET_COLUMNS] tiles. There is no
+## palette to choose: a sheet has none of its own, so it is drawn in the greys a
+## Game Boy would have shown before a palette was applied.
 func _render_sheet(directory: String, sheet: Dictionary, name: String) -> Image:
 	var indices: PackedByteArray = RomCache.read_indices(RomCache.tile_path(directory, name))
 	var strip_width: int = int(sheet["width"])
@@ -117,7 +120,9 @@ func _render_sheet(directory: String, sheet: Dictionary, name: String) -> Image:
 
 	return Gen2PicImage.from_indices(
 		folded, width, rows * Gen2Tiles.TILE_HEIGHT,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		Gen2Palette.pic_palette(PackedColorArray([
+			Color(0.66, 0.66, 0.66), Color(0.33, 0.33, 0.33),
+		]))
 	)
 
 


### PR DESCRIPTION
Stacked on #4, so the diff here is the battle work alone. GitHub retargets this at `main` once that one merges.

Two Pokémon, a status panel each and a text box, at the positions the hardware puts them. The screen draws what it is given and decides nothing: no turn order, no damage, no faint. When there is an engine it will hand the screen the same numbers a caller hands it today.

**The HUD graphics had to be found first.** The HP bar, the two panel borders and the exp bar sit in the same section as the font, and the four palettes the bars are drawn in sit immediately before the species palettes, which is how those were found: a table we already had predicted them. Two of the sheets are 2bpp, so tile decoding grew a 2bpp strip beside the 1bpp one.

None of those blobs has a name or a number in the cartridge, so the check is the one thing they do that nothing around them does: they count. A bar's fill levels are consecutive tiles, each lighting one more column than the last, so the ink climbs by exactly two pixels a step. The palettes are known values and are checked against them.

**Two pieces sit under the screen.** `Gen2BattleTiles` assembles the battle's tile page the way a battle does, copying four sheets into one run of tiles where the HUD borders deliberately overwrite the middle of the battle font, so the constants in the drawing code are the tile numbers the disassembly uses. `Gen2BattleHud` draws the panels on the tile grid.

**The HUD is not black on white**, which cost a version of this screen: a white-and-black palette collapses the two middle indices a 2bpp tile uses, so the first attempt drew a correct HP bar that could not be seen. The hardware gives every background tile its own four colours; this stacks one buffer per palette instead, which comes to the same picture and keeps the colour choice where the colour is. A tilemap layer with real per-tile attributes replaces it when the overworld needs one.

An HP bar is green down to half and yellow down to a fifth, measured in lit pixels rather than in hit points, so a Pokémon with a little health left shows a red bar. That is the cartridge's rule and there is a test that pins it.

Verified on all three cartridges: 3/3 import, the sheets read against pret's reference images, and the screen photographed at full health and at a third so both bar colours were seen. GUT: 220/220.