### PR TITLE
Give moves their stat changes

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -41,6 +41,11 @@ const THAWED: StringName = &"thawed"
 ## A status put on a Pokémon, and a slice taken off by one it already had.
 const STATUS_INFLICTED: StringName = &"status_inflicted"
 const HURT_BY_STATUS: StringName = &"hurt_by_status"
+## A stat moved a stage, or tried to and could not. [code]stat[/code] is the key
+## [Gen2BattleMon] keeps it under, or [code]"all"[/code] for the five Ancientpower
+## moves at once; [code]by[/code] is how many stages, signed.
+const STAT_CHANGED: StringName = &"stat_changed"
+const STAT_CHANGE_FAILED: StringName = &"stat_change_failed"
 ## A Pokémon called back, and a Pokémon put out. They are two events rather than
 ## one because a replacement after a faint is only the second half: there is
 ## nobody to call back, and the screen has one sentence to say rather than two.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -55,6 +55,20 @@ const INFLICTED: Dictionary = {
 	&"paralysis": "is paralyzed!",
 }
 
+## The word the games print for a stat, keyed the way [Gen2BattleMon] keeps the
+## stat itself. A key the engine grows later shows up here as its own snake_case
+## name in capitals rather than as a wrong word, the same fallback
+## [method _battler_name] gives a status it does not recognise.
+const STAT_NAMES: Dictionary = {
+	"attack": "ATTACK",
+	"defense": "DEFENSE",
+	"speed": "SPEED",
+	"sp_attack": "SP.ATK",
+	"sp_defense": "SP.DEF",
+	"accuracy": "ACCURACY",
+	"evasion": "EVASIVENESS",
+}
+
 const TILE: int = Gen2Font.TILE
 
 ## The white the hardware fills the battle background with.
@@ -374,6 +388,10 @@ func _describe(event: Dictionary) -> String:
 			]
 		Gen2Battle.HURT_BY_STATUS:
 			return "%s is hurt by its %s!" % [_battler_name(side), event["name"]]
+		Gen2Battle.STAT_CHANGED:
+			return _stat_changed_text(event)
+		Gen2Battle.STAT_CHANGE_FAILED:
+			return _stat_failed_text(event)
 		Gen2Battle.WITHDREW:
 			# Named out of the event, because by the time this is read the one on
 			# the field is already the one that came in.
@@ -391,6 +409,34 @@ func _describe(event: Dictionary) -> String:
 				return "Both sides are out of Pokémon!"
 			return "%s won!" % ("The enemy" if event["winner"] == Gen2Battle.ENEMY else "Player")
 	return ""
+
+
+## The sentence for a stat that actually moved. Ancientpower's [code]"all"[/code]
+## reads as one sentence about the Pokémon rather than five about its stats,
+## because that is the one thing the event says that a single stat's does not.
+func _stat_changed_text(event: Dictionary) -> String:
+	var who: String = _battler_name(int(event["target"]))
+	if String(event["stat"]) == "all":
+		return "%s's stats rose!" % who
+
+	var stat_name: String = STAT_NAMES.get(event["stat"], String(event["stat"]).to_upper())
+	var by: int = int(event["by"])
+	if by > 0:
+		return "%s's %s went way up!" % [who, stat_name] if by >= 2 \
+			else "%s's %s went up!" % [who, stat_name]
+	return "%s's %s sharply fell!" % [who, stat_name] if by <= -2 \
+		else "%s's %s fell!" % [who, stat_name]
+
+
+## The sentence for a stat that was already at the end of the line. Whether it
+## reads "rise" or "drop" depends only on which end, not on how the move phrases
+## itself, because that is the cartridge's own rule.
+func _stat_failed_text(event: Dictionary) -> String:
+	var who: String = _battler_name(int(event["target"]))
+	var stat_name: String = STAT_NAMES.get(event["stat"], String(event["stat"]).to_upper())
+	if int(event["by"]) > 0:
+		return "%s's %s won't rise anymore!" % [who, stat_name]
+	return "%s's %s won't drop anymore!" % [who, stat_name]
 
 
 ## How a battle refers to one of the two, which is by side and not by species:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -73,6 +73,94 @@ const BURN_TARGET: StringName = &"burntarget"
 const FREEZE_TARGET: StringName = &"freezetarget"
 const PARALYZE_TARGET: StringName = &"paralyzetarget"
 
+## Raises and lowers a stat by one stage or two, named the way the cartridge
+## names them and in the order [constant Gen2BattleMon.STAGED_STATS] plus
+## [constant Gen2BattleMon.STAGED_ODDS] already keeps the seven in, because that
+## is also the order the cartridge's own effect bytes run in: seven in a row for
+## "up by one", seven more for "down by one", and so on. [Gen2MoveEffect] is what
+## turns that run into a table; this only names the seven stops along it.
+const ATTACK_UP: StringName = &"attackup"
+const DEFENSE_UP: StringName = &"defenseup"
+const SPEED_UP: StringName = &"speedup"
+const SP_ATTACK_UP: StringName = &"specialattackup"
+const SP_DEFENSE_UP: StringName = &"specialdefenseup"
+const ACCURACY_UP: StringName = &"accuracyup"
+const EVASION_UP: StringName = &"evasionup"
+
+const ATTACK_UP_2: StringName = &"attackup2"
+const DEFENSE_UP_2: StringName = &"defenseup2"
+const SPEED_UP_2: StringName = &"speedup2"
+const SP_ATTACK_UP_2: StringName = &"specialattackup2"
+const SP_DEFENSE_UP_2: StringName = &"specialdefenseup2"
+const ACCURACY_UP_2: StringName = &"accuracyup2"
+const EVASION_UP_2: StringName = &"evasionup2"
+
+const ATTACK_DOWN: StringName = &"attackdown"
+const DEFENSE_DOWN: StringName = &"defensedown"
+const SPEED_DOWN: StringName = &"speeddown"
+const SP_ATTACK_DOWN: StringName = &"specialattackdown"
+const SP_DEFENSE_DOWN: StringName = &"specialdefensedown"
+const ACCURACY_DOWN: StringName = &"accuracydown"
+const EVASION_DOWN: StringName = &"evasiondown"
+
+const ATTACK_DOWN_2: StringName = &"attackdown2"
+const DEFENSE_DOWN_2: StringName = &"defensedown2"
+const SPEED_DOWN_2: StringName = &"speeddown2"
+const SP_ATTACK_DOWN_2: StringName = &"specialattackdown2"
+const SP_DEFENSE_DOWN_2: StringName = &"specialdefensedown2"
+const ACCURACY_DOWN_2: StringName = &"accuracydown2"
+const EVASION_DOWN_2: StringName = &"evasiondown2"
+
+## Raises the user's five real stats at once, which is what Ancientpower leaves
+## behind on a roll. Accuracy and evasion are not among them: the cartridge's own
+## command is a loop over the five stats a stage multiplies a real number for,
+## and the two odds are not that.
+const ALL_STATS_UP: StringName = &"allstatsup"
+
+## The stat commands in the run order the cartridge's effect bytes use, indexed
+## by [Gen2MoveEffect] rather than named one at a time there. Each entry is
+## [param stat_key, param amount, param targets_user]: the key
+## [method Gen2BattleMon.change_stage] takes, how many stages it moves by, and
+## whether the move points it at whoever used it rather than the other side.
+const STAT_COMMANDS: Dictionary = {
+	ATTACK_UP: ["attack", 1, true], DEFENSE_UP: ["defense", 1, true],
+	SPEED_UP: ["speed", 1, true], SP_ATTACK_UP: ["sp_attack", 1, true],
+	SP_DEFENSE_UP: ["sp_defense", 1, true], ACCURACY_UP: ["accuracy", 1, true],
+	EVASION_UP: ["evasion", 1, true],
+
+	ATTACK_UP_2: ["attack", 2, true], DEFENSE_UP_2: ["defense", 2, true],
+	SPEED_UP_2: ["speed", 2, true], SP_ATTACK_UP_2: ["sp_attack", 2, true],
+	SP_DEFENSE_UP_2: ["sp_defense", 2, true], ACCURACY_UP_2: ["accuracy", 2, true],
+	EVASION_UP_2: ["evasion", 2, true],
+
+	ATTACK_DOWN: ["attack", -1, false], DEFENSE_DOWN: ["defense", -1, false],
+	SPEED_DOWN: ["speed", -1, false], SP_ATTACK_DOWN: ["sp_attack", -1, false],
+	SP_DEFENSE_DOWN: ["sp_defense", -1, false], ACCURACY_DOWN: ["accuracy", -1, false],
+	EVASION_DOWN: ["evasion", -1, false],
+
+	ATTACK_DOWN_2: ["attack", -2, false], DEFENSE_DOWN_2: ["defense", -2, false],
+	SPEED_DOWN_2: ["speed", -2, false], SP_ATTACK_DOWN_2: ["sp_attack", -2, false],
+	SP_DEFENSE_DOWN_2: ["sp_defense", -2, false], ACCURACY_DOWN_2: ["accuracy", -2, false],
+	EVASION_DOWN_2: ["evasion", -2, false],
+}
+
+## The five real stats [constant ALL_STATS_UP] raises, in the cartridge's order.
+const ALL_STATS_KEYS: Array = ["attack", "defense", "speed", "sp_attack", "sp_defense"]
+
+## Reports a stat change, or says nothing for one that is folded into a hit and
+## has no message step of its own. Separate from the change itself because a
+## status move that fails to move a stat says so and a secondary effect that
+## fails to says nothing, which is two different steps rather than one asking
+## both questions.
+const STAT_UP_MESSAGE: StringName = &"statupmessage"
+const STAT_DOWN_MESSAGE: StringName = &"statdownmessage"
+
+## Reports that a stat could not go any higher or lower. Only on a status move's
+## own sequence: a secondary effect's sequence has no step here at all, so its
+## failure is silent, the way a failed [constant EFFECT_CHANCE] already is.
+const STAT_UP_FAIL_TEXT: StringName = &"statupfailtext"
+const STAT_DOWN_FAIL_TEXT: StringName = &"statdownfailtext"
+
 ## Recoil is a quarter of the damage dealt, never less than one, and it is the
 ## same quarter for every move that has it rather than a figure per move.
 const RECOIL_DIVISOR: int = 4
@@ -121,8 +209,17 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_status_target(turn, Gen2Status.FREEZE)
 		PARALYZE_TARGET:
 			_status_target(turn, Gen2Status.PARALYSIS)
+		ALL_STATS_UP:
+			_all_stats_up(turn)
+		STAT_UP_MESSAGE, STAT_DOWN_MESSAGE:
+			_stat_message(turn)
+		STAT_UP_FAIL_TEXT, STAT_DOWN_FAIL_TEXT:
+			_stat_fail_text(turn)
 		_:
-			push_error("No such effect command: %s" % command)
+			if STAT_COMMANDS.has(command):
+				_stat_change(command, turn)
+			else:
+				push_error("No such effect command: %s" % command)
 
 
 static func _used_move_text(turn: Gen2Turn) -> void:
@@ -266,4 +363,66 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 		"target": turn.target,
 		"status": defender.status,
 		"name": Gen2Status.name_of(defender.status),
+	})
+
+
+## Moves one stat by one command's worth, and writes down who it happened to and
+## whether it actually moved, for the message step behind it to read.
+##
+## A secondary effect's failed roll skips this the same way it skips a status:
+## the damage in front of it has already landed, and what was behind the roll is
+## the only thing the roll can still cost.
+static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
+	var entry: Array = STAT_COMMANDS[command]
+	var stat_key: String = String(entry[0])
+	var amount: int = int(entry[1])
+	var side: int = turn.side if bool(entry[2]) else turn.target
+
+	turn.stat_key = stat_key
+	turn.stat_by = amount
+	turn.stat_target = side
+
+	if turn.failed_chance:
+		turn.stat_moved = false
+		return
+
+	turn.stat_moved = turn.battle.mon(side).change_stage(stat_key, amount)
+
+
+## Ancientpower's roll: the user's five real stats, all at once, reported as one
+## event rather than five. Accuracy and evasion are not among them, because the
+## cartridge's own command loops over the five a stage multiplies a real number
+## for and not the two that only have a table of their own.
+static func _all_stats_up(turn: Gen2Turn) -> void:
+	if turn.failed_chance:
+		return
+
+	var mon: Gen2BattleMon = turn.attacker()
+	var moved: bool = false
+	for key: String in ALL_STATS_KEYS:
+		if mon.change_stage(key, 1):
+			moved = true
+
+	if moved:
+		turn.emit(Gen2Battle.STAT_CHANGED, {"target": turn.side, "stat": "all", "by": 1})
+
+
+## Says a stat moved, or says nothing. A move whose sequence has no fail-text
+## step behind this, which is every secondary effect, is silent either way when
+## the stage was already at its limit.
+static func _stat_message(turn: Gen2Turn) -> void:
+	if not turn.stat_moved:
+		return
+	turn.emit(Gen2Battle.STAT_CHANGED, {
+		"target": turn.stat_target, "stat": turn.stat_key, "by": turn.stat_by,
+	})
+
+
+## Says a stat could not move. Only reached from a status move's own sequence,
+## which is the only place the cartridge follows a message step with this one.
+static func _stat_fail_text(turn: Gen2Turn) -> void:
+	if turn.stat_moved:
+		return
+	turn.emit(Gen2Battle.STAT_CHANGE_FAILED, {
+		"target": turn.stat_target, "stat": turn.stat_key, "by": turn.stat_by,
 	})

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -99,8 +99,11 @@ const PARALYZE_SEQUENCE: Array = [
 
 ## An attack that leaves something behind if its roll comes up. The damage is
 ## done either way: the roll sits between the hit and the status, so a failed one
-## costs the status and nothing else.
-static func _secondary(status_command: StringName) -> Array:
+## costs [param trailing] and nothing else. Most callers leave one command
+## behind; a stat change leaves two, the change and its message, because a
+## secondary effect never carries the fail-text step a status move's own
+## sequence has.
+static func _secondary(trailing: Array) -> Array:
 	return [
 		Gen2EffectCommands.USED_MOVE_TEXT,
 		Gen2EffectCommands.DO_TURN,
@@ -110,9 +113,102 @@ static func _secondary(status_command: StringName) -> Array:
 		Gen2EffectCommands.EFFECT_CHANCE,
 		Gen2EffectCommands.APPLY_DAMAGE,
 		Gen2EffectCommands.CHECK_FAINT,
-		status_command,
+	] + trailing + [Gen2EffectCommands.END_MOVE]
+
+
+## Where each run of seven starts, in the cartridge's own numbering. The seven
+## across a run are [constant Gen2BattleMon.STAGED_STATS] followed by
+## [constant Gen2BattleMon.STAGED_ODDS], which is also the order
+## [Gen2EffectCommands] keeps its per-stat command lists in, so a run and an
+## index into those lists are the same number.
+const STAT_UP_BASE: int = 10
+const STAT_DOWN_BASE: int = 18
+const STAT_UP_2_BASE: int = 50
+const STAT_DOWN_2_BASE: int = 58
+const STAT_DOWN_HIT_BASE: int = 68
+const STAT_RUN_LENGTH: int = 7
+
+## The two effect bytes a run does not reach. Metal Claw raises the user's
+## Attack on a roll and Ancientpower raises all five of them, and neither sits
+## in a run of its own: 139 falls where an eighth "down by one, on a hit" stat
+## would if there were one, and 140 is the byte after it.
+const ATTACK_UP_HIT: int = 139
+const ALL_STATS_UP_HIT: int = 140
+
+const STAT_UP_COMMANDS: Array = [
+	Gen2EffectCommands.ATTACK_UP, Gen2EffectCommands.DEFENSE_UP,
+	Gen2EffectCommands.SPEED_UP, Gen2EffectCommands.SP_ATTACK_UP,
+	Gen2EffectCommands.SP_DEFENSE_UP, Gen2EffectCommands.ACCURACY_UP,
+	Gen2EffectCommands.EVASION_UP,
+]
+const STAT_UP_2_COMMANDS: Array = [
+	Gen2EffectCommands.ATTACK_UP_2, Gen2EffectCommands.DEFENSE_UP_2,
+	Gen2EffectCommands.SPEED_UP_2, Gen2EffectCommands.SP_ATTACK_UP_2,
+	Gen2EffectCommands.SP_DEFENSE_UP_2, Gen2EffectCommands.ACCURACY_UP_2,
+	Gen2EffectCommands.EVASION_UP_2,
+]
+const STAT_DOWN_COMMANDS: Array = [
+	Gen2EffectCommands.ATTACK_DOWN, Gen2EffectCommands.DEFENSE_DOWN,
+	Gen2EffectCommands.SPEED_DOWN, Gen2EffectCommands.SP_ATTACK_DOWN,
+	Gen2EffectCommands.SP_DEFENSE_DOWN, Gen2EffectCommands.ACCURACY_DOWN,
+	Gen2EffectCommands.EVASION_DOWN,
+]
+const STAT_DOWN_2_COMMANDS: Array = [
+	Gen2EffectCommands.ATTACK_DOWN_2, Gen2EffectCommands.DEFENSE_DOWN_2,
+	Gen2EffectCommands.SPEED_DOWN_2, Gen2EffectCommands.SP_ATTACK_DOWN_2,
+	Gen2EffectCommands.SP_DEFENSE_DOWN_2, Gen2EffectCommands.ACCURACY_DOWN_2,
+	Gen2EffectCommands.EVASION_DOWN_2,
+]
+
+## A status move that only raises a stat: it cannot miss, so there is no roll in
+## its list, only the change, its message, and the text for when it was already
+## at the top.
+static func _stat_up_sequence(command: StringName) -> Array:
+	return [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		command,
+		Gen2EffectCommands.STAT_UP_MESSAGE,
+		Gen2EffectCommands.STAT_UP_FAIL_TEXT,
 		Gen2EffectCommands.END_MOVE,
 	]
+
+
+## A status move that lowers the foe's stat: it can miss, which is the one
+## difference from the list above and the reason Screech has a roll where Swords
+## Dance does not.
+static func _stat_down_sequence(command: StringName) -> Array:
+	return [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.CHECK_HIT,
+		command,
+		Gen2EffectCommands.STAT_DOWN_MESSAGE,
+		Gen2EffectCommands.STAT_DOWN_FAIL_TEXT,
+		Gen2EffectCommands.END_MOVE,
+	]
+
+
+## The seven-wide runs, walked once into a dictionary rather than written out by
+## hand. A wrong entry here would be a wrong number in a table that self-checks
+## nothing, which is why [code]tools/dump_tables.gd[/code] and the published
+## effect list are what settled the five bases in the first place, not this
+## function.
+static func _stat_sequences() -> Dictionary:
+	var out: Dictionary = {}
+	for offset: int in STAT_RUN_LENGTH:
+		out[STAT_UP_BASE + offset] = _stat_up_sequence(STAT_UP_COMMANDS[offset])
+		out[STAT_UP_2_BASE + offset] = _stat_up_sequence(STAT_UP_2_COMMANDS[offset])
+		out[STAT_DOWN_BASE + offset] = _stat_down_sequence(STAT_DOWN_COMMANDS[offset])
+		out[STAT_DOWN_2_BASE + offset] = _stat_down_sequence(STAT_DOWN_2_COMMANDS[offset])
+		out[STAT_DOWN_HIT_BASE + offset] = _secondary([
+			STAT_DOWN_COMMANDS[offset], Gen2EffectCommands.STAT_DOWN_MESSAGE,
+		])
+	out[ATTACK_UP_HIT] = _secondary([
+		STAT_UP_COMMANDS[0], Gen2EffectCommands.STAT_UP_MESSAGE,
+	])
+	out[ALL_STATS_UP_HIT] = _secondary([Gen2EffectCommands.ALL_STATS_UP])
+	return out
 
 
 ## Effect bytes that do something other than [constant NORMAL_HIT]. An effect
@@ -123,17 +219,19 @@ static func _secondary(status_command: StringName) -> Array:
 ## doubles every turn, counted on a substatus that nothing here carries yet, so
 ## it is currently the weaker thing it is closest to rather than nothing at all.
 static func _sequences() -> Dictionary:
-	return {
+	var out: Dictionary = {
 		SLEEP: SLEEP_SEQUENCE,
 		POISON: POISON_SEQUENCE,
 		TOXIC: POISON_SEQUENCE,
 		PARALYZE: PARALYZE_SEQUENCE,
-		POISON_HIT: _secondary(Gen2EffectCommands.POISON_TARGET),
-		BURN_HIT: _secondary(Gen2EffectCommands.BURN_TARGET),
-		FREEZE_HIT: _secondary(Gen2EffectCommands.FREEZE_TARGET),
-		PARALYZE_HIT: _secondary(Gen2EffectCommands.PARALYZE_TARGET),
+		POISON_HIT: _secondary([Gen2EffectCommands.POISON_TARGET]),
+		BURN_HIT: _secondary([Gen2EffectCommands.BURN_TARGET]),
+		FREEZE_HIT: _secondary([Gen2EffectCommands.FREEZE_TARGET]),
+		PARALYZE_HIT: _secondary([Gen2EffectCommands.PARALYZE_TARGET]),
 		RECOIL_HIT: RECOIL_HIT_SEQUENCE,
 	}
+	out.merge(_stat_sequences())
+	return out
 
 
 ## The commands a move with this effect byte is made of.

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -48,6 +48,14 @@ var ended: bool = false
 ## behind the roll is skipped.
 var failed_chance: bool = false
 
+## What a stat-changing command worked out, for the message command behind it.
+## [member stat_target] is who it happened to, which is the user for a raise and
+## the defender for almost every drop.
+var stat_key: String = ""
+var stat_by: int = 0
+var stat_target: int = Gen2Battle.PLAYER
+var stat_moved: bool = false
+
 
 static func create(
 	in_battle: Gen2Battle, acting: int, from_slot: int, number: int, move_data: Dictionary,

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -35,6 +35,17 @@ const EMBER_BURNS: int = 92
 const NEVER_BURNS: int = 93
 const FLAME_WHEEL: int = 172
 
+## The stat-changing moves, in the shapes the effect bytes come in: a pure raise,
+## a pure drop, a raise on hit, and a drop on hit that always rolls or never
+## does, the same trick [constant EMBER_BURNS] and [constant NEVER_BURNS] already
+## use.
+const SWORDS_DANCE: int = 14
+const SCREECH: int = 103
+const METAL_CLAW: int = 232
+const ANCIENTPOWER: int = 246
+const PSYCHIC_LOWERS: int = 210
+const PSYCHIC_NEVER: int = 211
+
 const NORMAL: int = 0x00
 const GROUND: int = 0x04
 const ROCK: int = 0x05
@@ -44,6 +55,7 @@ const FIRE: int = 0x14
 const WATER: int = 0x15
 const GRASS: int = 0x16
 const ELECTRIC: int = 0x17
+const PSYCHIC_TYPE: int = 0x18
 const POISON: int = 0x03
 const FLYING: int = 0x02
 
@@ -120,7 +132,7 @@ static func _moves() -> Array:
 	# plain attacks they were written against.
 	var known: Dictionary = {
 		TACKLE: ["TACKLE", 35, NORMAL, 255, 35, 0, 0],
-		GROWL: ["GROWL", 0, NORMAL, 255, 40, 18, 0],
+		GROWL: ["GROWL", 0, NORMAL, 255, 40, Gen2MoveEffect.STAT_DOWN_BASE, 0],
 		EMBER: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 0],
 		THUNDERBOLT: ["THUNDERBOLT", 95, ELECTRIC, 255, 15, Gen2MoveEffect.PARALYZE_HIT, 0],
 		SLASH: ["SLASH", 70, NORMAL, 255, 20, 0, 0],
@@ -133,10 +145,24 @@ static func _moves() -> Array:
 		EMBER_BURNS: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 256],
 		NEVER_BURNS: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 0],
 		FLAME_WHEEL: ["FLAME WHEEL", 60, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 0],
+		# Attack up by two, on the user, with no roll to miss.
+		SWORDS_DANCE: ["SWORDS DANCE", 0, NORMAL, 255, 30, Gen2MoveEffect.STAT_UP_2_BASE, 0],
+		# Defense down by two, on the foe, which can still miss.
+		SCREECH: ["SCREECH", 0, NORMAL, 216, 40, Gen2MoveEffect.STAT_DOWN_2_BASE + 1, 0],
+		# Attack up on the user, behind a roll, the way Metal Claw does it.
+		METAL_CLAW: ["METAL CLAW", 50, STEEL, 255, 35, Gen2MoveEffect.ATTACK_UP_HIT, 256],
+		# All five real stats up on the user, behind a roll, the way Ancientpower
+		# does it.
+		ANCIENTPOWER: ["ANCIENTPOWER", 60, ROCK, 255, 5, Gen2MoveEffect.ALL_STATS_UP_HIT, 256],
+		# Sp.Defense down on the foe, behind a roll, the way Psychic does it. One
+		# chance never fails and the other never does, the same trick
+		# [constant EMBER_BURNS] and [constant NEVER_BURNS] use for a status.
+		PSYCHIC_LOWERS: ["PSYCHIC", 90, PSYCHIC_TYPE, 255, 10, Gen2MoveEffect.STAT_DOWN_HIT_BASE + 4, 256],
+		PSYCHIC_NEVER: ["PSYCHIC", 90, PSYCHIC_TYPE, 255, 10, Gen2MoveEffect.STAT_DOWN_HIT_BASE + 4, 0],
 	}
 
 	var out: Array = []
-	for number: int in range(1, FLAME_WHEEL + 1):
+	for number: int in range(1, ANCIENTPOWER + 1):
 		var entry: Array = known.get(number, ["FILLER", 40, NORMAL, 255, 20, 0, 0])
 		out.append({
 			"number": number,

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -507,3 +507,47 @@ func test_a_secondary_effect_that_does_not_come_up_still_does_its_damage() -> vo
 	var events: Array = battle.take_turn(0, 0)
 	assert_gt(int(_first(events, Gen2Battle.HIT)["amount"]), 0)
 	assert_eq(battle.enemy.status, Gen2Status.NONE)
+
+
+func test_a_stat_drop_actually_bends_the_stat_the_damage_formula_reads() -> void:
+	# Not just an event: the stage has to reach Gen2BattleMon.stat() itself, which
+	# is what a battle asserted only on the event log would miss.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	var before: int = battle.player.stat("attack")
+	battle.take_turn(0, 0)
+	assert_lt(battle.player.stat("attack"), before)
+
+
+func test_ancientpower_raises_the_users_stats_as_one_event() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.ANCIENTPOWER]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(battle.player.stage("attack"), 1)
+	assert_eq(battle.player.stage("speed"), 1)
+	assert_eq(_of_type(events, Gen2Battle.STAT_CHANGED).size(), 1, "one event for all five")
+
+
+func test_a_secondary_stat_drop_that_never_rolls_still_deals_its_damage() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PSYCHIC_NEVER]),
+		_mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	assert_gt(int(_first(events, Gen2Battle.HIT)["amount"]), 0)
+	assert_eq(battle.enemy.stage("sp_defense"), 0)
+
+
+func test_a_status_move_that_cannot_rise_further_says_so() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SWORDS_DANCE]),
+		_mon(Fixture.MAGCARGO, 50, [Fixture.TACKLE])
+	)
+	battle.player.change_stage("attack", Gen2Stats.MAX_STAGE)
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.STAT_CHANGED).size(), 0)
+	assert_eq(_of_type(events, Gen2Battle.STAT_CHANGE_FAILED).size(), 1)

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -62,6 +62,91 @@ func test_recoil_is_the_ordinary_list_with_a_step_in_it() -> void:
 	)
 
 
+func test_the_stat_runs_land_on_the_right_stat() -> void:
+	# Effect 20 is the down-by-one run's third stop (18 + 2) and String Shot is
+	# published as lowering Speed; effect 72 is the down-on-hit run's fifth stop
+	# (68 + 4) and Psychic is published as lowering Sp.Defense. Both are the
+	# numbers most likely to be off by one, and neither shows up in a passing
+	# battle unless the wrong stat actually moves.
+	assert_true(Gen2MoveEffect.sequence_for(20).has(Gen2EffectCommands.SPEED_DOWN))
+	assert_true(
+		Gen2MoveEffect.sequence_for(72).has(Gen2EffectCommands.SP_DEFENSE_DOWN)
+	)
+
+
+func test_a_stat_that_only_rises_cannot_miss() -> void:
+	# Swords Dance's own effect byte, 50, is the first stop of the up-by-two run.
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.STAT_UP_2_BASE)
+	assert_false(sequence.has(Gen2EffectCommands.CHECK_HIT))
+	assert_true(sequence.has(Gen2EffectCommands.ATTACK_UP_2))
+
+
+func test_a_stat_that_can_be_lowered_can_also_be_missed() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.STAT_DOWN_BASE)
+	assert_true(sequence.has(Gen2EffectCommands.CHECK_HIT))
+	assert_lt(
+		sequence.find(Gen2EffectCommands.CHECK_HIT),
+		sequence.find(Gen2EffectCommands.ATTACK_DOWN)
+	)
+
+
+func test_a_stage_already_at_the_top_reports_failure_not_a_rise() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.attacker().change_stage("attack", Gen2Stats.MAX_STAGE)
+
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTACK_UP, turn)
+	Gen2EffectCommands.run(Gen2EffectCommands.STAT_UP_MESSAGE, turn)
+	Gen2EffectCommands.run(Gen2EffectCommands.STAT_UP_FAIL_TEXT, turn)
+
+	assert_eq(turn.attacker().stage("attack"), Gen2Stats.MAX_STAGE)
+	assert_eq(_first(turn.events, Gen2Battle.STAT_CHANGED), {})
+	assert_eq(int(_first(turn.events, Gen2Battle.STAT_CHANGE_FAILED)["by"]), 1)
+
+
+func test_a_secondary_effects_failed_roll_costs_the_stat_and_not_the_damage() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.failed_chance = true
+
+	Gen2EffectCommands.run(Gen2EffectCommands.SP_DEFENSE_DOWN, turn)
+	Gen2EffectCommands.run(Gen2EffectCommands.STAT_DOWN_MESSAGE, turn)
+
+	assert_eq(turn.defender().stage("sp_defense"), 0)
+	assert_eq(turn.events.size(), 0, "a failed roll behind a hit says nothing at all")
+
+
+func test_a_hit_based_stat_drop_that_fails_says_nothing() -> void:
+	# The one difference from a status move's own sequence: there is no fail-text
+	# step behind a secondary effect, so a stage already at the bottom is silent
+	# rather than reporting it could not go lower.
+	var turn: Gen2Turn = _turn(_battle())
+	turn.defender().change_stage("sp_defense", Gen2Stats.MIN_STAGE)
+
+	Gen2EffectCommands.run(Gen2EffectCommands.SP_DEFENSE_DOWN, turn)
+	Gen2EffectCommands.run(Gen2EffectCommands.STAT_DOWN_MESSAGE, turn)
+
+	assert_eq(turn.events.size(), 0)
+
+
+func test_ancientpower_raises_all_five_real_stats_as_one_event() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	Gen2EffectCommands.run(Gen2EffectCommands.ALL_STATS_UP, turn)
+
+	for key: String in ["attack", "defense", "speed", "sp_attack", "sp_defense"]:
+		assert_eq(turn.attacker().stage(key), 1, key)
+	assert_eq(turn.attacker().stage("accuracy"), 0, "not among the five it raises")
+	assert_eq(turn.events.size(), 1)
+	assert_eq(String(turn.events[0]["stat"]), "all")
+
+
+func test_ancientpower_does_nothing_behind_a_failed_roll() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.failed_chance = true
+	Gen2EffectCommands.run(Gen2EffectCommands.ALL_STATS_UP, turn)
+
+	assert_eq(turn.attacker().stage("attack"), 0)
+	assert_eq(turn.events.size(), 0)
+
+
 func test_a_turn_knows_who_is_on_the_other_side_of_it() -> void:
 	var battle: Gen2Battle = _battle()
 	var turn: Gen2Turn = _turn(battle)


### PR DESCRIPTION
The five contiguous runs of effect bytes for raising and lowering a stat (up by one, down by one, up by two, down by two, down by one on a hit) now get their own command sequences instead of falling back to an ordinary attack. Metal Claw and Ancientpower, the two on-hit raises outside those runs, are written the same way.

Gen2BattleMon.change_stage already answered whether a stage actually moved; what was missing was the command shape around it, generated from the run bases the same way the status conditions generate theirs from _secondary(), rather than 37 sequences written out by hand.