### PR TITLE
Give Pokemon a second byte of battle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ the same thing for Generation 1.
 > verified cartridge decodes into species data, moves, items, types, the type
 > chart, learnsets, evolutions, palettes, every Pokémon sprite, every trainer
 > pic, the font, the text box borders and the battle HUD. A battle can be
-> fought: parties, switching, stats, damage, accuracy, turn order and the five
-> status conditions, on a real 160x144 screen with the bars draining and the
-> messages appearing. Every move effect other than the status ones is still an
-> ordinary attack, and the overworld, audio and the mod loader do not exist.
+> fought: parties, switching, stats, damage, accuracy, turn order, the five
+> status conditions, confusion, flinching, two-turn moves, recharging, Toxic,
+> Haze, Belly Drum and Psych Up, on a real 160x144 screen with the bars
+> draining and the messages appearing. Disable, Attract, multi-hit moves,
+> drain moves, OHKOs, Counter and the fixed-damage moves are still an ordinary
+> attack, and the overworld, audio and the mod loader do not exist.
 > There is nothing playable here today.
 
 ## Getting started

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -102,6 +102,7 @@ battle can be fought inside a test:
 | `battle/battle_mon.gd` | One Pokémon: its stats, PP, health and stages |
 | `battle/party.gd` | The six a side carries, and which of them is out |
 | `battle/status.gd` | The status byte, and the four things it does |
+| `battle/substatus.gd` | The second byte: confusion, flinching, a charge, a recharge |
 | `battle/turn.gd` | One move being used, while it is being used |
 | `battle/effect_commands.gd` | The steps a move is made of |
 | `battle/move_effect.gd` | Which steps each effect byte is made of |
@@ -172,6 +173,22 @@ next hundred of them have nowhere to go. The command names are the cartridge's
 own so a sequence can be read against `data/moves/effects.asm` line for line,
 and an effect with no list of its own falls back to the ordinary attack, which
 is why a move nobody has written yet behaves rather than doing nothing.
+
+`battle/status.gd` is one status byte, one at a time, refusing a second rather
+than adding it. `battle/substatus.gd` is everything that does not fit on that
+byte because a Pokémon can carry several of it at once: confusion alongside a
+burn, a two-turn move's charge alongside either. It is the same shape, flag
+constants and pure arithmetic holding no state of its own, but the counters
+that go with a flag (how many turns of confusion are left, which move was
+charged, how ramped a Toxic is) live on `Gen2BattleMon` next to it rather than
+packed into the byte, because `Gen2Turn` is discarded at the end of the move
+that needed them and the byte alone cannot say "and three turns of it". All of
+it clears on a switch, in `Gen2BattleMon.reset_volatile`, called from
+`Gen2Party.send_out` alongside `reset_stages` rather than folded into it: Haze
+resets stages on both sides without touching either one's volatiles, so the two
+have to stay two calls. A flag added here and forgotten in `reset_volatile` is
+a bug that only shows up after a switch, which is why one test exists purely to
+set every volatile field and ask for a blank Pokémon back.
 
 `Gen2Battle` answers a turn with a list of events rather than with a new state
 or a string. An event says what happened and carries the numbers behind it, so a

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -34,13 +34,31 @@ const HIT: StringName = &"hit"
 const RECOIL: StringName = &"recoil"
 const FAINTED: StringName = &"fainted"
 ## A status stopped a Pokémon moving. [code]reason[/code] says which one, since
-## the three read differently and only one of them is a surprise.
+## the six read differently and not all of them are a surprise: [code]&"sleep"[/code],
+## [code]&"freeze"[/code], [code]&"paralysis"[/code], [code]&"flinch"[/code],
+## [code]&"recharge"[/code].
 const CANNOT_MOVE: StringName = &"cannot_move"
 const WOKE_UP: StringName = &"woke_up"
 const THAWED: StringName = &"thawed"
 ## A status put on a Pokémon, and a slice taken off by one it already had.
 const STATUS_INFLICTED: StringName = &"status_inflicted"
 const HURT_BY_STATUS: StringName = &"hurt_by_status"
+## Confusion put on a target. Not [constant STATUS_INFLICTED]: confusion lives
+## on [Gen2Substatus] rather than the status byte, and a Pokémon can carry both
+## at once.
+const CONFUSE_INFLICTED: StringName = &"confuse_inflicted"
+## Confusion said every turn it is still there, and the turn it lifts.
+const CONFUSED: StringName = &"confused"
+const SNAPPED_OUT: StringName = &"snapped_out"
+## A confused Pokémon hit itself instead of moving.
+const HURT_ITSELF: StringName = &"hurt_itself"
+## The first half of a two-turn move: the user is locked in and nothing else
+## happens this turn. See [method move_for] for the second half.
+const CHARGING_UP: StringName = &"charging_up"
+## Haze: every stage on both sides is gone. About both sides, like [constant OVER].
+const STAGES_CLEARED: StringName = &"stages_cleared"
+## Psych Up: the target's stages, now the user's too.
+const STAGES_COPIED: StringName = &"stages_copied"
 ## A stat moved a stage, or tried to and could not. [code]stat[/code] is the key
 ## [Gen2BattleMon] keeps it under, or [code]"all"[/code] for the five Ancientpower
 ## moves at once; [code]by[/code] is how many stages, signed.
@@ -252,6 +270,11 @@ func take_turn(player_slot: int, enemy_slot: int) -> Array:
 ## After both moves rather than after each, and skipping whoever is already down:
 ## a Pokémon that has fainted this turn is not burned any further, and one that
 ## goes down to its burn faints here rather than in the middle of somebody's move.
+##
+## A poisoned Pokémon with a running [member Gen2BattleMon.toxic_counter] is
+## the one Toxic left, and it ramps instead of taking the flat eighth every
+## other poison and every burn take; the counter itself goes up here, once a
+## turn, so the turn it was inflicted on counts as the first.
 func _residual_damage(acting: Array, events: Array) -> void:
 	for side: int in acting:
 		var current: Gen2BattleMon = mon(side)
@@ -260,7 +283,14 @@ func _residual_damage(acting: Array, events: Array) -> void:
 		if not Gen2Status.has(current.status, Gen2Status.BURN | Gen2Status.POISON):
 			continue
 
-		var taken: int = current.take_damage(Gen2Status.residual_damage(current.max_hp()))
+		var amount: int
+		if Gen2Status.has(current.status, Gen2Status.POISON) and current.toxic_counter > 0:
+			amount = Gen2Status.toxic_damage(current.max_hp(), current.toxic_counter)
+			current.toxic_counter += 1
+		else:
+			amount = Gen2Status.residual_damage(current.max_hp())
+
+		var taken: int = current.take_damage(amount)
 		events.append({
 			"type": HURT_BY_STATUS,
 			"side": side,
@@ -289,13 +319,19 @@ func _move_for_action(side: int, action: Dictionary) -> int:
 
 ## Which move a side will actually use.
 ##
-## A slot with nothing usable in it answers Struggle, which is the cartridge's
-## answer for a Pokémon with no PP anywhere. Here it is also the answer for a
-## slot that is empty or spent while others are not, because a caller that points
-## at one has asked for something that cannot happen, and Struggle is the only
-## move that is always available.
+## A Pokémon locked into a two-turn move's release turn answers with what it
+## charged, whatever slot the caller asks for: on the cartridge nothing is
+## chosen on that turn at all, so nothing here is either.
+##
+## Failing that, a slot with nothing usable in it answers Struggle, which is
+## the cartridge's answer for a Pokémon with no PP anywhere. Here it is also the
+## answer for a slot that is empty or spent while others are not, because a
+## caller that points at one has asked for something that cannot happen, and
+## Struggle is the only move that is always available.
 func move_for(side: int, slot: int) -> int:
 	var attacker: Gen2BattleMon = mon(side)
+	if attacker.charged_move != 0:
+		return attacker.charged_move
 	return int(attacker.moves[slot]) if attacker.can_use(slot) else Gen2Damage.STRUGGLE
 
 
@@ -355,6 +391,10 @@ func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 		return
 
 	var turn: Gen2Turn = Gen2Turn.create(self, side, slot, move_number, move, events)
+	# The release turn of a two-turn move: the PP for it was already spent on
+	# the charge turn, and [method Gen2EffectCommands._do_turn] reads this so it
+	# is not spent again.
+	turn.locked = mon(side).charged_move == move_number and move_number != 0
 
 	# Whether the Pokémon can move at all is asked before the effect is looked up,
 	# which is the cartridge's arrangement: every move goes through it, so no

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -52,6 +52,23 @@ var stages: Dictionary = {}
 ## rather than with them.
 var status: int = Gen2Status.NONE
 
+## The second byte: see [Gen2Substatus]. Unlike [member status] this one clears
+## on a switch, along with the counters below it, which is what makes it
+## volatile rather than a status.
+var substatus: int = Gen2Substatus.NONE
+
+## How many turns of confusion are left, meaningful only while
+## [constant Gen2Substatus.CONFUSED] is set.
+var confusion_turns: int = 0
+
+## The move a two-turn move locked this Pokémon into, meaningful only while
+## [constant Gen2Substatus.CHARGING] is set. Zero means nothing is charged.
+var charged_move: int = 0
+
+## How many turns a badly poisoned Pokémon has been poisoned, which is what
+## Toxic's damage ramps on. Zero unless actually toxic.
+var toxic_counter: int = 0
+
 
 ## Builds a Pokémon at a level, at full health, knowing [param moves].
 ##
@@ -165,6 +182,17 @@ func reset_stages() -> void:
 	stages = {}
 	for key: String in STAGED_STATS + STAGED_ODDS:
 		stages[key] = 0
+
+
+## Clears everything [Gen2Substatus] holds, and the counters that go with it.
+## Called on a switch, alongside but separately from [method reset_stages]:
+## Haze resets the stages on both sides without touching either one's
+## volatiles, so the two have to stay two calls rather than become one.
+func reset_volatile() -> void:
+	substatus = Gen2Substatus.NONE
+	confusion_turns = 0
+	charged_move = 0
+	toxic_counter = 0
 
 
 ## The two type numbers, which are the same number twice for a single-type

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -45,11 +45,14 @@ const STOPPED_BY: Dictionary = {
 	&"sleep": "is fast asleep!",
 	&"freeze": "is frozen solid!",
 	&"paralysis": "is fully paralyzed!",
+	&"flinch": "flinched!",
+	&"recharge": "must recharge!",
 }
 
 const INFLICTED: Dictionary = {
 	&"sleep": "fell asleep!",
 	&"poison": "was poisoned!",
+	&"toxic": "was badly poisoned!",
 	&"burn": "was burned!",
 	&"freeze": "was frozen solid!",
 	&"paralysis": "is paralyzed!",
@@ -331,7 +334,7 @@ func _apply_event(event: Dictionary) -> void:
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
-		Gen2Battle.HURT_BY_STATUS:
+		Gen2Battle.HURT_BY_STATUS, Gen2Battle.HURT_ITSELF:
 			if int(event["side"]) == Gen2Battle.ENEMY:
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
@@ -388,6 +391,22 @@ func _describe(event: Dictionary) -> String:
 			]
 		Gen2Battle.HURT_BY_STATUS:
 			return "%s is hurt by its %s!" % [_battler_name(side), event["name"]]
+		Gen2Battle.CONFUSE_INFLICTED:
+			return "%s became confused!" % _battler_name(int(event["target"]))
+		Gen2Battle.CONFUSED:
+			return "%s is confused!" % _battler_name(side)
+		Gen2Battle.SNAPPED_OUT:
+			return "%s snapped out of confusion!" % _battler_name(side)
+		Gen2Battle.HURT_ITSELF:
+			return "It hurt itself in its confusion!"
+		Gen2Battle.CHARGING_UP:
+			# The real games print a line of the move's own, which nothing here has
+			# a source for yet; this is the one sentence every two-turn move shares.
+			return "%s is charging up its power!" % _battler_name(side)
+		Gen2Battle.STAGES_CLEARED:
+			return "All stat changes were eliminated!"
+		Gen2Battle.STAGES_COPIED:
+			return "%s copied the target's stat changes!" % _battler_name(side)
 		Gen2Battle.STAT_CHANGED:
 			return _stat_changed_text(event)
 		Gen2Battle.STAT_CHANGE_FAILED:

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -50,6 +50,11 @@ const STRUGGLE: int = 0xA5
 const STAB_NUMERATOR: int = 3
 const STAB_DENOMINATOR: int = 2
 
+## What a confused Pokémon hits itself for: a 40-power typeless physical hit
+## against its own Attack and Defense. Neither side's type comes into it, so
+## there is no STAB and no matchup, and it is never a critical.
+const CONFUSION_POWER: int = 40
+
 
 ## A hit, rolled. Returns what [method calculate_with] returns.
 static func calculate(
@@ -187,6 +192,16 @@ static func critical_level(move_number: int, focus_energy: bool = false) -> int:
 
 static func roll_variation(rng: RandomNumberGenerator) -> int:
 	return rng.randi_range(MIN_VARIATION, MAX_VARIATION)
+
+
+## What a confused Pokémon does to itself instead of moving: its own Attack
+## against its own Defense, with the stages and any burn applied exactly as an
+## ordinary physical hit would read them, but no STAB, no type matchup and no
+## critical, because the hit is not really an attack at all.
+static func confusion_damage(mon: Gen2BattleMon, rng: RandomNumberGenerator) -> int:
+	var damage: int = base_damage(mon.level, CONFUSION_POWER, mon.stat("attack"), mon.stat("defense"))
+	damage = mini(damage, DAMAGE_CAP) + MIN_DAMAGE
+	return apply_variation(damage, roll_variation(rng))
 
 
 ## Whether a move is worked out from Attack or from Special Attack.

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -73,6 +73,46 @@ const BURN_TARGET: StringName = &"burntarget"
 const FREEZE_TARGET: StringName = &"freezetarget"
 const PARALYZE_TARGET: StringName = &"paralyzetarget"
 
+## What Toxic leaves behind: the same poison flag [constant POISON_TARGET]
+## leaves, plus the ramping counter that makes it Toxic rather than an ordinary
+## poison. Its own command rather than [constant POISON_TARGET] with an extra
+## step after it, because the counter has to start before the first residual
+## turn sees it, and nothing else needs a command that touches both.
+const TOXIC_TARGET: StringName = &"toxictarget"
+
+## The two things a move can leave on [Gen2Substatus] rather than the status
+## byte. Flinch is only ever a secondary effect, so it obeys
+## [member Gen2Turn.failed_chance] the same way the five above do; confusion
+## comes both ways, as a status move of its own (Confuse Ray, Supersonic) and
+## as a secondary effect (Confusion, Psybeam), which is why [Gen2MoveEffect]
+## reaches for this command from both shapes of sequence.
+const FLINCH_TARGET: StringName = &"flinchtarget"
+const CONFUSE_TARGET: StringName = &"confusetarget"
+
+## Recharge: locks the user out of its next turn, the tail of Hyper Beam's own
+## list rather than anything a target-facing command touches.
+const RECHARGE: StringName = &"recharge"
+
+## A two-turn move's charge. The first time it is run it locks the user in,
+## announces the charge and ends the move there; the second time, it is the
+## release turn, so it clears the lock and lets the rest of the list run as an
+## ordinary attack. [Gen2Battle._act] is what makes sure the second call is the
+## user's only option: see [method Gen2Battle.move_for].
+const CHARGE_MOVE: StringName = &"chargemove"
+
+## Clears every stage on both sides. Only the stages: nothing here touches
+## either Pokémon's status byte or [Gen2Substatus].
+const HAZE: StringName = &"haze"
+
+## Costs half the user's maximum HP to raise its own Attack straight to the top
+## of its range. Fails without costing anything if the user does not have more
+## than half its health, or if Attack is already there.
+const BELLY_DRUM: StringName = &"bellydrum"
+
+## Copies the target's stages onto the user, all seven at once. Fails if the
+## target has nothing raised or lowered to copy.
+const PSYCH_UP: StringName = &"psychup"
+
 ## Raises and lowers a stat by one stage or two, named the way the cartridge
 ## names them and in the order [constant Gen2BattleMon.STAGED_STATS] plus
 ## [constant Gen2BattleMon.STAGED_ODDS] already keeps the seven in, because that
@@ -209,6 +249,22 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_status_target(turn, Gen2Status.FREEZE)
 		PARALYZE_TARGET:
 			_status_target(turn, Gen2Status.PARALYSIS)
+		TOXIC_TARGET:
+			_toxic_target(turn)
+		FLINCH_TARGET:
+			_flinch_target(turn)
+		CONFUSE_TARGET:
+			_confuse_target(turn)
+		RECHARGE:
+			_recharge(turn)
+		CHARGE_MOVE:
+			_charge_move(turn)
+		HAZE:
+			_haze(turn)
+		BELLY_DRUM:
+			_belly_drum(turn)
+		PSYCH_UP:
+			_psych_up(turn)
 		ALL_STATS_UP:
 			_all_stats_up(turn)
 		STAT_UP_MESSAGE, STAT_DOWN_MESSAGE:
@@ -227,8 +283,12 @@ static func _used_move_text(turn: Gen2Turn) -> void:
 
 
 ## Struggle is what a Pokémon does when there is nothing left to spend, so it
-## spends nothing, and it is the one move that arrives without a slot.
+## spends nothing, and it is the one move that arrives without a slot. Neither
+## does the release turn of a two-turn move: the PP for it went on the charge
+## turn, which is what [member Gen2Turn.locked] means here.
 static func _do_turn(turn: Gen2Turn) -> void:
+	if turn.locked:
+		return
 	if turn.slot >= 0 and turn.move_number != Gen2Damage.STRUGGLE:
 		turn.attacker().spend_pp(turn.slot)
 
@@ -293,16 +353,30 @@ static func _check_faint(turn: Gen2Turn) -> void:
 			turn.events.append({"type": Gen2Battle.FAINTED, "side": side})
 
 
-## Sleep, then freeze, then paralysis, which is the order the cartridge asks in.
-## A frozen Pokémon is never asked whether it is also paralysed, because the byte
-## cannot say both.
+## Recharge, then sleep, then freeze, then flinch, then confusion, then
+## paralysis, which is the cartridge's own order in [code]CheckPlayerTurn[/code].
+## Disable and Attract sit between flinch and confusion on the cartridge and are
+## not written yet; nothing here skips a slot for them because neither writes
+## [Gen2Substatus] yet either.
+##
+## A frozen Pokémon is never asked whether it is also paralysed, because the
+## status byte cannot say both; a confused Pokémon that hits itself is never
+## asked about paralysis either, because it has already spent its turn.
 ##
 ## Waking up does not cost the turn. The cartridge counts the sleep off, prints
 ## that the Pokémon woke, and carries on into the rest of its checks rather than
 ## ending the turn, so a Pokémon whose counter runs out attacks the same turn it
-## opens its eyes. That is Generation 2's rule and not Generation 1's.
+## opens its eyes. That is Generation 2's rule and not Generation 1's. Snapping
+## out of confusion works the same way: the counter reaching zero clears the
+## flag and lets the move through the same turn.
 static func _check_status(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
+
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.RECHARGING):
+		mon.substatus &= ~Gen2Substatus.RECHARGING
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"recharge"})
+		turn.end()
+		return
 
 	if Gen2Status.is_asleep(mon.status):
 		mon.status = Gen2Status.tick_sleep(mon.status)
@@ -321,6 +395,27 @@ static func _check_status(turn: Gen2Turn) -> void:
 			return
 		mon.status &= ~Gen2Status.FREEZE
 		turn.emit(Gen2Battle.THAWED)
+
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.FLINCHED):
+		mon.substatus &= ~Gen2Substatus.FLINCHED
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"flinch"})
+		turn.end()
+		return
+
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.CONFUSED):
+		mon.confusion_turns -= 1
+		if mon.confusion_turns <= 0:
+			mon.substatus &= ~Gen2Substatus.CONFUSED
+			turn.emit(Gen2Battle.SNAPPED_OUT)
+		else:
+			turn.emit(Gen2Battle.CONFUSED)
+			if Gen2Substatus.rolls_confusion_hit(turn.rng()):
+				var dealt: int = mon.take_damage(Gen2Damage.confusion_damage(mon, turn.rng()))
+				turn.emit(Gen2Battle.HURT_ITSELF, {
+					"amount": dealt, "hp": mon.hp, "max_hp": mon.max_hp(),
+				})
+				turn.end()
+				return
 
 	if Gen2Status.has(mon.status, Gen2Status.PARALYSIS) \
 		and Gen2Status.rolls_full_paralysis(turn.rng()):
@@ -364,6 +459,138 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 		"status": defender.status,
 		"name": Gen2Status.name_of(defender.status),
 	})
+
+
+## Poisons the target the way [constant POISON_TARGET] does, and starts the
+## counter that makes it Toxic rather than an ordinary poison: see
+## [method Gen2Status.toxic_damage], which reads it back at the end of every
+## turn from here on.
+static func _toxic_target(turn: Gen2Turn) -> void:
+	if turn.failed_chance:
+		return
+
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.is_fainted() or Gen2Status.is_afflicted(defender.status):
+		return
+
+	defender.status |= Gen2Status.POISON
+	defender.toxic_counter = 1
+	turn.emit(Gen2Battle.STATUS_INFLICTED, {
+		"target": turn.target, "status": defender.status, "name": &"toxic",
+	})
+
+
+## Sets the target flinching, for [constant CHECK_STATUS] to catch on its turn.
+## Only ever a secondary effect, so it obeys [member Gen2Turn.failed_chance] the
+## same way a status target does; a fainted target cannot be made to flinch on
+## a turn it will not take.
+static func _flinch_target(turn: Gen2Turn) -> void:
+	if turn.failed_chance:
+		return
+
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.is_fainted():
+		return
+
+	defender.substatus |= Gen2Substatus.FLINCHED
+
+
+## Sets the target confused and rolls how long for, or fails. A Pokémon already
+## confused is refused rather than having its counter restarted, which is the
+## rule [Gen2Substatus.CONFUSED] enforces the same way the status byte enforces
+## it for sleep, poison, burn, freeze and paralysis, except that confusion sits
+## alongside a status rather than instead of one: a poisoned Pokémon can still
+## be confused.
+static func _confuse_target(turn: Gen2Turn) -> void:
+	if turn.failed_chance:
+		return
+
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.is_fainted() or Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED):
+		return
+
+	defender.substatus |= Gen2Substatus.CONFUSED
+	defender.confusion_turns = Gen2Substatus.roll_confusion(turn.rng())
+
+	# Not [constant Gen2Battle.STATUS_INFLICTED]: that event's [code]status[/code]
+	# field is the status byte, and confusion never touches it.
+	turn.emit(Gen2Battle.CONFUSE_INFLICTED, {"target": turn.target})
+
+
+## Locks the user out of its next turn. The tail of Hyper Beam's own list,
+## always reached: there is no roll behind it and nothing it can fail against.
+static func _recharge(turn: Gen2Turn) -> void:
+	turn.attacker().substatus |= Gen2Substatus.RECHARGING
+
+
+## A two-turn move's charge, in the shape [code]docs/CONTRIBUTING.md[/code]
+## already describes: a list that ends early the first time.
+##
+## Not charging yet: locks the user in, announces it and ends the move before
+## the damage is even worked out. Already charging, which is the release turn:
+## clears the lock and falls through into the rest of the list, which is an
+## ordinary attack from here. [method Gen2Battle.move_for] is what guarantees
+## the release turn's move is the one that was charged, whatever slot the
+## caller asks for.
+static func _charge_move(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING):
+		mon.substatus &= ~Gen2Substatus.CHARGING
+		mon.charged_move = 0
+		return
+
+	mon.substatus |= Gen2Substatus.CHARGING
+	mon.charged_move = turn.move_number
+	turn.emit(Gen2Battle.CHARGING_UP)
+	turn.end()
+
+
+## Haze: every stage on both sides, back to nothing. Not [Gen2Substatus] and not
+## the status byte, either side's: only what [method Gen2BattleMon.reset_stages]
+## already resets on a switch is reset here on demand.
+static func _haze(turn: Gen2Turn) -> void:
+	turn.battle.mon(Gen2Battle.PLAYER).reset_stages()
+	turn.battle.mon(Gen2Battle.ENEMY).reset_stages()
+	turn.emit(Gen2Battle.STAGES_CLEARED)
+
+
+## Belly Drum. Fails, and costs nothing, unless the user has more than half its
+## maximum HP and Attack has somewhere left to go; otherwise it takes half the
+## maximum off and sends Attack straight to the top, however far short of it
+## the stage already was.
+static func _belly_drum(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	var has_enough_hp: bool = mon.hp * 2 > mon.max_hp()
+	var stage: int = mon.stage("attack")
+	if not has_enough_hp or stage >= Gen2Stats.MAX_STAGE:
+		turn.emit(Gen2Battle.STAT_CHANGE_FAILED, {"target": turn.side, "stat": "attack", "by": 6})
+		return
+
+	@warning_ignore("integer_division")
+	mon.take_damage(mon.max_hp() / 2)
+	mon.change_stage("attack", Gen2Stats.MAX_STAGE - stage)
+	turn.emit(Gen2Battle.STAT_CHANGED, {"target": turn.side, "stat": "attack", "by": 6})
+
+
+## Psych Up: the target's seven stages, copied onto the user in one go, or a
+## failure if the target has nothing raised or lowered for there to be anything
+## to copy.
+static func _psych_up(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	var defender: Gen2BattleMon = turn.defender()
+	var keys: Array = Gen2BattleMon.STAGED_STATS + Gen2BattleMon.STAGED_ODDS
+
+	var defender_changed: bool = false
+	for key: String in keys:
+		if int(defender.stages.get(key, 0)) != 0:
+			defender_changed = true
+			break
+	if not defender_changed:
+		return
+
+	for key: String in keys:
+		attacker.stages[key] = int(defender.stages.get(key, 0))
+	turn.emit(Gen2Battle.STAGES_COPIED)
 
 
 ## Moves one stat by one command's worth, and writes down who it happened to and

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -34,6 +34,39 @@ const RECOIL_HIT: int = 48
 const POISON: int = 66
 const PARALYZE: int = 67
 
+## The substatuses: flinching and confusion, each in the two shapes a status
+## can come in, plus Hyper Beam's own effect, which is the only move that
+## recharges. The numbers are read off the real cartridge's move table with
+## [code]tools/dump_tables.gd[/code], the same way every other effect byte here
+## was: Rolling Kick, Headbutt, Bite, Bone Club and Hyper Fang all carry 31;
+## Confusion and Psybeam carry 76; Supersonic and Confuse Ray carry 49; Hyper
+## Beam alone carries 80.
+const FLINCH_HIT: int = 31
+const CONFUSE_HIT: int = 76
+const CONFUSE: int = 49
+const RECHARGE_HIT: int = 80
+
+## The two-turn moves: charge on the first turn, hit on the second. Razor Wind,
+## Solarbeam, Fly and Dig share the plain shape; Sky Attack and Skull Bash each
+## add one thing behind the hit, which is why they keep their own effect byte
+## rather than folding into the plain one. Fly and Dig share 155 with each
+## other and nothing else, since both leave the field for their charge turn on
+## the cartridge, which nothing here models yet: see [code]HANDOFF.md[/code].
+const RAZOR_WIND: int = 39
+const SKY_ATTACK: int = 75
+const SKULL_BASH: int = 145
+const SOLARBEAM: int = 151
+const FLY_OR_DIG: int = 155
+
+## None of the three needs any state this file has not already grown for
+## something else: [Gen2BattleMon.reset_stages] for Haze,
+## [method Gen2BattleMon.change_stage] and [method Gen2BattleMon.take_damage]
+## for Belly Drum, and reading one side's stages to write the other's for
+## Psych Up.
+const HAZE: int = 25
+const BELLY_DRUM: int = 142
+const PSYCH_UP: int = 143
+
 ## An ordinary attack: say it, spend it, work it out, roll it, apply it, and see
 ## who is standing. Everything else is this with steps moved.
 const NORMAL_HIT: Array = [
@@ -83,6 +116,18 @@ const POISON_SEQUENCE: Array = [
 	Gen2EffectCommands.END_MOVE,
 ]
 
+## Toxic: the same shape as [constant POISON_SEQUENCE], with the command that
+## starts the ramping counter in place of the one that leaves a flat poison.
+const TOXIC_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.TOXIC_TARGET,
+	Gen2EffectCommands.END_MOVE,
+]
+
 ## The matchup before the roll rather than after it, which is the order the
 ## cartridge lists them in and the reason Thunder Wave against a Ground type says
 ## it had no effect rather than that it missed.
@@ -93,6 +138,107 @@ const PARALYZE_SEQUENCE: Array = [
 	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.PARALYZE_TARGET,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Supersonic and Confuse Ray: no power, so no matchup step either, the same
+## shape as [constant SLEEP_SEQUENCE].
+const CONFUSE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.CONFUSE_TARGET,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Hyper Beam: an ordinary attack with the recharge locked in behind the hit,
+## which is why it sits after [constant Gen2EffectCommands.CHECK_HIT] rather
+## than before it. A miss ends the move at [constant Gen2EffectCommands.CHECK_HIT]
+## the way any other miss does, so a missed Hyper Beam costs nothing extra.
+const RECHARGE_HIT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.RECHARGE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Razor Wind, Solarbeam, Fly and Dig: a normal attack with the charge in front
+## of it. The first time this runs, [constant Gen2EffectCommands.CHARGE_MOVE]
+## ends the move before [constant Gen2EffectCommands.DAMAGE_CALC] is reached;
+## the second time, it clears the lock and everything after it is
+## [constant NORMAL_HIT] again.
+const CHARGE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Sky Attack: the same charge, with a flinch chance behind the hit exactly the
+## way [constant FLINCH_HIT] carries one. The real cartridge's own move table
+## gives it a chance of zero, which is never, so this is written the way the
+## disassembly has it rather than left out: a flinch that cannot come up reads
+## the same as no flinch at all, and nothing here should assume that stays true
+## forever.
+const SKY_ATTACK_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.EFFECT_CHANCE,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.FLINCH_TARGET,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Skull Bash: the same charge, with the user's own Defense raised by one stage
+## behind the hit landing, which is the one thing that sets it apart from
+## [constant CHARGE_SEQUENCE].
+const SKULL_BASH_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.DEFENSE_UP,
+	Gen2EffectCommands.STAT_UP_MESSAGE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const HAZE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.HAZE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const BELLY_DRUM_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.BELLY_DRUM,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const PSYCH_UP_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.PSYCH_UP,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -214,21 +360,29 @@ static func _stat_sequences() -> Dictionary:
 ## Effect bytes that do something other than [constant NORMAL_HIT]. An effect
 ## that is not in here is an ordinary attack, which is what most of the table is
 ## and what an effect nobody has written yet falls back to.
-##
-## Toxic shares the ordinary poison list. On the cartridge it is a poison that
-## doubles every turn, counted on a substatus that nothing here carries yet, so
-## it is currently the weaker thing it is closest to rather than nothing at all.
 static func _sequences() -> Dictionary:
 	var out: Dictionary = {
 		SLEEP: SLEEP_SEQUENCE,
 		POISON: POISON_SEQUENCE,
-		TOXIC: POISON_SEQUENCE,
+		TOXIC: TOXIC_SEQUENCE,
 		PARALYZE: PARALYZE_SEQUENCE,
 		POISON_HIT: _secondary([Gen2EffectCommands.POISON_TARGET]),
 		BURN_HIT: _secondary([Gen2EffectCommands.BURN_TARGET]),
 		FREEZE_HIT: _secondary([Gen2EffectCommands.FREEZE_TARGET]),
 		PARALYZE_HIT: _secondary([Gen2EffectCommands.PARALYZE_TARGET]),
 		RECOIL_HIT: RECOIL_HIT_SEQUENCE,
+		FLINCH_HIT: _secondary([Gen2EffectCommands.FLINCH_TARGET]),
+		CONFUSE_HIT: _secondary([Gen2EffectCommands.CONFUSE_TARGET]),
+		CONFUSE: CONFUSE_SEQUENCE,
+		RECHARGE_HIT: RECHARGE_HIT_SEQUENCE,
+		RAZOR_WIND: CHARGE_SEQUENCE,
+		SOLARBEAM: CHARGE_SEQUENCE,
+		FLY_OR_DIG: CHARGE_SEQUENCE,
+		SKY_ATTACK: SKY_ATTACK_SEQUENCE,
+		SKULL_BASH: SKULL_BASH_SEQUENCE,
+		HAZE: HAZE_SEQUENCE,
+		BELLY_DRUM: BELLY_DRUM_SEQUENCE,
+		PSYCH_UP: PSYCH_UP_SEQUENCE,
 	}
 	out.merge(_stat_sequences())
 	return out

--- a/game/battle/party.gd
+++ b/game/battle/party.gd
@@ -91,10 +91,11 @@ func first_healthy() -> int:
 
 ## Puts [param index] out, and answers whether it went.
 ##
-## The Pokémon leaving keeps its health and its PP and loses its stat stages,
-## which is the cartridge's rule and the reason a stage is worth resetting rather
-## than a Pokémon worth rebuilding: a stage is a lens on a stat and the lens does
-## not survive the walk back to the ball.
+## The Pokémon leaving keeps its health and its PP and loses its stat stages and
+## everything [Gen2Substatus] holds, which is the cartridge's rule and the
+## reason a stage is worth resetting rather than a Pokémon worth rebuilding: a
+## stage is a lens on a stat and the lens does not survive the walk back to the
+## ball, and confusion, a charge or a recharge do not survive it either.
 func send_out(index: int) -> bool:
 	if not can_send_out(index):
 		return false
@@ -102,5 +103,6 @@ func send_out(index: int) -> bool:
 	var leaving: Gen2BattleMon = active_mon()
 	if leaving != null:
 		leaving.reset_stages()
+		leaving.reset_volatile()
 	active = index
 	return true

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -48,6 +48,11 @@ const CHANCE_RANGE: int = 256
 ## Burn and poison cost an eighth of the maximum, never less than one.
 const RESIDUAL_DIVISOR: int = 8
 
+## Toxic ramps rather than costing a flat eighth: a sixteenth of the maximum for
+## every turn it has been in effect, so the first turn costs the least of any
+## status and the Pokémon that stays in against it pays more each turn after.
+const TOXIC_RESIDUAL_DIVISOR: int = 16
+
 
 static func has(status: int, flag: int) -> bool:
 	return (status & flag) != 0
@@ -102,6 +107,14 @@ static func apply_paralysis(speed: int) -> int:
 static func residual_damage(max_hp: int) -> int:
 	@warning_ignore("integer_division")
 	return maxi(max_hp / RESIDUAL_DIVISOR, 1)
+
+
+## What Toxic takes at the end of a turn, at [param counter] turns of it having
+## been in effect. [param counter] starts at 1 the turn it is inflicted, so the
+## first hit is a sixteenth and not nothing.
+static func toxic_damage(max_hp: int, counter: int) -> int:
+	@warning_ignore("integer_division")
+	return maxi(max_hp * counter / TOXIC_RESIDUAL_DIVISOR, 1)
 
 
 ## What is on the byte, as a name a message can be built from, or an empty

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -1,0 +1,59 @@
+class_name Gen2Substatus
+extends RefCounted
+
+## The second byte of battle state, for everything the status byte cannot hold.
+##
+## [Gen2Status] is deliberately one status at a time, which is the cartridge's
+## own rule: a Pokémon that is already poisoned cannot also be confused by
+## refusing a second flag on the same byte. Confusion, flinching, being locked
+## into a recharge turn or a two-turn move's charge, Disable and Attract are all
+## independent of that and of each other, so they live on a byte of their own.
+##
+## Unlike [Gen2Status] this one is not the whole of its state: a few of these
+## flags need a counter alongside them (how many turns of confusion are left,
+## which move was charged), which is why [Gen2BattleMon] keeps those as separate
+## fields next to [member Gen2BattleMon.substatus] rather than packing them into
+## the byte. This class stays pure arithmetic and holds no state of its own,
+## the same shape as [Gen2Status].
+##
+## Every flag here clears on a switch, which is what makes it volatile rather
+## than a status: [method Gen2BattleMon.reset_volatile] is the single place that
+## happens, called from [method Gen2Party.send_out] alongside
+## [method Gen2BattleMon.reset_stages].
+
+const CONFUSED: int = 1 << 0
+const FLINCHED: int = 1 << 1
+const RECHARGING: int = 1 << 2
+const CHARGING: int = 1 << 3
+## Not yet written by any command; declared now so the byte's layout is decided
+## once rather than grown flag by flag as Disable and Attract are added.
+const DISABLED: int = 1 << 4
+const ATTRACTED: int = 1 << 5
+
+const NONE: int = 0
+
+## How many turns a confused Pokémon stays that way, rolled the same shape as
+## [constant Gen2Status.MIN_SLEEP] and [constant Gen2Status.MAX_SLEEP]: the
+## cartridge rolls the low bits until it gets something in range and the
+## counter starts inclusive of both ends.
+const MIN_CONFUSION: int = 2
+const MAX_CONFUSION: int = 5
+
+## Whether a confused Pokémon hurts itself instead of moving, out of 256: the
+## cartridge's own 128 in 256, a coin flip.
+const CONFUSION_HURTS_SELF_CHANCE: int = 128
+const CHANCE_RANGE: int = 256
+
+
+static func has(substatus: int, flag: int) -> bool:
+	return (substatus & flag) != 0
+
+
+## How long a newly confused Pokémon stays that way.
+static func roll_confusion(rng: RandomNumberGenerator) -> int:
+	return rng.randi_range(MIN_CONFUSION, MAX_CONFUSION)
+
+
+## Whether a confused Pokémon hurts itself this turn instead of moving.
+static func rolls_confusion_hit(rng: RandomNumberGenerator) -> bool:
+	return rng.randi_range(0, CHANCE_RANGE - 1) < CONFUSION_HURTS_SELF_CHANCE

--- a/game/battle/substatus.gd.uid
+++ b/game/battle/substatus.gd.uid
@@ -1,0 +1,1 @@
+uid://dcvj2t7c72hqx

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -43,6 +43,12 @@ var dealt: int = 0
 ## missed, because it did nothing, or because it reached its end.
 var ended: bool = false
 
+## Whether this is the release turn of a two-turn move, set by [Gen2Battle]
+## before anything runs. The PP for a two-turn move is spent once, on the
+## charge turn, so [method Gen2EffectCommands._do_turn] reads this rather than
+## spending again on the turn the attack actually lands.
+var locked: bool = false
+
 ## Set when a secondary effect's roll came up short. It is not the same as
 ## [member ended]: the move has happened and its damage stands, and only what was
 ## behind the roll is skipped.

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -46,6 +46,29 @@ const ANCIENTPOWER: int = 246
 const PSYCHIC_LOWERS: int = 210
 const PSYCHIC_NEVER: int = 211
 
+## The substatus moves. Flinch and confusion each in the two shapes they come
+## in, the same [code]_ALWAYS[/code]/nothing pairing [constant EMBER_BURNS] and
+## [constant NEVER_BURNS] use so a test can have one without a seed; Hyper Beam
+## for recharge, since nothing else in this table needs it.
+const ROLLING_KICK_ALWAYS: int = 247
+const ROLLING_KICK_NEVER: int = 248
+const CONFUSION_ALWAYS: int = 249
+const CONFUSION_NEVER: int = 250
+const SUPERSONIC: int = 251
+const HYPER_BEAM: int = 252
+
+## Solarbeam for the plain two-turn shape, Skull Bash for the one that raises a
+## stat behind the hit.
+const SOLARBEAM: int = 253
+const SKULL_BASH: int = 254
+const TOXIC: int = 255
+const HAZE: int = 256
+const BELLY_DRUM: int = 257
+const PSYCH_UP: int = 258
+
+## The highest move number this table fills. Grown as new moves are added.
+const MAX_MOVE: int = PSYCH_UP
+
 const NORMAL: int = 0x00
 const GROUND: int = 0x04
 const ROCK: int = 0x05
@@ -159,10 +182,25 @@ static func _moves() -> Array:
 		# [constant EMBER_BURNS] and [constant NEVER_BURNS] use for a status.
 		PSYCHIC_LOWERS: ["PSYCHIC", 90, PSYCHIC_TYPE, 255, 10, Gen2MoveEffect.STAT_DOWN_HIT_BASE + 4, 256],
 		PSYCHIC_NEVER: ["PSYCHIC", 90, PSYCHIC_TYPE, 255, 10, Gen2MoveEffect.STAT_DOWN_HIT_BASE + 4, 0],
+		# A flinch behind a roll, the way Rolling Kick does it.
+		ROLLING_KICK_ALWAYS: ["ROLLING KICK", 60, NORMAL, 255, 15, Gen2MoveEffect.FLINCH_HIT, 256],
+		ROLLING_KICK_NEVER: ["ROLLING KICK", 60, NORMAL, 255, 15, Gen2MoveEffect.FLINCH_HIT, 0],
+		# A confusion behind a roll, the way Confusion itself does it.
+		CONFUSION_ALWAYS: ["CONFUSION", 50, PSYCHIC_TYPE, 255, 25, Gen2MoveEffect.CONFUSE_HIT, 256],
+		CONFUSION_NEVER: ["CONFUSION", 50, PSYCHIC_TYPE, 255, 25, Gen2MoveEffect.CONFUSE_HIT, 0],
+		# Confusion as the whole of the move, the way Supersonic does it.
+		SUPERSONIC: ["SUPERSONIC", 0, NORMAL, 255, 20, Gen2MoveEffect.CONFUSE, 0],
+		HYPER_BEAM: ["HYPER BEAM", 150, NORMAL, 255, 5, Gen2MoveEffect.RECHARGE_HIT, 0],
+		SOLARBEAM: ["SOLARBEAM", 120, NORMAL, 255, 10, Gen2MoveEffect.SOLARBEAM, 0],
+		SKULL_BASH: ["SKULL BASH", 100, NORMAL, 255, 15, Gen2MoveEffect.SKULL_BASH, 0],
+		TOXIC: ["TOXIC", 0, POISON, 255, 10, Gen2MoveEffect.TOXIC, 0],
+		HAZE: ["HAZE", 0, NORMAL, 255, 30, Gen2MoveEffect.HAZE, 0],
+		BELLY_DRUM: ["BELLY DRUM", 0, NORMAL, 255, 10, Gen2MoveEffect.BELLY_DRUM, 0],
+		PSYCH_UP: ["PSYCH UP", 0, NORMAL, 255, 10, Gen2MoveEffect.PSYCH_UP, 0],
 	}
 
 	var out: Array = []
-	for number: int in range(1, ANCIENTPOWER + 1):
+	for number: int in range(1, MAX_MOVE + 1):
 		var entry: Array = known.get(number, ["FILLER", 40, NORMAL, 255, 20, 0, 0])
 		out.append({
 			"number": number,

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -551,3 +551,219 @@ func test_a_status_move_that_cannot_rise_further_says_so() -> void:
 	var events: Array = battle.take_turn(0, 0)
 	assert_eq(_of_type(events, Gen2Battle.STAT_CHANGED).size(), 0)
 	assert_eq(_of_type(events, Gen2Battle.STAT_CHANGE_FAILED).size(), 1)
+
+
+func test_a_flinch_from_the_faster_side_costs_the_slower_side_its_turn() -> void:
+	# Pikachu moves first and flinches Geodude with a roll that cannot fail;
+	# Geodude's own move never happens this turn.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.ROLLING_KICK_ALWAYS]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 1, "only Pikachu got to move")
+	var stopped: Dictionary = _first(events, Gen2Battle.CANNOT_MOVE)
+	assert_eq(int(stopped["side"]), Gen2Battle.ENEMY)
+	assert_eq(stopped["reason"], &"flinch")
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.FLINCHED), "cleared behind it")
+
+
+func test_a_flinch_that_never_rolls_leaves_the_slower_side_free_to_move() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.ROLLING_KICK_NEVER]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 2)
+	assert_eq(_of_type(events, Gen2Battle.CANNOT_MOVE).size(), 0)
+
+
+func test_a_status_move_confuses_rather_than_touching_the_status_byte() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SUPERSONIC]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.CONFUSED))
+	assert_eq(battle.enemy.status, Gen2Status.NONE, "confusion is not a status")
+	assert_eq(_of_type(events, Gen2Battle.CONFUSE_INFLICTED).size(), 1)
+
+
+func test_a_confused_pokemon_that_hits_itself_never_lands_its_own_move() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.substatus |= Gen2Substatus.CONFUSED
+	battle.player.confusion_turns = 3
+	var before: int = battle.player.hp
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.HURT_ITSELF).size(), 1)
+	assert_lt(battle.player.hp, before)
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 1, "only the enemy's own move")
+
+
+func test_a_pokemon_confused_and_paralysed_can_still_be_stopped_by_either() -> void:
+	# The two live on different bytes and are asked about independently, so a
+	# Pokémon can carry both, unlike two entries on the status byte itself.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.status = Gen2Status.PARALYSIS
+	battle.player.substatus |= Gen2Substatus.CONFUSED
+	battle.player.confusion_turns = 3
+	assert_true(Gen2Status.has(battle.player.status, Gen2Status.PARALYSIS))
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.CONFUSED))
+
+
+func test_hyper_beam_locks_the_user_out_the_turn_after_it_connects() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.HYPER_BEAM]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var first_turn: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(first_turn, Gen2Battle.HIT).filter(
+		func(event: Dictionary) -> bool: return int(event["side"]) == Gen2Battle.PLAYER
+	).size(), 1, "Hyper Beam connected")
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.RECHARGING))
+
+	var second_turn: Array = battle.take_turn(0, 0)
+	var stopped: Dictionary = _first(second_turn, Gen2Battle.CANNOT_MOVE)
+	assert_eq(int(stopped["side"]), Gen2Battle.PLAYER)
+	assert_eq(stopped["reason"], &"recharge")
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.RECHARGING))
+
+
+func test_switching_out_clears_confusion_and_recharge() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.player.substatus |= Gen2Substatus.CONFUSED | Gen2Substatus.RECHARGING
+	battle.player.confusion_turns = 4
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+	var bulbasaur: Gen2BattleMon = battle.player
+	assert_eq(bulbasaur.substatus, Gen2Substatus.NONE)
+	assert_eq(bulbasaur.confusion_turns, 0)
+
+
+func test_a_two_turn_move_charges_then_hits_on_the_next() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SOLARBEAM]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var before: int = int(battle.player.pp[0])
+
+	var first_turn: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(first_turn, Gen2Battle.CHARGING_UP).size(), 1)
+	assert_eq(_of_type(first_turn, Gen2Battle.HIT).filter(
+		func(event: Dictionary) -> bool: return int(event["side"]) == Gen2Battle.PLAYER
+	).size(), 0, "nothing lands on the charge turn")
+	assert_eq(int(battle.player.pp[0]), before - 1, "the PP goes on the charge turn")
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.CHARGING))
+
+	var second_turn: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(second_turn, Gen2Battle.HIT).filter(
+		func(event: Dictionary) -> bool: return int(event["side"]) == Gen2Battle.PLAYER
+	).size(), 1, "the release turn lands it")
+	assert_eq(int(battle.player.pp[0]), before - 1, "nothing more is spent on release")
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.CHARGING))
+
+
+func test_a_two_turn_move_ignores_the_slot_it_is_asked_for_on_release() -> void:
+	# Whatever slot the caller passes on the release turn, the move that
+	# actually happens is the one that was charged, because nothing is chosen
+	# on that turn at all on the cartridge.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SOLARBEAM, Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.take_turn(0, 0)
+	var second_turn: Array = battle.take_turn(1, 0)
+	assert_eq(int(_first(second_turn, Gen2Battle.USED_MOVE)["move"]), Fixture.SOLARBEAM)
+
+
+func test_skull_bashs_charge_raises_defense_only_once_it_lands() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SKULL_BASH]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.stage("defense"), 0, "nothing moves on the charge turn")
+
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.stage("defense"), 1)
+
+
+func test_toxic_takes_more_each_turn_than_an_ordinary_poison_would() -> void:
+	# Poison Powder rather than Tackle on the enemy, so nothing but the toxic
+	# counter changes what the residual step takes off Geodude.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TOXIC]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	var max_hp: int = battle.enemy.max_hp()
+
+	# The turn Toxic lands, the residual step already reads the counter it just
+	# started: one sixteenth, and then it ramps to two.
+	var first_turn: Array = battle.take_turn(0, 0)
+	assert_eq(int(_first(first_turn, Gen2Battle.HURT_BY_STATUS)["amount"]), Gen2Status.toxic_damage(max_hp, 1))
+	assert_eq(battle.enemy.toxic_counter, 2)
+
+	var second_turn: Array = battle.take_turn(0, 0)
+	assert_eq(int(_first(second_turn, Gen2Battle.HURT_BY_STATUS)["amount"]), Gen2Status.toxic_damage(max_hp, 2))
+	assert_eq(battle.enemy.toxic_counter, 3)
+	assert_gt(
+		int(_first(second_turn, Gen2Battle.HURT_BY_STATUS)["amount"]),
+		int(_first(first_turn, Gen2Battle.HURT_BY_STATUS)["amount"]),
+		"the counter ramped"
+	)
+
+
+func test_switching_out_a_toxic_pokemon_resets_the_ramp() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.player.status = Gen2Status.POISON
+	battle.player.toxic_counter = 4
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+	assert_eq(battle.player.toxic_counter, 0, "cleared with the rest of the volatiles")
+
+
+func test_haze_wipes_out_both_sides_stages_in_the_middle_of_a_battle() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.HAZE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.change_stage("speed", 2)
+	battle.enemy.change_stage("defense", -2)
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(battle.player.stage("speed"), 0)
+	assert_eq(battle.enemy.stage("defense"), 0, "both sides, not just the user's own")
+	assert_eq(_of_type(events, Gen2Battle.STAGES_CLEARED).size(), 1)
+
+
+func test_belly_drum_costs_the_user_half_its_health_for_a_maxed_attack() -> void:
+	# Thunder Wave rather than Tackle or Growl on the enemy: it neither damages
+	# Pikachu nor touches the stage Belly Drum is being checked against.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.BELLY_DRUM]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.THUNDER_WAVE])
+	)
+	var max_hp: int = battle.player.max_hp()
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.stage("attack"), Gen2Stats.MAX_STAGE)
+	@warning_ignore("integer_division")
+	assert_eq(battle.player.hp, max_hp - max_hp / 2)
+
+
+func test_psych_up_copies_stat_changes_across_in_a_real_turn() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PSYCH_UP]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.enemy.change_stage("defense", 3)
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.stage("defense"), 3)

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -144,6 +144,24 @@ func test_stages_reset() -> void:
 	assert_eq(mon.stat("speed"), 110)
 
 
+## A field added here and forgotten in [method Gen2BattleMon.reset_volatile]
+## is a bug that only shows up after a switch, so every volatile field is set
+## before this asks for a blank one back.
+func test_every_volatile_field_clears() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.substatus = Gen2Substatus.CONFUSED | Gen2Substatus.FLINCHED
+	mon.confusion_turns = 3
+	mon.charged_move = Fixture.TACKLE
+	mon.toxic_counter = 2
+
+	mon.reset_volatile()
+
+	assert_eq(mon.substatus, Gen2Substatus.NONE)
+	assert_eq(mon.confusion_turns, 0)
+	assert_eq(mon.charged_move, 0)
+	assert_eq(mon.toxic_counter, 0)
+
+
 func test_rolled_dvs_stay_inside_a_nibble_each() -> void:
 	var rng := RandomNumberGenerator.new()
 	rng.seed = 7

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -239,6 +239,261 @@ func test_a_move_that_dealt_nothing_costs_nothing_in_recoil() -> void:
 	assert_eq(turn.events.size(), 0)
 
 
+func test_flinch_hit_is_the_secondary_shape_with_flinch_target_in_it() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.FLINCH_HIT)
+	assert_true(Gen2MoveEffect.is_written(Gen2MoveEffect.FLINCH_HIT))
+	assert_true(sequence.has(Gen2EffectCommands.FLINCH_TARGET))
+	assert_true(sequence.has(Gen2EffectCommands.EFFECT_CHANCE))
+	assert_true(sequence.has(Gen2EffectCommands.APPLY_DAMAGE), "the damage happens either way")
+
+
+func test_flinch_target_sets_the_substatus_flag() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	Gen2EffectCommands.run(Gen2EffectCommands.FLINCH_TARGET, turn)
+	assert_true(Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.FLINCHED))
+
+
+func test_flinch_target_does_nothing_behind_a_failed_roll() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.failed_chance = true
+	Gen2EffectCommands.run(Gen2EffectCommands.FLINCH_TARGET, turn)
+	assert_false(Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.FLINCHED))
+
+
+func test_a_flinched_pokemon_cannot_move_and_the_flag_clears_either_way() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.FLINCHED
+	var turn: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.ENEMY, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), []
+	)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	assert_true(turn.ended)
+	assert_eq(_first(turn.events, Gen2Battle.CANNOT_MOVE)["reason"], &"flinch")
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.FLINCHED))
+
+
+func test_confuse_hit_is_the_secondary_shape_and_confuse_is_the_status_shape() -> void:
+	var hit: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.CONFUSE_HIT)
+	assert_true(hit.has(Gen2EffectCommands.CONFUSE_TARGET))
+	assert_true(hit.has(Gen2EffectCommands.APPLY_DAMAGE))
+
+	var status_move: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.CONFUSE)
+	assert_true(status_move.has(Gen2EffectCommands.CONFUSE_TARGET))
+	assert_false(status_move.has(Gen2EffectCommands.DAMAGE_CALC), "no power, so no matchup step")
+
+
+func test_confuse_target_sets_the_flag_and_rolls_a_duration() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	Gen2EffectCommands.run(Gen2EffectCommands.CONFUSE_TARGET, turn)
+	var defender: Gen2BattleMon = turn.defender()
+	assert_true(Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED))
+	assert_between(defender.confusion_turns, Gen2Substatus.MIN_CONFUSION, Gen2Substatus.MAX_CONFUSION)
+	assert_eq(_first(turn.events, Gen2Battle.CONFUSE_INFLICTED)["target"], turn.target)
+
+
+func test_an_already_confused_target_cannot_be_confused_again() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.defender().substatus |= Gen2Substatus.CONFUSED
+	turn.defender().confusion_turns = 3
+	Gen2EffectCommands.run(Gen2EffectCommands.CONFUSE_TARGET, turn)
+	assert_eq(turn.defender().confusion_turns, 3, "not restarted")
+	assert_eq(turn.events.size(), 0)
+
+
+func test_a_confused_pokemon_that_is_not_hit_by_itself_carries_on_into_its_move() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.CONFUSED
+	battle.player.confusion_turns = 3
+	# A seed where the confusion-hit roll comes up short, so the turn's own
+	# events are read rather than a self-hit's.
+	_rng.seed = 1
+	var turn: Gen2Turn = _turn(battle)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	assert_false(turn.ended)
+	assert_eq(_first(turn.events, Gen2Battle.CONFUSED)["side"], Gen2Battle.PLAYER)
+
+
+func test_a_confused_pokemon_that_hits_itself_never_reaches_its_move() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.CONFUSED
+	battle.player.confusion_turns = 3
+	var before: int = battle.player.hp
+	# A seed where the confusion-hit roll comes up, so this is a self-hit rather
+	# than the other branch: the pair proves both halves of the coin flip work.
+	_rng.seed = 12345
+	var turn: Gen2Turn = _turn(battle)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	assert_true(turn.ended)
+	assert_lt(battle.player.hp, before)
+	assert_eq(_first(turn.events, Gen2Battle.USED_MOVE), {}, "it never got to use anything")
+
+
+func test_confusion_running_out_lets_the_move_through_the_same_turn() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.CONFUSED
+	battle.player.confusion_turns = 1
+	var turn: Gen2Turn = _turn(battle)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	assert_false(turn.ended)
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.CONFUSED))
+	assert_eq(_first(turn.events, Gen2Battle.SNAPPED_OUT)["side"], Gen2Battle.PLAYER)
+
+
+func test_recharge_hit_locks_the_user_out_after_it_connects() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.RECHARGE_HIT)
+	assert_lt(
+		sequence.find(Gen2EffectCommands.CHECK_HIT), sequence.find(Gen2EffectCommands.RECHARGE),
+		"a miss ends the move before recharge is ever reached"
+	)
+
+	var turn: Gen2Turn = _turn(_battle())
+	Gen2EffectCommands.run(Gen2EffectCommands.RECHARGE, turn)
+	assert_true(Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.RECHARGING))
+
+
+func test_a_recharging_pokemon_cannot_move_and_the_flag_clears() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.RECHARGING
+	var turn: Gen2Turn = _turn(battle)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	assert_true(turn.ended)
+	assert_eq(_first(turn.events, Gen2Battle.CANNOT_MOVE)["reason"], &"recharge")
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.RECHARGING))
+
+
+func test_a_charge_move_ends_the_turn_before_the_damage_step() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.SOLARBEAM)
+	assert_lt(
+		sequence.find(Gen2EffectCommands.CHARGE_MOVE),
+		sequence.find(Gen2EffectCommands.DAMAGE_CALC)
+	)
+
+
+func test_charge_move_locks_the_user_in_and_says_so() -> void:
+	var turn: Gen2Turn = _turn(_battle(), Fixture.SOLARBEAM)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHARGE_MOVE, turn)
+	var mon: Gen2BattleMon = turn.attacker()
+	assert_true(Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING))
+	assert_eq(mon.charged_move, Fixture.SOLARBEAM)
+	assert_true(turn.ended)
+	assert_eq(_first(turn.events, Gen2Battle.CHARGING_UP)["side"], Gen2Battle.PLAYER)
+
+
+func test_charge_move_releases_on_the_second_call_and_lets_the_rest_run() -> void:
+	var turn: Gen2Turn = _turn(_battle(), Fixture.SOLARBEAM)
+	var mon: Gen2BattleMon = turn.attacker()
+	mon.substatus |= Gen2Substatus.CHARGING
+	mon.charged_move = Fixture.SOLARBEAM
+
+	Gen2EffectCommands.run(Gen2EffectCommands.CHARGE_MOVE, turn)
+	assert_false(turn.ended)
+	assert_false(Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING))
+	assert_eq(mon.charged_move, 0)
+
+
+func test_skull_bash_raises_defense_after_the_hit_lands() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.SKULL_BASH)
+	assert_lt(
+		sequence.find(Gen2EffectCommands.CHECK_FAINT),
+		sequence.find(Gen2EffectCommands.DEFENSE_UP)
+	)
+
+
+func test_toxic_starts_its_own_ramping_counter_rather_than_a_flat_poison() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.TOXIC)
+	assert_true(sequence.has(Gen2EffectCommands.TOXIC_TARGET))
+	assert_false(sequence.has(Gen2EffectCommands.POISON_TARGET))
+
+	var turn: Gen2Turn = _turn(_battle())
+	Gen2EffectCommands.run(Gen2EffectCommands.TOXIC_TARGET, turn)
+	var defender: Gen2BattleMon = turn.defender()
+	assert_true(Gen2Status.has(defender.status, Gen2Status.POISON))
+	assert_eq(defender.toxic_counter, 1)
+	assert_eq(_first(turn.events, Gen2Battle.STATUS_INFLICTED)["name"], &"toxic")
+
+
+func test_toxic_refuses_an_already_afflicted_target() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.defender().status = Gen2Status.BURN
+	Gen2EffectCommands.run(Gen2EffectCommands.TOXIC_TARGET, turn)
+	assert_eq(turn.defender().status, Gen2Status.BURN, "not replaced")
+	assert_eq(turn.defender().toxic_counter, 0)
+
+
+func test_haze_clears_both_sides_stages_and_nothing_else() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.change_stage("attack", 3)
+	battle.enemy.change_stage("speed", -2)
+	battle.enemy.status = Gen2Status.BURN
+
+	var turn: Gen2Turn = _turn(battle)
+	Gen2EffectCommands.run(Gen2EffectCommands.HAZE, turn)
+
+	assert_eq(battle.player.stage("attack"), 0)
+	assert_eq(battle.enemy.stage("speed"), 0)
+	assert_eq(battle.enemy.status, Gen2Status.BURN, "not a status cure")
+	assert_eq(_first(turn.events, Gen2Battle.STAGES_CLEARED), {"type": Gen2Battle.STAGES_CLEARED, "side": Gen2Battle.PLAYER})
+
+
+func test_belly_drum_maxes_attack_for_half_the_users_health() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	var mon: Gen2BattleMon = turn.attacker()
+	var max_hp: int = mon.max_hp()
+
+	Gen2EffectCommands.run(Gen2EffectCommands.BELLY_DRUM, turn)
+
+	assert_eq(mon.stage("attack"), Gen2Stats.MAX_STAGE)
+	@warning_ignore("integer_division")
+	assert_eq(mon.hp, max_hp - max_hp / 2)
+	assert_eq(_first(turn.events, Gen2Battle.STAT_CHANGED)["by"], 6)
+
+
+func test_belly_drum_fails_without_cost_under_half_health() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	var mon: Gen2BattleMon = turn.attacker()
+	mon.hp = 1
+
+	Gen2EffectCommands.run(Gen2EffectCommands.BELLY_DRUM, turn)
+
+	assert_eq(mon.stage("attack"), 0)
+	assert_eq(mon.hp, 1, "nothing spent on a failed attempt")
+	assert_eq(_first(turn.events, Gen2Battle.STAT_CHANGE_FAILED)["by"], 6)
+
+
+func test_belly_drum_fails_once_attack_is_already_at_the_top() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	var mon: Gen2BattleMon = turn.attacker()
+	mon.change_stage("attack", Gen2Stats.MAX_STAGE)
+	var before: int = mon.hp
+
+	Gen2EffectCommands.run(Gen2EffectCommands.BELLY_DRUM, turn)
+
+	assert_eq(mon.hp, before)
+	assert_eq(_of_type(turn.events, Gen2Battle.STAT_CHANGE_FAILED).size(), 1)
+
+
+func test_psych_up_copies_the_targets_stages_onto_the_user() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	turn.defender().change_stage("speed", -2)
+	turn.defender().change_stage("accuracy", 1)
+
+	Gen2EffectCommands.run(Gen2EffectCommands.PSYCH_UP, turn)
+
+	assert_eq(turn.attacker().stage("speed"), -2)
+	assert_eq(turn.attacker().stage("accuracy"), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.STAGES_COPIED).size(), 1)
+
+
+func test_psych_up_fails_when_the_target_has_nothing_to_copy() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	Gen2EffectCommands.run(Gen2EffectCommands.PSYCH_UP, turn)
+	assert_eq(turn.events.size(), 0)
+
+
+func _of_type(events: Array, type: StringName) -> Array:
+	return events.filter(func(event: Dictionary) -> bool: return event["type"] == type)
+
+
 func _first(events: Array, type: StringName) -> Dictionary:
 	for event: Dictionary in events:
 		if event["type"] == type:

--- a/tests/unit/test_party.gd
+++ b/tests/unit/test_party.gd
@@ -111,3 +111,14 @@ func test_a_pokemon_called_back_keeps_its_health_and_loses_its_stages() -> void:
 	assert_eq(party.active, 1)
 	assert_eq(leaving.hp, hurt, "it comes back as hurt as it left")
 	assert_eq(int(leaving.stages["attack"]), 0)
+
+
+func test_a_pokemon_called_back_loses_what_gen2substatus_holds() -> void:
+	var party: Gen2Party = _party(2)
+	var leaving: Gen2BattleMon = party.at(0)
+	leaving.substatus = Gen2Substatus.CONFUSED
+	leaving.confusion_turns = 4
+
+	assert_true(party.send_out(1))
+	assert_eq(leaving.substatus, Gen2Substatus.NONE)
+	assert_eq(leaving.confusion_turns, 0)

--- a/tests/unit/test_status.gd
+++ b/tests/unit/test_status.gd
@@ -72,6 +72,13 @@ func test_a_burn_or_a_poison_costs_an_eighth_and_never_nothing() -> void:
 	assert_eq(Gen2Status.residual_damage(4), 1, "a small Pokémon still loses one")
 
 
+func test_toxic_ramps_a_sixteenth_at_a_time_and_never_nothing() -> void:
+	assert_eq(Gen2Status.toxic_damage(160, 1), 10, "a sixteenth, half a plain poison's eighth")
+	assert_eq(Gen2Status.toxic_damage(160, 2), 20, "twice the counter, twice the damage")
+	assert_eq(Gen2Status.toxic_damage(160, 3), 30)
+	assert_eq(Gen2Status.toxic_damage(4, 1), 1, "a small Pokémon still loses one")
+
+
 func test_full_paralysis_is_about_a_quarter_of_the_time() -> void:
 	var stopped: int = 0
 	for _roll: int in 2000:


### PR DESCRIPTION
The status byte is deliberately one status at a time, which leaves nowhere for confusion, flinching, a two-turn move's charge, a recharge turn or Toxic's own ramp to live, since a Pokemon can carry any of those alongside an ordinary status. Gen2Substatus adds that second byte, with counters on Gen2BattleMon for what a flag alone can't say, clearing on every switch.

With that byte in place, the effect list gains flinch, confusion (both as a move's whole point and as a secondary chance), the five two-turn moves, Hyper Beam's recharge, Toxic's own ramping damage in place of the flat poison it used to share, and Haze, Belly Drum and Psych Up. Every effect byte was read off the real cartridges rather than assumed.