### PR TITLE
Decode trainer parties and fight one on the battle screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ What comes out today:
 | Items | All 255 names, indexed by item number |
 | Types | All 28 names, indexed by type number |
 | Type chart | Every matchup, and which two Foresight cancels |
-| Trainers | Every trainer class: name, pic and palette |
+| Trainers | Every trainer class: name, pic and palette; and every individual trainer's own party, level by level |
 | Palettes | Normal and shiny, as the cartridge's own 15-bit colours |
 | Sprites | Front and back for all 251 species, plus all 26 Unown forms |
 | Font | All 128 glyphs, indexed by character code |
@@ -159,9 +159,10 @@ the fastest way to see the bars change colour.
 
 Both Pokémon know what their level says they know, out of the learnset, and both
 pick at random from those moves: choosing one is a menu on the player's side and
-an AI on the enemy's, and neither exists yet. Each side brings two Pokémon, made
-up by the screen, because a real party comes from a save on one side and from
-the trainer party tables on the other and neither is decoded yet.
+an AI on the enemy's, and neither exists yet. What is on screen when you press
+Play is still two made-up Pokémon a side, because the player's party comes from
+a save that does not exist yet; call `show_trainer(trainer_class)` on the scene
+to fight one of the cartridge's own trainers instead, Falkner among them.
 
 ## Tests
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -101,6 +101,7 @@ battle can be fought inside a test:
 | `battle/accuracy.gd` | Whether a move connects |
 | `battle/battle_mon.gd` | One Pokémon: its stats, PP, health and stages |
 | `battle/party.gd` | The six a side carries, and which of them is out |
+| `battle/trainer_party.gd` | One of the cartridge's own trainers, built into a party |
 | `battle/status.gd` | The status byte, and the four things it does |
 | `battle/substatus.gd` | The second byte: confusion, flinching, a charge, a recharge |
 | `battle/turn.gd` | One move being used, while it is being used |
@@ -137,6 +138,19 @@ A switch is not a move with a very high priority. The cartridge settles it
 before it looks at priority at all, so a switching side always acts first and
 the other side's move hits whoever came in. That is why an action is
 `use_move` or `switch_to` rather than a move number.
+
+`Gen2TrainerParty.build` turns one of a trainer class's own trainers into a
+`Gen2Party`, the same way `Gen2Learnset` turns a species' learnset into what a
+level knows. It sits beside the rest of the battle engine rather than next to
+`Gen2Learnset` because what it hands back is battle types, not cartridge data,
+and it draws the same distinction the trainer party table itself draws
+between a NORMAL or ITEM trainer's Pokémon (which knows what its level teaches
+it, through `GameData.moves_at_level`, the same as a wild one) and a MOVES or
+ITEM_MOVES trainer's (which knows exactly what is stored with it, zero slots
+dropped rather than passed to `Gen2BattleMon` as a move). Its Pokémon carry
+`Gen2BattleMon.PERFECT_DVS` rather than the cartridge's own per-trainer-class
+DVs, because that is a second table (`data/trainers/dvs.asm` in pokecrystal)
+this change did not locate; see `HANDOFF.md`.
 
 **A move is a short program, not a special case.** The cartridge keeps a list of
 commands per effect byte and runs them in order, and an ordinary attack is the
@@ -290,6 +304,20 @@ So every offset ships with a check that would fail if it were wrong, and
   the shape a border has to have: inset from the top of its tile row, corners
   that carry the pattern of the side they hang from, and no two frames the
   same.
+- The trainer party table is a second table indexed the same way as the trainer
+  classes above, one pointer per class, and it is where the games' individual
+  trainers actually live: "LEADER" is the class every gym leader shares, and
+  "FALKNER" is stored inside class 1's own entry. Nothing inside a class's bytes
+  says where its group ends, so a class's span is bounded by the *next* class's
+  pointer, and the walk itself is the check: a span that does not land exactly
+  on the next class's start cannot be right, the same argument the evolution
+  and learnset table's pointers make. One class in every game shares its
+  pointer with the class after it, and reads as an honestly empty group rather
+  than a copy of somebody else's; see `RomLayout.EMPTY_TRAINER_CLASS`. On top
+  of that the total trainer count is a known figure per game, and both ends of
+  the table are content whose answer is known independently: Falkner's level 7
+  Pidgey and level 9 Pidgeotto open it, and the last class's first trainer's
+  name closes it.
 
 When you add an offset, add its check. "It produced output" is not evidence.
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -218,7 +218,7 @@ func send_out(side: int, index: int) -> Array:
 		})
 	events.append({
 		"type": SENT_OUT, "side": side, "index": index,
-		"species": current.active_mon().species,
+		"species": current.active_mon().species, "level": current.active_mon().level,
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
 	})
 	return events

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -69,6 +69,10 @@ var charged_move: int = 0
 ## Toxic's damage ramps on. Zero unless actually toxic.
 var toxic_counter: int = 0
 
+## The item this Pokémon is holding, by item number, or zero for none. Carried
+## through from a trainer's party or a save; nothing in the engine reads it yet.
+var item: int = 0
+
 
 ## Builds a Pokémon at a level, at full health, knowing [param moves].
 ##
@@ -80,7 +84,8 @@ static func create(
 	at_level: int,
 	known_moves: Array = [],
 	dv_word: int = PERFECT_DVS,
-	trained: Dictionary = {}
+	trained: Dictionary = {},
+	held_item: int = 0
 ) -> Gen2BattleMon:
 	if game_data == null:
 		return null
@@ -94,6 +99,7 @@ static func create(
 	out.dvs = dv_word
 	out.stat_exp = trained
 	out.moves = known_moves.slice(0, MAX_MOVES)
+	out.item = held_item
 	out.reset_stages()
 	out.recalculate()
 	out.hp = out.max_hp()

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -31,11 +31,10 @@ const DEFAULT_ENEMY: int = 16
 const DEFAULT_PLAYER: int = 155
 const DEFAULT_LEVEL: int = 5
 
-## How many Pokémon each side brings. Two, so that switching and being replaced
-## after a faint can both be seen. This is scaffolding: a real party comes from a
-## save on the player's side and from the trainer party tables on the enemy's,
-## and neither exists yet, so the screen makes one out of the species after the
-## one it is showing.
+## How many Pokémon [method _party_from] makes up, so that switching and being
+## replaced after a faint can both be seen on the player's side, which still has
+## nothing real to draw from: a save does not exist yet. [method show_trainer]
+## puts a real party of whatever size the cartridge gives it on the enemy's.
 const PARTY_SIZE: int = 2
 
 ## What a status says when it stops a Pokémon moving, and when it lands on one.
@@ -162,9 +161,46 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 	)
 
 
-## A party led by [param species], with the species after it behind. Scaffolding,
-## and the only thing on this screen that still invents a number: everything else
-## it draws now comes out of the cartridge or out of an event.
+## Puts the player against one of a trainer class's own trainers, built from the
+## cartridge's own party rather than invented. The player's side is still
+## [method _party_from]'s made-up one: nothing plays it yet, so there is nothing
+## real to put there.
+func show_trainer(
+	trainer_class: int, index: int = 0, player_species: int = DEFAULT_PLAYER,
+	player_level: int = DEFAULT_LEVEL
+) -> void:
+	var enemy_party: Gen2Party = Gen2TrainerParty.build(_data, trainer_class, index)
+	if enemy_party == null:
+		return
+
+	_player = _wrap_species(player_species)
+	_player_level = player_level
+
+	var lead: Gen2BattleMon = enemy_party.active_mon()
+	_enemy = lead.species
+	_enemy_level = lead.level
+
+	_pending = []
+	_battle = Gen2Battle.create_parties(
+		_data, _party_from(_player, _player_level), enemy_party, _rng
+	)
+	if _battle == null:
+		return
+
+	set_hp(
+		_battle.enemy.hp, _battle.enemy.max_hp(),
+		_battle.player.hp, _battle.player.max_hp()
+	)
+
+	var trainer: Dictionary = _data.trainer_party(trainer_class, index)
+	show_message("%s %s wants to fight!" % [
+		_data.trainer_name(trainer_class), String(trainer.get("name", "")),
+	])
+
+
+## A party led by [param species], with the species after it behind. Scaffolding
+## for the player's side, which still has nothing real to draw from: a save does
+## not exist yet. The enemy's side no longer uses this; see [method show_trainer].
 func _party_from(species: int, level: int) -> Gen2Party:
 	var members: Array = []
 	for offset: int in PARTY_SIZE:
@@ -342,12 +378,15 @@ func _apply_event(event: Dictionary) -> void:
 		Gen2Battle.SENT_OUT:
 			# The pic and the panel both change, and both come out of the event
 			# rather than out of the party, for the same reason every other number
-			# here does.
+			# here does. The level is part of that: a trainer's own party is not
+			# all one level the way the invented one used to be.
 			if int(event["side"]) == Gen2Battle.ENEMY:
 				_enemy = int(event["species"])
+				_enemy_level = int(event["level"])
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				_player = int(event["species"])
+				_player_level = int(event["level"])
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
 
 

--- a/game/battle/trainer_party.gd
+++ b/game/battle/trainer_party.gd
@@ -1,0 +1,62 @@
+class_name Gen2TrainerParty
+extends RefCounted
+
+## Turns one of a trainer class's individual trainers into a battle-ready party.
+##
+## Lives beside the rest of [code]game/battle/[/code] rather than next to
+## [Gen2Learnset], because what it produces is [Gen2BattleMon]s and
+## [Gen2Party]s, and the data layer holds no battle types. [RefCounted] and
+## static throughout, the same as [Gen2Learnset]: nothing here needs a scene,
+## only [GameData] and the trainer number to ask it about.
+##
+## A NORMAL or ITEM trainer's Pokémon knows what its level says it knows, out of
+## the learnset, the same as a wild one. A MOVES or ITEM_MOVES trainer's Pokémon
+## knows exactly the moves stored with it instead, which is why the two are read
+## through [method GameData.moves_at_level] and the stored list respectively
+## rather than through one shared path.
+##
+## Trainer Pokémon are given [constant Gen2BattleMon.PERFECT_DVS] here rather
+## than the cartridge's own per-trainer-class DVs, because that is a second
+## table this change does not locate; see [code]HANDOFF.md[/code].
+
+
+## The party a trainer class's [param index]th trainer brings, or null if
+## [param data] has no such trainer or none of its Pokémon could be built.
+static func build(data: GameData, trainer_class: int, index: int) -> Gen2Party:
+	if data == null:
+		return null
+
+	var trainer: Dictionary = data.trainer_party(trainer_class, index)
+	if trainer.is_empty():
+		return null
+
+	var mon_type: int = int(trainer["type"])
+	var members: Array = []
+	for mon: Dictionary in (trainer["party"] as Array):
+		var species: int = int(mon["species"])
+		var level: int = int(mon["level"])
+		var moves: Array = _moves_for(data, mon_type, species, level, mon["moves"])
+		members.append(
+			Gen2BattleMon.create(
+				data, species, level, moves, Gen2BattleMon.PERFECT_DVS, {}, int(mon["item"])
+			)
+		)
+
+	return Gen2Party.create(members)
+
+
+## What one of this trainer's Pokémon knows: its own stored moves if the
+## trainer's type says it carries them, or the ordinary learnset fill
+## otherwise. Zero is not a move; it is an empty slot in the stored list, and
+## is dropped rather than passed to [Gen2BattleMon] as one.
+static func _moves_for(
+	data: GameData, mon_type: int, species: int, level: int, stored: Array
+) -> Array:
+	if mon_type == RomLayout.TRAINER_MON_MOVES or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+		var out: Array = []
+		for move: Variant in stored:
+			if int(move) != 0:
+				out.append(int(move))
+		return out
+
+	return data.moves_at_level(species, level)

--- a/game/battle/trainer_party.gd.uid
+++ b/game/battle/trainer_party.gd.uid
@@ -1,0 +1,1 @@
+uid://c4s548jwmd85m

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -277,6 +277,46 @@ func trainer_palette(number: int) -> PackedColorArray:
 	]))
 
 
+## How many individual trainers trainer class [param number] carries. One class
+## in every game carries none: see [constant RomLayout.EMPTY_TRAINER_CLASS].
+func trainer_party_count(number: int) -> int:
+	return (trainer(number).get("trainers", []) as Array).size()
+
+
+## One of a trainer class's individual trainers, as { name, type, party }, where
+## [code]party[/code] is that trainer's Pokémon in the cartridge's own order, each
+## { level, species, item, moves }. Empty for a class or an index this class does
+## not have.
+##
+## [code]type[/code] is one of the [code]RomLayout.TRAINER_MON_*[/code]
+## constants and decides what a member's own Pokémon means: whether it knows
+## what its level teaches it or the moves stored with it, and whether it holds
+## an item. See [Gen2TrainerParty], which turns this into battle-ready Pokémon.
+func trainer_party(number: int, index: int) -> Dictionary:
+	var trainers: Array = trainer(number).get("trainers", [])
+	if index < 0 or index >= trainers.size():
+		return {}
+
+	var entry: Dictionary = trainers[index]
+	var party: Array = []
+	for mon: Dictionary in (entry.get("party", []) as Array):
+		var moves: Array = []
+		for move: Variant in (mon.get("moves", []) as Array):
+			moves.append(int(move))
+		party.append({
+			"level": int(mon.get("level", 0)),
+			"species": int(mon.get("species", 0)),
+			"item": int(mon.get("item", 0)),
+			"moves": moves,
+		})
+
+	return {
+		"name": String(entry.get("name", "")),
+		"type": int(entry.get("type", 0)),
+		"party": party,
+	}
+
+
 ## Where a trainer class sits in the trainer atlas. Every trainer is drawn at the
 ## same size, so unlike a species pic this one always fills its cell.
 func trainer_pic(number: int) -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -29,7 +29,7 @@ const TILES_DIR: String = "tiles"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 7
+const FORMAT_VERSION: int = 8
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -41,6 +41,17 @@ const FIRST_LEARNSET_MOVE: int = 33
 const STAT_EVOLUTION_SPECIES: int = 236
 const STAT_EVOLUTION_COUNT: int = 3
 
+## What the trainer *party* table is known to say, independently of the
+## cartridge, which is a different table from [constant TRAINER_FIRST_CLASS]:
+## that one is the class every gym leader shares ("LEADER"), and this one is the
+## individual trainer stored inside class 1's own entry. Falkner's level 7
+## Pidgey and level 9 Pidgeotto are the same in all three games.
+const TRAINER_PARTY_FIRST_NAME: String = "FALKNER"
+const TRAINER_PARTY_FIRST_LEVEL_1: int = 7
+const TRAINER_PARTY_FIRST_SPECIES_1: int = 16
+const TRAINER_PARTY_FIRST_LEVEL_2: int = 9
+const TRAINER_PARTY_FIRST_SPECIES_2: int = 17
+
 var _lz: Gen2Lz = Gen2Lz.new()
 
 
@@ -179,6 +190,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	var trainers: Dictionary = verify_trainers(rom, layout)
 	if not trainers["ok"]:
 		return trainers
+
+	var trainer_parties: Dictionary = verify_trainer_parties(rom, layout)
+	if not trainer_parties["ok"]:
+		return trainer_parties
 
 	return {"ok": true, "message": "Layout verified."}
 
@@ -859,6 +874,230 @@ static func _trainer_palette_check(
 	return {"ok": true, "message": ""}
 
 
+## Reads the whole trainer party table in one pass: every class's individual
+## trainers, each a name, a type and a party.
+##
+## This is not [method verify_trainers]'s table. That one is the class every
+## gym leader shares ("LEADER") and this one is the trainer inside it
+## ("FALKNER"), and the two are read through entirely different pointers, one
+## per class in both.
+##
+## Nothing inside a class's own bytes says where its group ends, so a class's
+## span is bounded by the *next* class's pointer rather than by anything it
+## carries itself, and the last class is walked until a byte that cannot open a
+## name is met instead. One class in every game shares its pointer with the
+## next, which is the one class the games never send into a battle: its honest
+## span is empty, not a copy of the class after it. See
+## [constant RomLayout.EMPTY_TRAINER_CLASS].
+##
+## Returns { ok, message, classes, total }, where [code]classes[/code] is one
+## Array of trainers per class, in order.
+static func read_trainer_parties(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var count: int = RomLayout.trainer_class_count(layout)
+	var table: int = int(layout["trainer_parties"])
+	var bank: int = RomLayout.bank_of(table)
+
+	var pointers: Array = []
+	for trainer_class: int in range(1, count + 1):
+		var offset: int = RomLayout.trainer_party_pointer_offset(layout, trainer_class)
+		if not rom.in_bounds(offset, RomLayout.TRAINER_PARTY_POINTER_SIZE):
+			return {
+				"ok": false,
+				"message": "Trainer party pointer %d is past the end." % trainer_class,
+			}
+		pointers.append(rom.u16le(offset))
+
+	var classes: Array = []
+	var total: int = 0
+	for trainer_class: int in range(1, count + 1):
+		var address: int = pointers[trainer_class - 1]
+		if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
+			return {
+				"ok": false,
+				"message": "Trainer class %d's party points at $%04X, outside the banked window." % [
+					trainer_class, address,
+				],
+			}
+		var at: int = RomFile.linear(bank, address)
+
+		# The pointers are non-decreasing in class order in every game but one,
+		# so the class after this one is what bounds it; the walk itself proves
+		# the offset, because a span that has slid cannot tile the region.
+		var end: int = -1
+		if trainer_class < count:
+			var next_address: int = pointers[trainer_class]
+			if next_address < address:
+				return {
+					"ok": false,
+					"message": "Trainer class %d's party pointer goes backwards." % trainer_class,
+				}
+			end = RomFile.linear(bank, next_address)
+
+		var group: Dictionary = _read_trainer_group(rom, at, end)
+		if not group["ok"]:
+			return {
+				"ok": false,
+				"message": "Trainer class %d: %s" % [trainer_class, group["message"]],
+			}
+
+		classes.append(group["trainers"])
+		total += (group["trainers"] as Array).size()
+
+	return {"ok": true, "message": "", "classes": classes, "total": total}
+
+
+## One class's span of trainers: read from [param start] to exactly
+## [param end], or, when [param end] is negative because this is the last
+## class, until a byte that cannot open a name (the padding past the real
+## table) is met. A span that overshoots [param end] is caught here rather than
+## left for the next class to notice, because there may not be a next class.
+static func _read_trainer_group(rom: RomFile, start: int, end: int) -> Dictionary:
+	var trainers: Array = []
+	var at: int = start
+
+	while true:
+		if end >= 0:
+			if at == end:
+				break
+			if at > end:
+				return {"ok": false, "message": "a trainer's own party walked past the next class."}
+		elif not rom.in_bounds(at) or rom.u8(at) == 0:
+			break
+
+		if trainers.size() >= RomLayout.MAX_TRAINERS_PER_CLASS:
+			return {"ok": false, "message": "more trainers than any real class carries."}
+
+		var trainer: Dictionary = _read_one_trainer(rom, at)
+		if trainer.is_empty():
+			return {"ok": false, "message": "a trainer at $%X did not parse." % at}
+
+		trainers.append(trainer)
+		at = int(trainer["_next"])
+
+	return {"ok": true, "message": "", "trainers": trainers}
+
+
+## One trainer: a $50-terminated name, a type byte, its Pokémon and $FF. Returns
+## an empty Dictionary for anything that does not parse as that shape, which is
+## most byte values, since a level, a species and a move number are all
+## range-checked as they are read.
+static func _read_one_trainer(rom: RomFile, at: int) -> Dictionary:
+	var start: int = at
+	var end: int = at
+	while rom.in_bounds(end) and rom.u8(end) != Gen2Text.TERMINATOR:
+		end += 1
+		if end - start > RomLayout.MAX_NAME_LENGTH:
+			return {}
+	if not rom.in_bounds(end):
+		return {}
+	var name: String = Gen2Text.decode(rom.bytes(), start, end - start)
+
+	var pos: int = end + 1
+	if not rom.in_bounds(pos):
+		return {}
+	var mon_type: int = rom.u8(pos)
+	if not RomLayout.TRAINER_MON_TYPES.has(mon_type):
+		return {}
+	pos += 1
+
+	var party: Array = []
+	while rom.in_bounds(pos) and rom.u8(pos) != RomLayout.TRAINER_PARTY_END:
+		if party.size() >= RomLayout.MAX_TRAINER_PARTY_SIZE:
+			return {}
+		if not rom.in_bounds(pos, 2):
+			return {}
+		var level: int = rom.u8(pos)
+		var species: int = rom.u8(pos + 1)
+		if level < 1 or level > RomLayout.MAX_LEVEL:
+			return {}
+		if species < 1 or species > RomLayout.SPECIES_COUNT:
+			return {}
+		pos += 2
+
+		var extra: int = RomLayout.trainer_mon_extra_size(mon_type)
+		if not rom.in_bounds(pos, extra):
+			return {}
+		var item: int = 0
+		var moves: Array = []
+		if mon_type == RomLayout.TRAINER_MON_ITEM or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+			item = rom.u8(pos)
+			pos += 1
+		if mon_type == RomLayout.TRAINER_MON_MOVES or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+			for slot: int in RomLayout.TRAINER_MON_MOVE_COUNT:
+				var move: int = rom.u8(pos + slot)
+				if move > RomLayout.MOVE_COUNT:
+					return {}
+				moves.append(move)
+			pos += RomLayout.TRAINER_MON_MOVE_COUNT
+
+		party.append({"level": level, "species": species, "item": item, "moves": moves})
+
+	if not rom.in_bounds(pos) or party.is_empty():
+		return {}
+	pos += 1
+
+	return {"name": name, "type": mon_type, "party": party, "_next": pos}
+
+
+## The trainer party table, checked by everything known about it independently:
+## the walk itself (see [method _read_trainer_group]), the one class with no
+## party of its own, the total trainer count, and Falkner's team at one end and
+## the last class's first trainer's name at the other.
+static func verify_trainer_parties(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var result: Dictionary = read_trainer_parties(rom, layout)
+	if not result["ok"]:
+		return result
+
+	var classes: Array = result["classes"]
+	if int(result["total"]) != int(layout["trainer_party_total"]):
+		return {
+			"ok": false,
+			"message": "Read %d trainers, expected %d." % [
+				result["total"], layout["trainer_party_total"],
+			],
+		}
+
+	for trainer_class: int in range(1, classes.size() + 1):
+		var group: Array = classes[trainer_class - 1]
+		var should_be_empty: bool = trainer_class == RomLayout.EMPTY_TRAINER_CLASS
+		if should_be_empty != group.is_empty():
+			return {
+				"ok": false,
+				"message": "Trainer class %d has %d trainers; expected %s." % [
+					trainer_class, group.size(), "none" if should_be_empty else "at least one",
+				],
+			}
+
+	var falkner: Dictionary = classes[0][0]
+	if String(falkner["name"]) != TRAINER_PARTY_FIRST_NAME:
+		return {
+			"ok": false,
+			"message": "Trainer class 1's first trainer: expected %s, read %s." % [
+				TRAINER_PARTY_FIRST_NAME, falkner["name"],
+			],
+		}
+	var falkner_party: Array = falkner["party"]
+	if falkner_party.size() != 2 \
+		or int(falkner_party[0]["level"]) != TRAINER_PARTY_FIRST_LEVEL_1 \
+		or int(falkner_party[0]["species"]) != TRAINER_PARTY_FIRST_SPECIES_1 \
+		or int(falkner_party[1]["level"]) != TRAINER_PARTY_FIRST_LEVEL_2 \
+		or int(falkner_party[1]["species"]) != TRAINER_PARTY_FIRST_SPECIES_2:
+		return {"ok": false, "message": "Falkner's party does not match what is known of it."}
+
+	var last_group: Array = classes[classes.size() - 1]
+	var last_trainer: Dictionary = last_group[0]
+	var wanted_last: String = String(layout["trainer_party_last_trainer"])
+	if String(last_trainer["name"]) != wanted_last:
+		return {
+			"ok": false,
+			"message": "Last trainer class's first trainer: expected %s, read %s." % [
+				wanted_last, last_trainer["name"],
+			],
+		}
+
+	return {"ok": true, "message": ""}
+
+
 ## Resolves one entry of the type name pointer table.
 static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> String:
 	var table: int = RomLayout.type_name_pointer_offset(layout, type_number)
@@ -884,6 +1123,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"types": 0,
 		"matchups": 0,
 		"trainers": 0,
+		"trainer_party_count": 0,
 		"evolutions": 0,
 		"learnset_moves": 0,
 		"elapsed_ms": 0,
@@ -945,6 +1185,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 
 	var evolutions: int = _count_in(species, "evolutions")
 	var learnset_moves: int = _count_in(species, "learnset")
+	var trainer_party_count: int = _count_in(trainers, "trainers")
 
 	var manifest: Dictionary = {
 		"format_version": RomCache.FORMAT_VERSION,
@@ -958,6 +1199,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"type_count": types.size(),
 		"matchup_count": matchups.size(),
 		"trainer_count": trainers.size(),
+		"trainer_party_count": trainer_party_count,
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"atlases": pics,
 		"tiles": tiles,
@@ -974,13 +1216,15 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	result["types"] = types.size()
 	result["matchups"] = matchups.size()
 	result["trainers"] = trainers.size()
+	result["trainer_party_count"] = trainer_party_count
 	result["evolutions"] = evolutions
 	result["learnset_moves"] = learnset_moves
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
 	result["message"] = ("Imported %d species, %d moves, %d items, %d type matchups, "
-		+ "%d trainer classes, %d evolutions and %d level-up moves in %d ms.") % [
+		+ "%d trainer classes carrying %d trainers, %d evolutions and %d level-up moves "
+		+ "in %d ms.") % [
 		species.size(), moves.size(), items.size(), matchups.size(), trainers.size(),
-		evolutions, learnset_moves, result["elapsed_ms"],
+		trainer_party_count, evolutions, learnset_moves, result["elapsed_ms"],
 	]
 	return result
 
@@ -1106,11 +1350,18 @@ func _import_types(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 ## A class has one palette and no shiny counterpart, so the pair is stored flat
 ## rather than under a key, and the pic is found by class number in the trainer
 ## atlas the way a species' is in the front one.
+## Decodes the trainer classes and, behind them, the trainer party table: who
+## carries what. The two are kept on the one entry rather than split into a
+## second cache file, the way a species' evolutions and learnset are, because
+## a class name and its trainers are the two tables one class number addresses,
+## not two separate questions.
 func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var names: PackedStringArray = Gen2Text.decode_sequence(
 		rom.bytes(), int(layout["trainer_class_names"]), count, RomLayout.MAX_NAME_LENGTH
 	)
+	var parties: Dictionary = RomImporter.read_trainer_parties(rom, layout)
+	var classes: Array = parties["classes"] if parties["ok"] else []
 	var out: Array = []
 
 	for trainer_class: int in range(1, count + 1):
@@ -1119,6 +1370,7 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 			"number": trainer_class,
 			"name": names[trainer_class - 1],
 			"palette": [rom.u16le(palette), rom.u16le(palette + Gen2Palette.COLOR_BYTES)],
+			"trainers": classes[trainer_class - 1] if trainer_class - 1 < classes.size() else [],
 		})
 
 		if on_progress.is_valid():

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -254,6 +254,57 @@ const BAR_STEP_PIXELS: int = 2
 ## Every trainer pic is this square, unlike a Pokémon's front pic.
 const TRAINER_PIC_TILES: int = 7
 
+## The trainer *party* table is a second table indexed the same way as the class
+## names, pics and palettes, one pointer per class, and it is where the game's
+## individual trainers actually live. "LEADER" is the class name every gym
+## leader shares; FALKNER is a name stored inside class 1's own party entry,
+## next to the Pokémon he brings. Reading a class's identity therefore always
+## means reading two tables, not one.
+##
+## The pointer is two bytes, in the pointer table's own bank, exactly like
+## [member evos_attacks]: the entries sit in the same bank as the pointers that
+## address them, so there is no bank number to store.
+const TRAINER_PARTY_POINTER_SIZE: int = 2
+
+## What a trainer's Pokémon carries, in the type byte between its name and its
+## first Pokémon. The low bit says whether it holds an item, the high bit
+## whether it knows chosen moves rather than whatever its level teaches it.
+const TRAINER_MON_NORMAL: int = 0
+const TRAINER_MON_MOVES: int = 1
+const TRAINER_MON_ITEM: int = 2
+const TRAINER_MON_ITEM_MOVES: int = 3
+const TRAINER_MON_TYPES: Array = [
+	TRAINER_MON_NORMAL, TRAINER_MON_MOVES, TRAINER_MON_ITEM, TRAINER_MON_ITEM_MOVES,
+]
+
+## How many move slots a stored-moves Pokémon carries in the table, whatever a
+## zero slot in it means: nothing, the way [Gen2BattleMon] treats one.
+const TRAINER_MON_MOVE_COUNT: int = 4
+
+## One trainer's Pokémon list ends here; so does a class's whole party group, but
+## the two terminators are not read the same way. A Pokémon's own end is read
+## for real; a group's is only reached by the *next* class's pointer, because
+## nothing marks a group's end from inside it. See [constant EMPTY_TRAINER_CLASS].
+const TRAINER_PARTY_END: int = 0xFF
+
+## What a trainer can carry. Six is the real maximum in all three games, not a
+## rule this layout invents.
+const MAX_TRAINER_PARTY_SIZE: int = 6
+
+## Runaway guard for a single class's trainers, well past the real maximum of 31
+## (the wandering trainer classes: YOUNGSTER, LASS and the like carry the most).
+const MAX_TRAINERS_PER_CLASS: int = 64
+
+## The one trainer class with no party of its own: the eleven o'clock scholar,
+## Professor Elm's class in the class table, whose name and pic exist but who
+## the games never send into a battle. Its own label in the source is followed
+## immediately by the next class's with nothing between, so its pointer equals
+## the next class's, and the honest reading of that is zero trainers rather than
+## a copy of somebody else's. Confirmed against pret's own party data
+## (`PokemonProfGroup` has no entries before `WillGroup`, in that order), and
+## the same class number in every game.
+const EMPTY_TRAINER_CLASS: int = 10
+
 ## Back pics are always this square. Front pics vary and carry their own size in
 ## the base stats.
 const BACKPIC_TILES: int = 6
@@ -319,6 +370,9 @@ const GOLD_SILVER: Dictionary = {
 	"trainer_class_names": 0x1B0955,
 	"trainer_classes": 66,
 	"trainer_last_class": "ROCKET",
+	"trainer_parties": 0x3993E,
+	"trainer_party_total": 495,
+	"trainer_party_last_trainer": "GRUNT",
 	# Gold and Silver patch three bank numbers and pass the rest through. The
 	# stored value is what the linker assigned before three pic sections were
 	# moved; see FixPicBank in pokegold.
@@ -350,6 +404,9 @@ const CRYSTAL: Dictionary = {
 	"trainer_class_names": 0x2C1EF,
 	"trainer_classes": 67,
 	"trainer_last_class": "MYSTICALMAN",
+	"trainer_parties": 0x39999,
+	"trainer_party_total": 541,
+	"trainer_party_last_trainer": "EUSINE",
 	# Crystal's equivalent table is a contiguous $48-$5F, so the whole remap
 	# collapses to a constant: PICS_FIX in pokecrystal.
 	"pic_bank_add": 0x36,
@@ -430,6 +487,25 @@ static func trainer_pic_pointer_offset(layout: Dictionary, trainer_class: int) -
 ## number minus one. The two are one entry out of step on purpose.
 static func trainer_palette_offset(layout: Dictionary, trainer_class: int) -> int:
 	return int(layout["trainer_palettes"]) + trainer_class * Gen2Palette.PAIR_BYTES
+
+
+## Where a trainer class's own pointer sits in the trainer party table. The
+## pointer itself still has to be resolved through [method bank_of] on this
+## offset and [method RomFile.linear], the same as [method evos_attacks_pointer_offset].
+static func trainer_party_pointer_offset(layout: Dictionary, trainer_class: int) -> int:
+	return int(layout["trainer_parties"]) + (trainer_class - 1) * TRAINER_PARTY_POINTER_SIZE
+
+
+## How many bytes one Pokémon occupies in a trainer's party, past its level and
+## species: nothing for [constant TRAINER_MON_NORMAL], an item, four moves, or
+## both, depending on the type byte its trainer opens with.
+static func trainer_mon_extra_size(mon_type: int) -> int:
+	var size: int = 0
+	if mon_type == TRAINER_MON_ITEM or mon_type == TRAINER_MON_ITEM_MOVES:
+		size += 1
+	if mon_type == TRAINER_MON_MOVES or mon_type == TRAINER_MON_ITEM_MOVES:
+		size += TRAINER_MON_MOVE_COUNT
+	return size
 
 
 static func move_data_offset(layout: Dictionary, move: int) -> int:

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -39,8 +39,23 @@ func _write_cache(complete: bool = true) -> void:
 		_matchup(RomLayout.TYPE_NORMAL, RomLayout.TYPE_GHOST, RomLayout.MATCHUP_NO_EFFECT, true),
 	])
 	RomCache.write_json(RomCache.trainers_path(_directory), [
-		{"number": 1, "name": "LEADER", "palette": [0x1234, 0x5678]},
-		{"number": 2, "name": "YOUNGSTER", "palette": [0x0C63, 0x1084]},
+		{
+			"number": 1, "name": "LEADER", "palette": [0x1234, 0x5678],
+			"trainers": [
+				{
+					"name": "FALKNER", "type": RomLayout.TRAINER_MON_NORMAL,
+					"party": [
+						{"level": 7, "species": 1, "item": 0, "moves": []},
+						{"level": 9, "species": 2, "item": 0, "moves": []},
+					],
+				},
+				{
+					"name": "PICKY", "type": RomLayout.TRAINER_MON_ITEM_MOVES,
+					"party": [{"level": 20, "species": 1, "item": 5, "moves": [1, 0, 0, 0]}],
+				},
+			],
+		},
+		{"number": 2, "name": "YOUNGSTER", "palette": [0x0C63, 0x1084], "trainers": []},
 	])
 	RomCache.write_indices(RomCache.pic_path(_directory, "front"), PackedByteArray([
 		0, 0, 1, 1,
@@ -277,6 +292,36 @@ func test_an_unknown_trainer_class_answers_empty() -> void:
 	_write_cache()
 	var data: GameData = GameData.open_directory(_directory)
 	assert_true(data.trainer(0).is_empty(), "class 0 is the player, who has no entry")
+
+
+func test_a_trainer_classs_own_trainers_are_counted_and_read_back() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.trainer_party_count(1), 2)
+	assert_eq(data.trainer_party_count(2), 0, "the one class this cache gives no party")
+
+	var falkner: Dictionary = data.trainer_party(1, 0)
+	assert_eq(falkner["name"], "FALKNER")
+	assert_eq(falkner["type"], RomLayout.TRAINER_MON_NORMAL)
+	assert_eq((falkner["party"] as Array).size(), 2)
+	assert_eq(int(falkner["party"][1]["level"]), 9, "JSON's one number type, coerced back")
+	assert_eq(int(falkner["party"][1]["species"]), 2)
+
+
+func test_a_stored_moves_trainers_item_and_moves_read_back_as_ints() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var picky: Dictionary = data.trainer_party(1, 1)
+	var mon: Dictionary = picky["party"][0]
+	assert_eq(int(mon["item"]), 5)
+	assert_eq(mon["moves"], [1, 0, 0, 0])
+
+
+func test_an_out_of_range_trainer_party_index_answers_empty() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_true(data.trainer_party(1, 2).is_empty())
+	assert_true(data.trainer_party(1, -1).is_empty())
 	assert_true(data.trainer_pic(99).is_empty())
 	assert_eq(data.trainer_name(99), "")
 

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -276,6 +276,237 @@ func test_a_dump_with_no_trainers_in_it_fails() -> void:
 	assert_false(RomImporter.verify_trainers(_rom(data), _layout)["ok"])
 
 
+## A plausible trainer party table for the real GOLD layout: Falkner's own team
+## at class 1, the one empty class genuinely empty, a filler trainer in every
+## other class, and the last class carrying whatever name the layout expects,
+## the whole table adding up to the exact total the layout knows.
+##
+## The known facts here (Falkner's team, the empty class, the total, the last
+## trainer's name) are the same kind pinned elsewhere in this file (Bulbasaur's
+## evolution, Tyrogue's three): real content, hand-verified against the
+## cartridges once, not bytes copied out of one.
+func _trainer_party_dump() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_trainer_parties(data, _trainer_party_classes())
+	return data
+
+
+func _trainer_party_classes() -> Array:
+	var count: int = RomLayout.trainer_class_count(_layout)
+	var total: int = int(_layout["trainer_party_total"])
+	var last_name: String = String(_layout["trainer_party_last_trainer"])
+
+	var classes: Array = []
+	classes.resize(count)
+	for i: int in count:
+		classes[i] = []
+
+	classes[0] = [{
+		"name": RomImporter.TRAINER_PARTY_FIRST_NAME, "type": RomLayout.TRAINER_MON_NORMAL,
+		"party": [
+			{"level": RomImporter.TRAINER_PARTY_FIRST_LEVEL_1,
+				"species": RomImporter.TRAINER_PARTY_FIRST_SPECIES_1},
+			{"level": RomImporter.TRAINER_PARTY_FIRST_LEVEL_2,
+				"species": RomImporter.TRAINER_PARTY_FIRST_SPECIES_2},
+		],
+	}]
+	# RomLayout.EMPTY_TRAINER_CLASS is left as the empty Array _trainer_party_classes()
+	# already gave it.
+	classes[count - 1] = [{
+		"name": last_name, "type": RomLayout.TRAINER_MON_NORMAL,
+		"party": [{"level": 5, "species": 1}],
+	}]
+
+	# Every other class gets one filler trainer each, and the remaining total is
+	# spread across them as evenly as a per-class cap allows, the same way
+	# _evos_entries() pads out the evolution count.
+	var filler_classes: Array = []
+	for trainer_class: int in range(1, count + 1):
+		if trainer_class != 1 and trainer_class != RomLayout.EMPTY_TRAINER_CLASS \
+			and trainer_class != count:
+			filler_classes.append(trainer_class)
+
+	var remaining: int = total - 2
+	var base: int = remaining / filler_classes.size()
+	var extra: int = remaining % filler_classes.size()
+	for i: int in filler_classes.size():
+		var trainer_class: int = filler_classes[i]
+		var mine: int = base + (1 if i < extra else 0)
+		var trainers: Array = []
+		for _n: int in mine:
+			trainers.append({
+				"name": "FILLER", "type": RomLayout.TRAINER_MON_NORMAL,
+				"party": [{"level": 5, "species": 1}],
+			})
+		classes[trainer_class - 1] = trainers
+
+	return classes
+
+
+## Writes the pointer table and, right behind it in the same bank, every
+## class's trainers back to back in class order. An empty class writes nothing
+## at all, so its pointer ends up equal to the next class's: the same thing the
+## real cartridge does for the one class with no party of its own.
+func _write_trainer_parties(data: PackedByteArray, classes: Array) -> void:
+	var table: int = int(_layout["trainer_parties"])
+	var bank: int = RomLayout.bank_of(table)
+	var at: int = table + classes.size() * RomLayout.TRAINER_PARTY_POINTER_SIZE
+
+	for i: int in classes.size():
+		var address: int = RomFile.BANK_SIZE + (at % RomFile.BANK_SIZE)
+		var pointer: int = table + i * RomLayout.TRAINER_PARTY_POINTER_SIZE
+		data[pointer] = address & 0xFF
+		data[pointer + 1] = address >> 8
+
+		for trainer: Dictionary in (classes[i] as Array):
+			var encoded: PackedByteArray = Gen2Text.encode(String(trainer["name"]))
+			encoded.append(Gen2Text.TERMINATOR)
+			_write(data, at, encoded)
+			at += encoded.size()
+			data[at] = int(trainer["type"])
+			at += 1
+			for mon: Dictionary in (trainer["party"] as Array):
+				data[at] = int(mon["level"])
+				data[at + 1] = int(mon["species"])
+				at += 2
+			data[at] = RomLayout.TRAINER_PARTY_END
+			at += 1
+
+	assert(RomLayout.bank_of(at) == bank, "the filler table overran its own bank")
+
+
+func test_a_plausible_trainer_party_table_verifies() -> void:
+	var result: Dictionary = RomImporter.verify_trainer_parties(_rom(_trainer_party_dump()), _layout)
+	assert_true(result["ok"], result["message"])
+
+
+func test_falkners_team_reads_back() -> void:
+	var result: Dictionary = RomImporter.read_trainer_parties(_rom(_trainer_party_dump()), _layout)
+	assert_true(result["ok"], result["message"])
+	var falkner: Dictionary = result["classes"][0][0]
+	assert_eq(String(falkner["name"]), "FALKNER")
+	assert_eq((falkner["party"] as Array).size(), 2)
+	assert_eq(int(falkner["party"][1]["species"]), RomImporter.TRAINER_PARTY_FIRST_SPECIES_2)
+
+
+func test_the_one_class_with_no_party_reads_back_empty() -> void:
+	var result: Dictionary = RomImporter.read_trainer_parties(_rom(_trainer_party_dump()), _layout)
+	assert_true(result["ok"], result["message"])
+	var empty_class: Array = result["classes"][RomLayout.EMPTY_TRAINER_CLASS - 1]
+	assert_eq(empty_class.size(), 0)
+
+
+func test_a_trainer_class_that_is_not_empty_where_the_layout_says_it_is_fails() -> void:
+	var classes: Array = _trainer_party_classes()
+	classes[RomLayout.EMPTY_TRAINER_CLASS - 1] = [{
+		"name": "OOPS", "type": RomLayout.TRAINER_MON_NORMAL, "party": [{"level": 5, "species": 1}],
+	}]
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_trainer_parties(data, classes)
+	var result: Dictionary = RomImporter.verify_trainer_parties(_rom(data), _layout)
+	assert_false(result["ok"])
+
+
+func test_a_trainer_party_with_the_wrong_total_fails() -> void:
+	var classes: Array = _trainer_party_classes()
+	classes[1] = []
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_trainer_parties(data, classes)
+	var result: Dictionary = RomImporter.verify_trainer_parties(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "trainers")
+
+
+func test_falkners_team_not_matching_what_is_known_fails() -> void:
+	var classes: Array = _trainer_party_classes()
+	classes[0][0]["party"][0]["species"] = 99
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_trainer_parties(data, classes)
+	var result: Dictionary = RomImporter.verify_trainer_parties(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "Falkner")
+
+
+func test_a_stored_moves_trainer_reads_its_moves_and_item() -> void:
+	var classes: Array = _trainer_party_classes()
+	classes[1] = [{
+		"name": "PICKY", "type": RomLayout.TRAINER_MON_ITEM_MOVES,
+		"party": [{"level": 20, "species": 4, "item": 5, "moves": [10, 20, 0, 0]}],
+	}]
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_full_trainer_parties(data, classes)
+	var result: Dictionary = RomImporter.read_trainer_parties(_rom(data), _layout)
+	assert_true(result["ok"], result["message"])
+	var mon: Dictionary = result["classes"][1][0]["party"][0]
+	assert_eq(int(mon["item"]), 5)
+	assert_eq(mon["moves"], [10, 20, 0, 0])
+
+
+## The general form of [method _write_trainer_parties], which only ever wrote
+## the type byte, level and species: this one also writes an item byte and four
+## move bytes when the type says a Pokémon carries them, for the one test that
+## needs a MOVES or ITEM trainer rather than a plain one.
+func _write_full_trainer_parties(data: PackedByteArray, classes: Array) -> void:
+	var table: int = int(_layout["trainer_parties"])
+	var at: int = table + classes.size() * RomLayout.TRAINER_PARTY_POINTER_SIZE
+
+	for i: int in classes.size():
+		var address: int = RomFile.BANK_SIZE + (at % RomFile.BANK_SIZE)
+		var pointer: int = table + i * RomLayout.TRAINER_PARTY_POINTER_SIZE
+		data[pointer] = address & 0xFF
+		data[pointer + 1] = address >> 8
+
+		for trainer: Dictionary in (classes[i] as Array):
+			var mon_type: int = int(trainer["type"])
+			var encoded: PackedByteArray = Gen2Text.encode(String(trainer["name"]))
+			encoded.append(Gen2Text.TERMINATOR)
+			_write(data, at, encoded)
+			at += encoded.size()
+			data[at] = mon_type
+			at += 1
+			for mon: Dictionary in (trainer["party"] as Array):
+				data[at] = int(mon["level"])
+				data[at + 1] = int(mon["species"])
+				at += 2
+				if mon_type == RomLayout.TRAINER_MON_ITEM \
+					or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+					data[at] = int(mon.get("item", 0))
+					at += 1
+				if mon_type == RomLayout.TRAINER_MON_MOVES \
+					or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+					for move: Variant in (mon.get("moves", [0, 0, 0, 0]) as Array):
+						data[at] = int(move)
+						at += 1
+			data[at] = RomLayout.TRAINER_PARTY_END
+			at += 1
+
+
+func test_a_trainer_pointer_outside_the_banked_window_fails() -> void:
+	var data: PackedByteArray = _trainer_party_dump()
+	data[int(_layout["trainer_parties"]) + 1] = 0x20
+	assert_false(RomImporter.verify_trainer_parties(_rom(data), _layout)["ok"])
+
+
+func test_a_trainer_party_pointer_table_with_no_terminator_anywhere_fails() -> void:
+	# The failure the last class's own walk exists for: nothing bounds it but a
+	# padding byte, and a dump with none reads on into whatever comes next.
+	var data: PackedByteArray = _trainer_party_dump()
+	var count: int = RomLayout.trainer_class_count(_layout)
+	var last_pointer: int = int(_layout["trainer_parties"]) \
+		+ (count - 1) * RomLayout.TRAINER_PARTY_POINTER_SIZE
+	var address: int = data[last_pointer] | (data[last_pointer + 1] << 8)
+	var bank: int = RomLayout.bank_of(int(_layout["trainer_parties"]))
+	var at: int = RomFile.linear(bank, address)
+	for i: int in RomFile.BANK_SIZE - (at % RomFile.BANK_SIZE):
+		data[at + i] = 0x41
+	assert_false(RomImporter.verify_trainer_parties(_rom(data), _layout)["ok"])
+
+
 ## A battle sheet at every offset the layout claims: two bars that count up, and
 ## two HUD borders whose tiles all differ.
 func _battle_dump() -> PackedByteArray:

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -150,6 +150,46 @@ func test_the_trainer_tables_do_not_run_off_the_end() -> void:
 		)
 
 
+func test_the_trainer_party_table_is_a_flat_run_of_pointers() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		assert_eq(
+			RomLayout.trainer_party_pointer_offset(layout, 1),
+			int(layout["trainer_parties"]), "%s parties start at the first class" % id
+		)
+		assert_eq(
+			RomLayout.trainer_party_pointer_offset(layout, 2),
+			int(layout["trainer_parties"]) + RomLayout.TRAINER_PARTY_POINTER_SIZE
+		)
+
+
+func test_the_trainer_party_table_does_not_run_off_the_end() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		var count: int = RomLayout.trainer_class_count(layout)
+		assert_lt(
+			RomLayout.trainer_party_pointer_offset(layout, count)
+				+ RomLayout.TRAINER_PARTY_POINTER_SIZE,
+			RomRegistry.EXPECTED_SIZE
+		)
+
+
+## A NORMAL Pokémon is level and species only; the other three types add an
+## item, four moves, or both, on top of that, never fewer than either half asks
+## for on its own.
+func test_a_trainer_mons_extra_size_matches_what_its_type_byte_says_it_carries() -> void:
+	assert_eq(RomLayout.trainer_mon_extra_size(RomLayout.TRAINER_MON_NORMAL), 0)
+	assert_eq(RomLayout.trainer_mon_extra_size(RomLayout.TRAINER_MON_ITEM), 1)
+	assert_eq(
+		RomLayout.trainer_mon_extra_size(RomLayout.TRAINER_MON_MOVES),
+		RomLayout.TRAINER_MON_MOVE_COUNT
+	)
+	assert_eq(
+		RomLayout.trainer_mon_extra_size(RomLayout.TRAINER_MON_ITEM_MOVES),
+		RomLayout.TRAINER_MON_MOVE_COUNT + 1
+	)
+
+
 func test_unown_forms_are_zero_based() -> void:
 	var layout: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
 	assert_eq(

--- a/tests/unit/test_trainer_party.gd
+++ b/tests/unit/test_trainer_party.gd
@@ -1,0 +1,157 @@
+extends GutTest
+
+## Turning one of a trainer class's own trainers into a battle-ready party.
+##
+## Builds its own small cache, the same way [code]test_game_data.gd[/code]
+## does: nothing here opens a cartridge, only [GameData] reading back what was
+## written the way the importer writes it.
+
+## Species and move numbers are arbitrary here: [GameData] indexes its species
+## table by position, so this cache's array has to be exactly as long as the
+## highest number used, which small numbers make easy to keep straight.
+const PIDGEY: int = 1
+const PIDGEOTTO: int = 2
+const TACKLE: int = 1
+const MUD_SLAP: int = 2
+const GUST: int = 3
+
+var _directory: String = ""
+var _data: GameData = null
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"trainerpartytest", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+	_data = GameData.open_directory(_directory)
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _write_cache() -> void:
+	RomCache.write_json(RomCache.species_path(_directory), [
+		{
+			"number": PIDGEY, "name": "PIDGEY",
+			"stats": {"hp": 40, "attack": 45, "defense": 40, "speed": 56,
+				"sp_attack": 35, "sp_defense": 35},
+			"types": [0, 0], "front_tiles": [7, 7],
+			"palette": {"normal": [0x1234, 0x5678], "shiny": [0x0C63, 0x1084]},
+			"learnset": [{"level": 1, "move": TACKLE}, {"level": 5, "move": MUD_SLAP}],
+		},
+		{
+			"number": PIDGEOTTO, "name": "PIDGEOTTO",
+			"stats": {"hp": 63, "attack": 60, "defense": 55, "speed": 71,
+				"sp_attack": 50, "sp_defense": 50},
+			"types": [0, 0], "front_tiles": [7, 7],
+			"palette": {"normal": [0x1234, 0x5678], "shiny": [0x0C63, 0x1084]},
+			"learnset": [
+				{"level": 1, "move": TACKLE}, {"level": 5, "move": MUD_SLAP},
+				{"level": 9, "move": GUST},
+			],
+		},
+	])
+	RomCache.write_json(RomCache.moves_path(_directory), [
+		{"number": TACKLE, "name": "TACKLE"},
+		{"number": MUD_SLAP, "name": "MUD-SLAP"},
+		{"number": GUST, "name": "GUST"},
+	])
+	RomCache.write_json(RomCache.items_path(_directory), [])
+	RomCache.write_json(RomCache.types_path(_directory), [{"number": 0, "name": "NORMAL"}])
+	RomCache.write_json(RomCache.matchups_path(_directory), [])
+	RomCache.write_json(RomCache.trainers_path(_directory), [
+		{
+			"number": 1, "name": "LEADER", "palette": [0x1234, 0x5678],
+			"trainers": [
+				{
+					"name": "FALKNER", "type": RomLayout.TRAINER_MON_NORMAL,
+					"party": [
+						{"level": 7, "species": PIDGEY, "item": 0, "moves": []},
+						{"level": 9, "species": PIDGEOTTO, "item": 0, "moves": []},
+					],
+				},
+				{
+					"name": "PICKY", "type": RomLayout.TRAINER_MON_ITEM_MOVES,
+					"party": [{
+						"level": 20, "species": PIDGEOTTO, "item": 5,
+						"moves": [GUST, TACKLE, 0, 0],
+					}],
+				},
+			],
+		},
+	])
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "trainerpartytest",
+		"sha1": "0123456789abcdef",
+		"complete": true,
+	})
+
+
+func test_a_normal_trainers_pokemon_knows_what_its_level_teaches_it() -> void:
+	var party: Gen2Party = Gen2TrainerParty.build(_data, 1, 0)
+	assert_not_null(party)
+	assert_eq(party.size(), 2)
+
+	var lead: Gen2BattleMon = party.at(0)
+	assert_eq(lead.species, PIDGEY)
+	assert_eq(lead.level, 7)
+	assert_eq(lead.moves, [TACKLE, MUD_SLAP], "everything a level 7 Pidgey has learned")
+
+	var second: Gen2BattleMon = party.at(1)
+	assert_eq(second.species, PIDGEOTTO)
+	assert_eq(second.moves, [TACKLE, MUD_SLAP, GUST])
+
+
+func test_trainer_pokemon_are_full_health_with_no_stat_experience() -> void:
+	var party: Gen2Party = Gen2TrainerParty.build(_data, 1, 0)
+	var lead: Gen2BattleMon = party.at(0)
+	assert_eq(lead.hp, lead.max_hp())
+	assert_eq(lead.dvs, Gen2BattleMon.PERFECT_DVS)
+	assert_eq(lead.stat_exp, {})
+
+
+func test_a_stored_moves_trainers_pokemon_knows_exactly_what_is_stored() -> void:
+	var party: Gen2Party = Gen2TrainerParty.build(_data, 1, 1)
+	var mon: Gen2BattleMon = party.at(0)
+	assert_eq(mon.moves, [GUST, TACKLE], "the two real slots, the zero padding dropped")
+	assert_eq(mon.item, 5)
+
+
+func test_a_normal_trainers_pokemon_holds_nothing() -> void:
+	var party: Gen2Party = Gen2TrainerParty.build(_data, 1, 0)
+	assert_eq(party.at(0).item, 0)
+
+
+func test_an_unknown_trainer_or_index_answers_null() -> void:
+	assert_null(Gen2TrainerParty.build(_data, 99, 0))
+	assert_null(Gen2TrainerParty.build(_data, 1, 9))
+	assert_null(Gen2TrainerParty.build(null, 1, 0))
+
+
+## Falkner's own party through a real battle: this is what
+## [code]battle_screen.gd[/code]'s [code]show_trainer[/code] puts on the enemy's
+## side, so the same replacement path it draws is worth proving here, where an
+## assertion can check it rather than an eye.
+func test_falkners_pidgeotto_replaces_his_pidgey_after_it_faints() -> void:
+	var enemy: Gen2Party = Gen2TrainerParty.build(_data, 1, 0)
+	var player: Gen2Party = Gen2Party.of(Gen2BattleMon.create(_data, PIDGEY, 30, [TACKLE]))
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, player, enemy, RandomNumberGenerator.new()
+	)
+	assert_not_null(battle)
+	assert_eq(battle.enemy.species, PIDGEY, "Falkner leads with his level 7 Pidgey")
+
+	battle.enemy.take_damage(battle.enemy.max_hp())
+	assert_true(battle.must_replace(Gen2Battle.ENEMY))
+
+	var events: Array = battle.send_out(Gen2Battle.ENEMY, 1)
+	assert_eq(battle.enemy.species, PIDGEOTTO)
+	assert_eq(battle.enemy.level, 9)
+	assert_false(battle.must_replace(Gen2Battle.ENEMY))
+
+	var sent_out: Dictionary = events[events.size() - 1]
+	assert_eq(sent_out["type"], Gen2Battle.SENT_OUT)
+	assert_eq(int(sent_out["level"]), 9, "the level battle_screen.gd reads out of the event")

--- a/tests/unit/test_trainer_party.gd.uid
+++ b/tests/unit/test_trainer_party.gd.uid
@@ -1,0 +1,1 @@
+uid://bgi6qbquav8rd

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -105,6 +105,8 @@ func _dump(directory: String, table: String) -> void:
 		"matchups":
 			print("\n%s (%d)" % [table, (rows as Array).size()])
 			_dump_matchups(directory, rows)
+		"trainers":
+			_dump_trainers(directory, rows)
 		"learnsets":
 			_dump_learnsets(directory, rows)
 		"evolutions":
@@ -155,6 +157,48 @@ func _dump_evolutions(directory: String, rows: Array) -> void:
 			parts.append(_describe_evolution(evolution, items, species))
 		print("  %3d  %-11s %s" % [int(row["number"]), String(row["name"]), "; ".join(parts)])
 	print("  %d evolutions" % total)
+
+
+## Every trainer class, and behind it every individual trainer's own party.
+## Reading this is the check the runtime one cannot be: a level, a species and
+## a move number are all in range whatever a wrong pointer does, but a group
+## that reads Falkner's Pidgey and Pidgeotto, or that leaves the one empty
+## class empty, is right and one that does not is not.
+func _dump_trainers(directory: String, rows: Array) -> void:
+	var species: Array = _names_in(RomCache.species_path(directory))
+	var moves: Array = _names_in(RomCache.moves_path(directory))
+	var items: Array = _names_in(RomCache.items_path(directory))
+	var total: int = 0
+
+	print("\ntrainers (%d classes)" % rows.size())
+	for row: Dictionary in rows:
+		print("  %s" % _describe("trainers", row))
+		var trainers: Array = row.get("trainers", [])
+		total += trainers.size()
+		for trainer: Dictionary in trainers:
+			var parts: PackedStringArray = []
+			for mon: Dictionary in (trainer.get("party", []) as Array):
+				parts.append(_describe_trainer_mon(mon, species, moves, items))
+			print("    %-13s %s" % [String(trainer["name"]), "; ".join(parts)])
+
+	print("  %d trainers" % total)
+
+
+func _describe_trainer_mon(mon: Dictionary, species: Array, moves: Array, items: Array) -> String:
+	var out: String = "%d %s" % [int(mon["level"]), _name_at(species, int(mon["species"]))]
+
+	var item: int = int(mon.get("item", 0))
+	if item != 0:
+		out += " @ %s" % _name_at(items, item)
+
+	var move_names: PackedStringArray = []
+	for move: Variant in (mon.get("moves", []) as Array):
+		if int(move) != 0:
+			move_names.append(_name_at(moves, int(move)))
+	if not move_names.is_empty():
+		out += " (%s)" % ", ".join(move_names)
+
+	return out
 
 
 func _describe_evolution(evolution: Dictionary, items: Array, species: Array) -> String:


### PR DESCRIPTION
Locates the trainer party table (one pointer per class, in the pointer table's own bank) and decodes every individual trainer's name, party, held item and chosen moves, for all three games. Gen2TrainerParty turns one into a real Gen2Party, and battle_screen.gd's show_trainer puts it on the enemy's side instead of the invented placeholder.

The class table ("LEADER") and a trainer's own identity ("FALKNER") turn out to be two separate tables read through two different pointers, and one class (Professor Elm's) genuinely carries nobody rather than being a decoding gap, which settles how the table is walked: in class order, bounded by the next class's own pointer, not by sorting addresses and taking the next higher one.

Verified against the published rosters for all eight gym leaders, the Elite Four, and both rivals.