### PR TITLE
Award experience and levelling up on a faint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ the same thing for Generation 1.
 > trainer class's own AI flags rather than a random pick, and every trainer's
 > Pokémon carries its own class's DVs rather than a perfect set. Multi-hit
 > moves, drain moves, Dream Eater, the fixed-damage moves and OHKOs all have
-> their own sequence now; Disable, Attract, Mist, Focus Energy, Counter and
-> Mirror Coat are still an ordinary attack, and the overworld, audio and the
-> mod loader do not exist.
+> their own sequence now, and a battle that ends awards something: the winner
+> gains experience and stat experience off the cartridge's own six growth
+> curves, levels up, recalculates its stats and picks up whatever its
+> learnset teaches along the way, with the exp bar moving to match. Disable,
+> Attract, Mist, Focus Energy, Counter and Mirror Coat are still an ordinary
+> attack, and the overworld, audio and the mod loader do not exist.
 > There is nothing playable here today.
 
 ## Getting started
@@ -160,6 +163,14 @@ the next one out is sent in. `W` switches, which costs the turn: the other side
 attacks whoever came in. Left and right change which Pokémon are on it, and `S`
 and `D` take health off the player's and the enemy's without a turn, which is
 the fastest way to see the bars change colour.
+
+Beating one of the enemy's Pokémon now awards experience: the player's own
+Pokémon gains it and its stat experience, levels up if it has earned it, and
+learns whatever its learnset teaches along the way, straight into an empty
+move slot or offered for one already taken. Nothing on this screen asks which
+move to give up yet, because the menu for that does not exist either, so an
+offer is declined automatically; `Gen2Battle.learn_move` and `decline_move`
+are the real answer for whatever asks properly later.
 
 Both Pokémon know what their level says they know, out of the learnset. The
 player still picks at random from those moves, because the menu does not exist

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -109,6 +109,7 @@ battle can be fought inside a test:
 | `battle/move_effect.gd` | Which steps each effect byte is made of |
 | `battle/battle.gd` | The turn: order, the switch, and running a move's steps |
 | `battle/ai.gd` | A trainer class's own AI: scores each move slot off its AI flags |
+| `battle/experience.gd` | The six growth curves, what a faint is worth, and how it splits |
 
 Everything in there is integer arithmetic in the order the hardware does it.
 That is not nostalgia. Every step truncates and the steps do not commute, so a
@@ -178,6 +179,36 @@ discipline the move table itself uses. See `HANDOFF.md`'s "Deliberate" section
 for what else the AI does not cover (a trainer's switch and item decisions,
 Razor Wind/Solar Beam/Fly's own handlers, which read weather and a
 semi-invulnerability substatus nothing here tracks).
+
+`Gen2Experience.total_exp_at` is the six growth curves as `CalcExpAtLevel`'s own
+formula, `exp(n) = floor(a*n^3/b) + c*n^2 + d*n - e`, pinned against
+pokecrystal's `data/growth_rates.asm` and checked against all 251 species in
+all three real games rather than trusted on the strength of the disassembly
+alone: see `tools/dump_tables.gd`'s `growth` view. `Gen2Battle` calls it from
+`_award_experience`, which runs once a turn, after `_residual_damage`, and
+reads every `FAINTED` event the turn produced rather than hooking a faint at
+its source: a faint can come from a move landing or from a status ticking, and
+this is the one point downstream of both. Experience itself is never divided
+among participants; only the stat experience `Gen2Experience.stat_exp_gain`
+works out is, which is the opposite of what dividing *something* for multiple
+participants might suggest, and is the cartridge's own rule rather than a
+simplification of it. Participants are tracked per side as whoever has been
+sent out since the opponent currently out was sent in, added to on
+`send_out`, and reset to whoever is left standing once experience has been
+given for that opponent's own faint, which is what lets a benched-but-alive
+switch-in still be credited for a kill it did not personally land. Levelling
+up and learning a move both ride on the same event: `_give_experience_to`
+loops one level at a time from old to new, because a move taught partway up a
+multi-level jump has to be checked at the level that actually teaches it, not
+at the last one reached. A move that finds an empty slot is learned without a
+question, the same as the cartridge asks none when there is nowhere for the
+answer to go; a full moveset gets a third policy hole, the same shape as
+`must_replace`: `Gen2Battle.must_learn_move`, `pending_learn`, `learn_move`
+and `decline_move` refuse to let a battle continue until an offer is answered,
+because which move to give up is not this engine's decision to make on its
+own. `battle_screen.gd` answers every such offer with `decline_move`
+automatically, since no menu exists yet to ask a person; see `HANDOFF.md`'s
+"Scaffolding" section.
 
 **A move is a short program, not a special case.** The cartridge keeps a list of
 commands per effect byte and runs them in order, and an ordinary attack is the
@@ -397,6 +428,16 @@ So every offset ships with a check that would fail if it were wrong, and
   sequence, the same technique the font, the matchup chart and the attributes
   table were found with, and it matched byte for byte across all 66 or 67
   classes in every game.
+- A species' growth rate and base experience are already inside the species
+  table, at an offset this project had decoded and shipped since the
+  importer's first session, and neither field had ever been read for anything
+  until `Gen2Experience` did. Both were plausible either way: a growth rate
+  byte 0-5 and a base exp byte are both legal values whatever the offset is,
+  so nothing about decoding them wrong would have looked wrong. What settled
+  them was reading a name against a curve published independently for every
+  one of the 251 species in all three games, not a handful of anchors: see
+  `tools/dump_tables.gd`'s `growth` view and the table it is checked against
+  in `data/pokemon/base_stats/*.asm`.
 
 When you add an offset, add its check. "It produced output" is not evidence.
 
@@ -460,6 +501,11 @@ check can only prove the shape. Every level and every move number stays in range
 whatever a wrong pointer does, so what settles it is reading Bulbasaur's list
 back and finding Tackle at 1 and Growl at 4, and reading Eevee's five evolutions
 and Tyrogue's three. Both resolve their numbers into names for that reason.
+
+`growth` is the same idea again for the two fields nothing structural can
+check: a growth rate byte and a base exp byte are both legal whatever the
+offset is, so what settles them is reading a name against a curve published
+independently, the same as the learnsets above.
 
 ## Seeing the UI without pressing Play
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -82,6 +82,30 @@ const WITHDREW: StringName = &"withdrew"
 const SENT_OUT: StringName = &"sent_out"
 const OVER: StringName = &"over"
 
+## Experience, once whoever fainted's own opponent has somebody left to award
+## it to. Never emitted for [constant ENEMY]: the cartridge's own
+## [code]GiveExperiencePoints[/code] only ever reads the player's own party
+## structure, so a trainer's Pokémon are never on the receiving end of this,
+## only ever the reason for it.
+const EXP_GAINED: StringName = &"exp_gained"
+## The five stats in [constant Gen2Experience.STAT_EXP_KEYS], split among
+## [constant Gen2Battle] participants the way [method Gen2Experience.stat_exp_gain]
+## splits them, none of it the same number as [constant EXP_GAINED].
+const STAT_EXP_GAINED: StringName = &"stat_exp_gained"
+## A level gained from the experience just awarded. [code]old_stats[/code] and
+## [code]new_stats[/code] are both [Gen2BattleMon.stats], so a screen can show
+## what moved without asking the Pokémon twice.
+const GREW_LEVEL: StringName = &"grew_level"
+## A move learned into a slot that had nothing in it, no question asked because
+## the cartridge does not ask one when there is nowhere for the answer to go.
+const MOVE_LEARNED: StringName = &"move_learned"
+## Every slot already held something, so nothing was learned automatically:
+## see [method must_learn_move].
+const MOVE_OFFERED: StringName = &"move_offered"
+## The offer from [constant MOVE_OFFERED] was answered, one way or the other.
+const MOVE_FORGOTTEN: StringName = &"move_forgotten"
+const MOVE_DECLINED: StringName = &"move_declined"
+
 ## What a side does with its turn. Switching is not a move with a very high
 ## priority: it is settled before priority is looked at, which is why it is an
 ## action rather than a move number.
@@ -109,8 +133,29 @@ const VITAL_THROW: int = 0xE9
 var data: GameData = null
 var rng: RandomNumberGenerator = null
 
+## Whether beating this opponent is worth the 1.5x [Gen2Experience] gives a
+## trainer battle. A wild encounter (the default, and every existing caller's
+## meaning before this field existed) never sets it.
+var is_trainer_battle: bool = false
+
 ## The two sides, keyed by [constant PLAYER] and [constant ENEMY].
 var parties: Dictionary = {}
+
+## Which of a side's own party indices have fought since the opponent currently
+## out was sent in, kept as a Dictionary used for its keys. Seeded with the
+## lead at [method create_parties], added to on every [method send_out], and
+## reset to just whoever is left standing once experience has been given for
+## the opponent that just fainted: see [method _award_experience].
+##
+## Only [constant PLAYER]'s side is ever read for anything, mirroring the
+## cartridge's own asymmetry (see [constant EXP_GAINED]), but both sides are
+## tracked the same way rather than leaving one of them a special case.
+var _participants: Dictionary = {PLAYER: {}, ENEMY: {}}
+
+## Moves waiting on [method learn_move] or [method decline_move], one queue per
+## side, FIFO: a level that teaches two moves into a full six-move team asks
+## about both, one at a time, in the order they were learned.
+var _move_learn_queue: Dictionary = {PLAYER: [], ENEMY: []}
 
 ## Whoever is out on each side. Read through the party every time rather than
 ## kept in step with it: a switch changes who this is, and a copy that had to be
@@ -128,7 +173,8 @@ static func create_parties(
 	game_data: GameData,
 	player_party: Gen2Party,
 	enemy_party: Gen2Party,
-	generator: RandomNumberGenerator
+	generator: RandomNumberGenerator,
+	trainer_battle: bool = false
 ) -> Gen2Battle:
 	if game_data == null or player_party == null or enemy_party == null:
 		return null
@@ -139,6 +185,8 @@ static func create_parties(
 	out.data = game_data
 	out.parties = {PLAYER: player_party, ENEMY: enemy_party}
 	out.rng = generator if generator != null else RandomNumberGenerator.new()
+	out.is_trainer_battle = trainer_battle
+	out._participants = {PLAYER: {player_party.active: true}, ENEMY: {enemy_party.active: true}}
 	return out
 
 
@@ -206,6 +254,63 @@ func awaiting_replacement() -> bool:
 	return must_replace(PLAYER) or must_replace(ENEMY)
 
 
+## Whether [param side] has a move waiting on [method learn_move] or
+## [method decline_move]: every slot already held something when a level
+## taught it a new one, so nothing was learned without asking, the same
+## refusal-until-answered shape [method must_replace] already uses.
+func must_learn_move(side: int) -> bool:
+	return not (_move_learn_queue.get(side, []) as Array).is_empty()
+
+
+func awaiting_move_learn() -> bool:
+	return must_learn_move(PLAYER) or must_learn_move(ENEMY)
+
+
+## The offer waiting on [param side], or an empty Dictionary if there is none.
+## [code]species[/code], [code]index[/code], [code]move[/code] and
+## [code]level[/code] are enough to say "your FOO wants to learn BAR" without
+## asking the Pokémon anything a caller cannot already read off the event that
+## put this here.
+func pending_learn(side: int) -> Dictionary:
+	var queue: Array = _move_learn_queue.get(side, [])
+	return queue[0] if not queue.is_empty() else {}
+
+
+## Answers a pending offer by giving up [param forget_slot] for it. Refuses if
+## there is nothing pending: an answer to a question nobody asked is not
+## approximated into one that was.
+func learn_move(side: int, forget_slot: int) -> Array:
+	if not must_learn_move(side):
+		return []
+
+	var offer: Dictionary = (_move_learn_queue[side] as Array).pop_front()
+	var learner: Gen2BattleMon = party(side).at(int(offer["index"]))
+	if learner == null or forget_slot < 0 or forget_slot >= learner.moves.size():
+		return []
+
+	var forgot: int = int(learner.moves[forget_slot])
+	if not learner.replace_move(forget_slot, int(offer["move"])):
+		return []
+
+	return [{
+		"type": MOVE_FORGOTTEN, "side": side, "index": int(offer["index"]),
+		"species": learner.species, "forgot": forgot, "learned": int(offer["move"]), "slot": forget_slot,
+	}]
+
+
+## Answers a pending offer by refusing it: the Pokémon keeps its four moves and
+## never learns the fifth.
+func decline_move(side: int) -> Array:
+	if not must_learn_move(side):
+		return []
+
+	var offer: Dictionary = (_move_learn_queue[side] as Array).pop_front()
+	return [{
+		"type": MOVE_DECLINED, "side": side, "index": int(offer["index"]),
+		"species": int(offer["species"]), "move": int(offer["move"]),
+	}]
+
+
 ## Sends a side's [param index] out, whether as a replacement or between turns.
 ## Returns the events, which is one event or none: a switch that cannot be made
 ## is refused rather than approximated.
@@ -232,6 +337,7 @@ func send_out(side: int, index: int) -> Array:
 		"species": current.active_mon().species, "level": current.active_mon().level,
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
 	})
+	(_participants[side] as Dictionary)[index] = true
 	return events
 
 
@@ -244,7 +350,7 @@ func send_out(side: int, index: int) -> Array:
 ## most of what speed is for.
 func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	var events: Array = []
-	if is_over() or awaiting_replacement():
+	if is_over() or awaiting_replacement() or awaiting_move_learn():
 		return events
 
 	var actions: Dictionary = {PLAYER: player_action, ENEMY: enemy_action}
@@ -263,6 +369,7 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 		_act(side, int(actions[side].get("slot", 0)), chosen[side], events)
 
 	_residual_damage(acting, events)
+	_award_experience(events)
 
 	if is_over():
 		events.append({"type": OVER, "winner": winner()})
@@ -313,6 +420,96 @@ func _residual_damage(acting: Array, events: Array) -> void:
 		})
 		if current.is_fainted():
 			events.append({"type": FAINTED, "side": side})
+
+
+## Experience for every enemy Pokémon that fainted this turn, whether the faint
+## came from a move ([method _act], already in [param events] by the time this
+## runs) or from status damage ([method _residual_damage], run just before
+## this).
+##
+## A side's own [constant FAINTED] clears its fainted member out of
+## [member _participants] regardless of which side it is, because that half of
+## the rule (a fainted Pokémon stops participating) is not specific to the
+## side that receives experience; only [method _give_experience_for] is.
+func _award_experience(events: Array) -> void:
+	for event: Dictionary in events.duplicate():
+		if StringName(event.get("type", "")) != FAINTED:
+			continue
+		var side: int = int(event["side"])
+		(_participants[side] as Dictionary).erase(party(side).active)
+		if side == ENEMY:
+			_give_experience_for(mon(ENEMY), events)
+
+
+## Splits the exp and the stat exp [param defeated] is worth among every
+## [constant PLAYER] party index that has fought since it was sent in, then
+## resets that set to whoever is left standing: the next enemy Pokémon, if the
+## trainer has one, starts its own participant count fresh.
+func _give_experience_for(defeated: Gen2BattleMon, events: Array) -> void:
+	var participants: Array = (_participants[PLAYER] as Dictionary).keys()
+	if not participants.is_empty():
+		var award: int = Gen2Experience.award_for(
+			defeated.level, defeated.base_exp(), is_trainer_battle
+		)
+		var stat_gains: Dictionary = Gen2Experience.stat_exp_gain(
+			defeated.base_stat_exp_shape(), participants.size()
+		)
+		for index: int in participants:
+			var learner: Gen2BattleMon = party(PLAYER).at(int(index))
+			if learner != null and not learner.is_fainted():
+				_give_experience_to(learner, int(index), award, stat_gains, events)
+
+	_participants[PLAYER] = {party(PLAYER).active: true}
+
+
+func _give_experience_to(
+	learner: Gen2BattleMon, index: int, award: int, stat_gains: Dictionary, events: Array
+) -> void:
+	learner.gain_exp(award)
+	events.append({
+		"type": EXP_GAINED, "side": PLAYER, "index": index,
+		"species": learner.species, "amount": award, "exp": learner.exp,
+	})
+
+	learner.gain_stat_exp(stat_gains)
+	events.append({
+		"type": STAT_EXP_GAINED, "side": PLAYER, "index": index, "gains": stat_gains,
+	})
+
+	var target_level: int = learner.level_for_exp()
+	while learner.level < target_level:
+		var old_level: int = learner.level
+		var old_stats: Dictionary = learner.stats.duplicate()
+		learner.level_up()
+		events.append({
+			"type": GREW_LEVEL, "side": PLAYER, "index": index, "species": learner.species,
+			"old_level": old_level, "new_level": learner.level,
+			"old_stats": old_stats, "new_stats": learner.stats.duplicate(),
+		})
+		_offer_moves_learned_at(learner, index, learner.level, events)
+
+
+## What [param learner] is taught at exactly [param level]: straight into an
+## empty slot with no question asked, the same as the cartridge asks none when
+## there is nowhere for the answer to go, or queued for [method learn_move] or
+## [method decline_move] when every slot already holds something.
+func _offer_moves_learned_at(learner: Gen2BattleMon, index: int, level: int, events: Array) -> void:
+	for move: int in data.moves_learned_at(learner.species, level):
+		if learner.moves.has(move):
+			continue
+		if learner.learn_move(move):
+			events.append({
+				"type": MOVE_LEARNED, "side": PLAYER, "index": index,
+				"species": learner.species, "move": move, "slot": learner.moves.size() - 1,
+			})
+		else:
+			(_move_learn_queue[PLAYER] as Array).append({
+				"index": index, "move": move, "level": level, "species": learner.species,
+			})
+			events.append({
+				"type": MOVE_OFFERED, "side": PLAYER, "index": index,
+				"species": learner.species, "move": move, "level": level,
+			})
 
 
 static func _is_switch(action: Dictionary) -> bool:

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -39,6 +39,13 @@ var level: int = 1
 var dvs: int = PERFECT_DVS
 var stat_exp: Dictionary = {}
 
+## Total experience, on this species' own growth curve. Seeded at
+## [method create] to exactly what [param at_level] starts with, not zero: a
+## level 7 Pidgey is created already carrying level 7's own threshold, the same
+## way the cartridge's box and party screens always agree with a Pokémon's
+## level rather than a fresh one reading level 1 until its first battle.
+var exp: int = 0
+
 ## Move numbers and the PP left in each, one to one.
 var moves: Array = []
 var pp: Array = []
@@ -104,6 +111,7 @@ static func create(
 	out.recalculate()
 	out.hp = out.max_hp()
 	out.restore_pp()
+	out.exp = Gen2Experience.total_exp_at(out.growth_rate(), out.level)
 	return out
 
 
@@ -212,6 +220,70 @@ func name_text() -> String:
 	return String(data.species(species).get("name", ""))
 
 
+## The curve [Gen2Experience] should read this species on, or medium fast for
+## a species the cache does not have: the same fallback [method recalculate]
+## already makes for a missing base stats entry.
+func growth_rate() -> int:
+	return int(data.species(species).get("growth_rate", Gen2Experience.GROWTH_MEDIUM_FAST))
+
+
+func base_exp() -> int:
+	return int(data.species(species).get("base_exp", 0))
+
+
+## The five base stats [Gen2Experience.stat_exp_gain] wants when this Pokémon
+## is the one fainting, keyed the way [member stat_exp] already is. Special
+## Attack's base value fills the shared [code]"special"[/code] slot, never
+## Special Defense's: see [constant Gen2Experience.STAT_EXP_KEYS] for why the
+## cartridge reads it that way.
+func base_stat_exp_shape() -> Dictionary:
+	var base: Dictionary = data.species(species).get("stats", {})
+	return {
+		"hp": int(base.get("hp", 0)),
+		"attack": int(base.get("attack", 0)),
+		"defense": int(base.get("defense", 0)),
+		"speed": int(base.get("speed", 0)),
+		"special": int(base.get("sp_attack", 0)),
+	}
+
+
+## Adds experience, capped the way the cartridge's own three-byte total is.
+func gain_exp(amount: int) -> void:
+	exp = clampi(exp + amount, 0, Gen2Experience.MAX_EXP)
+
+
+## Adds a level's worth of stat experience, one entry per key in [param gains],
+## each capped the way a stat's own training already is in [method recalculate].
+func gain_stat_exp(gains: Dictionary) -> void:
+	for key: String in gains:
+		var total: int = int(stat_exp.get(key, 0)) + int(gains[key])
+		stat_exp[key] = clampi(total, 0, Gen2Stats.MAX_STAT_EXP)
+
+
+## The level [member exp] has actually reached on this species' curve, which is
+## not necessarily [member level]: a caller awards experience first and asks
+## this after, one level at a time, so that a move learned partway up a
+## multi-level jump is offered at the level that actually teaches it.
+func level_for_exp() -> int:
+	return Gen2Experience.level_for_exp(growth_rate(), exp)
+
+
+## Raises the level by exactly one and recalculates every stat from it, the
+## same call [method create] makes and the only other time this is meant to
+## happen. Current HP gains the *difference* the new max makes, rather than
+## being refilled or left where it was: the cartridge adds the two maximums'
+## delta onto whatever HP was sitting at, so a Pokémon one hit from fainting
+## before the level up is still one hit from fainting after it, just against a
+## bigger hit.
+func level_up() -> void:
+	if level >= Gen2Experience.MAX_LEVEL:
+		return
+	var before_max: int = max_hp()
+	level += 1
+	recalculate()
+	hp += max_hp() - before_max
+
+
 func max_hp() -> int:
 	return int(stats.get("hp", 1))
 
@@ -256,6 +328,26 @@ func is_out_of_pp() -> bool:
 	for slot: int in moves.size():
 		if can_use(slot):
 			return false
+	return true
+
+
+## Learns a move into an empty slot, with its own full PP. Refuses if every
+## slot is already taken: [method Gen2Battle.learn_move] is what overwrites one
+## instead, because which one to give up is not this class's decision.
+func learn_move(move: int) -> bool:
+	if moves.size() >= MAX_MOVES:
+		return false
+	moves.append(move)
+	pp.append(int(data.move(move).get("pp", 0)))
+	return true
+
+
+## Overwrites [param slot] with [param move], full PP, whatever was there.
+func replace_move(slot: int, move: int) -> bool:
+	if slot < 0 or slot >= moves.size():
+		return false
+	moves[slot] = move
+	pp[slot] = int(data.move(move).get("pp", 0))
 	return true
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -139,7 +139,6 @@ func _ready() -> void:
 	_box.place_at_bottom()
 
 	show_matchup(DEFAULT_ENEMY, DEFAULT_PLAYER, DEFAULT_LEVEL, DEFAULT_LEVEL)
-	set_exp(0.5)
 	_announce()
 
 
@@ -170,6 +169,7 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 		_battle.enemy.hp, _battle.enemy.max_hp(),
 		_battle.player.hp, _battle.player.max_hp()
 	)
+	_refresh_exp_bar()
 
 
 ## Puts the player against one of a trainer class's own trainers, built from the
@@ -205,6 +205,7 @@ func show_trainer(
 		_battle.enemy.hp, _battle.enemy.max_hp(),
 		_battle.player.hp, _battle.player.max_hp()
 	)
+	_refresh_exp_bar()
 
 	var trainer: Dictionary = _data.trainer_party(trainer_class, index)
 	show_message("%s %s wants to fight!" % [
@@ -238,6 +239,23 @@ func set_hp(enemy: int, enemy_max: int, player: int, player_max: int) -> void:
 func set_exp(fraction: float) -> void:
 	_exp = clampf(fraction, 0.0, 1.0)
 	_refresh()
+
+
+## Where [member _battle]'s own player Pokémon sits between its current level's
+## own threshold and the next one's, on its own growth curve. Called whenever a
+## battle starts and whenever [constant Gen2Battle.EXP_GAINED] or
+## [constant Gen2Battle.GREW_LEVEL] says the number behind it moved, rather
+## than read once and left to go stale.
+func _refresh_exp_bar() -> void:
+	if _battle == null or _battle.player == null:
+		set_exp(0.0)
+		return
+
+	var mon: Gen2BattleMon = _battle.player
+	var rate: int = mon.growth_rate()
+	var floor_exp: int = Gen2Experience.total_exp_at(rate, mon.level)
+	var span: int = Gen2Experience.total_exp_at(rate, mon.level + 1) - floor_exp
+	set_exp(float(mon.exp - floor_exp) / float(span) if span > 0 else 1.0)
 
 
 func show_message(text: String) -> void:
@@ -295,6 +313,7 @@ func take_turn() -> void:
 	_pending = _battle.take_turn(_random_slot(Gen2Battle.PLAYER), _enemy_slot())
 	_player_turns_taken += 1
 	_enemy_turns_taken += 1
+	_auto_decline_move_learns()
 	_show_next_event()
 
 
@@ -332,7 +351,20 @@ func switch_player() -> void:
 	if next < 0:
 		return
 	_pending = _battle.take_actions(Gen2Battle.switch_to(next), Gen2Battle.use_move(0))
+	_auto_decline_move_learns()
 	_show_next_event()
+
+
+## No menu exists yet to ask which move to forget, the same scaffolding this
+## screen already has for which move to use ([method _random_slot]): a pending
+## offer is declined automatically instead, so a battle nobody is driving from
+## a real menu does not simply stop. [Gen2Battle] still exposes the real
+## question through [method Gen2Battle.must_learn_move] for whatever asks it
+## properly later.
+func _auto_decline_move_learns() -> void:
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		while _battle.must_learn_move(side):
+			_pending.append_array(_battle.decline_move(side))
 
 
 ## What a button press does. Finishes the current message if it is still
@@ -420,6 +452,22 @@ func _apply_event(event: Dictionary) -> void:
 				_player = int(event["species"])
 				_player_level = int(event["level"])
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
+			_refresh_exp_bar()
+		Gen2Battle.EXP_GAINED:
+			# Never [constant Gen2Battle.ENEMY]: see the event's own doc comment.
+			# [method _refresh_exp_bar] always reads whoever is active right now,
+			# which answers correctly on its own even when the index that gained
+			# it is a benched participant rather than the one on screen.
+			_refresh_exp_bar()
+		Gen2Battle.GREW_LEVEL:
+			# The level number in the panel belongs to whoever is on screen, so it
+			# only moves when the index that grew is the one currently active: a
+			# benched participant can level up too, and this screen has no bench
+			# to show it on.
+			if int(event["index"]) == _battle.party(Gen2Battle.PLAYER).active:
+				_player_level = int(event["new_level"])
+				_refresh()
+			_refresh_exp_bar()
 
 
 ## An event as a sentence, or an empty string for one there is nothing to say
@@ -498,6 +546,32 @@ func _describe(event: Dictionary) -> String:
 			if side == Gen2Battle.ENEMY:
 				return "Enemy sent out %s!" % _name_of(int(event["species"]))
 			return "Go! %s!" % _name_of(int(event["species"]))
+		Gen2Battle.EXP_GAINED:
+			return "%s gained %d EXP. Points!" % [_name_of(int(event["species"])), int(event["amount"])]
+		Gen2Battle.STAT_EXP_GAINED:
+			# The cartridge never prints a line of its own for this: it happens
+			# silently behind the EXP. Points message above it.
+			return ""
+		Gen2Battle.GREW_LEVEL:
+			return "%s grew to level %d!" % [_name_of(int(event["species"])), int(event["new_level"])]
+		Gen2Battle.MOVE_LEARNED:
+			return "%s learned %s!" % [
+				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
+			]
+		Gen2Battle.MOVE_OFFERED:
+			return "%s wants to learn %s!" % [
+				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
+			]
+		Gen2Battle.MOVE_FORGOTTEN:
+			return "%s forgot %s and learned %s!" % [
+				_name_of(int(event["species"])),
+				String(_data.move(int(event["forgot"])).get("name", "")),
+				String(_data.move(int(event["learned"])).get("name", "")),
+			]
+		Gen2Battle.MOVE_DECLINED:
+			return "%s did not learn %s." % [
+				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
+			]
 		Gen2Battle.OVER:
 			# Both sides can go down in the same turn, through recoil or a burn,
 			# and then there is nobody to declare.

--- a/game/battle/experience.gd
+++ b/game/battle/experience.gd
@@ -1,0 +1,162 @@
+class_name Gen2Experience
+extends RefCounted
+
+## Experience: the six growth curves, how much a defeated Pokémon is worth, and
+## how much of it a fainted Pokémon leaves behind in stat experience.
+##
+## [RefCounted] and static throughout, like [Gen2Stats] and [Gen2Damage]: pure
+## integer arithmetic in the hardware's own order, with every division
+## truncating. A curve rearranged into something tidier gives a different
+## answer, the same caution the rest of the battle engine's arithmetic carries.
+##
+## The six curves are [code]CalcExpAtLevel[/code]'s own formula, pinned against
+## pokecrystal's [code]data/growth_rates.asm[/code] and cross-checked against
+## the real cartridges: every one of the 251 species in all three games reads
+## the growth rate and base experience this module expects, not a plausible
+## guess at either. See [code]tools/dump_tables.gd[/code]'s [code]growth[/code]
+## view.
+
+## The cartridge's own byte order for [code]wBaseGrowthRate[/code]
+## ([code]GROWTH_*[/code] in pokecrystal). Only four of the six are ever used by
+## a real species in any of the three games (medium fast, medium slow, fast,
+## slow); the other two are named for completeness, not because a species
+## exercises them.
+const GROWTH_MEDIUM_FAST: int = 0
+const GROWTH_SLIGHTLY_FAST: int = 1
+const GROWTH_SLIGHTLY_SLOW: int = 2
+const GROWTH_MEDIUM_SLOW: int = 3
+const GROWTH_FAST: int = 4
+const GROWTH_SLOW: int = 5
+
+## Each curve as [code]a, b, c, d, e[/code] in
+## [code]exp(n) = floor(a*n^3/b) + c*n^2 + d*n - e[/code], the cartridge's own
+## formula and its own coefficients. [code]c[/code] carries its sign; the
+## cartridge stores it as a magnitude with the sign in a separate bit, which is
+## a storage detail this table does not need to repeat.
+const CURVES: Dictionary = {
+	GROWTH_MEDIUM_FAST: [1, 1, 0, 0, 0],
+	GROWTH_SLIGHTLY_FAST: [3, 4, 10, 0, 30],
+	GROWTH_SLIGHTLY_SLOW: [3, 4, 20, 0, 70],
+	GROWTH_MEDIUM_SLOW: [6, 5, -15, 100, 140],
+	GROWTH_FAST: [4, 5, 0, 0, 0],
+	GROWTH_SLOW: [5, 4, 0, 0, 0],
+}
+
+const MAX_LEVEL: int = 100
+
+## Experience is stored in three bytes on the cartridge, so this is the most a
+## Pokémon can ever be carrying. No curve reaches it before level 100, so the
+## cap exists for the same reason [Gen2Stats.MAX_STAT_EXP] does: to have an
+## answer ready rather than to ever actually be reached.
+const MAX_EXP: int = 0xFFFFFF
+
+## How many of the five stats a fainted Pokémon leaves behind in stat
+## experience: hit points, Attack, Defense, Speed, and Special. The cartridge
+## copies the *base Sp. Attack* into this fifth slot and never touches base
+## Sp. Defense at all, which is why [Gen2BattleMon.stat_exp] keeps one
+## [code]"special"[/code] entry rather than two: Special Defense's stat
+## experience is Special Attack's, borrowed, the same half-finished split the
+## base stats themselves show elsewhere in these games.
+const STAT_EXP_KEYS: Array = ["hp", "attack", "defense", "speed", "special"]
+
+## Awarding exp divides a base stat by the participant count, and the
+## cartridge's own routine skips the division outright rather than dividing by
+## one, which matters because the division truncates: a single participant
+## keeps the whole base stat rather than losing a remainder to the floor.
+const MIN_PARTICIPANTS_TO_SPLIT: int = 2
+
+## The exp award is multiplied by 1.5, truncating, for a trainer battle. The
+## cartridge computes this as [code]value + floor(value / 2)[/code] rather than
+## a multiply by 3 and a divide by 2, which agree except where the extra
+## truncation the multiply avoids would have mattered; this is the shape the
+## disassembly's own [code]BoostExp[/code] uses, so it is the shape kept here.
+## A traded Pokémon's own 1.5x and a held Lucky Egg's are the cartridge's other
+## two boosts; neither is implemented, because nothing in this project has an
+## original trainer ID or an item engine to read either from yet.
+const TRAINER_BONUS_NUMERATOR: int = 3
+const TRAINER_BONUS_DENOMINATOR: int = 2
+
+
+## The total experience a Pokémon on [param growth_rate]'s curve has at exactly
+## [param level].
+##
+## Level 1 is hard-coded to zero rather than run through the formula. The
+## cartridge's own formula underflows there for the medium slow curve
+## ([code]floor(6/5) - 15 + 100 - 140[/code] is negative, and the three-byte
+## total it is stored in has no sign), which pokecrystal's own
+## [code]docs/bugs_and_glitches.md[/code] documents as a bug and not a rule: a
+## level 1 Pokémon has no experience by definition, on every curve, and that is
+## the answer kept here rather than the underflow.
+static func total_exp_at(growth_rate: int, level: int) -> int:
+	var n: int = clampi(level, 1, MAX_LEVEL)
+	if n <= 1:
+		return 0
+
+	var curve: Array = CURVES.get(growth_rate, CURVES[GROWTH_MEDIUM_FAST])
+	var a: int = int(curve[0])
+	var b: int = int(curve[1])
+	var c: int = int(curve[2])
+	var d: int = int(curve[3])
+	var e: int = int(curve[4])
+
+	@warning_ignore("integer_division")
+	var cubic: int = (a * n * n * n) / b
+	var quadratic: int = c * n * n
+	var linear: int = d * n
+	return clampi(cubic + quadratic + linear - e, 0, MAX_EXP)
+
+
+## The level [param exp] has reached on [param growth_rate]'s curve, found the
+## way [code]CalcLevel[/code] finds it: by walking levels upward rather than
+## solving the cubic backward, because the forward formula truncates and its
+## inverse would not agree with it at every level if it were solved directly.
+static func level_for_exp(growth_rate: int, exp: int) -> int:
+	var level: int = 1
+	while level < MAX_LEVEL and total_exp_at(growth_rate, level + 1) <= exp:
+		level += 1
+	return level
+
+
+## What a Pokémon of [param defeated_level] and [param defeated_base_exp] is
+## worth, before it is split among anyone: [code]floor(base_exp * level / 7)[/code],
+## then a trainer battle's own 1.5x on top.
+##
+## Not divided by how many participants there were: that is the stat
+## experience's rule, not this one's. The cartridge's own
+## [code]GiveExperiencePoints[/code] hands every participant this same full
+## figure and only ever divides the *base stats* that feed
+## [method stat_exp_gain], which is easy to get backward from how recoil and
+## drain both split by what actually happened rather than by headcount.
+static func award_for(defeated_level: int, defeated_base_exp: int, is_trainer_battle: bool) -> int:
+	@warning_ignore("integer_division")
+	var award: int = (defeated_base_exp * defeated_level) / 7
+	if is_trainer_battle:
+		award = _boost(award)
+	return clampi(award, 0, MAX_EXP)
+
+
+## The 1.5x a trainer battle, a traded Pokémon or a held Lucky Egg each apply,
+## as the cartridge computes it: half of the value, truncated, added back to
+## the whole. Kept as its own step because a second boost stacking on the first
+## truncates its own half separately, and would give a different answer from
+## multiplying by 2.25 in one step.
+static func _boost(value: int) -> int:
+	@warning_ignore("integer_division")
+	return value + (value / 2)
+
+
+## How much of the five stats in [constant STAT_EXP_KEYS] a fainted Pokémon
+## leaves behind, keyed the way [Gen2BattleMon.stat_exp] is. Split evenly
+## across [param participants] when there is more than one, each share
+## truncated on its own rather than the total truncated once, because that is
+## the cartridge's own per-stat division, not a single combined one.
+static func stat_exp_gain(defeated_stats: Dictionary, participants: int) -> Dictionary:
+	var count: int = maxi(participants, 1)
+	var out: Dictionary = {}
+	for key: String in STAT_EXP_KEYS:
+		var base: int = int(defeated_stats.get(key, 0))
+		if count >= MIN_PARTICIPANTS_TO_SPLIT:
+			@warning_ignore("integer_division")
+			base = base / count
+		out[key] = base
+	return out

--- a/game/battle/experience.gd.uid
+++ b/game/battle/experience.gd.uid
@@ -1,0 +1,1 @@
+uid://b888rilxt6irc

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -117,6 +117,14 @@ func moves_at_level(number: int, level: int) -> Array:
 	return Gen2Learnset.moves_at_level(learnset(number), level)
 
 
+## The moves a Pokémon of this species is offered on reaching exactly
+## [param level] by levelling up, which is not [method moves_at_level]'s
+## question asked again: see [Gen2Learnset] for why Muk's own list answers the
+## two differently.
+func moves_learned_at(number: int, level: int) -> Array:
+	return Gen2Learnset.moves_learned_at(learnset(number), level)
+
+
 ## One of the per-species lists, with every named field coerced out of JSON's
 ## single number type.
 func _rows(entry: Dictionary, key: String, fields: Array) -> Array:

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -139,17 +139,45 @@ static func build(directory: String) -> GameData:
 ## The species table, indexed by number like the real one, with the gaps filled
 ## by entries that exist only so a number indexes its own row.
 static func _species() -> Array:
+	# Growth rate and base exp, appended after the type pair, are the published
+	# ones too: Pikachu and Magcargo are medium fast, Bulbasaur, Charmander and
+	# Geodude medium slow, which is why [constant Gen2Experience.GROWTH_MEDIUM_FAST]
+	# and [constant Gen2Experience.GROWTH_MEDIUM_SLOW] are the two
+	# [test_experience.gd] and [test_battle.gd] ever need a fixture for.
+	# The two learnsets exist only for [test_battle.gd]'s own experience tests:
+	# Charmander's single entry is the plain "an empty slot needs no question"
+	# case, and Geodude's two are a level-up jump that crosses both a free slot
+	# and, once that slot is gone, [Gen2Battle.must_learn_move]'s own offer.
 	var known: Dictionary = {
-		BULBASAUR: ["BULBASAUR", [45, 49, 49, 45, 65, 65], [GRASS, POISON]],
-		CHARMANDER: ["CHARMANDER", [39, 52, 43, 65, 60, 50], [FIRE, FIRE]],
-		PIKACHU: ["PIKACHU", [35, 55, 30, 90, 50, 40], [ELECTRIC, ELECTRIC]],
-		GEODUDE: ["GEODUDE", [40, 80, 100, 20, 30, 30], [ROCK, GROUND]],
-		MAGCARGO: ["MAGCARGO", [50, 50, 120, 30, 80, 80], [FIRE, ROCK]],
+		BULBASAUR: [
+			"BULBASAUR", [45, 49, 49, 45, 65, 65], [GRASS, POISON],
+			Gen2Experience.GROWTH_MEDIUM_SLOW, 64, [],
+		],
+		CHARMANDER: [
+			"CHARMANDER", [39, 52, 43, 65, 60, 50], [FIRE, FIRE],
+			Gen2Experience.GROWTH_MEDIUM_SLOW, 65, [{"level": 6, "move": EMBER}],
+		],
+		PIKACHU: [
+			"PIKACHU", [35, 55, 30, 90, 50, 40], [ELECTRIC, ELECTRIC],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 82, [],
+		],
+		GEODUDE: [
+			"GEODUDE", [40, 80, 100, 20, 30, 30], [ROCK, GROUND],
+			Gen2Experience.GROWTH_MEDIUM_SLOW, 86,
+			[{"level": 6, "move": GROWL}, {"level": 11, "move": SLASH}],
+		],
+		MAGCARGO: [
+			"MAGCARGO", [50, 50, 120, 30, 80, 80], [FIRE, ROCK],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 154, [],
+		],
 	}
 
 	var out: Array = []
 	for number: int in range(1, MAGCARGO + 1):
-		var entry: Array = known.get(number, ["FILLER", [10, 10, 10, 10, 10, 10], [NORMAL, NORMAL]])
+		var entry: Array = known.get(number, [
+			"FILLER", [10, 10, 10, 10, 10, 10], [NORMAL, NORMAL],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 64, [],
+		])
 		var stats: Array = entry[1]
 		out.append({
 			"number": number,
@@ -158,7 +186,10 @@ static func _species() -> Array:
 				"hp": stats[0], "attack": stats[1], "defense": stats[2],
 				"speed": stats[3], "sp_attack": stats[4], "sp_defense": stats[5],
 			},
+			"learnset": entry[5],
 			"types": entry[2],
+			"growth_rate": entry[3],
+			"base_exp": entry[4],
 			"front_tiles": [7, 7],
 			"palette": {"normal": [0x1234, 0x5678], "shiny": [0x0C63, 0x1084]},
 		})

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -812,3 +812,193 @@ func test_guillotine_faints_its_target_outright_in_a_real_turn() -> void:
 	# misses, so the outcome needs no seed to be sure of.
 	battle.take_turn(0, 0)
 	assert_eq(battle.enemy.hp, 0)
+
+
+## Experience: what a wild faint is worth, a trainer battle's own 1.5x, how it
+## splits among participants, and what a level crossed on the way there
+## actually teaches. [Gen2Experience]'s own arithmetic is checked in
+## [code]test_experience.gd[/code]; what matters here is that [Gen2Battle]
+## calls it with the right numbers at the right moment.
+
+
+func test_a_wild_faint_awards_experience_to_the_winner() -> void:
+	# Bulbasaur, base exp 64, at level 5: floor(64*5/7) = 45. A wild battle,
+	# [method _battle]'s own shape, never adds the trainer bonus.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 100, [Fixture.THUNDERBOLT]),
+		_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	var gained: Dictionary = _first(events, Gen2Battle.EXP_GAINED)
+	assert_eq(gained["side"], Gen2Battle.PLAYER)
+	assert_eq(gained["index"], 0)
+	assert_eq(gained["amount"], 45)
+
+	var stats: Dictionary = _first(events, Gen2Battle.STAT_EXP_GAINED)
+	# One participant, so nothing is divided: Bulbasaur's own base stats,
+	# plain, with base Sp. Attack (65) filling the shared "special" slot.
+	assert_eq(stats["gains"], {"hp": 45, "attack": 49, "defense": 49, "speed": 45, "special": 65})
+	assert_eq(battle.player.stat_exp, stats["gains"])
+
+
+func test_a_trainer_battle_adds_the_experience_bonus() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(_mon(Fixture.PIKACHU, 100, [Fixture.THUNDERBOLT])),
+		Gen2Party.of(_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE])), _rng, true
+	)
+	var events: Array = battle.take_turn(0, 0)
+	# 45 without the bonus (see the wild test above); with it, 45 + floor(45/2).
+	assert_eq(_first(events, Gen2Battle.EXP_GAINED)["amount"], 67)
+
+
+func test_experience_is_not_divided_among_participants_but_stat_experience_is() -> void:
+	# Geodude, base exp 86, at level 20: floor(86*20/7) = 245, the same number
+	# for every participant. Its own base stats (40/80/100/20/30), split two
+	# ways, truncated per stat, are the only thing that divides.
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]), _mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		]),
+		Gen2Party.create([_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])]), _rng
+	)
+	battle.send_out(Gen2Battle.PLAYER, 1)
+	battle.enemy.hp = 1
+	var events: Array = battle.take_turn(0, 0)
+
+	var gains: Array = _of_type(events, Gen2Battle.EXP_GAINED)
+	assert_eq(gains.size(), 2, "both the lead and the one switched in")
+	for gain: Dictionary in gains:
+		assert_eq(gain["amount"], 245, "full, unsplit, for every participant")
+
+	var stat_gains: Array = _of_type(events, Gen2Battle.STAT_EXP_GAINED)
+	assert_eq(stat_gains.size(), 2)
+	for stat_gain: Dictionary in stat_gains:
+		assert_eq(stat_gain["gains"]["attack"], 40, "80 / 2, truncated")
+		assert_eq(stat_gain["gains"]["speed"], 10, "20 / 2")
+
+
+func test_participants_narrow_to_whoever_is_active_once_an_enemy_faints() -> void:
+	# Three enemies, one at a time. The lead player Pokémon is credited for the
+	# first kill by default; switching in the second one adds it without
+	# dropping the lead, since both are still on the field's own roster for
+	# that enemy's life; only once experience has actually been given does the
+	# set narrow back down to whoever is active, which is what the third kill
+	# is here to prove.
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]), _mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		]),
+		Gen2Party.create([
+			_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE]),
+			_mon(Fixture.MAGCARGO, 20, [Fixture.TACKLE]),
+			_mon(Fixture.BULBASAUR, 20, [Fixture.TACKLE]),
+		]),
+		_rng
+	)
+
+	battle.enemy.hp = 1
+	var first_kill: Array = battle.take_turn(0, 0)
+	assert_eq(
+		_of_type(first_kill, Gen2Battle.EXP_GAINED).map(func(e: Dictionary) -> int: return e["index"]),
+		[0], "only the lead fought Geodude"
+	)
+	battle.send_out(Gen2Battle.ENEMY, 1)
+	battle.send_out(Gen2Battle.PLAYER, 1)
+
+	battle.enemy.hp = 1
+	var second_kill: Array = battle.take_turn(0, 0)
+	assert_eq(
+		(_of_type(second_kill, Gen2Battle.EXP_GAINED)
+			.map(func(e: Dictionary) -> int: return e["index"]) as Array), [0, 1],
+		"index 0 was still active when Magcargo's life began, so it still counts"
+	)
+	battle.send_out(Gen2Battle.ENEMY, 2)
+
+	battle.enemy.hp = 1
+	var third_kill: Array = battle.take_turn(0, 0)
+	assert_eq(
+		_of_type(third_kill, Gen2Battle.EXP_GAINED).map(func(e: Dictionary) -> int: return e["index"]),
+		[1], "index 0 was never sent back in during Bulbasaur's own life"
+	)
+
+
+func test_levelling_up_learns_a_move_into_an_empty_slot_without_asking() -> void:
+	# Charmander's own curve reads 135 at level 5. Beating a level 20 Geodude
+	# (245 exp) lands at 380, which is level 8: level 6 teaches Ember, and
+	# Charmander still has an empty fourth slot for it to go into.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	# The level gap that makes the exp worth crossing three levels also makes
+	# Geodude both faster and hard enough hitting to otherwise flatten a level 5
+	# Charmander before it gets a turn at all, which is not what this test is
+	# about; a healthy Charmander guaranteed to survive one hit is.
+	battle.player.hp = battle.player.max_hp() * 10
+	battle.enemy.hp = 1
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_eq(_of_type(events, Gen2Battle.GREW_LEVEL).size(), 3, "5 to 6, 6 to 7, 7 to 8")
+	var learned: Dictionary = _first(events, Gen2Battle.MOVE_LEARNED)
+	assert_eq(learned["move"], Fixture.EMBER)
+	assert_eq(learned["slot"], 1)
+	assert_eq(battle.player.moves, [Fixture.TACKLE, Fixture.EMBER])
+	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
+
+
+func test_a_full_moveset_is_offered_a_new_move_rather_than_taught_it() -> void:
+	# Geodude's own curve also reads 135 at level 5. A level 33 Magcargo (base
+	# exp 154) is worth floor(154*33/7) = 726 exactly, landing at 861, which is
+	# level 11: level 6 auto-learns Growl into the one empty slot, and level 11's
+	# own Slash finds every slot full.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+	var offer: Dictionary = battle.pending_learn(Gen2Battle.PLAYER)
+	assert_eq(offer["move"], Fixture.SLASH)
+	assert_eq(offer["level"], 11)
+	assert_eq(battle.player.moves, [
+		Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT, Fixture.GROWL,
+	], "Growl already took the one empty slot on the way up")
+
+
+func test_a_battle_refuses_to_continue_until_the_offered_move_is_answered() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+
+	assert_eq(battle.take_turn(0, 0), [], "a battle cannot go on with an unanswered offer")
+
+	var events: Array = battle.learn_move(Gen2Battle.PLAYER, 1)
+	assert_eq(events[0]["forgot"], Fixture.EMBER)
+	assert_eq(events[0]["learned"], Fixture.SLASH)
+	assert_eq(battle.player.moves[1], Fixture.SLASH)
+	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
+
+
+func test_declining_the_offered_move_keeps_the_four_already_known() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+	var before: Array = battle.player.moves.duplicate()
+
+	var events: Array = battle.decline_move(Gen2Battle.PLAYER)
+
+	assert_eq(events[0]["type"], Gen2Battle.MOVE_DECLINED)
+	assert_eq(events[0]["move"], Fixture.SLASH)
+	assert_eq(battle.player.moves, before)
+	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -162,6 +162,78 @@ func test_every_volatile_field_clears() -> void:
 	assert_eq(mon.toxic_counter, 0)
 
 
+func test_a_pokemon_is_created_already_on_its_curve_not_at_zero() -> void:
+	# Pikachu is medium fast, so a level 50 Pikachu is created already carrying
+	# 50 cubed, not zero, the same as a box screen always agreeing with a
+	# Pokémon's level.
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	assert_eq(mon.growth_rate(), Gen2Experience.GROWTH_MEDIUM_FAST)
+	assert_eq(mon.base_exp(), 82)
+	assert_eq(mon.exp, 125000)
+	assert_eq(mon.level_for_exp(), 50)
+
+
+func test_base_stat_exp_shape_uses_special_attacks_base_never_defenses() -> void:
+	# Pikachu: 35/55/30/90/50/40. The shared "special" slot borrows Sp. Attack's
+	# 50 and never Sp. Defense's 40, the same asymmetry the base stats table
+	# itself carries.
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	assert_eq(mon.base_stat_exp_shape(), {
+		"hp": 35, "attack": 55, "defense": 30, "speed": 90, "special": 50,
+	})
+
+
+func test_gaining_experience_can_cross_a_level_threshold() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	assert_eq(mon.level_for_exp(), 50)
+	mon.gain_exp(132651 - 125000)
+	assert_eq(mon.level_for_exp(), 51, "51 cubed is exactly 132651")
+
+
+func test_experience_is_capped_at_the_three_byte_maximum() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.gain_exp(Gen2Experience.MAX_EXP)
+	assert_eq(mon.exp, Gen2Experience.MAX_EXP)
+
+
+func test_stat_experience_accumulates_across_more_than_one_gain() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.gain_stat_exp({"attack": 45, "speed": 90})
+	mon.gain_stat_exp({"attack": 45, "hp": 35})
+	assert_eq(mon.stat_exp.get("attack"), 90)
+	assert_eq(mon.stat_exp.get("speed"), 90)
+	assert_eq(mon.stat_exp.get("hp"), 35)
+
+
+func test_stat_experience_gain_is_capped_the_same_as_training_it_by_hand() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.gain_stat_exp({"attack": Gen2Stats.MAX_STAT_EXP + 1000})
+	assert_eq(mon.stat_exp.get("attack"), Gen2Stats.MAX_STAT_EXP)
+
+
+func test_levelling_up_recalculates_stats_and_grows_current_hp_by_the_delta() -> void:
+	# Pikachu's own max HP is 110 at 50 and 112 at 51: a Pokémon that took five
+	# points of damage before levelling comes out with two more than it had,
+	# not refilled and not left where it was.
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.take_damage(5)
+	assert_eq(mon.hp, 105)
+
+	mon.level_up()
+
+	assert_eq(mon.level, 51)
+	assert_eq(mon.max_hp(), 112)
+	assert_eq(mon.hp, 107, "105 plus the two extra the new max hp is worth")
+
+
+func test_levelling_up_refuses_past_the_cap() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, Gen2Experience.MAX_LEVEL)
+	var before_hp: int = mon.hp
+	mon.level_up()
+	assert_eq(mon.level, Gen2Experience.MAX_LEVEL)
+	assert_eq(mon.hp, before_hp)
+
+
 func test_rolled_dvs_stay_inside_a_nibble_each() -> void:
 	var rng := RandomNumberGenerator.new()
 	rng.seed = 7

--- a/tests/unit/test_experience.gd
+++ b/tests/unit/test_experience.gd
@@ -1,0 +1,117 @@
+extends GutTest
+
+## The experience arithmetic, against the published totals for each curve.
+##
+## Every figure here is hand-worked from pokecrystal's own
+## [code]CalcExpAtLevel[/code] formula rather than recomputed the way the code
+## computes it, the same discipline [Gen2Damage]'s own tests hold to: a test
+## that ran the formula to check the formula would agree with a wrong one just
+## as readily as a right one.
+
+
+func test_medium_fast_is_a_plain_cube() -> void:
+	# The textbook curve, and the easiest to get right, which is why it opens
+	# the file: if this one is wrong, nothing else is worth trusting either.
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 2), 8)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 7), 343)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 50), 125000)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 100), 1000000)
+
+
+func test_fast_is_four_fifths_of_the_cube() -> void:
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_FAST, 50), 100000)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_FAST, 100), 800000)
+
+
+func test_slow_is_five_quarters_of_the_cube() -> void:
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLOW, 50), 156250)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLOW, 100), 1250000)
+
+
+func test_medium_slow_is_the_s_curve() -> void:
+	# Bulbasaur's own curve, and the one the underflow bug lives on.
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 2), 9)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 7), 236)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 50), 117360)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 100), 1059860)
+
+
+func test_the_two_curves_no_species_uses_still_answer_the_formula() -> void:
+	# Slightly Fast and Slightly Slow: found in the growth rate table and named
+	# in pokecrystal's own constants, but no species in Gold, Silver or Crystal
+	# is on either. Worth a formula check anyway, since the table entry is real.
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLIGHTLY_FAST, 100), 849970)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLIGHTLY_SLOW, 100), 949930)
+
+
+func test_level_one_is_zero_on_every_curve_not_the_formulas_underflow() -> void:
+	# Medium Slow's own formula goes negative at level 1
+	# (floor(6/5) - 15 + 100 - 140 = -54), which the real cartridge stores into
+	# an unsigned three-byte total and calls a bug rather than a rule. A level 1
+	# Pokémon has no experience by definition on every curve, underflow or not.
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 1), 0)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 1), 0)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_FAST, 1), 0)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLOW, 1), 0)
+
+
+func test_level_never_goes_below_one_or_past_the_cap() -> void:
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 0), 0)
+	assert_eq(
+		Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 200),
+		Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, Gen2Experience.MAX_LEVEL),
+	)
+
+
+func test_level_for_exp_is_the_forward_curve_walked_backward() -> void:
+	var rate: int = Gen2Experience.GROWTH_MEDIUM_FAST
+	assert_eq(Gen2Experience.level_for_exp(rate, 0), 1)
+	assert_eq(Gen2Experience.level_for_exp(rate, 7), 1, "one short of level 2's 8")
+	assert_eq(Gen2Experience.level_for_exp(rate, 8), 2, "exactly level 2's own threshold")
+	assert_eq(Gen2Experience.level_for_exp(rate, 342), 6, "one short of level 7's 343")
+	assert_eq(Gen2Experience.level_for_exp(rate, 343), 7)
+	assert_eq(Gen2Experience.level_for_exp(rate, 1000000), 100)
+	assert_eq(Gen2Experience.level_for_exp(rate, Gen2Experience.MAX_EXP), 100, "never past the cap")
+
+
+func test_award_is_base_exp_times_level_over_seven() -> void:
+	# A level 7 Pidgey, base exp 46 (Falkner's own lead): 46*7/7 = 46 exactly,
+	# chosen because the division cancels and is not itself the thing under
+	# test here.
+	assert_eq(Gen2Experience.award_for(7, 46, false), 46)
+	# A level 9 Pidgeotto, base exp 65: floor(65*9/7) = floor(83.57) = 83.
+	assert_eq(Gen2Experience.award_for(9, 65, false), 83)
+
+
+func test_a_trainer_battle_adds_half_again_truncated() -> void:
+	# 83 without the boost; with it, 83 + floor(83/2) = 83 + 41 = 124, not the
+	# 124.5 a plain multiply by 1.5 would suggest.
+	assert_eq(Gen2Experience.award_for(9, 65, true), 124)
+
+
+func test_stat_exp_is_not_split_for_a_single_participant() -> void:
+	var defeated: Dictionary = {
+		"hp": 40, "attack": 45, "defense": 40, "speed": 56, "special": 35,
+	}
+	var out: Dictionary = Gen2Experience.stat_exp_gain(defeated, 1)
+	assert_eq(out, defeated, "one participant keeps the whole base stat")
+
+
+func test_stat_exp_splits_evenly_for_two_or_more_participants() -> void:
+	var defeated: Dictionary = {
+		"hp": 40, "attack": 45, "defense": 40, "speed": 56, "special": 35,
+	}
+	var out: Dictionary = Gen2Experience.stat_exp_gain(defeated, 2)
+	assert_eq(out["hp"], 20)
+	assert_eq(out["attack"], 22, "45 / 2 truncated, not rounded")
+	assert_eq(out["speed"], 28)
+
+
+func test_stat_exp_split_truncates_per_stat_not_on_the_total() -> void:
+	var defeated: Dictionary = {
+		"hp": 45, "attack": 49, "defense": 49, "speed": 45, "special": 65,
+	}
+	var out: Dictionary = Gen2Experience.stat_exp_gain(defeated, 3)
+	assert_eq(out["hp"], 15)
+	assert_eq(out["attack"], 16, "49 / 3 truncated")
+	assert_eq(out["special"], 21, "65 / 3 truncated")

--- a/tests/unit/test_experience.gd.uid
+++ b/tests/unit/test_experience.gd.uid
@@ -1,0 +1,1 @@
+uid://bdp5wkulp4ppa

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -12,17 +12,26 @@ extends SceneTree
 
 const TABLES: PackedStringArray = [
 	"species", "moves", "items", "types", "matchups", "trainers", "learnsets",
-	"evolutions",
+	"evolutions", "growth",
 ]
 
 ## Which file a table is read out of, where it is not a file of its own.
-## Evolutions and level-up moves are two halves of one cartridge table and are
-## cached on the species, so they are two views of species.json rather than two
-## files.
+## Evolutions, level-up moves and growth rate/base exp are all read off the
+## species entry itself, so they are views of species.json rather than files
+## of their own.
 const SOURCES: Dictionary = {
 	"learnsets": RomCache.SPECIES,
 	"evolutions": RomCache.SPECIES,
+	"growth": RomCache.SPECIES,
 }
+
+## The six growth curves, in the cartridge's own byte order (GROWTH_MEDIUM_FAST
+## through GROWTH_SLOW). Only four are ever used by a real species in any of the
+## three games; the other two are named for completeness, not because a species
+## exercises them.
+const GROWTH_NAMES: PackedStringArray = [
+	"medium fast", "slightly fast", "slightly slow", "medium slow", "fast", "slow",
+]
 
 ## How an evolution method is written out. The parameter that follows it means
 ## something different in each case, which is the point of naming them here.
@@ -136,6 +145,8 @@ func _dump(directory: String, table: String) -> void:
 			_dump_learnsets(directory, rows)
 		"evolutions":
 			_dump_evolutions(directory, rows)
+		"growth":
+			_dump_growth(rows)
 		_:
 			print("\n%s (%d)" % [table, (rows as Array).size()])
 			for row: Dictionary in rows:
@@ -161,6 +172,22 @@ func _dump_learnsets(directory: String, rows: Array) -> void:
 			parts.append("%d %s" % [int(entry["level"]), _name_at(moves, int(entry["move"]))])
 		print("  %3d  %-11s %s" % [int(row["number"]), String(row["name"]), ", ".join(parts)])
 	print("  %d level-up moves" % total)
+
+
+## Every species' growth rate and base experience yield, the two fields
+## [Gen2Experience] needs and nothing else reads. Neither has a self-checking
+## shape (a growth rate byte 0-5 and a base exp byte are both plausible
+## whatever the offset is), so what settles them is reading a name against a
+## curve published independently: Bulbasaur medium slow, Caterpie medium fast,
+## Chansey fast, Mewtwo slow.
+func _dump_growth(rows: Array) -> void:
+	print("\ngrowth (%d species)" % rows.size())
+	for row: Dictionary in rows:
+		var rate: int = int(row.get("growth_rate", -1))
+		var rate_name: String = GROWTH_NAMES[rate] if rate >= 0 and rate < GROWTH_NAMES.size() else "?"
+		print("  %3d  %-11s %-13s base exp %3d" % [
+			int(row["number"]), String(row["name"]), rate_name, int(row.get("base_exp", 0)),
+		])
 
 
 ## Only the species that evolve, which is under half of them. The rest would be


### PR DESCRIPTION
A battle that ends now awards something: growth rate and base exp, already decoded and unused, feed the six real growth curves in Gen2Experience, pinned against pokecrystal's own formula and checked against all 251 species in all three real games. Gen2Battle splits stat experience among participants but never experience itself, levels up one level at a time so a move taught partway up a jump is learned at the right level, and adds a third policy hole alongside must_replace for when a level-up finds every move slot full. The battle screen's exp bar reads a real fraction instead of sitting at half.