### PR TITLE
Give Disable, Attract, Encore, Mist and Focus Energy their own sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ the same thing for Generation 1.
 > gains experience and stat experience off the cartridge's own six growth
 > curves, levels up, recalculates its stats and picks up whatever its
 > learnset teaches along the way, with the exp bar moving to match. Disable,
-> Attract, Mist, Focus Energy, Counter and Mirror Coat are still an ordinary
-> attack, and the overworld, audio and the mod loader do not exist.
-> There is nothing playable here today.
+> Attract, Encore, Mist and Focus Energy all lock a move slot, a target's
+> gender or the user's own state now too. Counter, Mirror Coat, Selfdestruct
+> and Explosion's own halved Defense, and Fly and Dig's semi-invulnerability
+> are still an ordinary attack, and the overworld, audio and the mod loader do
+> not exist. There is nothing playable here today.
 
 ## Getting started
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -263,17 +263,83 @@ the four fixed-damage effects (`FIXED_DAMAGE`, shared by Super Fang, Sonicboom,
 Seismic Toss and Psywave the way the cartridge shares one `ConstantDamage`
 routine between them) both overwrite what `DAMAGE_CALC` already worked out
 rather than replacing it in the list, keeping only the one thing worth keeping
-from that spent roll: whether the hit is immune at all. Drain is worth a second
-look before assuming its shape follows recoil's: it heals off
-`Gen2Turn.damage`, the number the formula calculated, not `Gen2Turn.dealt`, the
-number that actually came off a target with less left than that, because the
-cartridge's own `SapHealth` reads the same uncapped figure `ApplyDamage` reads
-before clamping it. `Gen2EffectCommands._recoil` uses `Gen2Turn.dealt` instead,
-which the disassembly's own `BattleCommand_Recoil` does not: it also reads the
-uncapped `wCurDamage`. That divergence was not fixed here, since it was found
-while writing an unrelated effect and touching an already-shipped, already-
-tested one was outside what this change was for; whoever picks it up should
-decide whether an overkill hit's recoil is worth correcting to match.
+from that spent roll: whether the hit is immune at all. Drain and recoil both
+heal or cost off `Gen2Turn.damage`, the number the formula calculated, not
+`Gen2Turn.dealt`, the number that actually came off a target with less left
+than that, because the cartridge's own `SapHealth` and `BattleCommand_Recoil`
+both read the same uncapped figure `ApplyDamage` reads before clamping it. A
+target with three hit points left against a move that calculates fifty takes
+three, but a draining attacker heals twenty-five and a recoiling one costs
+itself twelve or thirteen, not one; `_recoil` read `Gen2Turn.dealt` until a
+later session found the divergence and corrected it to match `_drain_target`,
+which had always read it correctly.
+
+Disable, Attract and Encore are a different shape of problem from the rest of
+this table: each acts on a target's own last-used move or its own gender,
+neither of which anything else here needed to track. `Gen2BattleMon.last_move_used`
+is set in `USED_MOVE_TEXT`, cleared on a switch alongside everything else
+`reset_volatile` clears, and is what both effects search the target's own move
+list for; `Gen2BattleMon.disabled_slot`/`disable_turns` and
+`encored_slot`/`encore_turns` are the slot each one locks and for how long,
+`-1` for neither so a locked slot 0 is never confusable with nothing locked at
+all. `Gen2BattleMon.gender` is `GetGender`'s own formula: the species' gender
+ratio compared against the Attack and Speed DVs folded into one byte, high
+nibble and low nibble, the same comparison a personality value gets from
+Generation 3 onward; a ratio of 0 or 254 answers outright with no comparison
+run, and 255 is genderless. Disable's own duration is a reroll-on-zero three
+bits of a random byte plus one (`Gen2Substatus.roll_disable`); Encore's is two
+bits plus three, no reroll; both are named after the cartridge's own rolls
+rather than assumed to share one shape.
+
+Disable is not a slot the *attacker* chooses: it searches the *target's* own
+move list for whatever `last_move_used` names, which is the cartridge's own
+rule (`BattleCommand_Disable` reads `BATTLE_VARS_LAST_COUNTER_MOVE_OPP`, not a
+menu selection), and fails on a target that has not moved yet, whose last move
+was Struggle, who is already disabled, or whose found slot has already run out
+of PP. `Gen2BattleMon.can_use` refuses a disabled slot outright, which is
+enough to reroute every ordinary caller to a different slot or to Struggle;
+`CHECK_STATUS` still carries a belt-and-suspenders refusal for a Pokémon
+somehow still about to use the disabled move regardless, compared by move
+*number* rather than by slot, because a slot that has already been rerouted to
+Struggle by `can_use` still names the disabled slot in `Gen2Turn.slot`, and
+comparing slots there would refuse the Struggle too. Both the tick-down and the
+belt-and-suspenders check sit between flinch and confusion in `CHECK_STATUS`,
+the cartridge's own order.
+
+Encore is the same search, with its own exclusions (Struggle, Encore itself,
+Mirror Move) and its own state, but nothing about *forcing* the locked move
+lives in its own command: `Gen2Battle.effective_slot` is what
+`Gen2Battle.move_for` and `Gen2Battle.take_actions` both read to decide which
+slot actually spends its PP, the same extension point `charged_move` already
+uses for a two-turn move's release turn. The real cartridge's own
+`CheckOpponentWentFirst` forces an already-chosen action over for the very
+turn Encore lands on top of, not only the ones after it, when the encored side
+has not gone yet this same turn; this engine gets that for free by not
+committing to `chosen[side]` until `Gen2Battle._act` actually reaches it,
+reading `effective_slot`/`move_for` fresh at that point rather than at the top
+of the turn where priority was decided. Encore's own countdown ticks once a
+turn rather than once a side's move, in `Gen2Battle._tick_encore`, run
+alongside `_residual_damage`: that is where the cartridge's own `HandleEncore`
+runs too, and it is also what ends Encore early the moment its own locked move
+runs out of PP, not only when the counter reaches zero on its own.
+
+Attract fails between the same gender, a genderless pair, or a target already
+in love, and otherwise sets a substatus flag with no counter, cleared only on
+a switch: what stops the target moving is a fresh coin flip every turn inside
+`CHECK_STATUS`, after confusion, not something decided once when Attract
+lands.
+
+Mist and Focus Energy need nothing `Gen2Substatus` had not already grown for
+something else: a flag, cleared on a switch, checked at the point that already
+existed. Mist's own check sits inside `_stat_change`, gating only the "down"
+and "down2" families (a rise is never checked, since only the entries that
+target the opponent are ever a drop worth blocking), and gets its own event,
+`MIST_PROTECTED`, rather than the generic `STAT_CHANGE_FAILED`: the cartridge
+prints its own line for this one rather than "won't go any lower". Focus
+Energy is closer to wiring than to building: `Gen2Damage.calculate`,
+`roll_critical` and `critical_level` already took a `focus_energy` argument
+before this, unused by any caller; the work was setting the flag and reading
+it back in `_damage_calc` and `_multi_hit`'s own per-hit reroll.
 
 `battle/status.gd` is one status byte, one at a time, refusing a second rather
 than adding it. `battle/substatus.gd` is everything that does not fit on that

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -213,13 +213,16 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 
 
 ## [constant RomLayout.AI_BASIC]: don't do anything redundant. A status move
-## whose target already carries a status does nothing on the cartridge, and
-## Confuse Ray or Supersonic against an already-confused target is the one
-## other case `AI_Redundant` covers that this engine's move list can reach;
-## the rest of that routine's table (Light Screen while it is already up, a
-## Substitute already standing, Mist, and so on) reads state this engine does
-## not carry yet and so never fires, which reads as "not redundant" rather
-## than as a wrong answer.
+## whose target already carries a status does nothing on the cartridge, and so
+## do Confuse Ray or Supersonic against an already-confused target, Disable or
+## Encore against an already-locked target, Attract against a target already
+## in love or of the same or an unknown gender, and Mist or Focus Energy used
+## a second time by the attacker itself, which is why those two read the
+## attacker's own state rather than the defender's. The rest of
+## `AI_Redundant`'s own table (Light Screen while it is already up, a
+## Substitute already standing, and so on) reads state this engine does not
+## carry yet and so never fires, which reads as "not redundant" rather than as
+## a wrong answer.
 static func _apply_basic(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int
@@ -233,6 +236,20 @@ static func _apply_basic(
 			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED)
 		elif STATUS_ONLY_EFFECTS.has(effect):
 			redundant = Gen2Status.is_afflicted(defender.status)
+		elif effect == Gen2MoveEffect.DISABLE:
+			redundant = defender.disabled_slot >= 0
+		elif effect == Gen2MoveEffect.ENCORE:
+			redundant = defender.encored_slot >= 0
+		elif effect == Gen2MoveEffect.ATTRACT:
+			var same_gender: bool = attacker.gender() == defender.gender()
+			var unknown_gender: bool = attacker.gender() == Gen2BattleMon.GENDER_NONE \
+				or defender.gender() == Gen2BattleMon.GENDER_NONE
+			redundant = same_gender or unknown_gender \
+				or Gen2Substatus.has(defender.substatus, Gen2Substatus.ATTRACTED)
+		elif effect == Gen2MoveEffect.MIST:
+			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.MIST)
+		elif effect == Gen2MoveEffect.FOCUS_ENERGY:
+			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY)
 		if redundant:
 			_discourage(scores, slot)
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -106,6 +106,46 @@ const MOVE_OFFERED: StringName = &"move_offered"
 const MOVE_FORGOTTEN: StringName = &"move_forgotten"
 const MOVE_DECLINED: StringName = &"move_declined"
 
+## Disable, Attract, Encore, Mist and Focus Energy each refuse for their own
+## reason (a target with nothing to disable, a same-gender or genderless
+## target, an already-encored target, and so on) rather than missing or doing
+## nothing to a type: not [constant MISSED], whose accuracy was rolled and
+## lost, and not [constant NO_EFFECT], which is about a type matchup. One event
+## for every one of the five, the same "but it failed!" the cartridge shares
+## across all of them.
+const MOVE_FAILED: StringName = &"move_failed"
+
+## Disable locked a slot, and later let it go. [code]slot[/code] and
+## [code]move[/code] on the first are the target's own, read off
+## [member Gen2BattleMon.disabled_slot] before it moves; the belt-and-suspenders
+## refusal for a Pokémon that is still locked into the disabled move itself is
+## [constant CANNOT_MOVE]'s own [code]&"disabled"[/code] reason, not this.
+const DISABLE_INFLICTED: StringName = &"disable_inflicted"
+const DISABLE_ENDED: StringName = &"disable_ended"
+
+## Attract's own two events: falling in love, which is
+## [constant Gen2Substatus.ATTRACTED] set and stays set until a switch, and the
+## turn a fresh roll finds the target too smitten to move, which is
+## [constant CANNOT_MOVE]'s own [code]&"attract"[/code] reason rather than an
+## event of its own, the same shape flinch and confusion already use.
+const ATTRACT_INFLICTED: StringName = &"attract_inflicted"
+
+## Encore locked a slot, and later let it go, the same pair
+## [constant DISABLE_INFLICTED] and [constant DISABLE_ENDED] are for Disable.
+const ENCORE_INFLICTED: StringName = &"encore_inflicted"
+const ENCORE_ENDED: StringName = &"encore_ended"
+
+## Mist and Focus Energy, set on the user. Both fail with [constant MOVE_FAILED]
+## on a second use rather than silently re-applying.
+const MIST_SET: StringName = &"mist_set"
+const FOCUS_ENERGY_SET: StringName = &"focus_energy_set"
+
+## A stat drop blocked by the target's own Mist. Not [constant STAT_CHANGE_FAILED]:
+## the cartridge prints a line of its own ("It's protected by mist!") rather
+## than the generic "won't go any lower" a drop already at its floor gets, and a
+## screen that read this as the generic failure would say the wrong thing.
+const MIST_PROTECTED: StringName = &"mist_protected"
+
 ## What a side does with its turn. Switching is not a move with a very high
 ## priority: it is settled before priority is looked at, which is why it is an
 ## action rather than a move number.
@@ -348,6 +388,17 @@ func send_out(side: int, index: int) -> Array:
 ## either side owes a replacement, and a faint ends the turn where it is: a
 ## Pokémon that is knocked out before it has moved does not get to move, which is
 ## most of what speed is for.
+##
+## The move each side is credited with for [method order]'s own priority check
+## is worked out once, before either side has acted, because that is the
+## moment the cartridge's own move order is decided too. What actually runs is
+## worked out again, fresh, right before [method _act]: Encore can land on a
+## side that has not gone yet this same turn, and the cartridge's own
+## `CheckOpponentWentFirst` forces that side's already-chosen action over for
+## the very turn it lands, not just the ones after it. Recomputing at the
+## point of use rather than committing to [param chosen] gets that for free,
+## since nothing about which move a side actually uses is settled until this
+## reaches it.
 func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	var events: Array = []
 	if is_over() or awaiting_replacement() or awaiting_move_learn():
@@ -366,9 +417,11 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 			continue
 		if mon(side).is_fainted() or mon(opponent_of(side)).is_fainted():
 			break
-		_act(side, int(actions[side].get("slot", 0)), chosen[side], events)
+		var slot: int = effective_slot(side, int(actions[side].get("slot", 0)))
+		_act(side, slot, move_for(side, slot), events)
 
 	_residual_damage(acting, events)
+	_tick_encore(acting, events)
 	_award_experience(events)
 
 	if is_over():
@@ -420,6 +473,28 @@ func _residual_damage(acting: Array, events: Array) -> void:
 		})
 		if current.is_fainted():
 			events.append({"type": FAINTED, "side": side})
+
+
+## Encore's own countdown, once a turn rather than once a side's move: the
+## cartridge's own `HandleEncore` runs after both sides have acted, the same
+## timing [method _residual_damage] already uses for a burn or a poison.
+##
+## Ends early, before the counter reaches zero, the moment the encored slot
+## itself runs out of PP: the cartridge checks that every turn Encore ticks,
+## not only when the counter would have expired on its own.
+func _tick_encore(acting: Array, events: Array) -> void:
+	for side: int in acting:
+		var current: Gen2BattleMon = mon(side)
+		if current.is_fainted() or current.encored_slot < 0:
+			continue
+
+		current.encore_turns -= 1
+		if current.encore_turns > 0 and current.pp_left(current.encored_slot) > 0:
+			continue
+
+		current.encored_slot = -1
+		current.encore_turns = 0
+		events.append({"type": ENCORE_ENDED, "side": side})
 
 
 ## Experience for every enemy Pokémon that fainted this turn, whether the faint
@@ -525,22 +600,38 @@ func _move_for_action(side: int, action: Dictionary) -> int:
 	return move_for(side, int(action.get("slot", 0)))
 
 
+## The slot PP is actually spent from, which is not always the slot a caller
+## asks for: Encore forces whichever slot it locked in, the same way a
+## two-turn move's release turn forces its own move number regardless of which
+## slot [method move_for] is asked about. Falls back to the encored slot only
+## while it is still usable, so an encored move that has run out of PP does not
+## reach for it once [method _tick_encore] has already ended the effect.
+func effective_slot(side: int, requested_slot: int) -> int:
+	var attacker: Gen2BattleMon = mon(side)
+	if attacker.encored_slot >= 0 and attacker.can_use(attacker.encored_slot):
+		return attacker.encored_slot
+	return requested_slot
+
+
 ## Which move a side will actually use.
 ##
 ## A Pokémon locked into a two-turn move's release turn answers with what it
 ## charged, whatever slot the caller asks for: on the cartridge nothing is
-## chosen on that turn at all, so nothing here is either.
+## chosen on that turn at all, so nothing here is either. Failing that, Encore
+## answers with whatever [method effective_slot] resolves to, which may not be
+## the slot the caller asked for either.
 ##
 ## Failing that, a slot with nothing usable in it answers Struggle, which is
 ## the cartridge's answer for a Pokémon with no PP anywhere. Here it is also the
-## answer for a slot that is empty or spent while others are not, because a
-## caller that points at one has asked for something that cannot happen, and
-## Struggle is the only move that is always available.
+## answer for a slot that is empty, spent or disabled while others are not,
+## because a caller that points at one has asked for something that cannot
+## happen, and Struggle is the only move that is always available.
 func move_for(side: int, slot: int) -> int:
 	var attacker: Gen2BattleMon = mon(side)
 	if attacker.charged_move != 0:
 		return attacker.charged_move
-	return int(attacker.moves[slot]) if attacker.can_use(slot) else Gen2Damage.STRUGGLE
+	var chosen_slot: int = effective_slot(side, slot)
+	return int(attacker.moves[chosen_slot]) if attacker.can_use(chosen_slot) else Gen2Damage.STRUGGLE
 
 
 ## Who goes first, as the two sides in the order they act.

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -76,6 +76,26 @@ var charged_move: int = 0
 ## Toxic's damage ramps on. Zero unless actually toxic.
 var toxic_counter: int = 0
 
+## Which move slot Disable has locked, or -1 for none: -1 rather than 0 so
+## "nothing disabled" is never confusable with the first slot. Meaningful only
+## while [constant Gen2Substatus.DISABLED] is set.
+var disabled_slot: int = -1
+## How many turns [member disabled_slot] stays locked.
+var disable_turns: int = 0
+
+## Which move slot Encore has locked, or -1 for none, the same shape as
+## [member disabled_slot]. Meaningful only while
+## [constant Gen2Substatus.ENCORED] is set.
+var encored_slot: int = -1
+## How many turns [member encored_slot] stays locked.
+var encore_turns: int = 0
+
+## The move this Pokémon last used, by move number, or zero for none: what
+## Disable and Encore both search a target's own move list for. The cartridge's
+## own `wLastPlayerMove`/`wLastEnemyMove` clear on a switch exactly the way this
+## does, since a freshly sent-out Pokémon has not used a move yet.
+var last_move_used: int = 0
+
 ## The item this Pokémon is holding, by item number, or zero for none. Carried
 ## through from a trainer's party or a save; nothing in the engine reads it yet.
 var item: int = 0
@@ -207,6 +227,45 @@ func reset_volatile() -> void:
 	confusion_turns = 0
 	charged_move = 0
 	toxic_counter = 0
+	disabled_slot = -1
+	disable_turns = 0
+	encored_slot = -1
+	encore_turns = 0
+	last_move_used = 0
+
+
+## The gender the cartridge's own `GetGender` would answer, from the species'
+## gender ratio and this Pokémon's own Attack and Speed DVs.
+##
+## Not a coin flip and not tied to a stat total: the cartridge folds the
+## Attack DV into the high nibble of one byte and the Speed DV into the low
+## nibble, and compares that byte against the species' own ratio the same way
+## a personality value is compared against one from Generation 3 onward. A
+## ratio of 0 is always male and 254 is always female outright, with no
+## comparison run at all; 255 is genderless. Otherwise a combined value below
+## the ratio is male and at or above it is female, which is why raising the
+## ratio raises the odds of female: [constant Gen2Species.GENDER_UNKNOWN] and
+## the two extremes are named on [Gen2BattleMon] rather than repeated at every
+## caller.
+const GENDER_F0: int = 0
+const GENDER_F100: int = 254
+const GENDER_UNKNOWN: int = 255
+
+const GENDER_MALE: StringName = &"male"
+const GENDER_FEMALE: StringName = &"female"
+const GENDER_NONE: StringName = &"genderless"
+
+func gender() -> StringName:
+	var ratio: int = int(data.species(species).get("gender_ratio", GENDER_UNKNOWN))
+	if ratio == GENDER_UNKNOWN:
+		return GENDER_NONE
+	if ratio == GENDER_F0:
+		return GENDER_MALE
+	if ratio == GENDER_F100:
+		return GENDER_FEMALE
+
+	var combined: int = (Gen2Stats.attack_dv(dvs) << 4) | Gen2Stats.speed_dv(dvs)
+	return GENDER_MALE if combined < ratio else GENDER_FEMALE
 
 
 ## The two type numbers, which are the same number twice for a single-type
@@ -318,8 +377,14 @@ func spend_pp(slot: int) -> void:
 
 
 ## Whether there is anything left to do with a move slot.
+##
+## A disabled slot answers false here regardless of its PP, the same way the
+## cartridge's own menu never offers it: [method Gen2Battle.effective_slot] and
+## [method Gen2Battle.move_for] are what reroute a caller that still asks for
+## it, and [constant Gen2EffectCommands.CHECK_STATUS]'s own belt-and-suspenders
+## check is what catches the one path that does not go through either.
 func can_use(slot: int) -> bool:
-	return slot >= 0 and slot < moves.size() and pp_left(slot) > 0
+	return slot >= 0 and slot < moves.size() and pp_left(slot) > 0 and slot != disabled_slot
 
 
 ## True when every slot is empty. The cartridge answers Struggle here; this

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -46,6 +46,8 @@ const STOPPED_BY: Dictionary = {
 	&"paralysis": "is fully paralyzed!",
 	&"flinch": "flinched!",
 	&"recharge": "must recharge!",
+	&"disabled": "is disabled!",
+	&"attract": "is immobilized by love!",
 }
 
 const INFLICTED: Dictionary = {
@@ -572,6 +574,26 @@ func _describe(event: Dictionary) -> String:
 			return "%s did not learn %s." % [
 				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
 			]
+		Gen2Battle.MOVE_FAILED:
+			return "But it failed!"
+		Gen2Battle.DISABLE_INFLICTED:
+			return "%s's %s was disabled!" % [
+				_battler_name(int(event["target"])), String(_data.move(int(event["move"])).get("name", "")),
+			]
+		Gen2Battle.DISABLE_ENDED:
+			return "%s is disabled no more!" % _battler_name(side)
+		Gen2Battle.ATTRACT_INFLICTED:
+			return "%s fell in love!" % _battler_name(int(event["target"]))
+		Gen2Battle.ENCORE_INFLICTED:
+			return "%s got an encore!" % _battler_name(int(event["target"]))
+		Gen2Battle.ENCORE_ENDED:
+			return "%s's encore ended!" % _battler_name(side)
+		Gen2Battle.MIST_SET:
+			return "%s is shrouded in mist!" % _battler_name(side)
+		Gen2Battle.FOCUS_ENERGY_SET:
+			return "%s is getting pumped!" % _battler_name(side)
+		Gen2Battle.MIST_PROTECTED:
+			return "%s's stat drop was blocked by mist!" % _battler_name(int(event["target"]))
 		Gen2Battle.OVER:
 			# Both sides can go down in the same turn, through recoil or a burn,
 			# and then there is nobody to declare.

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -136,6 +136,34 @@ const BELLY_DRUM: StringName = &"bellydrum"
 ## target has nothing raised or lowered to copy.
 const PSYCH_UP: StringName = &"psychup"
 
+## Locks one of the target's own move slots, the one it last used, out for a
+## few turns. Fails if the target has not used a move yet, if that move was
+## Struggle, if it has already run out of PP, or if the target is already
+## disabled: only one slot at a time, the same "one at a time" rule the status
+## byte enforces for a different kind of affliction.
+const DISABLE: StringName = &"disable"
+
+## Locks the target into repeating its own last move for a few turns. The same
+## exclusions as [constant DISABLE] apply, plus two the cartridge names outright
+## rather than leaving to a structural check: the last move cannot have been
+## Encore itself or Mirror Move, neither of which means anything repeated.
+const ENCORE: StringName = &"encore"
+
+## Puts the target in love, provided the user and the target have opposite,
+## known genders and the target is not already smitten. Persists until a
+## switch; [constant Gen2EffectCommands.CHECK_STATUS] is what rolls, every turn,
+## whether that stops the target moving at all.
+const ATTRACT: StringName = &"attract"
+
+## Shields the user from the opponent's own stat-lowering moves, until a
+## switch. Blocks a drop aimed at the user; never a rise, and never the user's
+## own drop aimed at the opponent. Fails, without re-applying, on a second use.
+const MIST: StringName = &"mist"
+
+## Raises the user's own critical-hit rate for the rest of the battle, until a
+## switch. Fails, without re-applying, on a second use.
+const FOCUS_ENERGY: StringName = &"focusenergy"
+
 ## Raises and lowers a stat by one stage or two, named the way the cartridge
 ## names them and in the order [constant Gen2BattleMon.STAGED_STATS] plus
 ## [constant Gen2BattleMon.STAGED_ODDS] already keeps the seven in, because that
@@ -232,6 +260,13 @@ const RECOIL_DIVISOR: int = 4
 ## Wheel and Sacred Fire, by move number.
 const THAWING_MOVES: Array = [172, 221]
 
+## What Encore refuses to lock a target into repeating even though the target
+## did just use it, by move number: Encore itself, and Mirror Move, since
+## forcing either to repeat means nothing (Encore stacked on Encore locks in
+## nothing new, and Mirror Move's own effect is to copy whatever the opponent
+## did last, not to repeat itself).
+const ENCORE_EXCLUDED_MOVES: Array = [119, 227]
+
 
 ## Runs one command against [param turn].
 ##
@@ -296,6 +331,16 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_belly_drum(turn)
 		PSYCH_UP:
 			_psych_up(turn)
+		DISABLE:
+			_disable(turn)
+		ENCORE:
+			_encore(turn)
+		ATTRACT:
+			_attract(turn)
+		MIST:
+			_mist(turn)
+		FOCUS_ENERGY:
+			_focus_energy(turn)
 		ALL_STATS_UP:
 			_all_stats_up(turn)
 		STAT_UP_MESSAGE, STAT_DOWN_MESSAGE:
@@ -309,7 +354,17 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 				push_error("No such effect command: %s" % command)
 
 
+## Announces the move, and records it as what Disable and Encore will find if
+## the opponent's next move searches for "what did this Pokémon last use".
+##
+## The real cartridge skips that second part on the release turn of a two-turn
+## move, so Disable and Encore that land mid-charge see the move that was
+## charging rather than the one that was just released; this always records
+## the move actually announced, which is simpler and only differs from the
+## cartridge in that one narrow interaction. Worth revisiting if Disable or
+## Encore's behaviour against a charging Pokémon ever needs to match exactly.
 static func _used_move_text(turn: Gen2Turn) -> void:
+	turn.attacker().last_move_used = turn.move_number
 	turn.emit(Gen2Battle.USED_MOVE, {"move": turn.move_number})
 
 
@@ -326,7 +381,8 @@ static func _do_turn(turn: Gen2Turn) -> void:
 
 static func _damage_calc(turn: Gen2Turn) -> void:
 	var result: Dictionary = Gen2Damage.calculate(
-		turn.attacker(), turn.defender(), turn.move, turn.rng()
+		turn.attacker(), turn.defender(), turn.move, turn.rng(),
+		Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.FOCUS_ENERGY)
 	)
 	turn.damage = int(result["damage"])
 	turn.critical = bool(result["critical"])
@@ -375,13 +431,20 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 	})
 
 
+## A quarter of [member Gen2Turn.damage], the number the formula calculated,
+## never less than one, and never [member Gen2Turn.dealt], the number that
+## actually came off a target with less left than that. The real cartridge's
+## own `BattleCommand_Recoil` reads the same uncapped `wCurDamage`
+## [constant Gen2EffectCommands.DRAIN_TARGET] already reads, so a target with
+## three hit points left against a move that calculates fifty costs the
+## attacker a quarter of fifty, not a quarter of three.
 static func _recoil(turn: Gen2Turn) -> void:
-	if turn.dealt <= 0:
+	if turn.damage <= 0:
 		return
 
 	var attacker: Gen2BattleMon = turn.attacker()
 	@warning_ignore("integer_division")
-	var taken: int = attacker.take_damage(maxi(turn.dealt / RECOIL_DIVISOR, 1))
+	var taken: int = attacker.take_damage(maxi(turn.damage / RECOIL_DIVISOR, 1))
 	turn.emit(Gen2Battle.RECOIL, {
 		"amount": taken, "hp": attacker.hp, "max_hp": attacker.max_hp(),
 	})
@@ -394,11 +457,10 @@ static func _check_faint(turn: Gen2Turn) -> void:
 			turn.events.append({"type": Gen2Battle.FAINTED, "side": side})
 
 
-## Recharge, then sleep, then freeze, then flinch, then confusion, then
-## paralysis, which is the cartridge's own order in [code]CheckPlayerTurn[/code].
-## Disable and Attract sit between flinch and confusion on the cartridge and are
-## not written yet; nothing here skips a slot for them because neither writes
-## [Gen2Substatus] yet either.
+## Recharge, then sleep, then freeze, then flinch, then Disable's own
+## countdown, then confusion, then Attract's immobilise roll, then a
+## belt-and-suspenders refusal for a Pokémon still locked into the disabled
+## move itself, then paralysis. This is the cartridge's own order.
 ##
 ## A frozen Pokémon is never asked whether it is also paralysed, because the
 ## status byte cannot say both; a confused Pokémon that hits itself is never
@@ -409,7 +471,11 @@ static func _check_faint(turn: Gen2Turn) -> void:
 ## ending the turn, so a Pokémon whose counter runs out attacks the same turn it
 ## opens its eyes. That is Generation 2's rule and not Generation 1's. Snapping
 ## out of confusion works the same way: the counter reaching zero clears the
-## flag and lets the move through the same turn.
+## flag and lets the move through the same turn, and Disable wearing off here
+## does too, for the same reason: [method Gen2BattleMon.can_use] already
+## refuses the slot before this runs, so a countdown that reaches zero this
+## turn has already stopped mattering by the time the belt-and-suspenders check
+## further down would otherwise have caught it.
 static func _check_status(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 
@@ -443,6 +509,14 @@ static func _check_status(turn: Gen2Turn) -> void:
 		turn.end()
 		return
 
+	if mon.disabled_slot >= 0:
+		mon.disable_turns -= 1
+		if mon.disable_turns <= 0:
+			var slot: int = mon.disabled_slot
+			mon.disabled_slot = -1
+			mon.disable_turns = 0
+			turn.emit(Gen2Battle.DISABLE_ENDED, {"slot": slot})
+
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.CONFUSED):
 		mon.confusion_turns -= 1
 		if mon.confusion_turns <= 0:
@@ -457,6 +531,25 @@ static func _check_status(turn: Gen2Turn) -> void:
 				})
 				turn.end()
 				return
+
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.ATTRACTED) \
+		and Gen2Substatus.rolls_attract_immobile(turn.rng()):
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"attract"})
+		turn.end()
+		return
+
+	# Belt-and-suspenders: a Pokémon that is still, somehow, about to use its
+	# own disabled move is refused here rather than allowed through on a
+	# technicality. By move number, not by slot: [method Gen2BattleMon.can_use]
+	# has already turned an ordinary request for the disabled slot into
+	# Struggle by the time this runs, and [member Gen2Turn.slot] still names
+	# the slot that was asked for rather than the one that is actually
+	# happening, so comparing slots here would refuse that Struggle too.
+	if mon.disabled_slot >= 0 and mon.disabled_slot < mon.moves.size() \
+		and turn.move_number == int(mon.moves[mon.disabled_slot]):
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"disabled"})
+		turn.end()
+		return
 
 	if Gen2Status.has(mon.status, Gen2Status.PARALYSIS) \
 		and Gen2Status.rolls_full_paralysis(turn.rng()):
@@ -595,9 +688,12 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	var hits: int = 2 if FIXED_TWO_HIT_EFFECTS.has(turn.effect()) else _roll_multi_hit_count(turn.rng())
 
+	var focus_energy: bool = Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY)
 	for hit: int in hits:
 		if hit > 0:
-			var result: Dictionary = Gen2Damage.calculate(attacker, defender, turn.move, turn.rng())
+			var result: Dictionary = Gen2Damage.calculate(
+				attacker, defender, turn.move, turn.rng(), focus_energy
+			)
 			turn.damage = int(result["damage"])
 			turn.critical = bool(result["critical"])
 			turn.effectiveness = int(result["effectiveness"])
@@ -779,24 +875,157 @@ static func _psych_up(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.STAGES_COPIED)
 
 
+## Locks one of the target's own move slots: whichever one holds
+## [member Gen2BattleMon.last_move_used], found by searching the target's own
+## move list the way the cartridge does rather than by asking which slot it
+## came from, because nothing the attacker did carries that information.
+##
+## Fails, doing nothing, if the target has not moved yet this battle, if that
+## move was Struggle, if the target is already disabled, if the move it used
+## is no longer in its list at all (a level-up mid-battle can replace a slot;
+## the cartridge never has to consider this since nothing on it can), or if
+## the slot that move sits in has already run out of PP.
+static func _disable(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.disabled_slot >= 0:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	var last_move: int = defender.last_move_used
+	if last_move == 0 or last_move == Gen2Damage.STRUGGLE:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	var slot: int = defender.moves.find(last_move)
+	if slot < 0 or defender.pp_left(slot) <= 0:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	defender.disabled_slot = slot
+	defender.disable_turns = Gen2Substatus.roll_disable(turn.rng())
+	defender.substatus |= Gen2Substatus.DISABLED
+	turn.emit(Gen2Battle.DISABLE_INFLICTED, {
+		"target": turn.target, "slot": slot, "move": last_move,
+	})
+
+
+## Locks the target into repeating [member Gen2BattleMon.last_move_used] for a
+## few turns, found the same way [method _disable] finds its own slot and
+## refused for the same reasons, plus two the cartridge names outright rather
+## than leaving to a structural check: see [constant ENCORE_EXCLUDED_MOVES].
+##
+## What actually forces the move each turn is not here: [method Gen2Battle.
+## effective_slot] and [method Gen2Battle.move_for] read
+## [member Gen2BattleMon.encored_slot] back at the point a side acts, the same
+## way a two-turn move's release turn is forced through
+## [member Gen2BattleMon.charged_move].
+static func _encore(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.encored_slot >= 0:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	var last_move: int = defender.last_move_used
+	if last_move == 0 or last_move == Gen2Damage.STRUGGLE \
+		or ENCORE_EXCLUDED_MOVES.has(last_move):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	var slot: int = defender.moves.find(last_move)
+	if slot < 0 or defender.pp_left(slot) <= 0:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	defender.encored_slot = slot
+	defender.encore_turns = Gen2Substatus.roll_encore(turn.rng())
+	defender.substatus |= Gen2Substatus.ENCORED
+	turn.emit(Gen2Battle.ENCORE_INFLICTED, {"target": turn.target, "slot": slot, "move": last_move})
+
+
+## Puts the target in love, provided the user and the target have opposite,
+## known genders (a genderless Pokémon or a matching pair refuses the same way
+## a Pokémon already in love does) and the target is not already smitten.
+## [constant Gen2EffectCommands.CHECK_STATUS] is what rolls, every turn from
+## here on, whether that stops the target moving at all.
+static func _attract(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	var defender: Gen2BattleMon = turn.defender()
+	if Gen2Substatus.has(defender.substatus, Gen2Substatus.ATTRACTED):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	var user_gender: StringName = attacker.gender()
+	var target_gender: StringName = defender.gender()
+	if user_gender == Gen2BattleMon.GENDER_NONE or target_gender == Gen2BattleMon.GENDER_NONE \
+		or user_gender == target_gender:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	defender.substatus |= Gen2Substatus.ATTRACTED
+	turn.emit(Gen2Battle.ATTRACT_INFLICTED, {"target": turn.target})
+
+
+## Shields the user from the opponent's own stat-lowering moves, until a
+## switch: [method _stat_change] is what actually blocks a drop, reading this
+## flag back off whichever side a drop is aimed at. Fails, without
+## re-applying, on a second use, the same as [method _focus_energy].
+static func _mist(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.MIST):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	mon.substatus |= Gen2Substatus.MIST
+	turn.emit(Gen2Battle.MIST_SET)
+
+
+## Raises the user's own critical-hit rate for the rest of the battle, until a
+## switch: [method _damage_calc] and [method _multi_hit] are what read this
+## flag back, through [method Gen2Damage.calculate]'s own [code]focus_energy[/code]
+## argument. Fails, without re-applying, on a second use.
+static func _focus_energy(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.FOCUS_ENERGY):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	mon.substatus |= Gen2Substatus.FOCUS_ENERGY
+	turn.emit(Gen2Battle.FOCUS_ENERGY_SET)
+
+
 ## Moves one stat by one command's worth, and writes down who it happened to and
 ## whether it actually moved, for the message step behind it to read.
 ##
 ## A secondary effect's failed roll skips this the same way it skips a status:
 ## the damage in front of it has already landed, and what was behind the roll is
 ## the only thing the roll can still cost.
+##
+## A drop aimed at a target shielded by Mist never reaches
+## [method Gen2BattleMon.change_stage] at all: every entry that lowers a stat
+## targets the opponent rather than the user (`entry[2]` is false for exactly
+## that set), which is the same thing Mist itself only ever blocks. A rise
+## always targets the user and is never checked against it, the same as the
+## cartridge's own [code]CheckMist[/code] only gates the "down" and "down2"
+## effect-byte ranges.
 static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	var entry: Array = STAT_COMMANDS[command]
 	var stat_key: String = String(entry[0])
 	var amount: int = int(entry[1])
-	var side: int = turn.side if bool(entry[2]) else turn.target
+	var targets_user: bool = bool(entry[2])
+	var side: int = turn.side if targets_user else turn.target
 
 	turn.stat_key = stat_key
 	turn.stat_by = amount
 	turn.stat_target = side
+	turn.stat_mist_blocked = false
 
 	if turn.failed_chance:
 		turn.stat_moved = false
+		return
+
+	if not targets_user and Gen2Substatus.has(turn.battle.mon(side).substatus, Gen2Substatus.MIST):
+		turn.stat_moved = false
+		turn.stat_mist_blocked = true
 		return
 
 	turn.stat_moved = turn.battle.mon(side).change_stage(stat_key, amount)
@@ -832,9 +1061,21 @@ static func _stat_message(turn: Gen2Turn) -> void:
 
 
 ## Says a stat could not move. Only reached from a status move's own sequence,
-## which is the only place the cartridge follows a message step with this one.
+## which is the only place the cartridge follows a message step with this one:
+## an on-hit drop blocked by Mist has no fail-text step behind it at all, the
+## same silent failure any other on-hit drop that misses its own roll already
+## gets, since [code]data/moves/effects.asm[/code] never follows one with
+## [code]statdownfailtext[/code] either.
+##
+## Mist gets its own line rather than the generic one: the cartridge's own
+## [code]BattleCommand_StatDownFailText[/code] prints
+## [code]ProtectedByMistText[/code] for exactly this case, not "won't go any
+## lower".
 static func _stat_fail_text(turn: Gen2Turn) -> void:
 	if turn.stat_moved:
+		return
+	if turn.stat_mist_blocked:
+		turn.emit(Gen2Battle.MIST_PROTECTED, {"target": turn.stat_target})
 		return
 	turn.emit(Gen2Battle.STAT_CHANGE_FAILED, {
 		"target": turn.stat_target, "stat": turn.stat_key, "by": turn.stat_by,

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -111,6 +111,19 @@ const HAZE: int = 25
 const BELLY_DRUM: int = 142
 const PSYCH_UP: int = 143
 
+## Disable, Mist, Focus Energy, Attract and Encore: the numbers are read off
+## the real cartridge with [code]tools/dump_tables.gd -- gold moves[/code], the
+## same way every other effect byte here was, since Gold, Silver and Crystal do
+## not share Generation 1's numbering. Mist and Focus Energy need nothing new;
+## Disable, Attract and Encore are what
+## [member Gen2BattleMon.disabled_slot]/[member Gen2BattleMon.encored_slot] and
+## [method Gen2BattleMon.gender] exist for.
+const DISABLE: int = 86
+const MIST: int = 46
+const FOCUS_ENERGY: int = 47
+const ATTRACT: int = 120
+const ENCORE: int = 90
+
 ## An ordinary attack: say it, spend it, work it out, roll it, apply it, and see
 ## who is standing. Everything else is this with steps moved.
 const NORMAL_HIT: Array = [
@@ -283,6 +296,52 @@ const PSYCH_UP_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.PSYCH_UP,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Mist and Focus Energy: no roll at all, the same shape as [constant HAZE_SEQUENCE]
+## and [constant BELLY_DRUM_SEQUENCE] above, since both fail on their own
+## precondition (already active) rather than ever missing.
+const MIST_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.MIST,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const FOCUS_ENERGY_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.FOCUS_ENERGY,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Disable, Attract and Encore all roll to connect before they do anything:
+## the cartridge's own sequences for all three are
+## [code]usedmovetext, doturn, checkhit, <effect>, endmove[/code], read off
+## [code]data/moves/effects.asm[/code] directly rather than assumed from the
+## shape of the other three above.
+const DISABLE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.DISABLE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const ATTRACT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.ATTRACT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const ENCORE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.ENCORE,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -503,6 +562,11 @@ static func _sequences() -> Dictionary:
 		HAZE: HAZE_SEQUENCE,
 		BELLY_DRUM: BELLY_DRUM_SEQUENCE,
 		PSYCH_UP: PSYCH_UP_SEQUENCE,
+		MIST: MIST_SEQUENCE,
+		FOCUS_ENERGY: FOCUS_ENERGY_SEQUENCE,
+		DISABLE: DISABLE_SEQUENCE,
+		ATTRACT: ATTRACT_SEQUENCE,
+		ENCORE: ENCORE_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DRAIN_SEQUENCE,
 		MULTI_HIT: MULTI_HIT_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -1,20 +1,29 @@
 class_name Gen2Substatus
 extends RefCounted
 
-## The second byte of battle state, for everything the status byte cannot hold.
+## The volatile flags of battle state, for everything the status byte cannot
+## hold.
 ##
 ## [Gen2Status] is deliberately one status at a time, which is the cartridge's
 ## own rule: a Pokémon that is already poisoned cannot also be confused by
 ## refusing a second flag on the same byte. Confusion, flinching, being locked
-## into a recharge turn or a two-turn move's charge, Disable and Attract are all
-## independent of that and of each other, so they live on a byte of their own.
+## into a recharge turn or a two-turn move's charge, Disable, Attract, Encore,
+## Mist and Focus Energy are all independent of that and of each other, so they
+## live apart from it.
+##
+## The cartridge itself keeps these as five separate bytes
+## (`wPlayerSubStatus1` through `wPlayerSubStatus5`), not one: this project
+## folds them into a single int because nothing here needs to address one of
+## the five in isolation the way the cartridge's own bit-numbering does, and a
+## flag is a flag regardless of which byte it started on.
 ##
 ## Unlike [Gen2Status] this one is not the whole of its state: a few of these
 ## flags need a counter alongside them (how many turns of confusion are left,
-## which move was charged), which is why [Gen2BattleMon] keeps those as separate
-## fields next to [member Gen2BattleMon.substatus] rather than packing them into
-## the byte. This class stays pure arithmetic and holds no state of its own,
-## the same shape as [Gen2Status].
+## which move was charged, which slot is disabled and for how long), which is
+## why [Gen2BattleMon] keeps those as separate fields next to
+## [member Gen2BattleMon.substatus] rather than packing them into the byte.
+## This class stays pure arithmetic and holds no state of its own, the same
+## shape as [Gen2Status].
 ##
 ## Every flag here clears on a switch, which is what makes it volatile rather
 ## than a status: [method Gen2BattleMon.reset_volatile] is the single place that
@@ -25,10 +34,11 @@ const CONFUSED: int = 1 << 0
 const FLINCHED: int = 1 << 1
 const RECHARGING: int = 1 << 2
 const CHARGING: int = 1 << 3
-## Not yet written by any command; declared now so the byte's layout is decided
-## once rather than grown flag by flag as Disable and Attract are added.
 const DISABLED: int = 1 << 4
 const ATTRACTED: int = 1 << 5
+const ENCORED: int = 1 << 6
+const MIST: int = 1 << 7
+const FOCUS_ENERGY: int = 1 << 8
 
 const NONE: int = 0
 
@@ -38,6 +48,24 @@ const NONE: int = 0
 ## counter starts inclusive of both ends.
 const MIN_CONFUSION: int = 2
 const MAX_CONFUSION: int = 5
+
+## How many turns Disable lasts, from `BattleCommand_Disable`'s own roll: three
+## bits of a random byte, rerolled on zero, plus one. The result is packed
+## alongside the disabled slot on the cartridge's own single counter byte; here
+## the two live as separate fields on [Gen2BattleMon] instead, since nothing
+## else needs the packed form.
+const MIN_DISABLE: int = 2
+const MAX_DISABLE: int = 8
+
+## How many turns Encore lasts. Unlike Disable's roll, this one does not
+## reroll on the low end: two bits of a random byte, plus three.
+const MIN_ENCORE: int = 3
+const MAX_ENCORE: int = 6
+
+## Whether an attracted Pokémon is too smitten to move, out of 256: the
+## cartridge's own 128 in 256, a coin flip, rolled fresh every turn it tries to
+## move rather than decided once when Attract lands.
+const ATTRACT_IMMOBILE_CHANCE: int = 128
 
 ## Whether a confused Pokémon hurts itself instead of moving, out of 256: the
 ## cartridge's own 128 in 256, a coin flip.
@@ -57,3 +85,24 @@ static func roll_confusion(rng: RandomNumberGenerator) -> int:
 ## Whether a confused Pokémon hurts itself this turn instead of moving.
 static func rolls_confusion_hit(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, CHANCE_RANGE - 1) < CONFUSION_HURTS_SELF_CHANCE
+
+
+## How long a newly disabled move stays that way. The cartridge rolls three
+## bits of a random byte and rerolls a zero, so the roll itself only ever
+## produces 1 through 7; the constant one added afterward is folded in here
+## rather than left for a caller to remember.
+static func roll_disable(rng: RandomNumberGenerator) -> int:
+	var roll: int = 0
+	while roll == 0:
+		roll = rng.randi_range(0, 7)
+	return roll + 1
+
+
+## How long a newly encored move stays that way.
+static func roll_encore(rng: RandomNumberGenerator) -> int:
+	return rng.randi_range(0, 3) + MIN_ENCORE
+
+
+## Whether an attracted Pokémon is too smitten to move this turn.
+static func rolls_attract_immobile(rng: RandomNumberGenerator) -> bool:
+	return rng.randi_range(0, CHANCE_RANGE - 1) < ATTRACT_IMMOBILE_CHANCE

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -62,6 +62,11 @@ var stat_by: int = 0
 var stat_target: int = Gen2Battle.PLAYER
 var stat_moved: bool = false
 
+## Set instead of moving a stat when a drop was blocked by the target's own
+## Mist, so the fail-text step behind it can tell that apart from the ordinary
+## "already at the bottom" failure and say the right thing.
+var stat_mist_blocked: bool = false
+
 
 static func create(
 	in_battle: Gen2Battle, acting: int, from_slot: int, number: int, move_data: Dictionary,

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -85,8 +85,26 @@ const PSYWAVE_MOVE: int = 267
 
 const OHKO_MOVE: int = 268
 
+## Disable, Attract, Encore, Mist and Focus Energy, with the real accuracy
+## bytes (Disable's own shade under 55%; the other four always hit) and the
+## real effect bytes, both read off the real cartridges with
+## [code]tools/dump_tables.gd -- gold moves[/code].
+const DISABLE_MOVE: int = 269
+const ENCORE_MOVE: int = 270
+const ATTRACT_MOVE: int = 271
+const MIST_MOVE: int = 272
+const FOCUS_ENERGY_MOVE: int = 273
+
 ## The highest move number this table fills. Grown as new moves are added.
-const MAX_MOVE: int = OHKO_MOVE
+const MAX_MOVE: int = FOCUS_ENERGY_MOVE
+
+## Gender ratios, the published bytes: `x percent = floor(x * 255 / 100)`, so a
+## species' own ratio here can be checked against pret's own base stats rather
+## than against this file. Bulbasaur and Charmander are really 12.5% female;
+## Pikachu, Geodude and Magcargo are really an even 50/50.
+const GENDER_F12_5: int = 31
+const GENDER_F50: int = 127
+const GENDER_UNKNOWN: int = 255
 
 const NORMAL: int = 0x00
 const GROUND: int = 0x04
@@ -151,24 +169,25 @@ static func _species() -> Array:
 	var known: Dictionary = {
 		BULBASAUR: [
 			"BULBASAUR", [45, 49, 49, 45, 65, 65], [GRASS, POISON],
-			Gen2Experience.GROWTH_MEDIUM_SLOW, 64, [],
+			Gen2Experience.GROWTH_MEDIUM_SLOW, 64, [], GENDER_F12_5,
 		],
 		CHARMANDER: [
 			"CHARMANDER", [39, 52, 43, 65, 60, 50], [FIRE, FIRE],
 			Gen2Experience.GROWTH_MEDIUM_SLOW, 65, [{"level": 6, "move": EMBER}],
+			GENDER_F12_5,
 		],
 		PIKACHU: [
 			"PIKACHU", [35, 55, 30, 90, 50, 40], [ELECTRIC, ELECTRIC],
-			Gen2Experience.GROWTH_MEDIUM_FAST, 82, [],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 82, [], GENDER_F50,
 		],
 		GEODUDE: [
 			"GEODUDE", [40, 80, 100, 20, 30, 30], [ROCK, GROUND],
 			Gen2Experience.GROWTH_MEDIUM_SLOW, 86,
-			[{"level": 6, "move": GROWL}, {"level": 11, "move": SLASH}],
+			[{"level": 6, "move": GROWL}, {"level": 11, "move": SLASH}], GENDER_F50,
 		],
 		MAGCARGO: [
 			"MAGCARGO", [50, 50, 120, 30, 80, 80], [FIRE, ROCK],
-			Gen2Experience.GROWTH_MEDIUM_FAST, 154, [],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 154, [], GENDER_F50,
 		],
 	}
 
@@ -176,7 +195,7 @@ static func _species() -> Array:
 	for number: int in range(1, MAGCARGO + 1):
 		var entry: Array = known.get(number, [
 			"FILLER", [10, 10, 10, 10, 10, 10], [NORMAL, NORMAL],
-			Gen2Experience.GROWTH_MEDIUM_FAST, 64, [],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 64, [], GENDER_UNKNOWN,
 		])
 		var stats: Array = entry[1]
 		out.append({
@@ -190,6 +209,7 @@ static func _species() -> Array:
 			"types": entry[2],
 			"growth_rate": entry[3],
 			"base_exp": entry[4],
+			"gender_ratio": entry[6],
 			"front_tiles": [7, 7],
 			"palette": {"normal": [0x1234, 0x5678], "shiny": [0x0C63, 0x1084]},
 		})
@@ -259,6 +279,11 @@ static func _moves() -> Array:
 		SUPER_FANG_MOVE: ["SUPER FANG", 1, NORMAL, 255, 10, Gen2MoveEffect.SUPER_FANG, 0],
 		PSYWAVE_MOVE: ["PSYWAVE", 1, PSYCHIC_TYPE, 255, 15, Gen2MoveEffect.PSYWAVE, 0],
 		OHKO_MOVE: ["GUILLOTINE", 0, NORMAL, 76, 5, Gen2MoveEffect.OHKO, 0],
+		DISABLE_MOVE: ["DISABLE", 0, NORMAL, 140, 20, Gen2MoveEffect.DISABLE, 0],
+		ENCORE_MOVE: ["ENCORE", 0, NORMAL, 255, 5, Gen2MoveEffect.ENCORE, 0],
+		ATTRACT_MOVE: ["ATTRACT", 0, NORMAL, 255, 15, Gen2MoveEffect.ATTRACT, 0],
+		MIST_MOVE: ["MIST", 0, NORMAL, 255, 30, Gen2MoveEffect.MIST, 0],
+		FOCUS_ENERGY_MOVE: ["FOCUS ENERGY", 0, NORMAL, 255, 30, Gen2MoveEffect.FOCUS_ENERGY, 0],
 	}
 
 	var out: Array = []

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -233,3 +233,76 @@ func test_opportunist_only_discourages_stall_moves_once_hp_is_low() -> void:
 	Gen2BattleAI._apply_opportunist(scores, pikachu, geodude, _data, _rng, 0, 0)
 	assert_eq(scores[0], 21)
 	assert_eq(scores[1], 20, "Tackle is not a stall move and is left alone")
+
+
+func test_basic_discourages_disable_against_an_already_disabled_target() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.DISABLE_MOVE, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.disabled_slot = 0
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
+		)
+		assert_eq(slot, 1, "disabling an already-disabled target does nothing on the cartridge")
+
+
+func test_basic_discourages_encore_against_an_already_encored_target() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.ENCORE_MOVE, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.encored_slot = 0
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
+		)
+		assert_eq(slot, 1, "encoring an already-encored target does nothing on the cartridge")
+
+
+func test_basic_discourages_attract_between_the_same_gender() -> void:
+	# Same DVs on the same species read the same gender, so Attract can never
+	# land between them.
+	var attacker: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE, Fixture.TACKLE],
+		Gen2Stats.pack_dvs(0, 0, 0, 0)
+	)
+	var defender: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE], Gen2Stats.pack_dvs(0, 0, 0, 0)
+	)
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(attacker, defender, _data, RomLayout.AI_BASIC, _rng)
+		assert_eq(slot, 1, "the same gender can never fall for Attract")
+
+
+func test_basic_discourages_attract_against_a_genderless_target() -> void:
+	var attacker: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE, Fixture.TACKLE]
+	)
+	# Species 6 is not named in the fixture, so it reads genderless.
+	var defender: Gen2BattleMon = Gen2BattleMon.create(_data, 6, 50, [Fixture.TACKLE])
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(attacker, defender, _data, RomLayout.AI_BASIC, _rng)
+		assert_eq(slot, 1, "a genderless target can never fall for Attract")
+
+
+func test_basic_discourages_mist_and_focus_energy_used_a_second_time() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MIST_MOVE, Fixture.TACKLE])
+	pikachu.substatus |= Gen2Substatus.MIST
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
+		)
+		assert_eq(slot, 1, "a second Mist fails without re-applying")
+
+	var pikachu2: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.FOCUS_ENERGY_MOVE, Fixture.TACKLE])
+	pikachu2.substatus |= Gen2Substatus.FOCUS_ENERGY
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu2, geodude, _data, RomLayout.AI_BASIC, _rng
+		)
+		assert_eq(slot, 1, "a second Focus Energy fails without re-applying")

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1002,3 +1002,187 @@ func test_declining_the_offered_move_keeps_the_four_already_known() -> void:
 	assert_eq(events[0]["move"], Fixture.SLASH)
 	assert_eq(battle.player.moves, before)
 	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
+
+
+func _used_move_by(events: Array, side: int) -> Dictionary:
+	for event: Dictionary in events:
+		if event["type"] == Gen2Battle.USED_MOVE and int(event["side"]) == side:
+			return event
+	return {}
+
+
+## Pikachu is faster than Geodude, so Encore lands before Geodude has acted
+## this same turn. The real cartridge's own `CheckOpponentWentFirst` forces an
+## already-chosen action over for the turn it lands on top of the ones after
+## it; this engine gets the same thing by not committing to a move until
+## [method Gen2Battle._act] actually reaches it, so Geodude's own request for
+## Slash is overridden back to Tackle in the very turn Encore lands, not only
+## the turns after.
+func test_encore_forces_the_targets_last_move_even_the_turn_it_lands() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.ENCORE_MOVE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE, Fixture.SLASH])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.last_move_used, Fixture.TACKLE)
+
+	var events: Array = battle.take_turn(1, 1)
+	assert_eq(battle.enemy.encored_slot, 0)
+	assert_eq(
+		int(_used_move_by(events, Gen2Battle.ENEMY)["move"]), Fixture.TACKLE,
+		"forced back to Tackle despite asking for Slash"
+	)
+
+
+func test_encore_keeps_forcing_the_locked_slot_on_a_later_turn_too() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE, Fixture.SLASH])
+	)
+	battle.enemy.encored_slot = 0
+	battle.enemy.encore_turns = 5
+
+	var events: Array = battle.take_turn(0, 1)
+	assert_eq(
+		int(_used_move_by(events, Gen2Battle.ENEMY)["move"]), Fixture.TACKLE,
+		"still locked, whatever slot is asked for"
+	)
+
+
+func test_encore_ends_when_its_own_counter_runs_out() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE, Fixture.SLASH])
+	)
+	battle.enemy.encored_slot = 0
+	battle.enemy.encore_turns = 1
+
+	var events: Array = battle.take_turn(0, 1)
+	assert_eq(
+		int(_used_move_by(events, Gen2Battle.ENEMY)["move"]), Fixture.TACKLE,
+		"still forced for the turn the counter reaches zero on"
+	)
+	assert_eq(battle.enemy.encored_slot, -1)
+	assert_eq(battle.enemy.encore_turns, 0)
+	assert_false(_first(events, Gen2Battle.ENCORE_ENDED).is_empty())
+
+
+func test_encore_ends_early_once_its_own_move_runs_out_of_pp() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE, Fixture.SLASH])
+	)
+	battle.enemy.encored_slot = 0
+	battle.enemy.encore_turns = 5
+	battle.enemy.pp[0] = 1
+
+	var events: Array = battle.take_turn(0, 1)
+	assert_eq(battle.enemy.pp[0], 0)
+	assert_eq(battle.enemy.encored_slot, -1, "ran out of PP mid-encore, not the counter")
+	assert_false(_first(events, Gen2Battle.ENCORE_ENDED).is_empty())
+
+
+## A regression test for a real bug found while writing this: comparing
+## [member Gen2Turn.slot] against the disabled slot inside
+## [constant Gen2EffectCommands.CHECK_STATUS] fired even when
+## [method Gen2BattleMon.can_use] had already rerouted the request to Struggle,
+## reading an ordinary Struggle turn as a false "cannot move: disabled". The
+## fix compares the move that is actually about to run, by number, instead.
+func test_a_disabled_slot_falls_back_to_struggle_rather_than_a_false_cannot_move() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.THUNDERBOLT]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.disabled_slot = 1
+	battle.player.disable_turns = 3
+
+	var events: Array = battle.take_turn(1, 0)
+	assert_eq(int(_used_move_by(events, Gen2Battle.PLAYER)["move"]), Gen2Damage.STRUGGLE)
+	assert_true(_first(events, Gen2Battle.CANNOT_MOVE).is_empty())
+
+
+func test_disable_wears_off_and_the_slot_becomes_usable_again() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.THUNDERBOLT]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.disabled_slot = 1
+	battle.player.disable_turns = 1
+
+	# Ticks down whichever move is actually used this turn: the countdown is
+	# unconditional, the same as confusion's own counter.
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(battle.player.disabled_slot, -1)
+	assert_eq(battle.player.disable_turns, 0)
+	assert_false(_first(events, Gen2Battle.DISABLE_ENDED).is_empty())
+	assert_true(battle.player.can_use(1))
+
+
+## Pinned against seed 12345, the same fixed seed [method before_each] already
+## sets for every test in this file: a bare coin flip like this one has no
+## accuracy field to guarantee it the way a move's own miss chance does, and
+## [method test_a_confused_pokemon_that_hits_itself_never_lands_its_own_move]
+## already leans on this same seed for the same reason.
+func test_attract_can_stop_a_pokemon_moving_on_the_immobilise_roll() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.substatus |= Gen2Substatus.ATTRACTED
+
+	var events: Array = battle.take_turn(0, 0)
+	var stopped: Dictionary = _first(events, Gen2Battle.CANNOT_MOVE)
+	assert_eq(int(stopped["side"]), Gen2Battle.PLAYER)
+	assert_eq(stopped["reason"], &"attract")
+	assert_true(_used_move_by(events, Gen2Battle.PLAYER).is_empty())
+
+
+func test_switching_out_clears_attract_disable_and_encore() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.player.substatus |= Gen2Substatus.ATTRACTED | Gen2Substatus.DISABLED | Gen2Substatus.ENCORED
+	battle.player.disabled_slot = 0
+	battle.player.disable_turns = 3
+	battle.player.encored_slot = 0
+	battle.player.encore_turns = 3
+	battle.player.last_move_used = Fixture.TACKLE
+
+	var pikachu: Gen2BattleMon = battle.player
+	battle.send_out(Gen2Battle.PLAYER, 1)
+
+	assert_eq(pikachu.substatus, Gen2Substatus.NONE)
+	assert_eq(pikachu.disabled_slot, -1)
+	assert_eq(pikachu.encored_slot, -1)
+	assert_eq(pikachu.last_move_used, 0)
+
+
+## The statistical confirmation that Focus Energy actually raises the rate
+## lives in test_damage.gd, against [method Gen2Damage.critical_level] directly;
+## this is only the wiring, that a real turn's own damage calc reads the flag
+## at all rather than the argument sitting unused.
+## Seed 12, pinned by search rather than assumed, is one where the same first
+## roll misses Tackle's own critical chance at the base rate and lands it at
+## the rate Focus Energy raises it to: the same draw read two different ways,
+## which is a direct proof the flag reaches the roll rather than a statistical
+## one over many turns.
+func test_focus_energy_reaches_the_damage_calc_of_a_real_turn() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.rng.seed = 12
+	var without_boost: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), []
+	)
+	Gen2EffectCommands.run(Gen2EffectCommands.DAMAGE_CALC, without_boost)
+	assert_false(without_boost.critical, "the base rate misses this particular roll")
+
+	battle.rng.seed = 12
+	battle.player.substatus |= Gen2Substatus.FOCUS_ENERGY
+	var with_boost: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), []
+	)
+	Gen2EffectCommands.run(Gen2EffectCommands.DAMAGE_CALC, with_boost)
+	assert_true(with_boost.critical, "the same roll lands once Focus Energy raises the rate")

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -153,6 +153,11 @@ func test_every_volatile_field_clears() -> void:
 	mon.confusion_turns = 3
 	mon.charged_move = Fixture.TACKLE
 	mon.toxic_counter = 2
+	mon.disabled_slot = 1
+	mon.disable_turns = 4
+	mon.encored_slot = 2
+	mon.encore_turns = 3
+	mon.last_move_used = Fixture.TACKLE
 
 	mon.reset_volatile()
 
@@ -160,6 +165,43 @@ func test_every_volatile_field_clears() -> void:
 	assert_eq(mon.confusion_turns, 0)
 	assert_eq(mon.charged_move, 0)
 	assert_eq(mon.toxic_counter, 0)
+	assert_eq(mon.disabled_slot, -1)
+	assert_eq(mon.disable_turns, 0)
+	assert_eq(mon.encored_slot, -1)
+	assert_eq(mon.encore_turns, 0)
+	assert_eq(mon.last_move_used, 0)
+
+
+## Attract's own "opposite gender" rule reads [method Gen2BattleMon.gender],
+## which the cartridge's own `GetGender` works out from the species' gender
+## ratio and the Attack and Speed DVs combined into one byte, not from a coin
+## flip. Bulbasaur is really 12.5% female (ratio 31); Pikachu is really an even
+## 50/50 (ratio 127), which is what makes it the one to check the exact
+## boundary on, since a combined value equal to the ratio reads female rather
+## than male.
+func test_gender_reads_the_combined_dv_byte_against_the_species_ratio() -> void:
+	var mostly_male := func(attack: int, speed: int) -> Gen2BattleMon:
+		var dvs: int = Gen2Stats.pack_dvs(attack, 0, speed, 0)
+		return Gen2BattleMon.create(_data, Fixture.BULBASAUR, 50, [], dvs)
+
+	assert_eq(mostly_male.call(0, 0).gender(), &"male")
+	assert_eq(mostly_male.call(15, 15).gender(), &"female")
+
+	var even_odds := func(attack: int, speed: int) -> Gen2BattleMon:
+		var dvs: int = Gen2Stats.pack_dvs(attack, 0, speed, 0)
+		return Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [], dvs)
+
+	# 126 is one under Pikachu's own ratio of 127; 127 is the ratio itself, and
+	# the cartridge reads a value equal to the ratio as female, not male.
+	assert_eq(even_odds.call(7, 14).gender(), &"male")
+	assert_eq(even_odds.call(7, 15).gender(), &"female")
+
+
+func test_gender_is_none_for_a_genderless_species() -> void:
+	# Every species this fixture does not name outright reads a gender ratio of
+	# 255, the cartridge's own "genderless" marker.
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, 6, 50)
+	assert_eq(mon.gender(), &"genderless")
 
 
 func test_a_pokemon_is_created_already_on_its_curve_not_at_zero() -> void:

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -220,14 +220,21 @@ func test_an_ordinary_move_spends_its_slot() -> void:
 	assert_eq(int(battle.player.pp[0]), before - 1)
 
 
-func test_recoil_is_a_quarter_of_what_was_dealt_and_never_nothing() -> void:
+## A quarter of [member Gen2Turn.damage], the number the formula calculated,
+## never [member Gen2Turn.dealt], the number that actually came off a target
+## with less left than that: the real cartridge's own recoil reads the same
+## uncapped figure drain does. A target with 3 HP left against a hit worth 20
+## costs the attacker a quarter of 20, not a quarter of 3.
+func test_recoil_is_a_quarter_of_what_the_formula_calculated_and_never_nothing() -> void:
 	var battle: Gen2Battle = _battle()
 	var turn: Gen2Turn = _turn(battle)
-	turn.dealt = 20
+	turn.damage = 20
+	turn.dealt = 3
 	Gen2EffectCommands.run(Gen2EffectCommands.RECOIL, turn)
 	assert_eq(int(_first(turn.events, Gen2Battle.RECOIL)["amount"]), 5)
 
 	var second: Gen2Turn = _turn(battle)
+	second.damage = 2
 	second.dealt = 2
 	Gen2EffectCommands.run(Gen2EffectCommands.RECOIL, second)
 	assert_eq(int(_first(second.events, Gen2Battle.RECOIL)["amount"]), 1)
@@ -707,6 +714,219 @@ func test_ohko_faints_the_target_outright_when_it_connects() -> void:
 	assert_eq(battle.enemy.hp, 0)
 	assert_eq(int(_first(turn.events, Gen2Battle.OHKO)["amount"]), battle.enemy.max_hp())
 	assert_eq(_first(turn.events, Gen2Battle.FAINTED)["side"], Gen2Battle.ENEMY)
+
+
+func test_disable_attract_encore_mist_and_focus_energy_have_their_own_sequences() -> void:
+	for effect: int in [
+		Gen2MoveEffect.DISABLE, Gen2MoveEffect.ATTRACT, Gen2MoveEffect.ENCORE,
+		Gen2MoveEffect.MIST, Gen2MoveEffect.FOCUS_ENERGY,
+	]:
+		assert_true(Gen2MoveEffect.is_written(effect))
+
+
+func test_disable_locks_the_targets_own_last_move() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.TACKLE
+	var turn: Gen2Turn = _turn(battle, Fixture.DISABLE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.DISABLE, turn)
+	assert_eq(battle.enemy.disabled_slot, 0)
+	assert_between(battle.enemy.disable_turns, Gen2Substatus.MIN_DISABLE, Gen2Substatus.MAX_DISABLE)
+	assert_eq(int(_first(turn.events, Gen2Battle.DISABLE_INFLICTED)["slot"]), 0)
+
+
+func test_disable_fails_against_a_target_that_has_not_moved_yet() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _turn(battle, Fixture.DISABLE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.DISABLE, turn)
+	assert_eq(battle.enemy.disabled_slot, -1)
+	assert_false(_first(turn.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+func test_disable_fails_against_struggle() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.STRUGGLE
+	var turn: Gen2Turn = _turn(battle, Fixture.DISABLE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.DISABLE, turn)
+	assert_eq(battle.enemy.disabled_slot, -1)
+
+
+func test_disable_fails_against_an_already_disabled_target() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.TACKLE
+	battle.enemy.disabled_slot = 0
+	battle.enemy.disable_turns = 3
+	var turn: Gen2Turn = _turn(battle, Fixture.DISABLE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.DISABLE, turn)
+	assert_eq(battle.enemy.disable_turns, 3, "unchanged, not re-rolled")
+	assert_false(_first(turn.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+func test_disable_fails_against_a_move_already_out_of_pp() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.TACKLE
+	battle.enemy.pp[0] = 0
+	var turn: Gen2Turn = _turn(battle, Fixture.DISABLE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.DISABLE, turn)
+	assert_eq(battle.enemy.disabled_slot, -1)
+
+
+func test_a_disabled_slot_cannot_be_used() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.THUNDERBOLT]
+	)
+	mon.disabled_slot = 0
+	assert_false(mon.can_use(0))
+	assert_true(mon.can_use(1))
+
+
+func test_encore_locks_the_targets_own_last_move() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.TACKLE
+	var turn: Gen2Turn = _turn(battle, Fixture.ENCORE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ENCORE, turn)
+	assert_eq(battle.enemy.encored_slot, 0)
+	assert_between(battle.enemy.encore_turns, Gen2Substatus.MIN_ENCORE, Gen2Substatus.MAX_ENCORE)
+	assert_eq(int(_first(turn.events, Gen2Battle.ENCORE_INFLICTED)["slot"]), 0)
+
+
+## 227 and 119 are Encore's and Mirror Move's own real move numbers, not this
+## fixture's arbitrary ones: the exclusion the cartridge writes is by move
+## number, checked before this project's own move list is ever searched, so
+## the numbers matter here and the fixture's own [constant Fixture.ENCORE_MOVE]
+## would not exercise it.
+func test_encore_refuses_struggle_encore_itself_and_mirror_move() -> void:
+	for excluded: int in [Fixture.STRUGGLE, 227, 119]:
+		var battle: Gen2Battle = _battle()
+		battle.enemy.last_move_used = excluded
+		var turn: Gen2Turn = _turn(battle, Fixture.ENCORE_MOVE)
+		Gen2EffectCommands.run(Gen2EffectCommands.ENCORE, turn)
+		assert_eq(battle.enemy.encored_slot, -1)
+
+
+func test_encore_fails_against_an_already_encored_target() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.TACKLE
+	battle.enemy.encored_slot = 0
+	battle.enemy.encore_turns = 4
+	var turn: Gen2Turn = _turn(battle, Fixture.ENCORE_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ENCORE, turn)
+	assert_eq(battle.enemy.encore_turns, 4, "unchanged, not re-rolled")
+
+
+func test_attract_succeeds_between_opposite_genders() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(
+			_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE], Gen2Stats.pack_dvs(0, 0, 0, 0)
+		),
+		Gen2BattleMon.create(
+			_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE], Gen2Stats.pack_dvs(15, 0, 15, 0)
+		),
+		_rng
+	)
+	var turn: Gen2Turn = _turn(battle, Fixture.ATTRACT_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTRACT, turn)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED))
+	assert_false(_first(turn.events, Gen2Battle.ATTRACT_INFLICTED).is_empty())
+
+
+func test_attract_fails_between_the_same_gender() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(
+			_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE], Gen2Stats.pack_dvs(0, 0, 0, 0)
+		),
+		Gen2BattleMon.create(
+			_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE], Gen2Stats.pack_dvs(0, 0, 0, 0)
+		),
+		_rng
+	)
+	var turn: Gen2Turn = _turn(battle, Fixture.ATTRACT_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTRACT, turn)
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED))
+	assert_false(_first(turn.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+func test_attract_fails_against_a_genderless_target() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE]),
+		Gen2BattleMon.create(_data, 6, 50, [Fixture.TACKLE]),
+		_rng
+	)
+	var turn: Gen2Turn = _turn(battle, Fixture.ATTRACT_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTRACT, turn)
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED))
+
+
+func test_attract_fails_against_an_already_smitten_target() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(
+			_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE], Gen2Stats.pack_dvs(0, 0, 0, 0)
+		),
+		Gen2BattleMon.create(
+			_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE], Gen2Stats.pack_dvs(15, 0, 15, 0)
+		),
+		_rng
+	)
+	battle.enemy.substatus |= Gen2Substatus.ATTRACTED
+	var turn: Gen2Turn = _turn(battle, Fixture.ATTRACT_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTRACT, turn)
+	assert_false(_first(turn.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+func test_mist_sets_the_flag_and_fails_on_a_second_use() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _turn(battle, Fixture.MIST_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.MIST, turn)
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.MIST))
+	assert_false(_first(turn.events, Gen2Battle.MIST_SET).is_empty())
+
+	var second: Gen2Turn = _turn(battle, Fixture.MIST_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.MIST, second)
+	assert_false(_first(second.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+func test_focus_energy_sets_the_flag_and_fails_on_a_second_use() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _turn(battle, Fixture.FOCUS_ENERGY_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.FOCUS_ENERGY, turn)
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.FOCUS_ENERGY))
+	assert_false(_first(turn.events, Gen2Battle.FOCUS_ENERGY_SET).is_empty())
+
+	var second: Gen2Turn = _turn(battle, Fixture.FOCUS_ENERGY_MOVE)
+	Gen2EffectCommands.run(Gen2EffectCommands.FOCUS_ENERGY, second)
+	assert_false(_first(second.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+func test_mist_blocks_a_drop_aimed_at_its_own_side() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.MIST
+	var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTACK_DOWN, turn)
+	assert_false(turn.stat_moved)
+	assert_true(turn.stat_mist_blocked)
+	assert_eq(battle.enemy.stage("attack"), 0)
+
+
+func test_mist_never_blocks_the_users_own_rise() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.MIST
+	var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTACK_UP, turn)
+	assert_true(turn.stat_moved)
+	assert_eq(battle.player.stage("attack"), 1)
+
+
+func test_mist_protected_gets_its_own_message_not_the_generic_fail() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.MIST
+	var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
+	Gen2EffectCommands.run(Gen2EffectCommands.ATTACK_DOWN, turn)
+	Gen2EffectCommands.run(Gen2EffectCommands.STAT_DOWN_FAIL_TEXT, turn)
+	assert_false(_first(turn.events, Gen2Battle.MIST_PROTECTED).is_empty())
+	assert_true(_first(turn.events, Gen2Battle.STAT_CHANGE_FAILED).is_empty())
 
 
 func _of_type(events: Array, type: StringName) -> Array:


### PR DESCRIPTION
These are the first move effects that need state outliving the move itself: which of a target's own move slots is locked, whether a target's gender rules out being attracted, whether the user has already used Mist or Focus Energy once. Disable and Encore search a target's own last-used move rather than letting the attacker name a slot, the same rule the cartridge itself follows; Encore forces the locked move through the same move_for/charged_move extension point a two-turn move's release turn already used, so its own same-turn forcing (the cartridge's CheckOpponentWentFirst) falls out for free rather than needing a mechanism of its own. Mist and Focus Energy needed nothing new at all: a flag on the substatus byte, read where the drop already happens and where the critical already rolls.

Also fixes a real divergence found while researching this: recoil was reading the capped damage a target actually had left rather than the uncapped figure the formula calculated, which drain already read correctly.

Every effect byte and rule is read directly off the real cartridges and pokecrystal's own disassembly rather than assumed, and cross-checked against Gold, Silver and Crystal.