### PR TITLE
Implement Counter, Selfdestruct, and Fly/Dig effects

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -177,8 +177,8 @@ engine cannot play out yet cannot be tested against a real cartridge's choice
 either, so it falls to the generic layers alone, the same falling-back
 discipline the move table itself uses. See `HANDOFF.md`'s "Deliberate" section
 for what else the AI does not cover (a trainer's switch and item decisions,
-Razor Wind/Solar Beam/Fly's own handlers, which read weather and a
-semi-invulnerability substatus nothing here tracks).
+Razor Wind/Solar Beam/Fly's own handlers, which read weather and move-specific
+setup state).
 
 `Gen2Experience.total_exp_at` is the six growth curves as `CalcExpAtLevel`'s own
 formula, `exp(n) = floor(a*n^3/b) + c*n^2 + d*n - e`, pinned against

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -82,10 +82,9 @@ const RESIDUAL_MOVE_NUMBERS: Array = [54, 73, 77, 78, 86, 116, 117, 139, 144, 16
 ## [code]HANDOFF.md[/code] for what pret's own table covers beyond this.
 ##
 ## Razor Wind, Solar Beam and Fly's own handlers are deliberately absent: all
-## three read either the weather or a semi-invulnerability substatus this
-## engine does not track yet, and a handler that always reads "not weather"
-## or "not invulnerable" is not a simplification, it is a handler that never
-## fires.
+## three read weather or move-specific setup state that is not part of the
+## generic scoring layers. The battle now tracks Fly and Dig's flags, but that
+## is not enough to reproduce the AI handler's full weather and setup checks.
 
 
 ## Picks a move slot for [param attacker] to use against [param defender], the

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -192,6 +192,12 @@ var parties: Dictionary = {}
 ## tracked the same way rather than leaving one of them a special case.
 var _participants: Dictionary = {PLAYER: {}, ENEMY: {}}
 
+## The last direct damage each side took during the current pair of actions.
+## Counter and Mirror Coat read this after the faster side has acted. It is
+## cleared at the start of every action pair, because the cartridge's own
+## `wCurDamage` is a move-local value rather than a battle-long history.
+var _last_damage_taken: Dictionary = {PLAYER: {}, ENEMY: {}}
+
 ## Moves waiting on [method learn_move] or [method decline_move], one queue per
 ## side, FIFO: a level that teaches two moves into a full six-move team asks
 ## about both, one at a time, in the order they were learned.
@@ -263,6 +269,31 @@ func mon(side: int) -> Gen2BattleMon:
 
 func opponent_of(side: int) -> int:
 	return ENEMY if side == PLAYER else PLAYER
+
+
+## Clears the damage that Counter and Mirror Coat are allowed to remember.
+## Residual damage is deliberately not recorded: the cartridge's counter move
+## reads the damage produced by the opponent's move, not end-of-turn status loss.
+func reset_damage_taken() -> void:
+	_last_damage_taken = {PLAYER: {}, ENEMY: {}}
+
+
+## Keeps the uncapped damage figure, the move that produced it and its source
+## side. The command layer calls this before HP clamping, matching the
+## cartridge's `wCurDamage` rather than the amount that happened to remain.
+func record_damage_taken(target: int, source: int, move_number: int, effect: int, amount: int) -> void:
+	if amount <= 0 or target not in [PLAYER, ENEMY] or source not in [PLAYER, ENEMY]:
+		return
+	_last_damage_taken[target] = {
+		"damage": amount,
+		"source": source,
+		"move": move_number,
+		"effect": effect,
+	}
+
+
+func last_damage_taken(side: int) -> Dictionary:
+	return _last_damage_taken.get(side, {})
 
 
 ## A battle is lost when a whole party is down, not when the Pokémon that is out
@@ -403,6 +434,7 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	var events: Array = []
 	if is_over() or awaiting_replacement() or awaiting_move_learn():
 		return events
+	reset_damage_taken()
 
 	var actions: Dictionary = {PLAYER: player_action, ENEMY: enemy_action}
 	var chosen: Dictionary = {

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -62,11 +62,12 @@ static func calculate(
 	defender: Gen2BattleMon,
 	move: Dictionary,
 	rng: RandomNumberGenerator,
-	focus_energy: bool = false
+	focus_energy: bool = false,
+	defense_halved: bool = false
 ) -> Dictionary:
 	return calculate_with(
 		attacker, defender, move,
-		roll_critical(move, rng, focus_energy), roll_variation(rng)
+		roll_critical(move, rng, focus_energy), roll_variation(rng), defense_halved
 	)
 
 
@@ -82,7 +83,8 @@ static func calculate_with(
 	defender: Gen2BattleMon,
 	move: Dictionary,
 	critical: bool,
-	variation: int
+	variation: int,
+	defense_halved: bool = false
 ) -> Dictionary:
 	var out: Dictionary = {
 		"damage": 0, "critical": critical, "effectiveness": RomLayout.MATCHUP_EFFECTIVE,
@@ -111,9 +113,12 @@ static func calculate_with(
 				break
 		return out
 
+	var defense: int = _defense_stat(attacker, defender, move_type, critical)
+	if defense_halved:
+		@warning_ignore("integer_division")
+		defense = maxi(defense / 2, 1)
 	var damage: int = base_damage(
-		attacker.level, power, _attack_stat(attacker, defender, move_type, critical),
-		_defense_stat(attacker, defender, move_type, critical)
+		attacker.level, power, _attack_stat(attacker, defender, move_type, critical), defense
 	)
 	if critical:
 		damage *= CRITICAL_MULTIPLIER

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -37,6 +37,16 @@ const CHECK_IMMUNE: StringName = &"checkimmune"
 ## Rolls whether the move connects, and ends it if it does not.
 const CHECK_HIT: StringName = &"checkhit"
 
+## Counter and Mirror Coat do not roll their own accuracy. They validate the
+## move that just hit the user, then leave the doubled damage for APPLY_DAMAGE.
+const COUNTER: StringName = &"counter"
+const MIRROR_COAT: StringName = &"mirrorcoat"
+
+## Selfdestruct and Explosion faint their user after the hit check, even when
+## the hit missed or was immune. The damage step still runs first so effect byte
+## 7 can halve the defender's Defense in the ordinary formula.
+const SELFDESTRUCT: StringName = &"selfdestruct"
+
 ## Takes the damage off, and reports what was actually taken.
 const APPLY_DAMAGE: StringName = &"applydamage"
 
@@ -285,6 +295,12 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_check_immune(turn)
 		CHECK_HIT:
 			_check_hit(turn)
+		COUNTER:
+			_counter(turn, false)
+		MIRROR_COAT:
+			_counter(turn, true)
+		SELFDESTRUCT:
+			_selfdestruct(turn)
 		APPLY_DAMAGE:
 			_apply_damage(turn)
 		RECOIL:
@@ -382,12 +398,15 @@ static func _do_turn(turn: Gen2Turn) -> void:
 static func _damage_calc(turn: Gen2Turn) -> void:
 	var result: Dictionary = Gen2Damage.calculate(
 		turn.attacker(), turn.defender(), turn.move, turn.rng(),
-		Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.FOCUS_ENERGY)
+		Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.FOCUS_ENERGY),
+		turn.effect() == Gen2MoveEffect.SELFDESTRUCT
 	)
 	turn.damage = int(result["damage"])
 	turn.critical = bool(result["critical"])
 	turn.effectiveness = int(result["effectiveness"])
 	turn.immune = bool(result["immune"])
+	if _doubles_flying_damage(turn) or _doubles_underground_damage(turn):
+		turn.damage = mini(turn.damage * 2, 0xFFFF)
 
 
 static func _check_immune(turn: Gen2Turn) -> void:
@@ -402,10 +421,27 @@ static func _check_immune(turn: Gen2Turn) -> void:
 ## check, reading as a miss on a target that is not asleep rather than as a
 ## distinct failure.
 static func _check_hit(turn: Gen2Turn) -> void:
+	if turn.immune:
+		turn.missed = true
+		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+		if turn.effect() != Gen2MoveEffect.SELFDESTRUCT:
+			turn.end()
+		return
+
+	if _is_hidden(turn.defender().substatus) \
+		and not _can_hit_hidden(turn.move_number, turn.defender().substatus):
+		turn.missed = true
+		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
+		if turn.effect() != Gen2MoveEffect.SELFDESTRUCT:
+			turn.end()
+		return
+
 	if turn.effect() == Gen2MoveEffect.DREAM_EATER \
 		and not Gen2Status.is_asleep(turn.defender().status):
+		turn.missed = true
 		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
-		turn.end()
+		if turn.effect() != Gen2MoveEffect.SELFDESTRUCT:
+			turn.end()
 		return
 
 	var chance: int = Gen2Accuracy.chance(
@@ -414,12 +450,19 @@ static func _check_hit(turn: Gen2Turn) -> void:
 	)
 	if Gen2Accuracy.rolls_hit(turn.rng(), chance):
 		return
+	turn.missed = true
 	turn.emit(Gen2Battle.MISSED, {"target": turn.target})
-	turn.end()
+	if turn.effect() != Gen2MoveEffect.SELFDESTRUCT:
+		turn.end()
 
 
 static func _apply_damage(turn: Gen2Turn) -> void:
+	if turn.missed or turn.damage <= 0:
+		return
 	var defender: Gen2BattleMon = turn.defender()
+	turn.battle.record_damage_taken(
+		turn.target, turn.side, turn.move_number, turn.effect(), turn.damage
+	)
 	turn.dealt = defender.take_damage(turn.damage)
 	turn.emit(Gen2Battle.HIT, {
 		"target": turn.target,
@@ -429,6 +472,75 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		"hp": defender.hp,
 		"max_hp": defender.max_hp(),
 	})
+
+
+static func _counter(turn: Gen2Turn, mirror_coat: bool) -> void:
+	var remembered: Dictionary = turn.battle.last_damage_taken(turn.side)
+	var expected_effect: int = (
+		Gen2MoveEffect.MIRROR_COAT if mirror_coat else Gen2MoveEffect.COUNTER
+	)
+	var last_move: Dictionary = turn.data().move(int(remembered.get("move", 0)))
+	var valid: bool = not remembered.is_empty() \
+		and int(remembered.get("source", -1)) == turn.target \
+		and int(remembered.get("effect", -1)) != expected_effect \
+		and not last_move.is_empty() \
+		and int(last_move.get("power", 0)) > 0 \
+		and Gen2Damage.is_physical(int(last_move.get("type", RomLayout.TYPE_NORMAL))) != mirror_coat \
+		and int(remembered.get("damage", 0)) > 0
+
+	if valid:
+		var matchup: int = turn.data().type_effectiveness(
+			int(turn.move.get("type", RomLayout.TYPE_NORMAL)), turn.defender().types()
+		)
+		if matchup == RomLayout.MATCHUP_NO_EFFECT:
+			turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+			turn.end()
+			return
+
+		turn.damage = mini(int(remembered["damage"]) * 2, 0xFFFF)
+		turn.critical = false
+		turn.effectiveness = matchup
+		turn.immune = false
+		turn.missed = false
+		return
+
+	turn.emit(Gen2Battle.MOVE_FAILED)
+	turn.end()
+
+
+## Selfdestruct's command clears the user's status and sets its HP to zero.
+## The faint event itself remains in CHECK_FAINT so the target is still reported
+## first when the explosion also brings it down.
+static func _selfdestruct(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	attacker.status = Gen2Status.NONE
+	attacker.substatus &= ~(Gen2Substatus.CHARGING | Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
+	attacker.take_damage(attacker.hp)
+
+
+static func _is_hidden(substatus: int) -> bool:
+	return Gen2Substatus.has(substatus, Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
+
+
+static func _can_hit_hidden(move_number: int, substatus: int) -> bool:
+	if Gen2Substatus.has(substatus, Gen2Substatus.FLYING):
+		return [Gen2MoveEffect.GUST_MOVE, Gen2MoveEffect.WHIRLWIND_MOVE,
+			Gen2MoveEffect.THUNDER_MOVE, Gen2MoveEffect.TWISTER_MOVE].has(move_number)
+	if Gen2Substatus.has(substatus, Gen2Substatus.UNDERGROUND):
+		return [Gen2MoveEffect.EARTHQUAKE_MOVE, Gen2MoveEffect.FISSURE_MOVE,
+			Gen2MoveEffect.MAGNITUDE_MOVE].has(move_number)
+	return false
+
+
+static func _doubles_flying_damage(turn: Gen2Turn) -> bool:
+	return Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.FLYING) \
+		and [Gen2MoveEffect.GUST_MOVE, Gen2MoveEffect.TWISTER_MOVE].has(turn.move_number)
+
+
+static func _doubles_underground_damage(turn: Gen2Turn) -> bool:
+	return Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.UNDERGROUND) \
+		and [Gen2MoveEffect.EARTHQUAKE_MOVE, Gen2MoveEffect.FISSURE_MOVE,
+			Gen2MoveEffect.MAGNITUDE_MOVE].has(turn.move_number)
 
 
 ## A quarter of [member Gen2Turn.damage], the number the formula calculated,
@@ -457,6 +569,14 @@ static func _check_faint(turn: Gen2Turn) -> void:
 			turn.events.append({"type": Gen2Battle.FAINTED, "side": side})
 
 
+## CantMove on the cartridge cancels a pending two-turn move. For Fly and Dig
+## that also makes the user visible again, so a sleep, flinch or paralysis on
+## the release turn cannot leave a Pokémon permanently untouchable.
+static func _cancel_charge(mon: Gen2BattleMon) -> void:
+	mon.substatus &= ~(Gen2Substatus.CHARGING | Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
+	mon.charged_move = 0
+
+
 ## Recharge, then sleep, then freeze, then flinch, then Disable's own
 ## countdown, then confusion, then Attract's immobilise roll, then a
 ## belt-and-suspenders refusal for a Pokémon still locked into the disabled
@@ -480,6 +600,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.RECHARGING):
+		_cancel_charge(mon)
 		mon.substatus &= ~Gen2Substatus.RECHARGING
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"recharge"})
 		turn.end()
@@ -488,6 +609,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 	if Gen2Status.is_asleep(mon.status):
 		mon.status = Gen2Status.tick_sleep(mon.status)
 		if Gen2Status.is_asleep(mon.status):
+			_cancel_charge(mon)
 			turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"sleep"})
 			turn.end()
 			return
@@ -497,6 +619,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 		# Flame Wheel and Sacred Fire are used through a freeze, and thaw the
 		# Pokémon using them; nothing else in the game does.
 		if not THAWING_MOVES.has(turn.move_number):
+			_cancel_charge(mon)
 			turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"freeze"})
 			turn.end()
 			return
@@ -504,6 +627,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 		turn.emit(Gen2Battle.THAWED)
 
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.FLINCHED):
+		_cancel_charge(mon)
 		mon.substatus &= ~Gen2Substatus.FLINCHED
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"flinch"})
 		turn.end()
@@ -525,6 +649,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 		else:
 			turn.emit(Gen2Battle.CONFUSED)
 			if Gen2Substatus.rolls_confusion_hit(turn.rng()):
+				_cancel_charge(mon)
 				var dealt: int = mon.take_damage(Gen2Damage.confusion_damage(mon, turn.rng()))
 				turn.emit(Gen2Battle.HURT_ITSELF, {
 					"amount": dealt, "hp": mon.hp, "max_hp": mon.max_hp(),
@@ -534,6 +659,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.ATTRACTED) \
 		and Gen2Substatus.rolls_attract_immobile(turn.rng()):
+		_cancel_charge(mon)
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"attract"})
 		turn.end()
 		return
@@ -547,12 +673,14 @@ static func _check_status(turn: Gen2Turn) -> void:
 	# happening, so comparing slots here would refuse that Struggle too.
 	if mon.disabled_slot >= 0 and mon.disabled_slot < mon.moves.size() \
 		and turn.move_number == int(mon.moves[mon.disabled_slot]):
+		_cancel_charge(mon)
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"disabled"})
 		turn.end()
 		return
 
 	if Gen2Status.has(mon.status, Gen2Status.PARALYSIS) \
 		and Gen2Status.rolls_full_paralysis(turn.rng()):
+		_cancel_charge(mon)
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"paralysis"})
 		turn.end()
 
@@ -699,6 +827,9 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 			turn.effectiveness = int(result["effectiveness"])
 
 		turn.dealt = defender.take_damage(turn.damage)
+		turn.battle.record_damage_taken(
+			turn.target, turn.side, turn.move_number, turn.effect(), turn.damage
+		)
 		turn.emit(Gen2Battle.HIT, {
 			"target": turn.target, "amount": turn.dealt, "critical": turn.critical,
 			"effectiveness": turn.effectiveness, "hp": defender.hp, "max_hp": defender.max_hp(),
@@ -792,6 +923,9 @@ static func _ohko(turn: Gen2Turn) -> void:
 		turn.end()
 		return
 
+	turn.battle.record_damage_taken(
+		turn.target, turn.side, turn.move_number, turn.effect(), 0xFFFF
+	)
 	var dealt: int = defender.take_damage(defender.hp)
 	turn.emit(Gen2Battle.OHKO, {
 		"target": turn.target, "amount": dealt, "hp": defender.hp, "max_hp": defender.max_hp(),
@@ -818,11 +952,17 @@ static func _charge_move(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING):
 		mon.substatus &= ~Gen2Substatus.CHARGING
+		mon.substatus &= ~(Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
 		mon.charged_move = 0
 		return
 
 	mon.substatus |= Gen2Substatus.CHARGING
 	mon.charged_move = turn.move_number
+	if turn.effect() == Gen2MoveEffect.FLY_OR_DIG:
+		if turn.move_number == Gen2MoveEffect.FLY_MOVE:
+			mon.substatus |= Gen2Substatus.FLYING
+		elif turn.move_number == Gen2MoveEffect.DIG_MOVE:
+			mon.substatus |= Gen2Substatus.UNDERGROUND
 	turn.emit(Gen2Battle.CHARGING_UP)
 	turn.end()
 

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -95,12 +95,29 @@ const RECHARGE_HIT: int = 80
 ## add one thing behind the hit, which is why they keep their own effect byte
 ## rather than folding into the plain one. Fly and Dig share 155 with each
 ## other and nothing else, since both leave the field for their charge turn on
-## the cartridge, which nothing here models yet: see [code]HANDOFF.md[/code].
+## the cartridge. Their shared charge command now carries the two distinct
+## semi-invulnerability flags and the incoming hit check reads them.
 const RAZOR_WIND: int = 39
 const SKY_ATTACK: int = 75
 const SKULL_BASH: int = 145
 const SOLARBEAM: int = 151
 const FLY_OR_DIG: int = 155
+const SELFDESTRUCT: int = 7
+const COUNTER: int = 0x59
+const MIRROR_COAT: int = 0x90
+
+## Real move numbers used by the shared two-turn and semi-invulnerability
+## commands. These are kept here because the cartridge stores Fly and Dig under
+## one effect byte, while the charge command still has to tell them apart.
+const FLY_MOVE: int = 19
+const DIG_MOVE: int = 91
+const GUST_MOVE: int = 16
+const WHIRLWIND_MOVE: int = 18
+const THUNDER_MOVE: int = 9
+const TWISTER_MOVE: int = 239
+const EARTHQUAKE_MOVE: int = 89
+const FISSURE_MOVE: int = 90
+const MAGNITUDE_MOVE: int = 222
 
 ## None of the three needs any state this file has not already grown for
 ## something else: [Gen2BattleMon.reset_stages] for Haze,
@@ -132,6 +149,41 @@ const NORMAL_HIT: Array = [
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Counter and Mirror Coat validate the damage the opponent dealt earlier in
+## this action pair, then apply twice that uncapped figure. Their command owns
+## the failure path, so neither one uses the ordinary accuracy or damage steps.
+const COUNTER_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.COUNTER,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const MIRROR_COAT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.MIRROR_COAT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## The cartridge runs Selfdestruct after the shared hit check and before its
+## failure text and damage application. Keeping that order means the user faints
+## even when the target is immune or the accuracy roll misses.
+const SELFDESTRUCT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.SELFDESTRUCT,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
 	Gen2EffectCommands.END_MOVE,
@@ -550,6 +602,9 @@ static func _sequences() -> Dictionary:
 		FREEZE_HIT: _secondary([Gen2EffectCommands.FREEZE_TARGET]),
 		PARALYZE_HIT: _secondary([Gen2EffectCommands.PARALYZE_TARGET]),
 		RECOIL_HIT: RECOIL_HIT_SEQUENCE,
+		COUNTER: COUNTER_SEQUENCE,
+		MIRROR_COAT: MIRROR_COAT_SEQUENCE,
+		SELFDESTRUCT: SELFDESTRUCT_SEQUENCE,
 		FLINCH_HIT: _secondary([Gen2EffectCommands.FLINCH_TARGET]),
 		CONFUSE_HIT: _secondary([Gen2EffectCommands.CONFUSE_TARGET]),
 		CONFUSE: CONFUSE_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -8,8 +8,8 @@ extends RefCounted
 ## own rule: a Pokémon that is already poisoned cannot also be confused by
 ## refusing a second flag on the same byte. Confusion, flinching, being locked
 ## into a recharge turn or a two-turn move's charge, Disable, Attract, Encore,
-## Mist and Focus Energy are all independent of that and of each other, so they
-## live apart from it.
+## Mist, Focus Energy, flying and underground are all independent of that and
+## of each other, so they live apart from it.
 ##
 ## The cartridge itself keeps these as five separate bytes
 ## (`wPlayerSubStatus1` through `wPlayerSubStatus5`), not one: this project
@@ -39,6 +39,8 @@ const ATTRACTED: int = 1 << 5
 const ENCORED: int = 1 << 6
 const MIST: int = 1 << 7
 const FOCUS_ENERGY: int = 1 << 8
+const FLYING: int = 1 << 9
+const UNDERGROUND: int = 1 << 10
 
 const NONE: int = 0
 

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -34,6 +34,7 @@ var damage: int = 0
 var critical: bool = false
 var effectiveness: int = RomLayout.MATCHUP_EFFECTIVE
 var immune: bool = false
+var missed: bool = false
 
 ## What was actually taken off, which is not the same as [member damage]: a
 ## Pokémon with three hit points left takes three from a hit worth forty.

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -57,6 +57,22 @@ const CONFUSION_NEVER: int = 250
 const SUPERSONIC: int = 251
 const HYPER_BEAM: int = 252
 
+## The three move families this fixture keeps at their real Generation 2 move
+## numbers, so the command layer can exercise the cartridge's number-based
+## exceptions as well as the effect-byte table.
+const COUNTER: int = 68
+const DIG: int = 91
+const SELFDESTRUCT: int = 120
+const EXPLOSION: int = 153
+const FLY: int = 19
+const MIRROR_COAT: int = 243
+const GUST: int = 16
+const THUNDER: int = 9
+const TWISTER: int = 239
+const EARTHQUAKE: int = 89
+const FISSURE: int = 90
+const MAGNITUDE: int = 222
+
 ## Solarbeam for the plain two-turn shape, Skull Bash for the one that raises a
 ## stat behind the hit.
 const SOLARBEAM: int = 253
@@ -107,6 +123,7 @@ const GENDER_F50: int = 127
 const GENDER_UNKNOWN: int = 255
 
 const NORMAL: int = 0x00
+const FIGHTING: int = 0x01
 const GROUND: int = 0x04
 const ROCK: int = 0x05
 const GHOST: int = 0x08
@@ -118,6 +135,8 @@ const ELECTRIC: int = 0x17
 const PSYCHIC_TYPE: int = 0x18
 const POISON: int = 0x03
 const FLYING: int = 0x02
+const DRAGON: int = 0x1A
+const DARK: int = 0x1B
 
 ## Only the matchups the battle tests use, not the whole chart. The chart itself
 ## is the importer's business and is tested there; what matters here is that the
@@ -128,6 +147,7 @@ const MATCHUPS: Array = [
 	[FIRE, GRASS, 20], [FIRE, WATER, 5], [FIRE, FIRE, 5], [FIRE, ROCK, 5],
 	[GRASS, ROCK, 20], [GRASS, GROUND, 20], [GRASS, POISON, 5], [GRASS, GRASS, 5],
 	[NORMAL, ROCK, 5], [NORMAL, STEEL, 5],
+	[FIGHTING, GHOST, 0], [PSYCHIC_TYPE, DARK, 0],
 ]
 
 ## The two the cartridge keeps past the Foresight marker.
@@ -261,6 +281,18 @@ static func _moves() -> Array:
 		# Confusion as the whole of the move, the way Supersonic does it.
 		SUPERSONIC: ["SUPERSONIC", 0, NORMAL, 255, 20, Gen2MoveEffect.CONFUSE, 0],
 		HYPER_BEAM: ["HYPER BEAM", 150, NORMAL, 255, 5, Gen2MoveEffect.RECHARGE_HIT, 0],
+		FLY: ["FLY", 70, FLYING, 242, 15, Gen2MoveEffect.FLY_OR_DIG, 0],
+		DIG: ["DIG", 100, GROUND, 255, 10, Gen2MoveEffect.FLY_OR_DIG, 0],
+		GUST: ["GUST", 40, FLYING, 255, 35, 0, 0],
+		THUNDER: ["THUNDER", 120, ELECTRIC, 179, 10, Gen2MoveEffect.PARALYZE_HIT, 0],
+		TWISTER: ["TWISTER", 40, DRAGON, 255, 20, Gen2MoveEffect.FLINCH_HIT, 0],
+		EARTHQUAKE: ["EARTHQUAKE", 100, GROUND, 255, 10, 0, 0],
+		FISSURE: ["FISSURE", 0, GROUND, 76, 5, Gen2MoveEffect.OHKO, 0],
+		MAGNITUDE: ["MAGNITUDE", 100, GROUND, 255, 30, 0, 0],
+		COUNTER: ["COUNTER", 0, FIGHTING, 255, 20, Gen2MoveEffect.COUNTER, 0],
+		SELFDESTRUCT: ["SELF-DESTRUCT", 200, NORMAL, 255, 5, Gen2MoveEffect.SELFDESTRUCT, 0],
+		EXPLOSION: ["EXPLOSION", 250, NORMAL, 255, 5, Gen2MoveEffect.SELFDESTRUCT, 0],
+		MIRROR_COAT: ["MIRROR COAT", 0, PSYCHIC_TYPE, 255, 20, Gen2MoveEffect.MIRROR_COAT, 0],
 		SOLARBEAM: ["SOLARBEAM", 120, NORMAL, 255, 10, Gen2MoveEffect.SOLARBEAM, 0],
 		SKULL_BASH: ["SKULL BASH", 100, NORMAL, 255, 15, Gen2MoveEffect.SKULL_BASH, 0],
 		TOXIC: ["TOXIC", 0, POISON, 255, 10, Gen2MoveEffect.TOXIC, 0],

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -81,6 +81,28 @@ func test_priority_beats_speed() -> void:
 	assert_eq(Gen2Battle.priority_of({"number": 1, "effect": 0x59}), 0, "Counter")
 
 
+func test_counter_doubles_the_raw_damage_taken_by_the_slower_side() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.COUNTER])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	var hits: Array = _of_type(events, Gen2Battle.HIT)
+	assert_eq(hits.size(), 2)
+	assert_eq(int(hits[1]["amount"]), int(hits[0]["amount"]) * 2)
+
+
+func test_counter_does_not_keep_damage_from_a_previous_action_pair() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL, Fixture.COUNTER])
+	)
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var events: Array = battle.take_actions(Gen2Battle.use_move(1), Gen2Battle.use_move(1))
+	assert_eq(_of_type(events, Gen2Battle.MOVE_FAILED).size(), 1)
+	assert_eq(_of_type(events, Gen2Battle.HIT).size(), 0)
+
+
 func test_vital_throw_says_it_is_last_in_the_move_and_not_in_the_effect() -> void:
 	# The one move the effect table cannot answer for.
 	assert_eq(Gen2Battle.priority_of({"number": Gen2Battle.VITAL_THROW, "effect": 17}), 0)

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -177,3 +177,16 @@ func test_a_move_with_no_power_never_crits() -> void:
 	rng.seed = 1
 	for _try: int in 200:
 		assert_false(Gen2Damage.roll_critical(_data.move(Fixture.GROWL), rng))
+
+
+func test_selfdestruct_halves_defense_before_the_formula() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU)
+	var defender: Gen2BattleMon = _mon(Fixture.BULBASAUR)
+	var move: Dictionary = _data.move(Fixture.SELFDESTRUCT)
+	var ordinary: Dictionary = Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION, false
+	)
+	var halved: Dictionary = Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION, true
+	)
+	assert_gt(int(halved["damage"]), int(ordinary["damage"]))

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -62,6 +62,121 @@ func test_recoil_is_the_ordinary_list_with_a_step_in_it() -> void:
 	)
 
 
+func test_counter_mirror_coat_and_selfdestruct_have_their_cartridge_sequences() -> void:
+	var counter: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.COUNTER)
+	var mirror: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.MIRROR_COAT)
+	var selfdestruct: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.SELFDESTRUCT)
+	assert_true(counter.has(Gen2EffectCommands.COUNTER))
+	assert_true(mirror.has(Gen2EffectCommands.MIRROR_COAT))
+	assert_true(selfdestruct.has(Gen2EffectCommands.SELFDESTRUCT))
+	assert_lt(
+		selfdestruct.find(Gen2EffectCommands.SELFDESTRUCT),
+		selfdestruct.find(Gen2EffectCommands.APPLY_DAMAGE)
+	)
+
+
+func test_counter_only_reflects_a_physical_move_that_hit_this_action_pair() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.THUNDERBOLT]),
+		Gen2BattleMon.create(_data, Fixture.BULBASAUR, 50, [Fixture.COUNTER]),
+		_rng
+	)
+	var events: Array = battle.take_turn(0, 0)
+	var hits: Array = _of_type(events, Gen2Battle.HIT)
+	assert_eq(hits.size(), 1, "the special-category check rejects Counter")
+	assert_eq(_of_type(events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+func test_mirror_coat_only_reflects_a_special_move_that_hit_this_action_pair() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.THUNDERBOLT]),
+		Gen2BattleMon.create(_data, Fixture.BULBASAUR, 50, [Fixture.MIRROR_COAT]),
+		_rng
+	)
+	var events: Array = battle.take_turn(0, 0)
+	var hits: Array = _of_type(events, Gen2Battle.HIT)
+	assert_eq(hits.size(), 2)
+	assert_eq(int(hits[1]["amount"]), int(hits[0]["amount"]) * 2)
+
+
+func test_selfdestruct_faints_the_user_after_dealing_its_damage() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.moves = [Fixture.SELFDESTRUCT]
+	battle.player.pp = [5]
+	var before: int = battle.enemy.hp
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(battle.player.hp, 0)
+	assert_lt(battle.enemy.hp, before)
+	assert_eq(_of_type(events, Gen2Battle.FAINTED).size(), 1)
+	assert_eq(int(_first(events, Gen2Battle.FAINTED)["side"]), Gen2Battle.PLAYER)
+
+
+func test_selfdestruct_still_faints_the_user_when_accuracy_fails() -> void:
+	var battle: Gen2Battle = _battle()
+	var move: Dictionary = _data.move(Fixture.SELFDESTRUCT).duplicate()
+	move["accuracy"] = 0
+	var turn: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, Fixture.SELFDESTRUCT, move, []
+	)
+	for command: StringName in Gen2MoveEffect.SELFDESTRUCT_SEQUENCE:
+		if turn.ended:
+			break
+		Gen2EffectCommands.run(command, turn)
+	assert_eq(battle.player.hp, 0)
+	assert_eq(_of_type(turn.events, Gen2Battle.MISSED).size(), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 0)
+	assert_eq(_of_type(turn.events, Gen2Battle.FAINTED).size(), 1)
+
+
+func test_fly_makes_the_user_untouchable_until_its_release_turn() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.FLY]),
+		Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_rng
+	)
+	var first: Array = battle.take_turn(0, 0)
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.FLYING))
+	assert_eq(battle.player.hp, battle.player.max_hp())
+	assert_eq(_of_type(first, Gen2Battle.MISSED).size(), 1)
+	assert_eq(_of_type(first, Gen2Battle.MISSED)[0]["side"], Gen2Battle.ENEMY)
+
+	var second: Array = battle.take_turn(0, 0)
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.FLYING))
+	assert_gt(_of_type(second, Gen2Battle.HIT).size(), 0)
+
+
+func test_a_status_that_stops_fly_on_release_makes_the_user_visible_again() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.FLY]),
+		Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_rng
+	)
+	battle.take_turn(0, 0)
+	battle.player.substatus |= Gen2Substatus.FLINCHED
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.CANNOT_MOVE).size(), 1)
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.FLYING))
+	assert_eq(battle.player.charged_move, 0)
+
+
+func test_dig_uses_underground_and_earthquake_can_hit_it() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.DIG]),
+		Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.EARTHQUAKE]),
+		_rng
+	)
+	var first: Array = battle.take_turn(0, 0)
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.UNDERGROUND))
+	assert_eq(_of_type(first, Gen2Battle.HIT).filter(
+		func(event: Dictionary) -> bool: return int(event["side"]) == Gen2Battle.ENEMY
+	).size(), 1)
+
+
 func test_the_stat_runs_land_on_the_right_stat() -> void:
 	# Effect 20 is the down-by-one run's third stop (18 + 2) and String Shot is
 	# published as lowering Speed; effect 72 is the down-on-hit run's fifth stop


### PR DESCRIPTION
Add cartridge-shaped Counter and Mirror Coat damage memory, Selfdestruct and Explosion Defense halving, and Fly/Dig semi-invulnerability.

Cover category validation, raw damage tracking, hit exceptions, charge cancellation, fixture moves, regression tests, and battle documentation. Leave the launcher untouched and point the handoff to Rollout and the Thrash family next.