### PR TITLE
Build save slot and party flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ the same thing for Generation 1.
 > and Explosion's own halved Defense, and Fly and Dig's semi-invulnerability
 > now have their own battle sequences as well, alongside Rollout, Defense Curl
 > and the Thrash family. The launcher lists the three supported cartridges,
-> shows which caches are ready, imports a verified dump through the UI and can
-> open the development battle against the selected cache. The development
-> battle now creates and reloads a validated save slot with a persistent player
-> party. The real new-game flow, overworld, audio and mod loader do not exist
-> yet. There is no complete game here today.
+> shows which caches are ready, imports a verified dump through the UI and opens
+> the selected cache's save screen. The save screen creates and validates a new
+> game, imports stable player and party fields from an original `.sav`, shows
+> persistent HP and status, and opens the selected party in the development
+> battle. The overworld, audio and mod loader do not exist yet. There is no
+> complete game here today.
 
 ## Getting started
 
@@ -152,9 +153,10 @@ Boots the main scene for 30 frames and exits, as a quick smoke check.
 
 The normal main scene is now the launcher. It shows the imported-cache status
 for Gold, Silver and Crystal, accepts a user-selected ROM through `Import ROM`,
-and opens the development battle for an imported game. The first development
-save slot is created under Godot's `user://` directory when the battle opens,
-then the validated player party is loaded back into the battle.
+and opens the save screen for an imported game. The save screen offers three
+validated project slots, new-game creation with Chikorita, Cyndaquil or
+Totodile, original `.sav` import, party inspection and the development battle.
+The selected party is written back to the same validated slot after a battle.
 
 The current save contract and the boundary between project saves and original
 cartridge SRAM are documented in [docs/SAVES.md](docs/SAVES.md).
@@ -194,7 +196,7 @@ yet; the enemy does too when what is on screen is `show_matchup`'s invented
 pairing, but fights with the cartridge's own trainer AI, scored by that
 trainer class's own AI flags, once `show_trainer(trainer_class)` is called on
 the scene to fight one of the cartridge's own trainers instead, Falkner among
-them. The launcher path loads the player's party from save slot 1, while
+them. The launcher path loads the player's party from the selected save slot, while
 directly opening the development scene still uses its fallback matchup.
 
 ## Tests

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -23,6 +23,29 @@ The format is versioned and validated against the selected `GameData` before a
 slot is accepted. The current implementation provides three slots per game
 revision and stores them as JSON under `user://save_slots`.
 
+## Player-facing flow
+
+The launcher selects an imported cartridge cache, then opens
+`game/save/save_screen.tscn`. The screen presents the three slots as `EMPTY`,
+`READY` or `INCOMPATIBLE`, and keeps the selected slot explicit while it creates
+a new game or imports an original `.sav`. A failed import is rejected before
+`Gen2SaveStore.save` is called, so it cannot replace an existing slot with
+partial data.
+
+New games require a player name of up to ten encoded characters and use the
+three starters from the real Johto opening sequence: Chikorita, Cyndaquil or
+Totodile at level 5, each holding Berry. Their starting moves come from the
+imported learnset. `game/save/party_screen.tscn` displays all six party
+positions, current and derived maximum HP, and persistent status. It starts the
+development battle only after selecting the same validated slot in
+`GameRuntime`.
+
+The development battle writes back through `Gen2SaveBattleAdapter` after the
+pending event messages have finished. It preserves player name, Pokémon
+identity, held item, happiness, Pokerus, caught data, nickname, original
+trainer, HP, status, experience, DVs, stat experience, moves and PP while still
+discarding volatile battle state.
+
 ## Original Generation 2 shape
 
 The canonical model follows the stable fields in the original Crystal source.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -87,6 +87,7 @@ var _pending: Array = []
 var _rng := RandomNumberGenerator.new()
 var _save_slot: int = -1
 var _save_written: bool = false
+var _source_save: Gen2SaveData = null
 
 ## The trainer class behind the enemy's own moves, or zero for
 ## [method show_matchup]'s invented pairing, which has no class and so no AI
@@ -166,6 +167,7 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 	_pending = []
 	_save_slot = -1
 	_save_written = false
+	_source_save = null
 	_enemy_trainer_class = 0
 	_enemy_turns_taken = 0
 	_player_turns_taken = 0
@@ -203,6 +205,7 @@ func show_trainer(
 	_pending = []
 	_save_slot = -1
 	_save_written = false
+	_source_save = null
 	_enemy_trainer_class = trainer_class
 	_enemy_turns_taken = 0
 	_player_turns_taken = 0
@@ -237,6 +240,7 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 	_pending = []
 	_save_slot = save.slot
 	_save_written = false
+	_source_save = save
 	_enemy_trainer_class = 0
 	_enemy_turns_taken = 0
 	_player_turns_taken = 0
@@ -435,7 +439,7 @@ func _save_battle_result() -> void:
 	if _save_slot < 0 or _save_written or _battle == null:
 		return
 	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
-		_data.id, _data.sha1, _save_slot, _battle.party(Gen2Battle.PLAYER)
+		_data.id, _data.sha1, _save_slot, _battle.party(Gen2Battle.PLAYER), "", _source_save
 	)
 	var result: Dictionary = Gen2SaveStore.save(save, _data)
 	if not result["ok"]:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -128,7 +128,7 @@ func _build_ui() -> void:
 	status_box.add_child(_progress_label)
 
 	var footer := Label.new()
-	footer.text = "Save slot 1 is used by the development battle. Mods are not available yet."
+	footer.text = "Choose a cartridge, then create or load a validated player save. Mods are not available yet."
 	footer.add_theme_color_override("font_color", MUTED)
 	footer.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	content.add_child(footer)
@@ -233,7 +233,7 @@ func _create_game_card(game_id: StringName, data: GameData) -> PanelContainer:
 		detail.text = "Bring your own verified dump.\nThe filename does not matter."
 	body.add_child(detail)
 
-	var action := _button("Play development battle" if imported else "Choose ROM", ACCENT if imported else TEXT)
+	var action := _button("Open save slots" if imported else "Choose ROM", ACCENT if imported else TEXT)
 	action.custom_minimum_size = Vector2(0, 38)
 	action.pressed.connect(_on_game_action.bind(game_id, imported))
 	body.add_child(action)
@@ -252,17 +252,12 @@ func _on_game_action(game_id: StringName, imported: bool) -> void:
 
 func _launch_game(game_id: StringName) -> void:
 	var data: GameData = GameData.open(game_id)
-	var save_result: Dictionary = Gen2SaveStore.ensure_development_save(data, 0)
-	if not save_result["ok"]:
-		_set_status("Could not open save slot 1.", String(save_result["message"]), ERROR)
-		_refresh_games()
-		return
-	if not GameRuntime.select_save_slot(game_id, 0):
+	if data == null or not GameRuntime.select_game(game_id):
 		_set_status("Could not select %s." % RomRegistry.title_for(game_id), "The registry did not recognise that game.", ERROR)
 		return
 	_selected_game_id = game_id
-	_set_status("Opening %s." % RomRegistry.title_for(game_id), "Save slot 1 is loaded for the development battle.", SUCCESS)
-	get_tree().change_scene_to_file.call_deferred("res://game/battle/battle_screen.tscn")
+	_set_status("Opening %s." % RomRegistry.title_for(game_id), "Choose a save slot or import an original cartridge save.", SUCCESS)
+	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
 
 
 func _open_import_dialog() -> void:
@@ -352,8 +347,17 @@ func _revision_for(game_id: StringName) -> String:
 
 func _save_slot_detail(game_id: StringName, data: GameData) -> String:
 	var slots: Array = Gen2SaveStore.slots_for(game_id, data.sha1, data)
-	var first: Dictionary = slots[0]
-	return "Save slot 1: %s" % ("READY" if first["valid"] else "EMPTY")
+	var ready: int = 0
+	var incompatible: int = 0
+	for row: Dictionary in slots:
+		if row["valid"]:
+			ready += 1
+		elif row["exists"]:
+			incompatible += 1
+	var detail: String = "%d/%d slots ready" % [ready, Gen2SaveStore.SLOT_COUNT]
+	if incompatible > 0:
+		detail += ", %d incompatible" % incompatible
+	return detail
 
 
 func _print_allowlist() -> void:

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -1,0 +1,261 @@
+class_name Gen2PartyScreen
+extends Control
+
+## Player party summary for a validated project save.
+
+const BACKGROUND: Color = Color("#09111f")
+const PANEL: Color = Color("#14233a")
+const BORDER: Color = Color("#2d4566")
+const TEXT: Color = Color("#f4f7fb")
+const MUTED: Color = Color("#9eacc0")
+const ACCENT: Color = Color("#f3c969")
+const SUCCESS: Color = Color("#7bd89a")
+const ERROR: Color = Color("#ef8a8a")
+
+var _data: GameData = null
+var _data_override: GameData = null
+var _save: Gen2SaveData = null
+var _save_override: Gen2SaveData = null
+var _cards: VBoxContainer = null
+var _player_label: Label = null
+var _status: Label = null
+
+
+func _ready() -> void:
+	_data = _data_override if _data_override != null else _resolve_data()
+	_save = _save_override if _save_override != null else _resolve_save()
+	_build_ui()
+	_refresh()
+
+
+## Test seam for a synthetic cache and validated save.
+func set_context(data: GameData, save: Gen2SaveData) -> void:
+	_data_override = data
+	_save_override = save
+	_data = data
+	_save = save
+	if is_inside_tree() and _cards != null:
+		_refresh()
+
+
+func party_snapshot() -> Dictionary:
+	var members: Array = []
+	if _data != null and _save != null:
+		for index: int in Gen2SaveData.MAX_PARTY:
+			if index >= _save.party.size():
+				members.append({"empty": true, "index": index})
+				continue
+			members.append(_member_snapshot(index, _save.party[index]))
+	return {
+		"player_name": _save.player_name if _save != null else "",
+		"slot": _save.slot if _save != null else -1,
+		"members": members,
+	}
+
+
+func _resolve_data() -> GameData:
+	if GameRuntime.has_selected_game():
+		return GameRuntime.selected_data()
+	return GameData.open_any()
+
+
+func _resolve_save() -> Gen2SaveData:
+	if _data == null or not GameRuntime.has_selected_save_slot():
+		return null
+	return GameRuntime.selected_save()
+
+
+func _build_ui() -> void:
+	var background := ColorRect.new()
+	background.color = BACKGROUND
+	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	background.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(background)
+
+	var margin := MarginContainer.new()
+	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	margin.add_theme_constant_override("margin_left", 64)
+	margin.add_theme_constant_override("margin_top", 42)
+	margin.add_theme_constant_override("margin_right", 64)
+	margin.add_theme_constant_override("margin_bottom", 42)
+	add_child(margin)
+
+	var content := VBoxContainer.new()
+	content.add_theme_constant_override("separation", 16)
+	margin.add_child(content)
+
+	var header := HBoxContainer.new()
+	header.add_theme_constant_override("separation", 18)
+	content.add_child(header)
+	var heading := VBoxContainer.new()
+	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	heading.add_theme_constant_override("separation", 3)
+	header.add_child(heading)
+	var title := Label.new()
+	title.text = "PARTY"
+	title.add_theme_color_override("font_color", TEXT)
+	title.add_theme_font_size_override("font_size", 32)
+	heading.add_child(title)
+	var subtitle := Label.new()
+	subtitle.text = "Player party and persistent condition"
+	subtitle.add_theme_color_override("font_color", MUTED)
+	heading.add_child(subtitle)
+	var back := _button("Back to save slots", TEXT)
+	back.custom_minimum_size = Vector2(190, 44)
+	back.pressed.connect(_back)
+	header.add_child(back)
+
+	_player_label = Label.new()
+	_player_label.add_theme_color_override("font_color", ACCENT)
+	_player_label.add_theme_font_size_override("font_size", 18)
+	content.add_child(_player_label)
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	content.add_child(scroll)
+	_cards = VBoxContainer.new()
+	_cards.add_theme_constant_override("separation", 9)
+	_cards.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(_cards)
+
+	var footer := HBoxContainer.new()
+	footer.add_theme_constant_override("separation", 10)
+	content.add_child(footer)
+	var battle := _button("Start development battle", ACCENT)
+	battle.pressed.connect(_start_battle)
+	footer.add_child(battle)
+	_status = Label.new()
+	_status.add_theme_color_override("font_color", MUTED)
+	_status.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_status.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	footer.add_child(_status)
+
+
+func _refresh() -> void:
+	if _cards == null:
+		return
+	for child: Node in _cards.get_children():
+		child.free()
+	if _player_label != null:
+		_player_label.text = "Player: %s" % (_save.player_name if _save != null else "Unavailable")
+	if _data == null or _save == null:
+		_status.text = "No validated save selected."
+		_status.add_theme_color_override("font_color", ERROR)
+		return
+	for index: int in Gen2SaveData.MAX_PARTY:
+		_cards.add_child(_member_card(index))
+	_status.text = "Slot %d" % (_save.slot + 1)
+	_status.add_theme_color_override("font_color", SUCCESS)
+
+
+func _member_card(index: int) -> PanelContainer:
+	var card := PanelContainer.new()
+	card.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 8))
+	var content := HBoxContainer.new()
+	content.add_theme_constant_override("separation", 18)
+	card.add_child(content)
+	var number := Label.new()
+	number.text = "%d" % (index + 1)
+	number.custom_minimum_size = Vector2(28, 0)
+	number.add_theme_color_override("font_color", ACCENT)
+	number.add_theme_font_size_override("font_size", 20)
+	content.add_child(number)
+	if _save == null or index >= _save.party.size():
+		var empty := Label.new()
+		empty.text = "Empty"
+		empty.add_theme_color_override("font_color", MUTED)
+		content.add_child(empty)
+		return card
+	var mon: Gen2SaveMon = _save.party[index]
+	var summary := VBoxContainer.new()
+	summary.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	summary.add_theme_constant_override("separation", 3)
+	content.add_child(summary)
+	var name := Label.new()
+	name.text = _display_name(mon)
+	name.add_theme_color_override("font_color", TEXT)
+	name.add_theme_font_size_override("font_size", 20)
+	summary.add_child(name)
+	var details := Label.new()
+	details.text = "%s    Level %d    HP %d/%d" % [
+		_species_name(mon.species), mon.level, mon.hp, _max_hp(mon)
+	]
+	details.add_theme_color_override("font_color", MUTED)
+	summary.add_child(details)
+	var condition := Label.new()
+	condition.text = "Status: %s" % _status_name(mon.status)
+	condition.add_theme_color_override("font_color", _status_color(mon.status))
+	summary.add_child(condition)
+	return card
+
+
+func _member_snapshot(index: int, mon: Gen2SaveMon) -> Dictionary:
+	return {
+		"empty": false,
+		"index": index,
+		"name": _display_name(mon),
+		"species": mon.species,
+		"level": mon.level,
+		"hp": mon.hp,
+		"max_hp": _max_hp(mon),
+		"status": _status_name(mon.status),
+	}
+
+
+func _max_hp(mon: Gen2SaveMon) -> int:
+	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
+	return battle_mon.max_hp() if battle_mon != null else 0
+
+
+func _display_name(mon: Gen2SaveMon) -> String:
+	return mon.nickname if not mon.nickname.is_empty() else _species_name(mon.species)
+
+
+func _species_name(species: int) -> String:
+	return String(_data.species(species).get("name", "UNKNOWN")) if _data != null else "UNKNOWN"
+
+
+func _status_name(status: int) -> String:
+	var name: StringName = Gen2Status.name_of(status)
+	return "OK" if name.is_empty() else String(name).to_upper()
+
+
+func _status_color(status: int) -> Color:
+	return SUCCESS if Gen2Status.name_of(status).is_empty() else ACCENT
+
+
+func _start_battle() -> void:
+	if _data == null or _save == null:
+		return
+	if not GameRuntime.select_save_slot(_data.id, _save.slot):
+		_status.text = "The selected cartridge is not in the registry."
+		_status.add_theme_color_override("font_color", ERROR)
+		return
+	get_tree().change_scene_to_file.call_deferred("res://game/battle/battle_screen.tscn")
+
+
+func _back() -> void:
+	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
+
+
+func _button(text: String, colour: Color) -> Button:
+	var button := Button.new()
+	button.text = text
+	button.add_theme_color_override("font_color", colour)
+	button.add_theme_color_override("font_hover_color", Color.WHITE)
+	button.add_theme_font_size_override("font_size", 14)
+	return button
+
+
+func _panel_style(fill: Color, line: Color, radius: int) -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = fill
+	style.border_color = line
+	style.set_border_width_all(1)
+	style.set_corner_radius_all(radius)
+	style.content_margin_left = 18
+	style.content_margin_top = 14
+	style.content_margin_right = 18
+	style.content_margin_bottom = 14
+	return style

--- a/game/save/party_screen.gd.uid
+++ b/game/save/party_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://bw2hqjp0deh8m

--- a/game/save/party_screen.tscn
+++ b/game/save/party_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://game/save/party_screen.gd" id="1"]
+
+[node name="PartyScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -50,7 +50,8 @@ static func to_battle_mon(data: GameData, saved: Gen2SaveMon) -> Gen2BattleMon:
 
 
 static func from_battle_party(
-	game_id: StringName, rom_sha1: String, slot: int, party: Gen2Party, player_name: String = ""
+	game_id: StringName, rom_sha1: String, slot: int, party: Gen2Party, player_name: String = "",
+	source_save: Gen2SaveData = null
 ) -> Gen2SaveData:
 	if party == null or party.mons.is_empty() or party.mons.size() > Gen2Party.MAX_SIZE:
 		return null
@@ -58,9 +59,21 @@ static func from_battle_party(
 	out.game_id = game_id
 	out.rom_sha1 = rom_sha1
 	out.slot = slot
-	out.player_name = player_name
-	for mon: Gen2BattleMon in party.mons:
-		out.party.append(from_battle_mon(mon))
+	out.player_name = source_save.player_name if source_save != null else player_name
+	for index: int in party.mons.size():
+		var saved_mon: Gen2SaveMon = from_battle_mon(party.mons[index])
+		if source_save != null and index < source_save.party.size():
+			var previous: Gen2SaveMon = source_save.party[index]
+			saved_mon.ot_id = previous.ot_id
+			saved_mon.happiness = previous.happiness
+			saved_mon.pokerus = previous.pokerus
+			saved_mon.caught_time = previous.caught_time
+			saved_mon.caught_gender = previous.caught_gender
+			saved_mon.caught_level = previous.caught_level
+			saved_mon.caught_location = previous.caught_location
+			saved_mon.nickname = previous.nickname
+			saved_mon.original_trainer = previous.original_trainer
+		out.party.append(saved_mon)
 	return out
 
 

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -9,6 +9,7 @@ extends RefCounted
 
 const FORMAT_VERSION: int = 1
 const MAX_PARTY: int = Gen2Party.MAX_SIZE
+const MAX_PLAYER_NAME: int = 10
 
 var format_version: int = FORMAT_VERSION
 var game_id: StringName = &""

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -1,0 +1,612 @@
+class_name Gen2SaveScreen
+extends Control
+
+## Player-facing save selection for one imported cartridge revision.
+##
+## The screen only coordinates validated save data. Original SRAM bytes enter
+## through [Gen2SramAdapter], and project slots are written through
+## [Gen2SaveStore], so no control here needs to know a cartridge offset.
+
+const BACKGROUND: Color = Color("#09111f")
+const PANEL: Color = Color("#14233a")
+const PANEL_SELECTED: Color = Color("#1d3352")
+const BORDER: Color = Color("#2d4566")
+const BORDER_SELECTED: Color = Color("#f3c969")
+const TEXT: Color = Color("#f4f7fb")
+const MUTED: Color = Color("#9eacc0")
+const ACCENT: Color = Color("#f3c969")
+const SUCCESS: Color = Color("#7bd89a")
+const ERROR: Color = Color("#ef8a8a")
+
+var _data: GameData = null
+var _data_override: GameData = null
+var _selected_slot: int = 0
+var _selected_starter: int = Gen2SaveStore.STARTER_SPECIES[1]
+var _new_game_visible: bool = false
+var _slots: Array = []
+var _pending_replace_action: StringName = &""
+var _pending_import_path: String = ""
+
+var _slots_container: HBoxContainer = null
+var _slots_section: Label = null
+var _slot_scroll: ScrollContainer = null
+var _details_box: VBoxContainer = null
+var _status_label: Label = null
+var _status_detail: Label = null
+var _name_input: LineEdit = null
+var _confirm_dialog: ConfirmationDialog = null
+var _file_dialog: FileDialog = null
+
+
+func _ready() -> void:
+	_data = _data_override if _data_override != null else _resolve_data()
+	_build_ui()
+	_refresh()
+
+
+## Test and tooling seam for synthetic caches. Production callers use the
+## selected registry game through [GameRuntime].
+func set_data(data: GameData) -> void:
+	_data_override = data
+	_data = data
+	if is_inside_tree() and _slots_container != null:
+		_refresh()
+
+
+## Selects one of the three project slots.
+func select_slot(slot: int) -> bool:
+	if slot < 0 or slot >= Gen2SaveStore.SLOT_COUNT:
+		return false
+	_selected_slot = slot
+	_new_game_visible = false
+	_refresh()
+	return true
+
+
+## Opens the new-game form for a slot. Existing slots require confirmation
+## through the button-driven path, while tests and tools may call this directly.
+func open_new_game(slot: int = -1) -> bool:
+	if slot >= 0 and not select_slot(slot):
+		return false
+	_new_game_visible = true
+	_refresh_details()
+	return true
+
+
+## Creates and validates a new-game save in the selected slot.
+func create_new_game(player_name: String, starter_species: int) -> bool:
+	if _data == null:
+		_set_status("New game unavailable.", "No imported cartridge cache is selected.", ERROR)
+		return false
+	var created: Gen2SaveData = Gen2SaveStore.create_new_game(
+		_data, _selected_slot, player_name, starter_species
+	)
+	if created == null:
+		_set_status(
+			"New game was not created.",
+			"Enter a name of ten characters or fewer and choose a valid starter.",
+			ERROR
+		)
+		return false
+	var result: Dictionary = Gen2SaveStore.save(created, _data)
+	if not result["ok"]:
+		_set_status("New game was not saved.", String(result["message"]), ERROR)
+		return false
+	_new_game_visible = false
+	_refresh()
+	_set_status(
+		"New game created in slot %d." % (_selected_slot + 1),
+		"%s is ready." % _species_name(starter_species),
+		SUCCESS
+	)
+	return true
+
+
+## Imports an original SRAM file into the selected project slot. A failed
+## import never reaches [Gen2SaveStore.save], so the previous slot remains.
+func import_sav_path(path: String, slot: int = -1) -> bool:
+	if _data == null:
+		_set_status("Save import unavailable.", "No imported cartridge cache is selected.", ERROR)
+		return false
+	if slot >= 0 and not select_slot(slot):
+		return false
+	if not FileAccess.file_exists(path):
+		_set_status("Save import failed.", "The selected file could not be opened.", ERROR)
+		return false
+	var raw: PackedByteArray = FileAccess.get_file_as_bytes(path)
+	if raw.is_empty():
+		_set_status("Save import failed.", "The selected file is empty.", ERROR)
+		return false
+	var imported: Dictionary = Gen2SramAdapter.import_bytes(
+		_data.id, _data.sha1, _selected_slot, raw, _data
+	)
+	if not imported["ok"]:
+		_set_status("Save import rejected.", String(imported["message"]), ERROR)
+		return false
+	var save: Gen2SaveData = imported["save"]
+	var result: Dictionary = Gen2SaveStore.save(save, _data)
+	if not result["ok"]:
+		_set_status("Save import failed.", String(result["message"]), ERROR)
+		return false
+	_new_game_visible = false
+	_refresh()
+	_set_status(
+		"Save imported into slot %d." % (_selected_slot + 1),
+		"The cartridge copy was %s and passed validation." % String(imported["copy"]),
+		SUCCESS
+	)
+	return true
+
+
+## Read-only state used by scene tests and screenshot drivers.
+func save_screen_snapshot() -> Dictionary:
+	return {
+		"game_id": String(_data.id) if _data != null else "",
+		"selected_slot": _selected_slot,
+		"new_game": _new_game_visible,
+		"status": _status_label.text if _status_label != null else "",
+		"detail": _status_detail.text if _status_detail != null else "",
+		"slots": _slots.duplicate(true),
+	}
+
+
+func _resolve_data() -> GameData:
+	if GameRuntime.has_selected_game():
+		return GameRuntime.selected_data()
+	return GameData.open_any()
+
+
+func _build_ui() -> void:
+	var background := ColorRect.new()
+	background.color = BACKGROUND
+	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	background.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(background)
+
+	var margin := MarginContainer.new()
+	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	margin.add_theme_constant_override("margin_left", 56)
+	margin.add_theme_constant_override("margin_top", 38)
+	margin.add_theme_constant_override("margin_right", 56)
+	margin.add_theme_constant_override("margin_bottom", 34)
+	add_child(margin)
+
+	var content := VBoxContainer.new()
+	content.add_theme_constant_override("separation", 16)
+	margin.add_child(content)
+
+	var header := HBoxContainer.new()
+	header.add_theme_constant_override("separation", 18)
+	content.add_child(header)
+
+	var heading := VBoxContainer.new()
+	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	heading.add_theme_constant_override("separation", 3)
+	header.add_child(heading)
+	var title := Label.new()
+	title.text = "SAVE DATA"
+	title.add_theme_color_override("font_color", TEXT)
+	title.add_theme_font_size_override("font_size", 32)
+	heading.add_child(title)
+	var subtitle := Label.new()
+	subtitle.text = _data.title() if _data != null else "No cartridge selected"
+	subtitle.add_theme_color_override("font_color", MUTED)
+	subtitle.add_theme_font_size_override("font_size", 16)
+	heading.add_child(subtitle)
+
+	var back := _button("Back to cartridges", TEXT)
+	back.custom_minimum_size = Vector2(190, 44)
+	back.pressed.connect(_back_to_launcher)
+	header.add_child(back)
+
+	_slots_section = Label.new()
+	var section: Label = _slots_section
+	section.text = "SAVE SLOTS"
+	section.add_theme_color_override("font_color", ACCENT)
+	section.add_theme_font_size_override("font_size", 13)
+	content.add_child(section)
+
+	_slot_scroll = ScrollContainer.new()
+	var slot_scroll: ScrollContainer = _slot_scroll
+	slot_scroll.custom_minimum_size = Vector2(0, 154)
+	slot_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	content.add_child(slot_scroll)
+	_slots_container = HBoxContainer.new()
+	_slots_container.add_theme_constant_override("separation", 16)
+	_slots_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_slots_container.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
+	slot_scroll.add_child(_slots_container)
+
+	var details_panel := PanelContainer.new()
+	details_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	details_panel.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 10))
+	content.add_child(details_panel)
+	var detail_scroll := ScrollContainer.new()
+	detail_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	details_panel.add_child(detail_scroll)
+	_details_box = VBoxContainer.new()
+	_details_box.add_theme_constant_override("separation", 10)
+	_details_box.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	detail_scroll.add_child(_details_box)
+
+	var status_panel := PanelContainer.new()
+	status_panel.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 10))
+	status_panel.custom_minimum_size = Vector2(0, 54)
+	content.add_child(status_panel)
+	var status_box := VBoxContainer.new()
+	status_box.add_theme_constant_override("separation", 3)
+	status_panel.add_child(status_box)
+	_status_label = Label.new()
+	_status_label.add_theme_color_override("font_color", TEXT)
+	_status_label.add_theme_font_size_override("font_size", 16)
+	status_box.add_child(_status_label)
+	_status_detail = Label.new()
+	_status_detail.add_theme_color_override("font_color", MUTED)
+	_status_detail.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	status_box.add_child(_status_detail)
+
+	_file_dialog = FileDialog.new()
+	_file_dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
+	_file_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	_file_dialog.filters = PackedStringArray(["*.sav; Game Boy save file", "*; All files"])
+	_file_dialog.title = "Choose an original Gold, Silver, or Crystal save"
+	_file_dialog.file_selected.connect(_on_file_selected)
+	add_child(_file_dialog)
+
+	_confirm_dialog = ConfirmationDialog.new()
+	_confirm_dialog.title = "Replace save slot?"
+	_confirm_dialog.confirmed.connect(_on_replace_confirmed)
+	add_child(_confirm_dialog)
+
+	_set_status(
+		"Select a save slot.",
+		"Create a new game, continue a validated save, or import an original cartridge save.",
+		MUTED
+	)
+
+
+func _refresh() -> void:
+	if _data == null:
+		_set_status("No cartridge cache is ready.", "Return to the launcher and import a supported ROM.", ERROR)
+		return
+	_slots = Gen2SaveStore.slots_for(_data.id, _data.sha1, _data)
+	if _selected_slot < 0 or _selected_slot >= _slots.size():
+		_selected_slot = 0
+	_slots_section.visible = not _new_game_visible
+	_slot_scroll.visible = not _new_game_visible
+	_refresh_slot_cards()
+	_refresh_details()
+
+
+func _refresh_slot_cards() -> void:
+	for child: Node in _slots_container.get_children():
+		child.free()
+	for row: Dictionary in _slots:
+		var slot: int = int(row["slot"])
+		var selected: bool = slot == _selected_slot
+		var card := PanelContainer.new()
+		card.custom_minimum_size = Vector2(250, 146)
+		card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		card.add_theme_stylebox_override(
+			"panel", _panel_style(PANEL_SELECTED if selected else PANEL, BORDER_SELECTED if selected else BORDER, 10)
+		)
+		_slots_container.add_child(card)
+		var body := VBoxContainer.new()
+		body.add_theme_constant_override("separation", 7)
+		card.add_child(body)
+		var title := Label.new()
+		title.text = "SLOT %d" % (slot + 1)
+		title.add_theme_color_override("font_color", TEXT)
+		title.add_theme_font_size_override("font_size", 21)
+		body.add_child(title)
+		var state := Label.new()
+		state.text = _slot_state(row)
+		state.add_theme_color_override("font_color", _slot_state_color(row))
+		state.add_theme_font_size_override("font_size", 14)
+		body.add_child(state)
+		var message := Label.new()
+		message.text = _slot_message(row)
+		message.add_theme_color_override("font_color", MUTED)
+		message.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		message.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		body.add_child(message)
+		var select := _button("Selected" if selected else "Select slot", ACCENT if selected else TEXT)
+		select.custom_minimum_size = Vector2(0, 34)
+		select.disabled = selected
+		select.pressed.connect(select_slot.bind(slot))
+		body.add_child(select)
+
+
+func _refresh_details() -> void:
+	if _details_box == null:
+		return
+	_slots_section.visible = not _new_game_visible
+	_slot_scroll.visible = not _new_game_visible
+	for child: Node in _details_box.get_children():
+		child.free()
+	if _data == null or _slots.is_empty():
+		return
+	var row: Dictionary = _slots[_selected_slot]
+	var heading := Label.new()
+	heading.text = "SLOT %d" % (_selected_slot + 1)
+	heading.add_theme_color_override("font_color", TEXT)
+	heading.add_theme_font_size_override("font_size", 24)
+	_details_box.add_child(heading)
+	var state := Label.new()
+	state.text = _slot_state(row)
+	state.add_theme_color_override("font_color", _slot_state_color(row))
+	_details_box.add_child(state)
+
+	if _new_game_visible:
+		_build_new_game_form()
+		return
+
+	var save: Gen2SaveData = _load_selected_save()
+	if save != null:
+		var player := Label.new()
+		player.text = "Player: %s" % save.player_name
+		player.add_theme_color_override("font_color", MUTED)
+		_details_box.add_child(player)
+		_add_party_summary(save)
+		var actions := HBoxContainer.new()
+		actions.add_theme_constant_override("separation", 10)
+		_details_box.add_child(actions)
+		var continue_button := _button("Continue", ACCENT)
+		continue_button.pressed.connect(_continue_selected)
+		actions.add_child(continue_button)
+		var party_button := _button("Open party", TEXT)
+		party_button.pressed.connect(_open_party)
+		actions.add_child(party_button)
+		var import_button := _button("Import .sav", TEXT)
+		import_button.pressed.connect(_request_import)
+		actions.add_child(import_button)
+		var replace_button := _button("Replace", TEXT)
+		replace_button.pressed.connect(_request_new_game)
+		actions.add_child(replace_button)
+		return
+
+	var message := Label.new()
+	message.text = _slot_message(row)
+	message.add_theme_color_override("font_color", MUTED)
+	message.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_details_box.add_child(message)
+	var actions := HBoxContainer.new()
+	actions.add_theme_constant_override("separation", 10)
+	_details_box.add_child(actions)
+	var new_button := _button("New game", ACCENT)
+	new_button.pressed.connect(_request_new_game)
+	actions.add_child(new_button)
+	var import_button := _button("Import .sav", TEXT)
+	import_button.pressed.connect(_request_import)
+	actions.add_child(import_button)
+
+
+func _build_new_game_form() -> void:
+	var prompt := Label.new()
+	prompt.text = "Choose a name and Professor Elm's starter Pokémon."
+	prompt.add_theme_color_override("font_color", MUTED)
+	prompt.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_details_box.add_child(prompt)
+	_name_input = LineEdit.new()
+	_name_input.placeholder_text = "Player name"
+	_name_input.max_length = Gen2SaveData.MAX_PLAYER_NAME
+	_name_input.custom_minimum_size = Vector2(0, 42)
+	_details_box.add_child(_labeled_control("PLAYER NAME", _name_input))
+	var starter_label := Label.new()
+	starter_label.text = "STARTER"
+	starter_label.add_theme_color_override("font_color", ACCENT)
+	starter_label.add_theme_font_size_override("font_size", 12)
+	_details_box.add_child(starter_label)
+	var starters := HBoxContainer.new()
+	starters.add_theme_constant_override("separation", 10)
+	_details_box.add_child(starters)
+	for starter: int in Gen2SaveStore.STARTER_SPECIES:
+		var button := _button(_species_name(starter), ACCENT if starter == _selected_starter else TEXT)
+		button.custom_minimum_size = Vector2(150, 38)
+		button.pressed.connect(_select_starter.bind(starter))
+		starters.add_child(button)
+	var actions := HBoxContainer.new()
+	actions.add_theme_constant_override("separation", 10)
+	_details_box.add_child(actions)
+	var create_button := _button("Create save", ACCENT)
+	create_button.pressed.connect(_create_from_form)
+	actions.add_child(create_button)
+	var cancel_button := _button("Cancel", TEXT)
+	cancel_button.pressed.connect(_cancel_new_game)
+	actions.add_child(cancel_button)
+
+
+func _add_party_summary(save: Gen2SaveData) -> void:
+	var label := Label.new()
+	label.text = "PARTY"
+	label.add_theme_color_override("font_color", ACCENT)
+	label.add_theme_font_size_override("font_size", 12)
+	_details_box.add_child(label)
+	for index: int in Gen2SaveData.MAX_PARTY:
+		var row := PanelContainer.new()
+		row.add_theme_stylebox_override("panel", _panel_style(Color("#102039"), BORDER, 6))
+		_details_box.add_child(row)
+		var content := VBoxContainer.new()
+		content.add_theme_constant_override("separation", 2)
+		row.add_child(content)
+		if index >= save.party.size():
+			var empty := Label.new()
+			empty.text = "%d. Empty" % (index + 1)
+			empty.add_theme_color_override("font_color", MUTED)
+			content.add_child(empty)
+			continue
+		var mon: Gen2SaveMon = save.party[index]
+		var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
+		var name := Label.new()
+		name.text = "%d. %s" % [index + 1, _display_name(mon)]
+		name.add_theme_color_override("font_color", TEXT)
+		content.add_child(name)
+		var details := Label.new()
+		details.text = "Lv.%d    HP %d/%d    %s" % [
+			mon.level, mon.hp, battle_mon.max_hp(), _status_name(mon.status)
+		]
+		details.add_theme_color_override("font_color", MUTED)
+		content.add_child(details)
+
+
+func _request_new_game() -> void:
+	if _slot_exists():
+		_pending_replace_action = &"new_game"
+		_pending_import_path = ""
+		_confirm_dialog.dialog_text = "Replace slot %d with a new game?" % (_selected_slot + 1)
+		_confirm_dialog.popup_centered()
+		return
+	open_new_game()
+
+
+func _request_import() -> void:
+	_file_dialog.popup_centered(Vector2i(900, 600))
+
+
+func _on_file_selected(path: String) -> void:
+	if _slot_exists():
+		_pending_replace_action = &"import"
+		_pending_import_path = path
+		_confirm_dialog.dialog_text = "Replace slot %d with this cartridge save?" % (_selected_slot + 1)
+		_confirm_dialog.popup_centered()
+		return
+	import_sav_path(path)
+
+
+func _on_replace_confirmed() -> void:
+	var action: StringName = _pending_replace_action
+	var path: String = _pending_import_path
+	_pending_replace_action = &""
+	_pending_import_path = ""
+	if action == &"new_game":
+		open_new_game()
+	elif action == &"import":
+		import_sav_path(path)
+
+
+func _create_from_form() -> void:
+	if _name_input != null:
+		create_new_game(_name_input.text, _selected_starter)
+
+
+func _select_starter(species: int) -> void:
+	_selected_starter = species
+	_refresh_details()
+
+
+func _cancel_new_game() -> void:
+	_new_game_visible = false
+	_refresh_details()
+
+
+func _continue_selected() -> void:
+	if _data == null or _load_selected_save() == null:
+		return
+	if not GameRuntime.select_save_slot(_data.id, _selected_slot):
+		_set_status("Could not select save slot.", "The selected cartridge is not in the registry.", ERROR)
+		return
+	get_tree().change_scene_to_file.call_deferred("res://game/battle/battle_screen.tscn")
+
+
+func _open_party() -> void:
+	if _data == null or _load_selected_save() == null:
+		return
+	if not GameRuntime.select_save_slot(_data.id, _selected_slot):
+		_set_status("Could not select save slot.", "The selected cartridge is not in the registry.", ERROR)
+		return
+	get_tree().change_scene_to_file.call_deferred("res://game/save/party_screen.tscn")
+
+
+func _back_to_launcher() -> void:
+	get_tree().change_scene_to_file.call_deferred("res://game/main/main.tscn")
+
+
+func _load_selected_save() -> Gen2SaveData:
+	if _data == null or _selected_slot < 0 or _selected_slot >= _slots.size():
+		return null
+	var row: Dictionary = _slots[_selected_slot]
+	if not row["valid"]:
+		return null
+	var result: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, _selected_slot, _data)
+	return result["save"] if result["ok"] else null
+
+
+func _slot_exists() -> bool:
+	return _selected_slot >= 0 and _selected_slot < _slots.size() and bool(_slots[_selected_slot]["exists"])
+
+
+func _slot_state(row: Dictionary) -> String:
+	if not row["exists"]:
+		return "EMPTY"
+	return "READY" if row["valid"] else "INCOMPATIBLE"
+
+
+func _slot_message(row: Dictionary) -> String:
+	if not row["exists"]:
+		return "No player data in this slot."
+	return "Ready to continue." if row["valid"] else String(row["message"])
+
+
+func _slot_state_color(row: Dictionary) -> Color:
+	if not row["exists"]:
+		return ACCENT
+	return SUCCESS if row["valid"] else ERROR
+
+
+func _display_name(mon: Gen2SaveMon) -> String:
+	if mon.nickname.is_empty():
+		return _species_name(mon.species)
+	return mon.nickname
+
+
+func _species_name(species: int) -> String:
+	if _data == null:
+		return "UNKNOWN"
+	return String(_data.species(species).get("name", "UNKNOWN"))
+
+
+func _status_name(status: int) -> String:
+	var name: StringName = Gen2Status.name_of(status)
+	return "OK" if name.is_empty() else String(name).to_upper()
+
+
+func _set_status(title: String, detail: String, colour: Color) -> void:
+	if _status_label == null:
+		return
+	_status_label.text = title
+	_status_label.add_theme_color_override("font_color", colour)
+	_status_detail.text = detail
+
+
+func _labeled_control(label_text: String, control: Control) -> VBoxContainer:
+	var box := VBoxContainer.new()
+	box.add_theme_constant_override("separation", 3)
+	var label := Label.new()
+	label.text = label_text
+	label.add_theme_color_override("font_color", ACCENT)
+	label.add_theme_font_size_override("font_size", 12)
+	box.add_child(label)
+	box.add_child(control)
+	return box
+
+
+func _button(text: String, colour: Color) -> Button:
+	var button := Button.new()
+	button.text = text
+	button.add_theme_color_override("font_color", colour)
+	button.add_theme_color_override("font_hover_color", Color.WHITE)
+	button.add_theme_font_size_override("font_size", 14)
+	return button
+
+
+func _panel_style(fill: Color, line: Color, radius: int) -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = fill
+	style.border_color = line
+	style.set_border_width_all(1)
+	style.set_corner_radius_all(radius)
+	style.content_margin_left = 18
+	style.content_margin_top = 14
+	style.content_margin_right = 18
+	style.content_margin_bottom = 14
+	return style

--- a/game/save/save_screen.gd.uid
+++ b/game/save/save_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cjedemapun86w

--- a/game/save/save_screen.tscn
+++ b/game/save/save_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://game/save/save_screen.gd" id="1"]
+
+[node name="SaveScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -6,6 +6,9 @@ extends RefCounted
 
 const ROOT: String = "user://save_slots"
 const SLOT_COUNT: int = 3
+const STARTER_LEVEL: int = 5
+const STARTER_SPECIES: Array[int] = [152, 155, 158]
+const STARTER_ITEM: int = 0xAD
 
 
 static func path_for(game_id: StringName, rom_sha1: String, slot: int) -> String:
@@ -92,7 +95,41 @@ static func create_development_save(data: GameData, slot: int) -> Gen2SaveData:
 		if mon == null:
 			return null
 		members.append(mon)
-	return Gen2SaveBattleAdapter.from_battle_party(data.id, data.sha1, slot, Gen2Party.create(members))
+	return Gen2SaveBattleAdapter.from_battle_party(
+		data.id, data.sha1, slot, Gen2Party.create(members), "PLAYER"
+	)
+
+
+## Creates the party obtained from Professor Elm's three starter balls. The
+## project save model does not own the player's trainer ID yet, so the starter
+## keeps the canonical zero value for its OT ID until that field exists.
+static func create_new_game(
+	data: GameData, slot: int, player_name: String, starter_species: int
+) -> Gen2SaveData:
+	if data == null or not _valid_slot(slot):
+		return null
+	if player_name.is_empty() or Gen2Text.encoded_length(player_name) > Gen2SaveData.MAX_PLAYER_NAME:
+		return null
+	if not STARTER_SPECIES.has(starter_species):
+		return null
+	if data.species(starter_species).is_empty() or data.item(STARTER_ITEM).is_empty():
+		return null
+	var known_moves: Array = data.moves_at_level(starter_species, STARTER_LEVEL)
+	var mon: Gen2BattleMon = Gen2BattleMon.create(
+		data, starter_species, STARTER_LEVEL, known_moves, Gen2BattleMon.PERFECT_DVS, {}, STARTER_ITEM
+	)
+	if mon == null:
+		return null
+	var save := Gen2SaveData.new()
+	save.game_id = data.id
+	save.rom_sha1 = data.sha1
+	save.slot = slot
+	save.player_name = player_name
+	var saved_mon: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(mon)
+	saved_mon.nickname = String(data.species(starter_species).get("name", ""))
+	saved_mon.original_trainer = player_name
+	save.party.append(saved_mon)
+	return save
 
 
 static func ensure_development_save(data: GameData, slot: int = 0) -> Dictionary:

--- a/game/save/save_validator.gd
+++ b/game/save/save_validator.gd
@@ -19,6 +19,10 @@ static func validate(save: Gen2SaveData, data: GameData) -> Dictionary:
 		return _failure("the save belongs to a different cartridge revision")
 	if save.slot < 0 or save.slot >= Gen2SaveStore.SLOT_COUNT:
 		return _failure("save slot %d is out of range" % save.slot)
+	if save.player_name.is_empty():
+		return _failure("the player name is empty")
+	if Gen2Text.encoded_length(save.player_name) > Gen2SaveData.MAX_PLAYER_NAME:
+		return _failure("the player name is too long")
 	if save.party.is_empty() or save.party.size() > Gen2SaveData.MAX_PARTY:
 		return _failure("the party must contain between one and six Pokémon")
 

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -122,6 +122,7 @@ const FOCUS_ENERGY_MOVE: int = 273
 
 ## The highest move number this table fills. Grown as new moves are added.
 const MAX_MOVE: int = FOCUS_ENERGY_MOVE
+const BERRY_ITEM: int = 0xAD
 
 ## Gender ratios, the published bytes: `x percent = floor(x * 255 / 100)`, so a
 ## species' own ratio here can be checked against pret's own base stats rather
@@ -170,7 +171,7 @@ static func build(directory: String) -> GameData:
 
 	RomCache.write_json(RomCache.species_path(directory), _species())
 	RomCache.write_json(RomCache.moves_path(directory), _moves())
-	RomCache.write_json(RomCache.items_path(directory), [])
+	RomCache.write_json(RomCache.items_path(directory), _items())
 	RomCache.write_json(RomCache.types_path(directory), _types())
 	RomCache.write_json(RomCache.matchups_path(directory), _matchups())
 	RomCache.write_json(RomCache.trainers_path(directory), [])
@@ -352,6 +353,16 @@ static func _types() -> Array:
 	var out: Array = []
 	for number: int in RomLayout.TYPE_COUNT:
 		out.append({"number": number, "name": "TYPE%d" % number})
+	return out
+
+
+static func _items() -> Array:
+	var out: Array = []
+	for number: int in range(1, BERRY_ITEM + 1):
+		out.append({
+			"number": number,
+			"name": "BERRY" if number == BERRY_ITEM else "ITEM%d" % number,
+		})
 	return out
 
 

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -91,6 +91,41 @@ func test_a_saved_pokemon_restores_stats_hp_status_exp_and_pp() -> void:
 	assert_eq(mon.substatus, Gen2Substatus.NONE, "volatile battle state is never loaded")
 
 
+func test_battle_save_writeback_preserves_player_and_pokemon_identity() -> void:
+	var source: Gen2SaveData = _save()
+	(source.party[0] as Gen2SaveMon).nickname = "SPARKY"
+	(source.party[0] as Gen2SaveMon).original_trainer = "RED"
+	var party: Gen2Party = Gen2SaveBattleAdapter.to_battle_party(_data, source)
+	var written: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
+		_data.id, _data.sha1, source.slot, party, "", source
+	)
+	assert_eq(written.player_name, "RED")
+	assert_eq((written.party[0] as Gen2SaveMon).nickname, "SPARKY")
+	assert_eq((written.party[0] as Gen2SaveMon).original_trainer, "RED")
+
+
+func test_new_game_uses_the_real_starter_choices_and_berry() -> void:
+	var created: Gen2SaveData = Gen2SaveStore.create_new_game(_data, 1, "ASH", 155)
+	assert_not_null(created)
+	assert_eq(created.player_name, "ASH")
+	assert_eq(created.slot, 1)
+	assert_eq(created.party.size(), 1)
+	var mon: Gen2SaveMon = created.party[0]
+	assert_eq(mon.species, 155)
+	assert_eq(mon.level, 5)
+	assert_eq(mon.item, Gen2SaveStore.STARTER_ITEM)
+	assert_eq(mon.nickname, "FILLER")
+	assert_eq(mon.original_trainer, "ASH")
+	var validation: Dictionary = Gen2SaveValidator.validate(created, _data)
+	assert_true(validation["ok"], validation["message"])
+
+
+func test_development_save_has_a_valid_default_player_name() -> void:
+	var result: Dictionary = Gen2SaveStore.ensure_development_save(_data, 2)
+	assert_true(result["ok"], result["message"])
+	assert_eq((result["save"] as Gen2SaveData).player_name, "PLAYER")
+
+
 func test_a_valid_save_is_accepted_against_its_cartridge_cache() -> void:
 	var result: Dictionary = Gen2SaveValidator.validate(_save(), _data)
 	assert_true(result["ok"], result["message"])

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -1,0 +1,141 @@
+extends GutTest
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
+var _directory: String = ""
+var _data: GameData = null
+var _screen: Gen2SaveScreen = null
+var _party_screen: Gen2PartyScreen = null
+var _save_directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"screentest", "0123456789abcdef")
+	_data = Fixture.build(_directory)
+	_save_directory = "%s/testgame_01234567" % Gen2SaveStore.ROOT
+	_clear_saves()
+
+
+func after_each() -> void:
+	if is_instance_valid(_screen):
+		_screen.free()
+	_screen = null
+	if is_instance_valid(_party_screen):
+		_party_screen.free()
+	_party_screen = null
+	_clear_saves()
+	RomCache.clear(_directory)
+
+
+func _clear_saves() -> void:
+	for slot: int in Gen2SaveStore.SLOT_COUNT:
+		var path: String = Gen2SaveStore.path_for(_data.id, _data.sha1, slot)
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(path)
+	if DirAccess.dir_exists_absolute(_save_directory):
+		DirAccess.remove_absolute(_save_directory)
+
+
+func _save() -> Gen2SaveData:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.PIKACHU, 20, [Fixture.TACKLE, Fixture.THUNDERBOLT]
+	)
+	mon.status = Gen2Status.POISON
+	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
+		_data.id, _data.sha1, 1, Gen2Party.of(mon), "RED"
+	)
+	(save.party[0] as Gen2SaveMon).nickname = "SPARKY"
+	return save
+
+
+func _open_save_screen() -> void:
+	var packed: PackedScene = load("res://game/save/save_screen.tscn")
+	_screen = packed.instantiate()
+	_screen.set_data(_data)
+	add_child(_screen)
+	await get_tree().process_frame
+
+
+func _open_party_screen(save: Gen2SaveData) -> void:
+	var packed: PackedScene = load("res://game/save/party_screen.tscn")
+	_party_screen = packed.instantiate()
+	_party_screen.set_context(_data, save)
+	add_child(_party_screen)
+	await get_tree().process_frame
+
+
+func test_save_screen_shows_three_empty_slots() -> void:
+	await _open_save_screen()
+	var snapshot: Dictionary = _screen.save_screen_snapshot()
+	assert_eq(snapshot["selected_slot"], 0)
+	assert_eq((snapshot["slots"] as Array).size(), Gen2SaveStore.SLOT_COUNT)
+	for row: Dictionary in snapshot["slots"]:
+		assert_false(row["exists"])
+		assert_false(row["valid"])
+
+
+func test_save_screen_distinguishes_an_occupied_slot() -> void:
+	var write: Dictionary = Gen2SaveStore.save(_save(), _data)
+	assert_true(write["ok"], write["message"])
+	await _open_save_screen()
+	var snapshot: Dictionary = _screen.save_screen_snapshot()
+	var second: Dictionary = snapshot["slots"][1]
+	assert_true(second["exists"])
+	assert_true(second["valid"])
+	assert_true(_screen.select_slot(1))
+	assert_eq(_screen.save_screen_snapshot()["selected_slot"], 1)
+
+
+func test_save_screen_marks_an_invalid_existing_slot_incompatible() -> void:
+	var path: String = Gen2SaveStore.path_for(_data.id, _data.sha1, 0)
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(JSON.stringify({
+		"format_version": Gen2SaveData.FORMAT_VERSION,
+		"game_id": String(_data.id),
+		"rom_sha1": "different",
+		"slot": 0,
+		"player_name": "RED",
+		"party": [],
+	}))
+	file.close()
+	await _open_save_screen()
+	var first: Dictionary = _screen.save_screen_snapshot()["slots"][0]
+	assert_true(first["exists"])
+	assert_false(first["valid"])
+	assert_string_contains(first["message"], "different cartridge")
+
+
+func test_save_screen_creates_a_valid_new_game() -> void:
+	await _open_save_screen()
+	assert_true(_screen.create_new_game("ASH", 155))
+	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
+	assert_true(loaded["ok"], loaded["message"])
+	var save: Gen2SaveData = loaded["save"]
+	assert_eq(save.player_name, "ASH")
+	assert_eq((save.party[0] as Gen2SaveMon).species, 155)
+
+
+func test_save_screen_rejects_an_invalid_sram_without_creating_a_slot() -> void:
+	await _open_save_screen()
+	var path: String = "user://save-screen-invalid.sav"
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_buffer(PackedByteArray([0x01, 0x02, 0x03]))
+	file.close()
+	assert_false(_screen.import_sav_path(path))
+	assert_false(Gen2SaveStore.exists(_data.id, _data.sha1, 0))
+	DirAccess.remove_absolute(path)
+
+
+func test_party_screen_exposes_saved_hp_status_and_empty_positions() -> void:
+	var save: Gen2SaveData = _save()
+	await _open_party_screen(save)
+	var snapshot: Dictionary = _party_screen.party_snapshot()
+	assert_eq(snapshot["player_name"], "RED")
+	assert_eq(snapshot["slot"], 1)
+	var members: Array = snapshot["members"]
+	assert_eq(members.size(), Gen2SaveData.MAX_PARTY)
+	assert_eq((members[0] as Dictionary)["name"], "SPARKY")
+	assert_eq((members[0] as Dictionary)["status"], "POISON")
+	assert_false((members[0] as Dictionary)["empty"])
+	assert_true((members[1] as Dictionary)["empty"])

--- a/tests/unit/test_save_screen.gd.uid
+++ b/tests/unit/test_save_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://c714nyyy0q7e7


### PR DESCRIPTION
Add validated three-slot saves with new-game creation, original SRAM import, and party inspection. Connect the selected save to the development battle while preserving player and Pokemon identity on writeback. Add focused save and UI tests, documentation, and the next map and overworld handoff.