### PR TITLE
Add overworld battle recovery flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > verified dump, opens its cache's save screen, creates or imports a party, and
 > starts the development battle. The first overworld runtime slice now renders
 > real maps, moves through connected maps and hosts explicit script requests,
-> including battles. Full story state, audio and the mod loader do not exist
+> including real trainer battles, imported win/loss text, map reloads and
+> save-safe blackout recovery. Full story state, audio and the mod loader do not exist
 > yet, so this is not a complete game.
 
 ## Getting started
@@ -134,7 +135,9 @@ Development scenes:
 - `game/world/world_screen.tscn`: renders the development map with real
   palettes, animation and object sprites. Arrows/WASD move the player, and
   `preview_battle_request()` exercises the battle overlay used by explicit
-  overworld battle requests.
+  overworld battle requests. The battle screen's
+  `preview_world_battle_loss()` drives the recovery message for a visual smoke
+  check.
 
 ## Tests
 

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -38,6 +38,12 @@ player name, Pokémon identity, held item, happiness, Pokerus, caught data,
 nickname, original trainer, HP, status, experience, DVs, stat experience, moves
 and PP. Volatile battle state is discarded.
 
+Overworld battle writeback is transactional. A confirmed win is saved only
+after its visible result messages finish. A loss never overwrites the selected
+slot: the host validates and reconstructs the source save party, then returns a
+blackout recovery result to the overworld. Map position, inventory and broader
+blackout relocation are still outside this party-only save format.
+
 ## Original Generation 2 shape
 
 The model follows stable fields in the original Crystal source. `box_struct`

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -93,6 +93,9 @@ var _source_save: Gen2SaveData = null
 var _world_battle_active: bool = false
 var _world_battle_request: Dictionary = {}
 var _world_battle_completion_sent: bool = false
+var _world_battle_terminal_text_shown: bool = false
+var _world_battle_recovery_shown: bool = false
+var _world_battle_recovery: Dictionary = {}
 
 ## The trainer class behind the enemy's own moves, or zero for
 ## [method show_matchup]'s invented pairing, which has no class and so no AI
@@ -171,6 +174,9 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 	_world_battle_active = false
 	_world_battle_request = {}
 	_world_battle_completion_sent = false
+	_world_battle_terminal_text_shown = false
+	_world_battle_recovery_shown = false
+	_world_battle_recovery = {}
 	_enemy = _wrap_species(enemy)
 	_player = _wrap_species(player)
 	_enemy_level = enemy_level
@@ -206,6 +212,9 @@ func show_trainer(
 	_world_battle_active = false
 	_world_battle_request = {}
 	_world_battle_completion_sent = false
+	_world_battle_terminal_text_shown = false
+	_world_battle_recovery_shown = false
+	_world_battle_recovery = {}
 	var enemy_party: Gen2Party = Gen2TrainerParty.build(_data, trainer_class, index)
 	if enemy_party == null:
 		return
@@ -249,6 +258,9 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 	_world_battle_active = false
 	_world_battle_request = {}
 	_world_battle_completion_sent = false
+	_world_battle_terminal_text_shown = false
+	_world_battle_recovery_shown = false
+	_world_battle_recovery = {}
 	var player_party: Gen2Party = Gen2SaveBattleAdapter.to_battle_party(_data, save)
 	var enemy_party: Gen2Party = _party_from(DEFAULT_ENEMY, DEFAULT_LEVEL)
 	if player_party == null or enemy_party == null:
@@ -299,6 +311,9 @@ func start_world_battle(request: Dictionary, save: Gen2SaveData = null) -> bool:
 	_world_battle_active = true
 	_world_battle_request = (prepared.get("request", {}) as Dictionary).duplicate(true)
 	_world_battle_completion_sent = false
+	_world_battle_terminal_text_shown = false
+	_world_battle_recovery_shown = false
+	_world_battle_recovery = {}
 	_pending = []
 	_save_slot = save.slot if save != null else -1
 	_save_written = false
@@ -330,6 +345,30 @@ func start_world_battle(request: Dictionary, save: Gen2SaveData = null) -> bool:
 	else:
 		_announce()
 	return true
+
+
+## Public screenshot driver for the overworld battle recovery boundary. It
+## starts a real host battle using the fallback development party, then
+## completes it as a loss so the recovery message is visible without input.
+func preview_world_battle_loss() -> void:
+	if _world_battle_active or _data == null:
+		return
+	if not start_world_battle({
+		"kind": &"wild", "pokemon": DEFAULT_ENEMY, "level": DEFAULT_LEVEL,
+	}):
+		return
+	call_deferred("_preview_world_battle_loss")
+
+
+func _preview_world_battle_loss() -> void:
+	if not _world_battle_active or _battle == null:
+		return
+	for mon: Gen2BattleMon in _battle.party(Gen2Battle.PLAYER).mons:
+		mon.hp = 0
+	_read_hp()
+	finish()
+	advance()
+	finish()
 
 
 func _start_world_battle_from_meta(meta: Variant) -> void:
@@ -516,6 +555,15 @@ func advance() -> void:
 	if _replace_the_fallen():
 		return
 	if _battle != null and _battle.is_over():
+		if _world_battle_active:
+			if _show_world_battle_terminal_text():
+				return
+			if _battle.winner() != Gen2Battle.PLAYER and not _world_battle_recovery_shown:
+				if not _prepare_world_battle_recovery():
+					return
+				_world_battle_recovery_shown = true
+				show_message("Blackout! Party restored.")
+				return
 		if _save_battle_result() and _world_battle_active:
 			_finish_world_battle()
 		return
@@ -527,6 +575,8 @@ func advance() -> void:
 ## seen yet, while the persistent save model intentionally has no such state.
 func _save_battle_result() -> bool:
 	if _save_slot < 0 or _save_written or _battle == null:
+		return true
+	if _battle.winner() != Gen2Battle.PLAYER:
 		return true
 	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
 		_data.id, _data.sha1, _save_slot, _battle.party(Gen2Battle.PLAYER), "", _source_save
@@ -552,14 +602,67 @@ func _finish_world_battle() -> void:
 		if winner == Gen2Battle.PLAYER
 		else Gen2WorldBattleAdapter.OUTCOME_LOST
 	)
-	_world_battle_completion_sent = true
-	battle_finished.emit({
+	var result: Dictionary = {
 		"ok": true,
 		"outcome": outcome,
 		"winner": winner,
 		"request": _world_battle_request.duplicate(true),
 		"save_written": _save_written,
-	})
+	}
+	if outcome == Gen2WorldBattleAdapter.OUTCOME_LOST:
+		result["recovery"] = _world_battle_recovery.duplicate(true)
+	_world_battle_completion_sent = true
+	battle_finished.emit(result)
+
+
+func _show_world_battle_terminal_text() -> bool:
+	if _world_battle_terminal_text_shown:
+		return false
+	_world_battle_terminal_text_shown = true
+	var key: String = (
+		"win_text" if _battle.winner() == Gen2Battle.PLAYER else "loss_text"
+	)
+	var raw_pointer: Variant = _world_battle_request.get(key, {})
+	if not raw_pointer is Dictionary:
+		return false
+	var pointer: Dictionary = raw_pointer as Dictionary
+	var address: int = int(pointer.get("address", 0))
+	if address <= 0:
+		return false
+	var bank: int = int(pointer.get("bank", 0))
+	var raw: PackedByteArray = _data.world_text(bank, address)
+	var decoded: Dictionary = Gen2WorldScript.decode_text(raw)
+	if not bool(decoded.get("ok", false)):
+		_emit_world_battle_failure(&"missing_battle_result_text", {
+			"bank": bank, "address": address, "text_kind": key,
+		})
+		return true
+	var text: String = String(decoded.get("text", ""))
+	if text.is_empty():
+		return false
+	show_message(text)
+	return true
+
+
+func _prepare_world_battle_recovery() -> bool:
+	if _source_save == null:
+		_world_battle_recovery = {"ok": true, "source": &"development"}
+		return true
+	var validation: Dictionary = Gen2SaveValidator.validate(_source_save, _data)
+	if not bool(validation.get("ok", false)):
+		_emit_world_battle_failure(&"battle_recovery_failed", {
+			"message": validation.get("message", "invalid source save"),
+		})
+		return false
+	if Gen2SaveBattleAdapter.to_battle_party(_data, _source_save) == null:
+		_emit_world_battle_failure(&"battle_recovery_failed", {
+			"message": "the saved party could not be reconstructed",
+		})
+		return false
+	_world_battle_recovery = {
+		"ok": true, "source": &"save", "slot": _source_save.slot,
+	}
+	return true
 
 
 ## Sends out the first Pokémon standing on any side that owes one, and answers

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -305,6 +305,11 @@ func complete_runtime_request(result: Dictionary) -> Array:
 	if StringName(advanced.get("status", &"")) == &"waiting":
 		results.append(advanced)
 		return results
+	if StringName(advanced.get("status", &"")) == &"recovered":
+		results.append(advanced)
+		_active_script = null
+		_script_queue.clear()
+		return results
 	if bool(advanced.get("ok", false)):
 		results.append(_finish_script_result(advanced))
 	else:
@@ -983,6 +988,16 @@ func _apply_map(
 	player_cell = _clamp_cell(target_cell)
 	_load_objects()
 	_queue_map_callbacks(-1)
+
+
+## Reloads the current map's live object records without changing the player
+## cell or queuing a second map transition. This is the host effect of
+## [code]reloadmapafterbattle[/code] when the suspended script resumes.
+func reload_current_map() -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return {"ok": false, "reason": &"missing_map"}
+	_load_objects()
+	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}
 
 
 func _on_world_state_changed() -> void:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -224,8 +224,11 @@ func _show_script_results(results: Array) -> void:
 	var waiting: bool = false
 	var failed: bool = false
 	var map_changed: bool = false
+	var recovered: bool = false
+	var recovery_prompt: String = ""
 	for result: Dictionary in results:
-		if StringName(result.get("status", &"")) == &"waiting":
+		var status: StringName = StringName(result.get("status", &""))
+		if status == &"waiting":
 			waiting = true
 			var event: Dictionary = result.get("event", {})
 			var event_type: StringName = StringName(event.get("type", &""))
@@ -249,21 +252,39 @@ func _show_script_results(results: Array) -> void:
 				_script_prompt = "Runtime request: %s, press Space to acknowledge" % String(
 					request.get("kind", "effect")
 				)
+		elif status == &"recovered":
+			recovered = true
 		elif not bool(result.get("ok", false)):
 			failed = true
 			_script_prompt = "Script stopped: %s" % String(result.get("reason", "unknown"))
 		for result_event: Dictionary in result.get("events", []):
 			if result_event.get("type", &"") == &"warp":
 				map_changed = true
+			elif result_event.get("type", &"") == &"battle_map_reload_requested":
+				map_changed = true
+			elif result_event.get("type", &"") == &"blackout":
+				recovered = true
+				var recovery: Variant = result_event.get("recovery", {})
+				var source: StringName = StringName(
+					recovery.get("source", &"save") if recovery is Dictionary else &"save"
+				)
+				recovery_prompt = (
+					"Blackout recovered from the development party"
+					if source == &"development"
+					else "Blackout recovered from the last saved party"
+				)
 			elif result_event.get("type", &"") in [
 				&"item_changed", &"money_changed", &"coins_changed", &"movement_blocked",
 				&"movement_failed",
 			]:
 				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
-	if not waiting and not failed:
+	if recovered and not recovery_prompt.is_empty():
+		_script_prompt = recovery_prompt
+	elif not waiting and not failed:
 		_script_prompt = ""
 	if _renderer != null:
 		if map_changed:
+			_world.reload_current_map()
 			_animation.configure(_world, time_of_day)
 			_renderer.set_world(_world, _animation)
 			_renderer.set_time_of_day(time_of_day)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -118,8 +118,8 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 
 
 ## Completes a host-owned runtime request without treating a button press as its
-## result. Battle loss is deliberately a structured failure until blackout and
-## save-backed recovery have a canonical host model.
+## result. A confirmed loss ends this invocation through the explicit blackout
+## recovery result without committing its staged world state.
 func complete_runtime_request(result: Dictionary) -> Dictionary:
 	if _pending.is_empty() or _pending.get("type", &"") != &"runtime_request":
 		return {
@@ -140,6 +140,24 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 	var outcome: StringName = StringName(result.get("outcome", &""))
 	if String(outcome).is_empty():
 		return _fail(&"invalid_battle_outcome", result)
+	if outcome == Gen2WorldBattleAdapter.OUTCOME_LOST:
+		var recovery: Variant = result.get("recovery", {})
+		if not recovery is Dictionary or not bool((recovery as Dictionary).get("ok", false)):
+			return _fail(&"battle_recovery_failed", result)
+		_events.append({
+			"type": &"battle_lost",
+			"outcome": outcome,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_events.append({
+			"type": &"blackout",
+			"recovery": (recovery as Dictionary).duplicate(true),
+		})
+		_pending = {}
+		_active = false
+		_completed = true
+		return _recovered_result(recovery as Dictionary)
 	if outcome != Gen2WorldBattleAdapter.OUTCOME_WON:
 		return _fail(StringName("battle_%s" % outcome), result)
 
@@ -185,7 +203,7 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 	var object_result: Dictionary = _execute_object_command(source_opcode, command)
 	if not object_result.is_empty():
 		return object_result
-	var later_result: Dictionary = _execute_later_command(source_opcode, command)
+	var later_result: Dictionary = _execute_later_command(source_opcode, command, bank)
 	if not later_result.is_empty():
 		return later_result
 	if Gen2WorldScript.is_terminal(opcode, _crystal_commands()):
@@ -362,30 +380,30 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 	}
 
 
-func _execute_later_command(source_opcode: int, command: Dictionary) -> Dictionary:
+func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
 	match source_opcode:
 		0x57, 0x58:
 			return _stage_menu(source_opcode == 0x57, command)
 		0x5C:
-			_battle_setup = {
+			_battle_setup = _new_battle_setup({
 				"kind": &"wild", "pokemon": int(command.get("pokemon", 0)),
 				"level": int(command.get("level", 0)),
-			}
+			})
 			_emit_runtime_event(&"battle_setup_changed", _battle_setup)
 		0x5D:
-			_battle_setup = {
+			_battle_setup = _new_battle_setup({
 				"kind": &"trainer", "trainer_group": int(command.get("trainer_group", 0)),
 				"trainer_id": int(command.get("trainer_id", 0)),
-			}
+			})
 			_emit_runtime_event(&"battle_setup_changed", _battle_setup)
 		0x5E:
 			if _battle_setup.is_empty():
 				return {
 					"ok": false, "reason": &"battle_setup_missing", "command": command,
 				}
-			return _stage_runtime_request(&"battle_requested", _battle_setup)
+			return _stage_runtime_request(&"battle_requested", _battle_request_values())
 		0x5F:
-			_emit_runtime_event(&"battle_map_reload_requested", {})
+			_emit_runtime_event(&"battle_map_reload_requested", {"requested": true})
 		0x60:
 			return _stage_runtime_request(&"catch_tutorial_requested", {
 				"value": int(command.get("value", 0)),
@@ -404,8 +422,12 @@ func _execute_later_command(source_opcode: int, command: Dictionary) -> Dictiona
 				"script_value": _script_value,
 			})
 		0x63:
-			_battle_setup["win_address"] = int(command.get("win_address", 0))
-			_battle_setup["loss_address"] = int(command.get("loss_address", 0))
+			_battle_setup["win_text"] = {
+				"bank": bank, "address": int(command.get("win_address", 0)),
+			}
+			_battle_setup["loss_text"] = {
+				"bank": bank, "address": int(command.get("loss_address", 0)),
+			}
 		0x64:
 			_emit_runtime_event(&"trainer_talk_after_requested", {})
 		0x65:
@@ -915,6 +937,38 @@ func _complete_result() -> Dictionary:
 		"warp": _staged_warp.duplicate(true),
 		"commands": _command_count,
 	}
+
+
+func _recovered_result(recovery: Dictionary) -> Dictionary:
+	return {
+		"ok": true,
+		"status": &"recovered",
+		"events": _events.duplicate(true),
+		"source": _request.duplicate(true),
+		"recovery": recovery.duplicate(true),
+		"commands": _command_count,
+	}
+
+
+func _new_battle_setup(base: Dictionary) -> Dictionary:
+	var out: Dictionary = base.duplicate(true)
+	for key: String in ["win_text", "loss_text"]:
+		if _battle_setup.has(key):
+			out[key] = (_battle_setup[key] as Dictionary).duplicate(true)
+	return out
+
+
+func _battle_request_values() -> Dictionary:
+	var out: Dictionary = _battle_setup.duplicate(true)
+	var source_event: Variant = _request.get("event", {})
+	if source_event is Dictionary:
+		out["event"] = (source_event as Dictionary).duplicate(true)
+	for key: String in [
+		"map_group", "map_number", "object_index", "distance", "direction", "trigger",
+	]:
+		if _request.has(key):
+			out[key] = _request[key]
+	return out
 
 
 func _waiting_result() -> Dictionary:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -540,6 +540,56 @@ func test_script_menu_and_battle_are_explicit_runtime_requests() -> void:
 	))
 
 
+func test_battle_request_keeps_trainer_source_and_result_text_pointers() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6090": [
+			0x64, 0x00, 0x70, 0x00, 0x71,
+			0x5E, 1, 0,
+			0x5F,
+			0x91,
+		],
+	})
+	data = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"sight", "map_group": 1, "map_number": 1, "bank": 48,
+		"script": 0x6090, "object_index": 2,
+		"distance": 3, "direction": Vector2i.DOWN,
+		"event": {"event_flag": 0x1234, "object_index": 2},
+	})
+	var waiting: Dictionary = runner.advance()
+	assert_eq(waiting["status"], &"waiting")
+	var values: Dictionary = waiting["event"]["request"]["values"]
+	assert_eq(values["kind"], &"trainer")
+	assert_eq(values["trainer_group"], 1)
+	assert_eq(values["trainer_id"], 0)
+	assert_eq(values["event"]["event_flag"], 0x1234)
+	assert_eq(values["object_index"], 2)
+	assert_eq(values["distance"], 3)
+	assert_eq(values["win_text"]["bank"], 48)
+	assert_eq(values["win_text"]["address"], 0x7000)
+	assert_eq(values["loss_text"]["address"], 0x7100)
+
+
+func test_reloadmapafterbattle_is_reported_after_a_confirmed_win() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:60A0": [0x5D, 25, 5, 0x5F, 0x60, 0x91],
+	})
+	data = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x60A0,
+	})
+	assert_eq(runner.advance()["status"], &"waiting")
+	var complete: Dictionary = runner.complete_runtime_request({
+		"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_WON,
+	})
+	assert_eq(complete["status"], &"complete")
+	assert_true(complete["events"].any(func(event: Dictionary) -> bool:
+		return event.get("type", &"") == &"battle_map_reload_requested"
+	))
+
+
 func test_world_battle_completion_commits_just_battled_only_after_the_host_result() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
@@ -575,12 +625,44 @@ func test_world_battle_loss_fails_without_committing_world_state() -> void:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
 	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
 
+	var recovered: Array = world.complete_runtime_request({
+		"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_LOST,
+		"recovery": {"ok": true, "source": &"save", "slot": 0},
+	})
+	assert_eq(recovered[0]["status"], &"recovered")
+	assert_true(recovered[0]["events"].any(func(event: Dictionary) -> bool:
+		return event.get("type", &"") == &"blackout"
+	))
+	assert_false(world.state.just_battled())
+	assert_true(world.pending_runtime_request().is_empty())
+
+
+func test_world_battle_loss_requires_host_recovery_before_ending() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6098": [0x5D, 25, 5, 0x5F, 0x91],
+	})
+	data = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6098
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+
 	var failed: Array = world.complete_runtime_request({
 		"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_LOST,
 	})
 	assert_eq(failed[0]["status"], &"failed")
-	assert_eq(failed[0]["reason"], &"battle_lost")
+	assert_eq(failed[0]["reason"], &"battle_recovery_failed")
 	assert_false(world.state.just_battled())
+
+
+func test_reloading_the_current_map_rebuilds_live_objects_without_moving_player() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(5, 6))
+	var before: Vector2i = world.player_cell
+	var reloaded: Dictionary = world.reload_current_map()
+	assert_true(reloaded["ok"])
+	assert_eq(reloaded["kind"], &"reload_map")
+	assert_eq(world.player_cell, before)
+	assert_eq(world.objects.size(), 1)
 
 
 func test_world_battle_requires_an_explicit_outcome() -> void:


### PR DESCRIPTION
Carry trainer context and imported win/loss text through the battle host. Require validated recovery on loss, protect saves from loss writeback, refresh live map objects after reloadmapafterbattle, and cover the result boundary with tests and documentation. Verified with 686 tests and 6410 assertions.