### PR TITLE
Shrink the cache, pace world animation by time, and add the mod boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > Poké Ball catch calculation behind a validated candidate-save boundary; wild
 > capture input uses that transaction.
 >
-> Full story state, complete phone UI and the mod loader do not exist yet, so
-> this is not a complete game. Scene-level integration tests cover trainer sight,
+> Full story state and the complete phone UI do not exist yet, so this is not a
+> complete game. The mod boundary is in: a mod under `user://mods/` can register
+> a replacement world renderer, which is what a 3D or HD view needs. Scene-level integration tests cover trainer sight,
 > imported terminal text, live object refresh, emotes, wild capture, save-backed
 > blackout recovery and all four service overlay modes.
 
@@ -194,6 +195,7 @@ marts, phone calls and audio requests.
 | `tests/` | GUT unit and integration tests |
 | `tools/` | Headless developer scripts |
 | `roms/` | User cartridges, excluded from Git and Godot imports |
+| `game/mods/` | Mod manifest and host |
 | `docs/` | Contributor notes |
 
 ## Platforms
@@ -201,7 +203,7 @@ marts, phone calls and audio requests.
 Windows, macOS, Linux, Android and iOS use GL Compatibility. Export presets
 are not configured. iOS forbids JIT and runtime native code, so mods must be
 interpreted GDScript, not compiled extensions. The project is therefore
-GDScript-first.
+GDScript-first. See [docs/MODS.md](docs/MODS.md).
 
 ## Contributing
 

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -2,12 +2,20 @@ extends Node
 
 ## Runtime selection shared by the launcher and screens opened from it.
 ##
-## This stores only identifiers. Cartridge bytes, decoded data and save data
-## remain owned by their existing layers and are opened when a screen needs
-## them.
+## Cartridge bytes and decoded data remain owned by their existing layers. The
+## selected save is the one exception: it is mutable, and every screen that
+## reads it has to be looking at the same one.
+##
+## Re-reading the slot per call returned a fresh instance each time, so a battle
+## result, a party transaction and a world snapshot each held a different save
+## and only whichever wrote last survived. The slot is loaded once here and kept
+## until the selection changes or a caller asks for it again from disk.
 
 var selected_game_id: StringName = &""
 var selected_save_slot: int = -1
+
+var _save: Gen2SaveData = null
+var _save_key: String = ""
 
 
 func select_game(game_id: StringName) -> bool:
@@ -15,6 +23,7 @@ func select_game(game_id: StringName) -> bool:
 		return false
 	if selected_game_id != game_id:
 		selected_save_slot = -1
+		reload_selected_save()
 	selected_game_id = game_id
 	return true
 
@@ -34,6 +43,8 @@ func select_save_slot(game_id: StringName, slot: int) -> bool:
 		return false
 	if not select_game(game_id):
 		return false
+	if selected_save_slot != slot:
+		reload_selected_save()
 	selected_save_slot = slot
 	return true
 
@@ -42,13 +53,30 @@ func has_selected_save_slot() -> bool:
 	return has_selected_game() and selected_save_slot >= 0
 
 
+## The selected slot, loaded once and shared. Callers may mutate it and write it
+## back through [Gen2SaveStore]; they are all holding the same save.
 func selected_save() -> Gen2SaveData:
 	if not has_selected_save_slot():
 		return null
+	var key: String = "%s:%d" % [selected_game_id, selected_save_slot]
+	if _save != null and _save_key == key:
+		return _save
 	var data: GameData = selected_data()
 	if data == null:
 		return null
 	var result: Dictionary = Gen2SaveStore.load_result(
 		data.id, data.sha1, selected_save_slot, data
 	)
-	return result["save"] if result["ok"] else null
+	if not result["ok"]:
+		return null
+	_save = result["save"]
+	_save_key = key
+	return _save
+
+
+## Drops the loaded save so the next read comes from disk again. For a caller
+## that has just rewritten the slot behind this one's back, such as an original
+## cartridge import.
+func reload_selected_save() -> void:
+	_save = null
+	_save_key = ""

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,9 +43,24 @@ keep rules separate from content and receive an injected
 | `text_codec.gd` | Generation 2 character encoding |
 | `palette.gd` | 15-bit BGR colours |
 | `rom_layout.gd` | Per-game table locations |
-| `rom_cache.gd` | Cache paths, formats and lifecycle |
+| `rom_cache.gd` | Cache paths, formats, payload blobs and lifecycle |
 | `world_services_importer.gd` | Menus, marts, phone records, audio pointers, cries and shared waveforms |
 | `rom_importer.gd` | Orchestration and layout checks |
+
+Raw cartridge byte runs do not go into JSON. A decimal array costs about four
+bytes on disk per cartridge byte and about twenty-six resident once parsed into
+an Array of Variants, which made scripts, text and audio 96 MB of a 100 MB
+cache. Write them with `RomCache.write_payload_map()` when the run is a whole
+value in a pointer map, or `RomCache.write_section()` when it is a `bytes`
+field of a record; both move the bytes into a `.bin` blob and leave an
+`[offset, length]` span in the JSON. `GameData` reads the blob as a
+`PackedByteArray` and hands the bytes back under `bytes`. Only a named `bytes`
+field is moved: plenty of cached arrays are small numbers without being
+payloads, and a mart list or an encounter rate must stay an array.
+
+World sections load on first use. The launcher, the pic viewer and a battle
+never read scripts, text or audio, and eagerly reading them made listing three
+games cost more than entering one.
 
 Decoders take bytes and return data, with no cartridge knowledge, so small
 hand-built inputs can test them. `game/data/game_data.gd` is the sole
@@ -88,6 +103,17 @@ scene nodes and audio devices so synthetic records can test headers, pointers,
 loops, timing and truncation. The renderer is deterministic and bounded; do
 not turn unsupported modulation into an unbounded stream or claim byte-level
 hardware fidelity.
+
+### Mods
+
+`game/mods/mod_manifest.gd` validates a mod's `mod.json` without running any of
+it; `game/mods/mod_host.gd` is the registry a mod is handed. The world screen
+constructs its renderer through the host, so a registered renderer replaces the
+view without the screen knowing what it draws with. Keep mods away from scene
+nodes and engine internals: a mod reaches cartridge content through `GameData`
+and world state through `Gen2WorldAPI`, both scene-free. See
+[MODS.md](MODS.md) for the contract and why a renderer must not write world
+state.
 
 ### Rendering and text
 

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1,0 +1,78 @@
+# Mods
+
+A mod is interpreted GDScript in a directory under `user://mods/`. iOS forbids
+JIT and loading native code at runtime, so a distributed mod cannot be a
+compiled extension.
+
+Mods never touch scene nodes or engine internals. A mod is handed
+`Gen2ModHost`, registers what it provides, and returns. Everything it can reach
+is cartridge content through `GameData` or live world state through
+`Gen2WorldAPI`, both of which are scene-free.
+
+## Layout
+
+```
+user://mods/<id>/
+  mod.json
+  mod.gd
+```
+
+`mod.json`:
+
+| Field | Meaning |
+|---|---|
+| `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
+| `name` | Shown to the player |
+| `version` | The mod's own version, not the host's |
+| `api_version` | Must equal `Gen2ModManifest.API_VERSION` |
+| `entry` | A `.gd` path inside the mod directory |
+| `description` | Optional |
+
+An entry that is absolute, contains `..` or is not GDScript is refused before
+anything runs. Manifests are read without executing mod code, so a launcher can
+list what is installed and say why something was rejected.
+
+`mod.gd` defines one method:
+
+```gdscript
+extends RefCounted
+
+func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
+	host.register_world_renderer(manifest.id, load("%s/renderer.gd" % manifest.directory), "Voxel")
+```
+
+A mod that fails to load is reported through `Gen2ModHost.failures()` and
+skipped. One broken mod does not stop the others and does not stop the game.
+
+## Replacing the world renderer
+
+The 2D renderer reads the world and draws it. Nothing about the world requires
+that the drawing be 2D: maps are node-free `RefCounted` records, each tileset is
+one addressable atlas, animated tiles replace atlas slots rather than map
+rectangles, and collision is a raw permission byte per 2x2 walk cell. A renderer
+that extrudes geometry from that same data is a registration, not a fork.
+
+A registered renderer is a `Node` providing:
+
+| Method | Called when |
+|---|---|
+| `set_world(world, animation)` | The map changed, or the view was created |
+| `set_time_of_day(time_of_day)` | The clock crossed 04:00, 10:00 or 18:00 |
+| `refresh()` | The player, an object or an event changed something |
+| `refresh_animation()` | A tileset animation command changed tile data |
+
+Registration is refused, by name, if any of these is missing or the script is
+not a `Node`, rather than failing on the first drawn frame.
+
+The host constructs a renderer per world, so `select_world_renderer()` can
+switch between the built-in `gen2` renderer and a mod's while the game runs. A
+renderer reads world state and must not write it: two views of one world have to
+agree.
+
+## Not built yet
+
+Semver ranges and inter-mod dependencies, per-mod save data, event hooks beyond
+the renderer, and `.zip`/`.pck` packs through
+`ProjectSettings.load_resource_pack()`. Evaluate
+[godot-mod-loader](https://github.com/GodotModding/godot-mod-loader) before
+expanding the loader itself.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -15,6 +15,12 @@ extends RefCounted
 ## Index buffers are loaded on first use and kept. A pic atlas is a megabyte or
 ## so of indices; reading four of them to draw one sprite would be a waste, and
 ## re-reading one per frame would be worse.
+##
+## The world sections are read the same way, for a blunter reason: scripts, text
+## and audio are almost all of a cache, and the launcher, the pic viewer and a
+## battle never look at any of them. Reading them at open() made listing three
+## games cost more than entering one, and put the whole cache in memory on a
+## phone that has no room for it.
 
 var id: StringName = &""
 var sha1: String = ""
@@ -50,6 +56,10 @@ var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
 var _world_phone: Dictionary = {}
 var _world_audio: Dictionary = {}
+## Which of the sections above have been read. A section that is genuinely empty
+## is indistinguishable from one that has not been read yet, so the answer is
+## recorded rather than inferred from the value.
+var _sections: Dictionary = {}
 
 
 ## Opens the cache for a registry game, or null if it has not been imported.
@@ -81,7 +91,6 @@ static func open_directory(path: String) -> GameData:
 	data._types = data._read_array(RomCache.types_path(path))
 	data._trainers = data._read_array(RomCache.trainers_path(path))
 	data._build_matchups(data._read_array(RomCache.matchups_path(path)))
-	data._load_world(path)
 	return data
 
 
@@ -104,70 +113,70 @@ func species_count() -> int:
 
 
 func map_count() -> int:
-	return _world_maps.size()
+	return _maps().size()
 
 
 ## One map by its stable cartridge group and number, or null when it is absent.
 func world_map(group: int, number: int) -> Gen2WorldMap:
-	for value: Gen2WorldMap in _world_maps:
+	for value: Gen2WorldMap in _maps():
 		if value.group == group and value.number == number:
 			return value
 	return null
 
 
 func world_maps() -> Array:
-	return _world_maps.duplicate()
+	return _maps().duplicate()
 
 
 ## Raw bounded script bytes indexed by the cartridge's bank and CPU address.
 ## Runtime never opens a ROM; these bytes come from the user cache only.
 func world_script(bank: int, address: int) -> PackedByteArray:
-	return _cached_bytes(_world_scripts.get(Gen2WorldScript.pointer_key(bank, address), []))
+	return _cached_bytes(_scripts().get(Gen2WorldScript.pointer_key(bank, address), []))
 
 
 ## One imported menu header referenced by an overworld script.
 func world_menu(bank: int, address: int) -> Dictionary:
-	var value: Variant = _world_menus.get(Gen2WorldScript.pointer_key(bank, address), {})
+	var value: Variant = _menus().get(Gen2WorldScript.pointer_key(bank, address), {})
 	return _coerce_service_dictionary(value)
 
 
 func world_menu_count() -> int:
-	return _world_menus.size()
+	return _menus().size()
 
 
 ## One mart item list by the source MART_* index, or the default list when the
 ## cartridge requested an index outside the static table.
 func world_mart(index: int) -> Dictionary:
-	var rows: Variant = _world_marts.get("marts", [])
+	var rows: Variant = _marts().get("marts", [])
 	if rows is Array and index >= 0 and index < (rows as Array).size():
 		return _coerce_service_dictionary((rows as Array)[index])
-	var default_value: Variant = _world_marts.get("default", {})
+	var default_value: Variant = _marts().get("default", {})
 	return _coerce_service_dictionary(default_value)
 
 
 func world_mart_count() -> int:
-	var rows: Variant = _world_marts.get("marts", [])
+	var rows: Variant = _marts().get("marts", [])
 	return (rows as Array).size() if rows is Array else 0
 
 
 func world_phone_contact(index: int) -> Dictionary:
-	return _service_row(_world_phone.get("contacts", []), index)
+	return _service_row(_phone().get("contacts", []), index)
 
 
 func world_special_phone_call(index: int) -> Dictionary:
-	return _service_row(_world_phone.get("special_calls", []), index)
+	return _service_row(_phone().get("special_calls", []), index)
 
 
 func world_phone_contact_count() -> int:
-	return _service_rows_count(_world_phone.get("contacts", []))
+	return _service_rows_count(_phone().get("contacts", []))
 
 
 func world_audio(kind: StringName, index: int) -> Dictionary:
-	return _service_row(_world_audio.get(String(kind), []), index)
+	return _service_row(_audio().get(String(kind), []), index)
 
 
 func world_audio_pointer(kind: StringName, bank: int, address: int) -> Dictionary:
-	var rows: Variant = _world_audio.get(String(kind), [])
+	var rows: Variant = _audio().get(String(kind), [])
 	if not rows is Array:
 		return {}
 	for value: Dictionary in rows as Array:
@@ -177,7 +186,7 @@ func world_audio_pointer(kind: StringName, bank: int, address: int) -> Dictionar
 
 
 func world_audio_asset(kind: StringName) -> Dictionary:
-	var value: Variant = _world_audio.get(String(kind), {})
+	var value: Variant = _audio().get(String(kind), {})
 	return _coerce_service_dictionary(value)
 
 
@@ -187,19 +196,19 @@ func world_audio_asset_bytes(kind: StringName) -> PackedByteArray:
 
 func world_service_counts() -> Dictionary:
 	return {
-		"menus": _world_menus.size(),
+		"menus": _menus().size(),
 		"marts": world_mart_count(),
 		"phone_contacts": world_phone_contact_count(),
-		"music": _service_rows_count(_world_audio.get("music", [])),
-		"sfx": _service_rows_count(_world_audio.get("sfx", [])),
-		"cries": _service_rows_count(_world_audio.get("cries", [])),
+		"music": _service_rows_count(_audio().get("music", [])),
+		"sfx": _service_rows_count(_audio().get("sfx", [])),
+		"cries": _service_rows_count(_audio().get("cries", [])),
 	}
 
 
 ## One standard-script entry by its source table index. The pointer is retained
 ## for diagnostics, while the bounded bytes keep the runtime independent of ROMs.
 func world_standard_script(index: int) -> Dictionary:
-	var value: Variant = _world_standard_scripts.get(str(index), {})
+	var value: Variant = _standard_scripts().get(str(index), {})
 	if not value is Dictionary:
 		return {}
 	var entry: Dictionary = (value as Dictionary).duplicate(true)
@@ -211,21 +220,21 @@ func world_standard_script(index: int) -> Dictionary:
 
 ## Raw bounded text bytes indexed by the cartridge's bank and CPU address.
 func world_text(bank: int, address: int) -> PackedByteArray:
-	return _cached_bytes(_world_text.get(Gen2WorldScript.pointer_key(bank, address), []))
+	return _cached_bytes(_text().get(Gen2WorldScript.pointer_key(bank, address), []))
 
 
 ## Raw bounded movement bytes indexed by the script bank and movement pointer.
 func world_movement(bank: int, address: int) -> PackedByteArray:
-	return _cached_bytes(_world_movements.get(Gen2WorldScript.pointer_key(bank, address), []))
+	return _cached_bytes(_movements().get(Gen2WorldScript.pointer_key(bank, address), []))
 
 
 ## One decoded tileset's metatile and collision tables, or null if absent.
 func world_tileset(number: int) -> Gen2WorldTileset:
-	return _world_tilesets.get(number, null)
+	return _tilesets().get(number, null)
 
 
 func world_tileset_count() -> int:
-	return _world_tilesets.size()
+	return _tilesets().size()
 
 
 ## One normal encounter record by method and map group/number. The runtime
@@ -233,7 +242,7 @@ func world_tileset_count() -> int:
 ## "water" name.
 func world_encounter(method: StringName, group: int, number: int) -> Dictionary:
 	var table_name: String = "water" if method == &"surf" else String(method)
-	var table: Variant = _world_encounters.get(table_name, {})
+	var table: Variant = _encounters().get(table_name, {})
 	if not table is Dictionary:
 		return {}
 	var value: Variant = (table as Dictionary).get("%d:%d" % [group, number], {})
@@ -245,7 +254,7 @@ func world_encounter(method: StringName, group: int, number: int) -> Dictionary:
 func world_fishing_group(group: int) -> Dictionary:
 	if group < 1:
 		return {}
-	var fishing: Variant = _world_encounters.get("fishing", {})
+	var fishing: Variant = _encounters().get("fishing", {})
 	if not fishing is Dictionary:
 		return {}
 	var groups: Variant = (fishing as Dictionary).get("groups", [])
@@ -258,7 +267,7 @@ func world_fishing_group(group: int) -> Dictionary:
 ## The twenty-two day/night fishing substitutions used by entries whose
 ## species byte is zero in the cartridge stream.
 func world_fishing_time_groups() -> Array:
-	var fishing: Variant = _world_encounters.get("fishing", {})
+	var fishing: Variant = _encounters().get("fishing", {})
 	if not fishing is Dictionary:
 		return []
 	var groups: Variant = (fishing as Dictionary).get("time_groups", [])
@@ -266,7 +275,7 @@ func world_fishing_time_groups() -> Array:
 
 
 func world_roaming_maps() -> Array:
-	var roaming: Variant = _world_encounters.get("roaming", {})
+	var roaming: Variant = _encounters().get("roaming", {})
 	if not roaming is Dictionary:
 		return []
 	var maps: Variant = (roaming as Dictionary).get("maps", [])
@@ -274,7 +283,7 @@ func world_roaming_maps() -> Array:
 
 
 func world_roaming_mons() -> Array:
-	var roaming: Variant = _world_encounters.get("roaming", {})
+	var roaming: Variant = _encounters().get("roaming", {})
 	if not roaming is Dictionary:
 		return []
 	var mons: Variant = (roaming as Dictionary).get("mons", [])
@@ -283,19 +292,19 @@ func world_roaming_mons() -> Array:
 
 func world_encounter_count(method: StringName) -> int:
 	var table_name: String = "water" if method == &"surf" else String(method)
-	var table: Variant = _world_encounters.get(table_name, {})
+	var table: Variant = _encounters().get(table_name, {})
 	return (table as Dictionary).size() if table is Dictionary else 0
 
 
 ## Metadata for one cartridge overworld sprite, indexed by the source sprite
 ## number. Sprite number zero is reserved for no sprite by the cartridge.
 func overworld_sprite(number: int) -> Gen2WorldSprite:
-	var row: Dictionary = _entry(_overworld_sprites, number - 1)
+	var row: Dictionary = _entry(_sprites(), number - 1)
 	return Gen2WorldSprite.from_cache(row) if not row.is_empty() else null
 
 
 func overworld_sprite_count() -> int:
-	return _overworld_sprites.size()
+	return _sprites().size()
 
 
 ## Indexed pixels for one raw overworld sprite tile strip, loaded on demand.
@@ -316,9 +325,9 @@ func overworld_sprite_indices(number: int) -> PackedByteArray:
 func overworld_sprite_palette(palette: int, time_of_day: int) -> PackedColorArray:
 	var group: int = clampi(time_of_day, 0, 3) * RomLayout.OVERWORLD_SPRITE_PALETTE_COUNT \
 		+ (palette & (RomLayout.OVERWORLD_SPRITE_PALETTE_COUNT - 1))
-	if group < 0 or group >= _overworld_sprite_palettes.size():
+	if group < 0 or group >= _sprite_palettes().size():
 		return PackedColorArray()
-	var raw: Variant = _overworld_sprite_palettes[group]
+	var raw: Variant = _sprite_palettes()[group]
 	if not raw is Array:
 		return PackedColorArray()
 	var out := PackedColorArray()
@@ -329,9 +338,9 @@ func overworld_sprite_palette(palette: int, time_of_day: int) -> PackedColorArra
 
 ## One of the cartridge's four-colour background palette groups.
 func world_palette(number: int) -> PackedColorArray:
-	if number < 0 or number >= _world_palettes.size():
+	if number < 0 or number >= _palettes().size():
 		return PackedColorArray()
-	var raw: Variant = _world_palettes[number]
+	var raw: Variant = _palettes()[number]
 	if not raw is Array:
 		return PackedColorArray()
 	var out := PackedColorArray()
@@ -342,7 +351,7 @@ func world_palette(number: int) -> PackedColorArray:
 
 ## Raw 2bpp frames embedded in the cartridge's animation routines.
 func world_animation_asset(name: String) -> PackedByteArray:
-	var raw: Variant = _world_animation_assets.get(name, [])
+	var raw: Variant = _animation_assets().get(name, [])
 	if not raw is Array:
 		return PackedByteArray()
 	var out := PackedByteArray()
@@ -739,63 +748,122 @@ func unown_pic(form: int, back: bool = false) -> Dictionary:
 	return pic
 
 
-func _load_world(path: String) -> void:
-	var map_rows: Variant = RomCache.read_json(RomCache.world_maps_path(path))
-	if map_rows is Array:
-		for value: Dictionary in map_rows as Array:
+## True once [param section] has been read, marking it read on the first ask.
+## The caller fills the matching member; a section is only ever read once.
+func _claim_section(section: String) -> bool:
+	if _sections.has(section):
+		return false
+	_sections[section] = true
+	return true
+
+
+## One cached world file, as an Array or a Dictionary. A file that is missing or
+## the wrong shape answers empty, which is the same answer an unimported section
+## gave before these became lazy.
+func _read_section(path: String, as_array: bool) -> Variant:
+	var value: Variant = RomCache.read_json(path)
+	if as_array:
+		return value if value is Array else []
+	return value if value is Dictionary else {}
+
+
+func _maps() -> Array:
+	if _claim_section("maps"):
+		for value: Dictionary in _read_section(RomCache.world_maps_path(directory), true):
 			_world_maps.append(Gen2WorldMap.from_cache(value))
+	return _world_maps
 
-	var script_rows: Variant = RomCache.read_json(RomCache.world_scripts_path(path))
-	if script_rows is Dictionary:
-		_world_scripts = script_rows
-	var standard_script_rows: Variant = RomCache.read_json(
-		RomCache.world_standard_scripts_path(path)
-	)
-	if standard_script_rows is Dictionary:
-		_world_standard_scripts = standard_script_rows
-	var text_rows: Variant = RomCache.read_json(RomCache.world_text_path(path))
-	if text_rows is Dictionary:
-		_world_text = text_rows
-	var movement_rows: Variant = RomCache.read_json(RomCache.world_movements_path(path))
-	if movement_rows is Dictionary:
-		_world_movements = movement_rows
 
-	var tileset_rows: Variant = RomCache.read_json(RomCache.world_tilesets_path(path))
-	if tileset_rows is Array:
-		for value: Dictionary in tileset_rows as Array:
+func _scripts() -> Dictionary:
+	if _claim_section("scripts"):
+		_world_scripts = _read_section(RomCache.world_scripts_path(directory), false)
+	return _world_scripts
+
+
+func _standard_scripts() -> Dictionary:
+	if _claim_section("standard_scripts"):
+		_world_standard_scripts = _read_section(
+			RomCache.world_standard_scripts_path(directory), false
+		)
+	return _world_standard_scripts
+
+
+func _text() -> Dictionary:
+	if _claim_section("text"):
+		_world_text = _read_section(RomCache.world_text_path(directory), false)
+	return _world_text
+
+
+func _movements() -> Dictionary:
+	if _claim_section("movements"):
+		_world_movements = _read_section(RomCache.world_movements_path(directory), false)
+	return _world_movements
+
+
+func _tilesets() -> Dictionary:
+	if _claim_section("tilesets"):
+		for value: Dictionary in _read_section(RomCache.world_tilesets_path(directory), true):
 			var tileset: Gen2WorldTileset = Gen2WorldTileset.from_cache(value)
 			_world_tilesets[tileset.number] = tileset
+	return _world_tilesets
 
-	var encounter_rows: Variant = RomCache.read_json(RomCache.world_encounters_path(path))
-	if encounter_rows is Dictionary:
-		_world_encounters = encounter_rows
 
-	var palettes: Variant = RomCache.read_json(RomCache.world_palettes_path(path))
-	if palettes is Array:
-		_world_palettes = palettes
-	var animation_assets: Variant = RomCache.read_json(RomCache.world_animation_assets_path(path))
-	if animation_assets is Dictionary:
-		_world_animation_assets = animation_assets
-	var sprites: Variant = RomCache.read_json(RomCache.overworld_sprites_path(path))
-	if sprites is Array:
-		_overworld_sprites = sprites
-	var sprite_palettes: Variant = RomCache.read_json(
-		RomCache.overworld_sprite_palettes_path(path)
-	)
-	if sprite_palettes is Array:
-		_overworld_sprite_palettes = sprite_palettes
-	var menus: Variant = RomCache.read_json(RomCache.world_menus_path(path))
-	if menus is Dictionary:
-		_world_menus = menus
-	var marts: Variant = RomCache.read_json(RomCache.world_marts_path(path))
-	if marts is Dictionary:
-		_world_marts = marts
-	var phone: Variant = RomCache.read_json(RomCache.world_phone_path(path))
-	if phone is Dictionary:
-		_world_phone = phone
-	var audio: Variant = RomCache.read_json(RomCache.world_audio_path(path))
-	if audio is Dictionary:
-		_world_audio = audio
+func _encounters() -> Dictionary:
+	if _claim_section("encounters"):
+		_world_encounters = _read_section(RomCache.world_encounters_path(directory), false)
+	return _world_encounters
+
+
+func _palettes() -> Array:
+	if _claim_section("palettes"):
+		_world_palettes = _read_section(RomCache.world_palettes_path(directory), true)
+	return _world_palettes
+
+
+func _animation_assets() -> Dictionary:
+	if _claim_section("animation_assets"):
+		_world_animation_assets = _read_section(
+			RomCache.world_animation_assets_path(directory), false
+		)
+	return _world_animation_assets
+
+
+func _sprites() -> Array:
+	if _claim_section("sprites"):
+		_overworld_sprites = _read_section(RomCache.overworld_sprites_path(directory), true)
+	return _overworld_sprites
+
+
+func _sprite_palettes() -> Array:
+	if _claim_section("sprite_palettes"):
+		_overworld_sprite_palettes = _read_section(
+			RomCache.overworld_sprite_palettes_path(directory), true
+		)
+	return _overworld_sprite_palettes
+
+
+func _menus() -> Dictionary:
+	if _claim_section("menus"):
+		_world_menus = _read_section(RomCache.world_menus_path(directory), false)
+	return _world_menus
+
+
+func _marts() -> Dictionary:
+	if _claim_section("marts"):
+		_world_marts = _read_section(RomCache.world_marts_path(directory), false)
+	return _world_marts
+
+
+func _phone() -> Dictionary:
+	if _claim_section("phone"):
+		_world_phone = _read_section(RomCache.world_phone_path(directory), false)
+	return _world_phone
+
+
+func _audio() -> Dictionary:
+	if _claim_section("audio"):
+		_world_audio = _read_section(RomCache.world_audio_path(directory), false)
+	return _world_audio
 
 
 func _read_array(path: String) -> Array:

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -131,7 +131,9 @@ func world_maps() -> Array:
 ## Raw bounded script bytes indexed by the cartridge's bank and CPU address.
 ## Runtime never opens a ROM; these bytes come from the user cache only.
 func world_script(bank: int, address: int) -> PackedByteArray:
-	return _cached_bytes(_scripts().get(Gen2WorldScript.pointer_key(bank, address), []))
+	return _payload_bytes(
+		_scripts().get(Gen2WorldScript.pointer_key(bank, address), []), _blob("scripts")
+	)
 
 
 ## One imported menu header referenced by an overworld script.
@@ -172,7 +174,7 @@ func world_phone_contact_count() -> int:
 
 
 func world_audio(kind: StringName, index: int) -> Dictionary:
-	return _service_row(_audio().get(String(kind), []), index)
+	return _service_row(_audio().get(String(kind), []), index, _blob("audio"))
 
 
 func world_audio_pointer(kind: StringName, bank: int, address: int) -> Dictionary:
@@ -181,17 +183,17 @@ func world_audio_pointer(kind: StringName, bank: int, address: int) -> Dictionar
 		return {}
 	for value: Dictionary in rows as Array:
 		if int(value.get("bank", -1)) == bank and int(value.get("address", -1)) == address:
-			return _coerce_service_dictionary(value)
+			return _coerce_service_dictionary(value, _blob("audio"))
 	return {}
 
 
 func world_audio_asset(kind: StringName) -> Dictionary:
 	var value: Variant = _audio().get(String(kind), {})
-	return _coerce_service_dictionary(value)
+	return _coerce_service_dictionary(value, _blob("audio"))
 
 
 func world_audio_asset_bytes(kind: StringName) -> PackedByteArray:
-	return _cached_bytes(world_audio_asset(kind).get("bytes", []))
+	return _payload_bytes(world_audio_asset(kind).get("bytes", []), _blob("audio"))
 
 
 func world_service_counts() -> Dictionary:
@@ -214,18 +216,23 @@ func world_standard_script(index: int) -> Dictionary:
 	var entry: Dictionary = (value as Dictionary).duplicate(true)
 	entry["bank"] = int(entry.get("bank", -1))
 	entry["address"] = int(entry.get("address", -1))
-	entry["data"] = _cached_bytes(entry.get("bytes", []))
+	entry["data"] = _payload_bytes(entry, _blob("standard_scripts")) if entry.has("payload") \
+		else _payload_bytes(entry.get("bytes", []), _blob("standard_scripts"))
 	return entry
 
 
 ## Raw bounded text bytes indexed by the cartridge's bank and CPU address.
 func world_text(bank: int, address: int) -> PackedByteArray:
-	return _cached_bytes(_text().get(Gen2WorldScript.pointer_key(bank, address), []))
+	return _payload_bytes(
+		_text().get(Gen2WorldScript.pointer_key(bank, address), []), _blob("text")
+	)
 
 
 ## Raw bounded movement bytes indexed by the script bank and movement pointer.
 func world_movement(bank: int, address: int) -> PackedByteArray:
-	return _cached_bytes(_movements().get(Gen2WorldScript.pointer_key(bank, address), []))
+	return _payload_bytes(
+		_movements().get(Gen2WorldScript.pointer_key(bank, address), []), _blob("movements")
+	)
 
 
 ## One decoded tileset's metatile and collision tables, or null if absent.
@@ -767,6 +774,35 @@ func _read_section(path: String, as_array: bool) -> Variant:
 	return value if value is Dictionary else {}
 
 
+## The binary blob a section's byte spans address, read once and kept. It is a
+## [PackedByteArray], so it costs one byte per cartridge byte rather than the
+## twenty-odd a Variant in an Array costs.
+func _blob(section: String) -> PackedByteArray:
+	var key: String = "blob/%s" % section
+	if _indices.has(key):
+		return _indices[key]
+	var data: PackedByteArray = RomCache.read_blob(
+		RomCache.blob_path(_section_json_path(section))
+	)
+	_indices[key] = data
+	return data
+
+
+func _section_json_path(section: String) -> String:
+	match section:
+		"scripts":
+			return RomCache.world_scripts_path(directory)
+		"standard_scripts":
+			return RomCache.world_standard_scripts_path(directory)
+		"text":
+			return RomCache.world_text_path(directory)
+		"movements":
+			return RomCache.world_movements_path(directory)
+		"audio":
+			return RomCache.world_audio_path(directory)
+	return ""
+
+
 func _maps() -> Array:
 	if _claim_section("maps"):
 		for value: Dictionary in _read_section(RomCache.world_maps_path(directory), true):
@@ -877,43 +913,75 @@ func _entry(rows: Array, index: int) -> Dictionary:
 	return rows[index]
 
 
-func _service_row(value: Variant, index: int) -> Dictionary:
+func _service_row(
+	value: Variant, index: int, blob: PackedByteArray = PackedByteArray()
+) -> Dictionary:
 	if not value is Array or index < 0 or index >= (value as Array).size():
 		return {}
-	return _coerce_service_dictionary((value as Array)[index])
+	return _coerce_service_dictionary((value as Array)[index], blob)
 
 
 func _service_rows_count(value: Variant) -> int:
 	return (value as Array).size() if value is Array else 0
 
 
-func _coerce_service_dictionary(value: Variant) -> Dictionary:
-	var coerced: Variant = _coerce_service_value(value)
+func _coerce_service_dictionary(
+	value: Variant, blob: PackedByteArray = PackedByteArray()
+) -> Dictionary:
+	var coerced: Variant = _coerce_service_value(value, blob)
 	return coerced if coerced is Dictionary else {}
 
 
-func _coerce_service_value(value: Variant) -> Variant:
+func _coerce_service_value(value: Variant, blob: PackedByteArray) -> Variant:
 	if value is float:
 		return int(value)
 	if value is Array:
 		var array: Array = []
 		for entry: Variant in value as Array:
-			array.append(_coerce_service_value(entry))
+			array.append(_coerce_service_value(entry, blob))
 		return array
 	if value is Dictionary:
 		var dictionary: Dictionary = {}
 		for key: Variant in value:
-			dictionary[key] = _coerce_service_value(value[key])
+			# A payload span is handed back under the name the record used to
+			# carry inline, so nothing downstream of here has to know that the
+			# bytes now live in a blob.
+			if String(key) == RomCache.PAYLOAD_KEY:
+				dictionary[RomCache.BYTES_KEY] = _span_bytes(value[key], blob)
+				continue
+			dictionary[key] = _coerce_service_value(value[key], blob)
 		return dictionary
 	return value
 
 
-func _cached_bytes(value: Variant) -> PackedByteArray:
+## Resolves one cached byte run, whichever way the cache holds it.
+##
+## A record carrying a [constant RomCache.PAYLOAD_KEY] is a span into the
+## section's blob. A bare Array is read inline, which is what a hand-written test
+## fixture holds. The two never have to be told apart by shape: the key says
+## which one this is.
+func _payload_bytes(value: Variant, blob: PackedByteArray) -> PackedByteArray:
+	if value is PackedByteArray:
+		return value
+	if value is Dictionary and (value as Dictionary).has(RomCache.PAYLOAD_KEY):
+		return _span_bytes((value as Dictionary)[RomCache.PAYLOAD_KEY], blob)
 	if not value is Array:
 		return PackedByteArray()
 	var raw: Array = value as Array
 	var out := PackedByteArray()
 	out.resize(raw.size())
 	for index: int in out.size():
-		out[index] = int(raw[index])
+		out[index] = int(raw[index]) & 0xFF
 	return out
+
+
+## Reads an [offset, length] span out of a section blob. A span that does not
+## address the blob answers empty rather than reading a neighbouring record.
+func _span_bytes(span: Variant, blob: PackedByteArray) -> PackedByteArray:
+	if not span is Array or (span as Array).size() != RomCache.PAYLOAD_SPAN:
+		return PackedByteArray()
+	var at: int = int((span as Array)[0])
+	var length: int = int((span as Array)[1])
+	if at < 0 or length < 0 or at + length > blob.size():
+		return PackedByteArray()
+	return blob.slice(at, at + length)

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -45,9 +45,18 @@ const WORLD_MARTS: String = "world_marts.json"
 const WORLD_PHONE: String = "world_phone.json"
 const WORLD_AUDIO: String = "world_audio.json"
 
+## The key a payload span is stored under, and how many numbers it holds. A
+## cartridge byte run written inline as JSON decimals costs about four bytes on
+## disk and about twenty-six resident once parsed into an Array of Variants.
+## Scripts, text and audio are almost entirely such runs, so they live in a
+## binary blob beside the JSON and the JSON keeps only [offset, length].
+const PAYLOAD_KEY: String = "payload"
+const PAYLOAD_SPAN: int = 2
+const BYTES_KEY: String = "bytes"
+
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 21
+const FORMAT_VERSION: int = 22
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -91,6 +100,12 @@ static func trainers_path(directory: String) -> String:
 
 static func world_maps_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_MAPS]
+
+
+## The binary blob beside a section's JSON, holding the cartridge byte runs that
+## the JSON refers to by span.
+static func blob_path(json_path: String) -> String:
+	return "%s.bin" % json_path.get_basename()
 
 
 static func world_scripts_path(directory: String) -> String:
@@ -206,6 +221,71 @@ static func read_json(path: String) -> Variant:
 	var text: String = file.get_as_text()
 	file.close()
 	return JSON.parse_string(text)
+
+
+## Writes a pointer map of raw cartridge byte runs: scripts, text and movements,
+## all of which are [code]{ "bank:address": [bytes] }[/code]. Every value is a
+## run, so each becomes a [constant PAYLOAD_KEY] span into the blob.
+static func write_payload_map(
+	json_path: String, blob_path: String, entries: Dictionary
+) -> bool:
+	var blob := PackedByteArray()
+	var stripped: Dictionary = {}
+	for key: Variant in entries:
+		var value: Variant = entries[key]
+		stripped[key] = {PAYLOAD_KEY: _append_payload(value, blob)} if value is Array \
+			else value
+	if not write_json(json_path, stripped):
+		return false
+	return write_indices(blob_path, blob)
+
+
+## Writes a section whose byte runs are named fields rather than whole values,
+## as the audio records and the standard-script table are.
+##
+## Only a [code]bytes[/code] field holding an array is moved. Nothing else is
+## touched: plenty of cached arrays are small numbers without being cartridge
+## payloads, and a mart list or an encounter rate must stay an array.
+static func write_section(json_path: String, blob_path: String, value: Variant) -> bool:
+	var blob := PackedByteArray()
+	var stripped: Variant = _extract_payloads(value, blob)
+	if not write_json(json_path, stripped):
+		return false
+	return write_indices(blob_path, blob)
+
+
+## The binary blob for a section, or empty when the section has none. Held as a
+## [PackedByteArray], which costs one byte per cartridge byte.
+static func read_blob(path: String) -> PackedByteArray:
+	return read_indices(path)
+
+
+## Replaces each [code]bytes[/code] array with a span into [param blob], walking
+## lists and records to reach the ones nested inside them.
+static func _extract_payloads(value: Variant, blob: PackedByteArray) -> Variant:
+	if value is Array:
+		var out: Array = []
+		for entry: Variant in value as Array:
+			out.append(_extract_payloads(entry, blob))
+		return out
+	if value is Dictionary:
+		var out_dictionary: Dictionary = {}
+		for key: Variant in value as Dictionary:
+			var entry: Variant = (value as Dictionary)[key]
+			if String(key) == BYTES_KEY and entry is Array:
+				out_dictionary[PAYLOAD_KEY] = _append_payload(entry as Array, blob)
+				continue
+			out_dictionary[key] = _extract_payloads(entry, blob)
+		return out_dictionary
+	return value
+
+
+static func _append_payload(run: Array, blob: PackedByteArray) -> Array:
+	var at: int = blob.size()
+	blob.resize(at + run.size())
+	for index: int in run.size():
+		blob[at + index] = int(run[index]) & 0xFF
+	return [at, run.size()]
 
 
 ## Index buffers are mostly runs of the same value, so they compress hard,

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -1328,18 +1328,10 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	if not bool(encounters.get("ok", false)):
 		result["message"] = String(encounters.get("message", "Could not import wild encounter data."))
 		return result
-	var script_cache: Variant = RomCache.read_json(RomCache.world_scripts_path(directory))
-	var standard_script_cache: Variant = RomCache.read_json(
-		RomCache.world_standard_scripts_path(directory)
-	)
-	var text_cache: Variant = RomCache.read_json(RomCache.world_text_path(directory))
-	var movement_cache: Variant = RomCache.read_json(RomCache.world_movements_path(directory))
 	var services: Dictionary = Gen2WorldServicesImporter.import_to_cache(
 		rom, layout, directory,
-		script_cache if script_cache is Dictionary else {},
-		standard_script_cache if standard_script_cache is Dictionary else {},
-		text_cache if text_cache is Dictionary else {},
-		movement_cache if movement_cache is Dictionary else {}
+		world.get("scripts", {}), world.get("standard_scripts", {}),
+		world.get("text", {}), world.get("movements", {})
 	)
 	if not bool(services.get("ok", false)):
 		result["message"] = String(services.get("message", "Could not import world service data."))

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -54,15 +54,29 @@ static func import_to_cache(
 		return {"ok": false, "message": "Could not write overworld animation data."}
 	if not RomCache.write_json(RomCache.world_maps_path(directory), result["maps"]):
 		return {"ok": false, "message": "Could not write overworld map data."}
-	if not RomCache.write_json(RomCache.world_scripts_path(directory), result["scripts"]):
+	if not RomCache.write_payload_map(
+		RomCache.world_scripts_path(directory),
+		RomCache.blob_path(RomCache.world_scripts_path(directory)),
+		result["scripts"],
+	):
 		return {"ok": false, "message": "Could not write overworld script data."}
-	if not RomCache.write_json(
-		RomCache.world_standard_scripts_path(directory), result["standard_scripts"]
+	if not RomCache.write_section(
+		RomCache.world_standard_scripts_path(directory),
+		RomCache.blob_path(RomCache.world_standard_scripts_path(directory)),
+		result["standard_scripts"],
 	):
 		return {"ok": false, "message": "Could not write standard overworld script data."}
-	if not RomCache.write_json(RomCache.world_text_path(directory), result["text"]):
+	if not RomCache.write_payload_map(
+		RomCache.world_text_path(directory),
+		RomCache.blob_path(RomCache.world_text_path(directory)),
+		result["text"],
+	):
 		return {"ok": false, "message": "Could not write overworld text data."}
-	if not RomCache.write_json(RomCache.world_movements_path(directory), result["movements"]):
+	if not RomCache.write_payload_map(
+		RomCache.world_movements_path(directory),
+		RomCache.blob_path(RomCache.world_movements_path(directory)),
+		result["movements"],
+	):
 		return {"ok": false, "message": "Could not write overworld movement data."}
 
 	var graphics: Dictionary = result["graphics"]
@@ -82,6 +96,13 @@ static func import_to_cache(
 		"maps": result["maps"].size(),
 		"tilesets": tilesets.size(),
 		"overworld_sprites": result["sprites"].size(),
+		# The service importer scans and extends these. Handing back what was
+		# just decoded keeps them raw byte runs; reading them off disk again
+		# would hand it the spans the cache stores instead.
+		"scripts": result["scripts"],
+		"standard_scripts": result["standard_scripts"],
+		"text": result["text"],
+		"movements": result["movements"],
 	}
 
 

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -41,13 +41,26 @@ static func import_to_cache(
 		return _error("Could not write world mart data.")
 	if not RomCache.write_json(RomCache.world_phone_path(directory), result["phone"]):
 		return _error("Could not write world phone data.")
-	if not RomCache.write_json(RomCache.world_audio_path(directory), result["audio"]):
+	if not RomCache.write_section(
+		RomCache.world_audio_path(directory),
+		RomCache.blob_path(RomCache.world_audio_path(directory)),
+		result["audio"],
+	):
 		return _error("Could not write world audio data.")
-	if not RomCache.write_json(RomCache.world_scripts_path(directory), scripts):
+	if not RomCache.write_payload_map(
+		RomCache.world_scripts_path(directory),
+		RomCache.blob_path(RomCache.world_scripts_path(directory)), scripts,
+	):
 		return _error("Could not update world scripts with phone scripts.")
-	if not RomCache.write_json(RomCache.world_text_path(directory), text_data):
+	if not RomCache.write_payload_map(
+		RomCache.world_text_path(directory),
+		RomCache.blob_path(RomCache.world_text_path(directory)), text_data,
+	):
 		return _error("Could not update world text with phone text.")
-	if not RomCache.write_json(RomCache.world_movements_path(directory), movement_data):
+	if not RomCache.write_payload_map(
+		RomCache.world_movements_path(directory),
+		RomCache.blob_path(RomCache.world_movements_path(directory)), movement_data,
+	):
 		return _error("Could not update world movements with phone movements.")
 
 	return {

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -1,0 +1,181 @@
+class_name Gen2ModHost
+extends RefCounted
+
+## What a mod is allowed to change, and the only way it gets to change it.
+##
+## A mod never touches scene nodes or engine internals. It is handed this host,
+## registers what it provides, and is done. Everything it can reach is either
+## cartridge content through [GameData] or live world state through
+## [Gen2WorldAPI], both of which are scene-free.
+##
+## The first thing a mod can replace is the world renderer. The 2D renderer here
+## reads the world and draws it; nothing about the world requires that the
+## drawing be 2D, so a renderer that builds geometry from the same block and
+## collision data is a registration rather than a fork. Swapping between two
+## registered renderers is [method select_world_renderer], which is why the
+## contract is a factory and not a one-time construction.
+##
+## Mods are interpreted GDScript. iOS forbids JIT and loading native code at
+## runtime, so a compiled extension is not an option for a distributed mod.
+
+## Where installed mods live. Under user:// because a mod is not part of the
+## build and must survive an update of it.
+const ROOT: String = "user://mods"
+## The methods a world renderer has to provide. A registration that is missing
+## one is refused at registration, where the mod's name is still in hand, rather
+## than failing on the first frame it is asked to draw.
+const WORLD_RENDERER_METHODS: Array[String] = [
+	"set_world", "set_time_of_day", "refresh", "refresh_animation",
+]
+## The id of the built-in 2D renderer, which is always registered.
+const BUILT_IN_RENDERER: StringName = &"gen2"
+
+static var _instance: Gen2ModHost = null
+
+var _manifests: Dictionary = {}
+var _renderers: Dictionary = {}
+var _selected_renderer: StringName = BUILT_IN_RENDERER
+var _failures: Array = []
+
+
+## The shared host. Created with the built-in renderer already registered, so a
+## caller that never loads a mod still goes through the same boundary.
+static func instance() -> Gen2ModHost:
+	if _instance == null:
+		_instance = Gen2ModHost.new()
+		_instance.register_world_renderer(
+			BUILT_IN_RENDERER, Gen2WorldRenderer, "Game Boy Color 2D"
+		)
+	return _instance
+
+
+## Discards every loaded mod and returns to the built-in renderer. For tests and
+## for a launcher that reloads the mod list.
+static func reset() -> void:
+	_instance = null
+
+
+## Registers a world renderer under [param id].
+##
+## [param script] is instantiated per world, so one registration serves a map
+## change, a snapshot restore and a live switch between renderers.
+func register_world_renderer(
+	id: StringName, script: Script, label: String = ""
+) -> Dictionary:
+	if String(id).is_empty() or script == null:
+		return {"ok": false, "reason": &"invalid_renderer"}
+	var probe: Object = script.new()
+	if probe == null:
+		return {"ok": false, "reason": &"renderer_not_instantiable", "detail": String(id)}
+	var missing: Array[String] = []
+	for method: String in WORLD_RENDERER_METHODS:
+		if not probe.has_method(method):
+			missing.append(method)
+	var is_node: bool = probe is Node
+	if probe is RefCounted:
+		probe = null
+	elif probe is Node:
+		(probe as Node).free()
+	if not is_node:
+		return {"ok": false, "reason": &"renderer_not_a_node", "detail": String(id)}
+	if not missing.is_empty():
+		return {
+			"ok": false, "reason": &"renderer_missing_methods",
+			"detail": "%s: %s" % [id, ", ".join(missing)],
+		}
+	_renderers[id] = {
+		"script": script,
+		"label": label if not label.is_empty() else String(id),
+	}
+	return {"ok": true, "id": id}
+
+
+func world_renderer_ids() -> Array:
+	return _renderers.keys()
+
+
+func world_renderer_label(id: StringName) -> String:
+	return String((_renderers.get(id, {}) as Dictionary).get("label", ""))
+
+
+func selected_world_renderer() -> StringName:
+	return _selected_renderer
+
+
+## Chooses which registered renderer new worlds are drawn with. The caller
+## rebuilds its view; this only decides what [method create_world_renderer]
+## hands back, so a keybind can flip between 2D and a mod's renderer.
+func select_world_renderer(id: StringName) -> Dictionary:
+	if not _renderers.has(id):
+		return {"ok": false, "reason": &"unknown_renderer", "detail": String(id)}
+	_selected_renderer = id
+	return {"ok": true, "id": id}
+
+
+## A fresh renderer node for the selected renderer, falling back to the built-in
+## one so a screen always has something to draw with.
+func create_world_renderer() -> Node:
+	var entry: Dictionary = _renderers.get(_selected_renderer, {})
+	var script: Variant = entry.get("script", null)
+	if script is Script:
+		var node: Object = (script as Script).new()
+		if node is Node:
+			return node as Node
+	return Gen2WorldRenderer.new()
+
+
+## Reads every installed mod's manifest without running any of them. The
+## launcher lists these; refusals are kept so it can say why one is absent.
+func discover(root: String = ROOT) -> Array:
+	_manifests = {}
+	_failures = []
+	var directory: DirAccess = DirAccess.open(root)
+	if directory == null:
+		return []
+	directory.list_dir_begin()
+	var name: String = directory.get_next()
+	while name != "":
+		if directory.current_is_dir() and not name.begins_with("."):
+			var result: Dictionary = Gen2ModManifest.read("%s/%s" % [root, name])
+			if bool(result.get("ok", false)):
+				var manifest: Gen2ModManifest = result["manifest"]
+				_manifests[manifest.id] = manifest
+			else:
+				result["directory"] = name
+				_failures.append(result)
+		name = directory.get_next()
+	directory.list_dir_end()
+	return _manifests.values()
+
+
+func failures() -> Array:
+	return _failures.duplicate(true)
+
+
+## Runs each discovered mod's entry script, which registers what it provides.
+##
+## A mod that will not load is reported and skipped: one broken mod must not
+## stop the others, and it must not stop the game starting.
+func load_discovered() -> Array:
+	var loaded: Array = []
+	for id: StringName in _manifests:
+		var result: Dictionary = load_mod(_manifests[id])
+		if bool(result.get("ok", false)):
+			loaded.append(id)
+		else:
+			_failures.append(result)
+	return loaded
+
+
+func load_mod(manifest: Gen2ModManifest) -> Dictionary:
+	var path: String = manifest.entry_path()
+	if not FileAccess.file_exists(path):
+		return {"ok": false, "reason": &"missing_entry_script", "detail": path}
+	var script: Variant = load(path)
+	if not script is Script:
+		return {"ok": false, "reason": &"entry_not_a_script", "detail": path}
+	var mod: Object = (script as Script).new()
+	if mod == null or not mod.has_method("register"):
+		return {"ok": false, "reason": &"entry_has_no_register", "detail": path}
+	mod.call("register", self, manifest)
+	return {"ok": true, "id": manifest.id}

--- a/game/mods/mod_host.gd.uid
+++ b/game/mods/mod_host.gd.uid
@@ -1,0 +1,1 @@
+uid://dabvmpe3m5455

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -1,0 +1,97 @@
+class_name Gen2ModManifest
+extends RefCounted
+
+## One mod's declared identity, read from its `mod.json`.
+##
+## Parsing is separate from loading so the launcher can list what is installed,
+## and say why something was refused, without running a line of mod code.
+##
+## [code]api_version[/code] is the contract in [Gen2ModHost], not the mod's own
+## version. A mod built against an older host is refused rather than loaded and
+## allowed to fail somewhere less obvious.
+
+const FILENAME: String = "mod.json"
+## Bumped when the host contract changes in a way an existing mod would notice.
+const API_VERSION: int = 1
+## Ids address directories and registry keys, so they stay to a plain lowercase
+## alphabet. A mod cannot name itself something that escapes its own folder.
+const ID_PATTERN: String = "^[a-z0-9][a-z0-9_-]*$"
+
+var id: StringName = &""
+var name: String = ""
+var version: String = ""
+var api_version: int = 0
+var entry: String = ""
+var description: String = ""
+## Absolute path of the directory the manifest was read from.
+var directory: String = ""
+
+
+## Reads and validates the manifest in [param directory].
+## Returns { ok, manifest } or { ok: false, reason, detail }.
+static func read(directory: String) -> Dictionary:
+	var path: String = "%s/%s" % [directory, FILENAME]
+	if not FileAccess.file_exists(path):
+		return _refuse(&"missing_manifest", path)
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return _refuse(&"unreadable_manifest", path)
+	var text: String = file.get_as_text()
+	file.close()
+	var parsed: Variant = JSON.parse_string(text)
+	if not parsed is Dictionary:
+		return _refuse(&"invalid_manifest", path)
+	return from_dictionary(parsed as Dictionary, directory)
+
+
+## Validates an already-parsed manifest. Split out so a test, and a future pack
+## reader, do not need a file on disk.
+static func from_dictionary(source: Dictionary, directory: String) -> Dictionary:
+	var manifest := Gen2ModManifest.new()
+	manifest.directory = directory
+	manifest.id = StringName(String(source.get("id", "")))
+	manifest.name = String(source.get("name", String(manifest.id)))
+	manifest.version = String(source.get("version", ""))
+	manifest.api_version = int(source.get("api_version", 0))
+	manifest.entry = String(source.get("entry", ""))
+	manifest.description = String(source.get("description", ""))
+
+	var regex := RegEx.new()
+	regex.compile(ID_PATTERN)
+	if regex.search(String(manifest.id)) == null:
+		return _refuse(&"invalid_id", String(manifest.id))
+	if manifest.api_version != API_VERSION:
+		return _refuse(
+			&"unsupported_api_version",
+			"mod declares %d, host provides %d" % [manifest.api_version, API_VERSION]
+		)
+	if manifest.entry.is_empty():
+		return _refuse(&"missing_entry", String(manifest.id))
+	# An entry is a path inside the mod's own directory. Anything that climbs
+	# out of it, or reaches for an absolute location, is refused.
+	if manifest.entry.begins_with("/") or manifest.entry.contains("..") \
+		or manifest.entry.contains(":"):
+		return _refuse(&"entry_escapes_mod", manifest.entry)
+	if not manifest.entry.ends_with(".gd"):
+		# iOS forbids JIT and loading native code at runtime, so a mod is
+		# interpreted GDScript or it is nothing.
+		return _refuse(&"entry_not_gdscript", manifest.entry)
+	return {"ok": true, "manifest": manifest}
+
+
+func entry_path() -> String:
+	return "%s/%s" % [directory, entry]
+
+
+func summary() -> Dictionary:
+	return {
+		"id": id,
+		"name": name,
+		"version": version,
+		"description": description,
+		"directory": directory,
+	}
+
+
+static func _refuse(reason: StringName, detail: String) -> Dictionary:
+	return {"ok": false, "reason": reason, "detail": detail}

--- a/game/mods/mod_manifest.gd.uid
+++ b/game/mods/mod_manifest.gd.uid
@@ -1,0 +1,1 @@
+uid://lskdewbe8nk0

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -92,6 +92,8 @@ func create_new_game(player_name: String, starter_species: int) -> bool:
 	if not result["ok"]:
 		_set_status("New game was not saved.", String(result["message"]), ERROR)
 		return false
+	# The slot now holds a different save than the one the runtime is sharing.
+	GameRuntime.reload_selected_save()
 	_new_game_visible = false
 	_refresh()
 	_set_status(
@@ -128,6 +130,7 @@ func import_sav_path(path: String, slot: int = -1) -> bool:
 	if not result["ok"]:
 		_set_status("Save import failed.", String(result["message"]), ERROR)
 		return false
+	GameRuntime.reload_selected_save()
 	_new_game_visible = false
 	_refresh()
 	_set_status(

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -8,6 +8,13 @@ extends RefCounted
 ## the indexed tile strip held by GameData.
 
 const TILE_BYTES: int = Gen2Tiles.TILE_BYTES
+## One command runs per hardware VBlank, so the sequence has to be paced by
+## elapsed time rather than by rendered frames. Stepping it once per drawn frame
+## makes water flow at the monitor's refresh rate instead of the cartridge's.
+const FRAME_SECONDS: float = 1.0 / 59.7275
+## The most catch-up frames one call will run. A stall should drop animation
+## frames, not spend the recovery frame walking thousands of commands.
+const MAX_CATCHUP_FRAMES: int = 4
 const TIMER_WATER_FRAMES: Array = [0, 1, 2, 3]
 const TIMER_FOUNTAIN_FRAMES: Array = [0, 1, 2, 3, 2, 3, 4, 0]
 const TIMER_TOWER_FRAMES: Array = [0, 1, 2, 3, 4, 3, 2, 1]
@@ -24,6 +31,8 @@ var _timer: int = 0
 var _water_color: int = -1
 var _cave_color: int = -1
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
+var _frame_seconds: float = 0.0
+var _changed: bool = false
 
 
 func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MORNING) -> void:
@@ -35,6 +44,8 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 	_timer = 0
 	_water_color = -1
 	_cave_color = -1
+	_frame_seconds = 0.0
+	_changed = false
 	_buffer.resize(TILE_BYTES)
 	if data == null or tileset == null:
 		_indices = PackedByteArray()
@@ -42,6 +53,33 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 		return
 	_indices = data.world_tileset_indices(tileset.number).duplicate()
 	_commands = tileset.animation_commands.duplicate(true)
+
+
+## Runs the commands that [param delta] seconds of real time are worth and
+## reports whether the tile strip or a palette row actually changed.
+##
+## Most commands are waits and timer bumps that draw nothing new, so the return
+## value is what a renderer should gate its atlas rebuild on; [method tick] is
+## the single-command step the sequence is defined in.
+func advance(delta: float) -> bool:
+	if _commands.is_empty() or tileset == null or delta <= 0.0:
+		return false
+	_frame_seconds = minf(
+		_frame_seconds + delta, FRAME_SECONDS * float(MAX_CATCHUP_FRAMES)
+	)
+	var changed: bool = false
+	while _frame_seconds >= FRAME_SECONDS:
+		_frame_seconds -= FRAME_SECONDS
+		_changed = false
+		tick()
+		changed = changed or _changed
+	return changed
+
+
+## How far into the command list the sequence has reached, for tests and cache
+## inspection.
+func command_index() -> int:
+	return _command_index
 
 
 func current_indices() -> PackedByteArray:
@@ -115,10 +153,14 @@ func tick() -> bool:
 		"scroll_vertical":
 			_scroll_vertical()
 		"water_palette":
-			_water_color = TIMER_WATER_PALETTE[(_timer & 6) >> 1]
+			var water_color: int = TIMER_WATER_PALETTE[(_timer & 6) >> 1]
+			_changed = _changed or water_color != _water_color
+			_water_color = water_color
 		"cave_palette":
 			if _time_of_day == Gen2WorldPalette.TIME_DARK:
-				_cave_color = (_timer >> 1) & 1
+				var cave_color: int = (_timer >> 1) & 1
+				_changed = _changed or cave_color != _cave_color
+				_cave_color = cave_color
 	return true
 
 
@@ -175,7 +217,11 @@ func _set_tile_bytes(tile: int, bytes: PackedByteArray) -> void:
 		var high: int = int(bytes[y * 2 + 1])
 		for x: int in Gen2Tiles.TILE_WIDTH:
 			var value: int = ((low >> (7 - x)) & 1) | (((high >> (7 - x)) & 1) << 1)
-			_indices[y * width + tile * Gen2Tiles.TILE_WIDTH + x] = value
+			var at: int = y * width + tile * Gen2Tiles.TILE_WIDTH + x
+			if _indices[at] == value:
+				continue
+			_indices[at] = value
+			_changed = true
 
 
 func _scroll_horizontal() -> void:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -37,6 +37,10 @@ var _block_overrides: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
+## Supplies the roaming jumps performed during map setup. A caller that needs a
+## reproducible route sets its own generator; otherwise map setup randomizes.
+var schedule_random: RandomNumberGenerator = null
+var _last_schedule: Dictionary = {}
 
 
 ## Opens one map through the public cartridge-content API.
@@ -706,22 +710,7 @@ func cancel_script_input() -> Array:
 	if StringName(advanced.get("status", &"")) == &"waiting":
 		results.append(advanced)
 		return results
-	if bool(advanced.get("ok", false)):
-		results.append(_finish_script_result(advanced))
-	else:
-		results.append(advanced)
-	_active_script = null
-	while _active_script == null and not _script_queue.is_empty():
-		var request: Dictionary = _script_queue.pop_front()
-		_active_script = Gen2WorldScriptRunner.begin(
-			data, state, request, Callable(self, "_validate_script_warp")
-		)
-		var next: Dictionary = _active_script.advance()
-		if StringName(next.get("status", &"")) == &"waiting":
-			results.append(next)
-			break
-		results.append(_finish_script_result(next) if bool(next.get("ok", false)) else next)
-		_active_script = null
+	results.append_array(_resume_after(advanced))
 	return results
 
 
@@ -741,11 +730,27 @@ func complete_runtime_request(result: Dictionary) -> Array:
 		_active_script = null
 		_script_queue.clear()
 		return results
-	if bool(advanced.get("ok", false)):
-		results.append(_finish_script_result(advanced))
-	else:
-		results.append(advanced)
+	results.append_array(_resume_after(advanced))
+	return results
+
+
+## Closes out a resumed invocation and runs whatever was queued behind it. Both
+## resume boundaries, a cancelled input and a completed host request, end the
+## same way, and the terminal result must not be finished twice.
+func _resume_after(advanced: Dictionary) -> Array:
+	var results: Array = []
+	results.append(
+		_finish_script_result(advanced) if bool(advanced.get("ok", false)) else advanced
+	)
 	_active_script = null
+	results.append_array(_drain_script_queue())
+	return results
+
+
+## Starts each queued script in turn and stops at the first one that waits for
+## the host.
+func _drain_script_queue() -> Array:
+	var results: Array = []
 	while _active_script == null and not _script_queue.is_empty():
 		var request: Dictionary = _script_queue.pop_front()
 		_active_script = Gen2WorldScriptRunner.begin(
@@ -1558,7 +1563,16 @@ func _apply_map(
 	current_tileset = target_tileset
 	player_cell = _clamp_cell(target_cell)
 	_load_objects()
+	# The cartridge moves roaming Pokémon in map setup, not on a timer, so a
+	# player who stands still does not watch them cross Johto.
+	_last_schedule = advance_schedule(schedule_random)
 	_queue_map_callbacks(-1)
+
+
+## The schedule update produced by the most recent map change, for a host that
+## wants to report where the roamers went.
+func last_schedule() -> Dictionary:
+	return _last_schedule.duplicate(true)
 
 
 ## Reloads the current map's live object records without changing the player

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -2,9 +2,13 @@ class_name Gen2WorldClock
 extends RefCounted
 
 ## Deterministic host clock for the real-time Generation 2 day cycle.
-## One elapsed host second is one cartridge clock second. Schedule work is
-## published at each completed game minute, while time-of-day changes use the
-## cartridge's 04:00, 10:00 and 18:00 boundaries.
+## One elapsed host second is one cartridge clock second. A tick is published at
+## each completed game minute, while time-of-day changes use the cartridge's
+## 04:00, 10:00 and 18:00 boundaries.
+##
+## The clock does not move roaming Pokémon. The cartridge advances those during
+## map setup, so [method Gen2WorldAPI.advance_schedule] is driven by a map
+## change rather than by elapsed time.
 
 const SECONDS_PER_MINUTE: float = 60.0
 const MINUTES_PER_HOUR: int = 60
@@ -36,9 +40,7 @@ func time_of_day() -> int:
 	return Gen2WorldPalette.TIME_NIGHT
 
 
-func advance(
-	seconds: float, world: Gen2WorldAPI, random: RandomNumberGenerator = null
-) -> Array:
+func advance(seconds: float, world: Gen2WorldAPI = null) -> Array:
 	if seconds <= 0.0:
 		return []
 	_elapsed_seconds += seconds
@@ -48,14 +50,12 @@ func advance(
 		_advance_minute()
 		if world != null:
 			world.set_world_clock(day, hour, minute)
-		var schedule: Dictionary = world.advance_schedule(random) if world != null else {}
 		ticks.append({
 			"kind": &"world_clock_minute",
 			"day": day,
 			"hour": hour,
 			"minute": minute,
 			"time_of_day": time_of_day(),
-			"schedule": schedule,
 		})
 	return ticks
 

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -24,10 +24,11 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 	queue_redraw()
 
 
+## Selects the palette rows this view draws with. The world owns the clock and
+## object visibility; a renderer only reads them, so a second view of the same
+## world cannot change what the first one sees.
 func set_time_of_day(time_of_day: int) -> void:
 	_time_of_day = clampi(time_of_day, 0, 3)
-	if _world != null:
-		_world.set_object_time(_world.object_hour, _time_of_day)
 	_actor_textures.clear()
 	_rebuild_atlas()
 	queue_redraw()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -125,7 +125,7 @@ func _build_world() -> void:
 
 
 func _process(delta: float) -> void:
-	if _animation != null and _animation.tick() and _renderer != null:
+	if _animation != null and _animation.advance(delta) and _renderer != null:
 		_renderer.refresh_animation()
 	if _world != null and _world.tick() and _renderer != null:
 		_renderer.refresh()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -26,7 +26,9 @@ var _data: GameData = null
 var _injected_data: GameData = null
 var _injected_save: Gen2SaveData = null
 var _world: Gen2WorldAPI = null
-var _renderer: Gen2WorldRenderer = null
+## Whatever the mod host supplies. Typed as Node because a registered renderer
+## only has to satisfy Gen2ModHost.WORLD_RENDERER_METHODS, not extend the 2D one.
+var _renderer: Node = null
 var _animation: Gen2WorldAnimation = null
 var _text_box: Gen2TextBox = null
 var _clock: Gen2WorldClock = null
@@ -108,7 +110,9 @@ func _build_world() -> void:
 	if not rods.is_empty() and not rods.has(_selected_rod):
 		_selected_rod = rods[0]
 	_animation.configure(_world, time_of_day)
-	_renderer = Gen2WorldRenderer.new()
+	# Constructed through the mod host rather than directly, so a registered
+	# renderer replaces this view without the screen knowing what it draws with.
+	_renderer = Gen2ModHost.instance().create_world_renderer()
 	_renderer.set_world(_world, _animation)
 	_renderer.set_time_of_day(time_of_day)
 	_screen.display(_renderer)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -98,6 +98,7 @@ func _build_world() -> void:
 	else:
 		_encounter_random.randomize()
 
+	_world.schedule_random = _encounter_random
 	_clock = Gen2WorldClock.new(hour, minute, day)
 	time_of_day = _clock.time_of_day()
 	_animation = Gen2WorldAnimation.new()
@@ -130,7 +131,7 @@ func _process(delta: float) -> void:
 	if _world != null and _world.tick() and _renderer != null:
 		_renderer.refresh()
 	if _clock != null and _world != null:
-		var ticks: Array = _clock.advance(delta, _world, _encounter_random)
+		var ticks: Array = _clock.advance(delta, _world)
 		_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
 		if not ticks.is_empty():
 			_update_time_of_day()
@@ -324,7 +325,7 @@ func persist_world_snapshot() -> Dictionary:
 func advance_world_time(seconds: float) -> Array:
 	if _clock == null or _world == null:
 		return []
-	var ticks: Array = _clock.advance(seconds, _world, _encounter_random)
+	var ticks: Array = _clock.advance(seconds, _world)
 	_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
 	if not ticks.is_empty():
 		_update_time_of_day()

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -66,3 +66,28 @@ func test_runtime_selection_accepts_registry_games_and_rejects_unknown_ids() -> 
 
 	GameRuntime.selected_game_id = previous
 	GameRuntime.selected_save_slot = previous_slot
+	GameRuntime.reload_selected_save()
+
+
+func test_the_selected_save_is_one_shared_instance_until_the_selection_changes() -> void:
+	var previous: StringName = GameRuntime.selected_game_id
+	var previous_slot: int = GameRuntime.selected_save_slot
+	var data: GameData = GameData.open_any()
+	if data == null:
+		pass_test("No imported cache on this machine.")
+		return
+
+	assert_true(GameRuntime.select_save_slot(data.id, 0))
+	var save: Gen2SaveData = GameRuntime.selected_save()
+	if save == null:
+		pass_test("Slot 0 of the imported cache is empty.")
+	else:
+		# Two readers must see one save, or a party change made by a battle is
+		# invisible to whoever writes the world snapshot.
+		assert_same(save, GameRuntime.selected_save())
+		GameRuntime.reload_selected_save()
+		assert_not_same(save, GameRuntime.selected_save())
+
+	GameRuntime.selected_game_id = previous
+	GameRuntime.selected_save_slot = previous_slot
+	GameRuntime.reload_selected_save()

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1,0 +1,171 @@
+extends GutTest
+
+## Mod tests write a real mod directory under user:// and load it the way the
+## launcher will, because the point of the boundary is that mod code the project
+## has never seen can reach it.
+
+const ROOT: String = "user://mod_tests"
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = "%s/voxel" % ROOT
+	_clear()
+	DirAccess.make_dir_recursive_absolute(_directory)
+	Gen2ModHost.reset()
+
+
+func after_each() -> void:
+	_clear()
+	Gen2ModHost.reset()
+
+
+func _clear() -> void:
+	var root: DirAccess = DirAccess.open(ROOT)
+	if root == null:
+		return
+	for name: String in root.get_directories():
+		var mod: DirAccess = DirAccess.open("%s/%s" % [ROOT, name])
+		if mod != null:
+			for file: String in mod.get_files():
+				DirAccess.remove_absolute("%s/%s/%s" % [ROOT, name, file])
+		DirAccess.remove_absolute("%s/%s" % [ROOT, name])
+	DirAccess.remove_absolute(ROOT)
+
+
+func _write(path: String, text: String) -> void:
+	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(text)
+	file.close()
+
+
+func _write_manifest(source: Dictionary) -> void:
+	_write("%s/mod.json" % _directory, JSON.stringify(source))
+
+
+func _valid_manifest() -> Dictionary:
+	return {
+		"id": "voxel",
+		"name": "Voxel World",
+		"version": "1.0.0",
+		"api_version": Gen2ModManifest.API_VERSION,
+		"entry": "mod.gd",
+	}
+
+
+func test_a_valid_manifest_is_read_without_running_the_mod() -> void:
+	_write_manifest(_valid_manifest())
+	var result: Dictionary = Gen2ModManifest.read(_directory)
+	assert_true(result["ok"])
+	var manifest: Gen2ModManifest = result["manifest"]
+	assert_eq(manifest.id, &"voxel")
+	assert_eq(manifest.name, "Voxel World")
+	assert_eq(manifest.entry_path(), "%s/mod.gd" % _directory)
+
+
+func test_a_manifest_built_for_another_host_is_refused() -> void:
+	var source: Dictionary = _valid_manifest()
+	source["api_version"] = Gen2ModManifest.API_VERSION + 1
+	_write_manifest(source)
+	assert_eq(Gen2ModManifest.read(_directory)["reason"], &"unsupported_api_version")
+
+
+func test_an_entry_that_leaves_the_mod_directory_is_refused() -> void:
+	for entry: String in ["../escape.gd", "/etc/passwd.gd", "res://game/main/main.gd"]:
+		var source: Dictionary = _valid_manifest()
+		source["entry"] = entry
+		_write_manifest(source)
+		var result: Dictionary = Gen2ModManifest.read(_directory)
+		assert_false(result["ok"], "entry %s must be refused" % entry)
+
+
+func test_a_native_entry_is_refused_because_ios_forbids_runtime_native_code() -> void:
+	var source: Dictionary = _valid_manifest()
+	source["entry"] = "mod.dll"
+	_write_manifest(source)
+	assert_eq(Gen2ModManifest.read(_directory)["reason"], &"entry_not_gdscript")
+
+
+func test_the_built_in_renderer_is_registered_before_any_mod_loads() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(host.world_renderer_ids().has(Gen2ModHost.BUILT_IN_RENDERER))
+	assert_eq(host.selected_world_renderer(), Gen2ModHost.BUILT_IN_RENDERER)
+	var renderer: Node = host.create_world_renderer()
+	assert_true(renderer is Gen2WorldRenderer)
+	renderer.free()
+
+
+func test_a_renderer_missing_a_contract_method_is_refused_at_registration() -> void:
+	var script := GDScript.new()
+	# Has set_world and refresh, but not the rest of the contract.
+	script.source_code = "extends Node2D\nfunc set_world(_w, _a = null) -> void:\n\tpass\nfunc refresh() -> void:\n\tpass\n"
+	script.reload()
+	var result: Dictionary = Gen2ModHost.instance().register_world_renderer(&"broken", script)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"renderer_missing_methods")
+	assert_string_contains(String(result["detail"]), "set_time_of_day")
+
+
+func test_a_discovered_mod_registers_a_renderer_the_world_then_draws_with() -> void:
+	_write_manifest(_valid_manifest())
+	_write("%s/renderer.gd" % _directory, """extends Node2D
+
+func set_world(_world, _animation = null) -> void:
+	pass
+
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func refresh_animation() -> void:
+	pass
+
+func is_voxel_renderer() -> bool:
+	return true
+""")
+	_write("%s/mod.gd" % _directory, """extends RefCounted
+
+func register(host, manifest) -> void:
+	host.register_world_renderer(
+		manifest.id, load("%s/renderer.gd"), "Voxel"
+	)
+""" % _directory)
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var found: Array = host.discover(ROOT)
+	assert_eq(found.size(), 1)
+	assert_eq(host.load_discovered(), [&"voxel"])
+	assert_true(host.world_renderer_ids().has(&"voxel"))
+
+	# Selecting is what a keybind does, and it must change what a new world is
+	# handed without the screen knowing which renderer it asked for.
+	assert_true(host.select_world_renderer(&"voxel")["ok"])
+	var renderer: Node = host.create_world_renderer()
+	assert_true(renderer.has_method("is_voxel_renderer"))
+	renderer.free()
+
+	assert_true(host.select_world_renderer(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+	var built_in: Node = host.create_world_renderer()
+	assert_true(built_in is Gen2WorldRenderer)
+	built_in.free()
+
+
+func test_a_broken_mod_is_reported_and_does_not_stop_the_others() -> void:
+	_write_manifest(_valid_manifest())
+	# Declared entry never written, so this mod cannot load.
+	DirAccess.make_dir_recursive_absolute("%s/other" % ROOT)
+	_write("%s/other/mod.json" % ROOT, JSON.stringify({
+		"id": "other", "name": "Other", "version": "1.0.0",
+		"api_version": Gen2ModManifest.API_VERSION, "entry": "mod.gd",
+	}))
+	_write("%s/other/mod.gd" % ROOT, "extends RefCounted\n\nfunc register(_host, _manifest) -> void:\n\tpass\n")
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	assert_eq(host.load_discovered(), [&"other"])
+	var failures: Array = host.failures()
+	assert_eq(failures.size(), 1)
+	assert_eq(failures[0]["reason"], &"missing_entry_script")

--- a/tests/unit/test_mods.gd.uid
+++ b/tests/unit/test_mods.gd.uid
@@ -1,0 +1,1 @@
+uid://be3o5ddrad1bl

--- a/tests/unit/test_rom_cache.gd
+++ b/tests/unit/test_rom_cache.gd
@@ -130,3 +130,45 @@ func test_clear_removes_subdirectories_too() -> void:
 	RomCache.write_indices(RomCache.pic_path(_directory, "front"), PackedByteArray([1, 2, 3]))
 	RomCache.clear(_directory)
 	assert_false(DirAccess.dir_exists_absolute(_directory))
+
+
+func test_a_payload_map_keeps_pointers_in_json_and_bytes_in_the_blob() -> void:
+	RomCache.prepare(_directory)
+	var json_path: String = RomCache.world_scripts_path(_directory)
+	var blob_path: String = RomCache.blob_path(json_path)
+	assert_true(RomCache.write_payload_map(json_path, blob_path, {
+		"48:6000": [0x33, 0x91],
+		"48:7000": [0x14, 0x02, 0x91],
+	}))
+
+	var stored: Variant = RomCache.read_json(json_path)
+	assert_true(stored is Dictionary)
+	# The pointer survives as the key; the run is a span, not decimal text.
+	assert_eq(_span((stored as Dictionary)["48:6000"]), [0, 2])
+	assert_eq(_span((stored as Dictionary)["48:7000"]), [2, 3])
+	assert_eq(RomCache.read_blob(blob_path), PackedByteArray([0x33, 0x91, 0x14, 0x02, 0x91]))
+
+
+func test_a_section_moves_only_named_byte_fields_into_the_blob() -> void:
+	RomCache.prepare(_directory)
+	var json_path: String = RomCache.world_audio_path(_directory)
+	var blob_path: String = RomCache.blob_path(json_path)
+	assert_true(RomCache.write_section(json_path, blob_path, {
+		"music": [{"bank": 2, "address": 0x4000, "bytes": [7, 8, 9]}],
+		"wave_samples": {"bytes": [1, 2]},
+	}))
+
+	var stored: Dictionary = RomCache.read_json(json_path)
+	var record: Dictionary = (stored["music"] as Array)[0]
+	assert_eq(_span(record), [0, 3])
+	# A pointer field is small and byte-sized but is not a payload, so it stays.
+	assert_eq(int(record["bank"]), 2)
+	assert_eq(int(record["address"]), 0x4000)
+	assert_eq(_span(stored["wave_samples"]), [3, 2])
+	assert_eq(RomCache.read_blob(blob_path), PackedByteArray([7, 8, 9, 1, 2]))
+
+
+## JSON has one number type, so a span reads back as floats.
+func _span(record: Variant) -> Array:
+	var raw: Array = (record as Dictionary)[RomCache.PAYLOAD_KEY]
+	return [int(raw[0]), int(raw[1])]

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -89,3 +89,45 @@ func test_water_command_writes_the_imported_frame_and_done_loops() -> void:
 	assert_true(animation.tick())
 	assert_true(animation.tick())
 	assert_eq(animation.current_indices()[0], 1)
+
+
+func test_advance_paces_commands_by_elapsed_time_not_by_rendered_frames() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world)
+
+	# A frame shorter than one hardware frame runs no command at all, so a fast
+	# display cannot make the sequence run faster than the cartridge does.
+	assert_false(animation.advance(Gen2WorldAnimation.FRAME_SECONDS * 0.5))
+	assert_eq(animation.current_indices()[0], 0)
+
+	# The remainder carries over: two half frames are one whole one.
+	assert_true(animation.advance(Gen2WorldAnimation.FRAME_SECONDS * 0.5))
+	assert_eq(animation.current_indices()[0], 1)
+
+
+func test_advance_reports_no_redraw_when_the_command_changes_nothing() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world)
+
+	assert_true(animation.advance(Gen2WorldAnimation.FRAME_SECONDS))
+	# "done" only rewinds the command index, so nothing new is drawn and the
+	# renderer must not rebuild its atlas for it.
+	assert_false(animation.advance(Gen2WorldAnimation.FRAME_SECONDS))
+	# The water command runs again, but writes the frame that is already there.
+	assert_false(animation.advance(Gen2WorldAnimation.FRAME_SECONDS))
+
+
+func test_advance_drops_frames_after_a_stall_instead_of_running_the_backlog() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world)
+
+	# Ten seconds of stall is close to 600 hardware frames. Only the capped
+	# catch-up runs, so recovery costs a bounded amount of work.
+	animation.advance(10.0)
+	assert_lt(animation.command_index(), Gen2WorldAnimation.MAX_CATCHUP_FRAMES + 1)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -534,6 +534,29 @@ func test_warp_resolves_one_based_destination_and_reloads_the_target_map() -> vo
 	assert_eq(world.player_cell, Vector2i(2, 2))
 
 
+func test_roaming_mons_move_on_map_setup_and_not_on_elapsed_time() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(6, 6))
+	var random := RandomNumberGenerator.new()
+	random.seed = 2
+	world.schedule_random = random
+	var before: Array = world.roaming_mons()
+	assert_eq(before[0]["map_group"], 1)
+	assert_eq(before[0]["map_number"], 2)
+
+	# An hour of clock does not move a roamer: the cartridge advances them in
+	# map setup, so standing still keeps them where they are.
+	var clock := Gen2WorldClock.new(6, 0, 0)
+	clock.advance(60.0 * 60.0, world)
+	var after_clock: Array = world.roaming_mons()
+	assert_eq(after_clock[0]["map_group"], 1)
+	assert_eq(after_clock[0]["map_number"], 2)
+
+	assert_true(world.try_warp()["ok"])
+	var moved: Array = world.last_schedule().get("roaming", [])
+	assert_eq(moved.size(), 1)
+	assert_eq(world.roaming_mons()[0]["map_number"], 1)
+
+
 func test_map_transition_queues_target_callbacks_for_the_next_script_pump() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(6, 6))
 	var transition: Dictionary = world.try_warp()

--- a/tests/unit/test_world_clock.gd
+++ b/tests/unit/test_world_clock.gd
@@ -6,8 +6,8 @@ extends GutTest
 
 func test_clock_publishes_one_schedule_tick_per_completed_minute() -> void:
 	var clock := Gen2WorldClock.new(9, 59, 2)
-	assert_eq(clock.advance(59.9, null).size(), 0)
-	var ticks: Array = clock.advance(0.1, null)
+	assert_eq(clock.advance(59.9).size(), 0)
+	var ticks: Array = clock.advance(0.1)
 	assert_eq(ticks.size(), 1)
 	assert_eq(ticks[0]["day"], 2)
 	assert_eq(ticks[0]["hour"], 10)
@@ -18,9 +18,9 @@ func test_clock_publishes_one_schedule_tick_per_completed_minute() -> void:
 func test_clock_uses_source_time_of_day_boundaries_and_wraps_the_week() -> void:
 	var clock := Gen2WorldClock.new(17, 59, 6)
 	assert_eq(clock.time_of_day(), Gen2WorldPalette.TIME_DAY)
-	clock.advance(60.0, null)
+	clock.advance(60.0)
 	assert_eq(clock.time_of_day(), Gen2WorldPalette.TIME_NIGHT)
 	assert_eq(clock.day, 6)
-	clock.advance(6.0 * 60.0 * 60.0, null)
+	clock.advance(6.0 * 60.0 * 60.0)
 	assert_eq(clock.hour, 0)
 	assert_eq(clock.day, 0)

--- a/tools/validate_world_scripts.gd
+++ b/tools/validate_world_scripts.gd
@@ -56,7 +56,9 @@ func _validate(game_id: StringName) -> bool:
 	var failure_opcodes: Dictionary = {}
 	var command_names: Dictionary = {}
 	for raw_key: Variant in (scripts_value as Dictionary):
-		var bytes: PackedByteArray = _bytes(scripts_value[raw_key])
+		# Read through GameData rather than off the JSON: the cache stores byte
+		# runs as spans into a blob, and this checks the path the runtime uses.
+		var bytes: PackedByteArray = _pointer_bytes(data, String(raw_key), false)
 		if bytes.is_empty():
 			parse_failures += 1
 			failure_reasons["empty_script"] = int(failure_reasons.get("empty_script", 0)) + 1
@@ -86,8 +88,8 @@ func _validate(game_id: StringName) -> bool:
 	var invalid_text: int = 0
 	var invalid_text_reasons: Dictionary = {}
 	var invalid_text_samples: Array = []
-	for raw_value: Variant in (text_value as Dictionary).values():
-		var raw_text: PackedByteArray = _bytes(raw_value)
+	for raw_key: Variant in (text_value as Dictionary):
+		var raw_text: PackedByteArray = _pointer_bytes(data, String(raw_key), true)
 		var decoded: Dictionary = Gen2WorldScript.decode_text(raw_text)
 		if not bool(decoded.get("ok", false)):
 			invalid_text += 1
@@ -110,13 +112,14 @@ func _validate(game_id: StringName) -> bool:
 	return true
 
 
-func _bytes(value: Variant) -> PackedByteArray:
-	var out := PackedByteArray()
-	if not value is Array:
-		return out
-	for byte: Variant in value as Array:
-		out.append(int(byte))
-	return out
+## Resolves one "bank:address" cache key through the runtime accessor.
+func _pointer_bytes(data: GameData, key: String, text: bool) -> PackedByteArray:
+	var parts: PackedStringArray = key.split(":")
+	if parts.size() != 2:
+		return PackedByteArray()
+	var bank: int = int(parts[0])
+	var address: int = ("0x%s" % parts[1]).hex_to_int()
+	return data.world_text(bank, address) if text else data.world_script(bank, address)
 
 
 func _head(bytes: PackedByteArray) -> String:


### PR DESCRIPTION
A pass over the project ahead of a first build. Five changes: cache size and
load cost, tileset animation pacing, roaming fidelity, save ownership, and the
mod extension boundary.

773 tests pass, up from 758. Editor scan and headless boot are clean, ROM
verification is 3/3, all three cartridges re-import, the full audio corpus
decodes, and the script corpus returns its usual bounded diagnostics.

## Cache format 22: byte runs in binary blobs

Scripts, text and audio are almost entirely raw cartridge byte runs, written as
JSON arrays of decimal numbers: about four bytes on disk per cartridge byte, and
about twenty-six resident once parsed into an Array of Variants. Three files
were 96 MB of a 100 MB Crystal cache.

Each section now writes its runs into a `.bin` blob beside the JSON, which keeps
the pointers and an `[offset, length]` span. The blob is read as a
`PackedByteArray`, so a cartridge byte costs a byte. Only a named `bytes` field
is moved, never a small-number array that merely looks like one.

| | before | after |
|---|---:|---:|
| Cache, three games | 269 MB | 29 MB |
| Audio records, resident | 158 MiB | 6.5 MiB |
| Script corpus, resident | 85 MiB | 6.5 MiB |
| Text corpus, resident | 74 MiB | 5.2 MiB |

**This invalidates existing caches. Re-import after merging.**

The importer no longer round-trips the script, text and movement tables through
the cache between the world and service passes. The corpus validator reads
through `GameData`, which is the path the runtime uses; it was parsing the cache
JSON itself and would have reported every script empty.

## World sections load on first use

`GameData.open()` read every world file, and the launcher calls it once per
registry game just to draw a title and a species count. Listing three games cost
1.4 seconds and about a gigabyte.

| | before | after |
|---|---:|---:|
| Launcher lists three games | ~1,400 ms / ~1 GB | 22 ms / ~0 MiB |
| Open one game | 467 ms / 339 MiB | 6 ms / ~0 MiB |

The test suite runs in half the time as a side effect.

## Tileset animation runs at the cartridge's rate

`AnimateTileset` is called once per VBlank and runs one command per call. The
screen stepped it once per rendered frame, so water flowed at the monitor's
refresh rate: 2.4x fast on a 144 Hz display. It also reported a change for every
command, rebuilding the whole tile atlas and its texture 60 or more times a
second for waits and timer bumps that draw nothing.

It now runs on an elapsed-time accumulator at 1/59.7275 s, caps catch-up at four
frames after a stall, and reports a redraw only when tile bytes or a palette row
changed.

## Roaming Pokemon move on map setup

The clock advanced them once per game minute, so a player who stood still
watched Raikou cross Johto. The cartridge advances them during map setup, so the
trigger is now a map change.

## One owner for the selected save

`GameRuntime.selected_save()` re-read and re-parsed the slot on every call and
returned a fresh instance, and the world screen calls it several times per key
press. A battle result, a party transaction and a world snapshot each held a
different save, so only whichever wrote last survived. The slot is loaded once
and shared, and dropped when a new game or a cartridge import replaces the file.

## Mod boundary

`game/mods/` was empty and there were no extension points, so replacing the
world view meant editing the world screen.

`Gen2ModManifest` reads and validates a `mod.json` without executing any mod
code, so a launcher can list what is installed and say why something was
refused. An entry that is absolute, climbs out of the mod directory, or is not
GDScript is rejected; iOS forbids runtime native code, so a mod is interpreted
GDScript or it is nothing.

`Gen2ModHost` is the registry a mod is handed. It carries the world renderer
contract, refuses an incomplete registration by name rather than on the first
drawn frame, and builds a renderer per world so a selection can switch between
the built-in 2D view and a mod's while the game runs. A mod that fails to load
is reported and skipped.

The data layer was already shaped for this: maps are node-free records, each
tileset is one addressable atlas, animated tiles replace atlas slots rather than
map rectangles, and collision is a permission byte per walk cell. Contract and
rationale are in `docs/MODS.md`.

## Smaller cleanups

- `Gen2WorldRenderer.set_time_of_day()` wrote object visibility back into the
  world. A renderer reads world state and does not produce it.
- The two script resume boundaries ended with the same queue-draining loop
  copied twice; both now share one.