### PR TITLE
Add overworld callbacks and PC storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >
 > The launcher imports a verified dump, opens its cache's save screen, creates
 > or imports a party, and starts the development battle. The overworld slice
-> renders real maps, traverses connected maps, runs explicit script requests,
+> renders real maps, enters the imported Crystal home callbacks from a new
+> game, traverses connected maps, runs explicit script requests,
 > handles trainer battles, imported win/loss text, map reloads and save-safe
 > blackout recovery, and covers object lifecycle, bounded followers, block
 > edits, emotes, surf, grass, fishing, roaming, repel and deterministic wild
@@ -46,6 +47,11 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > gifts, eggs, imported NPC trades, common HP/status items, repel and the core
 > Poké Ball catch calculation behind a validated candidate-save boundary; wild
 > capture input uses that transaction.
+
+The party screen opens a first PC storage presentation with fourteen numbered
+boxes and twenty fixed slots per box. It can deposit into the current box's
+first free slot and withdraw into a party with room. Each transfer validates and
+writes a candidate save atomically, and the last party member cannot be boxed.
 > Crystal rooftop stock switches from the imported first list after the Hall of
 > Fame engine flag is committed. The imported bargain shop keeps its Monday
 > morning, one-item-per-visit and daily close behavior in the world snapshot.
@@ -182,9 +188,10 @@ Development scenes:
   fishing; with an imported cache pass game and map after the output path, such
   as `silver 2 5`. Its one-argument form remains a fixture smoke test.
 
-  `tools/preview_world_story.gd` exercises a real imported map entry callback,
+  `tools/preview_world_story.gd` exercises real imported map entry callbacks,
   event-flag object visibility and a facing object interaction without opening
-  the cartridge at runtime. For example:
+  the cartridge at runtime. The Crystal home map also covers source decoration
+  callbacks and the long initial event setup script. For example:
 
   ```bash
   godot --headless --path . -s res://tools/preview_world_story.gd -- \

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -80,6 +80,11 @@ validator, store and battle adapter scene-free. It validates against
 fixed fourteen-box, twenty-slot PC model, with migration from format 1 that
 does not invent a world snapshot. Party-owned world transactions must update a
 candidate save and live snapshot together, then restore both on a failed write.
+`Gen2SaveStorage` applies the same candidate, validator and temporary-file
+boundary to explicit party-to-box and box-to-party transfers; `box_screen.gd`
+owns selection and presentation only. Keep box names, current-box UI state and
+cartridge SRAM placement outside the model until their source ownership is
+verified.
 The original SRAM adapter is a separate, checksum-aware boundary and remains
 party-focused until cartridge box ownership and layout are explicitly
 researched.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -65,6 +65,13 @@ invent a world position. Item and currency references are
 checked against the selected cache, and `Gen2WorldAPI.open_snapshot()` restores
 the saved position without clamping it elsewhere.
 
+The party screen opens `box_screen.tscn`, which presents one of fourteen numbered
+boxes at a time with twenty fixed slots and a party selection column. Depositing
+uses the current box's first free slot; withdrawal requires party capacity. Both
+directions use `Gen2SaveStorage` to validate and write a candidate save before
+updating the shared runtime object. The screen's current box is transient UI
+state, and box names and cartridge SRAM placement remain outside the model.
+
 Party-owned overworld transactions first modify a candidate `Gen2SaveData` and
 live world snapshot. Gifts, eggs, NPC trades, item effects and catches commit
 only after validation and optional persistence; a failed write restores live

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -1,0 +1,372 @@
+class_name Gen2BoxScreen
+extends Control
+
+## First PC presentation: one numbered box, its twenty fixed slots, and the
+## explicit party/box transfer boundary. Box names and cartridge SRAM layout
+## remain outside this screen until their canonical source is verified.
+
+const BACKGROUND: Color = Color("#09111f")
+const PANEL: Color = Color("#14233a")
+const BORDER: Color = Color("#2d4566")
+const TEXT: Color = Color("#f4f7fb")
+const MUTED: Color = Color("#9eacc0")
+const ACCENT: Color = Color("#f3c969")
+const SUCCESS: Color = Color("#7bd89a")
+const ERROR: Color = Color("#ef8a8a")
+
+var _data: GameData = null
+var _data_override: GameData = null
+var _save: Gen2SaveData = null
+var _save_override: Gen2SaveData = null
+var _box_index: int = 0
+var _selected_box_slot: int = -1
+var _selected_party_index: int = -1
+var _box_title: Label = null
+var _party_members: VBoxContainer = null
+var _box_grid: GridContainer = null
+var _selection: Label = null
+var _status: Label = null
+
+
+func _ready() -> void:
+	_data = _data_override if _data_override != null else _resolve_data()
+	_save = _save_override if _save_override != null else _resolve_save()
+	_build_ui()
+	_refresh()
+
+
+## Test seam for a synthetic cache and validated save.
+func set_context(data: GameData, save: Gen2SaveData) -> void:
+	_data_override = data
+	_save_override = save
+	_data = data
+	_save = save
+	if is_inside_tree() and _box_grid != null:
+		_refresh()
+
+
+func box_snapshot() -> Dictionary:
+	var boxes: Array = []
+	if _save != null:
+		for box_index: int in Gen2SaveData.BOX_COUNT:
+			var slots: Array = []
+			var box: Gen2SaveBox = _save.boxes[box_index] if box_index < _save.boxes.size() else null
+			for slot: int in Gen2SaveBox.CAPACITY:
+				var mon: Gen2SaveMon = box.slots[slot] if box != null and slot < box.slots.size() else null
+				slots.append(_mon_snapshot(box_index, slot, mon))
+			boxes.append({"index": box_index, "slots": slots})
+	return {
+		"box": _box_index,
+		"selected_box_slot": _selected_box_slot,
+		"selected_party_index": _selected_party_index,
+		"boxes": boxes,
+	}
+
+
+func select_box(box_index: int) -> bool:
+	if _save == null or box_index < 0 or box_index >= _save.boxes.size():
+		return false
+	_box_index = box_index
+	_selected_box_slot = -1
+	if _box_grid != null:
+		_refresh()
+	return true
+
+
+func select_box_slot(slot: int) -> bool:
+	if slot < 0 or slot >= Gen2SaveBox.CAPACITY:
+		return false
+	_selected_box_slot = slot
+	_selected_party_index = -1
+	if _box_grid != null:
+		_refresh_selection()
+	return true
+
+
+func select_party_member(index: int) -> bool:
+	if _save == null or index < 0 or index >= _save.party.size():
+		return false
+	_selected_party_index = index
+	_selected_box_slot = -1
+	if _party_members != null:
+		_refresh_selection()
+	return true
+
+
+func deposit_selected_party() -> bool:
+	if _save == null or _selected_party_index < 0:
+		_set_status("Select a party member first.", ERROR)
+		return false
+	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(
+		_save, _data, _selected_party_index, _box_index
+	)
+	if not bool(result.get("ok", false)):
+		_set_status(String(result.get("message", result.get("reason", "Deposit refused."))), ERROR)
+		return false
+	_set_status("Moved to Box %d slot %d." % [int(result["box"]) + 1, int(result["slot"]) + 1], SUCCESS)
+	_selected_party_index = -1
+	_refresh()
+	return true
+
+
+func withdraw_selected_box() -> bool:
+	if _save == null or _selected_box_slot < 0:
+		_set_status("Select a stored Pokémon first.", ERROR)
+		return false
+	var result: Dictionary = Gen2SaveStorage.withdraw_box_to_party(
+		_save, _data, _box_index, _selected_box_slot
+	)
+	if not bool(result.get("ok", false)):
+		_set_status(String(result.get("message", result.get("reason", "Withdrawal refused."))), ERROR)
+		return false
+	_set_status("Moved to party slot %d." % (int(result["party_index"]) + 1), SUCCESS)
+	_selected_box_slot = -1
+	_refresh()
+	return true
+
+
+func _resolve_data() -> GameData:
+	return GameRuntime.selected_data() if GameRuntime.has_selected_game() else GameData.open_any()
+
+
+func _resolve_save() -> Gen2SaveData:
+	if _data == null or not GameRuntime.has_selected_save_slot():
+		return null
+	return GameRuntime.selected_save()
+
+
+func _build_ui() -> void:
+	var background := ColorRect.new()
+	background.color = BACKGROUND
+	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	background.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(background)
+
+	var margin := MarginContainer.new()
+	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	margin.add_theme_constant_override("margin_left", 42)
+	margin.add_theme_constant_override("margin_top", 30)
+	margin.add_theme_constant_override("margin_right", 42)
+	margin.add_theme_constant_override("margin_bottom", 30)
+	add_child(margin)
+
+	var content := VBoxContainer.new()
+	content.add_theme_constant_override("separation", 12)
+	margin.add_child(content)
+
+	var header := HBoxContainer.new()
+	header.add_theme_constant_override("separation", 12)
+	content.add_child(header)
+	var heading := VBoxContainer.new()
+	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	heading.add_theme_constant_override("separation", 3)
+	header.add_child(heading)
+	var title := Label.new()
+	title.text = "PC STORAGE"
+	title.add_theme_color_override("font_color", TEXT)
+	title.add_theme_font_size_override("font_size", 30)
+	heading.add_child(title)
+	var subtitle := Label.new()
+	subtitle.text = "Party and fixed twenty-slot boxes"
+	subtitle.add_theme_color_override("font_color", MUTED)
+	heading.add_child(subtitle)
+	var previous := _button("Previous box", TEXT)
+	previous.pressed.connect(_previous_box)
+	header.add_child(previous)
+	var next := _button("Next box", TEXT)
+	next.pressed.connect(_next_box)
+	header.add_child(next)
+	var back := _button("Back to party", TEXT)
+	back.pressed.connect(_back)
+	header.add_child(back)
+
+	_box_title = Label.new()
+	_box_title.add_theme_color_override("font_color", ACCENT)
+	_box_title.add_theme_font_size_override("font_size", 18)
+	content.add_child(_box_title)
+
+	var main := HBoxContainer.new()
+	main.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	main.add_theme_constant_override("separation", 18)
+	content.add_child(main)
+
+	var box_panel := PanelContainer.new()
+	box_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	box_panel.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 8))
+	main.add_child(box_panel)
+	var box_margin := MarginContainer.new()
+	box_margin.add_theme_constant_override("margin_left", 14)
+	box_margin.add_theme_constant_override("margin_top", 14)
+	box_margin.add_theme_constant_override("margin_right", 14)
+	box_margin.add_theme_constant_override("margin_bottom", 14)
+	box_panel.add_child(box_margin)
+	_box_grid = GridContainer.new()
+	_box_grid.columns = 4
+	_box_grid.add_theme_constant_override("h_separation", 8)
+	_box_grid.add_theme_constant_override("v_separation", 8)
+	box_margin.add_child(_box_grid)
+
+	var side := VBoxContainer.new()
+	side.custom_minimum_size.x = 300
+	side.add_theme_constant_override("separation", 10)
+	main.add_child(side)
+	var party_heading := Label.new()
+	party_heading.text = "PARTY"
+	party_heading.add_theme_color_override("font_color", TEXT)
+	party_heading.add_theme_font_size_override("font_size", 18)
+	side.add_child(party_heading)
+	_party_members = VBoxContainer.new()
+	_party_members.add_theme_constant_override("separation", 6)
+	side.add_child(_party_members)
+	var deposit := _button("Deposit selected party member", ACCENT)
+	deposit.pressed.connect(deposit_selected_party)
+	side.add_child(deposit)
+	var withdraw := _button("Withdraw selected box slot", ACCENT)
+	withdraw.pressed.connect(withdraw_selected_box)
+	side.add_child(withdraw)
+	_selection = Label.new()
+	_selection.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_selection.custom_minimum_size.y = 56
+	_selection.add_theme_color_override("font_color", MUTED)
+	side.add_child(_selection)
+
+	_status = Label.new()
+	_status.add_theme_color_override("font_color", MUTED)
+	content.add_child(_status)
+
+
+func _refresh() -> void:
+	if _box_grid == null:
+		return
+	for child: Node in _box_grid.get_children():
+		child.free()
+	for slot: int in Gen2SaveBox.CAPACITY:
+		var button := _button(_slot_text(slot), TEXT)
+		button.custom_minimum_size = Vector2(170, 58)
+		button.pressed.connect(_select_box_slot.bind(slot))
+		_box_grid.add_child(button)
+	if _party_members != null:
+		for child: Node in _party_members.get_children():
+			child.free()
+		for index: int in Gen2SaveData.MAX_PARTY:
+			var member := _button(_party_text(index), TEXT)
+			member.custom_minimum_size = Vector2(280, 40)
+			if _save != null and index < _save.party.size():
+				member.pressed.connect(_select_party_member.bind(index))
+			else:
+				member.disabled = true
+			_party_members.add_child(member)
+	if _box_title != null:
+		_box_title.text = "Box %d of %d" % [_box_index + 1, Gen2SaveData.BOX_COUNT]
+	_refresh_selection()
+
+
+func _refresh_selection() -> void:
+	if _selection == null:
+		return
+	if _save == null:
+		_selection.text = "No validated save selected."
+		_set_status("No validated save selected.", ERROR)
+		return
+	if _selected_party_index >= 0 and _selected_party_index < _save.party.size():
+		_selection.text = "Selected party: %s\nDeposit uses the first free slot in Box %d." % [
+			_display_name(_save.party[_selected_party_index]), _box_index + 1,
+		]
+		return
+	if _selected_box_slot >= 0:
+		var box: Gen2SaveBox = _save.boxes[_box_index]
+		var mon: Gen2SaveMon = box.slots[_selected_box_slot] if box != null else null
+		_selection.text = "Selected Box %d slot %d: %s" % [
+			_box_index + 1, _selected_box_slot + 1,
+			_display_name(mon) if mon != null else "Empty",
+		]
+		return
+	_selection.text = "Select a party member or a stored Pokémon."
+
+
+func _slot_text(slot: int) -> String:
+	if _save == null or _box_index >= _save.boxes.size() or _save.boxes[_box_index] == null:
+		return "%02d\nEmpty" % (slot + 1)
+	var mon: Gen2SaveMon = _save.boxes[_box_index].slots[slot]
+	if mon == null:
+		return "%02d\nEmpty" % (slot + 1)
+	return "%02d  %s\nLv %d" % [slot + 1, _display_name(mon), mon.level]
+
+
+func _party_text(index: int) -> String:
+	if _save == null or index >= _save.party.size():
+		return "%d  Empty" % (index + 1)
+	var mon: Gen2SaveMon = _save.party[index]
+	return "%d  %s  Lv %d" % [index + 1, _display_name(mon), mon.level]
+
+
+func _mon_snapshot(box: int, slot: int, mon: Gen2SaveMon) -> Dictionary:
+	if mon == null:
+		return {"empty": true, "box": box, "slot": slot}
+	return {
+		"empty": false, "box": box, "slot": slot,
+		"name": _display_name(mon), "species": mon.species, "level": mon.level,
+	}
+
+
+func _display_name(mon: Gen2SaveMon) -> String:
+	if mon == null:
+		return "Empty"
+	if not mon.nickname.is_empty():
+		return mon.nickname
+	return String(_data.species(mon.species).get("name", "UNKNOWN")) if _data != null else "UNKNOWN"
+
+
+func _previous_box() -> void:
+	if _save != null:
+		_box_index = posmod(_box_index - 1, Gen2SaveData.BOX_COUNT)
+		_selected_box_slot = -1
+		_refresh()
+
+
+func _next_box() -> void:
+	if _save != null:
+		_box_index = posmod(_box_index + 1, Gen2SaveData.BOX_COUNT)
+		_selected_box_slot = -1
+		_refresh()
+
+
+func _select_box_slot(slot: int) -> void:
+	select_box_slot(slot)
+
+
+func _select_party_member(index: int) -> void:
+	select_party_member(index)
+
+
+func _set_status(message: String, colour: Color) -> void:
+	if _status == null:
+		return
+	_status.text = message
+	_status.add_theme_color_override("font_color", colour)
+
+
+func _back() -> void:
+	get_tree().change_scene_to_file.call_deferred("res://game/save/party_screen.tscn")
+
+
+func _button(text: String, colour: Color) -> Button:
+	var button := Button.new()
+	button.text = text
+	button.add_theme_color_override("font_color", colour)
+	button.add_theme_color_override("font_hover_color", Color.WHITE)
+	button.add_theme_font_size_override("font_size", 14)
+	return button
+
+
+func _panel_style(fill: Color, line: Color, radius: int) -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = fill
+	style.border_color = line
+	style.set_border_width_all(1)
+	style.set_corner_radius_all(radius)
+	style.content_margin_left = 18
+	style.content_margin_top = 14
+	style.content_margin_right = 18
+	style.content_margin_bottom = 14
+	return style

--- a/game/save/box_screen.gd.uid
+++ b/game/save/box_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://ca0i3k7s3npuk

--- a/game/save/box_screen.tscn
+++ b/game/save/box_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://game/save/box_screen.gd" id="1"]
+
+[node name="BoxScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -103,6 +103,10 @@ func _build_ui() -> void:
 	var back := _button("Back to save slots", TEXT)
 	back.custom_minimum_size = Vector2(190, 44)
 	back.pressed.connect(_back)
+	var storage := _button("Open PC storage", ACCENT)
+	storage.custom_minimum_size = Vector2(170, 44)
+	storage.pressed.connect(_open_storage)
+	header.add_child(storage)
 	header.add_child(back)
 
 	_player_label = Label.new()
@@ -237,6 +241,18 @@ func _start_battle() -> void:
 
 func _back() -> void:
 	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
+
+
+func _open_storage() -> void:
+	if _data == null or _save == null:
+		_status.text = "No validated save selected."
+		_status.add_theme_color_override("font_color", ERROR)
+		return
+	if not GameRuntime.select_save_slot(_data.id, _save.slot):
+		_status.text = "The selected cartridge is not in the registry."
+		_status.add_theme_color_override("font_color", ERROR)
+		return
+	get_tree().change_scene_to_file.call_deferred("res://game/save/box_screen.tscn")
 
 
 func _button(text: String, colour: Color) -> Button:

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -144,3 +144,23 @@ func add_party_or_box(mon: Gen2SaveMon) -> Dictionary:
 		"box": int(destination["box"]),
 		"slot": int(destination["slot"]),
 	}
+
+
+## Replaces this shared runtime save with a validated candidate while keeping
+## the object identity that GameRuntime and open screens already reference.
+func copy_from(source: Gen2SaveData) -> bool:
+	if source == null:
+		return false
+	var copied: Gen2SaveData = Gen2SaveData.from_dict(source.to_dict())
+	if copied == null:
+		return false
+	format_version = copied.format_version
+	game_id = copied.game_id
+	rom_sha1 = copied.rom_sha1
+	slot = copied.slot
+	player_name = copied.player_name
+	party = copied.party
+	boxes = copied.boxes
+	world = copied.world
+	boxes_shape_valid = copied.boxes_shape_valid
+	return true

--- a/game/save/save_storage.gd
+++ b/game/save/save_storage.gd
@@ -1,0 +1,137 @@
+class_name Gen2SaveStorage
+extends RefCounted
+
+## Atomic party and PC-box transactions for a validated project save.
+##
+## Each operation edits a deep candidate, validates it against the selected
+## cartridge cache, writes it through the save store, and only then updates the
+## shared runtime save object. A failed write or validation therefore leaves
+## both the in-memory and on-disk save untouched.
+
+
+static func deposit_party_to_box(
+	save: Gen2SaveData,
+	data: GameData,
+	party_index: int,
+	box_index: int = -1,
+	box_slot: int = -1,
+) -> Dictionary:
+	var candidate_result: Dictionary = _candidate(save, data)
+	if not bool(candidate_result.get("ok", false)):
+		return candidate_result
+	var candidate: Gen2SaveData = candidate_result["save"]
+	if party_index < 0 or party_index >= candidate.party.size():
+		return _failure(&"invalid_party_index")
+	if candidate.party.size() <= 1:
+		return _failure(&"last_party_member")
+	var mon: Gen2SaveMon = candidate.party[party_index]
+	if mon == null:
+		return _failure(&"missing_pokemon")
+	var destination: Dictionary = _box_destination(candidate, box_index, box_slot)
+	if not bool(destination.get("ok", false)):
+		return destination
+	var box: Gen2SaveBox = candidate.boxes[int(destination["box"])]
+	var placed: Dictionary = box.put(mon, int(destination["slot"]))
+	if not bool(placed.get("ok", false)):
+		return _failure(StringName(placed.get("reason", &"box_insert_failed")))
+	candidate.party.remove_at(party_index)
+	return _commit(save, data, candidate, {
+		"kind": &"party_to_box",
+		"party_index": party_index,
+		"box": int(destination["box"]),
+		"slot": int(destination["slot"]),
+	})
+
+
+static func withdraw_box_to_party(
+	save: Gen2SaveData,
+	data: GameData,
+	box_index: int,
+	box_slot: int,
+) -> Dictionary:
+	var candidate_result: Dictionary = _candidate(save, data)
+	if not bool(candidate_result.get("ok", false)):
+		return candidate_result
+	var candidate: Gen2SaveData = candidate_result["save"]
+	if box_index < 0 or box_index >= candidate.boxes.size():
+		return _failure(&"invalid_box_index")
+	if box_slot < 0 or box_slot >= Gen2SaveBox.CAPACITY:
+		return _failure(&"invalid_box_slot")
+	if candidate.party.size() >= Gen2SaveData.MAX_PARTY:
+		return _failure(&"party_full")
+	var box: Gen2SaveBox = candidate.boxes[box_index]
+	if box == null or box_slot >= box.slots.size():
+		return _failure(&"invalid_box_shape")
+	var mon: Gen2SaveMon = box.slots[box_slot]
+	if mon == null:
+		return _failure(&"empty_box_slot")
+	box.slots[box_slot] = null
+	candidate.party.append(mon)
+	return _commit(save, data, candidate, {
+		"kind": &"box_to_party",
+		"party_index": candidate.party.size() - 1,
+		"box": box_index,
+		"slot": box_slot,
+	})
+
+
+static func _candidate(save: Gen2SaveData, data: GameData) -> Dictionary:
+	if save == null or data == null:
+		return _failure(&"missing_save_context")
+	var candidate: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	if candidate == null:
+		return _failure(&"invalid_save_shape")
+	var validation: Dictionary = Gen2SaveValidator.validate(save, data)
+	if not bool(validation.get("ok", false)):
+		return {
+			"ok": false,
+			"reason": &"invalid_save",
+			"message": validation.get("message", "save validation failed"),
+		}
+	return {"ok": true, "save": candidate}
+
+
+static func _box_destination(
+	save: Gen2SaveData, box_index: int, box_slot: int
+) -> Dictionary:
+	if box_index < 0:
+		return save.first_empty_box_slot()
+	if box_index >= save.boxes.size():
+		return _failure(&"invalid_box_index")
+	var box: Gen2SaveBox = save.boxes[box_index]
+	if box == null:
+		return _failure(&"invalid_box_shape")
+	var target_slot: int = box_slot if box_slot >= 0 else box.first_empty_slot()
+	if target_slot < 0:
+		return _failure(&"box_full")
+	if target_slot >= Gen2SaveBox.CAPACITY:
+		return _failure(&"invalid_box_slot")
+	if target_slot >= box.slots.size():
+		return _failure(&"invalid_box_shape")
+	if box.slots[target_slot] != null:
+		return _failure(&"box_slot_occupied")
+	return {"ok": true, "box": box_index, "slot": target_slot}
+
+
+static func _commit(
+	source: Gen2SaveData,
+	data: GameData,
+	candidate: Gen2SaveData,
+	transaction: Dictionary,
+) -> Dictionary:
+	var write: Dictionary = Gen2SaveStore.save(candidate, data)
+	if not bool(write.get("ok", false)):
+		return {
+			"ok": false,
+			"reason": &"save_failed",
+			"message": write.get("message", "save failed"),
+		}
+	source.copy_from(candidate)
+	var result: Dictionary = {"ok": true, "message": ""}
+	for key: Variant in transaction:
+		result[key] = transaction[key]
+	return result
+
+
+static func _failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "reason": reason, "message": String(reason)}

--- a/game/save/save_storage.gd.uid
+++ b/game/save/save_storage.gd.uid
@@ -1,0 +1,1 @@
+uid://c4bgk8wjiojqn

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -33,6 +33,7 @@ var _object_visibility_overrides: Dictionary = {}
 var _object_position_overrides: Dictionary = {}
 var _object_facing_overrides: Dictionary = {}
 var _object_followers: Dictionary = {}
+var _variable_sprites: Dictionary = {}
 var _block_overrides: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
@@ -1062,6 +1063,21 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 		if event_type == &"map_reload_requested":
 			generated.append(reload_current_map())
 			continue
+		if event_type == &"variable_sprite_changed":
+			var variable_sprite: int = int(event.get("variable_sprite", -1))
+			var sprite: int = int(event.get("sprite", 0))
+			if variable_sprite < Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE \
+				or sprite <= 0:
+				generated.append({"type": &"variable_sprite_change_failed"})
+				continue
+			_variable_sprites[variable_sprite] = sprite
+			reload_objects = true
+			generated.append({
+				"type": &"variable_sprite_changed",
+				"variable_sprite": variable_sprite,
+				"sprite": sprite,
+			})
+			continue
 		if event_type == &"map_refresh_requested":
 			generated.append({"type": &"map_refreshed", "map": map_id()})
 			continue
@@ -1802,9 +1818,14 @@ func _load_objects() -> void:
 	var rows: Array = current_map.events.get("objects", [])
 	for index: int in rows.size():
 		var value: Dictionary = rows[index]
-		var sprite_number: int = int(value.get("sprite", 0))
+		var source_sprite_number: int = int(value.get("sprite", 0))
+		var sprite_number: int = int(_variable_sprites.get(
+			source_sprite_number, source_sprite_number
+		))
 		var sprite: Gen2WorldSprite = data.overworld_sprite(sprite_number)
-		var object: Gen2WorldObject = Gen2WorldObject.from_event(index, value, sprite)
+		var object_event: Dictionary = value.duplicate(true)
+		object_event["sprite"] = sprite_number
+		var object: Gen2WorldObject = Gen2WorldObject.from_event(index, object_event, sprite)
 		var key: String = _object_key(current_map.group, current_map.number, index)
 		if _object_position_overrides.has(key):
 			object.cell = _object_position_overrides[key]

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -108,7 +108,9 @@ const TEXT_PAGE: int = 0x50
 const TEXT_TERMINATOR: int = 0x57
 const TEXT_PROMPT: int = 0x58
 
-const MAX_COMMANDS: int = 128
+## Long map-entry initialization callbacks can include the cartridge's full
+## event-variable setup routine, which is larger than one hundred commands.
+const MAX_COMMANDS: int = 512
 const MAX_CALL_DEPTH: int = 8
 const MAX_SCRIPT_BYTES: int = 512
 const MAX_TEXT_BYTES: int = 1024

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -52,10 +52,23 @@ const PHONE_CONTACT_GOT: int = 0
 const PHONE_CONTACTS_FULL: int = 1
 const PHONE_CONTACT_REFUSED: int = 2
 const SPECIAL_ACTIVATE_FISHING_SWARM: int = 72
+const SPECIAL_TOGGLE_MAPTILE_DECORATIONS: int = 73
+const SPECIAL_TOGGLE_DECORATIONS_VISIBILITY: int = 74
 const SPECIAL_RANDOM_UNSEEN_WILD_MON: int = 91
 const SPECIAL_RANDOM_PHONE_WILD_MON: int = 92
 const SPECIAL_RANDOM_PHONE_MON: int = 93
 const TEXT_STRING_BUFFER: int = 0x14
+
+## Crystal event flags used by the player's room decoration callbacks. The
+## importer keeps raw cartridge flag numbers, so these values match the
+## source event flag table rather than a project-local enum.
+const EVENT_TEMPORARY_UNTIL_MAP_RELOAD_8: int = 7
+const EVENT_PLAYERS_ROOM_POSTER: int = 716
+const EVENT_PLAYERS_HOUSE_2F_CONSOLE: int = 1857
+const EVENT_PLAYERS_HOUSE_2F_DOLL_1: int = 1858
+const EVENT_PLAYERS_HOUSE_2F_DOLL_2: int = 1859
+const EVENT_PLAYERS_HOUSE_2F_BIG_DOLL: int = 1860
+const VARIABLE_SPRITE_BASE: int = 0xF0
 
 
 static func begin(
@@ -465,7 +478,7 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.CHECKCELLNUM:
 			_script_value = 1 if _phone_contact_registered(int(command["value"])) else 0
 		Gen2WorldScript.SPECIAL:
-			return _execute_phone_special(int(command["value"]))
+			return _execute_special(int(command["value"]))
 		Gen2WorldScript.RANDOM:
 			var maximum: int = int(command["value"])
 			_script_value = randi_range(0, maximum - 1) if maximum > 0 else 0
@@ -749,6 +762,13 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 			})
 		0x87:
 			return _stage_audio_request(&"special_sound", {"item": _last_item})
+		0x6C:
+			## variablesprite stores a sprite id in the source's variable-sprite
+			## table. The first operand is an index relative to SPRITE_VARS.
+			_emit_runtime_event(&"variable_sprite_changed", {
+				"variable_sprite": VARIABLE_SPRITE_BASE + int(command.get("value", 0)),
+				"sprite": int(command.get("value_2", 0)),
+			})
 		0x8A, 0x8B:
 			_emit_runtime_event(&"script_timing_requested", {
 				"kind": &"pause" if source_opcode == 0x8A else &"deactivate_facing",
@@ -815,7 +835,7 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 	var handled_sources: Array = [
 		0x57, 0x58, 0x5C, 0x5D, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64,
 		0x65, 0x66, 0x7F, 0x81, 0x82, 0x85, 0x8A, 0x8B, 0x98,
-		0x73, 0x74, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
+		0x6C, 0x73, 0x74, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
 	]
 	if source_opcode in handled_sources:
 		return {"ok": true}
@@ -1137,15 +1157,39 @@ func _clock_hour() -> int:
 	return clampi(int(clock.get("hour", 0)), 0, 23)
 
 
-func _execute_phone_special(special: int) -> Dictionary:
-	## These IDs are the source SpecialsPointers entries used by imported phone
-	## scripts. The random phone routines write StringBuffer4, while the
-	## fishing routine preserves wScriptVar as its species flag.
+func _execute_special(special: int) -> Dictionary:
+	## SPECIAL is a shared cartridge dispatch table. Phone routines are only one
+	## part of it; map callbacks also use the adjacent decoration routines.
 	match special:
 		SPECIAL_ACTIVATE_FISHING_SWARM:
 			_emit_runtime_event(&"phone_special_requested", {
 				"special": special, "kind": &"activate_fishing_swarm",
 				"species": _script_value,
+			})
+		SPECIAL_TOGGLE_MAPTILE_DECORATIONS:
+			## A fresh project save has no imported bedroom decoration selection.
+			## Crystal's default decoration values are zero, which leaves the
+			## decoration blocks unchanged and hides the room poster.
+			_staged_flags[EVENT_PLAYERS_ROOM_POSTER] = false
+			_emit_runtime_event(&"decoration_callback_applied", {
+				"special": special,
+				"kind": &"toggle_maptile_decorations",
+				"defaults": true,
+			})
+		SPECIAL_TOGGLE_DECORATIONS_VISIBILITY:
+			## With the default zero decoration selections, ToggleDecorationVisibility
+			## sets each object event flag and the renderer removes those objects.
+			for flag: int in [
+				EVENT_PLAYERS_HOUSE_2F_CONSOLE,
+				EVENT_PLAYERS_HOUSE_2F_DOLL_1,
+				EVENT_PLAYERS_HOUSE_2F_DOLL_2,
+				EVENT_PLAYERS_HOUSE_2F_BIG_DOLL,
+			]:
+				_staged_flags[flag] = true
+			_emit_runtime_event(&"decoration_callback_applied", {
+				"special": special,
+				"kind": &"toggle_decorations_visibility",
+				"defaults": true,
 			})
 		SPECIAL_RANDOM_UNSEEN_WILD_MON:
 			var rare_species: int = _phone_unseen_rare_species()

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -6,6 +6,7 @@ var _directory: String = ""
 var _data: GameData = null
 var _screen: Gen2SaveScreen = null
 var _party_screen: Gen2PartyScreen = null
+var _box_screen: Gen2BoxScreen = null
 var _save_directory: String = ""
 
 
@@ -22,7 +23,10 @@ func after_each() -> void:
 	_screen = null
 	if is_instance_valid(_party_screen):
 		_party_screen.free()
-	_party_screen = null
+		_party_screen = null
+	if is_instance_valid(_box_screen):
+		_box_screen.free()
+		_box_screen = null
 	_clear_saves()
 	RomCache.clear(_directory)
 
@@ -48,6 +52,15 @@ func _save() -> Gen2SaveData:
 	return save
 
 
+func _save_with_two() -> Gen2SaveData:
+	var save: Gen2SaveData = _save()
+	var second: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.GEODUDE, 18, [Fixture.GROWL]
+	)
+	save.party.append(Gen2SaveBattleAdapter.from_battle_mon(second))
+	return save
+
+
 func _open_save_screen() -> void:
 	var packed: PackedScene = load("res://game/save/save_screen.tscn")
 	_screen = packed.instantiate()
@@ -61,6 +74,14 @@ func _open_party_screen(save: Gen2SaveData) -> void:
 	_party_screen = packed.instantiate()
 	_party_screen.set_context(_data, save)
 	add_child(_party_screen)
+	await get_tree().process_frame
+
+
+func _open_box_screen(save: Gen2SaveData) -> void:
+	var packed: PackedScene = load("res://game/save/box_screen.tscn")
+	_box_screen = packed.instantiate()
+	_box_screen.set_context(_data, save)
+	add_child(_box_screen)
 	await get_tree().process_frame
 
 
@@ -139,3 +160,42 @@ func test_party_screen_exposes_saved_hp_status_and_empty_positions() -> void:
 	assert_eq((members[0] as Dictionary)["status"], "POISON")
 	assert_false((members[0] as Dictionary)["empty"])
 	assert_true((members[1] as Dictionary)["empty"])
+
+
+func test_box_screen_exposes_all_fourteen_fixed_boxes_and_slots() -> void:
+	var save: Gen2SaveData = _save()
+	await _open_box_screen(save)
+	var snapshot: Dictionary = _box_screen.box_snapshot()
+	var boxes: Array = snapshot["boxes"]
+	assert_eq(boxes.size(), Gen2SaveData.BOX_COUNT)
+	assert_eq((boxes[0]["slots"] as Array).size(), Gen2SaveBox.CAPACITY)
+	assert_true((boxes[0]["slots"][0] as Dictionary)["empty"])
+
+
+func test_pc_storage_moves_party_to_box_and_back_through_atomic_save() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	var initial_write: Dictionary = Gen2SaveStore.save(save, _data)
+	assert_true(initial_write["ok"], initial_write["message"])
+	await _open_box_screen(save)
+	assert_true(_box_screen.select_party_member(0))
+	assert_true(_box_screen.deposit_selected_party())
+	assert_eq(save.party.size(), 1)
+	assert_not_null(save.boxes[0].slots[0])
+	assert_true(_box_screen.select_box_slot(0))
+	assert_true(_box_screen.withdraw_selected_box())
+	assert_eq(save.party.size(), 2)
+	assert_null(save.boxes[0].slots[0])
+	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, save.slot, _data)
+	assert_true(loaded["ok"], loaded["message"])
+	var restored: Gen2SaveData = loaded["save"]
+	assert_eq(restored.party.size(), 2)
+	assert_null(restored.boxes[0].slots[0])
+
+
+func test_pc_storage_refuses_depositing_the_last_party_member() -> void:
+	var save: Gen2SaveData = _save()
+	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(save, _data, 0, 0)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"last_party_member")
+	assert_eq(save.party.size(), 1)
+	assert_null(save.boxes[0].slots[0])

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -420,6 +420,45 @@ func test_phone_special_ids_match_the_source_phone_routines() -> void:
 	assert_eq(_event_value(result[0]["events"], &"phone_special_requested", "kind", 3), &"random_phone_mon")
 
 
+func test_map_decoration_specials_apply_the_default_room_state() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6250"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_TOGGLE_DECORATIONS_VISIBILITY, 0,
+		Gen2WorldScript.ENDCALLBACK,
+	]
+	scripts["48:6260"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_TOGGLE_MAPTILE_DECORATIONS, 0,
+		Gen2WorldScript.ENDCALLBACK,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var map: Gen2WorldMap = data.world_map(1, 1)
+	map.scripts["callbacks"] = [
+		{"type": 5, "script": 0x6250},
+		{"type": 1, "script": 0x6260},
+	]
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var result: Array = world.dispatch_map_entry()
+	assert_eq(result.size(), 2, JSON.stringify(result))
+	for callback_result: Dictionary in result:
+		assert_eq(callback_result["status"], &"complete", JSON.stringify(result))
+	assert_true(world.event_flag_active(Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_CONSOLE))
+	assert_true(world.event_flag_active(Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_DOLL_1))
+	assert_true(world.event_flag_active(Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_DOLL_2))
+	assert_true(world.event_flag_active(Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_BIG_DOLL))
+	assert_false(world.event_flag_active(Gen2WorldScriptRunner.EVENT_PLAYERS_ROOM_POSTER))
+	assert_eq(
+		_event_value(result[0]["events"], &"decoration_callback_applied", "kind"),
+		&"toggle_decorations_visibility",
+		JSON.stringify(result),
+	)
+	assert_eq(
+		_event_value(result[1]["events"], &"decoration_callback_applied", "kind"),
+		&"toggle_maptile_decorations",
+		JSON.stringify(result),
+	)
+
+
 func test_random_unseen_wild_mon_uses_morning_rare_slots_and_seen_species() -> void:
 	_write_service_cache()
 	var species: Array = []

--- a/tools/preview_world_story.gd.uid
+++ b/tools/preview_world_story.gd.uid
@@ -1,0 +1,1 @@
+uid://bsqh6kwky7cwu


### PR DESCRIPTION
Promote imported Crystal home callbacks through the world runner, including bedroom decoration specials, variable sprites, and the longer initialization callback. Add the first fourteen-box PC screen with atomic party and box transfers. Preserve generated UID sidecars and update the project handoff and save documentation.