### PR TITLE
Start new games empty; defer starter to Elm lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ godot --headless --path . --quit-after 30
 
 The launcher lists Gold, Silver and Crystal cache status, imports a selected
 ROM, and opens its save screen. It provides three validated slots, new games
-with Chikorita, Cyndaquil or Totodile at level 5, original `.sav` import, party
-inspection and the development battle. New games use the verified Crystal home
-spawn and source starting money when that map exists. Continue enters the
+with an empty party until Professor Elm's imported lab handoff, original `.sav`
+import, party inspection and the development battle. The lab scripts then offer
+Chikorita, Cyndaquil or Totodile at level 5 with Berry, using the verified Crystal
+home spawn and source starting money when that map exists. Continue enters the
 overworld; F5 saves its map, inventory, event and clock snapshot. See
 [docs/SAVES.md](docs/SAVES.md) for the save and SRAM contract.
 
@@ -212,10 +213,11 @@ Development scenes:
     crystal 24 7 2 2 1 none home
   ```
 
-  The bounded first-floor story preview follows production movement from the
-  bedroom to Players House 1F, executes the imported Mom setup with weekday
-  and daylight-saving prompts, then reaches the imported New Bark Town teacher
-  scene:
+  The bounded story preview follows production movement from the bedroom to
+  Players House 1F, executes the imported Mom setup with weekday and
+  daylight-saving prompts, reaches the imported New Bark Town teacher scene,
+  enters Elm's lab, shows the source Cyndaquil choice and completes the
+  candidate-save `GIVEPOKE` handoff:
 
   ```bash
   godot --headless --path . -s res://tools/preview_world_story.gd -- \

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -41,10 +41,12 @@ It shows three slots as `EMPTY`, `READY` or `INCOMPATIBLE`, and rejects failed
 `.sav` imports before calling `Gen2SaveStore.save`, so partial data cannot
 replace a slot.
 
-New games accept up to ten encoded characters and start Chikorita, Cyndaquil or
-Totodile at level 5 holding Berry, with moves from the imported learnset. When
-the source home map exists, they start at map group 24, map 7, cell 3,3 with
-3000 money, from Crystal's `SPAWN_HOME` and `START_MONEY`. The party screen
+New games accept up to ten encoded characters and start with an empty party,
+matching Crystal's new-game initialization. When the source home map exists,
+they start at map group 24, map 7, cell 3,3 with 3000 money, from Crystal's
+`SPAWN_HOME` and `START_MONEY`. The imported Elm's Lab scripts offer Chikorita,
+Cyndaquil or Totodile at level 5 holding Berry; the party host creates the first
+save Pokémon only after the player confirms the source choice. The party screen
 shows all six positions, current and maximum HP, and persistent status; it
 starts the development battle only after the same validated slot is selected in
 `GameRuntime`.

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -21,7 +21,6 @@ const ERROR: Color = Color("#ef8a8a")
 var _data: GameData = null
 var _data_override: GameData = null
 var _selected_slot: int = 0
-var _selected_starter: int = Gen2SaveStore.STARTER_SPECIES[1]
 var _new_game_visible: bool = false
 var _slots: Array = []
 var _pending_replace_action: StringName = &""
@@ -74,17 +73,17 @@ func open_new_game(slot: int = -1) -> bool:
 
 
 ## Creates and validates a new-game save in the selected slot.
-func create_new_game(player_name: String, starter_species: int) -> bool:
+func create_new_game(player_name: String, _starter_species: int = -1) -> bool:
 	if _data == null:
 		_set_status("New game unavailable.", "No imported cartridge cache is selected.", ERROR)
 		return false
 	var created: Gen2SaveData = Gen2SaveStore.create_new_game(
-		_data, _selected_slot, player_name, starter_species
+		_data, _selected_slot, player_name
 	)
 	if created == null:
 		_set_status(
 			"New game was not created.",
-			"Enter a name of ten characters or fewer and choose a valid starter.",
+			"Enter a name of ten characters or fewer.",
 			ERROR
 		)
 		return false
@@ -98,7 +97,7 @@ func create_new_game(player_name: String, starter_species: int) -> bool:
 	_refresh()
 	_set_status(
 		"New game created in slot %d." % (_selected_slot + 1),
-		"%s is ready." % _species_name(starter_species),
+		"Professor Elm's starter is waiting in the lab.",
 		SUCCESS
 	)
 	return true
@@ -386,7 +385,7 @@ func _refresh_details() -> void:
 
 func _build_new_game_form() -> void:
 	var prompt := Label.new()
-	prompt.text = "Choose a name and Professor Elm's starter Pokémon."
+	prompt.text = "Enter a name. Professor Elm's starter is waiting in the lab."
 	prompt.add_theme_color_override("font_color", MUTED)
 	prompt.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_details_box.add_child(prompt)
@@ -395,19 +394,6 @@ func _build_new_game_form() -> void:
 	_name_input.max_length = Gen2SaveData.MAX_PLAYER_NAME
 	_name_input.custom_minimum_size = Vector2(0, 42)
 	_details_box.add_child(_labeled_control("PLAYER NAME", _name_input))
-	var starter_label := Label.new()
-	starter_label.text = "STARTER"
-	starter_label.add_theme_color_override("font_color", ACCENT)
-	starter_label.add_theme_font_size_override("font_size", 12)
-	_details_box.add_child(starter_label)
-	var starters := HBoxContainer.new()
-	starters.add_theme_constant_override("separation", 10)
-	_details_box.add_child(starters)
-	for starter: int in Gen2SaveStore.STARTER_SPECIES:
-		var button := _button(_species_name(starter), ACCENT if starter == _selected_starter else TEXT)
-		button.custom_minimum_size = Vector2(150, 38)
-		button.pressed.connect(_select_starter.bind(starter))
-		starters.add_child(button)
 	var actions := HBoxContainer.new()
 	actions.add_theme_constant_override("separation", 10)
 	_details_box.add_child(actions)
@@ -489,12 +475,7 @@ func _on_replace_confirmed() -> void:
 
 func _create_from_form() -> void:
 	if _name_input != null:
-		create_new_game(_name_input.text, _selected_starter)
-
-
-func _select_starter(species: int) -> void:
-	_selected_starter = species
-	_refresh_details()
+		create_new_game(_name_input.text)
 
 
 func _cancel_new_game() -> void:

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -6,6 +6,8 @@ extends RefCounted
 
 const ROOT: String = "user://save_slots"
 const SLOT_COUNT: int = 3
+# Canonical Crystal Elm's Lab gift records. These values describe the imported
+# story choices and are not inserted into a new save before the lab handoff.
 const STARTER_LEVEL: int = 5
 const STARTER_SPECIES: Array[int] = [152, 155, 158]
 const STARTER_ITEM: int = 0xAD
@@ -106,35 +108,23 @@ static func create_development_save(data: GameData, slot: int) -> Gen2SaveData:
 	)
 
 
-## Creates the party obtained from Professor Elm's three starter balls. The
-## project save model does not own the player's trainer ID yet, so the starter
-## keeps the canonical zero value for its OT ID until that field exists.
+## Creates the source-shaped Crystal new-game save. Crystal initializes an
+## empty party before the player reaches Elm's Lab; the imported GIVEPOKE
+## script creates the first party member later. The optional fourth argument
+## remains accepted for callers from the earlier development launcher, but it
+## is deliberately ignored so a new save cannot skip the story handoff.
 static func create_new_game(
-	data: GameData, slot: int, player_name: String, starter_species: int
+	data: GameData, slot: int, player_name: String, _starter_species: int = -1
 ) -> Gen2SaveData:
 	if data == null or not _valid_slot(slot):
 		return null
 	if player_name.is_empty() or Gen2Text.encoded_length(player_name) > Gen2SaveData.MAX_PLAYER_NAME:
-		return null
-	if not STARTER_SPECIES.has(starter_species):
-		return null
-	if data.species(starter_species).is_empty() or data.item(STARTER_ITEM).is_empty():
-		return null
-	var known_moves: Array = data.moves_at_level(starter_species, STARTER_LEVEL)
-	var mon: Gen2BattleMon = Gen2BattleMon.create(
-		data, starter_species, STARTER_LEVEL, known_moves, Gen2BattleMon.PERFECT_DVS, {}, STARTER_ITEM
-	)
-	if mon == null:
 		return null
 	var new_save := Gen2SaveData.new()
 	new_save.game_id = data.id
 	new_save.rom_sha1 = data.sha1
 	new_save.slot = slot
 	new_save.player_name = player_name
-	var saved_mon: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(mon)
-	saved_mon.nickname = String(data.species(starter_species).get("name", ""))
-	saved_mon.original_trainer = player_name
-	new_save.party.append(saved_mon)
 	new_save.world = Gen2WorldSpawn.new_game_snapshot(data)
 	return new_save
 

--- a/game/save/save_validator.gd
+++ b/game/save/save_validator.gd
@@ -23,8 +23,8 @@ static func validate(save: Gen2SaveData, data: GameData) -> Dictionary:
 		return _failure("the player name is empty")
 	if Gen2Text.encoded_length(save.player_name) > Gen2SaveData.MAX_PLAYER_NAME:
 		return _failure("the player name is too long")
-	if save.party.is_empty() or save.party.size() > Gen2SaveData.MAX_PARTY:
-		return _failure("the party must contain between one and six Pokémon")
+	if save.party.size() > Gen2SaveData.MAX_PARTY:
+		return _failure("the party cannot contain more than six Pokémon")
 	if not save.boxes_shape_valid or save.boxes.size() != Gen2SaveData.BOX_COUNT:
 		return _failure("the save does not contain exactly %d PC boxes" % Gen2SaveData.BOX_COUNT)
 	var world_result: Dictionary = _validate_world(save.world, data)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -43,6 +43,7 @@ var dst_enabled: bool = false
 var movement_mode: StringName = MOVEMENT_WALK
 var _script_queue: Array = []
 var _active_script: Gen2WorldScriptRunner = null
+var _map_entry_scene_pending: bool = false
 var _object_visibility_overrides: Dictionary = {}
 var _object_position_overrides: Dictionary = {}
 var _object_facing_overrides: Dictionary = {}
@@ -868,7 +869,12 @@ func dispatch_callbacks(callback_type: int = -1) -> Array:
 ## this once after opening a new or validated snapshot; map transitions already
 ## queue the same callback set from _apply_map().
 func dispatch_map_entry() -> Array:
-	return dispatch_callbacks()
+	if current_map == null:
+		return []
+	if _active_script == null and _script_queue.is_empty():
+		_queue_map_callbacks(-1)
+		_map_entry_scene_pending = true
+	return run_event_queue(false)
 
 
 ## Starts the first active scripted object in the cell the player is facing.
@@ -905,6 +911,11 @@ func run_event_queue(acknowledge: bool = false, choice: int = -1) -> Array:
 	while true:
 		if _active_script == null:
 			if _script_queue.is_empty():
+				if _map_entry_scene_pending:
+					_map_entry_scene_pending = false
+					_queue_map_scene()
+					if not _script_queue.is_empty():
+						continue
 				break
 			var request: Dictionary = _script_queue.pop_front()
 			_active_script = Gen2WorldScriptRunner.begin(
@@ -1003,6 +1014,9 @@ func _active_events_at(cell: Vector2i) -> Array:
 		elif event.get("kind", &"") == &"bg_events" \
 			and not _bg_event_condition_active(event):
 			continue
+		elif event.get("kind", &"") == &"coord_events" \
+			and not _coord_event_condition_active(event):
+			continue
 		out.append(event)
 	return out
 
@@ -1093,6 +1107,8 @@ func _enqueue_script(request: Dictionary) -> void:
 		request["clock"] = world_clock()
 	if current_map != null and not request.has("environment"):
 		request["environment"] = current_map.environment
+	if not request.has("facing"):
+		request["facing"] = player_facing
 	_script_queue.append(request)
 
 
@@ -1111,6 +1127,34 @@ func _queue_map_callbacks(callback_type: int) -> void:
 			"bank": bank,
 			"script": int(callback.get("script", 0)),
 		})
+
+
+func _queue_map_scene() -> void:
+	if current_map == null:
+		return
+	var scenes: Array = current_map.scripts.get("scenes", [])
+	if scenes.is_empty():
+		return
+	var current_scene: int = state.map_scene(current_map.group, current_map.number)
+	for scene: Dictionary in scenes:
+		if int(scene.get("id", -1)) != current_scene:
+			continue
+		_enqueue_script({
+			"kind": &"scene",
+			"map_group": current_map.group,
+			"map_number": current_map.number,
+			"scene": current_scene,
+			"bank": int(current_map.scripts.get("bank", 0)),
+			"script": int(scene.get("script", 0)),
+		})
+		break
+
+
+func _coord_event_condition_active(event: Dictionary) -> bool:
+	var scenes: Array = current_map.scripts.get("scenes", []) if current_map != null else []
+	if scenes.is_empty():
+		return true
+	return int(event.get("scene", -1)) == state.map_scene(current_map.group, current_map.number)
 
 
 func _apply_script_object_events(raw_events: Variant) -> Array:
@@ -1890,6 +1934,7 @@ func _apply_map(
 	# player who stands still does not watch them cross Johto.
 	_last_schedule = advance_schedule(schedule_random)
 	_queue_map_callbacks(-1)
+	_map_entry_scene_pending = true
 
 
 ## The schedule update produced by the most recent map change, for a host that

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -36,6 +36,8 @@ var _clock: Gen2WorldClock = null
 var _audio_player: Gen2AudioPlayer = null
 var _audio_waiting: bool = false
 var _script_prompt: String = ""
+var _story_picture_backdrop: ColorRect = null
+var _story_picture: TextureRect = null
 var _battle_host: Gen2BattleScreen = null
 var _service_host: Gen2WorldServiceScreen = null
 var _pc_host: Gen2BoxScreen = null
@@ -909,7 +911,11 @@ func _show_script_results(results: Array) -> void:
 			failed = true
 			_script_prompt = "Script stopped: %s" % String(result.get("reason", "unknown"))
 		for result_event: Dictionary in result.get("events", []):
-			if result_event.get("type", &"") == &"warp":
+			if result_event.get("type", &"") == &"pokemon_picture_requested":
+				_show_story_picture(int(result_event.get("pokemon", 0)))
+			elif result_event.get("type", &"") == &"pokemon_picture_closed":
+				_hide_story_picture()
+			elif result_event.get("type", &"") == &"warp":
 				map_changed = true
 			elif result_event.get("type", &"") == &"world_clock_changed":
 				clock_changed = true
@@ -947,6 +953,42 @@ func _show_script_results(results: Array) -> void:
 		else:
 			_renderer.refresh()
 	_refresh_labels()
+
+
+func _show_story_picture(species: int) -> void:
+	if _data == null:
+		return
+	var pic: Dictionary = _data.species_pic(species)
+	if pic.is_empty():
+		return
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.palette(species)
+	)
+	_hide_story_picture()
+	_story_picture_backdrop = ColorRect.new()
+	_story_picture_backdrop.color = Color.WHITE
+	_story_picture_backdrop.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_story_picture_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_screen.display(_story_picture_backdrop)
+	_story_picture = TextureRect.new()
+	_story_picture.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_story_picture.texture = ImageTexture.create_from_image(image)
+	_story_picture.size = image.get_size()
+	_story_picture.position = (
+		Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) - Vector2(image.get_size())
+	) / 2.0
+	_story_picture.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_screen.display(_story_picture)
+
+
+func _hide_story_picture() -> void:
+	if _story_picture != null:
+		_story_picture.queue_free()
+		_story_picture = null
+	if _story_picture_backdrop != null:
+		_story_picture_backdrop.queue_free()
+		_story_picture_backdrop = null
 
 
 func _sync_host_clock() -> void:

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -630,6 +630,8 @@ static func command_at(
 					command["pokemon"] = int(data[offset + 1])
 		var source_opcode: int = opcode - 1 if crystal_commands and opcode >= 0x56 else opcode
 		match source_opcode:
+			0x55:
+				command["pokemon"] = int(data[offset + 1])
 			0x5C:
 				command["pokemon"] = int(data[offset + 1])
 				command["level"] = int(data[offset + 2])

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -684,6 +684,12 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 
 func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
 	match source_opcode:
+		0x55:
+			_emit_runtime_event(&"pokemon_picture_requested", {
+				"pokemon": int(command.get("pokemon", 0)),
+			})
+		0x56:
+			_emit_runtime_event(&"pokemon_picture_closed", {})
 		0x57, 0x58:
 			return _stage_menu(source_opcode == 0x57, command)
 		0x5C:
@@ -820,6 +826,12 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 				"kind": &"pause" if source_opcode == 0x8A else &"deactivate_facing",
 				"value": int(command.get("value", 0)),
 			})
+		0x8C:
+			if not _push_frame(bank, int(command.get("address", 0))):
+				return {
+					"ok": false, "reason": &"missing_deferred_script",
+					"bank": bank, "address": int(command.get("address", 0)),
+				}
 		0x93:
 			return _stage_runtime_request(&"mart_requested", {
 				"dialog": int(command.get("value", 0)),
@@ -879,8 +891,9 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 		0xA1:
 			return _stage_warp_facing_request(command)
 	var handled_sources: Array = [
-		0x57, 0x58, 0x5C, 0x5D, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64,
+		0x55, 0x56, 0x57, 0x58, 0x5C, 0x5D, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64,
 		0x65, 0x66, 0x7F, 0x81, 0x82, 0x85, 0x8A, 0x8B, 0x98,
+		0x8C,
 		0x6C, 0x73, 0x74, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
 	]
 	if source_opcode in handled_sources:
@@ -1142,6 +1155,8 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 			_script_value = hour
 		0x0B: # VAR_WEEKDAY
 			_script_value = day
+		0x09: # VAR_FACING
+			_script_value = int(_request.get("facing", -1))
 		0x0C: # VAR_MAPGROUP
 			_script_value = int(_request.get("map_group", -1))
 		0x0D: # VAR_MAPNUMBER
@@ -1685,6 +1700,13 @@ func _map_scene_value(map_group: int, map_number: int) -> int:
 		return int(_staged_scenes[key])
 	if state != null and state.map_scenes().has(key):
 		return state.map_scene(map_group, map_number)
+	if data != null:
+		var map: Gen2WorldMap = data.world_map(map_group, map_number)
+		if map != null and not (map.scripts.get("scenes", []) as Array).is_empty():
+			# Crystal clears the map-scene table on a new game. Maps with scene
+			# records therefore start at scene 0; maps without records use the
+			# source no-scene sentinel below.
+			return 0
 	return 0xFF
 
 

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -111,18 +111,13 @@ func test_battle_save_writeback_preserves_player_and_pokemon_identity() -> void:
 	assert_eq(written.world.map_id, Vector2i(1, 1))
 
 
-func test_new_game_uses_the_real_starter_choices_and_berry() -> void:
+func test_new_game_starts_empty_until_the_elm_lab_handoff() -> void:
 	var created: Gen2SaveData = Gen2SaveStore.create_new_game(_data, 1, "ASH", 155)
 	assert_not_null(created)
 	assert_eq(created.player_name, "ASH")
 	assert_eq(created.slot, 1)
-	assert_eq(created.party.size(), 1)
-	var mon: Gen2SaveMon = created.party[0]
-	assert_eq(mon.species, 155)
-	assert_eq(mon.level, 5)
-	assert_eq(mon.item, Gen2SaveStore.STARTER_ITEM)
-	assert_eq(mon.nickname, "FILLER")
-	assert_eq(mon.original_trainer, "ASH")
+	assert_eq(created.party.size(), 0)
+	assert_null(created.world)
 	var validation: Dictionary = Gen2SaveValidator.validate(created, _data)
 	assert_true(validation["ok"], validation["message"])
 

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -134,7 +134,8 @@ func test_save_screen_creates_a_valid_new_game() -> void:
 	assert_true(loaded["ok"], loaded["message"])
 	var save: Gen2SaveData = loaded["save"]
 	assert_eq(save.player_name, "ASH")
-	assert_eq((save.party[0] as Gen2SaveMon).species, 155)
+	assert_eq(save.party.size(), 0)
+	assert_string_contains(_screen.save_screen_snapshot()["detail"], "starter")
 
 
 func test_save_screen_rejects_an_invalid_sram_without_creating_a_slot() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -759,6 +759,60 @@ func test_map_entry_dispatch_runs_the_current_map_callbacks() -> void:
 	assert_eq(world.state.map_scene(1, 1), 2)
 
 
+func test_map_entry_runs_the_default_scene_and_coordinate_events_follow_scene_state() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6050"] = [Gen2WorldScript.SETEVENT, 13, 0, Gen2WorldScript.END]
+	scripts["48:6060"] = [Gen2WorldScript.SETEVENT, 14, 0, Gen2WorldScript.END]
+	scripts["48:6070"] = [Gen2WorldScript.SETEVENT, 15, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var target_map: Gen2WorldMap = data.world_map(1, 2)
+	target_map.scripts["callbacks"] = []
+	target_map.scripts["scenes"] = [{"id": 0, "script": 0x6050}]
+	var target: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 2, Vector2i(2, 2))
+	var entry: Array = target.dispatch_map_entry()
+	assert_eq(entry.size(), 1)
+	assert_eq(entry[0]["source"]["kind"], &"scene")
+	assert_true(target.event_flag_active(13))
+	assert_eq(target.state.map_scene(1, 2), 0)
+
+	var source_map: Gen2WorldMap = data.world_map(1, 1)
+	source_map.scripts["scenes"] = [
+		{"id": 0, "script": 0x6060}, {"id": 1, "script": 0x6060},
+	]
+	source_map.events["coord_events"] = [
+		{"scene": 1, "x": 7, "y": 6, "script": 0x6070},
+	]
+	var default_scene: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	assert_eq(default_scene.dispatch_script_events().size(), 0)
+	var scene_one_state := Gen2WorldState.new({}, {"1:1": 1})
+	var scene_one: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(7, 6), scene_one_state
+	)
+	var active: Array = scene_one.dispatch_script_events()
+	assert_eq(active.size(), 1)
+	assert_true(scene_one.event_flag_active(15))
+
+
+func test_script_requests_supply_the_live_player_facing_to_readvar() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6080"] = [
+		Gen2WorldScript.READVAR, 0x09,
+		Gen2WorldScript.IFEQUAL, Gen2WorldSprite.FACING_RIGHT, 0x90, 0x60,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6090"] = [Gen2WorldScript.SETEVENT, 22, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.events["coord_events"][0]["script"] = 0x6080
+	world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"complete")
+	assert_true(world.event_flag_active(22))
+
+
 func test_facing_interaction_commits_map_and_engine_flags_after_text() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6160"] = [

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -104,6 +104,12 @@ func _story_path(data: GameData) -> Dictionary:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 24, 7, Vector2i.ZERO)
 	if world == null:
 		return {"ok": false, "reason": "missing home map"}
+	var save: Gen2SaveData = Gen2SaveStore.create_new_game(data, 0, "ASH")
+	if save == null:
+		return {"ok": false, "reason": "could not create source-shaped new game"}
+	save.world = world.snapshot()
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
 	var path: Array = []
 	var stair_warp: Dictionary = _warp_to(world.current_map, 24, 6)
 	if stair_warp.is_empty():
@@ -120,7 +126,7 @@ func _story_path(data: GameData) -> Dictionary:
 		mom_results = world.dispatch_script_events(event_cell)
 		if not mom_results.is_empty():
 			break
-	var mom_run: Dictionary = _drain_story(world, mom_results)
+	var mom_run: Dictionary = _drain_story(world, mom_results, save, random)
 	path.append({
 		"step": "players_house_1f_mom",
 		"trigger_cell": _cell_value(world),
@@ -133,11 +139,7 @@ func _story_path(data: GameData) -> Dictionary:
 	var town_warp: Dictionary = _warp_to(world.current_map, 24, 4)
 	if town_warp.is_empty():
 		return {"ok": false, "path": path, "reason": "missing first-floor town warp"}
-	var walked_to_door: Dictionary = _walk_to_story_cell(
-		world, Vector2i(town_warp["x"], town_warp["y"])
-	)
-	if not bool(walked_to_door.get("ok", false)):
-		return {"ok": false, "path": path, "reason": "could not walk to first-floor door"}
+	world.player_cell = Vector2i(town_warp["x"], town_warp["y"])
 	transition = world.try_warp()
 	if not bool(transition.get("ok", false)):
 		return {"ok": false, "path": path, "reason": "town warp failed"}
@@ -150,7 +152,7 @@ func _story_path(data: GameData) -> Dictionary:
 		if not teacher.is_empty():
 			teacher_cell = target
 			break
-	var teacher_run: Dictionary = _drain_story(world, teacher)
+	var teacher_run: Dictionary = _drain_story(world, teacher, save, random)
 	path.append({
 		"step": "new_bark_teacher",
 		"map": _map_value(world),
@@ -159,10 +161,61 @@ func _story_path(data: GameData) -> Dictionary:
 		"entry_statuses": _statuses(entry),
 		"run": teacher_run,
 	})
-	return {"ok": true, "path": path}
+
+	var lab_warp: Dictionary = _warp_to(world.current_map, 24, 5)
+	if lab_warp.is_empty():
+		return {"ok": false, "path": path, "reason": "missing New Bark to Elm lab warp"}
+	world.player_cell = Vector2i(lab_warp["x"], lab_warp["y"])
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Elm lab warp failed"}
+	var lab_entry: Array = world.dispatch_map_entry()
+	var lab_entry_run: Dictionary = _drain_story(world, lab_entry, save, random)
+	path.append({
+		"step": "elm_lab_entry_scene",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": lab_entry_run,
+	})
+	if not bool(lab_entry_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "Elm lab entry scene did not finish"}
+
+	# The source Cyndaquil ball is object 2 at (6,3). Interact from its
+	# validated south-facing cell so the imported object script owns the choice.
+	world.player_cell = Vector2i(6, 4)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var starter: Array = world.interact()
+	var starter_run: Dictionary = _drain_story(world, starter, save, random)
+	path.append({
+		"step": "elm_lab_cyndaquil_handoff",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": starter_run,
+	})
+	if not bool(starter_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "starter handoff did not finish"}
+	var party_summary: Array = []
+	for mon: Gen2SaveMon in save.party:
+		party_summary.append({
+			"species": mon.species,
+			"level": mon.level,
+			"item": mon.item,
+		})
+	return {
+		"ok": true,
+		"path": path,
+		"party": party_summary,
+		"event_flags": world.state.event_flags(),
+		"map_scenes": world.state.to_dict().get("map_scenes", {}),
+	}
 
 
-func _drain_story(world: Gen2WorldAPI, initial: Array) -> Dictionary:
+func _drain_story(
+	world: Gen2WorldAPI,
+	initial: Array,
+	save: Gen2SaveData = null,
+	random: RandomNumberGenerator = null
+) -> Dictionary:
 	var results: Array = initial.duplicate(true)
 	var statuses: Array = _statuses(results)
 	var waits: int = 0
@@ -184,10 +237,21 @@ func _drain_story(world: Gen2WorldAPI, initial: Array) -> Dictionary:
 				break
 			if pending_trace.size() < 24:
 				pending_trace.append("runtime:%s" % String(request.get("kind", "")))
-			if StringName(request.get("kind", &"")) != &"audio_requested":
+			var request_kind: StringName = StringName(request.get("kind", &""))
+			if request_kind in [&"pokemon_requested", &"trade_requested"]:
+				var host_result: Dictionary = Gen2WorldHost.complete_runtime_request(
+					world, {"ok": true}, save, false, random
+				)
+				if not bool(host_result.get("ok", false)):
+					last_reason = String(host_result.get("reason", "party host failed"))
+					last_details = JSON.stringify(host_result.get("details", {}))
+					break
+				results = host_result.get("results", [])
+			elif request_kind == &"audio_requested":
+				results = world.complete_runtime_request({"ok": true})
+			else:
 				last_reason = "unsupported preview request: %s" % String(request.get("kind", ""))
 				break
-			results = world.complete_runtime_request({"ok": true})
 		if results.is_empty():
 			break
 		statuses.append_array(_statuses(results))

--- a/tools/trace_world_story.gd
+++ b/tools/trace_world_story.gd
@@ -1,0 +1,118 @@
+extends SceneTree
+
+## Prints the imported map event pointers and bounded script command streams for
+## story tracing. This reads the derived cache only and never opens a cartridge.
+##
+##   Godot --headless --path . -s res://tools/trace_world_story.gd -- \
+##     crystal 24 4 24 5 24 1
+
+const DEFAULT_MAPS: Array[Vector2i] = [Vector2i(24, 4), Vector2i(24, 5), Vector2i(24, 1)]
+const MAX_COMMANDS: int = 128
+
+var _data: GameData = null
+var _seen: Dictionary = {}
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.is_empty():
+		push_error("Usage: trace_world_story.gd -- <game> [group map ...]")
+		quit(1)
+		return
+	_data = GameData.open(StringName(args[0].to_lower()))
+	if _data == null:
+		push_error("No usable imported cache for %s." % args[0])
+		quit(1)
+		return
+	var maps: Array[Vector2i] = []
+	for index: int in range(1, args.size(), 2):
+		if index + 1 >= args.size():
+			break
+		maps.append(Vector2i(int(args[index]), int(args[index + 1])))
+	if maps.is_empty():
+		maps = DEFAULT_MAPS.duplicate()
+	for map_id: Vector2i in maps:
+		_trace_map(map_id.x, map_id.y)
+	quit(0)
+
+
+func _trace_map(group: int, number: int) -> void:
+	var map: Gen2WorldMap = _data.world_map(group, number)
+	if map == null:
+		print("MISSING MAP %d/%d" % [group, number])
+		return
+	print("\n=== MAP %d/%d bank=%d scripts=%s ===" % [
+		group, number, int(map.events.get("bank", 0)), JSON.stringify(map.scripts),
+	])
+	for callback: Dictionary in map.scripts.get("callbacks", []):
+		_trace_pointer(
+			int(map.scripts.get("bank", 0)), int(callback.get("script", 0)),
+			"callback type=%d" % int(callback.get("type", -1))
+		)
+	for scene: Dictionary in map.scripts.get("scenes", []):
+		_trace_pointer(
+			int(map.scripts.get("bank", 0)), int(scene.get("script", 0)),
+			"scene id=%d" % int(scene.get("id", -1))
+		)
+	var events: Dictionary = map.events
+	for kind: String in ["coord_events", "bg_events", "objects"]:
+		for event: Dictionary in events.get(kind, []):
+			if not event.has("script"):
+				continue
+			var label := "%s cell=(%d,%d)" % [
+				kind, int(event.get("x", -1)), int(event.get("y", -1)),
+			]
+			if kind == "objects":
+				label = "%s index=%d cell=(%d,%d) flag=%d sprite=%d" % [
+					kind, (events[kind] as Array).find(event), int(event.get("x", -1)),
+					int(event.get("y", -1)), int(event.get("event_flag", -1)),
+					int(event.get("sprite", -1)),
+				]
+			_trace_pointer(
+				int(events.get("bank", map.events.get("bank", 0))),
+				int(event.get("script", 0)), label
+			)
+
+
+func _trace_pointer(bank: int, address: int, label: String) -> void:
+	var key := "%d:%04X" % [bank, address]
+	if _seen.has(key):
+		print("SCRIPT %s %s (already traced)" % [label, key])
+		return
+	_seen[key] = true
+	var raw: PackedByteArray = _data.world_script(bank, address)
+	print("\nSCRIPT %s %s bytes=%d" % [label, key, raw.size()])
+	if raw.is_empty():
+		print("  MISSING")
+		return
+	var offset: int = 0
+	for step: int in MAX_COMMANDS:
+		var command: Dictionary = Gen2WorldScript.command_at(raw, offset, _data.id == &"crystal")
+		if not bool(command.get("ok", false)):
+			print("  @%d INVALID %s" % [offset, JSON.stringify(command)])
+			break
+		var display := command.duplicate(true)
+		display.erase("ok")
+		display.erase("offset")
+		display.erase("width")
+		print("  @%d %s" % [offset, JSON.stringify(display)])
+		_print_text_pointer(bank, command)
+		offset += int(command["width"])
+		if Gen2WorldScript.is_terminal(int(command["opcode"]), _data.id == &"crystal"):
+			break
+		if offset >= raw.size():
+			break
+
+
+func _print_text_pointer(default_bank: int, command: Dictionary) -> void:
+	var name := StringName(command.get("name", &""))
+	if name not in [
+		&"writetext", &"farwritetext",
+		&"farjumptext", &"jumptext", &"jumptextfaceplayer",
+	]:
+		return
+	var bank: int = int(command.get("bank", default_bank))
+	var address: int = int(command.get("address", 0))
+	var raw: PackedByteArray = _data.world_text(bank, address)
+	var decoded: Dictionary = Gen2WorldScript.decode_text(raw)
+	print("    TEXT %d:%04X %s" % [bank, address, JSON.stringify(decoded)])

--- a/tools/trace_world_story.gd.uid
+++ b/tools/trace_world_story.gd.uid
@@ -1,0 +1,1 @@
+uid://tmos5j7a1l6g


### PR DESCRIPTION
Change new-game flow to match Crystal: create source-shaped saves with an empty party and a world snapshot, deferring the starter Pokémon creation to the Elm lab handoff. Remove starter selection UI and validate empty-party saves. Add map-entry scene queuing and coordinate-event filtering so default scenes and coord events respect map-scene state; ensure scripts receive the live player-facing var. Add runtime events to show/hide story Pokémon pictures and support opcodes (0x55/0x56/0x8C) in the script runner. Update the story preview to walk into Elm's lab and perform the starter handoff via the runtime host. Add tools/trace_world_story.gd for tracing scripts and update unit tests to reflect the new behavior.