### PR TITLE
Fix Gold/Silver trainer intro opcodes and enable source-equivalent approach

### DIFF
--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -101,6 +101,15 @@ const GOLD_END: int = 0x90
 const ENDCALLBACK: int = 0x90
 const END: int = 0x91
 
+## Gold/Silver raw opcodes for the trainer intro sequence. Crystal inserted
+## farjumptext at raw $52, so every Gold/Silver opcode at or above $52 shifts
+## up by one in Crystal's raw byte stream; see raw_opcode().
+const GOLD_LOADTEMPTRAINER: int = 0x5B
+const GOLD_STARTBATTLE: int = 0x5E
+const GOLD_RELOADMAPAFTERBATTLE: int = 0x5F
+const GOLD_TRAINERFLAGACTION: int = 0x62
+const GOLD_ENCOUNTERMUSIC: int = 0x7F
+
 const TEXT_START: int = 0x00
 ## World text uses the source text-command stream. $50 is a page control;
 ## $57 (done) ends the text box and $58 (prompt) pauses for a prompt.
@@ -480,6 +489,17 @@ static func _later_command_name(opcode: int, crystal_commands: bool) -> StringNa
 		0xA0: return &"credits"
 		0xA1: return &"warpfacing"
 	return &""
+
+
+## Converts a Gold/Silver source opcode into the raw byte the matching game's
+## command stream uses. Crystal's raw stream shifts every opcode at or above
+## $52 up by one; below that boundary the two profiles agree. This is the
+## documented inverse of the raw-to-source normalization in
+## Gen2WorldScriptRunner._execute().
+static func raw_opcode(source_opcode: int, crystal_commands: bool = true) -> int:
+	if crystal_commands and source_opcode >= 0x52:
+		return source_opcode + 1
+	return source_opcode
 
 
 static func is_endcallback(opcode: int, crystal_commands: bool = true) -> bool:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -121,7 +121,7 @@ static func begin(
 		started = runner._push_frame(
 			bank, address, runner._trainer_intro_script(trainer as Dictionary)
 		)
-		runner._trainer_intro_approach_pending = runner._crystal_commands()
+		runner._trainer_intro_approach_pending = true
 	else:
 		started = runner._push_frame(bank, address)
 	if not started:
@@ -1994,29 +1994,33 @@ func _trainer_text_pointer(trainer: Dictionary, key: String, default_bank: int) 
 	return {"bank": default_bank, "address": 0}
 
 
+## Builds the source SeenByTrainerScript/StartBattleWithMapTrainerScript
+## sequence: loadtemptrainer, encountermusic, farwritetext, waitbutton,
+## loadtemptrainer, startbattle, reloadmapafterbattle, trainerflagaction, end.
+## The sequence is identical between profiles at the source-opcode level;
+## only the raw bytes differ, so every command goes through
+## Gen2WorldScript.raw_opcode() rather than hard-coding either profile's byte.
 func _trainer_intro_script(trainer: Dictionary) -> PackedByteArray:
 	var seen: Dictionary = _trainer_text_pointer(
 		trainer, "seen_text", int(_request.get("bank", 0))
 	)
 	var bank: int = int(seen.get("bank", _request.get("bank", 0)))
 	var address: int = int(seen.get("address", 0))
+	var crystal: bool = _crystal_commands()
+	var raw: Callable = func(source_opcode: int) -> int:
+		return Gen2WorldScript.raw_opcode(source_opcode, crystal)
 	var bytes: Array = [
-		# Crystal's loadtemptrainer command points at the request's trainer record.
-		0x5C,
-	]
-	if _crystal_commands():
-		# Crystal's raw command byte is one higher than the Gold/Silver source
-		# opcode after farjumptext was inserted in the command table.
-		bytes.append(0x80) # encountermusic
-	bytes.append_array([
+		# loadtemptrainer points at the request's trainer record.
+		raw.call(Gen2WorldScript.GOLD_LOADTEMPTRAINER),
+		raw.call(Gen2WorldScript.GOLD_ENCOUNTERMUSIC),
 		Gen2WorldScript.FARWRITETEXT, bank, address & 0xFF, address >> 8,
-		Gen2WorldScript.WAITBUTTON,
-		0x5C,
-		0x5F,
-		0x60,
-		0x63, 1,
-		Gen2WorldScript.END,
-	])
+		raw.call(0x53), # waitbutton
+		raw.call(Gen2WorldScript.GOLD_LOADTEMPTRAINER),
+		raw.call(Gen2WorldScript.GOLD_STARTBATTLE),
+		raw.call(Gen2WorldScript.GOLD_RELOADMAPAFTERBATTLE),
+		raw.call(Gen2WorldScript.GOLD_TRAINERFLAGACTION), 1,
+		raw.call(Gen2WorldScript.GOLD_END),
+	]
 	return PackedByteArray(bytes)
 
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -27,6 +27,7 @@ func after_each() -> void:
 		_world_screen.free()
 		_world_screen = null
 	RomCache.clear(Fixture.directory())
+	RomCache.clear(Fixture.directory(&"gold"))
 
 
 func _open_world(with_save: bool = false) -> void:
@@ -113,6 +114,54 @@ func test_victory_displays_imported_text_reloads_objects_and_keeps_player_cell()
 	await get_tree().process_frame
 	var world: Dictionary = _world_screen.world_snapshot()
 	assert_eq(world["map"], Vector2i(Fixture.MAP_GROUP, Fixture.MAP_NUMBER))
+	assert_eq(world["player_cell"], Vector2i(5, 5))
+	assert_eq(world["visible_objects"], 0)
+	assert_true(world["just_battled"])
+
+
+## Gold/Silver share one command profile (Gen2WorldScriptRunner._crystal_commands()
+## returns false for both), so covering the "gold" game id also covers Silver's
+## opcode layout for this flow.
+func test_gold_profile_trainer_sight_reaches_the_real_battle_overlay() -> void:
+	_data = Fixture.build(&"gold")
+	await _open_world()
+	var before: Dictionary = _world_screen.world_snapshot()
+	await _trigger_trainer()
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_eq(before["player_cell"], Vector2i(4, 5))
+	assert_eq(_world_screen.world_snapshot()["player_cell"], Vector2i(5, 5))
+	assert_eq((_world_screen._world.objects[0] as Gen2WorldObject).cell, Vector2i(5, 4))
+	assert_eq(
+		(_world_screen._world.objects[0] as Gen2WorldObject).facing,
+		Gen2WorldSprite.FACING_DOWN
+	)
+	assert_eq(_world_screen._world.player_facing, Gen2WorldSprite.FACING_UP)
+	assert_true(host.is_ready())
+	var snapshot: Dictionary = host.battle_snapshot()
+	assert_eq(snapshot["enemy"], Fixture.TRAINER_SPECIES)
+	assert_eq(snapshot["message"], "LEADER RIVAL wants to fight!")
+	assert_eq(snapshot["world_battle_active"], true)
+
+
+func test_gold_profile_victory_commits_beaten_flag_and_reloads_objects() -> void:
+	_data = Fixture.build(&"gold")
+	await _open_world()
+	await _trigger_trainer()
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+
+	for _hit: int in 12:
+		host.hurt_enemy()
+	host.finish()
+	host.advance()
+	assert_eq(host.battle_snapshot()["message"], "YOU WON.")
+
+	host.finish()
+	host.advance()
+	await get_tree().process_frame
+	var world: Dictionary = _world_screen.world_snapshot()
 	assert_eq(world["player_cell"], Vector2i(5, 5))
 	assert_eq(world["visible_objects"], 0)
 	assert_true(world["just_battled"])

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -25,21 +25,26 @@ const TRAINER_SPECIES: int = 16
 const TRAINER_SPRITE: int = 1
 
 
-static func directory() -> String:
-	return RomCache.directory_for(GAME_ID, SHA1)
+## Every caller but the Gold/Silver profile tests uses the default id, so the
+## existing Crystal-profile fixture directory and manifest are unchanged.
+static func directory(game_id: StringName = GAME_ID) -> String:
+	return RomCache.directory_for(game_id, SHA1)
 
 
-static func build() -> GameData:
-	var directory: String = directory()
+static func build(game_id: StringName = GAME_ID) -> GameData:
+	var directory: String = directory(game_id)
 	var base: GameData = BattleFixture.build(directory)
 	assert(base != null)
 
 	var manifest: Dictionary = RomCache.read_manifest(directory)
+	# GameData.id, and therefore Gen2WorldScriptRunner's command profile, comes
+	# straight from this field, so the trainer script bytes below must match it.
+	var crystal_commands: bool = game_id != &"gold" and game_id != &"silver"
 	_write_trainers(directory)
-	_write_world(directory)
+	_write_world(directory, crystal_commands)
 	_write_overworld_graphics(directory)
 	_write_battle_graphics(directory, manifest)
-	manifest["game_id"] = String(GAME_ID)
+	manifest["game_id"] = String(game_id)
 	manifest["sha1"] = SHA1
 	manifest["complete"] = true
 	RomCache.write_json(RomCache.manifest_path(directory), manifest)
@@ -72,7 +77,7 @@ static func _write_trainers(directory: String) -> void:
 	}])
 
 
-static func _write_world(directory: String) -> void:
+static func _write_world(directory: String, crystal_commands: bool = true) -> void:
 	var blocks: Array = []
 	blocks.resize(MAP_WIDTH_BLOCKS * MAP_HEIGHT_BLOCKS)
 	blocks.fill(0)
@@ -165,15 +170,25 @@ static func _write_world(directory: String) -> void:
 		},
 	})
 
+	# These two scripts are stored at the object's/coord event's own address,
+	# separate from the synthesized SeenByTrainerScript sequence the runner
+	# builds for the initial sight-triggered phase. Their raw bytes must still
+	# match the requested profile.
+	var raw: Callable = func(source_opcode: int) -> int:
+		return Gen2WorldScript.raw_opcode(source_opcode, crystal_commands)
 	var script: Array = [
-		0x5E, 1, 0,
-		0x64, WIN_TEXT & 0xFF, WIN_TEXT >> 8, LOSS_TEXT & 0xFF, LOSS_TEXT >> 8,
-		0x5F,
-		0x33, TRAINER_FLAG & 0xFF, TRAINER_FLAG >> 8,
-		0x60,
-		0x91,
+		raw.call(0x5D), 1, 0, # loadtrainer
+		raw.call(0x63), WIN_TEXT & 0xFF, WIN_TEXT >> 8, LOSS_TEXT & 0xFF, LOSS_TEXT >> 8, # winlosstext
+		raw.call(0x5E), # startbattle
+		Gen2WorldScript.SETEVENT, TRAINER_FLAG & 0xFF, TRAINER_FLAG >> 8,
+		raw.call(0x5F), # reloadmapafterbattle
+		raw.call(0x90), # end
 	]
-	var tutorial_script: Array = [0x5D, TRAINER_SPECIES, 5, 0x61, 3, 0x91]
+	var tutorial_script: Array = [
+		raw.call(0x5C), TRAINER_SPECIES, 5, # loadwildmon
+		raw.call(0x60), 3, # catchtutorial
+		raw.call(0x90), # end
+	]
 	RomCache.write_json(RomCache.world_scripts_path(directory), {
 		Gen2WorldScript.pointer_key(BANK, TRAINER_SCRIPT): script,
 		Gen2WorldScript.pointer_key(BANK, TUTORIAL_SCRIPT): tutorial_script,

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -71,6 +71,52 @@ func test_crystal_trainer_and_tutorial_commands_use_the_pinned_layout() -> void:
 	assert_eq(tutorial["value"], 3)
 
 
+func test_raw_opcode_shifts_only_at_and_above_the_farjumptext_insertion() -> void:
+	# Below the shift boundary both profiles agree on the raw byte.
+	assert_eq(Gen2WorldScript.raw_opcode(0x51, false), 0x51)
+	assert_eq(Gen2WorldScript.raw_opcode(0x51, true), 0x51)
+	# At and above $52, Crystal's raw byte is one higher than the Gold/Silver
+	# source opcode because farjumptext was inserted at raw $52.
+	assert_eq(Gen2WorldScript.raw_opcode(0x52, false), 0x52)
+	assert_eq(Gen2WorldScript.raw_opcode(0x52, true), 0x53)
+	assert_eq(Gen2WorldScript.raw_opcode(0x53, true), 0x54) # gold waitbutton
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_LOADTEMPTRAINER, false), 0x5B)
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_LOADTEMPTRAINER, true), 0x5C)
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_STARTBATTLE, true), 0x5F)
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_RELOADMAPAFTERBATTLE, true), 0x60)
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_TRAINERFLAGACTION, true), 0x63)
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_ENCOUNTERMUSIC, true), 0x80)
+	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_END, true), 0x91)
+
+
+func test_raw_opcode_round_trips_the_trainer_intro_commands_through_command_at() -> void:
+	# Each trainer-intro command name should decode identically whether it is
+	# reached through the Gold/Silver raw byte or the shifted Crystal raw byte.
+	var intro_commands: Array = [
+		[Gen2WorldScript.GOLD_LOADTEMPTRAINER, &"loadtemptrainer"],
+		[Gen2WorldScript.GOLD_ENCOUNTERMUSIC, &"encountermusic"],
+		[0x53, &"waitbutton"],
+		[Gen2WorldScript.GOLD_STARTBATTLE, &"startbattle"],
+		[Gen2WorldScript.GOLD_RELOADMAPAFTERBATTLE, &"reloadmapafterbattle"],
+		[Gen2WorldScript.GOLD_TRAINERFLAGACTION, &"trainerflagaction"],
+		[Gen2WorldScript.GOLD_END, &"end"],
+	]
+	for entry: Array in intro_commands:
+		var source_opcode: int = entry[0]
+		var expected_name: StringName = entry[1]
+		for crystal_commands: bool in [false, true]:
+			var raw: int = Gen2WorldScript.raw_opcode(source_opcode, crystal_commands)
+			var operand_count: int = Gen2WorldScript.command_width(raw, crystal_commands) - 1
+			var bytes: PackedByteArray = PackedByteArray([raw])
+			bytes.resize(1 + maxi(operand_count, 0))
+			var decoded: Dictionary = Gen2WorldScript.command_at(bytes, 0, crystal_commands)
+			assert_true(
+				decoded["ok"],
+				"%s should decode under crystal_commands=%s" % [expected_name, crystal_commands]
+			)
+			assert_eq(decoded["name"], expected_name)
+
+
 func test_unknown_and_truncated_commands_are_structured_failures() -> void:
 	var unknown: Dictionary = Gen2WorldScript.command_at(PackedByteArray([0xFE]), 0)
 	assert_false(unknown["ok"])

--- a/tools/validate_gold_route30_trainer.gd
+++ b/tools/validate_gold_route30_trainer.gd
@@ -1,0 +1,256 @@
+extends SceneTree
+
+## Verifies the first Route 30 trainer against a freshly imported Gold cache.
+## The expected record comes from the pinned pokegold Route30 map source.
+## Gold and Silver share one command profile
+## (Gen2WorldScriptRunner._crystal_commands() returns false for both), so this
+## also covers Silver's opcode layout for this flow.
+##
+##   Godot --headless --path . -s res://tools/validate_gold_route30_trainer.gd
+
+const MAP_GROUP: int = 26
+const MAP_NUMBER: int = 1
+const TRAINER_OBJECT_INDEX: int = 1
+const TRAINER_CELL := Vector2i(6, 29)
+const START_CELL := Vector2i(5, 29)
+const SIGHT_CELL := Vector2i(4, 29)
+const OBJECT_EVENT_FLAG: int = 1813
+const TRAINER_EVENT_FLAG: int = 1449
+const TRAINER_GROUP: int = 22
+const TRAINER_ID: int = 1
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	var data: GameData = GameData.open(&"gold")
+	if data == null:
+		_fail("Gold cache is unavailable. Import roms/gold.gbc first.")
+		_finish()
+		return
+	var route: Gen2WorldMap = data.world_map(MAP_GROUP, MAP_NUMBER)
+	if route == null:
+		_fail("Route 30 map 26/1 is missing from the Gold cache.")
+		_finish()
+		return
+	var rows: Array = route.events.get("objects", [])
+	if not _check(rows.size() > TRAINER_OBJECT_INDEX, "Route 30 trainer object is missing."):
+		_finish()
+		return
+	var first_trainer_index: int = -1
+	for index: int in rows.size():
+		if rows[index] is Dictionary and int(
+			(rows[index] as Dictionary).get("object_type", -1)
+		) == Gen2WorldObject.OBJECTTYPE_TRAINER:
+			first_trainer_index = index
+			break
+	_check(
+		first_trainer_index == TRAINER_OBJECT_INDEX,
+		"Joey is not the first Route 30 trainer object in source order."
+	)
+	var event: Dictionary = (rows[TRAINER_OBJECT_INDEX] as Dictionary).duplicate(true)
+	var trainer_value: Variant = event.get("trainer", {})
+	if not _check(trainer_value is Dictionary, "Joey's trainer record is missing."):
+		_finish()
+		return
+	var trainer: Dictionary = (trainer_value as Dictionary).duplicate(true)
+	_verify_imported_record(data, event, trainer)
+	_verify_runtime_flow(data, trainer)
+	_finish()
+
+
+func _verify_imported_record(data: GameData, event: Dictionary, trainer: Dictionary) -> void:
+	_check(
+		Vector2i(int(event.get("x", -1)), int(event.get("y", -1))) == TRAINER_CELL,
+		"Joey's imported cell does not match the pinned Route30 object event."
+	)
+	_check(
+		int(event.get("movement", -1)) == Gen2WorldObject.MOVEMENT_FIXED_LEFT,
+		"Joey's imported facing movement is not fixed left."
+	)
+	_check(int(event.get("sight_range", -1)) == 4, "Joey's sight range is not four.")
+	_check(
+		int(event.get("event_flag", -1)) == OBJECT_EVENT_FLAG,
+		"Joey's object visibility flag is incorrect."
+	)
+	_check(
+		int(trainer.get("event_flag", -1)) == TRAINER_EVENT_FLAG,
+		"Joey's beaten-trainer flag is incorrect."
+	)
+	_check(
+		int(trainer.get("event_flag", -1)) != int(event.get("event_flag", -1)),
+		"Object visibility and beaten-trainer flags were collapsed."
+	)
+	_check(int(trainer.get("trainer_group", -1)) == TRAINER_GROUP, "Trainer class is wrong.")
+	_check(int(trainer.get("trainer_id", -1)) == TRAINER_ID, "Trainer party ID is wrong.")
+	_check(
+		int(trainer.get("after_script", 0)) == int(event.get("script", 0)) + 12,
+		"After-battle script does not follow the 12-byte trainer record."
+	)
+	var seen: Dictionary = trainer.get("seen_text", {})
+	var win: Dictionary = trainer.get("win_text", {})
+	var loss: Dictionary = trainer.get("loss_text", {})
+	_check(_text_decodes(data, seen), "Joey's seen text is not readable from the cache.")
+	_check(_text_decodes(data, win), "Joey's win text is not readable from the cache.")
+	_check(int(loss.get("address", -1)) == 0, "Joey's source loss-text sentinel is not zero.")
+
+
+func _verify_runtime_flow(data: GameData, trainer_record: Dictionary) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, MAP_GROUP, MAP_NUMBER, START_CELL, Gen2WorldState.new()
+	)
+	if not _check(world != null, "Route 30 could not be opened through the world API."):
+		return
+	var joey: Gen2WorldObject = world.objects[TRAINER_OBJECT_INDEX]
+	_check(joey.cell == TRAINER_CELL, "Joey's live object starts in the wrong cell.")
+	_check(joey.active, "Joey is hidden with no source flags set.")
+	_check(joey.facing == Gen2WorldSprite.FACING_LEFT, "Joey does not face left.")
+
+	var movement: Dictionary = world.move_result(Vector2i.LEFT)
+	_check(bool(movement.get("ok", false)), "The source approach setup cell cannot move left.")
+	_check(world.player_cell == SIGHT_CELL, "The player did not reach Joey's sight line.")
+
+	var sight: Array = world.dispatch_sight_events()
+	var sight_source: Dictionary = _single_result(sight, "trainer sight").get("source", {})
+	_check(int(sight_source.get("object_index", -1)) == TRAINER_OBJECT_INDEX, "Wrong trainer saw the player.")
+	_check(int(sight_source.get("distance", -1)) == 2, "Joey's sight distance is not two.")
+	_check(sight_source.get("direction", Vector2i.ZERO) == Vector2i.LEFT, "Joey's sight direction is wrong.")
+	var audio: Dictionary = _runtime_values(sight, &"audio_requested", "encounter music")
+	_check(audio.get("kind", &"") == &"encounter_music", "Trainer encounter music was not requested.")
+
+	var approach_results: Array = world.complete_runtime_request({
+		"ok": true, "audio_played": false,
+	})
+	var approach: Dictionary = _runtime_values(
+		approach_results, &"trainer_approach_requested", "trainer approach"
+	)
+	_check(int(approach.get("object_index", -1)) == TRAINER_OBJECT_INDEX, "Approach object is wrong.")
+	_check(int(approach.get("distance", -1)) == 2, "Approach distance is wrong.")
+	_check(approach.get("direction", Vector2i.ZERO) == Vector2i.LEFT, "Approach direction is wrong.")
+
+	var plan: Dictionary = world.start_trainer_approach(
+		TRAINER_OBJECT_INDEX, Vector2i.LEFT, 2
+	)
+	_check(bool(plan.get("ok", false)), "Joey's approach plan failed.")
+	_check(plan.get("path", []) == [Vector2i.LEFT], "Joey does not stop one cell away.")
+	_check(
+		int(plan.get("emote_frames", -1)) == Gen2WorldAPI.TRAINER_SHOCK_FRAMES,
+		"Joey's shock-emote duration is wrong."
+	)
+	for _frame: int in Gen2WorldAPI.TRAINER_SHOCK_FRAMES - 1:
+		world.tick()
+	_check(joey.emote_visible, "Joey's shock emote ended early.")
+	world.tick()
+	_check(not joey.emote_visible, "Joey's shock emote exceeded 30 frames.")
+
+	var step: Dictionary = world.advance_trainer_approach_step(
+		TRAINER_OBJECT_INDEX, Vector2i.LEFT
+	)
+	_check(bool(step.get("ok", false)), "Joey's approach step failed.")
+	_check(joey.cell == Vector2i(5, 29), "Joey did not stop before the player.")
+	var faced: Dictionary = world.finish_trainer_approach(TRAINER_OBJECT_INDEX)
+	_check(bool(faced.get("ok", false)), "Joey's approach could not finish.")
+	_check(joey.facing == Gen2WorldSprite.FACING_LEFT, "Joey's final facing is wrong.")
+	_check(world.player_facing == Gen2WorldSprite.FACING_RIGHT, "Player final facing is wrong.")
+
+	var text_results: Array = world.complete_runtime_request({
+		"ok": true, "object_index": TRAINER_OBJECT_INDEX, "path": plan.get("path", []),
+	})
+	var text_event: Dictionary = _waiting_event(text_results, &"text", "seen text")
+	var seen_pointer: Dictionary = trainer_record.get("seen_text", {})
+	var decoded: Dictionary = Gen2WorldScript.decode_text(data.world_text(
+		int(seen_pointer.get("bank", -1)), int(seen_pointer.get("address", 0))
+	))
+	_check(text_event.get("text", "") == decoded.get("text", ""), "Seen text does not use Joey's pointer.")
+	var button_event: Dictionary = _waiting_event(world.run_event_queue(true), &"button", "seen-text button")
+	_check(
+		button_event.get("command", &"") == &"waitbutton",
+		"Seen-text pause did not resolve to waitbutton under the Gold profile."
+	)
+	var battle_results: Array = world.run_event_queue(true)
+	var battle: Dictionary = _runtime_values(
+		battle_results, &"battle_requested", "trainer battle"
+	)
+	_check(int(battle.get("trainer_group", -1)) == TRAINER_GROUP, "Battle trainer class is wrong.")
+	_check(int(battle.get("trainer_id", -1)) == TRAINER_ID - 1, "Battle party index is wrong.")
+	_check(int(battle.get("trainer_flag", -1)) == TRAINER_EVENT_FLAG, "Battle trainer flag is wrong.")
+
+	var completed: Array = world.complete_runtime_request({
+		"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_WON,
+	})
+	var completion: Dictionary = _single_result(completed, "battle completion")
+	_check(completion.get("status", &"") == &"complete", "Trainer script did not complete after the win.")
+	_check(_has_event(completion, &"battle_map_reload_requested"), "Battle map reload was not requested.")
+	_check(world.state.is_event_flag_active(TRAINER_EVENT_FLAG), "Trainer beaten flag was not committed.")
+	_check(not world.state.is_event_flag_active(OBJECT_EVENT_FLAG), "Object visibility flag changed with the win.")
+	_check(world.dispatch_sight_events().is_empty(), "Beaten Joey can trigger sight again.")
+
+	world.reload_current_map()
+	joey = world.objects[TRAINER_OBJECT_INDEX]
+	_check(joey.active, "Beaten Joey was hidden by the trainer flag.")
+	_check(joey.cell == Vector2i(5, 29), "Joey's written approach cell did not survive reload.")
+	var after_battle: Array = world.interact()
+	var after_result: Dictionary = _single_result(after_battle, "after-battle interaction")
+	var source: Dictionary = after_result.get("source", {})
+	_check(source.get("trainer_phase", &"") == &"after", "Later interaction did not use trainer after phase.")
+	_check(
+		int(source.get("script", 0)) == int(trainer_record.get("after_script", -1)),
+		"Later interaction did not use Joey's after-battle script."
+	)
+
+
+func _text_decodes(data: GameData, pointer: Dictionary) -> bool:
+	var decoded: Dictionary = Gen2WorldScript.decode_text(data.world_text(
+		int(pointer.get("bank", -1)), int(pointer.get("address", 0))
+	))
+	return bool(decoded.get("ok", false)) and not String(decoded.get("text", "")).is_empty()
+
+
+func _runtime_values(results: Array, kind: StringName, label: String) -> Dictionary:
+	var event: Dictionary = _waiting_event(results, &"runtime_request", label)
+	var request: Dictionary = event.get("request", {})
+	_check(request.get("kind", &"") == kind, "%s request kind is wrong." % label.capitalize())
+	return request.get("values", {})
+
+
+func _waiting_event(results: Array, event_type: StringName, label: String) -> Dictionary:
+	var result: Dictionary = _single_result(results, label)
+	_check(result.get("status", &"") == &"waiting", "%s did not wait." % label.capitalize())
+	var event: Dictionary = result.get("event", {})
+	_check(event.get("type", &"") == event_type, "%s event type is wrong." % label.capitalize())
+	return event
+
+
+func _single_result(results: Array, label: String) -> Dictionary:
+	if not _check(results.size() == 1, "%s produced %d results." % [label.capitalize(), results.size()]):
+		return {}
+	if not _check(results[0] is Dictionary, "%s result is not a dictionary." % label.capitalize()):
+		return {}
+	return results[0] as Dictionary
+
+
+func _has_event(result: Dictionary, event_type: StringName) -> bool:
+	for raw: Variant in result.get("events", []):
+		if raw is Dictionary and (raw as Dictionary).get("type", &"") == event_type:
+			return true
+	return false
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS gold Route 30 trainer: imported record and initial encounter verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_gold_route30_trainer.gd.uid
+++ b/tools/validate_gold_route30_trainer.gd.uid
@@ -1,0 +1,1 @@
+uid://dn2mbdgvj54s0


### PR DESCRIPTION
The synthesized trainer intro script emitted Crystal's raw command bytes unconditionally, which decoded to the wrong commands under the Gold/Silver profile (loadtemptrainer read as loadwildmon, startbattle as reloadmapafterbattle, and so on), and the shock-emote approach was gated to Crystal only even though trainer dispatch itself was never profile-gated.

Gen2WorldScript.raw_opcode() makes the raw-byte shift explicit and is the tested inverse of the normalization Gen2WorldScriptRunner._execute() already performs, so _trainer_intro_script() now builds every command through it instead of hard-coded bytes.

Adds tools/validate_gold_route30_trainer.gd, mirroring the existing Crystal validator against a freshly imported Gold cache with constants derived from the live import and cross-checked against the pinned pokegold source. Extends the trainer fixture and integration suite with a Gold-profile case.