### PR TITLE
Interpolate the player walk step and trainer approach

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -134,27 +134,38 @@ What the contract above already supports:
   rectangles, so geometry textured from the atlas follows water and flowers
   without the renderer knowing an animation ran.
 
-What is missing, in the order it blocks work:
+What the contract above now also supports:
 
-1. **Sub-cell player position.** `Gen2WorldAPI` moves the player a whole walk
-   cell at a time and holds no interpolation, so a free-roam or first-person
-   camera has nothing to smooth against and a third-person one snaps. The API
-   needs a movement progress value, or a renderer has to invent its own and
-   drift from the world it is drawing.
-2. **Per-tile height.** Extruded height here is a guess from the collision
+- a movement progress value. `Gen2WorldAPI.player_step_offset_cells()` returns
+  the player's in-flight walk step as a fractional cell, from one cell behind
+  `player_cell` down to zero, paced by `advance_player_step(delta)` at the
+  same hardware-frame rate and stall cap `Gen2WorldAnimation` uses. The
+  logical cell still commits at the start of the step, exactly as documented
+  above; the fractional value is presentation only and never reaches
+  collision, events or the world snapshot. `mods/examples/voxel_preview/`
+  reads it for its player box and camera instead of snapping.
+
+What is still missing, in the order it blocks work:
+
+1. **Per-tile height.** Extruded height here is a guess from the collision
    permission, which cannot tell a tree from a cliff from a building. Gen II
    has no height data; a renderer needs a per-block table it supplies itself,
    and the host should let a mod attach one rather than have each renderer
    hard-code Johto.
-3. **Battles and interiors are not renderer-owned.** `Gen2BattleScreen` builds
+2. **Battles and interiors are not renderer-owned.** `Gen2BattleScreen` builds
    its own 160x144 presentation directly and does not go through the mod host,
    so the voxel mod's 3D battles have no equivalent here. Battle presentation
    needs the same registration the world renderer has.
-4. **No camera boundary.** The screen decides the visible page through
-   `Gen2WorldAPI.visible_origin_cell()`. A free camera would need the world to
-   stop being the thing that frames the view.
-5. **No input hook.** Camera pitch, first person and free-roam are all input a
+3. **No camera boundary.** The screen decides the visible page through
+   `Gen2WorldAPI.visible_origin_cell()`, which still follows the committed
+   cell rather than the interpolated one, so a free camera pans a step early.
+   A free camera would need the world to stop being the thing that frames the
+   view.
+4. **No input hook.** Camera pitch, first person and free-roam are all input a
    mod would have to receive, and the world screen currently reads keys itself.
+5. **NPC movement templates do not interpolate.** Wandering and follower
+   objects still snap between cells; only the player's ordinary walk and the
+   trainer-approach object share the sub-cell offset so far.
 
 Nothing in that list changes the world's own data, which is the part that
 matters: they are all presentation boundaries that do not exist yet, not

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -15,6 +15,9 @@ const MOVEMENT_SURF: StringName = &"surf"
 const TRAINER_SHOCK_EMOTE: int = 0
 const TRAINER_SHOCK_FRAMES: int = 30
 const TRAINER_SLOW_STEP_FRAMES: int = 16
+## StepVectors' normal-speed row: 2 pixels per frame for 8 frames, the source
+## duration for ordinary player walking (engine/overworld/map_objects.asm).
+const STEP_FRAMES_WALK: int = 8
 
 ## Crystal background event types from script_constants.asm. READ and the four
 ## facing variants point directly at a script. IFSET and IFNOTSET point at a
@@ -66,6 +69,14 @@ var script_random: RandomNumberGenerator = null
 var _last_schedule: Dictionary = {}
 var _phone_ring: Gen2WorldPhoneRing = null
 var _phone_ring_request: Dictionary = {}
+## Transient presentation offset for the player's own walk step. player_cell
+## already holds the committed destination; this only paces how far behind it
+## a renderer draws the sprite. Never read by collision, events or the
+## snapshot.
+var _player_step_direction: Vector2i = Vector2i.ZERO
+var _player_step_frames_total: int = 0
+var _player_step_frames_remaining: int = 0
+var _player_step_accumulator: float = 0.0
 
 const PHONE_ENTRANCE_COLLISIONS: Array[int] = [0x71, 0x79, 0x7A, 0x7B]
 
@@ -178,8 +189,64 @@ func player_view_cell() -> Vector2i:
 	return player_cell - visible_origin_cell()
 
 
+## The committed cell in pixels, offset by any in-flight walk step so a
+## renderer can draw the approach to it. player_cell itself never carries
+## this offset; collision, events and the snapshot never see it.
 func player_pixel_position() -> Vector2i:
-	return player_view_cell() * CELL_PIXELS
+	return player_view_cell() * CELL_PIXELS + Vector2i(
+		player_step_offset_cells() * float(CELL_PIXELS)
+	)
+
+
+func player_step_in_progress() -> bool:
+	return _player_step_frames_remaining > 0
+
+
+## The in-flight walk step's presentation offset in fractional walk cells,
+## from 1.0 cell behind player_cell down to zero, so a renderer that does not
+## think in hardware pixels (a 3D or free-roam mod) can still smooth against
+## it without reverse-engineering CELL_PIXELS.
+func player_step_offset_cells() -> Vector2:
+	if _player_step_frames_remaining <= 0 or _player_step_frames_total <= 0:
+		return Vector2.ZERO
+	var fraction: float = float(_player_step_frames_remaining) / float(_player_step_frames_total)
+	return Vector2(-_player_step_direction.x, -_player_step_direction.y) * fraction
+
+
+func _start_player_step(direction: Vector2i, frames: int) -> void:
+	_player_step_direction = direction
+	_player_step_frames_total = maxi(0, frames)
+	_player_step_frames_remaining = _player_step_frames_total
+
+
+func _clear_player_step() -> void:
+	_player_step_direction = Vector2i.ZERO
+	_player_step_frames_total = 0
+	_player_step_frames_remaining = 0
+	_player_step_accumulator = 0.0
+
+
+## Advances the player's walk-step offset by real elapsed time, at the same
+## hardware-frame rate and stall catch-up cap as Gen2WorldAnimation, so both
+## stay in phase after a pause instead of drifting apart. This only shrinks a
+## presentation offset that already starts and ends at player_cell; it never
+## changes player_cell, collision or event results, and callers that never
+## start a step (every existing caller of move()/move_result() before this
+## change) see no difference at all.
+func advance_player_step(delta: float) -> bool:
+	if _player_step_frames_remaining <= 0 or delta <= 0.0:
+		return false
+	_player_step_accumulator = minf(
+		_player_step_accumulator + delta,
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
+	)
+	var changed: bool = false
+	while _player_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS \
+		and _player_step_frames_remaining > 0:
+		_player_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
+		_player_step_frames_remaining -= 1
+		changed = true
+	return changed
 
 
 func player_sprite() -> Gen2WorldSprite:
@@ -695,7 +762,9 @@ func trainer_approach_plan(
 	}
 
 
-## Applies one source slow-step from an already validated approach plan.
+## Applies one source slow-step from an already validated approach plan and
+## starts that object's presentation offset for the pacing caller to consume;
+## the object's cell is already the destination when this returns.
 func advance_trainer_approach_step(object_index: int, direction: Vector2i) -> Dictionary:
 	if current_map == null or object_index < 0 or object_index >= objects.size():
 		return {"ok": false, "reason": &"invalid_trainer_object"}
@@ -708,6 +777,7 @@ func advance_trainer_approach_step(object_index: int, direction: Vector2i) -> Di
 			"object_index": object_index, "cell": destination,
 		}
 	object.cell = destination
+	object.start_step(direction, TRAINER_SLOW_STEP_FRAMES)
 	var key: String = _object_key(current_map.group, current_map.number, object_index)
 	_object_position_overrides[key] = object.cell
 	_object_facing_overrides[key] = object.facing
@@ -2062,6 +2132,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
 	_advance_followers(from_cell, previous_cells)
+	_start_player_step(direction, STEP_FRAMES_WALK)
 	return {
 		"ok": true,
 		"kind": &"water_move" if movement_mode == MOVEMENT_SURF else &"move",
@@ -2155,6 +2226,7 @@ func _apply_map(
 	current_map = target_map
 	current_tileset = target_tileset
 	player_cell = _clamp_cell(target_cell)
+	_clear_player_step()
 	_load_objects()
 	# The cartridge moves roaming Pokémon in map setup, not on a timer, so a
 	# player who stands still does not watch them cross Johto.

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -50,6 +50,12 @@ var deleted: bool = false
 var emote_id: int = -1
 var emote_visible: bool = false
 var emote_remaining: int = 0
+## Transient sub-cell presentation offset toward a cell this object already
+## committed to. The logical cell changes at the start of a step, not here;
+## a renderer reads this only to draw the approach to it.
+var step_direction: Vector2i = Vector2i.ZERO
+var step_frames_total: int = 0
+var step_frames_remaining: int = 0
 
 
 static func from_event(
@@ -175,3 +181,38 @@ func tick_emote() -> bool:
 		emote_visible = false
 		return true
 	return false
+
+
+## Starts the presentation offset for a step whose destination cell is
+## already committed. [param frames] is the caller's own step duration, kept
+## caller-side so a slow trainer approach and an ordinary walk can share this
+## helper without this class knowing which one is running.
+func start_step(direction: Vector2i, frames: int) -> void:
+	step_direction = direction
+	step_frames_total = maxi(0, frames)
+	step_frames_remaining = step_frames_total
+
+
+## Consumes one frame of an in-flight step. Returns true when a frame was
+## consumed, false once the step has already finished, so a caller pacing by
+## call count rather than delta time can tell "still stepping" from "done".
+func tick_step() -> bool:
+	if step_frames_remaining <= 0:
+		return false
+	step_frames_remaining -= 1
+	return true
+
+
+func is_stepping() -> bool:
+	return step_frames_remaining > 0
+
+
+## Pixel offset from the committed cell back toward where the step began,
+## shrinking to zero as step_frames_remaining reaches zero.
+func step_offset(cell_pixels: int) -> Vector2i:
+	if step_frames_remaining <= 0 or step_frames_total <= 0:
+		return Vector2i.ZERO
+	var behind: int = int(round(
+		float(step_frames_remaining) / float(step_frames_total) * float(cell_pixels)
+	))
+	return Vector2i(-step_direction.x, -step_direction.y) * behind

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -140,7 +140,8 @@ func _draw() -> void:
 	var actors: Array = _world.visible_objects()
 	actors.sort_custom(_sort_objects)
 	for object: Gen2WorldObject in actors:
-		var pixel: Vector2i = (object.cell - _world.visible_origin_cell()) * Gen2WorldAPI.CELL_PIXELS
+		var pixel: Vector2i = (object.cell - _world.visible_origin_cell()) * Gen2WorldAPI.CELL_PIXELS \
+			+ object.step_offset(Gen2WorldAPI.CELL_PIXELS)
 		var texture: Texture2D = _actor_texture(object.sprite, object.palette, object.facing, object.frame)
 		if texture != null:
 			draw_texture(texture, Vector2(pixel))

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -206,6 +206,8 @@ func cycle_world_renderer() -> Dictionary:
 func _process(delta: float) -> void:
 	if _animation != null and _animation.advance(delta) and _renderer != null:
 		_renderer.refresh_animation()
+	if _world != null and _world.advance_player_step(delta) and _renderer != null:
+		_renderer.refresh()
 	if _world != null and _world.tick() and _renderer != null:
 		_renderer.refresh()
 	if not _trainer_approach.is_empty():
@@ -349,7 +351,7 @@ func _unhandled_key_input(event: InputEvent) -> void:
 func move_player(direction: Vector2i) -> bool:
 	if _world == null or _world.fishing_busy() or _service_host != null \
 		or _pc_host != null or _world.phone_ring_active() \
-		or not _trainer_approach.is_empty():
+		or not _trainer_approach.is_empty() or _world.player_step_in_progress():
 		return false
 	var movement: Dictionary = _world.move_result(direction)
 	if not bool(movement.get("ok", false)):
@@ -831,7 +833,6 @@ func _start_trainer_approach(request: Dictionary) -> void:
 		"path_index": 0,
 		"emote_frames": int(plan.get("emote_frames", Gen2WorldAPI.TRAINER_SHOCK_FRAMES)),
 		"movement_delay": 1,
-		"step_frames": 0,
 	}
 	_script_prompt = "Trainer spotted you"
 	if _renderer != null:
@@ -839,6 +840,13 @@ func _start_trainer_approach(request: Dictionary) -> void:
 	_refresh_labels()
 
 
+## Paces the approach by call count rather than delta time, so this matches
+## the emote and movement-delay counters beside it and stays independent of
+## real frame timing. The stepping object's own step_frames_remaining (set by
+## [method Gen2WorldAPI.advance_trainer_approach_step]) is consumed here at
+## the same one-per-call rate the emote and delay counters already use; the
+## object's step_offset() gives the renderer the same 16-frame interpolation
+## without changing how many calls the approach takes to finish.
 func _advance_trainer_approach() -> void:
 	if _world == null:
 		_trainer_approach = {}
@@ -853,13 +861,15 @@ func _advance_trainer_approach() -> void:
 	if movement_delay > 0:
 		_trainer_approach["movement_delay"] = movement_delay - 1
 		return
-	var step_frames: int = int(_trainer_approach.get("step_frames", 0))
-	if step_frames > 0:
-		_trainer_approach["step_frames"] = step_frames - 1
+	var object_index: int = int(_trainer_approach.get("object_index", -1))
+	var stepping_object: Gen2WorldObject = _world.objects[object_index] \
+		if _world != null and object_index >= 0 and object_index < _world.objects.size() else null
+	if stepping_object != null and stepping_object.tick_step():
+		if _renderer != null:
+			_renderer.refresh()
 		return
 	var path: Array = _trainer_approach.get("path", [])
 	var path_index: int = int(_trainer_approach.get("path_index", 0))
-	var object_index: int = int(_trainer_approach.get("object_index", -1))
 	if path_index < path.size():
 		var direction_value: Variant = path[path_index]
 		if not direction_value is Vector2i:
@@ -873,7 +883,6 @@ func _advance_trainer_approach() -> void:
 			_finish_trainer_approach(false, step.get("reason", &"trainer_approach_failed"), step)
 			return
 		_trainer_approach["path_index"] = path_index + 1
-		_trainer_approach["step_frames"] = Gen2WorldAPI.TRAINER_SLOW_STEP_FRAMES
 		if _renderer != null:
 			_renderer.refresh()
 		return

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -119,7 +119,7 @@ func refresh_animation() -> void:
 func refresh() -> void:
 	if _world == null or _camera == null:
 		return
-	var here: Vector3 = _cell_center(_world.player_cell)
+	var here: Vector3 = _player_position()
 	_player.position = here + Vector3(0.0, 0.6, 0.0)
 	_camera.position = here + CAMERA_OFFSET
 	_camera.look_at(here, Vector3.UP)
@@ -128,6 +128,14 @@ func refresh() -> void:
 
 func _cell_center(cell: Vector2i) -> Vector3:
 	return Vector3(float(cell.x) * CELL_SIZE, 0.0, float(cell.y) * CELL_SIZE)
+
+
+## player_cell plus its in-flight walk step's fractional offset, so the box
+## and camera ease into a new cell instead of snapping the way they did
+## before Gen2WorldAPI carried any sub-cell presentation state.
+func _player_position() -> Vector3:
+	var offset: Vector2 = _world.player_step_offset_cells()
+	return _cell_center(_world.player_cell) + Vector3(offset.x, 0.0, offset.y) * CELL_SIZE
 
 
 ## One solid per walk cell, extruded by what the cell's collision permission

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -96,6 +96,53 @@ func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	assert_eq(snapshot["world_battle_active"], true)
 
 
+## The approach still takes the same number of process frames it did before
+## sub-cell interpolation existed (proven by every other case in this file
+## reaching the battle overlay through the same _trigger_trainer budget);
+## this only checks that while the trainer object is mid-step, its
+## presentation offset eases toward zero instead of snapping.
+func test_trainer_approach_step_interpolates_the_objects_position() -> void:
+	await _open_world()
+	assert_true(_world_screen.move_player(Vector2i.RIGHT))
+
+	var object := _world_screen._world.objects[0] as Gen2WorldObject
+	var saw_step: bool = false
+	var was_stepping: bool = false
+	var previous_magnitude: int = -1
+	var lowest_magnitude: int = Gen2WorldAPI.CELL_PIXELS
+	for _frame: int in 80:
+		await get_tree().process_frame
+		if _battle_host() != null:
+			break
+		if object.is_stepping():
+			var offset: Vector2i = object.step_offset(Gen2WorldAPI.CELL_PIXELS)
+			var magnitude: int = abs(offset.x) + abs(offset.y)
+			if not saw_step:
+				# The source's single-step Route 30 fixture path starts at a
+				# full cell of offset; a longer path would restart here too.
+				assert_eq(magnitude, Gen2WorldAPI.CELL_PIXELS)
+			elif was_stepping:
+				assert_true(
+					magnitude <= previous_magnitude,
+					"step offset must ease toward zero within one step, not grow"
+				)
+			saw_step = true
+			was_stepping = true
+			previous_magnitude = magnitude
+			lowest_magnitude = mini(lowest_magnitude, magnitude)
+		else:
+			was_stepping = false
+		var pending: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+			_world_screen._advance_script_input()
+	assert_not_null(_battle_host())
+	assert_true(saw_step)
+	# tick_step() decrements once per process call, the same rate the emote
+	# and movement-delay counters already use; the offset eases down to one
+	# sixteenth of a cell on the frame before the step formally ends.
+	assert_eq(lowest_magnitude, 1)
+
+
 func test_victory_displays_imported_text_reloads_objects_and_keeps_player_cell() -> void:
 	await _open_world()
 	await _trigger_trainer()

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -694,6 +694,116 @@ func test_trainer_approach_path_uses_the_source_longer_axis_first() -> void:
 	)
 
 
+func test_player_walk_step_starts_a_cell_behind_and_never_moves_the_committed_cell() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_false(world.player_step_in_progress())
+	assert_true(world.move(Vector2i.LEFT))
+	# The logical cell already committed to the destination; the step only
+	# paces a presentation offset that starts a full cell behind it.
+	assert_eq(world.player_cell, Vector2i(7, 6))
+	assert_true(world.player_step_in_progress())
+	assert_eq(world.player_step_offset_cells(), Vector2(1.0, 0.0))
+	assert_eq(
+		world.player_pixel_position(),
+		world.player_view_cell() * Gen2WorldAPI.CELL_PIXELS + Vector2i(16, 0)
+	)
+
+
+func test_advance_player_step_consumes_hardware_frames_and_caps_catchup() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(world.move(Vector2i.LEFT))
+	assert_eq(world.player_cell, Vector2i(7, 6))
+
+	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_eq(world.player_step_offset_cells(), Vector2(0.875, 0.0))
+
+	# A huge delta advances at most Gen2WorldAnimation.MAX_CATCHUP_FRAMES
+	# hardware frames per call, the same stall cap the tile animation uses, so
+	# a pause drops step frames instead of snapping the sprite to its
+	# destination. STEP_FRAMES_WALK is 8: one frame already consumed above,
+	# four more are capped here, leaving three of eight.
+	assert_true(world.advance_player_step(1000.0))
+	assert_eq(world.player_step_offset_cells(), Vector2(3.0 / 8.0, 0.0))
+	assert_eq(world.player_cell, Vector2i(7, 6))
+
+	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 3.0))
+	assert_false(world.player_step_in_progress())
+	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+	assert_eq(world.player_cell, Vector2i(7, 6))
+	assert_false(world.advance_player_step(1.0))
+
+
+func test_player_step_does_not_affect_cell_collision_or_events() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(world.move(Vector2i.LEFT))
+	assert_eq(world.player_cell, Vector2i(7, 6))
+	assert_true(world.player_step_in_progress())
+	var during_events: Array = world.dispatch_events()
+	var during_permission: int = world.collision_permission_at(world.player_cell)
+	var during_walkable: bool = world.can_walk_to(Vector2i(6, 6))
+
+	assert_true(world.advance_player_step(1000.0))
+	assert_true(world.advance_player_step(1000.0))
+	assert_false(world.player_step_in_progress())
+
+	# A presentation offset in flight never changes what resolves off the
+	# already-committed cell.
+	assert_eq(world.dispatch_events(), during_events)
+	assert_eq(world.collision_permission_at(world.player_cell), during_permission)
+	assert_eq(world.can_walk_to(Vector2i(6, 6)), during_walkable)
+	assert_eq(world.player_cell, Vector2i(7, 6))
+
+
+func test_player_step_clears_on_connection_transition() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(14, 6))
+	assert_true(world.move(Vector2i.RIGHT))
+	assert_eq(world.player_cell, Vector2i(15, 6))
+	assert_true(world.player_step_in_progress())
+
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_true(result["ok"])
+	assert_eq(result["kind"], &"connection")
+	assert_eq(world.map_id(), Vector2i(1, 2))
+	assert_false(world.player_step_in_progress())
+	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+
+
+func test_player_step_clears_on_warp() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(7, 6))
+	assert_true(world.move(Vector2i.LEFT))
+	assert_eq(world.player_cell, Vector2i(6, 6))
+	assert_true(world.player_step_in_progress())
+
+	var result: Dictionary = world.try_warp()
+	assert_true(result["ok"])
+	assert_eq(world.map_id(), Vector2i(1, 2))
+	assert_false(world.player_step_in_progress())
+	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+
+
+func test_snapshot_ignores_transient_player_step() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(world.move(Vector2i.LEFT))
+	assert_true(world.player_step_in_progress())
+	var mid_step: Dictionary = world.snapshot().to_dict()
+
+	assert_true(world.advance_player_step(1000.0))
+	assert_true(world.advance_player_step(1000.0))
+	assert_false(world.player_step_in_progress())
+	var finished: Dictionary = world.snapshot().to_dict()
+
+	# The snapshot is identical whether captured mid-step or after it
+	# finishes: nothing about the transient offset reaches it.
+	assert_eq(mid_step, finished)
+
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
+		GameData.open_directory(_directory), world.snapshot()
+	)
+	assert_not_null(restored)
+	assert_false(restored.player_step_in_progress())
+	assert_eq(restored.player_cell, Vector2i(7, 6))
+
+
 func test_script_object_visibility_changes_rendering_and_occupancy() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
 	var result: Array = world.dispatch_script_events(Vector2i(5, 6))

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -56,3 +56,33 @@ func test_random_wander_stays_cardinal() -> void:
 	random.seed = 1234
 	var direction: Vector2i = object.next_direction(random)
 	assert_eq(abs(direction.x) + abs(direction.y), 1)
+
+
+func test_step_offset_starts_a_full_cell_behind_and_reaches_zero() -> void:
+	var object: Gen2WorldObject = _object()
+	assert_false(object.is_stepping())
+	assert_eq(object.step_offset(16), Vector2i.ZERO)
+
+	object.start_step(Vector2i.RIGHT, 8)
+	assert_true(object.is_stepping())
+	# A step's destination cell is already committed; the offset starts a
+	# full cell behind it and eases toward zero, never overshooting.
+	assert_eq(object.step_offset(16), Vector2i(-16, 0))
+
+	for _frame: int in 8:
+		assert_true(object.tick_step())
+	assert_eq(object.step_offset(16), Vector2i.ZERO)
+	assert_false(object.is_stepping())
+	assert_false(object.tick_step())
+
+
+func test_step_offset_direction_matches_the_committed_movement() -> void:
+	var object: Gen2WorldObject = _object()
+	object.start_step(Vector2i.UP, 16)
+	object.tick_step()
+	# One of sixteen slow-step frames consumed: 15/16 of a cell remains
+	# behind the committed cell, in the direction moved away from.
+	assert_eq(object.step_offset(16), Vector2i(0, 15))
+
+	object.start_step(Vector2i.LEFT, 4)
+	assert_eq(object.step_offset(4), Vector2i(4, 0))


### PR DESCRIPTION
Gen2WorldAPI moved the player and resolved every event off a whole walk cell with no interpolation, and the trainer approach snapped its final cell instead of easing into it. The logical cell still commits at the start of a step; the new offset is presentation only and never reaches collision, events or the world snapshot.

The player's ordinary walk is paced by real elapsed time through advance_player_step(), sharing Gen2WorldAnimation's hardware-frame rate and stall cap. The trainer approach keeps its existing call-count pacing so its fixed-frame integration tests stay accurate, and now carries the same offset through Gen2WorldObject. The built-in renderer and the voxel preview mod both read the new value.