### PR TITLE
Pace and interpolate wandering NPC movement

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -144,6 +144,12 @@ What the contract above now also supports:
   above; the fractional value is presentation only and never reaches
   collision, events or the world snapshot. `mods/examples/voxel_preview/`
   reads it for its player box and camera instead of snapping.
+- the same progress value for NPCs. `Gen2WorldObject.step_offset_cells()`
+  returns a wandering or following object's in-flight step as a fractional
+  cell, on the same terms as the player's. `Gen2WorldAPI.advance_object_steps()`
+  paces the wandering and spinning movement templates at the source's own step
+  and wait durations, and the example renderer reads the offset for its object
+  markers.
 
 What is still missing, in the order it blocks work:
 
@@ -163,9 +169,10 @@ What is still missing, in the order it blocks work:
    view.
 4. **No input hook.** Camera pitch, first person and free-roam are all input a
    mod would have to receive, and the world screen currently reads keys itself.
-5. **NPC movement templates do not interpolate.** Wandering and follower
-   objects still snap between cells; only the player's ordinary walk and the
-   trainer-approach object share the sub-cell offset so far.
+5. **Scripted movement does not interpolate.** `applymovement` streams still
+   place objects a whole cell at a time, and so do the jump, teleport and
+   boulder step types. The wandering, spinning, following, player and
+   trainer-approach paths all carry the sub-cell offset.
 
 Nothing in that list changes the world's own data, which is the part that
 matters: they are all presentation boundaries that do not exist yet, not

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -18,6 +18,14 @@ const TRAINER_SLOW_STEP_FRAMES: int = 16
 ## StepVectors' normal-speed row: 2 pixels per frame for 8 frames, the source
 ## duration for ordinary player walking (engine/overworld/map_objects.asm).
 const STEP_FRAMES_WALK: int = 8
+## StepVectors' slow row: 1 pixel per frame for 16 frames. _RandomWalkContinue
+## calls InitStep with a direction of 0 to 3, which indexes that first row, so
+## a wandering object steps at half the player's walking speed.
+const STEP_FRAMES_NPC_WALK: int = 16
+## RandomStepDuration_Slow and _Fast mask the source random byte before storing
+## it as the wait preceding the next movement decision.
+const IDLE_MASK_SLOW: int = 0x7F
+const IDLE_MASK_FAST: int = 0x1F
 
 ## Crystal background event types from script_constants.asm. READ and the four
 ## facing variants point directly at a script. IFSET and IFNOTSET point at a
@@ -66,6 +74,10 @@ var schedule_random: RandomNumberGenerator = null
 ## apart from schedule_random so seeding one route does not shift the other.
 ## A null generator leaves each invocation to randomize its own.
 var script_random: RandomNumberGenerator = null
+## Supplies the wandering and spinning movement templates. Kept apart from the
+## other two so seeding NPC motion cannot shift an encounter, a phone roll or a
+## script's RANDOM result.
+var object_random: RandomNumberGenerator = null
 var _last_schedule: Dictionary = {}
 var _phone_ring: Gen2WorldPhoneRing = null
 var _phone_ring_request: Dictionary = {}
@@ -77,6 +89,9 @@ var _player_step_direction: Vector2i = Vector2i.ZERO
 var _player_step_frames_total: int = 0
 var _player_step_frames_remaining: int = 0
 var _player_step_accumulator: float = 0.0
+## Real time banked toward the next hardware frame of object movement, held
+## beside the player's own accumulator so the two stay in phase after a stall.
+var _object_step_accumulator: float = 0.0
 
 const PHONE_ENTRANCE_COLLISIONS: Array[int] = [0x71, 0x79, 0x7A, 0x7B]
 
@@ -1064,6 +1079,13 @@ func script_input_waiting() -> bool:
 	return _active_script != null and _active_script.is_waiting()
 
 
+## True while a script holds the world, either running or still queued. A host
+## that drives ambient motion checks this so a script keeps sole ownership of
+## the objects it may be moving.
+func script_busy() -> bool:
+	return _active_script != null or not _script_queue.is_empty()
+
+
 func pending_runtime_request() -> Dictionary:
 	return _active_script.pending_runtime_request() if _active_script != null else {}
 
@@ -2025,26 +2047,103 @@ func can_object_walk_to(cell: Vector2i, moving: Gen2WorldObject) -> bool:
 ## Advances the movement templates whose source behavior is data-driven in this
 ## slice. Scripted movement is executed by the script runner, while followers
 ## advance after each successful player step.
+##
+## This remains one movement decision per eligible object per call. A caller
+## that wants the source's own pacing uses advance_object_steps() instead,
+## which spends the step and idle durations this function records.
 func advance_objects(random: RandomNumberGenerator) -> int:
 	var moved: int = 0
 	for object: Gen2WorldObject in objects:
 		if not object.active or not object.movement_supported():
 			continue
-		if object.movement in [Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW, Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST]:
-			object.facing = random.randi_range(
-				Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
-			)
-			continue
-		var direction: Vector2i = object.next_direction(random)
-		if direction == Vector2i.ZERO:
-			continue
-		var destination: Vector2i = object.cell + direction
-		if not object.can_leave_to(destination) or not can_object_walk_to(destination, object):
-			continue
-		object.cell = destination
-		object.apply_direction(direction)
-		moved += 1
+		if _decide_object_movement(object, random):
+			moved += 1
 	return moved
+
+
+## One object's turn at StepFunction_FromMovement: the movement template picks
+## a facing or a direction, then records how long the resulting step or wait
+## lasts. Returns true when the object committed to a new cell.
+func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenerator) -> bool:
+	if object.movement in [
+		Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW, Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST
+	]:
+		# MovementFunction_RandomSpinSlow and _Fast set a facing and go straight
+		# to their own wait; neither ever starts a step.
+		object.facing = random.randi_range(
+			Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
+		)
+		var spin_mask: int = IDLE_MASK_SLOW \
+			if object.movement == Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW else IDLE_MASK_FAST
+		object.start_idle(random.randi() & spin_mask)
+		return false
+	var direction: Vector2i = object.next_direction(random)
+	if direction == Vector2i.ZERO:
+		return false
+	var destination: Vector2i = object.cell + direction
+	if not object.can_leave_to(destination) or not can_object_walk_to(destination, object):
+		# _RandomWalkContinue's .new_duration branch: a blocked object keeps its
+		# cell and waits again before trying another direction.
+		object.start_idle(random.randi() & IDLE_MASK_SLOW)
+		return false
+	object.cell = destination
+	object.apply_direction(direction)
+	object.start_step(direction, STEP_FRAMES_NPC_WALK)
+	return true
+
+
+## Paces the data-driven movement templates by real elapsed time, at the same
+## hardware-frame rate and stall catch-up cap the player's own walk step and
+## Gen2WorldAnimation use.
+##
+## Per frame an object either spends one frame of an in-flight step, one frame
+## of its wait, or takes a new movement decision, which is the source's
+## STEP_TYPE_CONTINUE_WALK, STEP_TYPE_SLEEP and STEP_TYPE_FROM_MOVEMENT cycle.
+## The cell commits when the step starts, matching InitStep and the player path;
+## only the presentation offset trails behind it. Returns true when something a
+## renderer draws changed.
+func advance_object_steps(delta: float, random: RandomNumberGenerator) -> bool:
+	if delta <= 0.0 or random == null or objects.is_empty():
+		return false
+	_object_step_accumulator = minf(
+		_object_step_accumulator + delta,
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
+	)
+	var changed: bool = false
+	while _object_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS:
+		_object_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
+		for object: Gen2WorldObject in objects:
+			if not object.active or object.deleted or object.sprite == null \
+				or not object.movement_advances():
+				continue
+			if object.tick_step():
+				changed = true
+				if not object.is_stepping():
+					# StepFunction_ContinueWalk rolls a new wait the moment the
+					# step duration reaches zero, so a wandering object pauses
+					# between steps instead of walking without stopping.
+					object.start_idle(random.randi() & IDLE_MASK_SLOW)
+				continue
+			if object.tick_idle():
+				continue
+			var facing_before: int = object.facing
+			if _decide_object_movement(object, random):
+				_remember_object_position(object)
+				changed = true
+			elif object.facing != facing_before:
+				_remember_object_position(object)
+				changed = true
+	return changed
+
+
+## Keeps a moved or turned object's live cell and facing across the map reloads
+## that rebuild object records, the same way the trainer approach does.
+func _remember_object_position(object: Gen2WorldObject) -> void:
+	if current_map == null:
+		return
+	var key: String = _object_key(current_map.group, current_map.number, object.index)
+	_object_position_overrides[key] = object.cell
+	_object_facing_overrides[key] = object.facing
 
 
 func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictionary) -> void:
@@ -2094,6 +2193,9 @@ func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictiona
 		if can_object_walk_to(destination, follower):
 			follower.cell = destination
 			follower.apply_direction(direction)
+			# A follower keeps pace with the player, so it takes the player's
+			# own walk duration rather than the slower wandering one.
+			follower.start_step(direction, STEP_FRAMES_WALK)
 			var override_key: String = _object_key(
 				current_map.group, current_map.number, follower_index
 			)
@@ -2227,6 +2329,9 @@ func _apply_map(
 	current_tileset = target_tileset
 	player_cell = _clamp_cell(target_cell)
 	_clear_player_step()
+	# _load_objects() rebuilds every record, so in-flight object steps end with
+	# the objects that owned them; only the shared frame accumulator survives.
+	_object_step_accumulator = 0.0
 	_load_objects()
 	# The cartridge moves roaming Pokémon in map setup, not on a timer, so a
 	# player who stands still does not watch them cross Johto.

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -56,6 +56,10 @@ var emote_remaining: int = 0
 var step_direction: Vector2i = Vector2i.ZERO
 var step_frames_total: int = 0
 var step_frames_remaining: int = 0
+## Frames this object waits before its movement template decides again. The
+## source keeps this in OBJECT_STEP_DURATION while the object sits in
+## STEP_TYPE_SLEEP (engine/overworld/map_objects.asm, StepFunction_Sleep).
+var idle_frames_remaining: int = 0
 
 
 static func from_event(
@@ -104,6 +108,17 @@ func movement_supported() -> bool:
 		MOVEMENT_WALK_UP_DOWN, MOVEMENT_WALK_LEFT_RIGHT,
 		MOVEMENT_FIXED_DOWN, MOVEMENT_FIXED_UP, MOVEMENT_FIXED_LEFT,
 		MOVEMENT_FIXED_RIGHT, MOVEMENT_SPINRANDOM_FAST, MOVEMENT_SWIM_WANDER,
+	]
+
+
+## The supported templates that actually decide something on their own: the
+## three random-walk rows and the two random-spin rows. The standing and
+## fixed-facing rows resolve once in the source and never ask again, so a
+## per-frame driver skips them rather than re-deciding nothing every frame.
+func movement_advances() -> bool:
+	return movement in [
+		MOVEMENT_WANDER, MOVEMENT_WALK_UP_DOWN, MOVEMENT_WALK_LEFT_RIGHT,
+		MOVEMENT_SWIM_WANDER, MOVEMENT_SPINRANDOM_SLOW, MOVEMENT_SPINRANDOM_FAST,
 	]
 
 
@@ -207,6 +222,26 @@ func is_stepping() -> bool:
 	return step_frames_remaining > 0
 
 
+## Starts the wait a movement template takes before deciding again. The source
+## rolls this duration itself; the caller supplies the rolled value so this
+## class stays free of the generator.
+func start_idle(frames: int) -> void:
+	idle_frames_remaining = maxi(0, frames)
+
+
+## Consumes one frame of that wait. Returns true when a frame was consumed,
+## matching tick_step() so one caller can pace both.
+func tick_idle() -> bool:
+	if idle_frames_remaining <= 0:
+		return false
+	idle_frames_remaining -= 1
+	return true
+
+
+func is_idle() -> bool:
+	return idle_frames_remaining > 0
+
+
 ## Pixel offset from the committed cell back toward where the step began,
 ## shrinking to zero as step_frames_remaining reaches zero.
 func step_offset(cell_pixels: int) -> Vector2i:
@@ -216,3 +251,14 @@ func step_offset(cell_pixels: int) -> Vector2i:
 		float(step_frames_remaining) / float(step_frames_total) * float(cell_pixels)
 	))
 	return Vector2i(-step_direction.x, -step_direction.y) * behind
+
+
+## The same offset in fractional walk cells, from one cell behind the committed
+## cell down to zero. A renderer that does not think in hardware pixels reads
+## this instead of step_offset(), exactly as a renderer reads the player's
+## Gen2WorldAPI.player_step_offset_cells().
+func step_offset_cells() -> Vector2:
+	if step_frames_remaining <= 0 or step_frames_total <= 0:
+		return Vector2.ZERO
+	var fraction: float = float(step_frames_remaining) / float(step_frames_total)
+	return Vector2(-step_direction.x, -step_direction.y) * fraction

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -45,6 +45,9 @@ var _trainer_approach: Dictionary = {}
 var _active_battle_save: Gen2SaveData = null
 var _active_battle_persist: bool = false
 var _encounter_random := RandomNumberGenerator.new()
+## NPC movement rolls from its own generator, so a seeded route keeps the same
+## encounters and script results however long the player stands watching.
+var _object_random := RandomNumberGenerator.new()
 var _selected_rod: StringName = Gen2WorldEncounter.METHOD_OLD_ROD
 
 @onready var _screen: Gen2Screen = %Screen
@@ -109,11 +112,14 @@ func _build_world() -> void:
 		return
 	if encounter_seed != 0:
 		_encounter_random.seed = encounter_seed
+		_object_random.seed = encounter_seed + 1
 	else:
 		_encounter_random.randomize()
+		_object_random.randomize()
 
 	_world.schedule_random = _encounter_random
 	_world.script_random = _encounter_random
+	_world.object_random = _object_random
 	_clock = Gen2WorldClock.new(initial_hour, initial_minute, initial_day)
 	time_of_day = _clock.time_of_day()
 	_animation = Gen2WorldAnimation.new()
@@ -210,6 +216,9 @@ func _process(delta: float) -> void:
 		_renderer.refresh()
 	if _world != null and _world.tick() and _renderer != null:
 		_renderer.refresh()
+	if _objects_may_move() and _world.advance_object_steps(delta, _object_random) \
+		and _renderer != null:
+		_renderer.refresh()
 	if not _trainer_approach.is_empty():
 		_advance_trainer_approach()
 	if _world != null and _world.phone_ring_active():
@@ -238,6 +247,18 @@ func _process(delta: float) -> void:
 		)
 		if bool(audio_result.get("ok", false)):
 			_show_script_results(audio_result.get("results", []))
+
+
+## Wandering objects keep to themselves while anything else owns the world. A
+## script may be moving those same objects, a trainer approach paces its own
+## object by call count, and an overlay hides the map entirely.
+func _objects_may_move() -> bool:
+	return _world != null \
+		and _battle_host == null and _service_host == null and _pc_host == null \
+		and _trainer_approach.is_empty() \
+		and not _world.script_busy() \
+		and not _world.phone_ring_active() \
+		and not _world.fishing_busy()
 
 
 func _unhandled_key_input(event: InputEvent) -> void:

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -239,7 +239,13 @@ func _rebuild_objects() -> void:
 		mesh.size = Vector3(0.6, 1.0, 0.6)
 		marker.mesh = mesh
 		marker.material_override = _material(Color("#f3c969"))
-		marker.position = _cell_center(object.cell) + Vector3(0.0, 0.5, 0.0)
+		# The same fractional offset the player box reads, from the object's
+		# own in-flight step, so a wandering NPC eases between cells here
+		# without this renderer knowing anything about hardware pixels.
+		var offset: Vector2 = object.step_offset_cells()
+		marker.position = _cell_center(object.cell) \
+			+ Vector3(offset.x, 0.0, offset.y) * CELL_SIZE \
+			+ Vector3(0.0, 0.5, 0.0)
 		_objects.add_child(marker)
 
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -804,6 +804,254 @@ func test_snapshot_ignores_transient_player_step() -> void:
 	assert_eq(restored.player_cell, Vector2i(7, 6))
 
 
+## The fixture's single object stands still. These tests hand it a wandering
+## template so the data-driven driver has something to decide about.
+func _wandering_world(
+	movement: int = Gen2WorldObject.MOVEMENT_WANDER, x_radius: int = 2, y_radius: int = 2,
+	start: Vector2i = Vector2i(12, 10)
+) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _world(start)
+	var object: Gen2WorldObject = world.objects[0]
+	object.movement = movement
+	object.x_radius = x_radius
+	object.y_radius = y_radius
+	return world
+
+
+func _advance_object_frames(
+	world: Gen2WorldAPI, frames: int, random: RandomNumberGenerator
+) -> void:
+	for _frame: int in frames:
+		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+
+
+func test_wander_object_commits_its_cell_and_eases_over_the_slow_step() -> void:
+	var world: Gen2WorldAPI = _wandering_world()
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 90210
+	var start: Vector2i = object.cell
+
+	# The first frame is the object's turn at the movement function.
+	assert_true(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	assert_true(object.is_stepping())
+	# StepVectors' slow row is 16 frames, half the player's walking speed.
+	assert_eq(object.step_frames_total, Gen2WorldAPI.STEP_FRAMES_NPC_WALK)
+	# The cell commits when the step starts, exactly as InitStep and the
+	# player's own walk do; only the drawn offset trails behind it.
+	assert_ne(object.cell, start)
+	assert_eq(object.step_offset_cells(), Vector2(start - object.cell))
+
+	# The deciding frame starts the step without spending one of its frames,
+	# the way the source runs the movement function and the step function on
+	# separate frames, so the full duration follows it.
+	_advance_object_frames(world, Gen2WorldAPI.STEP_FRAMES_NPC_WALK, random)
+	assert_false(object.is_stepping())
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+	assert_eq(abs(object.cell.x - start.x) + abs(object.cell.y - start.y), 1)
+
+
+func test_wander_object_waits_its_rolled_idle_before_deciding_again() -> void:
+	var world: Gen2WorldAPI = _wandering_world()
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 4242
+
+	_advance_object_frames(world, 1 + Gen2WorldAPI.STEP_FRAMES_NPC_WALK, random)
+	assert_false(object.is_stepping())
+	# The step's final frame rolls the next wait, exactly as
+	# StepFunction_ContinueWalk jumps to RandomStepDuration_Slow. That mask is
+	# $7F, so the wait never exceeds 127 frames.
+	assert_true(object.is_idle())
+	assert_true(object.idle_frames_remaining <= Gen2WorldAPI.IDLE_MASK_SLOW)
+
+	var resting_cell: Vector2i = object.cell
+	var idle_frames: int = object.idle_frames_remaining
+	_advance_object_frames(world, idle_frames, random)
+	assert_eq(object.cell, resting_cell)
+	assert_false(object.is_idle())
+
+
+func test_blocked_wander_object_keeps_its_cell_and_waits() -> void:
+	# A radius of zero leaves every neighbouring cell outside the object's
+	# bounds, which is the source's blocked branch.
+	var world: Gen2WorldAPI = _wandering_world(Gen2WorldObject.MOVEMENT_WANDER, 0, 0)
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 77
+	var start: Vector2i = object.cell
+
+	assert_false(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	assert_eq(object.cell, start)
+	assert_false(object.is_stepping())
+	# _RandomWalkContinue's .new_duration branch waits again rather than
+	# retrying a direction on the very next frame.
+	assert_true(object.is_idle())
+
+	_advance_object_frames(world, 400, random)
+	assert_eq(object.cell, start)
+
+
+func test_wander_object_never_leaves_its_source_radius() -> void:
+	var world: Gen2WorldAPI = _wandering_world(Gen2WorldObject.MOVEMENT_WANDER, 1, 1)
+	var object: Gen2WorldObject = world.objects[0]
+	var origin: Vector2i = object.initial_cell
+	var random := RandomNumberGenerator.new()
+	random.seed = 31337
+
+	var strayed: Vector2i = Vector2i.MAX
+	var visited: Dictionary = {}
+	for _frame: int in 2000:
+		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		visited[object.cell] = true
+		if abs(object.cell.x - origin.x) > 1 or abs(object.cell.y - origin.y) > 1:
+			strayed = object.cell
+			break
+	assert_eq(strayed, Vector2i.MAX, "object left its radius")
+	# The same run has to prove the object actually wandered, or a driver that
+	# never moved anything would pass the bound above.
+	assert_gt(visited.size(), 1, "object never moved")
+
+
+func test_spin_templates_turn_without_starting_a_step() -> void:
+	for movement: int in [
+		Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW, Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST,
+	]:
+		var world: Gen2WorldAPI = _wandering_world(movement)
+		var object: Gen2WorldObject = world.objects[0]
+		var random := RandomNumberGenerator.new()
+		random.seed = 8
+		var start: Vector2i = object.cell
+
+		_advance_object_frames(world, 200, random)
+		# MovementFunction_RandomSpinSlow and _Fast set a facing and wait; they
+		# never call InitStep, so a spinning object has no step to interpolate.
+		assert_eq(object.cell, start)
+		assert_false(object.is_stepping())
+		var mask: int = Gen2WorldAPI.IDLE_MASK_SLOW \
+			if movement == Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW else Gen2WorldAPI.IDLE_MASK_FAST
+		assert_true(object.idle_frames_remaining <= mask)
+
+
+func test_standing_objects_are_never_moved_by_the_driver() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(12, 10))
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 5
+	var start: Vector2i = object.cell
+	var facing: int = object.facing
+
+	for _frame: int in 300:
+		assert_false(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	assert_eq(object.cell, start)
+	assert_eq(object.facing, facing)
+
+
+func test_object_driver_caps_catchup_after_a_stall() -> void:
+	var world: Gen2WorldAPI = _wandering_world()
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 90210
+
+	assert_true(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	assert_eq(object.step_frames_remaining, Gen2WorldAPI.STEP_FRAMES_NPC_WALK)
+	# A huge delta spends at most MAX_CATCHUP_FRAMES frames, the same stall cap
+	# the tile animation and the player's walk step use.
+	assert_true(world.advance_object_steps(1000.0, random))
+	assert_eq(
+		object.step_frames_remaining,
+		Gen2WorldAPI.STEP_FRAMES_NPC_WALK - Gen2WorldAnimation.MAX_CATCHUP_FRAMES
+	)
+
+
+func test_object_steps_do_not_survive_a_map_transition() -> void:
+	var world: Gen2WorldAPI = _wandering_world(
+		Gen2WorldObject.MOVEMENT_WANDER, 2, 2, Vector2i(6, 6)
+	)
+	var random := RandomNumberGenerator.new()
+	random.seed = 90210
+	var object: Gen2WorldObject = world.objects[0]
+	# The player stands on the warp beside this object, so its first rolled
+	# direction may be blocked. Run until a step is genuinely in flight.
+	for _frame: int in 600:
+		if object.is_stepping():
+			break
+		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+	assert_true(object.is_stepping())
+
+	var result: Dictionary = world.try_warp()
+	assert_true(result["ok"])
+	assert_eq(world.map_id(), Vector2i(1, 2))
+	for loaded: Gen2WorldObject in world.objects:
+		assert_false(loaded.is_stepping())
+		assert_eq(loaded.step_offset_cells(), Vector2.ZERO)
+
+
+func test_object_movement_does_not_disturb_the_other_random_streams() -> void:
+	var world: Gen2WorldAPI = _wandering_world()
+	var script_random := RandomNumberGenerator.new()
+	script_random.seed = 1000
+	world.script_random = script_random
+	var schedule_random := RandomNumberGenerator.new()
+	schedule_random.seed = 2000
+	world.schedule_random = schedule_random
+
+	var object_random := RandomNumberGenerator.new()
+	object_random.seed = 3000
+	_advance_object_frames(world, 500, object_random)
+
+	# Watching an NPC wander for hundreds of frames must not shift the next
+	# encounter, phone or script roll by a single draw.
+	var expected_script := RandomNumberGenerator.new()
+	expected_script.seed = 1000
+	assert_eq(script_random.randi(), expected_script.randi())
+	var expected_schedule := RandomNumberGenerator.new()
+	expected_schedule.seed = 2000
+	assert_eq(schedule_random.randi(), expected_schedule.randi())
+
+
+func test_object_driver_ignores_a_missing_generator() -> void:
+	var world: Gen2WorldAPI = _wandering_world()
+	var object: Gen2WorldObject = world.objects[0]
+	var start: Vector2i = object.cell
+	assert_false(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, null))
+	assert_eq(object.cell, start)
+	assert_false(object.is_stepping())
+
+
+func test_advance_objects_still_makes_one_decision_per_call() -> void:
+	var world: Gen2WorldAPI = _wandering_world()
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 90210
+	var start: Vector2i = object.cell
+
+	# The existing per-call primitive keeps its contract: one decision, one
+	# committed cell, with no frame pacing involved.
+	assert_eq(world.advance_objects(random), 1)
+	assert_eq(abs(object.cell.x - start.x) + abs(object.cell.y - start.y), 1)
+
+
+func test_follower_carries_the_player_walk_step_offset() -> void:
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6080": [0x70, 2, 0, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6080
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
+	assert_eq(world.dispatch_script_events(Vector2i(7, 6))[0]["status"], &"complete")
+	assert_true(world.move(Vector2i.LEFT))
+
+	var follower: Gen2WorldObject = world.objects[0]
+	assert_eq(follower.cell, Vector2i(6, 6))
+	# A follower keeps the player's pace, not the slower wandering one.
+	assert_true(follower.is_stepping())
+	assert_eq(follower.step_frames_total, Gen2WorldAPI.STEP_FRAMES_WALK)
+	# The follower moved right, into the cell the player left, so it is drawn
+	# one cell to the left of its committed cell as the step begins.
+	assert_eq(follower.step_offset_cells(), Vector2(-1.0, 0.0))
+
+
 func test_script_object_visibility_changes_rendering_and_occupancy() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
 	var result: Array = world.dispatch_script_events(Vector2i(5, 6))

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -86,3 +86,48 @@ func test_step_offset_direction_matches_the_committed_movement() -> void:
 
 	object.start_step(Vector2i.LEFT, 4)
 	assert_eq(object.step_offset(4), Vector2i(4, 0))
+
+
+func test_fractional_step_offset_matches_the_pixel_offset() -> void:
+	var object: Gen2WorldObject = _object()
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+
+	object.start_step(Vector2i.RIGHT, 16)
+	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0))
+	# A renderer working in cells and one working in pixels must place the
+	# same sprite in the same place at every frame of the step.
+	for frame: int in 16:
+		var cells: Vector2 = object.step_offset_cells()
+		assert_eq(object.step_offset(16), Vector2i(roundi(cells.x * 16.0), roundi(cells.y * 16.0)))
+		assert_true(object.tick_step(), "frame %d should still be in flight" % frame)
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+
+
+func test_idle_frames_are_consumed_one_at_a_time() -> void:
+	var object: Gen2WorldObject = _object(Gen2WorldObject.MOVEMENT_WANDER)
+	assert_false(object.is_idle())
+	assert_false(object.tick_idle())
+
+	object.start_idle(3)
+	assert_true(object.is_idle())
+	for _frame: int in 3:
+		assert_true(object.tick_idle())
+	assert_false(object.is_idle())
+	assert_false(object.tick_idle())
+
+
+func test_only_deciding_templates_advance_on_their_own() -> void:
+	# The standing and fixed-facing rows resolve once in the source, so a
+	# per-frame driver must not keep asking them for a decision.
+	for movement: int in [
+		Gen2WorldObject.MOVEMENT_WANDER, Gen2WorldObject.MOVEMENT_WALK_UP_DOWN,
+		Gen2WorldObject.MOVEMENT_WALK_LEFT_RIGHT, Gen2WorldObject.MOVEMENT_SWIM_WANDER,
+		Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW, Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST,
+	]:
+		assert_true(_object(movement).movement_advances(), "movement %d advances" % movement)
+	for movement: int in [
+		Gen2WorldObject.MOVEMENT_STILL, Gen2WorldObject.MOVEMENT_FIXED_DOWN,
+		Gen2WorldObject.MOVEMENT_FIXED_UP, Gen2WorldObject.MOVEMENT_FIXED_LEFT,
+		Gen2WorldObject.MOVEMENT_FIXED_RIGHT,
+	]:
+		assert_false(_object(movement).movement_advances(), "movement %d stands" % movement)


### PR DESCRIPTION
Gen2WorldAPI.advance_objects() was never called from anywhere, so the wandering and spinning movement templates never ran in the game, and it had no pacing: one call moved an object a whole cell with no step duration and no wait between steps.

advance_object_steps() drives them by real elapsed time at the hardware frame rate and stall cap the player's walk step already uses, following the source's continue-walk, sleep and from-movement cycle. A wandering step takes the slow 16-frame StepVectors row, since _RandomWalkContinue indexes it with a direction of 0 to 3; a finished step immediately rolls the next wait, as StepFunction_ContinueWalk does; that wait is the source's masked random byte, and a blocked step keeps its cell and waits again. Spin templates set a facing and wait without ever stepping.

advance_objects() keeps its one-decision-per-call contract for callers that already have it. Objects gained the fractional step_offset_cells() mirror of the pixel offset, which the example voxel renderer reads for its markers, and followers now start the player's own 8-frame step. Movement rolls come from a separate object_random stream so watching an NPC cannot shift an encounter or a script result, and the screen drives all of it only when no script, overlay, battle, phone ring, fishing or trainer approach owns the world.