### PR TITLE
Make the Zephyr Badge reachable against a real Crystal cache

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -92,6 +92,11 @@ var _player_step_accumulator: float = 0.0
 ## Real time banked toward the next hardware frame of object movement, held
 ## beside the player's own accumulator so the two stay in phase after a stall.
 var _object_step_accumulator: float = 0.0
+## Read-only mirror of the selected save's party, refreshed by the screen
+## whenever the save or party changes. Gen2WorldAPI does not own a save, so
+## this stays optional; a script that reads it while empty fails rather than
+## reporting an invented zero. Never written by the script runner.
+var _party_summary: Dictionary = {}
 
 const PHONE_ENTRANCE_COLLISIONS: Array[int] = [0x71, 0x79, 0x7A, 0x7B]
 
@@ -273,6 +278,29 @@ func set_movement_mode(mode: StringName) -> Dictionary:
 		return {"ok": false, "reason": &"invalid_movement_mode", "mode": mode}
 	movement_mode = mode
 	return {"ok": true, "mode": movement_mode}
+
+
+## Sets the read-only party mirror a queued script's VAR_PARTYCOUNT read and
+## CheckPokerus special consult. count must be non-negative; has_pokerus is the
+## source's own low-nibble-nonzero check across the whole party, computed by
+## the caller because Gen2WorldAPI does not read Gen2SaveMon fields directly.
+func set_party_summary(count: int, has_pokerus: bool) -> Dictionary:
+	if count < 0:
+		return {"ok": false, "reason": &"invalid_party_summary", "count": count}
+	_party_summary = {"count": count, "pokerus": has_pokerus}
+	return {"ok": true}
+
+
+## Clears the mirror so a stale count cannot answer a later read after the
+## caller stops refreshing it (for example, closing the injected preview save).
+func clear_party_summary() -> void:
+	_party_summary = {}
+
+
+## Empty when no caller has set a summary yet; a script-visible read must fail
+## rather than invent a count in that case.
+func party_summary() -> Dictionary:
+	return _party_summary.duplicate()
 
 
 func available_fishing_rods() -> Array[StringName]:
@@ -1399,6 +1427,8 @@ func _enqueue_script(request: Dictionary) -> void:
 		request["environment"] = current_map.environment
 	if not request.has("facing"):
 		request["facing"] = player_facing
+	if not request.has("party") and not _party_summary.is_empty():
+		request["party"] = _party_summary.duplicate()
 	_script_queue.append(request)
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -110,6 +110,7 @@ func _build_world() -> void:
 		_caption.text = "Map %d/%d unavailable" % [map_group, map_number]
 		_hint.text = "Choose an imported map and starting cell in the scene settings."
 		return
+	_refresh_party_summary()
 	if encounter_seed != 0:
 		_encounter_random.seed = encounter_seed
 		_object_random.seed = encounter_seed + 1
@@ -1274,9 +1275,40 @@ func _play_current_map_music() -> void:
 	_audio_player.play_record(record, &"map_music", _audio_assets())
 
 
+## The save whose party a queued script's VAR_PARTYCOUNT read and CheckPokerus
+## special should see. A battle in progress may hold its own save, including a
+## synthesized development one from a fallback capture, so it takes priority
+## over the screen's ordinary selected save.
+func _active_party_save() -> Gen2SaveData:
+	if _active_battle_save != null:
+		return _active_battle_save
+	return _injected_save if _injected_save != null else _selected_runtime_save()
+
+
+## Mirrors the active save's party size and Pokerus state onto the world so a
+## queued script can answer VAR_PARTYCOUNT and CheckPokerus without the
+## scene-free world owning a save. Cleared, not zeroed, when no save is
+## selected, so a missing wiring fails loudly instead of reading an invented
+## empty party.
+func _refresh_party_summary() -> void:
+	if _world == null:
+		return
+	var save: Gen2SaveData = _active_party_save()
+	if save == null:
+		_world.clear_party_summary()
+		return
+	var has_pokerus: bool = false
+	for member: Variant in save.party:
+		if member is Gen2SaveMon and (int((member as Gen2SaveMon).pokerus) & 0x0F) != 0:
+			has_pokerus = true
+			break
+	_world.set_party_summary(save.party.size(), has_pokerus)
+
+
 func _refresh_labels() -> void:
 	if _world == null or _data == null:
 		return
+	_refresh_party_summary()
 	_caption.text = "%s   map %d/%d   cell %d,%d" % [
 		_data.title(), _world.current_map.group, _world.current_map.number,
 		_world.player_cell.x, _world.player_cell.y,

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -65,10 +65,13 @@ const PHONE_CONTACT_REFUSED: int = 2
 const SPECIAL_ACTIVATE_FISHING_SWARM: int = 72
 const SPECIAL_TOGGLE_MAPTILE_DECORATIONS: int = 73
 const SPECIAL_TOGGLE_DECORATIONS_VISIBILITY: int = 74
+const SPECIAL_POKEMON_CENTER_PC: int = 28
 const SPECIAL_PLAYERS_HOUSE_PC: int = 29
 const SPECIAL_SET_DAY_OF_WEEK: int = 37
 const SPECIAL_PLAY_MAP_MUSIC: int = 60
 const SPECIAL_RESTART_MAP_MUSIC: int = 61
+const SPECIAL_HEAL_MACHINE_ANIM: int = 62
+const SPECIAL_CHECK_POKERUS: int = 78
 const SPECIAL_RANDOM_UNSEEN_WILD_MON: int = 91
 const SPECIAL_RANDOM_PHONE_WILD_MON: int = 92
 const SPECIAL_RANDOM_PHONE_MON: int = 93
@@ -1288,8 +1291,17 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 	var hour: int = int(clock.get("hour", _clock_hour()))
 	var day: int = int(clock.get("day", 0))
 	match variable:
+		0x01: # VAR_PARTYCOUNT
+			var party: Dictionary = _request.get("party", {})
+			if party.is_empty():
+				return {
+					"ok": false, "reason": &"missing_party_summary", "variable": variable,
+				}
+			_script_value = int(party.get("count", 0))
 		0x04: # VAR_TIMEOFDAY
 			_script_value = Gen2WorldClock.new(hour, 0, day).time_of_day()
+		0x07: # VAR_BADGES
+			_script_value = state.badge_count() if state != null else 0
 		0x0A: # VAR_HOUR
 			_script_value = hour
 		0x0B: # VAR_WEEKDAY
@@ -1377,6 +1389,11 @@ func _execute_special(special: int) -> Dictionary:
 				"special": special,
 				"mode": &"players_house",
 			})
+		SPECIAL_POKEMON_CENTER_PC:
+			return _stage_runtime_request(&"pc_requested", {
+				"special": special,
+				"mode": &"pokemon_center",
+			})
 		SPECIAL_SET_DAY_OF_WEEK:
 			_stage_day_of_week_menu()
 			return {"ok": true}
@@ -1409,6 +1426,19 @@ func _execute_special(special: int) -> Dictionary:
 			## request so HP, status and PP are changed together with the selected
 			## project save.
 			return _stage_runtime_request(&"party_heal_requested", {"special": special})
+		SPECIAL_HEAL_MACHINE_ANIM:
+			## wScriptVar selects the machine's screen position: 0 Pokemon Center,
+			## 1 Elm's Lab, 2 Hall of Fame. A preceding SETVAL loads it, so it is
+			## carried through as presentation only; nothing here changes state.
+			_emit_runtime_event(&"presentation_special_applied", {
+				"special": special, "kind": &"heal_machine_anim",
+				"machine_type": _script_value,
+			})
+		SPECIAL_CHECK_POKERUS:
+			var party: Dictionary = _request.get("party", {})
+			if party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			_script_value = 1 if bool(party.get("pokerus", false)) else 0
 		48, 50, 51, 157:
 			## Fade, sprite reload and the dummied trainer-ranking bookkeeping
 			## affect presentation or source-only counters, not scene-free state.

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -20,6 +20,31 @@ const ENGINE_HALL_OF_FAME: int = ENGINE_CREDITS_SKIP
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 43
 const DAILY_ENGINE_FLAGS: Array[int] = [ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED]
 
+## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array;
+## VAR_BADGES counts both bytes together, not Johto alone.
+const ENGINE_ZEPHYRBADGE: int = 27
+const ENGINE_HIVEBADGE: int = 28
+const ENGINE_PLAINBADGE: int = 29
+const ENGINE_FOGBADGE: int = 30
+const ENGINE_MINERALBADGE: int = 31
+const ENGINE_STORMBADGE: int = 32
+const ENGINE_GLACIERBADGE: int = 33
+const ENGINE_RISINGBADGE: int = 34
+const ENGINE_BOULDERBADGE: int = 35
+const ENGINE_CASCADEBADGE: int = 36
+const ENGINE_THUNDERBADGE: int = 37
+const ENGINE_RAINBOWBADGE: int = 38
+const ENGINE_SOULBADGE: int = 39
+const ENGINE_MARSHBADGE: int = 40
+const ENGINE_VOLCANOBADGE: int = 41
+const ENGINE_EARTHBADGE: int = 42
+const BADGE_ENGINE_FLAGS: Array[int] = [
+	ENGINE_ZEPHYRBADGE, ENGINE_HIVEBADGE, ENGINE_PLAINBADGE, ENGINE_FOGBADGE,
+	ENGINE_MINERALBADGE, ENGINE_STORMBADGE, ENGINE_GLACIERBADGE, ENGINE_RISINGBADGE,
+	ENGINE_BOULDERBADGE, ENGINE_CASCADEBADGE, ENGINE_THUNDERBADGE, ENGINE_RAINBOWBADGE,
+	ENGINE_SOULBADGE, ENGINE_MARSHBADGE, ENGINE_VOLCANOBADGE, ENGINE_EARTHBADGE,
+]
+
 var _event_flags: Dictionary = {}
 var _engine_flags: Dictionary = {}
 var _map_scenes: Dictionary = {}
@@ -229,6 +254,15 @@ func set_hall_of_fame(active: bool = true) -> void:
 
 func bargain_merchant_closed() -> bool:
 	return is_engine_flag_active(ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED)
+
+
+## Mirrors _GetVarAction's .CountBadges: a popcount over both badge bytes.
+func badge_count() -> int:
+	var count: int = 0
+	for flag: int in BADGE_ENGINE_FLAGS:
+		if is_engine_flag_active(flag):
+			count += 1
+	return count
 
 
 ## Clears only source daily engine flags. Story flags such as Hall of Fame

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -79,6 +79,33 @@ func test_players_house_pc_embeds_box_storage_and_resumes_the_waiting_script() -
 	assert_false(_world_screen._world.script_input_waiting())
 
 
+func test_pokemon_center_pc_embeds_box_storage_and_resumes_the_waiting_script() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts["48:6195"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_POKEMON_CENTER_PC, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6195
+	var waiting: Array = _world_screen._world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(waiting.size(), 1)
+	assert_eq(waiting[0]["status"], &"waiting")
+	assert_eq(_world_screen._world.pending_runtime_request()["values"]["mode"], &"pokemon_center")
+	_world_screen._show_script_results(waiting)
+	await get_tree().process_frame
+
+	var pc: Gen2BoxScreen = _world_screen._pc_host
+	assert_not_null(pc)
+	assert_eq(pc.box_snapshot()["boxes"].size(), Gen2SaveData.BOX_COUNT)
+
+	pc.close_embedded()
+	await get_tree().process_frame
+	assert_null(_world_screen._pc_host)
+	assert_false(_world_screen._world.script_input_waiting())
+
+
 func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 	await _open_world()
 	await _queue_service()

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -446,6 +446,113 @@ func test_party_heal_special_restores_save_hp_status_and_move_pp() -> void:
 	assert_eq(healed_mon.pp[0], int(_data.move(BattleFixture.TACKLE).get("pp", 0)))
 
 
+## A trimmed PokecenterNurseScript: yesorno, HealParty, then HealMachineAnim,
+## matching the source's std script call order in
+## engine/events/std_scripts.asm.
+func test_nurse_script_heals_the_party_after_accepting_and_shows_the_heal_machine() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	var nurse_script: int = 0x6310
+	var done_script: int = 0x6320
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, nurse_script)] = [
+		Gen2WorldScript.YESORNO,
+		Gen2WorldScript.IFFALSE, done_script & 0xFF, (done_script >> 8) & 0xFF,
+		Gen2WorldScript.SPECIAL, 27, 0,
+		Gen2WorldScript.SETVAL, 0,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_HEAL_MACHINE_ANIM, 0,
+		Gen2WorldScript.END,
+	]
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, done_script)] = [Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world(true)
+
+	var save: Gen2SaveData = _world_screen._injected_save
+	var mon: Gen2SaveMon = save.party[0]
+	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
+	mon.hp = 1
+	_world_screen._world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 4, "y": 5, "script": nurse_script,
+	}]
+
+	var waiting: Array = _world_screen._world.dispatch_script_events(Vector2i(4, 5))
+	assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+	assert_eq(waiting[0]["event"]["type"], &"choice")
+
+	var after_choice: Array = _world_screen._world.choose_script_input(0)
+	assert_eq(after_choice[0]["status"], &"waiting", JSON.stringify(after_choice))
+	assert_eq(_world_screen._world.pending_runtime_request()["kind"], &"party_heal_requested")
+
+	var complete: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world_screen._world, {}, save, false
+	)
+	assert_true(complete["ok"], JSON.stringify(complete))
+	var results: Array = complete.get("results", [])
+	assert_eq(results[results.size() - 1]["status"], &"complete", JSON.stringify(results))
+	assert_eq(
+		_event_value(results[results.size() - 1].get("events", []), &"presentation_special_applied", "kind"),
+		&"heal_machine_anim",
+		JSON.stringify(results),
+	)
+	var healed_mon: Gen2SaveMon = save.party[0]
+	assert_eq(healed_mon.hp, battle_mon.max_hp())
+
+
+func test_nurse_script_leaves_the_party_unhealed_on_refusal() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	var nurse_script: int = 0x6330
+	var done_script: int = 0x6340
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, nurse_script)] = [
+		Gen2WorldScript.YESORNO,
+		Gen2WorldScript.IFFALSE, done_script & 0xFF, (done_script >> 8) & 0xFF,
+		Gen2WorldScript.SPECIAL, 27, 0,
+		Gen2WorldScript.END,
+	]
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, done_script)] = [Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world(true)
+
+	var save: Gen2SaveData = _world_screen._injected_save
+	var mon: Gen2SaveMon = save.party[0]
+	mon.hp = 1
+	_world_screen._world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 4, "y": 5, "script": nurse_script,
+	}]
+
+	var waiting: Array = _world_screen._world.dispatch_script_events(Vector2i(4, 5))
+	assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+
+	var after_choice: Array = _world_screen._world.choose_script_input(1)
+	assert_eq(after_choice[0]["status"], &"complete", JSON.stringify(after_choice))
+	assert_true(_world_screen._world.pending_runtime_request().is_empty())
+	assert_eq(save.party[0].hp, 1)
+
+
+func test_zephyr_badge_survives_a_snapshot_save_and_reload() -> void:
+	await _open_world(true)
+	_world_screen._world.state.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE)
+	assert_eq(_world_screen._world.state.badge_count(), 1)
+
+	var save: Gen2SaveData = _world_screen._injected_save
+	save.world = _world_screen._world.snapshot()
+	var validation: Dictionary = Gen2SaveValidator.validate(save, _data)
+	assert_true(validation["ok"], validation["message"])
+
+	var round_trip: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	assert_not_null(round_trip.world)
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(_data, round_trip.world)
+	assert_not_null(restored)
+	assert_eq(restored.state.badge_count(), 1)
+	assert_true(restored.state.is_engine_flag_active(Gen2WorldState.ENGINE_ZEPHYRBADGE))
+
+
+func _event_value(events: Array, event_type: StringName, key: String) -> Variant:
+	for event: Dictionary in events:
+		if event.get("type", &"") == event_type:
+			return event.get(key, null)
+	return null
+
+
 func test_new_game_uses_the_verified_home_spawn_and_source_start_money() -> void:
 	var save: Gen2SaveData = Gen2SaveStore.create_new_game(_data, 0, "TEST", 155)
 	assert_not_null(save)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1305,6 +1305,158 @@ func test_players_house_pc_special_is_a_host_request_and_returns_false_without_d
 	assert_true(world.pending_runtime_request().is_empty())
 
 
+func test_pokemon_center_pc_special_stages_the_pokemon_center_mode() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6195"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_POKEMON_CENTER_PC, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.events["coord_events"][0]["script"] = 0x6195
+	var waiting: Array = world.dispatch_script_events()
+	assert_eq(waiting.size(), 1)
+	assert_eq(waiting[0]["status"], &"waiting")
+	assert_eq(world.pending_runtime_request()["kind"], &"pc_requested")
+	assert_eq(world.pending_runtime_request()["values"]["mode"], &"pokemon_center")
+
+	var resumed: Array = world.complete_runtime_request({"ok": true, "script_value": 0})
+	assert_eq(resumed.size(), 1)
+	assert_eq(resumed[0]["status"], &"complete")
+
+
+func test_readvar_badges_counts_active_engine_flags_across_both_bytes() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6300"] = [
+		Gen2WorldScript.READVAR, 0x07,
+		Gen2WorldScript.IFEQUAL, 1, 0x10, 0x63,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6310"] = [Gen2WorldScript.SETEVENT, 40, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.state.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE)
+	world.current_map.events["coord_events"][0]["script"] = 0x6300
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_true(world.event_flag_active(40))
+
+
+func test_readvar_partycount_reads_the_set_party_summary() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6320"] = [
+		Gen2WorldScript.READVAR, 0x01,
+		Gen2WorldScript.IFEQUAL, 2, 0x30, 0x63,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6330"] = [Gen2WorldScript.SETEVENT, 41, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.set_party_summary(2, false)
+	world.current_map.events["coord_events"][0]["script"] = 0x6320
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_true(world.event_flag_active(41))
+
+
+func test_readvar_partycount_fails_without_a_party_summary() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6340"] = [Gen2WorldScript.READVAR, 0x01, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.events["coord_events"][0]["script"] = 0x6340
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"failed")
+	assert_eq(result[0]["reason"], &"missing_party_summary")
+
+
+func test_heal_machine_anim_special_emits_presentation_event_without_state_change() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6350"] = [
+		Gen2WorldScript.SETVAL, 0,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_HEAL_MACHINE_ANIM, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.events["coord_events"][0]["script"] = 0x6350
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_eq(
+		_event_value(result[0]["events"], &"presentation_special_applied", "kind"),
+		&"heal_machine_anim",
+		JSON.stringify(result),
+	)
+	assert_eq(
+		int(_event_value(result[0]["events"], &"presentation_special_applied", "machine_type")),
+		0,
+		JSON.stringify(result),
+	)
+	assert_false(world.event_flag_active(0))
+
+
+func test_check_pokerus_special_reads_the_low_nibble_across_the_party_summary() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6360"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_CHECK_POKERUS, 0,
+		Gen2WorldScript.IFTRUE, 0x70, 0x63,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6370"] = [Gen2WorldScript.SETEVENT, 42, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var infected := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	infected.set_party_summary(1, true)
+	infected.current_map.events["coord_events"][0]["script"] = 0x6360
+	var infected_result: Array = infected.dispatch_script_events()
+	assert_eq(infected_result[0]["status"], &"complete", JSON.stringify(infected_result))
+	assert_true(infected.event_flag_active(42))
+
+	var clean_data: GameData = GameData.open_directory(_directory)
+	var clean := Gen2WorldAPI.open(clean_data, 1, 1, Vector2i(7, 6))
+	clean.set_party_summary(1, false)
+	clean.current_map.events["coord_events"][0]["script"] = 0x6360
+	var clean_result: Array = clean.dispatch_script_events()
+	assert_eq(clean_result[0]["status"], &"complete", JSON.stringify(clean_result))
+	assert_false(clean.event_flag_active(42))
+
+
+func test_check_pokerus_special_fails_without_a_party_summary() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6380"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_CHECK_POKERUS, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.events["coord_events"][0]["script"] = 0x6380
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"failed")
+	assert_eq(result[0]["reason"], &"missing_party_summary")
+
+
+func test_party_summary_round_trips_and_reaches_queued_script_requests() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(world.party_summary().is_empty())
+	assert_true(world.set_party_summary(3, true)["ok"])
+	assert_eq(world.party_summary(), {"count": 3, "pokerus": true})
+	assert_false(world.set_party_summary(-1, false)["ok"])
+	assert_eq(world.party_summary(), {"count": 3, "pokerus": true})
+	world.clear_party_summary()
+	assert_true(world.party_summary().is_empty())
+
+
 func test_set_day_of_week_follows_the_source_selection_and_confirmation_flow() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:61A0"] = [

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -43,6 +43,33 @@ func test_engine_flags_round_trip_and_daily_reset_preserves_hall_of_fame() -> vo
 	assert_false(restored.reset_daily_flags())
 
 
+func test_badge_count_matches_active_flags_across_both_bytes() -> void:
+	var state := Gen2WorldState.new()
+	assert_eq(state.badge_count(), 0)
+	state.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE)
+	assert_eq(state.badge_count(), 1)
+	for flag: int in Gen2WorldState.BADGE_ENGINE_FLAGS:
+		state.set_engine_flag(flag)
+	assert_eq(state.badge_count(), 16)
+	## wBadges is one contiguous flag_array spanning both wJohtoBadges and
+	## wKantoBadges, so a Kanto badge must count toward the same total.
+	var kanto_only := Gen2WorldState.new()
+	kanto_only.set_engine_flag(Gen2WorldState.ENGINE_EARTHBADGE)
+	assert_eq(kanto_only.badge_count(), 1)
+
+
+func test_badge_flags_survive_round_trip_and_daily_or_map_reload_resets() -> void:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE)
+	state.set_engine_flag(Gen2WorldState.ENGINE_HIVEBADGE)
+	var restored := Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.badge_count(), 2)
+	restored.reset_daily_flags()
+	assert_eq(restored.badge_count(), 2)
+	restored.reset_map_reload_flags()
+	assert_eq(restored.badge_count(), 2)
+
+
 func test_source_temporary_event_flags_include_zero_and_reset_on_map_reload() -> void:
 	var state := Gen2WorldState.new()
 	state.set_event_flag(0)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -490,6 +490,113 @@ func _story_path(data: GameData) -> Dictionary:
 	})
 	if not bool(balls_run.get("terminal", false)):
 		return {"ok": false, "path": path, "reason": "Aide Poke Ball event did not finish"}
+
+	# Route 30 and Route 31 cross one-way ledges the ordinary walkable-cell
+	# pathfinding this tool uses cannot cross (ledge hops are not a modeled
+	# movement type yet). The badge slice this preview exists to exercise is
+	# the Pokemon Center and Violet Gym scripts, not that intervening terrain,
+	# so the world reopens directly in Violet City on the same mutable state
+	# rather than attempting to walk a route it cannot path through.
+	var violet_world: Gen2WorldAPI = Gen2WorldAPI.open(data, 10, 5, Vector2i(31, 25), world.state)
+	if violet_world == null:
+		return {"ok": false, "path": path, "reason": "missing Violet City map"}
+	world = violet_world
+	var violet_entry: Array = world.dispatch_map_entry()
+	var violet_entry_run: Dictionary = _drain_story(world, violet_entry, save, random, data)
+	path.append({
+		"step": "violet_city_entry",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": violet_entry_run,
+	})
+	if not bool(violet_entry_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "Violet City entry did not finish"}
+
+	# The Pokemon Center nurse reads CheckPokerus and VAR_PARTYCOUNT, so the
+	# world needs the read-only party mirror before either can resolve.
+	world.set_party_summary(save.party.size(), false)
+
+	var pokecenter_warp: Dictionary = _warp_to(world.current_map, 10, 10)
+	if pokecenter_warp.is_empty():
+		return {"ok": false, "path": path, "reason": "missing Violet Pokemon Center warp"}
+	world.player_cell = Vector2i(pokecenter_warp["x"], pokecenter_warp["y"])
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Violet Pokemon Center warp failed"}
+	var pokecenter_entry: Array = world.dispatch_map_entry()
+	var pokecenter_entry_run: Dictionary = _drain_story(world, pokecenter_entry, save, random, data)
+	path.append({
+		"step": "violet_pokecenter_entry",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": pokecenter_entry_run,
+	})
+
+	# VioletPokecenter1F places the nurse object at block (3,1); the counter
+	# tile directly below her at (3,2) is not walkable, so ordinary pathfinding
+	# cannot reach it. The player is placed there directly, the same
+	# known-limitation workaround already used for Route 30's ledge, rather
+	# than guessing an unverified counter-side approach.
+	world.player_cell = Vector2i(3, 2)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var nurse_events: Array = world.interact()
+	for mon: Gen2SaveMon in save.party:
+		mon.hp = 1
+	var nurse_run: Dictionary = _drain_story(world, nurse_events, save, random, data)
+	path.append({
+		"step": "violet_pokecenter_nurse",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": nurse_run,
+		"party_hp_after": _party_hp(save),
+	})
+	if not bool(nurse_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "Pokemon Center nurse event did not finish"}
+
+	var pokecenter_exit: Dictionary = _warp_to(world.current_map, 10, 5)
+	if pokecenter_exit.is_empty():
+		return {"ok": false, "path": path, "reason": "missing Violet Pokemon Center exit warp"}
+	world.player_cell = Vector2i(pokecenter_exit["x"], pokecenter_exit["y"])
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Violet Pokemon Center exit warp failed"}
+	path.append({"step": "violet_city_after_heal", "map": _map_value(world), "cell": _cell_value(world)})
+
+	var gym_warp: Dictionary = _warp_to(world.current_map, 10, 7)
+	if gym_warp.is_empty():
+		return {"ok": false, "path": path, "reason": "missing Violet Gym warp"}
+	world.player_cell = Vector2i(gym_warp["x"], gym_warp["y"])
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Violet Gym warp failed"}
+	var gym_entry: Array = world.dispatch_map_entry()
+	var gym_entry_run: Dictionary = _drain_story(world, gym_entry, save, random, data)
+	path.append({
+		"step": "violet_gym_entry",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": gym_entry_run,
+	})
+
+	# Falkner is object 0 at block (5,1); facing up from (5,2) matches the
+	# source's faceplayer interaction cell.
+	var falkner_events: Array = []
+	var walked_to_falkner: Dictionary = _walk_to_story_cell(world, Vector2i(5, 2))
+	if bool(walked_to_falkner.get("ok", false)):
+		world.player_facing = Gen2WorldSprite.FACING_UP
+		falkner_events = world.interact()
+	var falkner_run: Dictionary = _drain_story(world, falkner_events, save, random, data)
+	path.append({
+		"step": "violet_gym_falkner",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": falkner_run,
+		"badge_count": world.state.badge_count(),
+		"engine_flags": world.state.engine_flags(),
+	})
+	if not bool(falkner_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "Falkner event did not finish"}
+
 	var party_summary: Array = []
 	for mon: Gen2SaveMon in save.party:
 		party_summary.append({
@@ -503,7 +610,15 @@ func _story_path(data: GameData) -> Dictionary:
 		"party": party_summary,
 		"event_flags": world.state.event_flags(),
 		"map_scenes": world.state.to_dict().get("map_scenes", {}),
+		"badge_count": world.state.badge_count(),
 	}
+
+
+func _party_hp(save: Gen2SaveData) -> Array:
+	var values: Array = []
+	for mon: Gen2SaveMon in save.party:
+		values.append(int(mon.hp))
+	return values
 
 
 func _drain_story(


### PR DESCRIPTION
Implements the three runtime gaps blocking Violet Gym: readvar VAR_BADGES/VAR_PARTYCOUNT, and specials PokemonCenterPC, HealMachineAnim and CheckPokerus. Badges are ordinary engine flags with a popcount reader on Gen2WorldState; a new read-only party summary on Gen2WorldAPI lets queued scripts answer VAR_PARTYCOUNT and CheckPokerus without the scene-free world owning a save.

tools/preview_world_story.gd now continues past the intro through Violet City, heals a reduced-HP party via the real imported PokecenterNurseScript, and beats Falkner for the Zephyr Badge, all against a real imported Crystal cache. Route 30/31 ledges and the Pokemon Center PC's real tile-collision trigger are not modeled yet; the preview places the player past both rather than guessing an unverified path.