### PR TITLE
Add the overworld start menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,13 @@ Development scenes:
   `show_matchup` for a fallback pairing.
 - `game/world/world_screen.tscn`: arrows/WASD move Route 29, encounters use
   imported tables, and `F` fishes only while facing water with an owned rod.
-  Space, Enter or `Z` advances casting and bites; F5 saves. The host clock
+  Space or `Z` advances casting and bites; F5 saves. The host clock
   advances one real-time game minute per minute and updates source day
-  boundaries. `P` opens the registered Pokegear phone list. The imported
+  boundaries. `P` opens the registered Pokegear phone list. `Enter` or `Tab`
+  opens the start menu (Pokemon, Pack, Pokegear, Save, Exit; Pokedex, Player
+  and Options are listed in their source position but are not implemented
+  yet). Pokemon opens the embedded party screen; Pokegear and Save reach the
+  existing phone list and save path. The imported
   Players House PC opens the embedded numbered box storage screen and `Esc`
   closes it. `preview_emote()`, `preview_wild_encounter()`,
   `preview_fishing_battle()`, `preview_script_event()`,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -109,6 +109,22 @@ runner executes the imported caller/callee script at the same transaction
 boundary. Audio stays behind verified bounded decoder,
 renderer and player layers, with imported records validated before success.
 
+`world_start_menu.gd` is the scene-free model of `engine/menus/start_menu.asm`'s
+item list: it reproduces the source's Pokedex/Pokemon/Pokegear gating and
+`STATICMENU_WRAP` cursor, and still builds Pokedex, Player and Options in
+their source position, marked unavailable, rather than omitting entries this
+project has not implemented. `world_pack.gd` groups owned items into the four
+cartridge pack pockets using the item type byte `GameData` already imports
+under the confusingly-named `pocket` field; it is presentation only; item
+counts stay a flat map on `Gen2WorldState`, and pocket capacities are not
+enforced. `start_menu_screen.gd` is the overlay: it owns Pack and a Save
+confirmation as internal modes the same way `world_service_screen.gd` owns a
+mart mode, and delegates Pokemon and Pokegear to the existing party screen and
+phone list rather than re-implementing them. `Gen2PartyScreen` and
+`Gen2BoxScreen` share one embedded-mode shape: a `set_context(..., embedded)`
+flag and a `closed(result)` signal so the overworld can stack them above the
+running world instead of navigating away with `change_scene_to_file`.
+
 ### Audio
 
 | File | Role |

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -3,6 +3,11 @@ extends Control
 
 ## Player party summary for a validated project save.
 
+## Emitted only when embedded, mirroring Gen2BoxScreen.closed: the overworld
+## start menu resumes on this rather than the screen navigating away with
+## change_scene_to_file, which would tear down the running world.
+signal closed(result: Dictionary)
+
 const BACKGROUND: Color = Color("#09111f")
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#2d4566")
@@ -16,9 +21,12 @@ var _data: GameData = null
 var _data_override: GameData = null
 var _save: Gen2SaveData = null
 var _save_override: Gen2SaveData = null
+var _embedded: bool = false
 var _cards: VBoxContainer = null
 var _player_label: Label = null
 var _status: Label = null
+var _storage_button: Button = null
+var _battle_button: Button = null
 
 
 func _ready() -> void:
@@ -28,10 +36,14 @@ func _ready() -> void:
 	_refresh()
 
 
-## Test seam for a synthetic cache and validated save.
-func set_context(data: GameData, save: Gen2SaveData) -> void:
+## Test seam for a synthetic cache and validated save. `embedded` is the
+## overworld start menu's Pokemon entry: the save-screen navigation actions
+## (development battle, PC storage by scene change) do not apply while a
+## world is running, so they are hidden rather than left to tear it down.
+func set_context(data: GameData, save: Gen2SaveData, embedded: bool = false) -> void:
 	_data_override = data
 	_save_override = save
+	_embedded = embedded
 	_data = data
 	_save = save
 	if is_inside_tree() and _cards != null:
@@ -100,13 +112,14 @@ func _build_ui() -> void:
 	subtitle.text = "Player party and persistent condition"
 	subtitle.add_theme_color_override("font_color", MUTED)
 	heading.add_child(subtitle)
-	var back := _button("Back to save slots", TEXT)
+	var back := _button("Close" if _embedded else "Back to save slots", TEXT)
 	back.custom_minimum_size = Vector2(190, 44)
 	back.pressed.connect(_back)
-	var storage := _button("Open PC storage", ACCENT)
-	storage.custom_minimum_size = Vector2(170, 44)
-	storage.pressed.connect(_open_storage)
-	header.add_child(storage)
+	_storage_button = _button("Open PC storage", ACCENT)
+	_storage_button.custom_minimum_size = Vector2(170, 44)
+	_storage_button.pressed.connect(_open_storage)
+	_storage_button.visible = not _embedded
+	header.add_child(_storage_button)
 	header.add_child(back)
 
 	_player_label = Label.new()
@@ -126,9 +139,10 @@ func _build_ui() -> void:
 	var footer := HBoxContainer.new()
 	footer.add_theme_constant_override("separation", 10)
 	content.add_child(footer)
-	var battle := _button("Start development battle", ACCENT)
-	battle.pressed.connect(_start_battle)
-	footer.add_child(battle)
+	_battle_button = _button("Start development battle", ACCENT)
+	_battle_button.pressed.connect(_start_battle)
+	_battle_button.visible = not _embedded
+	footer.add_child(_battle_button)
 	_status = Label.new()
 	_status.add_theme_color_override("font_color", MUTED)
 	_status.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -240,7 +254,16 @@ func _start_battle() -> void:
 
 
 func _back() -> void:
+	if _embedded:
+		close_embedded()
+		return
 	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
+
+
+func close_embedded() -> void:
+	if not _embedded:
+		return
+	closed.emit({"ok": true})
 
 
 func _open_storage() -> void:

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1,0 +1,332 @@
+class_name Gen2StartMenuScreen
+extends Control
+
+## The overworld pause menu (engine/menus/start_menu.asm), presented as a
+## window-resolution Control panel consistent with the mart, phone and PC
+## storage overlays rather than the hardware `menu_coords` box.
+##
+## Pokemon and Pokegear are existing separate screens the world already owns
+## (Gen2PartyScreen, the phone list on Gen2WorldServiceScreen), so this screen
+## only reports the choice through [signal action_chosen] and lets the world
+## screen open them; Pack and Save are small enough to live here as their own
+## internal modes, the same way Gen2WorldServiceScreen owns a mart mode beside
+## its menu mode.
+
+## Emitted for an available entry this screen does not own itself
+## (Pokemon, Pokegear); the caller opens the matching screen.
+signal action_chosen(kind: StringName)
+## Emitted on Exit or cancel from the top-level list.
+signal closed
+
+enum Mode { LIST, PACK, SAVE_CONFIRM }
+
+const PANEL: Color = Color("#14233a")
+const BORDER: Color = Color("#4f6f9e")
+const SCRIM: Color = Color(0.02, 0.04, 0.08, 0.78)
+const TEXT: Color = Color("#f4f7fb")
+const MUTED: Color = Color("#9eacc0")
+const ACCENT: Color = Color("#f3c969")
+const SUCCESS: Color = Color("#7bd89a")
+const ERROR: Color = Color("#ef8a8a")
+
+var _world: Gen2WorldAPI = null
+var _data: GameData = null
+var _save_action: Callable = Callable()
+var _mode: Mode = Mode.LIST
+var _menu: Gen2WorldStartMenu = null
+
+var _pack_pockets: Array = []
+var _pack_pocket_index: int = 0
+var _pack_cursor: int = 0
+
+var _save_cursor: int = 0
+var _save_result_shown: bool = false
+
+var _title: Label = null
+var _summary: Label = null
+var _options: VBoxContainer = null
+var _status: Label = null
+var _footer: Label = null
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_build_ui()
+	if _menu != null:
+		_open_list_mode()
+
+
+## `save_action` is called with no arguments and must return a Dictionary
+## shaped like Gen2WorldScreen.persist_world_snapshot()'s result (an "ok" key,
+## with "reason" on failure). Kept as a Callable so this screen does not need
+## to know how a snapshot is written or where saves live.
+##
+## Mirrors Gen2BoxScreen.set_context(): the caller may open() before or after
+## adding this node to the tree, so building the option list is deferred to
+## _ready() until _title/_options exist, then run immediately here for a
+## caller that opens after the node is already inside the tree.
+func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_cursor: int = 0) -> bool:
+	_world = world
+	_data = data
+	_save_action = save_action
+	if _world == null or _data == null:
+		return false
+	_menu = Gen2WorldStartMenu.from_world(_world, previous_cursor)
+	if is_inside_tree() and _options != null:
+		_open_list_mode()
+	return true
+
+
+## The list model's cursor, so a caller can carry it into the next open() the
+## way the source's wBattleMenuCursorPosition survives a reopen.
+func cursor() -> int:
+	return _menu.cursor if _menu != null else 0
+
+
+func handle_key(keycode: int) -> bool:
+	match keycode:
+		KEY_UP, KEY_W:
+			_move(Vector2i.UP)
+			return true
+		KEY_DOWN, KEY_S:
+			_move(Vector2i.DOWN)
+			return true
+		KEY_LEFT, KEY_A:
+			_move(Vector2i.LEFT)
+			return true
+		KEY_RIGHT, KEY_D:
+			_move(Vector2i.RIGHT)
+			return true
+		KEY_SPACE, KEY_ENTER, KEY_Z:
+			_confirm()
+			return true
+		KEY_ESCAPE, KEY_X, KEY_B:
+			_cancel()
+			return true
+	return false
+
+
+func _move(direction: Vector2i) -> void:
+	match _mode:
+		Mode.LIST:
+			## The source's .MenuData omits STATICMENU_ENABLE_LEFT_RIGHT, so
+			## only vertical input moves the top-level list.
+			if direction.x == 0 and _menu != null and _menu.move(direction.y):
+				_render_list()
+		Mode.PACK:
+			if direction.x != 0:
+				_cycle_pocket(direction.x)
+			elif direction.y != 0:
+				_move_pack_cursor(direction.y)
+		Mode.SAVE_CONFIRM:
+			if not _save_result_shown and (direction.x != 0 or direction.y != 0):
+				_save_cursor = 1 - _save_cursor
+				_render_save_confirm()
+
+
+func _confirm() -> void:
+	match _mode:
+		Mode.LIST:
+			_confirm_list()
+		Mode.PACK:
+			if not _current_pocket_items().is_empty():
+				_status.text = "Items cannot be used from the Pack yet."
+				_status.add_theme_color_override("font_color", MUTED)
+		Mode.SAVE_CONFIRM:
+			_confirm_save()
+
+
+func _cancel() -> void:
+	match _mode:
+		Mode.LIST:
+			closed.emit()
+		Mode.PACK:
+			_open_list_mode()
+		Mode.SAVE_CONFIRM:
+			_open_list_mode()
+
+
+func _confirm_list() -> void:
+	if _menu == null or _menu.size() == 0:
+		return
+	if not _menu.selected_available():
+		_status.text = "%s is not available yet." % String(_menu.selected_item().get("label", ""))
+		_status.add_theme_color_override("font_color", MUTED)
+		return
+	match _menu.selected_kind():
+		Gen2WorldStartMenu.ITEM_PACK:
+			_open_pack_mode()
+		Gen2WorldStartMenu.ITEM_SAVE:
+			_open_save_confirm_mode()
+		Gen2WorldStartMenu.ITEM_EXIT:
+			closed.emit()
+		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_POKEGEAR:
+			action_chosen.emit(_menu.selected_kind())
+
+
+func _open_list_mode() -> void:
+	_mode = Mode.LIST
+	_title.text = "MENU"
+	_summary.text = ""
+	_status.text = ""
+	_footer.text = "Arrows: move    Space/Enter: choose    Esc: close"
+	_render_list()
+
+
+func _render_list() -> void:
+	if _menu == null:
+		return
+	_render_options(_menu.items(), _menu.cursor, func(entry: Dictionary) -> String:
+		var label: String = String(entry.get("label", ""))
+		return label if bool(entry.get("available", false)) else "%s (unavailable)" % label
+	)
+
+
+func _open_pack_mode() -> void:
+	_mode = Mode.PACK
+	_pack_pockets = Gen2WorldPack.build(_data, _world.state) if _world != null else []
+	_pack_pocket_index = 0
+	_pack_cursor = 0
+	_status.text = ""
+	_footer.text = "Left/Right: pocket    Up/Down: move    Esc: back"
+	_render_pack()
+
+
+func _current_pocket() -> Dictionary:
+	if _pack_pockets.is_empty():
+		return {}
+	return _pack_pockets[_pack_pocket_index]
+
+
+func _current_pocket_items() -> Array:
+	return _current_pocket().get("items", [])
+
+
+func _cycle_pocket(delta: int) -> void:
+	if _pack_pockets.is_empty():
+		return
+	_pack_pocket_index = wrapi(_pack_pocket_index + signi(delta), 0, _pack_pockets.size())
+	_pack_cursor = 0
+	_render_pack()
+
+
+func _move_pack_cursor(delta: int) -> void:
+	var items: Array = _current_pocket_items()
+	if items.is_empty():
+		return
+	_pack_cursor = wrapi(_pack_cursor + signi(delta), 0, items.size())
+	_render_pack()
+
+
+func _render_pack() -> void:
+	var pocket: Dictionary = _current_pocket()
+	_title.text = "PACK"
+	_summary.text = String(pocket.get("name", ""))
+	var items: Array = pocket.get("items", [])
+	if items.is_empty():
+		_status.text = "No items in this pocket."
+		_status.add_theme_color_override("font_color", MUTED)
+	_render_options(items, _pack_cursor, func(entry: Dictionary) -> String:
+		return "%s    x%d" % [entry.get("name", "UNKNOWN"), int(entry.get("quantity", 0))]
+	)
+
+
+func _open_save_confirm_mode() -> void:
+	_mode = Mode.SAVE_CONFIRM
+	_save_cursor = 0
+	_save_result_shown = false
+	_title.text = "SAVE"
+	_summary.text = "Save your progress?"
+	_status.text = ""
+	_footer.text = "Arrows: choose    Space/Enter: confirm    Esc: cancel"
+	_render_save_confirm()
+
+
+func _confirm_save() -> void:
+	if _save_result_shown:
+		_open_list_mode()
+		return
+	if _save_cursor == 1:
+		_open_list_mode()
+		return
+	var result: Dictionary = _save_action.call() if _save_action.is_valid() else {"ok": false, "reason": &"no_save_action"}
+	_save_result_shown = true
+	if bool(result.get("ok", false)):
+		_status.text = "World saved."
+		_status.add_theme_color_override("font_color", SUCCESS)
+	else:
+		_status.text = "Save failed: %s" % String(result.get("reason", "unknown"))
+		_status.add_theme_color_override("font_color", ERROR)
+	_render_options(["Continue"], 0, func(entry: Variant) -> String: return str(entry))
+
+
+func _render_save_confirm() -> void:
+	_render_options(["Yes", "No"], _save_cursor, func(entry: Variant) -> String: return str(entry))
+
+
+func _build_ui() -> void:
+	var scrim := ColorRect.new()
+	scrim.color = SCRIM
+	scrim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	scrim.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(scrim)
+
+	var center := CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(center)
+	var panel := PanelContainer.new()
+	panel.custom_minimum_size = Vector2(420, 320)
+	panel.add_theme_stylebox_override("panel", _panel_style())
+	center.add_child(panel)
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 24)
+	margin.add_theme_constant_override("margin_top", 20)
+	margin.add_theme_constant_override("margin_right", 24)
+	margin.add_theme_constant_override("margin_bottom", 20)
+	panel.add_child(margin)
+	var content := VBoxContainer.new()
+	content.add_theme_constant_override("separation", 10)
+	margin.add_child(content)
+	_title = Label.new()
+	_title.add_theme_color_override("font_color", TEXT)
+	_title.add_theme_font_size_override("font_size", 24)
+	content.add_child(_title)
+	_summary = Label.new()
+	_summary.add_theme_color_override("font_color", MUTED)
+	_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	content.add_child(_summary)
+	_options = VBoxContainer.new()
+	_options.add_theme_constant_override("separation", 4)
+	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	content.add_child(_options)
+	_status = Label.new()
+	_status.add_theme_color_override("font_color", MUTED)
+	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	content.add_child(_status)
+	_footer = Label.new()
+	_footer.add_theme_color_override("font_color", ACCENT)
+	content.add_child(_footer)
+
+
+func _render_options(values: Array, cursor: int, label_for: Callable) -> void:
+	if _options == null:
+		return
+	for child: Node in _options.get_children():
+		child.queue_free()
+	for index: int in values.size():
+		var label := Label.new()
+		var name: String = label_for.call(values[index])
+		label.text = ("> " if index == cursor else "  ") + name
+		label.add_theme_color_override("font_color", ACCENT if index == cursor else TEXT)
+		label.add_theme_font_size_override("font_size", 18)
+		_options.add_child(label)
+
+
+func _panel_style() -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = PANEL
+	style.border_color = BORDER
+	style.set_border_width_all(2)
+	style.set_corner_radius_all(8)
+	return style

--- a/game/world/start_menu_screen.gd.uid
+++ b/game/world/start_menu_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://f4ycrhlikf8k

--- a/game/world/start_menu_screen.tscn
+++ b/game/world/start_menu_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://game/world/start_menu_screen.gd" id="1"]
+
+[node name="StartMenuScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -1,0 +1,79 @@
+class_name Gen2WorldPack
+extends RefCounted
+
+## Scene-free grouping of owned items into the cartridge's four pack pockets.
+##
+## `Gen2WorldState` stores items as a flat item-to-quantity map; this class is
+## presentation only and does not change that shape. Classification uses the
+## item type byte GameData already imports under the confusingly-named
+## `pocket` field (`data/items/attributes.asm`'s `item_attribute` macro calls
+## it "pocket" while `constants/item_data_constants.asm` names the same values
+## `ITEM`/`KEY_ITEM`/`BALL`/`TM_HM`), which is the value that decides which
+## pack pocket a real item lives in. Source capacities (`MAX_ITEMS` = 20,
+## `MAX_BALLS` = 12, `MAX_KEY_ITEMS` = 25, `MAX_PC_ITEMS` = 50) are recorded
+## here for reference but not enforced, since enforcing them would change the
+## save's item storage shape.
+
+const TYPE_ITEM: int = 1
+const TYPE_KEY_ITEM: int = 2
+const TYPE_BALL: int = 3
+const TYPE_TM_HM: int = 4
+
+const MAX_ITEMS: int = 20
+const MAX_BALLS: int = 12
+const MAX_KEY_ITEMS: int = 25
+const MAX_ITEM_STACK: int = 99
+
+## `engine/items/pack.asm`'s own left/right pocket cycle
+## (`.ItemsPocketMenu` -> `.BallsPocketMenu` -> `.KeyItemsPocketMenu` ->
+## `.TMHMPocketMenu` -> back to Items), not the item type's numeric order.
+const POCKET_ORDER: Array[int] = [TYPE_ITEM, TYPE_BALL, TYPE_KEY_ITEM, TYPE_TM_HM]
+const POCKET_NAMES: Dictionary = {
+	TYPE_ITEM: "Items",
+	TYPE_BALL: "Balls",
+	TYPE_KEY_ITEM: "Key Items",
+	TYPE_TM_HM: "TMs/HMs",
+}
+
+
+## One entry per pocket in source display order, each carrying only the items
+## currently owned in that pocket. An unknown item number, or a quantity of
+## zero, is dropped rather than shown.
+static func build(data: GameData, state: Gen2WorldState) -> Array:
+	var pockets: Array = []
+	if data == null or state == null:
+		return pockets
+	var owned: Dictionary = state.items()
+	for pocket_type: int in POCKET_ORDER:
+		var pocket_items: Array = []
+		var item_numbers: Array = owned.keys()
+		item_numbers.sort()
+		for raw_item: Variant in item_numbers:
+			var item: int = int(raw_item)
+			var quantity: int = int(owned[raw_item])
+			if quantity <= 0:
+				continue
+			var definition: Dictionary = data.item(item)
+			if definition.is_empty() or int(definition.get("pocket", 0)) != pocket_type:
+				continue
+			pocket_items.append({
+				"item": item,
+				"name": String(definition.get("name", "UNKNOWN")),
+				"quantity": quantity,
+				"field_menu": int(definition.get("field_menu", 0)),
+			})
+		pockets.append({
+			"pocket": pocket_type,
+			"name": String(POCKET_NAMES.get(pocket_type, "")),
+			"items": pocket_items,
+		})
+	return pockets
+
+
+## The pack pocket a cartridge item number belongs to, or 0 when the item is
+## unknown. Matches `ItemAttributes`' per-item type byte, not a guess from the
+## item number's range.
+static func pocket_for(data: GameData, item: int) -> int:
+	if data == null:
+		return 0
+	return int(data.item(item).get("pocket", 0))

--- a/game/world/world_pack.gd.uid
+++ b/game/world/world_pack.gd.uid
@@ -1,0 +1,1 @@
+uid://dg6xutxvg4cpy

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -12,6 +12,8 @@ const MUTED: Color = Color("#9eacc0")
 const BATTLE_SCENE: PackedScene = preload("res://game/battle/battle_screen.tscn")
 const SERVICE_SCENE: PackedScene = preload("res://game/world/world_service_screen.tscn")
 const BOX_SCENE: PackedScene = preload("res://game/save/box_screen.tscn")
+const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_screen.tscn")
+const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
 
 @export var map_group: int = 24
@@ -41,6 +43,10 @@ var _story_picture: TextureRect = null
 var _battle_host: Gen2BattleScreen = null
 var _service_host: Gen2WorldServiceScreen = null
 var _pc_host: Gen2BoxScreen = null
+var _start_menu_host: Gen2StartMenuScreen = null
+var _party_host: Gen2PartyScreen = null
+## Mirrors the source's wBattleMenuCursorPosition surviving a reopen.
+var _start_menu_cursor: int = 0
 var _trainer_approach: Dictionary = {}
 var _active_battle_save: Gen2SaveData = null
 var _active_battle_persist: bool = false
@@ -233,6 +239,7 @@ func _process(delta: float) -> void:
 		if not ticks.is_empty():
 			_update_time_of_day()
 			if _service_host == null and _battle_host == null and _pc_host == null \
+				and _start_menu_host == null and _party_host == null \
 				and not _world.script_input_waiting():
 				var phone_schedule: Dictionary = _world.advance_phone_schedule(
 					ticks.size(), _encounter_random
@@ -256,6 +263,7 @@ func _process(delta: float) -> void:
 func _objects_may_move() -> bool:
 	return _world != null \
 		and _battle_host == null and _service_host == null and _pc_host == null \
+		and _start_menu_host == null and _party_host == null \
 		and _trainer_approach.is_empty() \
 		and not _world.script_busy() \
 		and not _world.phone_ring_active() \
@@ -279,15 +287,24 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			_pc_host.close_embedded()
 		accept_event()
 		return
+	if _party_host != null:
+		if key.keycode == KEY_ESCAPE:
+			_party_host.close_embedded()
+		accept_event()
+		return
+	if _start_menu_host != null:
+		if _start_menu_host.handle_key(key.keycode):
+			accept_event()
+		return
 	if _service_host != null:
 		if _service_host.handle_key(key.keycode):
 			accept_event()
 		return
-	if _world.fishing_busy() and key.keycode in [KEY_SPACE, KEY_ENTER, KEY_Z]:
+	if _world.fishing_busy() and key.keycode in [KEY_SPACE, KEY_Z]:
 		_handle_fishing_result(_world.advance_fishing())
 		accept_event()
 		return
-	if _world.script_input_waiting() and key.keycode in [KEY_SPACE, KEY_ENTER, KEY_Z]:
+	if _world.script_input_waiting() and key.keycode in [KEY_SPACE, KEY_Z]:
 		if _text_box != null and _text_box.visible:
 			_advance_script_input()
 		elif StringName(_world.pending_script_input().get("type", &"")) in [
@@ -319,7 +336,7 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			_show_script_results(_world.run_event_queue(true))
 		accept_event()
 		return
-	if key.keycode in [KEY_SPACE, KEY_ENTER, KEY_Z]:
+	if key.keycode in [KEY_SPACE, KEY_Z]:
 		if interact():
 			accept_event()
 		return
@@ -353,6 +370,10 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			_open_phone_list()
 			accept_event()
 			return
+		KEY_ENTER, KEY_TAB:
+			_open_start_menu()
+			accept_event()
+			return
 		KEY_V:
 			cycle_world_renderer()
 			accept_event()
@@ -372,7 +393,8 @@ func _unhandled_key_input(event: InputEvent) -> void:
 ## Public driver for screenshot tooling and scene tests.
 func move_player(direction: Vector2i) -> bool:
 	if _world == null or _world.fishing_busy() or _service_host != null \
-		or _pc_host != null or _world.phone_ring_active() \
+		or _pc_host != null or _start_menu_host != null or _party_host != null \
+		or _world.phone_ring_active() \
 		or not _trainer_approach.is_empty() or _world.player_step_in_progress():
 		return false
 	var movement: Dictionary = _world.move_result(direction)
@@ -420,7 +442,8 @@ func move_player(direction: Vector2i) -> bool:
 ## Public driver for the production NPC/object interaction path.
 func interact() -> bool:
 	if _world == null or _battle_host != null or _service_host != null \
-		or _pc_host != null or _world.phone_ring_active() or _world.fishing_busy():
+		or _pc_host != null or _start_menu_host != null or _party_host != null \
+		or _world.phone_ring_active() or _world.fishing_busy():
 		return false
 	var results: Array = _world.interact()
 	if results.is_empty():
@@ -998,6 +1021,97 @@ func _on_pc_closed(result: Dictionary) -> void:
 		_script_prompt = "PC storage closed"
 	else:
 		_show_script_results(resumed)
+	_refresh_labels()
+
+
+## Public driver for screenshot tooling and scene tests, mirroring
+## _open_pc_host()'s shape. The Enter/Tab key branch in
+## _unhandled_key_input() is the normal path.
+func _open_start_menu() -> void:
+	if _start_menu_host != null or _party_host != null or _service_host != null \
+		or _pc_host != null or _battle_host != null or _world == null or _data == null \
+		or not _trainer_approach.is_empty() or _world.script_busy() \
+		or _world.phone_ring_active() or _world.fishing_busy():
+		return
+	var host: Gen2StartMenuScreen = START_MENU_SCENE.instantiate() as Gen2StartMenuScreen
+	if host == null:
+		_script_prompt = "Start menu scene unavailable"
+		_refresh_labels()
+		return
+	if not host.open(
+		_world, _data, Callable(self, "persist_world_snapshot"), _start_menu_cursor
+	):
+		host.queue_free()
+		_script_prompt = "Start menu unavailable"
+		_refresh_labels()
+		return
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	add_child(host)
+	host.action_chosen.connect(_on_start_menu_action)
+	host.closed.connect(_on_start_menu_closed)
+	_start_menu_host = host
+	_script_prompt = "Start menu open"
+	_refresh_labels()
+
+
+func _on_start_menu_action(kind: StringName) -> void:
+	var host: Gen2StartMenuScreen = _start_menu_host
+	_start_menu_host = null
+	if host != null:
+		_start_menu_cursor = host.cursor()
+		host.queue_free()
+	match kind:
+		Gen2WorldStartMenu.ITEM_POKEMON:
+			_open_embedded_party()
+		Gen2WorldStartMenu.ITEM_POKEGEAR:
+			_open_phone_list()
+	_refresh_labels()
+
+
+func _on_start_menu_closed() -> void:
+	var host: Gen2StartMenuScreen = _start_menu_host
+	_start_menu_host = null
+	if host != null:
+		_start_menu_cursor = host.cursor()
+		host.queue_free()
+	_script_prompt = "Start menu closed"
+	_refresh_labels()
+
+
+func _open_embedded_party() -> void:
+	if _party_host != null or _world == null or _data == null:
+		return
+	var host: Gen2PartyScreen = PARTY_SCENE.instantiate() as Gen2PartyScreen
+	if host == null:
+		_script_prompt = "Party scene unavailable"
+		_refresh_labels()
+		return
+	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
+	if save == null:
+		save = Gen2SaveStore.create_development_save(_data, 0)
+	if save == null:
+		host.queue_free()
+		_script_prompt = "Party requires a validated save"
+		_refresh_labels()
+		return
+	host.set_context(_data, save, true)
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(host)
+	host.closed.connect(_on_party_closed)
+	_party_host = host
+	_script_prompt = "Party open"
+	_refresh_labels()
+
+
+func _on_party_closed(_result: Dictionary) -> void:
+	var host: Gen2PartyScreen = _party_host
+	_party_host = null
+	if host != null:
+		host.queue_free()
+	_script_prompt = "Party closed"
 	_refresh_labels()
 
 

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -1,0 +1,125 @@
+class_name Gen2WorldStartMenu
+extends RefCounted
+
+## Scene-free model of the cartridge start menu (engine/menus/start_menu.asm).
+##
+## `StartMenu.SetUpMenuItems` builds its list by appending items in a fixed
+## source order, skipping only the ones its own gate says are not present yet
+## (Pokedex behind wStatusFlags/STATUSFLAGS_POKEDEX_F, Pokemon behind a
+## non-zero wPartyCount, Pokegear behind wPokegearFlags/POKEGEAR_OBTAINED_F).
+## Everything else it always appends. This project does not yet have a dex
+## screen, a trainer card or an options screen, so those three entries are
+## still built in their source position, marked unavailable rather than
+## omitted, so the list shape does not silently change out from under a
+## future implementation of any of them. Bug Contest and link-mode branches
+## (STARTMENUITEM_QUIT, the contest status box) do not apply because this
+## project has neither system, which is why QUIT never appears here at all:
+## the source's own gate for it is never true.
+##
+## `STATICMENU_WRAP` is source flag data on `.MenuData`, so the cursor wraps
+## at both ends the same way a cached cartridge menu does.
+
+## constants/engine_flags.asm: ENGINE_POKEGEAR = 4, ENGINE_POKEDEX = 11. Both
+## indices are identical in pokecrystal and pokegold (unlike the badge and
+## Goldenrod merchant flags further down that table, which pokecrystal's extra
+## ENGINE_MOBILE_SYSTEM entry shifts by one), so no profile split is needed
+## for this menu's gating.
+const ENGINE_POKEGEAR: int = 4
+const ENGINE_POKEDEX: int = 11
+
+const ITEM_POKEDEX: StringName = &"pokedex"
+const ITEM_POKEMON: StringName = &"pokemon"
+const ITEM_PACK: StringName = &"pack"
+const ITEM_POKEGEAR: StringName = &"pokegear"
+const ITEM_PLAYER: StringName = &"player"
+const ITEM_SAVE: StringName = &"save"
+const ITEM_OPTION: StringName = &"option"
+const ITEM_EXIT: StringName = &"exit"
+
+var cursor: int = 0
+var _items: Array = []
+
+
+## `party_count`, `pokedex_obtained` and `pokegear_obtained` come from the
+## live world (party summary and engine flags 11 and 4); this stays scene-free
+## the same way Gen2WorldMenu does. `previous_cursor` mirrors the source's
+## `wBattleMenuCursorPosition`, which survives a reopen after a submenu closes;
+## it is clamped to the rebuilt list so a shrunk list cannot leave the cursor
+## out of range.
+static func build(
+	party_count: int,
+	pokedex_obtained: bool,
+	pokegear_obtained: bool,
+	previous_cursor: int = 0,
+) -> Gen2WorldStartMenu:
+	var menu := Gen2WorldStartMenu.new()
+	var items: Array = []
+	if pokedex_obtained:
+		items.append(_entry(ITEM_POKEDEX, "Pokedex", false))
+	if party_count > 0:
+		items.append(_entry(ITEM_POKEMON, "Pokemon", true))
+	items.append(_entry(ITEM_PACK, "Pack", true))
+	if pokegear_obtained:
+		items.append(_entry(ITEM_POKEGEAR, "Pokegear", true))
+	items.append(_entry(ITEM_PLAYER, "Player", false))
+	items.append(_entry(ITEM_SAVE, "Save", true))
+	items.append(_entry(ITEM_OPTION, "Options", false))
+	items.append(_entry(ITEM_EXIT, "Exit", true))
+	menu._items = items
+	menu.cursor = clampi(previous_cursor, 0, maxi(items.size() - 1, 0))
+	return menu
+
+
+## Convenience for a screen: reads party count from the live world's party
+## summary (0 when no caller has set one yet, matching the source's empty
+## party before Elm's lab) and both gating flags directly off Gen2WorldState.
+static func from_world(world: Gen2WorldAPI, previous_cursor: int = 0) -> Gen2WorldStartMenu:
+	if world == null or world.state == null:
+		return Gen2WorldStartMenu.build(0, false, false, previous_cursor)
+	var party_count: int = int(world.party_summary().get("count", 0))
+	return Gen2WorldStartMenu.build(
+		party_count,
+		world.state.is_engine_flag_active(ENGINE_POKEDEX),
+		world.state.is_engine_flag_active(ENGINE_POKEGEAR),
+		previous_cursor,
+	)
+
+
+static func _entry(kind: StringName, label: String, available: bool) -> Dictionary:
+	return {"kind": kind, "label": label, "available": available}
+
+
+func items() -> Array:
+	return _items.duplicate(true)
+
+
+func size() -> int:
+	return _items.size()
+
+
+## Mirrors StartMenu's STATICMENU_WRAP: moving past either end lands on the
+## opposite end rather than stopping.
+func move(delta: int) -> bool:
+	if _items.is_empty() or delta == 0:
+		return false
+	var next: int = cursor + signi(delta)
+	if next < 0:
+		next = _items.size() - 1
+	elif next >= _items.size():
+		next = 0
+	cursor = next
+	return true
+
+
+func selected_item() -> Dictionary:
+	if cursor < 0 or cursor >= _items.size():
+		return {}
+	return _items[cursor]
+
+
+func selected_kind() -> StringName:
+	return StringName(selected_item().get("kind", &""))
+
+
+func selected_available() -> bool:
+	return bool(selected_item().get("available", false))

--- a/game/world/world_start_menu.gd.uid
+++ b/game/world/world_start_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://sfkk2pdxxaw0

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1,0 +1,222 @@
+extends GutTest
+
+## Scene integration for the overworld start menu. The fixture is synthetic,
+## but the world screen, script runner and UI scenes are the production paths.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	_data = Fixture.build()
+	_write_pack_item()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+func _write_pack_item() -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		if int(raw.get("number", 0)) == 7:
+			raw["name"] = "POTION"
+			raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+
+
+func _open_world() -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	var state := Gen2WorldState.new({}, {}, {7: 1}, {0: 500})
+	var world := Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6), state
+	)
+	var save := Gen2SaveStore.create_development_save(_data, 0)
+	save.world = world.snapshot()
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+
+
+func test_start_menu_opens_and_blocks_movement() -> void:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	assert_not_null(_world_screen._start_menu_host)
+	assert_false(_world_screen.move_player(Vector2i.RIGHT))
+	assert_false(_world_screen._objects_may_move())
+
+
+func test_exit_closes_the_menu_and_restores_movement() -> void:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	## EXIT is the source's guaranteed last entry.
+	while host.cursor() < host.get("_menu").size() - 1:
+		host.handle_key(KEY_DOWN)
+	assert_eq(host.get("_menu").selected_kind(), Gen2WorldStartMenu.ITEM_EXIT)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_null(_world_screen._start_menu_host)
+	assert_true(_world_screen._objects_may_move())
+
+
+func test_cancel_closes_the_menu_the_same_as_exit() -> void:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	host.handle_key(KEY_ESCAPE)
+	await get_tree().process_frame
+	assert_null(_world_screen._start_menu_host)
+	assert_true(_world_screen._objects_may_move())
+
+
+func test_pokemon_opens_the_embedded_party_screen_and_returns() -> void:
+	await _open_world()
+	_world_screen._world.set_party_summary(1, false)
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_true(_kinds(host).has(Gen2WorldStartMenu.ITEM_POKEMON))
+	_select(host, Gen2WorldStartMenu.ITEM_POKEMON)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_null(_world_screen._start_menu_host)
+	var party: Gen2PartyScreen = _world_screen._party_host
+	assert_not_null(party)
+
+	party.close_embedded()
+	await get_tree().process_frame
+	assert_null(_world_screen._party_host)
+	assert_true(_world_screen._objects_may_move())
+
+
+func test_pack_lists_a_granted_item() -> void:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_PACK)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
+	var items_pocket: Dictionary = host.get("_pack_pockets")[0]
+	assert_eq(items_pocket["pocket"], Gen2WorldPack.TYPE_ITEM)
+	var items: Array = items_pocket["items"]
+	assert_eq(items.size(), 1)
+	assert_eq(items[0]["item"], 7)
+	assert_eq(items[0]["quantity"], 1)
+
+	host.handle_key(KEY_ESCAPE)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+
+
+func test_pokegear_reaches_the_existing_phone_list() -> void:
+	await _open_world()
+	_world_screen._world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEGEAR)
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_true(_kinds(host).has(Gen2WorldStartMenu.ITEM_POKEGEAR))
+	_select(host, Gen2WorldStartMenu.ITEM_POKEGEAR)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_null(_world_screen._start_menu_host)
+	assert_not_null(_world_screen._service_host)
+
+
+func test_save_writes_a_snapshot_to_the_injected_save_without_touching_disk() -> void:
+	await _open_world()
+	var save: Gen2SaveData = _world_screen._injected_save
+	## Set an event flag in place instead of moving, since a real move can
+	## roll this fixture's own wild grass encounter and open a battle; the
+	## screen's own _process() re-derives the clock from Gen2WorldClock every
+	## frame, so the clock is not a stable field to change for this check.
+	const MARKER_FLAG: int = 50
+	assert_false(save.world.world_state.is_event_flag_active(MARKER_FLAG))
+	_world_screen._world.state.set_event_flag(MARKER_FLAG)
+	var expected: Gen2WorldSnapshot = _world_screen._world.snapshot()
+
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_SAVE)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_CONFIRM)
+	## Yes is the confirm menu's default cursor position.
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(save.world.map_id, expected.map_id)
+	assert_eq(save.world.player_cell, expected.player_cell)
+	assert_true(save.world.world_state.is_event_flag_active(MARKER_FLAG))
+	## Continue returns to the list without reopening a fresh menu instance.
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+
+
+## Covers three of _open_start_menu()'s busy-state guards directly; the fourth
+## (phone_ring_active()) is the identical one-line pattern and is exercised
+## for the rest of the screen by test_world_service_screen.gd's phone cases.
+func test_start_menu_does_not_open_while_battling_fishing_or_scripted() -> void:
+	await _open_world()
+
+	_world_screen._battle_host = Gen2BattleScreen.new()
+	_world_screen._open_start_menu()
+	assert_null(_world_screen._start_menu_host)
+	_world_screen._battle_host.free()
+	_world_screen._battle_host = null
+
+	_world_screen._world._fishing._state = Gen2WorldFishing.STATE_CASTING
+	_world_screen._open_start_menu()
+	assert_null(_world_screen._start_menu_host)
+	_world_screen._world._fishing._state = Gen2WorldFishing.STATE_IDLE
+
+	## The script cache is lazy-loaded from disk on first use, so writing the
+	## file now still reaches the already-open Gen2WorldAPI instance; the map's
+	## coord_events were already parsed into memory, so that part is set
+	## directly rather than by rewriting the maps cache too late to matter.
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6320)] = [
+		Gen2WorldScript.SPECIAL, 27, 0, Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_world_screen._world.current_map.events["coord_events"] = [
+		{"x": 7, "y": 6, "script": 0x6320}
+	]
+	var waiting: Array = _world_screen._world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(waiting[0]["status"], &"waiting")
+	assert_true(_world_screen._world.script_busy())
+	_world_screen._open_start_menu()
+	assert_null(_world_screen._start_menu_host)
+
+
+func _kinds(host: Gen2StartMenuScreen) -> Array:
+	var out: Array = []
+	for entry: Dictionary in (host.get("_menu") as Gen2WorldStartMenu).items():
+		out.append(entry.get("kind"))
+	return out
+
+
+func _select(host: Gen2StartMenuScreen, kind: StringName) -> void:
+	var menu: Gen2WorldStartMenu = host.get("_menu")
+	var guard: int = menu.size() + 1
+	while menu.selected_kind() != kind and guard > 0:
+		host.handle_key(KEY_DOWN)
+		guard -= 1
+	assert_eq(menu.selected_kind(), kind)

--- a/tests/integration/test_world_start_menu_screen.gd.uid
+++ b/tests/integration/test_world_start_menu_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://b8bt8ngxvqg6j

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -1,0 +1,111 @@
+extends GutTest
+
+## Gen2WorldPack groups owned items into the four cartridge pack pockets using
+## the item type byte GameData already imports under "pocket"
+## (data/items/attributes.asm's item_attribute macro; constants/item_data_
+## constants.asm names the same values ITEM/KEY_ITEM/BALL/TM_HM). Presentation
+## only: Gen2WorldState keeps its existing flat item-to-quantity shape.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const ITEM_POTION: int = 1
+const ITEM_MASTER_BALL: int = 2
+const ITEM_BICYCLE: int = 3
+const ITEM_TM01: int = 4
+const ITEM_UNCLASSIFIED: int = 5
+
+var _data: GameData = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		match int(raw.get("number", 0)):
+			ITEM_POTION:
+				raw["name"] = "POTION"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["field_menu"] = 1
+			ITEM_MASTER_BALL:
+				raw["name"] = "MASTER BALL"
+				raw["pocket"] = Gen2WorldPack.TYPE_BALL
+			ITEM_BICYCLE:
+				raw["name"] = "BICYCLE"
+				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
+			ITEM_TM01:
+				raw["name"] = "TM01"
+				raw["pocket"] = Gen2WorldPack.TYPE_TM_HM
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func test_pockets_are_listed_in_the_source_cycle_order() -> void:
+	var state := Gen2WorldState.new()
+	var pockets: Array = Gen2WorldPack.build(_data, state)
+	var kinds: Array = []
+	for pocket: Dictionary in pockets:
+		kinds.append(pocket.get("pocket"))
+	assert_eq(kinds, [
+		Gen2WorldPack.TYPE_ITEM, Gen2WorldPack.TYPE_BALL,
+		Gen2WorldPack.TYPE_KEY_ITEM, Gen2WorldPack.TYPE_TM_HM,
+	])
+
+
+func test_an_item_lands_in_the_pocket_its_imported_type_byte_names() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 3, ITEM_MASTER_BALL: 1})
+	var pockets: Array = Gen2WorldPack.build(_data, state)
+	var items_pocket: Dictionary = pockets[0]
+	var balls_pocket: Dictionary = pockets[1]
+	assert_eq((items_pocket["items"] as Array).size(), 1)
+	assert_eq((items_pocket["items"] as Array)[0]["item"], ITEM_POTION)
+	assert_eq((items_pocket["items"] as Array)[0]["quantity"], 3)
+	assert_eq((balls_pocket["items"] as Array).size(), 1)
+	assert_eq((balls_pocket["items"] as Array)[0]["item"], ITEM_MASTER_BALL)
+
+
+func test_empty_pockets_stay_empty_not_absent() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 1})
+	var pockets: Array = Gen2WorldPack.build(_data, state)
+	assert_eq(pockets.size(), 4)
+	assert_eq((pockets[1]["items"] as Array).size(), 0)
+	assert_eq((pockets[2]["items"] as Array).size(), 0)
+	assert_eq((pockets[3]["items"] as Array).size(), 0)
+
+
+func test_a_zero_quantity_item_does_not_appear() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 1})
+	state.apply_changes({}, {}, {"items": {ITEM_POTION: 0}})
+	var pockets: Array = Gen2WorldPack.build(_data, state)
+	assert_eq((pockets[0]["items"] as Array).size(), 0)
+
+
+func test_field_menu_value_is_carried_through() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 1})
+	var pockets: Array = Gen2WorldPack.build(_data, state)
+	assert_eq((pockets[0]["items"] as Array)[0]["field_menu"], 1)
+
+
+## An item whose imported pocket byte is 0 does not belong to any of the four
+## cartridge pockets and must not be invented into one.
+func test_an_unclassified_item_appears_in_no_pocket() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_UNCLASSIFIED: 1})
+	var pockets: Array = Gen2WorldPack.build(_data, state)
+	for pocket: Dictionary in pockets:
+		assert_eq((pocket["items"] as Array).size(), 0)
+
+
+func test_pocket_for_reads_the_imported_type_byte() -> void:
+	assert_eq(Gen2WorldPack.pocket_for(_data, ITEM_POTION), Gen2WorldPack.TYPE_ITEM)
+	assert_eq(Gen2WorldPack.pocket_for(_data, ITEM_MASTER_BALL), Gen2WorldPack.TYPE_BALL)
+	assert_eq(Gen2WorldPack.pocket_for(_data, ITEM_BICYCLE), Gen2WorldPack.TYPE_KEY_ITEM)
+	assert_eq(Gen2WorldPack.pocket_for(_data, ITEM_TM01), Gen2WorldPack.TYPE_TM_HM)
+	assert_eq(Gen2WorldPack.pocket_for(null, ITEM_POTION), 0)
+
+
+func test_build_with_no_data_or_state_returns_empty() -> void:
+	assert_eq(Gen2WorldPack.build(null, Gen2WorldState.new()), [])
+	assert_eq(Gen2WorldPack.build(_data, null), [])

--- a/tests/unit/test_world_pack.gd.uid
+++ b/tests/unit/test_world_pack.gd.uid
@@ -1,0 +1,1 @@
+uid://dyeio3yt2qgp5

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -1,0 +1,129 @@
+extends GutTest
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+## engine/menus/start_menu.asm's StartMenu.SetUpMenuItems gating, reproduced
+## as data: Pokedex behind wStatusFlags/STATUSFLAGS_POKEDEX_F, Pokemon behind
+## a non-zero party count, Pokegear behind wPokegearFlags/POKEGEAR_OBTAINED_F,
+## everything else always present. Pokedex, Player and Options are always
+## built but marked unavailable since this project has none of the three yet.
+
+
+func _kinds(menu: Gen2WorldStartMenu) -> Array:
+	var out: Array = []
+	for entry: Dictionary in menu.items():
+		out.append(entry.get("kind"))
+	return out
+
+
+func test_default_list_omits_pokedex_pokemon_and_pokegear() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_eq(_kinds(menu), [
+		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
+		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
+		Gen2WorldStartMenu.ITEM_EXIT,
+	])
+
+
+func test_pokemon_appears_only_with_a_non_empty_party() -> void:
+	var empty: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_false(_kinds(empty).has(Gen2WorldStartMenu.ITEM_POKEMON))
+	var with_party: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, false, false)
+	assert_true(_kinds(with_party).has(Gen2WorldStartMenu.ITEM_POKEMON))
+
+
+func test_pokegear_appears_only_with_the_source_engine_flag() -> void:
+	var without: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_false(_kinds(without).has(Gen2WorldStartMenu.ITEM_POKEGEAR))
+	var with_flag: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, true)
+	assert_true(_kinds(with_flag).has(Gen2WorldStartMenu.ITEM_POKEGEAR))
+
+
+func test_pokedex_appears_only_with_the_source_engine_flag_and_stays_unavailable() -> void:
+	var without: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_false(_kinds(without).has(Gen2WorldStartMenu.ITEM_POKEDEX))
+	var with_flag: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, true, false)
+	assert_true(_kinds(with_flag).has(Gen2WorldStartMenu.ITEM_POKEDEX))
+	for entry: Dictionary in with_flag.items():
+		if entry.get("kind") == Gen2WorldStartMenu.ITEM_POKEDEX:
+			assert_false(entry.get("available"))
+
+
+func test_full_list_matches_the_source_item_order_when_every_gate_is_open() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
+	assert_eq(_kinds(menu), [
+		Gen2WorldStartMenu.ITEM_POKEDEX, Gen2WorldStartMenu.ITEM_POKEMON,
+		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_POKEGEAR,
+		Gen2WorldStartMenu.ITEM_PLAYER, Gen2WorldStartMenu.ITEM_SAVE,
+		Gen2WorldStartMenu.ITEM_OPTION, Gen2WorldStartMenu.ITEM_EXIT,
+	])
+
+
+func test_pack_pokemon_pokegear_save_and_exit_are_available_player_and_option_are_not() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
+	var available_by_kind: Dictionary = {}
+	for entry: Dictionary in menu.items():
+		available_by_kind[entry.get("kind")] = entry.get("available")
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_PACK])
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_POKEMON])
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_POKEGEAR])
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_SAVE])
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_EXIT])
+	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_POKEDEX])
+	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_PLAYER])
+	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_OPTION])
+
+
+func test_quit_never_appears_because_this_project_has_no_bug_contest() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
+	assert_false(_kinds(menu).has(&"quit"))
+
+
+## STATICMENU_WRAP is on the source .MenuData flags, so the cursor wraps at
+## both ends instead of stopping.
+func test_cursor_wraps_at_both_ends() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_eq(menu.size(), 5)
+	assert_true(menu.move(-1))
+	assert_eq(menu.cursor, 4)
+	assert_true(menu.move(1))
+	assert_eq(menu.cursor, 0)
+
+
+## wBattleMenuCursorPosition survives a reopen; rebuilding with the previous
+## cursor should keep the same selection rather than resetting to the top.
+func test_cursor_persists_across_a_rebuild_and_clamps_to_a_shrunk_list() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, false, true)
+	menu.move(2)
+	var reopened: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, false, true, menu.cursor)
+	assert_eq(reopened.cursor, menu.cursor)
+
+	var shrunk: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false, menu.cursor)
+	assert_lt(shrunk.cursor, shrunk.size())
+
+
+func test_moving_an_empty_menu_does_nothing() -> void:
+	var menu := Gen2WorldStartMenu.new()
+	assert_false(menu.move(1))
+	assert_eq(menu.selected_item(), {})
+	assert_eq(menu.selected_kind(), &"")
+	assert_false(menu.selected_available())
+
+
+func test_from_world_reads_party_count_and_engine_flags_off_the_live_world() -> void:
+	var data: GameData = Fixture.build()
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6)
+	)
+	var empty_menu: Gen2WorldStartMenu = Gen2WorldStartMenu.from_world(world)
+	assert_false(_kinds(empty_menu).has(Gen2WorldStartMenu.ITEM_POKEMON))
+	assert_false(_kinds(empty_menu).has(Gen2WorldStartMenu.ITEM_POKEGEAR))
+
+	world.set_party_summary(1, false)
+	world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEGEAR)
+	var populated_menu: Gen2WorldStartMenu = Gen2WorldStartMenu.from_world(world)
+	assert_true(_kinds(populated_menu).has(Gen2WorldStartMenu.ITEM_POKEMON))
+	assert_true(_kinds(populated_menu).has(Gen2WorldStartMenu.ITEM_POKEGEAR))
+
+	assert_eq(_kinds(Gen2WorldStartMenu.from_world(null)), _kinds(Gen2WorldStartMenu.build(0, false, false)))
+	RomCache.clear(Fixture.directory())

--- a/tests/unit/test_world_start_menu.gd.uid
+++ b/tests/unit/test_world_start_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://b0jurxiowns


### PR DESCRIPTION
Reachable with Enter/Tab, the menu joins the world screen's existing service/PC/battle overlay set. Five entries are wired to real state: Pokemon (the party screen, now embeddable), Pack (a new read-only grouping of owned items into the four cartridge pocket types), Pokegear (the existing phone list), Save (the existing snapshot path behind a yes/no confirmation) and Exit. Pokedex, Player and Options are built in their source list position and gated the same way the cartridge gates them, but marked unavailable, since this project has no dex screen, trainer-card save fields or options model yet.

Gen2WorldStartMenu reproduces StartMenu.SetUpMenuItems's gating and cursor wrap; Gen2WorldPack classifies items by the type byte GameData already imports under "pocket", presentation only, with no change to how items are stored. Gen2PartyScreen gained the same embedded-mode shape Gen2BoxScreen already had. Enter moves from a third overworld confirm key to Start; Space and Z remain the confirm keys everywhere else.