### PR TITLE
Fix Gold/Silver engine flag indices for badges and the bargain merchant

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -470,7 +470,7 @@ func advance_schedule(random: RandomNumberGenerator = null) -> Dictionary:
 func set_world_clock(day: int, hour: int, minute: int) -> void:
 	var next_day: int = posmod(day, Gen2WorldClock.DAYS_PER_WEEK)
 	if next_day != world_day and state != null:
-		state.reset_daily_flags()
+		state.reset_daily_flags(Gen2WorldState.is_crystal_profile(data))
 	world_day = next_day
 	world_hour = posmod(hour, Gen2WorldClock.HOURS_PER_DAY)
 	world_minute = posmod(minute, Gen2WorldClock.MINUTES_PER_HOUR)

--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -50,7 +50,8 @@ static func resolve_mart(
 			label = "ROOFTOP SALE"
 		_:
 			return _failure(&"unsupported_mart_dialog", {"dialog": dialog_id})
-	if variant == &"bargain" and world_state != null and world_state.bargain_merchant_closed():
+	if variant == &"bargain" and world_state != null \
+		and world_state.bargain_merchant_closed(Gen2WorldState.is_crystal_profile(data)):
 		return _failure(&"bargain_mart_closed", {"dialog": dialog_id})
 	if mart.is_empty() or not mart.has("items") or not mart["items"] is Array \
 		or (mart["items"] as Array).is_empty():
@@ -138,12 +139,15 @@ static func purchase(
 			"item": item, "price": price, "quantity": quantity,
 			"total": total, "balance": balance,
 		})
+	var merchant_closed_flag: int = Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED \
+		if Gen2WorldState.is_crystal_profile(world.data) \
+		else Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
 	var before: Gen2WorldSnapshot = world.snapshot()
 	var applied: Dictionary = world.state.apply_changes({}, {}, {
 		"items": {item: next_quantity},
 		"money": {MONEY_ACCOUNT: balance - total},
 		"engine_flags": {
-			Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: true,
+			merchant_closed_flag: true,
 		} if is_bargain else {},
 	})
 	if not bool(applied.get("ok", false)):

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1301,7 +1301,7 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 		0x04: # VAR_TIMEOFDAY
 			_script_value = Gen2WorldClock.new(hour, 0, day).time_of_day()
 		0x07: # VAR_BADGES
-			_script_value = state.badge_count() if state != null else 0
+			_script_value = state.badge_count(_crystal_commands()) if state != null else 0
 		0x0A: # VAR_HOUR
 			_script_value = hour
 		0x0B: # VAR_WEEKDAY

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -14,14 +14,22 @@ const PHONE_RECEIVE_DELAYS: Array[int] = [20, 10, 5, 3]
 const TEMPORARY_MAP_RELOAD_FLAGS: Array[int] = [0, 1, 2, 3, 4, 5, 6, 7]
 ## Crystal maps STATUSFLAGS_HALL_OF_FAME_F through the source engine flag
 ## table to ENGINE_CREDITS_SKIP, and the Goldenrod bargain merchant uses the
-## daily ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED flag.
+## daily ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED flag. Both names are
+## Crystal indices, called out explicitly because pokegold's shorter engine
+## flag table (see the badge comment below) puts the same symbol one index
+## lower there.
 const ENGINE_CREDITS_SKIP: int = 15
 const ENGINE_HALL_OF_FAME: int = ENGINE_CREDITS_SKIP
-const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 43
-const DAILY_ENGINE_FLAGS: Array[int] = [ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED]
+const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 86
+const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER: int = 85
 
 ## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array;
-## VAR_BADGES counts both bytes together, not Johto alone.
+## VAR_BADGES counts both bytes together, not Johto alone. These are Crystal
+## indices. pokegold's constants/engine_flags.asm has no ENGINE_MOBILE_SYSTEM
+## entry, which pokecrystal inserts ahead of the badge section, so every
+## pokegold badge (and the merchant flag above) sits exactly one index lower
+## than the same symbol here; `_GetVarAction.CountBadges` and the flag order
+## are otherwise identical between the two games.
 const ENGINE_ZEPHYRBADGE: int = 27
 const ENGINE_HIVEBADGE: int = 28
 const ENGINE_PLAINBADGE: int = 29
@@ -43,6 +51,12 @@ const BADGE_ENGINE_FLAGS: Array[int] = [
 	ENGINE_MINERALBADGE, ENGINE_STORMBADGE, ENGINE_GLACIERBADGE, ENGINE_RISINGBADGE,
 	ENGINE_BOULDERBADGE, ENGINE_CASCADEBADGE, ENGINE_THUNDERBADGE, ENGINE_RAINBOWBADGE,
 	ENGINE_SOULBADGE, ENGINE_MARSHBADGE, ENGINE_VOLCANOBADGE, ENGINE_EARTHBADGE,
+]
+const BADGE_ENGINE_FLAGS_GOLD_SILVER: Array[int] = [
+	ENGINE_ZEPHYRBADGE - 1, ENGINE_HIVEBADGE - 1, ENGINE_PLAINBADGE - 1, ENGINE_FOGBADGE - 1,
+	ENGINE_MINERALBADGE - 1, ENGINE_STORMBADGE - 1, ENGINE_GLACIERBADGE - 1, ENGINE_RISINGBADGE - 1,
+	ENGINE_BOULDERBADGE - 1, ENGINE_CASCADEBADGE - 1, ENGINE_THUNDERBADGE - 1, ENGINE_RAINBOWBADGE - 1,
+	ENGINE_SOULBADGE - 1, ENGINE_MARSHBADGE - 1, ENGINE_VOLCANOBADGE - 1, ENGINE_EARTHBADGE - 1,
 ]
 
 var _event_flags: Dictionary = {}
@@ -252,14 +266,17 @@ func set_hall_of_fame(active: bool = true) -> void:
 	set_engine_flag(ENGINE_HALL_OF_FAME, active)
 
 
-func bargain_merchant_closed() -> bool:
-	return is_engine_flag_active(ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED)
+## `crystal` selects which game's engine flag table this state's raw flag
+## numbers were written against; pass [method is_crystal_profile] with the
+## active GameData. Defaults to Crystal, matching every existing caller.
+func bargain_merchant_closed(crystal: bool = true) -> bool:
+	return is_engine_flag_active(_merchant_closed_flag(crystal))
 
 
 ## Mirrors _GetVarAction's .CountBadges: a popcount over both badge bytes.
-func badge_count() -> int:
+func badge_count(crystal: bool = true) -> int:
 	var count: int = 0
-	for flag: int in BADGE_ENGINE_FLAGS:
+	for flag: int in (BADGE_ENGINE_FLAGS if crystal else BADGE_ENGINE_FLAGS_GOLD_SILVER):
 		if is_engine_flag_active(flag):
 			count += 1
 	return count
@@ -267,9 +284,9 @@ func badge_count() -> int:
 
 ## Clears only source daily engine flags. Story flags such as Hall of Fame
 ## survive the day boundary.
-func reset_daily_flags() -> bool:
+func reset_daily_flags(crystal: bool = true) -> bool:
 	var did_change: bool = false
-	for flag: int in DAILY_ENGINE_FLAGS:
+	for flag: int in [_merchant_closed_flag(crystal)]:
 		if not _engine_flags.has(flag):
 			continue
 		_engine_flags.erase(flag)
@@ -277,6 +294,20 @@ func reset_daily_flags() -> bool:
 	if did_change:
 		changed.emit()
 	return did_change
+
+
+func _merchant_closed_flag(crystal: bool) -> int:
+	return ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED if crystal \
+		else ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
+
+
+## True unless [param data] is a verified Gold or Silver cache, matching
+## Gen2WorldScriptRunner._crystal_commands(). Both engine flag tables and
+## `_GetVarAction.CountBadges` agree on everything except this table's
+## offset, so every profile-dependent flag lookup here keys off the same
+## question the script command-width split already answers.
+static func is_crystal_profile(data: GameData) -> bool:
+	return data == null or (data.id != &"gold" and data.id != &"silver")
 
 
 ## The source resets its first eight event flags whenever a map reloads. These

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -149,6 +149,42 @@ func test_bargain_purchase_closes_merchant_and_sells_each_item_once() -> void:
 	assert_true(next_day["ok"])
 
 
+## The Goldenrod Underground merchant flag is one index lower in pinned
+## pokegold than in pinned pokecrystal (constants/engine_flags.asm). A
+## purchase against a Gold-profile GameData must close the merchant at that
+## lower index, not the Crystal one, or a real pokegold bargain script's
+## checkflag would never see the closure this project just wrote.
+func test_bargain_purchase_on_a_gold_profile_cache_closes_the_gold_silver_flag() -> void:
+	var gold_directory: String = Fixture.directory(&"gold")
+	var gold_data: GameData = Fixture.build(&"gold")
+	_write_services_at(gold_directory)
+	gold_data = GameData.open_directory(gold_directory)
+	var gold_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		gold_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6),
+		Gen2WorldState.new({}, {}, {7: 1}, {0: 500})
+	)
+	var gold_save: Gen2SaveData = Gen2SaveStore.create_development_save(gold_data, 0)
+	gold_save.world = gold_world.snapshot()
+
+	var bargain: Dictionary = Gen2WorldMartHost.resolve_mart(
+		gold_data, Gen2WorldMartHost.MARTTYPE_BARGAIN, 0, false, gold_world.state
+	)
+	assert_true(bargain["ok"])
+	var purchase: Dictionary = Gen2WorldMartHost.purchase(
+		gold_world, gold_save, bargain["mart"], 7, 1, false
+	)
+	assert_true(purchase["ok"])
+	assert_true(gold_world.state.bargain_merchant_closed(false))
+	assert_false(gold_world.state.bargain_merchant_closed(true))
+	var closed: Dictionary = Gen2WorldMartHost.resolve_mart(
+		gold_data, Gen2WorldMartHost.MARTTYPE_BARGAIN, 0, false, gold_world.state
+	)
+	assert_false(closed["ok"])
+	assert_eq(closed["reason"], &"bargain_mart_closed")
+
+	RomCache.clear(gold_directory)
+
+
 func test_bargain_host_refuses_a_closed_merchant_before_opening_ui() -> void:
 	_set_mart_script(Gen2WorldMartHost.MARTTYPE_BARGAIN)
 	_world.state.set_engine_flag(Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED)
@@ -286,13 +322,17 @@ func test_menu_input_can_be_cancelled_without_selecting_an_option() -> void:
 
 
 func _write_services() -> void:
-	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	_write_services_at(Fixture.directory())
+
+
+func _write_services_at(directory: String) -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(directory))
 	for raw: Dictionary in items:
 		if int(raw.get("number", 0)) == 7:
 			raw["name"] = "ITEM7"
 			raw["price"] = 120
-	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
-	RomCache.write_json(RomCache.world_marts_path(Fixture.directory()), {
+	RomCache.write_json(RomCache.items_path(directory), items)
+	RomCache.write_json(RomCache.world_marts_path(directory), {
 		"marts": [{"index": 0, "bank": Fixture.BANK, "address": 0x4000, "items": [7, 8]}],
 		"default": {"items": [7]}, "special": {
 			"bargain": [{"item": 7, "price": 50}],
@@ -300,7 +340,7 @@ func _write_services() -> void:
 			"rooftop_mart_2": [{"item": 8, "price": 20}],
 		},
 	})
-	RomCache.write_json(RomCache.world_phone_path(Fixture.directory()), {
+	RomCache.write_json(RomCache.world_phone_path(directory), {
 		"contacts": [{
 			"index": 0, "trainer_class": 1, "trainer_number": 2,
 			"map_group": Fixture.MAP_GROUP, "map_number": Fixture.MAP_NUMBER,
@@ -308,7 +348,7 @@ func _write_services() -> void:
 		}],
 		"special_calls": [],
 	})
-	RomCache.write_json(RomCache.world_audio_path(Fixture.directory()), {
+	RomCache.write_json(RomCache.world_audio_path(directory), {
 		"music": [{"index": 0, "bank": Fixture.BANK, "address": 0x4000,
 			"bytes": [0x00, 0x03, 0x40, 0xD4, 0x10, 0xFF], "byte_count": 6}],
 		"sfx": [],

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -58,6 +58,76 @@ func test_badge_count_matches_active_flags_across_both_bytes() -> void:
 	assert_eq(kanto_only.badge_count(), 1)
 
 
+## pokegold's engine flag table has no ENGINE_MOBILE_SYSTEM entry ahead of the
+## badge section, so every pokegold badge sits one index lower than the same
+## symbol in pokecrystal's constants/engine_flags.asm. A Crystal-numbered
+## ENGINE_ZEPHYRBADGE write must not count as a Gold/Silver badge, and a
+## Gold/Silver-numbered write (one lower) must not count as a Crystal badge.
+func test_badge_count_uses_the_gold_silver_table_when_requested() -> void:
+	## Index 42 (ENGINE_EARTHBADGE) is the Crystal table's Kanto endpoint and
+	## falls outside the Gold/Silver table (26-41), so it isolates the
+	## Crystal-only end of the one-index shift.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_EARTHBADGE)
+	assert_eq(state.badge_count(true), 1)
+	assert_eq(state.badge_count(false), 0)
+
+	## Index 26 (ENGINE_ZEPHYRBADGE - 1) is the Gold/Silver table's Johto
+	## endpoint and falls outside the Crystal table (27-42), isolating the
+	## Gold/Silver-only end.
+	var gold_state := Gen2WorldState.new()
+	gold_state.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE - 1)
+	assert_eq(gold_state.badge_count(false), 1)
+	assert_eq(gold_state.badge_count(true), 0)
+
+	for flag: int in Gen2WorldState.BADGE_ENGINE_FLAGS_GOLD_SILVER:
+		gold_state.set_engine_flag(flag)
+	assert_eq(gold_state.badge_count(false), 16)
+
+
+## Same one-index shift for the Goldenrod Underground merchant flag: pinned
+## pokecrystal has it at 86, pinned pokegold at 85.
+func test_bargain_merchant_closed_uses_the_gold_silver_flag_when_requested() -> void:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED)
+	assert_true(state.bargain_merchant_closed(true))
+	assert_false(state.bargain_merchant_closed(false))
+
+	var gold_state := Gen2WorldState.new()
+	gold_state.set_engine_flag(
+		Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
+	)
+	assert_true(gold_state.bargain_merchant_closed(false))
+	assert_false(gold_state.bargain_merchant_closed(true))
+
+
+func test_reset_daily_flags_clears_the_matching_profiles_merchant_flag_only() -> void:
+	var gold_state := Gen2WorldState.new()
+	gold_state.set_engine_flag(
+		Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
+	)
+	assert_false(gold_state.reset_daily_flags(true))
+	assert_true(gold_state.bargain_merchant_closed(false))
+	assert_true(gold_state.reset_daily_flags(false))
+	assert_false(gold_state.bargain_merchant_closed(false))
+
+
+## Gen2WorldState.is_crystal_profile mirrors
+## Gen2WorldScriptRunner._crystal_commands(): only a verified Gold or Silver
+## cache is treated as the shorter engine flag table.
+func test_is_crystal_profile_matches_the_game_id_and_defaults_true_for_no_data() -> void:
+	assert_true(Gen2WorldState.is_crystal_profile(null))
+	var crystal_data := GameData.new()
+	crystal_data.id = &"crystal"
+	assert_true(Gen2WorldState.is_crystal_profile(crystal_data))
+	var gold_data := GameData.new()
+	gold_data.id = &"gold"
+	assert_false(Gen2WorldState.is_crystal_profile(gold_data))
+	var silver_data := GameData.new()
+	silver_data.id = &"silver"
+	assert_false(Gen2WorldState.is_crystal_profile(silver_data))
+
+
 func test_badge_flags_survive_round_trip_and_daily_or_map_reload_resets() -> void:
 	var state := Gen2WorldState.new()
 	state.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE)


### PR DESCRIPTION
Gen2WorldState hardcoded Crystal's engine flag indices for badge_count(), bargain_merchant_closed() and reset_daily_flags(). pokecrystal's constants/engine_flags.asm inserts ENGINE_MOBILE_SYSTEM ahead of the badge section; pokegold has no such entry, so every pokegold badge sits one index lower than the same symbol in pokecrystal. The Goldenrod Underground merchant flag was declared as 43 in both profiles, which is ENGINE_UNLOCKED_UNOWNS_A_TO_K in both games; the real index is 86 in pokecrystal and 85 in pokegold.

Both methods now take a crystal parameter selecting the correct table, defaulting to the prior Crystal behavior so existing callers and tests are unaffected. Gen2WorldState.is_crystal_profile(data) mirrors Gen2WorldScriptRunner._crystal_commands() and threads through the three real call sites that read a GameData.