### PR TITLE
Reload map objects from map data on a map change

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -66,6 +66,11 @@ var _script_queue: Array = []
 var _active_script: Gen2WorldScriptRunner = null
 var _map_entry_scene_pending: bool = false
 var _object_visibility_overrides: Dictionary = {}
+## Live cells and facings written by moveobject, turnobject, followers and the
+## trainer approach. The cartridge keeps the same values in wMapObjects, which
+## a map load rebuilds from ROM, so these do not outlive the loaded map; see
+## _apply_map(). Visibility is not one of them, because disappear/appear write
+## event flags, which the cartridge does persist.
 var _object_position_overrides: Dictionary = {}
 var _object_facing_overrides: Dictionary = {}
 var _object_followers: Dictionary = {}
@@ -2439,6 +2444,18 @@ func _apply_map(
 	target_map: Gen2WorldMap, target_tileset: Gen2WorldTileset, target_cell: Vector2i
 ) -> void:
 	_block_overrides.clear()
+	# home/map.asm's map load calls ReadObjectEvents, which calls
+	# ClearObjectStructs and re-reads every object event from ROM. moveobject
+	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table
+	# (engine/overworld/scripting.asm's Script_moveobject through
+	# CopyDECoordsToMapObject), so a scripted position never survives a map
+	# load; a MAPCALLBACK_OBJECTS callback re-applies it when its own condition
+	# still holds. Keeping these overrides across a map change left objects
+	# where an earlier visit had put them: ElmsLabMoveElmCallback moves Elm to
+	# (3, 4) while the scene is SCENE_ELMSLAB_MEET_ELM, and the story then
+	# found nothing to talk to at his authored (5, 2) on returning.
+	_object_position_overrides.clear()
+	_object_facing_overrides.clear()
 	state.reset_map_reload_flags()
 	current_map = target_map
 	current_tileset = target_tileset

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1759,6 +1759,76 @@ func test_warp_resolves_one_based_destination_and_reloads_the_target_map() -> vo
 	assert_eq(world.player_cell, Vector2i(2, 2))
 
 
+## home/map.asm's map load calls ReadObjectEvents, which clears the object
+## structs and re-reads every object event from ROM, so the coordinates
+## moveobject wrote into wMapObjects
+## (engine/overworld/scripting.asm's Script_moveobject through
+## CopyDECoordsToMapObject) do not outlive the loaded map. A MAPCALLBACK_OBJECTS
+## callback re-applies them when its own condition still holds.
+func test_scripted_object_position_does_not_survive_a_map_change() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x72, 2, 3, 4, Gen2WorldScript.END])
+	assert_eq(world.objects[0].cell, Vector2i(5, 6))
+	var moved: Array = world.dispatch_script_events()
+	assert_eq(moved[0]["status"], &"complete", JSON.stringify(moved[0]))
+	assert_eq(world.objects[0].cell, Vector2i(3, 4))
+
+	world.player_cell = Vector2i(6, 6)
+	assert_true(world.try_warp()["ok"])
+	assert_eq(world.map_id(), Vector2i(1, 2))
+	assert_true(world.try_warp()["ok"])
+	assert_eq(world.map_id(), Vector2i(1, 1))
+	assert_eq(world.objects[0].cell, Vector2i(5, 6))
+
+
+func test_scripted_object_facing_does_not_survive_a_map_change() -> void:
+	var world: Gen2WorldAPI = _object_script_world([
+		0x76, 2, Gen2WorldSprite.FACING_RIGHT, Gen2WorldScript.END,
+	])
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.objects[0].facing, Gen2WorldSprite.FACING_RIGHT)
+
+	world.player_cell = Vector2i(6, 6)
+	assert_true(world.try_warp()["ok"])
+	assert_true(world.try_warp()["ok"])
+	assert_eq(world.objects[0].facing, Gen2WorldSprite.FACING_DOWN)
+
+
+## reloadmapafterbattle reloads the live records without the map load that
+## rebuilds them from the cache, so a trainer written to its post-approach cell
+## still answers there.
+func test_scripted_object_position_survives_a_reload_of_the_same_map() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x72, 2, 3, 4, Gen2WorldScript.END])
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.objects[0].cell, Vector2i(3, 4))
+	assert_true(world.reload_current_map()["ok"])
+	assert_eq(world.objects[0].cell, Vector2i(3, 4))
+
+
+## disappear writes an event flag rather than a map-object coordinate, and the
+## cartridge does persist event flags, so visibility is not cleared with the
+## position and facing overrides.
+func test_object_visibility_override_survives_a_map_change() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x6E, 2, Gen2WorldScript.END])
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_false(world.objects[0].active)
+
+	world.player_cell = Vector2i(6, 6)
+	assert_true(world.try_warp()["ok"])
+	assert_true(world.try_warp()["ok"])
+	assert_false(world.objects[0].active)
+
+
+## Opens map 1/1 standing on the coordinate event at (7, 6) with
+## [param script_bytes] behind it, so a test can drive one object command.
+func _object_script_world(script_bytes: Array) -> Gen2WorldAPI:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6220"] = script_bytes
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6220
+	return Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6), Gen2WorldState.new())
+
+
 func test_roaming_mons_move_on_map_setup_and_not_on_elapsed_time() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(6, 6))
 	var random := RandomNumberGenerator.new()

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -461,7 +461,7 @@ func _story_path(data: GameData) -> Dictionary:
 	if bool(walked_to_elm.get("ok", false)):
 		world.player_facing = Gen2WorldSprite.FACING_UP
 		elm_events = world.interact()
-	var elm_run: Dictionary = _drain_story(world, elm_events, save, random, data)
+	var elm_run: Dictionary = _drain_story(world, elm_events, save, random, data, true)
 	path.append({
 		"step": "elm_lab_mystery_egg_return",
 		"map": _map_value(world),
@@ -479,7 +479,7 @@ func _story_path(data: GameData) -> Dictionary:
 		balls_events = walked_to_balls.get("events", [])
 		if not balls_events.is_empty():
 			break
-	var balls_run: Dictionary = _drain_story(world, balls_events, save, random, data)
+	var balls_run: Dictionary = _drain_story(world, balls_events, save, random, data, true)
 	path.append({
 		"step": "elm_lab_aide_pokeballs",
 		"map": _map_value(world),
@@ -491,24 +491,98 @@ func _story_path(data: GameData) -> Dictionary:
 	if not bool(balls_run.get("terminal", false)):
 		return {"ok": false, "path": path, "reason": "Aide Poke Ball event did not finish"}
 
-	# Route 30 and Route 31 both cross one-way ledges, which this project now
-	# hops (Gen2WorldCollision.allows_hop, wired into _reachable_step below),
-	# and the northward corridor at Route 30 x=6..7 is plain floor the whole
-	# way to the map's north edge. The walk is still not driven here because
-	# _reachable_step resolves occupancy through Gen2WorldAPI.can_walk_to(),
-	# which refuses any cell holding an active object: Route 30 puts four
-	# objects on the single passable cell of its row 25 chokepoint at x=5,
-	# sealing the corridor for a static search even though those NPCs move at
-	# runtime. Ignoring occupancy the same search reaches the north edge, so
-	# the terrain and the hops are not what stops it; see
-	# tools/validate_ledge_hops.gd, which asserts exactly that. The badge
-	# slice this preview exists to exercise is the Pokemon Center and Violet
-	# Gym scripts, so the world reopens directly in Violet City on the same
-	# mutable state rather than waiting on transient-object pathfinding.
-	var violet_world: Gen2WorldAPI = Gen2WorldAPI.open(data, 10, 5, Vector2i(31, 25), world.state)
-	if violet_world == null:
-		return {"ok": false, "path": path, "reason": "missing Violet City map"}
-	world = violet_world
+	# Route 30's corridor north is sealed until ElmAfterTheftScript's
+	# setevent EVENT_ROUTE_30_BATTLE hides the two objects standing on it
+	# (maps/Route30.asm, maps/ElmsLab.asm; CheckObjectFlag in
+	# engine/overworld/map_objects_2.asm masks an object whose flag is set).
+	# The Mystery Egg return above is what sets it, so the route walks from
+	# here on the same world and state.
+	var lab_exit_warp: Dictionary = _warp_to(world.current_map, 24, 4)
+	if lab_exit_warp.is_empty():
+		return {"ok": false, "path": path, "reason": "missing Elm lab exit warp"}
+	world.player_cell = Vector2i(lab_exit_warp["x"], lab_exit_warp["y"])
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Elm lab exit warp failed"}
+	var departure_entry: Array = world.dispatch_map_entry()
+	var departure_run: Dictionary = _drain_story(world, departure_entry, save, random, data)
+	path.append({
+		"step": "new_bark_departure",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": departure_run,
+	})
+	if not bool(departure_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "New Bark departure entry did not finish"}
+
+	var legs: Array = [
+		{"step": "new_bark_to_route_29_north", "direction": "west", "group": 24, "number": 3},
+		{"step": "route_29_to_cherrygrove_north", "direction": "west", "group": 26, "number": 3},
+		{"step": "cherrygrove_to_route_30_north", "direction": "north", "group": 26, "number": 1},
+		{"step": "route_30_to_route_31", "direction": "north", "group": 26, "number": 2},
+	]
+	for leg: Dictionary in legs:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, String(leg["direction"]), int(leg["group"]), int(leg["number"]),
+			save, random, data
+		)
+		var leg_entry: Array = world.dispatch_map_entry()
+		var leg_run: Dictionary = _drain_story(world, leg_entry, save, random, data)
+		path.append({
+			"step": String(leg["step"]),
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"transition": _transition_value(walked.get("transition", {})),
+			"encounters": walked.get("encounters", []),
+			"run": leg_run,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+		if not bool(leg_run.get("terminal", false)):
+			return {"ok": false, "path": path, "reason": "%s entry did not finish" % leg["step"]}
+
+	# Route 31 reaches Violet City through Route31VioletGate, not through its
+	# west map connection: the map's four westmost cell columns are wall on
+	# every row, so no walkable west edge exists (maps/Route31.asm's
+	# warp_event 4, 6 and maps/Route31VioletGate.asm's warp_event 0, 4).
+	var gate_walk: Dictionary = _walk_cell_resolving(world, Vector2i(4, 6), save, random, data)
+	path.append({
+		"step": "route_31_to_violet_gate",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": gate_walk.get("encounters", []),
+	})
+	if not bool(gate_walk.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 31 gate approach failed: %s" % gate_walk.get("reason", ""),
+		}
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Route 31 Violet gate warp failed"}
+	var gate_entry: Array = world.dispatch_map_entry()
+	var gate_run: Dictionary = _drain_story(world, gate_entry, save, random, data)
+	path.append({
+		"step": "violet_gate_entry",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": gate_run,
+	})
+	if not bool(gate_run.get("terminal", false)):
+		return {"ok": false, "path": path, "reason": "Violet gate entry did not finish"}
+
+	var city_side: Dictionary = _walk_cell_resolving(world, Vector2i(0, 4), save, random, data)
+	if not bool(city_side.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Violet gate west exit unreachable: %s" % city_side.get("reason", ""),
+		}
+	transition = world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Violet gate to Violet City warp failed"}
 	var violet_entry: Array = world.dispatch_map_entry()
 	var violet_entry_run: Dictionary = _drain_story(world, violet_entry, save, random, data)
 	path.append({
@@ -587,13 +661,27 @@ func _story_path(data: GameData) -> Dictionary:
 	})
 
 	# Falkner is object 0 at block (5,1); facing up from (5,2) matches the
-	# source's faceplayer interaction cell.
+	# source's faceplayer interaction cell. The gym's two Bird Keepers stand
+	# on sight lines across the way to him, so they are fought on the approach
+	# exactly as they are on the cartridge.
 	var falkner_events: Array = []
-	var walked_to_falkner: Dictionary = _walk_to_story_cell(world, Vector2i(5, 2))
-	if bool(walked_to_falkner.get("ok", false)):
-		world.player_facing = Gen2WorldSprite.FACING_UP
-		falkner_events = world.interact()
-	var falkner_run: Dictionary = _drain_story(world, falkner_events, save, random, data)
+	var walked_to_falkner: Dictionary = _walk_cell_resolving(
+		world, Vector2i(5, 2), save, random, data
+	)
+	path.append({
+		"step": "violet_gym_bird_keepers",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": walked_to_falkner.get("encounters", []),
+	})
+	if not bool(walked_to_falkner.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Falkner approach failed: %s" % walked_to_falkner.get("reason", ""),
+		}
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	falkner_events = world.interact()
+	var falkner_run: Dictionary = _drain_story(world, falkner_events, save, random, data, true)
 	path.append({
 		"step": "violet_gym_falkner",
 		"map": _map_value(world),
@@ -629,13 +717,30 @@ func _party_hp(save: Gen2SaveData) -> Array:
 	return values
 
 
+## Runs a dispatched event list to its terminal state. [param require_events]
+## is set by a step whose whole point is that an imported script ran: without
+## it an empty [param initial] drains in zero iterations and reports terminal,
+## so a step that silently found nothing to talk to passes. Map-entry steps
+## leave it false, since a map with no entry callback legitimately dispatches
+## nothing.
 func _drain_story(
 	world: Gen2WorldAPI,
 	initial: Array,
 	save: Gen2SaveData = null,
 	random: RandomNumberGenerator = null,
 	data: GameData = null,
+	require_events: bool = false,
 ) -> Dictionary:
+	if require_events and initial.is_empty():
+		return {
+			"statuses": [],
+			"waits": 0,
+			"pending_trace": [],
+			"battles": [],
+			"terminal": false,
+			"reason": "no events dispatched",
+			"details": "",
+		}
 	var results: Array = initial.duplicate(true)
 	var statuses: Array = _statuses(results)
 	var waits: int = 0
@@ -643,6 +748,8 @@ func _drain_story(
 	var last_details: String = ""
 	var pending_trace: Array[String] = []
 	var battles: Array = []
+	var catch_tutorials: int = 0
+	var approaches: Array = []
 	for result: Dictionary in results:
 		if not bool(result.get("ok", false)):
 			last_reason = String(result.get("reason", "script_failed"))
@@ -707,6 +814,65 @@ func _drain_story(
 					"ok": true,
 					"outcome": Gen2WorldBattleAdapter.OUTCOME_WON,
 				})
+			elif request_kind == &"trainer_approach_requested":
+				# Route 30's trainers see the player on the corridor north, so
+				# the walked route runs the source presentation: shock emote for
+				# TRAINER_SHOCK_FRAMES, then one slow step per planned cell,
+				# then the facing update, before the seen text resumes. The
+				# same order tools/validate_crystal_route30_trainer.gd checks.
+				var approach_values: Dictionary = request.get("values", {})
+				var approach_index: int = int(approach_values.get("object_index", -1))
+				var raw_direction: Variant = approach_values.get("direction", Vector2i.ZERO)
+				var approach_direction: Vector2i = (
+					raw_direction if raw_direction is Vector2i else Vector2i.ZERO
+				)
+				var plan: Dictionary = world.start_trainer_approach(
+					approach_index, approach_direction,
+					int(approach_values.get("distance", 0))
+				)
+				if not bool(plan.get("ok", false)):
+					last_reason = String(plan.get("reason", "trainer approach plan failed"))
+					last_details = JSON.stringify(plan)
+					break
+				for _frame: int in int(plan.get("emote_frames", 0)):
+					world.tick()
+				var approach_failed: bool = false
+				for path_step: Vector2i in plan.get("path", []):
+					var stepped: Dictionary = world.advance_trainer_approach_step(
+						approach_index, path_step
+					)
+					if not bool(stepped.get("ok", false)):
+						last_reason = String(stepped.get("reason", "trainer approach step failed"))
+						last_details = JSON.stringify(stepped)
+						approach_failed = true
+						break
+				if approach_failed:
+					break
+				var faced: Dictionary = world.finish_trainer_approach(approach_index)
+				if not bool(faced.get("ok", false)):
+					last_reason = String(faced.get("reason", "trainer approach finish failed"))
+					last_details = JSON.stringify(faced)
+					break
+				approaches.append({
+					"object_index": approach_index,
+					"path": plan.get("path", []).size(),
+				})
+				results = world.complete_runtime_request({
+					"ok": true,
+					"object_index": approach_index,
+					"path": plan.get("path", []),
+				})
+			elif request_kind == &"catch_tutorial_requested":
+				# ElmAfterTheftScript sets SCENE_ROUTE29_CATCH_TUTORIAL, so this
+				# is on the route from here on. The source guarantees the ball,
+				# and Gen2WorldScriptRunner refuses any other outcome, so the
+				# only valid completion is OUTCOME_CAUGHT. It changes no
+				# persistent party, PC or ball state.
+				catch_tutorials += 1
+				results = world.complete_runtime_request({
+					"ok": true,
+					"outcome": Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
+				})
 			elif request_kind == &"audio_requested":
 				results = world.complete_runtime_request({"ok": true})
 			else:
@@ -733,6 +899,8 @@ func _drain_story(
 		"waits": waits,
 		"pending_trace": pending_trace,
 		"battles": battles,
+		"catch_tutorials": catch_tutorials,
+		"approaches": approaches,
 		"terminal": last_reason.is_empty() \
 			and not world.script_input_waiting() and world.pending_runtime_request().is_empty(),
 		"reason": last_reason,
@@ -783,7 +951,7 @@ func _walk_to_connection(
 		var moved: Dictionary = world.move_result(step)
 		if not bool(moved.get("ok", false)):
 			return {"ok": false, "reason": "walk step failed", "step": step}
-		var events: Array = world.dispatch_script_events(world.player_cell)
+		var events: Array = _dispatch_after_step(world)
 		if not events.is_empty():
 			return {"ok": false, "reason": "connection walk hit a scripted event", "events": events}
 	var transition: Dictionary = world.move_result(_connection_direction(direction_name))
@@ -849,7 +1017,7 @@ func _walk_to_story_cell(world: Gen2WorldAPI, target: Vector2i) -> Dictionary:
 	if world == null or world.current_map == null:
 		return {"ok": false, "reason": "missing world"}
 	if world.player_cell == target:
-		return {"ok": true, "events": world.dispatch_script_events(target)}
+		return {"ok": true, "events": _dispatch_after_step(world, target)}
 	var frontier: Array[Vector2i] = [world.player_cell]
 	var previous: Dictionary = {world.player_cell: {"cell": Vector2i(-1, -1), "direction": Vector2i.ZERO}}
 	var directions: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
@@ -878,10 +1046,102 @@ func _walk_to_story_cell(world: Gen2WorldAPI, target: Vector2i) -> Dictionary:
 		var moved: Dictionary = world.move_result(direction)
 		if not bool(moved.get("ok", false)):
 			return {"ok": false, "reason": "walk step failed", "step": direction}
-		events = world.dispatch_script_events(world.player_cell)
+		events = _dispatch_after_step(world)
 		if not events.is_empty():
 			break
 	return {"ok": true, "steps": steps.size(), "events": events}
+
+
+## The order Gen2WorldScreen uses after a successful step: a trainer who can
+## see the player answers before the cell's own scripts. A walked route past
+## Route 30's trainers reaches nothing otherwise, since sight is queued by
+## dispatch_sight_events() and never by dispatch_script_events().
+func _dispatch_after_step(world: Gen2WorldAPI, cell: Vector2i = Vector2i(-1, -1)) -> Array:
+	var sight: Array = world.dispatch_sight_events()
+	if not sight.is_empty():
+		return sight
+	return world.dispatch_script_events(cell if cell.x >= 0 else world.player_cell)
+
+
+## Walks toward a connection edge, resolving anything met on the way and
+## resuming from wherever the walk stopped. Route 30 puts two trainers on the
+## corridor north, and a trainer who sees the player interrupts the walk, so a
+## single _walk_to_connection() call cannot carry the route on its own.
+func _walk_connection_resolving(
+	world: Gen2WorldAPI,
+	direction_name: String,
+	target_group: int,
+	target_number: int,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+) -> Dictionary:
+	var runs: Array = []
+	for _attempt: int in 8:
+		var walked: Dictionary = _walk_to_connection(
+			world, direction_name, target_group, target_number
+		)
+		if bool(walked.get("ok", false)):
+			walked["encounters"] = runs
+			return walked
+		var events: Array = walked.get("events", [])
+		if events.is_empty():
+			walked["encounters"] = runs
+			return walked
+		var run: Dictionary = _drain_story(world, events, save, random, data, true)
+		runs.append({
+			"cell": _cell_value(world),
+			"statuses": run.get("statuses", []),
+			"battles": run.get("battles", []),
+		})
+		if not bool(run.get("terminal", false)):
+			return {
+				"ok": false,
+				"reason": "encounter on the way to the %s connection did not finish" % direction_name,
+				"encounters": runs,
+				"details": run.get("reason", ""),
+			}
+	return {"ok": false, "reason": "connection walk did not settle", "encounters": runs}
+
+
+## The _walk_to_story_cell() counterpart of _walk_connection_resolving().
+func _walk_cell_resolving(
+	world: Gen2WorldAPI,
+	target: Vector2i,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+) -> Dictionary:
+	var runs: Array = []
+	for _attempt: int in 8:
+		var walked: Dictionary = _walk_to_story_cell(world, target)
+		if not bool(walked.get("ok", false)):
+			walked["encounters"] = runs
+			return walked
+		var events: Array = walked.get("events", [])
+		if events.is_empty() and world.player_cell == target:
+			walked["encounters"] = runs
+			return walked
+		if events.is_empty():
+			return {
+				"ok": false,
+				"reason": "walk stopped short of %s" % target,
+				"encounters": runs,
+			}
+		var run: Dictionary = _drain_story(world, events, save, random, data, true)
+		runs.append({
+			"cell": _cell_value(world),
+			"statuses": run.get("statuses", []),
+			"battles": run.get("battles", []),
+		})
+		if not bool(run.get("terminal", false)):
+			return {
+				"ok": false,
+				"reason": "encounter on the way to %s did not finish" % target,
+				"encounters": runs,
+				"details": run.get("reason", ""),
+			}
+	return {"ok": false, "reason": "walk to %s did not settle" % target, "encounters": runs}
 
 
 func _warp_to(map: Gen2WorldMap, group: int, number: int) -> Dictionary:

--- a/tools/validate_ledge_hops.gd
+++ b/tools/validate_ledge_hops.gd
@@ -7,9 +7,9 @@ extends SceneTree
 ##
 ## This is the real-cartridge counterpart to tests/unit/test_world_collision.gd
 ## and the ledge cases in tests/unit/test_world_api.gd, which use synthetic
-## caches. It also pins the reason tools/preview_world_story.gd still reopens
-## in Violet City instead of walking Route 30: the terrain and the hops carry
-## the route, while a static search over occupied cells does not.
+## caches. It also pins what gates Route 30's corridor north, which
+## tools/preview_world_story.gd now walks: the terrain and the hops carry the
+## route, and EVENT_ROUTE_30_BATTLE is what opens the last two cells.
 ##
 ##   Godot --headless --path . -s res://tools/validate_ledge_hops.gd
 
@@ -24,6 +24,9 @@ const ROUTE30_HOP_ROW: int = 24
 const ROUTE30_HOP_COLUMNS: Array[int] = [2, 3, 4]
 ## The northward corridor is plain floor from row 7 to the map's north edge.
 const ROUTE30_CORRIDOR_COLUMNS: Array[int] = [6, 7]
+## constants/event_flags.asm's EVENT_ROUTE_30_BATTLE, carried by the objects
+## standing on the corridor north and set by maps/ElmsLab.asm.
+const ROUTE30_BATTLE_EVENT_FLAG: int = 1812
 
 var _failures: PackedStringArray = []
 
@@ -114,25 +117,40 @@ func _verify_route30(game_id: StringName, data: GameData) -> void:
 				"%s: Route 30 corridor cell %s is not land." % [game_id, cell]
 			)
 
-	# Terrain reachability, which is what the hops contribute to, reaches the
-	# north edge. The same search resolving live occupancy does not, because
-	# Route 30 parks objects on the single passable cell of its row 25
-	# chokepoint. That difference is the open limitation recorded in
-	# tools/preview_world_story.gd, and pinning it here keeps a future change
-	# to either side from going unnoticed.
-	var terrain: Dictionary = _reachable(world, true)
-	var occupied: Dictionary = _reachable(world, false)
-	_check(
-		_reaches_north_edge(world, terrain),
-		"%s: Route 30 north edge is unreachable even ignoring occupancy." % game_id
-	)
+	# The corridor north is a story gate, not a terrain or pathfinding problem.
+	# Two objects stand on its single-cell rows 24 and 25, both carrying
+	# EVENT_ROUTE_30_BATTLE, and CheckObjectFlag
+	# (engine/overworld/map_objects_2.asm) masks an object whose flag is set.
+	# maps/ElmsLab.asm's ElmAfterTheftScript sets that flag when the player
+	# hands Elm the Mystery Egg, so the route opens exactly when the cartridge
+	# opens it. Both halves are pinned here: sealed before the egg return,
+	# walkable after it, with live occupancy enforced in both searches.
+	var occupied: Dictionary = _reachable(world)
 	_check(
 		not _reaches_north_edge(world, occupied),
-		"%s: Route 30 north edge is now reachable through occupied cells; the story preview can walk the route and its Violet City reopen should be replaced." % game_id
+		"%s: Route 30 north edge is reachable before EVENT_ROUTE_30_BATTLE is set." % game_id
+	)
+
+	var opened_state := Gen2WorldState.new()
+	opened_state.set_event_flag(ROUTE30_BATTLE_EVENT_FLAG)
+	var opened_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ROUTE30_GROUP, ROUTE30_NUMBER, ROUTE30_ENTRY, opened_state
+	)
+	if not _check(opened_world != null, "%s: Route 30 did not reopen." % game_id):
+		return
+	_check(
+		opened_world.object_at(Vector2i(5, 24)) == null
+			and opened_world.object_at(Vector2i(5, 25)) == null,
+		"%s: EVENT_ROUTE_30_BATTLE did not clear the corridor objects." % game_id
+	)
+	var opened: Dictionary = _reachable(opened_world)
+	_check(
+		_reaches_north_edge(opened_world, opened),
+		"%s: Route 30 north edge is still unreachable after EVENT_ROUTE_30_BATTLE." % game_id
 	)
 	_check(
-		terrain.size() > occupied.size(),
-		"%s: ignoring occupancy did not widen Route 30 reachability." % game_id
+		opened.size() > occupied.size(),
+		"%s: EVENT_ROUTE_30_BATTLE did not widen Route 30 reachability." % game_id
 	)
 
 	# No assertion is made that hops widen whole-map reachability. A ledge is
@@ -145,10 +163,9 @@ func _verify_route30(game_id: StringName, data: GameData) -> void:
 
 ## Breadth-first reachability from the player's cell, following ordinary steps
 ## and ledge hops the same way tools/preview_world_story.gd's _reachable_step
-## does. [param terrain_only] resolves cells by collision permission alone,
-## ignoring live object occupancy; otherwise it uses the same
-## Gen2WorldAPI.can_walk_to() the runtime and the story preview use.
-func _reachable(world: Gen2WorldAPI, terrain_only: bool) -> Dictionary:
+## does. Cells resolve through the same Gen2WorldAPI.can_walk_to() the runtime
+## and the story preview use, so live object occupancy counts.
+func _reachable(world: Gen2WorldAPI) -> Dictionary:
 	var size: Vector2i = world.map_size_cells()
 	var frontier: Array[Vector2i] = [world.player_cell]
 	var seen: Dictionary = {world.player_cell: true}
@@ -160,9 +177,7 @@ func _reachable(world: Gen2WorldAPI, terrain_only: bool) -> Dictionary:
 			var next: Vector2i = Vector2i(-1, -1)
 			var open: bool = false
 			if direct.x >= 0 and direct.y >= 0 and direct.x < size.x and direct.y < size.y:
-				open = Gen2WorldCollision.permission_for(
-					world.collision_code_at(direct)
-				) == Gen2WorldCollision.LAND_TILE if terrain_only else world.can_walk_to(direct)
+				open = world.can_walk_to(direct)
 			if open:
 				next = direct
 			elif Gen2WorldCollision.allows_hop(world.collision_code_at(cell), step):


### PR DESCRIPTION
moveobject writes MAPOBJECT_X_COORD/Y_COORD into wMapObjects, and a map load calls ReadObjectEvents, which clears the object structs and re-reads every object event, so a scripted position never outlives the loaded map; a MAPCALLBACK_OBJECTS callback re-applies it while its own condition holds. Gen2WorldAPI kept those overrides forever, so ElmsLabMoveElmCallback left Elm on (3, 4) after the first visit and the story preview found nothing to talk to at his authored (5, 2). _apply_map() now clears the position and facing overrides. Visibility is left alone, since disappear/appear write event flags, which the cartridge does persist, and reload_current_map() is left alone so a trainer stays on its post-approach cell after a battle.

With Elm reachable the Mystery Egg return runs its imported commands, and the flags it sets open Route 30's corridor north, which was never a pathfinding problem: the objects sealing it are stationary and carry EVENT_ROUTE_30_BATTLE, which ElmAfterTheftScript clears.

The story preview now walks Cherrygrove to Violet City instead of reopening there. _drain_story() refuses to report success for a step that dispatched nothing, the walk helpers dispatch trainer sight before cell scripts as Gen2WorldScreen does, and the walk resolves what it meets: the Route 29 catch tutorial, Youngster Mikey and Bug Catcher Don on Route 30, and both Violet Gym Bird Keepers before Falkner. Route 31 enters Violet City through Route31VioletGate, since the map has no walkable west edge.

validate_ledge_hops.gd now pins the real gate: the corridor is sealed with EVENT_ROUTE_30_BATTLE clear and reaches the north edge with it set, with live occupancy enforced in both searches.

Based on pokecrystal 5593381195342e481b69a2fd4ab25e202ddcf708 and pokegold add1dbe018170d7f25f7b7360e8046cec6354906: engine/overworld/scripting.asm, engine/overworld/player_object.asm, home/map.asm,
engine/overworld/map_objects_2.asm, maps/ElmsLab.asm, maps/Route30.asm, maps/Route31.asm, maps/Route31VioletGate.asm and
constants/event_flags.asm.