### PR TITLE
Compress documentation and code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,62 +22,34 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 
 > ### Status: early
 >
-> The importer gate and first importer half are tested. A verified cartridge
-> decodes species, moves, items, types, the type chart, learnsets, evolutions,
-> palettes, all Pokémon sprites, trainer pics and parties, the font, text-box
-> borders and battle HUD. Battles support parties, switching, stats, damage,
-> accuracy, turn order, status and substatus effects, trainer AI, experience,
-> levelling and move learning on a real 160x144 screen.
+> Not a complete game yet. What works today:
 >
-> The launcher imports a verified dump, opens its cache's save screen, creates
-> or imports a party, and starts the development battle. The overworld slice
-> renders real maps, enters the imported Crystal home callbacks from a new
-> game, traverses connected maps, runs explicit script requests,
-> handles trainer battles, imported win/loss text, map reloads and save-safe
-> blackout recovery, and covers object lifecycle, bounded followers, block
-> edits, emotes, surf, ledge hops, grass, fishing, roaming, repel and
-> deterministic wild
-> battle requests. The real-data story preview now follows the post-starter
-> route through Elm's aide Potion, Route 29, Cherrygrove, Route 30, Mr. Pokémon's
-> Mystery Egg event, the first rival battle and the return to Elm's Lab for the
-> Egg and Poké Ball handoffs.
+> - **Import.** Species, moves, items, types, the type chart, learnsets,
+>   evolutions, palettes, every Pokémon sprite, trainer pics and parties, the
+>   font, text-box borders, the battle HUD, maps, overworld menus, 34 mart
+>   lists, phone contacts, special calls and music/SFX pointers. A scene-free
+>   host resolves all of it without reopening the ROM.
+> - **Battles.** Parties, switching, stats, damage, accuracy, turn order, status
+>   and substatus effects, trainer AI, experience, levelling, move learning and
+>   capture input on a real 160x144 screen.
+> - **Overworld.** Real maps, map connections, script requests, trainer battles
+>   with imported win/loss text, map reloads, save-safe blackout recovery,
+>   object lifecycle, followers, block edits, emotes, surf, ledge hops, grass,
+>   fishing, roaming, repel and wild encounters. The service overlay covers
+>   menu selection, mart dialog variants and quantity purchases, source-timed
+>   phone dispatch and bounded music, effects and cries.
+> - **Saves.** Three slots, `.sav` import, and a 14-box PC model with 20 slots
+>   per box. Gifts, eggs, NPC trades, HP/status items, repel and captures commit
+>   through a validated candidate save; a full party routes into the first free
+>   box slot and full storage refuses atomically. Format 1 saves migrate without
+>   inventing a world position.
+> - **Mods.** A mod under `user://mods/` can register a replacement world
+>   renderer, which is what a 3D or HD view needs.
 >
-> The importer also preserves referenced overworld menus, 34 mart lists, phone
-> contacts, special-call records and music/SFX pointer records. The scene-free
-> host resolves them without reopening the ROM. The production service overlay
-> supports cached vertical and two-dimensional menu selection, source mart dialog
-> variants, bounded quantity purchases, source-timed phone caller/callee dispatch
-> and bounded Gen II music, effects and cries. Party transactions cover
-> gifts, eggs, imported NPC trades, common HP/status items, repel and the core
-> Poké Ball catch calculation behind a validated candidate-save boundary; wild
-> capture input uses that transaction.
-
-The party screen opens a first PC storage presentation with fourteen numbered
-boxes and twenty fixed slots per box. It can deposit into the current box's
-first free slot and withdraw into a party with room. Each transfer validates and
-writes a candidate save atomically, and the last party member cannot be boxed.
-The imported Players House PC now reaches this same storage screen as an
-embedded overworld overlay. Closing it resumes the source script, while
-selected saves persist transfers and injected or development saves remain
-memory-only.
-> Crystal rooftop stock switches from the imported first list after the Hall of
-> Fame engine flag is committed. The imported bargain shop keeps its Monday
-> morning, one-item-per-visit and daily close behavior in the world snapshot.
->
-> Project saves now have a validated 14-box PC model with 20 slots per box.
-> Full parties route gifts, eggs and successful captures into the first free
-> box slot, while full storage refuses the transaction atomically. Format 1
-> project saves migrate without inventing a world position.
->
-> Full story state and complete phone presentation do not exist yet, so this is not
-> a complete game. Source two-ring timing, contact registration commands,
-> non-trainer caller labels, seen-species phone text and bounded phone pointer
-> semantics are implemented. The remaining source special-call condition branches
-> and story-driven permanent-contact setup are still pending. The mod boundary is
-> in: a mod under `user://mods/` can register
-> a replacement world renderer, which is what a 3D or HD view needs. Scene-level integration tests cover trainer sight,
-> imported terminal text, live object refresh, emotes, wild capture, save-backed
-> blackout recovery and all four service overlay modes.
+> The real-data story preview walks the Crystal route from Elm's lab through
+> Route 29, Cherrygrove, Route 30 and Mr. Pokémon's Mystery Egg event to the
+> Zephyr Badge. Missing: full story state, dex, trainer card, options, the
+> remaining special-call branches and story-driven permanent contacts.
 
 ## Getting started
 
@@ -161,100 +133,59 @@ godot --headless --path . --quit-after 30
 ```
 
 The launcher lists Gold, Silver and Crystal cache status, imports a selected
-ROM, and opens its save screen. It provides three validated slots, new games
-with an empty party until Professor Elm's imported lab handoff, original `.sav`
-import, party inspection and the development battle. The lab scripts then offer
-Chikorita, Cyndaquil or Totodile at level 5 with Berry, using the verified Crystal
-home spawn and source starting money when that map exists. Continue enters the
-overworld; F5 saves its map, inventory, event and clock snapshot. See
+ROM, and opens its save screen: three validated slots, `.sav` import, party
+inspection and the development battle. A new game starts with an empty party at
+the Crystal home spawn with source starting money; Elm's imported lab scripts
+offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry. Continue enters
+the overworld and F5 saves its map, inventory, event and clock snapshot. See
 [docs/SAVES.md](docs/SAVES.md) for the save and SRAM contract.
 
 Development scenes:
 
-- `game/render/pic_viewer.tscn`: left/right species, `S` shiny, `B` front/back,
-  `T` trainer classes.
-- `game/render/text_viewer.tscn`: Space advances, `F` cycles borders, `C` shows
-  every glyph.
-- `game/battle/battle_screen.tscn`: `A` turn, Space events, `W` switch,
-  left/right matchup, `S`/`D` damage either side. In wild battles, `B` opens
-  the owned-ball selector, left/right changes the ball and Space throws it.
-  Moves are currently random; full move sets decline the learn offer. Use
-  `show_trainer(trainer_class)` for a real party and trainer AI, or
-  `show_matchup` for a fallback pairing.
-- `game/world/world_screen.tscn`: arrows/WASD move Route 29, encounters use
-  imported tables, and `F` fishes only while facing water with an owned rod.
-  Space or `Z` advances casting and bites; F5 saves. The host clock
-  advances one real-time game minute per minute and updates source day
-  boundaries. `P` opens the registered Pokegear phone list. `Enter` or `Tab`
-  opens the start menu (Pokemon, Pack, Pokegear, Save, Exit; Pokedex, Player
-  and Options are listed in their source position but are not implemented
-  yet). Pokemon opens the embedded party screen; Pokegear and Save reach the
-  existing phone list and save path. The imported
-  Players House PC opens the embedded numbered box storage screen and `Esc`
-  closes it. `preview_emote()`, `preview_wild_encounter()`,
-  `preview_fishing_battle()`, `preview_script_event()`,
-  `preview_battle_request()`, `preview_world_battle_loss()`,
-  `preview_capture()` and `preview_party_transaction()` exercise their live
-  paths. The API also exposes swarm/roaming updates, repel countdowns and a
-  JSON-safe snapshot. `V` cycles the registered world renderers. The hint line
-  reports imported service counts.
+| Scene | Keys |
+|---|---|
+| `game/render/pic_viewer.tscn` | left/right species, `S` shiny, `B` front/back, `T` trainer classes |
+| `game/render/text_viewer.tscn` | Space advances, `F` cycles borders, `C` shows every glyph |
+| `game/battle/battle_screen.tscn` | `A` turn, Space events, `W` switch, left/right matchup, `S`/`D` damage either side; in wild battles `B` opens the ball selector, left/right changes ball, Space throws |
+| `game/world/world_screen.tscn` | arrows/WASD move, Space or `Z` confirms, `F` fishes while facing water with an owned rod, `P` opens the phone list, `Enter`/`Tab` opens the start menu, `Esc` closes an overlay, `V` cycles world renderers, F5 saves |
 
-  `tools/preview_world_services.gd` captures the production mart overlay with
-  the deterministic integration cache. `tools/preview_fishing.gd` captures
-  fishing; with an imported cache pass game and map after the output path, such
-  as `silver 2 5`. Its one-argument form remains a fixture smoke test.
+Battle-screen moves are random and a full move set declines the learn offer; use
+`show_trainer(trainer_class)` for a real party and trainer AI, or `show_matchup`
+for a fallback pairing.
 
-  `tools/preview_world_story.gd` exercises real imported map entry callbacks,
-  event-flag object visibility and a facing object interaction without opening
-  the cartridge at runtime. The Crystal home map also covers source decoration
-  callbacks and the long initial event setup script. For example:
+The world screen's start menu wires Pokemon, Pack, Pokegear, Save and Exit;
+Pokedex, Player and Options appear in their source position but do nothing yet.
+The imported Players House PC opens the embedded box storage screen. The host
+clock advances one game minute per real minute and crosses source day
+boundaries. `preview_emote()`, `preview_wild_encounter()`,
+`preview_fishing_battle()`, `preview_script_event()`, `preview_battle_request()`,
+`preview_world_battle_loss()`, `preview_capture()` and
+`preview_party_transaction()` drive their live paths; the API also exposes
+swarm/roaming updates, repel countdowns and a JSON-safe snapshot.
 
-  ```bash
-  godot --headless --path . -s res://tools/preview_world_story.gd -- \
-    crystal 3 19 3 5 1 37,1744
-  ```
+Headless tools, all against a real imported cache:
 
-  The real Crystal bedroom PC and the validated bedroom-to-town warp chain can
-  be checked with:
+| Tool | Checks |
+|---|---|
+| `preview_world_services.gd <png>` | mart overlay, deterministic integration cache |
+| `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
+| `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
+| `validate_crystal_route30_trainer.gd` | trainer record, sight line, approach, battle request, beaten flag, later interaction |
+| `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |
 
-  ```bash
-  godot --headless --path . -s res://tools/preview_world_story.gd -- \
-    crystal 24 7 2 2 1 none home
-  ```
+```bash
+# Crystal map 3/19: block edits, hidden object, facing interaction
+godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
+# bedroom PC and the bedroom-to-town warp chain
+godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
+# the full walked route, ending at the Zephyr Badge
+godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
+```
 
-  The bounded story preview follows production movement from the bedroom to
-  Players House 1F, executes the imported Mom setup with weekday and
-  daylight-saving prompts, reaches the imported New Bark Town teacher scene,
-  enters Elm's lab, completes the source starter and aide Potion events, crosses
-  Route 29 and Cherrygrove to Route 30, runs Mr. Pokémon's Mystery Egg event,
-  resolves the can-lose rival battle and party heal, then returns to Elm's lab
-  for the officer, Egg and five Poké Ball handoffs:
-
-  ```bash
-  godot --headless --path . -s res://tools/preview_world_story.gd -- \
-    crystal 24 7 2 2 1 none home story
-  ```
-
-  A freshly imported Crystal cache can verify the first Route 30 trainer's
-  source record, sight line, approach, battle request, beaten flag and later
-  interaction without reopening the cartridge:
-
-  ```bash
-  godot --headless --path . -s res://tools/validate_crystal_route30_trainer.gd
-  ```
-
-  Ledge hopping is checked the same way, against both games at once: the eight
-  source hop codes, the directions each one accepts, Route 30's own ledge
-  record and the two-cell landing.
-
-  ```bash
-  godot --headless --path . -s res://tools/validate_ledge_hops.gd
-  ```
-
-  World text follows the cartridge command stream: `$50` is a page break,
-  `$57` ends a text box and `$58` pauses for a prompt. The story runner keeps
-  the source yes/no order, weekday wrapping and first eight temporary event
-  flags, which reset on a map reload.
+World text follows the cartridge command stream: `$50` is a page break, `$57`
+ends a text box and `$58` pauses for a prompt. The story runner keeps the source
+yes/no order, weekday wrapping and first eight temporary event flags, which
+reset on a map reload.
 
 ## Tests
 

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -2,14 +2,12 @@ extends Node
 
 ## Runtime selection shared by the launcher and screens opened from it.
 ##
-## Cartridge bytes and decoded data remain owned by their existing layers. The
-## selected save is the one exception: it is mutable, and every screen that
-## reads it has to be looking at the same one.
-##
-## Re-reading the slot per call returned a fresh instance each time, so a battle
-## result, a party transaction and a world snapshot each held a different save
-## and only whichever wrote last survived. The slot is loaded once here and kept
-## until the selection changes or a caller asks for it again from disk.
+## Cartridge bytes and decoded data stay owned by their existing layers. The
+## selected save is the exception: it is mutable, and every screen has to see the
+## same instance. Re-reading the slot per call handed a battle result, a party
+## transaction and a world snapshot three different saves, and only the last
+## write survived. The slot is loaded once and kept until the selection changes
+## or a caller asks for it from disk again.
 
 var selected_game_id: StringName = &""
 var selected_save_slot: int = -1
@@ -21,10 +19,10 @@ var _loaded_mods: Array = []
 
 ## Loads installed mods before any screen exists.
 ##
-## A mod registers what it provides and returns, so this has to happen before the
-## first screen asks the host for one: a renderer registered after the overworld
-## was built would not be offered until the next map. Loading here also means a
-## broken mod is reported while there is still a launcher to report it in.
+## A mod registers what it provides and returns, so this must happen before the
+## first screen asks the host: a renderer registered after the overworld was
+## built would not be offered until the next map. It also means a broken mod is
+## reported while there is still a launcher to report it in.
 func _ready() -> void:
 	load_mods()
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,10 +53,9 @@ an Array of Variants, which made scripts, text and audio 96 MB of a 100 MB
 cache. Write them with `RomCache.write_payload_map()` when the run is a whole
 value in a pointer map, or `RomCache.write_section()` when it is a `bytes`
 field of a record; both move the bytes into a `.bin` blob and leave an
-`[offset, length]` span in the JSON. `GameData` reads the blob as a
-`PackedByteArray` and hands the bytes back under `bytes`. Only a named `bytes`
-field is moved: plenty of cached arrays are small numbers without being
-payloads, and a mart list or an encounter rate must stay an array.
+`[offset, length]` span in the JSON, which `GameData` reads back as a
+`PackedByteArray` under `bytes`. Only a named `bytes` field is moved: a mart
+list or an encounter rate is a small number array, not a payload.
 
 World sections load on first use. The launcher, the pic viewer and a battle
 never read scripts, text or audio, and eagerly reading them made listing three
@@ -66,64 +65,52 @@ Decoders take bytes and return data, with no cartridge knowledge, so small
 hand-built inputs can test them. `game/data/game_data.gd` is the sole
 engine-facing cartridge-content API; it owns the cache and converts JSON's
 single numeric type back to `int`. `game/data/learnset.gd` stays beside it
-because Pokémon can be created outside battle. Do not sort learnsets:
-
-- new-Pokémon filling stops at the first move above its level;
-- levelling reads every entry at the newly reached level.
-
-Muk is out of order in all three games, so these operations intentionally
-differ.
+because Pokémon can be created outside battle. Do not sort learnsets: filling a
+new Pokémon stops at the first move above its level, while levelling reads every
+entry at the newly reached level. Muk is out of order in all three games, so
+these operations intentionally differ.
 
 `game/save/` owns project saves, not cartridge data. Keep its versioned model,
-validator, store and battle adapter scene-free. It validates against
-`GameData` and writes through a temporary file. Project save format 2 owns a
-fixed fourteen-box, twenty-slot PC model, with migration from format 1 that
-does not invent a world snapshot. Party-owned world transactions must update a
-candidate save and live snapshot together, then restore both on a failed write.
-`Gen2SaveStorage` applies the same candidate, validator and temporary-file
-boundary to explicit party-to-box and box-to-party transfers; `box_screen.gd`
-owns selection and presentation only. Keep box names, current-box UI state and
-cartridge SRAM placement outside the model until their source ownership is
-verified.
-The original SRAM adapter is a separate, checksum-aware boundary and remains
-party-focused until cartridge box ownership and layout are explicitly
-researched.
+validator, store and battle adapter scene-free; it validates against `GameData`
+and writes through a temporary file. Format 2 owns a fixed fourteen-box,
+twenty-slot PC model, migrating from format 1 without inventing a world
+snapshot. Party-owned world transactions update a candidate save and live
+snapshot together and restore both on a failed write; `Gen2SaveStorage` applies
+the same boundary to explicit box transfers, and `box_screen.gd` owns selection
+and presentation only. Box names, current-box UI state and cartridge SRAM
+placement stay outside the model until their source ownership is verified. The
+SRAM adapter is a separate, checksum-aware boundary and remains party-focused
+for the same reason.
 
 `game/world/` separates request resolution from UI. `world_api.gd`,
 `world_host.gd` and scene-free service helpers validate imported map records,
 transactions and script result boundaries; `world_service_screen.gd` owns
-labels, selection and input. Map reloads clear the source first eight temporary event flags, while
-permanent event flags and engine flags remain separate. The script runner keeps
-the source yes/no result order and commits clock/daylight-saving changes only
-after the corresponding host prompt completes. Menu layout and
-cursor behavior follow cached vertical or two-dimensional records. Mart dialog
-variants and prices come from imported source lists, and purchases enforce the
-source 99-item stack limit before passing candidate-save validation to writeback.
-Crystal rooftop selection reads the persisted Hall of Fame engine flag. The
-Goldenrod Underground bargain shop is opened by its imported Monday morning
-script, sells one of each item per visit, and records the source daily
-merchant-closed flag after a purchase.
-Phone presentation lists registered
-contacts, dispatches outgoing calls and confirms pending host requests; the world
-runner executes the imported caller/callee script at the same transaction
-boundary. Audio stays behind verified bounded decoder,
-renderer and player layers, with imported records validated before success.
+labels, selection and input. Map reloads clear the source first eight temporary
+event flags; permanent event flags and engine flags stay separate. The script
+runner keeps the source yes/no result order and commits clock/daylight-saving
+changes only after the corresponding host prompt completes. Menus follow cached
+vertical or two-dimensional records. Mart dialog variants and prices come from
+imported lists, purchases enforce the source 99-item stack limit before
+candidate-save validation, Crystal rooftop selection reads the persisted Hall of
+Fame engine flag, and the Goldenrod Underground bargain shop sells one of each
+item per visit and records the daily merchant-closed flag. Phone presentation
+lists contacts and dispatches calls, with the world runner executing the
+imported caller/callee script at the same transaction boundary. Audio stays
+behind bounded decoder, renderer and player layers.
 
-`world_start_menu.gd` is the scene-free model of `engine/menus/start_menu.asm`'s
-item list: it reproduces the source's Pokedex/Pokemon/Pokegear gating and
-`STATICMENU_WRAP` cursor, and still builds Pokedex, Player and Options in
-their source position, marked unavailable, rather than omitting entries this
-project has not implemented. `world_pack.gd` groups owned items into the four
-cartridge pack pockets using the item type byte `GameData` already imports
-under the confusingly-named `pocket` field; it is presentation only; item
-counts stay a flat map on `Gen2WorldState`, and pocket capacities are not
-enforced. `start_menu_screen.gd` is the overlay: it owns Pack and a Save
-confirmation as internal modes the same way `world_service_screen.gd` owns a
-mart mode, and delegates Pokemon and Pokegear to the existing party screen and
-phone list rather than re-implementing them. `Gen2PartyScreen` and
-`Gen2BoxScreen` share one embedded-mode shape: a `set_context(..., embedded)`
-flag and a `closed(result)` signal so the overworld can stack them above the
-running world instead of navigating away with `change_scene_to_file`.
+`world_start_menu.gd` models `engine/menus/start_menu.asm`'s item list: source
+Pokedex/Pokemon/Pokegear gating, the `STATICMENU_WRAP` cursor, and Pokedex,
+Player and Options built in their source position marked unavailable rather than
+omitted. `world_pack.gd` groups owned items into the four cartridge pockets by
+the item type byte `GameData` imports under the confusingly-named `pocket`
+field; it is presentation only, item counts stay a flat map on `Gen2WorldState`
+and pocket capacities are not enforced. `start_menu_screen.gd` is the overlay,
+owning Pack and a Save confirmation as internal modes the way
+`world_service_screen.gd` owns a mart mode, and delegating Pokemon and Pokegear
+to the existing screens. `Gen2PartyScreen` and `Gen2BoxScreen` share one
+embedded-mode shape, a `set_context(..., embedded)` flag and a `closed(result)`
+signal, so the overworld can stack them above the running world instead of
+tearing it down with `change_scene_to_file`.
 
 ### Audio
 
@@ -146,9 +133,8 @@ it; `game/mods/mod_host.gd` is the registry a mod is handed. The world screen
 constructs its renderer through the host, so a registered renderer replaces the
 view without the screen knowing what it draws with. Keep mods away from scene
 nodes and engine internals: a mod reaches cartridge content through `GameData`
-and world state through `Gen2WorldAPI`, both scene-free. See
-[MODS.md](MODS.md) for the contract and why a renderer must not write world
-state.
+and world state through `Gen2WorldAPI`, both scene-free. [MODS.md](MODS.md) has
+the contract and why a renderer must not write world state.
 
 ### Rendering and text
 
@@ -210,10 +196,10 @@ operations in hardware order, including truncation:
 
 Moves are command programs: `move_effect.gd` is the table,
 `effect_commands.gd` the steps, `turn.gd` the handoff and `battle.gd` the
-runner. Unimplemented effects fall back to an ordinary attack. Loops remain
-inside one command, as with multi-hit and all-stat changes. Drain and recoil
-use uncapped `Gen2Turn.damage`, not capped HP loss, so a move calculating 50
-against 3 HP heals 25 or costs 12/13 as the cartridge does.
+runner. Unimplemented effects fall back to an ordinary attack. Loops stay inside
+one command, as with multi-hit and all-stat changes. Drain and recoil use
+uncapped `Gen2Turn.damage`, not capped HP loss, so a move calculating 50 against
+3 HP heals 25 or costs 12/13 as the cartridge does.
 
 Status and substatus are separate. One status is allowed; several substatuses
 and counters live on `Gen2BattleMon`. `CHECK_STATUS` order is recharge, sleep,
@@ -237,23 +223,21 @@ declines automatically.
 
 Trainer details:
 
-- trainer classes and individual trainers are separate tables; class names are
-  shared by gym leaders, while parties store names and rosters;
-- party pointers are walked in class order, not sorted. Class 10 is intentionally
-  empty because its pointer equals class 11;
-- one packed DVs word belongs to each class's whole party;
-- `Gen2BattleAI` chooses the lowest-scored move with random tie-breaking. This
-  matches the result, not the byte-level decrement race, and chooses no
-  switches/items;
-- only implemented `AI_Smart` handlers exist. Unsupported effects use generic
-  scoring; weather-sensitive Razor Wind, Solar Beam and Fly remain absent;
-- trainer experience uses six growth curves. Level 1 is zero, even for Medium
-  Slow, whose literal formula underflows. Experience is not divided among
+- trainer classes and individual trainers are separate tables. Class names are
+  shared by gym leaders; parties store names and rosters, and their pointers are
+  walked in class order, not sorted. Class 10 is intentionally empty because its
+  pointer equals class 11. One packed DVs word covers each class's whole party;
+- `Gen2BattleAI` picks the lowest-scored move with random tie-breaking, matching
+  the result rather than the byte-level decrement race, and never switches or
+  uses items. Only implemented `AI_Smart` handlers exist; unsupported effects use
+  generic scoring, and weather-sensitive Razor Wind, Solar Beam and Fly are
+  absent;
+- experience uses six growth curves and level 1 is zero, even for Medium Slow,
+  whose literal formula underflows. Experience is not divided among
   participants, stat experience is, and only the player side receives it.
   Participants were sent out since the current opponent arrived, excluding
-  fainted members at award time;
-- experience and learning process one level at a time. Level-up HP gains the
-  max-HP difference rather than refilling.
+  members fainted at award time. Levels process one at a time, and a level-up
+  adds the max-HP difference rather than refilling.
 
 `Gen2Battle` returns event lists, not strings or final state. The screen draws
 the event being shown because the turn has already resolved before display;
@@ -265,42 +249,19 @@ keep wording, animation and timing out of the engine.
 Because wrong offsets can decode plausible neighboring data,
 `RomImporter.verify_layout()` must run every check before decoding:
 
-- species names check first/last entries, stride and text mapping; base stats
-  self-identify by Pokédex number;
-- palettes are structurally checked as 15-bit colours, with no species drawn in
-  two blacks; move entries self-identify by animation number and type bytes are
-  range-checked;
-- variable-length move/item names are checked near and far; items also check
-  entry four. Item attributes, status-healing rows and HP-healing rows are
-  checked before import. Keep placeholder names such as `TERU-SAMA` as direct
-  item keys;
-- NPC trades check bounded species, gender and reserved bytes. Their 32-byte
-  shape includes the 11-byte nickname and OT fields, not the ten-byte species
-  name table;
-- font data checks the charmap, blank ranges and required ink. HUD bars must
-  have consecutive fill levels increasing by two lit pixels; borders use text
-  frame shape checks and known bar palettes are checked by value;
-- the type chart checks sparse IDs, the three non-neutral multipliers, exact
-  `$FE`/`$FF` terminators and known content at both ends. `$FE` rows are the
-  Normal/Fighting versus Ghost entries cancelled by Foresight;
-- trainer class name/pic/palette tables cross-check numbering, ends and pic
-  pointers. Parties walk to the next class pointer, including empty class 10,
-  and check counts/endpoints including Falkner's level 7 Pidgey and level 9
-  Pidgeotto and the last class's first name. Attributes validate defined flags
-  and class 1 bytes. DVs anchor both ends to known values; full tables match
-  the published reference byte-for-byte;
-- evolution/learnset pointers address the banked window; methods, species,
-  moves and levels are valid, levels ascend except Muk, and evolution count is
-  known. `EVOLVE_STAT` is four bytes, not three;
-- growth rate and base EXP bytes are checked for all 251 species in all three
-  games;
-- world services check source counts, pointer widths, banked addresses, mart
-  terminators, phone sizes, non-trainer caller-name pointer tables, packed audio
-  headers, cry pointers, shared waves, drumkits and bounded bank-window payloads.
-  Menu headers require valid data pointers and command-derived shape; the script
-  collector validates `phonecall` text pointers and leaves `memcall`/`memjump`
-  addresses to explicit runtime memory snapshots. Malformed bounded-script
-  candidates are ignored.
+| Data | Checks |
+|---|---|
+| Species | First/last names, stride and text mapping; base stats self-identify by Pokédex number |
+| Palettes | Structurally 15-bit colours, no species drawn in two blacks |
+| Moves | Entries self-identify by animation number; type bytes range-checked |
+| Names | Variable-length move/item names near and far; items also check entry four. Item attributes, status-healing and HP-healing rows. Placeholders such as `TERU-SAMA` stay direct item keys |
+| NPC trades | Bounded species, gender and reserved bytes. The 32-byte shape includes the 11-byte nickname and OT fields, not the ten-byte species name table |
+| Font and HUD | Charmap, blank ranges and required ink. HUD bar fill levels increase by two lit pixels; borders use text frame shape checks and bar palettes are checked by value |
+| Type chart | Sparse IDs, the three non-neutral multipliers, exact `$FE`/`$FF` terminators and known content at both ends. `$FE` rows are the Normal/Fighting versus Ghost entries cancelled by Foresight |
+| Trainers | Class name/pic/palette numbering, ends and pic pointers. Parties walk to the next class pointer, including empty class 10, checking counts and endpoints (Falkner's level 7 Pidgey and level 9 Pidgeotto, the last class's first name). Attributes validate defined flags and class 1 bytes; DVs anchor both ends and match the published tables byte-for-byte |
+| Evolutions, learnsets | Pointers address the banked window; methods, species, moves and levels valid, levels ascending except Muk, evolution count known. `EVOLVE_STAT` is four bytes, not three |
+| Growth | Growth rate and base EXP for all 251 species in all three games |
+| World services | Source counts, pointer widths, banked addresses, mart terminators, phone sizes, non-trainer caller-name pointer tables, packed audio headers, cry pointers, shared waves, drumkits and bounded bank-window payloads. Menu headers need valid data pointers and command-derived shape; the script collector validates `phonecall` text pointers, leaves `memcall`/`memjump` to runtime memory snapshots, and ignores malformed candidates |
 
 When adding an offset, add its check. Find data by searching a dump for
 independently known bytes, such as an encoded name or published base stats,
@@ -312,24 +273,19 @@ data but does not belong in this repository.
 
 ## Verify decoded output
 
-Inspect graphics, not only manifests:
+Runtime checks prove shape and endpoints, not every interior value, so inspect
+graphics and tables too:
 
 ```bash
 godot --headless --path . -s res://tools/preview_pics.gd -- gold /tmp/gold.png front
 godot --headless --path . -s res://tools/preview_pics.gd -- crystal /tmp/font.png font
-```
-
-Species contact sheets expose decompression, tile order, palettes and pointer
-errors. `trainers` exposes class palette shifts; `font` and `frames` expose
-charmap gaps. Dump tables for text checks:
-
-```bash
 godot --headless --path . -s res://tools/dump_tables.gd -- gold moves
 ```
 
-Cross-check move properties, Bulbasaur's Tackle/Growl, Eevee's five
-evolutions, Tyrogue's three and growth values against published data. Runtime
-checks prove shape and endpoints, not every interior value.
+Species contact sheets expose decompression, tile order, palette and pointer
+errors; `trainers` exposes class palette shifts; `font` and `frames` expose
+charmap gaps. Cross-check move properties, Bulbasaur's Tackle/Growl, Eevee's
+five evolutions, Tyrogue's three and growth values against published data.
 
 ## Inspect the UI without Play
 
@@ -382,6 +338,17 @@ starts the next turn when needed.
 - Tabs for indentation; static typing where practical.
 - `snake_case` for variables, functions and files; `PascalCase` for classes and
   nodes.
-- Comment only non-obvious constraints.
 - `.tscn` and `.tres` are plain-text format 3. Edit them directly. Do not invent
   `uid://` values; omit invalid fields and let Godot regenerate them.
+
+## Writing
+
+Comments and docs earn their length. Comment non-obvious constraints, source
+quirks and the disassembly symbol a rule came from; do not restate what the code
+says or argue at length that a decision was right. A source symbol plus a
+one-line reason is the target.
+
+State each fact once, where it is enforced, and link rather than repeat: source
+findings and constants near the code, contracts in `docs/`, current status in
+the project's own status notes. When something changes, replace the old text
+instead of appending a correction to it.

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -52,11 +52,11 @@ block and palette data the 2D view reads and extrudes geometry from it.
 
 ## Replacing the world renderer
 
-The 2D renderer reads the world and draws it. Nothing about the world requires
-that the drawing be 2D: maps are node-free `RefCounted` records, each tileset is
-one addressable atlas, animated tiles replace atlas slots rather than map
-rectangles, and collision is a raw permission byte per 2x2 walk cell. A renderer
-that extrudes geometry from that same data is a registration, not a fork.
+Nothing about the world requires that the drawing be 2D: maps are node-free
+`RefCounted` records, each tileset is one addressable atlas, animated tiles
+replace atlas slots rather than map rectangles, and collision is a raw
+permission byte per 2x2 walk cell. A renderer that extrudes geometry from that
+same data is a registration, not a fork.
 
 A registered renderer is a `Node` providing:
 
@@ -79,8 +79,7 @@ Two methods are optional:
 
 A view built out of geometry cannot be drawn into a 160x144 buffer and then
 magnified, so the second layer is what makes a 3D or HD renderer possible at
-all. Text boxes and menus keep being drawn in hardware pixels over the top,
-which is what an HD presentation of these games wants: the world gains
+all. Text boxes and menus stay hardware pixels over the top: the world gains
 resolution, the interface stays a Game Boy.
 
 The host constructs a renderer per world, so `select_world_renderer()` can
@@ -91,26 +90,22 @@ state and must not write it. Two views of one world have to agree.
 
 ## Logical world state and optional mod pose
 
-The normal game remains logically grid-based. The player and NPCs occupy walk
-cells, movement commits one cell at a time in the four cardinal directions, and
-interactions use the current logical cell plus one of the four cardinal facing
-directions. The original hardware may animate a sprite between cells during a
-step, but that visual progress does not change the source interaction model.
+The game stays logically grid-based. The player and NPCs occupy walk cells,
+movement commits one cell at a time in the four cardinal directions, and
+interactions use the current logical cell plus one cardinal facing. Animating a
+sprite between cells does not change that model.
 
 A movement mod may add a more precise pose for smooth, analog, first-person or
-3D movement. That pose can contain a sub-cell position and an arbitrary facing
-angle, but it is an optional mod layer, not a replacement for the authoritative
-world state. The core world remains responsible for collision, logical cell
-transitions, map triggers, warps and script or NPC interactions.
+3D movement, with a sub-cell position and an arbitrary facing angle. It is an
+extra layer, not a replacement: the core world stays responsible for collision,
+cell transitions, map triggers, warps and script or NPC interactions, and a mod
+must not overwrite the authoritative cell or bypass those boundaries.
 
-When a mod requests an interaction, it must project its pose back onto the
-normal rules. Resolve a deterministic logical cell, quantize the precise facing
-angle to one of the four source directions, and pass that cell and direction to
-the existing interaction path. Use the source tie-breaking behavior when an
-angle lies between directions. A mod must not directly replace the world's
-authoritative cell or bypass its collision and event boundaries. This lets a
-mod provide smooth movement while an NPC in the neighboring logical cell still
-interacts exactly as it would in the original game.
+When a mod requests an interaction it projects its pose back onto the normal
+rules: resolve a deterministic logical cell, quantize the facing angle to one of
+the four source directions using the source tie-breaking, and pass both to the
+existing interaction path. Smooth movement then leaves an NPC in the
+neighbouring cell interacting exactly as it would on the cartridge.
 
 ## Measured against the voxel mod
 
@@ -118,65 +113,53 @@ interacts exactly as it would in the original game.
 is the reference for what a renderer mod has to be able to do. It turns
 gen1recomp's overworld into a voxel diorama with selectable camera pitch,
 first- and third-person free-roam, VR through OpenXR, water reflections and a
-day cycle, and it ships no cartridge art: geometry is derived from the tile and
+day cycle, shipping no cartridge art: geometry is derived from the tile and
 sprite data the host already has.
 
-What the contract above already supports:
+Supported by the contract above:
 
 - deriving geometry from host data. Collision permissions, the block grid, the
   tileset atlas and its palettes are all reachable through `Gen2WorldAPI` and
-  `GameData` with no cartridge access and no authored 3D assets;
+  `GameData`, with no cartridge access and no authored 3D assets;
 - rendering at the window's resolution rather than the hardware's;
 - switching views mid-session on a keybind, with no world state involved;
-- a day cycle. `set_time_of_day` is called on the source 04:00, 10:00 and 18:00
-  boundaries, and the palette rows behind it are the cartridge's own;
-- animated tiles. `Gen2WorldAnimation` replaces atlas slots rather than map
-  rectangles, so geometry textured from the atlas follows water and flowers
-  without the renderer knowing an animation ran.
-
-What the contract above now also supports:
-
-- a movement progress value. `Gen2WorldAPI.player_step_offset_cells()` returns
-  the player's in-flight walk step as a fractional cell, from one cell behind
-  `player_cell` down to zero, paced by `advance_player_step(delta)` at the
-  same hardware-frame rate and stall cap `Gen2WorldAnimation` uses. The
-  logical cell still commits at the start of the step, exactly as documented
-  above; the fractional value is presentation only and never reaches
-  collision, events or the world snapshot. `mods/examples/voxel_preview/`
-  reads it for its player box and camera instead of snapping.
-- the same progress value for NPCs. `Gen2WorldObject.step_offset_cells()`
-  returns a wandering or following object's in-flight step as a fractional
-  cell, on the same terms as the player's. `Gen2WorldAPI.advance_object_steps()`
-  paces the wandering and spinning movement templates at the source's own step
-  and wait durations, and the example renderer reads the offset for its object
-  markers.
+- a day cycle, through `set_time_of_day` on the source 04:00, 10:00 and 18:00
+  boundaries, over the cartridge's own palette rows;
+- animated tiles, because `Gen2WorldAnimation` replaces atlas slots rather than
+  map rectangles, so geometry textured from the atlas follows water and flowers
+  without the renderer knowing an animation ran;
+- movement progress. `Gen2WorldAPI.player_step_offset_cells()` and
+  `Gen2WorldObject.step_offset_cells()` return an in-flight step as a fractional
+  cell, from one cell behind the committed cell down to zero, paced by
+  `advance_player_step(delta)` and `advance_object_steps()` at the hardware
+  frame rate and stall cap `Gen2WorldAnimation` uses. The logical cell still
+  commits at the start of the step; the fraction is presentation only and never
+  reaches collision, events or the world snapshot.
+  `mods/examples/voxel_preview/` reads both.
 
 What is still missing, in the order it blocks work:
 
-1. **Per-tile height.** Extruded height here is a guess from the collision
+1. **Per-tile height.** Extruded height is a guess from the collision
    permission, which cannot tell a tree from a cliff from a building. Gen II
-   has no height data; a renderer needs a per-block table it supplies itself,
-   and the host should let a mod attach one rather than have each renderer
-   hard-code Johto.
+   has no height data, so a renderer needs a per-block table it supplies
+   itself, and the host should let a mod attach one rather than have every
+   renderer hard-code Johto.
 2. **Battles and interiors are not renderer-owned.** `Gen2BattleScreen` builds
-   its own 160x144 presentation directly and does not go through the mod host,
+   its own 160x144 presentation directly instead of going through the mod host,
    so the voxel mod's 3D battles have no equivalent here. Battle presentation
    needs the same registration the world renderer has.
-3. **No camera boundary.** The screen decides the visible page through
-   `Gen2WorldAPI.visible_origin_cell()`, which still follows the committed
-   cell rather than the interpolated one, so a free camera pans a step early.
-   A free camera would need the world to stop being the thing that frames the
-   view.
+3. **No camera boundary.** `Gen2WorldAPI.visible_origin_cell()` still follows
+   the committed cell rather than the interpolated one, so a free camera pans a
+   step early. A free camera needs the world to stop framing the view.
 4. **No input hook.** Camera pitch, first person and free-roam are all input a
-   mod would have to receive, and the world screen currently reads keys itself.
-5. **Scripted movement does not interpolate.** `applymovement` streams still
-   place objects a whole cell at a time, and so do the jump, teleport and
-   boulder step types. The wandering, spinning, following, player and
-   trainer-approach paths all carry the sub-cell offset.
+   mod would have to receive, and the world screen reads keys itself.
+5. **Scripted movement does not interpolate.** `applymovement` streams, and the
+   jump, teleport and boulder step types, still place objects a whole cell at a
+   time. The wandering, spinning, following, player and trainer-approach paths
+   all carry the sub-cell offset.
 
-Nothing in that list changes the world's own data, which is the part that
-matters: they are all presentation boundaries that do not exist yet, not
-decisions that have been made the wrong way.
+All five are presentation boundaries that do not exist yet; none of them
+changes the world's own data.
 
 ## Not built yet
 

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -15,14 +15,14 @@ The exact revisions used by the local workflow are recorded in
 | Crystal | [pret/pokecrystal](https://github.com/pret/pokecrystal) | `5593381195342e481b69a2fd4ab25e202ddcf708` | Maps, scripts, events, data, battle behavior |
 | Gold and Silver | [pret/pokegold](https://github.com/pret/pokegold) | `add1dbe018170d7f25f7b7360e8046cec6354906` | Maps, scripts, events, data, battle behavior |
 
-The lock file is the machine-readable source of truth. The revisions are
-deliberately pinned so that source comparisons remain reproducible. The branch
-name recorded there is the upstream branch used when each revision was pinned;
-it is not used as a substitute for the commit hash.
+The lock file is the machine-readable source of truth; revisions are pinned so
+source comparisons stay reproducible. The branch name recorded there is the
+upstream branch used when each revision was pinned, never a substitute for the
+commit hash.
 
 ## Local checkout workflow
 
-Run these commands from the project root:
+Run from the project root:
 
 ```sh
 bash tools/fetch_reference_sources.sh
@@ -30,25 +30,24 @@ bash tools/reference_status.sh
 bash tools/reference_status.sh --remote
 ```
 
-The default checkout root is `.references/`. It is ignored by the project and
-is safe to remove and recreate. Set `GEN2_REFERENCE_ROOT` or pass a first
-argument to either script to use another local directory:
+The fetch script clones a missing repository, fetches the locked revision and
+checks it out detached. An existing checkout must have the expected origin and
+no local edits: the script refuses to replace local work or silently move to
+another revision. The status script reports each checkout as missing, dirty, at
+the wrong revision or ready; `--remote` also reports when the recorded upstream
+branch has moved past the pin.
+
+The default checkout root is `.references/`, ignored by the project and safe to
+remove and recreate. Set `GEN2_REFERENCE_ROOT`, or pass a first argument to
+either script, to use another directory:
 
 ```sh
 GEN2_REFERENCE_ROOT=/path/to/reference-cache bash tools/fetch_reference_sources.sh
 bash tools/reference_status.sh /path/to/reference-cache
 ```
 
-The fetch script clones a missing repository, fetches the locked revision, and
-checks it out detached. Existing repositories must have the expected origin
-and no local edits. The script refuses to replace local work or silently move
-the checkout to another revision.
-
-The status script reports whether each checkout is missing, dirty, at the wrong
-revision, or ready for comparison. With `--remote`, it also reports when the
-recorded upstream branch has moved beyond the pinned revision. Updating a pin
-is a deliberate maintenance change: inspect the source changes, update
-`references.lock`, and document the reason in the relevant project handoff.
+Updating a pin is deliberate maintenance: inspect the source changes, update
+`references.lock`, and record why.
 
 ## Source lookup guide
 
@@ -66,8 +65,7 @@ The two repositories use closely related paths. Check the matching path in
 | Wild encounters | `data/wild/*.asm`, `data/wild/fish.asm` |
 | Trainer parties and data | `data/trainers/parties.asm`, the matching trainer data files |
 
-When a source fact changes runtime behavior, record the source file and symbol
-near the implementation or in the project handoff. For facts tied to a
-particular source revision, record the pinned commit as well. Source-derived
-data should stay outside tracked files unless it is a small, verified runtime
-table or test fixture required by the project.
+When a source fact changes runtime behavior, record the file and symbol next to
+the implementation, plus the pinned commit if the fact is revision-specific.
+Source-derived data stays outside tracked files unless it is a small, verified
+runtime table or test fixture the project requires.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -47,9 +47,9 @@ they start at map group 24, map 7, cell 3,3 with 3000 money, from Crystal's
 `SPAWN_HOME` and `START_MONEY`. The imported Elm's Lab scripts offer Chikorita,
 Cyndaquil or Totodile at level 5 holding Berry; the party host creates the first
 save Pokémon only after the player confirms the source choice. The party screen
-shows all six positions, current and maximum HP, and persistent status; it
-starts the development battle only after the same validated slot is selected in
-`GameRuntime`.
+shows all six positions, current and maximum HP and persistent status, and
+starts the development battle only once `GameRuntime` holds the same validated
+slot.
 
 After battle messages finish, `Gen2SaveBattleAdapter` writes player name,
 Pokémon identity, held item, happiness, Pokerus, caught data, nickname, OT, HP,
@@ -57,36 +57,35 @@ status, experience, DVs, stat experience, moves and PP. Volatile state is
 discarded.
 
 Overworld writeback is transactional. A confirmed win saves after result
-messages finish. A loss never overwrites the selected slot: the host validates
-and reconstructs the source save party, then returns blackout recovery.
-Continue enters the overworld only when a validated snapshot exists; F5 writes
-map, player, items, currency, events, source engine flags and schedule state
-through `Gen2SaveStore`. Daily engine flags reset when the saved world day
-changes, while story flags such as Hall of Fame persist. Legacy saves without a
-snapshot keep the configured development entry because migration does not
-invent a world position. Item and currency references are
-checked against the selected cache, and `Gen2WorldAPI.open_snapshot()` restores
-the saved position without clamping it elsewhere.
+messages finish; a loss never overwrites the slot, and the host validates and
+reconstructs the source save party before returning blackout recovery. Continue
+enters the overworld only with a validated snapshot; F5 writes map, player,
+items, currency, events, source engine flags and schedule state through
+`Gen2SaveStore`, with item and currency references checked against the selected
+cache. Daily engine flags reset when the saved world day changes while story
+flags such as Hall of Fame persist. Saves without a snapshot keep the configured
+development entry, since migration invents no world position, and
+`Gen2WorldAPI.open_snapshot()` restores a saved position without clamping it.
 
-The party screen opens `box_screen.tscn`, which presents one of fourteen numbered
-boxes at a time with twenty fixed slots and a party selection column. Depositing
-uses the current box's first free slot; withdrawal requires party capacity. Both
-directions use `Gen2SaveStorage` to validate and write a candidate save before
-updating the shared runtime object. The screen's current box is transient UI
-state, and box names and cartridge SRAM placement remain outside the model.
+`box_screen.tscn`, opened from the party screen or from the imported Players
+House PC as an embedded overworld overlay, presents one numbered box at a time
+with twenty fixed slots and a party selection column. Depositing uses the
+current box's first free slot, withdrawal requires party capacity, and both go
+through `Gen2SaveStorage` to validate and write a candidate save before the
+shared runtime object changes. The last party member cannot be boxed. The
+current box is transient UI state; box names and SRAM placement stay outside the
+model. Closing the embedded overlay resumes the paused source script with no
+decoration change. Selected runtime saves persist transfers; injected scene-test
+and development saves use the validated in-memory candidate without writing a
+slot.
 
-The imported Players House PC opens the same box screen as an embedded
-overworld overlay. Its close result resumes the paused source script with no
-decoration change. Selected runtime saves persist transfers through the same
-candidate-save boundary; injected scene-test and development saves use the
-validated in-memory candidate without writing a slot.
-
-Party-owned overworld transactions first modify a candidate `Gen2SaveData` and
-live world snapshot. Gifts, eggs, NPC trades, source `HealParty` recovery, item
-effects and catches commit only after validation and optional persistence; a failed write restores live
-world state. A full party routes a valid addition to the first free PC slot. If
-the party and all 280 box slots are occupied, the transaction refuses before
-consuming an item or ball and leaves the save and world state unchanged.
+Party-owned overworld transactions modify a candidate `Gen2SaveData` and the
+live world snapshot first. Gifts, eggs, NPC trades, source `HealParty` recovery,
+item effects and catches commit only after validation and optional persistence,
+and a failed write restores live world state. A full party routes a valid
+addition to the first free PC slot; with the party and all 280 box slots
+occupied the transaction refuses before consuming an item or ball, leaving save
+and world state unchanged.
 
 ## Original Generation 2 shape
 

--- a/game/audio/gen2_audio_decoder.gd
+++ b/game/audio/gen2_audio_decoder.gd
@@ -3,12 +3,11 @@ extends RefCounted
 
 ## Bounded decoder for the Gen II music, SFX and cry streams.
 ##
-## The importer keeps the original bank/address and a bounded byte window for
-## every record. This decoder follows the command table used by the cartridge,
-## including little-endian stream pointers, note-duration accumulation,
-## subroutine returns and counted/infinite loops. It returns events rather than
-## touching an audio device, which keeps the cartridge format testable in
-## headless runs and lets the playback layer choose its output rate.
+## The importer keeps the original bank/address and a bounded byte window per
+## record. This follows the cartridge's command table: little-endian stream
+## pointers, note-duration accumulation, subroutine returns, counted and infinite
+## loops. It returns events rather than touching an audio device, so the format
+## stays testable headless and the playback layer picks its own output rate.
 
 const FIRST_MUSIC_COMMAND: int = 0xD0
 const SOUND_RETURN: int = 0xFF

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -40,14 +40,11 @@ func play_record(
 	if request_kind == &"music_fadeout":
 		return {"ok": true, "played": fade_out(int(record.get("fade_time", 0)))}
 	var music: bool = _is_music(request_kind)
-	# The music that is already playing is not started again. Two connected maps
-	# with the same header music are one continuous track on the cartridge, and
-	# restarting it at every map edge is audible.
-	#
-	# The comparison is against the last track started rather than against
-	# whether a channel is still sounding, which is what the cartridge compares:
-	# it keeps the current music id and skips when the new map asks for the same
-	# one. Stopping or fading clears the id, so those still start it again.
+	# Music already playing is not restarted: two connected maps with the same
+	# header music are one continuous track, and restarting at each map edge is
+	# audible. The comparison is against the last track started, not against
+	# whether a channel still sounds, which is what the cartridge compares.
+	# Stopping or fading clears the id, so those do start it again.
 	var key: String = "%d:%d" % [int(record.get("bank", -1)), int(record.get("address", -1))]
 	if music and not restart and key == _music_key:
 		return {"ok": true, "played": false, "continued": true}

--- a/game/battle/accuracy.gd
+++ b/game/battle/accuracy.gd
@@ -3,14 +3,12 @@ extends RefCounted
 
 ## Whether a move connects.
 ##
-## Accuracy is a byte out of 255 rather than a percentage, so a move that is
-## "100%" stores 255 and one that is "90%" stores 229. That is not a detail worth
-## converting away: the roll is against the same byte, and the cartridge treats a
-## stored 255 as a special case that never misses, which a percentage would lose.
+## Accuracy is a byte out of 255, not a percentage: "100%" stores 255 and "90%"
+## stores 229. Kept as the byte, because the roll is against it and a stored 255
+## is a special case that never misses.
 ##
-## Accuracy and evasion have their own multiplier table, separate from the one
-## the other stats use. The two curves are not the same shape, so a stage of -1
-## on accuracy and a stage of -1 on Attack are different fractions.
+## Accuracy and evasion use their own multiplier table, a different shape from
+## the other stats', so -1 accuracy and -1 Attack are different fractions.
 
 ## The move accuracy that cannot miss. Anything the stages leave below this rolls.
 const ALWAYS_HITS: int = 255
@@ -26,14 +24,12 @@ const STAGE_MULTIPLIERS: Array = [
 
 ## The chance a move connects, out of 255.
 ##
-## Evasion is applied by reading the same table from the other end, which is what
-## the cartridge does rather than keeping a second table: the multiplier for an
-## evasion of +2 is the one accuracy uses at -2.
+## Evasion reads the same table from the other end rather than a second table:
+## +2 evasion is the multiplier accuracy uses at -2.
 ##
-## [param foresight] is whether the defender has been identified, which drops
-## both sides' stages rather than only the evasion. It is narrower than it
-## sounds: the cartridge only skips them when the evasion stage is at least the
-## accuracy stage, so Foresight cannot undo an accuracy the attacker has raised.
+## [param foresight] drops both sides' stages, not only evasion, and only when
+## the evasion stage is at least the accuracy stage, so it cannot undo an
+## accuracy the attacker raised.
 static func chance(
 	move_accuracy: int,
 	accuracy_stage: int = 0,

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -3,34 +3,24 @@ extends RefCounted
 
 ## Scores an enemy trainer's move choice the way the cartridge's own AI does.
 ##
-## Every slot starts at 20; a slot with no PP starts at 80. Each bit set in the
-## trainer class's own [constant RomLayout.ATTR_AI_MOVE_WEIGHTS] word runs one
-## scoring layer over the four slots, in the cartridge's own bit order (see
-## [constant RomLayout.AI_BASIC] through [constant RomLayout.AI_RISKY]), each
-## nudging a score up (discourage) or down (encourage). The move with the
-## lowest score wins; a tie is broken at random.
+## Every slot starts at 20, or 80 with no PP. Each bit set in the trainer class's
+## [constant RomLayout.ATTR_AI_MOVE_WEIGHTS] word runs one scoring layer over the
+## four slots in the cartridge's bit order ([constant RomLayout.AI_BASIC] through
+## [constant RomLayout.AI_RISKY]), nudging scores up (discourage) or down
+## (encourage). Lowest score wins, ties broken at random.
 ##
-## [RefCounted], scene-free and its randomness passed in, the same discipline
-## [Gen2Battle] holds to, so a whole AI decision can be asserted on inside a
-## test.
+## [RefCounted], scene-free, randomness injected, so a whole decision can be
+## asserted on in a test.
 ##
-## The real routine (`engine/battle/ai/scoring.asm` in pokecrystal) picks the
-## lowest score by decrementing every slot's counter once per pass until one
-## reaches zero, then walking backward to give every tied slot the same
-## outcome before choosing among them at random. That is provably the same
-## thing as finding the minimum and breaking ties at random directly, which is
-## what [method choose_slot] does: the byte-level race is how eight-bit
-## hardware computes an argmin without a MIN instruction, not a rule of its
-## own to reproduce.
+## `engine/battle/ai/scoring.asm` finds that minimum by decrementing every slot's
+## counter per pass until one reaches zero, then walking backward to give tied
+## slots the same outcome. That is an argmin without a MIN instruction, not a
+## rule of its own, so [method choose_slot] takes the minimum directly.
 ##
-## Every percent chance below uses the cartridge's own "X percent" macro
-## (`X * 255 / 100`, truncated) rather than the odd byte a handful of call
-## sites add or subtract one from for a marginally different threshold; the
-## difference is at most one part in 256 and not worth the loss of a single
-## readable helper.
+## Percent chances use the cartridge's `X * 255 / 100` macro rather than the odd
+## byte a few call sites adjust by one; the difference is one part in 256.
 ##
-## What is here does not cover every trainer AI flag or every move's own
-## scoring handler; see [code]HANDOFF.md[/code] for what is and is not.
+## Not every AI flag or per-move handler exists yet.
 
 ## A move nobody can use, whatever the layers think of it.
 const DEFAULT_SCORE: int = 20
@@ -74,33 +64,18 @@ const STALL_MOVE_NUMBERS: Array = [
 ## at all by then: `data/battle/ai/residual_moves.asm` in pokecrystal.
 const RESIDUAL_MOVE_NUMBERS: Array = [54, 73, 77, 78, 86, 116, 117, 139, 144, 160, 164, 191]
 
-## The effect bytes with a scoring handler of their own, out of
-## `AI_Smart_EffectHandlers` in pokecrystal, restricted to the effects this
-## engine actually implements: an effect nobody has written a battle sequence
-## for yet cannot be tested against a real cartridge's choice, so it is left
-## to the generic layers rather than guessed at. See "What to do next" in
-## [code]HANDOFF.md[/code] for what pret's own table covers beyond this.
-##
-## Razor Wind, Solar Beam and Fly's own handlers are deliberately absent: all
-## three read weather or move-specific setup state that is not part of the
-## generic scoring layers. The battle now tracks Fly and Dig's flags, but that
-## is not enough to reproduce the AI handler's full weather and setup checks.
-
 
 ## Picks a move slot for [param attacker] to use against [param defender], the
 ## way [param ai_move_weights] (a trainer class's own
 ## [constant RomLayout.ATTR_AI_MOVE_WEIGHTS]) says to score it.
 ##
-## [param attacker_turns_taken] and [param defender_turns_taken] are how many
-## turns each side has already acted this battle, which only
-## [constant RomLayout.AI_SETUP] and [constant RomLayout.AI_CAUTIOUS] read, and
-## only to ask whether this is the very first one. Nothing in [Gen2Battle] counts
-## these yet, so a caller with no count of its own can leave both at zero, which
-## is the state that actually holds for the first turn of every battle.
+## [param attacker_turns_taken] and [param defender_turns_taken] are turns
+## already acted, read only by [constant RomLayout.AI_SETUP] and
+## [constant RomLayout.AI_CAUTIOUS] and only to ask whether this is the first.
+## [Gen2Battle] does not count them yet, so zero is the honest default.
 ##
-## Returns a slot in range even when nothing is usable: [method Gen2Battle.move_for]
-## already turns an unusable slot into Struggle, whichever one is named, so the
-## AI does not need a case of its own for a Pokémon with nothing left to spend.
+## Always returns a slot in range: [method Gen2Battle.move_for] turns an
+## unusable slot into Struggle, so no empty-moveset case is needed here.
 static func choose_slot(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -211,17 +186,13 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, 255) < 50
 
 
-## [constant RomLayout.AI_BASIC]: don't do anything redundant. A status move
-## whose target already carries a status does nothing on the cartridge, and so
-## do Confuse Ray or Supersonic against an already-confused target, Disable or
-## Encore against an already-locked target, Attract against a target already
-## in love or of the same or an unknown gender, and Mist or Focus Energy used
-## a second time by the attacker itself, which is why those two read the
-## attacker's own state rather than the defender's. The rest of
-## `AI_Redundant`'s own table (Light Screen while it is already up, a
-## Substitute already standing, and so on) reads state this engine does not
-## carry yet and so never fires, which reads as "not redundant" rather than as
-## a wrong answer.
+## [constant RomLayout.AI_BASIC]: nothing redundant. A status move against an
+## already-statused target, confusion against a confused one, Disable or Encore
+## against a locked one, Attract against a target already in love or of the same
+## or unknown gender, and a second Mist or Focus Energy, which is why those two
+## read the attacker rather than the defender. `AI_Redundant`'s remaining rows
+## (Light Screen already up, a standing Substitute) read state this engine does
+## not carry, so they never fire and read as "not redundant".
 static func _apply_basic(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int
@@ -253,11 +224,9 @@ static func _apply_basic(
 			_discourage(scores, slot)
 
 
-## [constant RomLayout.AI_SETUP]: use a stat move on the very first turn.
-## Raising a stat is encouraged only on the attacker's own first turn and
-## lowering one only on the defender's; past that, both are heavily
-## discouraged, because a stat move that has missed its opening is mostly
-## wasted tempo.
+## [constant RomLayout.AI_SETUP]: use a stat move on the first turn. Raising is
+## encouraged only on the attacker's first turn and lowering only on the
+## defender's; past that both are heavily discouraged.
 static func _apply_setup(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, atk_turns: int, def_turns: int
@@ -496,12 +465,10 @@ static func _apply_opportunist(
 ## ([constant RECKLESS_EFFECTS]) or does one point of damage that is really a
 ## fixed-damage move ([code]power < 2[/code]).
 ##
-## The estimate is [constant Gen2Damage.MAX_VARIATION] and never a critical,
-## the top of a hit's real range: the cartridge's own `AIDamageCalc` special-
-## cases a handful of fixed-damage effects this engine does not implement yet,
-## so those are estimated by the ordinary formula instead of exactly, which
-## only matters for how hard they are ranked against the rest, not whether
-## they are chosen as the strongest.
+## The estimate is [constant Gen2Damage.MAX_VARIATION] with no critical, the top
+## of a hit's real range. `AIDamageCalc` special-cases fixed-damage effects this
+## engine does not implement, so those use the ordinary formula: that shifts how
+## hard they rank, not which move is strongest.
 static func _apply_aggressive(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int
@@ -542,14 +509,10 @@ static func _estimate_damage(attacker: Gen2BattleMon, defender: Gen2BattleMon, m
 ## [constant RomLayout.AI_CAUTIOUS]: discourage [constant RESIDUAL_MOVE_NUMBERS]
 ## once it is no longer the attacker's first turn.
 ##
-## pret's own routine has a documented bug here (see
-## `docs/bugs_and_glitches.md`'s "'Cautious' AI may fail to discourage
-## residual moves"): a missed roll on one residual move stops it from
-## checking any of the rest of that mon's moves at all, rather than moving on
-## to the next slot. This implements the fix pret's own docs give rather than
-## the bug, the same call [code]Gen2EffectCommands._belly_drum[/code] makes
-## for Belly Drum's HP threshold; see [code]HANDOFF.md[/code] if bug-for-bug
-## fidelity turns out to matter here after all.
+## Diverges from a documented source bug (`docs/bugs_and_glitches.md`,
+## "'Cautious' AI may fail to discourage residual moves"): a missed roll there
+## abandons the remaining slots instead of moving on. This implements pret's own
+## fix, the same call [code]Gen2EffectCommands._belly_drum[/code] makes.
 static func _apply_cautious(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int
@@ -565,10 +528,9 @@ static func _apply_cautious(
 
 
 ## [constant RomLayout.AI_STATUS]: dismiss a status move the defender's typing
-## already shrugs off. Toxic and Poison fold into the general type check
-## rather than needing their own poison-type shortcut, because a Poison-type
+## shrugs off. Toxic and Poison need no poison-type shortcut, since a Poison-type
 ## defender against a Poison-type move already reads
-## [constant RomLayout.MATCHUP_NO_EFFECT] out of the real matchup chart.
+## [constant RomLayout.MATCHUP_NO_EFFECT] out of the real chart.
 static func _apply_status(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -3,21 +3,17 @@ extends RefCounted
 
 ## A battle: two parties, a turn at a time.
 ##
-## [RefCounted] and scene-free, with its randomness injected, so a whole battle
-## can be fought inside a test with no display. It knows nothing about how a
-## battle is drawn.
+## [RefCounted], scene-free, randomness injected, so a whole battle can be fought
+## in a test with no display.
 ##
-## A turn answers with a list of events rather than with a new state or a string.
-## An event says what happened and carries the numbers behind it; turning that
-## into a sentence, an animation or a bar that drains is the screen's job, and
-## keeping the two apart is what lets a battle be asserted on rather than read.
+## A turn answers with a list of events, not a new state or a string. An event
+## says what happened and carries its numbers; sentences, animation and draining
+## bars are the screen's job.
 ##
-## A side is a party, and a wild encounter is a party of one. Two things are the
-## caller's to decide rather than this class's, because the cartridge asks a
-## person or an AI for both and neither exists yet: which action a side takes,
-## and who replaces a Pokémon that has fainted. A turn that ends with somebody
-## down stops there and says so through [method must_replace]; nothing is sent
-## out until [method send_out] is called.
+## A side is a party, and a wild encounter is a party of one. The caller decides
+## which action a side takes and who replaces a fainted Pokémon: a turn that ends
+## with somebody down stops and says so through [method must_replace], and
+## nothing is sent out until [method send_out].
 
 ## The two sides, as plain numbers rather than an enum: they are dictionary keys
 ## and event payloads throughout, and an enum buys nothing where everything that
@@ -82,11 +78,10 @@ const WITHDREW: StringName = &"withdrew"
 const SENT_OUT: StringName = &"sent_out"
 const OVER: StringName = &"over"
 
-## Experience, once whoever fainted's own opponent has somebody left to award
-## it to. Never emitted for [constant ENEMY]: the cartridge's own
-## [code]GiveExperiencePoints[/code] only ever reads the player's own party
-## structure, so a trainer's Pokémon are never on the receiving end of this,
-## only ever the reason for it.
+## Experience, once the fainted Pokémon's opponent has somebody to award it to.
+## Never emitted for [constant ENEMY]: [code]GiveExperiencePoints[/code] only
+## reads the player's party structure, so a trainer's Pokémon are the reason for
+## this, never the recipient.
 const EXP_GAINED: StringName = &"exp_gained"
 ## The five stats in [constant Gen2Experience.STAT_EXP_KEYS], split among
 ## [constant Gen2Battle] participants the way [method Gen2Experience.stat_exp_gain]
@@ -107,27 +102,24 @@ const MOVE_FORGOTTEN: StringName = &"move_forgotten"
 const MOVE_DECLINED: StringName = &"move_declined"
 
 ## Disable, Attract, Encore, Mist and Focus Energy each refuse for their own
-## reason (a target with nothing to disable, a same-gender or genderless
-## target, an already-encored target, and so on) rather than missing or doing
-## nothing to a type: not [constant MISSED], whose accuracy was rolled and
-## lost, and not [constant NO_EFFECT], which is about a type matchup. One event
-## for every one of the five, the same "but it failed!" the cartridge shares
-## across all of them.
+## reason (nothing to disable, a same-gender or genderless target, an already
+## encored target) rather than missing a roll ([constant MISSED]) or losing to a
+## type ([constant NO_EFFECT]). One event for all five, the "but it failed!" the
+## cartridge shares across them.
 const MOVE_FAILED: StringName = &"move_failed"
 
 ## Disable locked a slot, and later let it go. [code]slot[/code] and
-## [code]move[/code] on the first are the target's own, read off
-## [member Gen2BattleMon.disabled_slot] before it moves; the belt-and-suspenders
-## refusal for a Pokémon that is still locked into the disabled move itself is
-## [constant CANNOT_MOVE]'s own [code]&"disabled"[/code] reason, not this.
+## [code]move[/code] on the first are the target's, read off
+## [member Gen2BattleMon.disabled_slot] before it moves. A Pokémon still locked
+## into the disabled move is refused through [constant CANNOT_MOVE]'s
+## [code]&"disabled"[/code] reason, not here.
 const DISABLE_INFLICTED: StringName = &"disable_inflicted"
 const DISABLE_ENDED: StringName = &"disable_ended"
 
-## Attract's own two events: falling in love, which is
-## [constant Gen2Substatus.ATTRACTED] set and stays set until a switch, and the
-## turn a fresh roll finds the target too smitten to move, which is
-## [constant CANNOT_MOVE]'s own [code]&"attract"[/code] reason rather than an
-## event of its own, the same shape flinch and confusion already use.
+## Attract's two events: falling in love, [constant Gen2Substatus.ATTRACTED] set
+## until a switch, and a turn where a fresh roll finds the target too smitten to
+## move, which is [constant CANNOT_MOVE]'s [code]&"attract"[/code] reason rather
+## than an event, the shape flinch and confusion use.
 const ATTRACT_INFLICTED: StringName = &"attract_inflicted"
 
 ## Encore locked a slot, and later let it go, the same pair
@@ -181,15 +173,12 @@ var is_trainer_battle: bool = false
 ## The two sides, keyed by [constant PLAYER] and [constant ENEMY].
 var parties: Dictionary = {}
 
-## Which of a side's own party indices have fought since the opponent currently
-## out was sent in, kept as a Dictionary used for its keys. Seeded with the
-## lead at [method create_parties], added to on every [method send_out], and
-## reset to just whoever is left standing once experience has been given for
-## the opponent that just fainted: see [method _award_experience].
-##
-## Only [constant PLAYER]'s side is ever read for anything, mirroring the
-## cartridge's own asymmetry (see [constant EXP_GAINED]), but both sides are
-## tracked the same way rather than leaving one of them a special case.
+## Which of a side's party indices have fought since the current opponent was
+## sent in, a Dictionary used for its keys. Seeded with the lead at
+## [method create_parties], added to on every [method send_out], and reset to
+## whoever is left standing once experience is awarded: see
+## [method _award_experience]. Only [constant PLAYER]'s side is read, mirroring
+## the cartridge's asymmetry, but both are tracked the same way.
 var _participants: Dictionary = {PLAYER: {}, ENEMY: {}}
 
 ## The last direct damage each side took during the current pair of actions.
@@ -337,11 +326,10 @@ func awaiting_move_learn() -> bool:
 	return must_learn_move(PLAYER) or must_learn_move(ENEMY)
 
 
-## The offer waiting on [param side], or an empty Dictionary if there is none.
-## [code]species[/code], [code]index[/code], [code]move[/code] and
-## [code]level[/code] are enough to say "your FOO wants to learn BAR" without
-## asking the Pokémon anything a caller cannot already read off the event that
-## put this here.
+## The offer waiting on [param side], or an empty Dictionary. [code]species[/code],
+## [code]index[/code], [code]move[/code] and [code]level[/code] are enough to say
+## "your FOO wants to learn BAR" without asking the Pokémon anything the event
+## did not already carry.
 func pending_learn(side: int) -> Dictionary:
 	var queue: Array = _move_learn_queue.get(side, [])
 	return queue[0] if not queue.is_empty() else {}
@@ -416,20 +404,13 @@ func send_out(side: int, index: int) -> Array:
 ## happened.
 ##
 ## An action is [method use_move] or [method switch_to]. Nothing happens while
-## either side owes a replacement, and a faint ends the turn where it is: a
-## Pokémon that is knocked out before it has moved does not get to move, which is
-## most of what speed is for.
+## either side owes a replacement, and a faint ends the turn where it is.
 ##
-## The move each side is credited with for [method order]'s own priority check
-## is worked out once, before either side has acted, because that is the
-## moment the cartridge's own move order is decided too. What actually runs is
-## worked out again, fresh, right before [method _act]: Encore can land on a
-## side that has not gone yet this same turn, and the cartridge's own
-## `CheckOpponentWentFirst` forces that side's already-chosen action over for
-## the very turn it lands, not just the ones after it. Recomputing at the
-## point of use rather than committing to [param chosen] gets that for free,
-## since nothing about which move a side actually uses is settled until this
-## reaches it.
+## [method order]'s priority check reads the move each side is credited with once,
+## before either has acted, which is when the cartridge decides order. What
+## actually runs is recomputed just before [method _act], because Encore can land
+## on a side that has not gone yet and `CheckOpponentWentFirst` overrides that
+## side's chosen action for the very turn it lands.
 func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	var events: Array = []
 	if is_over() or awaiting_replacement() or awaiting_move_learn():
@@ -470,14 +451,12 @@ func take_turn(player_slot: int, enemy_slot: int) -> Array:
 ## What a burn or a poison takes at the end of the turn, from each side in the
 ## order it acted.
 ##
-## After both moves rather than after each, and skipping whoever is already down:
-## a Pokémon that has fainted this turn is not burned any further, and one that
-## goes down to its burn faints here rather than in the middle of somebody's move.
+## After both moves rather than after each, skipping whoever is already down, so
+## a Pokémon that faints to its burn does so here rather than mid-move.
 ##
-## A poisoned Pokémon with a running [member Gen2BattleMon.toxic_counter] is
-## the one Toxic left, and it ramps instead of taking the flat eighth every
-## other poison and every burn take; the counter itself goes up here, once a
-## turn, so the turn it was inflicted on counts as the first.
+## A running [member Gen2BattleMon.toxic_counter] means Toxic, which ramps
+## instead of taking the flat eighth. The counter rises here, once a turn, so the
+## turn it was inflicted counts as the first.
 func _residual_damage(acting: Array, events: Array) -> void:
 	for side: int in acting:
 		var current: Gen2BattleMon = mon(side)
@@ -507,13 +486,10 @@ func _residual_damage(acting: Array, events: Array) -> void:
 			events.append({"type": FAINTED, "side": side})
 
 
-## Encore's own countdown, once a turn rather than once a side's move: the
-## cartridge's own `HandleEncore` runs after both sides have acted, the same
-## timing [method _residual_damage] already uses for a burn or a poison.
-##
-## Ends early, before the counter reaches zero, the moment the encored slot
-## itself runs out of PP: the cartridge checks that every turn Encore ticks,
-## not only when the counter would have expired on its own.
+## Encore's countdown, once a turn rather than once a side's move: `HandleEncore`
+## runs after both sides act, the timing [method _residual_damage] uses. Ends
+## early the moment the encored slot runs out of PP, which the cartridge checks
+## every tick, not only at expiry.
 func _tick_encore(acting: Array, events: Array) -> void:
 	for side: int in acting:
 		var current: Gen2BattleMon = mon(side)
@@ -529,15 +505,12 @@ func _tick_encore(acting: Array, events: Array) -> void:
 		events.append({"type": ENCORE_ENDED, "side": side})
 
 
-## Experience for every enemy Pokémon that fainted this turn, whether the faint
-## came from a move ([method _act], already in [param events] by the time this
-## runs) or from status damage ([method _residual_damage], run just before
-## this).
+## Experience for every enemy Pokémon that fainted this turn, from a move
+## ([method _act]) or from status damage ([method _residual_damage]).
 ##
-## A side's own [constant FAINTED] clears its fainted member out of
-## [member _participants] regardless of which side it is, because that half of
-## the rule (a fainted Pokémon stops participating) is not specific to the
-## side that receives experience; only [method _give_experience_for] is.
+## [constant FAINTED] clears the fainted member out of [member _participants] on
+## either side, since a fainted Pokémon stops participating regardless of which
+## side receives experience; only [method _give_experience_for] is asymmetric.
 func _award_experience(events: Array) -> void:
 	for event: Dictionary in events.duplicate():
 		if StringName(event.get("type", "")) != FAINTED:
@@ -632,12 +605,10 @@ func _move_for_action(side: int, action: Dictionary) -> int:
 	return move_for(side, int(action.get("slot", 0)))
 
 
-## The slot PP is actually spent from, which is not always the slot a caller
-## asks for: Encore forces whichever slot it locked in, the same way a
-## two-turn move's release turn forces its own move number regardless of which
-## slot [method move_for] is asked about. Falls back to the encored slot only
-## while it is still usable, so an encored move that has run out of PP does not
-## reach for it once [method _tick_encore] has already ended the effect.
+## The slot PP is actually spent from, not always the slot asked for: Encore
+## forces the slot it locked in, as a two-turn release forces its move number.
+## The encored slot is used only while still usable, so a move out of PP is not
+## reached for once [method _tick_encore] has ended the effect.
 func effective_slot(side: int, requested_slot: int) -> int:
 	var attacker: Gen2BattleMon = mon(side)
 	if attacker.encored_slot >= 0 and attacker.can_use(attacker.encored_slot):
@@ -647,18 +618,15 @@ func effective_slot(side: int, requested_slot: int) -> int:
 
 ## Which move a side will actually use.
 ##
-## A Pokémon locked into a two-turn move's release turn answers with what it
-## charged, whatever slot the caller asks for: on the cartridge nothing is
-## chosen on that turn at all, so nothing here is either. Rollout and rampage
-## continuations use the same rule, forcing the move that started the chain.
-## Failing that, Encore answers with whatever [method effective_slot] resolves
-## to, which may not be the slot the caller asked for either.
+## A release turn answers with the charged move whatever slot is asked for, since
+## the cartridge chooses nothing on that turn. Rollout and rampage continuations
+## force the move that started the chain the same way. Failing that, Encore
+## answers with [method effective_slot], which may also not be the asked slot.
 ##
-## Failing that, a slot with nothing usable in it answers Struggle, which is
-## the cartridge's answer for a Pokémon with no PP anywhere. Here it is also the
-## answer for a slot that is empty, spent or disabled while others are not,
-## because a caller that points at one has asked for something that cannot
-## happen, and Struggle is the only move that is always available.
+## Failing that, an unusable slot answers Struggle. That is the cartridge's
+## answer for a Pokémon with no PP anywhere, and it is used here for an empty,
+## spent or disabled slot too: the caller asked for something that cannot happen,
+## and Struggle is the only always-available move.
 func move_for(side: int, slot: int) -> int:
 	var attacker: Gen2BattleMon = mon(side)
 	if attacker.charged_move != 0:
@@ -674,16 +642,13 @@ func move_for(side: int, slot: int) -> int:
 
 ## Who goes first, as the two sides in the order they act.
 ##
-## A switch is settled before any of this: the cartridge sends the incoming
-## Pokémon out and then lets the other side's move hit it, so a side that is
-## switching acts first however fast the other one is and whatever priority its
-## move has. Two switches in the same turn go to the player, which is what the
-## cartridge does outside a link battle.
+## A switch is settled first: the incoming Pokémon comes out and then takes the
+## other side's move, so a switching side acts first at any speed or priority.
+## Two switches in one turn go to the player, as outside a link battle.
 ##
-## Failing that, priority decides it; equal priority goes to the faster Pokémon,
-## by its speed with stages applied; and a genuine tie is a coin flip. The
-## cartridge weighs a held Quick Claw between the priority and the speed, which
-## nothing here carries yet.
+## Otherwise priority decides, then speed with stages applied, then a coin flip.
+## The cartridge weighs a held Quick Claw between priority and speed; no held
+## items exist here yet.
 func order(chosen: Dictionary, actions: Dictionary = {}) -> Array:
 	var player_switching: bool = _is_switch(actions.get(PLAYER, {}))
 	var enemy_switching: bool = _is_switch(actions.get(ENEMY, {}))
@@ -716,12 +681,11 @@ static func priority_of(move: Dictionary) -> int:
 
 ## One side's move, run as the list of commands its effect is made of.
 ##
-## Nothing about what a particular move does lives here. The effect byte picks a
-## sequence out of [Gen2MoveEffect], the commands in it are run in order against
-## a [Gen2Turn] until one of them says the move is finished, and every rule about
-## announcing, spending, rolling, applying and fainting is one of those commands.
-## That is the cartridge's own arrangement, and it is what lets the rest of
-## Generation 2 be written as commands rather than as branches in here.
+## Nothing about a particular move lives here. The effect byte picks a sequence
+## out of [Gen2MoveEffect] and its commands run in order against a [Gen2Turn]
+## until one says the move is finished; announcing, spending, rolling, applying
+## and fainting are all commands. That is the cartridge's arrangement, and it is
+## why the rest of Generation 2 is commands rather than branches in here.
 func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 	var move: Dictionary = data.move(move_number)
 	if move.is_empty():

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -4,14 +4,13 @@ extends RefCounted
 ## One Pokémon as a battle sees it: its stats, what it knows, how much of it is
 ## left, and how far its stats have been pushed around.
 ##
-## [RefCounted] and scene-free, like everything below the renderer, so a whole
-## battle can be fought inside a test with no display. It reads cartridge content
-## through [GameData] and never touches a ROM.
+## [RefCounted] and scene-free, reading cartridge content through [GameData] and
+## never a ROM.
 ##
-## The stats are worked out once, when the Pokémon is built, because that is when
-## the cartridge works them out: a level up recalculates them, and nothing else
-## in a battle does. Stages are applied on the way out instead, to the unmodified
-## stat every time, which is why they are stored separately rather than folded in.
+## Stats are worked out once, at build time, because that is when the cartridge
+## works them out; only a level up recalculates them. Stages are applied on the
+## way out, to the unmodified stat every time, which is why they are stored
+## separately rather than folded in.
 
 ## What a Pokémon can carry into a battle, which is the same four slots
 ## [Gen2Learnset] fills.
@@ -39,11 +38,10 @@ var level: int = 1
 var dvs: int = PERFECT_DVS
 var stat_exp: Dictionary = {}
 
-## Total experience, on this species' own growth curve. Seeded at
-## [method create] to exactly what [param at_level] starts with, not zero: a
-## level 7 Pidgey is created already carrying level 7's own threshold, the same
-## way the cartridge's box and party screens always agree with a Pokémon's
-## level rather than a fresh one reading level 1 until its first battle.
+## Total experience on this species' growth curve. Seeded at [method create] to
+## what [param at_level] starts with, not zero: a level 7 Pidgey carries level
+## 7's threshold, so the box and party screens agree with its level rather than
+## reading level 1 until its first battle.
 @warning_ignore("shadowed_global_identifier")
 var exp: int = 0
 
@@ -185,11 +183,10 @@ func _stat(
 ## A stat as the damage formula sees it, with its stage and then its status
 ## applied.
 ##
-## The order is the cartridge's: it copies the stat, applies the stage, and then
-## halves the Attack of a burned Pokémon and quarters the Speed of a paralysed
-## one. Both land on the same copy the stages did, which is what decides that a
-## critical hit reading [method unmodified_stat] is free of the burn as well as of
-## the stages.
+## The cartridge's order: copy the stat, apply the stage, then halve a burned
+## Pokémon's Attack and quarter a paralysed one's Speed. Both land on the copy the
+## stages did, which is why a critical hit reading [method unmodified_stat] is
+## free of the burn as well as the stages.
 func stat(key: String) -> int:
 	var value: int = int(stats.get(key, 0))
 	if not STAGED_STATS.has(key):
@@ -252,16 +249,13 @@ func reset_volatile() -> void:
 ## The gender the cartridge's own `GetGender` would answer, from the species'
 ## gender ratio and this Pokémon's own Attack and Speed DVs.
 ##
-## Not a coin flip and not tied to a stat total: the cartridge folds the
-## Attack DV into the high nibble of one byte and the Speed DV into the low
-## nibble, and compares that byte against the species' own ratio the same way
-## a personality value is compared against one from Generation 3 onward. A
-## ratio of 0 is always male and 254 is always female outright, with no
-## comparison run at all; 255 is genderless. Otherwise a combined value below
-## the ratio is male and at or above it is female, which is why raising the
-## ratio raises the odds of female: [constant Gen2Species.GENDER_UNKNOWN] and
-## the two extremes are named on [Gen2BattleMon] rather than repeated at every
-## caller.
+## Not a coin flip and not a stat total: the cartridge folds the Attack DV into
+## one byte's high nibble and the Speed DV into its low nibble, then compares
+## that against the species ratio. Ratio 0 is always male and 254 always female
+## with no comparison at all; 255 is genderless. Otherwise below the ratio is
+## male and at or above it female, so a higher ratio means likelier female.
+## [constant Gen2Species.GENDER_UNKNOWN] and the two extremes are named here
+## rather than repeated at every caller.
 const GENDER_F0: int = 0
 const GENDER_F100: int = 254
 const GENDER_UNKNOWN: int = 255
@@ -306,11 +300,10 @@ func base_exp() -> int:
 	return int(data.species(species).get("base_exp", 0))
 
 
-## The five base stats [Gen2Experience.stat_exp_gain] wants when this Pokémon
-## is the one fainting, keyed the way [member stat_exp] already is. Special
-## Attack's base value fills the shared [code]"special"[/code] slot, never
-## Special Defense's: see [constant Gen2Experience.STAT_EXP_KEYS] for why the
-## cartridge reads it that way.
+## The five base stats [Gen2Experience.stat_exp_gain] wants when this Pokémon is
+## the one fainting, keyed like [member stat_exp]. Special Attack's base value
+## fills the shared [code]"special"[/code] slot, never Special Defense's: see
+## [constant Gen2Experience.STAT_EXP_KEYS].
 func base_stat_exp_shape() -> Dictionary:
 	var base: Dictionary = data.species(species).get("stats", {})
 	return {
@@ -343,13 +336,10 @@ func level_for_exp() -> int:
 	return Gen2Experience.level_for_exp(growth_rate(), exp)
 
 
-## Raises the level by exactly one and recalculates every stat from it, the
-## same call [method create] makes and the only other time this is meant to
-## happen. Current HP gains the *difference* the new max makes, rather than
-## being refilled or left where it was: the cartridge adds the two maximums'
-## delta onto whatever HP was sitting at, so a Pokémon one hit from fainting
-## before the level up is still one hit from fainting after it, just against a
-## bigger hit.
+## Raises the level by one and recalculates every stat, the same call
+## [method create] makes and the only other place this happens. Current HP gains
+## the max-HP *difference* rather than refilling: a Pokémon one hit from fainting
+## before the level up is still one hit from fainting after it.
 func level_up() -> void:
 	if level >= Gen2Experience.MAX_LEVEL:
 		return
@@ -394,11 +384,10 @@ func spend_pp(slot: int) -> void:
 
 ## Whether there is anything left to do with a move slot.
 ##
-## A disabled slot answers false here regardless of its PP, the same way the
-## cartridge's own menu never offers it: [method Gen2Battle.effective_slot] and
-## [method Gen2Battle.move_for] are what reroute a caller that still asks for
-## it, and [constant Gen2EffectCommands.CHECK_STATUS]'s own belt-and-suspenders
-## check is what catches the one path that does not go through either.
+## A disabled slot answers false whatever its PP, as the cartridge's menu never
+## offers it. [method Gen2Battle.effective_slot] and [method Gen2Battle.move_for]
+## reroute a caller that still asks; [constant Gen2EffectCommands.CHECK_STATUS]
+## catches the one path through neither.
 func can_use(slot: int) -> bool:
 	return slot >= 0 and slot < moves.size() and pp_left(slot) > 0 and slot != disabled_slot
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -7,22 +7,20 @@ signal capture_requested(ball: int)
 ## The battle screen: two Pokémon, two status panels and a text box, at the
 ## positions the hardware puts them.
 ##
-## This is the first screen that is not a development view. Everything on it
-## already existed a layer down (a pic from an atlas, a panel from the HUD
-## sheets, a box from the font and a border), and what this adds is where each
-## of them goes: the enemy's pic in the top right, the player's back pic below
-## and to the left of it, a panel each, and the standard box along the bottom.
+## Everything on it exists a layer down (a pic from an atlas, a panel from the
+## HUD sheets, a box from the font and a border); this decides placement: enemy
+## pic top right, player back pic below and left, a panel each, the standard box
+## along the bottom.
 ##
-## It draws what it is given and decides nothing. A [Gen2Battle] behind it works
-## out the turn and answers with a list of events; this shows them one at a time,
-## taking every number it draws out of the event rather than asking the engine
-## again. That is why the setters still take plain values: the engine is one
-## caller of them and not the only possible one.
+## It draws what it is given and decides nothing. A [Gen2Battle] resolves the
+## turn and answers with events; this shows them one at a time, reading every
+## number out of the event rather than asking the engine again, which is why the
+## setters still take plain values.
 ##
-## The panels are composed into one screen-sized index buffer and drawn over the
-## pics with index 0 transparent, because a panel is a shape on a white field
-## rather than a rectangle: the games draw them into the background layer, where
-## nothing overlaps, and the pics have to show through everything that is not ink.
+## Panels compose into one screen-sized index buffer drawn over the pics with
+## index 0 transparent: a panel is a shape on a white field, drawn into the
+## background layer on hardware, so the pics show through everything that is not
+## ink.
 
 ## Where the two pics sit, in tiles.
 const ENEMY_PIC: Vector2i = Vector2i(12, 0)
@@ -477,11 +475,10 @@ func set_exp(fraction: float) -> void:
 	_refresh()
 
 
-## Where [member _battle]'s own player Pokémon sits between its current level's
-## own threshold and the next one's, on its own growth curve. Called whenever a
-## battle starts and whenever [constant Gen2Battle.EXP_GAINED] or
-## [constant Gen2Battle.GREW_LEVEL] says the number behind it moved, rather
-## than read once and left to go stale.
+## Where the player's Pokémon sits between its current level's threshold and the
+## next, on its growth curve. Recomputed at battle start and whenever
+## [constant Gen2Battle.EXP_GAINED] or [constant Gen2Battle.GREW_LEVEL] moves the
+## number behind it.
 func _refresh_exp_bar() -> void:
 	if _battle == null or _battle.player == null:
 		set_exp(0.0)
@@ -710,12 +707,11 @@ func _hurt(mon: Gen2BattleMon) -> void:
 
 ## Plays one turn out, and the events come back to be shown one at a time.
 ##
-## The player still picks at random from what it knows: a menu does not exist
-## yet. The enemy does too, unless it is one of the cartridge's own trainers
-## ([method show_trainer] rather than [method show_matchup]), in which case
-## [Gen2BattleAI] scores its choice the way that trainer class's own AI flags
-## say to. Random rather than the first slot because a Pokémon that only ever
-## used its first move would never show what the other three do.
+## The player picks at random from what it knows, since no menu exists yet; so
+## does the enemy, unless it is a real trainer ([method show_trainer] rather than
+## [method show_matchup]), where [Gen2BattleAI] scores the choice from that
+## class's AI flags. Random rather than the first slot, so the other three moves
+## are ever seen.
 func take_turn() -> void:
 	if _battle == null or _battle.is_over() or not _pending.is_empty():
 		return
@@ -764,12 +760,11 @@ func switch_player() -> void:
 	_show_next_event()
 
 
-## No menu exists yet to ask which move to forget, the same scaffolding this
-## screen already has for which move to use ([method _random_slot]): a pending
-## offer is declined automatically instead, so a battle nobody is driving from
-## a real menu does not simply stop. [Gen2Battle] still exposes the real
-## question through [method Gen2Battle.must_learn_move] for whatever asks it
-## properly later.
+## No menu exists yet to ask which move to forget, the same gap
+## [method _random_slot] fills for which move to use, so a pending offer is
+## declined automatically and an undriven battle does not stop. [Gen2Battle]
+## still exposes the real question through
+## [method Gen2Battle.must_learn_move].
 func _auto_decline_move_learns() -> void:
 	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
 		while _battle.must_learn_move(side):
@@ -956,10 +951,9 @@ func _next_healthy(side: int) -> int:
 
 ## The next event, with whatever it changes applied first.
 ##
-## Every number drawn comes out of the event rather than out of the Pokémon,
-## because the turn has already finished resolving by the time the first event is
-## shown. Reading the Pokémon here would draw the end of the turn during the
-## middle of it.
+## Every number drawn comes from the event, not the Pokémon: the turn has already
+## resolved by the time the first event is shown, so reading the Pokémon would
+## draw the end of the turn during the middle of it.
 func _show_next_event() -> void:
 	while not _pending.is_empty():
 		var event: Dictionary = _pending.pop_front()
@@ -1279,10 +1273,9 @@ func _draw_pic(
 
 ## The panels, and then each bar over them in its own colour.
 ##
-## The hardware gives every tile of the background its own palette, so a green
-## HP bar sits in a panel of black text without either being a separate thing.
-## Layering is how that is done here, one buffer per palette, which is why the
-## bars are drawn apart from the panels that hold them.
+## The hardware gives every background tile its own palette, so a green HP bar
+## sits in a panel of black text without either being separate. Here that is one
+## buffer per palette, which is why the bars are drawn apart from the panels.
 func _draw_panels() -> void:
 	var panels: PackedByteArray = _new_buffer()
 	_hud.draw_enemy(panels, Gen2Screen.WIDTH, _name_of(_enemy), _enemy_level)

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -3,18 +3,16 @@ extends RefCounted
 
 ## The damage formula, in the order and the arithmetic the hardware uses.
 ##
-## Every step truncates, and the steps are not commutative, so this is written as
-## a sequence rather than as an expression. Rearranging it into one line changes
-## the answer: the type matchups are applied to the damage one type at a time
-## with a truncation between them, the critical multiplier lands before the cap
-## and the minimum, Rollout's multiplier lands after type but before variation,
-## and the random spread lands after everything.
+## Every step truncates and the steps are not commutative, so this is a sequence,
+## not an expression: rearranging it changes the answer. Type matchups apply one
+## type at a time with a truncation between, the critical multiplier lands before
+## the cap and minimum, Rollout's after type but before variation, and the random
+## spread after everything.
 ##
-## Randomness is injected. [method calculate] rolls the two things a hit rolls,
-## the critical and the spread, and hands both to [method calculate_with], which
-## is deterministic and is what a test should be pointed at. Asking for
-## [constant MAX_VARIATION] and no critical is the highest a hit can go, which is
-## the number a damage calculator quotes.
+## [method calculate] rolls the critical and the spread and hands both to the
+## deterministic [method calculate_with], which is what a test should target.
+## [constant MAX_VARIATION] with no critical is the highest a hit can go, the
+## number a damage calculator quotes.
 
 ## Where the formula's constants come from. The cap is applied before the
 ## minimum is added, so a hit that would flatten the counter lands at 999 and
@@ -76,11 +74,11 @@ static func calculate(
 
 ## A hit with both rolls decided. Deterministic, and the whole of the formula.
 ##
-## Returns { damage, critical, effectiveness, stab, immune }. [code]effectiveness[/code]
-## is in tenths and is the number the battle announces, which is not always the
-## number the damage was worked out with: see [method GameData.type_effectiveness].
-## [code]immune[/code] is the cartridge's own answer to a matchup of zero, which
-## it treats as a miss rather than as a hit for nothing.
+## Returns { damage, critical, effectiveness, stab, immune }.
+## [code]effectiveness[/code] is in tenths and is the announced number, not always
+## the one damage used: see [method GameData.type_effectiveness].
+## [code]immune[/code] is a matchup of zero, which the cartridge treats as a miss
+## rather than a hit for nothing.
 static func calculate_with(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -107,10 +105,9 @@ static func calculate_with(
 
 	if power <= 0:
 		# A move with no power is not a failed attack, it is a move that does
-		# something else. The matchup is still worked out, because the battle
-		# announces it either way, and because a status move is stopped by an
-		# immunity exactly as an attack is: Thunder Wave does nothing to a Ground
-		# type and Poison Powder nothing to a Steel one.
+		# something else. The matchup is still worked out: the battle announces
+		# it either way, and an immunity stops a status move exactly as it stops
+		# an attack (Thunder Wave against Ground, Poison Powder against Steel).
 		for defending_type: int in defending:
 			if data.type_matchup(move_type, defending_type) == RomLayout.MATCHUP_NO_EFFECT:
 				out["immune"] = true
@@ -216,13 +213,11 @@ static func confusion_damage(mon: Gen2BattleMon, rng: RandomNumberGenerator) -> 
 	return apply_variation(damage, roll_variation(rng))
 
 
-## Psywave: a random amount from one up to, but not including, one and a half
-## times the user's own level, the halving floored first. The cartridge draws
-## this by rerolling a byte until it lands inside that range rather than
-## clamping into it, which is a uniform pick over the same range and not a
-## detail worth reproducing bit for bit; a level of 1 has no such range at all
-## on the real hardware and would spin forever, which this reads as a minimum
-## of one rather than replicate.
+## Psywave: a random amount from one up to but excluding one and a half times the
+## user's level, the halving floored first. The cartridge rerolls a byte until it
+## lands in range rather than clamping, which is the same uniform pick. Level 1
+## has no such range and would spin forever on hardware, so it reads as a minimum
+## of one here.
 static func psywave_damage(level: int, rng: RandomNumberGenerator) -> int:
 	@warning_ignore("integer_division")
 	var upper: int = level / 2 + level
@@ -231,9 +226,9 @@ static func psywave_damage(level: int, rng: RandomNumberGenerator) -> int:
 
 ## Whether a move is worked out from Attack or from Special Attack.
 ##
-## Generation 2 splits by the move's type and not by the move: every type below
-## Fire is physical and every type from Fire up is special, which is why Hyper
-## Beam is special and Bite is physical.
+## Generation 2 splits by type, not by move: every type below Fire is physical
+## and every type from Fire up special, which is why Hyper Beam is special and
+## Bite physical.
 static func is_physical(move_type: int) -> bool:
 	return move_type < RomLayout.SPECIAL_TYPES_START
 
@@ -259,11 +254,10 @@ static func _defense_stat(
 ## A critical hit ignores both sides' stages, but only when they are working
 ## against the attacker.
 ##
-## This is narrower than it is usually described. The cartridge compares the two
-## stages and keeps them if the defender's is the lower one, so a critical hit
-## from an attacker who has raised its own Attack still gets the boost, and one
-## against a defender who has raised its Defense does not have to fight through
-## it. It is the attacker's advantage either way.
+## Narrower than usually described: the cartridge compares the two stages and
+## keeps them when the defender's is lower, so a critical from an attacker who
+## raised its Attack keeps the boost and one against a raised Defense ignores it.
+## The attacker's advantage either way.
 static func _ignores_stages(
 	attacker: Gen2BattleMon, defender: Gen2BattleMon, move_type: int, critical: bool
 ) -> bool:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -3,21 +3,19 @@ extends RefCounted
 
 ## The steps a move is made of.
 ##
-## A move in these games is not a special case in a switch statement, it is a
-## short program: the cartridge keeps a list of commands per effect and runs them
-## in order, and an ordinary attack is the list that announces the move, spends
-## the PP, works the damage out, rolls the hit, applies it and checks for a
-## faint. Every other move is that list with steps added, removed or replaced.
+## A move is a short program, not a switch case: the cartridge keeps a command
+## list per effect and runs it in order. An ordinary attack announces the move,
+## spends the PP, works out damage, rolls the hit, applies it and checks for a
+## faint; every other move is that list with steps added, removed or replaced.
 ##
-## Reproducing the shape rather than the outcome is what makes the rest of
-## Generation 2 additive. A burn is a command appended to a list; a move that
-## cannot miss is a list with the roll left out; a two-turn move is a list that
-## ends early the first time. None of that reaches [Gen2Battle], which knows only
-## how to run a list.
+## Keeping the shape is what makes the rest of Generation 2 additive: a burn is
+## an appended command, a move that cannot miss is a list without the roll, a
+## two-turn move is a list that ends early the first time. None of it reaches
+## [Gen2Battle], which only knows how to run a list.
 ##
-## The names are the cartridge's own, so a sequence here can be read against
-## [code]data/moves/effects.asm[/code] in the pret disassembly line for line. See
-## [Gen2MoveEffect] for the lists themselves.
+## The names are the cartridge's, so a sequence reads against
+## [code]data/moves/effects.asm[/code] line for line. [Gen2MoveEffect] holds the
+## lists.
 
 ## Announces the move. First, because a move that fails still says it was used.
 const USED_MOVE_TEXT: StringName = &"usedmovetext"
@@ -64,9 +62,9 @@ const END_MOVE: StringName = &"endmove"
 ## Whether the move happens at all. Sleep, freeze and paralysis are checked here,
 ## in that order, and any of them can cost the turn.
 ##
-## Not part of any sequence: the cartridge runs this before it looks the effect
-## up, so every move goes through it and no list has to remember to. [Gen2Battle]
-## runs it ahead of the list for that reason.
+## Not part of any sequence: the cartridge runs it before looking the effect up,
+## so every move goes through it and no list has to remember to. [Gen2Battle]
+## runs it ahead of the list for the same reason.
 const CHECK_STATUS: StringName = &"checkstatus"
 
 ## Whether a secondary effect happens, out of the move's own chance. A move whose
@@ -83,19 +81,17 @@ const BURN_TARGET: StringName = &"burntarget"
 const FREEZE_TARGET: StringName = &"freezetarget"
 const PARALYZE_TARGET: StringName = &"paralyzetarget"
 
-## What Toxic leaves behind: the same poison flag [constant POISON_TARGET]
-## leaves, plus the ramping counter that makes it Toxic rather than an ordinary
-## poison. Its own command rather than [constant POISON_TARGET] with an extra
-## step after it, because the counter has to start before the first residual
-## turn sees it, and nothing else needs a command that touches both.
+## What Toxic leaves behind: [constant POISON_TARGET]'s poison flag plus the
+## ramping counter. Its own command rather than an extra step after
+## [constant POISON_TARGET], because the counter has to start before the first
+## residual turn sees it.
 const TOXIC_TARGET: StringName = &"toxictarget"
 
 ## The two things a move can leave on [Gen2Substatus] rather than the status
-## byte. Flinch is only ever a secondary effect, so it obeys
-## [member Gen2Turn.failed_chance] the same way the five above do; confusion
-## comes both ways, as a status move of its own (Confuse Ray, Supersonic) and
-## as a secondary effect (Confusion, Psybeam), which is why [Gen2MoveEffect]
-## reaches for this command from both shapes of sequence.
+## byte. Flinch is only ever a secondary effect, obeying
+## [member Gen2Turn.failed_chance] like the five above; confusion comes both ways,
+## as its own status move (Confuse Ray, Supersonic) and as a secondary effect
+## (Confusion, Psybeam), so [Gen2MoveEffect] reaches for it from both shapes.
 const FLINCH_TARGET: StringName = &"flinchtarget"
 const CONFUSE_TARGET: StringName = &"confusetarget"
 
@@ -104,11 +100,11 @@ const CONFUSE_TARGET: StringName = &"confusetarget"
 ## rule inside [constant CHECK_HIT], for Dream Eater.
 const DRAIN_TARGET: StringName = &"draintarget"
 
-## Two to five hits for [constant Gen2MoveEffect.MULTI_HIT], or exactly two for
+## Two to five hits for [constant Gen2MoveEffect.MULTI_HIT], exactly two for
 ## [constant Gen2MoveEffect.DOUBLE_HIT] and [constant Gen2MoveEffect.TWINEEDLE]:
-## one command that repeats the roll and the hit itself rather than a sequence
-## repeated by the runner, the same way [constant ALL_STATS_UP] repeats a stage
-## change five times without five commands.
+## one command repeating the roll and the hit rather than a runner-repeated
+## sequence, as [constant ALL_STATS_UP] repeats a stage change five times in one
+## command.
 const MULTI_HIT: StringName = &"multihit"
 
 ## Overwrites what [constant DAMAGE_CALC] worked out with the number
@@ -126,11 +122,10 @@ const OHKO: StringName = &"ohko"
 ## list rather than anything a target-facing command touches.
 const RECHARGE: StringName = &"recharge"
 
-## A two-turn move's charge. The first time it is run it locks the user in,
-## announces the charge and ends the move there; the second time, it is the
-## release turn, so it clears the lock and lets the rest of the list run as an
-## ordinary attack. [Gen2Battle._act] is what makes sure the second call is the
-## user's only option: see [method Gen2Battle.move_for].
+## A two-turn move's charge. First run: lock the user in, announce, end the move.
+## Second run, the release turn: clear the lock and let the rest of the list run
+## as an ordinary attack. [method Gen2Battle.move_for] is what makes that second
+## call the user's only option.
 const CHARGE_MOVE: StringName = &"chargemove"
 
 ## Rollout checks whether a chain is already active, applies its power state and
@@ -157,11 +152,9 @@ const BELLY_DRUM: StringName = &"bellydrum"
 ## target has nothing raised or lowered to copy.
 const PSYCH_UP: StringName = &"psychup"
 
-## Locks one of the target's own move slots, the one it last used, out for a
-## few turns. Fails if the target has not used a move yet, if that move was
-## Struggle, if it has already run out of PP, or if the target is already
-## disabled: only one slot at a time, the same "one at a time" rule the status
-## byte enforces for a different kind of affliction.
+## Locks the target's last-used move slot for a few turns. Fails if the target
+## has not moved, if that move was Struggle, if the slot is out of PP, or if the
+## target is already disabled: one slot at a time.
 const DISABLE: StringName = &"disable"
 
 ## Locks the target into repeating its own last move for a few turns. The same
@@ -185,12 +178,11 @@ const MIST: StringName = &"mist"
 ## switch. Fails, without re-applying, on a second use.
 const FOCUS_ENERGY: StringName = &"focusenergy"
 
-## Raises and lowers a stat by one stage or two, named the way the cartridge
-## names them and in the order [constant Gen2BattleMon.STAGED_STATS] plus
-## [constant Gen2BattleMon.STAGED_ODDS] already keeps the seven in, because that
-## is also the order the cartridge's own effect bytes run in: seven in a row for
-## "up by one", seven more for "down by one", and so on. [Gen2MoveEffect] is what
-## turns that run into a table; this only names the seven stops along it.
+## Raises and lowers a stat by one stage or two, named as the cartridge names
+## them and in [constant Gen2BattleMon.STAGED_STATS] plus
+## [constant Gen2BattleMon.STAGED_ODDS] order, which is also the order the effect
+## bytes run in: seven in a row for "up by one", seven more for "down by one",
+## and so on. [Gen2MoveEffect] turns that run into a table; this names the stops.
 const ATTACK_UP: StringName = &"attackup"
 const DEFENSE_UP: StringName = &"defenseup"
 const SPEED_UP: StringName = &"speedup"
@@ -259,10 +251,9 @@ const STAT_COMMANDS: Dictionary = {
 ## The five real stats [constant ALL_STATS_UP] raises, in the cartridge's order.
 const ALL_STATS_KEYS: Array = ["attack", "defense", "speed", "sp_attack", "sp_defense"]
 
-## Reports a stat change, or says nothing for one that is folded into a hit and
-## has no message step of its own. Separate from the change itself because a
-## status move that fails to move a stat says so and a secondary effect that
-## fails to says nothing, which is two different steps rather than one asking
+## Reports a stat change, or says nothing for one folded into a hit. Separate
+## from the change itself, because a status move that fails to move a stat says
+## so and a secondary effect that fails says nothing: two steps, not one asking
 ## both questions.
 const STAT_UP_MESSAGE: StringName = &"statupmessage"
 const STAT_DOWN_MESSAGE: StringName = &"statdownmessage"
@@ -281,19 +272,17 @@ const RECOIL_DIVISOR: int = 4
 ## Wheel and Sacred Fire, by move number.
 const THAWING_MOVES: Array = [172, 221]
 
-## What Encore refuses to lock a target into repeating even though the target
-## did just use it, by move number: Encore itself, and Mirror Move, since
-## forcing either to repeat means nothing (Encore stacked on Encore locks in
-## nothing new, and Mirror Move's own effect is to copy whatever the opponent
-## did last, not to repeat itself).
+## What Encore refuses to lock a target into, by move number: Encore itself and
+## Mirror Move, since forcing either to repeat means nothing. Encore on Encore
+## locks in nothing new, and Mirror Move copies the opponent's last move rather
+## than repeating itself.
 const ENCORE_EXCLUDED_MOVES: Array = [119, 227]
 
 
 ## Runs one command against [param turn].
 ##
-## An unknown command is an error rather than a no-op: a sequence that names a
-## step nobody wrote would otherwise play out as a move that quietly does less
-## than it says.
+## An unknown command is an error, not a no-op: a sequence naming a step nobody
+## wrote would otherwise play out as a move that quietly does less than it says.
 static func run(command: StringName, turn: Gen2Turn) -> void:
 	match command:
 		USED_MOVE_TEXT:
@@ -392,12 +381,10 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 ## Announces the move, and records it as what Disable and Encore will find if
 ## the opponent's next move searches for "what did this Pokémon last use".
 ##
-## The real cartridge skips that second part on the release turn of a two-turn
-## move, so Disable and Encore that land mid-charge see the move that was
-## charging rather than the one that was just released; this always records
-## the move actually announced, which is simpler and only differs from the
-## cartridge in that one narrow interaction. Worth revisiting if Disable or
-## Encore's behaviour against a charging Pokémon ever needs to match exactly.
+## The cartridge skips that second part on a two-turn release, so Disable and
+## Encore landing mid-charge see the charging move rather than the released one.
+## This always records the move announced, differing only in that one narrow
+## interaction.
 static func _used_move_text(turn: Gen2Turn) -> void:
 	turn.attacker().last_move_used = turn.move_number
 	turn.emit(Gen2Battle.USED_MOVE, {"move": turn.move_number})
@@ -572,13 +559,11 @@ static func _doubles_underground_damage(turn: Gen2Turn) -> bool:
 			Gen2MoveEffect.MAGNITUDE_MOVE].has(turn.move_number)
 
 
-## A quarter of [member Gen2Turn.damage], the number the formula calculated,
-## never less than one, and never [member Gen2Turn.dealt], the number that
-## actually came off a target with less left than that. The real cartridge's
-## own `BattleCommand_Recoil` reads the same uncapped `wCurDamage`
-## [constant Gen2EffectCommands.DRAIN_TARGET] already reads, so a target with
-## three hit points left against a move that calculates fifty costs the
-## attacker a quarter of fifty, not a quarter of three.
+## A quarter of [member Gen2Turn.damage], the calculated number, at least one, and
+## never [member Gen2Turn.dealt]. `BattleCommand_Recoil` reads the same uncapped
+## `wCurDamage` [constant Gen2EffectCommands.DRAIN_TARGET] reads, so a move
+## calculating fifty against a target with three HP left costs a quarter of
+## fifty.
 static func _recoil(turn: Gen2Turn) -> void:
 	if turn.damage <= 0:
 		return
@@ -615,20 +600,14 @@ static func _cancel_charge(mon: Gen2BattleMon) -> void:
 ## belt-and-suspenders refusal for a Pokémon still locked into the disabled
 ## move itself, then paralysis. This is the cartridge's own order.
 ##
-## A frozen Pokémon is never asked whether it is also paralysed, because the
-## status byte cannot say both; a confused Pokémon that hits itself is never
-## asked about paralysis either, because it has already spent its turn.
+## A frozen Pokémon is never asked about paralysis, since the status byte cannot
+## say both; a confused one that hits itself has already spent its turn.
 ##
-## Waking up does not cost the turn. The cartridge counts the sleep off, prints
-## that the Pokémon woke, and carries on into the rest of its checks rather than
-## ending the turn, so a Pokémon whose counter runs out attacks the same turn it
-## opens its eyes. That is Generation 2's rule and not Generation 1's. Snapping
-## out of confusion works the same way: the counter reaching zero clears the
-## flag and lets the move through the same turn, and Disable wearing off here
-## does too, for the same reason: [method Gen2BattleMon.can_use] already
-## refuses the slot before this runs, so a countdown that reaches zero this
-## turn has already stopped mattering by the time the belt-and-suspenders check
-## further down would otherwise have caught it.
+## Waking up does not cost the turn: the counter runs out, the wake is printed,
+## and the remaining checks continue, so the Pokémon attacks the same turn. That
+## is Generation 2's rule, not Generation 1's. Confusion and Disable expire the
+## same way, and [method Gen2BattleMon.can_use] has already refused a disabled
+## slot before this runs.
 static func _check_status(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 
@@ -697,13 +676,10 @@ static func _check_status(turn: Gen2Turn) -> void:
 		turn.end()
 		return
 
-	# Belt-and-suspenders: a Pokémon that is still, somehow, about to use its
-	# own disabled move is refused here rather than allowed through on a
-	# technicality. By move number, not by slot: [method Gen2BattleMon.can_use]
-	# has already turned an ordinary request for the disabled slot into
-	# Struggle by the time this runs, and [member Gen2Turn.slot] still names
-	# the slot that was asked for rather than the one that is actually
-	# happening, so comparing slots here would refuse that Struggle too.
+	# Last line of defence against using a disabled move. By move number, not by
+	# slot: can_use() has already turned a request for the disabled slot into
+	# Struggle, while Gen2Turn.slot still names the slot asked for, so comparing
+	# slots would refuse that Struggle too.
 	if mon.disabled_slot >= 0 and mon.disabled_slot < mon.moves.size() \
 		and turn.move_number == int(mon.moves[mon.disabled_slot]):
 		_cancel_charge(mon)
@@ -718,13 +694,10 @@ static func _check_status(turn: Gen2Turn) -> void:
 		turn.end()
 
 
-## A secondary effect's roll. The chance is a byte out of 256 in the move's own
-## table, like accuracy, and what it gates is only what comes after it: the
-## damage in front of it has already been done.
-##
-## A chance of zero never comes up, which is what the cartridge's comparison
-## does with it too. That is worth leaving alone rather than reading as "no
-## chance was given, so always": a move that says zero is a move that says never.
+## A secondary effect's roll: a byte out of 256 in the move's table, like
+## accuracy, gating only what comes after it, since the damage in front has
+## already landed. A chance of zero never fires, which is what the cartridge's
+## comparison does too: zero means never, not "unspecified".
 static func _effect_chance(turn: Gen2Turn) -> void:
 	var chance: int = int(turn.move.get("effect_chance", 0))
 	if turn.rng().randi_range(0, Gen2Status.CHANCE_RANGE - 1) >= chance:
@@ -790,12 +763,10 @@ static func _flinch_target(turn: Gen2Turn) -> void:
 	defender.substatus |= Gen2Substatus.FLINCHED
 
 
-## Sets the target confused and rolls how long for, or fails. A Pokémon already
-## confused is refused rather than having its counter restarted, which is the
-## rule [Gen2Substatus.CONFUSED] enforces the same way the status byte enforces
-## it for sleep, poison, burn, freeze and paralysis, except that confusion sits
-## alongside a status rather than instead of one: a poisoned Pokémon can still
-## be confused.
+## Sets the target confused and rolls its duration, or fails. An already-confused
+## Pokémon is refused rather than having its counter restarted, the rule
+## [Gen2Substatus.CONFUSED] enforces. Unlike a status, confusion sits alongside
+## one: a poisoned Pokémon can still be confused.
 static func _confuse_target(turn: Gen2Turn) -> void:
 	if turn.failed_chance:
 		return
@@ -814,12 +785,10 @@ static func _confuse_target(turn: Gen2Turn) -> void:
 
 ## Heals the attacker for half of what the hit calculated, at least one.
 ##
-## Half of [member Gen2Turn.damage], the number the formula worked out, not
-## half of [member Gen2Turn.dealt], the number that actually came off a target
-## who had less than that left. The real cartridge's own drain reads the same
-## uncapped figure [constant APPLY_DAMAGE] read before clamping it to what the
-## defender had, so a move that calculates fifty against a target with three
-## hit points left heals twenty-five, not one.
+## Half of [member Gen2Turn.damage], the calculated number, not half of
+## [member Gen2Turn.dealt]. The cartridge's drain reads the same uncapped figure
+## [constant APPLY_DAMAGE] read before clamping, so a move calculating fifty
+## against a target with three HP left heals twenty-five.
 static func _drain_target(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	@warning_ignore("integer_division")
@@ -834,16 +803,12 @@ static func _drain_target(turn: Gen2Turn) -> void:
 ## Two to five hits for [constant Gen2MoveEffect.MULTI_HIT], or exactly two for
 ## [constant Gen2MoveEffect.DOUBLE_HIT] and [constant Gen2MoveEffect.TWINEEDLE].
 ##
-## [constant CHECK_HIT] has already rolled the one accuracy check the whole
-## move gets, the way the cartridge's own script checks it before the loop
-## that repeats the hit even starts; everything from here on is this command's
-## own job. The first hit reuses what [constant DAMAGE_CALC] already worked
-## out; every hit after it rerolls the critical and the spread fresh, the way
-## the cartridge's own loop does by jumping back to reroll rather than reusing
-## the first hit's numbers. A faint ends the move where it stands, which is
-## also why the "hit N times" summary is only sent when every planned hit
-## actually landed: the cartridge's own loop jumps straight past that line the
-## moment a hit brings the target down.
+## [constant CHECK_HIT] has already rolled the one accuracy check the whole move
+## gets, before the repeat loop starts. The first hit reuses
+## [constant DAMAGE_CALC]'s numbers; every later hit rerolls the critical and the
+## spread, as the cartridge's loop does. A faint ends the move where it stands,
+## which is why the "hit N times" summary is only sent when every planned hit
+## landed.
 static func _multi_hit(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	var defender: Gen2BattleMon = turn.defender()
@@ -890,17 +855,15 @@ static func _roll_multi_hit_count(rng: RandomNumberGenerator) -> int:
 	return rng.randi_range(0, 3) + 2
 
 
-## Overwrites what [constant DAMAGE_CALC] worked out with the number these four
-## effects actually deal, none of which come out of the ordinary formula:
-## [constant Gen2MoveEffect.LEVEL_DAMAGE] is the user's own level,
-## [constant Gen2MoveEffect.PSYWAVE] a roll of it, [constant Gen2MoveEffect.SUPER_FANG]
-## half the target's current HP, and [constant Gen2MoveEffect.STATIC_DAMAGE] the
-## move's own power field, taken directly rather than as an input to a formula.
-## None of the four criticals or gets announced as super or not very effective,
-## since the number was never actually multiplied by either; [constant DAMAGE_CALC]'s
-## own roll, already spent, is only kept for the one thing worth keeping from
-## it, whether the hit is immune at all, which [constant CHECK_IMMUNE] has
-## already acted on by the time this runs.
+## Overwrites [constant DAMAGE_CALC] with the number these four effects deal,
+## none from the ordinary formula: [constant Gen2MoveEffect.LEVEL_DAMAGE] the
+## user's level, [constant Gen2MoveEffect.PSYWAVE] a roll of it,
+## [constant Gen2MoveEffect.SUPER_FANG] half the target's current HP, and
+## [constant Gen2MoveEffect.STATIC_DAMAGE] the move's power field taken directly.
+## None criticals or announces effectiveness, since the number was never
+## multiplied by either; only the immunity from the spent
+## [constant DAMAGE_CALC] roll is kept, and [constant CHECK_IMMUNE] has already
+## acted on it.
 static func _fixed_damage(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	var defender: Gen2BattleMon = turn.defender()
@@ -928,13 +891,10 @@ const OHKO_LEVEL_BONUS: int = 2
 ## Guillotine, Horn Drill and Fissure: an instant faint with its own accuracy
 ## rule rather than the move's stored one read plainly.
 ##
-## A defender with a higher level than the attacker is immune outright, no
-## roll at all. Otherwise the move's own stored accuracy (a shade under 30%)
-## is raised by two for every level the attacker has over the defender, capped
-## the way any accuracy is, and rolled through the ordinary stage machinery
-## before it decides anything: an attacker that has lowered the target's
-## evasion or raised its own accuracy makes a one-hit KO likelier to land, the
-## same as it would any other move.
+## A higher-level defender is immune outright, with no roll. Otherwise the stored
+## accuracy (a shade under 30%) rises by two per level the attacker leads by,
+## capped as any accuracy is, and rolls through the ordinary stage machinery, so
+## lowered evasion or raised accuracy helps a one-hit KO like any other move.
 static func _ohko(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	var defender: Gen2BattleMon = turn.defender()
@@ -975,12 +935,10 @@ static func _recharge(turn: Gen2Turn) -> void:
 ## A two-turn move's charge, in the shape [code]docs/CONTRIBUTING.md[/code]
 ## already describes: a list that ends early the first time.
 ##
-## Not charging yet: locks the user in, announces it and ends the move before
-## the damage is even worked out. Already charging, which is the release turn:
-## clears the lock and falls through into the rest of the list, which is an
-## ordinary attack from here. [method Gen2Battle.move_for] is what guarantees
-## the release turn's move is the one that was charged, whatever slot the
-## caller asks for.
+## Not charging yet: lock the user in, announce it and end the move before damage
+## is worked out. Already charging, the release turn: clear the lock and fall
+## through into an ordinary attack. [method Gen2Battle.move_for] guarantees the
+## release turn uses the charged move whatever slot is asked for.
 static func _charge_move(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING):
@@ -1099,16 +1057,14 @@ static func _psych_up(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.STAGES_COPIED)
 
 
-## Locks one of the target's own move slots: whichever one holds
-## [member Gen2BattleMon.last_move_used], found by searching the target's own
-## move list the way the cartridge does rather than by asking which slot it
-## came from, because nothing the attacker did carries that information.
+## Locks whichever of the target's slots holds
+## [member Gen2BattleMon.last_move_used], found by searching the target's move
+## list as the cartridge does, since nothing the attacker did carries the slot.
 ##
-## Fails, doing nothing, if the target has not moved yet this battle, if that
-## move was Struggle, if the target is already disabled, if the move it used
-## is no longer in its list at all (a level-up mid-battle can replace a slot;
-## the cartridge never has to consider this since nothing on it can), or if
-## the slot that move sits in has already run out of PP.
+## Fails silently if the target has not moved this battle, the move was Struggle,
+## the target is already disabled, the move is no longer in its list (a mid-battle
+## level up can replace a slot, which the cartridge never has to consider), or
+## that slot is out of PP.
 static func _disable(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.disabled_slot >= 0:
@@ -1134,14 +1090,12 @@ static func _disable(turn: Gen2Turn) -> void:
 
 
 ## Locks the target into repeating [member Gen2BattleMon.last_move_used] for a
-## few turns, found the same way [method _disable] finds its own slot and
-## refused for the same reasons, plus two the cartridge names outright rather
-## than leaving to a structural check: see [constant ENCORE_EXCLUDED_MOVES].
+## few turns, found and refused as [method _disable] does, plus the two moves the
+## cartridge names outright: see [constant ENCORE_EXCLUDED_MOVES].
 ##
-## What actually forces the move each turn is not here: [method Gen2Battle.
-## effective_slot] and [method Gen2Battle.move_for] read
-## [member Gen2BattleMon.encored_slot] back at the point a side acts, the same
-## way a two-turn move's release turn is forced through
+## The forcing happens elsewhere: [method Gen2Battle.effective_slot] and
+## [method Gen2Battle.move_for] read [member Gen2BattleMon.encored_slot] when a
+## side acts, as a two-turn release reads
 ## [member Gen2BattleMon.charged_move].
 static func _encore(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
@@ -1166,11 +1120,10 @@ static func _encore(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.ENCORE_INFLICTED, {"target": turn.target, "slot": slot, "move": last_move})
 
 
-## Puts the target in love, provided the user and the target have opposite,
-## known genders (a genderless Pokémon or a matching pair refuses the same way
-## a Pokémon already in love does) and the target is not already smitten.
-## [constant Gen2EffectCommands.CHECK_STATUS] is what rolls, every turn from
-## here on, whether that stops the target moving at all.
+## Puts the target in love, given opposite known genders (a genderless Pokémon or
+## a matching pair refuses, as does one already in love).
+## [constant Gen2EffectCommands.CHECK_STATUS] rolls each turn from here on
+## whether that stops the target moving.
 static func _attract(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	var defender: Gen2BattleMon = turn.defender()
@@ -1220,17 +1173,14 @@ static func _focus_energy(turn: Gen2Turn) -> void:
 ## Moves one stat by one command's worth, and writes down who it happened to and
 ## whether it actually moved, for the message step behind it to read.
 ##
-## A secondary effect's failed roll skips this the same way it skips a status:
-## the damage in front of it has already landed, and what was behind the roll is
-## the only thing the roll can still cost.
+## A secondary effect's failed roll skips this as it skips a status: the damage in
+## front has already landed.
 ##
-## A drop aimed at a target shielded by Mist never reaches
-## [method Gen2BattleMon.change_stage] at all: every entry that lowers a stat
-## targets the opponent rather than the user (`entry[2]` is false for exactly
-## that set), which is the same thing Mist itself only ever blocks. A rise
-## always targets the user and is never checked against it, the same as the
-## cartridge's own [code]CheckMist[/code] only gates the "down" and "down2"
-## effect-byte ranges.
+## A drop against a target shielded by Mist never reaches
+## [method Gen2BattleMon.change_stage]: every lowering entry targets the opponent
+## (`entry[2]` false), which is exactly what Mist blocks. A rise always targets
+## the user and is never checked, matching [code]CheckMist[/code] gating only the
+## "down" and "down2" effect-byte ranges.
 static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	var entry: Array = STAT_COMMANDS[command]
 	var stat_key: String = String(entry[0])
@@ -1284,17 +1234,14 @@ static func _stat_message(turn: Gen2Turn) -> void:
 	})
 
 
-## Says a stat could not move. Only reached from a status move's own sequence,
-## which is the only place the cartridge follows a message step with this one:
-## an on-hit drop blocked by Mist has no fail-text step behind it at all, the
-## same silent failure any other on-hit drop that misses its own roll already
-## gets, since [code]data/moves/effects.asm[/code] never follows one with
-## [code]statdownfailtext[/code] either.
+## Says a stat could not move. Only reached from a status move's sequence, the
+## only place [code]data/moves/effects.asm[/code] follows a message step with
+## [code]statdownfailtext[/code]; an on-hit drop blocked by Mist fails silently,
+## like any on-hit drop that misses its roll.
 ##
-## Mist gets its own line rather than the generic one: the cartridge's own
+## Mist gets its own line, because
 ## [code]BattleCommand_StatDownFailText[/code] prints
-## [code]ProtectedByMistText[/code] for exactly this case, not "won't go any
-## lower".
+## [code]ProtectedByMistText[/code] here rather than "won't go any lower".
 static func _stat_fail_text(turn: Gen2Turn) -> void:
 	if turn.stat_moved:
 		return

--- a/game/battle/experience.gd
+++ b/game/battle/experience.gd
@@ -4,23 +4,20 @@ extends RefCounted
 ## Experience: the six growth curves, how much a defeated Pokémon is worth, and
 ## how much of it a fainted Pokémon leaves behind in stat experience.
 ##
-## [RefCounted] and static throughout, like [Gen2Stats] and [Gen2Damage]: pure
-## integer arithmetic in the hardware's own order, with every division
-## truncating. A curve rearranged into something tidier gives a different
-## answer, the same caution the rest of the battle engine's arithmetic carries.
+## [RefCounted] and static like [Gen2Stats] and [Gen2Damage]: integer arithmetic
+## in the hardware's order, every division truncating, so a tidier rearrangement
+## gives a different answer.
 ##
-## The six curves are [code]CalcExpAtLevel[/code]'s own formula, pinned against
-## pokecrystal's [code]data/growth_rates.asm[/code] and cross-checked against
-## the real cartridges: every one of the 251 species in all three games reads
-## the growth rate and base experience this module expects, not a plausible
-## guess at either. See [code]tools/dump_tables.gd[/code]'s [code]growth[/code]
-## view.
+## The six curves are [code]CalcExpAtLevel[/code]'s formula, pinned against
+## [code]data/growth_rates.asm[/code] and cross-checked against the real
+## cartridges: all 251 species in all three games read the growth rate and base
+## experience this module expects. See [code]tools/dump_tables.gd[/code]'s
+## [code]growth[/code] view.
 
-## The cartridge's own byte order for [code]wBaseGrowthRate[/code]
-## ([code]GROWTH_*[/code] in pokecrystal). Only four of the six are ever used by
-## a real species in any of the three games (medium fast, medium slow, fast,
-## slow); the other two are named for completeness, not because a species
-## exercises them.
+## The cartridge's byte order for [code]wBaseGrowthRate[/code]
+## ([code]GROWTH_*[/code]). Only four are used by a real species in any of the
+## three games (medium fast, medium slow, fast, slow); the other two are named
+## for completeness.
 const GROWTH_MEDIUM_FAST: int = 0
 const GROWTH_SLIGHTLY_FAST: int = 1
 const GROWTH_SLIGHTLY_SLOW: int = 2
@@ -29,10 +26,9 @@ const GROWTH_FAST: int = 4
 const GROWTH_SLOW: int = 5
 
 ## Each curve as [code]a, b, c, d, e[/code] in
-## [code]exp(n) = floor(a*n^3/b) + c*n^2 + d*n - e[/code], the cartridge's own
-## formula and its own coefficients. [code]c[/code] carries its sign; the
-## cartridge stores it as a magnitude with the sign in a separate bit, which is
-## a storage detail this table does not need to repeat.
+## [code]exp(n) = floor(a*n^3/b) + c*n^2 + d*n - e[/code], the cartridge's formula
+## and coefficients. [code]c[/code] carries its sign here; the cartridge stores a
+## magnitude with the sign in a separate bit, a storage detail not repeated.
 const CURVES: Dictionary = {
 	GROWTH_MEDIUM_FAST: [1, 1, 0, 0, 0],
 	GROWTH_SLIGHTLY_FAST: [3, 4, 10, 0, 30],
@@ -50,13 +46,10 @@ const MAX_LEVEL: int = 100
 ## answer ready rather than to ever actually be reached.
 const MAX_EXP: int = 0xFFFFFF
 
-## How many of the five stats a fainted Pokémon leaves behind in stat
-## experience: hit points, Attack, Defense, Speed, and Special. The cartridge
-## copies the *base Sp. Attack* into this fifth slot and never touches base
-## Sp. Defense at all, which is why [Gen2BattleMon.stat_exp] keeps one
-## [code]"special"[/code] entry rather than two: Special Defense's stat
-## experience is Special Attack's, borrowed, the same half-finished split the
-## base stats themselves show elsewhere in these games.
+## The five stats a fainted Pokémon leaves behind: HP, Attack, Defense, Speed and
+## Special. The cartridge copies *base Sp. Attack* into the fifth slot and never
+## touches base Sp. Defense, which is why [Gen2BattleMon.stat_exp] keeps one
+## [code]"special"[/code] entry rather than two.
 const STAT_EXP_KEYS: Array = ["hp", "attack", "defense", "speed", "special"]
 
 ## Awarding exp divides a base stat by the participant count, and the
@@ -65,14 +58,12 @@ const STAT_EXP_KEYS: Array = ["hp", "attack", "defense", "speed", "special"]
 ## keeps the whole base stat rather than losing a remainder to the floor.
 const MIN_PARTICIPANTS_TO_SPLIT: int = 2
 
-## The exp award is multiplied by 1.5, truncating, for a trainer battle. The
-## cartridge computes this as [code]value + floor(value / 2)[/code] rather than
-## a multiply by 3 and a divide by 2, which agree except where the extra
-## truncation the multiply avoids would have mattered; this is the shape the
-## disassembly's own [code]BoostExp[/code] uses, so it is the shape kept here.
-## A traded Pokémon's own 1.5x and a held Lucky Egg's are the cartridge's other
-## two boosts; neither is implemented, because nothing in this project has an
-## original trainer ID or an item engine to read either from yet.
+## A trainer battle multiplies the award by 1.5, truncating, computed as
+## [code]value + floor(value / 2)[/code] rather than multiply-by-3-divide-by-2:
+## the two disagree exactly where the extra truncation matters, and this is
+## [code]BoostExp[/code]'s own shape. The traded and Lucky Egg boosts are not
+## implemented, since nothing here has an original trainer ID or an item
+## engine.
 const TRAINER_BONUS_NUMERATOR: int = 3
 const TRAINER_BONUS_DENOMINATOR: int = 2
 
@@ -80,13 +71,11 @@ const TRAINER_BONUS_DENOMINATOR: int = 2
 ## The total experience a Pokémon on [param growth_rate]'s curve has at exactly
 ## [param level].
 ##
-## Level 1 is hard-coded to zero rather than run through the formula. The
-## cartridge's own formula underflows there for the medium slow curve
-## ([code]floor(6/5) - 15 + 100 - 140[/code] is negative, and the three-byte
-## total it is stored in has no sign), which pokecrystal's own
-## [code]docs/bugs_and_glitches.md[/code] documents as a bug and not a rule: a
-## level 1 Pokémon has no experience by definition, on every curve, and that is
-## the answer kept here rather than the underflow.
+## Level 1 is hard-coded to zero rather than run through the formula, which
+## underflows there on the medium slow curve
+## ([code]floor(6/5) - 15 + 100 - 140[/code] is negative in an unsigned
+## three-byte total). [code]docs/bugs_and_glitches.md[/code] documents that as a
+## bug, not a rule: a level 1 Pokémon has no experience on any curve.
 static func total_exp_at(growth_rate: int, level: int) -> int:
 	var n: int = clampi(level, 1, MAX_LEVEL)
 	if n <= 1:
@@ -121,12 +110,9 @@ static func level_for_exp(growth_rate: int, experience_points: int) -> int:
 ## worth, before it is split among anyone: [code]floor(base_exp * level / 7)[/code],
 ## then a trainer battle's own 1.5x on top.
 ##
-## Not divided by how many participants there were: that is the stat
-## experience's rule, not this one's. The cartridge's own
-## [code]GiveExperiencePoints[/code] hands every participant this same full
-## figure and only ever divides the *base stats* that feed
-## [method stat_exp_gain], which is easy to get backward from how recoil and
-## drain both split by what actually happened rather than by headcount.
+## Not divided by participant count: that is the stat experience's rule.
+## [code]GiveExperiencePoints[/code] hands every participant this full figure and
+## only divides the *base stats* feeding [method stat_exp_gain].
 static func award_for(defeated_level: int, defeated_base_exp: int, is_trainer_battle: bool) -> int:
 	@warning_ignore("integer_division")
 	var award: int = (defeated_base_exp * defeated_level) / 7
@@ -135,21 +121,19 @@ static func award_for(defeated_level: int, defeated_base_exp: int, is_trainer_ba
 	return clampi(award, 0, MAX_EXP)
 
 
-## The 1.5x a trainer battle, a traded Pokémon or a held Lucky Egg each apply,
-## as the cartridge computes it: half of the value, truncated, added back to
-## the whole. Kept as its own step because a second boost stacking on the first
-## truncates its own half separately, and would give a different answer from
-## multiplying by 2.25 in one step.
+## The 1.5x a trainer battle, a traded Pokémon or a held Lucky Egg each apply, as
+## the cartridge computes it: half the value, truncated, added back. Its own step
+## because a second boost truncates its own half separately and would differ from
+## multiplying by 2.25 in one go.
 static func _boost(value: int) -> int:
 	@warning_ignore("integer_division")
 	return value + (value / 2)
 
 
 ## How much of the five stats in [constant STAT_EXP_KEYS] a fainted Pokémon
-## leaves behind, keyed the way [Gen2BattleMon.stat_exp] is. Split evenly
-## across [param participants] when there is more than one, each share
-## truncated on its own rather than the total truncated once, because that is
-## the cartridge's own per-stat division, not a single combined one.
+## leaves behind, keyed like [Gen2BattleMon.stat_exp]. Split evenly across
+## [param participants], each share truncated on its own rather than the total
+## truncated once: the cartridge divides per stat, not once combined.
 static func stat_exp_gain(defeated_stats: Dictionary, participants: int) -> Dictionary:
 	var count: int = maxi(participants, 1)
 	var out: Dictionary = {}

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -3,44 +3,36 @@ extends RefCounted
 
 ## What each move's effect byte makes it do, as a list of commands.
 ##
-## This is the table the cartridge keeps in [code]data/moves/effects.asm[/code],
-## and the sequences below are meant to be read against it. Every move in these
-## games is one of these lists; a move number picks an effect byte and an effect
-## byte picks a list.
+## The table the cartridge keeps in [code]data/moves/effects.asm[/code], to be
+## read against it. A move number picks an effect byte and an effect byte picks a
+## list.
 ##
-## Almost every list is [constant NORMAL_HIT] with something inserted. That is
-## the whole reason for keeping the shape: burn, paralysis, the stat changes,
-## the multi-hit moves and the rest arrive as commands added to a list rather
-## than as branches added to the turn loop, and none of them reaches
-## [Gen2Battle], which knows only how to run a list.
-##
-## The effect bytes themselves are the cartridge's own, out of the move table.
+## Almost every list is [constant NORMAL_HIT] with something inserted, which is
+## the reason for keeping the shape: burn, paralysis, stat changes and the
+## multi-hit moves are commands added to a list rather than branches added to the
+## turn loop. The effect bytes are the cartridge's own.
 
-## The effect bytes with a list of their own. The numbers are the cartridge's,
-## out of the move table.
+## The effect bytes with a list of their own, numbered as the cartridge's move
+## table numbers them.
 ##
-## Recoil is here because Struggle needs it: a Pokémon with nothing left to spend
-## has to be able to hurt itself, or two empty Pokémon never finish their battle.
-## The rest are the status conditions, in the two shapes they come in: a move
-## whose whole purpose is the status, and a move that does damage and leaves
+## Recoil is here because Struggle needs it: without it two empty Pokémon never
+## finish their battle. The rest are the status conditions in their two shapes, a
+## move whose whole purpose is the status and a move that damages and leaves
 ## something behind on a roll.
 const SLEEP: int = 1
 const POISON_HIT: int = 2
-## Absorb, Mega Drain, Giga Drain and Leech Life: half of what the hit
-## calculated healed onto the attacker. Named for the disassembly's own
-## "LeechHit" label rather than a bare "drain", so this reads against
-## `data/moves/effects_pointers.asm` line for line the way every other
-## constant here does.
+## Absorb, Mega Drain, Giga Drain and Leech Life: half the calculated hit healed
+## onto the attacker. Named for the disassembly's "LeechHit" label rather than a
+## bare "drain", so this reads against `data/moves/effects_pointers.asm` line for
+## line.
 const LEECH_HIT: int = 3
 const BURN_HIT: int = 4
 const FREEZE_HIT: int = 5
 const PARALYZE_HIT: int = 6
-## Dream Eater: the same drain [constant LEECH_HIT] leaves, gated on the
-## target being asleep. The gate lives inside
-## [method Gen2EffectCommands._check_hit] rather than a command of its own,
-## because that is where the real cartridge's shared accuracy check puts it: a
-## Dream Eater used on a Pokémon that is not asleep is read as a miss, not as
-## a separate failure.
+## Dream Eater: [constant LEECH_HIT]'s drain gated on the target being asleep.
+## The gate lives inside [method Gen2EffectCommands._check_hit] rather than its
+## own command, because that is where the cartridge's shared accuracy check puts
+## it: against an awake target it reads as a miss, not a separate failure.
 const DREAM_EATER: int = 8
 const TOXIC: int = 33
 const RECOIL_HIT: int = 48
@@ -78,13 +70,11 @@ const LEVEL_DAMAGE: int = 87
 ## Psywave: a roll of the user's own, [method Gen2Damage.psywave_damage].
 const PSYWAVE: int = 88
 
-## The substatuses: flinching and confusion, each in the two shapes a status
-## can come in, plus Hyper Beam's own effect, which is the only move that
-## recharges. The numbers are read off the real cartridge's move table with
-## [code]tools/dump_tables.gd[/code], the same way every other effect byte here
-## was: Rolling Kick, Headbutt, Bite, Bone Club and Hyper Fang all carry 31;
-## Confusion and Psybeam carry 76; Supersonic and Confuse Ray carry 49; Hyper
-## Beam alone carries 80.
+## The substatuses: flinching and confusion in both shapes, plus Hyper Beam, the
+## only move that recharges. Numbers read off the real move table with
+## [code]tools/dump_tables.gd[/code]: Rolling Kick, Headbutt, Bite, Bone Club and
+## Hyper Fang carry 31; Confusion and Psybeam 76; Supersonic and Confuse Ray 49;
+## Hyper Beam 80.
 const FLINCH_HIT: int = 31
 const CONFUSE_HIT: int = 76
 const CONFUSE: int = 49
@@ -136,12 +126,11 @@ const HAZE: int = 25
 const BELLY_DRUM: int = 142
 const PSYCH_UP: int = 143
 
-## Disable, Mist, Focus Energy, Attract and Encore: the numbers are read off
-## the real cartridge with [code]tools/dump_tables.gd -- gold moves[/code], the
-## same way every other effect byte here was, since Gold, Silver and Crystal do
-## not share Generation 1's numbering. Mist and Focus Energy need nothing new;
-## Disable, Attract and Encore are what
-## [member Gen2BattleMon.disabled_slot]/[member Gen2BattleMon.encored_slot] and
+## Disable, Mist, Focus Energy, Attract and Encore, numbered off the real
+## cartridge with [code]tools/dump_tables.gd -- gold moves[/code], since Gen II
+## does not share Generation 1's numbering. Mist and Focus Energy need nothing
+## new; Disable, Attract and Encore are what
+## [member Gen2BattleMon.disabled_slot], [member Gen2BattleMon.encored_slot] and
 ## [method Gen2BattleMon.gender] exist for.
 const DISABLE: int = 86
 const MIST: int = 46

--- a/game/battle/party.gd
+++ b/game/battle/party.gd
@@ -3,14 +3,12 @@ extends RefCounted
 
 ## The Pokémon one side of a battle has, and which of them is out.
 ##
-## A party is an ordered list and a cursor into it, not a set: the order is what
-## a switch menu shows and what a replacement after a faint is chosen from, and
-## the first entry is who leads. A wild battle is a party of one, which is why
-## nothing here treats that as a special case.
+## An ordered list and a cursor into it, not a set: the order is what a switch
+## menu shows and what a replacement is chosen from, and the first entry leads. A
+## wild battle is a party of one, so it needs no special case.
 ##
-## Fainted Pokémon stay in the list. They are still carried, they still count
-## against the six, and a battle is lost when every one of them is down rather
-## than when the list runs out.
+## Fainted Pokémon stay in the list, still counting against the six. A battle is
+## lost when all of them are down, not when the list runs out.
 
 ## What a trainer can carry. Six is a rule of these games rather than of this
 ## class, but a party that is longer is a bug somewhere upstream and is worth
@@ -91,11 +89,9 @@ func first_healthy() -> int:
 
 ## Puts [param index] out, and answers whether it went.
 ##
-## The Pokémon leaving keeps its health and its PP and loses its stat stages and
-## everything [Gen2Substatus] holds, which is the cartridge's rule and the
-## reason a stage is worth resetting rather than a Pokémon worth rebuilding: a
-## stage is a lens on a stat and the lens does not survive the walk back to the
-## ball, and confusion, a charge or a recharge do not survive it either.
+## The Pokémon leaving keeps its health and PP and loses its stat stages and
+## everything [Gen2Substatus] holds. A stage is a lens on a stat, and neither it
+## nor confusion, a charge or a recharge survives the walk back to the ball.
 func send_out(index: int) -> bool:
 	if not can_send_out(index):
 		return false

--- a/game/battle/stats.gd
+++ b/game/battle/stats.gd
@@ -4,15 +4,13 @@ extends RefCounted
 ## The stat arithmetic: base stats, DVs and stat experience into the numbers a
 ## battle is fought with.
 ##
-## Integer arithmetic throughout, in the order the hardware does it. That is not
-## nostalgia: every division here truncates, and a formula rearranged to be
-## tidier gives a different answer often enough to matter. A Pokémon that
-## survives on one hit point does so because of a truncation somewhere in here.
+## Integer arithmetic in the hardware's order: every division truncates, and a
+## tidier rearrangement gives a different answer often enough to matter.
 ##
-## Generation 2 has DVs and stat experience, not the effort values later games
-## use. A DV is four bits per stat, and HP's is assembled from the low bit of the
-## other four rather than stored, which is why a shiny Pokémon has the stats it
-## does: shininess is a pattern in the same nibbles.
+## Generation 2 has DVs and stat experience, not later games' effort values. A DV
+## is four bits per stat, and HP's is assembled from the low bit of the other
+## four rather than stored, which is why a shiny Pokémon has the stats it does:
+## shininess is a pattern in the same nibbles.
 
 ## The two constants the formula ends on. A stat is never below its floor, so a
 ## level 1 Pokémon with nothing going for it still has 5 of everything and 11 hit
@@ -59,11 +57,10 @@ const DV_SPECIAL_SHIFT: int = 0
 ## square is at least [param value], never below 1 and never above
 ## [constant MAX_SQUARE_ROOT].
 ##
-## This is a ceiling, not a floor, which is easy to get wrong and shows up as a
-## stat being one out on a Pokémon that has been trained at all. The cartridge
-## scans a table of squares for the first entry that is not smaller than the
-## stat experience, and the first entry is 1, so a Pokémon with no stat
-## experience answers 1 rather than 0.
+## A ceiling, not a floor: getting it wrong shows up as a stat being one out on
+## any trained Pokémon. The cartridge scans a table of squares for the first
+## entry not smaller than the stat experience, and that table starts at 1, so an
+## untrained Pokémon answers 1 rather than 0.
 static func square_root(value: int) -> int:
 	for root: int in range(1, MAX_SQUARE_ROOT):
 		if root * root >= value:

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -3,17 +3,15 @@ extends RefCounted
 
 ## The status byte, and the four things it does to a Pokémon.
 ##
-## One byte holds all of it, the way the cartridge stores it: the low three bits
-## are how many turns of sleep are left and the four above them are one flag
-## each. That is not a storage detail worth hiding, because it is also the rule:
-## a Pokémon has one status at a time, and inflicting a second is refused rather
-## than added, which falls out of the byte being checked as a whole.
+## One byte, as the cartridge stores it: the low three bits are turns of sleep
+## left and the four above are one flag each. That is also the rule, not just
+## storage: one status at a time, a second refused rather than added, which falls
+## out of checking the byte as a whole.
 ##
-## What the four do is spread across the turn rather than gathered here. Sleep,
-## freeze and paralysis stop a Pokémon moving and are checked before its move;
-## burn and paralysis bend a stat and are applied where the stat is read; burn
-## and poison take a slice off at the end of the turn. This class is the
-## arithmetic behind all of that and holds no state of its own.
+## What the four do is spread across the turn. Sleep, freeze and paralysis are
+## checked before a move; burn and paralysis bend a stat where it is read; burn
+## and poison take a slice at the end of the turn. This class is the arithmetic
+## behind that and holds no state.
 
 ## The low three bits: turns of sleep left, from 1 to 7.
 const SLEEP_MASK: int = 0b111

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -4,31 +4,24 @@ extends RefCounted
 ## The volatile flags of battle state, for everything the status byte cannot
 ## hold.
 ##
-## [Gen2Status] is deliberately one status at a time, which is the cartridge's
-## own rule: a Pokémon that is already poisoned cannot also be confused by
-## refusing a second flag on the same byte. Confusion, flinching, being locked
-## into a recharge turn or a two-turn move's charge, Disable, Attract, Encore,
-## Mist, Focus Energy, flying and underground are all independent of that and
-## of each other, so they live apart from it.
+## [Gen2Status] is one status at a time, the cartridge's rule. Confusion,
+## flinching, a recharge turn, a two-turn charge, Disable, Attract, Encore, Mist,
+## Focus Energy, flying and underground are independent of that and of each
+## other, so they live apart from it.
 ##
-## The cartridge itself keeps these as five separate bytes
-## (`wPlayerSubStatus1` through `wPlayerSubStatus5`), not one: this project
-## folds them into a single int because nothing here needs to address one of
-## the five in isolation the way the cartridge's own bit-numbering does, and a
-## flag is a flag regardless of which byte it started on.
+## The cartridge keeps these as five bytes (`wPlayerSubStatus1` through
+## `wPlayerSubStatus5`); this folds them into one int, since nothing here needs
+## to address a byte in isolation.
 ##
-## Unlike [Gen2Status] this one is not the whole of its state: a few of these
-## flags need a counter alongside them (how many turns of confusion are left,
-## which move was charged, which slot is disabled and for how long, or how many
-## turns Rollout or a rampage has left), which is why [Gen2BattleMon] keeps
-## those as separate fields next to
-## [member Gen2BattleMon.substatus] rather than packing them into the byte.
-## This class stays pure arithmetic and holds no state of its own, the same
-## shape as [Gen2Status].
+## Some flags need a counter beside them (turns of confusion, the charged move,
+## the disabled slot and its duration, Rollout or rampage turns), which
+## [Gen2BattleMon] keeps as separate fields next to
+## [member Gen2BattleMon.substatus]. This class is pure arithmetic and holds no
+## state, the same shape as [Gen2Status].
 ##
-## Every flag here clears on a switch, which is what makes it volatile rather
-## than a status: [method Gen2BattleMon.reset_volatile] is the single place that
-## happens, called from [method Gen2Party.send_out] alongside
+## Every flag clears on a switch, which is what makes it volatile:
+## [method Gen2BattleMon.reset_volatile] is the one place that happens, called
+## from [method Gen2Party.send_out] beside
 ## [method Gen2BattleMon.reset_stages].
 
 const CONFUSED: int = 1 << 0

--- a/game/battle/trainer_party.gd
+++ b/game/battle/trainer_party.gd
@@ -3,23 +3,19 @@ extends RefCounted
 
 ## Turns one of a trainer class's individual trainers into a battle-ready party.
 ##
-## Lives beside the rest of [code]game/battle/[/code] rather than next to
-## [Gen2Learnset], because what it produces is [Gen2BattleMon]s and
-## [Gen2Party]s, and the data layer holds no battle types. [RefCounted] and
-## static throughout, the same as [Gen2Learnset]: nothing here needs a scene,
-## only [GameData] and the trainer number to ask it about.
+## Lives in [code]game/battle/[/code] rather than beside [Gen2Learnset] because
+## it produces [Gen2BattleMon]s and [Gen2Party]s, and the data layer holds no
+## battle types. [RefCounted] and static: it needs only [GameData] and a trainer
+## number.
 ##
-## A NORMAL or ITEM trainer's Pokémon knows what its level says it knows, out of
-## the learnset, the same as a wild one. A MOVES or ITEM_MOVES trainer's Pokémon
-## knows exactly the moves stored with it instead, which is why the two are read
-## through [method GameData.moves_at_level] and the stored list respectively
-## rather than through one shared path.
+## A NORMAL or ITEM trainer's Pokémon knows what its level teaches, from the
+## learnset, like a wild one; a MOVES or ITEM_MOVES trainer's knows exactly the
+## moves stored with it. Hence [method GameData.moves_at_level] for one and the
+## stored list for the other.
 ##
-## Trainer Pokémon carry the cartridge's own per-trainer-class DVs
-## ([method GameData.trainer_dvs]), not [constant Gen2BattleMon.PERFECT_DVS]: a
-## trainer's whole team shares one fixed set of DVs on the real cartridge,
-## which is why the word is asked for once per class rather than once per
-## Pokémon.
+## Trainer Pokémon carry the per-class DVs ([method GameData.trainer_dvs]), not
+## [constant Gen2BattleMon.PERFECT_DVS]: a trainer's whole team shares one fixed
+## word, asked for once per class.
 
 
 ## The party a trainer class's [param index]th trainer brings, or null if

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -3,15 +3,12 @@ extends RefCounted
 
 ## One move being used, while it is being used.
 ##
-## The commands in [Gen2EffectCommands] are steps in a sequence and have to hand
-## each other their working: the damage step writes down what it worked out and
-## the step that applies it reads that back, rather than either of them doing the
-## other's job. This is where that working lives, and it lasts exactly as long as
-## the move does.
+## The commands in [Gen2EffectCommands] hand each other their working: the damage
+## step writes down what it calculated and the applying step reads it back. This
+## is where that lives, for exactly as long as the move does.
 ##
-## It is not a copy of the battle. Everything about the two Pokémon is read
-## through the battle every time, so a command that changes one is seen by the
-## commands after it.
+## Not a copy of the battle: both Pokémon are read through the battle every time,
+## so a command that changes one is seen by the commands after it.
 
 var battle: Gen2Battle = null
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -3,24 +3,18 @@ extends RefCounted
 
 ## A decoded cartridge, read back out of the cache.
 ##
-## The importer's counterpart, and the only way the engine sees cartridge
-## content: nothing downstream of here opens a ROM, and nothing here knows what
-## a ROM is. It is [RefCounted] and scene-free like the layer that wrote it, so
-## a battle or a menu can be exercised in a test with no display.
+## The importer's counterpart and the only way the engine sees cartridge content:
+## nothing downstream opens a ROM, and nothing here knows what a ROM is.
+## [RefCounted] and scene-free, so a battle or menu can run in a test.
 ##
-## JSON has one number type, so every number in the cache comes back as a float
-## and every comparison against an int quietly fails. Coercion happens here,
-## once, rather than at each of the places that would otherwise have to remember.
+## JSON has one number type, so every cached number returns as a float and every
+## comparison against an int quietly fails. Coercion happens here, once.
 ##
-## Index buffers are loaded on first use and kept. A pic atlas is a megabyte or
-## so of indices; reading four of them to draw one sprite would be a waste, and
-## re-reading one per frame would be worse.
-##
-## The world sections are read the same way, for a blunter reason: scripts, text
-## and audio are almost all of a cache, and the launcher, the pic viewer and a
-## battle never look at any of them. Reading them at open() made listing three
-## games cost more than entering one, and put the whole cache in memory on a
-## phone that has no room for it.
+## Index buffers load on first use and are kept: a pic atlas is about a megabyte
+## of indices. World sections load the same way for a blunter reason, that
+## scripts, text and audio are almost all of a cache and the launcher, pic viewer
+## and battle never read them; reading them at open() made listing three games
+## cost more than entering one and put the whole cache in phone memory.
 
 var id: StringName = &""
 var sha1: String = ""
@@ -498,14 +492,12 @@ func type_name(number: int) -> String:
 ## How effective [param attacking] is against [param defending], in tenths: 0 for
 ## an immunity, 5 for a resistance, 20 for a weakness and 10 for everything else.
 ##
-## Tenths rather than a float because that is what the cartridge stores and what
-## the damage formula divides by, and because the games truncate after applying
-## each of a defender's two types. A float would agree most of the time and
-## disagree exactly where it matters.
+## Tenths rather than a float, because that is what the cartridge stores and what
+## the damage formula divides by, and the games truncate after each of a
+## defender's two types. A float would disagree exactly where it matters.
 ##
-## The chart lists only the exceptions, so an absent pair is neutral, and a type
-## number that is not in the chart at all (the padding run, which is where Curse
-## lives) is neutral against everything by the same rule.
+## Only exceptions are listed, so an absent pair is neutral, as is a type number
+## missing from the chart entirely (the padding run, where Curse lives).
 ##
 ## [param foresight] is whether the defender has been identified, which cancels
 ## the Ghost immunities and nothing else.
@@ -520,16 +512,14 @@ func type_matchup(attacking: int, defending: int, foresight: bool = false) -> in
 ## in tenths, accumulated the way the cartridge accumulates it: start at ten,
 ## multiply by each matching type in turn, and truncate after each.
 ##
-## This is the number a battle announces, not the number it deals damage with.
-## The two are computed separately on the hardware and do not always agree: the
-## accumulator truncates in tenths, so a move resisted by both halves of a dual
-## type reports 2 rather than 2.5, while the damage is worked out by multiplying
-## the damage itself once per type. Use this for the message and
-## [method type_matchup] per type for the damage.
+## The number a battle announces, not the one it deals damage with. The hardware
+## computes them separately and they disagree: this accumulator truncates in
+## tenths, so a move resisted by both halves of a dual type reports 2 rather than
+## 2.5, while damage multiplies the damage itself once per type. Use this for the
+## message and [method type_matchup] per type for damage.
 ##
-## A single-type Pokémon carries its type in both slots. The cartridge applies a
-## row at most once, matching either slot, so a repeat is skipped here for the
-## same reason.
+## A single-type Pokémon carries its type in both slots, and the cartridge
+## applies a row at most once, so a repeat is skipped here too.
 func type_effectiveness(attacking: int, defending: Array, foresight: bool = false) -> int:
 	var out: int = RomLayout.MATCHUP_EFFECTIVE
 	var applied: Array = []

--- a/game/data/learnset.gd
+++ b/game/data/learnset.gd
@@ -3,27 +3,23 @@ extends RefCounted
 
 ## What a Pokémon knows, worked out from its level-up moves.
 ##
-## The cartridge asks this in two different ways and gets two different answers,
-## so both are here and neither is the other's shortcut:
+## The cartridge asks two different questions and gets two different answers, so
+## both are here and neither is the other's shortcut:
 ##
-## [method moves_at_level] is how a Pokémon that has just been brought into
-## existence is furnished, whether it is wild, in a trainer's party or a starter.
-## It walks the list from the beginning and stops at the first move whose level is
-## above the one being filled for.
+## [method moves_at_level] furnishes a newly created Pokémon, wild, trainer-owned
+## or a starter. It walks from the beginning and stops at the first move above
+## the level being filled for.
 ##
-## [method moves_learned_at] is how a Pokémon that has just levelled up is
-## offered something new. It reads the whole list and takes the entries whose
-## level is exactly the one just reached.
+## [method moves_learned_at] offers a just-levelled Pokémon something new. It
+## reads the whole list and takes entries at exactly the level reached.
 ##
-## The difference is not academic. One species' list is not in ascending order
-## (see [constant RomLayout.UNSORTED_LEARNSET_SPECIES]), so the first stops early
-## and misses moves the second finds. That is the cartridge's behaviour, not a
-## rounding of it: a Muk caught in the wild really is missing three moves that a
-## Muk raised to the same level has.
+## One species' list is not ascending (see
+## [constant RomLayout.UNSORTED_LEARNSET_SPECIES]), so the first stops early and
+## misses moves the second finds: a wild Muk really is short three moves a raised
+## Muk has.
 ##
-## [RefCounted] and static throughout: a learnset is an Array of
-## { level, move } out of [GameData], and nothing here needs a cache, a scene or
-## a Pokémon to answer.
+## [RefCounted] and static: a learnset is an Array of { level, move } from
+## [GameData], and nothing here needs a cache, scene or Pokémon.
 
 ## How many moves a Pokémon can know at once.
 const MOVE_SLOTS: int = 4
@@ -32,10 +28,9 @@ const MOVE_SLOTS: int = 4
 ## The moves a Pokémon of [param level] is created knowing, in the order it knows
 ## them.
 ##
-## The list is walked from the start, skipping moves that are already known, and
-## the walk stops at the first entry above [param level] rather than filtering the
-## whole list. When all four slots are full the oldest is pushed out, which is why
-## the answer is the last four learnable moves and not the first four.
+## Walked from the start, skipping already-known moves, stopping at the first
+## entry above [param level] rather than filtering the whole list. A full four
+## slots pushes the oldest out, so the answer is the last four learnable moves.
 static func moves_at_level(learnset: Array, level: int) -> Array:
 	var out: Array = []
 

--- a/game/import/lz_decompressor.gd
+++ b/game/import/lz_decompressor.gd
@@ -18,12 +18,10 @@ extends RefCounted
 ##
 ## The three back-references take an offset that is either a one-byte distance
 ## back from the write head (high bit set) or a two-byte absolute position from
-## the start of the output (high bit clear). Sources may overlap the bytes being
-## written, which is how the format expresses runs, so the copy has to be
-## byte-at-a-time, not a slice.
-##
-## The bit-reversing opcode exists because these streams encode 2bpp tiles: a
-## mirrored sprite half is the same bytes with their bits flipped.
+## the output's start (high bit clear). Sources may overlap the bytes being
+## written, which is how the format expresses runs, so the copy is
+## byte-at-a-time, not a slice. The bit-reversing opcode exists because these
+## streams encode 2bpp tiles: a mirrored sprite half is the same bytes flipped.
 
 enum Op {
 	LITERAL,

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -6,10 +6,10 @@ extends RefCounted
 ## A colour is 15 bits packed little-endian as $0BBBBBGG GGGRRRRR, five bits
 ## per channel, red in the low bits. The hardware ignores bit 15.
 ##
-## A Pokémon's stored palette holds only two colours. The other two are implied:
-## every pic uses index 0 for white and index 3 for black, so only the middle
-## pair varies. Each species stores two such pairs, normal and shiny, which is
-## the whole of what being shiny means to the renderer.
+## A stored Pokémon palette holds only two colours; every pic uses index 0 for
+## white and index 3 for black, so only the middle pair varies. Each species
+## stores two such pairs, normal and shiny, which is all being shiny means to the
+## renderer.
 
 const COLOR_BYTES: int = 2
 ## The two middle colours a pic is drawn with. A trainer class stores one such

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -3,18 +3,16 @@ extends RefCounted
 
 ## Where decoded cartridge data lives between runs.
 ##
-## Under [code]user://[/code], never inside the project: the cache is derived
-## from a commercial cartridge, so it must not be committed and must not end up
-## in an export. Keeping it here is the runtime half of the rule the .gitignore
-## and the pre-commit hook enforce at build time.
+## Under [code]user://[/code], never inside the project: cartridge-derived data
+## must not be committed or exported. This is the runtime half of the rule
+## .gitignore and the pre-commit hook enforce at build time.
 ##
-## One directory per dump, named by game and hash, so two revisions of the same
-## game never share a cache and a re-import cannot half-overwrite the last one.
+## One directory per dump, named by game and hash, so two revisions never share a
+## cache and a re-import cannot half-overwrite the last one.
 ##
-## Pixel data is stored as raw colour indices rather than as images. It is what
-## the renderer wants (palettes are applied per species and per shiny state at
-## draw time), and it avoids a decode round-trip whose exactness would have to
-## be trusted.
+## Pixel data is raw colour indices rather than images: it is what the renderer
+## wants, with palettes applied per species and shiny state at draw time, and it
+## avoids a decode round-trip whose exactness would have to be trusted.
 
 const ROOT: String = "user://rom_cache"
 const MANIFEST: String = "manifest.json"
@@ -225,12 +223,11 @@ static func read_json(path: String) -> Variant:
 
 ## One cached grid of cartridge bytes, packed on the way out of JSON.
 ##
-## A JSON number comes back as a float and an Array of them costs about
-## twenty-six bytes resident per cartridge byte. The map block, map collision and
-## tileset lookup tables are all byte grids that are read once per drawn tile and
-## are resident for every map at once, so they are unboxed here rather than at
-## each lookup. A value that is not an array answers empty, which the record's
-## own bounds checks then report as absent.
+## A JSON number returns as a float, and an Array of them costs about twenty-six
+## resident bytes per cartridge byte. Map block, map collision and tileset lookup
+## tables are byte grids read once per drawn tile and resident for every map at
+## once, so they are unboxed here rather than at each lookup. A non-array answers
+## empty, which the record's bounds checks report as absent.
 static func packed_bytes(value: Variant) -> PackedByteArray:
 	if value is PackedByteArray:
 		return value

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3,16 +3,13 @@ extends RefCounted
 
 ## Decodes a verified cartridge into the cache under [code]user://[/code].
 ##
-## The ROM is an asset database, read once and released. Nothing downstream of
-## the cache holds a reference to it, and nothing in the engine reads cartridge
-## bytes at play time.
+## The ROM is an asset database, read once and released. Nothing downstream holds
+## a reference, and nothing in the engine reads cartridge bytes at play time.
 ##
-## Order of business, and it matters: verify the hash, then verify the layout,
-## then decode. [method verify_layout] exists because an offset table is a claim
-## that can rot: a wrong constant produces plausible-looking garbage rather
-## than an error, and garbage that reaches the cache is indistinguishable from
-## real data later on. Checking a handful of values whose correct answers are
-## known independently turns that class of mistake into an immediate failure.
+## The order matters: verify the hash, then the layout, then decode. A wrong
+## offset produces plausible garbage rather than an error, and garbage in the
+## cache is indistinguishable from real data later, so [method verify_layout]
+## checks values whose correct answers are known independently.
 
 ## Atlas cells are the largest pic of their kind so a renderer can index them
 ## arithmetically; smaller pics sit in the top-left of their cell and record
@@ -243,10 +240,9 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 ## Walks the type matchup chart from its offset to the terminator.
 ##
 ## Returns an Array of { attacker, defender, multiplier, negated_by_foresight },
-## or an empty Array if the walk ran away without finding an end. The rows after
-## the $FE marker carry the flag: they are the matchups that stop applying once
-## Foresight has identified the defender, which is how the cartridge gets a Ghost
-## to be hittable by Normal without a second table.
+## empty if the walk ran away without finding an end. Rows after the $FE marker
+## carry the flag: they stop applying once Foresight identifies the defender,
+## which is how a Ghost becomes hittable by Normal without a second table.
 static func read_matchups(rom: RomFile, layout: Dictionary) -> Array:
 	var at: int = int(layout["type_matchups"])
 	var out: Array = []
@@ -279,12 +275,11 @@ static func read_matchups(rom: RomFile, layout: Dictionary) -> Array:
 
 ## The matchup chart, checked by the shape a chart of exceptions has to have.
 ##
-## It carries no name and no number, but it is unusually hard to land on by
-## accident: every row is two sparse type numbers and a multiplier drawn from a
-## set of three, the whole run has to walk to a $FE and then a $FF at exactly the
-## right distance, and both ends are known content. A wrong offset fails on the
-## very first row, because the padding run between the two groups of type numbers
-## is most of the byte range.
+## No name and no number, but hard to land on by accident: every row is two
+## sparse type numbers and one of three multipliers, the run must reach $FE then
+## $FF at exactly the right distance, and both ends are known content. A wrong
+## offset fails on the first row, since the padding run between the two type
+## groups is most of the byte range.
 static func verify_matchups(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var rows: Array = read_matchups(rom, layout)
 	if rows.is_empty():
@@ -358,17 +353,16 @@ static func verify_matchups(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 ## Walks one species' entry in the combined evolution and level-up move table.
 ##
-## Returns { evolutions, learnset }, or an empty Dictionary if the walk did not
-## find both terminators where a well-formed entry has them. An evolution is
-## { method, parameter, condition, target } and a level-up move is
-## { level, move }; [code]condition[/code] is zero for every method except
-## [constant RomLayout.EVOLVE_STAT], which is the only one that asks two
-## questions.
+## Returns { evolutions, learnset }, empty if both terminators were not where a
+## well-formed entry has them. An evolution is
+## { method, parameter, condition, target }, a level-up move { level, move };
+## [code]condition[/code] is zero except for [constant RomLayout.EVOLVE_STAT],
+## the only method asking two questions.
 ##
-## Level-up moves are kept in the cartridge's order rather than sorted. The order
-## is what decides which move a fresh Pokémon ends up with when more than four are
-## on offer, and one species is genuinely out of order; see
-## [constant RomLayout.UNSORTED_LEARNSET_SPECIES].
+## Level-up moves keep the cartridge's order rather than being sorted: the order
+## decides which move a fresh Pokémon ends up with when more than four are on
+## offer, and one species really is out of order (see
+## [constant RomLayout.UNSORTED_LEARNSET_SPECIES]).
 static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) -> Dictionary:
 	var table: int = RomLayout.evos_attacks_pointer_offset(layout, species)
 	if not rom.in_bounds(table, RomLayout.EVOS_ATTACKS_POINTER_SIZE):
@@ -419,15 +413,13 @@ static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) ->
 
 ## The evolution and learnset table, checked species by species.
 ##
-## Nothing in it says which species an entry belongs to, so what is checked is
-## the shape: 251 pointers into the banked window, each naming a run of
-## evolutions whose methods come from a set of five and whose targets are real
-## species, then a run of level-up moves at real levels teaching real moves. A
-## wrong pointer fails on the first byte it reads, because most byte values are
-## not an evolution method and not a terminator.
-##
-## On top of that, the levels ascend in all but one species, the totals are known,
-## and both ends of the table are content whose answer is known independently.
+## Nothing says which species an entry belongs to, so the shape is checked: 251
+## pointers into the banked window, each naming evolutions whose methods come
+## from a set of five and whose targets are real species, then level-up moves at
+## real levels teaching real moves. A wrong pointer fails on its first byte,
+## since most byte values are neither an evolution method nor a terminator. On
+## top of that, levels ascend in all but one species, the totals are known, and
+## both ends are independently known content.
 static func verify_evos_attacks(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entries: Array = []
 	var evolutions: int = 0
@@ -587,10 +579,9 @@ static func _verify_known_evos_attacks(entries: Array) -> Dictionary:
 ## thing that is known about it independently: the charmap.
 ##
 ## The font is indexed by character code, so the letters and digits [Gen2Text]
-## claims are there must have ink, and the runs of codes it has no character for
-## must be blank. Those runs sit between the alphabets, so an offset out by a
-## single tile drags a blank onto "z" and a glyph onto a code that has none, and
-## the check fails in both directions at once.
+## claims must have ink and the runs it has no character for must be blank. Those
+## runs sit between the alphabets, so an offset out by one tile drags a blank
+## onto "z" and a glyph onto an unmapped code, failing both ways at once.
 static func verify_font(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var offset: int = RomLayout.font_offset(layout)
 	var length: int = RomLayout.FONT_TILES * Gen2Tiles.TILE_1BPP_BYTES
@@ -695,12 +686,10 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## The battle HUD's graphics, checked by the one thing they do that nothing else
 ## in the section does: they count.
 ##
-## A bar's fill levels are consecutive tiles, each lighting one more column than
-## the last, so the ink in that run climbs by exactly two pixels a step. Neither
-## bar has a name or a number in the cartridge, but a run that counts up like
-## that is not something a wrong offset lands on. The two HUD borders have
-## neither content nor a progression, so they are checked the way the text box
-## frames are: every tile has ink, and no two tiles are the same.
+## A bar's fill levels are consecutive tiles each lighting one more column, so
+## the ink climbs by exactly two pixels a step, which a wrong offset does not
+## land on. The two HUD borders have neither content nor a progression, so they
+## are checked like the text box frames: every tile has ink, no two alike.
 static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 
@@ -805,11 +794,10 @@ static func _ink(pixels: PackedByteArray) -> int:
 
 ## The three trainer tables, each checked by what is known about it independently.
 ##
-## They are checked together because they are three views of one numbering, and
-## a mistake in any of them shows up as the three disagreeing: the names say what
-## a class is, the palette table has one entry more than the pic table because
-## the player owns the first one, and the pic table's entries have to decompress
-## into pics of the one size every trainer is drawn at.
+## Checked together because they are three views of one numbering, so a mistake
+## shows up as the three disagreeing: names say what a class is, the palette
+## table has one entry more than the pic table because the player owns the first,
+## and pic entries must decompress to the one size every trainer is drawn at.
 static func verify_trainers(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var names: PackedStringArray = Gen2Text.decode_sequence(
@@ -919,21 +907,18 @@ static func _trainer_palette_check(
 ## Reads the whole trainer party table in one pass: every class's individual
 ## trainers, each a name, a type and a party.
 ##
-## This is not [method verify_trainers]'s table. That one is the class every
-## gym leader shares ("LEADER") and this one is the trainer inside it
-## ("FALKNER"), and the two are read through entirely different pointers, one
-## per class in both.
+## Not [method verify_trainers]'s table: that is the class every gym leader
+## shares ("LEADER"), this is the trainer inside it ("FALKNER"), read through
+## different pointers, one per class in both.
 ##
-## Nothing inside a class's own bytes says where its group ends, so a class's
-## span is bounded by the *next* class's pointer rather than by anything it
-## carries itself, and the last class is walked until a byte that cannot open a
-## name is met instead. One class in every game shares its pointer with the
-## next, which is the one class the games never send into a battle: its honest
-## span is empty, not a copy of the class after it. See
-## [constant RomLayout.EMPTY_TRAINER_CLASS].
+## Nothing in a class's bytes says where its group ends, so its span is bounded
+## by the *next* class's pointer, and the last class is walked until a byte that
+## cannot open a name. One class per game shares its pointer with the next, the
+## one class never sent into battle: its honest span is empty, not a copy of the
+## next. See [constant RomLayout.EMPTY_TRAINER_CLASS].
 ##
-## Returns { ok, message, classes, total }, where [code]classes[/code] is one
-## Array of trainers per class, in order.
+## Returns { ok, message, classes, total }, [code]classes[/code] being one Array
+## of trainers per class, in order.
 static func read_trainer_parties(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var table: int = int(layout["trainer_parties"])
@@ -1209,13 +1194,11 @@ static func read_trainer_dvs(rom: RomFile, layout: Dictionary, trainer_class: in
 	return (rom.u8(offset) << 8) | rom.u8(offset + 1)
 
 
-## The trainer DVs table has no structural shape to check: every nibble is a
-## legal DV, so a wrong offset produces a plausible-looking table exactly the
-## way it always would. What settles it is content whose answer is known
-## independently at both ends, the same way the move and item name tables are
-## checked: Falkner opens the table with his own known DVs, and the class that
-## closes it (a different one per game, since Crystal alone carries
-## MYSTICALMAN) carries its own, stored in the layout as [code]trainer_dvs_last[/code].
+## No structural shape to check: every nibble is a legal DV, so a wrong offset
+## still looks plausible. Settled by content known independently at both ends,
+## like the move and item name tables: Falkner opens with his own known DVs, and
+## the closing class (different per game, since only Crystal carries MYSTICALMAN)
+## carries its own as [code]trainer_dvs_last[/code].
 static func verify_trainer_dvs(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var last_offset: int = RomLayout.trainer_dvs_offset(layout, count)
@@ -1686,16 +1669,13 @@ func _import_types(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 
 ## Decodes the trainer classes: a name and the two colours the class is drawn in.
 ##
-## A class has one palette and no shiny counterpart, so the pair is stored flat
-## rather than under a key, and the pic is found by class number in the trainer
-## atlas the way a species' is in the front one.
-## Decodes the trainer classes and, behind them, the trainer party table (who
-## carries what), the trainer attributes table (how the class's AI plays it)
-## and the trainer DVs table (how good its Pokémon's stats are). The four are
-## kept on the one entry rather than split into cache files of their own, the
-## way a species' evolutions and learnset are, because a class name, its
-## trainers, its own AI behaviour and its own DVs are four tables one class
-## number addresses, not four separate questions.
+## A class has one palette and no shiny counterpart, so the pair is stored flat,
+## and the pic is found by class number in the trainer atlas.
+##
+## Behind the classes sit the party table (who carries what), the attributes
+## table (how the class's AI plays it) and the DVs table. All four stay on one
+## entry rather than in separate cache files, because they are four tables one
+## class number addresses, not four separate questions.
 func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var names: PackedStringArray = Gen2Text.decode_sequence(
@@ -1737,16 +1717,14 @@ func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## Decodes the fixed tile sheets: the font, the eight text box borders and the
 ## battle HUD's graphics, each as one strip of tiles.
 ##
-## None of them is compressed and none is per-species, so unlike a pic there is
-## nothing to look up: each is a fixed run of tiles at a known place. They are
-## kept as strips because each is addressed by a number, whether a character code
-## or a tile in a bar, and a strip turns that number into a horizontal offset and
-## nothing else.
+## None is compressed or per-species, so there is nothing to look up: each is a
+## fixed run of tiles at a known place. Strips, because each is addressed by a
+## number (a character code, a tile in a bar) and a strip turns that number into
+## a horizontal offset and nothing else.
 ##
-## [code]first_code[/code] is the character code a sheet's first tile draws, and
-## is zero for the sheets that are graphics rather than characters. [code]bits[/code]
-## is how the cartridge stores them: the font and the borders are 1bpp, the
-## battle graphics 2bpp.
+## [code]first_code[/code] is the character code the first tile draws, zero for
+## graphics sheets. [code]bits[/code] is the cartridge's storage: font and
+## borders 1bpp, battle graphics 2bpp.
 func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 	var sheets: Dictionary = {

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -8,16 +8,14 @@ extends RefCounted
 ## map, while a few data sections use per-game offsets; Crystal moved almost
 ## everything and is its own table.
 ##
-## Every offset here was located in the cartridges themselves, by searching for
-## content whose bytes are known independently (the encoded string "BULBASAUR",
-## Bulbasaur's published base stats), and then cross-checked against the pret
-## disassemblies for structure. That is why there is no entry for a ROM that is
-## not in [RomRegistry]: an offset table is a claim about a specific dump, and
-## the honest answer for an uncharacterised one is a refusal, not a guess.
+## Every offset was located in the cartridges themselves, by searching for
+## independently known bytes (the encoded string "BULBASAUR", Bulbasaur's
+## published base stats), then cross-checked against the pret disassemblies for
+## structure. An offset table is a claim about a specific dump, which is why an
+## uncharacterised ROM is refused rather than guessed at.
 ##
-## An offset is only trustworthy alongside the check that proves it: see
-## [method RomImporter.verify_layout], which the importer runs before it decodes
-## anything.
+## An offset is only trustworthy alongside its check: see
+## [method RomImporter.verify_layout], run before anything is decoded.
 
 const SPECIES_COUNT: int = 251
 const NAME_LENGTH: int = 10
@@ -192,10 +190,9 @@ const MAX_NAME_LENGTH: int = 16
 ## table is [constant MATCHUP_EFFECTIVE], which is why the whole of Generation 2
 ## fits in 332 bytes.
 ##
-## Multipliers are in tenths, as the cartridge stores them, so a matchup is
-## applied by multiplying and then dividing by ten. Keeping the tenth rather
-## than a float is not pedantry: the games truncate after each of a defender's
-## two types, and a Pokémon that survives on one hit point does so because of it.
+## Multipliers are in tenths as the cartridge stores them, applied by multiplying
+## then dividing by ten. Tenths rather than a float because the games truncate
+## after each of a defender's two types.
 const MATCHUP_ENTRY_SIZE: int = 3
 const MATCHUP_ATTACKER: int = 0
 const MATCHUP_DEFENDER: int = 1
@@ -292,12 +289,11 @@ const EVOLUTION_COUNT: int = 122
 ## that way in all three games, and it is not a decoding artefact: pret's own
 ## listing carries a comment saying so.
 ##
-## It is worth naming rather than working around, because the order is load
-## bearing. Filling a fresh Pokémon's moves stops at the first entry above the
-## level being filled for, so a Muk below 45 never reaches the three moves listed
-## after the level 45 one and is short of what its level says it should know.
-## Checking the order everywhere else is worth the one exception: scrambled
-## levels are exactly what a wrong offset produces.
+## Named rather than worked around, because the order is load bearing: filling a
+## fresh Pokémon stops at the first entry above its level, so a Muk below 45
+## never reaches the three moves after the level 45 one. Checking the order
+## everywhere else is worth the exception, since scrambled levels are exactly
+## what a wrong offset produces.
 const UNSORTED_LEARNSET_SPECIES: int = 89
 
 ## Unown's entry in the main pic table is a deliberate $FF placeholder: its 26
@@ -390,16 +386,13 @@ const BAR_STEP_PIXELS: int = 2
 ## Every trainer pic is this square, unlike a Pokémon's front pic.
 const TRAINER_PIC_TILES: int = 7
 
-## The trainer *party* table is a second table indexed the same way as the class
-## names, pics and palettes, one pointer per class, and it is where the game's
-## individual trainers actually live. "LEADER" is the class name every gym
-## leader shares; FALKNER is a name stored inside class 1's own party entry,
-## next to the Pokémon he brings. Reading a class's identity therefore always
-## means reading two tables, not one.
+## A second table indexed like the class names, pics and palettes, one pointer
+## per class, holding the individual trainers. "LEADER" is the class name every
+## gym leader shares; FALKNER is stored inside class 1's party entry beside the
+## Pokémon he brings, so a class's identity always means reading two tables.
 ##
-## The pointer is two bytes, in the pointer table's own bank, exactly like
-## [member evos_attacks]: the entries sit in the same bank as the pointers that
-## address them, so there is no bank number to store.
+## Two-byte pointers in the pointer table's own bank, like [member evos_attacks]:
+## the entries share that bank, so there is no bank number to store.
 const TRAINER_PARTY_POINTER_SIZE: int = 2
 
 ## What a trainer's Pokémon carries, in the type byte between its name and its
@@ -434,13 +427,11 @@ const MAX_TRAINERS_PER_CLASS: int = 64
 ## The trainer *attributes* table: a third table indexed the same way as the
 ## class names, pics, palettes and parties, one fixed-stride entry per class
 ## rather than a pointer, and it is where a class's own AI behaviour lives.
-## Seven bytes: two item numbers a trainer of this class may use, a base money
-## reward, then two words of bit flags. Confirmed against pret's own
-## `TrainerClassAttributes`, entry by entry: Falkner opens the table with the
-## bytes his own listing gives, class 5 (Pryce) is the first to differ (he may
-## use a Hyper Potion), and one class further down the list carries an AI move
-## weight word of zero ([constant NO_AI]), which the check below has to allow
-## rather than reject as garbage.
+## Seven bytes: two item numbers this class may use, a base money reward, then
+## two words of bit flags. Confirmed against `TrainerClassAttributes` entry by
+## entry: Falkner opens with his listed bytes, class 5 (Pryce) is the first to
+## differ with a Hyper Potion, and one class carries an AI move weight word of
+## zero ([constant NO_AI]), which the check must allow rather than reject.
 const TRAINER_ATTRIBUTES_SIZE: int = 7
 const ATTR_ITEM1: int = 0
 const ATTR_ITEM2: int = 1
@@ -486,24 +477,20 @@ const AI_ITEM_SWITCH_MASK: int = SWITCH_OFTEN | SWITCH_RARELY | SWITCH_SOMETIMES
 
 ## The trainer *DVs* table: a fifth trainer table, indexed the same way as the
 ## attributes table, one fixed two-byte entry per class rather than a pointer.
-## Two nibbles a byte, attack and defense in the first and speed and special in
-## the second, which is exactly the shape [method Gen2Stats.pack_dvs] already
-## packs a DV word into: a class's two raw bytes, read as one big-endian
-## integer, are a [Gen2BattleMon] DV word with no repacking. Confirmed against
-## pret's own `TrainerClassDVs` entry by entry in all three games: Falkner opens
-## the table with his own known DVs, and the class that closes it (class 66 in
-## Gold and Silver, 67 in Crystal, since Crystal alone carries MYSTICALMAN)
-## carries its own.
+## Two nibbles a byte, attack and defense in the first, speed and special in the
+## second: exactly the shape [method Gen2Stats.pack_dvs] packs into, so a class's
+## two raw bytes read big-endian are a [Gen2BattleMon] DV word unchanged.
+## Confirmed against `TrainerClassDVs` entry by entry in all three games, with
+## Falkner opening the table and the closing class (66 in Gold and Silver, 67 in
+## Crystal, which alone carries MYSTICALMAN) carrying its own.
 const TRAINER_DVS_SIZE: int = 2
 
-## The one trainer class with no party of its own: the eleven o'clock scholar,
-## Professor Elm's class in the class table, whose name and pic exist but who
-## the games never send into a battle. Its own label in the source is followed
-## immediately by the next class's with nothing between, so its pointer equals
-## the next class's, and the honest reading of that is zero trainers rather than
-## a copy of somebody else's. Confirmed against pret's own party data
-## (`PokemonProfGroup` has no entries before `WillGroup`, in that order), and
-## the same class number in every game.
+## The one trainer class with no party: Professor Elm's class, whose name and pic
+## exist but who is never sent into battle. Its source label is followed
+## immediately by the next class's, so its pointer equals that one, and the
+## honest reading is zero trainers rather than a copy. Confirmed against pret's
+## party data (`PokemonProfGroup` has no entries before `WillGroup`), same class
+## number in every game.
 const EMPTY_TRAINER_CLASS: int = 10
 
 ## Back pics are always this square. Front pics vary and carry their own size in

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -3,15 +3,13 @@ extends RefCounted
 
 ## The Generation 2 character encoding, for the international ROMs.
 ##
-## One byte per character, terminated by $50, with the alphabet laid out in
-## runs: $80 is "A", $A0 is "a", $F6 is "0". Several codes expand to whole
-## words ($5D is "TRAINER") or name the player at print time ($52); those are
-## kept as bracketed markers so a caller can substitute them, and so nothing is
-## silently lost.
+## One byte per character, terminated by $50, the alphabet in runs: $80 is "A",
+## $A0 is "a", $F6 is "0". Some codes expand to whole words ($5D is "TRAINER") or
+## name the player at print time ($52); those stay bracketed markers so a caller
+## can substitute them and nothing is silently lost.
 ##
 ## The Japanese cartridges reuse most of this range for kana. They are not in
-## [RomRegistry] and this table would decode them into nonsense, which is the
-## same reason the import gate refuses an unknown hash.
+## [RomRegistry], and this table would decode them into nonsense.
 
 const TERMINATOR: int = 0x50
 const SPACE: int = 0x7F
@@ -59,15 +57,14 @@ static func decode_fixed(data: PackedByteArray, offset: int, length: int) -> Str
 
 ## Walks [param count] consecutive terminated strings starting at [param offset].
 ##
-## The species names are a fixed-width table, but the move and item names are
-## not: each entry ends at its terminator and the next one begins on the very
-## next byte. Nothing announces how long an entry is, so a single wrong byte
-## slides every name after it, which is why the importer checks the last entry
-## of such a table and not only the first.
+## Species names are fixed-width, but move and item names are not: each entry
+## ends at its terminator and the next begins on the very next byte. Nothing
+## announces a length, so one wrong byte slides every name after it, which is why
+## the importer checks such a table's last entry as well as its first.
 ##
-## [param max_length] is a runaway guard rather than a field width. Without it, a
-## table read past its own end would scan the remaining megabyte looking for a
-## terminator that is not coming.
+## [param max_length] is a runaway guard, not a field width: without it a table
+## read past its end would scan the remaining megabyte for a terminator that is
+## not coming.
 static func decode_sequence(
 	data: PackedByteArray, offset: int, count: int, max_length: int
 ) -> PackedStringArray:
@@ -86,14 +83,13 @@ static func decode_sequence(
 
 ## Turns a string into the codes that draw it, one code per tile.
 ##
-## The inverse of [method decode] over the printable range only. The engine's
-## own strings have to become tiles somehow, and a name read back out of the
-## cache is a Godot [String] by then, so this is the way back. Control codes and
-## the ones that stand for a name at print time are decode-only: they are not
-## glyphs, and the layer that lays text out handles line breaks itself.
+## The inverse of [method decode] over the printable range only: a name read back
+## out of the cache is a Godot [String] and has to become tiles again. Control
+## codes and print-time name codes are decode-only, since they are not glyphs and
+## the layout layer handles line breaks itself.
 ##
 ## Anything the font cannot draw becomes [constant UNKNOWN] rather than being
-## dropped, on the same principle as an unrecognised byte on the way in.
+## dropped, like an unrecognised byte on the way in.
 static func encode(text: String) -> PackedByteArray:
 	var codes: Dictionary = _encodings()
 	var out: PackedByteArray = PackedByteArray()

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -7,9 +7,9 @@ extends RefCounted
 ## low bit of every pixel in that row and the second the high bit. Bit 7 is the
 ## leftmost pixel.
 ##
-## Decoding stops at indices 0-3. Turning those into colours needs a palette,
-## which is a separate concern; see [Gen2Palette]. Keeping the two apart is
-## what makes shiny variants free: same pixels, different palette.
+## Decoding stops at indices 0-3; turning those into colours needs a palette (see
+## [Gen2Palette]). Keeping the two apart makes shiny variants free: same pixels,
+## different palette.
 
 const TILE_WIDTH: int = 8
 const TILE_HEIGHT: int = 8
@@ -50,11 +50,11 @@ static func decode_tile(data: PackedByteArray, offset: int) -> PackedByteArray:
 ## Decodes [param count] consecutive 1bpp tiles into a single strip of indices,
 ## eight pixels tall and [param count] * 8 wide.
 ##
-## The font and the text box borders are stored this way, and both are addressed
-## by a character code rather than by a grid position, so one row is the layout
-## that makes a glyph's position arithmetic on that code. A short or absent
-## source leaves the remaining tiles blank rather than failing: a strip with a
-## hole in it is visible on screen, which is the point.
+## The font and text box borders are stored this way and are addressed by
+## character code rather than grid position, so a single row makes a glyph's
+## position arithmetic on that code. A short or absent source leaves the
+## remaining tiles blank rather than failing: a hole in the strip is visible on
+## screen, which is the point.
 static func decode_1bpp_strip(data: PackedByteArray, offset: int, count: int) -> PackedByteArray:
 	var width: int = count * TILE_WIDTH
 	var out: PackedByteArray = PackedByteArray()
@@ -108,14 +108,13 @@ static func decode_2bpp_strip(data: PackedByteArray, offset: int, count: int) ->
 ## Decodes a Pokémon or trainer pic into a row-major index buffer
 ## [param columns] * 8 wide and [param rows] * 8 tall.
 ##
-## Pics store their tiles column-major, the whole left column top to bottom and
-## then the next, because the game streams them into VRAM a column at a time.
-## Every other tilemap in these games is row-major, so this is the one place
-## that ordering flips.
+## Pics store tiles column-major, the whole left column top to bottom then the
+## next, because the game streams them into VRAM a column at a time. Every other
+## tilemap here is row-major, so this is the one place the ordering flips.
 ##
-## Trailing data is ignored: Crystal's front pics carry the frames of the
-## Pokédex animation after the still image, so a stream is routinely longer
-## than [param columns] * [param rows] tiles.
+## Trailing data is ignored: Crystal's front pics carry Pokédex animation frames
+## after the still image, so a stream is routinely longer than
+## [param columns] * [param rows] tiles.
 static func decode_pic(data: PackedByteArray, columns: int, rows: int) -> PackedByteArray:
 	var width: int = columns * TILE_WIDTH
 	var out: PackedByteArray = PackedByteArray()

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -8,9 +8,9 @@ const TRAINER_RECORD_SIZE: int = 12
 ## object graphics and addressable overworld tile strips for a verified
 ## Generation 2 cartridge.
 ##
-## The parser follows the official map macros and the runtime's collision
-## lookup: map blocks are 4x4 graphics tiles, walk coordinates are 2x2 cells per
-## block, and collision bytes use x as the low bit and y as the high bit.
+## Follows the official map macros and the runtime collision lookup: map blocks
+## are 4x4 graphics tiles, walk coordinates 2x2 cells per block, and collision
+## bytes use x as the low bit and y as the high bit.
 
 static func verify_layout(rom: RomFile) -> Dictionary:
 	var result: Dictionary = read_world(rom, RomLayout.for_id(rom.id))

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -3,20 +3,19 @@ extends RefCounted
 
 ## What a mod is allowed to change, and the only way it gets to change it.
 ##
-## A mod never touches scene nodes or engine internals. It is handed this host,
-## registers what it provides, and is done. Everything it can reach is either
-## cartridge content through [GameData] or live world state through
-## [Gen2WorldAPI], both of which are scene-free.
+## A mod never touches scene nodes or engine internals: it is handed this host,
+## registers what it provides, and is done. All it can reach is cartridge content
+## through [GameData] and live world state through [Gen2WorldAPI], both
+## scene-free.
 ##
-## The first thing a mod can replace is the world renderer. The 2D renderer here
-## reads the world and draws it; nothing about the world requires that the
-## drawing be 2D, so a renderer that builds geometry from the same block and
-## collision data is a registration rather than a fork. Swapping between two
-## registered renderers is [method select_world_renderer], which is why the
-## contract is a factory and not a one-time construction.
+## The first replaceable thing is the world renderer. Nothing about the world
+## requires the drawing to be 2D, so a renderer building geometry from the same
+## block and collision data is a registration, not a fork.
+## [method select_world_renderer] swaps between registered renderers, which is
+## why the contract is a factory rather than a one-time construction.
 ##
-## Mods are interpreted GDScript. iOS forbids JIT and loading native code at
-## runtime, so a compiled extension is not an option for a distributed mod.
+## Mods are interpreted GDScript: iOS forbids JIT and runtime native loading, so
+## a compiled extension is not an option for a distributed mod.
 
 ## Where installed mods live. Under user:// because a mod is not part of the
 ## build and must survive an update of it.
@@ -27,14 +26,13 @@ const ROOT: String = "user://mods"
 const WORLD_RENDERER_METHODS: Array[String] = [
 	"set_world", "set_time_of_day", "refresh", "refresh_animation",
 ]
-## Optional. A renderer that defines this and answers false is given the screen's
-## own rectangle at the window's resolution instead of the 160x144 hardware
-## viewport. A view built out of geometry rather than hardware tiles cannot be
-## drawn into a 160x144 buffer and then magnified, so this is the difference
-## between a 3D or HD renderer being possible and not.
+## Optional. A renderer defining this and answering false gets the screen's own
+## rectangle at window resolution instead of the 160x144 viewport. A view built
+## from geometry cannot be drawn into a 160x144 buffer and magnified, so this is
+## what makes a 3D or HD renderer possible at all.
 ##
 ## A renderer that does not define it draws in hardware pixels, which is what the
-## built-in one does and what a mod that only recolours tiles wants.
+## built-in one does and what a tile-recolouring mod wants.
 const WORLD_RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
 ## Optional. Called with the native layer's size in window pixels when it is
 ## created and whenever the window changes it. Only reached by a renderer that

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -3,12 +3,12 @@ extends RefCounted
 
 ## One mod's declared identity, read from its `mod.json`.
 ##
-## Parsing is separate from loading so the launcher can list what is installed,
-## and say why something was refused, without running a line of mod code.
+## Parsing is separate from loading, so the launcher can list what is installed
+## and say why something was refused without running a line of mod code.
 ##
-## [code]api_version[/code] is the contract in [Gen2ModHost], not the mod's own
-## version. A mod built against an older host is refused rather than loaded and
-## allowed to fail somewhere less obvious.
+## [code]api_version[/code] is [Gen2ModHost]'s contract, not the mod's own
+## version. A mod built against an older host is refused rather than allowed to
+## fail somewhere less obvious.
 
 const FILENAME: String = "mod.json"
 ## Bumped when the host contract changes in a way an existing mod would notice.

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -3,19 +3,18 @@ extends RefCounted
 
 ## The two status panels a battle draws, on the tile grid the hardware uses.
 ##
-## Everything here is in tiles, and every position is the one the games use. The
-## enemy's panel hangs from a side on its left at the top of the screen and the
-## player's from a side on its right below the middle, and neither is a box: they
-## are an edge and two corners with the contents printed inside them, which is
-## why they are drawn from the HUD sheets rather than from a text box frame.
+## Everything is in tiles at the positions the games use. The enemy's panel hangs
+## from a side on its left at the top, the player's from a side on its right
+## below the middle. Neither is a box: an edge and two corners with the contents
+## printed inside, which is why both come from the HUD sheets rather than a text
+## box frame.
 ##
-## The panels differ in more than position. The player's carries its Pokémon's
-## HP as numbers and an exp bar along its bottom edge, and its bar closes with
-## the cap that hangs off the other side. The enemy's has neither, because the
-## player is not supposed to know either number.
+## The player's panel also carries HP as numbers and an exp bar along its bottom
+## edge, closed by the cap hanging off the other side. The enemy's has neither,
+## because the player is not supposed to know either number.
 ##
 ## Node-free: it writes indices into a buffer, so a HUD can be drawn and read
-## back in a headless test.
+## back headless.
 
 const TILE: int = Gen2Font.TILE
 
@@ -78,10 +77,10 @@ static func bar_pixels(current: int, maximum: int, length: int) -> int:
 ## The enemy's panel except for the bar's fill: the name, the level, the "HP:"
 ## label, the cap that closes the bar and the edge under it.
 ##
-## The fill is drawn separately because it is the one thing on the panel that is
-## not black on white. The hardware gives every tile its own palette; this
-## layers instead, which comes to the same picture and keeps the palette choice
-## where the colour is.
+## The fill is drawn separately as the one thing on the panel that is not black
+## on white. The hardware gives every tile its own palette; this layers instead,
+## which comes to the same picture and keeps the palette choice where the colour
+## is.
 func draw_enemy(
 	into: PackedByteArray, width: int, name: String, level: int
 ) -> void:

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -3,16 +3,14 @@ extends RefCounted
 
 ## The battle screen's tile page, assembled the way the hardware assembles it.
 ##
-## A battle loads four sheets into one run of tile numbers, and they overlap on
-## purpose: the battle font is copied in first and the two HUD borders are
-## copied over the middle of it, so thirteen of its tiles are never seen. Rather
-## than trim the sheets and renumber them, this copies them in the same order
-## into one strip and keeps the cartridge's own tile numbers. The result is that
-## the constants below are the numbers the disassembly uses, and a screen built
-## from them can be read against it.
+## A battle loads four sheets into one run of tile numbers, overlapping on
+## purpose: the battle font goes in first and the two HUD borders over the middle
+## of it, so thirteen of its tiles are never seen. This copies them in the same
+## order into one strip and keeps the cartridge's tile numbers, so the constants
+## below are the disassembly's own.
 ##
-## Node-free like the rest of the drawing layer: it writes indices into a buffer,
-## so a whole HUD can be laid out and checked with no display.
+## Node-free like the rest of the drawing layer: indices into a buffer, so a
+## whole HUD can be laid out and checked with no display.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -3,20 +3,17 @@ extends RefCounted
 
 ## The cartridge's own font, drawn a tile at a time.
 ##
-## Text on this hardware is not typeset, it is tilemapped: every character is
-## one 8x8 tile, every tile is the same width, and a character code is already
-## the number of the tile that draws it. So this does not measure or kern
-## anything. It copies indices into a buffer at multiples of eight, and the only
-## question it ever answers is which tile a code names.
+## Text here is tilemapped, not typeset: every character is one 8x8 tile of equal
+## width, and a character code is already the tile number that draws it. Nothing
+## is measured or kerned; indices are copied into a buffer at multiples of eight.
 ##
 ## Both sheets are one row of tiles ([method Gen2Tiles.decode_1bpp_strip]), so a
-## code becomes a horizontal offset and nothing else. A code the sheet has no
-## tile for draws nothing at all rather than a placeholder: the space at $7F is
-## exactly that case, and the hardware treats it the same way.
+## code is a horizontal offset and nothing else. A code with no tile draws
+## nothing rather than a placeholder, which is what the space at $7F is and what
+## the hardware does.
 ##
-## Node-free like the rest of the drawing layer. It writes into an index buffer,
-## not onto the screen, so a whole text box can be laid out and checked in a
-## headless test.
+## Node-free: it writes into an index buffer, not the screen, so a whole text box
+## can be laid out and checked headless.
 
 const TILE: int = 8
 

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -3,24 +3,21 @@ extends Control
 
 ## A Game Boy Color screen: 160x144 pixels, scaled by a whole number to fit.
 ##
-## The game does not run at the window's resolution and must not. A GBC pixel
-## has to stay square and stay sharp, so everything the game draws goes into a
-## [SubViewport] the size of the real hardware and that image is blown up by an
-## integer factor. Any other scale resamples an 8x8 tile into something that
-## crawls when it moves.
+## The game must not run at the window's resolution: a GBC pixel has to stay
+## square and sharp, so everything the game draws goes into a hardware-sized
+## [SubViewport] blown up by an integer factor. Any other scale resamples an 8x8
+## tile into something that crawls when it moves.
 ##
-## The launcher chrome around it is ordinary Godot UI at the window's own
-## resolution. Keeping the two apart is why this is a [Control] rather than a
-## project-wide stretch setting: menus stay crisp at any window size, and the
-## game stays a Game Boy.
+## Surrounding chrome is ordinary Godot UI at window resolution. Keeping the two
+## apart is why this is a [Control] rather than a project-wide stretch setting.
 ##
 ## Add what the game draws with [method display]; it goes inside the viewport.
 ##
-## There is a second layer behind it, [method display_native], covering the same
-## rectangle at the window's own resolution. A view that is not made of hardware
-## pixels goes there: a 3D or HD renderer cannot be drawn in a 160x144 buffer and
-## then magnified, but it still has to line up with the text boxes and menus
-## drawn above it, which are hardware pixels and stay that way.
+## [method display_native] is a second layer behind it, covering the same
+## rectangle at window resolution, for a view not made of hardware pixels: a 3D
+## or HD renderer cannot be drawn into a 160x144 buffer and magnified, but still
+## has to line up with the text boxes and menus above it, which stay hardware
+## pixels.
 
 const WIDTH: int = 160
 const HEIGHT: int = 144

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -3,17 +3,15 @@ extends RefCounted
 
 ## Colour indices plus a palette to an [Image].
 ##
-## The cache stores what the cartridge stores: two bits per pixel, no colour. A
-## palette is chosen here, at draw time, which is why a shiny sprite costs one
-## different [PackedColorArray] and not a second copy of the pixels.
+## The cache stores what the cartridge stores: two bits per pixel, no colour. The
+## palette is chosen here, at draw time, so a shiny sprite costs one different
+## [PackedColorArray] rather than a second copy of the pixels.
 ##
-## The whole image is built as one buffer and handed to
-## [method Image.create_from_data]. Per-pixel [method Image.set_pixel] on a
-## 56x56 sprite is 3136 calls through the binding for something that is a table
-## lookup, and a battle can want several sprites in a frame.
+## The image is built as one buffer for [method Image.create_from_data]:
+## per-pixel [method Image.set_pixel] on a 56x56 sprite is 3136 binding calls for
+## a table lookup, and a battle can want several sprites a frame.
 ##
-## Node-free like the layers below it: an [Image] is data, not a scene, so this
-## can be checked in a headless test.
+## Node-free: an [Image] is data, not a scene, so this can be checked headless.
 
 const CHANNELS: int = 4
 

--- a/game/render/pic_viewer.gd
+++ b/game/render/pic_viewer.gd
@@ -2,15 +2,13 @@ extends Control
 
 ## Development view: one species on a real 160x144 screen.
 ##
-## Scaffolding, and deliberately so. It exists to prove the whole path from a
-## cartridge to a lit pixel (cache to indices to palette to viewport to an
-## integer-scaled window) and to make a wrong decode visible without a dev tool
-## writing a PNG. The battle screen will do this properly, with the pic where
-## the hardware puts it and a tile-based font around it.
+## Deliberate scaffolding: it proves the whole path from cartridge to lit pixel
+## (cache, indices, palette, viewport, integer-scaled window) and makes a wrong
+## decode visible without a tool writing a PNG.
 ##
-## Left/right change species, S toggles shiny, B swaps front for back, and T
-## switches to the trainer classes, which have one palette each and no back pic.
-## Each is also a plain method so `tools/screenshot.gd` can drive it.
+## Left/right change species, S toggles shiny, B swaps front for back, T switches
+## to the trainer classes, which have one palette each and no back pic. Each is
+## also a plain method so `tools/screenshot.gd` can drive it.
 
 ## The white the hardware fills a pic window with. Index 0 of every pic is this
 ## colour, so a sprite on it looks exactly as it does in the game.

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -3,22 +3,19 @@ extends TextureRect
 
 ## A bordered text window, drawn the way the hardware draws one.
 ##
-## Everything here is on the tile grid. The border is six tiles of the chosen
-## frame printed as box-drawing characters, the interior is white, and the text
-## sits one tile in from the left on every second row, because a line of text is
-## eight pixels tall in a box whose rows are sixteen apart. None of those are
-## style choices; they are what the games do, and a box that ignores them looks
-## wrong in a way that is hard to name and easy to see.
+## Everything is on the tile grid, at the games' own measurements rather than by
+## choice: the border is six tiles of the chosen frame printed as box-drawing
+## characters, the interior is white, and text sits one tile in from the left on
+## every second row, since a line is eight pixels tall in a box whose rows are
+## sixteen apart.
 ##
-## The whole box is composed as one index buffer and handed to the same
-## index-plus-palette path a sprite goes through, so a glyph and a Pokémon are
-## lit by the same code. Only index 0 and index 3 ever appear in it: 1bpp
-## graphics have no middle colours.
+## The box composes into one index buffer and goes through the same
+## index-plus-palette path a sprite does, so a glyph and a Pokémon are lit by the
+## same code. Only indices 0 and 3 appear: 1bpp graphics have no middle colours.
 ##
-## Text is revealed a tile at a time and waits to be advanced at the end of each
-## page. [method advance] and [method finish] are plain methods as well as key
-## handlers so a screen can be photographed mid-sentence; see
-## docs/CONTRIBUTING.md.
+## Text reveals a tile at a time and waits at the end of each page.
+## [method advance] and [method finish] are plain methods as well as key
+## handlers, so a screen can be photographed mid-sentence.
 
 ## Emitted when the last page has been shown and advanced past.
 signal finished

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -3,19 +3,17 @@ extends RefCounted
 
 ## Breaking a string into the lines and pages a text box can show.
 ##
-## Pure rules, no font and no screen: it counts tiles and returns strings, so
-## the whole of a conversation's pagination can be checked in a test without
-## drawing anything.
+## Pure rules, no font and no screen: it counts tiles and returns strings, so a
+## conversation's pagination can be checked without drawing anything.
 ##
-## Widths are counted in tiles, never in characters. A ligature like "'s" is two
-## characters in a single glyph, so [method String.length] overstates a line and
-## would wrap it a column early; [method Gen2Text.encoded_length] is the measure
-## that matches what ends up on screen.
+## Widths count tiles, never characters: a ligature like "'s" is two characters
+## in one glyph, so [method String.length] overstates a line and wraps it a
+## column early. [method Gen2Text.encoded_length] is the measure that matches the
+## screen.
 ##
-## The cartridges do not do this. Their text is pre-broken at authoring time
-## with control codes for the line and page breaks, which works when every
-## string is known in advance and does not when a mod adds one or a name is
-## longer than the writer assumed.
+## The cartridges do not wrap at runtime; their text is pre-broken at authoring
+## time with control codes, which works when every string is known in advance and
+## does not when a mod adds one or a name runs long.
 
 
 ## Breaks [param text] into lines of at most [param columns] tiles.

--- a/game/render/text_viewer.gd
+++ b/game/render/text_viewer.gd
@@ -2,18 +2,16 @@ extends Control
 
 ## Development view: the cartridge's font and text box on a real 160x144 screen.
 ##
-## Scaffolding, like `pic_viewer.tscn`, and for the same reason: a wrong decode
-## has to be visible. A font that has slid by one tile still draws letters, and
-## a border whose six tiles are in the wrong order still draws a box, so both
-## are checked by looking at them rather than by counting bytes.
+## Scaffolding like `pic_viewer.tscn`, for the same reason: a font slid by one
+## tile still draws letters and a border with its six tiles out of order still
+## draws a box, so both are checked by looking rather than by counting bytes.
 ##
-## The chart draws all 128 glyphs in code order. The alphabet runs, the gaps
-## between them and the digits at the end are the shape the charmap describes,
-## and anything out of place shows up as a blank in the middle of a word or a
-## letter where a gap should be.
+## The chart draws all 128 glyphs in code order, so the alphabet runs, the gaps
+## between them and the trailing digits show up as the charmap describes, and
+## anything out of place is a blank mid-word or a letter in a gap.
 ##
-## Space advances, F cycles the border, C toggles the chart. Each is also a
-## plain method so `tools/screenshot.gd` can drive it.
+## Space advances, F cycles the border, C toggles the chart. Each is also a plain
+## method so `tools/screenshot.gd` can drive it.
 
 const BACKGROUND: Color = Color.WHITE
 

--- a/game/rom/rom_file.gd
+++ b/game/rom/rom_file.gd
@@ -4,13 +4,12 @@ extends RefCounted
 ## A cartridge dump held in memory for the duration of an import.
 ##
 ## Node-free like the rest of the ROM layer. [method open_verified] refuses
-## anything [RomVerifier] has not accepted: every offset in [RomLayout] is only
-## meaningful for a characterised dump, so an unverified file must never reach
-## a decoder.
+## anything [RomVerifier] has not accepted, since every [RomLayout] offset is
+## only meaningful for a characterised dump.
 ##
-## Reads are bounds-checked and return zero rather than faulting. Decoders walk
-## data whose length is only known once it has been decoded, and a corrupt stream
-## should end up as an honest "that did not decode" instead of an engine error.
+## Reads are bounds-checked and return zero rather than faulting: decoders walk
+## data whose length is only known once decoded, and a corrupt stream should end
+## as an honest "that did not decode" rather than an engine error.
 
 ## Cartridge banks are 16 KiB; the CPU sees one fixed and one switchable.
 const BANK_SIZE: int = 0x4000

--- a/game/rom/rom_registry.gd
+++ b/game/rom/rom_registry.gd
@@ -3,15 +3,14 @@ extends RefCounted
 
 ## The allowlist of ROMs this project can import from.
 ##
-## gen2recomp ships no game data. A user supplies their own cartridge dump and
-## it is matched against this table by SHA-1 before a single byte is read for
-## content. An unknown hash is a hard refusal, never a "try anyway": a ROM we
-## have not characterised has unknown bank layout, and guessing produces
-## corrupt assets rather than an honest error.
+## The project ships no game data. A user-supplied dump is matched here by SHA-1
+## before a byte is read for content. An unknown hash is a hard refusal: an
+## uncharacterised ROM has unknown bank layout, and guessing produces corrupt
+## assets rather than an honest error.
 ##
-## Gen 2 is three games. Crystal's two common filenames (the "(UE) (V1.1)" and
-## "(USA, Europe) (Rev 1)" dumps) are byte-identical, so they collapse to one
-## entry here: matching is by hash, never by filename.
+## Crystal's two common filenames (the "(UE) (V1.1)" and "(USA, Europe) (Rev 1)"
+## dumps) are byte-identical and collapse to one entry: matching is by hash,
+## never by filename.
 
 ## Every Game Boy Color cartridge in this generation is 2 MiB. Used only as a
 ## cheap pre-filter so a wrong file is rejected before we hash it.

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -4,11 +4,10 @@ extends RefCounted
 ## Boundary between an original Generation 2 SRAM image and the project's
 ## party-focused save model.
 ##
-## The adapter only writes an existing, checksummed cartridge image. This is
-## deliberate: the current canonical save model does not own map, options,
-## inventory, PC boxes or event flags, so creating those bytes from scratch
-## would silently invent game state. Bytes outside the fields mapped here stay
-## untouched.
+## Only an existing, checksummed cartridge image is written. The canonical save
+## model does not own map, options, inventory, PC boxes or event flags, so
+## creating those bytes from scratch would invent game state. Bytes outside the
+## mapped fields stay untouched.
 
 const SRAM_SIZE: int = 0x8000
 const SAVE_CHECK_VALUE_1: int = 99

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -5,12 +5,10 @@ extends Control
 ## window-resolution Control panel consistent with the mart, phone and PC
 ## storage overlays rather than the hardware `menu_coords` box.
 ##
-## Pokemon and Pokegear are existing separate screens the world already owns
-## (Gen2PartyScreen, the phone list on Gen2WorldServiceScreen), so this screen
-## only reports the choice through [signal action_chosen] and lets the world
-## screen open them; Pack and Save are small enough to live here as their own
-## internal modes, the same way Gen2WorldServiceScreen owns a mart mode beside
-## its menu mode.
+## Pokemon and Pokegear are screens the world already owns (Gen2PartyScreen, the
+## phone list on Gen2WorldServiceScreen), so this only reports the choice through
+## [signal action_chosen]. Pack and Save live here as internal modes, the way
+## Gen2WorldServiceScreen owns a mart mode beside its menu mode.
 
 ## Emitted for an available entry this screen does not own itself
 ## (Pokemon, Pokegear); the caller opens the matching screen.
@@ -62,10 +60,9 @@ func _ready() -> void:
 ## with "reason" on failure). Kept as a Callable so this screen does not need
 ## to know how a snapshot is written or where saves live.
 ##
-## Mirrors Gen2BoxScreen.set_context(): the caller may open() before or after
-## adding this node to the tree, so building the option list is deferred to
-## _ready() until _title/_options exist, then run immediately here for a
-## caller that opens after the node is already inside the tree.
+## Mirrors Gen2BoxScreen.set_context(): open() may be called before or after this
+## node enters the tree, so building the option list defers to _ready() until
+## _title/_options exist, and runs immediately here otherwise.
 func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_cursor: int = 0) -> bool:
 	_world = world
 	_data = data

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -258,13 +258,11 @@ func _clear_player_step() -> void:
 	_player_step_accumulator = 0.0
 
 
-## Advances the player's walk-step offset by real elapsed time, at the same
-## hardware-frame rate and stall catch-up cap as Gen2WorldAnimation, so both
-## stay in phase after a pause instead of drifting apart. This only shrinks a
-## presentation offset that already starts and ends at player_cell; it never
-## changes player_cell, collision or event results, and callers that never
-## start a step (every existing caller of move()/move_result() before this
-## change) see no difference at all.
+## Advances the player's walk-step offset by real elapsed time, at
+## Gen2WorldAnimation's hardware-frame rate and stall catch-up cap, so both stay
+## in phase after a pause. This only shrinks a presentation offset that starts
+## and ends at player_cell; it never changes player_cell, collision or event
+## results, and a caller that never starts a step sees no difference.
 func advance_player_step(delta: float) -> bool:
 	if _player_step_frames_remaining <= 0 or delta <= 0.0:
 		return false
@@ -2123,9 +2121,9 @@ func can_object_walk_to(cell: Vector2i, moving: Gen2WorldObject) -> bool:
 ## slice. Scripted movement is executed by the script runner, while followers
 ## advance after each successful player step.
 ##
-## This remains one movement decision per eligible object per call. A caller
-## that wants the source's own pacing uses advance_object_steps() instead,
-## which spends the step and idle durations this function records.
+## One movement decision per eligible object per call. A caller wanting the
+## source's pacing uses advance_object_steps(), which spends the step and idle
+## durations this records.
 func advance_objects(random: RandomNumberGenerator) -> int:
 	var moved: int = 0
 	for object: Gen2WorldObject in objects:
@@ -2171,12 +2169,11 @@ func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenera
 ## hardware-frame rate and stall catch-up cap the player's own walk step and
 ## Gen2WorldAnimation use.
 ##
-## Per frame an object either spends one frame of an in-flight step, one frame
-## of its wait, or takes a new movement decision, which is the source's
-## STEP_TYPE_CONTINUE_WALK, STEP_TYPE_SLEEP and STEP_TYPE_FROM_MOVEMENT cycle.
-## The cell commits when the step starts, matching InitStep and the player path;
-## only the presentation offset trails behind it. Returns true when something a
-## renderer draws changed.
+## Per frame an object spends one frame of an in-flight step, one frame of its
+## wait, or takes a new decision: the source's STEP_TYPE_CONTINUE_WALK,
+## STEP_TYPE_SLEEP and STEP_TYPE_FROM_MOVEMENT cycle. The cell commits when the
+## step starts, matching InitStep and the player path, and only the presentation
+## offset trails. Returns true when something a renderer draws changed.
 func advance_object_steps(delta: float, random: RandomNumberGenerator) -> bool:
 	if delta <= 0.0 or random == null or objects.is_empty():
 		return false
@@ -2323,17 +2320,14 @@ func move_result(direction: Vector2i) -> Dictionary:
 	}
 
 
-## engine/overworld/player_movement.asm's .TryJump, reached only after an
-## ordinary step into [param direction] is blocked. Reads the collision code
-## of the cell the player already stands on, not the faced cell; on a match
-## the player covers two cells in one bounded action, bypassing collision on
-## both the intervening and landing cells exactly as the source does. Returns
-## an empty Dictionary when no hop applies, so the caller falls through to an
-## ordinary blocked result. Surfing never reaches .TryJump in the source
-## (.Surf calls .TrySurf then jumps straight to .NotMoving), so this refuses
-## outright while surfing. A landing cell outside the map is refused rather
-## than attempted, matching this project's existing rule that out-of-range
-## cells always block.
+## engine/overworld/player_movement.asm's .TryJump, reached only after an ordinary
+## step into [param direction] is blocked. Reads the collision code of the cell
+## the player already stands on, not the faced cell; on a match the player covers
+## two cells in one bounded action, bypassing collision on both the intervening
+## and landing cells as the source does. An empty Dictionary means no hop, so the
+## caller falls through to an ordinary blocked result. Surfing refuses outright,
+## since .Surf calls .TrySurf then jumps straight to .NotMoving; a landing cell
+## outside the map is refused too, as out-of-range cells always block here.
 func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	if movement_mode == MOVEMENT_SURF:
 		return {}
@@ -2446,14 +2440,12 @@ func _apply_map(
 	_block_overrides.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
-	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table
-	# (engine/overworld/scripting.asm's Script_moveobject through
-	# CopyDECoordsToMapObject), so a scripted position never survives a map
-	# load; a MAPCALLBACK_OBJECTS callback re-applies it when its own condition
-	# still holds. Keeping these overrides across a map change left objects
-	# where an earlier visit had put them: ElmsLabMoveElmCallback moves Elm to
-	# (3, 4) while the scene is SCENE_ELMSLAB_MEET_ELM, and the story then
-	# found nothing to talk to at his authored (5, 2) on returning.
+	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
+	# position never survives a map load; a MAPCALLBACK_OBJECTS callback
+	# re-applies it while its condition holds. Keeping these overrides across a
+	# map change left objects where an earlier visit had put them:
+	# ElmsLabMoveElmCallback moves Elm to (3, 4) during SCENE_ELMSLAB_MEET_ELM,
+	# and the story then found nothing at his authored (5, 2) on returning.
 	_object_position_overrides.clear()
 	_object_facing_overrides.clear()
 	state.reset_map_reload_flags()

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -6,9 +6,9 @@ extends RefCounted
 ## each completed game minute, while time-of-day changes use the cartridge's
 ## 04:00, 10:00 and 18:00 boundaries.
 ##
-## The clock does not move roaming Pokémon. The cartridge advances those during
-## map setup, so [method Gen2WorldAPI.advance_schedule] is driven by a map
-## change rather than by elapsed time.
+## The clock does not move roaming Pokémon: the cartridge advances those during
+## map setup, so [method Gen2WorldAPI.advance_schedule] is driven by a map change
+## rather than elapsed time.
 
 const SECONDS_PER_MINUTE: float = 60.0
 const MINUTES_PER_HOUR: int = 60

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -3,16 +3,16 @@ extends RefCounted
 
 ## Generation 2 collision-code permissions.
 ##
-## A map's collision grid stores the raw collision code from the tileset's
-## four-cell table. The game looks that code up in a second table before it
-## decides whether ordinary walking can enter the cell. Keeping that lookup
-## here leaves the imported code available for water, ledges and warp handling.
+## A map's collision grid stores the raw code from the tileset's four-cell table,
+## which the game looks up in a second table before deciding whether ordinary
+## walking can enter. Keeping that lookup here leaves the imported code available
+## for water, ledges and warps.
 ##
-## The table below is the source [code]CollisionPermissionTable[/code], entry for
-## entry; Gold, Silver and Crystal ship the same 256 bytes. It is carried whole
-## rather than as a list of the interesting codes, because a code left off such a
-## list silently becomes ordinary ground: that is how the waterfall, current and
-## buoy families, and one of the two headbutt trees, were walkable here.
+## The table below is the source [code]CollisionPermissionTable[/code] entry for
+## entry; all three games ship the same 256 bytes. Carried whole rather than as a
+## list of interesting codes, because a code left off such a list silently
+## becomes ordinary ground: that is how the waterfall, current and buoy families,
+## and one of the two headbutt trees, were walkable here.
 
 const LAND_TILE: int = 0x00
 const WATER_TILE: int = 0x01
@@ -70,13 +70,12 @@ static func is_walkable(collision_code: int) -> bool:
 	return permission_for(collision_code) == LAND_TILE
 
 
-## Ledges: engine/overworld/player_movement.asm's .TryJump. A hop is only
-## attempted after an ordinary step into the faced cell is blocked, and it
-## reads the collision code of the cell the player is already standing on
-## (wPlayerTileCollision), not the faced cell. All eight hop codes are
-## LAND_TILE in PERMISSIONS, so the player already walks onto one normally;
-## the hop itself bypasses collision on both the intervening and landing
-## cells, matching the source, which never checks either.
+## Ledges: engine/overworld/player_movement.asm's .TryJump. Attempted only after
+## an ordinary step into the faced cell is blocked, reading the collision code of
+## the cell the player already stands on (wPlayerTileCollision). All eight hop
+## codes are LAND_TILE in PERMISSIONS, so the player walks onto one normally; the
+## hop bypasses collision on both the intervening and landing cells, as the
+## source never checks either.
 const HI_NYBBLE_LEDGES: int = 0xA0
 const COLL_HOP_RIGHT: int = 0xA0
 const COLL_HOP_LEFT: int = 0xA1
@@ -142,14 +141,12 @@ static func allows_hop(collision_code: int, direction: Vector2i) -> bool:
 
 
 ## Tile-collision std scripts: engine/events/std_collision.asm's
-## CheckFacingTileForStdScript, dispatched on A after object and background
-## events both find nothing. data/collision/collision_stdscripts.asm is byte
-## identical between pokecrystal and pokegold, but the std-script index each
-## entry resolves to is not: engine/events/std_scripts.asm lists PCScript at
-## index 49 in Crystal and 43 in Gold/Silver, because Crystal's table carries
-## six extra phone entries earlier in the same list. Every other entry here
-## was recounted in both pinned repositories and lands on the same index in
-## both games.
+## CheckFacingTileForStdScript, dispatched on A once object and background events
+## both find nothing. data/collision/collision_stdscripts.asm is byte identical
+## between the two repositories, but the std-script index each entry resolves to
+## is not: PCScript is 49 in Crystal and 43 in Gold/Silver, because Crystal's
+## table carries six extra phone entries earlier. Every other entry was recounted
+## in both and lands on the same index.
 const COLL_BOOKSHELF: int = 0x91
 const COLL_PC: int = 0x93
 const COLL_RADIO: int = 0x94

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -3,16 +3,15 @@ extends RefCounted
 
 ## Scene-free grouping of owned items into the cartridge's four pack pockets.
 ##
-## `Gen2WorldState` stores items as a flat item-to-quantity map; this class is
-## presentation only and does not change that shape. Classification uses the
-## item type byte GameData already imports under the confusingly-named
-## `pocket` field (`data/items/attributes.asm`'s `item_attribute` macro calls
-## it "pocket" while `constants/item_data_constants.asm` names the same values
-## `ITEM`/`KEY_ITEM`/`BALL`/`TM_HM`), which is the value that decides which
-## pack pocket a real item lives in. Source capacities (`MAX_ITEMS` = 20,
-## `MAX_BALLS` = 12, `MAX_KEY_ITEMS` = 25, `MAX_PC_ITEMS` = 50) are recorded
-## here for reference but not enforced, since enforcing them would change the
-## save's item storage shape.
+## `Gen2WorldState` stores items as a flat item-to-quantity map; this is
+## presentation only and does not change that. Classification uses the item type
+## byte GameData imports under the confusingly-named `pocket` field
+## (`data/items/attributes.asm`'s `item_attribute` macro calls it "pocket";
+## `constants/item_data_constants.asm` names the same values
+## `ITEM`/`KEY_ITEM`/`BALL`/`TM_HM`), which is what decides a real item's pocket.
+## Source capacities (`MAX_ITEMS` 20, `MAX_BALLS` 12, `MAX_KEY_ITEMS` 25,
+## `MAX_PC_ITEMS` 50) are recorded but not enforced, since enforcing them would
+## change the save's item storage shape.
 
 const TYPE_ITEM: int = 1
 const TYPE_KEY_ITEM: int = 2

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -16,12 +16,10 @@ const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_scree
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
 ## constants/sfx_constants.asm's SFX_JUMP_OVER_LEDGE (comments there are hex,
-## confirmed against neighboring entries $0a/$0f/$1a), played by
-## engine/overworld/player_movement.asm's .TryJump as the hop starts. Played
-## directly rather than through the script-request path in
-## _handle_audio_request(), which expects a runtime request to acknowledge; a
-## hop is player movement, not a script. _play_current_map_music() below is
-## the existing precedent for this direct-play shape.
+## confirmed against neighbouring $0a/$0f/$1a), played by .TryJump as the hop
+## starts. Played directly rather than through _handle_audio_request(), which
+## expects a runtime request to acknowledge; a hop is movement, not a script.
+## _play_current_map_music() below is the precedent for this shape.
 const SFX_JUMP_OVER_LEDGE: int = 0x16
 
 @export var map_group: int = 24
@@ -164,12 +162,11 @@ func _build_world() -> void:
 ## Builds the view for the selected renderer and attaches it to the layer that
 ## renderer asked for.
 ##
-## Constructed through the mod host rather than directly, so a registered
-## renderer replaces this view without the screen knowing what it draws with. A
-## renderer that answers the surface question with false is given the screen's
-## rectangle at window resolution instead of the hardware viewport, which is what
-## a 3D or HD view needs; the text boxes and menus above it stay hardware pixels
-## either way.
+## Constructed through the mod host, so a registered renderer replaces this view
+## without the screen knowing what it draws with. A renderer answering the
+## surface question false gets the screen's rectangle at window resolution
+## instead of the hardware viewport, which is what a 3D or HD view needs; text
+## boxes and menus above it stay hardware pixels either way.
 func _build_renderer() -> void:
 	if _world == null:
 		return
@@ -895,13 +892,12 @@ func _start_trainer_approach(request: Dictionary) -> void:
 	_refresh_labels()
 
 
-## Paces the approach by call count rather than delta time, so this matches
-## the emote and movement-delay counters beside it and stays independent of
-## real frame timing. The stepping object's own step_frames_remaining (set by
-## [method Gen2WorldAPI.advance_trainer_approach_step]) is consumed here at
-## the same one-per-call rate the emote and delay counters already use; the
-## object's step_offset() gives the renderer the same 16-frame interpolation
-## without changing how many calls the approach takes to finish.
+## Paced by call count rather than delta time, matching the emote and
+## movement-delay counters beside it and staying independent of real frame
+## timing. The object's step_frames_remaining (set by
+## [method Gen2WorldAPI.advance_trainer_approach_step]) is consumed one per call
+## like those counters, while step_offset() still gives the renderer 16-frame
+## interpolation.
 func _advance_trainer_approach() -> void:
 	if _world == null:
 		_trainer_approach = {}

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -3,21 +3,18 @@ extends RefCounted
 
 ## Scene-free model of the cartridge start menu (engine/menus/start_menu.asm).
 ##
-## `StartMenu.SetUpMenuItems` builds its list by appending items in a fixed
-## source order, skipping only the ones its own gate says are not present yet
-## (Pokedex behind wStatusFlags/STATUSFLAGS_POKEDEX_F, Pokemon behind a
-## non-zero wPartyCount, Pokegear behind wPokegearFlags/POKEGEAR_OBTAINED_F).
-## Everything else it always appends. This project does not yet have a dex
-## screen, a trainer card or an options screen, so those three entries are
-## still built in their source position, marked unavailable rather than
-## omitted, so the list shape does not silently change out from under a
-## future implementation of any of them. Bug Contest and link-mode branches
-## (STARTMENUITEM_QUIT, the contest status box) do not apply because this
-## project has neither system, which is why QUIT never appears here at all:
-## the source's own gate for it is never true.
+## `StartMenu.SetUpMenuItems` appends items in a fixed source order, skipping only
+## what its own gate refuses: Pokedex behind wStatusFlags/STATUSFLAGS_POKEDEX_F,
+## Pokemon behind a non-zero wPartyCount, Pokegear behind
+## wPokegearFlags/POKEGEAR_OBTAINED_F.
 ##
-## `STATICMENU_WRAP` is source flag data on `.MenuData`, so the cursor wraps
-## at both ends the same way a cached cartridge menu does.
+## This project has no dex, trainer card or options screen, so those three are
+## still built in their source position and marked unavailable rather than
+## omitted, keeping the list shape stable for whichever arrives first. QUIT never
+## appears because its Bug Contest and link-mode gate is never true here.
+##
+## `STATICMENU_WRAP` is source flag data on `.MenuData`, so the cursor wraps at
+## both ends like a cached cartridge menu.
 
 ## constants/engine_flags.asm: ENGINE_POKEGEAR = 4, ENGINE_POKEDEX = 11. Both
 ## indices are identical in pokecrystal and pokegold (unlike the badge and

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -23,13 +23,12 @@ const ENGINE_HALL_OF_FAME: int = ENGINE_CREDITS_SKIP
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 86
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER: int = 85
 
-## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array;
-## VAR_BADGES counts both bytes together, not Johto alone. These are Crystal
-## indices. pokegold's constants/engine_flags.asm has no ENGINE_MOBILE_SYSTEM
-## entry, which pokecrystal inserts ahead of the badge section, so every
-## pokegold badge (and the merchant flag above) sits exactly one index lower
-## than the same symbol here; `_GetVarAction.CountBadges` and the flag order
-## are otherwise identical between the two games.
+## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array, and
+## VAR_BADGES counts both bytes, not Johto alone. These are Crystal indices:
+## pokegold's constants/engine_flags.asm has no ENGINE_MOBILE_SYSTEM, which
+## pokecrystal inserts ahead of the badge section, so every pokegold badge (and
+## the merchant flag above) sits one index lower. `_GetVarAction.CountBadges` and
+## the flag order are otherwise identical.
 const ENGINE_ZEPHYRBADGE: int = 27
 const ENGINE_HIVEBADGE: int = 28
 const ENGINE_PLAINBADGE: int = 29

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -2,21 +2,17 @@ extends SubViewportContainer
 
 ## A world renderer that draws geometry instead of hardware tiles.
 ##
-## The point of this example is that nothing about the world requires the view to
-## be 2D. It reads exactly what the built-in renderer reads: the collision
-## permission of each walk cell, the block grid, the tileset's palettes and the
-## player's cell. From that it extrudes a solid per cell and points a camera at
-## the player.
+## The point is that nothing about the world requires the view to be 2D. It reads
+## exactly what the built-in renderer reads (each walk cell's collision
+## permission, the block grid, the tileset's palettes, the player's cell) and
+## extrudes a solid per cell with a camera on the player.
 ##
-## It answers [code]uses_hardware_viewport[/code] with false, so the screen gives
-## it the rectangle the Game Boy screen occupies at the window's own resolution
-## rather than a 160x144 buffer. Text boxes and menus keep being drawn in
-## hardware pixels over the top, which is what an HD or 3D presentation of these
-## games wants.
+## It answers [code]uses_hardware_viewport[/code] false, so it gets the Game Boy
+## screen's rectangle at window resolution rather than a 160x144 buffer. Text
+## boxes and menus stay hardware pixels over the top.
 ##
-## It reads the world and never writes it. Two views of one world have to agree,
-## so the built-in renderer and this one can be swapped mid-step and neither can
-## tell the other what changed.
+## It reads the world and never writes it, so the two renderers can be swapped
+## mid-step and neither can tell the other what changed.
 
 const CELL_SIZE: float = 1.0
 const WALL_HEIGHT: float = 1.0

--- a/roms/README.md
+++ b/roms/README.md
@@ -1,29 +1,16 @@
 # Your cartridges go here
 
-The project ships no game data. Put your own dumps here, for example:
-
-```
-roms/gold.gbc
-roms/silver.gbc
-roms/crystal.gbc
-```
+The project ships no game data. Put your own dumps here, for example
+`roms/gold.gbc`, `roms/silver.gbc`, `roms/crystal.gbc`.
 
 Everything here except this file is gitignored and excluded from Godot imports
 by `.gdignore`, so it cannot enter commits or exports. Keep `.gdignore`.
-
-## Verify
 
 ```bash
 godot --headless --path . -s res://tools/verify_rom.gd -- roms
 ```
 
-Names do not matter; every file is matched by SHA-1.
-
-| Game | SHA-1 |
-|---|---|
-| Gold (USA/Europe) | `d8b8a3600a465308c9953dfa04f0081c05bdcb94` |
-| Silver (USA/Europe) | `49b163f7e57702bc939d642a18f591de55d92dae` |
-| Crystal (USA/Europe Rev 1) | `f2f52230b536214ef7c9924f483392993e226cfb` |
-
-Unknown hashes are refused rather than imported with an uncharacterised bank
-layout that could produce corrupt assets.
+Names do not matter: every file is matched by SHA-1 against the supported
+cartridges listed in [the README](../README.md#supported-cartridges). Unknown
+hashes are refused rather than imported with an uncharacterised bank layout that
+could produce corrupt assets.

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -2,14 +2,13 @@ extends RefCounted
 
 ## A cache the battle tests are fought inside.
 ##
-## Not a cartridge and not a fake of one: it is a real cache directory with a
-## handful of real species and moves in it, written the way the importer writes
-## one. The battle engine reads cartridge content through [GameData] and nothing
-## else, so a cache with four Pokémon in it exercises the same path a cache with
-## 251 does, and the suite still runs on a machine that has no ROM.
+## Not a fake cartridge: a real cache directory with a handful of real species
+## and moves, written the way the importer writes one. The battle engine reads
+## cartridge content only through [GameData], so four Pokémon exercise the same
+## path 251 do and the suite runs on a machine with no ROM.
 ##
-## The numbers here are the published ones, so a stat or a damage figure in a
-## test can be checked against a calculator rather than against this file.
+## The numbers are the published ones, so a stat or damage figure in a test can
+## be checked against a calculator rather than against this file.
 
 const PIKACHU: int = 25
 const GEODUDE: int = 74
@@ -187,15 +186,12 @@ static func build(directory: String) -> GameData:
 ## The species table, indexed by number like the real one, with the gaps filled
 ## by entries that exist only so a number indexes its own row.
 static func _species() -> Array:
-	# Growth rate and base exp, appended after the type pair, are the published
-	# ones too: Pikachu and Magcargo are medium fast, Bulbasaur, Charmander and
-	# Geodude medium slow, which is why [constant Gen2Experience.GROWTH_MEDIUM_FAST]
-	# and [constant Gen2Experience.GROWTH_MEDIUM_SLOW] are the two
-	# [test_experience.gd] and [test_battle.gd] ever need a fixture for.
-	# The two learnsets exist only for [test_battle.gd]'s own experience tests:
-	# Charmander's single entry is the plain "an empty slot needs no question"
-	# case, and Geodude's two are a level-up jump that crosses both a free slot
-	# and, once that slot is gone, [Gen2Battle.must_learn_move]'s own offer.
+	# Growth rate and base exp after the type pair are published values too:
+	# Pikachu and Magcargo medium fast, Bulbasaur, Charmander and Geodude medium
+	# slow, which is why those are the only two curves the tests fixture.
+	# The two learnsets serve test_battle.gd's experience tests: Charmander's
+	# single entry is the "empty slot needs no question" case, Geodude's two are
+	# a level-up jump crossing a free slot and then must_learn_move's offer.
 	var known: Dictionary = {
 		BULBASAUR: [
 			"BULBASAUR", [45, 49, 49, 45, 65, 65], [GRASS, POISON],

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -2,14 +2,11 @@ extends GutTest
 
 ## The battle AI: which move a trainer class's own flag word ends up preferring.
 ##
-## Most assertions here pick a scenario where a layer's own logic settles the
-## outcome without any help from the tie-break, so the test is not really about
-## the random number generator at all: a discouraged move starts ten points
-## behind a plain one, which nothing here comes close to erasing by chance. The
-## handful of genuinely probabilistic layers (Setup, Opportunist) are checked by
-## calling the layer directly across many seeds and asking whether both of its
-## outcomes are reachable, which is what "50% chance" and "90% chance" actually
-## claim.
+## Most assertions pick a scenario a layer's own logic settles without the
+## tie-break: a discouraged move starts ten points behind, which chance does not
+## erase. The genuinely probabilistic layers (Setup, Opportunist) are called
+## directly across many seeds to check both outcomes are reachable, which is what
+## "50% chance" and "90% chance" claim.
 
 const Fixture := preload("res://tests/unit/battle_fixture.gd")
 

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1055,13 +1055,11 @@ func _used_move_by(events: Array, side: int) -> Dictionary:
 	return {}
 
 
-## Pikachu is faster than Geodude, so Encore lands before Geodude has acted
-## this same turn. The real cartridge's own `CheckOpponentWentFirst` forces an
-## already-chosen action over for the turn it lands on top of the ones after
-## it; this engine gets the same thing by not committing to a move until
-## [method Gen2Battle._act] actually reaches it, so Geodude's own request for
-## Slash is overridden back to Tackle in the very turn Encore lands, not only
-## the turns after.
+## Pikachu outspeeds Geodude, so Encore lands before Geodude acts this turn.
+## `CheckOpponentWentFirst` overrides an already-chosen action for the turn it
+## lands on as well as later ones; this engine gets that by not committing to a
+## move until [method Gen2Battle._act] reaches it, so Geodude's Slash is
+## overridden back to Tackle in the very turn Encore lands.
 func test_encore_forces_the_targets_last_move_even_the_turn_it_lands() -> void:
 	var battle: Gen2Battle = _battle(
 		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.ENCORE_MOVE]),
@@ -1202,15 +1200,13 @@ func test_switching_out_clears_attract_disable_and_encore() -> void:
 	assert_eq(pikachu.last_move_used, 0)
 
 
-## The statistical confirmation that Focus Energy actually raises the rate
-## lives in test_damage.gd, against [method Gen2Damage.critical_level] directly;
-## this is only the wiring, that a real turn's own damage calc reads the flag
-## at all rather than the argument sitting unused.
-## Seed 12, pinned by search rather than assumed, is one where the same first
-## roll misses Tackle's own critical chance at the base rate and lands it at
-## the rate Focus Energy raises it to: the same draw read two different ways,
-## which is a direct proof the flag reaches the roll rather than a statistical
-## one over many turns.
+## test_damage.gd confirms statistically that Focus Energy raises the rate,
+## against [method Gen2Damage.critical_level]; this only checks the wiring, that
+## a real turn's damage calc reads the flag at all.
+## Seed 12, found by search, is one where the same first roll misses Tackle's
+## critical chance at the base rate and lands it at the Focus Energy rate: one
+## draw read two ways, which proves the flag reaches the roll directly rather
+## than statistically.
 func test_focus_energy_reaches_the_damage_calc_of_a_real_turn() -> void:
 	var battle: Gen2Battle = _battle(
 		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -178,13 +178,11 @@ func test_every_volatile_field_clears() -> void:
 	assert_eq(mon.last_move_used, 0)
 
 
-## Attract's own "opposite gender" rule reads [method Gen2BattleMon.gender],
-## which the cartridge's own `GetGender` works out from the species' gender
-## ratio and the Attack and Speed DVs combined into one byte, not from a coin
-## flip. Bulbasaur is really 12.5% female (ratio 31); Pikachu is really an even
-## 50/50 (ratio 127), which is what makes it the one to check the exact
-## boundary on, since a combined value equal to the ratio reads female rather
-## than male.
+## Attract's "opposite gender" rule reads [method Gen2BattleMon.gender], which
+## `GetGender` works out from the species ratio and the Attack and Speed DVs
+## combined into one byte, not a coin flip. Bulbasaur is 12.5% female (ratio 31);
+## Pikachu is an even 50/50 (ratio 127), which is why it checks the boundary,
+## since a combined value equal to the ratio reads female.
 func test_gender_reads_the_combined_dv_byte_against_the_species_ratio() -> void:
 	var mostly_male := func(attack: int, speed: int) -> Gen2BattleMon:
 		var dvs: int = Gen2Stats.pack_dvs(attack, 0, speed, 0)

--- a/tests/unit/test_experience.gd
+++ b/tests/unit/test_experience.gd
@@ -2,11 +2,10 @@ extends GutTest
 
 ## The experience arithmetic, against the published totals for each curve.
 ##
-## Every figure here is hand-worked from pokecrystal's own
-## [code]CalcExpAtLevel[/code] formula rather than recomputed the way the code
-## computes it, the same discipline [Gen2Damage]'s own tests hold to: a test
-## that ran the formula to check the formula would agree with a wrong one just
-## as readily as a right one.
+## Every figure is hand-worked from [code]CalcExpAtLevel[/code] rather than
+## recomputed the way the code computes it, like [Gen2Damage]'s tests: a test
+## that runs the formula to check the formula agrees with a wrong one just as
+## readily.
 
 
 func test_medium_fast_is_a_plain_cube() -> void:

--- a/tests/unit/test_learnset.gd
+++ b/tests/unit/test_learnset.gd
@@ -3,12 +3,11 @@ extends GutTest
 ## What a Pokémon knows at a level, against learnsets copied out of the
 ## cartridges rather than invented.
 ##
-## Two species carry everything worth testing between them. Golbat learns the
-## same move twice, which is what the duplicate check is for. Muk's list is not
-## in ascending order, which is the cartridge's own mistake and the reason the
-## two questions here give different answers: filling a fresh Pokémon's moves
-## stops at the first entry above its level, so a Muk caught at 40 is three moves
-## short of one raised to 40.
+## Two species cover everything worth testing. Golbat learns the same move twice,
+## which is the duplicate check. Muk's list is not ascending, which is why the
+## two questions give different answers: filling a fresh Pokémon stops at the
+## first entry above its level, so a Muk caught at 40 is three moves short of one
+## raised to 40.
 
 const SCREECH: int = 103
 const LEECH_LIFE: int = 141

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -2,11 +2,9 @@ extends GutTest
 
 ## The commands a move is made of, one at a time.
 ##
-## The turn loop is tested through whole battles in test_battle.gd. What is
-## tested here is the machinery underneath it: that an effect picks a list, that
-## a command writes down what the next one reads, and that a command which ends
-## the move really does stop the ones behind it. Those are the properties every
-## effect written from here on will lean on.
+## test_battle.gd tests the turn loop through whole battles. This tests the
+## machinery underneath: an effect picks a list, a command writes down what the
+## next one reads, and a command that ends the move stops the ones behind it.
 
 const Fixture := preload("res://tests/unit/battle_fixture.gd")
 

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -281,10 +281,9 @@ func test_a_dump_with_no_trainers_in_it_fails() -> void:
 ## other class, and the last class carrying whatever name the layout expects,
 ## the whole table adding up to the exact total the layout knows.
 ##
-## The known facts here (Falkner's team, the empty class, the total, the last
-## trainer's name) are the same kind pinned elsewhere in this file (Bulbasaur's
-## evolution, Tyrogue's three): real content, hand-verified against the
-## cartridges once, not bytes copied out of one.
+## The known facts (Falkner's team, the empty class, the total, the last
+## trainer's name) are the same kind pinned elsewhere here: real content
+## hand-verified against the cartridges once, not bytes copied out of one.
 func _trainer_party_dump() -> PackedByteArray:
 	var data: PackedByteArray = PackedByteArray()
 	data.resize(RomRegistry.EXPECTED_SIZE)

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -4,11 +4,10 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/dump_tables.gd -- <game> [table]
 ##
-## The written-down counterpart of the contact sheet: a bad offset in a name
-## table produces plausible words rather than an error, so the check is to read
-## the output. <game> is a registry id (gold, silver, crystal); [table] is one of
-## species, moves, items, types, matchups, trainers, learnsets, evolutions, or
-## all.
+## The written counterpart of the contact sheet: a bad offset in a name table
+## produces plausible words rather than an error, so the check is reading the
+## output. <game> is a registry id; [table] is species, moves, items, types,
+## matchups, trainers, learnsets, evolutions or all.
 
 const TABLES: PackedStringArray = [
 	"species", "moves", "items", "types", "matchups", "trainers", "learnsets",
@@ -353,11 +352,10 @@ func _name_at(names: Array, number: int) -> String:
 
 ## The chart as a grid, attacker down the side and defender across the top.
 ##
-## A list of 110 rows is not something anyone checks; a grid is, because the
-## published table has the same shape and a single wrong cell stands out. Only
-## the seventeen types that exist are shown: the padding numbers between the two
-## groups have names but no matchups, so a column each would be seventeen columns
-## of nothing.
+## Nobody checks a list of 110 rows; a grid gets checked, because the published
+## table has the same shape and a wrong cell stands out. Only the seventeen real
+## types are shown: the padding numbers between the two groups have names but no
+## matchups.
 func _dump_matchups(directory: String, rows: Array) -> void:
 	var names: Array = _type_names(directory)
 	var chart: Dictionary = {}

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -6,15 +6,14 @@ extends SceneTree
 ##
 ## e.g. gold /tmp/gold_front.png front
 ##
-## The cache stores colour indices, not pixels; a palette is applied at draw
-## time so that shiny is free. This applies one and writes the result out, which
-## is the only way to tell a correct decode from a plausible-looking wrong one.
-## Runs headless: it writes an image, it does not open a window.
+## The cache stores colour indices, not pixels, with a palette applied at draw
+## time so shiny is free. This applies one and writes the result out, the only
+## way to tell a correct decode from a plausible wrong one. Headless: it writes
+## an image and opens no window.
 ##
-## The font and the borders come out too. They are one row of tiles rather than
-## a grid, so the font is folded to sixteen tiles a row on the way out: that is
-## the shape the charmap describes, and it puts the alphabets, the gaps between
-## them and the digits where they can be read at a glance.
+## The font and borders come out too. Both are one row of tiles, so the font is
+## folded to sixteen a row, the shape the charmap describes, putting the
+## alphabets, the gaps and the digits where they can be read at a glance.
 
 const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back", "trainers"]
 const SHEETS: PackedStringArray = [

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -962,13 +962,12 @@ func _walk_to_connection(
 	}
 
 
-## The cell [param step] from [param cell] reaches through an ordinary walk
-## or, when the ordinary step is blocked, a ledge hop
-## (Gen2WorldCollision.allows_hop, mirroring Gen2WorldAPI._try_ledge_hop's own
-## order and its surf and map-bounds refusals). Returns (-1, -1) when neither
-## applies, so callers can use it as a single reachability test in a BFS
-## frontier. Replaying the recorded direction through world.move_result()
-## performs the same hop automatically; no separate hop replay step exists.
+## The cell [param step] from [param cell] reaches by an ordinary walk or, when
+## that is blocked, a ledge hop (Gen2WorldCollision.allows_hop, mirroring
+## Gen2WorldAPI._try_ledge_hop's order and its surf and map-bounds refusals).
+## Returns (-1, -1) when neither applies, so a BFS frontier can use it as one
+## reachability test. Replaying the recorded direction through
+## world.move_result() performs the same hop, so no separate replay step exists.
 func _reachable_step(world: Gen2WorldAPI, cell: Vector2i, step: Vector2i) -> Vector2i:
 	var direct: Vector2i = cell + step
 	if world.can_walk_to(direct):

--- a/tools/screenshot.gd
+++ b/tools/screenshot.gd
@@ -6,11 +6,10 @@ extends SceneTree
 ##   Godot --path . -s res://tools/screenshot.gd -- <scene> <output.png> [frames] [method] [times]
 ##
 ## The optional method/times pair calls a no-argument method on the scene root
-## before capturing, which is how you photograph a screen mid-interaction
-## rather than only on its first frame.
+## before capturing, which is how a screen is photographed mid-interaction.
 ##
-## Note this opens a real window for a moment: rendering needs a display, so it
-## cannot run under --headless.
+## This opens a real window for a moment: rendering needs a display, so it cannot
+## run under --headless.
 
 const DEFAULT_FRAMES: int = 12
 const WINDOW_SIZE := Vector2i(1152, 648)

--- a/tools/validate_ledge_hops.gd
+++ b/tools/validate_ledge_hops.gd
@@ -5,11 +5,11 @@ extends SceneTree
 ## pokegold sources: engine/overworld/player_movement.asm's .TryJump, its
 ## .ledge_table, and data/collision/collision_permissions.asm.
 ##
-## This is the real-cartridge counterpart to tests/unit/test_world_collision.gd
-## and the ledge cases in tests/unit/test_world_api.gd, which use synthetic
-## caches. It also pins what gates Route 30's corridor north, which
-## tools/preview_world_story.gd now walks: the terrain and the hops carry the
-## route, and EVENT_ROUTE_30_BATTLE is what opens the last two cells.
+## The real-cartridge counterpart to tests/unit/test_world_collision.gd and the
+## ledge cases in tests/unit/test_world_api.gd, which use synthetic caches. It
+## also pins what gates Route 30's corridor north, which
+## tools/preview_world_story.gd walks: terrain and hops carry the route, and
+## EVENT_ROUTE_30_BATTLE opens the last two cells.
 ##
 ##   Godot --headless --path . -s res://tools/validate_ledge_hops.gd
 
@@ -117,14 +117,13 @@ func _verify_route30(game_id: StringName, data: GameData) -> void:
 				"%s: Route 30 corridor cell %s is not land." % [game_id, cell]
 			)
 
-	# The corridor north is a story gate, not a terrain or pathfinding problem.
-	# Two objects stand on its single-cell rows 24 and 25, both carrying
+	# The corridor north is a story gate, not terrain or pathfinding. Two objects
+	# stand on its single-cell rows 24 and 25, both carrying
 	# EVENT_ROUTE_30_BATTLE, and CheckObjectFlag
 	# (engine/overworld/map_objects_2.asm) masks an object whose flag is set.
-	# maps/ElmsLab.asm's ElmAfterTheftScript sets that flag when the player
-	# hands Elm the Mystery Egg, so the route opens exactly when the cartridge
-	# opens it. Both halves are pinned here: sealed before the egg return,
-	# walkable after it, with live occupancy enforced in both searches.
+	# maps/ElmsLab.asm's ElmAfterTheftScript sets it on the Mystery Egg handover,
+	# so the route opens when the cartridge opens it. Both halves are pinned:
+	# sealed before the egg return, walkable after, occupancy enforced in both.
 	var occupied: Dictionary = _reachable(world)
 	_check(
 		not _reaches_north_edge(world, occupied),

--- a/tools/verify_rom.gd
+++ b/tools/verify_rom.gd
@@ -4,9 +4,8 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/verify_rom.gd -- [file-or-dir ...]
 ##
-## Defaults to res://roms, the gitignored drop folder. Accepts absolute host
-## paths too. Exits 0 only if every candidate verified as a supported
-## cartridge.
+## Defaults to res://roms, the gitignored drop folder; absolute host paths work
+## too. Exits 0 only if every candidate verified as a supported cartridge.
 
 const DEFAULT_DIR: String = "res://roms"
 


### PR DESCRIPTION
Docs and comments had grown to restate the same facts several ways, with narration of how work went sitting beside the facts themselves. Nothing load bearing is removed: source symbols, constants, quirks and contracts are all kept, stated once in the place that owns them.

- README: status becomes a scannable list, development scenes and headless tools become tables, and the cartridge hash table now lives only in the README, with roms/README.md linking to it.
- CONTRIBUTING: layout checks become a table, overlapping architecture and trainer prose is folded together, and a Writing section records the rule.
- MODS, SAVES, REFERENCES: prose tightened, restated rationale dropped.
- Comments across game/, tests/ and tools/: essayistic framing and repeated justification cut, leaving the constraint, the source symbol and the reason. Stale references to files outside the repository are gone.

GUT 942 tests / 9,151 assertions pass, editor scan and headless boot clean.