### PR TITLE
Add side-wall and side-buoy directional collision masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Headless tools, all against a real imported cache:
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
 | `validate_crystal_route30_trainer.gd` | trainer record, sight line, approach, battle request, beaten flag, later interaction |
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |
+| `validate_side_walls.gd` | the side-wall/side-buoy codes, their face masks and map census, in both games; Celadon Mansion Roof's fence and staircase landings on Crystal |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -824,7 +824,7 @@ func advance_trainer_approach_step(object_index: int, direction: Vector2i) -> Di
 	var object: Gen2WorldObject = objects[object_index]
 	var destination: Vector2i = object.cell + direction
 	object.apply_direction(direction)
-	if not can_object_walk_to(destination, object):
+	if not can_object_walk_to(destination, object, direction):
 		return {
 			"ok": false, "reason": &"movement_blocked",
 			"object_index": object_index, "cell": destination,
@@ -1045,6 +1045,23 @@ func collision_code_at(cell: Vector2i) -> int:
 
 func collision_permission_at(cell: Vector2i) -> int:
 	return Gen2WorldCollision.permission_for(collision_code_at(cell))
+
+
+## home/map.asm's GetMovementPermissions for a player standing at [param cell]:
+## the standing code's own walled edges plus each neighbour's wall facing back,
+## profile-split per Gen2WorldCollision.tile_permissions(). A neighbour outside
+## the map answers -1, which side_wall_face_mask() treats as no wall; the
+## cartridge would read a border block there, but callers already refuse an
+## out-of-map destination before this matters.
+func tile_permissions_at(cell: Vector2i) -> int:
+	return Gen2WorldCollision.tile_permissions(
+		collision_code_at(cell),
+		collision_code_at(cell + Vector2i.UP),
+		collision_code_at(cell + Vector2i.DOWN),
+		collision_code_at(cell + Vector2i.LEFT),
+		collision_code_at(cell + Vector2i.RIGHT),
+		Gen2WorldState.is_crystal_profile(data),
+	)
 
 
 ## Returns the raw warp record at a cell, or an empty Dictionary when the
@@ -1745,7 +1762,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			object.apply_direction(direction)
 			var destination: Vector2i = object.cell + direction
-			if can_object_walk_to(destination, object):
+			if can_object_walk_to(destination, object, direction):
 				object.cell = destination
 			else:
 				generated.append({
@@ -1820,7 +1837,7 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			player_facing = _facing_for_direction(direction)
 			var destination: Vector2i = player_cell + direction
-			if can_walk_to(destination):
+			if can_walk_to(destination, direction):
 				player_cell = destination
 			else:
 				generated.append({
@@ -2089,12 +2106,20 @@ func try_connection(direction: Vector2i) -> Dictionary:
 	}
 
 
-func can_walk_to(cell: Vector2i) -> bool:
+## [param direction] is the attempted movement direction, matching
+## .CheckLandPerms/.CheckSurfPerms ANDing wFacingDirection against
+## wTilePermissions computed at the player's current cell. Vector2i.ZERO skips
+## that test for callers that only want the destination's plain permission.
+func can_walk_to(cell: Vector2i, direction: Vector2i = Vector2i.ZERO) -> bool:
 	if current_map == null or cell.x < 0 or cell.y < 0 \
 		or cell.x >= current_map.collision_width or cell.y >= current_map.collision_height:
 		return false
 	if object_at(cell) != null:
 		return false
+	if direction != Vector2i.ZERO:
+		var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+		if face != 0 and (tile_permissions_at(player_cell) & face) != 0:
+			return false
 	var permission: int = collision_permission_at(cell)
 	if movement_mode == MOVEMENT_SURF:
 		var current_permission: int = collision_permission_at(player_cell)
@@ -2104,11 +2129,21 @@ func can_walk_to(cell: Vector2i) -> bool:
 	return permission == Gen2WorldCollision.LAND_TILE
 
 
-func can_object_walk_to(cell: Vector2i, moving: Gen2WorldObject) -> bool:
+## [param direction] matches CanObjectMoveInDirection's CanObjectLeaveTile
+## (moving's own cell) and WillObjectBumpIntoTile (the destination) side-wall
+## checks; Vector2i.ZERO skips them for callers that only want the destination
+## permission and occupancy.
+func can_object_walk_to(
+	cell: Vector2i, moving: Gen2WorldObject, direction: Vector2i = Vector2i.ZERO
+) -> bool:
 	if current_map == null or cell.x < 0 or cell.y < 0 \
 		or cell.x >= current_map.collision_width or cell.y >= current_map.collision_height:
 		return false
 	if Gen2WorldCollision.permission_for(collision_code_at(cell)) != Gen2WorldCollision.LAND_TILE:
+		return false
+	if direction != Vector2i.ZERO and Gen2WorldCollision.side_wall_step_blocked(
+		collision_code_at(moving.cell), collision_code_at(cell), direction
+	):
 		return false
 	for object: Gen2WorldObject in objects:
 		if object != moving and object.active and not object.deleted \
@@ -2154,7 +2189,8 @@ func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenera
 	if direction == Vector2i.ZERO:
 		return false
 	var destination: Vector2i = object.cell + direction
-	if not object.can_leave_to(destination) or not can_object_walk_to(destination, object):
+	if not object.can_leave_to(destination) \
+		or not can_object_walk_to(destination, object, direction):
 		# _RandomWalkContinue's .new_duration branch: a blocked object keeps its
 		# cell and waits again before trying another direction.
 		object.start_idle(random.randi() & IDLE_MASK_SLOW)
@@ -2262,7 +2298,7 @@ func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictiona
 		else:
 			direction = Vector2i(0, signi(delta.y))
 		var destination: Vector2i = follower.cell + direction
-		if can_object_walk_to(destination, follower):
+		if can_object_walk_to(destination, follower, direction):
 			follower.cell = destination
 			follower.apply_direction(direction)
 			# A follower keeps pace with the player, so it takes the player's
@@ -2295,7 +2331,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 				state.consume_repel_step()
 			return transition
 		return {"ok": false, "kind": &"move", "reason": &"map_edge"}
-	if not can_walk_to(destination):
+	if not can_walk_to(destination, direction):
 		var hop: Dictionary = _try_ledge_hop(direction)
 		if not hop.is_empty():
 			return hop

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -112,7 +112,9 @@ const LEDGE_FACE_MASK: Array[int] = [
 ]
 
 
-static func _face_mask_for_direction(direction: Vector2i) -> int:
+## wFacingDirection's FACE_* bit for a cardinal [param direction], or 0 for a
+## diagonal or zero vector.
+static func face_mask_for_direction(direction: Vector2i) -> int:
 	if direction == Vector2i.UP:
 		return FACE_UP
 	if direction == Vector2i.DOWN:
@@ -133,11 +135,108 @@ static func allows_hop(collision_code: int, direction: Vector2i) -> bool:
 		return false
 	if (collision_code & 0xF0) != HI_NYBBLE_LEDGES:
 		return false
-	var face: int = _face_mask_for_direction(direction)
+	var face: int = face_mask_for_direction(direction)
 	if face == 0:
 		return false
 	var index: int = collision_code & 0x07
 	return (LEDGE_FACE_MASK[index] & face) != 0
+
+
+## Side walls and side buoys: home/map.asm's GetMovementPermissions and
+## engine/overworld/npc_movement.asm's CanObjectLeaveTile/WillObjectBumpIntoTile.
+## Unlike the ledge codes above, these stay their plain permission ($b0-$b7
+## LAND_TILE, $c0-$c7 WATER_TILE in PERMISSIONS) and additionally wall off one
+## or two of the standing tile's own edges by direction.
+const HI_NYBBLE_SIDE_WALLS: int = 0xB0
+const HI_NYBBLE_SIDE_BUOYS: int = 0xC0
+const COLL_RIGHT_WALL: int = 0xB0
+const COLL_LEFT_WALL: int = 0xB1
+const COLL_UP_WALL: int = 0xB2
+const COLL_DOWN_WALL: int = 0xB3
+const COLL_DOWN_RIGHT_WALL: int = 0xB4
+const COLL_DOWN_LEFT_WALL: int = 0xB5
+const COLL_UP_RIGHT_WALL: int = 0xB6
+const COLL_UP_LEFT_WALL: int = 0xB7
+
+## .MovementPermissionsData, entry for entry, indexed by a wall/buoy code's low
+## three bits: which of the standing tile's own edges it walls off, in FACE_*
+## terms. Numerically identical to LEDGE_FACE_MASK above; kept as its own
+## table because a ledge direction and a walled edge are different things, and
+## the source keeps them as two separate tables too.
+const SIDE_WALL_FACE_MASK: Array[int] = [
+	FACE_RIGHT,               # COLL_RIGHT_WALL/BUOY
+	FACE_LEFT,                # COLL_LEFT_WALL/BUOY
+	FACE_UP,                  # COLL_UP_WALL/BUOY
+	FACE_DOWN,                # COLL_DOWN_WALL/BUOY
+	FACE_DOWN | FACE_RIGHT,   # COLL_DOWN_RIGHT_WALL/BUOY
+	FACE_DOWN | FACE_LEFT,    # COLL_DOWN_LEFT_WALL/BUOY
+	FACE_UP | FACE_RIGHT,     # COLL_UP_RIGHT_WALL/BUOY
+	FACE_UP | FACE_LEFT,      # COLL_UP_LEFT_WALL/BUOY
+]
+
+
+## The FACE_* mask of edges [param collision_code] walls off, or 0 when it is
+## not a side-wall or side-buoy code. .CheckHiNybble ANDs against $f0 before
+## comparing, so $b8-$bf and $c8-$cf alias onto the same eight entries as
+## $b0-$b7/$c0-$c7 rather than being rejected, the same way allows_hop()
+## preserves the $a8-$af ledge alias above.
+static func side_wall_face_mask(collision_code: int) -> int:
+	if collision_code < 0 or collision_code > 0xFF:
+		return 0
+	var hi_nybble: int = collision_code & 0xF0
+	if hi_nybble != HI_NYBBLE_SIDE_WALLS and hi_nybble != HI_NYBBLE_SIDE_BUOYS:
+		return 0
+	return SIDE_WALL_FACE_MASK[collision_code & 0x07]
+
+
+## engine/overworld/npc_movement.asm's CanObjectLeaveTile (leave rule, on
+## [param from_code]) and WillObjectBumpIntoTile (enter rule, on [param
+## to_code] at the destination). Both routines index a differently bit-packed
+## table than SIDE_WALL_FACE_MASK (GetSideWallDirectionMask's DOWN_MASK/
+## UP_MASK/LEFT_MASK/RIGHT_MASK, keyed by wWalkingDirection rather than
+## wFacingDirection), but produce the identical per-code, per-direction result;
+## this reuses the FACE_* table rather than re-encoding the same rule twice.
+## Both games ship byte-identical npc_movement.asm, so unlike tile_permissions()
+## below this never takes a profile argument.
+static func side_wall_step_blocked(from_code: int, to_code: int, direction: Vector2i) -> bool:
+	var forward_face: int = face_mask_for_direction(direction)
+	if forward_face == 0:
+		return false
+	if (side_wall_face_mask(from_code) & forward_face) != 0:
+		return true
+	return (side_wall_face_mask(to_code) & face_mask_for_direction(-direction)) != 0
+
+
+## home/map.asm's GetMovementPermissions: the wTilePermissions byte for a
+## player standing on [param standing_code] with the four cardinal neighbours
+## already read. The leave rule (side_wall_face_mask of the standing code) is
+## byte-identical between both games; the enter rule (whether a neighbour's own
+## wall faces back at the player) is not. pokegold/pokecrystal diverge only in
+## .ok_down/.ok_up/.ok_right/.ok_left: crystal ORs the matching FACE_* constant
+## on a match, gold always sets bit RIGHT, numerically FACE_DOWN, since
+## wFacingDirection and wWalkingDirection use transposed bit layouts and
+## .ok_down/.ok_up/.ok_right/.ok_left were written with the latter's RIGHT by
+## mistake. Every enter-rule match therefore blocks only DOWN on Gold/Silver.
+## No shipped Gold/Silver map carries a side-wall code whose low three bits
+## differ from 2 (COLL_UP_WALL, whose own FACE_UP mask cannot match any
+## opposite-face test below), so this split changes no pinned map's
+## reachability; it stays because a mod-authored map could reach it.
+static func tile_permissions(
+	standing_code: int, up_code: int, down_code: int, left_code: int, right_code: int,
+	is_crystal: bool = true,
+) -> int:
+	var permissions: int = side_wall_face_mask(standing_code)
+	if (side_wall_face_mask(down_code) & FACE_UP) != 0:
+		# .ok_down already wants FACE_DOWN on both games, so the Gold quirk is
+		# not observable here even though .Down shares the same shape.
+		permissions |= FACE_DOWN
+	if (side_wall_face_mask(up_code) & FACE_DOWN) != 0:
+		permissions |= FACE_UP if is_crystal else FACE_DOWN
+	if (side_wall_face_mask(right_code) & FACE_LEFT) != 0:
+		permissions |= FACE_RIGHT if is_crystal else FACE_DOWN
+	if (side_wall_face_mask(left_code) & FACE_RIGHT) != 0:
+		permissions |= FACE_LEFT if is_crystal else FACE_DOWN
+	return permissions
 
 
 ## Tile-collision std scripts: engine/events/std_collision.asm's

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -17,7 +17,7 @@ func after_each() -> void:
 	RomCache.clear(_directory)
 
 
-func _write_cache() -> void:
+func _write_cache(game_id: String = "testworld") -> void:
 	RomCache.write_json(RomCache.species_path(_directory), [])
 	RomCache.write_json(RomCache.moves_path(_directory), [])
 	var items: Array = []
@@ -72,6 +72,27 @@ func _write_cache() -> void:
 	collision[2 * 16 + 14] = 0xA0  # COLL_HOP_RIGHT, landing would be x=16
 	collision[2 * 16 + 15] = 0x07  # wall right of the edge hop cell
 	collision[2 * 16 + 10] = 0x93  # COLL_PC, faced (not stood on) for std scripts
+
+	# Side-wall fixture, row 8: a COLL_RIGHT_WALL/COLL_LEFT_WALL pair at (2,8)
+	# and (3,8), matching Celadon Mansion Roof's railing. Both stay LAND_TILE
+	# permission; every surrounding cell is left at its default LAND_TILE.
+	collision[8 * 16 + 2] = 0xB0  # COLL_RIGHT_WALL
+	collision[8 * 16 + 3] = 0xB1  # COLL_LEFT_WALL
+	# A COLL_RIGHT_BUOY/COLL_LEFT_BUOY pair at (4,8) and (5,8), both
+	# WATER_TILE permission, to check the same rule while surfing.
+	collision[8 * 16 + 4] = 0xC0  # COLL_RIGHT_BUOY
+	collision[8 * 16 + 5] = 0xC1  # COLL_LEFT_BUOY
+	# An isolated COLL_LEFT_WALL at (7,8), approached from open land at
+	# (6,8): the enter rule alone, with no leave-rule wall on the standing
+	# tile to also block it. This is what the Gold/Silver profile quirk
+	# changes: crystal blocks entering from the west, gold does not.
+	collision[8 * 16 + 7] = 0xB1  # COLL_LEFT_WALL
+
+	# A lone COLL_UP_WALL at (2,10), matching real Route 42 cliff cells: it
+	# blocks stepping off the edge (entering from above, moving DOWN) but not
+	# climbing it (moving UP from below), since the enter rule only tests the
+	# DOWN handler's opposite-face condition, which COLL_UP_WALL matches.
+	collision[10 * 16 + 2] = 0xB2  # COLL_UP_WALL
 
 	var source_events: Dictionary = {
 		"bank": 48,
@@ -227,7 +248,7 @@ func _write_cache() -> void:
 
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
-		"game_id": "testworld",
+		"game_id": game_id,
 		"sha1": "0123456789abcdef",
 		"complete": true,
 	})
@@ -735,6 +756,116 @@ func test_ledge_hop_never_fires_while_surfing() -> void:
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"blocked")
 	assert_eq(world.player_cell, Vector2i(3, 2))
+
+
+func test_side_wall_blocks_leaving_the_standing_tile_only_in_its_own_direction() -> void:
+	# (2,8) is COLL_RIGHT_WALL, land permission on every side.
+	var world: Gen2WorldAPI = _world(Vector2i(2, 8))
+	var right: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_false(right["ok"], JSON.stringify(right))
+	assert_eq(right["reason"], &"blocked")
+	assert_eq(world.player_cell, Vector2i(2, 8))
+
+	assert_true(world.move_result(Vector2i.UP)["ok"])
+	assert_eq(world.player_cell, Vector2i(2, 7))
+
+
+func test_side_wall_does_not_block_entering_from_the_far_side() -> void:
+	# COLL_RIGHT_WALL only walls its own right edge; entering it from the
+	# west is an ordinary step, matching the mansion-roof railing you can
+	# walk up to but not cross.
+	var world: Gen2WorldAPI = _world(Vector2i(1, 8))
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(world.player_cell, Vector2i(2, 8))
+
+
+func test_side_wall_pair_blocks_crossing_from_either_side() -> void:
+	# COLL_RIGHT_WALL at (2,8) and COLL_LEFT_WALL at (3,8) form a fence
+	# neither tile can cross into the other, though both are LAND_TILE.
+	var from_right_wall: Gen2WorldAPI = _world(Vector2i(2, 8))
+	var blocked_right: Dictionary = from_right_wall.move_result(Vector2i.RIGHT)
+	assert_false(blocked_right["ok"])
+	assert_eq(blocked_right["reason"], &"blocked")
+
+	var from_left_wall: Gen2WorldAPI = _world(Vector2i(3, 8))
+	var blocked_left: Dictionary = from_left_wall.move_result(Vector2i.LEFT)
+	assert_false(blocked_left["ok"])
+	assert_eq(blocked_left["reason"], &"blocked")
+
+
+func test_side_wall_blocks_surfing_the_same_way_as_walking() -> void:
+	# COLL_RIGHT_BUOY at (4,8) and COLL_LEFT_BUOY at (5,8) are WATER_TILE
+	# permission, gated by the same wTilePermissions AND as land.
+	var world: Gen2WorldAPI = _world(Vector2i(4, 8))
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.collision_permission_at(Vector2i(4, 8)), Gen2WorldCollision.WATER_TILE)
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_false(result["ok"], JSON.stringify(result))
+	assert_eq(result["reason"], &"blocked")
+	assert_eq(world.player_cell, Vector2i(4, 8))
+
+
+func test_can_walk_to_with_no_direction_ignores_side_walls() -> void:
+	# The position-only form (Vector2i.ZERO) keeps answering the destination's
+	# plain permission, matching every existing tool and test call site that
+	# does not go through move_result().
+	var world: Gen2WorldAPI = _world(Vector2i(2, 8))
+	assert_true(world.can_walk_to(Vector2i(3, 8)))
+	assert_true(world.can_walk_to(Vector2i(2, 8), Vector2i.ZERO))
+
+
+func test_up_wall_blocks_stepping_off_the_edge_but_not_climbing_it() -> void:
+	# (2,10) is COLL_UP_WALL: matches every real $b2 cell in the pinned
+	# caches, which blocks entering from above (walking off a cliff) while
+	# leaving the approach from below (climbing it) open, since the enter
+	# rule for COLL_UP_WALL only feeds the DOWN handler.
+	var from_above: Gen2WorldAPI = _world(Vector2i(2, 9))
+	var stepped_off: Dictionary = from_above.move_result(Vector2i.DOWN)
+	assert_false(stepped_off["ok"], JSON.stringify(stepped_off))
+	assert_eq(stepped_off["reason"], &"blocked")
+
+	var from_below: Gen2WorldAPI = _world(Vector2i(2, 11))
+	var climbed: Dictionary = from_below.move_result(Vector2i.UP)
+	assert_true(climbed["ok"], JSON.stringify(climbed))
+	assert_eq(from_below.player_cell, Vector2i(2, 10))
+
+
+func test_side_wall_enter_rule_blocks_crystal_from_the_isolated_wall() -> void:
+	# (7,8) is a lone COLL_LEFT_WALL with open land to its west at (6,8), so
+	# only the enter rule can be responsible for any block here.
+	var world: Gen2WorldAPI = _world(Vector2i(6, 8))
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_false(result["ok"], JSON.stringify(result))
+	assert_eq(result["reason"], &"blocked")
+
+
+func test_side_wall_gold_profile_enter_rule_only_blocks_down() -> void:
+	# pokegold's .ok_right sets bit RIGHT, numerically FACE_DOWN rather than
+	# FACE_RIGHT (wFacingDirection and wWalkingDirection use transposed bit
+	# layouts), so the same isolated COLL_LEFT_WALL that blocks Crystal above
+	# does not block Gold/Silver: the bit it sets is irrelevant to a RIGHT
+	# move. No shipped Gold/Silver map has a code that reaches this branch;
+	# this pins the source's own quirk for a mod-authored one.
+	var gold_directory: String = RomCache.directory_for(&"testworldgold", "abcdef0123456789ab")
+	RomCache.clear(gold_directory)
+	RomCache.prepare(gold_directory)
+	var saved_directory: String = _directory
+	_directory = gold_directory
+	_write_cache("gold")
+	_directory = saved_directory
+
+	var data: GameData = GameData.open_directory(gold_directory)
+	assert_eq(data.id, &"gold")
+	assert_false(Gen2WorldState.is_crystal_profile(data))
+	var state: Gen2WorldState = Gen2WorldState.new({}, {}, {Gen2WorldInventory.ITEM_OLD_ROD: 1})
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(6, 8), state)
+
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(world.player_cell, Vector2i(7, 8))
+
+	RomCache.clear(gold_directory)
 
 
 func test_interact_dispatches_a_tile_collision_std_script_when_nothing_else_answers() -> void:

--- a/tests/unit/test_world_collision.gd
+++ b/tests/unit/test_world_collision.gd
@@ -80,3 +80,152 @@ func test_tile_collision_std_index_answers_missing_for_untabled_codes() -> void:
 	assert_eq(Gen2WorldCollision.tile_collision_std_index(0x00, true), -1)
 	assert_eq(Gen2WorldCollision.tile_collision_std_index(0x07, false), -1)
 	assert_eq(Gen2WorldCollision.tile_collision_std_index(0xA0, true), -1)
+
+
+## home/map.asm's .MovementPermissionsData, recounted per code (constants/
+## collision_constants.asm's COLL_*_WALL/BUOY names). $c0-$c7 share the table.
+func test_side_wall_face_mask_matches_movement_permissions_data() -> void:
+	var expected: Dictionary = {
+		0xB0: Gen2WorldCollision.FACE_RIGHT,
+		0xB1: Gen2WorldCollision.FACE_LEFT,
+		0xB2: Gen2WorldCollision.FACE_UP,
+		0xB3: Gen2WorldCollision.FACE_DOWN,
+		0xB4: Gen2WorldCollision.FACE_DOWN | Gen2WorldCollision.FACE_RIGHT,
+		0xB5: Gen2WorldCollision.FACE_DOWN | Gen2WorldCollision.FACE_LEFT,
+		0xB6: Gen2WorldCollision.FACE_UP | Gen2WorldCollision.FACE_RIGHT,
+		0xB7: Gen2WorldCollision.FACE_UP | Gen2WorldCollision.FACE_LEFT,
+	}
+	for wall_code: int in expected:
+		var buoy_code: int = wall_code + 0x10
+		assert_eq(
+			Gen2WorldCollision.side_wall_face_mask(wall_code), expected[wall_code],
+			"$%02X" % wall_code
+		)
+		assert_eq(
+			Gen2WorldCollision.side_wall_face_mask(buoy_code), expected[wall_code],
+			"$%02X" % buoy_code
+		)
+
+
+func test_side_wall_face_mask_refuses_non_wall_non_buoy_codes() -> void:
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(0x00), 0)
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(0xA0), 0)
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(-1), 0)
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(0x100), 0)
+
+
+func test_side_wall_face_mask_aliases_b8_to_bf_and_c8_to_cf() -> void:
+	# .CheckHiNybble ANDs against $f0 before comparing, so $b8 shares $b0's
+	# hi nybble and aliases onto the same entry, mirroring the $a8-$af ledge
+	# alias allows_hop() already preserves.
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(0xB8), Gen2WorldCollision.FACE_RIGHT)
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(0xBF), Gen2WorldCollision.FACE_UP | Gen2WorldCollision.FACE_LEFT)
+	assert_eq(Gen2WorldCollision.side_wall_face_mask(0xC8), Gen2WorldCollision.FACE_RIGHT)
+
+
+func test_side_wall_codes_keep_their_plain_permission() -> void:
+	for code: int in range(0xB0, 0xB8):
+		assert_eq(Gen2WorldCollision.permission_for(code), Gen2WorldCollision.LAND_TILE, "$%02X" % code)
+	for code: int in range(0xC0, 0xC8):
+		assert_eq(Gen2WorldCollision.permission_for(code), Gen2WorldCollision.WATER_TILE, "$%02X" % code)
+
+
+## home/map.asm's GetMovementPermissions, crystal profile: .ok_down/.ok_up/
+## .ok_right/.ok_left OR their own FACE_* constant on a match.
+func test_tile_permissions_crystal_blocks_the_matching_face_per_neighbor() -> void:
+	var open_code: int = 0x00
+	# Standing tile itself walls off FACE_RIGHT (leave rule).
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(0xB0, open_code, open_code, open_code, open_code, true),
+		Gen2WorldCollision.FACE_RIGHT
+	)
+	# Neighbour below is COLL_UP_WALL ($b2): its own mask includes FACE_UP,
+	# so entering it from above (moving DOWN) is blocked.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, 0xB2, open_code, open_code, true),
+		Gen2WorldCollision.FACE_DOWN
+	)
+	# Neighbour above is COLL_DOWN_WALL ($b3): blocks moving UP into it.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, 0xB3, open_code, open_code, open_code, true),
+		Gen2WorldCollision.FACE_UP
+	)
+	# Neighbour to the right is COLL_LEFT_WALL ($b1): blocks moving RIGHT.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, open_code, open_code, 0xB1, true),
+		Gen2WorldCollision.FACE_RIGHT
+	)
+	# Neighbour to the left is COLL_RIGHT_WALL ($b0): blocks moving LEFT.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, open_code, 0xB0, open_code, true),
+		Gen2WorldCollision.FACE_LEFT
+	)
+	# Standing on a diagonal code (leave rule) blocks both faces it names.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(0xB4, open_code, open_code, open_code, open_code, true),
+		Gen2WorldCollision.FACE_DOWN | Gen2WorldCollision.FACE_RIGHT
+	)
+	# A DOWN_LEFT neighbour below the player (mask FACE_DOWN|FACE_LEFT) does
+	# not contain FACE_UP, the opposite of DOWN, so entering it from above is
+	# not blocked by the enter rule.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, 0xB5, open_code, open_code, true),
+		0
+	)
+
+
+## pokegold/home/map.asm's .ok_down/.ok_up/.ok_right/.ok_left all set bit
+## RIGHT (numerically FACE_DOWN), so every enter-rule match blocks only DOWN.
+## No shipped Gold/Silver map exercises this: every real $bx/$cx cell in those
+## caches has low three bits 2 (COLL_UP_WALL), which only ever feeds the
+## down-neighbor check anyway, so the crystal and gold results already agree
+## there. This pins the source's own divergence for a mod-authored map.
+func test_tile_permissions_gold_silver_enter_rule_always_sets_face_down() -> void:
+	var open_code: int = 0x00
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, 0xB3, open_code, open_code, open_code, false),
+		Gen2WorldCollision.FACE_DOWN
+	)
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, open_code, open_code, 0xB1, false),
+		Gen2WorldCollision.FACE_DOWN
+	)
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, open_code, 0xB0, open_code, false),
+		Gen2WorldCollision.FACE_DOWN
+	)
+	# The leave rule is unaffected: standing on a wall code still walls off
+	# its own real face on both games.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(0xB1, open_code, open_code, open_code, open_code, false),
+		Gen2WorldCollision.FACE_LEFT
+	)
+	# The down-neighbor case already matches FACE_DOWN on crystal too, so it
+	# does not by itself distinguish the two profiles.
+	assert_eq(
+		Gen2WorldCollision.tile_permissions(open_code, open_code, 0xB2, open_code, open_code, false),
+		Gen2WorldCollision.FACE_DOWN
+	)
+
+
+## engine/overworld/npc_movement.asm's CanObjectLeaveTile and
+## WillObjectBumpIntoTile, byte-identical between both pinned repositories.
+func test_side_wall_step_blocked_matches_the_leave_and_enter_rules() -> void:
+	var open_code: int = 0x00
+	# Leaving a RIGHT_WALL tile moving RIGHT is blocked (leave rule).
+	assert_true(Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, Vector2i.RIGHT))
+	# Leaving the same tile moving LEFT, UP or DOWN is not.
+	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, Vector2i.LEFT))
+	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, Vector2i.UP))
+	# Entering a LEFT_WALL tile from the west (moving RIGHT) is blocked
+	# (enter rule: the destination's own mask contains FACE_LEFT, the
+	# opposite of RIGHT).
+	assert_true(Gen2WorldCollision.side_wall_step_blocked(open_code, 0xB1, Vector2i.RIGHT))
+	assert_false(Gen2WorldCollision.side_wall_step_blocked(open_code, 0xB1, Vector2i.LEFT))
+	# A RIGHT_WALL/LEFT_WALL pair blocks crossing in both directions even
+	# though both tiles are plain LAND_TILE permission.
+	assert_true(Gen2WorldCollision.side_wall_step_blocked(0xB0, 0xB1, Vector2i.RIGHT))
+	assert_true(Gen2WorldCollision.side_wall_step_blocked(0xB1, 0xB0, Vector2i.LEFT))
+	# A zero or diagonal direction never blocks.
+	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, 0xB1, Vector2i.ZERO))
+	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, 0xB1, Vector2i(1, 1)))

--- a/tools/validate_side_walls.gd
+++ b/tools/validate_side_walls.gd
@@ -1,0 +1,209 @@
+extends SceneTree
+
+## Verifies side-wall and side-buoy directional masks against freshly imported
+## real caches, for both command profiles. The expected codes come from the
+## pinned pokecrystal and pokegold sources: home/map.asm's
+## GetMovementPermissions and engine/overworld/npc_movement.asm's
+## CanObjectLeaveTile/WillObjectBumpIntoTile.
+##
+## The real-cartridge counterpart to the side-wall cases in
+## tests/unit/test_world_collision.gd and tests/unit/test_world_api.gd, which
+## use synthetic caches. It also pins the map census HANDOFF.md's open-work
+## entry measured against these caches, so a future cache change is loud.
+##
+##   Godot --headless --path . -s res://tools/validate_side_walls.gd
+
+## constants/map_constants.asm's CELADON_MANSION_ROOF, Crystal map group 21
+## number 15. The only map in either pinned cartridge with $b0 or $b1 cells: a
+## COLL_RIGHT_WALL column at x=4 and a COLL_LEFT_WALL column at x=5, rows 2-6,
+## plus two COLL_LEFT_WALL cells at the row-1 staircase landings.
+const ROOF_GROUP: int = 21
+const ROOF_NUMBER: int = 15
+
+## Every code the CanObjectMoveInDirection/GetMovementPermissions family
+## recognizes, and its FACE_* mask of walled-off edges (home/map.asm's
+## .MovementPermissionsData, recounted by hand per code).
+const EXPECTED_FACE_MASK: Dictionary = {
+	0xB0: Gen2WorldCollision.FACE_RIGHT,
+	0xB1: Gen2WorldCollision.FACE_LEFT,
+	0xB2: Gen2WorldCollision.FACE_UP,
+	0xB3: Gen2WorldCollision.FACE_DOWN,
+	0xB4: Gen2WorldCollision.FACE_DOWN | Gen2WorldCollision.FACE_RIGHT,
+	0xB5: Gen2WorldCollision.FACE_DOWN | Gen2WorldCollision.FACE_LEFT,
+	0xB6: Gen2WorldCollision.FACE_UP | Gen2WorldCollision.FACE_RIGHT,
+	0xB7: Gen2WorldCollision.FACE_UP | Gen2WorldCollision.FACE_LEFT,
+}
+
+## Measured against the three real caches in user://rom_cache, 2026-08-07.
+## Silver is not scanned separately: it shares Gold's command profile and
+## import layout, and Gold's count here already matches Silver's.
+const EXPECTED_CENSUS: Dictionary = {
+	&"crystal": {0xB0: 5, 0xB1: 7, 0xB2: 2343},
+	&"gold": {0xB2: 2320},
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in [&"crystal", &"gold"]:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_codes(game_id)
+		_verify_census(game_id, data)
+	_verify_celadon_mansion_roof()
+	_finish()
+
+
+## $b0-$b7/$c0-$c7 stay their plain permission (LAND/WATER) and additionally
+## wall off the edges EXPECTED_FACE_MASK names. $b8-$bf/$c8-$cf alias onto the
+## same eight entries, matching the $a8-$af ledge alias; $af is a ledge code
+## and never a side wall, so it must answer 0 here.
+func _verify_codes(game_id: StringName) -> void:
+	for wall_code: int in EXPECTED_FACE_MASK:
+		var buoy_code: int = wall_code + 0x10
+		var alias_code: int = wall_code + 0x08
+		_check(
+			Gen2WorldCollision.permission_for(wall_code) == Gen2WorldCollision.LAND_TILE,
+			"%s: $%02X is not LAND_TILE." % [game_id, wall_code]
+		)
+		_check(
+			Gen2WorldCollision.permission_for(buoy_code) == Gen2WorldCollision.WATER_TILE,
+			"%s: $%02X is not WATER_TILE." % [game_id, buoy_code]
+		)
+		_check(
+			Gen2WorldCollision.side_wall_face_mask(wall_code) == EXPECTED_FACE_MASK[wall_code],
+			"%s: $%02X's face mask does not match .MovementPermissionsData." % [game_id, wall_code]
+		)
+		_check(
+			Gen2WorldCollision.side_wall_face_mask(buoy_code) == EXPECTED_FACE_MASK[wall_code],
+			"%s: $%02X's face mask does not match .MovementPermissionsData." % [game_id, buoy_code]
+		)
+		_check(
+			Gen2WorldCollision.side_wall_face_mask(alias_code) == EXPECTED_FACE_MASK[wall_code],
+			"%s: $%02X does not alias %s's entry." % [game_id, alias_code, wall_code]
+		)
+	_check(
+		Gen2WorldCollision.side_wall_face_mask(0xAF) == 0,
+		"%s: $AF (a ledge code) answers a side-wall face mask." % game_id
+	)
+
+
+## Pins HANDOFF.md's map census so a future cache change is loud rather than
+## silently changing which cells this feature affects.
+func _verify_census(game_id: StringName, data: GameData) -> void:
+	var expected: Dictionary = EXPECTED_CENSUS[game_id]
+	var counts: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		for code: int in map.collision:
+			if code >= 0xB0 and code <= 0xCF:
+				counts[code] = int(counts.get(code, 0)) + 1
+	for code: int in expected:
+		_check(
+			int(counts.get(code, 0)) == int(expected[code]),
+			"%s: $%02X census is %d cells, expected %d." % [
+				game_id, code, int(counts.get(code, 0)), int(expected[code]),
+			]
+		)
+	for code: int in counts:
+		if code in expected:
+			continue
+		_check(
+			false,
+			"%s: $%02X has %d cells with no expected count; census is stale." % [
+				game_id, code, int(counts[code]),
+			]
+		)
+
+
+## Live checks against Crystal's Celadon Mansion Roof, the only map in either
+## pinned cartridge carrying $b0 or $b1.
+func _verify_celadon_mansion_roof() -> void:
+	var data: GameData = GameData.open(&"crystal")
+	if data == null:
+		return
+	var right_wall := Gen2WorldAPI.open(
+		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(4, 4), Gen2WorldState.new()
+	)
+	if not _check(right_wall != null, "crystal: Celadon Mansion Roof (21/15) is missing."):
+		return
+	_check(
+		right_wall.collision_code_at(Vector2i(4, 4)) == 0xB0,
+		"crystal: roof (4,4) is not COLL_RIGHT_WALL."
+	)
+	var blocked_right: Dictionary = right_wall.move_result(Vector2i.RIGHT)
+	_check(
+		not bool(blocked_right.get("ok", false)),
+		"crystal: roof (4,4) did not block moving RIGHT off its own wall."
+	)
+
+	var left_wall := Gen2WorldAPI.open(
+		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(5, 4), Gen2WorldState.new()
+	)
+	_check(
+		left_wall.collision_code_at(Vector2i(5, 4)) == 0xB1,
+		"crystal: roof (5,4) is not COLL_LEFT_WALL."
+	)
+	var blocked_left: Dictionary = left_wall.move_result(Vector2i.LEFT)
+	_check(
+		not bool(blocked_left.get("ok", false)),
+		"crystal: roof (5,4) did not block moving LEFT off its own wall."
+	)
+
+	var vertical := Gen2WorldAPI.open(
+		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(4, 3), Gen2WorldState.new()
+	)
+	var down: Dictionary = vertical.move_result(Vector2i.DOWN)
+	_check(
+		bool(down.get("ok", false)) and vertical.player_cell == Vector2i(4, 4),
+		"crystal: roof (4,3) could not step down its own wall column."
+	)
+
+	var staircase_left := Gen2WorldAPI.open(
+		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(2, 1), Gen2WorldState.new()
+	)
+	var landing_left: Dictionary = staircase_left.move_result(Vector2i.LEFT)
+	_check(
+		not bool(landing_left.get("ok", false)),
+		"crystal: roof (2,1) did not block leaving its own COLL_LEFT_WALL."
+	)
+
+	var staircase_right := Gen2WorldAPI.open(
+		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(1, 1), Gen2WorldState.new()
+	)
+	var entering_wall: Dictionary = staircase_right.move_result(Vector2i.RIGHT)
+	_check(
+		not bool(entering_wall.get("ok", false)),
+		"crystal: roof (1,1) did not block entering (2,1)'s COLL_LEFT_WALL."
+	)
+
+	var staircase_up := Gen2WorldAPI.open(
+		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(1, 2), Gen2WorldState.new()
+	)
+	var climbed: Dictionary = staircase_up.move_result(Vector2i.UP)
+	_check(
+		bool(climbed.get("ok", false)) and staircase_up.player_cell == Vector2i(1, 1),
+		"crystal: roof (1,2) could not climb to the staircase landing."
+	)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS side walls: codes, census and Celadon Mansion Roof verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_side_walls.gd.uid
+++ b/tools/validate_side_walls.gd.uid
@@ -1,0 +1,1 @@
+uid://dspaehkdn3jjf


### PR DESCRIPTION
GetMovementPermissions' $b0-$b7/$c0-$c7 codes wall off one or two of a tile's own edges by direction on top of their plain LAND/WATER permission; the player and NPC paths ignored this, so cliff-edge and railing tiles were walkable from every side. Gen2WorldCollision gains the face-mask table and the player/NPC rules, including pokegold's enter-rule quirk, and Gen2WorldAPI's can_walk_to/can_object_walk_to take an optional movement direction to enforce them at every runtime call site.