### PR TITLE
Register battle presentation as a Gen2ModHost renderer

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -88,6 +88,28 @@ switch between the built-in `gen2` renderer and a mod's while the game runs.
 the player and any running script are untouched, because a renderer reads world
 state and must not write it. Two views of one world have to agree.
 
+## Replacing the battle renderer
+
+The same boundary covers battle presentation. `Gen2BattleScreen` owns the
+battle, the events and the text box; it decides nothing about how a Pokémon,
+a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
+
+| Method | Called when |
+|---|---|
+| `set_battle_data(data) -> bool` | The screen is ready, before the first view; a false return leaves the screen not ready |
+| `set_view(view: Dictionary)` | The screen has new plain display values to show |
+| `refresh()` | The renderer should redraw its current view |
+
+`view` carries `enemy_species`, `player_species`, `enemy_name`, `player_name`,
+`enemy_level`, `player_level`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
+`player_max_hp` and `exp_fraction`: plain values read out of a resolved battle
+event, never the battle engine itself, the same rule `Gen2BattleScreen`'s own
+setters already followed.
+
+Registration uses the same refusal rules as a world renderer, and shares both
+optional methods (`uses_hardware_viewport()`, `set_native_size()`) and the `V`
+cycle, bound in `Gen2BattleScreen` the way `Gen2WorldScreen` binds it.
+
 ## Logical world state and optional mod pose
 
 The game stays logically grid-based. The player and NPCs occupy walk cells,
@@ -144,10 +166,8 @@ What is still missing, in the order it blocks work:
    has no height data, so a renderer needs a per-block table it supplies
    itself, and the host should let a mod attach one rather than have every
    renderer hard-code Johto.
-2. **Battles and interiors are not renderer-owned.** `Gen2BattleScreen` builds
-   its own 160x144 presentation directly instead of going through the mod host,
-   so the voxel mod's 3D battles have no equivalent here. Battle presentation
-   needs the same registration the world renderer has.
+2. **Interiors are not renderer-owned.** Only the overworld and battle are
+   registered; a 3D interior view has no equivalent boundary here.
 3. **No camera boundary.** `Gen2WorldAPI.visible_origin_cell()` still follows
    the committed cell rather than the interpolated one, so a free camera pans a
    step early. A free camera needs the world to stop framing the view.

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -1,0 +1,165 @@
+class_name Gen2BattleRenderer
+extends Control
+
+## Draws the battle field: two pics, two status panels, two HP bars and the exp
+## bar, at the positions the hardware puts them. It does not own the battle;
+## call [method set_battle_data] once, then [method set_view] whenever the
+## screen has new display values to show.
+##
+## Panels compose into one screen-sized index buffer drawn over the pics with
+## index 0 transparent: a panel is a shape on a white field, drawn into the
+## background layer on hardware, so the pics show through everything that is not
+## ink.
+
+## Where the two pics sit, in tiles.
+const ENEMY_PIC: Vector2i = Vector2i(12, 0)
+const PLAYER_PIC: Vector2i = Vector2i(2, 6)
+
+const TILE: int = Gen2Font.TILE
+
+## The white the hardware fills the battle background with.
+const BACKGROUND: Color = Color.WHITE
+
+var _data: GameData = null
+var _hud: Gen2BattleHud = null
+var _view: Dictionary = {}
+
+var _enemy_pic: TextureRect = null
+var _player_pic: TextureRect = null
+var _panels: TextureRect = null
+var _enemy_bar: TextureRect = null
+var _player_bar: TextureRect = null
+var _exp_bar: TextureRect = null
+
+
+## Reads what it draws with out of the cache and builds its layers. Answers
+## false if the cache is missing something the HUD needs, mirroring
+## [method Gen2BattleHud.from_data].
+func set_battle_data(data: GameData) -> bool:
+	_data = data
+	_hud = Gen2BattleHud.from_data(data)
+	if _hud == null:
+		return false
+
+	var field := ColorRect.new()
+	field.color = BACKGROUND
+	field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	add_child(field)
+
+	_enemy_pic = _new_layer()
+	_player_pic = _new_layer()
+	_panels = _new_layer()
+	_enemy_bar = _new_layer()
+	_player_bar = _new_layer()
+	_exp_bar = _new_layer()
+	return true
+
+
+## The display values a battle screen has settled on right now. Plain values,
+## not the battle engine: what is drawn deliberately lags what has resolved,
+## since a turn resolves at once and is then shown an event at a time.
+func set_view(view: Dictionary) -> void:
+	_view = view
+	refresh()
+
+
+func refresh() -> void:
+	if _hud == null:
+		return
+
+	_draw_pic(
+		_enemy_pic, _data.species_pic(int(_view.get("enemy_species", 0))),
+		_data.palette(int(_view.get("enemy_species", 0))), ENEMY_PIC
+	)
+	_draw_pic(
+		_player_pic, _data.species_pic(int(_view.get("player_species", 0)), true),
+		_data.palette(int(_view.get("player_species", 0))), PLAYER_PIC
+	)
+	_draw_panels()
+
+
+func _draw_pic(
+	into: TextureRect, pic: Dictionary, palette: PackedColorArray, at: Vector2i
+) -> void:
+	if into == null or pic.is_empty():
+		return
+
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
+	)
+	into.texture = ImageTexture.create_from_image(image)
+	into.size = image.get_size()
+	into.position = Vector2(at.x * TILE, at.y * TILE)
+
+
+## The panels, and then each bar over them in its own colour.
+##
+## The hardware gives every background tile its own palette, so a green HP bar
+## sits in a panel of black text without either being separate. Here that is one
+## buffer per palette, which is why the bars are drawn apart from the panels.
+func _draw_panels() -> void:
+	var enemy_hp: int = int(_view.get("enemy_hp", 0))
+	var enemy_max_hp: int = int(_view.get("enemy_max_hp", 0))
+	var player_hp: int = int(_view.get("player_hp", 0))
+	var player_max_hp: int = int(_view.get("player_max_hp", 0))
+
+	var panels: PackedByteArray = _new_buffer()
+	_hud.draw_enemy(
+		panels, Gen2Screen.WIDTH, String(_view.get("enemy_name", "")),
+		int(_view.get("enemy_level", 0))
+	)
+	_hud.draw_player(
+		panels, Gen2Screen.WIDTH, String(_view.get("player_name", "")),
+		int(_view.get("player_level", 0)), player_hp, player_max_hp
+	)
+	_show_layer(
+		_panels, panels,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+
+	var enemy: PackedByteArray = _new_buffer()
+	_hud.draw_hp_bar(enemy, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, enemy_hp, enemy_max_hp)
+	_show_layer(_enemy_bar, enemy, _hp_palette(enemy_hp, enemy_max_hp))
+
+	var player: PackedByteArray = _new_buffer()
+	_hud.draw_hp_bar(player, Gen2Screen.WIDTH, Gen2BattleHud.PLAYER_BAR, player_hp, player_max_hp)
+	_show_layer(_player_bar, player, _hp_palette(player_hp, player_max_hp))
+
+	var gained: PackedByteArray = _new_buffer()
+	_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, float(_view.get("exp_fraction", 0.0)))
+	_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
+
+
+func _new_layer() -> TextureRect:
+	var out := TextureRect.new()
+	# Nearest, or the integer-scaled viewport is undone on the last hop.
+	out.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	add_child(out)
+	return out
+
+
+func _new_buffer() -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	return out
+
+
+## Every layer above the pics is drawn with index 0 transparent: a panel is a
+## shape on the background, not a rectangle over it.
+func _show_layer(
+	into: TextureRect, indices: PackedByteArray, palette: PackedColorArray
+) -> void:
+	var image: Image = Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
+	)
+	into.texture = ImageTexture.create_from_image(image)
+	into.size = image.get_size()
+
+
+## An HP bar is green, yellow or red by how much of it is lit rather than by the
+## hit points behind it, which is the rule the games use.
+func _hp_palette(hp: int, max_hp: int) -> PackedColorArray:
+	var lit: int = Gen2BattleHud.bar_pixels(
+		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
+	)
+	return _data.bar_palette(GameData.hp_bar_palette_name(lit))

--- a/game/battle/battle_renderer.gd.uid
+++ b/game/battle/battle_renderer.gd.uid
@@ -1,0 +1,1 @@
+uid://d2aps4tnqq2pf

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -4,27 +4,15 @@ extends Control
 signal battle_finished(result: Dictionary)
 signal capture_requested(ball: int)
 
-## The battle screen: two Pokémon, two status panels and a text box, at the
-## positions the hardware puts them.
+## Owns the battle, the events and the text box; decides nothing about how they
+## are drawn. A [Gen2Battle] resolves the turn and answers with events; this
+## shows them one at a time, reading every number out of the event rather than
+## asking the engine again, which is why the setters still take plain values.
 ##
-## Everything on it exists a layer down (a pic from an atlas, a panel from the
-## HUD sheets, a box from the font and a border); this decides placement: enemy
-## pic top right, player back pic below and left, a panel each, the standard box
-## along the bottom.
-##
-## It draws what it is given and decides nothing. A [Gen2Battle] resolves the
-## turn and answers with events; this shows them one at a time, reading every
-## number out of the event rather than asking the engine again, which is why the
-## setters still take plain values.
-##
-## Panels compose into one screen-sized index buffer drawn over the pics with
-## index 0 transparent: a panel is a shape on a white field, drawn into the
-## background layer on hardware, so the pics show through everything that is not
-## ink.
-
-## Where the two pics sit, in tiles.
-const ENEMY_PIC: Vector2i = Vector2i(12, 0)
-const PLAYER_PIC: Vector2i = Vector2i(2, 6)
+## Presentation is a registered renderer, the same boundary the overworld's map
+## goes through: [method _push_view] hands plain display values to whatever
+## [Gen2ModHost] constructs, and the text box stays hardware pixels over it, as
+## menus do over the world renderer.
 
 ## What is on screen before a caller says otherwise: the first battle a player
 ## of Gold or Silver is likely to have.
@@ -72,14 +60,13 @@ const STAT_NAMES: Dictionary = {
 	"evasion": "EVASIVENESS",
 }
 
-const TILE: int = Gen2Font.TILE
-
-## The white the hardware fills the battle background with.
-const BACKGROUND: Color = Color.WHITE
-
 var _data: GameData = null
 var _injected_data: GameData = null
-var _hud: Gen2BattleHud = null
+## Whatever the mod host supplies. Typed as Node because a registered renderer
+## only has to satisfy Gen2ModHost.BATTLE_RENDERER_METHODS, not extend the
+## built-in one.
+var _renderer: Node = null
+var _renderer_ready: bool = false
 
 ## The battle behind the screen, and the two Pokémon in it. The display state
 ## below is what is currently drawn, which is not always where the battle has
@@ -125,12 +112,6 @@ var _player_hp: int = 0
 var _player_max_hp: int = 0
 var _exp: float = 0.0
 
-var _enemy_pic: TextureRect = null
-var _player_pic: TextureRect = null
-var _panels: TextureRect = null
-var _enemy_bar: TextureRect = null
-var _player_bar: TextureRect = null
-var _exp_bar: TextureRect = null
 var _box: Gen2TextBox = null
 
 @onready var _screen: Gen2Screen = %Screen
@@ -140,24 +121,12 @@ func _ready() -> void:
 	_data = _injected_data if _injected_data != null else _selected_runtime_data()
 	if _data == null:
 		_data = GameData.open_any()
-	_hud = Gen2BattleHud.from_data(_data)
-	if _hud == null:
+	_build_renderer()
+	if not _renderer_ready:
 		return
 
-	var field := ColorRect.new()
-	field.color = BACKGROUND
-	field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
-	_screen.display(field)
-
-	_enemy_pic = _new_layer()
-	_player_pic = _new_layer()
-	_panels = _new_layer()
-	_enemy_bar = _new_layer()
-	_player_bar = _new_layer()
-	_exp_bar = _new_layer()
-
 	_box = Gen2TextBox.new()
-	_box.font = _hud.font
+	_box.font = Gen2Font.from_data(_data)
 	_screen.display(_box)
 	_box.place_at_bottom()
 
@@ -194,9 +163,9 @@ func _selected_runtime_save() -> Gen2SaveData:
 	return null
 
 
-## True once the cache had everything the screen draws with.
+## True once the cache had everything the renderer draws with.
 func is_ready() -> bool:
-	return _hud != null
+	return _renderer_ready and _box != null
 
 
 ## Puts two Pokémon on the screen at a level each, both at full health, and
@@ -331,7 +300,7 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 ## keeps the world API alive while this screen owns the battle presentation.
 func start_world_battle(request: Dictionary, save: Gen2SaveData = null) -> bool:
 	_clear_capture_action()
-	if _data == null or _hud == null:
+	if _data == null or not is_ready():
 		_emit_world_battle_failure(&"missing_battle_data")
 		return false
 	var player_party: Gen2Party = (
@@ -466,13 +435,13 @@ func set_hp(enemy: int, enemy_max: int, player: int, player_max: int) -> void:
 	_enemy_max_hp = enemy_max
 	_player_hp = player
 	_player_max_hp = player_max
-	_refresh()
+	_push_view()
 
 
 ## How full the exp bar is, from nothing to a level's worth.
 func set_exp(fraction: float) -> void:
 	_exp = clampf(fraction, 0.0, 1.0)
-	_refresh()
+	_push_view()
 
 
 ## Where the player's Pokémon sits between its current level's threshold and the
@@ -1004,7 +973,7 @@ func _apply_event(event: Dictionary) -> void:
 			# to show it on.
 			if int(event["index"]) == _battle.party(Gen2Battle.PLAYER).active:
 				_player_level = int(event["new_level"])
-				_refresh()
+				_push_view()
 			_refresh_exp_bar()
 
 
@@ -1187,7 +1156,7 @@ func _read_hp() -> void:
 
 
 func _unhandled_key_input(event: InputEvent) -> void:
-	if _hud == null or not event.is_pressed():
+	if not is_ready() or not event.is_pressed():
 		return
 
 	var key: InputEventKey = event as InputEventKey
@@ -1230,17 +1199,11 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			switch_player()
 		KEY_SPACE, KEY_ENTER:
 			advance()
+		KEY_V:
+			cycle_battle_renderer()
 		_:
 			return
 	accept_event()
-
-
-func _new_layer() -> TextureRect:
-	var out := TextureRect.new()
-	# Nearest, or the integer-scaled viewport is undone on the last hop.
-	out.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_screen.display(out)
-	return out
 
 
 func _wrap_species(number: int) -> int:
@@ -1248,87 +1211,68 @@ func _wrap_species(number: int) -> int:
 	return wrapi(number, 1, maxi(count, 1) + 1) if count > 0 else 1
 
 
-func _refresh() -> void:
-	if _hud == null:
+## Builds the view for the selected renderer and attaches it to the layer that
+## renderer asked for. See [method Gen2WorldScreen._build_renderer], the same
+## boundary for the map.
+func _build_renderer() -> void:
+	if _renderer != null:
+		if _screen.native_size_changed.is_connected(_on_native_size_changed):
+			_screen.native_size_changed.disconnect(_on_native_size_changed)
+		_renderer.get_parent().remove_child(_renderer)
+		_renderer.queue_free()
+	_renderer = Gen2ModHost.instance().create_battle_renderer()
+	if Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
+		_screen.display(_renderer)
+	else:
+		_screen.display_native(_renderer)
+		_screen.native_size_changed.connect(_on_native_size_changed)
+		_on_native_size_changed(_screen.native_size())
+	_renderer_ready = bool(_renderer.set_battle_data(_data))
+	_push_view()
+
+
+func _on_native_size_changed(size_pixels: Vector2i) -> void:
+	if _renderer != null and _renderer.has_method(Gen2ModHost.RENDERER_RESIZE_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_RESIZE_METHOD, size_pixels)
+
+
+## Switches the live view to another registered renderer without disturbing the
+## battle behind it.
+func select_battle_renderer(id: StringName) -> Dictionary:
+	var result: Dictionary = Gen2ModHost.instance().select_battle_renderer(id)
+	if not bool(result.get("ok", false)):
+		show_message("Renderer unavailable: %s" % String(result.get("reason", "unknown")))
+		return result
+	_build_renderer()
+	show_message("Renderer: %s" % Gen2ModHost.instance().battle_renderer_label(id))
+	return result
+
+
+## Selects the registered renderer after the current one, wrapping.
+func cycle_battle_renderer() -> Dictionary:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var ids: Array = host.battle_renderer_ids()
+	if ids.size() < 2:
+		show_message("No other renderer is registered")
+		return {"ok": false, "reason": &"single_renderer"}
+	var at: int = ids.find(host.selected_battle_renderer())
+	return select_battle_renderer(ids[posmod(at + 1, ids.size())])
+
+
+## Pushes the current display values to the renderer. Plain values only, never
+## the battle engine: a turn resolves at once and is then shown an event at a
+## time, so what is drawn deliberately lags where the battle has got to.
+func _push_view() -> void:
+	if not _renderer_ready:
 		return
-
-	_draw_pic(_enemy_pic, _data.species_pic(_enemy), _data.palette(_enemy), ENEMY_PIC)
-	_draw_pic(_player_pic, _data.species_pic(_player, true), _data.palette(_player), PLAYER_PIC)
-	_draw_panels()
-
-
-func _draw_pic(
-	into: TextureRect, pic: Dictionary, palette: PackedColorArray, at: Vector2i
-) -> void:
-	if into == null or pic.is_empty():
-		return
-
-	var image: Image = Gen2PicImage.from_atlas(
-		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
-	)
-	into.texture = ImageTexture.create_from_image(image)
-	into.size = image.get_size()
-	into.position = Vector2(at.x * TILE, at.y * TILE)
-
-
-## The panels, and then each bar over them in its own colour.
-##
-## The hardware gives every background tile its own palette, so a green HP bar
-## sits in a panel of black text without either being separate. Here that is one
-## buffer per palette, which is why the bars are drawn apart from the panels.
-func _draw_panels() -> void:
-	var panels: PackedByteArray = _new_buffer()
-	_hud.draw_enemy(panels, Gen2Screen.WIDTH, _name_of(_enemy), _enemy_level)
-	_hud.draw_player(
-		panels, Gen2Screen.WIDTH, _name_of(_player), _player_level, _player_hp, _player_max_hp
-	)
-	_show_layer(
-		_panels, panels,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
-	)
-
-	var enemy: PackedByteArray = _new_buffer()
-	_hud.draw_hp_bar(
-		enemy, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, _enemy_hp, _enemy_max_hp
-	)
-	_show_layer(_enemy_bar, enemy, _hp_palette(_enemy_hp, _enemy_max_hp))
-
-	var player: PackedByteArray = _new_buffer()
-	_hud.draw_hp_bar(
-		player, Gen2Screen.WIDTH, Gen2BattleHud.PLAYER_BAR, _player_hp, _player_max_hp
-	)
-	_show_layer(_player_bar, player, _hp_palette(_player_hp, _player_max_hp))
-
-	var gained: PackedByteArray = _new_buffer()
-	_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, _exp)
-	_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
-
-
-func _new_buffer() -> PackedByteArray:
-	var out: PackedByteArray = PackedByteArray()
-	out.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
-	return out
-
-
-## Every layer above the pics is drawn with index 0 transparent: a panel is a
-## shape on the background, not a rectangle over it.
-func _show_layer(
-	into: TextureRect, indices: PackedByteArray, palette: PackedColorArray
-) -> void:
-	var image: Image = Gen2PicImage.from_indices(
-		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
-	)
-	into.texture = ImageTexture.create_from_image(image)
-	into.size = image.get_size()
-
-
-## An HP bar is green, yellow or red by how much of it is lit rather than by the
-## hit points behind it, which is the rule the games use.
-func _hp_palette(hp: int, max_hp: int) -> PackedColorArray:
-	var lit: int = Gen2BattleHud.bar_pixels(
-		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
-	)
-	return _data.bar_palette(GameData.hp_bar_palette_name(lit))
+	_renderer.set_view({
+		"enemy_species": _enemy, "player_species": _player,
+		"enemy_name": _name_of(_enemy), "player_name": _name_of(_player),
+		"enemy_level": _enemy_level, "player_level": _player_level,
+		"enemy_hp": _enemy_hp, "enemy_max_hp": _enemy_max_hp,
+		"player_hp": _player_hp, "player_max_hp": _player_max_hp,
+		"exp_fraction": _exp,
+	})
 
 
 func _name_of(species: int) -> String:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -8,11 +8,13 @@ extends RefCounted
 ## through [GameData] and live world state through [Gen2WorldAPI], both
 ## scene-free.
 ##
-## The first replaceable thing is the world renderer. Nothing about the world
-## requires the drawing to be 2D, so a renderer building geometry from the same
-## block and collision data is a registration, not a fork.
-## [method select_world_renderer] swaps between registered renderers, which is
-## why the contract is a factory rather than a one-time construction.
+## Two things are replaceable this way: the world renderer and the battle
+## renderer. Nothing about either requires the drawing to be 2D, so a renderer
+## building geometry from the same block and collision data, or drawing a battle
+## from the same display values, is a registration, not a fork.
+## [method select_world_renderer] and [method select_battle_renderer] swap
+## between registered renderers, which is why the contract is a factory rather
+## than a one-time construction.
 ##
 ## Mods are interpreted GDScript: iOS forbids JIT and runtime native loading, so
 ## a compiled extension is not an option for a distributed mod.
@@ -26,30 +28,38 @@ const ROOT: String = "user://mods"
 const WORLD_RENDERER_METHODS: Array[String] = [
 	"set_world", "set_time_of_day", "refresh", "refresh_animation",
 ]
+## The methods a battle renderer has to provide.
+const BATTLE_RENDERER_METHODS: Array[String] = [
+	"set_battle_data", "set_view", "refresh",
+]
 ## Optional. A renderer defining this and answering false gets the screen's own
 ## rectangle at window resolution instead of the 160x144 viewport. A view built
 ## from geometry cannot be drawn into a 160x144 buffer and magnified, so this is
 ## what makes a 3D or HD renderer possible at all.
 ##
 ## A renderer that does not define it draws in hardware pixels, which is what the
-## built-in one does and what a tile-recolouring mod wants.
-const WORLD_RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
+## built-in ones do and what a tile-recolouring mod wants. Shared by both
+## renderer kinds.
+const RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
 ## Optional. Called with the native layer's size in window pixels when it is
 ## created and whenever the window changes it. Only reached by a renderer that
-## asked for the native layer.
-const WORLD_RENDERER_RESIZE_METHOD: String = "set_native_size"
-## The id of the built-in 2D renderer, which is always registered.
+## asked for the native layer. Shared by both renderer kinds.
+const RENDERER_RESIZE_METHOD: String = "set_native_size"
+## The id of the built-in 2D renderer, which is always registered for both
+## renderer kinds.
 const BUILT_IN_RENDERER: StringName = &"gen2"
 
 static var _instance: Gen2ModHost = null
 
 var _manifests: Dictionary = {}
-var _renderers: Dictionary = {}
-var _selected_renderer: StringName = BUILT_IN_RENDERER
+var _world_renderers: Dictionary = {}
+var _selected_world_renderer: StringName = BUILT_IN_RENDERER
+var _battle_renderers: Dictionary = {}
+var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
 var _failures: Array = []
 
 
-## The shared host. Created with the built-in renderer already registered, so a
+## The shared host. Created with the built-in renderers already registered, so a
 ## caller that never loads a mod still goes through the same boundary.
 static func instance() -> Gen2ModHost:
 	if _instance == null:
@@ -57,10 +67,13 @@ static func instance() -> Gen2ModHost:
 		_instance.register_world_renderer(
 			BUILT_IN_RENDERER, Gen2WorldRenderer, "Game Boy Color 2D"
 		)
+		_instance.register_battle_renderer(
+			BUILT_IN_RENDERER, Gen2BattleRenderer, "Game Boy Color 2D"
+		)
 	return _instance
 
 
-## Discards every loaded mod and returns to the built-in renderer. For tests and
+## Discards every loaded mod and returns to the built-in renderers. For tests and
 ## for a launcher that reloads the mod list.
 static func reset() -> void:
 	_instance = null
@@ -73,13 +86,83 @@ static func reset() -> void:
 func register_world_renderer(
 	id: StringName, script: Script, label: String = ""
 ) -> Dictionary:
+	return _register(_world_renderers, WORLD_RENDERER_METHODS, id, script, label)
+
+
+func world_renderer_ids() -> Array:
+	return _world_renderers.keys()
+
+
+func world_renderer_label(id: StringName) -> String:
+	return _renderer_label(_world_renderers, id)
+
+
+func selected_world_renderer() -> StringName:
+	return _selected_world_renderer
+
+
+## Chooses which registered renderer new worlds are drawn with. The caller
+## rebuilds its view; this only decides what [method create_world_renderer]
+## hands back, so a keybind can flip between 2D and a mod's renderer.
+func select_world_renderer(id: StringName) -> Dictionary:
+	var result: Dictionary = _select(_world_renderers, id)
+	if bool(result.get("ok", false)):
+		_selected_world_renderer = id
+	return result
+
+
+## A fresh renderer node for the selected world renderer, falling back to the
+## built-in one so a screen always has something to draw with.
+func create_world_renderer() -> Node:
+	return _create(_world_renderers, _selected_world_renderer, Gen2WorldRenderer)
+
+
+## Registers a battle renderer under [param id]. See
+## [method register_world_renderer]; the same registration rules apply.
+func register_battle_renderer(
+	id: StringName, script: Script, label: String = ""
+) -> Dictionary:
+	return _register(_battle_renderers, BATTLE_RENDERER_METHODS, id, script, label)
+
+
+func battle_renderer_ids() -> Array:
+	return _battle_renderers.keys()
+
+
+func battle_renderer_label(id: StringName) -> String:
+	return _renderer_label(_battle_renderers, id)
+
+
+func selected_battle_renderer() -> StringName:
+	return _selected_battle_renderer
+
+
+## Chooses which registered renderer new battles are drawn with. See
+## [method select_world_renderer].
+func select_battle_renderer(id: StringName) -> Dictionary:
+	var result: Dictionary = _select(_battle_renderers, id)
+	if bool(result.get("ok", false)):
+		_selected_battle_renderer = id
+	return result
+
+
+## A fresh renderer node for the selected battle renderer, falling back to the
+## built-in one so a screen always has something to draw with.
+func create_battle_renderer() -> Node:
+	return _create(_battle_renderers, _selected_battle_renderer, Gen2BattleRenderer)
+
+
+func _register(
+	registry: Dictionary, methods: Array[String], id: StringName, script: Script,
+	label: String,
+) -> Dictionary:
 	if String(id).is_empty() or script == null:
 		return {"ok": false, "reason": &"invalid_renderer"}
 	var probe: Object = script.new()
 	if probe == null:
 		return {"ok": false, "reason": &"renderer_not_instantiable", "detail": String(id)}
 	var missing: Array[String] = []
-	for method: String in WORLD_RENDERER_METHODS:
+	for method: String in methods:
 		if not probe.has_method(method):
 			missing.append(method)
 	var is_node: bool = probe is Node
@@ -94,54 +177,41 @@ func register_world_renderer(
 			"ok": false, "reason": &"renderer_missing_methods",
 			"detail": "%s: %s" % [id, ", ".join(missing)],
 		}
-	_renderers[id] = {
+	registry[id] = {
 		"script": script,
 		"label": label if not label.is_empty() else String(id),
 	}
 	return {"ok": true, "id": id}
 
 
-func world_renderer_ids() -> Array:
-	return _renderers.keys()
+func _renderer_label(registry: Dictionary, id: StringName) -> String:
+	return String((registry.get(id, {}) as Dictionary).get("label", ""))
 
 
-func world_renderer_label(id: StringName) -> String:
-	return String((_renderers.get(id, {}) as Dictionary).get("label", ""))
-
-
-func selected_world_renderer() -> StringName:
-	return _selected_renderer
-
-
-## Chooses which registered renderer new worlds are drawn with. The caller
-## rebuilds its view; this only decides what [method create_world_renderer]
-## hands back, so a keybind can flip between 2D and a mod's renderer.
-func select_world_renderer(id: StringName) -> Dictionary:
-	if not _renderers.has(id):
+func _select(registry: Dictionary, id: StringName) -> Dictionary:
+	if not registry.has(id):
 		return {"ok": false, "reason": &"unknown_renderer", "detail": String(id)}
-	_selected_renderer = id
 	return {"ok": true, "id": id}
 
 
-## A fresh renderer node for the selected renderer, falling back to the built-in
-## one so a screen always has something to draw with.
-func create_world_renderer() -> Node:
-	var entry: Dictionary = _renderers.get(_selected_renderer, {})
+func _create(registry: Dictionary, selected: StringName, fallback_script: Script) -> Node:
+	var entry: Dictionary = registry.get(selected, {})
 	var script: Variant = entry.get("script", null)
 	if script is Script:
 		var node: Object = (script as Script).new()
 		if node is Node:
 			return node as Node
-	return Gen2WorldRenderer.new()
+	return fallback_script.new()
 
 
 ## Which of the screen's two layers [param renderer] is drawn on. See
-## [constant WORLD_RENDERER_SURFACE_METHOD]; not answering means hardware pixels,
-## so a renderer written before this existed keeps the layer it was written for.
+## [constant RENDERER_SURFACE_METHOD]; not answering means hardware pixels, so a
+## renderer written before this existed keeps the layer it was written for.
+## Shared by both renderer kinds.
 static func renderer_uses_hardware_viewport(renderer: Node) -> bool:
-	if renderer == null or not renderer.has_method(WORLD_RENDERER_SURFACE_METHOD):
+	if renderer == null or not renderer.has_method(RENDERER_SURFACE_METHOD):
 		return true
-	return bool(renderer.call(WORLD_RENDERER_SURFACE_METHOD))
+	return bool(renderer.call(RENDERER_SURFACE_METHOD))
 
 
 ## Reads every installed mod's manifest without running any of them. The

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -188,8 +188,8 @@ func _build_renderer() -> void:
 
 func _on_native_size_changed(size_pixels: Vector2i) -> void:
 	if _renderer != null \
-		and _renderer.has_method(Gen2ModHost.WORLD_RENDERER_RESIZE_METHOD):
-		_renderer.call(Gen2ModHost.WORLD_RENDERER_RESIZE_METHOD, size_pixels)
+		and _renderer.has_method(Gen2ModHost.RENDERER_RESIZE_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_RESIZE_METHOD, size_pixels)
 
 
 ## Switches the live view to another registered renderer without disturbing the

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -80,7 +80,7 @@ func _init() -> void:
 
 
 ## This renderer is not made of hardware pixels, so it asks for the layer that is
-## not either. See Gen2ModHost.WORLD_RENDERER_SURFACE_METHOD.
+## not either. See Gen2ModHost.RENDERER_SURFACE_METHOD.
 func uses_hardware_viewport() -> bool:
 	return false
 

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -1,0 +1,128 @@
+extends GutTest
+
+## Scene integration for battle presentation through Gen2ModHost. The cache is
+## synthetic, but the battle screen, the mod host and the built-in renderer are
+## the production paths.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+var _data: GameData = null
+var _battle_screen: Gen2BattleScreen = null
+
+
+func before_each() -> void:
+	Gen2ModHost.reset()
+	_data = Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	if is_instance_valid(_battle_screen):
+		_battle_screen.free()
+		_battle_screen = null
+	RomCache.clear(Fixture.directory())
+	Gen2ModHost.reset()
+
+
+func _open_battle() -> void:
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_battle_screen = packed.instantiate() as Gen2BattleScreen
+	_battle_screen.set_data(_data)
+	add_child(_battle_screen)
+	await get_tree().process_frame
+
+
+func _stub_script(body: String) -> GDScript:
+	var script := GDScript.new()
+	script.source_code = body
+	script.reload()
+	return script
+
+
+func test_the_built_in_renderer_draws_the_matchup_and_reports_ready() -> void:
+	await _open_battle()
+	assert_true(_battle_screen.is_ready())
+	assert_true(_battle_screen._renderer is Gen2BattleRenderer)
+	_battle_screen.show_matchup(16, 155, 5, 5)
+	assert_true(_battle_screen.battle_snapshot()["ready"])
+
+
+func test_a_registered_stub_renderer_receives_battle_data_and_a_matching_view() -> void:
+	var script: GDScript = _stub_script("""extends Control
+
+var received_data: bool = false
+var last_view: Dictionary = {}
+
+func set_battle_data(_data) -> bool:
+	received_data = true
+	return true
+
+func set_view(view: Dictionary) -> void:
+	last_view = view
+
+func refresh() -> void:
+	pass
+""")
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"stub", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"stub")["ok"])
+
+	await _open_battle()
+	assert_true(_battle_screen.is_ready())
+	var renderer: Node = _battle_screen._renderer
+	assert_true(bool(renderer.get("received_data")))
+
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_battle_screen.set_hp(10, 20, 3, 4)
+	var view: Dictionary = renderer.get("last_view")
+	assert_eq(int(view.get("enemy_level", -1)), 7)
+	assert_eq(int(view.get("player_level", -1)), 9)
+	assert_eq(int(view.get("enemy_hp", -1)), 10)
+	assert_eq(int(view.get("enemy_max_hp", -1)), 20)
+	assert_eq(int(view.get("player_hp", -1)), 3)
+	assert_eq(int(view.get("player_max_hp", -1)), 4)
+
+
+func test_a_renderer_reporting_missing_data_leaves_the_screen_not_ready() -> void:
+	var script: GDScript = _stub_script("""extends Control
+
+func set_battle_data(_data) -> bool:
+	return false
+
+func set_view(_view: Dictionary) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+""")
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"broken_data", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"broken_data")["ok"])
+
+	await _open_battle()
+	assert_false(_battle_screen.is_ready())
+	# Input must stay inert rather than crash on a renderer that never armed.
+	_battle_screen._unhandled_key_input(InputEventKey.new())
+
+
+func test_a_renderer_choosing_the_native_layer_lands_on_the_screens_native_layer() -> void:
+	var script: GDScript = _stub_script("""extends Control
+
+func set_battle_data(_data) -> bool:
+	return true
+
+func set_view(_view: Dictionary) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func uses_hardware_viewport() -> bool:
+	return false
+""")
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"native", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"native")["ok"])
+
+	await _open_battle()
+	assert_true(_battle_screen.is_ready())
+	# Hardware pixels live inside the SubViewport; a renderer that opted out of
+	# that must not end up there.
+	assert_false(_battle_screen._renderer.get_parent() is SubViewport)

--- a/tests/integration/test_battle_renderer.gd.uid
+++ b/tests/integration/test_battle_renderer.gd.uid
@@ -1,0 +1,1 @@
+uid://bifqe4qorcvjh

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -96,6 +96,102 @@ func test_the_built_in_renderer_is_registered_before_any_mod_loads() -> void:
 	renderer.free()
 
 
+func test_the_built_in_battle_renderer_is_registered_before_any_mod_loads() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(host.battle_renderer_ids().has(Gen2ModHost.BUILT_IN_RENDERER))
+	assert_eq(host.selected_battle_renderer(), Gen2ModHost.BUILT_IN_RENDERER)
+	var renderer: Node = host.create_battle_renderer()
+	assert_true(renderer is Gen2BattleRenderer)
+	renderer.free()
+
+
+func test_a_battle_renderer_missing_a_contract_method_is_refused_at_registration() -> void:
+	var script := GDScript.new()
+	# Has set_battle_data and refresh, but not set_view.
+	script.source_code = "extends Control\nfunc set_battle_data(_d) -> bool:\n\treturn true\nfunc refresh() -> void:\n\tpass\n"
+	script.reload()
+	var result: Dictionary = Gen2ModHost.instance().register_battle_renderer(&"broken", script)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"renderer_missing_methods")
+	assert_string_contains(String(result["detail"]), "set_view")
+
+
+func test_a_discovered_mod_registers_a_battle_renderer_the_screen_then_draws_with() -> void:
+	# A directory and mod id distinct from the world-renderer mod test above:
+	# res:// scripts load through Godot's resource cache keyed by path, so two
+	# tests writing different content to the same user:// script path in the
+	# same process can read back a stale cached script.
+	var directory: String = "%s/voxel_battle" % ROOT
+	DirAccess.make_dir_recursive_absolute(directory)
+	var manifest: Dictionary = _valid_manifest()
+	manifest["id"] = "voxel_battle"
+	_write("%s/mod.json" % directory, JSON.stringify(manifest))
+	_write("%s/battle_renderer.gd" % directory, """extends Control
+
+func set_battle_data(_data) -> bool:
+	return true
+
+func set_view(_view: Dictionary) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func is_voxel_battle_renderer() -> bool:
+	return true
+""")
+	_write("%s/mod.gd" % directory, """extends RefCounted
+
+func register(host, manifest) -> void:
+	host.register_battle_renderer(
+		manifest.id, load("%s/battle_renderer.gd"), "Voxel"
+	)
+""" % directory)
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var found: Array = host.discover(ROOT)
+	assert_eq(found.size(), 1)
+	assert_eq(host.load_discovered(), [&"voxel_battle"])
+	assert_true(host.battle_renderer_ids().has(&"voxel_battle"))
+
+	assert_true(host.select_battle_renderer(&"voxel_battle")["ok"])
+	var renderer: Node = host.create_battle_renderer()
+	assert_true(renderer.has_method("is_voxel_battle_renderer"))
+	renderer.free()
+
+	assert_true(host.select_battle_renderer(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+	var built_in: Node = host.create_battle_renderer()
+	assert_true(built_in is Gen2BattleRenderer)
+	built_in.free()
+
+
+func test_a_battle_renderer_choosing_the_native_layer_is_not_confined_to_hardware_pixels() -> void:
+	var hardware := Gen2BattleRenderer.new()
+	assert_true(Gen2ModHost.renderer_uses_hardware_viewport(hardware))
+	hardware.free()
+
+	var script := GDScript.new()
+	script.source_code = """extends Control
+
+func set_battle_data(_data) -> bool:
+	return true
+
+func set_view(_view: Dictionary) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func uses_hardware_viewport() -> bool:
+	return false
+"""
+	script.reload()
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"native", script)["ok"])
+	var native: Node = script.new()
+	assert_false(Gen2ModHost.renderer_uses_hardware_viewport(native))
+	native.free()
+
+
 func test_a_renderer_missing_a_contract_method_is_refused_at_registration() -> void:
 	var script := GDScript.new()
 	# Has set_world and refresh, but not the rest of the contract.


### PR DESCRIPTION
Gen2BattleScreen drew pics, panels and bars directly instead of going through the mod host, so the renderer boundary the overworld has stopped short of battles. Gen2ModHost now shares one registry mechanism between world and battle renderers; Gen2BattleRenderer holds the moved drawing code, and Gen2BattleScreen pushes plain display values to whatever the host constructs, the same way the world screen already does.