### PR TITLE
Give a world renderer its own camera and the input the screen leaves

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -70,7 +70,7 @@ A registered renderer is a `Node` providing:
 Registration is refused, by name, if any of these is missing or the script is
 not a `Node`, rather than failing on the first drawn frame.
 
-Two methods are optional:
+Two methods are optional, on either renderer kind:
 
 | Method | Effect |
 |---|---|
@@ -81,6 +81,42 @@ A view built out of geometry cannot be drawn into a 160x144 buffer and then
 magnified, so the second layer is what makes a 3D or HD renderer possible at
 all. Text boxes and menus stay hardware pixels over the top: the world gains
 resolution, the interface stays a Game Boy.
+
+A world renderer has a third:
+
+| Method | Effect |
+|---|---|
+| `handle_world_input(event: InputEvent) -> bool` | Every input event the world screen did not use. Answering true consumes it |
+
+The screen claims what it needs and offers the rest, so camera pitch, first
+person and free-roam are all reachable while a movement or interaction key never
+arrives: a renderer reads world state and must not write it, and moving the
+player is writing it. Free-roam movement is the pose layer below, not this. An
+open overlay, a running script, a battle or a trainer approach takes the event
+first, exactly as it does for the screen's own keys.
+
+Implement this rather than Godot's `_input` or `_unhandled_input`. A node in the
+tree is offered events before the screen decides what it needs, so a renderer
+reading them directly races the gameplay keys instead of taking what is left of
+them.
+
+## Framing the view
+
+`Gen2WorldAPI` offers a camera; it does not impose one.
+
+| Method | Value |
+|---|---|
+| `player_position_cells() -> Vector2` | The committed cell plus any in-flight step, in walk cells |
+| `visible_origin_cells() -> Vector2` | The framed view's top-left in fractional walk cells, centred on that position and clamped to the map |
+| `visible_origin_cell() -> Vector2i` | The hardware page origin, which follows the committed cell |
+
+`player_cell` commits at the start of a step, so the hardware page origin moves a
+whole cell the instant one begins. That is what the 160x144 tile page wants and
+what a camera does not: following it pans a step early.
+`visible_origin_cells()` frames the interpolated position instead, and the two
+agree whenever no step is in flight. A renderer that frames its own view, which
+is what a free camera is, can ignore all three and read
+`player_position_cells()` and `map_size_cells()` directly.
 
 The host constructs a renderer per world, so `select_world_renderer()` can
 switch between the built-in `gen2` renderer and a mod's while the game runs.
@@ -157,7 +193,11 @@ Supported by the contract above:
   frame rate and stall cap `Gen2WorldAnimation` uses. The logical cell still
   commits at the start of the step; the fraction is presentation only and never
   reaches collision, events or the world snapshot.
-  `mods/examples/voxel_preview/` reads both.
+  `mods/examples/voxel_preview/` reads both;
+- a camera of its own, through `player_position_cells()` and
+  `visible_origin_cells()` above, without inheriting the tile page's framing;
+- steering that camera, through `handle_world_input`. `mods/examples/voxel_preview/`
+  puts pitch on `Q` and `E`, two keys the world screen does not read.
 
 What is still missing, in the order it blocks work:
 
@@ -168,17 +208,12 @@ What is still missing, in the order it blocks work:
    renderer hard-code Johto.
 2. **Interiors are not renderer-owned.** Only the overworld and battle are
    registered; a 3D interior view has no equivalent boundary here.
-3. **No camera boundary.** `Gen2WorldAPI.visible_origin_cell()` still follows
-   the committed cell rather than the interpolated one, so a free camera pans a
-   step early. A free camera needs the world to stop framing the view.
-4. **No input hook.** Camera pitch, first person and free-roam are all input a
-   mod would have to receive, and the world screen reads keys itself.
-5. **Scripted movement does not interpolate.** `applymovement` streams, and the
+3. **Scripted movement does not interpolate.** `applymovement` streams, and the
    jump, teleport and boulder step types, still place objects a whole cell at a
    time. The wandering, spinning, following, player and trainer-approach paths
    all carry the sub-cell offset.
 
-All five are presentation boundaries that do not exist yet; none of them
+All three are presentation boundaries that do not exist yet; none of them
 changes the world's own data.
 
 ## Not built yet

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -45,6 +45,20 @@ const RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
 ## created and whenever the window changes it. Only reached by a renderer that
 ## asked for the native layer. Shared by both renderer kinds.
 const RENDERER_RESIZE_METHOD: String = "set_native_size"
+## Optional, world renderers only. Offered every input event the world screen
+## chose not to use, so a renderer can own camera pitch, first person or
+## free-roam. Answering true consumes the event.
+##
+## The screen decides first and offers what is left, so a renderer can never take
+## a movement or interaction key: a renderer reads world state and must not write
+## it, and moving the player is writing it. A renderer wanting free-roam movement
+## is the separate pose layer docs/MODS.md describes, not this.
+##
+## Implement this rather than Godot's own [method Node._input] or
+## [method Node._unhandled_input]: a node in the tree is offered events before
+## the screen decides what it needs, so reading them directly races the gameplay
+## keys instead of taking what is left.
+const RENDERER_INPUT_METHOD: String = "handle_world_input"
 ## The id of the built-in 2D renderer, which is always registered for both
 ## renderer kinds.
 const BUILT_IN_RENDERER: StringName = &"gen2"
@@ -212,6 +226,16 @@ static func renderer_uses_hardware_viewport(renderer: Node) -> bool:
 	if renderer == null or not renderer.has_method(RENDERER_SURFACE_METHOD):
 		return true
 	return bool(renderer.call(RENDERER_SURFACE_METHOD))
+
+
+## Offers [param event] to [param renderer], returning whether it was consumed.
+## See [constant RENDERER_INPUT_METHOD]; a renderer that does not take input
+## leaves every event where it was.
+static func renderer_handles_input(renderer: Node, event: InputEvent) -> bool:
+	if renderer == null or event == null \
+		or not renderer.has_method(RENDERER_INPUT_METHOD):
+		return false
+	return bool(renderer.call(RENDERER_INPUT_METHOD, event))
 
 
 ## Reads every installed mod's manifest without running any of them. The

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -221,6 +221,32 @@ func player_view_cell() -> Vector2i:
 	return player_cell - visible_origin_cell()
 
 
+## The player's presentation position in walk cells: the committed cell plus any
+## in-flight step. A renderer that frames its own view reads this instead of
+## composing player_cell and player_step_offset_cells() itself. player_cell
+## stays the authoritative logical cell.
+func player_position_cells() -> Vector2:
+	return Vector2(player_cell) + player_step_offset_cells()
+
+
+## The framed view's top-left in fractional walk cells.
+##
+## visible_origin_cell() is the hardware page origin: it follows the committed
+## cell, so it moves a whole cell the instant a step starts. A camera that is not
+## drawing a tile page would pan a step early on that, so this frames the
+## interpolated position with the same centring and map clamp. With no step in
+## flight the two agree.
+func visible_origin_cells() -> Vector2:
+	if current_map == null:
+		return Vector2.ZERO
+	var size: Vector2i = map_size_cells()
+	var position: Vector2 = player_position_cells()
+	return Vector2(
+		clampf(position.x - floorf(float(VIEW_CELLS.x) / 2.0), 0.0, float(maxi(0, size.x - VIEW_CELLS.x))),
+		clampf(position.y - floorf(float(VIEW_CELLS.y) / 2.0), 0.0, float(maxi(0, size.y - VIEW_CELLS.y)))
+	)
+
+
 ## The committed cell in pixels, offset by any in-flight walk step so a
 ## renderer can draw the approach to it. player_cell itself never carries
 ## this offset; collision, events and the snapshot never see it.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -390,9 +390,32 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			accept_event()
 			return
 		_:
+			# Everything the screen wants has been claimed above, so what reaches
+			# here is what a renderer may have a use for.
+			if Gen2ModHost.renderer_handles_input(_renderer, key):
+				accept_event()
 			return
 	move_player(direction)
 	accept_event()
+
+
+## Non-key input the screen never reads, offered to the renderer on the same
+## terms as the leftover keys: a free camera needs pointer and stick motion, and
+## the screen has no opinion about either.
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey or not _renderer_input_free():
+		return
+	if Gen2ModHost.renderer_handles_input(_renderer, event):
+		accept_event()
+
+
+## Whether the overworld itself is idle. The key path reaches the renderer only
+## after the same overlays, pauses and hosts have each refused the event.
+func _renderer_input_free() -> bool:
+	return _world != null and _battle_host == null and _service_host == null \
+		and _pc_host == null and _start_menu_host == null and _party_host == null \
+		and _trainer_approach.is_empty() and not _world.phone_ring_active() \
+		and not _world.fishing_busy() and not _world.script_input_waiting()
 
 
 ## Public driver for screenshot tooling and scene tests.

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -17,9 +17,17 @@ extends SubViewportContainer
 const CELL_SIZE: float = 1.0
 const WALL_HEIGHT: float = 1.0
 const WATER_DEPTH: float = -0.25
-## How far back and above the player the camera sits. Roughly the pitch the
-## overworld reads at while still showing the extrusion.
-const CAMERA_OFFSET := Vector3(0.0, 9.0, 7.5)
+## How far from the player the camera sits, and the angle above the horizon it
+## starts at: together the (0, 9, 7.5) offset this view used before the pitch
+## was steerable. Roughly what the overworld reads at while still showing the
+## extrusion.
+const CAMERA_DISTANCE: float = 11.715
+const CAMERA_PITCH_DEGREES: float = 50.19
+## Q and E walk the pitch between a near-flat and a near-overhead camera. The
+## screen does not read either key, which is the only reason this view is
+## allowed to.
+const CAMERA_PITCH_STEP: float = 5.0
+const CAMERA_PITCH_LIMITS := Vector2(10.0, 88.0)
 ## Light colour per time of day, in the order Gen2WorldPalette names them.
 const DAY_LIGHT: Array[Color] = [
 	Color(1.0, 0.94, 0.86), Color(1.0, 1.0, 0.98),
@@ -34,6 +42,7 @@ var _terrain: MeshInstance3D = null
 var _player: MeshInstance3D = null
 var _objects: Node3D = null
 var _time_of_day: int = 0
+var _camera_pitch: float = CAMERA_PITCH_DEGREES
 
 
 func _init() -> void:
@@ -112,26 +121,56 @@ func refresh_animation() -> void:
 	pass
 
 
+## Camera pitch, which is input the world screen has no use for and therefore
+## hands over. See Gen2ModHost.RENDERER_INPUT_METHOD: a movement or interaction
+## key never arrives here, because the screen claims those first.
+func handle_world_input(event: InputEvent) -> bool:
+	var key := event as InputEventKey
+	if key == null or not key.pressed:
+		return false
+	match key.keycode:
+		KEY_Q:
+			_set_camera_pitch(_camera_pitch - CAMERA_PITCH_STEP)
+		KEY_E:
+			_set_camera_pitch(_camera_pitch + CAMERA_PITCH_STEP)
+		_:
+			return false
+	return true
+
+
+func camera_pitch() -> float:
+	return _camera_pitch
+
+
+func _set_camera_pitch(degrees: float) -> void:
+	_camera_pitch = clampf(degrees, CAMERA_PITCH_LIMITS.x, CAMERA_PITCH_LIMITS.y)
+	refresh()
+
+
 func refresh() -> void:
 	if _world == null or _camera == null:
 		return
 	var here: Vector3 = _player_position()
 	_player.position = here + Vector3(0.0, 0.6, 0.0)
-	_camera.position = here + CAMERA_OFFSET
+	_camera.position = here + _camera_offset()
 	_camera.look_at(here, Vector3.UP)
 	_rebuild_objects()
+
+
+func _camera_offset() -> Vector3:
+	var pitch: float = deg_to_rad(_camera_pitch)
+	return Vector3(0.0, sin(pitch), cos(pitch)) * CAMERA_DISTANCE
 
 
 func _cell_center(cell: Vector2i) -> Vector3:
 	return Vector3(float(cell.x) * CELL_SIZE, 0.0, float(cell.y) * CELL_SIZE)
 
 
-## player_cell plus its in-flight walk step's fractional offset, so the box
-## and camera ease into a new cell instead of snapping the way they did
-## before Gen2WorldAPI carried any sub-cell presentation state.
+## The committed cell plus its in-flight step, so the box and camera ease into a
+## new cell instead of snapping. Gen2WorldAPI composes the two.
 func _player_position() -> Vector3:
-	var offset: Vector2 = _world.player_step_offset_cells()
-	return _cell_center(_world.player_cell) + Vector3(offset.x, 0.0, offset.y) * CELL_SIZE
+	var position: Vector2 = _world.player_position_cells()
+	return Vector3(position.x * CELL_SIZE, 0.0, position.y * CELL_SIZE)
 
 
 ## One solid per walk cell, extruded by what the cell's collision permission

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -1,0 +1,118 @@
+extends GutTest
+
+## Scene integration for the renderer input hook. The fixture is synthetic, but
+## the world screen and mod host are the production paths.
+##
+## The contract under test is an order, not a keymap: the screen claims what it
+## needs and offers the rest, so a renderer can own a camera and still never be
+## in a position to move the player.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const RENDERER_SOURCE: String = """extends Node2D
+
+var seen: Array = []
+
+func set_world(_world, _animation = null) -> void:
+	pass
+
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func refresh_animation() -> void:
+	pass
+
+func handle_world_input(event) -> bool:
+	seen.append(event.keycode)
+	return event.keycode == KEY_Q
+"""
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	_data = Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+	Gen2ModHost.reset()
+
+
+func after_each() -> void:
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	Gen2ModHost.reset()
+	RomCache.clear(Fixture.directory())
+
+
+func _open_world_with_renderer() -> Node:
+	var script := GDScript.new()
+	script.source_code = RENDERER_SOURCE
+	script.reload()
+	assert_true(Gen2ModHost.instance().register_world_renderer(&"camera", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_world_renderer(&"camera")["ok"])
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	var world := Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6)
+	)
+	var save := Gen2SaveStore.create_development_save(_data, 0)
+	save.world = world.snapshot()
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	return _world_screen._renderer
+
+
+func _press(keycode: Key) -> InputEventKey:
+	var key := InputEventKey.new()
+	key.keycode = keycode
+	key.pressed = true
+	return key
+
+
+func test_a_renderer_receives_the_keys_the_screen_does_not_use() -> void:
+	var renderer: Node = await _open_world_with_renderer()
+	assert_true(renderer.has_method(Gen2ModHost.RENDERER_INPUT_METHOD))
+	_world_screen._unhandled_key_input(_press(KEY_Q))
+	assert_eq(renderer.get("seen"), [KEY_Q])
+
+
+func test_a_renderer_never_receives_a_movement_or_interaction_key() -> void:
+	var renderer: Node = await _open_world_with_renderer()
+	var before: Vector2i = _world_screen._world.player_cell
+	_world_screen._unhandled_key_input(_press(KEY_RIGHT))
+	_world_screen._unhandled_key_input(_press(KEY_SPACE))
+	# The screen claimed both: the player moved, and neither key was offered on.
+	assert_ne(_world_screen._world.player_cell, before)
+	assert_eq(renderer.get("seen"), [])
+
+
+func test_an_open_overlay_keeps_leftover_keys_from_the_renderer() -> void:
+	var renderer: Node = await _open_world_with_renderer()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	assert_not_null(_world_screen._start_menu_host)
+	_world_screen._unhandled_key_input(_press(KEY_Q))
+	assert_eq(renderer.get("seen"), [])
+
+
+func test_a_renderer_without_the_hook_leaves_the_screen_unchanged() -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	# The built-in renderer takes no input, so an unused key stays unused.
+	assert_false(_world_screen._renderer.has_method(Gen2ModHost.RENDERER_INPUT_METHOD))
+	_world_screen._unhandled_key_input(_press(KEY_Q))

--- a/tests/integration/test_world_renderer_input.gd.uid
+++ b/tests/integration/test_world_renderer_input.gd.uid
@@ -1,0 +1,1 @@
+uid://11j6ql8wbgxj

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -281,6 +281,50 @@ func uses_hardware_viewport() -> bool:
 	native.free()
 
 
+func test_a_renderer_can_take_the_input_the_screen_left_it() -> void:
+	# Camera pitch, first person and free-roam are all input a renderer has to
+	# receive, and answering false has to leave the event where it was.
+	var script := GDScript.new()
+	script.source_code = """extends Node2D
+
+var seen: Array = []
+
+func set_world(_world, _animation = null) -> void:
+	pass
+
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func refresh_animation() -> void:
+	pass
+
+func handle_world_input(event) -> bool:
+	seen.append(event.keycode)
+	return event.keycode == KEY_Q
+"""
+	script.reload()
+	assert_true(Gen2ModHost.instance().register_world_renderer(&"camera", script)["ok"])
+	var renderer: Node = script.new()
+	var claimed := InputEventKey.new()
+	claimed.keycode = KEY_Q
+	var declined := InputEventKey.new()
+	declined.keycode = KEY_E
+	assert_true(Gen2ModHost.renderer_handles_input(renderer, claimed))
+	assert_false(Gen2ModHost.renderer_handles_input(renderer, declined))
+	assert_eq(renderer.get("seen"), [KEY_Q, KEY_E])
+	renderer.free()
+
+	# The hook is optional: a renderer written before it existed, or one with no
+	# use for input, is never asked and consumes nothing.
+	var built_in := Gen2WorldRenderer.new()
+	assert_false(Gen2ModHost.renderer_handles_input(built_in, claimed))
+	built_in.free()
+	assert_false(Gen2ModHost.renderer_handles_input(null, claimed))
+
+
 func test_manifests_survive_reading_the_failures_recorded_after_discovery() -> void:
 	_write_manifest(_valid_manifest())
 	var host: Gen2ModHost = Gen2ModHost.instance()

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1008,6 +1008,40 @@ func test_player_walk_step_starts_a_cell_behind_and_never_moves_the_committed_ce
 	)
 
 
+func test_the_interpolated_camera_origin_does_not_pan_a_step_early() -> void:
+	var world: Gen2WorldAPI = _world()
+	# Standing still, the hardware page origin and the camera agree.
+	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
+	assert_eq(world.visible_origin_cell(), Vector2i(3, 2))
+	assert_eq(world.visible_origin_cells(), Vector2(3.0, 2.0))
+
+	assert_true(world.move(Vector2i.LEFT))
+	# The page origin follows the committed cell, so it moves at once. The player
+	# has not visibly left the old cell yet, and the camera stays with them.
+	assert_eq(world.visible_origin_cell(), Vector2i(2, 2))
+	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
+	assert_eq(world.visible_origin_cells(), Vector2(3.0, 2.0))
+
+	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_eq(world.player_position_cells(), Vector2(7.875, 6.0))
+	assert_eq(world.visible_origin_cells(), Vector2(2.875, 2.0))
+
+	# The step lands on the committed cell, where the two agree again.
+	assert_true(world.advance_player_step(1000.0))
+	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 3.0))
+	assert_false(world.player_step_in_progress())
+	assert_eq(world.player_position_cells(), Vector2(7.0, 6.0))
+	assert_eq(world.visible_origin_cells(), Vector2(world.visible_origin_cell()))
+
+
+func test_the_interpolated_camera_origin_clamps_to_the_map_like_the_page_does() -> void:
+	var corner: Gen2WorldAPI = _world(Vector2i(15, 11))
+	assert_eq(corner.visible_origin_cell(), Vector2i(6, 3))
+	assert_eq(corner.visible_origin_cells(), Vector2(6.0, 3.0))
+	var top_left: Gen2WorldAPI = _world(Vector2i.ZERO)
+	assert_eq(top_left.visible_origin_cells(), Vector2.ZERO)
+
+
 func test_advance_player_step_consumes_hardware_frames_and_caps_catchup() -> void:
 	var world: Gen2WorldAPI = _world()
 	assert_true(world.move(Vector2i.LEFT))


### PR DESCRIPTION
## Summary
- `Gen2WorldAPI.visible_origin_cell()` frames the hardware tile page and follows the committed cell, so a free camera built on it panned a step early; `player_position_cells()` and `visible_origin_cells()` add the same centring and map clamp over the interpolated player position instead.
- `Gen2ModHost` gains the optional `handle_world_input` contract: `Gen2WorldScreen` offers a renderer every input event it did not claim itself, so a mod can own camera pitch, first person or free-roam without ever being handed a movement or interaction key.
- `mods/examples/voxel_preview/` uses both, putting camera pitch on `Q`/`E`.

## Test plan
- [x] Editor scan (`--editor --path . --quit`): no parse or script errors
- [x] Full GUT suite: 979 tests, 9,350 assertions, all passing
- [x] 30-second headless boot: clean
- [x] Manual check against the real Crystal cache: installed the example mod, opened Route 29, confirmed `Q`/`E` move the camera pitch (50.19° → 80.19° → 20.19°) through the new hook while `KEY_RIGHT` still moves the player and never reaches the renderer