### PR TITLE
Normalize roaming records to integers on the way into world state

### DIFF
--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -532,11 +532,20 @@ func map_scenes() -> Dictionary:
 	return _map_scenes.duplicate()
 
 
+## Every entry point for a roaming record funnels through here: the constructor,
+## ensure_roaming_mons(), restore() and roaming_mons(). The importer writes these
+## four fields as integers, but a cache or snapshot round-trips through JSON,
+## where they come back as floats, so they are normalized once on the way in
+## rather than at each read.
 func _copy_roaming_mons(source: Array) -> Array:
 	var out: Array = []
 	for raw: Variant in source:
 		if raw is Dictionary:
-			out.append((raw as Dictionary).duplicate(true))
+			var mon: Dictionary = (raw as Dictionary).duplicate(true)
+			for field: String in ["species", "level", "map_group", "map_number"]:
+				if mon.has(field):
+					mon[field] = int(mon[field])
+			out.append(mon)
 	return out
 
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1960,6 +1960,13 @@ func _object_script_world(script_bytes: Array) -> Gen2WorldAPI:
 	return Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6), Gen2WorldState.new())
 
 
+func test_roaming_records_are_integers_rather_than_json_floats() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(6, 6))
+	var mon: Dictionary = world.roaming_mons()[0]
+	for field: String in ["species", "level", "map_group", "map_number"]:
+		assert_eq(typeof(mon[field]), TYPE_INT, "%s must be an int" % field)
+
+
 func test_roaming_mons_move_on_map_setup_and_not_on_elapsed_time() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(6, 6))
 	var random := RandomNumberGenerator.new()


### PR DESCRIPTION
## Summary
- The importer writes `species`/`level`/`map_group`/`map_number` as integers, but a cache or snapshot round-trips them through JSON, where they come back as floats.
- Every read inside `Gen2WorldState` already wrapped them in `int()`, so nothing was wrong at runtime, but `roaming_mons()` handed the raw floats out, producing the suite's only float/int comparison warnings.
- `_copy_roaming_mons()` is the single funnel every entry point uses (constructor, `ensure_roaming_mons()`, `restore()`, `roaming_mons()`), so the four fields are normalized once there instead of at each read.

## Test plan
- [x] Editor scan: no parse or script errors
- [x] Full GUT suite: 973 tests, 9,315 assertions, all passing, 0 warnings (was 4)
- [x] 30-second headless boot: clean