### PR TITLE
Normalize Gold/Silver special indices onto the Crystal table

### DIFF
--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -502,6 +502,24 @@ static func raw_opcode(source_opcode: int, crystal_commands: bool = true) -> int
 	return source_opcode
 
 
+## Converts a raw SPECIAL operand into the Crystal-canonical index the runner's
+## handlers are numbered with. data/events/special_pointers.asm's
+## SpecialsPointers agrees for the first 47 entries, then Crystal inserts
+## BattleTowerFade at 47 and a mobile/Battle Tower block at 109, so Gold/Silver
+## 47-107 sit one lower and its last three entries land after that block.
+## Gold/Silver 110 is MrChrono, which Crystal has no entry for; -1 leaves it
+## unhandled rather than aliasing it onto an unrelated routine.
+static func special_index(raw_special: int, crystal_commands: bool = true) -> int:
+	if crystal_commands or raw_special <= 46:
+		return raw_special
+	match raw_special:
+		108: return 166
+		109: return 167
+		110: return -1
+		111: return 168
+	return raw_special + 1
+
+
 static func is_endcallback(opcode: int, crystal_commands: bool = true) -> bool:
 	return opcode == ENDCALLBACK if crystal_commands else opcode == GOLD_ENDCALLBACK
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -619,7 +619,9 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.CHECKCELLNUM:
 			_script_value = 1 if _phone_contact_registered(int(command["value"])) else 0
 		Gen2WorldScript.SPECIAL:
-			return _execute_special(int(command["value"]))
+			return _execute_special(
+				Gen2WorldScript.special_index(int(command["value"]), _crystal_commands())
+			)
 		Gen2WorldScript.RANDOM:
 			var maximum: int = int(command["value"])
 			_script_value = _random.randi_range(0, maximum - 1) if maximum > 0 else 0
@@ -1380,6 +1382,9 @@ func _clock_minute() -> int:
 	return clampi(int(clock.get("minute", 0)), 0, 59)
 
 
+## [param special] is the Crystal-canonical index from
+## Gen2WorldScript.special_index(), not the raw stream byte, so the payloads
+## below report that index on both profiles.
 func _execute_special(special: int) -> Dictionary:
 	## SPECIAL is a shared cartridge dispatch table. Phone routines are only one
 	## part of it; map callbacks and the new-game clock setup use the same table.

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -868,6 +868,97 @@ func test_side_wall_gold_profile_enter_rule_only_blocks_down() -> void:
 	RomCache.clear(gold_directory)
 
 
+func test_gold_profile_specials_normalize_onto_the_crystal_handlers() -> void:
+	# data/events/special_pointers.asm's SpecialsPointers shifts by one from
+	# BattleTowerFade at Crystal 47, and Crystal's mobile block at 109 pushes the
+	# DST entries to 166 and 167. Without the profile split these raw Gold bytes
+	# reach RestartMapMusic, ToggleMaptileDecorations and PrintDiploma instead.
+	var gold_directory: String = RomCache.directory_for(&"testworldgoldspecial", "9876543210fedcba")
+	RomCache.clear(gold_directory)
+	RomCache.prepare(gold_directory)
+	var saved_directory: String = _directory
+	_directory = gold_directory
+	_write_cache("gold")
+
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(gold_directory))
+	scripts["48:6400"] = [
+		Gen2WorldScript.SETVAL, 1,
+		Gen2WorldScript.SPECIAL, 61, 0, # HealMachineAnim
+		Gen2WorldScript.GOLD_END,
+	]
+	scripts["48:6410"] = [
+		Gen2WorldScript.SPECIAL, 108, 0, # InitialSetDSTFlag
+		Gen2WorldScript.YESORNO, Gen2WorldScript.GOLD_END,
+	]
+	scripts["48:6420"] = [
+		Gen2WorldScript.SPECIAL, 73, 0, # ToggleDecorationsVisibility
+		Gen2WorldScript.GOLD_ENDCALLBACK,
+	]
+	scripts["48:6430"] = [
+		Gen2WorldScript.SPECIAL, 110, 0, # MrChrono, absent from Crystal
+		Gen2WorldScript.GOLD_END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(gold_directory), scripts)
+	_directory = saved_directory
+
+	var data: GameData = GameData.open_directory(gold_directory)
+	assert_eq(data.id, &"gold")
+
+	var heal := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6400,
+	})
+	var heal_result: Dictionary = heal.advance()
+	assert_eq(heal_result["status"], &"complete", JSON.stringify(heal_result))
+	assert_eq(
+		_event_value(heal_result["events"], &"presentation_special_applied", "kind"),
+		&"heal_machine_anim",
+		JSON.stringify(heal_result),
+	)
+	assert_eq(
+		int(_event_value(heal_result["events"], &"presentation_special_applied", "machine_type")),
+		1,
+		JSON.stringify(heal_result),
+	)
+
+	var dst := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6410,
+		"clock": {"day": 1, "hour": 10, "minute": 5},
+	})
+	assert_eq(dst.advance()["event"]["text"], "10:05 DST,\nis that OK?")
+	assert_eq(dst.advance(true)["event"]["type"], &"choice")
+	var dst_result: Dictionary = dst.advance(true, 0)
+	assert_eq(dst_result["status"], &"complete", JSON.stringify(dst_result))
+	assert_true(dst_result["dst_enabled"])
+
+	var decoration_state := Gen2WorldState.new()
+	var decoration := Gen2WorldScriptRunner.begin(data, decoration_state, {
+		"kind": &"test", "bank": 48, "script": 0x6420,
+	})
+	var decoration_result: Dictionary = decoration.advance()
+	assert_eq(decoration_result["status"], &"complete", JSON.stringify(decoration_result))
+	assert_eq(
+		_event_value(decoration_result["events"], &"decoration_callback_applied", "kind"),
+		&"toggle_decorations_visibility",
+		JSON.stringify(decoration_result),
+	)
+	for flag: int in [
+		Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_CONSOLE,
+		Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_DOLL_1,
+		Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_DOLL_2,
+		Gen2WorldScriptRunner.EVENT_PLAYERS_HOUSE_2F_BIG_DOLL,
+	]:
+		assert_true(decoration_state.is_event_flag_active(flag))
+
+	var chrono := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6430,
+	})
+	var chrono_result: Dictionary = chrono.advance()
+	assert_eq(chrono_result["status"], &"failed", JSON.stringify(chrono_result))
+	assert_eq(chrono_result["reason"], &"unsupported_phone_special")
+
+	RomCache.clear(gold_directory)
+
+
 func test_interact_dispatches_a_tile_collision_std_script_when_nothing_else_answers() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6900"] = [Gen2WorldScript.SETSCENE, 90, Gen2WorldScript.END]

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -89,6 +89,33 @@ func test_raw_opcode_shifts_only_at_and_above_the_farjumptext_insertion() -> voi
 	assert_eq(Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_END, true), 0x91)
 
 
+func test_special_index_normalizes_gold_silver_onto_the_crystal_table() -> void:
+	# SpecialsPointers agrees for 0-46, so Crystal is the identity everywhere and
+	# Gold/Silver is the identity below the BattleTowerFade insertion at 47.
+	for crystal_index: int in [27, 37, 62, 78, 106, 166, 168]:
+		assert_eq(Gen2WorldScript.special_index(crystal_index, true), crystal_index)
+	assert_eq(Gen2WorldScript.special_index(0, false), 0)
+	assert_eq(Gen2WorldScript.special_index(46, false), 46)
+
+	# 47-107 sit one lower on Gold/Silver: FadeOutToBlack, RestartMapMusic,
+	# HealMachineAnim, ToggleDecorationsVisibility, CheckPokerus, FadeOutMusic.
+	assert_eq(Gen2WorldScript.special_index(47, false), 48)
+	assert_eq(Gen2WorldScript.special_index(60, false), 61)
+	assert_eq(Gen2WorldScript.special_index(61, false), 62)
+	assert_eq(Gen2WorldScript.special_index(73, false), 74)
+	assert_eq(Gen2WorldScript.special_index(77, false), 78)
+	assert_eq(Gen2WorldScript.special_index(105, false), 106)
+	assert_eq(Gen2WorldScript.special_index(107, false), 108)
+
+	# Crystal's mobile block at 109-165 pushes the last three entries past it.
+	assert_eq(Gen2WorldScript.special_index(108, false), 166) # InitialSetDSTFlag
+	assert_eq(Gen2WorldScript.special_index(109, false), 167) # InitialClearDSTFlag
+	assert_eq(Gen2WorldScript.special_index(111, false), 168) # UnusedDummySpecial
+
+	# Gold/Silver 110 is MrChrono, which Crystal has no entry for at all.
+	assert_eq(Gen2WorldScript.special_index(110, false), -1)
+
+
 func test_raw_opcode_round_trips_the_trainer_intro_commands_through_command_at() -> void:
 	# Each trainer-intro command name should decode identically whether it is
 	# reached through the Gold/Silver raw byte or the shifted Crystal raw byte.


### PR DESCRIPTION
SpecialsPointers (data/events/special_pointers.asm) has 169 Crystal entries and 112 Gold/Silver ones, agreeing only to index 46. Crystal inserts BattleTowerFade at 47 and a mobile block at 109, so Gold/Silver 47-107 sit one lower and its last entries land against Crystal 166-168. The runner matched raw operands against Crystal literals on both profiles, so a Gold bedroom callback ran ActivateFishingSwarm instead of ToggleMaptileDecorations, HealMachineAnim staged map music, and CheckPokerus and the initial daylight-saving specials failed the script outright. Since the new-game spawn is the same map 24/7 on all three games, this was reachable from a Gold or Silver new game.

Gen2WorldScript.special_index() converts a raw operand into the Crystal numbering the handlers use; Gold/Silver 110 is MrChrono, which Crystal has no entry for, so it stays unhandled rather than aliasing onto another routine.