### PR TITLE
Cut a tree from the party submenu

### DIFF
--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -7,6 +7,10 @@ extends Control
 ## start menu resumes on this rather than the screen navigating away with
 ## change_scene_to_file, which would tear down the running world.
 signal closed(result: Dictionary)
+## A chosen submenu entry this screen does not own, mirroring
+## Gen2StartMenuScreen.action_chosen. Field moves need the live world, which
+## belongs to the world screen, so the choice is reported rather than run here.
+signal action_chosen(action: Dictionary)
 
 const BACKGROUND: Color = Color("#09111f")
 const PANEL: Color = Color("#14233a")
@@ -16,6 +20,16 @@ const MUTED: Color = Color("#9eacc0")
 const ACCENT: Color = Color("#f3c969")
 const SUCCESS: Color = Color("#7bd89a")
 const ERROR: Color = Color("#ef8a8a")
+
+## data/mon_menu.asm's MONMENUVALUE_* option strings, in that file's order.
+const OPTION_STATS: StringName = &"stats"
+const OPTION_SWITCH: StringName = &"switch"
+const OPTION_ITEM: StringName = &"item"
+const OPTION_CANCEL: StringName = &"cancel"
+const OPTION_MOVE: StringName = &"move"
+## engine/pokemon/mon_submenu.asm's NUM_MONMENU_ITEMS: a list already this long
+## drops CANCEL rather than growing.
+const MAX_SUBMENU_ITEMS: int = 8
 
 var _data: GameData = null
 var _data_override: GameData = null
@@ -27,6 +41,14 @@ var _player_label: Label = null
 var _status: Label = null
 var _storage_button: Button = null
 var _battle_button: Button = null
+## The keyboard cursor and per-mon submenu. Reachable only through handle_key(),
+## which only the world screen calls, so the standalone save-screen view keeps
+## its mouse-driven behavior unchanged.
+var _member_cursor: int = 0
+var _submenu: VBoxContainer = null
+var _submenu_items: Array = []
+var _submenu_cursor: int = 0
+var _submenu_open: bool = false
 
 
 func _ready() -> void:
@@ -46,6 +68,10 @@ func set_context(data: GameData, save: Gen2SaveData, embedded: bool = false) -> 
 	_embedded = embedded
 	_data = data
 	_save = save
+	_member_cursor = 0
+	_submenu_open = false
+	_submenu_items = []
+	_submenu_cursor = 0
 	if is_inside_tree() and _cards != null:
 		_refresh()
 
@@ -63,6 +89,167 @@ func party_snapshot() -> Dictionary:
 		"slot": _save.slot if _save != null else -1,
 		"members": members,
 	}
+
+
+## engine/pokemon/mon_submenu.asm's GetMonSubmenuItems for one party member.
+##
+## An egg gets three entries and no moves. Otherwise the four move slots are
+## walked in the mon's own slot order, appending every move that appears in
+## MonMenuOptions' field-move rows, then the fixed options follow. Only entries
+## this project acts on are marked available; the rest keep their source
+## position rather than being omitted, the same way Gen2WorldStartMenu carries
+## its unimplemented entries.
+##
+## The MAIL branch is not reproduced: ItemIsMail tests the held item against
+## data/items/mail_items.asm, and this project has no mail, so ITEM is always
+## the entry in that position.
+static func submenu_items_for(data: GameData, mon: Gen2SaveMon) -> Array:
+	var items: Array = []
+	if mon == null:
+		return items
+	# The source compares wCurPartySpecies against EGG ($fd); this save model
+	# carries the same fact as Gen2SaveMon.is_egg beside a real species.
+	if mon.is_egg:
+		items.append(_option_entry(OPTION_STATS, "STATS"))
+		items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
+		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
+		return items
+	for move: int in mon.moves:
+		if move == 0 or not Gen2WorldFieldMove.is_field_move(move):
+			continue
+		items.append({
+			"kind": &"field_move",
+			"move": move,
+			"label": String(data.move(move).get("name", "MOVE")) if data != null else "MOVE",
+			"available": true,
+		})
+	items.append(_option_entry(OPTION_STATS, "STATS"))
+	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
+	items.append(_option_entry(OPTION_MOVE, "MOVE"))
+	items.append(_option_entry(OPTION_ITEM, "ITEM"))
+	if items.size() < MAX_SUBMENU_ITEMS:
+		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
+	return items
+
+
+static func _option_entry(option: StringName, label: String) -> Dictionary:
+	return {"kind": &"option", "option": option, "label": label, "available": false}
+
+
+func _party_size() -> int:
+	return _save.party.size() if _save != null else 0
+
+
+## Keyboard driver for the embedded overworld view, mirroring
+## Gen2StartMenuScreen.handle_key's key lists. Returns whether the key was used.
+func handle_key(keycode: int) -> bool:
+	if _party_size() == 0:
+		if keycode in [KEY_ESCAPE, KEY_X, KEY_B]:
+			close_embedded()
+			return true
+		return false
+	match keycode:
+		KEY_UP, KEY_W:
+			_move_cursor(-1)
+			return true
+		KEY_DOWN, KEY_S:
+			_move_cursor(1)
+			return true
+		KEY_SPACE, KEY_ENTER, KEY_Z:
+			_confirm()
+			return true
+		KEY_ESCAPE, KEY_X, KEY_B:
+			_cancel()
+			return true
+	return false
+
+
+func _move_cursor(delta: int) -> void:
+	if _submenu_open:
+		if _submenu_items.is_empty():
+			return
+		_submenu_cursor = wrapi(_submenu_cursor + delta, 0, _submenu_items.size())
+	else:
+		_member_cursor = wrapi(_member_cursor + delta, 0, _party_size())
+	_refresh()
+
+
+func _confirm() -> void:
+	if not _submenu_open:
+		_open_submenu()
+		return
+	if _submenu_cursor < 0 or _submenu_cursor >= _submenu_items.size():
+		return
+	var entry: Dictionary = _submenu_items[_submenu_cursor]
+	if StringName(entry.get("option", &"")) == OPTION_CANCEL:
+		_close_submenu()
+		return
+	if not bool(entry.get("available", false)):
+		_status.text = "%s is not available yet." % String(entry.get("label", ""))
+		_status.add_theme_color_override("font_color", MUTED)
+		return
+	if StringName(entry.get("kind", &"")) != &"field_move":
+		return
+	action_chosen.emit({
+		"kind": &"field_move",
+		"move": int(entry.get("move", 0)),
+		"slot": _member_cursor,
+		"name": _display_name(_save.party[_member_cursor]),
+	})
+
+
+func _cancel() -> void:
+	if _submenu_open:
+		_close_submenu()
+		return
+	close_embedded()
+
+
+func _open_submenu() -> void:
+	if _member_cursor < 0 or _member_cursor >= _party_size():
+		return
+	_submenu_items = submenu_items_for(_data, _save.party[_member_cursor])
+	_submenu_cursor = 0
+	_submenu_open = not _submenu_items.is_empty()
+	_refresh()
+
+
+func _close_submenu() -> void:
+	_submenu_open = false
+	_submenu_items = []
+	_submenu_cursor = 0
+	_refresh()
+
+
+## Test and host seam: the submenu as the screen currently shows it.
+func submenu_snapshot() -> Dictionary:
+	return {
+		"open": _submenu_open,
+		"cursor": _submenu_cursor,
+		"member": _member_cursor,
+		"items": _submenu_items.duplicate(true),
+	}
+
+
+func _render_submenu() -> void:
+	if _submenu == null:
+		return
+	for child: Node in _submenu.get_children():
+		child.queue_free()
+	_submenu.visible = _submenu_open
+	if not _submenu_open:
+		return
+	for index: int in _submenu_items.size():
+		var entry: Dictionary = _submenu_items[index]
+		var label := Label.new()
+		var text: String = String(entry.get("label", ""))
+		if not bool(entry.get("available", false)) \
+			and StringName(entry.get("option", &"")) != OPTION_CANCEL:
+			text = "%s (unavailable)" % text
+		label.text = ("> " if index == _submenu_cursor else "  ") + text
+		label.add_theme_color_override("font_color", ACCENT if index == _submenu_cursor else TEXT)
+		label.add_theme_font_size_override("font_size", 18)
+		_submenu.add_child(label)
 
 
 func _resolve_data() -> GameData:
@@ -136,6 +323,11 @@ func _build_ui() -> void:
 	_cards.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.add_child(_cards)
 
+	_submenu = VBoxContainer.new()
+	_submenu.add_theme_constant_override("separation", 4)
+	_submenu.visible = false
+	content.add_child(_submenu)
+
 	var footer := HBoxContainer.new()
 	footer.add_theme_constant_override("separation", 10)
 	content.add_child(footer)
@@ -163,13 +355,17 @@ func _refresh() -> void:
 		return
 	for index: int in Gen2SaveData.MAX_PARTY:
 		_cards.add_child(_member_card(index))
+	_render_submenu()
 	_status.text = "Slot %d" % (_save.slot + 1)
 	_status.add_theme_color_override("font_color", SUCCESS)
 
 
 func _member_card(index: int) -> PanelContainer:
 	var card := PanelContainer.new()
-	card.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 8))
+	var selected: bool = index == _member_cursor and index < _party_size()
+	card.add_theme_stylebox_override(
+		"panel", _panel_style(PANEL, ACCENT if selected else BORDER, 8)
+	)
 	var content := HBoxContainer.new()
 	content.add_theme_constant_override("separation", 18)
 	card.add_child(content)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -76,6 +76,10 @@ var _object_facing_overrides: Dictionary = {}
 var _object_followers: Dictionary = {}
 var _variable_sprites: Dictionary = {}
 var _block_overrides: Dictionary = {}
+## A resolved but uncommitted Cut, held between cut_request() and complete_cut()
+## the way Script_Cut holds wCutWhirlpool* across its writetext. Cleared with the
+## block overrides, since the block it names belongs to the loaded map.
+var _pending_cut: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
@@ -390,6 +394,79 @@ func advance_fishing() -> Dictionary:
 
 func cancel_fishing() -> Dictionary:
 	return _fishing.cancel()
+
+
+## engine/events/overworld.asm's CutFunction, staged rather than applied.
+##
+## The source order is load bearing: .CheckAble tests ENGINE_HIVEBADGE before it
+## ever looks at the tile, so a player without the badge is told about the badge
+## even while facing a cuttable tree. A match records the block, replacement and
+## animation the way CheckMapForSomethingToCut fills wCutWhirlpool*; nothing is
+## written until complete_cut(), because Script_Cut shows its text first and only
+## then calls CutDownTreeOrGrass.
+func cut_request() -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return _cut_failure(&"missing_map")
+	if not _pending_cut.is_empty():
+		return _cut_failure(&"cut_in_progress")
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	if not state.is_engine_flag_active(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, crystal)
+	):
+		return _cut_failure(&"badge_required")
+	var target: Vector2i = facing_cell()
+	if not Gen2WorldFieldMove.cuttable(collision_code_at(target)):
+		return _cut_failure(&"nothing_to_cut")
+	var block_cell: Vector2i = _script_block_cell(target)
+	var replacement: Dictionary = Gen2WorldFieldMove.cut_replacement(
+		current_map.tileset, block_at(block_cell.x, block_cell.y), crystal
+	)
+	if not bool(replacement.get("ok", false)):
+		return _cut_failure(&"nothing_to_cut")
+	_pending_cut = {
+		"ok": true,
+		"kind": &"cut_requested",
+		"move": Gen2WorldFieldMove.MOVE_CUT,
+		"cell": target,
+		"block_cell": block_cell,
+		"block": int(replacement["block"]),
+		"animation": int(replacement["animation"]),
+	}
+	return _pending_cut.duplicate(true)
+
+
+## Empty until cut_request() succeeds. A host shows its text while this is set.
+func pending_cut() -> Dictionary:
+	return _pending_cut.duplicate(true)
+
+
+## CutDownTreeOrGrass: writes the replacement into the loaded map's block grid.
+## change_block() already re-resolves collision through the tileset and drops the
+## override on a map change or reload, which is the cartridge's own behavior,
+## since the routine writes wOverworldMapBlocks and a map load re-reads the
+## block data from ROM. The tree regrows on the next visit.
+func complete_cut() -> Dictionary:
+	if _pending_cut.is_empty():
+		return _cut_failure(&"no_pending_cut")
+	var request: Dictionary = _pending_cut
+	_pending_cut = {}
+	var block_cell: Vector2i = request["block_cell"]
+	var changed: Dictionary = change_block(block_cell.x, block_cell.y, int(request["block"]))
+	if not bool(changed.get("ok", false)):
+		return changed
+	return {
+		"ok": true,
+		"kind": &"cut_applied",
+		"move": int(request["move"]),
+		"cell": request["cell"],
+		"block_cell": block_cell,
+		"block": int(request["block"]),
+		"animation": int(request["animation"]),
+	}
+
+
+static func _cut_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"cut_failed", "reason": reason}
 
 
 ## Rolls an encounter from the current map. Auto mode preserves the existing
@@ -2500,6 +2577,7 @@ func _apply_map(
 	target_map: Gen2WorldMap, target_tileset: Gen2WorldTileset, target_cell: Vector2i
 ) -> void:
 	_block_overrides.clear()
+	_pending_cut.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
 	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
@@ -2539,6 +2617,7 @@ func reload_current_map() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return {"ok": false, "reason": &"missing_map"}
 	_block_overrides.clear()
+	_pending_cut.clear()
 	state.reset_map_reload_flags()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -1,0 +1,121 @@
+class_name Gen2WorldFieldMove
+extends RefCounted
+
+## Scene-free tables and gates for the overworld field moves
+## (engine/events/overworld.asm).
+##
+## Only Cut is resolved here so far. The shape each remaining move reuses is the
+## one CutFunction defines: check the badge, then check the faced tile, then look
+## the standing block up in a per-tileset replacement table.
+
+## constants/move_constants.asm. The submenu, not CutFunction, is what checks a
+## party Pokemon knows this.
+const MOVE_CUT: int = 15
+
+## CheckBadge's argument in CutFunction's .CheckAble, as a source badge-order
+## index rather than a flag number, so Gen2WorldState.badge_flag() resolves it
+## on either profile: ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold/Silver.
+const BADGE_HIVE: int = 1
+
+## data/mon_menu.asm's MonMenuOptions field-move rows, in table order. Both pins
+## ship the same rows, so this needs no profile split. Cut is the only one this
+## project acts on; the rest are listed because IsFieldMove decides submenu
+## membership from this table alone, and a move missing from it would silently
+## stop appearing when the next one lands.
+const FIELD_MOVES: Array[int] = [MOVE_CUT]
+
+## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of
+## the six block ($12, $1a); the four grass codes are LAND_TILE and cuttable
+## anyway, which is why membership here is separate from the permission.
+const CUTTABLE_COLLISIONS: Array[int] = [
+	0x12,  # COLL_CUT_TREE
+	0x1A,  # COLL_CUT_TREE_1A
+	0x10,  # COLL_TALL_GRASS_10
+	0x18,  # COLL_TALL_GRASS
+	0x14,  # COLL_LONG_GRASS
+	0x1C,  # COLL_LONG_GRASS_1C
+]
+
+## OWCutAnimation's index in e: which of the two cut animations the replacement
+## plays. Recorded because CheckOverworldTileArrays returns it beside the
+## replacement block; this renderer draws neither.
+const ANIMATION_TREE: int = 0
+const ANIMATION_GRASS: int = 1
+
+## constants/tileset_constants.asm. Numbers 1 to 3 agree between the pins, but
+## pokegold has no BATTLE_TOWER_OUTSIDE, POKECOM_CENTER or BATTLE_TOWER_INSIDE,
+## so everything above $03 is shifted. PARK and FOREST are the two tilesets in
+## the cut table that this reaches.
+const TILESET_JOHTO: int = 0x01
+const TILESET_JOHTO_MODERN: int = 0x02
+const TILESET_KANTO: int = 0x03
+const TILESET_PARK_CRYSTAL: int = 0x19
+const TILESET_PARK_GOLD_SILVER: int = 0x16
+const TILESET_FOREST_CRYSTAL: int = 0x1F
+const TILESET_FOREST_GOLD_SILVER: int = 0x1C
+
+## data/collision/field_move_blocks.asm's CutTreeBlockPointers, byte identical
+## between the pins: facing block to [replacement block, animation]. Only the
+## tileset numbers keying it are profile split, so the lists are shared and
+## _cut_tables() picks the keys.
+const CUT_BLOCKS_JOHTO: Dictionary = {
+	0x03: [0x02, ANIMATION_GRASS],
+	0x5B: [0x3C, ANIMATION_TREE],
+	0x5F: [0x3D, ANIMATION_TREE],
+	0x63: [0x3F, ANIMATION_TREE],
+	0x67: [0x3E, ANIMATION_TREE],
+}
+const CUT_BLOCKS_JOHTO_MODERN: Dictionary = {
+	0x03: [0x02, ANIMATION_GRASS],
+}
+const CUT_BLOCKS_KANTO: Dictionary = {
+	0x0B: [0x0A, ANIMATION_GRASS],
+	0x32: [0x6D, ANIMATION_TREE],
+	0x33: [0x6C, ANIMATION_TREE],
+	0x34: [0x6F, ANIMATION_TREE],
+	0x35: [0x4C, ANIMATION_TREE],
+	0x60: [0x6E, ANIMATION_TREE],
+}
+const CUT_BLOCKS_PARK: Dictionary = {
+	0x13: [0x03, ANIMATION_GRASS],
+	0x03: [0x04, ANIMATION_GRASS],
+}
+const CUT_BLOCKS_FOREST: Dictionary = {
+	0x0F: [0x17, ANIMATION_TREE],
+}
+
+
+static func is_field_move(move: int) -> bool:
+	return FIELD_MOVES.has(move)
+
+
+## CheckCutCollision: whether the faced cell's collision code is one Cut acts on
+## at all. A match still needs a block in the tileset's list.
+static func cuttable(collision_code: int) -> bool:
+	return CUTTABLE_COLLISIONS.has(collision_code)
+
+
+## The tileset-to-block-list mapping for one profile. Kept as a function rather
+## than two constants so the shared lists above stay single-sourced.
+static func _cut_tables(is_crystal: bool) -> Dictionary:
+	return {
+		TILESET_JOHTO: CUT_BLOCKS_JOHTO,
+		TILESET_JOHTO_MODERN: CUT_BLOCKS_JOHTO_MODERN,
+		TILESET_KANTO: CUT_BLOCKS_KANTO,
+		TILESET_PARK_CRYSTAL if is_crystal else TILESET_PARK_GOLD_SILVER: CUT_BLOCKS_PARK,
+		TILESET_FOREST_CRYSTAL if is_crystal else TILESET_FOREST_GOLD_SILVER: CUT_BLOCKS_FOREST,
+	}
+
+
+## CheckOverworldTileArrays against CutTreeBlockPointers: the replacement for
+## [param block] in [param tileset], or a not-ok result when the tileset carries
+## no list or the block is not in it. Both misses are the source's same
+## "nothing to cut" answer.
+static func cut_replacement(tileset: int, block: int, is_crystal: bool) -> Dictionary:
+	var blocks: Variant = _cut_tables(is_crystal).get(tileset)
+	if blocks == null:
+		return {"ok": false}
+	var row: Variant = (blocks as Dictionary).get(block)
+	if row == null:
+		return {"ok": false}
+	return {"ok": true, "block": int(row[0]), "animation": int(row[1])}

--- a/game/world/world_field_move.gd.uid
+++ b/game/world/world_field_move.gd.uid
@@ -1,0 +1,1 @@
+uid://cbpkfx3lje43d

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -21,6 +21,10 @@ const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
 ## expects a runtime request to acknowledge; a hop is movement, not a script.
 ## _play_current_map_music() below is the precedent for this shape.
 const SFX_JUMP_OVER_LEDGE: int = 0x16
+## constants/sfx_constants.asm's SFX_PLACE_PUZZLE_PIECE_DOWN, played by
+## OWCutAnimation before its sprite animation. The animation itself is not
+## rendered here; the sound is.
+const SFX_CUT: int = 0x1E
 
 @export var map_group: int = 24
 @export var map_number: int = 3
@@ -51,6 +55,9 @@ var _service_host: Gen2WorldServiceScreen = null
 var _pc_host: Gen2BoxScreen = null
 var _start_menu_host: Gen2StartMenuScreen = null
 var _party_host: Gen2PartyScreen = null
+## Whether a field-move message is on screen waiting for its acknowledge. The
+## world is idle while it is, the same way a script text pause holds it.
+var _field_move_text: bool = false
 ## Mirrors the source's wBattleMenuCursorPosition surviving a reopen.
 var _start_menu_cursor: int = 0
 var _trainer_approach: Dictionary = {}
@@ -269,6 +276,7 @@ func _objects_may_move() -> bool:
 	return _world != null \
 		and _battle_host == null and _service_host == null and _pc_host == null \
 		and _start_menu_host == null and _party_host == null \
+		and not _field_move_text \
 		and _trainer_approach.is_empty() \
 		and not _world.script_busy() \
 		and not _world.phone_ring_active() \
@@ -293,8 +301,12 @@ func _unhandled_key_input(event: InputEvent) -> void:
 		accept_event()
 		return
 	if _party_host != null:
-		if key.keycode == KEY_ESCAPE:
-			_party_host.close_embedded()
+		_party_host.handle_key(key.keycode)
+		accept_event()
+		return
+	if _field_move_text:
+		if key.keycode in [KEY_SPACE, KEY_ENTER, KEY_Z]:
+			_acknowledge_field_move_text()
 		accept_event()
 		return
 	if _start_menu_host != null:
@@ -414,6 +426,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _renderer_input_free() -> bool:
 	return _world != null and _battle_host == null and _service_host == null \
 		and _pc_host == null and _start_menu_host == null and _party_host == null \
+		and not _field_move_text \
 		and _trainer_approach.is_empty() and not _world.phone_ring_active() \
 		and not _world.fishing_busy() and not _world.script_input_waiting()
 
@@ -422,7 +435,7 @@ func _renderer_input_free() -> bool:
 func move_player(direction: Vector2i) -> bool:
 	if _world == null or _world.fishing_busy() or _service_host != null \
 		or _pc_host != null or _start_menu_host != null or _party_host != null \
-		or _world.phone_ring_active() \
+		or _field_move_text or _world.phone_ring_active() \
 		or not _trainer_approach.is_empty() or _world.player_step_in_progress():
 		return false
 	var movement: Dictionary = _world.move_result(direction)
@@ -473,7 +486,7 @@ func move_player(direction: Vector2i) -> bool:
 func interact() -> bool:
 	if _world == null or _battle_host != null or _service_host != null \
 		or _pc_host != null or _start_menu_host != null or _party_host != null \
-		or _world.phone_ring_active() or _world.fishing_busy():
+		or _field_move_text or _world.phone_ring_active() or _world.fishing_busy():
 		return false
 	var results: Array = _world.interact()
 	if results.is_empty():
@@ -604,6 +617,39 @@ func preview_script_event() -> void:
 				return
 	_script_prompt = "No active script at this map's event records"
 	_refresh_labels()
+
+
+## Public screenshot driver for the party submenu's field-move entry. Grants the
+## Hive Badge and teaches the first party member Cut, then injects that save so
+## persistence stays off, the way preview_party_transaction() does.
+func preview_field_move() -> void:
+	if _world == null or _data == null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Field move preview needs a party"
+		_refresh_labels()
+		return
+	(save.party[0] as Gen2SaveMon).moves[0] = Gen2WorldFieldMove.MOVE_CUT
+	_injected_save = save
+	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_HIVE, Gen2WorldState.is_crystal_profile(_data)
+	))
+	_open_embedded_party()
+	if _party_host == null:
+		return
+	_party_host.handle_key(KEY_SPACE)
+
+
+## The rest of that sequence, one step per call: the first chooses the submenu's
+## Cut entry and shows its message, the second acknowledges it and commits.
+func preview_field_move_use() -> void:
+	if _field_move_text:
+		_acknowledge_field_move_text()
+		return
+	preview_field_move()
+	if _party_host != null:
+		_party_host.handle_key(KEY_SPACE)
 
 
 ## Public screenshot driver for the scene-free party item transaction. It uses a
@@ -1059,6 +1105,7 @@ func _on_pc_closed(result: Dictionary) -> void:
 func _open_start_menu() -> void:
 	if _start_menu_host != null or _party_host != null or _service_host != null \
 		or _pc_host != null or _battle_host != null or _world == null or _data == null \
+		or _field_move_text \
 		or not _trainer_approach.is_empty() or _world.script_busy() \
 		or _world.phone_ring_active() or _world.fishing_busy():
 		return
@@ -1108,6 +1155,14 @@ func _on_start_menu_closed() -> void:
 	_refresh_labels()
 
 
+## The save the embedded party view shows: the injected or selected one, or a
+## development party when neither exists.
+func _embedded_party_save() -> Gen2SaveData:
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	return save if save != null else Gen2SaveStore.create_development_save(_data, 0)
+
+
 func _open_embedded_party() -> void:
 	if _party_host != null or _world == null or _data == null:
 		return
@@ -1116,9 +1171,7 @@ func _open_embedded_party() -> void:
 		_script_prompt = "Party scene unavailable"
 		_refresh_labels()
 		return
-	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
-	if save == null:
-		save = Gen2SaveStore.create_development_save(_data, 0)
+	var save: Gen2SaveData = _embedded_party_save()
 	if save == null:
 		host.queue_free()
 		_script_prompt = "Party requires a validated save"
@@ -1130,6 +1183,7 @@ func _open_embedded_party() -> void:
 	host.mouse_filter = Control.MOUSE_FILTER_STOP
 	add_child(host)
 	host.closed.connect(_on_party_closed)
+	host.action_chosen.connect(_on_party_action)
 	_party_host = host
 	_script_prompt = "Party open"
 	_refresh_labels()
@@ -1141,6 +1195,73 @@ func _on_party_closed(_result: Dictionary) -> void:
 	if host != null:
 		host.queue_free()
 	_script_prompt = "Party closed"
+	_refresh_labels()
+
+
+## MonMenu_Cut's shape: the party menu closes first, then CutFunction runs and
+## either queues Script_Cut or pushes its own refusal text. Both refusals and
+## the success message go through the hardware text box, and the block change
+## waits for the acknowledge, matching Script_Cut showing UseCutText before it
+## calls CutDownTreeOrGrass.
+func _on_party_action(action: Dictionary) -> void:
+	var host: Gen2PartyScreen = _party_host
+	_party_host = null
+	if host != null:
+		host.queue_free()
+	if _world == null or StringName(action.get("kind", &"")) != &"field_move":
+		_refresh_labels()
+		return
+	if int(action.get("move", 0)) != Gen2WorldFieldMove.MOVE_CUT:
+		_show_field_move_text("Can't use that here.")
+		return
+	var request: Dictionary = _world.cut_request()
+	if not bool(request.get("ok", false)):
+		_show_field_move_text(_cut_refusal(StringName(request.get("reason", &""))))
+		return
+	_show_field_move_text("%s used CUT!" % String(action.get("name", "")))
+
+
+## engine/events/overworld.asm's two refusal texts, verbatim from
+## data/text/common_2.asm. A reason without a source text falls back to
+## _CantUseItemText, which is the source's own generic field-move refusal.
+func _cut_refusal(reason: StringName) -> String:
+	match reason:
+		&"badge_required":
+			return "Sorry! A new BADGE is required."
+		&"nothing_to_cut":
+			return "There's nothing to CUT here."
+	return "Can't use that here."
+
+
+func _show_field_move_text(text: String) -> void:
+	_field_move_text = true
+	if _text_box != null and _text_box.font != null:
+		_text_box.show_text(text)
+		_text_box.visible = true
+	_script_prompt = "Space/Enter: continue"
+	_refresh_labels()
+
+
+## The acknowledge that closes a field-move message. A staged Cut commits here
+## rather than when it was resolved, because Script_Cut only reaches
+## CutDownTreeOrGrass after UseCutText. A refusal has nothing staged and just
+## closes.
+func _acknowledge_field_move_text() -> void:
+	_field_move_text = false
+	if _text_box != null:
+		_text_box.visible = false
+	if _world == null or _world.pending_cut().is_empty():
+		_script_prompt = ""
+		_refresh_labels()
+		return
+	var applied: Dictionary = _world.complete_cut()
+	if bool(applied.get("ok", false)):
+		_play_sfx(SFX_CUT)
+		if _renderer != null:
+			_renderer.refresh()
+		_script_prompt = "Cut"
+	else:
+		_script_prompt = "Cut failed: %s" % String(applied.get("reason", "unknown"))
 	_refresh_labels()
 
 
@@ -1419,9 +1540,13 @@ func _play_current_map_music() -> void:
 
 
 func _play_ledge_hop_sfx() -> void:
+	_play_sfx(SFX_JUMP_OVER_LEDGE)
+
+
+func _play_sfx(index: int) -> void:
 	if _audio_player == null or _data == null:
 		return
-	var record: Dictionary = _data.world_audio(&"sfx", SFX_JUMP_OVER_LEDGE)
+	var record: Dictionary = _data.world_audio(&"sfx", index)
 	if record.is_empty():
 		return
 	_audio_player.play_record(record, &"sound", _audio_assets())

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -272,6 +272,15 @@ func bargain_merchant_closed(crystal: bool = true) -> bool:
 	return is_engine_flag_active(_merchant_closed_flag(crystal))
 
 
+## The engine flag one badge occupies on the table [param crystal] selects,
+## indexed in source badge order: 0 is ZEPHYRBADGE and 15 EARTHBADGE. Out of
+## range answers -1, which is_engine_flag_active() reads as inactive. This is
+## what a CheckBadge caller uses, so no caller indexes the two arrays itself.
+static func badge_flag(badge: int, crystal: bool = true) -> int:
+	var flags: Array[int] = BADGE_ENGINE_FLAGS if crystal else BADGE_ENGINE_FLAGS_GOLD_SILVER
+	return flags[badge] if badge >= 0 and badge < flags.size() else -1
+
+
 ## Mirrors _GetVarAction's .CountBadges: a popcount over both badge bytes.
 func badge_count(crystal: bool = true) -> int:
 	var count: int = 0

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1,0 +1,237 @@
+extends GutTest
+
+## Scene integration for Cut: the party submenu, the field-move message and the
+## block change, driven through the production world screen and party screen.
+##
+## The shared trainer fixture is patched here rather than extended, the same way
+## test_world_start_menu_screen.gd patches its Potion in: the map moves onto
+## TILESET_JOHTO so the real CutTreeBlockPointers rows apply, and block $5b's
+## bottom-left quadrant becomes the cut tree.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
+
+const TILESET: int = Gen2WorldFieldMove.TILESET_JOHTO
+const BLOCK_COUNT: int = 0x68
+const BLOCK_TREE: int = 0x5B
+const BLOCK_TREE_CUT: int = 0x3C
+const TREE_BLOCK: Vector2i = Vector2i(1, 1)
+const TREE_CELL: Vector2i = Vector2i(2, 3)
+const PLAYER_CELL: Vector2i = Vector2i(2, 2)
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	_data = Fixture.build()
+	_write_cut_tree()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+func _write_cut_tree() -> void:
+	var directory: String = Fixture.directory()
+	var moves: Array = RomCache.read_json(RomCache.moves_path(directory))
+	for raw: Dictionary in moves:
+		if int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_CUT:
+			raw["name"] = "CUT"
+	RomCache.write_json(RomCache.moves_path(directory), moves)
+
+	var tilesets: Array = RomCache.read_json(RomCache.world_tilesets_path(directory))
+	var tileset: Dictionary = tilesets[0]
+	tileset["number"] = TILESET
+	tileset["block_count"] = BLOCK_COUNT
+	var meta: Array = []
+	for block: int in BLOCK_COUNT:
+		for tile: int in 16:
+			meta.append((block + tile) & 0xFF)
+	tileset["meta"] = meta
+	var tile_collision: Array = []
+	tile_collision.resize(BLOCK_COUNT * 4)
+	tile_collision.fill(0)
+	# Quadrant order is top-left, top-right, bottom-left, bottom-right.
+	tile_collision[BLOCK_TREE * 4 + 2] = 0x12  # COLL_CUT_TREE
+	tileset["collision"] = tile_collision
+	RomCache.write_json(RomCache.world_tilesets_path(directory), tilesets)
+
+	var maps: Array = RomCache.read_json(RomCache.world_maps_path(directory))
+	for raw: Dictionary in maps:
+		raw["tileset"] = TILESET
+		if int(raw.get("group", 0)) != Fixture.MAP_GROUP \
+			or int(raw.get("number", 0)) != Fixture.MAP_NUMBER:
+			continue
+		var blocks: Array = raw["blocks"]
+		blocks[TREE_BLOCK.y * Fixture.MAP_WIDTH_BLOCKS + TREE_BLOCK.x] = BLOCK_TREE
+		var collision: Array = raw["collision"]
+		collision[TREE_CELL.y * Fixture.MAP_WIDTH_CELLS + TREE_CELL.x] = 0x12
+	RomCache.write_json(RomCache.world_maps_path(directory), maps)
+
+	var tiles: PackedByteArray = PackedByteArray()
+	tiles.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
+	tiles.fill(1)
+	RomCache.write_indices(RomCache.world_tile_path(directory, TILESET), tiles)
+
+
+## A save whose first party member knows Cut and whose second does not, so one
+## submenu offers the move and the other does not.
+func _save_with_cut() -> Gen2SaveData:
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	(save.party[0] as Gen2SaveMon).moves = [Gen2WorldFieldMove.MOVE_CUT, 0, 0, 0]
+	(save.party[0] as Gen2SaveMon).nickname = "TESTMON"
+	if save.party.size() > 1:
+		(save.party[1] as Gen2SaveMon).moves = [BattleFixture.TACKLE, 0, 0, 0]
+	return save
+
+
+func _open_world(badge: bool = true) -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = PLAYER_CELL
+	var state := Gen2WorldState.new()
+	if badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_HIVE, Gen2WorldState.is_crystal_profile(_data)
+		))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, state
+	)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var save: Gen2SaveData = _save_with_cut()
+	save.world = world.snapshot()
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen._world.player_cell = PLAYER_CELL
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+
+func _open_party() -> Gen2PartyScreen:
+	_world_screen._open_embedded_party()
+	await get_tree().process_frame
+	return _world_screen._party_host
+
+
+## The text box holds its message as wrapped lines, so the assertions below
+## rejoin them rather than depending on where the wrap lands.
+func _shown_text() -> String:
+	var lines: PackedStringArray = PackedStringArray()
+	for page: PackedStringArray in _world_screen._text_box.get("_pages"):
+		lines.append_array(page)
+	return " ".join(lines)
+
+
+func _labels(items: Array) -> Array:
+	var out: Array = []
+	for entry: Dictionary in items:
+		out.append(String(entry.get("label", "")))
+	return out
+
+
+func test_submenu_lists_cut_only_for_a_mon_that_knows_it() -> void:
+	await _open_world()
+	var party: Gen2PartyScreen = await _open_party()
+	assert_not_null(party)
+	party.handle_key(KEY_SPACE)
+	var first: Dictionary = party.submenu_snapshot()
+	assert_true(bool(first["open"]))
+	# GetMonSubmenuItems walks the move slots first, so a field move leads.
+	assert_eq(_labels(first["items"]), ["CUT", "STATS", "SWITCH", "MOVE", "ITEM", "CANCEL"])
+
+	party.handle_key(KEY_ESCAPE)
+	party.handle_key(KEY_DOWN)
+	party.handle_key(KEY_SPACE)
+	assert_eq(
+		_labels(party.submenu_snapshot()["items"]),
+		["STATS", "SWITCH", "MOVE", "ITEM", "CANCEL"]
+	)
+
+
+func test_an_egg_submenu_carries_only_the_three_source_entries() -> void:
+	await _open_world()
+	var egg := Gen2SaveMon.new()
+	egg.is_egg = true
+	egg.moves = [Gen2WorldFieldMove.MOVE_CUT, 0, 0, 0]
+	assert_eq(
+		_labels(Gen2PartyScreen.submenu_items_for(_data, egg)),
+		["STATS", "SWITCH", "CANCEL"]
+	)
+
+
+func test_choosing_cut_shows_the_message_and_defers_the_block_change() -> void:
+	await _open_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	assert_false(world.can_walk_to(TREE_CELL))
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_null(_world_screen._party_host)
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_shown_text(), "TESTMON used CUT!")
+	# Script_Cut writes the block only after UseCutText.
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+	assert_false(world.can_walk_to(TREE_CELL))
+	# The world is idle while the message is up.
+	assert_false(_world_screen.move_player(Vector2i.RIGHT))
+	assert_false(_world_screen.interact())
+	assert_false(_world_screen._objects_may_move())
+
+	_world_screen._acknowledge_field_move_text()
+	assert_false(_world_screen._field_move_text)
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE_CUT)
+	assert_true(world.can_walk_to(TREE_CELL))
+	assert_true(_world_screen.move_player(Vector2i.DOWN))
+	assert_eq(world.player_cell, TREE_CELL)
+
+
+func test_cut_without_the_badge_reports_the_badge_and_changes_nothing() -> void:
+	await _open_world(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_shown_text(), "Sorry! A new BADGE is required.")
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+	assert_false(world.can_walk_to(TREE_CELL))
+
+
+func test_cut_facing_nothing_reports_the_source_refusal() -> void:
+	await _open_world()
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "There's nothing to CUT here.")
+	_world_screen._acknowledge_field_move_text()
+	assert_true(_world_screen._world.pending_cut().is_empty())
+	assert_eq(_world_screen._world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+
+
+func test_cancel_closes_the_submenu_before_the_party_screen() -> void:
+	await _open_world()
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	assert_true(bool(party.submenu_snapshot()["open"]))
+	party.handle_key(KEY_ESCAPE)
+	assert_false(bool(party.submenu_snapshot()["open"]))
+	assert_not_null(_world_screen._party_host)
+	party.handle_key(KEY_ESCAPE)
+	await get_tree().process_frame
+	assert_null(_world_screen._party_host)

--- a/tests/integration/test_world_field_move_screen.gd.uid
+++ b/tests/integration/test_world_field_move_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://biquysbpdbtwy

--- a/tests/unit/test_world_collision.gd
+++ b/tests/unit/test_world_collision.gd
@@ -229,3 +229,20 @@ func test_side_wall_step_blocked_matches_the_leave_and_enter_rules() -> void:
 	# A zero or diagonal direction never blocks.
 	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, 0xB1, Vector2i.ZERO))
 	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, 0xB1, Vector2i(1, 1)))
+
+
+## engine/overworld/tile_events.asm's CheckCutCollision list against the
+## permission table those codes ride on: two of the six block, four are ordinary
+## ground, and only two of the six are used by any pinned tileset.
+func test_cuttable_codes_keep_the_permissions_cut_depends_on() -> void:
+	for code: int in [0x12, 0x1A]:
+		assert_eq(
+			Gen2WorldCollision.permission_for(code), Gen2WorldCollision.WALL_TILE,
+			"cut tree $%02x" % code
+		)
+		assert_true(Gen2WorldCollision.talks(code), "cut tree $%02x" % code)
+	for code: int in [0x10, 0x14, 0x18, 0x1C]:
+		assert_eq(
+			Gen2WorldCollision.permission_for(code), Gen2WorldCollision.LAND_TILE,
+			"grass $%02x" % code
+		)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1,0 +1,316 @@
+extends GutTest
+
+## Field-move tables and the Cut boundary, against a synthetic cache built for
+## this file so the shared world fixture stays untouched.
+##
+## The cache uses tileset number 1 (TILESET_JOHTO) so the real CutTreeBlockPointers
+## rows apply: block $5b is a tree replaced by $3c, block $03 is grass replaced
+## by $02. Tileset 5 is TILESET_PLAYERS_HOUSE, which the source table has no
+## entry for.
+
+const TILESET_CUTTABLE: int = Gen2WorldFieldMove.TILESET_JOHTO
+const TILESET_NO_ENTRY: int = 5
+const BLOCK_TREE: int = 0x5B
+const BLOCK_TREE_CUT: int = 0x3C
+const BLOCK_GRASS: int = 0x03
+const BLOCK_GRASS_CUT: int = 0x02
+const BLOCK_FLOOR: int = 0x01
+const BLOCK_COUNT: int = 0x68
+
+## The cut tree stands at block (1,1)'s bottom-left quadrant and the grass at
+## block (2,1)'s, mirroring Ilex Forest's own block $0f layout.
+const TREE_CELL: Vector2i = Vector2i(2, 3)
+const TREE_BLOCK: Vector2i = Vector2i(1, 1)
+const GRASS_CELL: Vector2i = Vector2i(4, 3)
+const GRASS_BLOCK: Vector2i = Vector2i(2, 1)
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"testfieldmove", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _write_cache() -> void:
+	RomCache.write_json(RomCache.species_path(_directory), [])
+	RomCache.write_json(RomCache.moves_path(_directory), [])
+	RomCache.write_json(RomCache.items_path(_directory), [])
+	RomCache.write_json(RomCache.types_path(_directory), [])
+	RomCache.write_json(RomCache.matchups_path(_directory), [])
+	RomCache.write_json(RomCache.trainers_path(_directory), [])
+
+	RomCache.write_json(RomCache.world_tilesets_path(_directory), [
+		_tileset(TILESET_CUTTABLE), _tileset(TILESET_NO_ENTRY),
+	])
+	RomCache.write_json(RomCache.world_maps_path(_directory), [
+		_map(1, TILESET_CUTTABLE), _map(2, TILESET_NO_ENTRY),
+	])
+
+	var pixels := PackedByteArray()
+	pixels.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
+	for index: int in pixels.size():
+		pixels[index] = index % 4
+	for number: int in [TILESET_CUTTABLE, TILESET_NO_ENTRY]:
+		RomCache.write_indices(RomCache.world_tile_path(_directory, number), pixels)
+
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "testfieldmove",
+		"sha1": "0123456789abcdef",
+		"complete": true,
+	})
+
+
+func _tileset(number: int) -> Dictionary:
+	var meta: Array = []
+	for block: int in BLOCK_COUNT:
+		for tile: int in 16:
+			meta.append((block + tile) & 0xFF)
+	var collision: Array = []
+	collision.resize(BLOCK_COUNT * 4)
+	for index: int in collision.size():
+		collision[index] = 0
+	# Quadrant order is top-left, top-right, bottom-left, bottom-right, so the
+	# bottom-left cell is index 2. Only the uncut blocks carry a cuttable code.
+	collision[BLOCK_TREE * 4 + 2] = 0x12   # COLL_CUT_TREE
+	collision[BLOCK_GRASS * 4 + 2] = 0x18  # COLL_TALL_GRASS
+	return {
+		"number": number,
+		"block_count": BLOCK_COUNT,
+		"tile_count": RomLayout.TILESET_TILE_COUNT,
+		"meta": meta,
+		"collision": collision,
+	}
+
+
+func _map(number: int, tileset: int) -> Dictionary:
+	var blocks: Array = []
+	for index: int in 16:
+		blocks.append(BLOCK_FLOOR)
+	blocks[TREE_BLOCK.y * 4 + TREE_BLOCK.x] = BLOCK_TREE
+	blocks[GRASS_BLOCK.y * 4 + GRASS_BLOCK.x] = BLOCK_GRASS
+	var collision: Array = []
+	collision.resize(64)
+	for index: int in collision.size():
+		collision[index] = 0
+	collision[TREE_CELL.y * 8 + TREE_CELL.x] = 0x12
+	collision[GRASS_CELL.y * 8 + GRASS_CELL.x] = 0x18
+	return {
+		"group": 1,
+		"number": number,
+		"tileset": tileset,
+		"width_blocks": 4,
+		"height_blocks": 4,
+		"blocks": blocks,
+		"collision": collision,
+		"collision_width": 8,
+		"collision_height": 8,
+		"events": {},
+	}
+
+
+func _gold_profile() -> void:
+	var manifest: Dictionary = RomCache.read_json(RomCache.manifest_path(_directory))
+	manifest["game_id"] = "gold"
+	RomCache.write_json(RomCache.manifest_path(_directory), manifest)
+
+
+## A world standing above the cut tree and facing it, with the Hive Badge set on
+## whichever engine flag table the opened cache selects.
+func _world(map_number: int = 1, badge: bool = true) -> Gen2WorldAPI:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	if badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_HIVE, Gen2WorldState.is_crystal_profile(data)
+		))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, map_number, TREE_CELL + Vector2i.UP, state
+	)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	return world
+
+
+func test_cuttable_carries_the_six_check_cut_collision_codes() -> void:
+	for code: int in [0x12, 0x1A, 0x10, 0x18, 0x14, 0x1C]:
+		assert_true(Gen2WorldFieldMove.cuttable(code), "code $%02x" % code)
+	# Neighbours of the cuttable runs, and the codes the other field moves own.
+	for code: int in [0x00, 0x11, 0x13, 0x15, 0x19, 0x1B, 0x1D, 0x24, 0x33, 0x07]:
+		assert_false(Gen2WorldFieldMove.cuttable(code), "code $%02x" % code)
+
+
+func test_cut_tree_block_table_matches_the_pinned_rows() -> void:
+	var rows: Array = [
+		# tileset, facing block, replacement, animation
+		[Gen2WorldFieldMove.TILESET_JOHTO, 0x03, 0x02, 1],
+		[Gen2WorldFieldMove.TILESET_JOHTO, 0x5B, 0x3C, 0],
+		[Gen2WorldFieldMove.TILESET_JOHTO, 0x5F, 0x3D, 0],
+		[Gen2WorldFieldMove.TILESET_JOHTO, 0x63, 0x3F, 0],
+		[Gen2WorldFieldMove.TILESET_JOHTO, 0x67, 0x3E, 0],
+		[Gen2WorldFieldMove.TILESET_JOHTO_MODERN, 0x03, 0x02, 1],
+		[Gen2WorldFieldMove.TILESET_KANTO, 0x0B, 0x0A, 1],
+		[Gen2WorldFieldMove.TILESET_KANTO, 0x32, 0x6D, 0],
+		[Gen2WorldFieldMove.TILESET_KANTO, 0x33, 0x6C, 0],
+		[Gen2WorldFieldMove.TILESET_KANTO, 0x34, 0x6F, 0],
+		[Gen2WorldFieldMove.TILESET_KANTO, 0x35, 0x4C, 0],
+		[Gen2WorldFieldMove.TILESET_KANTO, 0x60, 0x6E, 0],
+	]
+	for row: Array in rows:
+		for crystal: bool in [true, false]:
+			var result: Dictionary = Gen2WorldFieldMove.cut_replacement(row[0], row[1], crystal)
+			assert_true(bool(result.get("ok", false)), "tileset %d block $%02x" % [row[0], row[1]])
+			assert_eq(int(result["block"]), int(row[2]))
+			assert_eq(int(result["animation"]), int(row[3]))
+
+
+func test_park_and_forest_tileset_numbers_are_profile_split() -> void:
+	var park: Array = [[0x13, 0x03, 1], [0x03, 0x04, 1]]
+	var forest: Array = [[0x0F, 0x17, 0]]
+	var cases: Array = [
+		[Gen2WorldFieldMove.TILESET_PARK_CRYSTAL, true, park],
+		[Gen2WorldFieldMove.TILESET_PARK_GOLD_SILVER, false, park],
+		[Gen2WorldFieldMove.TILESET_FOREST_CRYSTAL, true, forest],
+		[Gen2WorldFieldMove.TILESET_FOREST_GOLD_SILVER, false, forest],
+	]
+	for case: Array in cases:
+		for row: Array in case[2] as Array:
+			var hit: Dictionary = Gen2WorldFieldMove.cut_replacement(case[0], row[0], case[1])
+			assert_true(bool(hit.get("ok", false)), "tileset %d block $%02x" % [case[0], row[0]])
+			assert_eq(int(hit["block"]), int(row[1]))
+			assert_eq(int(hit["animation"]), int(row[2]))
+			# The other profile numbers the same tileset differently, so its
+			# number must not resolve there.
+			var miss: Dictionary = Gen2WorldFieldMove.cut_replacement(
+				case[0], row[0], not bool(case[1])
+			)
+			assert_false(bool(miss.get("ok", false)), "tileset %d on the other profile" % case[0])
+
+
+func test_cut_replacement_refuses_an_absent_tileset_or_block() -> void:
+	assert_false(bool(Gen2WorldFieldMove.cut_replacement(
+		TILESET_NO_ENTRY, BLOCK_TREE, true
+	).get("ok", false)))
+	assert_false(bool(Gen2WorldFieldMove.cut_replacement(
+		Gen2WorldFieldMove.TILESET_JOHTO, 0x00, true
+	).get("ok", false)))
+
+
+func test_cut_request_checks_the_badge_before_the_tile() -> void:
+	# .CheckAble calls CheckBadge first, so a player facing a real tree without
+	# the Hive Badge is told about the badge, not about the tree.
+	var world: Gen2WorldAPI = _world(1, false)
+	var refused: Dictionary = world.cut_request()
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(refused["reason"], &"badge_required")
+	assert_true(world.pending_cut().is_empty())
+
+
+func test_cut_request_reads_the_gold_silver_badge_flag() -> void:
+	_gold_profile()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_false(Gen2WorldState.is_crystal_profile(data))
+	# Crystal's ENGINE_HIVEBADGE (28) must not answer on a Gold cache, whose
+	# shorter engine flag table puts the same badge at 27.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_HIVEBADGE)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, TREE_CELL + Vector2i.UP, state
+	)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_eq(world.cut_request()["reason"], &"badge_required")
+
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, false))
+	assert_true(bool(world.cut_request().get("ok", false)))
+
+
+func test_cut_request_refuses_a_tile_that_is_not_cuttable() -> void:
+	var world: Gen2WorldAPI = _world()
+	world.player_cell = Vector2i(6, 6)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var refused: Dictionary = world.cut_request()
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(refused["reason"], &"nothing_to_cut")
+
+
+func test_cut_request_refuses_a_tileset_without_a_block_list() -> void:
+	# Map 2 carries the identical tree cell on TILESET_PLAYERS_HOUSE, which
+	# CutTreeBlockPointers has no entry for.
+	var world: Gen2WorldAPI = _world(2)
+	assert_true(Gen2WorldFieldMove.cuttable(world.collision_code_at(TREE_CELL)))
+	assert_eq(world.cut_request()["reason"], &"nothing_to_cut")
+
+
+func test_cut_request_stages_without_changing_the_map() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_false(world.can_walk_to(TREE_CELL))
+	var staged: Dictionary = world.cut_request()
+	assert_true(bool(staged.get("ok", false)), JSON.stringify(staged))
+	assert_eq(staged["block_cell"], TREE_BLOCK)
+	assert_eq(int(staged["block"]), BLOCK_TREE_CUT)
+	assert_eq(int(staged["animation"]), Gen2WorldFieldMove.ANIMATION_TREE)
+	# Script_Cut writes the block only after its text, so nothing has moved yet.
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+	assert_false(world.can_walk_to(TREE_CELL))
+	assert_eq(world.pending_cut()["block"], BLOCK_TREE_CUT)
+
+
+func test_complete_cut_replaces_the_block_and_opens_the_cell() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(bool(world.cut_request().get("ok", false)))
+	var applied: Dictionary = world.complete_cut()
+	assert_true(bool(applied.get("ok", false)), JSON.stringify(applied))
+	assert_eq(applied["kind"], &"cut_applied")
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE_CUT)
+	assert_eq(world.collision_code_at(TREE_CELL), 0x00)
+	assert_true(world.can_walk_to(TREE_CELL))
+	assert_true(world.pending_cut().is_empty())
+
+
+func test_cutting_grass_keeps_the_cell_walkable_and_swaps_the_block() -> void:
+	var world: Gen2WorldAPI = _world()
+	world.player_cell = GRASS_CELL + Vector2i.UP
+	# The four grass codes are LAND_TILE, so this cell was always walkable; only
+	# the block changes.
+	assert_true(world.can_walk_to(GRASS_CELL))
+	var staged: Dictionary = world.cut_request()
+	assert_true(bool(staged.get("ok", false)), JSON.stringify(staged))
+	assert_eq(int(staged["animation"]), Gen2WorldFieldMove.ANIMATION_GRASS)
+	assert_true(bool(world.complete_cut().get("ok", false)))
+	assert_eq(world.block_at(GRASS_BLOCK.x, GRASS_BLOCK.y), BLOCK_GRASS_CUT)
+	assert_true(world.can_walk_to(GRASS_CELL))
+
+
+func test_a_second_request_refuses_while_one_is_staged() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(bool(world.cut_request().get("ok", false)))
+	assert_eq(world.cut_request()["reason"], &"cut_in_progress")
+
+
+func test_complete_cut_without_a_request_fails() -> void:
+	var world: Gen2WorldAPI = _world()
+	var applied: Dictionary = world.complete_cut()
+	assert_false(bool(applied.get("ok", false)))
+	assert_eq(applied["reason"], &"no_pending_cut")
+
+
+func test_a_map_reload_regrows_the_tree_and_drops_a_staged_cut() -> void:
+	var world: Gen2WorldAPI = _world()
+	assert_true(bool(world.cut_request().get("ok", false)))
+	assert_true(bool(world.complete_cut().get("ok", false)))
+	assert_true(world.can_walk_to(TREE_CELL))
+	# CutDownTreeOrGrass only writes wOverworldMapBlocks, and a map load re-reads
+	# the block data from ROM, so the tree is back on the next visit.
+	assert_true(bool(world.reload_current_map().get("ok", false)))
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+	assert_false(world.can_walk_to(TREE_CELL))
+
+	assert_true(bool(world.cut_request().get("ok", false)))
+	world.reload_current_map()
+	assert_true(world.pending_cut().is_empty())

--- a/tests/unit/test_world_field_move.gd.uid
+++ b/tests/unit/test_world_field_move.gd.uid
@@ -1,0 +1,1 @@
+uid://n4wwouahlb4l

--- a/tools/validate_cut.gd
+++ b/tools/validate_cut.gd
@@ -1,0 +1,244 @@
+extends SceneTree
+
+## Verifies Cut against freshly imported real caches, for both command profiles.
+##
+## The expected values come from the pinned pokecrystal and pokegold sources:
+## engine/events/overworld.asm's CutFunction and CheckMapForSomethingToCut,
+## engine/overworld/tile_events.asm's CheckCutCollision,
+## data/collision/field_move_blocks.asm's CutTreeBlockPointers, and
+## constants/tileset_constants.asm, whose PARK and FOREST numbers are the only
+## part of that table that differs between the two games.
+##
+## The real-cartridge counterpart to tests/unit/test_world_field_move.gd, which
+## uses a synthetic cache. Ilex Forest is the acceptance case, because its single
+## cut tree is what gates the route west out of the forest.
+##
+##   Godot --headless --path . -s res://tools/validate_cut.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push
+## Ilex Forest eight places later within the same group.
+const ILEX_GROUP: int = 3
+const ILEX_NUMBER_CRYSTAL: int = 52
+const ILEX_NUMBER_GOLD_SILVER: int = 44
+## maps/IlexForest.blk, identical in both pins: one block $0f, whose bottom-left
+## quadrant is the COLL_CUT_TREE cell (data/tilesets/forest_collision.asm).
+const ILEX_BLOCK := Vector2i(4, 12)
+const ILEX_TREE_CELL := Vector2i(8, 25)
+const ILEX_BLOCK_UNCUT: int = 0x0F
+const ILEX_BLOCK_CUT: int = 0x17
+
+## Census of the real caches, pinned so a cache change is loud. Crystal offers
+## 28 more cuttable cells than it can act on: park blocks $33 and $3f are
+## all-LONG_GRASS (data/tilesets/park_collision.asm) but CutTreeBlockPointers'
+## .park list holds only $13 and $03, so the cartridge answers "nothing to cut"
+## on them too. Every Gold/Silver cuttable cell resolves.
+const EXPECTED_CENSUS: Dictionary = {
+	# game id: [cuttable cells, cells resolving to a replacement, maps]
+	&"gold": [3404, 3404, 54],
+	&"silver": [3404, 3404, 54],
+	&"crystal": [3444, 3416, 54],
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_tileset_numbers(game_id, data, crystal)
+		_census(game_id, data, crystal)
+		_verify_ilex_forest(game_id, data, crystal)
+	_finish()
+
+
+## Every tileset CutTreeBlockPointers names must exist in this cache under the
+## number this profile uses, so a wrong split would fail loudly rather than
+## quietly making a tileset uncuttable.
+func _verify_tileset_numbers(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var expected: Array[int] = [
+		Gen2WorldFieldMove.TILESET_JOHTO,
+		Gen2WorldFieldMove.TILESET_JOHTO_MODERN,
+		Gen2WorldFieldMove.TILESET_KANTO,
+		Gen2WorldFieldMove.TILESET_PARK_CRYSTAL if crystal \
+			else Gen2WorldFieldMove.TILESET_PARK_GOLD_SILVER,
+		Gen2WorldFieldMove.TILESET_FOREST_CRYSTAL if crystal \
+			else Gen2WorldFieldMove.TILESET_FOREST_GOLD_SILVER,
+	]
+	for number: int in expected:
+		_check(
+			data.world_tileset(number) != null,
+			"%s: tileset %d from CutTreeBlockPointers is missing." % [game_id, number]
+		)
+
+
+## Counts the cells a real cache actually offers Cut, so a cache change that
+## moves a block or a collision code is loud rather than silently making the
+## forest uncuttable.
+func _census(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var cuttable_cells: int = 0
+	var resolved_cells: int = 0
+	var maps_with_cut: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		var found: bool = false
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				if not Gen2WorldFieldMove.cuttable(map.collision_at(x, y)):
+					continue
+				cuttable_cells += 1
+				var replacement: Dictionary = Gen2WorldFieldMove.cut_replacement(
+					map.tileset, map.block_at(x >> 1, y >> 1), crystal
+				)
+				if bool(replacement.get("ok", false)):
+					resolved_cells += 1
+					found = true
+		if found:
+			maps_with_cut[Vector2i(map.group, map.number)] = true
+	var counts: Array = [cuttable_cells, resolved_cells, maps_with_cut.size()]
+	print("%s: %d cuttable cells, %d resolving to a replacement across %d maps." % [
+		game_id, counts[0], counts[1], counts[2],
+	])
+	_check(
+		counts == EXPECTED_CENSUS.get(game_id, []),
+		"%s: census is %s, not the pinned %s." % [
+			game_id, counts, EXPECTED_CENSUS.get(game_id, []),
+		]
+	)
+
+
+func _verify_ilex_forest(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var number: int = ILEX_NUMBER_CRYSTAL if crystal else ILEX_NUMBER_GOLD_SILVER
+	var badge: int = Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, crystal)
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(badge)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP, state
+	)
+	if not _check(
+		world != null, "%s: Ilex Forest map %d/%d is missing." % [game_id, ILEX_GROUP, number]
+	):
+		return
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+	var tileset: int = world.current_map.tileset
+	var expected_tileset: int = Gen2WorldFieldMove.TILESET_FOREST_CRYSTAL if crystal \
+		else Gen2WorldFieldMove.TILESET_FOREST_GOLD_SILVER
+	_check(
+		tileset == expected_tileset,
+		"%s: Ilex Forest is tileset %d, not the expected FOREST %d." % [
+			game_id, tileset, expected_tileset,
+		]
+	)
+	var block: int = world.block_at(ILEX_BLOCK.x, ILEX_BLOCK.y)
+	_check(
+		block == ILEX_BLOCK_UNCUT,
+		"%s: Ilex Forest block %s is $%02X, not $%02X." % [
+			game_id, ILEX_BLOCK, block, ILEX_BLOCK_UNCUT,
+		]
+	)
+	var code: int = world.collision_code_at(ILEX_TREE_CELL)
+	_check(
+		code == 0x12,
+		"%s: Ilex Forest %s is $%02X, not COLL_CUT_TREE." % [game_id, ILEX_TREE_CELL, code]
+	)
+	_check(
+		not world.can_walk_to(ILEX_TREE_CELL),
+		"%s: Ilex Forest cut tree at %s does not block." % [game_id, ILEX_TREE_CELL]
+	)
+
+	var staged: Dictionary = world.cut_request()
+	if not _check(
+		bool(staged.get("ok", false)),
+		"%s: Ilex Forest refused Cut: %s." % [game_id, staged.get("reason", "unknown")]
+	):
+		return
+	_check(
+		int(staged.get("block", -1)) == ILEX_BLOCK_CUT
+			and staged.get("block_cell", Vector2i.ZERO) == ILEX_BLOCK,
+		"%s: Ilex Forest staged %s, not block $%02X at %s." % [
+			game_id, JSON.stringify(staged), ILEX_BLOCK_CUT, ILEX_BLOCK,
+		]
+	)
+	# Script_Cut writes the block only after UseCutText, so staging alone must
+	# leave the map exactly as it was.
+	_check(
+		world.block_at(ILEX_BLOCK.x, ILEX_BLOCK.y) == ILEX_BLOCK_UNCUT
+			and not world.can_walk_to(ILEX_TREE_CELL),
+		"%s: Ilex Forest changed before the cut was committed." % game_id
+	)
+
+	_check(
+		bool(world.complete_cut().get("ok", false)),
+		"%s: Ilex Forest cut did not commit." % game_id
+	)
+	_check(
+		world.block_at(ILEX_BLOCK.x, ILEX_BLOCK.y) == ILEX_BLOCK_CUT,
+		"%s: Ilex Forest block is $%02X after the cut." % [
+			game_id, world.block_at(ILEX_BLOCK.x, ILEX_BLOCK.y),
+		]
+	)
+	_check(
+		world.can_walk_to(ILEX_TREE_CELL),
+		"%s: Ilex Forest %s is still blocked after the cut." % [game_id, ILEX_TREE_CELL]
+	)
+	print("%s: Ilex Forest %d/%d %s $%02X -> $%02X, cell %s opened." % [
+		game_id, ILEX_GROUP, number, ILEX_BLOCK, ILEX_BLOCK_UNCUT, ILEX_BLOCK_CUT,
+		ILEX_TREE_CELL,
+	])
+
+	# CutDownTreeOrGrass only writes wOverworldMapBlocks, which a map load
+	# re-reads from ROM, so the tree is back on the next visit.
+	world.reload_current_map()
+	_check(
+		world.block_at(ILEX_BLOCK.x, ILEX_BLOCK.y) == ILEX_BLOCK_UNCUT
+			and not world.can_walk_to(ILEX_TREE_CELL),
+		"%s: Ilex Forest tree did not regrow on a map reload." % game_id
+	)
+
+	# .CheckAble tests the badge before the tile, on whichever engine flag table
+	# this profile numbers ENGINE_HIVEBADGE on.
+	var unbadged := Gen2WorldState.new()
+	var unbadged_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP, unbadged
+	)
+	unbadged_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_check(
+		StringName(unbadged_world.cut_request().get("reason", &"")) == &"badge_required",
+		"%s: Ilex Forest allowed Cut without engine flag %d." % [game_id, badge]
+	)
+	# The other profile's flag number must not answer for this one.
+	var wrong := Gen2WorldState.new()
+	wrong.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, not crystal))
+	var wrong_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP, wrong
+	)
+	wrong_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_check(
+		StringName(wrong_world.cut_request().get("reason", &"")) == &"badge_required",
+		"%s: Ilex Forest accepted the other profile's Hive Badge flag." % game_id
+	)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS cut: block tables, tileset numbers and Ilex Forest verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_cut.gd.uid
+++ b/tools/validate_cut.gd.uid
@@ -1,0 +1,1 @@
+uid://bjpxn0di7farc


### PR DESCRIPTION
Field moves had no entry point: the collision codes decoded and blocked, but nothing acted on them. Cut lands first, on the boundary the other five reuse.

Gen2WorldFieldMove carries CheckCutCollision's six codes and CutTreeBlockPointers. The block lists are byte identical between the games; the tileset numbers keying them are not, because pokegold's shorter tileset table puts PARK at $16 and FOREST at $1c against Crystal's $19 and $1f.

cut_request() follows .CheckAble's order, badge before tile, and stages the replacement without writing it. complete_cut() applies it when the message is acknowledged, matching Script_Cut reaching CutDownTreeOrGrass only after UseCutText. The override dies with the loaded map, so the tree regrows on the next visit the way the cartridge's does.

The party view gains the source per-mon submenu: field moves in the mon's own move-slot order, then STATS, SWITCH, MOVE, ITEM and CANCEL, with an egg cut down to three entries. It reports the choice through action_chosen rather than touching the world, the way the start menu reports Pokemon and Pokegear.

tools/validate_cut.gd pins the census against all three real caches and drives Ilex Forest, whose single cut tree gates the route west.