### PR TITLE
Surf from the party submenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ for a fallback pairing.
 
 The world screen's start menu wires Pokemon, Pack, Pokegear, Save and Exit;
 Pokedex, Player and Options appear in their source position but do nothing yet.
+The party submenu offers Cut and Surf to a Pokemon that knows one; both show
+their message first and change the world on the acknowledge, and stepping from
+water back onto land stops surfing.
 The imported Players House PC opens the embedded box storage screen. The host
 clock advances one game minute per real minute and crosses source day
 boundaries. `preview_emote()`, `preview_wild_encounter()`,
@@ -173,6 +176,8 @@ Headless tools, all against a real imported cache:
 | `validate_crystal_route30_trainer.gd` | trainer record, sight line, approach, battle request, beaten flag, later interaction |
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |
 | `validate_side_walls.gd` | the side-wall/side-buoy codes, their face masks and map census, in both games; Celadon Mansion Roof's fence and staircase landings on Crystal |
+| `validate_cut.gd` | the cut block tables, the profile-split tileset numbers and cuttable-cell census, and Ilex Forest's tree, in all three games |
+| `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -62,6 +62,10 @@ var world_hour: int = 6
 var world_minute: int = 0
 var dst_enabled: bool = false
 var movement_mode: StringName = MOVEMENT_WALK
+## wPlayerState resolved through ChrisStateSprites, which is the only part of
+## that state a renderer reads. movement_mode carries the rest; the two surfing
+## states differ from each other here and nowhere else.
+var player_sprite_number: int = Gen2WorldSprite.SPRITE_PLAYER
 var _script_queue: Array = []
 var _active_script: Gen2WorldScriptRunner = null
 var _map_entry_scene_pending: bool = false
@@ -80,6 +84,10 @@ var _block_overrides: Dictionary = {}
 ## the way Script_Cut holds wCutWhirlpool* across its writetext. Cleared with the
 ## block overrides, since the block it names belongs to the loaded map.
 var _pending_cut: Dictionary = {}
+## The same for Surf, held between surf_request() and complete_surf() while
+## UsedSurfScript shows its text. The cell it names belongs to the loaded map,
+## so it is cleared beside the Cut request.
+var _pending_surf: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
@@ -166,6 +174,7 @@ static func open_snapshot(game_data: GameData, world_snapshot: Gen2WorldSnapshot
 	)
 	out.player_facing = world_snapshot.player_facing
 	out.movement_mode = world_snapshot.movement_mode
+	out.player_sprite_number = world_snapshot.player_sprite_number
 	out.world_day = world_snapshot.world_day
 	out.world_hour = world_snapshot.world_hour
 	out.world_minute = world_snapshot.world_minute
@@ -309,8 +318,9 @@ func advance_player_step(delta: float) -> bool:
 	return changed
 
 
+## GetPlayerSprite: the sprite for the player's current state, not a fixed one.
 func player_sprite() -> Gen2WorldSprite:
-	return data.overworld_sprite(1) if data != null else null
+	return data.overworld_sprite(player_sprite_number) if data != null else null
 
 
 func set_movement_mode(mode: StringName) -> Dictionary:
@@ -467,6 +477,86 @@ func complete_cut() -> Dictionary:
 
 static func _cut_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"cut_failed", "reason": reason}
+
+
+## engine/events/overworld.asm's SurfFunction .TrySurf, staged rather than
+## applied, for the same reason Cut is: UsedSurfScript changes nothing until its
+## text is acknowledged.
+##
+## The refusal order is the source's. The badge is tested before the player's own
+## state and before the tile, so a player without the Fog Badge is told about the
+## badge whether or not the water in front of them is surfable. CheckBadge itself
+## is what pushes that text, which is why this reports the same badge_required
+## Cut does. [param species] is the chosen party member's, for GetSurfType.
+##
+## The source's wBikeFlags branch has no counterpart here, since no bike exists.
+func surf_request(species: int = 0) -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return _surf_failure(&"missing_map")
+	if not _pending_surf.is_empty():
+		return _surf_failure(&"surf_in_progress")
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	if not state.is_engine_flag_active(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, crystal)
+	):
+		return _surf_failure(&"badge_required")
+	if movement_mode == MOVEMENT_SURF:
+		return _surf_failure(&"already_surfing")
+	var target: Vector2i = facing_cell()
+	if collision_permission_at(target) != Gen2WorldCollision.WATER_TILE:
+		return _surf_failure(&"cannot_surf")
+	var direction: Vector2i = _direction_for_facing(player_facing)
+	# CheckDirection: the standing cell's own permissions must not wall off the
+	# way the player faces.
+	var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+	if face != 0 and (tile_permissions_at(player_cell) & face) != 0:
+		return _surf_failure(&"cannot_surf")
+	# CheckFacingObject is Crystal only. pokegold's .TrySurf omits it and carries
+	# the "You can Surf on top of NPCs" bug comment.
+	if crystal and object_at(target) != null:
+		return _surf_failure(&"cannot_surf")
+	_pending_surf = {
+		"ok": true,
+		"kind": &"surf_requested",
+		"move": Gen2WorldFieldMove.MOVE_SURF,
+		"cell": target,
+		"direction": direction,
+		"sprite": Gen2WorldFieldMove.surf_sprite(species),
+	}
+	return _pending_surf.duplicate(true)
+
+
+## Empty until surf_request() succeeds. A host shows its text while this is set.
+func pending_surf() -> Dictionary:
+	return _pending_surf.duplicate(true)
+
+
+## The rest of UsedSurfScript after its waitbutton: writevar VAR_MOVEMENT,
+## UpdatePlayerSprite, then SurfStartStep's single slow_step into the water.
+##
+## That step is an applymovement, not player input, so it neither consumes a
+## repel step nor rolls an encounter, and it is not re-validated: .TrySurf
+## already checked the cell, and the movement engine does not check again.
+func complete_surf() -> Dictionary:
+	if _pending_surf.is_empty():
+		return _surf_failure(&"no_pending_surf")
+	var request: Dictionary = _pending_surf
+	_pending_surf = {}
+	movement_mode = MOVEMENT_SURF
+	player_sprite_number = int(request["sprite"])
+	player_cell = request["cell"]
+	_start_player_step(request["direction"], STEP_FRAMES_NPC_WALK)
+	return {
+		"ok": true,
+		"kind": &"surf_applied",
+		"move": int(request["move"]),
+		"cell": player_cell,
+		"sprite": player_sprite_number,
+	}
+
+
+static func _surf_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"surf_failed", "reason": reason}
 
 
 ## Rolls an encounter from the current map. Auto mode preserves the existing
@@ -2444,6 +2534,18 @@ func move_result(direction: Vector2i) -> Dictionary:
 	var previous_cells: Dictionary = {}
 	for index: int in objects.size():
 		previous_cells[index] = (objects[index] as Gen2WorldObject).cell
+	## .TrySurf's .ExitWater: .GetOutOfWater restores PLAYER_NORMAL and the walking
+	## sprite before .DoStep runs, so the state is already back to walking while
+	## the step onto land is still being taken.
+	var exiting_water: bool = movement_mode == MOVEMENT_SURF \
+		and collision_permission_at(destination) == Gen2WorldCollision.LAND_TILE
+	var kind: StringName = &"move"
+	if exiting_water:
+		movement_mode = MOVEMENT_WALK
+		player_sprite_number = Gen2WorldSprite.SPRITE_PLAYER
+		kind = &"exit_water"
+	elif movement_mode == MOVEMENT_SURF:
+		kind = &"water_move"
 	player_cell = destination
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
@@ -2451,7 +2553,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 	_start_player_step(direction, STEP_FRAMES_WALK)
 	return {
 		"ok": true,
-		"kind": &"water_move" if movement_mode == MOVEMENT_SURF else &"move",
+		"kind": kind,
 		"from_map": from_map,
 		"from_cell": from_cell,
 		"to_map": from_map,
@@ -2573,11 +2675,30 @@ func _at_connection_edge(direction_name: String) -> bool:
 	return false
 
 
+## engine/overworld/map_setup.asm's CheckUpdatePlayerSprite, which every warp and
+## connection reaches through warp_connection.asm. The cartridge re-derives the
+## player state from the cell it lands on rather than carrying it over:
+## .CheckSurfing starts surfing on water and keeps an existing surf state,
+## .ResetSurfingOrBikingState restores PLAYER_NORMAL anywhere else. Without it a
+## warp taken from a water tile lands on dry land still surfing, where nothing
+## but water is a legal step. .CheckForcedBiking has no counterpart here.
+func _apply_map_setup_player_state() -> void:
+	if collision_permission_at(player_cell) == Gen2WorldCollision.WATER_TILE:
+		if movement_mode != MOVEMENT_SURF:
+			movement_mode = MOVEMENT_SURF
+			player_sprite_number = Gen2WorldSprite.SPRITE_SURF
+		return
+	if movement_mode == MOVEMENT_SURF:
+		movement_mode = MOVEMENT_WALK
+		player_sprite_number = Gen2WorldSprite.SPRITE_PLAYER
+
+
 func _apply_map(
 	target_map: Gen2WorldMap, target_tileset: Gen2WorldTileset, target_cell: Vector2i
 ) -> void:
 	_block_overrides.clear()
 	_pending_cut.clear()
+	_pending_surf.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
 	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
@@ -2592,6 +2713,7 @@ func _apply_map(
 	current_map = target_map
 	current_tileset = target_tileset
 	player_cell = _clamp_cell(target_cell)
+	_apply_map_setup_player_state()
 	_clear_player_step()
 	# _load_objects() rebuilds every record, so in-flight object steps end with
 	# the objects that owned them; only the shared frame accumulator survives.
@@ -2618,6 +2740,7 @@ func reload_current_map() -> Dictionary:
 		return {"ok": false, "reason": &"missing_map"}
 	_block_overrides.clear()
 	_pending_cut.clear()
+	_pending_surf.clear()
 	state.reset_map_reload_flags()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -4,25 +4,37 @@ extends RefCounted
 ## Scene-free tables and gates for the overworld field moves
 ## (engine/events/overworld.asm).
 ##
-## Only Cut is resolved here so far. The shape each remaining move reuses is the
-## one CutFunction defines: check the badge, then check the faced tile, then look
-## the standing block up in a per-tileset replacement table.
+## Cut and Surf are resolved here. Both follow the shape CutFunction defines:
+## check the badge, then check the faced tile, then stage a change the text
+## acknowledge commits. Strength, Whirlpool, Waterfall, Flash and Headbutt are
+## not resolved yet.
 
-## constants/move_constants.asm. The submenu, not CutFunction, is what checks a
-## party Pokemon knows this.
-const MOVE_CUT: int = 15
+## constants/move_constants.asm, whose comment column is hex. The submenu, not
+## CutFunction or SurfFunction, is what checks a party Pokemon knows these.
+const MOVE_CUT: int = 0x0F
+const MOVE_SURF: int = 0x39
 
-## CheckBadge's argument in CutFunction's .CheckAble, as a source badge-order
-## index rather than a flag number, so Gen2WorldState.badge_flag() resolves it
-## on either profile: ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold/Silver.
+## CheckBadge's arguments in CutFunction's .CheckAble and SurfFunction's
+## .TrySurf, as source badge-order indices rather than flag numbers, so
+## Gen2WorldState.badge_flag() resolves them on either profile: ENGINE_HIVEBADGE
+## is 28 in Crystal and 27 in Gold/Silver, ENGINE_FOGBADGE 30 and 29.
 const BADGE_HIVE: int = 1
+const BADGE_FOG: int = 3
 
-## data/mon_menu.asm's MonMenuOptions field-move rows, in table order. Both pins
-## ship the same rows, so this needs no profile split. Cut is the only one this
-## project acts on; the rest are listed because IsFieldMove decides submenu
-## membership from this table alone, and a move missing from it would silently
-## stop appearing when the next one lands.
-const FIELD_MOVES: Array[int] = [MOVE_CUT]
+## GetSurfType's comparison, constants/pokemon_constants.asm.
+const SPECIES_PIKACHU: int = 0x19
+
+## constants/music_constants.asm. home/audio.asm's SpecialMapMusic returns this
+## ahead of the map header's own music whenever the player state is surfing, so
+## it belongs to Surf rather than to any one map. Surf has no sound effect:
+## UsedSurfScript never calls PlaySFX.
+const MUSIC_SURF: int = 0x21
+
+## The data/mon_menu.asm MonMenuOptions field-move rows this project acts on.
+## Both pins ship the same rows, so this needs no profile split. IsFieldMove
+## decides submenu membership from this list alone, so a move stops appearing
+## the moment it leaves it.
+const FIELD_MOVES: Array[int] = [MOVE_CUT, MOVE_SURF]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of
 ## the six block ($12, $1a); the four grass codes are LAND_TILE and cuttable
@@ -87,6 +99,15 @@ const CUT_BLOCKS_FOREST: Dictionary = {
 
 static func is_field_move(move: int) -> bool:
 	return FIELD_MOVES.has(move)
+
+
+## GetSurfType resolved through ChrisStateSprites: the surfing player's sprite
+## for the party member carrying the move. The source keeps the Pikachu variant
+## as a separate wPlayerState value; only the sprite differs, so this collapses
+## the two lookups into the one number a renderer needs.
+static func surf_sprite(species: int) -> int:
+	return Gen2WorldSprite.SPRITE_SURFING_PIKACHU if species == SPECIES_PIKACHU \
+		else Gen2WorldSprite.SPRITE_SURF
 
 
 ## CheckCutCollision: whether the faced cell's collision code is one Cut acts on

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -443,9 +443,15 @@ func move_player(direction: Vector2i) -> bool:
 		return false
 	if movement.get("kind", &"") == &"ledge_hop":
 		_play_ledge_hop_sfx()
+	## .ExitWater calls PlayMapMusic before the step, which is what drops the
+	## surfing track once the player is walking again.
+	if movement.get("kind", &"") == &"exit_water":
+		_play_current_map_music()
 
 	var transition: Dictionary = movement
-	if movement.get("kind", &"") in [&"move", &"ledge_hop"]:
+	## CheckTileEvent gates warps on nothing, so surfing onto a warp tile and the
+	## step back onto land both reach one.
+	if movement.get("kind", &"") in [&"move", &"ledge_hop", &"water_move", &"exit_water"]:
 		transition = _world.try_warp()
 	if _renderer != null:
 		if bool(transition.get("ok", false)) and transition.get("kind", &"") != &"move":
@@ -620,29 +626,15 @@ func preview_script_event() -> void:
 
 
 ## Public screenshot driver for the party submenu's field-move entry. Grants the
-## Hive Badge and teaches the first party member Cut, then injects that save so
-## persistence stays off, the way preview_party_transaction() does.
+## move's badge and teaches it to the first party member, then injects that save
+## so persistence stays off, the way preview_party_transaction() does.
 func preview_field_move() -> void:
-	if _world == null or _data == null:
-		return
-	var save: Gen2SaveData = _embedded_party_save()
-	if save == null or save.party.is_empty():
-		_script_prompt = "Field move preview needs a party"
-		_refresh_labels()
-		return
-	(save.party[0] as Gen2SaveMon).moves[0] = Gen2WorldFieldMove.MOVE_CUT
-	_injected_save = save
-	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
-		Gen2WorldFieldMove.BADGE_HIVE, Gen2WorldState.is_crystal_profile(_data)
-	))
-	_open_embedded_party()
-	if _party_host == null:
-		return
-	_party_host.handle_key(KEY_SPACE)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE)
 
 
 ## The rest of that sequence, one step per call: the first chooses the submenu's
-## Cut entry and shows its message, the second acknowledges it and commits.
+## field-move entry and shows its message, the second acknowledges it and
+## commits.
 func preview_field_move_use() -> void:
 	if _field_move_text:
 		_acknowledge_field_move_text()
@@ -650,6 +642,41 @@ func preview_field_move_use() -> void:
 	preview_field_move()
 	if _party_host != null:
 		_party_host.handle_key(KEY_SPACE)
+
+
+## The same pair for Surf. The scene must be opened on a map where the player
+## starts beside water and facing it; the Cut preview has the matching
+## requirement of a cuttable tile.
+func preview_surf() -> void:
+	_preview_field_move(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
+
+
+func preview_surf_use() -> void:
+	if _field_move_text:
+		_acknowledge_field_move_text()
+		return
+	preview_surf()
+	if _party_host != null:
+		_party_host.handle_key(KEY_SPACE)
+
+
+func _preview_field_move(move: int, badge: int) -> void:
+	if _world == null or _data == null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Field move preview needs a party"
+		_refresh_labels()
+		return
+	(save.party[0] as Gen2SaveMon).moves[0] = move
+	_injected_save = save
+	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
+		badge, Gen2WorldState.is_crystal_profile(_data)
+	))
+	_open_embedded_party()
+	if _party_host == null:
+		return
+	_party_host.handle_key(KEY_SPACE)
 
 
 ## Public screenshot driver for the scene-free party item transaction. It uses a
@@ -1198,11 +1225,12 @@ func _on_party_closed(_result: Dictionary) -> void:
 	_refresh_labels()
 
 
-## MonMenu_Cut's shape: the party menu closes first, then CutFunction runs and
-## either queues Script_Cut or pushes its own refusal text. Both refusals and
-## the success message go through the hardware text box, and the block change
-## waits for the acknowledge, matching Script_Cut showing UseCutText before it
-## calls CutDownTreeOrGrass.
+## MonMenu_Cut and MonMenu_Surf share a shape: the party menu closes first, then
+## the field-move function runs and either queues its script or pushes its own
+## refusal text. Both refusals and the success message go through the hardware
+## text box, and nothing changes until the acknowledge, matching Script_Cut
+## reaching CutDownTreeOrGrass and UsedSurfScript reaching SurfStartStep only
+## after their text.
 func _on_party_action(action: Dictionary) -> void:
 	var host: Gen2PartyScreen = _party_host
 	_party_host = null
@@ -1211,17 +1239,35 @@ func _on_party_action(action: Dictionary) -> void:
 	if _world == null or StringName(action.get("kind", &"")) != &"field_move":
 		_refresh_labels()
 		return
-	if int(action.get("move", 0)) != Gen2WorldFieldMove.MOVE_CUT:
-		_show_field_move_text("Can't use that here.")
-		return
-	var request: Dictionary = _world.cut_request()
-	if not bool(request.get("ok", false)):
-		_show_field_move_text(_cut_refusal(StringName(request.get("reason", &""))))
-		return
-	_show_field_move_text("%s used CUT!" % String(action.get("name", "")))
+	match int(action.get("move", 0)):
+		Gen2WorldFieldMove.MOVE_CUT:
+			var cut: Dictionary = _world.cut_request()
+			if not bool(cut.get("ok", false)):
+				_show_field_move_text(_cut_refusal(StringName(cut.get("reason", &""))))
+				return
+			_show_field_move_text("%s used CUT!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_SURF:
+			var surf: Dictionary = _world.surf_request(_party_species(int(action.get("slot", -1))))
+			if not bool(surf.get("ok", false)):
+				_show_field_move_text(_surf_refusal(StringName(surf.get("reason", &""))))
+				return
+			_show_field_move_text("%s used SURF!" % String(action.get("name", "")))
+		_:
+			_show_field_move_text("Can't use that here.")
 
 
-## engine/events/overworld.asm's two refusal texts, verbatim from
+## GetSurfType reads wPartySpecies at wCurPartyMon; the submenu action carries
+## that slot. Zero when no save or slot answers, which is no species and so the
+## ordinary surf sprite.
+func _party_species(slot: int) -> int:
+	var save: Gen2SaveData = _active_party_save()
+	if save == null or slot < 0 or slot >= save.party.size():
+		return 0
+	var member: Variant = save.party[slot]
+	return int((member as Gen2SaveMon).species) if member is Gen2SaveMon else 0
+
+
+## engine/events/overworld.asm's refusal texts, verbatim from
 ## data/text/common_2.asm. A reason without a source text falls back to
 ## _CantUseItemText, which is the source's own generic field-move refusal.
 func _cut_refusal(reason: StringName) -> String:
@@ -1230,6 +1276,17 @@ func _cut_refusal(reason: StringName) -> String:
 			return "Sorry! A new BADGE is required."
 		&"nothing_to_cut":
 			return "There's nothing to CUT here."
+	return "Can't use that here."
+
+
+func _surf_refusal(reason: StringName) -> String:
+	match reason:
+		&"badge_required":
+			return "Sorry! A new BADGE is required."
+		&"already_surfing":
+			return "You're already SURFING."
+		&"cannot_surf":
+			return "You can't SURF here."
 	return "Can't use that here."
 
 
@@ -1242,26 +1299,43 @@ func _show_field_move_text(text: String) -> void:
 	_refresh_labels()
 
 
-## The acknowledge that closes a field-move message. A staged Cut commits here
+## The acknowledge that closes a field-move message. A staged move commits here
 ## rather than when it was resolved, because Script_Cut only reaches
-## CutDownTreeOrGrass after UseCutText. A refusal has nothing staged and just
+## CutDownTreeOrGrass after UseCutText and UsedSurfScript only reaches
+## SurfStartStep after its waitbutton. A refusal has nothing staged and just
 ## closes.
 func _acknowledge_field_move_text() -> void:
 	_field_move_text = false
 	if _text_box != null:
 		_text_box.visible = false
-	if _world == null or _world.pending_cut().is_empty():
+	if _world == null:
 		_script_prompt = ""
 		_refresh_labels()
 		return
-	var applied: Dictionary = _world.complete_cut()
+	if not _world.pending_cut().is_empty():
+		_commit_field_move(_world.complete_cut(), "Cut")
+		return
+	if not _world.pending_surf().is_empty():
+		_commit_field_move(_world.complete_surf(), "Surf")
+		return
+	_script_prompt = ""
+	_refresh_labels()
+
+
+## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN and Surf changes the music, so each
+## commit reports its own audio; both redraw, because both changed what the map
+## or the player looks like.
+func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
-		_play_sfx(SFX_CUT)
+		if StringName(applied.get("kind", &"")) == &"surf_applied":
+			_play_current_map_music()
+		else:
+			_play_sfx(SFX_CUT)
 		if _renderer != null:
 			_renderer.refresh()
-		_script_prompt = "Cut"
+		_script_prompt = label
 	else:
-		_script_prompt = "Cut failed: %s" % String(applied.get("reason", "unknown"))
+		_script_prompt = "%s failed: %s" % [label, String(applied.get("reason", "unknown"))]
 	_refresh_labels()
 
 
@@ -1530,10 +1604,15 @@ func _audio_assets() -> Dictionary:
 	}
 
 
+## PlayMapMusic: SpecialMapMusic answers first, so a surfing player carries
+## MUSIC_SURF across map loads, warps and the step back onto land.
 func _play_current_map_music() -> void:
 	if _audio_player == null or _data == null or _world == null or _world.current_map == null:
 		return
-	var record: Dictionary = _data.world_audio(&"music", _world.current_map.music)
+	var track: int = Gen2WorldFieldMove.MUSIC_SURF \
+		if _world.movement_mode == Gen2WorldAPI.MOVEMENT_SURF \
+		else _world.current_map.music
+	var record: Dictionary = _data.world_audio(&"music", track)
 	if record.is_empty():
 		return
 	_audio_player.play_record(record, &"map_music", _audio_assets())

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -11,6 +11,7 @@ var map_id: Vector2i = Vector2i(-1, -1)
 var player_cell: Vector2i = Vector2i.ZERO
 var player_facing: int = Gen2WorldSprite.FACING_DOWN
 var movement_mode: StringName = &"walk"
+var player_sprite_number: int = Gen2WorldSprite.SPRITE_PLAYER
 var world_day: int = 0
 var world_hour: int = 6
 var world_minute: int = 0
@@ -26,6 +27,7 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.player_cell = world.player_cell
 	out.player_facing = world.player_facing
 	out.movement_mode = world.movement_mode
+	out.player_sprite_number = world.player_sprite_number
 	var clock: Dictionary = world.world_clock()
 	out.world_day = int(clock.get("day", 0))
 	out.world_hour = int(clock.get("hour", 6))
@@ -42,6 +44,7 @@ func to_dict() -> Dictionary:
 		"player_cell": [player_cell.x, player_cell.y],
 		"player_facing": player_facing,
 		"movement_mode": String(movement_mode),
+		"player_sprite_number": player_sprite_number,
 		"clock": [world_day, world_hour, world_minute],
 		"dst_enabled": dst_enabled,
 		"world_state": world_state.to_dict() if world_state != null else {},
@@ -58,6 +61,13 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 	out.player_cell = _vector_from_value(source.get("player_cell", [0, 0]))
 	out.player_facing = int(source.get("player_facing", Gen2WorldSprite.FACING_DOWN))
 	out.movement_mode = StringName(source.get("movement_mode", "walk"))
+	# Snapshots written before the sprite joined the format carry the movement
+	# mode alone, which resolves every state but the Pikachu surf variant.
+	out.player_sprite_number = int(source.get(
+		"player_sprite_number",
+		Gen2WorldSprite.SPRITE_SURF if out.movement_mode == &"surf" \
+			else Gen2WorldSprite.SPRITE_PLAYER,
+	))
 	var raw_clock: Variant = source.get("clock", [0, 6, 0])
 	if raw_clock is Array and (raw_clock as Array).size() >= 3:
 		var clock: Array = raw_clock as Array

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -15,6 +15,14 @@ const FACING_UP: int = 1
 const FACING_LEFT: int = 2
 const FACING_RIGHT: int = 3
 
+## data/sprites/player_sprites.asm's ChrisStateSprites, the wPlayerState to
+## sprite lookup GetPlayerSprite walks. Identical in both pins, and the numbers
+## themselves (constants/sprite_constants.asm) agree too. KrisStateSprites is not
+## reproduced because this project has no gender model.
+const SPRITE_PLAYER: int = 0x01
+const SPRITE_SURFING_PIKACHU: int = 0x34
+const SPRITE_SURF: int = 0x53
+
 var number: int = 0
 var address: int = 0
 var bank: int = 0

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1,12 +1,14 @@
 extends GutTest
 
-## Scene integration for Cut: the party submenu, the field-move message and the
-## block change, driven through the production world screen and party screen.
+## Scene integration for Cut and Surf: the party submenu, the field-move message
+## and the change each commits, driven through the production world screen and
+## party screen.
 ##
 ## The shared trainer fixture is patched here rather than extended, the same way
 ## test_world_start_menu_screen.gd patches its Potion in: the map moves onto
 ## TILESET_JOHTO so the real CutTreeBlockPointers rows apply, and block $5b's
-## bottom-left quadrant becomes the cut tree.
+## bottom-left quadrant becomes the cut tree. The fixture's own water cell at
+## (8,7) is what Surf is driven against.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
@@ -18,6 +20,9 @@ const BLOCK_TREE_CUT: int = 0x3C
 const TREE_BLOCK: Vector2i = Vector2i(1, 1)
 const TREE_CELL: Vector2i = Vector2i(2, 3)
 const PLAYER_CELL: Vector2i = Vector2i(2, 2)
+## The fixture's own water cell and the land directly above it.
+const WATER_CELL: Vector2i = Vector2i(8, 7)
+const SHORE_CELL: Vector2i = Vector2i(8, 6)
 
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
@@ -42,6 +47,8 @@ func _write_cut_tree() -> void:
 	for raw: Dictionary in moves:
 		if int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_CUT:
 			raw["name"] = "CUT"
+		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_SURF:
+			raw["name"] = "SURF"
 	RomCache.write_json(RomCache.moves_path(directory), moves)
 
 	var tilesets: Array = RomCache.read_json(RomCache.world_tilesets_path(directory))
@@ -79,40 +86,49 @@ func _write_cut_tree() -> void:
 	RomCache.write_indices(RomCache.world_tile_path(directory, TILESET), tiles)
 
 
-## A save whose first party member knows Cut and whose second does not, so one
-## submenu offers the move and the other does not.
-func _save_with_cut() -> Gen2SaveData:
+## A save whose first party member knows the field move and whose second does
+## not, so one submenu offers it and the other does not.
+func _save_with_move(move: int) -> Gen2SaveData:
 	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
-	(save.party[0] as Gen2SaveMon).moves = [Gen2WorldFieldMove.MOVE_CUT, 0, 0, 0]
+	(save.party[0] as Gen2SaveMon).moves = [move, 0, 0, 0]
 	(save.party[0] as Gen2SaveMon).nickname = "TESTMON"
 	if save.party.size() > 1:
 		(save.party[1] as Gen2SaveMon).moves = [BattleFixture.TACKLE, 0, 0, 0]
 	return save
 
 
-func _open_world(badge: bool = true) -> void:
+func _open_world(
+	badge: bool = true,
+	move: int = Gen2WorldFieldMove.MOVE_CUT,
+	badge_index: int = Gen2WorldFieldMove.BADGE_HIVE,
+	cell: Vector2i = PLAYER_CELL,
+) -> void:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
 	_world_screen.map_number = Fixture.MAP_NUMBER
-	_world_screen.start_cell = PLAYER_CELL
+	_world_screen.start_cell = cell
 	var state := Gen2WorldState.new()
 	if badge:
 		state.set_engine_flag(Gen2WorldState.badge_flag(
-			Gen2WorldFieldMove.BADGE_HIVE, Gen2WorldState.is_crystal_profile(_data)
+			badge_index, Gen2WorldState.is_crystal_profile(_data)
 		))
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(
-		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, state
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, cell, state
 	)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
-	var save: Gen2SaveData = _save_with_cut()
+	var save: Gen2SaveData = _save_with_move(move)
 	save.world = world.snapshot()
 	_world_screen.set_data(_data)
 	_world_screen.set_save(save)
 	add_child(_world_screen)
 	await get_tree().process_frame
-	_world_screen._world.player_cell = PLAYER_CELL
+	_world_screen._world.player_cell = cell
 	_world_screen._world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+
+func _open_surf_world(badge: bool = true, cell: Vector2i = SHORE_CELL) -> void:
+	await _open_world(badge, Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG, cell)
 
 
 func _open_party() -> Gen2PartyScreen:
@@ -222,6 +238,103 @@ func test_cut_facing_nothing_reports_the_source_refusal() -> void:
 	_world_screen._acknowledge_field_move_text()
 	assert_true(_world_screen._world.pending_cut().is_empty())
 	assert_eq(_world_screen._world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+
+
+func test_submenu_lists_surf_for_a_mon_that_knows_it() -> void:
+	await _open_surf_world()
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	assert_eq(
+		_labels(party.submenu_snapshot()["items"]),
+		["SURF", "STATS", "SWITCH", "MOVE", "ITEM", "CANCEL"]
+	)
+
+
+func test_choosing_surf_shows_the_message_and_defers_entering_the_water() -> void:
+	await _open_surf_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_null(_world_screen._party_host)
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_shown_text(), "TESTMON used SURF!")
+	# UsedSurfScript reaches writevar VAR_MOVEMENT only after its waitbutton.
+	assert_eq(world.player_cell, SHORE_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+	assert_false(_world_screen.move_player(Vector2i.RIGHT))
+
+	_world_screen._acknowledge_field_move_text()
+	assert_false(_world_screen._field_move_text)
+	assert_eq(world.player_cell, WATER_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_SURF)
+	assert_true(world.pending_surf().is_empty())
+
+
+func test_stepping_back_onto_land_stops_surfing_through_the_screen() -> void:
+	await _open_surf_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+
+	# The entry step is a slow_step, so the presentation offset has to run out
+	# before the screen accepts input again.
+	while world.player_step_in_progress():
+		world.advance_player_step(1.0)
+	assert_true(_world_screen.move_player(Vector2i.UP))
+	assert_eq(world.player_cell, SHORE_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+
+
+func test_surf_without_the_badge_reports_the_badge_and_changes_nothing() -> void:
+	await _open_surf_world(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "Sorry! A new BADGE is required.")
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.player_cell, SHORE_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+
+
+func test_surf_facing_land_reports_the_source_refusal() -> void:
+	await _open_surf_world()
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "You can't SURF here.")
+	_world_screen._acknowledge_field_move_text()
+	assert_true(_world_screen._world.pending_surf().is_empty())
+	assert_eq(_world_screen._world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+
+
+func test_surf_while_already_surfing_reports_the_source_refusal() -> void:
+	await _open_surf_world(true, WATER_CELL)
+	var world: Gen2WorldAPI = _world_screen._world
+	assert_true(world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)["ok"])
+	world.player_cell = WATER_CELL
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "You're already SURFING.")
 
 
 func test_cancel_closes_the_submenu_before_the_party_screen() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2932,6 +2932,92 @@ func test_surf_movement_accepts_water_and_exposes_an_encounter_request() -> void
 	assert_true(world.move(Vector2i.UP))
 
 
+func test_stepping_onto_land_while_surfing_gets_out_of_the_water() -> void:
+	# .TrySurf's .ExitWater: .GetOutOfWater restores PLAYER_NORMAL and the
+	# walking sprite before .DoStep, so the mode is already back by the time the
+	# result is reported.
+	var world := _world(Vector2i(8, 7))
+	assert_true(world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)["ok"])
+	world.player_sprite_number = Gen2WorldSprite.SPRITE_SURF
+	assert_eq(world.collision_permission_at(Vector2i(8, 7)), Gen2WorldCollision.WATER_TILE)
+
+	var exited: Dictionary = world.move_result(Vector2i.UP)
+	assert_true(exited["ok"], JSON.stringify(exited))
+	assert_eq(exited["kind"], &"exit_water")
+	assert_eq(world.player_cell, Vector2i(8, 6))
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+	# Walking again, so the water cell is no longer a legal step.
+	assert_false(world.move(Vector2i.DOWN))
+
+
+func test_a_step_between_water_cells_stays_a_water_move() -> void:
+	var world := _world(Vector2i(8, 6))
+	assert_true(world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)["ok"])
+	world.player_sprite_number = Gen2WorldSprite.SPRITE_SURF
+	assert_eq(world.move_result(Vector2i.DOWN)["kind"], &"water_move")
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_SURF)
+
+
+func test_surf_request_refuses_a_facing_object_on_crystal_only() -> void:
+	# Crystal's .TrySurf ends with a CheckFacingObject that pokegold's omits,
+	# under its own "You can Surf on top of NPCs" bug comment.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, true))
+	var world := _world(Vector2i(8, 6), state)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	world.objects[0].cell = Vector2i(8, 7)
+	assert_not_null(world.object_at(Vector2i(8, 7)))
+	assert_eq(world.surf_request()["reason"], &"cannot_surf")
+
+	var gold_directory: String = RomCache.directory_for(&"testworldsurfgold", "abcdef0123456789cd")
+	RomCache.clear(gold_directory)
+	RomCache.prepare(gold_directory)
+	var saved_directory: String = _directory
+	_directory = gold_directory
+	_write_cache("gold")
+	_directory = saved_directory
+
+	var gold_data: GameData = GameData.open_directory(gold_directory)
+	assert_false(Gen2WorldState.is_crystal_profile(gold_data))
+	var gold_state := Gen2WorldState.new()
+	gold_state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, false))
+	var gold_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		gold_data, 1, 1, Vector2i(8, 6), gold_state
+	)
+	gold_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	gold_world.objects[0].cell = Vector2i(8, 7)
+	assert_not_null(gold_world.object_at(Vector2i(8, 7)))
+	assert_true(bool(gold_world.surf_request().get("ok", false)))
+	RomCache.clear(gold_directory)
+
+
+func test_world_snapshot_round_trips_the_surfing_player_sprite() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+	assert_true(world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)["ok"])
+	world.player_sprite_number = Gen2WorldSprite.SPRITE_SURFING_PIKACHU
+	var encoded: Dictionary = world.snapshot().to_dict()
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
+		data, Gen2WorldSnapshot.from_dict(encoded)
+	)
+	assert_not_null(restored)
+	assert_eq(restored.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(restored.player_sprite_number, Gen2WorldSprite.SPRITE_SURFING_PIKACHU)
+
+	# A snapshot written before the sprite joined the format carries the movement
+	# mode alone, which resolves every state but the Pikachu variant.
+	encoded.erase("player_sprite_number")
+	var legacy := Gen2WorldSnapshot.from_dict(encoded)
+	assert_eq(legacy.player_sprite_number, Gen2WorldSprite.SPRITE_SURF)
+	encoded["movement_mode"] = "walk"
+	assert_eq(
+		Gen2WorldSnapshot.from_dict(encoded).player_sprite_number,
+		Gen2WorldSprite.SPRITE_PLAYER
+	)
+
+
 func test_explicit_fishing_uses_the_current_map_fish_group() -> void:
 	var world := _world(Vector2i(8, 6))
 	var encounter: Dictionary = world.encounter_request(

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1,7 +1,7 @@
 extends GutTest
 
-## Field-move tables and the Cut boundary, against a synthetic cache built for
-## this file so the shared world fixture stays untouched.
+## Field-move tables and the Cut and Surf boundaries, against a synthetic cache
+## built for this file so the shared world fixture stays untouched.
 ##
 ## The cache uses tileset number 1 (TILESET_JOHTO) so the real CutTreeBlockPointers
 ## rows apply: block $5b is a tree replaced by $3c, block $03 is grass replaced
@@ -15,6 +15,10 @@ const BLOCK_TREE_CUT: int = 0x3C
 const BLOCK_GRASS: int = 0x03
 const BLOCK_GRASS_CUT: int = 0x02
 const BLOCK_FLOOR: int = 0x01
+## Two blocks CutTreeBlockPointers has no row for, so the surf fixture cannot
+## disturb any Cut case.
+const BLOCK_WATER: int = 0x20
+const BLOCK_WALLED_SHORE: int = 0x21
 const BLOCK_COUNT: int = 0x68
 
 ## The cut tree stands at block (1,1)'s bottom-left quadrant and the grass at
@@ -23,6 +27,16 @@ const TREE_CELL: Vector2i = Vector2i(2, 3)
 const TREE_BLOCK: Vector2i = Vector2i(1, 1)
 const GRASS_CELL: Vector2i = Vector2i(4, 3)
 const GRASS_BLOCK: Vector2i = Vector2i(2, 1)
+
+## A shore in block (3,1): land above COLL_WATER, the New Bark Town shape the
+## real-cache validator drives. The second shore in block (0,3) stands on
+## COLL_DOWN_WALL, whose own edge mask is what CheckDirection reads.
+const WATER_CELL: Vector2i = Vector2i(6, 3)
+const SHORE_CELL: Vector2i = Vector2i(6, 2)
+const WALLED_WATER_CELL: Vector2i = Vector2i(0, 7)
+const WALLED_SHORE_CELL: Vector2i = Vector2i(0, 6)
+const COLL_WATER: int = 0x29
+const COLL_DOWN_WALL: int = 0xB3
 
 var _directory: String = ""
 
@@ -81,6 +95,9 @@ func _tileset(number: int) -> Dictionary:
 	# bottom-left cell is index 2. Only the uncut blocks carry a cuttable code.
 	collision[BLOCK_TREE * 4 + 2] = 0x12   # COLL_CUT_TREE
 	collision[BLOCK_GRASS * 4 + 2] = 0x18  # COLL_TALL_GRASS
+	collision[BLOCK_WATER * 4 + 2] = COLL_WATER
+	collision[BLOCK_WALLED_SHORE * 4 + 0] = COLL_DOWN_WALL
+	collision[BLOCK_WALLED_SHORE * 4 + 2] = COLL_WATER
 	return {
 		"number": number,
 		"block_count": BLOCK_COUNT,
@@ -96,12 +113,21 @@ func _map(number: int, tileset: int) -> Dictionary:
 		blocks.append(BLOCK_FLOOR)
 	blocks[TREE_BLOCK.y * 4 + TREE_BLOCK.x] = BLOCK_TREE
 	blocks[GRASS_BLOCK.y * 4 + GRASS_BLOCK.x] = BLOCK_GRASS
+	blocks[1 * 4 + 3] = BLOCK_WATER
+	blocks[3 * 4 + 0] = BLOCK_WALLED_SHORE
 	var collision: Array = []
 	collision.resize(64)
 	for index: int in collision.size():
 		collision[index] = 0
 	collision[TREE_CELL.y * 8 + TREE_CELL.x] = 0x12
 	collision[GRASS_CELL.y * 8 + GRASS_CELL.x] = 0x18
+	collision[WATER_CELL.y * 8 + WATER_CELL.x] = COLL_WATER
+	collision[WALLED_SHORE_CELL.y * 8 + WALLED_SHORE_CELL.x] = COLL_DOWN_WALL
+	collision[WALLED_WATER_CELL.y * 8 + WALLED_WATER_CELL.x] = COLL_WATER
+	# A warp pair between the shore and the water cell of the other map, so a map
+	# transition can land the player on either kind of tile. Destinations are
+	# one-based, so both point at the other map's only warp.
+	var warp_cell: Vector2i = SHORE_CELL if number == 1 else WATER_CELL
 	return {
 		"group": 1,
 		"number": number,
@@ -112,7 +138,10 @@ func _map(number: int, tileset: int) -> Dictionary:
 		"collision": collision,
 		"collision_width": 8,
 		"collision_height": 8,
-		"events": {},
+		"events": {"warps": [{
+			"x": warp_cell.x, "y": warp_cell.y, "destination": 1,
+			"map_group": 1, "map_number": 2 if number == 1 else 1,
+		}]},
 	}
 
 
@@ -136,6 +165,196 @@ func _world(map_number: int = 1, badge: bool = true) -> Gen2WorldAPI:
 	)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
 	return world
+
+
+## A world standing on the shore facing the water, with the Fog Badge set on
+## whichever engine flag table the opened cache selects.
+func _surf_world(badge: bool = true, stand: Vector2i = SHORE_CELL) -> Gen2WorldAPI:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	if badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_FOG, Gen2WorldState.is_crystal_profile(data)
+		))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, stand, state)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	return world
+
+
+func test_cut_and_surf_are_the_field_moves_the_submenu_offers() -> void:
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_CUT))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SURF))
+	assert_eq(Gen2WorldFieldMove.MOVE_CUT, 0x0F)
+	assert_eq(Gen2WorldFieldMove.MOVE_SURF, 0x39)
+	# MonMenuOptions rows this project does not act on yet must stay out, or the
+	# submenu would offer an entry nothing answers: FLY, STRENGTH, FLASH,
+	# WATERFALL, WHIRLPOOL, HEADBUTT.
+	for move: int in [0x13, 0x46, 0x94, 0x7F, 0xFA, 0x1D]:
+		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
+
+
+func test_surf_sprite_follows_get_surf_type() -> void:
+	assert_eq(
+		Gen2WorldFieldMove.surf_sprite(Gen2WorldFieldMove.SPECIES_PIKACHU),
+		Gen2WorldSprite.SPRITE_SURFING_PIKACHU
+	)
+	assert_eq(Gen2WorldFieldMove.SPECIES_PIKACHU, 25)
+	assert_eq(Gen2WorldSprite.SPRITE_SURF, 83)
+	assert_eq(Gen2WorldSprite.SPRITE_SURFING_PIKACHU, 52)
+	for species: int in [0, 1, 24, 26, 251]:
+		assert_eq(Gen2WorldFieldMove.surf_sprite(species), Gen2WorldSprite.SPRITE_SURF)
+
+
+func test_surf_request_checks_the_badge_before_the_state_and_the_tile() -> void:
+	# .TrySurf calls CheckBadge first, so a player without the Fog Badge is told
+	# about the badge whether or not the tile in front of them is surfable.
+	var world: Gen2WorldAPI = _surf_world(false)
+	var refused: Dictionary = world.surf_request()
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(refused["reason"], &"badge_required")
+	assert_true(world.pending_surf().is_empty())
+
+	# Facing land, and already surfing, still answer the badge first.
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(world.surf_request()["reason"], &"badge_required")
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.surf_request()["reason"], &"badge_required")
+
+
+func test_surf_request_reads_the_gold_silver_badge_flag() -> void:
+	_gold_profile()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_false(Gen2WorldState.is_crystal_profile(data))
+	# Crystal's ENGINE_FOGBADGE (30) must not answer on a Gold cache, whose
+	# shorter engine flag table puts the same badge at 29.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_FOGBADGE)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, SHORE_CELL, state)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_eq(world.surf_request()["reason"], &"badge_required")
+
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, false))
+	assert_true(bool(world.surf_request().get("ok", false)))
+
+
+func test_surf_request_refuses_a_tile_that_is_not_water() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var refused: Dictionary = world.surf_request()
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(refused["reason"], &"cannot_surf")
+
+
+func test_surf_request_refuses_when_the_standing_tile_walls_the_direction() -> void:
+	# CheckDirection ANDs wTilePermissions against the facing bit, so a
+	# COLL_DOWN_WALL shore refuses even with water directly below it.
+	var world: Gen2WorldAPI = _surf_world(true, WALLED_SHORE_CELL)
+	assert_eq(
+		world.collision_permission_at(WALLED_WATER_CELL), Gen2WorldCollision.WATER_TILE
+	)
+	assert_eq(
+		world.tile_permissions_at(WALLED_SHORE_CELL) & Gen2WorldCollision.FACE_DOWN,
+		Gen2WorldCollision.FACE_DOWN
+	)
+	assert_eq(world.surf_request()["reason"], &"cannot_surf")
+
+
+func test_surf_request_stages_without_moving_the_player() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	var staged: Dictionary = world.surf_request()
+	assert_true(bool(staged.get("ok", false)), JSON.stringify(staged))
+	assert_eq(staged["kind"], &"surf_requested")
+	assert_eq(staged["cell"], WATER_CELL)
+	assert_eq(staged["direction"], Vector2i.DOWN)
+	assert_eq(int(staged["sprite"]), Gen2WorldSprite.SPRITE_SURF)
+	# UsedSurfScript shows its text before writevar VAR_MOVEMENT, so nothing has
+	# changed yet.
+	assert_eq(world.player_cell, SHORE_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+	assert_eq(world.pending_surf()["cell"], WATER_CELL)
+
+
+func test_complete_surf_enters_the_water_without_spending_a_step() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	world.state.set_repel_steps(20)
+	assert_true(bool(world.surf_request().get("ok", false)))
+	var applied: Dictionary = world.complete_surf()
+	assert_true(bool(applied.get("ok", false)), JSON.stringify(applied))
+	assert_eq(applied["kind"], &"surf_applied")
+	assert_eq(world.player_cell, WATER_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_SURF)
+	# SurfStartStep is an applymovement, not player input: no repel step is
+	# consumed and no encounter is rolled.
+	assert_eq(world.state.repel_steps(), 20)
+	assert_true(world.player_step_in_progress())
+	assert_true(world.pending_surf().is_empty())
+
+
+func test_complete_surf_carries_the_pikachu_variant() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	assert_true(bool(
+		world.surf_request(Gen2WorldFieldMove.SPECIES_PIKACHU).get("ok", false)
+	))
+	assert_eq(
+		int(world.complete_surf()["sprite"]), Gen2WorldSprite.SPRITE_SURFING_PIKACHU
+	)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_SURFING_PIKACHU)
+
+
+func test_surf_request_refuses_while_staged_or_already_surfing() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	assert_true(bool(world.surf_request().get("ok", false)))
+	assert_eq(world.surf_request()["reason"], &"surf_in_progress")
+	assert_true(bool(world.complete_surf().get("ok", false)))
+	assert_eq(world.surf_request()["reason"], &"already_surfing")
+
+
+func test_complete_surf_without_a_request_fails() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	var applied: Dictionary = world.complete_surf()
+	assert_false(bool(applied.get("ok", false)))
+	assert_eq(applied["reason"], &"no_pending_surf")
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+
+
+func test_a_map_transition_rederives_the_player_state_from_the_landing_cell() -> void:
+	# CheckUpdatePlayerSprite runs on every warp and connection: .CheckSurfing
+	# starts surfing on water, .ResetSurfingOrBikingState restores walking
+	# anywhere else. Without it a warp taken from water strands the player on
+	# land in a mode where only water is a legal step.
+	var world: Gen2WorldAPI = _surf_world()
+	var onto_water: Dictionary = world.try_warp()
+	assert_true(bool(onto_water.get("ok", false)), JSON.stringify(onto_water))
+	assert_eq(world.player_cell, WATER_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_SURF)
+
+	var onto_land: Dictionary = world.try_warp()
+	assert_true(bool(onto_land.get("ok", false)), JSON.stringify(onto_land))
+	assert_eq(world.player_cell, SHORE_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+
+
+func test_a_map_transition_keeps_the_pikachu_surf_variant() -> void:
+	# .CheckSurfing keeps an existing surf state rather than overwriting it, so
+	# the Pikachu sprite survives a warp between two water cells.
+	var world: Gen2WorldAPI = _surf_world()
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.player_sprite_number = Gen2WorldSprite.SPRITE_SURFING_PIKACHU
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_eq(world.player_cell, WATER_CELL)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_SURFING_PIKACHU)
+
+
+func test_a_map_reload_drops_a_staged_surf() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	assert_true(bool(world.surf_request().get("ok", false)))
+	assert_true(bool(world.reload_current_map().get("ok", false)))
+	assert_true(world.pending_surf().is_empty())
 
 
 func test_cuttable_carries_the_six_check_cut_collision_codes() -> void:

--- a/tools/validate_surf.gd
+++ b/tools/validate_surf.gd
@@ -1,0 +1,269 @@
+extends SceneTree
+
+## Verifies Surf against freshly imported real caches, for both command profiles.
+##
+## The expected values come from the pinned pokecrystal and pokegold sources:
+## engine/events/overworld.asm's SurfFunction (.TrySurf, GetSurfType,
+## CheckDirection) and UsedSurfScript, engine/overworld/player_object.asm's
+## SurfStartStep, and engine/overworld/player_movement.asm's .TrySurf/.ExitWater.
+##
+## The real-cartridge counterpart to tests/unit/test_world_field_move.gd, which
+## uses a synthetic cache. New Bark Town is the acceptance case: its east shore
+## is the first real water a player walks up to, and maps/NewBarkTown.blk and
+## data/tilesets/johto_collision.asm are byte identical between the pins, so the
+## same cells answer on all three games.
+##
+##   Godot --headless --path . -s res://tools/validate_surf.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm, NEW_BARK group. Unlike Ilex Forest, Crystal's
+## extra maps are all in earlier groups, so the pair is the same in both.
+const NEW_BARK_GROUP: int = 24
+const NEW_BARK_NUMBER: int = 4
+## maps/NewBarkTown.blk through data/tilesets/johto_collision.asm: the town's
+## east shore. x=19 is the map edge into Route 27, so the checks stay on x=18.
+const SHORE_CELL := Vector2i(17, 6)
+const WATER_CELL := Vector2i(18, 6)
+const COLL_FLOOR: int = 0x00
+const COLL_WATER: int = 0x29
+
+## Census of the real caches, pinned so a cache change is loud. A surf-entry cell
+## is a land cell with a water neighbour the standing tile's own permissions do
+## not wall off, which is exactly what .TrySurf accepts.
+const EXPECTED_CENSUS: Dictionary = {
+	# game id: [surf-entry cells, maps offering one]
+	&"gold": [2141, 66],
+	&"silver": [2141, 66],
+	&"crystal": [2116, 66],
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_surf_sprites(game_id, data)
+		_verify_surf_music(game_id, data)
+		_census(game_id, data)
+		_verify_new_bark_town(game_id, data, crystal)
+	_finish()
+
+
+## ChrisStateSprites names two sprites this renderer has to draw, so a cache
+## whose sprite table stops short would fail loudly rather than falling back to
+## the missing-sprite marker.
+func _verify_surf_sprites(game_id: StringName, data: GameData) -> void:
+	for number: int in [Gen2WorldSprite.SPRITE_SURF, Gen2WorldSprite.SPRITE_SURFING_PIKACHU]:
+		var sprite: Gen2WorldSprite = data.overworld_sprite(number)
+		if not _check(
+			sprite != null, "%s: overworld sprite %d is missing." % [game_id, number]
+		):
+			continue
+		_check(
+			sprite.sprite_type == Gen2WorldSprite.TYPE_WALKING,
+			"%s: overworld sprite %d is type %d, not WALKING." % [
+				game_id, number, sprite.sprite_type,
+			]
+		)
+		_check(
+			sprite.tiles == 12,
+			"%s: overworld sprite %d has %d tiles, not the 12 sprites.asm declares." % [
+				game_id, number, sprite.tiles,
+			]
+		)
+		_check(
+			not data.overworld_sprite_indices(number).is_empty(),
+			"%s: overworld sprite %d has no decoded tile strip." % [game_id, number]
+		)
+
+
+## SpecialMapMusic answers MUSIC_SURF ahead of the map header, so the record has
+## to exist in every cache.
+func _verify_surf_music(game_id: StringName, data: GameData) -> void:
+	_check(
+		not data.world_audio(&"music", Gen2WorldFieldMove.MUSIC_SURF).is_empty(),
+		"%s: music record %d (MUSIC_SURF) is missing." % [game_id, Gen2WorldFieldMove.MUSIC_SURF]
+	)
+
+
+## Counts the cells a real cache actually offers Surf, so a cache change that
+## moves a shore or a collision code is loud.
+func _census(game_id: StringName, data: GameData) -> void:
+	var entry_cells: int = 0
+	var maps_with_surf: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		var tileset: Gen2WorldTileset = data.world_tileset(map.tileset)
+		if tileset == null:
+			continue
+		var world: Gen2WorldAPI = Gen2WorldAPI.new(
+			data, map, tileset, Vector2i.ZERO, Gen2WorldState.new()
+		)
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				var cell := Vector2i(x, y)
+				if world.collision_permission_at(cell) != Gen2WorldCollision.LAND_TILE:
+					continue
+				var permissions: int = world.tile_permissions_at(cell)
+				for direction: Vector2i in [
+					Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT
+				]:
+					var neighbour: Vector2i = cell + direction
+					if neighbour.x < 0 or neighbour.y < 0 \
+						or neighbour.x >= map.collision_width \
+						or neighbour.y >= map.collision_height:
+						continue
+					if world.collision_permission_at(neighbour) \
+						!= Gen2WorldCollision.WATER_TILE:
+						continue
+					if (permissions & Gen2WorldCollision.face_mask_for_direction(direction)) != 0:
+						continue
+					entry_cells += 1
+					maps_with_surf[Vector2i(map.group, map.number)] = true
+	var counts: Array = [entry_cells, maps_with_surf.size()]
+	print("%s: %d surf-entry cells across %d maps." % [game_id, counts[0], counts[1]])
+	_check(
+		counts == EXPECTED_CENSUS.get(game_id, []),
+		"%s: census is %s, not the pinned %s." % [
+			game_id, counts, EXPECTED_CENSUS.get(game_id, []),
+		]
+	)
+
+
+func _verify_new_bark_town(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var badge: int = Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, crystal)
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(badge)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, SHORE_CELL, state
+	)
+	if not _check(
+		world != null,
+		"%s: New Bark Town map %d/%d is missing." % [
+			game_id, NEW_BARK_GROUP, NEW_BARK_NUMBER,
+		]
+	):
+		return
+	world.player_facing = Gen2WorldSprite.FACING_RIGHT
+
+	var shore_code: int = world.collision_code_at(SHORE_CELL)
+	_check(
+		shore_code == COLL_FLOOR,
+		"%s: New Bark Town %s is $%02X, not COLL_FLOOR." % [game_id, SHORE_CELL, shore_code]
+	)
+	var water_code: int = world.collision_code_at(WATER_CELL)
+	_check(
+		water_code == COLL_WATER,
+		"%s: New Bark Town %s is $%02X, not COLL_WATER." % [game_id, WATER_CELL, water_code]
+	)
+	# Walking cannot enter the water; that is what Surf is for.
+	_check(
+		not world.can_walk_to(WATER_CELL, Vector2i.RIGHT),
+		"%s: New Bark Town %s is walkable on foot." % [game_id, WATER_CELL]
+	)
+
+	var staged: Dictionary = world.surf_request()
+	if not _check(
+		bool(staged.get("ok", false)),
+		"%s: New Bark Town refused Surf: %s." % [game_id, staged.get("reason", "unknown")]
+	):
+		return
+	_check(
+		staged.get("cell", Vector2i.ZERO) == WATER_CELL
+			and int(staged.get("sprite", -1)) == Gen2WorldSprite.SPRITE_SURF,
+		"%s: New Bark Town staged %s, not %s with sprite %d." % [
+			game_id, JSON.stringify(staged), WATER_CELL, Gen2WorldSprite.SPRITE_SURF,
+		]
+	)
+	# UsedSurfScript reaches writevar VAR_MOVEMENT only after its waitbutton, so
+	# staging alone must leave the player exactly where they were.
+	_check(
+		world.player_cell == SHORE_CELL
+			and world.movement_mode == Gen2WorldAPI.MOVEMENT_WALK,
+		"%s: New Bark Town moved the player before the surf was committed." % game_id
+	)
+
+	_check(
+		bool(world.complete_surf().get("ok", false)),
+		"%s: New Bark Town surf did not commit." % game_id
+	)
+	_check(
+		world.player_cell == WATER_CELL
+			and world.movement_mode == Gen2WorldAPI.MOVEMENT_SURF
+			and world.player_sprite_number == Gen2WorldSprite.SPRITE_SURF,
+		"%s: New Bark Town surf left the player at %s in %s with sprite %d." % [
+			game_id, world.player_cell, world.movement_mode, world.player_sprite_number,
+		]
+	)
+	_check(
+		StringName(world.surf_request().get("reason", &"")) == &"already_surfing",
+		"%s: New Bark Town allowed a second Surf while surfing." % game_id
+	)
+	print("%s: New Bark Town %d/%d %s -> %s, surfing on sprite %d." % [
+		game_id, NEW_BARK_GROUP, NEW_BARK_NUMBER, SHORE_CELL, WATER_CELL,
+		Gen2WorldSprite.SPRITE_SURF,
+	])
+
+	# .ExitWater restores PLAYER_NORMAL and the walking sprite as the step onto
+	# land is taken.
+	var exited: Dictionary = world.move_result(Vector2i.LEFT)
+	_check(
+		bool(exited.get("ok", false))
+			and StringName(exited.get("kind", &"")) == &"exit_water",
+		"%s: New Bark Town step back to land reported %s." % [game_id, JSON.stringify(exited)]
+	)
+	_check(
+		world.player_cell == SHORE_CELL
+			and world.movement_mode == Gen2WorldAPI.MOVEMENT_WALK
+			and world.player_sprite_number == Gen2WorldSprite.SPRITE_PLAYER,
+		"%s: New Bark Town exit water left the player at %s in %s with sprite %d." % [
+			game_id, world.player_cell, world.movement_mode, world.player_sprite_number,
+		]
+	)
+
+	# .TrySurf tests the badge before the tile, on whichever engine flag table
+	# this profile numbers ENGINE_FOGBADGE on.
+	var unbadged_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, SHORE_CELL, Gen2WorldState.new()
+	)
+	unbadged_world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	_check(
+		StringName(unbadged_world.surf_request().get("reason", &"")) == &"badge_required",
+		"%s: New Bark Town allowed Surf without engine flag %d." % [game_id, badge]
+	)
+	# The other profile's flag number must not answer for this one.
+	var wrong := Gen2WorldState.new()
+	wrong.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, not crystal))
+	var wrong_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, SHORE_CELL, wrong
+	)
+	wrong_world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	_check(
+		StringName(wrong_world.surf_request().get("reason", &"")) == &"badge_required",
+		"%s: New Bark Town accepted the other profile's Fog Badge flag." % game_id
+	)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS surf: sprites, music, the cell census and New Bark Town verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_surf.gd.uid
+++ b/tools/validate_surf.gd.uid
@@ -1,0 +1,1 @@
+uid://1mwawf5aqs26


### PR DESCRIPTION
Surf follows Cut's staged shape: surf_request() resolves .TrySurf and holds, complete_surf() enters the water on the text acknowledge, matching UsedSurfScript reaching SurfStartStep only after its waitbutton. The entry step is that routine's single 16-frame slow_step, and being an applymovement it spends no repel step and rolls no encounter.

The refusal order is the source's: badge, then the already-surfing state, then the faced tile, then CheckDirection, then CheckFacingObject last on Crystal only, since pokegold omits it under its own "You can Surf on top of NPCs" bug comment.

player_sprite_number carries wPlayerState resolved through ChrisStateSprites, which is the only part of that state a renderer reads and the only place the Pikachu variant differs. Stepping onto land is .ExitWater, restoring walking and the walking sprite before the step, and a warp or connection re-derives the state from the cell it lands on the way CheckUpdatePlayerSprite does; without that, a warp taken off water stranded the player on land in a mode where only water was a legal step. SpecialMapMusic answers before the map header, so a surfing player carries MUSIC_SURF.

Also fixed in passing: a water step never tried a warp, though CheckTileEvent gates warps on nothing.

tools/validate_surf.gd pins the surf-entry cell census and drives New Bark Town's east shore against all three real caches.