### PR TITLE
Whirlpool from the party submenu, and the tiles that force a step

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ for a fallback pairing.
 
 The world screen's start menu wires Pokemon, Pack, Pokegear, Save and Exit;
 Pokedex, Player and Options appear in their source position but do nothing yet.
-The party submenu offers Cut and Surf to a Pokemon that knows one; both show
-their message first and change the world on the acknowledge, and stepping from
-water back onto land stops surfing.
+The party submenu offers Cut, Surf and Whirlpool to a Pokemon that knows one; all
+three show their message first and change the world on the acknowledge, and
+stepping from water back onto land stops surfing. Standing on a whirlpool,
+waterfall, door, staircase or cave tile overrides the pressed direction the way
+the cartridge does.
 The imported Players House PC opens the embedded box storage screen. The host
 clock advances one game minute per real minute and crosses source day
 boundaries. `preview_emote()`, `preview_wild_encounter()`,
@@ -178,6 +180,7 @@ Headless tools, all against a real imported cache:
 | `validate_side_walls.gd` | the side-wall/side-buoy codes, their face masks and map census, in both games; Celadon Mansion Roof's fence and staircase landings on Crystal |
 | `validate_cut.gd` | the cut block tables, the profile-split tileset numbers and cuttable-cell census, and Ilex Forest's tree, in all three games |
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
+| `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -88,6 +88,9 @@ var _pending_cut: Dictionary = {}
 ## UsedSurfScript shows its text. The cell it names belongs to the loaded map,
 ## so it is cleared beside the Cut request.
 var _pending_surf: Dictionary = {}
+## The same for Whirlpool, which shares the source's wCutWhirlpool* slots with
+## Cut and is cleared beside it for the same reason.
+var _pending_whirlpool: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
@@ -557,6 +560,75 @@ func complete_surf() -> Dictionary:
 
 static func _surf_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"surf_failed", "reason": reason}
+
+
+## engine/events/overworld.asm's WhirlpoolFunction .TryWhirlpool, staged the way
+## Cut is: TryWhirlpoolMenu fills the same wCutWhirlpool* slots, and
+## Script_UsedWhirlpool reaches DisappearWhirlpool only after UseWhirlpoolText.
+##
+## .TryWhirlpool checks ENGINE_GLACIERBADGE before the tile, the same order
+## .CheckAble has. It checks no player state at all: the source neither requires
+## nor refuses surfing, so a player facing a whirlpool from land resolves too.
+func whirlpool_request() -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return _whirlpool_failure(&"missing_map")
+	if not _pending_whirlpool.is_empty():
+		return _whirlpool_failure(&"whirlpool_in_progress")
+	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_GLACIER, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return _whirlpool_failure(&"badge_required")
+	var target: Vector2i = facing_cell()
+	if not Gen2WorldFieldMove.whirlpool_tile(collision_code_at(target)):
+		return _whirlpool_failure(&"nothing_to_whirlpool")
+	var block_cell: Vector2i = _script_block_cell(target)
+	var replacement: Dictionary = Gen2WorldFieldMove.whirlpool_replacement(
+		current_map.tileset, block_at(block_cell.x, block_cell.y)
+	)
+	if not bool(replacement.get("ok", false)):
+		return _whirlpool_failure(&"nothing_to_whirlpool")
+	_pending_whirlpool = {
+		"ok": true,
+		"kind": &"whirlpool_requested",
+		"move": Gen2WorldFieldMove.MOVE_WHIRLPOOL,
+		"cell": target,
+		"block_cell": block_cell,
+		"block": int(replacement["block"]),
+		"animation": int(replacement["animation"]),
+	}
+	return _pending_whirlpool.duplicate(true)
+
+
+## Empty until whirlpool_request() succeeds. A host shows its text while this is set.
+func pending_whirlpool() -> Dictionary:
+	return _pending_whirlpool.duplicate(true)
+
+
+## DisappearWhirlpool, which writes the replacement block and re-runs
+## GetMovementPermissions exactly as CutDownTreeOrGrass does, so the override
+## dies with the loaded map and the whirlpool returns on the next visit.
+func complete_whirlpool() -> Dictionary:
+	if _pending_whirlpool.is_empty():
+		return _whirlpool_failure(&"no_pending_whirlpool")
+	var request: Dictionary = _pending_whirlpool
+	_pending_whirlpool = {}
+	var block_cell: Vector2i = request["block_cell"]
+	var changed: Dictionary = change_block(block_cell.x, block_cell.y, int(request["block"]))
+	if not bool(changed.get("ok", false)):
+		return changed
+	return {
+		"ok": true,
+		"kind": &"whirlpool_applied",
+		"move": int(request["move"]),
+		"cell": request["cell"],
+		"block_cell": block_cell,
+		"block": int(request["block"]),
+		"animation": int(request["animation"]),
+	}
+
+
+static func _whirlpool_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"whirlpool_failed", "reason": reason}
 
 
 ## Rolls an encounter from the current map. Auto mode preserves the existing
@@ -2511,9 +2583,19 @@ func move_result(direction: Vector2i) -> Dictionary:
 		return {"ok": false, "kind": &"move", "reason": &"phone_ring_active"}
 	if abs(direction.x) + abs(direction.y) != 1:
 		return {"ok": false, "kind": &"move", "reason": &"invalid_direction"}
-	var destination: Vector2i = player_cell + direction
 	if current_map == null:
 		return {"ok": false, "kind": &"move", "reason": &"missing_map"}
+	## .CheckTile runs before .CheckTurning and .TryStep/.TrySurf and overwrites
+	## wWalkingDirection, so the standing tile wins over the pressed direction.
+	var forced: Dictionary = forced_movement()
+	var forced_walk: bool = false
+	match StringName(forced.get("kind", &"none")):
+		&"force_turn":
+			return _forced_turn()
+		&"walk":
+			direction = forced["direction"]
+			forced_walk = true
+	var destination: Vector2i = player_cell + direction
 	if destination.x < 0 or destination.y < 0 \
 		or destination.x >= current_map.collision_width \
 		or destination.y >= current_map.collision_height:
@@ -2524,6 +2606,8 @@ func move_result(direction: Vector2i) -> Dictionary:
 				state.consume_repel_step()
 			return transition
 		return {"ok": false, "kind": &"move", "reason": &"map_edge"}
+	if forced_walk:
+		return _forced_step(direction, destination)
 	if not can_walk_to(destination, direction):
 		var hop: Dictionary = _try_ledge_hop(direction)
 		if not hop.is_empty():
@@ -2554,6 +2638,69 @@ func move_result(direction: Vector2i) -> Dictionary:
 	return {
 		"ok": true,
 		"kind": kind,
+		"from_map": from_map,
+		"from_cell": from_cell,
+		"to_map": from_map,
+		"to_cell": player_cell,
+	}
+
+
+## .CheckTile for the cell the player stands on: whether the tile overrides input,
+## and with what. [code]none[/code] leaves ordinary movement alone.
+func forced_movement() -> Dictionary:
+	if current_map == null:
+		return {"kind": &"none"}
+	return Gen2WorldCollision.forced_action(collision_code_at(player_cell))
+
+
+## Applies whatever the standing tile forces, with no input at all, because the
+## source polls .CheckTile every frame rather than only on a press. Empty when
+## the tile forces nothing.
+func advance_forced_movement() -> Dictionary:
+	var forced: Dictionary = forced_movement()
+	match StringName(forced.get("kind", &"none")):
+		&"force_turn":
+			return _forced_turn()
+		&"walk":
+			return move_result(forced["direction"])
+	return {}
+
+
+## PLAYERMOVEMENT_FORCE_TURN, which queues Script_ForcedMovement: it reads
+## VAR_FACING, the committed facing rather than the pressed direction, and applies
+## a stream of step_dig, turn_in and turn_head. None of those opcodes moves a cell,
+## so the whole effect is that the player is spun to face the way they came. A
+## player who surfs onto a whirlpool therefore cannot walk off it, which is the
+## cartridge's own behavior and not a gap here.
+func _forced_turn() -> Dictionary:
+	player_facing = _facing_for_direction(-_direction_for_facing(player_facing))
+	return {
+		"ok": true,
+		"kind": &"forced_turn",
+		"cell": player_cell,
+		"facing": player_facing,
+	}
+
+
+## .continue_walk: STEP_WALK through .DoStep, which never consults permissions, so
+## a forced step commits into a cell an ordinary step would refuse. It reaches
+## .CheckTile before .TrySurf, so it also never runs .ExitWater: a forced step from
+## water onto land keeps the surfing state. No shipped map places a forced tile
+## where either matters; both are kept because the source has no guard for them.
+func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
+	var from_map: Vector2i = map_id()
+	var from_cell: Vector2i = player_cell
+	var previous_cells: Dictionary = {}
+	for index: int in objects.size():
+		previous_cells[index] = (objects[index] as Gen2WorldObject).cell
+	player_cell = destination
+	player_facing = _facing_for_direction(direction)
+	state.consume_repel_step()
+	_advance_followers(from_cell, previous_cells)
+	_start_player_step(direction, STEP_FRAMES_WALK)
+	return {
+		"ok": true,
+		"kind": &"forced_move",
 		"from_map": from_map,
 		"from_cell": from_cell,
 		"to_map": from_map,
@@ -2699,6 +2846,7 @@ func _apply_map(
 	_block_overrides.clear()
 	_pending_cut.clear()
 	_pending_surf.clear()
+	_pending_whirlpool.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
 	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
@@ -2741,6 +2889,7 @@ func reload_current_map() -> Dictionary:
 	_block_overrides.clear()
 	_pending_cut.clear()
 	_pending_surf.clear()
+	_pending_whirlpool.clear()
 	state.reset_map_reload_flags()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -239,6 +239,83 @@ static func tile_permissions(
 	return permissions
 
 
+## Forced tiles: engine/overworld/player_movement.asm's DoPlayerMovement.CheckTile,
+## which runs in all three movement modes after .GetAction and before .CheckTurning,
+## .TryStep/.TrySurf and .CheckWarp. It reads the code of the cell the player
+## already stands on and overwrites wWalkingDirection, so the pressed direction is
+## discarded. A match reaches .continue_walk, whose .DoStep never consults
+## permissions, so a forced step ignores collision entirely.
+const HI_NYBBLE_CURRENT: int = 0x30
+const HI_NYBBLE_WALK: int = 0x40
+const HI_NYBBLE_WALK_ALT: int = 0x50
+const HI_NYBBLE_WARPS: int = 0x70
+const COLL_WHIRLPOOL: int = 0x24
+const COLL_WHIRLPOOL_2C: int = 0x2C
+const COLL_DOOR: int = 0x71
+const COLL_DOOR_79: int = 0x79
+const COLL_STAIRCASE: int = 0x7A
+const COLL_CAVE: int = 0x7B
+
+## .water_table, indexed by a current code's low two bits. The source masks
+## NUM_DIRECTIONS, not seven, so every code $30-$3f reaches this table.
+const CURRENT_DIRECTION: Array[Vector2i] = [
+	Vector2i.RIGHT,   # COLL_WATERFALL_RIGHT
+	Vector2i.LEFT,    # COLL_WATERFALL_LEFT
+	Vector2i.UP,      # COLL_WATERFALL_UP
+	Vector2i.DOWN,    # COLL_WATERFALL
+]
+
+## .land1_table and .land2_table, indexed by the low three bits. Vector2i.ZERO is
+## the source's STANDING, which falls through to no forced movement.
+const WALK_DIRECTION: Array[Vector2i] = [
+	Vector2i.ZERO,    # COLL_BRAKE
+	Vector2i.RIGHT,   # COLL_WALK_RIGHT
+	Vector2i.LEFT,    # COLL_WALK_LEFT
+	Vector2i.UP,      # COLL_WALK_UP
+	Vector2i.DOWN,    # COLL_WALK_DOWN
+	Vector2i.ZERO,    # COLL_BRAKE_45
+	Vector2i.ZERO,    # COLL_BRAKE_46
+	Vector2i.ZERO,    # COLL_BRAKE_47
+]
+const WALK_ALT_DIRECTION: Array[Vector2i] = [
+	Vector2i.RIGHT,   # COLL_WALK_RIGHT_ALT
+	Vector2i.LEFT,    # COLL_WALK_LEFT_ALT
+	Vector2i.UP,      # COLL_WALK_UP_ALT
+	Vector2i.DOWN,    # COLL_WALK_DOWN_ALT
+	Vector2i.ZERO,    # COLL_BRAKE_ALT
+	Vector2i.ZERO,    # COLL_BRAKE_55
+	Vector2i.ZERO,    # COLL_BRAKE_56
+	Vector2i.ZERO,    # COLL_BRAKE_57
+]
+
+## The .warps branch accepts four codes and refuses every other $7x.
+const WARP_STEP_CODES: Array[int] = [COLL_DOOR, COLL_DOOR_79, COLL_STAIRCASE, COLL_CAVE]
+
+
+## What .CheckTile does to a player standing on [param collision_code]:
+## [code]none[/code], [code]force_turn[/code] (CheckWhirlpoolTile matched, so
+## PLAYERMOVEMENT_FORCE_TURN queues Script_ForcedMovement) or [code]walk[/code]
+## with the direction the tile imposes. Branch order is the source's.
+static func forced_action(collision_code: int) -> Dictionary:
+	if collision_code < 0 or collision_code > 0xFF:
+		return {"kind": &"none"}
+	if collision_code == COLL_WHIRLPOOL or collision_code == COLL_WHIRLPOOL_2C:
+		return {"kind": &"force_turn"}
+	var direction: Vector2i = Vector2i.ZERO
+	match collision_code & 0xF0:
+		HI_NYBBLE_CURRENT:
+			direction = CURRENT_DIRECTION[collision_code & 0x03]
+		HI_NYBBLE_WALK:
+			direction = WALK_DIRECTION[collision_code & 0x07]
+		HI_NYBBLE_WALK_ALT:
+			direction = WALK_ALT_DIRECTION[collision_code & 0x07]
+		HI_NYBBLE_WARPS:
+			direction = Vector2i.DOWN if WARP_STEP_CODES.has(collision_code) else Vector2i.ZERO
+	if direction == Vector2i.ZERO:
+		return {"kind": &"none"}
+	return {"kind": &"walk", "direction": direction}
+
+
 ## Tile-collision std scripts: engine/events/std_collision.asm's
 ## CheckFacingTileForStdScript, dispatched on A once object and background events
 ## both find nothing. data/collision/collision_stdscripts.asm is byte identical

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -4,22 +4,26 @@ extends RefCounted
 ## Scene-free tables and gates for the overworld field moves
 ## (engine/events/overworld.asm).
 ##
-## Cut and Surf are resolved here. Both follow the shape CutFunction defines:
-## check the badge, then check the faced tile, then stage a change the text
-## acknowledge commits. Strength, Whirlpool, Waterfall, Flash and Headbutt are
-## not resolved yet.
+## Cut, Surf and Whirlpool are resolved here. All three follow the shape
+## CutFunction defines: check the badge, then check the faced tile, then stage a
+## change the text acknowledge commits. Strength, Waterfall, Flash and Headbutt
+## are not resolved yet.
 
 ## constants/move_constants.asm, whose comment column is hex. The submenu, not
-## CutFunction or SurfFunction, is what checks a party Pokemon knows these.
+## CutFunction, SurfFunction or WhirlpoolFunction, is what checks a party Pokemon
+## knows these.
 const MOVE_CUT: int = 0x0F
 const MOVE_SURF: int = 0x39
+const MOVE_WHIRLPOOL: int = 0xFA
 
-## CheckBadge's arguments in CutFunction's .CheckAble and SurfFunction's
-## .TrySurf, as source badge-order indices rather than flag numbers, so
-## Gen2WorldState.badge_flag() resolves them on either profile: ENGINE_HIVEBADGE
-## is 28 in Crystal and 27 in Gold/Silver, ENGINE_FOGBADGE 30 and 29.
+## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf
+## and WhirlpoolFunction's .TryWhirlpool, as source badge-order indices rather
+## than flag numbers, so Gen2WorldState.badge_flag() resolves them on either
+## profile: ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold/Silver,
+## ENGINE_FOGBADGE 30 and 29, ENGINE_GLACIERBADGE 33 and 32.
 const BADGE_HIVE: int = 1
 const BADGE_FOG: int = 3
+const BADGE_GLACIER: int = 6
 
 ## GetSurfType's comparison, constants/pokemon_constants.asm.
 const SPECIES_PIKACHU: int = 0x19
@@ -34,7 +38,7 @@ const MUSIC_SURF: int = 0x21
 ## Both pins ship the same rows, so this needs no profile split. IsFieldMove
 ## decides submenu membership from this list alone, so a move stops appearing
 ## the moment it leaves it.
-const FIELD_MOVES: Array[int] = [MOVE_CUT, MOVE_SURF]
+const FIELD_MOVES: Array[int] = [MOVE_CUT, MOVE_SURF, MOVE_WHIRLPOOL]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of
 ## the six block ($12, $1a); the four grass codes are LAND_TILE and cuttable
@@ -137,6 +141,41 @@ static func cut_replacement(tileset: int, block: int, is_crystal: bool) -> Dicti
 	if blocks == null:
 		return {"ok": false}
 	var row: Variant = (blocks as Dictionary).get(block)
+	if row == null:
+		return {"ok": false}
+	return {"ok": true, "block": int(row[0]), "animation": int(row[1])}
+
+
+## home/map_objects.asm's CheckWhirlpoolTile, which TryWhirlpoolMenu applies to
+## the faced tile. Both codes are WATER_TILE | TALK, so the cell is reachable by
+## surfing straight onto it; what makes it an obstacle is
+## Gen2WorldCollision.forced_action(), not the permission.
+const WHIRLPOOL_COLLISIONS: Array[int] = [
+	Gen2WorldCollision.COLL_WHIRLPOOL,
+	Gen2WorldCollision.COLL_WHIRLPOOL_2C,
+]
+
+## data/collision/field_move_blocks.asm's WhirlpoolBlockPointers, byte identical
+## between the pins like CutTreeBlockPointers. It names only TILESET_JOHTO, which
+## is $01 in both games, so unlike the cut table this needs no profile split.
+const WHIRLPOOL_BLOCKS_JOHTO: Dictionary = {
+	0x07: [0x36, ANIMATION_TREE],
+}
+
+
+## CheckWhirlpoolTile: whether the faced cell's collision code is one Whirlpool
+## acts on. A match still needs a block in the tileset's list.
+static func whirlpool_tile(collision_code: int) -> bool:
+	return WHIRLPOOL_COLLISIONS.has(collision_code)
+
+
+## CheckOverworldTileArrays against WhirlpoolBlockPointers, the counterpart of
+## cut_replacement(). Both misses, absent tileset and absent block, are the
+## source's same "nothing to do" answer.
+static func whirlpool_replacement(tileset: int, block: int) -> Dictionary:
+	if tileset != TILESET_JOHTO:
+		return {"ok": false}
+	var row: Variant = WHIRLPOOL_BLOCKS_JOHTO.get(block)
 	if row == null:
 		return {"ok": false}
 	return {"ok": true, "block": int(row[0]), "animation": int(row[1])}

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -25,6 +25,9 @@ const SFX_JUMP_OVER_LEDGE: int = 0x16
 ## OWCutAnimation before its sprite animation. The animation itself is not
 ## rendered here; the sound is.
 const SFX_CUT: int = 0x1E
+## constants/sfx_constants.asm's SFX_SURF, which is what PlayWhirlpoolSound plays
+## (engine/events/field_moves.asm); there is no whirlpool-specific effect.
+const SFX_WHIRLPOOL: int = 0x53
 
 @export var map_group: int = 24
 @export var map_number: int = 3
@@ -235,6 +238,7 @@ func _process(delta: float) -> void:
 		_renderer.refresh()
 	if _world != null and _world.tick() and _renderer != null:
 		_renderer.refresh()
+	_advance_forced_movement()
 	if _objects_may_move() and _world.advance_object_steps(delta, _object_random) \
 		and _renderer != null:
 		_renderer.refresh()
@@ -267,6 +271,26 @@ func _process(delta: float) -> void:
 		)
 		if bool(audio_result.get("ok", false)):
 			_show_script_results(audio_result.get("results", []))
+
+
+## .CheckTile's forced walk, which the source polls every frame with no input:
+## a waterfall pushes the player back down and a door, staircase or cave tile
+## steps them off it. The step already in progress paces it.
+##
+## PLAYERMOVEMENT_FORCE_TURN is deliberately not drained here. Its
+## Script_ForcedMovement is a queued script whose two step_dig runs pace the spin,
+## and this project renders none of that, so draining it per frame would flip the
+## facing at the frame rate. Gen2WorldAPI.move_result() answers it on the movement
+## attempt instead, which is where a player meets it.
+func _advance_forced_movement() -> void:
+	if not _objects_may_move() or _world.script_input_waiting() \
+		or _world.player_step_in_progress():
+		return
+	if StringName(_world.forced_movement().get("kind", &"none")) != &"walk":
+		return
+	var forced: Dictionary = _world.advance_forced_movement()
+	if bool(forced.get("ok", false)):
+		_after_player_move(forced)
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -441,6 +465,21 @@ func move_player(direction: Vector2i) -> bool:
 	var movement: Dictionary = _world.move_result(direction)
 	if not bool(movement.get("ok", false)):
 		return false
+	## A whirlpool spins the player rather than moving them, so nothing a completed
+	## step owes applies: no warp, no encounter, no repel step.
+	if movement.get("kind", &"") == &"forced_turn":
+		if _renderer != null:
+			_renderer.refresh()
+		_refresh_labels()
+		return true
+	return _after_player_move(movement)
+
+
+## Everything a completed step owes the rest of the screen: contextual audio, the
+## warp it may have landed on, the redraw, then sight, phone and encounter checks
+## in that order. Shared with the forced-tile path, which reaches it without a
+## key press.
+func _after_player_move(movement: Dictionary) -> bool:
 	if movement.get("kind", &"") == &"ledge_hop":
 		_play_ledge_hop_sfx()
 	## .ExitWater calls PlayMapMusic before the step, which is what drops the
@@ -451,7 +490,9 @@ func move_player(direction: Vector2i) -> bool:
 	var transition: Dictionary = movement
 	## CheckTileEvent gates warps on nothing, so surfing onto a warp tile and the
 	## step back onto land both reach one.
-	if movement.get("kind", &"") in [&"move", &"ledge_hop", &"water_move", &"exit_water"]:
+	if movement.get("kind", &"") in [
+		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
+	]:
 		transition = _world.try_warp()
 	if _renderer != null:
 		if bool(transition.get("ok", false)) and transition.get("kind", &"") != &"move":
@@ -656,6 +697,21 @@ func preview_surf_use() -> void:
 		_acknowledge_field_move_text()
 		return
 	preview_surf()
+	if _party_host != null:
+		_party_host.handle_key(KEY_SPACE)
+
+
+## And for Whirlpool, which needs the scene opened facing a COLL_WHIRLPOOL cell:
+## Dragon's Den B1F, Route 41 or Route 27 are the only maps that carry one.
+func preview_whirlpool() -> void:
+	_preview_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER)
+
+
+func preview_whirlpool_use() -> void:
+	if _field_move_text:
+		_acknowledge_field_move_text()
+		return
+	preview_whirlpool()
 	if _party_host != null:
 		_party_host.handle_key(KEY_SPACE)
 
@@ -1252,6 +1308,14 @@ func _on_party_action(action: Dictionary) -> void:
 				_show_field_move_text(_surf_refusal(StringName(surf.get("reason", &""))))
 				return
 			_show_field_move_text("%s used SURF!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
+			var whirlpool: Dictionary = _world.whirlpool_request()
+			if not bool(whirlpool.get("ok", false)):
+				_show_field_move_text(
+					_whirlpool_refusal(StringName(whirlpool.get("reason", &"")))
+				)
+				return
+			_show_field_move_text("%s used WHIRLPOOL!" % String(action.get("name", "")))
 		_:
 			_show_field_move_text("Can't use that here.")
 
@@ -1290,6 +1354,15 @@ func _surf_refusal(reason: StringName) -> String:
 	return "Can't use that here."
 
 
+## .FailWhirlpool has no text of its own: it calls FieldMoveFailed, so every
+## refusal but the badge falls back to _CantUseItemText. Cut is the exception,
+## not the rule.
+func _whirlpool_refusal(reason: StringName) -> String:
+	if reason == &"badge_required":
+		return "Sorry! A new BADGE is required."
+	return "Can't use that here."
+
+
 func _show_field_move_text(text: String) -> void:
 	_field_move_text = true
 	if _text_box != null and _text_box.font != null:
@@ -1318,19 +1391,25 @@ func _acknowledge_field_move_text() -> void:
 	if not _world.pending_surf().is_empty():
 		_commit_field_move(_world.complete_surf(), "Surf")
 		return
+	if not _world.pending_whirlpool().is_empty():
+		_commit_field_move(_world.complete_whirlpool(), "Whirlpool")
+		return
 	_script_prompt = ""
 	_refresh_labels()
 
 
-## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN and Surf changes the music, so each
-## commit reports its own audio; both redraw, because both changed what the map
-## or the player looks like.
+## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN, Whirlpool plays SFX_SURF and Surf
+## changes the music, so each commit reports its own audio; all three redraw,
+## because each changed what the map or the player looks like.
 func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
-		if StringName(applied.get("kind", &"")) == &"surf_applied":
-			_play_current_map_music()
-		else:
-			_play_sfx(SFX_CUT)
+		match StringName(applied.get("kind", &"")):
+			&"surf_applied":
+				_play_current_map_music()
+			&"whirlpool_applied":
+				_play_sfx(SFX_WHIRLPOOL)
+			_:
+				_play_sfx(SFX_CUT)
 		if _renderer != null:
 			_renderer.refresh()
 		_script_prompt = label

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1,14 +1,15 @@
 extends GutTest
 
-## Scene integration for Cut and Surf: the party submenu, the field-move message
-## and the change each commits, driven through the production world screen and
-## party screen.
+## Scene integration for Cut, Surf and Whirlpool: the party submenu, the
+## field-move message and the change each commits, driven through the production
+## world screen and party screen.
 ##
 ## The shared trainer fixture is patched here rather than extended, the same way
 ## test_world_start_menu_screen.gd patches its Potion in: the map moves onto
-## TILESET_JOHTO so the real CutTreeBlockPointers rows apply, and block $5b's
-## bottom-left quadrant becomes the cut tree. The fixture's own water cell at
-## (8,7) is what Surf is driven against.
+## TILESET_JOHTO so the real CutTreeBlockPointers and WhirlpoolBlockPointers rows
+## apply, block $5b's bottom-left quadrant becomes the cut tree and block $07's
+## the whirlpool. The fixture's own water cell at (8,7) is what Surf is driven
+## against.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
@@ -23,6 +24,12 @@ const PLAYER_CELL: Vector2i = Vector2i(2, 2)
 ## The fixture's own water cell and the land directly above it.
 const WATER_CELL: Vector2i = Vector2i(8, 7)
 const SHORE_CELL: Vector2i = Vector2i(8, 6)
+## WhirlpoolBlockPointers' only row, on the same TILESET_JOHTO the cut rows use.
+const BLOCK_WHIRLPOOL: int = 0x07
+const BLOCK_WHIRLPOOL_GONE: int = 0x36
+const WHIRLPOOL_BLOCK: Vector2i = Vector2i(1, 3)
+const WHIRLPOOL_CELL: Vector2i = Vector2i(2, 7)
+const WHIRLPOOL_STAND_CELL: Vector2i = Vector2i(2, 6)
 
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
@@ -49,6 +56,8 @@ func _write_cut_tree() -> void:
 			raw["name"] = "CUT"
 		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_SURF:
 			raw["name"] = "SURF"
+		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_WHIRLPOOL:
+			raw["name"] = "WHIRLPOOL"
 	RomCache.write_json(RomCache.moves_path(directory), moves)
 
 	var tilesets: Array = RomCache.read_json(RomCache.world_tilesets_path(directory))
@@ -65,6 +74,7 @@ func _write_cut_tree() -> void:
 	tile_collision.fill(0)
 	# Quadrant order is top-left, top-right, bottom-left, bottom-right.
 	tile_collision[BLOCK_TREE * 4 + 2] = 0x12  # COLL_CUT_TREE
+	tile_collision[BLOCK_WHIRLPOOL * 4 + 2] = 0x24  # COLL_WHIRLPOOL
 	tileset["collision"] = tile_collision
 	RomCache.write_json(RomCache.world_tilesets_path(directory), tilesets)
 
@@ -76,8 +86,10 @@ func _write_cut_tree() -> void:
 			continue
 		var blocks: Array = raw["blocks"]
 		blocks[TREE_BLOCK.y * Fixture.MAP_WIDTH_BLOCKS + TREE_BLOCK.x] = BLOCK_TREE
+		blocks[WHIRLPOOL_BLOCK.y * Fixture.MAP_WIDTH_BLOCKS + WHIRLPOOL_BLOCK.x] = BLOCK_WHIRLPOOL
 		var collision: Array = raw["collision"]
 		collision[TREE_CELL.y * Fixture.MAP_WIDTH_CELLS + TREE_CELL.x] = 0x12
+		collision[WHIRLPOOL_CELL.y * Fixture.MAP_WIDTH_CELLS + WHIRLPOOL_CELL.x] = 0x24
 	RomCache.write_json(RomCache.world_maps_path(directory), maps)
 
 	var tiles: PackedByteArray = PackedByteArray()
@@ -129,6 +141,14 @@ func _open_world(
 
 func _open_surf_world(badge: bool = true, cell: Vector2i = SHORE_CELL) -> void:
 	await _open_world(badge, Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG, cell)
+
+
+func _open_whirlpool_world(
+	badge: bool = true, cell: Vector2i = WHIRLPOOL_STAND_CELL
+) -> void:
+	await _open_world(
+		badge, Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER, cell
+	)
 
 
 func _open_party() -> Gen2PartyScreen:
@@ -348,3 +368,62 @@ func test_cancel_closes_the_submenu_before_the_party_screen() -> void:
 	party.handle_key(KEY_ESCAPE)
 	await get_tree().process_frame
 	assert_null(_world_screen._party_host)
+
+
+func test_submenu_lists_whirlpool_for_a_mon_that_knows_it() -> void:
+	await _open_whirlpool_world()
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	assert_eq(
+		_labels(party.submenu_snapshot()["items"]),
+		["WHIRLPOOL", "STATS", "SWITCH", "MOVE", "ITEM", "CANCEL"]
+	)
+
+
+func test_choosing_whirlpool_shows_the_message_and_defers_the_block_change() -> void:
+	await _open_whirlpool_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_null(_world_screen._party_host)
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_shown_text(), "TESTMON used WHIRLPOOL!")
+	# Script_UsedWhirlpool reaches DisappearWhirlpool only after UseWhirlpoolText.
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL)
+	assert_eq(world.collision_code_at(WHIRLPOOL_CELL), 0x24)
+
+	_world_screen._acknowledge_field_move_text()
+	assert_false(_world_screen._field_move_text)
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL_GONE)
+	assert_ne(world.collision_code_at(WHIRLPOOL_CELL), 0x24)
+	assert_true(world.pending_whirlpool().is_empty())
+
+
+func test_whirlpool_without_the_badge_reports_the_badge_and_changes_nothing() -> void:
+	await _open_whirlpool_world(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "Sorry! A new BADGE is required.")
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL)
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL)
+
+
+## .FailWhirlpool calls FieldMoveFailed, so the tile refusal is _CantUseItemText
+## rather than a whirlpool-specific line the way Cut's .FailCut has one.
+func test_whirlpool_facing_nothing_reports_the_generic_refusal() -> void:
+	await _open_whirlpool_world()
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "Can't use that here.")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -88,6 +88,15 @@ func _write_cache(game_id: String = "testworld") -> void:
 	# changes: crystal blocks entering from the west, gold does not.
 	collision[8 * 16 + 7] = 0xB1  # COLL_LEFT_WALL
 
+	# Forced-tile fixture, row 5, for DoPlayerMovement.CheckTile: a waterfall at
+	# (1,5) pushing DOWN onto open land, a door at (12,5) whose cell below is a
+	# wall, and a forced-right tile at (15,5) on the east edge, where the forced
+	# step leaves the map through the connection.
+	collision[5 * 16 + 1] = 0x33   # COLL_WATERFALL
+	collision[5 * 16 + 12] = 0x71  # COLL_DOOR
+	collision[6 * 16 + 12] = 0x07  # wall below the door
+	collision[5 * 16 + 15] = 0x41  # COLL_WALK_RIGHT
+
 	# A lone COLL_UP_WALL at (2,10), matching real Route 42 cliff cells: it
 	# blocks stepping off the edge (entering from above, moving DOWN) but not
 	# climbing it (moving UP from below), since the enter rule only tests the
@@ -3143,3 +3152,57 @@ func _event_value(
 	if index >= 0:
 		return (matches[index] as Dictionary).get(key, null) if index < matches.size() else null
 	return (matches[0] as Dictionary).get(key, null) if not matches.is_empty() else null
+
+
+## engine/overworld/player_movement.asm's DoPlayerMovement.CheckTile, which runs
+## before .CheckTurning and .TryStep and overwrites wWalkingDirection, so the
+## standing tile decides the step and the pressed direction is discarded.
+func test_a_waterfall_tile_pushes_the_player_down_whatever_is_pressed() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 5))
+	assert_eq(StringName(world.forced_movement()["kind"]), &"walk")
+	assert_eq(world.forced_movement()["direction"], Vector2i.DOWN)
+
+	var forced: Dictionary = world.move_result(Vector2i.UP)
+	assert_true(bool(forced.get("ok", false)), JSON.stringify(forced))
+	assert_eq(forced["kind"], &"forced_move")
+	assert_eq(world.player_cell, Vector2i(1, 6))
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_DOWN)
+	# Off the waterfall, ordinary movement resumes.
+	assert_eq(StringName(world.forced_movement()["kind"]), &"none")
+	assert_eq(world.move_result(Vector2i.UP)["kind"], &"move")
+
+
+func test_a_forced_step_commits_into_a_cell_an_ordinary_step_refuses() -> void:
+	# .continue_walk reaches .DoStep, which never consults permissions, so the
+	# wall below a door does not stop the step off it.
+	var world: Gen2WorldAPI = _world(Vector2i(12, 5))
+	assert_false(world.can_walk_to(Vector2i(12, 6), Vector2i.DOWN))
+	var forced: Dictionary = world.move_result(Vector2i.LEFT)
+	assert_true(bool(forced.get("ok", false)), JSON.stringify(forced))
+	assert_eq(forced["kind"], &"forced_move")
+	assert_eq(world.player_cell, Vector2i(12, 6))
+
+
+func test_a_forced_step_off_the_map_edge_takes_the_connection() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(15, 5))
+	assert_eq(world.forced_movement()["direction"], Vector2i.RIGHT)
+	var forced: Dictionary = world.move_result(Vector2i.LEFT)
+	assert_true(bool(forced.get("ok", false)), JSON.stringify(forced))
+	assert_eq(world.map_id(), Vector2i(1, 2))
+
+
+func test_a_forced_step_spends_a_repel_step_like_an_ordinary_one() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 5))
+	world.state.set_repel_steps(5)
+	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)))
+	assert_eq(world.state.repel_steps(), 4)
+
+
+## advance_forced_movement() is the no-input path, since the source polls
+## .CheckTile every frame rather than only on a press.
+func test_advance_forced_movement_moves_without_a_pressed_direction() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 5))
+	var forced: Dictionary = world.advance_forced_movement()
+	assert_true(bool(forced.get("ok", false)), JSON.stringify(forced))
+	assert_eq(world.player_cell, Vector2i(1, 6))
+	assert_true(world.advance_forced_movement().is_empty())

--- a/tests/unit/test_world_collision.gd
+++ b/tests/unit/test_world_collision.gd
@@ -246,3 +246,81 @@ func test_cuttable_codes_keep_the_permissions_cut_depends_on() -> void:
 			Gen2WorldCollision.permission_for(code), Gen2WorldCollision.LAND_TILE,
 			"grass $%02x" % code
 		)
+
+
+## engine/overworld/player_movement.asm's DoPlayerMovement.CheckTile, branch for
+## branch. Its tables are indexed after a mask, not by an exact code, so most of
+## these entries have no COLL_* name and none is reachable on a pinned cartridge
+## except $24, $33 and the three warp codes.
+func test_forced_action_answers_none_on_ordinary_ground() -> void:
+	for code: int in [0x00, 0x07, 0x12, 0x18, 0x20, 0x29, 0x60, 0x91, 0xA3, 0xB0, 0xC0]:
+		assert_eq(
+			StringName(Gen2WorldCollision.forced_action(code)["kind"]), &"none",
+			"code $%02x" % code
+		)
+	for code: int in [-1, 0x100]:
+		assert_eq(StringName(Gen2WorldCollision.forced_action(code)["kind"]), &"none")
+
+
+func test_forced_action_turns_the_player_on_both_whirlpool_codes() -> void:
+	for code: int in [0x24, 0x2C]:
+		var forced: Dictionary = Gen2WorldCollision.forced_action(code)
+		assert_eq(StringName(forced["kind"]), &"force_turn", "code $%02x" % code)
+		assert_false(forced.has("direction"))
+	# Their neighbours are ordinary water.
+	for code: int in [0x23, 0x25, 0x2B, 0x2D]:
+		assert_eq(StringName(Gen2WorldCollision.forced_action(code)["kind"]), &"none")
+
+
+func test_forced_action_walks_every_current_code() -> void:
+	# .water masks NUM_DIRECTIONS, so all sixteen $3x codes index the four-entry
+	# .water_table rather than only $30-$33.
+	var expected: Array[Vector2i] = [
+		Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN,
+	]
+	for code: int in range(0x30, 0x40):
+		var forced: Dictionary = Gen2WorldCollision.forced_action(code)
+		assert_eq(StringName(forced["kind"]), &"walk", "code $%02x" % code)
+		assert_eq(forced["direction"], expected[code & 0x03], "code $%02x" % code)
+	# COLL_WATERFALL, the only one of the sixteen any pinned map ships.
+	assert_eq(Gen2WorldCollision.forced_action(0x33)["direction"], Vector2i.DOWN)
+
+
+func test_forced_action_follows_both_forced_walk_tables() -> void:
+	var land1: Array[Vector2i] = [
+		Vector2i.ZERO, Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP,
+		Vector2i.DOWN, Vector2i.ZERO, Vector2i.ZERO, Vector2i.ZERO,
+	]
+	var land2: Array[Vector2i] = [
+		Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN,
+		Vector2i.ZERO, Vector2i.ZERO, Vector2i.ZERO, Vector2i.ZERO,
+	]
+	for index: int in 8:
+		_assert_forced_walk(0x40 + index, land1[index])
+		_assert_forced_walk(0x50 + index, land2[index])
+	# The masks are three bits wide, so the upper half of each row aliases onto
+	# the same eight entries, as the ledge and side-wall codes do.
+	for index: int in 8:
+		_assert_forced_walk(0x48 + index, land1[index])
+		_assert_forced_walk(0x58 + index, land2[index])
+
+
+## .warps accepts four codes and lets every other $7x fall through, so a warp
+## panel or an unnamed $7x tile forces nothing.
+func test_forced_action_steps_down_off_doors_stairs_and_caves() -> void:
+	for code: int in [0x71, 0x79, 0x7A, 0x7B]:
+		_assert_forced_walk(code, Vector2i.DOWN)
+	for code: int in [0x70, 0x72, 0x73, 0x74, 0x75, 0x78, 0x7C, 0x7D, 0x7F]:
+		assert_eq(
+			StringName(Gen2WorldCollision.forced_action(code)["kind"]), &"none",
+			"code $%02x" % code
+		)
+
+
+func _assert_forced_walk(code: int, direction: Vector2i) -> void:
+	var forced: Dictionary = Gen2WorldCollision.forced_action(code)
+	if direction == Vector2i.ZERO:
+		assert_eq(StringName(forced["kind"]), &"none", "code $%02x" % code)
+		return
+	assert_eq(StringName(forced["kind"]), &"walk", "code $%02x" % code)
+	assert_eq(forced["direction"], direction, "code $%02x" % code)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1,12 +1,14 @@
 extends GutTest
 
-## Field-move tables and the Cut and Surf boundaries, against a synthetic cache
-## built for this file so the shared world fixture stays untouched.
+## Field-move tables and the Cut, Surf and Whirlpool boundaries, against a
+## synthetic cache built for this file so the shared world fixture stays
+## untouched.
 ##
 ## The cache uses tileset number 1 (TILESET_JOHTO) so the real CutTreeBlockPointers
 ## rows apply: block $5b is a tree replaced by $3c, block $03 is grass replaced
-## by $02. Tileset 5 is TILESET_PLAYERS_HOUSE, which the source table has no
-## entry for.
+## by $02. WhirlpoolBlockPointers names the same tileset, where block $07 is
+## replaced by $36. Tileset 5 is TILESET_PLAYERS_HOUSE, which neither source
+## table has an entry for.
 
 const TILESET_CUTTABLE: int = Gen2WorldFieldMove.TILESET_JOHTO
 const TILESET_NO_ENTRY: int = 5
@@ -19,6 +21,9 @@ const BLOCK_FLOOR: int = 0x01
 ## disturb any Cut case.
 const BLOCK_WATER: int = 0x20
 const BLOCK_WALLED_SHORE: int = 0x21
+## WhirlpoolBlockPointers' only row, which CutTreeBlockPointers has no entry for.
+const BLOCK_WHIRLPOOL: int = 0x07
+const BLOCK_WHIRLPOOL_GONE: int = 0x36
 const BLOCK_COUNT: int = 0x68
 
 ## The cut tree stands at block (1,1)'s bottom-left quadrant and the grass at
@@ -37,6 +42,13 @@ const WALLED_WATER_CELL: Vector2i = Vector2i(0, 7)
 const WALLED_SHORE_CELL: Vector2i = Vector2i(0, 6)
 const COLL_WATER: int = 0x29
 const COLL_DOWN_WALL: int = 0xB3
+
+## A whirlpool in block (3,3)'s bottom-left quadrant, with the water it sits in
+## directly above it, so a surfing player can reach and face it.
+const WHIRLPOOL_CELL: Vector2i = Vector2i(6, 7)
+const WHIRLPOOL_BLOCK: Vector2i = Vector2i(3, 3)
+const WHIRLPOOL_STAND_CELL: Vector2i = Vector2i(6, 6)
+const COLL_WHIRLPOOL: int = 0x24
 
 var _directory: String = ""
 
@@ -98,6 +110,12 @@ func _tileset(number: int) -> Dictionary:
 	collision[BLOCK_WATER * 4 + 2] = COLL_WATER
 	collision[BLOCK_WALLED_SHORE * 4 + 0] = COLL_DOWN_WALL
 	collision[BLOCK_WALLED_SHORE * 4 + 2] = COLL_WATER
+	# Both whirlpool blocks are water apart from the whirlpool quadrant itself, so
+	# the cell the player surfs from stays water after the block is replaced.
+	for quadrant: int in 4:
+		collision[BLOCK_WHIRLPOOL * 4 + quadrant] = COLL_WATER
+		collision[BLOCK_WHIRLPOOL_GONE * 4 + quadrant] = COLL_WATER
+	collision[BLOCK_WHIRLPOOL * 4 + 2] = COLL_WHIRLPOOL
 	return {
 		"number": number,
 		"block_count": BLOCK_COUNT,
@@ -115,6 +133,7 @@ func _map(number: int, tileset: int) -> Dictionary:
 	blocks[GRASS_BLOCK.y * 4 + GRASS_BLOCK.x] = BLOCK_GRASS
 	blocks[1 * 4 + 3] = BLOCK_WATER
 	blocks[3 * 4 + 0] = BLOCK_WALLED_SHORE
+	blocks[WHIRLPOOL_BLOCK.y * 4 + WHIRLPOOL_BLOCK.x] = BLOCK_WHIRLPOOL
 	var collision: Array = []
 	collision.resize(64)
 	for index: int in collision.size():
@@ -124,6 +143,8 @@ func _map(number: int, tileset: int) -> Dictionary:
 	collision[WATER_CELL.y * 8 + WATER_CELL.x] = COLL_WATER
 	collision[WALLED_SHORE_CELL.y * 8 + WALLED_SHORE_CELL.x] = COLL_DOWN_WALL
 	collision[WALLED_WATER_CELL.y * 8 + WALLED_WATER_CELL.x] = COLL_WATER
+	collision[WHIRLPOOL_CELL.y * 8 + WHIRLPOOL_CELL.x] = COLL_WHIRLPOOL
+	collision[WHIRLPOOL_STAND_CELL.y * 8 + WHIRLPOOL_STAND_CELL.x] = COLL_WATER
 	# A warp pair between the shore and the water cell of the other map, so a map
 	# transition can land the player on either kind of tile. Destinations are
 	# one-based, so both point at the other map's only warp.
@@ -181,15 +202,32 @@ func _surf_world(badge: bool = true, stand: Vector2i = SHORE_CELL) -> Gen2WorldA
 	return world
 
 
-func test_cut_and_surf_are_the_field_moves_the_submenu_offers() -> void:
+## A world beside the whirlpool and facing it, surfing, with the Glacier Badge on
+## whichever engine flag table the opened cache selects.
+func _whirlpool_world(badge: bool = true) -> Gen2WorldAPI:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	if badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_GLACIER, Gen2WorldState.is_crystal_profile(data)
+		))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WHIRLPOOL_STAND_CELL, state)
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	return world
+
+
+func test_cut_surf_and_whirlpool_are_the_field_moves_the_submenu_offers() -> void:
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_CUT))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SURF))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL))
 	assert_eq(Gen2WorldFieldMove.MOVE_CUT, 0x0F)
 	assert_eq(Gen2WorldFieldMove.MOVE_SURF, 0x39)
+	assert_eq(Gen2WorldFieldMove.MOVE_WHIRLPOOL, 0xFA)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
 	# submenu would offer an entry nothing answers: FLY, STRENGTH, FLASH,
-	# WATERFALL, WHIRLPOOL, HEADBUTT.
-	for move: int in [0x13, 0x46, 0x94, 0x7F, 0xFA, 0x1D]:
+	# WATERFALL, HEADBUTT.
+	for move: int in [0x13, 0x46, 0x94, 0x7F, 0x1D]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 
@@ -533,3 +571,162 @@ func test_a_map_reload_regrows_the_tree_and_drops_a_staged_cut() -> void:
 	assert_true(bool(world.cut_request().get("ok", false)))
 	world.reload_current_map()
 	assert_true(world.pending_cut().is_empty())
+
+
+func test_whirlpool_tile_carries_both_check_whirlpool_tile_codes() -> void:
+	for code: int in [0x24, 0x2C]:
+		assert_true(Gen2WorldFieldMove.whirlpool_tile(code), "code $%02x" % code)
+	# Neighbours of both codes, and the codes Cut and the waterfall own.
+	for code: int in [0x00, 0x20, 0x23, 0x25, 0x2B, 0x2D, 0x12, 0x33]:
+		assert_false(Gen2WorldFieldMove.whirlpool_tile(code), "code $%02x" % code)
+
+
+func test_whirlpool_block_table_matches_the_pinned_row() -> void:
+	var hit: Dictionary = Gen2WorldFieldMove.whirlpool_replacement(
+		Gen2WorldFieldMove.TILESET_JOHTO, BLOCK_WHIRLPOOL
+	)
+	assert_true(bool(hit.get("ok", false)))
+	assert_eq(int(hit["block"]), BLOCK_WHIRLPOOL_GONE)
+	assert_eq(int(hit["animation"]), Gen2WorldFieldMove.ANIMATION_TREE)
+	# WhirlpoolBlockPointers names TILESET_JOHTO alone, and nothing else in it.
+	assert_false(bool(Gen2WorldFieldMove.whirlpool_replacement(
+		Gen2WorldFieldMove.TILESET_JOHTO, 0x03
+	).get("ok", false)))
+	for tileset: int in [
+		Gen2WorldFieldMove.TILESET_JOHTO_MODERN, Gen2WorldFieldMove.TILESET_KANTO,
+		Gen2WorldFieldMove.TILESET_FOREST_CRYSTAL, TILESET_NO_ENTRY,
+	]:
+		assert_false(bool(Gen2WorldFieldMove.whirlpool_replacement(
+			tileset, BLOCK_WHIRLPOOL
+		).get("ok", false)), "tileset %d" % tileset)
+
+
+func test_whirlpool_request_checks_the_badge_before_the_tile() -> void:
+	# .TryWhirlpool calls CheckBadge first, the same order .CheckAble has.
+	var world: Gen2WorldAPI = _whirlpool_world(false)
+	var refused: Dictionary = world.whirlpool_request()
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(refused["reason"], &"badge_required")
+	assert_true(world.pending_whirlpool().is_empty())
+
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(world.whirlpool_request()["reason"], &"badge_required")
+
+
+func test_whirlpool_request_reads_the_gold_silver_badge_flag() -> void:
+	_gold_profile()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_false(Gen2WorldState.is_crystal_profile(data))
+	# Crystal's ENGINE_GLACIERBADGE (33) must not answer on a Gold cache, whose
+	# shorter engine flag table puts the same badge at 32.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_GLACIERBADGE)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WHIRLPOOL_STAND_CELL, state)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_eq(world.whirlpool_request()["reason"], &"badge_required")
+
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_GLACIER, false))
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+
+
+func test_whirlpool_request_refuses_a_tile_that_is_not_a_whirlpool() -> void:
+	var world: Gen2WorldAPI = _whirlpool_world()
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(world.whirlpool_request()["reason"], &"nothing_to_whirlpool")
+
+
+func test_whirlpool_request_refuses_a_tileset_without_a_block_list() -> void:
+	# Map 2 carries the identical whirlpool cell on TILESET_PLAYERS_HOUSE, which
+	# WhirlpoolBlockPointers has no entry for.
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_GLACIER, Gen2WorldState.is_crystal_profile(data)
+	))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 2, WHIRLPOOL_STAND_CELL, state)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(Gen2WorldFieldMove.whirlpool_tile(world.collision_code_at(WHIRLPOOL_CELL)))
+	assert_eq(world.whirlpool_request()["reason"], &"nothing_to_whirlpool")
+
+
+func test_whirlpool_request_resolves_from_land_too() -> void:
+	# .TryWhirlpool checks no player state at all, so walking is not a refusal.
+	var world: Gen2WorldAPI = _whirlpool_world()
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_WALK)
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+
+
+func test_whirlpool_request_stages_without_changing_the_map() -> void:
+	var world: Gen2WorldAPI = _whirlpool_world()
+	var staged: Dictionary = world.whirlpool_request()
+	assert_true(bool(staged.get("ok", false)), JSON.stringify(staged))
+	assert_eq(staged["kind"], &"whirlpool_requested")
+	assert_eq(staged["cell"], WHIRLPOOL_CELL)
+	assert_eq(staged["block_cell"], WHIRLPOOL_BLOCK)
+	assert_eq(int(staged["block"]), BLOCK_WHIRLPOOL_GONE)
+	# Script_UsedWhirlpool reaches DisappearWhirlpool only after UseWhirlpoolText.
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL)
+	assert_eq(world.collision_code_at(WHIRLPOOL_CELL), COLL_WHIRLPOOL)
+	assert_eq(world.pending_whirlpool()["block"], BLOCK_WHIRLPOOL_GONE)
+
+
+func test_complete_whirlpool_replaces_the_block_and_clears_the_code() -> void:
+	var world: Gen2WorldAPI = _whirlpool_world()
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+	var applied: Dictionary = world.complete_whirlpool()
+	assert_true(bool(applied.get("ok", false)), JSON.stringify(applied))
+	assert_eq(applied["kind"], &"whirlpool_applied")
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL_GONE)
+	assert_ne(world.collision_code_at(WHIRLPOOL_CELL), COLL_WHIRLPOOL)
+	assert_true(world.pending_whirlpool().is_empty())
+
+
+func test_a_second_whirlpool_request_refuses_while_one_is_staged() -> void:
+	var world: Gen2WorldAPI = _whirlpool_world()
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+	assert_eq(world.whirlpool_request()["reason"], &"whirlpool_in_progress")
+
+
+func test_complete_whirlpool_without_a_request_fails() -> void:
+	var world: Gen2WorldAPI = _whirlpool_world()
+	var applied: Dictionary = world.complete_whirlpool()
+	assert_false(bool(applied.get("ok", false)))
+	assert_eq(applied["reason"], &"no_pending_whirlpool")
+
+
+func test_a_map_reload_restores_the_whirlpool_and_drops_a_staged_request() -> void:
+	var world: Gen2WorldAPI = _whirlpool_world()
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+	assert_true(bool(world.complete_whirlpool().get("ok", false)))
+	assert_true(bool(world.reload_current_map().get("ok", false)))
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL)
+	assert_eq(world.collision_code_at(WHIRLPOOL_CELL), COLL_WHIRLPOOL)
+
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+	world.reload_current_map()
+	assert_true(world.pending_whirlpool().is_empty())
+
+
+func test_the_whirlpool_traps_a_player_until_it_is_removed() -> void:
+	# .CheckTile answers before .TrySurf, so the cell is enterable but not
+	# leavable: Script_ForcedMovement only spins the player around.
+	var world: Gen2WorldAPI = _whirlpool_world()
+	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)))
+	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+
+	var spun: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_eq(spun["kind"], &"forced_turn")
+	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
+	assert_eq(world.move_result(Vector2i.UP)["kind"], &"forced_turn")
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_DOWN)
+	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+
+	# Removing it from the neighbouring cell frees it.
+	world.player_cell = WHIRLPOOL_STAND_CELL
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(bool(world.whirlpool_request().get("ok", false)))
+	assert_true(bool(world.complete_whirlpool().get("ok", false)))
+	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)))
+	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+	assert_eq(world.forced_movement()["kind"], &"none")

--- a/tools/validate_side_walls.gd
+++ b/tools/validate_side_walls.gd
@@ -170,13 +170,21 @@ func _verify_celadon_mansion_roof() -> void:
 		"crystal: roof (2,1) did not block leaving its own COLL_LEFT_WALL."
 	)
 
+	# (1,1) is the staircase landing itself, COLL_STAIRCASE, so .CheckTile answers
+	# before .TryStep ever reaches the enter rule: pressing RIGHT there steps DOWN
+	# off the staircase. The enter rule is checked directly for that reason.
 	var staircase_right := Gen2WorldAPI.open(
 		data, ROOF_GROUP, ROOF_NUMBER, Vector2i(1, 1), Gen2WorldState.new()
 	)
-	var entering_wall: Dictionary = staircase_right.move_result(Vector2i.RIGHT)
 	_check(
-		not bool(entering_wall.get("ok", false)),
+		not staircase_right.can_walk_to(Vector2i(2, 1), Vector2i.RIGHT),
 		"crystal: roof (1,1) did not block entering (2,1)'s COLL_LEFT_WALL."
+	)
+	var forced_off: Dictionary = staircase_right.move_result(Vector2i.RIGHT)
+	_check(
+		bool(forced_off.get("ok", false))
+			and staircase_right.player_cell == Vector2i(1, 2),
+		"crystal: roof (1,1) staircase did not force the player down off it."
 	)
 
 	var staircase_up := Gen2WorldAPI.open(

--- a/tools/validate_whirlpool.gd
+++ b/tools/validate_whirlpool.gd
@@ -1,0 +1,280 @@
+extends SceneTree
+
+## Verifies Whirlpool and the forced-tile layer against freshly imported real
+## caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## engine/events/overworld.asm's WhirlpoolFunction and TryWhirlpoolMenu,
+## home/map_objects.asm's CheckWhirlpoolTile, data/collision/field_move_blocks.asm's
+## WhirlpoolBlockPointers and engine/overworld/player_movement.asm's
+## DoPlayerMovement.CheckTile. All four are byte identical between the pins, and
+## WhirlpoolBlockPointers names only TILESET_JOHTO, which is $01 in both games, so
+## nothing here is profile split except the badge flag number and Dragon's Den's
+## map number.
+##
+## The real-cartridge counterpart to tests/unit/test_world_field_move.gd and the
+## forced-tile tests in tests/unit/test_world_api.gd. Dragon's Den B1F is the
+## acceptance case, because its whirlpool is the one a Crystal playthrough meets.
+##
+##   Godot --headless --path . -s res://tools/validate_whirlpool.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push
+## Dragon's Den B1F eight places later within the same group.
+const DEN_GROUP: int = 3
+const DEN_NUMBER_CRYSTAL: int = 81
+const DEN_NUMBER_GOLD_SILVER: int = 73
+## maps/DragonsDenB1F.blk: one block $07, whose bottom-left quadrant carries
+## COLL_WHIRLPOOL (data/tilesets/johto_collision.asm).
+const DEN_BLOCK := Vector2i(5, 10)
+const DEN_CELL := Vector2i(10, 20)
+const DEN_BLOCK_WHIRLPOOL: int = 0x07
+const DEN_BLOCK_GONE: int = 0x36
+
+## Census of the real caches, pinned so a cache change is loud. Every whirlpool
+## cell in all three cartridges sits on TILESET_JOHTO block $07, so all of them
+## resolve; the maps are Dragon's Den B1F, Route 41 and Route 27.
+const EXPECTED_CENSUS: Dictionary = {
+	# game id: [whirlpool cells, cells resolving to a replacement, maps]
+	&"gold": [6, 6, 3],
+	&"silver": [6, 6, 3],
+	&"crystal": [6, 6, 3],
+}
+
+## .CheckTile's warp branch forces DOWN off door, staircase and cave tiles, and
+## .DoStep never checks permissions, so the handful of cells with no walkable
+## ground below are pinned rather than special-cased. All of them are on a map's
+## bottom edge except Route 34's, which has COLL_WALL below it.
+const EXPECTED_WARP_STEP_CENSUS: Dictionary = {
+	# game id: [warp-family cells, cells with no walkable cell below]
+	&"gold": [356, 2],
+	&"silver": [356, 2],
+	&"crystal": [387, 4],
+}
+
+## The only forced-tile families any pinned cartridge ships. The forced-walk
+## tables ($40-$47, $50-$57) and the second whirlpool code ($2c) are implemented
+## from the source table but unused, like the $a8-$af ledge alias.
+const EXPECTED_FORCED_CODES: Dictionary = {
+	&"gold": {0x24: 6, 0x33: 164, 0x71: 234, 0x7A: 74, 0x7B: 48},
+	&"silver": {0x24: 6, 0x33: 164, 0x71: 234, 0x7A: 74, 0x7B: 48},
+	&"crystal": {0x24: 6, 0x33: 164, 0x71: 257, 0x7A: 78, 0x7B: 52},
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_census(game_id, data)
+		_verify_dragons_den(game_id, data, Gen2WorldState.is_crystal_profile(data))
+	_finish()
+
+
+## Counts every cell .CheckTile or Whirlpool acts on, so a cache change that moves
+## a block or a collision code is loud rather than quietly reopening a route.
+func _census(game_id: StringName, data: GameData) -> void:
+	var whirlpool_cells: int = 0
+	var resolved_cells: int = 0
+	var whirlpool_maps: Dictionary = {}
+	var forced_codes: Dictionary = {}
+	var warp_step_cells: int = 0
+	var warp_step_blocked: int = 0
+	for map: Gen2WorldMap in data.world_maps():
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				var code: int = map.collision_at(x, y)
+				var forced: Dictionary = Gen2WorldCollision.forced_action(code)
+				if StringName(forced.get("kind", &"none")) != &"none":
+					forced_codes[code] = int(forced_codes.get(code, 0)) + 1
+				if Gen2WorldCollision.WARP_STEP_CODES.has(code):
+					warp_step_cells += 1
+					var below: int = map.collision_at(x, y + 1) if y + 1 < map.collision_height else -1
+					if not Gen2WorldCollision.is_walkable(below):
+						warp_step_blocked += 1
+				if not Gen2WorldFieldMove.whirlpool_tile(code):
+					continue
+				whirlpool_cells += 1
+				if bool(Gen2WorldFieldMove.whirlpool_replacement(
+					map.tileset, map.block_at(x >> 1, y >> 1)
+				).get("ok", false)):
+					resolved_cells += 1
+					whirlpool_maps[Vector2i(map.group, map.number)] = true
+
+	var counts: Array = [whirlpool_cells, resolved_cells, whirlpool_maps.size()]
+	print("%s: %d whirlpool cells, %d resolving to a replacement across %d maps." % [
+		game_id, counts[0], counts[1], counts[2],
+	])
+	_check(
+		counts == EXPECTED_CENSUS.get(game_id, []),
+		"%s: whirlpool census is %s, not the pinned %s." % [
+			game_id, counts, EXPECTED_CENSUS.get(game_id, []),
+		]
+	)
+
+	var warp_counts: Array = [warp_step_cells, warp_step_blocked]
+	print("%s: %d door/staircase/cave cells, %d with no walkable cell below." % [
+		game_id, warp_counts[0], warp_counts[1],
+	])
+	_check(
+		warp_counts == EXPECTED_WARP_STEP_CENSUS.get(game_id, []),
+		"%s: forced-step census is %s, not the pinned %s." % [
+			game_id, warp_counts, EXPECTED_WARP_STEP_CENSUS.get(game_id, []),
+		]
+	)
+	_check(
+		forced_codes == EXPECTED_FORCED_CODES.get(game_id, {}),
+		"%s: forced-tile codes are %s, not the pinned %s." % [
+			game_id, forced_codes, EXPECTED_FORCED_CODES.get(game_id, {}),
+		]
+	)
+
+
+func _verify_dragons_den(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var number: int = DEN_NUMBER_CRYSTAL if crystal else DEN_NUMBER_GOLD_SILVER
+	var badge: int = Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_GLACIER, crystal)
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(badge)
+	var approach: Vector2i = DEN_CELL + Vector2i.UP
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, DEN_GROUP, number, approach, state)
+	if not _check(
+		world != null, "%s: Dragon's Den B1F %d/%d is missing." % [game_id, DEN_GROUP, number]
+	):
+		return
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+
+	_check(
+		world.current_map.tileset == Gen2WorldFieldMove.TILESET_JOHTO,
+		"%s: Dragon's Den B1F is tileset %d, not JOHTO." % [game_id, world.current_map.tileset]
+	)
+	_check(
+		world.block_at(DEN_BLOCK.x, DEN_BLOCK.y) == DEN_BLOCK_WHIRLPOOL,
+		"%s: Dragon's Den block %s is $%02X, not $%02X." % [
+			game_id, DEN_BLOCK, world.block_at(DEN_BLOCK.x, DEN_BLOCK.y), DEN_BLOCK_WHIRLPOOL,
+		]
+	)
+	_check(
+		world.collision_code_at(DEN_CELL) == Gen2WorldCollision.COLL_WHIRLPOOL,
+		"%s: Dragon's Den %s is $%02X, not COLL_WHIRLPOOL." % [
+			game_id, DEN_CELL, world.collision_code_at(DEN_CELL),
+		]
+	)
+
+	# .CheckSurfable reads the permission with TALK masked off, so the whirlpool
+	# is water and a surfing player swims onto it. .CheckTile then traps them:
+	# Script_ForcedMovement only spins the player around.
+	_check(
+		bool(world.move_result(Vector2i.DOWN).get("ok", false))
+			and world.player_cell == DEN_CELL,
+		"%s: Dragon's Den whirlpool refused a surfing step onto it." % game_id
+	)
+	var spun: Dictionary = world.move_result(Vector2i.DOWN)
+	_check(
+		StringName(spun.get("kind", &"")) == &"forced_turn"
+			and world.player_cell == DEN_CELL
+			and world.player_facing == Gen2WorldSprite.FACING_UP,
+		"%s: Dragon's Den whirlpool did not spin the player in place: %s." % [
+			game_id, JSON.stringify(spun),
+		]
+	)
+
+	world.player_cell = approach
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var staged: Dictionary = world.whirlpool_request()
+	if not _check(
+		bool(staged.get("ok", false)),
+		"%s: Dragon's Den refused Whirlpool: %s." % [game_id, staged.get("reason", "unknown")]
+	):
+		return
+	_check(
+		int(staged.get("block", -1)) == DEN_BLOCK_GONE
+			and staged.get("block_cell", Vector2i.ZERO) == DEN_BLOCK,
+		"%s: Dragon's Den staged %s, not block $%02X at %s." % [
+			game_id, JSON.stringify(staged), DEN_BLOCK_GONE, DEN_BLOCK,
+		]
+	)
+	# Script_UsedWhirlpool reaches DisappearWhirlpool only after UseWhirlpoolText.
+	_check(
+		world.block_at(DEN_BLOCK.x, DEN_BLOCK.y) == DEN_BLOCK_WHIRLPOOL
+			and world.collision_code_at(DEN_CELL) == Gen2WorldCollision.COLL_WHIRLPOOL,
+		"%s: Dragon's Den changed before the whirlpool was committed." % game_id
+	)
+
+	_check(
+		bool(world.complete_whirlpool().get("ok", false)),
+		"%s: Dragon's Den whirlpool did not commit." % game_id
+	)
+	_check(
+		world.block_at(DEN_BLOCK.x, DEN_BLOCK.y) == DEN_BLOCK_GONE,
+		"%s: Dragon's Den block is $%02X after the whirlpool." % [
+			game_id, world.block_at(DEN_BLOCK.x, DEN_BLOCK.y),
+		]
+	)
+	_check(
+		StringName(Gen2WorldCollision.forced_action(
+			world.collision_code_at(DEN_CELL)
+		)["kind"]) == &"none",
+		"%s: Dragon's Den %s still forces movement after the whirlpool." % [game_id, DEN_CELL]
+	)
+	_check(
+		bool(world.move_result(Vector2i.DOWN).get("ok", false))
+			and world.player_cell == DEN_CELL,
+		"%s: Dragon's Den %s is still trapped after the whirlpool." % [game_id, DEN_CELL]
+	)
+	print("%s: Dragon's Den B1F %d/%d %s $%02X -> $%02X, cell %s freed." % [
+		game_id, DEN_GROUP, number, DEN_BLOCK, DEN_BLOCK_WHIRLPOOL, DEN_BLOCK_GONE, DEN_CELL,
+	])
+
+	# DisappearWhirlpool only writes wOverworldMapBlocks, which a map load re-reads
+	# from ROM, so the whirlpool is back on the next visit.
+	world.reload_current_map()
+	_check(
+		world.block_at(DEN_BLOCK.x, DEN_BLOCK.y) == DEN_BLOCK_WHIRLPOOL
+			and world.collision_code_at(DEN_CELL) == Gen2WorldCollision.COLL_WHIRLPOOL,
+		"%s: Dragon's Den whirlpool did not return on a map reload." % game_id
+	)
+
+	# .TryWhirlpool tests the badge before the tile, on whichever engine flag table
+	# this profile numbers ENGINE_GLACIERBADGE on.
+	var unbadged: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, DEN_GROUP, number, approach, Gen2WorldState.new()
+	)
+	unbadged.player_facing = Gen2WorldSprite.FACING_DOWN
+	_check(
+		StringName(unbadged.whirlpool_request().get("reason", &"")) == &"badge_required",
+		"%s: Dragon's Den allowed Whirlpool without engine flag %d." % [game_id, badge]
+	)
+	var wrong := Gen2WorldState.new()
+	wrong.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_GLACIER, not crystal))
+	var wrong_world: Gen2WorldAPI = Gen2WorldAPI.open(data, DEN_GROUP, number, approach, wrong)
+	wrong_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_check(
+		StringName(wrong_world.whirlpool_request().get("reason", &"")) == &"badge_required",
+		"%s: Dragon's Den accepted the other profile's Glacier Badge flag." % game_id
+	)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS whirlpool: block table, forced-tile census and Dragon's Den verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_whirlpool.gd.uid
+++ b/tools/validate_whirlpool.gd.uid
@@ -1,0 +1,1 @@
+uid://dyviu0jrurs75


### PR DESCRIPTION
A whirlpool never stopped anyone: COLL_WHIRLPOOL is WATER_TILE | TALK, and .CheckSurfable reads the permission with TALK already masked off, so a surfing player swam over all six cells and straight off again. The same held for the 164 COLL_WATERFALL cells. What stops them on the cartridge is DoPlayerMovement.CheckTile, which had no counterpart here.

Gen2WorldCollision.forced_action() is that routine, branch for branch: the two whirlpool codes force a turn, $30-$3f index .water_table through a two-bit mask, $40-$47 and $50-$57 index the two forced-walk tables through a three-bit one, and only COLL_DOOR, COLL_DOOR_79, COLL_STAIRCASE and COLL_CAVE force DOWN out of the $7x range. move_result() reads it before anything else and discards the pressed direction, since .CheckTile runs ahead of .CheckTurning and .TryStep/.TrySurf. A forced walk stays an ordinary step for repel, warps and encounters but skips the permission check and never runs .ExitWater, because .DoStep does neither; four Crystal door cells and two Gold/Silver ones have no walkable cell below them, and the validator pins that rather than special-casing it.

PLAYERMOVEMENT_FORCE_TURN queues Script_ForcedMovement, whose four streams are step_dig, turn_in and turn_head, none of which moves a cell: the player is spun to face the way they came and cannot walk off. The screen answers that on the movement attempt rather than per frame, because the source's spin is paced by two step_dig runs this project does not render.

Whirlpool itself is Cut with one row. WhirlpoolBlockPointers names TILESET_JOHTO alone, block $07 to $36, and is byte identical between the pins, so nothing here is profile split. whirlpool_request() follows .TryWhirlpool, badge before tile, and checks no player state because the source checks none. The refusal is FieldMoveFailed's generic text, not a move-specific line the way Cut's is, and PlayWhirlpoolSound plays SFX_SURF.

Also fixed in passing: validate_side_walls.gd asserted that Celadon Mansion Roof's staircase landing blocks entering the fence beside it. That cell is COLL_STAIRCASE, so .CheckTile forces the player off it before the enter rule is ever reached; the check now tests can_walk_to() directly and pins the forced step beside it.

tools/validate_whirlpool.gd pins the whirlpool and forced-tile censuses and drives Dragon's Den B1F against all three real caches.