### PR TITLE
Use an item from the pack, and let a mod add a menu entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ for a fallback pairing.
 
 The world screen's start menu wires Pokemon, Pack, Pokegear, Save and Exit;
 Pokedex, Player and Options appear in their source position but do nothing yet.
+The Pack opens each item's own source submenu and can use one: a Potion asks
+which Pokemon and heals it, a Repel sets its step count, and GIVE, TOSS and SEL
+keep their source position marked unavailable.
 The party submenu offers Cut, Surf and Whirlpool to a Pokemon that knows one; all
 three show their message first and change the world on the acknowledge, and
 stepping from water back onto land stops surfing. Standing on a whirlpool,

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -281,10 +281,36 @@ What is still missing, in the order it blocks work:
 All three are presentation boundaries that do not exist yet; none of them
 changes the world's own data.
 
+## Adding a menu entry
+
+`register_menu_entry(menu, id, entry)` appends to a menu the game builds. The
+cartridge's own entries are never registered, so a mod can add but not reorder
+or remove them.
+
+| Menu | Where the entry lands | `entry` keys |
+|---|---|---|
+| `Gen2ModHost.MENU_START` | the start menu, immediately before EXIT | `label`, optional `handler: Callable` |
+| `Gen2ModHost.MENU_PACK_POCKET` | after the pack's four source pockets | `label`, `pocket` |
+
+```gdscript
+func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
+	host.register_menu_entry(Gen2ModHost.MENU_START, manifest.id, {
+		"label": "Atlas",
+		"handler": func() -> void: print("opened"),
+	})
+```
+
+A start-menu entry without a handler still appears, marked unavailable, which is
+what Pokedex, Player and Options already do. A pocket's number has to be at or
+above `Gen2ModHost.FIRST_MOD_POCKET`: 1 to 4 are the cartridge's ITEM, KEY_ITEM,
+BALL and TM_HM, and an item joins the pocket its own definition names. Two mods
+claiming the same entry id is refused with `duplicate_menu_entry` rather than one
+silently winning.
+
 ## Not built yet
 
 Semver ranges and inter-mod dependencies, per-mod save data, hooks beyond the
-renderer, and `.zip`/`.pck` packs through
+renderer and menu entries, and `.zip`/`.pck` packs through
 `ProjectSettings.load_resource_pack()`. Evaluate
 [godot-mod-loader](https://github.com/GodotModding/godot-mod-loader) before
 expanding the loader itself.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -155,10 +155,13 @@ const ITEM_ATTRIBUTE_HELP: int = 6
 ## The item attribute table calls this field a pocket, but its value is the
 ## cartridge's item type: ITEM=1, KEY_ITEM=2, BALL=3, TM_HM=4.
 const ITEM_POCKET_BALL: int = 3
+const ITEMMENU_NOUSE: int = 0
 const ITEMMENU_CURRENT: int = 4
 const ITEMMENU_PARTY: int = 5
 const ITEMMENU_CLOSE: int = 6
+## Both permission bits read inverted: a set bit is what the item cannot do.
 const ITEM_ATTRIBUTE_CANT_SELECT: int = 1 << 6
+const ITEM_ATTRIBUTE_CANT_TOSS: int = 1 << 7
 const TRADE_RECORD_SIZE: int = 32
 const TRADE_NAME_LENGTH: int = 11
 const TRADE_GENDER_EITHER: int = 0

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -63,6 +63,18 @@ const RENDERER_INPUT_METHOD: String = "handle_world_input"
 ## renderer kinds.
 const BUILT_IN_RENDERER: StringName = &"gen2"
 
+## The menus a mod may append an entry to. The cartridge's own entries are not
+## registered here: they live in Gen2WorldStartMenu and Gen2WorldPack, which
+## build their source list first and then append whatever is registered, so a
+## mod can only add and never reorder or remove what the game shipped.
+const MENU_START: StringName = &"start_menu"
+const MENU_PACK_POCKET: StringName = &"pack_pocket"
+const MENU_IDS: Array[StringName] = [MENU_START, MENU_PACK_POCKET]
+## Pocket type numbers 1 to 4 are the cartridge's ITEM, KEY_ITEM, BALL and TM_HM,
+## so a registered pocket has to claim a number above them, the same reservation
+## the content overlay will need for species and item numbers.
+const FIRST_MOD_POCKET: int = 5
+
 static var _instance: Gen2ModHost = null
 
 var _manifests: Dictionary = {}
@@ -70,6 +82,7 @@ var _world_renderers: Dictionary = {}
 var _selected_world_renderer: StringName = BUILT_IN_RENDERER
 var _battle_renderers: Dictionary = {}
 var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
+var _menu_entries: Dictionary = {}
 var _failures: Array = []
 
 
@@ -164,6 +177,49 @@ func select_battle_renderer(id: StringName) -> Dictionary:
 ## built-in one so a screen always has something to draw with.
 func create_battle_renderer() -> Node:
 	return _create(_battle_renderers, _selected_battle_renderer, Gen2BattleRenderer)
+
+
+## Adds one entry to [param menu]. [param entry] needs a [code]label[/code]; the
+## start menu takes an optional [code]handler[/code] Callable the screen calls
+## when the entry is chosen, and a pack pocket needs a [code]pocket[/code] type
+## number at or above [constant FIRST_MOD_POCKET], which is the number its items
+## carry in their own definitions.
+##
+## An entry without a handler still appears, marked unavailable, which is what
+## every unimplemented cartridge entry already does.
+func register_menu_entry(menu: StringName, id: StringName, entry: Dictionary) -> Dictionary:
+	if not MENU_IDS.has(menu):
+		return {"ok": false, "reason": &"unknown_menu", "detail": String(menu)}
+	if String(id).is_empty():
+		return {"ok": false, "reason": &"invalid_menu_entry", "detail": String(menu)}
+	var label: String = String(entry.get("label", ""))
+	if label.is_empty():
+		return {"ok": false, "reason": &"menu_entry_missing_label", "detail": String(id)}
+	var registered: Dictionary = {"kind": id, "label": label}
+	if menu == MENU_PACK_POCKET:
+		var pocket: int = int(entry.get("pocket", 0))
+		if pocket < FIRST_MOD_POCKET:
+			return {"ok": false, "reason": &"reserved_pocket", "detail": String(id)}
+		registered["pocket"] = pocket
+	else:
+		var handler: Variant = entry.get("handler", null)
+		registered["available"] = handler is Callable and (handler as Callable).is_valid()
+		if bool(registered["available"]):
+			registered["handler"] = handler
+	var entries: Array = _menu_entries.get(menu, [])
+	for existing: Dictionary in entries:
+		if StringName(existing.get("kind", &"")) == id:
+			return {"ok": false, "reason": &"duplicate_menu_entry", "detail": String(id)}
+	entries.append(registered)
+	_menu_entries[menu] = entries
+	return {"ok": true, "id": id}
+
+
+## Every entry registered for [param menu], in registration order. The callers
+## append these to their own source list rather than the other way round.
+func menu_entries(menu: StringName) -> Array:
+	var entries: Array = _menu_entries.get(menu, [])
+	return entries.duplicate(true)
 
 
 func _register(

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -16,7 +16,11 @@ signal action_chosen(kind: StringName)
 ## Emitted on Exit or cancel from the top-level list.
 signal closed
 
-enum Mode { LIST, PACK, SAVE_CONFIRM }
+enum Mode { LIST, PACK, PACK_ITEM, PACK_TARGET, PACK_RESULT, SAVE_CONFIRM }
+
+## engine/items/pack.asm's own refusal texts, verbatim from data/text/common_2.asm.
+const OAK_TEXT: String = "OAK: This isn't the time to use that!"
+const NO_MON_TEXT: String = "You don't have a #MON!"
 
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#4f6f9e")
@@ -36,6 +40,13 @@ var _menu: Gen2WorldStartMenu = null
 var _pack_pockets: Array = []
 var _pack_pocket_index: int = 0
 var _pack_cursor: int = 0
+var _pack_save: Gen2SaveData = null
+var _pack_persist: bool = true
+var _item_actions: Array = []
+var _item_cursor: int = 0
+var _target_cursor: int = 0
+var _pack_result: String = ""
+var _pack_result_ok: bool = false
 
 var _save_cursor: int = 0
 var _save_result_shown: bool = false
@@ -73,6 +84,18 @@ func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_c
 	if is_inside_tree() and _options != null:
 		_open_list_mode()
 	return true
+
+
+## The save the pack's USE applies to, and whether that write reaches disk.
+## Optional: without it the pack still lists items and refuses to use one, which
+## is what a screenshot tool driving an injected world gets.
+##
+## Passed rather than wrapped in a Callable the way `save_action` is, because
+## using an item is a Gen2WorldPartyHost transaction over this same save, not a
+## world-snapshot write only the world screen knows how to do.
+func set_party_context(save: Gen2SaveData, persist: bool = true) -> void:
+	_pack_save = save
+	_pack_persist = persist
 
 
 ## The list model's cursor, so a caller can carry it into the next open() the
@@ -116,6 +139,16 @@ func _move(direction: Vector2i) -> void:
 				_cycle_pocket(direction.x)
 			elif direction.y != 0:
 				_move_pack_cursor(direction.y)
+		Mode.PACK_ITEM:
+			if direction.y != 0 and not _item_actions.is_empty():
+				_item_cursor = wrapi(_item_cursor + signi(direction.y), 0, _item_actions.size())
+				_render_item_menu()
+		Mode.PACK_TARGET:
+			if direction.y != 0 and not _party_targets().is_empty():
+				_target_cursor = wrapi(
+					_target_cursor + signi(direction.y), 0, _party_targets().size()
+				)
+				_render_targets()
 		Mode.SAVE_CONFIRM:
 			if not _save_result_shown and (direction.x != 0 or direction.y != 0):
 				_save_cursor = 1 - _save_cursor
@@ -128,8 +161,13 @@ func _confirm() -> void:
 			_confirm_list()
 		Mode.PACK:
 			if not _current_pocket_items().is_empty():
-				_status.text = "Items cannot be used from the Pack yet."
-				_status.add_theme_color_override("font_color", MUTED)
+				_open_item_mode()
+		Mode.PACK_ITEM:
+			_confirm_item_action()
+		Mode.PACK_TARGET:
+			_use_selected_item(_target_cursor)
+		Mode.PACK_RESULT:
+			_open_pack_mode(false)
 		Mode.SAVE_CONFIRM:
 			_confirm_save()
 
@@ -140,6 +178,10 @@ func _cancel() -> void:
 			closed.emit()
 		Mode.PACK:
 			_open_list_mode()
+		Mode.PACK_ITEM, Mode.PACK_RESULT:
+			_open_pack_mode(false)
+		Mode.PACK_TARGET:
+			_open_item_mode()
 		Mode.SAVE_CONFIRM:
 			_open_list_mode()
 
@@ -160,6 +202,12 @@ func _confirm_list() -> void:
 			closed.emit()
 		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_POKEGEAR:
 			action_chosen.emit(_menu.selected_kind())
+		_:
+			# A Gen2ModHost-registered entry. Its handler is what made it
+			# available at all, so this cannot reach an entry without one.
+			var handler: Variant = _menu.selected_item().get("handler", null)
+			if handler is Callable:
+				(handler as Callable).call()
 
 
 func _open_list_mode() -> void:
@@ -180,13 +228,19 @@ func _render_list() -> void:
 	)
 
 
-func _open_pack_mode() -> void:
+## [param reset] false keeps the pocket and cursor, which is what returning from
+## an item submenu does; the source restores each pocket's own saved cursor the
+## same way. The item list is always rebuilt, since a USE changed a quantity.
+func _open_pack_mode(reset: bool = true) -> void:
 	_mode = Mode.PACK
 	_pack_pockets = Gen2WorldPack.build(_data, _world.state) if _world != null else []
-	_pack_pocket_index = 0
-	_pack_cursor = 0
+	if reset:
+		_pack_pocket_index = 0
+		_pack_cursor = 0
+	_pack_pocket_index = clampi(_pack_pocket_index, 0, maxi(_pack_pockets.size() - 1, 0))
+	_pack_cursor = clampi(_pack_cursor, 0, maxi(_current_pocket_items().size() - 1, 0))
 	_status.text = ""
-	_footer.text = "Left/Right: pocket    Up/Down: move    Esc: back"
+	_footer.text = "Left/Right: pocket    Up/Down: move    Space/Enter: choose    Esc: back"
 	_render_pack()
 
 
@@ -227,6 +281,173 @@ func _render_pack() -> void:
 	_render_options(items, _pack_cursor, func(entry: Dictionary) -> String:
 		return "%s    x%d" % [entry.get("name", "UNKNOWN"), int(entry.get("quantity", 0))]
 	)
+
+
+func _selected_item() -> Dictionary:
+	var items: Array = _current_pocket_items()
+	if _pack_cursor < 0 or _pack_cursor >= items.size():
+		return {}
+	return items[_pack_cursor]
+
+
+## `.ItemBallsKey_LoadSubmenu` and `.TMHMPocketMenu` both open a submenu on the
+## selected item rather than acting on it directly.
+func _open_item_mode() -> void:
+	var item: Dictionary = _selected_item()
+	if item.is_empty():
+		return
+	_mode = Mode.PACK_ITEM
+	_item_actions = Gen2WorldPack.item_submenu(_data, int(item.get("item", 0)))
+	_item_cursor = 0
+	_status.text = ""
+	_summary.text = String(item.get("name", ""))
+	_footer.text = "Up/Down: move    Space/Enter: choose    Esc: back"
+	_render_item_menu()
+
+
+func _render_item_menu() -> void:
+	_title.text = "PACK"
+	_render_options(_item_actions, _item_cursor, func(entry: Dictionary) -> String:
+		var label: String = String(entry.get("label", ""))
+		return label if bool(entry.get("available", false)) else "%s (unavailable)" % label
+	)
+
+
+func _confirm_item_action() -> void:
+	if _item_cursor < 0 or _item_cursor >= _item_actions.size():
+		return
+	var entry: Dictionary = _item_actions[_item_cursor]
+	var action: StringName = StringName(entry.get("action", &""))
+	if action == Gen2WorldPack.ACTION_QUIT:
+		_open_pack_mode(false)
+		return
+	if not bool(entry.get("available", false)):
+		_status.text = "%s is not available yet." % String(entry.get("label", ""))
+		_status.add_theme_color_override("font_color", MUTED)
+		return
+	_confirm_use()
+
+
+## `UseItem`'s jumptable: `.Oak` refuses, `.Current` and `.Field` apply straight
+## away, and `.Party` asks which Pokemon first. `.Field`'s extra
+## `PACKSTATE_QUITRUNSCRIPT` on success has no counterpart yet, because no
+## `ITEMMENU_CLOSE` item has an effect here: Escape Rope and Dig need the spawn
+## warp, so every one of them reaches `.Oak`'s refusal instead.
+func _confirm_use() -> void:
+	var item: Dictionary = _selected_item()
+	if item.is_empty():
+		return
+	match Gen2WorldPack.field_use_kind(_data, int(item.get("item", 0))):
+		Gen2WorldPack.ITEMMENU_PARTY:
+			if _party_targets().is_empty():
+				_show_pack_result(NO_MON_TEXT, false)
+				return
+			_open_target_mode()
+		Gen2WorldPack.ITEMMENU_CURRENT, Gen2WorldPack.ITEMMENU_CLOSE:
+			_use_selected_item(-1)
+		_:
+			_show_pack_result(OAK_TEXT, false)
+
+
+## `.Party`'s party list. Reads the same save the USE will be applied to, so a
+## screen without one offers no targets and answers `.NoPokemon`.
+func _party_targets() -> Array:
+	if _pack_save == null:
+		return []
+	var targets: Array = []
+	for member: Variant in _pack_save.party:
+		var mon: Gen2SaveMon = member as Gen2SaveMon
+		if mon == null:
+			continue
+		# Max HP is derived, not stored, the same way Gen2PartyScreen derives it.
+		var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
+		targets.append({
+			"name": mon.nickname if not mon.nickname.is_empty() \
+				else String(_data.species(mon.species).get("name", "UNKNOWN")),
+			"hp": mon.hp,
+			"max_hp": battle_mon.max_hp() if battle_mon != null else 0,
+			"egg": mon.is_egg,
+		})
+	return targets
+
+
+func _open_target_mode() -> void:
+	_mode = Mode.PACK_TARGET
+	_target_cursor = clampi(_target_cursor, 0, maxi(_party_targets().size() - 1, 0))
+	_status.text = ""
+	_footer.text = "Up/Down: move    Space/Enter: use    Esc: back"
+	_render_targets()
+
+
+func _render_targets() -> void:
+	_title.text = "USE ON"
+	_summary.text = String(_selected_item().get("name", ""))
+	_render_options(_party_targets(), 0 if _party_targets().is_empty() else _target_cursor,
+		func(entry: Dictionary) -> String:
+			if bool(entry.get("egg", false)):
+				return "%s    EGG" % String(entry.get("name", ""))
+			return "%s    %d/%d HP" % [
+				String(entry.get("name", "")), int(entry.get("hp", 0)),
+				int(entry.get("max_hp", 0)),
+			]
+	)
+
+
+func _use_selected_item(party_index: int) -> void:
+	var item: Dictionary = _selected_item()
+	if item.is_empty():
+		return
+	if _pack_save == null or _world == null:
+		_show_pack_result("No save is loaded.", false)
+		return
+	var number: int = int(item.get("item", 0))
+	var result: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _pack_save, number, party_index, _pack_persist
+	)
+	if not bool(result.get("ok", false)):
+		_show_pack_result(_use_refusal(StringName(result.get("reason", &""))), false)
+		return
+	_show_pack_result(_use_summary(item, result), true)
+
+
+## The source has no single "it worked" line: the effect routine prints its own.
+## These name what changed, from the values Gen2WorldPartyHost already returns.
+func _use_summary(item: Dictionary, result: Dictionary) -> String:
+	var name: String = String(item.get("name", "ITEM"))
+	if int(result.get("repel_steps", -1)) >= 0:
+		return "%s will repel weak Pokemon for %d steps." % [
+			name, int(result.get("repel_steps", 0)),
+		]
+	var healed: int = int(result.get("healed", 0))
+	if healed > 0:
+		return "%s restored %d HP." % [name, healed]
+	if int(result.get("status_cleared", 0)) != 0:
+		return "%s cured the status." % name
+	return "%s was used." % name
+
+
+func _use_refusal(reason: StringName) -> String:
+	match reason:
+		&"item_has_no_effect":
+			return "It won't have any effect."
+		&"insufficient_item_quantity":
+			return "You have none of those."
+	return "Can't use that here: %s" % String(reason)
+
+
+func _show_pack_result(message: String, ok: bool) -> void:
+	_mode = Mode.PACK_RESULT
+	_pack_result = message
+	_pack_result_ok = ok
+	_footer.text = "Space/Enter: continue"
+	_render_pack_result()
+
+
+func _render_pack_result() -> void:
+	_title.text = "PACK"
+	_status.text = _pack_result
+	_status.add_theme_color_override("font_color", SUCCESS if _pack_result_ok else MUTED)
+	_render_options(["Continue"], 0, func(entry: Variant) -> String: return str(entry))
 
 
 func _open_save_confirm_mode() -> void:

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -12,6 +12,9 @@ extends RefCounted
 ## Source capacities (`MAX_ITEMS` 20, `MAX_BALLS` 12, `MAX_KEY_ITEMS` 25,
 ## `MAX_PC_ITEMS` 50) are recorded but not enforced, since enforcing them would
 ## change the save's item storage shape.
+##
+## Pockets registered on `Gen2ModHost` follow the four source ones, and the item
+## submenu below is `engine/items/pack.asm`'s own header selection.
 
 const TYPE_ITEM: int = 1
 const TYPE_KEY_ITEM: int = 2
@@ -34,6 +37,59 @@ const POCKET_NAMES: Dictionary = {
 	TYPE_TM_HM: "TMs/HMs",
 }
 
+## `ITEMATTR_PERMISSIONS` bits and the field-menu nibble `CheckItemMenu` returns,
+## named here in this file's own terms but valued from the import layer, so the
+## numbers stay defined once. A set permission bit is what the item *cannot* do,
+## which is why the source's own branch labels around
+## `.ItemBallsKey_LoadSubmenu` read backwards.
+const CANT_SELECT: int = RomLayout.ITEM_ATTRIBUTE_CANT_SELECT
+const CANT_TOSS: int = RomLayout.ITEM_ATTRIBUTE_CANT_TOSS
+const ITEMMENU_NOUSE: int = RomLayout.ITEMMENU_NOUSE
+const ITEMMENU_CURRENT: int = RomLayout.ITEMMENU_CURRENT
+const ITEMMENU_PARTY: int = RomLayout.ITEMMENU_PARTY
+const ITEMMENU_CLOSE: int = RomLayout.ITEMMENU_CLOSE
+
+const ACTION_USE: StringName = &"use"
+const ACTION_GIVE: StringName = &"give"
+const ACTION_TOSS: StringName = &"toss"
+const ACTION_SELECT: StringName = &"select"
+const ACTION_QUIT: StringName = &"quit"
+
+## The six field submenu headers `.ItemBallsKey_LoadSubmenu` chooses between,
+## plus the TM/HM pocket's own two. Keyed by [can toss, can select, can use] for
+## the first six; the header names in the source are as inverted as its branch
+## labels, so the action lists are what to read here, not the names.
+const SUBMENU_USE_GIVE_TOSS_SELECT_QUIT: Array[StringName] = [
+	ACTION_USE, ACTION_GIVE, ACTION_TOSS, ACTION_SELECT, ACTION_QUIT,
+]
+const SUBMENU_USE_GIVE_TOSS_QUIT: Array[StringName] = [
+	ACTION_USE, ACTION_GIVE, ACTION_TOSS, ACTION_QUIT,
+]
+const SUBMENU_GIVE_TOSS_SELECT_QUIT: Array[StringName] = [
+	ACTION_GIVE, ACTION_TOSS, ACTION_SELECT, ACTION_QUIT,
+]
+const SUBMENU_GIVE_TOSS_QUIT: Array[StringName] = [
+	ACTION_GIVE, ACTION_TOSS, ACTION_QUIT,
+]
+const SUBMENU_USE_SELECT_QUIT: Array[StringName] = [ACTION_USE, ACTION_SELECT, ACTION_QUIT]
+const SUBMENU_USE_QUIT: Array[StringName] = [ACTION_USE, ACTION_QUIT]
+const SUBMENU_TMHM_USE_GIVE_QUIT: Array[StringName] = [
+	ACTION_USE, ACTION_GIVE, ACTION_QUIT,
+]
+
+const ACTION_LABELS: Dictionary = {
+	ACTION_USE: "USE",
+	ACTION_GIVE: "GIVE",
+	ACTION_TOSS: "TOSS",
+	ACTION_SELECT: "SEL",
+	ACTION_QUIT: "QUIT",
+}
+
+## GIVE needs a held-item model, TOSS a quantity prompt and SEL the Select-button
+## registration; none exists yet, so all three keep their source position and are
+## marked unavailable, the way the party submenu carries STATS, SWITCH and MOVE.
+const IMPLEMENTED_ACTIONS: Array[StringName] = [ACTION_USE, ACTION_QUIT]
+
 
 ## One entry per pocket in source display order, each carrying only the items
 ## currently owned in that pocket. An unknown item number, or a quantity of
@@ -43,7 +99,7 @@ static func build(data: GameData, state: Gen2WorldState) -> Array:
 	if data == null or state == null:
 		return pockets
 	var owned: Dictionary = state.items()
-	for pocket_type: int in POCKET_ORDER:
+	for pocket_type: int in pocket_order():
 		var pocket_items: Array = []
 		var item_numbers: Array = owned.keys()
 		item_numbers.sort()
@@ -63,10 +119,76 @@ static func build(data: GameData, state: Gen2WorldState) -> Array:
 			})
 		pockets.append({
 			"pocket": pocket_type,
-			"name": String(POCKET_NAMES.get(pocket_type, "")),
+			"name": pocket_name(pocket_type),
 			"items": pocket_items,
 		})
 	return pockets
+
+
+## The source pocket cycle followed by whatever a mod registered, so a mod pocket
+## is reached by continuing right past TMs/HMs rather than displacing a
+## cartridge one.
+static func pocket_order() -> Array[int]:
+	var order: Array[int] = POCKET_ORDER.duplicate()
+	for entry: Dictionary in Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_PACK_POCKET):
+		var pocket: int = int(entry.get("pocket", 0))
+		if pocket > 0 and not order.has(pocket):
+			order.append(pocket)
+	return order
+
+
+static func pocket_name(pocket_type: int) -> String:
+	if POCKET_NAMES.has(pocket_type):
+		return String(POCKET_NAMES[pocket_type])
+	for entry: Dictionary in Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_PACK_POCKET):
+		if int(entry.get("pocket", 0)) == pocket_type:
+			return String(entry.get("label", ""))
+	return ""
+
+
+## `.ItemBallsKey_LoadSubmenu` and `.TMHMPocketMenu`'s own two-way split, as the
+## action list the chosen header carries. The three checks the source makes are
+## all inverted, so this reads them once into positive terms and branches in the
+## source's order: tossable first, then selectable, then usable.
+static func item_submenu(data: GameData, item: int) -> Array:
+	if data == null:
+		return []
+	var definition: Dictionary = data.item(item)
+	if definition.is_empty():
+		return []
+	var permissions: int = int(definition.get("permissions", 0))
+	var can_toss: bool = (permissions & CANT_TOSS) == 0
+	var can_select: bool = (permissions & CANT_SELECT) == 0
+	# CheckItemMenu tests the nibble against zero, not against ITEMMENU_CURRENT,
+	# so a value of 1 to 3 would offer USE and then reach .Oak's refusal. No
+	# cartridge item carries one; all 256 rows are NOUSE, CURRENT, PARTY or CLOSE.
+	var can_use: bool = int(definition.get("field_menu", 0)) != 0
+	var actions: Array[StringName] = SUBMENU_USE_QUIT
+	if int(definition.get("pocket", 0)) == TYPE_TM_HM:
+		actions = SUBMENU_USE_QUIT if not can_toss else SUBMENU_TMHM_USE_GIVE_QUIT
+	elif not can_toss:
+		actions = SUBMENU_USE_QUIT if not can_select else SUBMENU_USE_SELECT_QUIT
+	elif not can_select:
+		actions = SUBMENU_USE_GIVE_TOSS_QUIT if can_use else SUBMENU_GIVE_TOSS_QUIT
+	else:
+		actions = SUBMENU_USE_GIVE_TOSS_SELECT_QUIT if can_use else SUBMENU_GIVE_TOSS_SELECT_QUIT
+	var entries: Array = []
+	for action: StringName in actions:
+		entries.append({
+			"action": action,
+			"label": String(ACTION_LABELS.get(action, "")),
+			"available": IMPLEMENTED_ACTIONS.has(action),
+		})
+	return entries
+
+
+## `UseItem`'s jumptable index: which of `.Oak`, `.Current`, `.Party` and
+## `.Field` a USE reaches. Everything below `ITEMMENU_CURRENT` is `.Oak`.
+static func field_use_kind(data: GameData, item: int) -> int:
+	if data == null:
+		return ITEMMENU_NOUSE
+	var menu: int = int(data.item(item).get("field_menu", 0))
+	return menu if menu >= ITEMMENU_CURRENT else ITEMMENU_NOUSE
 
 
 ## The pack pocket a cartridge item number belongs to, or 0 when the item is

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -8,6 +8,7 @@ extends RefCounted
 ## the candidate after both sides have succeeded. The six-party limit is
 ## deliberate until the save model has a real PC-box owner.
 
+const ITEM_POTION: int = 0x12
 const ITEM_REVIVE: int = 0x27
 const ITEM_MAX_REVIVE: int = 0x28
 const ITEM_REPEL: int = 0x14

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -747,14 +747,16 @@ func preview_party_transaction() -> void:
 		_refresh_labels()
 		return
 	preview_save.world = _world.snapshot()
-	var item_result: Dictionary = _world.state.apply_changes({}, {}, {"items": {0x12: 1}})
+	var item_result: Dictionary = _world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_POTION: 1}}
+	)
 	if not bool(item_result.get("ok", false)):
 		_script_prompt = "Party transaction preview unavailable"
 		_refresh_labels()
 		return
 	preview_save.party[0].hp = 1
 	var result: Dictionary = Gen2WorldPartyHost.use_item(
-		_world, preview_save, 0x12, 0, false
+		_world, preview_save, Gen2WorldPartyHost.ITEM_POTION, 0, false
 	)
 	var preview_caption: String = ""
 	if bool(result.get("ok", false)):
@@ -766,6 +768,31 @@ func preview_party_transaction() -> void:
 	_refresh_labels()
 	if not preview_caption.is_empty():
 		_caption.text = preview_caption
+
+
+## Public screenshot driver for the pack's item use. It grants a Potion and hurts
+## the first party member on an injected save, so nothing persists, then advances
+## one menu step per call: Pack, the item, USE, the target, the result.
+func preview_pack_use() -> void:
+	if _world == null or _data == null:
+		return
+	if _start_menu_host != null:
+		_start_menu_host.handle_key(KEY_SPACE)
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Pack preview needs a party"
+		_refresh_labels()
+		return
+	(save.party[0] as Gen2SaveMon).hp = 1
+	_injected_save = save
+	_world.state.apply_changes({}, {}, {"items": {Gen2WorldPartyHost.ITEM_POTION: 1}})
+	_open_start_menu()
+	if _start_menu_host == null:
+		return
+	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
+		_start_menu_host.handle_key(KEY_DOWN)
+	_start_menu_host.handle_key(KEY_SPACE)
 
 
 ## Public screenshot driver for the battle-request host path. It starts the
@@ -1197,6 +1224,12 @@ func _open_start_menu() -> void:
 		_script_prompt = "Start menu scene unavailable"
 		_refresh_labels()
 		return
+	# An injected save is a development or test one, so its item use stays in
+	# memory the same way preview_party_transaction() does.
+	host.set_party_context(
+		_injected_save if _injected_save != null else _selected_runtime_save(),
+		_injected_save == null
+	)
 	if not host.open(
 		_world, _data, Callable(self, "persist_world_snapshot"), _start_menu_cursor
 	):

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -13,6 +13,9 @@ extends RefCounted
 ## omitted, keeping the list shape stable for whichever arrives first. QUIT never
 ## appears because its Bug Contest and link-mode gate is never true here.
 ##
+## Entries registered on `Gen2ModHost` are spliced in ahead of EXIT, so a mod can
+## add a screen without reordering or removing anything the cartridge shipped.
+##
 ## `STATICMENU_WRAP` is source flag data on `.MenuData`, so the cursor wraps at
 ## both ends like a cached cartridge menu.
 
@@ -33,6 +36,27 @@ const ITEM_SAVE: StringName = &"save"
 const ITEM_OPTION: StringName = &"option"
 const ITEM_EXIT: StringName = &"exit"
 
+## What `SetUpMenuItems` gates each source entry on. An empty gate is always
+## appended, matching the entries the source adds unconditionally.
+const GATE_POKEDEX: StringName = &"pokedex"
+const GATE_PARTY: StringName = &"party"
+const GATE_POKEGEAR: StringName = &"pokegear"
+
+## `SetUpMenuItems` in source order, as data rather than a run of appends, so the
+## host's registered entries can be spliced in without the order becoming a
+## question. EXIT stays last: it is what closes the menu, and the source never
+## puts anything after it.
+const SOURCE_ENTRIES: Array[Dictionary] = [
+	{"kind": ITEM_POKEDEX, "label": "Pokedex", "available": false, "gate": GATE_POKEDEX},
+	{"kind": ITEM_POKEMON, "label": "Pokemon", "available": true, "gate": GATE_PARTY},
+	{"kind": ITEM_PACK, "label": "Pack", "available": true, "gate": &""},
+	{"kind": ITEM_POKEGEAR, "label": "Pokegear", "available": true, "gate": GATE_POKEGEAR},
+	{"kind": ITEM_PLAYER, "label": "Player", "available": false, "gate": &""},
+	{"kind": ITEM_SAVE, "label": "Save", "available": true, "gate": &""},
+	{"kind": ITEM_OPTION, "label": "Options", "available": false, "gate": &""},
+	{"kind": ITEM_EXIT, "label": "Exit", "available": true, "gate": &""},
+]
+
 var cursor: int = 0
 var _items: Array = []
 
@@ -50,18 +74,21 @@ static func build(
 	previous_cursor: int = 0,
 ) -> Gen2WorldStartMenu:
 	var menu := Gen2WorldStartMenu.new()
+	var passes: Dictionary = {
+		GATE_POKEDEX: pokedex_obtained,
+		GATE_PARTY: party_count > 0,
+		GATE_POKEGEAR: pokegear_obtained,
+	}
 	var items: Array = []
-	if pokedex_obtained:
-		items.append(_entry(ITEM_POKEDEX, "Pokedex", false))
-	if party_count > 0:
-		items.append(_entry(ITEM_POKEMON, "Pokemon", true))
-	items.append(_entry(ITEM_PACK, "Pack", true))
-	if pokegear_obtained:
-		items.append(_entry(ITEM_POKEGEAR, "Pokegear", true))
-	items.append(_entry(ITEM_PLAYER, "Player", false))
-	items.append(_entry(ITEM_SAVE, "Save", true))
-	items.append(_entry(ITEM_OPTION, "Options", false))
-	items.append(_entry(ITEM_EXIT, "Exit", true))
+	for entry: Dictionary in SOURCE_ENTRIES:
+		var gate: StringName = StringName(entry.get("gate", &""))
+		if not String(gate).is_empty() and not bool(passes.get(gate, false)):
+			continue
+		if entry["kind"] == ITEM_EXIT:
+			items.append_array(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START))
+		items.append(_entry(
+			StringName(entry["kind"]), String(entry["label"]), bool(entry["available"])
+		))
 	menu._items = items
 	menu.cursor = clampi(previous_cursor, 0, maxi(items.size() - 1, 0))
 	return menu

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -22,12 +22,17 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory())
 
 
+## Item 7 carries POTION's real ItemAttributes row, so the pack builds the
+## source's own USE/GIVE/TOSS/QUIT submenu for it and USE reaches .Party.
 func _write_pack_item() -> void:
 	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
 	for raw: Dictionary in items:
 		if int(raw.get("number", 0)) == 7:
 			raw["name"] = "POTION"
 			raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+			raw["permissions"] = Gen2WorldPack.CANT_SELECT
+			raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
+			raw["heal_amount"] = 20
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 
 
@@ -220,3 +225,96 @@ func _select(host: Gen2StartMenuScreen, kind: StringName) -> void:
 		host.handle_key(KEY_DOWN)
 		guard -= 1
 	assert_eq(menu.selected_kind(), kind)
+
+
+## Opens the pack with the cursor on the granted Potion, having damaged the
+## first party member so the item has something to do.
+func _open_pack_with_a_hurt_party() -> Gen2StartMenuScreen:
+	await _open_world()
+	var save: Gen2SaveData = _world_screen.get("_injected_save")
+	var mon: Gen2SaveMon = save.party[0]
+	mon.hp = maxi(mon.hp - 15, 1)
+	mon.nickname = "TESTMON"
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_PACK)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	return host
+
+
+func test_choosing_an_item_opens_the_source_submenu() -> void:
+	var host: Gen2StartMenuScreen = await _open_pack_with_a_hurt_party()
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
+	var labels: Array = []
+	for entry: Dictionary in host.get("_item_actions"):
+		labels.append(String(entry.get("label", "")))
+	assert_eq(labels, ["USE", "GIVE", "TOSS", "QUIT"])
+
+	# QUIT returns to the pocket list, keeping the cursor the source restores.
+	while StringName((host.get("_item_actions")[host.get("_item_cursor")] as Dictionary)
+		.get("action", &"")) != Gen2WorldPack.ACTION_QUIT:
+		host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
+
+
+func test_use_on_a_party_item_asks_which_mon_then_heals_and_spends_it() -> void:
+	var host: Gen2StartMenuScreen = await _open_pack_with_a_hurt_party()
+	var save: Gen2SaveData = _world_screen.get("_injected_save")
+	var before: int = (save.party[0] as Gen2SaveMon).hp
+	host.handle_key(KEY_ENTER)
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+	# Nothing has changed until the target is chosen.
+	assert_eq((save.party[0] as Gen2SaveMon).hp, before)
+	assert_eq(_world_screen._world.state.item_quantity(7), 1)
+
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq((save.party[0] as Gen2SaveMon).hp, before + 15)
+	assert_eq(_world_screen._world.state.item_quantity(7), 0)
+	assert_eq(String(host.get("_pack_result")), "POTION restored 15 HP.")
+
+	# The spent item leaves the pocket on the way back.
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
+	assert_eq(((host.get("_pack_pockets")[0] as Dictionary)["items"] as Array).size(), 0)
+
+
+func test_using_an_item_with_nothing_to_do_reports_it_and_spends_nothing() -> void:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_PACK)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	host.handle_key(KEY_ENTER)
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(String(host.get("_pack_result")), "It won't have any effect.")
+	assert_eq(_world_screen._world.state.item_quantity(7), 1)
+
+
+## UseItem's .Oak branch: an item whose field menu is ITEMMENU_NOUSE never
+## reaches an effect at all.
+func test_an_item_with_no_field_menu_reports_oaks_refusal() -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		if int(raw.get("number", 0)) == 7:
+			raw["field_menu"] = Gen2WorldPack.ITEMMENU_NOUSE
+			raw["permissions"] = Gen2WorldPack.CANT_TOSS
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	_data = GameData.open_directory(Fixture.directory())
+
+	var host: Gen2StartMenuScreen = await _open_pack_with_a_hurt_party()
+	host.handle_key(KEY_ENTER)
+	# CANT_TOSS with CANT_SELECT clear is MenuHeader_UnusableKeyItem: USE stays.
+	host.handle_key(KEY_ENTER)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(String(host.get("_pack_result")), Gen2StartMenuScreen.OAK_TEXT)
+	assert_eq(_world_screen._world.state.item_quantity(7), 1)

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -634,3 +634,57 @@ func test_following_a_refused_url_stores_nothing() -> void:
 	DirAccess.make_dir_recursive_absolute(ROOT)
 	assert_false(Gen2ModIndex.follow("http://mods.example.com/", store)["ok"])
 	assert_eq(Gen2ModIndex.followed(store).size(), 0)
+
+
+func test_menu_entries_are_registered_per_menu_and_kept_in_order() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(host.menu_entries(Gen2ModHost.MENU_START), [])
+	assert_true(bool(host.register_menu_entry(
+		Gen2ModHost.MENU_START, &"first", {"label": "First"}
+	).get("ok", false)))
+	assert_true(bool(host.register_menu_entry(
+		Gen2ModHost.MENU_START, &"second", {"label": "Second"}
+	).get("ok", false)))
+	assert_true(bool(host.register_menu_entry(
+		Gen2ModHost.MENU_PACK_POCKET, &"relics",
+		{"label": "Relics", "pocket": Gen2ModHost.FIRST_MOD_POCKET}
+	).get("ok", false)))
+	var start: Array = host.menu_entries(Gen2ModHost.MENU_START)
+	assert_eq(start.size(), 2)
+	assert_eq(StringName(start[0]["kind"]), &"first")
+	assert_eq(StringName(start[1]["kind"]), &"second")
+	assert_eq(host.menu_entries(Gen2ModHost.MENU_PACK_POCKET).size(), 1)
+
+
+func test_a_menu_entry_is_refused_rather_than_silently_dropped() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(
+		StringName(host.register_menu_entry(&"nowhere", &"x", {"label": "X"})["reason"]),
+		&"unknown_menu"
+	)
+	assert_eq(
+		StringName(host.register_menu_entry(Gen2ModHost.MENU_START, &"", {"label": "X"})["reason"]),
+		&"invalid_menu_entry"
+	)
+	assert_eq(
+		StringName(host.register_menu_entry(Gen2ModHost.MENU_START, &"x", {})["reason"]),
+		&"menu_entry_missing_label"
+	)
+	# Pocket numbers 1 to 4 are the cartridge's own, so a mod cannot claim one.
+	for pocket: int in [0, Gen2WorldPack.TYPE_ITEM, Gen2WorldPack.TYPE_TM_HM]:
+		assert_eq(
+			StringName(host.register_menu_entry(
+				Gen2ModHost.MENU_PACK_POCKET, &"p", {"label": "P", "pocket": pocket}
+			)["reason"]),
+			&"reserved_pocket", "pocket %d" % pocket
+		)
+	assert_true(bool(host.register_menu_entry(
+		Gen2ModHost.MENU_START, &"x", {"label": "X"}
+	).get("ok", false)))
+	# Two mods claiming the same id is the conflict a player would want named.
+	assert_eq(
+		StringName(host.register_menu_entry(
+			Gen2ModHost.MENU_START, &"x", {"label": "Other"}
+		)["reason"]),
+		&"duplicate_menu_entry"
+	)

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -17,7 +17,10 @@ const ITEM_UNCLASSIFIED: int = 5
 var _data: GameData = null
 
 
+## Each fixture item carries its real ItemAttributes row, so the submenu shapes
+## below are the ones the cartridge builds rather than invented combinations.
 func before_each() -> void:
+	Gen2ModHost.reset()
 	Fixture.build()
 	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
 	for raw: Dictionary in items:
@@ -25,22 +28,37 @@ func before_each() -> void:
 			ITEM_POTION:
 				raw["name"] = "POTION"
 				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
-				raw["field_menu"] = 1
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
 			ITEM_MASTER_BALL:
 				raw["name"] = "MASTER BALL"
 				raw["pocket"] = Gen2WorldPack.TYPE_BALL
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_NOUSE
 			ITEM_BICYCLE:
 				raw["name"] = "BICYCLE"
 				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
 			ITEM_TM01:
 				raw["name"] = "TM01"
 				raw["pocket"] = Gen2WorldPack.TYPE_TM_HM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 	_data = GameData.open_directory(Fixture.directory())
 
 
 func after_each() -> void:
 	RomCache.clear(Fixture.directory())
+	Gen2ModHost.reset()
+
+
+func _actions(item: int) -> Array:
+	var out: Array = []
+	for entry: Dictionary in Gen2WorldPack.item_submenu(_data, item):
+		out.append(StringName(entry.get("action", &"")))
+	return out
 
 
 func test_pockets_are_listed_in_the_source_cycle_order() -> void:
@@ -86,7 +104,9 @@ func test_a_zero_quantity_item_does_not_appear() -> void:
 func test_field_menu_value_is_carried_through() -> void:
 	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 1})
 	var pockets: Array = Gen2WorldPack.build(_data, state)
-	assert_eq((pockets[0]["items"] as Array)[0]["field_menu"], 1)
+	assert_eq(
+		(pockets[0]["items"] as Array)[0]["field_menu"], Gen2WorldPack.ITEMMENU_PARTY
+	)
 
 
 ## An item whose imported pocket byte is 0 does not belong to any of the four
@@ -109,3 +129,92 @@ func test_pocket_for_reads_the_imported_type_byte() -> void:
 func test_build_with_no_data_or_state_returns_empty() -> void:
 	assert_eq(Gen2WorldPack.build(null, Gen2WorldState.new()), [])
 	assert_eq(Gen2WorldPack.build(_data, null), [])
+
+
+## engine/items/pack.asm's .ItemBallsKey_LoadSubmenu picks between six headers on
+## two inverted permission bits and the field-menu nibble. POTION is CANT_SELECT
+## with a usable field menu, so it reaches MenuHeader_UsableItem.
+func test_a_usable_unselectable_item_offers_use_give_toss_quit() -> void:
+	assert_eq(_actions(ITEM_POTION), [
+		Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_GIVE,
+		Gen2WorldPack.ACTION_TOSS, Gen2WorldPack.ACTION_QUIT,
+	])
+
+
+## MASTER BALL shares POTION's permissions but has no field menu, so USE is not
+## offered at all: MenuHeader_HoldableItem.
+func test_an_unusable_unselectable_item_offers_give_toss_quit() -> void:
+	assert_eq(_actions(ITEM_MASTER_BALL), [
+		Gen2WorldPack.ACTION_GIVE, Gen2WorldPack.ACTION_TOSS, Gen2WorldPack.ACTION_QUIT,
+	])
+
+
+## BICYCLE is CANT_TOSS and selectable, so the source drops TOSS and GIVE and
+## keeps SEL: MenuHeader_UnusableKeyItem.
+func test_an_untossable_selectable_item_offers_use_sel_quit() -> void:
+	assert_eq(_actions(ITEM_BICYCLE), [
+		Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_SELECT, Gen2WorldPack.ACTION_QUIT,
+	])
+
+
+## The TM/HM pocket has its own two-way split on CANT_TOSS alone. TM01 can be
+## tossed, so it reaches .MenuHeader2.
+func test_the_tm_pocket_has_its_own_submenu() -> void:
+	assert_eq(_actions(ITEM_TM01), [
+		Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_GIVE, Gen2WorldPack.ACTION_QUIT,
+	])
+
+
+## GIVE, TOSS and SEL keep their source position and are marked unavailable, the
+## way the party submenu carries STATS, SWITCH and MOVE.
+func test_only_use_and_quit_are_available() -> void:
+	for entry: Dictionary in Gen2WorldPack.item_submenu(_data, ITEM_POTION):
+		var action: StringName = StringName(entry.get("action", &""))
+		assert_eq(
+			bool(entry.get("available", false)),
+			action in [Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_QUIT],
+			"action %s" % action
+		)
+
+
+func test_an_unknown_item_has_no_submenu() -> void:
+	assert_eq(Gen2WorldPack.item_submenu(_data, 250), [])
+	assert_eq(Gen2WorldPack.item_submenu(null, ITEM_POTION), [])
+
+
+## UseItem's jumptable: everything below ITEMMENU_CURRENT is .Oak's refusal.
+func test_field_use_kind_collapses_the_oak_entries() -> void:
+	assert_eq(Gen2WorldPack.field_use_kind(_data, ITEM_POTION), Gen2WorldPack.ITEMMENU_PARTY)
+	assert_eq(Gen2WorldPack.field_use_kind(_data, ITEM_BICYCLE), Gen2WorldPack.ITEMMENU_CLOSE)
+	assert_eq(
+		Gen2WorldPack.field_use_kind(_data, ITEM_MASTER_BALL), Gen2WorldPack.ITEMMENU_NOUSE
+	)
+	assert_eq(Gen2WorldPack.field_use_kind(null, ITEM_POTION), Gen2WorldPack.ITEMMENU_NOUSE)
+
+
+## A registered pocket follows the four source ones rather than displacing one,
+## so the cartridge cycle is reached the same way it always was.
+func test_a_registered_pocket_follows_the_source_cycle() -> void:
+	var mod_pocket: int = Gen2ModHost.FIRST_MOD_POCKET
+	assert_true(bool(Gen2ModHost.instance().register_menu_entry(
+		Gen2ModHost.MENU_PACK_POCKET, &"relics", {"label": "Relics", "pocket": mod_pocket}
+	).get("ok", false)))
+	assert_eq(Gen2WorldPack.pocket_order(), [
+		Gen2WorldPack.TYPE_ITEM, Gen2WorldPack.TYPE_BALL,
+		Gen2WorldPack.TYPE_KEY_ITEM, Gen2WorldPack.TYPE_TM_HM, mod_pocket,
+	])
+	assert_eq(Gen2WorldPack.pocket_name(mod_pocket), "Relics")
+
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		if int(raw.get("number", 0)) == ITEM_UNCLASSIFIED:
+			raw["name"] = "RELIC"
+			raw["pocket"] = mod_pocket
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	var pockets: Array = Gen2WorldPack.build(
+		data, Gen2WorldState.new({}, {}, {ITEM_UNCLASSIFIED: 2})
+	)
+	assert_eq(pockets.size(), 5)
+	assert_eq(pockets[4]["name"], "Relics")
+	assert_eq((pockets[4]["items"] as Array)[0]["item"], ITEM_UNCLASSIFIED)

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -127,3 +127,38 @@ func test_from_world_reads_party_count_and_engine_flags_off_the_live_world() -> 
 
 	assert_eq(_kinds(Gen2WorldStartMenu.from_world(null)), _kinds(Gen2WorldStartMenu.build(0, false, false)))
 	RomCache.clear(Fixture.directory())
+
+
+## The registry seam: a mod entry is spliced in ahead of EXIT, which stays last
+## because it is what closes the menu, and no source entry moves.
+func test_a_registered_entry_lands_before_exit() -> void:
+	Gen2ModHost.reset()
+	var called: Array = []
+	assert_true(bool(Gen2ModHost.instance().register_menu_entry(
+		Gen2ModHost.MENU_START, &"atlas",
+		{"label": "Atlas", "handler": func() -> void: called.append(true)}
+	).get("ok", false)))
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_eq(_kinds(menu), [
+		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
+		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
+		&"atlas", Gen2WorldStartMenu.ITEM_EXIT,
+	])
+	var entry: Dictionary = menu.items()[4]
+	assert_eq(String(entry.get("label", "")), "Atlas")
+	assert_true(bool(entry.get("available", false)))
+	(entry["handler"] as Callable).call()
+	assert_eq(called.size(), 1)
+	Gen2ModHost.reset()
+
+
+## An entry with no handler still appears, marked unavailable, the way Pokedex,
+## Player and Options do.
+func test_a_registered_entry_without_a_handler_is_unavailable() -> void:
+	Gen2ModHost.reset()
+	Gen2ModHost.instance().register_menu_entry(
+		Gen2ModHost.MENU_START, &"atlas", {"label": "Atlas"}
+	)
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+	assert_false(bool(menu.items()[4].get("available", false)))
+	Gen2ModHost.reset()


### PR DESCRIPTION
The pack listed items and said they could not be used. It now opens each item's own submenu and USE reaches a real transaction.

Which submenu appears is engine/items/pack.asm's own header selection, and all three checks it makes are inverted: _CheckTossableItem and CheckSelectableItem return non-zero when the item cannot be tossed or selected, which is why the source's branch labels and header names read backwards, .tossable being the can't-toss case and MenuHeader_UnusableItem the one that still offers USE. Gen2WorldPack.item_submenu() reads them into positive terms once and branches in the source's order, covering the six Items/Balls/Key headers and the TM/HM pocket's own two. GIVE, TOSS and SEL keep their source position marked unavailable, since a held item, a quantity prompt and Select-button registration are each a model that does not exist yet.

USE follows UseItem's jumptable: .Oak refuses, .Current applies at once, .Party asks which Pokemon first and answers _YouDontHaveAMonText on an empty party. The apply is Gen2WorldPartyHost.use_item(), so a Potion heals a chosen member and spends itself through the same candidate-save validation a mart purchase uses, and persistence stays off for an injected save. .Field is a boundary rather than a branch: no ITEMMENU_CLOSE item has an effect here, because Escape Rope and Dig need the spawn warp, so every one of them reaches .Oak instead and PACKSTATE_QUITRUNSCRIPT has nothing to close.

The menu-entry registry seam landed with it, where HANDOFF scheduled it. Gen2ModHost.register_menu_entry() takes MENU_START and MENU_PACK_POCKET; Gen2WorldStartMenu.SOURCE_ENTRIES is now the source list as data rather than a run of appends, and registered entries are spliced in ahead of EXIT, which stays last because it is what closes the menu. Pockets follow the four source ones and must claim a type number at or above FIRST_MOD_POCKET. A mod can add, never reorder or remove, and two mods claiming one id is refused rather than one silently winning.

Also fixed in passing: the item attribute constants existed twice, unused in RomLayout and about to be redeclared in Gen2WorldPack. RomLayout keeps the definitions, gaining ITEMMENU_NOUSE and ITEM_ATTRIBUTE_CANT_TOSS, and the pack aliases them under its own names.