### PR TITLE
Walk the story route from Olivine to the Glacier Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > through the Dance Theatre's Kimono Girls for HM03 Surf, Routes 38 and 39, the
 > Olivine Lighthouse, Routes 40 and 41 surfed to Cianwood for the SecretPotion,
 > and Jasmine to the Mineral Badge, then east across Route 42's lakes to
-> Mahogany, the Lake of Rage's Red Gyarados and Lance, and into the Rocket
-> hideout as far as its two passwords.
+> Mahogany, the Lake of Rage's Red Gyarados and Lance, the Rocket hideout's
+> three floors and Pryce to the Glacier Badge.
 > Missing: full story state, dex, trainer card, options, the remaining
 > special-call branches and story-driven permanent contacts.
 
@@ -199,7 +199,7 @@ Headless tools, all against a real imported cache:
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route, ending inside the Rocket hideout
+# the full walked route, ending at the Glacier Badge
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -54,7 +54,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 22
+const FORMAT_VERSION: int = 23
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -3,6 +3,10 @@ extends RefCounted
 
 const OBJECTTYPE_TRAINER: int = 2
 const TRAINER_RECORD_SIZE: int = 12
+## The two background-event types whose pointer addresses a conditional_event
+## record rather than a script (constants/script_constants.asm).
+const BGEVENT_IFSET: int = 5
+const BGEVENT_IFNOTSET: int = 6
 
 ## Imports the map table, map attributes, map events, tileset tables, overworld
 ## object graphics and addressable overworld tile strips for a verified
@@ -524,6 +528,10 @@ static func _read_map(
 				rom, scripts_bank, int(event.get("script", 0)),
 				script_data, text_data, movement_data
 			)
+			if source == "bg_events":
+				_collect_conditional_bg_script(
+					rom, scripts_bank, event, script_data, text_data, movement_data
+				)
 
 	var tileset: Dictionary = tilesets[tileset_number]
 	var collision_grid: Array = []
@@ -813,6 +821,33 @@ static func _read_map_scripts(
 		at += RomLayout.MAP_CALLBACK_SIZE
 
 	return {"ok": true, "scenes": scenes, "callbacks": callbacks}
+
+
+## A `BGEVENT_IFSET` or `BGEVENT_IFNOTSET` background event does not point at a
+## script. It points at the four-byte `conditional_event` record
+## (`macros/scripts/maps.asm`), an event flag then a near script pointer, and the
+## script is one level behind that. Collecting only the event's own pointer left
+## the door to Giovanni's office and the Rocket hideout's transmitter door
+## resolving to a script that was never cached.
+static func _collect_conditional_bg_script(
+	rom: RomFile,
+	bank: int,
+	event: Dictionary,
+	script_data: Dictionary,
+	text_data: Dictionary,
+	movement_data: Dictionary,
+) -> void:
+	if int(event.get("type", -1)) not in [BGEVENT_IFSET, BGEVENT_IFNOTSET]:
+		return
+	var address: int = int(event.get("script", 0))
+	if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
+		return
+	var offset: int = _far_offset(rom, {"bank": bank, "address": address})
+	if offset < 0 or not rom.in_bounds(offset, 4):
+		return
+	_collect_script(
+		rom, bank, rom.u16le(offset + 2), script_data, text_data, movement_data
+	)
 
 
 static func _collect_script(

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1761,6 +1761,15 @@ func _enqueue_script(request: Dictionary) -> void:
 		request["facing"] = player_facing
 	if not request.has("party") and not _party_summary.is_empty():
 		request["party"] = _party_summary.duplicate()
+	if not request.has("object_event_flags"):
+		## `disappear` and `appear` write an object's event flag where the source
+		## does, inside the script, so a later `checkevent` on the same flag sees
+		## it. The runner holds no object table, so it is handed the flag per
+		## object index the way it is handed collision and the clock.
+		var object_flags: Array[int] = []
+		for object: Gen2WorldObject in objects:
+			object_flags.append(object.event_flag)
+		request["object_event_flags"] = object_flags
 	_script_queue.append(request)
 
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1146,6 +1146,7 @@ func _execute_object_command(source_opcode: int, command: Dictionary) -> Diction
 				"object_index": _object_index_from_id(int(command.get("object_id", 0))),
 				"active": true,
 			})
+			_stage_object_event_flag(int(command.get("object_id", 0)), true)
 		0x6E:
 			_emit_object_event(&"object_visibility", {
 				"object_index": _object_index_from_id(int(command.get("object_id", 0))),
@@ -1155,6 +1156,7 @@ func _execute_object_command(source_opcode: int, command: Dictionary) -> Diction
 				"object_index": _object_index_from_id(int(command.get("object_id", 0))),
 				"active": false,
 			})
+			_stage_object_event_flag(int(command.get("object_id", 0)), false)
 		0x6F, 0x76:
 			_emit_object_event(&"object_follow", {
 				"object_index": _object_index_from_id(int(command.get("object_id", 0))),
@@ -1748,6 +1750,20 @@ func _just_battled() -> bool:
 	if _has_staged_just_battled:
 		return _staged_just_battled
 	return state != null and state.just_battled()
+
+
+## `disappear` and `appear` set and clear the object's own event flag where the
+## source does, so a `checkevent` later in the same script reads it back.
+## TeamRocketBaseB2F's third Electrode checks all three straight after
+## disappearing its own, and read the committed value without this.
+func _stage_object_event_flag(object_id: int, active: bool) -> void:
+	var index: int = _object_index_from_id(object_id)
+	var flags: Array = _request.get("object_event_flags", [])
+	if index < 0 or index >= flags.size():
+		return
+	var flag: int = int(flags[index])
+	if flag > 0:
+		_staged_flags[flag] = active
 
 
 func _stage_just_battled(value: bool) -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1996,6 +1996,37 @@ func test_checkpoke_answers_the_party_summary_species_and_fails_without_one() ->
 	assert_eq(failed[0]["reason"], &"missing_party_summary")
 
 
+func test_disappear_writes_the_object_flag_the_same_script_can_check() -> void:
+	# TeamRocketBaseB2F's third Electrode disappears itself and then checks all
+	# three electrode events before running the script that ends the hideout, so
+	# the flag has to be readable inside the same script the way Script_disappear
+	# writes it.
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6380"] = [
+		Gen2WorldScript.raw_opcode(0x6D, true), 2, # disappear, first object
+		Gen2WorldScript.CHECKEVENT, 0, 0,
+		Gen2WorldScript.IFTRUE, 0x90, 0x63,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6390"] = [Gen2WorldScript.SETEVENT, 44, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var flag: int = (world.objects[0] as Gen2WorldObject).event_flag
+	assert_gt(flag, 0, "the fixture's first object needs an event flag")
+	scripts["48:6380"][3] = flag & 0xFF
+	scripts["48:6380"][4] = flag >> 8
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+
+	var reloaded: GameData = GameData.open_directory(_directory)
+	var checked: Gen2WorldAPI = Gen2WorldAPI.open(reloaded, 1, 1, Vector2i(7, 6))
+	checked.current_map.events["coord_events"][0]["script"] = 0x6380
+	var result: Array = checked.dispatch_script_events()
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_true(checked.event_flag_active(flag), JSON.stringify(result))
+	assert_true(checked.event_flag_active(44), JSON.stringify(result))
+
+
 func test_talking_to_a_beaten_trainer_clears_the_just_battled_flag_first() -> void:
 	# LoadTrainer_continue clears wRunningTrainerBattleScript for every trainer
 	# encounter (home/trainers.asm), so an after-battle script only stops at

--- a/tests/unit/test_world_importer.gd
+++ b/tests/unit/test_world_importer.gd
@@ -33,3 +33,37 @@ func test_trainer_record_decodes_the_source_fields_and_after_script_pointer() ->
 	assert_eq(record["win_text"], {"bank": bank, "address": 0x7010})
 	assert_eq(record["loss_text"], {"bank": bank, "address": 0x7020})
 	assert_eq(record["after_script"], 0x600C)
+
+
+func test_a_conditional_background_event_collects_the_script_behind_it() -> void:
+	# BGEVENT_IFSET and BGEVENT_IFNOTSET point at a four-byte conditional_event
+	# record, an event flag then a near script pointer, not at a script
+	# (macros/scripts/maps.asm). Giovanni's office door and the Rocket hideout's
+	# transmitter door are both reached this way.
+	var bank: int = 48
+	var record: int = 0x6100
+	var script: int = 0x6200
+	var bytes := PackedByteArray()
+	bytes.resize(RomFile.linear(bank, script) + 8)
+	var record_offset: int = RomFile.linear(bank, record)
+	bytes[record_offset] = 0x22
+	bytes[record_offset + 1] = 0x11
+	bytes[record_offset + 2] = script & 0xFF
+	bytes[record_offset + 3] = script >> 8
+	bytes[RomFile.linear(bank, script)] = Gen2WorldScript.END
+
+	var rom: RomFile = RomFile.from_bytes(bytes, RomRegistry.CRYSTAL)
+	var script_data: Dictionary = {}
+	Gen2WorldImporter._collect_conditional_bg_script(
+		rom, bank, {"type": Gen2WorldImporter.BGEVENT_IFNOTSET, "script": record},
+		script_data, {}, {}
+	)
+	assert_true(
+		script_data.has(Gen2WorldScript.pointer_key(bank, script)), JSON.stringify(script_data)
+	)
+
+	var read_only: Dictionary = {}
+	Gen2WorldImporter._collect_conditional_bg_script(
+		rom, bank, {"type": 0, "script": record}, read_only, {}, {}
+	)
+	assert_true(read_only.is_empty(), "a plain BGEVENT_READ points straight at its script")

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -740,9 +740,9 @@ func _story_path(data: GameData) -> Dictionary:
 	if not bool(mineral.get("ok", false)):
 		return mineral
 
-	var hideout: Dictionary = _rocket_hideout_path(world, save, random, data, path)
-	if not bool(hideout.get("ok", false)):
-		return hideout
+	var glacier: Dictionary = _glacier_badge_path(world, save, random, data, path)
+	if not bool(glacier.get("ok", false)):
+		return glacier
 
 	var party_summary: Array = []
 	for mon: Gen2SaveMon in save.party:
@@ -1858,17 +1858,17 @@ func _mineral_badge_path(
 	return {"ok": true}
 
 
-## The Mineral Badge to the Rocket hideout's two passwords. Mahogany's gym is
-## closed until the hideout under its souvenir shop is cleared
+## The Mineral Badge to the Glacier Badge. Mahogany's gym is closed until the
+## Rocket hideout under its souvenir shop is cleared
 ## (`EVENT_MAHOGANY_TOWN_POKEFAN_M_BLOCKS_GYM`, `maps/MahoganyTown.asm`), and the
 ## hideout only opens after Lance is met at the Lake of Rage, which is behind the
 ## Red Gyarados in the middle of the water.
 ##
-## The leg stops on B3F with both passwords learned. What is left of the hideout
-## needs floor shuttles this walk does not do yet: B3F's northern half, where the
-## rival, Giovanni's door and the executive are, is reachable only from B2F's own
-## northern half, which the heal room does not reach either.
-func _rocket_hideout_path(
+## The hideout is three floors of one-way halves rather than one maze: each floor
+## is cut in two and the halves are joined through the other floor, so the route
+## climbs and drops the same ladders several times. Its own doors are the only
+## other links, and each opens on something learned a floor away.
+func _glacier_badge_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
 	random: RandomNumberGenerator,
@@ -2219,6 +2219,210 @@ func _rocket_hideout_path(
 					grunt["name"], password.get("reason", ""),
 				],
 			}
+
+	# B3F's northern half is walled off from this one, and it is entered from
+	# B2F's own northern half, so the route goes up one ladder and down another.
+	var b3f_up: Dictionary = _warp_walk(world, Vector2i(27, 2), save, random, data)
+	if not bool(b3f_up.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B3F north-east ladder unreachable: %s" % b3f_up.get("reason", ""),
+		}
+	var _b2f_north: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	var b3f_down: Dictionary = _warp_walk(world, Vector2i(3, 2), save, random, data)
+	if not bool(b3f_down.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B2F north-west ladder unreachable: %s" % b3f_down.get("reason", ""),
+		}
+	var _b3f_north: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	var rival: Dictionary = _walk_cell_resolving(world, Vector2i(8, 10), save, random, data)
+	path.append({
+		"step": "rocket_base_b3f_rival",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": rival.get("encounters", []),
+		"scene": world.state.map_scene(3, 51),
+	})
+	if not bool(rival.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B3F rival scene failed: %s" % rival.get("reason", ""),
+		}
+	# Giovanni's door is the only way into the office: row 9 is solid either side
+	# of it. It opens on the two passwords and changeblocks itself to floor.
+	var office_door: Dictionary = _talk_to(
+		world, Vector2i(10, 10), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "rocket_base_b3f_giovannis_door",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": office_door.get("run", {}),
+	})
+	if not bool(office_door.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B3F office door failed: %s" % office_door.get("reason", ""),
+		}
+	var executive: Dictionary = _walk_cell_resolving(world, Vector2i(10, 8), save, random, data)
+	path.append({
+		"step": "rocket_base_b3f_executive",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": executive.get("encounters", []),
+		"scene": world.state.map_scene(3, 51),
+	})
+	if not bool(executive.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B3F executive failed: %s" % executive.get("reason", ""),
+		}
+	# The Murkrow behind the desk is what says the transmitter password.
+	var murkrow: Dictionary = _talk_to(
+		world, Vector2i(7, 3), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "rocket_base_b3f_murkrow",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": murkrow.get("run", {}),
+	})
+	if not bool(murkrow.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B3F Murkrow failed: %s" % murkrow.get("reason", ""),
+		}
+
+	# Back down to the machine room's own floor, which means unwinding the same
+	# three ladders: B2F's north-west pocket does not reach its south half either.
+	for ladder: Dictionary in [
+		{"step": "b3f_north_to_b2f_north", "cell": Vector2i(3, 2)},
+		{"step": "b2f_north_to_b3f_south", "cell": Vector2i(27, 2)},
+		{"step": "b3f_south_to_b2f_south", "cell": Vector2i(27, 14)},
+	]:
+		var taken: Dictionary = _warp_walk(world, ladder["cell"], save, random, data)
+		if not bool(taken.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s ladder unreachable: %s" % [
+					ladder["step"], taken.get("reason", ""),
+				],
+			}
+		var _floor_entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+	# The machine room is walled off on every side but its own door: B2F's row 12
+	# is solid and rows 3 to 11 between x=7 and x=22 touch nothing else. So the
+	# transmitter door is the way in, and it opens on the password the Murkrow
+	# gave.
+	var transmitter_door: Dictionary = _talk_to(
+		world, Vector2i(14, 13), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "rocket_base_b2f_transmitter_door",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": transmitter_door.get("run", {}),
+	})
+	if not bool(transmitter_door.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "B2F transmitter door failed: %s" % transmitter_door.get("reason", ""),
+		}
+	# Stepping onto the cell north of that door is the executive's coord event,
+	# and it ends by arming the electrodes.
+	# The scene walks the player itself and then confines them with the
+	# electrodes, so the walk is expected not to reach its own target: what says
+	# the executive happened is the scene moving on.
+	var boss_f: Dictionary = _walk_cell_resolving(world, Vector2i(14, 11), save, random, data)
+	var electrodes_armed: bool = world.state.map_scene(3, 50) == 2
+	path.append({
+		"step": "rocket_base_b2f_executive",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": boss_f.get("encounters", []),
+		"scene": world.state.map_scene(3, 50),
+	})
+	if not electrodes_armed:
+		return {
+			"ok": false, "path": path,
+			"reason": "B2F executive failed: %s" % boss_f.get("reason", ""),
+		}
+	# Three Electrodes power the transmitter. Each is a loadwildmon battle, and
+	# the third one to fall runs the script that ends the hideout.
+	for electrode: Dictionary in [
+		{"name": "1", "cell": Vector2i(8, 5)},
+		{"name": "2", "cell": Vector2i(8, 7)},
+		{"name": "3", "cell": Vector2i(8, 9)},
+	]:
+		var zapped: Dictionary = _talk_to(
+			world, electrode["cell"], Gen2WorldSprite.FACING_LEFT, save, random, data
+		)
+		path.append({
+			"step": "rocket_base_b2f_electrode_%s" % electrode["name"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"run": zapped.get("run", {}),
+			"items": _named_items(data, world.state.items()),
+		})
+		if not bool(zapped.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "B2F electrode %s failed: %s" % [
+					electrode["name"], zapped.get("reason", ""),
+				],
+			}
+
+	# Out the way the route came in. Clearing the base hides the grunts, so the
+	# walk back is not the one that came down.
+	for ladder: Dictionary in [
+		{"step": "b2f_to_b1f", "group": 3, "number": 49, "cell": Vector2i(3, 14)},
+		{"step": "b1f_to_the_shop", "group": 3, "number": 48, "cell": Vector2i(27, 2)},
+		{"step": "shop_to_mahogany", "group": 2, "number": 7, "cell": Vector2i(3, 7)},
+	]:
+		var climbed: Dictionary = _warp_walk(world, ladder["cell"], save, random, data)
+		if not bool(climbed.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s unreachable: %s" % [ladder["step"], climbed.get("reason", "")],
+			}
+		var _above: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+
+	world.set_party_summary(save.party.size(), false)
+	var gym: Dictionary = _warp_walk(world, Vector2i(6, 13), save, random, data)
+	if not bool(gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Mahogany Gym door unreachable: %s" % gym.get("reason", ""),
+		}
+	var gym_entry: Dictionary = _drain_story(world, world.dispatch_map_entry(), save, random, data)
+	# Pryce's floor is COLL_ICE, which is LAND_TILE, so the walk crosses it
+	# without the source's sliding.
+	var pryce: Dictionary = _talk_to(
+		world, Vector2i(5, 4), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "mahogany_gym_pryce",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"entry_statuses": gym_entry.get("statuses", []),
+		"run": pryce.get("run", {}),
+		"badge_count": world.state.badge_count(),
+		"engine_flags": world.state.engine_flags(),
+		"items": _named_items(data, world.state.items()),
+	})
+	if not bool(pryce.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Pryce failed: %s" % pryce.get("reason", ""),
+		}
 	return {"ok": true}
 
 


### PR DESCRIPTION
The walked route reaches Mahogany's gym: Route 42's two surfed lakes, the Lake of Rage's Red Gyarados and Lance, the souvenir shop staircase, the Rocket hideout's three floors from the secret switch to the transmitter Electrodes, and Pryce. 111 steps and 273 event flags, ending on ENGINE_GLACIERBADGE with six badges. The Storm Badge is still skipped, since Cianwood Gym needs Strength.

The hideout is three floors cut in half rather than one maze, and each half is joined through another floor, so the route climbs and drops the same ladders several times. Its own doors are the only other links, and each opens on something learned a floor away.

Two fixes the walk found:

- A background event of type IFSET or IFNOTSET points at a four-byte conditional_event record, an event flag then a near script pointer, not at a script. Only the event's own pointer was collected, so the script one level behind it was never cached and both of the hideout's locked doors failed with missing_script. Cache format 23.
- disappear and appear now write the object's own event flag inside the script, the way Script_disappear does, so a checkevent on it later in the same script reads it back. The runner holds no object table, so it is handed the map's object event flags with the rest of its request context. The third Electrode checks all three straight after disappearing its own, and the script that ends the hideout, hands over HM06 and opens the gym is behind that check.