### PR TITLE
Push boulders with Strength

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Headless tools, all against a real imported cache:
 | `validate_cut.gd` | the cut block tables, the profile-split tileset numbers and cuttable-cell census, and Ilex Forest's tree, in all three games |
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
+| `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -250,5 +250,12 @@ static func _encodings() -> Dictionary:
 		if not out.has(text):
 			out[text] = code
 
+	# constants/charmap.asm maps "#" to $54, the POKé ligature, which is how every
+	# source text writes it. Encode only: decoding $54 stays "POKé", so a round
+	# trip through the cartridge's own shorthand is not silently rewritten.
+	# Without this a synthesized literal such as "a #MON!" encodes "#" as UNKNOWN
+	# and draws a question mark.
+	out["#"] = 0x54
+
 	_codes = out
 	return _codes

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -29,6 +29,9 @@ const STEP_FRAMES_HOP: int = STEP_FRAMES_WALK * 2
 ## calls InitStep with a direction of 0 to 3, which indexes that first row, so
 ## a wandering object steps at half the player's walking speed.
 const STEP_FRAMES_NPC_WALK: int = 16
+## MovementFunction_Strength calls InitStep with `direction | 0`, so a pushed
+## boulder indexes that same slow row and slides at a wandering NPC's speed.
+const STEP_FRAMES_BOULDER_PUSH: int = STEP_FRAMES_NPC_WALK
 ## RandomStepDuration_Slow and _Fast mask the source random byte before storing
 ## it as the wait preceding the next movement decision.
 const IDLE_MASK_SLOW: int = 0x7F
@@ -91,6 +94,11 @@ var _pending_surf: Dictionary = {}
 ## The same for Whirlpool, which shares the source's wCutWhirlpool* slots with
 ## Cut and is cleared beside it for the same reason.
 var _pending_whirlpool: Dictionary = {}
+## The same for Strength, held while Script_UsedStrength shows its text. It names
+## no cell or block, but it is cleared with the others anyway: the source queues
+## Script_StrengthFromMenu and runs it at once, so a request cannot outlive the
+## map it was made on.
+var _pending_strength: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
@@ -337,16 +345,22 @@ func set_movement_mode(mode: StringName) -> Dictionary:
 ## CheckPokerus special and its checkpoke consult. count must be non-negative;
 ## has_pokerus is the source's own low-nibble-nonzero check across the whole
 ## party, computed by the caller because Gen2WorldAPI does not read Gen2SaveMon
-## fields directly. [param species] mirrors `wPartySpecies` for `checkpoke`, and
-## an empty list only means no caller supplied one, so `checkpoke` fails the way
-## VAR_PARTYCOUNT does rather than answering false.
+## fields directly. [param species] mirrors `wPartySpecies` for `checkpoke`.
+## [param moves] is one move list per slot, mirroring the party's move slots for
+## `CheckPartyMove`, and [param names] one display name per slot for
+## `GetPartyNickname`; TryStrengthOW asks the first and Script_UsedStrength the
+## second. Only an absent summary fails a script-visible read; a summary whose
+## list is empty answers "not in the party", which is what the story preview's
+## own callers rely on.
 func set_party_summary(
-	count: int, has_pokerus: bool, species: Array[int] = [] as Array[int]
+	count: int, has_pokerus: bool, species: Array[int] = [] as Array[int],
+	moves: Array = [], names: Array = []
 ) -> Dictionary:
 	if count < 0:
 		return {"ok": false, "reason": &"invalid_party_summary", "count": count}
 	_party_summary = {
 		"count": count, "pokerus": has_pokerus, "species": species.duplicate(),
+		"moves": moves.duplicate(true), "names": names.duplicate(),
 	}
 	return {"ok": true}
 
@@ -636,6 +650,69 @@ func complete_whirlpool() -> Dictionary:
 
 static func _whirlpool_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"whirlpool_failed", "reason": reason}
+
+
+## engine/events/overworld.asm's StrengthFunction .TryStrength, staged the way
+## the other three are because Script_UsedStrength sets nothing until after its
+## text either.
+##
+## Unlike them, .TryStrength is a badge check and nothing else: no faced tile, no
+## block table, no player state, and no check that a boulder is even in front.
+## Its .AlreadyUsingStrength branch is annotated unreferenced in both pins, so an
+## already-active flag is not a refusal here. [param species] is the chosen party
+## member's, for SetStrengthFlag's wStrengthSpecies.
+func strength_request(species: int = 0) -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return _strength_failure(&"missing_map")
+	if not _pending_strength.is_empty():
+		return _strength_failure(&"strength_in_progress")
+	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_PLAIN, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return _strength_failure(&"badge_required")
+	_pending_strength = {
+		"ok": true,
+		"kind": &"strength_requested",
+		"move": Gen2WorldFieldMove.MOVE_STRENGTH,
+		"species": species,
+	}
+	return _pending_strength.duplicate(true)
+
+
+## Empty until strength_request() succeeds. A host shows its text while this is set.
+func pending_strength() -> Dictionary:
+	return _pending_strength.duplicate(true)
+
+
+## SetStrengthFlag: the engine flag plus wStrengthSpecies, which is only read
+## back by Script_UsedStrength's own cry. Nothing in the pinned sources ever
+## clears the flag, so this is the one write and it persists for the save.
+func complete_strength() -> Dictionary:
+	if _pending_strength.is_empty():
+		return _strength_failure(&"no_pending_strength")
+	var request: Dictionary = _pending_strength
+	_pending_strength = {}
+	state.set_engine_flag(
+		Gen2WorldState.strength_active_flag(Gen2WorldState.is_crystal_profile(data)), true
+	)
+	return {
+		"ok": true,
+		"kind": &"strength_applied",
+		"move": int(request["move"]),
+		"species": int(request["species"]),
+	}
+
+
+## Whether BIKEFLAGS_STRENGTH_ACTIVE_F is set, the single condition
+## DoPlayerMovement.CheckStrengthBoulder and TryStrengthOW both read.
+func strength_active() -> bool:
+	return state.is_engine_flag_active(
+		Gen2WorldState.strength_active_flag(Gen2WorldState.is_crystal_profile(data))
+	)
+
+
+static func _strength_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"strength_failed", "reason": reason}
 
 
 ## Rolls an encounter from the current map. Auto mode preserves the existing
@@ -2409,10 +2486,17 @@ func try_connection(direction: Vector2i) -> Dictionary:
 ## wTilePermissions computed at the player's current cell. Vector2i.ZERO skips
 ## that test for callers that only want the destination's plain permission.
 func can_walk_to(cell: Vector2i, direction: Vector2i = Vector2i.ZERO) -> bool:
+	if not _step_permission_allows(cell, direction):
+		return false
+	return object_at(cell) == null
+
+
+## .CheckLandPerms/.CheckSurfPerms alone, without .CheckNPC. Split out because
+## the source runs the two in that order and only reaches the NPC test when the
+## permission passed, which is what makes a boulder on a wall unpushable.
+func _step_permission_allows(cell: Vector2i, direction: Vector2i) -> bool:
 	if current_map == null or cell.x < 0 or cell.y < 0 \
 		or cell.x >= current_map.collision_width or cell.y >= current_map.collision_height:
-		return false
-	if object_at(cell) != null:
 		return false
 	if direction != Vector2i.ZERO:
 		var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
@@ -2519,16 +2603,24 @@ func advance_object_steps(delta: float, random: RandomNumberGenerator) -> bool:
 	while _object_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS:
 		_object_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
 		for object: Gen2WorldObject in objects:
-			if not object.active or object.deleted or object.sprite == null \
-				or not object.movement_advances():
+			if not object.active or object.deleted or object.sprite == null:
 				continue
-			if object.tick_step():
-				changed = true
-				if not object.is_stepping():
-					# StepFunction_ContinueWalk rolls a new wait the moment the
-					# step duration reaches zero, so a wandering object pauses
-					# between steps instead of walking without stopping.
-					object.start_idle(random.randi() & IDLE_MASK_SLOW)
+			# A step in flight is drained whatever put it there, so a pushed
+			# boulder slides even though its template never decides anything.
+			# StepFunction_StrengthBoulder ends by standing the boulder back up
+			# without rolling a wait, which is why only a template that decides
+			# reaches start_idle below.
+			if object.is_stepping():
+				if object.tick_step():
+					changed = true
+					if not object.is_stepping() and object.movement_advances():
+						# StepFunction_ContinueWalk rolls a new wait the moment
+						# the step duration reaches zero, so a wandering object
+						# pauses between steps instead of walking without
+						# stopping.
+						object.start_idle(random.randi() & IDLE_MASK_SLOW)
+				continue
+			if not object.movement_advances():
 				continue
 			if object.tick_idle():
 				continue
@@ -2642,9 +2734,17 @@ func move_result(direction: Vector2i) -> Dictionary:
 	if forced_walk:
 		return _forced_step(direction, destination)
 	if not can_walk_to(destination, direction):
+		## .CheckNPC runs after .CheckLandPerms and before .TryJump, and its own
+		## comment says a movable boulder is treated the same as any NPC in front:
+		## both .bump. So a push starts the boulder and still refuses the player,
+		## and .bump returns without carry, so the ledge hop is tried afterwards
+		## exactly as it would have been.
+		var pushed: Dictionary = _try_push_boulder(direction, destination)
 		var hop: Dictionary = _try_ledge_hop(direction)
 		if not hop.is_empty():
 			return hop
+		if not pushed.is_empty():
+			return pushed
 		return {"ok": false, "kind": &"move", "reason": &"blocked"}
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
@@ -2738,6 +2838,62 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 		"from_cell": from_cell,
 		"to_map": from_map,
 		"to_cell": player_cell,
+	}
+
+
+## .CheckStrengthBoulder, then the boulder's own MovementFunction_Strength.
+##
+## The source splits these across two frames: the player's step flags the boulder
+## and bumps, and the boulder starts moving on its next movement tick. Nothing
+## observable sits between the two, because the boulder is not asked to decide
+## anything in between and the flag it carries is cleared unread by nobody, so
+## both are resolved here in one call. The player is not moved either way; the
+## caller still reports a blocked step.
+##
+## Refusals, in the source's own order: BIKEFLAGS_STRENGTH_ACTIVE_F, then a
+## boulder that is standing (OBJECT_WALKING == STANDING, so a boulder already
+## mid-push is not pushed again), then the destination the boulder would take.
+## The boulder's own cell being a pit stops it permanently
+## (MovementFunction_Strength .on_pit), which is Blackthorn Gym 2F's puzzle and
+## the only thing that reads it.
+##
+## [param destination] is the boulder's cell, already known to have refused the
+## player. Its permission is checked here because .CheckLandPerms runs before
+## .CheckNPC, so a boulder standing somewhere the player could not walk anyway is
+## never even considered.
+func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary:
+	if not strength_active():
+		return {}
+	if not _step_permission_allows(destination, direction):
+		return {}
+	var boulder: Gen2WorldObject = object_at(destination)
+	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
+		return {}
+	if Gen2WorldCollision.is_pit_tile(collision_code_at(boulder.cell)):
+		return {}
+	var landing: Vector2i = boulder.cell + direction
+	# CanObjectMoveInDirection with the boulder's own flags: WONT_DELETE,
+	# FIXED_FACING, SLIDING and MOVE_ANYWHERE, palette bit STRENGTH_BOULDER and
+	# no NOCLIP or SWIMMING. That leaves the destination's land permission, both
+	# side-wall rules, and IsNPCAtCoord over the object structs, which start at
+	# the player's own. can_object_walk_to() is those four tests.
+	if not can_object_walk_to(landing, boulder, direction):
+		return {}
+	boulder.cell = landing
+	# FIXED_FACING is set on the boulder's movement data, so InitStep skips the
+	# OBJECT_DIRECTION write and the sprite keeps facing down while it slides.
+	boulder.start_step(direction, STEP_FRAMES_BOULDER_PUSH)
+	_remember_object_position(boulder)
+	return {
+		"ok": false,
+		"kind": &"move",
+		"reason": &"blocked",
+		"boulder_pushed": {
+			"index": boulder.index,
+			"from_cell": landing - direction,
+			"to_cell": landing,
+			"direction": direction,
+		},
 	}
 
 
@@ -2880,6 +3036,7 @@ func _apply_map(
 	_pending_cut.clear()
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
+	_pending_strength.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
 	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
@@ -2923,6 +3080,7 @@ func reload_current_map() -> Dictionary:
 	_pending_cut.clear()
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
+	_pending_strength.clear()
 	state.reset_map_reload_flags()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -264,9 +264,16 @@ const COLL_PIT_68: int = 0x68
 ## an ordinary floor tile is inert, which is what lets a player walk over
 ## Burned Tower B1F's (10,8) instead of being sent back upstairs.
 static func is_warp_tile(collision_code: int) -> bool:
-	if collision_code == COLL_PIT or collision_code == COLL_PIT_68:
+	if is_pit_tile(collision_code):
 		return true
 	return (collision_code & 0xF0) == HI_NYBBLE_WARPS
+
+
+## home/map_objects.asm's CheckPitTile, the two codes on their own. Read by
+## is_warp_tile() above and by MovementFunction_Strength, which stops a boulder
+## standing on one for good.
+static func is_pit_tile(collision_code: int) -> bool:
+	return collision_code == COLL_PIT or collision_code == COLL_PIT_68
 
 ## .water_table, indexed by a current code's low two bits. The source masks
 ## NUM_DIRECTIONS, not seven, so every code $30-$3f reaches this table.

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -4,24 +4,31 @@ extends RefCounted
 ## Scene-free tables and gates for the overworld field moves
 ## (engine/events/overworld.asm).
 ##
-## Cut, Surf and Whirlpool are resolved here. All three follow the shape
-## CutFunction defines: check the badge, then check the faced tile, then stage a
-## change the text acknowledge commits. Strength, Waterfall, Flash and Headbutt
-## are not resolved yet.
+## Cut, Surf, Strength and Whirlpool are resolved here. Cut, Surf and Whirlpool
+## follow the shape CutFunction defines: check the badge, then check the faced
+## tile, then stage a change the text acknowledge commits. Strength is the odd
+## one, see BADGE_PLAIN. Waterfall, Flash and Headbutt are not resolved yet.
 
 ## constants/move_constants.asm, whose comment column is hex. The submenu, not
 ## CutFunction, SurfFunction or WhirlpoolFunction, is what checks a party Pokemon
 ## knows these.
 const MOVE_CUT: int = 0x0F
 const MOVE_SURF: int = 0x39
+const MOVE_STRENGTH: int = 0x46
 const MOVE_WHIRLPOOL: int = 0xFA
 
-## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf
-## and WhirlpoolFunction's .TryWhirlpool, as source badge-order indices rather
-## than flag numbers, so Gen2WorldState.badge_flag() resolves them on either
-## profile: ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold/Silver,
-## ENGINE_FOGBADGE 30 and 29, ENGINE_GLACIERBADGE 33 and 32.
+## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
+## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
+## source badge-order indices rather than flag numbers, so
+## Gen2WorldState.badge_flag() resolves them on either profile:
+## ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold/Silver, ENGINE_PLAINBADGE
+## 29 and 28, ENGINE_FOGBADGE 30 and 29, ENGINE_GLACIERBADGE 33 and 32.
 const BADGE_HIVE: int = 1
+## .TryStrength is the whole gate: CheckBadge ENGINE_PLAINBADGE and nothing
+## else. It checks no tile, no block table and no player state, unlike the other
+## three, and its .AlreadyUsingStrength branch is marked unreferenced in both
+## pins, so an already-active flag is not a refusal either.
+const BADGE_PLAIN: int = 2
 const BADGE_FOG: int = 3
 const BADGE_GLACIER: int = 6
 
@@ -38,7 +45,7 @@ const MUSIC_SURF: int = 0x21
 ## Both pins ship the same rows, so this needs no profile split. IsFieldMove
 ## decides submenu membership from this list alone, so a move stops appearing
 ## the moment it leaves it.
-const FIELD_MOVES: Array[int] = [MOVE_CUT, MOVE_SURF, MOVE_WHIRLPOOL]
+const FIELD_MOVES: Array[int] = [MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of
 ## the six block ($12, $1a); the four grass codes are LAND_TILE and cuttable

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -19,6 +19,11 @@ const MOVEMENT_SPINRANDOM_FAST: int = 10
 const MOVEMENT_PLAYER: int = 11
 const MOVEMENT_FOLLOW: int = 19
 const MOVEMENT_SCRIPTED: int = 20
+## SPRITEMOVEDATA_STRENGTH_BOULDER. The constants file's comment column is hex,
+## which is why this is $19 and not 19: 19 is SPRITEMOVEDATA_FOLLOWING ($13)
+## above. A boulder decides nothing on its own, so it is deliberately in neither
+## movement_supported() nor movement_advances(); it only reacts to a push.
+const MOVEMENT_STRENGTH_BOULDER: int = 0x19
 const MOVEMENT_SWIM_WANDER: int = 0x24
 
 const OBJECTTYPE_SCRIPT: int = 0
@@ -100,6 +105,13 @@ func initial_facing() -> int:
 			return Gen2WorldSprite.FACING_RIGHT
 		_:
 			return Gen2WorldSprite.FACING_DOWN
+
+
+## The source's own test in DoPlayerMovement.CheckStrengthBoulder: OBJECT_PALETTE
+## bit STRENGTH_BOULDER, which data/sprites/map_objects.asm sets on exactly the
+## SPRITEMOVEDATA_STRENGTH_BOULDER row, so the movement template answers it.
+func is_strength_boulder() -> bool:
+	return movement == MOVEMENT_STRENGTH_BOULDER
 
 
 func movement_supported() -> bool:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -28,6 +28,9 @@ const SFX_CUT: int = 0x1E
 ## constants/sfx_constants.asm's SFX_SURF, which is what PlayWhirlpoolSound plays
 ## (engine/events/field_moves.asm); there is no whirlpool-specific effect.
 const SFX_WHIRLPOOL: int = 0x53
+## constants/sfx_constants.asm's SFX_STRENGTH, played by MovementFunction_Strength
+## as a pushed boulder starts moving, not by the menu that sets the flag.
+const SFX_STRENGTH: int = 0x1B
 
 @export var map_group: int = 24
 @export var map_number: int = 3
@@ -464,6 +467,14 @@ func move_player(direction: Vector2i) -> bool:
 		return false
 	var movement: Dictionary = _world.move_result(direction)
 	if not bool(movement.get("ok", false)):
+		## A push bumps the player and starts the boulder, so the step reports
+		## blocked while the map still changed. MovementFunction_Strength plays
+		## SFX_STRENGTH here, not the menu that set the flag.
+		if movement.has("boulder_pushed"):
+			_play_sfx(SFX_STRENGTH)
+			if _renderer != null:
+				_renderer.refresh()
+			_refresh_labels()
 		return false
 	## A whirlpool spins the player rather than moving them, so nothing a completed
 	## step owes applies: no warp, no encounter, no repel step.
@@ -712,6 +723,23 @@ func preview_whirlpool_use() -> void:
 		_acknowledge_field_move_text()
 		return
 	preview_whirlpool()
+	if _party_host != null:
+		_party_host.handle_key(KEY_SPACE)
+
+
+## And for Strength, which unlike the other three needs nothing in front of the
+## player: .TryStrength checks the badge and stops. To watch a boulder actually
+## move, open the scene on a map that has one and press a direction into it after
+## the second call; Cianwood Gym (22/5) and Ice Path B1F are the reachable ones.
+func preview_strength() -> void:
+	_preview_field_move(Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.BADGE_PLAIN)
+
+
+func preview_strength_use() -> void:
+	if _field_move_text:
+		_acknowledge_field_move_text()
+		return
+	preview_strength()
 	if _party_host != null:
 		_party_host.handle_key(KEY_SPACE)
 
@@ -1341,6 +1369,16 @@ func _on_party_action(action: Dictionary) -> void:
 				_show_field_move_text(_surf_refusal(StringName(surf.get("reason", &""))))
 				return
 			_show_field_move_text("%s used SURF!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_STRENGTH:
+			var strength: Dictionary = _world.strength_request(
+				_party_species(int(action.get("slot", -1)))
+			)
+			if not bool(strength.get("ok", false)):
+				_show_field_move_text(
+					_strength_refusal(StringName(strength.get("reason", &"")))
+				)
+				return
+			_show_field_move_text("%s used STRENGTH!" % String(action.get("name", "")))
 		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
 			var whirlpool: Dictionary = _world.whirlpool_request()
 			if not bool(whirlpool.get("ok", false)):
@@ -1396,6 +1434,14 @@ func _whirlpool_refusal(reason: StringName) -> String:
 	return "Can't use that here."
 
 
+## .TryStrength's only refusal is CheckBadge's, since it checks nothing else;
+## anything past it is this project's own guard, not a cartridge branch.
+func _strength_refusal(reason: StringName) -> String:
+	if reason == &"badge_required":
+		return "Sorry! A new BADGE is required."
+	return "Can't use that here."
+
+
 func _show_field_move_text(text: String) -> void:
 	_field_move_text = true
 	if _text_box != null and _text_box.font != null:
@@ -1427,13 +1473,18 @@ func _acknowledge_field_move_text() -> void:
 	if not _world.pending_whirlpool().is_empty():
 		_commit_field_move(_world.complete_whirlpool(), "Whirlpool")
 		return
+	if not _world.pending_strength().is_empty():
+		_commit_field_move(_world.complete_strength(), "Strength")
+		return
 	_script_prompt = ""
 	_refresh_labels()
 
 
 ## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN, Whirlpool plays SFX_SURF and Surf
-## changes the music, so each commit reports its own audio; all three redraw,
-## because each changed what the map or the player looks like.
+## changes the music, so each commit reports its own audio. Strength is the one
+## that plays nothing: Script_UsedStrength has no PlaySFX, because SFX_STRENGTH
+## belongs to the boulder that moves later, not to the flag being set. All four
+## redraw anyway, since the party overlay closed over the map.
 func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
 		match StringName(applied.get("kind", &"")):
@@ -1441,6 +1492,8 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 				_play_current_map_music()
 			&"whirlpool_applied":
 				_play_sfx(SFX_WHIRLPOOL)
+			&"strength_applied":
+				pass
 			_:
 				_play_sfx(SFX_CUT)
 		if _renderer != null:
@@ -1767,12 +1820,31 @@ func _refresh_party_summary() -> void:
 		return
 	var has_pokerus: bool = false
 	var species: Array[int] = []
+	var moves: Array = []
+	var names: Array = []
 	for member: Variant in save.party:
 		if member is Gen2SaveMon:
-			if (int((member as Gen2SaveMon).pokerus) & 0x0F) != 0:
+			var mon: Gen2SaveMon = member as Gen2SaveMon
+			if (int(mon.pokerus) & 0x0F) != 0:
 				has_pokerus = true
-			species.append(int((member as Gen2SaveMon).species))
-	_world.set_party_summary(save.party.size(), has_pokerus, species)
+			species.append(int(mon.species))
+			# CheckPartyMove walks every slot's four move slots; zeroes are empty
+			# slots, not moves, so they are dropped rather than searched.
+			var mon_moves: Array = []
+			for move: int in mon.moves:
+				if move != 0:
+					mon_moves.append(move)
+			moves.append(mon_moves)
+			names.append(_mon_display_name(mon))
+	_world.set_party_summary(save.party.size(), has_pokerus, species, moves, names)
+
+
+## GetPartyNickname's answer for one slot, following the party screen's own rule:
+## the stored nickname, or the species name when the save carries none.
+func _mon_display_name(mon: Gen2SaveMon) -> String:
+	if not mon.nickname.is_empty():
+		return mon.nickname
+	return String(_data.species(mon.species).get("name", "")) if _data != null else ""
 
 
 func _refresh_labels() -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -80,6 +80,23 @@ const SPECIAL_INITIAL_SET_DST_FLAG: int = 166
 const SPECIAL_INITIAL_CLEAR_DST_FLAG: int = 167
 const SPECIAL_FADE_OUT_MUSIC: int = 106
 const SPECIAL_INIT_ROAM_MONS: int = 105
+## StrengthBoulderScript's index in StdScripts (engine/events/std_scripts.asm),
+## the same 14 in both pins despite the tables being 52 and 46 long. Every
+## boulder object in every map reaches Strength through `jumpstd` on it.
+const STD_STRENGTH_BOULDER: int = 14
+## TryStrengthOW's three wScriptVar answers. `.already_using` names the branch
+## taken when `bit` sets Z, that is when the flag is still *clear*, so 0 is the
+## value that asks and 2 the value that reports the flag already set.
+const STRENGTH_OW_ASK: int = 0
+const STRENGTH_OW_UNABLE: int = 1
+const STRENGTH_OW_ALREADY_ACTIVE: int = 2
+## data/text/common_2.asm. Synthesized rather than decoded because the script
+## that shows them is reached only through `callasm`, which has no runner; see
+## _stage_strength_boulder().
+const STRENGTH_ASK_TEXT: String = \
+	"A #MON may be\nable to move this.\n\nWant to use\nSTRENGTH?"
+const STRENGTH_MAY_MOVE_TEXT: String = "A #MON may be\nable to move this."
+const STRENGTH_BOULDERS_MOVE_TEXT: String = "Boulders may now\nbe moved!"
 ## wBattleResult, which startbattle copies into wScriptVar
 ## (constants/battle_constants.asm).
 const BATTLE_RESULT_WIN: int = 0
@@ -197,6 +214,34 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				_script_value = 1
 				return advance()
 			_stage_day_of_week_menu()
+			return _waiting_result()
+		## AskStrengthScript's `.AskStrength`: opentext, writetext, yesorno. The
+		## text pause is acknowledged first, then the choice is offered.
+		if pending_type == &"text" and _pending.get("special", &"") == &"strength_ask":
+			_pending = {
+				"type": &"choice",
+				"command": &"yesorno",
+				"choices": [&"yes", &"no"],
+				"special": &"strength_ask",
+				"slot": int(_pending.get("slot", -1)),
+				"source": _request.duplicate(true),
+			}
+			return _waiting_result()
+		if pending_type == &"choice" and _pending.get("special", &"") == &"strength_ask":
+			if choice < 0:
+				return _waiting_result()
+			var chosen_slot: int = int(_pending.get("slot", -1))
+			_pending = {}
+			## `iftrue Script_UsedStrength`, and a no falls to closetext/end.
+			_script_value = 1 if choice == 0 else 0
+			if choice != 0:
+				return _complete()
+			_stage_strength_used(chosen_slot)
+			return _waiting_result()
+		## Script_UsedStrength's second writetext, _MoveBoulderText.
+		if pending_type == &"text" and _pending.get("special", &"") == &"strength_used":
+			var used_name: String = String(_pending.get("name", "#MON"))
+			_stage_internal_text("%s can\nmove boulders." % used_name, true)
 			return _waiting_result()
 		if pending_type in [&"choice", &"menu"]:
 			if choice < 0:
@@ -583,6 +628,8 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.IFLESS:
 			return _branch(_script_value < int(command["value"]), bank, int(command["address"]))
 		Gen2WorldScript.JUMPSTD:
+			if int(command["address"]) == STD_STRENGTH_BOULDER:
+				return _stage_strength_boulder()
 			var jump_standard: Dictionary = _standard_script(int(command["address"]))
 			if jump_standard.is_empty():
 				return {
@@ -595,6 +642,8 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 				jump_standard["data"]
 			)
 		Gen2WorldScript.CALLSTD:
+			if int(command["address"]) == STD_STRENGTH_BOULDER:
+				return _stage_strength_boulder()
 			var call_standard: Dictionary = _standard_script(int(command["address"]))
 			if call_standard.is_empty():
 				return {
@@ -781,9 +830,10 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 			## Script_checkpoke sets wScriptVar from whether the species is in
 			## wPartySpecies (engine/overworld/scripting.asm). The read-only party
 			## summary is the only party this scene-free runner may read, and an
-			## absent one fails the way VAR_PARTYCOUNT does.
+			## absent one fails the way VAR_PARTYCOUNT does. A summary carrying an
+			## empty species list answers 0, not a failure.
 			var party: Dictionary = _request.get("party", {})
-			if party.is_empty() or not party.has("species"):
+			if party.is_empty():
 				return {"ok": false, "reason": &"missing_party_summary", "command": command}
 			var species: Array = party.get("species", [])
 			_script_value = 1 if int(command.get("value", 0)) in species else 0
@@ -1848,6 +1898,84 @@ func _emit_object_event(event_type: StringName, values: Dictionary) -> void:
 	for key: Variant in values:
 		event[key] = values[key]
 	_events.append(event)
+
+
+## engine/events/overworld.asm's AskStrengthScript, synthesized.
+##
+## StrengthBoulderScript is `farsjump AskStrengthScript`, whose first command is
+## `callasm TryStrengthOW`. `callasm` has no runner here and its operand is a
+## link-time address absent from the pinned disassemblies, so the seam sits on
+## the standard-script index instead, which is 14 in both pins and verified by
+## the imported table. The synthesized body is the same shape trainer object
+## dispatch takes: source sequence, project metadata.
+##
+## Every branch of AskStrengthScript terminates, so this never returns to a
+## caller and jumpstd and callstd resolve alike.
+func _stage_strength_boulder() -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "standard_index": STD_STRENGTH_BOULDER}
+	var slot: int = _party_slot_with_move(Gen2WorldFieldMove.MOVE_STRENGTH)
+	var has_badge: bool = _engine_flag_active(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_PLAIN, _crystal_commands())
+	)
+	if slot < 0 or not has_badge:
+		_script_value = STRENGTH_OW_UNABLE
+		return _stage_internal_text(STRENGTH_MAY_MOVE_TEXT, true)
+	if _engine_flag_active(Gen2WorldState.strength_active_flag(_crystal_commands())):
+		_script_value = STRENGTH_OW_ALREADY_ACTIVE
+		return _stage_internal_text(STRENGTH_BOULDERS_MOVE_TEXT, true)
+	_script_value = STRENGTH_OW_ASK
+	_pending = {
+		"type": &"text",
+		"text": STRENGTH_ASK_TEXT,
+		"internal_text": true,
+		"special": &"strength_ask",
+		"slot": slot,
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = false
+	return {"ok": true}
+
+
+## CheckPartyMove: the first slot whose move list carries [param move], or -1.
+## The mirror's per-slot lists are the only party this scene-free runner reads.
+func _party_slot_with_move(move: int) -> int:
+	var moves: Array = _request.get("party", {}).get("moves", [])
+	for slot: int in moves.size():
+		if moves[slot] is Array and (moves[slot] as Array).has(move):
+			return slot
+	return -1
+
+
+## SetStrengthFlag plus Script_UsedStrength's two texts. The cry and its three
+## frame pause are presentation the runner does not own, so the two writetexts
+## become two pauses back to back, which is what a reader sees either way.
+func _stage_strength_used(slot: int) -> Dictionary:
+	_staged_engine_flags[Gen2WorldState.strength_active_flag(_crystal_commands())] = true
+	var names: Array = _request.get("party", {}).get("names", [])
+	var name: String = String(names[slot]) if slot >= 0 and slot < names.size() else "#MON"
+	_pending = {
+		"type": &"text",
+		"text": "%s used\nSTRENGTH!" % name,
+		"internal_text": true,
+		"special": &"strength_used",
+		"name": name,
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = false
+	return {"ok": true}
+
+
+func _stage_internal_text(text: String, finish_after: bool) -> Dictionary:
+	_pending = {
+		"type": &"text",
+		"text": text,
+		"internal_text": true,
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = finish_after
+	return {"ok": true}
 
 
 func _stage_button(command: Dictionary) -> Dictionary:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -28,6 +28,13 @@ const ENGINE_HALL_OF_FAME: int = ENGINE_CREDITS_SKIP
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 86
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER: int = 85
 
+## wBikeFlags' BIKEFLAGS_STRENGTH_ACTIVE_F, three engine flags ahead of the badge
+## section and so profile split the same way. Nothing in the pinned engine/ or
+## home/ ever clears it: SetStrengthFlag is the only writer, so it persists for
+## the save across maps, warps and snapshots.
+const ENGINE_STRENGTH_ACTIVE: int = 24
+const ENGINE_STRENGTH_ACTIVE_GOLD_SILVER: int = 23
+
 ## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array, and
 ## VAR_BADGES counts both bytes, not Johto alone. These are Crystal indices:
 ## pokegold's constants/engine_flags.asm has no ENGINE_MOBILE_SYSTEM, which
@@ -294,6 +301,13 @@ func bargain_merchant_closed(crystal: bool = true) -> bool:
 static func badge_flag(badge: int, crystal: bool = true) -> int:
 	var flags: Array[int] = BADGE_ENGINE_FLAGS if crystal else BADGE_ENGINE_FLAGS_GOLD_SILVER
 	return flags[badge] if badge >= 0 and badge < flags.size() else -1
+
+
+## The engine flag SetStrengthFlag sets and TryStrengthOW and
+## DoPlayerMovement.CheckStrengthBoulder read, resolved for [param crystal] the
+## way badge_flag() resolves a badge.
+static func strength_active_flag(crystal: bool = true) -> int:
+	return ENGINE_STRENGTH_ACTIVE if crystal else ENGINE_STRENGTH_ACTIVE_GOLD_SILVER
 
 
 ## Mirrors _GetVarAction's .CountBadges: a popcount over both badge bytes.

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -56,6 +56,8 @@ func _write_cut_tree() -> void:
 			raw["name"] = "CUT"
 		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_SURF:
 			raw["name"] = "SURF"
+		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_STRENGTH:
+			raw["name"] = "STRENGTH"
 		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_WHIRLPOOL:
 			raw["name"] = "WHIRLPOOL"
 	RomCache.write_json(RomCache.moves_path(directory), moves)
@@ -368,6 +370,58 @@ func test_cancel_closes_the_submenu_before_the_party_screen() -> void:
 	party.handle_key(KEY_ESCAPE)
 	await get_tree().process_frame
 	assert_null(_world_screen._party_host)
+
+
+func _open_strength_world(badge: bool = true) -> void:
+	await _open_world(
+		badge, Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.BADGE_PLAIN
+	)
+
+
+func test_submenu_lists_strength_for_a_mon_that_knows_it() -> void:
+	await _open_strength_world()
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	assert_eq(
+		_labels(party.submenu_snapshot()["items"]),
+		["STRENGTH", "STATS", "SWITCH", "MOVE", "ITEM", "CANCEL"]
+	)
+
+
+## .TryStrength checks the badge and stops, so the entry resolves facing open
+## floor with no boulder in sight, and the flag waits for the acknowledge the way
+## Cut's block change does.
+func test_choosing_strength_shows_the_message_and_defers_the_flag() -> void:
+	await _open_strength_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_null(_world_screen._party_host)
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_shown_text(), "TESTMON used STRENGTH!")
+	assert_false(world.strength_active())
+
+	_world_screen._acknowledge_field_move_text()
+	assert_false(_world_screen._field_move_text)
+	assert_true(world.strength_active())
+	assert_true(world.pending_strength().is_empty())
+
+
+func test_strength_without_the_badge_reports_the_badge_and_changes_nothing() -> void:
+	await _open_strength_world(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_key(KEY_SPACE)
+	party.handle_key(KEY_SPACE)
+	await get_tree().process_frame
+
+	assert_eq(_shown_text(), "Sorry! A new BADGE is required.")
+	_world_screen._acknowledge_field_move_text()
+	assert_false(world.strength_active())
 
 
 func test_submenu_lists_whirlpool_for_a_mon_that_knows_it() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -772,6 +772,152 @@ func test_ledge_hop_never_fires_while_surfing() -> void:
 	assert_eq(world.player_cell, Vector2i(3, 2))
 
 
+## Puts one SPRITEMOVEDATA_STRENGTH_BOULDER on [param at] and reloads, so the
+## shared fixture's own object list is untouched by every other test here.
+## ReadObjectEvents rebuilds from map data on a reload, which is what makes this
+## the same path a real map load takes.
+func _boulder_world(
+	start: Vector2i, at: Vector2i, strength: bool = true, surfing: bool = false
+) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _world(start)
+	if strength:
+		world.state.set_engine_flag(Gen2WorldState.strength_active_flag(
+			Gen2WorldState.is_crystal_profile(world.data)
+		))
+	world.current_map.events["objects"].append({
+		"sprite": 1, "x": at.x, "y": at.y,
+		"movement": Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER, "event_flag": 0xFFFF,
+	})
+	if surfing:
+		world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.reload_current_map()
+	return world
+
+
+func _boulder_at(world: Gen2WorldAPI, cell: Vector2i) -> Gen2WorldObject:
+	return world.object_at(cell)
+
+
+## Column x=11 is open land from y=0 to the map's south edge, so a push there
+## meets nothing but the rule under test.
+const BOULDER_STAND: Vector2i = Vector2i(11, 4)
+const BOULDER_CELL: Vector2i = Vector2i(11, 5)
+const BOULDER_LANDING: Vector2i = Vector2i(11, 6)
+
+
+## .CheckNPC's own comment: a movable boulder is treated the same as an NPC in
+## front, so both bump. The boulder advances a cell, the player does not, and the
+## step still reports blocked.
+func test_strength_push_moves_the_boulder_and_bumps_the_player() -> void:
+	var world: Gen2WorldAPI = _boulder_world(BOULDER_STAND, BOULDER_CELL)
+	var boulder: Gen2WorldObject = _boulder_at(world, BOULDER_CELL)
+	assert_not_null(boulder)
+
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_false(result["ok"], JSON.stringify(result))
+	assert_eq(result["reason"], &"blocked")
+	assert_eq(world.player_cell, BOULDER_STAND)
+	assert_true(result.has("boulder_pushed"), JSON.stringify(result))
+	assert_eq(result["boulder_pushed"]["from_cell"], BOULDER_CELL)
+	assert_eq(result["boulder_pushed"]["to_cell"], BOULDER_LANDING)
+	assert_eq(boulder.cell, BOULDER_LANDING)
+	assert_null(_boulder_at(world, BOULDER_CELL))
+
+
+## MovementFunction_Strength calls InitStep with `direction | 0`, the slow
+## StepVectors row: 16 frames. The cell commits when the step starts, so only the
+## drawn offset trails, and the boulder never rolls a wait afterwards because
+## StepFunction_StrengthBoulder just stands it back up.
+func test_strength_push_slides_the_boulder_over_the_slow_step_duration() -> void:
+	var world: Gen2WorldAPI = _boulder_world(BOULDER_STAND, BOULDER_CELL)
+	world.move_result(Vector2i.DOWN)
+	var boulder: Gen2WorldObject = _boulder_at(world, BOULDER_LANDING)
+	assert_not_null(boulder)
+	assert_true(boulder.is_stepping())
+	assert_eq(boulder.step_frames_total, Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH)
+
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH:
+		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+	assert_false(boulder.is_stepping())
+	assert_false(boulder.is_idle())
+	assert_eq(boulder.cell, BOULDER_LANDING)
+
+
+## The flag is the first thing .CheckStrengthBoulder tests, so without it the
+## boulder is an ordinary blocking object.
+func test_strength_push_refuses_without_the_active_flag() -> void:
+	var world: Gen2WorldAPI = _boulder_world(BOULDER_STAND, BOULDER_CELL, false)
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"blocked")
+	assert_false(result.has("boulder_pushed"))
+	assert_eq(_boulder_at(world, BOULDER_CELL).cell, BOULDER_CELL)
+
+
+## CanObjectMoveInDirection: WillObjectBumpIntoWater refuses a landing cell that
+## is not LAND_TILE, and WillObjectBumpIntoSomeoneElse refuses an occupied one.
+func test_strength_push_refuses_a_landing_cell_the_boulder_cannot_take() -> void:
+	# (2,2) is a wall directly above the boulder at (2,3).
+	var walled: Gen2WorldAPI = _boulder_world(Vector2i(2, 4), Vector2i(2, 3))
+	var into_wall: Dictionary = walled.move_result(Vector2i.UP)
+	assert_false(into_wall.has("boulder_pushed"), JSON.stringify(into_wall))
+	assert_eq(_boulder_at(walled, Vector2i(2, 3)).cell, Vector2i(2, 3))
+
+	# The shared fixture's own object stands at (5,6), so a boulder at (5,5)
+	# pushed DOWN has nowhere to land.
+	var occupied: Gen2WorldAPI = _boulder_world(Vector2i(5, 4), Vector2i(5, 5))
+	assert_not_null(occupied.object_at(Vector2i(5, 6)))
+	var into_object: Dictionary = occupied.move_result(Vector2i.DOWN)
+	assert_false(into_object.has("boulder_pushed"), JSON.stringify(into_object))
+	assert_eq(_boulder_at(occupied, Vector2i(5, 5)).cell, Vector2i(5, 5))
+
+
+## .CheckLandPerms runs before .CheckNPC, so a boulder standing where the player
+## could not walk anyway is never even considered: the leave rule on the player's
+## own COLL_RIGHT_WALL cell refuses first.
+func test_strength_push_refuses_when_the_step_itself_is_walled_off() -> void:
+	var world: Gen2WorldAPI = _boulder_world(Vector2i(2, 8), Vector2i(3, 8))
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_false(result["ok"])
+	assert_false(result.has("boulder_pushed"), JSON.stringify(result))
+	assert_eq(_boulder_at(world, Vector2i(3, 8)).cell, Vector2i(3, 8))
+
+
+## MovementFunction_Strength .on_pit stops a boulder for good before it ever
+## reads BOULDER_MOVING. Blackthorn Gym 2F is the only map that reaches it. The
+## pit is LAND_TILE, so nothing else here would have refused.
+func test_strength_push_refuses_a_boulder_standing_on_a_pit() -> void:
+	var world: Gen2WorldAPI = _boulder_world(Vector2i(6, 5), Vector2i(6, 6))
+	assert_true(Gen2WorldCollision.is_pit_tile(world.collision_code_at(Vector2i(6, 6))))
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_false(result.has("boulder_pushed"), JSON.stringify(result))
+	assert_eq(_boulder_at(world, Vector2i(6, 6)).cell, Vector2i(6, 6))
+
+
+## A boulder already sliding is not STANDING, which is .CheckStrengthBoulder's
+## second test, so a second press does not chain it another cell.
+func test_strength_push_refuses_a_boulder_already_mid_push() -> void:
+	var world: Gen2WorldAPI = _boulder_world(BOULDER_STAND, BOULDER_CELL)
+	assert_true(world.move_result(Vector2i.DOWN).has("boulder_pushed"))
+	var again: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_false(again.has("boulder_pushed"), JSON.stringify(again))
+	assert_eq(_boulder_at(world, BOULDER_LANDING).cell, BOULDER_LANDING)
+
+
+## .TrySurf calls the same .CheckNPC and .CheckStrengthBoulder checks no player
+## state, so a surfing player stepping onto a land cell pushes the boulder on it.
+func test_strength_push_works_while_surfing_onto_land() -> void:
+	# (4,8) is COLL_RIGHT_BUOY, water permission, with land below at (4,9).
+	var world: Gen2WorldAPI = _boulder_world(
+		Vector2i(4, 8), Vector2i(4, 9), true, true
+	)
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_true(result.has("boulder_pushed"), JSON.stringify(result))
+	assert_eq(_boulder_at(world, Vector2i(4, 10)).cell, Vector2i(4, 10))
+
+
 func test_side_wall_blocks_leaving_the_standing_tile_only_in_its_own_direction() -> void:
 	# (2,8) is COLL_RIGHT_WALL, land permission on every side.
 	var world: Gen2WorldAPI = _world(Vector2i(2, 8))
@@ -1153,6 +1299,121 @@ func test_interact_dispatches_a_tile_collision_std_script_when_nothing_else_answ
 	assert_false(results.is_empty())
 	assert_eq(results[0]["status"], &"complete", JSON.stringify(results[0]))
 	assert_eq(world.state.map_scene(1, 1), 90)
+
+
+## A world facing a boulder whose script is `jumpstd StrengthBoulderScript`, the
+## shape every boulder object in every map has. No standard-script entry is
+## written for index 14 on purpose: the intercept must answer before the table is
+## ever consulted, because the real entry is `farsjump AskStrengthScript` and
+## that script's first command is a `callasm` this runner cannot execute.
+func _boulder_script_world(
+	moves: Array, badge: bool = true, strength: bool = false
+) -> Gen2WorldAPI:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6100"] = [Gen2WorldScript.JUMPSTD, 14, 0]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+
+	var world: Gen2WorldAPI = _world(Vector2i(11, 4))
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	if badge:
+		world.state.set_engine_flag(
+			Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_PLAIN, crystal)
+		)
+	if strength:
+		world.state.set_engine_flag(Gen2WorldState.strength_active_flag(crystal))
+	world.current_map.events["objects"].append({
+		"sprite": 1, "x": 11, "y": 5,
+		"movement": Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER,
+		"script": 0x6100, "event_flag": 0xFFFF,
+	})
+	world.reload_current_map()
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	world.set_party_summary(1, false, [25] as Array[int], moves, ["CHIKORITA"])
+	return world
+
+
+## TryStrengthOW answers 1 when CheckPartyMove finds nothing or the badge is
+## missing, and AskStrengthScript's `.DontMeetRequirements` shows
+## BouldersMayMoveText for it.
+func test_boulder_script_reports_no_strength_without_the_move_or_the_badge() -> void:
+	var no_move: Gen2WorldAPI = _boulder_script_world([[]])
+	var without_move: Array = no_move.interact()
+	assert_eq(without_move[0]["status"], &"waiting", JSON.stringify(without_move[0]))
+	assert_eq(
+		String(without_move[0]["event"]["text"]),
+		Gen2WorldScriptRunner.STRENGTH_MAY_MOVE_TEXT
+	)
+	assert_eq(no_move.run_event_queue(true)[0]["status"], &"complete")
+	assert_false(no_move.strength_active())
+
+	var no_badge: Gen2WorldAPI = _boulder_script_world(
+		[[Gen2WorldFieldMove.MOVE_STRENGTH]], false
+	)
+	var without_badge: Array = no_badge.interact()
+	assert_eq(
+		String(without_badge[0]["event"]["text"]),
+		Gen2WorldScriptRunner.STRENGTH_MAY_MOVE_TEXT
+	)
+	assert_false(no_badge.strength_active())
+
+
+## TryStrengthOW answers 2 once the flag is set, and `.AlreadyUsedStrength` shows
+## BouldersMoveText without asking again.
+func test_boulder_script_reports_boulders_already_movable() -> void:
+	var world: Gen2WorldAPI = _boulder_script_world(
+		[[Gen2WorldFieldMove.MOVE_STRENGTH]], true, true
+	)
+	var results: Array = world.interact()
+	assert_eq(
+		String(results[0]["event"]["text"]),
+		Gen2WorldScriptRunner.STRENGTH_BOULDERS_MOVE_TEXT
+	)
+	assert_eq(world.run_event_queue(true)[0]["status"], &"complete")
+	assert_true(world.strength_active())
+
+
+## TryStrengthOW answers 0, so `.AskStrength` opens the yes/no. A yes runs
+## Script_UsedStrength: SetStrengthFlag, then its two texts.
+func test_boulder_script_asks_and_a_yes_sets_the_flag() -> void:
+	var world: Gen2WorldAPI = _boulder_script_world([[Gen2WorldFieldMove.MOVE_STRENGTH]])
+	var asked: Array = world.interact()
+	assert_eq(
+		String(asked[0]["event"]["text"]), Gen2WorldScriptRunner.STRENGTH_ASK_TEXT
+	)
+	assert_false(world.strength_active())
+
+	var choice: Array = world.run_event_queue(true)
+	assert_eq(StringName(choice[0]["event"]["type"]), &"choice")
+	assert_eq(choice[0]["event"]["choices"], [&"yes", &"no"])
+
+	var used: Array = world.run_event_queue(true, 0)
+	assert_eq(String(used[0]["event"]["text"]), "CHIKORITA used\nSTRENGTH!")
+
+	var boulders: Array = world.run_event_queue(true)
+	assert_eq(String(boulders[0]["event"]["text"]), "CHIKORITA can\nmove boulders.")
+
+	assert_eq(world.run_event_queue(true)[0]["status"], &"complete")
+	assert_true(world.strength_active())
+
+
+## A no falls through to closetext/end, so nothing is committed.
+func test_boulder_script_leaves_the_flag_clear_on_a_no() -> void:
+	var world: Gen2WorldAPI = _boulder_script_world([[Gen2WorldFieldMove.MOVE_STRENGTH]])
+	world.interact()
+	world.run_event_queue(true)
+	var refused: Array = world.run_event_queue(true, 1)
+	assert_eq(refused[0]["status"], &"complete", JSON.stringify(refused[0]))
+	assert_false(world.strength_active())
+
+
+## CheckPartyMove has nothing to read without the mirror, so the script fails
+## rather than answering "nobody knows it", the way VAR_PARTYCOUNT does.
+func test_boulder_script_fails_without_a_party_summary() -> void:
+	var world: Gen2WorldAPI = _boulder_script_world([[Gen2WorldFieldMove.MOVE_STRENGTH]])
+	world.clear_party_summary()
+	var results: Array = world.interact()
+	assert_eq(results[0]["status"], &"failed", JSON.stringify(results[0]))
+	assert_eq(results[0]["reason"], &"missing_party_summary")
 
 
 func test_interact_finds_no_tile_collision_script_for_an_untabled_code() -> void:
@@ -2170,10 +2431,16 @@ func test_check_pokerus_special_fails_without_a_party_summary() -> void:
 func test_party_summary_round_trips_and_reaches_queued_script_requests() -> void:
 	var world: Gen2WorldAPI = _world()
 	assert_true(world.party_summary().is_empty())
-	assert_true(world.set_party_summary(3, true, [25, 1] as Array[int])["ok"])
-	assert_eq(world.party_summary(), {"count": 3, "pokerus": true, "species": [25, 1]})
+	assert_true(world.set_party_summary(
+		3, true, [25, 1] as Array[int], [[0x46], []], ["PIKA", "BULBASAUR"]
+	)["ok"])
+	var expected: Dictionary = {
+		"count": 3, "pokerus": true, "species": [25, 1],
+		"moves": [[0x46], []], "names": ["PIKA", "BULBASAUR"],
+	}
+	assert_eq(world.party_summary(), expected)
 	assert_false(world.set_party_summary(-1, false)["ok"])
-	assert_eq(world.party_summary(), {"count": 3, "pokerus": true, "species": [25, 1]})
+	assert_eq(world.party_summary(), expected)
 	world.clear_party_summary()
 	assert_true(world.party_summary().is_empty())
 

--- a/tests/unit/test_world_collision.gd
+++ b/tests/unit/test_world_collision.gd
@@ -317,6 +317,18 @@ func test_forced_action_steps_down_off_doors_stairs_and_caves() -> void:
 		)
 
 
+## home/map_objects.asm's CheckPitTile is the two codes and nothing else, so the
+## neighbouring warp codes must not answer it even though is_warp_tile() takes
+## all of them.
+func test_pit_tiles_are_the_two_source_codes() -> void:
+	assert_true(Gen2WorldCollision.is_pit_tile(0x60))
+	assert_true(Gen2WorldCollision.is_pit_tile(0x68))
+	for code: int in [0x61, 0x67, 0x69, 0x70, 0x71, 0x7B, 0x00]:
+		assert_false(Gen2WorldCollision.is_pit_tile(code), "code $%02x" % code)
+	assert_true(Gen2WorldCollision.is_warp_tile(0x60))
+	assert_true(Gen2WorldCollision.is_warp_tile(0x68))
+
+
 func _assert_forced_walk(code: int, direction: Vector2i) -> void:
 	var forced: Dictionary = Gen2WorldCollision.forced_action(code)
 	if direction == Vector2i.ZERO:

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -216,6 +216,19 @@ func _surf_world(badge: bool = true, stand: Vector2i = SHORE_CELL) -> Gen2WorldA
 	return world
 
 
+## A world on the shore with the Plain Badge on whichever engine flag table the
+## opened cache selects. Strength needs nothing in front of the player, so the
+## start cell only has to be somewhere ordinary.
+func _strength_world(badge: bool = true) -> Gen2WorldAPI:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	if badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_PLAIN, Gen2WorldState.is_crystal_profile(data)
+		))
+	return Gen2WorldAPI.open(data, 1, 1, SHORE_CELL, state)
+
+
 ## A world beside the whirlpool and facing it, surfing, with the Glacier Badge on
 ## whichever engine flag table the opened cache selects.
 func _whirlpool_world(badge: bool = true) -> Gen2WorldAPI:
@@ -231,18 +244,106 @@ func _whirlpool_world(badge: bool = true) -> Gen2WorldAPI:
 	return world
 
 
-func test_cut_surf_and_whirlpool_are_the_field_moves_the_submenu_offers() -> void:
+func test_cut_surf_strength_and_whirlpool_are_the_field_moves_the_submenu_offers() -> void:
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_CUT))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SURF))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_STRENGTH))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL))
 	assert_eq(Gen2WorldFieldMove.MOVE_CUT, 0x0F)
 	assert_eq(Gen2WorldFieldMove.MOVE_SURF, 0x39)
+	assert_eq(Gen2WorldFieldMove.MOVE_STRENGTH, 0x46)
 	assert_eq(Gen2WorldFieldMove.MOVE_WHIRLPOOL, 0xFA)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: FLY, STRENGTH, FLASH,
-	# WATERFALL, HEADBUTT.
-	for move: int in [0x13, 0x46, 0x94, 0x7F, 0x1D]:
+	# submenu would offer an entry nothing answers: FLY, FLASH, WATERFALL,
+	# HEADBUTT.
+	for move: int in [0x13, 0x94, 0x7F, 0x1D]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
+
+
+## .TryStrength is CheckBadge ENGINE_PLAINBADGE and nothing else, so a request
+## made facing open floor with no boulder anywhere resolves. That is the whole
+## difference from Cut, Surf and Whirlpool.
+func test_strength_request_checks_the_plain_badge_and_nothing_else() -> void:
+	var world: Gen2WorldAPI = _strength_world()
+	world.player_cell = Vector2i(1, 1)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var request: Dictionary = world.strength_request(25)
+	assert_true(request["ok"], JSON.stringify(request))
+	assert_eq(StringName(request["kind"]), &"strength_requested")
+	assert_eq(int(request["move"]), Gen2WorldFieldMove.MOVE_STRENGTH)
+	assert_eq(int(request["species"]), 25)
+	assert_eq(world.pending_strength(), request)
+
+
+func test_strength_request_refuses_without_the_plain_badge() -> void:
+	var world: Gen2WorldAPI = _strength_world(false)
+	var request: Dictionary = world.strength_request()
+	assert_false(request["ok"])
+	assert_eq(StringName(request["kind"]), &"strength_failed")
+	assert_eq(StringName(request["reason"]), &"badge_required")
+	assert_true(world.pending_strength().is_empty())
+
+
+## The badge flag is profile split, so a Crystal-numbered write must not satisfy
+## a Gold/Silver .TryStrength, the way the Cut and Surf cases check theirs.
+func test_strength_request_refuses_the_other_profiles_badge_flag() -> void:
+	_gold_profile()
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_PLAIN, true))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(1, 1), state)
+	assert_eq(StringName(world.strength_request()["reason"]), &"badge_required")
+
+
+## SetStrengthFlag is the only writer of BIKEFLAGS_STRENGTH_ACTIVE_F in the
+## pinned sources, and Script_UsedStrength reaches it only after its text, so
+## nothing is set until the commit.
+func test_complete_strength_sets_the_flag_only_after_the_request() -> void:
+	var world: Gen2WorldAPI = _strength_world()
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	assert_false(world.strength_active())
+
+	assert_eq(StringName(world.complete_strength()["reason"]), &"no_pending_strength")
+	assert_false(world.strength_active())
+
+	assert_true(world.strength_request(25)["ok"])
+	assert_false(world.strength_active())
+
+	var applied: Dictionary = world.complete_strength()
+	assert_true(applied["ok"], JSON.stringify(applied))
+	assert_eq(StringName(applied["kind"]), &"strength_applied")
+	assert_eq(int(applied["species"]), 25)
+	assert_true(world.strength_active())
+	assert_true(world.state.is_engine_flag_active(
+		Gen2WorldState.strength_active_flag(crystal)
+	))
+	assert_true(world.pending_strength().is_empty())
+
+
+## Nothing clears the flag, so it has to outlive the map reload and the warp that
+## drop every staged field-move request.
+func test_strength_stays_active_across_a_map_reload_and_a_warp() -> void:
+	var world: Gen2WorldAPI = _strength_world()
+	assert_true(world.strength_request()["ok"])
+	assert_true(world.complete_strength()["ok"])
+
+	world.reload_current_map()
+	assert_true(world.strength_active())
+
+	world.player_cell = SHORE_CELL
+	assert_true(world.try_warp()["ok"])
+	assert_eq(world.map_id(), Vector2i(1, 2))
+	assert_true(world.strength_active())
+
+
+## A staged request dies with the loaded map beside the other three, because
+## Script_StrengthFromMenu runs the moment it is queued.
+func test_pending_strength_is_dropped_by_a_map_reload() -> void:
+	var world: Gen2WorldAPI = _strength_world()
+	assert_true(world.strength_request()["ok"])
+	world.reload_current_map()
+	assert_true(world.pending_strength().is_empty())
+	assert_false(world.strength_active())
 
 
 func test_surf_sprite_follows_get_surf_type() -> void:

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -129,5 +129,27 @@ func test_only_deciding_templates_advance_on_their_own() -> void:
 		Gen2WorldObject.MOVEMENT_STILL, Gen2WorldObject.MOVEMENT_FIXED_DOWN,
 		Gen2WorldObject.MOVEMENT_FIXED_UP, Gen2WorldObject.MOVEMENT_FIXED_LEFT,
 		Gen2WorldObject.MOVEMENT_FIXED_RIGHT,
+		Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER,
 	]:
 		assert_false(_object(movement).movement_advances(), "movement %d stands" % movement)
+
+
+## SPRITEMOVEDATA_STRENGTH_BOULDER is $19, and the constants file's comment
+## column is hex: reading it as decimal 19 would collide with
+## SPRITEMOVEDATA_FOLLOWING. A boulder reacts to a push and decides nothing on
+## its own, so it stays out of both template sets.
+func test_strength_boulder_is_a_hex_template_that_never_decides() -> void:
+	assert_eq(Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER, 0x19)
+	assert_ne(Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER, Gen2WorldObject.MOVEMENT_FOLLOW)
+	var boulder: Gen2WorldObject = _object(Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER)
+	assert_true(boulder.is_strength_boulder())
+	assert_false(boulder.movement_supported())
+	assert_false(boulder.movement_advances())
+	assert_eq(boulder.next_direction(RandomNumberGenerator.new()), Vector2i.ZERO)
+	for movement: int in [
+		Gen2WorldObject.MOVEMENT_STILL, Gen2WorldObject.MOVEMENT_FOLLOW,
+		Gen2WorldObject.MOVEMENT_WANDER,
+	]:
+		assert_false(
+			_object(movement).is_strength_boulder(), "movement %d is not a boulder" % movement
+		)

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -58,6 +58,44 @@ func test_badge_count_matches_active_flags_across_both_bytes() -> void:
 	assert_eq(kanto_only.badge_count(), 1)
 
 
+## BIKEFLAGS_STRENGTH_ACTIVE_F sits three flags ahead of ENGINE_ZEPHYRBADGE, so
+## it carries the same one-index profile shift the badges do, and it must not be
+## confused with a badge in either direction.
+func test_strength_active_flag_is_profile_split_and_is_not_a_badge() -> void:
+	assert_eq(Gen2WorldState.strength_active_flag(true), 24)
+	assert_eq(Gen2WorldState.strength_active_flag(false), 23)
+	assert_eq(
+		Gen2WorldState.strength_active_flag(true),
+		Gen2WorldState.badge_flag(0, true) - 3
+	)
+	assert_eq(
+		Gen2WorldState.strength_active_flag(false),
+		Gen2WorldState.badge_flag(0, false) - 3
+	)
+
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.strength_active_flag(true))
+	assert_true(state.is_engine_flag_active(Gen2WorldState.strength_active_flag(true)))
+	assert_false(state.is_engine_flag_active(Gen2WorldState.strength_active_flag(false)))
+	assert_eq(state.badge_count(true), 0)
+	assert_eq(state.badge_count(false), 0)
+
+
+## Nothing in the pinned engine/ or home/ ever clears BIKEFLAGS_STRENGTH_ACTIVE_F,
+## and engine flags serialize with the world snapshot, so the flag has to outlive
+## a round trip and the map-reload reset that clears temporary event flags.
+func test_strength_active_flag_survives_round_trip_and_map_reload() -> void:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.strength_active_flag(true))
+	state.set_event_flag(0, true)
+
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_true(restored.is_engine_flag_active(Gen2WorldState.strength_active_flag(true)))
+	restored.reset_map_reload_flags()
+	assert_true(restored.is_engine_flag_active(Gen2WorldState.strength_active_flag(true)))
+	assert_false(restored.is_event_flag_active(0))
+
+
 ## pokegold's engine flag table has no ENGINE_MOBILE_SYSTEM entry ahead of the
 ## badge section, so every pokegold badge sits one index lower than the same
 ## symbol in pokecrystal's constants/engine_flags.asm. A Crystal-numbered

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -627,7 +627,7 @@ func _story_path(data: GameData) -> Dictionary:
 
 	# The Pokemon Center nurse reads CheckPokerus and VAR_PARTYCOUNT, so the
 	# world needs the read-only party mirror before either can resolve.
-	world.set_party_summary(save.party.size(), false)
+	_mirror_party(world, save)
 
 	var pokecenter_warp: Dictionary = _warp_to(world.current_map, 10, 10)
 	if pokecenter_warp.is_empty():
@@ -842,7 +842,7 @@ func _hive_badge_path(
 		return {"ok": false, "path": path, "reason": "Togepi egg event did not finish"}
 	if not _party_has_egg(save):
 		return {"ok": false, "path": path, "reason": "the Togepi egg did not reach the party"}
-	world.set_party_summary(save.party.size(), false)
+	_mirror_party(world, save)
 
 	var leaving_pokecenter: Dictionary = _warp_step(world, 10, 5)
 	if not bool(leaving_pokecenter.get("ok", false)):
@@ -1238,7 +1238,7 @@ func _plain_badge_path(
 			"reason": "Route 34 to Goldenrod failed: %s" % goldenrod.get("reason", ""),
 		}
 
-	world.set_party_summary(save.party.size(), false)
+	_mirror_party(world, save)
 	var gym: Dictionary = _warp_walk(world, Vector2i(24, 7), save, random, data)
 	if not bool(gym.get("ok", false)):
 		return {
@@ -1614,7 +1614,7 @@ func _fog_badge_path(
 		world, world.dispatch_map_entry(), save, random, data
 	)
 
-	world.set_party_summary(save.party.size(), false)
+	_mirror_party(world, save)
 	var gym: Dictionary = _warp_walk(world, Vector2i(6, 27), save, random, data)
 	if not bool(gym.get("ok", false)):
 		return {
@@ -1829,7 +1829,7 @@ func _mineral_badge_path(
 	if not bool(second_visit.get("ok", false)):
 		return second_visit
 
-	world.set_party_summary(save.party.size(), false)
+	_mirror_party(world, save)
 	var gym: Dictionary = _warp_walk(world, Vector2i(10, 11), save, random, data)
 	if not bool(gym.get("ok", false)):
 		return {
@@ -2395,7 +2395,7 @@ func _glacier_badge_path(
 			world, world.dispatch_map_entry(), save, random, data
 		)
 
-	world.set_party_summary(save.party.size(), false)
+	_mirror_party(world, save)
 	var gym: Dictionary = _warp_walk(world, Vector2i(6, 13), save, random, data)
 	if not bool(gym.get("ok", false)):
 		return {
@@ -2754,6 +2754,24 @@ func _party_species(save: Gen2SaveData) -> Array:
 	for mon: Gen2SaveMon in save.party:
 		values.append({"species": mon.species, "level": mon.level, "egg": mon.is_egg})
 	return values
+
+
+## The whole read-only mirror in one call, so every leg answers VAR_PARTYCOUNT,
+## CheckPokerus, checkpoke and CheckPartyMove the same way. Pokerus is false
+## throughout: nothing on this route gives it.
+func _mirror_party(world: Gen2WorldAPI, save: Gen2SaveData) -> void:
+	var species: Array[int] = []
+	var moves: Array = []
+	var names: Array = []
+	for mon: Gen2SaveMon in save.party:
+		species.append(int(mon.species))
+		var mon_moves: Array = []
+		for move: int in mon.moves:
+			if move != 0:
+				mon_moves.append(move)
+		moves.append(mon_moves)
+		names.append(mon.nickname if not mon.nickname.is_empty() else "")
+	world.set_party_summary(save.party.size(), false, species, moves, names)
 
 
 func _party_has_egg(save: Gen2SaveData) -> bool:

--- a/tools/validate_strength.gd
+++ b/tools/validate_strength.gd
@@ -1,0 +1,235 @@
+extends SceneTree
+
+## Verifies Strength and boulder pushing against freshly imported real caches,
+## for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## engine/events/overworld.asm's StrengthFunction, TryStrengthOW and
+## AskStrengthScript, engine/overworld/player_movement.asm's
+## DoPlayerMovement.CheckStrengthBoulder, engine/overworld/map_objects.asm's
+## MovementFunction_Strength and engine/overworld/npc_movement.asm's
+## CanObjectMoveInDirection. All five are byte identical between the pins, so
+## nothing here is profile split except the two engine flag numbers.
+##
+## The real-cartridge counterpart to the Strength cases in
+## tests/unit/test_world_field_move.gd and tests/unit/test_world_api.gd.
+## Cianwood Gym is the acceptance case, because its three-boulder wall is what a
+## playthrough meets first.
+##
+##   Godot --headless --path . -s res://tools/validate_strength.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm, CIANWOOD group. Unlike Dragon's Den, the group
+## and number agree between the pins.
+const GYM_GROUP: int = 22
+const GYM_NUMBER: int = 5
+## maps/CianwoodGym.asm's object events: one boulder north at (5,1) and the
+## three-boulder wall across the corridor at row 7.
+const GYM_WALL_CELLS: Array[Vector2i] = [
+	Vector2i(3, 7), Vector2i(4, 7), Vector2i(5, 7),
+]
+const GYM_LONE_BOULDER: Vector2i = Vector2i(5, 1)
+## The wall's middle boulder, approached from below and pushed north.
+const GYM_PUSH_CELL: Vector2i = Vector2i(4, 7)
+const GYM_PUSH_STAND: Vector2i = Vector2i(4, 8)
+const GYM_PUSH_LANDING: Vector2i = Vector2i(4, 6)
+## maps/CianwoodGym.asm's first warp event, out to Cianwood City.
+const GYM_EXIT_CELL: Vector2i = Vector2i(4, 17)
+
+## Census of the real caches, pinned so a cache change is loud. Both pins ship
+## the same 20 boulders over the same 9 maps: Blackthorn Gym 2F 6, Cianwood Gym
+## and Ice Path B1F 4 each, and one each in Burned Tower B1F, Mount Mortar B1F,
+## Mount Mortar 1F Inside, Union Cave B1F, Slowpoke Well B1F and Whirl Island
+## B1F.
+const EXPECTED_CENSUS: Dictionary = {
+	# game id: [boulder objects, maps carrying one]
+	&"gold": [20, 9],
+	&"silver": [20, 9],
+	&"crystal": [20, 9],
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_census(game_id, data)
+		_verify_cianwood_gym(game_id, data, Gen2WorldState.is_crystal_profile(data))
+	_finish()
+
+
+## Counts every SPRITEMOVEDATA_STRENGTH_BOULDER object event, so a cache change
+## that drops or moves one is loud rather than quietly sealing a route.
+func _census(game_id: StringName, data: GameData) -> void:
+	var boulders: int = 0
+	var maps: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		for row: Dictionary in map.events.get("objects", []):
+			if int(row.get("movement", 0)) != Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER:
+				continue
+			boulders += 1
+			maps[Vector2i(map.group, map.number)] = true
+
+	var counts: Array = [boulders, maps.size()]
+	print("%s: %d strength boulders across %d maps." % [game_id, counts[0], counts[1]])
+	_check(
+		counts == EXPECTED_CENSUS.get(game_id, []),
+		"%s: boulder census is %s, not the pinned %s." % [
+			game_id, counts, EXPECTED_CENSUS.get(game_id, []),
+		]
+	)
+
+
+func _verify_cianwood_gym(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var badge: int = Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_PLAIN, crystal)
+	var world: Gen2WorldAPI = _gym_world(data, crystal, true)
+	if not _check(
+		world != null, "%s: Cianwood Gym %d/%d is missing." % [game_id, GYM_GROUP, GYM_NUMBER]
+	):
+		return
+
+	for cell: Vector2i in GYM_WALL_CELLS + [GYM_LONE_BOULDER]:
+		var boulder: Gen2WorldObject = world.object_at(cell)
+		_check(
+			boulder != null and boulder.is_strength_boulder(),
+			"%s: Cianwood Gym %s carries no strength boulder." % [game_id, cell]
+		)
+
+	# .CheckLandPerms passes on the boulder's own cell, so what refuses the step
+	# is .CheckNPC alone: the wall is objects, not collision.
+	_check(
+		world.collision_permission_at(GYM_PUSH_CELL) == Gen2WorldCollision.LAND_TILE,
+		"%s: Cianwood Gym %s is not walkable ground under its boulder." % [
+			game_id, GYM_PUSH_CELL,
+		]
+	)
+
+	# .CheckNPC's own comment: a movable boulder bumps the player like any other.
+	var pushed: Dictionary = world.move_result(Vector2i.UP)
+	_check(
+		not bool(pushed.get("ok", false))
+			and StringName(pushed.get("reason", &"")) == &"blocked"
+			and world.player_cell == GYM_PUSH_STAND,
+		"%s: Cianwood Gym push moved the player instead of bumping them." % game_id
+	)
+	_check(
+		pushed.has("boulder_pushed")
+			and pushed["boulder_pushed"]["to_cell"] == GYM_PUSH_LANDING,
+		"%s: Cianwood Gym boulder at %s did not move to %s." % [
+			game_id, GYM_PUSH_CELL, GYM_PUSH_LANDING,
+		]
+	)
+	_check(
+		world.object_at(GYM_PUSH_CELL) == null
+			and world.object_at(GYM_PUSH_LANDING) != null,
+		"%s: Cianwood Gym boulder did not free %s." % [game_id, GYM_PUSH_CELL]
+	)
+	print("%s: Cianwood Gym %d/%d boulder %s -> %s, corridor cell freed." % [
+		game_id, GYM_GROUP, GYM_NUMBER, GYM_PUSH_CELL, GYM_PUSH_LANDING,
+	])
+
+	# reload_current_map() keeps a moved object where it stands, which is the
+	# after-battle rule a trainer relies on, so a boulder pushed before a battle
+	# is still out of the way afterwards.
+	world.reload_current_map()
+	_check(
+		world.object_at(GYM_PUSH_LANDING) != null and world.object_at(GYM_PUSH_CELL) == null,
+		"%s: Cianwood Gym boulder lost its pushed cell on a map reload." % game_id
+	)
+
+	# A map change is the other half: ReadObjectEvents rebuilds every object from
+	# map data, so the boulder is back on its authored cell on the next visit,
+	# the way a cut tree regrows.
+	world.player_cell = GYM_EXIT_CELL
+	if _check(
+		bool(world.try_warp().get("ok", false)),
+		"%s: Cianwood Gym exit warp at %s did not fire." % [game_id, GYM_EXIT_CELL]
+	):
+		var returned: Gen2WorldAPI = Gen2WorldAPI.open(
+			data, GYM_GROUP, GYM_NUMBER, GYM_PUSH_STAND, world.state
+		)
+		_check(
+			returned.object_at(GYM_PUSH_CELL) != null,
+			"%s: Cianwood Gym boulder did not return to %s on the next visit." % [
+				game_id, GYM_PUSH_CELL,
+			]
+		)
+
+	# .CheckStrengthBoulder reads BIKEFLAGS_STRENGTH_ACTIVE_F first, so without it
+	# the wall is immovable however many badges the player has.
+	var inactive: Gen2WorldAPI = _gym_world(data, crystal, false)
+	var refused: Dictionary = inactive.move_result(Vector2i.UP)
+	_check(
+		not refused.has("boulder_pushed")
+			and inactive.object_at(GYM_PUSH_CELL) != null,
+		"%s: Cianwood Gym boulder moved without the strength flag." % game_id
+	)
+
+	# .TryStrength tests the badge on whichever engine flag table this profile
+	# numbers ENGINE_PLAINBADGE on, and nothing else.
+	var unbadged: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, GYM_GROUP, GYM_NUMBER, GYM_PUSH_STAND, Gen2WorldState.new()
+	)
+	_check(
+		StringName(unbadged.strength_request().get("reason", &"")) == &"badge_required",
+		"%s: Cianwood Gym allowed Strength without engine flag %d." % [game_id, badge]
+	)
+	var wrong := Gen2WorldState.new()
+	wrong.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_PLAIN, not crystal))
+	var wrong_world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, GYM_GROUP, GYM_NUMBER, GYM_PUSH_STAND, wrong
+	)
+	_check(
+		StringName(wrong_world.strength_request().get("reason", &"")) == &"badge_required",
+		"%s: Cianwood Gym accepted the other profile's Plain Badge flag." % game_id
+	)
+
+	# The badge alone resolves: .TryStrength never looks at a tile or a boulder.
+	var badged: Gen2WorldAPI = _gym_world(data, crystal, false)
+	badged.state.set_engine_flag(badge)
+	_check(
+		bool(badged.strength_request().get("ok", false))
+			and bool(badged.complete_strength().get("ok", false))
+			and badged.strength_active(),
+		"%s: Cianwood Gym refused Strength with the Plain Badge set." % game_id
+	)
+
+
+## A world below the wall's middle boulder, facing it, with the Plain Badge set
+## and the strength flag set when [param active].
+func _gym_world(data: GameData, crystal: bool, active: bool) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_PLAIN, crystal))
+	if active:
+		state.set_engine_flag(Gen2WorldState.strength_active_flag(crystal))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, GYM_GROUP, GYM_NUMBER, GYM_PUSH_STAND, state
+	)
+	if world != null:
+		world.player_facing = Gen2WorldSprite.FACING_UP
+	return world
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS strength: boulder census and Cianwood Gym verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_strength.gd.uid
+++ b/tools/validate_strength.gd.uid
@@ -1,0 +1,1 @@
+uid://eyynbtpkk1m8


### PR DESCRIPTION
Strength joins Cut, Surf and Whirlpool in the party submenu, and the boulders it moves become passable.

StrengthFunction's .TryStrength is a badge check and nothing else, so strength_request() resolves facing open floor; complete_strength() is SetStrengthFlag, which sets ENGINE_STRENGTH_ACTIVE (24 Crystal, 23 Gold/Silver). Nothing in the pinned sources ever clears that flag.

Pushing is a separate layer. .CheckNPC runs after .CheckLandPerms and treats a movable boulder as an ordinary bump, so a push advances the boulder one cell and still refuses the player, with the ledge hop after it still tried. The landing follows CanObjectMoveInDirection, which for a boulder's flags is exactly can_object_walk_to(); it slides on the slow 16-frame StepVectors row and never rolls a wait. Surfing pushes too, since .TrySurf calls the same .CheckNPC. A boulder on a pit is stopped for good.

A boulder's jumpstd StrengthBoulderScript is answered by a synthesized AskStrengthScript: the real body is farsjump into a script whose first command is a callasm with no runner and a link-time operand absent from the pins, so the seam sits on the standard-script index, 14 in both. TryStrengthOW's three answers come from the party mirror, the badge and the flag, so the mirror now carries per-slot move lists and names.

tools/validate_strength.gd pins the 20-boulder, 9-map census and drives Cianwood Gym's corridor push against all three real caches.

Fixed in passing: the party-mirror doc claimed an empty species list failed a script read when it answers "not in the party", and "#" now encodes to the POKe ligature the way constants/charmap.asm maps it, so synthesized text no longer draws a question mark.