### PR TITLE
Teach a TM or HM from the pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > errand, Sudowoodo, the Burned Tower beasts and Morty to the Fog Badge, and on
 > through the Dance Theatre's Kimono Girls for HM03 Surf, Routes 38 and 39, the
 > Olivine Lighthouse, Routes 40 and 41 surfed to Cianwood for the SecretPotion,
-> and Jasmine to the Mineral Badge, then east across Route 42's lakes to
-> Mahogany, the Lake of Rage's Red Gyarados and Lance, the Rocket hideout's
-> three floors and Pryce to the Glacier Badge.
+> and Jasmine to the Mineral Badge, catching a Geodude in Union Cave on the way
+> and teaching it HM04 Strength to push Cianwood Gym's boulders aside for the
+> Storm Badge, then east across Route 42's lakes to Mahogany, the Lake of Rage's
+> Red Gyarados and Lance, the Rocket hideout's three floors and Pryce to the
+> Glacier Badge.
 > Missing: full story state, dex, trainer card, options, the remaining
 > special-call branches and story-driven permanent contacts.
 
@@ -101,6 +103,7 @@ to check without writing.
 | Learnsets | All 251 species' level-up moves in cartridge order |
 | Evolutions | Every evolution and method/requirements |
 | Moves | Names, power, type, accuracy, PP, effect and chance |
+| TM/HM moves | The 57 Gold/Silver or 60 Crystal TM, HM and move-tutor rows, which is what turns a TM in the bag into a move |
 | Items, types | 255 item names, prices, effects, menus, pockets, healing metadata and 28 type names |
 | NPC trades | Gold/Silver six-row or Crystal seven-row records with requested/offered species, DVs, held item and OT data |
 | Type chart | Every matchup and the two Foresight-cancelled entries |
@@ -194,6 +197,7 @@ Headless tools, all against a real imported cache:
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
+| `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, and the whole species compatibility census, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -22,6 +22,9 @@ var directory: String = ""
 
 var _species: Array = []
 var _moves: Array = []
+## TMHMMoves in TMNUM order, restored to integers because JSON reads them back
+## as floats.
+var _tmhm_moves: Array[int] = []
 var _items: Array = []
 var _world_trades: Array = []
 var _types: Array = []
@@ -86,6 +89,7 @@ static func open_directory(path: String) -> GameData:
 	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
+	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
 	data._items = data._read_array(RomCache.items_path(path))
 	data._world_trades = data._read_array(RomCache.world_trades_path(path))
 	data._types = data._read_array(RomCache.types_path(path))
@@ -464,6 +468,29 @@ func _rows(entry: Dictionary, key: String, fields: Array) -> Array:
 
 func move(number: int) -> Dictionary:
 	return _entry(_moves, number - 1)
+
+
+## Every TM/HM/tutor move in TMNUM order, so index n-1 is TM/HM number n.
+func tmhm_moves() -> Array[int]:
+	return _tmhm_moves.duplicate()
+
+
+## GetTMHMMove: the move one TM/HM number teaches, or 0 when the number is not
+## one this cartridge carries.
+func tmhm_move(number: int) -> int:
+	if number < 1 or number > _tmhm_moves.size():
+		return 0
+	return _tmhm_moves[number - 1]
+
+
+## CanLearnTMHMMove's own scan of TMHMMoves for wPutativeTMHMMove: the one-based
+## number that teaches [param move], or 0. The source takes the first match, so
+## this does too.
+func tmhm_number_for_move(move_number: int) -> int:
+	if move_number <= 0:
+		return 0
+	var found: int = _tmhm_moves.find(move_number)
+	return found + 1 if found >= 0 else 0
 
 
 func item(number: int) -> Dictionary:
@@ -935,6 +962,13 @@ func _audio() -> Dictionary:
 func _read_array(path: String) -> Array:
 	var value: Variant = RomCache.read_json(path)
 	return value if value is Array else []
+
+
+func _read_int_array(path: String) -> Array[int]:
+	var out: Array[int] = []
+	for value: Variant in _read_array(path):
+		out.append(int(value))
+	return out
 
 
 func _entry(rows: Array, index: int) -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -18,6 +18,7 @@ const ROOT: String = "user://rom_cache"
 const MANIFEST: String = "manifest.json"
 const SPECIES: String = "species.json"
 const MOVES: String = "moves.json"
+const TMHM_MOVES: String = "tmhm_moves.json"
 const ITEMS: String = "items.json"
 const WORLD_TRADES: String = "world_trades.json"
 const TYPES: String = "types.json"
@@ -54,7 +55,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 23
+const FORMAT_VERSION: int = 24
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -71,6 +72,10 @@ static func species_path(directory: String) -> String:
 
 static func moves_path(directory: String) -> String:
 	return "%s/%s" % [directory, MOVES]
+
+
+static func tmhm_moves_path(directory: String) -> String:
+	return "%s/%s" % [directory, TMHM_MOVES]
 
 
 static func items_path(directory: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -38,6 +38,11 @@ const FIRST_LEARNSET_MOVE: int = 33
 const STAT_EVOLUTION_SPECIES: int = 236
 const STAT_EVOLUTION_COUNT: int = 3
 
+## HM01's move, which is TMHMMoves' row 51 and so the entry directly after the
+## fifty TMs. Checking it is what pins the table: a run of legal move numbers
+## elsewhere in the bank would pass the range and terminator checks alone.
+const MOVE_CUT: int = 0x0F
+
 ## What the trainer *party* table is known to say, independently of the
 ## cartridge, which is a different table from [constant TRAINER_FIRST_CLASS]:
 ## that one is the class every gym leader shares ("LEADER"), and this one is the
@@ -1298,6 +1303,10 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		return result
 
 	var moves: Array = _import_moves(rom, layout, on_progress)
+	var tmhm_moves: Array = _import_tmhm_moves(rom, layout)
+	if tmhm_moves.is_empty():
+		result["message"] = "TM/HM move table is outside the cartridge or malformed."
+		return result
 	var items: Array = _import_items(rom, layout, on_progress)
 	var trades: Array = _import_world_trades(rom, layout)
 	var types: Array = _import_types(rom, layout, on_progress)
@@ -1325,6 +1334,9 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		return result
 	if not RomCache.write_json(RomCache.moves_path(directory), moves):
 		result["message"] = "Could not write move data."
+		return result
+	if not RomCache.write_json(RomCache.tmhm_moves_path(directory), tmhm_moves):
+		result["message"] = "Could not write TM/HM move data."
 		return result
 	if not RomCache.write_json(RomCache.items_path(directory), items):
 		result["message"] = "Could not write item data."
@@ -1521,6 +1533,31 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 		if on_progress.is_valid():
 			on_progress.call("moves", move, RomLayout.MOVE_COUNT)
 
+	return out
+
+
+## data/moves/tmhm_moves.asm's TMHMMoves, in TMNUM order. Empty on any layout or
+## content failure, which the caller reports rather than caching a half table.
+##
+## Checked rather than trusted: every entry has to be a real move number, the
+## terminating zero has to be there, and HM01's row has to be CUT. The last is
+## what actually pins the table, since a nearby run of bytes can pass the first
+## two.
+func _import_tmhm_moves(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout.get("tmhm_moves", -1))
+	var count: int = int(layout.get("tmhm_move_count", 0))
+	if count <= RomLayout.TMHM_TM_COUNT or not rom.in_bounds(at, count + 1):
+		return []
+	if rom.u8(at + count) != 0:
+		return []
+	var out: Array = []
+	for index: int in count:
+		var move: int = rom.u8(at + index)
+		if move <= 0 or move > RomLayout.MOVE_COUNT:
+			return []
+		out.append(move)
+	if int(out[RomLayout.TMHM_TM_COUNT]) != MOVE_CUT:
+		return []
 	return out
 
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -523,7 +523,51 @@ const OFFSET_GROWTH_RATE: int = 22
 ## Packed nibbles, one egg group per half.
 const OFFSET_EGG_GROUPS: int = 23
 const OFFSET_TMHM: int = 24
+## Eight bytes of learnable flags, one bit per TM/HM/tutor number, indexed by the
+## entry's own zero-based place in TMHMMoves. Sixty-four bits for sixty numbers,
+## so the top four are always clear.
 const TMHM_BYTES: int = 8
+
+## data/moves/tmhm_moves.asm's TMHMMoves: fifty TMs, then seven HMs, then
+## Crystal's three move tutors, then a zero terminator. Indexed by TMNUM, which
+## is one-based, so entry n-1 is TM/HM number n. The first fifty-seven bytes are
+## identical between the pins; only Crystal's tutor rows follow.
+const TMHM_TM_COUNT: int = 50
+const TMHM_HM_COUNT: int = 7
+## constants/item_constants.asm. TM01 is $bf and HM01 $f3, but the run is not
+## contiguous: ITEM_C3 and ITEM_DC are dummy items inside it, which is why
+## GetTMHMNumber skips them rather than subtracting.
+const ITEM_TM01: int = 0xBF
+const ITEM_HM01: int = 0xF3
+const ITEM_DUMMY_TM04_05: int = 0xC3
+const ITEM_DUMMY_TM28_29: int = 0xDC
+
+
+## engine/items/items.asm's GetTMHMNumber: the one-based TM/HM number an item id
+## carries, or 0 when [param item] is not one. The two dummy items in the range
+## have no number of their own and answer 0 as well.
+static func tmhm_number_for_item(item: int, count: int) -> int:
+	if item < ITEM_TM01 or item == ITEM_DUMMY_TM04_05 or item == ITEM_DUMMY_TM28_29:
+		return 0
+	var value: int = item
+	if value >= ITEM_DUMMY_TM04_05:
+		if value >= ITEM_DUMMY_TM28_29:
+			value -= 1
+		value -= 1
+	var number: int = value - ITEM_TM01 + 1
+	return number if number >= 1 and number <= count else 0
+
+
+## GetNumberedTMHM, the inverse: the item id a one-based TM/HM number carries.
+static func item_for_tmhm_number(number: int, count: int) -> int:
+	if number < 1 or number > count:
+		return 0
+	var value: int = number
+	if value >= ITEM_DUMMY_TM04_05 - (ITEM_TM01 - 1):
+		if value >= ITEM_DUMMY_TM28_29 - (ITEM_TM01 - 1) - 1:
+			value += 1
+		value += 1
+	return value + ITEM_TM01 - 1
 
 ## Byte positions within a 7-byte move entry.
 ## The animation is the move's own number, which is what makes the table
@@ -552,6 +596,8 @@ const GOLD_SILVER: Dictionary = {
 	"world_trades": 0xFCC24,
 	"world_trade_count": 6,
 	"move_data": 0x41AFE,
+	"tmhm_moves": 0x11A66,
+	"tmhm_move_count": 57,
 	"evos_attacks": 0x427BD,
 	"type_names": 0x509AE,
 	"type_matchups": 0x34D01,
@@ -676,6 +722,8 @@ const CRYSTAL: Dictionary = {
 	"world_trades": 0xFCE58,
 	"world_trade_count": 7,
 	"move_data": 0x41AFB,
+	"tmhm_moves": 0x1167A,
+	"tmhm_move_count": 60,
 	"evos_attacks": 0x425B1,
 	"type_names": 0x5097B,
 	"type_matchups": 0x34BB1,

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -16,7 +16,7 @@ signal action_chosen(kind: StringName)
 ## Emitted on Exit or cancel from the top-level list.
 signal closed
 
-enum Mode { LIST, PACK, PACK_ITEM, PACK_TARGET, PACK_RESULT, SAVE_CONFIRM }
+enum Mode { LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET, PACK_RESULT, SAVE_CONFIRM }
 
 ## engine/items/pack.asm's own refusal texts, verbatim from data/text/common_2.asm.
 const OAK_TEXT: String = "OAK: This isn't the time to use that!"
@@ -47,6 +47,12 @@ var _item_cursor: int = 0
 var _target_cursor: int = 0
 var _pack_result: String = ""
 var _pack_result_ok: bool = false
+## AskTeachTMHM's resolved prompt, held while its yes/no is on screen, and
+## whether the party list that follows is ChooseMonToLearnTMHM's rather than
+## `.Party`'s.
+var _teach_prompt: Dictionary = {}
+var _teach_cursor: int = 0
+var _teaching: bool = false
 
 var _save_cursor: int = 0
 var _save_result_shown: bool = false
@@ -143,6 +149,10 @@ func _move(direction: Vector2i) -> void:
 			if direction.y != 0 and not _item_actions.is_empty():
 				_item_cursor = wrapi(_item_cursor + signi(direction.y), 0, _item_actions.size())
 				_render_item_menu()
+		Mode.PACK_TEACH:
+			if direction.y != 0 or direction.x != 0:
+				_teach_cursor = 1 - _teach_cursor
+				_render_teach()
 		Mode.PACK_TARGET:
 			if direction.y != 0 and not _party_targets().is_empty():
 				_target_cursor = wrapi(
@@ -164,8 +174,13 @@ func _confirm() -> void:
 				_open_item_mode()
 		Mode.PACK_ITEM:
 			_confirm_item_action()
+		Mode.PACK_TEACH:
+			_confirm_teach()
 		Mode.PACK_TARGET:
-			_use_selected_item(_target_cursor)
+			if _teaching:
+				_teach_selected_item(_target_cursor)
+			else:
+				_use_selected_item(_target_cursor)
 		Mode.PACK_RESULT:
 			_open_pack_mode(false)
 		Mode.SAVE_CONFIRM:
@@ -178,7 +193,7 @@ func _cancel() -> void:
 			closed.emit()
 		Mode.PACK:
 			_open_list_mode()
-		Mode.PACK_ITEM, Mode.PACK_RESULT:
+		Mode.PACK_ITEM, Mode.PACK_RESULT, Mode.PACK_TEACH:
 			_open_pack_mode(false)
 		Mode.PACK_TARGET:
 			_open_item_mode()
@@ -337,7 +352,13 @@ func _confirm_use() -> void:
 	var item: Dictionary = _selected_item()
 	if item.is_empty():
 		return
-	match Gen2WorldPack.field_use_kind(_data, int(item.get("item", 0))):
+	var number: int = int(item.get("item", 0))
+	## The TM/HM pocket never reaches `UseItem`'s jumptable: engine/items/pack.asm
+	## gives it its own USE, which runs AskTeachTMHM first.
+	if Gen2WorldPack.pocket_for(_data, number) == Gen2WorldPack.TYPE_TM_HM:
+		_open_teach_mode(number)
+		return
+	match Gen2WorldPack.field_use_kind(_data, number):
 		Gen2WorldPack.ITEMMENU_PARTY:
 			if _party_targets().is_empty():
 				_show_pack_result(NO_MON_TEXT, false)
@@ -369,6 +390,87 @@ func _party_targets() -> Array:
 			"egg": mon.is_egg,
 		})
 	return targets
+
+
+## AskTeachTMHM: the booted-up text and its yes/no. A TM/HM the cartridge does
+## not carry has no move, which is the source's `.NotTMHM` fall-through, so no
+## prompt appears and USE reports nothing happened.
+func _open_teach_mode(item: int) -> void:
+	_teach_prompt = Gen2WorldTMHM.teach_prompt(_data, item)
+	if not bool(_teach_prompt.get("ok", false)):
+		_show_pack_result(OAK_TEXT, false)
+		return
+	_teaching = false
+	_teach_cursor = 0
+	_mode = Mode.PACK_TEACH
+	_status.text = ""
+	_footer.text = "Up/Down: move    Space/Enter: choose    Esc: back"
+	_render_teach()
+
+
+func _render_teach() -> void:
+	_title.text = "TEACH"
+	_summary.text = String(_teach_prompt.get("text", ""))
+	_render_options([{"label": "YES"}, {"label": "NO"}], _teach_cursor,
+		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
+	)
+
+
+## The yes/no answer. Yes reaches ChooseMonToLearnTMHM, which is the same party
+## list `.Party` uses; no closes the way the source's carry return does.
+func _confirm_teach() -> void:
+	if _teach_cursor != 0:
+		_open_pack_mode(false)
+		return
+	if _party_targets().is_empty():
+		_show_pack_result(NO_MON_TEXT, false)
+		return
+	_teaching = true
+	_open_target_mode()
+
+
+func _teach_selected_item(party_index: int) -> void:
+	if _pack_save == null or _world == null:
+		_show_pack_result("No save is loaded.", false)
+		return
+	var item: int = int(_teach_prompt.get("item", 0))
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(
+		_world, _pack_save, item, party_index, _pack_persist
+	)
+	_teaching = false
+	if not bool(result.get("ok", false)):
+		_show_pack_result(_teach_refusal(StringName(result.get("reason", &"")), party_index), false)
+		return
+	_show_pack_result("%s learned %s!" % [
+		_target_name(party_index), String(_teach_prompt.get("move_name", "")),
+	], true)
+
+
+func _target_name(party_index: int) -> String:
+	var targets: Array = _party_targets()
+	if party_index < 0 or party_index >= targets.size():
+		return "#MON"
+	return String((targets[party_index] as Dictionary).get("name", "#MON"))
+
+
+## TeachTMHM's own refusals, verbatim from data/text/common_2.asm and
+## common_3.asm. A full moveset is where the source opens ForgetMove, which does
+## not exist here, so it says so rather than inventing a replacement.
+func _teach_refusal(reason: StringName, party_index: int) -> String:
+	var move_name: String = String(_teach_prompt.get("move_name", "that move"))
+	var name: String = _target_name(party_index)
+	match reason:
+		&"not_compatible":
+			return "%s is not compatible with %s. It can't learn %s." % [
+				move_name, name, move_name,
+			]
+		&"already_knows_move":
+			return "%s knows %s." % [name, move_name]
+		&"moveset_full":
+			return "%s already knows four moves. Forgetting one is not available yet." % name
+		&"cannot_teach_egg":
+			return "An EGG can't learn anything."
+	return "Can't teach that: %s" % String(reason)
 
 
 func _open_target_mode() -> void:

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -233,6 +233,93 @@ static func use_item(
 	}
 
 
+## engine/items/tmhm.asm's TeachTMHM, as one candidate transaction beside
+## use_item(). The pack's own USE reaches this, not `UseItem`'s jumptable: the
+## TM/HM pocket runs AskTeachTMHM, ChooseMonToLearnTMHM and TeachTMHM instead
+## (engine/items/pack.asm's .UseItem).
+##
+## The refusal order is the source's. CanLearnTMHMMove comes first, then
+## KnowsMove, then LearnMove's own search for an empty slot; each answers before
+## anything is written. A full moveset is where the source opens ForgetMove,
+## which does not exist here, so it is a typed refusal rather than an invented
+## replacement.
+##
+## An HM is not consumed: TeachTMHM returns straight after IsHM, so it skips both
+## ConsumeTM and the happiness change. The happiness change a TM does make is a
+## boundary, since no ChangeHappiness table is imported.
+static func teach_tm_hm(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	item: int,
+	party_index: int,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or save == null or world.data == null:
+		return _failure(&"missing_save", {})
+	if world.state == null or world.state.item_quantity(item) <= 0:
+		return _failure(&"insufficient_item_quantity", {"item": item})
+	var move: int = Gen2WorldTMHM.move_for_item(world.data, item)
+	if move <= 0:
+		return _failure(&"not_a_tm_hm", {"item": item})
+	if party_index < 0 or party_index >= save.party.size():
+		return _failure(&"invalid_party_index", {"party_index": party_index})
+	var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
+	if mon == null:
+		return _failure(&"invalid_party_index", {"party_index": party_index})
+	# ChooseMonToLearnTMHM refuses an egg with SFX_WRONG and reopens the list, so
+	# an egg never reaches TeachTMHM at all.
+	if mon.is_egg:
+		return _failure(&"cannot_teach_egg", {"party_index": party_index})
+	if not Gen2WorldTMHM.can_learn(world.data, mon.species, move):
+		return _failure(&"not_compatible", {"species": mon.species, "move": move})
+	if Gen2WorldTMHM.knows_move(mon.moves, move):
+		return _failure(&"already_knows_move", {"move": move})
+	var slot: int = Gen2WorldTMHM.first_empty_slot(mon.moves)
+	if slot < 0:
+		return _failure(&"moveset_full", {"party_index": party_index, "move": move})
+
+	var validation: Dictionary = Gen2SaveValidator.validate(save, world.data)
+	if not bool(validation.get("ok", false)):
+		return _failure(&"invalid_save", {"message": validation.get("message", "")})
+	var candidate: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	var learner: Gen2SaveMon = candidate.party[party_index] as Gen2SaveMon
+	learner.moves[slot] = move
+	# LearnMove writes the move, then its PP from Moves + MOVE_PP: a freshly
+	# learned move always arrives at full PP.
+	learner.pp[slot] = int(world.data.move(move).get("pp", 0))
+
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var consumed: bool = not Gen2WorldTMHM.is_hm(item)
+	var applied: Dictionary = {"ok": true}
+	if consumed:
+		applied = world.state.apply_changes({}, {}, {
+			"items": {item: world.state.item_quantity(item) - 1},
+		})
+	if not bool(applied.get("ok", false)):
+		return _failure(&"item_state_failed", applied)
+	candidate.world = world.snapshot()
+	var candidate_validation: Dictionary = Gen2SaveValidator.validate(candidate, world.data)
+	if not bool(candidate_validation.get("ok", false)):
+		world.state.restore_from_dict(before.world_state.to_dict())
+		return _failure(&"candidate_save_invalid", candidate_validation)
+	var write_result: Dictionary = {"ok": true}
+	if persist:
+		write_result = Gen2SaveStore.save(candidate, world.data)
+	if not bool(write_result.get("ok", false)):
+		world.state.restore_from_dict(before.world_state.to_dict())
+		return _failure(&"save_failed", write_result)
+	_copy_save(save, candidate)
+	return {
+		"ok": true,
+		"item": item,
+		"party_index": party_index,
+		"move": move,
+		"slot": slot,
+		"pp": learner.pp[slot],
+		"consumed": consumed,
+	}
+
+
 ## Attempts to catch one wild battle mon and consumes the ball on either result.
 ## The battle screen owns the animation; this host owns the cartridge outcome and
 ## the save/world writeback. A caught mon enters the party when there is room and

--- a/game/world/world_tmhm.gd
+++ b/game/world/world_tmhm.gd
@@ -1,0 +1,97 @@
+class_name Gen2WorldTMHM
+extends RefCounted
+
+## Scene-free tables and gates for teaching a TM or HM
+## (engine/items/tmhm.asm, engine/items/tmhm2.asm).
+##
+## The TM/HM pocket does not reach `UseItem`'s jumptable at all: its own USE
+## entry runs AskTeachTMHM, then ChooseMonToLearnTMHM, then TeachTMHM
+## (engine/items/pack.asm's .UseItem). This class owns the first and the checks
+## the third makes; Gen2WorldPartyHost.teach_tm_hm() owns the transaction.
+##
+## Everything here is byte identical between the pins. pokegold's TeachTMHM
+## differs by one line, a stubbed trainer-ranking call that does nothing.
+
+## constants/item_constants.asm. The run from TM01 to HM07 is not contiguous:
+## ITEM_C3 and ITEM_DC sit inside it as dummies, which is why the number a TM
+## carries comes from RomLayout.tmhm_number_for_item() rather than subtraction.
+const ITEM_TM01: int = RomLayout.ITEM_TM01
+const ITEM_HM01: int = RomLayout.ITEM_HM01
+
+## Eight bytes of learnable flags on each species, one bit per TMNUM, indexed by
+## the entry's own zero-based place in TMHMMoves.
+const TMHM_FLAG_BYTES: int = RomLayout.TMHM_BYTES
+
+
+## AskTeachTMHM's first test, `cp TM01` before anything else: an item below TM01
+## is not a TM or HM and the prompt never appears.
+static func is_tm_hm(item: int) -> bool:
+	return item >= ITEM_TM01
+
+
+## IsHM, which TeachTMHM asks before ConsumeTM: an HM is never used up.
+static func is_hm(item: int) -> bool:
+	return item >= ITEM_HM01
+
+
+## GetTMHMItemMove: the move [param item] teaches, or 0 when it is not a TM/HM
+## this cartridge carries.
+static func move_for_item(data: GameData, item: int) -> int:
+	if data == null or not is_tm_hm(item):
+		return 0
+	var number: int = RomLayout.tmhm_number_for_item(item, data.tmhm_moves().size())
+	return data.tmhm_move(number)
+
+
+## CanLearnTMHMMove: the species' own flag bit for the TM/HM that teaches
+## [param move]. A move no TM/HM teaches answers false, matching the source's
+## `.end` branch, which returns c = 0 after walking off the end of TMHMMoves.
+static func can_learn(data: GameData, species: int, move: int) -> bool:
+	if data == null:
+		return false
+	var number: int = data.tmhm_number_for_move(move)
+	if number < 1:
+		return false
+	var flags: Array = data.species(species).get("tmhm", [])
+	if flags.size() < TMHM_FLAG_BYTES:
+		return false
+	# SmallFarFlagAction with d = 0: byte index >> 3, then bit index & 7 counted
+	# from the *low* bit, since it shifts 1 left that many times.
+	var index: int = number - 1
+	var byte: int = int(flags[index >> 3])
+	return (byte & (1 << (index & 7))) != 0
+
+
+## KnowsMove (engine/pokemon/knows_move.asm), which TeachTMHM asks after
+## compatibility and before LearnMove: all four slots, zeros included, though a
+## zero can never match a real move.
+static func knows_move(moves: Array, move: int) -> bool:
+	return moves.has(move)
+
+
+## LearnMove's own first step: the first empty move slot, or -1 when all four are
+## taken and the source would open ForgetMove instead.
+static func first_empty_slot(moves: Array) -> int:
+	for slot: int in moves.size():
+		if int(moves[slot]) == 0:
+			return slot
+	return -1
+
+
+## AskTeachTMHM's two texts, BootedTMText/BootedHMText then ContainedMoveText,
+## as the one prompt this project shows before its yes/no. The source prints them
+## as two boxes; the wording is verbatim.
+static func teach_prompt(data: GameData, item: int) -> Dictionary:
+	var move: int = move_for_item(data, item)
+	if move <= 0:
+		return {"ok": false, "reason": &"not_a_tm_hm", "item": item}
+	var move_name: String = String(data.move(move).get("name", "MOVE"))
+	var booted: String = "Booted up an HM." if is_hm(item) else "Booted up a TM."
+	return {
+		"ok": true,
+		"item": item,
+		"move": move,
+		"move_name": move_name,
+		"hm": is_hm(item),
+		"text": "%s It contained %s. Teach %s to a #MON?" % [booted, move_name, move_name],
+	}

--- a/game/world/world_tmhm.gd.uid
+++ b/game/world/world_tmhm.gd.uid
@@ -1,0 +1,1 @@
+uid://b35obxl3c14xg

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -130,6 +130,151 @@ func test_pack_lists_a_granted_item() -> void:
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
 
 
+## HM04 with its real item number, plus the TM/HM table and the flag bit that
+## lets the development save's first party member learn it.
+const HM_ITEM: int = 0xF6
+const HM_MOVE: int = 0x46
+
+
+func _write_tmhm_item(learnable: bool = true) -> void:
+	var table: Array = []
+	for index: int in RomLayout.TMHM_TM_COUNT + RomLayout.TMHM_HM_COUNT:
+		table.append(0x60 + index)
+	table[RomLayout.TMHM_TM_COUNT + 3] = HM_MOVE
+	RomCache.write_json(RomCache.tmhm_moves_path(Fixture.directory()), table)
+
+	var moves: Array = RomCache.read_json(RomCache.moves_path(Fixture.directory()))
+	for raw: Dictionary in moves:
+		if int(raw.get("number", 0)) == HM_MOVE:
+			raw["name"] = "STRENGTH"
+			raw["pp"] = 15
+	RomCache.write_json(RomCache.moves_path(Fixture.directory()), moves)
+
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	while items.size() < HM_ITEM:
+		items.append({
+			"number": items.size() + 1, "name": "HM%02d" % items.size(),
+			"permissions": 0, "pocket": Gen2WorldPack.TYPE_TM_HM,
+			"field_menu": 0, "battle_menu": 0, "status_mask": 0, "heal_amount": 0,
+		})
+	(items[HM_ITEM - 1] as Dictionary)["name"] = "HM04"
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+
+	var species: Array = RomCache.read_json(RomCache.species_path(Fixture.directory()))
+	for raw: Dictionary in species:
+		var flags: Array = []
+		flags.resize(RomLayout.TMHM_BYTES)
+		for index: int in flags.size():
+			flags[index] = 0
+		if learnable:
+			# TMNUM 54, so bit 53: byte 6, bit 5 from the low end.
+			flags[6] = 0x20
+		raw["tmhm"] = flags
+	RomCache.write_json(RomCache.species_path(Fixture.directory()), species)
+	_data = GameData.open_directory(Fixture.directory())
+
+
+## Opens the pack on the TM/HM pocket with HM04 in the bag and the cursor on it.
+## _write_tmhm_item() has to have run before the world screen was built, since
+## the screen keeps the GameData it was handed.
+func _open_tmhm_pack() -> Gen2StartMenuScreen:
+	_world_screen._world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_PACK)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	var pockets: Array = host.get("_pack_pockets")
+	for index: int in pockets.size():
+		if int((pockets[index] as Dictionary)["pocket"]) == Gen2WorldPack.TYPE_TM_HM:
+			host.set("_pack_pocket_index", index)
+			break
+	host.set("_pack_cursor", 0)
+	return host
+
+
+## engine/items/pack.asm gives the TM/HM pocket its own USE, which runs
+## AskTeachTMHM rather than reaching UseItem's jumptable.
+func test_tmhm_use_asks_before_teaching_and_a_yes_teaches_the_move() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	var host: Gen2StartMenuScreen = await _open_tmhm_pack()
+	var save: Gen2SaveData = _world_screen._injected_save
+	assert_false(save.party[0].moves.has(HM_MOVE))
+
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TEACH)
+	assert_eq(
+		String(host.get("_teach_prompt")["text"]),
+		"Booted up an HM. It contained STRENGTH. Teach STRENGTH to a #MON?"
+	)
+
+	## Yes is the prompt's default cursor position, matching YesNoBox.
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_true(bool(host.get("_pack_result_ok")), String(host.get("_pack_result")))
+	assert_true(save.party[0].moves.has(HM_MOVE))
+	## IsHM returns before ConsumeTM, so the HM stays in the bag.
+	assert_eq(_world_screen._world.state.item_quantity(HM_ITEM), 1)
+
+
+## The yes/no is a real refusal, not decoration: no leaves the party alone.
+func test_tmhm_use_declined_teaches_nothing() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	var host: Gen2StartMenuScreen = await _open_tmhm_pack()
+	var save: Gen2SaveData = _world_screen._injected_save
+
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TEACH)
+
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
+	assert_false(save.party[0].moves.has(HM_MOVE))
+
+
+## CanLearnTMHMMove is the first thing TeachTMHM asks, and its refusal is
+## TMHMNotCompatibleText rather than a silent no-op.
+func test_tmhm_use_reports_an_incompatible_species() -> void:
+	_write_tmhm_item(false)
+	await _open_world()
+	var host: Gen2StartMenuScreen = await _open_tmhm_pack()
+	var save: Gen2SaveData = _world_screen._injected_save
+
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_false(bool(host.get("_pack_result_ok")))
+	assert_true(
+		String(host.get("_pack_result")).contains("not compatible"),
+		String(host.get("_pack_result"))
+	)
+	assert_false(save.party[0].moves.has(HM_MOVE))
+
+
 func test_pokegear_reaches_the_existing_phone_list() -> void:
 	await _open_world()
 	_world_screen._world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEGEAR)

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -150,6 +150,147 @@ func test_item_with_no_effect_is_not_consumed() -> void:
 	assert_eq(_world.state.item_quantity(0x09), before_quantity)
 
 
+## TM01 and HM04 in this fixture's cache. The party's first member learns both,
+## the second learns neither, so one save covers compatibility both ways.
+const TM_ITEM: int = 0xBF
+const HM_ITEM: int = 0xF6
+const TM_MOVE: int = 0xDF
+const HM_MOVE: int = 0x46
+
+
+func _add_tmhm_metadata() -> void:
+	var table: Array = []
+	for index: int in RomLayout.TMHM_TM_COUNT + RomLayout.TMHM_HM_COUNT:
+		table.append(0x60 + index)
+	table[0] = TM_MOVE
+	table[RomLayout.TMHM_TM_COUNT + 3] = HM_MOVE
+	RomCache.write_json(RomCache.tmhm_moves_path(Fixture.directory()), table)
+
+	var species: Array = RomCache.read_json(RomCache.species_path(Fixture.directory()))
+	for raw: Dictionary in species:
+		var flags: Array = []
+		flags.resize(RomLayout.TMHM_BYTES)
+		for index: int in flags.size():
+			flags[index] = 0
+		if int(raw["number"]) == _save.party[0].species:
+			# TMNUM 1 (TM01) and 54 (HM04), bit index TMNUM - 1 from the low bit.
+			flags[0] = 0x01
+			flags[6] = 0x20
+		raw["tmhm"] = flags
+	RomCache.write_json(RomCache.species_path(Fixture.directory()), species)
+
+	var moves: Array = RomCache.read_json(RomCache.moves_path(Fixture.directory()))
+	for raw: Dictionary in moves:
+		if int(raw["number"]) in [TM_MOVE, HM_MOVE]:
+			raw["pp"] = 15
+	RomCache.write_json(RomCache.moves_path(Fixture.directory()), moves)
+
+	# The fixture's item table stops short of the TM/HM range, and the save
+	# validator rejects a world holding an item the cache does not know, so the
+	# rows have to exist before either can sit in the bag.
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	while items.size() < HM_ITEM:
+		var number: int = items.size() + 1
+		items.append({
+			"number": number, "name": "TM%02d" % number,
+			"permissions": 0, "pocket": Gen2WorldPack.TYPE_TM_HM,
+			"field_menu": 0, "battle_menu": 0, "status_mask": 0, "heal_amount": 0,
+		})
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+
+	_data = GameData.open_directory(Fixture.directory())
+	_world.data = _data
+
+
+func _teachable_save() -> Gen2SaveMon:
+	_add_tmhm_metadata()
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.moves = [1, 0, 0, 0]
+	mon.pp = [10, 0, 0, 0]
+	return mon
+
+
+## LearnMove writes the move into the first empty slot and its PP from
+## Moves + MOVE_PP, so a freshly taught move arrives at full PP. TeachTMHM
+## returns straight after IsHM, so an HM is never consumed.
+func test_teaching_an_hm_fills_the_first_empty_slot_and_keeps_the_hm() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, false)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(int(result["move"]), HM_MOVE)
+	assert_eq(int(result["slot"]), 1)
+	assert_eq(int(result["pp"]), 15)
+	assert_false(bool(result["consumed"]))
+	# _copy_save() rebuilds the party from the candidate, so the committed mon is
+	# a new object and the one held before the call is stale.
+	var taught: Gen2SaveMon = _save.party[0]
+	assert_eq(taught.moves[1], HM_MOVE)
+	assert_eq(taught.pp[1], 15)
+	assert_eq(taught.moves[0], mon.moves[0], "the slot already in use is untouched")
+	assert_eq(_world.state.item_quantity(HM_ITEM), 1)
+
+
+## ConsumeTM runs for a TM, after IsHM lets it through.
+func test_teaching_a_tm_consumes_it() -> void:
+	_teachable_save()
+	_world.state.apply_changes({}, {}, {"items": {TM_ITEM: 2}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, false)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_true(bool(result["consumed"]))
+	assert_eq(_world.state.item_quantity(TM_ITEM), 1)
+
+
+## The refusal order is CanLearnTMHMMove, then KnowsMove, then LearnMove's slot
+## search. Each answers before anything is written.
+func test_teaching_refuses_an_incompatible_species_without_writing() -> void:
+	_teachable_save()
+	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	var before: Dictionary = _save.to_dict()
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 1, false)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"not_compatible")
+	assert_eq(_save.to_dict(), before)
+	assert_eq(_world.state.item_quantity(HM_ITEM), 1)
+
+
+func test_teaching_refuses_a_move_the_mon_already_knows() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.moves = [HM_MOVE, 0, 0, 0]
+	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, false)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"already_knows_move")
+	assert_eq(_world.state.item_quantity(HM_ITEM), 1)
+
+
+## Where the source opens ForgetMove, which does not exist here.
+func test_teaching_refuses_a_full_moveset_rather_than_replacing_one() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.moves = [1, 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, false)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"moveset_full")
+	assert_eq(mon.moves, [1, 2, 3, 4])
+
+
+func test_teaching_refuses_an_item_that_is_not_a_tm_or_hm_and_an_absent_one() -> void:
+	_teachable_save()
+	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	assert_eq(
+		Gen2WorldPartyHost.teach_tm_hm(_world, _save, 0x12, 0, false)["reason"],
+		&"not_a_tm_hm"
+	)
+	# ConvertCurItemIntoCurTMHM is reached only from the pocket, so an item the
+	# bag does not hold fails on the quantity first.
+	assert_eq(
+		Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, false)["reason"],
+		&"insufficient_item_quantity"
+	)
+
+
 func test_master_ball_captures_a_wild_mon_and_records_catch_metadata() -> void:
 	var wild: Gen2BattleMon = Gen2BattleMon.create(
 		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234

--- a/tests/unit/test_world_tmhm.gd
+++ b/tests/unit/test_world_tmhm.gd
@@ -1,0 +1,210 @@
+extends GutTest
+
+## TM/HM tables and gates against a synthetic cache built for this file, so the
+## shared world fixture stays untouched.
+##
+## The table is TMHMMoves' real shape: fifty TMs, seven HMs, three tutors. Only
+## the rows the tests name carry meaningful moves; the rest are filler, which is
+## enough because every routine here indexes rather than searches by content.
+
+const TM_COUNT: int = RomLayout.TMHM_TM_COUNT
+const HM_COUNT: int = RomLayout.TMHM_HM_COUNT
+const TUTOR_COUNT: int = 3
+const ENTRY_COUNT: int = TM_COUNT + HM_COUNT + TUTOR_COUNT
+
+## The four HM moves this project acts on, at their real TMNUMs: HM01 is 51.
+const MOVE_CUT: int = 0x0F
+const MOVE_SURF: int = 0x39
+const MOVE_STRENGTH: int = 0x46
+const MOVE_WHIRLPOOL: int = 0xFA
+## TM01's move, so the first row is a real one too.
+const MOVE_DYNAMICPUNCH: int = 0xDF
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"testtmhm", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _write_cache() -> void:
+	var moves: Array = []
+	for number: int in range(1, 0x100):
+		moves.append({
+			"number": number, "name": "MOVE%02X" % number, "effect": 0, "power": 40,
+			"type": 0, "accuracy": 255, "pp": 10 + (number % 5), "effect_chance": 0,
+		})
+	moves[MOVE_CUT - 1]["name"] = "CUT"
+	moves[MOVE_SURF - 1]["name"] = "SURF"
+	moves[MOVE_STRENGTH - 1]["name"] = "STRENGTH"
+	moves[MOVE_WHIRLPOOL - 1]["name"] = "WHIRLPOOL"
+	moves[MOVE_DYNAMICPUNCH - 1]["name"] = "DYNAMICPUNCH"
+	RomCache.write_json(RomCache.moves_path(_directory), moves)
+
+	var table: Array = []
+	for index: int in ENTRY_COUNT:
+		# Filler rows sit in $60-$9b, which holds none of the named moves below,
+		# so tmhm_number_for_move() cannot match two entries by accident.
+		table.append(0x60 + index)
+	table[0] = MOVE_DYNAMICPUNCH
+	table[TM_COUNT + 0] = MOVE_CUT
+	table[TM_COUNT + 2] = MOVE_SURF
+	table[TM_COUNT + 3] = MOVE_STRENGTH
+	table[TM_COUNT + 5] = MOVE_WHIRLPOOL
+	RomCache.write_json(RomCache.tmhm_moves_path(_directory), table)
+
+	# Species 1 learns HM04 (TMNUM 54) and TM01 (TMNUM 1); species 2 learns
+	# neither. Bit index is TMNUM - 1, byte index >> 3, bit index & 7 from the
+	# low bit, which is what SmallFarFlagAction does.
+	RomCache.write_json(RomCache.species_path(_directory), [
+		_species(1, [1, 54]), _species(2, []), _species(3, [51]),
+	])
+	RomCache.write_json(RomCache.items_path(_directory), [])
+	RomCache.write_json(RomCache.types_path(_directory), [])
+	RomCache.write_json(RomCache.matchups_path(_directory), [])
+	RomCache.write_json(RomCache.trainers_path(_directory), [])
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "testtmhm",
+		"sha1": "0123456789abcdef",
+		"complete": true,
+	})
+
+
+func _species(number: int, learnable: Array) -> Dictionary:
+	var flags: Array = []
+	flags.resize(RomLayout.TMHM_BYTES)
+	for index: int in flags.size():
+		flags[index] = 0
+	for tmnum: int in learnable:
+		var bit: int = tmnum - 1
+		flags[bit >> 3] = int(flags[bit >> 3]) | (1 << (bit & 7))
+	return {"number": number, "name": "MON%d" % number, "tmhm": flags}
+
+
+func _data() -> GameData:
+	return GameData.open_directory(_directory)
+
+
+## engine/items/items.asm's GetTMHMNumber and GetNumberedTMHM. The run is not
+## contiguous: ITEM_C3 sits between TM04 and TM05 and ITEM_DC between TM28 and
+## TM29, so a plain subtraction is wrong on either side of both.
+func test_item_numbers_skip_the_two_dummy_items() -> void:
+	for pair: Array in [
+		[0xBF, 1], [0xC0, 2], [0xC2, 4],   # TM01, TM02, TM04
+		[0xC4, 5], [0xDB, 28],             # TM05 and TM28 straddle ITEM_C3
+		[0xDD, 29], [0xF2, 50],            # TM29 and TM50 straddle ITEM_DC
+		[0xF3, 51], [0xF6, 54], [0xF9, 57],  # HM01, HM04, HM07
+	]:
+		assert_eq(
+			RomLayout.tmhm_number_for_item(int(pair[0]), ENTRY_COUNT), int(pair[1]),
+			"item $%02x" % int(pair[0])
+		)
+		assert_eq(
+			RomLayout.item_for_tmhm_number(int(pair[1]), ENTRY_COUNT), int(pair[0]),
+			"number %d" % int(pair[1])
+		)
+	# Both dummies and everything below TM01 have no number of their own.
+	for item: int in [0x00, 0x01, 0xBE, 0xC3, 0xDC]:
+		assert_eq(
+			RomLayout.tmhm_number_for_item(item, ENTRY_COUNT), 0, "item $%02x" % item
+		)
+	# Every number in range maps to exactly one item and back.
+	var seen: Dictionary = {}
+	for number: int in range(1, ENTRY_COUNT + 1):
+		var item: int = RomLayout.item_for_tmhm_number(number, ENTRY_COUNT)
+		assert_false(seen.has(item), "item $%02x claimed twice" % item)
+		seen[item] = true
+		assert_eq(RomLayout.tmhm_number_for_item(item, ENTRY_COUNT), number)
+
+
+func test_is_tm_hm_and_is_hm_follow_the_source_thresholds() -> void:
+	assert_false(Gen2WorldTMHM.is_tm_hm(0xBE))
+	assert_true(Gen2WorldTMHM.is_tm_hm(0xBF))
+	assert_true(Gen2WorldTMHM.is_tm_hm(0xF6))
+	assert_false(Gen2WorldTMHM.is_hm(0xF2))
+	assert_true(Gen2WorldTMHM.is_hm(0xF3))
+	assert_true(Gen2WorldTMHM.is_hm(0xF9))
+
+
+func test_move_for_item_resolves_through_the_imported_table() -> void:
+	var data: GameData = _data()
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0xBF), MOVE_DYNAMICPUNCH)
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0xF3), MOVE_CUT)
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0xF5), MOVE_SURF)
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0xF6), MOVE_STRENGTH)
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0xF8), MOVE_WHIRLPOOL)
+	# Not a TM/HM, and a dummy item inside the range.
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0x12), 0)
+	assert_eq(Gen2WorldTMHM.move_for_item(data, 0xC3), 0)
+	assert_eq(Gen2WorldTMHM.move_for_item(null, 0xF6), 0)
+
+
+func test_tmhm_number_for_move_is_the_inverse_of_tmhm_move() -> void:
+	var data: GameData = _data()
+	assert_eq(data.tmhm_moves().size(), ENTRY_COUNT)
+	assert_eq(data.tmhm_number_for_move(MOVE_STRENGTH), 54)
+	assert_eq(data.tmhm_move(54), MOVE_STRENGTH)
+	assert_eq(data.tmhm_number_for_move(MOVE_CUT), 51)
+	# A move no TM or HM teaches, and both ends of the range.
+	assert_eq(data.tmhm_number_for_move(0), 0)
+	assert_eq(data.tmhm_move(0), 0)
+	assert_eq(data.tmhm_move(ENTRY_COUNT + 1), 0)
+
+
+## CanLearnTMHMMove reads bit (TMNUM - 1) of the species' eight flag bytes, and
+## SmallFarFlagAction counts that bit from the low end of its byte.
+func test_can_learn_reads_the_species_flag_for_that_tm_number() -> void:
+	var data: GameData = _data()
+	assert_true(Gen2WorldTMHM.can_learn(data, 1, MOVE_STRENGTH))
+	assert_true(Gen2WorldTMHM.can_learn(data, 1, MOVE_DYNAMICPUNCH))
+	assert_false(Gen2WorldTMHM.can_learn(data, 1, MOVE_CUT))
+	assert_false(Gen2WorldTMHM.can_learn(data, 2, MOVE_STRENGTH))
+	assert_true(Gen2WorldTMHM.can_learn(data, 3, MOVE_CUT))
+	assert_false(Gen2WorldTMHM.can_learn(data, 3, MOVE_STRENGTH))
+	# .end: a move no TM/HM teaches leaves c at zero, which is "cannot learn".
+	assert_false(Gen2WorldTMHM.can_learn(data, 1, 0x02))
+	assert_false(Gen2WorldTMHM.can_learn(null, 1, MOVE_STRENGTH))
+
+
+func test_knows_move_and_first_empty_slot_match_learn_moves_own_search() -> void:
+	assert_true(Gen2WorldTMHM.knows_move([MOVE_CUT, 0, 0, 0], MOVE_CUT))
+	assert_false(Gen2WorldTMHM.knows_move([MOVE_CUT, 0, 0, 0], MOVE_SURF))
+	assert_eq(Gen2WorldTMHM.first_empty_slot([MOVE_CUT, 0, 0, 0]), 1)
+	assert_eq(Gen2WorldTMHM.first_empty_slot([MOVE_CUT, MOVE_SURF, 0, MOVE_STRENGTH]), 2)
+	assert_eq(
+		Gen2WorldTMHM.first_empty_slot([MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL]),
+		-1
+	)
+
+
+## BootedTMText/BootedHMText then ContainedMoveText, which is the one prompt
+## AskTeachTMHM shows before its yes/no.
+func test_teach_prompt_names_the_move_and_distinguishes_a_tm_from_an_hm() -> void:
+	var data: GameData = _data()
+	var hm: Dictionary = Gen2WorldTMHM.teach_prompt(data, 0xF6)
+	assert_true(hm["ok"])
+	assert_true(hm["hm"])
+	assert_eq(int(hm["move"]), MOVE_STRENGTH)
+	assert_eq(String(hm["move_name"]), "STRENGTH")
+	assert_eq(
+		String(hm["text"]),
+		"Booted up an HM. It contained STRENGTH. Teach STRENGTH to a #MON?"
+	)
+
+	var tm: Dictionary = Gen2WorldTMHM.teach_prompt(data, 0xBF)
+	assert_true(tm["ok"])
+	assert_false(tm["hm"])
+	assert_true(String(tm["text"]).begins_with("Booted up a TM."))
+
+	# .NotTMHM: an item below TM01 never reaches the prompt at all.
+	var ordinary: Dictionary = Gen2WorldTMHM.teach_prompt(data, 0x12)
+	assert_false(ordinary["ok"])
+	assert_eq(StringName(ordinary["reason"]), &"not_a_tm_hm")

--- a/tests/unit/test_world_tmhm.gd.uid
+++ b/tests/unit/test_world_tmhm.gd.uid
@@ -1,0 +1,1 @@
+uid://cxmsrtb1scokf

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -31,6 +31,11 @@ const ITEM_HM_STRENGTH: int = 0xF6
 ## ENGINE_STORMBADGE's place in source badge order, for Gen2WorldState.badge_flag().
 const BADGE_STORM: int = 5
 
+## How many forced Union Cave encounters the route may roll looking for a
+## STRENGTH-capable catch. Its own five Poké Balls are the real limit; this only
+## bounds the rolls that find nothing worth throwing at.
+const CATCH_ATTEMPTS: int = 64
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
@@ -891,6 +896,10 @@ func _hive_badge_path(
 		"encounters": union_cave.get("encounters", []),
 		"run": union_entry,
 	})
+
+	var caught: Dictionary = _catch_strength_mon(world, save, random, data, path)
+	if not bool(caught.get("ok", false)):
+		return caught
 
 	var route33: Dictionary = _warp_walk(world, Vector2i(17, 31), save, random, data)
 	if not bool(route33.get("ok", false)):
@@ -2557,10 +2566,9 @@ func _lighthouse_shaft(
 ## maps/OlivineCafe.asm's sailor at (4,3), who hands over HM04 behind
 ## EVENT_GOT_HM04_STRENGTH. The cafe is Olivine City warp 7 at (7,21).
 ##
-## The move is then written straight into a party member's slots, because
-## AskTeachTMHM and TeachTMHM are not implemented: nothing else can turn the HM
-## in the bag into a move the party knows, and the boulder script's
-## CheckPartyMove reads exactly that. See _teach_move().
+## The HM is then taught through Gen2WorldPartyHost.teach_tm_hm(), the same
+## transaction the pack's own USE reaches, so the route learns STRENGTH the way a
+## player does rather than writing a move slot behind the game's back.
 func _olivine_cafe_hm04(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -2580,7 +2588,7 @@ func _olivine_cafe_hm04(
 	var sailor: Dictionary = _talk_to(
 		world, Vector2i(4, 4), Gen2WorldSprite.FACING_UP, save, random, data
 	)
-	var taught: bool = _teach_move(save, Gen2WorldFieldMove.MOVE_STRENGTH)
+	var taught: Dictionary = _teach_hm(world, save, ITEM_HM_STRENGTH)
 	_mirror_party(world, save)
 	path.append({
 		"step": "olivine_cafe_hm04_strength",
@@ -2598,8 +2606,11 @@ func _olivine_cafe_hm04(
 		}
 	if not world.state.items().has(ITEM_HM_STRENGTH):
 		return {"ok": false, "path": path, "reason": "HM04 did not reach the bag"}
-	if not taught:
-		return {"ok": false, "path": path, "reason": "no party member could learn STRENGTH"}
+	if not bool(taught.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "teaching STRENGTH failed: %s" % taught.get("reason", ""),
+		}
 	var leaving: Dictionary = _warp_step(world, 1, 14)
 	if not bool(leaving.get("ok", false)):
 		return {"ok": false, "path": path, "reason": "Olivine Cafe exit warp failed"}
@@ -2758,19 +2769,79 @@ func _push_boulder_at(
 	}
 
 
-## Stands in for AskTeachTMHM and TeachTMHM, which are not implemented: fills the
-## first empty move slot of the first party member that has one, so the party
-## mirror can answer CheckPartyMove. An egg is skipped, matching
-## CheckIfCurPartyMonIsFitToFight refusing one as a combatant.
-func _teach_move(save: Gen2SaveData, move: int) -> bool:
-	for mon: Gen2SaveMon in save.party:
-		if mon.is_egg or mon.moves.has(move):
+## Catches something in Union Cave that can learn STRENGTH, which is the only
+## way this route ever gets one: the starter is still unevolved by Olivine and
+## Chikorita, Cyndaquil and Totodile all learn it only after evolving
+## (data/pokemon/base_stats/*.asm). Union Cave 1F's own table carries Geodude and
+## Onix, which both can.
+##
+## The walk itself never rolls a wild encounter, so this forces one, checks the
+## species against CanLearnTMHMMove and throws a Poké Ball, retrying until the
+## bag runs out. Both rolls come from the route's seeded generator, so the answer
+## is the same on every run.
+func _catch_strength_mon(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var attempts: Array = []
+	var caught: Dictionary = {}
+	for _attempt: int in CATCH_ATTEMPTS:
+		if world.state.item_quantity(Gen2WorldPartyHost.ITEM_POKE_BALL) <= 0:
+			break
+		var encounter: Dictionary = world.encounter_request(random, true)
+		if encounter.is_empty():
+			break
+		var species: int = int(encounter.get("pokemon", 0))
+		var level: int = int(encounter.get("level", 0))
+		if not Gen2WorldTMHM.can_learn(data, species, Gen2WorldFieldMove.MOVE_STRENGTH):
+			attempts.append({"species": species, "level": level, "thrown": false})
 			continue
-		for slot: int in mon.moves.size():
-			if int(mon.moves[slot]) == 0:
-				mon.moves[slot] = move
-				return true
-	return false
+		var wild: Gen2BattleMon = Gen2BattleMon.create(
+			data, species, level, data.moves_at_level(species, level), random.randi() & 0xFFFF
+		)
+		var throw_result: Dictionary = Gen2WorldPartyHost.capture_wild(
+			world, save, wild, Gen2WorldPartyHost.ITEM_POKE_BALL, random, 0, false
+		)
+		attempts.append({
+			"species": species, "level": level, "thrown": true,
+			"caught": bool(throw_result.get("caught", false)),
+			"reason": throw_result.get("reason", ""),
+		})
+		if bool(throw_result.get("caught", false)):
+			caught = throw_result
+			break
+	_mirror_party(world, save)
+	path.append({
+		"step": "union_cave_catch_for_strength",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"attempts": attempts,
+		"party": _party_species(save),
+		"items": _named_items(data, world.state.items()),
+	})
+	if caught.is_empty():
+		return {
+			"ok": false, "path": path,
+			"reason": "no STRENGTH-capable catch in %d encounters" % attempts.size(),
+		}
+	return {"ok": true}
+
+
+## TeachTMHM against the first party member the HM will take, which is what
+## ChooseMonToLearnTMHM leaves the player to pick. Compatibility, a known move
+## and a full moveset are all real refusals, so the walk tries each slot in party
+## order and reports the last reason when none of them can learn it.
+func _teach_hm(world: Gen2WorldAPI, save: Gen2SaveData, item: int) -> Dictionary:
+	var reason: String = "no party member"
+	for index: int in save.party.size():
+		var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(world, save, item, index, false)
+		if bool(result.get("ok", false)):
+			return result
+		reason = String(result.get("reason", ""))
+	return {"ok": false, "reason": reason}
 
 
 func _party_moves(save: Gen2SaveData) -> Array:

--- a/tools/validate_tmhm.gd
+++ b/tools/validate_tmhm.gd
@@ -1,0 +1,200 @@
+extends SceneTree
+
+## Verifies the TM/HM table and compatibility flags against freshly imported
+## real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## data/moves/tmhm_moves.asm's TMHMMoves, engine/items/items.asm's
+## GetTMHMNumber and GetNumberedTMHM, engine/items/tmhm2.asm's CanLearnTMHMMove
+## and engine/items/tmhm.asm's AskTeachTMHM and TeachTMHM. All are byte identical
+## between the pins apart from one stubbed trainer-ranking call, so nothing here
+## is profile split except the table's own length.
+##
+## The real-cartridge counterpart to tests/unit/test_world_tmhm.gd. The census is
+## what actually pins it: every species' learnable set is compared against the
+## table rather than spot checked, so a wrong flag bit order shows up at once.
+##
+##   Godot --headless --path . -s res://tools/validate_tmhm.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/item_constants.asm: fifty TMs and seven HMs in both games, plus
+## Crystal's three move tutors. The first fifty-seven rows are byte identical.
+const EXPECTED_ENTRIES: Dictionary = {
+	&"gold": 57,
+	&"silver": 57,
+	&"crystal": 60,
+}
+
+## The four HM moves this project acts on, at their real TMNUMs. HM01 is 51, so
+## these also pin where the TM run ends and the HM run starts.
+const EXPECTED_HM_ROWS: Dictionary = {
+	51: 0x0F,  # HM01 CUT
+	52: 0x13,  # HM02 FLY
+	53: 0x39,  # HM03 SURF
+	54: 0x46,  # HM04 STRENGTH
+	55: 0x94,  # HM05 FLASH
+	56: 0xFA,  # HM06 WHIRLPOOL
+	57: 0x7F,  # HM07 WATERFALL
+}
+
+## Census of the real caches, pinned so a cache change is loud: the total number
+## of species-and-TM pairs the flags allow, over all 251 species. Both totals are
+## counted independently from the pins' own data/pokemon/base_stats/*.asm `tmhm`
+## lines, and Crystal's extra 220 are exactly its three move tutor rows.
+const EXPECTED_LEARNABLE_PAIRS: Dictionary = {
+	&"gold": 6372,
+	&"silver": 6372,
+	&"crystal": 6592,
+}
+## Caterpie, Ditto, Kakuna, Magikarp, Metapod, Smeargle, Unown, Weedle and
+## Wobbuffet, the same nine in both games.
+const EXPECTED_SPECIES_WITH_NONE: int = 9
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_table(game_id, data)
+		_verify_item_numbers(game_id, data)
+		_census(game_id, data)
+	_finish()
+
+
+func _verify_table(game_id: StringName, data: GameData) -> void:
+	var table: Array[int] = data.tmhm_moves()
+	_check(
+		table.size() == int(EXPECTED_ENTRIES.get(game_id, -1)),
+		"%s: TMHMMoves has %d entries, not the pinned %d." % [
+			game_id, table.size(), int(EXPECTED_ENTRIES.get(game_id, -1)),
+		]
+	)
+	for number: int in EXPECTED_HM_ROWS:
+		var expected: int = int(EXPECTED_HM_ROWS[number])
+		_check(
+			data.tmhm_move(number) == expected,
+			"%s: TM/HM %d teaches $%02X, not the pinned $%02X." % [
+				game_id, number, data.tmhm_move(number), expected,
+			]
+		)
+	# CanLearnTMHMMove takes the first match when it scans for a move, so a
+	# duplicated row would silently shadow one of them.
+	var seen: Dictionary = {}
+	for move: int in table:
+		_check(
+			not seen.has(move),
+			"%s: move $%02X appears in TMHMMoves twice." % [game_id, move]
+		)
+		seen[move] = true
+		_check(
+			not data.move(move).is_empty(),
+			"%s: TMHMMoves names move $%02X, which the move table does not have." % [
+				game_id, move,
+			]
+		)
+	print("%s: %d TM/HM/tutor entries, HM01 through HM07 verified." % [game_id, table.size()])
+
+
+## GetTMHMNumber and GetNumberedTMHM against every number the cartridge carries.
+## The two dummy items inside the run are what make this worth checking: a plain
+## subtraction is wrong on either side of both.
+func _verify_item_numbers(game_id: StringName, data: GameData) -> void:
+	var count: int = data.tmhm_moves().size()
+	var claimed: Dictionary = {}
+	for number: int in range(1, count + 1):
+		var item: int = RomLayout.item_for_tmhm_number(number, count)
+		_check(
+			not claimed.has(item),
+			"%s: item $%02X is claimed by two TM/HM numbers." % [game_id, item]
+		)
+		claimed[item] = number
+		_check(
+			RomLayout.tmhm_number_for_item(item, count) == number,
+			"%s: item $%02X answers TM/HM %d, not %d." % [
+				game_id, item, RomLayout.tmhm_number_for_item(item, count), number,
+			]
+		)
+		_check(
+			Gen2WorldTMHM.move_for_item(data, item) == data.tmhm_move(number),
+			"%s: item $%02X teaches the wrong move for TM/HM %d." % [game_id, item, number]
+		)
+	for item: int in [RomLayout.ITEM_DUMMY_TM04_05, RomLayout.ITEM_DUMMY_TM28_29]:
+		_check(
+			RomLayout.tmhm_number_for_item(item, count) == 0,
+			"%s: dummy item $%02X answered a TM/HM number." % [game_id, item]
+		)
+	# HM01 is where the HM run starts, which is also where ConsumeTM stops.
+	_check(
+		Gen2WorldTMHM.is_hm(RomLayout.ITEM_HM01)
+			and not Gen2WorldTMHM.is_hm(RomLayout.ITEM_HM01 - 1),
+		"%s: the HM threshold is not at $%02X." % [game_id, RomLayout.ITEM_HM01]
+	)
+
+
+## Every species against every TM/HM number, so a wrong bit order or byte order
+## cannot hide behind a lucky spot check.
+func _census(game_id: StringName, data: GameData) -> void:
+	var table: Array[int] = data.tmhm_moves()
+	var pairs: int = 0
+	var species_with_none: int = 0
+	for species: int in range(1, data.species_count() + 1):
+		var flags: Array = data.species(species).get("tmhm", [])
+		if not _check(
+			flags.size() == RomLayout.TMHM_BYTES,
+			"%s: species %d carries %d TM/HM flag bytes." % [game_id, species, flags.size()]
+		):
+			return
+		var learnable: int = 0
+		for number: int in range(1, table.size() + 1):
+			if Gen2WorldTMHM.can_learn(data, species, data.tmhm_move(number)):
+				learnable += 1
+		# The top four bits of the eight-byte run are past the last TM/HM number
+		# in both games, so no species may set them.
+		var spare: int = int(flags[RomLayout.TMHM_BYTES - 1]) >> (table.size() - 56)
+		_check(
+			spare == 0,
+			"%s: species %d sets a flag past TM/HM %d." % [game_id, species, table.size()]
+		)
+		pairs += learnable
+		if learnable == 0:
+			species_with_none += 1
+	print("%s: %d learnable species/TM pairs, %d species learn none." % [
+		game_id, pairs, species_with_none,
+	])
+	_check(
+		pairs == int(EXPECTED_LEARNABLE_PAIRS.get(game_id, -1)),
+		"%s: learnable census is %d, not the pinned %d." % [
+			game_id, pairs, int(EXPECTED_LEARNABLE_PAIRS.get(game_id, -1)),
+		]
+	)
+	_check(
+		species_with_none == EXPECTED_SPECIES_WITH_NONE,
+		"%s: %d species learn no TM or HM, not the pinned %d." % [
+			game_id, species_with_none, EXPECTED_SPECIES_WITH_NONE,
+		]
+	)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS tmhm: table, item numbers and compatibility census verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_tmhm.gd.uid
+++ b/tools/validate_tmhm.gd.uid
@@ -1,0 +1,1 @@
+uid://cvnw7m6y4tcm1


### PR DESCRIPTION
The TM/HM pocket's USE never reaches UseItem's jumptable: pack.asm gives it its own, which is AskTeachTMHM, ChooseMonToLearnTMHM, TeachTMHM. That whole path now works, so an HM in the bag becomes a move the party knows.

TMHMMoves is imported, which is the data that was missing. Cache format goes to 24. GetTMHMNumber skips the two dummy items sitting inside the TM run, so item numbers map through the source routine rather than a subtraction that is wrong on either side of both.

CanLearnTMHMMove reads bit TMNUM-1 of the species' eight flag bytes, counted from the low bit of each because SmallFarFlagAction shifts left. validate_tmhm.gd checks that against every species and every TM number: 6,372 learnable pairs on Gold and Silver, 6,592 on Crystal, both counted independently from the pins' own base_stats tmhm lines, with Crystal's extra 220 being exactly its three move tutor rows.

TeachTMHM's refusal order is compatibility, then KnowsMove, then LearnMove's empty slot search, each answering before anything is written. A learned move arrives at full PP. IsHM returns before ConsumeTM, so an HM is never used up. A full moveset is a typed refusal, since ForgetMove does not exist here, and the happiness change a TM makes stays a boundary because no ChangeHappiness table is imported.

The walked route teaches HM04 through the real transaction now. That exposed something the old hand-written move slot hid: nothing evolves on level up here and the preview's battles award no experience, so the route's starter is a level 5 Chikorita, and none of the three starters learns Strength before evolving. The route catches a Geodude in Union Cave instead, through a forced encounter and a real capture_wild throw, both rolled from its own seeded generator so the catch is the same every run.