### PR TITLE
Forget a move to make room for a fifth

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Headless tools, all against a real imported cache:
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
-| `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, and the whole species compatibility census, in all three games |
+| `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -338,18 +338,34 @@ func pending_learn(side: int) -> Dictionary:
 ## Answers a pending offer by giving up [param forget_slot] for it. Refuses if
 ## there is nothing pending: an answer to a question nobody asked is not
 ## approximated into one that was.
+##
+## An HM slot is refused too, because `ForgetMove` never returns one: its
+## `.hmmove` branch prints `MoveCantForgetHMText` and redisplays the list
+## (engine/pokemon/learn.asm). A refused answer leaves the offer pending, so
+## [method must_learn_move] still holds and the caller can ask again.
 func learn_move(side: int, forget_slot: int) -> Array:
 	if not must_learn_move(side):
 		return []
 
-	var offer: Dictionary = (_move_learn_queue[side] as Array).pop_front()
+	var offer: Dictionary = (_move_learn_queue[side] as Array)[0]
 	var learner: Gen2BattleMon = party(side).at(int(offer["index"]))
 	if learner == null or forget_slot < 0 or forget_slot >= learner.moves.size():
 		return []
 
 	var forgot: int = int(learner.moves[forget_slot])
+	if Gen2MoveForget.is_hm_move(forgot):
+		return []
 	if not learner.replace_move(forget_slot, int(offer["move"])):
 		return []
+	(_move_learn_queue[side] as Array).pop_front()
+
+	# LearnMove clears a Disable naming the move that just went, but only in
+	# battle. The cartridge compares move numbers against wDisabledMove; Disable
+	# is a slot here, and the new move takes the forgotten one's slot, so slot
+	# equality is the same test.
+	if learner.disabled_slot == forget_slot:
+		learner.disabled_slot = -1
+		learner.disable_turns = 0
 
 	return [{
 		"type": MOVE_FORGOTTEN, "side": side, "index": int(offer["index"]),

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -94,6 +94,15 @@ var _capture_messages: Array[String] = []
 var _capture_terminal: bool = false
 var _capture_result: Dictionary = {}
 
+## Where a level-up's move offer has got to, following LearnMove and ForgetMove
+## (engine/pokemon/learn.asm): [code]&"ask"[/code] is AskForgetMoveText's yes/no,
+## [code]&"list"[/code] ForgetMove's own .loop, [code]&"stop"[/code]
+## LearnMove.cancel's StopLearningMoveText. Empty when nothing is pending.
+var _forget_stage: StringName = &""
+var _forget_moves: Array = []
+var _forget_cursor: int = 0
+var _forget_confirm_cursor: int = 0
+
 ## The trainer class behind the enemy's own moves, or zero for
 ## [method show_matchup]'s invented pairing, which has no class and so no AI
 ## flags of its own to read: it falls back to [method _random_slot], same as
@@ -684,10 +693,14 @@ func _hurt(mon: Gen2BattleMon) -> void:
 func take_turn() -> void:
 	if _battle == null or _battle.is_over() or not _pending.is_empty():
 		return
+	## An unanswered move offer stops everything, the way an unanswered
+	## replacement does: KEY_A reaches here without going through
+	## [method advance].
+	if _battle.awaiting_move_learn():
+		return
 	_pending = _battle.take_turn(_random_slot(Gen2Battle.PLAYER), _enemy_slot())
 	_player_turns_taken += 1
 	_enemy_turns_taken += 1
-	_auto_decline_move_learns()
 	_show_next_event()
 
 
@@ -721,23 +734,146 @@ func _enemy_slot() -> int:
 func switch_player() -> void:
 	if _battle == null or _battle.is_over() or not _pending.is_empty():
 		return
+	if _battle.awaiting_move_learn():
+		return
 	var next: int = _next_healthy(Gen2Battle.PLAYER)
 	if next < 0:
 		return
 	_pending = _battle.take_actions(Gen2Battle.switch_to(next), Gen2Battle.use_move(0))
-	_auto_decline_move_learns()
 	_show_next_event()
 
 
-## No menu exists yet to ask which move to forget, the same gap
-## [method _random_slot] fills for which move to use, so a pending offer is
-## declined automatically and an undriven battle does not stop. [Gen2Battle]
-## still exposes the real question through
-## [method Gen2Battle.must_learn_move].
-func _auto_decline_move_learns() -> void:
-	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
-		while _battle.must_learn_move(side):
-			_pending.append_array(_battle.decline_move(side))
+## Opens LearnMove's full-slot branch, or keeps it open. Answered through
+## [method _unhandled_key_input], the same way capture ball selection is.
+##
+## Only the player side is ever queued
+## ([method Gen2Battle._offer_moves_learned_at]), so there is one stage rather
+## than one per side.
+func _open_move_learn() -> bool:
+	if _battle == null:
+		return false
+	if _forget_stage == &"":
+		if not _battle.must_learn_move(Gen2Battle.PLAYER):
+			return false
+		var offer: Dictionary = _battle.pending_learn(Gen2Battle.PLAYER)
+		var learner: Gen2BattleMon = _battle.party(Gen2Battle.PLAYER).at(int(offer["index"]))
+		if learner == null:
+			return false
+		_forget_moves = Gen2MoveForget.options(_data, learner.moves)
+		if _forget_moves.is_empty():
+			return false
+		_forget_cursor = 0
+		_forget_confirm_cursor = 0
+		_show_forget_stage(&"ask")
+	return true
+
+
+func _show_forget_stage(stage: StringName) -> void:
+	_forget_stage = stage
+	_forget_confirm_cursor = 0
+	if stage == &"list":
+		_show_forget_list()
+	else:
+		_show_forget_confirm()
+
+
+## The two yes/no boxes, which open on YES the way YesNoBox does.
+func _show_forget_confirm() -> void:
+	show_message("%s %s Left/Right: move, Space: choose" % [
+		_forget_prompt_text(),
+		">YES  NO" if _forget_confirm_cursor == 0 else " YES >NO",
+	])
+
+
+func _show_forget_list() -> void:
+	var names: PackedStringArray = []
+	for index: int in _forget_moves.size():
+		var entry: Dictionary = _forget_moves[index]
+		var name: String = String(entry.get("name", ""))
+		names.append("[%s]" % name if index == _forget_cursor else name)
+	show_message("%s %s Up/Down: move, Space: forget, B: back" % [
+		Gen2MoveForget.which_text(), " ".join(names),
+	])
+
+
+## The offer's own name fields, which [method Gen2Battle.pending_learn] carries
+## so neither is re-derived from a party that may already have changed.
+func _forget_move_name() -> String:
+	var offer: Dictionary = _battle.pending_learn(Gen2Battle.PLAYER)
+	return String(_data.move(int(offer.get("move", 0))).get("name", ""))
+
+
+func _forget_learner_name() -> String:
+	var offer: Dictionary = _battle.pending_learn(Gen2Battle.PLAYER)
+	return _name_of(int(offer.get("species", 0)))
+
+
+## The yes/no boxes and the list, in LearnMove's own order. An HM row prints
+## MoveCantForgetHMText and leaves the list open, since .hmmove is `jr .loop`.
+func _answer_forget(keycode: int) -> void:
+	## AskForgetMoveText is three paragraphs, so the box still has pages to turn.
+	## A confirm reveals and pages first, the way [method advance] does, rather
+	## than answering a question the player has not finished reading.
+	if keycode in [KEY_SPACE, KEY_ENTER] and _box != null and _box.advance():
+		return
+	match _forget_stage:
+		&"ask", &"stop":
+			match keycode:
+				KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN:
+					_forget_confirm_cursor = 1 - _forget_confirm_cursor
+					_show_forget_confirm()
+				KEY_SPACE, KEY_ENTER:
+					_confirm_forget_stage()
+		&"list":
+			match keycode:
+				KEY_UP:
+					_forget_cursor = wrapi(_forget_cursor - 1, 0, _forget_moves.size())
+					_show_forget_list()
+				KEY_DOWN:
+					_forget_cursor = wrapi(_forget_cursor + 1, 0, _forget_moves.size())
+					_show_forget_list()
+				KEY_SPACE, KEY_ENTER:
+					_confirm_forget_slot()
+				KEY_ESCAPE, KEY_B:
+					_show_forget_stage(&"stop")
+
+
+func _forget_prompt_text() -> String:
+	if _forget_stage == &"stop":
+		return Gen2MoveForget.stop_text(_forget_move_name())
+	return Gen2MoveForget.ask_text(_forget_learner_name(), _forget_move_name())
+
+
+func _confirm_forget_stage() -> void:
+	var yes: bool = _forget_confirm_cursor == 0
+	if _forget_stage == &"ask":
+		# No is YesNoBox's carry, which is LearnMove.cancel.
+		_show_forget_stage(&"list" if yes else &"stop")
+		return
+	if not yes:
+		# `jp .loop` reaches ForgetMove's ask again.
+		_show_forget_stage(&"ask")
+		return
+	_forget_stage = &""
+	_pending = _battle.decline_move(Gen2Battle.PLAYER)
+	_show_next_event()
+
+
+func _confirm_forget_slot() -> void:
+	if _forget_cursor < 0 or _forget_cursor >= _forget_moves.size():
+		return
+	var entry: Dictionary = _forget_moves[_forget_cursor]
+	if not bool(entry.get("forgettable", false)):
+		show_message("%s %s" % [
+			Gen2MoveForget.cant_forget_hm_text(), Gen2MoveForget.which_text(),
+		])
+		return
+	var events: Array = _battle.learn_move(Gen2Battle.PLAYER, int(entry.get("slot", -1)))
+	if events.is_empty():
+		return
+	_forget_stage = &""
+	_pending = events
+	_show_next_event()
 
 
 ## What a button press does. Finishes the current message if it is still
@@ -765,6 +901,10 @@ func advance() -> void:
 		return
 	if not _pending.is_empty():
 		_show_next_event()
+		return
+	## LearnMove runs inside the experience handler, before the loop asks for a
+	## replacement, so the offer is answered first.
+	if _open_move_learn():
 		return
 	if _replace_the_fallen():
 		return
@@ -1161,6 +1301,11 @@ func _unhandled_key_input(event: InputEvent) -> void:
 
 	var key: InputEventKey = event as InputEventKey
 	if key == null:
+		return
+
+	if _forget_stage != &"":
+		_answer_forget(key.keycode)
+		accept_event()
 		return
 
 	if _capture_selecting:

--- a/game/data/move_forget.gd
+++ b/game/data/move_forget.gd
@@ -1,0 +1,112 @@
+class_name Gen2MoveForget
+extends RefCounted
+
+## Giving up one of four moves to make room for a fifth
+## (engine/pokemon/learn.asm's LearnMove and ForgetMove).
+##
+## `LearnMove` reaches `ForgetMove` from both of its callers: `TeachTMHM` for a
+## TM or HM out of the pack, and a level-up in battle. So the tables and the
+## wording live here rather than beside either one, and neither
+## [Gen2WorldPartyHost] nor [Gen2Battle] owns the other's copy.
+##
+## Everything here is byte identical between the pins. learn.asm differs by one
+## line, `bit B_PAD_B` against `bit B_BUTTON_F`, which is the same bit under two
+## names; home/hm_moves.asm and the seven move numbers are identical.
+##
+## The order the source asks in, which both screens follow:
+##
+## 1. `AskForgetMoveText` and its yes/no. No returns carry, which is
+##    `LearnMove.cancel`.
+## 2. `MoveAskForgetText` and the move list. B is also `LearnMove.cancel`; an HM
+##    row prints `MoveCantForgetHMText` and redisplays the list (`jr .loop`),
+##    which is not a cancel.
+## 3. `LearnMove.cancel` is `StopLearningMoveText` and its yes/no. Yes ends with
+##    `DidNotLearnMoveText`; no returns to step 1.
+
+## How many moves a Pokémon can know at once, NUM_MOVES.
+const MOVE_SLOTS: int = 4
+
+## home/hm_moves.asm's `IsHMMove.HMMoves`, in source order, from
+## constants/move_constants.asm's hex comment column. Seven moves, which is a
+## longer list than the four [constant Gen2WorldFieldMove.FIELD_MOVES] this
+## project acts on in the overworld: forgetting is gated on every HM the
+## cartridge has, not on the ones with a field effect here.
+const HM_MOVES: Array[int] = [
+	0x0F,  # CUT
+	0x13,  # FLY
+	0x39,  # SURF
+	0x46,  # STRENGTH
+	0x94,  # FLASH
+	0x7F,  # WATERFALL
+	0xFA,  # WHIRLPOOL
+]
+
+
+## `IsHMMove`: whether [param move] is one an HM teaches, and so one
+## `ForgetMove` refuses to give up.
+static func is_hm_move(move: int) -> bool:
+	return HM_MOVES.has(move)
+
+
+## The rows `ListMoves` draws, one per move the Pokémon actually knows.
+##
+## `ListMoves` stops at the first zero, so a padded slot is not listed; in
+## practice `ForgetMove` is only reached with all four taken. `forgettable` is
+## the `IsHMMove` test the menu makes on confirm, resolved up front so a screen
+## can mark the row rather than only refuse it.
+static func options(data: GameData, moves: Array) -> Array:
+	var out: Array = []
+	if data == null:
+		return out
+	for slot: int in mini(moves.size(), MOVE_SLOTS):
+		var move: int = int(moves[slot])
+		if move == 0:
+			break
+		out.append({
+			"slot": slot,
+			"move": move,
+			"name": String(data.move(move).get("name", "MOVE")),
+			"forgettable": not is_hm_move(move),
+		})
+	return out
+
+
+## `AskForgetMoveText`. The source prints it as one box of three paragraphs.
+static func ask_text(mon_name: String, move_name: String) -> String:
+	return "%s is trying to learn %s. But %s can't learn more than four moves. Delete an older move to make room for %s?" % [
+		mon_name, move_name, mon_name, move_name,
+	]
+
+
+## `MoveAskForgetText`, the heading over the move list.
+static func which_text() -> String:
+	return "Which move should be forgotten?"
+
+
+## `StopLearningMoveText`, `LearnMove.cancel`'s own yes/no.
+static func stop_text(move_name: String) -> String:
+	return "Stop learning %s?" % move_name
+
+
+## `DidNotLearnMoveText`, the end of a cancelled offer.
+static func did_not_learn_text(mon_name: String, move_name: String) -> String:
+	return "%s did not learn %s." % [mon_name, move_name]
+
+
+## `Text_1_2_and_Poof` then `_MoveForgotText`, as the one line this project
+## shows where the source shows two boxes and a pause. The SFX_SWITCH_POKEMON
+## between them is a boundary: neither screen that reaches this has an SFX
+## route.
+static func forgot_text(mon_name: String, old_move_name: String) -> String:
+	return "1, 2 and… Poof! %s forgot %s. And…" % [mon_name, old_move_name]
+
+
+## `LearnedMoveText`, which `LearnMove.learned` prints on either path into it.
+static func learned_text(mon_name: String, move_name: String) -> String:
+	return "%s learned %s!" % [mon_name, move_name]
+
+
+## `MoveCantForgetHMText`. The list stays open behind it, since the source's
+## `.hmmove` branch is `jr .loop`.
+static func cant_forget_hm_text() -> String:
+	return "HM moves can't be forgotten now."

--- a/game/data/move_forget.gd.uid
+++ b/game/data/move_forget.gd.uid
@@ -1,0 +1,1 @@
+uid://doy332vrqpxv8

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -260,5 +260,12 @@ static func _encodings() -> Dictionary:
 	# and draws a question mark.
 	out["#"] = 0x54
 
+	# charmap.asm maps "…" to $75, which is likewise below FIRST_PRINTABLE and so
+	# decode-only. Source text writes the character itself (Text_MoveForgetCount's
+	# "1, 2 and…"), so a synthesized line quoting that wording needs it to encode
+	# rather than draw a question mark. $56 is "……" and stays decode-only: two
+	# $75s draw the same thing, and nothing has to choose between them.
+	out["…"] = 0x75
+
 	_codes = out
 	return _codes

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -16,7 +16,11 @@ signal action_chosen(kind: StringName)
 ## Emitted on Exit or cancel from the top-level list.
 signal closed
 
-enum Mode { LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET, PACK_RESULT, SAVE_CONFIRM }
+enum Mode {
+	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
+	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING,
+	PACK_RESULT, SAVE_CONFIRM,
+}
 
 ## engine/items/pack.asm's own refusal texts, verbatim from data/text/common_2.asm.
 const OAK_TEXT: String = "OAK: This isn't the time to use that!"
@@ -53,6 +57,14 @@ var _pack_result_ok: bool = false
 var _teach_prompt: Dictionary = {}
 var _teach_cursor: int = 0
 var _teaching: bool = false
+
+## ForgetMove's list and the two yes/no boxes around it. The party index is held
+## because the second teach_tm_hm() call has to name the same Pokémon the first
+## one refused.
+var _forget_moves: Array = []
+var _forget_cursor: int = 0
+var _forget_party_index: int = -1
+var _forget_confirm_cursor: int = 0
 
 var _save_cursor: int = 0
 var _save_result_shown: bool = false
@@ -153,6 +165,21 @@ func _move(direction: Vector2i) -> void:
 			if direction.y != 0 or direction.x != 0:
 				_teach_cursor = 1 - _teach_cursor
 				_render_teach()
+		Mode.PACK_FORGET_ASK:
+			if direction.y != 0 or direction.x != 0:
+				_forget_confirm_cursor = 1 - _forget_confirm_cursor
+				_render_forget_ask()
+		Mode.PACK_FORGET:
+			## w2DMenuNumCols is 1, so only vertical input moves the move list.
+			if direction.y != 0 and not _forget_moves.is_empty():
+				_forget_cursor = wrapi(
+					_forget_cursor + signi(direction.y), 0, _forget_moves.size()
+				)
+				_render_forget_list()
+		Mode.PACK_STOP_LEARNING:
+			if direction.y != 0 or direction.x != 0:
+				_forget_confirm_cursor = 1 - _forget_confirm_cursor
+				_render_stop_learning()
 		Mode.PACK_TARGET:
 			if direction.y != 0 and not _party_targets().is_empty():
 				_target_cursor = wrapi(
@@ -176,6 +203,12 @@ func _confirm() -> void:
 			_confirm_item_action()
 		Mode.PACK_TEACH:
 			_confirm_teach()
+		Mode.PACK_FORGET_ASK:
+			_confirm_forget_ask()
+		Mode.PACK_FORGET:
+			_confirm_forget()
+		Mode.PACK_STOP_LEARNING:
+			_confirm_stop_learning()
 		Mode.PACK_TARGET:
 			if _teaching:
 				_teach_selected_item(_target_cursor)
@@ -195,6 +228,13 @@ func _cancel() -> void:
 			_open_list_mode()
 		Mode.PACK_ITEM, Mode.PACK_RESULT, Mode.PACK_TEACH:
 			_open_pack_mode(false)
+		## B at ForgetMove's ask is YesNoBox's no, and B in the move list is its
+		## own .cancel's scf. Both are the carry LearnMove.cancel tests.
+		Mode.PACK_FORGET_ASK, Mode.PACK_FORGET:
+			_open_stop_learning()
+		## No to "Stop learning?" is `jp .loop`, back to ForgetMove's ask.
+		Mode.PACK_STOP_LEARNING:
+			_open_forget_ask()
 		Mode.PACK_TARGET:
 			_open_item_mode()
 		Mode.SAVE_CONFIRM:
@@ -435,15 +475,124 @@ func _teach_selected_item(party_index: int) -> void:
 		return
 	var item: int = int(_teach_prompt.get("item", 0))
 	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(
-		_world, _pack_save, item, party_index, _pack_persist
+		_world, _pack_save, item, party_index, -1, _pack_persist
 	)
 	_teaching = false
 	if not bool(result.get("ok", false)):
-		_show_pack_result(_teach_refusal(StringName(result.get("reason", &"")), party_index), false)
+		var reason: StringName = StringName(result.get("reason", &""))
+		# LearnMove runs after CanLearnTMHMMove and KnowsMove, so this is the one
+		# refusal that opens a menu instead of ending the USE.
+		if reason == &"moveset_full":
+			var details: Dictionary = result.get("details", {})
+			_forget_party_index = party_index
+			_forget_moves = Gen2MoveForget.options(_data, details.get("moves", []))
+			if not _forget_moves.is_empty():
+				_open_forget_ask()
+				return
+		_show_pack_result(_teach_refusal(reason, party_index), false)
 		return
-	_show_pack_result("%s learned %s!" % [
-		_target_name(party_index), String(_teach_prompt.get("move_name", "")),
+	_show_pack_result(Gen2MoveForget.learned_text(
+		_target_name(party_index), String(_teach_prompt.get("move_name", ""))
+	), true)
+
+
+## ForgetMove's own AskForgetMoveText yes/no, which it prints before the list.
+func _open_forget_ask() -> void:
+	_mode = Mode.PACK_FORGET_ASK
+	_forget_confirm_cursor = 0
+	_status.text = ""
+	_footer.text = "Up/Down: move    Space/Enter: choose    Esc: back"
+	_render_forget_ask()
+
+
+func _render_forget_ask() -> void:
+	_title.text = "TEACH"
+	_summary.text = Gen2MoveForget.ask_text(
+		_target_name(_forget_party_index), String(_teach_prompt.get("move_name", ""))
+	)
+	_render_options([{"label": "YES"}, {"label": "NO"}], _forget_confirm_cursor,
+		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
+	)
+
+
+func _confirm_forget_ask() -> void:
+	if _forget_confirm_cursor != 0:
+		_open_stop_learning()
+		return
+	_open_forget_list()
+
+
+## ForgetMove's .loop: MoveAskForgetText over the moves ListMoves drew. The
+## cartridge's list is plain move names, so an HM is not marked here; it answers
+## on confirm, the way .hmmove does.
+func _open_forget_list() -> void:
+	_mode = Mode.PACK_FORGET
+	_forget_cursor = 0
+	_status.text = ""
+	_footer.text = "Up/Down: move    Space/Enter: forget    Esc: back"
+	_render_forget_list()
+
+
+func _render_forget_list() -> void:
+	_title.text = "FORGET"
+	_summary.text = Gen2MoveForget.which_text()
+	_render_options(_forget_moves, _forget_cursor,
+		func(entry: Dictionary) -> String: return String(entry.get("name", ""))
+	)
+
+
+## The answer TeachTMHM is called a second time with. An HM keeps the list open
+## behind MoveCantForgetHMText, since .hmmove is `jr .loop` and not a cancel.
+func _confirm_forget() -> void:
+	if _forget_cursor < 0 or _forget_cursor >= _forget_moves.size():
+		return
+	var entry: Dictionary = _forget_moves[_forget_cursor]
+	if not bool(entry.get("forgettable", false)):
+		_status.text = Gen2MoveForget.cant_forget_hm_text()
+		_status.add_theme_color_override("font_color", ERROR)
+		return
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(
+		_world, _pack_save, int(_teach_prompt.get("item", 0)), _forget_party_index,
+		int(entry.get("slot", -1)), _pack_persist
+	)
+	if not bool(result.get("ok", false)):
+		_show_pack_result(
+			_teach_refusal(StringName(result.get("reason", &"")), _forget_party_index), false
+		)
+		return
+	var name: String = _target_name(_forget_party_index)
+	_show_pack_result("%s %s" % [
+		Gen2MoveForget.forgot_text(name, String(entry.get("name", ""))),
+		Gen2MoveForget.learned_text(name, String(_teach_prompt.get("move_name", ""))),
 	], true)
+
+
+## LearnMove.cancel, reached from the ask's no and from B in the list alike.
+func _open_stop_learning() -> void:
+	_mode = Mode.PACK_STOP_LEARNING
+	_forget_confirm_cursor = 0
+	_status.text = ""
+	_footer.text = "Up/Down: move    Space/Enter: choose    Esc: back"
+	_render_stop_learning()
+
+
+func _render_stop_learning() -> void:
+	_title.text = "TEACH"
+	_summary.text = Gen2MoveForget.stop_text(String(_teach_prompt.get("move_name", "")))
+	_render_options([{"label": "YES"}, {"label": "NO"}], _forget_confirm_cursor,
+		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
+	)
+
+
+## Yes ends the offer with DidNotLearnMoveText; no is `jp .loop`, which reaches
+## ForgetMove's ask again.
+func _confirm_stop_learning() -> void:
+	if _forget_confirm_cursor != 0:
+		_open_forget_ask()
+		return
+	_show_pack_result(Gen2MoveForget.did_not_learn_text(
+		_target_name(_forget_party_index), String(_teach_prompt.get("move_name", ""))
+	), false)
 
 
 func _target_name(party_index: int) -> String:
@@ -454,8 +603,9 @@ func _target_name(party_index: int) -> String:
 
 
 ## TeachTMHM's own refusals, verbatim from data/text/common_2.asm and
-## common_3.asm. A full moveset is where the source opens ForgetMove, which does
-## not exist here, so it says so rather than inventing a replacement.
+## common_3.asm. A full moveset is not among them: it opens ForgetMove's menu
+## instead, so the only way to reach the two forget-slot reasons here is a
+## revalidation failing between the two teach_tm_hm() calls.
 func _teach_refusal(reason: StringName, party_index: int) -> String:
 	var move_name: String = String(_teach_prompt.get("move_name", "that move"))
 	var name: String = _target_name(party_index)
@@ -466,8 +616,10 @@ func _teach_refusal(reason: StringName, party_index: int) -> String:
 			]
 		&"already_knows_move":
 			return "%s knows %s." % [name, move_name]
-		&"moveset_full":
-			return "%s already knows four moves. Forgetting one is not available yet." % name
+		&"cannot_forget_hm":
+			return Gen2MoveForget.cant_forget_hm_text()
+		&"invalid_forget_slot":
+			return "%s can't forget that move." % name
 		&"cannot_teach_egg":
 			return "An EGG can't learn anything."
 	return "Can't teach that: %s" % String(reason)

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -240,9 +240,14 @@ static func use_item(
 ##
 ## The refusal order is the source's. CanLearnTMHMMove comes first, then
 ## KnowsMove, then LearnMove's own search for an empty slot; each answers before
-## anything is written. A full moveset is where the source opens ForgetMove,
-## which does not exist here, so it is a typed refusal rather than an invented
-## replacement.
+## anything is written.
+##
+## A full moveset is where LearnMove reaches ForgetMove, which is a menu, so this
+## is called twice: once with [param forget_slot] left at -1, which is what runs
+## the two compatibility checks and answers `moveset_full` having written
+## nothing, and again with the slot the player gave up. An empty slot always
+## wins over a passed [param forget_slot], because LearnMove.loop only reaches
+## ForgetMove when its own scan finds no zero.
 ##
 ## An HM is not consumed: TeachTMHM returns straight after IsHM, so it skips both
 ## ConsumeTM and the happiness change. The happiness change a TM does make is a
@@ -252,6 +257,7 @@ static func teach_tm_hm(
 	save: Gen2SaveData,
 	item: int,
 	party_index: int,
+	forget_slot: int = -1,
 	persist: bool = true
 ) -> Dictionary:
 	if world == null or save == null or world.data == null:
@@ -275,8 +281,20 @@ static func teach_tm_hm(
 	if Gen2WorldTMHM.knows_move(mon.moves, move):
 		return _failure(&"already_knows_move", {"move": move})
 	var slot: int = Gen2WorldTMHM.first_empty_slot(mon.moves)
+	var forgot: int = 0
 	if slot < 0:
-		return _failure(&"moveset_full", {"party_index": party_index, "move": move})
+		# ForgetMove's own refusals, answering before the candidate save is built
+		# the way every refusal above them does.
+		if forget_slot < 0:
+			return _failure(&"moveset_full", {
+				"party_index": party_index, "move": move, "moves": mon.moves.duplicate(),
+			})
+		if forget_slot >= mon.moves.size():
+			return _failure(&"invalid_forget_slot", {"forget_slot": forget_slot})
+		forgot = int(mon.moves[forget_slot])
+		if Gen2MoveForget.is_hm_move(forgot):
+			return _failure(&"cannot_forget_hm", {"forget_slot": forget_slot, "forgot": forgot})
+		slot = forget_slot
 
 	var validation: Dictionary = Gen2SaveValidator.validate(save, world.data)
 	if not bool(validation.get("ok", false)):
@@ -315,6 +333,7 @@ static func teach_tm_hm(
 		"party_index": party_index,
 		"move": move,
 		"slot": slot,
+		"forgot": forgot,
 		"pp": learner.pp[slot],
 		"consumed": consumed,
 	}

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -823,6 +823,70 @@ func preview_pack_use() -> void:
 	_start_menu_host.handle_key(KEY_SPACE)
 
 
+## Public screenshot driver for ForgetMove. It fills the first party member's
+## four move slots and grants a TM or HM that member can learn, on an injected
+## save so nothing persists, then advances one menu step per call: Pack, the
+## TM/HM, USE, YES, the party member, ForgetMove's ask, and the move list.
+##
+## The granted item is whichever TM or HM this species can actually learn, since
+## a development save's first member is whatever the cache holds; a species that
+## can learn none reports that rather than opening a menu it cannot fill.
+func preview_move_forget() -> void:
+	if _world == null or _data == null:
+		return
+	if _start_menu_host != null:
+		_start_menu_host.handle_key(KEY_SPACE)
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Forget preview needs a party"
+		_refresh_labels()
+		return
+	var mon: Gen2SaveMon = save.party[0]
+	var item: int = _teachable_tmhm_for(mon.species)
+	if item <= 0:
+		_script_prompt = "Forget preview: this species learns no TM or HM"
+		_refresh_labels()
+		return
+	# Four moves the species need not know legitimately: ForgetMove is reached by
+	# the slot count alone, and this is a screenshot rather than a save.
+	mon.moves = [1, 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	_injected_save = save
+	_world.state.apply_changes({}, {}, {"items": {item: 1}})
+	_open_start_menu()
+	if _start_menu_host == null:
+		return
+	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
+		_start_menu_host.handle_key(KEY_DOWN)
+	_start_menu_host.handle_key(KEY_SPACE)
+	# The pack opens on the ITEM pocket, and the granted item is in the TM/HM
+	# one. The guard bounds the walk in case no such pocket is built.
+	var guard: int = Gen2WorldPack.POCKET_ORDER.size() + 1
+	while guard > 0 and _previewed_pocket() != Gen2WorldPack.TYPE_TM_HM:
+		_start_menu_host.handle_key(KEY_RIGHT)
+		guard -= 1
+
+
+func _previewed_pocket() -> int:
+	var pockets: Array = _start_menu_host.get("_pack_pockets")
+	var index: int = int(_start_menu_host.get("_pack_pocket_index"))
+	if index < 0 or index >= pockets.size():
+		return -1
+	return int((pockets[index] as Dictionary).get("pocket", -1))
+
+
+## The first TM or HM item [param species] can learn, or 0. Walks the numbers
+## rather than the items, since the run is not contiguous.
+func _teachable_tmhm_for(species: int) -> int:
+	var count: int = _data.tmhm_moves().size()
+	for number: int in range(1, count + 1):
+		var move: int = _data.tmhm_move(number)
+		if move > 0 and Gen2WorldTMHM.can_learn(_data, species, move):
+			return RomLayout.item_for_tmhm_number(number, count)
+	return 0
+
+
 ## Public screenshot driver for the battle-request host path. It starts the
 ## same request shape emitted by [Gen2WorldScriptRunner], without pretending a
 ## map event was present in the selected development map.

--- a/tests/integration/test_battle_move_forget.gd
+++ b/tests/integration/test_battle_move_forget.gd
@@ -1,0 +1,213 @@
+extends GutTest
+
+## Scene integration for LearnMove's full-slot branch inside a battle.
+##
+## The cache is synthetic, but the battle screen, its text box and [Gen2Battle]
+## are the production paths. The setup is the one
+## `test_a_full_moveset_is_offered_a_new_move_rather_than_taught_it` uses in
+## tests/unit/test_battle.gd: a level 5 Geodude with three moves beats a level 33
+## Magcargo, Growl fills the fourth slot at level 6, and level 11's Slash finds
+## every slot taken.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
+
+## SURF, HM03, which ForgetMove's .hmmove branch refuses to give up.
+const MOVE_SURF: int = 0x39
+
+var _data: GameData = null
+var _screen: Gen2BattleScreen = null
+var _rng := RandomNumberGenerator.new()
+
+
+func before_each() -> void:
+	Gen2ModHost.reset()
+	_data = Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+	_rng.seed = 11
+
+
+func after_each() -> void:
+	if is_instance_valid(_screen):
+		_screen.free()
+		_screen = null
+	RomCache.clear(Fixture.directory())
+	Gen2ModHost.reset()
+
+
+## Opens the screen, then puts the crafted battle on it. show_matchup() builds
+## its parties from the learnset, which cannot produce a full moveset at level
+## 5, so the battle itself is assembled the way the unit tests assemble one.
+func _open_with_full_moveset(third_move: int = BattleFixture.THUNDERBOLT) -> void:
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_screen = packed.instantiate() as Gen2BattleScreen
+	_screen.set_data(_data)
+	add_child(_screen)
+	await get_tree().process_frame
+	_screen.show_matchup(BattleFixture.MAGCARGO, BattleFixture.GEODUDE, 33, 5)
+
+	var player: Gen2BattleMon = Gen2BattleMon.create(
+		_data, BattleFixture.GEODUDE, 5,
+		[BattleFixture.TACKLE, BattleFixture.EMBER, third_move]
+	)
+	var enemy: Gen2BattleMon = Gen2BattleMon.create(
+		_data, BattleFixture.MAGCARGO, 33, [BattleFixture.TACKLE]
+	)
+	var battle: Gen2Battle = Gen2Battle.create(_data, player, enemy, _rng)
+	battle.enemy.hp = 1
+	_screen.set("_battle", battle)
+	_screen.set("_pending", battle.take_turn(0, 0))
+	await get_tree().process_frame
+
+
+## Presses through every queued event until the offer opens, which is what a
+## player pressing A does.
+func _advance_to_offer(limit: int = 40) -> void:
+	for _press: int in limit:
+		if String(_screen.get("_forget_stage")) != "":
+			return
+		_screen.finish()
+		_screen.advance()
+		await get_tree().process_frame
+
+
+func _stage() -> String:
+	return String(_screen.get("_forget_stage"))
+
+
+## AskForgetMoveText is three paragraphs, so a confirm press pages the box
+## before it answers anything. Reading it to the end first is what a player
+## does; the paging itself is covered by
+## test_a_confirm_pages_the_prompt_before_answering_it.
+func _drain_box() -> void:
+	var box: Gen2TextBox = _screen.get("_box")
+	while box != null and box.advance():
+		pass
+
+
+func _press(keycode: int) -> void:
+	await _drain_box()
+	_screen._answer_forget(keycode)
+	await get_tree().process_frame
+
+
+## The offer used to be declined automatically because no menu existed. It now
+## stops and asks, and the battle does not go on behind it.
+func test_a_full_moveset_opens_the_ask_instead_of_declining() -> void:
+	await _open_with_full_moveset()
+	var battle: Gen2Battle = _screen.get("_battle")
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+
+	await _advance_to_offer()
+	assert_eq(_stage(), "ask")
+	assert_true(
+		_screen.battle_snapshot()["message"].contains("can't learn more than four moves"),
+		String(_screen.battle_snapshot()["message"])
+	)
+
+	## take_turn is reachable straight from a key press, so it has its own guard.
+	_screen.take_turn()
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER), "the offer still stands")
+	assert_eq(_stage(), "ask")
+
+
+## Yes opens ForgetMove's list, and a chosen slot is the answer.
+func test_choosing_a_slot_forgets_that_move_and_learns_the_offered_one() -> void:
+	await _open_with_full_moveset()
+	var battle: Gen2Battle = _screen.get("_battle")
+	await _advance_to_offer()
+
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "list")
+	assert_eq((_screen.get("_forget_moves") as Array).size(), 4)
+
+	## Slot 1 is Ember, an ordinary move.
+	await _press(KEY_DOWN)
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "", "the offer is answered")
+	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
+	assert_eq(battle.player.moves[1], BattleFixture.SLASH)
+	assert_false(battle.player.moves.has(BattleFixture.EMBER))
+
+
+## .hmmove prints MoveCantForgetHMText and is `jr .loop`: the list stays open
+## and the offer is still unanswered.
+func test_an_hm_row_is_refused_and_the_list_stays_open() -> void:
+	await _open_with_full_moveset(MOVE_SURF)
+	var battle: Gen2Battle = _screen.get("_battle")
+	await _advance_to_offer()
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "list")
+
+	## Slot 2 is SURF.
+	await _press(KEY_DOWN)
+	await _press(KEY_DOWN)
+	await _press(KEY_SPACE)
+
+	assert_eq(_stage(), "list", "the list stays open")
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+	assert_eq(battle.player.moves[2], MOVE_SURF)
+	assert_true(
+		_screen.battle_snapshot()["message"].contains("HM moves can't be forgotten"),
+		String(_screen.battle_snapshot()["message"])
+	)
+
+
+## No at the ask is LearnMove.cancel: the stop-learning yes/no, whose yes ends
+## the offer with DidNotLearnMoveText and keeps the four moves.
+func test_refusing_reaches_stop_learning_and_declines_the_move() -> void:
+	await _open_with_full_moveset()
+	var battle: Gen2Battle = _screen.get("_battle")
+	await _advance_to_offer()
+	var before: Array = battle.player.moves.duplicate()
+
+	await _press(KEY_RIGHT)
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "stop")
+
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "")
+	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
+	assert_eq(battle.player.moves, before, "nothing was forgotten")
+
+
+## No to "Stop learning?" is `jp .loop`, back to ForgetMove's ask.
+func test_declining_to_stop_returns_to_the_ask() -> void:
+	await _open_with_full_moveset()
+	var battle: Gen2Battle = _screen.get("_battle")
+	await _advance_to_offer()
+
+	await _press(KEY_RIGHT)
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "stop")
+
+	await _press(KEY_RIGHT)
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "ask")
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+	assert_eq(_screen.get("_forget_confirm_cursor"), 0, "YesNoBox reopens on YES")
+
+
+## A confirm reveals and pages before it answers, so the three paragraphs of
+## AskForgetMoveText cannot be skipped past by the press that opens them.
+func test_a_confirm_pages_the_prompt_before_answering_it() -> void:
+	await _open_with_full_moveset()
+	await _advance_to_offer()
+	assert_eq(_stage(), "ask")
+
+	var box: Gen2TextBox = _screen.get("_box")
+	assert_true(box.advance(), "the prompt still has pages to turn")
+	_screen._answer_forget(KEY_SPACE)
+	await get_tree().process_frame
+	assert_eq(_stage(), "ask", "the press turned a page rather than answering")
+
+
+## B in the list is ForgetMove's own .cancel, the same carry the ask's no sets.
+func test_backing_out_of_the_list_reaches_stop_learning() -> void:
+	await _open_with_full_moveset()
+	await _advance_to_offer()
+	await _press(KEY_SPACE)
+	assert_eq(_stage(), "list")
+
+	await _press(KEY_B)
+	assert_eq(_stage(), "stop")

--- a/tests/integration/test_battle_move_forget.gd.uid
+++ b/tests/integration/test_battle_move_forget.gd.uid
@@ -1,0 +1,1 @@
+uid://ce0iccwl7k5c7

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -275,6 +275,145 @@ func test_tmhm_use_reports_an_incompatible_species() -> void:
 	assert_false(save.party[0].moves.has(HM_MOVE))
 
 
+## Fills the first party member's four move slots so LearnMove's scan finds no
+## zero and reaches ForgetMove. Slot 1 is SURF, HM03, the row .hmmove refuses.
+func _fill_moveset(with_hm: bool = true) -> Gen2SaveMon:
+	var mon: Gen2SaveMon = _world_screen._injected_save.party[0]
+	mon.moves = [1, 0x39 if with_hm else 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	return mon
+
+
+## Walks the pack to the TEACH prompt and answers yes, which reaches the party
+## list and then LearnMove.
+func _reach_forget_ask() -> Gen2StartMenuScreen:
+	var host: Gen2StartMenuScreen = await _open_tmhm_pack()
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	return host
+
+
+## LearnMove reaches ForgetMove, whose ask comes before the list.
+func test_a_full_moveset_opens_forget_move_and_a_choice_replaces_that_slot() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	var mon: Gen2SaveMon = _fill_moveset()
+	var host: Gen2StartMenuScreen = await _reach_forget_ask()
+
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
+	assert_true(
+		String(host.get("_summary").text).contains("can't learn more than four moves"),
+		String(host.get("_summary").text)
+	)
+
+	## Yes is YesNoBox's default, which opens the list.
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET)
+	assert_eq((host.get("_forget_moves") as Array).size(), 4)
+
+	## Slot 2, past the HM, is an ordinary move.
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_true(bool(host.get("_pack_result_ok")), String(host.get("_pack_result")))
+	assert_eq(_world_screen._injected_save.party[0].moves, [1, 0x39, HM_MOVE, 4])
+	assert_true(String(host.get("_pack_result")).contains("forgot"), String(host.get("_pack_result")))
+
+
+## .hmmove prints MoveCantForgetHMText and is `jr .loop`, so the list stays open
+## and nothing is written.
+func test_choosing_an_hm_row_refuses_and_keeps_the_list_open() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	_fill_moveset()
+	var host: Gen2StartMenuScreen = await _reach_forget_ask()
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET, "the list stays open")
+	assert_eq(String(host.get("_status").text), "HM moves can't be forgotten now.")
+	assert_eq(_world_screen._injected_save.party[0].moves, [1, 0x39, 3, 4])
+
+
+## No at the ask is YesNoBox's carry, which is LearnMove.cancel: the
+## stop-learning yes/no, and yes there ends with DidNotLearnMoveText.
+func test_refusing_to_forget_reaches_stop_learning_and_teaches_nothing() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	_fill_moveset()
+	var host: Gen2StartMenuScreen = await _reach_forget_ask()
+
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_STOP_LEARNING)
+	assert_true(
+		String(host.get("_summary").text).begins_with("Stop learning"),
+		String(host.get("_summary").text)
+	)
+
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_false(bool(host.get("_pack_result_ok")))
+	assert_true(
+		String(host.get("_pack_result")).contains("did not learn"),
+		String(host.get("_pack_result"))
+	)
+	assert_eq(_world_screen._injected_save.party[0].moves, [1, 0x39, 3, 4])
+	## An HM is never consumed, refused or not.
+	assert_eq(_world_screen._world.state.item_quantity(HM_ITEM), 1)
+
+
+## No to "Stop learning?" is `jp .loop`, which reaches ForgetMove's ask again
+## rather than ending the offer.
+func test_declining_to_stop_returns_to_the_forget_ask() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	_fill_moveset()
+	var host: Gen2StartMenuScreen = await _reach_forget_ask()
+
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_STOP_LEARNING)
+
+	host.handle_key(KEY_DOWN)
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
+	## YesNoBox opens on YES every time it is opened.
+	assert_eq(host.get("_forget_confirm_cursor"), 0)
+
+
+## B in the list is ForgetMove's own .cancel, the same carry the ask's no sets.
+func test_backing_out_of_the_move_list_reaches_stop_learning() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	_fill_moveset()
+	var host: Gen2StartMenuScreen = await _reach_forget_ask()
+	host.handle_key(KEY_ENTER)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET)
+
+	host.handle_key(KEY_ESCAPE)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_STOP_LEARNING)
+
+
 func test_pokegear_reaches_the_existing_phone_list() -> void:
 	await _open_world()
 	_world_screen._world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEGEAR)

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1031,6 +1031,83 @@ func test_a_battle_refuses_to_continue_until_the_offered_move_is_answered() -> v
 	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
 
 
+## ForgetMove's .hmmove branch redisplays the list instead of answering, so an
+## HM slot is not an answer the source can produce. Refusing it has to leave the
+## offer standing, or the move would be lost to a press the cartridge ignores.
+func test_an_hm_slot_is_refused_and_leaves_the_offer_pending() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+	# Slot 2 becomes SURF, HM03, which ForgetMove refuses to give up.
+	battle.player.moves[2] = 0x39
+	var before: Array = battle.player.moves.duplicate()
+
+	assert_eq(battle.learn_move(Gen2Battle.PLAYER, 2), [])
+	assert_eq(battle.player.moves, before, "nothing is overwritten")
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER), "the offer still stands")
+
+	## An ordinary slot still answers it afterwards.
+	assert_eq(battle.learn_move(Gen2Battle.PLAYER, 1).size(), 1)
+	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
+
+
+## An out-of-range slot is not an answer either, so it must not swallow the
+## offer on its way to refusing.
+func test_an_out_of_range_slot_leaves_the_offer_pending() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+
+	assert_eq(battle.learn_move(Gen2Battle.PLAYER, 9), [])
+	assert_eq(battle.learn_move(Gen2Battle.PLAYER, -1), [])
+	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
+
+
+## LearnMove clears a Disable naming the move that just went (its wDisabledMove
+## check, in battle only). Disable is a slot here and the new move takes the
+## forgotten one's slot, so the test is slot equality.
+func test_forgetting_the_disabled_move_clears_the_disable() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+	battle.player.disabled_slot = 1
+	battle.player.disable_turns = 4
+
+	battle.learn_move(Gen2Battle.PLAYER, 1)
+
+	assert_eq(battle.player.disabled_slot, -1)
+	assert_eq(battle.player.disable_turns, 0)
+	assert_true(battle.player.can_use(1), "the slot is usable again")
+
+
+## A different slot leaves the Disable where it was: the cartridge compares the
+## forgotten move against wDisabledMove rather than clearing unconditionally.
+func test_forgetting_another_move_leaves_the_disable_alone() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),
+		_mon(Fixture.MAGCARGO, 33, [Fixture.TACKLE])
+	)
+	battle.enemy.hp = 1
+	battle.take_turn(0, 0)
+	battle.player.disabled_slot = 0
+	battle.player.disable_turns = 4
+
+	battle.learn_move(Gen2Battle.PLAYER, 1)
+
+	assert_eq(battle.player.disabled_slot, 0)
+	assert_eq(battle.player.disable_turns, 4)
+
+
 func test_declining_the_offered_move_keeps_the_four_already_known() -> void:
 	var battle: Gen2Battle = _battle(
 		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE, Fixture.EMBER, Fixture.THUNDERBOLT]),

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -1,0 +1,138 @@
+extends GutTest
+
+## ForgetMove's table and list against a synthetic cache built for this file.
+##
+## The load-bearing part is the HM list: it is seven moves, not the four
+## [constant Gen2WorldFieldMove.FIELD_MOVES] this project acts on in the
+## overworld, and getting that wrong would let a player forget Fly or Flash.
+
+## home/hm_moves.asm's IsHMMove.HMMoves with the names
+## constants/move_constants.asm gives them, in source order.
+const HM_MOVES: Dictionary = {
+	0x0F: "CUT",
+	0x13: "FLY",
+	0x39: "SURF",
+	0x46: "STRENGTH",
+	0x94: "FLASH",
+	0x7F: "WATERFALL",
+	0xFA: "WHIRLPOOL",
+}
+
+## Two moves no HM teaches, one either side of the HM range.
+const MOVE_TACKLE: int = 0x21
+const MOVE_SLASH: int = 0xA3
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"testforget", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _write_cache() -> void:
+	var moves: Array = []
+	for number: int in range(1, 0x100):
+		moves.append({
+			"number": number, "name": "MOVE%02X" % number, "effect": 0, "power": 40,
+			"type": 0, "accuracy": 255, "pp": 10, "effect_chance": 0,
+		})
+	for move: int in HM_MOVES:
+		moves[move - 1]["name"] = String(HM_MOVES[move])
+	moves[MOVE_TACKLE - 1]["name"] = "TACKLE"
+	moves[MOVE_SLASH - 1]["name"] = "SLASH"
+	RomCache.write_json(RomCache.moves_path(_directory), moves)
+
+	RomCache.write_json(RomCache.species_path(_directory), [])
+	RomCache.write_json(RomCache.items_path(_directory), [])
+	RomCache.write_json(RomCache.types_path(_directory), [])
+	RomCache.write_json(RomCache.matchups_path(_directory), [])
+	RomCache.write_json(RomCache.trainers_path(_directory), [])
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "testforget",
+		"sha1": "0123456789abcdef",
+		"complete": true,
+	})
+
+
+func _data() -> GameData:
+	return GameData.open_directory(_directory)
+
+
+## All seven, and nothing else. The count is asserted too, so an eighth entry
+## slipping in from FIELD_MOVES or a TM list is a failure rather than a pass.
+func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
+	assert_eq(Gen2MoveForget.HM_MOVES.size(), 7)
+	for move: int in HM_MOVES:
+		assert_true(Gen2MoveForget.is_hm_move(move), String(HM_MOVES[move]))
+	assert_false(Gen2MoveForget.is_hm_move(MOVE_TACKLE))
+	assert_false(Gen2MoveForget.is_hm_move(MOVE_SLASH))
+	assert_false(Gen2MoveForget.is_hm_move(0))
+
+
+## The overworld's field-move list is a different, shorter question: Fly, Flash
+## and Waterfall are HMs that this project does not act on, and forgetting is
+## gated on all seven regardless.
+func test_the_hm_list_is_wider_than_the_overworld_field_moves() -> void:
+	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
+		assert_true(Gen2MoveForget.is_hm_move(move), "field move %d" % move)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 4)
+	assert_true(Gen2MoveForget.is_hm_move(0x13), "FLY is an HM with no field effect here")
+	assert_false(Gen2WorldFieldMove.FIELD_MOVES.has(0x13))
+
+
+## ListMoves walks the slots and stops at the first zero, so a padded slot is
+## not offered. In practice ForgetMove only opens with all four taken.
+func test_options_lists_known_moves_and_stops_at_the_first_empty_slot() -> void:
+	var rows: Array = Gen2MoveForget.options(
+		_data(), [MOVE_TACKLE, 0x39, 0, MOVE_SLASH]
+	)
+	assert_eq(rows.size(), 2)
+	assert_eq(rows[0]["slot"], 0)
+	assert_eq(rows[0]["name"], "TACKLE")
+	assert_eq(rows[1]["slot"], 1)
+	assert_eq(rows[1]["name"], "SURF")
+
+
+## The IsHMMove test the menu makes on confirm, resolved per row.
+func test_options_marks_hm_rows_as_not_forgettable() -> void:
+	var rows: Array = Gen2MoveForget.options(
+		_data(), [MOVE_TACKLE, 0x39, 0x94, MOVE_SLASH]
+	)
+	assert_eq(rows.size(), 4)
+	assert_true(bool(rows[0]["forgettable"]), "TACKLE")
+	assert_false(bool(rows[1]["forgettable"]), "SURF is HM03")
+	assert_false(bool(rows[2]["forgettable"]), "FLASH is HM05")
+	assert_true(bool(rows[3]["forgettable"]), "SLASH")
+
+
+func test_options_answers_empty_without_data() -> void:
+	assert_eq(Gen2MoveForget.options(null, [MOVE_TACKLE]), [])
+	assert_eq(Gen2MoveForget.options(_data(), []), [])
+
+
+## The wording is the source's, so a screen reads it rather than inventing one.
+func test_prompts_name_the_pokemon_and_both_moves() -> void:
+	assert_eq(
+		Gen2MoveForget.ask_text("GEODUDE", "STRENGTH"),
+		"GEODUDE is trying to learn STRENGTH. But GEODUDE can't learn more than four moves. Delete an older move to make room for STRENGTH?"
+	)
+	assert_eq(Gen2MoveForget.which_text(), "Which move should be forgotten?")
+	assert_eq(Gen2MoveForget.stop_text("STRENGTH"), "Stop learning STRENGTH?")
+	assert_eq(
+		Gen2MoveForget.did_not_learn_text("GEODUDE", "STRENGTH"),
+		"GEODUDE did not learn STRENGTH."
+	)
+	assert_eq(
+		Gen2MoveForget.forgot_text("GEODUDE", "TACKLE"),
+		"1, 2 and… Poof! GEODUDE forgot TACKLE. And…"
+	)
+	assert_eq(Gen2MoveForget.learned_text("GEODUDE", "STRENGTH"), "GEODUDE learned STRENGTH!")
+	assert_eq(Gen2MoveForget.cant_forget_hm_text(), "HM moves can't be forgotten now.")

--- a/tests/unit/test_move_forget.gd.uid
+++ b/tests/unit/test_move_forget.gd.uid
@@ -1,0 +1,1 @@
+uid://d1frridpy4qm4

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -64,6 +64,16 @@ func test_hash_encodes_the_poke_ligature_the_source_charmap_names() -> void:
 	assert_eq(Gen2Text.encoded_length("POKéMON"), 7)
 
 
+## $75 is decode-only for the same reason $54 is, and source text writes the
+## character itself, so a synthesized line quoting it has to encode.
+func test_ellipsis_encodes_the_source_charmap_code() -> void:
+	assert_eq(Gen2Text.encode("…"), PackedByteArray([0x75]))
+	assert_ne(Gen2Text.encode("…")[0], Gen2Text.UNKNOWN)
+	assert_eq(Gen2Text.decode(Gen2Text.encode("1, 2 and…"), 0, 16), "1, 2 and…")
+	## One tile, so a message using it is laid out at its real width.
+	assert_eq(Gen2Text.encoded_length("and…"), 4)
+
+
 func test_apostrophe_ligatures_expand_to_two_characters() -> void:
 	# One tile in the font, two letters on screen.
 	assert_eq(Gen2Text.decode(PackedByteArray([0x88, 0xD5]), 0, 4), "I't")

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -216,7 +216,7 @@ func _teachable_save() -> Gen2SaveMon:
 func test_teaching_an_hm_fills_the_first_empty_slot_and_keeps_the_hm() -> void:
 	var mon: Gen2SaveMon = _teachable_save()
 	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
-	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, false)
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, -1, false)
 	assert_true(result["ok"], JSON.stringify(result))
 	assert_eq(int(result["move"]), HM_MOVE)
 	assert_eq(int(result["slot"]), 1)
@@ -235,7 +235,7 @@ func test_teaching_an_hm_fills_the_first_empty_slot_and_keeps_the_hm() -> void:
 func test_teaching_a_tm_consumes_it() -> void:
 	_teachable_save()
 	_world.state.apply_changes({}, {}, {"items": {TM_ITEM: 2}})
-	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, false)
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, -1, false)
 	assert_true(result["ok"], JSON.stringify(result))
 	assert_true(bool(result["consumed"]))
 	assert_eq(_world.state.item_quantity(TM_ITEM), 1)
@@ -247,7 +247,7 @@ func test_teaching_refuses_an_incompatible_species_without_writing() -> void:
 	_teachable_save()
 	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
 	var before: Dictionary = _save.to_dict()
-	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 1, false)
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 1, -1, false)
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"not_compatible")
 	assert_eq(_save.to_dict(), before)
@@ -258,35 +258,104 @@ func test_teaching_refuses_a_move_the_mon_already_knows() -> void:
 	var mon: Gen2SaveMon = _teachable_save()
 	mon.moves = [HM_MOVE, 0, 0, 0]
 	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
-	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, false)
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, -1, false)
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"already_knows_move")
 	assert_eq(_world.state.item_quantity(HM_ITEM), 1)
 
 
-## Where the source opens ForgetMove, which does not exist here.
-func test_teaching_refuses_a_full_moveset_rather_than_replacing_one() -> void:
+## Where LearnMove opens ForgetMove. With no slot named, this is the call that
+## runs the two compatibility checks and then asks; it writes nothing, and it
+## carries the moves the menu lists.
+func test_teaching_a_full_moveset_asks_rather_than_replacing_one() -> void:
 	var mon: Gen2SaveMon = _teachable_save()
 	mon.moves = [1, 2, 3, 4]
 	mon.pp = [10, 10, 10, 10]
 	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
-	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, false)
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, -1, false)
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"moveset_full")
+	assert_eq(result["details"]["moves"], [1, 2, 3, 4], "the list ForgetMove's menu draws")
 	assert_eq(mon.moves, [1, 2, 3, 4])
+	assert_eq(_world.state.item_quantity(HM_ITEM), 1)
+
+
+## LearnMove.learn writes the same way on both branches, so a forgotten slot
+## takes the new move at full PP just as an empty one does.
+func test_teaching_with_a_forget_slot_replaces_that_move_at_full_pp() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.moves = [1, 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	_world.state.apply_changes({}, {}, {"items": {TM_ITEM: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, 2, false)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(int(result["slot"]), 2)
+	assert_eq(int(result["forgot"]), 3)
+	assert_eq(int(result["pp"]), 15)
+	var taught: Gen2SaveMon = _save.party[0]
+	assert_eq(taught.moves, [1, 2, TM_MOVE, 4])
+	assert_eq(taught.pp[2], 15)
+	## ConsumeTM still runs: a forgotten move does not change whether the item is
+	## used up, only IsHM does.
+	assert_true(bool(result["consumed"]))
+	assert_eq(_world.state.item_quantity(TM_ITEM), 0)
+
+
+## ForgetMove's .hmmove branch never returns an HM slot, so one arriving here is
+## refused outright rather than honoured.
+func test_teaching_refuses_to_forget_an_hm_move_without_writing() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	# Slot 1 is SURF, HM03.
+	mon.moves = [1, 0x39, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	_world.state.apply_changes({}, {}, {"items": {TM_ITEM: 1}})
+	var before: Dictionary = _save.to_dict()
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, 1, false)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"cannot_forget_hm")
+	assert_eq(int(result["details"]["forgot"]), 0x39)
+	assert_eq(_save.to_dict(), before)
+	assert_eq(_world.state.item_quantity(TM_ITEM), 1)
+
+
+func test_teaching_refuses_an_out_of_range_forget_slot_without_writing() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.moves = [1, 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	_world.state.apply_changes({}, {}, {"items": {TM_ITEM: 1}})
+	var before: Dictionary = _save.to_dict()
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, 4, false)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"invalid_forget_slot")
+	assert_eq(_save.to_dict(), before)
+
+
+## LearnMove.loop reaches ForgetMove only when its own scan finds no zero, so an
+## empty slot wins over a slot the caller named. The save model keeps moves
+## contiguous, so the gap is at the end.
+func test_an_empty_slot_wins_over_a_passed_forget_slot() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.moves = [1, 2, 0, 0]
+	mon.pp = [10, 10, 0, 0]
+	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, 0, false)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(int(result["slot"]), 2, "the first empty slot, not the named one")
+	assert_eq(int(result["forgot"]), 0)
+	assert_eq(_save.party[0].moves, [1, 2, HM_MOVE, 0])
 
 
 func test_teaching_refuses_an_item_that_is_not_a_tm_or_hm_and_an_absent_one() -> void:
 	_teachable_save()
 	_world.state.apply_changes({}, {}, {"items": {HM_ITEM: 1}})
 	assert_eq(
-		Gen2WorldPartyHost.teach_tm_hm(_world, _save, 0x12, 0, false)["reason"],
+		Gen2WorldPartyHost.teach_tm_hm(_world, _save, 0x12, 0, -1, false)["reason"],
 		&"not_a_tm_hm"
 	)
 	# ConvertCurItemIntoCurTMHM is reached only from the pocket, so an item the
 	# bag does not hold fails on the quantity first.
 	assert_eq(
-		Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, false)["reason"],
+		Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, -1, false)["reason"],
 		&"insufficient_item_quantity"
 	)
 

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -2837,7 +2837,7 @@ func _catch_strength_mon(
 func _teach_hm(world: Gen2WorldAPI, save: Gen2SaveData, item: int) -> Dictionary:
 	var reason: String = "no party member"
 	for index: int in save.party.size():
-		var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(world, save, item, index, false)
+		var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(world, save, item, index, -1, false)
 		if bool(result.get("ok", false)):
 			return result
 		reason = String(result.get("reason", ""))

--- a/tools/validate_tmhm.gd
+++ b/tools/validate_tmhm.gd
@@ -26,8 +26,8 @@ const EXPECTED_ENTRIES: Dictionary = {
 	&"crystal": 60,
 }
 
-## The four HM moves this project acts on, at their real TMNUMs. HM01 is 51, so
-## these also pin where the TM run ends and the HM run starts.
+## Every HM move at its real TMNUM. HM01 is 51, so these also pin where the TM
+## run ends and the HM run starts.
 const EXPECTED_HM_ROWS: Dictionary = {
 	51: 0x0F,  # HM01 CUT
 	52: 0x13,  # HM02 FLY
@@ -62,8 +62,39 @@ func _initialize() -> void:
 			continue
 		_verify_table(game_id, data)
 		_verify_item_numbers(game_id, data)
+		_verify_forget_move(game_id, data)
 		_census(game_id, data)
 	_finish()
+
+
+## home/hm_moves.asm's IsHMMove against the cartridge's own HM rows.
+##
+## The two lists are separate in the source and could drift: IsHMMove is a
+## hand-written array, TMHMMoves rows 51 to 57 are the items. ForgetMove reads
+## the first, so this checks they name the same seven moves in each real cache,
+## and that each resolves to a move the cache actually has.
+func _verify_forget_move(game_id: StringName, data: GameData) -> void:
+	var from_table: Dictionary = {}
+	for number: int in EXPECTED_HM_ROWS:
+		from_table[data.tmhm_move(number)] = true
+	_check(
+		Gen2MoveForget.HM_MOVES.size() == from_table.size(),
+		"%s: IsHMMove lists %d moves, TMHMMoves has %d HM rows." % [
+			game_id, Gen2MoveForget.HM_MOVES.size(), from_table.size(),
+		]
+	)
+	for move: int in Gen2MoveForget.HM_MOVES:
+		_check(
+			from_table.has(move),
+			"%s: IsHMMove names $%02X, which is not one of the cartridge's HM rows." % [
+				game_id, move,
+			]
+		)
+		_check(
+			not data.move(move).is_empty(),
+			"%s: IsHMMove names $%02X, which the move table does not have." % [game_id, move]
+		)
+	print("%s: IsHMMove's %d moves match the HM rows." % [game_id, Gen2MoveForget.HM_MOVES.size()])
 
 
 func _verify_table(game_id: StringName, data: GameData) -> void:


### PR DESCRIPTION
LearnMove's full-slot branch, shared by the pack's TeachTMHM and a battle level-up, so Gen2MoveForget owns IsHMMove's table and the wording and neither caller holds a copy.

The order is AskForgetMoveText's yes/no, ForgetMove's own list, then LearnMove.cancel's StopLearningMoveText. No at the ask and B in the list both set the carry LearnMove.cancel tests, and its own no is `jp .loop` back to the ask. An HM row prints MoveCantForgetHMText and redisplays the list, since .hmmove is `jr .loop` rather than a cancel; the list is seven moves, not the four field moves the overworld acts on, so Fly, Flash and Waterfall are protected too.

teach_tm_hm() takes the chosen slot and is called twice: once with none, which runs CanLearnTMHMMove and KnowsMove and answers moveset_full having written nothing, and again with the answer. An empty slot still wins over a passed one, because LearnMove.loop only reaches ForgetMove when its own scan finds no zero.

Gen2Battle.learn_move() now refuses an HM or out-of-range slot and leaves the offer pending instead of swallowing it, and clears a Disable naming the slot that went, which is LearnMove's own wDisabledMove check. The battle screen asks rather than declining automatically, and an unanswered offer stops take_turn and switch_player the way an unanswered replacement does.

Also alias "…" to $75 when encoding. Like $54 it sits below FIRST_PRINTABLE and so was decode-only, which drew Text_MoveForgetCount's own wording as a question mark in the battle text box.

validate_tmhm.gd now checks IsHMMove's seven moves against the cartridge's own HM rows in all three games.