### PR TITLE
Walk east past Mahogany to Blackthorn City

### DIFF
--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1420,7 +1420,7 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 		0x04: # VAR_TIMEOFDAY
 			_script_value = Gen2WorldClock.new(hour, 0, day).time_of_day()
 		0x07: # VAR_BADGES
-			_script_value = state.badge_count(_crystal_commands()) if state != null else 0
+			_script_value = _staged_badge_count()
 		0x0A: # VAR_HOUR
 			_script_value = hour
 		0x0B: # VAR_WEEKDAY
@@ -2150,6 +2150,25 @@ func _engine_flag_active(flag: int) -> bool:
 	if _staged_engine_flags.has(flag):
 		return bool(_staged_engine_flags[flag])
 	return state != null and state.is_engine_flag_active(flag)
+
+
+## _GetVarAction's .CountBadges, over staged flags rather than committed ones.
+##
+## The cartridge has no staging: `setflag` writes wBadges and the `readvar`
+## after it reads what was just written. Mahogany Gym is where that matters:
+## PryceScript sets ENGINE_GLACIERBADGE, reads VAR_BADGES and branches on 7 to
+## RadioTowerRocketsScript, which is what opens Mahogany's east exit. Counting
+## committed flags answered 6 there and took the Goldenrod branch instead.
+func _staged_badge_count() -> int:
+	var crystal: bool = _crystal_commands()
+	var count: int = 0
+	for flag: int in (
+		Gen2WorldState.BADGE_ENGINE_FLAGS if crystal
+		else Gen2WorldState.BADGE_ENGINE_FLAGS_GOLD_SILVER
+	):
+		if _engine_flag_active(flag):
+			count += 1
+	return count
 
 
 func _map_scene_value(map_group: int, map_number: int) -> int:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2080,6 +2080,36 @@ func test_script_requests_supply_the_live_player_facing_to_readvar() -> void:
 	assert_true(world.event_flag_active(22))
 
 
+## Every gym does `setflag` on its badge, then `readvar VAR_BADGES`, then
+## branches on the count in the same script (maps/MahoganyGym.asm's
+## MahoganyGymActivateRockets). The cartridge has no staging, so the read sees
+## the badge just awarded; counting committed flags answered one short and took
+## the wrong branch, which left Mahogany's east exit shut for the whole game.
+func test_readvar_badges_counts_a_badge_set_earlier_in_the_same_script() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:60A0"] = [
+		Gen2WorldScript.SETFLAG, Gen2WorldState.ENGINE_ZEPHYRBADGE, 0,
+		Gen2WorldScript.READVAR, 0x07,
+		Gen2WorldScript.IFEQUAL, 2, 0xB0, 0x60,
+		Gen2WorldScript.END,
+	]
+	scripts["48:60B0"] = [Gen2WorldScript.SETEVENT, 23, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	## One badge already committed, so the staged one has to make it two.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.ENGINE_HIVEBADGE)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6), state)
+	world.current_map.events["coord_events"][0]["script"] = 0x60A0
+
+	var result: Array = world.dispatch_script_events()
+
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"complete")
+	assert_true(world.event_flag_active(23), "the two-badge branch was taken")
+	assert_eq(world.state.badge_count(), 2)
+
+
 func test_facing_interaction_commits_map_and_engine_flags_after_text() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6160"] = [

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -36,6 +36,38 @@ const BADGE_STORM: int = 5
 ## bounds the rolls that find nothing worth throwing at.
 const CATCH_ATTEMPTS: int = 64
 
+## Mahogany Town, whose map scene and merchant flag are what open the east exit
+## onto Route 44 (`data/maps/maps.asm`).
+const MAHOGANY_TOWN_GROUP: int = 2
+const MAHOGANY_TOWN_NUMBER: int = 7
+## constants/event_flags.asm. RadioTowerRocketsScript sets it, which hides the
+## RageCandyBar merchant standing on Mahogany's east edge.
+const EVENT_MAHOGANY_POKEFAN_M_BLOCKS_EAST: int = 1878
+
+## Route 44's Ice Path door and then every warp cell the cave is crossed by, in
+## order (`maps/Route44.asm`, `maps/IcePath*.asm`).
+##
+## The cave is six floor-crossings, not one. Stepping on a warp takes it, so a
+## floor is only crossed between warps its own walk connects, and on Ice Path
+## those regions are disjoint: 1F's Route 44 door reaches the first staircase
+## and nothing else, while the Blackthorn door is reached only from the second
+## staircase, at the far end of the loop through B1F, both B2Fs and B3F.
+##
+## The `stonetable` boulders on B1F are not on this path. Their holes (B1F warps
+## 3 to 6) are shortcuts into B2F Mahogany side, which the walk already reaches
+## through warp 2, so the command-queue gap that stops Blackthorn Gym does not
+## stop the cave.
+const ICE_PATH_DOORS: Array = [
+	{"step": "route_44_to_ice_path_1f", "cell": Vector2i(56, 7)},
+	{"step": "ice_path_1f_to_b1f", "cell": Vector2i(37, 5)},
+	{"step": "ice_path_b1f_to_b2f_mahogany", "cell": Vector2i(17, 3)},
+	{"step": "ice_path_b2f_mahogany_to_b3f", "cell": Vector2i(9, 11)},
+	{"step": "ice_path_b3f_to_b2f_blackthorn", "cell": Vector2i(15, 5)},
+	{"step": "ice_path_b2f_blackthorn_to_b1f", "cell": Vector2i(3, 15)},
+	{"step": "ice_path_b1f_to_1f", "cell": Vector2i(5, 25)},
+	{"step": "ice_path_1f_to_blackthorn", "cell": Vector2i(36, 27)},
+]
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
@@ -753,6 +785,10 @@ func _story_path(data: GameData) -> Dictionary:
 	var glacier: Dictionary = _glacier_badge_path(world, save, random, data, path)
 	if not bool(glacier.get("ok", false)):
 		return glacier
+
+	var blackthorn: Dictionary = _blackthorn_path(world, save, random, data, path)
+	if not bool(blackthorn.get("ok", false)):
+		return blackthorn
 
 	var party_summary: Array = []
 	for mon: Gen2SaveMon in save.party:
@@ -2442,12 +2478,104 @@ func _glacier_badge_path(
 		"badge_count": world.state.badge_count(),
 		"engine_flags": world.state.engine_flags(),
 		"items": _named_items(data, world.state.items()),
+		# The badge is not all Pryce commits. `readvar VAR_BADGES` then
+		# `scall MahoganyGymActivateRockets` reaches RadioTowerRocketsScript at
+		# seven badges, which is what retires Mahogany's RageCandyBar coord
+		# events and hides the merchant blocking the east exit. Reported here
+		# because the next leg cannot start without both.
+		"mahogany_scene": world.state.map_scene(
+			MAHOGANY_TOWN_GROUP, MAHOGANY_TOWN_NUMBER
+		),
+		"east_merchant_hidden": world.state.is_event_flag_active(
+			EVENT_MAHOGANY_POKEFAN_M_BLOCKS_EAST
+		),
 	})
 	if not bool(pryce.get("ok", false)):
 		return {
 			"ok": false, "path": path,
 			"reason": "Pryce failed: %s" % pryce.get("reason", ""),
 		}
+	return {"ok": true}
+
+
+## Mahogany Town east to Blackthorn City, on the same world, state and save.
+##
+## Route 44 carries seven trainers and no scripted gate, so the leg is a walk
+## the trainers interrupt rather than a sequence of errands. Its one warp is the
+## Ice Path door at (56,7) (`maps/Route44.asm`); the east connection to
+## Blackthorn exists in `data/maps/attributes.asm` but the cartridge's own way
+## through is the cave.
+##
+## Ice Path 1F is the only floor on the way: its second warp is Blackthorn's own
+## (`maps/IcePath1F.asm` warp 2 to BLACKTHORN_CITY 7), so the `stonetable`
+## boulder puzzle on B1F is beside the route rather than across it. The floor is
+## COLL_ICE, which is LAND_TILE, so the walk crosses it without the source's
+## sliding; sliding only ever removes choices, so nothing reachable with it is
+## unreachable here.
+##
+## Appends to [param path] and answers only ok or the failure.
+func _blackthorn_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var leaving_gym: Dictionary = _warp_step(world, 2, 7)
+	if not bool(leaving_gym.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Mahogany Gym exit warp failed"}
+	var _town_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+
+	var to_route_44: Dictionary = _walk_connection_resolving(
+		world, "east", 2, 6, save, random, data
+	)
+	var route_44_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "mahogany_to_route_44",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": to_route_44.get("encounters", []),
+		"run": route_44_entry,
+	})
+	if not bool(to_route_44.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Mahogany to Route 44 failed: %s" % to_route_44.get("reason", ""),
+		}
+
+	# The Ice Path door, then the cave itself. Every trainer with a sight line
+	# onto the way there answers first, which is what the resolving walk is for.
+	for door: Dictionary in ICE_PATH_DOORS:
+		var walked: Dictionary = _warp_walk(
+			world, door["cell"], save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": String(door["step"]),
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s failed: %s" % [door["step"], walked.get("reason", "")],
+			}
+
+	path.append({
+		"step": "blackthorn_city_arrival",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"party": _party_species(save),
+		"badge_count": world.state.badge_count(),
+	})
 	return {"ok": true}
 
 


### PR DESCRIPTION
The walked Crystal route now runs Route 44 and the whole of Ice Path, ending in Blackthorn City at 126 steps and 283 event flags.

Beating Pryce is what opens the way. PryceScript sets ENGINE_GLACIERBADGE, reads VAR_BADGES and branches on seven to RadioTowerRocketsScript, which sets EVENT_MAHOGANY_TOWN_POKEFAN_M_BLOCKS_EAST and Mahogany's SCENE_MAHOGANYTOWN_NOOP and so retires the RageCandyBar merchant standing on the east edge. That branch was never taken: readvar VAR_BADGES counted committed engine flags, and the badge it had just set was still staged, so the count came out one short and the Goldenrod branch ran instead. It now counts through the same staging layer checkflag already reads, which is what the cartridge does by having no staging at all. Both values are reported on the Pryce step, since the next leg cannot start without them.

Ice Path is six floor-crossings rather than one. Stepping on a warp takes it, so a floor is only crossed between warps its own walk connects, and 1F's two doors are in disjoint regions: the Route 44 door reaches the first staircase, and the Blackthorn door is reached only from the second, at the far end of the loop through B1F, both B2Fs and B3F. The stonetable boulders on B1F are not on that path, so the command queue gap that stops Blackthorn Gym does not stop the cave.

Route 44's Bird Keeper Vance and Psychic Phil are the two trainers with a sight line onto the walked path, and Blackthorn's arrival callback sets Santos.