### PR TITLE
Import command queue payloads and drop boulders through holes

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Headless tools, all against a real imported cache:
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
+| `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -48,6 +48,7 @@ var _world_scripts: Dictionary = {}
 var _world_standard_scripts: Dictionary = {}
 var _world_text: Dictionary = {}
 var _world_movements: Dictionary = {}
+var _world_command_queues: Dictionary = {}
 var _world_tilesets: Dictionary = {}
 var _world_encounters: Dictionary = {}
 var _world_palettes: Array = []
@@ -259,6 +260,15 @@ func world_movement(bank: int, address: int) -> PackedByteArray:
 	return _payload_bytes(
 		_movements().get(Gen2WorldScript.pointer_key(bank, address), []), _blob("movements")
 	)
+
+
+## The decoded `cmdqueue` a `writecmdqueue` at this pointer writes. Empty when
+## the cartridge has none there, which is every map but two.
+func world_command_queue(bank: int, address: int) -> Dictionary:
+	var value: Variant = _command_queues().get(
+		Gen2WorldScript.pointer_key(bank, address), {}
+	)
+	return (value as Dictionary).duplicate(true) if value is Dictionary else {}
 
 
 ## One decoded tileset's metatile and collision tables, or null if absent.
@@ -849,6 +859,8 @@ func _section_json_path(section: String) -> String:
 			return RomCache.world_text_path(directory)
 		"movements":
 			return RomCache.world_movements_path(directory)
+		"command_queues":
+			return RomCache.world_command_queues_path(directory)
 		"audio":
 			return RomCache.world_audio_path(directory)
 	return ""
@@ -891,6 +903,14 @@ func _movements() -> Dictionary:
 	if _claim_section("movements"):
 		_world_movements = _read_section(RomCache.world_movements_path(directory), false)
 	return _world_movements
+
+
+func _command_queues() -> Dictionary:
+	if _claim_section("command_queues"):
+		_world_command_queues = _read_section(
+			RomCache.world_command_queues_path(directory), false
+		)
+	return _world_command_queues
 
 
 func _tilesets() -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -31,6 +31,7 @@ const WORLD_SCRIPTS: String = "world_scripts.json"
 const WORLD_STANDARD_SCRIPTS: String = "world_standard_scripts.json"
 const WORLD_TEXT: String = "world_text.json"
 const WORLD_MOVEMENTS: String = "world_movements.json"
+const WORLD_COMMAND_QUEUES: String = "world_command_queues.json"
 const WORLD_TILESETS: String = "world_tilesets.json"
 const WORLD_ENCOUNTERS: String = "world_encounters.json"
 const WORLD_PALETTES: String = "world_palettes.json"
@@ -55,7 +56,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 24
+const FORMAT_VERSION: int = 25
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -125,6 +126,12 @@ static func world_text_path(directory: String) -> String:
 
 static func world_movements_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_MOVEMENTS]
+
+
+## The decoded `cmdqueue` payloads a `writecmdqueue` points at, keyed by that
+## pointer. Only Blackthorn Gym 2F and Ice Path B1F ship one, both stone tables.
+static func world_command_queues_path(directory: String) -> String:
+	return "%s/%s" % [directory, WORLD_COMMAND_QUEUES]
 
 
 static func world_tilesets_path(directory: String) -> String:

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -85,6 +85,10 @@ static func import_to_cache(
 		result["movements"],
 	):
 		return {"ok": false, "message": "Could not write overworld movement data."}
+	if not RomCache.write_json(
+		RomCache.world_command_queues_path(directory), result["command_queues"]
+	):
+		return {"ok": false, "message": "Could not write overworld command queue data."}
 
 	var graphics: Dictionary = result["graphics"]
 	for number: int in graphics:
@@ -174,6 +178,12 @@ static func read_world(
 	if not bool(standard_result.get("ok", false)):
 		return standard_result
 
+	var queue_result: Dictionary = _read_command_queues(
+		rom, script_data, text_data, movement_data
+	)
+	if not bool(queue_result.get("ok", false)):
+		return queue_result
+
 	return {
 		"ok": true,
 		"maps": maps,
@@ -181,6 +191,7 @@ static func read_world(
 		"standard_scripts": standard_result["scripts"],
 		"text": text_data,
 		"movements": movement_data,
+		"command_queues": queue_result["queues"],
 		"tilesets": tilesets,
 		"graphics": graphics,
 		"palettes": palettes["groups"],
@@ -189,6 +200,110 @@ static func read_world(
 		"sprite_palettes": sprites["palettes"],
 		"sprite_graphics": sprites["graphics"],
 	}
+
+
+## The `cmdqueue` payloads, as a second pass over the scripts already collected.
+##
+## A `writecmdqueue` operand points at data, not at script, so the recursive
+## walk in _collect_script() cannot follow it the way it follows a call: the
+## bytes there are a queue entry, and behind that a stone table. Both are read
+## here, and each table row's own script is collected like any other.
+##
+## Only Blackthorn Gym 2F and Ice Path B1F write a queue, and both write a
+## CMDQUEUE_STONETABLE, so an entry of any other type is kept for its pointer
+## and left undecoded rather than guessed at.
+##
+## A pointer that does not resolve is skipped, not fatal. Scripts are collected
+## as fixed slices, so a slice that runs past its own end can decode stray bytes
+## as a `writecmdqueue`; the corpus counts already treat that as expected. What
+## keeps this honest is `tools/validate_command_queues.gd`, which asserts the two
+## real tables against the pinned sources rather than trusting the scan.
+static func _read_command_queues(
+	rom: RomFile, script_data: Dictionary, text_data: Dictionary, movement_data: Dictionary
+) -> Dictionary:
+	var queues: Dictionary = {}
+	for key: Variant in script_data:
+		var parts: PackedStringArray = String(key).split(":")
+		if parts.size() != 2:
+			continue
+		var bytes: PackedByteArray = PackedByteArray(script_data[key])
+		var references: Dictionary = Gen2WorldScript.scan_references(
+			bytes, int(parts[0]), 0, rom.id == &"crystal"
+		)
+		for reference: Dictionary in references.get("command_queues", []):
+			_read_command_queue(
+				rom, int(reference["bank"]), int(reference["address"]),
+				queues, script_data, text_data, movement_data
+			)
+	return {"ok": true, "queues": queues}
+
+
+static func _read_command_queue(
+	rom: RomFile,
+	bank: int,
+	address: int,
+	queues: Dictionary,
+	script_data: Dictionary,
+	text_data: Dictionary,
+	movement_data: Dictionary,
+) -> void:
+	var key: String = Gen2WorldScript.pointer_key(bank, address)
+	if queues.has(key) or not _valid_cpu_address(address):
+		return
+	var offset: int = _far_offset(rom, {"bank": bank, "address": address})
+	if offset < 0 or not rom.in_bounds(offset, Gen2WorldScript.CMDQUEUE_ENTRY_SIZE):
+		return
+	var entry: Dictionary = Gen2WorldScript.decode_command_queue_entry(
+		rom.slice(offset, Gen2WorldScript.CMDQUEUE_ENTRY_SIZE)
+	)
+	if not bool(entry.get("ok", false)):
+		return
+	var record: Dictionary = {
+		"bank": bank,
+		"address": address,
+		"type": int(entry["type"]),
+		"data_address": int(entry["address"]),
+	}
+	if int(entry["type"]) == Gen2WorldScript.CMDQUEUE_STONETABLE:
+		var rows: Array = _read_stone_table(
+			rom, bank, int(entry["address"]), script_data, text_data, movement_data
+		)
+		if rows.is_empty():
+			return
+		record["rows"] = rows
+	queues[key] = record
+
+
+## The `stonetable` behind a CMDQUEUE_STONETABLE entry, or an empty Array when
+## the bytes there are not one.
+static func _read_stone_table(
+	rom: RomFile,
+	bank: int,
+	address: int,
+	script_data: Dictionary,
+	text_data: Dictionary,
+	movement_data: Dictionary,
+) -> Array:
+	if not _valid_cpu_address(address):
+		return []
+	var offset: int = _far_offset(rom, {"bank": bank, "address": address})
+	if offset < 0 or not rom.in_bounds(offset, 1):
+		return []
+	var span: int = Gen2WorldScript.STONETABLE_ROW_SIZE * Gen2WorldScript.MAX_STONETABLE_ROWS + 1
+	var decoded: Dictionary = Gen2WorldScript.decode_stone_table(
+		rom.slice(offset, mini(span, rom.size() - offset))
+	)
+	if not bool(decoded.get("ok", false)):
+		return []
+	var rows: Array = decoded["rows"]
+	for row: Dictionary in rows:
+		if not _valid_cpu_address(int(row["script"])):
+			return []
+	for row: Dictionary in rows:
+		_collect_script(
+			rom, bank, int(row["script"]), script_data, text_data, movement_data
+		)
+	return rows
 
 
 ## JUMPSTD and CALLSTD address a profile-specific far-pointer table. These

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1297,10 +1297,65 @@ func apply_command_queue_write(bank: int, address: int) -> Dictionary:
 	var key: String = "%d:%04X" % [bank, address]
 	var queue_id: int = _next_command_queue_id
 	_next_command_queue_id += 1
-	_command_queues[key] = {
-		"id": queue_id, "bank": bank, "address": address,
-	}
+	var queue: Dictionary = {"id": queue_id, "bank": bank, "address": address}
+	# The imported payload, so a written queue carries what it does and not only
+	# where it came from. A queue the cartridge has no entry for stays pointer
+	# only, which is what every type but CMDQUEUE_STONETABLE is.
+	if data != null:
+		var record: Dictionary = data.world_command_queue(bank, address)
+		if not record.is_empty():
+			queue["type"] = int(record.get("type", 0))
+			queue["rows"] = record.get("rows", [])
+	_command_queues[key] = queue
 	return {"ok": true, "kind": &"command_queue_written", "queue": _command_queues[key]}
+
+
+## The one-based warp index `HandleStoneQueue.check_on_warp` counts, or 0 when
+## the cell carries no warp event. One-based because the source's
+## `.found_warp` answers `count - remaining + 1`.
+func warp_index_at(cell: Vector2i) -> int:
+	if current_map == null:
+		return 0
+	var warps: Array = current_map.events.get("warps", [])
+	for index: int in warps.size():
+		var event: Dictionary = warps[index]
+		if int(event.get("x", -1)) == cell.x and int(event.get("y", -1)) == cell.y:
+			return index + 1
+	return 0
+
+
+## engine/overworld/cmd_queue.asm's CmdQueue_StoneTable and home/stone_queue.asm's
+## HandleStoneQueue, as one question: which script does this boulder's cell fire?
+##
+## The source's own order, all five tests. The object must be a Strength boulder,
+## standing on a pit tile (`CheckPitTile`, COLL_PIT or COLL_PIT_68), not mid-step,
+## on a warp event, and named by a written CMDQUEUE_STONETABLE row for that
+## warp. Answers an empty Dictionary when any of them refuses.
+##
+## The row's object id is an `object_const_def` constant, which starts at 2, so
+## it is compared against the object's own index plus two. That is the same
+## mapping `applymovement` uses, and the source makes it by comparing against
+## OBJECT_MAP_OBJECT_INDEX + 1 over a table whose index zero is the player.
+func stone_queue_script(boulder: Gen2WorldObject) -> Dictionary:
+	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
+		return {}
+	if not Gen2WorldCollision.is_pit_tile(collision_code_at(boulder.cell)):
+		return {}
+	var warp: int = warp_index_at(boulder.cell)
+	if warp <= 0:
+		return {}
+	var object_id: int = boulder.index + 2
+	for key: Variant in _command_queues:
+		var queue: Dictionary = _command_queues[key]
+		if int(queue.get("type", 0)) != Gen2WorldScript.CMDQUEUE_STONETABLE:
+			continue
+		for row: Dictionary in queue.get("rows", []):
+			if int(row.get("warp", -1)) != warp or int(row.get("object", -1)) != object_id:
+				continue
+			# The row scripts were collected under the queue's own bank, which is
+			# the map script bank the writecmdqueue ran in.
+			return {"bank": int(queue.get("bank", 0)), "script": int(row.get("script", 0))}
+	return {}
 
 
 func apply_command_queue_delete(queue_id: int) -> Dictionary:
@@ -2880,20 +2935,37 @@ func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary
 	if not can_object_walk_to(landing, boulder, direction):
 		return {}
 	boulder.cell = landing
+	# The stone queue is asked here, on the call that commits the cell, for the
+	# same reason the push itself is resolved here: the source waits for the
+	# boulder to reach STANDING, and nothing between those frames asks the
+	# boulder anything or moves it again.
+	var fall: Dictionary = stone_queue_script(boulder)
 	# FIXED_FACING is set on the boulder's movement data, so InitStep skips the
 	# OBJECT_DIRECTION write and the sprite keeps facing down while it slides.
 	boulder.start_step(direction, STEP_FRAMES_BOULDER_PUSH)
 	_remember_object_position(boulder)
+	var pushed: Dictionary = {
+		"index": boulder.index,
+		"from_cell": landing - direction,
+		"to_cell": landing,
+		"direction": direction,
+	}
+	if not fall.is_empty():
+		pushed["fall_script"] = int(fall["script"])
+		_enqueue_script({
+			"kind": &"stone_table",
+			"map_group": current_map.group,
+			"map_number": current_map.number,
+			"cell": landing,
+			"bank": int(fall["bank"]),
+			"script": int(fall["script"]),
+			"object_index": boulder.index,
+		})
 	return {
 		"ok": false,
 		"kind": &"move",
 		"reason": &"blocked",
-		"boulder_pushed": {
-			"index": boulder.index,
-			"from_cell": landing - direction,
-			"to_cell": landing,
-			"direction": direction,
-		},
+		"boulder_pushed": pushed,
 	}
 
 

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -125,6 +125,20 @@ const MAX_CALL_DEPTH: int = 8
 const MAX_SCRIPT_BYTES: int = 512
 const MAX_TEXT_BYTES: int = 1024
 
+## constants/script_constants.asm's cmdqueue block. An entry is
+## `dbw type, address` plus two filler bytes; four fit in wCmdQueue.
+const CMDQUEUE_ENTRY_SIZE: int = 5
+const CMDQUEUE_CAPACITY: int = 4
+const CMDQUEUE_NULL: int = 0
+const CMDQUEUE_STONETABLE: int = 2
+
+## macros/scripts/maps.asm's `stonetable warp_id, object_id, script`, which is
+## `db warp_id, object_id` then `dw script`, ending at a $ff warp id. Only two
+## maps ship one, so the bound is generous rather than tight.
+const STONETABLE_ROW_SIZE: int = 4
+const STONETABLE_TERMINATOR: int = 0xFF
+const MAX_STONETABLE_ROWS: int = 16
+
 
 static func pointer_key(bank: int, address: int) -> String:
 	return "%d:%04X" % [bank, address]
@@ -840,6 +854,7 @@ static func scan_references(
 	var scripts: Array = []
 	var texts: Array = []
 	var movements: Array = []
+	var command_queues: Array = []
 	var at: int = 0
 	var command_count: int = 0
 	while at < data.size() and command_count < MAX_COMMANDS:
@@ -881,15 +896,61 @@ static func scan_references(
 				## phonecall passes a caller-name text pointer to PhoneCall. It is
 				## not a script pointer and must be collected as text data.
 				texts.append({"bank": bank, "address": int(command["address"])})
+			0x7C:
+				## writecmdqueue points at a cmdqueue entry, which is data rather
+				## than script, so it is collected as its own kind.
+				command_queues.append({"bank": bank, "address": int(command["address"])})
 		at += int(command["width"])
 		command_count += 1
 		if is_terminal(opcode, crystal_commands):
 			break
-	return {"scripts": scripts, "texts": texts, "movements": movements}
+	return {
+		"scripts": scripts, "texts": texts, "movements": movements,
+		"command_queues": command_queues,
+	}
 
 
 ## Decodes the bounded text-command slice collected by the importer. Map text
 ## begins with text_start and ends with the source done command $57. The generic
+## Decodes one `cmdqueue` entry: `dbw type, address` and two filler bytes
+## (macros/scripts/maps.asm). Answers the type and the data pointer only; what
+## the pointer means is the type's business.
+static func decode_command_queue_entry(data: PackedByteArray) -> Dictionary:
+	if data.size() < CMDQUEUE_ENTRY_SIZE:
+		return {"ok": false, "reason": &"short_command_queue_entry"}
+	var type: int = data[0]
+	if type == CMDQUEUE_NULL:
+		return {"ok": false, "reason": &"null_command_queue"}
+	return {
+		"ok": true,
+		"type": type,
+		"address": data[1] | (data[2] << 8),
+	}
+
+
+## Decodes a `stonetable`, the only cmdqueue payload either game ships.
+##
+## Rows are `warp_id, object_id, script` until a $ff warp id, and the ids are
+## the source's own: the warp is one-based, as `.check_on_warp` counts it, and
+## the object is an `object_const_def` constant, which starts at 2, so it is two
+## more than the map's own object index.
+static func decode_stone_table(data: PackedByteArray) -> Dictionary:
+	var rows: Array = []
+	var at: int = 0
+	while at < data.size() and rows.size() <= MAX_STONETABLE_ROWS:
+		if data[at] == STONETABLE_TERMINATOR:
+			return {"ok": true, "rows": rows, "bytes": at + 1}
+		if at + STONETABLE_ROW_SIZE > data.size():
+			break
+		rows.append({
+			"warp": data[at],
+			"object": data[at + 1],
+			"script": data[at + 2] | (data[at + 3] << 8),
+		})
+		at += STONETABLE_ROW_SIZE
+	return {"ok": false, "reason": &"unterminated_stone_table", "rows": rows}
+
+
 ## Gen2Text codec uses $50 for fixed names, but in world text $50 is a page
 ## control and must remain in the decoded stream. Unknown bytes remain visible
 ## as bracketed markers instead of being discarded.

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -896,6 +896,102 @@ func test_strength_push_refuses_a_boulder_standing_on_a_pit() -> void:
 	assert_eq(_boulder_at(world, Vector2i(6, 6)).cell, Vector2i(6, 6))
 
 
+## The fixture's warp at (6,6) is on COLL_PIT, which is exactly what a stone
+## table needs: HandleStoneQueue wants a boulder standing on a pit that is also
+## a warp event. Writes the queue the way a MAPCALLBACK_CMDQUEUE would, then
+## pushes a boulder onto it from the north.
+func _stone_table_world(rows: Array, boulder_at: Vector2i = Vector2i(6, 5)) -> Gen2WorldAPI:
+	RomCache.write_json(RomCache.world_command_queues_path(_directory), {
+		"48:6200": {
+			"bank": 48, "address": 0x6200,
+			"type": Gen2WorldScript.CMDQUEUE_STONETABLE,
+			"data_address": 0x6205, "rows": rows,
+		},
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6210": [Gen2WorldScript.SETEVENT, 24, 0, Gen2WorldScript.END],
+	})
+	var world: Gen2WorldAPI = _boulder_world(boulder_at + Vector2i.UP, boulder_at)
+	world.apply_command_queue_write(48, 0x6200)
+	return world
+
+
+## The warp at (6,6) is the map's first, so HandleStoneQueue's one-based count
+## makes it warp 1. The boulder appended by _boulder_world() is the second
+## object, so its object_const_def id is 3.
+const STONE_WARP: int = 1
+const STONE_OBJECT: int = 3
+const STONE_SCRIPT: int = 0x6210
+
+
+## CmdQueue_StoneTable then HandleStoneQueue, all five tests passing at once: a
+## Strength boulder, standing, on a pit, on a warp, named by a written row.
+func test_a_boulder_pushed_onto_a_stone_table_warp_queues_its_fall_script() -> void:
+	var world: Gen2WorldAPI = _stone_table_world([
+		{"warp": STONE_WARP, "object": STONE_OBJECT, "script": STONE_SCRIPT},
+	])
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+
+	assert_true(result.has("boulder_pushed"), JSON.stringify(result))
+	assert_eq(result["boulder_pushed"]["to_cell"], Vector2i(6, 6))
+	assert_eq(int(result["boulder_pushed"]["fall_script"]), STONE_SCRIPT)
+	## The row's script is queued, not run behind the caller's back.
+	var pumped: Array = world.run_event_queue(false)
+	assert_eq(pumped.size(), 1)
+	assert_eq(pumped[0]["status"], &"complete")
+	assert_true(world.event_flag_active(24))
+
+
+## The warp id is matched, not merely the fact of a warp: a row naming a
+## different one leaves the push an ordinary push.
+func test_a_stone_table_row_for_another_warp_does_not_fire() -> void:
+	var world: Gen2WorldAPI = _stone_table_world([
+		{"warp": STONE_WARP + 1, "object": STONE_OBJECT, "script": STONE_SCRIPT},
+	])
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_true(result.has("boulder_pushed"))
+	assert_false(result["boulder_pushed"].has("fall_script"), JSON.stringify(result))
+
+
+## And so is the object id, which is an object_const_def constant and so two
+## more than the map's own index.
+func test_a_stone_table_row_for_another_boulder_does_not_fire() -> void:
+	var world: Gen2WorldAPI = _stone_table_world([
+		{"warp": STONE_WARP, "object": STONE_OBJECT + 1, "script": STONE_SCRIPT},
+	])
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_true(result.has("boulder_pushed"))
+	assert_false(result["boulder_pushed"].has("fall_script"), JSON.stringify(result))
+
+
+## A boulder pushed onto ordinary floor is not on a warp at all, so the queue
+## never answers however many rows it holds.
+func test_a_boulder_pushed_onto_open_floor_fires_no_stone_table() -> void:
+	var world: Gen2WorldAPI = _stone_table_world([
+		{"warp": STONE_WARP, "object": STONE_OBJECT, "script": STONE_SCRIPT},
+	], BOULDER_CELL)
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_true(result.has("boulder_pushed"))
+	assert_false(result["boulder_pushed"].has("fall_script"), JSON.stringify(result))
+
+
+## HandleStoneQueue reads the queue that was written, so a map whose callback
+## never ran has none and nothing falls.
+func test_no_stone_table_fires_without_a_written_queue() -> void:
+	var world: Gen2WorldAPI = _boulder_world(Vector2i(6, 4), Vector2i(6, 5))
+	assert_true(world.command_queues().is_empty())
+	var result: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_true(result.has("boulder_pushed"))
+	assert_false(result["boulder_pushed"].has("fall_script"))
+
+
+## The one-based index .check_on_warp counts, and zero for a cell with no warp.
+func test_warp_index_is_one_based_and_zero_off_a_warp() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(7, 6))
+	assert_eq(world.warp_index_at(Vector2i(6, 6)), 1)
+	assert_eq(world.warp_index_at(Vector2i(7, 6)), 0)
+
+
 ## A boulder already sliding is not STANDING, which is .CheckStrengthBoulder's
 ## second test, so a second press does not chain it another cell.
 func test_strength_push_refuses_a_boulder_already_mid_push() -> void:

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -299,3 +299,62 @@ func test_command_parser_reads_scripted_overworld_feature_operands() -> void:
 	assert_true(delete_queue["ok"])
 	assert_eq(delete_queue["name"], &"delcmdqueue")
 	assert_eq(delete_queue["value"], 2)
+
+
+## macros/scripts/maps.asm's `cmdqueue`: a type byte, a two-byte data pointer,
+## then two filler bytes. A null type is the empty slot the cartridge leaves
+## behind, not a queue.
+func test_command_queue_entry_decodes_type_and_pointer() -> void:
+	var entry: Dictionary = Gen2WorldScript.decode_command_queue_entry(
+		PackedByteArray([Gen2WorldScript.CMDQUEUE_STONETABLE, 0x30, 0x57, 0, 0])
+	)
+	assert_true(entry["ok"])
+	assert_eq(entry["type"], Gen2WorldScript.CMDQUEUE_STONETABLE)
+	assert_eq(entry["address"], 0x5730)
+
+	assert_false(Gen2WorldScript.decode_command_queue_entry(
+		PackedByteArray([Gen2WorldScript.CMDQUEUE_NULL, 0x30, 0x57, 0, 0])
+	)["ok"])
+	assert_false(Gen2WorldScript.decode_command_queue_entry(
+		PackedByteArray([2, 0x30])
+	)["ok"])
+
+
+## `stonetable warp_id, object_id, script` is four bytes a row, ending at a $ff
+## warp id. Blackthorn Gym 2F's own three rows, verbatim.
+func test_stone_table_decodes_rows_until_the_terminator() -> void:
+	var table: Dictionary = Gen2WorldScript.decode_stone_table(PackedByteArray([
+		5, 4, 0x3D, 0x57,
+		3, 5, 0x42, 0x57,
+		4, 6, 0x47, 0x57,
+		0xFF,
+	]))
+	assert_true(table["ok"])
+	assert_eq(table["bytes"], 13)
+	var rows: Array = table["rows"]
+	assert_eq(rows.size(), 3)
+	assert_eq(rows[0], {"warp": 5, "object": 4, "script": 0x573D})
+	assert_eq(rows[1], {"warp": 3, "object": 5, "script": 0x5742})
+	assert_eq(rows[2], {"warp": 4, "object": 6, "script": 0x5747})
+
+
+## Without a terminator the bytes are not a table, so the importer skips them
+## rather than keeping however many rows happened to parse.
+func test_stone_table_refuses_an_unterminated_run() -> void:
+	assert_false(Gen2WorldScript.decode_stone_table(
+		PackedByteArray([5, 4, 0x3D, 0x57, 3, 5])
+	)["ok"])
+	assert_true(Gen2WorldScript.decode_stone_table(PackedByteArray([0xFF]))["ok"])
+
+
+## writecmdqueue points at data rather than script, so the reference scan has to
+## report it separately or the recursive walk would try to run the queue.
+func test_reference_scan_reports_command_queue_pointers() -> void:
+	## Crystal opcode $7d, the profile-normalised writecmdqueue.
+	var references: Dictionary = Gen2WorldScript.scan_references(
+		PackedByteArray([0x7D, 0x2B, 0x57, 0x91]), 48, 0x6000, true
+	)
+	var queues: Array = references["command_queues"]
+	assert_eq(queues.size(), 1)
+	assert_eq(queues[0], {"bank": 48, "address": 0x572B})
+	assert_true(references["scripts"].is_empty())

--- a/tools/validate_command_queues.gd
+++ b/tools/validate_command_queues.gd
@@ -1,0 +1,232 @@
+extends SceneTree
+
+## Verifies the imported `cmdqueue` payloads against freshly imported real
+## caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## macros/scripts/maps.asm's `cmdqueue` and `stonetable`, engine/overworld/
+## cmd_queue.asm's CmdQueue_StoneTable, home/stone_queue.asm's HandleStoneQueue,
+## and the two maps that write one, maps/BlackthornGym2F.asm and
+## maps/IcePathB1F.asm. Both files are byte identical between the pins.
+##
+## The importer skips a queue pointer it cannot resolve, because scripts are
+## collected as fixed slices and a slice running past its own end can decode
+## stray bytes as a `writecmdqueue`. This is what makes that tolerance safe: it
+## asserts the two real tables are present, complete and correct rather than
+## trusting the scan not to have missed one.
+##
+##   Godot --headless --path . -s res://tools/validate_command_queues.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## Blackthorn Gym 2F and Ice Path B1F, the only two maps in either game with a
+## MAPCALLBACK_CMDQUEUE (`data/maps/maps.asm` group/number pairs). The gym sits
+## at the same pair in both games; Crystal's own extra maps push Ice Path B1F
+## eight places down its group.
+const BLACKTHORN_GYM_2F: Array = [5, 2]
+const ICE_PATH_B1F: Dictionary = {
+	&"gold": [3, 54],
+	&"silver": [3, 54],
+	&"crystal": [3, 62],
+}
+
+## The `stonetable` rows verbatim, warp id then object id. Object ids are
+## `object_const_def` constants, which start at 2: Blackthorn Gym 2F lists two
+## trainers before its boulders, so its first boulder is 4, while Ice Path B1F
+## lists boulders first, so its first is 2.
+const EXPECTED_ROWS: Dictionary = {
+	"blackthorn": [[5, 4], [3, 5], [4, 6]],
+	"ice_path": [[3, 2], [4, 3], [5, 4], [6, 5]],
+}
+
+## The pit warps each row names, as the cell the boulder has to reach. Read off
+## the two maps' own `def_warp_events`, one-based like the source counts them.
+const EXPECTED_WARP_CELLS: Dictionary = {
+	"blackthorn": {3: Vector2i(2, 5), 4: Vector2i(8, 7), 5: Vector2i(8, 3)},
+	"ice_path": {
+		3: Vector2i(11, 2), 4: Vector2i(4, 7), 5: Vector2i(5, 12), 6: Vector2i(12, 13),
+	},
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_map(data, game_id, "blackthorn", BLACKTHORN_GYM_2F)
+		_verify_map(data, game_id, "ice_path", ICE_PATH_B1F[game_id])
+		_drive_blackthorn(data, game_id)
+	_finish()
+
+
+func _verify_map(data: GameData, game_id: StringName, name: String, id: Array) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, id[0], id[1], Vector2i.ZERO)
+	if world == null:
+		_fail("%s: map %d/%d is missing." % [game_id, id[0], id[1]])
+		return
+
+	# The queue is written by a MAPCALLBACK_CMDQUEUE, so running the map's own
+	# callbacks is what puts it on the world. Nothing else writes one.
+	var _entry: Array = world.dispatch_map_entry()
+	for _step: int in 8:
+		if world.pending_script_input().is_empty():
+			break
+		world.run_event_queue(true)
+
+	var queues: Array = world.command_queues()
+	var tables: Array = []
+	for queue: Dictionary in queues:
+		if int(queue.get("type", 0)) == Gen2WorldScript.CMDQUEUE_STONETABLE:
+			tables.append(queue)
+	if not _check(
+		tables.size() == 1,
+		"%s %s: %d stone tables written, not 1." % [game_id, name, tables.size()]
+	):
+		return
+
+	var rows: Array = (tables[0] as Dictionary).get("rows", [])
+	var expected: Array = EXPECTED_ROWS[name]
+	if not _check(
+		rows.size() == expected.size(),
+		"%s %s: %d stonetable rows, not the pinned %d." % [
+			game_id, name, rows.size(), expected.size(),
+		]
+	):
+		return
+	for index: int in expected.size():
+		var row: Dictionary = rows[index]
+		var want: Array = expected[index]
+		_check(
+			int(row["warp"]) == int(want[0]) and int(row["object"]) == int(want[1]),
+			"%s %s row %d is warp %d object %d, not the pinned warp %d object %d." % [
+				game_id, name, index,
+				int(row["warp"]), int(row["object"]), int(want[0]), int(want[1]),
+			]
+		)
+		_check(
+			int(row["script"]) >= RomFile.BANK_SIZE,
+			"%s %s row %d has script $%04X, which is not a banked address." % [
+				game_id, name, index, int(row["script"]),
+			]
+		)
+
+	# Every named warp has to be a real warp event on a pit tile, or the boulder
+	# could never satisfy HandleStoneQueue.
+	var cells: Dictionary = EXPECTED_WARP_CELLS[name]
+	for warp: int in cells:
+		var cell: Vector2i = cells[warp]
+		_check(
+			world.warp_index_at(cell) == warp,
+			"%s %s: warp %d is not at %s." % [game_id, name, warp, cell]
+		)
+		_check(
+			Gen2WorldCollision.is_pit_tile(world.collision_code_at(cell)),
+			"%s %s: warp %d at %s is collision $%02X, not a pit." % [
+				game_id, name, warp, cell, world.collision_code_at(cell),
+			]
+		)
+
+	# And every row has to name a boulder object the map actually carries.
+	for row: Dictionary in rows:
+		var index: int = int(row["object"]) - 2
+		if not _check(
+			index >= 0 and index < world.objects.size(),
+			"%s %s: object id %d is outside the map's object list." % [
+				game_id, name, int(row["object"]),
+			]
+		):
+			continue
+		var object: Gen2WorldObject = world.objects[index]
+		_check(
+			object.is_strength_boulder(),
+			"%s %s: object id %d is not a Strength boulder." % [game_id, name, int(row["object"])]
+		)
+	print("%s %s: %d stonetable rows over %d pit warps verified." % [
+		game_id, name, rows.size(), cells.size(),
+	])
+
+
+## Blackthorn Gym 2F's first row, driven against the real cache: BOULDER1 stands
+## at (8,2) and warp 5 is the pit directly below it, so one push south is the
+## whole puzzle step. The flag it sets is what BlackthornGym1FBouldersCallback
+## reads to changeblock the floor below.
+func _drive_blackthorn(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, BLACKTHORN_GYM_2F[0], BLACKTHORN_GYM_2F[1], Vector2i(8, 1)
+	)
+	if world == null:
+		_fail("%s: Blackthorn Gym 2F is missing." % game_id)
+		return
+	world.state.set_engine_flag(Gen2WorldState.strength_active_flag(
+		Gen2WorldState.is_crystal_profile(data)
+	))
+	var _entry: Array = world.dispatch_map_entry()
+
+	var boulder: Gen2WorldObject = world.object_at(Vector2i(8, 2))
+	if not _check(
+		boulder != null and boulder.is_strength_boulder(),
+		"%s: no boulder at (8,2) on Blackthorn Gym 2F." % game_id
+	):
+		return
+	var flag: int = boulder.event_flag
+	_check(
+		not world.state.is_event_flag_active(flag),
+		"%s: boulder flag %d is already set before the push." % [game_id, flag]
+	)
+
+	var pushed: Dictionary = world.move_result(Vector2i.DOWN)
+	if not _check(
+		pushed.has("boulder_pushed"),
+		"%s: the boulder at (8,2) did not move: %s" % [game_id, pushed.get("reason", "")]
+	):
+		return
+	if not _check(
+		pushed["boulder_pushed"].has("fall_script"),
+		"%s: the boulder reached the pit warp without firing its stone table." % game_id
+	):
+		return
+
+	var results: Array = world.run_event_queue(false)
+	for _step: int in 16:
+		if world.pending_script_input().is_empty():
+			break
+		results = world.run_event_queue(true)
+	var status: StringName = StringName(
+		(results[results.size() - 1] as Dictionary).get("status", &"")
+	) if not results.is_empty() else &""
+	_check(
+		status == &"complete",
+		"%s: the fall script ended as %s, not complete." % [game_id, status]
+	)
+	_check(
+		world.state.is_event_flag_active(flag),
+		"%s: the fall script did not set boulder flag %d." % [game_id, flag]
+	)
+	print("%s blackthorn: the real push fired its stone table and set flag %d." % [
+		game_id, flag,
+	])
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS command queues: both stone tables and their pit warps verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL command queues: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_command_queues.gd.uid
+++ b/tools/validate_command_queues.gd.uid
@@ -1,0 +1,1 @@
+uid://fnq5q6g2b1me


### PR DESCRIPTION
The importer follows a writecmdqueue to its cmdqueue entry and, for the only type either game ships, on to its stonetable. Both are decoded into world_command_queues.json, and the rows' own scripts are collected like any other, so cache format goes to 25.

A writecmdqueue points at data rather than script, so the recursive script walk cannot follow it the way it follows a call; the payloads are read in a second pass over the scripts already collected. That pass skips a pointer it cannot resolve, because scripts are collected as fixed slices and a slice running past its own end can decode stray bytes as a writecmdqueue. What keeps it honest is validate_command_queues.gd, which asserts both real tables rather than trusting the scan: exactly one CMDQUEUE_STONETABLE per map on Blackthorn Gym 2F and Ice Path B1F, their three and four rows verbatim, every named warp a warp event on a pit tile, and every named object a Strength boulder.

stone_queue_script() is CmdQueue_StoneTable plus HandleStoneQueue as one question, with all five of the source's tests: a Strength boulder, standing, on a pit, on a warp, named by a written row for that warp. Row object ids are object_const_def constants and so two more than the map's own index, which is the same mapping applymovement already uses; warp ids are one-based, as .check_on_warp counts them. A push that lands on a match queues the row's script rather than running it behind the caller.

Against each real cache the validator drives the puzzle end to end: Blackthorn Gym 2F's boulder at (8,2) pushed south onto warp 5's pit fires its imported fall script, which disappears the boulder and sets EVENT_BOULDER_IN_BLACKTHORN_GYM_1, the flag BlackthornGym1FBouldersCallback reads.