### PR TITLE
Clear the Goldenrod Radio Tower on the story route

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Headless tools, all against a real imported cache:
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
+| `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1513,11 +1513,18 @@ func dispatch_events(cell: Vector2i = player_cell, execute_scripts: bool = false
 	return events
 
 
-## Queues the active scripted records at a cell in cartridge source order and
-## advances until the queue reaches text/button input or is empty.
+## The step path, `CheckTileEvent` (engine/overworld/events.asm): coordinate
+## events only. Background events and object scripts need `CheckAPressOW`, so
+## they belong to interact(); a walk onto a cell carrying one runs nothing.
+## dispatch_events(cell, true) is the explicit-execution call that still reaches
+## every record.
 func dispatch_script_events(cell: Vector2i = player_cell) -> Array:
 	if _active_script == null and _script_queue.is_empty():
-		_enqueue_script_events(_active_events_at(cell))
+		var stepped: Array = []
+		for event: Dictionary in _active_events_at(cell):
+			if event.get("kind", &"") == &"coord_events":
+				stepped.append(event)
+		_enqueue_script_events(stepped)
 	return run_event_queue(false)
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -669,7 +669,7 @@ func preview_script_event() -> void:
 	for source: String in ["coord_events", "bg_events", "objects"]:
 		for event: Dictionary in _world.current_map.events.get(source, []):
 			var cell := Vector2i(int(event.get("x", -1)), int(event.get("y", -1)))
-			var results: Array = _world.dispatch_script_events(cell)
+			var results: Array = _world.dispatch_events(cell, true)
 			if not results.is_empty():
 				_show_script_results(results)
 				return

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -678,7 +678,10 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.SETVAL:
 			_script_value = int(command["value"])
 		Gen2WorldScript.ADDVAL:
-			_script_value += int(command["value"])
+			## Script_addval adds into wScriptVar, one byte, so it wraps there
+			## and not only where the value is later written. Goldenrod's switch
+			## room turns a switch off with `addval -1` and branches on it.
+			_script_value = (_script_value + int(command["value"])) & 0xFF
 		Gen2WorldScript.READMEM:
 			_script_value = _script_memory_value(int(command["address"]))
 		Gen2WorldScript.WRITEMEM:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1288,6 +1288,58 @@ func test_script_memory_commands_read_write_and_commit_a_byte() -> void:
 	assert_eq(state.script_memory(address), 9, "the ifequal branch ran and committed")
 
 
+## Script_addval adds into wScriptVar, one byte, so it wraps in the variable
+## itself. The Goldenrod switch room turns a switch off with `addval -1` on
+## wUndergroundSwitchPositions and then branches on the result
+## (maps/GoldenrodUndergroundSwitchRoomEntrances.asm).
+func test_addval_wraps_in_the_script_variable_like_the_source_byte_add() -> void:
+	var address: int = 0xD1D7
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# setval 1, addval -1, writemem, then branch on zero.
+	scripts["48:6C20"] = [
+		Gen2WorldScript.SETVAL, 1,
+		Gen2WorldScript.ADDVAL, 0xFF,
+		Gen2WorldScript.WRITEMEM, address & 0xFF, address >> 8,
+		Gen2WorldScript.IFEQUAL, 0, 0x30, 0x6C,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6C30"] = [
+		Gen2WorldScript.SETVAL, 42,
+		Gen2WorldScript.WRITEMEM, address & 0xFF, address >> 8,
+		Gen2WorldScript.END,
+	]
+	# The other edge: 0 - 1 is 255, not -1, so the wrapped value is what a
+	# later ifequal and any writemem see.
+	scripts["48:6C40"] = [
+		Gen2WorldScript.SETVAL, 0,
+		Gen2WorldScript.ADDVAL, 0xFF,
+		Gen2WorldScript.WRITEMEM, address & 0xFF, address >> 8,
+		Gen2WorldScript.IFEQUAL, 255, 0x50, 0x6C,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6C50"] = [
+		Gen2WorldScript.SETVAL, 7,
+		Gen2WorldScript.WRITEMEM, address & 0xFF, address >> 8,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+
+	var down := Gen2WorldState.new()
+	var to_zero := Gen2WorldScriptRunner.begin(data, down, {
+		"kind": &"test", "bank": 48, "script": 0x6C20,
+	})
+	assert_eq(to_zero.advance()["status"], &"complete")
+	assert_eq(down.script_memory(address), 42, "1 + -1 branched as 0")
+
+	var under := Gen2WorldState.new()
+	var to_255 := Gen2WorldScriptRunner.begin(data, under, {
+		"kind": &"test", "bank": 48, "script": 0x6C40,
+	})
+	assert_eq(to_255.advance()["status"], &"complete")
+	assert_eq(under.script_memory(address), 7, "0 + -1 branched as 255")
+
+
 ## Burned Tower's rival scene opens the hole under the player and then relies on
 ## warpcheck to drop them through it, so the command has to resolve the warp at
 ## the standing cell rather than one the script names.
@@ -2008,7 +2060,7 @@ func test_follower_carries_the_player_walk_step_offset() -> void:
 
 func test_script_object_visibility_changes_rendering_and_occupancy() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
-	var result: Array = world.dispatch_script_events(Vector2i(5, 6))
+	var result: Array = world.dispatch_events(Vector2i(5, 6), true)
 	assert_eq(result.size(), 1)
 	assert_eq(result[0]["status"], &"complete")
 	assert_eq(result[0]["events"][0]["type"], &"object_visibility")
@@ -2266,9 +2318,32 @@ func test_background_events_honor_source_direction_and_conditional_pointer_recor
 	assert_eq(world.dispatch_events(Vector2i(8, 5)).size(), 0)
 	world.set_event_flag(12)
 	assert_eq(world.dispatch_events(Vector2i(8, 5)).size(), 1)
-	var conditional: Array = world.dispatch_script_events(Vector2i(8, 5))
+	var conditional: Array = world.dispatch_events(Vector2i(8, 5), true)
 	assert_eq(conditional.size(), 1)
 	assert_true(world.event_flag_active(11))
+
+
+## CheckTileEvent (engine/overworld/events.asm) runs warps, coord events, the
+## step count and encounters. TryBGEvent is behind CheckAPressOW, so walking
+## onto a background event's own cell runs nothing; only interact() reaches it.
+func test_a_step_onto_a_background_event_runs_nothing() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6178"] = [Gen2WorldScript.SETEVENT, 13, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
+	world.current_map.events["bg_events"] = [
+		{"x": 8, "y": 6, "type": Gen2WorldAPI.BGEVENT_READ, "script": 0x6178},
+	]
+
+	assert_true(world.dispatch_script_events(Vector2i(8, 6)).is_empty())
+	assert_false(world.event_flag_active(13))
+
+	# The same record still answers an A press and explicit execution.
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	world.player_cell = Vector2i(8, 7)
+	assert_eq(world.interact().size(), 1)
+	assert_true(world.event_flag_active(13))
 
 
 func test_players_house_pc_special_is_a_host_request_and_returns_false_without_decoration_changes() -> void:
@@ -2670,7 +2745,7 @@ func test_restart_map_music_special_uses_the_audio_runtime_request() -> void:
 
 func test_script_warp_is_validated_before_transition() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
-	var result: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var result: Array = world.dispatch_events(Vector2i(8, 6), true)
 	assert_eq(result.size(), 2)
 	assert_eq(result[0]["status"], &"complete")
 	assert_eq(result[1]["source"]["kind"], &"callback")
@@ -2684,7 +2759,7 @@ func test_script_queue_keeps_event_source_order() -> void:
 	coordinate["x"] = 8
 	coordinate["y"] = 6
 	coordinate["script"] = 0x6010
-	var results: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var results: Array = world.dispatch_events(Vector2i(8, 6), true)
 	assert_eq(results.size(), 3)
 	assert_eq(results[0]["source"]["kind"], &"coord_events")
 	assert_eq(results[1]["source"]["kind"], &"bg_events")
@@ -3580,7 +3655,7 @@ func test_disappear_and_appear_update_the_object_event_flag() -> void:
 	scripts["48:6035"] = [0x6F, 2, 0x91]
 	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
 	var world := _world(Vector2i(5, 6))
-	var disappeared: Array = world.dispatch_script_events()
+	var disappeared: Array = world.dispatch_events(world.player_cell, true)
 	assert_eq(disappeared[0]["status"], &"complete")
 	assert_true(world.event_flag_active(7))
 	assert_eq(world.visible_objects().size(), 0)
@@ -3588,7 +3663,7 @@ func test_disappear_and_appear_update_the_object_event_flag() -> void:
 	world.clear_event_flag(7)
 	var map: Gen2WorldMap = world.current_map
 	map.events["bg_events"][0]["script"] = 0x6035
-	var appeared: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var appeared: Array = world.dispatch_events(Vector2i(8, 6), true)
 	assert_eq(appeared[0]["status"], &"complete")
 	assert_false(world.event_flag_active(7))
 	assert_eq(world.visible_objects().size(), 1)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -28,6 +28,9 @@ const WALK_RESOLVE_ATTEMPTS: int = 16
 
 ## constants/item_constants.asm's add_hm list, whose comment column is hex.
 const ITEM_HM_STRENGTH: int = 0xF6
+## The two Radio Tower keys, from the same hex comment column.
+const ITEM_CARD_KEY: int = 0x7F
+const ITEM_BASEMENT_KEY: int = 0x85
 ## ENGINE_STORMBADGE's place in source badge order, for Gen2WorldState.badge_flag().
 const BADGE_STORM: int = 5
 
@@ -43,6 +46,11 @@ const MAHOGANY_TOWN_NUMBER: int = 7
 ## constants/event_flags.asm. RadioTowerRocketsScript sets it, which hides the
 ## RageCandyBar merchant standing on Mahogany's east edge.
 const EVENT_MAHOGANY_POKEFAN_M_BLOCKS_EAST: int = 1878
+## The two flags RadioTower5FRocketBossScript sets that this leg exists for. The
+## second hides BLACKTHORNCITY_SUPER_NERD1, who otherwise stands on the only
+## cell that reaches Blackthorn Gym's door (`maps/BlackthornCity.asm`).
+const EVENT_CLEARED_RADIO_TOWER: int = 33
+const EVENT_BLACKTHORN_SUPER_NERD_BLOCKS_GYM: int = 1763
 
 ## Route 44's Ice Path door and then every warp cell the cave is crossed by, in
 ## order (`maps/Route44.asm`, `maps/IcePath*.asm`).
@@ -55,8 +63,7 @@ const EVENT_MAHOGANY_POKEFAN_M_BLOCKS_EAST: int = 1878
 ##
 ## The `stonetable` boulders on B1F are not on this path. Their holes (B1F warps
 ## 3 to 6) are shortcuts into B2F Mahogany side, which the walk already reaches
-## through warp 2, so the command-queue gap that stops Blackthorn Gym does not
-## stop the cave.
+## through warp 2.
 const ICE_PATH_DOORS: Array = [
 	{"step": "route_44_to_ice_path_1f", "cell": Vector2i(56, 7)},
 	{"step": "ice_path_1f_to_b1f", "cell": Vector2i(37, 5)},
@@ -785,6 +792,10 @@ func _story_path(data: GameData) -> Dictionary:
 	var glacier: Dictionary = _glacier_badge_path(world, save, random, data, path)
 	if not bool(glacier.get("ok", false)):
 		return glacier
+
+	var radio_tower: Dictionary = _radio_tower_path(world, save, random, data, path)
+	if not bool(radio_tower.get("ok", false)):
+		return radio_tower
 
 	var blackthorn: Dictionary = _blackthorn_path(world, save, random, data, path)
 	if not bool(blackthorn.get("ok", false)):
@@ -2498,7 +2509,557 @@ func _glacier_badge_path(
 	return {"ok": true}
 
 
+## Mahogany Town west to Goldenrod City and back, clearing the Radio Tower.
+##
+## This leg is what opens Blackthorn Gym. `maps/BlackthornCity.asm` stands
+## BLACKTHORNCITY_SUPER_NERD1 on (18,12), the only cell that reaches the gym
+## door warp at (18,11), and its event flag is set only by
+## `maps/RadioTower5F.asm`'s boss script. Beating Pryce already ran
+## `RadioTowerRocketsScript` (`engine/events/std_scripts.asm`), so the takeover
+## is armed before the leg starts: the Rockets are visible and the Black Belt
+## who would block 2F's stairs is hidden.
+##
+## The walk back is six connections west, all of them crossed eastward earlier
+## in the route, and the two Route 42 lakes are surfed in reverse. Appends to
+## [param path] and answers only ok or the failure.
+func _radio_tower_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var leaving_gym: Dictionary = _warp_step(world, 2, 7)
+	if not bool(leaving_gym.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Mahogany Gym exit warp failed"}
+	var _town_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+
+	var westward: Dictionary = _goldenrod_crossing(world, save, random, data, path, "west")
+	if not bool(westward.get("ok", false)):
+		return westward
+
+	var basement_key: Dictionary = _radio_tower_basement_key(world, save, random, data, path)
+	if not bool(basement_key.get("ok", false)):
+		return basement_key
+
+	var card_key: Dictionary = _goldenrod_underground_card_key(world, save, random, data, path)
+	if not bool(card_key.get("ok", false)):
+		return card_key
+
+	var boss: Dictionary = _radio_tower_boss(world, save, random, data, path)
+	if not bool(boss.get("ok", false)):
+		return boss
+
+	var eastward: Dictionary = _goldenrod_crossing(world, save, random, data, path, "east")
+	if not bool(eastward.get("ok", false)):
+		return eastward
+
+	return {"ok": true}
+
+
+## The card-key shutter on Radio Tower 3F and the Rocket boss on 5F.
+##
+## `CardKeySlotScript` is a BGEVENT_UP at (14,2), so it is read by facing up
+## from (14,3). It changeblocks the shutter open and sets
+## EVENT_USED_THE_CARD_KEY_IN_THE_RADIO_TOWER, which is what
+## RadioTower3FCardKeyShutterCallback replays on every later load. Only then
+## does 3F's second staircase at (17,0) exist, and it is the only way into the
+## 4F and 5F shafts the boss stands in.
+func _radio_tower_boss(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var climbed: Dictionary = _warp_chain(
+		world, save, random, data,
+		[Vector2i(5, 15), Vector2i(15, 0), Vector2i(0, 0)]
+	)
+	if not bool(climbed.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Radio Tower return climb failed: %s" % climbed.get("reason", ""),
+		}
+
+	var slot: Dictionary = _talk_to(
+		world, Vector2i(14, 3), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "radio_tower_card_key_slot",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": slot.get("run", {}),
+	})
+	if not bool(slot.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "card key slot failed: %s" % slot.get("reason", ""),
+		}
+
+	var to_boss: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(17, 0), Vector2i(12, 0)]
+	)
+	if not bool(to_boss.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Radio Tower shutter shaft failed: %s" % to_boss.get("reason", ""),
+		}
+
+	var boss: Dictionary = _walk_cell_resolving(world, Vector2i(16, 5), save, random, data)
+	path.append({
+		"step": "radio_tower_rocket_boss",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": boss.get("encounters", []),
+		"cleared_radio_tower": world.event_flag_active(EVENT_CLEARED_RADIO_TOWER),
+		"blackthorn_gym_open": world.event_flag_active(
+			EVENT_BLACKTHORN_SUPER_NERD_BLOCKS_GYM
+		),
+	})
+	if not bool(boss.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Rocket boss failed: %s" % boss.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_CLEARED_RADIO_TOWER):
+		return {"ok": false, "path": path, "reason": "the Radio Tower did not clear"}
+	if not world.event_flag_active(EVENT_BLACKTHORN_SUPER_NERD_BLOCKS_GYM):
+		return {"ok": false, "path": path, "reason": "Blackthorn Gym is still sealed"}
+
+	var descended: Dictionary = _warp_chain(
+		world, save, random, data,
+		[Vector2i(12, 0), Vector2i(17, 0), Vector2i(0, 0), Vector2i(15, 0), Vector2i(2, 7)]
+	)
+	if not bool(descended.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Radio Tower return descent failed: %s" % descended.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## Goldenrod City to the warehouse director's CARD_KEY, and back.
+##
+## Three maps, each cut into regions the others join. GoldenrodUnderground's
+## north half is reached from the switch room's south corridor and ends at the
+## basement door (18,6), which `BasementDoorScript` unlocks with the
+## BASEMENT_KEY and which then warps to the underground's south half. That half
+## reaches the switch room's top corridor, where the three switches are.
+##
+## The puzzle is `GoldenrodUndergroundSwitchRoomEntrances_UpdateDoors`: switch 1,
+## 2 and 3 add 1, 2 and 3 to `wUndergroundSwitchPositions` and each position
+## opens some doors and closes others, leaving the ones it does not name alone,
+## so states accumulate. Turning 3, then 2, then 1 walks positions 3, 5 and 6 and
+## ends with doors 3, 5, 6, 8, 9 and 11 open, which is the one chain from the top
+## corridor to the warehouse doors at (22,10) and (23,10).
+##
+## Coming back needs the emergency switch: the warehouse's own
+## MAPCALLBACK_NEWMAP clears every door event, so re-entering the switch room
+## seals the room the warehouse opens into, and `EmergencySwitchScript` at
+## (20,11) is the only switch reachable from inside it.
+func _goldenrod_underground_card_key(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var inbound: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(9, 5), Vector2i(21, 25)]
+	)
+	if not bool(inbound.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Goldenrod Underground entry failed: %s" % inbound.get("reason", ""),
+		}
+
+	var basement_door: Dictionary = _talk_to(
+		world, Vector2i(18, 7), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "goldenrod_underground_basement_door",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": basement_door.get("run", {}),
+	})
+	if not bool(basement_door.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "basement door failed: %s" % basement_door.get("reason", ""),
+		}
+
+	var to_switch_room: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(18, 6), Vector2i(22, 27)]
+	)
+	if not bool(to_switch_room.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "basement door crossing failed: %s" % to_switch_room.get("reason", ""),
+		}
+
+	# Switch 3, then 2, then 1. The rival's coord event at (19,4) and (19,5) sits
+	# on the way to the first of them.
+	for switch: Vector2i in [Vector2i(2, 2), Vector2i(10, 2), Vector2i(16, 2)]:
+		var thrown: Dictionary = _talk_to(
+			world, switch, Gen2WorldSprite.FACING_UP, save, random, data
+		)
+		path.append({
+			"step": "goldenrod_underground_switch",
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"run": thrown.get("run", {}),
+		})
+		if not bool(thrown.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "switch at %s failed: %s" % [switch, thrown.get("reason", "")],
+			}
+
+	var to_warehouse: Dictionary = _warp_chain(world, save, random, data, [Vector2i(22, 10)])
+	if not bool(to_warehouse.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "warehouse door failed: %s" % to_warehouse.get("reason", ""),
+		}
+
+	var director: Dictionary = _talk_to(
+		world, Vector2i(12, 9), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "goldenrod_warehouse_director",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": director.get("run", {}),
+		"items": _named_items(data, world.state.items()),
+	})
+	if not bool(director.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "warehouse director failed: %s" % director.get("reason", ""),
+		}
+	if not world.state.items().has(ITEM_CARD_KEY):
+		return {"ok": false, "path": path, "reason": "the warehouse director left no CARD_KEY"}
+
+	var back_to_switch_room: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(2, 12)]
+	)
+	if not bool(back_to_switch_room.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "warehouse exit failed: %s" % back_to_switch_room.get("reason", ""),
+		}
+
+	var emergency: Dictionary = _talk_to(
+		world, Vector2i(20, 12), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "goldenrod_underground_emergency_switch",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": emergency.get("run", {}),
+	})
+	if not bool(emergency.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "emergency switch failed: %s" % emergency.get("reason", ""),
+		}
+
+	var outbound: Dictionary = _warp_chain(
+		world, save, random, data,
+		[Vector2i(23, 3), Vector2i(21, 31), Vector2i(3, 2), Vector2i(20, 29)]
+	)
+	if not bool(outbound.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Goldenrod Underground exit failed: %s" % outbound.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## Goldenrod City to the fake director on Radio Tower 5F, and back out.
+##
+## The climb is one shaft: 1F (15,0), 2F (0,0), 3F (7,0), 4F (0,0). 2F's stairs
+## are behind the Black Belt on (0,1), whom `RadioTowerRocketsScript` already
+## hid, and 3F's other staircase at (17,0) is behind the card-key shutter, which
+## is the second half of the leg. 4F and 5F are each two shafts that do not
+## join, so the fake director at 5F (0,3) is reachable only from this one.
+func _radio_tower_basement_key(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var climbed: Dictionary = _warp_chain(
+		world, save, random, data,
+		[Vector2i(5, 15), Vector2i(15, 0), Vector2i(0, 0), Vector2i(7, 0), Vector2i(0, 0)]
+	)
+	if not bool(climbed.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Radio Tower climb failed: %s" % climbed.get("reason", ""),
+		}
+
+	# FakeDirectorScript is a coord event, not an interaction: stepping onto
+	# (0,3) runs it (`maps/RadioTower5F.asm`). It battles EXECUTIVEM_3, hands
+	# over the BASEMENT_KEY and arms the boss coord event with
+	# setscene SCENE_RADIOTOWER5F_ROCKET_BOSS.
+	var fake_director: Dictionary = _walk_cell_resolving(
+		world, Vector2i(0, 3), save, random, data
+	)
+	path.append({
+		"step": "radio_tower_fake_director",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": fake_director.get("encounters", []),
+		"items": _named_items(data, world.state.items()),
+	})
+	if not bool(fake_director.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "fake director failed: %s" % fake_director.get("reason", ""),
+		}
+	if not world.state.items().has(ITEM_BASEMENT_KEY):
+		return {"ok": false, "path": path, "reason": "the fake director left no BASEMENT_KEY"}
+
+	var descended: Dictionary = _warp_chain(
+		world, save, random, data,
+		[Vector2i(0, 0), Vector2i(9, 0), Vector2i(0, 0), Vector2i(15, 0), Vector2i(2, 7)]
+	)
+	if not bool(descended.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Radio Tower descent failed: %s" % descended.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## Walks each cell in [param cells] on the map it belongs to and takes the warp
+## there, draining the arrival callbacks between maps.
+func _warp_chain(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	cells: Array,
+) -> Dictionary:
+	for cell: Vector2i in cells:
+		var walked: Dictionary = _warp_walk(world, cell, save, random, data)
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false,
+				"reason": "warp at %s on %s failed: %s" % [
+					cell, _map_value(world), walked.get("reason", ""),
+				],
+			}
+		var _entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+	return {"ok": true}
+
+
+## Mahogany Town and Goldenrod City in either direction, on the same world,
+## state and save. [param heading] is "west" for Mahogany to Goldenrod and
+## "east" for the return.
+##
+## The chain is Mahogany, Route 42, Ecruteak City, Route 37, Route 36, Route 35,
+## Goldenrod (`data/maps/attributes.asm`), with Route 35's south end a gate
+## building rather than a connection (`maps/Route35.asm` warp to
+## ROUTE_35_GOLDENROD_GATE). Route 42's two lakes have no land path around them,
+## so both are surfed, and Route 35's cut tree regrows on every map load, so it
+## is cut on every crossing.
+func _goldenrod_crossing(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+	heading: String,
+) -> Dictionary:
+	var westbound: bool = heading == "west"
+	if westbound:
+		var to_route_42: Dictionary = _walk_connection_resolving(
+			world, "west", 2, 5, save, random, data
+		)
+		var _r42_entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		if not bool(to_route_42.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Mahogany to Route 42 failed: %s" % to_route_42.get("reason", ""),
+			}
+		# The same two lakes _glacier_badge_path() crossed eastward, taken from
+		# the far shore each time.
+		var second_lake: Dictionary = _lake_crossing(
+			world, save, random, data,
+			Vector2i(42, 9), Gen2WorldSprite.FACING_LEFT, Vector2i(33, 10)
+		)
+		if not bool(second_lake.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Route 42 east lake westbound failed: %s" % second_lake.get("reason", ""),
+			}
+		var first_lake: Dictionary = _lake_crossing(
+			world, save, random, data,
+			Vector2i(22, 12), Gen2WorldSprite.FACING_LEFT, Vector2i(13, 9)
+		)
+		if not bool(first_lake.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Route 42 west lake westbound failed: %s" % first_lake.get("reason", ""),
+			}
+		path.append({
+			"step": "route_42_lakes_westbound",
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"movement_mode": String(world.movement_mode),
+		})
+		# Route 42's west end is the Ecruteak gate, not a connection: (0,8) and
+		# (0,9) are its only west-edge cells and both are warps
+		# (`maps/Route42.asm`).
+		var to_ecruteak: Dictionary = _gate_leg(
+			world, save, random, data, Vector2i(0, 8), 4, 9
+		)
+		if not bool(to_ecruteak.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Route 42 to Ecruteak failed: %s" % to_ecruteak.get("reason", ""),
+			}
+		for leg: Array in [["south", 10, 4], ["south", 10, 3], ["south", 10, 2]]:
+			var walked: Dictionary = _walk_connection_resolving(
+				world, String(leg[0]), int(leg[1]), int(leg[2]), save, random, data
+			)
+			var _entry: Dictionary = _drain_story(
+				world, world.dispatch_map_entry(), save, random, data
+			)
+			if not bool(walked.get("ok", false)):
+				return {
+					"ok": false, "path": path,
+					"reason": "walk %s to %d/%d failed: %s" % [
+						leg[0], leg[1], leg[2], walked.get("reason", ""),
+					],
+				}
+		var south_cut: Dictionary = _cut_at(
+			world, Vector2i(17, 5), Gen2WorldSprite.FACING_DOWN, save, random, data
+		)
+		if not bool(south_cut.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Route 35 southbound cut failed: %s" % south_cut.get("reason", ""),
+			}
+		var to_goldenrod: Dictionary = _gate_leg(
+			world, save, random, data, Vector2i(9, 33), 11, 2
+		)
+		if not bool(to_goldenrod.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Route 35 to Goldenrod failed: %s" % to_goldenrod.get("reason", ""),
+			}
+		path.append({
+			"step": "mahogany_to_goldenrod",
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+		})
+		return {"ok": true}
+
+	var to_route_35: Dictionary = _gate_leg(
+		world, save, random, data, Vector2i(19, 1), 10, 2
+	)
+	if not bool(to_route_35.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Goldenrod to Route 35 failed: %s" % to_route_35.get("reason", ""),
+		}
+	var north_cut: Dictionary = _cut_at(
+		world, Vector2i(17, 7), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	if not bool(north_cut.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 35 northbound cut failed: %s" % north_cut.get("reason", ""),
+		}
+	for leg: Array in [["north", 10, 3], ["north", 10, 4], ["north", 4, 9]]:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, String(leg[0]), int(leg[1]), int(leg[2]), save, random, data
+		)
+		var _entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "walk %s to %d/%d failed: %s" % [
+					leg[0], leg[1], leg[2], walked.get("reason", ""),
+				],
+			}
+	var to_route_42: Dictionary = _gate_leg(
+		world, save, random, data, Vector2i(35, 26), 2, 5
+	)
+	if not bool(to_route_42.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Ecruteak to Route 42 failed: %s" % to_route_42.get("reason", ""),
+		}
+	var west_lake: Dictionary = _lake_crossing(
+		world, save, random, data,
+		Vector2i(13, 9), Gen2WorldSprite.FACING_RIGHT, Vector2i(22, 12)
+	)
+	if not bool(west_lake.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 42 west lake eastbound failed: %s" % west_lake.get("reason", ""),
+		}
+	var east_lake: Dictionary = _lake_crossing(
+		world, save, random, data,
+		Vector2i(33, 10), Gen2WorldSprite.FACING_RIGHT, Vector2i(42, 9)
+	)
+	if not bool(east_lake.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 42 east lake eastbound failed: %s" % east_lake.get("reason", ""),
+		}
+	var to_mahogany: Dictionary = _walk_connection_resolving(
+		world, "east", 2, 7, save, random, data
+	)
+	var _mahogany_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	if not bool(to_mahogany.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 42 to Mahogany failed: %s" % to_mahogany.get("reason", ""),
+		}
+	path.append({
+		"step": "goldenrod_to_mahogany",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+	})
+	return {"ok": true}
+
+
+## Surfs from [param shore] in [param facing] and lands on [param landfall],
+## keeping the plan on the water in between so it cannot step ashore partway.
+func _lake_crossing(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	shore: Vector2i,
+	facing: int,
+	landfall: Vector2i,
+) -> Dictionary:
+	var entered: Dictionary = _surf_at(world, shore, facing, save, random, data)
+	if not bool(entered.get("ok", false)):
+		return entered
+	return _walk_cell_resolving(world, landfall, save, random, data, true)
+
+
 ## Mahogany Town east to Blackthorn City, on the same world, state and save.
+## Starts in the town, since the Radio Tower leg before it left the gym.
 ##
 ## Route 44 carries seven trainers and no scripted gate, so the leg is a walk
 ## the trainers interrupt rather than a sequence of errands. Its one warp is the
@@ -2521,13 +3082,6 @@ func _blackthorn_path(
 	data: GameData,
 	path: Array,
 ) -> Dictionary:
-	var leaving_gym: Dictionary = _warp_step(world, 2, 7)
-	if not bool(leaving_gym.get("ok", false)):
-		return {"ok": false, "path": path, "reason": "Mahogany Gym exit warp failed"}
-	var _town_entry: Dictionary = _drain_story(
-		world, world.dispatch_map_entry(), save, random, data
-	)
-
 	var to_route_44: Dictionary = _walk_connection_resolving(
 		world, "east", 2, 6, save, random, data
 	)

--- a/tools/validate_radio_tower.gd
+++ b/tools/validate_radio_tower.gd
@@ -1,0 +1,289 @@
+extends SceneTree
+
+## Verifies the gates the Goldenrod Radio Tower leg turns, against freshly
+## imported real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `maps/BlackthornCity.asm`, `maps/RadioTower2F.asm`, `maps/RadioTower3F.asm`
+## and `maps/GoldenrodUndergroundSwitchRoomEntrances.asm`. Blackthorn City's
+## event rows, RadioTower3F whole, and the switch room's `ugdoor_def` table and
+## `..._UpdateDoors` body are byte identical between the pins, and every event
+## flag below has the same number in both.
+##
+## The leg is route work, so what is worth pinning is not the scripts but the
+## three places a wrong flag or a missed `changeblock` would silently seal the
+## route: Blackthorn Gym's door, Radio Tower 2F's stairs and 3F's card-key
+## shutter, and the switch room's eleven doors.
+##
+##   Godot --headless --path . -s res://tools/validate_radio_tower.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## data/maps/maps.asm group/number pairs. Blackthorn City and the Radio Tower
+## floors sit at the same pair in both games; Crystal's own extra maps push the
+## Goldenrod Underground eight places down the Dungeons group.
+const BLACKTHORN_CITY: Array = [5, 10]
+const RADIO_TOWER_2F: Array = [3, 18]
+const RADIO_TOWER_3F: Array = [3, 19]
+const SWITCH_ROOM: Dictionary = {
+	&"gold": [3, 46],
+	&"silver": [3, 46],
+	&"crystal": [3, 54],
+}
+
+## constants/event_flags.asm, same numbers in both pins.
+const EVENT_USED_THE_CARD_KEY: int = 37
+const EVENT_BLACKBELT_BLOCKS_STAIRS: int = 1745
+const EVENT_SUPER_NERD_BLOCKS_GYM: int = 1763
+const EVENT_SUPER_NERD_DOES_NOT_BLOCK_GYM: int = 1764
+## EVENT_DOOR_1_OPEN is 727, so door n is this plus n.
+const EVENT_DOOR_OPEN_BASE: int = 726
+
+## The `ugdoor_def` table verbatim: door id, then each row's source cell with
+## its closed and open block ids. Rows 1 to 6 are the single-block vertical
+## links between bands; 7 to 11 are the two-block horizontal doors whose $2a
+## upper half stays a wall and whose $2d lower half is what opens.
+const UGDOORS: Array = [
+	{"door": 1, "rows": [[Vector2i(16, 6), 0x3e, 0x2d]]},
+	{"door": 2, "rows": [[Vector2i(10, 6), 0x3e, 0x2d]]},
+	{"door": 3, "rows": [[Vector2i(2, 6), 0x3e, 0x2d]]},
+	{"door": 4, "rows": [[Vector2i(2, 10), 0x3e, 0x2d]]},
+	{"door": 5, "rows": [[Vector2i(10, 10), 0x3e, 0x2d]]},
+	{"door": 6, "rows": [[Vector2i(16, 10), 0x3e, 0x2d]]},
+	{"door": 7, "rows": [[Vector2i(12, 6), 0x3f, 0x2a], [Vector2i(12, 8), 0x3d, 0x2d]]},
+	{"door": 8, "rows": [[Vector2i(6, 6), 0x3f, 0x2a], [Vector2i(6, 8), 0x3d, 0x2d]]},
+	{"door": 9, "rows": [[Vector2i(12, 10), 0x3f, 0x2a], [Vector2i(12, 12), 0x3d, 0x2d]]},
+	{"door": 10, "rows": [[Vector2i(6, 10), 0x3f, 0x2a], [Vector2i(6, 12), 0x3d, 0x2d]]},
+	{"door": 11, "rows": [[Vector2i(18, 10), 0x3f, 0x2a], [Vector2i(18, 12), 0x3d, 0x2d]]},
+]
+
+## What `..._UpdateDoors` leaves open after switch 3, then 2, then 1, which
+## walks positions 3, 5 and 6. Position 6 opens 6, 8, 9 and 11 and closes only
+## 1, 7 and 10, so 3 and 5 survive from the two positions before it.
+const OPEN_AT_POSITION_6: Array[int] = [3, 5, 6, 8, 9, 11]
+
+## The switch room's top corridor, entered from GoldenrodUnderground's south
+## half, and the two warps into the warehouse.
+const SWITCH_ROOM_ENTRY: Vector2i = Vector2i(23, 3)
+const WAREHOUSE_DOORS: Array = [Vector2i(22, 10), Vector2i(23, 10)]
+
+const STEPS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_blackthorn_gym_door(data, game_id)
+		_verify_radio_tower_stairs(data, game_id)
+		_verify_switch_room(data, game_id)
+	_finish()
+
+
+## The gate this whole leg exists to open. BLACKTHORNCITY_SUPER_NERD1 stands on
+## (18,12), the only cell that reaches the gym door warp at (18,11), and
+## RadioTower5FRocketBossScript is the only thing that hides it.
+func _verify_blackthorn_gym_door(data: GameData, game_id: StringName) -> void:
+	var sealed: Gen2WorldAPI = _open(
+		data, BLACKTHORN_CITY, Vector2i(18, 13), [EVENT_SUPER_NERD_DOES_NOT_BLOCK_GYM]
+	)
+	if sealed == null:
+		_fail("%s: Blackthorn City is missing." % game_id)
+		return
+
+	var warp: Dictionary = sealed.warp_at(Vector2i(18, 11))
+	_check(
+		not warp.is_empty() and int(warp.get("map_group", -1)) == 5
+			and int(warp.get("map_number", -1)) == 1,
+		"%s: (18,11) is not the Blackthorn Gym warp." % game_id
+	)
+	_check(
+		Gen2WorldCollision.is_warp_tile(sealed.collision_code_at(Vector2i(18, 11))),
+		"%s: the gym door at (18,11) is not on a warp tile." % game_id
+	)
+	for wall: Vector2i in [Vector2i(17, 11), Vector2i(19, 11)]:
+		_check(
+			not sealed.can_walk_to(wall),
+			"%s: %s beside the gym door is walkable, so (18,12) is not the only way in." % [
+				game_id, wall,
+			]
+		)
+	_check(
+		not _reaches(sealed, Vector2i(18, 13), Vector2i(18, 11)),
+		"%s: the gym door is reachable before the Radio Tower is cleared." % game_id
+	)
+
+	var open_city: Gen2WorldAPI = _open(
+		data, BLACKTHORN_CITY, Vector2i(18, 13), [EVENT_SUPER_NERD_BLOCKS_GYM]
+	)
+	_check(
+		_reaches(open_city, Vector2i(18, 13), Vector2i(18, 11)),
+		"%s: the gym door is still sealed after the Radio Tower is cleared." % game_id
+	)
+
+
+## 2F's stairs are behind the Black Belt on (0,1), whom RadioTowerRocketsScript
+## hides; 3F's second staircase is behind the card-key shutter, which
+## RadioTower3FCardKeyShutterCallback changeblocks open on every later load.
+func _verify_radio_tower_stairs(data: GameData, game_id: StringName) -> void:
+	var blocked: Gen2WorldAPI = _open(data, RADIO_TOWER_2F, Vector2i(15, 0), [])
+	if blocked == null:
+		_fail("%s: Radio Tower 2F is missing." % game_id)
+		return
+	_check(
+		not _reaches(blocked, Vector2i(15, 0), Vector2i(0, 0)),
+		"%s: Radio Tower 2F's stairs are open before the takeover." % game_id
+	)
+	var cleared: Gen2WorldAPI = _open(
+		data, RADIO_TOWER_2F, Vector2i(15, 0), [EVENT_BLACKBELT_BLOCKS_STAIRS]
+	)
+	_check(
+		_reaches(cleared, Vector2i(15, 0), Vector2i(0, 0)),
+		"%s: Radio Tower 2F's stairs are still blocked after the takeover." % game_id
+	)
+
+	var shut: Gen2WorldAPI = _open(data, RADIO_TOWER_3F, Vector2i(0, 0), [])
+	if shut == null:
+		_fail("%s: Radio Tower 3F is missing." % game_id)
+		return
+	_check(
+		_reaches(shut, Vector2i(0, 0), Vector2i(7, 0)),
+		"%s: Radio Tower 3F's first staircase is unreachable." % game_id
+	)
+	_check(
+		_reaches(shut, Vector2i(0, 0), Vector2i(14, 3)),
+		"%s: the card-key slot cannot be faced from (14,3)." % game_id
+	)
+	_check(
+		not _reaches(shut, Vector2i(0, 0), Vector2i(17, 0)),
+		"%s: Radio Tower 3F's shutter staircase is open without the card key." % game_id
+	)
+	var opened: Gen2WorldAPI = _open(
+		data, RADIO_TOWER_3F, Vector2i(0, 0), [EVENT_USED_THE_CARD_KEY]
+	)
+	_check(
+		_reaches(opened, Vector2i(0, 0), Vector2i(17, 0)),
+		"%s: the card-key shutter did not open the second staircase." % game_id
+	)
+
+
+## Every `ugdoor_def` row against the blocks its callback writes, then the one
+## chain from the top corridor to the warehouse that the three switches open.
+func _verify_switch_room(data: GameData, game_id: StringName) -> void:
+	var id: Array = SWITCH_ROOM[game_id]
+	var closed: Gen2WorldAPI = _open(data, id, SWITCH_ROOM_ENTRY, [])
+	if closed == null:
+		_fail("%s: the switch room is missing." % game_id)
+		return
+	for door: Dictionary in UGDOORS:
+		for row: Array in door["rows"]:
+			var cell: Vector2i = row[0]
+			_check(
+				closed.block_at(cell.x / 2, cell.y / 2) == int(row[1]),
+				"%s: door %d at %s is block $%02x closed, not the pinned $%02x." % [
+					game_id, int(door["door"]), cell,
+					closed.block_at(cell.x / 2, cell.y / 2), int(row[1]),
+				]
+			)
+
+	var all_doors: Array[int] = []
+	for door: Dictionary in UGDOORS:
+		all_doors.append(EVENT_DOOR_OPEN_BASE + int(door["door"]))
+	var opened: Gen2WorldAPI = _open(data, id, SWITCH_ROOM_ENTRY, all_doors)
+	for door: Dictionary in UGDOORS:
+		for row: Array in door["rows"]:
+			var cell: Vector2i = row[0]
+			_check(
+				opened.block_at(cell.x / 2, cell.y / 2) == int(row[2]),
+				"%s: door %d at %s is block $%02x open, not the pinned $%02x." % [
+					game_id, int(door["door"]), cell,
+					opened.block_at(cell.x / 2, cell.y / 2), int(row[2]),
+				]
+			)
+
+	for warehouse_door: Vector2i in WAREHOUSE_DOORS:
+		_check(
+			not _reaches(closed, SWITCH_ROOM_ENTRY, warehouse_door),
+			"%s: the warehouse door %s is reachable with every door shut." % [
+				game_id, warehouse_door,
+			]
+		)
+
+	var position_6: Array[int] = []
+	for door: int in OPEN_AT_POSITION_6:
+		position_6.append(EVENT_DOOR_OPEN_BASE + door)
+	var solved: Gen2WorldAPI = _open(data, id, SWITCH_ROOM_ENTRY, position_6)
+	for warehouse_door: Vector2i in WAREHOUSE_DOORS:
+		_check(
+			_reaches(solved, SWITCH_ROOM_ENTRY, warehouse_door),
+			"%s: switches 3, 2 and 1 do not open a way to the warehouse door %s." % [
+				game_id, warehouse_door,
+			]
+		)
+	# The emergency switch is inside the room the warehouse opens into, which is
+	# why coming back needs it rather than the three switches.
+	_check(
+		_reaches(solved, WAREHOUSE_DOORS[0], Vector2i(20, 12)),
+		"%s: the emergency switch cannot be faced from inside the warehouse room." % game_id
+	)
+
+
+func _open(data: GameData, id: Array, cell: Vector2i, flags: Array) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	for flag: int in flags:
+		state.set_event_flag(flag)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, id[0], id[1], cell, state)
+	if world == null:
+		return null
+	# The door and shutter blocks are written by MAPCALLBACK_TILES, so the map's
+	# own callbacks have to run before anything is read off the grid.
+	var _entry: Array = world.dispatch_map_entry()
+	for _step: int in 8:
+		if world.pending_script_input().is_empty():
+			break
+		world.run_event_queue(true)
+	return world
+
+
+## Plain walking reachability, which is all these gates turn on.
+func _reaches(world: Gen2WorldAPI, from: Vector2i, target: Vector2i) -> bool:
+	if world == null:
+		return false
+	var seen: Dictionary = {from: true}
+	var frontier: Array[Vector2i] = [from]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		if cell == target:
+			return true
+		for step: Vector2i in STEPS:
+			var next: Vector2i = cell + step
+			if seen.has(next) or not world.can_walk_to(next, step):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return false
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS radio tower: the Blackthorn, stairs, shutter and switch-room gates verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL radio tower: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_radio_tower.gd.uid
+++ b/tools/validate_radio_tower.gd.uid
@@ -1,0 +1,1 @@
+uid://dv8u7f3io12k7


### PR DESCRIPTION
Blackthorn Gym is sealed until the Radio Tower falls: BlackthornCity stands a Super Nerd on (18,12), the only cell that reaches the gym door warp, and RadioTower5F's boss script is the only thing that hides him. So the walked route turns west after Pryce.

The leg surfs Route 42's two lakes in reverse and crosses Ecruteak and Routes 37, 36 and 35 to Goldenrod, climbs the tower's first shaft to FakeDirectorScript for the BASEMENT_KEY, unlocks the underground's basement door, walks the switch room's three switches to position 6 and takes the warehouse director's CARD_KEY, then opens 3F's shutter and reaches the 5F boss. Coming back needs the emergency switch, since the warehouse's own MAPCALLBACK_NEWMAP shuts every door behind it.

Two source divergences met on the way:

- dispatch_script_events() queued background events, so walking onto a cell carrying one ran its script with no A press. CheckTileEvent handles warps, coord events, the step count and encounters; TryBGEvent is behind CheckAPressOW. It now queues coordinate events only, and dispatch_events(cell, true) stays the explicit-execution call. Goldenrod's basement door is both a warp_event and a bg_event on (18,6), which is where the two first had to be told apart.
- addval kept its sum unmasked. Script_addval adds into wScriptVar, one byte, so it wraps there; the switch room turns a switch off with `addval -1`.

validate_radio_tower.gd pins the gates in all three games: the gym door and its only approach, 2F's stairs and 3F's shutter, and all eleven ugdoor rows with the one chain to the warehouse.