### PR TITLE
Walk Blackthorn Gym and the Dragon Shrine to the Rising Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > and teaching it HM04 Strength to push Cianwood Gym's boulders aside for the
 > Storm Badge, then east across Route 42's lakes to Mahogany, the Lake of Rage's
 > Red Gyarados and Lance, the Rocket hideout's three floors and Pryce to the
-> Glacier Badge.
+> Glacier Badge, back west for the Goldenrod Radio Tower's basement and card
+> keys and its Rocket boss, then Route 44 and the Ice Path to Blackthorn, its
+> gym's boulder puzzle and Clair, and the Dragon Shrine's quiz for the Rising
+> Badge.
 > Missing: full story state, dex, trainer card, options, the remaining
 > special-call branches and story-driven permanent contacts.
 
@@ -200,6 +203,7 @@ Headless tools, all against a real imported cache:
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |
+| `validate_rising_badge.gd` | Blackthorn Gym 2F's boulders and holes, the 1F block changes that open Clair's room, the lake crossing to the Dragon's Den door, and Dragon's Den B1F's whirlpool and shrine landfall, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -246,7 +246,13 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		if pending_type in [&"choice", &"menu"]:
 			if choice < 0:
 				return _waiting_result()
-			if pending_type == &"choice" \
+			if pending_type == &"menu":
+				## Script_verticalmenu and Script__2dmenu store wMenuCursorY and
+				## wMenuCursorPosition, which count from one; cancel_input()
+				## already writes the zero their carry branch does. So a caller's
+				## zero-based option is the source's option minus one.
+				_script_value = choice + 1
+			elif pending_type == &"choice" \
 				and _pending.get("choices", []) == [&"yes", &"no"]:
 				_script_value = 1 if choice == 0 else 0
 			else:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3032,6 +3032,51 @@ func test_special_phone_call_check_reads_staged_id_before_commit() -> void:
 	assert_eq(state.pending_special_phone_call(), 2, JSON.stringify(completed))
 
 
+## Script_verticalmenu stores wMenuCursorY, which counts from one, so the
+## Dragon Shrine's `ifequal 1, .RightAnswer` is asking for the first option.
+## cancel_input() keeps the zero the source's carry branch writes.
+func test_a_vertical_menu_answers_the_source_one_based_option() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6C60"] = [
+		Gen2WorldScript.LOADMENU, 0x34, 0x12,
+		0x59, # verticalmenu, raw Crystal
+		Gen2WorldScript.IFEQUAL, 2, 0x70, 0x6C,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6C70"] = [
+		Gen2WorldScript.SETVAL, 99,
+		Gen2WorldScript.WRITEMEM, 0xD8, 0xD1,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+
+	var chosen := Gen2WorldState.new()
+	var runner := Gen2WorldScriptRunner.begin(data, chosen, {
+		"kind": &"test", "bank": 48, "script": 0x6C60,
+	})
+	assert_eq(runner.advance()["event"]["type"], &"menu")
+	# The second option, which the source numbers 2.
+	assert_eq(runner.advance(true, 1)["status"], &"complete")
+	assert_eq(chosen.script_memory(0xD1D8), 99, "option 1 answered the source's 2")
+
+	var first := Gen2WorldState.new()
+	var other := Gen2WorldScriptRunner.begin(data, first, {
+		"kind": &"test", "bank": 48, "script": 0x6C60,
+	})
+	assert_eq(other.advance()["event"]["type"], &"menu")
+	assert_eq(other.advance(true, 0)["status"], &"complete")
+	assert_eq(first.script_memory(0xD1D8), 0, "option 0 answered the source's 1")
+
+	var cancelled := Gen2WorldState.new()
+	var backed_out := Gen2WorldScriptRunner.begin(data, cancelled, {
+		"kind": &"test", "bank": 48, "script": 0x6C60,
+	})
+	assert_eq(backed_out.advance()["event"]["type"], &"menu")
+	assert_eq(backed_out.cancel_input()["status"], &"complete")
+	assert_eq(cancelled.script_memory(0xD1D8), 0, "cancelling still answers zero")
+
+
 func test_script_menu_and_battle_are_explicit_runtime_requests() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -51,6 +51,71 @@ const EVENT_MAHOGANY_POKEFAN_M_BLOCKS_EAST: int = 1878
 ## cell that reaches Blackthorn Gym's door (`maps/BlackthornCity.asm`).
 const EVENT_CLEARED_RADIO_TOWER: int = 33
 const EVENT_BLACKTHORN_SUPER_NERD_BLOCKS_GYM: int = 1763
+## The Blackthorn Gym boulders' own object event flags, which
+## `BlackthornGym1FBouldersCallback` reads back as `changeblock`s on 1F.
+const EVENT_BOULDER_IN_BLACKTHORN_GYM_1: int = 1798
+const EVENT_BOULDER_IN_BLACKTHORN_GYM_3: int = 1800
+const EVENT_BEAT_CLAIR: int = 1220
+const EVENT_ANSWERED_DRAGON_MASTER_QUIZ_WRONG: int = 193
+## ENGINE_RISINGBADGE's place in source badge order (`constants/engine_flags.asm`).
+const BADGE_RISING: int = 7
+
+## Blackthorn Gym 2F's pushes in order, each an approach cell and the direction
+## stepped from it (`maps/BlackthornGym2F.asm`).
+##
+## Four of the six boulders move. BOULDER5 on (6,1) and BOULDER6 on (8,14) are
+## in neither the `stonetable` nor any event flag: they seal the two pockets the
+## puzzle needs, the top-right one holding BOULDER1 and its hole, and the
+## bottom one holding the row BOULDER3 has to be pushed from. Shoving each three
+## cells clears both. BOULDER1 is then one push into (8,3), and BOULDER3 goes
+## north until the wall at (6,6) stops it and then east into (8,7).
+##
+## BOULDER2 is left alone. Its hole is a `stonetable` row like the other two,
+## but the 1F cell its flag opens, (2,5), is a dead end beside the entrance.
+const BLACKTHORN_GYM_PUSHES: Array = [
+	{
+		"step": "blackthorn_gym_clear_top_pocket",
+		"pushes": [
+			[Vector2i(5, 1), Vector2i.RIGHT],
+			[Vector2i(6, 1), Vector2i.RIGHT],
+			[Vector2i(7, 1), Vector2i.RIGHT],
+		],
+	},
+	{
+		"step": "blackthorn_gym_boulder_1",
+		"flag": 1798,
+		"pushes": [[Vector2i(8, 1), Vector2i.DOWN]],
+	},
+	{
+		"step": "blackthorn_gym_clear_south_pocket",
+		"pushes": [
+			[Vector2i(8, 13), Vector2i.DOWN],
+			[Vector2i(8, 14), Vector2i.DOWN],
+			[Vector2i(8, 15), Vector2i.DOWN],
+		],
+	},
+	{
+		"step": "blackthorn_gym_boulder_3",
+		"flag": 1800,
+		"pushes": [
+			[Vector2i(6, 17), Vector2i.UP], [Vector2i(6, 16), Vector2i.UP],
+			[Vector2i(6, 15), Vector2i.UP], [Vector2i(6, 14), Vector2i.UP],
+			[Vector2i(6, 13), Vector2i.UP], [Vector2i(6, 12), Vector2i.UP],
+			[Vector2i(6, 11), Vector2i.UP], [Vector2i(6, 10), Vector2i.UP],
+			[Vector2i(6, 9), Vector2i.UP],
+			[Vector2i(5, 7), Vector2i.RIGHT], [Vector2i(6, 7), Vector2i.RIGHT],
+		],
+	},
+]
+
+## The Dragon Shrine quiz, answered right (`maps/DragonShrine.asm`). Each
+## question is a three-option `verticalmenu` and these are zero-based, so the
+## source's accepted options are 1, 1, 2, 1 and 2.
+const DRAGON_SHRINE_ANSWERS: Array[int] = [0, 0, 1, 0, 1]
+
+## How many hardware frames one pushed boulder may spend sliding before the walk
+## calls it stuck. The slide is STEP_FRAMES_BOULDER_PUSH, well inside this.
+const OBJECT_STEP_FRAME_BUDGET: int = 64
 
 ## Route 44's Ice Path door and then every warp cell the cave is crossed by, in
 ## order (`maps/Route44.asm`, `maps/IcePath*.asm`).
@@ -800,6 +865,10 @@ func _story_path(data: GameData) -> Dictionary:
 	var blackthorn: Dictionary = _blackthorn_path(world, save, random, data, path)
 	if not bool(blackthorn.get("ok", false)):
 		return blackthorn
+
+	var rising: Dictionary = _rising_badge_path(world, save, random, data, path)
+	if not bool(rising.get("ok", false)):
+		return rising
 
 	var party_summary: Array = []
 	for mon: Gen2SaveMon in save.party:
@@ -3058,6 +3127,297 @@ func _lake_crossing(
 	return _walk_cell_resolving(world, landfall, save, random, data, true)
 
 
+## Blackthorn City to the Rising Badge, on the same world, state and save.
+##
+## The badge is not Clair's. `BlackthornGymClairScript` sets only
+## `EVENT_BEAT_CLAIR` and swaps the two Blackthorn gramps so the Dragon's Den
+## door at (20,1) opens; `maps/DragonShrine.asm` is what runs
+## `setflag ENGINE_RISINGBADGE`, at the end of the elder's five-question quiz.
+##
+## Appends to [param path] and answers only ok or the failure.
+func _rising_badge_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var gym: Dictionary = _blackthorn_gym_leg(world, save, random, data, path)
+	if not bool(gym.get("ok", false)):
+		return gym
+
+	var shrine: Dictionary = _dragon_shrine_leg(world, save, random, data, path)
+	if not bool(shrine.get("ok", false)):
+		return shrine
+
+	return {"ok": true}
+
+
+## Blackthorn Gym's boulder puzzle and Clair.
+##
+## 1F is four regions, and the entrance reaches only one of them. 2F's three
+## holes are `stonetable` rows, and a boulder that falls through one is
+## `disappear`ed and sets its own event flag, which
+## `BlackthornGym1FBouldersCallback` turns into a `changeblock` on 1F. Two of
+## those changes are the route: BOULDER1 through the (8,3) hole opens 1F (8,3),
+## joining the middle corridor to Clair's room, and BOULDER3 through the (8,7)
+## hole opens 1F (8,7), joining that corridor to the pocket 2F's (7,9) staircase
+## drops into. BOULDER2's hole adds one 1F cell beside the entrance and reaches
+## nothing, so the walk leaves it alone.
+##
+## BOULDER1 is one push; BOULDER3 starts nine cells south of the row it has to
+## cross on, so it goes north until the wall at (6,6) stops it and then east
+## into the hole.
+func _blackthorn_gym_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	if not world.strength_active():
+		return {"ok": false, "path": path, "reason": "Strength is not active"}
+	var to_gym: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(18, 11), Vector2i(1, 7)]
+	)
+	if not bool(to_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn Gym 2F unreachable: %s" % to_gym.get("reason", ""),
+		}
+
+	for leg: Dictionary in BLACKTHORN_GYM_PUSHES:
+		var pushes: Array = []
+		for push: Array in leg["pushes"]:
+			var moved: Dictionary = _push_boulder_run(
+				world, push[0], push[1], save, random, data
+			)
+			pushes.append(moved)
+			if not bool(moved.get("ok", false)):
+				path.append({
+					"step": String(leg["step"]),
+					"map": _map_value(world),
+					"cell": _cell_value(world),
+					"pushes": pushes,
+				})
+				return {
+					"ok": false, "path": path,
+					"reason": "%s failed: %s" % [leg["step"], moved.get("reason", "")],
+				}
+		var flag: int = int(leg.get("flag", -1))
+		path.append({
+			"step": String(leg["step"]),
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"pushes": pushes.size(),
+			"fell": flag >= 0 and world.event_flag_active(flag),
+		})
+		if flag >= 0 and not world.event_flag_active(flag):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s did not fall through" % leg["step"],
+			}
+
+	# 2F's (7,9) staircase drops into the 1F pocket the two fallen boulders have
+	# just joined to Clair's room.
+	var down: Dictionary = _warp_chain(world, save, random, data, [Vector2i(7, 9)])
+	if not bool(down.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn Gym 1F return failed: %s" % down.get("reason", ""),
+		}
+
+	var clair: Dictionary = _talk_to(
+		world, Vector2i(5, 4), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "blackthorn_gym_clair",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": clair.get("run", {}),
+		"beat_clair": world.event_flag_active(EVENT_BEAT_CLAIR),
+	})
+	if not bool(clair.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Clair failed: %s" % clair.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_BEAT_CLAIR):
+		return {"ok": false, "path": path, "reason": "Clair was not beaten"}
+	return {"ok": true}
+
+
+## Blackthorn City to the Dragon Shrine, and the elder's quiz.
+##
+## Clair's script sets `EVENT_BLACKTHORN_CITY_GRAMPS_BLOCKS_DRAGONS_DEN` and
+## clears its partner, which swaps the gramps standing on (20,2) for one beside
+## it and opens the den door at (20,1). Neither den floor needs a field move:
+## B1F's shrine warp at (19,29) is on the same land region as the ladder from
+## 1F, and the whirlpool at (10,20) guards the water pocket rather than the way
+## through.
+##
+## The quiz is answered correctly. `.WrongAnswer` on the last question checks
+## `EVENT_TEMPORARY_UNTIL_MAP_RELOAD_6`, which question 5 has already set, so it
+## asks question 5 again: a wrong answer there is the one that does not move on.
+func _dragon_shrine_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var out_of_gym: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(7, 9), Vector2i(1, 7), Vector2i(4, 17)]
+	)
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn Gym exit failed: %s" % out_of_gym.get("reason", ""),
+		}
+
+	# The den door is across the lake, not around it. Every land route from the
+	# town centre is walled off by the $b2 fence line and the one-way $a3 ledges,
+	# and (20,4) below the door's shore is COLL_WATER, so the crossing is the
+	# way in. That is also what the gramps on (20,3) blocks until Clair moves him.
+	var crossing: Dictionary = _lake_crossing(
+		world, save, random, data,
+		Vector2i(22, 12), Gen2WorldSprite.FACING_UP, Vector2i(20, 3)
+	)
+	path.append({
+		"step": "blackthorn_lake_crossing",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+	})
+	if not bool(crossing.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn lake crossing failed: %s" % crossing.get("reason", ""),
+		}
+
+	# Dragon's Den 1F is two halves joined by its own warp pair, (3,3) into
+	# (5,13), so the ladder down at (5,15) is only reached through it.
+	var to_den: Dictionary = _warp_chain(
+		world, save, random, data,
+		[Vector2i(20, 1), Vector2i(3, 3), Vector2i(5, 15)]
+	)
+	if not bool(to_den.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den B1F unreachable: %s" % to_den.get("reason", ""),
+		}
+
+	# B1F is a lake with the shrine on its far shore: the ladder's own land
+	# region has 271 cells and none of them touch the shrine, whose only landfall
+	# from the water is (14,31). The whirlpool on (10,20) sits in the way.
+	var entered: Dictionary = _surf_at(
+		world, Vector2i(10, 7), Gen2WorldSprite.FACING_DOWN, save, random, data
+	)
+	if not bool(entered.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den surf entry failed: %s" % entered.get("reason", ""),
+		}
+	var cleared: Dictionary = _whirlpool_at(
+		world, Vector2i(10, 19), Gen2WorldSprite.FACING_DOWN, save, random, data
+	)
+	path.append({
+		"step": "dragons_den_whirlpool",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": cleared,
+	})
+	if not bool(cleared.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den whirlpool failed: %s" % cleared.get("reason", ""),
+		}
+	var den_crossing: Dictionary = _walk_cell_resolving(
+		world, Vector2i(14, 31), save, random, data, true
+	)
+	path.append({
+		"step": "dragons_den_crossing",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+	})
+	if not bool(den_crossing.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den crossing failed: %s" % den_crossing.get("reason", ""),
+		}
+
+	var to_shrine: Dictionary = _warp_chain(world, save, random, data, [Vector2i(19, 29)])
+	if not bool(to_shrine.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon Shrine unreachable: %s" % to_shrine.get("reason", ""),
+		}
+
+	# The shrine's scene 0 is SCENE_DRAGONSHRINE_TAKE_TEST, an sdefer, so the
+	# quiz runs off the map entry rather than an interaction.
+	var quiz: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data, true,
+		DRAGON_SHRINE_ANSWERS
+	)
+	path.append({
+		"step": "dragon_shrine_rising_badge",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": quiz,
+		"badge_count": world.state.badge_count(),
+		"answered_wrong": world.event_flag_active(EVENT_ANSWERED_DRAGON_MASTER_QUIZ_WRONG),
+	})
+	if not bool(quiz.get("terminal", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Dragon Shrine quiz did not finish: %s" % quiz.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		BADGE_RISING, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return {"ok": false, "path": path, "reason": "the Rising Badge was not given"}
+	return {"ok": true}
+
+
+## _push_boulder_at() for a boulder that may land on a `stonetable` pit: the
+## fall script is queued by the push that commits the cell, and the boulder
+## needs its own slide finished before the next push can reach it.
+func _push_boulder_run(
+	world: Gen2WorldAPI,
+	approach: Vector2i,
+	direction: Vector2i,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+) -> Dictionary:
+	var pushed: Dictionary = _push_boulder_at(world, approach, direction, save, random, data)
+	if not bool(pushed.get("ok", false)):
+		return pushed
+	var fall: Dictionary = _drain_story(
+		world, world.run_event_queue(false), save, random, data
+	)
+	if not bool(fall.get("terminal", true)):
+		return {"ok": false, "reason": "fall script did not finish: %s" % fall.get("reason", "")}
+	_settle_object_steps(world, random)
+	return pushed
+
+
+## Spends hardware frames until no object is mid-step. A pushed boulder slides
+## for STEP_FRAMES_BOULDER_PUSH frames and refuses a second push until it stands
+## again, and advance_object_steps() caps its own catch-up, so this has to tick.
+func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) -> void:
+	for _frame: int in OBJECT_STEP_FRAME_BUDGET:
+		var stepping: bool = false
+		for object: Gen2WorldObject in world.objects:
+			if object.is_stepping():
+				stepping = true
+				break
+		if not stepping:
+			return
+		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+
+
 ## Mahogany Town east to Blackthorn City, on the same world, state and save.
 ## Starts in the town, since the Radio Tower leg before it left the gym.
 ##
@@ -3691,6 +4051,31 @@ func _surf_at(
 	return {"ok": true, "cell": applied.get("cell", approach)}
 
 
+## Clears the whirlpool the given water cell faces, the way _cut_at() cuts:
+## request then commit, since Script_UsedWhirlpool reaches DisappearWhirlpool
+## only after UseWhirlpoolText. The frontier stays on water, so the approach
+## cannot step ashore on the way.
+func _whirlpool_at(
+	world: Gen2WorldAPI,
+	approach: Vector2i,
+	facing: int,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+) -> Dictionary:
+	var walked: Dictionary = _walk_cell_resolving(world, approach, save, random, data, true)
+	if not bool(walked.get("ok", false)):
+		return walked
+	world.player_facing = facing
+	var request: Dictionary = world.whirlpool_request()
+	if not bool(request.get("ok", false)):
+		return {"ok": false, "reason": "whirlpool refused: %s" % request.get("reason", "")}
+	var applied: Dictionary = world.complete_whirlpool()
+	if not bool(applied.get("ok", false)):
+		return {"ok": false, "reason": "whirlpool failed: %s" % applied.get("reason", "")}
+	return {"ok": true, "cell": applied.get("cell", approach)}
+
+
 ## Walks to [param cell], faces [param facing] and drains the interaction.
 func _talk_to(
 	world: Gen2WorldAPI,
@@ -3810,7 +4195,9 @@ func _drain_story(
 	random: RandomNumberGenerator = null,
 	data: GameData = null,
 	require_events: bool = false,
+	answers: Array[int] = [],
 ) -> Dictionary:
+	var pending_answers: Array[int] = answers.duplicate()
 	if require_events and initial.is_empty():
 		return {
 			"statuses": [],
@@ -3850,7 +4237,13 @@ func _drain_story(
 		elif input_type in [&"text", &"button"]:
 			results = world.run_event_queue(true)
 		elif input_type in [&"choice", &"menu"]:
-			results = world.choose_script_input(0)
+			## Choices default to the source's first option, which is yes on a
+			## yesorno. A caller that needs particular answers, like the Dragon
+			## Shrine quiz, supplies them in the order the script asks.
+			var choice: int = 0
+			if not pending_answers.is_empty():
+				choice = pending_answers.pop_front()
+			results = world.choose_script_input(choice)
 		else:
 			var request: Dictionary = world.pending_runtime_request()
 			if request.is_empty():

--- a/tools/validate_rising_badge.gd
+++ b/tools/validate_rising_badge.gd
@@ -1,0 +1,337 @@
+extends SceneTree
+
+## Verifies the gates between Blackthorn Gym's door and the Rising Badge,
+## against freshly imported real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `maps/BlackthornGym2F.asm`, `maps/BlackthornGym1F.asm`,
+## `maps/BlackthornCity.asm` and `maps/DragonsDenB1F.asm`. Gym 2F's map events
+## and `BlackthornGym1FBouldersCallback` are byte identical between the pins;
+## Gold and Silver have no Dragon Shrine, so their B1F carries no warp to it and
+## the shrine checks are Crystal only.
+##
+## What is worth pinning here is not the scripts but the four places the leg
+## would silently stop: the two boulders that seal 2F's pockets, the two 1F
+## `changeblock`s that actually open Clair's room, the lake that is the only way
+## to the Dragon's Den door, and the whirlpool between the den ladder and the
+## shrine's one landfall.
+##
+##   Godot --headless --path . -s res://tools/validate_rising_badge.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## data/maps/maps.asm group/number pairs. The gym floors and the city sit at the
+## same pair in both games; Crystal's own extra maps push Dragon's Den B1F eight
+## places down the Dungeons group.
+const BLACKTHORN_GYM_1F: Array = [5, 1]
+const BLACKTHORN_GYM_2F: Array = [5, 2]
+const BLACKTHORN_CITY: Array = [5, 10]
+const DRAGONS_DEN_B1F: Dictionary = {
+	&"gold": [3, 73],
+	&"silver": [3, 73],
+	&"crystal": [3, 81],
+}
+
+## constants/event_flags.asm, same numbers in both pins. Each boulder's own
+## object event flag, which its `stonetable` fall script sets and
+## BlackthornGym1FBouldersCallback reads back as a `changeblock`.
+const EVENT_BOULDER_1: int = 1798
+const EVENT_BOULDER_2: int = 1799
+const EVENT_BOULDER_3: int = 1800
+const EVENT_BEAT_CLAIR: int = 1220
+const EVENT_GRAMPS_BLOCKS_DRAGONS_DEN: int = 1868
+
+## `maps/BlackthornGym2F.asm`'s object rows in order. The first three are the
+## `stonetable` boulders; BOULDER4 is scenery and BOULDER5 and BOULDER6 are the
+## two that seal the pockets.
+const GYM_2F_BOULDERS: Array = [
+	Vector2i(8, 2), Vector2i(2, 3), Vector2i(6, 16),
+	Vector2i(3, 3), Vector2i(6, 1), Vector2i(8, 14),
+]
+## The three holes, from the same file's `def_warp_events`.
+const GYM_2F_HOLES: Array = [Vector2i(2, 5), Vector2i(8, 7), Vector2i(8, 3)]
+## The staircase 2F is entered by; its other one, (7,9), drops into the 1F
+## pocket the fallen boulders join to Clair's room.
+const GYM_2F_STAIRS: Vector2i = Vector2i(1, 7)
+
+## 1F's staircase from 2F's (7,9), and the cell Clair is faced from.
+const GYM_1F_LANDING: Vector2i = Vector2i(7, 9)
+const GYM_1F_FACE_CLAIR: Vector2i = Vector2i(5, 4)
+
+## Blackthorn City: the den door, the shore the route surfs from, and the cell
+## it lands on. (20,4) below the landing is COLL_WATER, which is what makes the
+## crossing the only way in.
+const CITY_DEN_DOOR: Vector2i = Vector2i(20, 1)
+const CITY_GYM_DOOR: Vector2i = Vector2i(18, 11)
+const CITY_SURF_SHORE: Vector2i = Vector2i(22, 12)
+const CITY_DEN_LANDFALL: Vector2i = Vector2i(20, 3)
+const CITY_DEN_WATER: Vector2i = Vector2i(20, 4)
+
+## Dragon's Den B1F: the ladder from 1F, the whirlpool in the way, and the one
+## cell the shrine's own region can be walked ashore on.
+const DEN_LADDER: Vector2i = Vector2i(20, 3)
+const DEN_WHIRLPOOL: Vector2i = Vector2i(10, 20)
+const DEN_LANDFALL: Vector2i = Vector2i(14, 31)
+const DEN_SHRINE_WARP: Vector2i = Vector2i(19, 29)
+
+const STEPS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_gym_2f(data, game_id)
+		_verify_gym_1f(data, game_id)
+		_verify_city_lake(data, game_id)
+		_verify_dragons_den(data, game_id)
+	_finish()
+
+
+## The six boulders, the three holes, and the two pockets BOULDER5 and BOULDER6
+## seal. Neither of those two is in the `stonetable` or carries an event flag,
+## so nothing else in the cache says they matter.
+func _verify_gym_2f(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, BLACKTHORN_GYM_2F, GYM_2F_STAIRS, [])
+	if world == null:
+		_fail("%s: Blackthorn Gym 2F is missing." % game_id)
+		return
+
+	var boulders: Array = []
+	for object: Gen2WorldObject in world.objects:
+		if object.is_strength_boulder():
+			boulders.append(object.cell)
+	_check(
+		boulders == GYM_2F_BOULDERS,
+		"%s: 2F's boulders are at %s, not the pinned %s." % [
+			game_id, boulders, GYM_2F_BOULDERS,
+		]
+	)
+	for hole: Vector2i in GYM_2F_HOLES:
+		_check(
+			Gen2WorldCollision.is_pit_tile(world.collision_code_at(hole))
+				and world.warp_index_at(hole) > 0,
+			"%s: 2F's hole at %s is not a warp on a pit tile." % [game_id, hole]
+		)
+
+	# The push cells for the two `stonetable` boulders, both sealed until the
+	# scenery boulders move.
+	_check(
+		not _reaches(world, GYM_2F_STAIRS, Vector2i(8, 1)),
+		"%s: 2F's (8,1) is reachable with BOULDER5 still on (6,1)." % game_id
+	)
+	_check(
+		not _reaches(world, GYM_2F_STAIRS, Vector2i(6, 17)),
+		"%s: 2F's (6,17) is reachable with BOULDER6 still on (8,14)." % game_id
+	)
+	# BOULDER3's run north stops on the wall above (6,7), which is what puts it
+	# on the row its hole is on.
+	for y: int in range(7, 17):
+		_check(
+			world.collision_permission_at(Vector2i(6, y)) == Gen2WorldCollision.LAND_TILE,
+			"%s: 2F's (6,%d) is not floor, so the north push cannot cross it." % [game_id, y]
+		)
+	_check(
+		not world.can_walk_to(Vector2i(6, 6)),
+		"%s: 2F's (6,6) is open, so the north push would not stop on (6,7)." % game_id
+	)
+
+
+## Which fallen boulders actually open Clair's room. Two of the three do;
+## BOULDER2's `changeblock` adds one cell beside the entrance and reaches
+## nothing, which is why the walked route leaves it alone.
+func _verify_gym_1f(data: GameData, game_id: StringName) -> void:
+	var sealed: Gen2WorldAPI = _open(data, BLACKTHORN_GYM_1F, GYM_1F_LANDING, [])
+	if sealed == null:
+		_fail("%s: Blackthorn Gym 1F is missing." % game_id)
+		return
+	_check(
+		not _reaches(sealed, GYM_1F_LANDING, GYM_1F_FACE_CLAIR),
+		"%s: Clair is reachable with no boulder fallen." % game_id
+	)
+
+	var one: Gen2WorldAPI = _open(data, BLACKTHORN_GYM_1F, GYM_1F_LANDING, [EVENT_BOULDER_1])
+	_check(
+		not _reaches(one, GYM_1F_LANDING, GYM_1F_FACE_CLAIR),
+		"%s: the first boulder alone reaches Clair." % game_id
+	)
+	var three: Gen2WorldAPI = _open(data, BLACKTHORN_GYM_1F, GYM_1F_LANDING, [EVENT_BOULDER_3])
+	_check(
+		not _reaches(three, GYM_1F_LANDING, GYM_1F_FACE_CLAIR),
+		"%s: the third boulder alone reaches Clair." % game_id
+	)
+	var both: Gen2WorldAPI = _open(
+		data, BLACKTHORN_GYM_1F, GYM_1F_LANDING, [EVENT_BOULDER_1, EVENT_BOULDER_3]
+	)
+	_check(
+		_reaches(both, GYM_1F_LANDING, GYM_1F_FACE_CLAIR),
+		"%s: the first and third boulders together do not reach Clair." % game_id
+	)
+
+	var second: Gen2WorldAPI = _open(data, BLACKTHORN_GYM_1F, GYM_1F_LANDING, [EVENT_BOULDER_2])
+	_check(
+		_region(second, GYM_1F_LANDING).size() == _region(sealed, GYM_1F_LANDING).size(),
+		"%s: the second boulder changes the landing's region, so it is not a dead end." % game_id
+	)
+
+
+## The Dragon's Den door is across the lake. Every land route from the town
+## centre is walled off, and (20,4) below the door's shore is water.
+func _verify_city_lake(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(
+		data, BLACKTHORN_CITY, CITY_GYM_DOOR,
+		[EVENT_BEAT_CLAIR, EVENT_GRAMPS_BLOCKS_DRAGONS_DEN]
+	)
+	if world == null:
+		_fail("%s: Blackthorn City is missing." % game_id)
+		return
+	_check(
+		not _reaches(world, CITY_GYM_DOOR, CITY_DEN_DOOR),
+		"%s: the Dragon's Den door is walkable from the gym door." % game_id
+	)
+	_check(
+		world.collision_permission_at(CITY_DEN_WATER) == Gen2WorldCollision.WATER_TILE,
+		"%s: %s below the den's shore is not water." % [game_id, CITY_DEN_WATER]
+	)
+	_check(
+		world.collision_permission_at(CITY_SURF_SHORE + Vector2i.UP)
+			== Gen2WorldCollision.WATER_TILE,
+		"%s: the cell the route surfs into from %s is not water." % [game_id, CITY_SURF_SHORE]
+	)
+	var lake: Dictionary = _water_region(world, CITY_DEN_WATER)
+	_check(
+		lake.has(CITY_SURF_SHORE + Vector2i.UP),
+		"%s: the shore at %s faces a different body of water than the den's." % [
+			game_id, CITY_SURF_SHORE,
+		]
+	)
+	_check(
+		world.can_walk_to(CITY_DEN_LANDFALL)
+			and _reaches(world, CITY_DEN_LANDFALL, CITY_DEN_DOOR),
+		"%s: the den landfall %s does not reach the door." % [game_id, CITY_DEN_LANDFALL]
+	)
+
+
+## The den's own lake, the whirlpool across it, and the shrine's one landfall.
+## Gold and Silver have no Dragon Shrine, so only the water is checked there.
+func _verify_dragons_den(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, DRAGONS_DEN_B1F[game_id], DEN_LADDER, [])
+	if world == null:
+		_fail("%s: Dragon's Den B1F is missing." % game_id)
+		return
+	var forced: Dictionary = Gen2WorldCollision.forced_action(
+		world.collision_code_at(DEN_WHIRLPOOL)
+	)
+	_check(
+		StringName(forced.get("kind", &"none")) == &"force_turn",
+		"%s: %s is not a whirlpool." % [game_id, DEN_WHIRLPOOL]
+	)
+	var lake: Dictionary = _water_region(world, DEN_WHIRLPOOL)
+	_check(
+		lake.has(DEN_LANDFALL + Vector2i.LEFT),
+		"%s: the shrine landfall %s is not on the whirlpool's water." % [game_id, DEN_LANDFALL]
+	)
+
+	if game_id != &"crystal":
+		_check(
+			world.warp_index_at(DEN_SHRINE_WARP) <= 0,
+			"%s has a Dragon Shrine warp, which only Crystal ships." % game_id
+		)
+		return
+	_check(
+		world.warp_index_at(DEN_SHRINE_WARP) > 0,
+		"crystal: %s is not the Dragon Shrine warp." % DEN_SHRINE_WARP
+	)
+	_check(
+		not _reaches(world, DEN_LADDER, DEN_SHRINE_WARP),
+		"crystal: the shrine is walkable from the B1F ladder."
+	)
+	_check(
+		_reaches(world, DEN_LANDFALL, DEN_SHRINE_WARP),
+		"crystal: the landfall %s does not reach the shrine." % DEN_LANDFALL
+	)
+
+
+func _open(data: GameData, id: Array, cell: Vector2i, flags: Array) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	for flag: int in flags:
+		state.set_event_flag(flag)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, id[0], id[1], cell, state)
+	if world == null:
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	for _step: int in 8:
+		if world.pending_script_input().is_empty():
+			break
+		world.run_event_queue(true)
+	return world
+
+
+## Plain walking reachability, which is what every gate above turns on. Warp
+## tiles are walls unless they are the target, the way a walked route has it:
+## stepping onto one takes it.
+func _region(world: Gen2WorldAPI, from: Vector2i, target: Vector2i = Vector2i(-1, -1)) -> Dictionary:
+	var seen: Dictionary = {from: true}
+	var frontier: Array[Vector2i] = [from]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for step: Vector2i in STEPS:
+			var next: Vector2i = cell + step
+			if seen.has(next) or not world.can_walk_to(next, step):
+				continue
+			if next != target and not world.warp_at(next).is_empty() \
+				and Gen2WorldCollision.is_warp_tile(world.collision_code_at(next)):
+				continue
+			# can_walk_to() reads the leave/enter mask at the API's own player
+			# cell; from a frontier it has to be anchored on the frontier cell,
+			# the way tools/preview_world_story.gd's _reachable_step() does.
+			var face: int = Gen2WorldCollision.face_mask_for_direction(step)
+			if face != 0 and (world.tile_permissions_at(cell) & face) != 0:
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _reaches(world: Gen2WorldAPI, from: Vector2i, target: Vector2i) -> bool:
+	return world != null and _region(world, from, target).has(target)
+
+
+func _water_region(world: Gen2WorldAPI, from: Vector2i) -> Dictionary:
+	var seen: Dictionary = {from: true}
+	var frontier: Array[Vector2i] = [from]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for step: Vector2i in STEPS:
+			var next: Vector2i = cell + step
+			if seen.has(next) \
+				or world.collision_permission_at(next) != Gen2WorldCollision.WATER_TILE:
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS rising badge: the gym pockets, 1F block changes and both crossings verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL rising badge: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_rising_badge.gd.uid
+++ b/tools/validate_rising_badge.gd.uid
@@ -1,0 +1,1 @@
+uid://4rn53geu2stx


### PR DESCRIPTION
Four of Blackthorn Gym 2F's six boulders move. The two the puzzle is about are BOULDER1 into the (8,3) hole and BOULDER3 into (8,7), whose fall scripts set the flags BlackthornGym1FBouldersCallback turns into the two changeblocks that join 1F's middle corridor to Clair's room. Neither is reachable at first: BOULDER5 on (6,1) seals the pocket holding BOULDER1, and BOULDER6 on (8,14) seals the row BOULDER3 has to be pushed along, and neither is in the stonetable or carries an event flag. Shoving each three cells clears both. BOULDER2's hole opens one 1F cell beside the entrance and reaches nothing, so it is left alone.

Clair gives no badge. Her script sets EVENT_BEAT_CLAIR and swaps the two Blackthorn gramps, which frees the shore below the Dragon's Den door; maps/DragonShrine.asm is what runs setflag ENGINE_RISINGBADGE.

Both approaches are water, not land. Blackthorn's $b2 fence line and one-way $a3 ledges wall the town centre off from the den door, and (20,4) below its shore is COLL_WATER; Dragon's Den B1F puts the shrine on the far side of its own lake with the whirlpool on (10,20) in the way and one landfall at (14,31). The decoded collision for Blackthorn City was checked cell for cell against the pinned .blk and johto_collision.asm first: it matches exactly, so the split is the map.

One source divergence met on the way: a menu answered the caller's zero-based option, but Script_verticalmenu stores wMenuCursorY and Script__2dmenu wMenuCursorPosition, both counting from one, with the zero on their carry branch being the cancel cancel_input() already wrote. The shrine's five questions are the first script on the walked route that reads the value back, and every one of them was landing on the wrong branch.

validate_rising_badge.gd pins the gates in all three games: the boulder cells and holes, the two pockets, the push column, which flag pair opens Clair's room, and both crossings. Gold and Silver ship no Dragon Shrine, so their B1F is checked to carry no warp to one.