### PR TITLE
Walk back west from the Dragon Shrine to Kanto's doorstep

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,14 @@ Headless tools, all against a real imported cache:
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |
 | `validate_rising_badge.gd` | Blackthorn Gym 2F's boulders and holes, the 1F block changes that open Clair's room, the lake crossing to the Dragon's Den door, and Dragon's Den B1F's whirlpool and shrine landfall, in all three games |
+| `validate_route_27.gd` | the forced step off a cave mouth, Route 27's sealed Kanto landfall and three seas, and the Tohjo Falls channels that need Waterfall, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route, ending at the Glacier Badge
+# the full walked route, ending on Route 27's Kanto landfall
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -140,6 +140,10 @@ const ICE_PATH_DOORS: Array = [
 	{"step": "ice_path_1f_to_blackthorn", "cell": Vector2i(36, 27)},
 ]
 
+## Route 27's landfall from New Bark Town, which is also the
+## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord pair (`maps/Route27.asm`).
+const ROUTE_27_LANDFALL: Vector2i = Vector2i(18, 10)
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
@@ -869,6 +873,10 @@ func _story_path(data: GameData) -> Dictionary:
 	var rising: Dictionary = _rising_badge_path(world, save, random, data, path)
 	if not bool(rising.get("ok", false)):
 		return rising
+
+	var kanto: Dictionary = _kanto_approach_path(world, save, random, data, path)
+	if not bool(kanto.get("ok", false)):
+		return kanto
 
 	var party_summary: Array = []
 	for mon: Gen2SaveMon in save.party:
@@ -3378,6 +3386,267 @@ func _dragon_shrine_leg(
 	)):
 		return {"ok": false, "path": path, "reason": "the Rising Badge was not given"}
 	return {"ok": true}
+
+
+## The Dragon Shrine back to New Bark Town and the first step into Kanto, on the
+## same world, state and save.
+##
+## This is where the walked route stops, and Route 27 is the wall. Its landfall
+## region reaches no map edge and no other land: row 5 is a solid cliff apart
+## from the two Tohjo Falls mouths, and both are `COLL_CAVE`, whose `.CheckTile`
+## `.warps` branch forces DOWN, so a player leaving either mouth always steps
+## south of it and the block north of the cliff can never be entered. The only
+## crossing of the channel east of the landfall starts in the pocket south of
+## the east mouth, and that pocket is reached only by leaving Tohjo Falls there,
+## which means crossing the cave. The cave cannot be crossed: its two lower
+## channels reach the pool that feeds them only by climbing `COLL_WATERFALL`
+## cells. Route 26, the Victory Road Gate badge check, Victory Road and Indigo
+## Plateau are all behind that climb, so they need HM07 and a Waterfall field
+## move. `tools/validate_route_27.gd` pins every census behind this, in all
+## three games, and `HANDOFF.md` open work has what has to land first.
+##
+## Appends to [param path] and answers only ok or the failure.
+func _kanto_approach_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var departure: Dictionary = _blackthorn_departure(world, save, random, data, path)
+	if not bool(departure.get("ok", false)):
+		return departure
+
+	return _kanto_approach(world, save, random, data, path)
+
+
+## The Dragon Shrine back to New Bark Town.
+##
+## The way out of the den is the way in reversed, and the whirlpool with it:
+## `complete_whirlpool()` is a transient block override, so the warp to the
+## shrine restored (10,20) and the water south of it reaches the shrine's
+## landfall and nothing else.
+##
+## Blackthorn's own exit is south, not west: Route 45 into Route 46 into the
+## Route 29 gate. Route 46 is walked downhill only. Its ledges leave the region
+## around the gate cells reaching no map edge at all, so a route that tried to
+## climb it from Route 29 would stop; entered from Route 45's west edge it
+## reaches the gate.
+func _blackthorn_departure(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var to_den: Dictionary = _warp_chain(world, save, random, data, [Vector2i(4, 9)])
+	if not bool(to_den.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon Shrine exit failed: %s" % to_den.get("reason", ""),
+		}
+
+	# The shrine armed SCENE_DRAGONSDENB1F_CLAIR_GIVES_TM (maps/DragonShrine.asm),
+	# so B1F's coord event at (19,30), one cell below the warp back, is Clair's
+	# TM24 gift. It is on the way out whether or not the walk asks for it.
+	var clair_tm: Dictionary = _walk_cell_resolving(
+		world, Vector2i(19, 30), save, random, data
+	)
+	path.append({
+		"step": "dragons_den_clair_tm",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": clair_tm.get("encounters", []),
+		"items": _named_items(data, world.state.items()),
+	})
+	if not bool(clair_tm.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Clair's TM scene failed: %s" % clair_tm.get("reason", ""),
+		}
+
+	var entered: Dictionary = _surf_at(
+		world, Vector2i(14, 31), Gen2WorldSprite.FACING_LEFT, save, random, data
+	)
+	if not bool(entered.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den return surf failed: %s" % entered.get("reason", ""),
+		}
+	var cleared: Dictionary = _whirlpool_at(
+		world, Vector2i(10, 21), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "dragons_den_whirlpool_return",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": cleared,
+	})
+	if not bool(cleared.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den return whirlpool failed: %s" % cleared.get("reason", ""),
+		}
+	var back_ashore: Dictionary = _walk_cell_resolving(
+		world, Vector2i(10, 7), save, random, data, true
+	)
+	path.append({
+		"step": "dragons_den_return_crossing",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+	})
+	if not bool(back_ashore.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den return crossing failed: %s" % back_ashore.get("reason", ""),
+		}
+
+	var to_town: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(20, 3), Vector2i(5, 13), Vector2i(3, 5)]
+	)
+	if not bool(to_town.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den exit failed: %s" % to_town.get("reason", ""),
+		}
+
+	# The den door's shore is still an island: the town's $b2 fence line and its
+	# one-way $a3 ledges wall off every land route, so the lake is crossed back
+	# the way it was crossed in.
+	var crossing: Dictionary = _lake_crossing(
+		world, save, random, data,
+		Vector2i(20, 3), Gen2WorldSprite.FACING_DOWN, Vector2i(22, 12)
+	)
+	path.append({
+		"step": "blackthorn_lake_crossing_return",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+	})
+	if not bool(crossing.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn return crossing failed: %s" % crossing.get("reason", ""),
+		}
+
+	for leg: Dictionary in [
+		{"step": "blackthorn_to_route_45", "direction": "south", "group": 5, "number": 8},
+		{"step": "route_45_to_route_46", "direction": "west", "group": 5, "number": 9},
+	]:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, String(leg["direction"]), int(leg["group"]), int(leg["number"]),
+			save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": String(leg["step"]),
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+
+	# Route 46's south connection to Route 29 exists in the map attributes but
+	# the gate building stands on it: Route 29's north edge is unreachable from
+	# inside the map, and its (27,1) is the gate's own warp.
+	var gate: Dictionary = _gate_leg(world, save, random, data, Vector2i(7, 33), 24, 3)
+	path.append({
+		"step": "route_46_to_route_29_gate",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+	})
+	if not bool(gate.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 29 gate failed: %s" % gate.get("reason", ""),
+		}
+
+	var to_new_bark: Dictionary = _walk_connection_resolving(
+		world, "east", 24, 4, save, random, data
+	)
+	var new_bark_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "route_29_to_new_bark_town",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": to_new_bark.get("encounters", []),
+		"run": new_bark_entry,
+	})
+	if not bool(to_new_bark.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 29 to New Bark failed: %s" % to_new_bark.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## New Bark Town to Route 27's landfall, which is as far east as the route goes.
+##
+## New Bark's east column is wall except the four water rows 6 to 9, so leaving
+## town east is a crossing rather than a step. The far side is still water, so
+## one water-only walk comes ashore on ROUTE_27_LANDFALL, one of the two
+## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord cells, and the scene runs on
+## arrival. _kanto_approach_path() has why the walk stops here.
+func _kanto_approach(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var entered: Dictionary = _surf_at(
+		world, Vector2i(17, 8), Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	if not bool(entered.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "New Bark surf entry failed: %s" % entered.get("reason", ""),
+		}
+	var crossed: Dictionary = _walk_connection_resolving(
+		world, "east", 24, 2, save, random, data, true
+	)
+	var entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	var ashore: Dictionary = {}
+	if bool(crossed.get("ok", false)):
+		ashore = _walk_cell_resolving(world, ROUTE_27_LANDFALL, save, random, data, true)
+	path.append({
+		"step": "new_bark_town_to_route_27",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+		"encounters": crossed.get("encounters", []),
+		"landfall_encounters": ashore.get("encounters", []),
+		"run": entry,
+	})
+	if not bool(crossed.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "New Bark to Route 27 failed: %s" % crossed.get("reason", ""),
+		}
+	if not bool(ashore.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 27 landfall failed: %s" % ashore.get("reason", ""),
+		}
+	if world.player_cell != ROUTE_27_LANDFALL:
+		return {
+			"ok": false, "path": path,
+			"reason": "the Kanto scene left the player on %s" % world.player_cell,
+		}
+	return {"ok": true}
+
 
 
 ## _push_boulder_at() for a boulder that may land on a `stonetable` pit: the

--- a/tools/validate_route_27.gd
+++ b/tools/validate_route_27.gd
@@ -1,0 +1,283 @@
+extends SceneTree
+
+## Verifies why the walked route stops on Route 27, against freshly imported
+## real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `maps/Route27.asm`, `maps/TohjoFalls.asm` and
+## `engine/overworld/player_movement.asm`. `TohjoFalls.blk` is byte identical
+## between the pins; `Route27.blk` is not, so its land census is profile split
+## while every water figure happens to match.
+##
+## The claim being pinned is a negative one, and negative claims rot quietly.
+## Route 27's landfall region reaches no map edge; the only crossing of the
+## channel east of it starts in a pocket that can only be left through Tohjo
+## Falls; and the cave's two lower channels reach each other only over
+## `COLL_WATERFALL` cells, which `.CheckTile` will only ever step a player down.
+## So Route 26 and everything past it need HM07 and a Waterfall field move. When
+## one lands, this tool is what says so.
+##
+##   Godot --headless -s res://tools/validate_route_27.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## data/maps/maps.asm group/number pairs. Route 27 sits at the same pair in both
+## games; Crystal's own extra maps push Tohjo Falls nine places down the
+## Dungeons group.
+const ROUTE_27: Array = [24, 2]
+const TOHJO_FALLS: Dictionary = {
+	&"gold": [3, 74],
+	&"silver": [3, 74],
+	&"crystal": [3, 83],
+}
+
+## Route 27. The landfall is the cell a surf from New Bark Town comes ashore on,
+## and one of the two SCENE_ROUTE27_FIRST_STEP_INTO_KANTO coord cells. The two
+## mouths are Tohjo Falls' doors, the pocket is the cell below the east mouth,
+## and the shore is the pocket's own edge on the channel.
+const LANDFALL: Vector2i = Vector2i(18, 10)
+const WEST_MOUTH: Vector2i = Vector2i(26, 5)
+const EAST_MOUTH: Vector2i = Vector2i(36, 5)
+const EAST_POCKET: Vector2i = Vector2i(36, 6)
+const POCKET_SHORE: Vector2i = Vector2i(39, 6)
+const LANDFALL_WATER: Vector2i = Vector2i(18, 9)
+const CHANNEL_WATER: Vector2i = Vector2i(42, 6)
+const EAST_WATER: Vector2i = Vector2i(79, 8)
+
+## Route 27's three water bodies, identical in both pins: the sea New Bark's
+## crossing arrives on, the channel the east pocket surfs, and the sea on the
+## Route 26 edge.
+const WEST_SEA_CELLS: int = 120
+const CHANNEL_CELLS: int = 48
+const EAST_SEA_CELLS: int = 12
+
+## Tohjo Falls. The two lower channels each touch their own door's land, and the
+## pool is what the waterfalls fall from.
+const WEST_CHANNEL: Vector2i = Vector2i(9, 14)
+const EAST_CHANNEL: Vector2i = Vector2i(21, 14)
+const POOL: Vector2i = Vector2i(12, 4)
+const WEST_CHANNEL_CELLS: int = 40
+const EAST_CHANNEL_CELLS: int = 34
+const POOL_CELLS: int = 144
+## TILESET_CAVE block $2c is four WATERFALL quadrants and the cave writes ten of
+## them (`data/tilesets/cave_collision.asm`). COLL_WATERFALL is $33.
+const COLL_WATERFALL: int = 0x33
+const WATERFALL_CELLS: int = 40
+
+const STEPS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	_verify_forced_tiles()
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_route_27(data, game_id)
+		_verify_tohjo_falls(data, game_id)
+	_finish()
+
+
+## `.CheckTile`'s `.warps` branch: four codes force a step DOWN and every other
+## $7x falls through to `.no_walk`. That one table is what makes a cave mouth a
+## one-way doorway, so a player leaving one always ends south of it.
+func _verify_forced_tiles() -> void:
+	for code: int in [
+		Gen2WorldCollision.COLL_DOOR, Gen2WorldCollision.COLL_DOOR_79,
+		Gen2WorldCollision.COLL_STAIRCASE, Gen2WorldCollision.COLL_CAVE,
+	]:
+		var forced: Dictionary = Gen2WorldCollision.forced_action(code)
+		_check(
+			StringName(forced.get("kind", &"none")) == &"walk"
+				and forced.get("direction", Vector2i.ZERO) == Vector2i.DOWN,
+			"$%02x does not force a step down, so a cave mouth is not one-way." % code
+		)
+	for code: int in range(0x70, 0x80):
+		if Gen2WorldCollision.WARP_STEP_CODES.has(code):
+			continue
+		_check(
+			StringName(Gen2WorldCollision.forced_action(code).get("kind", &"none")) == &"none",
+			"$%02x forces a step, but .warps accepts only four codes." % code
+		)
+
+
+## The landfall region is sealed, and the pocket that could leave it is on the
+## far side of a cave door.
+func _verify_route_27(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, ROUTE_27, LANDFALL)
+	if world == null:
+		_fail("%s: Route 27 is missing." % game_id)
+		return
+	var size: Vector2i = world.map_size_cells()
+
+	for mouth: Vector2i in [WEST_MOUTH, EAST_MOUTH]:
+		_check(
+			world.collision_code_at(mouth) == Gen2WorldCollision.COLL_CAVE
+				and not world.warp_at(mouth).is_empty(),
+			"%s: Route 27's mouth at %s is not a COLL_CAVE warp." % [game_id, mouth]
+		)
+
+	var region: Dictionary = _region(world, LANDFALL)
+	var on_edge: bool = false
+	for y: int in size.y:
+		on_edge = on_edge or region.has(Vector2i(size.x - 1, y))
+	_check(
+		not on_edge,
+		"%s: Route 27's landfall region reaches the Route 26 edge on foot." % game_id
+	)
+	_check(
+		not region.has(EAST_POCKET) and not region.has(POCKET_SHORE),
+		"%s: Route 27's landfall region reaches the east pocket without the cave." % game_id
+	)
+
+	# Surfing does not get around it either: the sea the crossing from New Bark
+	# arrives on touches neither the channel nor the Route 26 edge.
+	var west_sea: Dictionary = _swim(world, LANDFALL_WATER)
+	_check(
+		west_sea.size() == WEST_SEA_CELLS,
+		"%s: Route 27's west sea is %d cells, not the pinned %d." % [
+			game_id, west_sea.size(), WEST_SEA_CELLS,
+		]
+	)
+	_check(
+		not west_sea.has(CHANNEL_WATER) and not west_sea.has(EAST_WATER),
+		"%s: Route 27's west sea reaches the channel or the east sea." % game_id
+	)
+	_check(
+		_swim(world, CHANNEL_WATER).size() == CHANNEL_CELLS,
+		"%s: Route 27's channel is not %d cells." % [game_id, CHANNEL_CELLS]
+	)
+	_check(
+		_swim(world, EAST_WATER).size() == EAST_SEA_CELLS,
+		"%s: Route 27's east sea is not %d cells." % [game_id, EAST_SEA_CELLS]
+	)
+
+
+## The cave the pocket is behind cannot be crossed: its two lower channels only
+## ever receive the pool, never reach it.
+func _verify_tohjo_falls(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, TOHJO_FALLS[game_id], WEST_CHANNEL)
+	if world == null:
+		_fail("%s: Tohjo Falls is missing." % game_id)
+		return
+	var size: Vector2i = world.map_size_cells()
+
+	var waterfalls: int = 0
+	for y: int in size.y:
+		for x: int in size.x:
+			if world.collision_code_at(Vector2i(x, y)) == COLL_WATERFALL:
+				waterfalls += 1
+	_check(
+		waterfalls == WATERFALL_CELLS,
+		"%s: Tohjo Falls has %d waterfall cells, not the pinned %d." % [
+			game_id, waterfalls, WATERFALL_CELLS,
+		]
+	)
+
+	var west: Dictionary = _swim(world, WEST_CHANNEL)
+	var east: Dictionary = _swim(world, EAST_CHANNEL)
+	var pool: Dictionary = _swim(world, POOL)
+	_check(
+		west.size() == WEST_CHANNEL_CELLS and east.size() == EAST_CHANNEL_CELLS
+			and pool.size() == POOL_CELLS,
+		"%s: Tohjo Falls' bodies are %d/%d/%d, not the pinned %d/%d/%d." % [
+			game_id, west.size(), east.size(), pool.size(),
+			WEST_CHANNEL_CELLS, EAST_CHANNEL_CELLS, POOL_CELLS,
+		]
+	)
+	_check(
+		not west.has(EAST_CHANNEL) and not west.has(POOL),
+		"%s: Tohjo Falls' west channel climbs out without Waterfall." % game_id
+	)
+	_check(
+		not east.has(WEST_CHANNEL) and not east.has(POOL),
+		"%s: Tohjo Falls' east channel climbs out without Waterfall." % game_id
+	)
+	_check(
+		pool.has(WEST_CHANNEL) and pool.has(EAST_CHANNEL),
+		"%s: Tohjo Falls' pool does not fall into both channels." % game_id
+	)
+
+
+func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, id[0], id[1], cell, Gen2WorldState.new())
+	if world == null:
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	for _step: int in 8:
+		if world.pending_script_input().is_empty():
+			break
+		world.run_event_queue(true)
+	return world
+
+
+## Plain walking reachability, the way tools/preview_world_story.gd's
+## _reachable_step() has it: a warp tile is a wall, because stepping onto one
+## takes it.
+func _region(world: Gen2WorldAPI, from: Vector2i) -> Dictionary:
+	var seen: Dictionary = {from: true}
+	var frontier: Array[Vector2i] = [from]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for step: Vector2i in STEPS:
+			var next: Vector2i = cell + step
+			if seen.has(next) or not world.can_walk_to(next, step):
+				continue
+			if not world.warp_at(next).is_empty() \
+				and Gen2WorldCollision.is_warp_tile(world.collision_code_at(next)):
+				continue
+			var face: int = Gen2WorldCollision.face_mask_for_direction(step)
+			if face != 0 and (world.tile_permissions_at(cell) & face) != 0:
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+## Surfing reachability with the source `.CheckTile` rule applied: a player
+## standing on a waterfall cell has the pressed direction discarded and is
+## stepped down, so a waterfall is an edge that only ever points one way.
+func _swim(world: Gen2WorldAPI, from: Vector2i) -> Dictionary:
+	var seen: Dictionary = {from: true}
+	var frontier: Array[Vector2i] = [from]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		var forced: Dictionary = Gen2WorldCollision.forced_action(world.collision_code_at(cell))
+		for step: Vector2i in STEPS:
+			if StringName(forced.get("kind", &"none")) == &"walk" \
+				and forced.get("direction", Vector2i.ZERO) != step:
+				continue
+			var next: Vector2i = cell + step
+			if seen.has(next) \
+				or world.collision_permission_at(next) != Gen2WorldCollision.WATER_TILE:
+				continue
+			var face: int = Gen2WorldCollision.face_mask_for_direction(step)
+			if face != 0 and (world.tile_permissions_at(cell) & face) != 0:
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS route 27: the landfall is sealed and Tohjo Falls needs Waterfall.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL route 27: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_route_27.gd.uid
+++ b/tools/validate_route_27.gd.uid
@@ -1,0 +1,1 @@
+uid://detgghph707j8


### PR DESCRIPTION
Extends the story route past the Rising Badge: out of the Dragon's Den for Clair's TM24, back over the lake, south down Routes 45 and 46 to the Route 29 gate, and a last surf east out of New Bark onto Route 27's Kanto landfall. 156 steps, eight badges.

The route stops there because the leg past it needs Waterfall. validate_route_27.gd pins why in all three games: the landfall's region reaches no map edge, its sea touches neither the channel nor the Route 26 edge, both Tohjo Falls mouths are COLL_CAVE and .CheckTile forces a step down off them, and the cave's two lower channels reach the pool that feeds them only by climbing COLL_WATERFALL cells.