### PR TITLE
Climb Tohjo Falls and walk on to Indigo Plateau

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,15 @@ Pokedex, Player and Options appear in their source position but do nothing yet.
 The Pack opens each item's own source submenu and can use one: a Potion asks
 which Pokemon and heals it, a Repel sets its step count, and GIVE, TOSS and SEL
 keep their source position marked unavailable.
-The party submenu offers Cut, Surf and Whirlpool to a Pokemon that knows one; all
-three show their message first and change the world on the acknowledge, and
-stepping from water back onto land stops surfing. Standing on a whirlpool,
-waterfall, door, staircase or cave tile overrides the pressed direction the way
-the cartridge does.
+The party submenu offers Cut, Surf, Strength, Whirlpool and Waterfall to a
+Pokemon that knows one; all five show their message first and change the world
+on the acknowledge, and stepping from water back onto land stops surfing. A
+Waterfall climb runs the whole column in one command and ends on the first cell
+above it that is not a waterfall. Standing on a whirlpool, waterfall, door,
+staircase or cave tile overrides the pressed direction the way the cartridge
+does, which is also how a waterfall is ridden back down.
+Poké Balls on the ground are picked up by facing them: an item ball's pointer is
+item data rather than a script, so it is decoded and its item received.
 The imported Players House PC opens the embedded box storage screen. The host
 clock advances one game minute per real minute and crosses source day
 boundaries. `preview_emote()`, `preview_wild_encounter()`,
@@ -204,14 +208,15 @@ Headless tools, all against a real imported cache:
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |
 | `validate_rising_badge.gd` | Blackthorn Gym 2F's boulders and holes, the 1F block changes that open Clair's room, the lake crossing to the Dragon's Den door, and Dragon's Den B1F's whirlpool and shrine landfall, in all three games |
-| `validate_route_27.gd` | the forced step off a cave mouth, Route 27's sealed Kanto landfall and three seas, and the Tohjo Falls channels that need Waterfall, in all three games |
+| `validate_route_27.gd` | the forced step off a cave mouth, Route 27's sealed Kanto landfall and three seas, and the Tohjo Falls climb and ride back down, in all three games |
+| `validate_item_balls.gd` | Ice Path 1F's HM07 and Route 44's balls decoding from the `itemball` macro and reaching the bag, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route, ending on Route 27's Kanto landfall
+# the full walked route, ending at the Indigo Plateau Pokemon Center
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -99,6 +99,9 @@ var _pending_whirlpool: Dictionary = {}
 ## Script_StrengthFromMenu and runs it at once, so a request cannot outlive the
 ## map it was made on.
 var _pending_strength: Dictionary = {}
+## The same for Waterfall, held while Script_UsedWaterfall shows its text. It
+## names the faced cell, so it is cleared with the loaded map like the rest.
+var _pending_waterfall: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
@@ -650,6 +653,93 @@ func complete_whirlpool() -> Dictionary:
 
 static func _whirlpool_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"whirlpool_failed", "reason": reason}
+
+
+## engine/events/overworld.asm's WaterfallFunction .TryWaterfall, staged the way
+## the other four are: Script_UsedWaterfall shows _UseWaterfallText and waits on
+## its button before the first climbing step, so nothing moves until the commit.
+##
+## .TryWaterfall is CheckBadge ENGINE_RISINGBADGE, then CheckMapCanWaterfall,
+## which is two tests and no more: `wPlayerDirection & $c` must be FACE_UP, and
+## wTileUp must satisfy CheckWaterfallTile. It reads no player state, so like
+## .TryWhirlpool it neither requires nor refuses surfing, and its refusal is
+## FieldMoveFailed's generic _CantUseItemText rather than a move-specific line.
+func waterfall_request() -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return _waterfall_failure(&"missing_map")
+	if not _pending_waterfall.is_empty():
+		return _waterfall_failure(&"waterfall_in_progress")
+	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_RISING, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return _waterfall_failure(&"badge_required")
+	## CheckMapCanWaterfall tests the facing before the tile, and only FACE_UP
+	## passes: a waterfall faced from any other direction is not climbable even
+	## though the same cell would answer the tile test.
+	if player_facing != Gen2WorldSprite.FACING_UP:
+		return _waterfall_failure(&"wrong_facing")
+	var target: Vector2i = facing_cell()
+	if not Gen2WorldFieldMove.waterfall_tile(collision_code_at(target)):
+		return _waterfall_failure(&"nothing_to_climb")
+	_pending_waterfall = {
+		"ok": true,
+		"kind": &"waterfall_requested",
+		"move": Gen2WorldFieldMove.MOVE_WATERFALL,
+		"cell": target,
+	}
+	return _pending_waterfall.duplicate(true)
+
+
+## Empty until waterfall_request() succeeds. A host shows its text while this is set.
+func pending_waterfall() -> Dictionary:
+	return _pending_waterfall.duplicate(true)
+
+
+## Script_UsedWaterfall's loop: `applymovement PLAYER, .WaterfallStep` is one
+## `turn_waterfall UP`, and `.CheckContinueWaterfall` repeats it while the cell
+## the player now stands on still answers CheckWaterfallTile. So the climb ends
+## on the first cell above the column that is not a waterfall, however tall it
+## is, and the whole run is one command rather than a step the caller paces.
+##
+## Each step is an applymovement, so it consults no collision, spends no repel
+## step and rolls no encounter, exactly as complete_surf()'s single slow_step
+## does. The landing does re-derive the player state, the way a warp does:
+## CheckUpdatePlayerSprite keeps surfing on water and restores walking anywhere
+## else, which is what puts a climber ashore on the ledge above.
+func complete_waterfall() -> Dictionary:
+	if _pending_waterfall.is_empty():
+		return _waterfall_failure(&"no_pending_waterfall")
+	var request: Dictionary = _pending_waterfall
+	_pending_waterfall = {}
+	var size: Vector2i = map_size_cells()
+	var cell: Vector2i = player_cell
+	var climbed: int = 0
+	## The column is bounded by the map, and MAX_CLIMB is that bound rather than
+	## a guess: a stream that never left a waterfall would otherwise not end.
+	while climbed < size.y:
+		var next: Vector2i = cell + Vector2i.UP
+		if next.y < 0:
+			return _waterfall_failure(&"climb_left_the_map")
+		cell = next
+		climbed += 1
+		if not Gen2WorldFieldMove.waterfall_tile(collision_code_at(cell)):
+			break
+	if climbed <= 0 or Gen2WorldFieldMove.waterfall_tile(collision_code_at(cell)):
+		return _waterfall_failure(&"climb_did_not_finish")
+	player_cell = cell
+	_apply_map_setup_player_state()
+	return {
+		"ok": true,
+		"kind": &"waterfall_applied",
+		"move": int(request["move"]),
+		"cell": cell,
+		"steps": climbed,
+		"movement_mode": movement_mode,
+	}
+
+
+static func _waterfall_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"waterfall_failed", "reason": reason}
 
 
 ## engine/events/overworld.asm's StrengthFunction .TryStrength, staged the way
@@ -1794,7 +1884,45 @@ func _enqueue_script_events(events: Array) -> void:
 		var trainer_request: Dictionary = _trainer_request_for_event(event)
 		if not trainer_request.is_empty():
 			request = trainer_request
+		var item_ball_request: Dictionary = _item_ball_request_for_event(event)
+		if not item_ball_request.is_empty():
+			request = item_ball_request
 		_enqueue_script(request)
+
+
+## ObjectEventTypeArray's `.itemball` (engine/overworld/events.asm): an item
+## ball's script pointer is not a script. The two bytes it points at are the
+## `itemball` macro's `db item, quantity`, copied into `wItemBallData`, and what
+## runs is PLAYEREVENT_ITEMBALL's FindItemInBallScript. Decoding them here is
+## what keeps the runner from parsing item data as opcodes.
+func _item_ball_request_for_event(event: Dictionary) -> Dictionary:
+	if event.get("kind", &"") != &"objects" or current_map == null or data == null:
+		return {}
+	var object_index: int = int(event.get("object_index", -1))
+	if object_index < 0 or object_index >= objects.size():
+		return {}
+	var object: Gen2WorldObject = objects[object_index]
+	if object.object_type != Gen2WorldObject.OBJECTTYPE_ITEMBALL:
+		return {}
+	var pointer: int = int(event.get("script", object.event_script))
+	if pointer <= 0:
+		return {}
+	var bank: int = int(current_map.events.get("bank", 0))
+	var raw: PackedByteArray = data.world_script(bank, pointer)
+	if raw.size() < 2 or int(raw[0]) <= 0:
+		return {}
+	return {
+		"kind": &"item_ball",
+		"map_group": current_map.group,
+		"map_number": current_map.number,
+		"cell": object.cell,
+		"bank": bank,
+		"script": pointer,
+		"object_index": object.index,
+		"event": event.duplicate(true),
+		"item": int(raw[0]),
+		"quantity": maxi(1, int(raw[1])),
+	}
 
 
 func _trainer_request_for_event(event: Dictionary) -> Dictionary:
@@ -3116,6 +3244,7 @@ func _apply_map(
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
 	_pending_strength.clear()
+	_pending_waterfall.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
 	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
@@ -3160,6 +3289,7 @@ func reload_current_map() -> Dictionary:
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
 	_pending_strength.clear()
+	_pending_waterfall.clear()
 	state.reset_map_reload_flags()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -251,6 +251,11 @@ const HI_NYBBLE_WALK_ALT: int = 0x50
 const HI_NYBBLE_WARPS: int = 0x70
 const COLL_WHIRLPOOL: int = 0x24
 const COLL_WHIRLPOOL_2C: int = 0x2C
+## The two codes home/map_objects.asm's CheckWaterfallTile compares. The second
+## is marked unused in both pins and kept for the same reason the whole
+## permission table is: the source compares it.
+const COLL_WATERFALL: int = 0x33
+const COLL_CURRENT_DOWN: int = 0x3B
 const COLL_DOOR: int = 0x71
 const COLL_DOOR_79: int = 0x79
 const COLL_STAIRCASE: int = 0x7A

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -7,7 +7,7 @@ extends RefCounted
 ## Cut, Surf, Strength and Whirlpool are resolved here. Cut, Surf and Whirlpool
 ## follow the shape CutFunction defines: check the badge, then check the faced
 ## tile, then stage a change the text acknowledge commits. Strength is the odd
-## one, see BADGE_PLAIN. Waterfall, Flash and Headbutt are not resolved yet.
+## one, see BADGE_PLAIN. Flash and Headbutt are not resolved yet.
 
 ## constants/move_constants.asm, whose comment column is hex. The submenu, not
 ## CutFunction, SurfFunction or WhirlpoolFunction, is what checks a party Pokemon
@@ -16,6 +16,7 @@ const MOVE_CUT: int = 0x0F
 const MOVE_SURF: int = 0x39
 const MOVE_STRENGTH: int = 0x46
 const MOVE_WHIRLPOOL: int = 0xFA
+const MOVE_WATERFALL: int = 0x7F
 
 ## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
 ## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
@@ -31,6 +32,9 @@ const BADGE_HIVE: int = 1
 const BADGE_PLAIN: int = 2
 const BADGE_FOG: int = 3
 const BADGE_GLACIER: int = 6
+## WaterfallFunction's .TryWaterfall, whose CheckBadge argument is
+## ENGINE_RISINGBADGE: 34 in Crystal and 33 in Gold/Silver.
+const BADGE_RISING: int = 7
 
 ## GetSurfType's comparison, constants/pokemon_constants.asm.
 const SPECIES_PIKACHU: int = 0x19
@@ -45,7 +49,9 @@ const MUSIC_SURF: int = 0x21
 ## Both pins ship the same rows, so this needs no profile split. IsFieldMove
 ## decides submenu membership from this list alone, so a move stops appearing
 ## the moment it leaves it.
-const FIELD_MOVES: Array[int] = [MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL]
+const FIELD_MOVES: Array[int] = [
+	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL,
+]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of
 ## the six block ($12, $1a); the four grass codes are LAND_TILE and cuttable
@@ -186,3 +192,20 @@ static func whirlpool_replacement(tileset: int, block: int) -> Dictionary:
 	if row == null:
 		return {"ok": false}
 	return {"ok": true, "block": int(row[0]), "animation": int(row[1])}
+
+
+## home/map_objects.asm's CheckWaterfallTile, which CheckMapCanWaterfall applies
+## to wTileUp. COLL_CURRENT_DOWN is in the table beside COLL_WATERFALL and is
+## marked unused in both pins; it is kept because the source compares both and a
+## list of interesting codes that quietly drops one is how a table rots.
+const WATERFALL_COLLISIONS: Array[int] = [
+	Gen2WorldCollision.COLL_WATERFALL,
+	Gen2WorldCollision.COLL_CURRENT_DOWN,
+]
+
+
+## CheckWaterfallTile: whether [param collision_code] is one Waterfall climbs.
+## Unlike Cut and Whirlpool this needs no block table, because Waterfall changes
+## no block. It moves the player and nothing else.
+static func waterfall_tile(collision_code: int) -> bool:
+	return WATERFALL_COLLISIONS.has(collision_code)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -31,6 +31,9 @@ const SFX_WHIRLPOOL: int = 0x53
 ## constants/sfx_constants.asm's SFX_STRENGTH, played by MovementFunction_Strength
 ## as a pushed boulder starts moving, not by the menu that sets the flag.
 const SFX_STRENGTH: int = 0x1B
+## constants/sfx_constants.asm's SFX_BUBBLEBEAM, which Script_UsedWaterfall plays
+## after its text and before the first climbing step.
+const SFX_WATERFALL: int = 0x51
 
 @export var map_group: int = 24
 @export var map_number: int = 3
@@ -1451,6 +1454,14 @@ func _on_party_action(action: Dictionary) -> void:
 				)
 				return
 			_show_field_move_text("%s used WHIRLPOOL!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_WATERFALL:
+			var waterfall: Dictionary = _world.waterfall_request()
+			if not bool(waterfall.get("ok", false)):
+				_show_field_move_text(
+					_waterfall_refusal(StringName(waterfall.get("reason", &"")))
+				)
+				return
+			_show_field_move_text("%s used WATERFALL!" % String(action.get("name", "")))
 		_:
 			_show_field_move_text("Can't use that here.")
 
@@ -1498,6 +1509,15 @@ func _whirlpool_refusal(reason: StringName) -> String:
 	return "Can't use that here."
 
 
+## .TryWaterfall refuses through FieldMoveFailed, whose text is the generic
+## _CantUseItemText, so only the badge has a line of its own; CheckMapCanWaterfall
+## has no message at all.
+func _waterfall_refusal(reason: StringName) -> String:
+	if reason == &"badge_required":
+		return "Sorry! A new BADGE is required."
+	return "Can't use that here."
+
+
 ## .TryStrength's only refusal is CheckBadge's, since it checks nothing else;
 ## anything past it is this project's own guard, not a cartridge branch.
 func _strength_refusal(reason: StringName) -> String:
@@ -1540,15 +1560,19 @@ func _acknowledge_field_move_text() -> void:
 	if not _world.pending_strength().is_empty():
 		_commit_field_move(_world.complete_strength(), "Strength")
 		return
+	if not _world.pending_waterfall().is_empty():
+		_commit_field_move(_world.complete_waterfall(), "Waterfall")
+		return
 	_script_prompt = ""
 	_refresh_labels()
 
 
-## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN, Whirlpool plays SFX_SURF and Surf
-## changes the music, so each commit reports its own audio. Strength is the one
-## that plays nothing: Script_UsedStrength has no PlaySFX, because SFX_STRENGTH
-## belongs to the boulder that moves later, not to the flag being set. All four
-## redraw anyway, since the party overlay closed over the map.
+## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN, Whirlpool plays SFX_SURF, Waterfall
+## plays SFX_BUBBLEBEAM and Surf changes the music, so each commit reports its
+## own audio. Strength is the one that plays nothing: Script_UsedStrength has no
+## PlaySFX, because SFX_STRENGTH belongs to the boulder that moves later, not to
+## the flag being set. All five redraw anyway, since the party overlay closed
+## over the map.
 func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
 		match StringName(applied.get("kind", &"")):
@@ -1558,6 +1582,8 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 				_play_sfx(SFX_WHIRLPOOL)
 			&"strength_applied":
 				pass
+			&"waterfall_applied":
+				_play_sfx(SFX_WATERFALL)
 			_:
 				_play_sfx(SFX_CUT)
 		if _renderer != null:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -97,6 +97,11 @@ const STRENGTH_ASK_TEXT: String = \
 	"A #MON may be\nable to move this.\n\nWant to use\nSTRENGTH?"
 const STRENGTH_MAY_MOVE_TEXT: String = "A #MON may be\nable to move this."
 const STRENGTH_BOULDERS_MOVE_TEXT: String = "Boulders may now\nbe moved!"
+## data/text/common_2.asm's _FoundItemText, less its <PLAYER>; see
+## _stage_item_ball(). The source line break sits before the item name.
+const FOUND_ITEM_TEXT: String = "Found\n%s!"
+## The `disappear LAST_TALKED` operand (constants/map_object_constants.asm).
+const LAST_TALKED: int = 0xFE
 ## wBattleResult, which startbattle copies into wScriptVar
 ## (constants/battle_constants.asm).
 const BATTLE_RESULT_WIN: int = 0
@@ -166,6 +171,14 @@ static func begin(
 		## approaches.
 		runner._trainer_intro_approach_pending = request.get("direction", Vector2i.ZERO) \
 			in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+	elif StringName(request.get("kind", &"")) == &"item_ball":
+		## The pointer is item data, not code, so the frame that stands in for it
+		## is a bare `end` and _stage_item_ball() replays FindItemInBallScript.
+		started = runner._push_frame(bank, address, PackedByteArray([
+			Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_END, runner._crystal_commands())
+		]))
+		if started:
+			runner._stage_item_ball()
 	else:
 		started = runner._push_frame(bank, address)
 	if not started:
@@ -1945,6 +1958,43 @@ func _stage_strength_boulder() -> Dictionary:
 	}
 	_finish_after_pending = false
 	return {"ok": true}
+
+
+## engine/events/misc_scripts.asm's FindItemInBallScript, synthesized.
+##
+## An item ball's script pointer is not code: it is the `itemball` macro's
+## `db item, quantity`, which `ObjectEventTypeArray.itemball` copies into
+## wItemBallData before raising PLAYEREVENT_ITEMBALL. So the seam is the object
+## type, not a script address, and Gen2WorldAPI hands the two decoded bytes over
+## as an item_ball request. The script's own first command is `callasm
+## .TryReceiveItem` and both its texts are engine text rather than map text, so
+## the body is replayed here the way AskStrengthScript's is.
+##
+## Source order is receive, `disappear LAST_TALKED`, then the text, so the ball
+## is already gone when the box is drawn. `itemnotify` is the `item_changed`
+## event _stage_item_delta() emits.
+##
+## Two boundaries. `.no_room` cannot be reached: ReceiveItem refuses on a full
+## pocket and this project models per-item counts with no pocket capacity. And
+## `_FoundItemText` names <PLAYER>, which the scene-free runner has no route to,
+## the way the strength texts have none either.
+func _stage_item_ball() -> Dictionary:
+	var item: int = int(_request.get("item", 0))
+	var quantity: int = maxi(1, int(_request.get("quantity", 1)))
+	if item <= 0:
+		return _fail(&"invalid_item_ball", {"item": item, "quantity": quantity})
+	_stage_item_delta(item, quantity)
+	_emit_object_event(&"object_visibility", {
+		"object_index": _last_talked_object_index, "active": false,
+	})
+	_emit_object_event(&"object_event_flag", {
+		"object_index": _last_talked_object_index, "active": true,
+	})
+	_stage_object_event_flag(LAST_TALKED, true)
+	var item_name: String = data.item_name(item) if data != null else ""
+	if item_name.is_empty():
+		item_name = "ITEM"
+	return _stage_internal_text(FOUND_ITEM_TEXT % item_name, true)
 
 
 ## CheckPartyMove: the first slot whose move list carries [param move], or -1.

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -77,13 +77,13 @@ func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
 	assert_false(Gen2MoveForget.is_hm_move(0))
 
 
-## The overworld's field-move list is a different, shorter question: Fly, Flash
-## and Waterfall are HMs that this project does not act on, and forgetting is
-## gated on all seven regardless.
+## The overworld's field-move list is a different, shorter question: Fly and
+## Flash are HMs that this project does not act on, and forgetting is gated on
+## all seven regardless.
 func test_the_hm_list_is_wider_than_the_overworld_field_moves() -> void:
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
 		assert_true(Gen2MoveForget.is_hm_move(move), "field move %d" % move)
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 4)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 5)
 	assert_true(Gen2MoveForget.is_hm_move(0x13), "FLY is an HM with no field effect here")
 	assert_false(Gen2WorldFieldMove.FIELD_MOVES.has(0x13))
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4064,3 +4064,57 @@ func test_advance_forced_movement_moves_without_a_pressed_direction() -> void:
 	assert_true(bool(forced.get("ok", false)), JSON.stringify(forced))
 	assert_eq(world.player_cell, Vector2i(1, 6))
 	assert_true(world.advance_forced_movement().is_empty())
+
+
+## ObjectEventTypeArray's `.itemball` copies `db item, quantity` into
+## wItemBallData rather than running it, so the pointer must never reach the
+## script runner as code.
+func test_an_item_ball_is_dispatched_from_its_two_data_bytes() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# itemball ITEM3, 2. Byte $02 is `iffalse` and $91 `end`, so a runner that
+	# parsed these as code would branch, not hand over an item.
+	scripts["48:6030"] = [3, 2, 0x91]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+
+	var world: Gen2WorldAPI = _world(Vector2i(5, 5))
+	var ball: Gen2WorldObject = world.objects[0]
+	ball.object_type = Gen2WorldObject.OBJECTTYPE_ITEMBALL
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+	var results: Array = world.interact()
+	assert_eq(results.size(), 1, JSON.stringify(results))
+	assert_eq(results[0]["source"]["kind"], &"item_ball")
+	assert_eq(results[0]["source"]["item"], 3)
+	assert_eq(results[0]["source"]["quantity"], 2)
+	# FindItemInBallScript receives before it shows anything, and the text names
+	# the item off the imported table, whose lookup is one-based like the source's.
+	assert_eq(results[0]["status"], &"waiting", JSON.stringify(results[0]))
+	assert_eq(results[0]["event"]["text"], "Found\n%s!" % _item_name(3))
+
+	var finished: Array = world.run_event_queue(true)
+	assert_eq(finished[0]["status"], &"complete", JSON.stringify(finished[0]))
+	assert_eq(world.state.items().get(3, 0), 2)
+	# `disappear LAST_TALKED` writes the ball's own event flag, so it stays gone.
+	assert_true(world.event_flag_active(7))
+	assert_false((world.objects[0] as Gen2WorldObject).active)
+
+
+func test_an_item_ball_with_no_item_byte_fails_instead_of_running_data() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6030"] = [0, 0, 0x91]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+
+	var world: Gen2WorldAPI = _world(Vector2i(5, 5))
+	var ball: Gen2WorldObject = world.objects[0]
+	ball.object_type = Gen2WorldObject.OBJECTTYPE_ITEMBALL
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+	# A zero item is not an item ball the cache can answer, so the typed request
+	# is not built and the object falls back to its own pointer.
+	var results: Array = world.interact()
+	assert_eq(results.size(), 1, JSON.stringify(results))
+	assert_ne(results[0]["source"]["kind"], &"item_ball")
+
+
+func _item_name(number: int) -> String:
+	return GameData.open_directory(_directory).item_name(number)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -56,6 +56,13 @@ const WHIRLPOOL_BLOCK: Vector2i = Vector2i(3, 3)
 const WHIRLPOOL_STAND_CELL: Vector2i = Vector2i(6, 6)
 const COLL_WHIRLPOOL: int = 0x24
 
+## A two-cell waterfall column in x=2, with the water a surfing player climbs
+## from below it and floor above it, so the climb ends ashore and
+## CheckUpdatePlayerSprite has something to restore walking on.
+const WATERFALL_STAND_CELL: Vector2i = Vector2i(2, 7)
+const WATERFALL_CELLS: Array[Vector2i] = [Vector2i(2, 6), Vector2i(2, 5)]
+const WATERFALL_LANDING_CELL: Vector2i = Vector2i(2, 4)
+
 var _directory: String = ""
 
 
@@ -151,6 +158,9 @@ func _map(number: int, tileset: int) -> Dictionary:
 	collision[WALLED_WATER_CELL.y * 8 + WALLED_WATER_CELL.x] = COLL_WATER
 	collision[WHIRLPOOL_CELL.y * 8 + WHIRLPOOL_CELL.x] = COLL_WHIRLPOOL
 	collision[WHIRLPOOL_STAND_CELL.y * 8 + WHIRLPOOL_STAND_CELL.x] = COLL_WATER
+	collision[WATERFALL_STAND_CELL.y * 8 + WATERFALL_STAND_CELL.x] = COLL_WATER
+	for waterfall_cell: Vector2i in WATERFALL_CELLS:
+		collision[waterfall_cell.y * 8 + waterfall_cell.x] = Gen2WorldCollision.COLL_WATERFALL
 	# A warp pair between the shore and the water cell of the other map, so a map
 	# transition can land the player on either kind of tile. Destinations are
 	# one-based, so both point at the other map's only warp.
@@ -244,19 +254,20 @@ func _whirlpool_world(badge: bool = true) -> Gen2WorldAPI:
 	return world
 
 
-func test_cut_surf_strength_and_whirlpool_are_the_field_moves_the_submenu_offers() -> void:
+func test_the_five_resolved_moves_are_the_field_moves_the_submenu_offers() -> void:
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_CUT))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SURF))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_STRENGTH))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_WATERFALL))
 	assert_eq(Gen2WorldFieldMove.MOVE_CUT, 0x0F)
 	assert_eq(Gen2WorldFieldMove.MOVE_SURF, 0x39)
 	assert_eq(Gen2WorldFieldMove.MOVE_STRENGTH, 0x46)
 	assert_eq(Gen2WorldFieldMove.MOVE_WHIRLPOOL, 0xFA)
+	assert_eq(Gen2WorldFieldMove.MOVE_WATERFALL, 0x7F)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: FLY, FLASH, WATERFALL,
-	# HEADBUTT.
-	for move: int in [0x13, 0x94, 0x7F, 0x1D]:
+	# submenu would offer an entry nothing answers: FLY, FLASH, HEADBUTT.
+	for move: int in [0x13, 0x94, 0x1D]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 
@@ -846,3 +857,128 @@ func test_the_whirlpool_traps_a_player_until_it_is_removed() -> void:
 	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)))
 	assert_eq(world.player_cell, WHIRLPOOL_CELL)
 	assert_eq(world.forced_movement()["kind"], &"none")
+
+
+## A world in the water below the waterfall column, facing up, with the Rising
+## Badge on whichever engine flag table the opened cache selects.
+func _waterfall_world(badge: bool = true) -> Gen2WorldAPI:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	if badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_RISING, Gen2WorldState.is_crystal_profile(data)
+		))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WATERFALL_STAND_CELL, state)
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	return world
+
+
+func test_waterfall_tile_carries_both_check_waterfall_tile_codes() -> void:
+	for code: int in [Gen2WorldCollision.COLL_WATERFALL, Gen2WorldCollision.COLL_CURRENT_DOWN]:
+		assert_true(Gen2WorldFieldMove.waterfall_tile(code), "code $%02x" % code)
+	for code: int in [0x00, COLL_WATER, COLL_WHIRLPOOL, 0x32]:
+		assert_false(Gen2WorldFieldMove.waterfall_tile(code), "code $%02x" % code)
+
+
+func test_waterfall_request_checks_the_badge_before_the_tile() -> void:
+	var world: Gen2WorldAPI = _waterfall_world(false)
+	var refused: Dictionary = world.waterfall_request()
+	assert_false(bool(refused.get("ok", true)))
+	assert_eq(refused["reason"], &"badge_required")
+	assert_true(world.pending_waterfall().is_empty())
+
+
+func test_waterfall_request_reads_the_gold_silver_badge_flag() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	var state := Gen2WorldState.new()
+	# The other profile's number is not this profile's badge.
+	state.set_engine_flag(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_RISING, not crystal
+	))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WATERFALL_STAND_CELL, state)
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(world.waterfall_request()["reason"], &"badge_required")
+
+
+## CheckMapCanWaterfall tests the facing before the tile, and only FACE_UP passes.
+func test_waterfall_request_refuses_every_facing_but_up() -> void:
+	for facing: int in [
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_LEFT,
+		Gen2WorldSprite.FACING_RIGHT,
+	]:
+		var world: Gen2WorldAPI = _waterfall_world()
+		world.player_facing = facing
+		assert_eq(world.waterfall_request()["reason"], &"wrong_facing", "facing %d" % facing)
+
+
+func test_waterfall_request_refuses_a_tile_that_is_not_a_waterfall() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	world.player_cell = WHIRLPOOL_STAND_CELL
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(world.waterfall_request()["reason"], &"nothing_to_climb")
+
+
+## .TryWaterfall reads no player state, so walking is not a refusal, the same
+## way .TryWhirlpool has it.
+func test_waterfall_request_resolves_from_land_too() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_WALK)
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+
+
+func test_waterfall_request_stages_without_moving_the_player() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	var staged: Dictionary = world.waterfall_request()
+	assert_true(bool(staged.get("ok", false)), JSON.stringify(staged))
+	assert_eq(staged["kind"], &"waterfall_requested")
+	assert_eq(staged["cell"], WATERFALL_CELLS[0])
+	# Script_UsedWaterfall steps only after _UseWaterfallText's waitbutton.
+	assert_eq(world.player_cell, WATERFALL_STAND_CELL)
+	assert_eq(world.pending_waterfall()["cell"], WATERFALL_CELLS[0])
+
+
+## .CheckContinueWaterfall repeats the step while the cell stood on is still a
+## waterfall, so a two-cell column is one command and three steps.
+func test_complete_waterfall_climbs_the_whole_column_in_one_command() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+	var applied: Dictionary = world.complete_waterfall()
+	assert_true(bool(applied.get("ok", false)), JSON.stringify(applied))
+	assert_eq(applied["kind"], &"waterfall_applied")
+	assert_eq(applied["cell"], WATERFALL_LANDING_CELL)
+	assert_eq(int(applied["steps"]), WATERFALL_CELLS.size() + 1)
+	assert_eq(world.player_cell, WATERFALL_LANDING_CELL)
+	assert_true(world.pending_waterfall().is_empty())
+
+
+## The landing re-derives the player state the way a warp does, so a climb that
+## ends on land puts the surfer back on foot.
+func test_complete_waterfall_restores_walking_when_it_lands_ashore() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+	var applied: Dictionary = world.complete_waterfall()
+	assert_eq(applied["movement_mode"], Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+
+
+func test_complete_waterfall_without_a_request_refuses() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	var refused: Dictionary = world.complete_waterfall()
+	assert_false(bool(refused.get("ok", true)))
+	assert_eq(refused["reason"], &"no_pending_waterfall")
+
+
+## The request names a cell on the loaded map, so a map change drops it the way
+## the other four are dropped.
+func test_a_map_change_clears_a_pending_waterfall() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+	# Map 1's only warp is the shore pit; TRANSITION_PIT_CELL belongs to map 2.
+	world.player_cell = SHORE_CELL
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_true(world.pending_waterfall().is_empty())

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -28,16 +28,29 @@ const WALK_RESOLVE_ATTEMPTS: int = 16
 
 ## constants/item_constants.asm's add_hm list, whose comment column is hex.
 const ITEM_HM_STRENGTH: int = 0xF6
+const ITEM_HM_WATERFALL: int = 0xF9
+## Ice Path 1F's HM07 ball stands on (31,7) in both games, on the same region as
+## the Route 44 door and the first staircase (`maps/IcePath1F.asm`). Three of its
+## four neighbours are wall, so (30,7) facing right is the only approach.
+const HM07_APPROACH: Vector2i = Vector2i(30, 7)
+## constants/mart_constants.asm's MART_BLACKTHORN, which
+## BlackthornMartClerkScript names. Its stock is the cartridge's
+## (`data/items/marts.asm` MartBlackthorn), and it sells no Poké Balls at all.
+## How many balls the route buys is its own choice, not the cartridge's; five
+## Great Balls is what the source start money covers.
+const MART_BLACKTHORN: int = 17
+const GREAT_BALLS_BOUGHT: int = 5
 ## The two Radio Tower keys, from the same hex comment column.
 const ITEM_CARD_KEY: int = 0x7F
 const ITEM_BASEMENT_KEY: int = 0x85
 ## ENGINE_STORMBADGE's place in source badge order, for Gen2WorldState.badge_flag().
 const BADGE_STORM: int = 5
 
-## How many forced Union Cave encounters the route may roll looking for a
-## STRENGTH-capable catch. Its own five Poké Balls are the real limit; this only
-## bounds the rolls that find nothing worth throwing at.
-const CATCH_ATTEMPTS: int = 64
+## How many forced encounters the route may roll looking for a catch that can
+## learn the move it needs. The bag is the real limit; this only bounds the
+## rolls that find nothing worth throwing at, and Dragon's Den answers with a
+## Dratini about one roll in ten.
+const CATCH_ATTEMPTS: int = 256
 
 ## Mahogany Town, whose map scene and merchant flag are what open the east exit
 ## onto Route 44 (`data/maps/maps.asm`).
@@ -130,7 +143,7 @@ const OBJECT_STEP_FRAME_BUDGET: int = 64
 ## 3 to 6) are shortcuts into B2F Mahogany side, which the walk already reaches
 ## through warp 2.
 const ICE_PATH_DOORS: Array = [
-	{"step": "route_44_to_ice_path_1f", "cell": Vector2i(56, 7)},
+	{"step": "route_44_to_ice_path_1f", "cell": Vector2i(56, 7), "hm07": true},
 	{"step": "ice_path_1f_to_b1f", "cell": Vector2i(37, 5)},
 	{"step": "ice_path_b1f_to_b2f_mahogany", "cell": Vector2i(17, 3)},
 	{"step": "ice_path_b2f_mahogany_to_b3f", "cell": Vector2i(9, 11)},
@@ -143,6 +156,45 @@ const ICE_PATH_DOORS: Array = [
 ## Route 27's landfall from New Bark Town, which is also the
 ## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord pair (`maps/Route27.asm`).
 const ROUTE_27_LANDFALL: Vector2i = Vector2i(18, 10)
+
+## Tohjo Falls, west to east (`maps/TohjoFalls.asm`, `maps/Route27.asm`). The
+## two mouths are Route 27 cells; everything between them is inside the cave.
+##
+## The west door lands on (13,15) in an eight-cell pocket whose only water is to
+## the left, so the surf starts on (10,14). The climb's foot is (8,12), directly
+## below the four-cell `COLL_WATERFALL` column at x 8, and the descent's top is
+## (18,5) on the pool, directly above the east column.
+const TOHJO_WEST_MOUTH: Vector2i = Vector2i(26, 5)
+const TOHJO_WEST_SHORE: Vector2i = Vector2i(10, 14)
+const TOHJO_CLIMB_FOOT: Vector2i = Vector2i(8, 12)
+const TOHJO_DESCENT_TOP: Vector2i = Vector2i(18, 5)
+const TOHJO_EAST_LANDFALL: Vector2i = Vector2i(22, 14)
+const TOHJO_EAST_DOOR: Vector2i = Vector2i(25, 15)
+## The tallest waterfall either game ships is four cells, so this only has to
+## outlast a stuck forced step rather than bound a real column.
+const WATERFALL_RIDE_LIMIT: int = 32
+
+## constants/event_flags.asm. `VictoryRoadRivalNext` sets it before loading the
+## RIVAL1 party, so it is what says the Victory Road scene really ran.
+const EVENT_RIVAL_VICTORY_ROAD: int = 1730
+## `PlateauRivalBattle1`/`2` open on this, a Kanto event the walked route never
+## reaches, so the plateau coord event falls straight to PlateauRivalScriptDone.
+const EVENT_BEAT_RIVAL_IN_MT_MOON: int = 793
+## ENGINE_FLYPOINT_INDIGO_PLATEAU, set by Route23FlypointCallback on map entry.
+const ENGINE_FLYPOINT_INDIGO_PLATEAU: int = 64
+
+## Victory Road's regions, in the order its warp maze joins them
+## (`maps/VictoryRoad.asm`). The internal warps are pairs, so warp 2 at (1,49)
+## arrives on warp 3 at (1,35) and warp 4 at (13,31) on warp 5 at (13,17). The
+## fourth region, behind (0,11) and (0,27), is a dead end and is not walked.
+## The cell below `PlateauRivalBattle1`'s coord event, which is stepped onto
+## from here (`maps/IndigoPlateauPokecenter1F.asm`).
+const PLATEAU_RIVAL_APPROACH: Vector2i = Vector2i(16, 5)
+
+const VICTORY_ROAD_LADDERS: Array = [
+	{"step": "victory_road_first_ladder", "cell": Vector2i(1, 49)},
+	{"step": "victory_road_second_ladder", "cell": Vector2i(13, 31)},
+]
 
 
 func _initialize() -> void:
@@ -232,7 +284,16 @@ func _home_path(data: GameData) -> Array:
 
 
 func _story_path(data: GameData) -> Dictionary:
-	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 24, 7, Vector2i.ZERO)
+	# The walked route is a new game, so it starts on the new game's own world
+	# state rather than a bare one: Gen2WorldSpawn is what the launcher hands the
+	# screen, and its SPAWN_HOME record carries the source start money. Without
+	# it the route reaches Blackthorn with nothing to spend.
+	var spawn: Gen2WorldSnapshot = Gen2WorldSpawn.new_game_snapshot(data)
+	if spawn == null:
+		return {"ok": false, "reason": "missing new-game spawn"}
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 24, 7, Vector2i.ZERO, spawn.world_state
+	)
 	if world == null:
 		return {"ok": false, "reason": "missing home map"}
 	var save: Gen2SaveData = Gen2SaveStore.create_new_game(data, 0, "ASH")
@@ -1021,7 +1082,10 @@ func _hive_badge_path(
 		"run": union_entry,
 	})
 
-	var caught: Dictionary = _catch_strength_mon(world, save, random, data, path)
+	var caught: Dictionary = _catch_field_move_mon(
+		world, save, random, data, path,
+		Gen2WorldFieldMove.MOVE_STRENGTH, "union_cave_catch_for_strength"
+	)
 	if not bool(caught.get("ok", false)):
 		return caught
 
@@ -3150,6 +3214,28 @@ func _rising_badge_path(
 	data: GameData,
 	path: Array,
 ) -> Dictionary:
+	# The mart before the gym, because the Dragon's Den catch on the way back out
+	# needs more balls than Elm's aide gave and Blackthorn is the last town the
+	# route stands in before it.
+	var mart_trip: Dictionary = _warp_chain(world, save, random, data, [Vector2i(15, 29)])
+	if not bool(mart_trip.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn Mart unreachable: %s" % mart_trip.get("reason", ""),
+		}
+	var bought: Dictionary = _buy_great_balls(world, save, data, path, GREAT_BALLS_BOUGHT)
+	if not bool(bought.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn Mart failed: %s" % bought.get("reason", ""),
+		}
+	var out_of_mart: Dictionary = _warp_chain(world, save, random, data, [Vector2i(2, 7)])
+	if not bool(out_of_mart.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blackthorn Mart exit failed: %s" % out_of_mart.get("reason", ""),
+		}
+
 	var gym: Dictionary = _blackthorn_gym_leg(world, save, random, data, path)
 	if not bool(gym.get("ok", false)):
 		return gym
@@ -3388,22 +3474,18 @@ func _dragon_shrine_leg(
 	return {"ok": true}
 
 
-## The Dragon Shrine back to New Bark Town and the first step into Kanto, on the
-## same world, state and save.
+## The Dragon Shrine to Indigo Plateau, on the same world, state and save.
 ##
-## This is where the walked route stops, and Route 27 is the wall. Its landfall
-## region reaches no map edge and no other land: row 5 is a solid cliff apart
-## from the two Tohjo Falls mouths, and both are `COLL_CAVE`, whose `.CheckTile`
-## `.warps` branch forces DOWN, so a player leaving either mouth always steps
-## south of it and the block north of the cliff can never be entered. The only
-## crossing of the channel east of the landfall starts in the pocket south of
-## the east mouth, and that pocket is reached only by leaving Tohjo Falls there,
-## which means crossing the cave. The cave cannot be crossed: its two lower
-## channels reach the pool that feeds them only by climbing `COLL_WATERFALL`
-## cells. Route 26, the Victory Road Gate badge check, Victory Road and Indigo
-## Plateau are all behind that climb, so they need HM07 and a Waterfall field
-## move. `tools/validate_route_27.gd` pins every census behind this, in all
-## three games, and `HANDOFF.md` open work has what has to land first.
+## `VictoryRoadGate`'s coord event at (10,11) is a `readvar VAR_BADGES` against
+## `NUM_JOHTO_BADGES - 1`, so it is the first script on the walked route that
+## reads the badge count back, and the eighth badge is what opens the leg.
+##
+## Route 27 is the reason this leg waited on Waterfall. Its Kanto landfall sits
+## in a region that reaches no map edge, and the only crossing of the channel
+## east of it starts in a pocket reached solely by leaving Tohjo Falls there.
+## The cave in turn is two lower channels that reach the pool feeding them only
+## by climbing `COLL_WATERFALL` cells. `tools/validate_route_27.gd` pins all of
+## it.
 ##
 ## Appends to [param path] and answers only ok or the failure.
 func _kanto_approach_path(
@@ -3417,7 +3499,15 @@ func _kanto_approach_path(
 	if not bool(departure.get("ok", false)):
 		return departure
 
-	return _kanto_approach(world, save, random, data, path)
+	var kanto: Dictionary = _kanto_approach(world, save, random, data, path)
+	if not bool(kanto.get("ok", false)):
+		return kanto
+
+	var gate: Dictionary = _victory_road_gate_leg(world, save, random, data, path)
+	if not bool(gate.get("ok", false)):
+		return gate
+
+	return _victory_road_leg(world, save, random, data, path)
 
 
 ## The Dragon Shrine back to New Bark Town.
@@ -3473,6 +3563,33 @@ func _blackthorn_departure(
 			"ok": false, "path": path,
 			"reason": "Dragon's Den return surf failed: %s" % entered.get("reason", ""),
 		}
+
+	# The Rising Badge is in, so WATERFALL is usable from here on, and this is
+	# the water it can be learned on: Dragon's Den B1F's own table is the only
+	# one the walked route surfs that carries a species which learns it
+	# (`data/wild/johto_water.asm` DRATINI, against MAGIKARP in the other two
+	# slots). None of the party can.
+	var dratini: Dictionary = _catch_field_move_mon(
+		world, save, random, data, path,
+		Gen2WorldFieldMove.MOVE_WATERFALL, "dragons_den_catch_for_waterfall"
+	)
+	if not bool(dratini.get("ok", false)):
+		return dratini
+	var taught: Dictionary = _teach_hm(world, save, ITEM_HM_WATERFALL)
+	_mirror_party(world, save)
+	path.append({
+		"step": "dragons_den_teach_waterfall",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"party": _party_species(save),
+		"moves": _party_moves(save),
+	})
+	if not bool(taught.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "WATERFALL could not be taught: %s" % taught.get("reason", ""),
+		}
+
 	var cleared: Dictionary = _whirlpool_at(
 		world, Vector2i(10, 21), Gen2WorldSprite.FACING_UP, save, random, data
 	)
@@ -3590,13 +3707,20 @@ func _blackthorn_departure(
 	return {"ok": true}
 
 
-## New Bark Town to Route 27's landfall, which is as far east as the route goes.
+## New Bark Town to Route 26, along Route 27 and through Tohjo Falls.
 ##
 ## New Bark's east column is wall except the four water rows 6 to 9, so leaving
 ## town east is a crossing rather than a step. The far side is still water, so
 ## one water-only walk comes ashore on ROUTE_27_LANDFALL, one of the two
 ## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord cells, and the scene runs on
-## arrival. _kanto_approach_path() has why the walk stops here.
+## arrival.
+##
+## From there the way east is the cave, twice over. Row 5 of Route 27 is solid
+## cliff apart from Tohjo Falls' two mouths, and both are `COLL_CAVE`, whose
+## `.CheckTile` `.warps` branch forces a step DOWN: a player leaving either
+## mouth always ends south of it. So the west mouth is entered from the
+## landfall's region, the cave is crossed, and the east mouth drops the player
+## into the pocket whose own shore is the channel across to Route 26's edge.
 func _kanto_approach(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3640,13 +3764,370 @@ func _kanto_approach(
 			"ok": false, "path": path,
 			"reason": "Route 27 landfall failed: %s" % ashore.get("reason", ""),
 		}
-	if world.player_cell != ROUTE_27_LANDFALL:
+
+	var cave: Dictionary = _tohjo_falls_leg(world, save, random, data, path)
+	if not bool(cave.get("ok", false)):
+		return cave
+
+	# The east mouth's forced step already put the player in the pocket. Row 4's
+	# eastern strip is walled off from the rest of Route 27, so (46,4) is the
+	# landfall and rows 10 and 11 are the only land cells on the Route 26 edge a
+	# walk can leave by.
+	var channel: Dictionary = _surf_at(
+		world, Vector2i(39, 6), Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	if not bool(channel.get("ok", false)):
 		return {
 			"ok": false, "path": path,
-			"reason": "the Kanto scene left the player on %s" % world.player_cell,
+			"reason": "Route 27 channel surf failed: %s" % channel.get("reason", ""),
+		}
+	var landed: Dictionary = _walk_cell_resolving(
+		world, Vector2i(46, 4), save, random, data, true
+	)
+	if not bool(landed.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 27 channel landfall failed: %s" % landed.get("reason", ""),
+		}
+	var to_route_26: Dictionary = _walk_connection_resolving(
+		world, "east", 24, 1, save, random, data
+	)
+	var route_26_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "route_27_to_route_26",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+		"encounters": to_route_26.get("encounters", []),
+		"run": route_26_entry,
+	})
+	if not bool(to_route_26.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 27 to Route 26 failed: %s" % to_route_26.get("reason", ""),
 		}
 	return {"ok": true}
 
+
+## Tohjo Falls, west mouth to east mouth, which is one Waterfall climb and one
+## ride back down.
+##
+## The cave is three water bodies joined only by its waterfalls. From the west
+## door's landing the surf runs west and north to the foot of the x 8 to 11
+## column; the climb ends on the pool above it, still on water. The east
+## waterfall is then ridden down rather than climbed: stepping onto its top cell
+## leaves the player standing on a `COLL_WATERFALL`, and `.CheckTile` takes over
+## from there, which is `advance_forced_movement()` here.
+func _tohjo_falls_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_cave: Dictionary = _warp_chain(world, save, random, data, [TOHJO_WEST_MOUTH])
+	if not bool(into_cave.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Tohjo Falls entrance failed: %s" % into_cave.get("reason", ""),
+		}
+
+	var entered: Dictionary = _surf_at(
+		world, TOHJO_WEST_SHORE, Gen2WorldSprite.FACING_LEFT, save, random, data
+	)
+	if not bool(entered.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Tohjo Falls surf entry failed: %s" % entered.get("reason", ""),
+		}
+	var climbed: Dictionary = _waterfall_at(
+		world, TOHJO_CLIMB_FOOT, save, random, data
+	)
+	path.append({
+		"step": "tohjo_falls_climb",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": climbed,
+		"movement_mode": String(world.movement_mode),
+	})
+	if not bool(climbed.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Tohjo Falls climb failed: %s" % climbed.get("reason", ""),
+		}
+
+	var descent: Dictionary = _ride_waterfall_down(
+		world, save, random, data, TOHJO_DESCENT_TOP
+	)
+	path.append({
+		"step": "tohjo_falls_descent",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"steps": descent.get("steps", 0),
+	})
+	if not bool(descent.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Tohjo Falls descent failed: %s" % descent.get("reason", ""),
+		}
+
+	var ashore: Dictionary = _walk_cell_resolving(
+		world, TOHJO_EAST_LANDFALL, save, random, data, true
+	)
+	if not bool(ashore.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Tohjo Falls landfall failed: %s" % ashore.get("reason", ""),
+		}
+	var out_of_cave: Dictionary = _warp_chain(world, save, random, data, [TOHJO_EAST_DOOR])
+	path.append({
+		"step": "tohjo_falls_east_mouth",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+	})
+	if not bool(out_of_cave.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Tohjo Falls exit failed: %s" % out_of_cave.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## Climbs the waterfall the given water cell faces, the way _cut_at() cuts:
+## request then commit, since Script_UsedWaterfall reaches its first step only
+## after _UseWaterfallText's waitbutton. The whole column is one commit.
+func _waterfall_at(
+	world: Gen2WorldAPI,
+	approach: Vector2i,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+) -> Dictionary:
+	var walked: Dictionary = _walk_cell_resolving(world, approach, save, random, data, true)
+	if not bool(walked.get("ok", false)):
+		return walked
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var request: Dictionary = world.waterfall_request()
+	if not bool(request.get("ok", false)):
+		return {"ok": false, "reason": "waterfall refused: %s" % request.get("reason", "")}
+	var applied: Dictionary = world.complete_waterfall()
+	if not bool(applied.get("ok", false)):
+		return {"ok": false, "reason": "waterfall failed: %s" % applied.get("reason", "")}
+	return applied
+
+
+## Steps onto a waterfall's top cell and lets `.CheckTile` carry the player down
+## it. Going down needs no move and no badge: the tile does it, which is why the
+## project has had the layer since the forced-tile work and only the climb was
+## missing.
+func _ride_waterfall_down(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	top: Vector2i,
+) -> Dictionary:
+	var walked: Dictionary = _walk_cell_resolving(world, top, save, random, data, true)
+	if not bool(walked.get("ok", false)):
+		return walked
+	var stepped: Dictionary = world.move_result(Vector2i.DOWN)
+	if not bool(stepped.get("ok", false)):
+		return {"ok": false, "reason": "the descent's first step refused"}
+	var steps: int = 1
+	for _frame: int in WATERFALL_RIDE_LIMIT:
+		var forced: Dictionary = world.advance_forced_movement()
+		if forced.is_empty():
+			return {"ok": true, "steps": steps}
+		if not bool(forced.get("ok", false)):
+			return {"ok": false, "reason": "forced step refused", "steps": steps}
+		steps += 1
+	return {"ok": false, "reason": "the descent did not settle", "steps": steps}
+
+
+## Route 26's heal house and the Victory Road Gate badge check.
+##
+## The gate is not walked with _gate_leg(): that helper reaches the far warp
+## with _warp_step(), which assigns the cell rather than walking to it, and the
+## badge check is a coord event at (10,11) that only a real walk can meet.
+func _victory_road_gate_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	_mirror_party(world, save)
+
+	# Route26HealHouseTeacherScript is an unconditional HealParty, the one heal
+	# on this leg that is not a Pokemon Center nurse.
+	for mon: Gen2SaveMon in save.party:
+		mon.hp = 1
+	var into_house: Dictionary = _warp_chain(world, save, random, data, [Vector2i(15, 57)])
+	if not bool(into_house.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 26 heal house entrance failed: %s" % into_house.get("reason", ""),
+		}
+	var healed: Dictionary = _talk_to(
+		world, Vector2i(2, 4), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "route_26_heal_house",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": healed.get("run", {}),
+		"party_hp_after": _party_hp(save),
+	})
+	if not bool(healed.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 26 heal house failed: %s" % healed.get("reason", ""),
+		}
+	var out_of_house: Dictionary = _warp_chain(world, save, random, data, [Vector2i(2, 7)])
+	if not bool(out_of_house.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 26 heal house exit failed: %s" % out_of_house.get("reason", ""),
+		}
+
+	var into_gate: Dictionary = _warp_chain(world, save, random, data, [Vector2i(7, 5)])
+	if not bool(into_gate.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Victory Road Gate entrance failed: %s" % into_gate.get("reason", ""),
+		}
+	var checked: Dictionary = _walk_cell_resolving(
+		world, Vector2i(10, 11), save, random, data
+	)
+	path.append({
+		"step": "victory_road_gate_badge_check",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"badge_count": world.state.badge_count(),
+		"encounters": checked.get("encounters", []),
+	})
+	if not bool(checked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Victory Road Gate badge check failed: %s" % checked.get("reason", ""),
+		}
+	# The officer's refusal branch is an applymovement that steps the player back
+	# down, so staying on (10,11) is what says the eighth badge was accepted.
+	if world.player_cell != Vector2i(10, 11):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gate turned the player back at %s" % world.player_cell,
+		}
+	return {"ok": true}
+
+
+## Victory Road and Route 23 to the Indigo Plateau Pokemon Center.
+##
+## Victory Road is a warp maze, not one floor: the gate's entrance region
+## reaches only the ladder at (1,49), whose pair lands on (1,35) in a second
+## region, whose ladder at (13,31) lands on (13,17) in the third. Only that
+## third region holds the rival's coord event and the exit to Route 23.
+func _victory_road_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_road: Dictionary = _warp_chain(world, save, random, data, [Vector2i(9, 0)])
+	if not bool(into_road.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Victory Road entrance failed: %s" % into_road.get("reason", ""),
+		}
+
+	for ladder: Dictionary in VICTORY_ROAD_LADDERS:
+		var climbed: Dictionary = _warp_chain(world, save, random, data, [ladder["cell"]])
+		path.append({
+			"step": String(ladder["step"]),
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+		})
+		if not bool(climbed.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s failed: %s" % [ladder["step"], climbed.get("reason", "")],
+			}
+
+	# The rival's own cell, walked rather than left to the path to the exit: the
+	# coord event pair is (12,8) and (13,8), and a walk that happened to route
+	# around both would skip the battle without saying so.
+	var rival: Dictionary = _walk_cell_resolving(world, Vector2i(13, 8), save, random, data)
+	path.append({
+		"step": "victory_road_rival",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": rival.get("encounters", []),
+		"beat_rival": world.event_flag_active(EVENT_RIVAL_VICTORY_ROAD),
+	})
+	if not bool(rival.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Victory Road rival failed: %s" % rival.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_RIVAL_VICTORY_ROAD):
+		return {"ok": false, "path": path, "reason": "the Victory Road rival did not appear"}
+
+	var to_plateau: Dictionary = _warp_chain(
+		world, save, random, data, [Vector2i(13, 5), Vector2i(9, 5)]
+	)
+	if not bool(to_plateau.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Indigo Plateau unreachable: %s" % to_plateau.get("reason", ""),
+		}
+
+	# PlateauRivalBattle1 and 2 open on EVENT_BEAT_RIVAL_IN_MT_MOON, which this
+	# route never reaches, so the coord event runs to PlateauRivalScriptDone and
+	# no second rival battle happens here.
+	#
+	# That branch ends without a `setscene`, so the coord event stays armed and
+	# answers again every time the player stands on it. The cell is stepped onto
+	# once rather than walked to, because a resolving walk would re-dispatch it
+	# until it ran out of attempts.
+	var approach: Dictionary = _walk_cell_resolving(
+		world, PLATEAU_RIVAL_APPROACH, save, random, data
+	)
+	if not bool(approach.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Indigo Plateau approach failed: %s" % approach.get("reason", ""),
+		}
+	var stepped: Dictionary = world.move_result(Vector2i.UP)
+	var plateau: Dictionary = {"ok": bool(stepped.get("ok", false))}
+	if bool(plateau.get("ok", false)):
+		var fired: Array = _dispatch_after_step(world)
+		var run: Dictionary = _drain_story(world, fired, save, random, data, true)
+		plateau = {
+			"ok": bool(run.get("terminal", false)),
+			"reason": run.get("reason", ""),
+			"encounters": [{"cell": _cell_value(world), "statuses": run.get("statuses", []),
+				"battles": run.get("battles", [])}],
+		}
+	path.append({
+		"step": "indigo_plateau_pokecenter",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": plateau.get("encounters", []),
+		"mt_moon_rival": world.event_flag_active(EVENT_BEAT_RIVAL_IN_MT_MOON),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_INDIGO_PLATEAU),
+		"badge_count": world.state.badge_count(),
+	})
+	if not bool(plateau.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Indigo Plateau Pokemon Center failed: %s" % plateau.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_INDIGO_PLATEAU):
+		return {"ok": false, "path": path, "reason": "the Indigo Plateau flypoint was not set"}
+	return {"ok": true}
 
 
 ## _push_boulder_at() for a boulder that may land on a `stonetable` pit: the
@@ -3751,6 +4232,28 @@ func _blackthorn_path(
 				"ok": false, "path": path,
 				"reason": "%s failed: %s" % [door["step"], walked.get("reason", "")],
 			}
+		if not bool(door.get("hm07", false)):
+			continue
+		# HM07 is an item ball on the 1F region the Route 44 door opens into,
+		# and nothing else in either game gives WATERFALL. It is taken in
+		# passing, before the staircase the next door takes.
+		var picked_up: Dictionary = _talk_to(
+			world, HM07_APPROACH, Gen2WorldSprite.FACING_RIGHT, save, random, data
+		)
+		path.append({
+			"step": "ice_path_1f_hm07",
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"run": picked_up.get("run", {}),
+			"items": _named_items(data, world.state.items()),
+		})
+		if not bool(picked_up.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "HM07 pickup failed: %s" % picked_up.get("reason", ""),
+			}
+		if world.state.item_quantity(ITEM_HM_WATERFALL) <= 0:
+			return {"ok": false, "path": path, "reason": "HM07 did not reach the bag"}
 
 	path.append({
 		"step": "blackthorn_city_arrival",
@@ -4080,44 +4583,98 @@ func _push_boulder_at(
 	}
 
 
-## Catches something in Union Cave that can learn STRENGTH, which is the only
-## way this route ever gets one: the starter is still unevolved by Olivine and
-## Chikorita, Cyndaquil and Totodile all learn it only after evolving
-## (data/pokemon/base_stats/*.asm). Union Cave 1F's own table carries Geodude and
-## Onix, which both can.
+## BlackthornMartClerkScript's `pokemart MARTTYPE_STANDARD, MART_BLACKTHORN`,
+## bought from headlessly the way _teach_hm() teaches: through the same host the
+## service overlay drives, rather than through the overlay.
+##
+## The route needs this once. Elm's aide gives five Poké Balls, Union Cave's
+## Geodude costs one, and Dratini is a far lower catch rate than Geodude, so the
+## four left do not land it. Blackthorn is the last town the route stands in
+## before the Dragon's Den, and its stock is the cartridge's: MartBlackthorn
+## sells no Poké Balls, so what the route buys is Great Balls: they are the
+## cheapest ball it stocks, and the source start money buys five of them against
+## two Ultra Balls.
+func _buy_great_balls(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	data: GameData,
+	path: Array,
+	quantity: int,
+) -> Dictionary:
+	var resolved: Dictionary = Gen2WorldMartHost.resolve_mart(
+		data, Gen2WorldMartHost.MARTTYPE_STANDARD, MART_BLACKTHORN, false, world.state
+	)
+	if not bool(resolved.get("ok", false)):
+		return {
+			"ok": false,
+			"reason": "Blackthorn mart did not resolve: %s" % resolved.get("reason", ""),
+		}
+	var bought: Dictionary = Gen2WorldMartHost.purchase(
+		world, save, resolved.get("mart", {}),
+		Gen2WorldPartyHost.ITEM_GREAT_BALL, quantity, false
+	)
+	path.append({
+		"step": "blackthorn_mart_great_balls",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"balls": world.state.item_quantity(Gen2WorldPartyHost.ITEM_GREAT_BALL),
+		"money": world.state.money(),
+	})
+	if not bool(bought.get("ok", false)):
+		return {"ok": false, "reason": "purchase refused: %s" % bought.get("reason", "")}
+	return {"ok": true}
+
+
+## Catches something on the current map that can learn [param move], which is
+## how this route gets both of the HMs its own party cannot take.
+##
+## Neither is optional. The starter is still unevolved by Olivine and Chikorita,
+## Cyndaquil and Totodile all learn STRENGTH only after evolving, so Union Cave
+## 1F's Geodude and Onix are the first catch; none of the party learns WATERFALL
+## at all, so Dragon's Den B1F's Dratini is the second
+## (`data/pokemon/base_stats/*.asm`, `data/wild/johto_water.asm`).
 ##
 ## The walk itself never rolls a wild encounter, so this forces one, checks the
 ## species against CanLearnTMHMMove and throws a Poké Ball, retrying until the
 ## bag runs out. Both rolls come from the route's seeded generator, so the answer
 ## is the same on every run.
-func _catch_strength_mon(
+func _catch_field_move_mon(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
 	random: RandomNumberGenerator,
 	data: GameData,
 	path: Array,
+	move: int,
+	step: String,
 ) -> Dictionary:
 	var attempts: Array = []
 	var caught: Dictionary = {}
 	for _attempt: int in CATCH_ATTEMPTS:
-		if world.state.item_quantity(Gen2WorldPartyHost.ITEM_POKE_BALL) <= 0:
+		var ball: int = _best_ball(world)
+		if ball <= 0:
 			break
 		var encounter: Dictionary = world.encounter_request(random, true)
 		if encounter.is_empty():
 			break
 		var species: int = int(encounter.get("pokemon", 0))
 		var level: int = int(encounter.get("level", 0))
-		if not Gen2WorldTMHM.can_learn(data, species, Gen2WorldFieldMove.MOVE_STRENGTH):
+		if not Gen2WorldTMHM.can_learn(data, species, move):
 			attempts.append({"species": species, "level": level, "thrown": false})
 			continue
 		var wild: Gen2BattleMon = Gen2BattleMon.create(
 			data, species, level, data.moves_at_level(species, level), random.randi() & 0xFFFF
 		)
+		# CatchMon reads the wild's current HP, and this tool simulates no wild
+		# battle, the same way _drain_story() answers every trainer battle with a
+		# win rather than fighting it. So the throw is made at the one HP a
+		# player would have brought it to. Union Cave's Geodude lands at full HP
+		# on a catch rate of 255; Dratini's is far lower and does not.
+		wild.hp = 1
 		var throw_result: Dictionary = Gen2WorldPartyHost.capture_wild(
-			world, save, wild, Gen2WorldPartyHost.ITEM_POKE_BALL, random, 0, false
+			world, save, wild, ball, random, 0, false
 		)
 		attempts.append({
-			"species": species, "level": level, "thrown": true,
+			"species": species, "level": level, "thrown": true, "ball": ball,
 			"caught": bool(throw_result.get("caught", false)),
 			"reason": throw_result.get("reason", ""),
 		})
@@ -4126,7 +4683,7 @@ func _catch_strength_mon(
 			break
 	_mirror_party(world, save)
 	path.append({
-		"step": "union_cave_catch_for_strength",
+		"step": step,
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"attempts": attempts,
@@ -4136,7 +4693,7 @@ func _catch_strength_mon(
 	if caught.is_empty():
 		return {
 			"ok": false, "path": path,
-			"reason": "no STRENGTH-capable catch in %d encounters" % attempts.size(),
+			"reason": "no catch that learns move %d in %d encounters" % [move, attempts.size()],
 		}
 	return {"ok": true}
 
@@ -4153,6 +4710,18 @@ func _teach_hm(world: Gen2WorldAPI, save: Gen2SaveData, item: int) -> Dictionary
 			return result
 		reason = String(result.get("reason", ""))
 	return {"ok": false, "reason": reason}
+
+
+## GetBallIndex's order in reverse: the best ball still in the bag, or -1 when
+## none is. Master Balls never reach this route.
+func _best_ball(world: Gen2WorldAPI) -> int:
+	for ball: int in [
+		Gen2WorldPartyHost.ITEM_ULTRA_BALL, Gen2WorldPartyHost.ITEM_GREAT_BALL,
+		Gen2WorldPartyHost.ITEM_POKE_BALL,
+	]:
+		if world.state.item_quantity(ball) > 0:
+			return ball
+	return -1
 
 
 func _party_moves(save: Gen2SaveData) -> Array:

--- a/tools/validate_item_balls.gd
+++ b/tools/validate_item_balls.gd
@@ -1,0 +1,183 @@
+extends SceneTree
+
+## Verifies `OBJECTTYPE_ITEMBALL` dispatch against freshly imported real caches,
+## for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `engine/overworld/events.asm`'s `ObjectEventTypeArray.itemball`,
+## `engine/events/misc_scripts.asm`'s `FindItemInBallScript`, and the
+## `itemball` macro in `macros/scripts/maps.asm`.
+##
+## The point of pinning it is that an item ball's script pointer is not a
+## script. It addresses `db item, quantity`, and before this dispatch existed
+## `interact()` handed those two bytes to the runner as opcodes. Ice Path 1F's
+## HM07 is the one that matters most: nothing else in either game gives
+## Waterfall.
+##
+##   Godot --headless -s res://tools/validate_item_balls.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## data/maps/maps.asm group/number pairs. Crystal's own extra maps push both
+## dungeon floors down the Dungeons group.
+const ICE_PATH_1F: Dictionary = {
+	&"gold": [3, 53],
+	&"silver": [3, 53],
+	&"crystal": [3, 61],
+}
+const ROUTE_44: Array = [2, 6]
+
+## constants/item_constants.asm's `add_hm` list, whose comment column is hex.
+const ITEM_HM_WATERFALL: int = 0xF9
+
+## The balls this drives, by map and cell, with the item each `itemball` names.
+## Ice Path 1F's HM07 is on (31,7) in both games (`maps/IcePath1F.asm`), which is
+## the only cell on this list that has to match: nothing else gives Waterfall.
+## Route 44 is profile split (`maps/Route44.asm`). Crystal ships three balls and
+## Gold and Silver two, and the Ultra Ball moved between them.
+const HM07_CELL: Vector2i = Vector2i(31, 7)
+const ROUTE_44_BALLS: Dictionary = {
+	&"gold": [
+		{"cell": Vector2i(30, 8), "item": 0x28},   # MAX_REVIVE
+		{"cell": Vector2i(43, 2), "item": 0x02},   # ULTRA_BALL
+	],
+	&"silver": [
+		{"cell": Vector2i(30, 8), "item": 0x28},
+		{"cell": Vector2i(43, 2), "item": 0x02},
+	],
+	&"crystal": [
+		{"cell": Vector2i(30, 8), "item": 0x28},
+		{"cell": Vector2i(45, 4), "item": 0x02},
+		{"cell": Vector2i(14, 9), "item": 0x2B},   # MAX_REPEL
+	],
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_hm07(data, game_id)
+		_verify_route_44(data, game_id)
+	_finish()
+
+
+## The one that unblocks the route: picking HM07 up puts Waterfall in the bag,
+## sets the ball's own event flag and takes the object off the map.
+func _verify_hm07(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, ICE_PATH_1F[game_id], HM07_CELL + Vector2i.UP)
+	if world == null:
+		_fail("%s: Ice Path 1F is missing." % game_id)
+		return
+	var ball: Gen2WorldObject = world.object_at(HM07_CELL)
+	if ball == null:
+		_fail("%s: Ice Path 1F has no object on %s." % [game_id, HM07_CELL])
+		return
+	if not _check(
+		ball.object_type == Gen2WorldObject.OBJECTTYPE_ITEMBALL,
+		"%s: Ice Path 1F's %s is not an item ball." % [game_id, HM07_CELL]
+	):
+		return
+
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var results: Array = world.interact()
+	if not _check(
+		results.size() == 1
+			and StringName(results[0].get("source", {}).get("kind", &"")) == &"item_ball",
+		"%s: Ice Path 1F's HM07 did not dispatch as an item ball." % game_id
+	):
+		return
+	var request: Dictionary = results[0].get("source", {})
+	_check(
+		int(request.get("item", 0)) == ITEM_HM_WATERFALL
+			and int(request.get("quantity", 0)) == 1,
+		"%s: Ice Path 1F's ball carries item $%02x x%d, not HM07 x1." % [
+			game_id, int(request.get("item", 0)), int(request.get("quantity", 0)),
+		]
+	)
+	_check(
+		StringName(results[0].get("status", &"")) == &"waiting",
+		"%s: the HM07 ball did not pause on its found-item text." % game_id
+	)
+
+	var finished: Array = world.run_event_queue(true)
+	_check(
+		not finished.is_empty()
+			and StringName(finished[0].get("status", &"")) == &"complete",
+		"%s: the HM07 ball's script did not finish." % game_id
+	)
+	_check(
+		int(world.state.items().get(ITEM_HM_WATERFALL, 0)) == 1,
+		"%s: HM07 is not in the bag after the pickup." % game_id
+	)
+	# `disappear LAST_TALKED` writes the ball's own event flag, so a map reload
+	# keeps it gone the way every other disappeared object does.
+	_check(
+		ball.event_flag <= 0 or world.event_flag_active(ball.event_flag),
+		"%s: the HM07 ball's event flag was not set." % game_id
+	)
+	_check(
+		not ball.active and world.object_at(HM07_CELL) == null,
+		"%s: the HM07 ball is still on the map after the pickup." % game_id
+	)
+
+
+## More on one map, to show the decode is the macro's two bytes and not HM07
+## alone.
+func _verify_route_44(data: GameData, game_id: StringName) -> void:
+	for entry: Dictionary in ROUTE_44_BALLS[game_id]:
+		var cell: Vector2i = entry["cell"]
+		var world: Gen2WorldAPI = _open(data, ROUTE_44, cell + Vector2i.UP)
+		if world == null:
+			_fail("%s: Route 44 is missing." % game_id)
+			return
+		var ball: Gen2WorldObject = world.object_at(cell)
+		if ball == null or ball.object_type != Gen2WorldObject.OBJECTTYPE_ITEMBALL:
+			_fail("%s: Route 44 has no item ball on %s." % [game_id, cell])
+			continue
+		world.player_facing = Gen2WorldSprite.FACING_DOWN
+		var results: Array = world.interact()
+		var request: Dictionary = results[0].get("source", {}) if not results.is_empty() else {}
+		_check(
+			int(request.get("item", 0)) == int(entry["item"]),
+			"%s: Route 44's ball on %s carries $%02x, not the pinned $%02x." % [
+				game_id, cell, int(request.get("item", 0)), int(entry["item"]),
+			]
+		)
+
+
+func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, id[0], id[1], cell, Gen2WorldState.new())
+	if world == null:
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	for _step: int in 8:
+		if world.pending_script_input().is_empty():
+			break
+		world.run_event_queue(true)
+	return world
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS item balls: HM07 and Route 44's balls decode and are received.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL item balls: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_item_balls.gd.uid
+++ b/tools/validate_item_balls.gd.uid
@@ -1,0 +1,1 @@
+uid://b2gmj3qekuscf

--- a/tools/validate_route_27.gd
+++ b/tools/validate_route_27.gd
@@ -9,13 +9,16 @@ extends SceneTree
 ## between the pins; `Route27.blk` is not, so its land census is profile split
 ## while every water figure happens to match.
 ##
-## The claim being pinned is a negative one, and negative claims rot quietly.
-## Route 27's landfall region reaches no map edge; the only crossing of the
-## channel east of it starts in a pocket that can only be left through Tohjo
-## Falls; and the cave's two lower channels reach each other only over
+## Two halves. The first is geometry, and it is why this leg waited on
+## Waterfall: Route 27's landfall region reaches no map edge; the only crossing
+## of the channel east of it starts in a pocket that can only be left through
+## Tohjo Falls; and the cave's two lower channels reach each other only over
 ## `COLL_WATERFALL` cells, which `.CheckTile` will only ever step a player down.
-## So Route 26 and everything past it need HM07 and a Waterfall field move. When
-## one lands, this tool is what says so.
+##
+## The second is the way through, now that there is one. With the Rising Badge
+## the climb at the foot of the west column reaches the pool in a single
+## commit, and the east column is ridden back down by the same forced-tile rule
+## that made it a wall in the first place.
 ##
 ##   Godot --headless -s res://tools/validate_route_27.gd
 
@@ -60,9 +63,19 @@ const WEST_CHANNEL_CELLS: int = 40
 const EAST_CHANNEL_CELLS: int = 34
 const POOL_CELLS: int = 144
 ## TILESET_CAVE block $2c is four WATERFALL quadrants and the cave writes ten of
-## them (`data/tilesets/cave_collision.asm`). COLL_WATERFALL is $33.
-const COLL_WATERFALL: int = 0x33
+## them (`data/tilesets/cave_collision.asm`).
 const WATERFALL_CELLS: int = 40
+
+## The crossing itself. The west column's foot is the water directly below it and
+## its top the first pool cell above; the east column is entered from the pool
+## and ridden to the water below it. Both counts include the step onto the
+## column, which is what Script_UsedWaterfall's loop does before its first check.
+const CLIMB_FOOT: Vector2i = Vector2i(8, 12)
+const CLIMB_TOP: Vector2i = Vector2i(8, 7)
+const CLIMB_STEPS: int = 5
+const DESCENT_TOP: Vector2i = Vector2i(18, 5)
+const DESCENT_BOTTOM: Vector2i = Vector2i(18, 10)
+const DESCENT_STEPS: int = 5
 
 const STEPS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
 
@@ -78,6 +91,7 @@ func _initialize() -> void:
 			continue
 		_verify_route_27(data, game_id)
 		_verify_tohjo_falls(data, game_id)
+		_verify_waterfall_crossing(data, game_id)
 	_finish()
 
 
@@ -168,7 +182,7 @@ func _verify_tohjo_falls(data: GameData, game_id: StringName) -> void:
 	var waterfalls: int = 0
 	for y: int in size.y:
 		for x: int in size.x:
-			if world.collision_code_at(Vector2i(x, y)) == COLL_WATERFALL:
+			if world.collision_code_at(Vector2i(x, y)) == Gen2WorldCollision.COLL_WATERFALL:
 				waterfalls += 1
 	_check(
 		waterfalls == WATERFALL_CELLS,
@@ -199,6 +213,109 @@ func _verify_tohjo_falls(data: GameData, game_id: StringName) -> void:
 	_check(
 		pool.has(WEST_CHANNEL) and pool.has(EAST_CHANNEL),
 		"%s: Tohjo Falls' pool does not fall into both channels." % game_id
+	)
+
+
+## Drives the crossing the geometry above forbids without Waterfall: climb the
+## west column, ride the east one down, and end on the water the east door's
+## land region touches.
+func _verify_waterfall_crossing(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, TOHJO_FALLS[game_id], CLIMB_FOOT)
+	if world == null:
+		_fail("%s: Tohjo Falls is missing." % game_id)
+		return
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+
+	# .TryWaterfall is CheckBadge before CheckMapCanWaterfall, so the badge is
+	# the first refusal and the other profile's flag number is not this one's.
+	_check(
+		StringName(world.waterfall_request().get("reason", &"")) == &"badge_required",
+		"%s: the climb resolved without the Rising Badge." % game_id
+	)
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	world.state.set_engine_flag(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_RISING, not crystal)
+	)
+	_check(
+		StringName(world.waterfall_request().get("reason", &"")) == &"badge_required",
+		"%s: the climb read the other profile's badge flag." % game_id
+	)
+	world.state.set_engine_flag(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_RISING, crystal)
+	)
+
+	# CheckMapCanWaterfall passes only on FACE_UP, whatever the tile answers.
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_check(
+		StringName(world.waterfall_request().get("reason", &"")) == &"wrong_facing",
+		"%s: the climb resolved while facing away from the column." % game_id
+	)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+
+	var staged: Dictionary = world.waterfall_request()
+	if not _check(
+		bool(staged.get("ok", false)) and world.player_cell == CLIMB_FOOT,
+		"%s: the climb did not stage from %s: %s" % [
+			game_id, CLIMB_FOOT, staged.get("reason", ""),
+		]
+	):
+		return
+	var climbed: Dictionary = world.complete_waterfall()
+	_check(
+		bool(climbed.get("ok", false)) and climbed.get("cell", Vector2i.ZERO) == CLIMB_TOP,
+		"%s: the climb ended on %s, not the pinned %s." % [
+			game_id, climbed.get("cell", Vector2i.ZERO), CLIMB_TOP,
+		]
+	)
+	# The whole column is one command: Script_UsedWaterfall loops until the cell
+	# stood on is no longer a waterfall.
+	_check(
+		int(climbed.get("steps", 0)) == CLIMB_STEPS,
+		"%s: the climb took %d steps, not the pinned %d." % [
+			game_id, int(climbed.get("steps", 0)), CLIMB_STEPS,
+		]
+	)
+	_check(
+		_swim(world, world.player_cell).has(DESCENT_TOP),
+		"%s: the pool does not reach the east column from the climb's landing." % game_id
+	)
+
+	# Down needs no move and no badge: stepping onto the column leaves the
+	# player standing on a COLL_WATERFALL and .CheckTile does the rest.
+	world.player_cell = DESCENT_TOP
+	var down: Dictionary = world.move_result(Vector2i.DOWN)
+	if not _check(
+		bool(down.get("ok", false)),
+		"%s: the step onto the east column refused." % game_id
+	):
+		return
+	var rode: int = 1
+	for _step: int in 32:
+		var forced: Dictionary = world.advance_forced_movement()
+		if forced.is_empty():
+			break
+		if not _check(
+			bool(forced.get("ok", false)),
+			"%s: a forced step down the east column refused." % game_id
+		):
+			return
+		rode += 1
+	_check(
+		world.player_cell == DESCENT_BOTTOM,
+		"%s: the descent ended on %s, not the pinned %s." % [
+			game_id, world.player_cell, DESCENT_BOTTOM,
+		]
+	)
+	_check(
+		rode == DESCENT_STEPS,
+		"%s: the descent took %d steps, not the pinned %d." % [
+			game_id, rode, DESCENT_STEPS,
+		]
+	)
+	_check(
+		_swim(world, world.player_cell).has(EAST_CHANNEL),
+		"%s: the descent did not land in the east channel." % game_id
 	)
 
 
@@ -274,7 +391,7 @@ func _fail(message: String) -> void:
 
 func _finish() -> void:
 	if _failures.is_empty():
-		print("PASS route 27: the landfall is sealed and Tohjo Falls needs Waterfall.")
+		print("PASS route 27: the landfall is sealed and Waterfall is the way through.")
 		quit(0)
 		return
 	for failure: String in _failures:


### PR DESCRIPTION
Two mechanics and the leg they unblock.

Item balls are dispatched by object type instead of being handed to the script runner as opcodes. An item ball's pointer addresses the itemball macro's `db item, quantity`, which ObjectEventTypeArray.itemball copies into wItemBallData before raising PLAYEREVENT_ITEMBALL, so Gen2WorldAPI decodes the two bytes and the runner replays FindItemInBallScript: receive, disappear LAST_TALKED, then the found-item text.

Waterfall joins Cut, Surf, Strength and Whirlpool on the staged-request model. .TryWaterfall is CheckBadge ENGINE_RISINGBADGE then CheckMapCanWaterfall, which passes only on FACE_UP at a CheckWaterfallTile cell, and the commit runs Script_UsedWaterfall's whole loop in one command, ending on the first cell above the column that is not a waterfall.

The walked route then reaches the Indigo Plateau Pokemon Center over 170 steps: HM07 off Ice Path 1F, Great Balls from Blackthorn Mart, a Dratini caught on the Dragon's Den lake and taught Waterfall, Tohjo Falls climbed and ridden back down, Route 26's heal house, the gate's badge check and Victory Road's rival.

Two defects fixed in passing: the route never seeded the new game's start money, so Blackthorn Mart had nothing to sell it, and README listed three field moves when there were four.