### PR TITLE
Walk the Elite Four and the Hall of Fame

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,13 +210,14 @@ Headless tools, all against a real imported cache:
 | `validate_rising_badge.gd` | Blackthorn Gym 2F's boulders and holes, the 1F block changes that open Clair's room, the lake crossing to the Dragon's Den door, and Dragon's Den B1F's whirlpool and shrine landfall, in all three games |
 | `validate_route_27.gd` | the forced step off a cave mouth, Route 27's sealed Kanto landfall and three seas, and the Tohjo Falls climb and ride back down, in all three games |
 | `validate_item_balls.gd` | Ice Path 1F's HM07 and Route 44's balls decoding from the `itemball` macro and reaching the bag, in all three games |
+| `validate_elite_four.gd` | the seven Indigo Plateau maps, the one door into the rooms, the prepare callback's flag reset, and each room's sealed entrance and boss-opened exit, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route, ending at the Indigo Plateau Pokemon Center
+# the full walked route, ending in the Hall of Fame
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2107,6 +2107,14 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 				"transition": checked.duplicate(true),
 			})
 			continue
+		if event_type == &"player_facing_requested":
+			## Script_warpfacing writes the player's facing before the warp, and
+			## the map load never touches it, so the facing outlives the
+			## transition. Lance's room is where it shows: `warpfacing UP` is
+			## what the player enters the Hall of Fame already facing.
+			player_facing = int(event.get("facing", player_facing))
+			generated.append({"type": &"player_facing", "facing": player_facing})
+			continue
 		if event_type == &"player_movement_requested":
 			generated.append_array(_apply_player_movement(event))
 			continue

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3191,6 +3191,42 @@ func test_crystal_engine_flags_and_hall_of_fame_commit_at_script_end() -> void:
 	))
 
 
+## LancesRoomLanceScript ends on `warpfacing UP, HALL_OF_FAME, 4, 13`, and the
+## Hall of Fame's own scene is what runs `halloffame`. A map scene queued by a
+## warp is picked up by the same run_event_queue() loop that took the warp, so
+## both happen inside one drain and the presentation event surfaces on the
+## warping dispatch's results rather than on a later dispatch_map_entry().
+##
+## The facing is the other half: Script_warpfacing writes it before the warp and
+## nothing in the map load clears it.
+func test_a_warpfacing_runs_the_target_map_scene_in_the_same_event_queue() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# Raw Crystal bytes: warpfacing is source $a1, sdefer $8c, halloffame $9f.
+	scripts["48:6300"] = [0xA3, Gen2WorldSprite.FACING_UP, 1, 2, 2, 2, Gen2WorldScript.END]
+	scripts["48:6310"] = [0x8D, 0x20, 0x63, Gen2WorldScript.END]
+	scripts["48:6320"] = [Gen2WorldScript.SETEVENT, 31, 0, 0xA1, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var target_map: Gen2WorldMap = data.world_map(1, 2)
+	target_map.scripts["callbacks"] = []
+	target_map.scripts["scenes"] = [{"id": 0, "script": 0x6310}]
+
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.events["coord_events"][0]["script"] = 0x6300
+	var results: Array = world.dispatch_script_events()
+
+	assert_eq(world.map_id(), Vector2i(1, 2))
+	assert_eq(world.player_cell, Vector2i(2, 2))
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
+	assert_true(world.event_flag_active(31))
+	assert_true(world.state.hall_of_fame())
+	assert_true(results.any(func(result: Dictionary) -> bool:
+		return result.get("events", []).any(func(event: Dictionary) -> bool:
+			return event.get("type", &"") == &"hall_of_fame_requested"
+		)
+	))
+
+
 func test_the_source_random_command_rolls_on_the_injected_generator() -> void:
 	# RANDOM 4, then set one of four event flags by the value it rolled.
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -196,6 +196,49 @@ const VICTORY_ROAD_LADDERS: Array = [
 	{"step": "victory_road_second_ladder", "cell": Vector2i(13, 31)},
 ]
 
+## The Elite Four, in the order their doors join them. Every map is in the
+## INDIGO group (16); `maps/IndigoPlateauPokecenter1F.asm` warp 4 at (14,3) is
+## the only way in and each room's exit pair leads to the next.
+##
+## The four rooms share one shape. `<Room>DoorLocksBehindYouScript` walks the
+## player four cells north of the arrival warp and walls the entrance, the boss
+## stands on (5,7) and is faced from (5,8), and beating them opens the exit
+## block over (4,2)/(5,2). Lance's room is taller and is not talked to at all:
+## its coord events on (4,5) and (5,5) run the approach and the champion scene.
+const ELITE_FOUR_ROOM_ARRIVAL: Vector2i = Vector2i(5, 17)
+const ELITE_FOUR_ROOM_BOSS_FACE: Vector2i = Vector2i(5, 8)
+const ELITE_FOUR_ROOM_EXIT: Vector2i = Vector2i(5, 2)
+## Four `step UP` (`<Room>_EnterMovement`), so the scene settles here.
+const ELITE_FOUR_ENTER_STEPS: int = 4
+const INDIGO_PLATEAU_ELITE_FOUR_DOOR: Vector2i = Vector2i(14, 3)
+
+## constants/event_flags.asm, the same numbers in both pins. Each room sets its
+## own entrance flag on entry and its exit flag when its boss falls.
+const ELITE_FOUR_ROOMS: Array = [
+	{"step": "wills_room", "number": 3, "beat": 1464, "entrance": 777, "exit": 778},
+	{"step": "kogas_room", "number": 4, "beat": 1465, "entrance": 779, "exit": 780},
+	{"step": "brunos_room", "number": 5, "beat": 1466, "entrance": 781, "exit": 782},
+	{"step": "karens_room", "number": 6, "beat": 1467, "entrance": 783, "exit": 784},
+]
+
+## Lance's room (16/7) and the Hall of Fame (16/8).
+const LANCES_ROOM_NUMBER: int = 7
+const HALL_OF_FAME_NUMBER: int = 8
+const LANCES_ROOM_ARRIVAL: Vector2i = Vector2i(5, 23)
+## The coord event pair is (4,5) and (5,5); the walk stops below the right one
+## and steps onto it, because a resolving walk would re-dispatch the cell.
+const LANCE_APPROACH: Vector2i = Vector2i(5, 6)
+const EVENT_LANCES_ROOM_ENTRANCE_CLOSED: int = 785
+const EVENT_BEAT_CHAMPION_LANCE: int = 1468
+## `warpfacing UP, HALL_OF_FAME, 4, 13` is the last command of the champion
+## scene, so the player never walks Lance's own exit door.
+const HALL_OF_FAME_ARRIVAL: Vector2i = Vector2i(4, 13)
+## The flags `HallOfFameEnterScript` writes before `halloffame`.
+const EVENT_BEAT_ELITE_FOUR: int = 68
+const EVENT_TELEPORT_GUY: int = 1916
+const EVENT_RIVAL_SPROUT_TOWER: int = 1732
+const EVENT_RED_IN_MT_SILVER: int = 1890
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
@@ -3507,7 +3550,11 @@ func _kanto_approach_path(
 	if not bool(gate.get("ok", false)):
 		return gate
 
-	return _victory_road_leg(world, save, random, data, path)
+	var road: Dictionary = _victory_road_leg(world, save, random, data, path)
+	if not bool(road.get("ok", false)):
+		return road
+
+	return _elite_four_leg(world, save, random, data, path)
 
 
 ## The Dragon Shrine back to New Bark Town.
@@ -4127,6 +4174,212 @@ func _victory_road_leg(
 		}
 	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_INDIGO_PLATEAU):
 		return {"ok": false, "path": path, "reason": "the Indigo Plateau flypoint was not set"}
+	return {"ok": true}
+
+
+## The Indigo Plateau Pokemon Center to the Hall of Fame.
+##
+## The five rooms are one corridor with a door between each pair, and no heal
+## anywhere in it. `_drain_story()` answers every battle with a win, so what
+## this walks is the doors, the scenes and the flags, not five fights a party
+## survived.
+##
+## `IndigoPlateauPokecenter1FPrepareElite4Callback` has already run on the
+## Pokemon Center's own map entry: it sets all six scenes and clears the twelve
+## room flags, so each room arrives on its `_LOCK_DOOR` scene.
+func _elite_four_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var entered: Dictionary = _warp_chain(
+		world, save, random, data, [INDIGO_PLATEAU_ELITE_FOUR_DOOR]
+	)
+	if not bool(entered.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Elite Four door failed: %s" % entered.get("reason", ""),
+		}
+
+	for room: Dictionary in ELITE_FOUR_ROOMS:
+		var settled: Vector2i = ELITE_FOUR_ROOM_ARRIVAL \
+			+ Vector2i(0, -ELITE_FOUR_ENTER_STEPS)
+		if world.player_cell != settled:
+			return {
+				"ok": false, "path": path,
+				"reason": "%s left the player on %s, not %s" % [
+					room["step"], world.player_cell, settled,
+				],
+			}
+		if not world.event_flag_active(int(room["entrance"])):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s did not lock its entrance" % room["step"],
+			}
+
+		var boss: Dictionary = _talk_to(
+			world, ELITE_FOUR_ROOM_BOSS_FACE, Gen2WorldSprite.FACING_UP,
+			save, random, data
+		)
+		path.append({
+			"step": room["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"entrance_closed": world.event_flag_active(int(room["entrance"])),
+			"beaten": world.event_flag_active(int(room["beat"])),
+			"exit_open": world.event_flag_active(int(room["exit"])),
+			"battles": boss.get("run", {}).get("battles", []),
+		})
+		if not bool(boss.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s failed: %s" % [room["step"], boss.get("reason", "")],
+			}
+		if not world.event_flag_active(int(room["beat"])):
+			return {"ok": false, "path": path, "reason": "%s was not beaten" % room["step"]}
+		if not world.event_flag_active(int(room["exit"])):
+			return {"ok": false, "path": path, "reason": "%s did not open its exit" % room["step"]}
+
+		var onward: Dictionary = _warp_chain(
+			world, save, random, data, [ELITE_FOUR_ROOM_EXIT]
+		)
+		if not bool(onward.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the door out of %s failed: %s" % [
+					room["step"], onward.get("reason", ""),
+				],
+			}
+
+	var lance: Dictionary = _lances_room_leg(world, save, random, data, path)
+	if not bool(lance.get("ok", false)):
+		return lance
+	return _hall_of_fame_leg(
+		world, save, random, data, path, int(lance.get("hall_of_fame", 0))
+	)
+
+
+## Lance's room. Nothing here is talked to: `LancesRoomDoorLocksBehindYouScript`
+## sets SCENE_LANCESROOM_APPROACH_LANCE, which arms the coord events on (4,5)
+## and (5,5), and stepping onto one runs the approach, the battle and the whole
+## champion scene through to `warpfacing UP, HALL_OF_FAME, 4, 13`.
+##
+## The cell is stepped onto rather than walked to, the way the Plateau rival
+## coord event is: a resolving walk would re-dispatch it until it ran out of
+## attempts.
+func _lances_room_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var settled: Vector2i = LANCES_ROOM_ARRIVAL + Vector2i(0, -ELITE_FOUR_ENTER_STEPS)
+	if world.map_id() != Vector2i(16, LANCES_ROOM_NUMBER) or world.player_cell != settled:
+		return {
+			"ok": false, "path": path,
+			"reason": "Lance's room started on %s %s, not 16/%d %s" % [
+				_map_value(world), world.player_cell, LANCES_ROOM_NUMBER, settled,
+			],
+		}
+	if not world.event_flag_active(EVENT_LANCES_ROOM_ENTRANCE_CLOSED):
+		return {"ok": false, "path": path, "reason": "Lance's room did not lock its entrance"}
+
+	var approach: Dictionary = _walk_cell_resolving(
+		world, LANCE_APPROACH, save, random, data
+	)
+	if not bool(approach.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk to Lance failed: %s" % approach.get("reason", ""),
+		}
+	var stepped: Dictionary = world.move_result(Vector2i.UP)
+	var champion: Dictionary = {"ok": false, "reason": "the step onto the coord event refused"}
+	if bool(stepped.get("ok", false)):
+		champion = _drain_story(
+			world, _dispatch_after_step(world), save, random, data, true
+		)
+		champion["ok"] = bool(champion.get("terminal", false))
+	path.append({
+		"step": "lances_room",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"beat_lance": world.event_flag_active(EVENT_BEAT_CHAMPION_LANCE),
+		"battles": champion.get("battles", []),
+	})
+	if not bool(champion.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the champion scene failed: %s" % champion.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_BEAT_CHAMPION_LANCE):
+		return {"ok": false, "path": path, "reason": "Lance was not beaten"}
+	if world.map_id() != Vector2i(16, HALL_OF_FAME_NUMBER):
+		return {
+			"ok": false, "path": path,
+			"reason": "the champion scene ended on %s, not the Hall of Fame" % [
+				_map_value(world),
+			],
+		}
+	return {"ok": true, "hall_of_fame": int(champion.get("hall_of_fame", 0))}
+
+
+## The Hall of Fame. `warpfacing` lands here mid-script, and a map scene queued
+## by a warp is picked up by the same run_event_queue() loop that took the warp,
+## so SCENE_HALLOFFAME_ENTER usually runs inside the champion drain and this
+## step's own dispatch finds nothing left. [param carried] is that drain's count
+## of the one event this leg exists to reach.
+##
+## `halloffame` is a presentation boundary: it commits ENGINE_HALL_OF_FAME and
+## emits `hall_of_fame_requested`, which no screen answers yet.
+func _hall_of_fame_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+	carried: int,
+) -> Dictionary:
+	var run: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	var presentations: int = carried + int(run.get("hall_of_fame", 0))
+	path.append({
+		"step": "hall_of_fame",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"beat_elite_four": world.event_flag_active(EVENT_BEAT_ELITE_FOUR),
+		"teleport_guy": world.event_flag_active(EVENT_TELEPORT_GUY),
+		"red_in_mt_silver": world.event_flag_active(EVENT_RED_IN_MT_SILVER),
+		"hall_of_fame_events": presentations,
+		"hall_of_fame_flag": world.state.hall_of_fame(),
+		"badge_count": world.state.badge_count(),
+	})
+	if not bool(run.get("terminal", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Hall of Fame scene failed: %s" % run.get("reason", ""),
+		}
+	for flag: int in [EVENT_BEAT_ELITE_FOUR, EVENT_TELEPORT_GUY, EVENT_RIVAL_SPROUT_TOWER]:
+		if not world.event_flag_active(flag):
+			return {
+				"ok": false, "path": path,
+				"reason": "the Hall of Fame did not set event flag %d" % flag,
+			}
+	if world.event_flag_active(EVENT_RED_IN_MT_SILVER):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Hall of Fame did not clear EVENT_RED_IN_MT_SILVER",
+		}
+	if presentations != 1:
+		return {
+			"ok": false, "path": path,
+			"reason": "halloffame emitted %d presentation events, not one" % presentations,
+		}
+	if not world.state.hall_of_fame():
+		return {"ok": false, "path": path, "reason": "ENGINE_HALL_OF_FAME was not set"}
 	return {"ok": true}
 
 
@@ -5054,6 +5307,7 @@ func _drain_story(
 	var pending_trace: Array[String] = []
 	var battles: Array = []
 	var catch_tutorials: int = 0
+	var hall_of_fame: int = _hall_of_fame_events(results)
 	var approaches: Array = []
 	for result: Dictionary in results:
 		if not bool(result.get("ok", false)):
@@ -5199,6 +5453,7 @@ func _drain_story(
 		if results.is_empty():
 			break
 		statuses.append_array(_statuses(results))
+		hall_of_fame += _hall_of_fame_events(results)
 		waits += 1
 		for result: Dictionary in results:
 			if not bool(result.get("ok", false)):
@@ -5218,6 +5473,7 @@ func _drain_story(
 		"pending_trace": pending_trace,
 		"battles": battles,
 		"catch_tutorials": catch_tutorials,
+		"hall_of_fame": hall_of_fame,
 		"approaches": approaches,
 		"terminal": last_reason.is_empty() \
 			and not world.script_input_waiting() and world.pending_runtime_request().is_empty(),
@@ -5553,3 +5809,15 @@ func _statuses(results: Array) -> Array[String]:
 	for result: Dictionary in results:
 		out.append(String(result.get("status", "")))
 	return out
+
+
+## `halloffame` commits ENGINE_HALL_OF_FAME and emits this, the one presentation
+## event on the route with no screen behind it. Counted so the walk can say the
+## boundary was reached rather than only that the flag is set.
+func _hall_of_fame_events(results: Array) -> int:
+	var count: int = 0
+	for result: Dictionary in results:
+		for event: Dictionary in result.get("events", []):
+			if StringName(event.get("type", &"")) == &"hall_of_fame_requested":
+				count += 1
+	return count

--- a/tools/validate_elite_four.gd
+++ b/tools/validate_elite_four.gd
@@ -1,0 +1,359 @@
+extends SceneTree
+
+## Verifies the corridor from the Indigo Plateau Pokemon Center to the Hall of
+## Fame, against freshly imported real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `maps/IndigoPlateauPokecenter1F.asm`, `maps/WillsRoom.asm`,
+## `maps/KogasRoom.asm`, `maps/BrunosRoom.asm`, `maps/KarensRoom.asm`,
+## `maps/LancesRoom.asm` and `maps/HallOfFame.asm`. The Pokemon Center and the
+## Hall of Fame are byte identical between the pins and the four rooms differ
+## only in their `reanchormap` operand ($86 Crystal, $85 Gold/Silver). Lance's
+## room is the profile split: Gold and Silver put Lance one row further up, its
+## exit warps on y=0 rather than y=1, and end the champion scene with `warp`
+## rather than `warpfacing`.
+##
+## What is worth pinning is the two block changes each room turns on. Nothing
+## else stops the leg: the door behind the player is walled by the entrance
+## scene, and the door ahead is opened only by the boss.
+##
+##   Godot --headless --path . -s res://tools/validate_elite_four.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm's INDIGO group, the 16th `newgroup`.
+const INDIGO_GROUP: int = 16
+const POKECENTER_NUMBER: int = 2
+const LANCES_ROOM_NUMBER: int = 7
+const HALL_OF_FAME_NUMBER: int = 8
+
+## `IndigoPlateauPokecenter1F_MapEvents` warp 4, the only way in.
+const ELITE_FOUR_DOOR: Vector2i = Vector2i(14, 3)
+## The cell the route stands on when it takes that door.
+const POKECENTER_APPROACH: Vector2i = Vector2i(16, 4)
+
+## The four rooms, in door order. Each is 5x9 blocks, arrives on (5,17), walls
+## (4,14) behind the player and opens (4,2) ahead of them.
+const ROOMS: Array = [3, 4, 5, 6]
+const ROOM_SIZE_BLOCKS: Vector2i = Vector2i(5, 9)
+const ROOM_ARRIVAL: Vector2i = Vector2i(5, 17)
+const ROOM_BOSS: Vector2i = Vector2i(5, 7)
+const ROOM_EXIT: Vector2i = Vector2i(4, 2)
+const ROOM_SEAL: Vector2i = Vector2i(4, 14)
+## `<Room>_EnterMovement` is four `step UP`.
+const ENTER_STEPS: int = 4
+
+## Lance's room is 5x12 blocks and everything in it sits four rows lower.
+const LANCES_ROOM_SIZE_BLOCKS: Vector2i = Vector2i(5, 12)
+const LANCES_ROOM_ARRIVAL: Vector2i = Vector2i(5, 23)
+const LANCES_ROOM_SEAL: Vector2i = Vector2i(4, 22)
+const LANCES_ROOM_DOOR: Vector2i = Vector2i(4, 0)
+## `coord_event 4, 5` and `coord_event 5, 5`, both on
+## SCENE_LANCESROOM_APPROACH_LANCE, which is scene 1: scene constants count from
+## zero in `scene_script` declaration order (`macros/scripts/maps.asm`).
+const LANCE_COORD_EVENTS: Array = [Vector2i(4, 5), Vector2i(5, 5)]
+const LANCE_APPROACH_SCENE: int = 1
+
+## The Hall of Fame is 5x7 blocks; the champion scene lands the player on (4,13)
+## and Lance is already standing on (4,12).
+const HALL_OF_FAME_SIZE_BLOCKS: Vector2i = Vector2i(5, 7)
+const HALL_OF_FAME_ARRIVAL: Vector2i = Vector2i(4, 13)
+const HALL_OF_FAME_LANCE: Vector2i = Vector2i(4, 12)
+
+## The block ids the rooms change (`<Room>DoorsCallback` and the boss scripts).
+const BLOCK_ROOM_WALL: int = 0x2a
+const BLOCK_ROOM_DOOR: int = 0x16
+const BLOCK_LANCE_WALL: int = 0x34
+const BLOCK_LANCE_DOOR: int = 0x0b
+
+## constants/event_flags.asm, the same numbers in both pins. The twelve
+## `IndigoPlateauPokecenter1FPrepareElite4Callback` clears, then the five it
+## leaves the boss scripts to set.
+const PREPARED_FLAGS: Array[int] = [
+	777, 778, 779, 780, 781, 782, 783, 784, 785, 786,
+	1464, 1465, 1466, 1467, 1468,
+]
+## The same callback's one `setevent`, which is what puts Oak and Mary out of
+## Lance's room until the champion scene calls them in.
+const EVENT_LANCES_ROOM_OAK_AND_MARY: int = 1887
+
+const STEPS: Array[Vector2i] = [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_pokecenter(data, game_id)
+		for number: int in ROOMS:
+			_verify_room(data, game_id, number)
+		_verify_lances_room(data, game_id)
+		_verify_hall_of_fame(data, game_id)
+	_finish()
+
+
+## The one door in, and the prepare callback that resets the leg.
+##
+## This is the one map here worth entering: `MAPCALLBACK_NEWMAP` is what
+## `IndigoPlateauPokecenter1FPrepareElite4Callback` hangs off, and it is a
+## reset, so it is checked by setting every flag it clears beforehand.
+func _verify_pokecenter(data: GameData, game_id: StringName) -> void:
+	var state := Gen2WorldState.new()
+	for flag: int in PREPARED_FLAGS:
+		state.set_event_flag(flag)
+	state.set_event_flag(EVENT_LANCES_ROOM_OAK_AND_MARY, false)
+	var world: Gen2WorldAPI = _open(data, POKECENTER_NUMBER, POKECENTER_APPROACH, state)
+	if world == null:
+		_fail("%s: Indigo Plateau Pokemon Center is missing." % game_id)
+		return
+	var warp: Dictionary = world.warp_at(ELITE_FOUR_DOOR)
+	_check(
+		int(warp.get("map_group", -1)) == INDIGO_GROUP
+			and int(warp.get("map_number", -1)) == ROOMS[0],
+		"%s: %s is not the door into Will's room." % [game_id, ELITE_FOUR_DOOR]
+	)
+	_check(
+		_reaches(world, POKECENTER_APPROACH, ELITE_FOUR_DOOR),
+		"%s: the Elite Four door is not reachable from %s." % [game_id, POKECENTER_APPROACH]
+	)
+
+	var _entry: Array = world.dispatch_map_entry()
+	for _step: int in 8:
+		if world.pending_script_input().is_empty():
+			break
+		world.run_event_queue(true)
+	for flag: int in PREPARED_FLAGS:
+		_check(
+			not world.event_flag_active(flag),
+			"%s: the prepare callback left event flag %d set." % [game_id, flag]
+		)
+	_check(
+		world.event_flag_active(EVENT_LANCES_ROOM_OAK_AND_MARY),
+		"%s: the prepare callback did not hide Oak and Mary." % game_id
+	)
+
+
+## One of the four identical rooms: the boss on its own cell, the entrance the
+## scene walls behind the player, and the exit only the boss opens.
+func _verify_room(data: GameData, game_id: StringName, number: int) -> void:
+	var world: Gen2WorldAPI = _open(data, number, ROOM_ARRIVAL)
+	if world == null:
+		_fail("%s: map %d/%d is missing." % [game_id, INDIGO_GROUP, number])
+		return
+	_check(
+		Vector2i(world.current_map.width_blocks, world.current_map.height_blocks)
+			== ROOM_SIZE_BLOCKS,
+		"%s: %d/%d is %dx%d blocks, not the pinned %s." % [
+			game_id, INDIGO_GROUP, number, world.current_map.width_blocks,
+			world.current_map.height_blocks, ROOM_SIZE_BLOCKS,
+		]
+	)
+	_check(
+		_object_at(world, ROOM_BOSS),
+		"%s: %d/%d has no boss object on %s." % [game_id, INDIGO_GROUP, number, ROOM_BOSS]
+	)
+	var exit_warp: Dictionary = world.warp_at(ROOM_EXIT)
+	_check(
+		int(exit_warp.get("map_group", -1)) == INDIGO_GROUP
+			and int(exit_warp.get("map_number", -1)) == number + 1,
+		"%s: %d/%d's exit on %s does not lead to the next room." % [
+			game_id, INDIGO_GROUP, number, ROOM_EXIT,
+		]
+	)
+	_verify_doors(
+		world, game_id, "%d/%d" % [INDIGO_GROUP, number], ROOM_ARRIVAL,
+		ROOM_SEAL, BLOCK_ROOM_WALL, ROOM_EXIT, ROOM_EXIT, BLOCK_ROOM_DOOR
+	)
+
+
+## Lance's room. Its geometry is the profile split, and it is the only room
+## whose boss is reached by a coord event rather than by facing an object.
+func _verify_lances_room(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, LANCES_ROOM_NUMBER, LANCES_ROOM_ARRIVAL)
+	if world == null:
+		_fail("%s: Lance's room is missing." % game_id)
+		return
+	_check(
+		Vector2i(world.current_map.width_blocks, world.current_map.height_blocks)
+			== LANCES_ROOM_SIZE_BLOCKS,
+		"%s: Lance's room is %dx%d blocks, not the pinned %s." % [
+			game_id, world.current_map.width_blocks, world.current_map.height_blocks,
+			LANCES_ROOM_SIZE_BLOCKS,
+		]
+	)
+	# Gold and Silver stand Lance one row higher and put the Hall of Fame warps
+	# on y=0 rather than y=1.
+	var crystal: bool = game_id == &"crystal"
+	var lance_cell := Vector2i(5, 3 if crystal else 2)
+	var exit_cell := Vector2i(4, 1 if crystal else 0)
+	_check(
+		_object_at(world, lance_cell),
+		"%s: Lance is not standing on %s." % [game_id, lance_cell]
+	)
+	var coords: Array = []
+	for event: Dictionary in world.current_map.events.get("coord_events", []):
+		coords.append(Vector2i(int(event.get("x", -1)), int(event.get("y", -1))))
+		_check(
+			int(event.get("scene", -1)) == LANCE_APPROACH_SCENE,
+			"%s: Lance's coord event on %s is not on scene %d." % [
+				game_id, coords[-1], LANCE_APPROACH_SCENE,
+			]
+		)
+	_check(
+		coords == LANCE_COORD_EVENTS,
+		"%s: Lance's coord events are on %s, not the pinned %s." % [
+			game_id, coords, LANCE_COORD_EVENTS,
+		]
+	)
+	var exit_warp: Dictionary = world.warp_at(exit_cell)
+	_check(
+		int(exit_warp.get("map_group", -1)) == INDIGO_GROUP
+			and int(exit_warp.get("map_number", -1)) == HALL_OF_FAME_NUMBER,
+		"%s: Lance's exit on %s does not lead to the Hall of Fame." % [game_id, exit_cell]
+	)
+	_verify_doors(
+		world, game_id, "Lance's room", LANCES_ROOM_ARRIVAL,
+		LANCES_ROOM_SEAL, BLOCK_LANCE_WALL, LANCES_ROOM_DOOR, exit_cell, BLOCK_LANCE_DOOR
+	)
+
+
+## The Hall of Fame, which the champion scene warps into rather than walks into.
+func _verify_hall_of_fame(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, HALL_OF_FAME_NUMBER, HALL_OF_FAME_ARRIVAL)
+	if world == null:
+		_fail("%s: the Hall of Fame is missing." % game_id)
+		return
+	_check(
+		Vector2i(world.current_map.width_blocks, world.current_map.height_blocks)
+			== HALL_OF_FAME_SIZE_BLOCKS,
+		"%s: the Hall of Fame is %dx%d blocks, not the pinned %s." % [
+			game_id, world.current_map.width_blocks, world.current_map.height_blocks,
+			HALL_OF_FAME_SIZE_BLOCKS,
+		]
+	)
+	_check(
+		_object_at(world, HALL_OF_FAME_LANCE),
+		"%s: Lance is not standing on %s." % [game_id, HALL_OF_FAME_LANCE]
+	)
+	# HallOfFame_WalkUpWithLance is eight `step UP` then one `step RIGHT`, with
+	# the player following, so the column north of the arrival has to be open.
+	_check(
+		_reaches(world, HALL_OF_FAME_ARRIVAL, HALL_OF_FAME_ARRIVAL + Vector2i(0, -9)),
+		"%s: the Hall of Fame machine is not reachable from %s." % [
+			game_id, HALL_OF_FAME_ARRIVAL,
+		]
+	)
+
+
+## The two block changes a room turns on, checked as reachability rather than as
+## collision bytes: the entrance scene has to cut the arrival warp off, and the
+## boss has to open a door that was solid before them.
+##
+## [param seal] and [param door] are source walk cells, which a `changeblock`
+## takes; a block spans 2x2 of them, so the block index is the cell halved.
+func _verify_doors(
+	world: Gen2WorldAPI,
+	game_id: StringName,
+	label: String,
+	arrival: Vector2i,
+	seal: Vector2i,
+	seal_block: int,
+	door: Vector2i,
+	exit_cell: Vector2i,
+	door_block: int,
+) -> void:
+	var settled: Vector2i = arrival + Vector2i(0, -ENTER_STEPS)
+	_check(
+		world.can_walk_to(settled) and _reaches(world, settled, arrival),
+		"%s: %s does not walk %d cells north of %s." % [game_id, label, ENTER_STEPS, arrival]
+	)
+	_check(
+		_reaches(world, settled, exit_cell + Vector2i(0, 1)),
+		"%s: %s does not reach its own exit door from %s." % [game_id, label, settled]
+	)
+	_check(
+		not world.can_walk_to(exit_cell) and not _reaches(world, settled, exit_cell),
+		"%s: %s's exit on %s is open before its boss." % [game_id, label, exit_cell]
+	)
+	_check(
+		bool(world.change_block(seal.x / 2, seal.y / 2, seal_block).get("ok", false))
+			and not _reaches(world, settled, arrival),
+		"%s: %s's entrance scene does not seal %s." % [game_id, label, arrival]
+	)
+	_check(
+		bool(world.change_block(door.x / 2, door.y / 2, door_block).get("ok", false))
+			and world.can_walk_to(exit_cell) and _reaches(world, settled, exit_cell),
+		"%s: %s's boss does not open the exit on %s." % [game_id, label, exit_cell]
+	)
+
+
+## Map entry is deliberately not dispatched for the rooms. Every one of them
+## has an entry scene that walls the door behind the player, and the Hall of
+## Fame's walks Lance off his own cell, so a dispatched world describes the
+## scripts rather than the map they run on. Proving the scripts is the walked
+## route's job (`tools/preview_world_story.gd`); this pins what they act on.
+func _open(
+	data: GameData, number: int, cell: Vector2i, state: Gen2WorldState = null
+) -> Gen2WorldAPI:
+	return Gen2WorldAPI.open(
+		data, INDIGO_GROUP, number, cell,
+		state if state != null else Gen2WorldState.new()
+	)
+
+
+func _object_at(world: Gen2WorldAPI, cell: Vector2i) -> bool:
+	for object: Gen2WorldObject in world.objects:
+		if object.cell == cell:
+			return true
+	return false
+
+
+## Plain walking reachability. Warp tiles are walls unless they are the target,
+## the way a walked route has it: stepping onto one takes it.
+func _reaches(world: Gen2WorldAPI, from: Vector2i, target: Vector2i) -> bool:
+	var seen: Dictionary = {from: true}
+	var frontier: Array[Vector2i] = [from]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		if cell == target:
+			return true
+		for step: Vector2i in STEPS:
+			var next: Vector2i = cell + step
+			if seen.has(next) or not world.can_walk_to(next, step):
+				continue
+			if next != target and not world.warp_at(next).is_empty() \
+				and Gen2WorldCollision.is_warp_tile(world.collision_code_at(next)):
+				continue
+			# can_walk_to() reads the leave/enter mask at the API's own player
+			# cell; from a frontier it has to be anchored on the frontier cell.
+			var face: int = Gen2WorldCollision.face_mask_for_direction(step)
+			if face != 0 and (world.tile_permissions_at(cell) & face) != 0:
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen.has(target)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS elite four: the five rooms' doors, coord events and flags verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL elite four: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_elite_four.gd.uid
+++ b/tools/validate_elite_four.gd.uid
@@ -1,0 +1,1 @@
+uid://b12t1xtw2bfrc


### PR DESCRIPTION
The story route reached the Indigo Plateau Pokemon Center and stopped. It now carries on through Will, Koga, Bruno, Karen and Lance into the Hall of Fame, ending on halloffame.

The five rooms are one corridor with a door between each pair and no heal anywhere in it. _drain_story() answers every battle with a win, so what the walk proves is the doors, the scenes and the flags, not that a party survived the fights.

Lance is not talked to: his room's entry scene arms the coord events on (4,5) and (5,5), and stepping onto one runs the approach, the battle and the champion scene through to warpfacing UP, HALL_OF_FAME, 4, 13. A map scene queued by a script warp is picked up by the same run_event_queue() loop that took the warp, so HallOfFameEnterScript runs in that same drain and the one hall_of_fame_requested event surfaces there.

warpfacing dropped its facing: the runner emitted player_facing_requested and nothing applied it. Script_warpfacing writes the facing before the warp and the map load never clears it, so it is applied beside the warp now.

tools/validate_elite_four.gd pins the seven maps, the one door in, the prepare callback's flag reset and each room's sealed entrance and boss-opened exit, in all three games. It does not dispatch map entry: every room's scene would rewrite the map the check is about.