### PR TITLE
Show the Hall of Fame

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Headless tools, all against a real imported cache:
 |---|---|
 | `preview_world_services.gd <png>` | mart overlay, deterministic integration cache |
 | `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
+| `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
 | `validate_crystal_route30_trainer.gd` | trainer record, sight line, approach, battle request, beaten flag, later interaction |
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -266,7 +266,15 @@ const GENDER_NONE: StringName = &"genderless"
 
 
 func gender() -> StringName:
-	var ratio: int = int(data.species(species).get("gender_ratio", GENDER_UNKNOWN))
+	return gender_for(data, species, dvs)
+
+
+## The same answer for a Pokémon that is not in a battle, so the Hall of Fame's
+## induction panel reads the rule from here rather than restating it.
+static func gender_for(data_source: GameData, species_number: int, mon_dvs: int) -> StringName:
+	var ratio: int = int(
+		data_source.species(species_number).get("gender_ratio", GENDER_UNKNOWN)
+	)
 	if ratio == GENDER_UNKNOWN:
 		return GENDER_NONE
 	if ratio == GENDER_F0:
@@ -274,7 +282,7 @@ func gender() -> StringName:
 	if ratio == GENDER_F100:
 		return GENDER_FEMALE
 
-	var combined: int = (Gen2Stats.attack_dv(dvs) << 4) | Gen2Stats.speed_dv(dvs)
+	var combined: int = (Gen2Stats.attack_dv(mon_dvs) << 4) | Gen2Stats.speed_dv(mon_dvs)
 	return GENDER_MALE if combined < ratio else GENDER_FEMALE
 
 

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -101,6 +101,53 @@ func draw_frame_code(
 	blit_slot(_frames, _frame_width, slot, into, into_width, at_x, at_y)
 
 
+## A whole box border, [param columns] by [param rows] tiles with its top-left
+## at [param at_x]/[param at_y] in pixels. The right-hand side reuses the same
+## vertical tile as the left and the bottom edge reuses the top's horizontal: a
+## frame is six tiles, not eight, and the two it does not have are the two the
+## hardware never needed.
+func draw_box(
+	frame: int,
+	into: PackedByteArray,
+	into_width: int,
+	at_x: int,
+	at_y: int,
+	columns: int,
+	rows: int
+) -> void:
+	if columns < 2 or rows < 2:
+		return
+	var right: int = at_x + (columns - 1) * TILE
+	var bottom: int = at_y + (rows - 1) * TILE
+	var vertical: int = RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_VERTICAL
+	var horizontal: int = RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_HORIZONTAL
+
+	draw_frame_code(
+		frame, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_LEFT,
+		into, into_width, at_x, at_y
+	)
+	draw_frame_code(
+		frame, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_RIGHT,
+		into, into_width, right, at_y
+	)
+	draw_frame_code(
+		frame, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_BOTTOM_LEFT,
+		into, into_width, at_x, bottom
+	)
+	draw_frame_code(
+		frame, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_BOTTOM_RIGHT,
+		into, into_width, right, bottom
+	)
+	for column: int in range(1, columns - 1):
+		var x: int = at_x + column * TILE
+		draw_frame_code(frame, horizontal, into, into_width, x, at_y)
+		draw_frame_code(frame, horizontal, into, into_width, x, bottom)
+	for row: int in range(1, rows - 1):
+		var y: int = at_y + row * TILE
+		draw_frame_code(frame, vertical, into, into_width, at_x, y)
+		draw_frame_code(frame, vertical, into, into_width, right, y)
+
+
 ## Copies one tile out of a strip, clipped to the destination. Clipping rather
 ## than refusing, because a text box that runs off the edge of the screen should
 ## look wrong at the edge and be right everywhere else.

--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -1,0 +1,140 @@
+class_name Gen2HallOfFamePage
+extends RefCounted
+
+## One Hall of Fame induction panel, on the tile grid the hardware uses.
+##
+## Positions are `engine/events/halloffame.asm`'s own: DisplayHOFMon's two text
+## boxes, its frontpic at (6,5) and every field row it prints, and
+## HOF_AnimatePlayerPic's name box for the player's page.
+##
+## Three of the source's glyphs are not drawn, because the project imports no
+## strip that has them. The font cache is 128 tiles from $80
+## ([constant RomLayout.FONT_FIRST_CODE]), while `№` is $74, `<ID>` is $73 and
+## `<LV>` is $6e, all in `gfx/font/font_battle_extra.png`. Plain words stand in
+## rather than invented artwork, which shifts the two number columns one tile
+## right of the cartridge's.
+##
+## Node-free: it writes indices into a buffer, so a page can be drawn and read
+## back headless. The Pokémon's own pic is not in that buffer; it has its own
+## palette and is composed over the page by the screen.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## DisplayHOFMon: `Textbox` takes the interior, so 18x3 at (0,0) draws 20x5.
+const MON_TOP_BOX: Rect2i = Rect2i(0, 0, 20, 5)
+const MON_BOTTOM_BOX: Rect2i = Rect2i(0, 12, 20, 6)
+const CAPTION: Vector2i = Vector2i(1, 2)
+const CAPTION_TEXT: String = "New Hall of Famer!"
+
+## `hlcoord 6, 5`, and the pic is seven tiles square.
+const PIC_AT: Vector2i = Vector2i(6, 5)
+const PIC_TILES: int = 7
+
+## The source prints `№` then `<DOT>` in two tiles and the three digits in the
+## next three, leaving column 6 blank before the name. "No." fills three tiles,
+## so the number and the name each move one column right and the blank stays.
+const DEX_LABEL: Vector2i = Vector2i(1, 13)
+const DEX_NUMBER: Vector2i = Vector2i(4, 13)
+const DEX_DIGITS: int = 3
+const SPECIES_NAME: Vector2i = Vector2i(8, 13)
+const GENDER: Vector2i = Vector2i(18, 13)
+const NICKNAME_SLASH: Vector2i = Vector2i(8, 14)
+const LEVEL: Vector2i = Vector2i(1, 16)
+## `<ID>№/` is three tiles at (7,16); "ID" plus the slash is three as well.
+const OT_LABEL: Vector2i = Vector2i(7, 16)
+const OT_NUMBER: Vector2i = Vector2i(10, 16)
+const OT_DIGITS: int = 5
+
+## HOF_AnimatePlayerPic's `Textbox` at (0,2) with a 9x8 interior.
+const PLAYER_BOX: Rect2i = Rect2i(0, 2, 11, 10)
+const PLAYER_NAME: Vector2i = Vector2i(2, 4)
+
+## `Textbox` draws with wTextboxFrame, whose new-game value is the first frame.
+## The options screen that lets a player change it does not exist yet.
+const FRAME_STYLE: int = 0
+
+var font: Gen2Font = null
+
+
+static func from_data(data: GameData) -> Gen2HallOfFamePage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null:
+		return null
+	var out := Gen2HallOfFamePage.new()
+	out.font = glyphs
+	return out
+
+
+## The whole 160x144 page as palette indices. [param page] is one row of
+## [method Gen2HallOfFame.pages].
+func draw(page: Dictionary) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(COLUMNS * TILE * ROWS * TILE)
+	if font == null:
+		return indices
+	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_PLAYER:
+		_draw_player(page, indices)
+	else:
+		_draw_mon(page, indices)
+	return indices
+
+
+## Where the screen puts the front pic, in pixels.
+static func pic_position() -> Vector2i:
+	return PIC_AT * TILE
+
+
+static func pic_size() -> int:
+	return PIC_TILES * TILE
+
+
+func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_box(indices, width, MON_TOP_BOX)
+	_box(indices, width, MON_BOTTOM_BOX)
+	_text(indices, width, CAPTION_TEXT, CAPTION)
+
+	_text(indices, width, "No.", DEX_LABEL)
+	## PRINTNUM_LEADINGZEROS, so a two-digit dex number keeps its column.
+	_text(indices, width, "%0*d" % [DEX_DIGITS, int(page.get("dex_number", 0))], DEX_NUMBER)
+	_text(indices, width, String(page.get("species_name", "")), SPECIES_NAME)
+	_text(indices, width, _gender_glyph(StringName(page.get("gender", &""))), GENDER)
+
+	_text(indices, width, "/", NICKNAME_SLASH)
+	_text(indices, width, String(page.get("nickname", "")), NICKNAME_SLASH + Vector2i(1, 0))
+	_text(indices, width, "Lv%d" % int(page.get("level", 0)), LEVEL)
+	_text(indices, width, "ID/", OT_LABEL)
+	_text(indices, width, "%0*d" % [OT_DIGITS, int(page.get("ot_id", 0))], OT_NUMBER)
+
+
+## The player's page is the name box alone. The source also slides in the
+## player's own pic and prints the trainer ID and PLAY TIME beneath the name;
+## the project imports no player pic and its save model carries neither number,
+## so nothing stands in for them.
+func _draw_player(page: Dictionary, indices: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_box(indices, width, PLAYER_BOX)
+	_text(indices, width, String(page.get("player_name", "")), PLAYER_NAME)
+
+
+## GetGender answers one of three, and the source prints a space for a
+## genderless Pokémon rather than a symbol.
+func _gender_glyph(gender: StringName) -> String:
+	if gender == Gen2BattleMon.GENDER_MALE:
+		return "♂"
+	if gender == Gen2BattleMon.GENDER_FEMALE:
+		return "♀"
+	return " "
+
+
+func _box(indices: PackedByteArray, width: int, box: Rect2i) -> void:
+	font.draw_box(
+		FRAME_STYLE, indices, width,
+		box.position.x * TILE, box.position.y * TILE, box.size.x, box.size.y
+	)
+
+
+func _text(indices: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
+	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE)

--- a/game/render/hall_of_fame_page.gd.uid
+++ b/game/render/hall_of_fame_page.gd.uid
@@ -1,0 +1,1 @@
+uid://flkdvtarwowy

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -167,39 +167,8 @@ func _redraw() -> void:
 	size = Vector2(width, height)
 
 
-## The border, as the characters $79 to $7E. The right-hand side reuses the same
-## vertical tile as the left and the bottom edge reuses the top's horizontal:
-## a frame is six tiles, not eight, and the two it does not have are the two the
-## hardware never needed.
 func _draw_border(indices: PackedByteArray, width: int) -> void:
-	var right: int = (columns - 1) * TILE
-	var bottom: int = (rows - 1) * TILE
-	var vertical: int = RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_VERTICAL
-	var horizontal: int = RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_HORIZONTAL
-
-	font.draw_frame_code(
-		frame_style, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_LEFT, indices, width, 0, 0
-	)
-	font.draw_frame_code(
-		frame_style, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_RIGHT,
-		indices, width, right, 0
-	)
-	font.draw_frame_code(
-		frame_style, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_BOTTOM_LEFT,
-		indices, width, 0, bottom
-	)
-	font.draw_frame_code(
-		frame_style, RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_BOTTOM_RIGHT,
-		indices, width, right, bottom
-	)
-
-	for column: int in range(1, columns - 1):
-		font.draw_frame_code(frame_style, horizontal, indices, width, column * TILE, 0)
-		font.draw_frame_code(frame_style, horizontal, indices, width, column * TILE, bottom)
-
-	for row: int in range(1, rows - 1):
-		font.draw_frame_code(frame_style, vertical, indices, width, 0, row * TILE)
-		font.draw_frame_code(frame_style, vertical, indices, width, right, row * TILE)
+	font.draw_box(frame_style, indices, width, 0, 0, columns, rows)
 
 
 func _draw_lines(indices: PackedByteArray, width: int) -> void:

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -1,0 +1,59 @@
+class_name Gen2HallOfFame
+extends RefCounted
+
+## The induction sequence `halloffame` asks for, as pages a screen can draw.
+##
+## `engine/events/halloffame.asm`'s AnimateHallOfFame walks the party built by
+## GetHallOfFameParty, showing one panel per Pokémon and then the player's own,
+## so the order and the contents here are that routine's, not a choice.
+##
+## What this does not carry is what the project has no source for. The panel's
+## `<ID>№/` line needs the mon's OT ID, which the save does keep; the player's
+## panel additionally wants the trainer ID and PLAY TIME, which the save model
+## has neither of, so those lines are absent rather than drawn as zeros.
+
+## GetHallOfFameParty's own cap: it copies at most a full party and stops on the
+## -1 terminator.
+const MAX_MONS: int = 6
+
+const PAGE_MON: StringName = &"mon"
+const PAGE_PLAYER: StringName = &"player"
+
+
+## The pages, in AnimateHallOfFame's order: every non-egg party member, then the
+## player. An empty or egg-only party still answers the player's page, matching
+## LoadHOFTeam's carry falling straight through to HOF_AnimatePlayerPic.
+static func pages(data: GameData, save: Gen2SaveData) -> Array:
+	var out: Array = []
+	if data == null or save == null:
+		return out
+	for mon: Gen2SaveMon in save.party:
+		if out.size() >= MAX_MONS:
+			break
+		## GetHallOfFameParty skips EGG without consuming a slot, so an egg is
+		## not inducted and does not shorten the list either.
+		if mon.is_egg:
+			continue
+		out.append(_mon_page(data, mon))
+	out.append({"kind": PAGE_PLAYER, "player_name": save.player_name})
+	return out
+
+
+static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
+	var species_name: String = String(data.species(mon.species).get("name", ""))
+	## DisplayHOFMon prints the species name from GetBasePokemonName and the
+	## nickname separately, so a mon that was never renamed shows the same word
+	## twice. That is the cartridge's own panel, not a bug to collapse.
+	var nickname: String = mon.nickname if not mon.nickname.is_empty() else species_name
+	return {
+		"kind": PAGE_MON,
+		"species": mon.species,
+		## Gen 2 species numbers are dex numbers, which is why DisplayHOFMon
+		## prints wCurPartySpecies straight into the №. field.
+		"dex_number": mon.species,
+		"species_name": species_name,
+		"nickname": nickname,
+		"level": mon.level,
+		"ot_id": mon.ot_id,
+		"gender": Gen2BattleMon.gender_for(data, mon.species, mon.dvs),
+	}

--- a/game/world/hall_of_fame.gd.uid
+++ b/game/world/hall_of_fame.gd.uid
@@ -1,0 +1,1 @@
+uid://cbjybwu86sxrk

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -1,0 +1,136 @@
+class_name Gen2HallOfFameScreen
+extends Control
+
+## The screen behind `halloffame`, embedded in the overworld the way the PC and
+## the mart overlays are.
+##
+## `engine/events/halloffame.asm`'s HallOfFame saves, walks the party one panel
+## at a time and then shows the player's own, and finally runs the credits. What
+## is here is that walk: one page per non-egg party member, then the player's,
+## advanced by A. The credits, ProfOaksPCRating, the backpic and frontpic slides
+## and the palette rotations are not, and neither is the persisted Hall of Fame
+## record, which has no save field to go in.
+##
+## The source pauses 60 frames per panel and moves on by itself. This waits for
+## a key instead: there is no animation to watch yet, so a timer would only be a
+## delay.
+
+signal closed()
+
+const BACKDROP: Color = Color.WHITE
+
+var _data: GameData = null
+var _pages: Array = []
+var _index: int = 0
+var _page_renderer: Gen2HallOfFamePage = null
+var _background: TextureRect = null
+var _pic: TextureRect = null
+
+
+## [param pages] is [method Gen2HallOfFame.pages]. An empty list closes at once
+## rather than showing a blank screen.
+func set_context(data: GameData, pages: Array) -> void:
+	_data = data
+	_pages = pages
+	_page_renderer = Gen2HallOfFamePage.from_data(data)
+	_index = 0
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _page_renderer == null or _pages.is_empty():
+		closed.emit()
+		return
+	_build()
+	_refresh()
+
+
+## How many pages are left, including the one on screen. Drives the scene tests
+## and the screenshot tool without reaching into the array.
+func remaining() -> int:
+	return maxi(_pages.size() - _index, 0)
+
+
+func current_page() -> Dictionary:
+	if _index < 0 or _index >= _pages.size():
+		return {}
+	return _pages[_index]
+
+
+## A, Space or Enter moves on, matching every other text pause in the overworld.
+## There is no way back: the cartridge's panels do not rewind either.
+func handle_key(keycode: int) -> bool:
+	if keycode not in [KEY_Z, KEY_SPACE, KEY_ENTER, KEY_KP_ENTER]:
+		return false
+	advance()
+	return true
+
+
+func advance() -> void:
+	_index += 1
+	if _index >= _pages.size():
+		closed.emit()
+		return
+	_refresh()
+
+
+func _build() -> void:
+	var backdrop := ColorRect.new()
+	backdrop.color = BACKDROP
+	backdrop.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(backdrop)
+
+	## The pic sits under the page so the bottom box's border stays drawn over
+	## it, the way the hardware's window does.
+	_pic = TextureRect.new()
+	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_pic)
+
+	_background = TextureRect.new()
+	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_background)
+
+
+func _refresh() -> void:
+	var page: Dictionary = current_page()
+	if page.is_empty() or _background == null:
+		return
+	var indices: PackedByteArray = _page_renderer.draw(page)
+	var image: Image = Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])),
+		true
+	)
+	_background.texture = ImageTexture.create_from_image(image)
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_refresh_pic(page)
+
+
+func _refresh_pic(page: Dictionary) -> void:
+	if _pic == null:
+		return
+	_pic.texture = null
+	if _data == null or StringName(page.get("kind", &"")) != Gen2HallOfFame.PAGE_MON:
+		return
+	var species: int = int(page.get("species", 0))
+	var pic: Dictionary = _data.species_pic(species)
+	if pic.is_empty():
+		return
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.palette(species)
+	)
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = Vector2(image.get_size())
+	## The source centres a seven-tile cell on (6,5); a pic smaller than that
+	## cell is drawn at its bottom, the way _PrepMonFrontpic places it.
+	var cell: int = Gen2HallOfFamePage.pic_size()
+	var at: Vector2i = Gen2HallOfFamePage.pic_position()
+	_pic.position = Vector2(
+		at.x + (cell - image.get_width()) / 2.0,
+		at.y + cell - image.get_height()
+	)

--- a/game/world/hall_of_fame_screen.gd.uid
+++ b/game/world/hall_of_fame_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://c7qudthje5mpw

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -34,6 +34,9 @@ const SFX_STRENGTH: int = 0x1B
 ## constants/sfx_constants.asm's SFX_BUBBLEBEAM, which Script_UsedWaterfall plays
 ## after its text and before the first climbing step.
 const SFX_WATERFALL: int = 0x51
+## constants/music_constants.asm, which AnimateHallOfFame plays over the whole
+## induction.
+const MUSIC_HALL_OF_FAME: int = 20
 
 @export var map_group: int = 24
 @export var map_number: int = 3
@@ -64,6 +67,7 @@ var _service_host: Gen2WorldServiceScreen = null
 var _pc_host: Gen2BoxScreen = null
 var _start_menu_host: Gen2StartMenuScreen = null
 var _party_host: Gen2PartyScreen = null
+var _hall_of_fame_host: Gen2HallOfFameScreen = null
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
@@ -262,6 +266,7 @@ func _process(delta: float) -> void:
 			_update_time_of_day()
 			if _service_host == null and _battle_host == null and _pc_host == null \
 				and _start_menu_host == null and _party_host == null \
+				and _hall_of_fame_host == null \
 				and not _world.script_input_waiting():
 				var phone_schedule: Dictionary = _world.advance_phone_schedule(
 					ticks.size(), _encounter_random
@@ -306,6 +311,7 @@ func _objects_may_move() -> bool:
 	return _world != null \
 		and _battle_host == null and _service_host == null and _pc_host == null \
 		and _start_menu_host == null and _party_host == null \
+		and _hall_of_fame_host == null \
 		and not _field_move_text \
 		and _trainer_approach.is_empty() \
 		and not _world.script_busy() \
@@ -323,6 +329,13 @@ func _unhandled_key_input(event: InputEvent) -> void:
 		accept_event()
 		return
 	if _world.phone_ring_active():
+		accept_event()
+		return
+	## Before the PC and the party overlay because the Hall of Fame is the one
+	## overlay a script opens with nothing behind it: there is no map to go back
+	## to until it has finished, and it takes no cancel.
+	if _hall_of_fame_host != null:
+		_hall_of_fame_host.handle_key(key.keycode)
 		accept_event()
 		return
 	if _pc_host != null:
@@ -456,7 +469,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _renderer_input_free() -> bool:
 	return _world != null and _battle_host == null and _service_host == null \
 		and _pc_host == null and _start_menu_host == null and _party_host == null \
-		and not _field_move_text \
+		and _hall_of_fame_host == null and not _field_move_text \
 		and _trainer_approach.is_empty() and not _world.phone_ring_active() \
 		and not _world.fishing_busy() and not _world.script_input_waiting()
 
@@ -465,6 +478,7 @@ func _renderer_input_free() -> bool:
 func move_player(direction: Vector2i) -> bool:
 	if _world == null or _world.fishing_busy() or _service_host != null \
 		or _pc_host != null or _start_menu_host != null or _party_host != null \
+		or _hall_of_fame_host != null \
 		or _field_move_text or _world.phone_ring_active() \
 		or not _trainer_approach.is_empty() or _world.player_step_in_progress():
 		return false
@@ -547,6 +561,7 @@ func _after_player_move(movement: Dictionary) -> bool:
 func interact() -> bool:
 	if _world == null or _battle_host != null or _service_host != null \
 		or _pc_host != null or _start_menu_host != null or _party_host != null \
+		or _hall_of_fame_host != null \
 		or _field_move_text or _world.phone_ring_active() or _world.fishing_busy():
 		return false
 	var results: Array = _world.interact()
@@ -1304,13 +1319,71 @@ func _on_pc_closed(result: Dictionary) -> void:
 	_refresh_labels()
 
 
+## Opens the induction sequence `halloffame` asks for. Public so the screenshot
+## tool and the scene tests can reach it without replaying the whole route.
+##
+## The party is the active save's, so an injected or development save inducts
+## whatever it is carrying. A cache with no font answers nothing rather than
+## drawing an empty screen.
+func open_hall_of_fame() -> void:
+	if _hall_of_fame_host != null or _world == null or _data == null:
+		return
+	var save: Gen2SaveData = _active_party_save()
+	if save == null:
+		_script_prompt = "Hall of Fame needs a save"
+		_refresh_labels()
+		return
+	var pages: Array = Gen2HallOfFame.pages(_data, save)
+	## No anchor preset: this is a child of the 160x144 Gen2Screen and sizes
+	## itself in native pixels, the way the story picture does.
+	var host := Gen2HallOfFameScreen.new()
+	host.set_context(_data, pages)
+	host.closed.connect(_on_hall_of_fame_closed)
+	_hall_of_fame_host = host
+	_screen.display(host)
+	if _hall_of_fame_host == null:
+		## set_context() with nothing to show closes on _ready(), which runs as
+		## soon as the node enters the tree.
+		return
+	_play_hall_of_fame_music()
+	_script_prompt = "Hall of Fame"
+	_refresh_labels()
+
+
+## HallOfFame calls SaveGameData before the animation, so the record is written
+## whether or not the player watches it. This writes at the end instead: the
+## screen owns no save state, and the snapshot it would write mid-sequence is
+## the same one.
+func _on_hall_of_fame_closed() -> void:
+	var host: Gen2HallOfFameScreen = _hall_of_fame_host
+	_hall_of_fame_host = null
+	if host != null:
+		host.queue_free()
+	var written: Dictionary = persist_world_snapshot()
+	_script_prompt = "Hall of Fame recorded" if bool(written.get("ok", false)) \
+		else "Hall of Fame not saved: %s" % String(written.get("reason", "unknown"))
+	_play_current_map_music()
+	if _renderer != null:
+		_renderer.refresh()
+	_refresh_labels()
+
+
+func _play_hall_of_fame_music() -> void:
+	if _audio_player == null or _data == null:
+		return
+	var record: Dictionary = _data.world_audio(&"music", MUSIC_HALL_OF_FAME)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
 ## Public driver for screenshot tooling and scene tests, mirroring
 ## _open_pc_host()'s shape. The Enter/Tab key branch in
 ## _unhandled_key_input() is the normal path.
 func _open_start_menu() -> void:
 	if _start_menu_host != null or _party_host != null or _service_host != null \
 		or _pc_host != null or _battle_host != null or _world == null or _data == null \
-		or _field_move_text \
+		or _hall_of_fame_host != null or _field_move_text \
 		or not _trainer_approach.is_empty() or _world.script_busy() \
 		or _world.phone_ring_active() or _world.fishing_busy():
 		return
@@ -1706,7 +1779,12 @@ func _show_script_results(results: Array) -> void:
 			failed = true
 			_script_prompt = "Script stopped: %s" % String(result.get("reason", "unknown"))
 		for result_event: Dictionary in result.get("events", []):
-			if result_event.get("type", &"") == &"pokemon_picture_requested":
+			if result_event.get("type", &"") == &"hall_of_fame_requested":
+				## An event, not a runtime request: `halloffame` commits its flag
+				## and runs on, and the source's own `end` is the next command,
+				## so nothing is waiting to be resumed when this opens.
+				open_hall_of_fame()
+			elif result_event.get("type", &"") == &"pokemon_picture_requested":
 				_show_story_picture(int(result_event.get("pokemon", 0)))
 			elif result_event.get("type", &"") == &"pokemon_picture_closed":
 				_hide_story_picture()

--- a/tests/integration/test_world_hall_of_fame_screen.gd
+++ b/tests/integration/test_world_hall_of_fame_screen.gd
@@ -1,0 +1,139 @@
+extends GutTest
+
+## Scene integration for the Hall of Fame: the overlay `halloffame` opens, the
+## pages it walks, the input it blocks while open, and the save it writes when
+## it closes. Driven through the production world screen.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
+
+const PLAYER_CELL: Vector2i = Vector2i(2, 2)
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+func _open_world(party_size: int = 2) -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = PLAYER_CELL
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, Gen2WorldState.new()
+	)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	while save.party.size() > party_size:
+		save.party.pop_back()
+	save.world = world.snapshot()
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+
+
+func _host() -> Gen2HallOfFameScreen:
+	return _world_screen._hall_of_fame_host
+
+
+func test_the_overlay_opens_with_one_page_per_party_member_and_the_player() -> void:
+	await _open_world(2)
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	assert_not_null(_host())
+	assert_eq(_host().remaining(), 3)
+	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_MON)
+
+
+## The overlay hides the map, so the overworld must not move under it. This is
+## the sixth overlay the world screen's guards have to know about.
+func test_the_overworld_does_not_move_while_the_overlay_is_open() -> void:
+	await _open_world(1)
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	var before: Vector2i = _world_screen._world.player_cell
+	assert_false(_world_screen.move_player(Vector2i.DOWN))
+	assert_false(_world_screen.interact())
+	assert_eq(_world_screen._world.player_cell, before)
+
+
+func test_a_key_walks_the_pages_and_the_last_one_closes_the_overlay() -> void:
+	await _open_world(1)
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	assert_eq(_host().remaining(), 2)
+
+	_host().handle_key(KEY_Z)
+	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_eq(_host().remaining(), 1)
+
+	_host().handle_key(KEY_Z)
+	await get_tree().process_frame
+	assert_null(_world_screen._hall_of_fame_host)
+	assert_true(_world_screen.move_player(Vector2i.DOWN))
+
+
+## A key the panel does not use is refused rather than swallowed as an advance.
+func test_an_unrelated_key_does_not_advance_a_page() -> void:
+	await _open_world(2)
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	var before: int = _host().remaining()
+	assert_false(_host().handle_key(KEY_ESCAPE))
+	assert_eq(_host().remaining(), before)
+
+
+## HallOfFame calls SaveGameData around the induction. The screen's save is
+## injected here, so the write lands in memory and the world snapshot is the
+## one the overlay closed on.
+func test_closing_the_overlay_writes_the_world_snapshot() -> void:
+	await _open_world(1)
+	var save: Gen2SaveData = _world_screen._injected_save
+	save.world = null
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	_host().handle_key(KEY_Z)
+	_host().handle_key(KEY_Z)
+	await get_tree().process_frame
+	assert_null(_world_screen._hall_of_fame_host)
+	assert_not_null(save.world)
+
+
+## `halloffame` is an event, not a runtime request: it commits its own flag and
+## the script runs on to `end`, so the overlay opens off the drained results.
+func test_the_halloffame_command_opens_the_overlay() -> void:
+	await _open_world(1)
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	# Raw Crystal bytes: halloffame is source $9f.
+	scripts["%d:7000" % Fixture.BANK] = [0xA1, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+	_data = GameData.open_directory(directory)
+
+	# The fixture's own coord event, repointed at the halloffame script and
+	# stepped onto the way the overworld reaches one.
+	var world: Gen2WorldAPI = _world_screen._world
+	world.data = _data
+	world.current_map.events["coord_events"][0]["script"] = 0x7000
+	var cell := Vector2i(
+		int(world.current_map.events["coord_events"][0]["x"]),
+		int(world.current_map.events["coord_events"][0]["y"])
+	)
+	world.player_cell = cell
+	_world_screen._show_script_results(world.dispatch_script_events())
+	await get_tree().process_frame
+
+	assert_true(world.state.hall_of_fame())
+	assert_not_null(_world_screen._hall_of_fame_host)

--- a/tests/integration/test_world_hall_of_fame_screen.gd.uid
+++ b/tests/integration/test_world_hall_of_fame_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dlyvpf2s4xkbe

--- a/tests/unit/test_hall_of_fame.gd
+++ b/tests/unit/test_hall_of_fame.gd
@@ -1,0 +1,120 @@
+extends GutTest
+
+## The induction sequence and the panel it draws, against a synthetic cache.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const TILE: int = Gen2Font.TILE
+
+var _data: GameData = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func _save(species_list: Array, eggs: Array = []) -> Gen2SaveData:
+	var save := Gen2SaveData.new()
+	save.player_name = "ASH"
+	for index: int in species_list.size():
+		var mon := Gen2SaveMon.new()
+		mon.species = int(species_list[index])
+		mon.level = 10 + index
+		mon.ot_id = 1234
+		mon.is_egg = index in eggs
+		save.party.append(mon)
+	return save
+
+
+func test_pages_follow_the_party_and_end_with_the_player() -> void:
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4]))
+	assert_eq(pages.size(), 3)
+	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_MON)
+	assert_eq(int(pages[0]["species"]), 1)
+	assert_eq(int(pages[0]["dex_number"]), 1)
+	assert_eq(int(pages[1]["species"]), 4)
+	assert_eq(StringName(pages[2]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_eq(String(pages[2]["player_name"]), "ASH")
+
+
+## GetHallOfFameParty skips EGG without consuming a slot, so the egg is neither
+## inducted nor counted against the six.
+func test_an_egg_is_skipped_and_the_player_page_still_follows() -> void:
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4, 7], [1]))
+	assert_eq(pages.size(), 3)
+	assert_eq(int(pages[0]["species"]), 1)
+	assert_eq(int(pages[1]["species"]), 7)
+	assert_eq(StringName(pages[2]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+
+
+## LoadHOFTeam's carry falls straight through to HOF_AnimatePlayerPic, so a
+## party with nothing to induct still reaches the player's own panel.
+func test_a_party_of_only_eggs_answers_the_player_page_alone() -> void:
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4], [0, 1]))
+	assert_eq(pages.size(), 1)
+	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+
+
+## DisplayHOFMon prints the species name and the nickname in two places, so a
+## mon that was never renamed shows the same word twice rather than a blank.
+func test_an_unnamed_mon_takes_its_species_name_as_its_nickname() -> void:
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
+	assert_eq(String(pages[0]["nickname"]), String(pages[0]["species_name"]))
+	assert_false(String(pages[0]["species_name"]).is_empty())
+
+
+func test_a_nickname_is_kept() -> void:
+	var save: Gen2SaveData = _save([1])
+	(save.party[0] as Gen2SaveMon).nickname = "SPARKY"
+	var pages: Array = Gen2HallOfFame.pages(_data, save)
+	assert_eq(String(pages[0]["nickname"]), "SPARKY")
+
+
+func test_pages_stop_at_a_full_party() -> void:
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 2, 3, 4, 5, 6, 7]))
+	assert_eq(pages.size(), Gen2HallOfFame.MAX_MONS + 1)
+
+
+func test_a_missing_cache_or_save_answers_nothing() -> void:
+	assert_eq(Gen2HallOfFame.pages(null, _save([1])).size(), 0)
+	assert_eq(Gen2HallOfFame.pages(_data, null).size(), 0)
+
+
+## The panel is drawn as indices on the hardware's own grid, so the whole page
+## is one 160x144 buffer and the two text boxes are really in it.
+func test_a_mon_panel_draws_both_boxes_on_a_full_screen_buffer() -> void:
+	var page_renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(_data)
+	assert_not_null(page_renderer)
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
+	var indices: PackedByteArray = page_renderer.draw(pages[0])
+	assert_eq(indices.size(), Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	assert_true(_has_ink(indices, Gen2HallOfFamePage.MON_TOP_BOX))
+	assert_true(_has_ink(indices, Gen2HallOfFamePage.MON_BOTTOM_BOX))
+
+
+## The player's page is the name box alone: nothing is drawn where the mon
+## panel's bottom box would be, because the source's fields there have no data.
+func test_the_player_panel_draws_its_own_box_only() -> void:
+	var page_renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(_data)
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
+	var indices: PackedByteArray = page_renderer.draw(pages[1])
+	assert_eq(indices.size(), Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	assert_true(_has_ink(indices, Gen2HallOfFamePage.PLAYER_BOX))
+	assert_false(_has_ink(indices, Gen2HallOfFamePage.MON_BOTTOM_BOX))
+
+
+## Any non-zero palette index inside a tile rectangle. Index 0 is the page's
+## own background, so ink means something was drawn there.
+func _has_ink(indices: PackedByteArray, box: Rect2i) -> bool:
+	for row: int in box.size.y * TILE:
+		var y: int = box.position.y * TILE + row
+		for column: int in box.size.x * TILE:
+			var at: int = y * Gen2Screen.WIDTH + box.position.x * TILE + column
+			if at < indices.size() and indices[at] != 0:
+				return true
+	return false

--- a/tests/unit/test_hall_of_fame.gd.uid
+++ b/tests/unit/test_hall_of_fame.gd.uid
@@ -1,0 +1,1 @@
+uid://jc82dasuh72r

--- a/tools/preview_hall_of_fame.gd
+++ b/tools/preview_hall_of_fame.gd
@@ -1,0 +1,75 @@
+extends SceneTree
+
+## Captures the production Hall of Fame overlay against a real imported cache,
+## which is what makes it worth looking at: the panel draws a real front pic,
+## the real font and the real text-box frame.
+##
+##   Godot --path . -s res://tools/preview_hall_of_fame.gd -- crystal /tmp/hof.png [page]
+##
+## [page] is how many times to advance before the capture, so 0 is the first
+## party member and the last page is the player's own.
+
+const WINDOW_SIZE := Vector2i(1152, 648)
+## Enough frames for the scene to lay out and the overlay to draw once.
+const SETTLE_FRAMES: int = 18
+
+var _screen: Gen2WorldScreen = null
+var _output_path: String = ""
+var _advance: int = 0
+var _frames: int = 0
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_hall_of_fame.gd -- <game> <output.png> [page]")
+		quit(1)
+		return
+	_output_path = args[1]
+	_advance = int(args[2]) if args.size() > 2 else 0
+
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var spawn: Gen2WorldSnapshot = Gen2WorldSpawn.new_game_snapshot(data)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if spawn == null or save == null:
+		push_error("Missing new-game spawn or development save")
+		quit(1)
+		return
+
+	root.set_content_scale_size(WINDOW_SIZE)
+	root.size = WINDOW_SIZE
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_screen = packed.instantiate() as Gen2WorldScreen
+	_screen.map_group = spawn.map_id.x
+	_screen.map_number = spawn.map_id.y
+	_screen.start_cell = spawn.player_cell
+	save.world = spawn
+	_screen.set_data(data)
+	_screen.set_save(save)
+	root.add_child(_screen)
+	current_scene = _screen
+
+
+func _process(_delta: float) -> bool:
+	_frames += 1
+	if _frames == 3:
+		_screen.open_hall_of_fame()
+		for _step: int in _advance:
+			if _screen._hall_of_fame_host != null:
+				_screen._hall_of_fame_host.advance()
+	if _frames < SETTLE_FRAMES:
+		return false
+	var image: Image = root.get_texture().get_image()
+	var error: Error = image.save_png(_output_path)
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [_output_path, error])
+		quit(1)
+		return true
+	print("Wrote %s (%dx%d)" % [_output_path, image.get_width(), image.get_height()])
+	quit(0)
+	return true

--- a/tools/preview_hall_of_fame.gd.uid
+++ b/tools/preview_hall_of_fame.gd.uid
@@ -1,0 +1,1 @@
+uid://c1x7tsp4g8psd


### PR DESCRIPTION
halloffame committed its flag and emitted a presentation event that nothing answered, so the end of the story route ran with no screen behind it. It has one now: one panel per non-egg party member, then the player's own, advanced by A.

The panel is the cartridge's. Gen2HallOfFame builds GetHallOfFameParty's list, Gen2HallOfFamePage draws DisplayHOFMon's two text boxes and every field row it prints on the hardware tile grid, and Gen2HallOfFameScreen composes the real front pic over it. Closing writes the world snapshot, which is where HallOfFame's own SaveGameData lands.

Three of the source's glyphs are absent rather than invented. The font cache is 128 tiles from $80, while the number sign, the ID mark and the level mark live in font_battle_extra, which the importer does not read, so plain words stand in and the two number columns sit one tile right of the cartridge's. The player's panel is the name box alone: there is no player pic to draw and the save model carries neither trainer ID nor play time.

The credits, ProfOaksPCRating, both pic slides, the palette rotations and the persisted Hall of Fame record are still out.

Box borders now have one owner in Gen2Font.draw_box, which the text box was already doing by hand, and the gender rule keeps its own in Gen2BattleMon so the panel reads it rather than restating it.