### PR TITLE
Open the engine to mods at its own chokepoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   through a validated candidate save; a full party routes into the first free
 >   box slot and full storage refuses atomically. Format 1 saves migrate without
 >   inventing a world position.
-> - **Mods.** A mod under `user://mods/` can register a replacement world
->   renderer, which is what a 3D or HD view needs.
+> - **Mods.** A mod under `user://mods/` can add a species, move, item or trainer
+>   class, rebalance one the cartridge shipped, register a move effect and the
+>   steps it is built from, watch the world and battle event channels, add a menu
+>   entry, and replace the world or battle renderer, which is what a 3D or HD
+>   view needs.
 >
 > The real-data story preview walks the Crystal route from Elm's lab through
 > Route 29, Cherrygrove, Route 30 and Mr. Pokémon's Mystery Egg event to the
@@ -253,8 +256,8 @@ marts, phone calls and audio requests.
 | `tests/` | GUT unit and integration tests |
 | `tools/` | Headless developer scripts |
 | `roms/` | User cartridges, excluded from Git and Godot imports |
-| `game/mods/` | Mod manifest and host |
-| `mods/examples/` | Example mods to copy into `user://mods/` |
+| `game/mods/` | Mod manifest, host, installer and refusal wording |
+| `mods/examples/` | Example mods to copy into `user://mods/`: a world renderer and a content mod |
 | `docs/` | Contributor notes |
 
 ## Platforms

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -46,9 +46,12 @@ func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
 A mod that fails to load is reported through `Gen2ModHost.failures()` and
 skipped. One broken mod does not stop the others and does not stop the game.
 
-`mods/examples/voxel_preview/` is a working renderer: copy it into
-`user://mods/` and press `V` in the overworld. It reads the same collision,
-block and palette data the 2D view reads and extrudes geometry from it.
+Two example mods are in `mods/examples/`, to copy into `user://mods/`:
+
+| Mod | Shows |
+|---|---|
+| `voxel_preview/` | A world renderer. Press `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it |
+| `new_content/` | A species, a move, a move effect, two rebalancing patches and both event channels |
 
 ## Installing
 
@@ -114,6 +117,95 @@ GitHub slug.
 A listed mod installs through the same path an imported `.zip` does, and its
 manifest id must match the one the feed advertised, so a listing grants a mod
 nothing that picking the same file by hand would not.
+
+## Adding content
+
+`mods/examples/new_content/` registers a species, a move, a move effect and two
+rebalancing patches, and watches both event channels. Copy it and read it beside
+this section.
+
+A content number is per kind and starts at `Gen2ContentOverlay.FIRST_MOD_NUMBER`,
+which is 256. Every cartridge number fits in a byte, so a number that does not is
+unambiguously not the cartridge's, and a mod's own numbers mean the same thing on
+Gold, Silver and Crystal. Four kinds are reachable: `KIND_SPECIES`, `KIND_MOVE`,
+`KIND_ITEM` and `KIND_TRAINER`. Types are not, because the matchup lookup keys on
+the type count and a twenty-ninth type would renumber every pair in the chart.
+
+```gdscript
+host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
+	"name": "VOLTLING",
+	"stats": {"speed": 115},
+	"learnset": [{"level": 1, "move": 33}, {"level": 36, "move": 85}],
+})
+```
+
+A definition is partial. Whatever it leaves out comes from the kind's defaults,
+which exist because readers index these rows directly: `palette.normal` and
+`front_tiles` are read without asking whether they are there, so a definition
+that omitted either would crash the reader rather than draw wrong.
+
+Everything a species carries is a field on the one row, so a learnset, an
+evolution and TM compatibility are part of the definition rather than three more
+registrations. The engine then reads them the way it reads Pikachu's, because
+every content read in the game goes through one place, `GameData._content()`.
+
+`patch_content()` changes a row the cartridge does have. Only the fields named
+change, and a Dictionary field merges, so patching one stat leaves the other five
+alone. A patch of a number this cartridge lacks changes nothing rather than
+inventing a row, which is what keeps a mod that patches Crystal's MYSTICALMAN
+from conjuring one on Gold.
+
+Two mods claiming one number is refused and named, rather than decided by load
+order. `Gen2ContentOverlay.owner_of()` says which mod won a number.
+
+What content does not get: a pic. The atlases are decoded from the cartridge and
+hold its own 251 slots, so a defined species draws nothing until a renderer draws
+it. `Gen2SramAdapter` cannot export a mod species to a real `.sav` either, since
+the cartridge stores a species in one byte; the project's own save is JSON and
+carries them fine.
+
+## Adding a move effect
+
+A move's effect byte is a number until something answers for it.
+`Gen2MoveEffect` holds the cartridge's lists and `Gen2EffectCommands` the steps
+one is built from; a registration is a list of those steps.
+
+```gdscript
+host.register_move_effect(manifest.id, 0xF0, [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.RECOIL,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.END_MOVE,
+])
+```
+
+A list naming a step nobody wrote is refused at registration, where the mod's id
+is still in hand, rather than pushing an error in the middle of a turn.
+`register_effect_command()` adds a step of your own, as a Callable taking the
+`Gen2Turn`; it cannot take a name the engine already uses, so a registration can
+never quietly change what every move in the game does.
+
+A registered effect replaces the cartridge's list for that byte, which is how a
+mod rewrites Sleep rather than only adding to the table.
+`Gen2MoveEffect.RESERVED_EFFECTS` is the exception: the multi-hit, fixed-damage,
+Rollout and Selfdestruct bytes are read back off the turn by their own commands,
+so replacing one would leave that command answering for a list it is no longer
+in.
+
+## Watching what happens
+
+`subscribe(channel, id, handler)` on `Gen2ModHost.CHANNEL_WORLD` or
+`CHANNEL_BATTLE` calls `handler` with each event dictionary as the screen showing
+it reads it, so a subscriber sees what the player sees, in that order.
+
+Reading only. The handler is given a copy and nothing reads its return value:
+observation cannot make two mods fight over the same state, which is what makes
+this safe to hand out before any mutation hook exists. Events are published from
+the screens, so a headless tool or a test driving the engine directly fires none.
 
 ## Replacing the world renderer
 
@@ -309,8 +401,8 @@ silently winning.
 
 ## Not built yet
 
-Semver ranges and inter-mod dependencies, per-mod save data, hooks beyond the
-renderer and menu entries, and `.zip`/`.pck` packs through
-`ProjectSettings.load_resource_pack()`. Evaluate
+Semver ranges and inter-mod dependencies, per-mod save data, art for mod content,
+mutation hooks on the event channels, entries in the party submenu or the mart,
+and `.zip`/`.pck` packs through `ProjectSettings.load_resource_pack()`. Evaluate
 [godot-mod-loader](https://github.com/GodotModding/godot-mod-loader) before
 expanding the loader itself.

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -87,8 +87,8 @@ var rampage_move: int = 0
 var toxic_counter: int = 0
 
 ## Which move slot Disable has locked, or -1 for none: -1 rather than 0 so
-## "nothing disabled" is never confusable with the first slot. Meaningful only
-## while [constant Gen2Substatus.DISABLED] is set.
+## "nothing disabled" is never confusable with the first slot, and so this alone
+## answers whether anything is disabled, the way `wDisabledMove` does.
 var disabled_slot: int = -1
 ## How many turns [member disabled_slot] stays locked.
 var disable_turns: int = 0

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1066,6 +1066,7 @@ func _next_healthy(side: int) -> int:
 func _show_next_event() -> void:
 	while not _pending.is_empty():
 		var event: Dictionary = _pending.pop_front()
+		Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
 		_apply_event(event)
 		var text: String = _describe(event)
 		if not text.is_empty():

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -279,10 +279,29 @@ const THAWING_MOVES: Array = [172, 221]
 const ENCORE_EXCLUDED_MOVES: Array = [119, 227]
 
 
+## Every step name this file answers to, read off its own constants so the list
+## cannot drift from the match below.
+static var _engine_commands: Dictionary = {}
+
+
+## Whether [param command] is one of the engine's own steps. What
+## [method Gen2MoveEffect.register_command] refuses a mod, so a registration can
+## never shadow a step every move in the game depends on.
+static func is_engine_command(command: StringName) -> bool:
+	if _engine_commands.is_empty():
+		var constants: Dictionary = Gen2EffectCommands.new().get_script().get_script_constant_map()
+		for value: Variant in constants.values():
+			if value is StringName:
+				_engine_commands[value] = true
+	return _engine_commands.has(command)
+
+
 ## Runs one command against [param turn].
 ##
 ## An unknown command is an error, not a no-op: a sequence naming a step nobody
 ## wrote would otherwise play out as a move that quietly does less than it says.
+## A mod's own step is reached through [Gen2MoveEffect]'s registry, after this
+## match has refused the name.
 static func run(command: StringName, turn: Gen2Turn) -> void:
 	match command:
 		USED_MOVE_TEXT:
@@ -374,7 +393,7 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 		_:
 			if STAT_COMMANDS.has(command):
 				_stat_change(command, turn)
-			else:
+			elif not Gen2MoveEffect.run_registered_command(command, turn):
 				push_error("No such effect command: %s" % command)
 
 
@@ -1083,7 +1102,6 @@ static func _disable(turn: Gen2Turn) -> void:
 
 	defender.disabled_slot = slot
 	defender.disable_turns = Gen2Substatus.roll_disable(turn.rng())
-	defender.substatus |= Gen2Substatus.DISABLED
 	turn.emit(Gen2Battle.DISABLE_INFLICTED, {
 		"target": turn.target, "slot": slot, "move": last_move,
 	})

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -627,6 +627,20 @@ static func _stat_sequences() -> Dictionary:
 	return out
 
 
+## The cartridge's own table, built once. It is a constant answer to a constant
+## question, and [method sequence_for] is asked it on every move of every turn,
+## so rebuilding forty-odd lists and the five stat runs per attack was work
+## nobody read.
+static var _cached_sequences: Dictionary = {}
+## Effect bytes a mod added, kept apart from the cartridge's so
+## [method reset_registry] can drop them without rebuilding the table.
+static var _registered_sequences: Dictionary = {}
+## Command name to handler, for a step the engine does not have.
+static var _registered_commands: Dictionary = {}
+## What claimed each effect byte and command name, so a conflict names both mods.
+static var _registry_owners: Dictionary = {}
+
+
 ## Effect bytes that do something other than [constant NORMAL_HIT]. An effect
 ## that is not in here is an ordinary attack, which is what most of the table is
 ## and what an effect nobody has written yet falls back to.
@@ -679,12 +693,131 @@ static func _sequences() -> Dictionary:
 	return out
 
 
+## The cartridge's table, built on the first ask and kept.
+static func _table() -> Dictionary:
+	if _cached_sequences.is_empty():
+		_cached_sequences = _sequences()
+	return _cached_sequences
+
+
 ## The commands a move with this effect byte is made of.
+##
+## A registered effect wins over the cartridge's, which is what lets a mod
+## rewrite one as well as add one. [method register_effect] is where that is
+## refused for the effects the engine relies on reading back off a turn.
 static func sequence_for(effect: int) -> Array:
-	return _sequences().get(effect, NORMAL_HIT)
+	if _registered_sequences.has(effect):
+		return _registered_sequences[effect]
+	return _table().get(effect, NORMAL_HIT)
 
 
 ## Whether an effect has a list of its own yet, which is what separates a move
 ## that is fully implemented from one that is standing in as an ordinary attack.
 static func is_written(effect: int) -> bool:
-	return _sequences().has(effect)
+	return _registered_sequences.has(effect) or _table().has(effect)
+
+
+## Effect bytes whose command reads the byte back off the turn to decide what it
+## is: the multi-hit count, the four fixed-damage figures, Rollout's multiplier
+## and Selfdestruct's halved Defense all work that way. Rewriting one would make
+## its own command answer for a list it is no longer in, so these are refused
+## rather than left to fail at the point of use.
+const RESERVED_EFFECTS: Array[int] = [
+	MULTI_HIT, DOUBLE_HIT, TWINEEDLE, SUPER_FANG, STATIC_DAMAGE, LEVEL_DAMAGE,
+	PSYWAVE, ROLLOUT, SELFDESTRUCT,
+]
+
+
+## Registers the command list a move carrying [param effect] runs.
+##
+## Every step named has to be one the engine knows or one already registered
+## through [method register_command], so a list that would push an error mid-turn
+## is refused here, where the mod's id is still in hand.
+static func register_effect(id: StringName, effect: int, commands: Array) -> Dictionary:
+	if effect < 0 or effect > 0xFF:
+		return {"ok": false, "reason": &"invalid_effect", "detail": str(effect)}
+	if RESERVED_EFFECTS.has(effect):
+		return {"ok": false, "reason": &"reserved_effect", "detail": str(effect)}
+	if commands.is_empty():
+		return {"ok": false, "reason": &"empty_effect", "detail": str(effect)}
+	var unknown: Array[String] = []
+	for command: Variant in commands:
+		if not _command_exists(StringName(command)):
+			unknown.append(String(command))
+	if not unknown.is_empty():
+		return {
+			"ok": false, "reason": &"unknown_effect_command",
+			"detail": "%d: %s" % [effect, ", ".join(unknown)],
+		}
+	var claim: Dictionary = _claim(&"effect", id, effect)
+	if not bool(claim.get("ok", false)):
+		return claim
+	var sequence: Array = []
+	for command: Variant in commands:
+		sequence.append(StringName(command))
+	_registered_sequences[effect] = sequence
+	return {"ok": true, "effect": effect}
+
+
+## Registers a step a command list may name, run with the [Gen2Turn] the way
+## every built-in step is.
+##
+## The engine's own commands are tried first, so a registration cannot shadow
+## [constant Gen2EffectCommands.APPLY_DAMAGE] and quietly change what every move
+## in the game does.
+static func register_command(
+	id: StringName, command: StringName, handler: Callable
+) -> Dictionary:
+	if String(command).is_empty():
+		return {"ok": false, "reason": &"invalid_effect_command"}
+	if not handler.is_valid():
+		return {"ok": false, "reason": &"invalid_effect_handler", "detail": String(command)}
+	if Gen2EffectCommands.is_engine_command(command):
+		return {"ok": false, "reason": &"reserved_effect_command", "detail": String(command)}
+	var claim: Dictionary = _claim(&"command", id, command)
+	if not bool(claim.get("ok", false)):
+		return claim
+	_registered_commands[command] = handler
+	return {"ok": true, "command": command}
+
+
+## Runs a registered command, answering whether there was one.
+## [method Gen2EffectCommands.run] reaches this only after its own match has
+## refused the name.
+static func run_registered_command(command: StringName, turn: Gen2Turn) -> bool:
+	var handler: Variant = _registered_commands.get(command, null)
+	if not handler is Callable:
+		return false
+	(handler as Callable).call(turn)
+	return true
+
+
+## Drops every registered effect and command. [method Gen2ModHost.reset] calls
+## this; the cartridge's own table is untouched, since nothing can change it.
+static func reset_registry() -> void:
+	_registered_sequences = {}
+	_registered_commands = {}
+	_registry_owners = {}
+
+
+## Whether [param command] is a step something can run: one the engine has, or
+## one a mod registered before naming it in a list.
+static func _command_exists(command: StringName) -> bool:
+	return Gen2EffectCommands.is_engine_command(command) \
+		or _registered_commands.has(command)
+
+
+## One effect byte or command name, one mod, for the same reason
+## [method Gen2ContentOverlay._claim] holds: load order must not decide which of
+## two mods a move belongs to.
+static func _claim(kind: StringName, id: StringName, key: Variant) -> Dictionary:
+	var owners: Dictionary = _registry_owners.get(kind, {})
+	var owner: StringName = StringName(owners.get(key, &""))
+	if owner != &"" and owner != id:
+		return {
+			"ok": false, "reason": &"duplicate_move_effect",
+			"detail": "%s %s: %s and %s" % [kind, key, owner, id],
+		}
+	owners[key] = id
+	_registry_owners[kind] = owners
+	return {"ok": true}

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -28,7 +28,11 @@ const CONFUSED: int = 1 << 0
 const FLINCHED: int = 1 << 1
 const RECHARGING: int = 1 << 2
 const CHARGING: int = 1 << 3
-const DISABLED: int = 1 << 4
+## Bit 4 was a DISABLED flag. The cartridge has none: `wDisabledMove` and
+## `wPlayerDisableCount` are the whole of it, which is what
+## [member Gen2BattleMon.disabled_slot] and [member Gen2BattleMon.disable_turns]
+## already are, and every reader tested those rather than the flag. It is left
+## unused rather than reassigned so a bit number keeps meaning what it did.
 const ATTRACTED: int = 1 << 5
 const ENCORED: int = 1 << 6
 const MIST: int = 1 << 7

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -1,0 +1,258 @@
+class_name Gen2ContentOverlay
+extends RefCounted
+
+## Content a mod adds or changes, consulted ahead of the cartridge's own tables.
+##
+## [GameData] funnels every species, move, item and trainer read through one
+## place, so this is the one place that has to answer to add a Pokémon or
+## rebalance a move. Nothing downstream knows a mod exists: a defined species has
+## a learnset, evolutions and TM flags because those live on the species row, and
+## the engine reads them the way it reads Pikachu's.
+##
+## Two operations, deliberately distinct:
+##
+## - [method define] adds content at a number the cartridge does not use.
+## - [method patch] changes fields of a row the cartridge does use.
+##
+## Definitions are normalized on the way in, against [constant DEFAULTS], because
+## readers index these rows directly: [method GameData.palette] reads
+## [code]palette.normal[/code] and [method GameData.species_pic] reads
+## [code]front_tiles[/code], and a definition that omitted either would crash the
+## reader rather than draw wrong. A mod supplies what it cares about.
+
+## The content kinds a mod may reach. Types are not one of them: the matchup
+## lookup keys on [constant RomLayout.TYPE_COUNT], so a twenty-ninth type would
+## renumber every pair already in the chart.
+const KIND_SPECIES: StringName = &"species"
+const KIND_MOVE: StringName = &"move"
+const KIND_ITEM: StringName = &"item"
+const KIND_TRAINER: StringName = &"trainer"
+const KINDS: Array[StringName] = [KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER]
+
+## The first number a mod may define. Every cartridge content number is one byte,
+## in all three games, so a number that does not fit in one is unambiguously not
+## the cartridge's. That is what makes a mod's own numbers mean the same thing on
+## Gold, Silver and Crystal, which a boundary derived from a per-game count
+## (251 species, 66 or 67 trainer classes) would not.
+##
+## The cost is that a mod number does not fit the cartridge's byte-wide storage:
+## [Gen2SramAdapter] exports party species to a real `.sav` and cannot carry one.
+## The project save is JSON and carries them fine.
+const FIRST_MOD_NUMBER: int = 256
+
+## What a definition that omits a field gets instead, per kind. The field lists
+## are the importer's own rows (`_import_species`, `_import_moves`,
+## `_import_items`, `_import_trainers`), so a definition is a cartridge row with
+## the parts a mod did not care about filled in.
+const DEFAULTS: Dictionary = {
+	KIND_SPECIES: {
+		"name": "?",
+		"stats": {
+			"hp": 1, "attack": 1, "defense": 1,
+			"speed": 1, "sp_attack": 1, "sp_defense": 1,
+		},
+		"types": [0, 0],
+		"catch_rate": 255,
+		"base_exp": 0,
+		"held_items": [0, 0],
+		# 127 is the cartridge's own even split; 255 would be genderless.
+		"gender_ratio": 127,
+		"hatch_cycles": 20,
+		"growth_rate": 0,
+		# 15 is EGG_NONE, so a defined species does not breed until it says so.
+		"egg_groups": [15, 15],
+		"tmhm": [0, 0, 0, 0, 0, 0, 0, 0],
+		"evolutions": [],
+		"learnset": [],
+		"front_tiles": [7, 7],
+		# White and black, which draws something legible and obviously not
+		# coloured, the same answer bar_palette() gives an unknown name.
+		"palette": {"normal": [0x7FFF, 0x0000], "shiny": [0x7FFF, 0x0000]},
+	},
+	KIND_MOVE: {
+		"name": "?",
+		"effect": 0,
+		"power": 0,
+		"type": 0,
+		# $FF skips the accuracy roll, so an unspecified move always connects
+		# rather than never doing.
+		"accuracy": 255,
+		"pp": 5,
+		"effect_chance": 0,
+	},
+	KIND_ITEM: {
+		"name": "?",
+		"price": 0,
+		"effect": 0,
+		"parameter": -1,
+		"permissions": 0,
+		"pocket": 1,
+		"field_menu": 0,
+		"battle_menu": 0,
+	},
+	KIND_TRAINER: {
+		"name": "?",
+		"palette": [0x7FFF, 0x0000],
+		"trainers": [],
+		"attributes": {
+			"item1": 0, "item2": 0, "base_reward": 0,
+			"ai_move_weights": 0, "ai_item_switch": 0,
+		},
+		"dvs": Gen2BattleMon.PERFECT_DVS,
+	},
+}
+
+static var _shared: Gen2ContentOverlay = null
+
+## kind to number to the whole normalized row.
+var _defined: Dictionary = {}
+## kind to number to the fields that replace the cartridge's.
+var _patched: Dictionary = {}
+## kind to number to the mod id that claimed it, so a conflict can name both.
+var _owners: Dictionary = {}
+
+
+## The overlay [GameData] consults. Shared rather than per-cache because mods
+## load before any cache is opened and their content applies to whichever game
+## the player then picks.
+static func shared() -> Gen2ContentOverlay:
+	if _shared == null:
+		_shared = Gen2ContentOverlay.new()
+	return _shared
+
+
+## Discards every registration. [method Gen2ModHost.reset] calls this, so
+## reloading the mod list does not leave the last load's content behind.
+static func reset() -> void:
+	_shared = null
+
+
+## Whether anything is registered at all. Every content read asks this first, so
+## a game with no mods pays one dictionary check per species lookup.
+func is_empty() -> bool:
+	return _defined.is_empty() and _patched.is_empty()
+
+
+## Adds content at a number the cartridge does not use.
+##
+## [param row] is a partial row: whatever it does not carry comes from
+## [constant DEFAULTS], so a species defined with a name, stats and a learnset is
+## a complete species. Refused if the number is a cartridge number, if the kind
+## is not one of [constant KINDS], or if another mod already claimed it.
+func define(kind: StringName, id: StringName, number: int, row: Dictionary) -> Dictionary:
+	if not KINDS.has(kind):
+		return {"ok": false, "reason": &"unknown_content_kind", "detail": String(kind)}
+	if number < FIRST_MOD_NUMBER:
+		return {
+			"ok": false, "reason": &"reserved_content_number",
+			"detail": "%s %d" % [kind, number],
+		}
+	var conflict: Dictionary = _claim(kind, id, number)
+	if not bool(conflict.get("ok", false)):
+		return conflict
+	var defined: Dictionary = _defined.get(kind, {})
+	defined[number] = _normalized(kind, number, row)
+	_defined[kind] = defined
+	return {"ok": true, "kind": kind, "number": number}
+
+
+## Replaces named fields of a cartridge row: a move's power, a species' types, an
+## item's price.
+##
+## Only the fields given change, and a Dictionary field merges rather than
+## replacing, so patching [code]{"stats": {"speed": 120}}[/code] leaves the other
+## five stats alone. Refused for a number a mod would have to [method define].
+func patch(kind: StringName, id: StringName, number: int, fields: Dictionary) -> Dictionary:
+	if not KINDS.has(kind):
+		return {"ok": false, "reason": &"unknown_content_kind", "detail": String(kind)}
+	if number < 1 or number >= FIRST_MOD_NUMBER:
+		return {
+			"ok": false, "reason": &"not_a_cartridge_number",
+			"detail": "%s %d" % [kind, number],
+		}
+	if fields.is_empty():
+		return {"ok": false, "reason": &"empty_content_patch", "detail": String(kind)}
+	var conflict: Dictionary = _claim(kind, id, number)
+	if not bool(conflict.get("ok", false)):
+		return conflict
+	var patched: Dictionary = _patched.get(kind, {})
+	patched[number] = fields.duplicate(true)
+	_patched[kind] = patched
+	return {"ok": true, "kind": kind, "number": number}
+
+
+## The row a reader gets for [param number], given the cartridge's own
+## [param base]. A definition answers on its own; a patch is folded onto the
+## base; anything else is the base untouched.
+##
+## A patch of a number this cartridge does not carry answers empty rather than
+## conjuring a row out of the patch alone: Crystal's MYSTICALMAN is not a trainer
+## class Gold has, and a mod patching it must not invent one there.
+func resolve(kind: StringName, number: int, base: Dictionary) -> Dictionary:
+	var defined: Dictionary = _defined.get(kind, {})
+	if defined.has(number):
+		return defined[number]
+	if base.is_empty():
+		return base
+	var patched: Dictionary = _patched.get(kind, {})
+	if not patched.has(number):
+		return base
+	return _merged(base, patched[number])
+
+
+## Every number defined for [param kind], in ascending order. What a menu or a
+## dex listing walks to show mod content beside the cartridge's, since
+## [method GameData.species_count] stays the cartridge's own count.
+func defined_numbers(kind: StringName) -> Array[int]:
+	var out: Array[int] = []
+	for number: int in (_defined.get(kind, {}) as Dictionary).keys():
+		out.append(number)
+	out.sort()
+	return out
+
+
+## Which mod claimed [param number], or an empty name. For a launcher listing
+## what changed the game it is about to start.
+func owner_of(kind: StringName, number: int) -> StringName:
+	return StringName((_owners.get(kind, {}) as Dictionary).get(number, &""))
+
+
+## One number, one mod. Two mods reaching for the same species is exactly the
+## conflict a player wants named rather than resolved by load order.
+func _claim(kind: StringName, id: StringName, number: int) -> Dictionary:
+	var owners: Dictionary = _owners.get(kind, {})
+	var owner: StringName = StringName(owners.get(number, &""))
+	if owner != &"" and owner != id:
+		return {
+			"ok": false, "reason": &"duplicate_content",
+			"detail": "%s %d: %s and %s" % [kind, number, owner, id],
+		}
+	owners[number] = id
+	_owners[kind] = owners
+	return {"ok": true}
+
+
+## A partial definition filled out against [constant DEFAULTS]. The number is
+## written last so a row cannot disagree with the key it is stored under.
+func _normalized(kind: StringName, number: int, row: Dictionary) -> Dictionary:
+	var out: Dictionary = _merged(DEFAULTS[kind], row)
+	out["number"] = number
+	return out
+
+
+## [param over] laid on [param base], recursing into Dictionary values so a
+## partial [code]stats[/code] keeps the stats it did not name. Arrays replace
+## whole: a two-element [code]types[/code] merged element-wise would make
+## [code][15][/code] mean "Ice and whatever was there", which is not what writing
+## it says.
+func _merged(base: Dictionary, over: Dictionary) -> Dictionary:
+	var out: Dictionary = base.duplicate(true)
+	for key: Variant in over:
+		var value: Variant = over[key]
+		if value is Dictionary and out.get(key, null) is Dictionary:
+			out[key] = _merged(out[key], value)
+		elif value is Dictionary or value is Array:
+			out[key] = value.duplicate(true)
+		else:
+			out[key] = value
+	return out

--- a/game/data/content_overlay.gd.uid
+++ b/game/data/content_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bblxb0jgsnqv3

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -20,6 +20,10 @@ var id: StringName = &""
 var sha1: String = ""
 var directory: String = ""
 
+## Mod content, consulted ahead of the cached tables by [method _content]. Null
+## for a [GameData] built by hand, which is what a fixture does.
+var _overlay: Gen2ContentOverlay = null
+
 var _species: Array = []
 var _moves: Array = []
 ## TMHMMoves in TMNUM order, restored to integers because JSON reads them back
@@ -82,6 +86,7 @@ static func open_directory(path: String) -> GameData:
 
 	var manifest: Dictionary = RomCache.read_manifest(path)
 	var data := GameData.new()
+	data._overlay = Gen2ContentOverlay.shared()
 	data.directory = path
 	data.id = StringName(manifest.get("game_id", ""))
 	data.sha1 = String(manifest.get("sha1", ""))
@@ -113,6 +118,10 @@ func title() -> String:
 	return RomRegistry.title_for(id)
 
 
+## How many species the cartridge carried, which is not how many exist: mod
+## content is numbered above the cartridge's range and enumerated through
+## [method Gen2ContentOverlay.defined_numbers]. Callers here wrap and iterate
+## over the cartridge's own run, and a mod number is not part of it.
 func species_count() -> int:
 	return _species.size()
 
@@ -423,7 +432,7 @@ func world_tileset_indices(number: int) -> PackedByteArray:
 ## One species by Pokédex number, or an empty Dictionary if there is no such
 ## number. Out of range is a question, not a crash: a mod may well ask.
 func species(number: int) -> Dictionary:
-	return _entry(_species, number - 1)
+	return _content(Gen2ContentOverlay.KIND_SPECIES, _species, number)
 
 
 ## A species' level-up moves, in the cartridge's own order, as
@@ -477,7 +486,7 @@ func _rows(entry: Dictionary, key: String, fields: Array) -> Array:
 
 
 func move(number: int) -> Dictionary:
-	return _entry(_moves, number - 1)
+	return _content(Gen2ContentOverlay.KIND_MOVE, _moves, number)
 
 
 ## Every TM/HM/tutor move in TMNUM order, so index n-1 is TM/HM number n.
@@ -504,7 +513,7 @@ func tmhm_number_for_move(move_number: int) -> int:
 
 
 func item(number: int) -> Dictionary:
-	return _entry(_items, number - 1)
+	return _content(Gen2ContentOverlay.KIND_ITEM, _items, number)
 
 
 func item_name(number: int) -> String:
@@ -628,7 +637,7 @@ func trainer_count() -> int:
 ## player, who is a class in the cartridge's tables and has no pic, so the cache
 ## does not carry an entry for them.
 func trainer(number: int) -> Dictionary:
-	return _entry(_trainers, number - 1)
+	return _content(Gen2ContentOverlay.KIND_TRAINER, _trainers, number)
 
 
 func trainer_name(number: int) -> String:
@@ -995,6 +1004,28 @@ func _entry(rows: Array, index: int) -> Dictionary:
 	if index < 0 or index >= rows.size():
 		return {}
 	return rows[index]
+
+
+## One numbered content row, with the mod overlay consulted first.
+##
+## The chokepoint species, moves, items and trainers all read through, and so the
+## one place that has to know a mod may have added or changed one. Everything
+## carried on a species row rides along: a defined species has a learnset,
+## evolutions and TM flags because [method learnset], [method evolutions] and the
+## TM/HM gate all read them back off this row.
+##
+## Numbering is one-based, the cartridge's own; see [Gen2ContentOverlay].
+func _content(kind: StringName, rows: Array, number: int) -> Dictionary:
+	var base: Dictionary = _entry(rows, number - 1)
+	if _overlay == null or _overlay.is_empty():
+		return base
+	return _overlay.resolve(kind, number, base)
+
+
+## Replaces the mod content this cache answers with. For a tool or a test that
+## needs content of its own without touching the shared overlay.
+func set_content_overlay(overlay: Gen2ContentOverlay) -> void:
+	_overlay = overlay
 
 
 func _service_row(

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -349,6 +349,11 @@ const FRAME_BOTTOM_RIGHT: int = 5
 ## and are the boxes a name and a level sit in, one shape for the enemy's and one
 ## for the player's. The exp bar is 2bpp and is seven fill levels and two ends.
 const BATTLE_FONT_TILES: int = 32
+## Where `_LoadFontsBattleExtra` puts its first tile: `ld hl, vTiles2 tile $60`.
+## Its twenty-five tiles cover $60 to $78, so a code in that run addresses this
+## strip rather than the main font while it is loaded, which is what
+## [constant Gen2Text.FONT_BATTLE_EXTRA] names.
+const BATTLE_FONT_FIRST_CODE: int = 0x60
 const ENEMY_HUD_TILES: int = 4
 const PLAYER_HUD_TILES: int = 6
 const EXP_BAR_TILES: int = 9

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -10,9 +10,42 @@ extends RefCounted
 ##
 ## The Japanese cartridges reuse most of this range for kana. They are not in
 ## [RomRegistry], and this table would decode them into nonsense.
+##
+## A byte does not name a character on its own. `constants/charmap.asm` maps the
+## $60 to $7F run twice over, once from `gfx/font/font.png` and again from
+## `gfx/font/font_battle_extra.png` under its own "Actual characters" heading,
+## and $6e three times; the byte means whichever strip the hardware last loaded
+## into video memory. Every entry point here takes the strip, defaulting to the
+## main font, which is what all but the battle and Hall of Fame screens have up.
 
 const TERMINATOR: int = 0x50
 const SPACE: int = 0x7F
+
+## Which strip is loaded. [constant FONT_MAIN] is `_LoadStandardFont`'s;
+## [constant FONT_BATTLE_EXTRA] is what `_LoadFontsBattleExtra` leaves behind,
+## which `engine/events/halloffame.asm` calls before it prints a panel.
+const FONT_MAIN: StringName = &"main"
+const FONT_BATTLE_EXTRA: StringName = &"battle_extra"
+
+## The run `_LoadFontsBattleExtra` overwrites: twenty-five tiles from $60, which
+## is `ld hl, vTiles2 tile $60` and `lb bc, BANK(FontBattleExtra), 25`. Outside
+## it the main font is still up, so letters, digits and the box-drawing codes
+## mean what they always did.
+const BATTLE_EXTRA_FIRST_CODE: int = 0x60
+const BATTLE_EXTRA_LAST_CODE: int = 0x78
+
+## What that run says. The rest of it is the HP bar's fill levels and the two HUD
+## borders, which are graphics rather than characters, so a code in the run and
+## not in here has no character at all: falling back to the main font's would
+## decode $75 as an ellipsis when the tile in memory is a piece of a bar.
+const BATTLE_EXTRA_CHARACTERS: Dictionary = {
+	0x6E: "<LV>",
+	0x70: "<DO>",
+	0x71: "◀",
+	0x72: "『",
+	0x73: "<ID>",
+	0x74: "№",
+}
 
 ## The lowest code the font has a tile for. Everything below it is a space, a
 ## border, a control code or a name substituted at print time, so it is also the
@@ -34,11 +67,14 @@ const MAX_LIGATURE: int = 2
 
 static var _table: Dictionary = {}
 static var _codes: Dictionary = {}
+static var _battle_extra_codes: Dictionary = {}
 
 
 ## Decodes bytes from [param offset] up to a terminator or [param max_length]
 ## characters, whichever comes first.
-static func decode(data: PackedByteArray, offset: int, max_length: int) -> String:
+static func decode(
+	data: PackedByteArray, offset: int, max_length: int, font: StringName = FONT_MAIN
+) -> String:
 	var out: String = ""
 	for i: int in max_length:
 		var at: int = offset + i
@@ -47,7 +83,7 @@ static func decode(data: PackedByteArray, offset: int, max_length: int) -> Strin
 		var byte: int = data[at]
 		if byte == TERMINATOR:
 			break
-		out += character(byte)
+		out += character(byte, font)
 	return out
 
 
@@ -93,8 +129,12 @@ static func decode_sequence(
 ##
 ## Anything the font cannot draw becomes [constant UNKNOWN] rather than being
 ## dropped, like an unrecognised byte on the way in.
-static func encode(text: String) -> PackedByteArray:
-	var codes: Dictionary = _encodings()
+## [param font] adds the strip's own single characters. Its bracketed markers
+## (`<LV>`, `<ID>`, `<DO>`) stay decode-only, the way `<PLAYER>` and the word
+## codes already are: a marker is not a character someone types, and the callers
+## that place one place the code itself.
+static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArray:
+	var codes: Dictionary = _encodings() if font == FONT_MAIN else _battle_extra_encodings()
 	var out: PackedByteArray = PackedByteArray()
 	var at: int = 0
 
@@ -118,11 +158,16 @@ static func encode(text: String) -> PackedByteArray:
 
 ## How many tiles a string occupies, which is not its length: a ligature is two
 ## characters in one tile, so anything laying text out has to ask.
-static func encoded_length(text: String) -> int:
-	return encode(text).size()
+static func encoded_length(text: String, font: StringName = FONT_MAIN) -> int:
+	return encode(text, font).size()
 
 
-static func character(byte: int) -> String:
+static func character(byte: int, font: StringName = FONT_MAIN) -> String:
+	if font == FONT_BATTLE_EXTRA \
+		and byte >= BATTLE_EXTRA_FIRST_CODE and byte <= BATTLE_EXTRA_LAST_CODE:
+		# The run this strip owns answers only from its own table, never from the
+		# main font's meaning for the same byte.
+		return BATTLE_EXTRA_CHARACTERS.get(byte, "<%02X>" % byte)
 	var table: Dictionary = _characters()
 	if table.has(byte):
 		return table[byte]
@@ -269,3 +314,27 @@ static func _encodings() -> Dictionary:
 
 	_codes = out
 	return _codes
+
+
+## The main font's encodings with the battle-extra run replaced.
+##
+## The main table's entries for $60 to $78 are dropped rather than kept
+## alongside: with that strip loaded there is no tile drawing an ellipsis, so
+## encoding one would place a byte that draws part of an HP bar.
+static func _battle_extra_encodings() -> Dictionary:
+	if not _battle_extra_codes.is_empty():
+		return _battle_extra_codes
+
+	var out: Dictionary = {}
+	var main: Dictionary = _encodings()
+	for text: String in main:
+		var code: int = main[text]
+		if code < BATTLE_EXTRA_FIRST_CODE or code > BATTLE_EXTRA_LAST_CODE:
+			out[text] = code
+	for code: int in BATTLE_EXTRA_CHARACTERS:
+		var character_text: String = BATTLE_EXTRA_CHARACTERS[code]
+		if character_text.length() <= MAX_LIGATURE:
+			out[character_text] = code
+
+	_battle_extra_codes = out
+	return _battle_extra_codes

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -250,26 +250,8 @@ func import_mod_path(path: String, replace: bool = false) -> Dictionary:
 	return result
 
 
-## The refusal reasons a player can act on, said plainly. Anything else falls
-## back to the reason itself rather than being flattened into one useless line.
 func _mod_refusal(result: Dictionary) -> String:
-	var detail: String = String(result.get("detail", ""))
-	match StringName(result.get("reason", &"")):
-		&"not_a_zip":
-			return "%s is not a .zip archive." % detail.get_file()
-		&"archive_not_found":
-			return "%s could not be read." % detail.get_file()
-		&"archive_has_no_manifest":
-			return "The archive has no %s, so it is not a mod." % Gen2ModManifest.FILENAME
-		&"archive_holds_more_than_one_folder":
-			return "The archive must hold a single mod folder."
-		&"unsupported_api_version":
-			return "That mod was built for a different host: %s." % detail
-		&"unsafe_archive_entry":
-			return "The archive tries to write outside the mod folder (%s)." % detail
-		&"archive_too_large", &"archive_too_many_entries":
-			return "That archive is too large to be a mod."
-	return "%s %s" % [result.get("reason", "refused"), detail]
+	return Gen2ModRefusal.text(result)
 
 
 func _open_mod_dialog() -> void:

--- a/game/main/mod_index_dialog.gd
+++ b/game/main/mod_index_dialog.gd
@@ -287,23 +287,5 @@ func _set_status(text: String, colour: Color) -> void:
 	_status.add_theme_color_override("font_color", colour)
 
 
-## Refusals a player can act on. Anything else shows the reason itself rather
-## than being flattened into one unhelpful line.
 func _reason_text(result: Dictionary) -> String:
-	var detail: String = String(result.get("detail", ""))
-	match StringName(result.get("reason", &"")):
-		&"empty_index_url":
-			return "Enter an index address first."
-		&"index_url_not_https":
-			return "An index must be an https address."
-		&"index_not_json":
-			return "That address did not return an index."
-		&"unsupported_index_schema":
-			return "That index uses format %s; this build reads %d." % [
-				detail, Gen2ModIndex.SCHEMA_VERSION,
-			]
-		&"unexpected_mod_id":
-			return "the download is a different mod (%s)" % detail
-		&"already_installed":
-			return "it is already installed"
-	return "%s %s" % [result.get("reason", "refused"), detail]
+	return Gen2ModRefusal.text(result)

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -70,9 +70,16 @@ const BUILT_IN_RENDERER: StringName = &"gen2"
 const MENU_START: StringName = &"start_menu"
 const MENU_PACK_POCKET: StringName = &"pack_pocket"
 const MENU_IDS: Array[StringName] = [MENU_START, MENU_PACK_POCKET]
+
+## The event channels a mod may watch. Both carry the typed dictionaries the
+## engine already produces, published where the screen reads them, so a
+## subscriber sees exactly the events a player sees and in the same order.
+const CHANNEL_WORLD: StringName = &"world"
+const CHANNEL_BATTLE: StringName = &"battle"
+const CHANNELS: Array[StringName] = [CHANNEL_WORLD, CHANNEL_BATTLE]
 ## Pocket type numbers 1 to 4 are the cartridge's ITEM, KEY_ITEM, BALL and TM_HM,
 ## so a registered pocket has to claim a number above them, the same reservation
-## the content overlay will need for species and item numbers.
+## [constant Gen2ContentOverlay.FIRST_MOD_NUMBER] makes for content.
 const FIRST_MOD_POCKET: int = 5
 
 static var _instance: Gen2ModHost = null
@@ -83,6 +90,7 @@ var _selected_world_renderer: StringName = BUILT_IN_RENDERER
 var _battle_renderers: Dictionary = {}
 var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
 var _menu_entries: Dictionary = {}
+var _subscribers: Dictionary = {}
 var _failures: Array = []
 
 
@@ -104,6 +112,8 @@ static func instance() -> Gen2ModHost:
 ## for a launcher that reloads the mod list.
 static func reset() -> void:
 	_instance = null
+	Gen2ContentOverlay.reset()
+	Gen2MoveEffect.reset_registry()
 
 
 ## Registers a world renderer under [param id].
@@ -222,6 +232,91 @@ func menu_entries(menu: StringName) -> Array:
 	return entries.duplicate(true)
 
 
+## Adds a species, move, item or trainer class the cartridge does not have.
+##
+## [param number] has to be at or above
+## [constant Gen2ContentOverlay.FIRST_MOD_NUMBER], and [param row] is a partial
+## row: whatever it leaves out comes from the kind's defaults. Everything a
+## species carries is on that row, so a defined Pokémon's learnset, evolutions
+## and TM compatibility are fields rather than separate registrations.
+func register_content(
+	kind: StringName, id: StringName, number: int, row: Dictionary
+) -> Dictionary:
+	return Gen2ContentOverlay.shared().define(kind, id, number, row)
+
+
+## Changes named fields of a row the cartridge does have: a move's power, a
+## species' types, an item's price. Dictionary fields merge, so patching one stat
+## leaves the other five alone.
+func patch_content(
+	kind: StringName, id: StringName, number: int, fields: Dictionary
+) -> Dictionary:
+	return Gen2ContentOverlay.shared().patch(kind, id, number, fields)
+
+
+## The overlay every opened [GameData] reads through, for a launcher listing what
+## a mod changed before the player starts.
+func content_overlay() -> Gen2ContentOverlay:
+	return Gen2ContentOverlay.shared()
+
+
+## Watches one of [constant CHANNELS]. [param handler] is called with each event
+## dictionary as it reaches the screen showing it.
+##
+## Reading only. A subscriber is handed a copy, so writing to it changes nothing,
+## and there is no return value the engine reads: observation cannot make two
+## mods fight over the same state, which is what makes this safe to hand out
+## before any mutation hook exists.
+func subscribe(channel: StringName, id: StringName, handler: Callable) -> Dictionary:
+	if not CHANNELS.has(channel):
+		return {"ok": false, "reason": &"unknown_channel", "detail": String(channel)}
+	if String(id).is_empty():
+		return {"ok": false, "reason": &"invalid_subscriber", "detail": String(channel)}
+	if not handler.is_valid():
+		return {"ok": false, "reason": &"invalid_subscriber_handler", "detail": String(id)}
+	var handlers: Dictionary = _subscribers.get(channel, {})
+	if handlers.has(id):
+		return {"ok": false, "reason": &"duplicate_subscriber", "detail": String(id)}
+	handlers[id] = handler
+	_subscribers[channel] = handlers
+	return {"ok": true, "id": id}
+
+
+func unsubscribe(channel: StringName, id: StringName) -> void:
+	(_subscribers.get(channel, {}) as Dictionary).erase(id)
+
+
+## Hands [param event] to whoever is watching [param channel].
+##
+## Static and null-safe on the instance, because this sits on the path every
+## battle event and every world result takes: a game with no mods must not build
+## a host, or copy an event, to publish to nobody.
+static func publish(channel: StringName, event: Dictionary) -> void:
+	if _instance == null:
+		return
+	var handlers: Dictionary = _instance._subscribers.get(channel, {})
+	if handlers.is_empty():
+		return
+	for id: StringName in handlers.keys():
+		var handler: Callable = handlers[id]
+		if handler.is_valid():
+			handler.call(event.duplicate(true))
+
+
+## Adds a move effect, as the list of commands a move carrying [param effect]
+## runs. See [Gen2MoveEffect] for the lists the cartridge's own effects use and
+## [Gen2EffectCommands] for the steps one is built from.
+func register_move_effect(id: StringName, effect: int, commands: Array) -> Dictionary:
+	return Gen2MoveEffect.register_effect(id, effect, commands)
+
+
+## Adds a step a move effect's list can name, as a Callable taking the
+## [Gen2Turn]. Registered commands are tried after the engine's own, so a mod
+## cannot shadow [constant Gen2EffectCommands.APPLY_DAMAGE] with something else.
+func register_effect_command(id: StringName, command: StringName, handler: Callable) -> Dictionary:
+	return Gen2MoveEffect.register_command(id, command, handler)
+
+
 func _register(
 	registry: Dictionary, methods: Array[String], id: StringName, script: Script,
 	label: String,
@@ -247,6 +342,11 @@ func _register(
 			"ok": false, "reason": &"renderer_missing_methods",
 			"detail": "%s: %s" % [id, ", ".join(missing)],
 		}
+	# Two mods claiming one renderer id is a conflict a player wants named, the
+	# same way two claiming a menu entry id is. Silently keeping the last loaded
+	# would leave the earlier mod installed, listed and drawing nothing.
+	if registry.has(id):
+		return {"ok": false, "reason": &"duplicate_renderer", "detail": String(id)}
 	registry[id] = {
 		"script": script,
 		"label": label if not label.is_empty() else String(id),

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -1,0 +1,110 @@
+class_name Gen2ModRefusal
+extends RefCounted
+
+## Why a mod was refused, said to a player rather than to a log.
+##
+## One table for every reason the mod layer produces: the installer's, the index
+## feed's, the manifest reader's and the host's registrations alike. The launcher
+## and the index dialog each used to keep their own, covering different halves of
+## the same set, so a mod refused through the wrong screen showed a raw
+## StringName. A new reason is worded here, once, and both screens have it.
+##
+## Anything unworded falls back to the reason itself, which is a poor line but an
+## honest one: it names something a search finds.
+
+## Reasons that read the same wherever they come from. A [code]%s[/code] is
+## filled with the result's own [code]detail[/code]; a reason wanting anything
+## else is a branch in [method text].
+const WORDING: Dictionary = {
+	# Choosing and reading the archive.
+	&"not_a_zip": "%s is not a .zip archive.",
+	&"archive_not_found": "%s could not be read.",
+	&"archive_unreadable": "That archive could not be opened.",
+	&"archive_is_empty": "That archive is empty.",
+	&"archive_holds_more_than_one_folder": "The archive must hold a single mod folder.",
+	&"archive_too_large": "That archive is too large to be a mod.",
+	&"archive_too_many_entries": "That archive is too large to be a mod.",
+	&"unsafe_archive_entry": "The archive tries to write outside the mod folder (%s).",
+
+	# What the manifest says.
+	&"missing_manifest": "The mod has no %s.",
+	&"unreadable_manifest": "The mod's %s could not be read.",
+	&"invalid_manifest": "The mod's %s is not valid JSON.",
+	&"invalid_id": "\"%s\" is not a usable mod id.",
+	&"missing_entry": "The mod names no entry script.",
+	&"entry_not_gdscript": "A mod's entry script has to be GDScript (%s).",
+	&"entry_escapes_mod": "The entry script points outside the mod folder (%s).",
+
+	# Writing it into place.
+	&"could_not_create_mod_directory": "The mod folder could not be created.",
+	&"could_not_stage_archive": "The download could not be written to disk.",
+	&"could_not_write_mod_file": "%s could not be written.",
+	&"already_installed": "It is already installed.",
+
+	# Running it.
+	&"missing_entry_script": "The entry script %s is missing.",
+	&"entry_not_a_script": "The entry %s is not a script.",
+	&"entry_has_no_register": "The entry script %s has no register() function.",
+
+	# What it registered.
+	&"invalid_renderer": "A mod registered a renderer with no id or script.",
+	&"renderer_not_instantiable": "%s's renderer could not be created.",
+	&"renderer_not_a_node": "%s's renderer is not a Node.",
+	&"renderer_missing_methods": "A renderer is missing methods it needs (%s).",
+	&"duplicate_renderer": "Two mods both registered the renderer \"%s\".",
+	&"unknown_renderer": "There is no renderer called \"%s\".",
+	&"unknown_menu": "There is no menu called \"%s\".",
+	&"invalid_menu_entry": "A mod registered a menu entry with no id.",
+	&"menu_entry_missing_label": "%s's menu entry has no label.",
+	&"duplicate_menu_entry": "Two mods both registered the menu entry \"%s\".",
+	&"unknown_channel": "There is no event channel called \"%s\".",
+	&"invalid_subscriber": "A mod subscribed with no id.",
+	&"invalid_subscriber_handler": "%s subscribed with nothing to call.",
+	&"duplicate_subscriber": "%s subscribed to the same channel twice.",
+	&"unknown_content_kind": "There is no content kind called \"%s\".",
+	&"duplicate_content": "Two mods both claimed the same content (%s).",
+	&"empty_content_patch": "A %s patch changes nothing.",
+	&"invalid_effect": "%s is not a move effect number.",
+	&"reserved_effect": "Move effect %s is one the engine reads back and cannot be replaced.",
+	&"empty_effect": "Move effect %s was registered with no commands.",
+	&"unknown_effect_command": "A move effect names steps that do not exist (%s).",
+	&"invalid_effect_command": "A mod registered an effect command with no name.",
+	&"invalid_effect_handler": "The effect command \"%s\" was registered with nothing to call.",
+	&"reserved_effect_command": "\"%s\" is one of the engine's own steps.",
+	&"duplicate_move_effect": "Two mods both claimed the same move effect (%s).",
+
+	# Index feeds.
+	&"empty_index_url": "Enter an index address first.",
+	&"index_url_not_https": "An index must be an https address.",
+	&"index_not_json": "That address did not return an index.",
+	&"index_has_no_mods": "That index lists no mods.",
+	&"index_too_large": "That index is too large to read.",
+	&"unexpected_mod_id": "The download is a different mod (%s).",
+}
+
+
+## What to show a player for [param result], which is any
+## [code]{ok: false, reason, detail}[/code] the mod layer answers with.
+static func text(result: Dictionary) -> String:
+	var reason: StringName = StringName(result.get("reason", &""))
+	var detail: String = String(result.get("detail", ""))
+	match reason:
+		# Two reasons need something other than the detail: a filename rather
+		# than the whole path, and a version this build can name itself.
+		&"not_a_zip", &"archive_not_found":
+			detail = detail.get_file()
+		&"archive_has_no_manifest", &"missing_manifest", &"unreadable_manifest", \
+		&"invalid_manifest":
+			# The detail is a path; the filename is what a player recognises.
+			detail = Gen2ModManifest.FILENAME
+		&"unsupported_api_version":
+			# The detail already names both versions.
+			return "That mod was built for a different host: %s." % detail
+		&"unsupported_index_schema":
+			return "That index uses format %s; this build reads %d." % [
+				detail, Gen2ModIndex.SCHEMA_VERSION,
+			]
+	if not WORDING.has(reason):
+		return "%s %s" % [reason if reason != &"" else &"refused", detail]
+	var wording: String = WORDING[reason]
+	return wording % detail if wording.contains("%s") else wording

--- a/game/mods/mod_refusal.gd.uid
+++ b/game/mods/mod_refusal.gd.uid
@@ -1,0 +1,1 @@
+uid://dj1eaixkw1fvx

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -7,10 +7,17 @@ extends RefCounted
 ## width, and a character code is already the tile number that draws it. Nothing
 ## is measured or kerned; indices are copied into a buffer at multiples of eight.
 ##
-## Both sheets are one row of tiles ([method Gen2Tiles.decode_1bpp_strip]), so a
+## Every sheet is one row of tiles ([method Gen2Tiles.decode_1bpp_strip]), so a
 ## code is a horizontal offset and nothing else. A code with no tile draws
 ## nothing rather than a placeholder, which is what the space at $7F is and what
 ## the hardware does.
+##
+## Three sheets, because the hardware has three loaded at once and one of them
+## changes. The main font covers $80 upward and the frames $79 to $7E in both
+## strips; `_LoadFontsBattleExtra` replaces $60 to $78, which is where `№`,
+## `<ID>` and `<LV>` live. Which of the two is up is [Gen2Text]'s font argument,
+## carried through to the tile it addresses, so a caller says which screen it is
+## drawing rather than which sheet a byte came from.
 ##
 ## Node-free: it writes into an index buffer, not the screen, so a whole text box
 ## can be laid out and checked headless.
@@ -26,6 +33,10 @@ var _frames: PackedByteArray = PackedByteArray()
 var _frame_width: int = 0
 var _frame_first_code: int = RomLayout.FRAME_FIRST_CODE
 var _frame_tiles: int = 0
+
+var _battle_extra: PackedByteArray = PackedByteArray()
+var _battle_extra_width: int = 0
+var _battle_extra_tiles: int = 0
 
 
 ## Reads both sheets out of a cache, or null if that cache has no font in it.
@@ -49,6 +60,13 @@ static func from_data(data: GameData) -> Gen2Font:
 	out._frame_first_code = int(frames.get("first_code", RomLayout.FRAME_FIRST_CODE))
 	out._frame_tiles = int(frames.get("tiles", 0))
 
+	# Optional: a font with no battle-extra strip draws the main run and refuses
+	# the other, which is what a cache written before this was read back holds.
+	var battle_extra: Dictionary = data.tile_sheet("battle_font")
+	out._battle_extra = data.tile_indices("battle_font")
+	out._battle_extra_width = int(battle_extra.get("width", 0))
+	out._battle_extra_tiles = int(battle_extra.get("tiles", 0))
+
 	return out if out.is_usable() else null
 
 
@@ -63,11 +81,30 @@ func frame_count() -> int:
 	return _frame_tiles / RomLayout.FRAME_TILES
 
 
+## Whether the battle-extra strip was in the cache this was read from.
+func has_battle_extra() -> bool:
+	return _battle_extra_width > 0 and _battle_extra_tiles > 0
+
+
 ## Draws one character code at a tile position, in pixels from the top left.
 ## A code with no tile draws nothing, which is what a space is.
+##
+## [param font] says which strip is loaded. Under
+## [constant Gen2Text.FONT_BATTLE_EXTRA] a code in $60 to $78 comes off the
+## battle-extra sheet; everything else comes off the main font either way,
+## because that load replaces only those tiles.
 func draw_code(
-	code: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int
+	code: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int,
+	font: StringName = Gen2Text.FONT_MAIN
 ) -> void:
+	if font == Gen2Text.FONT_BATTLE_EXTRA \
+		and code >= Gen2Text.BATTLE_EXTRA_FIRST_CODE \
+		and code <= Gen2Text.BATTLE_EXTRA_LAST_CODE:
+		var within: int = code - RomLayout.BATTLE_FONT_FIRST_CODE
+		if within < 0 or within >= _battle_extra_tiles:
+			return
+		blit_slot(_battle_extra, _battle_extra_width, within, into, into_width, at_x, at_y)
+		return
 	var slot: int = code - _first_code
 	if slot < 0 or slot >= _glyph_tiles:
 		return
@@ -78,11 +115,12 @@ func draw_code(
 ## tile. Returns how many tiles were drawn, which is not the string's length
 ## when it contains a ligature.
 func draw_text(
-	text: String, into: PackedByteArray, into_width: int, at_x: int, at_y: int
+	text: String, into: PackedByteArray, into_width: int, at_x: int, at_y: int,
+	font: StringName = Gen2Text.FONT_MAIN
 ) -> int:
-	var codes: PackedByteArray = Gen2Text.encode(text)
+	var codes: PackedByteArray = Gen2Text.encode(text, font)
 	for i: int in codes.size():
-		draw_code(codes[i], into, into_width, at_x + i * TILE, at_y)
+		draw_code(codes[i], into, into_width, at_x + i * TILE, at_y, font)
 	return codes.size()
 
 

--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -7,12 +7,10 @@ extends RefCounted
 ## boxes, its frontpic at (6,5) and every field row it prints, and
 ## HOF_AnimatePlayerPic's name box for the player's page.
 ##
-## Three of the source's glyphs are not drawn, because the project imports no
-## strip that has them. The font cache is 128 tiles from $80
-## ([constant RomLayout.FONT_FIRST_CODE]), while `№` is $74, `<ID>` is $73 and
-## `<LV>` is $6e, all in `gfx/font/font_battle_extra.png`. Plain words stand in
-## rather than invented artwork, which shifts the two number columns one tile
-## right of the cartridge's.
+## `halloffame.asm:298` calls `LoadFontsBattleExtra` before any of this, so the
+## panel prints with `gfx/font/font_battle_extra.png` over $60 to $78 and `№`,
+## `<ID>` and `<LV>` are real tiles. Every glyph and column here is the
+## cartridge's; see [constant Gen2Text.FONT_BATTLE_EXTRA].
 ##
 ## Node-free: it writes indices into a buffer, so a page can be drawn and read
 ## back headless. The Pokémon's own pic is not in that buffer; it has its own
@@ -32,20 +30,34 @@ const CAPTION_TEXT: String = "New Hall of Famer!"
 const PIC_AT: Vector2i = Vector2i(6, 5)
 const PIC_TILES: int = 7
 
-## The source prints `№` then `<DOT>` in two tiles and the three digits in the
-## next three, leaving column 6 blank before the name. "No." fills three tiles,
-## so the number and the name each move one column right and the blank stays.
+## `ld a, '№' / ld [hli], a / ld [hl], '<DOT>'` at `hlcoord 1, 13`, then
+## `hlcoord 3, 13` for three digits, leaving column 6 blank before the name.
 const DEX_LABEL: Vector2i = Vector2i(1, 13)
-const DEX_NUMBER: Vector2i = Vector2i(4, 13)
+const DEX_NUMBER: Vector2i = Vector2i(3, 13)
 const DEX_DIGITS: int = 3
-const SPECIES_NAME: Vector2i = Vector2i(8, 13)
+const SPECIES_NAME: Vector2i = Vector2i(7, 13)
 const GENDER: Vector2i = Vector2i(18, 13)
 const NICKNAME_SLASH: Vector2i = Vector2i(8, 14)
+## `PrintLevel` writes `<LV>` and then the number left-aligned beside it. Its
+## three-digit branch backs over the `<LV>`, which no level in these games
+## reaches: 100 is the cap and the branch is `cp 100` on a byte.
 const LEVEL: Vector2i = Vector2i(1, 16)
-## `<ID>№/` is three tiles at (7,16); "ID" plus the slash is three as well.
+## `<ID>`, `№`, `/` at `hlcoord 7, 16`, then five digits at `hlcoord 10, 16`.
 const OT_LABEL: Vector2i = Vector2i(7, 16)
 const OT_NUMBER: Vector2i = Vector2i(10, 16)
 const OT_DIGITS: int = 5
+
+## The codes the panel places directly, the way the source does: `ld [hl], '№'`
+## puts a byte down, it does not print a string, and a bracketed marker is not
+## something [method Gen2Text.encode] will produce.
+const CODE_NUMERO: int = 0x74
+const CODE_DOT: int = 0xF2
+const CODE_ID: int = 0x73
+const CODE_LEVEL: int = 0x6E
+const CODE_SLASH: int = 0xF3
+
+## Everything on a panel is printed with the battle-extra strip loaded.
+const FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
 
 ## HOF_AnimatePlayerPic's `Textbox` at (0,2) with a 9x8 interior.
 const PLAYER_BOX: Rect2i = Rect2i(0, 2, 11, 10)
@@ -96,16 +108,24 @@ func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:
 	_box(indices, width, MON_BOTTOM_BOX)
 	_text(indices, width, CAPTION_TEXT, CAPTION)
 
-	_text(indices, width, "No.", DEX_LABEL)
+	_code(indices, width, CODE_NUMERO, DEX_LABEL)
+	_code(indices, width, CODE_DOT, DEX_LABEL + Vector2i(1, 0))
 	## PRINTNUM_LEADINGZEROS, so a two-digit dex number keeps its column.
 	_text(indices, width, "%0*d" % [DEX_DIGITS, int(page.get("dex_number", 0))], DEX_NUMBER)
 	_text(indices, width, String(page.get("species_name", "")), SPECIES_NAME)
 	_text(indices, width, _gender_glyph(StringName(page.get("gender", &""))), GENDER)
 
-	_text(indices, width, "/", NICKNAME_SLASH)
+	_code(indices, width, CODE_SLASH, NICKNAME_SLASH)
 	_text(indices, width, String(page.get("nickname", "")), NICKNAME_SLASH + Vector2i(1, 0))
-	_text(indices, width, "Lv%d" % int(page.get("level", 0)), LEVEL)
-	_text(indices, width, "ID/", OT_LABEL)
+
+	_code(indices, width, CODE_LEVEL, LEVEL)
+	## PRINTNUM_LEFTALIGN, so the digits start against the symbol rather than
+	## being padded out to the field's width.
+	_text(indices, width, str(int(page.get("level", 0))), LEVEL + Vector2i(1, 0))
+
+	_code(indices, width, CODE_ID, OT_LABEL)
+	_code(indices, width, CODE_NUMERO, OT_LABEL + Vector2i(1, 0))
+	_code(indices, width, CODE_SLASH, OT_LABEL + Vector2i(2, 0))
 	_text(indices, width, "%0*d" % [OT_DIGITS, int(page.get("ot_id", 0))], OT_NUMBER)
 
 
@@ -137,4 +157,9 @@ func _box(indices: PackedByteArray, width: int, box: Rect2i) -> void:
 
 
 func _text(indices: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
-	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE)
+	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE, FONT)
+
+
+## One glyph placed by its code, which is what `ld [hl], '№'` does.
+func _code(indices: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
+	font.draw_code(code, indices, width, at.x * TILE, at.y * TILE, FONT)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -264,10 +264,7 @@ func _process(delta: float) -> void:
 		_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
 		if not ticks.is_empty():
 			_update_time_of_day()
-			if _service_host == null and _battle_host == null and _pc_host == null \
-				and _start_menu_host == null and _party_host == null \
-				and _hall_of_fame_host == null \
-				and not _world.script_input_waiting():
+			if not _overlay_open() and not _world.script_input_waiting():
 				var phone_schedule: Dictionary = _world.advance_phone_schedule(
 					ticks.size(), _encounter_random
 				)
@@ -304,14 +301,21 @@ func _advance_forced_movement() -> void:
 		_after_player_move(forced)
 
 
+## Whether any embedded screen is up. Every overlay is named here and nowhere
+## else: the six callers below each need a different set of the other pauses, but
+## they all need this one, and adding an overlay to five of six lists by hand is
+## what the Cut and Hall of Fame work each paid for once.
+func _overlay_open() -> bool:
+	return _battle_host != null or _service_host != null or _pc_host != null \
+		or _start_menu_host != null or _party_host != null \
+		or _hall_of_fame_host != null
+
+
 ## Wandering objects keep to themselves while anything else owns the world. A
 ## script may be moving those same objects, a trainer approach paces its own
 ## object by call count, and an overlay hides the map entirely.
 func _objects_may_move() -> bool:
-	return _world != null \
-		and _battle_host == null and _service_host == null and _pc_host == null \
-		and _start_menu_host == null and _party_host == null \
-		and _hall_of_fame_host == null \
+	return _world != null and not _overlay_open() \
 		and not _field_move_text \
 		and _trainer_approach.is_empty() \
 		and not _world.script_busy() \
@@ -467,18 +471,14 @@ func _unhandled_input(event: InputEvent) -> void:
 ## Whether the overworld itself is idle. The key path reaches the renderer only
 ## after the same overlays, pauses and hosts have each refused the event.
 func _renderer_input_free() -> bool:
-	return _world != null and _battle_host == null and _service_host == null \
-		and _pc_host == null and _start_menu_host == null and _party_host == null \
-		and _hall_of_fame_host == null and not _field_move_text \
+	return _world != null and not _overlay_open() and not _field_move_text \
 		and _trainer_approach.is_empty() and not _world.phone_ring_active() \
 		and not _world.fishing_busy() and not _world.script_input_waiting()
 
 
 ## Public driver for screenshot tooling and scene tests.
 func move_player(direction: Vector2i) -> bool:
-	if _world == null or _world.fishing_busy() or _service_host != null \
-		or _pc_host != null or _start_menu_host != null or _party_host != null \
-		or _hall_of_fame_host != null \
+	if _world == null or _overlay_open() or _world.fishing_busy() \
 		or _field_move_text or _world.phone_ring_active() \
 		or not _trainer_approach.is_empty() or _world.player_step_in_progress():
 		return false
@@ -559,9 +559,7 @@ func _after_player_move(movement: Dictionary) -> bool:
 
 ## Public driver for the production NPC/object interaction path.
 func interact() -> bool:
-	if _world == null or _battle_host != null or _service_host != null \
-		or _pc_host != null or _start_menu_host != null or _party_host != null \
-		or _hall_of_fame_host != null \
+	if _world == null or _overlay_open() \
 		or _field_move_text or _world.phone_ring_active() or _world.fishing_busy():
 		return false
 	var results: Array = _world.interact()
@@ -1381,9 +1379,7 @@ func _play_hall_of_fame_music() -> void:
 ## _open_pc_host()'s shape. The Enter/Tab key branch in
 ## _unhandled_key_input() is the normal path.
 func _open_start_menu() -> void:
-	if _start_menu_host != null or _party_host != null or _service_host != null \
-		or _pc_host != null or _battle_host != null or _world == null or _data == null \
-		or _hall_of_fame_host != null or _field_move_text \
+	if _world == null or _data == null or _overlay_open() or _field_move_text \
 		or not _trainer_approach.is_empty() or _world.script_busy() \
 		or _world.phone_ring_active() or _world.fishing_busy():
 		return
@@ -1707,6 +1703,7 @@ func _show_script_results(results: Array) -> void:
 	var recovered: bool = false
 	var recovery_prompt: String = ""
 	for result: Dictionary in results:
+		Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, result)
 		if result.has("clock"):
 			clock_changed = true
 		var status: StringName = StringName(result.get("status", &""))

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -1,0 +1,125 @@
+extends RefCounted
+
+## Everything a mod can register that is not a renderer, in one file.
+##
+## Nothing here is a scene node, a cartridge read or an engine internal: the mod
+## is handed the host, registers, and returns. What it registers is then read
+## back by the ordinary engine, which never learns that a mod defined any of it.
+##
+## Copy this directory into `user://mods/` to run it.
+
+## Mod numbers start at Gen2ContentOverlay.FIRST_MOD_NUMBER, which is 256: every
+## cartridge content number fits in a byte, so anything above one is
+## unambiguously not the cartridge's, and these numbers mean the same thing on
+## Gold, Silver and Crystal.
+## Numbering is per kind, so the first species and the first move share one.
+const VOLTLING: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
+const STATIC_FIELD: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
+## An effect byte no cartridge move carries.
+const RECOIL_AND_PARALYSE: int = 0xF0
+
+## Electric. RomLayout names only the types the engine itself names; the rest are
+## reached by number, since a move's type byte is already one.
+const ELECTRIC: int = 0x17
+## Cartridge numbers, for the two rows this mod changes rather than adds.
+const PIKACHU: int = 25
+const THUNDERBOLT: int = 85
+
+
+func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
+	_add_a_species(host, manifest.id)
+	_add_a_move(host, manifest.id)
+	_rebalance(host, manifest.id)
+	_watch(host, manifest.id)
+
+
+## A whole Pokémon. Everything a species carries is a field on one row, so the
+## learnset, the evolution and the TM flags are part of the definition rather
+## than four separate registrations; anything left out gets the kind's default,
+## which is why this does not have to name a hatch cycle or a gender ratio.
+##
+## It has no pic: the atlas is decoded from the cartridge and holds 251 slots. A
+## mod wanting art for its own species needs a renderer, which is the other half
+## of docs/MODS.md.
+func _add_a_species(host: Gen2ModHost, id: StringName) -> void:
+	host.register_content(Gen2ContentOverlay.KIND_SPECIES, id, VOLTLING, {
+		"name": "VOLTLING",
+		"stats": {
+			"hp": 70, "attack": 65, "defense": 60,
+			"speed": 115, "sp_attack": 110, "sp_defense": 70,
+		},
+		# The second slot repeated is how the cartridge writes a single type.
+		"types": [ELECTRIC, ELECTRIC],
+		"catch_rate": 45,
+		"base_exp": 180,
+		"growth_rate": Gen2Experience.GROWTH_MEDIUM_FAST,
+		"learnset": [
+			{"level": 1, "move": 33},   # TACKLE
+			{"level": 8, "move": 84},   # THUNDERSHOCK
+			{"level": 20, "move": STATIC_FIELD},
+			{"level": 36, "move": THUNDERBOLT},
+		],
+		"evolutions": [],
+	})
+
+
+## A move, and the effect that decides what it does.
+##
+## The effect is registered before the move, because a move's effect byte is only
+## a number until something answers for it, and a list naming a step that does
+## not exist is refused at registration rather than failing mid-turn.
+func _add_a_move(host: Gen2ModHost, id: StringName) -> void:
+	# The cartridge's own lists are in Gen2MoveEffect and the steps in
+	# Gen2EffectCommands. This is NORMAL_HIT with the recoil of Take Down and the
+	# paralysis chance of Body Slam, which no cartridge effect combines.
+	host.register_move_effect(id, RECOIL_AND_PARALYSE, [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.DAMAGE_CALC,
+		Gen2EffectCommands.CHECK_IMMUNE,
+		Gen2EffectCommands.CHECK_HIT,
+		Gen2EffectCommands.EFFECT_CHANCE,
+		Gen2EffectCommands.APPLY_DAMAGE,
+		Gen2EffectCommands.RECOIL,
+		Gen2EffectCommands.CHECK_FAINT,
+		Gen2EffectCommands.PARALYZE_TARGET,
+		Gen2EffectCommands.END_MOVE,
+	])
+	host.register_content(Gen2ContentOverlay.KIND_MOVE, id, STATIC_FIELD, {
+		"name": "STATICFIELD",
+		"effect": RECOIL_AND_PARALYSE,
+		"power": 95,
+		"type": ELECTRIC,
+		"accuracy": 230,
+		"pp": 10,
+		"effect_chance": 76,
+	})
+
+
+## Changing what the cartridge shipped, rather than adding to it. A patch names
+## only the fields it changes, and a Dictionary field merges, so this moves one
+## stat and one number and leaves everything else on both rows alone.
+func _rebalance(host: Gen2ModHost, id: StringName) -> void:
+	host.patch_content(Gen2ContentOverlay.KIND_SPECIES, id, PIKACHU, {
+		"stats": {"speed": 110},
+	})
+	host.patch_content(Gen2ContentOverlay.KIND_MOVE, id, THUNDERBOLT, {"power": 90})
+
+
+## Watching the game without changing it. Both channels carry the typed
+## dictionaries the engine already produces, handed over as copies where the
+## screen shows them, so a subscriber sees what the player sees and writing to
+## one reaches nothing.
+func _watch(host: Gen2ModHost, id: StringName) -> void:
+	host.subscribe(Gen2ModHost.CHANNEL_BATTLE, id, _on_battle_event)
+	host.subscribe(Gen2ModHost.CHANNEL_WORLD, id, _on_world_event)
+
+
+func _on_battle_event(event: Dictionary) -> void:
+	if StringName(event.get("type", &"")) == Gen2Battle.FAINTED:
+		print("[new_content] side %d fainted" % int(event.get("side", -1)))
+
+
+func _on_world_event(event: Dictionary) -> void:
+	if StringName(event.get("status", &"")) == &"waiting":
+		print("[new_content] the world is waiting on %s" % event.get("event", {}).get("type", ""))

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -1,0 +1,8 @@
+{
+	"id": "new_content",
+	"name": "New Content Example",
+	"version": "1.0.0",
+	"api_version": 1,
+	"entry": "mod.gd",
+	"description": "Adds a species, a move and a move effect, rebalances a cartridge one, and watches the world and battle event channels. The reference for everything a mod can register that is not a renderer."
+}

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1261,7 +1261,7 @@ func test_switching_out_clears_attract_disable_and_encore() -> void:
 		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])],
 		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
 	)
-	battle.player.substatus |= Gen2Substatus.ATTRACTED | Gen2Substatus.DISABLED | Gen2Substatus.ENCORED
+	battle.player.substatus |= Gen2Substatus.ATTRACTED | Gen2Substatus.ENCORED
 	battle.player.disabled_slot = 0
 	battle.player.disable_turns = 3
 	battle.player.encored_slot = 0

--- a/tests/unit/test_content_overlay.gd
+++ b/tests/unit/test_content_overlay.gd
@@ -1,0 +1,181 @@
+extends GutTest
+
+## The overlay is reached the way a mod reaches it, through Gen2ModHost, and read
+## the way the engine reads it, through a real GameData built over a real cache.
+## Nothing here knows a mod exists once the content is registered, which is the
+## whole point of putting it at GameData's own chokepoint.
+
+const MOD: StringName = &"testmod"
+const NEW_SPECIES: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
+const NEW_MOVE: int = Gen2ContentOverlay.FIRST_MOD_NUMBER + 1
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	Gen2ModHost.reset()
+	_directory = RomCache.directory_for(&"overlaygame", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+	Gen2ModHost.reset()
+
+
+func _write_cache() -> void:
+	RomCache.write_json(RomCache.species_path(_directory), [{
+		"number": 1, "name": "BULBASAUR",
+		"stats": {"hp": 45, "attack": 49, "defense": 49, "speed": 45,
+			"sp_attack": 65, "sp_defense": 65},
+		"types": [0, 3], "front_tiles": [7, 7],
+		"palette": {"normal": [0x1234, 0x1234], "shiny": [0x5678, 0x5678]},
+		"evolutions": [], "learnset": [{"level": 1, "move": 33}],
+	}])
+	RomCache.write_json(RomCache.moves_path(_directory), [
+		{"number": 1, "name": "POUND", "power": 40, "type": 0, "accuracy": 255, "pp": 35},
+	])
+	RomCache.write_json(RomCache.items_path(_directory), [
+		{"number": 1, "name": "MASTER BALL", "price": 0},
+	])
+	RomCache.write_json(RomCache.types_path(_directory), [{"number": 0, "name": "NORMAL"}])
+	RomCache.write_json(RomCache.matchups_path(_directory), [])
+	RomCache.write_json(RomCache.trainers_path(_directory), [
+		{"number": 1, "name": "LEADER", "palette": [0x1234, 0x5678], "trainers": []},
+	])
+	RomCache.write_json(RomCache.world_trades_path(_directory), [])
+	RomCache.write_json(RomCache.tmhm_moves_path(_directory), [1])
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "overlaygame",
+		"sha1": "0123456789abcdef",
+		"atlases": {
+			"front": {"width": 56, "height": 56, "cell": 56, "columns": 1, "decoded": 1},
+			"back": {"width": 56, "height": 56, "cell": 56, "columns": 1, "decoded": 1},
+		},
+		"tiles": {},
+		"complete": true,
+	})
+
+
+func _data() -> GameData:
+	return GameData.open_directory(_directory)
+
+
+func test_a_defined_species_reads_back_like_a_cartridge_one() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.register_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES, {
+			"name": "VOLTLING",
+			"stats": {"speed": 200},
+			"types": [0, 0],
+			"learnset": [{"level": 1, "move": 1}, {"level": 7, "move": 2}],
+			"evolutions": [{
+				"method": RomLayout.EVOLVE_LEVEL, "parameter": 16, "condition": 0, "target": 1,
+			}],
+		}
+	).get("ok", false)))
+
+	var data: GameData = _data()
+	var entry: Dictionary = data.species(NEW_SPECIES)
+	assert_eq(String(entry["name"]), "VOLTLING")
+	assert_eq(int(entry["number"]), NEW_SPECIES)
+	# A partial stats block keeps the defaults it did not name, so nothing
+	# downstream divides by a missing HP.
+	assert_eq(int(entry["stats"]["speed"]), 200)
+	assert_eq(int(entry["stats"]["hp"]), 1)
+	# Everything a species carries rides on the same row, so the learnset and
+	# evolution readers answer without knowing a mod defined this one.
+	assert_eq(data.moves_at_level(NEW_SPECIES, 10).size(), 2)
+	assert_eq(int(data.evolutions(NEW_SPECIES)[0]["target"]), 1)
+	# And the fields a reader indexes directly are always there.
+	assert_eq(data.palette(NEW_SPECIES).size(), 4)
+	assert_false(data.species_pic(NEW_SPECIES).is_empty())
+
+
+func test_a_patch_changes_named_fields_and_leaves_the_rest() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, 1, {"stats": {"speed": 200}}
+	).get("ok", false)))
+	assert_true(bool(host.patch_content(
+		Gen2ContentOverlay.KIND_MOVE, MOD, 1, {"power": 250}
+	).get("ok", false)))
+
+	var data: GameData = _data()
+	assert_eq(int(data.species(1)["stats"]["speed"]), 200)
+	assert_eq(int(data.species(1)["stats"]["hp"]), 45, "an unnamed stat is untouched")
+	assert_eq(String(data.species(1)["name"]), "BULBASAUR")
+	assert_eq(int(data.move(1)["power"]), 250)
+
+
+func test_a_patch_does_not_invent_a_row_this_cartridge_lacks() -> void:
+	# Crystal has a trainer class Gold does not. A mod patching it must change
+	# nothing on the game that never had it, rather than conjure one.
+	assert_true(bool(Gen2ModHost.instance().patch_content(
+		Gen2ContentOverlay.KIND_TRAINER, MOD, 40, {"name": "GHOST"}
+	).get("ok", false)))
+	assert_true(_data().trainer(40).is_empty())
+
+
+func test_cartridge_numbers_and_mod_numbers_keep_their_own_side() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(
+		StringName(host.register_content(
+			Gen2ContentOverlay.KIND_SPECIES, MOD, 25, {"name": "NOTPIKACHU"}
+		)["reason"]),
+		&"reserved_content_number"
+	)
+	assert_eq(
+		StringName(host.patch_content(
+			Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES, {"name": "X"}
+		)["reason"]),
+		&"not_a_cartridge_number"
+	)
+	assert_eq(
+		StringName(host.register_content(&"pokeblock", MOD, NEW_SPECIES, {})["reason"]),
+		&"unknown_content_kind"
+	)
+
+
+func test_two_mods_claiming_one_number_is_refused_rather_than_decided_by_load_order() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.register_content(
+		Gen2ContentOverlay.KIND_MOVE, MOD, NEW_MOVE, {"name": "FIRST"}
+	).get("ok", false)))
+	var second: Dictionary = host.register_content(
+		Gen2ContentOverlay.KIND_MOVE, &"othermod", NEW_MOVE, {"name": "SECOND"}
+	)
+	assert_eq(StringName(second["reason"]), &"duplicate_content")
+	assert_eq(String(_data().move(NEW_MOVE)["name"]), "FIRST")
+	# The same mod refining its own registration is not a conflict.
+	assert_true(bool(host.register_content(
+		Gen2ContentOverlay.KIND_MOVE, MOD, NEW_MOVE, {"name": "AGAIN"}
+	).get("ok", false)))
+
+
+func test_a_cache_with_no_mods_reads_exactly_what_the_cartridge_held() -> void:
+	var data: GameData = _data()
+	assert_eq(String(data.species(1)["name"]), "BULBASAUR")
+	assert_true(data.species(NEW_SPECIES).is_empty())
+	assert_true(Gen2ContentOverlay.shared().is_empty())
+
+
+func test_resetting_the_host_drops_what_the_last_load_registered() -> void:
+	Gen2ModHost.instance().register_content(
+		Gen2ContentOverlay.KIND_ITEM, MOD, Gen2ContentOverlay.FIRST_MOD_NUMBER, {"name": "THING"}
+	)
+	assert_eq(String(_data().item(Gen2ContentOverlay.FIRST_MOD_NUMBER)["name"]), "THING")
+	Gen2ModHost.reset()
+	assert_true(_data().item(Gen2ContentOverlay.FIRST_MOD_NUMBER).is_empty())
+
+
+func test_the_overlay_names_who_claimed_what() -> void:
+	Gen2ModHost.instance().register_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES, {"name": "VOLTLING"}
+	)
+	var overlay: Gen2ContentOverlay = Gen2ModHost.instance().content_overlay()
+	assert_eq(overlay.defined_numbers(Gen2ContentOverlay.KIND_SPECIES), [NEW_SPECIES] as Array[int])
+	assert_eq(overlay.owner_of(Gen2ContentOverlay.KIND_SPECIES, NEW_SPECIES), MOD)

--- a/tests/unit/test_content_overlay.gd.uid
+++ b/tests/unit/test_content_overlay.gd.uid
@@ -1,0 +1,1 @@
+uid://bv01m7t2gi5ch

--- a/tests/unit/test_font.gd
+++ b/tests/unit/test_font.gd
@@ -9,6 +9,10 @@ extends GutTest
 const SHEET_TILES: int = 3
 const WIDTH: int = SHEET_TILES * Gen2Font.TILE
 
+const BATTLE_EXTRA_WIDTH: int = RomLayout.BATTLE_FONT_TILES * Gen2Font.TILE
+## Not [constant Gen2Tiles.INK], so a pixel says which strip it came from.
+const BATTLE_EXTRA_INK: int = 2
+
 var _directory: String = ""
 var _font: Gen2Font = null
 
@@ -37,6 +41,13 @@ func _write_cache() -> void:
 	frames.fill(Gen2Tiles.INK)
 	RomCache.write_indices(RomCache.tile_path(_directory, "frames"), frames)
 
+	# The battle-extra strip, filled with a different index so a glyph taken
+	# from it cannot be mistaken for one taken from the main font.
+	var battle_extra: PackedByteArray = PackedByteArray()
+	battle_extra.resize(BATTLE_EXTRA_WIDTH * Gen2Font.TILE)
+	battle_extra.fill(BATTLE_EXTRA_INK)
+	RomCache.write_indices(RomCache.tile_path(_directory, "battle_font"), battle_extra)
+
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "fontgame",
@@ -50,6 +61,10 @@ func _write_cache() -> void:
 			"frames": {
 				"width": RomLayout.FRAME_TILES * Gen2Font.TILE, "height": Gen2Font.TILE,
 				"tiles": RomLayout.FRAME_TILES, "first_code": RomLayout.FRAME_FIRST_CODE,
+			},
+			"battle_font": {
+				"width": BATTLE_EXTRA_WIDTH, "height": Gen2Font.TILE,
+				"tiles": RomLayout.BATTLE_FONT_TILES, "first_code": 0,
 			},
 		},
 	})
@@ -142,3 +157,46 @@ func test_a_frame_that_was_never_cached_draws_nothing() -> void:
 	_font.draw_frame_code(7, RomLayout.FRAME_FIRST_CODE, into, Gen2Font.TILE, 0, 0)
 	assert_eq(into.count(0), into.size())
 	assert_eq(_font.frame_count(), 1, "this cache holds one")
+
+
+## _LoadFontsBattleExtra replaces $60 to $78 and leaves the rest of video memory
+## alone, so which sheet a code addresses depends on the strip and the run.
+
+func test_a_battle_extra_code_is_drawn_from_that_strip() -> void:
+	var into: PackedByteArray = _canvas(1)
+	# $74 is № there, at tile $74 - $60 within the sheet.
+	_font.draw_code(0x74, into, Gen2Font.TILE, 0, 0, Gen2Text.FONT_BATTLE_EXTRA)
+	assert_eq(into[0], BATTLE_EXTRA_INK)
+
+
+func test_the_same_code_draws_nothing_with_the_main_font_loaded() -> void:
+	# The main font sheet starts at $80, so $74 is below it and has no tile.
+	var into: PackedByteArray = _canvas(1)
+	_font.draw_code(0x74, into, Gen2Font.TILE, 0, 0)
+	assert_eq(into[0], 0)
+
+
+func test_letters_still_come_from_the_main_font_under_the_battle_strip() -> void:
+	var into: PackedByteArray = _canvas(1)
+	_font.draw_code(
+		RomLayout.FONT_FIRST_CODE, into, Gen2Font.TILE, 0, 0, Gen2Text.FONT_BATTLE_EXTRA
+	)
+	assert_eq(into[0], Gen2Tiles.INK, "$80 is outside the run that load replaces")
+
+
+func test_a_cache_without_the_battle_strip_refuses_that_run_rather_than_guessing() -> void:
+	# A cache written before anything read this strip: the main font still works
+	# and the other run draws nothing, rather than reaching into the wrong sheet.
+	var manifest: Dictionary = RomCache.read_manifest(_directory)
+	(manifest["tiles"] as Dictionary).erase("battle_font")
+	RomCache.write_json(RomCache.manifest_path(_directory), manifest)
+
+	var font: Gen2Font = Gen2Font.from_data(GameData.open_directory(_directory))
+	assert_not_null(font)
+	assert_false(font.has_battle_extra())
+	var into: PackedByteArray = _canvas(1)
+	font.draw_code(0x74, into, Gen2Font.TILE, 0, 0, Gen2Text.FONT_BATTLE_EXTRA)
+	assert_eq(into[0], 0)
+	# And the letters it does have still draw.
+	font.draw_code(RomLayout.FONT_FIRST_CODE, into, Gen2Font.TILE, 0, 0)
+	assert_eq(into[0], Gen2Tiles.INK)

--- a/tests/unit/test_hall_of_fame.gd
+++ b/tests/unit/test_hall_of_fame.gd
@@ -118,3 +118,52 @@ func _has_ink(indices: PackedByteArray, box: Rect2i) -> bool:
 			if at < indices.size() and indices[at] != 0:
 				return true
 	return false
+
+
+## The panel's columns are DisplayHOFMon's own. They were one tile right of it
+## while plain words stood in for the glyphs the battle-extra strip carries, so
+## the positions are pinned rather than left to the next reader to notice.
+func test_the_panel_sits_on_the_source_columns() -> void:
+	assert_eq(Gen2HallOfFamePage.DEX_LABEL, Vector2i(1, 13), "hlcoord 1, 13")
+	assert_eq(Gen2HallOfFamePage.DEX_NUMBER, Vector2i(3, 13), "hlcoord 3, 13")
+	assert_eq(Gen2HallOfFamePage.SPECIES_NAME, Vector2i(7, 13), "hlcoord 7, 13")
+	assert_eq(Gen2HallOfFamePage.GENDER, Vector2i(18, 13), "hlcoord 18, 13")
+	assert_eq(Gen2HallOfFamePage.NICKNAME_SLASH, Vector2i(8, 14), "hlcoord 8, 14")
+	assert_eq(Gen2HallOfFamePage.LEVEL, Vector2i(1, 16), "hlcoord 1, 16")
+	assert_eq(Gen2HallOfFamePage.OT_LABEL, Vector2i(7, 16), "hlcoord 7, 16")
+	assert_eq(Gen2HallOfFamePage.OT_NUMBER, Vector2i(10, 16), "hlcoord 10, 16")
+	# And the glyphs it places are the charmap's, read under the strip
+	# halloffame.asm loads before printing any of this.
+	assert_eq(Gen2HallOfFamePage.FONT, Gen2Text.FONT_BATTLE_EXTRA)
+	assert_eq(
+		Gen2Text.character(Gen2HallOfFamePage.CODE_NUMERO, Gen2HallOfFamePage.FONT), "№"
+	)
+	assert_eq(Gen2Text.character(Gen2HallOfFamePage.CODE_ID, Gen2HallOfFamePage.FONT), "<ID>")
+	assert_eq(Gen2Text.character(Gen2HallOfFamePage.CODE_LEVEL, Gen2HallOfFamePage.FONT), "<LV>")
+	assert_eq(Gen2Text.character(Gen2HallOfFamePage.CODE_DOT), ".")
+	assert_eq(Gen2Text.character(Gen2HallOfFamePage.CODE_SLASH), "/")
+
+
+## The three glyphs stood in as words before, so the columns they occupy are
+## what proves they are drawn now: the dex label is two tiles, not three, and
+## column 6 is the blank the source leaves before the name.
+func test_the_dex_row_draws_two_label_tiles_and_leaves_column_six_blank() -> void:
+	var page_renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(_data)
+	assert_not_null(page_renderer)
+	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
+	var indices: PackedByteArray = page_renderer.draw(pages[0])
+	# The fixture fills each sheet with an index of its own, so a drawn pixel
+	# says which strip it came from: 1 is battle_font, 3 is the main font.
+	assert_eq(_index_at(indices, Vector2i(1, 13)), 1, "№ comes off the battle strip")
+	assert_eq(_index_at(indices, Vector2i(2, 13)), 3, "the dot is a main-font code")
+	assert_eq(_index_at(indices, Vector2i(6, 13)), 0, "the blank before the name")
+	assert_eq(_index_at(indices, Vector2i(7, 13)), 3, "the name starts at 7")
+	assert_eq(_index_at(indices, Vector2i(1, 16)), 1, "the level symbol")
+	assert_eq(_index_at(indices, Vector2i(7, 16)), 1, "<ID>")
+	assert_eq(_index_at(indices, Vector2i(8, 16)), 1, "№")
+
+
+## The palette index of a tile's top-left pixel.
+func _index_at(indices: PackedByteArray, tile: Vector2i) -> int:
+	var at: int = tile.y * TILE * Gen2Screen.WIDTH + tile.x * TILE
+	return indices[at] if at < indices.size() else -1

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -1,0 +1,231 @@
+extends GutTest
+
+## The three registries a mod reaches that are not a renderer: move effects,
+## effect commands and the read-only event channel. Each is checked for what it
+## lets a mod add and for what it refuses to let one take over.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+const MOD: StringName = &"testmod"
+## An effect byte no cartridge move carries, so registering it cannot change a
+## move already in the table.
+const NEW_EFFECT: int = 0xF0
+
+var _directory: String = ""
+var _data: GameData = null
+var _ran: Array = []
+var _seen: Array = []
+
+
+func before_each() -> void:
+	Gen2ModHost.reset()
+	_directory = RomCache.directory_for(&"registrytest", "0123456789abcdef")
+	_data = Fixture.build(_directory)
+	_ran = []
+	_seen = []
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+	Gen2ModHost.reset()
+
+
+func _note(turn: Gen2Turn) -> void:
+	_ran.append(turn.move_number)
+
+
+func _watch(event: Dictionary) -> void:
+	_seen.append(event)
+
+
+func test_a_registered_command_runs_inside_a_real_move_sequence() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.register_effect_command(MOD, &"marker", _note).get("ok", false)))
+	assert_true(bool(host.register_move_effect(MOD, NEW_EFFECT, [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		&"marker",
+		Gen2EffectCommands.END_MOVE,
+	]).get("ok", false)))
+
+	assert_eq(Gen2MoveEffect.sequence_for(NEW_EFFECT).size(), 4)
+	assert_true(Gen2MoveEffect.is_written(NEW_EFFECT))
+
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		RandomNumberGenerator.new()
+	)
+	var turn: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), []
+	)
+	for command: StringName in Gen2MoveEffect.sequence_for(NEW_EFFECT):
+		Gen2EffectCommands.run(command, turn)
+	assert_eq(_ran, [Fixture.TACKLE], "the registered step ran with the turn")
+
+
+func test_a_registration_cannot_shadow_a_step_every_move_depends_on() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(
+		StringName(host.register_effect_command(
+			MOD, Gen2EffectCommands.APPLY_DAMAGE, _note
+		)["reason"]),
+		&"reserved_effect_command"
+	)
+	# And the stat commands are engine steps too, not just the shared ones.
+	assert_eq(
+		StringName(host.register_effect_command(
+			MOD, Gen2EffectCommands.ATTACK_UP, _note
+		)["reason"]),
+		&"reserved_effect_command"
+	)
+
+
+func test_an_effect_naming_a_step_nobody_wrote_is_refused_at_registration() -> void:
+	# Refused here, where the mod's id is in hand, rather than pushing an error
+	# in the middle of a turn.
+	var result: Dictionary = Gen2ModHost.instance().register_move_effect(MOD, NEW_EFFECT, [
+		Gen2EffectCommands.USED_MOVE_TEXT, &"nosuchstep",
+	])
+	assert_eq(StringName(result["reason"]), &"unknown_effect_command")
+	assert_false(Gen2MoveEffect.is_written(NEW_EFFECT))
+
+
+func test_effects_whose_command_reads_the_byte_back_are_not_replaceable() -> void:
+	for effect: int in Gen2MoveEffect.RESERVED_EFFECTS:
+		assert_eq(
+			StringName(Gen2ModHost.instance().register_move_effect(
+				MOD, effect, [Gen2EffectCommands.END_MOVE]
+			)["reason"]),
+			&"reserved_effect", "effect %d" % effect
+		)
+
+
+func test_a_registered_effect_replaces_the_cartridge_list_and_reset_restores_it() -> void:
+	var before: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.SLEEP)
+	assert_true(bool(Gen2ModHost.instance().register_move_effect(
+		MOD, Gen2MoveEffect.SLEEP, [Gen2EffectCommands.END_MOVE]
+	).get("ok", false)))
+	assert_eq(Gen2MoveEffect.sequence_for(Gen2MoveEffect.SLEEP).size(), 1)
+	Gen2ModHost.reset()
+	assert_eq(Gen2MoveEffect.sequence_for(Gen2MoveEffect.SLEEP), before)
+
+
+func test_two_mods_claiming_one_effect_is_refused() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_move_effect(MOD, NEW_EFFECT, [Gen2EffectCommands.END_MOVE])
+	assert_eq(
+		StringName(host.register_move_effect(
+			&"othermod", NEW_EFFECT, [Gen2EffectCommands.END_MOVE]
+		)["reason"]),
+		&"duplicate_move_effect"
+	)
+
+
+func test_a_subscriber_sees_published_events_and_cannot_write_through_them() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.subscribe(Gen2ModHost.CHANNEL_BATTLE, MOD, _watch).get("ok", false)))
+	var event: Dictionary = {"type": Gen2Battle.HIT, "damage": 12}
+	Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
+	assert_eq(_seen.size(), 1)
+	assert_eq(int(_seen[0]["damage"]), 12)
+	# The subscriber holds a copy, so writing to it reaches nothing.
+	(_seen[0] as Dictionary)["damage"] = 999
+	assert_eq(int(event["damage"]), 12)
+	# And the other channel is a different conversation.
+	Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, {"status": &"waiting"})
+	assert_eq(_seen.size(), 1)
+
+
+func test_unsubscribing_and_unknown_channels() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(
+		StringName(host.subscribe(&"nowhere", MOD, _watch)["reason"]), &"unknown_channel"
+	)
+	assert_eq(
+		StringName(host.subscribe(
+			Gen2ModHost.CHANNEL_WORLD, MOD, Callable()
+		)["reason"]),
+		&"invalid_subscriber_handler"
+	)
+	host.subscribe(Gen2ModHost.CHANNEL_WORLD, MOD, _watch)
+	assert_eq(
+		StringName(host.subscribe(Gen2ModHost.CHANNEL_WORLD, MOD, _watch)["reason"]),
+		&"duplicate_subscriber"
+	)
+	host.unsubscribe(Gen2ModHost.CHANNEL_WORLD, MOD)
+	Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, {"status": &"waiting"})
+	assert_eq(_seen.size(), 0)
+
+
+func test_publishing_with_no_host_built_does_nothing() -> void:
+	# The publish call sits on the path every battle event takes, so a game with
+	# no mods must not build a host to publish to nobody.
+	Gen2ModHost.reset()
+	Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, {"type": Gen2Battle.HIT})
+	assert_eq(_seen.size(), 0)
+
+
+func test_two_mods_claiming_one_renderer_id_is_named_rather_than_silently_won() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(
+		StringName(host.register_world_renderer(
+			Gen2ModHost.BUILT_IN_RENDERER, Gen2WorldRenderer
+		)["reason"]),
+		&"duplicate_renderer"
+	)
+	assert_eq(
+		StringName(host.register_battle_renderer(
+			Gen2ModHost.BUILT_IN_RENDERER, Gen2BattleRenderer
+		)["reason"]),
+		&"duplicate_renderer"
+	)
+
+
+func test_the_shipped_example_mod_registers_everything_it_documents() -> void:
+	# mods/examples/new_content/ is the reference a mod author copies, so it is
+	# run here rather than only read: a registration it gets wrong would be
+	# refused silently and the example would teach the refusal.
+	var manifest: Dictionary = Gen2ModManifest.read("res://mods/examples/new_content")
+	assert_true(bool(manifest.get("ok", false)), "example manifest reads")
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.load_mod(manifest["manifest"]).get("ok", false)))
+
+	var overlay: Gen2ContentOverlay = host.content_overlay()
+	assert_false(overlay.is_empty())
+	assert_eq(
+		overlay.defined_numbers(Gen2ContentOverlay.KIND_SPECIES),
+		[Gen2ContentOverlay.FIRST_MOD_NUMBER] as Array[int]
+	)
+	# Its move names an effect it registered itself, so the effect resolves to
+	# the list rather than falling back to an ordinary attack.
+	var move: Dictionary = overlay.resolve(
+		Gen2ContentOverlay.KIND_MOVE, Gen2ContentOverlay.FIRST_MOD_NUMBER, {}
+	)
+	assert_true(Gen2MoveEffect.is_written(int(move["effect"])))
+	assert_true(Gen2MoveEffect.sequence_for(int(move["effect"])).has(
+		Gen2EffectCommands.RECOIL
+	))
+	# And its patch reaches a cartridge row without replacing the rest of it.
+	var pikachu: Dictionary = overlay.resolve(
+		Gen2ContentOverlay.KIND_SPECIES, 25,
+		{"name": "PIKACHU", "stats": {"hp": 35, "speed": 90}}
+	)
+	assert_eq(int(pikachu["stats"]["speed"]), 110)
+	assert_eq(int(pikachu["stats"]["hp"]), 35)
+	assert_eq(String(pikachu["name"]), "PIKACHU")
+
+
+func test_every_refusal_reason_the_mod_layer_produces_has_player_wording() -> void:
+	# The launcher and the index dialog share one table now; a reason worded in
+	# neither used to show as a raw StringName through whichever screen met it.
+	for reason: StringName in [
+		&"not_a_zip", &"unsafe_archive_entry", &"unsupported_api_version",
+		&"unsupported_index_schema", &"already_installed", &"duplicate_renderer",
+		&"duplicate_content", &"reserved_effect_command", &"missing_entry_script",
+	]:
+		var text: String = Gen2ModRefusal.text({"reason": reason, "detail": "x/y.zip"})
+		assert_false(text.begins_with(String(reason)), "worded: %s" % reason)
+		assert_false(text.is_empty())
+	# An unworded reason still names something a search finds.
+	assert_string_contains(Gen2ModRefusal.text({"reason": &"brand_new"}), "brand_new")

--- a/tests/unit/test_mod_registries.gd.uid
+++ b/tests/unit/test_mod_registries.gd.uid
@@ -1,0 +1,1 @@
+uid://bim0sjwmvimt2

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -172,3 +172,58 @@ func test_control_codes_are_decode_only() -> void:
 func test_a_space_encodes_even_though_the_font_has_no_tile_for_it() -> void:
 	assert_eq(Gen2Text.encode(" "), PackedByteArray([Gen2Text.SPACE]))
 	assert_true(Gen2Text.SPACE < Gen2Text.FIRST_PRINTABLE, "so it draws nothing")
+
+
+## constants/charmap.asm maps $60 to $7f twice over, once from the main font and
+## again from font_battle_extra, and $6e three times. A byte means whichever
+## strip the hardware last loaded, so the codec has to be told which.
+
+func test_the_main_font_keeps_its_quotes_and_ellipsis() -> void:
+	assert_eq(Gen2Text.decode(PackedByteArray([0x72, 0x73, 0x74, 0x75]), 0, 10), "“”·…")
+
+
+func test_the_battle_extra_strip_gives_the_same_bytes_its_own_glyphs() -> void:
+	# halloffame.asm calls LoadFontsBattleExtra before printing a panel, which is
+	# what makes № and <ID> real tiles there.
+	assert_eq(
+		Gen2Text.decode(
+			PackedByteArray([0x73, 0x74]), 0, 10, Gen2Text.FONT_BATTLE_EXTRA
+		),
+		"<ID>№"
+	)
+	assert_eq(Gen2Text.character(0x6E, Gen2Text.FONT_BATTLE_EXTRA), "<LV>")
+	assert_eq(Gen2Text.character(0x72, Gen2Text.FONT_BATTLE_EXTRA), "『")
+
+
+func test_the_battle_extra_run_does_not_fall_back_to_the_main_font() -> void:
+	# $75 is an ellipsis in the main font; with the other strip loaded that tile
+	# is part of an HP bar, so it has no character rather than the main one's.
+	assert_eq(Gen2Text.character(0x75, Gen2Text.FONT_BATTLE_EXTRA), "<75>")
+
+
+func test_letters_and_frames_are_the_same_under_either_strip() -> void:
+	# _LoadFontsBattleExtra replaces $60 to $78 and nothing else.
+	for font: StringName in [Gen2Text.FONT_MAIN, Gen2Text.FONT_BATTLE_EXTRA]:
+		assert_eq(Gen2Text.decode(_encode("AB"), 0, 10, font), "AB", String(font))
+		assert_eq(Gen2Text.character(0x79, font), "┌", String(font))
+		assert_eq(Gen2Text.character(0xF6, font), "0", String(font))
+
+
+func test_encoding_follows_the_loaded_strip() -> void:
+	assert_eq(Gen2Text.encode("№", Gen2Text.FONT_BATTLE_EXTRA), PackedByteArray([0x74]))
+	# The main font has no such glyph, so it draws a question mark rather than a
+	# byte that means something else there.
+	assert_eq(Gen2Text.encode("№"), PackedByteArray([Gen2Text.UNKNOWN]))
+	# And an ellipsis is encodable only where a tile draws one.
+	assert_eq(Gen2Text.encode("…"), PackedByteArray([0x75]))
+	assert_eq(
+		Gen2Text.encode("…", Gen2Text.FONT_BATTLE_EXTRA), PackedByteArray([Gen2Text.UNKNOWN])
+	)
+
+
+func test_bracketed_markers_stay_decode_only_under_either_strip() -> void:
+	# <ID> and <LV> are names for tiles, not text someone types, the same way
+	# <PLAYER> is. A caller that wants one places the code.
+	assert_eq(
+		Gen2Text.encode("<ID>", Gen2Text.FONT_BATTLE_EXTRA).size(), 4, "no ligature for a marker"
+	)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -398,6 +398,19 @@ func _story_path(data: GameData) -> Dictionary:
 	save.world = world.snapshot()
 	var random := RandomNumberGenerator.new()
 	random.seed = 7
+	# Every map load advances the roaming beasts, and an unset schedule_random
+	# makes Gen2WorldState.advance_roaming() randomize() one of its own, which is
+	# what world_screen.gd:153 sets on the real path. Without this the route's
+	# reported roaming positions differ run to run while the rest is identical,
+	# so the walk cannot be diffed against itself.
+	#
+	# Its own generator, not the route's: the schedule rolls once per map load,
+	# and drawing them from the same stream would shift every encounter and catch
+	# behind them. That separation is the whole point of Gen2WorldAPI keeping
+	# three.
+	var schedule_random := RandomNumberGenerator.new()
+	schedule_random.seed = 11
+	world.schedule_random = schedule_random
 	var path: Array = []
 
 	# The bedroom's MAPCALLBACK_NEWMAP is what runs InitializeEventsScript
@@ -4467,6 +4480,7 @@ func _kanto_crossing_path(
 	)
 	if spawned == null:
 		return {"ok": false, "path": path, "reason": "the post-credits spawn map is missing"}
+	spawned.schedule_random = world.schedule_random
 	_mirror_party(spawned, save)
 	var entry: Dictionary = _drain_story(
 		spawned, spawned.dispatch_map_entry(), save, random, data


### PR DESCRIPTION
Content, move effects and game events each had one right place to be extended and no way in. Each now has a registry at the point every read already passed through, so what a mod adds is read back by the ordinary engine rather than by a branch that knows about mods.

- Gen2ContentOverlay sits at GameData._content(), the chokepoint species, moves, items and trainers all read through. A definition is partial and filled out against the kind's defaults, since readers index palette and front_tiles directly. Numbers from 256 up are a mod's, because every cartridge content number is one byte and so a number that is not one means the same thing on all three games. Everything a species carries is a field on its row, so a defined Pokemon's learnset, evolutions and TM flags need no registration of their own.
- Gen2MoveEffect registers effect bytes and the steps they are built from. A list naming a step nobody wrote is refused where the mod's id is in hand rather than pushing an error mid-turn, and the engine's own step names, read off its constants, cannot be shadowed. The cartridge's table is now built once instead of on every move of every turn.
- Gen2ModHost publishes world and battle events to subscribers as copies, from the two screens that show them. Static and null-safe, so a game with no mods builds no host and copies no event.

Registrations that collide are named rather than settled by load order, which a duplicate renderer id was not. Gen2ModRefusal is one table for every refusal reason; the launcher and the index dialog each carried half of one, so a mod refused through the wrong screen showed a raw name.

Font strips, which the Hall of Fame needed:

constants/charmap.asm maps $60 to $7f twice, from font.png and again from font_battle_extra.png, and $6e three times: a byte means whichever strip is loaded. Gen2Text now takes the strip and Gen2Font addresses the sheet that run belongs to. halloffame.asm calls LoadFontsBattleExtra before it prints, so the panel draws the cartridge's own No, ID and Lv tiles on DisplayHOFMon's own columns instead of standing words in one tile right. The strip was already imported for the battle HUD, so no cache format change was needed.

Also:

- world_screen.gd names its overlays in one place. Six callers each kept their own list and had drifted; move_player() now refuses while a battle overlay is up.
- Dropped the DISABLED substatus flag. The cartridge has no such flag, only wDisabledMove and wPlayerDisableCount, and every reader already tested disabled_slot.
- preview_world_story.gd seeds schedule_random, on a generator of its own so the schedule's rolls do not shift the encounters behind them. Gen2WorldState.advance_roaming() randomize()s one when passed null, so the walked route's roaming positions differed run to run. The route is now reproducible and diffs byte for byte against the run before this work apart from those positions.

mods/examples/new_content/ registers all of it in one file and the suite loads it, so the example a mod author copies is run rather than read.