### PR TITLE
Cross the S.S. Aqua and land at Vermilion

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Headless tools, all against a real imported cache:
 | `validate_route_27.gd` | the forced step off a cave mouth, Route 27's sealed Kanto landfall and three seas, and the Tohjo Falls climb and ride back down, in all three games |
 | `validate_item_balls.gd` | Ice Path 1F's HM07 and Route 44's balls decoding from the `itemball` macro and reaching the bag, in all three games |
 | `validate_elite_four.gd` | the seven Indigo Plateau maps, the one door into the rooms, the prepare callback's flag reset, and each room's sealed entrance and boss-opened exit, in all three games |
+| `validate_ss_aqua.gd` | the S.S. Aqua's B1F sailors and the coord events that toggle them, 1F's deck and west wing, the lazy sailor and the granddaughter, and the corridor before and after the errand that opens it, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2344,7 +2344,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			object.apply_direction(direction)
 			var destination: Vector2i = object.cell + direction
-			if can_object_walk_to(destination, object, direction):
+			if _cell_in_bounds(destination):
 				object.cell = destination
 			else:
 				generated.append({
@@ -2385,6 +2385,14 @@ func _apply_object_movement(event: Dictionary) -> Array:
 	return generated
 
 
+## A scripted step commits its cell without a permission check: every step
+## command reaches `NormalStep` (`engine/overworld/movement.asm`), whose
+## `InitStep`/`GetNextTile` (`engine/overworld/map_objects.asm`) only compute the
+## vector, and the movement command set has no collision toggle. Walking through
+## walls is what several cutscenes are built on, the S.S. Aqua's
+## `SSAquaCaptainsCabinWarpsToGrandpasCabinMovement` among them: it crosses five
+## wall rows to carry the player from the captain's cabin into the grandpa's.
+## Only the map bounds still refuse.
 func _apply_player_movement(event: Dictionary) -> Array:
 	var generated: Array = []
 	var map_group: int = int(event.get("map_group", -1))
@@ -2419,7 +2427,7 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			player_facing = _facing_for_direction(direction)
 			var destination: Vector2i = player_cell + direction
-			if can_walk_to(destination, direction):
+			if _cell_in_bounds(destination):
 				player_cell = destination
 			else:
 				generated.append({
@@ -2451,6 +2459,13 @@ func _movement_direction(direction: int) -> Vector2i:
 		3:
 			return Vector2i.RIGHT
 	return Vector2i.ZERO
+
+
+func _cell_in_bounds(cell: Vector2i) -> bool:
+	if current_map == null:
+		return false
+	return cell.x >= 0 and cell.y >= 0 \
+		and cell.x < current_map.collision_width and cell.y < current_map.collision_height
 
 
 func _object_key(map_group: int, map_number: int, object_index: int) -> String:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2952,6 +2952,42 @@ func test_script_applymovement_executes_imported_object_and_player_streams() -> 
 	assert_eq(world.player_cell, Vector2i(7, 5))
 
 
+## Every step command reaches NormalStep (engine/overworld/movement.asm), which
+## only calls InitStep and never reads a permission, so a scripted step walks
+## through a wall. The S.S. Aqua's granddaughter scene is built on it.
+func test_script_movement_steps_through_a_wall_the_way_normal_step_does() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 0, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
+	assert_false(world.can_walk_to(Vector2i(9, 6)), "the fixture wall moved")
+	var results: Array = world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(results.size(), 1)
+	assert_eq(results[0]["status"], &"complete")
+	assert_eq(world.player_cell, Vector2i(9, 6))
+
+
+func test_script_movement_still_refuses_a_step_off_the_map() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 0, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(15, 6))
+	var results: Array = world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(results.size(), 1)
+	assert_eq(results[0]["status"], &"complete")
+	assert_eq(world.player_cell, Vector2i(15, 6))
+
+
 func test_follow_command_moves_the_follower_after_a_player_step() -> void:
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
 		"48:6080": [0x70, 2, 0, 0x91],

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -269,6 +269,56 @@ const SHIP_GRANDPA_APPROACH: Vector2i = Vector2i(25, 5)
 ## `.CanArrive` wants EVENT_FAST_SHIP_FOUND_GIRL instead.
 const EVENT_FAST_SHIP_FIRST_TIME: int = 48
 
+## The rest of the Fast Ship group, and the interior crossing's own cells.
+## `constants/map_constants.asm`; every number and flag below is identical in
+## both pins, and the five maps' event tables are byte identical.
+const FAST_SHIP_B1F_NUMBER: int = 7
+const FAST_SHIP_NE_CABIN_NUMBER: int = 4
+const FAST_SHIP_CAPTAIN_CABIN_NUMBER: int = 6
+const VERMILION_PORT_NUMBER: int = 2
+
+## 1F is three regions, not one deck: the boarding cell, the 132-cell deck, and
+## a 25-cell west wing holding the captain's cabin door and the B1F west stairs.
+## The sailor on (14,7) walls the deck off from the wing for good, so B1F is the
+## only way over (`maps/FastShip1F.asm` object_event 14, 7).
+const SHIP_1F_TO_B1F_EAST: Vector2i = Vector2i(30, 14)
+const SHIP_1F_TO_NE_CABIN: Vector2i = Vector2i(19, 8)
+const SHIP_1F_TO_CAPTAIN_CABIN: Vector2i = Vector2i(3, 13)
+const SHIP_1F_SAILOR_FACE: Vector2i = Vector2i(25, 3)
+
+## B1F's east region is 18 cells: columns 30 and 31 from row 7 down to row 15.
+## The two sailors stand on (30,6) and (31,6) and the coord events below them
+## toggle which one does, so the corridor north is sealed while the map scene is
+## SCENE_FASTSHIPB1F_SAILOR_BLOCKS (`maps/FastShipB1F.asm`). The approach is the
+## cell below the east coord event: stepping onto (31,7) is what runs it, and a
+## resolving walk aimed at (31,7) would re-dispatch it until it ran out.
+const SHIP_B1F_TO_1F_EAST: Vector2i = Vector2i(31, 13)
+const SHIP_B1F_TO_1F_WEST: Vector2i = Vector2i(5, 11)
+const SHIP_B1F_SAILOR_APPROACH: Vector2i = Vector2i(31, 8)
+const SCENE_FASTSHIPB1F_NOOP: int = 1
+
+## `maps/FastShipCabins_NNW_NNE_NE.asm`'s lazy sailor on (4,26), faced from
+## below, and the NE cabin's own door back to 1F.
+const SHIP_NE_CABIN_DOOR: Vector2i = Vector2i(2, 24)
+const SHIP_LAZY_SAILOR_FACE: Vector2i = Vector2i(4, 27)
+
+## The captain's cabin is the third section of
+## `maps/FastShipCabins_SE_SSE_CaptainsCabin.asm`, reached from 1F's west wing.
+## The granddaughter stands on (2,25) with wall on three sides, so she is faced
+## from (1,25). `SSAquaCaptainsCabinWarpsToGrandpasCabinMovement` then carries
+## the player one cell right and six up, through five rows of wall, onto (2,19),
+## which is the grandpa cabin's own door back to 1F's east deck.
+const SHIP_GRANDDAUGHTER_FACE: Vector2i = Vector2i(1, 25)
+const SHIP_GRANDPA_CABIN_DOOR: Vector2i = Vector2i(2, 19)
+
+## constants/event_flags.asm, same numbers in both pins.
+const EVENT_FAST_SHIP_HAS_ARRIVED: int = 49
+const EVENT_FAST_SHIP_FOUND_GIRL: int = 50
+const EVENT_FAST_SHIP_LAZY_SAILOR: int = 51
+const EVENT_FAST_SHIP_INFORMED_ABOUT_LAZY_SAILOR: int = 52
+const EVENT_GOT_METAL_COAT_FROM_GRANDPA: int = 113
+const EVENT_FAST_SHIP_NE_CABIN_SAILOR: int = 1837
+
 ## New Bark Town to Olivine City. Map connections except where a `gate` cell is
 ## named, which is the door of a gate building whose far warp is the join
 ## (`data/maps/attributes.asm`, `maps/Route31.asm`, `maps/EcruteakCity.asm`).
@@ -4707,6 +4757,235 @@ func _ss_aqua_worried_grandpa(
 			"ok": false, "path": path,
 			"reason": "the grandpa scene failed: %s" % scene.get("reason", ""),
 		}
+	return _ss_aqua_interior(world, save, random, data, path)
+
+
+## The crossing itself: the B1F sailors, the errand that stands them down, the
+## west wing they were sealing off, and the gangway at Vermilion.
+func _ss_aqua_interior(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var informed: Dictionary = _ss_aqua_b1f_sailor(world, save, random, data, path)
+	if not bool(informed.get("ok", false)):
+		return informed
+	var found: Dictionary = _ss_aqua_lazy_sailor(world, save, random, data, path)
+	if not bool(found.get("ok", false)):
+		return found
+	var docked: Dictionary = _ss_aqua_granddaughter(world, save, random, data, path)
+	if not bool(docked.get("ok", false)):
+		return docked
+	return _ss_aqua_disembark(world, save, random, data, path)
+
+
+## B1F's on-duty sailor, who is the only thing that reveals the lazy one.
+##
+## `FastShipB1FSailorScript` reaches its `clearevent
+## EVENT_FAST_SHIP_CABINS_NNW_NNE_NE_SAILOR` only with FIRST_TIME, LAZY_SAILOR
+## and INFORMED all clear, which is exactly the outbound first trip. Stepping
+## onto the coord event first is not optional: `FastShipB1FSailorBlocksRight`
+## moves the visible sailor onto the player's own column, so the sailor being
+## talked to is on (31,6) whichever one started there.
+func _ss_aqua_b1f_sailor(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var below: Dictionary = _warp_chain(world, save, random, data, [SHIP_1F_TO_B1F_EAST])
+	if not bool(below.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the stairs down to B1F failed: %s" % below.get("reason", ""),
+		}
+	if world.map_id() != Vector2i(FAST_SHIP_GROUP, FAST_SHIP_B1F_NUMBER):
+		return {"ok": false, "path": path, "reason": "the stairs ended on %s" % [_map_value(world)]}
+
+	var approach: Dictionary = _walk_cell_resolving(
+		world, SHIP_B1F_SAILOR_APPROACH, save, random, data
+	)
+	if not bool(approach.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk up B1F's east corridor failed: %s" % approach.get("reason", ""),
+		}
+	var stepped: Dictionary = world.move_result(Vector2i.UP)
+	var blocked: Dictionary = {"ok": false, "reason": "the step onto the coord event refused"}
+	if bool(stepped.get("ok", false)):
+		blocked = _drain_story(world, _dispatch_after_step(world), save, random, data, true)
+		blocked["ok"] = bool(blocked.get("terminal", false))
+	if not bool(blocked.get("ok", false)):
+		path.append({"step": "ss_aqua_b1f_sailor_blocks", "run": blocked})
+		return {
+			"ok": false, "path": path,
+			"reason": "the sailor block scene failed: %s" % blocked.get("reason", ""),
+		}
+
+	# Interacted in place rather than through _talk_to(): its walk would aim at
+	# the coord event cell the player is already standing on and re-dispatch it
+	# until it ran out of attempts.
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var run: Dictionary = _drain_story(world, world.interact(), save, random, data, true)
+	var talked: Dictionary = {
+		"ok": bool(run.get("terminal", false)), "reason": run.get("reason", ""), "run": run,
+	}
+	path.append({
+		"step": "ss_aqua_b1f_sailor",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"informed": world.event_flag_active(EVENT_FAST_SHIP_INFORMED_ABOUT_LAZY_SAILOR),
+		"lazy_sailor_visible": not world.event_flag_active(EVENT_FAST_SHIP_NE_CABIN_SAILOR),
+	})
+	if not bool(talked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the on-duty sailor did not finish: %s" % talked.get("reason", ""),
+		}
+	if world.event_flag_active(EVENT_FAST_SHIP_NE_CABIN_SAILOR):
+		return {"ok": false, "path": path, "reason": "the lazy sailor is still hidden"}
+	return {"ok": true}
+
+
+## The lazy sailor in the NE cabin, whose own script stands the B1F pair down.
+##
+## `FastShipLazySailorScript` is a trainer battle inside an OBJECTTYPE_SCRIPT
+## object, and its tail is what matters here: `setevent
+## EVENT_FAST_SHIP_LAZY_SAILOR` and `setmapscene FAST_SHIP_B1F,
+## SCENE_FASTSHIPB1F_NOOP`, which retires both coord events for good.
+func _ss_aqua_lazy_sailor(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var to_cabin: Dictionary = _warp_chain(
+		world, save, random, data, [SHIP_B1F_TO_1F_EAST, SHIP_1F_TO_NE_CABIN]
+	)
+	if not bool(to_cabin.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the NE cabin door failed: %s" % to_cabin.get("reason", ""),
+		}
+	var talked: Dictionary = _talk_to(
+		world, SHIP_LAZY_SAILOR_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "ss_aqua_lazy_sailor",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"lazy_sailor": world.event_flag_active(EVENT_FAST_SHIP_LAZY_SAILOR),
+		"b1f_scene": world.state.map_scene(FAST_SHIP_GROUP, FAST_SHIP_B1F_NUMBER),
+		"run": talked,
+	})
+	if not bool(talked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the lazy sailor did not finish: %s" % talked.get("reason", ""),
+		}
+	if world.state.map_scene(FAST_SHIP_GROUP, FAST_SHIP_B1F_NUMBER) != SCENE_FASTSHIPB1F_NOOP:
+		return {"ok": false, "path": path, "reason": "B1F's sailor-block scene did not retire"}
+	return {"ok": true}
+
+
+## West past the stood-down sailors to the captain's cabin, and the docking the
+## granddaughter's scene runs.
+##
+## With the scene retired the coord events are inert, so the sailor left standing
+## on (31,6) leaves (30,6) open and B1F's west stairs are reachable. The
+## granddaughter's own scene is the way back east: it walks the player through
+## the wall onto the grandpa cabin's door, which opens onto the deck.
+func _ss_aqua_granddaughter(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var westward: Dictionary = _warp_chain(world, save, random, data, [
+		SHIP_NE_CABIN_DOOR, SHIP_1F_TO_B1F_EAST, SHIP_B1F_TO_1F_WEST,
+		SHIP_1F_TO_CAPTAIN_CABIN,
+	])
+	if not bool(westward.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the crossing to the captain's cabin failed: %s" % westward.get("reason", ""),
+		}
+	var talked: Dictionary = _talk_to(
+		world, SHIP_GRANDDAUGHTER_FACE, Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	path.append({
+		"step": "ss_aqua_granddaughter",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"arrived": world.event_flag_active(EVENT_FAST_SHIP_HAS_ARRIVED),
+		"found_girl": world.event_flag_active(EVENT_FAST_SHIP_FOUND_GIRL),
+		"metal_coat": world.event_flag_active(EVENT_GOT_METAL_COAT_FROM_GRANDPA),
+		"items": _named_items(data, world.state.items()),
+	})
+	if not bool(talked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the granddaughter scene did not finish: %s" % talked.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_FAST_SHIP_HAS_ARRIVED):
+		return {"ok": false, "path": path, "reason": "the ship never docked"}
+	if world.player_cell != SHIP_GRANDPA_CABIN_DOOR:
+		return {
+			"ok": false, "path": path,
+			"reason": "the scene left the player on %s, not the grandpa cabin's door" % [
+				_cell_value(world),
+			],
+		}
+	return {"ok": true}
+
+
+## The gangway. `FastShip1FSailor1Script`'s `.Arrived` branch needs
+## EVENT_FAST_SHIP_HAS_ARRIVED and DESTINATION_OLIVINE clear, which the Olivine
+## boarding cleared; it warps to Vermilion Port itself after `setmapscene
+## VERMILION_PORT, SCENE_VERMILIONPORT_LEAVE_SHIP`, so the deferred landfall
+## scene runs inside the same drain.
+func _ss_aqua_disembark(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var to_deck: Dictionary = _warp_chain(
+		world, save, random, data, [SHIP_GRANDPA_CABIN_DOOR]
+	)
+	if not bool(to_deck.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the grandpa cabin door failed: %s" % to_deck.get("reason", ""),
+		}
+	var talked: Dictionary = _talk_to(
+		world, SHIP_1F_SAILOR_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "ss_aqua_vermilion_landfall",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"first_time": world.event_flag_active(EVENT_FAST_SHIP_FIRST_TIME),
+		"run": talked,
+	})
+	if not bool(talked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gangway sailor did not finish: %s" % talked.get("reason", ""),
+		}
+	if world.map_id() != Vector2i(FAST_SHIP_GROUP, VERMILION_PORT_NUMBER):
+		return {
+			"ok": false, "path": path,
+			"reason": "the crossing ended on %s, not Vermilion Port" % [_map_value(world)],
+		}
+	if not world.event_flag_active(EVENT_FAST_SHIP_FIRST_TIME):
+		return {"ok": false, "path": path, "reason": "the landfall scene did not run"}
 	return {"ok": true}
 
 

--- a/tools/validate_ss_aqua.gd
+++ b/tools/validate_ss_aqua.gd
@@ -1,0 +1,333 @@
+extends SceneTree
+
+## Verifies the S.S. Aqua's interior against freshly imported real caches, for
+## both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## maps/FastShip1F.asm, maps/FastShipB1F.asm, maps/FastShipCabins_NNW_NNE_NE.asm,
+## maps/FastShipCabins_SE_SSE_CaptainsCabin.asm and constants/event_flags.asm.
+## All five maps' event tables are byte identical between the pins and every
+## event flag below has the same number in both, so nothing here is profile
+## split; only the text and Crystal's own gender branch differ.
+##
+## The crossing is one puzzle. B1F's two sailors stand on (30,6) and (31,6) and
+## the coord events below them each move the visible one onto the player's own
+## column, so the corridor west is sealed for as long as the map scene is
+## SCENE_FASTSHIPB1F_SAILOR_BLOCKS. Nothing on B1F opens it: the on-duty sailor
+## reveals the lazy one in the NE cabin, and that sailor's own script sets
+## SCENE_FASTSHIPB1F_NOOP, which retires both coord events.
+##
+##   Godot --headless --path . -s res://tools/validate_ss_aqua.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## `constants/map_constants.asm`'s 15th `newgroup`.
+const GROUP: int = 15
+const VERMILION_PORT: int = 2
+const FAST_SHIP_1F: int = 3
+const NE_CABIN: int = 4
+const CAPTAIN_CABIN: int = 6
+const FAST_SHIP_B1F: int = 7
+
+## Scene ids are ordinal in `scene_script` declaration order
+## (`macros/scripts/maps.asm`), so B1F's first scene is the blocking one.
+const SCENE_SAILOR_BLOCKS: int = 0
+const SCENE_NOOP: int = 1
+
+## constants/event_flags.asm, identical in both pins.
+const EVENT_B1F_SAILOR_LEFT: int = 1838
+const EVENT_B1F_SAILOR_RIGHT: int = 1839
+const EVENT_NE_CABIN_SAILOR: int = 1837
+const EVENT_TWIN_2: int = 1842
+
+## `maps/FastShipB1F.asm`'s own event table.
+const B1F_SAILORS: Array[Vector2i] = [Vector2i(30, 6), Vector2i(31, 6)]
+const B1F_COORD_EVENTS: Array[Vector2i] = [Vector2i(30, 7), Vector2i(31, 7)]
+const B1F_EAST_DOOR: Vector2i = Vector2i(31, 13)
+const B1F_WEST_STAIRS: Vector2i = Vector2i(5, 11)
+
+## The 1F doors this crossing uses, in `def_warp_events` order.
+const ONE_F_TO_NE_CABIN: Vector2i = Vector2i(19, 8)
+const ONE_F_TO_CAPTAIN_CABIN: Vector2i = Vector2i(3, 13)
+const ONE_F_TO_B1F_WEST: Vector2i = Vector2i(6, 12)
+const ONE_F_TO_B1F_EAST: Vector2i = Vector2i(30, 14)
+
+const LAZY_SAILOR: Vector2i = Vector2i(4, 26)
+const NE_CABIN_DOOR: Vector2i = Vector2i(2, 24)
+const GRANDDAUGHTER: Vector2i = Vector2i(2, 25)
+const GRANDDAUGHTER_FACE: Vector2i = Vector2i(1, 25)
+const GRANDPA_CABIN_DOOR: Vector2i = Vector2i(2, 19)
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_b1f_records(data, game_id)
+		_verify_one_f_regions(data, game_id)
+		_verify_cabins(data, game_id)
+		_drive_sealed_corridor(data, game_id)
+		_drive_open_corridor(data, game_id)
+	_finish()
+
+
+## B1F's two sailors, their flags and the coord events that move them.
+func _verify_b1f_records(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, FAST_SHIP_B1F, B1F_EAST_DOOR)
+	if world == null:
+		_fail("%s: FAST_SHIP_B1F is missing." % game_id)
+		return
+	var flags: Array[int] = [EVENT_B1F_SAILOR_LEFT, EVENT_B1F_SAILOR_RIGHT]
+	for index: int in B1F_SAILORS.size():
+		var object: Gen2WorldObject = world.object_at(B1F_SAILORS[index])
+		if not _check(
+			object != null,
+			"%s: no sailor on %s of B1F." % [game_id, B1F_SAILORS[index]]
+		):
+			continue
+		_check(
+			object.event_flag == flags[index],
+			"%s: the sailor on %s carries flag %d, not the pinned %d." % [
+				game_id, B1F_SAILORS[index], object.event_flag, flags[index],
+			]
+		)
+	var coord_events: Array = world.current_map.events.get("coord_events", [])
+	var seen: Array[Vector2i] = []
+	for event: Dictionary in coord_events:
+		var cell := Vector2i(int(event.get("x", -1)), int(event.get("y", -1)))
+		seen.append(cell)
+		_check(
+			int(event.get("scene", -1)) == SCENE_SAILOR_BLOCKS,
+			"%s: B1F's coord event on %s is scene %d, not the blocking one." % [
+				game_id, cell, int(event.get("scene", -1)),
+			]
+		)
+	_check(
+		seen == B1F_COORD_EVENTS,
+		"%s: B1F's coord events are on %s, not the pinned %s." % [
+			game_id, seen, B1F_COORD_EVENTS,
+		]
+	)
+	_check(
+		world.warp_index_at(B1F_EAST_DOOR) == 2 and world.warp_index_at(B1F_WEST_STAIRS) == 1,
+		"%s: B1F's two warps are not on %s and %s." % [
+			game_id, B1F_WEST_STAIRS, B1F_EAST_DOOR,
+		]
+	)
+	print("%s b1f: both sailors, both coord events and both warps match the pins." % game_id)
+
+
+## 1F is three walkable regions, and the deck cannot reach the west wing: the
+## sailor on (14,7) has event flag -1, so nothing ever moves him.
+func _verify_one_f_regions(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, FAST_SHIP_1F, ONE_F_TO_B1F_EAST)
+	if world == null:
+		_fail("%s: FAST_SHIP_1F is missing." % game_id)
+		return
+	var deck: Dictionary = _region(world, ONE_F_TO_B1F_EAST)
+	_check(
+		deck.has(ONE_F_TO_NE_CABIN),
+		"%s: 1F's deck does not reach the NE cabin door." % game_id
+	)
+	_check(
+		not deck.has(ONE_F_TO_CAPTAIN_CABIN) and not deck.has(ONE_F_TO_B1F_WEST),
+		"%s: 1F's deck reaches the west wing without going below." % game_id
+	)
+	var wing: Dictionary = _region(world, ONE_F_TO_B1F_WEST)
+	_check(
+		wing.has(ONE_F_TO_CAPTAIN_CABIN),
+		"%s: 1F's west wing does not reach the captain's cabin door." % game_id
+	)
+	print("%s 1f: the deck is %d cells and the west wing %d, with no path between." % [
+		game_id, deck.size(), wing.size(),
+	])
+
+
+## The lazy sailor and the granddaughter, and the five rows of wall the
+## granddaughter's scene walks the player through.
+func _verify_cabins(data: GameData, game_id: StringName) -> void:
+	var cabin: Gen2WorldAPI = _open(data, NE_CABIN, NE_CABIN_DOOR)
+	if cabin == null:
+		_fail("%s: the NE cabin is missing." % game_id)
+	else:
+		var sailor: Gen2WorldObject = cabin.object_at(LAZY_SAILOR)
+		if _check(sailor != null, "%s: no lazy sailor on %s." % [game_id, LAZY_SAILOR]):
+			_check(
+				sailor.event_flag == EVENT_NE_CABIN_SAILOR,
+				"%s: the lazy sailor carries flag %d, not the pinned %d." % [
+					game_id, sailor.event_flag, EVENT_NE_CABIN_SAILOR,
+				]
+			)
+		_check(
+			_region(cabin, NE_CABIN_DOOR).has(Vector2i(4, 27)),
+			"%s: the lazy sailor cannot be faced from the NE cabin's own door." % game_id
+		)
+
+	var captain: Gen2WorldAPI = _open(data, CAPTAIN_CABIN, Vector2i(2, 33))
+	if captain == null:
+		_fail("%s: the captain's cabin is missing." % game_id)
+		return
+	var twin: Gen2WorldObject = captain.object_at(GRANDDAUGHTER)
+	if _check(twin != null, "%s: no granddaughter on %s." % [game_id, GRANDDAUGHTER]):
+		_check(
+			twin.event_flag == EVENT_TWIN_2,
+			"%s: the granddaughter carries flag %d, not the pinned %d." % [
+				game_id, twin.event_flag, EVENT_TWIN_2,
+			]
+		)
+	var section: Dictionary = _region(captain, Vector2i(2, 33))
+	_check(
+		section.has(GRANDDAUGHTER_FACE),
+		"%s: the granddaughter cannot be faced from the captain's cabin door." % game_id
+	)
+	_check(
+		not section.has(GRANDPA_CABIN_DOOR),
+		"%s: the captain's cabin already walks to the grandpa cabin's door." % game_id
+	)
+	# SSAquaCaptainsCabinWarpsToGrandpasCabinMovement is one big_step RIGHT and
+	# six UP, from (1,25) to (2,19). Every cell between is wall, which is the
+	# whole reason the scene is the only way back east.
+	for y: int in range(20, 25):
+		_check(
+			not captain.can_walk_to(Vector2i(2, y)),
+			"%s: (2,%d) of the captain's cabin is walkable, so the scene crosses no wall." % [
+				game_id, y,
+			]
+		)
+	_check(
+		captain.warp_index_at(GRANDPA_CABIN_DOOR) == 3,
+		"%s: %s is not the grandpa cabin's own door." % [game_id, GRANDPA_CABIN_DOOR]
+	)
+	print("%s cabins: the lazy sailor, the granddaughter and her scene's five wall rows check out." % game_id)
+
+
+## The puzzle itself, on the map the cartridge ships: whichever coord event the
+## player steps onto, the cell north of them is the one the sailor takes.
+func _drive_sealed_corridor(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(
+		data, FAST_SHIP_B1F, Vector2i(31, 8), {EVENT_B1F_SAILOR_RIGHT: true}
+	)
+	if world == null:
+		return
+	for step: Array in [[Vector2i.UP, Vector2i(31, 7)], [Vector2i.LEFT, Vector2i(30, 7)]]:
+		var moved: Dictionary = world.move_result(step[0])
+		if not _check(
+			bool(moved.get("ok", false)) and world.player_cell == step[1],
+			"%s: the step onto %s refused: %s" % [game_id, step[1], moved.get("reason", "")]
+		):
+			return
+		var results: Array = world.dispatch_script_events()
+		if not _check(
+			not results.is_empty(),
+			"%s: %s dispatched no coord event while the scene blocks." % [game_id, step[1]]
+		):
+			return
+		for _attempt: int in 16:
+			if world.pending_script_input().is_empty():
+				break
+			results = world.run_event_queue(true)
+		var north: Vector2i = world.player_cell + Vector2i.UP
+		_check(
+			world.object_at(north) != null,
+			"%s: %s is open after the coord event on %s ran." % [game_id, north, step[1]]
+		)
+	# Which is the whole seal: the two sailor cells are the east region's only
+	# way onto row 6, and each is entered only from the coord event below it, so
+	# a walk that steps north is always stepping into the sailor that step just
+	# summoned. A plain region test cannot say that, because after the second
+	# toggle the column the player is not standing in really is open.
+	for cell: Vector2i in B1F_SAILORS:
+		_check(
+			cell + Vector2i.DOWN in B1F_COORD_EVENTS,
+			"%s: %s is not entered from a coord event cell." % [game_id, cell]
+		)
+	_check(
+		not _region(world, world.player_cell, B1F_COORD_EVENTS).has(B1F_WEST_STAIRS),
+		"%s: B1F's west stairs are reachable while the sailors still block." % game_id
+	)
+	print("%s b1f sealed: both coord events put a sailor back in the player's own column." % game_id)
+
+
+## And once the lazy sailor's `setmapscene FAST_SHIP_B1F, SCENE_FASTSHIPB1F_NOOP`
+## has run, the coord events are inert and the free column is a corridor.
+func _drive_open_corridor(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(
+		data, FAST_SHIP_B1F, Vector2i(31, 8), {EVENT_B1F_SAILOR_RIGHT: true},
+		{Gen2WorldState.map_scene_key(GROUP, FAST_SHIP_B1F): SCENE_NOOP}
+	)
+	if world == null:
+		return
+	var moved: Dictionary = world.move_result(Vector2i.UP)
+	if not _check(
+		bool(moved.get("ok", false)),
+		"%s: the step onto (31,7) refused with the scene retired." % game_id
+	):
+		return
+	_check(
+		world.dispatch_script_events().is_empty(),
+		"%s: (31,7) still dispatches a coord event with the scene retired." % game_id
+	)
+	var region: Dictionary = _region(world, world.player_cell)
+	_check(
+		region.has(B1F_WEST_STAIRS),
+		"%s: B1F's west stairs are still unreachable with the scene retired." % game_id
+	)
+	print("%s b1f open: the retired scene leaves a %d-cell region reaching the west stairs." % [
+		game_id, region.size(),
+	])
+
+
+func _open(
+	data: GameData, number: int, cell: Vector2i,
+	flags: Dictionary = {}, scenes: Dictionary = {},
+) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new(flags, scenes)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, GROUP, number, cell, state)
+	if world == null:
+		_fail("map %d/%d is missing." % [GROUP, number])
+	return world
+
+
+## [param sealed_north] names cells a walk may enter but never step north from,
+## which is how a coord event that summons a sailor onto the cell above behaves.
+func _region(
+	world: Gen2WorldAPI, start: Vector2i, sealed_north: Array[Vector2i] = []
+) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			if direction == Vector2i.UP and cell in sealed_north:
+				continue
+			var next: Vector2i = cell + direction
+			if seen.has(next) or not world.can_walk_to(next, direction):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS ss aqua: the B1F sailors, the errand that stands them down and the cabins verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL ss aqua: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_ss_aqua.gd.uid
+++ b/tools/validate_ss_aqua.gd.uid
@@ -1,0 +1,1 @@
+uid://cb6nfmxapi2ly


### PR DESCRIPTION
The story route now walks the ship's interior instead of stopping at the worried grandpa. The crossing is one errand rather than a corridor: B1F's two sailors toggle between (30,6) and (31,6) as the coord events below them fire, so nothing on that deck opens the way west. The on-duty sailor's clearevent reveals the lazy sailor in the NE cabin, and beating him sets SCENE_FASTSHIPB1F_NOOP, which retires both coord events. Only then is 1F's west wing reachable, and with it the captain's cabin, whose granddaughter scene hands over the METAL_COAT, docks the ship and walks the player back east onto the grandpa cabin's door. The gangway sailor warps to Vermilion Port, whose deferred landfall scene runs in the same drain.

A scripted step no longer consults collision. Every step command reaches NormalStep, whose InitStep only computes the vector, and the movement command set has no collision toggle, so cutscenes that walk through walls are the source's own tool. Only the map bounds still refuse. SSAquaCaptainsCabinWarpsToGrandpasCabinMovement crosses five rows of wall and is the only way out of the captain's cabin. The rest of the walked route is byte identical across the change.

validate_ss_aqua.gd pins the geometry and the puzzle in all three games.