### PR TITLE
Cut into the Vermilion gym yard for the Thunder Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Headless tools, all against a real imported cache:
 | `validate_item_balls.gd` | Ice Path 1F's HM07 and Route 44's balls decoding from the `itemball` macro and reaching the bag, in all three games |
 | `validate_elite_four.gd` | the seven Indigo Plateau maps, the one door into the rooms, the prepare callback's flag reset, and each room's sealed entrance and boss-opened exit, in all three games |
 | `validate_ss_aqua.gd` | the S.S. Aqua's B1F sailors and the coord events that toggle them, 1F's deck and west wing, the lazy sailor and the granddaughter, and the corridor before and after the errand that opens it, in all three games |
+| `validate_vermilion.gd` | the Vermilion port passage's stair pair, the cut tree sealing the gym yard, the gym door's one approach, and the gym's own lack of a scene or callback, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -311,6 +311,34 @@ const SHIP_LAZY_SAILOR_FACE: Vector2i = Vector2i(4, 27)
 const SHIP_GRANDDAUGHTER_FACE: Vector2i = Vector2i(1, 25)
 const SHIP_GRANDPA_CABIN_DOOR: Vector2i = Vector2i(2, 19)
 
+## Vermilion City (12/3) and its gym (12/11), the first Kanto maps the route
+## walks. `maps/VermilionPortPassage.asm` is two regions joined by its own stair
+## pair ((3,2) to (15,4)), the way Olivine's passage is, so the walk from the
+## dock to the city takes three warps.
+const VERMILION_GROUP: int = 12
+const VERMILION_CITY_NUMBER: int = 3
+const VERMILION_GYM_NUMBER: int = 11
+const VERMILION_PORT_EXIT: Vector2i = Vector2i(9, 5)
+const VERMILION_PASSAGE_STAIRS: Vector2i = Vector2i(3, 2)
+const VERMILION_PASSAGE_EXIT: Vector2i = Vector2i(15, 0)
+## `maps/VermilionCity.asm` warp 7, entered from below: the row above it is the
+## mart block's wall, so (10,20) is its only approach.
+const VERMILION_GYM_DOOR: Vector2i = Vector2i(10, 19)
+## And the gym's whole yard, 42 cells of it, is walled off from the rest of the
+## city by one `COLL_CUT_TREE` ($12) on (13,18). Cutting it is the only way in,
+## so this is the first Kanto cell the route has to open rather than walk.
+const VERMILION_GYM_TREE_APPROACH: Vector2i = Vector2i(13, 17)
+## `maps/VermilionGym.asm` puts Surge on (5,2) behind the pillar grid, faced
+## from the cell below. The gym has no scene scripts and no callbacks: unlike
+## its Gen 1 self it is open from the door, and the three trainers are sight
+## lines across the grid rather than a gate.
+const SURGE_FACE: Vector2i = Vector2i(5, 3)
+## ENGINE_THUNDERBADGE's place in source badge order, for
+## Gen2WorldState.badge_flag(), and the flypoint the city's own NEWMAP callback
+## sets (`constants/engine_flags.asm`).
+const BADGE_THUNDER: int = 10
+const ENGINE_FLYPOINT_VERMILION: int = 58
+
 ## constants/event_flags.asm, same numbers in both pins.
 const EVENT_FAST_SHIP_HAS_ARRIVED: int = 49
 const EVENT_FAST_SHIP_FOUND_GIRL: int = 50
@@ -4558,6 +4586,10 @@ func _kanto_crossing_path(
 	var crossing: Dictionary = _ss_aqua_crossing(spawned, save, random, data, path)
 	if not bool(crossing.get("ok", false)):
 		return crossing
+
+	var thunder: Dictionary = _thunder_badge_path(spawned, save, random, data, path)
+	if not bool(thunder.get("ok", false)):
+		return thunder
 	return {"ok": true, "world": spawned}
 
 
@@ -4941,6 +4973,89 @@ func _ss_aqua_granddaughter(
 				_cell_value(world),
 			],
 		}
+	return {"ok": true}
+
+
+## The Vermilion Port dock to the Thunder Badge, the route's first Kanto leg.
+##
+## Nothing gates it. `VermilionGym_MapScripts` declares neither a scene nor a
+## callback, so the gym is open from the door and Surge answers as soon as he is
+## faced; `VermilionGymSurgeScript` is his own `checkflag ENGINE_THUNDERBADGE`,
+## the battle, and the three trainer flags he sets whether they were fought or
+## not.
+func _thunder_badge_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var to_city: Dictionary = _warp_chain(
+		world, save, random, data,
+		[VERMILION_PORT_EXIT, VERMILION_PASSAGE_STAIRS, VERMILION_PASSAGE_EXIT]
+	)
+	if not bool(to_city.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk up from the dock failed: %s" % to_city.get("reason", ""),
+		}
+	if world.map_id() != Vector2i(VERMILION_GROUP, VERMILION_CITY_NUMBER):
+		return {
+			"ok": false, "path": path,
+			"reason": "the passage ended on %s, not Vermilion City" % [_map_value(world)],
+		}
+	path.append({
+		"step": "vermilion_city",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_VERMILION),
+	})
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_VERMILION):
+		return {"ok": false, "path": path, "reason": "the city's flypoint callback did not run"}
+
+	var tree: Dictionary = _cut_at(
+		world, VERMILION_GYM_TREE_APPROACH, Gen2WorldSprite.FACING_DOWN,
+		save, random, data
+	)
+	path.append({
+		"step": "vermilion_gym_tree",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"cut": tree.get("cell", []),
+	})
+	if not bool(tree.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gym yard's tree failed: %s" % tree.get("reason", ""),
+		}
+
+	var to_gym: Dictionary = _warp_chain(world, save, random, data, [VERMILION_GYM_DOOR])
+	if not bool(to_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gym door failed: %s" % to_gym.get("reason", ""),
+		}
+	var surge: Dictionary = _talk_to(
+		world, SURGE_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "vermilion_gym_surge",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"thunder_badge": world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+			BADGE_THUNDER, Gen2WorldState.is_crystal_profile(data)
+		)),
+		"run": surge,
+	})
+	if not bool(surge.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Lt. Surge did not finish: %s" % surge.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		BADGE_THUNDER, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return {"ok": false, "path": path, "reason": "ENGINE_THUNDERBADGE was not set"}
 	return {"ok": true}
 
 
@@ -5790,6 +5905,10 @@ func _talk_to(
 	return {
 		"ok": bool(run.get("terminal", false)),
 		"reason": run.get("reason", ""),
+		# Anything met on the way, which for a gym is the trainers between the
+		# door and the leader. Reported rather than dropped: the walk resolves
+		# them, so without this a fought battle leaves no trace in the path.
+		"encounters": walked.get("encounters", []),
 		"run": run,
 	}
 

--- a/tools/validate_vermilion.gd
+++ b/tools/validate_vermilion.gd
@@ -1,0 +1,292 @@
+extends SceneTree
+
+## Verifies Vermilion City, its gym and the passage up from the dock against
+## freshly imported real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## maps/VermilionCity.asm, maps/VermilionGym.asm, maps/VermilionPortPassage.asm
+## and constants/map_constants.asm. `VermilionCity.asm` and `VermilionCity.blk`
+## are byte identical between the pins and the gym differs only in Surge's text,
+## so nothing here is profile split.
+##
+## The one thing worth pinning is that this gym is not its Gen 1 self. There is
+## no trash-can puzzle: `VermilionGym_MapScripts` declares neither a scene nor a
+## callback, so the gym is open from the door. The gate is outside it, in the
+## city: the whole 42-cell gym yard is walled off by a single COLL_CUT_TREE on
+## (13,18), which makes Cut the price of the Thunder Badge.
+##
+##   Godot --headless --path . -s res://tools/validate_vermilion.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm: the VERMILION group is 12 and the FAST_SHIP
+## group 15, which is where the port and its passage live.
+const VERMILION_GROUP: int = 12
+const CITY: int = 3
+const GYM: int = 11
+const FAST_SHIP_GROUP: int = 15
+const PASSAGE: int = 9
+
+const CITY_SIZE: Vector2i = Vector2i(40, 36)
+const GYM_SIZE: Vector2i = Vector2i(10, 18)
+
+## `maps/VermilionCity.asm`'s own event table.
+const CITY_PASSAGE_DOORS: Array[Vector2i] = [Vector2i(19, 31), Vector2i(20, 31)]
+const GYM_DOOR: Vector2i = Vector2i(10, 19)
+const GYM_DOOR_APPROACH: Vector2i = Vector2i(10, 20)
+const GYM_TREE: Vector2i = Vector2i(13, 18)
+const GYM_TREE_APPROACH: Vector2i = Vector2i(13, 17)
+const GYM_YARD_CELLS: int = 42
+
+## `maps/VermilionPortPassage.asm`: warp 5 lands from the port, warps 3 and 4 are
+## its own stair pair, and warps 1 and 2 open onto the city.
+const PASSAGE_FROM_PORT: Vector2i = Vector2i(3, 14)
+const PASSAGE_STAIRS_DOWN: Vector2i = Vector2i(3, 2)
+const PASSAGE_STAIRS_UP: Vector2i = Vector2i(15, 4)
+const PASSAGE_TO_CITY: Vector2i = Vector2i(15, 0)
+
+## `maps/VermilionGym.asm`'s object events, in `object_const_def` order, with the
+## trainer classes `constants/trainer_constants.asm` gives them.
+const SURGE: Vector2i = Vector2i(5, 2)
+const GYM_TRAINERS: Array[Vector2i] = [
+	Vector2i(8, 8), Vector2i(4, 7), Vector2i(0, 10),
+]
+const GYM_WARPS: Array[Vector2i] = [Vector2i(4, 17), Vector2i(5, 17)]
+
+## engine/overworld/tile_events.asm's CheckCutCollision entry for a tree, and
+## ENGINE_HIVEBADGE's place in source badge order, which is the badge
+## `.CheckAble` wants before it looks at the tile at all.
+const COLL_CUT_TREE: int = 0x12
+const BADGE_HIVE: int = 1
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_passage(data, game_id)
+		_verify_city(data, game_id)
+		_verify_gym(data, game_id)
+		_drive_gym_tree(data, game_id)
+	_finish()
+
+
+## The passage is two regions joined by its own stair pair, the way Olivine's
+## is, so the dock reaches the city in three warps rather than one.
+func _verify_passage(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, FAST_SHIP_GROUP, PASSAGE, PASSAGE_FROM_PORT)
+	if world == null:
+		return
+	var lower: Dictionary = _region(world, PASSAGE_FROM_PORT)
+	var upper: Dictionary = _region(world, PASSAGE_STAIRS_UP)
+	_check(
+		lower.has(PASSAGE_STAIRS_DOWN),
+		"%s: the passage's port landing does not reach its own stairs." % game_id
+	)
+	_check(
+		not lower.has(PASSAGE_TO_CITY),
+		"%s: the passage's port landing walks straight to the city." % game_id
+	)
+	_check(
+		upper.has(PASSAGE_TO_CITY),
+		"%s: the passage's upper region does not reach the city door." % game_id
+	)
+	_check(
+		world.warp_index_at(PASSAGE_STAIRS_DOWN) == 4
+			and world.warp_index_at(PASSAGE_STAIRS_UP) == 3,
+		"%s: the passage's stair pair is not warps 3 and 4." % game_id
+	)
+	print("%s passage: two regions of %d and %d cells joined by their own stairs." % [
+		game_id, lower.size(), upper.size(),
+	])
+
+
+## The city itself, and the one tree that seals the gym off.
+func _verify_city(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, VERMILION_GROUP, CITY, CITY_PASSAGE_DOORS[0])
+	if world == null:
+		return
+	_check(
+		world.map_size_cells() == CITY_SIZE,
+		"%s: Vermilion City is %s, not the pinned %s." % [
+			game_id, world.map_size_cells(), CITY_SIZE,
+		]
+	)
+	_check(
+		world.collision_code_at(GYM_TREE) == COLL_CUT_TREE,
+		"%s: %s is collision $%02X, not a cut tree." % [
+			game_id, GYM_TREE, world.collision_code_at(GYM_TREE),
+		]
+	)
+	var city: Dictionary = _region(world, CITY_PASSAGE_DOORS[0])
+	var yard: Dictionary = _region(world, GYM_DOOR_APPROACH)
+	_check(
+		not city.has(GYM_DOOR) and not city.has(GYM_DOOR_APPROACH),
+		"%s: the gym yard is reachable without cutting." % game_id
+	)
+	_check(
+		yard.size() == GYM_YARD_CELLS,
+		"%s: the gym yard is %d cells, not the pinned %d." % [
+			game_id, yard.size(), GYM_YARD_CELLS,
+		]
+	)
+	_check(
+		city.has(GYM_TREE_APPROACH),
+		"%s: the tree cannot be faced from the city side." % game_id
+	)
+	# And the tree really is the only join: every other cell bordering the yard
+	# is wall, so no second route exists for a walk to find.
+	var seams: Array[Vector2i] = []
+	for cell: Vector2i in yard:
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			if city.has(next):
+				seams.append(next)
+	_check(
+		seams.is_empty(),
+		"%s: the gym yard touches the city at %s without a tree between." % [game_id, seams]
+	)
+	_check(
+		world.warp_index_at(GYM_DOOR) == 7,
+		"%s: %s is not the gym door." % [game_id, GYM_DOOR]
+	)
+	# The gym door is a COLL_DOOR, so it forces a step south off itself; the mart
+	# block above it is wall, which leaves (10,20) as its only approach.
+	var approaches: Array[Vector2i] = []
+	for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+		if world.can_walk_to(GYM_DOOR + direction):
+			approaches.append(GYM_DOOR + direction)
+	_check(
+		approaches == [GYM_DOOR_APPROACH],
+		"%s: the gym door is approached from %s, not %s alone." % [
+			game_id, approaches, GYM_DOOR_APPROACH,
+		]
+	)
+	print("%s city: a %d-cell yard behind one cut tree, and a gym door with one approach." % [
+		game_id, yard.size(),
+	])
+
+
+## The gym has no puzzle: no scene scripts, no callbacks, and Surge answers as
+## soon as he is faced.
+func _verify_gym(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, VERMILION_GROUP, GYM, GYM_WARPS[0])
+	if world == null:
+		return
+	_check(
+		world.map_size_cells() == GYM_SIZE,
+		"%s: Vermilion Gym is %s, not the pinned %s." % [
+			game_id, world.map_size_cells(), GYM_SIZE,
+		]
+	)
+	_check(
+		world.current_map.scripts.get("scenes", []).is_empty(),
+		"%s: Vermilion Gym ships a scene script; it should have none." % game_id
+	)
+	_check(
+		world.current_map.scripts.get("callbacks", []).is_empty(),
+		"%s: Vermilion Gym ships a callback; it should have none." % game_id
+	)
+	_check(
+		world.object_at(SURGE) != null,
+		"%s: no Surge on %s." % [game_id, SURGE]
+	)
+	for cell: Vector2i in GYM_TRAINERS:
+		_check(
+			world.object_at(cell) != null,
+			"%s: no gym trainer on %s." % [game_id, cell]
+		)
+	for index: int in GYM_WARPS.size():
+		_check(
+			world.warp_index_at(GYM_WARPS[index]) == index + 1,
+			"%s: %s is not gym warp %d." % [game_id, GYM_WARPS[index], index + 1]
+		)
+	# Both doors land on the same city cell, and Surge is reachable from either.
+	var floor_cells: Dictionary = _region(world, GYM_WARPS[0])
+	_check(
+		floor_cells.has(SURGE + Vector2i.DOWN),
+		"%s: Surge cannot be faced from the gym door." % game_id
+	)
+	print("%s gym: no scene, no callback, and Surge reachable across the pillar grid." % game_id)
+
+
+## The cut itself, against the real cache: the tree opens, the yard joins, and a
+## map load grows it back, so the gym door has to be taken in the same visit.
+func _drive_gym_tree(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, VERMILION_GROUP, CITY, GYM_TREE_APPROACH)
+	if world == null:
+		return
+	world.state.set_engine_flag(Gen2WorldState.badge_flag(
+		BADGE_HIVE, Gen2WorldState.is_crystal_profile(data)
+	))
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var request: Dictionary = world.cut_request()
+	if not _check(
+		bool(request.get("ok", false)),
+		"%s: cut refused at %s: %s" % [game_id, GYM_TREE, request.get("reason", "")]
+	):
+		return
+	var applied: Dictionary = world.complete_cut()
+	if not _check(
+		bool(applied.get("ok", false)),
+		"%s: the cut failed: %s" % [game_id, applied.get("reason", "")]
+	):
+		return
+	_check(
+		_region(world, GYM_TREE_APPROACH).has(GYM_DOOR),
+		"%s: the gym door is still unreachable after the cut." % game_id
+	)
+	var _reloaded: Dictionary = world.reload_current_map()
+	_check(
+		world.collision_code_at(GYM_TREE) == COLL_CUT_TREE,
+		"%s: the tree did not grow back on a map load." % game_id
+	)
+	print("%s cut: the tree opens the yard and grows back on the next map load." % game_id)
+
+
+func _open(data: GameData, group: int, number: int, cell: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, cell)
+	if world == null:
+		_fail("map %d/%d is missing." % [group, number])
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
+
+
+func _region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			if seen.has(next) or not world.can_walk_to(next, direction):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS vermilion: the passage, the gym yard's tree and the gym itself verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL vermilion: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_vermilion.gd.uid
+++ b/tools/validate_vermilion.gd.uid
@@ -1,0 +1,1 @@
+uid://dyhr4yps3t5ck


### PR DESCRIPTION
Kanto proper starts at the Vermilion Port dock. The passage up is two regions joined by its own stair pair, the way Olivine's is, so the walk to the city takes three warps; the city's own NEWMAP callback sets ENGINE_FLYPOINT_VERMILION on arrival.

The gym is not its Gen 1 self. VermilionGym_MapScripts declares neither a scene nor a callback, so there is no trash-can puzzle and Surge answers as soon as he is faced. The gate is outside, in the city: one COLL_CUT_TREE on (13,18) seals the whole 42-cell gym yard off, which makes Cut the price of the badge. Two of the three gym trainers see the player crossing the pillar grid, and Surge sets all three beaten flags himself whether they were fought or not.

_talk_to() now reports what the walk to its target resolved instead of dropping it. Every gym trainer fought on the way in was landing in no path entry at all, which is exactly where it matters most.

validate_vermilion.gd pins the passage, the tree as the yard's only seam, the gym door's single approach and the gym's own lack of a scene, then cuts the tree against each real cache and watches it grow back.