### PR TITLE
Walk the Saffron warp maze to the Marsh Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Headless tools, all against a real imported cache:
 | `validate_elite_four.gd` | the seven Indigo Plateau maps, the one door into the rooms, the prepare callback's flag reset, and each room's sealed entrance and boss-opened exit, in all three games |
 | `validate_ss_aqua.gd` | the S.S. Aqua's B1F sailors and the coord events that toggle them, 1F's deck and west wing, the lazy sailor and the granddaughter, and the corridor before and after the errand that opens it, in all three games |
 | `validate_vermilion.gd` | the Vermilion port passage's stair pair, the cut tree sealing the gym yard, the gym door's one approach, and the gym's own lack of a scene or callback, in all three games |
+| `validate_saffron.gd` | Route 6's dead-end north connection and the gate that carries the crossing, Saffron Gym's nine rooms and fifteen self-warp pairs, and the one chain of pads that reaches Sabrina, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2692,6 +2692,21 @@ func try_connection(direction: Vector2i) -> Dictionary:
 			"from_cell": player_cell,
 			"direction": direction_name,
 		}
+	## A connected step is still a step. The cartridge copies the connection strip
+	## into the same block buffer the current map lives in, so `GetTileCollision`
+	## reads the neighbour's real collision and `.CheckLandPerms` refuses a wall
+	## across an edge exactly as it does inside one. Without this the edge itself
+	## was the only test, and Route 6's northwest corner walked into (10,35) of
+	## Saffron City, a wall cell with no walkable neighbour at all.
+	if not _connection_step_allows(target_map, target_cell, direction):
+		return {
+			"ok": false,
+			"kind": &"connection",
+			"reason": &"blocked_target_cell",
+			"from_map": map_id(),
+			"from_cell": player_cell,
+			"direction": direction_name,
+		}
 
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
@@ -2716,6 +2731,26 @@ func can_walk_to(cell: Vector2i, direction: Vector2i = Vector2i.ZERO) -> bool:
 	if not _step_permission_allows(cell, direction):
 		return false
 	return object_at(cell) == null
+
+
+## _step_permission_allows() for a cell on a map that is not loaded yet: the
+## leave-side face mask still reads the current map, the destination permission
+## the connected one. No block override can apply to a map this world has not
+## drawn, so the map's own collision is exact.
+func _connection_step_allows(
+	target_map: Gen2WorldMap, target_cell: Vector2i, direction: Vector2i
+) -> bool:
+	var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+	if face != 0 and (tile_permissions_at(player_cell) & face) != 0:
+		return false
+	var permission: int = Gen2WorldCollision.permission_for(
+		target_map.collision_at(target_cell.x, target_cell.y)
+	)
+	if movement_mode == MOVEMENT_SURF:
+		if collision_permission_at(player_cell) == Gen2WorldCollision.WATER_TILE:
+			return permission in [Gen2WorldCollision.LAND_TILE, Gen2WorldCollision.WATER_TILE]
+		return permission == Gen2WorldCollision.WATER_TILE
+	return permission == Gen2WorldCollision.LAND_TILE
 
 
 ## .CheckLandPerms/.CheckSurfPerms alone, without .CheckNPC. Split out because

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2909,6 +2909,22 @@ func test_connected_edge_step_translates_the_player_and_reloads_the_target_map()
 	assert_eq(world.player_cell, Vector2i(15, 6))
 
 
+## The cartridge copies the connection strip into the same block buffer the
+## current map lives in, so `.CheckLandPerms` reads the neighbour's real
+## collision and refuses a wall across an edge exactly as it does inside one.
+func test_connected_edge_step_refuses_a_wall_on_the_target_map() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var target: Gen2WorldMap = data.world_map(1, 2)
+	target.collision[4 * target.collision_width + 0] = 0x07
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(15, 4))
+	var result: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_false(result["ok"])
+	assert_eq(result["kind"], &"connection")
+	assert_eq(result["reason"], &"blocked_target_cell")
+	assert_eq(world.map_id(), Vector2i(1, 1))
+	assert_eq(world.player_cell, Vector2i(15, 4))
+
+
 func test_connection_requires_the_player_to_be_on_the_requested_edge() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
 	var result: Dictionary = world.try_connection(Vector2i.RIGHT)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -338,6 +338,40 @@ const SURGE_FACE: Vector2i = Vector2i(5, 3)
 ## sets (`constants/engine_flags.asm`).
 const BADGE_THUNDER: int = 10
 const ENGINE_FLYPOINT_VERMILION: int = 58
+## The gym's own exit, and the tree faced from the yard side. Leaving the gym
+## reloads the city, which regrows the tree behind the player, so the way out is
+## cut a second time exactly as the way in was.
+const VERMILION_GYM_EXIT: Vector2i = Vector2i(4, 17)
+const VERMILION_GYM_TREE_RETURN: Vector2i = Vector2i(13, 19)
+
+## Route 6 and Saffron City. Vermilion connects north to Route 6
+## (`data/maps/attributes.asm`), but Saffron is entered through
+## `ROUTE_6_SAFFRON_GATE` rather than a connection, the way Violet and Ecruteak
+## are on the Johto legs.
+const ROUTE_6_GROUP: int = 12
+const ROUTE_6_NUMBER: int = 1
+const ROUTE_6_SAFFRON_GATE_DOOR: Vector2i = Vector2i(6, 1)
+const SAFFRON_GROUP: int = 25
+const SAFFRON_CITY_NUMBER: int = 2
+const SAFFRON_GYM_NUMBER: int = 4
+const SAFFRON_GYM_DOOR: Vector2i = Vector2i(34, 3)
+
+## `maps/SaffronGym.asm` is nine rooms walled off from each other, joined only by
+## fifteen pairs of self-warps. Sabrina's room holds exactly one pad, warp 32 on
+## (11,9), and the only pad that reaches it is warp 17 on (1,5), so the way in is
+## a fixed chain rather than anything a walk can plan: the entrance room's only
+## pad, then one pad per room until the corner room that holds warp 17.
+const SAFFRON_GYM_MAZE: Array[Vector2i] = [
+	Vector2i(11, 15),  # warp 3 -> 18 (19,17)
+	Vector2i(15, 17),  # warp 11 -> 26 (5,15)
+	Vector2i(5, 17),   # warp 12 -> 27 (5,11)
+	Vector2i(1, 11),   # warp 6 -> 21 (5,5)
+	Vector2i(1, 5),    # warp 17 -> 32 (11,9), Sabrina's room
+]
+const SABRINA_FACE: Vector2i = Vector2i(9, 9)
+## ENGINE_MARSHBADGE's place in source badge order, and Saffron's own flypoint.
+const BADGE_MARSH: int = 13
+const ENGINE_FLYPOINT_SAFFRON: int = 60
 
 ## constants/event_flags.asm, same numbers in both pins.
 const EVENT_FAST_SHIP_HAS_ARRIVED: int = 49
@@ -4590,6 +4624,10 @@ func _kanto_crossing_path(
 	var thunder: Dictionary = _thunder_badge_path(spawned, save, random, data, path)
 	if not bool(thunder.get("ok", false)):
 		return thunder
+
+	var marsh: Dictionary = _marsh_badge_path(spawned, save, random, data, path)
+	if not bool(marsh.get("ok", false)):
+		return marsh
 	return {"ok": true, "world": spawned}
 
 
@@ -5056,6 +5094,141 @@ func _thunder_badge_path(
 		BADGE_THUNDER, Gen2WorldState.is_crystal_profile(data)
 	)):
 		return {"ok": false, "path": path, "reason": "ENGINE_THUNDERBADGE was not set"}
+	return {"ok": true}
+
+
+## Vermilion Gym to the Marsh Badge, by way of Route 6 and Saffron City.
+##
+## The gym exit reloads the city, so the yard's tree has grown back and is cut a
+## second time from the inside. Saffron is then a gate crossing rather than a
+## connection, and its own gym is a warp maze: nine rooms with no doors between
+## them, joined by fifteen pairs of self-warps, walked as the fixed chain
+## SAFFRON_GYM_MAZE names.
+func _marsh_badge_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var out_of_gym: Dictionary = _warp_chain(
+		world, save, random, data, [VERMILION_GYM_EXIT]
+	)
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving Vermilion Gym failed: %s" % out_of_gym.get("reason", ""),
+		}
+	var regrown: Dictionary = _cut_at(
+		world, VERMILION_GYM_TREE_RETURN, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	if not bool(regrown.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the regrown gym tree failed: %s" % regrown.get("reason", ""),
+		}
+
+	var northward: Dictionary = _walk_connection_resolving(
+		world, "north", ROUTE_6_GROUP, ROUTE_6_NUMBER, save, random, data
+	)
+	var route_6_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "vermilion_to_route_6",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": northward.get("encounters", []),
+		"run": route_6_entry,
+	})
+	if not bool(northward.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk north to Route 6 failed: %s" % northward.get("reason", ""),
+		}
+
+	var gate: Dictionary = _gate_leg(
+		world, save, random, data, ROUTE_6_SAFFRON_GATE_DOOR,
+		SAFFRON_GROUP, SAFFRON_CITY_NUMBER
+	)
+	path.append({
+		"step": "saffron_city",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_SAFFRON),
+	})
+	if not bool(gate.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Saffron gate failed: %s" % gate.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_SAFFRON):
+		return {"ok": false, "path": path, "reason": "Saffron's flypoint callback did not run"}
+
+	return _saffron_gym_leg(world, save, random, data, path)
+
+
+## The warp maze, then Sabrina.
+##
+## Every pad is one half of a bidirectional pair, so a wrong one is recoverable
+## rather than fatal, but only warp 17 reaches Sabrina's room at all. The walk
+## between pads is ordinary: within a room the floor is open, and the BFS treats
+## every other pad as a wall, which is what keeps it from wandering onto one.
+func _saffron_gym_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_gym: Dictionary = _warp_chain(world, save, random, data, [SAFFRON_GYM_DOOR])
+	if not bool(into_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Saffron Gym door failed: %s" % into_gym.get("reason", ""),
+		}
+	var pads: Array = []
+	for pad: Vector2i in SAFFRON_GYM_MAZE:
+		var stepped: Dictionary = _warp_walk(world, pad, save, random, data)
+		pads.append({
+			"pad": _cell_value_from_vector(pad),
+			"landed": _cell_value(world),
+			"encounters": stepped.get("encounters", []),
+		})
+		if not bool(stepped.get("ok", false)):
+			path.append({"step": "saffron_gym_maze", "pads": pads})
+			return {
+				"ok": false, "path": path,
+				"reason": "the maze pad on %s failed: %s" % [pad, stepped.get("reason", "")],
+			}
+	path.append({
+		"step": "saffron_gym_maze",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"pads": pads,
+	})
+
+	var sabrina: Dictionary = _talk_to(
+		world, SABRINA_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "saffron_gym_sabrina",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"marsh_badge": world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+			BADGE_MARSH, Gen2WorldState.is_crystal_profile(data)
+		)),
+		"run": sabrina,
+	})
+	if not bool(sabrina.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Sabrina did not finish: %s" % sabrina.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		BADGE_MARSH, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return {"ok": false, "path": path, "reason": "ENGINE_MARSHBADGE was not set"}
 	return {"ok": true}
 
 

--- a/tools/validate_saffron.gd
+++ b/tools/validate_saffron.gd
@@ -1,0 +1,306 @@
+extends SceneTree
+
+## Verifies the way into Saffron City and its gym's warp maze against freshly
+## imported real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## maps/SaffronCity.asm, maps/SaffronGym.asm, maps/Route6.asm,
+## maps/Route6SaffronGate.asm and data/maps/attributes.asm. The city, the gym and
+## the gate are byte identical between the pins; Route 6 differs only in the two
+## extra Pokefans Crystal puts on (9,12) and (10,12), both sight range 0, so
+## nothing here is profile split.
+##
+## Two things are worth pinning. Saffron has a real south connection to Route 6,
+## but the city's own south row is wall everywhere Route 6's north edge aligns
+## to, so `ROUTE_6_SAFFRON_GATE` is the only way in, the way Route 31's gate is
+## into Violet. And Saffron Gym is nine rooms with no walkable path between them,
+## joined only by fifteen pairs of self-warps: Sabrina's room holds exactly one
+## pad and exactly one pad reaches it, so the way in is a fixed chain.
+##
+##   Godot --headless --path . -s res://tools/validate_saffron.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm.
+const VERMILION_GROUP: int = 12
+const ROUTE_6: int = 1
+const ROUTE_6_SAFFRON_GATE: int = 12
+const SAFFRON_GROUP: int = 25
+const SAFFRON_CITY: int = 2
+const SAFFRON_GYM: int = 4
+
+const GYM_SIZE: Vector2i = Vector2i(20, 18)
+const GYM_ROOMS: int = 9
+
+## `maps/Route6SaffronGate.asm`: the Route 6 door and the pair onto the city.
+const ROUTE_6_GATE_DOOR: Vector2i = Vector2i(6, 1)
+const GATE_TO_CITY: Array[Vector2i] = [Vector2i(4, 0), Vector2i(5, 0)]
+const CITY_FROM_GATE: Array[Vector2i] = [Vector2i(16, 33), Vector2i(17, 33)]
+
+## `maps/SaffronGym.asm`'s own event table, warp 1 first. Warps 1 and 2 leave for
+## the city; every other warp is a self-warp naming another warp's id.
+const GYM_EXITS: Array[Vector2i] = [Vector2i(8, 17), Vector2i(9, 17)]
+const GYM_PAD_COUNT: int = 30
+
+## The entrance room's only pad, and the chain it starts. Each entry is the pad
+## stepped on and the cell it lands the player on.
+const MAZE_CHAIN: Array[Dictionary] = [
+	{"pad": Vector2i(11, 15), "landed": Vector2i(19, 17)},
+	{"pad": Vector2i(15, 17), "landed": Vector2i(5, 15)},
+	{"pad": Vector2i(5, 17), "landed": Vector2i(5, 11)},
+	{"pad": Vector2i(1, 11), "landed": Vector2i(5, 5)},
+	{"pad": Vector2i(1, 5), "landed": Vector2i(11, 9)},
+]
+const SABRINA: Vector2i = Vector2i(9, 8)
+const SABRINA_ROOM_PAD: Vector2i = Vector2i(11, 9)
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_gate_is_the_only_way(data, game_id)
+		_verify_maze_records(data, game_id)
+		_drive_maze(data, game_id)
+	_finish()
+
+
+## Route 6's north edge is a real connection and a dead end: every walkable cell
+## on it refuses the step north, so the gate carries the whole crossing.
+func _verify_gate_is_the_only_way(data: GameData, game_id: StringName) -> void:
+	var route: Gen2WorldAPI = _open(data, VERMILION_GROUP, ROUTE_6, ROUTE_6_GATE_DOOR)
+	if route == null:
+		return
+	# Crossing the connection is not the question; reaching the city is. A step
+	# north off Route 6's northwest corner does land on Saffron, in the sealed
+	# two-by-two pocket its own southwest corner ends in, and no walk out of that
+	# pocket exists. Each cell gets its own world, since a crossing moves the one
+	# it was taken on.
+	var reached: Array[Vector2i] = []
+	for x: int in route.map_size_cells().x:
+		var edge := Vector2i(x, 0)
+		if not route.can_walk_to(edge):
+			continue
+		var attempt: Gen2WorldAPI = _open(data, VERMILION_GROUP, ROUTE_6, edge)
+		if attempt == null:
+			continue
+		if not bool(attempt.move_result(Vector2i.UP).get("ok", false)):
+			continue
+		if attempt.map_id() != Vector2i(SAFFRON_GROUP, SAFFRON_CITY):
+			continue
+		if _region(attempt, attempt.player_cell).has(CITY_FROM_GATE[0]):
+			reached.append(edge)
+	_check(
+		reached.is_empty(),
+		"%s: Route 6's north edge walks into Saffron proper at %s." % [game_id, reached]
+	)
+	_check(
+		route.warp_index_at(ROUTE_6_GATE_DOOR) == 2,
+		"%s: %s is not Route 6's gate door." % [game_id, ROUTE_6_GATE_DOOR]
+	)
+
+	var gate: Gen2WorldAPI = _open(
+		data, VERMILION_GROUP, ROUTE_6_SAFFRON_GATE, GATE_TO_CITY[0]
+	)
+	if gate == null:
+		return
+	for index: int in GATE_TO_CITY.size():
+		var warp: Dictionary = gate.warp_at(GATE_TO_CITY[index])
+		_check(
+			int(warp.get("map_group", -1)) == SAFFRON_GROUP
+				and int(warp.get("map_number", -1)) == SAFFRON_CITY,
+			"%s: the gate's %s does not open onto Saffron City." % [game_id, GATE_TO_CITY[index]]
+		)
+	var city: Gen2WorldAPI = _open(data, SAFFRON_GROUP, SAFFRON_CITY, CITY_FROM_GATE[0])
+	if city == null:
+		return
+	for cell: Vector2i in CITY_FROM_GATE:
+		_check(
+			city.warp_index_at(cell) > 0,
+			"%s: %s of Saffron City is not the gate's landing." % [game_id, cell]
+		)
+	print("%s gate: Route 6's north edge is sealed, so the gate is the only way into Saffron." % game_id)
+
+
+## The gym's nine rooms and the fifteen self-warp pairs that join them.
+func _verify_maze_records(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, SAFFRON_GROUP, SAFFRON_GYM, GYM_EXITS[0])
+	if world == null:
+		return
+	_check(
+		world.map_size_cells() == GYM_SIZE,
+		"%s: Saffron Gym is %s, not the pinned %s." % [game_id, world.map_size_cells(), GYM_SIZE]
+	)
+	var warps: Array = world.current_map.events.get("warps", [])
+	_check(
+		warps.size() == GYM_EXITS.size() + GYM_PAD_COUNT,
+		"%s: Saffron Gym has %d warps, not the pinned %d." % [
+			game_id, warps.size(), GYM_EXITS.size() + GYM_PAD_COUNT,
+		]
+	)
+
+	# Every pad is one half of a bidirectional pair: warp N names M and M names N.
+	var pads: Dictionary = {}
+	for index: int in warps.size():
+		var warp: Dictionary = warps[index]
+		var cell := Vector2i(int(warp.get("x", -1)), int(warp.get("y", -1)))
+		if index < GYM_EXITS.size():
+			_check(
+				cell == GYM_EXITS[index],
+				"%s: gym warp %d is on %s, not %s." % [game_id, index + 1, cell, GYM_EXITS[index]]
+			)
+			continue
+		if not _check(
+			int(warp.get("map_group", -1)) == SAFFRON_GROUP
+				and int(warp.get("map_number", -1)) == SAFFRON_GYM,
+			"%s: gym warp %d leaves the map; every pad should be a self-warp." % [
+				game_id, index + 1,
+			]
+		):
+			continue
+		pads[index + 1] = int(warp.get("destination", -1))
+	for source: int in pads:
+		var target: int = pads[source]
+		_check(
+			pads.has(target) and int(pads[target]) == source,
+			"%s: gym pad %d names %d, which does not name it back." % [game_id, source, target]
+		)
+
+	# Nine rooms, no walkable path between any two of them.
+	var rooms: Array = _rooms(world)
+	_check(
+		rooms.size() == GYM_ROOMS,
+		"%s: Saffron Gym is %d walkable regions, not the pinned %d." % [
+			game_id, rooms.size(), GYM_ROOMS,
+		]
+	)
+	var entrance: Dictionary = _region(world, GYM_EXITS[0])
+	_check(
+		not entrance.has(SABRINA + Vector2i.DOWN),
+		"%s: Sabrina is reachable from the gym door on foot." % game_id
+	)
+
+	# Sabrina's room holds one pad, and one pad reaches it.
+	var sabrina_room: Dictionary = _region(world, SABRINA_ROOM_PAD)
+	var inside: Array[int] = []
+	for index: int in warps.size():
+		var warp: Dictionary = warps[index]
+		var cell := Vector2i(int(warp.get("x", -1)), int(warp.get("y", -1)))
+		if sabrina_room.has(cell):
+			inside.append(index + 1)
+	_check(
+		inside.size() == 1 and Vector2i(
+			int((warps[inside[0] - 1] as Dictionary).get("x", -1)),
+			int((warps[inside[0] - 1] as Dictionary).get("y", -1))
+		) == SABRINA_ROOM_PAD,
+		"%s: Sabrina's room holds pads %s, not one on %s." % [
+			game_id, inside, SABRINA_ROOM_PAD,
+		]
+	)
+	var reaching: Array[int] = []
+	for source: int in pads:
+		if int(pads[source]) == inside[0]:
+			reaching.append(source)
+	_check(
+		reaching.size() == 1,
+		"%s: %d pads reach Sabrina's room, not one." % [game_id, reaching.size()]
+	)
+	print("%s gym: %d rooms, %d self-warp pairs, and one pad into Sabrina's room." % [
+		game_id, rooms.size(), pads.size() / 2,
+	])
+
+
+## The chain itself, driven against the real cache from the gym door.
+func _drive_maze(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, SAFFRON_GROUP, SAFFRON_GYM, GYM_EXITS[0])
+	if world == null:
+		return
+	for hop: Dictionary in MAZE_CHAIN:
+		var pad: Vector2i = hop["pad"]
+		if not _check(
+			_region(world, world.player_cell).has(pad),
+			"%s: the maze pad on %s is not in the room the player is standing in." % [game_id, pad]
+		):
+			return
+		world.player_cell = pad
+		var taken: Dictionary = world.try_warp()
+		if not _check(
+			bool(taken.get("ok", false)),
+			"%s: the pad on %s did not fire: %s" % [game_id, pad, taken.get("reason", "")]
+		):
+			return
+		_check(
+			world.player_cell == hop["landed"],
+			"%s: the pad on %s landed the player on %s, not %s." % [
+				game_id, pad, world.player_cell, hop["landed"],
+			]
+		)
+	_check(
+		_region(world, world.player_cell).has(SABRINA + Vector2i.DOWN),
+		"%s: the chain did not end in reach of Sabrina." % game_id
+	)
+	print("%s maze: the five-pad chain reaches Sabrina from the gym door." % game_id)
+
+
+func _rooms(world: Gen2WorldAPI) -> Array:
+	var size: Vector2i = world.map_size_cells()
+	var assigned: Dictionary = {}
+	var found: Array = []
+	for y: int in size.y:
+		for x: int in size.x:
+			var start := Vector2i(x, y)
+			if assigned.has(start) or not world.can_walk_to(start):
+				continue
+			var cells: Dictionary = _region(world, start)
+			for cell: Vector2i in cells:
+				assigned[cell] = true
+			found.append(cells)
+	return found
+
+
+func _open(data: GameData, group: int, number: int, cell: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, cell)
+	if world == null:
+		_fail("map %d/%d is missing." % [group, number])
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
+
+
+func _region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			if seen.has(next) or not world.can_walk_to(next, direction):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS saffron: the gate, the gym's nine rooms and the chain to Sabrina verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL saffron: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_saffron.gd.uid
+++ b/tools/validate_saffron.gd.uid
@@ -1,0 +1,1 @@
+uid://c1dk7qlh2edig


### PR DESCRIPTION
Leaving Vermilion Gym reloads the city, so the yard's tree has grown back and is cut a second time from the inside. Vermilion connects north to Route 6, but Saffron is a gate building rather than a connection: the city's south row is wall everywhere Route 6's north edge aligns to.

Saffron Gym is nine rooms with no doors between them, joined only by fifteen pairs of self-warps. Sabrina's room holds exactly one pad and exactly one pad reaches it, so the way in is a fixed five-pad chain rather than anything a walk can plan. Mediums Rebecca and Doris are met on two of the landings, and Sabrina sets all four of her trainers' flags the way Surge does.

A connected step is now permission-checked. The cartridge copies the connection strip into the same block buffer the current map lives in, so CheckLandPerms refuses a wall across an edge exactly as it does inside one. Only the edge itself was being tested, which let Route 6's northwest corner walk into (10,35) of Saffron City, a wall cell with no walkable neighbour at all. The walked route is byte identical across the change and all fifteen geometry validators still pass.

validate_saffron.gd pins the dead-end connection, the thirty pads and their pairing, the nine rooms, and the chain that reaches Sabrina.