### PR TITLE
Cut into the Celadon gym yard for the Rainbow Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Headless tools, all against a real imported cache:
 | `validate_ss_aqua.gd` | the S.S. Aqua's B1F sailors and the coord events that toggle them, 1F's deck and west wing, the lazy sailor and the granddaughter, and the corridor before and after the errand that opens it, in all three games |
 | `validate_vermilion.gd` | the Vermilion port passage's stair pair, the cut tree sealing the gym yard, the gym door's one approach, and the gym's own lack of a scene or callback, in all three games |
 | `validate_saffron.gd` | Route 6's dead-end north connection and the gate that carries the crossing, Saffron Gym's nine rooms and fifteen self-warp pairs, and the one chain of pads that reaches Sabrina, in all three games |
+| `validate_celadon.gd` | Saffron's dead-end west connection and its gate, Route 7's open connection onto Celadon, the city's only cut tree sealing the gym yard from either side, and Celadon Gym's three unavoidable sight lines, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -373,6 +373,42 @@ const SABRINA_FACE: Vector2i = Vector2i(9, 9)
 const BADGE_MARSH: int = 13
 const ENGINE_FLYPOINT_SAFFRON: int = 60
 
+## Every pad is one half of a bidirectional pair, so the way out of Sabrina's
+## room is SAFFRON_GYM_MAZE reversed: each landing shares a room with the next
+## pad, and the last one is the entrance room the exit warps sit in.
+const SAFFRON_GYM_MAZE_OUT: Array[Vector2i] = [
+	Vector2i(11, 9),   # warp 32 -> 17 (1,5)
+	Vector2i(5, 5),    # warp 21 -> 6 (1,11)
+	Vector2i(5, 11),   # warp 27 -> 12 (5,17)
+	Vector2i(5, 15),   # warp 26 -> 11 (15,17)
+	Vector2i(19, 17),  # warp 18 -> 3 (11,15), the entrance room
+]
+const SAFFRON_GYM_EXIT: Vector2i = Vector2i(8, 17)
+
+## Route 7 and Celadon City. Saffron connects west to Route 7
+## (`data/maps/attributes.asm`) but the crossing is `ROUTE_7_SAFFRON_GATE`, the
+## way Route 6's is; Route 7's own west edge is a real open connection into
+## Celadon, so that half needs no gate.
+const CELADON_GROUP: int = 21
+const ROUTE_7_NUMBER: int = 1
+const CELADON_CITY_NUMBER: int = 4
+const CELADON_GYM_NUMBER: int = 21
+const SAFFRON_ROUTE_7_GATE_DOOR: Vector2i = Vector2i(0, 24)
+## Celadon ships exactly one `COLL_CUT_TREE` ($12), on (28,35), and it is the
+## only seam between the 619-cell city and the 70-cell gym yard. Cut is the
+## price of this badge the way it was of the Thunder Badge.
+const CELADON_GYM_TREE_APPROACH: Vector2i = Vector2i(28, 34)
+## `maps/CeladonGym.asm` declares neither a scene nor a callback, so Erika
+## answers as soon as she is faced. Her four trainers are sight lines across the
+## flower beds: the twins on (4,10)/(5,10) and Beauty Julia on (3,5) each watch
+## a whole row's only gap, and row 8's four cells are covered by Picnicker Tanya
+## and Lass Michelle between them, so three of the five fights are unavoidable.
+const CELADON_GYM_DOOR: Vector2i = Vector2i(10, 29)
+const ERIKA_FACE: Vector2i = Vector2i(5, 4)
+## ENGINE_RAINBOWBADGE's place in source badge order, and Celadon's flypoint.
+const BADGE_RAINBOW: int = 11
+const ENGINE_FLYPOINT_CELADON: int = 61
+
 ## constants/event_flags.asm, same numbers in both pins.
 const EVENT_FAST_SHIP_HAS_ARRIVED: int = 49
 const EVENT_FAST_SHIP_FOUND_GIRL: int = 50
@@ -380,6 +416,7 @@ const EVENT_FAST_SHIP_LAZY_SAILOR: int = 51
 const EVENT_FAST_SHIP_INFORMED_ABOUT_LAZY_SAILOR: int = 52
 const EVENT_GOT_METAL_COAT_FROM_GRANDPA: int = 113
 const EVENT_FAST_SHIP_NE_CABIN_SAILOR: int = 1837
+const EVENT_GOT_TM19_GIGA_DRAIN: int = 220
 
 ## New Bark Town to Olivine City. Map connections except where a `gate` cell is
 ## named, which is the door of a gate building whose far warp is the join
@@ -4628,6 +4665,10 @@ func _kanto_crossing_path(
 	var marsh: Dictionary = _marsh_badge_path(spawned, save, random, data, path)
 	if not bool(marsh.get("ok", false)):
 		return marsh
+
+	var rainbow: Dictionary = _rainbow_badge_path(spawned, save, random, data, path)
+	if not bool(rainbow.get("ok", false)):
+		return rainbow
 	return {"ok": true, "world": spawned}
 
 
@@ -5229,6 +5270,145 @@ func _saffron_gym_leg(
 		BADGE_MARSH, Gen2WorldState.is_crystal_profile(data)
 	)):
 		return {"ok": false, "path": path, "reason": "ENGINE_MARSHBADGE was not set"}
+	return {"ok": true}
+
+
+## Saffron Gym to the Rainbow Badge, by way of Route 7 and Celadon City.
+##
+## The maze is walked back out pad for pad, since every pad is one half of a
+## bidirectional pair. Saffron's west edge is a connection into Route 7 the way
+## its south one is into Route 6, and carries no more traffic: the crossing is
+## `ROUTE_7_SAFFRON_GATE`. Route 7's own west edge is the open half, a real
+## connection onto Celadon City, and the gate that replaces it is inside the
+## city: one cut tree seals the whole gym yard.
+func _rainbow_badge_path(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var pads: Array = []
+	for pad: Vector2i in SAFFRON_GYM_MAZE_OUT:
+		var stepped: Dictionary = _warp_walk(world, pad, save, random, data)
+		pads.append({
+			"pad": _cell_value_from_vector(pad),
+			"landed": _cell_value(world),
+			"encounters": stepped.get("encounters", []),
+		})
+		if not bool(stepped.get("ok", false)):
+			path.append({"step": "saffron_gym_exit", "pads": pads})
+			return {
+				"ok": false, "path": path,
+				"reason": "the maze pad on %s failed: %s" % [pad, stepped.get("reason", "")],
+			}
+	var out_of_gym: Dictionary = _warp_chain(world, save, random, data, [SAFFRON_GYM_EXIT])
+	path.append({
+		"step": "saffron_gym_exit",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"pads": pads,
+	})
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving Saffron Gym failed: %s" % out_of_gym.get("reason", ""),
+		}
+
+	var gate: Dictionary = _gate_leg(
+		world, save, random, data, SAFFRON_ROUTE_7_GATE_DOOR,
+		CELADON_GROUP, ROUTE_7_NUMBER
+	)
+	path.append({"step": "route_7", "map": _map_value(world), "cell": _cell_value(world)})
+	if not bool(gate.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Route 7 gate failed: %s" % gate.get("reason", ""),
+		}
+
+	var westward: Dictionary = _walk_connection_resolving(
+		world, "west", CELADON_GROUP, CELADON_CITY_NUMBER, save, random, data
+	)
+	var city_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "celadon_city",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_CELADON),
+		"encounters": westward.get("encounters", []),
+		"run": city_entry,
+	})
+	if not bool(westward.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk west to Celadon failed: %s" % westward.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_CELADON):
+		return {"ok": false, "path": path, "reason": "Celadon's flypoint callback did not run"}
+
+	return _celadon_gym_leg(world, save, random, data, path)
+
+
+## The yard's tree, then Erika.
+##
+## Cutting (28,35) is what joins the city to the gym yard at all. The walk to
+## Erika crosses three sight lines it cannot route around, so the trainers the
+## walk resolves are reported with her.
+func _celadon_gym_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var tree: Dictionary = _cut_at(
+		world, CELADON_GYM_TREE_APPROACH, Gen2WorldSprite.FACING_DOWN,
+		save, random, data
+	)
+	path.append({
+		"step": "celadon_gym_tree",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"cut": tree.get("cell", []),
+	})
+	if not bool(tree.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gym yard's tree failed: %s" % tree.get("reason", ""),
+		}
+
+	var to_gym: Dictionary = _warp_chain(world, save, random, data, [CELADON_GYM_DOOR])
+	if not bool(to_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gym door failed: %s" % to_gym.get("reason", ""),
+		}
+	var erika: Dictionary = _talk_to(
+		world, ERIKA_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "celadon_gym_erika",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"rainbow_badge": world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+			BADGE_RAINBOW, Gen2WorldState.is_crystal_profile(data)
+		)),
+		# Set behind Erika's own verbosegiveitem, so it is what says the TM
+		# offer finished rather than being refused.
+		"giga_drain": world.event_flag_active(EVENT_GOT_TM19_GIGA_DRAIN),
+		"run": erika,
+	})
+	if not bool(erika.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Erika did not finish: %s" % erika.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		BADGE_RAINBOW, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return {"ok": false, "path": path, "reason": "ENGINE_RAINBOWBADGE was not set"}
 	return {"ok": true}
 
 

--- a/tools/validate_celadon.gd
+++ b/tools/validate_celadon.gd
@@ -1,0 +1,458 @@
+extends SceneTree
+
+## Verifies the way west from Saffron City to Celadon City and its gym against
+## freshly imported real caches, for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## maps/SaffronCity.asm, maps/Route7SaffronGate.asm, maps/Route7.asm,
+## maps/CeladonCity.asm, maps/CeladonGym.asm and data/maps/attributes.asm.
+## Route7.asm, Route7SaffronGate.asm and all four .blk files are byte identical
+## between the pins; CeladonCity.asm and CeladonGym.asm differ only in NPC text
+## and an `_CRYSTAL_AU` block, so nothing here is profile split.
+##
+## Three things are worth pinning. Saffron has a real west connection to Route 7
+## and it is a dead end, landing in a sealed four-cell corner, so
+## `ROUTE_7_SAFFRON_GATE` carries that crossing the way it does the Route 6 one.
+## Route 7's own west edge is the open half: a real connection onto Celadon City
+## that needs no gate. And the gate that replaces it is inside the city, one
+## COLL_CUT_TREE on (28,35) sealing the whole gym yard, which makes Cut the price
+## of the Rainbow Badge the way it was of the Thunder Badge.
+##
+##   Godot --headless --path . -s res://tools/validate_celadon.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm: the CELADON group is 21 and the SAFFRON group 25.
+const CELADON_GROUP: int = 21
+const ROUTE_7: int = 1
+const CELADON_CITY: int = 4
+const CELADON_GYM: int = 21
+const ROUTE_7_SAFFRON_GATE: int = 25
+const SAFFRON_GROUP: int = 25
+const SAFFRON_CITY: int = 2
+
+const CITY_SIZE: Vector2i = Vector2i(40, 36)
+const ROUTE_7_SIZE: Vector2i = Vector2i(20, 18)
+const GATE_SIZE: Vector2i = Vector2i(10, 8)
+const GYM_SIZE: Vector2i = Vector2i(10, 18)
+
+## `maps/SaffronCity.asm` warps 10 and 11, and the gate cells they name.
+const SAFFRON_GATE_DOORS: Array[Vector2i] = [Vector2i(0, 24), Vector2i(0, 25)]
+const GATE_FROM_CITY: Vector2i = Vector2i(9, 4)
+const GATE_TO_ROUTE: Vector2i = Vector2i(0, 4)
+## `maps/Route7.asm` warp 1, which is where the gate lands the player.
+const ROUTE_7_FROM_GATE: Vector2i = Vector2i(15, 6)
+## The two cells Saffron's own west edge crosses on, and the sealed corner of
+## Route 7 they land in.
+const SAFFRON_WEST_EDGE: Array[Vector2i] = [Vector2i(0, 34), Vector2i(0, 35)]
+const ROUTE_7_SEALED_CORNER: Array[Vector2i] = [Vector2i(19, 16), Vector2i(19, 17)]
+const ROUTE_7_SEALED_CELLS: int = 4
+## Route 7's west edge and the Celadon cells it opens onto, connection offset -5
+## (`data/maps/attributes.asm`).
+const ROUTE_7_WEST_EDGE: Array[Vector2i] = [Vector2i(0, 0), Vector2i(0, 1)]
+const CELADON_FROM_ROUTE_7: Array[Vector2i] = [Vector2i(39, 10), Vector2i(39, 11)]
+
+## `maps/CeladonCity.asm` warp 8 and the cell below it, and the tree between the
+## city and the yard the gym door sits in.
+const GYM_DOOR: Vector2i = Vector2i(10, 29)
+const GYM_DOOR_APPROACH: Vector2i = Vector2i(10, 30)
+const GYM_TREE: Vector2i = Vector2i(28, 35)
+const GYM_TREE_APPROACH: Vector2i = Vector2i(28, 34)
+const GYM_TREE_RETURN: Vector2i = Vector2i(27, 35)
+const CITY_CELLS: int = 619
+const GYM_YARD_CELLS: int = 70
+
+## engine/overworld/tile_events.asm's CheckCutCollision entry for a tree, the
+## `CutTreeBlockPointers` row TILESET_KANTO gives it
+## (`data/collision/field_move_blocks.asm`), and ENGINE_HIVEBADGE's place in
+## source badge order, which is the badge `.CheckAble` wants before the tile.
+const COLL_CUT_TREE: int = 0x12
+const TREE_BLOCK_UNCUT: int = 0x60
+const TREE_BLOCK_CUT: int = 0x6E
+const TREE_BLOCK: Vector2i = Vector2i(14, 17)
+const BADGE_HIVE: int = 1
+
+## `maps/CeladonGym.asm`'s object events, in `object_const_def` order, and its
+## two door warps.
+const ERIKA: Vector2i = Vector2i(5, 3)
+const ERIKA_APPROACH: Vector2i = Vector2i(5, 4)
+const GYM_WARPS: Array[Vector2i] = [Vector2i(4, 17), Vector2i(5, 17)]
+## Each trainer's own sight cells, from the facing and range its object event
+## gives it: Michelle STANDING_LEFT range 2 on (7,8), Tanya STANDING_RIGHT
+## range 2 on (2,8), Julia STANDING_RIGHT range 2 on (3,5), and the twins
+## STANDING_DOWN range 1 on (4,10) and (5,10).
+const GYM_TRAINERS: Array[Vector2i] = [
+	Vector2i(7, 8), Vector2i(2, 8), Vector2i(3, 5), Vector2i(4, 10), Vector2i(5, 10),
+]
+const SIGHT_TWINS: Array[Vector2i] = [Vector2i(4, 11), Vector2i(5, 11)]
+const SIGHT_JULIA: Array[Vector2i] = [Vector2i(4, 5), Vector2i(5, 5)]
+const SIGHT_TANYA: Array[Vector2i] = [Vector2i(3, 8), Vector2i(4, 8)]
+const SIGHT_MICHELLE: Array[Vector2i] = [Vector2i(5, 8), Vector2i(6, 8)]
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_gate_carries_saffron(data, game_id)
+		_verify_route_7_connection(data, game_id)
+		_verify_city(data, game_id)
+		_verify_gym(data, game_id)
+		_drive_gym_tree(data, game_id)
+	_finish()
+
+
+## Saffron's west edge is a real connection and a dead end: the only two cells it
+## crosses on land in a sealed corner of Route 7, so the gate carries it.
+func _verify_gate_carries_saffron(data: GameData, game_id: StringName) -> void:
+	var city: Gen2WorldAPI = _open(data, SAFFRON_GROUP, SAFFRON_CITY, SAFFRON_GATE_DOORS[0])
+	if city == null:
+		return
+	# Each cell gets its own world, since a crossing moves the one it was taken on.
+	var crossed: Array[Vector2i] = []
+	for y: int in city.map_size_cells().y:
+		var edge := Vector2i(0, y)
+		if not city.can_walk_to(edge):
+			continue
+		var attempt: Gen2WorldAPI = _open(data, SAFFRON_GROUP, SAFFRON_CITY, edge)
+		if attempt == null:
+			continue
+		if not bool(attempt.move_result(Vector2i.LEFT).get("ok", false)):
+			continue
+		crossed.append(edge)
+	_check(
+		crossed == SAFFRON_WEST_EDGE,
+		"%s: Saffron's west edge crosses on %s, not %s." % [
+			game_id, crossed, SAFFRON_WEST_EDGE,
+		]
+	)
+
+	var route: Gen2WorldAPI = _open(data, CELADON_GROUP, ROUTE_7, ROUTE_7_FROM_GATE)
+	if route == null:
+		return
+	_check(
+		route.map_size_cells() == ROUTE_7_SIZE,
+		"%s: Route 7 is %s, not the pinned %s." % [
+			game_id, route.map_size_cells(), ROUTE_7_SIZE,
+		]
+	)
+	var gate_side: Dictionary = _region(route, ROUTE_7_FROM_GATE)
+	for cell: Vector2i in ROUTE_7_SEALED_CORNER:
+		_check(
+			not gate_side.has(cell),
+			"%s: Route 7's %s is reachable from the gate landing." % [game_id, cell]
+		)
+		_check(
+			_region(route, cell).size() == ROUTE_7_SEALED_CELLS,
+			"%s: Route 7's corner at %s is %d cells, not the pinned %d." % [
+				game_id, cell, _region(route, cell).size(), ROUTE_7_SEALED_CELLS,
+			]
+		)
+
+	for index: int in SAFFRON_GATE_DOORS.size():
+		var warp: Dictionary = city.warp_at(SAFFRON_GATE_DOORS[index])
+		_check(
+			int(warp.get("map_group", -1)) == CELADON_GROUP
+				and int(warp.get("map_number", -1)) == ROUTE_7_SAFFRON_GATE,
+			"%s: Saffron's %s does not open onto the Route 7 gate." % [
+				game_id, SAFFRON_GATE_DOORS[index],
+			]
+		)
+	var gate: Gen2WorldAPI = _open(
+		data, CELADON_GROUP, ROUTE_7_SAFFRON_GATE, GATE_FROM_CITY
+	)
+	if gate == null:
+		return
+	_check(
+		gate.map_size_cells() == GATE_SIZE,
+		"%s: the Route 7 gate is %s, not the pinned %s." % [
+			game_id, gate.map_size_cells(), GATE_SIZE,
+		]
+	)
+	_check(
+		_region(gate, GATE_FROM_CITY).has(GATE_TO_ROUTE),
+		"%s: the Route 7 gate's two doors are not joined on foot." % game_id
+	)
+	var far: Dictionary = gate.warp_at(GATE_TO_ROUTE)
+	_check(
+		int(far.get("map_group", -1)) == CELADON_GROUP
+			and int(far.get("map_number", -1)) == ROUTE_7,
+		"%s: the gate's %s does not open onto Route 7." % [game_id, GATE_TO_ROUTE]
+	)
+	print("%s gate: Saffron's west edge is a sealed crossing, so the gate carries it." % game_id)
+
+
+## Route 7's own west edge is the open half of the leg: a real connection onto
+## Celadon City, with no gate building between them.
+func _verify_route_7_connection(data: GameData, game_id: StringName) -> void:
+	var route: Gen2WorldAPI = _open(data, CELADON_GROUP, ROUTE_7, ROUTE_7_FROM_GATE)
+	if route == null:
+		return
+	var gate_side: Dictionary = _region(route, ROUTE_7_FROM_GATE)
+	var crossed: Array[Vector2i] = []
+	var landed: Array[Vector2i] = []
+	for y: int in route.map_size_cells().y:
+		var edge := Vector2i(0, y)
+		if not gate_side.has(edge):
+			continue
+		var attempt: Gen2WorldAPI = _open(data, CELADON_GROUP, ROUTE_7, edge)
+		if attempt == null:
+			continue
+		if not bool(attempt.move_result(Vector2i.LEFT).get("ok", false)):
+			continue
+		if attempt.map_id() != Vector2i(CELADON_GROUP, CELADON_CITY):
+			continue
+		crossed.append(edge)
+		landed.append(attempt.player_cell)
+	_check(
+		crossed == ROUTE_7_WEST_EDGE and landed == CELADON_FROM_ROUTE_7,
+		"%s: Route 7 crosses west on %s into %s, not %s into %s." % [
+			game_id, crossed, landed, ROUTE_7_WEST_EDGE, CELADON_FROM_ROUTE_7,
+		]
+	)
+	print("%s route 7: an open west connection onto Celadon City on %s." % [game_id, crossed])
+
+
+## The city itself, and the one tree that seals the gym yard off.
+func _verify_city(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, CELADON_GROUP, CELADON_CITY, CELADON_FROM_ROUTE_7[0])
+	if world == null:
+		return
+	_check(
+		world.map_size_cells() == CITY_SIZE,
+		"%s: Celadon City is %s, not the pinned %s." % [
+			game_id, world.map_size_cells(), CITY_SIZE,
+		]
+	)
+	# One cuttable cell in the whole city, and it is the seam.
+	var cuttable: Array[Vector2i] = []
+	for y: int in CITY_SIZE.y:
+		for x: int in CITY_SIZE.x:
+			var cell := Vector2i(x, y)
+			if Gen2WorldFieldMove.CUTTABLE_COLLISIONS.has(world.collision_code_at(cell)):
+				cuttable.append(cell)
+	_check(
+		cuttable == [GYM_TREE],
+		"%s: Celadon's cuttable cells are %s, not %s alone." % [game_id, cuttable, GYM_TREE]
+	)
+	_check(
+		world.collision_code_at(GYM_TREE) == COLL_CUT_TREE,
+		"%s: %s is collision $%02X, not a cut tree." % [
+			game_id, GYM_TREE, world.collision_code_at(GYM_TREE),
+		]
+	)
+
+	var city: Dictionary = _region(world, CELADON_FROM_ROUTE_7[0])
+	var yard: Dictionary = _region(world, GYM_DOOR_APPROACH)
+	_check(
+		city.size() == CITY_CELLS,
+		"%s: Celadon's walkable city is %d cells, not the pinned %d." % [
+			game_id, city.size(), CITY_CELLS,
+		]
+	)
+	_check(
+		yard.size() == GYM_YARD_CELLS,
+		"%s: the gym yard is %d cells, not the pinned %d." % [
+			game_id, yard.size(), GYM_YARD_CELLS,
+		]
+	)
+	_check(
+		not city.has(GYM_DOOR) and not city.has(GYM_DOOR_APPROACH),
+		"%s: the gym yard is reachable without cutting." % game_id
+	)
+	_check(
+		city.has(GYM_TREE_APPROACH) and yard.has(GYM_TREE_RETURN),
+		"%s: the tree cannot be faced from both sides." % game_id
+	)
+	# And the tree really is the only join, checked by walking the yard's whole
+	# border rather than by naming a cell.
+	var seams: Array[Vector2i] = []
+	for cell: Vector2i in yard:
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			if city.has(cell + direction):
+				seams.append(cell + direction)
+	_check(
+		seams.is_empty(),
+		"%s: the gym yard touches the city at %s without a tree between." % [game_id, seams]
+	)
+	_check(
+		world.warp_index_at(GYM_DOOR) == 8,
+		"%s: %s is not Celadon's gym door." % [game_id, GYM_DOOR]
+	)
+	print("%s city: a %d-cell yard behind the city's only cut tree." % [game_id, yard.size()])
+
+
+## The gym has no puzzle either: no scene scripts, no callbacks, and Erika
+## answers as soon as she is faced. The gate is the flower beds, which leave
+## three of the five trainers no cell to route around.
+func _verify_gym(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, CELADON_GROUP, CELADON_GYM, GYM_WARPS[0])
+	if world == null:
+		return
+	_check(
+		world.map_size_cells() == GYM_SIZE,
+		"%s: Celadon Gym is %s, not the pinned %s." % [
+			game_id, world.map_size_cells(), GYM_SIZE,
+		]
+	)
+	_check(
+		world.current_map.scripts.get("scenes", []).is_empty(),
+		"%s: Celadon Gym ships a scene script; it should have none." % game_id
+	)
+	_check(
+		world.current_map.scripts.get("callbacks", []).is_empty(),
+		"%s: Celadon Gym ships a callback; it should have none." % game_id
+	)
+	_check(
+		world.object_at(ERIKA) != null,
+		"%s: no Erika on %s." % [game_id, ERIKA]
+	)
+	for cell: Vector2i in GYM_TRAINERS:
+		_check(
+			world.object_at(cell) != null,
+			"%s: no gym trainer on %s." % [game_id, cell]
+		)
+	for index: int in GYM_WARPS.size():
+		_check(
+			world.warp_index_at(GYM_WARPS[index]) == index + 1,
+			"%s: %s is not gym warp %d." % [game_id, GYM_WARPS[index], index + 1]
+		)
+	_check(
+		_region(world, GYM_WARPS[0]).has(ERIKA_APPROACH),
+		"%s: Erika cannot be faced from the gym door." % game_id
+	)
+
+	# The twins and Julia each watch the only gap in a row, and row 8's four
+	# cells are covered by Tanya and Michelle between them, so three fights are
+	# unavoidable while either of those two alone can be dodged.
+	for sealed: Array in [SIGHT_TWINS, SIGHT_JULIA, SIGHT_TANYA + SIGHT_MICHELLE]:
+		_check(
+			not _region(world, GYM_WARPS[0], sealed).has(ERIKA_APPROACH),
+			"%s: Erika is reachable without crossing %s." % [game_id, sealed]
+		)
+	for dodged: Array in [SIGHT_TANYA, SIGHT_MICHELLE]:
+		_check(
+			_region(world, GYM_WARPS[0], dodged).has(ERIKA_APPROACH),
+			"%s: %s cannot be dodged, but the other row-8 trainer's line is open." % [
+				game_id, dodged,
+			]
+		)
+	print("%s gym: no scene, no callback, and three sight lines with no way around." % game_id)
+
+
+## The cut itself, against the real cache: the tree opens from either side, the
+## yard joins, and a map load grows it back. Leaving the gym reloads the city, so
+## the way out is cut a second time exactly as the way in was.
+func _drive_gym_tree(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, CELADON_GROUP, CELADON_CITY, GYM_TREE_APPROACH)
+	if world == null:
+		return
+	world.state.set_engine_flag(Gen2WorldState.badge_flag(
+		BADGE_HIVE, Gen2WorldState.is_crystal_profile(data)
+	))
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var request: Dictionary = world.cut_request()
+	if not _check(
+		bool(request.get("ok", false)),
+		"%s: cut refused at %s: %s" % [game_id, GYM_TREE, request.get("reason", "")]
+	):
+		return
+	_check(
+		int(request.get("block", -1)) == TREE_BLOCK_CUT
+			and request.get("block_cell", Vector2i.ZERO) == TREE_BLOCK,
+		"%s: the tree staged %s, not block $%02X at %s." % [
+			game_id, JSON.stringify(request), TREE_BLOCK_CUT, TREE_BLOCK,
+		]
+	)
+	# Script_Cut writes the block only after UseCutText, so staging alone must
+	# leave the map exactly as it was.
+	_check(
+		world.block_at(TREE_BLOCK.x, TREE_BLOCK.y) == TREE_BLOCK_UNCUT
+			and not world.can_walk_to(GYM_TREE),
+		"%s: Celadon changed before the cut was committed." % game_id
+	)
+	if not _check(
+		bool(world.complete_cut().get("ok", false)),
+		"%s: the cut did not commit." % game_id
+	):
+		return
+	_check(
+		_region(world, GYM_TREE_APPROACH).has(GYM_DOOR_APPROACH),
+		"%s: the gym door is still unreachable after the cut." % game_id
+	)
+	var _reloaded: Dictionary = world.reload_current_map()
+	_check(
+		world.collision_code_at(GYM_TREE) == COLL_CUT_TREE,
+		"%s: the tree did not grow back on a map load." % game_id
+	)
+
+	# And the same tree faced from the yard side, which is the cut the walk out
+	# of the gym has to make.
+	var back: Gen2WorldAPI = _open(data, CELADON_GROUP, CELADON_CITY, GYM_TREE_RETURN)
+	if back == null:
+		return
+	back.state.set_engine_flag(Gen2WorldState.badge_flag(
+		BADGE_HIVE, Gen2WorldState.is_crystal_profile(data)
+	))
+	back.player_facing = Gen2WorldSprite.FACING_RIGHT
+	if not _check(
+		bool(back.cut_request().get("ok", false))
+			and bool(back.complete_cut().get("ok", false)),
+		"%s: the tree refused the cut from the yard side." % game_id
+	):
+		return
+	_check(
+		_region(back, GYM_TREE_RETURN).has(CELADON_FROM_ROUTE_7[0]),
+		"%s: the yard still cannot reach the city after the return cut." % game_id
+	)
+	print("%s cut: the tree opens from either side and grows back on the next map load." % game_id)
+
+
+func _open(data: GameData, group: int, number: int, cell: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, cell)
+	if world == null:
+		_fail("map %d/%d is missing." % [group, number])
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
+
+
+## [param sealed] cells are treated as wall, which is how a sight line is asked
+## whether a walk could have gone around it.
+func _region(world: Gen2WorldAPI, start: Vector2i, sealed: Array = []) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			if seen.has(next) or sealed.has(next) or not world.can_walk_to(next, direction):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS celadon: the gate, the open Route 7 connection, the gym yard's tree and the gym verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL celadon: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_celadon.gd.uid
+++ b/tools/validate_celadon.gd.uid
@@ -1,0 +1,1 @@
+uid://de3pf2a6hh05l


### PR DESCRIPTION
Saffron Gym's maze is walked back out pad for pad, since every pad is one half of a bidirectional pair. Saffron's west edge then repeats its south one: a real connection to Route 7 that crosses on two cells into a sealed four-cell corner, so ROUTE_7_SAFFRON_GATE carries the whole crossing. Route 7's own west edge is the open half, a real connection onto Celadon City with no gate building at all.

The gate is inside the city instead. Celadon ships exactly one COLL_CUT_TREE, on (28,35), and it is the only seam between the 619-cell city and the 70-cell gym yard, so Cut is the price of a second Kanto badge. CeladonGym_MapScripts declares neither a scene nor a callback, the way Vermilion's and Saffron's do not; the flower beds are the puzzle instead. Twins Jo and Zoe and Beauty Julia each watch the only gap in a row the walk has to cross, and row 8's four cells are covered by Picnicker Tanya and Lass Michelle between them, so three of the five fights happen whatever route is taken. Erika sets all four trainer flags herself and hands over TM19 through her own verbosegiveitem.

The route's first 202 steps are byte identical across the change.

validate_celadon.gd pins the sealed west crossing and its gate, the open Route 7 connection, the city's single cut tree and the yard behind it, and the three sight lines with no way around, then cuts the tree from both sides against each real cache and watches it grow back.