### PR TITLE
Fight Misty over the gym's own pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Headless tools, all against a real imported cache:
 | `validate_vermilion.gd` | the Vermilion port passage's stair pair, the cut tree sealing the gym yard, the gym door's one approach, and the gym's own lack of a scene or callback, in all three games |
 | `validate_saffron.gd` | Route 6's dead-end north connection and the gate that carries the crossing, Saffron Gym's nine rooms and fifteen self-warp pairs, and the one chain of pads that reaches Sabrina, in all three games |
 | `validate_celadon.gd` | Saffron's dead-end west connection and its gate, Route 7's open connection onto Celadon, the city's only cut tree sealing the gym yard from either side, and Celadon Gym's three unavoidable sight lines, in all three games |
-| `validate_cerulean.gd` | the Route 5 gate out of Saffron, Cerulean's single east crossing, Route 9's entry pocket and the Pokecenter yard its one cut tree opens, and the Power Plant's edgeless region, the buoy line that refuses a shore entry and the river that reaches it, in all three games |
+| `validate_cerulean.gd` | the Route 5 gate out of Saffron, Cerulean's single east crossing, Route 9's entry pocket and the Pokecenter yard its one cut tree opens, the Power Plant's edgeless region, the buoy line that refuses a shore entry and the river that reaches it, and Cerulean Gym's pool with the three swimmer approaches that cross it, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -14,9 +14,9 @@ const MOVEMENT_WALK: StringName = &"walk"
 const MOVEMENT_SURF: StringName = &"surf"
 const TRAINER_SHOCK_EMOTE: int = 0
 const TRAINER_SHOCK_FRAMES: int = 30
-const TRAINER_SLOW_STEP_FRAMES: int = 16
 ## StepVectors' normal-speed row: 2 pixels per frame for 8 frames, the source
-## duration for ordinary player walking (engine/overworld/map_objects.asm).
+## duration for ordinary player walking (engine/overworld/map_objects.asm). The
+## trainer approach shares it: see advance_trainer_approach_step().
 const STEP_FRAMES_WALK: int = 8
 ## A ledge hop is two chained STEP_WALK-duration cells back to back
 ## (engine/overworld/map_objects.asm's StepFunction_PlayerJump: .initjump/
@@ -1223,7 +1223,7 @@ func start_trainer_approach(
 	object.set_emote(TRAINER_SHOCK_EMOTE, true, TRAINER_SHOCK_FRAMES)
 	plan["emote_id"] = TRAINER_SHOCK_EMOTE
 	plan["emote_frames"] = TRAINER_SHOCK_FRAMES
-	plan["step_frames"] = TRAINER_SLOW_STEP_FRAMES
+	plan["step_frames"] = STEP_FRAMES_WALK
 	return plan
 
 
@@ -1255,22 +1255,33 @@ func trainer_approach_plan(
 	}
 
 
-## Applies one source slow-step from an already validated approach plan and
-## starts that object's presentation offset for the pacing caller to consume;
-## the object's cell is already the destination when this returns.
+## Applies one step from an already validated approach plan and starts that
+## object's presentation offset for the pacing caller to consume; the object's
+## cell is already the destination when this returns.
+##
+## Only the map bounds refuse, as in _apply_object_movement(): the approach is
+## `applymovementlasttalked wMovementBuffer` (engine/events/trainer_scripts.asm)
+## and its steps reach NormalStep (engine/overworld/movement.asm), which never
+## calls CanObjectMoveInDirection. That is what walks Cerulean Gym's swimmers
+## over their own pool.
+##
+## STEP_FRAMES_WALK, not the slow row: TrainerWalkToPlayer passes 1 in d and
+## `.GetPathToPlayer`'s `push de`/`pop af` hands it to
+## ComputePathToWalkToPlayer, whose `ld b, a` selects `.MovementData`'s `step`
+## row (engine/overworld/player_object.asm, home/movement.asm).
 func advance_trainer_approach_step(object_index: int, direction: Vector2i) -> Dictionary:
 	if current_map == null or object_index < 0 or object_index >= objects.size():
 		return {"ok": false, "reason": &"invalid_trainer_object"}
 	var object: Gen2WorldObject = objects[object_index]
 	var destination: Vector2i = object.cell + direction
 	object.apply_direction(direction)
-	if not can_object_walk_to(destination, object, direction):
+	if not _cell_in_bounds(destination):
 		return {
 			"ok": false, "reason": &"movement_blocked",
 			"object_index": object_index, "cell": destination,
 		}
 	object.cell = destination
-	object.start_step(direction, TRAINER_SLOW_STEP_FRAMES)
+	object.start_step(direction, STEP_FRAMES_WALK)
 	var key: String = _object_key(current_map.group, current_map.number, object_index)
 	_object_position_overrides[key] = object.cell
 	_object_facing_overrides[key] = object.facing
@@ -2966,6 +2977,10 @@ func _remember_object_position(object: Gen2WorldObject) -> void:
 	_object_facing_overrides[key] = object.facing
 
 
+## Follower steps commit on the map bounds alone, for the same reason a scripted
+## step and a trainer approach do: MovementFunction_Follow is HandleMovementData
+## over the queued leader commands (engine/overworld/map_objects.asm), so every
+## one of them lands in NormalStep and never reaches CanObjectMoveInDirection.
 func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictionary) -> void:
 	var relations: Array = []
 	for key: String in _object_followers:
@@ -3010,11 +3025,12 @@ func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictiona
 		else:
 			direction = Vector2i(0, signi(delta.y))
 		var destination: Vector2i = follower.cell + direction
-		if can_object_walk_to(destination, follower, direction):
+		if _cell_in_bounds(destination):
 			follower.cell = destination
 			follower.apply_direction(direction)
-			# A follower keeps pace with the player, so it takes the player's
-			# own walk duration rather than the slower wandering one.
+			# The player's own walk duration, not the slower wandering one:
+			# QueueFollowerFirstStep queues `movement_step` and the queue after
+			# it holds the leader's own command bytes.
 			follower.start_step(direction, STEP_FRAMES_WALK)
 			var override_key: String = _object_key(
 				current_map.group, current_map.number, follower_index

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -139,8 +139,8 @@ func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 	assert_true(saw_step)
 	# tick_step() decrements once per process call, the same rate the emote
 	# and movement-delay counters already use; the offset eases down to one
-	# sixteenth of a cell on the frame before the step formally ends.
-	assert_eq(lowest_magnitude, 1)
+	# STEP_FRAMES_WALK-th of a cell on the frame before the step formally ends.
+	assert_eq(lowest_magnitude, Gen2WorldAPI.CELL_PIXELS / Gen2WorldAPI.STEP_FRAMES_WALK)
 
 
 func test_victory_displays_imported_text_reloads_objects_and_keeps_player_cell() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3522,6 +3522,48 @@ func test_real_trainer_metadata_runs_seen_text_battle_and_beaten_flag() -> void:
 	assert_eq(after_battle[0]["source"]["script"], 0x6040)
 
 
+## The approach is `applymovementlasttalked wMovementBuffer`, so every step
+## reaches NormalStep (engine/overworld/movement.asm) and no permission stands
+## between a seen trainer and the cell beside the player. Cerulean Gym is what
+## needs it: its three swimmers stand on the pool.
+func test_trainer_approach_crosses_water_a_wandering_object_could_not() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(8, 5))
+	var trainer: Gen2WorldObject = world.objects[0]
+	trainer.cell = Vector2i(8, 8)
+	trainer.object_type = Gen2WorldObject.OBJECTTYPE_TRAINER
+	assert_eq(world.collision_permission_at(Vector2i(8, 7)), Gen2WorldCollision.WATER_TILE)
+	assert_false(world.can_object_walk_to(Vector2i(8, 7), trainer, Vector2i.UP))
+
+	var plan: Dictionary = world.trainer_approach_plan(0, Vector2i.UP, 3)
+	assert_true(plan["ok"], JSON.stringify(plan))
+	assert_eq(plan["target_cell"], Vector2i(8, 6))
+	assert_eq(plan["path"], [Vector2i.UP, Vector2i.UP])
+
+	var crossed: Dictionary = world.advance_trainer_approach_step(0, Vector2i.UP)
+	assert_true(crossed["ok"], JSON.stringify(crossed))
+	assert_eq(trainer.cell, Vector2i(8, 7))
+	# TrainerWalkToPlayer passes 1 to ComputePathToWalkToPlayer, which selects
+	# `step` rather than `slow_step`: StepVectors' normal row, 8 frames.
+	assert_eq(trainer.step_frames_total, Gen2WorldAPI.STEP_FRAMES_WALK)
+	assert_true(world.advance_trainer_approach_step(0, Vector2i.UP)["ok"])
+	assert_eq(trainer.cell, Vector2i(8, 6))
+
+
+## Only GetNextTile's own bounds refuse, the same limit _apply_object_movement()
+## keeps for a scripted step.
+func test_trainer_approach_step_refuses_only_outside_the_map() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(8, 5))
+	var trainer: Gen2WorldObject = world.objects[0]
+	trainer.cell = Vector2i(8, 0)
+	trainer.object_type = Gen2WorldObject.OBJECTTYPE_TRAINER
+
+	var refused: Dictionary = world.advance_trainer_approach_step(0, Vector2i.UP)
+	assert_false(refused["ok"])
+	assert_eq(refused["reason"], &"movement_blocked")
+	assert_eq(refused["cell"], Vector2i(8, -1))
+	assert_eq(trainer.cell, Vector2i(8, 0))
+
+
 ## StartBattleWithMapTrainerScript (engine/events/trainer_scripts.asm) falls
 ## through into AlreadyBeatenTrainerScript's scripttalkafter with
 ## wRunningTrainerBattleScript set, so the after-battle script runs at once and

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -450,6 +450,10 @@ const POWER_PLANT_MANAGER_FACE: Vector2i = Vector2i(14, 11)
 ## `maps/CeruleanCity.asm` warp 5 and the gym's own exit.
 const CERULEAN_GYM_DOOR: Vector2i = Vector2i(30, 23)
 const CERULEAN_GYM_EXIT: Vector2i = Vector2i(4, 15)
+## `maps/CeruleanGym.asm`: Misty on (5,3), faced from the pool's north bank.
+## ENGINE_CASCADEBADGE's place in source badge order.
+const MISTY_FACE: Vector2i = Vector2i(5, 4)
+const BADGE_CASCADE: int = 9
 ## The MACHINE_PART the Route 24 grunt says he dropped in the gym pool. Its own
 ## cell is water, so it is faced from the bank directly above it.
 const MACHINE_PART_APPROACH: Vector2i = Vector2i(3, 7)
@@ -464,6 +468,9 @@ const EVENT_RETURNED_MACHINE_PART: int = 201
 const EVENT_MET_MANAGER_AT_POWER_PLANT: int = 202
 const EVENT_RESTORED_POWER_TO_KANTO: int = 205
 const EVENT_TRAINERS_IN_CERULEAN_GYM: int = 1903
+## The three swimmer flags `CeruleanGymMistyScript` sets itself, and her own.
+const EVENT_BEAT_MISTY: int = 1222
+const CERULEAN_GYM_TRAINER_FLAGS: Array[int] = [1017, 1018, 1448]
 ## constants/item_constants.asm.
 const ITEM_MACHINE_PART: int = 0x80
 
@@ -5575,13 +5582,6 @@ func _cerulean_approach_path(
 ## the pool, the pool holds the MACHINE_PART, the manager takes it back, and only
 ## Route 25's date puts Misty in her gym. Two of those steps are at the plant, so
 ## the river is ridden twice each way.
-##
-## The walk stops with Misty in her gym and unfought. Her three swimmers stand on
-## the pool, and `can_object_walk_to()` accepts LAND_TILE only, so a swimmer that
-## sees the player cannot complete the source approach and the sight request
-## fails with `movement_blocked`. `CanObjectMoveInDirection` branches on
-## SWIMMING_F and calls WillObjectBumpIntoLand instead, but nothing imports which
-## sprites swim, so the branch has no input yet.
 func _machine_part_errand(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5632,6 +5632,67 @@ func _machine_part_errand(
 		return {"ok": false, "path": path, "reason": "the machine part was not handed over"}
 	if world.event_flag_active(EVENT_TRAINERS_IN_CERULEAN_GYM):
 		return {"ok": false, "path": path, "reason": "Misty is still hidden"}
+	return _cerulean_gym_leg(world, save, random, data, path)
+
+
+## Misty, once the errand has put her in her gym.
+##
+## The gym is a pool with the leader on an island, and its trainers are what the
+## walk has to answer: Swimmer Diana watches the one row every route to Misty
+## crosses, and Swimmers Parker and Briana watch the pool's two alternative
+## columns, so one of the pair is met whichever way round it goes. All three stand
+## on water and walk over it to reach the player, which the cartridge allows
+## because `SeenByTrainerScript` is `applymovementlasttalked` and its steps reach
+## `NormalStep`, checking no permission. `tools/validate_cerulean.gd` pins the
+## geometry and each approach.
+##
+## Misty herself sets all three of their beaten flags along with her own, the way
+## Surge, Erika and Sabrina do, so they are reported rather than gated on.
+func _cerulean_gym_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_gym: Dictionary = _warp_chain(world, save, random, data, [CERULEAN_GYM_DOOR])
+	if not bool(into_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Cerulean Gym door failed: %s" % into_gym.get("reason", ""),
+		}
+	var misty: Dictionary = _talk_to(
+		world, MISTY_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	var badge: int = Gen2WorldState.badge_flag(
+		BADGE_CASCADE, Gen2WorldState.is_crystal_profile(data)
+	)
+	var trainers_beaten: int = 0
+	for flag: int in CERULEAN_GYM_TRAINER_FLAGS:
+		if world.event_flag_active(flag):
+			trainers_beaten += 1
+	path.append({
+		"step": "cerulean_gym_misty",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"cascade_badge": world.state.is_engine_flag_active(badge),
+		"beat_misty": world.event_flag_active(EVENT_BEAT_MISTY),
+		"swimmer_flags": trainers_beaten,
+		"swimmers_fought": misty.get("encounters", []),
+		"run": misty,
+	})
+	if not bool(misty.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Misty did not finish: %s" % misty.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(badge):
+		return {"ok": false, "path": path, "reason": "ENGINE_CASCADEBADGE was not set"}
+	if trainers_beaten != CERULEAN_GYM_TRAINER_FLAGS.size():
+		return {
+			"ok": false, "path": path,
+			"reason": "Misty set %d of her three swimmer flags" % trainers_beaten,
+		}
 	return {"ok": true}
 
 

--- a/tools/validate_cerulean.gd
+++ b/tools/validate_cerulean.gd
@@ -25,6 +25,12 @@ extends SceneTree
 ## 56 and 57 and come out in Route 10 North's own lake, one step from the
 ## plant's shore.
 ##
+## The gym behind that errand is a pool. Its three swimmers stand on the water,
+## and the walk to Misty cannot avoid Diana's sight line or both of the other
+## two, so the badge needs approaches that cross water. They do, because
+## SeenByTrainerScript is `applymovementlasttalked` and NormalStep consults no
+## permission.
+##
 ##   Godot --headless --path . -s res://tools/validate_cerulean.gd
 
 const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
@@ -55,6 +61,32 @@ const CERULEAN_GYM_DOOR: Vector2i = Vector2i(30, 23)
 const CERULEAN_GYM_APPROACH: Vector2i = Vector2i(30, 24)
 const CERULEAN_EAST_EDGE: Vector2i = Vector2i(39, 22)
 const ROUTE_9_FROM_CERULEAN: Vector2i = Vector2i(0, 4)
+
+## Cerulean Gym: the door's landing, Misty and the cell she is faced from, and
+## the grunt whose own scene clears him off the ladder column.
+const CERULEAN_GYM_CELLS: Vector2i = Vector2i(10, 16)
+const CERULEAN_GYM_LANDING: Vector2i = Vector2i(4, 15)
+const MISTY_CELL: Vector2i = Vector2i(5, 3)
+const MISTY_FACE: Vector2i = Vector2i(5, 4)
+const EVENT_CERULEAN_GYM_ROCKET: int = 1901
+const EVENT_TRAINERS_IN_CERULEAN_GYM: int = 1903
+const CERULEAN_GYM_HIDDEN_OBJECTS: int = 5
+## The three swimmers, as object index, cell, sight range, the cell each sees the
+## player on, where its approach stops, the sight direction and its beaten flag.
+## Every stopping cell is water, which is the point: the pool is what the
+## approach crosses. Briana's is her own cell, since a sight distance of one
+## gives TrainerWalkToPlayer an empty movement buffer.
+const GYM_SWIMMERS: Array = [
+	[4, Vector2i(8, 9), 3, Vector2i(5, 9), Vector2i(6, 9), Vector2i.LEFT, 1448],
+	[2, Vector2i(4, 6), 3, Vector2i(7, 6), Vector2i(6, 6), Vector2i.RIGHT, 1017],
+	[3, Vector2i(1, 9), 1, Vector2i(2, 9), Vector2i(1, 9), Vector2i.RIGHT, 1018],
+]
+## Diana's is the one sight line no walk to Misty can avoid. Parker's and
+## Briana's guard the pool's two alternative columns, so shutting either leaves
+## the other open while shutting both seals Misty off: one of the pair is always
+## fought, whichever way round the pool the walk goes.
+const GYM_SIGHT_UNAVOIDABLE: Array[int] = [2]
+const GYM_SIGHT_ALTERNATIVES: Array[int] = [4, 3]
 
 ## Route 9's entry pocket, its one blocking tree, and what cutting it opens.
 ## $12 is CheckCutCollision's tree; the four grass codes on this route are
@@ -109,6 +141,7 @@ func _initialize() -> void:
 			continue
 		_verify_route_5_gate(data, game_id)
 		_verify_cerulean(data, game_id)
+		_verify_cerulean_gym(data, game_id)
 		_verify_route_9_dead_end(data, game_id)
 		_verify_power_plant_is_reached_by_river(data, game_id)
 	_finish()
@@ -189,22 +222,207 @@ func _verify_cerulean(data: GameData, game_id: StringName) -> void:
 		]
 	)
 
-	# The gym's own four hide-flagged objects, which is what makes the badge an
-	# errand rather than a walk.
-	var gym: Gen2WorldAPI = _open(data, CERULEAN_GROUP, CERULEAN_GYM, Vector2i(4, 15))
+	print("%s cerulean: one east crossing onto Route 9." % game_id)
+
+
+## The gym, which is a pool with three swimmers standing on it.
+##
+## Five of its six objects hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, which is
+## what makes the badge an errand; the sixth is the grunt, whose own scene takes
+## him off the ladder column. The load-bearing part is the last: no walk to Misty
+## avoids Diana's sight line or both of the other two, and every approach stops
+## on water that `can_object_walk_to()` refuses. They resolve anyway, because
+## SeenByTrainerScript is `applymovementlasttalked` and every step in that buffer
+## reaches NormalStep, which consults no permission at all.
+func _verify_cerulean_gym(data: GameData, game_id: StringName) -> void:
+	var gym: Gen2WorldAPI = _open(data, CERULEAN_GROUP, CERULEAN_GYM, CERULEAN_GYM_LANDING)
 	if gym == null:
 		return
-	var hidden: int = 0
-	for row: Dictionary in gym.current_map.events.get("objects", []):
-		if int(row.get("event_flag", -1)) == 1903:
-			hidden += 1
 	_check(
-		hidden == 5,
-		"%s: %d Cerulean Gym objects hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, not 5." % [
-			game_id, hidden,
+		gym.map_size_cells() == CERULEAN_GYM_CELLS,
+		"%s: Cerulean Gym is %s cells, not the pinned %s." % [
+			game_id, gym.map_size_cells(), CERULEAN_GYM_CELLS,
 		]
 	)
-	print("%s cerulean: one east crossing, and a gym of five objects behind one hide flag." % game_id)
+	var hidden: int = 0
+	for row: Dictionary in gym.current_map.events.get("objects", []):
+		if int(row.get("event_flag", -1)) == EVENT_TRAINERS_IN_CERULEAN_GYM:
+			hidden += 1
+	_check(
+		hidden == CERULEAN_GYM_HIDDEN_OBJECTS,
+		"%s: %d gym objects hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, not %d." % [
+			game_id, hidden, CERULEAN_GYM_HIDDEN_OBJECTS,
+		]
+	)
+	_check(
+		gym.collision_permission_at(MISTY_CELL) == Gen2WorldCollision.LAND_TILE
+			and (gym.objects[1] as Gen2WorldObject).cell == MISTY_CELL,
+		"%s: Misty does not stand on land at %s." % [game_id, MISTY_CELL]
+	)
+	for swimmer: Array in GYM_SWIMMERS:
+		var object: Gen2WorldObject = gym.objects[swimmer[0]]
+		_check(
+			object.cell == swimmer[1] and object.sight_range == swimmer[2]
+				and object.object_type == Gen2WorldObject.OBJECTTYPE_TRAINER,
+			"%s: swimmer %d is %s with sight %d, not %s with %d." % [
+				game_id, swimmer[0], object.cell, object.sight_range, swimmer[1], swimmer[2],
+			]
+		)
+		# Misty sets all three herself, the way Surge, Erika and Sabrina do.
+		_check(
+			int(object.trainer_data.get("event_flag", -1)) == int(swimmer[6]),
+			"%s: swimmer %d's beaten flag is %s, not %d." % [
+				game_id, swimmer[0], object.trainer_data.get("event_flag", -1), swimmer[6],
+			]
+		)
+		for cell: Vector2i in [swimmer[1], swimmer[4]]:
+			_check(
+				gym.collision_permission_at(cell) == Gen2WorldCollision.WATER_TILE,
+				"%s: %s is not water, so swimmer %d proves nothing." % [
+					game_id, cell, swimmer[0],
+				]
+			)
+		_check(
+			not gym.can_object_walk_to(swimmer[4], object, swimmer[5]),
+			"%s: swimmer %d could wander onto %s, so the approach is not the check."
+				% [game_id, swimmer[0], swimmer[4]]
+		)
+
+	# The grunt is gone by the time the badge is walked, so the walk is measured
+	# with his flag set, the way the errand leaves it.
+	var walked: Gen2WorldAPI = _open_gym_after_the_grunt(data)
+	if walked == null:
+		return
+	var region: Dictionary = _region(walked, CERULEAN_GYM_LANDING)
+	_check(
+		region.has(MISTY_FACE),
+		"%s: the gym door cannot reach %s, so Misty cannot be faced." % [game_id, MISTY_FACE]
+	)
+	# Which sight lines a walk to Misty cannot route around, checked by shutting
+	# seen cells rather than by naming a path.
+	var alternatives: Dictionary = {}
+	for swimmer: Array in GYM_SWIMMERS:
+		var avoidable: bool = _region(walked, CERULEAN_GYM_LANDING, {swimmer[3]: true}).has(
+			MISTY_FACE
+		)
+		if int(swimmer[0]) in GYM_SIGHT_ALTERNATIVES:
+			alternatives[swimmer[3]] = true
+		_check(
+			avoidable == (int(swimmer[0]) not in GYM_SIGHT_UNAVOIDABLE),
+			"%s: shutting swimmer %d's %s %s Misty, which is the wrong way round." % [
+				game_id, swimmer[0], swimmer[3],
+				"still reaches" if avoidable else "seals off",
+			]
+		)
+		# Every one of the three is seen from its own cell, avoidable or not, so
+		# the sight lines themselves are pinned either way, and each approach is
+		# driven whether or not the walk has to take it.
+		var probe: Gen2WorldAPI = _open_gym_after_the_grunt(data, swimmer[3])
+		if probe == null:
+			continue
+		var sight: Array = probe.dispatch_sight_events()
+		_check(
+			not sight.is_empty() and int(
+				(sight[0].get("source", {}) as Dictionary).get("object_index", -1)
+			) == int(swimmer[0]),
+			"%s: swimmer %d does not see the player on %s." % [
+				game_id, swimmer[0], swimmer[3],
+			]
+		)
+		_verify_swimmer_approach(data, game_id, swimmer)
+	_check(
+		not _region(walked, CERULEAN_GYM_LANDING, alternatives).has(MISTY_FACE),
+		"%s: Misty is reachable past both %s, so neither swimmer has to be fought."
+			% [game_id, alternatives.keys()]
+	)
+	print(
+		"%s cerulean gym: a pool, five hidden objects, three approaches over it and Diana unavoidable."
+		% game_id
+	)
+
+
+## One swimmer's whole sight-to-approach sequence, driven through the runtime the
+## world screen and the story preview both use.
+func _verify_swimmer_approach(data: GameData, game_id: StringName, swimmer: Array) -> void:
+	var index: int = int(swimmer[0])
+	var world: Gen2WorldAPI = _open_gym_after_the_grunt(data, swimmer[3])
+	if world == null:
+		return
+	var swimmer_object: Gen2WorldObject = world.objects[index]
+	var sight: Array = world.dispatch_sight_events()
+	if not _check(
+		not sight.is_empty(),
+		"%s: nobody sees the player on %s." % [game_id, swimmer[3]]
+	):
+		return
+	var source: Dictionary = sight[0].get("source", {})
+	_check(
+		int(source.get("object_index", -1)) == index
+			and int(source.get("distance", -1)) == int(swimmer[2])
+			and source.get("direction", Vector2i.ZERO) == swimmer[5],
+		"%s: %s is seen as %s, not by swimmer %d at distance %d facing %s." % [
+			game_id, swimmer[3], source, index, swimmer[2], swimmer[5],
+		]
+	)
+	var approach: Array = world.complete_runtime_request({"ok": true, "audio_played": false})
+	_check(
+		not approach.is_empty() and StringName(
+			((approach[0].get("event", {}) as Dictionary).get("request", {}) as Dictionary)
+				.get("kind", &"")
+		) == &"trainer_approach_requested",
+		"%s: swimmer %d's encounter music did not reach the approach request."
+			% [game_id, index]
+	)
+	var plan: Dictionary = world.start_trainer_approach(index, swimmer[5], int(swimmer[2]))
+	if not _check(
+		bool(plan.get("ok", false)),
+		"%s: swimmer %d's approach plan failed: %s" % [game_id, index, plan]
+	):
+		return
+	_check(
+		plan.get("target_cell", Vector2i.ZERO) == swimmer[4],
+		"%s: swimmer %d stops on %s, not %s." % [
+			game_id, index, plan.get("target_cell", Vector2i.ZERO), swimmer[4],
+		]
+	)
+	for step_direction: Vector2i in plan.get("path", []):
+		var step: Dictionary = world.advance_trainer_approach_step(index, step_direction)
+		if not _check(
+			bool(step.get("ok", false)),
+			"%s: swimmer %d's step %s failed: %s" % [game_id, index, step_direction, step]
+		):
+			return
+		_check(
+			swimmer_object.step_frames_total == Gen2WorldAPI.STEP_FRAMES_WALK,
+			"%s: swimmer %d steps over %d frames, not %d." % [
+				game_id, index, swimmer_object.step_frames_total, Gen2WorldAPI.STEP_FRAMES_WALK,
+			]
+		)
+	_check(
+		swimmer_object.cell == swimmer[4],
+		"%s: swimmer %d ended on %s, not %s." % [
+			game_id, index, swimmer_object.cell, swimmer[4],
+		]
+	)
+	_check(
+		bool(world.finish_trainer_approach(index).get("ok", false)),
+		"%s: swimmer %d's approach could not finish." % [game_id, index]
+	)
+
+
+func _open_gym_after_the_grunt(
+	data: GameData, cell: Vector2i = CERULEAN_GYM_LANDING
+) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	state.set_event_flag(EVENT_CERULEAN_GYM_ROCKET, true)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, CERULEAN_GROUP, CERULEAN_GYM, cell, state
+	)
+	if world == null:
+		_fail("Cerulean Gym is missing.")
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
 
 
 ## Route 9's entry pocket, and the fact that its one cut tree opens onto a yard
@@ -497,7 +715,12 @@ func _crossings(
 ## Ledge hops included, mirroring `tools/preview_world_story.gd`'s
 ## _reachable_step(): a region drawn without them would claim walls that a real
 ## walk can cross, which is exactly the mistake these counts are here to catch.
-func _region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
+##
+## [param closed] cells are treated as unwalkable, which is how an unavoidable
+## cell is proved: shut it and see what stops being reachable.
+func _region(
+	world: Gen2WorldAPI, start: Vector2i, closed: Dictionary = {}
+) -> Dictionary:
 	var seen: Dictionary = {start: true}
 	var frontier: Array[Vector2i] = [start]
 	var size: Vector2i = world.map_size_cells()
@@ -513,7 +736,7 @@ func _region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
 				next = cell + direction * 2
 				if next.x < 0 or next.y < 0 or next.x >= size.x or next.y >= size.y:
 					continue
-			if seen.has(next):
+			if seen.has(next) or closed.has(next):
 				continue
 			seen[next] = true
 			frontier.append(next)
@@ -532,7 +755,7 @@ func _fail(message: String) -> void:
 
 func _finish() -> void:
 	if _failures.is_empty():
-		print("PASS cerulean: the Route 5 gate, the city's one east crossing and the river into the Power Plant verified.")
+		print("PASS cerulean: the Route 5 gate, the city's one east crossing, the river into the Power Plant and the gym's pool verified.")
 		quit(0)
 		return
 	for failure: String in _failures:


### PR DESCRIPTION
The trainer approach was gated on can_object_walk_to(), which no source path puts in its way: SeenByTrainerScript is applymovementlasttalked and every step in that buffer reaches NormalStep, which consults no permission. Only the map bounds refuse now, so Cerulean Gym's three swimmers walk over the water they stand on, and the walked route takes the Cascade Badge.

The step duration was the 16-frame slow row. TrainerWalkToPlayer passes 1 in d, which ComputePathToWalkToPlayer uses to select .MovementData's `step` row, so it is StepVectors' 8-frame normal one. Follower steps had the same permission gate and lose it for the same reason, MovementFunction_Follow being HandleMovementData over the leader's own queued commands.

validate_cerulean.gd now pins the gym: the pool, Misty's island, the three swimmers' cells, sight ranges and beaten flags, which sight lines a walk to her cannot avoid, and each approach driven across the water.