### PR TITLE
Bring the launcher up to a full feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ godot --headless --path . --quit-after 30
 ```
 
 The launcher lists Gold, Silver and Crystal cache status, imports a selected
-ROM, and opens its save screen: three validated slots, `.sav` import, party
-inspection and the development battle. A new game starts with an empty party at
+ROM, and opens its save screen: validated save slots created as you need them,
+naming, export and import, `.sav` import, party inspection and the development
+battle. A new game starts with an empty party at
 the Crystal home spawn with source starting money; Elm's imported lab scripts
 offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry. Continue enters
 the overworld and F5 saves its map, inventory, event and clock snapshot. See

--- a/README.md
+++ b/README.md
@@ -153,11 +153,17 @@ godot --headless --path . --quit-after 30
 The launcher lists Gold, Silver and Crystal cache status, imports a selected
 ROM, and opens its save screen: validated save slots created as you need them,
 naming, export and import, `.sav` import, party inspection and the development
-battle. A new game starts with an empty party at
-the Crystal home spawn with source starting money; Elm's imported lab scripts
-offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry. Continue enters
-the overworld and F5 saves its map, inventory, event and clock snapshot. See
-[docs/SAVES.md](docs/SAVES.md) for the save and SRAM contract.
+battle, plus a save editor for party, boxes, bag, flags, position and dex that
+cannot produce a save the game will not load. A new game starts with an empty
+party at the Crystal home spawn with source starting money; Elm's imported lab
+scripts offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry.
+Continue enters the overworld and F5 saves its map, inventory, event and clock
+snapshot. See [docs/SAVES.md](docs/SAVES.md) for the save and SRAM contract.
+
+It also carries settings, split into the cartridge's own OPTION values and
+application ones; a mod list where each mod can be switched off without being
+uninstalled; per-cartridge re-import, cache folder and cache deletion; and a
+release check that runs only when you ask for it.
 
 Development scenes:
 

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -69,7 +69,7 @@ func selected_data() -> GameData:
 
 
 func select_save_slot(game_id: StringName, slot: int) -> bool:
-	if slot < 0 or slot >= Gen2SaveStore.SLOT_COUNT:
+	if slot < 0 or slot >= Gen2SaveStore.MAX_SLOTS:
 		return false
 	if not select_game(game_id):
 		return false

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -13,6 +13,14 @@ is cartridge content through `GameData` or live world state through
 exists, creating `user://mods/` when it is absent. The launcher lists what
 loaded and names anything it refused.
 
+A mod can be switched off without uninstalling it. `Gen2ModState` keeps the
+disabled ids in `user://mods_disabled.json`, and only `load_discovered()`
+consults them: a disabled mod is still discovered and still listed, it just
+does not run, and that is not a refusal. Disabled ids are stored rather than
+enabled ones, so a newly installed mod runs without an entry being written for
+it and a damaged file means everything runs rather than nothing. Uninstalling
+drops the id, so reinstalling later does not find it silently off.
+
 ## Layout
 
 ```

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -28,20 +28,26 @@ Save format version 2 stores:
 
 Derived battle stats are recalculated on load. Volatile state, including stages,
 confusion, recharge, Disable, Encore, Fly, Dig, Rollout and rampage, is never
-saved. The validator checks the selected `GameData`; three JSON slots exist per
-game revision under `user://save_slots`. Box names, current-box UI state and
-cartridge SRAM box placement are intentionally outside this model.
+saved. The validator checks the selected `GameData`. Slots live under
+`user://save_slots` per game revision and are created on demand rather than
+preallocated, up to `Gen2SaveStore.MAX_SLOTS`; a slot number is still its file
+name, so slots written before this stay where they were. Each save carries its
+own `label`, the player's name for the slot, so an exported file names itself;
+an empty label means fall back to the player name. Box names, current-box UI
+state and cartridge SRAM box placement are intentionally outside this model.
 
-Version 1 project saves migrate in memory by adding fourteen empty boxes. The
-migration preserves a missing world snapshot as missing; it does not invent a
-map, player position or event state. The next successful save writes version 2.
+Older project saves migrate in memory one version step at a time: version 1
+gains fourteen empty boxes, version 2 gains an empty label. Migration preserves
+a missing world snapshot as missing; it does not invent a map, player position
+or event state. The next successful save writes version 3.
 
 ## Player flow
 
 The launcher selects an imported cache and opens `game/save/save_screen.tscn`.
-It shows three slots as `EMPTY`, `READY` or `INCOMPATIBLE`, and rejects failed
-`.sav` imports before calling `Gen2SaveStore.save`, so partial data cannot
-replace a slot.
+It lists the slots that exist as `READY` or `INCOMPATIBLE`, offers a new one at
+the lowest free number, and rejects failed `.sav` imports before calling
+`Gen2SaveStore.save`, so partial data cannot replace a slot. A game with no
+saves lists none and has nothing selected.
 
 New games accept up to ten encoded characters and start with an empty party,
 matching Crystal's new-game initialization. When the source home map exists,
@@ -104,9 +110,13 @@ file, a bad header or checksum, invalid JSON, a failed migration or a validator
 rejection. When both fail, the primary's message is reported. A slot counts as
 occupied while either copy exists, so a lost primary cannot present itself as an
 empty slot that a new game would overwrite. Unlike `TryLoadSaveFile`, a load
-never repairs the weak copy, because drawing the slot menu loads all three
-slots; the next save rewrites both. Slots written before the header existed load
-unchecked.
+never repairs the weak copy, because drawing the slot menu loads every slot;
+the next save rewrites both. Slots written before the header existed load
+unchecked, which is also how an exported file with no header is accepted.
+
+Export copies a slot file verbatim, header included. Import reads one back,
+refuses a save recorded against another cartridge, and lands it in the lowest
+free slot with that number written into the copy.
 
 ## Original Generation 2 shape
 

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -491,7 +491,9 @@ func _save_slot_detail(game_id: StringName, data: GameData) -> String:
 			ready_slots += 1
 		elif row["exists"]:
 			incompatible += 1
-	var detail: String = "%d/%d slots ready" % [ready_slots, Gen2SaveStore.SLOT_COUNT]
+	if slots.is_empty():
+		return "No saves yet"
+	var detail: String = "%d of %d saves ready" % [ready_slots, slots.size()]
 	if incompatible > 0:
 		detail += ", %d incompatible" % incompatible
 	return detail

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -29,9 +29,17 @@ var _mods_label: Label = null
 var _mod_button: Button = null
 var _index_button: Button = null
 var _index_dialog: Gen2ModIndexDialog = null
+var _settings_dialog: Gen2SettingsDialog = null
+var _mods_dialog: Gen2ModsDialog = null
+var _manage_dialog: AcceptDialog = null
+var _manage_body: VBoxContainer = null
+var _update_http: HTTPRequest = null
 var _cards: Dictionary = {}
 var _selected_game_id: StringName = &""
 var _importing: bool = false
+## The game a re-import is replacing, so a cache is only overwritten by a dump
+## of the cartridge it already holds.
+var _reimport_game_id: StringName = &""
 
 
 func _ready() -> void:
@@ -50,17 +58,17 @@ func _build_ui() -> void:
 	var margin := MarginContainer.new()
 	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	margin.add_theme_constant_override("margin_left", 64)
-	margin.add_theme_constant_override("margin_top", 46)
+	margin.add_theme_constant_override("margin_top", 30)
 	margin.add_theme_constant_override("margin_right", 64)
-	margin.add_theme_constant_override("margin_bottom", 42)
+	margin.add_theme_constant_override("margin_bottom", 24)
 	add_child(margin)
 
 	var content := VBoxContainer.new()
 	content.add_theme_constant_override("separation", 18)
 	margin.add_child(content)
 
-	var header := HBoxContainer.new()
-	header.add_theme_constant_override("separation", 20)
+	var header := VBoxContainer.new()
+	header.add_theme_constant_override("separation", 12)
 	content.add_child(header)
 
 	var heading := VBoxContainer.new()
@@ -71,7 +79,7 @@ func _build_ui() -> void:
 	var title := Label.new()
 	title.text = "gen2recomp"
 	title.add_theme_color_override("font_color", TEXT)
-	title.add_theme_font_size_override("font_size", 38)
+	title.add_theme_font_size_override("font_size", 30)
 	heading.add_child(title)
 
 	var subtitle := Label.new()
@@ -80,20 +88,42 @@ func _build_ui() -> void:
 	subtitle.add_theme_font_size_override("font_size", 16)
 	heading.add_child(subtitle)
 
+	# Wrapping, because the row outgrew the window once the settings, mods and
+	# update actions joined it.
+	var toolbar := HFlowContainer.new()
+	toolbar.add_theme_constant_override("h_separation", 12)
+	toolbar.add_theme_constant_override("v_separation", 8)
+	header.add_child(toolbar)
+
 	_import_button = _button("Import ROM", ACCENT)
 	_import_button.custom_minimum_size = Vector2(168, 48)
 	_import_button.pressed.connect(_open_import_dialog)
-	header.add_child(_import_button)
+	toolbar.add_child(_import_button)
 
 	_mod_button = _button("Import mod", MUTED)
 	_mod_button.custom_minimum_size = Vector2(168, 48)
 	_mod_button.pressed.connect(_open_mod_dialog)
-	header.add_child(_mod_button)
+	toolbar.add_child(_mod_button)
 
 	_index_button = _button("Mod index", MUTED)
 	_index_button.custom_minimum_size = Vector2(168, 48)
 	_index_button.pressed.connect(_open_index_dialog)
-	header.add_child(_index_button)
+	toolbar.add_child(_index_button)
+
+	var mods_button: Button = _button("Mods", MUTED)
+	mods_button.custom_minimum_size = Vector2(120, 48)
+	mods_button.pressed.connect(_open_mods_dialog)
+	toolbar.add_child(mods_button)
+
+	var settings_button: Button = _button("Settings", MUTED)
+	settings_button.custom_minimum_size = Vector2(120, 48)
+	settings_button.pressed.connect(_open_settings_dialog)
+	toolbar.add_child(settings_button)
+
+	var updates_button: Button = _button("Check for updates", MUTED)
+	updates_button.custom_minimum_size = Vector2(180, 48)
+	updates_button.pressed.connect(check_for_updates)
+	toolbar.add_child(updates_button)
 
 	var section := Label.new()
 	section.text = "CARTRIDGES"
@@ -102,7 +132,7 @@ func _build_ui() -> void:
 	content.add_child(section)
 
 	var scroll := ScrollContainer.new()
-	scroll.custom_minimum_size = Vector2(0, 216)
+	scroll.custom_minimum_size = Vector2(0, 250)
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	content.add_child(scroll)
@@ -115,7 +145,7 @@ func _build_ui() -> void:
 
 	var status_panel := PanelContainer.new()
 	status_panel.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 10))
-	status_panel.custom_minimum_size = Vector2(0, 78)
+	status_panel.custom_minimum_size = Vector2(0, 62)
 	content.add_child(status_panel)
 
 	var status_box := VBoxContainer.new()
@@ -193,6 +223,27 @@ func _build_ui() -> void:
 	_index_dialog = Gen2ModIndexDialog.new()
 	_index_dialog.mod_installed.connect(_on_index_mod_installed)
 	add_child(_index_dialog)
+
+	_settings_dialog = Gen2SettingsDialog.new()
+	add_child(_settings_dialog)
+
+	_mods_dialog = Gen2ModsDialog.new()
+	_mods_dialog.mods_changed.connect(func() -> void: _mods_label.text = _mods_summary())
+	add_child(_mods_dialog)
+
+	_manage_dialog = AcceptDialog.new()
+	_manage_dialog.ok_button_text = "Close"
+	_manage_body = VBoxContainer.new()
+	_manage_body.custom_minimum_size = Vector2(460, 0)
+	_manage_dialog.add_child(_manage_body)
+	add_child(_manage_dialog)
+
+	# Created once and reused. The check only ever runs from the button: it
+	# reaches a third party and says this build exists, so it is the player's
+	# act and never a side effect of opening the launcher.
+	_update_http = HTTPRequest.new()
+	_update_http.request_completed.connect(_on_update_response)
+	add_child(_update_http)
 
 	# A window drop is the same import, so the OS file manager works wherever it
 	# offers one. Routing is by extension because the two imports validate very
@@ -272,6 +323,119 @@ func _open_index_dialog() -> void:
 	_index_dialog.popup_centered(Vector2i(720, 560))
 
 
+func _open_settings_dialog() -> void:
+	if _importing:
+		return
+	_settings_dialog.popup_centered()
+
+
+func _open_mods_dialog() -> void:
+	if _importing:
+		return
+	_mods_dialog.refresh()
+	_mods_dialog.popup_centered(Vector2i(640, 420))
+
+
+## Asks the release API what the latest version is. Public so a test can drive
+## the request path without a button press.
+func check_for_updates() -> void:
+	if _importing or _update_http == null:
+		return
+	_set_status("Checking for updates...", Gen2UpdateCheck.RELEASES_API, MUTED)
+	var headers: PackedStringArray = PackedStringArray([
+		"Accept: application/vnd.github+json",
+	])
+	if _update_http.request(Gen2UpdateCheck.RELEASES_API, headers) != OK:
+		_set_status("The update check could not start.", "No request was made.", ERROR)
+
+
+func _on_update_response(
+	result: int, code: int, _headers: PackedStringArray, body: PackedByteArray
+) -> void:
+	if result != HTTPRequest.RESULT_SUCCESS:
+		_set_status(
+			"The update check did not reach the network.",
+			"This build is %s." % Gen2UpdateCheck.current_version(),
+			ERROR,
+		)
+		return
+	var status: Dictionary = Gen2UpdateCheck.status_for(code, body.get_string_from_utf8())
+	var colour: Color = MUTED
+	match int(status["status"]):
+		Gen2UpdateCheck.Status.UPDATE_AVAILABLE:
+			colour = ACCENT
+		Gen2UpdateCheck.Status.UP_TO_DATE:
+			colour = SUCCESS
+		Gen2UpdateCheck.Status.UNREADABLE:
+			colour = ERROR
+	_set_status(
+		Gen2UpdateCheck.describe(status),
+		String(status.get("url", Gen2UpdateCheck.RELEASES_PAGE)),
+		colour,
+	)
+
+
+func _open_manage_dialog(game_id: StringName) -> void:
+	if _importing:
+		return
+	var data: GameData = GameData.open(game_id)
+	_manage_dialog.title = "Manage %s" % RomRegistry.title_for(game_id)
+	for child: Node in _manage_body.get_children():
+		child.queue_free()
+
+	var state := Label.new()
+	state.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	state.text = (
+		"The cartridge for this game is imported and verified."
+		if data != null else "No cache exists for this game yet."
+	)
+	_manage_body.add_child(state)
+
+	var directory := Label.new()
+	directory.text = RomCache.directory_for(game_id, RomRegistry.sha1_for(game_id))
+	directory.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_manage_body.add_child(directory)
+
+	var reimport: Button = _button("Re-import ROM" if data != null else "Import ROM", ACCENT)
+	reimport.pressed.connect(func() -> void:
+		_reimport_game_id = game_id
+		_manage_dialog.hide()
+		_open_import_dialog()
+	)
+	_manage_body.add_child(reimport)
+
+	if data != null:
+		var open_folder: Button = _button("Open cache folder", TEXT)
+		open_folder.pressed.connect(func() -> void: _open_cache_folder(game_id))
+		_manage_body.add_child(open_folder)
+
+		var delete: Button = _button("Delete cache", ERROR)
+		delete.pressed.connect(func() -> void: _delete_cache(game_id))
+		_manage_body.add_child(delete)
+
+	_manage_dialog.popup_centered()
+
+
+func _open_cache_folder(game_id: StringName) -> void:
+	var directory: String = RomCache.directory_for(game_id, RomRegistry.sha1_for(game_id))
+	OS.shell_open(ProjectSettings.globalize_path(directory))
+
+
+## Removes the decoded cartridge data and nothing else. Saves live under their
+## own root, so deleting a cache costs an import and no player progress.
+func _delete_cache(game_id: StringName) -> void:
+	RomCache.clear(RomCache.directory_for(game_id, RomRegistry.sha1_for(game_id)))
+	if _selected_game_id == game_id:
+		_selected_game_id = &""
+	_manage_dialog.hide()
+	_set_status(
+		"Removed the %s cache." % RomRegistry.title_for(game_id),
+		"Your saves were not touched. Import the cartridge again to play.",
+		MUTED,
+	)
+	_refresh_games()
+
+
 func _on_index_mod_installed(_id: StringName) -> void:
 	GameRuntime.load_mods()
 	_mods_label.text = _mods_summary()
@@ -327,7 +491,7 @@ func _create_game_card(game_id: StringName, data: GameData) -> PanelContainer:
 	var imported: bool = data != null
 	var selected: bool = game_id == _selected_game_id
 	var card := PanelContainer.new()
-	card.custom_minimum_size = Vector2(300, 202)
+	card.custom_minimum_size = Vector2(300, 218)
 	card.add_theme_stylebox_override(
 		"panel", _panel_style(PANEL_SELECTED if selected else PANEL, BORDER_SELECTED if selected else BORDER, 10)
 	)
@@ -339,7 +503,7 @@ func _create_game_card(game_id: StringName, data: GameData) -> PanelContainer:
 	var title := Label.new()
 	title.text = RomRegistry.title_for(game_id)
 	title.add_theme_color_override("font_color", TEXT)
-	title.add_theme_font_size_override("font_size", 26)
+	title.add_theme_font_size_override("font_size", 22)
 	body.add_child(title)
 
 	var revision := Label.new()
@@ -359,7 +523,7 @@ func _create_game_card(game_id: StringName, data: GameData) -> PanelContainer:
 
 	var detail := Label.new()
 	detail.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	detail.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	detail.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
 	detail.add_theme_color_override("font_color", MUTED)
 	if imported:
 		detail.text = "%d species, %d trainer classes\nCache format %d\n%s" % [
@@ -370,10 +534,19 @@ func _create_game_card(game_id: StringName, data: GameData) -> PanelContainer:
 		detail.text = "Bring your own verified dump.\nThe filename does not matter."
 	body.add_child(detail)
 
+	var actions := HBoxContainer.new()
+	body.add_child(actions)
+
 	var action := _button("Open save slots" if imported else "Choose ROM", ACCENT if imported else TEXT)
 	action.custom_minimum_size = Vector2(0, 38)
+	action.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	action.pressed.connect(_on_game_action.bind(game_id, imported))
-	body.add_child(action)
+	actions.add_child(action)
+
+	var manage := _button("Manage", MUTED)
+	manage.custom_minimum_size = Vector2(90, 38)
+	manage.pressed.connect(_open_manage_dialog.bind(game_id))
+	actions.add_child(manage)
 
 	return card
 
@@ -420,6 +593,18 @@ func _on_file_selected(path: String) -> void:
 		_finish_import(false, String(identity["message"]))
 		return
 
+	# A re-import replaces one game's cache, so it only accepts that game's own
+	# dump. Without this, choosing the wrong file from the manage dialog would
+	# quietly import a different cartridge instead of saying so.
+	if not _reimport_game_id.is_empty() and StringName(identity["id"]) != _reimport_game_id:
+		var wanted: StringName = _reimport_game_id
+		_reimport_game_id = &""
+		_finish_import(false, "That dump is %s, not %s." % [
+			RomRegistry.title_for(StringName(identity["id"])), RomRegistry.title_for(wanted),
+		])
+		return
+	_reimport_game_id = &""
+
 	var rom: RomFile = RomFile.open_verified(path)
 	if rom == null:
 		_finish_import(false, "The verified cartridge could not be read.")
@@ -465,8 +650,9 @@ func _update_import_controls() -> void:
 		_import_button.disabled = _importing
 	for card: PanelContainer in _cards.values():
 		var body: VBoxContainer = card.get_child(0)
-		var action: Button = body.get_child(body.get_child_count() - 1)
-		action.disabled = _importing
+		var actions: HBoxContainer = body.get_child(body.get_child_count() - 1)
+		for button: Button in actions.get_children():
+			button.disabled = _importing
 
 
 func _set_status(title: String, detail: String, colour: Color) -> void:
@@ -493,10 +679,9 @@ func _save_slot_detail(game_id: StringName, data: GameData) -> String:
 			incompatible += 1
 	if slots.is_empty():
 		return "No saves yet"
-	var detail: String = "%d of %d saves ready" % [ready_slots, slots.size()]
 	if incompatible > 0:
-		detail += ", %d incompatible" % incompatible
-	return detail
+		return "Saves: %d ready, %d unreadable" % [ready_slots, incompatible]
+	return "Saves: %d ready" % ready_slots
 
 
 ## What the mod host found, said in one line. A refused mod is named with its

--- a/game/main/mods_dialog.gd
+++ b/game/main/mods_dialog.gd
@@ -1,0 +1,129 @@
+class_name Gen2ModsDialog
+extends AcceptDialog
+
+## Lists installed mods with an on/off switch and a delete, beside the refusals
+## the host recorded. Installing lives on the launcher itself, next to the ROM
+## import that works the same way.
+##
+## Switching one off takes effect on the next start, which the dialog says
+## rather than pretending a running registration can be withdrawn: a mod has
+## already registered its content and renderers by the time this is reachable.
+
+signal mods_changed
+
+var _list: VBoxContainer = null
+var _status: Label = null
+
+
+func _init() -> void:
+	title = "Mods"
+	ok_button_text = "Close"
+	_build()
+
+
+func _build() -> void:
+	var root := VBoxContainer.new()
+	root.custom_minimum_size = Vector2(560, 320)
+	add_child(root)
+
+	var actions := HBoxContainer.new()
+	root.add_child(actions)
+	actions.add_child(_action("Enable all", func() -> void: _set_all(true)))
+	actions.add_child(_action("Disable all", func() -> void: _set_all(false)))
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	root.add_child(scroll)
+	_list = VBoxContainer.new()
+	_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(_list)
+
+	_status = Label.new()
+	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	root.add_child(_status)
+
+
+func refresh() -> void:
+	for child: Node in _list.get_children():
+		child.queue_free()
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifests: Array = host.manifests()
+	if manifests.is_empty() and host.failures().is_empty():
+		_list.add_child(_text("No mods installed. Put one in %s to load it at start." % Gen2ModHost.ROOT))
+		return
+
+	for manifest: Gen2ModManifest in manifests:
+		_list.add_child(_row(manifest))
+	for failure: Dictionary in host.failures():
+		_list.add_child(_text("%s was refused: %s" % [
+			failure.get("directory", failure.get("id", "?")),
+			Gen2ModRefusal.text(failure),
+		]))
+
+
+func _row(manifest: Gen2ModManifest) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	var name := Label.new()
+	name.text = "%s  %s" % [manifest.name, manifest.version]
+	name.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(name)
+
+	var toggle := CheckBox.new()
+	toggle.text = "Enabled"
+	toggle.button_pressed = Gen2ModState.is_enabled(manifest.id)
+	toggle.toggled.connect(func(on: bool) -> void: _set_enabled(manifest, on))
+	row.add_child(toggle)
+
+	row.add_child(_action("Delete", func() -> void: _delete(manifest)))
+	return row
+
+
+func _set_enabled(manifest: Gen2ModManifest, enabled: bool) -> void:
+	if not Gen2ModState.set_enabled(manifest.id, enabled):
+		_status.text = "That switch could not be written to %s." % Gen2ModState.PATH
+		return
+	_status.text = "%s is %s. Restart to apply." % [
+		manifest.name, "enabled" if enabled else "disabled",
+	]
+	mods_changed.emit()
+
+
+func _set_all(enabled: bool) -> void:
+	var ids: Array = []
+	for manifest: Gen2ModManifest in Gen2ModHost.instance().manifests():
+		ids.append(manifest.id)
+	if ids.is_empty():
+		return
+	if not Gen2ModState.set_all_enabled(ids, enabled):
+		_status.text = "Those switches could not be written to %s." % Gen2ModState.PATH
+		return
+	_status.text = "All mods %s. Restart to apply." % ("enabled" if enabled else "disabled")
+	refresh()
+	mods_changed.emit()
+
+
+func _delete(manifest: Gen2ModManifest) -> void:
+	var result: Dictionary = Gen2ModInstaller.uninstall(manifest.id)
+	if not bool(result.get("ok", false)):
+		_status.text = "%s could not be removed." % manifest.name
+		return
+	# Rediscover so the removed mod leaves the list; what it already registered
+	# this session stays until restart, which the message above says.
+	Gen2ModHost.instance().discover()
+	_status.text = "%s was removed. Restart to apply." % manifest.name
+	refresh()
+	mods_changed.emit()
+
+
+func _text(message: String) -> Label:
+	var label := Label.new()
+	label.text = message
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	return label
+
+
+func _action(text: String, handler: Callable) -> Button:
+	var button := Button.new()
+	button.text = text
+	button.pressed.connect(handler)
+	return button

--- a/game/main/mods_dialog.gd.uid
+++ b/game/main/mods_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://bq1uwup561np8

--- a/game/main/settings_dialog.gd
+++ b/game/main/settings_dialog.gd
@@ -1,0 +1,145 @@
+class_name Gen2SettingsDialog
+extends AcceptDialog
+
+## Edits [Gen2Options] in two sections: the cartridge's own OPTION menu and the
+## things the hardware had no concept of.
+##
+## Stock controls, no styling. Every change writes immediately, because there is
+## no state here worth an apply button and a half-applied options file is worse
+## than none.
+
+## Label, then the values in the order the source cycles them.
+const TEXT_SPEEDS: Array[String] = ["Fast", "Mid", "Slow"]
+const PRINTER_LABELS: Array[String] = ["Lightest", "Lighter", "Normal", "Darker", "Darkest"]
+
+var _options: Gen2Options = null
+var _saved: Label = null
+
+
+func _init() -> void:
+	title = "Settings"
+	ok_button_text = "Close"
+	_options = Gen2OptionsStore.current()
+	_build()
+
+
+func _build() -> void:
+	var root := VBoxContainer.new()
+	root.custom_minimum_size = Vector2(520, 0)
+	add_child(root)
+
+	root.add_child(_heading("Cartridge options"))
+	root.add_child(_choice("Text speed", TEXT_SPEEDS, _options.text_speed,
+		func(index: int) -> void: _options.text_speed = index
+	))
+	root.add_child(_toggle("Battle scene", _options.battle_scene,
+		func(on: bool) -> void: _options.battle_scene = on
+	))
+	root.add_child(_choice("Battle style", ["Shift", "Set"], 1 if _options.battle_style_set else 0,
+		func(index: int) -> void: _options.battle_style_set = index == 1
+	))
+	root.add_child(_choice("Sound", ["Mono", "Stereo"], 1 if _options.stereo else 0,
+		func(index: int) -> void: _options.stereo = index == 1
+	))
+	root.add_child(_number("Textbox frame", _options.textbox_frame, 0, Gen2Options.FRAME_COUNT - 1,
+		func(value: int) -> void: _options.textbox_frame = value
+	))
+	root.add_child(_toggle("Menu account", _options.menu_account,
+		func(on: bool) -> void: _options.menu_account = on
+	))
+	root.add_child(_choice("Print", PRINTER_LABELS, _options.printer_brightness,
+		func(index: int) -> void: _options.printer_brightness = index
+	))
+
+	root.add_child(_heading("Application"))
+	root.add_child(_number("Music volume", _options.music_volume, 0, Gen2Options.MAX_VOLUME,
+		func(value: int) -> void: _options.music_volume = value
+	))
+	root.add_child(_number("Sound volume", _options.sfx_volume, 0, Gen2Options.MAX_VOLUME,
+		func(value: int) -> void: _options.sfx_volume = value
+	))
+	root.add_child(_choice("Video mode", _titles(Gen2Options.VIDEO_MODES),
+		maxi(Gen2Options.VIDEO_MODES.find(_options.video_mode), 0),
+		func(index: int) -> void: _options.video_mode = Gen2Options.VIDEO_MODES[index]
+	))
+	root.add_child(_choice("Game speed", _titles(Gen2Options.GAME_SPEEDS),
+		maxi(Gen2Options.GAME_SPEEDS.find(_options.game_speed), 0),
+		func(index: int) -> void: _options.game_speed = Gen2Options.GAME_SPEEDS[index]
+	))
+	var fps_labels: Array[String] = []
+	for fps: int in Gen2Options.FPS_CHOICES:
+		fps_labels.append("Unlimited" if fps == 0 else str(fps))
+	root.add_child(_choice("Max FPS", fps_labels,
+		maxi(Gen2Options.FPS_CHOICES.find(_options.max_fps), 0),
+		func(index: int) -> void: _options.max_fps = Gen2Options.FPS_CHOICES[index]
+	))
+
+	_saved = Label.new()
+	root.add_child(_saved)
+
+
+func _titles(values: Array[StringName]) -> Array[String]:
+	var out: Array[String] = []
+	for value: StringName in values:
+		out.append(String(value).capitalize())
+	return out
+
+
+func _persist() -> void:
+	var ok: bool = Gen2OptionsStore.save(_options)
+	_saved.text = "Saved to %s" % Gen2OptionsStore.PATH if ok else "The options file could not be written."
+
+
+func _heading(text: String) -> Label:
+	var label := Label.new()
+	label.text = text.to_upper()
+	return label
+
+
+func _row(text: String) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	var label := Label.new()
+	label.text = text
+	label.custom_minimum_size = Vector2(180, 0)
+	row.add_child(label)
+	return row
+
+
+func _choice(text: String, values: Array, selected: int, handler: Callable) -> HBoxContainer:
+	var row: HBoxContainer = _row(text)
+	var picker := OptionButton.new()
+	for index: int in values.size():
+		picker.add_item(String(values[index]), index)
+	picker.selected = clampi(selected, 0, values.size() - 1)
+	picker.item_selected.connect(func(index: int) -> void:
+		handler.call(index)
+		_persist()
+	)
+	row.add_child(picker)
+	return row
+
+
+func _toggle(text: String, pressed: bool, handler: Callable) -> HBoxContainer:
+	var row: HBoxContainer = _row(text)
+	var box := CheckBox.new()
+	box.button_pressed = pressed
+	box.toggled.connect(func(on: bool) -> void:
+		handler.call(on)
+		_persist()
+	)
+	row.add_child(box)
+	return row
+
+
+func _number(text: String, value: int, minimum: int, maximum: int, handler: Callable) -> HBoxContainer:
+	var row: HBoxContainer = _row(text)
+	var spin := SpinBox.new()
+	spin.min_value = minimum
+	spin.max_value = maximum
+	spin.value = value
+	spin.value_changed.connect(func(changed: float) -> void:
+		handler.call(int(changed))
+		_persist()
+	)
+	row.add_child(spin)
+	return row

--- a/game/main/settings_dialog.gd.uid
+++ b/game/main/settings_dialog.gd.uid
@@ -1,0 +1,1 @@
+uid://cybwcoib2nxrn

--- a/game/main/update_check.gd
+++ b/game/main/update_check.gd
@@ -1,0 +1,131 @@
+class_name Gen2UpdateCheck
+extends RefCounted
+
+## Compares this build against the project's published releases.
+##
+## Everything here is pure: no HTTP and no filesystem, so the version rules and
+## the shape of a release feed are testable without a network. The launcher owns
+## the request itself, the way [Gen2ModIndex] leaves fetching to its dialog.
+##
+## The check never runs on its own. It reaches a third party and reports that
+## this build exists, so it happens when the player asks and not before.
+
+const RELEASES_API: String = "https://api.github.com/repos/Decryptu/gen2recomp/releases/latest"
+const RELEASES_PAGE: String = "https://github.com/Decryptu/gen2recomp/releases"
+## A release document is metadata. Anything larger is not one.
+const MAX_RESPONSE_BYTES: int = 1024 * 1024
+
+enum Status {
+	UP_TO_DATE,
+	UPDATE_AVAILABLE,
+	AHEAD,
+	NO_RELEASES,
+	UNREADABLE,
+}
+
+
+## The running build, from `application/config/version` in project.godot so the
+## exported binary and this check cannot disagree.
+static func current_version() -> String:
+	return String(ProjectSettings.get_setting("application/config/version", "0.0.0"))
+
+
+## Splits a version into comparable integers. A leading "v" is accepted because
+## tags usually carry one, and any trailing prerelease or build suffix is cut,
+## since ordering those is a promise this does not need to make.
+static func parse_version(raw: String) -> Array[int]:
+	var text: String = raw.strip_edges().lstrip("vV")
+	for separator: String in ["-", "+", " "]:
+		var at: int = text.find(separator)
+		if at >= 0:
+			text = text.substr(0, at)
+	var parts: PackedStringArray = text.split(".", false)
+	var out: Array[int] = []
+	for part: String in parts:
+		if not part.is_valid_int():
+			break
+		out.append(int(part))
+	return out
+
+
+## Negative when [param left] is older, positive when newer, zero when equal.
+## Missing components count as zero, so "1.2" and "1.2.0" are the same version.
+static func compare_versions(left: String, right: String) -> int:
+	var a: Array[int] = parse_version(left)
+	var b: Array[int] = parse_version(right)
+	for index: int in maxi(a.size(), b.size()):
+		var one: int = a[index] if index < a.size() else 0
+		var two: int = b[index] if index < b.size() else 0
+		if one != two:
+			return -1 if one < two else 1
+	return 0
+
+
+## Reads GitHub's latest-release document into the fields the launcher shows.
+## Returns { ok, version, name, url, published } or { ok: false, reason }.
+static func parse_release(text: String) -> Dictionary:
+	if text.length() > MAX_RESPONSE_BYTES:
+		return {"ok": false, "reason": &"release_too_large"}
+	var json := JSON.new()
+	if json.parse(text) != OK or json.data is not Dictionary:
+		return {"ok": false, "reason": &"release_not_readable"}
+	var row: Dictionary = json.data
+	var tag: String = String(row.get("tag_name", "")).strip_edges()
+	if tag.is_empty() or parse_version(tag).is_empty():
+		return {"ok": false, "reason": &"release_has_no_version"}
+	var url: String = String(row.get("html_url", "")).strip_edges()
+	return {
+		"ok": true,
+		"version": tag,
+		"name": String(row.get("name", tag)).strip_edges(),
+		"url": url if url.begins_with("https://") else RELEASES_PAGE,
+		"published": String(row.get("published_at", "")).strip_edges(),
+	}
+
+
+## What to tell the player, given this build and whatever the request returned.
+## A 404 is the repository having published nothing yet, which is an answer
+## rather than a failure: the check worked, there is simply no release.
+static func status_for(http_code: int, body: String, current: String = "") -> Dictionary:
+	var running: String = current if not current.is_empty() else current_version()
+	if http_code == 404:
+		return {"status": Status.NO_RELEASES, "current": running, "version": ""}
+	if http_code != 200:
+		return {"status": Status.UNREADABLE, "current": running, "version": ""}
+	var release: Dictionary = parse_release(body)
+	if not release["ok"]:
+		return {"status": Status.UNREADABLE, "current": running, "version": ""}
+	var difference: int = compare_versions(running, String(release["version"]))
+	var status: Status = Status.UP_TO_DATE
+	if difference < 0:
+		status = Status.UPDATE_AVAILABLE
+	elif difference > 0:
+		status = Status.AHEAD
+	return {
+		"status": status,
+		"current": running,
+		"version": release["version"],
+		"name": release["name"],
+		"url": release["url"],
+		"published": release["published"],
+	}
+
+
+## One line for the launcher's status area.
+static func describe(result: Dictionary) -> String:
+	var current: String = String(result.get("current", ""))
+	match int(result.get("status", Status.UNREADABLE)):
+		Status.UP_TO_DATE:
+			return "gen2recomp %s is the latest release." % current
+		Status.UPDATE_AVAILABLE:
+			return "Version %s is available. This build is %s." % [
+				result.get("version", "?"), current
+			]
+		Status.AHEAD:
+			return "This build, %s, is newer than the latest release %s." % [
+				current, result.get("version", "?")
+			]
+		Status.NO_RELEASES:
+			return "No release has been published yet. This build is %s." % current
+		_:
+			return "The release list could not be read."

--- a/game/main/update_check.gd.uid
+++ b/game/main/update_check.gd.uid
@@ -1,0 +1,1 @@
+uid://dvd80gp5davnm

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -431,10 +431,13 @@ func failures() -> Array:
 ## Runs each discovered mod's entry script, which registers what it provides.
 ##
 ## A mod that will not load is reported and skipped: one broken mod must not
-## stop the others, and it must not stop the game starting.
+## stop the others, and it must not stop the game starting. A mod the player
+## switched off is skipped silently and is not a failure.
 func load_discovered() -> Array:
 	var loaded: Array = []
 	for id: StringName in _manifests:
+		if not Gen2ModState.is_enabled(id):
+			continue
 		var result: Dictionary = load_mod(_manifests[id])
 		if bool(result.get("ok", false)):
 			loaded.append(id)

--- a/game/mods/mod_installer.gd
+++ b/game/mods/mod_installer.gd
@@ -199,6 +199,9 @@ static func uninstall(id: StringName, root: String = Gen2ModHost.ROOT) -> Dictio
 	if String(id).is_empty():
 		return _refuse(&"invalid_id", String(id))
 	var directory: String = "%s/%s" % [root, id]
+	# Drop any off switch with the mod itself, so reinstalling it later does not
+	# find it silently disabled by a decision about a mod that no longer exists.
+	Gen2ModState.forget(id)
 	if not DirAccess.dir_exists_absolute(directory):
 		return {"ok": true, "id": id, "removed": false}
 	_remove_tree(directory)

--- a/game/mods/mod_state.gd
+++ b/game/mods/mod_state.gd
@@ -1,0 +1,120 @@
+class_name Gen2ModState
+extends RefCounted
+
+## Which installed mods the player has switched off.
+##
+## Disabled ids are stored rather than enabled ones, so a mod that was just
+## installed runs without needing an entry written for it, and a file lost or
+## damaged means every mod runs rather than none.
+##
+## A disabled mod is still discovered and still listed. Only [method
+## Gen2ModHost.load_discovered] skips it, so the launcher can show it, say it
+## is off, and switch it back on without reinstalling.
+
+const PATH: String = "user://mods_disabled.json"
+
+static var _disabled: Dictionary = {}
+static var _loaded: bool = false
+
+
+static func is_enabled(id: StringName) -> bool:
+	_ensure_loaded()
+	return not _disabled.has(id)
+
+
+static func disabled_ids() -> Array[StringName]:
+	_ensure_loaded()
+	var out: Array[StringName] = []
+	for id: StringName in _disabled:
+		out.append(id)
+	out.sort()
+	return out
+
+
+## Returns false only when the change could not be written, in which case the
+## in-memory set is rolled back so it never disagrees with the file.
+static func set_enabled(id: StringName, enabled: bool) -> bool:
+	_ensure_loaded()
+	if String(id).is_empty():
+		return false
+	var was_disabled: bool = _disabled.has(id)
+	if enabled:
+		_disabled.erase(id)
+	else:
+		_disabled[id] = true
+	if _write():
+		return true
+	if was_disabled:
+		_disabled[id] = true
+	else:
+		_disabled.erase(id)
+	return false
+
+
+static func set_all_enabled(ids: Array, enabled: bool) -> bool:
+	_ensure_loaded()
+	var previous: Dictionary = _disabled.duplicate()
+	for id: Variant in ids:
+		if enabled:
+			_disabled.erase(StringName(id))
+		else:
+			_disabled[StringName(id)] = true
+	if _write():
+		return true
+	_disabled = previous
+	return false
+
+
+## Drops an id entirely, for a mod that no longer exists. A removed mod that
+## stayed in the file would silently switch itself off if it were reinstalled.
+static func forget(id: StringName) -> bool:
+	_ensure_loaded()
+	if not _disabled.has(id):
+		return true
+	_disabled.erase(id)
+	return _write()
+
+
+static func reload() -> void:
+	_loaded = false
+	_disabled = {}
+	_ensure_loaded()
+
+
+static func _ensure_loaded() -> void:
+	if _loaded:
+		return
+	_loaded = true
+	_disabled = {}
+	if not FileAccess.file_exists(PATH):
+		return
+	var file: FileAccess = FileAccess.open(PATH, FileAccess.READ)
+	if file == null:
+		return
+	var text: String = file.get_as_text()
+	file.close()
+	var json := JSON.new()
+	if json.parse(text) != OK:
+		return
+	if json.data is not Dictionary:
+		return
+	var raw: Variant = (json.data as Dictionary).get("disabled", [])
+	if raw is not Array:
+		return
+	for id: Variant in raw as Array:
+		var name := StringName(String(id))
+		if not String(name).is_empty():
+			_disabled[name] = true
+
+
+static func _write() -> bool:
+	var ids: Array[String] = []
+	for id: StringName in _disabled:
+		ids.append(String(id))
+	ids.sort()
+	var file: FileAccess = FileAccess.open(PATH, FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_string(JSON.stringify({"disabled": ids}, "\t"))
+	file.close()
+	return true

--- a/game/mods/mod_state.gd.uid
+++ b/game/mods/mod_state.gd.uid
@@ -1,0 +1,1 @@
+uid://cavopj53isc16

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -1,0 +1,177 @@
+class_name Gen2Options
+extends RefCounted
+
+## Player options, in two independent blocks.
+##
+## The cartridge block is the real `wOptions` .. `wOptionsEnd` bytes, so the
+## in-game OPTION menu and this launcher screen can never disagree about what a
+## setting means. The app block is everything the hardware had no concept of.
+##
+## `data/default_options.asm` is byte identical between the two pins, so nothing
+## here is profile split.
+
+const FORMAT_VERSION: int = 1
+
+## `constants/ram_constants.asm`: bits 0-2 of `wOptions`.
+const TEXT_DELAY_FAST: int = 1
+const TEXT_DELAY_MED: int = 3
+const TEXT_DELAY_SLOW: int = 5
+const TEXT_DELAY_MASK: int = 0b111
+const TEXT_DELAYS: Array[int] = [TEXT_DELAY_FAST, TEXT_DELAY_MED, TEXT_DELAY_SLOW]
+
+## Both of these read backwards: `options_menu.asm` `Options_BattleScene`
+## clears BATTLE_SCENE to turn the scene ON, and `Options_BattleStyle` sets
+## BATTLE_SHIFT to select SET rather than SHIFT.
+const BIT_NO_TEXT_SCROLL: int = 4
+const BIT_STEREO: int = 5
+const BIT_BATTLE_SHIFT: int = 6
+const BIT_BATTLE_SCENE: int = 7
+## `wOptions2`. pokecrystal's wram comment says bit 1; its own MENU_ACCOUNT
+## constant and every `bit`/`set`/`res` against it say bit 0, as does pokegold.
+const BIT_MENU_ACCOUNT: int = 0
+
+const FRAME_COUNT: int = 8
+## `GetPrinterSetting` maps only these five values; anything else reads NORMAL.
+const PRINTER_BRIGHTNESS: Array[int] = [0x00, 0x20, 0x40, 0x60, 0x7F]
+const PRINTER_NORMAL_INDEX: int = 2
+
+## `DefaultOptions` is 8 bytes ending at `wOptionsEnd`; byte 1 is
+## `wSaveFileExists` and bytes 6-7 are padding, so neither is an option.
+const SOURCE_BLOCK_SIZE: int = 8
+const OFFSET_OPTIONS: int = 0
+const OFFSET_TEXTBOX_FRAME: int = 2
+const OFFSET_TEXTBOX_FLAGS: int = 3
+const OFFSET_PRINTER: int = 4
+const OFFSET_OPTIONS2: int = 5
+
+## `wTextboxFlags` bit 0. Default on, meaning the text speed above is used.
+const BIT_FAST_TEXT_DELAY: int = 0
+
+const MAX_VOLUME: int = 10
+const VIDEO_MODES: Array[StringName] = [&"windowed", &"fullscreen", &"borderless"]
+const GAME_SPEEDS: Array[StringName] = [&"normal", &"double", &"half"]
+const FPS_CHOICES: Array[int] = [30, 60, 120, 144, 0]
+
+# Cartridge block.
+var text_speed: int = 1
+var battle_scene: bool = true
+var battle_style_set: bool = false
+var stereo: bool = false
+var printer_brightness: int = PRINTER_NORMAL_INDEX
+var menu_account: bool = true
+var textbox_frame: int = 0
+var fast_text_delay: bool = true
+
+# App block.
+var music_volume: int = 7
+var sfx_volume: int = 7
+var video_mode: StringName = &"windowed"
+var max_fps: int = 60
+var game_speed: StringName = &"normal"
+
+
+## The cartridge block as the bytes the hardware kept, `DefaultOptions` order.
+func to_source_bytes() -> PackedByteArray:
+	var bytes: PackedByteArray = PackedByteArray()
+	bytes.resize(SOURCE_BLOCK_SIZE)
+	var options: int = TEXT_DELAYS[clampi(text_speed, 0, TEXT_DELAYS.size() - 1)]
+	if not battle_scene:
+		options |= 1 << BIT_BATTLE_SCENE
+	if battle_style_set:
+		options |= 1 << BIT_BATTLE_SHIFT
+	if stereo:
+		options |= 1 << BIT_STEREO
+	bytes[OFFSET_OPTIONS] = options
+	bytes[OFFSET_TEXTBOX_FRAME] = clampi(textbox_frame, 0, FRAME_COUNT - 1)
+	bytes[OFFSET_TEXTBOX_FLAGS] = (1 << BIT_FAST_TEXT_DELAY) if fast_text_delay else 0
+	bytes[OFFSET_PRINTER] = PRINTER_BRIGHTNESS[
+		clampi(printer_brightness, 0, PRINTER_BRIGHTNESS.size() - 1)
+	]
+	bytes[OFFSET_OPTIONS2] = (1 << BIT_MENU_ACCOUNT) if menu_account else 0
+	return bytes
+
+
+## Reads a cartridge block back. A short block is refused rather than padded,
+## since a truncated one says nothing about what the missing bytes meant.
+func apply_source_bytes(bytes: PackedByteArray) -> bool:
+	if bytes.size() < SOURCE_BLOCK_SIZE:
+		return false
+	var options: int = bytes[OFFSET_OPTIONS]
+	text_speed = _text_speed_index(options & TEXT_DELAY_MASK)
+	battle_scene = (options & (1 << BIT_BATTLE_SCENE)) == 0
+	battle_style_set = (options & (1 << BIT_BATTLE_SHIFT)) != 0
+	stereo = (options & (1 << BIT_STEREO)) != 0
+	textbox_frame = bytes[OFFSET_TEXTBOX_FRAME] & 0b111
+	fast_text_delay = (bytes[OFFSET_TEXTBOX_FLAGS] & (1 << BIT_FAST_TEXT_DELAY)) != 0
+	printer_brightness = _printer_index(bytes[OFFSET_PRINTER])
+	menu_account = (bytes[OFFSET_OPTIONS2] & (1 << BIT_MENU_ACCOUNT)) != 0
+	return true
+
+
+## `GetTextSpeed` recognises only fast and slow; everything else is medium.
+func _text_speed_index(delay: int) -> int:
+	match delay:
+		TEXT_DELAY_FAST:
+			return 0
+		TEXT_DELAY_SLOW:
+			return 2
+		_:
+			return 1
+
+
+## `GetPrinterSetting`, whose fallthrough is NORMAL for any unlisted value.
+func _printer_index(brightness: int) -> int:
+	var found: int = PRINTER_BRIGHTNESS.find(brightness & 0x7F)
+	return found if found >= 0 else PRINTER_NORMAL_INDEX
+
+
+func to_dict() -> Dictionary:
+	return {
+		"format_version": FORMAT_VERSION,
+		"text_speed": text_speed,
+		"battle_scene": battle_scene,
+		"battle_style_set": battle_style_set,
+		"stereo": stereo,
+		"printer_brightness": printer_brightness,
+		"menu_account": menu_account,
+		"textbox_frame": textbox_frame,
+		"fast_text_delay": fast_text_delay,
+		"music_volume": music_volume,
+		"sfx_volume": sfx_volume,
+		"video_mode": String(video_mode),
+		"max_fps": max_fps,
+		"game_speed": String(game_speed),
+	}
+
+
+## Every field is clamped rather than refused: an options file is not a save,
+## and one unreadable value should not cost the player the rest of the file.
+static func parse(raw: Variant) -> Gen2Options:
+	var options := Gen2Options.new()
+	if raw is not Dictionary:
+		return options
+	var row: Dictionary = raw
+	options.text_speed = clampi(int(row.get("text_speed", 1)), 0, 2)
+	options.battle_scene = bool(row.get("battle_scene", true))
+	options.battle_style_set = bool(row.get("battle_style_set", false))
+	options.stereo = bool(row.get("stereo", false))
+	options.printer_brightness = clampi(
+		int(row.get("printer_brightness", PRINTER_NORMAL_INDEX)),
+		0,
+		PRINTER_BRIGHTNESS.size() - 1,
+	)
+	options.menu_account = bool(row.get("menu_account", true))
+	options.textbox_frame = clampi(int(row.get("textbox_frame", 0)), 0, FRAME_COUNT - 1)
+	options.fast_text_delay = bool(row.get("fast_text_delay", true))
+	options.music_volume = clampi(int(row.get("music_volume", 7)), 0, MAX_VOLUME)
+	options.sfx_volume = clampi(int(row.get("sfx_volume", 7)), 0, MAX_VOLUME)
+	options.video_mode = _one_of(row.get("video_mode", ""), VIDEO_MODES)
+	options.game_speed = _one_of(row.get("game_speed", ""), GAME_SPEEDS)
+	var fps: int = int(row.get("max_fps", 60))
+	options.max_fps = fps if FPS_CHOICES.has(fps) else 60
+	return options
+
+
+static func _one_of(value: Variant, allowed: Array[StringName]) -> StringName:
+	var name := StringName(String(value))
+	return name if allowed.has(name) else allowed[0]

--- a/game/options/options.gd.uid
+++ b/game/options/options.gd.uid
@@ -1,0 +1,1 @@
+uid://dkkqglbia44v3

--- a/game/options/options_store.gd
+++ b/game/options/options_store.gd
@@ -1,0 +1,53 @@
+class_name Gen2OptionsStore
+extends RefCounted
+
+## Persistence for [Gen2Options].
+##
+## Deliberately not the save store's checksummed two-file container. Options
+## carry no player progress and [method Gen2Options.parse] clamps every field,
+## so the worst a damaged file costs is a return to defaults. A save cannot
+## afford that, which is why it keeps the heavier scheme.
+
+const PATH: String = "user://options.json"
+
+static var _cached: Gen2Options = null
+
+
+## The live options. Read once, then shared, so callers can hold the object and
+## see later edits the way [Gen2SaveData] is shared through GameRuntime.
+static func current() -> Gen2Options:
+	if _cached == null:
+		_cached = load_options()
+	return _cached
+
+
+static func load_options() -> Gen2Options:
+	if not FileAccess.file_exists(PATH):
+		return Gen2Options.new()
+	var file: FileAccess = FileAccess.open(PATH, FileAccess.READ)
+	if file == null:
+		return Gen2Options.new()
+	var text: String = file.get_as_text()
+	file.close()
+	# JSON.parse_string pushes an engine error on malformed input; a damaged
+	# options file is an expected outcome here, not something to report.
+	var json := JSON.new()
+	if json.parse(text) != OK:
+		return Gen2Options.new()
+	return Gen2Options.parse(json.data)
+
+
+static func save(options: Gen2Options) -> bool:
+	var file: FileAccess = FileAccess.open(PATH, FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_string(JSON.stringify(options.to_dict(), "\t"))
+	file.close()
+	_cached = options
+	return true
+
+
+## Drops the shared object so the next [method current] reads the file again.
+## Tests need this; nothing in the game does.
+static func forget_cached() -> void:
+	_cached = null

--- a/game/options/options_store.gd.uid
+++ b/game/options/options_store.gd.uid
@@ -1,0 +1,1 @@
+uid://dk67obso53fba

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -7,10 +7,14 @@ extends RefCounted
 ## the wrong cartridge cache. The schema is versioned so a future save shape
 ## can be refused or migrated deliberately instead of being guessed at.
 
-const FORMAT_VERSION: int = 2
+const FORMAT_VERSION: int = 3
 const LEGACY_FORMAT_VERSION: int = 1
 const MAX_PARTY: int = Gen2Party.MAX_SIZE
 const MAX_PLAYER_NAME: int = 10
+## The player's own name for the slot, which the cartridge had no concept of:
+## it held one save and named it after the player. Empty means fall back to
+## [member player_name], so a slot always has something to show.
+const MAX_LABEL: int = 24
 const BOX_COUNT: int = 14
 const BOX_CAPACITY: int = Gen2SaveBox.CAPACITY
 
@@ -19,6 +23,7 @@ var game_id: StringName = &""
 var rom_sha1: String = ""
 var slot: int = -1
 var player_name: String = ""
+var label: String = ""
 var party: Array = []
 var boxes: Array = []
 var world: Gen2WorldSnapshot = null
@@ -43,6 +48,7 @@ func to_dict() -> Dictionary:
 		"rom_sha1": rom_sha1,
 		"slot": slot,
 		"player_name": player_name,
+		"label": label,
 		"party": saved_party,
 		"boxes": saved_boxes,
 		"world": world.to_dict() if world != null else {},
@@ -64,6 +70,7 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	out.rom_sha1 = String(source.get("rom_sha1", ""))
 	out.slot = int(source.get("slot", -1))
 	out.player_name = String(source.get("player_name", ""))
+	out.label = String(source.get("label", ""))
 	var raw_party: Variant = source.get("party", [])
 	if raw_party is Array:
 		for raw_mon: Variant in raw_party as Array:
@@ -89,9 +96,12 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	return out
 
 
-## Converts the previous project save shape into the current schema. Version 1
-## had no PC-box field, so migration adds empty boxes and preserves every
-## existing party/world field. A missing world snapshot remains missing.
+## Converts an older project save shape into the current schema, one version
+## step at a time so a version 1 file reaches the current one through every
+## step rather than skipping to it. Each step adds only what its version
+## lacked; a missing world snapshot stays missing throughout.
+##
+## Version 1 had no PC-box field. Version 2 had no slot label.
 static func migrate_dict(raw: Variant) -> Dictionary:
 	if not raw is Dictionary:
 		return {"ok": false, "message": "save data is not an object"}
@@ -99,19 +109,25 @@ static func migrate_dict(raw: Variant) -> Dictionary:
 	var version: int = int(source.get("format_version", -1))
 	if version == FORMAT_VERSION:
 		return {"ok": true, "data": source.duplicate(true), "migrated": false}
-	if version != LEGACY_FORMAT_VERSION:
+	if version < LEGACY_FORMAT_VERSION or version > FORMAT_VERSION:
 		return {"ok": false, "message": "unsupported save format %d" % version}
 	var migrated: Dictionary = source.duplicate(true)
+	if version < 2 and not migrated.has("boxes"):
+		migrated["boxes"] = _empty_boxes()
+	if version < 3 and not migrated.has("label"):
+		migrated["label"] = ""
 	migrated["format_version"] = FORMAT_VERSION
-	if not migrated.has("boxes"):
-		var empty_boxes: Array = []
-		for _box_index: int in BOX_COUNT:
-			var empty_slots: Array = []
-			for _slot: int in BOX_CAPACITY:
-				empty_slots.append(null)
-			empty_boxes.append(empty_slots)
-		migrated["boxes"] = empty_boxes
 	return {"ok": true, "data": migrated, "migrated": true}
+
+
+static func _empty_boxes() -> Array:
+	var empty_boxes: Array = []
+	for _box_index: int in BOX_COUNT:
+		var empty_slots: Array = []
+		for _slot: int in BOX_CAPACITY:
+			empty_slots.append(null)
+		empty_boxes.append(empty_slots)
+	return empty_boxes
 
 
 func first_empty_box_slot() -> Dictionary:
@@ -159,6 +175,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	rom_sha1 = copied.rom_sha1
 	slot = copied.slot
 	player_name = copied.player_name
+	label = copied.label
 	party = copied.party
 	boxes = copied.boxes
 	world = copied.world

--- a/game/save/save_editor.gd
+++ b/game/save/save_editor.gd
@@ -1,0 +1,460 @@
+class_name Gen2SaveEditor
+extends RefCounted
+
+## Edits a save slot while keeping it loadable.
+##
+## Every setter here maintains the invariants [Gen2SaveValidator] enforces
+## rather than letting the player write a value and discover at save time that
+## the slot is dead: level and experience are kept in agreement through the
+## species' own growth curve, HP is clamped to the recomputed maximum, PP
+## follows the move it belongs to, and move slots stay contiguous. The
+## validator is still the gate on [method commit], so a bug here costs a
+## refused write, not a corrupted slot.
+##
+## Scene free on purpose. The editor screen owns presentation only.
+
+## An empty move slot. The validator refuses any move after one of these, so
+## removing a move compacts the list rather than leaving a hole.
+const NO_MOVE: int = 0
+
+var data: GameData = null
+var save: Gen2SaveData = null
+
+var _dirty: bool = false
+
+
+static func open(source: Gen2SaveData, game_data: GameData) -> Gen2SaveEditor:
+	if source == null or game_data == null:
+		return null
+	# A working copy, so abandoning the editor cannot leave a half-edited save
+	# behind in the object GameRuntime is sharing.
+	var copy: Gen2SaveData = Gen2SaveData.from_dict(source.to_dict())
+	if copy == null:
+		return null
+	var editor := Gen2SaveEditor.new()
+	editor.data = game_data
+	editor.save = copy
+	return editor
+
+
+func is_dirty() -> bool:
+	return _dirty
+
+
+## What [method commit] would say, without writing anything. This is what the
+## screen shows continuously so an illegal state is visible before saving.
+func validate() -> Dictionary:
+	return Gen2SaveValidator.validate(save, data)
+
+
+func commit() -> Dictionary:
+	var result: Dictionary = Gen2SaveStore.save(save, data)
+	if bool(result.get("ok", false)):
+		_dirty = false
+	return result
+
+
+# --- Player -----------------------------------------------------------------
+
+
+func set_player_name(name: String) -> Dictionary:
+	var trimmed: String = name.strip_edges()
+	if trimmed.is_empty():
+		return _refuse("the player name cannot be empty")
+	if Gen2Text.encoded_length(trimmed) > Gen2SaveData.MAX_PLAYER_NAME:
+		return _refuse("the player name is at most %d characters" % Gen2SaveData.MAX_PLAYER_NAME)
+	save.player_name = trimmed
+	return _changed()
+
+
+func set_label(label: String) -> Dictionary:
+	var trimmed: String = label.strip_edges()
+	if trimmed.length() > Gen2SaveData.MAX_LABEL:
+		return _refuse("the slot name is at most %d characters" % Gen2SaveData.MAX_LABEL)
+	save.label = trimmed
+	return _changed()
+
+
+# --- Party ------------------------------------------------------------------
+
+
+## Creates a member at [param level] of [param species], with the moves that
+## species knows at that level, exactly as a caught Pokemon would arrive.
+func add_party_member(species: int, level: int) -> Dictionary:
+	if save.party.size() >= Gen2SaveData.MAX_PARTY:
+		return _refuse("the party is full")
+	var mon: Gen2SaveMon = _create_mon(species, level)
+	if mon == null:
+		return _refuse("species %d is not in this cartridge cache" % species)
+	save.party.append(mon)
+	return _changed()
+
+
+## An empty party is legal, the way a new game has one before Elm's Lab, so
+## removing the last member is allowed rather than guessed at.
+func remove_party_member(index: int) -> Dictionary:
+	if not _party_index_valid(index):
+		return _refuse("there is no party member %d" % (index + 1))
+	save.party.remove_at(index)
+	return _changed()
+
+
+func move_party_member(from_index: int, to_index: int) -> Dictionary:
+	if not _party_index_valid(from_index) or not _party_index_valid(to_index):
+		return _refuse("that party position does not exist")
+	if from_index == to_index:
+		return _changed()
+	var mon: Gen2SaveMon = save.party[from_index]
+	save.party.remove_at(from_index)
+	save.party.insert(to_index, mon)
+	return _changed()
+
+
+# --- One Pokemon ------------------------------------------------------------
+
+
+## Changing species re-runs experience against the new growth curve and
+## re-clamps HP, since both are species derived.
+func set_species(mon: Gen2SaveMon, species: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if data.species(species).is_empty():
+		return _refuse("species %d is not in this cartridge cache" % species)
+	mon.species = species
+	_resync_level(mon, mon.level)
+	return _changed()
+
+
+func set_level(mon: Gen2SaveMon, level: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if level < 1 or level > Gen2Experience.MAX_LEVEL:
+		return _refuse("level is 1 to %d" % Gen2Experience.MAX_LEVEL)
+	_resync_level(mon, level)
+	return _changed()
+
+
+## Sets a move and gives it full PP, the way `LearnMove` does. Slot order is
+## kept contiguous, so clearing a move pulls the later ones forward.
+func set_move(mon: Gen2SaveMon, slot: int, move_number: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if slot < 0 or slot >= Gen2SaveMon.MAX_MOVES:
+		return _refuse("there is no move slot %d" % (slot + 1))
+	if move_number == NO_MOVE:
+		mon.moves[slot] = NO_MOVE
+		mon.pp[slot] = 0
+		_compact_moves(mon)
+		return _changed()
+	var move: Dictionary = data.move(move_number)
+	if move.is_empty():
+		return _refuse("move %d is not in this cartridge cache" % move_number)
+	if slot > 0 and int(mon.moves[slot - 1]) == NO_MOVE:
+		return _refuse("fill move slot %d first" % slot)
+	mon.moves[slot] = move_number
+	mon.pp[slot] = int(move.get("pp", 0))
+	return _changed()
+
+
+func set_pp(mon: Gen2SaveMon, slot: int, pp: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if slot < 0 or slot >= Gen2SaveMon.MAX_MOVES:
+		return _refuse("there is no move slot %d" % (slot + 1))
+	if int(mon.moves[slot]) == NO_MOVE:
+		return _refuse("that move slot is empty")
+	var maximum: int = int(data.move(int(mon.moves[slot])).get("pp", 0))
+	mon.pp[slot] = clampi(pp, 0, maximum)
+	return _changed()
+
+
+func set_hp(mon: Gen2SaveMon, hp: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	mon.hp = clampi(hp, 0, max_hp_for(mon))
+	return _changed()
+
+
+func set_status(mon: Gen2SaveMon, status: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if not Gen2SaveValidator.is_valid_status(status):
+		return _refuse("that status combination cannot exist")
+	mon.status = status
+	return _changed()
+
+
+## DVs are five 4-bit values packed into one word, so each is clamped on its
+## own rather than trusting a hand-typed number.
+func set_dvs(mon: Gen2SaveMon, attack: int, defense: int, speed: int, special: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	mon.dvs = Gen2Stats.pack_dvs(
+		clampi(attack, 0, Gen2Stats.MAX_DV),
+		clampi(defense, 0, Gen2Stats.MAX_DV),
+		clampi(speed, 0, Gen2Stats.MAX_DV),
+		clampi(special, 0, Gen2Stats.MAX_DV),
+	)
+	# HP's DV is derived from the other four, so the HP ceiling just moved.
+	mon.hp = mini(mon.hp, max_hp_for(mon))
+	return _changed()
+
+
+func set_stat_exp(mon: Gen2SaveMon, key: String, value: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if not Gen2SaveMon.STAT_EXP_KEYS.has(key):
+		return _refuse("there is no %s stat experience" % key)
+	mon.stat_exp[key] = clampi(value, 0, Gen2Stats.MAX_STAT_EXP)
+	if key == "hp":
+		mon.hp = mini(mon.hp, max_hp_for(mon))
+	return _changed()
+
+
+func set_held_item(mon: Gen2SaveMon, item: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	if item != 0 and data.item(item).is_empty():
+		return _refuse("item %d is not in this cartridge cache" % item)
+	mon.item = maxi(item, 0)
+	return _changed()
+
+
+func set_nickname(mon: Gen2SaveMon, nickname: String) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	mon.nickname = nickname.strip_edges()
+	return _changed()
+
+
+func set_happiness(mon: Gen2SaveMon, happiness: int) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	mon.happiness = clampi(happiness, 0, 255)
+	return _changed()
+
+
+func set_is_egg(mon: Gen2SaveMon, is_egg: bool) -> Dictionary:
+	if mon == null:
+		return _refuse("no Pokemon is selected")
+	mon.is_egg = is_egg
+	return _changed()
+
+
+## The HP ceiling this Pokemon's identity and training produce right now.
+func max_hp_for(mon: Gen2SaveMon) -> int:
+	if mon == null:
+		return 0
+	var base: Dictionary = data.species(mon.species).get("stats", {})
+	return Gen2Stats.calculate(
+		int(base.get("hp", 0)),
+		Gen2Stats.hp_dv(mon.dvs),
+		int(mon.stat_exp.get("hp", 0)),
+		mon.level,
+		true,
+	)
+
+
+# --- Boxes ------------------------------------------------------------------
+
+
+func box(index: int) -> Gen2SaveBox:
+	if index < 0 or index >= save.boxes.size():
+		return null
+	return save.boxes[index]
+
+
+func add_box_member(box_index: int, species: int, level: int) -> Dictionary:
+	var target: Gen2SaveBox = box(box_index)
+	if target == null:
+		return _refuse("there is no box %d" % (box_index + 1))
+	var mon: Gen2SaveMon = _create_mon(species, level)
+	if mon == null:
+		return _refuse("species %d is not in this cartridge cache" % species)
+	var placed: Dictionary = target.put(mon)
+	if not bool(placed.get("ok", false)):
+		return _refuse("box %d is full" % (box_index + 1))
+	return _changed()
+
+
+func remove_box_member(box_index: int, slot: int) -> Dictionary:
+	var target: Gen2SaveBox = box(box_index)
+	if target == null:
+		return _refuse("there is no box %d" % (box_index + 1))
+	if slot < 0 or slot >= target.slots.size() or target.slots[slot] == null:
+		return _refuse("that box slot is empty")
+	target.slots[slot] = null
+	return _changed()
+
+
+# --- World ------------------------------------------------------------------
+
+
+## The bag, money, flags and dex all live in the world snapshot, so a save
+## written before the overworld existed has none of them to edit.
+func has_world() -> bool:
+	return save.world != null and save.world.world_state != null
+
+
+func inventory() -> Gen2WorldInventory:
+	if not has_world():
+		return null
+	return Gen2WorldInventory.new(data, save.world.world_state)
+
+
+func set_item_quantity(item: int, quantity: int) -> Dictionary:
+	var bag: Gen2WorldInventory = inventory()
+	if bag == null:
+		return _refuse("this save has no world state to edit")
+	if item != 0 and data.item(item).is_empty():
+		return _refuse("item %d is not in this cartridge cache" % item)
+	var result: Dictionary = bag.set_item_quantity(item, quantity)
+	if not bool(result.get("ok", false)):
+		return _refuse(String(result.get("reason", "that item quantity was refused")))
+	return _changed()
+
+
+func set_money(account: int, balance: int) -> Dictionary:
+	var bag: Gen2WorldInventory = inventory()
+	if bag == null:
+		return _refuse("this save has no world state to edit")
+	var result: Dictionary = bag.set_money(
+		account, clampi(balance, 0, Gen2WorldInventory.MAX_MONEY)
+	)
+	if not bool(result.get("ok", false)):
+		return _refuse(String(result.get("reason", "that balance was refused")))
+	return _changed()
+
+
+func set_coins(balance: int) -> Dictionary:
+	var bag: Gen2WorldInventory = inventory()
+	if bag == null:
+		return _refuse("this save has no world state to edit")
+	var result: Dictionary = bag.set_coins(clampi(balance, 0, Gen2WorldInventory.MAX_COINS))
+	if not bool(result.get("ok", false)):
+		return _refuse(String(result.get("reason", "that balance was refused")))
+	return _changed()
+
+
+func set_event_flag(flag: int, active: bool) -> Dictionary:
+	if not has_world():
+		return _refuse("this save has no world state to edit")
+	if flag < 0:
+		return _refuse("an event flag number is not negative")
+	save.world.world_state.set_event_flag(flag, active)
+	return _changed()
+
+
+## Badges are engine flags, so this is how a badge is granted or taken away.
+## The numbers differ between the profiles, which is why they are read from
+## the state rather than hardcoded here.
+func set_engine_flag(flag: int, active: bool) -> Dictionary:
+	if not has_world():
+		return _refuse("this save has no world state to edit")
+	if flag < 0:
+		return _refuse("an engine flag number is not negative")
+	save.world.world_state.set_engine_flag(flag, active)
+	return _changed()
+
+
+func badge_flags() -> Array[int]:
+	var out: Array[int] = []
+	if not has_world():
+		return out
+	var gold_silver: bool = save.game_id != RomRegistry.CRYSTAL
+	var flags: Array[int] = (
+		Gen2WorldState.BADGE_ENGINE_FLAGS_GOLD_SILVER if gold_silver
+		else Gen2WorldState.BADGE_ENGINE_FLAGS
+	)
+	out.assign(flags)
+	return out
+
+
+func set_seen_species(species: int, seen: bool) -> Dictionary:
+	if not has_world():
+		return _refuse("this save has no world state to edit")
+	if data.species(species).is_empty():
+		return _refuse("species %d is not in this cartridge cache" % species)
+	save.world.world_state.set_species_seen(species, seen)
+	return _changed()
+
+
+## Moving the player is checked against the destination map's own collision
+## grid, because the validator refuses a cell outside it and a save that will
+## not load is exactly what this editor exists to prevent.
+func set_player_position(map_id: Vector2i, cell: Vector2i) -> Dictionary:
+	if not has_world():
+		return _refuse("this save has no world state to edit")
+	var map: Gen2WorldMap = data.world_map(map_id.x, map_id.y)
+	if map == null:
+		return _refuse("map %d/%d is not in this cartridge cache" % [map_id.x, map_id.y])
+	if cell.x < 0 or cell.y < 0 or cell.x >= map.collision_width or cell.y >= map.collision_height:
+		return _refuse("that cell is outside map %d/%d" % [map_id.x, map_id.y])
+	save.world.map_id = map_id
+	save.world.player_cell = cell
+	return _changed()
+
+
+func set_clock(day: int, hour: int, minute: int) -> Dictionary:
+	if not has_world():
+		return _refuse("this save has no world state to edit")
+	save.world.world_day = clampi(day, 0, Gen2WorldClock.DAYS_PER_WEEK - 1)
+	save.world.world_hour = clampi(hour, 0, Gen2WorldClock.HOURS_PER_DAY - 1)
+	save.world.world_minute = clampi(minute, 0, Gen2WorldClock.MINUTES_PER_HOUR - 1)
+	return _changed()
+
+
+# --- Internals --------------------------------------------------------------
+
+
+## Level and experience must agree, so setting either sets both: experience
+## becomes the curve's own total for that level under this species' growth
+## rate. HP then re-clamps, because the maximum moved with the level.
+func _resync_level(mon: Gen2SaveMon, level: int) -> void:
+	var growth: int = int(
+		data.species(mon.species).get("growth_rate", Gen2Experience.GROWTH_MEDIUM_FAST)
+	)
+	mon.level = clampi(level, 1, Gen2Experience.MAX_LEVEL)
+	mon.exp = Gen2Experience.total_exp_at(growth, mon.level)
+	mon.hp = mini(mon.hp, max_hp_for(mon))
+
+
+func _create_mon(species: int, level: int) -> Gen2SaveMon:
+	if data.species(species).is_empty():
+		return null
+	var wanted: int = clampi(level, 1, Gen2Experience.MAX_LEVEL)
+	var battle_mon: Gen2BattleMon = Gen2BattleMon.create(
+		data, species, wanted, data.moves_at_level(species, wanted)
+	)
+	if battle_mon == null:
+		return null
+	return Gen2SaveBattleAdapter.from_battle_mon(battle_mon)
+
+
+## Pulls later moves forward so no gap sits before a filled slot, which the
+## validator refuses.
+func _compact_moves(mon: Gen2SaveMon) -> void:
+	var moves: Array = []
+	var pp: Array = []
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		if int(mon.moves[slot]) != NO_MOVE:
+			moves.append(mon.moves[slot])
+			pp.append(mon.pp[slot])
+	while moves.size() < Gen2SaveMon.MAX_MOVES:
+		moves.append(NO_MOVE)
+		pp.append(0)
+	mon.moves = moves
+	mon.pp = pp
+
+
+func _party_index_valid(index: int) -> bool:
+	return index >= 0 and index < save.party.size()
+
+
+func _changed() -> Dictionary:
+	_dirty = true
+	return {"ok": true, "message": ""}
+
+
+func _refuse(message: String) -> Dictionary:
+	return {"ok": false, "message": message}

--- a/game/save/save_editor.gd.uid
+++ b/game/save/save_editor.gd.uid
@@ -1,0 +1,1 @@
+uid://d3c3ywon81prx

--- a/game/save/save_editor_screen.gd
+++ b/game/save/save_editor_screen.gd
@@ -1,0 +1,593 @@
+extends Control
+
+## The save editor. Presentation only: every rule lives in [Gen2SaveEditor],
+## which is what keeps an edit from producing a slot that will not load.
+##
+## Deliberately built from stock controls with no styling. The look is a later
+## pass, and a plain screen is the one that is cheapest to replace.
+
+## Kept in the order the tabs are drawn in, so a snapshot names a tab rather
+## than an index a reader has to count.
+const TABS: Array[StringName] = [&"party", &"boxes", &"items", &"events", &"map", &"dex"]
+
+var _editor: Gen2SaveEditor = null
+var _tabs: TabContainer = null
+var _status: Label = null
+var _validity: Label = null
+var _party_list: ItemList = null
+var _party_form: VBoxContainer = null
+var _box_picker: OptionButton = null
+var _box_list: ItemList = null
+var _item_list: ItemList = null
+var _money_field: SpinBox = null
+var _coins_field: SpinBox = null
+var _flag_field: SpinBox = null
+var _badge_boxes: Array[CheckBox] = []
+var _map_fields: Dictionary = {}
+var _dex_field: SpinBox = null
+var _dex_list: ItemList = null
+var _selected_party: int = -1
+var _selected_box: int = 0
+
+
+func _ready() -> void:
+	_build_ui()
+	if _editor == null:
+		_open_selected_slot()
+	_refresh()
+
+
+## Opens an explicit save. Tests and tools use this instead of relying on
+## whatever the runtime happens to have selected.
+func set_editor(editor: Gen2SaveEditor) -> void:
+	_editor = editor
+	if is_inside_tree():
+		_refresh()
+
+
+func _open_selected_slot() -> void:
+	var data: GameData = GameData.open(GameRuntime.selected_game_id)
+	if data == null or GameRuntime.selected_save_slot < 0:
+		return
+	var result: Dictionary = Gen2SaveStore.load_result(
+		data.id, data.sha1, GameRuntime.selected_save_slot, data
+	)
+	if bool(result.get("ok", false)):
+		_editor = Gen2SaveEditor.open(result["save"], data)
+
+
+## A read-only view for tests, in the shape the other screens expose.
+func editor_snapshot() -> Dictionary:
+	if _editor == null:
+		return {"open": false, "tab": &"", "valid": false}
+	var validation: Dictionary = _editor.validate()
+	var party: Array = []
+	for mon: Gen2SaveMon in _editor.save.party:
+		party.append({"species": mon.species, "level": mon.level, "hp": mon.hp})
+	return {
+		"open": true,
+		"tab": TABS[_tabs.current_tab] if _tabs != null else &"",
+		"valid": bool(validation["ok"]),
+		"message": String(validation["message"]),
+		"dirty": _editor.is_dirty(),
+		"player_name": _editor.save.player_name,
+		"label": _editor.save.label,
+		"party": party,
+		"selected_party": _selected_party,
+		"selected_box": _selected_box,
+		"has_world": _editor.has_world(),
+	}
+
+
+func select_party_member(index: int) -> bool:
+	if _editor == null or index < 0 or index >= _editor.save.party.size():
+		return false
+	_selected_party = index
+	_refresh_party_form()
+	return true
+
+
+func select_tab(tab: StringName) -> bool:
+	var index: int = TABS.find(tab)
+	if index < 0 or _tabs == null:
+		return false
+	_tabs.current_tab = index
+	return true
+
+
+func save_now() -> bool:
+	if _editor == null:
+		return false
+	var result: Dictionary = _editor.commit()
+	_set_status(String(result["message"]) if not result["ok"] else "Saved.")
+	if result["ok"]:
+		# The slot on disk changed under whatever the runtime is holding.
+		GameRuntime.reload_selected_save()
+	_refresh()
+	return bool(result["ok"])
+
+
+func reload_now() -> bool:
+	if _editor == null:
+		return false
+	var result: Dictionary = Gen2SaveStore.load_result(
+		_editor.save.game_id, _editor.save.rom_sha1, _editor.save.slot, _editor.data
+	)
+	if not bool(result.get("ok", false)):
+		_set_status(String(result.get("message", "the slot could not be reloaded")))
+		return false
+	_editor = Gen2SaveEditor.open(result["save"], _editor.data)
+	_selected_party = -1
+	_set_status("Reloaded from disk.")
+	_refresh()
+	return true
+
+
+# --- Layout -----------------------------------------------------------------
+
+
+func _build_ui() -> void:
+	var margin := MarginContainer.new()
+	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	for side: String in ["left", "top", "right", "bottom"]:
+		margin.add_theme_constant_override("margin_%s" % side, 8)
+	add_child(margin)
+
+	var root := VBoxContainer.new()
+	margin.add_child(root)
+
+	var header := HBoxContainer.new()
+	root.add_child(header)
+	var title := Label.new()
+	title.text = "Save editor"
+	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	header.add_child(title)
+	_validity = Label.new()
+	header.add_child(_validity)
+	header.add_child(_action("Reload", reload_now))
+	header.add_child(_action("Save", save_now))
+	header.add_child(_action("Close", _close))
+
+	_tabs = TabContainer.new()
+	_tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	root.add_child(_tabs)
+	_tabs.add_child(_build_party_tab())
+	_tabs.add_child(_build_boxes_tab())
+	_tabs.add_child(_build_items_tab())
+	_tabs.add_child(_build_events_tab())
+	_tabs.add_child(_build_map_tab())
+	_tabs.add_child(_build_dex_tab())
+	for index: int in TABS.size():
+		_tabs.set_tab_title(index, String(TABS[index]).capitalize())
+
+	_status = Label.new()
+	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	root.add_child(_status)
+
+
+func _build_party_tab() -> Control:
+	var page := HBoxContainer.new()
+	page.name = "Party"
+
+	var left := VBoxContainer.new()
+	left.custom_minimum_size = Vector2(260, 0)
+	page.add_child(left)
+	_party_list = ItemList.new()
+	_party_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_party_list.item_selected.connect(func(index: int) -> void: select_party_member(index))
+	left.add_child(_party_list)
+
+	var add_row := HBoxContainer.new()
+	left.add_child(add_row)
+	var species_field := SpinBox.new()
+	species_field.max_value = 255
+	species_field.value = 1
+	add_row.add_child(species_field)
+	var level_field := SpinBox.new()
+	level_field.min_value = 1
+	level_field.max_value = Gen2Experience.MAX_LEVEL
+	level_field.value = 5
+	add_row.add_child(level_field)
+	add_row.add_child(_action("Add", func() -> void:
+		_apply(_editor.add_party_member(int(species_field.value), int(level_field.value)))
+	))
+	add_row.add_child(_action("Remove", func() -> void:
+		_apply(_editor.remove_party_member(_selected_party))
+		_selected_party = -1
+	))
+
+	_party_form = VBoxContainer.new()
+	_party_form.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	page.add_child(_party_form)
+	return page
+
+
+func _build_boxes_tab() -> Control:
+	var page := VBoxContainer.new()
+	page.name = "Boxes"
+	var row := HBoxContainer.new()
+	page.add_child(row)
+	_box_picker = OptionButton.new()
+	for index: int in Gen2SaveData.BOX_COUNT:
+		_box_picker.add_item("Box %d" % (index + 1), index)
+	_box_picker.item_selected.connect(func(index: int) -> void:
+		_selected_box = index
+		_refresh_boxes()
+	)
+	row.add_child(_box_picker)
+
+	var species_field := SpinBox.new()
+	species_field.max_value = 255
+	species_field.value = 1
+	row.add_child(species_field)
+	var level_field := SpinBox.new()
+	level_field.min_value = 1
+	level_field.max_value = Gen2Experience.MAX_LEVEL
+	level_field.value = 5
+	row.add_child(level_field)
+	row.add_child(_action("Add", func() -> void:
+		_apply(_editor.add_box_member(
+			_selected_box, int(species_field.value), int(level_field.value)
+		))
+	))
+	row.add_child(_action("Remove", func() -> void:
+		_apply(_editor.remove_box_member(_selected_box, _box_list.get_selected_items()[0] \
+			if not _box_list.get_selected_items().is_empty() else -1))
+	))
+
+	_box_list = ItemList.new()
+	_box_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	page.add_child(_box_list)
+	return page
+
+
+func _build_items_tab() -> Control:
+	var page := VBoxContainer.new()
+	page.name = "Items"
+
+	var money_row := HBoxContainer.new()
+	page.add_child(money_row)
+	money_row.add_child(_label("Money"))
+	_money_field = SpinBox.new()
+	_money_field.max_value = Gen2WorldInventory.MAX_MONEY
+	_money_field.value_changed.connect(func(value: float) -> void:
+		_apply(_editor.set_money(0, int(value)), false)
+	)
+	money_row.add_child(_money_field)
+	money_row.add_child(_label("Coins"))
+	_coins_field = SpinBox.new()
+	_coins_field.max_value = Gen2WorldInventory.MAX_COINS
+	_coins_field.value_changed.connect(func(value: float) -> void:
+		_apply(_editor.set_coins(int(value)), false)
+	)
+	money_row.add_child(_coins_field)
+
+	var item_row := HBoxContainer.new()
+	page.add_child(item_row)
+	var item_field := SpinBox.new()
+	item_field.max_value = 255
+	item_field.value = 1
+	item_row.add_child(item_field)
+	var quantity_field := SpinBox.new()
+	quantity_field.max_value = 99
+	quantity_field.value = 1
+	item_row.add_child(quantity_field)
+	item_row.add_child(_action("Set", func() -> void:
+		_apply(_editor.set_item_quantity(int(item_field.value), int(quantity_field.value)))
+	))
+
+	_item_list = ItemList.new()
+	_item_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	page.add_child(_item_list)
+	return page
+
+
+func _build_events_tab() -> Control:
+	var page := VBoxContainer.new()
+	page.name = "Events"
+
+	var badges := HFlowContainer.new()
+	page.add_child(badges)
+	_badge_boxes = []
+	for index: int in Gen2WorldState.BADGE_ENGINE_FLAGS.size():
+		var box := CheckBox.new()
+		box.text = "Badge %d" % (index + 1)
+		box.toggled.connect(func(pressed: bool) -> void: _set_badge(index, pressed))
+		badges.add_child(box)
+		_badge_boxes.append(box)
+
+	var flag_row := HBoxContainer.new()
+	page.add_child(flag_row)
+	flag_row.add_child(_label("Event flag"))
+	_flag_field = SpinBox.new()
+	_flag_field.max_value = 4095
+	flag_row.add_child(_flag_field)
+	flag_row.add_child(_action("Set", func() -> void:
+		_apply(_editor.set_event_flag(int(_flag_field.value), true))
+	))
+	flag_row.add_child(_action("Clear", func() -> void:
+		_apply(_editor.set_event_flag(int(_flag_field.value), false))
+	))
+	return page
+
+
+func _build_map_tab() -> Control:
+	var page := VBoxContainer.new()
+	page.name = "Map"
+	for field: String in ["group", "number", "x", "y"]:
+		var row := HBoxContainer.new()
+		page.add_child(row)
+		row.add_child(_label(field.capitalize()))
+		var spin := SpinBox.new()
+		spin.max_value = 999
+		row.add_child(spin)
+		_map_fields[field] = spin
+	page.add_child(_action("Move player", _apply_position))
+
+	for field: String in ["day", "hour", "minute"]:
+		var row := HBoxContainer.new()
+		page.add_child(row)
+		row.add_child(_label(field.capitalize()))
+		var spin := SpinBox.new()
+		spin.max_value = 59
+		row.add_child(spin)
+		_map_fields[field] = spin
+	page.add_child(_action("Set clock", func() -> void:
+		_apply(_editor.set_clock(
+			int(_map_fields["day"].value),
+			int(_map_fields["hour"].value),
+			int(_map_fields["minute"].value),
+		))
+	))
+	return page
+
+
+func _build_dex_tab() -> Control:
+	var page := VBoxContainer.new()
+	page.name = "Dex"
+	var row := HBoxContainer.new()
+	page.add_child(row)
+	row.add_child(_label("Species"))
+	_dex_field = SpinBox.new()
+	_dex_field.min_value = 1
+	_dex_field.max_value = 255
+	_dex_field.value = 1
+	row.add_child(_dex_field)
+	row.add_child(_action("Seen", func() -> void:
+		_apply(_editor.set_seen_species(int(_dex_field.value), true))
+	))
+	row.add_child(_action("Clear", func() -> void:
+		_apply(_editor.set_seen_species(int(_dex_field.value), false))
+	))
+	_dex_list = ItemList.new()
+	_dex_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	page.add_child(_dex_list)
+	return page
+
+
+# --- Refresh ----------------------------------------------------------------
+
+
+func _refresh() -> void:
+	if _editor == null:
+		_set_status("No save is open.")
+		return
+	_refresh_validity()
+	_refresh_party()
+	_refresh_party_form()
+	_refresh_boxes()
+	_refresh_items()
+	_refresh_events()
+	_refresh_map()
+	_refresh_dex()
+
+
+func _refresh_validity() -> void:
+	var validation: Dictionary = _editor.validate()
+	_validity.text = "Validates clean" if validation["ok"] else String(validation["message"])
+
+
+func _refresh_party() -> void:
+	_party_list.clear()
+	for mon: Gen2SaveMon in _editor.save.party:
+		_party_list.add_item("%s  Lv%d  %d/%d HP" % [
+			_species_name(mon.species), mon.level, mon.hp, _editor.max_hp_for(mon),
+		])
+	if _selected_party >= 0 and _selected_party < _party_list.item_count:
+		_party_list.select(_selected_party)
+
+
+## The per-Pokemon form is rebuilt rather than updated, because every control
+## in it belongs to whichever member is selected and none of them outlive that.
+func _refresh_party_form() -> void:
+	if _party_form == null:
+		return
+	for child: Node in _party_form.get_children():
+		child.queue_free()
+	if _selected_party < 0 or _selected_party >= _editor.save.party.size():
+		return
+	var mon: Gen2SaveMon = _editor.save.party[_selected_party]
+
+	_party_form.add_child(_field("Species", mon.species, 1, 255, func(value: int) -> void:
+		_apply(_editor.set_species(mon, value))
+	))
+	_party_form.add_child(_field("Level", mon.level, 1, Gen2Experience.MAX_LEVEL,
+		func(value: int) -> void: _apply(_editor.set_level(mon, value))
+	))
+	_party_form.add_child(_field("HP", mon.hp, 0, _editor.max_hp_for(mon),
+		func(value: int) -> void: _apply(_editor.set_hp(mon, value))
+	))
+	_party_form.add_child(_field("Happiness", mon.happiness, 0, 255,
+		func(value: int) -> void: _apply(_editor.set_happiness(mon, value))
+	))
+	_party_form.add_child(_field("Held item", mon.item, 0, 255,
+		func(value: int) -> void: _apply(_editor.set_held_item(mon, value))
+	))
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		_party_form.add_child(_field(
+			"Move %d" % (slot + 1), int(mon.moves[slot]), 0, 255,
+			func(value: int) -> void: _apply(_editor.set_move(mon, slot, value))
+		))
+	var dv_row := HBoxContainer.new()
+	dv_row.add_child(_label("DVs"))
+	var dv_fields: Array[SpinBox] = []
+	for dv: int in [
+		Gen2Stats.attack_dv(mon.dvs), Gen2Stats.defense_dv(mon.dvs),
+		Gen2Stats.speed_dv(mon.dvs), Gen2Stats.special_dv(mon.dvs),
+	]:
+		var spin := SpinBox.new()
+		spin.max_value = Gen2Stats.MAX_DV
+		spin.value = dv
+		dv_row.add_child(spin)
+		dv_fields.append(spin)
+	dv_row.add_child(_action("Apply", func() -> void:
+		_apply(_editor.set_dvs(
+			mon, int(dv_fields[0].value), int(dv_fields[1].value),
+			int(dv_fields[2].value), int(dv_fields[3].value),
+		))
+	))
+	_party_form.add_child(dv_row)
+
+
+func _refresh_boxes() -> void:
+	if _box_list == null:
+		return
+	_box_list.clear()
+	var box: Gen2SaveBox = _editor.box(_selected_box)
+	if box == null:
+		return
+	for slot: int in box.slots.size():
+		var mon: Gen2SaveMon = box.slots[slot]
+		_box_list.add_item("%d. %s" % [
+			slot + 1,
+			"empty" if mon == null else "%s Lv%d" % [_species_name(mon.species), mon.level],
+		])
+
+
+func _refresh_items() -> void:
+	if _item_list == null:
+		return
+	_item_list.clear()
+	var state: Gen2WorldState = _editor.save.world.world_state if _editor.has_world() else null
+	if state == null:
+		_item_list.add_item("This save has no world state.")
+		_money_field.editable = false
+		_coins_field.editable = false
+		return
+	_money_field.set_value_no_signal(state.money(0))
+	_coins_field.set_value_no_signal(state.coins())
+	for item: Variant in state.items():
+		_item_list.add_item("%s x%d" % [
+			_item_name(int(item)), state.item_quantity(int(item)),
+		])
+
+
+func _refresh_events() -> void:
+	var flags: Array[int] = _editor.badge_flags()
+	var state: Gen2WorldState = _editor.save.world.world_state if _editor.has_world() else null
+	for index: int in _badge_boxes.size():
+		var box: CheckBox = _badge_boxes[index]
+		box.disabled = state == null or index >= flags.size()
+		box.set_pressed_no_signal(
+			state != null and index < flags.size() and state.is_engine_flag_active(flags[index])
+		)
+
+
+func _refresh_map() -> void:
+	if not _editor.has_world():
+		return
+	var world: Gen2WorldSnapshot = _editor.save.world
+	_map_fields["group"].set_value_no_signal(world.map_id.x)
+	_map_fields["number"].set_value_no_signal(world.map_id.y)
+	_map_fields["x"].set_value_no_signal(world.player_cell.x)
+	_map_fields["y"].set_value_no_signal(world.player_cell.y)
+	_map_fields["day"].set_value_no_signal(world.world_day)
+	_map_fields["hour"].set_value_no_signal(world.world_hour)
+	_map_fields["minute"].set_value_no_signal(world.world_minute)
+
+
+func _refresh_dex() -> void:
+	if _dex_list == null:
+		return
+	_dex_list.clear()
+	if not _editor.has_world():
+		_dex_list.add_item("This save has no world state.")
+		return
+	var seen: Dictionary = _editor.save.world.world_state.seen_species()
+	var numbers: Array = seen.keys()
+	numbers.sort()
+	for species: Variant in numbers:
+		_dex_list.add_item("%d %s" % [int(species), _species_name(int(species))])
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+func _set_badge(index: int, pressed: bool) -> void:
+	var flags: Array[int] = _editor.badge_flags()
+	if index >= flags.size():
+		return
+	_apply(_editor.set_engine_flag(flags[index], pressed))
+
+
+func _apply_position() -> void:
+	_apply(_editor.set_player_position(
+		Vector2i(int(_map_fields["group"].value), int(_map_fields["number"].value)),
+		Vector2i(int(_map_fields["x"].value), int(_map_fields["y"].value)),
+	))
+
+
+## A refused edit reports why and leaves the controls showing what is actually
+## stored, which is why this refreshes on failure as well as success.
+func _apply(result: Dictionary, refresh: bool = true) -> void:
+	if _editor == null:
+		return
+	_set_status("" if bool(result["ok"]) else String(result["message"]))
+	if refresh:
+		_refresh()
+	else:
+		_refresh_validity()
+
+
+func _close() -> void:
+	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
+
+
+func _species_name(species: int) -> String:
+	var row: Dictionary = _editor.data.species(species)
+	return String(row.get("name", "?")) if not row.is_empty() else "unknown %d" % species
+
+
+func _item_name(item: int) -> String:
+	var row: Dictionary = _editor.data.item(item)
+	return String(row.get("name", "?")) if not row.is_empty() else "unknown %d" % item
+
+
+func _set_status(message: String) -> void:
+	if _status != null:
+		_status.text = message
+
+
+func _label(text: String) -> Label:
+	var label := Label.new()
+	label.text = text
+	return label
+
+
+func _action(text: String, handler: Callable) -> Button:
+	var button := Button.new()
+	button.text = text
+	button.pressed.connect(handler)
+	return button
+
+
+func _field(text: String, value: int, minimum: int, maximum: int, handler: Callable) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	row.add_child(_label(text))
+	var spin := SpinBox.new()
+	spin.min_value = minimum
+	spin.max_value = maximum
+	spin.value = value
+	spin.value_changed.connect(func(changed: float) -> void: handler.call(int(changed)))
+	row.add_child(spin)
+	return row

--- a/game/save/save_editor_screen.gd.uid
+++ b/game/save/save_editor_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://8ka6twveyvpv

--- a/game/save/save_editor_screen.tscn
+++ b/game/save/save_editor_screen.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://game/save/save_editor_screen.gd" id="1"]
+
+[node name="SaveEditorScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -52,9 +52,9 @@ func set_data(data: GameData) -> void:
 		_refresh()
 
 
-## Selects one of the three project slots.
+## Selects a project slot by number.
 func select_slot(slot: int) -> bool:
-	if slot < 0 or slot >= Gen2SaveStore.SLOT_COUNT:
+	if slot < 0 or slot >= Gen2SaveStore.MAX_SLOTS:
 		return false
 	_selected_slot = slot
 	_new_game_visible = false
@@ -64,9 +64,28 @@ func select_slot(slot: int) -> bool:
 
 ## Opens the new-game form for a slot. Existing slots require confirmation
 ## through the button-driven path, while tests and tools may call this directly.
+## Without a slot, an unselected screen falls back to a fresh one, which is the
+## only thing a game with no saves at all can mean.
 func open_new_game(slot: int = -1) -> bool:
 	if slot >= 0 and not select_slot(slot):
 		return false
+	if slot < 0 and _selected_slot < 0 and not open_new_slot():
+		return false
+	_new_game_visible = true
+	_refresh_details()
+	return true
+
+
+## Targets the next unused slot, the "new save slot" action. Fails only when
+## every slot number is taken.
+func open_new_slot() -> bool:
+	if _data == null:
+		return false
+	var slot: int = Gen2SaveStore.next_free_slot(_data.id, _data.sha1)
+	if slot < 0:
+		_set_status("No new slot is available.", "Delete a save to free one.", ERROR)
+		return false
+	_selected_slot = slot
 	_new_game_visible = true
 	_refresh_details()
 	return true
@@ -76,6 +95,13 @@ func open_new_game(slot: int = -1) -> bool:
 func create_new_game(player_name: String, _starter_species: int = -1) -> bool:
 	if _data == null:
 		_set_status("New game unavailable.", "No imported cartridge cache is selected.", ERROR)
+		return false
+	# Nothing is selected when the game has no saves at all, and a new game is
+	# then unambiguously a new slot.
+	if _selected_slot < 0:
+		_selected_slot = Gen2SaveStore.next_free_slot(_data.id, _data.sha1)
+	if _selected_slot < 0:
+		_set_status("New game was not created.", "Every save slot is in use.", ERROR)
 		return false
 	var created: Gen2SaveData = Gen2SaveStore.create_new_game(
 		_data, _selected_slot, player_name
@@ -272,8 +298,10 @@ func _refresh() -> void:
 		_set_status("No cartridge cache is ready.", "Return to the launcher and import a supported ROM.", ERROR)
 		return
 	_slots = Gen2SaveStore.slots_for(_data.id, _data.sha1, _data)
-	if _selected_slot < 0 or _selected_slot >= _slots.size():
-		_selected_slot = 0
+	# Slots are created on demand, so a slot number is no longer its own index
+	# in this list and a game with no saves has no selectable slot at all.
+	if _row_for(_selected_slot).is_empty():
+		_selected_slot = int(_slots[0]["slot"]) if not _slots.is_empty() else -1
 	_slots_section.visible = not _new_game_visible
 	_slot_scroll.visible = not _new_game_visible
 	_refresh_slot_cards()
@@ -326,9 +354,9 @@ func _refresh_details() -> void:
 	_slot_scroll.visible = not _new_game_visible
 	for child: Node in _details_box.get_children():
 		child.free()
-	if _data == null or _slots.is_empty():
+	var row: Dictionary = _row_for(_selected_slot)
+	if _data == null or row.is_empty():
 		return
-	var row: Dictionary = _slots[_selected_slot]
 	var heading := Label.new()
 	heading.text = "SLOT %d" % (_selected_slot + 1)
 	heading.add_theme_color_override("font_color", TEXT)
@@ -505,18 +533,29 @@ func _back_to_launcher() -> void:
 	get_tree().change_scene_to_file.call_deferred("res://game/main/main.tscn")
 
 
+## The listed row for a slot number, or an empty dictionary when that slot has
+## no save. [member _slots] holds only occupied slots, so this is a search
+## rather than an index.
+func _row_for(slot: int) -> Dictionary:
+	if slot < 0:
+		return {}
+	for row: Dictionary in _slots:
+		if int(row["slot"]) == slot:
+			return row
+	return {}
+
+
 func _load_selected_save() -> Gen2SaveData:
-	if _data == null or _selected_slot < 0 or _selected_slot >= _slots.size():
-		return null
-	var row: Dictionary = _slots[_selected_slot]
-	if not row["valid"]:
+	var row: Dictionary = _row_for(_selected_slot)
+	if _data == null or row.is_empty() or not row["valid"]:
 		return null
 	var result: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, _selected_slot, _data)
 	return result["save"] if result["ok"] else null
 
 
 func _slot_exists() -> bool:
-	return _selected_slot >= 0 and _selected_slot < _slots.size() and bool(_slots[_selected_slot]["exists"])
+	var row: Dictionary = _row_for(_selected_slot)
+	return not row.is_empty() and bool(row["exists"])
 
 
 func _slot_state(row: Dictionary) -> String:

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -34,6 +34,9 @@ var _status_label: Label = null
 var _status_detail: Label = null
 var _name_input: LineEdit = null
 var _confirm_dialog: ConfirmationDialog = null
+var _delete_dialog: ConfirmationDialog = null
+var _export_dialog: FileDialog = null
+var _slot_import_dialog: FileDialog = null
 var _file_dialog: FileDialog = null
 
 
@@ -286,6 +289,30 @@ func _build_ui() -> void:
 	_confirm_dialog.confirmed.connect(_on_replace_confirmed)
 	add_child(_confirm_dialog)
 
+	_delete_dialog = ConfirmationDialog.new()
+	_delete_dialog.title = "Delete save slot?"
+	_delete_dialog.ok_button_text = "Delete"
+	_delete_dialog.confirmed.connect(_delete_selected_slot)
+	add_child(_delete_dialog)
+
+	_export_dialog = FileDialog.new()
+	_export_dialog.file_mode = FileDialog.FILE_MODE_SAVE_FILE
+	_export_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	_export_dialog.filters = PackedStringArray(["*.json; gen2recomp save"])
+	_export_dialog.title = "Export this save slot"
+	_export_dialog.use_native_dialog = _file_dialog.use_native_dialog
+	_export_dialog.file_selected.connect(_export_selected_slot)
+	add_child(_export_dialog)
+
+	_slot_import_dialog = FileDialog.new()
+	_slot_import_dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
+	_slot_import_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	_slot_import_dialog.filters = PackedStringArray(["*.json; gen2recomp save"])
+	_slot_import_dialog.title = "Import a gen2recomp save"
+	_slot_import_dialog.use_native_dialog = _file_dialog.use_native_dialog
+	_slot_import_dialog.file_selected.connect(_import_slot_file)
+	add_child(_slot_import_dialog)
+
 	_set_status(
 		"Select a save slot.",
 		"Create a new game, continue a validated save, or import an original cartridge save.",
@@ -393,6 +420,7 @@ func _refresh_details() -> void:
 		var replace_button := _button("Replace", TEXT)
 		replace_button.pressed.connect(_request_new_game)
 		actions.add_child(replace_button)
+		_add_slot_management()
 		return
 
 	var message := Label.new()
@@ -409,6 +437,101 @@ func _refresh_details() -> void:
 	var import_button := _button("Import .sav", TEXT)
 	import_button.pressed.connect(_request_import)
 	actions.add_child(import_button)
+	_add_slot_management()
+
+
+## Naming, export, deletion and the editor. Kept in its own row below the play
+## actions, because these are about the slot as a file rather than the game in
+## it, and only the last of them is reversible.
+func _add_slot_management() -> void:
+	var name_row := HBoxContainer.new()
+	name_row.add_theme_constant_override("separation", 10)
+	_details_box.add_child(name_row)
+	var name_input := LineEdit.new()
+	name_input.placeholder_text = "Slot name"
+	name_input.max_length = Gen2SaveData.MAX_LABEL
+	name_input.text = String(_row_for(_selected_slot).get("label", ""))
+	name_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	name_row.add_child(name_input)
+	var rename_button := _button("Rename", TEXT)
+	rename_button.pressed.connect(func() -> void: _rename_slot(name_input.text))
+	name_row.add_child(rename_button)
+
+	var file_row := HBoxContainer.new()
+	file_row.add_theme_constant_override("separation", 10)
+	_details_box.add_child(file_row)
+	var edit_button := _button("Edit save", ACCENT)
+	edit_button.pressed.connect(_open_editor)
+	file_row.add_child(edit_button)
+	var export_button := _button("Export", TEXT)
+	export_button.pressed.connect(func() -> void: _export_dialog.popup_centered(Vector2i(900, 600)))
+	file_row.add_child(export_button)
+	var import_button := _button("Import save", TEXT)
+	import_button.pressed.connect(func() -> void: _slot_import_dialog.popup_centered(Vector2i(900, 600)))
+	file_row.add_child(import_button)
+	var delete_button := _button("Delete slot", ERROR)
+	delete_button.pressed.connect(_request_delete)
+	file_row.add_child(delete_button)
+	var new_slot_button := _button("New slot", TEXT)
+	new_slot_button.pressed.connect(func() -> void: open_new_slot())
+	file_row.add_child(new_slot_button)
+
+
+func _rename_slot(label: String) -> void:
+	if _data == null:
+		return
+	var result: Dictionary = Gen2SaveStore.rename_slot(
+		_data.id, _data.sha1, _selected_slot, label, _data
+	)
+	if not result["ok"]:
+		_set_status("The slot was not renamed.", String(result["message"]), ERROR)
+		return
+	_set_status("Renamed slot %d." % (_selected_slot + 1), label, SUCCESS)
+	_refresh()
+
+
+func _request_delete() -> void:
+	if not _slot_exists():
+		return
+	_delete_dialog.dialog_text = "Delete slot %d? This cannot be undone." % (_selected_slot + 1)
+	_delete_dialog.popup_centered()
+
+
+func _delete_selected_slot() -> void:
+	if _data == null or not Gen2SaveStore.delete_slot(_data.id, _data.sha1, _selected_slot):
+		_set_status("The slot was not deleted.", "Nothing was removed.", ERROR)
+		return
+	_set_status("Deleted slot %d." % (_selected_slot + 1), "", MUTED)
+	_selected_slot = -1
+	GameRuntime.reload_selected_save()
+	_refresh()
+
+
+func _export_selected_slot(path: String) -> void:
+	var result: Dictionary = Gen2SaveStore.export_slot(
+		_data.id, _data.sha1, _selected_slot, path
+	)
+	if not result["ok"]:
+		_set_status("The save was not exported.", String(result["message"]), ERROR)
+		return
+	_set_status("Exported slot %d." % (_selected_slot + 1), path, SUCCESS)
+
+
+func _import_slot_file(path: String) -> void:
+	var result: Dictionary = Gen2SaveStore.import_slot(path, _data)
+	if not result["ok"]:
+		_set_status("That save was not imported.", String(result["message"]), ERROR)
+		return
+	_selected_slot = int(result["slot"])
+	_set_status("Imported into slot %d." % (_selected_slot + 1), path, SUCCESS)
+	_refresh()
+
+
+func _open_editor() -> void:
+	if _data == null or not GameRuntime.select_save_slot(_data.id, _selected_slot):
+		_set_status("The editor could not open.", "Select a readable slot first.", ERROR)
+		return
+	get_tree().change_scene_to_file.call_deferred("res://game/save/save_editor_screen.tscn")
 
 
 func _build_new_game_form() -> void:

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -5,7 +5,13 @@ extends RefCounted
 ## cartridge-derived data and has a different lifecycle.
 
 const ROOT: String = "user://save_slots"
-const SLOT_COUNT: int = 3
+## Slots are created on demand rather than preallocated, so this is only a
+## ceiling: it keeps a slot number a bounded, validatable thing and stops a
+## runaway caller filling the directory. Slot files are still `slot_N.json`,
+## so the three slots written before this stay exactly where they were.
+const MAX_SLOTS: int = 99
+const SLOT_PREFIX: String = "slot_"
+const SLOT_SUFFIX: String = ".json"
 const BACKUP_SUFFIX: String = ".bak"
 const CONTAINER_PREFIX: String = "#gen2save"
 const CONTAINER_VERSION: int = 1
@@ -16,8 +22,14 @@ const STARTER_SPECIES: Array[int] = [152, 155, 158]
 const STARTER_ITEM: int = 0xAD
 
 
+static func directory_for(game_id: StringName, rom_sha1: String) -> String:
+	return "%s/%s_%s" % [ROOT, String(game_id), rom_sha1.substr(0, 8)]
+
+
 static func path_for(game_id: StringName, rom_sha1: String, slot: int) -> String:
-	return "%s/%s_%s/slot_%d.json" % [ROOT, String(game_id), rom_sha1.substr(0, 8), slot]
+	return "%s/%s%d%s" % [
+		directory_for(game_id, rom_sha1), SLOT_PREFIX, slot, SLOT_SUFFIX
+	]
 
 
 static func backup_path_for(game_id: StringName, rom_sha1: String, slot: int) -> String:
@@ -85,21 +97,144 @@ static func load_result(game_id: StringName, rom_sha1: String, slot: int, data: 
 	return primary_result
 
 
+## The slots that exist, in slot order. Unlike the fixed-count version this
+## returns nothing for a game with no saves, so a caller draws what is there
+## and offers to create the rest.
 static func slots_for(game_id: StringName, rom_sha1: String, data: GameData) -> Array:
 	var out: Array = []
-	for slot: int in SLOT_COUNT:
+	for slot: int in occupied_slots(game_id, rom_sha1):
 		var row: Dictionary = {
 			"slot": slot,
-			"exists": exists(game_id, rom_sha1, slot),
+			"exists": true,
 			"valid": false,
+			"label": "",
+			"player_name": "",
 			"message": "Empty",
 		}
-		if row["exists"]:
-			var result: Dictionary = load_result(game_id, rom_sha1, slot, data)
-			row["valid"] = bool(result["ok"])
-			row["message"] = "Ready" if result["ok"] else String(result["message"])
+		var result: Dictionary = load_result(game_id, rom_sha1, slot, data)
+		row["valid"] = bool(result["ok"])
+		row["message"] = "Ready" if result["ok"] else String(result["message"])
+		if result["ok"]:
+			var loaded: Gen2SaveData = result["save"]
+			row["label"] = loaded.label
+			row["player_name"] = loaded.player_name
 		out.append(row)
 	return out
+
+
+## Slot numbers with a primary or backup copy on disk, ascending. Reads the
+## directory rather than probing every number, so an empty game costs one
+## listing instead of MAX_SLOTS existence checks.
+static func occupied_slots(game_id: StringName, rom_sha1: String) -> Array[int]:
+	var found: Array[int] = []
+	var directory: String = directory_for(game_id, rom_sha1)
+	if not DirAccess.dir_exists_absolute(directory):
+		return found
+	for file_name: String in DirAccess.get_files_at(directory):
+		var slot: int = _slot_from_file_name(file_name)
+		if slot >= 0 and not found.has(slot):
+			found.append(slot)
+	found.sort()
+	return found
+
+
+## Accepts the backup copy too, so a slot whose primary was lost still counts
+## as occupied, matching [method exists].
+static func _slot_from_file_name(file_name: String) -> int:
+	var name: String = file_name
+	if name.ends_with(BACKUP_SUFFIX):
+		name = name.substr(0, name.length() - BACKUP_SUFFIX.length())
+	if not name.begins_with(SLOT_PREFIX) or not name.ends_with(SLOT_SUFFIX):
+		return -1
+	var digits: String = name.substr(
+		SLOT_PREFIX.length(), name.length() - SLOT_PREFIX.length() - SLOT_SUFFIX.length()
+	)
+	if not digits.is_valid_int():
+		return -1
+	var slot: int = int(digits)
+	return slot if _valid_slot(slot) else -1
+
+
+## The lowest unused slot number, or -1 when the ceiling is reached. Reusing a
+## freed number rather than always counting up keeps a player who deletes and
+## recreates from drifting towards the cap.
+static func next_free_slot(game_id: StringName, rom_sha1: String) -> int:
+	var used: Array[int] = occupied_slots(game_id, rom_sha1)
+	for slot: int in MAX_SLOTS:
+		if not used.has(slot):
+			return slot
+	return -1
+
+
+## Renames a slot in place. The label lives in the save itself rather than a
+## sidecar, so an exported file carries its own name.
+static func rename_slot(
+	game_id: StringName, rom_sha1: String, slot: int, new_label: String, data: GameData
+) -> Dictionary:
+	var trimmed: String = new_label.strip_edges()
+	if trimmed.length() > Gen2SaveData.MAX_LABEL:
+		return _failure("a slot name is at most %d characters" % Gen2SaveData.MAX_LABEL)
+	var result: Dictionary = load_result(game_id, rom_sha1, slot, data)
+	if not result["ok"]:
+		return result
+	var loaded: Gen2SaveData = result["save"]
+	loaded.label = trimmed
+	return save(loaded, data)
+
+
+## Copies the primary slot file to a player-chosen path. The container header
+## goes with it, so an exported file is exactly what [method import_slot]
+## expects back and is checksum-checked on the way in.
+static func export_slot(
+	game_id: StringName, rom_sha1: String, slot: int, target_path: String
+) -> Dictionary:
+	if not exists(game_id, rom_sha1, slot):
+		return _failure("save slot %d is empty" % (slot + 1))
+	var source: String = path_for(game_id, rom_sha1, slot)
+	if not FileAccess.file_exists(source):
+		source = backup_path_for(game_id, rom_sha1, slot)
+	var reader: FileAccess = FileAccess.open(source, FileAccess.READ)
+	if reader == null:
+		return _failure("the save could not be read for export")
+	var document: String = reader.get_as_text()
+	reader.close()
+	var written: Dictionary = _write_file(target_path, document)
+	if not written["ok"]:
+		return _failure("the save could not be written to %s" % target_path)
+	return {"ok": true, "message": "", "path": target_path}
+
+
+## Reads an exported file into the next free slot. The file is validated
+## against the selected cache before anything is written, and its recorded
+## game and cartridge must match, so one cartridge's save cannot land under
+## another's.
+static func import_slot(source_path: String, data: GameData) -> Dictionary:
+	if data == null:
+		return _failure("no cartridge cache is selected")
+	var reader: FileAccess = FileAccess.open(source_path, FileAccess.READ)
+	if reader == null:
+		return _failure("that file could not be read")
+	var text: String = reader.get_as_text()
+	reader.close()
+	var container: Dictionary = _unwrap(text)
+	if not container["ok"]:
+		return _failure(String(container["message"]))
+	var parser := JSON.new()
+	if parser.parse(String(container["payload"])) != OK:
+		return _failure("that file is not valid save data")
+	var candidate: Gen2SaveData = Gen2SaveData.from_dict(parser.data)
+	if candidate == null:
+		return _failure("that file is not valid save data")
+	if candidate.game_id != data.id or candidate.rom_sha1 != data.sha1:
+		return _failure("that save belongs to a different cartridge")
+	var slot: int = next_free_slot(data.id, data.sha1)
+	if slot < 0:
+		return _failure("every save slot is in use")
+	candidate.slot = slot
+	var result: Dictionary = save(candidate, data)
+	if not result["ok"]:
+		return result
+	return {"ok": true, "message": "", "slot": slot, "save": candidate}
 
 
 ## Creates the same deterministic development party the old battle screen used,
@@ -242,7 +377,7 @@ static func _checksum(payload: String) -> int:
 
 
 static func _valid_slot(slot: int) -> bool:
-	return slot >= 0 and slot < SLOT_COUNT
+	return slot >= 0 and slot < MAX_SLOTS
 
 
 static func _failure(message: String) -> Dictionary:

--- a/game/save/save_validator.gd
+++ b/game/save/save_validator.gd
@@ -17,12 +17,14 @@ static func validate(save: Gen2SaveData, data: GameData) -> Dictionary:
 		return _failure("the save belongs to %s, not %s" % [save.game_id, data.id])
 	if save.rom_sha1 != data.sha1:
 		return _failure("the save belongs to a different cartridge revision")
-	if save.slot < 0 or save.slot >= Gen2SaveStore.SLOT_COUNT:
+	if save.slot < 0 or save.slot >= Gen2SaveStore.MAX_SLOTS:
 		return _failure("save slot %d is out of range" % save.slot)
 	if save.player_name.is_empty():
 		return _failure("the player name is empty")
 	if Gen2Text.encoded_length(save.player_name) > Gen2SaveData.MAX_PLAYER_NAME:
 		return _failure("the player name is too long")
+	if save.label.length() > Gen2SaveData.MAX_LABEL:
+		return _failure("the slot name is too long")
 	if save.party.size() > Gen2SaveData.MAX_PARTY:
 		return _failure("the party cannot contain more than six Pokémon")
 	if not save.boxes_shape_valid or save.boxes.size() != Gen2SaveData.BOX_COUNT:

--- a/game/save/save_validator.gd
+++ b/game/save/save_validator.gd
@@ -129,7 +129,7 @@ static func _validate_mon(
 	)
 	if mon.hp < 0 or mon.hp > max_hp:
 		return _failure("%s has invalid HP" % subject)
-	if not _valid_status(mon.status):
+	if not is_valid_status(mon.status):
 		return _failure("%s has invalid status" % subject)
 
 	if mon.moves.size() != Gen2SaveMon.MAX_MOVES or mon.pp.size() != Gen2SaveMon.MAX_MOVES:
@@ -159,7 +159,9 @@ static func _validate_mon(
 	return {"ok": true, "message": ""}
 
 
-static func _valid_status(status: int) -> bool:
+## Public because [Gen2SaveEditor] refuses the same statuses this rejects, and
+## one of the two having its own copy is how they drift apart.
+static func is_valid_status(status: int) -> bool:
 	if status < 0 or (status & ~Gen2Status.ANY) != 0:
 		return false
 	var flags: int = status & (Gen2Status.POISON | Gen2Status.BURN | Gen2Status.FREEZE | Gen2Status.PARALYSIS)

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -196,7 +196,7 @@ static func _validate_request(
 		return _failure("unsupported cartridge game %s" % game_id)
 	if RomRegistry.sha1_for(game_id) != rom_sha1:
 		return _failure("the save belongs to an unsupported cartridge revision")
-	if slot < 0 or slot >= Gen2SaveStore.SLOT_COUNT:
+	if slot < 0 or slot >= Gen2SaveStore.MAX_SLOTS:
 		return _failure("save slot %d is out of range" % slot)
 	if raw.size() < SRAM_SIZE:
 		return _failure("cartridge save is shorter than 32 KiB")

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -534,6 +534,17 @@ func seen_species() -> Dictionary:
 	return _seen_species.duplicate()
 
 
+## Clearing drops the entry rather than storing false, so the dictionary holds
+## only what has been seen and round-trips through a snapshot unchanged.
+func set_species_seen(species: int, seen: bool = true) -> void:
+	if species <= 0:
+		return
+	if seen:
+		_seen_species[species] = true
+	else:
+		_seen_species.erase(species)
+
+
 ## Advances each active roaming Pokémon using the source's connected-map
 ## selection. A zero in the source's five-bit mask performs a random jump to a
 ## roaming map; otherwise the low two bits select one of the current row's

--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="gen2recomp"
+config/version="0.1.0"
 run/main_scene="res://game/main/main.tscn"
 config/features=PackedStringArray("4.8", "GL Compatibility")
 config/icon="res://icon.svg"

--- a/tests/integration/test_save_editor_screen.gd
+++ b/tests/integration/test_save_editor_screen.gd
@@ -1,0 +1,115 @@
+extends GutTest
+
+## Drives the real editor scene. The rules are covered by test_save_editor.gd;
+## this checks the screen shows what the editor holds and reports a refusal
+## instead of quietly leaving a stale control on screen.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
+var _directory: String = ""
+var _data: GameData = null
+var _screen: Control = null
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"savetest", "0123456789abcdef")
+	_data = Fixture.build(_directory)
+
+
+func after_each() -> void:
+	if is_instance_valid(_screen):
+		_screen.free()
+	_screen = null
+	Gen2SaveStore.delete_slot(_data.id, _data.sha1, 0)
+	RomCache.clear(_directory)
+
+
+func _save() -> Gen2SaveData:
+	var pikachu: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.PIKACHU, 20, [Fixture.TACKLE], Gen2BattleMon.PERFECT_DVS
+	)
+	return Gen2SaveBattleAdapter.from_battle_party(
+		_data.id, _data.sha1, 0, Gen2Party.create([pikachu]), "RED"
+	)
+
+
+func _open(save: Gen2SaveData = null) -> void:
+	var packed: PackedScene = load("res://game/save/save_editor_screen.tscn")
+	_screen = packed.instantiate()
+	add_child(_screen)
+	await get_tree().process_frame
+	_screen.set_editor(Gen2SaveEditor.open(save if save != null else _save(), _data))
+
+
+func test_the_screen_opens_a_save_and_reports_it_valid() -> void:
+	await _open()
+	var snapshot: Dictionary = _screen.editor_snapshot()
+
+	assert_true(snapshot["open"])
+	assert_true(snapshot["valid"], snapshot["message"])
+	assert_false(snapshot["dirty"])
+	assert_eq(snapshot["player_name"], "RED")
+	assert_eq((snapshot["party"] as Array).size(), 1)
+
+
+func test_a_screen_with_no_save_reports_closed() -> void:
+	var packed: PackedScene = load("res://game/save/save_editor_screen.tscn")
+	_screen = packed.instantiate()
+	add_child(_screen)
+	await get_tree().process_frame
+
+	assert_false(_screen.editor_snapshot()["open"])
+
+
+func test_every_tab_can_be_selected_by_name() -> void:
+	await _open()
+	for tab: StringName in _screen.TABS:
+		assert_true(_screen.select_tab(tab), String(tab))
+		assert_eq(_screen.editor_snapshot()["tab"], tab)
+	assert_false(_screen.select_tab(&"nowhere"))
+
+
+func test_selecting_a_party_member_that_is_not_there_is_refused() -> void:
+	await _open()
+	assert_true(_screen.select_party_member(0))
+	assert_eq(_screen.editor_snapshot()["selected_party"], 0)
+	assert_false(_screen.select_party_member(3))
+
+
+func test_saving_writes_the_slot_and_leaves_it_clean() -> void:
+	await _open()
+	assert_true(_screen.select_party_member(0))
+	var editor: Gen2SaveEditor = Gen2SaveEditor.open(_save(), _data)
+	_screen.set_editor(editor)
+	assert_true(editor.set_player_name("ASH")["ok"])
+	assert_true(_screen.editor_snapshot()["dirty"])
+
+	assert_true(_screen.save_now())
+	assert_false(_screen.editor_snapshot()["dirty"])
+
+	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
+	assert_true(loaded["ok"], loaded["message"])
+	assert_eq((loaded["save"] as Gen2SaveData).player_name, "ASH")
+
+
+func test_reloading_drops_uncommitted_edits() -> void:
+	var stored: Gen2SaveData = _save()
+	assert_true(Gen2SaveStore.save(stored, _data)["ok"])
+	await _open(stored)
+
+	var editor: Gen2SaveEditor = Gen2SaveEditor.open(stored, _data)
+	_screen.set_editor(editor)
+	assert_true(editor.set_player_name("ASH")["ok"])
+
+	assert_true(_screen.reload_now())
+	assert_eq(_screen.editor_snapshot()["player_name"], "RED")
+	assert_false(_screen.editor_snapshot()["dirty"])
+
+
+## The fixture cache has no maps, so a world snapshot on it is exactly the case
+## the map tab must refuse rather than write.
+func test_a_save_without_world_state_still_opens() -> void:
+	await _open()
+	assert_false(_screen.editor_snapshot()["has_world"])
+	assert_true(_screen.select_tab(&"items"))
+	assert_true(_screen.editor_snapshot()["valid"])

--- a/tests/integration/test_save_editor_screen.gd.uid
+++ b/tests/integration/test_save_editor_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://blgohm8xq2607

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -68,7 +68,7 @@ func test_runtime_selection_accepts_registry_games_and_rejects_unknown_ids() -> 
 	assert_eq(GameRuntime.selected_save_slot, 1)
 	assert_false(GameRuntime.select_game(&"not_a_game"))
 	assert_eq(GameRuntime.selected_game_id, RomRegistry.CRYSTAL)
-	assert_false(GameRuntime.select_save_slot(RomRegistry.CRYSTAL, Gen2SaveStore.SLOT_COUNT))
+	assert_false(GameRuntime.select_save_slot(RomRegistry.CRYSTAL, Gen2SaveStore.MAX_SLOTS))
 	assert_eq(GameRuntime.selected_save_slot, 1)
 
 	GameRuntime.selected_game_id = previous

--- a/tests/unit/test_mod_state.gd
+++ b/tests/unit/test_mod_state.gd
@@ -1,0 +1,119 @@
+extends GutTest
+
+## Enable/disable state and the host's use of it. These write real files under
+## user://, so each test clears both the state file and the mod root it uses.
+
+const ROOT: String = "user://mod-state-test"
+const MOD_ID: StringName = &"state_probe"
+const OTHER_ID: StringName = &"state_probe_two"
+
+
+func before_each() -> void:
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
+	_clear_root()
+
+
+func after_each() -> void:
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
+	_clear_root()
+
+
+func _clear_root() -> void:
+	if not DirAccess.dir_exists_absolute(ROOT):
+		return
+	for id: String in DirAccess.get_directories_at(ROOT):
+		var directory: String = "%s/%s" % [ROOT, id]
+		for file_name: String in DirAccess.get_files_at(directory):
+			DirAccess.remove_absolute("%s/%s" % [directory, file_name])
+		DirAccess.remove_absolute(directory)
+	DirAccess.remove_absolute(ROOT)
+
+
+## A minimal installed mod: a manifest plus an entry script whose register()
+## records that it ran, so a skipped mod is observable rather than assumed.
+func _install(id: StringName) -> void:
+	var directory: String = "%s/%s" % [ROOT, id]
+	DirAccess.make_dir_recursive_absolute(directory)
+	var manifest: FileAccess = FileAccess.open(
+		"%s/%s" % [directory, Gen2ModManifest.FILENAME], FileAccess.WRITE
+	)
+	manifest.store_string(JSON.stringify({
+		"id": String(id), "name": "State probe", "version": "1.0.0", "entry": "mod.gd",
+		"api_version": Gen2ModManifest.API_VERSION,
+	}))
+	manifest.close()
+	var entry: FileAccess = FileAccess.open("%s/mod.gd" % directory, FileAccess.WRITE)
+	entry.store_string("extends RefCounted\n\n\nfunc register(_host, _manifest) -> void:\n\tpass\n")
+	entry.close()
+
+
+func test_a_mod_is_enabled_until_it_is_switched_off() -> void:
+	assert_true(Gen2ModState.is_enabled(MOD_ID))
+
+	assert_true(Gen2ModState.set_enabled(MOD_ID, false))
+	assert_false(Gen2ModState.is_enabled(MOD_ID))
+
+	assert_true(Gen2ModState.set_enabled(MOD_ID, true))
+	assert_true(Gen2ModState.is_enabled(MOD_ID))
+
+
+func test_the_off_switch_survives_a_reload() -> void:
+	assert_true(Gen2ModState.set_enabled(MOD_ID, false))
+	Gen2ModState.reload()
+
+	assert_false(Gen2ModState.is_enabled(MOD_ID))
+	assert_eq(Gen2ModState.disabled_ids(), [MOD_ID] as Array[StringName])
+
+
+func test_disabling_many_at_once_is_one_write() -> void:
+	assert_true(Gen2ModState.set_all_enabled([MOD_ID, OTHER_ID], false))
+	Gen2ModState.reload()
+
+	assert_false(Gen2ModState.is_enabled(MOD_ID))
+	assert_false(Gen2ModState.is_enabled(OTHER_ID))
+
+	assert_true(Gen2ModState.set_all_enabled([MOD_ID, OTHER_ID], true))
+	Gen2ModState.reload()
+	assert_eq(Gen2ModState.disabled_ids().size(), 0)
+
+
+func test_an_empty_id_is_refused() -> void:
+	assert_false(Gen2ModState.set_enabled(&"", false))
+
+
+func test_a_damaged_state_file_leaves_every_mod_enabled() -> void:
+	var file: FileAccess = FileAccess.open(Gen2ModState.PATH, FileAccess.WRITE)
+	file.store_string("{ not json")
+	file.close()
+	Gen2ModState.reload()
+
+	assert_true(Gen2ModState.is_enabled(MOD_ID))
+	assert_eq(Gen2ModState.disabled_ids().size(), 0)
+
+
+func test_a_disabled_mod_is_discovered_but_not_loaded() -> void:
+	_install(MOD_ID)
+	var host := Gen2ModHost.new()
+
+	assert_eq(host.discover(ROOT).size(), 1, "a disabled mod is still listed")
+	assert_eq(host.load_discovered(), [MOD_ID] as Array)
+
+	assert_true(Gen2ModState.set_enabled(MOD_ID, false))
+	var second := Gen2ModHost.new()
+	assert_eq(second.discover(ROOT).size(), 1)
+	assert_eq(second.load_discovered().size(), 0, "it is skipped, not run")
+	assert_eq(second.failures().size(), 0, "and being off is not a failure")
+
+
+func test_uninstalling_forgets_the_off_switch() -> void:
+	_install(MOD_ID)
+	assert_true(Gen2ModState.set_enabled(MOD_ID, false))
+
+	assert_true(Gen2ModInstaller.uninstall(MOD_ID, ROOT)["ok"])
+	assert_eq(Gen2ModState.disabled_ids().size(), 0)
+	assert_true(
+		Gen2ModState.is_enabled(MOD_ID),
+		"a reinstall must not find itself silently disabled",
+	)

--- a/tests/unit/test_mod_state.gd.uid
+++ b/tests/unit/test_mod_state.gd.uid
@@ -1,0 +1,1 @@
+uid://cfnmpy0y6v4sf

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -1,0 +1,170 @@
+extends GutTest
+
+## The cartridge block is checked against `data/default_options.asm` and the
+## `options_menu.asm` handlers, which are byte identical between the two pins.
+
+const DEFAULT_OPTIONS_BYTES: Array[int] = [0x03, 0x00, 0x00, 0x01, 0x40, 0x01, 0x00, 0x00]
+
+
+func after_each() -> void:
+	Gen2OptionsStore.forget_cached()
+	DirAccess.remove_absolute(Gen2OptionsStore.PATH)
+
+
+func test_defaults_match_the_source_default_options_table() -> void:
+	var options := Gen2Options.new()
+	var bytes: PackedByteArray = options.to_source_bytes()
+
+	assert_eq(bytes.size(), Gen2Options.SOURCE_BLOCK_SIZE)
+	for index: int in DEFAULT_OPTIONS_BYTES.size():
+		assert_eq(
+			bytes[index],
+			DEFAULT_OPTIONS_BYTES[index],
+			"DefaultOptions byte %d" % index,
+		)
+
+
+func test_battle_scene_bit_is_set_when_the_scene_is_off() -> void:
+	var options := Gen2Options.new()
+	options.battle_scene = true
+	assert_eq(options.to_source_bytes()[0] & (1 << Gen2Options.BIT_BATTLE_SCENE), 0)
+
+	options.battle_scene = false
+	assert_ne(options.to_source_bytes()[0] & (1 << Gen2Options.BIT_BATTLE_SCENE), 0)
+
+
+func test_battle_shift_bit_is_set_for_set_not_for_shift() -> void:
+	var options := Gen2Options.new()
+	options.battle_style_set = false
+	assert_eq(options.to_source_bytes()[0] & (1 << Gen2Options.BIT_BATTLE_SHIFT), 0)
+
+	options.battle_style_set = true
+	assert_ne(options.to_source_bytes()[0] & (1 << Gen2Options.BIT_BATTLE_SHIFT), 0)
+
+
+func test_text_speed_round_trips_through_the_source_delays() -> void:
+	for index: int in Gen2Options.TEXT_DELAYS.size():
+		var options := Gen2Options.new()
+		options.text_speed = index
+		var bytes: PackedByteArray = options.to_source_bytes()
+		assert_eq(bytes[0] & Gen2Options.TEXT_DELAY_MASK, Gen2Options.TEXT_DELAYS[index])
+
+		var restored := Gen2Options.new()
+		assert_true(restored.apply_source_bytes(bytes))
+		assert_eq(restored.text_speed, index)
+
+
+func test_an_unlisted_text_delay_reads_as_medium() -> void:
+	var bytes: PackedByteArray = Gen2Options.new().to_source_bytes()
+	bytes[0] = (bytes[0] & ~Gen2Options.TEXT_DELAY_MASK) | 0b111
+
+	var options := Gen2Options.new()
+	assert_true(options.apply_source_bytes(bytes))
+	assert_eq(options.text_speed, 1, "GetTextSpeed falls through to medium")
+
+
+func test_an_unlisted_printer_brightness_reads_as_normal() -> void:
+	var bytes: PackedByteArray = Gen2Options.new().to_source_bytes()
+	bytes[Gen2Options.OFFSET_PRINTER] = 0x11
+
+	var options := Gen2Options.new()
+	assert_true(options.apply_source_bytes(bytes))
+	assert_eq(options.printer_brightness, Gen2Options.PRINTER_NORMAL_INDEX)
+
+
+func test_a_short_source_block_is_refused() -> void:
+	var options := Gen2Options.new()
+	assert_false(options.apply_source_bytes(PackedByteArray([0x03, 0x00])))
+
+
+func test_every_cartridge_field_survives_a_byte_round_trip() -> void:
+	var options := Gen2Options.new()
+	options.text_speed = 2
+	options.battle_scene = false
+	options.battle_style_set = true
+	options.stereo = true
+	options.printer_brightness = 4
+	options.menu_account = false
+	options.textbox_frame = 6
+	options.fast_text_delay = false
+
+	var restored := Gen2Options.new()
+	assert_true(restored.apply_source_bytes(options.to_source_bytes()))
+	assert_eq(restored.text_speed, 2)
+	assert_false(restored.battle_scene)
+	assert_true(restored.battle_style_set)
+	assert_true(restored.stereo)
+	assert_eq(restored.printer_brightness, 4)
+	assert_false(restored.menu_account)
+	assert_eq(restored.textbox_frame, 6)
+	assert_false(restored.fast_text_delay)
+
+
+func test_out_of_range_values_are_clamped_rather_than_refused() -> void:
+	var options: Gen2Options = Gen2Options.parse({
+		"text_speed": 99,
+		"music_volume": -4,
+		"sfx_volume": 900,
+		"textbox_frame": 12,
+		"video_mode": "hologram",
+		"game_speed": "",
+		"max_fps": 7,
+	})
+
+	assert_eq(options.text_speed, 2)
+	assert_eq(options.music_volume, 0)
+	assert_eq(options.sfx_volume, Gen2Options.MAX_VOLUME)
+	assert_eq(options.textbox_frame, Gen2Options.FRAME_COUNT - 1)
+	assert_eq(options.video_mode, &"windowed")
+	assert_eq(options.game_speed, &"normal")
+	assert_eq(options.max_fps, 60, "an unlisted frame cap falls back to 60")
+
+
+func test_a_non_dictionary_parses_as_defaults() -> void:
+	var options: Gen2Options = Gen2Options.parse("not options")
+	assert_eq(options.to_source_bytes(), Gen2Options.new().to_source_bytes())
+
+
+func test_saving_then_loading_keeps_both_blocks() -> void:
+	var options := Gen2Options.new()
+	options.battle_scene = false
+	options.textbox_frame = 3
+	options.music_volume = 2
+	options.video_mode = &"fullscreen"
+	options.max_fps = 120
+	assert_true(Gen2OptionsStore.save(options))
+
+	Gen2OptionsStore.forget_cached()
+	var loaded: Gen2Options = Gen2OptionsStore.load_options()
+	assert_false(loaded.battle_scene)
+	assert_eq(loaded.textbox_frame, 3)
+	assert_eq(loaded.music_volume, 2)
+	assert_eq(loaded.video_mode, &"fullscreen")
+	assert_eq(loaded.max_fps, 120)
+
+
+func test_a_missing_file_loads_defaults() -> void:
+	DirAccess.remove_absolute(Gen2OptionsStore.PATH)
+	Gen2OptionsStore.forget_cached()
+
+	var loaded: Gen2Options = Gen2OptionsStore.load_options()
+	assert_eq(loaded.to_source_bytes(), Gen2Options.new().to_source_bytes())
+
+
+func test_a_damaged_file_loads_defaults_rather_than_failing() -> void:
+	var file: FileAccess = FileAccess.open(Gen2OptionsStore.PATH, FileAccess.WRITE)
+	file.store_string("{ this is not json")
+	file.close()
+	Gen2OptionsStore.forget_cached()
+
+	var loaded: Gen2Options = Gen2OptionsStore.load_options()
+	assert_eq(loaded.to_source_bytes(), Gen2Options.new().to_source_bytes())
+
+
+func test_current_shares_one_object_until_forgotten() -> void:
+	var first: Gen2Options = Gen2OptionsStore.current()
+	first.music_volume = 1
+	assert_eq(Gen2OptionsStore.current().music_volume, 1)
+
+	Gen2OptionsStore.forget_cached()
+	assert_eq(Gen2OptionsStore.current().music_volume, 7)

--- a/tests/unit/test_options.gd.uid
+++ b/tests/unit/test_options.gd.uid
@@ -1,0 +1,1 @@
+uid://bvfundnhnqru5

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -25,7 +25,7 @@ func after_each() -> void:
 
 func _clear_saves() -> void:
 	var game_id: StringName = _data.id if _data != null else &"savetest"
-	for slot: int in Gen2SaveStore.SLOT_COUNT:
+	for slot: int in Gen2SaveStore.MAX_SLOTS:
 		var path: String = Gen2SaveStore.path_for(game_id, "0123456789abcdef", slot)
 		for copy: String in [path, "%s.bak" % path, "%s.tmp" % path, "%s.bak.tmp" % path]:
 			if FileAccess.file_exists(copy):

--- a/tests/unit/test_save_editor.gd
+++ b/tests/unit/test_save_editor.gd
@@ -1,0 +1,364 @@
+extends GutTest
+
+## The editor's whole promise is that an edited save still loads, so most of
+## these assert the invariant rather than the field: level and experience agree,
+## HP stays under a recomputed maximum, move slots stay contiguous.
+##
+## Party and box editing use the synthetic battle cache. World editing asserts
+## the state it changes directly, because that fixture has no maps and a world
+## snapshot only validates against a cartridge that does.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
+var _directory: String = ""
+var _data: GameData = null
+var _editor: Gen2SaveEditor = null
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"savetest", "0123456789abcdef")
+	_data = Fixture.build(_directory)
+	_editor = Gen2SaveEditor.open(_source_save(), _data)
+
+
+func after_each() -> void:
+	_editor = null
+	RomCache.clear(_directory)
+
+
+func _source_save() -> Gen2SaveData:
+	var pikachu: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.PIKACHU, 20, [Fixture.TACKLE, Fixture.THUNDERBOLT],
+		Gen2BattleMon.PERFECT_DVS
+	)
+	return Gen2SaveBattleAdapter.from_battle_party(
+		_data.id, _data.sha1, 0, Gen2Party.create([pikachu]), "RED"
+	)
+
+
+func _first() -> Gen2SaveMon:
+	return _editor.save.party[0]
+
+
+func _with_world() -> Gen2SaveEditor:
+	_editor.save.world = Gen2WorldSnapshot.new()
+	return _editor
+
+
+func test_opening_takes_a_working_copy() -> void:
+	var source: Gen2SaveData = _source_save()
+	var editor: Gen2SaveEditor = Gen2SaveEditor.open(source, _data)
+
+	assert_true(editor.set_player_name("ASH")["ok"])
+	assert_eq(source.player_name, "RED", "the original is untouched until commit")
+
+
+func test_opening_without_a_save_or_cache_answers_null() -> void:
+	assert_null(Gen2SaveEditor.open(null, _data))
+	assert_null(Gen2SaveEditor.open(_source_save(), null))
+
+
+func test_a_fresh_editor_is_clean_and_valid() -> void:
+	assert_false(_editor.is_dirty())
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_an_edit_marks_the_editor_dirty() -> void:
+	assert_true(_editor.set_player_name("ASH")["ok"])
+	assert_true(_editor.is_dirty())
+
+
+func test_an_empty_or_overlong_player_name_is_refused() -> void:
+	assert_false(_editor.set_player_name("   ")["ok"])
+	assert_false(_editor.set_player_name("ABCDEFGHIJK")["ok"])
+	assert_eq(_editor.save.player_name, "RED")
+
+
+func test_setting_a_level_moves_experience_onto_the_curve() -> void:
+	assert_true(_editor.set_level(_first(), 50)["ok"])
+
+	var growth: int = int(_data.species(Fixture.PIKACHU)["growth_rate"])
+	assert_eq(_first().level, 50)
+	assert_eq(_first().exp, Gen2Experience.total_exp_at(growth, 50))
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_an_out_of_range_level_is_refused_rather_than_clamped() -> void:
+	assert_false(_editor.set_level(_first(), 0)["ok"])
+	assert_false(_editor.set_level(_first(), Gen2Experience.MAX_LEVEL + 1)["ok"])
+	assert_eq(_first().level, 20)
+
+
+func test_lowering_the_level_pulls_current_hp_under_the_new_maximum() -> void:
+	assert_true(_editor.set_level(_first(), 100)["ok"])
+	assert_true(_editor.set_hp(_first(), _editor.max_hp_for(_first()))["ok"])
+	var high_hp: int = _first().hp
+
+	assert_true(_editor.set_level(_first(), 5)["ok"])
+	assert_lt(_first().hp, high_hp)
+	assert_eq(_first().hp, _editor.max_hp_for(_first()))
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_changing_species_re_runs_experience_on_the_new_growth_curve() -> void:
+	assert_true(_editor.set_species(_first(), Fixture.GEODUDE)["ok"])
+
+	var growth: int = int(_data.species(Fixture.GEODUDE)["growth_rate"])
+	assert_eq(_first().species, Fixture.GEODUDE)
+	assert_eq(_first().exp, Gen2Experience.total_exp_at(growth, _first().level))
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_an_unknown_species_is_refused() -> void:
+	assert_false(_editor.set_species(_first(), 9999)["ok"])
+	assert_eq(_first().species, Fixture.PIKACHU)
+
+
+func test_hp_is_clamped_to_the_computed_maximum() -> void:
+	assert_true(_editor.set_hp(_first(), 99999)["ok"])
+	assert_eq(_first().hp, _editor.max_hp_for(_first()))
+
+	assert_true(_editor.set_hp(_first(), -5)["ok"])
+	assert_eq(_first().hp, 0)
+
+
+func test_a_learned_move_arrives_at_full_pp() -> void:
+	assert_true(_editor.set_move(_first(), 2, Fixture.GROWL)["ok"])
+
+	assert_eq(_first().moves[2], Fixture.GROWL)
+	assert_eq(_first().pp[2], int(_data.move(Fixture.GROWL)["pp"]))
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_clearing_a_move_pulls_the_later_ones_forward() -> void:
+	assert_true(_editor.set_move(_first(), 2, Fixture.GROWL)["ok"])
+	assert_true(_editor.set_move(_first(), 0, Gen2SaveEditor.NO_MOVE)["ok"])
+
+	assert_eq(_first().moves[0], Fixture.THUNDERBOLT)
+	assert_eq(_first().moves[1], Fixture.GROWL)
+	assert_eq(_first().moves[2], Gen2SaveEditor.NO_MOVE)
+	assert_eq(_first().pp[2], 0, "a cleared slot keeps no PP")
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_a_move_cannot_be_written_after_a_gap() -> void:
+	assert_false(_editor.set_move(_first(), 3, Fixture.GROWL)["ok"])
+	assert_eq(_first().moves[3], Gen2SaveEditor.NO_MOVE)
+
+
+func test_an_unknown_move_is_refused() -> void:
+	assert_false(_editor.set_move(_first(), 0, 9999)["ok"])
+	assert_eq(_first().moves[0], Fixture.TACKLE)
+
+
+func test_pp_is_clamped_to_the_moves_own_maximum() -> void:
+	assert_true(_editor.set_pp(_first(), 0, 999)["ok"])
+	assert_eq(_first().pp[0], int(_data.move(Fixture.TACKLE)["pp"]))
+
+
+func test_pp_on_an_empty_slot_is_refused() -> void:
+	assert_false(_editor.set_pp(_first(), 3, 5)["ok"])
+
+
+func test_dvs_are_clamped_per_component() -> void:
+	assert_true(_editor.set_dvs(_first(), 99, -3, 7, 15)["ok"])
+
+	assert_eq(Gen2Stats.attack_dv(_first().dvs), Gen2Stats.MAX_DV)
+	assert_eq(Gen2Stats.defense_dv(_first().dvs), 0)
+	assert_eq(Gen2Stats.speed_dv(_first().dvs), 7)
+	assert_eq(Gen2Stats.special_dv(_first().dvs), 15)
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_lowering_dvs_pulls_hp_under_the_new_maximum() -> void:
+	assert_true(_editor.set_hp(_first(), _editor.max_hp_for(_first()))["ok"])
+	assert_true(_editor.set_dvs(_first(), 0, 0, 0, 0)["ok"])
+
+	assert_eq(_first().hp, _editor.max_hp_for(_first()))
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_stat_experience_is_clamped_and_named() -> void:
+	assert_true(_editor.set_stat_exp(_first(), "attack", 999999)["ok"])
+	assert_eq(int(_first().stat_exp["attack"]), Gen2Stats.MAX_STAT_EXP)
+	assert_false(_editor.set_stat_exp(_first(), "charisma", 1)["ok"])
+
+
+func test_an_impossible_status_combination_is_refused() -> void:
+	assert_true(_editor.set_status(_first(), Gen2Status.BURN)["ok"])
+	assert_false(
+		_editor.set_status(_first(), Gen2Status.BURN | Gen2Status.FREEZE)["ok"],
+		"two major statuses at once cannot exist",
+	)
+	assert_eq(_first().status, Gen2Status.BURN)
+
+
+func test_an_unknown_held_item_is_refused() -> void:
+	assert_false(_editor.set_held_item(_first(), 9999)["ok"])
+	assert_true(_editor.set_held_item(_first(), 0)["ok"], "no item is always allowed")
+
+
+func test_adding_a_party_member_creates_a_legal_one() -> void:
+	assert_true(_editor.add_party_member(Fixture.GEODUDE, 15)["ok"])
+
+	assert_eq(_editor.save.party.size(), 2)
+	var added: Gen2SaveMon = _editor.save.party[1]
+	assert_eq(added.species, Fixture.GEODUDE)
+	assert_eq(added.level, 15)
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_a_full_party_refuses_another_member() -> void:
+	for _index: int in Gen2SaveData.MAX_PARTY - 1:
+		assert_true(_editor.add_party_member(Fixture.GEODUDE, 5)["ok"])
+
+	assert_eq(_editor.save.party.size(), Gen2SaveData.MAX_PARTY)
+	assert_false(_editor.add_party_member(Fixture.GEODUDE, 5)["ok"])
+
+
+func test_removing_the_last_member_leaves_a_legal_empty_party() -> void:
+	assert_true(_editor.remove_party_member(0)["ok"])
+
+	assert_eq(_editor.save.party.size(), 0)
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_removing_a_member_that_is_not_there_is_refused() -> void:
+	assert_false(_editor.remove_party_member(4)["ok"])
+
+
+func test_reordering_the_party_keeps_both_members() -> void:
+	assert_true(_editor.add_party_member(Fixture.GEODUDE, 15)["ok"])
+	assert_true(_editor.move_party_member(1, 0)["ok"])
+
+	assert_eq((_editor.save.party[0] as Gen2SaveMon).species, Fixture.GEODUDE)
+	assert_eq((_editor.save.party[1] as Gen2SaveMon).species, Fixture.PIKACHU)
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+
+func test_a_box_member_is_added_and_removed() -> void:
+	assert_true(_editor.add_box_member(0, Fixture.GEODUDE, 12)["ok"])
+	assert_eq(_editor.box(0).occupied_count(), 1)
+	assert_true(_editor.validate()["ok"], _editor.validate()["message"])
+
+	assert_true(_editor.remove_box_member(0, 0)["ok"])
+	assert_eq(_editor.box(0).occupied_count(), 0)
+
+
+func test_a_box_that_does_not_exist_is_refused() -> void:
+	assert_null(_editor.box(Gen2SaveData.BOX_COUNT))
+	assert_false(_editor.add_box_member(Gen2SaveData.BOX_COUNT, Fixture.GEODUDE, 5)["ok"])
+
+
+func test_removing_an_empty_box_slot_is_refused() -> void:
+	assert_false(_editor.remove_box_member(0, 0)["ok"])
+
+
+func test_committing_writes_the_slot_and_clears_dirty() -> void:
+	assert_true(_editor.set_player_name("ASH")["ok"])
+	var result: Dictionary = _editor.commit()
+	assert_true(result["ok"], result["message"])
+	assert_false(_editor.is_dirty())
+
+	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
+	assert_true(loaded["ok"], loaded["message"])
+	assert_eq((loaded["save"] as Gen2SaveData).player_name, "ASH")
+
+	Gen2SaveStore.delete_slot(_data.id, _data.sha1, 0)
+
+
+# --- World ------------------------------------------------------------------
+
+
+func test_a_save_with_no_world_refuses_every_world_edit() -> void:
+	assert_false(_editor.has_world())
+	assert_false(_editor.set_item_quantity(1, 5)["ok"])
+	assert_false(_editor.set_money(0, 100)["ok"])
+	assert_false(_editor.set_coins(10)["ok"])
+	assert_false(_editor.set_event_flag(3, true)["ok"])
+	assert_false(_editor.set_engine_flag(3, true)["ok"])
+	assert_false(_editor.set_seen_species(Fixture.PIKACHU, true)["ok"])
+	assert_false(_editor.set_clock(1, 2, 3)["ok"])
+	assert_null(_editor.inventory())
+
+
+func test_money_and_coins_are_clamped_to_source_ceilings() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+
+	assert_true(editor.set_money(0, 999999999)["ok"])
+	assert_eq(editor.save.world.world_state.money(0), Gen2WorldInventory.MAX_MONEY)
+
+	assert_true(editor.set_coins(999999)["ok"])
+	assert_eq(editor.save.world.world_state.coins(), Gen2WorldInventory.MAX_COINS)
+
+
+func test_an_unknown_bag_item_is_refused() -> void:
+	assert_false(_with_world().set_item_quantity(9999, 3)["ok"])
+
+
+func test_event_and_engine_flags_are_set_and_cleared() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+	var state: Gen2WorldState = editor.save.world.world_state
+
+	assert_true(editor.set_event_flag(12, true)["ok"])
+	assert_true(state.is_event_flag_active(12))
+	assert_true(editor.set_event_flag(12, false)["ok"])
+	assert_false(state.is_event_flag_active(12))
+
+	assert_true(editor.set_engine_flag(Gen2WorldState.ENGINE_ZEPHYRBADGE, true)["ok"])
+	assert_true(state.is_engine_flag_active(Gen2WorldState.ENGINE_ZEPHYRBADGE))
+
+
+func test_a_negative_flag_number_is_refused() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+	assert_false(editor.set_event_flag(-1, true)["ok"])
+	assert_false(editor.set_engine_flag(-1, true)["ok"])
+
+
+## The badge engine flags differ between the profiles, so the list follows the
+## save's own game rather than a single hardcoded set.
+func test_badge_flags_follow_the_saves_own_profile() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+	editor.save.game_id = RomRegistry.CRYSTAL
+	assert_eq(editor.badge_flags(), Gen2WorldState.BADGE_ENGINE_FLAGS)
+
+	editor.save.game_id = RomRegistry.GOLD
+	assert_eq(editor.badge_flags(), Gen2WorldState.BADGE_ENGINE_FLAGS_GOLD_SILVER)
+
+
+func test_seen_species_is_recorded_and_cleared() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+	var state: Gen2WorldState = editor.save.world.world_state
+
+	assert_true(editor.set_seen_species(Fixture.PIKACHU, true)["ok"])
+	assert_true(state.has_seen_species(Fixture.PIKACHU))
+
+	assert_true(editor.set_seen_species(Fixture.PIKACHU, false)["ok"])
+	assert_false(state.has_seen_species(Fixture.PIKACHU))
+	assert_false(
+		state.seen_species().has(Fixture.PIKACHU),
+		"clearing drops the entry rather than storing false",
+	)
+
+
+func test_an_unknown_species_cannot_be_marked_seen() -> void:
+	assert_false(_with_world().set_seen_species(9999, true)["ok"])
+
+
+func test_the_clock_is_clamped_to_its_own_ranges() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+	assert_true(editor.set_clock(99, 99, 99)["ok"])
+
+	assert_eq(editor.save.world.world_day, Gen2WorldClock.DAYS_PER_WEEK - 1)
+	assert_eq(editor.save.world.world_hour, Gen2WorldClock.HOURS_PER_DAY - 1)
+	assert_eq(editor.save.world.world_minute, Gen2WorldClock.MINUTES_PER_HOUR - 1)
+
+
+## The cache behind these tests has no maps at all, which is exactly the case
+## that must be refused rather than written into a save that then will not load.
+func test_moving_the_player_to_a_map_the_cache_lacks_is_refused() -> void:
+	var editor: Gen2SaveEditor = _with_world()
+	var before: Vector2i = editor.save.world.player_cell
+
+	assert_false(editor.set_player_position(Vector2i(24, 4), Vector2i(3, 3))["ok"])
+	assert_eq(editor.save.world.player_cell, before)

--- a/tests/unit/test_save_editor.gd.uid
+++ b/tests/unit/test_save_editor.gd.uid
@@ -1,0 +1,1 @@
+uid://dfl27bs0rpkur

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -32,7 +32,7 @@ func after_each() -> void:
 
 
 func _clear_saves() -> void:
-	for slot: int in Gen2SaveStore.SLOT_COUNT:
+	for slot: int in Gen2SaveStore.MAX_SLOTS:
 		var path: String = Gen2SaveStore.path_for(_data.id, _data.sha1, slot)
 		for copy: String in [path, "%s.bak" % path, "%s.tmp" % path, "%s.bak.tmp" % path]:
 			if FileAccess.file_exists(copy):
@@ -86,14 +86,13 @@ func _open_box_screen(save: Gen2SaveData) -> void:
 	await get_tree().process_frame
 
 
-func test_save_screen_shows_three_empty_slots() -> void:
+## Slots are created on demand, so a game with no saves lists none at all and
+## has nothing selected. The old screen preallocated three empty ones.
+func test_save_screen_shows_no_slots_before_any_save_exists() -> void:
 	await _open_save_screen()
 	var snapshot: Dictionary = _screen.save_screen_snapshot()
-	assert_eq(snapshot["selected_slot"], 0)
-	assert_eq((snapshot["slots"] as Array).size(), Gen2SaveStore.SLOT_COUNT)
-	for row: Dictionary in snapshot["slots"]:
-		assert_false(row["exists"])
-		assert_false(row["valid"])
+	assert_eq(snapshot["selected_slot"], -1)
+	assert_eq((snapshot["slots"] as Array).size(), 0)
 
 
 func test_save_screen_distinguishes_an_occupied_slot() -> void:
@@ -101,7 +100,11 @@ func test_save_screen_distinguishes_an_occupied_slot() -> void:
 	assert_true(write["ok"], write["message"])
 	await _open_save_screen()
 	var snapshot: Dictionary = _screen.save_screen_snapshot()
-	var second: Dictionary = snapshot["slots"][1]
+	# Only occupied slots are listed, so the one save is the only row and its
+	# slot number is no longer its index.
+	assert_eq((snapshot["slots"] as Array).size(), 1)
+	var second: Dictionary = snapshot["slots"][0]
+	assert_eq(second["slot"], 1)
 	assert_true(second["exists"])
 	assert_true(second["valid"])
 	assert_true(_screen.select_slot(1))

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -214,3 +214,37 @@ func test_pc_storage_can_commit_in_memory_without_writing_slot() -> void:
 	assert_eq(save.party.size(), 1)
 	assert_not_null(save.boxes[0].slots[0])
 	assert_false(Gen2SaveStore.exists(_data.id, _data.sha1, save.slot))
+
+
+## Slot management. The store's own rules are covered by test_save_slots.gd;
+## these check the screen reaches them and reports what happened.
+func test_the_screen_opens_a_new_slot_at_the_lowest_free_number() -> void:
+	var write: Dictionary = Gen2SaveStore.save(_save(), _data)
+	assert_true(write["ok"], write["message"])
+	await _open_save_screen()
+
+	assert_true(_screen.open_new_slot())
+	assert_eq(
+		_screen.save_screen_snapshot()["selected_slot"], 0,
+		"slot 1 is taken, so the new one is slot 0",
+	)
+
+
+func test_creating_a_new_game_with_nothing_selected_takes_a_free_slot() -> void:
+	await _open_save_screen()
+	assert_eq(_screen.save_screen_snapshot()["selected_slot"], -1)
+
+	assert_true(_screen.create_new_game("ASH"))
+	assert_true(Gen2SaveStore.exists(_data.id, _data.sha1, 0))
+
+
+func test_renaming_from_the_screen_reaches_the_slot() -> void:
+	assert_true(Gen2SaveStore.save(_save(), _data)["ok"])
+	await _open_save_screen()
+	assert_true(_screen.select_slot(1))
+
+	assert_true(Gen2SaveStore.rename_slot(_data.id, _data.sha1, 1, "Run two", _data)["ok"])
+	_screen.set_data(_data)
+
+	var rows: Array = _screen.save_screen_snapshot()["slots"]
+	assert_eq(rows[0]["label"], "Run two")

--- a/tests/unit/test_save_slots.gd
+++ b/tests/unit/test_save_slots.gd
@@ -1,0 +1,202 @@
+extends GutTest
+
+## Dynamic slot creation, naming, export and import. Shares the synthetic cache
+## the other save tests use, so nothing here needs a cartridge.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+const EXPORT_PATH: String = "user://slot-export-test.json"
+
+var _directory: String = ""
+var _data: GameData = null
+var _save_directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"savetest", "0123456789abcdef")
+	_data = Fixture.build(_directory)
+	_save_directory = Gen2SaveStore.directory_for(_data.id, _data.sha1)
+	_clear_saves()
+
+
+func after_each() -> void:
+	_clear_saves()
+	DirAccess.remove_absolute(EXPORT_PATH)
+	RomCache.clear(_directory)
+
+
+func _clear_saves() -> void:
+	for slot: int in Gen2SaveStore.MAX_SLOTS:
+		var path: String = Gen2SaveStore.path_for(_data.id, _data.sha1, slot)
+		for copy: String in [path, "%s.bak" % path, "%s.tmp" % path, "%s.bak.tmp" % path]:
+			if FileAccess.file_exists(copy):
+				DirAccess.remove_absolute(copy)
+	if DirAccess.dir_exists_absolute(_save_directory):
+		DirAccess.remove_absolute(_save_directory)
+
+
+func _write_slot(slot: int, player_name: String = "RED") -> Gen2SaveData:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.PIKACHU, 20, [Fixture.TACKLE], Gen2BattleMon.PERFECT_DVS
+	)
+	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
+		_data.id, _data.sha1, slot, Gen2Party.create([mon]), player_name
+	)
+	var result: Dictionary = Gen2SaveStore.save(save, _data)
+	assert_true(result["ok"], result["message"])
+	return save
+
+
+func test_a_game_with_no_saves_lists_nothing() -> void:
+	assert_eq(Gen2SaveStore.occupied_slots(_data.id, _data.sha1), [] as Array[int])
+	assert_eq(Gen2SaveStore.slots_for(_data.id, _data.sha1, _data).size(), 0)
+
+
+func test_occupied_slots_reports_written_slots_in_order() -> void:
+	_write_slot(4)
+	_write_slot(0)
+
+	assert_eq(Gen2SaveStore.occupied_slots(_data.id, _data.sha1), [0, 4] as Array[int])
+
+
+func test_a_slot_with_only_a_backup_copy_still_counts_as_occupied() -> void:
+	_write_slot(2)
+	DirAccess.remove_absolute(Gen2SaveStore.path_for(_data.id, _data.sha1, 2))
+
+	assert_eq(Gen2SaveStore.occupied_slots(_data.id, _data.sha1), [2] as Array[int])
+
+
+func test_next_free_slot_reuses_the_lowest_gap() -> void:
+	_write_slot(0)
+	_write_slot(1)
+	_write_slot(3)
+
+	assert_eq(Gen2SaveStore.next_free_slot(_data.id, _data.sha1), 2)
+
+
+func test_next_free_slot_starts_at_zero_for_a_new_game() -> void:
+	assert_eq(Gen2SaveStore.next_free_slot(_data.id, _data.sha1), 0)
+
+
+func test_slot_rows_carry_the_label_and_player_name() -> void:
+	_write_slot(0, "ASH")
+	assert_true(Gen2SaveStore.rename_slot(_data.id, _data.sha1, 0, "Nuzlocke", _data)["ok"])
+
+	var rows: Array = Gen2SaveStore.slots_for(_data.id, _data.sha1, _data)
+	assert_eq(rows.size(), 1)
+	assert_eq(rows[0]["label"], "Nuzlocke")
+	assert_eq(rows[0]["player_name"], "ASH")
+
+
+func test_renaming_trims_and_survives_a_reload() -> void:
+	_write_slot(0)
+	assert_true(Gen2SaveStore.rename_slot(_data.id, _data.sha1, 0, "  Run two  ", _data)["ok"])
+
+	var result: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
+	assert_true(result["ok"], result["message"])
+	assert_eq((result["save"] as Gen2SaveData).label, "Run two")
+
+
+func test_an_overlong_label_is_refused_without_touching_the_save() -> void:
+	_write_slot(0)
+	var long_name: String = "x".repeat(Gen2SaveData.MAX_LABEL + 1)
+
+	var result: Dictionary = Gen2SaveStore.rename_slot(_data.id, _data.sha1, 0, long_name, _data)
+	assert_false(result["ok"])
+
+	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
+	assert_eq((loaded["save"] as Gen2SaveData).label, "")
+
+
+func test_renaming_an_empty_slot_fails() -> void:
+	assert_false(Gen2SaveStore.rename_slot(_data.id, _data.sha1, 0, "ghost", _data)["ok"])
+
+
+func test_export_then_import_round_trips_into_a_free_slot() -> void:
+	_write_slot(0, "ASH")
+	assert_true(Gen2SaveStore.rename_slot(_data.id, _data.sha1, 0, "Nuzlocke", _data)["ok"])
+	assert_true(Gen2SaveStore.export_slot(_data.id, _data.sha1, 0, EXPORT_PATH)["ok"])
+
+	var imported: Dictionary = Gen2SaveStore.import_slot(EXPORT_PATH, _data)
+	assert_true(imported["ok"], imported["message"])
+	assert_eq(imported["slot"], 1, "the export lands in the next free slot")
+
+	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 1, _data)
+	assert_true(loaded["ok"], loaded["message"])
+	var save: Gen2SaveData = loaded["save"]
+	assert_eq(save.player_name, "ASH")
+	assert_eq(save.label, "Nuzlocke", "the label travels inside the file")
+	assert_eq(save.slot, 1, "the imported copy owns its new slot number")
+
+
+func test_exporting_an_empty_slot_writes_nothing() -> void:
+	assert_false(Gen2SaveStore.export_slot(_data.id, _data.sha1, 0, EXPORT_PATH)["ok"])
+	assert_false(FileAccess.file_exists(EXPORT_PATH))
+
+
+## Written without the container header, which `_unwrap` accepts unchecked as
+## the pre-container path, so this reaches the identity guard rather than
+## stopping at a checksum the test would otherwise have to recompute.
+func test_importing_another_cartridges_save_is_refused() -> void:
+	var raw: Dictionary = _write_slot(0).to_dict()
+	raw["rom_sha1"] = "fedcba9876543210"
+	var file: FileAccess = FileAccess.open(EXPORT_PATH, FileAccess.WRITE)
+	file.store_string(JSON.stringify(raw))
+	file.close()
+
+	var result: Dictionary = Gen2SaveStore.import_slot(EXPORT_PATH, _data)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "different cartridge")
+
+
+func test_importing_a_damaged_file_is_refused() -> void:
+	var file: FileAccess = FileAccess.open(EXPORT_PATH, FileAccess.WRITE)
+	file.store_string("not a save at all")
+	file.close()
+
+	assert_false(Gen2SaveStore.import_slot(EXPORT_PATH, _data)["ok"])
+
+
+func test_importing_a_file_whose_checksum_was_broken_is_refused() -> void:
+	_write_slot(0)
+	assert_true(Gen2SaveStore.export_slot(_data.id, _data.sha1, 0, EXPORT_PATH)["ok"])
+	var reader: FileAccess = FileAccess.open(EXPORT_PATH, FileAccess.READ)
+	var text: String = reader.get_as_text()
+	reader.close()
+	var writer: FileAccess = FileAccess.open(EXPORT_PATH, FileAccess.WRITE)
+	writer.store_string(text.replace("\"player_name\": \"RED\"", "\"player_name\": \"BLU\""))
+	writer.close()
+
+	var result: Dictionary = Gen2SaveStore.import_slot(EXPORT_PATH, _data)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "checksum")
+
+
+func test_a_version_two_save_migrates_by_gaining_an_empty_label() -> void:
+	var raw: Dictionary = _write_slot(0).to_dict()
+	raw["format_version"] = 2
+	raw.erase("label")
+
+	var migration: Dictionary = Gen2SaveData.migrate_dict(raw)
+	assert_true(migration["ok"], migration.get("message", ""))
+	assert_true(migration["migrated"])
+	assert_eq(migration["data"]["format_version"], Gen2SaveData.FORMAT_VERSION)
+	assert_eq(migration["data"]["label"], "")
+
+
+func test_a_version_one_save_gains_both_boxes_and_a_label() -> void:
+	var raw: Dictionary = _write_slot(0).to_dict()
+	raw["format_version"] = 1
+	raw.erase("boxes")
+	raw.erase("label")
+
+	var migration: Dictionary = Gen2SaveData.migrate_dict(raw)
+	assert_true(migration["ok"], migration.get("message", ""))
+	assert_eq((migration["data"]["boxes"] as Array).size(), Gen2SaveData.BOX_COUNT)
+	assert_eq(migration["data"]["label"], "")
+
+
+func test_a_save_from_a_later_format_is_refused_rather_than_guessed_at() -> void:
+	var raw: Dictionary = _write_slot(0).to_dict()
+	raw["format_version"] = Gen2SaveData.FORMAT_VERSION + 1
+
+	assert_false(Gen2SaveData.migrate_dict(raw)["ok"])

--- a/tests/unit/test_save_slots.gd.uid
+++ b/tests/unit/test_save_slots.gd.uid
@@ -1,0 +1,1 @@
+uid://ji6xflfopya6

--- a/tests/unit/test_update_check.gd
+++ b/tests/unit/test_update_check.gd
@@ -1,0 +1,116 @@
+extends GutTest
+
+## Version rules and release parsing only. Nothing here touches the network:
+## the launcher owns the request and hands the result to `status_for`.
+
+
+func test_the_project_declares_a_version() -> void:
+	assert_false(Gen2UpdateCheck.current_version().is_empty())
+	assert_false(Gen2UpdateCheck.parse_version(Gen2UpdateCheck.current_version()).is_empty())
+
+
+func test_a_tag_may_carry_a_leading_v() -> void:
+	assert_eq(Gen2UpdateCheck.parse_version("v1.2.3"), [1, 2, 3] as Array[int])
+	assert_eq(Gen2UpdateCheck.parse_version("1.2.3"), [1, 2, 3] as Array[int])
+
+
+func test_a_prerelease_or_build_suffix_is_cut() -> void:
+	assert_eq(Gen2UpdateCheck.parse_version("1.2.3-beta.1"), [1, 2, 3] as Array[int])
+	assert_eq(Gen2UpdateCheck.parse_version("1.2.3+build7"), [1, 2, 3] as Array[int])
+
+
+func test_a_version_without_numbers_parses_empty() -> void:
+	assert_eq(Gen2UpdateCheck.parse_version("nightly"), [] as Array[int])
+
+
+func test_missing_components_count_as_zero() -> void:
+	assert_eq(Gen2UpdateCheck.compare_versions("1.2", "1.2.0"), 0)
+	assert_eq(Gen2UpdateCheck.compare_versions("1.2", "1.2.1"), -1)
+
+
+func test_versions_order_by_component_not_by_text() -> void:
+	assert_eq(Gen2UpdateCheck.compare_versions("0.9.0", "0.10.0"), -1)
+	assert_eq(Gen2UpdateCheck.compare_versions("1.0.0", "0.99.99"), 1)
+	assert_eq(Gen2UpdateCheck.compare_versions("2.0.0", "2.0.0"), 0)
+
+
+func test_a_release_document_reads_into_display_fields() -> void:
+	var release: Dictionary = Gen2UpdateCheck.parse_release(JSON.stringify({
+		"tag_name": "v0.2.0",
+		"name": "Second release",
+		"html_url": "https://github.com/Decryptu/gen2recomp/releases/tag/v0.2.0",
+		"published_at": "2026-08-08T10:00:00Z",
+	}))
+
+	assert_true(release["ok"])
+	assert_eq(release["version"], "v0.2.0")
+	assert_eq(release["name"], "Second release")
+	assert_string_contains(release["url"], "releases/tag/v0.2.0")
+
+
+func test_a_release_url_that_is_not_https_falls_back_to_the_releases_page() -> void:
+	var release: Dictionary = Gen2UpdateCheck.parse_release(JSON.stringify({
+		"tag_name": "0.2.0", "html_url": "http://example.invalid/tricked",
+	}))
+
+	assert_true(release["ok"])
+	assert_eq(release["url"], Gen2UpdateCheck.RELEASES_PAGE)
+
+
+func test_a_release_without_a_usable_tag_is_refused() -> void:
+	assert_false(Gen2UpdateCheck.parse_release(JSON.stringify({"name": "no tag"}))["ok"])
+	assert_false(Gen2UpdateCheck.parse_release(JSON.stringify({"tag_name": "nightly"}))["ok"])
+
+
+func test_unreadable_json_is_refused() -> void:
+	assert_false(Gen2UpdateCheck.parse_release("{ not json")["ok"])
+
+
+func test_a_newer_release_reports_an_update() -> void:
+	var body: String = JSON.stringify({"tag_name": "v0.2.0"})
+	var result: Dictionary = Gen2UpdateCheck.status_for(200, body, "0.1.0")
+
+	assert_eq(result["status"], Gen2UpdateCheck.Status.UPDATE_AVAILABLE)
+	assert_string_contains(Gen2UpdateCheck.describe(result), "0.2.0")
+
+
+func test_the_same_release_reports_up_to_date() -> void:
+	var body: String = JSON.stringify({"tag_name": "v0.1.0"})
+	var result: Dictionary = Gen2UpdateCheck.status_for(200, body, "0.1.0")
+
+	assert_eq(result["status"], Gen2UpdateCheck.Status.UP_TO_DATE)
+
+
+func test_a_local_build_ahead_of_the_release_says_so() -> void:
+	var body: String = JSON.stringify({"tag_name": "v0.1.0"})
+	var result: Dictionary = Gen2UpdateCheck.status_for(200, body, "0.2.0")
+
+	assert_eq(result["status"], Gen2UpdateCheck.Status.AHEAD)
+
+
+## GitHub answers 404 for a repository that has published nothing. The check
+## worked; there is simply nothing to compare against.
+func test_a_repository_with_no_releases_is_an_answer_not_a_failure() -> void:
+	var result: Dictionary = Gen2UpdateCheck.status_for(404, "", "0.1.0")
+
+	assert_eq(result["status"], Gen2UpdateCheck.Status.NO_RELEASES)
+	assert_string_contains(Gen2UpdateCheck.describe(result), "0.1.0")
+
+
+func test_any_other_http_code_is_unreadable() -> void:
+	assert_eq(
+		Gen2UpdateCheck.status_for(503, "", "0.1.0")["status"],
+		Gen2UpdateCheck.Status.UNREADABLE,
+	)
+
+
+func test_a_two_hundred_with_a_damaged_body_is_unreadable() -> void:
+	assert_eq(
+		Gen2UpdateCheck.status_for(200, "{ not json", "0.1.0")["status"],
+		Gen2UpdateCheck.Status.UNREADABLE,
+	)
+
+
+func test_an_oversized_response_is_refused_before_parsing() -> void:
+	var huge: String = "x".repeat(Gen2UpdateCheck.MAX_RESPONSE_BYTES + 1)
+	assert_false(Gen2UpdateCheck.parse_release(huge)["ok"])

--- a/tests/unit/test_update_check.gd.uid
+++ b/tests/unit/test_update_check.gd.uid
@@ -1,0 +1,1 @@
+uid://fqxua88iqu58


### PR DESCRIPTION
Everything the launcher was missing next to a comparable Gen 1 project:
settings, real save slot management, a save editor, mod switches, per-cartridge
maintenance and a release check. No styling work: the screens use stock controls
so the look can be designed later against something that already works.

## Options

Options start where the hardware put them. The cartridge block is the real
`wOptions` .. `wOptionsEnd` bytes, so the in-game OPTION menu and this screen
cannot disagree about what a setting means, with the application block beside it
rather than mixed in. `data/default_options.asm` is byte identical between the
pins, so none of it is profile split.

Two bits read backwards and are pinned by their own tests: `Options_BattleScene`
clears `BATTLE_SCENE` to turn the scene on, and `Options_BattleStyle` sets
`BATTLE_SHIFT` to select SET. pokecrystal's wram comment puts `MENU_ACCOUNT` on
bit 1; its own constant and every access say bit 0, as does pokegold.

Unlike a save, a damaged options file costs nothing worth refusing over, so
every field clamps and the store keeps no checksummed container.

## Save slots

Three preallocated slots was the cartridge's limit, not ours. Slots are created
on demand up to a ceiling, so a game with no saves lists none rather than three
empty cards, and a slot number is no longer its own index in that list. The
screen looked slots up by index in four places and would have read the wrong
save the moment the numbers diverged.

Slot files keep their `slot_N.json` names, so slots already on disk stay where
they are, and the checksummed primary-then-backup pair is untouched.

A save now carries its own label, which is what makes export worth having: the
file names itself instead of leaning on a sidecar the copy would leave behind.
That is format 3, and migration walks one step at a time so a version 1 file
gains boxes and then a label rather than skipping to the end.

## Save editor

`Gen2SaveEditor` keeps the invariants the validator enforces instead of letting
a value be typed and the slot discovered dead at save time. Level and experience
move together through the species' growth curve, HP re-clamps whenever the
maximum moves under it, PP follows the move it belongs to, and clearing a move
compacts the slots rather than leaving the gap the validator refuses.

It works on a copy, so abandoning the editor cannot leave a half-edited save in
the object the runtime is sharing, and the validator is still the gate on
commit: a bug there costs a refused write, not a corrupted slot.

Party, boxes, bag, money, event and engine flags, map position, clock and seen
species are all editable. The status rule now has one owner rather than two
copies, and `Gen2WorldState` gained the seen-species setter it only ever had a
getter for.

## Mods

Discovery and loading were the same decision, so the only way to stop a mod
running was to delete it. They are now separate: a disabled mod is still
discovered and still listed, it just is not run, and that is not counted as a
refusal alongside mods that genuinely failed.

The file stores the ids that are off rather than the ids that are on, so a mod
that was just installed runs without anything being written for it and a damaged
file means every mod runs rather than none. Uninstalling drops the id so a later
reinstall does not find itself silently disabled.

## Cartridge maintenance and updates

Each cartridge gets re-import, opening its cache folder and deleting its cache.
A re-import accepts only the game it replaces; choosing the wrong file from a
cartridge's own dialog would otherwise have quietly imported a different one.
Deleting a cache says what it does not touch, since saves live under their own
root.

The project declared no version, so there was nothing an update check could be
about. `application/config/version` is now the one place it lives. Comparison is
by component, so 0.9.0 is correctly older than 0.10.0, and a 404 from the
releases API means nothing has been published yet rather than a failure to read.
The comparison and feed shape are pure and tested without a network; the request
only ever starts from the button, because it reaches a third party and reports
that this build exists.

## Verification

1,372 tests and 11,523 assertions pass, up from 1,266 and 11,145. Editor scan
and headless boot are clean and `verify_rom` is 3/3. Screenshots of the launcher
and editor were checked, which caught three clipping defects that are fixed
here: the toolbar outgrew the window, the cartridge card actions were drawn
below the fold, and the editor's Close button was cut off at the edge.

One behaviour change worth naming: a game with no saves now lists no slots and
has nothing selected, where the old screen preallocated three empty ones.
`test_save_screen_shows_no_slots_before_any_save_exists` pins it.