### PR TITLE
Reach Pewter, Cinnabar and Viridian, and gate field moves on the party

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,14 @@ Headless tools, all against a real imported cache:
 | `validate_lavender.gd` | Saffron's east gate, Route 8's single east crossing and the eight ledges that leave only one of its five sight lines unavoidable, Lavender Town's flypoint and its two open edges, and the EXPN CARD the Kanto Radio Tower withholds until the Power Plant runs, in all three games |
 | `validate_fuchsia.gd` | the four connected routes south of Lavender and which of their eighteen sight lines each profile's walk cannot route around, the Route 15 gate, Fuchsia City's region behind it, and Fuchsia Gym's wall maze with no sight trainer in it, in all three games |
 | `validate_radio.gd` | the radio station table and its three profile splits, every station's music record, the two big objects either game ships, Vermilion City sealed at the Diglett's Cave mouth by the Snorlax's two-by-two body, the whole tune-and-wake chain, and the Route 2 pocket behind the cave that one cut tree opens onto Pewter and Viridian, in all three games |
+| `validate_pewter.gd` | Fuchsia's gate out and the five ungated connections back to Vermilion, the eight-cell pocket the Snorlax seals off the Route 11 crossing, Diglett's Cave's three regions and two ladders, Route 2's crossing onto Pewter once its tree is cut, and Pewter City's one south corridor and the gym sight line it owes, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route: Johto, the Hall of Fame, and Kanto as far as Fuchsia
+# the full walked route: Johto, the Hall of Fame, and Kanto as far as Pewter
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,13 +238,14 @@ Headless tools, all against a real imported cache:
 | `validate_fuchsia.gd` | the four connected routes south of Lavender and which of their eighteen sight lines each profile's walk cannot route around, the Route 15 gate, Fuchsia City's region behind it, and Fuchsia Gym's wall maze with no sight trainer in it, in all three games |
 | `validate_radio.gd` | the radio station table and its three profile splits, every station's music record, the two big objects either game ships, Vermilion City sealed at the Diglett's Cave mouth by the Snorlax's two-by-two body, the whole tune-and-wake chain, and the Route 2 pocket behind the cave that one cut tree opens onto Pewter and Viridian, in all three games |
 | `validate_pewter.gd` | Fuchsia's gate out and the five ungated connections back to Vermilion, the eight-cell pocket the Snorlax seals off the Route 11 crossing, Diglett's Cave's three regions and two ladders, Route 2's crossing onto Pewter once its tree is cut, and Pewter City's one south corridor and the gym sight line it owes, in all three games |
+| `validate_cinnabar.gd` | the four connections from Pewter down to Pallet, Pallet's pond and the south edge that only crosses while surfing, Route 21's sea, Cinnabar's two seamless land regions and which crossing reaches Blue, Route 20's sealed west channel and the east landfall behind it, Seafoam Gym, and Viridian Gym's two objects behind one event flag, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route: Johto, the Hall of Fame, and Kanto as far as Pewter
+# the full walked route: Johto, the Hall of Fame, and every Kanto gym
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -430,17 +430,42 @@ func set_movement_mode(mode: StringName) -> Dictionary:
 ## second. Only an absent summary fails a script-visible read; a summary whose
 ## list is empty answers "not in the party", which is what the story preview's
 ## own callers rely on.
+## [param eggs] marks which slots are eggs, because `CheckPartyMove` skips them:
+## an egg carries the moves it will hatch with and would otherwise answer for a
+## move no usable party member knows.
 func set_party_summary(
 	count: int, has_pokerus: bool, species: Array[int] = [] as Array[int],
-	moves: Array = [], names: Array = []
+	moves: Array = [], names: Array = [], eggs: Array = []
 ) -> Dictionary:
 	if count < 0:
 		return {"ok": false, "reason": &"invalid_party_summary", "count": count}
 	_party_summary = {
 		"count": count, "pokerus": has_pokerus, "species": species.duplicate(),
 		"moves": moves.duplicate(true), "names": names.duplicate(),
+		"eggs": eggs.duplicate(),
 	}
 	return {"ok": true}
+
+
+## CheckPartyMove (`engine/events/overworld.asm`): the first party slot whose own
+## move list carries [param move], or -1 when none does. Eggs are skipped, empty
+## and terminator slots end the walk, and the answer is the slot index the source
+## leaves in `wCurPartyMon`.
+##
+## Every field move is gated on this. The party submenu reaches `CutFunction` and
+## friends only for a mon that knows the move, and the overworld prompts
+## (`TryCutOW`, `TrySurfOW`, `TryWhirlpoolOW`, `TryWaterfallOW`, `TryStrengthOW`)
+## each call `CheckPartyMove` themselves, so there is no path in either game that
+## uses a field move the party does not know.
+func party_slot_with_move(move: int) -> int:
+	var moves: Array = _party_summary.get("moves", [])
+	var eggs: Array = _party_summary.get("eggs", [])
+	for slot: int in moves.size():
+		if slot < eggs.size() and bool(eggs[slot]):
+			continue
+		if moves[slot] is Array and (moves[slot] as Array).has(move):
+			return slot
+	return -1
 
 
 ## Clears the mirror so a stale count cannot answer a later read after the
@@ -533,6 +558,10 @@ func cut_request() -> Dictionary:
 		return _cut_failure(&"missing_map")
 	if not _pending_cut.is_empty():
 		return _cut_failure(&"cut_in_progress")
+	## TryCutOW asks CheckPartyMove before the badge; the submenu path cannot
+	## reach here without the move at all.
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_CUT) < 0:
+		return _cut_failure(&"move_not_known")
 	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
 	if not state.is_engine_flag_active(
 		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, crystal)
@@ -614,6 +643,10 @@ func surf_request(species: int = 0) -> Dictionary:
 		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, crystal)
 	):
 		return _surf_failure(&"badge_required")
+	## Surf is the one move whose overworld prompt asks CheckPartyMove after the
+	## badge rather than before it (`TrySurfOW`).
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_SURF) < 0:
+		return _surf_failure(&"move_not_known")
 	if movement_mode == MOVEMENT_SURF:
 		return _surf_failure(&"already_surfing")
 	var target: Vector2i = facing_cell()
@@ -685,6 +718,9 @@ func whirlpool_request() -> Dictionary:
 		return _whirlpool_failure(&"missing_map")
 	if not _pending_whirlpool.is_empty():
 		return _whirlpool_failure(&"whirlpool_in_progress")
+	## TryWhirlpoolOW asks CheckPartyMove before the badge.
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL) < 0:
+		return _whirlpool_failure(&"move_not_known")
 	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
 		Gen2WorldFieldMove.BADGE_GLACIER, Gen2WorldState.is_crystal_profile(data)
 	)):
@@ -756,6 +792,9 @@ func waterfall_request() -> Dictionary:
 		return _waterfall_failure(&"missing_map")
 	if not _pending_waterfall.is_empty():
 		return _waterfall_failure(&"waterfall_in_progress")
+	## TryWaterfallOW asks CheckPartyMove before the badge.
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_WATERFALL) < 0:
+		return _waterfall_failure(&"move_not_known")
 	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
 		Gen2WorldFieldMove.BADGE_RISING, Gen2WorldState.is_crystal_profile(data)
 	)):

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -471,6 +471,18 @@ func facing_cell() -> Vector2i:
 	return player_cell + _direction_for_facing(player_facing)
 
 
+## The cell CheckFacingObject searches, which is the faced one doubled away when
+## the tile between is a counter (`engine/overworld/npc_movement.asm`). A mart
+## clerk, a gym receptionist and the Radio Tower's Radio Card woman are all
+## talked to across one.
+func object_facing_cell() -> Vector2i:
+	var direction: Vector2i = _direction_for_facing(player_facing)
+	var faced: Vector2i = player_cell + direction
+	if Gen2WorldCollision.is_counter(collision_code_at(faced)):
+		return faced + direction
+	return faced
+
+
 func fishing_request(
 	rod: StringName,
 	random: RandomNumberGenerator = null,
@@ -1771,7 +1783,10 @@ func interact() -> Array:
 	var events: Array = []
 	## TryObjectEvent runs before TryBGEvent in the cartridge event loop. Keep
 	## that order even though events_at() exposes the cache's source order.
-	for event: Dictionary in _active_events_at(target):
+	## Only the object half looks across a counter: CheckFacingBGEvent and
+	## TryTileCollisionEvent both read the plain GetFacingTileCoord, which is
+	## what keeps a Pokemon Center PC on the counter itself reachable.
+	for event: Dictionary in _active_events_at(object_facing_cell()):
 		if event.get("kind", &"") == &"objects" and event.has("script"):
 			events.append(event)
 	for event: Dictionary in _active_events_at(target):

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -347,6 +347,11 @@ static func forced_action(collision_code: int) -> Dictionary:
 ## is not: PCScript is 49 in Crystal and 43 in Gold/Silver, because Crystal's
 ## table carries six extra phone entries earlier. Every other entry was recounted
 ## in both and lands on the same index.
+## CheckCounterTile (`home/map_objects.asm`). $98 ships in the table but no map
+## uses it.
+const COLL_COUNTER: int = 0x90
+const COLL_COUNTER_98: int = 0x98
+
 const COLL_BOOKSHELF: int = 0x91
 const COLL_PC: int = 0x93
 const COLL_RADIO: int = 0x94
@@ -377,6 +382,12 @@ const TILE_COLLISION_STD_INDEX_GOLD_SILVER: Dictionary = {
 	COLL_WINDOW: 8,           # WindowScript
 	COLL_INCENSE_BURNER: 5,   # IncenseBurnerScript
 }
+
+
+## CheckCounterTile. A counter is what CheckFacingObject doubles the facing
+## distance over, so an NPC behind one is talked to across it.
+static func is_counter(collision_code: int) -> bool:
+	return collision_code in [COLL_COUNTER, COLL_COUNTER_98]
 
 
 ## The std-script index [param collision_code] dispatches to on A, or -1 when

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2004,6 +2004,7 @@ func _refresh_party_summary() -> void:
 	var species: Array[int] = []
 	var moves: Array = []
 	var names: Array = []
+	var eggs: Array = []
 	for member: Variant in save.party:
 		if member is Gen2SaveMon:
 			var mon: Gen2SaveMon = member as Gen2SaveMon
@@ -2018,7 +2019,8 @@ func _refresh_party_summary() -> void:
 					mon_moves.append(move)
 			moves.append(mon_moves)
 			names.append(_mon_display_name(mon))
-	_world.set_party_summary(save.party.size(), has_pokerus, species, moves, names)
+			eggs.append(mon.is_egg)
+	_world.set_party_summary(save.party.size(), has_pokerus, species, moves, names, eggs)
 
 
 ## GetPartyNickname's answer for one slot, following the party screen's own rule:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -2049,9 +2049,14 @@ func _stage_hidden_item() -> Dictionary:
 
 ## CheckPartyMove: the first slot whose move list carries [param move], or -1.
 ## The mirror's per-slot lists are the only party this scene-free runner reads.
+## Eggs are skipped, the way the source's own `cp EGG` branch skips them.
 func _party_slot_with_move(move: int) -> int:
-	var moves: Array = _request.get("party", {}).get("moves", [])
+	var party: Dictionary = _request.get("party", {})
+	var moves: Array = party.get("moves", [])
+	var eggs: Array = party.get("eggs", [])
 	for slot: int in moves.size():
+		if slot < eggs.size() and bool(eggs[slot]):
+			continue
 		if moves[slot] is Array and (moves[slot] as Array).has(move):
 			return slot
 	return -1

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -73,6 +73,11 @@ func _write_cache(game_id: String = "testworld") -> void:
 	collision[2 * 16 + 15] = 0x07  # wall right of the edge hop cell
 	collision[2 * 16 + 10] = 0x93  # COLL_PC, faced (not stood on) for std scripts
 
+	# Counter fixture, row 9: CheckFacingObject doubles the facing distance over
+	# a counter, so an object on (13,10) is talked to from (13,8) across this
+	# cell. (11,9) is left at LAND_TILE as the control for the same geometry.
+	collision[9 * 16 + 13] = 0x90  # COLL_COUNTER
+
 	# Side-wall fixture, row 8: a COLL_RIGHT_WALL/COLL_LEFT_WALL pair at (2,8)
 	# and (3,8), matching Celadon Mansion Roof's railing. Both stay LAND_TILE
 	# permission; every surrounding cell is left at its default LAND_TILE.
@@ -1575,6 +1580,50 @@ func test_interact_finds_no_tile_collision_script_for_an_untabled_code() -> void
 	world.player_facing = Gen2WorldSprite.FACING_LEFT
 	assert_eq(world.collision_code_at(world.facing_cell()), 0)
 	assert_eq(world.interact(), [])
+
+
+## A world with a scripted object two cells ahead of [param stand], for
+## CheckFacingObject's counter rule.
+func _counter_world(stand: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _world(stand)
+	world.current_map.events["objects"].append({
+		"sprite": 1, "x": stand.x, "y": stand.y + 2,
+		"script": 0x6040, "event_flag": 0xFFFF,
+	})
+	world.reload_current_map()
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	return world
+
+
+## CheckFacingObject doubles the facing distance when the faced tile is a
+## counter, which is how a mart clerk or the Radio Tower's Radio Card woman is
+## talked to from outside the desk they stand behind.
+func test_interact_reaches_an_object_across_a_counter() -> void:
+	var world: Gen2WorldAPI = _counter_world(Vector2i(13, 8))
+	assert_eq(world.collision_code_at(world.facing_cell()), Gen2WorldCollision.COLL_COUNTER)
+	assert_eq(world.object_facing_cell(), Vector2i(13, 10))
+	var results: Array = world.interact()
+	assert_false(results.is_empty())
+	assert_eq(results[0]["status"], &"complete", JSON.stringify(results[0]))
+	assert_eq(world.state.map_scene(1, 1), 3)
+
+
+## The same geometry without a counter answers nothing: the doubling is the
+## counter's, not a general two-cell reach.
+func test_interact_does_not_reach_an_object_two_cells_away_without_a_counter() -> void:
+	var world: Gen2WorldAPI = _counter_world(Vector2i(11, 8))
+	assert_eq(world.collision_code_at(world.facing_cell()), 0)
+	assert_eq(world.object_facing_cell(), Vector2i(11, 9))
+	assert_eq(world.interact(), [])
+
+
+## $98 ships in CheckCounterTile's pair but no map uses it. Both codes answer.
+func test_counter_codes_are_the_pinned_pair() -> void:
+	assert_true(Gen2WorldCollision.is_counter(Gen2WorldCollision.COLL_COUNTER))
+	assert_true(Gen2WorldCollision.is_counter(Gen2WorldCollision.COLL_COUNTER_98))
+	assert_eq(Gen2WorldCollision.COLL_COUNTER, 0x90)
+	assert_eq(Gen2WorldCollision.COLL_COUNTER_98, 0x98)
+	assert_false(Gen2WorldCollision.is_counter(Gen2WorldCollision.COLL_PC))
 
 
 func test_tile_collision_std_index_is_profile_split_for_pc_only() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2737,11 +2737,11 @@ func test_party_summary_round_trips_and_reaches_queued_script_requests() -> void
 	var world: Gen2WorldAPI = _world()
 	assert_true(world.party_summary().is_empty())
 	assert_true(world.set_party_summary(
-		3, true, [25, 1] as Array[int], [[0x46], []], ["PIKA", "BULBASAUR"]
+		3, true, [25, 1] as Array[int], [[0x46], []], ["PIKA", "BULBASAUR"], [false, true]
 	)["ok"])
 	var expected: Dictionary = {
 		"count": 3, "pokerus": true, "species": [25, 1],
-		"moves": [[0x46], []], "names": ["PIKA", "BULBASAUR"],
+		"moves": [[0x46], []], "names": ["PIKA", "BULBASAUR"], "eggs": [false, true],
 	}
 	assert_eq(world.party_summary(), expected)
 	assert_false(world.set_party_summary(-1, false)["ok"])
@@ -4133,6 +4133,11 @@ func test_surf_request_refuses_a_facing_object_on_crystal_only() -> void:
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
 	world.objects[0].cell = Vector2i(8, 7)
 	assert_not_null(world.object_at(Vector2i(8, 7)))
+	# CheckPartyMove runs before CheckFacingObject, so the party has to know Surf
+	# for the object test to be the one that answers.
+	world.set_party_summary(
+		1, false, [1] as Array[int], [[Gen2WorldFieldMove.MOVE_SURF]], ["MON"], [false]
+	)
 	assert_eq(world.surf_request()["reason"], &"cannot_surf")
 
 	var gold_directory: String = RomCache.directory_for(&"testworldsurfgold", "abcdef0123456789cd")
@@ -4153,6 +4158,9 @@ func test_surf_request_refuses_a_facing_object_on_crystal_only() -> void:
 	gold_world.player_facing = Gen2WorldSprite.FACING_DOWN
 	gold_world.objects[0].cell = Vector2i(8, 7)
 	assert_not_null(gold_world.object_at(Vector2i(8, 7)))
+	gold_world.set_party_summary(
+		1, false, [1] as Array[int], [[Gen2WorldFieldMove.MOVE_SURF]], ["MON"], [false]
+	)
 	assert_true(bool(gold_world.surf_request().get("ok", false)))
 	RomCache.clear(gold_directory)
 

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -196,9 +196,19 @@ func _gold_profile() -> void:
 	RomCache.write_json(RomCache.manifest_path(_directory), manifest)
 
 
+## The one thing every field move is gated on besides its badge: a party member
+## that knows it (`CheckPartyMove`). One non-egg slot carrying [param move] is
+## what the party submenu guarantees on the real path, so the fixtures set it,
+## and each move's own case drives the empty party for the refusal.
+func _knowing_party(world: Gen2WorldAPI, move: int) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [[move]], ["MON"], [false]
+	)
+
+
 ## A world standing above the cut tree and facing it, with the Hive Badge set on
 ## whichever engine flag table the opened cache selects.
-func _world(map_number: int = 1, badge: bool = true) -> Gen2WorldAPI:
+func _world(map_number: int = 1, badge: bool = true, knows: bool = true) -> Gen2WorldAPI:
 	var data: GameData = GameData.open_directory(_directory)
 	var state := Gen2WorldState.new()
 	if badge:
@@ -209,12 +219,16 @@ func _world(map_number: int = 1, badge: bool = true) -> Gen2WorldAPI:
 		data, 1, map_number, TREE_CELL + Vector2i.UP, state
 	)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	if knows:
+		_knowing_party(world, Gen2WorldFieldMove.MOVE_CUT)
 	return world
 
 
 ## A world standing on the shore facing the water, with the Fog Badge set on
 ## whichever engine flag table the opened cache selects.
-func _surf_world(badge: bool = true, stand: Vector2i = SHORE_CELL) -> Gen2WorldAPI:
+func _surf_world(
+	badge: bool = true, stand: Vector2i = SHORE_CELL, knows: bool = true
+) -> Gen2WorldAPI:
 	var data: GameData = GameData.open_directory(_directory)
 	var state := Gen2WorldState.new()
 	if badge:
@@ -223,6 +237,8 @@ func _surf_world(badge: bool = true, stand: Vector2i = SHORE_CELL) -> Gen2WorldA
 		))
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, stand, state)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	if knows:
+		_knowing_party(world, Gen2WorldFieldMove.MOVE_SURF)
 	return world
 
 
@@ -241,7 +257,7 @@ func _strength_world(badge: bool = true) -> Gen2WorldAPI:
 
 ## A world beside the whirlpool and facing it, surfing, with the Glacier Badge on
 ## whichever engine flag table the opened cache selects.
-func _whirlpool_world(badge: bool = true) -> Gen2WorldAPI:
+func _whirlpool_world(badge: bool = true, knows: bool = true) -> Gen2WorldAPI:
 	var data: GameData = GameData.open_directory(_directory)
 	var state := Gen2WorldState.new()
 	if badge:
@@ -251,6 +267,8 @@ func _whirlpool_world(badge: bool = true) -> Gen2WorldAPI:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WHIRLPOOL_STAND_CELL, state)
 	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	if knows:
+		_knowing_party(world, Gen2WorldFieldMove.MOVE_WHIRLPOOL)
 	return world
 
 
@@ -395,6 +413,7 @@ func test_surf_request_reads_the_gold_silver_badge_flag() -> void:
 	state.set_engine_flag(Gen2WorldState.ENGINE_FOGBADGE)
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, SHORE_CELL, state)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_SURF)
 	assert_eq(world.surf_request()["reason"], &"badge_required")
 
 	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, false))
@@ -608,9 +627,53 @@ func test_cut_request_reads_the_gold_silver_badge_flag() -> void:
 		data, 1, 1, TREE_CELL + Vector2i.UP, state
 	)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_CUT)
 	assert_eq(world.cut_request()["reason"], &"badge_required")
 
 	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, false))
+	assert_true(bool(world.cut_request().get("ok", false)))
+
+
+## CheckPartyMove, which every one of the four gates on. TryCutOW,
+## TryWhirlpoolOW and TryWaterfallOW ask it before their badge; TrySurfOW asks it
+## after. An empty party answers the same way a party without the move does,
+## because neither can reach the move on any source path.
+func test_each_field_move_refuses_a_party_that_does_not_know_it() -> void:
+	assert_eq(_world(1, true, false).cut_request()["reason"], &"move_not_known")
+	assert_eq(
+		_surf_world(true, SHORE_CELL, false).surf_request()["reason"], &"move_not_known"
+	)
+	assert_eq(_whirlpool_world(true, false).whirlpool_request()["reason"], &"move_not_known")
+	assert_eq(_waterfall_world(true, false).waterfall_request()["reason"], &"move_not_known")
+
+
+## The refusal order the overworld prompts use: Cut, Whirlpool and Waterfall
+## report the missing move even when the badge is missing too, and Surf reports
+## the missing badge first.
+func test_the_party_move_check_runs_before_the_badge_except_for_surf() -> void:
+	assert_eq(_world(1, false, false).cut_request()["reason"], &"move_not_known")
+	assert_eq(_whirlpool_world(false, false).whirlpool_request()["reason"], &"move_not_known")
+	assert_eq(_waterfall_world(false, false).waterfall_request()["reason"], &"move_not_known")
+	assert_eq(
+		_surf_world(false, SHORE_CELL, false).surf_request()["reason"], &"badge_required"
+	)
+
+
+## An egg carries the moves it will hatch with, and CheckPartyMove skips it.
+func test_an_egg_that_would_hatch_with_the_move_does_not_answer_for_it() -> void:
+	var world: Gen2WorldAPI = _world(1, true, false)
+	world.set_party_summary(
+		1, false, [1] as Array[int], [[Gen2WorldFieldMove.MOVE_CUT]], ["EGG"], [true]
+	)
+	assert_eq(world.cut_request()["reason"], &"move_not_known")
+	assert_eq(world.party_slot_with_move(Gen2WorldFieldMove.MOVE_CUT), -1)
+
+	world.set_party_summary(
+		2, false, [1, 2] as Array[int],
+		[[Gen2WorldFieldMove.MOVE_CUT], [Gen2WorldFieldMove.MOVE_CUT]],
+		["EGG", "MON"], [true, false]
+	)
+	assert_eq(world.party_slot_with_move(Gen2WorldFieldMove.MOVE_CUT), 1)
 	assert_true(bool(world.cut_request().get("ok", false)))
 
 
@@ -750,6 +813,7 @@ func test_whirlpool_request_reads_the_gold_silver_badge_flag() -> void:
 	state.set_engine_flag(Gen2WorldState.ENGINE_GLACIERBADGE)
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WHIRLPOOL_STAND_CELL, state)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_WHIRLPOOL)
 	assert_eq(world.whirlpool_request()["reason"], &"badge_required")
 
 	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_GLACIER, false))
@@ -772,6 +836,7 @@ func test_whirlpool_request_refuses_a_tileset_without_a_block_list() -> void:
 	))
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 2, WHIRLPOOL_STAND_CELL, state)
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_WHIRLPOOL)
 	assert_true(Gen2WorldFieldMove.whirlpool_tile(world.collision_code_at(WHIRLPOOL_CELL)))
 	assert_eq(world.whirlpool_request()["reason"], &"nothing_to_whirlpool")
 
@@ -861,7 +926,7 @@ func test_the_whirlpool_traps_a_player_until_it_is_removed() -> void:
 
 ## A world in the water below the waterfall column, facing up, with the Rising
 ## Badge on whichever engine flag table the opened cache selects.
-func _waterfall_world(badge: bool = true) -> Gen2WorldAPI:
+func _waterfall_world(badge: bool = true, knows: bool = true) -> Gen2WorldAPI:
 	var data: GameData = GameData.open_directory(_directory)
 	var state := Gen2WorldState.new()
 	if badge:
@@ -871,6 +936,8 @@ func _waterfall_world(badge: bool = true) -> Gen2WorldAPI:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WATERFALL_STAND_CELL, state)
 	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
 	world.player_facing = Gen2WorldSprite.FACING_UP
+	if knows:
+		_knowing_party(world, Gen2WorldFieldMove.MOVE_WATERFALL)
 	return world
 
 
@@ -900,6 +967,7 @@ func test_waterfall_request_reads_the_gold_silver_badge_flag() -> void:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, WATERFALL_STAND_CELL, state)
 	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
 	world.player_facing = Gen2WorldSprite.FACING_UP
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_WATERFALL)
 	assert_eq(world.waterfall_request()["reason"], &"badge_required")
 
 

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -27,6 +27,7 @@ const SPECIALCALL_ASSISTANT: int = 3
 const WALK_RESOLVE_ATTEMPTS: int = 16
 
 ## constants/item_constants.asm's add_hm list, whose comment column is hex.
+const ITEM_HM_CUT: int = 0xF3
 const ITEM_HM_STRENGTH: int = 0xF6
 const ITEM_HM_WATERFALL: int = 0xF9
 ## Ice Path 1F's HM07 ball stands on (31,7) in both games, on the same region as
@@ -592,6 +593,85 @@ const BROCK_FACE: Vector2i = Vector2i(5, 2)
 const BADGE_BOULDER: int = 8
 const EVENT_BEAT_BROCK: int = 1221
 const EVENT_BEAT_CAMPER_JERRY: int = 1067
+## `maps/PewterGym.asm` warps 1 and 2, both back onto Pewter's warp 2.
+const PEWTER_GYM_EXIT: Vector2i = Vector2i(4, 13)
+
+## South from Pewter to Cinnabar: Route 2, Viridian City, Route 1, Pallet Town,
+## Route 21 and Cinnabar Island are six plain connections with no gate building
+## and no door on any of them (`data/maps/attributes.asm`, and neither Route 1
+## nor Route 21 declares a warp at all). Coming back onto Route 2 from Pewter
+## lands in its main region, which already holds the Viridian crossing, so the
+## cut tree is not on this half of the walk.
+const VIRIDIAN_CITY_NUMBER: int = 3
+const PALLET_GROUP: int = 13
+const ROUTE_1_NUMBER: int = 1
+const PALLET_TOWN_NUMBER: int = 2
+const ENGINE_FLYPOINT_VIRIDIAN: int = 54
+const ENGINE_FLYPOINT_PALLET: int = 53
+
+## Pallet Town's own pond is the route's way south: its south edge is sixteen
+## cells of water on x=4 to 7, and the land beside it is (4,13). Everything from
+## there to Seafoam Gym's door is surfed.
+const PALLET_SURF_APPROACH: Vector2i = Vector2i(4, 13)
+const SEAFOAM_GROUP: int = 6
+const ROUTE_21_NUMBER: int = 7
+const CINNABAR_ISLAND_NUMBER: int = 8
+const ROUTE_20_NUMBER: int = 6
+const SEAFOAM_GYM_NUMBER: int = 4
+
+## Cinnabar Island is two land regions with no seam between them, so which cell
+## the crossing lands on decides whether Blue is reachable at all. Route 21's
+## south edge is water from x=1 to 14, and Cinnabar's row 0 is water on x=1 to 3
+## and land on x=11 to 18: crossing on the eastern half exits the water into an
+## 89-cell region that reaches neither Blue nor the Pokecenter, so the walk stays
+## on the water down the island's west side and lands on (4,10) instead, in the
+## 51-cell region that holds both.
+const CINNABAR_LANDING: Vector2i = Vector2i(4, 10)
+## `maps/CinnabarIsland.asm` object 1 on (9,6), walled on three sides, so (8,6)
+## facing right is its only approach. `CinnabarIslandBlue` is what clears
+## EVENT_VIRIDIAN_GYM_BLUE and so the only thing that opens Viridian Gym.
+const BLUE_FACE: Vector2i = Vector2i(8, 6)
+const EVENT_VIRIDIAN_GYM_BLUE: int = 1910
+const ENGINE_FLYPOINT_CINNABAR: int = 63
+
+## Cinnabar's east edge is one cell, (19,16), and it is water, so the leg surfs
+## again from the same shore it landed on. `Route20ClearRocksCallback` is a
+## MAPCALLBACK_NEWMAP, so arriving is what sets EVENT_CINNABAR_ROCKS_CLEARED and
+## unseals Fuchsia's south edge; nothing on the route walks that way, but the
+## flag is the reason this leg comes before Viridian's.
+const CINNABAR_SURF_APPROACH: Vector2i = Vector2i(4, 10)
+const EVENT_CINNABAR_ROCKS_CLEARED: int = 215
+## Route 20's island cluster, landed on from the east and not the west. The
+## channel on x=26 and 27 that runs up the island's west shore is walled off from
+## the open sea on every side: column 25 is wall from row 2 to 13, row 1 closes it
+## above and row 13's own eleven wall cells close it below. The east shore is
+## open water, so (41,8) is the landfall and (38,7) the `$7b` cave tile that
+## warps into the gym.
+const ROUTE_20_LANDING: Vector2i = Vector2i(41, 8)
+const SEAFOAM_GYM_DOOR: Vector2i = Vector2i(38, 7)
+## `maps/SeafoamGym.asm`: Blaine on (5,2) inside a 13-cell cave, faced from the
+## cell below. His script `appear`s the gym guide, which is a `clearevent` on the
+## guide's own hide flag, and it runs only on the branch a won battle takes.
+const BLAINE_FACE: Vector2i = Vector2i(5, 3)
+const BADGE_VOLCANO: int = 14
+const EVENT_BEAT_BLAINE: int = 1227
+const EVENT_SEAFOAM_GYM_GYM_GUIDE: int = 1911
+## `maps/SeafoamGym.asm` warp 1, back onto the Route 20 cave tile.
+const SEAFOAM_GYM_EXIT: Vector2i = Vector2i(5, 5)
+## The island's east shore again, surfed from rather than landed on.
+const ROUTE_20_SURF_APPROACH: Vector2i = Vector2i(41, 8)
+## Pallet's pond from the sea side: the same sixteen cells, landed on at (4,13).
+const PALLET_LANDING: Vector2i = Vector2i(4, 13)
+
+## Viridian Gym, the last badge on the walked route. `maps/ViridianGym.asm`
+## declares neither a scene nor a callback and ships no trainer: both its objects
+## are hidden by EVENT_VIRIDIAN_GYM_BLUE, so the gym is empty until Cinnabar's
+## Blue clears it, and that is the whole gate.
+const VIRIDIAN_GYM_NUMBER: int = 4
+const VIRIDIAN_GYM_DOOR: Vector2i = Vector2i(32, 7)
+const BLUE_GYM_FACE: Vector2i = Vector2i(5, 4)
+const BADGE_EARTH: int = 15
+const EVENT_BEAT_BLUE: int = 1228
 
 ## constants/item_constants.asm.
 const ITEM_MACHINE_PART: int = 0x80
@@ -1817,6 +1897,26 @@ func _plain_badge_path(
 	})
 	if not bool(cut_gift.get("terminal", false)):
 		return {"ok": false, "path": path, "reason": "HM01 handoff did not finish"}
+
+	# And taught, not just carried. The starter is the only line in this party
+	# that CanLearnTMHMMove accepts for CUT, and HM01 arrives here, one walk
+	# before the first tree, so this is the earliest the route can be honest
+	# about the move. `teach_tm_hm()` is the same transaction the pack's USE
+	# reaches, the way _olivine_cafe_hm04() teaches STRENGTH.
+	var taught: Dictionary = _teach_hm(world, save, ITEM_HM_CUT)
+	_mirror_party(world, save)
+	path.append({
+		"step": "ilex_forest_teach_cut",
+		"map": _map_value(world),
+		"taught": taught.get("ok", false),
+		"species": _party_species(save),
+		"moves": _party_moves(save),
+	})
+	if not bool(taught.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "no party member learned CUT: %s" % taught.get("reason", ""),
+		}
 
 	var walked_to_tree: Dictionary = _walk_cell_resolving(
 		world, ILEX_CUT_APPROACH, save, random, data
@@ -6322,6 +6422,356 @@ func _pewter_gym_leg(
 		return {"ok": false, "path": path, "reason": "ENGINE_BOULDERBADGE was not set"}
 	if not world.event_flag_active(EVENT_BEAT_CAMPER_JERRY):
 		return {"ok": false, "path": path, "reason": "Brock did not set Camper Jerry's flag"}
+	return _cinnabar_leg(world, save, random, data, path)
+
+
+## Pewter Gym south to Cinnabar Island and east to Seafoam Gym's Volcano Badge.
+##
+## Six plain connections carry the walk down the west coast, and then it is water
+## the rest of the way: Pallet's own pond is the last land, and Route 21,
+## Cinnabar's west side and Route 20 are all surfed. Two things make this leg the
+## one that has to come before Viridian's. Blue stands on Cinnabar until he is
+## talked to, and `CinnabarIslandBlue` is the only `clearevent` for
+## EVENT_VIRIDIAN_GYM_BLUE in either pin; and `Route20ClearRocksCallback` is a
+## MAPCALLBACK_NEWMAP, so simply arriving on Route 20 sets
+## EVENT_CINNABAR_ROCKS_CLEARED and takes the six `$7a` wall blocks off Route 19.
+func _cinnabar_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var out_of_gym: Dictionary = _warp_chain(world, save, random, data, [PEWTER_GYM_EXIT])
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving Pewter Gym failed: %s" % out_of_gym.get("reason", ""),
+		}
+
+	var southbound: Array = [
+		{"step": "route_2_southbound", "group": ROUTE_2_GROUP, "number": ROUTE_2_NUMBER},
+		{"step": "viridian_city", "group": ROUTE_2_GROUP, "number": VIRIDIAN_CITY_NUMBER,
+			"flypoint": ENGINE_FLYPOINT_VIRIDIAN},
+		{"step": "route_1", "group": PALLET_GROUP, "number": ROUTE_1_NUMBER},
+		{"step": "pallet_town", "group": PALLET_GROUP, "number": PALLET_TOWN_NUMBER,
+			"flypoint": ENGINE_FLYPOINT_PALLET},
+	]
+	for leg: Dictionary in southbound:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, "south", int(leg["group"]), int(leg["number"]), save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		var step: Dictionary = {
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		}
+		if leg.has("flypoint"):
+			step["flypoint"] = world.state.is_engine_flag_active(int(leg["flypoint"]))
+		path.append(step)
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the walk to %s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+		if leg.has("flypoint") \
+			and not world.state.is_engine_flag_active(int(leg["flypoint"])):
+			return {
+				"ok": false, "path": path,
+				"reason": "%s's flypoint callback did not run" % leg["step"],
+			}
+
+	var boarded: Dictionary = _surf_at(
+		world, PALLET_SURF_APPROACH, Gen2WorldSprite.FACING_DOWN, save, random, data
+	)
+	path.append({
+		"step": "pallet_pond_surf",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": boarded.get("encounters", []),
+	})
+	if not bool(boarded.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Pallet's surf entry failed: %s" % boarded.get("reason", ""),
+		}
+
+	for leg: Dictionary in [
+		{"step": "route_21", "number": ROUTE_21_NUMBER},
+		{"step": "cinnabar_island", "number": CINNABAR_ISLAND_NUMBER},
+	]:
+		var surfed: Dictionary = _walk_connection_resolving(
+			world, "south", SEAFOAM_GROUP, int(leg["number"]), save, random, data, true
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": surfed.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(surfed.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the surf to %s failed: %s" % [leg["step"], surfed.get("reason", "")],
+			}
+
+	var ashore: Dictionary = _walk_cell_resolving(
+		world, CINNABAR_LANDING, save, random, data, true
+	)
+	if not bool(ashore.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "landing on Cinnabar failed: %s" % ashore.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_CINNABAR):
+		return {"ok": false, "path": path, "reason": "Cinnabar's flypoint callback did not run"}
+
+	var blue: Dictionary = _talk_to(
+		world, BLUE_FACE, Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	path.append({
+		"step": "cinnabar_blue",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_CINNABAR),
+		"viridian_gym_blue": world.event_flag_active(EVENT_VIRIDIAN_GYM_BLUE),
+		"encounters": blue.get("encounters", []),
+		"run": blue.get("run", {}),
+	})
+	if not bool(blue.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blue did not finish: %s" % blue.get("reason", ""),
+		}
+	if world.event_flag_active(EVENT_VIRIDIAN_GYM_BLUE):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blue did not clear EVENT_VIRIDIAN_GYM_BLUE",
+		}
+
+	return _seafoam_gym_leg(world, save, random, data, path)
+
+
+## Cinnabar east to Route 20 and Blaine's cave.
+func _seafoam_gym_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var boarded: Dictionary = _surf_at(
+		world, CINNABAR_SURF_APPROACH, Gen2WorldSprite.FACING_LEFT, save, random, data
+	)
+	if not bool(boarded.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Cinnabar's surf entry failed: %s" % boarded.get("reason", ""),
+		}
+	var eastbound: Dictionary = _walk_connection_resolving(
+		world, "east", SEAFOAM_GROUP, ROUTE_20_NUMBER, save, random, data, true
+	)
+	var entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "route_20",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"cinnabar_rocks_cleared": world.event_flag_active(EVENT_CINNABAR_ROCKS_CLEARED),
+		"encounters": eastbound.get("encounters", []),
+		"run": entry,
+	})
+	if not bool(eastbound.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the surf to Route 20 failed: %s" % eastbound.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_CINNABAR_ROCKS_CLEARED):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route20ClearRocksCallback did not run",
+		}
+
+	var ashore: Dictionary = _walk_cell_resolving(
+		world, ROUTE_20_LANDING, save, random, data, true
+	)
+	path.append({
+		"step": "route_20_landfall",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": ashore.get("encounters", []),
+	})
+	if not bool(ashore.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "landing on Route 20 failed: %s" % ashore.get("reason", ""),
+		}
+
+	var into_gym: Dictionary = _warp_chain(world, save, random, data, [SEAFOAM_GYM_DOOR])
+	if not bool(into_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Seafoam Gym mouth failed: %s" % into_gym.get("reason", ""),
+		}
+
+	var blaine: Dictionary = _talk_to(
+		world, BLAINE_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	var badge: int = Gen2WorldState.badge_flag(
+		BADGE_VOLCANO, Gen2WorldState.is_crystal_profile(data)
+	)
+	path.append({
+		"step": "seafoam_gym_blaine",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"volcano_badge": world.state.is_engine_flag_active(badge),
+		"beat_blaine": world.event_flag_active(EVENT_BEAT_BLAINE),
+		# `appear SEAFOAMGYM_GYM_GUIDE` is a clearevent on the guide's own hide
+		# flag, and it sits on the branch only a won battle reaches.
+		"gym_guide_hidden": world.event_flag_active(EVENT_SEAFOAM_GYM_GYM_GUIDE),
+		"encounters": blaine.get("encounters", []),
+		"run": blaine.get("run", {}),
+	})
+	if not bool(blaine.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blaine did not finish: %s" % blaine.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(badge):
+		return {"ok": false, "path": path, "reason": "ENGINE_VOLCANOBADGE was not set"}
+	return _viridian_leg(world, save, random, data, path)
+
+
+## Seafoam Gym back up the coast to Viridian Gym and the Earth Badge.
+##
+## The way back is the way down reversed, water included: Route 20's east shore,
+## Cinnabar, Route 21 and Pallet's own pond, then three connections north. The
+## gym at the end has no puzzle and no trainer in it. Both its objects carry
+## EVENT_VIRIDIAN_GYM_BLUE as their hide flag, so before Cinnabar the building is
+## empty and after it Blue is simply standing there.
+func _viridian_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var out_of_gym: Dictionary = _warp_chain(world, save, random, data, [SEAFOAM_GYM_EXIT])
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving Seafoam Gym failed: %s" % out_of_gym.get("reason", ""),
+		}
+	var boarded: Dictionary = _surf_at(
+		world, ROUTE_20_SURF_APPROACH, Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	if not bool(boarded.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 20's surf entry failed: %s" % boarded.get("reason", ""),
+		}
+
+	var northbound: Array = [
+		{"step": "cinnabar_return", "direction": "west", "number": CINNABAR_ISLAND_NUMBER},
+		{"step": "route_21_northbound", "direction": "north", "number": ROUTE_21_NUMBER},
+		{"step": "pallet_return", "direction": "north", "number": PALLET_TOWN_NUMBER,
+			"group": PALLET_GROUP, "ashore": PALLET_LANDING},
+	]
+	for leg: Dictionary in northbound:
+		var surfed: Dictionary = _walk_connection_resolving(
+			world, String(leg["direction"]), int(leg.get("group", SEAFOAM_GROUP)),
+			int(leg["number"]), save, random, data, true
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": surfed.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(surfed.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the surf to %s failed: %s" % [leg["step"], surfed.get("reason", "")],
+			}
+		if leg.has("ashore"):
+			var ashore: Dictionary = _walk_cell_resolving(
+				world, leg["ashore"], save, random, data, true
+			)
+			if not bool(ashore.get("ok", false)):
+				return {
+					"ok": false, "path": path,
+					"reason": "landing on %s failed: %s" % [
+						leg["ashore"], ashore.get("reason", ""),
+					],
+				}
+
+	for leg: Dictionary in [
+		{"step": "route_1_northbound", "group": PALLET_GROUP, "number": ROUTE_1_NUMBER},
+		{"step": "viridian_return", "group": ROUTE_2_GROUP, "number": VIRIDIAN_CITY_NUMBER},
+	]:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, "north", int(leg["group"]), int(leg["number"]), save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the walk to %s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+
+	var into_gym: Dictionary = _warp_chain(world, save, random, data, [VIRIDIAN_GYM_DOOR])
+	if not bool(into_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Viridian Gym door failed: %s" % into_gym.get("reason", ""),
+		}
+
+	var blue: Dictionary = _talk_to(
+		world, BLUE_GYM_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	var badge: int = Gen2WorldState.badge_flag(
+		BADGE_EARTH, Gen2WorldState.is_crystal_profile(data)
+	)
+	path.append({
+		"step": "viridian_gym_blue",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"earth_badge": world.state.is_engine_flag_active(badge),
+		"beat_blue": world.event_flag_active(EVENT_BEAT_BLUE),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
+		"encounters": blue.get("encounters", []),
+		"run": blue.get("run", {}),
+	})
+	if not bool(blue.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Blue did not finish: %s" % blue.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(badge):
+		return {"ok": false, "path": path, "reason": "ENGINE_EARTHBADGE was not set"}
 	return {"ok": true}
 
 

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -27,8 +27,19 @@ const SPECIALCALL_ASSISTANT: int = 3
 const WALK_RESOLVE_ATTEMPTS: int = 16
 
 ## constants/item_constants.asm's add_hm list, whose comment column is hex.
+## `maps/Route32.asm` warp 1 and `maps/Route32Pokecenter1F.asm` warp 1, the
+## fishing guru on (1,4) faced from below, and the nearest shore cell the rod is
+## cast from: (10,42) faces water on (9,42) and sits in the same region as the
+## Pokemon Center door.
+const ROUTE_32_POKECENTER_DOOR: Vector2i = Vector2i(11, 73)
+const ROUTE_32_POKECENTER_EXIT: Vector2i = Vector2i(3, 7)
+const FISHING_GURU_FACE: Vector2i = Vector2i(1, 5)
+const ROUTE_32_SHORE: Vector2i = Vector2i(10, 42)
+
 const ITEM_HM_CUT: int = 0xF3
+const ITEM_HM_SURF: int = 0xF5
 const ITEM_HM_STRENGTH: int = 0xF6
+const ITEM_HM_WHIRLPOOL: int = 0xF8
 const ITEM_HM_WATERFALL: int = 0xF9
 ## Ice Path 1F's HM07 ball stands on (31,7) in both games, on the same region as
 ## the Route 44 door and the first staircase (`maps/IcePath1F.asm`). Three of its
@@ -41,6 +52,9 @@ const HM07_APPROACH: Vector2i = Vector2i(30, 7)
 ## Great Balls is what the source start money covers.
 const MART_BLACKTHORN: int = 17
 const GREAT_BALLS_BOUGHT: int = 5
+## `maps/BlackthornMart.asm` object 1 on (1,3), standing right behind the
+## counter on (2,3), so it is talked to from (3,3) facing left.
+const BLACKTHORN_MART_CLERK_FACE: Vector2i = Vector2i(3, 3)
 ## The two Radio Tower keys, from the same hex comment column.
 const ITEM_CARD_KEY: int = 0x7F
 const ITEM_BASEMENT_KEY: int = 0x85
@@ -1595,6 +1609,10 @@ func _hive_badge_path(
 			"reason": "Violet City to Route 32 failed: %s" % route32_leg.get("reason", ""),
 		}
 
+	var rod: Dictionary = _route_32_old_rod(world, save, random, data, path)
+	if not bool(rod.get("ok", false)):
+		return rod
+
 	# Route 32's south edge does connect to Route 33, but that lands in the
 	# plaza north of Route 33's wall row, whose only exit is the Union Cave
 	# warp. The cartridge's own path is Route 32 (6,79) into Union Cave 1F and
@@ -2482,6 +2500,23 @@ func _mineral_badge_path(
 			"reason": "HM03 handoff failed: %s" % surf_guy.get("reason", ""),
 		}
 
+	# Taught here, two legs before Route 40's south edge asks for it. The Ilex
+	# Forest Psyduck is the only party member CanLearnTMHMMove accepts.
+	var surf_taught: Dictionary = _teach_hm(world, save, ITEM_HM_SURF)
+	_mirror_party(world, save)
+	path.append({
+		"step": "dance_theater_teach_surf",
+		"map": _map_value(world),
+		"taught": surf_taught.get("ok", false),
+		"species": _party_species(save),
+		"moves": _party_moves(save),
+	})
+	if not bool(surf_taught.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "no party member learned SURF: %s" % surf_taught.get("reason", ""),
+		}
+
 	var leaving_theater: Dictionary = _warp_step(world, 4, 9)
 	if not bool(leaving_theater.get("ok", false)):
 		return {"ok": false, "path": path, "reason": "Dance Theater exit warp failed"}
@@ -3145,6 +3180,25 @@ func _glacier_badge_path(
 				],
 			}
 
+	# The third Electrode brings Lance back with HM06, and it is taught here for
+	# the same reason Surf is taught in the Dance Theater: Dragon's Den B1F's
+	# whirlpool is several legs away, and the only party member
+	# CanLearnTMHMMove accepts for WHIRLPOOL is the Ilex Forest Psyduck.
+	var whirlpool_taught: Dictionary = _teach_hm(world, save, ITEM_HM_WHIRLPOOL)
+	_mirror_party(world, save)
+	path.append({
+		"step": "rocket_base_b2f_teach_whirlpool",
+		"map": _map_value(world),
+		"taught": whirlpool_taught.get("ok", false),
+		"species": _party_species(save),
+		"moves": _party_moves(save),
+	})
+	if not bool(whirlpool_taught.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "no party member learned WHIRLPOOL: %s" % whirlpool_taught.get("reason", ""),
+		}
+
 	# Out the way the route came in. Clearing the base hides the grunts, so the
 	# walk back is not the one that came down.
 	for ladder: Dictionary in [
@@ -3807,7 +3861,9 @@ func _rising_badge_path(
 			"ok": false, "path": path,
 			"reason": "Blackthorn Mart unreachable: %s" % mart_trip.get("reason", ""),
 		}
-	var bought: Dictionary = _buy_great_balls(world, save, data, path, GREAT_BALLS_BOUGHT)
+	var bought: Dictionary = _buy_great_balls(
+		world, save, random, data, path, GREAT_BALLS_BOUGHT
+	)
 	if not bool(bought.get("ok", false)):
 		return {
 			"ok": false, "path": path,
@@ -7586,9 +7642,7 @@ func _push_boulder_at(
 	}
 
 
-## BlackthornMartClerkScript's `pokemart MARTTYPE_STANDARD, MART_BLACKTHORN`,
-## bought from headlessly the way _teach_hm() teaches: through the same host the
-## service overlay drives, rather than through the overlay.
+## BlackthornMartClerkScript, talked to across its own counter.
 ##
 ## The route needs this once. Elm's aide gives five Poké Balls, Union Cave's
 ## Geodude costs one, and Dratini is a far lower catch rate than Geodude, so the
@@ -7597,24 +7651,27 @@ func _push_boulder_at(
 ## sells no Poké Balls, so what the route buys is Great Balls: they are the
 ## cheapest ball it stocks, and the source start money buys five of them against
 ## two Ultra Balls.
+##
+## The clerk stands on (1,3) behind the `$90` counter on (2,3), so this is a
+## CheckFacingObject doubled reach like the Radio Card woman's, and the buying
+## itself happens inside the clerk's own `pokemart` pause rather than beside it.
 func _buy_great_balls(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
+	random: RandomNumberGenerator,
 	data: GameData,
 	path: Array,
 	quantity: int,
 ) -> Dictionary:
-	var resolved: Dictionary = Gen2WorldMartHost.resolve_mart(
-		data, Gen2WorldMartHost.MARTTYPE_STANDARD, MART_BLACKTHORN, false, world.state
+	var walked: Dictionary = _walk_cell_resolving(
+		world, BLACKTHORN_MART_CLERK_FACE, save, random, data
 	)
-	if not bool(resolved.get("ok", false)):
-		return {
-			"ok": false,
-			"reason": "Blackthorn mart did not resolve: %s" % resolved.get("reason", ""),
-		}
-	var bought: Dictionary = Gen2WorldMartHost.purchase(
-		world, save, resolved.get("mart", {}),
-		Gen2WorldPartyHost.ITEM_GREAT_BALL, quantity, false
+	if not bool(walked.get("ok", false)):
+		return {"ok": false, "reason": "the mart clerk is unreachable: %s" % walked.get("reason", "")}
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var run: Dictionary = _drain_story(
+		world, world.interact(), save, random, data, true, [],
+		{"item": Gen2WorldPartyHost.ITEM_GREAT_BALL, "quantity": quantity}
 	)
 	path.append({
 		"step": "blackthorn_mart_great_balls",
@@ -7622,10 +7679,88 @@ func _buy_great_balls(
 		"cell": _cell_value(world),
 		"balls": world.state.item_quantity(Gen2WorldPartyHost.ITEM_GREAT_BALL),
 		"money": world.state.money(),
+		"purchases": run.get("purchases", []),
+		"run": run,
 	})
-	if not bool(bought.get("ok", false)):
-		return {"ok": false, "reason": "purchase refused: %s" % bought.get("reason", "")}
+	if not bool(run.get("terminal", false)):
+		return {"ok": false, "reason": "the mart clerk did not finish: %s" % run.get("reason", "")}
+	if world.state.item_quantity(Gen2WorldPartyHost.ITEM_GREAT_BALL) < quantity:
+		return {"ok": false, "reason": "the Great Balls did not reach the bag"}
 	return {"ok": true}
+
+
+## Route 32's Pokemon Center for the OLD ROD, and then the shore below it for
+## what the rod is here to catch.
+##
+## This is the route's answer to Surf and Whirlpool, and it has to be a rod
+## rather than a walk. Every grass wild in reach before Route 40's south edge
+## that CanLearnTMHMMove accepts for SURF is night only except Slowpoke Well's
+## Slowpoke, and Slowpoke does not take WHIRLPOOL at all; the walked route runs
+## on the new game's own 06:00 clock, so a night slot is not something it can
+## honestly reach. Route 32's own Old Rod row is the one time-independent source
+## of a mon that takes both, at Tentacool on the last threshold
+## (`data/wild/fish.asm`).
+##
+## `Route32Pokecenter1FFishingGuruScript` gates the rod on its own yes/no and
+## then `verbosegiveitem OLD_ROD`, which is what `Gen2WorldInventory.owns_rod()`
+## reads back.
+func _route_32_old_rod(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_center: Dictionary = _warp_chain(
+		world, save, random, data, [ROUTE_32_POKECENTER_DOOR]
+	)
+	if not bool(into_center.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Route 32 Pokemon Center door failed: %s" % into_center.get("reason", ""),
+		}
+	var guru: Dictionary = _talk_to(
+		world, FISHING_GURU_FACE, Gen2WorldSprite.FACING_UP,
+		save, random, data, [0] as Array[int]
+	)
+	path.append({
+		"step": "route_32_fishing_guru_old_rod",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"old_rod": world.state.item_quantity(Gen2WorldInventory.ITEM_OLD_ROD) > 0,
+		"run": guru.get("run", {}),
+	})
+	if not bool(guru.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the fishing guru did not finish: %s" % guru.get("reason", ""),
+		}
+	if world.state.item_quantity(Gen2WorldInventory.ITEM_OLD_ROD) <= 0:
+		return {"ok": false, "path": path, "reason": "the OLD ROD did not reach the bag"}
+
+	var outside: Dictionary = _warp_chain(
+		world, save, random, data, [ROUTE_32_POKECENTER_EXIT]
+	)
+	if not bool(outside.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving the Route 32 Pokemon Center failed: %s" % outside.get("reason", ""),
+		}
+
+	var walked: Dictionary = _walk_cell_resolving(
+		world, ROUTE_32_SHORE, save, random, data
+	)
+	if not bool(walked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 32's shore is unreachable: %s" % walked.get("reason", ""),
+		}
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	return _catch_field_move_mon(
+		world, save, random, data, path,
+		Gen2WorldFieldMove.MOVE_SURF, "route_32_fish_for_surf",
+		Gen2WorldEncounter.METHOD_OLD_ROD
+	)
 
 
 ## Catches something on the current map that can learn [param move], which is
@@ -7649,6 +7784,7 @@ func _catch_field_move_mon(
 	path: Array,
 	move: int,
 	step: String,
+	method: StringName = &"auto",
 ) -> Dictionary:
 	var attempts: Array = []
 	var caught: Dictionary = {}
@@ -7656,7 +7792,7 @@ func _catch_field_move_mon(
 		var ball: int = _best_ball(world)
 		if ball <= 0:
 			break
-		var encounter: Dictionary = world.encounter_request(random, true)
+		var encounter: Dictionary = world.encounter_request(random, true, method)
 		if encounter.is_empty():
 			break
 		var species: int = int(encounter.get("pokemon", 0))
@@ -7999,6 +8135,7 @@ func _mirror_party(world: Gen2WorldAPI, save: Gen2SaveData) -> void:
 	var species: Array[int] = []
 	var moves: Array = []
 	var names: Array = []
+	var eggs: Array = []
 	for mon: Gen2SaveMon in save.party:
 		species.append(int(mon.species))
 		var mon_moves: Array = []
@@ -8007,7 +8144,8 @@ func _mirror_party(world: Gen2WorldAPI, save: Gen2SaveData) -> void:
 				mon_moves.append(move)
 		moves.append(mon_moves)
 		names.append(mon.nickname if not mon.nickname.is_empty() else "")
-	world.set_party_summary(save.party.size(), false, species, moves, names)
+		eggs.append(mon.is_egg)
+	world.set_party_summary(save.party.size(), false, species, moves, names, eggs)
 
 
 func _party_has_egg(save: Gen2SaveData) -> bool:
@@ -8052,8 +8190,13 @@ func _drain_story(
 	data: GameData = null,
 	require_events: bool = false,
 	answers: Array[int] = [],
+	purchase: Dictionary = {},
 ) -> Dictionary:
 	var pending_answers: Array[int] = answers.duplicate()
+	## What to buy if a `pokemart` opens while this drain runs. Cleared once it
+	## is spent, so one standing order buys once.
+	var pending_purchase: Dictionary = purchase.duplicate()
+	var purchases: Array = []
 	if require_events and initial.is_empty():
 		return {
 			"statuses": [],
@@ -8210,6 +8353,35 @@ func _drain_story(
 					"ok": true,
 					"outcome": Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
 				})
+			elif request_kind == &"mart_requested":
+				# `pokemart` is a runtime pause the same way a battle is, so the
+				# clerk's own script is what opens the mart and the caller's
+				# standing order is what buys from it. Gen2WorldHost resolves the
+				# dialog and mart id off the request exactly as the service
+				# screen does.
+				var mart_host: Dictionary = Gen2WorldHost.resolve_runtime_request(world, request)
+				if not bool(mart_host.get("ok", false)):
+					last_reason = String(mart_host.get("reason", "mart host failed"))
+					last_details = JSON.stringify(mart_host)
+					break
+				var mart: Dictionary = mart_host.get("data", {}).get("mart", {})
+				if not pending_purchase.is_empty():
+					var bought: Dictionary = Gen2WorldMartHost.purchase(
+						world, save, mart, int(pending_purchase.get("item", 0)),
+						int(pending_purchase.get("quantity", 0)), false
+					)
+					purchases.append({
+						"item": int(pending_purchase.get("item", 0)),
+						"quantity": int(pending_purchase.get("quantity", 0)),
+						"ok": bool(bought.get("ok", false)),
+						"reason": bought.get("reason", ""),
+					})
+					if not bool(bought.get("ok", false)):
+						last_reason = String(bought.get("reason", "purchase refused"))
+						last_details = JSON.stringify(bought)
+						break
+					pending_purchase = {}
+				results = world.complete_runtime_request({"ok": true})
 			elif request_kind == &"audio_requested":
 				results = world.complete_runtime_request({"ok": true})
 			else:
@@ -8237,6 +8409,7 @@ func _drain_story(
 		"waits": waits,
 		"pending_trace": pending_trace,
 		"battles": battles,
+		"purchases": purchases,
 		"catch_tutorials": catch_tutorials,
 		"hall_of_fame": hall_of_fame,
 		"approaches": approaches,

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -64,6 +64,19 @@ const EVENT_MAHOGANY_POKEFAN_M_BLOCKS_EAST: int = 1878
 ## cell that reaches Blackthorn Gym's door (`maps/BlackthornCity.asm`).
 const EVENT_CLEARED_RADIO_TOWER: int = 33
 const EVENT_BLACKTHORN_SUPER_NERD_BLOCKS_GYM: int = 1763
+## `RadioTower1FRadioCardWomanScript` on (12,6), standing up. She and the two
+## men beside her are sealed in the lobby's own 8x2 desk pocket, so she is not
+## reached but talked to across the `$90` counter on (12,5) from (12,4), which
+## is what CheckFacingObject's doubled distance is for. She is hidden by
+## EVENT_GOLDENROD_CITY_CIVILIANS, which the boss script clears, so the card is
+## taken on the way back down and not before (`maps/RadioTower1F.asm`,
+## `maps/RadioTower5F.asm`).
+const RADIO_CARD_WOMAN_FACE: Vector2i = Vector2i(12, 4)
+## Her quiz is six `yesorno`s: the offer, then five questions whose accepted
+## answers are yes, yes, no, yes, no, because questions three and five branch to
+## `.WrongAnswer` on `iftrue` where the others branch on `iffalse`. Zero-based,
+## the way DRAGON_SHRINE_ANSWERS is.
+const RADIO_CARD_ANSWERS: Array[int] = [0, 0, 0, 1, 0, 1]
 ## The Blackthorn Gym boulders' own object event flags, which
 ## `BlackthornGym1FBouldersCallback` reads back as `changeblock`s on 1F.
 const EVENT_BOULDER_IN_BLACKTHORN_GYM_1: int = 1798
@@ -513,6 +526,73 @@ const BADGE_SOUL: int = 12
 const EVENT_BEAT_JANINE: int = 1225
 const FUCHSIA_GYM_TRAINER_FLAGS: Array[int] = [1303, 1306, 1154, 1054]
 const EVENT_GOT_TM06_TOXIC: int = 221
+
+## Fuchsia back to Vermilion, which is four connections and one gate, not the
+## walk back through Lavender and Saffron the route came by: Route 12 connects
+## west onto Route 11 and Route 11 west onto Vermilion City
+## (`data/maps/attributes.asm`), and `maps/Route11.asm` declares no warps at
+## all, so nothing on that pair is gated. `maps/FuchsiaGym.asm` warps 1 and 2
+## both land on Fuchsia's warp 3.
+const FUCHSIA_GYM_EXIT: Vector2i = Vector2i(4, 17)
+## `maps/FuchsiaCity.asm` warp 8, the east half of the Route 15 gate pair.
+const FUCHSIA_ROUTE_15_GATE_DOOR: Vector2i = Vector2i(37, 22)
+const ROUTE_11_NUMBER: int = 2
+
+## Vermilion's Snorlax. The whole chain is pinned and checked against the cache
+## by `tools/validate_radio.gd`, which is where these values are explained; only
+## the cells the walk needs are repeated here.
+##
+## `maps/VermilionCity.asm` object 4 is a BIG_OBJECT filling (34,8) to (35,9),
+## and the cave mouth on (34,7) is sealed until it moves.
+##
+## The route arrives from Route 11, not from the port, and that lands it inside
+## the eight-cell pocket the Snorlax's own body seals off the city's east edge:
+## (36..39, 8) and (36..39, 9), measured against the cache. So the walk uses
+## (36,9) facing left, which is the last of `SnorlaxAwake.ProximityCoords` and
+## the only kind of cell an eastbound player ever has. Three of those five
+## coordinates sit in pockets like this one, which is why the source lists all
+## five rather than only the two the port side can stand on.
+const SNORLAX_TALK: Vector2i = Vector2i(36, 9)
+const DIGLETTS_CAVE_MOUTH: Vector2i = Vector2i(34, 7)
+## `engine/pokegear/pokegear.asm` RadioChannels: 20.0, the Poke Flute channel.
+const KNOB_POKE_FLUTE: int = 78
+const EVENT_FOUGHT_SNORLAX: int = 1872
+const EVENT_VERMILION_CITY_SNORLAX: int = 1904
+
+## Diglett's Cave, the one door into west Kanto (`maps/DiglettsCave.asm`).
+##
+## Three walkable regions, not one tunnel, so it is crossed by warps: the
+## Vermilion entrance sits in a 14-cell room whose only ladder is (5,31); that
+## lands on (17,33) in the 99-cell middle, which reaches the second ladder on
+## (3,3); and that lands on (17,3) in a 15-cell room holding the Route 2 door.
+## Measured against the cache, not read off the warp table, since the table
+## alone does not say which cells share a region.
+const DIGLETTS_CAVE_GROUP: int = 3
+const DIGLETTS_CAVE_NUMBER: int = 84
+const DIGLETTS_CAVE_CHAIN: Array[Vector2i] = [
+	Vector2i(5, 31), Vector2i(3, 3), Vector2i(15, 5),
+]
+
+## Route 2 and Pewter City. The cave lands in a 125-cell pocket closed by two
+## cut trees, and the northern one on (5,8) is the only one that opens the rest
+## of the route; cutting it reaches 469 cells and both the Pewter and the
+## Viridian crossing (`tools/validate_radio.gd` checks both counts).
+const ROUTE_2_GROUP: int = 23
+const ROUTE_2_NUMBER: int = 1
+const ROUTE_2_CUT_APPROACH: Vector2i = Vector2i(5, 9)
+const PEWTER_GROUP: int = 14
+const PEWTER_CITY_NUMBER: int = 2
+## `maps/PewterCity.asm` warp 2, and its own NEWMAP flypoint callback.
+const PEWTER_GYM_DOOR: Vector2i = Vector2i(16, 17)
+const ENGINE_FLYPOINT_PEWTER: int = 55
+## `maps/PewterGym.asm`: Brock on (5,1), faced from the cell below. Camper Jerry
+## on (2,5) watches three cells east along row 5, which the walk up column 5
+## crosses, so his battle is unavoidable. Beating Brock sets his flag too.
+const BROCK_FACE: Vector2i = Vector2i(5, 2)
+const BADGE_BOULDER: int = 8
+const EVENT_BEAT_BROCK: int = 1221
+const EVENT_BEAT_CAMPER_JERRY: int = 1067
+
 ## constants/item_constants.asm.
 const ITEM_MACHINE_PART: int = 0x80
 
@@ -3144,14 +3224,44 @@ func _radio_tower_boss(
 	if not world.event_flag_active(EVENT_BLACKTHORN_SUPER_NERD_BLOCKS_GYM):
 		return {"ok": false, "path": path, "reason": "Blackthorn Gym is still sealed"}
 
+	# The descent stops on 1F rather than running straight out of the door,
+	# because the boss script above just cleared EVENT_GOLDENROD_CITY_CIVILIANS
+	# (`maps/RadioTower5F.asm`) and the Radio Card woman is one of the objects
+	# that flag hides.
 	var descended: Dictionary = _warp_chain(
 		world, save, random, data,
-		[Vector2i(12, 0), Vector2i(17, 0), Vector2i(0, 0), Vector2i(15, 0), Vector2i(2, 7)]
+		[Vector2i(12, 0), Vector2i(17, 0), Vector2i(0, 0), Vector2i(15, 0)]
 	)
 	if not bool(descended.get("ok", false)):
 		return {
 			"ok": false, "path": path,
 			"reason": "Radio Tower return descent failed: %s" % descended.get("reason", ""),
+		}
+
+	var card: Dictionary = _talk_to(
+		world, RADIO_CARD_WOMAN_FACE, Gen2WorldSprite.FACING_DOWN,
+		save, random, data, RADIO_CARD_ANSWERS
+	)
+	path.append({
+		"step": "radio_tower_radio_card",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"radio_card": world.state.is_engine_flag_active(Gen2WorldState.ENGINE_RADIO_CARD),
+		"run": card.get("run", {}),
+	})
+	if not bool(card.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Radio Card quiz did not finish: %s" % card.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(Gen2WorldState.ENGINE_RADIO_CARD):
+		return {"ok": false, "path": path, "reason": "ENGINE_RADIO_CARD was not set"}
+
+	var out_of_tower: Dictionary = _warp_chain(world, save, random, data, [Vector2i(2, 7)])
+	if not bool(out_of_tower.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving the Radio Tower failed: %s" % out_of_tower.get("reason", ""),
 		}
 	return {"ok": true}
 
@@ -5970,6 +6080,248 @@ func _fuchsia_leg(
 			"ok": false, "path": path,
 			"reason": "Janine set %d of her four trainer flags" % disguised,
 		}
+	return _pewter_leg(world, save, random, data, path)
+
+
+## Fuchsia Gym back to Vermilion, through Diglett's Cave to Route 2, and up to
+## Pewter Gym for the Boulder Badge.
+##
+## The order is forced. Measured against a real Crystal cache, a walk out of
+## Cerulean reaches 91 maps and none of Route 3, Route 4's main region, Mount
+## Moon, Route 2, Viridian, Pallet, Cinnabar, Route 20 or Seafoam Gym, and
+## Fuchsia's own south edge is sealed the other way while
+## EVENT_CINNABAR_ROCKS_CLEARED is clear. Diglett's Cave is the one door into
+## west Kanto, and the Snorlax on top of it is the lock.
+##
+## What opens that lock is the radio, which is why the Goldenrod leg now takes
+## the Radio Card: `SnorlaxAwake` answers only while the Poke Flute channel is
+## the track in `wMapMusic`, and a station's music id is neither sentinel
+## `ExitPokegearRadio_HandleMusic` restores on, so it survives the Pokegear
+## closing. `tools/validate_radio.gd` owns that whole chain and the Route 2
+## counts behind it.
+func _pewter_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var out_of_gym: Dictionary = _warp_chain(world, save, random, data, [FUCHSIA_GYM_EXIT])
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving Fuchsia Gym failed: %s" % out_of_gym.get("reason", ""),
+		}
+
+	var to_route_15: Dictionary = _gate_leg(
+		world, save, random, data, FUCHSIA_ROUTE_15_GATE_DOOR, FUCHSIA_GROUP, ROUTE_15_NUMBER
+	)
+	path.append({
+		"step": "route_15_eastbound",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": to_route_15.get("encounters", []),
+	})
+	if not bool(to_route_15.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Route 15 gate east failed: %s" % to_route_15.get("reason", ""),
+		}
+
+	var northbound: Array = [
+		{"step": "route_14_northbound", "direction": "east", "group": FUCHSIA_GROUP,
+			"number": ROUTE_14_NUMBER},
+		{"step": "route_13_northbound", "direction": "north", "group": FUCHSIA_GROUP,
+			"number": ROUTE_13_NUMBER},
+		{"step": "route_12_northbound", "direction": "north", "group": LAVENDER_GROUP,
+			"number": ROUTE_12_NUMBER},
+		{"step": "route_11_westbound", "direction": "west", "group": VERMILION_GROUP,
+			"number": ROUTE_11_NUMBER},
+		{"step": "vermilion_return", "direction": "west", "group": VERMILION_GROUP,
+			"number": VERMILION_CITY_NUMBER},
+	]
+	for leg: Dictionary in northbound:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, String(leg["direction"]), int(leg["group"]), int(leg["number"]),
+			save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the walk to %s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+
+	var snorlax: Dictionary = _wake_snorlax(world, save, random, data, path)
+	if not bool(snorlax.get("ok", false)):
+		return snorlax
+
+	var through_cave: Dictionary = _warp_chain(
+		world, save, random, data, [DIGLETTS_CAVE_MOUTH] + DIGLETTS_CAVE_CHAIN
+	)
+	path.append({
+		"step": "digletts_cave",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+	})
+	if not bool(through_cave.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Diglett's Cave failed: %s" % through_cave.get("reason", ""),
+		}
+	if world.map_id() != Vector2i(ROUTE_2_GROUP, ROUTE_2_NUMBER):
+		return {"ok": false, "path": path, "reason": "the cave did not come out on Route 2"}
+
+	# The sixth site the route cuts without a party member that knows CUT, which
+	# is open work item 9 and not this leg's to fix.
+	var cut: Dictionary = _cut_at(
+		world, ROUTE_2_CUT_APPROACH, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "route_2_cut",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"encounters": cut.get("encounters", []),
+	})
+	if not bool(cut.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Route 2's cut tree failed: %s" % cut.get("reason", ""),
+		}
+
+	var to_pewter: Dictionary = _walk_connection_resolving(
+		world, "north", PEWTER_GROUP, PEWTER_CITY_NUMBER, save, random, data
+	)
+	var pewter_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "pewter_city",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_PEWTER),
+		"encounters": to_pewter.get("encounters", []),
+		"run": pewter_entry,
+	})
+	if not bool(to_pewter.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk to Pewter failed: %s" % to_pewter.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_PEWTER):
+		return {"ok": false, "path": path, "reason": "Pewter's flypoint callback did not run"}
+
+	return _pewter_gym_leg(world, save, random, data, path)
+
+
+## Vermilion's Snorlax, which is the only thing between the walked route and
+## west Kanto.
+##
+## Tuning is the whole interaction: `SnorlaxAwake` compares `wMapMusic` against
+## the Poke Flute channel and takes its false branch otherwise, so the dial is
+## moved to 20.0 and the Pokegear closed before it is talked to. The card the
+## dial needs is `ENGINE_RADIO_CARD`, taken on the Goldenrod leg, and the region
+## check behind the station needs `ENGINE_EXPN_CARD`, taken on the Lavender one.
+func _wake_snorlax(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	if not world.state.is_engine_flag_active(Gen2WorldState.ENGINE_RADIO_CARD):
+		return {"ok": false, "path": path, "reason": "the route reached the Snorlax with no radio card"}
+
+	var walked: Dictionary = _walk_cell_resolving(world, SNORLAX_TALK, save, random, data)
+	if not bool(walked.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk to the Snorlax failed: %s" % walked.get("reason", ""),
+		}
+	var tuned: Dictionary = world.tune_radio(KNOB_POKE_FLUTE)
+	world.close_radio()
+	if not bool(tuned.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "20.0 answered no station: %s" % tuned.get("reason", ""),
+		}
+
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var run: Dictionary = _drain_story(world, world.interact(), save, random, data, true)
+	path.append({
+		"step": "vermilion_snorlax",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"map_music": world.state.map_music(),
+		"fought_snorlax": world.event_flag_active(EVENT_FOUGHT_SNORLAX),
+		"vermilion_city_snorlax": world.event_flag_active(EVENT_VERMILION_CITY_SNORLAX),
+		"cave_mouth_open": world.object_at(DIGLETTS_CAVE_MOUTH) == null,
+		"encounters": walked.get("encounters", []),
+		"run": run,
+	})
+	if not bool(run.get("terminal", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Snorlax script did not finish: %s" % run.get("reason", ""),
+		}
+	if not world.event_flag_active(EVENT_FOUGHT_SNORLAX):
+		return {"ok": false, "path": path, "reason": "the Snorlax was not fought"}
+	if not world.event_flag_active(EVENT_VERMILION_CITY_SNORLAX):
+		return {"ok": false, "path": path, "reason": "the Snorlax did not disappear"}
+	return {"ok": true}
+
+
+## Pewter Gym and the Boulder Badge. `maps/PewterGym.asm` declares neither a
+## scene nor a callback, so Brock answers as soon as he is faced, and his own
+## script sets Camper Jerry's flag whether or not Jerry was fought.
+func _pewter_gym_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_gym: Dictionary = _warp_chain(world, save, random, data, [PEWTER_GYM_DOOR])
+	if not bool(into_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Pewter Gym door failed: %s" % into_gym.get("reason", ""),
+		}
+
+	var brock: Dictionary = _talk_to(
+		world, BROCK_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	var badge: int = Gen2WorldState.badge_flag(
+		BADGE_BOULDER, Gen2WorldState.is_crystal_profile(data)
+	)
+	path.append({
+		"step": "pewter_gym_brock",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"boulder_badge": world.state.is_engine_flag_active(badge),
+		"beat_brock": world.event_flag_active(EVENT_BEAT_BROCK),
+		"beat_camper_jerry": world.event_flag_active(EVENT_BEAT_CAMPER_JERRY),
+		"encounters": brock.get("encounters", []),
+		"run": brock,
+	})
+	if not bool(brock.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Brock did not finish: %s" % brock.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(badge):
+		return {"ok": false, "path": path, "reason": "ENGINE_BOULDERBADGE was not set"}
+	if not world.event_flag_active(EVENT_BEAT_CAMPER_JERRY):
+		return {"ok": false, "path": path, "reason": "Brock did not set Camper Jerry's flag"}
 	return {"ok": true}
 
 
@@ -7122,6 +7474,8 @@ func _whirlpool_at(
 
 
 ## Walks to [param cell], faces [param facing] and drains the interaction.
+## [param answers] is passed through to _drain_story() for an NPC who asks, the
+## way the Radio Card woman's five-question quiz does.
 func _talk_to(
 	world: Gen2WorldAPI,
 	cell: Vector2i,
@@ -7129,12 +7483,15 @@ func _talk_to(
 	save: Gen2SaveData,
 	random: RandomNumberGenerator,
 	data: GameData,
+	answers: Array[int] = [],
 ) -> Dictionary:
 	var walked: Dictionary = _walk_cell_resolving(world, cell, save, random, data)
 	if not bool(walked.get("ok", false)):
 		return walked
 	world.player_facing = facing
-	var run: Dictionary = _drain_story(world, world.interact(), save, random, data, true)
+	var run: Dictionary = _drain_story(
+		world, world.interact(), save, random, data, true, answers
+	)
 	return {
 		"ok": bool(run.get("terminal", false)),
 		"reason": run.get("reason", ""),

--- a/tools/validate_celadon.gd
+++ b/tools/validate_celadon.gd
@@ -417,6 +417,7 @@ func _open(data: GameData, group: int, number: int, cell: Vector2i) -> Gen2World
 	if world == null:
 		_fail("map %d/%d is missing." % [group, number])
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	return world
 
@@ -456,3 +457,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL celadon: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_cerulean.gd
+++ b/tools/validate_cerulean.gd
@@ -641,6 +641,7 @@ func _surf_entries(
 			var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, cell, state)
 			if world == null:
 				continue
+			_field_move_party(world)
 			var _entry: Array = world.dispatch_map_entry()
 			if cut_route_9:
 				world.player_cell = ROUTE_9_TREE_APPROACH
@@ -679,6 +680,7 @@ func _open(data: GameData, group: int, number: int, cell: Vector2i) -> Gen2World
 	if world == null:
 		_fail("map %d/%d is missing." % [group, number])
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	return world
 
@@ -762,3 +764,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL cerulean: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_cinnabar.gd
+++ b/tools/validate_cinnabar.gd
@@ -1,0 +1,546 @@
+extends SceneTree
+
+## Verifies the walk south from Pewter to Cinnabar Island, east to Seafoam Gym,
+## and back north to Viridian Gym, against freshly imported real caches for both
+## command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## data/maps/attributes.asm, maps/PalletTown.asm, maps/Route21.asm,
+## maps/CinnabarIsland.asm, maps/Route20.asm, maps/SeafoamGym.asm and
+## maps/ViridianGym.asm.
+##
+## Three findings carry the leg. Cinnabar Island is two land regions with no
+## seam between them, and the crossing off Route 21 can land on either, so which
+## cell it lands on decides whether Blue is reachable at all. Route 20's west
+## channel is walled off from the open sea on every side, so the island holding
+## the gym mouth is landed on from the east and not the west. And Viridian Gym
+## has no puzzle and no trainer: both its objects carry EVENT_VIRIDIAN_GYM_BLUE
+## as their hide flag, so the whole gate is Cinnabar's Blue clearing it.
+##
+##   Godot --headless --path . -s res://tools/validate_cinnabar.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm. Nothing on this leg splits between the profiles.
+const PEWTER_GROUP: int = 14
+const PEWTER_CITY: int = 2
+const VIRIDIAN_GROUP: int = 23
+const ROUTE_2: int = 1
+const VIRIDIAN_CITY: int = 3
+const VIRIDIAN_GYM: int = 4
+const PALLET_GROUP: int = 13
+const ROUTE_1: int = 1
+const PALLET_TOWN: int = 2
+const SEAFOAM_GROUP: int = 6
+const SEAFOAM_GYM: int = 4
+const ROUTE_20: int = 6
+const ROUTE_21: int = 7
+const CINNABAR_ISLAND: int = 8
+
+## The land half of the walk south, as [label, group, number, the cell it is
+## entered on, the target group and number its south edge crosses onto].
+const SOUTHBOUND: Array = [
+	["Pewter City", PEWTER_GROUP, PEWTER_CITY, Vector2i(18, 35), VIRIDIAN_GROUP, ROUTE_2],
+	["Route 2", VIRIDIAN_GROUP, ROUTE_2, Vector2i(8, 0), VIRIDIAN_GROUP, VIRIDIAN_CITY],
+	["Viridian City", VIRIDIAN_GROUP, VIRIDIAN_CITY, Vector2i(18, 0), PALLET_GROUP, ROUTE_1],
+	["Route 1", PALLET_GROUP, ROUTE_1, Vector2i(8, 0), PALLET_GROUP, PALLET_TOWN],
+]
+const ENGINE_FLYPOINT_VIRIDIAN: int = 54
+const ENGINE_FLYPOINT_PALLET: int = 53
+const ENGINE_FLYPOINT_CINNABAR: int = 63
+
+## Pallet Town's pond, which is the last land on the way down: sixteen water
+## cells on x=4 to 7, rows 14 to 17, entered from (4,13).
+const PALLET_SURF_APPROACH: Vector2i = Vector2i(4, 13)
+const PALLET_POND_CELL: Vector2i = Vector2i(4, 14)
+const PALLET_POND_CELLS: int = 16
+const PALLET_LAND_CELLS: int = 205
+
+## Route 21 is one sea, and its south edge crosses onto Cinnabar.
+const ROUTE_21_CELL: Vector2i = Vector2i(4, 0)
+const ROUTE_21_WATER_CELLS: int = 479
+
+## Cinnabar Island. The west crossing cells stay water on both sides; the east
+## ones exit onto the 89-cell region, which reaches neither Blue nor the
+## Pokecenter door.
+const CINNABAR_WEST_CROSSING: Array[Vector2i] = [
+	Vector2i(1, 0), Vector2i(2, 0), Vector2i(3, 0),
+]
+const CINNABAR_EAST_CROSSING: Vector2i = Vector2i(11, 0)
+const CINNABAR_EAST_REGION_CELLS: int = 89
+const CINNABAR_WATER_CELLS: int = 91
+const CINNABAR_LANDING: Vector2i = Vector2i(4, 10)
+const CINNABAR_BLUE_REGION_CELLS: int = 51
+const BLUE_CELL: Vector2i = Vector2i(9, 6)
+const BLUE_FACE: Vector2i = Vector2i(8, 6)
+const CINNABAR_POKECENTER_DOOR: Vector2i = Vector2i(11, 11)
+## The island's whole east edge, and it is water, so the leg surfs out of the
+## same shore it landed on.
+const CINNABAR_EAST_EDGE: Vector2i = Vector2i(19, 16)
+
+## Route 20. The channel on x=26 and 27 runs up the gym island's west shore and
+## is sealed from the sea, so (28,8) is not a landfall even though it is shore.
+const ROUTE_20_SEA_CELL: Vector2i = Vector2i(42, 8)
+const ROUTE_20_WATER_CELLS: int = 697
+const ROUTE_20_WEST_CHANNEL: Vector2i = Vector2i(27, 8)
+const ROUTE_20_LANDING: Vector2i = Vector2i(41, 8)
+const ROUTE_20_ISLAND_CELLS: int = 88
+const SEAFOAM_GYM_DOOR: Vector2i = Vector2i(38, 7)
+const EVENT_CINNABAR_ROCKS_CLEARED: int = 215
+
+## Seafoam Gym: thirteen cells, Blaine on (5,2) faced from below, and a guide
+## his own script `appear`s.
+const SEAFOAM_GYM_LANDING: Vector2i = Vector2i(5, 5)
+const SEAFOAM_GYM_CELLS: int = 13
+const BLAINE_CELL: Vector2i = Vector2i(5, 2)
+const BLAINE_FACE: Vector2i = Vector2i(5, 3)
+const EVENT_SEAFOAM_GYM_GYM_GUIDE: int = 1911
+
+## Viridian Gym: both objects hidden by the same flag, so the gym is empty until
+## Cinnabar's Blue clears it.
+const VIRIDIAN_GYM_DOOR: Vector2i = Vector2i(32, 7)
+const VIRIDIAN_GYM_LANDING: Vector2i = Vector2i(4, 17)
+const VIRIDIAN_GYM_CELLS: int = 82
+const VIRIDIAN_BLUE_CELL: Vector2i = Vector2i(5, 3)
+const VIRIDIAN_BLUE_FACE: Vector2i = Vector2i(5, 4)
+const EVENT_VIRIDIAN_GYM_BLUE: int = 1910
+const VIRIDIAN_GYM_OBJECTS: int = 2
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_southbound(data, game_id, crystal)
+		_verify_pallet_pond(data, game_id)
+		_verify_cinnabar(data, game_id, crystal)
+		_verify_route_20(data, game_id)
+		_verify_seafoam_gym(data, game_id)
+		_verify_viridian_gym(data, game_id)
+	_finish()
+
+
+## The land half: four connections, each proved by the map its region crosses
+## onto, and the two flypoints the walk collects.
+func _verify_southbound(data: GameData, game_id: StringName, crystal: bool) -> void:
+	for leg: Array in SOUTHBOUND:
+		var label: String = leg[0]
+		var start: Vector2i = leg[3]
+		var world: Gen2WorldAPI = _open(data, int(leg[1]), int(leg[2]), start)
+		if world == null:
+			continue
+		var crossing: Dictionary = _crossing(world, _region(world, start), "south")
+		_check(
+			int(crossing.get("map_group", -1)) == int(leg[4])
+				and int(crossing.get("map_number", -1)) == int(leg[5]),
+			"%s: %s's south edge reaches %d/%d, not the pinned %d/%d." % [
+				game_id, label,
+				int(crossing.get("map_group", -1)), int(crossing.get("map_number", -1)),
+				int(leg[4]), int(leg[5]),
+			]
+		)
+	for pair: Array in [
+		[VIRIDIAN_GROUP, VIRIDIAN_CITY, ENGINE_FLYPOINT_VIRIDIAN, Vector2i(18, 0)],
+		[PALLET_GROUP, PALLET_TOWN, ENGINE_FLYPOINT_PALLET, Vector2i(8, 0)],
+	]:
+		var town: Gen2WorldAPI = _open(data, int(pair[0]), int(pair[1]), pair[3])
+		if town == null:
+			continue
+		var flag: int = int(pair[2]) if crystal else int(pair[2]) - 1
+		_check(
+			town.state.is_engine_flag_active(flag),
+			"%s: %d/%d did not set flypoint engine flag %d on arrival." % [
+				game_id, int(pair[0]), int(pair[1]), flag,
+			]
+		)
+	print("%s southbound: four connections from Pewter to Pallet, both flypoints." % game_id)
+
+
+## Pallet's pond, and the fact that its south edge only crosses while surfing.
+func _verify_pallet_pond(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, PALLET_GROUP, PALLET_TOWN, PALLET_SURF_APPROACH)
+	if world == null:
+		return
+	_check(
+		_region(world, PALLET_SURF_APPROACH).size() == PALLET_LAND_CELLS,
+		"%s: Pallet's land is %d cells, not the pinned %d." % [
+			game_id, _region(world, PALLET_SURF_APPROACH).size(), PALLET_LAND_CELLS,
+		]
+	)
+	_check(
+		world.collision_permission_at(PALLET_POND_CELL) == Gen2WorldCollision.WATER_TILE,
+		"%s: %s is not water." % [game_id, PALLET_POND_CELL]
+	)
+	var pond: Dictionary = _water_region(world, PALLET_POND_CELL)
+	_check(
+		pond.size() == PALLET_POND_CELLS,
+		"%s: Pallet's pond is %d cells, not the pinned %d." % [
+			game_id, pond.size(), PALLET_POND_CELLS,
+		]
+	)
+	# The crossing itself is a surfing question: connection_target reads the
+	# player's own movement mode, so a walking player is refused at the same cell.
+	var edge := Vector2i(PALLET_POND_CELL.x, world.map_size_cells().y - 1)
+	_check(
+		pond.has(edge),
+		"%s: Pallet's pond does not reach its own south edge at %s." % [game_id, edge]
+	)
+	world.player_cell = edge
+	_check(
+		not bool(world.connection_target(edge, Vector2i.DOWN).get("ok", false)),
+		"%s: Pallet's south edge crosses onto water while walking." % game_id
+	)
+	world.movement_mode = Gen2WorldAPI.MOVEMENT_SURF
+	var crossed: Dictionary = world.connection_target(edge, Vector2i.DOWN)
+	_check(
+		bool(crossed.get("ok", false))
+			and int(crossed.get("map_group", -1)) == SEAFOAM_GROUP
+			and int(crossed.get("map_number", -1)) == ROUTE_21,
+		"%s: Pallet's south edge does not surf onto Route 21." % game_id
+	)
+
+	var route: Gen2WorldAPI = _open(data, SEAFOAM_GROUP, ROUTE_21, ROUTE_21_CELL)
+	if route == null:
+		return
+	var sea: Dictionary = _water_region(route, ROUTE_21_CELL)
+	_check(
+		sea.size() == ROUTE_21_WATER_CELLS,
+		"%s: Route 21 is %d water cells, not the pinned %d." % [
+			game_id, sea.size(), ROUTE_21_WATER_CELLS,
+		]
+	)
+	route.movement_mode = Gen2WorldAPI.MOVEMENT_SURF
+	var onward: Dictionary = _crossing(route, sea, "south")
+	_check(
+		int(onward.get("map_group", -1)) == SEAFOAM_GROUP
+			and int(onward.get("map_number", -1)) == CINNABAR_ISLAND,
+		"%s: Route 21's south edge does not reach Cinnabar." % game_id
+	)
+	print("%s pallet: a %d-cell pond that only crosses while surfing, and Route 21's %d-cell sea." % [
+		game_id, pond.size(), sea.size(),
+	])
+
+
+## Cinnabar's two land regions, and which crossing reaches Blue.
+func _verify_cinnabar(data: GameData, game_id: StringName, crystal: bool) -> void:
+	var world: Gen2WorldAPI = _open(data, SEAFOAM_GROUP, CINNABAR_ISLAND, CINNABAR_LANDING)
+	if world == null:
+		return
+	var flag: int = ENGINE_FLYPOINT_CINNABAR if crystal else ENGINE_FLYPOINT_CINNABAR - 1
+	_check(
+		world.state.is_engine_flag_active(flag),
+		"%s: CinnabarIslandFlypointCallback did not set engine flag %d." % [game_id, flag]
+	)
+
+	var blue_region: Dictionary = _region(world, CINNABAR_LANDING)
+	_check(
+		blue_region.size() == CINNABAR_BLUE_REGION_CELLS,
+		"%s: Cinnabar's west region is %d cells, not the pinned %d." % [
+			game_id, blue_region.size(), CINNABAR_BLUE_REGION_CELLS,
+		]
+	)
+	for cell: Vector2i in [BLUE_FACE, CINNABAR_POKECENTER_DOOR]:
+		_check(
+			blue_region.has(cell),
+			"%s: Cinnabar's west region does not reach %s." % [game_id, cell]
+		)
+	_check(
+		world.object_at(BLUE_CELL) != null,
+		"%s: %s is not Blue's cell." % [game_id, BLUE_CELL]
+	)
+
+	var east_region: Dictionary = _region(world, CINNABAR_EAST_CROSSING)
+	_check(
+		east_region.size() == CINNABAR_EAST_REGION_CELLS,
+		"%s: Cinnabar's east region is %d cells, not the pinned %d." % [
+			game_id, east_region.size(), CINNABAR_EAST_REGION_CELLS,
+		]
+	)
+	# The whole point of the west landing: the two regions share no seam.
+	for cell: Vector2i in [BLUE_FACE, CINNABAR_POKECENTER_DOOR, CINNABAR_LANDING]:
+		_check(
+			not east_region.has(cell),
+			"%s: Cinnabar's east region reaches %s, so the island is one region." % [
+				game_id, cell,
+			]
+		)
+	for cell: Vector2i in CINNABAR_WEST_CROSSING:
+		_check(
+			world.collision_permission_at(cell) == Gen2WorldCollision.WATER_TILE,
+			"%s: %s is not one of Cinnabar's water crossing cells." % [game_id, cell]
+		)
+
+	var water: Dictionary = _water_region(world, CINNABAR_WEST_CROSSING[0])
+	_check(
+		water.size() == CINNABAR_WATER_CELLS,
+		"%s: Cinnabar's water is %d cells, not the pinned %d." % [
+			game_id, water.size(), CINNABAR_WATER_CELLS,
+		]
+	)
+	_check(
+		water.has(CINNABAR_EAST_EDGE),
+		"%s: Cinnabar's water does not reach its east edge at %s." % [
+			game_id, CINNABAR_EAST_EDGE,
+		]
+	)
+	world.movement_mode = Gen2WorldAPI.MOVEMENT_SURF
+	var east: Dictionary = _crossing(world, water, "east")
+	_check(
+		int(east.get("map_group", -1)) == SEAFOAM_GROUP
+			and int(east.get("map_number", -1)) == ROUTE_20
+			and Vector2i(east.get("edge", Vector2i.ZERO)) == CINNABAR_EAST_EDGE,
+		"%s: Cinnabar's east crossing is not %s onto Route 20." % [game_id, CINNABAR_EAST_EDGE]
+	)
+	print("%s cinnabar: two land regions of %d and %d cells with no seam, and one east edge cell." % [
+		game_id, east_region.size(), blue_region.size(),
+	])
+
+
+## Route 20's sealed west channel, its sea and the gym mouth behind the east
+## landfall.
+func _verify_route_20(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, SEAFOAM_GROUP, ROUTE_20, ROUTE_20_SEA_CELL)
+	if world == null:
+		return
+	_check(
+		world.event_flag_active(EVENT_CINNABAR_ROCKS_CLEARED),
+		"%s: Route20ClearRocksCallback did not set event flag %d on arrival." % [
+			game_id, EVENT_CINNABAR_ROCKS_CLEARED,
+		]
+	)
+	var sea: Dictionary = _water_region(world, ROUTE_20_SEA_CELL)
+	_check(
+		sea.size() == ROUTE_20_WATER_CELLS,
+		"%s: Route 20 is %d water cells, not the pinned %d." % [
+			game_id, sea.size(), ROUTE_20_WATER_CELLS,
+		]
+	)
+	_check(
+		not sea.has(ROUTE_20_WEST_CHANNEL),
+		"%s: the west channel at %s is reachable from the sea after all." % [
+			game_id, ROUTE_20_WEST_CHANNEL,
+		]
+	)
+	_check(
+		world.collision_permission_at(ROUTE_20_WEST_CHANNEL)
+			== Gen2WorldCollision.WATER_TILE,
+		"%s: %s is not water, so it is not the channel." % [game_id, ROUTE_20_WEST_CHANNEL]
+	)
+	var island: Dictionary = _region(world, ROUTE_20_LANDING)
+	_check(
+		island.size() == ROUTE_20_ISLAND_CELLS,
+		"%s: Route 20's island is %d cells, not the pinned %d." % [
+			game_id, island.size(), ROUTE_20_ISLAND_CELLS,
+		]
+	)
+	_check(
+		island.has(SEAFOAM_GYM_DOOR),
+		"%s: the island does not reach the gym mouth at %s." % [game_id, SEAFOAM_GYM_DOOR]
+	)
+	var mouth: Dictionary = world.warp_at(SEAFOAM_GYM_DOOR)
+	_check(
+		int(mouth.get("map_group", -1)) == SEAFOAM_GROUP
+			and int(mouth.get("map_number", -1)) == SEAFOAM_GYM,
+		"%s: %s is not the Seafoam Gym warp." % [game_id, SEAFOAM_GYM_DOOR]
+	)
+	print("%s route 20: a %d-cell sea, a sealed west channel, and the gym mouth on the east island." % [
+		game_id, sea.size(),
+	])
+
+
+func _verify_seafoam_gym(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(data, SEAFOAM_GROUP, SEAFOAM_GYM, SEAFOAM_GYM_LANDING)
+	if world == null:
+		return
+	var region: Dictionary = _region(world, SEAFOAM_GYM_LANDING)
+	_check(
+		region.size() == SEAFOAM_GYM_CELLS,
+		"%s: Seafoam Gym is %d cells, not the pinned %d." % [
+			game_id, region.size(), SEAFOAM_GYM_CELLS,
+		]
+	)
+	_check(
+		region.has(BLAINE_FACE) and world.object_at(BLAINE_CELL) != null,
+		"%s: Blaine on %s is not faced from %s." % [game_id, BLAINE_CELL, BLAINE_FACE]
+	)
+	var trainers: int = 0
+	for row: Variant in world.current_map.events.get("objects", []):
+		if row is Dictionary and int((row as Dictionary).get("type", -1)) \
+			== Gen2WorldObject.OBJECTTYPE_TRAINER:
+			trainers += 1
+	_check(trainers == 0, "%s: Seafoam Gym ships %d trainers." % [game_id, trainers])
+	# The guide is hidden behind his own flag until Blaine's script appears him.
+	var hidden := Gen2WorldState.new()
+	hidden.set_event_flag(EVENT_SEAFOAM_GYM_GYM_GUIDE)
+	var without: Gen2WorldAPI = _open(
+		data, SEAFOAM_GROUP, SEAFOAM_GYM, SEAFOAM_GYM_LANDING, hidden
+	)
+	if without != null:
+		_check(
+			without.visible_objects().size() == world.visible_objects().size() - 1,
+			"%s: the Seafoam Gym guide's hide flag changes nothing." % game_id
+		)
+	print("%s seafoam gym: %d cells, Blaine faced from below, no trainer in it." % [
+		game_id, region.size(),
+	])
+
+
+## Viridian Gym, whose entire gate is one event flag on both of its objects.
+func _verify_viridian_gym(data: GameData, game_id: StringName) -> void:
+	var city: Gen2WorldAPI = _open(data, VIRIDIAN_GROUP, VIRIDIAN_CITY, Vector2i(18, 0))
+	if city != null:
+		_check(
+			_region(city, Vector2i(18, 0)).has(VIRIDIAN_GYM_DOOR),
+			"%s: Viridian's gym door at %s is not reachable from the north edge." % [
+				game_id, VIRIDIAN_GYM_DOOR,
+			]
+		)
+	var world: Gen2WorldAPI = _open(
+		data, VIRIDIAN_GROUP, VIRIDIAN_GYM, VIRIDIAN_GYM_LANDING
+	)
+	if world == null:
+		return
+	var region: Dictionary = _region(world, VIRIDIAN_GYM_LANDING)
+	_check(
+		region.size() == VIRIDIAN_GYM_CELLS,
+		"%s: Viridian Gym is %d cells, not the pinned %d." % [
+			game_id, region.size(), VIRIDIAN_GYM_CELLS,
+		]
+	)
+	_check(
+		region.has(VIRIDIAN_BLUE_FACE) and world.object_at(VIRIDIAN_BLUE_CELL) != null,
+		"%s: Blue on %s is not faced from %s." % [
+			game_id, VIRIDIAN_BLUE_CELL, VIRIDIAN_BLUE_FACE,
+		]
+	)
+	_check(
+		world.visible_objects().size() == VIRIDIAN_GYM_OBJECTS,
+		"%s: Viridian Gym shows %d objects with the flag clear, not %d." % [
+			game_id, world.visible_objects().size(), VIRIDIAN_GYM_OBJECTS,
+		]
+	)
+	var sealed := Gen2WorldState.new()
+	sealed.set_event_flag(EVENT_VIRIDIAN_GYM_BLUE)
+	var empty: Gen2WorldAPI = _open(
+		data, VIRIDIAN_GROUP, VIRIDIAN_GYM, VIRIDIAN_GYM_LANDING, sealed
+	)
+	if empty != null:
+		_check(
+			empty.visible_objects().is_empty(),
+			"%s: Viridian Gym is not empty while EVENT_VIRIDIAN_GYM_BLUE is set." % game_id
+		)
+	print("%s viridian gym: %d cells, two objects, and both gone behind one flag." % [
+		game_id, region.size(),
+	])
+
+
+## The map [param region] crosses onto over [param axis], as the first edge cell
+## in it that really connects. Empty when the region reaches no such edge.
+func _crossing(world: Gen2WorldAPI, region: Dictionary, axis: String) -> Dictionary:
+	var size: Vector2i = world.map_size_cells()
+	var direction: Vector2i = {
+		"north": Vector2i.UP, "south": Vector2i.DOWN,
+		"west": Vector2i.LEFT, "east": Vector2i.RIGHT,
+	}[axis]
+	for index: int in (size.y if axis in ["west", "east"] else size.x):
+		var edge: Vector2i = Vector2i(index, 0) if axis == "north" \
+			else Vector2i(index, size.y - 1) if axis == "south" \
+			else Vector2i(0, index) if axis == "west" \
+			else Vector2i(size.x - 1, index)
+		if not region.has(edge):
+			continue
+		# connection_target reads the player's own cell for the leave-side face
+		# mask, so a surfed crossing has to be asked from the edge itself.
+		world.player_cell = edge
+		var target: Dictionary = world.connection_target(edge, direction)
+		if bool(target.get("ok", false)):
+			target["edge"] = edge
+			return target
+	return {}
+
+
+func _open(
+	data: GameData, group: int, number: int, cell: Vector2i, state: Gen2WorldState = null
+) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, group, number, cell, state if state != null else Gen2WorldState.new()
+	)
+	if world == null:
+		_fail("map %d/%d is missing." % [group, number])
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
+
+
+## Ledge hops included, the way tools/validate_pewter.gd walks.
+func _region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	var size: Vector2i = world.map_size_cells()
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+			var walled: bool = face != 0 and (world.tile_permissions_at(cell) & face) != 0
+			if walled or not world.can_walk_to(next):
+				if not Gen2WorldCollision.allows_hop(world.collision_code_at(cell), direction):
+					continue
+				next = cell + direction * 2
+				if next.x < 0 or next.y < 0 or next.x >= size.x or next.y >= size.y:
+					continue
+			if seen.has(next):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+## The water a surfing player can cross without going ashore, which is what
+## decides where a sea leg can and cannot land.
+func _water_region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	var size: Vector2i = world.map_size_cells()
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			if next.x < 0 or next.y < 0 or next.x >= size.x or next.y >= size.y:
+				continue
+			var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+			if face != 0 and (world.tile_permissions_at(cell) & face) != 0:
+				continue
+			if world.collision_permission_at(next) != Gen2WorldCollision.WATER_TILE:
+				continue
+			if world.object_at(next) != null or seen.has(next):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS cinnabar: the southbound chain, Pallet's pond, Cinnabar's two regions, Route 20's sealed channel, Seafoam Gym and Viridian Gym verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL cinnabar: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_cinnabar.gd
+++ b/tools/validate_cinnabar.gd
@@ -473,6 +473,7 @@ func _open(
 	if world == null:
 		_fail("map %d/%d is missing." % [group, number])
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	return world
 
@@ -544,3 +545,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL cinnabar: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_cinnabar.gd.uid
+++ b/tools/validate_cinnabar.gd.uid
@@ -1,0 +1,1 @@
+uid://dfibws6rnd2a1

--- a/tools/validate_cut.gd
+++ b/tools/validate_cut.gd
@@ -124,6 +124,7 @@ func _verify_ilex_forest(game_id: StringName, data: GameData, crystal: bool) -> 
 	):
 		return
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_field_move_party(world)
 
 	var tileset: int = world.current_map.tileset
 	var expected_tileset: int = Gen2WorldFieldMove.TILESET_FOREST_CRYSTAL if crystal \
@@ -207,6 +208,7 @@ func _verify_ilex_forest(game_id: StringName, data: GameData, crystal: bool) -> 
 		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP, unbadged
 	)
 	unbadged_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_field_move_party(unbadged_world)
 	_check(
 		StringName(unbadged_world.cut_request().get("reason", &"")) == &"badge_required",
 		"%s: Ilex Forest allowed Cut without engine flag %d." % [game_id, badge]
@@ -218,6 +220,7 @@ func _verify_ilex_forest(game_id: StringName, data: GameData, crystal: bool) -> 
 		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP, wrong
 	)
 	wrong_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_field_move_party(wrong_world)
 	_check(
 		StringName(wrong_world.cut_request().get("reason", &"")) == &"badge_required",
 		"%s: Ilex Forest accepted the other profile's Hive Badge flag." % game_id
@@ -242,3 +245,14 @@ func _finish() -> void:
 	for message: String in _failures:
 		print("FAIL %s" % message)
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and these files are about the tables
+## and the map rather than the party, so every world they open carries one
+## member that knows all five. The route preview is where a real party earning
+## them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_pewter.gd
+++ b/tools/validate_pewter.gd
@@ -1,0 +1,443 @@
+extends SceneTree
+
+## Verifies the walk back from Fuchsia City to Vermilion, through Diglett's Cave
+## onto Route 2, and north to Pewter Gym, against freshly imported real caches
+## for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## data/maps/attributes.asm, maps/Route11.asm, maps/VermilionCity.asm,
+## maps/DiglettsCave.asm, maps/Route2.asm, maps/PewterCity.asm and
+## maps/PewterGym.asm.
+##
+## Three findings carry the leg. The way back to Vermilion is five plain
+## connections with one gate at the start, not the walk through Lavender and
+## Saffron the route came by, because Route 12 connects west onto Route 11 and
+## Route 11 declares no warps at all. The Route 11 crossing lands inside the
+## eight-cell pocket the Snorlax's own two-by-two body seals off Vermilion's
+## east edge, which is why SnorlaxAwake lists five proximity coordinates rather
+## than the two the port side can stand on. And Diglett's Cave is three
+## disjoint regions joined by two ladders, so it is crossed by warps rather than
+## walked.
+##
+## The Snorlax chain itself, the Route 2 cut and their counts belong to
+## tools/validate_radio.gd and are not repeated here.
+##
+##   Godot --headless --path . -s res://tools/validate_pewter.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm. Only Diglett's Cave splits between the profiles.
+const FUCHSIA_GROUP: int = 17
+const FUCHSIA_CITY: int = 5
+const ROUTE_13: int = 1
+const ROUTE_14: int = 2
+const ROUTE_15: int = 3
+const ROUTE_15_FUCHSIA_GATE: int = 13
+const LAVENDER_GROUP: int = 18
+const ROUTE_12: int = 2
+const VERMILION_GROUP: int = 12
+const ROUTE_11: int = 2
+const VERMILION_CITY: int = 3
+const DUNGEONS_GROUP: int = 3
+const DIGLETTS_CAVE: int = 84
+const DIGLETTS_CAVE_GOLD_SILVER: int = 75
+const VIRIDIAN_GROUP: int = 23
+const ROUTE_2: int = 1
+const PEWTER_GROUP: int = 14
+const PEWTER_CITY: int = 2
+const PEWTER_GYM: int = 4
+
+## The way out of Fuchsia: `maps/FuchsiaCity.asm` warp 8 into the gate, and the
+## gate's own east door onto Route 15.
+const CITY_GATE_DOOR: Vector2i = Vector2i(37, 22)
+const GATE_FROM_CITY: Vector2i = Vector2i(0, 4)
+const GATE_TO_ROUTE: Vector2i = Vector2i(9, 4)
+
+## The chain back, as [label, group, number, the cell it is entered on, the
+## direction it leaves by, the target group and number of that crossing].
+const NORTHBOUND: Array = [
+	["Route 15", FUCHSIA_GROUP, ROUTE_15, Vector2i(2, 4), "east", FUCHSIA_GROUP, ROUTE_14],
+	["Route 14", FUCHSIA_GROUP, ROUTE_14, Vector2i(0, 26), "north", FUCHSIA_GROUP, ROUTE_13],
+	["Route 13", FUCHSIA_GROUP, ROUTE_13, Vector2i(12, 17), "north", LAVENDER_GROUP, ROUTE_12],
+	["Route 12", LAVENDER_GROUP, ROUTE_12, Vector2i(14, 53), "west", VERMILION_GROUP, ROUTE_11],
+	["Route 11", VERMILION_GROUP, ROUTE_11, Vector2i(39, 8), "west", VERMILION_GROUP, VERMILION_CITY],
+]
+
+## Vermilion's east pocket. `maps/VermilionCity.asm` object 4 is a BIG_OBJECT on
+## (34,8), so it fills a two-by-two, and the cells east of it are cut off from
+## the city until it moves.
+const VERMILION_EAST_LANDING: Vector2i = Vector2i(39, 8)
+const VERMILION_EAST_POCKET_CELLS: int = 8
+const SNORLAX_CELL: Vector2i = Vector2i(34, 8)
+## The two cells of that pocket SnorlaxAwake.ProximityCoords names, which are
+## the only ones an eastbound player can talk to it from.
+const EAST_PROXIMITY: Array[Vector2i] = [Vector2i(36, 8), Vector2i(36, 9)]
+const DIGLETTS_CAVE_MOUTH: Vector2i = Vector2i(34, 7)
+
+## Diglett's Cave, as [the cell a region is entered on, its size, the cell the
+## region's own way on sits on]. The last leg's exit is the Route 2 door rather
+## than a ladder (`maps/DiglettsCave.asm` warps 2, 6 and 3).
+const CAVE_REGIONS: Array = [
+	[Vector2i(3, 33), 14, Vector2i(5, 31)],
+	[Vector2i(17, 33), 99, Vector2i(3, 3)],
+	[Vector2i(17, 3), 15, Vector2i(15, 5)],
+]
+const CAVE_LANDING_ON_ROUTE_2: Vector2i = Vector2i(12, 7)
+
+## Route 2's cut tree and the crossing behind it, both owned by
+## tools/validate_radio.gd; what is checked here is only that the opened route
+## really crosses onto Pewter.
+const ROUTE_2_CUT_APPROACH: Vector2i = Vector2i(5, 9)
+const ROUTE_2_CUT_TREE: Vector2i = Vector2i(5, 8)
+
+## Pewter City. The south connection lands on the two-cell corridor at x=18 and
+## 19, which is the only one of the three pockets along that edge that reaches
+## the city at all.
+const PEWTER_SOUTH_LANDING: Vector2i = Vector2i(18, 35)
+const PEWTER_CITY_CELLS: int = 730
+const PEWTER_SEALED_SOUTH_EDGE: Array[Vector2i] = [Vector2i(10, 35), Vector2i(30, 35)]
+const PEWTER_GYM_DOOR: Vector2i = Vector2i(16, 17)
+const ENGINE_FLYPOINT_PEWTER: int = 55
+const ENGINE_FLYPOINT_PEWTER_GOLD_SILVER: int = 54
+
+## The gym. `maps/PewterGym.asm` is byte identical between the pins: Brock on
+## (5,1) faced from below, Camper Jerry watching three cells east along row 5,
+## and the guide by the door.
+const GYM_LANDING: Vector2i = Vector2i(4, 13)
+const BROCK_CELL: Vector2i = Vector2i(5, 1)
+const BROCK_FACE: Vector2i = Vector2i(5, 2)
+const JERRY_INDEX: int = 1
+const GYM_OBJECTS: int = 3
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_return_chain(data, game_id)
+		_verify_vermilion_pocket(data, game_id, crystal)
+		_verify_cave(data, game_id, crystal)
+		_verify_route_2_crossing(data, game_id, crystal)
+		_verify_pewter(data, game_id, crystal)
+	_finish()
+
+
+## Fuchsia's gate and the five connections back to Vermilion, each proved by the
+## crossing it actually reaches rather than by its edge coordinate.
+func _verify_return_chain(data: GameData, game_id: StringName) -> void:
+	var city: Gen2WorldAPI = _open(data, FUCHSIA_GROUP, FUCHSIA_CITY, CITY_GATE_DOOR)
+	if city != null:
+		var door: Dictionary = city.warp_at(CITY_GATE_DOOR)
+		_check(
+			int(door.get("map_group", -1)) == FUCHSIA_GROUP
+				and int(door.get("map_number", -1)) == ROUTE_15_FUCHSIA_GATE,
+			"%s: Fuchsia's %s does not open onto the Route 15 gate." % [game_id, CITY_GATE_DOOR]
+		)
+	var gate: Gen2WorldAPI = _open(data, FUCHSIA_GROUP, ROUTE_15_FUCHSIA_GATE, GATE_FROM_CITY)
+	if gate != null:
+		_check(
+			_region(gate, GATE_FROM_CITY).has(GATE_TO_ROUTE),
+			"%s: the Fuchsia gate's two doors are not joined on foot." % game_id
+		)
+
+	for leg: Array in NORTHBOUND:
+		var label: String = leg[0]
+		var start: Vector2i = leg[3]
+		var world: Gen2WorldAPI = _open(data, int(leg[1]), int(leg[2]), start)
+		if world == null:
+			continue
+		var region: Dictionary = _region(world, start)
+		var crossing: Dictionary = _crossing(world, region, String(leg[4]))
+		_check(
+			int(crossing.get("map_group", -1)) == int(leg[5])
+				and int(crossing.get("map_number", -1)) == int(leg[6]),
+			"%s: %s's %s edge reaches %d/%d, not the pinned %d/%d." % [
+				game_id, label, leg[4],
+				int(crossing.get("map_group", -1)), int(crossing.get("map_number", -1)),
+				int(leg[5]), int(leg[6]),
+			]
+		)
+		# Route 11 is the whole reason this way back is shorter than the one the
+		# route came by: no warps means no gate building to walk through.
+		if int(leg[2]) == ROUTE_11 and int(leg[1]) == VERMILION_GROUP:
+			_check(
+				world.current_map.events.get("warps", []).is_empty(),
+				"%s: Route 11 declares warps, so it is gated after all." % game_id
+			)
+	print("%s return chain: Fuchsia's gate and five connections back to Vermilion." % game_id)
+
+
+## The pocket the Route 11 crossing lands in, and what seals it.
+func _verify_vermilion_pocket(data: GameData, game_id: StringName, _crystal: bool) -> void:
+	var world: Gen2WorldAPI = _open(data, VERMILION_GROUP, VERMILION_CITY, VERMILION_EAST_LANDING)
+	if world == null:
+		return
+	var snorlax: Gen2WorldObject = world.object_at(SNORLAX_CELL)
+	if not _check(
+		snorlax != null and snorlax.is_big_object(),
+		"%s: %s is not the big Snorlax object." % [game_id, SNORLAX_CELL]
+	):
+		return
+	var pocket: Dictionary = _region(world, VERMILION_EAST_LANDING)
+	_check(
+		pocket.size() == VERMILION_EAST_POCKET_CELLS,
+		"%s: Vermilion's east landing is %d cells, not the pinned %d." % [
+			game_id, pocket.size(), VERMILION_EAST_POCKET_CELLS,
+		]
+	)
+	_check(
+		not pocket.has(DIGLETTS_CAVE_MOUTH),
+		"%s: the east pocket already reaches the cave mouth." % game_id
+	)
+	for cell: Vector2i in EAST_PROXIMITY:
+		_check(
+			pocket.has(cell),
+			"%s: %s is not in the pocket the Route 11 crossing lands in." % [game_id, cell]
+		)
+		var faces: bool = false
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			if world.object_at(cell + direction) == snorlax:
+				faces = true
+		_check(faces, "%s: %s does not face the Snorlax." % [game_id, cell])
+	print("%s vermilion: the Route 11 crossing lands in a %d-cell pocket the Snorlax seals." % [
+		game_id, pocket.size(),
+	])
+
+
+## Diglett's Cave: three regions, two ladders and the Route 2 door.
+func _verify_cave(data: GameData, game_id: StringName, crystal: bool) -> void:
+	var number: int = DIGLETTS_CAVE if crystal else DIGLETTS_CAVE_GOLD_SILVER
+	for leg: Array in CAVE_REGIONS:
+		var start: Vector2i = leg[0]
+		var exit_cell: Vector2i = leg[2]
+		var world: Gen2WorldAPI = _open(data, DUNGEONS_GROUP, number, start)
+		if world == null:
+			continue
+		var region: Dictionary = _region(world, start)
+		_check(
+			region.size() == int(leg[1]),
+			"%s: the cave region at %s is %d cells, not the pinned %d." % [
+				game_id, start, region.size(), int(leg[1]),
+			]
+		)
+		_check(
+			region.has(exit_cell),
+			"%s: the cave region at %s does not reach its own way on at %s." % [
+				game_id, start, exit_cell,
+			]
+		)
+	var last: Gen2WorldAPI = _open(data, DUNGEONS_GROUP, number, Vector2i(17, 3))
+	if last != null:
+		var door: Dictionary = last.warp_at(Vector2i(15, 5))
+		_check(
+			int(door.get("map_group", -1)) == VIRIDIAN_GROUP
+				and int(door.get("map_number", -1)) == ROUTE_2,
+			"%s: the cave's %s does not open onto Route 2." % [game_id, Vector2i(15, 5)]
+		)
+	print("%s digletts cave: three regions of 14, 99 and 15 cells, crossed by two ladders." % game_id)
+
+
+## Route 2 once its northern tree is cut: the crossing behind it is Pewter's.
+func _verify_route_2_crossing(data: GameData, game_id: StringName, crystal: bool) -> void:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, crystal), true
+	)
+	var world: Gen2WorldAPI = _open(data, VIRIDIAN_GROUP, ROUTE_2, CAVE_LANDING_ON_ROUTE_2, state)
+	if world == null:
+		return
+	world.player_cell = ROUTE_2_CUT_APPROACH
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if not _check(
+		bool(world.cut_request().get("ok", false))
+			and bool(world.complete_cut().get("ok", false)),
+		"%s: Route 2's %s did not cut." % [game_id, ROUTE_2_CUT_TREE]
+	):
+		return
+	var region: Dictionary = _region(world, ROUTE_2_CUT_APPROACH)
+	var crossing: Dictionary = _crossing(world, region, "north")
+	_check(
+		int(crossing.get("map_group", -1)) == PEWTER_GROUP
+			and int(crossing.get("map_number", -1)) == PEWTER_CITY,
+		"%s: Route 2's north edge reaches %d/%d, not Pewter." % [
+			game_id,
+			int(crossing.get("map_group", -1)), int(crossing.get("map_number", -1)),
+		]
+	)
+	print("%s route 2: the cut route crosses north onto Pewter City." % game_id)
+
+
+## Pewter City and its gym.
+func _verify_pewter(data: GameData, game_id: StringName, crystal: bool) -> void:
+	var city: Gen2WorldAPI = _open(data, PEWTER_GROUP, PEWTER_CITY, PEWTER_SOUTH_LANDING)
+	if city == null:
+		return
+	var flypoint: int = ENGINE_FLYPOINT_PEWTER if crystal \
+		else ENGINE_FLYPOINT_PEWTER_GOLD_SILVER
+	_check(
+		city.state.is_engine_flag_active(flypoint),
+		"%s: PewterCityFlypointCallback did not set engine flag %d on arrival." % [
+			game_id, flypoint,
+		]
+	)
+	var region: Dictionary = _region(city, PEWTER_SOUTH_LANDING)
+	_check(
+		region.size() == PEWTER_CITY_CELLS,
+		"%s: Pewter City is %d cells from %s, not the pinned %d." % [
+			game_id, region.size(), PEWTER_SOUTH_LANDING, PEWTER_CITY_CELLS,
+		]
+	)
+	_check(
+		region.has(PEWTER_GYM_DOOR),
+		"%s: the south landing does not reach the gym door." % game_id
+	)
+	# The other two pockets along the same edge go nowhere, so the crossing cell
+	# is not a matter of taste.
+	for cell: Vector2i in PEWTER_SEALED_SOUTH_EDGE:
+		_check(
+			not _region(city, cell).has(PEWTER_GYM_DOOR),
+			"%s: %s reaches the gym, so the south edge is not one corridor." % [game_id, cell]
+		)
+
+	var gym: Gen2WorldAPI = _open(data, PEWTER_GROUP, PEWTER_GYM, GYM_LANDING)
+	if gym == null:
+		return
+	_check(
+		gym.current_map.events.get("objects", []).size() == GYM_OBJECTS,
+		"%s: Pewter Gym has %d objects, not the pinned %d." % [
+			game_id, gym.current_map.events.get("objects", []).size(), GYM_OBJECTS,
+		]
+	)
+	var gym_region: Dictionary = _region(gym, GYM_LANDING)
+	_check(
+		gym_region.has(BROCK_FACE),
+		"%s: Brock's approach at %s is not reachable from the door." % [game_id, BROCK_FACE]
+	)
+	_check(
+		gym.object_at(BROCK_CELL) != null,
+		"%s: %s is not Brock's cell." % [game_id, BROCK_CELL]
+	)
+	# Camper Jerry watches the only column that reaches Brock, so his battle is
+	# owed rather than optional.
+	var lines: Dictionary = _sight_lines(data, PEWTER_GROUP, PEWTER_GYM, gym_region)
+	var owed: Array = []
+	for index: int in lines:
+		if not _region(gym, GYM_LANDING, lines[index]).has(BROCK_FACE):
+			owed.append(index)
+	owed.sort()
+	_check(
+		owed == [JERRY_INDEX],
+		"%s: Pewter Gym owes sight lines %s, not the pinned [%d]." % [
+			game_id, owed, JERRY_INDEX,
+		]
+	)
+	print("%s pewter: a %d-cell city from the south corridor, and a gym that owes Jerry." % [
+		game_id, region.size(),
+	])
+
+
+## Every cell in [param region] a trainer sees the player on, as object index to
+## the set of cells.
+func _sight_lines(
+	data: GameData, group: int, number: int, region: Dictionary
+) -> Dictionary:
+	var out: Dictionary = {}
+	for cell: Vector2i in region:
+		var probe: Gen2WorldAPI = _open(data, group, number, cell)
+		if probe == null:
+			continue
+		var sight: Array = probe.dispatch_sight_events()
+		if sight.is_empty():
+			continue
+		var index: int = int((sight[0].get("source", {}) as Dictionary).get("object_index", -1))
+		if not out.has(index):
+			out[index] = {}
+		(out[index] as Dictionary)[cell] = true
+	return out
+
+
+## The map [param region] crosses onto over [param axis], as the first edge cell
+## in it that really connects. Empty when the region reaches no such edge.
+func _crossing(world: Gen2WorldAPI, region: Dictionary, axis: String) -> Dictionary:
+	var size: Vector2i = world.map_size_cells()
+	var direction: Vector2i = {
+		"north": Vector2i.UP, "south": Vector2i.DOWN,
+		"west": Vector2i.LEFT, "east": Vector2i.RIGHT,
+	}[axis]
+	for index: int in (size.y if axis in ["west", "east"] else size.x):
+		var edge: Vector2i = Vector2i(index, 0) if axis == "north" \
+			else Vector2i(index, size.y - 1) if axis == "south" \
+			else Vector2i(0, index) if axis == "west" \
+			else Vector2i(size.x - 1, index)
+		if not region.has(edge):
+			continue
+		var target: Dictionary = world.connection_target(edge, direction)
+		if bool(target.get("ok", false)):
+			return target
+	return {}
+
+
+func _open(
+	data: GameData, group: int, number: int, cell: Vector2i, state: Gen2WorldState = null
+) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, group, number, cell, state if state != null else Gen2WorldState.new()
+	)
+	if world == null:
+		_fail("map %d/%d is missing." % [group, number])
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
+
+
+## Ledge hops included, the way tools/validate_fuchsia.gd walks. [param closed]
+## cells are treated as unwalkable, which is how an owed sight line is proved.
+func _region(
+	world: Gen2WorldAPI, start: Vector2i, closed: Dictionary = {}
+) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	var size: Vector2i = world.map_size_cells()
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+			var walled: bool = face != 0 and (world.tile_permissions_at(cell) & face) != 0
+			if walled or not world.can_walk_to(next):
+				if not Gen2WorldCollision.allows_hop(world.collision_code_at(cell), direction):
+					continue
+				next = cell + direction * 2
+				if next.x < 0 or next.y < 0 or next.x >= size.x or next.y >= size.y:
+					continue
+			if seen.has(next) or closed.has(next):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS pewter: the return chain, the Snorlax's east pocket, Diglett's Cave, Route 2's crossing and Pewter Gym verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL pewter: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_pewter.gd
+++ b/tools/validate_pewter.gd
@@ -391,6 +391,7 @@ func _open(
 	if world == null:
 		_fail("map %d/%d is missing." % [group, number])
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	return world
 
@@ -441,3 +442,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL pewter: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_pewter.gd.uid
+++ b/tools/validate_pewter.gd.uid
@@ -1,0 +1,1 @@
+uid://bmas7mvot2v7i

--- a/tools/validate_radio.gd
+++ b/tools/validate_radio.gd
@@ -444,6 +444,7 @@ func _open(
 	if world == null:
 		_fail("map %d/%d is missing." % [group, number])
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	return world
 
@@ -491,3 +492,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL radio: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_route_27.gd
+++ b/tools/validate_route_27.gd
@@ -323,6 +323,7 @@ func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, id[0], id[1], cell, Gen2WorldState.new())
 	if world == null:
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
 		if world.pending_script_input().is_empty():
@@ -398,3 +399,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL route 27: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_surf.gd
+++ b/tools/validate_surf.gd
@@ -163,6 +163,7 @@ func _verify_new_bark_town(game_id: StringName, data: GameData, crystal: bool) -
 	):
 		return
 	world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	_field_move_party(world)
 
 	var shore_code: int = world.collision_code_at(SHORE_CELL)
 	_check(
@@ -245,6 +246,7 @@ func _verify_new_bark_town(game_id: StringName, data: GameData, crystal: bool) -
 		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, SHORE_CELL, Gen2WorldState.new()
 	)
 	unbadged_world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	_field_move_party(unbadged_world)
 	_check(
 		StringName(unbadged_world.surf_request().get("reason", &"")) == &"badge_required",
 		"%s: New Bark Town allowed Surf without engine flag %d." % [game_id, badge]
@@ -256,6 +258,7 @@ func _verify_new_bark_town(game_id: StringName, data: GameData, crystal: bool) -
 		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, SHORE_CELL, wrong
 	)
 	wrong_world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	_field_move_party(wrong_world)
 	_check(
 		StringName(wrong_world.surf_request().get("reason", &"")) == &"badge_required",
 		"%s: New Bark Town accepted the other profile's Fog Badge flag." % game_id
@@ -357,3 +360,14 @@ func _finish() -> void:
 	for message: String in _failures:
 		print("FAIL %s" % message)
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the tables and
+## the map rather than the party, so every world it opens carries one member
+## that knows all five. The route preview is where a real party earning them is
+## proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_vermilion.gd
+++ b/tools/validate_vermilion.gd
@@ -253,6 +253,7 @@ func _open(data: GameData, group: int, number: int, cell: Vector2i) -> Gen2World
 	if world == null:
 		_fail("map %d/%d is missing." % [group, number])
 		return null
+	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	return world
 
@@ -290,3 +291,13 @@ func _finish() -> void:
 		printerr(failure)
 	printerr("FAIL vermilion: %d problems." % _failures.size())
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the map rather
+## than the party, so every world it opens carries one member that knows all
+## five. The route preview is where a real party earning them is proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)

--- a/tools/validate_whirlpool.gd
+++ b/tools/validate_whirlpool.gd
@@ -147,6 +147,7 @@ func _verify_dragons_den(game_id: StringName, data: GameData, crystal: bool) -> 
 	):
 		return
 	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_field_move_party(world)
 	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
 
 	_check(
@@ -246,6 +247,7 @@ func _verify_dragons_den(game_id: StringName, data: GameData, crystal: bool) -> 
 		data, DEN_GROUP, number, approach, Gen2WorldState.new()
 	)
 	unbadged.player_facing = Gen2WorldSprite.FACING_DOWN
+	_field_move_party(unbadged)
 	_check(
 		StringName(unbadged.whirlpool_request().get("reason", &"")) == &"badge_required",
 		"%s: Dragon's Den allowed Whirlpool without engine flag %d." % [game_id, badge]
@@ -254,6 +256,7 @@ func _verify_dragons_den(game_id: StringName, data: GameData, crystal: bool) -> 
 	wrong.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_GLACIER, not crystal))
 	var wrong_world: Gen2WorldAPI = Gen2WorldAPI.open(data, DEN_GROUP, number, approach, wrong)
 	wrong_world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_field_move_party(wrong_world)
 	_check(
 		StringName(wrong_world.whirlpool_request().get("reason", &"")) == &"badge_required",
 		"%s: Dragon's Den accepted the other profile's Glacier Badge flag." % game_id
@@ -278,3 +281,14 @@ func _finish() -> void:
 	for message: String in _failures:
 		print("FAIL %s" % message)
 	quit(1)
+
+
+## CheckPartyMove gates every field move, and this file is about the tables and
+## the map rather than the party, so every world it opens carries one member
+## that knows all five. The route preview is where a real party earning them is
+## proved.
+func _field_move_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [Gen2WorldFieldMove.FIELD_MOVES.duplicate()],
+		["MON"], [false]
+	)


### PR DESCRIPTION
Extends the story route west and south, and makes every field move check the party before it runs.

## What changes

- The radio wakes the Snorlax and opens west Kanto; Cut, Surf and Whirlpool routes reach Pewter, Cinnabar and Viridian.
- A field move is offered only when a party member actually knows it, rather than on the badge alone.
- Collision and script runner handling for the new routes.

## Verification

`tools/validate_*.gd` cover each leg against a real imported cache. Full GUT suite passes.