### PR TITLE
Spend the sixteenth badge on Oak and climb Mt. Silver to Red

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,13 +251,14 @@ Headless tools, all against a real imported cache:
 | `validate_radio.gd` | the radio station table and its three profile splits, every station's music record, the two big objects either game ships, Vermilion City sealed at the Diglett's Cave mouth by the Snorlax's two-by-two body, the whole tune-and-wake chain, and the Route 2 pocket behind the cave that one cut tree opens onto Pewter and Viridian, in all three games |
 | `validate_pewter.gd` | Fuchsia's gate out and the five ungated connections back to Vermilion, the eight-cell pocket the Snorlax seals off the Route 11 crossing, Diglett's Cave's three regions and two ladders, Route 2's crossing onto Pewter once its tree is cut, and Pewter City's one south corridor and the gym sight line it owes, in all three games |
 | `validate_cinnabar.gd` | the four connections from Pewter down to Pallet, Pallet's pond and the south edge that only crosses while surfing, Route 21's sea, Cinnabar's two seamless land regions and which crossing reaches Blue, Route 20's sealed west channel and the east landfall behind it, Seafoam Gym, and Viridian Gym's two objects behind one event flag, in all three games |
+| `validate_mt_silver.gd` | the nine doors from Viridian Gym to Silver Cave Room 3, Viridian's west connection and Route 28's, Oak's lab, the Victory Road Gate's three regions and the black belt standing in each of the two cells that join them across all four flag combinations, Silver Cave Outside and its flypoint, the Pokecenter counter, each cave room as one region, and Red behind his own hide flag, in all three games |
 
 ```bash
 # Crystal map 3/19: block edits, hidden object, facing interaction
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 3 19 3 5 1 37,1744
 # bedroom PC and the bedroom-to-town warp chain
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home
-# the full walked route: Johto, the Hall of Fame, and every Kanto gym
+# the full walked route: Johto, the Hall of Fame, every Kanto gym, and Red
 godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story
 ```
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -73,6 +73,10 @@ const SPECIAL_PLAY_MAP_MUSIC: int = 60
 const SPECIAL_RESTART_MAP_MUSIC: int = 61
 const SPECIAL_HEAL_MACHINE_ANIM: int = 62
 const SPECIAL_CHECK_POKERUS: int = 78
+## ProfOaksPCBoot, 101 in Crystal and 100 in Gold/Silver, which special_index()
+## already normalizes. Oak's Kanto script reaches it on every branch
+## (maps/OaksLab.asm's `.CheckPokedex`).
+const SPECIAL_PROF_OAKS_PC_BOOT: int = 101
 ## SnorlaxAwake, 96 in Crystal and 95 in Gold/Silver, which special_index()
 ## already normalizes. Its five proximity coordinates are the cells the source
 ## lists, in its own x,y order (engine/events/specials.asm's .ProximityCoords),
@@ -1166,6 +1170,13 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 		0x9F:
 			_staged_engine_flags[Gen2WorldState.ENGINE_HALL_OF_FAME] = true
 			_events.append({"type": &"hall_of_fame_requested"})
+		0xA0:
+			## Script_credits farcalls RedCredits and then falls into
+			## Script_endall the way Script_halloffame does
+			## (engine/overworld/scripting.asm's ReturnFromCredits). No flag and
+			## no state: presentation only, and both call sites are followed by
+			## the source's own `end`, so this runs on rather than stopping.
+			_events.append({"type": &"credits_requested"})
 		0xA1:
 			return _stage_warp_facing_request(command)
 	var handled_sources: Array = [
@@ -1173,6 +1184,7 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 		0x65, 0x66, 0x7F, 0x81, 0x82, 0x85, 0x8A, 0x8B, 0x8D, 0x98,
 		0x8C,
 		0x6C, 0x73, 0x74, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
+		0xA0,
 	]
 	if source_opcode in handled_sources:
 		return {"ok": true}
@@ -1589,6 +1601,14 @@ func _execute_special(special: int) -> Dictionary:
 			_emit_runtime_event(&"presentation_special_applied", {
 				"special": special, "kind": &"heal_machine_anim",
 				"machine_type": _script_value,
+			})
+		SPECIAL_PROF_OAKS_PC_BOOT:
+			## engine/events/prof_oaks_pc.asm's ProfOaksPCBoot prints, counts the
+			## set bits in wPokedexSeen and wPokedexCaught for the rating, plays
+			## the rating's sound and waits for A or B. No dex is modelled and
+			## nothing is written.
+			_emit_runtime_event(&"presentation_special_applied", {
+				"special": special, "kind": &"prof_oaks_pc_boot",
 			})
 		SPECIAL_CHECK_POKERUS:
 			var party: Dictionary = _request.get("party", {})

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3379,6 +3379,95 @@ func test_crystal_engine_flags_and_hall_of_fame_commit_at_script_end() -> void:
 	))
 
 
+## Script_credits farcalls RedCredits and falls into the same Script_endall tail
+## as Script_halloffame (engine/overworld/scripting.asm's ReturnFromCredits), so
+## it commits nothing. maps/SilverCaveRoom3.asm's Red is its one call site.
+func test_credits_is_a_presentation_boundary_that_commits_no_flag() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# credits is Crystal $a2: pokegold's $a0 plus farjumptext at $52 and
+	# verbosegiveitemvar at $9f.
+	scripts["48:6100"] = [0xA2, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	var runner := Gen2WorldScriptRunner.begin(data, state, {
+		"kind": &"test", "bank": 48, "script": 0x6100,
+	})
+
+	var result: Dictionary = runner.advance()
+
+	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	assert_false(state.hall_of_fame())
+	assert_eq(state.engine_flags().size(), 0)
+	assert_eq(result["events"].filter(func(event: Dictionary) -> bool:
+		return event.get("type", &"") == &"credits_requested"
+	).size(), 1)
+
+
+## ProfOaksPCBoot prints, counts the set bits in wPokedexSeen and wPokedexCaught
+## and waits for a button (engine/events/prof_oaks_pc.asm). Oak's Kanto script
+## reaches it on every branch, including the one that opens Mt. Silver.
+func test_prof_oaks_pc_boot_is_presentation_and_writes_nothing() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6110"] = [Gen2WorldScript.SPECIAL, 101, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	var runner := Gen2WorldScriptRunner.begin(data, state, {
+		"kind": &"test", "bank": 48, "script": 0x6110,
+	})
+
+	var result: Dictionary = runner.advance()
+
+	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	assert_eq(state.event_flags().size(), 0)
+	assert_eq(state.engine_flags().size(), 0)
+	assert_true(result["events"].any(func(event: Dictionary) -> bool:
+		return event.get("type", &"") == &"presentation_special_applied" \
+			and event.get("kind", &"") == &"prof_oaks_pc_boot"
+	), JSON.stringify(result["events"]))
+
+
+## constants/event_flags.asm, the flag Oak sets on the sixteen-badge branch.
+const EVENT_OPENED_MT_SILVER: int = 1871
+
+
+## maps/OaksLab.asm's Oak reads VAR_BADGES and opens Mt. Silver only on
+## `ifequal NUM_BADGES`, which is NUM_JOHTO_BADGES + NUM_KANTO_BADGES = 16
+## (constants/ram_constants.asm). Eight badges take `.Complain` instead, so the
+## count has to span both badge bytes for the walk west to be earned.
+func test_oaks_lab_opens_mt_silver_only_on_all_sixteen_badges() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6120"] = [
+		Gen2WorldScript.READVAR, 0x07,
+		Gen2WorldScript.IFEQUAL, 16, 0x30, 0x61,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6130"] = [
+		Gen2WorldScript.SETEVENT, EVENT_OPENED_MT_SILVER & 0xFF,
+		EVENT_OPENED_MT_SILVER >> 8, Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+
+	for badges: int in [8, 16]:
+		var state := Gen2WorldState.new()
+		for badge: int in range(badges):
+			state.set_engine_flag(Gen2WorldState.badge_flag(badge))
+		var runner := Gen2WorldScriptRunner.begin(data, state, {
+			"kind": &"test", "bank": 48, "script": 0x6120,
+		})
+
+		var result: Dictionary = runner.advance()
+
+		assert_eq(result["status"], &"complete", JSON.stringify(result))
+		assert_eq(state.badge_count(), badges)
+		assert_eq(
+			state.is_event_flag_active(EVENT_OPENED_MT_SILVER), badges == 16,
+			"%d badges" % badges
+		)
+
+
 ## LancesRoomLanceScript ends on `warpfacing UP, HALL_OF_FAME, 4, 13`, and the
 ## Hall of Fame's own scene is what runs `halloffame`. A map scene queued by a
 ## warp is picked up by the same run_event_queue() loop that took the warp, so

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -686,6 +686,56 @@ const VIRIDIAN_GYM_DOOR: Vector2i = Vector2i(32, 7)
 const BLUE_GYM_FACE: Vector2i = Vector2i(5, 4)
 const BADGE_EARTH: int = 15
 const EVENT_BEAT_BLUE: int = 1228
+const VIRIDIAN_GYM_EXIT: Vector2i = Vector2i(4, 17)
+
+## Mt. Silver. Every step past the gate is a warp or a connection, so the leg
+## needs only the map the walk west crosses onto (`constants/map_constants.asm`,
+## `data/maps/attributes.asm`). The three cave rooms are the one place the
+## profiles renumber, 74 to 76 in Crystal and 66 to 68 in Gold and Silver, which
+## is why `tools/validate_mt_silver.gd` splits them and this Crystal-only walk
+## does not name them at all.
+const SILVER_GROUP: int = 19
+const SILVER_CAVE_OUTSIDE_NUMBER: int = 2
+const ROUTE_22_NUMBER: int = 2
+## `maps/SilverCaveOutside.asm`'s MAPCALLBACK_NEWMAP, the leg's one flypoint.
+const ENGINE_FLYPOINT_SILVER_CAVE: int = 76
+
+## Pallet Town and Oak's lab. `maps/OaksLab.asm`'s Oak reads VAR_BADGES and takes
+## `.OpenMtSilver` only on `ifequal NUM_BADGES`, which is sixteen
+## (`constants/ram_constants.asm`), so this errand is the last badge's own
+## reward. Every branch then falls into `.CheckPokedex` and its
+## `special ProfOaksPCBoot`.
+const OAKS_LAB_DOOR: Vector2i = Vector2i(12, 11)
+const OAKS_LAB_EXIT: Vector2i = Vector2i(4, 11)
+const OAK_FACE: Vector2i = Vector2i(4, 3)
+const EVENT_TALKED_TO_OAK_IN_KANTO: int = 225
+const EVENT_OPENED_MT_SILVER: int = 1871
+
+## The Victory Road Gate is three regions joined by two single cells, and a black
+## belt stands in each (`maps/VictoryRoadGate.asm`). The right belt on (12,5)
+## joins the corridor to the Route 22 arm and is hidden by EVENT_FOUGHT_SNORLAX,
+## which `_wake_snorlax()` already set; the left belt on (7,5) joins it to the
+## Route 28 arm and is hidden by EVENT_OPENED_MT_SILVER. Oak is therefore the
+## gate on Mt. Silver, not a courtesy, and `tools/validate_mt_silver.gd` pins all
+## four flag combinations.
+const ROUTE_22_GATE_DOOR: Vector2i = Vector2i(13, 5)
+const GATE_WEST_DOOR: Vector2i = Vector2i(1, 7)
+
+## Silver Cave. Every room is one region, so each ladder is walked to directly.
+const SILVER_CAVE_POKECENTER_DOOR: Vector2i = Vector2i(23, 19)
+const SILVER_CAVE_POKECENTER_EXIT: Vector2i = Vector2i(3, 7)
+## The counter tile below the nurse is not walkable, the same as every other
+## Pokemon Center on the route, so she is faced from a cell placed directly.
+const SILVER_CAVE_NURSE_STAND: Vector2i = Vector2i(3, 2)
+const SILVER_CAVE_MOUTH: Vector2i = Vector2i(18, 11)
+const SILVER_CAVE_ROOM_1_LADDER: Vector2i = Vector2i(15, 1)
+const SILVER_CAVE_ROOM_2_LADDER: Vector2i = Vector2i(11, 5)
+## Red's own hide flag is EVENT_RED_IN_MT_SILVER, already pinned below for the
+## Hall of Fame that clears it.
+const RED_FACE: Vector2i = Vector2i(9, 11)
+## `data/trainers/parties.asm`: trainer class RED ($3f) with one party, which
+## `loadtrainer`'s one-based operand reaches as index 0.
+const TRAINER_CLASS_RED: int = 63
 
 ## constants/item_constants.asm.
 const ITEM_MACHINE_PART: int = 0x80
@@ -6828,6 +6878,308 @@ func _viridian_leg(
 		}
 	if not world.state.is_engine_flag_active(badge):
 		return {"ok": false, "path": path, "reason": "ENGINE_EARTHBADGE was not set"}
+	return _mt_silver_leg(world, save, random, data, path)
+
+
+## Viridian Gym to Red, which is Oak's errand and then a walk west.
+##
+## The sixteenth badge is what opens this leg and Oak is what spends it:
+## `maps/OaksLab.asm` takes `.OpenMtSilver` only on `ifequal NUM_BADGES`, so the
+## walk goes south to Pallet before it goes west. That is not a courtesy call.
+## The Victory Road Gate is three regions joined by two single cells and a black
+## belt stands in each, so EVENT_OPENED_MT_SILVER is the one thing that joins
+## the corridor to the Route 28 arm, exactly as EVENT_FOUGHT_SNORLAX joins it to
+## the Route 22 arm the leg arrives through. `tools/validate_mt_silver.gd` pins
+## all four combinations.
+##
+## Red himself is the route's second presentation boundary: his script ends on
+## `credits`, which commits nothing and emits one event, the way `halloffame`
+## does. `disappear` then sets EVENT_RED_IN_MT_SILVER again, so the room the
+## Hall of Fame opened closes behind the walk.
+func _mt_silver_leg(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var out_of_gym: Dictionary = _warp_chain(world, save, random, data, [VIRIDIAN_GYM_EXIT])
+	if not bool(out_of_gym.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "leaving Viridian Gym failed: %s" % out_of_gym.get("reason", ""),
+		}
+
+	for leg: Dictionary in [
+		{"step": "route_1_southbound", "group": PALLET_GROUP, "number": ROUTE_1_NUMBER},
+		{"step": "pallet_town_return", "group": PALLET_GROUP, "number": PALLET_TOWN_NUMBER},
+	]:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, "south", int(leg["group"]), int(leg["number"]), save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the walk to %s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+
+	var oak: Dictionary = _oaks_lab_errand(world, save, random, data, path)
+	if not bool(oak.get("ok", false)):
+		return oak
+
+	for leg: Dictionary in [
+		{"step": "route_1_northbound", "direction": "north",
+			"group": PALLET_GROUP, "number": ROUTE_1_NUMBER},
+		{"step": "viridian_northbound", "direction": "north",
+			"group": ROUTE_2_GROUP, "number": VIRIDIAN_CITY_NUMBER},
+		{"step": "route_22_westbound", "direction": "west",
+			"group": ROUTE_2_GROUP, "number": ROUTE_22_NUMBER},
+	]:
+		var walked: Dictionary = _walk_connection_resolving(
+			world, String(leg["direction"]), int(leg["group"]), int(leg["number"]),
+			save, random, data
+		)
+		var entry: Dictionary = _drain_story(
+			world, world.dispatch_map_entry(), save, random, data
+		)
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": walked.get("encounters", []),
+			"run": entry,
+		})
+		if not bool(walked.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the walk to %s failed: %s" % [leg["step"], walked.get("reason", "")],
+			}
+
+	var through_gate: Dictionary = _warp_chain(
+		world, save, random, data, [ROUTE_22_GATE_DOOR, GATE_WEST_DOOR]
+	)
+	path.append({
+		"step": "victory_road_gate_west_arm",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"opened_mt_silver": world.event_flag_active(EVENT_OPENED_MT_SILVER),
+		"fought_snorlax": world.event_flag_active(EVENT_FOUGHT_SNORLAX),
+	})
+	if not bool(through_gate.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the gate's west arm failed: %s" % through_gate.get("reason", ""),
+		}
+
+	var westbound: Dictionary = _walk_connection_resolving(
+		world, "west", SILVER_GROUP, SILVER_CAVE_OUTSIDE_NUMBER, save, random, data
+	)
+	var outside_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	path.append({
+		"step": "silver_cave_outside",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_SILVER_CAVE),
+		"encounters": westbound.get("encounters", []),
+		"run": outside_entry,
+	})
+	if not bool(westbound.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the walk onto Silver Cave Outside failed: %s" % westbound.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_SILVER_CAVE):
+		return {
+			"ok": false, "path": path,
+			"reason": "SilverCaveOutsideFlypointCallback did not run",
+		}
+
+	var healed: Dictionary = _silver_cave_heal(world, save, random, data, path)
+	if not bool(healed.get("ok", false)):
+		return healed
+
+	return _silver_cave_rooms(world, save, random, data, path)
+
+
+## Oak's lab, which is the only thing that opens Mt. Silver. The sixteen-badge
+## branch sets EVENT_OPENED_MT_SILVER and then falls into `.CheckPokedex`, whose
+## `special ProfOaksPCBoot` is presentation and writes nothing.
+func _oaks_lab_errand(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_lab: Dictionary = _warp_chain(world, save, random, data, [OAKS_LAB_DOOR])
+	if not bool(into_lab.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Oak's lab door failed: %s" % into_lab.get("reason", ""),
+		}
+	var badges: int = world.state.badge_count(Gen2WorldState.is_crystal_profile(data))
+	var oak: Dictionary = _talk_to(
+		world, OAK_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "oaks_lab_opens_mt_silver",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"badge_count": badges,
+		"talked_to_oak": world.event_flag_active(EVENT_TALKED_TO_OAK_IN_KANTO),
+		"opened_mt_silver": world.event_flag_active(EVENT_OPENED_MT_SILVER),
+		"run": oak.get("run", {}),
+	})
+	if not bool(oak.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Oak did not finish: %s" % oak.get("reason", ""),
+		}
+	if badges != 16:
+		return {
+			"ok": false, "path": path,
+			"reason": "Oak was asked with %d badges, not sixteen" % badges,
+		}
+	if not world.event_flag_active(EVENT_OPENED_MT_SILVER):
+		return {"ok": false, "path": path, "reason": "EVENT_OPENED_MT_SILVER was not set"}
+	var out_of_lab: Dictionary = _warp_chain(world, save, random, data, [OAKS_LAB_EXIT])
+	if not bool(out_of_lab.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Oak's lab exit failed: %s" % out_of_lab.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## The last heal before Red. The nurse stands behind a counter the walk cannot
+## step onto, so the approach cell is placed rather than walked to.
+func _silver_cave_heal(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var into_center: Dictionary = _warp_chain(
+		world, save, random, data, [SILVER_CAVE_POKECENTER_DOOR]
+	)
+	if not bool(into_center.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Mt. Silver Pokecenter door failed: %s" % into_center.get("reason", ""),
+		}
+	_mirror_party(world, save)
+	for mon: Gen2SaveMon in save.party:
+		mon.hp = 1
+	world.player_cell = SILVER_CAVE_NURSE_STAND
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var nurse: Dictionary = _drain_story(
+		world, world.interact(), save, random, data, true
+	)
+	path.append({
+		"step": "silver_cave_pokecenter_nurse",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": nurse,
+		"party_hp_after": _party_hp(save),
+	})
+	if not bool(nurse.get("terminal", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Mt. Silver nurse did not finish: %s" % nurse.get("reason", ""),
+		}
+	var out_of_center: Dictionary = _warp_chain(
+		world, save, random, data, [SILVER_CAVE_POKECENTER_EXIT]
+	)
+	if not bool(out_of_center.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Mt. Silver Pokecenter exit failed: %s" % out_of_center.get("reason", ""),
+		}
+	return {"ok": true}
+
+
+## The three rooms and Red. Every room is one region, so each ladder is walked
+## to directly; `tools/validate_mt_silver.gd` is what says so.
+func _silver_cave_rooms(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	for leg: Dictionary in [
+		{"step": "silver_cave_room_1", "cell": SILVER_CAVE_MOUTH},
+		{"step": "silver_cave_room_2", "cell": SILVER_CAVE_ROOM_1_LADDER},
+		{"step": "silver_cave_room_3", "cell": SILVER_CAVE_ROOM_2_LADDER},
+	]:
+		var climbed: Dictionary = _warp_chain(world, save, random, data, [leg["cell"]])
+		path.append({
+			"step": leg["step"],
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+		})
+		if not bool(climbed.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the ladder to %s failed: %s" % [
+					leg["step"], climbed.get("reason", ""),
+				],
+			}
+
+	_mirror_party(world, save)
+	var red: Dictionary = _talk_to(
+		world, RED_FACE, Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	var run: Dictionary = red.get("run", {})
+	path.append({
+		"step": "silver_cave_red",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"battles": run.get("battles", []),
+		"credits": int(run.get("credits", 0)),
+		"red_hidden_again": world.event_flag_active(EVENT_RED_IN_MT_SILVER),
+		"party_hp_after": _party_hp(save),
+		"encounters": red.get("encounters", []),
+		"run": run,
+	})
+	if not bool(red.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Red did not finish: %s" % red.get("reason", ""),
+		}
+	var battles: Array = run.get("battles", [])
+	if battles.size() != 1 \
+		or int((battles[0] as Dictionary).get("trainer_class", 0)) != TRAINER_CLASS_RED:
+		return {
+			"ok": false, "path": path,
+			"reason": "Red's script fought %s, not one battle as class %d" % [
+				JSON.stringify(battles), TRAINER_CLASS_RED,
+			],
+		}
+	if int(run.get("credits", 0)) != 1:
+		return {
+			"ok": false, "path": path,
+			"reason": "Red's script emitted %d credits events, not one" % int(
+				run.get("credits", 0)
+			),
+		}
+	# disappear sets the hide flag the Hall of Fame cleared, so the room closes
+	# behind the walk the way the cartridge closes it.
+	if not world.event_flag_active(EVENT_RED_IN_MT_SILVER):
+		return {"ok": false, "path": path, "reason": "EVENT_RED_IN_MT_SILVER was not set again"}
 	return {"ok": true}
 
 
@@ -8216,6 +8568,7 @@ func _drain_story(
 	var battles: Array = []
 	var catch_tutorials: int = 0
 	var hall_of_fame: int = _hall_of_fame_events(results)
+	var credits: int = _credits_events(results)
 	var approaches: Array = []
 	for result: Dictionary in results:
 		if not bool(result.get("ok", false)):
@@ -8391,6 +8744,7 @@ func _drain_story(
 			break
 		statuses.append_array(_statuses(results))
 		hall_of_fame += _hall_of_fame_events(results)
+		credits += _credits_events(results)
 		waits += 1
 		for result: Dictionary in results:
 			if not bool(result.get("ok", false)):
@@ -8412,6 +8766,7 @@ func _drain_story(
 		"purchases": purchases,
 		"catch_tutorials": catch_tutorials,
 		"hall_of_fame": hall_of_fame,
+		"credits": credits,
 		"approaches": approaches,
 		"terminal": last_reason.is_empty() \
 			and not world.script_input_waiting() and world.pending_runtime_request().is_empty(),
@@ -8755,9 +9110,19 @@ func _statuses(results: Array) -> Array[String]:
 ## event on the route with no screen behind it. Counted so the walk can say the
 ## boundary was reached rather than only that the flag is set.
 func _hall_of_fame_events(results: Array) -> int:
+	return _presentation_events(results, &"hall_of_fame_requested")
+
+
+## `credits` is the same kind of boundary, reached once by Red
+## (`maps/SilverCaveRoom3.asm`).
+func _credits_events(results: Array) -> int:
+	return _presentation_events(results, &"credits_requested")
+
+
+func _presentation_events(results: Array, type: StringName) -> int:
 	var count: int = 0
 	for result: Dictionary in results:
 		for event: Dictionary in result.get("events", []):
-			if StringName(event.get("type", &"")) == &"hall_of_fame_requested":
+			if StringName(event.get("type", &"")) == type:
 				count += 1
 	return count

--- a/tools/validate_mt_silver.gd
+++ b/tools/validate_mt_silver.gd
@@ -1,0 +1,513 @@
+extends SceneTree
+
+## Verifies the walk from Viridian Gym to Red on Silver Cave Room 3, against
+## freshly imported real caches for both command profiles.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## data/maps/attributes.asm, constants/map_constants.asm, maps/PalletTown.asm,
+## maps/OaksLab.asm, maps/Route22.asm, maps/VictoryRoadGate.asm,
+## maps/Route28.asm, maps/SilverCaveOutside.asm and maps/SilverCaveRoom1.asm
+## through maps/SilverCaveRoom3.asm.
+##
+## Three findings carry the leg. The Victory Road Gate is three regions joined
+## by two single cells, and a black belt stands in each, so each belt's hide
+## flag is the gate on its own arm: EVENT_FOUGHT_SNORLAX opens the Route 22 arm
+## and EVENT_OPENED_MT_SILVER the Route 28 one, which makes Oak a hard gate on
+## Mt. Silver rather than a courtesy. Each Silver Cave room is one region, so no
+## room needs a hand-named intermediate cell the way Cinnabar did. And Red
+## carries EVENT_RED_IN_MT_SILVER as his hide flag, which InitializeEventsScript
+## sets at a new game and only HallOfFameEnterScript clears, so the room is
+## empty until the Hall of Fame.
+##
+##   Godot --headless --path . -s res://tools/validate_mt_silver.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm. The DUNGEONS group is the one split on this leg:
+## Crystal inserts maps ahead of Silver Cave, so its three rooms are 74, 75 and
+## 76 where Gold and Silver number them 66, 67 and 68.
+const DUNGEONS_GROUP: int = 3
+const SILVER_CAVE_ROOM_1: int = 74
+const SILVER_CAVE_ROOM_1_GOLD_SILVER: int = 66
+const PALLET_GROUP: int = 13
+const ROUTE_1: int = 1
+const PALLET_TOWN: int = 2
+const OAKS_LAB: int = 6
+const SILVER_GROUP: int = 19
+const ROUTE_28: int = 1
+const SILVER_CAVE_OUTSIDE: int = 2
+const SILVER_CAVE_POKECENTER_1F: int = 3
+const VIRIDIAN_GROUP: int = 23
+const ROUTE_22: int = 2
+const VIRIDIAN_CITY: int = 3
+const VIRIDIAN_GYM: int = 4
+const VICTORY_ROAD_GATE: int = 13
+
+## The warp chain, as [label, group, number, the cell the warp stands on, the
+## target group and number, and the one-based destination warp index that
+## decides the landing cell]. [param room_1] is the profile's first Silver Cave
+## room, which the other two follow.
+func _warp_chain(room_1: int) -> Array:
+	return [
+		["Viridian Gym's door", VIRIDIAN_GROUP, VIRIDIAN_GYM, Vector2i(4, 17),
+			VIRIDIAN_GROUP, VIRIDIAN_CITY, 1],
+		["Pallet Town's lab door", PALLET_GROUP, PALLET_TOWN, Vector2i(12, 11),
+			PALLET_GROUP, OAKS_LAB, 1],
+		["Oak's lab exit", PALLET_GROUP, OAKS_LAB, Vector2i(4, 11),
+			PALLET_GROUP, PALLET_TOWN, 3],
+		["Route 22's gate door", VIRIDIAN_GROUP, ROUTE_22, Vector2i(13, 5),
+			VIRIDIAN_GROUP, VICTORY_ROAD_GATE, 1],
+		["the gate's west door", VIRIDIAN_GROUP, VICTORY_ROAD_GATE, Vector2i(1, 7),
+			SILVER_GROUP, ROUTE_28, 2],
+		["the Mt. Silver Pokecenter door", SILVER_GROUP, SILVER_CAVE_OUTSIDE, Vector2i(23, 19),
+			SILVER_GROUP, SILVER_CAVE_POKECENTER_1F, 1],
+		["Silver Cave's mouth", SILVER_GROUP, SILVER_CAVE_OUTSIDE, Vector2i(18, 11),
+			DUNGEONS_GROUP, room_1, 1],
+		["Room 1's north ladder", DUNGEONS_GROUP, room_1, Vector2i(15, 1),
+			DUNGEONS_GROUP, room_1 + 1, 1],
+		["Room 2's north ladder", DUNGEONS_GROUP, room_1 + 1, Vector2i(11, 5),
+			DUNGEONS_GROUP, room_1 + 2, 1],
+	]
+
+## The two plain connections the leg walks, as [label, group, number, the cell
+## the walk starts on, the axis, and the map that axis crosses onto].
+const CONNECTIONS: Array = [
+	["Viridian City", VIRIDIAN_GROUP, VIRIDIAN_CITY, Vector2i(18, 0), "west",
+		VIRIDIAN_GROUP, ROUTE_22],
+	["Route 28", SILVER_GROUP, ROUTE_28, Vector2i(33, 5), "west",
+		SILVER_GROUP, SILVER_CAVE_OUTSIDE],
+]
+
+## Pallet Town, where Oak stands. The lab door is the third warp, so the walk
+## south off Route 1 has to reach it on foot.
+const PALLET_LANDING: Vector2i = Vector2i(8, 0)
+const OAKS_LAB_DOOR: Vector2i = Vector2i(12, 11)
+const OAKS_LAB_LANDING: Vector2i = Vector2i(4, 11)
+const OAK_CELL: Vector2i = Vector2i(4, 2)
+const OAK_FACE: Vector2i = Vector2i(4, 3)
+const EVENT_OPENED_MT_SILVER: int = 1871
+
+## Victory Road Gate, which is three regions joined by two single cells, and a
+## black belt stands in each. The left belt on (7,5) joins the central corridor
+## to the west arm and the Route 28 door; the right belt on (12,5) joins it to
+## the east arm and the Route 22 door. Each belt's hide flag is therefore the
+## gate on its own arm, which is why Oak has to be talked to before the walk
+## west is open at all.
+const GATE_LANDING: Vector2i = Vector2i(17, 7)
+const GATE_WEST_DOOR: Vector2i = Vector2i(1, 7)
+const GATE_ROUTE_26_DOOR: Vector2i = Vector2i(9, 17)
+const GATE_VICTORY_ROAD_DOOR: Vector2i = Vector2i(9, 0)
+const GATE_LEFT_BLACK_BELT: Vector2i = Vector2i(7, 5)
+const GATE_RIGHT_BLACK_BELT: Vector2i = Vector2i(12, 5)
+const GATE_BADGE_CHECK: Vector2i = Vector2i(10, 11)
+const EVENT_FOUGHT_SNORLAX: int = 1872
+
+## Route 28 and Silver Cave Outside.
+const ROUTE_28_LANDING: Vector2i = Vector2i(33, 5)
+const SILVER_CAVE_OUTSIDE_POKECENTER_DOOR: Vector2i = Vector2i(23, 19)
+const SILVER_CAVE_MOUTH: Vector2i = Vector2i(18, 11)
+const ENGINE_FLYPOINT_SILVER_CAVE: int = 76
+
+## The Mt. Silver Pokecenter, the last heal before Red.
+const POKECENTER_LANDING: Vector2i = Vector2i(3, 7)
+const NURSE_CELL: Vector2i = Vector2i(3, 1)
+const NURSE_FACE: Vector2i = Vector2i(3, 2)
+
+## The three rooms, as [label, the offset off the profile's first room, the cell
+## the room is entered on, the cell the walk has to reach in it].
+const SILVER_CAVE_ROOMS: Array = [
+	["Room 1", 0, Vector2i(9, 33), Vector2i(15, 1)],
+	["Room 2", 1, Vector2i(17, 31), Vector2i(11, 5)],
+	["Room 3", 2, Vector2i(9, 33), Vector2i(9, 11)],
+]
+const RED_CELL: Vector2i = Vector2i(9, 10)
+const RED_FACE: Vector2i = Vector2i(9, 11)
+const EVENT_RED_IN_MT_SILVER: int = 1890
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_warp_chain(
+			data, game_id, SILVER_CAVE_ROOM_1 if crystal else SILVER_CAVE_ROOM_1_GOLD_SILVER
+		)
+		_verify_connections(data, game_id)
+		_verify_oaks_lab(data, game_id)
+		_verify_gate(data, game_id)
+		_verify_silver_cave_outside(data, game_id, crystal)
+		_verify_pokecenter(data, game_id)
+		_verify_rooms(
+			data, game_id, SILVER_CAVE_ROOM_1 if crystal else SILVER_CAVE_ROOM_1_GOLD_SILVER
+		)
+	_finish()
+
+
+## Every door on the leg, by the warp it stands on and the cell it lands on.
+func _verify_warp_chain(data: GameData, game_id: StringName, room_1: int) -> void:
+	for leg: Array in _warp_chain(room_1):
+		var label: String = leg[0]
+		var world: Gen2WorldAPI = _open(data, int(leg[1]), int(leg[2]), leg[3])
+		if world == null:
+			continue
+		var warp: Dictionary = world.warp_at(leg[3])
+		if not _check(
+			int(warp.get("map_group", -1)) == int(leg[4])
+				and int(warp.get("map_number", -1)) == int(leg[5]),
+			"%s: %s reaches %d/%d, not the pinned %d/%d." % [
+				game_id, label,
+				int(warp.get("map_group", -1)), int(warp.get("map_number", -1)),
+				int(leg[4]), int(leg[5]),
+			]
+		):
+			continue
+		_check(
+			int(warp.get("destination", -1)) == int(leg[6]),
+			"%s: %s targets warp %d, not the pinned %d." % [
+				game_id, label, int(warp.get("destination", -1)), int(leg[6]),
+			]
+		)
+	print("%s warps: %d doors from Viridian Gym to Silver Cave Room 3." % [
+		game_id, _warp_chain(room_1).size(),
+	])
+
+
+## The two plain connections, each proved by the map its region crosses onto.
+func _verify_connections(data: GameData, game_id: StringName) -> void:
+	for leg: Array in CONNECTIONS:
+		var label: String = leg[0]
+		var start: Vector2i = leg[3]
+		var world: Gen2WorldAPI = _open(data, int(leg[1]), int(leg[2]), start)
+		if world == null:
+			continue
+		var crossing: Dictionary = _crossing(world, _region(world, start), String(leg[4]))
+		_check(
+			int(crossing.get("map_group", -1)) == int(leg[5])
+				and int(crossing.get("map_number", -1)) == int(leg[6]),
+			"%s: %s's %s edge reaches %d/%d, not the pinned %d/%d." % [
+				game_id, label, String(leg[4]),
+				int(crossing.get("map_group", -1)), int(crossing.get("map_number", -1)),
+				int(leg[5]), int(leg[6]),
+			]
+		)
+	print("%s connections: Viridian west onto Route 22, Route 28 west onto Silver Cave Outside." % game_id)
+
+
+## Pallet Town's lab door reached on foot from Route 1, and Oak inside it.
+func _verify_oaks_lab(data: GameData, game_id: StringName) -> void:
+	var town: Gen2WorldAPI = _open(data, PALLET_GROUP, PALLET_TOWN, PALLET_LANDING)
+	if town != null:
+		_check(
+			_region(town, PALLET_LANDING).has(OAKS_LAB_DOOR),
+			"%s: Pallet's lab door at %s is not reachable from the north edge." % [
+				game_id, OAKS_LAB_DOOR,
+			]
+		)
+	var world: Gen2WorldAPI = _open(data, PALLET_GROUP, OAKS_LAB, OAKS_LAB_LANDING)
+	if world == null:
+		return
+	var region: Dictionary = _region(world, OAKS_LAB_LANDING)
+	_check(
+		region.has(OAK_FACE) and world.object_at(OAK_CELL) != null,
+		"%s: Oak on %s is not faced from %s." % [game_id, OAK_CELL, OAK_FACE]
+	)
+	# Oak's own object carries no hide flag, so the lab is the same before and
+	# after the sixteenth badge: only his script branches.
+	var sealed := Gen2WorldState.new()
+	sealed.set_event_flag(EVENT_OPENED_MT_SILVER)
+	var opened: Gen2WorldAPI = _open(data, PALLET_GROUP, OAKS_LAB, OAKS_LAB_LANDING, sealed)
+	if opened != null:
+		_check(
+			opened.visible_objects().size() == world.visible_objects().size(),
+			"%s: EVENT_OPENED_MT_SILVER changes Oak's lab objects." % game_id
+		)
+	print("%s oak's lab: a %d-cell room, Oak faced from below, nothing behind a flag." % [
+		game_id, region.size(),
+	])
+
+
+## The gate, whose two arms are each shut by a black belt standing in the one
+## cell that joins them to the corridor. Both flags are needed to walk Route 22
+## to Route 28, and the walked route sets EVENT_FOUGHT_SNORLAX in Vermilion long
+## before it reaches Oak.
+func _verify_gate(data: GameData, game_id: StringName) -> void:
+	# [label, the flags set, the crossings that must work, the ones that must not].
+	for case: Array in [
+		["a new gate", [], [[GATE_ROUTE_26_DOOR, GATE_VICTORY_ROAD_DOOR]],
+			[[GATE_LANDING, GATE_WEST_DOOR], [GATE_LANDING, GATE_VICTORY_ROAD_DOOR],
+				[GATE_ROUTE_26_DOOR, GATE_WEST_DOOR]]],
+		["the Snorlax fought", [EVENT_FOUGHT_SNORLAX],
+			[[GATE_LANDING, GATE_VICTORY_ROAD_DOOR]],
+			[[GATE_LANDING, GATE_WEST_DOOR], [GATE_ROUTE_26_DOOR, GATE_WEST_DOOR]]],
+		["Mt. Silver opened", [EVENT_OPENED_MT_SILVER],
+			[[GATE_ROUTE_26_DOOR, GATE_WEST_DOOR]], [[GATE_LANDING, GATE_WEST_DOOR]]],
+		["both", [EVENT_FOUGHT_SNORLAX, EVENT_OPENED_MT_SILVER],
+			[[GATE_LANDING, GATE_WEST_DOOR]], []],
+	]:
+		var state := Gen2WorldState.new()
+		for flag: int in case[1] as Array:
+			state.set_event_flag(flag)
+		var world: Gen2WorldAPI = _open(
+			data, VIRIDIAN_GROUP, VICTORY_ROAD_GATE, GATE_LANDING, state
+		)
+		if world == null:
+			continue
+		_check(
+			world.visible_objects().size() == 3 - (case[1] as Array).size(),
+			"%s: with %s the gate shows %d objects, not %d." % [
+				game_id, String(case[0]), world.visible_objects().size(),
+				3 - (case[1] as Array).size(),
+			]
+		)
+		for pair: Array in case[2] as Array:
+			_check(
+				_region(world, pair[0]).has(pair[1]),
+				"%s: with %s the gate does not join %s to %s." % [
+					game_id, String(case[0]), pair[0], pair[1],
+				]
+			)
+		for pair: Array in case[3] as Array:
+			_check(
+				not _region(world, pair[0]).has(pair[1]),
+				"%s: with %s the gate already joins %s to %s." % [
+					game_id, String(case[0]), pair[0], pair[1],
+				]
+			)
+
+	var open := Gen2WorldState.new()
+	open.set_event_flag(EVENT_FOUGHT_SNORLAX)
+	open.set_event_flag(EVENT_OPENED_MT_SILVER)
+	var crossed: Gen2WorldAPI = _open(
+		data, VIRIDIAN_GROUP, VICTORY_ROAD_GATE, GATE_LANDING, open
+	)
+	if crossed == null:
+		return
+	# The badge-check coord event is spent by the time the leg arrives, but the
+	# walk must not need its cell either, so it is never re-dispatched.
+	_check(
+		not _path_cells(crossed, GATE_LANDING, GATE_WEST_DOOR).has(GATE_BADGE_CHECK),
+		"%s: the gate cannot be crossed without stepping on %s." % [game_id, GATE_BADGE_CHECK]
+	)
+	var shut: Gen2WorldAPI = _open(data, VIRIDIAN_GROUP, VICTORY_ROAD_GATE, GATE_LANDING)
+	if shut != null:
+		for cell: Vector2i in [GATE_LEFT_BLACK_BELT, GATE_RIGHT_BLACK_BELT]:
+			_check(
+				shut.object_at(cell) != null and crossed.object_at(cell) == null,
+				"%s: %s is not a black belt cell that both flags clear." % [game_id, cell]
+			)
+	print("%s gate: two arms, each shut by one black belt standing in the one cell that joins it." % game_id)
+
+
+## Silver Cave Outside: the flypoint its map callback sets, and the two doors.
+func _verify_silver_cave_outside(data: GameData, game_id: StringName, crystal: bool) -> void:
+	var route: Gen2WorldAPI = _open(data, SILVER_GROUP, ROUTE_28, ROUTE_28_LANDING)
+	if route != null:
+		_check(
+			_region(route, ROUTE_28_LANDING).size() > 0,
+			"%s: Route 28's gate landing at %s is not walkable." % [game_id, ROUTE_28_LANDING]
+		)
+	var world: Gen2WorldAPI = _open(data, SILVER_GROUP, SILVER_CAVE_OUTSIDE, SILVER_CAVE_MOUTH)
+	if world == null:
+		return
+	var flag: int = ENGINE_FLYPOINT_SILVER_CAVE if crystal else ENGINE_FLYPOINT_SILVER_CAVE - 1
+	_check(
+		world.state.is_engine_flag_active(flag),
+		"%s: SilverCaveOutsideFlypointCallback did not set engine flag %d." % [game_id, flag]
+	)
+	var region: Dictionary = _region(world, SILVER_CAVE_MOUTH)
+	for cell: Vector2i in [SILVER_CAVE_OUTSIDE_POKECENTER_DOOR, SILVER_CAVE_MOUTH]:
+		_check(
+			region.has(cell),
+			"%s: Silver Cave Outside does not reach %s." % [game_id, cell]
+		)
+	print("%s silver cave outside: a %d-cell region holding both doors, flypoint %d." % [
+		game_id, region.size(), flag,
+	])
+
+
+func _verify_pokecenter(data: GameData, game_id: StringName) -> void:
+	var world: Gen2WorldAPI = _open(
+		data, SILVER_GROUP, SILVER_CAVE_POKECENTER_1F, POKECENTER_LANDING
+	)
+	if world == null:
+		return
+	var region: Dictionary = _region(world, POKECENTER_LANDING)
+	_check(
+		world.object_at(NURSE_CELL) != null,
+		"%s: %s is not the nurse's cell." % [game_id, NURSE_CELL]
+	)
+	# The counter tile below her is not walkable, so the nurse is talked to from
+	# a cell placed directly rather than walked to, the way every other
+	# Pokemon Center on the route is.
+	_check(
+		not region.has(NURSE_FACE),
+		"%s: %s is walkable, so the counter is not a counter." % [game_id, NURSE_FACE]
+	)
+	print("%s mt. silver pokecenter: a %d-cell room, the nurse behind her counter on %s." % [
+		game_id, region.size(), NURSE_CELL,
+	])
+
+
+## The three rooms. Each is one region, which is what lets the leg warp straight
+## through without a hand-named intermediate cell.
+func _verify_rooms(data: GameData, game_id: StringName, room_1: int) -> void:
+	for room: Array in SILVER_CAVE_ROOMS:
+		var label: String = room[0]
+		var entry: Vector2i = room[2]
+		var target: Vector2i = room[3]
+		var world: Gen2WorldAPI = _open(data, DUNGEONS_GROUP, room_1 + int(room[1]), entry)
+		if world == null:
+			continue
+		var region: Dictionary = _region(world, entry)
+		_check(
+			region.has(target),
+			"%s: Silver Cave %s does not reach %s from %s." % [
+				game_id, label, target, entry,
+			]
+		)
+		print("%s silver cave %s: %d cells from %s, reaching %s." % [
+			game_id, label, region.size(), entry, target,
+		])
+
+	# Red is hidden by his own flag, which a new game sets and only the Hall of
+	# Fame clears (engine/events/std_scripts.asm, maps/HallOfFame.asm).
+	var room_3: Gen2WorldAPI = _open(
+		data, DUNGEONS_GROUP, room_1 + 2, Vector2i(9, 33)
+	)
+	if room_3 == null:
+		return
+	_check(
+		room_3.object_at(RED_CELL) != null,
+		"%s: %s is not Red's cell." % [game_id, RED_CELL]
+	)
+	_check(
+		room_3.visible_objects().size() == 1,
+		"%s: Silver Cave Room 3 shows %d objects with the flag clear, not one." % [
+			game_id, room_3.visible_objects().size(),
+		]
+	)
+	var before := Gen2WorldState.new()
+	before.set_event_flag(EVENT_RED_IN_MT_SILVER)
+	var empty: Gen2WorldAPI = _open(
+		data, DUNGEONS_GROUP, room_1 + 2, Vector2i(9, 33), before
+	)
+	if empty != null:
+		_check(
+			empty.visible_objects().is_empty(),
+			"%s: Room 3 is not empty while EVENT_RED_IN_MT_SILVER is set." % game_id
+		)
+	print("%s silver cave red: one object on %s, gone behind EVENT_RED_IN_MT_SILVER." % [
+		game_id, RED_CELL,
+	])
+
+
+## The map [param region] crosses onto over [param axis], as the first edge cell
+## in it that really connects. Empty when the region reaches no such edge.
+func _crossing(world: Gen2WorldAPI, region: Dictionary, axis: String) -> Dictionary:
+	var size: Vector2i = world.map_size_cells()
+	var direction: Vector2i = {
+		"north": Vector2i.UP, "south": Vector2i.DOWN,
+		"west": Vector2i.LEFT, "east": Vector2i.RIGHT,
+	}[axis]
+	for index: int in (size.y if axis in ["west", "east"] else size.x):
+		var edge: Vector2i = Vector2i(index, 0) if axis == "north" \
+			else Vector2i(index, size.y - 1) if axis == "south" \
+			else Vector2i(0, index) if axis == "west" \
+			else Vector2i(size.x - 1, index)
+		if not region.has(edge):
+			continue
+		world.player_cell = edge
+		var target: Dictionary = world.connection_target(edge, direction)
+		if bool(target.get("ok", false)):
+			target["edge"] = edge
+			return target
+	return {}
+
+
+## One shortest walk from [param start] to [param goal], as the cells it steps
+## on. Empty when the goal is in another region.
+func _path_cells(world: Gen2WorldAPI, start: Vector2i, goal: Vector2i) -> Array[Vector2i]:
+	var came_from: Dictionary = {start: start}
+	var frontier: Array[Vector2i] = [start]
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		if cell == goal:
+			var path: Array[Vector2i] = []
+			var step: Vector2i = goal
+			while step != start:
+				path.append(step)
+				step = came_from[step]
+			return path
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+			if face != 0 and (world.tile_permissions_at(cell) & face) != 0:
+				continue
+			if not world.can_walk_to(next) or came_from.has(next):
+				continue
+			came_from[next] = cell
+			frontier.append(next)
+	return []
+
+
+func _open(
+	data: GameData, group: int, number: int, cell: Vector2i, state: Gen2WorldState = null
+) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, group, number, cell, state if state != null else Gen2WorldState.new()
+	)
+	if world == null:
+		_fail("map %d/%d is missing." % [group, number])
+		return null
+	var _entry: Array = world.dispatch_map_entry()
+	return world
+
+
+## Ledge hops included, the way tools/validate_cinnabar.gd walks.
+func _region(world: Gen2WorldAPI, start: Vector2i) -> Dictionary:
+	var seen: Dictionary = {start: true}
+	var frontier: Array[Vector2i] = [start]
+	var size: Vector2i = world.map_size_cells()
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_front()
+		for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			var next: Vector2i = cell + direction
+			var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+			var walled: bool = face != 0 and (world.tile_permissions_at(cell) & face) != 0
+			if walled or not world.can_walk_to(next):
+				if not Gen2WorldCollision.allows_hop(world.collision_code_at(cell), direction):
+					continue
+				next = cell + direction * 2
+				if next.x < 0 or next.y < 0 or next.x >= size.x or next.y >= size.y:
+					continue
+			if seen.has(next):
+				continue
+			seen[next] = true
+			frontier.append(next)
+	return seen
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS mt. silver: the warp chain, both connections, Oak's lab, the gate's two black-belt arms, Silver Cave Outside and the three rooms verified.")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr(failure)
+	printerr("FAIL mt. silver: %d problems." % _failures.size())
+	quit(1)

--- a/tools/validate_mt_silver.gd.uid
+++ b/tools/validate_mt_silver.gd.uid
@@ -1,0 +1,1 @@
+uid://vwnb2ntjrhba


### PR DESCRIPTION
Carry the walked route from Viridian Gym back south to Pallet for Oak's errand, then west through the Victory Road Gate and up Silver Cave to Red, which is the last of Kanto apart from the Magnet Train.

The gate is two standing NPCs, not its warps. Victory Road Gate is three walkable regions joined by exactly one cell each, and a black belt stands in both joining cells, so each belt's hide flag is the gate on its own arm: the Route 22 arm needs EVENT_FOUGHT_SNORLAX, which Vermilion already set, and the Route 28 arm needs EVENT_OPENED_MT_SILVER. Reading the scripts alone says Mt. Silver is open from the start, because the warps are unconditional and the badge check guards only the corridor. It is not, and Oak's `.OpenMtSilver` is the only thing that sets that flag in either pin. It wants VAR_BADGES to equal sixteen exactly, so the walk south to Pallet is what the last badge buys.

Two commands the leg reaches had no handler. `credits` ($a0) now emits one presentation event and commits nothing, the way `halloffame` does; Script_credits and Script_halloffame share the same Script_endall tail, and both call sites are followed by the source's own `end`, so running on costs nothing. ProfOaksPCBoot (special 101, 100 in Gold/Silver) prints, counts dex bits for its rating and waits for a button, so it reports as presentation and writes nothing. Neither reaches a screen yet.

Past the gate, Route 28 connects west onto Silver Cave Outside and its flypoint, the Pokecenter nurse is the last heal, and the three cave rooms are each one region, so the mouth and both ladders are walked to directly. Red is one battle as trainer class 63, and his `disappear` sets EVENT_RED_IN_MT_SILVER again, closing behind the walk the room the Hall of Fame opened.

tools/validate_mt_silver.gd pins the nine doors, both connections, Oak's lab, the gate under all four flag combinations, Silver Cave Outside, the Pokecenter counter, each room as one region and Red's hide flag, on all three profiles. The Dungeons group is the leg's one profile split: the rooms are 74 to 76 on Crystal and 66 to 68 on Gold and Silver.