### PR TITLE
Let a wild encounter be run from

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   font, text-box borders, the battle HUD, maps, overworld menus, 34 mart
 >   lists, phone contacts, special calls and music/SFX pointers. A scene-free
 >   host resolves all of it without reopening the ROM.
-> - **Battles.** Parties, switching, stats, damage, accuracy, turn order, status
->   and substatus effects, trainer AI, experience, levelling, move learning and
->   capture input on a real 160x144 screen.
+> - **Battles.** Parties, switching, running, stats, damage, accuracy, turn
+>   order, status and substatus effects, trainer AI, experience, levelling, move
+>   learning and capture input on a real 160x144 screen.
 > - **Overworld.** Real maps, map connections, script requests, trainer battles
 >   with imported win/loss text, map reloads, save-safe blackout recovery,
 >   object lifecycle, followers, block edits, emotes, surf, ledge hops, grass,
@@ -183,7 +183,7 @@ Development scenes:
 |---|---|
 | `game/render/pic_viewer.tscn` | left/right species, `S` shiny, `B` front/back, `T` trainer classes |
 | `game/render/text_viewer.tscn` | Space advances, `F` cycles borders, `C` shows every glyph |
-| `game/battle/battle_screen.tscn` | `A` turn, Space events, `W` switch, left/right matchup, `S`/`D` damage either side; in wild battles `B` opens the ball selector, left/right changes ball, Space throws |
+| `game/battle/battle_screen.tscn` | `A` turn, Space events, `W` switch, `R` run, left/right matchup, `S`/`D` damage either side; in wild battles `B` opens the ball selector, left/right changes ball, Space throws |
 | `game/world/world_screen.tscn` | arrows/WASD move, Space or `Z` confirms, `F` fishes while facing water with an owned rod, `P` opens the phone list directly, `Enter`/`Tab` opens the start menu and its Pokegear entry the whole device, `Esc` closes an overlay, `V` cycles world renderers, F5 saves |
 
 Battle-screen moves are random and a full move set declines the learn offer; use

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -76,6 +76,18 @@ const STAT_CHANGE_FAILED: StringName = &"stat_change_failed"
 ## nobody to call back, and the screen has one sentence to say rather than two.
 const WITHDREW: StringName = &"withdrew"
 const SENT_OUT: StringName = &"sent_out"
+## The player got away. `how` says which branch answered: [code]&"battle_type"[/code]
+## for the two types that always escape, [code]&"item"[/code] for the Smoke Ball,
+## [code]&"speed"[/code] for the plain comparison, [code]&"odds"[/code] for the
+## accumulated odds and [code]&"roll"[/code] for the last random check.
+const FLED: StringName = &"fled"
+## The roll came up short. The turn is spent and the enemy still acts, which is
+## `.cant_escape_2` setting `wBattlePlayerAction` to `BATTLEPLAYERACTION_USEITEM`.
+const RUN_FAILED: StringName = &"run_failed"
+## Running was refused outright, which costs no turn at all: `BattleMenu_Run`
+## reopens the menu. `reason` is [code]&"trainer"[/code] or
+## [code]&"battle_type"[/code].
+const RUN_BLOCKED: StringName = &"run_blocked"
 const OVER: StringName = &"over"
 
 ## Experience, once the fainted Pokémon's opponent has somebody to award it to.
@@ -143,6 +155,38 @@ const MIST_PROTECTED: StringName = &"mist_protected"
 ## action rather than a move number.
 const ACTION_MOVE: StringName = &"move"
 const ACTION_SWITCH: StringName = &"switch"
+## Running is settled before the turn rather than inside it, because
+## `BattleMenu_Run` runs at menu time: a successful run ends the battle before
+## either side moves, and a refusal the player can do nothing about sends them
+## back to the menu with no turn spent at all.
+const ACTION_RUN: StringName = &"run"
+
+## `wBattleType`. Only the values `TryToRunAwayFromBattle` branches on are named;
+## everything else reaches the ordinary speed check.
+const BATTLETYPE_NORMAL: int = 0
+const BATTLETYPE_DEBUG: int = 2
+const BATTLETYPE_CONTEST: int = 6
+const BATTLETYPE_FORCESHINY: int = 7
+const BATTLETYPE_TRAP: int = 9
+const BATTLETYPE_CELEBI: int = 11
+const BATTLETYPE_SUICUNE: int = 12
+## The two lists it reads them against, in source order.
+const ALWAYS_ESCAPES: Array[int] = [BATTLETYPE_DEBUG, BATTLETYPE_CONTEST]
+const NEVER_ESCAPES: Array[int] = [
+	BATTLETYPE_TRAP, BATTLETYPE_CELEBI, BATTLETYPE_FORCESHINY, BATTLETYPE_SUICUNE,
+]
+
+## `HELD_ESCAPE` (constants/item_data_constants.asm), the Smoke Ball's held
+## effect, which is imported as an item's own `effect` field.
+const HELD_ESCAPE: int = 72
+
+## `TryToRunAwayFromBattle`'s own arithmetic. The odds are
+## `player_speed * 32 / ((enemy_speed / 4) & $ff)`, then 30 per attempt after the
+## first, and anything over a byte gets away without a roll.
+const FLEE_SPEED_MULTIPLIER: int = 32
+const FLEE_ENEMY_SPEED_SHIFT: int = 2
+const FLEE_ATTEMPT_BONUS: int = 30
+const FLEE_ODDS_RANGE: int = 256
 
 ## Priority runs from 0 to 3 and most moves are 1, so a move can go below the
 ## ordinary as well as above it. The values are keyed by the move's effect byte,
@@ -169,6 +213,19 @@ var rng: RandomNumberGenerator = null
 ## trainer battle. A wild encounter (the default, and every existing caller's
 ## meaning before this field existed) never sets it.
 var is_trainer_battle: bool = false
+
+## `wBattleType`, which only running reads so far. A `loadvar VAR_BATTLETYPE`
+## before `startbattle` is what sets it on the world path; everything else is
+## BATTLETYPE_NORMAL.
+var battle_type: int = BATTLETYPE_NORMAL
+
+## `wNumFleeAttempts`. Every failed run raises the odds behind the next one, and
+## choosing FIGHT clears it again, which is `BattleMenu_Fight`'s own `xor a`.
+var flee_attempts: int = 0
+
+## Set once the player has run. The battle is over with no winner, which is the
+## DRAW `wBattleResult` the cartridge writes.
+var _fled: bool = false
 
 ## The two sides, keyed by [constant PLAYER] and [constant ENEMY].
 var parties: Dictionary = {}
@@ -248,6 +305,10 @@ static func switch_to(index: int) -> Dictionary:
 	return {"type": ACTION_SWITCH, "index": index}
 
 
+static func run_away() -> Dictionary:
+	return {"type": ACTION_RUN}
+
+
 func party(side: int) -> Gen2Party:
 	return parties[side]
 
@@ -288,7 +349,74 @@ func last_damage_taken(side: int) -> Dictionary:
 ## A battle is lost when a whole party is down, not when the Pokémon that is out
 ## has fainted. One of those is a defeat and the other is a Pokémon to replace.
 func is_over() -> bool:
-	return party(PLAYER).is_wiped() or party(ENEMY).is_wiped()
+	return _fled or party(PLAYER).is_wiped() or party(ENEMY).is_wiped()
+
+
+## Whether the player has run from this battle. The parties are both still
+## standing, so [method is_over] alone does not say which ending it was.
+func has_fled() -> bool:
+	return _fled
+
+
+## `TryToRunAwayFromBattle`, resolved without spending anything.
+##
+## Answers `outcome`: [code]&"fled"[/code], [code]&"failed"[/code] for the roll
+## that came up short and costs the turn, or [code]&"blocked"[/code] for a
+## refusal that costs nothing. `how` or `reason` says which branch answered.
+##
+## Two of the source's checks are missing rather than passing, and they are the
+## two whose state this engine does not keep: `SUBSTATUS_CANT_RUN` (Mean Look and
+## Spider Web) and `wPlayerWrapCount` (the trapping moves). Neither effect is
+## implemented, so there is nothing to read; both belong here the day they are.
+func run_odds() -> Dictionary:
+	if battle_type in ALWAYS_ESCAPES:
+		return {"outcome": &"fled", "how": &"battle_type", "battle_type": battle_type}
+	if battle_type in NEVER_ESCAPES:
+		return {"outcome": &"blocked", "reason": &"battle_type", "battle_type": battle_type}
+	if is_trainer_battle:
+		return {"outcome": &"blocked", "reason": &"trainer"}
+
+	var runner: Gen2BattleMon = mon(PLAYER)
+	var chaser: Gen2BattleMon = mon(ENEMY)
+	if _held_effect(runner) == HELD_ESCAPE:
+		return {"outcome": &"fled", "how": &"item", "item": runner.item}
+
+	# wNumFleeAttempts rises before the arithmetic reads it, so the first attempt
+	# counts as one and the bonus loop below runs one fewer time than that.
+	var attempts: int = flee_attempts + 1
+	var speed: int = runner.stat("speed")
+	var enemy_speed: int = chaser.stat("speed")
+	if speed >= enemy_speed:
+		return {"outcome": &"fled", "how": &"speed", "attempts": attempts}
+
+	# The divisor is one byte of enemy_speed >> 2, so a fast enough enemy wraps
+	# it to zero and the run simply succeeds. That is the cartridge's own
+	# `and a; jr z, .can_escape`, not a guard against dividing by zero.
+	var divisor: int = (enemy_speed >> FLEE_ENEMY_SPEED_SHIFT) & 0xFF
+	if divisor == 0:
+		return {"outcome": &"fled", "how": &"speed", "attempts": attempts}
+
+	# The dividend is the low sixteen bits of the product, which is what taking
+	# hProduct + 2 and + 3 leaves behind.
+	var odds: int = ((speed * FLEE_SPEED_MULTIPLIER) & 0xFFFF) / divisor
+	if odds > 0xFF:
+		return {"outcome": &"fled", "how": &"odds", "odds": odds, "attempts": attempts}
+	for _bonus: int in attempts - 1:
+		odds += FLEE_ATTEMPT_BONUS
+		if odds > 0xFF:
+			return {"outcome": &"fled", "how": &"odds", "odds": odds, "attempts": attempts}
+	return {
+		"outcome": &"roll", "odds": odds, "attempts": attempts,
+		"range": FLEE_ODDS_RANGE,
+	}
+
+
+## The held effect of whatever [param battler] is carrying, or zero. The item's
+## own `effect` field is `ItemAttributes`' held effect byte.
+func _held_effect(battler: Gen2BattleMon) -> int:
+	if battler == null or battler.item <= 0 or data == null:
+		return 0
+	return int(data.item(battler.item).get("effect", 0))
 
 
 ## Whoever is still standing, or null if the battle is not over. Both sides can
@@ -296,6 +424,9 @@ func is_over() -> bool:
 ## and there is nobody, so this answers null for that too.
 func winner() -> Variant:
 	if not is_over():
+		return null
+	# Running is a DRAW: both parties are still standing and nobody beat anybody.
+	if _fled:
 		return null
 	if party(PLAYER).is_wiped() and party(ENEMY).is_wiped():
 		return null
@@ -433,6 +564,36 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 		return events
 	reset_damage_taken()
 
+	if _is_run(player_action):
+		var attempt: Dictionary = run_odds()
+		var outcome: StringName = StringName(attempt.get("outcome", &"roll"))
+		if outcome == &"roll":
+			# BattleRandom against the accumulated odds. The comparison is
+			# `cp b; jr nc`, so the odds getting away on a tie is the source's.
+			flee_attempts += 1
+			var rolled: int = rng.randi_range(0, FLEE_ODDS_RANGE - 1)
+			attempt["roll"] = rolled
+			outcome = &"fled" if int(attempt["odds"]) >= rolled else &"failed"
+			attempt["how"] = &"roll"
+		elif outcome != &"blocked":
+			flee_attempts += 1
+		if outcome == &"fled":
+			_fled = true
+			events.append(_run_event(FLED, attempt))
+			events.append({"type": OVER, "winner": winner(), "fled": true})
+			return events
+		if outcome == &"blocked":
+			# BattleMenu_Run's `jp BattleMenu`: nothing was spent, so no residual
+			# damage and no enemy move either.
+			events.append(_run_event(RUN_BLOCKED, attempt))
+			return events
+		events.append(_run_event(RUN_FAILED, attempt))
+
+	# BattleMenu_Fight clears wNumFleeAttempts, so the odds a run has built up
+	# survive only a run followed by another run.
+	if StringName(player_action.get("type", ACTION_MOVE)) == ACTION_MOVE:
+		flee_attempts = 0
+
 	var actions: Dictionary = {PLAYER: player_action, ENEMY: enemy_action}
 	var chosen: Dictionary = {
 		PLAYER: _move_for_action(PLAYER, player_action),
@@ -441,6 +602,8 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 
 	var acting: Array = order(chosen, actions)
 	for side: int in acting:
+		if _is_run(actions[side]):
+			continue
 		if _is_switch(actions[side]):
 			events.append_array(send_out(side, int(actions[side].get("index", -1))))
 			continue
@@ -612,11 +775,24 @@ static func _is_switch(action: Dictionary) -> bool:
 	return StringName(action.get("type", ACTION_MOVE)) == ACTION_SWITCH
 
 
+static func _is_run(action: Dictionary) -> bool:
+	return StringName(action.get("type", ACTION_MOVE)) == ACTION_RUN
+
+
+## The event a run attempt produces, carrying whatever branch answered it.
+func _run_event(type: StringName, attempt: Dictionary) -> Dictionary:
+	var out: Dictionary = attempt.duplicate(true)
+	out.erase("outcome")
+	out["type"] = type
+	out["side"] = PLAYER
+	return out
+
+
 ## The move an action commits a side to, which is nothing at all for a switch.
 ## Struggle stands in there so that the order can be worked out without a special
 ## case; a switching side never reaches the point of using it.
 func _move_for_action(side: int, action: Dictionary) -> int:
-	if _is_switch(action):
+	if _is_switch(action) or _is_run(action):
 		return Gen2Damage.STRUGGLE
 	return move_for(side, int(action.get("slot", 0)))
 
@@ -666,7 +842,11 @@ func move_for(side: int, slot: int) -> int:
 ## The cartridge weighs a held Quick Claw between priority and speed; no held
 ## items exist here yet.
 func order(chosen: Dictionary, actions: Dictionary = {}) -> Array:
-	var player_switching: bool = _is_switch(actions.get(PLAYER, {}))
+	# A failed run is settled before the enemy moves, the way a switch is: the
+	# cartridge spends the turn as BATTLEPLAYERACTION_USEITEM, which resolves at
+	# once and leaves the enemy's move behind it.
+	var player_switching: bool = _is_switch(actions.get(PLAYER, {})) \
+		or _is_run(actions.get(PLAYER, {}))
 	var enemy_switching: bool = _is_switch(actions.get(ENEMY, {}))
 	if player_switching or enemy_switching:
 		return _sides(player_switching)

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -727,6 +727,19 @@ func _enemy_slot() -> int:
 	)
 
 
+## Tries to run, which is `BattleMenu_Run` and settles before the turn does.
+##
+## Offered in a trainer battle too, because the cartridge offers it there and
+## answers with its own refusal rather than greying the entry out.
+func run_from_battle() -> void:
+	if _battle == null or _battle.is_over() or not _pending.is_empty():
+		return
+	if _battle.awaiting_move_learn():
+		return
+	_pending = _battle.take_actions(Gen2Battle.run_away(), Gen2Battle.use_move(_enemy_slot()))
+	_show_next_event()
+
+
 ## Swaps the player's Pokémon for the next one that is standing, as a turn.
 ##
 ## The enemy attacks while it happens, because a switch is not free: this is the
@@ -909,7 +922,9 @@ func advance() -> void:
 	if _replace_the_fallen():
 		return
 	if _battle != null and _battle.is_over():
-		if _world_battle_active:
+		if _world_battle_active and not _battle.has_fled():
+			# A run shows neither a win nor a loss text and blacks nobody out:
+			# `wBattleResult` is DRAW and the party is still standing.
 			if _show_world_battle_terminal_text():
 				return
 			if _battle.winner() != Gen2Battle.PLAYER and not _world_battle_recovery_shown:
@@ -952,9 +967,13 @@ func _finish_world_battle() -> void:
 		return
 	var winner: Variant = _battle.winner()
 	var outcome: StringName = (
-		Gen2WorldBattleAdapter.OUTCOME_WON
-		if winner == Gen2Battle.PLAYER
-		else Gen2WorldBattleAdapter.OUTCOME_LOST
+		Gen2WorldBattleAdapter.OUTCOME_RAN
+		if _battle.has_fled()
+		else (
+			Gen2WorldBattleAdapter.OUTCOME_WON
+			if winner == Gen2Battle.PLAYER
+			else Gen2WorldBattleAdapter.OUTCOME_LOST
+		)
 	)
 	var result: Dictionary = {
 		"ok": true,
@@ -1240,7 +1259,26 @@ func _describe(event: Dictionary) -> String:
 			return "%s is getting pumped!" % _battler_name(side)
 		Gen2Battle.MIST_PROTECTED:
 			return "%s's stat drop was blocked by mist!" % _battler_name(int(event["target"]))
+		Gen2Battle.FLED:
+			# BattleText_UserFledUsingAStringBuffer1 is the Smoke Ball's own
+			# line; every other branch reaches BattleText_GotAwaySafely.
+			if StringName(event.get("how", &"")) == &"item":
+				return "%s fled using a %s!" % [
+					_battler_name(Gen2Battle.PLAYER),
+					_data.item_name(int(event.get("item", 0))),
+				]
+			return "Got away safely!"
+		Gen2Battle.RUN_FAILED:
+			return "Can't escape!"
+		Gen2Battle.RUN_BLOCKED:
+			if StringName(event.get("reason", &"")) == &"trainer":
+				return "No! There's no running from a trainer battle!"
+			return "Can't escape!"
 		Gen2Battle.OVER:
+			# A run is a draw with both parties standing, and the line before
+			# this one already said so.
+			if bool(event.get("fled", false)):
+				return ""
 			# Both sides can go down in the same turn, through recoil or a burn,
 			# and then there is nobody to declare.
 			if event["winner"] == null:
@@ -1343,6 +1381,8 @@ func _unhandled_key_input(event: InputEvent) -> void:
 			take_turn()
 		KEY_W:
 			switch_player()
+		KEY_R:
+			run_from_battle()
 		KEY_SPACE, KEY_ENTER:
 			advance()
 		KEY_V:

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -61,6 +61,10 @@ static func prepare(
 	)
 	if battle == null:
 		return _failure(&"battle_setup_failed")
+	# wBattleType, which a `loadvar VAR_BATTLETYPE` before `startbattle` sets.
+	# Running is the only thing that reads it so far, and four of its values are
+	# what make Celebi, Suicune and the Rocket trap battles inescapable.
+	battle.battle_type = int(values.get("battle_type", Gen2Battle.BATTLETYPE_NORMAL))
 
 	return {
 		"ok": true,

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -532,6 +532,21 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		})
 		_pending = {}
 		return advance()
+	if outcome == Gen2WorldBattleAdapter.OUTCOME_RAN:
+		## `.can_escape` writes DRAW into wBattleResult, and the script carries
+		## on: `reloadmapafterbattle` only branches on LOSE. The eight corpus
+		## scripts that `iftrue` straight after `startbattle` are asking "did I
+		## not win", and a run answers yes.
+		_stage_just_battled(true)
+		_script_value = BATTLE_RESULT_DRAW
+		_events.append({
+			"type": &"battle_completed",
+			"outcome": outcome,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
+		return advance()
 	if outcome != Gen2WorldBattleAdapter.OUTCOME_WON:
 		return _fail(StringName("battle_%s" % outcome), result)
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -642,3 +642,60 @@ func _install_story_slice() -> void:
 	object["object_type"] = Gen2WorldObject.OBJECTTYPE_SCRIPT
 	object["script"] = STORY_OBJECT
 	object["event_flag"] = STORY_EVENT_FLAG
+
+
+## Running from a real wild encounter, through the production overlay: the
+## battle ends with nobody having won, the party is untouched, and the world
+## comes back rather than blacking out.
+##
+## The player's Pokémon is faster than the fixture's wild one, so
+## `TryToRunAwayFromBattle`'s speed comparison answers and no roll happens.
+func test_running_from_a_wild_encounter_returns_to_the_world_without_a_loss() -> void:
+	await _open_world()
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	var party_before: int = host._battle.party(Gen2Battle.PLAYER).at(0).hp
+
+	host.run_from_battle()
+
+	assert_true(host._battle.has_fled())
+	assert_null(host._battle.winner())
+	assert_eq(host.battle_snapshot()["message"], "Got away safely!")
+	assert_eq(host._battle.party(Gen2Battle.PLAYER).at(0).hp, party_before)
+
+	host.finish()
+	host.advance()
+	host.finish()
+	host.advance()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_null(_battle_host(), "the overlay stayed open after the run")
+	var world: Dictionary = _world_screen.world_snapshot()
+	assert_eq(world["map"], Vector2i(Fixture.MAP_GROUP, Fixture.MAP_NUMBER))
+
+
+## A trainer battle answers the same request with its own refusal, and the
+## overlay stays open with both sides where they were: `BattleMenu_Run` reopens
+## the menu rather than spending the turn.
+func test_a_trainer_battle_refuses_the_run_and_the_overlay_stays_open() -> void:
+	await _open_world()
+	await _trigger_trainer()
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	var enemy_before: int = host._battle.mon(Gen2Battle.ENEMY).hp
+	var player_before: int = host._battle.mon(Gen2Battle.PLAYER).hp
+
+	host.run_from_battle()
+
+	assert_false(host._battle.has_fled())
+	assert_false(host._battle.is_over())
+	assert_eq(
+		host.battle_snapshot()["message"],
+		"No! There's no running from a trainer battle!"
+	)
+	assert_eq(host._battle.mon(Gen2Battle.ENEMY).hp, enemy_before)
+	assert_eq(host._battle.mon(Gen2Battle.PLAYER).hp, player_before, "the turn was spent")
+	assert_not_null(_battle_host())

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -122,6 +122,11 @@ const FOCUS_ENERGY_MOVE: int = 273
 ## The highest move number this table fills. Grown as new moves are added.
 const MAX_MOVE: int = FOCUS_ENERGY_MOVE
 const BERRY_ITEM: int = 0xAD
+## The Smoke Ball and its held effect, both the cartridge's own numbers
+## (constants/item_constants.asm, constants/item_data_constants.asm). It is the
+## one item running reads.
+const SMOKE_BALL: int = 0x6A
+const HELD_ESCAPE: int = 72
 
 ## Gender ratios, the published bytes: `x percent = floor(x * 255 / 100)`, so a
 ## species' own ratio here can be checked against pret's own base stats rather
@@ -357,7 +362,12 @@ static func _items() -> Array:
 	for number: int in range(1, BERRY_ITEM + 1):
 		out.append({
 			"number": number,
-			"name": "BERRY" if number == BERRY_ITEM else "ITEM%d" % number,
+			"name": "BERRY" if number == BERRY_ITEM else (
+				"SMOKE BALL" if number == SMOKE_BALL else "ITEM%d" % number
+			),
+			# ItemAttributes' held effect byte, which the importer keeps as
+			# `effect`. Only the Smoke Ball's is load bearing so far.
+			"effect": HELD_ESCAPE if number == SMOKE_BALL else 0,
 		})
 	return out
 

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1303,3 +1303,183 @@ func test_focus_energy_reaches_the_damage_calc_of_a_real_turn() -> void:
 	)
 	Gen2EffectCommands.run(Gen2EffectCommands.DAMAGE_CALC, with_boost)
 	assert_true(with_boost.critical, "the same roll lands once Focus Energy raises the rate")
+
+
+## `TryToRunAwayFromBattle`'s speed comparison, which is the whole check when
+## the runner is at least as fast: `CompareBytes` then `jr nc, .can_escape`, so a
+## tie gets away too.
+func test_a_runner_at_least_as_fast_as_the_wild_always_gets_away() -> void:
+	for pair: Array in [
+		[Fixture.PIKACHU, Fixture.GEODUDE],
+		[Fixture.GEODUDE, Fixture.GEODUDE],
+	]:
+		var battle: Gen2Battle = _battle(
+			_mon(int(pair[0]), 50, [Fixture.TACKLE]),
+			_mon(int(pair[1]), 50, [Fixture.TACKLE])
+		)
+
+		var attempt: Dictionary = battle.run_odds()
+
+		assert_eq(attempt["outcome"], &"fled", JSON.stringify(attempt))
+		assert_eq(attempt["how"], &"speed")
+
+
+## The odds themselves: `player_speed * 32 / ((enemy_speed / 4) & $ff)`, then
+## thirty per attempt after the first. The fixture's mon carry maximum DVs, so
+## Geodude at level 50 has 40 Speed and Pikachu 110, and the first attempt is
+## `1280 / 27`, which is 47.
+func test_the_flee_odds_are_the_source_arithmetic_and_rise_per_attempt() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+
+	for expected: Array in [[0, 47], [1, 77], [2, 107], [3, 137]]:
+		battle.flee_attempts = int(expected[0])
+
+		var attempt: Dictionary = battle.run_odds()
+
+		assert_eq(attempt["outcome"], &"roll", JSON.stringify(attempt))
+		assert_eq(int(attempt["odds"]), int(expected[1]), "after %d attempts" % int(expected[0]))
+		assert_eq(int(attempt["attempts"]), int(expected[0]) + 1)
+
+	# Once the bonus carries the odds past a byte the roll never happens, which
+	# is the source's `jr c, .can_escape` out of the loop.
+	battle.flee_attempts = 8
+
+	var certain: Dictionary = battle.run_odds()
+
+	assert_eq(certain["outcome"], &"fled", JSON.stringify(certain))
+	assert_eq(certain["how"], &"odds")
+
+
+## A trainer battle refuses outright and costs nothing: `BattleMenu_Run` prints
+## `BattleText_TheresNoEscapeFromTrainerBattle` and jumps back to `BattleMenu`,
+## so no turn is spent and the enemy does not move.
+func test_a_trainer_battle_refuses_the_run_and_spends_no_turn() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.of(_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])),
+		_rng, true
+	)
+	var before: int = battle.mon(Gen2Battle.PLAYER).hp
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.run_away(), Gen2Battle.use_move(0)
+	)
+
+	assert_eq(_of_type(events, Gen2Battle.RUN_BLOCKED).size(), 1, JSON.stringify(events))
+	assert_eq(events[0]["reason"], &"trainer")
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 0, "the enemy moved anyway")
+	assert_eq(battle.mon(Gen2Battle.PLAYER).hp, before)
+	assert_false(battle.is_over())
+	assert_eq(battle.flee_attempts, 0, "a refusal is not an attempt")
+
+
+## The four battle types that cannot be escaped and the two that always can
+## (`wBattleType`, checked before anything else).
+func test_the_battle_type_decides_before_speed_does() -> void:
+	for row: Array in [
+		[Gen2Battle.BATTLETYPE_TRAP, &"blocked"],
+		[Gen2Battle.BATTLETYPE_CELEBI, &"blocked"],
+		[Gen2Battle.BATTLETYPE_FORCESHINY, &"blocked"],
+		[Gen2Battle.BATTLETYPE_SUICUNE, &"blocked"],
+		[Gen2Battle.BATTLETYPE_DEBUG, &"fled"],
+		[Gen2Battle.BATTLETYPE_CONTEST, &"fled"],
+	]:
+		# A matchup the speed check would refuse, so the type is what answered.
+		var battle: Gen2Battle = _battle(
+			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+			_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+		)
+		battle.battle_type = int(row[0])
+
+		var attempt: Dictionary = battle.run_odds()
+
+		assert_eq(attempt["outcome"], StringName(row[1]), "battle type %d" % int(row[0]))
+		assert_eq(attempt["battle_type"], int(row[0]))
+
+
+## The Smoke Ball is checked before the odds are, so it gets away from anything.
+func test_the_smoke_ball_escapes_whatever_the_speeds_are() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+	assert_eq(battle.run_odds()["outcome"], &"roll", "the matchup has to be one that rolls")
+	battle.mon(Gen2Battle.PLAYER).item = Fixture.SMOKE_BALL
+
+	var attempt: Dictionary = battle.run_odds()
+
+	assert_eq(attempt["outcome"], &"fled", JSON.stringify(attempt))
+	assert_eq(attempt["how"], &"item")
+	assert_eq(int(attempt["item"]), Fixture.SMOKE_BALL)
+
+
+## Getting away ends the battle with nobody having won, which is the DRAW the
+## cartridge writes into `wBattleResult`.
+func test_getting_away_ends_the_battle_with_no_winner() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.run_away(), Gen2Battle.use_move(0)
+	)
+
+	assert_eq(_of_type(events, Gen2Battle.FLED).size(), 1, JSON.stringify(events))
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 0, "the wild moved anyway")
+	assert_true(battle.is_over())
+	assert_true(battle.has_fled())
+	assert_null(battle.winner())
+	assert_false(battle.party(Gen2Battle.PLAYER).is_wiped(), "nobody was beaten")
+	assert_false(battle.party(Gen2Battle.ENEMY).is_wiped())
+
+
+## Choosing FIGHT clears the attempts the runs before it built up, which is
+## `BattleMenu_Fight`'s own `xor a` on `wNumFleeAttempts`.
+func test_fighting_clears_the_odds_a_run_had_built_up() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+	battle.flee_attempts = 4
+	assert_eq(int(battle.run_odds()["odds"]), 167)
+
+	var _events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+	)
+
+	assert_eq(battle.flee_attempts, 0)
+	assert_eq(int(battle.run_odds()["odds"]), 47, "the odds went back to a first attempt")
+
+
+## A roll that comes up short spends the turn: `.cant_escape_2` sets
+## `wBattlePlayerAction` to `BATTLEPLAYERACTION_USEITEM`, so the player does
+## nothing and the wild attacks anyway. The attempt still counts, which is what
+## raises the odds behind the next one.
+##
+## Seeded rather than arranged, because the roll really is a roll: the odds here
+## are 47 out of 256, so most seeds fail and this one is only pinning which.
+func test_a_failed_run_costs_the_turn_and_the_wild_still_attacks() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+	battle.rng.seed = 12345
+	assert_eq(int(battle.run_odds()["odds"]), 47, "the matchup has to be one that rolls")
+	var before: int = battle.mon(Gen2Battle.PLAYER).hp
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.run_away(), Gen2Battle.use_move(0)
+	)
+
+	assert_eq(_of_type(events, Gen2Battle.RUN_FAILED).size(), 1, JSON.stringify(events))
+	assert_eq(_of_type(events, Gen2Battle.FLED).size(), 0)
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 1, "the wild did not attack")
+	assert_lt(battle.mon(Gen2Battle.PLAYER).hp, before, "the turn was not spent")
+	assert_false(battle.is_over())
+	assert_eq(battle.flee_attempts, 1)
+	assert_eq(int(battle.run_odds()["odds"]), 77, "the failed attempt did not raise the odds")


### PR DESCRIPTION
Implement TryToRunAwayFromBattle as an action settled before the turn, the way BattleMenu_Run settles before the menu closes. It is the battle gap a wild encounter hits first and the only one a player cannot route around.

Running has three endings and they cost different amounts, which is the part worth getting right. A hard refusal writes nothing and falls to `jp BattleMenu`, so no turn is spent, no residual damage runs and the enemy does not move. A roll that comes up short writes BATTLEPLAYERACTION_USEITEM, so the turn is spent and the wild attacks anyway. A getaway ends the battle with a null winner, which is the DRAW the cartridge puts in wBattleResult, with both parties still standing.

The odds are the source arithmetic rather than a percentage: player_speed * 32 / ((enemy_speed / 4) & $ff), compared against a roll out of 256 and getting away on a tie, with thirty added per attempt after the first. A tie on speed gets away without rolling, the divisor is one byte so a fast enough enemy wraps it to zero and the run simply succeeds, and BattleMenu_Fight clears the attempts, so the bonus survives only consecutive runs. The Smoke Ball is checked before any of it, reading the held effect the importer already keeps as an item's `effect`.

wBattleType now reaches the battle, since four of its values are what make the Rocket trap, Celebi and Suicune battles inescapable and two more always escape. On the world path a run reports OUTCOME_RAN, a constant that was already reserved, and the script runner answers it with BATTLE_RESULT_DRAW and carries on, because reloadmapafterbattle branches only on LOSE.

Two of the source's own checks are missing rather than passing, and both are named in run_odds(): SUBSTATUS_CANT_RUN and wPlayerWrapCount have no state to read, because EFFECT_MEAN_LOOK and EFFECT_TRAP_TARGET are not implemented. A run out of a Mean Look therefore succeeds where the cartridge refuses. Those two effects are the next task.