### PR TITLE
Bind a Pokemon in place and refuse the way out

### DIFF
--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -27,8 +27,8 @@ Save format version 2 stores:
   behavior does not exist yet.
 
 Derived battle stats are recalculated on load. Volatile state, including stages,
-confusion, recharge, Disable, Encore, Fly, Dig, Rollout and rampage, is never
-saved. The validator checks the selected `GameData`. Slots live under
+confusion, recharge, Disable, Encore, trapping, Fly, Dig, Rollout and rampage,
+is never saved. The validator checks the selected `GameData`. Slots live under
 `user://save_slots` per game revision and are created on demand rather than
 preallocated, up to `Gen2SaveStore.MAX_SLOTS`; a slot number is still its file
 name, so slots written before this stay where they were. Each save carries its

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -139,6 +139,25 @@ const ATTRACT_INFLICTED: StringName = &"attract_inflicted"
 const ENCORE_INFLICTED: StringName = &"encore_inflicted"
 const ENCORE_ENDED: StringName = &"encore_ended"
 
+## Bind, Wrap, Fire Spin, Clamp and Whirlpool: the target was bound, lost a
+## sixteenth of its health to the binding, or was let go. [code]move[/code] on all
+## three is the move that did it, which is what the cartridge's own texts name
+## through `wStringBuffer1`. The release carries no damage, because the turn the
+## counter reaches zero costs nothing.
+const TRAPPED: StringName = &"trapped"
+const HURT_BY_TRAP: StringName = &"hurt_by_trap"
+const RELEASED_FROM_TRAP: StringName = &"released_from_trap"
+
+## Mean Look and Spider Web landed. Set on the user, cleared by any send-out;
+## a second one from the same user is [constant MOVE_FAILED].
+const CANT_ESCAPE_SET: StringName = &"cant_escape_set"
+
+## A switch `TryPlayerSwitch` refused, which costs nothing at all: it prints
+## `BattleText_MonCantBeRecalled` and jumps back to `BattleMenuPKMN_Loop`, so no
+## turn is spent and the enemy does not move. The same shape as
+## [constant RUN_BLOCKED].
+const SWITCH_BLOCKED: StringName = &"switch_blocked"
+
 ## Mist and Focus Energy, set on the user. Both fail with [constant MOVE_FAILED]
 ## on a second use rather than silently re-applying.
 const MIST_SET: StringName = &"mist_set"
@@ -364,10 +383,11 @@ func has_fled() -> bool:
 ## that came up short and costs the turn, or [code]&"blocked"[/code] for a
 ## refusal that costs nothing. `how` or `reason` says which branch answered.
 ##
-## Two of the source's checks are missing rather than passing, and they are the
-## two whose state this engine does not keep: `SUBSTATUS_CANT_RUN` (Mean Look and
-## Spider Web) and `wPlayerWrapCount` (the trapping moves). Neither effect is
-## implemented, so there is nothing to read; both belong here the day they are.
+## Both trapping checks are refusals that cost nothing rather than failed rolls:
+## `.cant_escape` prints and returns without writing
+## `BATTLEPLAYERACTION_USEITEM`, so `BattleMenu_Run` falls through to
+## `jp BattleMenu`. Only `.cant_escape_2`, the roll that came up short, spends
+## the turn.
 func run_odds() -> Dictionary:
 	if battle_type in ALWAYS_ESCAPES:
 		return {"outcome": &"fled", "how": &"battle_type", "battle_type": battle_type}
@@ -378,6 +398,15 @@ func run_odds() -> Dictionary:
 
 	var runner: Gen2BattleMon = mon(PLAYER)
 	var chaser: Gen2BattleMon = mon(ENEMY)
+
+	# Both ahead of the Smoke Ball, which is the source's order, so a trapped
+	# holder does not walk out on the item either. The flag is read off whoever
+	# is doing the trapping and the counter off whoever is bound.
+	if Gen2Substatus.has(chaser.substatus, Gen2Substatus.CANT_RUN):
+		return {"outcome": &"blocked", "reason": &"cant_run"}
+	if runner.trapped_turns > 0:
+		return {"outcome": &"blocked", "reason": &"trapped", "move": runner.trapping_move}
+
 	if _held_effect(runner) == HELD_ESCAPE:
 		return {"outcome": &"fled", "how": &"item", "item": runner.item}
 
@@ -531,6 +560,7 @@ func send_out(side: int, index: int) -> Array:
 	var withdrawing: bool = not current.active_mon().is_fainted()
 	if not current.send_out(index):
 		return events
+	_clear_trapping()
 
 	# Nothing is called back after a faint, so the first half of the pair is only
 	# there when there was somebody to call back.
@@ -545,6 +575,32 @@ func send_out(side: int, index: int) -> Array:
 	})
 	(_participants[side] as Dictionary)[index] = true
 	return events
+
+
+## Ends the whole trapping relationship, on both sides at once.
+##
+## `NewBattleMonStatus` and `NewEnemyMonStatus` each clear both wrap counters and
+## the opponent's `SUBSTATUS_CANT_RUN` beside their own substatus block, so a
+## send-out by either side frees the other as well.
+## [method Gen2BattleMon.reset_volatile] cannot answer for that on its own: it
+## runs on the Pokémon leaving, and half of this state lives on the one staying.
+func _clear_trapping() -> void:
+	for side: int in [PLAYER, ENEMY]:
+		var battler: Gen2BattleMon = mon(side)
+		battler.trapped_turns = 0
+		battler.trapping_move = 0
+		battler.substatus &= ~Gen2Substatus.CANT_RUN
+
+
+## Whether `TryPlayerSwitch` would refuse to recall the player's Pokémon: it is
+## bound, or the opponent is holding it with Mean Look or Spider Web.
+##
+## Player-only, as the cartridge's is. `AI_Switch` makes no such check, so the
+## enemy switches out of either one, and that asymmetry is the cartridge's rather
+## than an omission here.
+func switch_blocked() -> bool:
+	return mon(PLAYER).trapped_turns > 0 \
+		or Gen2Substatus.has(mon(ENEMY).substatus, Gen2Substatus.CANT_RUN)
 
 
 ## Both sides act, and the turn plays out. Returns the events in the order they
@@ -562,6 +618,16 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	var events: Array = []
 	if is_over() or awaiting_replacement() or awaiting_move_learn():
 		return events
+
+	# Settled before anything is spent, because `TryPlayerSwitch` runs at menu
+	# time: the refusal jumps back to `BattleMenuPKMN_Loop` with no turn taken.
+	if _is_switch(player_action) and switch_blocked():
+		events.append({
+			"type": SWITCH_BLOCKED, "side": PLAYER,
+			"index": party(PLAYER).active, "species": mon(PLAYER).species,
+		})
+		return events
+
 	reset_damage_taken()
 
 	if _is_run(player_action):
@@ -613,6 +679,7 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 		_act(side, slot, move_for(side, slot), events)
 
 	_residual_damage(acting, events)
+	_tick_wrap(events)
 	_tick_encore(acting, events)
 	_award_experience(events)
 
@@ -657,6 +724,46 @@ func _residual_damage(acting: Array, events: Array) -> void:
 			"side": side,
 			"status": current.status,
 			"name": Gen2Status.name_of(current.status),
+			"amount": taken,
+			"hp": current.hp,
+			"max_hp": current.max_hp(),
+		})
+		if current.is_fainted():
+			events.append({"type": FAINTED, "side": side})
+
+
+## `HandleWrap`: one turn off each bound Pokémon's counter, and a sixteenth of
+## its health with it.
+##
+## Between [method _residual_damage] and [method _tick_encore] because
+## `HandleBetweenTurnEffects` runs future sight, weather, wrap and perish song
+## before its leftovers block and `HandleEncore` last, while poison and burn are
+## taken inside each side's own move well ahead of any of it.
+##
+## Always the player first, whoever moved first: unlike `ResidualDamage`, which
+## runs inside a turn and so follows it, `HandleWrap` is `SetPlayerTurn` then
+## `SetEnemyTurn` outside a link battle.
+##
+## The turn the counter reaches zero is the release and costs nothing, which is
+## why the rolled three to six turns are two to five turns of damage.
+func _tick_wrap(events: Array) -> void:
+	for side: int in [PLAYER, ENEMY]:
+		var current: Gen2BattleMon = mon(side)
+		if current.is_fainted() or current.trapped_turns <= 0:
+			continue
+
+		var move_number: int = current.trapping_move
+		current.trapped_turns -= 1
+		if current.trapped_turns <= 0:
+			current.trapping_move = 0
+			events.append({"type": RELEASED_FROM_TRAP, "side": side, "move": move_number})
+			continue
+
+		var taken: int = current.take_damage(Gen2Substatus.trap_damage(current.max_hp()))
+		events.append({
+			"type": HURT_BY_TRAP,
+			"side": side,
+			"move": move_number,
 			"amount": taken,
 			"hp": current.hp,
 			"max_hp": current.max_hp(),

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -100,6 +100,13 @@ var encored_slot: int = -1
 ## How many turns [member encored_slot] stays locked.
 var encore_turns: int = 0
 
+## `wPlayerWrapCount` and `wPlayerTrappingMove`: how many turns this Pokémon
+## stays bound by Bind, Wrap, Fire Spin, Clamp or Whirlpool, and which of them
+## bound it. On the Pokémon that is trapped rather than the one that trapped it,
+## which is the side `BattleCommand_TrapTarget` writes.
+var trapped_turns: int = 0
+var trapping_move: int = 0
+
 ## The move this Pokémon last used, by move number, or zero for none: what
 ## Disable and Encore both search a target's own move list for. The cartridge's
 ## own `wLastPlayerMove`/`wLastEnemyMove` clear on a switch exactly the way this
@@ -243,6 +250,8 @@ func reset_volatile() -> void:
 	disable_turns = 0
 	encored_slot = -1
 	encore_turns = 0
+	trapped_turns = 0
+	trapping_move = 0
 	last_move_used = 0
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -60,6 +60,14 @@ const STAT_NAMES: Dictionary = {
 	"evasion": "EVASIVENESS",
 }
 
+## The three trapping moves whose landing line spells the move out, since
+## `BattleCommand_TrapTarget`'s `.Traps` table writes them into the text rather
+## than reading a name buffer. Fire Spin and Whirlpool share the line that names
+## nothing, so neither needs a number here.
+const BIND: int = 20
+const WRAP: int = 35
+const CLAMP: int = 128
+
 var _data: GameData = null
 var _injected_data: GameData = null
 ## Whatever the mod host supplies. Typed as Node because a registered renderer
@@ -1253,6 +1261,20 @@ func _describe(event: Dictionary) -> String:
 			return "%s got an encore!" % _battler_name(int(event["target"]))
 		Gen2Battle.ENCORE_ENDED:
 			return "%s's encore ended!" % _battler_name(side)
+		Gen2Battle.TRAPPED:
+			return _trapped_text(event)
+		Gen2Battle.HURT_BY_TRAP:
+			return "%s's hurt by %s!" % [
+				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
+			]
+		Gen2Battle.RELEASED_FROM_TRAP:
+			return "%s was released from %s!" % [
+				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
+			]
+		Gen2Battle.CANT_ESCAPE_SET:
+			return "%s can't escape now!" % _battler_name(int(event["target"]))
+		Gen2Battle.SWITCH_BLOCKED:
+			return "%s can't be recalled!" % _battler_name(side)
 		Gen2Battle.MIST_SET:
 			return "%s is shrouded in mist!" % _battler_name(side)
 		Gen2Battle.FOCUS_ENERGY_SET:
@@ -1290,6 +1312,24 @@ func _describe(event: Dictionary) -> String:
 ## The sentence for a stat that actually moved. Ancientpower's [code]"all"[/code]
 ## reads as one sentence about the Pokémon rather than five about its stats,
 ## because that is the one thing the event says that a single stat's does not.
+## The sentence a trapping move lands with, which is a per-move line rather than
+## one sentence with the move's name in it: `BattleCommand_TrapTarget`'s `.Traps`
+## table names five texts, three of which spell the move out and two of which do
+## not name it at all. A move number the table does not know cannot happen, since
+## those five are the whole of `EFFECT_TRAP_TARGET`.
+func _trapped_text(event: Dictionary) -> String:
+	var who: String = _battler_name(int(event["target"]))
+	var user: String = _battler_name(int(event["side"]))
+	match int(event["move"]):
+		BIND:
+			return "%s used BIND on %s!" % [user, who]
+		WRAP:
+			return "%s was WRAPPED by %s!" % [who, user]
+		CLAMP:
+			return "%s was CLAMPED by %s!" % [who, user]
+	return "%s was trapped!" % who
+
+
 func _stat_changed_text(event: Dictionary) -> String:
 	var who: String = _battler_name(int(event["target"]))
 	if String(event["stat"]) == "all":

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -178,6 +178,18 @@ const MIST: StringName = &"mist"
 ## switch. Fails, without re-applying, on a second use.
 const FOCUS_ENERGY: StringName = &"focusenergy"
 
+## Binds the target for a rolled number of turns: it can neither run nor be
+## recalled, and loses a sixteenth of its health at the end of each of them.
+## Nothing here stops it moving, which is the Generation 2 rule. A target that is
+## already bound is left alone without a failure message, since
+## `BattleCommand_TrapTarget` simply returns.
+const TRAP_TARGET: StringName = &"traptarget"
+
+## Mean Look and Spider Web: the target can neither run nor be recalled, with no
+## counter and no damage behind it. The flag goes on the user, which is what
+## [constant Gen2Substatus.CANT_RUN] documents.
+const ARENA_TRAP: StringName = &"arenatrap"
+
 ## Raises and lowers a stat by one stage or two, named as the cartridge names
 ## them and in [constant Gen2BattleMon.STAGED_STATS] plus
 ## [constant Gen2BattleMon.STAGED_ODDS] order, which is also the order the effect
@@ -384,6 +396,10 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_mist(turn)
 		FOCUS_ENERGY:
 			_focus_energy(turn)
+		TRAP_TARGET:
+			_trap_target(turn)
+		ARENA_TRAP:
+			_arena_trap(turn)
 		ALL_STATS_UP:
 			_all_stats_up(turn)
 		STAT_UP_MESSAGE, STAT_DOWN_MESSAGE:
@@ -596,10 +612,22 @@ static func _recoil(turn: Gen2Turn) -> void:
 
 
 ## The defender first, then the attacker, which is the order they can go down in.
+##
+## A defender that went down ends the move: `BattleCommand_CheckFaint` finishes
+## on `jp EndMoveEffect`, so the steps the cartridge places behind it, which is
+## every secondary status and [constant TRAP_TARGET], never run against something
+## that has already fainted. The attacker going down to its own recoil ends
+## nothing, because the cartridge tests only the opponent's HP here.
+##
+## The commands behind it keep their own fainted-target check as well, since the
+## lists that have no faint step at all, Twineedle's among them, can still reach
+## one through [constant MULTI_HIT].
 static func _check_faint(turn: Gen2Turn) -> void:
 	for side: int in [turn.target, turn.side]:
 		if turn.battle.mon(side).is_fainted():
 			turn.events.append({"type": Gen2Battle.FAINTED, "side": side})
+	if turn.battle.mon(turn.target).is_fainted():
+		turn.end()
 
 
 ## CantMove on the cartridge cancels a pending two-turn move, Rollout or
@@ -1186,6 +1214,45 @@ static func _focus_energy(turn: Gen2Turn) -> void:
 
 	mon.substatus |= Gen2Substatus.FOCUS_ENERGY
 	turn.emit(Gen2Battle.FOCUS_ENERGY_SET)
+
+
+## Binds the target for three to six turns, of which
+## [method Gen2Battle._tick_wrap] spends the first without damage.
+##
+## `BattleCommand_TrapTarget`'s own three refusals, in its order: a missed move,
+## a target that is already bound, and a target behind a Substitute. The first is
+## structural here, since [method _check_hit] ends the move before this step is
+## reached, and the third has nothing to read until Substitute exists. An
+## already-bound target is silent rather than a [constant Gen2Battle.MOVE_FAILED],
+## because the cartridge returns without printing anything.
+static func _trap_target(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.trapped_turns > 0:
+		return
+
+	defender.trapped_turns = Gen2Substatus.roll_trap_turns(turn.rng())
+	defender.trapping_move = turn.move_number
+	turn.emit(Gen2Battle.TRAPPED, {
+		"target": turn.target, "move": turn.move_number, "turns": defender.trapped_turns,
+	})
+
+
+## Stops the target running or being recalled for as long as the user stays out.
+##
+## `BattleCommand_ArenaTrap` fails against a target that is flying or
+## underground (`CheckHiddenOpponent`) and against one already held, and the
+## check for "already held" is the user's own flag rather than the target's: two
+## Mean Looks from the same Pokémon is what fails, not a Mean Look on a target
+## the opponent's previous Pokémon had already caught.
+static func _arena_trap(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	if _is_hidden(turn.defender().substatus) \
+		or Gen2Substatus.has(attacker.substatus, Gen2Substatus.CANT_RUN):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	attacker.substatus |= Gen2Substatus.CANT_RUN
+	turn.emit(Gen2Battle.CANT_ESCAPE_SET, {"target": turn.target})
 
 
 ## Moves one stat by one command's worth, and writes down who it happened to and

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -138,6 +138,11 @@ const FOCUS_ENERGY: int = 47
 const ATTRACT: int = 120
 const ENCORE: int = 90
 
+## The two trapping effects, numbered the same way. Bind, Wrap, Fire Spin, Clamp
+## and Whirlpool carry the first; Mean Look and Spider Web the second.
+const TRAP_TARGET: int = 42
+const MEAN_LOOK: int = 106
+
 ## An ordinary attack: say it, spend it, work it out, roll it, apply it, and see
 ## who is standing. Everything else is this with steps moved.
 const NORMAL_HIT: Array = [
@@ -436,6 +441,31 @@ const ENCORE_SEQUENCE: Array = [
 	Gen2EffectCommands.END_MOVE,
 ]
 
+## An ordinary attack that binds what it hits: `TrapTarget` is `NormalHit` with
+## `traptarget` in `kingsrock`'s place, behind the faint check, so a knocked out
+## target is never bound.
+const TRAP_TARGET_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.TRAP_TARGET,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Mean Look and Spider Web, which are four commands and no accuracy roll:
+## `MeanLook` has no `checkhit`, so the 100% both moves carry in the move table
+## is never consulted and neither one can miss.
+const MEAN_LOOK_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.ARENA_TRAP,
+	Gen2EffectCommands.END_MOVE,
+]
+
 ## [constant MULTI_HIT] and [constant DOUBLE_HIT]: the accuracy roll happens
 ## once, the way the cartridge's own script checks it before the loop that
 ## repeats the hit even starts, and everything from the critical roll onward
@@ -678,6 +708,8 @@ static func _sequences() -> Dictionary:
 		DISABLE: DISABLE_SEQUENCE,
 		ATTRACT: ATTRACT_SEQUENCE,
 		ENCORE: ENCORE_SEQUENCE,
+		TRAP_TARGET: TRAP_TARGET_SEQUENCE,
+		MEAN_LOOK: MEAN_LOOK_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DRAIN_SEQUENCE,
 		MULTI_HIT: MULTI_HIT_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -43,6 +43,13 @@ const CURLED: int = 1 << 11
 const ROLLOUT: int = 1 << 12
 const RAMPAGING: int = 1 << 13
 
+## `SUBSTATUS_CANT_RUN`, what Mean Look and Spider Web leave behind. It sits on
+## the Pokémon that used the move rather than the one that cannot leave:
+## `BattleCommand_ArenaTrap` sets `BATTLE_VARS_SUBSTATUS5`, the user's own, and
+## `TryToRunAwayFromBattle` refuses the player by reading `wEnemySubStatus5`.
+## The cartridge's name is kept for that reason.
+const CANT_RUN: int = 1 << 14
+
 const NONE: int = 0
 
 ## How many turns a confused Pokémon stays that way, rolled the same shape as
@@ -74,6 +81,17 @@ const MAX_DISABLE: int = 8
 ## reroll on the low end: two bits of a random byte, plus three.
 const MIN_ENCORE: int = 3
 const MAX_ENCORE: int = 6
+
+## How long `BattleCommand_TrapTarget` binds a target: `BattleRandom` masked to
+## two bits and then incremented three times, so three to six. The landing turn's
+## own `HandleWrap` spends one of them without dealing damage, which is why the
+## source comments the same roll as two to five turns.
+const MIN_TRAP_TURNS: int = 3
+const MAX_TRAP_TURNS: int = 6
+
+## What a bound Pokémon loses each turn, `GetSixteenthMaxHP`'s at-least-one
+## sixteenth (engine/battle/core.asm).
+const TRAP_DIVISOR: int = 16
 
 ## Whether an attracted Pokémon is too smitten to move, out of 256: the
 ## cartridge's own 128 in 256, a coin flip, rolled fresh every turn it tries to
@@ -129,3 +147,14 @@ static func roll_encore(rng: RandomNumberGenerator) -> int:
 ## Whether an attracted Pokémon is too smitten to move this turn.
 static func rolls_attract_immobile(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, CHANCE_RANGE - 1) < ATTRACT_IMMOBILE_CHANCE
+
+
+## How long a newly bound Pokémon stays bound.
+static func roll_trap_turns(rng: RandomNumberGenerator) -> int:
+	return rng.randi_range(MIN_TRAP_TURNS, MAX_TRAP_TURNS)
+
+
+## What one turn of being bound costs.
+static func trap_damage(max_hp: int) -> int:
+	@warning_ignore("integer_division")
+	return maxi(max_hp / TRAP_DIVISOR, 1)

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -72,6 +72,14 @@ const EARTHQUAKE: int = 89
 const FISSURE: int = 90
 const MAGNITUDE: int = 222
 
+## The two trapping effects, at their real move numbers because the landing text
+## is chosen by number rather than by effect. Wrap and Bind are one effect apart
+## from each other only in that text, which is what makes the pair enough to see
+## that an already-bound target keeps the move that bound it.
+const WRAP: int = 35
+const BIND: int = 20
+const MEAN_LOOK: int = 212
+
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
 ## the cartridge.
@@ -332,6 +340,13 @@ static func _moves() -> Array:
 		ATTRACT_MOVE: ["ATTRACT", 0, NORMAL, 255, 15, Gen2MoveEffect.ATTRACT, 0],
 		MIST_MOVE: ["MIST", 0, NORMAL, 255, 30, Gen2MoveEffect.MIST, 0],
 		FOCUS_ENERGY_MOVE: ["FOCUS ENERGY", 0, NORMAL, 255, 30, Gen2MoveEffect.FOCUS_ENERGY, 0],
+		# Real rows, accuracy bytes included: Wrap and Bind can miss, so a test
+		# that needs one to land raises the attacker's accuracy stage rather than
+		# pretending either move always hits. Mean Look really is 255, and its
+		# sequence never rolls it anyway.
+		WRAP: ["WRAP", 15, NORMAL, 216, 20, Gen2MoveEffect.TRAP_TARGET, 0],
+		BIND: ["BIND", 15, NORMAL, 191, 20, Gen2MoveEffect.TRAP_TARGET, 0],
+		MEAN_LOOK: ["MEAN LOOK", 0, NORMAL, 255, 5, Gen2MoveEffect.MEAN_LOOK, 0],
 	}
 
 	var out: Array = []

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -265,6 +265,16 @@ func _faint(mon: Gen2BattleMon) -> void:
 	mon.take_damage(mon.max_hp())
 
 
+## Holds the player where it stands, the two ways the cartridge can: Mean Look's
+## flag on whoever cast it, or a binding move's counter on whoever it caught.
+func _hold(battle: Gen2Battle, held_by: StringName) -> void:
+	if held_by == &"mean_look":
+		battle.mon(Gen2Battle.ENEMY).substatus |= Gen2Substatus.CANT_RUN
+		return
+	battle.mon(Gen2Battle.PLAYER).trapped_turns = 3
+	battle.mon(Gen2Battle.PLAYER).trapping_move = Fixture.WRAP
+
+
 func test_a_battle_is_not_over_while_a_party_still_has_somebody() -> void:
 	var battle: Gen2Battle = _party_battle(
 		[_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])],
@@ -1483,3 +1493,243 @@ func test_a_failed_run_costs_the_turn_and_the_wild_still_attacks() -> void:
 	assert_false(battle.is_over())
 	assert_eq(battle.flee_attempts, 1)
 	assert_eq(int(battle.run_odds()["odds"]), 77, "the failed attempt did not raise the odds")
+
+
+## `.cant_escape` prints and returns without writing
+## `BATTLEPLAYERACTION_USEITEM`, so `BattleMenu_Run` falls through to
+## `jp BattleMenu`: unlike the roll that comes up short, neither trapping check
+## spends the turn or counts as an attempt.
+func test_a_trapped_runner_is_refused_without_spending_the_turn() -> void:
+	for held_by: StringName in [&"mean_look", &"wrap"]:
+		# A matchup that would otherwise get away on speed alone, so the refusal
+		# is the only thing that can be answering.
+		var battle: Gen2Battle = _battle(
+			_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+		)
+		_hold(battle, held_by)
+		var before: int = battle.mon(Gen2Battle.PLAYER).hp
+
+		var events: Array = battle.take_actions(
+			Gen2Battle.run_away(), Gen2Battle.use_move(0)
+		)
+
+		assert_eq(_of_type(events, Gen2Battle.RUN_BLOCKED).size(), 1, JSON.stringify(events))
+		assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 0, "the wild attacked anyway")
+		assert_eq(battle.mon(Gen2Battle.PLAYER).hp, before)
+		assert_eq(battle.flee_attempts, 0)
+		assert_false(battle.has_fled())
+
+
+## Both checks sit ahead of the Smoke Ball in `TryToRunAwayFromBattle`, so
+## holding one is no way out of either.
+func test_the_smoke_ball_does_not_carry_a_trapped_runner_out() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+	battle.mon(Gen2Battle.PLAYER).item = Fixture.SMOKE_BALL
+	assert_eq(battle.run_odds()["how"], &"item", "the item has to be the answer without a trap")
+
+	battle.mon(Gen2Battle.PLAYER).trapped_turns = 3
+
+	var attempt: Dictionary = battle.run_odds()
+
+	assert_eq(attempt["outcome"], &"blocked", JSON.stringify(attempt))
+	assert_eq(attempt["reason"], &"trapped")
+
+
+## `TryPlayerSwitch` refuses at menu time and jumps back to
+## `BattleMenuPKMN_Loop`, so the refusal is free: no switch, no enemy move.
+func test_a_trapped_pokemon_cannot_be_recalled() -> void:
+	for held_by: StringName in [&"mean_look", &"wrap"]:
+		var battle: Gen2Battle = _party_battle(
+			[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])],
+			[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+		)
+		_hold(battle, held_by)
+		var before: int = battle.mon(Gen2Battle.PLAYER).hp
+
+		var events: Array = battle.take_actions(
+			Gen2Battle.switch_to(1), Gen2Battle.use_move(0)
+		)
+
+		assert_eq(_of_type(events, Gen2Battle.SWITCH_BLOCKED).size(), 1, JSON.stringify(events))
+		assert_eq(_of_type(events, Gen2Battle.SENT_OUT).size(), 0)
+		assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 0, "the enemy moved anyway")
+		assert_eq(battle.party(Gen2Battle.PLAYER).active, 0)
+		assert_eq(battle.mon(Gen2Battle.PLAYER).hp, before)
+
+
+## `AI_Switch` makes neither check, so the asymmetry is the cartridge's: only the
+## player is held.
+func test_the_enemy_switches_out_of_a_trap_the_player_could_not_leave() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.mon(Gen2Battle.ENEMY).trapped_turns = 3
+	battle.mon(Gen2Battle.PLAYER).substatus |= Gen2Substatus.CANT_RUN
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
+	)
+
+	assert_eq(_of_type(events, Gen2Battle.SENT_OUT).size(), 1, JSON.stringify(events))
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+
+
+## `HandleWrap` decrements before it looks, so the turn the counter reaches zero
+## is the release and costs nothing. Three to six turns of counter are two to
+## five turns of damage, which is what the source comments.
+func test_being_bound_costs_a_sixteenth_a_turn_until_the_release() -> void:
+	for counter: int in range(
+		Gen2Substatus.MIN_TRAP_TURNS, Gen2Substatus.MAX_TRAP_TURNS + 1
+	):
+		# Growl both sides, so nothing but the binding takes any health and the
+		# battle cannot end partway through the count.
+		var battle: Gen2Battle = _battle(
+			_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+			_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+		)
+		var bound: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+		var expected: int = Gen2Substatus.trap_damage(bound.max_hp())
+		bound.trapped_turns = counter
+		bound.trapping_move = Fixture.WRAP
+
+		var hurt: int = 0
+		var released: int = 0
+		for _turn: int in counter:
+			var events: Array = battle.take_actions(
+				Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+			)
+			for event: Dictionary in _of_type(events, Gen2Battle.HURT_BY_TRAP):
+				if int(event["side"]) == Gen2Battle.PLAYER:
+					hurt += 1
+					assert_eq(int(event["amount"]), expected)
+					assert_eq(int(event["move"]), Fixture.WRAP)
+			for event: Dictionary in _of_type(events, Gen2Battle.RELEASED_FROM_TRAP):
+				if int(event["side"]) == Gen2Battle.PLAYER:
+					released += 1
+					assert_eq(int(event["move"]), Fixture.WRAP)
+
+		assert_eq(hurt, counter - 1, "a counter of %d is %d turns of damage" % [
+			counter, counter - 1
+		])
+		assert_eq(released, 1, "a counter of %d was never released" % counter)
+		assert_eq(bound.trapped_turns, 0)
+		assert_eq(bound.trapping_move, 0)
+
+
+## `HandleBetweenTurnEffects` runs wrap after the poison and burn each side took
+## inside its own move, and `HandleEncore` after all of it.
+func test_the_wrap_tick_sits_between_the_status_damage_and_encore() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var bound: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+	bound.status = Gen2Status.POISON
+	bound.trapped_turns = 3
+	bound.trapping_move = Fixture.WRAP
+	bound.encored_slot = 0
+	bound.encore_turns = 1
+	bound.substatus |= Gen2Substatus.ENCORED
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+	)
+	var types: Array = events.map(func(event: Dictionary) -> StringName: return event["type"])
+
+	assert_lt(
+		types.find(Gen2Battle.HURT_BY_STATUS), types.find(Gen2Battle.HURT_BY_TRAP)
+	)
+	assert_lt(
+		types.find(Gen2Battle.HURT_BY_TRAP), types.find(Gen2Battle.ENCORE_ENDED)
+	)
+
+
+## `HandleWrap` is `SetPlayerTurn` then `SetEnemyTurn` outside a link battle, so
+## it does not follow the order the two sides moved in the way `ResidualDamage`,
+## which runs inside a turn, does.
+func test_the_wrap_tick_is_always_the_player_first() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		battle.mon(side).trapped_turns = 3
+		battle.mon(side).trapping_move = Fixture.WRAP
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+	)
+	var hurt: Array = _of_type(events, Gen2Battle.HURT_BY_TRAP)
+
+	assert_eq(_first(events, Gen2Battle.USED_MOVE)["side"], Gen2Battle.ENEMY, "the enemy is faster")
+	assert_eq(hurt.size(), 2)
+	assert_eq(int(hurt[0]["side"]), Gen2Battle.PLAYER)
+	assert_eq(int(hurt[1]["side"]), Gen2Battle.ENEMY)
+
+
+## `NewBattleMonStatus` and `NewEnemyMonStatus` each clear both wrap counters and
+## the opponent's `SUBSTATUS_CANT_RUN`, so a send-out by either side ends the
+## whole relationship rather than only its own half.
+func test_a_send_out_frees_both_sides_of_a_trap() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+	)
+	battle.mon(Gen2Battle.ENEMY).trapped_turns = 3
+	battle.mon(Gen2Battle.ENEMY).trapping_move = Fixture.WRAP
+	battle.mon(Gen2Battle.ENEMY).substatus |= Gen2Substatus.CANT_RUN
+	# The player is the one leaving, and the enemy's half of the state is the
+	# half [method Gen2BattleMon.reset_volatile] cannot reach.
+	battle.mon(Gen2Battle.PLAYER).substatus |= Gen2Substatus.CANT_RUN
+
+	battle.send_out(Gen2Battle.PLAYER, 1)
+
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		assert_eq(battle.mon(side).trapped_turns, 0)
+		assert_eq(battle.mon(side).trapping_move, 0)
+		assert_false(Gen2Substatus.has(battle.mon(side).substatus, Gen2Substatus.CANT_RUN))
+
+
+## Being bound stops a Pokémon leaving, not moving: `HandleWrap` takes the
+## sixteenth and nothing in `CheckStatus` reads the counter at all.
+func test_being_bound_does_not_stop_the_bound_pokemon_moving() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.mon(Gen2Battle.PLAYER).trapped_turns = 3
+	battle.mon(Gen2Battle.PLAYER).trapping_move = Fixture.WRAP
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+	)
+
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 2, JSON.stringify(events))
+
+
+## A Pokémon that goes down to the binding faints there, the same shape a burn
+## or a poison already has.
+func test_a_pokemon_can_faint_to_the_binding() -> void:
+	# Growl both sides, so the binding is the only thing that can take the last
+	# point of health.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	var bound: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	bound.hp = 1
+	bound.trapped_turns = 3
+	bound.trapping_move = Fixture.WRAP
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+	)
+
+	assert_false(_first(events, Gen2Battle.HURT_BY_TRAP).is_empty(), JSON.stringify(events))
+	assert_true(bound.is_fainted())
+	assert_true(battle.is_over())

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -1208,6 +1208,116 @@ func test_mist_protected_gets_its_own_message_not_the_generic_fail() -> void:
 	assert_true(_first(turn.events, Gen2Battle.STAT_CHANGE_FAILED).is_empty())
 
 
+## `TrapTarget` is `NormalHit` with `traptarget` where `kingsrock` sits, behind
+## the faint check; `MeanLook` is four commands with no `checkhit` at all, so
+## neither Mean Look nor Spider Web can miss despite the 100% both carry.
+func test_the_two_trapping_effects_have_their_cartridge_sequences() -> void:
+	var trap: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.TRAP_TARGET)
+	assert_true(Gen2MoveEffect.is_written(Gen2MoveEffect.TRAP_TARGET))
+	assert_eq(trap.size(), Gen2MoveEffect.NORMAL_HIT.size() + 1)
+	assert_lt(
+		trap.find(Gen2EffectCommands.CHECK_FAINT),
+		trap.find(Gen2EffectCommands.TRAP_TARGET)
+	)
+
+	var mean_look: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.MEAN_LOOK)
+	assert_true(Gen2MoveEffect.is_written(Gen2MoveEffect.MEAN_LOOK))
+	assert_eq(mean_look, [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.ARENA_TRAP,
+		Gen2EffectCommands.END_MOVE,
+	])
+
+
+func test_a_trapping_move_binds_its_target_for_three_to_six_turns() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _turn(battle, Fixture.WRAP)
+
+	Gen2EffectCommands.run(Gen2EffectCommands.TRAP_TARGET, turn)
+
+	assert_between(
+		battle.enemy.trapped_turns,
+		Gen2Substatus.MIN_TRAP_TURNS, Gen2Substatus.MAX_TRAP_TURNS
+	)
+	assert_eq(battle.enemy.trapping_move, Fixture.WRAP)
+	assert_eq(int(_first(turn.events, Gen2Battle.TRAPPED)["move"]), Fixture.WRAP)
+
+
+## `BattleCommand_TrapTarget` returns on an already-bound target without
+## printing anything, so the second move neither re-rolls the counter nor takes
+## the first move's place, and it is not a "But it failed!" either.
+func test_a_second_trapping_move_leaves_an_already_bound_target_alone() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.trapped_turns = 4
+	battle.enemy.trapping_move = Fixture.WRAP
+	var turn: Gen2Turn = _turn(battle, Fixture.BIND)
+
+	Gen2EffectCommands.run(Gen2EffectCommands.TRAP_TARGET, turn)
+
+	assert_eq(battle.enemy.trapped_turns, 4)
+	assert_eq(battle.enemy.trapping_move, Fixture.WRAP)
+	assert_true(turn.events.is_empty())
+
+
+## The flag goes on the user, which is the whole reason `TryToRunAwayFromBattle`
+## reads `wEnemySubStatus5` to refuse the player.
+func test_mean_look_flags_its_user_rather_than_its_target() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _turn(battle, Fixture.MEAN_LOOK)
+
+	Gen2EffectCommands.run(Gen2EffectCommands.ARENA_TRAP, turn)
+
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.CANT_RUN))
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.CANT_RUN))
+	assert_false(_first(turn.events, Gen2Battle.CANT_ESCAPE_SET).is_empty())
+
+
+func test_mean_look_fails_against_a_hidden_target_and_on_a_second_use() -> void:
+	var flying: Gen2Battle = _battle()
+	flying.enemy.substatus |= Gen2Substatus.FLYING
+	var first: Gen2Turn = _turn(flying, Fixture.MEAN_LOOK)
+	Gen2EffectCommands.run(Gen2EffectCommands.ARENA_TRAP, first)
+	assert_false(Gen2Substatus.has(flying.player.substatus, Gen2Substatus.CANT_RUN))
+	assert_false(_first(first.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+	# The "already trapped" check is the user's own flag, so a second Mean Look
+	# from the same Pokémon is what fails.
+	var again: Gen2Battle = _battle()
+	again.player.substatus |= Gen2Substatus.CANT_RUN
+	var second: Gen2Turn = _turn(again, Fixture.MEAN_LOOK)
+	Gen2EffectCommands.run(Gen2EffectCommands.ARENA_TRAP, second)
+	assert_false(_first(second.events, Gen2Battle.MOVE_FAILED).is_empty())
+
+
+## Every secondary effect sits behind `checkfaint` in `data/moves/effects.asm`,
+## and `BattleCommand_CheckFaint` ends on `jp EndMoveEffect`, so a knocked out
+## target is never left burned, poisoned, flinching or confused either.
+func test_a_knocked_out_target_takes_no_secondary_effect() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.hp = 1
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.EMBER_BURNS)
+
+	assert_true(battle.enemy.is_fainted())
+	assert_eq(battle.enemy.status, Gen2Status.NONE)
+	assert_true(_first(turn.events, Gen2Battle.STATUS_INFLICTED).is_empty())
+
+
+## `BattleCommand_CheckFaint` ends on `jp EndMoveEffect`, so nothing the
+## cartridge places behind it reaches a target that has already gone down.
+func test_a_knocked_out_target_is_never_bound() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.hp = 1
+	battle.player.change_stage("accuracy", 6)
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.WRAP)
+
+	assert_true(battle.enemy.is_fainted())
+	assert_eq(battle.enemy.trapped_turns, 0)
+	assert_true(_first(turn.events, Gen2Battle.TRAPPED).is_empty())
+
+
 func _of_type(events: Array, type: StringName) -> Array:
 	return events.filter(func(event: Dictionary) -> bool: return event["type"] == type)
 


### PR DESCRIPTION
Bind, Wrap, Fire Spin, Clamp and Whirlpool hold what they hit for three to six turns and take a sixteenth of its health at the end of each of them; Mean Look and Spider Web hold it with no counter at all. Neither stops the bound Pokemon moving.

Both are what run_odds() was missing: a run and a recall now refuse for nothing, the way .cant_escape and TryPlayerSwitch return to the menu, and both refusals sit ahead of the Smoke Ball. Any send-out frees both sides.

checkfaint ends the move when the target goes down, which is where every step the cartridge places behind it stops.