### PR TITLE
Let a Pokemon patch itself up, and watch the clock doing it

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -200,9 +200,9 @@ never quietly change what every move in the game does.
 A registered effect replaces the cartridge's list for that byte, which is how a
 mod rewrites Sleep rather than only adding to the table.
 `Gen2MoveEffect.RESERVED_EFFECTS` is the exception: the multi-hit, fixed-damage,
-Rollout and Selfdestruct bytes are read back off the turn by their own commands,
-so replacing one would leave that command answering for a list it is no longer
-in.
+Rollout, Selfdestruct and time-based heal bytes are read back off the turn by
+their own commands, so replacing one would leave that command answering for a
+list it is no longer in.
 
 ## Watching what happens
 

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -415,6 +415,9 @@ static func _apply_smart(
 				)
 			Gen2MoveEffect.TRAP_TARGET:
 				_smart_trap_target(scores, slot, attacker, defender, def_turns, rng)
+			Gen2MoveEffect.HEAL, Gen2MoveEffect.MORNING_SUN, Gen2MoveEffect.SYNTHESIS, \
+			Gen2MoveEffect.MOONLIGHT:
+				_smart_heal(scores, slot, attacker, rng)
 
 
 ## `AI_Smart_Solarbeam`: 80% to encourage it greatly in sun, where it needs no
@@ -603,6 +606,21 @@ static func _smart_hyper_beam(
 	if _skip_50_50(rng):
 		return
 	_encourage(scores, slot, 1)
+
+
+## `AI_Smart_Heal`, which `AI_Smart_MorningSun`, `AI_Smart_Synthesis` and
+## `AI_Smart_Moonlight` are all labels on: 90% to encourage it greatly below a
+## quarter health, discourage it above half, and nothing in between. The AI reads
+## its own health here, never the player's.
+static func _smart_heal(
+	scores: Array, slot: int, attacker: Gen2BattleMon, rng: RandomNumberGenerator
+) -> void:
+	if not _above_quarter(attacker):
+		if not _roll(rng, 10):
+			_encourage(scores, slot, 2)
+		return
+	if _above_half(attacker):
+		_discourage(scores, slot, 1)
 
 
 static func _smart_belly_drum(scores: Array, slot: int, attacker: Gen2BattleMon) -> void:

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -164,6 +164,17 @@ const WEATHER_CONTINUES: StringName = &"weather_continues"
 const WEATHER_ENDED: StringName = &"weather_ended"
 const HURT_BY_SANDSTORM: StringName = &"hurt_by_sandstorm"
 
+## The heal family. [constant HP_RESTORED] carries the user's `hp` and `max_hp`
+## so a screen moves the bar without reading the battle back;
+## [constant HP_ALREADY_FULL] is `BattleCommand_Heal`'s own refusal, which costs
+## the turn. Rest's two lines are separate events rather than one with a flag,
+## because the cartridge chooses between them on whether there was a status to
+## clear and a screen should not have to know that rule.
+const HP_RESTORED: StringName = &"hp_restored"
+const HP_ALREADY_FULL: StringName = &"hp_already_full"
+const WENT_TO_SLEEP: StringName = &"went_to_sleep"
+const RESTED: StringName = &"rested"
+
 ## Bind, Wrap, Fire Spin, Clamp and Whirlpool: the target was bound, lost a
 ## sixteenth of its health to the binding, or was let go. [code]move[/code] on all
 ## three is the move that did it, which is what the cartridge's own texts name
@@ -268,6 +279,13 @@ var flee_attempts: int = 0
 ## weather, so a fresh [Gen2Battle] starts clear.
 var weather: int = Gen2Weather.NONE
 var weather_turns: int = 0
+
+## `wTimeOfDay`, which only the three time-based heals read. It holds
+## `MORN_F`/`DAY_F`/`NITE_F` (engine/rtc/rtc.asm, `GetTimeOfDay`), the bit
+## indices 0/1/2 rather than the shifted flags, and those are the same three
+## numbers [Gen2WorldPalette] already uses, so the overworld's value is written
+## here unmapped. A battle nobody told stands at midday.
+var time_of_day: int = Gen2WorldPalette.TIME_DAY
 
 ## Set once the player has run. The battle is over with no winner, which is the
 ## DRAW `wBattleResult` the cartridge writes.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -112,6 +112,10 @@ var _world_battle_terminal_text_shown: bool = false
 var _world_battle_recovery_shown: bool = false
 var _world_battle_recovery: Dictionary = {}
 var _last_message: String = ""
+## What the overworld clock said when the battle started, for the three heals
+## that read it. Only the world path supplies one; the development drivers below
+## leave [Gen2Battle] at its own midday default.
+var _time_of_day: int = Gen2WorldPalette.TIME_DAY
 var _capture_balls: Array[int] = []
 var _capture_quantities: Dictionary = {}
 var _capture_ball_index: int = 0
@@ -356,6 +360,7 @@ func start_world_battle(request: Dictionary, save: Gen2SaveData = null) -> bool:
 	_source_save = save
 	_enemy_trainer_class = int(prepared.get("trainer_class", 0))
 	_battle = prepared["battle"]
+	_battle.time_of_day = _time_of_day
 	var player_party_ready: Gen2Party = prepared["player_party"]
 	var enemy_party_ready: Gen2Party = prepared["enemy_party"]
 	_player = player_party_ready.active_mon().species
@@ -510,6 +515,13 @@ func battle_snapshot() -> Dictionary:
 		"capture_balls": _capture_balls.duplicate(),
 		"capture_quantities": _capture_quantities.duplicate(),
 	}
+
+
+## Supplies the battle with the overworld's own clock reading, which Morning Sun,
+## Synthesis and Moonlight are the only things to read. Set before the request is
+## started; a battle begun without it stands at midday.
+func set_time_of_day(value: int) -> void:
+	_time_of_day = value
 
 
 ## Supplies the wild battle with the supported balls currently owned by the
@@ -1117,7 +1129,7 @@ func _apply_event(event: Dictionary) -> void:
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
-		Gen2Battle.HURT_BY_STATUS, Gen2Battle.HURT_ITSELF:
+		Gen2Battle.HURT_BY_STATUS, Gen2Battle.HURT_ITSELF, Gen2Battle.HP_RESTORED:
 			if int(event["side"]) == Gen2Battle.ENEMY:
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
@@ -1269,6 +1281,14 @@ func _describe(event: Dictionary) -> String:
 			return "%s got an encore!" % _battler_name(int(event["target"]))
 		Gen2Battle.ENCORE_ENDED:
 			return "%s's encore ended!" % _battler_name(side)
+		Gen2Battle.HP_RESTORED:
+			return "%s regained health!" % _battler_name(side)
+		Gen2Battle.HP_ALREADY_FULL:
+			return "%s's HP is full!" % _battler_name(side)
+		Gen2Battle.WENT_TO_SLEEP:
+			return "%s went to sleep!" % _battler_name(side)
+		Gen2Battle.RESTED:
+			return "%s fell asleep and became healthy!" % _battler_name(side)
 		Gen2Battle.WEATHER_STARTED:
 			return WEATHER_STARTED_TEXT.get(int(event["weather"]), "")
 		Gen2Battle.WEATHER_CONTINUES:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -197,6 +197,11 @@ const START_RAIN: StringName = &"startrain"
 const START_SUN: StringName = &"startsun"
 const START_SANDSTORM: StringName = &"startsandstorm"
 
+## Recover, Softboiled, Milk Drink and Rest, and separately the three heals that
+## read the clock. Both refuse at full HP, and both spend the turn doing it.
+const HEAL: StringName = &"heal"
+const TIMED_HEAL: StringName = &"timedheal"
+
 ## Thunder's own accuracy, replacing the move's byte for this turn only: half in
 ## sun, and certain in rain. The rain half is redundant with
 ## [constant CHECK_HIT]'s own always-hits branch, which the cartridge says so
@@ -307,6 +312,21 @@ const RECOIL_DIVISOR: int = 4
 ## What [constant THUNDER_ACCURACY] leaves behind in sun: the cartridge's
 ## `50 percent + 1`, one past the `x * 255 / 100` the rest of the engine uses.
 const THUNDER_SUN_ACCURACY: int = 128
+
+## `.Multipliers`, the four fractions a time-based heal indexes, in its own
+## order. The fourth row is the whole bar and is [method _heal_fraction]'s
+## fallthrough, so it needs no name of its own.
+const HEAL_EIGHTH: int = 0
+const HEAL_QUARTER: int = 1
+const HEAL_HALF: int = 2
+
+## The time of day each of the three asks for: `MORN_F`, `DAY_F` and `NITE_F`,
+## the three labels `BattleCommand_TimeBasedHealContinue` is entered at.
+const HEAL_TIMES: Dictionary = {
+	Gen2MoveEffect.MORNING_SUN: Gen2WorldPalette.TIME_MORNING,
+	Gen2MoveEffect.SYNTHESIS: Gen2WorldPalette.TIME_DAY,
+	Gen2MoveEffect.MOONLIGHT: Gen2WorldPalette.TIME_NIGHT,
+}
 
 ## The two moves a frozen Pokémon can use, which thaw it in the using. Flame
 ## Wheel and Sacred Fire, by move number.
@@ -434,6 +454,10 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_start_weather(turn, Gen2Weather.SUN)
 		START_SANDSTORM:
 			_start_weather(turn, Gen2Weather.SANDSTORM)
+		HEAL:
+			_heal(turn)
+		TIMED_HEAL:
+			_timed_heal(turn)
 		THUNDER_ACCURACY:
 			_thunder_accuracy(turn)
 		SKIP_SUN_CHARGE:
@@ -1375,6 +1399,78 @@ static func _start_weather(turn: Gen2Turn, weather: int) -> void:
 	turn.battle.weather = weather
 	turn.battle.weather_turns = Gen2Weather.TURNS
 	turn.emit(Gen2Battle.WEATHER_STARTED, {"weather": weather})
+
+
+## `BattleCommand_Heal`: Recover, Softboiled and Milk Drink take back half the
+## maximum; Rest takes back all of it and pays for that with two turns asleep.
+##
+## The full-HP refusal is checked before anything else, so Rest at full health
+## fails and stays awake even when there is a status sitting on it that sleeping
+## would have cleared. Rest writes `REST_SLEEP_TURNS + 1` over the whole status
+## byte rather than into the sleep bits, which is why it is the one move that
+## cures a burn or a paralysis, and it clears Toxic's ramp with it.
+static func _heal(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	if attacker.hp >= attacker.max_hp():
+		turn.emit(Gen2Battle.HP_ALREADY_FULL)
+		return
+
+	var is_rest: bool = turn.move_number == Gen2MoveEffect.REST_MOVE
+	if is_rest:
+		var had_status: bool = Gen2Status.is_afflicted(attacker.status)
+		attacker.toxic_counter = 0
+		attacker.status = Gen2Status.REST_SLEEP_TURNS + 1
+		turn.emit(Gen2Battle.RESTED if had_status else Gen2Battle.WENT_TO_SLEEP)
+
+	@warning_ignore("integer_division")
+	var amount: int = attacker.max_hp() if is_rest else maxi(attacker.max_hp() / 2, 1)
+	attacker.heal(amount)
+	turn.emit(Gen2Battle.HP_RESTORED, {
+		"hp": attacker.hp, "max_hp": attacker.max_hp(),
+	})
+
+
+## `BattleCommand_TimeBasedHealContinue`: Morning Sun, Synthesis and Moonlight.
+##
+## Half the maximum by default. One step down the table outside the move's own
+## time of day, which is the cartridge's real rule: matching the clock buys
+## nothing, missing it costs. Then one step up in sun, or one step down in any
+## other weather, so the worst case is an eighth and the best is the whole bar.
+## Link battles skip the time step; there are none here.
+static func _timed_heal(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	if attacker.hp >= attacker.max_hp():
+		turn.emit(Gen2Battle.HP_ALREADY_FULL)
+		return
+
+	var index: int = HEAL_HALF
+	if turn.battle.time_of_day != HEAL_TIMES.get(turn.effect(), Gen2WorldPalette.TIME_DAY):
+		index -= 1
+	if Gen2Weather.is_active(turn.battle.weather):
+		index += 1 if turn.battle.weather == Gen2Weather.SUN else -1
+
+	attacker.heal(_heal_fraction(attacker.max_hp(), index))
+	turn.emit(Gen2Battle.HP_RESTORED, {
+		"hp": attacker.hp, "max_hp": attacker.max_hp(),
+	})
+
+
+## One row of `.Multipliers`. `GetEighthMaxHP` halves `GetQuarterMaxHP`'s answer
+## rather than dividing the maximum by eight, so its own floor of one is applied
+## twice and a two-HP Pokémon is healed for one either way.
+static func _heal_fraction(max_hp: int, index: int) -> int:
+	match index:
+		HEAL_EIGHTH:
+			@warning_ignore("integer_division")
+			return maxi(maxi(max_hp / 4, 1) / 2, 1)
+		HEAL_QUARTER:
+			@warning_ignore("integer_division")
+			return maxi(max_hp / 4, 1)
+		HEAL_HALF:
+			@warning_ignore("integer_division")
+			return maxi(max_hp / 2, 1)
+		_:
+			return max_hp
 
 
 ## Thunder's accuracy for this turn: `50 percent + 1` (128) in sun, and

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -116,6 +116,9 @@ const PETAL_DANCE_MOVE: int = 80
 const OUTRAGE_MOVE: int = 200
 const ROLLOUT_MOVE: int = 205
 const DEFENSE_CURL_MOVE: int = 111
+## Rest, kept here for the same reason Fly and Dig are: four moves share
+## [constant HEAL] and `BattleCommand_Heal` tells this one apart by number.
+const REST_MOVE: int = 156
 
 ## None of the three needs any state this file has not already grown for
 ## something else: [Gen2BattleMon.reset_stages] for Haze,
@@ -142,6 +145,15 @@ const ENCORE: int = 90
 ## and Whirlpool carry the first; Mean Look and Spider Web the second.
 const TRAP_TARGET: int = 42
 const MEAN_LOOK: int = 106
+
+## The heal family. [constant HEAL] is Recover, Softboiled, Milk Drink and Rest
+## sharing `BattleCommand_Heal`; the other three are one command,
+## `BattleCommand_TimeBasedHealContinue`, entered at three different labels that
+## differ only in the time of day they ask for.
+const HEAL: int = 32
+const MORNING_SUN: int = 132
+const SYNTHESIS: int = 133
+const MOONLIGHT: int = 134
 
 ## The three weather moves and the two moves that read the weather back.
 ## [constant SOLARBEAM] is already above, since it was a two-turn move before it
@@ -471,6 +483,28 @@ const TRAP_TARGET_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
 	Gen2EffectCommands.TRAP_TARGET,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## The heal family, the same four-step shape as the weather moves: announce,
+## spend, heal. Neither list rolls accuracy, so the 100% every one of the seven
+## carries is never read. The cartridge's own lists open with `checkobedience`,
+## which this engine does not model and no other list here carries either.
+const HEAL_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.HEAL,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Morning Sun, Synthesis and Moonlight share one list as they share one command:
+## the time of day each wants is read back off the effect byte, the way
+## [constant Gen2EffectCommands.FIXED_DAMAGE] reads which of its four figures it
+## is.
+const TIME_HEAL_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.TIMED_HEAL,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -804,6 +838,10 @@ static func _sequences() -> Dictionary:
 		ENCORE: ENCORE_SEQUENCE,
 		TRAP_TARGET: TRAP_TARGET_SEQUENCE,
 		MEAN_LOOK: MEAN_LOOK_SEQUENCE,
+		HEAL: HEAL_SEQUENCE,
+		MORNING_SUN: TIME_HEAL_SEQUENCE,
+		SYNTHESIS: TIME_HEAL_SEQUENCE,
+		MOONLIGHT: TIME_HEAL_SEQUENCE,
 		RAIN_DANCE: START_RAIN_SEQUENCE,
 		SUNNY_DAY: START_SUN_SEQUENCE,
 		SANDSTORM: START_SANDSTORM_SEQUENCE,
@@ -848,13 +886,14 @@ static func is_written(effect: int) -> bool:
 
 
 ## Effect bytes whose command reads the byte back off the turn to decide what it
-## is: the multi-hit count, the four fixed-damage figures, Rollout's multiplier
-## and Selfdestruct's halved Defense all work that way. Rewriting one would make
-## its own command answer for a list it is no longer in, so these are refused
-## rather than left to fail at the point of use.
+## is: the multi-hit count, the four fixed-damage figures, Rollout's multiplier,
+## Selfdestruct's halved Defense and the three time-based heals' time of day all
+## work that way. Rewriting one would make its own command answer for a list it
+## is no longer in, so these are refused rather than left to fail at the point of
+## use.
 const RESERVED_EFFECTS: Array[int] = [
 	MULTI_HIT, DOUBLE_HIT, TWINEEDLE, SUPER_FANG, STATIC_DAMAGE, LEVEL_DAMAGE,
-	PSYWAVE, ROLLOUT, SELFDESTRUCT,
+	PSYWAVE, ROLLOUT, SELFDESTRUCT, MORNING_SUN, SYNTHESIS, MOONLIGHT,
 ]
 
 

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -34,6 +34,11 @@ const ANY: int = SLEEP_MASK | POISON | BURN | FREEZE | PARALYSIS
 const MIN_SLEEP: int = 2
 const MAX_SLEEP: int = 7
 
+## Rest does not roll: it writes `REST_SLEEP_TURNS + 1`
+## (constants/battle_constants.asm) over the whole byte, so the sleeper loses
+## two turns and every other status goes with it.
+const REST_SLEEP_TURNS: int = 2
+
 ## Burn halves the Attack and paralysis quarters the Speed, both to a minimum of
 ## one, and both are shifts rather than divisions on the hardware.
 const BURN_ATTACK_SHIFT: int = 1

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1078,6 +1078,7 @@ func _start_battle_request(request: Dictionary) -> void:
 	_active_battle_persist = save != null and _injected_save == null
 	var host: Gen2BattleScreen = BATTLE_SCENE.instantiate() as Gen2BattleScreen
 	host.set_data(_data)
+	host.set_time_of_day(time_of_day)
 	if _world != null and not tutorial:
 		host.set_capture_balls(
 			Gen2WorldPartyHost.owned_capture_balls(_world), _world.state.items()

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -146,6 +146,17 @@ const ATTRACT_MOVE: int = 271
 const MIST_MOVE: int = 272
 const FOCUS_ENERGY_MOVE: int = 273
 
+## The heal family at its real move numbers. Rest has to be real, because
+## `BattleCommand_Heal` tells it from the other three by number; the rest are
+## real for company, and all seven fit under [constant MAX_MOVE] already.
+const RECOVER: int = 105
+const SOFTBOILED: int = 135
+const REST: int = 156
+const MILK_DRINK: int = 208
+const MORNING_SUN: int = 234
+const SYNTHESIS: int = 235
+const MOONLIGHT: int = 236
+
 ## The highest move number this table fills. Grown as new moves are added.
 const MAX_MOVE: int = THUNDER_ALWAYS_PARALYZES
 const BERRY_ITEM: int = 0xAD
@@ -409,6 +420,16 @@ static func _moves() -> Array:
 		WRAP: ["WRAP", 15, NORMAL, 216, 20, Gen2MoveEffect.TRAP_TARGET, 0],
 		BIND: ["BIND", 15, NORMAL, 191, 20, Gen2MoveEffect.TRAP_TARGET, 0],
 		MEAN_LOOK: ["MEAN LOOK", 0, NORMAL, 255, 5, Gen2MoveEffect.MEAN_LOOK, 0],
+		# The heal family, real rows: no power, 100% accuracy, and Rest the only
+		# one of the seven that is not Normal or Grass. None of the four lists
+		# rolls accuracy, so the byte is never read.
+		RECOVER: ["RECOVER", 0, NORMAL, 255, 20, Gen2MoveEffect.HEAL, 0],
+		SOFTBOILED: ["SOFTBOILED", 0, NORMAL, 255, 10, Gen2MoveEffect.HEAL, 0],
+		REST: ["REST", 0, PSYCHIC_TYPE, 255, 10, Gen2MoveEffect.HEAL, 0],
+		MILK_DRINK: ["MILK DRINK", 0, NORMAL, 255, 10, Gen2MoveEffect.HEAL, 0],
+		MORNING_SUN: ["MORNING SUN", 0, NORMAL, 255, 5, Gen2MoveEffect.MORNING_SUN, 0],
+		SYNTHESIS: ["SYNTHESIS", 0, GRASS, 255, 5, Gen2MoveEffect.SYNTHESIS, 0],
+		MOONLIGHT: ["MOONLIGHT", 0, NORMAL, 255, 5, Gen2MoveEffect.MOONLIGHT, 0],
 	}
 
 	var out: Array = []

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -476,3 +476,30 @@ func test_smart_binds_a_fresh_target_but_not_on_its_last_legs() -> void:
 		var scores: Array = [Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE]
 		Gen2BattleAI._apply_smart(scores, spent, charmander, _data, _rng, 0, 0, Gen2Weather.NONE)
 		assert_eq(int(scores[0]), Gen2BattleAI.DEFAULT_SCORE, "nothing to hold it there with")
+
+
+## `AI_Smart_Heal`, which the three time-based heals are labels on too: the AI
+## reads its own health, and a healthy AI would rather attack.
+func test_smart_heal_is_discouraged_while_the_ai_is_healthy() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.RECOVER, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
+		)
+		assert_eq(slot, 1, "healing a full bar is wasted")
+
+
+## Below a quarter it is greatly encouraged nine times in ten, which is enough
+## to win against a plain attack on most seeds.
+func test_smart_heal_is_encouraged_once_the_ai_is_nearly_out() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MORNING_SUN, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var chose_heal: int = 0
+	for seed: int in 20:
+		_rng.seed = seed
+		pikachu.hp = 1
+		if Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_SMART, _rng) == 0:
+			chose_heal += 1
+	assert_gt(chose_heal, 10, "the 90% branch should dominate twenty seeds")

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -2189,3 +2189,27 @@ func test_the_between_turn_items_do_not_agree_on_an_order() -> void:
 	)
 	assert_eq(berries.size(), 2)
 	assert_eq(int(berries[0]["side"]), Gen2Battle.ENEMY, "the healing items go the other way")
+
+
+## The heal family through a whole turn rather than a bare command: Recover
+## reaches the caller's event list with the numbers a screen draws from.
+func test_recover_reaches_the_turn_loop_with_the_numbers_a_screen_needs() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.RECOVER])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])
+	var battle: Gen2Battle = _battle(pikachu, geodude)
+	pikachu.hp = 1
+
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+	)
+
+	var restored: Dictionary = _first(events, Gen2Battle.HP_RESTORED)
+	assert_false(restored.is_empty(), JSON.stringify(events))
+	assert_eq(int(restored["side"]), Gen2Battle.PLAYER)
+	assert_eq(int(restored["max_hp"]), pikachu.max_hp())
+	# The event carries what the bar read at the moment of the heal, not what is
+	# left at the end of the turn: Pikachu is the faster of the two, so Geodude's
+	# attack lands after this and takes some of it straight back.
+	@warning_ignore("integer_division")
+	assert_eq(int(restored["hp"]), 1 + pikachu.max_hp() / 2)
+	assert_lt(pikachu.hp, int(restored["hp"]))

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -1632,3 +1632,204 @@ func test_a_focus_band_changes_nothing_about_a_hit_that_was_not_lethal() -> void
 		Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
 		assert_eq(battle.enemy.hp, before - 5)
 		assert_true(_first(turn.events, Gen2Battle.ENDURED).is_empty())
+
+
+## The heal family. `BattleCommand_Heal` for the four that just heal, and
+## `BattleCommand_TimeBasedHealContinue` for the three that read the clock and
+## the sky.
+func test_recover_takes_back_half_the_maximum() -> void:
+	var battle: Gen2Battle = _battle()
+	var mon: Gen2BattleMon = battle.player
+	mon.hp = 1
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.RECOVER)
+
+	@warning_ignore("integer_division")
+	assert_eq(mon.hp, 1 + mon.max_hp() / 2)
+	assert_false(_first(turn.events, Gen2Battle.HP_RESTORED).is_empty())
+
+
+func test_a_heal_at_full_health_fails_and_costs_the_turn() -> void:
+	var battle: Gen2Battle = _battle()
+	var mon: Gen2BattleMon = battle.player
+	var before: int = mon.hp
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.SOFTBOILED)
+
+	assert_eq(mon.hp, before)
+	assert_false(_first(turn.events, Gen2Battle.HP_ALREADY_FULL).is_empty())
+	assert_true(_first(turn.events, Gen2Battle.HP_RESTORED).is_empty())
+
+
+## Rest is the whole bar rather than half, which is what the move number buys:
+## the other three moves on this effect byte run the same command.
+func test_rest_fills_the_bar_where_milk_drink_takes_half() -> void:
+	var rested: Gen2Battle = _battle()
+	rested.player.hp = 1
+	var sleeping: Gen2Turn = _run_move(rested, Fixture.REST)
+
+	assert_eq(rested.player.hp, rested.player.max_hp())
+	assert_eq(Gen2Status.sleep_turns(rested.player.status), Gen2Status.REST_SLEEP_TURNS + 1)
+	assert_false(_first(sleeping.events, Gen2Battle.WENT_TO_SLEEP).is_empty())
+
+	var milk: Gen2Battle = _battle()
+	milk.player.hp = 1
+
+	_run_move(milk, Fixture.MILK_DRINK)
+
+	@warning_ignore("integer_division")
+	assert_eq(milk.player.hp, 1 + milk.player.max_hp() / 2)
+	assert_eq(Gen2Status.sleep_turns(milk.player.status), 0, "only Rest sleeps")
+
+
+## Rest writes its counter over the whole status byte, so it is the one move in
+## the game that cures a burn, and it clears Toxic's ramp with it.
+func test_rest_clears_every_other_status_and_the_toxic_ramp() -> void:
+	var battle: Gen2Battle = _battle()
+	var mon: Gen2BattleMon = battle.player
+	mon.hp = 1
+	mon.status = Gen2Status.POISON
+	mon.toxic_counter = 4
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.REST)
+
+	assert_false(Gen2Status.has(mon.status, Gen2Status.POISON))
+	assert_eq(mon.toxic_counter, 0)
+	assert_eq(Gen2Status.sleep_turns(mon.status), Gen2Status.REST_SLEEP_TURNS + 1)
+	# "fell asleep and became healthy" rather than "went to sleep", chosen on
+	# whether there was a status to clear.
+	assert_false(_first(turn.events, Gen2Battle.RESTED).is_empty())
+	assert_true(_first(turn.events, Gen2Battle.WENT_TO_SLEEP).is_empty())
+
+
+## The full-HP refusal is checked before the Rest branch, so a burned Pokémon at
+## full health neither sleeps nor loses the burn.
+func test_rest_at_full_health_fails_without_sleeping() -> void:
+	var battle: Gen2Battle = _battle()
+	var mon: Gen2BattleMon = battle.player
+	mon.status = Gen2Status.BURN
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.REST)
+
+	assert_eq(mon.status, Gen2Status.BURN, "the burn survives")
+	assert_eq(Gen2Status.sleep_turns(mon.status), 0)
+	assert_false(_first(turn.events, Gen2Battle.HP_ALREADY_FULL).is_empty())
+
+
+## Half by default, and matching the move's own time of day buys nothing: it is
+## missing it that costs a step. `BattleCommand_TimeBasedHealContinue` skips its
+## `dec c` when `wTimeOfDay` equals the label's own `MORN_F`/`DAY_F`/`NITE_F`.
+func test_a_timed_heal_is_half_in_its_own_time_and_a_quarter_outside_it() -> void:
+	var morning: Gen2Battle = _battle()
+	morning.time_of_day = Gen2WorldPalette.TIME_MORNING
+	morning.player.hp = 1
+
+	_run_move(morning, Fixture.MORNING_SUN)
+
+	@warning_ignore("integer_division")
+	assert_eq(morning.player.hp, 1 + morning.player.max_hp() / 2)
+
+	var midday: Gen2Battle = _battle()
+	midday.time_of_day = Gen2WorldPalette.TIME_DAY
+	midday.player.hp = 1
+
+	_run_move(midday, Fixture.MORNING_SUN)
+
+	@warning_ignore("integer_division")
+	assert_eq(midday.player.hp, 1 + midday.player.max_hp() / 4)
+
+
+## Synthesis asks for the day and Moonlight for the night, which is the only
+## thing separating the three moves.
+func test_synthesis_and_moonlight_ask_for_their_own_times() -> void:
+	var day: Gen2Battle = _battle()
+	day.time_of_day = Gen2WorldPalette.TIME_DAY
+	day.player.hp = 1
+
+	_run_move(day, Fixture.SYNTHESIS)
+
+	@warning_ignore("integer_division")
+	assert_eq(day.player.hp, 1 + day.player.max_hp() / 2)
+
+	var night: Gen2Battle = _battle()
+	night.time_of_day = Gen2WorldPalette.TIME_NIGHT
+	night.player.hp = 1
+
+	_run_move(night, Fixture.MOONLIGHT)
+
+	@warning_ignore("integer_division")
+	assert_eq(night.player.hp, 1 + night.player.max_hp() / 2)
+
+
+## Sun is one step up the table and any other weather one step down, never two:
+## `.Weather` increments first and only then takes two off for a sky that is not
+## the sun.
+func test_sun_doubles_a_timed_heal_and_rain_or_sand_halves_it() -> void:
+	var sunny: Gen2Battle = _battle()
+	sunny.time_of_day = Gen2WorldPalette.TIME_MORNING
+	sunny.weather = Gen2Weather.SUN
+	sunny.player.hp = 1
+
+	_run_move(sunny, Fixture.MORNING_SUN)
+
+	assert_eq(sunny.player.hp, sunny.player.max_hp(), "the whole bar")
+
+	for weather: int in [Gen2Weather.RAIN, Gen2Weather.SANDSTORM]:
+		var battle: Gen2Battle = _battle()
+		battle.time_of_day = Gen2WorldPalette.TIME_MORNING
+		battle.weather = weather
+		battle.player.hp = 1
+
+		_run_move(battle, Fixture.MORNING_SUN)
+
+		@warning_ignore("integer_division")
+		assert_eq(battle.player.hp, 1 + battle.player.max_hp() / 4, str(weather))
+
+
+## The floor of the table, reached only by missing both the time and the sun.
+func test_the_wrong_time_in_the_rain_heals_an_eighth() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.time_of_day = Gen2WorldPalette.TIME_NIGHT
+	battle.weather = Gen2Weather.RAIN
+	battle.player.hp = 1
+
+	_run_move(battle, Fixture.MORNING_SUN)
+
+	@warning_ignore("integer_division")
+	assert_eq(battle.player.hp, 1 + maxi(battle.player.max_hp() / 4, 1) / 2)
+
+
+## `GetEighthMaxHP` halves `GetQuarterMaxHP`'s answer rather than dividing by
+## eight, and both apply their own floor of one, so the smallest heal in the game
+## is still one hit point.
+func test_the_smallest_timed_heal_is_still_one_hit_point() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.time_of_day = Gen2WorldPalette.TIME_NIGHT
+	battle.weather = Gen2Weather.RAIN
+	battle.player.stats["hp"] = 2
+	battle.player.hp = 1
+
+	_run_move(battle, Fixture.MORNING_SUN)
+
+	assert_eq(battle.player.hp, 2)
+
+
+func test_a_timed_heal_at_full_health_fails() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.time_of_day = Gen2WorldPalette.TIME_MORNING
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.MORNING_SUN)
+
+	assert_eq(battle.player.hp, battle.player.max_hp())
+	assert_false(_first(turn.events, Gen2Battle.HP_ALREADY_FULL).is_empty())
+
+
+func test_the_heal_family_has_its_cartridge_sequences() -> void:
+	for effect: int in [
+		Gen2MoveEffect.HEAL, Gen2MoveEffect.MORNING_SUN,
+		Gen2MoveEffect.SYNTHESIS, Gen2MoveEffect.MOONLIGHT,
+	]:
+		assert_true(Gen2MoveEffect.is_written(effect), str(effect))
+		# Announce, spend, heal, end: no accuracy roll, and no obedience check,
+		# which this engine does not model on any list.
+		assert_eq(Gen2MoveEffect.sequence_for(effect).size(), 4, str(effect))


### PR DESCRIPTION
Recover, Softboiled, Milk Drink and Rest take back half the bar, or all of it for Rest, which sleeps for two turns and shrugs off everything else it was carrying. Morning Sun, Synthesis and Moonlight ask the overworld clock and the sky first: half by default, a quarter outside their own time of day, a step up in sun and a step down in any other weather.

A heal at full health still costs the turn, and Rest refuses before it sleeps, so a burned Pokemon at full health keeps its burn. The AI heals when it is nearly out and attacks when it is not.