### PR TITLE
Split the spoils properly, and cut the bench in on them

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -95,9 +95,10 @@ const OVER: StringName = &"over"
 ## reads the player's party structure, so a trainer's Pokémon are the reason for
 ## this, never the recipient.
 const EXP_GAINED: StringName = &"exp_gained"
-## The five stats in [constant Gen2Experience.STAT_EXP_KEYS], split among
-## [constant Gen2Battle] participants the way [method Gen2Experience.stat_exp_gain]
-## splits them, none of it the same number as [constant EXP_GAINED].
+## The five stats in [constant Gen2Experience.STAT_EXP_KEYS], out of the same
+## divided block [constant EXP_GAINED]'s award came from: see
+## [method Gen2Experience.shared_block]. Divided by the same count, but a base
+## stat rather than a figure the level formula has been through.
 const STAT_EXP_GAINED: StringName = &"stat_exp_gained"
 ## A level gained from the experience just awarded. [code]old_stats[/code] and
 ## [code]new_stats[/code] are both [Gen2BattleMon.stats], so a screen can show
@@ -1021,34 +1022,72 @@ func _award_experience(events: Array) -> void:
 			_give_experience_for(mon(ENEMY), events)
 
 
-## Splits the exp and the stat exp [param defeated] is worth among every
-## [constant PLAYER] party index that has fought since it was sent in, then
-## resets that set to whoever is left standing: the next enemy Pokémon, if the
-## trainer has one, starts its own participant count fresh.
+## Splits what [param defeated] is worth between everyone owed a share, then
+## resets the participant set to whoever is left standing: the next enemy
+## Pokémon, if the trainer has one, starts its own participant count fresh.
+##
+## `UpdateFaintedPlayerMon` awards in two passes when anything alive is holding
+## an Exp. Share. The block is halved once, then that same halved block is split
+## among the participants, and split again among the holders, so each group
+## divides half of it. A Pokémon that both fought and holds one is in both
+## passes and is awarded twice.
 func _give_experience_for(defeated: Gen2BattleMon, events: Array) -> void:
 	var participants: Array = (_participants[PLAYER] as Dictionary).keys()
-	if not participants.is_empty():
-		var award: int = Gen2Experience.award_for(
-			defeated.level, defeated.base_exp(), is_trainer_battle
-		)
-		var stat_gains: Dictionary = Gen2Experience.stat_exp_gain(
-			defeated.base_stat_exp_shape(), participants.size()
-		)
-		for index: int in participants:
-			var learner: Gen2BattleMon = party(PLAYER).at(int(index))
-			if learner != null and not learner.is_fainted():
-				_give_experience_to(learner, int(index), award, stat_gains, events)
+	var holders: Array = _exp_share_holders()
+	var halved: bool = not holders.is_empty()
+
+	_award_share(defeated, participants, halved, false, events)
+	_award_share(defeated, holders, halved, true, events)
 
 	_participants[PLAYER] = {party(PLAYER).active: true}
 
 
+## One of the two passes: the block divided among [param recipients], then handed
+## to each of them that is still standing.
+func _award_share(
+	defeated: Gen2BattleMon, recipients: Array, halved: bool, by_exp_share: bool, events: Array
+) -> void:
+	if recipients.is_empty():
+		return
+	var block: Dictionary = Gen2Experience.shared_block(
+		defeated.base_stat_exp_shape(), defeated.base_exp(), halved, recipients.size()
+	)
+	var award: int = Gen2Experience.award_for(
+		defeated.level, int(block["base_exp"]), is_trainer_battle
+	)
+	var stat_gains: Dictionary = block["stats"]
+	for index: int in recipients:
+		var learner: Gen2BattleMon = party(PLAYER).at(int(index))
+		if learner != null and not learner.is_fainted():
+			_give_experience_to(learner, int(index), award, stat_gains, by_exp_share, events)
+
+
+## `IsAnyMonHoldingExpShare`: every living party index carrying one, in party
+## order. A fainted holder is skipped and does not count towards the split, the
+## same test the routine makes before it looks at the item at all.
+func _exp_share_holders() -> Array:
+	var out: Array = []
+	var party_side: Gen2Party = party(PLAYER)
+	for index: int in party_side.size():
+		var member: Gen2BattleMon = party_side.at(index)
+		if member != null and not member.is_fainted() \
+				and member.item == Gen2Experience.EXP_SHARE_ITEM:
+			out.append(index)
+	return out
+
+
 func _give_experience_to(
-	learner: Gen2BattleMon, index: int, award: int, stat_gains: Dictionary, events: Array
+	learner: Gen2BattleMon, index: int, award: int, stat_gains: Dictionary,
+	by_exp_share: bool, events: Array
 ) -> void:
 	learner.gain_exp(award)
 	events.append({
 		"type": EXP_GAINED, "side": PLAYER, "index": index,
 		"species": learner.species, "amount": award, "exp": learner.exp,
+		# Which of the two passes this came from. The cartridge prints the same
+		# line either way; this is here so a Pokémon that is in both passes can
+		# be told apart from one awarded twice for any other reason.
+		"exp_share": by_exp_share,
 	})
 
 	learner.gain_stat_exp(stat_gains)

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -325,7 +325,7 @@ func base_exp() -> int:
 	return int(data.species(species).get("base_exp", 0))
 
 
-## The five base stats [Gen2Experience.stat_exp_gain] wants when this Pokémon is
+## The five base stats [Gen2Experience.shared_block] wants when this Pokémon is
 ## the one fainting, keyed like [member stat_exp]. Special Attack's base value
 ## fills the shared [code]"special"[/code] slot, never Special Defense's: see
 ## [constant Gen2Experience.STAT_EXP_KEYS].

--- a/game/battle/experience.gd
+++ b/game/battle/experience.gd
@@ -52,11 +52,16 @@ const MAX_EXP: int = 0xFFFFFF
 ## [code]"special"[/code] entry rather than two.
 const STAT_EXP_KEYS: Array = ["hp", "attack", "defense", "speed", "special"]
 
-## Awarding exp divides a base stat by the participant count, and the
-## cartridge's own routine skips the division outright rather than dividing by
-## one, which matters because the division truncates: a single participant
-## keeps the whole base stat rather than losing a remainder to the floor.
+## Awarding exp divides the block by the recipient count, and the cartridge's
+## own routine skips the division outright rather than dividing by one, which
+## matters because the division truncates: a single recipient keeps the whole
+## byte rather than losing a remainder to the floor.
 const MIN_PARTICIPANTS_TO_SPLIT: int = 2
+
+## Exp. Share, checked by item number rather than by held effect, the way
+## `IsAnyMonHoldingExpShare` checks it and the way Thick Club and Light Ball are
+## checked in [Gen2HeldItem]. It carries no `ITEMATTR_EFFECT` at all.
+const EXP_SHARE_ITEM: int = 39
 
 ## A trainer battle multiplies the award by 1.5, truncating, computed as
 ## [code]value + floor(value / 2)[/code] rather than multiply-by-3-divide-by-2:
@@ -107,12 +112,15 @@ static func level_for_exp(growth_rate: int, experience_points: int) -> int:
 
 
 ## What a Pokémon of [param defeated_level] and [param defeated_base_exp] is
-## worth, before it is split among anyone: [code]floor(base_exp * level / 7)[/code],
-## then a trainer battle's own 1.5x on top.
+## worth to one recipient: [code]floor(base_exp * level / 7)[/code], then a
+## trainer battle's own 1.5x on top.
 ##
-## Not divided by participant count: that is the stat experience's rule.
-## [code]GiveExperiencePoints[/code] hands every participant this full figure and
-## only divides the *base stats* feeding [method stat_exp_gain].
+## [param defeated_base_exp] is the base experience *after*
+## [method shared_block] has divided it. The split is not a separate step
+## applied to the award: `wEnemyMonBaseExp` sits inside the same seven-byte block
+## as the base stats and `.EvenlyDivideExpAmongParticipants` divides all of it in
+## one loop, before `GiveExperiencePoints` reads the byte back. Dividing the
+## award instead would truncate in the wrong place.
 static func award_for(defeated_level: int, defeated_base_exp: int, is_trainer_battle: bool) -> int:
 	@warning_ignore("integer_division")
 	var award: int = (defeated_base_exp * defeated_level) / 7
@@ -135,12 +143,43 @@ static func _boost(value: int) -> int:
 ## [param participants], each share truncated on its own rather than the total
 ## truncated once: the cartridge divides per stat, not once combined.
 static func stat_exp_gain(defeated_stats: Dictionary, participants: int) -> Dictionary:
-	var count: int = maxi(participants, 1)
-	var out: Dictionary = {}
+	return shared_block(defeated_stats, 0, false, participants)["stats"]
+
+
+## The seven-byte block `wEnemyMonBaseStats` to `wEnemyMonEnd`, shared out.
+##
+## The five base stats and the base experience live in one run of bytes and are
+## always divided together, in one loop, which is why this answers for both at
+## once rather than leaving the award to be divided separately afterwards. The
+## catch rate is the seventh byte and is divided with them; nothing reads it
+## after a faint, so it is not carried here.
+##
+## [param halved] is the Exp. Share pass of `UpdateFaintedPlayerMon`: every byte
+## is halved before any division, once, however many holders there are, and
+## whether or not this particular share is the holders' one. [param recipients]
+## is how many mons this block is being split between, and a lone recipient
+## skips the division rather than dividing by one.
+static func shared_block(
+	defeated_stats: Dictionary, defeated_base_exp: int, halved: bool, recipients: int
+) -> Dictionary:
+	var stats: Dictionary = {}
 	for key: String in STAT_EXP_KEYS:
-		var base: int = int(defeated_stats.get(key, 0))
-		if count >= MIN_PARTICIPANTS_TO_SPLIT:
-			@warning_ignore("integer_division")
-			base = base / count
-		out[key] = base
-	return out
+		stats[key] = _shared_byte(int(defeated_stats.get(key, 0)), halved, recipients)
+	return {
+		"stats": stats,
+		"base_exp": _shared_byte(defeated_base_exp, halved, recipients),
+	}
+
+
+## One byte of the block: halved for Exp. Share, then divided among however many
+## are sharing it, each truncating on its own.
+static func _shared_byte(value: int, halved: bool, recipients: int) -> int:
+	var byte: int = value
+	if halved:
+		@warning_ignore("integer_division")
+		byte = byte / 2
+	var count: int = maxi(recipients, 1)
+	if count >= MIN_PARTICIPANTS_TO_SPLIT:
+		@warning_ignore("integer_division")
+		byte = byte / count
+	return byte

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -188,6 +188,11 @@ const PSNCUREBERRY: int = 74
 const MIRACLEBERRY: int = 109
 const BITTER_BERRY: int = 83
 
+## Exp. Share, at its real number. It carries no held effect at all: the routine
+## that finds it checks the item number, so the default row is the whole of what
+## the fixture needs.
+const EXP_SHARE: int = 39
+
 ## Gender ratios, the published bytes: `x percent = floor(x * 255 / 100)`, so a
 ## species' own ratio here can be checked against pret's own base stats rather
 ## than against this file. Bulbasaur and Charmander are really 12.5% female;

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -905,10 +905,14 @@ func test_a_trainer_battle_adds_the_experience_bonus() -> void:
 	assert_eq(_first(events, Gen2Battle.EXP_GAINED)["amount"], 67)
 
 
-func test_experience_is_not_divided_among_participants_but_stat_experience_is() -> void:
-	# Geodude, base exp 86, at level 20: floor(86*20/7) = 245, the same number
-	# for every participant. Its own base stats (40/80/100/20/30), split two
-	# ways, truncated per stat, are the only thing that divides.
+## Base experience is the seventh byte of the same block as the base stats, and
+## `.EvenlyDivideExpAmongParticipants` divides the whole block in one loop before
+## `GiveExperiencePoints` reads any of it. So the award divides too, and it
+## divides at the base-exp byte rather than at the finished figure.
+func test_experience_and_stat_experience_both_divide_among_participants() -> void:
+	# Geodude, base exp 86, at level 20, two participants: the byte becomes
+	# floor(86/2) = 43, and the award is floor(43*20/7) = 122. Its own base stats
+	# (40/80/100/20/30) are split the same two ways in the same loop.
 	var battle: Gen2Battle = Gen2Battle.create_parties(
 		_data,
 		Gen2Party.create([
@@ -923,7 +927,8 @@ func test_experience_is_not_divided_among_participants_but_stat_experience_is() 
 	var gains: Array = _of_type(events, Gen2Battle.EXP_GAINED)
 	assert_eq(gains.size(), 2, "both the lead and the one switched in")
 	for gain: Dictionary in gains:
-		assert_eq(gain["amount"], 245, "full, unsplit, for every participant")
+		assert_eq(gain["amount"], 122, "half the base exp byte, then the formula")
+		assert_false(bool(gain["exp_share"]), "earned by fighting, not by holding")
 
 	var stat_gains: Array = _of_type(events, Gen2Battle.STAT_EXP_GAINED)
 	assert_eq(stat_gains.size(), 2)
@@ -2213,3 +2218,125 @@ func test_recover_reaches_the_turn_loop_with_the_numbers_a_screen_needs() -> voi
 	@warning_ignore("integer_division")
 	assert_eq(int(restored["hp"]), 1 + pikachu.max_hp() / 2)
 	assert_lt(pikachu.hp, int(restored["hp"]))
+
+
+## Exp. Share. `UpdateFaintedPlayerMon` halves the block once, then splits that
+## halved block among the participants and again among the holders, so each
+## group is dividing half of it.
+func test_an_exp_share_halves_the_fighters_award_and_pays_the_bench() -> void:
+	# Bulbasaur, base exp 64, at level 5. Halved: floor(64/2) = 32, one
+	# participant and one holder, so neither pass divides again. The award each
+	# way is floor(32*5/7) = 22, against the 45 an unshared faint pays.
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 100, [Fixture.THUNDERBOLT]),
+			_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE])), _rng
+	)
+	battle.party(Gen2Battle.PLAYER).at(1).item = Fixture.EXP_SHARE
+
+	var gains: Array = _of_type(battle.take_turn(0, 0), Gen2Battle.EXP_GAINED)
+
+	assert_eq(gains.size(), 2, "the fighter and the holder")
+	assert_eq(gains[0]["index"], 0)
+	assert_eq(gains[0]["amount"], 22, "half of what it would have earned alone")
+	assert_false(bool(gains[0]["exp_share"]))
+	assert_eq(gains[1]["index"], 1)
+	assert_eq(gains[1]["amount"], 22)
+	assert_true(bool(gains[1]["exp_share"]), "earned by holding")
+
+
+## A Pokémon that both fought and holds one is in both passes, and the cartridge
+## awards it twice rather than merging the two shares.
+func test_a_fighter_holding_the_exp_share_is_paid_by_both_passes() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 100, [Fixture.THUNDERBOLT]),
+		_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE])
+	)
+	battle.player.item = Fixture.EXP_SHARE
+	var before: int = battle.player.exp
+
+	var gains: Array = _of_type(battle.take_turn(0, 0), Gen2Battle.EXP_GAINED)
+
+	assert_eq(gains.size(), 2, "once for fighting and once for holding")
+	assert_eq(gains[0]["amount"], 22)
+	assert_eq(gains[1]["amount"], 22)
+	assert_false(bool(gains[0]["exp_share"]))
+	assert_true(bool(gains[1]["exp_share"]))
+	# Two halves back to a whole, which is not the same as never having halved:
+	# 22 + 22 is 44, one short of the 45 a lone unshared winner takes.
+	assert_eq(battle.player.exp - before, 44)
+
+
+## `IsAnyMonHoldingExpShare` checks HP before it looks at the item, so a fainted
+## holder neither collects nor counts towards the split, and with no living
+## holder left nothing is halved at all.
+func test_a_fainted_exp_share_holder_neither_collects_nor_halves() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 100, [Fixture.THUNDERBOLT]),
+			_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE])), _rng
+	)
+	var bench: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	bench.item = Fixture.EXP_SHARE
+	bench.hp = 0
+
+	var gains: Array = _of_type(battle.take_turn(0, 0), Gen2Battle.EXP_GAINED)
+
+	assert_eq(gains.size(), 1, "only the fighter")
+	assert_eq(gains[0]["amount"], 45, "the full award, nothing halved")
+
+
+## Two holders split the halved block between them, on top of the participants
+## splitting their own copy of it.
+func test_two_exp_share_holders_split_their_half() -> void:
+	# Geodude, base exp 86, at level 20. Halved: 43. One participant takes it
+	# whole, floor(43*20/7) = 122; two holders take floor(43/2) = 21 each, which
+	# is floor(21*20/7) = 60.
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 100, [Fixture.TACKLE]),
+			_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+			_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])), _rng
+	)
+	battle.party(Gen2Battle.PLAYER).at(1).item = Fixture.EXP_SHARE
+	battle.party(Gen2Battle.PLAYER).at(2).item = Fixture.EXP_SHARE
+	battle.enemy.hp = 1
+
+	var gains: Array = _of_type(battle.take_turn(0, 0), Gen2Battle.EXP_GAINED)
+
+	assert_eq(gains.size(), 3)
+	assert_eq(gains[0]["amount"], 122, "the lone participant, on the halved block")
+	assert_eq(gains[1]["amount"], 60)
+	assert_eq(gains[2]["amount"], 60)
+
+
+## The stat experience rides the same seven bytes, so it is halved and split by
+## exactly the same arithmetic.
+func test_an_exp_share_halves_the_stat_experience_too() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 100, [Fixture.THUNDERBOLT]),
+			_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE])), _rng
+	)
+	battle.party(Gen2Battle.PLAYER).at(1).item = Fixture.EXP_SHARE
+
+	var stat_gains: Array = _of_type(battle.take_turn(0, 0), Gen2Battle.STAT_EXP_GAINED)
+
+	assert_eq(stat_gains.size(), 2)
+	for gain: Dictionary in stat_gains:
+		# Bulbasaur's 45/49/49/45/65, each byte halved on its own.
+		assert_eq(gain["gains"], {
+			"hp": 22, "attack": 24, "defense": 24, "speed": 22, "special": 32,
+		})

--- a/tests/unit/test_experience.gd
+++ b/tests/unit/test_experience.gd
@@ -114,3 +114,46 @@ func test_stat_exp_split_truncates_per_stat_not_on_the_total() -> void:
 	assert_eq(out["hp"], 15)
 	assert_eq(out["attack"], 16, "49 / 3 truncated")
 	assert_eq(out["special"], 21, "65 / 3 truncated")
+
+
+## The block is the five base stats and the base experience together, because
+## the cartridge keeps them in one run of bytes and divides all of them in one
+## loop before reading any of them back.
+func test_the_shared_block_divides_base_exp_alongside_the_base_stats() -> void:
+	var defeated: Dictionary = {
+		"hp": 45, "attack": 49, "defense": 49, "speed": 45, "special": 65,
+	}
+
+	var alone: Dictionary = Gen2Experience.shared_block(defeated, 64, false, 1)
+	assert_eq(alone["base_exp"], 64, "one recipient skips the division entirely")
+	assert_eq(alone["stats"], defeated)
+
+	var split: Dictionary = Gen2Experience.shared_block(defeated, 64, false, 3)
+	assert_eq(split["base_exp"], 21, "64 / 3 truncated")
+	assert_eq(split["stats"]["attack"], 16)
+
+
+## Exp. Share halves every byte once, before any division, and the halving
+## truncates on its own so it is not the same as dividing by twice as many.
+func test_halving_for_an_exp_share_truncates_before_the_split() -> void:
+	var defeated: Dictionary = {
+		"hp": 45, "attack": 49, "defense": 49, "speed": 45, "special": 65,
+	}
+
+	var halved: Dictionary = Gen2Experience.shared_block(defeated, 65, true, 1)
+	assert_eq(halved["base_exp"], 32, "65 / 2 truncated")
+	assert_eq(halved["stats"]["attack"], 24, "49 / 2 truncated")
+
+	var halved_and_split: Dictionary = Gen2Experience.shared_block(defeated, 65, true, 2)
+	assert_eq(halved_and_split["base_exp"], 16, "floor(floor(65/2)/2)")
+	assert_eq(halved_and_split["stats"]["special"], 16)
+
+
+func test_stat_exp_gain_still_answers_for_the_stats_alone() -> void:
+	var defeated: Dictionary = {
+		"hp": 40, "attack": 45, "defense": 40, "speed": 56, "special": 35,
+	}
+	assert_eq(
+		Gen2Experience.stat_exp_gain(defeated, 2),
+		Gen2Experience.shared_block(defeated, 0, false, 2)["stats"]
+	)


### PR DESCRIPTION
Base experience sits in the same seven bytes as the base stats, and the cartridge divides the whole run in one loop before it reads any of it. So the award was never the flat figure this gave every participant: two fighters take half each, and the split lands on the base EXP byte rather than on the finished number.

Exp. Share rides the same block. Anything alive holding one halves it, the fighters share that half and the holders share it again, so a benched Pokemon earns without stepping out and a fighter carrying one is paid by both passes.