### PR TITLE
Make the dark caves dark, and give Flash something to do

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -106,6 +106,7 @@ var _pending_strength: Dictionary = {}
 ## The same for Waterfall, held while Script_UsedWaterfall shows its text. It
 ## names the faced cell, so it is cleared with the loaded map like the rest.
 var _pending_waterfall: Dictionary = {}
+var _pending_flash: Dictionary = {}
 var _command_queues: Dictionary = {}
 var _next_command_queue_id: int = 0
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
@@ -869,6 +870,69 @@ func complete_waterfall() -> Dictionary:
 
 static func _waterfall_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"waterfall_failed", "reason": reason}
+
+
+## engine/events/overworld.asm's FlashFunction .CheckUseFlash, staged the way the
+## other five are.
+##
+## Flash is the one field move that checks no tile at all. Its whole test is the
+## badge and then whether this map is a dark one, which is the map header's own
+## palette byte rather than anything under the player. The Aerodactyl chamber's
+## `SpecialAerodactylChamber` branch, which lets Flash be used in a lit room
+## there, is a Ruins of Alph puzzle that is not implemented, so the palette is
+## the only way through here.
+func flash_request() -> Dictionary:
+	if current_map == null:
+		return _flash_failure(&"missing_map")
+	if not _pending_flash.is_empty():
+		return _flash_failure(&"flash_in_progress")
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_FLASH) < 0:
+		return _flash_failure(&"move_not_known")
+	## The badge is checked before the map, so a player without it is told about
+	## the badge even standing in the dark.
+	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_ZEPHYR, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return _flash_failure(&"badge_required")
+	if not Gen2WorldPalette.is_dark(current_map.palette):
+		return _flash_failure(&"not_dark")
+	if state.used_flash():
+		return _flash_failure(&"already_lit")
+	_pending_flash = {
+		"ok": true,
+		"kind": &"flash_requested",
+		"move": Gen2WorldFieldMove.MOVE_FLASH,
+	}
+	return _pending_flash.duplicate(true)
+
+
+## Empty until flash_request() succeeds. A host shows its text while this is set.
+func pending_flash() -> Dictionary:
+	return _pending_flash.duplicate(true)
+
+
+## `BlindingFlash`, which Script_UseFlash reaches only after its text: the flag
+## goes on and every palette the map draws with changes with it.
+func complete_flash() -> Dictionary:
+	if _pending_flash.is_empty():
+		return _flash_failure(&"no_pending_flash")
+	_pending_flash = {}
+	state.set_used_flash(true)
+	return {"ok": true, "kind": &"flash_used", "time_of_day": map_time_of_day()}
+
+
+static func _flash_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"flash_failed", "reason": reason}
+
+
+## Which palette row the current map draws with, once its own header byte, the
+## clock and the Flash flag have all had their say.
+func map_time_of_day() -> int:
+	if current_map == null:
+		return Gen2WorldPalette.TIME_MORNING
+	return Gen2WorldPalette.map_time_of_day(
+		current_map.palette, object_time_of_day, state.used_flash()
+	)
 
 
 ## engine/events/overworld.asm's StrengthFunction .TryStrength, staged the way
@@ -3564,6 +3628,9 @@ func _apply_map(
 	_object_position_overrides.clear()
 	_object_facing_overrides.clear()
 	state.reset_map_reload_flags()
+	# ResetFlashIfOutOfCave, which runs in map setup: stepping out into a route
+	# or a town puts the light out, and a cave to cave doorway does not.
+	state.clear_flash_if_outdoors(target_map.environment)
 	current_map = target_map
 	current_tileset = target_tileset
 	player_cell = _clamp_cell(target_cell)

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -4,10 +4,12 @@ extends RefCounted
 ## Scene-free tables and gates for the overworld field moves
 ## (engine/events/overworld.asm).
 ##
-## Cut, Surf, Strength and Whirlpool are resolved here. Cut, Surf and Whirlpool
-## follow the shape CutFunction defines: check the badge, then check the faced
-## tile, then stage a change the text acknowledge commits. Strength is the odd
-## one, see BADGE_PLAIN. Flash and Headbutt are not resolved yet.
+## Cut, Surf, Strength, Whirlpool, Waterfall and Flash are resolved here. Cut,
+## Surf and Whirlpool follow the shape CutFunction defines: check the badge, then
+## check the faced tile, then stage a change the text acknowledge commits.
+## Strength is the odd one, see BADGE_PLAIN; Flash checks the map rather than a
+## tile, see [method Gen2WorldPalette.is_dark]. Headbutt is not resolved yet: it
+## needs treemon encounter data the importer does not read.
 
 ## constants/move_constants.asm, whose comment column is hex. The submenu, not
 ## CutFunction, SurfFunction or WhirlpoolFunction, is what checks a party Pokemon
@@ -17,6 +19,7 @@ const MOVE_SURF: int = 0x39
 const MOVE_STRENGTH: int = 0x46
 const MOVE_WHIRLPOOL: int = 0xFA
 const MOVE_WATERFALL: int = 0x7F
+const MOVE_FLASH: int = 0x94
 
 ## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
 ## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
@@ -35,6 +38,10 @@ const BADGE_GLACIER: int = 6
 ## WaterfallFunction's .TryWaterfall, whose CheckBadge argument is
 ## ENGINE_RISINGBADGE: 34 in Crystal and 33 in Gold/Silver.
 const BADGE_RISING: int = 7
+## FlashFunction's .CheckUseFlash, whose CheckBadge argument is
+## ENGINE_ZEPHYRBADGE: 27 in Crystal and 26 in Gold/Silver. It is the first
+## badge, so Flash is gated on the least of the eight.
+const BADGE_ZEPHYR: int = 0
 
 ## GetSurfType's comparison, constants/pokemon_constants.asm.
 const SPECIES_PIKACHU: int = 0x19
@@ -50,7 +57,7 @@ const MUSIC_SURF: int = 0x21
 ## decides submenu membership from this list alone, so a move stops appearing
 ## the moment it leaves it.
 const FIELD_MOVES: Array[int] = [
-	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL,
+	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
 ]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -13,6 +13,47 @@ const TIME_DAY: int = 1
 const TIME_NIGHT: int = 2
 const TIME_DARK: int = 3
 
+## `wMapTimeOfDay`, the low nibble of the map header's seventh byte and already
+## on [member Gen2WorldMap.palette]. It says which of the four rows above a map
+## uses, and whether the clock gets a say at all.
+const PALETTE_AUTO: int = 0
+const PALETTE_DAY: int = 1
+const PALETTE_NITE: int = 2
+const PALETTE_MORN: int = 3
+const PALETTE_DARK: int = 4
+
+## `.BrightnessLevels`, one row per [constant PALETTE_AUTO] and its four
+## neighbours, read by the clock's own time of day. The cartridge packs each row
+## into a byte two bits at a time and `GetTimePalette` picks the pair back out;
+## the byte is not kept here because nothing else reads it.
+const BRIGHTNESS_LEVELS: Array = [
+	[TIME_MORNING, TIME_DAY, TIME_NIGHT, TIME_DARK],
+	[TIME_DAY, TIME_DAY, TIME_DAY, TIME_DAY],
+	[TIME_NIGHT, TIME_NIGHT, TIME_NIGHT, TIME_NIGHT],
+	[TIME_MORNING, TIME_MORNING, TIME_MORNING, TIME_MORNING],
+	[TIME_DARK, TIME_DARK, TIME_DARK, TIME_DARK],
+]
+
+
+## Which of the four palette rows a map draws with right now.
+##
+## `ReplaceTimeOfDayPals` and `GetTimePalette` together. A
+## [constant PALETTE_DARK] map is the only one the clock cannot reach: it is
+## [constant TIME_DARK] until Flash has been used and [constant TIME_NIGHT]
+## afterwards, which is why a lit cave still looks like a cave.
+static func map_time_of_day(
+	map_palette: int, clock_time_of_day: int, used_flash: bool = false
+) -> int:
+	if map_palette == PALETTE_DARK:
+		return TIME_NIGHT if used_flash else TIME_DARK
+	var row: Array = BRIGHTNESS_LEVELS[clampi(map_palette, 0, BRIGHTNESS_LEVELS.size() - 1)]
+	return int(row[clampi(clock_time_of_day, 0, row.size() - 1)])
+
+
+## Whether a map is one of the caves Flash is for.
+static func is_dark(map_palette: int) -> bool:
+	return map_palette == PALETTE_DARK
+
 const PALETTE_ROWS: Array = [
 	[
 		[0, 1, 2, 40, 4, 5, 6, 7],

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -203,7 +203,16 @@ func _build_renderer() -> void:
 		_screen.native_size_changed.connect(_on_native_size_changed)
 		_on_native_size_changed(_screen.native_size())
 	_renderer.set_world(_world, _animation)
-	_renderer.set_time_of_day(time_of_day)
+	_renderer.set_time_of_day(_render_time_of_day())
+
+
+## What the renderer actually draws with, which is not always the clock: a dark
+## cave stays dark until Flash is used and looks like night afterwards. See
+## [method Gen2WorldPalette.map_time_of_day].
+func _render_time_of_day() -> int:
+	if _world == null:
+		return time_of_day
+	return _world.map_time_of_day()
 
 
 func _on_native_size_changed(size_pixels: Vector2i) -> void:
@@ -658,7 +667,7 @@ func _update_time_of_day() -> void:
 	if _animation != null:
 		_animation.configure(_world, time_of_day)
 	if _renderer != null:
-		_renderer.set_time_of_day(time_of_day)
+		_renderer.set_time_of_day(_render_time_of_day())
 
 
 ## Public screenshot driver for the scripted emote state and renderer path.
@@ -1532,6 +1541,12 @@ func _on_party_action(action: Dictionary) -> void:
 				)
 				return
 			_show_field_move_text("%s used WATERFALL!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_FLASH:
+			var flash: Dictionary = _world.flash_request()
+			if not bool(flash.get("ok", false)):
+				_show_field_move_text(_flash_refusal(StringName(flash.get("reason", &""))))
+				return
+			_show_field_move_text("%s used FLASH!" % String(action.get("name", "")))
 		_:
 			_show_field_move_text("Can't use that here.")
 
@@ -1588,6 +1603,14 @@ func _waterfall_refusal(reason: StringName) -> String:
 	return "Can't use that here."
 
 
+## .CheckUseFlash has no refusal text of its own for a lit map: it reaches
+## FieldMoveFailed, which is _CantUseItemText. Only the badge has a line.
+func _flash_refusal(reason: StringName) -> String:
+	if reason == &"badge_required":
+		return "Sorry! A new BADGE is required."
+	return "Can't use that here."
+
+
 ## .TryStrength's only refusal is CheckBadge's, since it checks nothing else;
 ## anything past it is this project's own guard, not a cartridge branch.
 func _strength_refusal(reason: StringName) -> String:
@@ -1633,6 +1656,9 @@ func _acknowledge_field_move_text() -> void:
 	if not _world.pending_waterfall().is_empty():
 		_commit_field_move(_world.complete_waterfall(), "Waterfall")
 		return
+	if not _world.pending_flash().is_empty():
+		_commit_field_move(_world.complete_flash(), "Flash")
+		return
 	_script_prompt = ""
 	_refresh_labels()
 
@@ -1641,8 +1667,8 @@ func _acknowledge_field_move_text() -> void:
 ## plays SFX_BUBBLEBEAM and Surf changes the music, so each commit reports its
 ## own audio. Strength is the one that plays nothing: Script_UsedStrength has no
 ## PlaySFX, because SFX_STRENGTH belongs to the boulder that moves later, not to
-## the flag being set. All five redraw anyway, since the party overlay closed
-## over the map.
+## the flag being set, and neither does Flash. All six redraw anyway, since the
+## party overlay closed over the map.
 func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
 		match StringName(applied.get("kind", &"")):
@@ -1654,6 +1680,15 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 				pass
 			&"waterfall_applied":
 				_play_sfx(SFX_WATERFALL)
+			&"flash_used":
+				# BlindingFlash has no sound of its own: it fades to white,
+				# swaps the palette set and fades back. The palette is the whole
+				# of what changed, so the renderer is told the new row rather
+				# than just asked to redraw.
+				if _renderer != null:
+					_renderer.set_time_of_day(_render_time_of_day())
+				if _animation != null:
+					_animation.configure(_world, _render_time_of_day())
 			_:
 				_play_sfx(SFX_CUT)
 		if _renderer != null:
@@ -1835,7 +1870,7 @@ func _show_script_results(results: Array) -> void:
 			_world.reload_current_map()
 			_animation.configure(_world, time_of_day)
 			_renderer.set_world(_world, _animation)
-			_renderer.set_time_of_day(time_of_day)
+			_renderer.set_time_of_day(_render_time_of_day())
 			_play_current_map_music()
 		else:
 			_renderer.refresh()

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -104,6 +104,12 @@ var _script_memory: Dictionary = {}
 ## than something derived from the current map because `PlayMapMusic` writes it
 ## and compares against it, and because a tuned radio station overwrites it and
 ## survives the Pokegear closing. `SnorlaxAwake` reads exactly that byte.
+## `wStatusFlags`' `STATUSFLAGS_FLASH_F`. Its own byte on the cartridge rather
+## than an engine flag, and it does not survive walking out into the open:
+## `ResetFlashIfOutOfCave` clears it on entering a ROUTE or a TOWN, so a lit cave
+## goes dark again the moment the player leaves and comes back.
+var _used_flash: bool = false
+
 var _map_music: int = MUSIC_NONE
 var _radio_knob: int = Gen2WorldRadio.KNOB_MIN
 var _radio_channel: int = -1
@@ -497,6 +503,25 @@ func just_battled() -> bool:
 
 ## `wMapMusic`: the track that is playing, not the track the current map asks
 ## for. The two differ whenever a radio station is tuned.
+func used_flash() -> bool:
+	return _used_flash
+
+
+## `BlindingFlash`'s own `set STATUSFLAGS_FLASH_F`.
+func set_used_flash(value: bool) -> void:
+	if _used_flash == value:
+		return
+	_used_flash = value
+	changed.emit()
+
+
+## `ResetFlashIfOutOfCave`, called on entering a map: only a route or a town puts
+## the light out, so walking from one cave room into another keeps it.
+func clear_flash_if_outdoors(environment: int) -> void:
+	if Gen2WorldPhoneHost.is_outside_environment(environment):
+		set_used_flash(false)
+
+
 func map_music() -> int:
 	return _map_music
 

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -83,7 +83,7 @@ func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
 func test_the_hm_list_is_wider_than_the_overworld_field_moves() -> void:
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
 		assert_true(Gen2MoveForget.is_hm_move(move), "field move %d" % move)
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 5)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 6)
 	assert_true(Gen2MoveForget.is_hm_move(0x13), "FLY is an HM with no field effect here")
 	assert_false(Gen2WorldFieldMove.FIELD_MOVES.has(0x13))
 

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -63,6 +63,11 @@ const WATERFALL_STAND_CELL: Vector2i = Vector2i(2, 7)
 const WATERFALL_CELLS: Array[Vector2i] = [Vector2i(2, 6), Vector2i(2, 5)]
 const WATERFALL_LANDING_CELL: Vector2i = Vector2i(2, 4)
 
+## constants/map_data_constants.asm: ROUTE and TOWN are the two
+## `ResetFlashIfOutOfCave` treats as outdoors; DUNGEON is not one of them.
+const ENVIRONMENT_TOWN: int = 1
+const ENVIRONMENT_DUNGEON: int = 7
+
 var _directory: String = ""
 
 
@@ -90,6 +95,10 @@ func _write_cache() -> void:
 	])
 	RomCache.write_json(RomCache.world_maps_path(_directory), [
 		_map(1, TILESET_CUTTABLE), _map(2, TILESET_NO_ENTRY),
+		# A third map that is a dark cave, for Flash: PALETTE_DARK with the
+		# DUNGEON environment, which is what keeps the light on when the player
+		# walks from it into another cave room.
+		_map(3, TILESET_CUTTABLE, Gen2WorldPalette.PALETTE_DARK, ENVIRONMENT_DUNGEON),
 	])
 
 	var pixels := PackedByteArray()
@@ -138,7 +147,7 @@ func _tileset(number: int) -> Dictionary:
 	}
 
 
-func _map(number: int, tileset: int) -> Dictionary:
+func _map(number: int, tileset: int, palette: int = 0, environment: int = 0) -> Dictionary:
 	var blocks: Array = []
 	for index: int in 16:
 		blocks.append(BLOCK_FLOOR)
@@ -180,6 +189,8 @@ func _map(number: int, tileset: int) -> Dictionary:
 		"group": 1,
 		"number": number,
 		"tileset": tileset,
+		"palette": palette,
+		"environment": environment,
 		"width_blocks": 4,
 		"height_blocks": 4,
 		"blocks": blocks,
@@ -272,7 +283,7 @@ func _whirlpool_world(badge: bool = true, knows: bool = true) -> Gen2WorldAPI:
 	return world
 
 
-func test_the_five_resolved_moves_are_the_field_moves_the_submenu_offers() -> void:
+func test_the_six_resolved_moves_are_the_field_moves_the_submenu_offers() -> void:
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_CUT))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SURF))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_STRENGTH))
@@ -282,10 +293,12 @@ func test_the_five_resolved_moves_are_the_field_moves_the_submenu_offers() -> vo
 	assert_eq(Gen2WorldFieldMove.MOVE_SURF, 0x39)
 	assert_eq(Gen2WorldFieldMove.MOVE_STRENGTH, 0x46)
 	assert_eq(Gen2WorldFieldMove.MOVE_WHIRLPOOL, 0xFA)
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_FLASH))
 	assert_eq(Gen2WorldFieldMove.MOVE_WATERFALL, 0x7F)
+	assert_eq(Gen2WorldFieldMove.MOVE_FLASH, 0x94)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: FLY, FLASH, HEADBUTT.
-	for move: int in [0x13, 0x94, 0x1D]:
+	# submenu would offer an entry nothing answers: FLY and HEADBUTT.
+	for move: int in [0x13, 0x1D]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 
@@ -1050,3 +1063,112 @@ func test_a_map_change_clears_a_pending_waterfall() -> void:
 	world.player_cell = SHORE_CELL
 	assert_true(bool(world.try_warp().get("ok", false)))
 	assert_true(world.pending_waterfall().is_empty())
+
+
+## Flash. `.CheckUseFlash` checks the badge and then the map's own palette byte,
+## and nothing else: it is the one field move that never looks at a tile.
+func _flash_world(with_badge: bool = true, map_number: int = 3) -> Gen2WorldAPI:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	if with_badge:
+		state.set_engine_flag(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_ZEPHYR, Gen2WorldState.is_crystal_profile(data)
+		))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, map_number, Vector2i(1, 1), state)
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_FLASH)
+	return world
+
+
+func test_flash_request_needs_the_zephyr_badge_before_it_looks_at_the_map() -> void:
+	var world: Gen2WorldAPI = _flash_world(false)
+
+	var refused: Dictionary = world.flash_request()
+
+	assert_false(bool(refused.get("ok", true)))
+	assert_eq(refused["reason"], &"badge_required", "the badge, even standing in the dark")
+	assert_true(world.pending_flash().is_empty())
+
+
+func test_flash_request_reads_the_gold_silver_badge_flag() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_ZEPHYR, not crystal
+	))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 3, Vector2i(1, 1), state)
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_FLASH)
+
+	assert_eq(world.flash_request()["reason"], &"badge_required")
+
+
+## A map that is not PALETTE_DARK reaches FieldMoveFailed, whatever is under the
+## player: map 1 is an ordinary outdoor map.
+func test_flash_refuses_on_a_map_that_is_not_dark() -> void:
+	var world: Gen2WorldAPI = _flash_world(true, 1)
+
+	assert_eq(world.flash_request()["reason"], &"not_dark")
+
+
+func test_flash_lights_the_cave_and_only_on_the_acknowledge() -> void:
+	var world: Gen2WorldAPI = _flash_world()
+
+	assert_eq(world.map_time_of_day(), Gen2WorldPalette.TIME_DARK)
+	var staged: Dictionary = world.flash_request()
+	assert_true(bool(staged["ok"]))
+	assert_false(world.state.used_flash(), "nothing changes until the text is answered")
+	assert_eq(world.map_time_of_day(), Gen2WorldPalette.TIME_DARK)
+
+	var applied: Dictionary = world.complete_flash()
+
+	assert_true(bool(applied["ok"]))
+	assert_true(world.state.used_flash())
+	# A lit cave is drawn as night, not as day: the cartridge swaps DARKNESS_PALSET
+	# for a night palset rather than for the clock's own.
+	assert_eq(world.map_time_of_day(), Gen2WorldPalette.TIME_NIGHT)
+	assert_true(world.pending_flash().is_empty())
+
+
+func test_flash_refuses_a_second_time_in_the_same_cave() -> void:
+	var world: Gen2WorldAPI = _flash_world()
+	world.flash_request()
+	world.complete_flash()
+
+	assert_eq(world.flash_request()["reason"], &"already_lit")
+
+
+## `ResetFlashIfOutOfCave`: only a route or a town puts the light out, so walking
+## between two cave rooms keeps it.
+func test_the_light_survives_a_cave_door_and_dies_outdoors() -> void:
+	var state := Gen2WorldState.new()
+
+	state.set_used_flash(true)
+	state.clear_flash_if_outdoors(ENVIRONMENT_DUNGEON)
+	assert_true(state.used_flash(), "a dungeon is not outdoors")
+
+	state.clear_flash_if_outdoors(ENVIRONMENT_TOWN)
+	assert_false(state.used_flash())
+
+
+## `ReplaceTimeOfDayPals`' brightness table: only PALETTE_AUTO lets the clock
+## decide, and PALETTE_DARK ignores it in both states.
+func test_the_map_palette_byte_decides_how_much_the_clock_matters() -> void:
+	for clock: int in [
+		Gen2WorldPalette.TIME_MORNING, Gen2WorldPalette.TIME_DAY, Gen2WorldPalette.TIME_NIGHT,
+	]:
+		assert_eq(
+			Gen2WorldPalette.map_time_of_day(Gen2WorldPalette.PALETTE_AUTO, clock), clock,
+			"AUTO is the clock, unchanged"
+		)
+		assert_eq(
+			Gen2WorldPalette.map_time_of_day(Gen2WorldPalette.PALETTE_NITE, clock),
+			Gen2WorldPalette.TIME_NIGHT, "a NITE map is night at noon"
+		)
+		assert_eq(
+			Gen2WorldPalette.map_time_of_day(Gen2WorldPalette.PALETTE_DARK, clock),
+			Gen2WorldPalette.TIME_DARK
+		)
+		assert_eq(
+			Gen2WorldPalette.map_time_of_day(Gen2WorldPalette.PALETTE_DARK, clock, true),
+			Gen2WorldPalette.TIME_NIGHT
+		)


### PR DESCRIPTION
Thirteen maps carry PALETTE_DARK in their headers: the Whirl Islands, both Dark Cave entrances, Rock Tunnel and Silver Cave Room 1. Until now the clock decided their palette like anywhere else, so they were lit and Flash had nothing to answer.

The header byte decides instead. A dark map draws with the darkness row until Flash is used and with the night row afterwards, which is why a lit cave still looks like a cave. Walking out into a town or a route puts the light back out; a door between two cave rooms does not.