### PR TITLE
Break the rocks, and find out who was under them

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,15 @@ which is how the Poke Flute channel wakes Vermilion's Snorlax.
 The Pack opens each item's own source submenu and can use one: a Potion asks
 which Pokemon and heals it, a Repel sets its step count, and GIVE, TOSS and SEL
 keep their source position marked unavailable.
-The party submenu offers Cut, Surf, Strength, Whirlpool, Waterfall, Flash and
-Headbutt to a Pokemon that knows one; all seven show their message first and
-change the world on the acknowledge, and stepping from water back onto land
-stops surfing. Headbutt is the one with no badge behind it: facing a tree and
-knowing the move is the whole gate, and the acknowledge rolls the tree's own
-encounter, which on Crystal can arrive asleep. A
+The party submenu offers Cut, Surf, Strength, Whirlpool, Waterfall, Flash,
+Headbutt and Rock Smash to a Pokemon that knows one; all eight show their
+message first and change the world on the acknowledge, and stepping from water
+back onto land stops surfing. The last two have no badge behind them: for
+Headbutt, facing a tree and knowing the move is the whole gate, and the
+acknowledge rolls the tree's own encounter, which on Crystal can arrive asleep.
+Rock Smash asks the faced object rather than the ground, and a smashed rock is
+gone until the map reloads unless it carries an event flag. It can also be
+reached by talking to the rock, which asks first. A
 Waterfall climb runs the whole column in one command and ends on the first cell
 above it that is not a waterfall. Standing on a whirlpool, waterfall, door,
 staircase or cave tile overrides the pressed direction the way the cartridge
@@ -275,6 +278,7 @@ Headless tools, all against a real imported cache:
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |
 | `validate_side_walls.gd` | the side-wall/side-buoy codes, their face masks and map census, in both games; Celadon Mansion Roof's fence and staircase landings on Crystal |
 | `validate_cut.gd` | the cut block tables, the profile-split tileset numbers and cuttable-cell census, and Ilex Forest's tree, in all three games |
+| `validate_rock_smash.gd` | the rock map table, the smashable-rock census and its one flagged rock, and Cianwood City's rock, in all three games |
 | `validate_headbutt.gd` | the treemon map tables and sets, the profile-split set numbering, the headbutt-tree census, and Ilex Forest's tree, in all three games |
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -106,12 +106,19 @@ var _pending_strength: Dictionary = {}
 ## The same for Waterfall, held while Script_UsedWaterfall shows its text. It
 ## names the faced cell, so it is cleared with the loaded map like the rest.
 var _pending_waterfall: Dictionary = {}
+## The same for Flash. It names no cell or block, but it is cleared with the
+## others so a request left unacknowledged across a map load cannot refuse every
+## later Flash with flash_in_progress.
 var _pending_flash: Dictionary = {}
 ## The same for Headbutt, held while HeadbuttScript shows UseHeadbuttText. It
 ## names the faced tree, so it is cleared with the loaded map like the rest;
 ## the encounter behind it is only rolled on the commit, since TreeMonEncounter
 ## runs after that text.
 var _pending_headbutt: Dictionary = {}
+## The same for Rock Smash, held while RockSmashScript shows UseRockSmashText.
+## It names the faced rock's object index, so it is cleared with the loaded map
+## like the rest.
+var _pending_rock_smash: Dictionary = {}
 ## wPlayerID, mirrored from the selected save the way _party_summary mirrors
 ## its party. GetTreeScore is the only reader; -1 means no save has set one,
 ## which refuses rather than scoring against an invented zero.
@@ -1041,6 +1048,123 @@ func _treemon_encounter(cell: Vector2i, random: RandomNumberGenerator) -> Dictio
 
 static func _headbutt_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"headbutt_failed", "reason": reason}
+
+
+## engine/events/overworld.asm's TryRockSmashFromMenu, staged the way the other
+## six are: RockSmashScript reaches RockMonEncounter only after
+## UseRockSmashText, so the roll and the rock both belong to the commit.
+##
+## Rock Smash asks neither a badge nor a tile. `GetFacingObject` is
+## `CheckFacingObject` and then the faced object's own `MAPOBJECT_MOVEMENT`
+## byte, compared against `SPRITEMOVEDATA_SMASHABLE_ROCK`, so the question is
+## which object is in front rather than what the ground is. That is also why it
+## reads the doubled counter cell the way `interact()` does: it is the same
+## `CheckFacingObject`.
+func rock_smash_request() -> Dictionary:
+	if current_map == null or current_tileset == null:
+		return _rock_smash_failure(&"missing_map")
+	if not _pending_rock_smash.is_empty():
+		return _rock_smash_failure(&"rock_smash_in_progress")
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_ROCK_SMASH) < 0:
+		return _rock_smash_failure(&"move_not_known")
+	var target: Vector2i = object_facing_cell()
+	var rock: Gen2WorldObject = object_at(target)
+	if rock == null or not rock.is_smashable_rock():
+		return _rock_smash_failure(&"nothing_to_smash")
+	_pending_rock_smash = {
+		"ok": true,
+		"kind": &"rock_smash_requested",
+		"move": Gen2WorldFieldMove.MOVE_ROCK_SMASH,
+		"cell": target,
+		"object_index": rock.index,
+	}
+	return _pending_rock_smash.duplicate(true)
+
+
+## Empty until rock_smash_request() succeeds.
+func pending_rock_smash() -> Dictionary:
+	return _pending_rock_smash.duplicate(true)
+
+
+## RockSmashScript after its text: `disappear LAST_TALKED` and then
+## `RockMonEncounter`. The rock goes whether or not anything comes out of it,
+## because the disappear is before the roll.
+func complete_rock_smash(random: RandomNumberGenerator) -> Dictionary:
+	if _pending_rock_smash.is_empty():
+		return _rock_smash_failure(&"no_pending_rock_smash")
+	if random == null:
+		return _rock_smash_failure(&"missing_generator")
+	if data == null or current_map == null:
+		return _rock_smash_failure(&"missing_map")
+	var request: Dictionary = _pending_rock_smash
+	_pending_rock_smash = {}
+	var object_index: int = int(request["object_index"])
+	smash_object(object_index)
+	return {
+		"ok": true,
+		"kind": &"rock_smash_applied",
+		"move": int(request["move"]),
+		"cell": request["cell"],
+		"object_index": object_index,
+		"encounter": _rock_encounter(random),
+	}
+
+
+## `Script_disappear`: `DeleteObjectStruct` plus
+## `ApplyEventActionAppearDisappear`, which writes the object's own event flag
+## only when it has one. Fifteen of the sixteen rocks carry `-1`, so they are
+## gone until the map reloads and back on the next visit; Mt. Moon Square's
+## carries `EVENT_MT_MOON_SQUARE_ROCK`, so that one stays smashed, which is what
+## gates the Clefairy dance.
+func smash_object(object_index: int) -> Dictionary:
+	if current_map == null or object_index < 0 or object_index >= objects.size():
+		return {"ok": false, "reason": &"missing_object"}
+	var object: Gen2WorldObject = objects[object_index]
+	## DeleteObjectStruct only, with no visibility override behind it: a map
+	## load runs ReadObjectEvents and rebuilds every object from map data, so
+	## what survives a reload is the event flag and nothing else.
+	object.deleted = true
+	object.active = false
+	if object.event_flag > 0:
+		state.set_event_flag(object.event_flag, true)
+	return {"ok": true, "object_index": object_index, "event_flag": object.event_flag}
+
+
+## RockMonEncounter over the imported RockMonMaps and the ROCK set. Unlike a
+## tree it carries no BATTLETYPE_TREE, so nothing about it can start asleep.
+func _rock_encounter(random: RandomNumberGenerator) -> Dictionary:
+	var set_number: int = data.treemon_set_for_map(
+		current_map.group, current_map.number, true
+	)
+	if not Gen2WorldTreemon.set_is_usable(
+		set_number, Gen2WorldState.is_crystal_profile(data)
+	):
+		return {}
+	var resolved: Dictionary = Gen2WorldTreemon.rock_encounter(
+		data.treemon_set(set_number), random
+	)
+	if resolved.is_empty():
+		return {}
+	var species: int = int(resolved["species"])
+	var level: int = int(resolved["level"])
+	return {
+		"kind": &"wild_encounter_requested",
+		"method": Gen2WorldEncounter.METHOD_ROCK_SMASH,
+		"source": Gen2WorldEncounter.SOURCE_ROCK,
+		"pokemon": species,
+		"level": level,
+		"map": map_id(),
+		"cell": player_cell,
+		"movement": movement_mode,
+		"treemon_set": set_number,
+		"encounter_roll": int(resolved["encounter_roll"]),
+		"slot_roll": int(resolved["slot_roll"]),
+		"values": {"kind": &"wild", "pokemon": species, "level": level},
+	}
+
+
+static func _rock_smash_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"rock_smash_failed", "reason": reason}
 
 
 ## Mirrors the selected save's wPlayerID, the way set_party_summary() mirrors
@@ -2244,6 +2368,12 @@ func _enqueue_script_events(events: Array) -> void:
 			"script": script_address,
 			"event": event.duplicate(true),
 		}
+		# hLastTalked, which GetFacingObject writes before an object's script
+		# runs. Without it every `disappear LAST_TALKED` in an ordinary object
+		# script resolves to object -1: the trainer and item-ball requests below
+		# carry their own, so only the plain object case was missing one.
+		if event.get("kind", &"") == &"objects" and event.has("object_index"):
+			request["object_index"] = int(event["object_index"])
 		var trainer_request: Dictionary = _trainer_request_for_event(event)
 		if not trainer_request.is_empty():
 			request = trainer_request
@@ -3755,6 +3885,8 @@ func _apply_map(
 	_pending_strength.clear()
 	_pending_waterfall.clear()
 	_pending_headbutt.clear()
+	_pending_rock_smash.clear()
+	_pending_flash.clear()
 	# home/map.asm's map load calls ReadObjectEvents, which calls
 	# ClearObjectStructs and re-reads every object event from ROM. moveobject
 	# writes MAPOBJECT_X_COORD/Y_COORD in that same rebuilt table, so a scripted
@@ -3808,6 +3940,8 @@ func reload_current_map() -> Dictionary:
 	_pending_strength.clear()
 	_pending_waterfall.clear()
 	_pending_headbutt.clear()
+	_pending_rock_smash.clear()
+	_pending_flash.clear()
 	state.reset_map_reload_flags()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -15,12 +15,15 @@ const METHOD_SUPER_ROD: StringName = &"super_rod"
 ## slot table and no repel step, so nothing in resolve() handles it: it is a
 ## name for the request a headbutt produces.
 const METHOD_HEADBUTT: StringName = &"headbutt"
+## RockMonEncounter's own method, which reads no rate and no slot table either.
+const METHOD_ROCK_SMASH: StringName = &"rock_smash"
 
 const SOURCE_NORMAL: StringName = &"normal"
 const SOURCE_SWARM: StringName = &"swarm"
 const SOURCE_ROAMING: StringName = &"roaming"
 const SOURCE_FISHING: StringName = &"fishing"
 const SOURCE_TREE: StringName = &"tree"
+const SOURCE_ROCK: StringName = &"rock"
 
 
 static func resolve(

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -21,6 +21,7 @@ const MOVE_WHIRLPOOL: int = 0xFA
 const MOVE_WATERFALL: int = 0x7F
 const MOVE_FLASH: int = 0x94
 const MOVE_HEADBUTT: int = 0x1D
+const MOVE_ROCK_SMASH: int = 0xF9
 
 ## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
 ## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
@@ -59,7 +60,7 @@ const MUSIC_SURF: int = 0x21
 ## the moment it leaves it.
 const FIELD_MOVES: Array[int] = [
 	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
-	MOVE_HEADBUTT,
+	MOVE_HEADBUTT, MOVE_ROCK_SMASH,
 ]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -24,6 +24,11 @@ const MOVEMENT_SCRIPTED: int = 20
 ## above. A boulder decides nothing on its own, so it is deliberately in neither
 ## movement_supported() nor movement_advances(); it only reacts to a push.
 const MOVEMENT_STRENGTH_BOULDER: int = 0x19
+## SPRITEMOVEDATA_SMASHABLE_ROCK, the row directly below the boulder and in
+## neither template set for the same reason: a rock decides nothing and only
+## reacts to being smashed. Its flags1 are the boulder's, minus the palette bit
+## and plus USE_OBP1, so nothing but the movement byte tells the two apart.
+const MOVEMENT_SMASHABLE_ROCK: int = 0x18
 const MOVEMENT_SWIM_WANDER: int = 0x24
 ## The three rows data/sprites/map_objects.asm gives BIG_OBJECT in their palette
 ## flags. Only two objects in either game use one: the player's bedroom big doll
@@ -121,6 +126,14 @@ func initial_facing() -> int:
 ## SPRITEMOVEDATA_STRENGTH_BOULDER row, so the movement template answers it.
 func is_strength_boulder() -> bool:
 	return movement == MOVEMENT_STRENGTH_BOULDER
+
+
+## TryRockSmashFromMenu's own test: GetFacingObject hands MAPOBJECT_MOVEMENT
+## back in `d` and the whole check is `cp SPRITEMOVEDATA_SMASHABLE_ROCK`. Unlike
+## the three below it that is the source asking the movement byte directly
+## rather than a palette flag the row happens to carry.
+func is_smashable_rock() -> bool:
+	return movement == MOVEMENT_SMASHABLE_ROCK
 
 
 ## OBJECT_PALETTE bit SWIMMING, which CanObjectMoveInDirection reads to pick

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1580,6 +1580,14 @@ func _on_party_action(action: Dictionary) -> void:
 				return
 			## _UseHeadbuttText is "did a HEADBUTT!", not the "used" the other five share.
 			_show_field_move_text("%s did a HEADBUTT!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_ROCK_SMASH:
+			var rock_smash: Dictionary = _world.rock_smash_request()
+			if not bool(rock_smash.get("ok", false)):
+				_show_field_move_text(
+					_rock_smash_refusal(StringName(rock_smash.get("reason", &"")))
+				)
+				return
+			_show_field_move_text("%s used ROCK SMASH!" % String(action.get("name", "")))
 		_:
 			_show_field_move_text("Can't use that here.")
 
@@ -1644,6 +1652,13 @@ func _flash_refusal(reason: StringName) -> String:
 	return "Can't use that here."
 
 
+## TryRockSmashFromMenu refuses through FieldMoveFailed too, so its only text is
+## the generic one. AskRockSmashScript's _MaySmashText belongs to the other
+## path, where the runner owns it.
+func _rock_smash_refusal(_reason: StringName) -> String:
+	return "Can't use that here."
+
+
 ## TryHeadbuttFromMenu refuses through FieldMoveFailed, so every refusal is
 ## _CantUseItemText. There is no badge branch to add one: Headbutt is gated on
 ## CheckPartyMove and the faced tile alone.
@@ -1702,6 +1717,9 @@ func _acknowledge_field_move_text() -> void:
 	if not _world.pending_headbutt().is_empty():
 		_commit_field_move(_world.complete_headbutt(_encounter_random), "Headbutt")
 		return
+	if not _world.pending_rock_smash().is_empty():
+		_commit_field_move(_world.complete_rock_smash(_encounter_random), "Rock Smash")
+		return
 	_script_prompt = ""
 	_refresh_labels()
 
@@ -1734,6 +1752,8 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 					_animation.configure(_world, _render_time_of_day())
 			&"headbutt_applied":
 				_play_sfx(SFX_HEADBUTT_TREE)
+			&"rock_smash_applied":
+				_play_sfx(SFX_STRENGTH)
 			_:
 				_play_sfx(SFX_CUT)
 		if _renderer != null:
@@ -1741,6 +1761,9 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 		_script_prompt = label
 		if StringName(applied.get("kind", &"")) == &"headbutt_applied":
 			_finish_headbutt(applied)
+			return
+		if StringName(applied.get("kind", &"")) == &"rock_smash_applied":
+			_finish_rock_smash(applied)
 			return
 	else:
 		_script_prompt = "%s failed: %s" % [label, String(applied.get("reason", "unknown"))]
@@ -1754,6 +1777,22 @@ func _finish_headbutt(applied: Dictionary) -> void:
 	var encounter: Variant = applied.get("encounter", {})
 	if not encounter is Dictionary or (encounter as Dictionary).is_empty():
 		_show_field_move_text("Nope. Nothing…")
+		return
+	_refresh_labels()
+	_start_battle_request({
+		"kind": &"battle_requested",
+		"values": (encounter as Dictionary)["values"],
+		"encounter": (encounter as Dictionary).duplicate(true),
+	})
+
+
+## RockSmashScript after the rock is gone: RockMonEncounter either reaches
+## startbattle or the script ends. Unlike Headbutt there is no nothing-text,
+## because `.done` is a bare `end`.
+func _finish_rock_smash(applied: Dictionary) -> void:
+	var encounter: Variant = applied.get("encounter", {})
+	if not encounter is Dictionary or (encounter as Dictionary).is_empty():
+		_refresh_labels()
 		return
 	_refresh_labels()
 	_start_battle_request({

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -47,6 +47,10 @@ var _finish_after_pending: bool = false
 var _loaded_menu: Dictionary = {}
 var _loaded_emote: int = -1
 var _trainer_intro_approach_pending: bool = false
+## Set while RockSmashScript's `playsound SFX_STRENGTH` is out with the host, so
+## its acknowledge continues into the earthquake, the disappear and the roll.
+## The same shape _trainer_intro_approach_pending has for encounter music.
+var _rock_smash_after_sound: bool = false
 var _battle_setup: Dictionary = {}
 var _loaded_battle_type: int = -1
 var _phone_context: Dictionary = {}
@@ -100,6 +104,10 @@ const SPECIAL_INIT_ROAM_MONS: int = 105
 ## the same 14 in both pins despite the tables being 52 and 46 long. Every
 ## boulder object in every map reaches Strength through `jumpstd` on it.
 const STD_STRENGTH_BOULDER: int = 14
+## SmashRockScript's index, directly after the boulder's and the same 15 in both
+## pins. Every rock object in every map reaches Rock Smash through `jumpstd` on
+## it, exactly as every boulder reaches Strength through 14.
+const STD_SMASH_ROCK: int = 15
 ## TryStrengthOW's three wScriptVar answers. `.already_using` names the branch
 ## taken when `bit` sets Z, that is when the flag is still *clear*, so 0 is the
 ## value that asks and 2 the value that reports the flag already set.
@@ -113,6 +121,19 @@ const STRENGTH_ASK_TEXT: String = \
 	"A #MON may be\nable to move this.\n\nWant to use\nSTRENGTH?"
 const STRENGTH_MAY_MOVE_TEXT: String = "A #MON may be\nable to move this."
 const STRENGTH_BOULDERS_MOVE_TEXT: String = "Boulders may now\nbe moved!"
+## data/text/common_2.asm again, for AskRockSmashScript. `HasRockSmash` answers
+## 1 when CheckPartyMove fails, which is the `ifequal 1, .no` that reaches
+## _MaySmashText; anything else asks.
+const ROCK_SMASH_ASK_TEXT: String = \
+	"This rock looks\nbreakable.\n\nWant to use ROCK\nSMASH?"
+const ROCK_SMASH_MAY_SMASH_TEXT: String = "Maybe a #MON\ncan break this."
+const ROCK_SMASH_USED_TEXT: String = "%s used\nROCK SMASH!"
+## Script_earthquake's operand in RockSmashScript, kept because the runner
+## reports the request rather than shaking anything.
+const ROCK_SMASH_EARTHQUAKE: int = 84
+## constants/sfx_constants.asm, whose comment column is hex. RockSmashScript
+## plays the boulder's own sound rather than one of its own.
+const SFX_STRENGTH: int = 0x1B
 ## data/text/common_2.asm's _FoundItemText, less its <PLAYER>; see
 ## _stage_item_ball(). The source line break sits before the item name.
 const FOUND_ITEM_TEXT: String = "Found\n%s!"
@@ -275,6 +296,36 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		if pending_type == &"text" and _pending.get("special", &"") == &"strength_used":
 			var used_name: String = String(_pending.get("name", "#MON"))
 			_stage_internal_text("%s can\nmove boulders." % used_name, true)
+			return _waiting_result()
+		## AskRockSmashScript, the same opentext/writetext/yesorno shape.
+		if pending_type == &"text" and _pending.get("special", &"") == &"rock_smash_ask":
+			_pending = {
+				"type": &"choice",
+				"command": &"yesorno",
+				"choices": [&"yes", &"no"],
+				"special": &"rock_smash_ask",
+				"slot": int(_pending.get("slot", -1)),
+				"source": _request.duplicate(true),
+			}
+			return _waiting_result()
+		if pending_type == &"choice" and _pending.get("special", &"") == &"rock_smash_ask":
+			if choice < 0:
+				return _waiting_result()
+			var smash_slot: int = int(_pending.get("slot", -1))
+			_pending = {}
+			## `iftrue RockSmashScript`, and a no falls to closetext/end.
+			_script_value = 1 if choice == 0 else 0
+			if choice != 0:
+				return _complete()
+			_stage_rock_smash_used(smash_slot)
+			return _waiting_result()
+		## RockSmashScript's `closetext`, `special WaitSFX` and
+		## `playsound SFX_STRENGTH`. The rest of the script waits on the sound
+		## the way a trainer's approach waits on its encounter music.
+		if pending_type == &"text" and _pending.get("special", &"") == &"rock_smash_used":
+			_pending = {}
+			_rock_smash_after_sound = true
+			_stage_audio_request(&"sound", {"address": SFX_STRENGTH})
 			return _waiting_result()
 		if pending_type in [&"choice", &"menu"]:
 			if choice < 0:
@@ -460,10 +511,16 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		var approach_after_audio: bool = kind == &"audio_requested" \
 			and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
 			== &"encounter_music" and _trainer_intro_approach_pending
+		var smash_after_sound: bool = kind == &"audio_requested" \
+			and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
+			== &"sound" and _rock_smash_after_sound
 		_pending = {}
 		if approach_after_audio:
 			_trainer_intro_approach_pending = false
 			_stage_trainer_approach()
+		if smash_after_sound:
+			_rock_smash_after_sound = false
+			_stage_rock_smashed()
 		return advance()
 	if kind == &"rival_name_requested":
 		if not bool(result.get("ok", false)):
@@ -695,6 +752,8 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.JUMPSTD:
 			if int(command["address"]) == STD_STRENGTH_BOULDER:
 				return _stage_strength_boulder()
+			if int(command["address"]) == STD_SMASH_ROCK:
+				return _stage_smash_rock()
 			var jump_standard: Dictionary = _standard_script(int(command["address"]))
 			if jump_standard.is_empty():
 				return {
@@ -709,6 +768,8 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.CALLSTD:
 			if int(command["address"]) == STD_STRENGTH_BOULDER:
 				return _stage_strength_boulder()
+			if int(command["address"]) == STD_SMASH_ROCK:
+				return _stage_smash_rock()
 			var call_standard: Dictionary = _standard_script(int(command["address"]))
 			if call_standard.is_empty():
 				return {
@@ -2150,6 +2211,101 @@ func _stage_strength_used(slot: int) -> Dictionary:
 	}
 	_finish_after_pending = false
 	return {"ok": true}
+
+
+## engine/events/overworld.asm's AskRockSmashScript, synthesized for the same
+## reason AskStrengthScript is: SmashRockScript is `farsjump AskRockSmashScript`
+## and its first command is `callasm HasRockSmash`, whose operand is a link-time
+## address absent from the pins. The seam is the standard-script index, 15 in
+## both.
+##
+## `HasRockSmash` is CheckPartyMove and nothing else, so unlike the boulder
+## there is no badge and no already-active flag to check: the whole gate is
+## whether a party member knows ROCK SMASH.
+func _stage_smash_rock() -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "standard_index": STD_SMASH_ROCK}
+	var slot: int = _party_slot_with_move(Gen2WorldFieldMove.MOVE_ROCK_SMASH)
+	if slot < 0:
+		return _stage_internal_text(ROCK_SMASH_MAY_SMASH_TEXT, true)
+	_pending = {
+		"type": &"text",
+		"text": ROCK_SMASH_ASK_TEXT,
+		"internal_text": true,
+		"special": &"rock_smash_ask",
+		"slot": slot,
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = false
+	return {"ok": true}
+
+
+## RockSmashScript's `callasm GetPartyNickname` and `writetext UseRockSmashText`.
+func _stage_rock_smash_used(slot: int) -> Dictionary:
+	var names: Array = _request.get("party", {}).get("names", [])
+	var name: String = String(names[slot]) if slot >= 0 and slot < names.size() else "#MON"
+	_pending = {
+		"type": &"text",
+		"text": ROCK_SMASH_USED_TEXT % name,
+		"internal_text": true,
+		"special": &"rock_smash_used",
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = false
+	return {"ok": true}
+
+
+## Everything RockSmashScript does after its text: `playsound SFX_STRENGTH`,
+## `earthquake 84`, the rock's own one-command movement, `disappear LAST_TALKED`
+## and then RockMonEncounter. The sound and the shake are reported as events,
+## the way the runner reports every other presentation request.
+##
+## `readmem wTempWildMonSpecies` and `iffalse .done` are what test the roll, so
+## a species of zero ends the script and anything else reaches `randomwildmon`,
+## `startbattle` and `reloadmapafterbattle`.
+func _stage_rock_smashed() -> void:
+	_emit_runtime_event(&"earthquake_requested", {"duration": ROCK_SMASH_EARTHQUAKE})
+	## `disappear LAST_TALKED` is DeleteObjectStruct plus
+	## ApplyEventActionAppearDisappear. The delete is reported as
+	## `object_deleted` rather than a visibility override, so a rock with no
+	## event flag is back on the next map load exactly as the cartridge's is;
+	## the flag half is what makes Mt. Moon Square's stay smashed.
+	_emit_object_event(&"object_deleted", {
+		"object_index": _last_talked_object_index,
+	})
+	_emit_object_event(&"object_event_flag", {
+		"object_index": _last_talked_object_index, "active": true,
+	})
+	_stage_object_event_flag(LAST_TALKED, true)
+	var encounter: Dictionary = _rock_encounter()
+	if encounter.is_empty():
+		## `readmem wTempWildMonSpecies` then `iffalse .done`, and `.done` is
+		## `end`. Clearing the frames is what reaching that end looks like here.
+		_script_value = 0
+		_frames.clear()
+		return
+	_battle_setup = _new_battle_setup({
+		"kind": &"wild",
+		"pokemon": int(encounter["species"]),
+		"level": int(encounter["level"]),
+	})
+	_emit_runtime_event(&"battle_setup_changed", _battle_setup)
+	_emit_runtime_event(&"battle_map_reload_requested", {"requested": true})
+	_stage_runtime_request(&"battle_requested", _battle_request_values())
+
+
+## RockMonEncounter over the imported RockMonMaps and the ROCK set, rolled on
+## this invocation's own generator like every other roll the runner makes.
+func _rock_encounter() -> Dictionary:
+	if data == null:
+		return {}
+	var group: int = int(_request.get("map_group", -1))
+	var number: int = int(_request.get("map_number", -1))
+	var set_number: int = data.treemon_set_for_map(group, number, true)
+	if not Gen2WorldTreemon.set_is_usable(set_number, _crystal_commands()):
+		return {}
+	return Gen2WorldTreemon.rock_encounter(data.treemon_set(set_number), _random)
 
 
 func _stage_internal_text(text: String, finish_after: bool) -> Dictionary:

--- a/game/world/world_treemon.gd
+++ b/game/world/world_treemon.gd
@@ -1,13 +1,15 @@
 class_name Gen2WorldTreemon
 extends RefCounted
 
-## The headbutt-tree encounter roll (engine/events/treemons.asm).
+## The headbutt-tree and rock-smash encounter rolls
+## (engine/events/treemons.asm), which share their tables.
 ##
 ## TreeMonEncounter is four questions in order: does this map have a treemon
 ## set, does that set exist under this profile's limit, does GetTreeMon's score
 ## and roll produce an encounter, and which row does SelectTreeMon land on.
 ## Only the last two are random; the first two are table lookups the caller
-## resolves through [GameData].
+## resolves through [GameData]. RockMonEncounter is the same two lookups over
+## RockMonMaps and then one flat roll, see [method rock_encounter].
 ##
 ## The generator is required rather than defaulted, so nothing here can roll on
 ## an uninjected generator the way advance_roaming() still can.
@@ -34,6 +36,11 @@ const ENCOUNTER_THRESHOLDS: Dictionary = {
 	SCORE_GOOD: 5,
 	SCORE_RARE: 8,
 }
+
+## RockMonEncounter's own threshold, commented "40% chance of an encounter" in
+## both pins. It is a flat chance rather than one of three, because nothing
+## scores a rock.
+const ROCK_ENCOUNTER_THRESHOLD: int = 4
 
 ## CheckSleepingTreeMon's status turns for a tree encounter that starts asleep
 ## (constants/battle_constants.asm's TREEMON_SLEEP_TURNS).
@@ -116,6 +123,37 @@ static func resolve(
 	selected["score"] = tier
 	selected["encounter_roll"] = encounter_roll
 	return selected
+
+
+## RockMonEncounter, which is the same tables and a much shorter question:
+## GetTreeMonSet over RockMonMaps, GetTreeMons, then a flat 40 percent
+## `RandomRange(10)` under 4 and `SelectTreeMon` on the common table. It calls
+## SelectTreeMon directly rather than GetTreeMon, so there is no score, no
+## trainer ID and no rare table, which is why TreeMonSet_Rock can ship without
+## one. It also writes no wBattleType, so a smashed rock is an ordinary wild
+## battle and CheckSleepingTreeMon never looks at it.
+static func rock_encounter(
+	set_record: Dictionary, random: RandomNumberGenerator
+) -> Dictionary:
+	if set_record.is_empty() or random == null:
+		return {}
+	var encounter_roll: int = random.randi_range(0, 9)
+	if not rock_encounter_allowed(encounter_roll):
+		return {}
+	var table: Variant = set_record.get("common", [])
+	if not table is Array or (table as Array).is_empty():
+		return {}
+	var selected: Dictionary = select_at(table as Array, random.randi_range(0, 99))
+	if selected.is_empty():
+		return {}
+	selected["encounter_roll"] = encounter_roll
+	return selected
+
+
+## RockMonEncounter's `cp 4` against its RandomRange(10), kept apart from the
+## roll the way the tree thresholds are.
+static func rock_encounter_allowed(roll: int) -> bool:
+	return roll < ROCK_ENCOUNTER_THRESHOLD
 
 
 ## GetTreeMon's per-tier comparison against its RandomRange(10) result, kept

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -39,6 +39,20 @@ const HEADBUTT_CELL: Vector2i = Vector2i(6, 3)
 const HEADBUTT_STAND_CELL: Vector2i = Vector2i(6, 2)
 const TREEMON_SET: int = 1
 const TREEMON_SPECIES: int = Fixture.TRAINER_SPECIES
+## A smashable rock and the cell the player stands on to face it. The rock is a
+## map object, not a tile, which is the whole difference from a headbutt tree:
+## TryRockSmashFromMenu asks GetFacingObject rather than the collision byte.
+const ROCK_CELL: Vector2i = Vector2i(9, 3)
+const ROCK_STAND_CELL: Vector2i = Vector2i(9, 2)
+const ROCK_OBJECT_INDEX: int = 1
+## RockMonMaps names the same map, with the ROCK set at its Crystal number.
+const ROCK_SET: int = 7
+## The rock's own script, which every real rock has: `jumpstd SmashRockScript`.
+const ROCK_SCRIPT: int = 0x6400
+const STD_SMASH_ROCK: int = 15
+## Any permanent flag: the fixture's rock carries -1 like the real ones, so a
+## test that wants Mt. Moon Square's behavior gives it one.
+const ROCK_EVENT_FLAG: int = 900
 
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
@@ -71,6 +85,8 @@ func _write_cut_tree() -> void:
 			raw["name"] = "WHIRLPOOL"
 		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_HEADBUTT:
 			raw["name"] = "HEADBUTT"
+		elif int(raw.get("number", 0)) == Gen2WorldFieldMove.MOVE_ROCK_SMASH:
+			raw["name"] = "ROCK SMASH"
 	RomCache.write_json(RomCache.moves_path(directory), moves)
 
 	var tilesets: Array = RomCache.read_json(RomCache.world_tilesets_path(directory))
@@ -107,6 +123,18 @@ func _write_cut_tree() -> void:
 		collision[WHIRLPOOL_CELL.y * Fixture.MAP_WIDTH_CELLS + WHIRLPOOL_CELL.x] = 0x24
 		collision[HEADBUTT_CELL.y * Fixture.MAP_WIDTH_CELLS + HEADBUTT_CELL.x] = \
 			Gen2WorldCollision.COLL_HEADBUTT_TREE
+		# A second object beside the fixture's trainer, carrying the rock's own
+		# movement byte and the fixture's only sprite. Its event flag is -1, the
+		# way fifteen of the sixteen real rocks are, so smashing it lasts only
+		# as long as the loaded map.
+		(raw["events"]["objects"] as Array).append({
+			"sprite": Fixture.TRAINER_SPRITE,
+			"x": ROCK_CELL.x, "y": ROCK_CELL.y,
+			"movement": Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK,
+			"x_radius": 0, "y_radius": 0, "hour_1": -1, "hour_2": -1, "palette": 0,
+			"object_type": Gen2WorldObject.OBJECTTYPE_SCRIPT,
+			"sight_range": 0, "script": ROCK_SCRIPT, "event_flag": 0xFFFF,
+		})
 	RomCache.write_json(RomCache.world_maps_path(directory), maps)
 
 	# TreeMonMaps and one populated set, patched into the fixture's own
@@ -120,17 +148,34 @@ func _write_cut_tree() -> void:
 			"map_number": Fixture.MAP_NUMBER,
 			"set": TREEMON_SET,
 		}],
-		"rock_maps": [],
+		"rock_maps": [{
+			"map_group": Fixture.MAP_GROUP,
+			"map_number": Fixture.MAP_NUMBER,
+			"set": ROCK_SET,
+		}],
 		"sets": [
 			{"common": [], "rare": []},
 			{
 				"common": [{"percent": 100, "species": TREEMON_SPECIES, "level": 5}],
 				"rare": [{"percent": 100, "species": TREEMON_SPECIES, "level": 5}],
 			},
+			{"common": [], "rare": []},
+			{"common": [], "rare": []},
+			{"common": [], "rare": []},
+			{"common": [], "rare": []},
+			{"common": [], "rare": []},
+			## TreeMonSet_Rock's own shape: a common table and no rare one.
+			{"common": [{"percent": 100, "species": TREEMON_SPECIES, "level": 5}], "rare": []},
 		],
 		"asleep": {"morn": [], "day": [], "nite": []},
 	}
 	RomCache.write_json(RomCache.world_encounters_path(directory), encounters)
+
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, ROCK_SCRIPT)] = [
+		Gen2WorldScript.JUMPSTD, STD_SMASH_ROCK, 0,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
 
 	var tiles: PackedByteArray = PackedByteArray()
 	tiles.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
@@ -155,6 +200,11 @@ func _open_world(
 	badge_index: int = Gen2WorldFieldMove.BADGE_HIVE,
 	cell: Vector2i = PLAYER_CELL,
 ) -> void:
+	# A test that opens a second world frees the first here rather than leaking
+	# it: after_each() only ever sees the last one.
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
@@ -635,3 +685,220 @@ func _open_headbutt_world(badge: bool = true) -> void:
 		badge, Gen2WorldFieldMove.MOVE_HEADBUTT, Gen2WorldFieldMove.BADGE_HIVE,
 		HEADBUTT_STAND_CELL
 	)
+
+
+func test_submenu_lists_rock_smash_for_a_mon_that_knows_it() -> void:
+	await _open_rock_smash_world()
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(
+		_labels(party.submenu_snapshot()["items"]),
+		["ROCK SMASH", "STATS", "SWITCH", "MOVE", "ITEM", "CANCEL"]
+	)
+
+
+## RockSmashScript reaches `disappear LAST_TALKED` and RockMonEncounter only
+## after UseRockSmashText, so the rock is still there while the message is up.
+func test_choosing_rock_smash_shows_the_message_and_defers_the_rock() -> void:
+	await _open_rock_smash_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	assert_false(world.can_walk_to(ROCK_CELL), "an active object blocks its cell")
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_shown_text(), "TESTMON used ROCK SMASH!")
+	assert_false(world.pending_rock_smash().is_empty())
+	assert_not_null(world.object_at(ROCK_CELL), "the rock is still there")
+	assert_false(world.can_walk_to(ROCK_CELL))
+
+	_world_screen._encounter_random.seed = 4
+	_world_screen._acknowledge_field_move_text()
+	await get_tree().process_frame
+	assert_true(world.pending_rock_smash().is_empty())
+	assert_null(world.object_at(ROCK_CELL), "disappear LAST_TALKED deleted it")
+	assert_true(world.can_walk_to(ROCK_CELL), "and its cell is walkable")
+
+
+## Rock Smash asks no badge and no tile: the faced object's movement byte is the
+## whole question, so facing away refuses even standing beside the rock.
+func test_rock_smash_needs_no_badge_and_refuses_when_facing_no_rock() -> void:
+	await _open_rock_smash_world(false)
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(_shown_text(), "TESTMON used ROCK SMASH!", "no badge is involved")
+	_world_screen._acknowledge_field_move_text()
+
+	await _open_rock_smash_world()
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
+	var facing_away: Gen2PartyScreen = await _open_party()
+	facing_away.handle_button(Gen2Button.A)
+	facing_away.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(_shown_text(), "Can't use that here.")
+	_world_screen._acknowledge_field_move_text()
+	assert_not_null(_world_screen._world.object_at(ROCK_CELL), "and the rock stays")
+
+
+## RockMonEncounter is a flat 40 percent: seed 2's first RandomRange(10) is 0,
+## which passes, and seed 4's is 7, which does not. The rock goes either way,
+## because the disappear is before the roll.
+func test_a_passed_rock_roll_opens_a_battle_and_a_failed_one_does_not() -> void:
+	await _open_rock_smash_world()
+	await _rock_smash_with(2)
+	assert_not_null(_world_screen._battle_host, "a roll under 4 reaches startbattle")
+	var battle: Gen2Battle = _world_screen._battle_host._battle
+	assert_eq(battle.party(Gen2Battle.ENEMY).active_mon().species, TREEMON_SPECIES)
+	# RockMonEncounter writes no wBattleType, unlike TreeMonEncounter.
+	assert_eq(battle.battle_type, Gen2Battle.BATTLETYPE_NORMAL)
+	assert_null(_world_screen._world.object_at(ROCK_CELL))
+
+	await _open_rock_smash_world()
+	await _rock_smash_with(4)
+	assert_null(_world_screen._battle_host, "a roll of 4 or more is no encounter")
+	assert_null(_world_screen._world.object_at(ROCK_CELL), "and the rock is gone anyway")
+
+
+## Chooses ROCK SMASH from the submenu and acknowledges its text with the roll
+## pinned, the way _headbutt_with() does.
+func _rock_smash_with(seed_value: int) -> void:
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	_world_screen._encounter_random.seed = seed_value
+	_world_screen._acknowledge_field_move_text()
+	await get_tree().process_frame
+
+
+func _open_rock_smash_world(badge: bool = true) -> void:
+	await _open_world(
+		badge, Gen2WorldFieldMove.MOVE_ROCK_SMASH, Gen2WorldFieldMove.BADGE_HIVE,
+		ROCK_STAND_CELL
+	)
+
+
+## The other half of Rock Smash, and the half Headbutt does not have: talking to
+## the rock. Every rock's script is `jumpstd SmashRockScript`, whose body is
+## `farsjump AskRockSmashScript`, so the runner answers standard-script index 15
+## with the synthesized ask the way it answers 14 with the boulder's.
+func test_talking_to_a_rock_asks_and_then_smashes_it() -> void:
+	await _open_rock_smash_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	# RockMonEncounter rolls on the script's own generator. Seed 4's first
+	# RandomRange(10) is 7, which is 4 or more, so this run takes `.done` and
+	# the script ends instead of waiting on a battle.
+	world.script_random = RandomNumberGenerator.new()
+	world.script_random.seed = 4
+
+	var opened: Array = world.interact()
+	assert_eq(opened[0]["status"], &"waiting", JSON.stringify(opened))
+	assert_string_contains(String(opened[0]["event"]["text"]), "This rock looks")
+
+	# opentext, writetext, yesorno: the text is acknowledged, then the choice.
+	var asked: Array = world.run_event_queue(true)
+	assert_eq(asked[0]["event"]["type"], &"choice", JSON.stringify(asked))
+	var used: Array = world.choose_script_input(0)
+	assert_string_contains(String(used[0]["event"]["text"]), "used")
+	assert_not_null(world.object_at(ROCK_CELL), "the rock is still there mid-script")
+
+	# closetext, WaitSFX and playsound SFX_STRENGTH, which the host answers
+	# before the earthquake, the disappear and the roll.
+	var sound: Array = world.run_event_queue(true)
+	assert_eq(
+		sound[0]["event"]["request"]["kind"], &"audio_requested", JSON.stringify(sound)
+	)
+	# Answered on the world rather than through Gen2WorldHost, which would want
+	# audio data this synthetic cache does not carry.
+	var completed: Array = world.complete_runtime_request({"ok": true})
+	assert_eq(completed[0]["status"], &"complete", JSON.stringify(completed))
+	assert_true(
+		_has_event(completed[0]["events"], &"screen_shake_requested"),
+		"earthquake 84 is reported"
+	)
+	assert_null(world.object_at(ROCK_CELL), "disappear LAST_TALKED took the rock")
+	assert_true(world.can_walk_to(ROCK_CELL))
+
+
+## The same path with a roll that passes: `readmem wTempWildMonSpecies` is
+## non-zero, so the script reaches randomwildmon and startbattle instead of
+## ending, and the rock is gone either way.
+func test_a_talked_rock_that_rolls_an_encounter_asks_for_a_battle() -> void:
+	await _open_rock_smash_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	# Seed 2's first RandomRange(10) is 0, which is under 4.
+	world.script_random = RandomNumberGenerator.new()
+	world.script_random.seed = 2
+
+	world.interact()
+	world.run_event_queue(true)
+	world.choose_script_input(0)
+	world.run_event_queue(true)
+	var after_sound: Array = world.complete_runtime_request({"ok": true})
+	assert_eq(after_sound[0]["status"], &"waiting", JSON.stringify(after_sound))
+	var request: Dictionary = after_sound[0]["event"]["request"]
+	assert_eq(request["kind"], &"battle_requested")
+	assert_eq(int(request["values"]["pokemon"]), TREEMON_SPECIES)
+	assert_eq(request["values"]["kind"], &"wild")
+
+
+## `HasRockSmash` is CheckPartyMove and nothing else, so a party without the
+## move is told _MaySmashText and never offered the choice.
+func test_talking_to_a_rock_without_the_move_only_reports_it() -> void:
+	await _open_world(
+		true, Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE, ROCK_STAND_CELL
+	)
+	var world: Gen2WorldAPI = _world_screen._world
+	var opened: Array = world.interact()
+	assert_string_contains(String(opened[0]["event"]["text"]), "Maybe a #MON")
+	var after: Array = world.run_event_queue(true)
+	assert_eq(after[0]["status"], &"complete", JSON.stringify(after))
+	assert_not_null(world.object_at(ROCK_CELL), "and the rock is untouched")
+
+
+## Whether a result's event list carries one type, for the presentation
+## requests a script reports rather than performs.
+func _has_event(events: Array, type: StringName) -> bool:
+	for event: Variant in events:
+		if event is Dictionary and StringName((event as Dictionary).get("type", &"")) == type:
+			return true
+	return false
+
+
+## `disappear` is DeleteObjectStruct plus ApplyEventActionAppearDisappear, and
+## the second half writes nothing when the object's event flag is `-1`. A map
+## load runs ReadObjectEvents and rebuilds every object, so an unflagged rock
+## comes back and only a flagged one stays smashed. Fifteen of the sixteen real
+## rocks are unflagged; Mt. Moon Square's is the exception.
+func test_an_unflagged_rock_comes_back_on_a_map_reload() -> void:
+	await _open_rock_smash_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	await _rock_smash_with(4)
+	assert_null(world.object_at(ROCK_CELL))
+
+	world.reload_current_map()
+	assert_not_null(world.object_at(ROCK_CELL), "the rock is back")
+	assert_false(world.can_walk_to(ROCK_CELL), "and it blocks again")
+
+
+## The same rock given an event flag stays smashed, which is what gates
+## Mt. Moon Square's Clefairy dance.
+func test_a_flagged_rock_stays_smashed_across_a_reload() -> void:
+	await _open_rock_smash_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var rock: Gen2WorldObject = world.objects[ROCK_OBJECT_INDEX]
+	rock.event_flag = ROCK_EVENT_FLAG
+	assert_true(bool(world.smash_object(ROCK_OBJECT_INDEX).get("ok", false)))
+	assert_true(world.state.is_event_flag_active(ROCK_EVENT_FLAG))
+
+	# The cache's own record still carries -1, so the reloaded object needs the
+	# flag put back on it the way the cartridge's map data carries it.
+	world.reload_current_map()
+	(world.objects[ROCK_OBJECT_INDEX] as Gen2WorldObject).event_flag = ROCK_EVENT_FLAG
+	world.set_object_time(world.object_hour, world.object_time_of_day)
+	assert_null(world.object_at(ROCK_CELL), "a set event flag keeps it hidden")

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -2,9 +2,9 @@ extends GutTest
 
 ## ForgetMove's table and list against a synthetic cache built for this file.
 ##
-## The load-bearing part is the HM list: it is seven moves, not the four
-## [constant Gen2WorldFieldMove.FIELD_MOVES] this project acts on in the
-## overworld, and getting that wrong would let a player forget Fly or Flash.
+## The load-bearing part is the HM list: it is seven moves, which is neither a
+## subset nor a superset of the [constant Gen2WorldFieldMove.FIELD_MOVES] this
+## project acts on, and getting it wrong would let a player forget Fly or Flash.
 
 ## home/hm_moves.asm's IsHMMove.HMMoves with the names
 ## constants/move_constants.asm gives them, in source order.
@@ -78,18 +78,25 @@ func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
 
 
 ## The overworld's field-move list is a different question, and neither list
-## contains the other. Fly is an HM this project does not act on; Headbutt is a
-## TM it does, so it is a field move that ForgetMove will happily forget.
+## contains the other. Fly is an HM this project does not act on; Headbutt and
+## Rock Smash are TMs it does, so they are field moves ForgetMove will happily
+## forget.
+const TM_FIELD_MOVES: Array[int] = [
+	Gen2WorldFieldMove.MOVE_HEADBUTT, Gen2WorldFieldMove.MOVE_ROCK_SMASH,
+]
+
+
 func test_the_hm_list_and_the_overworld_field_moves_only_overlap() -> void:
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 7)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 8)
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
-		if move == Gen2WorldFieldMove.MOVE_HEADBUTT:
+		if TM_FIELD_MOVES.has(move):
 			continue
 		assert_true(Gen2MoveForget.is_hm_move(move), "field move %d" % move)
-	assert_false(
-		Gen2MoveForget.is_hm_move(Gen2WorldFieldMove.MOVE_HEADBUTT),
-		"HEADBUTT is TM02, so IsHMMove does not protect it"
-	)
+	for move: int in TM_FIELD_MOVES:
+		assert_false(
+			Gen2MoveForget.is_hm_move(move),
+			"TM02 HEADBUTT and TM08 ROCK SMASH are not protected by IsHMMove"
+		)
 	assert_true(Gen2MoveForget.is_hm_move(0x13), "FLY is an HM with no field effect here")
 	assert_false(Gen2WorldFieldMove.FIELD_MOVES.has(0x13))
 

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -328,7 +328,7 @@ func _whirlpool_world(badge: bool = true, knows: bool = true) -> Gen2WorldAPI:
 	return world
 
 
-func test_the_seven_resolved_moves_are_the_field_moves_the_submenu_offers() -> void:
+func test_the_eight_resolved_moves_are_the_field_moves_the_submenu_offers() -> void:
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_CUT))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SURF))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_STRENGTH))
@@ -340,13 +340,15 @@ func test_the_seven_resolved_moves_are_the_field_moves_the_submenu_offers() -> v
 	assert_eq(Gen2WorldFieldMove.MOVE_WHIRLPOOL, 0xFA)
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_FLASH))
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_HEADBUTT))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_ROCK_SMASH))
 	assert_eq(Gen2WorldFieldMove.MOVE_WATERFALL, 0x7F)
 	assert_eq(Gen2WorldFieldMove.MOVE_FLASH, 0x94)
 	assert_eq(Gen2WorldFieldMove.MOVE_HEADBUTT, 0x1D)
+	assert_eq(Gen2WorldFieldMove.MOVE_ROCK_SMASH, 0xF9)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
 	# submenu would offer an entry nothing answers: FLY, DIG, TELEPORT,
-	# SOFTBOILED, ROCK_SMASH, MILK_DRINK and SWEET_SCENT.
-	for move: int in [0x13, 0x5B, 0x64, 0x87, 0xF9, 0xD0, 0xE6]:
+	# SOFTBOILED, MILK_DRINK and SWEET_SCENT.
+	for move: int in [0x13, 0x5B, 0x64, 0x87, 0xD0, 0xE6]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -153,3 +153,26 @@ func test_strength_boulder_is_a_hex_template_that_never_decides() -> void:
 		assert_false(
 			_object(movement).is_strength_boulder(), "movement %d is not a boulder" % movement
 		)
+
+
+## TryRockSmashFromMenu's whole test after GetFacingObject: the faced object's
+## MAPOBJECT_MOVEMENT byte against SPRITEMOVEDATA_SMASHABLE_ROCK. The boulder
+## is the row directly after it, so the two must not be confused.
+func test_a_smashable_rock_is_answered_by_its_movement_byte() -> void:
+	assert_eq(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK, 0x18)
+	assert_true(_object(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK).is_smashable_rock())
+	assert_false(_object(Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER).is_smashable_rock())
+	assert_false(_object(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK).is_strength_boulder())
+	assert_false(_object().is_smashable_rock())
+	# The rock's own row carries no palette flag, so it is none of the three
+	# questions the palette bits answer.
+	assert_false(_object(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK).is_big_object())
+	assert_false(_object(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK).is_swimming())
+
+
+## A rock decides nothing on its own, exactly like the boulder: it is in neither
+## template set, so no per-frame driver ever asks it to move.
+func test_a_smashable_rock_is_in_neither_movement_set() -> void:
+	var rock: Gen2WorldObject = _object(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK)
+	assert_false(rock.movement_supported())
+	assert_false(rock.movement_advances())

--- a/tests/unit/test_world_treemon.gd
+++ b/tests/unit/test_world_treemon.gd
@@ -218,3 +218,43 @@ func test_resolve_draws_both_rolls_and_stays_inside_the_table() -> void:
 		)
 		found[int(result["species"])] = true
 	assert_gt(found.size(), 0, "forty seeds produce at least one encounter")
+
+
+## RockMonEncounter is a flat 40 percent rather than one of three tiers: `ld a,
+## 10 / call RandomRange / cp 4`, so a roll under 4 passes and nothing scores.
+func test_the_rock_threshold_is_flat_and_has_no_tier() -> void:
+	assert_eq(Gen2WorldTreemon.ROCK_ENCOUNTER_THRESHOLD, 4)
+	for roll: int in 4:
+		assert_true(Gen2WorldTreemon.rock_encounter_allowed(roll), "roll %d passes" % roll)
+	for roll: int in range(4, 10):
+		assert_false(Gen2WorldTreemon.rock_encounter_allowed(roll), "roll %d fails" % roll)
+
+
+## RockMonEncounter calls SelectTreeMon directly rather than GetTreeMon, so it
+## never reads a rare table. TreeMonSet_Rock ships none, and a rock set that did
+## would still be ignored.
+func test_a_rock_encounter_only_ever_reads_the_common_table() -> void:
+	var found: Dictionary = {}
+	for seed_value: int in 40:
+		var generator := RandomNumberGenerator.new()
+		generator.seed = seed_value
+		var result: Dictionary = Gen2WorldTreemon.rock_encounter(SET, generator)
+		if result.is_empty():
+			continue
+		assert_between(int(result["encounter_roll"]), 0, 3, "only rolls under 4 resolve")
+		assert_true(
+			int(result["species"]) in [21, 22],
+			"a rock reads the common table, never the rare one"
+		)
+		assert_false(result.has("score"), "nothing scores a rock")
+		found[int(result["species"])] = true
+	assert_gt(found.size(), 0, "forty seeds produce at least one rock encounter")
+
+
+func test_a_rock_encounter_refuses_without_a_generator_or_a_set() -> void:
+	assert_true(Gen2WorldTreemon.rock_encounter(SET, null).is_empty())
+	assert_true(Gen2WorldTreemon.rock_encounter({}, _seeded()).is_empty())
+	assert_true(
+		Gen2WorldTreemon.rock_encounter({"common": [], "rare": RARE}, _seeded()).is_empty(),
+		"an empty common table is no encounter, whatever the rare half holds"
+	)

--- a/tools/validate_rock_smash.gd
+++ b/tools/validate_rock_smash.gd
@@ -1,0 +1,269 @@
+extends SceneTree
+
+## Verifies Rock Smash against freshly imported real caches, for both command
+## profiles.
+##
+## The expected values come from the pinned pokecrystal and pokegold sources:
+## engine/events/overworld.asm's TryRockSmashFromMenu, RockSmashScript and
+## AskRockSmashScript, engine/events/treemons.asm's RockMonEncounter,
+## engine/events/std_scripts.asm's SmashRockScript, and
+## data/sprites/map_objects.asm's SPRITEMOVEDATA_SMASHABLE_ROCK row.
+##
+## The real-cartridge counterpart to the rock half of
+## tests/unit/test_world_treemon.gd and
+## tests/integration/test_world_field_move_screen.gd. Cianwood City is the
+## acceptance case, because its six rocks are the largest population and its map
+## is one of the four RockMonMaps names.
+##
+##   Godot --headless --path . -s res://tools/validate_rock_smash.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## constants/map_constants.asm. Cianwood City and Route 40 keep their numbers
+## between the pins; the two dungeon maps do not, the way Ilex Forest does not.
+const CIANWOOD_GROUP: int = 22
+const CIANWOOD_NUMBER: int = 3
+const ROUTE_40_GROUP: int = 22
+const ROUTE_40_NUMBER: int = 1
+const DARK_CAVE_GROUP: int = 3
+const DARK_CAVE_CRYSTAL: int = 78
+const DARK_CAVE_GOLD_SILVER: int = 70
+const SLOWPOKE_WELL_GROUP: int = 3
+const SLOWPOKE_WELL_CRYSTAL: int = 40
+const SLOWPOKE_WELL_GOLD_SILVER: int = 32
+
+## maps/CianwoodCity.asm's first rock object, identical in both pins, and the
+## cell the player stands on to face it.
+const CIANWOOD_ROCK_CELL := Vector2i(8, 16)
+const CIANWOOD_STAND_CELL := Vector2i(8, 15)
+
+## Census of the real caches. Crystal ships one rock fewer than Gold and Silver.
+## Only 13 of them stand on a map RockMonMaps names, because Burned Tower 1F,
+## Ice Path B3F and Mt. Moon Square carry rocks with no rock set: smashing those
+## is the source's own guaranteed nothing.
+const EXPECTED_CENSUS: Dictionary = {
+	# game id: [rocks, maps, rocks on a map with a rock set]
+	&"gold": [17, 6, 13],
+	&"silver": [17, 6, 13],
+	&"crystal": [16, 6, 13],
+}
+
+## constants/event_flags.asm's EVENT_MT_MOON_SQUARE_ROCK, the only event flag any
+## rock carries. The other fifteen or sixteen are `-1`, so they come back on the
+## next map load and this one does not.
+const MT_MOON_SQUARE_GROUP: int = 15
+const MT_MOON_SQUARE_NUMBER: int = 10
+const MT_MOON_SQUARE_ROCK_FLAG: int = 1912
+
+## data/wild/treemons.asm's TreeMonSet_Rock.
+const KRABBY: int = 98
+const SHUCKLE: int = 213
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_rock_map_table(game_id, data, crystal)
+		_census(game_id, data, crystal)
+		_verify_cianwood(game_id, data, crystal)
+	_finish()
+
+
+## GetTreeMonSet over RockMonMaps, at all four rows. Slowpoke Well B1F is in the
+## table and ships no rock at all, which is checked in _census() rather than
+## here: the table naming a map is not a promise that anything smashable stands
+## on it.
+func _verify_rock_map_table(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var expected_set: int = 7 if crystal else 3
+	var rows: Array = [
+		Vector2i(CIANWOOD_GROUP, CIANWOOD_NUMBER),
+		Vector2i(ROUTE_40_GROUP, ROUTE_40_NUMBER),
+		Vector2i(DARK_CAVE_GROUP, DARK_CAVE_CRYSTAL if crystal else DARK_CAVE_GOLD_SILVER),
+		Vector2i(
+			SLOWPOKE_WELL_GROUP,
+			SLOWPOKE_WELL_CRYSTAL if crystal else SLOWPOKE_WELL_GOLD_SILVER
+		),
+	]
+	for pair: Vector2i in rows:
+		_check(
+			data.treemon_set_for_map(pair.x, pair.y, true) == expected_set,
+			"%s: RockMonMaps row %s is set %d, not TREEMON_SET_ROCK %d." % [
+				game_id, pair, data.treemon_set_for_map(pair.x, pair.y, true), expected_set,
+			]
+		)
+	# TreeMonMaps must not answer for these: the two tables are separate lookups
+	# and a rock reads only its own.
+	_check(
+		data.treemon_set_for_map(ROUTE_40_GROUP, ROUTE_40_NUMBER) == 0,
+		"%s: Route 40 has a tree set, which TreeMonMaps gives TREEMON_SET_NONE." % game_id
+	)
+	var rock: Dictionary = data.treemon_set(expected_set)
+	var common: Array = rock.get("common", [])
+	_check(
+		common.size() == 2 and int(common[0]["species"]) == KRABBY \
+			and int(common[1]["species"]) == SHUCKLE,
+		"%s: TreeMonSet_Rock is not the pinned KRABBY and SHUCKLE." % game_id
+	)
+
+
+## Counts the smashable rocks a real cache carries, so a cache change that drops
+## one is loud. Also pins the single flagged rock and the RockMonMaps row that
+## has no rock on it.
+func _census(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var rocks: int = 0
+	var with_set: int = 0
+	var flagged: Array = []
+	var maps: Dictionary = {}
+	var slowpoke_number: int = SLOWPOKE_WELL_CRYSTAL if crystal else SLOWPOKE_WELL_GOLD_SILVER
+	var slowpoke_rocks: int = 0
+	for map: Gen2WorldMap in data.world_maps():
+		var rows: Variant = map.events.get("objects", [])
+		if not rows is Array:
+			continue
+		var usable: bool = Gen2WorldTreemon.set_is_usable(
+			data.treemon_set_for_map(map.group, map.number, true), crystal
+		)
+		for row: Variant in rows as Array:
+			if not row is Dictionary:
+				continue
+			if int((row as Dictionary).get("movement", 0)) \
+				!= Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK:
+				continue
+			rocks += 1
+			maps[Vector2i(map.group, map.number)] = true
+			if usable:
+				with_set += 1
+			if map.group == SLOWPOKE_WELL_GROUP and map.number == slowpoke_number:
+				slowpoke_rocks += 1
+			var flag: int = int((row as Dictionary).get("event_flag", 0))
+			if flag != 0xFFFF and flag > 0:
+				flagged.append([map.group, map.number, flag])
+	var counts: Array = [rocks, maps.size(), with_set]
+	print("%s: %d smashable rocks over %d maps, %d of them on a map RockMonMaps names." % [
+		game_id, counts[0], counts[1], counts[2],
+	])
+	_check(
+		counts == EXPECTED_CENSUS.get(game_id, []),
+		"%s: census is %s, not the pinned %s." % [
+			game_id, counts, EXPECTED_CENSUS.get(game_id, []),
+		]
+	)
+	_check(
+		flagged == [[MT_MOON_SQUARE_GROUP, MT_MOON_SQUARE_NUMBER, MT_MOON_SQUARE_ROCK_FLAG]],
+		"%s: the flagged rocks are %s, not Mt. Moon Square's alone." % [game_id, flagged]
+	)
+	_check(
+		slowpoke_rocks == 0,
+		"%s: Slowpoke Well B1F has %d rocks; RockMonMaps names it but no rock stands there."
+			% [game_id, slowpoke_rocks]
+	)
+
+
+## The acceptance case: a real rock, faced from a real cell, with no badge set
+## anywhere, staged and then committed.
+func _verify_cianwood(game_id: StringName, data: GameData, _crystal: bool) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, CIANWOOD_GROUP, CIANWOOD_NUMBER, CIANWOOD_STAND_CELL, Gen2WorldState.new()
+	)
+	if not _check(world != null, "%s: Cianwood City is missing." % game_id):
+		return
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var rock: Gen2WorldObject = world.object_at(CIANWOOD_ROCK_CELL)
+	if not _check(
+		rock != null and rock.is_smashable_rock(),
+		"%s: Cianwood City %s is not a smashable rock." % [game_id, CIANWOOD_ROCK_CELL]
+	):
+		return
+	_check(
+		not world.can_walk_to(CIANWOOD_ROCK_CELL),
+		"%s: Cianwood City's rock does not block its cell." % game_id
+	)
+
+	# CheckPartyMove is the whole gate: no badge, no tile and no player state.
+	var refused: Dictionary = world.rock_smash_request()
+	_check(
+		StringName(refused.get("reason", &"")) == &"move_not_known",
+		"%s: a party without ROCK SMASH answered %s." % [game_id, refused]
+	)
+	_rock_smash_party(world)
+	var request: Dictionary = world.rock_smash_request()
+	if not _check(
+		bool(request.get("ok", false)),
+		"%s: Cianwood City rock smash refused with %s." % [game_id, request.get("reason", "")]
+	):
+		return
+
+	var random := RandomNumberGenerator.new()
+	random.seed = 2
+	var applied: Dictionary = world.complete_rock_smash(random)
+	_check(
+		bool(applied.get("ok", false)),
+		"%s: the commit failed with %s." % [game_id, applied.get("reason", "")]
+	)
+	_check(
+		world.object_at(CIANWOOD_ROCK_CELL) == null,
+		"%s: the rock is still there after disappear LAST_TALKED." % game_id
+	)
+	_check(
+		world.can_walk_to(CIANWOOD_ROCK_CELL),
+		"%s: the smashed rock's cell is still blocked." % game_id
+	)
+	# Its event flag is -1, so nothing was written and the next map load brings
+	# it back, which is what the cartridge does with fifteen of the sixteen.
+	world.reload_current_map()
+	_check(
+		world.object_at(CIANWOOD_ROCK_CELL) != null,
+		"%s: an unflagged rock did not come back on a map reload." % game_id
+	)
+
+	var encounter: Dictionary = applied.get("encounter", {})
+	if _check(
+		not encounter.is_empty(),
+		"%s: seed 2's roll of 0 is under RockMonEncounter's 4 and must resolve." % game_id
+	):
+		_check(
+			int(encounter["pokemon"]) in [KRABBY, SHUCKLE],
+			"%s: a Cianwood rock produced species %d, not one of the ROCK set's two."
+				% [game_id, int(encounter["pokemon"])]
+		)
+		_check(
+			not encounter["values"].has("battle_type"),
+			"%s: RockMonEncounter writes no wBattleType, unlike TreeMonEncounter." % game_id
+		)
+		print("%s: Cianwood City %s smashed to species %d at level %d." % [
+			game_id, CIANWOOD_ROCK_CELL, int(encounter["pokemon"]), int(encounter["level"]),
+		])
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS rock smash: the rock table, the census and Cianwood City verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)
+
+
+## CheckPartyMove gates Rock Smash and nothing else does.
+func _rock_smash_party(world: Gen2WorldAPI) -> void:
+	world.set_party_summary(
+		1, false, [1] as Array[int], [[Gen2WorldFieldMove.MOVE_ROCK_SMASH]],
+		["MON"], [false]
+	)

--- a/tools/validate_rock_smash.gd.uid
+++ b/tools/validate_rock_smash.gd.uid
@@ -1,0 +1,1 @@
+uid://dd1u4a25t2gpt


### PR DESCRIPTION
Rock Smash is the last MonMenuOptions row this project acts on, and the only field move with two ways in. The submenu path asks the faced object rather than the ground: GetFacingObject and then the movement byte against SPRITEMOVEDATA_SMASHABLE_ROCK, with no badge and no tile anywhere in it. The other path is talking to the rock, which every rock in every map does through jumpstd SmashRockScript, and that ask lives inside a standard script, so the runner answers index 15 the way it already answers the boulder's 14.

The encounter behind it was already imported. RockMonEncounter is the treemon tables and a much shorter question: no score, no trainer ID and no rare table, which is what lets TreeMonSet_Rock ship without one, and no wBattleType, so nothing smashed out of a rock is asleep.

Two things the rock found on the way. An ordinary object script never had hLastTalked set, so every disappear LAST_TALKED in one resolved to object -1; the request now carries the object it is talking to. And a disappear whose object has no event flag has to die with the loaded map rather than outlive it, which is what brings fifteen of the sixteen rocks back and leaves Mt. Moon Square's smashed.