### PR TITLE
Ask before cutting, and take no for an answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,11 @@ back onto land stops surfing. The last two have no badge behind them: for
 Headbutt, facing a tree and knowing the move is the whole gate, and the
 acknowledge rolls the tree's own encounter, which on Crystal can arrive asleep.
 Rock Smash asks the faced object rather than the ground, and a smashed rock is
-gone until the map reloads unless it carries an event flag. It can also be
-reached by talking to the rock, which asks first. A
+gone until the map reloads unless it carries an event flag.
+Facing something and pressing A is the other way to all of them: a cut tree, a
+whirlpool, a waterfall, a headbutt tree and open water each offer their move and
+ask before using it, in the cartridge's own order, and each refuses in the
+cartridge's own words or, for Headbutt and Surf, says nothing at all. A
 Waterfall climb runs the whole column in one command and ends on the first cell
 above it that is not a waterfall. Standing on a whirlpool, waterfall, door,
 staircase or cave tile overrides the pressed direction the way the cartridge
@@ -278,6 +281,7 @@ Headless tools, all against a real imported cache:
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |
 | `validate_side_walls.gd` | the side-wall/side-buoy codes, their face masks and map census, in both games; Celadon Mansion Roof's fence and staircase landings on Crystal |
 | `validate_cut.gd` | the cut block tables, the profile-split tileset numbers and cuttable-cell census, and Ilex Forest's tree, in all three games |
+| `validate_field_move_prompts.gd` | the faced-tile prompt chain, both gates and all three answers for Cut, Surf and Headbutt, in all three games |
 | `validate_rock_smash.gd` | the rock map table, the smashable-rock census and its one flagged rock, and Cianwood City's rock, in all three games |
 | `validate_headbutt.gd` | the treemon map tables and sets, the profile-split set numbering, the headbutt-tree census, and Ilex Forest's tree, in all three games |
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2168,9 +2168,75 @@ func interact() -> Array:
 	## background event answered (engine/overworld/events.asm PlayerEvents).
 	var tile_request: Dictionary = _tile_collision_script_request(target)
 	if tile_request.is_empty():
+		## The rest of TryTileCollisionEvent: the five field-move branches, in
+		## the source's own order, each of which is a Try*OW gate and an ask.
+		tile_request = _field_move_prompt_request(target)
+	if tile_request.is_empty():
 		return []
 	_enqueue_script(tile_request)
 	return run_event_queue(false)
+
+
+## TryTileCollisionEvent from `.cut` on. The faced tile picks the branch, in the
+## source's order: a cut tree, then a whirlpool, then a waterfall, then a
+## headbutt tree, and `.surf` as the fallback any other tile reaches.
+##
+## Only the tile-shaped half of each gate is answered here, because only this
+## layer can read the map: whether the branch applies at all, and for Whirlpool
+## and Waterfall whether TryWhirlpoolMenu and CheckMapCanWaterfall would pass.
+## The party and the badge belong to the runner, which replays the Ask*Script.
+##
+## `.surf` is the one branch that is silent rather than refused when its own
+## tile checks fail: TrySurfOW answers no carry and the player event ends, so an
+## ordinary wall produces no request at all.
+func _field_move_prompt_request(cell: Vector2i) -> Dictionary:
+	if current_map == null or current_tileset == null or data == null:
+		return {}
+	var collision: int = collision_code_at(cell)
+	var move: int = 0
+	var tile_ok: bool = true
+	if Gen2WorldFieldMove.cut_tree_tile(collision):
+		move = Gen2WorldFieldMove.MOVE_CUT
+	elif Gen2WorldFieldMove.whirlpool_tile(collision):
+		move = Gen2WorldFieldMove.MOVE_WHIRLPOOL
+		tile_ok = bool(Gen2WorldFieldMove.whirlpool_replacement(
+			current_map.tileset, block_at(_script_block_cell(cell).x, _script_block_cell(cell).y)
+		).get("ok", false))
+	elif Gen2WorldFieldMove.waterfall_tile(collision):
+		move = Gen2WorldFieldMove.MOVE_WATERFALL
+		## CheckMapCanWaterfall is the facing and the tile above, which is this
+		## cell only when the player faces up.
+		tile_ok = player_facing == Gen2WorldSprite.FACING_UP
+	elif Gen2WorldFieldMove.headbutt_tile(collision):
+		move = Gen2WorldFieldMove.MOVE_HEADBUTT
+	elif _surf_prompt_applies(cell):
+		move = Gen2WorldFieldMove.MOVE_SURF
+	if move == 0:
+		return {}
+	return {
+		"kind": &"field_move_prompt",
+		"map_group": current_map.group,
+		"map_number": current_map.number,
+		"cell": cell,
+		"bank": 0,
+		"script": 0,
+		"move": move,
+		"tile_ok": tile_ok,
+	}
+
+
+## TrySurfOW's own checks, less the badge and the party the runner makes: not
+## already surfing, facing water, and CheckDirection's face mask. The bike flag
+## is not modelled, since nothing in this project sets one.
+func _surf_prompt_applies(cell: Vector2i) -> bool:
+	if movement_mode == MOVEMENT_SURF:
+		return false
+	if collision_permission_at(cell) != Gen2WorldCollision.WATER_TILE:
+		return false
+	var face: int = Gen2WorldCollision.face_mask_for_direction(
+		_direction_for_facing(player_facing)
+	)
+	return face == 0 or (tile_permissions_at(player_cell) & face) == 0
 
 
 ## engine/events/std_collision.asm's CheckFacingTileForStdScript. Keyed by the
@@ -2566,7 +2632,12 @@ func _script_address_for_event(event: Dictionary) -> int:
 
 
 func _enqueue_script(request: Dictionary) -> void:
-	if int(request.get("script", 0)) <= 0:
+	## A field-move prompt is the one queued request with no address of its own:
+	## the source reaches its Ask*Script through CallScript on a link-time
+	## address the pins do not resolve, so the runner synthesizes the body from
+	## the request kind the way it does for an item ball.
+	if int(request.get("script", 0)) <= 0 \
+		and StringName(request.get("kind", &"")) != &"field_move_prompt":
 		return
 	if not request.has("collision"):
 		var cell_value: Variant = request.get("cell", player_cell)

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -143,6 +143,17 @@ static func cuttable(collision_code: int) -> bool:
 	return CUTTABLE_COLLISIONS.has(collision_code)
 
 
+## home/map_objects.asm's CheckCutTreeTile, which is the two tree codes alone.
+## TryTileCollisionEvent's `.cut` branch reads this rather than
+## CheckCutCollision, so pressing A at tall grass offers nothing while the party
+## submenu's CUT still cuts it.
+const CUT_TREE_COLLISIONS: Array[int] = [0x12, 0x1A]
+
+
+static func cut_tree_tile(collision_code: int) -> bool:
+	return CUT_TREE_COLLISIONS.has(collision_code)
+
+
 ## The tileset-to-block-list mapping for one profile. Kept as a function rather
 ## than two constants so the shared lists above stay single-sourced.
 static func _cut_tables(is_crystal: bool) -> Dictionary:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1936,6 +1936,12 @@ func _show_script_results(results: Array) -> void:
 				## and runs on, and the source's own `end` is the next command,
 				## so nothing is waiting to be resumed when this opens.
 				open_hall_of_fame()
+			elif result_event.get("type", &"") == &"field_move_confirmed":
+				## `iftrue Script_Cut` and its four counterparts. The move is the
+				## host's, and it is the same staged request and acknowledge the
+				## party submenu reaches, so the two ways in stay one path.
+				_use_prompted_field_move(int(result_event.get("move", 0)),
+					int(result_event.get("slot", -1)))
 			elif result_event.get("type", &"") == &"pokemon_picture_requested":
 				_show_story_picture(int(result_event.get("pokemon", 0)))
 			elif result_event.get("type", &"") == &"pokemon_picture_closed":
@@ -1978,6 +1984,45 @@ func _show_script_results(results: Array) -> void:
 		else:
 			_renderer.refresh()
 	_refresh_labels()
+
+
+## The yes half of an Ask*Script. Each move's own request is what decides
+## whether anything happens, exactly as in the submenu path; the difference is
+## that a refusal here is silent, because AskCutScript's `.CheckMap` failure
+## falls straight to `closetext` with no text of its own.
+func _use_prompted_field_move(move: int, slot: int) -> void:
+	if _world == null:
+		return
+	var requested: Dictionary = {}
+	var label: String = ""
+	match move:
+		Gen2WorldFieldMove.MOVE_CUT:
+			requested = _world.cut_request()
+			label = "used CUT!"
+		Gen2WorldFieldMove.MOVE_SURF:
+			requested = _world.surf_request(_party_species(slot))
+			label = "used SURF!"
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
+			requested = _world.whirlpool_request()
+			label = "used WHIRLPOOL!"
+		Gen2WorldFieldMove.MOVE_WATERFALL:
+			requested = _world.waterfall_request()
+			label = "used WATERFALL!"
+		Gen2WorldFieldMove.MOVE_HEADBUTT:
+			requested = _world.headbutt_request()
+			label = "did a HEADBUTT!"
+	if not bool(requested.get("ok", false)):
+		return
+	_show_field_move_text("%s %s" % [_prompted_field_move_name(slot), label])
+
+
+## GetPartyNickname, which every one of these scripts calls before its own text.
+func _prompted_field_move_name(slot: int) -> String:
+	var save: Gen2SaveData = _active_party_save()
+	if save == null or slot < 0 or slot >= save.party.size():
+		return "#MON"
+	var member: Variant = save.party[slot]
+	return _mon_display_name(member as Gen2SaveMon) if member is Gen2SaveMon else "#MON"
 
 
 func _show_story_picture(species: int) -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -134,6 +134,27 @@ const ROCK_SMASH_EARTHQUAKE: int = 84
 ## constants/sfx_constants.asm, whose comment column is hex. RockSmashScript
 ## plays the boulder's own sound rather than one of its own.
 const SFX_STRENGTH: int = 0x1B
+
+## data/text/common_2.asm, for the five Ask*Scripts TryTileCollisionEvent
+## reaches. Synthesized rather than decoded for the reason AskStrengthScript's
+## are: each is reached through `CallScript` on a link-time address, so there is
+## no pointer in the pins to follow. All five are byte identical between them.
+const CUT_ASK_TEXT: String = "This tree can be\nCUT!\n\nWant to use CUT?"
+const CUT_CAN_TEXT: String = "This tree can be\nCUT!"
+const SURF_ASK_TEXT: String = "The water is calm.\nWant to SURF?"
+const WHIRLPOOL_ASK_TEXT: String = \
+	"A whirlpool is in\nthe way.\n\nWant to use\nWHIRLPOOL?"
+const WHIRLPOOL_MAY_PASS_TEXT: String = \
+	"It's a vicious\nwhirlpool!\n\nA #MON may be\nable to pass it."
+const WATERFALL_ASK_TEXT: String = "Do you want to use\nWATERFALL?"
+const WATERFALL_HUGE_TEXT: String = "Wow, it's a huge\nwaterfall."
+const HEADBUTT_ASK_TEXT: String = \
+	"A #MON could be\nin this tree.\n\nWant to HEADBUTT\nit?"
+## A field-move prompt has no source address to push a frame at, since
+## CallScript's operand is a link-time one the pins do not resolve. The bare
+## `end` frame still has to sit in the CPU's switchable window for _push_frame,
+## so it is put at its base; nothing ever reads the address back.
+const FIELD_MOVE_PROMPT_FRAME: int = RomFile.BANK_SIZE
 ## data/text/common_2.asm's _FoundItemText, less its <PLAYER>; see
 ## _stage_item_ball(). The source line break sits before the item name.
 const FOUND_ITEM_TEXT: String = "Found\n%s!"
@@ -208,6 +229,18 @@ static func begin(
 		## approaches.
 		runner._trainer_intro_approach_pending = request.get("direction", Vector2i.ZERO) \
 			in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]
+	elif StringName(request.get("kind", &"")) == &"field_move_prompt":
+		## TryTileCollisionEvent's five field-move branches each reach an
+		## Ask*Script through CallScript on a link-time address, so there is no
+		## pointer to push and the frame that stands in for one is a bare `end`,
+		## exactly as an item ball's is.
+		started = runner._push_frame(
+			bank, FIELD_MOVE_PROMPT_FRAME, PackedByteArray([
+				Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_END, runner._crystal_commands())
+			])
+		)
+		if started:
+			runner._stage_field_move_prompt()
 	elif StringName(request.get("kind", &"")) in [&"item_ball", &"hidden_item"]:
 		## Neither pointer is code, so the frame that stands in for it is a bare
 		## `end` and the staging call replays FindItemInBallScript or
@@ -297,6 +330,34 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			var used_name: String = String(_pending.get("name", "#MON"))
 			_stage_internal_text("%s can\nmove boulders." % used_name, true)
 			return _waiting_result()
+		## The five Ask*Scripts TryTileCollisionEvent reaches, all one shape:
+		## opentext, writetext, yesorno, iftrue <the move>, closetext, end.
+		if pending_type == &"text" and _pending.get("special", &"") == &"field_move_ask":
+			_pending = {
+				"type": &"choice",
+				"command": &"yesorno",
+				"choices": [&"yes", &"no"],
+				"special": &"field_move_ask",
+				"move": int(_pending.get("move", 0)),
+				"slot": int(_pending.get("slot", -1)),
+				"source": _request.duplicate(true),
+			}
+			return _waiting_result()
+		if pending_type == &"choice" and _pending.get("special", &"") == &"field_move_ask":
+			if choice < 0:
+				return _waiting_result()
+			var asked_move: int = int(_pending.get("move", 0))
+			var asked_slot: int = int(_pending.get("slot", -1))
+			_pending = {}
+			_script_value = 1 if choice == 0 else 0
+			if choice == 0:
+				## `iftrue Script_Cut` and its four counterparts. The move
+				## itself belongs to the host, which owns the staged request
+				## and the commit the party submenu already reaches.
+				_emit_runtime_event(&"field_move_confirmed", {
+					"move": asked_move, "slot": asked_slot,
+				})
+			return _complete()
 		## AskRockSmashScript, the same opentext/writetext/yesorno shape.
 		if pending_type == &"text" and _pending.get("special", &"") == &"rock_smash_ask":
 			_pending = {
@@ -2211,6 +2272,95 @@ func _stage_strength_used(slot: int) -> Dictionary:
 	}
 	_finish_after_pending = false
 	return {"ok": true}
+
+
+## engine/overworld/events.asm's TryTileCollisionEvent, from `.cut` on: the five
+## field-move branches a faced tile can reach, each of which is a `Try*OW` gate
+## and then an `Ask*Script`. Synthesized for the reason AskStrengthScript is,
+## and dispatched on the request kind rather than a standard-script index
+## because these are reached through `CallScript` rather than `jumpstd`.
+##
+## Which move the tile offers is [Gen2WorldAPI]'s answer, since only it can read
+## the map; so is `tile_ok`, the tile-shaped half of the gate that
+## TryWhirlpoolMenu and CheckMapCanWaterfall own. What is left here is the party
+## and the badge, which is what this runner already reads for the boulder.
+##
+## Three of the five have a refusal text and two do not: TryHeadbuttOW and
+## TrySurfOW return no carry and the player event ends with nothing shown.
+func _stage_field_move_prompt() -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "kind": &"field_move_prompt"}
+	var move: int = int(_request.get("move", 0))
+	var slot: int = _party_slot_with_move(move)
+	var badge: int = _field_move_prompt_badge(move)
+	var allowed: bool = slot >= 0
+	if allowed and badge >= 0:
+		allowed = _engine_flag_active(
+			Gen2WorldState.badge_flag(badge, _crystal_commands())
+		)
+	if allowed and not bool(_request.get("tile_ok", true)):
+		allowed = false
+	if not allowed:
+		var refusal: String = _field_move_prompt_refusal(move)
+		if refusal.is_empty():
+			## `.noevent`: TryHeadbuttOW and TrySurfOW answer no carry, so the
+			## player event ends and nothing is shown at all.
+			_script_value = 0
+			return _complete()
+		return _stage_internal_text(refusal, true)
+	_pending = {
+		"type": &"text",
+		"text": _field_move_prompt_ask(move),
+		"internal_text": true,
+		"special": &"field_move_ask",
+		"move": move,
+		"slot": slot,
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = false
+	return {"ok": true}
+
+
+## Each Try*OW's own CheckEngineFlag argument, as a badge-order index, or -1 for
+## the one that checks none. TryHeadbuttOW is CheckPartyMove and nothing else.
+func _field_move_prompt_badge(move: int) -> int:
+	match move:
+		Gen2WorldFieldMove.MOVE_CUT:
+			return Gen2WorldFieldMove.BADGE_HIVE
+		Gen2WorldFieldMove.MOVE_SURF:
+			return Gen2WorldFieldMove.BADGE_FOG
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
+			return Gen2WorldFieldMove.BADGE_GLACIER
+		Gen2WorldFieldMove.MOVE_WATERFALL:
+			return Gen2WorldFieldMove.BADGE_RISING
+	return -1
+
+
+func _field_move_prompt_ask(move: int) -> String:
+	match move:
+		Gen2WorldFieldMove.MOVE_CUT:
+			return CUT_ASK_TEXT
+		Gen2WorldFieldMove.MOVE_SURF:
+			return SURF_ASK_TEXT
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
+			return WHIRLPOOL_ASK_TEXT
+		Gen2WorldFieldMove.MOVE_WATERFALL:
+			return WATERFALL_ASK_TEXT
+	return HEADBUTT_ASK_TEXT
+
+
+## CantCutScript, Script_MightyWhirlpool and Script_CantDoWaterfall. Headbutt
+## and Surf have none, which is what the empty String means.
+func _field_move_prompt_refusal(move: int) -> String:
+	match move:
+		Gen2WorldFieldMove.MOVE_CUT:
+			return CUT_CAN_TEXT
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
+			return WHIRLPOOL_MAY_PASS_TEXT
+		Gen2WorldFieldMove.MOVE_WATERFALL:
+			return WATERFALL_HUGE_TEXT
+	return ""
 
 
 ## engine/events/overworld.asm's AskRockSmashScript, synthesized for the same

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -42,6 +42,11 @@ const TREEMON_SPECIES: int = Fixture.TRAINER_SPECIES
 ## A smashable rock and the cell the player stands on to face it. The rock is a
 ## map object, not a tile, which is the whole difference from a headbutt tree:
 ## TryRockSmashFromMenu asks GetFacingObject rather than the collision byte.
+## A two-cell waterfall column with water below it, so the climb has somewhere
+## to start and CheckMapCanWaterfall has a facing to check.
+const WATERFALL_STAND_CELL: Vector2i = Vector2i(4, 7)
+const WATERFALL_CELL: Vector2i = Vector2i(4, 6)
+const WATERFALL_TOP_CELL: Vector2i = Vector2i(4, 5)
 const ROCK_CELL: Vector2i = Vector2i(9, 3)
 const ROCK_STAND_CELL: Vector2i = Vector2i(9, 2)
 const ROCK_OBJECT_INDEX: int = 1
@@ -123,6 +128,10 @@ func _write_cut_tree() -> void:
 		collision[WHIRLPOOL_CELL.y * Fixture.MAP_WIDTH_CELLS + WHIRLPOOL_CELL.x] = 0x24
 		collision[HEADBUTT_CELL.y * Fixture.MAP_WIDTH_CELLS + HEADBUTT_CELL.x] = \
 			Gen2WorldCollision.COLL_HEADBUTT_TREE
+		collision[WATERFALL_STAND_CELL.y * Fixture.MAP_WIDTH_CELLS + WATERFALL_STAND_CELL.x] = 0x29
+		for waterfall_cell: Vector2i in [WATERFALL_CELL, WATERFALL_TOP_CELL]:
+			collision[waterfall_cell.y * Fixture.MAP_WIDTH_CELLS + waterfall_cell.x] = \
+				Gen2WorldCollision.COLL_WATERFALL
 		# A second object beside the fixture's trainer, carrying the rock's own
 		# movement byte and the fixture's only sprite. Its event flag is -1, the
 		# way fifteen of the sixteen real rocks are, so smashing it lasts only
@@ -902,3 +911,172 @@ func test_a_flagged_rock_stays_smashed_across_a_reload() -> void:
 	(world.objects[ROCK_OBJECT_INDEX] as Gen2WorldObject).event_flag = ROCK_EVENT_FLAG
 	world.set_object_time(world.object_hour, world.object_time_of_day)
 	assert_null(world.object_at(ROCK_CELL), "a set event flag keeps it hidden")
+
+
+## TryTileCollisionEvent's five field-move branches: facing a cut tree and
+## pressing A asks before cutting, which is the way the cartridge teaches every
+## one of these. The party submenu is the other way in and both end in the same
+## staged request.
+func test_facing_a_cut_tree_asks_before_cutting() -> void:
+	await _open_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	assert_false(world.can_walk_to(TREE_CELL))
+
+	var opened: Array = world.interact()
+	assert_eq(opened[0]["status"], &"waiting", JSON.stringify(opened))
+	assert_string_contains(String(opened[0]["event"]["text"]), "This tree can be")
+	assert_string_contains(String(opened[0]["event"]["text"]), "Want to use CUT?")
+
+	var asked: Array = world.run_event_queue(true)
+	assert_eq(asked[0]["event"]["type"], &"choice", JSON.stringify(asked))
+	_world_screen._show_script_results(world.choose_script_input(0))
+	assert_eq(_shown_text(), "TESTMON used CUT!")
+	# Script_Cut still only writes the block after UseCutText.
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE_CUT)
+	assert_true(world.can_walk_to(TREE_CELL))
+
+
+## `iffalse .declined` is closetext and end: no is no, and nothing is staged.
+func test_declining_the_cut_prompt_leaves_the_tree_standing() -> void:
+	await _open_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	world.interact()
+	world.run_event_queue(true)
+	var declined: Array = world.choose_script_input(1)
+	assert_eq(declined[0]["status"], &"complete", JSON.stringify(declined))
+	assert_true(world.pending_cut().is_empty())
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+
+
+## TryCutOW checks CheckPartyMove and then the badge, and a failure of either
+## reaches CantCutScript, whose _CanCutText says the tree could be cut without
+## offering to. There is no yes/no behind it.
+func test_a_cut_tree_without_the_badge_only_reports_that_it_can_be_cut() -> void:
+	await _open_world(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	var opened: Array = world.interact()
+	assert_eq(String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.CUT_CAN_TEXT)
+	var after: Array = world.run_event_queue(true)
+	assert_eq(after[0]["status"], &"complete", JSON.stringify(after))
+	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
+
+
+## The same branch reached without the move at all, which is CheckPartyMove
+## failing first.
+func test_a_cut_tree_without_the_move_reports_the_same_text() -> void:
+	await _open_world(true, Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_HIVE)
+	var opened: Array = _world_screen._world.interact()
+	assert_eq(String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.CUT_CAN_TEXT)
+
+
+## `.headbutt` is CheckPartyMove and nothing else, and its failure is
+## `.noevent`: no text, no choice, nothing at all.
+func test_facing_a_headbutt_tree_asks_and_without_the_move_says_nothing() -> void:
+	await _open_headbutt_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var opened: Array = world.interact()
+	assert_string_contains(String(opened[0]["event"]["text"]), "Want to HEADBUTT")
+	var asked: Array = world.run_event_queue(true)
+	assert_eq(asked[0]["event"]["type"], &"choice")
+
+	await _open_world(true, Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE,
+		HEADBUTT_STAND_CELL)
+	var silent: Array = _world_screen._world.interact()
+	assert_eq(silent[0]["status"], &"complete", JSON.stringify(silent))
+	assert_eq(
+		silent[0]["events"], [],
+		"TryHeadbuttOW answers no carry, so the player event ends with nothing shown"
+	)
+
+
+## `.surf` is the fallback branch every other tile reaches, and it is silent on
+## every failure: no badge, no move and no water each end the player event with
+## nothing shown.
+func test_facing_water_asks_to_surf_and_is_silent_without_the_badge() -> void:
+	await _open_surf_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var opened: Array = world.interact()
+	assert_eq(String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.SURF_ASK_TEXT)
+	_world_screen._show_script_results(world.run_event_queue(true))
+	_world_screen._show_script_results(world.choose_script_input(0))
+	assert_eq(_shown_text(), "TESTMON used SURF!")
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
+
+	await _open_surf_world(false)
+	var quiet: Array = _world_screen._world.interact()
+	assert_eq(quiet[0]["status"], &"complete", JSON.stringify(quiet))
+	assert_eq(
+		quiet[0]["events"], [],
+		"TrySurfOW quits with no carry when the badge is missing"
+	)
+
+
+## A wall is not a surf prompt, and neither is anything else that is not water:
+## `.surf` reads GetTilePermission before it reads anything else.
+func test_facing_a_plain_wall_offers_no_prompt_at_all() -> void:
+	await _open_world()
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(_world_screen._world.interact(), [])
+
+
+## TryWhirlpoolOW checks the party, the badge and then TryWhirlpoolMenu, and any
+## of the three failing reaches Script_MightyWhirlpool rather than an offer.
+func test_facing_a_whirlpool_asks_before_dispelling_it() -> void:
+	await _open_whirlpool_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var opened: Array = world.interact()
+	assert_eq(String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.WHIRLPOOL_ASK_TEXT)
+	world.run_event_queue(true)
+	_world_screen._show_script_results(world.choose_script_input(0))
+	assert_eq(_shown_text(), "TESTMON used WHIRLPOOL!")
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL)
+	_world_screen._acknowledge_field_move_text()
+	assert_eq(world.block_at(WHIRLPOOL_BLOCK.x, WHIRLPOOL_BLOCK.y), BLOCK_WHIRLPOOL_GONE)
+
+
+func test_a_whirlpool_without_the_badge_reports_that_a_mon_may_pass_it() -> void:
+	await _open_whirlpool_world(false)
+	var opened: Array = _world_screen._world.interact()
+	assert_eq(
+		String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.WHIRLPOOL_MAY_PASS_TEXT
+	)
+	var after: Array = _world_screen._world.run_event_queue(true)
+	assert_eq(after[0]["status"], &"complete", "no yes/no follows the refusal")
+
+
+## CheckMapCanWaterfall is two tests and no more: the facing must be up and the
+## tile above must be a waterfall. Facing it from the side is the refusal, not
+## the offer, which is why the prompt carries the facing question and the badge
+## does not answer it.
+func test_facing_a_waterfall_asks_only_when_facing_up() -> void:
+	await _open_waterfall_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var opened: Array = world.interact()
+	assert_eq(String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.WATERFALL_ASK_TEXT)
+	world.run_event_queue(true)
+	_world_screen._show_script_results(world.choose_script_input(0))
+	assert_eq(_shown_text(), "TESTMON used WATERFALL!")
+	_world_screen._acknowledge_field_move_text()
+	# The climb runs the whole column and ends on the first cell above it that
+	# is not a waterfall, which is one past the top of the two.
+	assert_eq(world.player_cell, WATERFALL_TOP_CELL + Vector2i.UP)
+
+
+func test_a_waterfall_without_the_badge_reports_a_huge_waterfall() -> void:
+	await _open_waterfall_world(false)
+	var opened: Array = _world_screen._world.interact()
+	assert_eq(
+		String(opened[0]["event"]["text"]), Gen2WorldScriptRunner.WATERFALL_HUGE_TEXT
+	)
+
+
+func _open_waterfall_world(badge: bool = true) -> void:
+	await _open_world(
+		badge, Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING,
+		WATERFALL_STAND_CELL
+	)
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
+	_world_screen._world.movement_mode = Gen2WorldAPI.MOVEMENT_SURF

--- a/tools/validate_field_move_prompts.gd
+++ b/tools/validate_field_move_prompts.gd
@@ -1,0 +1,253 @@
+extends SceneTree
+
+## Verifies the overworld field-move prompts against freshly imported real
+## caches, for both command profiles.
+##
+## The expected values come from the pinned pokecrystal and pokegold sources:
+## engine/overworld/events.asm's TryTileCollisionEvent from `.cut` on, and
+## engine/events/overworld.asm's TryCutOW, TryWhirlpoolOW, TryWaterfallOW,
+## TryHeadbuttOW, TrySurfOW and the five Ask*Scripts behind them, all of which
+## are byte identical between the pins.
+##
+## The real-cartridge counterpart to the prompt half of
+## tests/integration/test_world_field_move_screen.gd. Each move is driven on the
+## same map its own validator uses, so a failure here is about the prompt rather
+## than about the move.
+##
+##   Godot --headless --path . -s res://tools/validate_field_move_prompts.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## validate_cut.gd's Ilex Forest tree, and the cell it is faced from.
+const ILEX_GROUP: int = 3
+const ILEX_NUMBER_CRYSTAL: int = 52
+const ILEX_NUMBER_GOLD_SILVER: int = 44
+const ILEX_TREE_CELL := Vector2i(8, 25)
+
+## validate_surf.gd's New Bark Town shore, the same in all three games.
+const NEW_BARK_GROUP: int = 24
+const NEW_BARK_NUMBER: int = 4
+const NEW_BARK_SHORE_CELL := Vector2i(17, 6)
+const NEW_BARK_WATER_CELL := Vector2i(18, 6)
+
+## validate_headbutt.gd's Ilex Forest tree, faced from below.
+const ILEX_HEADBUTT_CELL := Vector2i(13, 0)
+const ILEX_HEADBUTT_STAND := Vector2i(13, 1)
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_cut_prompt(game_id, data, crystal)
+		_verify_surf_prompt(game_id, data, crystal)
+		_verify_headbutt_prompt(game_id, data, crystal)
+	_finish()
+
+
+## TryCutOW: CheckPartyMove, then ENGINE_HIVEBADGE, then AskCutScript. A failure
+## of either gate is CantCutScript's _CanCutText, which has no yes/no behind it.
+func _verify_cut_prompt(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var number: int = ILEX_NUMBER_CRYSTAL if crystal else ILEX_NUMBER_GOLD_SILVER
+	var world: Gen2WorldAPI = _world(
+		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP,
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldFieldMove.MOVE_CUT,
+		Gen2WorldFieldMove.BADGE_HIVE, crystal
+	)
+	if world == null:
+		_fail("%s: Ilex Forest is missing." % game_id)
+		return
+	var opened: Array = world.interact()
+	if not _check(
+		_waiting_text(opened) == Gen2WorldScriptRunner.CUT_ASK_TEXT,
+		"%s: facing Ilex Forest's cut tree asked %s." % [game_id, _waiting_text(opened)]
+	):
+		return
+	_check(
+		_choice_offered(world.run_event_queue(true)),
+		"%s: AskCutScript's yesorno did not follow its text." % game_id
+	)
+	var confirmed: Array = world.choose_script_input(0)
+	_check(
+		_confirmed_move(confirmed) == Gen2WorldFieldMove.MOVE_CUT,
+		"%s: a yes did not confirm CUT." % game_id
+	)
+
+	# The badge alone decides between the offer and CantCutScript, so the same
+	# tree with no badge is the refusal and nothing else.
+	var unbadged: Gen2WorldAPI = _world(
+		data, ILEX_GROUP, number, ILEX_TREE_CELL + Vector2i.UP,
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldFieldMove.MOVE_CUT, -1, crystal
+	)
+	var refused: Array = unbadged.interact()
+	_check(
+		_waiting_text(refused) == Gen2WorldScriptRunner.CUT_CAN_TEXT,
+		"%s: an unbadged cut tree said %s." % [game_id, _waiting_text(refused)]
+	)
+	_check(
+		StringName((unbadged.run_event_queue(true)[0] as Dictionary).get("status", &"")) \
+			== &"complete",
+		"%s: CantCutScript offered a choice it does not have." % game_id
+	)
+
+
+## TrySurfOW is the `.surf` fallback every tile that matched nothing else
+## reaches, and every one of its failures is silent.
+func _verify_surf_prompt(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var world: Gen2WorldAPI = _world(
+		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, NEW_BARK_SHORE_CELL,
+		Gen2WorldSprite.FACING_RIGHT, Gen2WorldFieldMove.MOVE_SURF,
+		Gen2WorldFieldMove.BADGE_FOG, crystal
+	)
+	if world == null:
+		_fail("%s: New Bark Town is missing." % game_id)
+		return
+	_check(
+		world.collision_permission_at(NEW_BARK_WATER_CELL) == Gen2WorldCollision.WATER_TILE,
+		"%s: New Bark Town %s is not water." % [game_id, NEW_BARK_WATER_CELL]
+	)
+	var opened: Array = world.interact()
+	if not _check(
+		_waiting_text(opened) == Gen2WorldScriptRunner.SURF_ASK_TEXT,
+		"%s: facing New Bark Town's water asked %s." % [game_id, _waiting_text(opened)]
+	):
+		return
+	world.run_event_queue(true)
+	_check(
+		_confirmed_move(world.choose_script_input(0)) == Gen2WorldFieldMove.MOVE_SURF,
+		"%s: a yes did not confirm SURF." % game_id
+	)
+
+	# Without the badge TrySurfOW answers no carry: no text, no choice.
+	var unbadged: Gen2WorldAPI = _world(
+		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, NEW_BARK_SHORE_CELL,
+		Gen2WorldSprite.FACING_RIGHT, Gen2WorldFieldMove.MOVE_SURF, -1, crystal
+	)
+	_check(
+		_silent(unbadged.interact()),
+		"%s: an unbadged shore was not silent." % game_id
+	)
+	# Facing away from the water is not the surf branch at all.
+	var inland: Gen2WorldAPI = _world(
+		data, NEW_BARK_GROUP, NEW_BARK_NUMBER, NEW_BARK_SHORE_CELL,
+		Gen2WorldSprite.FACING_LEFT, Gen2WorldFieldMove.MOVE_SURF,
+		Gen2WorldFieldMove.BADGE_FOG, crystal
+	)
+	_check(
+		inland.interact().is_empty(),
+		"%s: facing inland produced a prompt." % game_id
+	)
+
+
+## TryHeadbuttOW is CheckPartyMove and nothing else, so its only two answers are
+## the ask and silence.
+func _verify_headbutt_prompt(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var number: int = ILEX_NUMBER_CRYSTAL if crystal else ILEX_NUMBER_GOLD_SILVER
+	var world: Gen2WorldAPI = _world(
+		data, ILEX_GROUP, number, ILEX_HEADBUTT_STAND, Gen2WorldSprite.FACING_UP,
+		Gen2WorldFieldMove.MOVE_HEADBUTT, -1, crystal
+	)
+	if world == null:
+		_fail("%s: Ilex Forest is missing." % game_id)
+		return
+	var opened: Array = world.interact()
+	_check(
+		_waiting_text(opened) == Gen2WorldScriptRunner.HEADBUTT_ASK_TEXT,
+		"%s: facing Ilex Forest's headbutt tree asked %s." % [game_id, _waiting_text(opened)]
+	)
+	_check(
+		_choice_offered(world.run_event_queue(true)),
+		"%s: AskHeadbuttScript's yesorno did not follow its text." % game_id
+	)
+
+	var unknowing: Gen2WorldAPI = _world(
+		data, ILEX_GROUP, number, ILEX_HEADBUTT_STAND, Gen2WorldSprite.FACING_UP,
+		Gen2WorldFieldMove.MOVE_CUT, -1, crystal
+	)
+	_check(
+		_silent(unknowing.interact()),
+		"%s: a headbutt tree without the move was not silent." % game_id
+	)
+	print("%s: cut, surf and headbutt prompts answered on their own maps." % game_id)
+
+
+## A world standing where it was put, knowing one move and holding at most one
+## badge. Every field-move gate reads only these.
+func _world(
+	data: GameData, group: int, number: int, cell: Vector2i, facing: int,
+	move: int, badge: int, crystal: bool
+) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	if badge >= 0:
+		state.set_engine_flag(Gen2WorldState.badge_flag(badge, crystal))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, cell, state)
+	if world == null:
+		return null
+	world.player_facing = facing
+	world.set_player_id(0)
+	world.set_party_summary(
+		1, false, [1] as Array[int], [[move]], ["MON"], [false]
+	)
+	return world
+
+
+func _waiting_text(results: Array) -> String:
+	if results.is_empty():
+		return ""
+	var result: Dictionary = results[0]
+	if StringName(result.get("status", &"")) != &"waiting":
+		return ""
+	return String((result.get("event", {}) as Dictionary).get("text", ""))
+
+
+func _choice_offered(results: Array) -> bool:
+	if results.is_empty():
+		return false
+	var event: Dictionary = (results[0] as Dictionary).get("event", {})
+	return StringName(event.get("type", &"")) == &"choice"
+
+
+## `.noevent`: the player event ends having shown nothing. A completed result
+## with no events is what that looks like here.
+func _silent(results: Array) -> bool:
+	if results.is_empty():
+		return true
+	var result: Dictionary = results[0]
+	return StringName(result.get("status", &"")) == &"complete" \
+		and (result.get("events", []) as Array).is_empty()
+
+
+func _confirmed_move(results: Array) -> int:
+	for result: Variant in results:
+		if not result is Dictionary:
+			continue
+		for event: Variant in (result as Dictionary).get("events", []):
+			if event is Dictionary \
+				and StringName((event as Dictionary).get("type", &"")) == &"field_move_confirmed":
+				return int((event as Dictionary).get("move", 0))
+	return 0
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS field move prompts: the tile chain, both gates and all three answers verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_field_move_prompts.gd.uid
+++ b/tools/validate_field_move_prompts.gd.uid
@@ -1,0 +1,1 @@
+uid://b3ntfi54a36ma


### PR DESCRIPTION
TryTileCollisionEvent does not end at CheckFacingTileForStdScript. Five field-move branches follow it, in the order cut tree, whirlpool, waterfall, headbutt tree, then surf as the fallback any other tile reaches, and each is a Try*OW gate and an Ask*Script. Facing a tree and pressing A is how the cartridge teaches every one of these; the party submenu was the only way in here.

The split follows what each layer can see. Which branch a tile takes is the world's answer, and so is the tile-shaped half of the gate: CheckCutTreeTile is the two tree codes alone rather than CheckCutCollision's six, so tall grass offers nothing while the submenu still cuts it, and TryWhirlpoolMenu's block lookup and CheckMapCanWaterfall's facing ride along as tile_ok. The party and the badge are the runner's, which synthesizes each ask off the request kind the way it already synthesizes an item ball, since CallScript's operand is a link-time address the pins do not resolve.

Three branches refuse in the cartridge's own words and two say nothing at all. A yes runs the same staged request the submenu reaches, so both ways in stay one path, and AskCutScript's own tile check happens after the yes, which is why a refusal is silent here and spoken there.