### PR TITLE
Let the player set the options without leaving the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,10 @@ Battle-screen moves are random and a full move set declines the learn offer; use
 `show_trainer(trainer_class)` for a real party and trainer AI, or `show_matchup`
 for a fallback pairing.
 
-The world screen's start menu wires Pokemon, Pack, Pokegear, Save and Exit;
-Pokedex, Player and Options appear in their source position but do nothing yet.
+The world screen's start menu wires Pokemon, Pack, Pokegear, Save, Options and
+Exit; Pokedex and Player appear in their source position but do nothing yet.
+Options is the cartridge's own seven-row OPTION screen over the same values the
+launcher's settings edit, so the two can never disagree.
 Pokegear opens its card list, in the source's clock, map, phone, radio order and
 showing only cards the player owns; the map card keeps its position marked
 unavailable. The radio card tunes with left and right over the cartridge's own

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -99,13 +99,15 @@ imported caller/callee script at the same transaction boundary. Audio stays
 behind bounded decoder, renderer and player layers.
 
 `world_start_menu.gd` models `engine/menus/start_menu.asm`'s item list: source
-Pokedex/Pokemon/Pokegear gating, the `STATICMENU_WRAP` cursor, and Pokedex,
-Player and Options built in their source position marked unavailable rather than
-omitted. `world_pack.gd` groups owned items into the four cartridge pockets by
+Pokedex/Pokemon/Pokegear gating, the `STATICMENU_WRAP` cursor, and Pokedex and
+Player built in their source position marked unavailable rather than omitted.
+`world_options_menu.gd` models `engine/menus/options_menu.asm` over
+[Gen2Options], seven value rows plus CANCEL, and leaves persistence to
+`Gen2OptionsStore`. `world_pack.gd` groups owned items into the four cartridge pockets by
 the item type byte `GameData` imports under the confusingly-named `pocket`
 field; it is presentation only, item counts stay a flat map on `Gen2WorldState`
 and pocket capacities are not enforced. `start_menu_screen.gd` is the overlay,
-owning Pack and a Save confirmation as internal modes the way
+owning Pack, a Save confirmation and the OPTION menu as internal modes the way
 `world_service_screen.gd` owns a mart mode, and delegating Pokemon and Pokegear
 to the existing screens. `Gen2PartyScreen` and `Gen2BoxScreen` share one
 embedded-mode shape, a `set_context(..., embedded)` flag and a `closed(result)`

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -401,7 +401,7 @@ func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
 ```
 
 A start-menu entry without a handler still appears, marked unavailable, which is
-what Pokedex, Player and Options already do. A pocket's number has to be at or
+what Pokedex and Player already do. A pocket's number has to be at or
 above `Gen2ModHost.FIRST_MOD_POCKET`: 1 to 4 are the cartridge's ITEM, KEY_ITEM,
 BALL and TM_HM, and an item joins the pocket its own definition names. Two mods
 claiming the same entry id is refused with `duplicate_menu_entry` rather than one

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -19,7 +19,7 @@ signal closed
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
 	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING,
-	PACK_RESULT, SAVE_CONFIRM,
+	PACK_RESULT, SAVE_CONFIRM, OPTIONS,
 }
 
 ## engine/items/pack.asm's own refusal texts, verbatim from data/text/common_2.asm.
@@ -68,6 +68,8 @@ var _forget_confirm_cursor: int = 0
 
 var _save_cursor: int = 0
 var _save_result_shown: bool = false
+
+var _options_menu: Gen2WorldOptionsMenu = null
 
 var _title: Label = null
 var _summary: Label = null
@@ -181,6 +183,13 @@ func _move(direction: Vector2i) -> void:
 			if not _save_result_shown and (direction.x != 0 or direction.y != 0):
 				_save_cursor = 1 - _save_cursor
 				_render_save_confirm()
+		Mode.OPTIONS:
+			if direction.y != 0:
+				_options_menu.move(direction.y)
+				_render_options_menu()
+			elif direction.x != 0 and _options_menu.adjust(direction.x):
+				_persist_options()
+				_render_options_menu()
 
 
 func _confirm() -> void:
@@ -209,6 +218,10 @@ func _confirm() -> void:
 			_open_pack_mode(false)
 		Mode.SAVE_CONFIRM:
 			_confirm_save()
+		## Options_Cancel is the only handler that reads A.
+		Mode.OPTIONS:
+			if _options_menu.is_cancel():
+				_open_list_mode()
 
 
 func _cancel() -> void:
@@ -230,6 +243,9 @@ func _cancel() -> void:
 			_open_item_mode()
 		Mode.SAVE_CONFIRM:
 			_open_list_mode()
+		## `_Option.joypad_loop` exits on PAD_START | PAD_B from any row.
+		Mode.OPTIONS:
+			_open_list_mode()
 
 
 func _confirm_list() -> void:
@@ -244,6 +260,8 @@ func _confirm_list() -> void:
 			_open_pack_mode()
 		Gen2WorldStartMenu.ITEM_SAVE:
 			_open_save_confirm_mode()
+		Gen2WorldStartMenu.ITEM_OPTION:
+			_open_options_mode()
 		Gen2WorldStartMenu.ITEM_EXIT:
 			closed.emit()
 		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_POKEGEAR:
@@ -271,6 +289,37 @@ func _render_list() -> void:
 	_render_options(_menu.items(), _menu.cursor, func(entry: Dictionary) -> String:
 		var label: String = String(entry.get("label", ""))
 		return label if bool(entry.get("available", false)) else "%s (unavailable)" % label
+	)
+
+
+## `StartMenu_Option`'s `farcall Option`. The model edits the shared
+## [Gen2OptionsStore] object, so the launcher's settings card and this menu can
+## never disagree about a value, which is the same reason the cartridge block
+## exists at all.
+func _open_options_mode() -> void:
+	_mode = Mode.OPTIONS
+	_options_menu = Gen2WorldOptionsMenu.build(Gen2OptionsStore.current())
+	_title.text = "OPTION"
+	_summary.text = ""
+	_status.text = ""
+	_footer.text = "Up and down: move    Left and right: change    B: back"
+	_render_options_menu()
+
+
+## Written on every change, matching the launcher card and the cartridge, which
+## commits each press to `wOptions` rather than on the way out.
+func _persist_options() -> void:
+	if Gen2OptionsStore.save(_options_menu.options()):
+		return
+	_status.text = "The options file could not be written."
+	_status.add_theme_color_override("font_color", ERROR)
+
+
+func _render_options_menu() -> void:
+	_render_options(_options_menu.rows(), _options_menu.cursor, func(row: Dictionary) -> String:
+		var value: String = String(row.get("value", ""))
+		var label: String = String(row.get("label", ""))
+		return label if value.is_empty() else "%s    %s" % [label, value]
 	)
 
 

--- a/game/world/world_options_menu.gd
+++ b/game/world/world_options_menu.gd
@@ -1,0 +1,147 @@
+class_name Gen2WorldOptionsMenu
+extends RefCounted
+
+## Scene-free model of the in-game OPTION menu (engine/menus/options_menu.asm).
+##
+## Seven value rows plus CANCEL, each row a left/right cycle over one field of
+## [Gen2Options]. The model edits that object in place and never touches the
+## file: [Gen2OptionsStore] owns persistence, the way [Gen2InputActions] leaves
+## it alone.
+##
+## `data/default_options.asm` and the whole menu are byte identical between the
+## pins except pokegold's `.ExitOptions` lacking the `SFX_TRANSACTION` play, so
+## nothing here is profile split.
+
+## GetOptionPointer.Pointers indexes.
+const OPT_TEXT_SPEED: int = 0
+const OPT_BATTLE_SCENE: int = 1
+const OPT_BATTLE_STYLE: int = 2
+const OPT_SOUND: int = 3
+const OPT_PRINT: int = 4
+const OPT_MENU_ACCOUNT: int = 5
+const OPT_FRAME: int = 6
+const OPT_CANCEL: int = 7
+const NUM_OPTIONS: int = 8
+
+## `StringOptions` and each handler's own value strings.
+const TEXT_SPEED_VALUES: Array[String] = ["FAST", "MID", "SLOW"]
+const PRINT_VALUES: Array[String] = ["LIGHTEST", "LIGHTER", "NORMAL", "DARKER", "DARKEST"]
+
+const ROWS: Array[Dictionary] = [
+	{"index": OPT_TEXT_SPEED, "label": "TEXT SPEED"},
+	{"index": OPT_BATTLE_SCENE, "label": "BATTLE SCENE"},
+	{"index": OPT_BATTLE_STYLE, "label": "BATTLE STYLE"},
+	{"index": OPT_SOUND, "label": "SOUND"},
+	{"index": OPT_PRINT, "label": "PRINT"},
+	{"index": OPT_MENU_ACCOUNT, "label": "MENU ACCOUNT"},
+	{"index": OPT_FRAME, "label": "FRAME"},
+	{"index": OPT_CANCEL, "label": "CANCEL"},
+]
+
+var cursor: int = 0
+var _options: Gen2Options = null
+
+
+static func build(options: Gen2Options) -> Gen2WorldOptionsMenu:
+	var menu := Gen2WorldOptionsMenu.new()
+	menu._options = options if options != null else Gen2Options.new()
+	return menu
+
+
+func options() -> Gen2Options:
+	return _options
+
+
+func size() -> int:
+	return ROWS.size()
+
+
+## `OptionsControl`. Its two odd branches, `.CheckMenuAccount` writing
+## OPT_MENU_ACCOUNT back before its own `inc` and `.UpPressed` special-casing
+## OPT_FRAME, each land on exactly the value the plain step would, so this is a
+## plain wrap in both directions. The source's own comments call them
+## unexplained.
+func move(delta: int) -> bool:
+	if delta == 0:
+		return false
+	cursor = wrapi(cursor + signi(delta), 0, ROWS.size())
+	return true
+
+
+## CANCEL is the only row A answers: every other handler reads left and right
+## alone, so A on them does nothing.
+func is_cancel() -> bool:
+	return cursor == OPT_CANCEL
+
+
+## Left or right on the selected row. The four bit rows toggle on either
+## direction, since each handler's `.LeftPressed` jumps to the opposite branch
+## from `.NonePressed` rather than stepping the other way. Returns whether a
+## value changed, so a caller knows when to write the file.
+func adjust(delta: int) -> bool:
+	if delta == 0:
+		return false
+	var step: int = signi(delta)
+	match cursor:
+		OPT_TEXT_SPEED:
+			_options.text_speed = wrapi(
+				_options.text_speed + step, 0, TEXT_SPEED_VALUES.size()
+			)
+		OPT_BATTLE_SCENE:
+			_options.battle_scene = not _options.battle_scene
+		OPT_BATTLE_STYLE:
+			_options.battle_style_set = not _options.battle_style_set
+		OPT_SOUND:
+			_options.stereo = not _options.stereo
+		OPT_PRINT:
+			_options.printer_brightness = wrapi(
+				_options.printer_brightness + step, 0, PRINT_VALUES.size()
+			)
+		OPT_MENU_ACCOUNT:
+			_options.menu_account = not _options.menu_account
+		## `maskbits NUM_FRAMES`, so it wraps rather than clamping.
+		OPT_FRAME:
+			_options.textbox_frame = wrapi(
+				_options.textbox_frame + step, 0, Gen2Options.FRAME_COUNT
+			)
+		_:
+			return false
+	return true
+
+
+## One `{index, label, value}` per row for a renderer. CANCEL carries an empty
+## value, since the source prints no setting beside it.
+func rows() -> Array:
+	var built: Array = []
+	for row: Dictionary in ROWS:
+		built.append({
+			"index": int(row["index"]),
+			"label": String(row["label"]),
+			"value": _value_label(int(row["index"])),
+		})
+	return built
+
+
+func _value_label(index: int) -> String:
+	match index:
+		OPT_TEXT_SPEED:
+			return TEXT_SPEED_VALUES[
+				clampi(_options.text_speed, 0, TEXT_SPEED_VALUES.size() - 1)
+			]
+		OPT_BATTLE_SCENE:
+			return "ON" if _options.battle_scene else "OFF"
+		OPT_BATTLE_STYLE:
+			return "SET" if _options.battle_style_set else "SHIFT"
+		OPT_SOUND:
+			return "STEREO" if _options.stereo else "MONO"
+		OPT_PRINT:
+			return PRINT_VALUES[
+				clampi(_options.printer_brightness, 0, PRINT_VALUES.size() - 1)
+			]
+		OPT_MENU_ACCOUNT:
+			return "ON" if _options.menu_account else "OFF"
+		## `UpdateFrame` draws the stored 0-7 with `add '1'`.
+		OPT_FRAME:
+			return "TYPE %d" % (clampi(_options.textbox_frame, 0, Gen2Options.FRAME_COUNT - 1) + 1)
+		_:
+			return ""

--- a/game/world/world_options_menu.gd.uid
+++ b/game/world/world_options_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://sbjuxawk2mcx

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -8,10 +8,10 @@ extends RefCounted
 ## Pokemon behind a non-zero wPartyCount, Pokegear behind
 ## wPokegearFlags/POKEGEAR_OBTAINED_F.
 ##
-## This project has no dex, trainer card or options screen, so those three are
-## still built in their source position and marked unavailable rather than
-## omitted, keeping the list shape stable for whichever arrives first. QUIT never
-## appears because its Bug Contest and link-mode gate is never true here.
+## This project has no dex or trainer card, so those two are still built in
+## their source position and marked unavailable rather than omitted, keeping the
+## list shape stable for whichever arrives first. QUIT never appears because its
+## Bug Contest and link-mode gate is never true here.
 ##
 ## Entries registered on `Gen2ModHost` are spliced in ahead of EXIT, so a mod can
 ## add a screen without reordering or removing anything the cartridge shipped.
@@ -53,7 +53,7 @@ const SOURCE_ENTRIES: Array[Dictionary] = [
 	{"kind": ITEM_POKEGEAR, "label": "Pokegear", "available": true, "gate": GATE_POKEGEAR},
 	{"kind": ITEM_PLAYER, "label": "Player", "available": false, "gate": &""},
 	{"kind": ITEM_SAVE, "label": "Save", "available": true, "gate": &""},
-	{"kind": ITEM_OPTION, "label": "Options", "available": false, "gate": &""},
+	{"kind": ITEM_OPTION, "label": "Options", "available": true, "gate": &""},
 	{"kind": ITEM_EXIT, "label": "Exit", "available": true, "gate": &""},
 ]
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -13,6 +13,10 @@ func before_each() -> void:
 	_data = Fixture.build()
 	_write_pack_item()
 	_data = GameData.open_directory(Fixture.directory())
+	## The OPTION menu writes through Gen2OptionsStore, so the file and the
+	## shared instance both start clean.
+	Gen2OptionsStore.forget_cached()
+	DirAccess.remove_absolute(Gen2OptionsStore.PATH)
 
 
 func after_each() -> void:
@@ -20,6 +24,8 @@ func after_each() -> void:
 		_world_screen.free()
 		_world_screen = null
 	RomCache.clear(Fixture.directory())
+	Gen2OptionsStore.forget_cached()
+	DirAccess.remove_absolute(Gen2OptionsStore.PATH)
 
 
 ## Item 7 carries POTION's real ItemAttributes row, so the pack builds the
@@ -602,3 +608,58 @@ func test_an_item_with_no_field_menu_reports_oaks_refusal() -> void:
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
 	assert_eq(String(host.get("_pack_result")), Gen2StartMenuScreen.OAK_TEXT)
 	assert_eq(_world_screen._world.state.item_quantity(7), 1)
+
+
+## StartMenu_Option's farcall Option, as a mode on this screen.
+func _open_options_menu() -> Gen2StartMenuScreen:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_OPTION)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.OPTIONS)
+	return host
+
+
+func test_option_is_available_and_opens_the_option_menu() -> void:
+	var host: Gen2StartMenuScreen = await _open_options_menu()
+	var menu: Gen2WorldOptionsMenu = host.get("_options_menu")
+	assert_eq(menu.size(), Gen2WorldOptionsMenu.NUM_OPTIONS)
+	assert_eq(menu.cursor, Gen2WorldOptionsMenu.OPT_TEXT_SPEED)
+
+
+func test_a_change_reaches_the_shared_options_and_the_file() -> void:
+	var host: Gen2StartMenuScreen = await _open_options_menu()
+	var menu: Gen2WorldOptionsMenu = host.get("_options_menu")
+	menu.cursor = Gen2WorldOptionsMenu.OPT_BATTLE_STYLE
+	assert_false(Gen2OptionsStore.current().battle_style_set)
+	host.handle_button(Gen2Button.RIGHT)
+	assert_true(Gen2OptionsStore.current().battle_style_set)
+
+	Gen2OptionsStore.forget_cached()
+	assert_true(Gen2OptionsStore.current().battle_style_set)
+
+
+## Every other handler reads left and right alone, so A on a value row does
+## nothing and the menu stays open.
+func test_a_on_a_value_row_changes_nothing_and_cancel_returns_to_the_list() -> void:
+	var host: Gen2StartMenuScreen = await _open_options_menu()
+	var menu: Gen2WorldOptionsMenu = host.get("_options_menu")
+	menu.cursor = Gen2WorldOptionsMenu.OPT_SOUND
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.OPTIONS)
+	assert_false(Gen2OptionsStore.current().stereo)
+
+	menu.cursor = Gen2WorldOptionsMenu.OPT_CANCEL
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+
+
+## _Option.joypad_loop exits on PAD_B from any row.
+func test_b_returns_to_the_list_from_a_value_row() -> void:
+	var host: Gen2StartMenuScreen = await _open_options_menu()
+	(host.get("_options_menu") as Gen2WorldOptionsMenu).cursor = Gen2WorldOptionsMenu.OPT_FRAME
+	host.handle_button(Gen2Button.B)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+	assert_not_null(_world_screen._start_menu_host)

--- a/tests/unit/test_world_options_menu.gd
+++ b/tests/unit/test_world_options_menu.gd
@@ -1,0 +1,164 @@
+extends GutTest
+
+## The in-game OPTION menu model (engine/menus/options_menu.asm).
+
+var _options: Gen2Options = null
+var _menu: Gen2WorldOptionsMenu = null
+
+
+func before_each() -> void:
+	_options = Gen2Options.new()
+	_menu = Gen2WorldOptionsMenu.build(_options)
+
+
+func _select(index: int) -> void:
+	_menu.cursor = index
+
+
+func _value_at(index: int) -> String:
+	return String(_menu.rows()[index].get("value", ""))
+
+
+func test_the_rows_are_the_source_order_and_labels() -> void:
+	var labels: Array = []
+	for row: Dictionary in _menu.rows():
+		labels.append(String(row.get("label", "")))
+	assert_eq(labels, [
+		"TEXT SPEED", "BATTLE SCENE", "BATTLE STYLE", "SOUND",
+		"PRINT", "MENU ACCOUNT", "FRAME", "CANCEL",
+	])
+	assert_eq(_menu.size(), Gen2WorldOptionsMenu.NUM_OPTIONS)
+
+
+func test_cancel_carries_no_value_and_is_the_only_row_a_answers() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_CANCEL)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_CANCEL), "")
+	assert_true(_menu.is_cancel())
+	_select(Gen2WorldOptionsMenu.OPT_FRAME)
+	assert_false(_menu.is_cancel())
+
+
+## OptionsControl wraps at both ends; its two odd branches land on the same
+## value the plain step does.
+func test_the_cursor_wraps_at_both_ends() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_CANCEL)
+	_menu.move(1)
+	assert_eq(_menu.cursor, Gen2WorldOptionsMenu.OPT_TEXT_SPEED)
+	_menu.move(-1)
+	assert_eq(_menu.cursor, Gen2WorldOptionsMenu.OPT_CANCEL)
+
+
+func test_menu_account_and_frame_step_normally_despite_the_source_oddities() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_MENU_ACCOUNT)
+	_menu.move(1)
+	assert_eq(_menu.cursor, Gen2WorldOptionsMenu.OPT_FRAME)
+	_menu.move(-1)
+	assert_eq(_menu.cursor, Gen2WorldOptionsMenu.OPT_MENU_ACCOUNT)
+
+
+func test_move_by_zero_changes_nothing() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_SOUND)
+	assert_false(_menu.move(0))
+	assert_eq(_menu.cursor, Gen2WorldOptionsMenu.OPT_SOUND)
+
+
+func test_text_speed_cycles_and_wraps_both_ways() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_TEXT_SPEED)
+	_options.text_speed = 0
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_TEXT_SPEED), "FAST")
+	_menu.adjust(1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_TEXT_SPEED), "MID")
+	_menu.adjust(1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_TEXT_SPEED), "SLOW")
+	_menu.adjust(1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_TEXT_SPEED), "FAST")
+	_menu.adjust(-1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_TEXT_SPEED), "SLOW")
+
+
+func test_print_cycles_five_values_and_wraps_both_ways() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_PRINT)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_PRINT), "NORMAL")
+	_menu.adjust(-1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_PRINT), "LIGHTER")
+	_menu.adjust(-1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_PRINT), "LIGHTEST")
+	_menu.adjust(-1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_PRINT), "DARKEST")
+	_menu.adjust(1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_PRINT), "LIGHTEST")
+
+
+## Each bit row's .LeftPressed jumps to the opposite branch from .NonePressed,
+## so left and right both toggle rather than stepping opposite ways.
+func test_the_four_bit_rows_toggle_on_either_direction() -> void:
+	for index: int in [
+		Gen2WorldOptionsMenu.OPT_BATTLE_SCENE,
+		Gen2WorldOptionsMenu.OPT_BATTLE_STYLE,
+		Gen2WorldOptionsMenu.OPT_SOUND,
+		Gen2WorldOptionsMenu.OPT_MENU_ACCOUNT,
+	]:
+		_select(index)
+		var start: String = _value_at(index)
+		_menu.adjust(1)
+		var toggled: String = _value_at(index)
+		assert_ne(toggled, start)
+		_menu.adjust(-1)
+		assert_eq(_value_at(index), start)
+		_menu.adjust(-1)
+		assert_eq(_value_at(index), toggled)
+
+
+func test_the_bit_rows_read_the_source_polarity() -> void:
+	_options.battle_scene = true
+	_options.battle_style_set = false
+	_options.stereo = false
+	_options.menu_account = true
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_BATTLE_SCENE), "ON")
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_BATTLE_STYLE), "SHIFT")
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_SOUND), "MONO")
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_MENU_ACCOUNT), "ON")
+	_options.battle_style_set = true
+	_options.stereo = true
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_BATTLE_STYLE), "SET")
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_SOUND), "STEREO")
+
+
+## `maskbits NUM_FRAMES` over eight frames, drawn one-based by `add '1'`.
+func test_frame_wraps_over_eight_types_and_is_drawn_one_based() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_FRAME)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_FRAME), "TYPE 1")
+	_menu.adjust(-1)
+	assert_eq(_options.textbox_frame, Gen2Options.FRAME_COUNT - 1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_FRAME), "TYPE 8")
+	_menu.adjust(1)
+	assert_eq(_value_at(Gen2WorldOptionsMenu.OPT_FRAME), "TYPE 1")
+
+
+func test_cancel_has_nothing_to_adjust() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_CANCEL)
+	assert_false(_menu.adjust(1))
+	assert_false(_menu.adjust(-1))
+
+
+func test_adjust_by_zero_changes_nothing() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_TEXT_SPEED)
+	assert_false(_menu.adjust(0))
+	assert_eq(_options.text_speed, 1)
+
+
+## The model edits the object it was handed, which is what lets the launcher
+## card and this menu share one Gen2OptionsStore instance.
+func test_the_menu_edits_the_options_object_it_was_given() -> void:
+	_select(Gen2WorldOptionsMenu.OPT_BATTLE_STYLE)
+	_menu.adjust(1)
+	assert_true(_options.battle_style_set)
+	assert_same(_menu.options(), _options)
+
+
+## A null Gen2Options is a caller mistake, not a crash: the menu builds its own
+## defaults the way Gen2Options.parse clamps rather than refusing.
+func test_a_null_options_object_builds_defaults() -> void:
+	var menu: Gen2WorldOptionsMenu = Gen2WorldOptionsMenu.build(null)
+	assert_not_null(menu.options())
+	assert_eq(menu.rows().size(), Gen2WorldOptionsMenu.NUM_OPTIONS)

--- a/tests/unit/test_world_options_menu.gd.uid
+++ b/tests/unit/test_world_options_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://bfgxk5ag4dlg1

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -59,7 +59,7 @@ func test_full_list_matches_the_source_item_order_when_every_gate_is_open() -> v
 	])
 
 
-func test_pack_pokemon_pokegear_save_and_exit_are_available_player_and_option_are_not() -> void:
+func test_every_entry_but_pokedex_and_player_is_available() -> void:
 	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
 	var available_by_kind: Dictionary = {}
 	for entry: Dictionary in menu.items():
@@ -69,9 +69,9 @@ func test_pack_pokemon_pokegear_save_and_exit_are_available_player_and_option_ar
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_POKEGEAR])
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_SAVE])
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_EXIT])
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_OPTION])
 	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_POKEDEX])
 	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_PLAYER])
-	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_OPTION])
 
 
 func test_quit_never_appears_because_this_project_has_no_bug_contest() -> void:


### PR DESCRIPTION
The start menu's OPTION entry opens the cartridge's own seven-row screen over the same Gen2Options object the launcher's settings card edits, so the two cannot disagree about a value.

Text speed and print cycle and wrap; battle scene, battle style, sound and menu account toggle on either direction, since each handler's .LeftPressed jumps to the opposite branch from .NonePressed; frame wraps under maskbits NUM_FRAMES and draws one-based. OptionsControl's two odd branches each land where a plain step does, so the cursor is a plain wrap. A answers CANCEL alone.