### PR TITLE
Open the Pokedex, and let it say what it knows

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,16 @@ Battle-screen moves are random and a full move set declines the learn offer; use
 `show_trainer(trainer_class)` for a real party and trainer AI, or `show_matchup`
 for a fallback pairing.
 
-The world screen's start menu wires Pokemon, Pack, Pokegear, Player, Save,
-Options and Exit; only Pokedex appears in its source position without doing
-anything yet. Options is the cartridge's own seven-row OPTION screen over the
-same values the launcher's settings edit, so the two can never disagree, and
-Player is the trainer card, drawn from the cartridge's own graphics with its
-badge pages and its play timer.
+The world screen's start menu wires every source entry: Pokedex, Pokemon, Pack,
+Pokegear, Player, Save, Options and Exit. Options is the cartridge's own
+seven-row OPTION screen over the same values the launcher's settings edit, so
+the two can never disagree, and Player is the trainer card, drawn from the
+cartridge's own graphics with its badge pages and its play timer.
+Pokedex lists the species in the cartridge's own NEW, OLD and A to Z orders,
+showing a name once seen and a caught mark once caught, and opens each seen
+species' entry with its category, height, weight and both description pages.
+SELECT changes the order; the mode is saved. Its SEARCH screen, the Unown dex
+and the entry screen's AREA, CRY and PRNT buttons are not built.
 Pokegear opens its card list, in the source's clock, map, phone, radio order and
 showing only cards the player owns; the map card keeps its position marked
 unavailable. The radio card tunes with left and right over the cartridge's own

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -99,8 +99,12 @@ imported caller/callee script at the same transaction boundary. Audio stays
 behind bounded decoder, renderer and player layers.
 
 `world_start_menu.gd` models `engine/menus/start_menu.asm`'s item list: source
-Pokedex/Pokemon/Pokegear gating, the `STATICMENU_WRAP` cursor, and Pokedex
-built in its source position marked unavailable rather than omitted.
+Pokedex/Pokemon/Pokegear gating and the `STATICMENU_WRAP` cursor.
+`pokedex.gd` models `engine/pokedex/pokedex.asm`'s listing: the three orderings
+`Pokedex_OrderMonsByMode` builds, `.FindLastSeen`'s listing end, `.PrintEntry`'s
+per-row decision and `Pokedex_ListingHandleDPadInput`'s cursor and paging walk.
+`pokedex_screen.gd` is its listing, entry and OPTION states; the entry's two
+measurements go through `_PrintNum`'s own blanking rather than a format string.
 `world_options_menu.gd` models `engine/menus/options_menu.asm` over
 [Gen2Options], seven value rows plus CANCEL, and leaves persistence to
 `Gen2OptionsStore`. `trainer_card.gd` and `render/trainer_card_page.gd` are

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -400,8 +400,8 @@ func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
 	})
 ```
 
-A start-menu entry without a handler still appears, marked unavailable, which is
-what Pokedex already does. A pocket's number has to be at or
+A start-menu entry without a handler still appears, marked unavailable. A
+pocket's number has to be at or
 above `Gen2ModHost.FIRST_MOD_POCKET`: 1 to 4 are the cartridge's ITEM, KEY_ITEM,
 BALL and TM_HM, and an item joins the pocket its own definition names. Two mods
 claiming the same entry id is refused with `duplicate_menu_entry` rather than one
@@ -411,6 +411,10 @@ silently winning.
 
 Semver ranges and inter-mod dependencies, per-mod save data, art for mod content,
 mutation hooks on the event channels, entries in the party submenu or the mart,
-and `.zip`/`.pck` packs through `ProjectSettings.load_resource_pack()`. Evaluate
+and `.zip`/`.pck` packs through `ProjectSettings.load_resource_pack()`. A mod
+species does not appear in the Pokedex either: both dex order tables are
+cartridge data of exactly 251 entries, and nothing splices `defined_numbers()`
+into them, though a mod species that replaces a cartridge one does carry its own
+dex entry. Evaluate
 [godot-mod-loader](https://github.com/GodotModding/godot-mod-loader) before
 expanding the loader itself.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -29,6 +29,9 @@ var _moves: Array = []
 ## TMHMMoves in TMNUM order, restored to integers because JSON reads them back
 ## as floats.
 var _tmhm_moves: Array[int] = []
+## The two cached dex orderings, by the key each mode reads, restored to
+## integers because JSON reads them back as floats.
+var _dex_orders: Dictionary = {}
 var _items: Array = []
 var _world_trades: Array = []
 var _types: Array = []
@@ -98,6 +101,7 @@ static func open_directory(path: String) -> GameData:
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
+	data._load_dex_orders(RomCache.dex_orders_path(path))
 	data._items = data._read_array(RomCache.items_path(path))
 	data._world_trades = data._read_array(RomCache.world_trades_path(path))
 	data._types = data._read_array(RomCache.types_path(path))
@@ -509,6 +513,58 @@ func learnset(number: int) -> Array:
 ## [constant RomLayout.EVOLVE_STAT].
 func evolutions(number: int) -> Array:
 	return _rows(species(number), "evolutions", ["method", "parameter", "condition", "target"])
+
+
+## A species' Pokedex entry as { category, height, weight, pages }, or an empty
+## Dictionary if there is no such number.
+##
+## [code]height[/code] and [code]weight[/code] are the cartridge's own numbers,
+## not measurements: see [method RomImporter.read_dex_entry]. [code]pages[/code]
+## is the two description pages, in order. It goes through [method species] so a
+## mod that replaces a species replaces its dex entry with it.
+func dex_entry(number: int) -> Dictionary:
+	var entry: Variant = species(number).get("dex", {})
+	if not entry is Dictionary or (entry as Dictionary).is_empty():
+		return {}
+	var dex: Dictionary = entry
+	var pages: PackedStringArray = PackedStringArray()
+	for page: Variant in dex.get("pages", []):
+		pages.append(String(page))
+	return {
+		"category": String(dex.get("category", "")),
+		"height": int(dex.get("height", 0)),
+		"weight": int(dex.get("weight", 0)),
+		"pages": pages,
+	}
+
+
+## data/pokemon/dex_order_new.asm, the order DEXMODE_NEW lists species in.
+func dex_order_new() -> PackedInt32Array:
+	return _dex_orders.get("new", PackedInt32Array())
+
+
+## data/pokemon/dex_order_alpha.asm, the order DEXMODE_ABC filters down to the
+## species that have been seen.
+func dex_order_alpha() -> PackedInt32Array:
+	return _dex_orders.get("alpha", PackedInt32Array())
+
+
+## Both order tables, coerced out of JSON's single number type once on open. A
+## table that is missing or the wrong length is dropped rather than half-kept:
+## an order with a hole in it would list a species number of zero, which
+## `.PrintEntry` treats as the end of the list.
+func _load_dex_orders(path: String) -> void:
+	var raw: Variant = RomCache.read_json(path)
+	if not raw is Dictionary:
+		return
+	for key: String in ["new", "alpha"]:
+		var value: Variant = (raw as Dictionary).get(key, [])
+		if not value is Array or (value as Array).size() != RomLayout.SPECIES_COUNT:
+			continue
+		var order: PackedInt32Array = PackedInt32Array()
+		for number: Variant in value as Array:
+			order.append(int(number))
+		_dex_orders[key] = order
 
 
 ## The moves a Pokémon of this species is created knowing at [param level].

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -19,6 +19,7 @@ const MANIFEST: String = "manifest.json"
 const SPECIES: String = "species.json"
 const MOVES: String = "moves.json"
 const TMHM_MOVES: String = "tmhm_moves.json"
+const DEX_ORDERS: String = "dex_orders.json"
 const ITEMS: String = "items.json"
 const WORLD_TRADES: String = "world_trades.json"
 const TYPES: String = "types.json"
@@ -56,7 +57,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 27
+const FORMAT_VERSION: int = 28
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -77,6 +78,13 @@ static func moves_path(directory: String) -> String:
 
 static func tmhm_moves_path(directory: String) -> String:
 	return "%s/%s" % [directory, TMHM_MOVES]
+
+
+## The two Pokedex orderings, kept apart from the species records because an
+## order is asked for by dex mode, not by species: the same reason the type
+## matchups are not stored on the types.
+static func dex_orders_path(directory: String) -> String:
+	return "%s/%s" % [directory, DEX_ORDERS]
 
 
 static func items_path(directory: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -68,6 +68,23 @@ const TRAINER_ATTR_FIRST_AI_ITEM_SWITCH: int = RomLayout.CONTEXT_USE | RomLayout
 ## [method Gen2Stats.pack_dvs] packs a DV word.
 const TRAINER_DVS_FIRST: int = 0x9A77
 
+## What the first and last Pokedex entries are known to say, independently of
+## the cartridge: the published category, height as decimal feet and inches, and
+## weight in tenths of a pound. All three dumps agree on every one of these;
+## it is the description text, not the measurements, that differs between them.
+const DEX_FIRST_CATEGORY: String = "SEED"
+const DEX_FIRST_HEIGHT: int = 204
+const DEX_FIRST_WEIGHT: int = 150
+const DEX_LAST_CATEGORY: String = "TIMETRAVEL"
+const DEX_LAST_HEIGHT: int = 200
+const DEX_LAST_WEIGHT: int = 110
+
+## The species each order table opens with, known from pret's
+## `NewPokedexOrder` (Chikorita, the first of the new dex) and
+## `AlphabeticalPokedexOrder` (Abra).
+const DEX_ORDER_NEW_FIRST: int = 152
+const DEX_ORDER_ALPHA_FIRST: int = 63
+
 var _lz: Gen2Lz = Gen2Lz.new()
 
 
@@ -198,6 +215,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	var evos_attacks: Dictionary = verify_evos_attacks(rom, layout)
 	if not evos_attacks["ok"]:
 		return evos_attacks
+
+	var pokedex: Dictionary = verify_pokedex(rom, layout)
+	if not pokedex["ok"]:
+		return pokedex
 
 	var font: Dictionary = verify_font(rom, layout)
 	if not font["ok"]:
@@ -416,6 +437,60 @@ static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) ->
 	return {"evolutions": evolutions, "learnset": learnset}
 
 
+## Walks one species' Pokedex entry (data/pokemon/dex_entries.asm).
+##
+## Returns { category, height, weight, pages }, empty if the pointer or the walk
+## left the cartridge. [code]pages[/code] is always
+## [constant RomLayout.DEX_ENTRY_PAGES] strings.
+##
+## Height and weight are the cartridge's own numbers rather than converted
+## measurements: height is decimal digits of feet and inches and weight is tenths
+## of a pound, and `DisplayDexEntry` prints both by punctuating the digits. A
+## zero in either is the source's own "no measurement" and is kept, since
+## `.skip_height` and `.skip_weight` leave the row blank rather than printing a
+## zero.
+static func read_dex_entry(rom: RomFile, layout: Dictionary, species: int) -> Dictionary:
+	var table: int = RomLayout.dex_entry_pointer_offset(layout, species)
+	if not rom.in_bounds(table, RomLayout.DEX_ENTRY_POINTER_SIZE):
+		return {}
+
+	# The pointer carries no bank; the bank is chosen by species number, so the
+	# address still has to be one the switchable window can hold.
+	var address: int = rom.u16le(table)
+	if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
+		return {}
+
+	var data: PackedByteArray = rom.bytes()
+	var at: int = RomLayout.dex_entry_offset(layout, species, address)
+	if not rom.in_bounds(at):
+		return {}
+
+	var category: String = Gen2Text.decode(
+		data, at, RomLayout.DEX_ENTRY_MAX_CATEGORY_LENGTH
+	)
+	at = Gen2Text.terminated_end(data, at, RomLayout.DEX_ENTRY_MAX_CATEGORY_LENGTH)
+
+	var measurements: int = RomLayout.DEX_ENTRY_MEASUREMENT_BYTES * 2
+	if not rom.in_bounds(at, measurements):
+		return {}
+	var height: int = rom.u16le(at)
+	var weight: int = rom.u16le(at + RomLayout.DEX_ENTRY_MEASUREMENT_BYTES)
+	at += measurements
+
+	# The page break is the terminator itself (macros/scripts/text.asm's `page`
+	# is `db "@"`), so the two pages are simply two consecutive runs.
+	var pages: PackedStringArray = PackedStringArray()
+	for page: int in RomLayout.DEX_ENTRY_PAGES:
+		if not rom.in_bounds(at):
+			return {}
+		pages.append(Gen2Text.decode(data, at, RomLayout.DEX_ENTRY_MAX_PAGE_LENGTH))
+		at = Gen2Text.terminated_end(data, at, RomLayout.DEX_ENTRY_MAX_PAGE_LENGTH)
+	if at > rom.size():
+		return {}
+
+	return {"category": category, "height": height, "weight": weight, "pages": pages}
+
+
 ## The evolution and learnset table, checked species by species.
 ##
 ## Nothing says which species an entry belongs to, so the shape is checked: 251
@@ -576,6 +651,106 @@ static func _verify_known_evos_attacks(entries: Array) -> Dictionary:
 					STAT_EVOLUTION_SPECIES, int(evolution["method"]),
 				],
 			}
+
+	return {"ok": true, "message": ""}
+
+
+## One of the two orderings `Pokedex_OrderMonsByMode` reads
+## (data/pokemon/dex_order_new.asm, dex_order_alpha.asm), as species numbers.
+## Empty if the table is outside the cartridge.
+static func read_dex_order(rom: RomFile, layout: Dictionary, key: String) -> PackedInt32Array:
+	var pokedex: Dictionary = layout["pokedex"]
+	var at: int = int(pokedex.get(key, -1))
+	if not rom.in_bounds(at, RomLayout.SPECIES_COUNT):
+		return PackedInt32Array()
+	var out: PackedInt32Array = PackedInt32Array()
+	for index: int in RomLayout.SPECIES_COUNT:
+		out.append(rom.u8(at + index))
+	return out
+
+
+## The Pokedex entries and the two order tables.
+##
+## The entries have no self-identifying field, so they are checked the way the
+## palettes are: every one of the 251 has to walk to a category and two pages
+## without leaving the cartridge, and the two ends have to say what they are
+## independently known to say. A pointer table that is one entry out still walks
+## into readable text, which is why the measurements are checked and not just
+## the strings.
+##
+## Each order table has to be a permutation of the whole species range. That is
+## a stronger check than a range check: a run of legal species numbers elsewhere
+## in the bank would pass the latter, and only the real table has every species
+## exactly once.
+static func verify_pokedex(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if not layout.has("pokedex"):
+		return {"ok": false, "message": "No Pokedex offsets for this game."}
+
+	var entries: Array = []
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var entry: Dictionary = read_dex_entry(rom, layout, species)
+		if entry.is_empty():
+			return {
+				"ok": false,
+				"message": "Pokedex entry %d does not read as an entry." % species,
+			}
+		if String(entry["category"]).is_empty():
+			return {"ok": false, "message": "Pokedex entry %d has no category." % species}
+		var pages: PackedStringArray = entry["pages"]
+		for page: int in pages.size():
+			if pages[page].is_empty():
+				return {
+					"ok": false,
+					"message": "Pokedex entry %d has an empty page %d." % [species, page + 1],
+				}
+		entries.append(entry)
+
+	var first: Dictionary = entries[0]
+	if String(first["category"]) != DEX_FIRST_CATEGORY \
+		or int(first["height"]) != DEX_FIRST_HEIGHT \
+		or int(first["weight"]) != DEX_FIRST_WEIGHT:
+		return {
+			"ok": false,
+			"message": "Pokedex entry 1: expected %s %d %d, read %s %d %d." % [
+				DEX_FIRST_CATEGORY, DEX_FIRST_HEIGHT, DEX_FIRST_WEIGHT,
+				String(first["category"]), int(first["height"]), int(first["weight"]),
+			],
+		}
+
+	var last: Dictionary = entries[RomLayout.SPECIES_COUNT - 1]
+	if String(last["category"]) != DEX_LAST_CATEGORY \
+		or int(last["height"]) != DEX_LAST_HEIGHT \
+		or int(last["weight"]) != DEX_LAST_WEIGHT:
+		return {
+			"ok": false,
+			"message": "Pokedex entry %d: expected %s %d %d, read %s %d %d." % [
+				RomLayout.SPECIES_COUNT, DEX_LAST_CATEGORY, DEX_LAST_HEIGHT, DEX_LAST_WEIGHT,
+				String(last["category"]), int(last["height"]), int(last["weight"]),
+			],
+		}
+
+	for order: Array in [
+		["order_new", DEX_ORDER_NEW_FIRST], ["order_alpha", DEX_ORDER_ALPHA_FIRST],
+	]:
+		var key: String = order[0]
+		var species_numbers: PackedInt32Array = read_dex_order(rom, layout, key)
+		if species_numbers.size() != RomLayout.SPECIES_COUNT:
+			return {"ok": false, "message": "Dex order table %s is outside the ROM." % key}
+		if species_numbers[0] != int(order[1]):
+			return {
+				"ok": false,
+				"message": "Dex order table %s: expected species %d first, read %d." % [
+					key, int(order[1]), species_numbers[0],
+				],
+			}
+		var seen: Dictionary = {}
+		for number: int in species_numbers:
+			if number < 1 or number > RomLayout.SPECIES_COUNT or seen.has(number):
+				return {
+					"ok": false,
+					"message": "Dex order table %s is not a permutation: %d." % [key, number],
+				}
+			seen[number] = true
 
 	return {"ok": true, "message": ""}
 
@@ -1302,6 +1477,11 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		result["message"] = "Could not write the font."
 		return result
 
+	var dex_orders: Dictionary = _import_dex_orders(rom, layout)
+	if dex_orders.is_empty():
+		result["message"] = "Dex order tables are outside the cartridge."
+		return result
+
 	var moves: Array = _import_moves(rom, layout, on_progress)
 	var tmhm_moves: Array = _import_tmhm_moves(rom, layout)
 	if tmhm_moves.is_empty():
@@ -1337,6 +1517,9 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		return result
 	if not RomCache.write_json(RomCache.tmhm_moves_path(directory), tmhm_moves):
 		result["message"] = "Could not write TM/HM move data."
+		return result
+	if not RomCache.write_json(RomCache.dex_orders_path(directory), dex_orders):
+		result["message"] = "Could not write dex order data."
 		return result
 	if not RomCache.write_json(RomCache.items_path(directory), items):
 		result["message"] = "Could not write item data."
@@ -1472,6 +1655,7 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 		var egg_groups: int = rom.u8(stats + RomLayout.OFFSET_EGG_GROUPS)
 		var palette: int = RomLayout.palette_offset(layout, species)
 		var evos_attacks: Dictionary = read_evos_attacks(rom, layout, species)
+		var dex: Dictionary = read_dex_entry(rom, layout, species)
 
 		out.append({
 			"number": species,
@@ -1506,6 +1690,15 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 			"evolutions": evos_attacks.get("evolutions", []),
 			"learnset": evos_attacks.get("learnset", []),
 			"front_tiles": [dimensions & 0x0F, dimensions >> 4],
+			# The Pokedex entry. On the species rather than in a table of its
+			# own because it is asked for by species number and nothing else,
+			# the same reason the learnset lives here.
+			"dex": {
+				"category": dex.get("category", ""),
+				"height": int(dex.get("height", 0)),
+				"weight": int(dex.get("weight", 0)),
+				"pages": Array(dex.get("pages", PackedStringArray())),
+			},
 			"palette": {
 				"normal": [rom.u16le(palette), rom.u16le(palette + 2)],
 				"shiny": [rom.u16le(palette + 4), rom.u16le(palette + 6)],
@@ -1516,6 +1709,20 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 			on_progress.call("species", species, RomLayout.SPECIES_COUNT)
 
 	return out
+
+
+## The two dex orderings, keyed by the mode that reads each. Empty on any layout
+## failure, which the caller reports rather than caching a half table.
+##
+## The third ordering, DEXMODE_OLD, has no table: `.OldMode` counts from 1 to
+## 251, so storing it would be storing the species range twice.
+func _import_dex_orders(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var new_order: PackedInt32Array = read_dex_order(rom, layout, "order_new")
+	var alpha_order: PackedInt32Array = read_dex_order(rom, layout, "order_alpha")
+	if new_order.size() != RomLayout.SPECIES_COUNT \
+		or alpha_order.size() != RomLayout.SPECIES_COUNT:
+		return {}
+	return {"new": Array(new_order), "alpha": Array(alpha_order)}
 
 
 func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -258,6 +258,43 @@ const MAX_MATCHUPS: int = 256
 const PHYSICAL_TYPES_END: int = 0x09
 const SPECIAL_TYPES_START: int = 0x14
 
+## One Pokedex entry (data/pokemon/dex_entries.asm): a terminated category
+## string, then height and weight as little-endian words, then two terminated
+## description pages.
+##
+## The page break is the terminator itself, not a code of its own: `MACRO page`
+## in macros/scripts/text.asm is `db "@", \#`, so an entry ends after the second
+## terminated run rather than at the first.
+##
+## Height is decimal digits of feet and inches (204 is 2'04") and weight is
+## tenths of a pound (150 is 15.0 lb), which is why both are stored raw and
+## formatted at draw time rather than converted here.
+const DEX_ENTRY_PAGES: int = 2
+const DEX_ENTRY_MEASUREMENT_BYTES: int = 2
+## Runaway guard for a page walk, well past the longest entry in any of the
+## three dumps (the longest measured is under 200 bytes).
+const DEX_ENTRY_MAX_PAGE_LENGTH: int = 256
+## The category is at most twelve characters, the same guard the move and item
+## name walks use.
+const DEX_ENTRY_MAX_CATEGORY_LENGTH: int = MAX_NAME_LENGTH
+
+## Pointers are two bytes and bank-local, and the bank is chosen by species
+## rather than stored: GetDexEntryPointer (engine/pokedex/pokedex_2.asm) rotates
+## `species - 1` twice and masks to NUM_DEX_ENTRY_BANKS bits, which is
+## `(species - 1) >> 6`. The four sections are species 1-64, 65-128, 129-192 and
+## 193-251.
+const DEX_ENTRY_POINTER_SIZE: int = 2
+const DEX_ENTRY_BANK_SPECIES: int = 64
+const DEX_ENTRY_BANK_COUNT: int = 4
+
+## The three orderings Pokedex_OrderMonsByMode builds, as constants/ram_constants.asm
+## numbers them. UNOWN is the fourth mode and is not one of these: it lists Unown
+## forms rather than species, from its own table.
+const DEXMODE_NEW: int = 0
+const DEXMODE_OLD: int = 1
+const DEXMODE_ABC: int = 2
+const DEXMODE_UNOWN: int = 3
+
 ## Evolutions and level-up moves are one table, not two. A species' entry lists
 ## its evolutions, then a zero byte, then its level-up moves as level and move
 ## pairs, then another zero byte. One pointer answers both questions, which is
@@ -686,6 +723,19 @@ const GOLD_SILVER: Dictionary = {
 		"right_corner": -1,
 		"badge_palette": 0xA385,
 	},
+	# Pokedex. Located by encoding Bulbasaur's known category and published
+	# height and weight ("SEED", 204, 150) and matching the bytes, then finding
+	# the only 251-pointer run whose four 64-species groups each ascend and
+	# restart. Both order tables were located by encoding the pinned
+	# data/pokemon/dex_order_*.asm species lists whole. Nested for the same
+	# reason trainer_card is.
+	"pokedex": {
+		"entry_pointers": 0x44360,
+		# BANK("Pokedex Entries 001-064") through 193-251.
+		"entry_banks": [0x68, 0x69, 0x6A, 0x6B],
+		"order_alpha": 0x40C65,
+		"order_new": 0x40D60,
+	},
 	"trainer_pic_pointers": 0x80000,
 	"trainer_palettes": 0xB53D,
 	"trainer_class_names": 0x1B0955,
@@ -832,6 +882,16 @@ const CRYSTAL: Dictionary = {
 		"badges": 0x26043,
 		"right_corner": 0x265C3,
 		"badge_palette": 0x9F16,
+	},
+	# Pokedex; see the Gold and Silver block above for how these were located.
+	# Both order tables sit at the same offsets in all three dumps; the entries
+	# and their banks do not, and Gold and Silver do not even share description
+	# text with each other, so every profile is read from its own cartridge.
+	"pokedex": {
+		"entry_pointers": 0x44378,
+		"entry_banks": [0x60, 0x6E, 0x73, 0x74],
+		"order_alpha": 0x40C65,
+		"order_new": 0x40D60,
 	},
 	"trainer_pic_pointers": 0x128000,
 	"trainer_palettes": 0xB0CE,
@@ -984,6 +1044,25 @@ static func species_name_offset(layout: Dictionary, species: int) -> int:
 
 static func base_stats_offset(layout: Dictionary, species: int) -> int:
 	return int(layout["base_stats"]) + (species - 1) * BASE_STATS_SIZE
+
+
+static func dex_entry_pointer_offset(layout: Dictionary, species: int) -> int:
+	var pokedex: Dictionary = layout["pokedex"]
+	return int(pokedex["entry_pointers"]) + (species - 1) * DEX_ENTRY_POINTER_SIZE
+
+
+## The bank a species' Pokedex entry lives in, by
+## `GetDexEntryPointer`'s `(species - 1) >> 6`.
+static func dex_entry_bank(layout: Dictionary, species: int) -> int:
+	var pokedex: Dictionary = layout["pokedex"]
+	var banks: Array = pokedex["entry_banks"]
+	return int(banks[(species - 1) / DEX_ENTRY_BANK_SPECIES])
+
+
+## Where a species' Pokedex entry starts in the dump, given the bank-local
+## [param address] read from the table.
+static func dex_entry_offset(layout: Dictionary, species: int, address: int) -> int:
+	return RomFile.linear(dex_entry_bank(layout, species), address)
 
 
 ## The palette table carries a leading entry before Bulbasaur, so unlike every

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -113,11 +113,22 @@ static func decode_sequence(
 		if at < 0 or at >= data.size():
 			break
 		out.append(decode(data, at, max_length))
-		var end: int = at
-		while end < data.size() and data[end] != TERMINATOR and end - at < max_length:
-			end += 1
-		at = end + 1
+		at = terminated_end(data, at, max_length)
 	return out
+
+
+## The offset just past the terminator of the string at [param offset].
+##
+## What a caller needs to read the field that follows a variable-length string:
+## a Pokedex entry's height sits directly after its category, and its second
+## description page directly after its first. [param max_length] is the same
+## runaway guard [method decode_sequence] uses, and a walk that hits it, or the
+## end of the data, still answers one past where it stopped rather than looping.
+static func terminated_end(data: PackedByteArray, offset: int, max_length: int) -> int:
+	var end: int = offset
+	while end < data.size() and data[end] != TERMINATOR and end - offset < max_length:
+		end += 1
+	return end + 1
 
 
 ## Turns a string into the codes that draw it, one code per tile.

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -1,0 +1,440 @@
+class_name Gen2Pokedex
+extends RefCounted
+
+## Scene-free model of the Pokedex (engine/pokedex/pokedex.asm).
+##
+## Holds what `wPokedexDataStart`..`wPokedexDataEnd` holds: the current mode, the
+## species order that mode built, how far down the listing runs, and the cursor
+## and scroll offset into it. A screen draws [method rows] and feeds buttons back
+## in; nothing here knows what a Control is.
+##
+## The two orderings come from the cache ([method GameData.dex_order_new] and
+## [method GameData.dex_order_alpha]); DEXMODE_OLD has no table because
+## `.OldMode` counts from 1. Seen and caught come from [Gen2WorldState], which
+## already keeps both arrays.
+
+## `wDexListingHeight` as the main screen sets it (`ld a, 7`). The search results
+## screen sets its own, which is why this is the listing's height rather than the
+## model's.
+const LISTING_HEIGHT: int = 7
+
+## What `.PrintEntry` draws instead of a name for a species that has not been
+## seen (`.NameNotSeen`).
+const NOT_SEEN_NAME: String = "-----"
+
+## `wPokedexStatus`, which `Pokedex_Page` toggles with `xor 1`.
+const PAGE_1: int = 0
+const PAGE_2: int = 1
+
+## `Pokedex_DrawOptionScreenBG.Modes`, verbatim, and the description
+## `Pokedex_DisplayModeDescription` prints under each. UNOWN is built in its
+## source position and refused, the way the start menu builds Pokedex: nothing
+## here tracks STATUSFLAGS_UNOWN_DEX_F, so `wUnlockedUnownMode` is always false
+## and `.NoUnownModeArrowCursorData`'s three rows are what the screen gets.
+const MODE_ROWS: Array[Dictionary] = [
+	{
+		"mode": RomLayout.DEXMODE_NEW,
+		"label": "NEW #DEX MODE",
+		"description": "#MN are listed by\nevolution type.",
+	},
+	{
+		"mode": RomLayout.DEXMODE_OLD,
+		"label": "OLD #DEX MODE",
+		"description": "#MN are listed by\nofficial type.",
+	},
+	{
+		"mode": RomLayout.DEXMODE_ABC,
+		"label": "A to Z MODE",
+		"description": "#MN are listed\nalphabetically.",
+	},
+	{
+		"mode": RomLayout.DEXMODE_UNOWN,
+		"label": "UNOWN MODE",
+		"description": "UNOWN are listed\nin catching order.",
+	},
+]
+
+## `Pokedex_DisplayChangingModesMessage`'s own text, shown while a mode change
+## rebuilds the order.
+const CHANGING_MODES_TEXT: String = "Changing modes.\nPlease wait."
+
+var mode: int = RomLayout.DEXMODE_NEW
+## `wDexListingScrollOffset` and `wDexListingCursor`. The selected row is their
+## sum, which is what `Pokedex_GetSelectedMon` adds.
+var scroll: int = 0
+var cursor: int = 0
+## `wDexListingEnd`, the 1-based position of the last species the listing runs
+## to. Not a count of seen species outside ABC mode: see [method _find_last_seen].
+var listing_end: int = 0
+## `wPokedexStatus`, the description page the entry screen is showing.
+var page: int = PAGE_1
+## `wPrevDexEntry`. Plain WRAM0 rather than saved data, so it survives the dex
+## closing and reopening within a session and is zero on boot; the caller owns it
+## for exactly that reason, the way the world screen owns the start menu cursor.
+var prev_entry: int = 0
+
+var _data: GameData = null
+var _state: Gen2WorldState = null
+## `wPokedexOrder`, always [constant RomLayout.SPECIES_COUNT] long. ABC mode
+## zero-fills its tail, and a zero is what `.PrintEntry` draws nothing for.
+var _order: PackedInt32Array = PackedInt32Array()
+
+
+## `Pokedex_Init`: clears its own WRAM block, takes the mode from
+## `wLastDexMode`, orders the species and seeks the cursor to `wPrevDexEntry`.
+static func open(
+	data: GameData, state: Gen2WorldState, last_mode: int, previous_entry: int = 0
+) -> Gen2Pokedex:
+	var dex := Gen2Pokedex.new()
+	dex._data = data
+	dex._state = state
+	dex.mode = last_mode if last_mode in [
+		RomLayout.DEXMODE_NEW, RomLayout.DEXMODE_OLD, RomLayout.DEXMODE_ABC,
+	] else RomLayout.DEXMODE_NEW
+	dex.prev_entry = previous_entry
+	dex.order_by_mode()
+	dex.init_cursor_position()
+	return dex
+
+
+## `Pokedex_OrderMonsByMode`. NEW copies the new-dex table, OLD counts from 1,
+## and ABC keeps only the species that have been seen and zero-fills the rest.
+func order_by_mode() -> void:
+	_order = PackedInt32Array()
+	_order.resize(RomLayout.SPECIES_COUNT)
+	match mode:
+		RomLayout.DEXMODE_ABC:
+			_order_abc()
+		RomLayout.DEXMODE_OLD:
+			for index: int in RomLayout.SPECIES_COUNT:
+				_order[index] = index + 1
+			_find_last_seen()
+		_:
+			var table: PackedInt32Array = _data.dex_order_new() if _data != null \
+				else PackedInt32Array()
+			for index: int in RomLayout.SPECIES_COUNT:
+				_order[index] = table[index] if index < table.size() else 0
+			_find_last_seen()
+
+
+## `Pokedex_ABCMode`: the alphabetical table filtered down to what has been
+## seen, and `wDexListingEnd` is that count rather than a position.
+func _order_abc() -> void:
+	var table: PackedInt32Array = _data.dex_order_alpha() if _data != null \
+		else PackedInt32Array()
+	listing_end = 0
+	for index: int in table.size():
+		if not _has_seen(table[index]):
+			continue
+		_order[listing_end] = table[index]
+		listing_end += 1
+
+
+## `.FindLastSeen`: walks the order backwards and stops at the first species that
+## has been seen, answering that species' 1-based position. Nothing seen at all
+## answers zero, which the loop reaches by counting all the way down.
+func _find_last_seen() -> void:
+	var end: int = RomLayout.SPECIES_COUNT
+	for index: int in range(RomLayout.SPECIES_COUNT - 1, -1, -1):
+		if _has_seen(_order[index]):
+			break
+		end -= 1
+	listing_end = end
+
+
+## `Pokedex_InitCursorPosition`: seeks the cursor to `wPrevDexEntry`, scrolling
+## first while there is more than one page and then moving the cursor within it.
+##
+## A zero or out-of-range previous entry leaves both at zero. An entry that is
+## not in the order at all is not special-cased on the cartridge either: the
+## second walk runs its full seven steps and leaves the cursor past the last row,
+## which ABC mode can reach when the last entry viewed has not been seen.
+func init_cursor_position() -> void:
+	scroll = 0
+	cursor = 0
+	if prev_entry <= 0 or prev_entry > RomLayout.SPECIES_COUNT:
+		return
+	var index: int = 0
+	if listing_end >= LISTING_HEIGHT + 1:
+		for step: int in listing_end - LISTING_HEIGHT:
+			if _order[index] == prev_entry:
+				return
+			index += 1
+			scroll += 1
+	for step: int in LISTING_HEIGHT:
+		if index < _order.size() and _order[index] == prev_entry:
+			return
+		index += 1
+		cursor += 1
+
+
+## `Pokedex_GetSelectedMon`, which is the order read at cursor plus scroll.
+func selected_species() -> int:
+	var index: int = cursor + scroll
+	if index < 0 or index >= _order.size():
+		return 0
+	return _order[index]
+
+
+## The listing as [constant LISTING_HEIGHT] rows, in `Pokedex_PrintListing`'s
+## own order, each as `.PrintEntry` would draw it:
+## { species, empty, number, seen, caught, name, selected }.
+##
+## [code]empty[/code] is the species-zero row `.PrintEntry` returns from
+## immediately, which is what the tail of an ABC listing is made of.
+## [code]number[/code] is the three-digit zero-padded dex number, and only OLD
+## mode prints one.
+func rows() -> Array:
+	var out: Array = []
+	for index: int in LISTING_HEIGHT:
+		var at: int = scroll + index
+		var species: int = _order[at] if at >= 0 and at < _order.size() else 0
+		var seen: bool = _has_seen(species)
+		out.append({
+			"species": species,
+			"empty": species == 0,
+			"number": "%03d" % species if mode == RomLayout.DEXMODE_OLD and species != 0 else "",
+			"seen": seen,
+			"caught": _has_caught(species),
+			"name": _species_name(species) if seen else NOT_SEEN_NAME,
+			"selected": index == cursor,
+		})
+	return out
+
+
+## `Pokedex_DrawMainScreenBG`'s two `CountSetBits` totals.
+func seen_count() -> int:
+	return _state.seen_count() if _state != null else 0
+
+
+func caught_count() -> int:
+	return _state.caught_count() if _state != null else 0
+
+
+## `Pokedex_ListingHandleDPadInput`. Answers whether the position changed, which
+## is the carry flag the source returns.
+##
+## Left and right page the listing and are refused outright while it fits on one
+## screen: the source checks `wDexListingHeight` against `wDexListingEnd` before
+## it looks at either button.
+func move_listing(button: int) -> bool:
+	match button:
+		Gen2Button.UP:
+			return _move_cursor_up()
+		Gen2Button.DOWN:
+			return _move_cursor_down()
+	if LISTING_HEIGHT >= listing_end:
+		return false
+	match button:
+		Gen2Button.LEFT:
+			return _move_up_one_page()
+		Gen2Button.RIGHT:
+			return _move_down_one_page()
+	return false
+
+
+## `Pokedex_ListingMoveCursorUp`: the cursor moves first, and only a cursor
+## already at the top scrolls.
+func _move_cursor_up() -> bool:
+	if cursor != 0:
+		cursor -= 1
+		return true
+	if scroll == 0:
+		return false
+	scroll -= 1
+	return true
+
+
+## `Pokedex_ListingMoveCursorDown`: refused at the end of the listing, then the
+## cursor moves while it is inside the visible rows and the listing scrolls once
+## it is not.
+func _move_cursor_down() -> bool:
+	var next: int = cursor + 1
+	if next >= listing_end:
+		return false
+	if next < LISTING_HEIGHT:
+		cursor = next
+		return true
+	if next + scroll >= listing_end:
+		return false
+	scroll += 1
+	return true
+
+
+## `Pokedex_ListingMoveUpOnePage`: a page up, or to the top when less than a page
+## from it.
+func _move_up_one_page() -> bool:
+	if scroll == 0:
+		return false
+	scroll = scroll - LISTING_HEIGHT if scroll >= LISTING_HEIGHT else 0
+	return true
+
+
+## `Pokedex_ListingMoveDownOnePage`, which always reports a change.
+##
+## The source adds two pages to the offset in one byte and treats the carry as
+## "near the bottom", so an offset that would overflow lands on the last page
+## exactly as one that runs past `wDexListingEnd` does. The wrap is kept because
+## it is the comparison, not an accident of it.
+func _move_down_one_page() -> bool:
+	var reach: int = LISTING_HEIGHT * 2 + scroll
+	if reach > 0xFF or reach >= listing_end:
+		scroll = listing_end - LISTING_HEIGHT
+	else:
+		scroll += LISTING_HEIGHT
+	return true
+
+
+## `Pokedex_UpdateMainScreen`'s A: the entry screen opens only for a species that
+## has been seen (`Pokedex_CheckSeen; ret z`).
+func can_open_entry() -> bool:
+	return _has_seen(selected_species())
+
+
+## `Pokedex_InitDexEntryScreen`, which opens on page 1 and records the species as
+## `wPrevDexEntry`.
+func open_entry() -> void:
+	page = PAGE_1
+	prev_entry = selected_species()
+
+
+## `Pokedex_Page`'s `xor 1`.
+func toggle_page() -> void:
+	page = PAGE_2 if page == PAGE_1 else PAGE_1
+	prev_entry = selected_species()
+
+
+## `Pokedex_NextOrPreviousDexEntry`: moves in the pressed direction until it
+## lands on a species that has been seen, and puts the cursor and scroll back
+## where they were if it runs out of listing first.
+##
+## Answers whether it moved. A move re-enters the entry screen at page 1, which
+## is `Pokedex_ReinitDexEntryScreen`.
+func step_entry(button: int) -> bool:
+	if button != Gen2Button.UP and button != Gen2Button.DOWN:
+		return false
+	var backup_cursor: int = cursor
+	var backup_scroll: int = scroll
+	while true:
+		var moved: bool = _move_cursor_up() if button == Gen2Button.UP else _move_cursor_down()
+		if not moved:
+			cursor = backup_cursor
+			scroll = backup_scroll
+			return false
+		if _has_seen(selected_species()):
+			page = PAGE_1
+			prev_entry = selected_species()
+			return true
+	return false
+
+
+## The selected species' entry, as `DisplayDexEntry` prints it:
+## { species, name, number, category, caught, height, weight, page, text }.
+##
+## The name, the category and the number are printed whether or not the species
+## has been caught; the caught check sits after them and gates the measurements
+## and the description. A zero height or weight is left blank rather than printed
+## as a zero, which is `.skip_height` and `.skip_weight`.
+func entry() -> Dictionary:
+	var species: int = selected_species()
+	var dex: Dictionary = _data.dex_entry(species) if _data != null else {}
+	var caught: bool = _has_caught(species)
+	var pages: PackedStringArray = dex.get("pages", PackedStringArray())
+	var height: int = int(dex.get("height", 0))
+	var weight: int = int(dex.get("weight", 0))
+	return {
+		"species": species,
+		"name": _species_name(species),
+		"number": "%03d" % species,
+		"category": String(dex.get("category", "")),
+		"caught": caught,
+		"height": height_text(height) if caught and height != 0 else "",
+		"weight": weight_text(weight) if caught and weight != 0 else "",
+		"page": page,
+		"text": pages[page] if caught and page < pages.size() else "",
+	}
+
+
+## `_PrintNum` (engine/math/print_num.asm) for the two calls this screen makes:
+## [param digits] digits with [param before_point] of them in front of a decimal
+## point, and neither the money nor the leading-zero flag set.
+##
+## A leading zero is not printed and not replaced: `.PrintLeadingZero` writes
+## nothing while the flag is clear and `.AdvancePointer` steps over the cell
+## regardless, leaving the background template's own space. That is why this
+## returns a fixed-width field with spaces rather than a trimmed number.
+##
+## The digit immediately in front of the point is always printed, even when it
+## is a zero: `.PrintDigit` latches "a digit has been printed" as `e` runs out,
+## which is what makes a height of 8 read 0'08" rather than blank.
+static func print_num(value: int, digits: int, before_point: int) -> String:
+	var text: String = ""
+	var padded: String = String.num_int64(maxi(value, 0)).lpad(digits, "0").right(digits)
+	var printed: bool = false
+	for index: int in digits:
+		var digit: String = padded[index]
+		## `dec e` reaching zero on this digit, which is the last one in front
+		## of the point.
+		if index == before_point - 1:
+			printed = true
+		if digit != "0":
+			printed = true
+		text += digit if printed else " "
+		if index == before_point - 1:
+			text += "."
+	return text
+
+
+## The height as `DisplayDexEntry` prints it: four digits with two in front of
+## the point, and the point overwritten by the feet mark. The stored 204 reads
+## " 2'04"".
+static func height_text(height: int) -> String:
+	return "%s\"" % print_num(height, 4, 2).replace(".", "'")
+
+
+## The weight as `DisplayDexEntry` prints it: five digits with four in front of
+## the point. The stored 150 reads "  15.0".
+static func weight_text(weight: int) -> String:
+	return print_num(weight, 5, 4)
+
+
+## The OPTION screen's rows. UNOWN is dropped while `wUnlockedUnownMode` is
+## clear, which is `.NoUnownModeArrowCursorData`'s shorter table.
+static func mode_rows(unown_unlocked: bool = false) -> Array:
+	var out: Array = []
+	for row: Dictionary in MODE_ROWS:
+		if int(row["mode"]) == RomLayout.DEXMODE_UNOWN and not unown_unlocked:
+			continue
+		out.append(row.duplicate(true))
+	return out
+
+
+## `.ChangeMode`: choosing the mode already in use changes nothing, and choosing
+## another reorders the listing and puts the cursor back at the top before
+## seeking `wPrevDexEntry` again.
+##
+## Answers whether the mode changed, which is what decides whether the screen
+## shows [constant CHANGING_MODES_TEXT].
+func change_mode(next_mode: int) -> bool:
+	if next_mode == mode:
+		return false
+	mode = next_mode
+	order_by_mode()
+	scroll = 0
+	cursor = 0
+	init_cursor_position()
+	return true
+
+
+func _has_seen(species: int) -> bool:
+	return _state != null and _state.has_seen_species(species)
+
+
+func _has_caught(species: int) -> bool:
+	return _state != null and _state.has_caught_species(species)
+
+
+func _species_name(species: int) -> String:
+	if _data == null:
+		return ""
+	return String(_data.species(species).get("name", ""))

--- a/game/world/pokedex.gd.uid
+++ b/game/world/pokedex.gd.uid
@@ -1,0 +1,1 @@
+uid://b2xe2glli055w

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -1,0 +1,327 @@
+class_name Gen2PokedexScreen
+extends Control
+
+## The Pokedex (engine/pokedex/pokedex.asm), embedded in the overworld the way
+## the start menu and its own submenus are.
+##
+## Presented as a window-resolution Control panel, consistent with the start
+## menu, mart, phone and PC storage overlays rather than the hardware's tiled
+## screen: no `gfx/pokedex` graphics are imported, so there is nothing to draw a
+## tile-accurate listing with. Every rule the screen obeys is [Gen2Pokedex]'s,
+## which is the source's own.
+##
+## Three of the source's six states are here: the listing, the entry screen and
+## the OPTION screen. SEARCH, its results and the Unown dex are not, so START on
+## the listing does nothing rather than opening a screen that is not built.
+
+## Emitted on B from the listing, which is where `DEXSTATE_EXIT` lands.
+signal closed
+
+enum Mode { LIST, ENTRY, OPTION }
+
+const PANEL: Color = Color("#14233a")
+const BORDER: Color = Color("#4f6f9e")
+const SCRIM: Color = Color(0.02, 0.04, 0.08, 0.78)
+const TEXT: Color = Color("#f4f7fb")
+const MUTED: Color = Color("#9eacc0")
+const ACCENT: Color = Color("#f3c969")
+
+## `Pokedex_PlaceCaughtSymbolIfCaught` writes one tile ahead of the name, and a
+## row that is not caught keeps the blank the listing was cleared with.
+const CAUGHT_SYMBOL: String = "*"
+const UNCAUGHT_SYMBOL: String = " "
+
+var _dex: Gen2Pokedex = null
+var _world: Gen2WorldAPI = null
+var _data: GameData = null
+var _mode: Mode = Mode.LIST
+## The OPTION screen's own cursor (`wDexArrowCursorPosIndex`), which opens on
+## the row matching the current mode.
+var _option_cursor: int = 0
+var _mode_rows: Array = []
+
+var _title: Label = null
+var _summary: Label = null
+var _options: VBoxContainer = null
+var _status: Label = null
+var _footer: Label = null
+
+
+## Optional the way the trainer card is: without a world, its state or a cache
+## carrying the dex order tables there is no listing, so this answers false and
+## the caller keeps the start menu open.
+func open(data: GameData, world: Gen2WorldAPI, previous_entry: int = 0) -> bool:
+	_data = data
+	_world = world
+	if _data == null or _world == null or _world.state == null:
+		return false
+	if _data.dex_order_new().is_empty() or _data.dex_order_alpha().is_empty():
+		return false
+	_dex = Gen2Pokedex.open(
+		_data, _world.state, _world.state.last_dex_mode(), previous_entry
+	)
+	if is_inside_tree() and _options != null:
+		_open_list_mode()
+	return true
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_build_ui()
+	if _dex != null:
+		_open_list_mode()
+
+
+## `wPrevDexEntry`, so the caller can carry it into the next open() the way the
+## cartridge's own byte survives the dex closing.
+func previous_entry() -> int:
+	return _dex.prev_entry if _dex != null else 0
+
+
+func current_mode() -> Mode:
+	return _mode
+
+
+func handle_button(button: int) -> bool:
+	if _dex == null:
+		return false
+	match _mode:
+		Mode.LIST:
+			return _handle_list(button)
+		Mode.ENTRY:
+			return _handle_entry(button)
+		Mode.OPTION:
+			return _handle_option(button)
+	return false
+
+
+## `Pokedex_UpdateMainScreen`. START would open SEARCH, which is not built, so
+## it is answered as handled and does nothing rather than reaching a screen that
+## is not there.
+func _handle_list(button: int) -> bool:
+	match button:
+		Gen2Button.B:
+			_exit()
+			return true
+		Gen2Button.A:
+			if _dex.can_open_entry():
+				_dex.open_entry()
+				_open_entry_mode()
+			return true
+		Gen2Button.SELECT:
+			_open_option_mode()
+			return true
+		Gen2Button.START:
+			return true
+	if _dex.move_listing(button):
+		_render_list()
+	return Gen2Button.is_direction(button)
+
+
+## `Pokedex_UpdateDexEntryScreen`: B returns to the listing, A turns the page,
+## and up and down step to the neighbouring entry.
+##
+## The source's four-button row is PAGE, AREA, CRY and PRNT; only PAGE is built,
+## so A always turns the page rather than moving a cursor along a row whose
+## other three entries would refuse.
+func _handle_entry(button: int) -> bool:
+	match button:
+		Gen2Button.B:
+			_open_list_mode()
+			return true
+		Gen2Button.A:
+			_dex.toggle_page()
+			_render_entry()
+			return true
+		Gen2Button.UP, Gen2Button.DOWN:
+			if _dex.step_entry(button):
+				_render_entry()
+			return true
+	return false
+
+
+## `Pokedex_UpdateOptionScreen`: SELECT and B both return to the listing, and A
+## takes the row's mode.
+func _handle_option(button: int) -> bool:
+	match button:
+		Gen2Button.B, Gen2Button.SELECT:
+			_open_list_mode()
+			return true
+		Gen2Button.A:
+			_choose_mode()
+			return true
+		Gen2Button.UP, Gen2Button.DOWN:
+			## `.ArrowCursorData` allows up and down only, and
+			## `Pokedex_MoveArrowCursor` stops at either end rather than wrapping.
+			var next: int = _option_cursor + (1 if button == Gen2Button.DOWN else -1)
+			_option_cursor = clampi(next, 0, _mode_rows.size() - 1)
+			_render_option()
+			return true
+	return false
+
+
+## `.ChangeMode`, including the message it shows while the order is rebuilt.
+## Choosing the mode already in use returns to the listing untouched.
+func _choose_mode() -> void:
+	var row: Dictionary = _mode_rows[_option_cursor]
+	var changed: bool = _dex.change_mode(int(row["mode"]))
+	if changed:
+		_world.state.set_last_dex_mode(_dex.mode)
+	_open_list_mode()
+	if changed:
+		_status.text = Gen2Pokedex.CHANGING_MODES_TEXT
+		_status.add_theme_color_override("font_color", MUTED)
+
+
+## `.exit` writes the mode back to `wLastDexMode` before it leaves.
+func _exit() -> void:
+	_world.state.set_last_dex_mode(_dex.mode)
+	closed.emit()
+
+
+func _open_list_mode() -> void:
+	_mode = Mode.LIST
+	_title.text = "#DEX"
+	_footer.text = "D-pad: move    A: entry    SELECT: option    B: close"
+	_status.text = ""
+	_render_list()
+
+
+func _open_entry_mode() -> void:
+	_mode = Mode.ENTRY
+	_footer.text = "A: page    Up/Down: entry    B: back"
+	_status.text = ""
+	_render_entry()
+
+
+func _open_option_mode() -> void:
+	_mode = Mode.OPTION
+	_mode_rows = Gen2Pokedex.mode_rows()
+	_title.text = "OPTION"
+	_summary.text = ""
+	_status.text = ""
+	_footer.text = "D-pad: move    A: choose    B: back"
+	## `Pokedex_InitOptionScreen` points the cursor at the current mode, which
+	## it can do directly because the modes are the row indices.
+	_option_cursor = 0
+	for index: int in _mode_rows.size():
+		if int(_mode_rows[index]["mode"]) == _dex.mode:
+			_option_cursor = index
+	_render_option()
+
+
+## The listing, plus the SEEN and OWN totals `Pokedex_DrawMainScreenBG` prints
+## beside it.
+func _render_list() -> void:
+	_summary.text = "SEEN %3d    OWN %3d" % [_dex.seen_count(), _dex.caught_count()]
+	var rows: Array = _dex.rows()
+	_render_rows(rows, func(row: Dictionary) -> String:
+		if bool(row["empty"]):
+			return ""
+		var symbol: String = CAUGHT_SYMBOL if bool(row["caught"]) else UNCAUGHT_SYMBOL
+		var number: String = String(row["number"])
+		var prefix: String = "%s " % number if not number.is_empty() else ""
+		return "%s%s%s" % [prefix, symbol, String(row["name"])]
+	)
+
+
+func _render_entry() -> void:
+	var entry: Dictionary = _dex.entry()
+	_title.text = "No.%s  %s" % [String(entry["number"]), String(entry["name"])]
+	_summary.text = String(entry["category"])
+	for child: Node in _options.get_children():
+		child.queue_free()
+	## The height and weight rows come from the entry screen's own template
+	## ("HT" and "WT"), and stay blank for a species that has not been caught.
+	_add_line("HT  %s" % String(entry["height"]))
+	_add_line("WT  %slb" % String(entry["weight"]))
+	_add_line("")
+	for line: String in String(entry["text"]).split("\n"):
+		_add_line(line)
+	_status.text = "P.%d" % (int(entry["page"]) + 1) if bool(entry["caught"]) else ""
+
+
+func _render_option() -> void:
+	_render_rows(_mode_rows, func(row: Dictionary) -> String:
+		return String(row["label"])
+	)
+	_summary.text = String(_mode_rows[_option_cursor]["description"])
+
+
+func _render_rows(values: Array, label_for: Callable) -> void:
+	if _options == null:
+		return
+	for child: Node in _options.get_children():
+		child.queue_free()
+	var cursor: int = _dex.cursor if _mode == Mode.LIST else _option_cursor
+	for index: int in values.size():
+		var label := Label.new()
+		var text: String = label_for.call(values[index])
+		label.text = ("> " if index == cursor and not text.is_empty() else "  ") + text
+		label.add_theme_color_override(
+			"font_color", ACCENT if index == cursor else TEXT
+		)
+		label.add_theme_font_size_override("font_size", 18)
+		_options.add_child(label)
+
+
+func _add_line(text: String) -> void:
+	var label := Label.new()
+	label.text = text
+	label.add_theme_color_override("font_color", TEXT)
+	label.add_theme_font_size_override("font_size", 18)
+	_options.add_child(label)
+
+
+func _build_ui() -> void:
+	var scrim := ColorRect.new()
+	scrim.color = SCRIM
+	scrim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	scrim.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(scrim)
+
+	var center := CenterContainer.new()
+	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(center)
+	var panel := PanelContainer.new()
+	panel.custom_minimum_size = Vector2(420, 320)
+	panel.add_theme_stylebox_override("panel", _panel_style())
+	center.add_child(panel)
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 24)
+	margin.add_theme_constant_override("margin_top", 20)
+	margin.add_theme_constant_override("margin_right", 24)
+	margin.add_theme_constant_override("margin_bottom", 20)
+	panel.add_child(margin)
+	var content := VBoxContainer.new()
+	content.add_theme_constant_override("separation", 10)
+	margin.add_child(content)
+	_title = Label.new()
+	_title.add_theme_color_override("font_color", TEXT)
+	_title.add_theme_font_size_override("font_size", 24)
+	content.add_child(_title)
+	_summary = Label.new()
+	_summary.add_theme_color_override("font_color", MUTED)
+	_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	content.add_child(_summary)
+	_options = VBoxContainer.new()
+	_options.add_theme_constant_override("separation", 4)
+	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	content.add_child(_options)
+	_status = Label.new()
+	_status.add_theme_color_override("font_color", MUTED)
+	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	content.add_child(_status)
+	_footer = Label.new()
+	_footer.add_theme_color_override("font_color", ACCENT)
+	content.add_child(_footer)
+
+
+func _panel_style() -> StyleBoxFlat:
+	var style := StyleBoxFlat.new()
+	style.bg_color = PANEL
+	style.border_color = BORDER
+	style.set_border_width_all(2)
+	style.set_corner_radius_all(8)
+	return style

--- a/game/world/pokedex_screen.gd.uid
+++ b/game/world/pokedex_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://b0ob20xmjaa61

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -5,13 +5,14 @@ extends Control
 ## window-resolution Control panel consistent with the mart, phone and PC
 ## storage overlays rather than the hardware `menu_coords` box.
 ##
-## Pokemon and Pokegear are screens the world already owns (Gen2PartyScreen, the
-## phone list on Gen2WorldServiceScreen), so this only reports the choice through
+## Pokedex, Pokemon and Pokegear are screens the world already owns
+## (Gen2PokedexScreen, Gen2PartyScreen, the phone list on
+## Gen2WorldServiceScreen), so this only reports the choice through
 ## [signal action_chosen]. Pack and Save live here as internal modes, the way
 ## Gen2WorldServiceScreen owns a mart mode beside its menu mode.
 
 ## Emitted for an available entry this screen does not own itself
-## (Pokemon, Pokegear, Player); the caller opens the matching screen.
+## (Pokedex, Pokemon, Pokegear, Player); the caller opens the matching screen.
 signal action_chosen(kind: StringName)
 ## Emitted on Exit or cancel from the top-level list.
 signal closed
@@ -264,8 +265,8 @@ func _confirm_list() -> void:
 			_open_options_mode()
 		Gen2WorldStartMenu.ITEM_EXIT:
 			closed.emit()
-		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_POKEGEAR, \
-		Gen2WorldStartMenu.ITEM_PLAYER:
+		Gen2WorldStartMenu.ITEM_POKEDEX, Gen2WorldStartMenu.ITEM_POKEMON, \
+		Gen2WorldStartMenu.ITEM_POKEGEAR, Gen2WorldStartMenu.ITEM_PLAYER:
 			action_chosen.emit(_menu.selected_kind())
 		_:
 			# A Gen2ModHost-registered entry. Its handler is what made it

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -68,6 +68,11 @@ var _story_picture_backdrop: ColorRect = null
 var _story_picture: TextureRect = null
 var _battle_host: Gen2BattleScreen = null
 var _trainer_card_host: Gen2TrainerCardScreen = null
+var _pokedex_host: Gen2PokedexScreen = null
+## `wPrevDexEntry`, which is plain WRAM rather than saved data: it survives the
+## dex closing and reopening for as long as the game runs, the way the start
+## menu cursor below survives its own screen.
+var _pokedex_prev_entry: int = 0
 ## Leftover of a frame the play timer has not counted yet.
 var _game_time_seconds: float = 0.0
 var _service_host: Gen2WorldServiceScreen = null
@@ -361,7 +366,8 @@ func _advance_held_direction(delta: float) -> void:
 func _overlay_open() -> bool:
 	return _battle_host != null or _service_host != null or _pc_host != null \
 		or _start_menu_host != null or _party_host != null \
-		or _hall_of_fame_host != null or _trainer_card_host != null
+		or _hall_of_fame_host != null or _trainer_card_host != null \
+		or _pokedex_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -421,6 +427,8 @@ func _handle_button(button: int) -> bool:
 		if button == Gen2Button.A:
 			_acknowledge_field_move_text()
 		return true
+	if _pokedex_host != null:
+		return _pokedex_host.handle_button(button)
 	if _trainer_card_host != null:
 		return _trainer_card_host.handle_button(button)
 	if _start_menu_host != null:
@@ -1502,6 +1510,37 @@ func _on_start_menu_action(kind: StringName) -> void:
 			_open_pokegear()
 		Gen2WorldStartMenu.ITEM_PLAYER:
 			_open_trainer_card()
+		Gen2WorldStartMenu.ITEM_POKEDEX:
+			_open_pokedex()
+	_refresh_labels()
+
+
+## `StartMenu_Pokedex`'s `farcall Pokedex`. Its own B returns to the overworld,
+## which is where DEXSTATE_EXIT lands too.
+func _open_pokedex() -> void:
+	if _pokedex_host != null or _data == null:
+		return
+	var host := Gen2PokedexScreen.new()
+	if not host.open(_data, _world, _pokedex_prev_entry):
+		host.free()
+		_script_prompt = "The Pokedex needs a cache that carries its entries"
+		_refresh_labels()
+		return
+	host.z_index = 10
+	add_child(host)
+	host.closed.connect(_on_pokedex_closed)
+	_pokedex_host = host
+	_script_prompt = "Pokedex open"
+	_refresh_labels()
+
+
+func _on_pokedex_closed() -> void:
+	var host: Gen2PokedexScreen = _pokedex_host
+	_pokedex_host = null
+	if host != null:
+		_pokedex_prev_entry = host.previous_entry()
+		host.queue_free()
+	_script_prompt = "Pokedex closed"
 	_refresh_labels()
 
 

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -8,10 +8,8 @@ extends RefCounted
 ## Pokemon behind a non-zero wPartyCount, Pokegear behind
 ## wPokegearFlags/POKEGEAR_OBTAINED_F.
 ##
-## This project has no dex, so Pokedex is still built in its source position and
-## marked unavailable rather than omitted, keeping the list shape stable for when
-## it arrives. QUIT never appears because its Bug Contest and link-mode gate is
-## never true here.
+## QUIT never appears because its Bug Contest and link-mode gate is never true
+## here.
 ##
 ## Entries registered on `Gen2ModHost` are spliced in ahead of EXIT, so a mod can
 ## add a screen without reordering or removing anything the cartridge shipped.
@@ -47,7 +45,7 @@ const GATE_POKEGEAR: StringName = &"pokegear"
 ## question. EXIT stays last: it is what closes the menu, and the source never
 ## puts anything after it.
 const SOURCE_ENTRIES: Array[Dictionary] = [
-	{"kind": ITEM_POKEDEX, "label": "Pokedex", "available": false, "gate": GATE_POKEDEX},
+	{"kind": ITEM_POKEDEX, "label": "Pokedex", "available": true, "gate": GATE_POKEDEX},
 	{"kind": ITEM_POKEMON, "label": "Pokemon", "available": true, "gate": GATE_PARTY},
 	{"kind": ITEM_PACK, "label": "Pack", "available": true, "gate": &""},
 	{"kind": ITEM_POKEGEAR, "label": "Pokegear", "available": true, "gate": GATE_POKEGEAR},

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -117,6 +117,10 @@ var _used_flash: bool = false
 var _map_music: int = MUSIC_NONE
 var _radio_knob: int = Gen2WorldRadio.KNOB_MIN
 var _radio_channel: int = -1
+## `wLastDexMode`, which sits in the saved player data beside `wPokegearFlags`
+## and `wRadioTuningKnob` rather than in the Pokedex's own cleared block: the
+## dex takes its mode from here on opening and writes the mode back on exit.
+var _last_dex_mode: int = RomLayout.DEXMODE_NEW
 
 
 func _init(
@@ -205,6 +209,7 @@ func to_dict() -> Dictionary:
 		"map_music": _map_music,
 		"radio_knob": _radio_knob,
 		"radio_channel": _radio_channel,
+		"last_dex_mode": _last_dex_mode,
 	}
 
 
@@ -240,6 +245,7 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored._map_music = maxi(0, int(source.get("map_music", MUSIC_NONE)))
 	restored.set_radio_knob(int(source.get("radio_knob", Gen2WorldRadio.KNOB_MIN)))
 	restored._radio_channel = int(source.get("radio_channel", -1))
+	restored.set_last_dex_mode(int(source.get("last_dex_mode", RomLayout.DEXMODE_NEW)))
 	return restored
 
 
@@ -271,6 +277,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_map_music = restored._map_music
 	_radio_knob = restored._radio_knob
 	_radio_channel = restored._radio_channel
+	_last_dex_mode = restored._last_dex_mode
 	changed.emit()
 
 
@@ -564,6 +571,22 @@ func radio_knob() -> int:
 
 
 ## Clamped and snapped to the source's own two-step dial.
+func last_dex_mode() -> int:
+	return _last_dex_mode
+
+
+## `.exit`'s `ld a, [wCurDexMode]; ld [wLastDexMode], a`. A mode outside the
+## three the listing can be in is refused rather than stored: the fourth,
+## DEXMODE_UNOWN, is the Unown dex, which never becomes `wCurDexMode`.
+func set_last_dex_mode(mode: int) -> void:
+	if mode not in [
+		RomLayout.DEXMODE_NEW, RomLayout.DEXMODE_OLD, RomLayout.DEXMODE_ABC,
+	] or mode == _last_dex_mode:
+		return
+	_last_dex_mode = mode
+	changed.emit()
+
+
 func set_radio_knob(knob: int) -> void:
 	var next_knob: int = clampi(knob, Gen2WorldRadio.KNOB_MIN, Gen2WorldRadio.KNOB_MAX)
 	next_knob -= next_knob % Gen2WorldRadio.KNOB_STEP

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -701,3 +701,54 @@ func test_the_play_timer_counts_while_the_world_runs() -> void:
 	save.game_time = Gen2GameTime.new()
 	_world_screen._advance_game_time(Gen2WorldAnimation.FRAME_SECONDS * 3.0)
 	assert_eq(save.game_time.frames, 3)
+
+
+## `StartMenu_Pokedex`'s `farcall Pokedex`, as an overlay the world screen owns
+## the way it owns the trainer card.
+func test_pokedex_opens_from_the_start_menu_and_b_returns_to_the_overworld() -> void:
+	await _open_world()
+	_world_screen._world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX)
+	_world_screen._world.state.set_species_seen(Fixture.TRAINER_SPECIES)
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_POKEDEX)
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_null(_world_screen._start_menu_host)
+	var dex: Gen2PokedexScreen = _world_screen._pokedex_host
+	assert_not_null(dex)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.LIST)
+	assert_false(_world_screen.move_player(Vector2i.RIGHT), "the dex blocks the overworld")
+
+	## SELECT reaches the OPTION screen, and B comes back to the listing.
+	dex.handle_button(Gen2Button.SELECT)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.OPTION)
+	dex.handle_button(Gen2Button.B)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.LIST)
+
+	dex.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+	assert_null(_world_screen._pokedex_host)
+	assert_true(_world_screen._objects_may_move())
+
+
+## A mode chosen on the OPTION screen is written back to wLastDexMode, which is
+## saved player data, so the next opening starts there.
+func test_the_chosen_dex_mode_survives_closing_the_dex() -> void:
+	await _open_world()
+	var state: Gen2WorldState = _world_screen._world.state
+	state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX)
+	_world_screen._open_pokedex()
+	var dex: Gen2PokedexScreen = _world_screen._pokedex_host
+	assert_not_null(dex)
+	dex.handle_button(Gen2Button.SELECT)
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(state.last_dex_mode(), RomLayout.DEXMODE_OLD)
+	dex.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+
+	_world_screen._open_pokedex()
+	var reopened: Gen2PokedexScreen = _world_screen._pokedex_host
+	assert_eq(reopened.get("_dex").mode, RomLayout.DEXMODE_OLD)

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -239,6 +239,7 @@ static func build(directory: String) -> GameData:
 	RomCache.prepare(directory)
 
 	RomCache.write_json(RomCache.species_path(directory), _species())
+	RomCache.write_json(RomCache.dex_orders_path(directory), _dex_orders())
 	RomCache.write_json(RomCache.moves_path(directory), _moves())
 	RomCache.write_json(RomCache.items_path(directory), _items())
 	RomCache.write_json(RomCache.types_path(directory), _types())
@@ -319,9 +320,27 @@ static func _species() -> Array:
 			"base_exp": entry[4],
 			"gender_ratio": entry[6],
 			"front_tiles": [7, 7],
+			"dex": {
+				"category": "%s MON" % entry[0],
+				"height": 204,
+				"weight": 150,
+				"pages": ["page one", "page two"],
+			},
 			"palette": {"normal": [0x1234, 0x5678], "shiny": [0x0C63, 0x1084]},
 		})
 	return out
+
+
+## Both dex order tables, which every real cache carries and the Pokedex refuses
+## to open without. The species range stands in for NewPokedexOrder, since
+## nothing here checks a listing against the cartridge's own order.
+static func _dex_orders() -> Dictionary:
+	var forward: Array = []
+	var backward: Array = []
+	for number: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		forward.append(number)
+		backward.append(RomLayout.SPECIES_COUNT + 1 - number)
+	return {"new": forward, "alpha": backward}
 
 
 static func _moves() -> Array:

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -1,0 +1,74 @@
+extends RefCounted
+
+## A cache carrying a full species range and both dex order tables, written in
+## the same files the importer writes.
+##
+## The dex is the one screen that needs all 251 species: the order tables are
+## that long and [method Gen2Pokedex.order_by_mode] fills the whole listing, so
+## the battle fixture's short table cannot stand in. Names and entry text are
+## generated rather than published values, since nothing here checks content
+## against a cartridge; [method RomImporter.verify_pokedex] does that.
+
+const GAME_ID: StringName = &"pokedexfixture"
+const SHA1: String = "0123456789abcdef"
+
+## Deliberately unlike the species range and unlike each other, so a test that
+## passes under the wrong table fails: NEW runs backwards, and ABC lists the
+## even numbers before the odd ones.
+static func new_order() -> Array:
+	var out: Array = []
+	for number: int in range(RomLayout.SPECIES_COUNT, 0, -1):
+		out.append(number)
+	return out
+
+
+static func alpha_order() -> Array:
+	var out: Array = []
+	for number: int in range(2, RomLayout.SPECIES_COUNT + 1, 2):
+		out.append(number)
+	for number: int in range(1, RomLayout.SPECIES_COUNT + 1, 2):
+		out.append(number)
+	return out
+
+
+static func species_name(number: int) -> String:
+	return "MON%03d" % number
+
+
+static func directory() -> String:
+	return RomCache.directory_for(GAME_ID, SHA1)
+
+
+static func build() -> GameData:
+	var path: String = directory()
+	RomCache.clear(path)
+	RomCache.prepare(path)
+	RomCache.write_json(RomCache.species_path(path), _species())
+	RomCache.write_json(RomCache.dex_orders_path(path), {
+		"new": new_order(), "alpha": alpha_order(),
+	})
+	RomCache.write_json(RomCache.manifest_path(path), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": String(GAME_ID),
+		"sha1": SHA1,
+		"complete": true,
+	})
+	return GameData.open_directory(path)
+
+
+## Heights and weights are the species number and twice it, so a formatting test
+## can pick a number and know what it should read without a table here.
+static func _species() -> Array:
+	var out: Array = []
+	for number: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		out.append({
+			"number": number,
+			"name": species_name(number),
+			"dex": {
+				"category": "CAT%03d" % number,
+				"height": number,
+				"weight": number * 2,
+				"pages": ["page one %d" % number, "page two %d" % number],
+			},
+		})
+	return out

--- a/tests/unit/pokedex_fixture.gd.uid
+++ b/tests/unit/pokedex_fixture.gd.uid
@@ -1,0 +1,1 @@
+uid://b6ag4j3pv1qsd

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -87,6 +87,9 @@ func _write_cache(complete: bool = true) -> void:
 		"music": [{"index": 0, "bank": 1, "address": 0x4000}],
 		"sfx": [{"index": 0, "bank": 2, "address": 0x4000}],
 	})
+	RomCache.write_json(RomCache.dex_orders_path(_directory), {
+		"new": _dex_order(true), "alpha": _dex_order(false),
+	})
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "testgame",
@@ -102,6 +105,15 @@ func _write_cache(complete: bool = true) -> void:
 		},
 		"complete": complete,
 	})
+
+
+## A full-length order table, since GameData drops one that is not: the two
+## differ only in direction, which is enough to tell them apart.
+func _dex_order(forward: bool) -> Array:
+	var out: Array = []
+	for number: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		out.append(number if forward else RomLayout.SPECIES_COUNT + 1 - number)
+	return out
 
 
 func _matchup(
@@ -128,6 +140,12 @@ func _species(number: int, name: String, normal: int, shiny: int) -> Dictionary:
 			"method": RomLayout.EVOLVE_LEVEL, "parameter": 16, "condition": 0, "target": 2,
 		}],
 		"learnset": [{"level": 1, "move": 33}, {"level": 4, "move": 45}],
+		"dex": {
+			"category": "SEED",
+			"height": 204,
+			"weight": 150,
+			"pages": ["page one", "page two"],
+		},
 	}
 
 
@@ -454,3 +472,32 @@ func test_a_species_knows_what_its_level_says_it_knows() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	assert_eq(data.moves_at_level(1, 1), [33], "the move at level 4 is not learned yet")
 	assert_eq(data.moves_at_level(1, 4), [33, 45])
+
+
+## The dex entry travels on the species, so a number with no species has none.
+func test_a_dex_entry_comes_back_with_its_numbers_coerced() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var entry: Dictionary = data.dex_entry(1)
+	assert_eq(String(entry["category"]), "SEED")
+	assert_eq(int(entry["height"]), 204)
+	assert_eq(int(entry["weight"]), 150)
+	assert_eq(Array(entry["pages"] as PackedStringArray), ["page one", "page two"])
+	assert_true(data.dex_entry(999).is_empty(), "no species, no entry")
+
+
+func test_both_dex_order_tables_come_back_as_species_numbers() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.dex_order_new().size(), RomLayout.SPECIES_COUNT)
+	assert_eq(data.dex_order_new()[0], 1)
+	assert_eq(data.dex_order_alpha()[0], RomLayout.SPECIES_COUNT)
+
+
+## A table that is not the full species range would list a species number of
+## zero, which the listing treats as its end, so it is dropped whole.
+func test_a_short_dex_order_table_is_dropped() -> void:
+	_write_cache()
+	RomCache.write_json(RomCache.dex_orders_path(_directory), {"new": [1, 2, 3]})
+	var data: GameData = GameData.open_directory(_directory)
+	assert_true(data.dex_order_new().is_empty())

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -1,0 +1,298 @@
+extends GutTest
+
+## engine/pokedex/pokedex.asm, as the listing order, the cursor walk and the
+## entry the screen prints.
+
+const Fixture := preload("res://tests/unit/pokedex_fixture.gd")
+
+var _data: GameData = null
+
+
+func before_each() -> void:
+	_data = Fixture.build()
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func _state(seen: Array, caught: Array = []) -> Gen2WorldState:
+	var seen_map: Dictionary = {}
+	for species: int in seen:
+		seen_map[species] = true
+	var caught_map: Dictionary = {}
+	for species: int in caught:
+		caught_map[species] = true
+	return Gen2WorldState.new(
+		{}, {}, {}, {}, 0, {}, 0, Vector2i(-1, -1), 0, [], false, 0,
+		Gen2WorldState.PHONE_RECEIVE_DELAYS[0], 0, seen_map, {}, {}, caught_map
+	)
+
+
+func _dex(seen: Array, caught: Array = [], mode: int = RomLayout.DEXMODE_NEW,
+	previous: int = 0) -> Gen2Pokedex:
+	return Gen2Pokedex.open(_data, _state(seen, caught), mode, previous)
+
+
+## `.NewMode` copies NewPokedexOrder whole, and `.OldMode` counts from 1.
+func test_new_mode_lists_the_new_dex_table_and_old_mode_the_species_range() -> void:
+	var new_dex: Gen2Pokedex = _dex([RomLayout.SPECIES_COUNT])
+	assert_eq(new_dex.rows()[0]["species"], RomLayout.SPECIES_COUNT)
+
+	var old_dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	var species: Array = []
+	for row: Dictionary in old_dex.rows():
+		species.append(int(row["species"]))
+	assert_eq(species, [1, 2, 3, 4, 5, 6, 7])
+
+
+## `Pokedex_ABCMode` keeps only the species that have been seen, and
+## `wDexListingEnd` is that count.
+func test_abc_mode_lists_only_seen_species_and_zero_fills_the_tail() -> void:
+	# 4 and 8 are the first two even numbers in the fixture's alphabetical
+	# table, and 3 is the first odd one, so ABC order puts them in that order.
+	var dex: Gen2Pokedex = _dex([3, 4, 8], [], RomLayout.DEXMODE_ABC)
+	assert_eq(dex.listing_end, 3)
+	var rows: Array = dex.rows()
+	assert_eq(int(rows[0]["species"]), 4)
+	assert_eq(int(rows[1]["species"]), 8)
+	assert_eq(int(rows[2]["species"]), 3)
+	assert_true(bool(rows[3]["empty"]), "the tail past the seen species is zero")
+
+
+## `.FindLastSeen` answers the last seen species' position in the order, which
+## is not the number of species seen.
+func test_listing_end_is_the_last_seen_position_not_a_count() -> void:
+	# The fixture's new order runs backwards, so species 251 is at position 1
+	# and species 249 at position 3.
+	var dex: Gen2Pokedex = _dex([251, 249])
+	assert_eq(dex.listing_end, 3)
+
+
+func test_listing_end_is_zero_when_nothing_has_been_seen() -> void:
+	assert_eq(_dex([]).listing_end, 0)
+
+
+## `.PrintEntry`: an unseen row is the default string and nothing else, a seen
+## row carries the name, and only a caught one carries the symbol.
+func test_a_row_shows_a_name_only_once_seen_and_a_symbol_only_once_caught() -> void:
+	var dex: Gen2Pokedex = _dex([251, 250], [250], RomLayout.DEXMODE_OLD)
+	dex.scroll = 249
+	var rows: Array = dex.rows()
+	assert_eq(String(rows[0]["name"]), Fixture.species_name(250))
+	assert_true(bool(rows[0]["caught"]))
+	assert_eq(String(rows[1]["name"]), Fixture.species_name(251))
+	assert_false(bool(rows[1]["caught"]), "seen but not caught")
+
+	var unseen: Gen2Pokedex = _dex([251], [], RomLayout.DEXMODE_OLD)
+	assert_eq(String(unseen.rows()[0]["name"]), Gen2Pokedex.NOT_SEEN_NAME)
+	assert_false(bool(unseen.rows()[0]["seen"]))
+
+
+## `Pokedex_PrintNumberIfOldMode` prints a number in OLD mode only.
+func test_only_old_mode_numbers_its_rows() -> void:
+	assert_eq(String(_dex([1], [], RomLayout.DEXMODE_OLD).rows()[0]["number"]), "001")
+	assert_eq(String(_dex([251]).rows()[0]["number"]), "")
+
+
+## `Pokedex_ListingMoveCursorDown` moves the cursor inside the visible rows and
+## scrolls once it is at the bottom of them, and refuses at the listing's end.
+func test_the_cursor_moves_then_scrolls_and_stops_at_the_end() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	dex.listing_end = 10
+	for step: int in Gen2Pokedex.LISTING_HEIGHT - 1:
+		assert_true(dex.move_listing(Gen2Button.DOWN))
+	assert_eq(dex.cursor, Gen2Pokedex.LISTING_HEIGHT - 1)
+	assert_eq(dex.scroll, 0)
+
+	assert_true(dex.move_listing(Gen2Button.DOWN))
+	assert_eq(dex.cursor, Gen2Pokedex.LISTING_HEIGHT - 1, "the cursor stays at the bottom row")
+	assert_eq(dex.scroll, 1)
+
+	assert_true(dex.move_listing(Gen2Button.DOWN))
+	assert_eq(dex.scroll, 2)
+	assert_true(dex.move_listing(Gen2Button.DOWN))
+	assert_eq(dex.scroll, 3, "ten entries over seven rows scroll three times")
+	assert_false(dex.move_listing(Gen2Button.DOWN), "the listing ends at 10")
+
+
+## `Pokedex_ListingMoveCursorUp` scrolls only once the cursor is at the top.
+func test_moving_up_empties_the_cursor_before_it_scrolls() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	dex.listing_end = 20
+	dex.cursor = 2
+	dex.scroll = 5
+	assert_true(dex.move_listing(Gen2Button.UP))
+	assert_eq(dex.cursor, 1)
+	assert_eq(dex.scroll, 5)
+	dex.cursor = 0
+	assert_true(dex.move_listing(Gen2Button.UP))
+	assert_eq(dex.scroll, 4)
+
+	dex.scroll = 0
+	assert_false(dex.move_listing(Gen2Button.UP), "nothing above the top")
+
+
+## `Pokedex_ListingHandleDPadInput` checks the height against the listing end
+## before it reads left or right at all.
+func test_paging_is_refused_while_the_listing_fits_on_one_screen() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	dex.listing_end = Gen2Pokedex.LISTING_HEIGHT
+	assert_false(dex.move_listing(Gen2Button.RIGHT))
+	assert_false(dex.move_listing(Gen2Button.LEFT))
+	assert_eq(dex.scroll, 0)
+
+
+## `Pokedex_ListingMoveDownOnePage` and `..._MoveUpOnePage`.
+func test_a_page_moves_a_screen_and_clamps_to_either_end() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	dex.listing_end = 30
+	assert_true(dex.move_listing(Gen2Button.RIGHT))
+	assert_eq(dex.scroll, Gen2Pokedex.LISTING_HEIGHT)
+
+	dex.scroll = 25
+	assert_true(dex.move_listing(Gen2Button.RIGHT))
+	assert_eq(dex.scroll, 30 - Gen2Pokedex.LISTING_HEIGHT, "clamped to the last page")
+
+	assert_true(dex.move_listing(Gen2Button.LEFT))
+	assert_eq(dex.scroll, 30 - Gen2Pokedex.LISTING_HEIGHT * 2)
+
+	dex.scroll = 3
+	assert_true(dex.move_listing(Gen2Button.LEFT))
+	assert_eq(dex.scroll, 0, "less than a page from the top goes to the top")
+
+
+## `Pokedex_UpdateMainScreen`'s A refuses a species that has not been seen.
+func test_the_entry_screen_opens_only_for_a_seen_species() -> void:
+	var dex: Gen2Pokedex = _dex([250], [], RomLayout.DEXMODE_OLD)
+	assert_false(dex.can_open_entry(), "species 1 has not been seen")
+	dex.scroll = 249
+	assert_true(dex.can_open_entry())
+
+
+## `DisplayDexEntry` prints the name, the category and the number either way,
+## and the caught check gates the measurements and the description.
+func test_an_uncaught_entry_shows_its_name_and_category_but_no_measurements() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	var entry: Dictionary = dex.entry()
+	assert_eq(String(entry["name"]), Fixture.species_name(1))
+	assert_eq(String(entry["category"]), "CAT001")
+	assert_eq(String(entry["number"]), "001")
+	assert_eq(String(entry["height"]), "")
+	assert_eq(String(entry["weight"]), "")
+	assert_eq(String(entry["text"]), "")
+
+
+func test_a_caught_entry_carries_its_measurements_and_both_pages() -> void:
+	var dex: Gen2Pokedex = _dex([204], [204], RomLayout.DEXMODE_OLD)
+	dex.scroll = 203
+	var entry: Dictionary = dex.entry()
+	assert_eq(String(entry["text"]), "page one 204")
+	dex.toggle_page()
+	assert_eq(String(dex.entry()["text"]), "page two 204")
+	dex.toggle_page()
+	assert_eq(String(dex.entry()["text"]), "page one 204", "the page toggles back")
+
+
+## `.skip_height` and `.skip_weight` leave a zero measurement blank rather than
+## printing a zero.
+func test_a_zero_measurement_is_left_blank() -> void:
+	RomCache.write_json(RomCache.species_path(Fixture.directory()), [{
+		"number": 1, "name": "MON001",
+		"dex": {"category": "CAT", "height": 0, "weight": 0, "pages": ["a", "b"]},
+	}])
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	var dex: Gen2Pokedex = Gen2Pokedex.open(
+		data, _state([1], [1]), RomLayout.DEXMODE_OLD
+	)
+	var entry: Dictionary = dex.entry()
+	assert_eq(String(entry["height"]), "")
+	assert_eq(String(entry["weight"]), "")
+
+
+## `_PrintNum` with the two calls DisplayDexEntry makes: a blanked leading zero
+## leaves a space, and the digit in front of the point always prints.
+func test_the_measurements_are_punctuated_the_way_print_num_punctuates_them() -> void:
+	assert_eq(Gen2Pokedex.height_text(204), " 2'04\"", "Bulbasaur")
+	assert_eq(Gen2Pokedex.height_text(3002), "30'02\"", "Steelix")
+	assert_eq(Gen2Pokedex.height_text(8), " 0'08\"", "a zero in front of the point still prints")
+	assert_eq(Gen2Pokedex.weight_text(150), "  15.0", "Bulbasaur")
+	assert_eq(Gen2Pokedex.weight_text(10140), "1014.0", "Snorlax")
+	assert_eq(Gen2Pokedex.weight_text(2), "   0.2")
+
+
+## `Pokedex_NextOrPreviousDexEntry` keeps moving until it reaches a species that
+## has been seen, and puts the cursor back when it runs out.
+func test_stepping_through_entries_skips_unseen_species() -> void:
+	var dex: Gen2Pokedex = _dex([1, 5], [], RomLayout.DEXMODE_OLD)
+	dex.open_entry()
+	assert_eq(int(dex.entry()["species"]), 1)
+	assert_true(dex.step_entry(Gen2Button.DOWN))
+	assert_eq(int(dex.entry()["species"]), 5, "2 through 4 have not been seen")
+
+	assert_false(dex.step_entry(Gen2Button.DOWN), "nothing seen below 5")
+	assert_eq(int(dex.entry()["species"]), 5, "the cursor is put back")
+	assert_eq(dex.cursor, 4)
+
+
+func test_stepping_to_a_new_entry_returns_to_page_one() -> void:
+	var dex: Gen2Pokedex = _dex([1, 2], [1, 2], RomLayout.DEXMODE_OLD)
+	dex.open_entry()
+	dex.toggle_page()
+	assert_eq(dex.page, Gen2Pokedex.PAGE_2)
+	assert_true(dex.step_entry(Gen2Button.DOWN))
+	assert_eq(dex.page, Gen2Pokedex.PAGE_1)
+
+
+## `Pokedex_InitCursorPosition` seeks the cursor to wPrevDexEntry.
+func test_the_dex_opens_on_the_last_entry_viewed() -> void:
+	var seen: Array = []
+	for number: int in range(1, 21):
+		seen.append(number)
+	var dex: Gen2Pokedex = Gen2Pokedex.open(
+		_data, _state(seen), RomLayout.DEXMODE_OLD, 12
+	)
+	assert_eq(dex.selected_species(), 12)
+
+
+func test_no_previous_entry_opens_at_the_top() -> void:
+	var dex: Gen2Pokedex = _dex([1, 2, 3], [], RomLayout.DEXMODE_OLD)
+	assert_eq(dex.cursor, 0)
+	assert_eq(dex.scroll, 0)
+
+
+## `Pokedex_DrawOptionScreenBG` hides UNOWN MODE while wUnlockedUnownMode is
+## clear, which is the only state this project can be in.
+func test_the_option_screen_lists_three_modes_without_the_unown_dex() -> void:
+	var rows: Array = Gen2Pokedex.mode_rows()
+	assert_eq(rows.size(), 3)
+	assert_eq(String(rows[0]["label"]), "NEW #DEX MODE")
+	assert_eq(String(rows[2]["label"]), "A to Z MODE")
+	assert_eq(Gen2Pokedex.mode_rows(true).size(), 4)
+
+
+## `.ChangeMode` skips a mode that is already current, and reorders and reseeks
+## when it is not.
+func test_changing_to_the_current_mode_changes_nothing() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	dex.scroll = 3
+	assert_false(dex.change_mode(RomLayout.DEXMODE_OLD))
+	assert_eq(dex.scroll, 3, "the listing is left alone")
+
+
+func test_changing_mode_reorders_and_reseeks_the_previous_entry() -> void:
+	var seen: Array = []
+	for number: int in range(1, 21):
+		seen.append(number)
+	var dex: Gen2Pokedex = Gen2Pokedex.open(_data, _state(seen), RomLayout.DEXMODE_OLD, 12)
+	assert_eq(dex.selected_species(), 12)
+	assert_true(dex.change_mode(RomLayout.DEXMODE_ABC))
+	assert_eq(dex.mode, RomLayout.DEXMODE_ABC)
+	assert_eq(dex.selected_species(), 12, "the last entry viewed is found again")
+
+
+## `Pokedex_DrawMainScreenBG`'s two CountSetBits totals.
+func test_the_screen_counts_seen_and_owned() -> void:
+	var dex: Gen2Pokedex = _dex([1, 2, 3], [1])
+	assert_eq(dex.seen_count(), 3)
+	assert_eq(dex.caught_count(), 1)

--- a/tests/unit/test_pokedex.gd.uid
+++ b/tests/unit/test_pokedex.gd.uid
@@ -1,0 +1,1 @@
+uid://bdjrs6iklaisx

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -322,3 +322,57 @@ func test_a_fixed_bank_still_addresses_inside_the_cartridge() -> void:
 		for stored: int in range(0x10, 0x40):
 			var bank: int = RomLayout.fix_pic_bank(layout, stored)
 			assert_lt(RomFile.linear(bank, 0x7FFF), RomRegistry.EXPECTED_SIZE)
+
+
+## GetDexEntryPointer picks the bank from the species number rather than the
+## pointer: `(species - 1) >> 6`, so each of the four sections covers 64 species
+## and the last covers the 59 that are left.
+func test_dex_entry_banks_change_every_sixty_four_species() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		var banks: Array = (layout["pokedex"] as Dictionary)["entry_banks"]
+		assert_eq(banks.size(), RomLayout.DEX_ENTRY_BANK_COUNT, "%s bank count" % id)
+		for boundary: Array in [[1, 0], [64, 0], [65, 1], [128, 1], [129, 2], [192, 2],
+			[193, 3], [RomLayout.SPECIES_COUNT, 3]]:
+			assert_eq(
+				RomLayout.dex_entry_bank(layout, int(boundary[0])),
+				int(banks[int(boundary[1])]),
+				"%s species %d" % [id, int(boundary[0])]
+			)
+
+
+func test_dex_entry_pointers_are_one_based_and_two_bytes_wide() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.CRYSTAL)
+	var table: int = int((layout["pokedex"] as Dictionary)["entry_pointers"])
+	assert_eq(RomLayout.dex_entry_pointer_offset(layout, 1), table)
+	assert_eq(
+		RomLayout.dex_entry_pointer_offset(layout, 2),
+		table + RomLayout.DEX_ENTRY_POINTER_SIZE
+	)
+
+
+## A dex entry address is bank-local, so the flat offset is its bank's base plus
+## the address's position within the window.
+func test_a_dex_entry_address_resolves_into_its_own_bank() -> void:
+	var layout: Dictionary = RomLayout.for_id(RomRegistry.CRYSTAL)
+	var bank: int = RomLayout.dex_entry_bank(layout, 1)
+	assert_eq(
+		RomLayout.dex_entry_offset(layout, 1, 0x5695),
+		bank * RomFile.BANK_SIZE + 0x1695
+	)
+
+
+## Every Pokedex table has to sit inside the dump like the flat offsets do; the
+## nested Dictionary keeps them out of that check, so they are checked here.
+func test_pokedex_tables_land_inside_a_cartridge() -> void:
+	for id: StringName in RomRegistry.ORDER:
+		var pokedex: Dictionary = RomLayout.for_id(id)["pokedex"]
+		for key: String in ["entry_pointers", "order_new", "order_alpha"]:
+			assert_between(
+				int(pokedex[key]), 0, RomRegistry.EXPECTED_SIZE - 1, "%s.%s" % [id, key]
+			)
+		for bank: int in pokedex["entry_banks"]:
+			assert_between(
+				bank * RomFile.BANK_SIZE, 0, RomRegistry.EXPECTED_SIZE - 1,
+				"%s bank %d" % [id, bank]
+			)

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -5,8 +5,7 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 ## engine/menus/start_menu.asm's StartMenu.SetUpMenuItems gating, reproduced
 ## as data: Pokedex behind wStatusFlags/STATUSFLAGS_POKEDEX_F, Pokemon behind
 ## a non-zero party count, Pokegear behind wPokegearFlags/POKEGEAR_OBTAINED_F,
-## everything else always present. Pokedex is always built but marked
-## unavailable, since this project has no dex yet.
+## everything else always present.
 
 
 func _kinds(menu: Gen2WorldStartMenu) -> Array:
@@ -39,14 +38,14 @@ func test_pokegear_appears_only_with_the_source_engine_flag() -> void:
 	assert_true(_kinds(with_flag).has(Gen2WorldStartMenu.ITEM_POKEGEAR))
 
 
-func test_pokedex_appears_only_with_the_source_engine_flag_and_stays_unavailable() -> void:
+func test_pokedex_appears_only_with_the_source_engine_flag() -> void:
 	var without: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
 	assert_false(_kinds(without).has(Gen2WorldStartMenu.ITEM_POKEDEX))
 	var with_flag: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, true, false)
 	assert_true(_kinds(with_flag).has(Gen2WorldStartMenu.ITEM_POKEDEX))
 	for entry: Dictionary in with_flag.items():
 		if entry.get("kind") == Gen2WorldStartMenu.ITEM_POKEDEX:
-			assert_false(entry.get("available"))
+			assert_true(entry.get("available"))
 
 
 func test_full_list_matches_the_source_item_order_when_every_gate_is_open() -> void:
@@ -59,7 +58,7 @@ func test_full_list_matches_the_source_item_order_when_every_gate_is_open() -> v
 	])
 
 
-func test_every_entry_but_pokedex_is_available() -> void:
+func test_every_entry_the_gates_admit_is_available() -> void:
 	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
 	var available_by_kind: Dictionary = {}
 	for entry: Dictionary in menu.items():
@@ -71,7 +70,7 @@ func test_every_entry_but_pokedex_is_available() -> void:
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_EXIT])
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_OPTION])
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_PLAYER])
-	assert_false(available_by_kind[Gen2WorldStartMenu.ITEM_POKEDEX])
+	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_POKEDEX])
 
 
 func test_quit_never_appears_because_this_project_has_no_bug_contest() -> void:
@@ -152,8 +151,7 @@ func test_a_registered_entry_lands_before_exit() -> void:
 	Gen2ModHost.reset()
 
 
-## An entry with no handler still appears, marked unavailable, the way Pokedex
-## does.
+## An entry with no handler still appears, marked unavailable.
 func test_a_registered_entry_without_a_handler_is_unavailable() -> void:
 	Gen2ModHost.reset()
 	Gen2ModHost.instance().register_menu_entry(

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -290,3 +290,21 @@ func test_seeding_roaming_mons_keeps_a_record_that_already_moved() -> void:
 	var loose: Gen2WorldState = Gen2WorldState.from_dict({"roaming_mons": moved})
 	loose.ensure_roaming_mons(initial)
 	assert_eq(loose.roaming_mons(), moved)
+
+
+## `wLastDexMode` sits in the saved player data, so it survives a snapshot the
+## way the radio knob beside it does.
+func test_the_last_dex_mode_round_trips() -> void:
+	var state := Gen2WorldState.new()
+	assert_eq(state.last_dex_mode(), RomLayout.DEXMODE_NEW, "a fresh state opens on NEW")
+	state.set_last_dex_mode(RomLayout.DEXMODE_ABC)
+	var restored := Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.last_dex_mode(), RomLayout.DEXMODE_ABC)
+
+
+## DEXMODE_UNOWN is the Unown dex rather than a listing order, and never becomes
+## wCurDexMode, so it is refused rather than stored.
+func test_the_unown_dex_is_not_a_listing_mode() -> void:
+	var state := Gen2WorldState.new()
+	state.set_last_dex_mode(RomLayout.DEXMODE_UNOWN)
+	assert_eq(state.last_dex_mode(), RomLayout.DEXMODE_NEW)


### PR DESCRIPTION
Import every species' dex entry (category, height, weight and both description pages) and the two order tables NEW and A to Z list by, then build the listing, entry and OPTION screens over them.

Entries are located from encoded SEED and Bulbasaur's published 204 and 150; the bank is chosen by species rather than stored, the way GetDexEntryPointer masks (species - 1) >> 6. Gold and Silver share the offsets but not the text, so each profile is read from its own cartridge.

The measurements go through _PrintNum's own blanking rather than a format string, so a suppressed leading zero is a space and the digit in front of the point always prints. wLastDexMode is saved player data and lives on the world state; wPrevDexEntry is plain WRAM and lives on the world screen, so the dex reopens where it was but a save does not carry it.

Cache format 28: an old cache is discarded and re-imported.