### PR TITLE
Let the dex be asked what it has, by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,9 @@ cartridge's own graphics with its badge pages and its play timer.
 Pokedex lists the species in the cartridge's own NEW, OLD and A to Z orders,
 showing a name once seen and a caught mark once caught, and opens each seen
 species' entry with its category, height, weight and both description pages.
-SELECT changes the order; the mode is saved. Its SEARCH screen, the Unown dex
-and the entry screen's AREA, CRY and PRNT buttons are not built.
+SELECT changes the order and the mode is saved; START searches by one or two
+types over the species already caught. The Unown dex and the entry screen's
+AREA, CRY and PRNT buttons are not built.
 Pokegear opens its card list, in the source's clock, map, phone, radio order and
 showing only cards the player owns; the map card keeps its position marked
 unavailable. The radio card tunes with left and right over the cartridge's own

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -103,8 +103,11 @@ Pokedex/Pokemon/Pokegear gating and the `STATICMENU_WRAP` cursor.
 `pokedex.gd` models `engine/pokedex/pokedex.asm`'s listing: the three orderings
 `Pokedex_OrderMonsByMode` builds, `.FindLastSeen`'s listing end, `.PrintEntry`'s
 per-row decision and `Pokedex_ListingHandleDPadInput`'s cursor and paging walk.
-`pokedex_screen.gd` is its listing, entry and OPTION states; the entry's two
-measurements go through `_PrintNum`'s own blanking rather than a format string.
+It also models `Pokedex_SearchForMons`, whose two type rows wrap differently and
+whose passes filter the listing in place, so two types narrow rather than widen.
+`pokedex_screen.gd` is its listing, entry, OPTION, SEARCH and results states;
+the entry's two measurements go through `_PrintNum`'s own blanking rather than a
+format string.
 `world_options_menu.gd` models `engine/menus/options_menu.asm` over
 [Gen2Options], seven value rows plus CANCEL, and leaves persistence to
 `Gen2OptionsStore`. `trainer_card.gd` and `render/trainer_card_page.gd` are

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -137,7 +137,11 @@ const AUDIO_WAVE_SAMPLE_BYTES: int = 16
 const AUDIO_DRUMKIT_COUNT: int = 6
 const AUDIO_DRUMKIT_SAMPLE_COUNT: int = 13
 const AUDIO_DRUMKIT_BYTES: int = 0x174
-const AUDIO_CRY_COUNT: int = 67
+## `NUM_CRIES`, which is 68 rather than 67: constants/cry_constants.asm runs
+## CRY_NIDORAN_M through CRY_DONPHAN inclusive. The pointer table's own last
+## entry is CRY_DONPHAN and the next three bytes are already the SFX table, so a
+## count of 67 dropped exactly one cry, the one species 232 asks for.
+const AUDIO_CRY_COUNT: int = 68
 
 ## The overworld palette file contains 42 four-colour groups: morning, day,
 ## night and dark outdoor groups, the indoor group, and the two animated water

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -13,10 +13,12 @@ extends RefCounted
 ## `.OldMode` counts from 1. Seen and caught come from [Gen2WorldState], which
 ## already keeps both arrays.
 
-## `wDexListingHeight` as the main screen sets it (`ld a, 7`). The search results
-## screen sets its own, which is why this is the listing's height rather than the
-## model's.
+## What each screen writes to `wDexListingHeight`: the main screen `ld a, 7` and
+## the search results screen `ld a, 4`. It is WRAM the source rewrites per
+## screen, so [member listing_height] carries it and these are only the two
+## values written to it.
 const LISTING_HEIGHT: int = 7
+const SEARCH_RESULTS_HEIGHT: int = 4
 
 ## What `.PrintEntry` draws instead of a name for a species that has not been
 ## seen (`.NameNotSeen`).
@@ -58,6 +60,42 @@ const MODE_ROWS: Array[Dictionary] = [
 ## rebuilds the order.
 const CHANGING_MODES_TEXT: String = "Changing modes.\nPlease wait."
 
+## `PokedexTypeSearchConversionTable` (data/types/search_types.asm), which is
+## what turns a search row's 1-based position into a real type number. Its order
+## is the cartridge's own and is not the type numbering: FIRE follows NORMAL
+## because the search screen lists the special types first.
+##
+## Kept as named constants rather than imported, the way the matchup multipliers
+## are: all seventeen entries are types [RomLayout] already names, and the table
+## is identical in both pins.
+const SEARCH_TYPES: Array[int] = [
+	RomLayout.TYPE_NORMAL, RomLayout.TYPE_FIRE, RomLayout.TYPE_WATER,
+	RomLayout.TYPE_GRASS, RomLayout.TYPE_ELECTRIC, RomLayout.TYPE_ICE,
+	RomLayout.TYPE_FIGHTING, RomLayout.TYPE_POISON, RomLayout.TYPE_GROUND,
+	RomLayout.TYPE_FLYING, RomLayout.TYPE_PSYCHIC, RomLayout.TYPE_BUG,
+	RomLayout.TYPE_ROCK, RomLayout.TYPE_GHOST, RomLayout.TYPE_DRAGON,
+	RomLayout.TYPE_DARK, RomLayout.TYPE_STEEL,
+]
+## `NUM_TYPES`, which is [constant SEARCH_TYPES]' own length and the highest
+## value either search row takes.
+const SEARCH_TYPE_MAX: int = 17
+## `PokedexTypeSearchStrings`' first entry, which is the row's "no type chosen"
+## and the only value the second row can hold that the first cannot.
+const SEARCH_TYPE_NONE: int = 0
+const SEARCH_TYPE_NONE_NAME: String = "----"
+
+## `Pokedex_UpdateSearchScreen.ArrowCursorData`'s four rows. The two type rows
+## are the ones left and right change, which is `Pokedex_UpdateSearchMonType`'s
+## own `cp 2` check.
+const SEARCH_ROW_TYPE_1: int = 0
+const SEARCH_ROW_TYPE_2: int = 1
+const SEARCH_ROW_BEGIN: int = 2
+const SEARCH_ROW_CANCEL: int = 3
+const SEARCH_ROWS: Array[String] = ["TYPE1", "TYPE2", "BEGIN SEARCH!!", "CANCEL"]
+
+## `Pokedex_DisplayTypeNotFoundMessage`'s own text.
+const TYPE_NOT_FOUND_TEXT: String = "The specified type\nwas not found."
+
 var mode: int = RomLayout.DEXMODE_NEW
 ## `wDexListingScrollOffset` and `wDexListingCursor`. The selected row is their
 ## sum, which is what `Pokedex_GetSelectedMon` adds.
@@ -68,13 +106,30 @@ var cursor: int = 0
 var listing_end: int = 0
 ## `wPokedexStatus`, the description page the entry screen is showing.
 var page: int = PAGE_1
+## `wDexListingHeight`, how many rows the screen currently on top draws.
+var listing_height: int = LISTING_HEIGHT
 ## `wPrevDexEntry`. Plain WRAM0 rather than saved data, so it survives the dex
 ## closing and reopening within a session and is zero on boot; the caller owns it
 ## for exactly that reason, the way the world screen owns the start menu cursor.
 var prev_entry: int = 0
 
+## `wDexSearchMonType1` and `wDexSearchMonType2`, as 1-based positions in
+## [constant SEARCH_TYPES]. `Pokedex_InitSearchScreen` opens on `NORMAL + 1`,
+## which is position 1, and leaves the second row on
+## [constant SEARCH_TYPE_NONE].
+var search_type_1: int = 1
+var search_type_2: int = SEARCH_TYPE_NONE
+## `wDexArrowCursorPosIndex` while the search screen is up.
+var search_cursor: int = SEARCH_ROW_TYPE_1
+## `wDexSearchResultCount`.
+var search_result_count: int = 0
+
 var _data: GameData = null
 var _state: Gen2WorldState = null
+## `wDexListingScrollOffsetBackup`, `wDexListingCursorBackup` and
+## `wPrevDexEntryBackup`, which `.show_search_results` fills so leaving the
+## results screen puts the main listing back exactly where it was.
+var _listing_backup: Dictionary = {}
 ## `wPokedexOrder`, always [constant RomLayout.SPECIES_COUNT] long. ABC mode
 ## zero-fills its tail, and a zero is what `.PrintEntry` draws nothing for.
 var _order: PackedInt32Array = PackedInt32Array()
@@ -155,13 +210,13 @@ func init_cursor_position() -> void:
 	if prev_entry <= 0 or prev_entry > RomLayout.SPECIES_COUNT:
 		return
 	var index: int = 0
-	if listing_end >= LISTING_HEIGHT + 1:
-		for step: int in listing_end - LISTING_HEIGHT:
+	if listing_end >= listing_height + 1:
+		for step: int in listing_end - listing_height:
 			if _order[index] == prev_entry:
 				return
 			index += 1
 			scroll += 1
-	for step: int in LISTING_HEIGHT:
+	for step: int in listing_height:
 		if index < _order.size() and _order[index] == prev_entry:
 			return
 		index += 1
@@ -186,7 +241,7 @@ func selected_species() -> int:
 ## mode prints one.
 func rows() -> Array:
 	var out: Array = []
-	for index: int in LISTING_HEIGHT:
+	for index: int in listing_height:
 		var at: int = scroll + index
 		var species: int = _order[at] if at >= 0 and at < _order.size() else 0
 		var seen: bool = _has_seen(species)
@@ -223,7 +278,7 @@ func move_listing(button: int) -> bool:
 			return _move_cursor_up()
 		Gen2Button.DOWN:
 			return _move_cursor_down()
-	if LISTING_HEIGHT >= listing_end:
+	if listing_height >= listing_end:
 		return false
 	match button:
 		Gen2Button.LEFT:
@@ -252,7 +307,7 @@ func _move_cursor_down() -> bool:
 	var next: int = cursor + 1
 	if next >= listing_end:
 		return false
-	if next < LISTING_HEIGHT:
+	if next < listing_height:
 		cursor = next
 		return true
 	if next + scroll >= listing_end:
@@ -266,7 +321,7 @@ func _move_cursor_down() -> bool:
 func _move_up_one_page() -> bool:
 	if scroll == 0:
 		return false
-	scroll = scroll - LISTING_HEIGHT if scroll >= LISTING_HEIGHT else 0
+	scroll = scroll - listing_height if scroll >= listing_height else 0
 	return true
 
 
@@ -277,11 +332,11 @@ func _move_up_one_page() -> bool:
 ## exactly as one that runs past `wDexListingEnd` does. The wrap is kept because
 ## it is the comparison, not an accident of it.
 func _move_down_one_page() -> bool:
-	var reach: int = LISTING_HEIGHT * 2 + scroll
+	var reach: int = listing_height * 2 + scroll
 	if reach > 0xFF or reach >= listing_end:
-		scroll = listing_end - LISTING_HEIGHT
+		scroll = listing_end - listing_height
 	else:
-		scroll += LISTING_HEIGHT
+		scroll += listing_height
 	return true
 
 
@@ -424,6 +479,117 @@ func change_mode(next_mode: int) -> bool:
 	cursor = 0
 	init_cursor_position()
 	return true
+
+
+## `Pokedex_InitSearchScreen`, which resets both rows every time the screen is
+## opened rather than remembering the last search.
+func open_search() -> void:
+	search_type_1 = 1
+	search_type_2 = SEARCH_TYPE_NONE
+	search_cursor = SEARCH_ROW_TYPE_1
+
+
+## What `Pokedex_PlaceTypeString` prints for a search row: the imported type name
+## for a chosen type, and `PokedexTypeSearchStrings`' first entry for the second
+## row's empty value. The strings table is the type names padded to a fixed
+## width, so the name itself is what a row says.
+func search_type_name(value: int) -> String:
+	if value <= SEARCH_TYPE_NONE or value > SEARCH_TYPES.size():
+		return SEARCH_TYPE_NONE_NAME
+	return _data.type_name(SEARCH_TYPES[value - 1]) if _data != null else ""
+
+
+## `Pokedex_UpdateSearchMonType`, which reads left and right on the two type rows
+## only and answers whether the value changed.
+##
+## The two rows wrap differently, and deliberately: the first row runs 1 to
+## NUM_TYPES and can never be empty, while the second wraps through
+## [constant SEARCH_TYPE_NONE] as well, which is the only way to search on one
+## type after choosing two.
+func move_search_type(button: int) -> bool:
+	if search_cursor > SEARCH_ROW_TYPE_2:
+		return false
+	match button:
+		Gen2Button.RIGHT:
+			_step_search_type(1)
+			return true
+		Gen2Button.LEFT:
+			_step_search_type(-1)
+			return true
+	return false
+
+
+func _step_search_type(delta: int) -> void:
+	var first: bool = search_cursor == SEARCH_ROW_TYPE_1
+	var value: int = search_type_1 if first else search_type_2
+	var lowest: int = 1 if first else SEARCH_TYPE_NONE
+	if delta > 0:
+		value = lowest if value >= SEARCH_TYPE_MAX else value + 1
+	else:
+		value = SEARCH_TYPE_MAX if value <= lowest else value - 1
+	if first:
+		search_type_1 = value
+	else:
+		search_type_2 = value
+
+
+## `Pokedex_SearchForMons` plus `.MenuAction_BeginSearch`'s answer to it.
+##
+## Each chosen type filters the listing in place and the second row is applied
+## first, so choosing two types finds the species carrying both rather than
+## either. A species has to have been *caught*, not merely seen: `.Search`
+## checks `Pokedex_CheckCaught`.
+##
+## Answers the number of results. Zero leaves the listing rebuilt by mode, which
+## is what `.MenuAction_BeginSearch` does before showing its own not-found text;
+## anything else moves the listing onto the results and backs up what it
+## replaced.
+func begin_search() -> int:
+	search_result_count = 0
+	if search_type_2 != SEARCH_TYPE_NONE:
+		_filter_by_type(search_type_2)
+	if search_type_1 != SEARCH_TYPE_NONE:
+		_filter_by_type(search_type_1)
+	if search_result_count == 0:
+		order_by_mode()
+		return 0
+	_listing_backup = {"scroll": scroll, "cursor": cursor, "prev_entry": prev_entry}
+	listing_end = search_result_count
+	scroll = 0
+	cursor = 0
+	return search_result_count
+
+
+## One `.Search` pass: the order is rewritten from its own front, keeping the
+## caught species that carry [param value]'s type in either slot and zero-filling
+## what is left behind.
+func _filter_by_type(value: int) -> void:
+	var wanted: int = SEARCH_TYPES[value - 1]
+	var kept: int = 0
+	for index: int in _order.size():
+		var species: int = _order[index]
+		if species == 0 or not _has_caught(species):
+			continue
+		var types: Array = _data.species(species).get("types", []) if _data != null else []
+		if types.size() < 2 or (int(types[0]) != wanted and int(types[1]) != wanted):
+			continue
+		_order[kept] = species
+		kept += 1
+	for index: int in range(kept, _order.size()):
+		_order[index] = 0
+	search_result_count = kept
+
+
+## `.return_to_search_screen`: the three backups go back and the listing is then
+## rebuilt by mode, so the search screen is reached with the main listing exactly
+## as it was. `wDexListingHeight` is not put back here, because the source never
+## does: each screen's own Init writes it.
+func leave_search_results() -> void:
+	scroll = int(_listing_backup.get("scroll", 0))
+	cursor = int(_listing_backup.get("cursor", 0))
+	prev_entry = int(_listing_backup.get("prev_entry", 0))
+	_listing_backup = {}
+	order_by_mode()
 
 
 func _has_seen(species: int) -> bool:

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -10,14 +10,15 @@ extends Control
 ## tile-accurate listing with. Every rule the screen obeys is [Gen2Pokedex]'s,
 ## which is the source's own.
 ##
-## Three of the source's six states are here: the listing, the entry screen and
-## the OPTION screen. SEARCH, its results and the Unown dex are not, so START on
-## the listing does nothing rather than opening a screen that is not built.
+## Five of the source's six states are here: the listing, the entry screen, the
+## OPTION screen, SEARCH and its results. The Unown dex is not, so the OPTION
+## screen draws `.NoUnownModeArrowCursorData`'s three rows, which is what the
+## cartridge draws while `wUnlockedUnownMode` is clear.
 
 ## Emitted on B from the listing, which is where `DEXSTATE_EXIT` lands.
 signal closed
 
-enum Mode { LIST, ENTRY, OPTION }
+enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS }
 
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#4f6f9e")
@@ -93,12 +94,14 @@ func handle_button(button: int) -> bool:
 			return _handle_entry(button)
 		Mode.OPTION:
 			return _handle_option(button)
+		Mode.SEARCH:
+			return _handle_search(button)
+		Mode.SEARCH_RESULTS:
+			return _handle_search_results(button)
 	return false
 
 
-## `Pokedex_UpdateMainScreen`. START would open SEARCH, which is not built, so
-## it is answered as handled and does nothing rather than reaching a screen that
-## is not there.
+## `Pokedex_UpdateMainScreen`.
 func _handle_list(button: int) -> bool:
 	match button:
 		Gen2Button.B:
@@ -113,6 +116,7 @@ func _handle_list(button: int) -> bool:
 			_open_option_mode()
 			return true
 		Gen2Button.START:
+			_open_search_mode()
 			return true
 	if _dex.move_listing(button):
 		_render_list()
@@ -180,8 +184,11 @@ func _exit() -> void:
 	closed.emit()
 
 
+## `Pokedex_InitMainScreen`, whose own `ld a, 7` is what puts the listing height
+## back after the search results screen has set it to four.
 func _open_list_mode() -> void:
 	_mode = Mode.LIST
+	_dex.listing_height = Gen2Pokedex.LISTING_HEIGHT
 	_title.text = "#DEX"
 	_footer.text = "D-pad: move    A: entry    SELECT: option    B: close"
 	_status.text = ""
@@ -209,6 +216,120 @@ func _open_option_mode() -> void:
 		if int(_mode_rows[index]["mode"]) == _dex.mode:
 			_option_cursor = index
 	_render_option()
+
+
+## `Pokedex_UpdateSearchScreen`: up and down move the four rows, left and right
+## change a type on the two rows that carry one, A takes the row, and START or B
+## both cancel back to the listing.
+func _handle_search(button: int) -> bool:
+	match button:
+		Gen2Button.B, Gen2Button.START:
+			_open_list_mode()
+			return true
+		Gen2Button.A:
+			_confirm_search_row()
+			return true
+		Gen2Button.UP, Gen2Button.DOWN:
+			var next: int = _dex.search_cursor + (1 if button == Gen2Button.DOWN else -1)
+			_dex.search_cursor = clampi(next, 0, Gen2Pokedex.SEARCH_ROWS.size() - 1)
+			_render_search()
+			return true
+		Gen2Button.LEFT, Gen2Button.RIGHT:
+			if _dex.move_search_type(button):
+				_render_search()
+			return true
+	return false
+
+
+## `.MenuActionJumptable`: A on either type row steps it the way right does, A on
+## BEGIN SEARCH runs the search, and A on CANCEL leaves.
+func _confirm_search_row() -> void:
+	match _dex.search_cursor:
+		Gen2Pokedex.SEARCH_ROW_TYPE_1, Gen2Pokedex.SEARCH_ROW_TYPE_2:
+			_dex.move_search_type(Gen2Button.RIGHT)
+			_render_search()
+		Gen2Pokedex.SEARCH_ROW_BEGIN:
+			if _dex.begin_search() > 0:
+				_open_search_results_mode()
+				return
+			## `.MenuAction_BeginSearch`'s no-result branch redraws the search
+			## screen under its own message rather than leaving it.
+			_render_search()
+			_status.text = Gen2Pokedex.TYPE_NOT_FOUND_TEXT
+			_status.add_theme_color_override("font_color", MUTED)
+		Gen2Pokedex.SEARCH_ROW_CANCEL:
+			_open_list_mode()
+
+
+## `Pokedex_UpdateSearchResultsScreen`: the same listing walk as the main screen
+## over four rows instead of seven, A opens an entry and B goes back to SEARCH.
+func _handle_search_results(button: int) -> bool:
+	match button:
+		Gen2Button.B:
+			_dex.leave_search_results()
+			_open_search_mode()
+			return true
+		Gen2Button.A:
+			if _dex.can_open_entry():
+				_dex.open_entry()
+				_open_entry_mode()
+			return true
+	if _dex.move_listing(button):
+		_render_search_results()
+	return Gen2Button.is_direction(button)
+
+
+## `Pokedex_InitSearchScreen`, which resets both type rows every time.
+##
+## Coming back from the results screen resets them too: `.return_to_search_screen`
+## jumps to DEXSTATE_SEARCH_SCR, and that jumptable entry is this Init rather
+## than its Update, so the search is not remembered.
+func _open_search_mode() -> void:
+	_mode = Mode.SEARCH
+	_dex.open_search()
+	_title.text = "SEARCH"
+	_status.text = ""
+	_footer.text = "D-pad: move    Left/Right: type    A: choose    B: back"
+	_render_search()
+
+
+## `Pokedex_InitSearchResultsScreen`, whose own `ld a, 4` is the shorter listing.
+func _open_search_results_mode() -> void:
+	_mode = Mode.SEARCH_RESULTS
+	_dex.listing_height = Gen2Pokedex.SEARCH_RESULTS_HEIGHT
+	_title.text = "SEARCH RESULTS"
+	_status.text = ""
+	_footer.text = "D-pad: move    A: entry    B: back"
+	_render_search_results()
+
+
+func _render_search() -> void:
+	_summary.text = ""
+	_render_rows(Gen2Pokedex.SEARCH_ROWS, func(row: String) -> String:
+		match row:
+			Gen2Pokedex.SEARCH_ROWS[Gen2Pokedex.SEARCH_ROW_TYPE_1]:
+				return "%s  %s" % [row, _dex.search_type_name(_dex.search_type_1)]
+			Gen2Pokedex.SEARCH_ROWS[Gen2Pokedex.SEARCH_ROW_TYPE_2]:
+				return "%s  %s" % [row, _dex.search_type_name(_dex.search_type_2)]
+		return row
+	, _dex.search_cursor)
+
+
+## `.BottomWindowText` and `Pokedex_PlaceSearchResultsTypeStrings`: the count and
+## the types it was found for sit under the listing.
+func _render_search_results() -> void:
+	var types: String = _dex.search_type_name(_dex.search_type_1)
+	if _dex.search_type_2 != Gen2Pokedex.SEARCH_TYPE_NONE:
+		types += "/%s" % _dex.search_type_name(_dex.search_type_2)
+	_summary.text = "%s    %3d FOUND!" % [types, _dex.search_result_count]
+	_render_rows(_dex.rows(), func(row: Dictionary) -> String:
+		if bool(row["empty"]):
+			return ""
+		var symbol: String = CAUGHT_SYMBOL if bool(row["caught"]) else UNCAUGHT_SYMBOL
+		var number: String = String(row["number"])
+		var prefix: String = "%s " % number if not number.is_empty() else ""
+		return "%s%s%s" % [prefix, symbol, String(row["name"])]
+	)
 
 
 ## The listing, plus the SEEN and OWN totals `Pokedex_DrawMainScreenBG` prints
@@ -249,12 +370,16 @@ func _render_option() -> void:
 	_summary.text = String(_mode_rows[_option_cursor]["description"])
 
 
-func _render_rows(values: Array, label_for: Callable) -> void:
+## [param row_cursor] is the highlighted row; the listing screens pass the
+## dex's own cursor and the two form screens pass theirs.
+func _render_rows(values: Array, label_for: Callable, row_cursor: int = -1) -> void:
 	if _options == null:
 		return
 	for child: Node in _options.get_children():
 		child.queue_free()
-	var cursor: int = _dex.cursor if _mode == Mode.LIST else _option_cursor
+	var cursor: int = row_cursor
+	if cursor < 0:
+		cursor = _option_cursor if _mode == Mode.OPTION else _dex.cursor
 	for index: int in values.size():
 		var label := Label.new()
 		var text: String = label_for.call(values[index])

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -752,3 +752,51 @@ func test_the_chosen_dex_mode_survives_closing_the_dex() -> void:
 	_world_screen._open_pokedex()
 	var reopened: Gen2PokedexScreen = _world_screen._pokedex_host
 	assert_eq(reopened.get("_dex").mode, RomLayout.DEXMODE_OLD)
+
+
+## `Pokedex_UpdateMainScreen`'s START reaches the search screen, and its CANCEL
+## row comes back to the listing.
+func test_the_dex_search_screen_opens_from_the_listing_and_cancels_back() -> void:
+	await _open_world()
+	var state: Gen2WorldState = _world_screen._world.state
+	state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX)
+	_world_screen._open_pokedex()
+	var dex: Gen2PokedexScreen = _world_screen._pokedex_host
+	assert_not_null(dex)
+
+	dex.handle_button(Gen2Button.START)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH)
+
+	## Down twice reaches BEGIN SEARCH and once more CANCEL, which leaves.
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.LIST)
+	assert_eq(dex.get("_dex").listing_height, Gen2Pokedex.LISTING_HEIGHT)
+
+
+## A search with a caught species behind it reaches the results screen, and B
+## returns through the search screen with the main listing put back.
+func test_a_dex_search_reaches_its_results_and_back() -> void:
+	await _open_world()
+	var state: Gen2WorldState = _world_screen._world.state
+	state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX)
+	state.set_species_caught(Fixture.TRAINER_SPECIES)
+	_world_screen._open_pokedex()
+	var dex: Gen2PokedexScreen = _world_screen._pokedex_host
+	var model: Gen2Pokedex = dex.get("_dex")
+
+	dex.handle_button(Gen2Button.START)
+	## The fixture's species are all NORMAL, which is the row the screen opens on.
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH_RESULTS)
+	assert_eq(model.search_result_count, 1)
+	assert_eq(model.listing_height, Gen2Pokedex.SEARCH_RESULTS_HEIGHT)
+	assert_eq(model.selected_species(), Fixture.TRAINER_SPECIES)
+
+	dex.handle_button(Gen2Button.B)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH)
+	assert_eq(model.search_type_1, 1, "the search screen re-initialises its rows")

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -5,8 +5,8 @@ extends RefCounted
 ##
 ## The dex is the one screen that needs all 251 species: the order tables are
 ## that long and [method Gen2Pokedex.order_by_mode] fills the whole listing, so
-## the battle fixture's short table cannot stand in. Names and entry text are
-## generated rather than published values, since nothing here checks content
+## the battle fixture's short table cannot stand in. Names, types and entry text
+## are generated rather than published values, since nothing here checks content
 ## against a cartridge; [method RomImporter.verify_pokedex] does that.
 
 const GAME_ID: StringName = &"pokedexfixture"
@@ -33,6 +33,17 @@ static func alpha_order() -> Array:
 
 static func species_name(number: int) -> String:
 	return "MON%03d" % number
+
+
+## Species cycle through the search order's own types, so a search for the type
+## at a given search position has a known set of species behind it: species N
+## carries SEARCH_TYPES[(N - 1) % 17] in both slots, except the multiples of ten,
+## which carry FIRE in the second slot so a two-type search has something to
+## find.
+static func types_for(number: int) -> Array:
+	var first: int = Gen2Pokedex.SEARCH_TYPES[(number - 1) % Gen2Pokedex.SEARCH_TYPES.size()]
+	var second: int = RomLayout.TYPE_FIRE if number % 10 == 0 else first
+	return [first, second]
 
 
 static func directory() -> String:
@@ -64,6 +75,7 @@ static func _species() -> Array:
 		out.append({
 			"number": number,
 			"name": species_name(number),
+			"types": types_for(number),
 			"dex": {
 				"category": "CAT%03d" % number,
 				"height": number,

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -296,3 +296,133 @@ func test_the_screen_counts_seen_and_owned() -> void:
 	var dex: Gen2Pokedex = _dex([1, 2, 3], [1])
 	assert_eq(dex.seen_count(), 3)
 	assert_eq(dex.caught_count(), 1)
+
+
+## `Pokedex_InitSearchScreen` opens on NORMAL with the second row empty, and
+## does so every time rather than remembering the last search.
+func test_the_search_screen_opens_on_normal_with_no_second_type() -> void:
+	var dex: Gen2Pokedex = _dex([1])
+	dex.search_type_1 = 9
+	dex.search_type_2 = 4
+	dex.open_search()
+	assert_eq(dex.search_type_1, 1)
+	assert_eq(dex.search_type_2, Gen2Pokedex.SEARCH_TYPE_NONE)
+	assert_eq(dex.search_cursor, Gen2Pokedex.SEARCH_ROW_TYPE_1)
+
+
+## `PokedexTypeSearchConversionTable`'s order is the search screen's, not the
+## type numbering: FIRE follows NORMAL.
+func test_the_search_order_is_the_conversion_tables_own() -> void:
+	assert_eq(Gen2Pokedex.SEARCH_TYPES.size(), Gen2Pokedex.SEARCH_TYPE_MAX)
+	assert_eq(Gen2Pokedex.SEARCH_TYPES[0], RomLayout.TYPE_NORMAL)
+	assert_eq(Gen2Pokedex.SEARCH_TYPES[1], RomLayout.TYPE_FIRE)
+	assert_eq(Gen2Pokedex.SEARCH_TYPES[Gen2Pokedex.SEARCH_TYPE_MAX - 1], RomLayout.TYPE_STEEL)
+
+
+## `Pokedex_UpdateSearchMonType` reads left and right on the two type rows only.
+func test_the_type_rows_are_the_only_ones_left_and_right_change() -> void:
+	var dex: Gen2Pokedex = _dex([1])
+	dex.search_cursor = Gen2Pokedex.SEARCH_ROW_BEGIN
+	assert_false(dex.move_search_type(Gen2Button.RIGHT))
+	dex.search_cursor = Gen2Pokedex.SEARCH_ROW_TYPE_1
+	assert_true(dex.move_search_type(Gen2Button.RIGHT))
+	assert_eq(dex.search_type_1, 2)
+
+
+## The two rows wrap differently: the first never empties, and the second wraps
+## through the empty value, which is the only way back to a one-type search.
+func test_the_first_row_never_empties_and_the_second_wraps_through_empty() -> void:
+	var dex: Gen2Pokedex = _dex([1])
+	dex.search_cursor = Gen2Pokedex.SEARCH_ROW_TYPE_1
+	dex.move_search_type(Gen2Button.LEFT)
+	assert_eq(dex.search_type_1, Gen2Pokedex.SEARCH_TYPE_MAX, "1 wraps to the last type")
+	dex.move_search_type(Gen2Button.RIGHT)
+	assert_eq(dex.search_type_1, 1, "and back round to the first, never to none")
+
+	dex.search_cursor = Gen2Pokedex.SEARCH_ROW_TYPE_2
+	assert_eq(dex.search_type_2, Gen2Pokedex.SEARCH_TYPE_NONE)
+	dex.move_search_type(Gen2Button.LEFT)
+	assert_eq(dex.search_type_2, Gen2Pokedex.SEARCH_TYPE_MAX)
+	dex.move_search_type(Gen2Button.RIGHT)
+	assert_eq(dex.search_type_2, Gen2Pokedex.SEARCH_TYPE_NONE, "the second row can empty again")
+
+
+## A row prints the imported type name, and the empty value prints
+## PokedexTypeSearchStrings' own first entry.
+func test_a_search_row_names_its_type() -> void:
+	var dex: Gen2Pokedex = _dex([1])
+	assert_eq(dex.search_type_name(Gen2Pokedex.SEARCH_TYPE_NONE), Gen2Pokedex.SEARCH_TYPE_NONE_NAME)
+	assert_eq(dex.search_type_name(1), _data.type_name(RomLayout.TYPE_NORMAL))
+
+
+## `.Search` checks Pokedex_CheckCaught, so a species that has only been seen is
+## not a result.
+func test_a_search_finds_caught_species_only() -> void:
+	# Species 1 and 18 are both the fixture's first search type; only 1 is caught.
+	var dex: Gen2Pokedex = _dex([1, 18], [1], RomLayout.DEXMODE_OLD)
+	dex.search_type_1 = 1
+	assert_eq(dex.begin_search(), 1)
+	assert_eq(dex.rows()[0]["species"], 1)
+
+
+## Two chosen types filter one after the other, so the result carries both.
+func test_two_types_narrow_the_search_rather_than_widening_it() -> void:
+	var caught: Array = []
+	for number: int in range(1, 41):
+		caught.append(number)
+	var dex: Gen2Pokedex = _dex(caught, caught, RomLayout.DEXMODE_OLD)
+	# Species 20 is the fixture's third search type with FIRE second; species 3
+	# is that same first type without it.
+	dex.search_type_1 = 3
+	var one_type: int = dex.begin_search()
+	dex.leave_search_results()
+
+	dex.search_type_1 = 3
+	dex.search_type_2 = 2
+	var two_types: int = dex.begin_search()
+	assert_lt(two_types, one_type, "the second type narrows the result")
+	assert_eq(dex.rows()[0]["species"], 20)
+
+
+## A search that finds nothing rebuilds the listing by mode rather than leaving
+## it filtered, which is what `.MenuAction_BeginSearch` does before its message.
+func test_a_search_with_no_results_leaves_the_listing_whole() -> void:
+	var dex: Gen2Pokedex = _dex([1], [], RomLayout.DEXMODE_OLD)
+	dex.search_type_1 = 1
+	assert_eq(dex.begin_search(), 0)
+	assert_eq(dex.rows()[0]["species"], 1, "the listing is the mode's own again")
+	assert_eq(dex.listing_end, 1)
+
+
+## `.show_search_results` backs the listing up and `.return_to_search_screen`
+## puts it back.
+func test_leaving_the_results_restores_the_listing_exactly() -> void:
+	var caught: Array = []
+	for number: int in range(1, 41):
+		caught.append(number)
+	var dex: Gen2Pokedex = _dex(caught, caught, RomLayout.DEXMODE_OLD)
+	dex.scroll = 12
+	dex.cursor = 3
+	dex.prev_entry = 15
+	dex.search_type_1 = 1
+	assert_gt(dex.begin_search(), 0)
+	assert_eq(dex.scroll, 0, "the results open at the top")
+	assert_eq(dex.cursor, 0)
+
+	dex.leave_search_results()
+	assert_eq(dex.scroll, 12)
+	assert_eq(dex.cursor, 3)
+	assert_eq(dex.prev_entry, 15)
+	assert_eq(dex.listing_end, 40, "and the listing is the mode's own again")
+
+
+## The results screen draws four rows rather than seven (`ld a, 4`).
+func test_the_results_listing_is_four_rows() -> void:
+	var caught: Array = []
+	for number: int in range(1, 41):
+		caught.append(number)
+	var dex: Gen2Pokedex = _dex(caught, caught, RomLayout.DEXMODE_OLD)
+	dex.search_type_1 = 1
+	dex.begin_search()
+	dex.listing_height = Gen2Pokedex.SEARCH_RESULTS_HEIGHT
+	assert_eq(dex.rows().size(), 4)

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -376,3 +376,15 @@ func test_pokedex_tables_land_inside_a_cartridge() -> void:
 				bank * RomFile.BANK_SIZE, 0, RomRegistry.EXPECTED_SIZE - 1,
 				"%s bank %d" % [id, bank]
 			)
+
+
+## constants/cry_constants.asm runs CRY_NIDORAN_M through CRY_DONPHAN
+## inclusive, so NUM_CRIES is 68. A count of 67 dropped CRY_DONPHAN, which is
+## the cry species 232 asks for and the last entry before the SFX table.
+func test_the_cry_table_carries_every_cry_constant() -> void:
+	assert_eq(RomLayout.AUDIO_CRY_COUNT, 68)
+	for id: StringName in RomRegistry.ORDER:
+		var layout: Dictionary = RomLayout.for_id(id)
+		var last: int = int(layout["cry_pointers"]) \
+			+ (RomLayout.AUDIO_CRY_COUNT - 1) * RomLayout.AUDIO_POINTER_SIZE
+		assert_lt(last + RomLayout.AUDIO_POINTER_SIZE, RomRegistry.EXPECTED_SIZE, "%s" % id)


### PR DESCRIPTION
Build the search screen and its results, the two states START reaches on the cartridge and reached nothing here.

The two type rows wrap differently on purpose: the first runs 1 to NUM_TYPES and can never empty, while the second wraps through the empty value, which is the only way back to a one-type search. Each chosen type filters the listing in place and the second is applied first, so two types narrow rather than widen and the results keep the current mode's order. A result has to have been caught, not merely seen.

wDexListingHeight becomes a variable, because it is WRAM each screen's own Init writes: seven rows on the main screen and four on the results. Coming back from the results re-initialises both rows, since .return_to_search_screen jumps to the Init rather than the Update.

Fix the cry count while here: NUM_CRIES is 68, not 67, so CRY_DONPHAN was dropped from every cache and species 232 had no cry at all.