### PR TITLE
Let a charging move say what it is doing

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -51,6 +51,26 @@ const INFLICTED: Dictionary = {
 	&"paralysis": "is paralyzed!",
 }
 
+## What a two-turn move says on its charge turn, from
+## `BattleCommand_Charge.UsedText` (data/text/common_2.asm), which picks its line
+## by move number rather than by effect: Fly and Dig share an effect byte and do
+## not share a sentence.
+##
+## The source's own `line` is a line break in a fixed-width box rather than part
+## of the sentence, so these read as one flowing string the way every other
+## message here does.
+const CHARGE_TEXT: Dictionary = {
+	Gen2MoveEffect.RAZOR_WIND_MOVE: "made a whirlwind!",
+	Gen2MoveEffect.SOLARBEAM_MOVE: "took in sunlight!",
+	Gen2MoveEffect.SKULL_BASH_MOVE: "lowered its head!",
+	Gen2MoveEffect.SKY_ATTACK_MOVE: "is glowing!",
+	Gen2MoveEffect.FLY_MOVE: "flew up high!",
+	Gen2MoveEffect.DIG_MOVE: "dug a hole!",
+}
+## `.UsedText`'s own fallthrough: the Dig branch is the only one of the six with
+## no `jr z` behind it, so a move that is none of the other five prints its line.
+const CHARGE_DUG: String = "dug a hole!"
+
 ## The word the games print for a stat, keyed the way [Gen2BattleMon] keeps the
 ## stat itself. A key the engine grows later shows up here as its own snake_case
 ## name in capitals rather than as a wrong word, the same fallback
@@ -1245,9 +1265,9 @@ func _describe(event: Dictionary) -> String:
 		Gen2Battle.HURT_ITSELF:
 			return "It hurt itself in its confusion!"
 		Gen2Battle.CHARGING_UP:
-			# The real games print a line of the move's own, which nothing here has
-			# a source for yet; this is the one sentence every two-turn move shares.
-			return "%s is charging up its power!" % _battler_name(side)
+			return "%s %s" % [
+				_battler_name(side), CHARGE_TEXT.get(int(event.get("move", 0)), CHARGE_DUG),
+			]
 		Gen2Battle.STAGES_CLEARED:
 			return "All stat changes were eliminated!"
 		Gen2Battle.STAGES_COPIED:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -1135,7 +1135,9 @@ static func _charge_move(turn: Gen2Turn) -> void:
 			mon.substatus |= Gen2Substatus.FLYING
 		elif turn.move_number == Gen2MoveEffect.DIG_MOVE:
 			mon.substatus |= Gen2Substatus.UNDERGROUND
-	turn.emit(Gen2Battle.CHARGING_UP)
+	## `.UsedText` picks its line by move number rather than by effect, so the
+	## move travels with the event and the screen owns the wording.
+	turn.emit(Gen2Battle.CHARGING_UP, {"move": turn.move_number})
 	turn.end()
 
 

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -104,6 +104,13 @@ const MIRROR_COAT: int = 0x90
 ## one effect byte, while the charge command still has to tell them apart.
 const FLY_MOVE: int = 19
 const DIG_MOVE: int = 91
+## The other four moves `BattleCommand_Charge.UsedText` names by number, kept
+## beside Fly and Dig for the same reason: the charge text is chosen by move
+## rather than by effect, and Fly and Dig already share an effect byte.
+const RAZOR_WIND_MOVE: int = 13
+const SKY_ATTACK_MOVE: int = 143
+const SKULL_BASH_MOVE: int = 130
+const SOLARBEAM_MOVE: int = 76
 const GUST_MOVE: int = 16
 const WHIRLWIND_MOVE: int = 18
 const THUNDER_MOVE: int = 87

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -527,7 +527,10 @@ func test_charge_move_locks_the_user_in_and_says_so() -> void:
 	assert_true(Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING))
 	assert_eq(mon.charged_move, Fixture.SOLARBEAM)
 	assert_true(turn.ended)
-	assert_eq(_first(turn.events, Gen2Battle.CHARGING_UP)["side"], Gen2Battle.PLAYER)
+	var event: Dictionary = _first(turn.events, Gen2Battle.CHARGING_UP)
+	assert_eq(event["side"], Gen2Battle.PLAYER)
+	## `.UsedText` picks its line by move number, so the move travels with it.
+	assert_eq(int(event["move"]), Fixture.SOLARBEAM)
 
 
 func test_charge_move_releases_on_the_second_call_and_lets_the_rest_run() -> void:
@@ -1833,3 +1836,25 @@ func test_the_heal_family_has_its_cartridge_sequences() -> void:
 		# Announce, spend, heal, end: no accuracy roll, and no obedience check,
 		# which this engine does not model on any list.
 		assert_eq(Gen2MoveEffect.sequence_for(effect).size(), 4, str(effect))
+
+
+## `BattleCommand_Charge.UsedText` names six moves by number, and Fly and Dig do
+## not share a sentence although they share an effect byte.
+func test_each_two_turn_move_has_its_own_charge_line() -> void:
+	var text: Dictionary = Gen2BattleScreen.CHARGE_TEXT
+	assert_eq(text[Gen2MoveEffect.RAZOR_WIND_MOVE], "made a whirlwind!")
+	assert_eq(text[Gen2MoveEffect.SOLARBEAM_MOVE], "took in sunlight!")
+	assert_eq(text[Gen2MoveEffect.SKULL_BASH_MOVE], "lowered its head!")
+	assert_eq(text[Gen2MoveEffect.SKY_ATTACK_MOVE], "is glowing!")
+	assert_eq(text[Gen2MoveEffect.FLY_MOVE], "flew up high!")
+	assert_eq(text[Gen2MoveEffect.DIG_MOVE], "dug a hole!")
+	assert_ne(
+		text[Gen2MoveEffect.FLY_MOVE], text[Gen2MoveEffect.DIG_MOVE],
+		"one effect byte, two sentences"
+	)
+
+
+## `.UsedText`'s Dig branch is the only one of the six with no `jr z` behind it,
+## so it is what a move reaching that dispatch without matching prints.
+func test_the_charge_line_falls_through_to_dig() -> void:
+	assert_eq(Gen2BattleScreen.CHARGE_DUG, Gen2BattleScreen.CHARGE_TEXT[Gen2MoveEffect.DIG_MOVE])


### PR DESCRIPTION
BattleCommand_Charge.UsedText picks its line by move number rather than by effect, so the move travels on the charging_up event and the screen holds the six lines. Fly and Dig share an effect byte and do not share a sentence, which is why the effect could never have answered this.

Dig's line is the fallthrough: its branch is the only one of the six with no jr z behind it, so a move reaching that dispatch without matching prints it.

Drops the generic sentence every two-turn move shared, and with it one of the known intentional divergences.