### PR TITLE
Let the HP bar fall instead of dropping

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -307,6 +307,12 @@ a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
 event, never the battle engine itself, the same rule `Gen2BattleScreen`'s own
 setters already followed.
 
+The two HP values are the *drawn* ones, not the committed ones: a hit drains the
+bar over roughly a second the way the cartridge does, and `set_view` is called
+again on every step of that drain. A renderer that wants the bar to move needs
+no work; one that wants the final number should wait for the drain to end rather
+than reading the view, since mid-drain it is deliberately not the real HP.
+
 Registration uses the same refusal rules as a world renderer, and shares both
 optional methods (`uses_hardware_viewport()`, `set_native_size()`) and the `V`
 cycle, bound in `Gen2BattleScreen` the way `Gen2WorldScreen` binds it.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -137,6 +137,14 @@ var _world_battle_terminal_text_shown: bool = false
 var _world_battle_recovery_shown: bool = false
 var _world_battle_recovery: Dictionary = {}
 var _last_message: String = ""
+## A running [Gen2HpBarAnimation] per side. A side with no entry is not moving.
+var _bars: Dictionary = {}
+## The text the event pump produced while a bar was still draining. The source
+## prints it after the bar arrives, since `applydamage` runs before
+## `criticaltext` and `supereffectivetext`.
+var _held_message: String = ""
+## Leftover of a hardware frame the bars have not counted yet.
+var _bar_elapsed: float = 0.0
 ## What the overworld clock said when the battle started, for the three heals
 ## that read it. Only the world path supplies one; the development drivers below
 ## leave [Gen2Battle] at its own midday default.
@@ -178,6 +186,19 @@ var _exp: float = 0.0
 var _box: Gen2TextBox = null
 
 @onready var _screen: Gen2Screen = %Screen
+
+
+## Bars drain on hardware frames, not on rendered ones, the same reason
+## [Gen2WorldAnimation] paces the overworld that way: the two-frame step
+## `HPBarAnim_BGMapUpdate` waits is a hardware frame count.
+func _process(delta: float) -> void:
+	if _bars.is_empty():
+		_bar_elapsed = 0.0
+		return
+	_bar_elapsed += delta
+	while _bar_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and not _bars.is_empty():
+		_bar_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_bars()
 
 
 func _ready() -> void:
@@ -490,12 +511,74 @@ func _party_from(species: int, level: int) -> Gen2Party:
 
 
 ## Both HP totals, for a caller that has its own numbers.
+## The committed HP, which is what [method battle_snapshot] and every caller
+## that places state reads. It does not animate on its own: `AnimateHPBar` is
+## called by `DoEnemyDamage` and its siblings, not by every write to
+## `wBattleMonHP`, so the bar is started by the events that mean damage or
+## healing and this snaps.
 func set_hp(enemy: int, enemy_max: int, player: int, player_max: int) -> void:
+	if enemy != _enemy_hp or enemy_max != _enemy_max_hp:
+		_bars.erase(Gen2Battle.ENEMY)
+	if player != _player_hp or player_max != _player_max_hp:
+		_bars.erase(Gen2Battle.PLAYER)
 	_enemy_hp = enemy
 	_enemy_max_hp = enemy_max
 	_player_hp = player
 	_player_max_hp = player_max
 	_push_view()
+
+
+## Begins a bar animation from [param from_hp] to the HP now committed for
+## [param side], which is what an event meaning damage or healing does after it
+## has written the new value.
+##
+## A maximum that moved under the bar is not the same bar draining: a Pokemon
+## coming out gets its bar drawn at once, the way `LoadHPBar` puts one up.
+func _start_bar(side: int, from_hp: int, from_max: int) -> void:
+	var to_hp: int = _enemy_hp if side == Gen2Battle.ENEMY else _player_hp
+	var max_hp: int = _enemy_max_hp if side == Gen2Battle.ENEMY else _player_max_hp
+	if max_hp != from_max or from_hp == to_hp:
+		return
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(from_hp, to_hp, max_hp)
+	if animation.finished():
+		return
+	_bars[side] = animation
+	_push_view()
+
+
+## What the bar for [param side] is drawing: the animation's value while one is
+## running, and the committed HP otherwise.
+func _drawn_hp(side: int) -> int:
+	var animation: Gen2HpBarAnimation = _bars.get(side, null)
+	if animation == null:
+		return _enemy_hp if side == Gen2Battle.ENEMY else _player_hp
+	return animation.hp()
+
+
+## Whether any bar is still moving, which is what holds the next message back.
+func bars_animating() -> bool:
+	return not _bars.is_empty()
+
+
+## One hardware frame of every running bar. Public so a test or a screenshot
+## driver can settle the bars without waiting on real time.
+func advance_bars() -> bool:
+	if _bars.is_empty():
+		return false
+	var moved: bool = false
+	for side: int in _bars.keys():
+		var animation: Gen2HpBarAnimation = _bars[side]
+		if animation.advance_frame():
+			moved = true
+		if animation.finished():
+			_bars.erase(side)
+	if moved:
+		_push_view()
+	if _bars.is_empty() and not _held_message.is_empty():
+		var text: String = _held_message
+		_held_message = ""
+		show_message(text)
+	return moved
 
 
 ## How full the exp bar is, from nothing to a level's worth.
@@ -966,6 +1049,11 @@ func _confirm_forget_slot() -> void:
 func advance() -> void:
 	if _box == null:
 		return
+	## A bar the source is still animating has not printed its message yet, so
+	## there is nothing for a press to advance past. Without this the press
+	## would pop the next event and the held line would never be shown.
+	if bars_animating():
+		return
 	if _box.advance():
 		return
 	if _capture_selecting or _capture_waiting:
@@ -1160,11 +1248,40 @@ func _show_next_event() -> void:
 		_apply_event(event)
 		var text: String = _describe(event)
 		if not text.is_empty():
-			show_message(text)
+			## `applydamage` animates the bar and only then does `criticaltext`
+			## print, so a message caused by an event that moved a bar waits for
+			## it rather than racing it.
+			if bars_animating():
+				_held_message = text
+			else:
+				show_message(text)
 			return
 
 
+## The events that mean a bar moved rather than a bar was placed: each is a
+## point where the source reaches `AnimateHPBar` through `DoEnemyDamage`,
+## `DoPlayerDamage` or one of the heal commands. `SENT_OUT` is deliberately not
+## among them, because that bar is drawn rather than drained.
+const HP_BAR_EVENTS: Array[StringName] = [
+	Gen2Battle.HIT, Gen2Battle.RECOIL, Gen2Battle.DRAINED, Gen2Battle.OHKO,
+	Gen2Battle.HURT_BY_STATUS, Gen2Battle.HURT_ITSELF, Gen2Battle.HP_RESTORED,
+	Gen2Battle.TRAINER_USED_ITEM,
+]
+
+
 func _apply_event(event: Dictionary) -> void:
+	var before_enemy: int = _enemy_hp
+	var before_enemy_max: int = _enemy_max_hp
+	var before_player: int = _player_hp
+	var before_player_max: int = _player_max_hp
+	_apply_event_state(event)
+	if not HP_BAR_EVENTS.has(StringName(event["type"])):
+		return
+	_start_bar(Gen2Battle.ENEMY, before_enemy, before_enemy_max)
+	_start_bar(Gen2Battle.PLAYER, before_player, before_player_max)
+
+
+func _apply_event_state(event: Dictionary) -> void:
 	match event["type"]:
 		Gen2Battle.HIT, Gen2Battle.RECOIL, Gen2Battle.DRAINED, Gen2Battle.OHKO:
 			var target: int = int(event.get("target", event["side"]))
@@ -1621,8 +1738,11 @@ func _push_view() -> void:
 		"enemy_species": _enemy, "player_species": _player,
 		"enemy_name": _name_of(_enemy), "player_name": _name_of(_player),
 		"enemy_level": _enemy_level, "player_level": _player_level,
-		"enemy_hp": _enemy_hp, "enemy_max_hp": _enemy_max_hp,
-		"player_hp": _player_hp, "player_max_hp": _player_max_hp,
+		## The bars draw whatever the animation is on rather than the committed
+		## HP, which is what makes them drain. Everything else, including
+		## [method battle_snapshot], keeps reading the committed value.
+		"enemy_hp": _drawn_hp(Gen2Battle.ENEMY), "enemy_max_hp": _enemy_max_hp,
+		"player_hp": _drawn_hp(Gen2Battle.PLAYER), "player_max_hp": _player_max_hp,
 		"exp_fraction": _exp,
 	})
 

--- a/game/battle/hp_bar_animation.gd
+++ b/game/battle/hp_bar_animation.gd
@@ -1,0 +1,85 @@
+class_name Gen2HpBarAnimation
+extends RefCounted
+
+## The HP bar draining or filling, one pixel at a time
+## (engine/battle/anim_hp_bar.asm).
+##
+## Scene-free like the rest of the battle layer: the screen ticks this once per
+## hardware frame and draws [method pixels], and the bar arrives before the
+## message that describes the hit is printed. That ordering is the source's, not
+## a choice: `NormalHit` runs `applydamage` before `criticaltext` and
+## `supereffectivetext`, and `DoEnemyDamage` ends with `predef AnimateHPBar`.
+##
+## `_AnimateHPBar` has two branches, keyed on whether the maximum is at least
+## `HP_BAR_LENGTH_PX`: over it the loop steps real HP and redraws only when the
+## pixel moves, under it the loop steps the pixel itself. Both redraw exactly one
+## pixel per iteration, so both are one pixel per step here; what differs is only
+## the HP *number* printed beside the bar, which [method hp] answers.
+
+## `HP_BAR_LENGTH * TILE_WIDTH`, the bar's full width in pixels.
+const LENGTH_PX: int = Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
+
+## `HPBarAnim_BGMapUpdate` waits two frames per redraw, on both the DMG path and
+## the CGB one: a battle bar is `wWhichHPBar` 0 or 1, which takes `.load_0` or
+## `.load_1` into `.finish`'s two `DelayFrame`s.
+const FRAMES_PER_STEP: int = 2
+
+var _max_hp: int = 0
+var _to_hp: int = 0
+var _pixels: int = 0
+var _target_pixels: int = 0
+var _frames: int = 0
+
+
+## The animation from [param from_hp] to [param to_hp]. A bar already at its
+## destination is finished on arrival and never ticks.
+static func create(from_hp: int, to_hp: int, max_hp: int) -> Gen2HpBarAnimation:
+	var animation := Gen2HpBarAnimation.new()
+	animation._max_hp = max_hp
+	animation._to_hp = to_hp
+	animation._pixels = Gen2BattleHud.bar_pixels(from_hp, max_hp, LENGTH_PX)
+	animation._target_pixels = Gen2BattleHud.bar_pixels(to_hp, max_hp, LENGTH_PX)
+	return animation
+
+
+func finished() -> bool:
+	return _pixels == _target_pixels
+
+
+func pixels() -> int:
+	return _pixels
+
+
+## One hardware frame. Answers whether the bar moved, which is what tells the
+## screen to redraw.
+func advance_frame() -> bool:
+	if finished():
+		return false
+	_frames += 1
+	if _frames < FRAMES_PER_STEP:
+		return false
+	_frames = 0
+	_pixels += 1 if _target_pixels > _pixels else -1
+	return true
+
+
+## The HP to print beside the bar while it moves, and the real value once it has
+## arrived.
+##
+## Mid-animation this is the inverse of `ComputeHPBarPixels`, which is what the
+## long branch prints as it steps real HP toward the target. The short branch
+## back-computes with `ShortHPBar_CalcPixelFrame` instead, whose documented
+## off-by-one for low HP is not reproduced; see the divergence note in
+## `HANDOFF.md`. Only the number differs, never the bar.
+func hp() -> int:
+	if finished():
+		return _to_hp
+	if _max_hp <= 0:
+		return 0
+	if _pixels <= 0:
+		return 0
+	if _pixels >= LENGTH_PX:
+		return _max_hp
+	@warning_ignore("integer_division")
+	var value: int = _pixels * _max_hp / LENGTH_PX
+	return clampi(maxi(value, 1), 0, _max_hp)

--- a/game/battle/hp_bar_animation.gd.uid
+++ b/game/battle/hp_bar_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://c4wt25fy0r1f2

--- a/tests/integration/test_battle_move_forget.gd
+++ b/tests/integration/test_battle_move_forget.gd
@@ -62,10 +62,21 @@ func _open_with_full_moveset(third_move: int = BattleFixture.THUNDERBOLT) -> voi
 
 ## Presses through every queued event until the offer opens, which is what a
 ## player pressing A does.
+## A draining HP bar swallows a press, the way `AnimateHPBar`'s own loop does,
+## so the bar is walked to its end before the next one. In play the screen's
+## frames do this; a test that pressed without it would stall on the first hit.
+func _settle_bars() -> void:
+	var guard: int = 4000
+	while _screen.bars_animating() and guard > 0:
+		_screen.advance_bars()
+		guard -= 1
+
+
 func _advance_to_offer(limit: int = 40) -> void:
 	for _press: int in limit:
 		if String(_screen.get("_forget_stage")) != "":
 			return
+		_settle_bars()
 		_screen.finish()
 		_screen.advance()
 		await get_tree().process_frame
@@ -86,6 +97,7 @@ func _drain_box() -> void:
 
 
 func _press(button: int) -> void:
+	_settle_bars()
 	await _drain_box()
 	_screen._answer_forget(button)
 	await get_tree().process_frame

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -126,3 +126,50 @@ func uses_hardware_viewport() -> bool:
 	# Hardware pixels live inside the SubViewport; a renderer that opted out of
 	# that must not end up there.
 	assert_false(_battle_screen._renderer.get_parent() is SubViewport)
+
+
+## `NormalHit` runs `applydamage` before `criticaltext` and `supereffectivetext`,
+## and `DoEnemyDamage` ends with `predef AnimateHPBar`, so the bar drains first
+## and the line describing the hit waits for it.
+func test_a_hit_drains_the_bar_before_it_says_what_the_hit_was() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_battle_screen.set_hp(48, 48, 40, 40)
+
+	_battle_screen._pending = [{
+		"type": Gen2Battle.HIT, "side": Gen2Battle.PLAYER, "target": Gen2Battle.ENEMY,
+		"hp": 24, "max_hp": 48, "critical": false,
+		"effectiveness": RomLayout.MATCHUP_SUPER_EFFECTIVE,
+	}]
+	_battle_screen._show_next_event()
+
+	assert_true(_battle_screen.bars_animating(), "the bar is still on its way down")
+	assert_ne(
+		_battle_screen.battle_snapshot()["message"], "It's super effective!",
+		"and the line has not been printed yet"
+	)
+	assert_eq(int(_battle_screen.get("_enemy_hp")), 24, "the committed HP is already there")
+
+	## A press during the animation is swallowed, the way AnimateHPBar's own
+	## blocking loop swallows one.
+	_battle_screen.advance()
+	assert_true(_battle_screen.bars_animating())
+
+	var guard: int = 4000
+	while _battle_screen.bars_animating() and guard > 0:
+		_battle_screen.advance_bars()
+		guard -= 1
+	assert_eq(_battle_screen.battle_snapshot()["message"], "It's super effective!")
+
+
+## A Pokemon coming out gets its bar drawn rather than drained: the maximum
+## moved under it, so it is not the same bar.
+func test_a_new_pokemon_does_not_animate_its_bar_up() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_battle_screen.set_hp(10, 48, 40, 40)
+	_battle_screen._apply_event({
+		"type": Gen2Battle.SENT_OUT, "side": Gen2Battle.ENEMY,
+		"species": 155, "level": 7, "hp": 30, "max_hp": 30,
+	})
+	assert_false(_battle_screen.bars_animating())

--- a/tests/unit/test_hp_bar_animation.gd
+++ b/tests/unit/test_hp_bar_animation.gd
@@ -1,0 +1,87 @@
+extends GutTest
+
+## engine/battle/anim_hp_bar.asm, as the bar's own walk.
+
+
+func _settle(animation: Gen2HpBarAnimation, limit: int = 4000) -> int:
+	var frames: int = 0
+	while not animation.finished() and frames < limit:
+		animation.advance_frame()
+		frames += 1
+	return frames
+
+
+## `HPBarAnim_BGMapUpdate` waits two frames per redraw, and a redraw is one
+## pixel, so a full bar takes twice its own width in frames.
+func test_the_bar_moves_one_pixel_every_two_frames() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(48, 0, 48)
+	assert_eq(animation.pixels(), Gen2HpBarAnimation.LENGTH_PX)
+	assert_false(animation.advance_frame(), "the first frame of the pair draws nothing")
+	assert_true(animation.advance_frame())
+	assert_eq(animation.pixels(), Gen2HpBarAnimation.LENGTH_PX - 1)
+
+
+func test_a_full_drain_takes_two_frames_per_pixel() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(48, 0, 48)
+	assert_eq(
+		_settle(animation),
+		Gen2HpBarAnimation.LENGTH_PX * Gen2HpBarAnimation.FRAMES_PER_STEP
+	)
+	assert_eq(animation.pixels(), 0)
+
+
+## A bar that is not moving never ticks, which is what lets the screen treat
+## "no animation" and "arrived" as the same thing.
+func test_a_bar_already_where_it_is_going_is_finished() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(20, 20, 20)
+	assert_true(animation.finished())
+	assert_false(animation.advance_frame())
+
+
+## Healing walks the other way.
+func test_the_bar_fills_as_well_as_drains() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(0, 100, 100)
+	assert_eq(animation.pixels(), 0)
+	_settle(animation)
+	assert_eq(animation.pixels(), Gen2HpBarAnimation.LENGTH_PX)
+	assert_eq(animation.hp(), 100)
+
+
+## `ComputeHPBarPixels` keeps a surviving Pokemon on at least one pixel, so a
+## drain to a single HP stops one pixel short of empty.
+func test_a_survivor_keeps_a_pixel() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(200, 1, 200)
+	_settle(animation)
+	assert_eq(animation.pixels(), 1)
+	assert_eq(animation.hp(), 1, "and the number is the real one once it arrives")
+
+
+func test_a_faint_empties_the_bar() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(200, 0, 200)
+	_settle(animation)
+	assert_eq(animation.pixels(), 0)
+	assert_eq(animation.hp(), 0)
+
+
+## The number beside the bar counts down with it rather than jumping.
+func test_the_printed_hp_follows_the_bar_down() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(100, 0, 100)
+	var seen: Array = []
+	while not animation.finished():
+		animation.advance_frame()
+		seen.append(animation.hp())
+	assert_gt(seen.size(), 2, "a hundred HP over 48 pixels is a real walk")
+	for index: int in range(1, seen.size()):
+		assert_true(int(seen[index]) <= int(seen[index - 1]), "the number never goes back up")
+	assert_eq(int(seen[-1]), 0)
+
+
+## The two source branches are keyed on whether the maximum reaches the bar's
+## own width; both redraw one pixel at a time, so both take the same walk.
+func test_a_small_maximum_still_walks_pixel_by_pixel() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(20, 0, 20)
+	assert_eq(animation.pixels(), Gen2HpBarAnimation.LENGTH_PX)
+	assert_eq(
+		_settle(animation),
+		Gen2HpBarAnimation.LENGTH_PX * Gen2HpBarAnimation.FRAMES_PER_STEP
+	)

--- a/tests/unit/test_hp_bar_animation.gd.uid
+++ b/tests/unit/test_hp_bar_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://myq3fqde1nvx


### PR DESCRIPTION
_AnimateHPBar walks the bar one pixel per redraw and waits two frames per redraw, on the DMG path and the CGB one alike: a battle bar is wWhichHPBar 0 or 1, which takes .load_0 or .load_1 into .finish's two DelayFrames.

The ordering against the text is the source's and not a choice. NormalHit runs applydamage before criticaltext and supereffectivetext, and DoEnemyDamage ends with predef AnimateHPBar, so the bar arrives and only then does the line describing the hit print. A press during the drain is swallowed, the way that blocking loop swallows one.

set_hp stays the committed value that every caller and battle_snapshot read; AnimateHPBar is reached from DoEnemyDamage and its siblings rather than from every write to wBattleMonHP, so the bar is started by the events that mean damage or healing. A Pokemon coming out is not one of them: its maximum moved, so LoadHPBar puts that bar up whole.