### PR TITLE
Let the EXP bar fill the way the level rises

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -303,15 +303,18 @@ a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
 
 `view` carries `enemy_species`, `player_species`, `enemy_name`, `player_name`,
 `enemy_level`, `player_level`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
-`player_max_hp` and `exp_fraction`: plain values read out of a resolved battle
+`player_max_hp` and `exp_pixels`: plain values read out of a resolved battle
 event, never the battle engine itself, the same rule `Gen2BattleScreen`'s own
-setters already followed.
+setters already followed. `exp_pixels` is a count out of 64, which is
+`PlaceExpBar`'s own unit; the exp bar is never a ratio, because `CalcExpBar` has
+already done the division and rounded it the cartridge's way.
 
-The two HP values are the *drawn* ones, not the committed ones: a hit drains the
-bar over roughly a second the way the cartridge does, and `set_view` is called
-again on every step of that drain. A renderer that wants the bar to move needs
-no work; one that wants the final number should wait for the drain to end rather
-than reading the view, since mid-drain it is deliberately not the real HP.
+The two HP values and `exp_pixels` are the *drawn* ones, not the committed ones:
+a hit drains the bar over roughly a second the way the cartridge does, an award
+fills the exp bar over one, and `set_view` is called again on every step of
+either. A renderer that wants a bar to move needs no work; one that wants the
+final number should wait for the animation to end rather than reading the view,
+since mid-animation it is deliberately not the real value.
 
 Registration uses the same refusal rules as a world renderer, and shares both
 optional methods (`uses_hardware_viewport()`, `set_native_size()`) and the `V`

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -126,7 +126,7 @@ func _draw_panels() -> void:
 	_show_layer(_player_bar, player, _hp_palette(player_hp, player_max_hp))
 
 	var gained: PackedByteArray = _new_buffer()
-	_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, float(_view.get("exp_fraction", 0.0)))
+	_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, int(_view.get("exp_pixels", 0)))
 	_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -139,6 +139,8 @@ var _world_battle_recovery: Dictionary = {}
 var _last_message: String = ""
 ## A running [Gen2HpBarAnimation] per side. A side with no entry is not moving.
 var _bars: Dictionary = {}
+## The running [Gen2ExpBarAnimation], or null when the exp bar is not filling.
+var _exp_bar: Gen2ExpBarAnimation = null
 ## The text the event pump produced while a bar was still draining. The source
 ## prints it after the bar arrives, since `applydamage` runs before
 ## `criticaltext` and `supereffectivetext`.
@@ -181,7 +183,8 @@ var _enemy_hp: int = 0
 var _enemy_max_hp: int = 0
 var _player_hp: int = 0
 var _player_max_hp: int = 0
-var _exp: float = 0.0
+## The committed exp bar, in `PlaceExpBar`'s pixels.
+var _exp: int = 0
 
 var _box: Gen2TextBox = null
 
@@ -192,11 +195,11 @@ var _box: Gen2TextBox = null
 ## [Gen2WorldAnimation] paces the overworld that way: the two-frame step
 ## `HPBarAnim_BGMapUpdate` waits is a hardware frame count.
 func _process(delta: float) -> void:
-	if _bars.is_empty():
+	if not bars_animating():
 		_bar_elapsed = 0.0
 		return
 	_bar_elapsed += delta
-	while _bar_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and not _bars.is_empty():
+	while _bar_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and bars_animating():
 		_bar_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
 		advance_bars()
 
@@ -557,13 +560,13 @@ func _drawn_hp(side: int) -> int:
 
 ## Whether any bar is still moving, which is what holds the next message back.
 func bars_animating() -> bool:
-	return not _bars.is_empty()
+	return not _bars.is_empty() or _exp_bar != null
 
 
 ## One hardware frame of every running bar. Public so a test or a screenshot
 ## driver can settle the bars without waiting on real time.
 func advance_bars() -> bool:
-	if _bars.is_empty():
+	if not bars_animating():
 		return false
 	var moved: bool = false
 	for side: int in _bars.keys():
@@ -572,18 +575,42 @@ func advance_bars() -> bool:
 			moved = true
 		if animation.finished():
 			_bars.erase(side)
+
+	var boundary: bool = false
+	if _exp_bar != null:
+		if _exp_bar.advance_frame():
+			moved = true
+		boundary = _exp_bar.segment_finished()
+		if _exp_bar.finished():
+			_exp_bar = null
+			# The levels crossed on the way did not touch the committed count, so
+			# the end of the walk is where it catches up.
+			_refresh_exp_bar()
+
 	if moved:
 		_push_view()
-	if _bars.is_empty() and not _held_message.is_empty():
+
+	if not _held_message.is_empty() and _bars.is_empty():
 		var text: String = _held_message
 		_held_message = ""
 		show_message(text)
+	elif boundary and _exp_bar != null:
+		# The bar has reached the end of the level it was filling and stopped
+		# there. `.LoopLevels` prints its grew-to-level line at exactly this
+		# point, so the pump runs on to the event that carries it.
+		_show_next_event()
 	return moved
 
 
-## How full the exp bar is, from nothing to a level's worth.
-func set_exp(fraction: float) -> void:
-	_exp = clampf(fraction, 0.0, 1.0)
+## How full the exp bar is, in `PlaceExpBar`'s own pixels. The committed value:
+## the animation below draws its own while it runs, the way the HP bars do, and
+## a write that moves the committed count cancels it for the same reason
+## [method set_hp] cancels a drain.
+func set_exp(pixels: int) -> void:
+	var value: int = clampi(pixels, 0, Gen2ExpBarAnimation.LENGTH_PX)
+	if value != _exp:
+		_exp_bar = null
+	_exp = value
 	_push_view()
 
 
@@ -593,14 +620,59 @@ func set_exp(fraction: float) -> void:
 ## number behind it.
 func _refresh_exp_bar() -> void:
 	if _battle == null or _battle.player == null:
-		set_exp(0.0)
+		set_exp(0)
+		return
+
+	var mon: Gen2BattleMon = _battle.player
+	set_exp(Gen2ExpBarAnimation.pixels_for(mon.growth_rate(), mon.level, mon.exp))
+
+
+## What the exp bar is drawing: the animation's pixels while one runs, and the
+## committed count otherwise.
+func _drawn_exp() -> int:
+	return _exp if _exp_bar == null else _exp_bar.pixels()
+
+
+## Begins the fill [param event]'s award earns, which is `AnimateExpBar`, from
+## the [param from_pixels] the bar stood at before the award was committed.
+##
+## The segments are read out of the events still queued behind this one: one
+## ending at the end of the bar per level this gain crosses, then the partial
+## fill `.FinishExpBar` computes from the exp and level the gain settled on.
+##
+## Two of the routine's own guards return before any of that, and both are kept:
+## a gainer who is not the Pokémon on the field animates nothing
+## (`wCurPartyMon` against `wCurBattleMon`), and neither does one already at
+## `MAX_LEVEL`.
+func _start_exp_bar(event: Dictionary, from_pixels: int) -> void:
+	_exp_bar = null
+	if _battle == null or _battle.player == null:
+		return
+
+	var index: int = int(event["index"])
+	if index != _battle.party(Gen2Battle.PLAYER).active:
 		return
 
 	var mon: Gen2BattleMon = _battle.player
 	var rate: int = mon.growth_rate()
-	var floor_exp: int = Gen2Experience.total_exp_at(rate, mon.level)
-	var span: int = Gen2Experience.total_exp_at(rate, mon.level + 1) - floor_exp
-	set_exp(float(mon.exp - floor_exp) / float(span) if span > 0 else 1.0)
+	# Only this award's own level-ups: a second [constant Gen2Battle.EXP_GAINED]
+	# behind it is the Exp. Share pass, and its levels belong to its own bar.
+	var levels: int = 0
+	for queued: Dictionary in _pending:
+		var kind: StringName = StringName(queued["type"])
+		if kind == Gen2Battle.EXP_GAINED:
+			break
+		if kind == Gen2Battle.GREW_LEVEL and int(queued["index"]) == index:
+			levels += 1
+	if mon.level - levels >= Gen2Experience.MAX_LEVEL:
+		return
+
+	var targets: Array[int] = []
+	for _level: int in levels:
+		targets.append(Gen2ExpBarAnimation.LENGTH_PX)
+	targets.append(Gen2ExpBarAnimation.pixels_for(rate, mon.level, mon.exp))
+	_exp_bar = Gen2ExpBarAnimation.create(from_pixels, targets)
+	_push_view()
 
 
 func show_message(text: String) -> void:
@@ -1049,6 +1121,15 @@ func _confirm_forget_slot() -> void:
 func advance() -> void:
 	if _box == null:
 		return
+	## The exp bar stopped at a level boundary is under `.LoopLevels`' own
+	## `StdBattleTextbox`, which blocks on a button: this press is that button,
+	## and it lets the loop run on into the next level's fill rather than
+	## advancing the battle.
+	if _exp_bar != null and _exp_bar.paused():
+		if _box.advance():
+			return
+		_exp_bar.resume()
+		return
 	## A bar the source is still animating has not printed its message yet, so
 	## there is nothing for a press to advance past. Without this the press
 	## would pop the next event and the held line would never be shown.
@@ -1251,7 +1332,7 @@ func _show_next_event() -> void:
 			## `applydamage` animates the bar and only then does `criticaltext`
 			## print, so a message caused by an event that moved a bar waits for
 			## it rather than racing it.
-			if bars_animating():
+			if not _bars.is_empty():
 				_held_message = text
 			else:
 				show_message(text)
@@ -1274,7 +1355,11 @@ func _apply_event(event: Dictionary) -> void:
 	var before_enemy_max: int = _enemy_max_hp
 	var before_player: int = _player_hp
 	var before_player_max: int = _player_max_hp
+	var before_exp: int = _exp
 	_apply_event_state(event)
+	if StringName(event["type"]) == Gen2Battle.EXP_GAINED:
+		_start_exp_bar(event, before_exp)
+		return
 	if not HP_BAR_EVENTS.has(StringName(event["type"])):
 		return
 	_start_bar(Gen2Battle.ENEMY, before_enemy, before_enemy_max)
@@ -1321,10 +1406,15 @@ func _apply_event_state(event: Dictionary) -> void:
 			# only moves when the index that grew is the one currently active: a
 			# benched participant can level up too, and this screen has no bench
 			# to show it on.
+			# The bar itself is not recomputed here: `.LoopLevels` is inside
+			# `AnimateExpBar`, so from the award until the walk ends the animation
+			# owns the bar and [method advance_bars] commits the real count when
+			# it arrives.
 			if int(event["index"]) == _battle.party(Gen2Battle.PLAYER).active:
 				_player_level = int(event["new_level"])
 				_push_view()
-			_refresh_exp_bar()
+			if _exp_bar == null:
+				_refresh_exp_bar()
 
 
 ## An event as a sentence, or an empty string for one there is nothing to say
@@ -1743,7 +1833,7 @@ func _push_view() -> void:
 		## [method battle_snapshot], keeps reading the committed value.
 		"enemy_hp": _drawn_hp(Gen2Battle.ENEMY), "enemy_max_hp": _enemy_max_hp,
 		"player_hp": _drawn_hp(Gen2Battle.PLAYER), "player_max_hp": _player_max_hp,
-		"exp_fraction": _exp,
+		"exp_pixels": _drawn_exp(),
 	})
 
 

--- a/game/battle/exp_bar_animation.gd
+++ b/game/battle/exp_bar_animation.gd
@@ -1,0 +1,185 @@
+class_name Gen2ExpBarAnimation
+extends RefCounted
+
+## The exp bar filling, one pixel at a time (`AnimateExpBar`,
+## engine/battle/core.asm).
+##
+## Scene-free like the rest of the battle layer: the screen ticks this once per
+## hardware frame and draws [method fraction].
+##
+## It is not the HP bar again. `AnimateExpBar` walks over level boundaries
+## rather than between two values: the bar fills to the end, the level goes up,
+## and it refills from empty, which is what `.LoopLevels` does with `ld c, $40`
+## and then `ld b, $0` before it loops. So this is a list of segments, one per
+## level crossed plus the final partial fill `.FinishExpBar` computes.
+##
+## Its ordering against the text is the source's too, and it is the opposite of
+## the HP bar's on the way in: `Text_MonGainedExpPoint` is printed before
+## `call AnimateExpBar`, while `BattleText_StringBuffer1GrewToLevel` is printed
+## inside `.LoopLevels` after that level's segment has reached the end.
+##
+## The whole routine is byte identical between the pins but for three guards
+## Gold and Silver lack: the `$ffffff` exp clamp in `.NoOverflow`, the `cp e`
+## downward clamp after `CalcLevel`, and `.LoopLevels`' own `cp MAX_LEVEL`.
+## Crystal's top-of-routine level check is `cp MAX_LEVEL` / `jp nc` against
+## pokegold's `jp z`. None of them is reachable from a gain: a level only rises
+## and [method Gen2Experience.level_for_exp] stops at `MAX_LEVEL`, so nothing
+## here is profile split.
+
+## `EXP_BAR_LENGTH * TILE_WIDTH`, the bar's full width in pixels. `CalcExpBar`
+## multiplies by 64 and returns `$40 - b`; `PlaceExpBar` draws eight tiles.
+const LENGTH_PX: int = Gen2BattleHud.EXP_BAR_TILES * Gen2BattleHud.TILE
+
+## `.PlayExpBarSound`'s `ld c, 10` / `call DelayFrames`, spent before each
+## segment starts moving. The `SFX_EXP_BAR` beside it is the same boundary the
+## Poof's `SFX_SWITCH_POKEMON` is: no battle screen has an SFX route.
+const LEAD_FRAMES: int = 10
+
+## `.LoopBarAnimation`'s `ld d, 3`, and its floor. The delay is spent twice per
+## value and then decremented, so a segment paces 3, 3, 2, 2, 1, 1, 1, 1 and on
+## at one frame a pixel. `ld d, 3` is inside the routine, which is called once
+## per segment, so every segment starts slow again.
+const START_DELAY: int = 3
+const MIN_DELAY: int = 1
+
+## How many pixels each delay value is held for before it is decremented.
+const STEPS_PER_DELAY: int = 2
+
+## Where each segment ends, in pixels. All but the last are [constant LENGTH_PX],
+## since a level boundary is reached at the end of the bar.
+var _targets: Array[int] = []
+var _segment: int = 0
+var _pixels: int = 0
+var _lead: int = 0
+var _delay: int = START_DELAY
+var _held: int = 0
+var _frames: int = 0
+var _segment_ended: bool = false
+## Set when a level boundary has been reached and the bar is still showing it
+## full, cleared by the next segment's first draw.
+var _pending_reset: bool = false
+## Stopped at a level boundary under the grew-to-level textbox.
+var _paused: bool = false
+
+
+## The bar's own pixel count for [param exp_points] at [param level], which is
+## `CalcExpBar`: 64 minus the exp still owed to the next level, scaled over the
+## span between the two levels.
+##
+## The subtraction is on that side on purpose. Scaling the exp already earned
+## instead floors the other way and answers one pixel high wherever the division
+## is inexact, which is most values.
+static func pixels_for(growth_rate: int, level: int, exp_points: int) -> int:
+	if level >= Gen2Experience.MAX_LEVEL:
+		return LENGTH_PX
+
+	var floor_exp: int = Gen2Experience.total_exp_at(growth_rate, level)
+	var span: int = Gen2Experience.total_exp_at(growth_rate, level + 1) - floor_exp
+	if span <= 0:
+		return LENGTH_PX
+
+	var remaining: int = clampi(floor_exp + span - exp_points, 0, span)
+	@warning_ignore("integer_division")
+	var owed: int = LENGTH_PX * remaining / span
+	return clampi(LENGTH_PX - owed, 0, LENGTH_PX)
+
+
+## The walk from [param from_pixels] over [param targets], each of which is
+## where one segment ends.
+##
+## A segment that covers no distance is not skipped: `.LoopBarAnimation` draws
+## and waits before it compares, so a gain too small to move a pixel still costs
+## its lead and one delay, exactly as it does on the cartridge. Only an empty
+## [param targets] is finished on arrival.
+static func create(from_pixels: int, targets: Array[int]) -> Gen2ExpBarAnimation:
+	var animation := Gen2ExpBarAnimation.new()
+	animation._pixels = clampi(from_pixels, 0, LENGTH_PX)
+	for target: int in targets:
+		animation._targets.append(clampi(target, 0, LENGTH_PX))
+	if not animation.finished():
+		animation._lead = LEAD_FRAMES
+	return animation
+
+
+func finished() -> bool:
+	return _segment >= _targets.size()
+
+
+func pixels() -> int:
+	return _pixels
+
+
+## Whether the last [method advance_frame] ended a segment, which is a level
+## boundary for every segment but the last. It is what prints the grew-to-level
+## line `.LoopLevels` prints once the bar has reached the end.
+func segment_finished() -> bool:
+	return _segment_ended
+
+
+## Whether the bar is stopped at a level boundary waiting to be let go, which is
+## `.LoopLevels`' own `StdBattleTextbox`: that textbox blocks on a button before
+## the loop reaches `.PlayExpBarSound` again.
+func paused() -> bool:
+	return _paused
+
+
+## The press that dismisses the grew-to-level textbox, which is what lets
+## `.LoopLevels` run on into the next level's fill.
+func resume() -> void:
+	if not _paused:
+		return
+	_paused = false
+	_pending_reset = true
+	_lead = LEAD_FRAMES
+	_delay = START_DELAY
+	_held = 0
+	_frames = 0
+
+
+## One hardware frame. Answers whether the bar moved, which is what tells the
+## screen to redraw.
+func advance_frame() -> bool:
+	_segment_ended = false
+	if finished() or _paused:
+		return false
+
+	if _lead > 0:
+		_lead -= 1
+		if _lead > 0 or not _pending_reset:
+			return false
+		# `ld b, $0` is set at the end of `.LoopLevels`, but nothing draws it
+		# until the next `.LoopBarAnimation` runs, which is after
+		# `.PlayExpBarSound`'s ten frames. So the full bar stays up under the
+		# grew-to-level textbox and empties on the new segment's first draw.
+		_pending_reset = false
+		_pixels = 0
+		return true
+
+	_frames += 1
+	if _frames < _delay:
+		return false
+	_frames = 0
+
+	var target: int = _targets[_segment]
+	var moved: bool = _pixels != target
+	if moved:
+		_pixels += 1 if target > _pixels else -1
+
+	_held += 1
+	if _held >= STEPS_PER_DELAY:
+		_held = 0
+		_delay = maxi(_delay - 1, MIN_DELAY)
+
+	if _pixels == target:
+		_end_segment()
+	return moved
+
+
+## `.LoopLevels`' own tail: the level goes up and its line is printed by a
+## textbox that blocks on a button, so the bar stops here full. [method resume]
+## is that button, and it is what empties the bar and starts the next fill.
+func _end_segment() -> void:
+	_segment_ended = true
+	_segment += 1
+	if not finished():
+		_paused = true

--- a/game/battle/exp_bar_animation.gd.uid
+++ b/game/battle/exp_bar_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://0nl8amwk8pmf

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -149,9 +149,13 @@ func draw_hp_bar(
 
 ## The exp bar, whose ends are the HP bar's own tiles and whose partial fills
 ## are the only thing its own sheet is for.
-func draw_exp_bar(into: PackedByteArray, width: int, fraction: float) -> void:
+##
+## [param pixels] is `PlaceExpBar`'s own `b`: the bar is a pixel count, never a
+## ratio, because `CalcExpBar` has already done the division and rounded it the
+## cartridge's way.
+func draw_exp_bar(into: PackedByteArray, width: int, pixels: int) -> void:
 	var length: int = EXP_BAR_TILES * TILE
-	var lit: int = clampi(int(fraction * float(length)), 0, length)
+	var lit: int = clampi(pixels, 0, length)
 	var left: int = PLAYER_EXP.x * TILE
 	var top: int = PLAYER_EXP.y * TILE
 

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -173,3 +173,96 @@ func test_a_new_pokemon_does_not_animate_its_bar_up() -> void:
 		"species": 155, "level": 7, "hp": 30, "max_hp": 30,
 	})
 	assert_false(_battle_screen.bars_animating())
+
+
+## `Text_MonGainedExpPoint` is printed before `call AnimateExpBar`, so the EXP.
+## Points line leads its bar; `BattleText_StringBuffer1GrewToLevel` is printed
+## inside `.LoopLevels` once that level's segment has reached the end of the bar,
+## so the level line waits for it.
+func test_experience_says_its_line_first_and_the_level_line_after_the_bar() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+
+	var mon: Gen2BattleMon = _battle_screen._battle.player
+	var rate: int = mon.growth_rate()
+	var index: int = _battle_screen._battle.party(Gen2Battle.PLAYER).active
+	mon.exp = Gen2Experience.total_exp_at(rate, mon.level)
+	_battle_screen._refresh_exp_bar()
+	assert_eq(int(_battle_screen.get("_exp")), 0, "the bar starts at the level's own threshold")
+
+	# What `_give_experience_to` does to the Pokemon before it describes it: an
+	# award that carries it over the next level.
+	var award: int = Gen2Experience.total_exp_at(rate, mon.level + 1) - mon.exp + 4
+	var grown: int = mon.level + 1
+	mon.gain_exp(award)
+	mon.level_up()
+
+	_battle_screen._pending = [
+		{
+			"type": Gen2Battle.EXP_GAINED, "side": Gen2Battle.PLAYER, "index": index,
+			"species": mon.species, "amount": award, "exp": mon.exp, "exp_share": false,
+		},
+		{
+			"type": Gen2Battle.GREW_LEVEL, "side": Gen2Battle.PLAYER, "index": index,
+			"species": mon.species, "old_level": grown - 1, "new_level": grown,
+			"old_stats": {}, "new_stats": {},
+		},
+	]
+
+	_battle_screen._show_next_event()
+	assert_true(_battle_screen.bars_animating(), "the bar is filling")
+	assert_string_contains(
+		String(_battle_screen.battle_snapshot()["message"]), "EXP. Points",
+		"and its own line is already on screen"
+	)
+
+	# A press during the fill is swallowed, the way AnimateExpBar's own blocking
+	# loop swallows one.
+	_battle_screen.advance()
+	assert_true(_battle_screen.bars_animating())
+
+	# The first segment ends at the end of the bar, where the level line is
+	# printed and the walk stops for the button that dismisses it.
+	var guard: int = 4000
+	while not _battle_screen._exp_bar.paused() and guard > 0:
+		_battle_screen.advance_bars()
+		guard -= 1
+	assert_gt(guard, 0, "the bar reached the end of the level")
+	assert_eq(
+		_battle_screen._exp_bar.pixels(), Gen2ExpBarAnimation.LENGTH_PX,
+		"and it is sitting there full"
+	)
+	assert_string_contains(
+		String(_battle_screen.battle_snapshot()["message"]), "grew to level",
+		"the level line waited for the bar to reach the end"
+	)
+
+	_battle_screen._box.advance()
+	_battle_screen.advance()
+	assert_false(_battle_screen._exp_bar.paused(), "the press let the next fill start")
+
+	guard = 4000
+	while _battle_screen.bars_animating() and guard > 0:
+		_battle_screen.advance_bars()
+		guard -= 1
+	assert_gt(guard, 0, "the walk ended")
+	assert_eq(
+		int(_battle_screen.get("_exp")),
+		Gen2ExpBarAnimation.pixels_for(rate, mon.level, mon.exp),
+		"and the committed count caught up when it did"
+	)
+
+
+## `AnimateExpBar` returns before it touches the bar when the gainer is not the
+## Pokemon on the field, which is every Exp. Share holder on the bench.
+func test_a_benched_gainer_animates_no_bar() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	var mon: Gen2BattleMon = _battle_screen._battle.player
+	var benched: int = _battle_screen._battle.party(Gen2Battle.PLAYER).active + 1
+
+	_battle_screen._apply_event({
+		"type": Gen2Battle.EXP_GAINED, "side": Gen2Battle.PLAYER, "index": benched,
+		"species": mon.species, "amount": 40, "exp": mon.exp, "exp_share": true,
+	})
+	assert_false(_battle_screen.bars_animating())

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -181,6 +181,40 @@ func test_the_hp_bar_fill_is_drawn_apart_from_the_panel() -> void:
 	assert_eq(_ink_in_row(empty, Gen2BattleHud.ENEMY_BAR.y), 0, "a fainted bar draws nothing")
 
 
+## `PlaceExpBar` takes a pixel count in `b`, walks eight tiles filling whole
+## ones and draws the remainder as a partial. It is never a ratio: `CalcExpBar`
+## has already divided.
+func test_the_exp_bar_is_drawn_from_a_pixel_count() -> void:
+	_write_cache()
+	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
+	var length: int = Gen2BattleHud.EXP_BAR_TILES * Gen2BattleHud.TILE
+
+	var empty: PackedByteArray = PackedByteArray()
+	empty.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_exp_bar(empty, Gen2Screen.WIDTH, 0)
+	assert_eq(_ink_in_row(empty, Gen2BattleHud.PLAYER_EXP.y), 0, "no exp draws nothing")
+
+	var part: PackedByteArray = PackedByteArray()
+	part.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_exp_bar(part, Gen2Screen.WIDTH, length / 2)
+
+	var full: PackedByteArray = PackedByteArray()
+	full.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_exp_bar(full, Gen2Screen.WIDTH, length)
+
+	var part_ink: int = _ink_in_row(part, Gen2BattleHud.PLAYER_EXP.y)
+	var full_ink: int = _ink_in_row(full, Gen2BattleHud.PLAYER_EXP.y)
+	assert_ne(part_ink, 0)
+	assert_gt(full_ink, part_ink, "a fuller bar is more ink")
+
+	var over: PackedByteArray = PackedByteArray()
+	over.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_exp_bar(over, Gen2Screen.WIDTH, length * 2)
+	assert_eq(
+		_ink_in_row(over, Gen2BattleHud.PLAYER_EXP.y), full_ink, "the bar stops at its own end"
+	)
+
+
 ## Lit pixels in one row of tiles.
 func _ink_in_row(screen: PackedByteArray, row: int) -> int:
 	var out: int = 0

--- a/tests/unit/test_exp_bar_animation.gd
+++ b/tests/unit/test_exp_bar_animation.gd
@@ -1,0 +1,142 @@
+extends GutTest
+
+## `AnimateExpBar` (engine/battle/core.asm), as the bar's own walk.
+
+
+func _settle(animation: Gen2ExpBarAnimation, limit: int = 4000) -> int:
+	var frames: int = 0
+	while not animation.finished() and frames < limit:
+		animation.advance_frame()
+		frames += 1
+	return frames
+
+
+## The frames each of the first pixels costs, which is `.LoopBarAnimation`'s own
+## `d` held for two values at a time and floored at one.
+func _delays(animation: Gen2ExpBarAnimation, count: int) -> Array[int]:
+	var out: Array[int] = []
+	var waited: int = 0
+	while out.size() < count and waited < 4000:
+		waited += 1
+		if animation.advance_frame():
+			out.append(waited)
+			waited = 0
+	return out
+
+
+## `CalcExpBar` scales the exp still *owed* to the next level and subtracts it
+## from 64, which is not the same as scaling the exp already earned: the two
+## floor on opposite sides and disagree by a pixel wherever the division is
+## inexact.
+func test_pixels_are_calc_exp_bar_rather_than_the_ratio_earned() -> void:
+	var rate: int = Gen2Experience.GROWTH_MEDIUM_FAST
+	var floor_exp: int = Gen2Experience.total_exp_at(rate, 20)
+	var next_exp: int = Gen2Experience.total_exp_at(rate, 21)
+	var span: int = next_exp - floor_exp
+
+	assert_eq(Gen2ExpBarAnimation.pixels_for(rate, 20, floor_exp), 0)
+	assert_eq(Gen2ExpBarAnimation.pixels_for(rate, 20, next_exp), Gen2ExpBarAnimation.LENGTH_PX)
+	# The scaling is a truncating divide, so anything owing less than a pixel's
+	# worth of the span reads as the whole bar: the cartridge shows a full exp
+	# bar for the last few points before a level.
+	assert_eq(
+		Gen2ExpBarAnimation.pixels_for(rate, 20, next_exp - 1), Gen2ExpBarAnimation.LENGTH_PX
+	)
+	@warning_ignore("integer_division")
+	var pixel_worth: int = span / Gen2ExpBarAnimation.LENGTH_PX
+	assert_eq(
+		Gen2ExpBarAnimation.pixels_for(rate, 20, next_exp - pixel_worth - 1),
+		Gen2ExpBarAnimation.LENGTH_PX - 1,
+		"a pixel's worth of the span short of the level is a pixel short of the bar"
+	)
+
+	var half: int = floor_exp + span / 2
+	@warning_ignore("integer_division")
+	var owed: int = Gen2ExpBarAnimation.LENGTH_PX * (next_exp - half) / span
+	assert_eq(
+		Gen2ExpBarAnimation.pixels_for(rate, 20, half), Gen2ExpBarAnimation.LENGTH_PX - owed
+	)
+
+
+## `cp MAX_LEVEL` returns before the bar is touched, and a level 100 Pokémon has
+## no next level to scale against.
+func test_the_bar_is_full_at_the_maximum_level() -> void:
+	assert_eq(
+		Gen2ExpBarAnimation.pixels_for(Gen2Experience.GROWTH_MEDIUM_FAST, Gen2Experience.MAX_LEVEL, 0),
+		Gen2ExpBarAnimation.LENGTH_PX
+	)
+
+
+## `.PlayExpBarSound`'s `ld c, 10` / `call DelayFrames` runs before
+## `.LoopBarAnimation` draws anything.
+func test_ten_frames_are_spent_before_the_bar_moves() -> void:
+	var animation := Gen2ExpBarAnimation.create(0, [8] as Array[int])
+	for frame: int in Gen2ExpBarAnimation.LEAD_FRAMES:
+		assert_false(animation.advance_frame(), "the lead draws nothing")
+	assert_eq(animation.pixels(), 0)
+
+
+## `ld d, 3`, spent twice per value, decremented and floored at one.
+func test_the_bar_starts_slow_and_settles_at_a_frame_a_pixel() -> void:
+	var animation := Gen2ExpBarAnimation.create(0, [8] as Array[int])
+	for frame: int in Gen2ExpBarAnimation.LEAD_FRAMES:
+		animation.advance_frame()
+	assert_eq(_delays(animation, 8), [3, 3, 2, 2, 1, 1, 1, 1] as Array[int])
+	assert_eq(animation.pixels(), 8)
+	assert_true(animation.finished())
+
+
+## `.LoopLevels` fills to `$40`, prints its line and loops with `ld b, $0`, so a
+## gain over a level boundary is two walks rather than one.
+func test_a_level_boundary_fills_the_bar_and_refills_it_from_empty() -> void:
+	var animation := Gen2ExpBarAnimation.create(
+		60, [Gen2ExpBarAnimation.LENGTH_PX, 3] as Array[int]
+	)
+	while not animation.segment_finished():
+		animation.advance_frame()
+	assert_eq(animation.pixels(), Gen2ExpBarAnimation.LENGTH_PX, "the level is reached full")
+	assert_false(animation.finished(), "the second segment is still owed")
+	assert_true(animation.paused(), "and it waits under the grew-to-level textbox")
+
+	assert_eq(_settle(animation, 200), 200, "a paused bar never ticks on its own")
+	animation.resume()
+	_settle(animation)
+	assert_eq(animation.pixels(), 3)
+	assert_true(animation.finished())
+
+
+## Nothing draws `ld b, $0` until the next `.LoopBarAnimation` runs, which is
+## after the next `.PlayExpBarSound`. So the full bar stays up under the
+## grew-to-level textbox and empties only when the new segment starts.
+func test_the_full_bar_stays_up_across_the_level_message() -> void:
+	var animation := Gen2ExpBarAnimation.create(
+		63, [Gen2ExpBarAnimation.LENGTH_PX, 5] as Array[int]
+	)
+	while not animation.segment_finished():
+		animation.advance_frame()
+	animation.resume()
+
+	for frame: int in Gen2ExpBarAnimation.LEAD_FRAMES - 1:
+		animation.advance_frame()
+		assert_eq(animation.pixels(), Gen2ExpBarAnimation.LENGTH_PX)
+	animation.advance_frame()
+	assert_eq(animation.pixels(), 0, "the new segment's first draw is the empty bar")
+
+
+## `.LoopBarAnimation` draws and waits before it compares, so an award too small
+## to move a pixel still costs its lead and one delay.
+func test_a_gain_too_small_to_move_a_pixel_still_takes_its_time() -> void:
+	var animation := Gen2ExpBarAnimation.create(12, [12] as Array[int])
+	assert_false(animation.finished())
+	assert_eq(
+		_settle(animation), Gen2ExpBarAnimation.LEAD_FRAMES + Gen2ExpBarAnimation.START_DELAY
+	)
+	assert_eq(animation.pixels(), 12)
+
+
+## Which is what lets the screen treat "no animation" and "arrived" as the same
+## question.
+func test_an_animation_with_no_segments_is_finished_and_never_ticks() -> void:
+	var animation := Gen2ExpBarAnimation.create(20, [] as Array[int])
+	assert_true(animation.finished())
+	assert_false(animation.advance_frame())

--- a/tests/unit/test_exp_bar_animation.gd.uid
+++ b/tests/unit/test_exp_bar_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://bq0x6lek4xw5


### PR DESCRIPTION
`Gen2ExpBarAnimation` is `AnimateExpBar`: a walk over level boundaries rather than between two values. A gain is one segment per level crossed, each ending at the full 64 pixels, then `.FinishExpBar`'s partial fill. `.LoopBarAnimation` paces a segment 3, 3, 2, 2, 1, 1 frames a pixel and on at one, behind `.PlayExpBarSound`'s ten-frame lead.

At a boundary the bar stops full, since `.LoopLevels` prints its grew-to-level line through a textbox that blocks on a button, and that press is what empties the bar and starts the next fill. The EXP. Points line leads its bar instead, `Text_MonGainedExpPoint` printing before `call AnimateExpBar`.

The bar is a pixel count out of 64 everywhere, never a ratio: `CalcExpBar` scales the exp still owed and subtracts from 64, and scaling the exp earned floored the other way and read a pixel high on most values.