### PR TITLE
Slide the two pics in before a battle says anything

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -303,11 +303,24 @@ a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
 
 `view` carries `enemy_species`, `player_species`, `enemy_name`, `player_name`,
 `enemy_level`, `player_level`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
-`player_max_hp` and `exp_pixels`: plain values read out of a resolved battle
-event, never the battle engine itself, the same rule `Gen2BattleScreen`'s own
-setters already followed. `exp_pixels` is a count out of 64, which is
-`PlaceExpBar`'s own unit; the exp bar is never a ratio, because `CalcExpBar` has
-already done the division and rounded it the cartridge's way.
+`player_max_hp`, `exp_pixels`, `raster_scx` and `player_pic_visible`: plain
+values read out of a resolved battle event, never the battle engine itself, the
+same rule `Gen2BattleScreen`'s own setters already followed. `exp_pixels` is a
+count out of 64, which is `PlaceExpBar`'s own unit; the exp bar is never a
+ratio, because `CalcExpBar` has already done the division and rounded it the
+cartridge's way.
+
+`raster_scx` is the background's own horizontal scroll, one value per scanline
+in the order the hardware draws them, and empty whenever the background is
+sitting still, which is every frame outside the opening slide. An offset is a
+distance to look *right* into a background map 256 pixels wide against the
+screen's 160, so a larger one puts the drawn content further left and the map's
+blank columns wrap in behind it. `Gen2Raster.scroll(image, offsets, 256)` is
+that operation and is what the built-in renderer applies to each of its layers;
+a renderer that ignores the field simply draws no slide. `player_pic_visible`
+is false for exactly that stretch, because `InitBattleDisplay` places the
+player's back pic with `PlaceGraphic` only after `BattleIntroSlidingPics` has
+returned, so during the slide it is not on the map to be scrolled.
 
 The two HP values and `exp_pixels` are the *drawn* ones, not the committed ones:
 a hit drains the bar over roughly a second the way the cartridge does, an award

--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -1,0 +1,156 @@
+class_name Gen2BattleIntro
+extends RefCounted
+
+## The two pics sliding into place at the start of a battle
+## (`BattleIntroSlidingPics`, engine/battle/sliding_intro.asm), as the
+## background scroll it really is.
+##
+## Nothing slides here as an object. The routine scrolls the background itself,
+## in horizontal bands, by rewriting `SCX` part way down the frame: the top band
+## comes in from one side and the middle band from the other, and the bottom of
+## the screen never moves. A band edge falls inside the player's own status
+## panel, which is why this is a per-scanline offset rather than a moving layer.
+##
+## The background map is 32 tiles wide against a 20-tile screen, and
+## `InitBattleDisplay.BlankBGMap` leaves everything past the drawn scene blank,
+## so an offset wraps at [constant MAP_WIDTH] and blank is what scrolls in.
+##
+## This is the one part of the battle presentation the two games do not share.
+## Crystal drives it through `wLYOverrides`, an HBlank table carrying a value
+## per scanline; pokegold busy-waits on `rLY` and writes `rSCX` twice a frame.
+## The band edges, the starting offsets and the shape of the walk all differ, so
+## both are written out rather than one standing in for the other.
+##
+## Neither band lands on zero. Crystal's middle ends at 2 and Gold's top at 4,
+## and `InitBattleDisplay`'s own `xor a` / `ldh [hSCX], a` after the call is what
+## settles the screen; [method finished] is that write.
+##
+## `.subfunction3`, the eighteen `wShadowOAMSprite00` entries walked two pixels
+## left a frame, is the overworld's own objects being slid off before
+## `HideSprites` clears them. This screen has no OAM and no overworld objects in
+## it, so there is nothing to walk; it is a boundary, not a gap.
+##
+## Scene-free like the rest of the battle layer: the screen ticks this once per
+## hardware frame and hands [method offsets] to whatever is drawing.
+
+## The background map's width in pixels, which is what an offset wraps at: 32
+## tiles of 8. Everything from the screen's own 160 up to it is blank.
+const MAP_WIDTH: int = 256
+
+## Screen height in pixels, and so the length of [method offsets].
+const HEIGHT: int = Gen2Screen.HEIGHT
+
+## How much a band moves per frame. Both games step twice, in opposite
+## directions: `dec d` twice against `inc e` twice.
+const STEP: int = 2
+
+## Crystal's `ld d, $90` and `ld e, $72`, over `.subfunction5`'s three runs of
+## 62, 34 and 48 scanlines, for `$48 + 1` frames.
+const CRYSTAL_FRAMES: int = 73
+const CRYSTAL_TOP_START: int = 0x90
+const CRYSTAL_MIDDLE_START: int = 0x72
+const CRYSTAL_TOP_ROWS: int = 62
+const CRYSTAL_MIDDLE_ROWS: int = 34
+
+## Gold and Silver's `ld b, $70` and `ld c, $90`, with `rSCX` rewritten at `rLY`
+## 64 and 96, for the 72 frames `dec c` twice takes to reach zero.
+const GOLD_LOOP_FRAMES: int = 72
+const GOLD_TOP_START: int = 0x90
+const GOLD_MIDDLE_START: int = 0x70
+const GOLD_TOP_ROWS: int = 64
+const GOLD_MIDDLE_ROWS: int = 32
+
+## Gold and Silver spend one frame before the loop: `ld a, c` / `ldh [hSCX], a`
+## / `call DelayFrame` puts the whole screen at the starting offset, with no
+## band written yet. Crystal delays nowhere before its own loop, so it has none.
+const GOLD_LEAD_FRAMES: int = 1
+
+var _crystal: bool = true
+var _frame: int = 0
+
+
+## The intro for [param data]'s own game.
+static func for_data(data: GameData) -> Gen2BattleIntro:
+	return create(Gen2WorldState.is_crystal_profile(data))
+
+
+static func create(crystal: bool) -> Gen2BattleIntro:
+	var intro := Gen2BattleIntro.new()
+	intro._crystal = crystal
+	return intro
+
+
+## How many frames the whole slide is on screen for. Both games take the same
+## number, by different arithmetic.
+func frames() -> int:
+	return CRYSTAL_FRAMES if _crystal else GOLD_LEAD_FRAMES + GOLD_LOOP_FRAMES
+
+
+func finished() -> bool:
+	return _frame >= frames()
+
+
+## One hardware frame. Answers whether the screen should be redrawn, which is
+## every frame of the walk and the one that ends it, since the settle to zero is
+## a change like any other.
+func advance_frame() -> bool:
+	if finished():
+		return false
+	_frame += 1
+	return true
+
+
+## The background offset for every scanline, in the order the hardware draws
+## them. An offset is a distance to look *right* into the background map, so a
+## larger one puts the drawn scene further left.
+func offsets() -> PackedInt32Array:
+	var out: PackedInt32Array = PackedInt32Array()
+	out.resize(HEIGHT)
+	if finished():
+		out.fill(0)
+		return out
+
+	var top: int = _top_offset()
+	var middle: int = _middle_offset()
+	var top_rows: int = CRYSTAL_TOP_ROWS if _crystal else GOLD_TOP_ROWS
+	var middle_rows: int = CRYSTAL_MIDDLE_ROWS if _crystal else GOLD_MIDDLE_ROWS
+	for row: int in HEIGHT:
+		if row < top_rows:
+			out[row] = top
+		elif row < top_rows + middle_rows:
+			out[row] = middle
+		else:
+			# Gold and Silver's lead frame is the whole screen at the starting
+			# offset: `rSCX` still holds it and nothing has written a band yet.
+			out[row] = GOLD_TOP_START if _is_gold_lead() else 0
+	return out
+
+
+## Whether this is Gold and Silver's pre-loop frame, which has no bands at all.
+func _is_gold_lead() -> bool:
+	return not _crystal and _frame < GOLD_LEAD_FRAMES
+
+
+## Crystal steps its top band every frame, `ld d, $90` down by two.
+##
+## Gold and Silver write theirs to `hSCX`, which the VBlank handler copies to
+## `rSCX` only after the frame it was written during, so their top band trails
+## the middle one by a frame: the lead frame and the loop's own first frame both
+## show the starting offset. Crystal's two bands come out of one table and lag
+## together, so only Gold's separate writes make a lag visible.
+func _top_offset() -> int:
+	if _crystal:
+		return posmod(CRYSTAL_TOP_START - STEP * _frame, MAP_WIDTH)
+	var stepped: int = maxi(_frame - GOLD_LEAD_FRAMES, 0)
+	return posmod(GOLD_TOP_START - STEP * maxi(stepped - 1, 0), MAP_WIDTH)
+
+
+## Both middle bands step every frame of their own loop, `$72` and `$70` up by
+## two. Crystal's runs past the end of a byte and wraps, which is why it lands
+## on 2 rather than on nothing.
+func _middle_offset() -> int:
+	if _crystal:
+		return posmod(CRYSTAL_MIDDLE_START + STEP * _frame, MAP_WIDTH)
+	if _is_gold_lead():
+		return GOLD_TOP_START
+	return posmod(GOLD_MIDDLE_START + STEP * (_frame - GOLD_LEAD_FRAMES), MAP_WIDTH)

--- a/game/battle/battle_intro.gd.uid
+++ b/game/battle/battle_intro.gd.uid
@@ -1,0 +1,1 @@
+uid://dmhj32so0sl4c

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -10,6 +10,12 @@ extends Control
 ## index 0 transparent: a panel is a shape on a white field, drawn into the
 ## background layer on hardware, so the pics show through everything that is not
 ## ink.
+##
+## Every layer here is part of that one background plane, so a scroll applies to
+## all of them alike: [member Gen2BattleIntro] hands the screen a per-scanline
+## offset and each layer is scrolled through [Gen2Raster] by the same one. That
+## is the same answer as scrolling a single merged buffer would give, and it
+## keeps a palette per layer, which the hardware's per-tile palettes need.
 
 ## Where the two pics sit, in tiles.
 const ENEMY_PIC: Vector2i = Vector2i(12, 0)
@@ -71,13 +77,22 @@ func refresh() -> void:
 		_enemy_pic, _data.species_pic(int(_view.get("enemy_species", 0))),
 		_data.palette(int(_view.get("enemy_species", 0))), ENEMY_PIC
 	)
-	_draw_pic(
-		_player_pic, _data.species_pic(int(_view.get("player_species", 0)), true),
-		_data.palette(int(_view.get("player_species", 0))), PLAYER_PIC
-	)
+	# `InitBattleDisplay` places the player's back pic with `PlaceGraphic` only
+	# after `BattleIntroSlidingPics` has returned, so it is not on the map to be
+	# scrolled and is simply not there yet.
+	if bool(_view.get("player_pic_visible", true)):
+		_draw_pic(
+			_player_pic, _data.species_pic(int(_view.get("player_species", 0)), true),
+			_data.palette(int(_view.get("player_species", 0))), PLAYER_PIC
+		)
+	else:
+		_player_pic.texture = null
 	_draw_panels()
 
 
+## A pic is drawn into a screen-sized layer rather than a rectangle placed at
+## its own corner, because a scroll wraps at the background map's width and so
+## needs to know where the screen ends.
 func _draw_pic(
 	into: TextureRect, pic: Dictionary, palette: PackedColorArray, at: Vector2i
 ) -> void:
@@ -87,9 +102,13 @@ func _draw_pic(
 	var image: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
 	)
-	into.texture = ImageTexture.create_from_image(image)
-	into.size = image.get_size()
-	into.position = Vector2(at.x * TILE, at.y * TILE)
+	var layer: Image = Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, image.get_format()
+	)
+	layer.blit_rect(
+		image, Rect2i(Vector2i.ZERO, image.get_size()), Vector2i(at.x * TILE, at.y * TILE)
+	)
+	_show_image(into, layer)
 
 
 ## The panels, and then each bar over them in its own colour.
@@ -149,11 +168,21 @@ func _new_buffer() -> PackedByteArray:
 func _show_layer(
 	into: TextureRect, indices: PackedByteArray, palette: PackedColorArray
 ) -> void:
-	var image: Image = Gen2PicImage.from_indices(
+	_show_image(into, Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
-	)
+	))
+
+
+## One background layer, scrolled by whatever the view is asking for. An empty
+## or absent offset list is a background sitting still, which is every frame
+## outside the intro.
+func _show_image(into: TextureRect, image: Image) -> void:
+	var offsets: PackedInt32Array = PackedInt32Array(_view.get("raster_scx", []))
+	if not offsets.is_empty():
+		image = Gen2Raster.scroll(image, offsets, Gen2BattleIntro.MAP_WIDTH)
 	into.texture = ImageTexture.create_from_image(image)
 	into.size = image.get_size()
+	into.position = Vector2.ZERO
 
 
 ## An HP bar is green, yellow or red by how much of it is lit rather than by the

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -141,12 +141,18 @@ var _last_message: String = ""
 var _bars: Dictionary = {}
 ## The running [Gen2ExpBarAnimation], or null when the exp bar is not filling.
 var _exp_bar: Gen2ExpBarAnimation = null
+## The running [Gen2BattleIntro], or null once the pics have slid into place.
+var _intro: Gen2BattleIntro = null
+## What `BattleStartMessage` will say. It is held for the whole slide, because
+## `InitBattleDisplay` returns before it is called and the box drawn before the
+## slide is an empty one.
+var _intro_message: String = ""
 ## The text the event pump produced while a bar was still draining. The source
 ## prints it after the bar arrives, since `applydamage` runs before
 ## `criticaltext` and `supereffectivetext`.
 var _held_message: String = ""
-## Leftover of a hardware frame the bars have not counted yet.
-var _bar_elapsed: float = 0.0
+## Leftover of a hardware frame the bars and the intro have not counted yet.
+var _frame_elapsed: float = 0.0
 ## What the overworld clock said when the battle started, for the three heals
 ## that read it. Only the world path supplies one; the development drivers below
 ## leave [Gen2Battle] at its own midday default.
@@ -191,17 +197,33 @@ var _box: Gen2TextBox = null
 @onready var _screen: Gen2Screen = %Screen
 
 
-## Bars drain on hardware frames, not on rendered ones, the same reason
-## [Gen2WorldAnimation] paces the overworld that way: the two-frame step
-## `HPBarAnim_BGMapUpdate` waits is a hardware frame count.
+## Bars drain and the intro slides on hardware frames, not on rendered ones, the
+## same reason [Gen2WorldAnimation] paces the overworld that way: the two-frame
+## step `HPBarAnim_BGMapUpdate` waits and `BattleIntroSlidingPics`' own
+## `DelayFrame` are both hardware frame counts.
 func _process(delta: float) -> void:
-	if not bars_animating():
-		_bar_elapsed = 0.0
+	if not frames_running():
+		_frame_elapsed = 0.0
 		return
-	_bar_elapsed += delta
-	while _bar_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and bars_animating():
-		_bar_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
-		advance_bars()
+	_frame_elapsed += delta
+	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and frames_running():
+		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_frame()
+
+
+## Whether anything is counting hardware frames right now. Public with
+## [method advance_frame] so a test or a screenshot driver can settle the screen
+## without waiting on real time.
+func frames_running() -> bool:
+	return bars_animating() or _intro != null
+
+
+## One hardware frame of everything that counts them. Public through
+## [method advance_bars] and [method advance_intro] so a test or a screenshot
+## driver can settle either without waiting on real time.
+func advance_frame() -> bool:
+	var moved: bool = advance_intro()
+	return advance_bars() or moved
 
 
 func _ready() -> void:
@@ -284,11 +306,7 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 	if _battle == null:
 		return
 
-	set_hp(
-		_battle.enemy.hp, _battle.enemy.max_hp(),
-		_battle.player.hp, _battle.player.max_hp()
-	)
-	_refresh_exp_bar()
+	_init_battle_display()
 
 
 ## Puts the player against one of a trainer class's own trainers, built from the
@@ -329,11 +347,7 @@ func show_trainer(
 		return
 	_battle.load_trainer_items(trainer_class)
 
-	set_hp(
-		_battle.enemy.hp, _battle.enemy.max_hp(),
-		_battle.player.hp, _battle.player.max_hp()
-	)
-	_refresh_exp_bar()
+	_init_battle_display()
 
 	var trainer: Dictionary = _data.trainer_party(trainer_class, index)
 	show_message("%s %s wants to fight!" % [
@@ -372,11 +386,7 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 	if _battle == null:
 		_save_slot = -1
 		return false
-	set_hp(
-		_battle.enemy.hp, _battle.enemy.max_hp(),
-		_battle.player.hp, _battle.player.max_hp()
-	)
-	_refresh_exp_bar()
+	_init_battle_display()
 	return true
 
 
@@ -420,11 +430,7 @@ func start_world_battle(request: Dictionary, save: Gen2SaveData = null) -> bool:
 	_player_level = player_party_ready.active_mon().level
 	_enemy = enemy_party_ready.active_mon().species
 	_enemy_level = enemy_party_ready.active_mon().level
-	set_hp(
-		_battle.enemy.hp, _battle.enemy.max_hp(),
-		_battle.player.hp, _battle.player.max_hp()
-	)
-	_refresh_exp_bar()
+	_init_battle_display()
 
 	if _world_battle_tutorial:
 		show_message("Gotcha! %s was caught!" % _name_of(_enemy))
@@ -563,6 +569,46 @@ func bars_animating() -> bool:
 	return not _bars.is_empty() or _exp_bar != null
 
 
+## Whether the two pics are still sliding into place.
+func intro_running() -> bool:
+	return _intro != null
+
+
+## `InitBattleDisplay`: the display a battle opens with, and the slide that puts
+## it there. Every caller that has just built a battle reaches this, which is the
+## same order the source uses, `InitBattleDisplay` before `BattleStartMessage`.
+func _init_battle_display() -> void:
+	set_hp(
+		_battle.enemy.hp, _battle.enemy.max_hp(),
+		_battle.player.hp, _battle.player.max_hp()
+	)
+	_refresh_exp_bar()
+	_intro = Gen2BattleIntro.for_data(_data)
+	_intro_message = ""
+	_push_view()
+
+
+## One hardware frame of the intro. Public so a test or a screenshot driver can
+## settle it without waiting on real time.
+func advance_intro() -> bool:
+	if _intro == null:
+		return false
+	if not _intro.advance_frame():
+		return false
+	if _intro.finished():
+		# `InitBattleDisplay`'s own `xor a` / `ldh [hSCX], a` after the call, and
+		# then `BattleStartMessage`.
+		_intro = null
+		_push_view()
+		if not _intro_message.is_empty():
+			var text: String = _intro_message
+			_intro_message = ""
+			show_message(text)
+		return true
+	_push_view()
+	return true
+
+
 ## One hardware frame of every running bar. Public so a test or a screenshot
 ## driver can settle the bars without waiting on real time.
 func advance_bars() -> bool:
@@ -676,6 +722,12 @@ func _start_exp_bar(event: Dictionary, from_pixels: int) -> void:
 
 
 func show_message(text: String) -> void:
+	# `BattleStartMessage` is called after `InitBattleDisplay` returns, so
+	# nothing is said while the pics are still sliding: the box drawn before the
+	# slide is an empty one.
+	if _intro != null:
+		_intro_message = text
+		return
 	_last_message = text
 	if _box != null:
 		_box.show_text(text)
@@ -1120,6 +1172,10 @@ func _confirm_forget_slot() -> void:
 ## starts a turn when there is nothing left to say.
 func advance() -> void:
 	if _box == null:
+		return
+	## `BattleIntroSlidingPics` is a run of unconditional `DelayFrame`s with
+	## nothing reading a button, so a press during the slide does nothing at all.
+	if _intro != null:
 		return
 	## The exp bar stopped at a level boundary is under `.LoopLevels`' own
 	## `StdBattleTextbox`, which blocks on a button: this press is that button,
@@ -1834,7 +1890,30 @@ func _push_view() -> void:
 		"enemy_hp": _drawn_hp(Gen2Battle.ENEMY), "enemy_max_hp": _enemy_max_hp,
 		"player_hp": _drawn_hp(Gen2Battle.PLAYER), "player_max_hp": _player_max_hp,
 		"exp_pixels": _drawn_exp(),
+		## The background's own scroll, a value per scanline, empty when it is
+		## sitting still. `PlaceGraphic` puts the player's back pic up only after
+		## the slide has returned, so during it there is nothing to draw there.
+		"raster_scx": _raster_offsets(),
+		"player_pic_visible": _intro == null,
 	})
+	if _box != null:
+		_box.raster_scx = _box_raster_offsets()
+
+
+## The background scroll for the whole screen, which only the intro ever asks
+## for.
+func _raster_offsets() -> PackedInt32Array:
+	return PackedInt32Array() if _intro == null else _intro.offsets()
+
+
+## The same scroll, narrowed to the rows the text box occupies. A box is drawn
+## into the background plane like everything else, so `Textbox`'s own rows move
+## with whatever moves the plane.
+func _box_raster_offsets() -> PackedInt32Array:
+	if _intro == null:
+		return PackedInt32Array()
+	var top: int = Gen2TextBox.STANDARD_TOP * Gen2Font.TILE
+	return _intro.offsets().slice(top, top + _box.rows * Gen2Font.TILE)
 
 
 func _name_of(species: int) -> String:

--- a/game/render/raster.gd
+++ b/game/render/raster.gd
@@ -1,0 +1,61 @@
+class_name Gen2Raster
+extends RefCounted
+
+## A background scrolled by a different amount on each scanline, which is what
+## the hardware's `SCX` is once a routine rewrites it part way down a frame.
+##
+## The background map is wider than the screen, [param map_width] against the
+## image's own width, and everything past what was drawn is blank. So an offset
+## does not slide an image sideways and leave a gap: it wraps, and blank is what
+## comes in. An offset is a distance to look *right* into the map, so a larger
+## one puts the drawn content further left.
+##
+## Node-free and pure: it takes an image and answers a new one, which is what
+## lets a scroll be asserted headless rather than photographed.
+
+## Rows sharing an offset are moved together, since a run of scanlines with one
+## value is the shape every routine that does this produces: three bands for
+## `BattleIntroSlidingPics`, one for a whole-screen scroll.
+static func scroll(
+	source: Image, offsets: PackedInt32Array, map_width: int
+) -> Image:
+	var width: int = source.get_width()
+	var height: int = source.get_height()
+	if width <= 0 or height <= 0 or map_width <= 0 or offsets.size() < height:
+		return source
+
+	var out: Image = Image.create_empty(width, height, false, source.get_format())
+	var row: int = 0
+	while row < height:
+		var offset: int = posmod(offsets[row], map_width)
+		var run: int = 1
+		while row + run < height and posmod(offsets[row + run], map_width) == offset:
+			run += 1
+		_scroll_run(source, out, row, run, offset, map_width)
+		row += run
+	return out
+
+
+## One run of scanlines at one offset. The visible row is at most two pieces of
+## the drawn image with blank between them, since the map is the image followed
+## by blank up to [param map_width] and then round again.
+static func _scroll_run(
+	source: Image, out: Image, row: int, run: int, offset: int, map_width: int
+) -> void:
+	if offset == 0:
+		out.blit_rect(source, Rect2i(0, row, source.get_width(), run), Vector2i(0, row))
+		return
+
+	var width: int = source.get_width()
+	# What is still on screen of the drawn image, pushed left by the offset.
+	var kept: int = clampi(width - offset, 0, width)
+	if kept > 0:
+		out.blit_rect(source, Rect2i(offset, row, kept, run), Vector2i(0, row))
+
+	# What has come round the far side of the map. The gap between the two is
+	# the map's blank columns, which the empty image already is.
+	var wrapped: int = clampi(offset + width - map_width, 0, width)
+	if wrapped > 0:
+		out.blit_rect(
+			source, Rect2i(0, row, wrapped, run), Vector2i(map_width - offset, row)
+		)

--- a/game/render/raster.gd.uid
+++ b/game/render/raster.gd.uid
@@ -1,0 +1,1 @@
+uid://bu4paf55ilgdp

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -36,6 +36,14 @@ const TILE: int = Gen2Font.TILE
 ## Tiles per second while a page is revealing. The games run this off the frame
 ## counter; a rate is the same thing said in a way that does not assume 60 Hz.
 @export var reveal_speed: float = 30.0
+## Per-scanline background offsets for the box's own rows, empty when the
+## background is sitting still. A box is drawn into the background plane like
+## everything else, so a routine that scrolls the plane scrolls the box with it;
+## see [Gen2Raster].
+@export var raster_scx: PackedInt32Array = PackedInt32Array():
+	set(value):
+		raster_scx = value
+		_redraw()
 @export var columns: int = STANDARD_COLUMNS
 @export var rows: int = STANDARD_ROWS
 @export_range(0, 7) var frame_style: int = 0
@@ -163,6 +171,8 @@ func _redraw() -> void:
 		indices, width, height,
 		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 	)
+	if not raster_scx.is_empty():
+		image = Gen2Raster.scroll(image, raster_scx, Gen2BattleIntro.MAP_WIDTH)
 	texture = ImageTexture.create_from_image(image)
 	size = Vector2(width, height)
 

--- a/tests/integration/test_battle_move_forget.gd
+++ b/tests/integration/test_battle_move_forget.gd
@@ -63,12 +63,13 @@ func _open_with_full_moveset(third_move: int = BattleFixture.THUNDERBOLT) -> voi
 ## Presses through every queued event until the offer opens, which is what a
 ## player pressing A does.
 ## A draining HP bar swallows a press, the way `AnimateHPBar`'s own loop does,
-## so the bar is walked to its end before the next one. In play the screen's
-## frames do this; a test that pressed without it would stall on the first hit.
+## and so does the opening slide, so both are walked to their end before the
+## next press. In play the screen's frames do this; a test that pressed without
+## it would stall on the intro and then on the first hit.
 func _settle_bars() -> void:
 	var guard: int = 4000
-	while _screen.bars_animating() and guard > 0:
-		_screen.advance_bars()
+	while _screen.frames_running() and guard > 0:
+		_screen.advance_frame()
 		guard -= 1
 
 

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -32,6 +32,16 @@ func _open_battle() -> void:
 	await get_tree().process_frame
 
 
+## `BattleIntroSlidingPics` runs before `BattleStartMessage`, so a battle says
+## and does nothing until the pics are in place. In play the screen's own frames
+## spend that; a test driving events without it would drive them into the slide.
+func _settle_intro() -> void:
+	var guard: int = 4000
+	while _battle_screen.intro_running() and guard > 0:
+		_battle_screen.advance_frame()
+		guard -= 1
+
+
 func _stub_script(body: String) -> GDScript:
 	var script := GDScript.new()
 	script.source_code = body
@@ -134,6 +144,7 @@ func uses_hardware_viewport() -> bool:
 func test_a_hit_drains_the_bar_before_it_says_what_the_hit_was() -> void:
 	await _open_battle()
 	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
 	_battle_screen.set_hp(48, 48, 40, 40)
 
 	_battle_screen._pending = [{
@@ -182,6 +193,7 @@ func test_a_new_pokemon_does_not_animate_its_bar_up() -> void:
 func test_experience_says_its_line_first_and_the_level_line_after_the_bar() -> void:
 	await _open_battle()
 	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
 
 	var mon: Gen2BattleMon = _battle_screen._battle.player
 	var rate: int = mon.growth_rate()
@@ -266,3 +278,55 @@ func test_a_benched_gainer_animates_no_bar() -> void:
 		"species": mon.species, "amount": 40, "exp": mon.exp, "exp_share": true,
 	})
 	assert_false(_battle_screen.bars_animating())
+
+
+## `InitBattleDisplay` runs `BattleIntroSlidingPics` and only then does
+## `BattleStartMessage` say anything, so a battle opens on an empty box with the
+## background sliding, and the player's back pic is not on the map at all until
+## `PlaceGraphic` puts it there after the slide.
+func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_battle_screen.show_message("Wild PIDGEY appeared!")
+
+	assert_true(_battle_screen.intro_running())
+	assert_eq(String(_battle_screen.battle_snapshot()["message"]), "", "the box is empty")
+
+	var view: Dictionary = _battle_screen._renderer._view
+	assert_false(bool(view["player_pic_visible"]), "the back pic is not placed yet")
+	var offsets: PackedInt32Array = PackedInt32Array(view["raster_scx"])
+	assert_eq(offsets.size(), Gen2Screen.HEIGHT)
+	assert_ne(offsets[0], 0, "and the background is somewhere else entirely")
+
+	# The slide is a run of unconditional `DelayFrame`s with nothing reading a
+	# button, so a press does nothing at all.
+	_battle_screen.advance()
+	assert_true(_battle_screen.intro_running())
+
+	_settle_intro()
+	assert_eq(
+		String(_battle_screen.battle_snapshot()["message"]), "Wild PIDGEY appeared!",
+		"the start message waited for the slide"
+	)
+	var settled: Dictionary = _battle_screen._renderer._view
+	assert_true(bool(settled["player_pic_visible"]))
+	assert_true(PackedInt32Array(settled["raster_scx"]).is_empty(), "and nothing is scrolled")
+
+
+## The text box is drawn into the background plane like everything else, so
+## Gold and Silver's lead frame, which puts the whole screen at the starting
+## offset, takes the box with it.
+func test_the_text_box_is_scrolled_with_the_rest_of_the_background() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+
+	var box: Gen2TextBox = _battle_screen._box
+	assert_eq(box.raster_scx.size(), box.rows * Gen2Font.TILE)
+	var offsets: PackedInt32Array = PackedInt32Array(
+		_battle_screen._renderer._view["raster_scx"]
+	)
+	var top: int = Gen2TextBox.STANDARD_TOP * Gen2Font.TILE
+	assert_eq(box.raster_scx[0], offsets[top], "the box takes its own rows of the scroll")
+
+	_settle_intro()
+	assert_true(box.raster_scx.is_empty())

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -66,10 +66,20 @@ func _trigger_trainer() -> void:
 	assert_not_null(_battle_host())
 
 
+## The battle overlay, with its opening slide walked to the end.
+##
+## `BattleIntroSlidingPics` runs before `BattleStartMessage`, so a battle says
+## nothing until the pics are in place. In play the screen's own frames spend
+## that; a test that read the box without it would read an empty one.
 func _battle_host() -> Gen2BattleScreen:
 	for child: Node in _world_screen.get_children():
 		if child is Gen2BattleScreen:
-			return child as Gen2BattleScreen
+			var host: Gen2BattleScreen = child as Gen2BattleScreen
+			var guard: int = 4000
+			while host.frames_running() and guard > 0:
+				host.advance_frame()
+				guard -= 1
+			return host
 	return null
 
 

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -1,0 +1,132 @@
+extends GutTest
+
+## `BattleIntroSlidingPics` (engine/battle/sliding_intro.asm), the one part of
+## the battle presentation the two games do not share.
+
+
+func _frame(intro: Gen2BattleIntro, index: int) -> PackedInt32Array:
+	for step: int in index:
+		intro.advance_frame()
+	return intro.offsets()
+
+
+func _settle(intro: Gen2BattleIntro, limit: int = 400) -> int:
+	var frames: int = 0
+	while not intro.finished() and frames < limit:
+		intro.advance_frame()
+		frames += 1
+	return frames
+
+
+## Crystal's `.subfunction5` writes 62 rows of `d`, 34 of `e` and 48 of zero,
+## which is the screen's own height. Gold and Silver rewrite `rSCX` at `rLY` 64
+## and 96 instead, so their bands are 64, 32 and 48.
+func test_each_game_has_its_own_bands() -> void:
+	var crystal: PackedInt32Array = Gen2BattleIntro.create(true).offsets()
+	assert_eq(crystal.size(), Gen2Screen.HEIGHT)
+	assert_eq(crystal[61], Gen2BattleIntro.CRYSTAL_TOP_START)
+	assert_eq(crystal[62], Gen2BattleIntro.CRYSTAL_MIDDLE_START, "the middle band starts at 62")
+	assert_eq(crystal[95], Gen2BattleIntro.CRYSTAL_MIDDLE_START)
+	assert_eq(crystal[96], 0, "and the bottom of the screen never moves")
+	assert_eq(crystal[Gen2Screen.HEIGHT - 1], 0)
+
+	# Gold and Silver's own first frame is the lead one, before any band exists.
+	var gold: PackedInt32Array = _frame(Gen2BattleIntro.create(false), 1)
+	assert_eq(gold[63], Gen2BattleIntro.GOLD_TOP_START)
+	assert_eq(gold[64], Gen2BattleIntro.GOLD_MIDDLE_START, "the middle band starts at 64")
+	assert_eq(gold[95], Gen2BattleIntro.GOLD_MIDDLE_START)
+	assert_eq(gold[96], 0)
+
+
+## `ld a, c` / `ldh [hSCX], a` / `call DelayFrame` before `.loop1` is a frame of
+## the whole screen at the starting offset, bottom band included. Crystal
+## delays nowhere before its own loop and so has no such frame.
+func test_only_gold_and_silver_lead_with_a_whole_screen_frame() -> void:
+	var gold: PackedInt32Array = Gen2BattleIntro.create(false).offsets()
+	assert_eq(gold[0], Gen2BattleIntro.GOLD_TOP_START)
+	assert_eq(gold[80], Gen2BattleIntro.GOLD_TOP_START, "the middle band is not written yet")
+	assert_eq(gold[Gen2Screen.HEIGHT - 1], Gen2BattleIntro.GOLD_TOP_START, "nor the bottom")
+
+	var crystal: PackedInt32Array = Gen2BattleIntro.create(true).offsets()
+	assert_eq(crystal[Gen2Screen.HEIGHT - 1], 0, "Crystal's bottom band is there from the start")
+
+
+## `dec d` twice against `inc e` twice: the two bands walk in opposite
+## directions, which is what makes the top and the middle of the screen come in
+## from opposite sides.
+func test_the_two_bands_walk_in_opposite_directions() -> void:
+	var intro := Gen2BattleIntro.create(true)
+	var first: PackedInt32Array = intro.offsets()
+	var second: PackedInt32Array = _frame(intro, 1)
+	assert_eq(second[0], first[0] - Gen2BattleIntro.STEP)
+	assert_eq(second[70], first[70] + Gen2BattleIntro.STEP)
+
+
+## Gold and Silver write their top band through `hSCX`, which is not copied to
+## `rSCX` until the frame it was written during has finished, so it trails the
+## middle band by a frame: the lead frame and the loop's first frame both show
+## the starting offset.
+func test_the_gold_top_band_trails_its_middle_one_by_a_frame() -> void:
+	var intro := Gen2BattleIntro.create(false)
+	assert_eq(_frame(intro, 1)[0], Gen2BattleIntro.GOLD_TOP_START)
+	assert_eq(intro.offsets()[80], Gen2BattleIntro.GOLD_MIDDLE_START)
+
+	assert_eq(_frame(intro, 1)[0], Gen2BattleIntro.GOLD_TOP_START, "still, one frame later")
+	assert_eq(intro.offsets()[80], Gen2BattleIntro.GOLD_MIDDLE_START + Gen2BattleIntro.STEP)
+
+	assert_eq(
+		_frame(intro, 1)[0], Gen2BattleIntro.GOLD_TOP_START - Gen2BattleIntro.STEP,
+		"and only then does the top move"
+	)
+
+
+## `$48 + 1` frames for Crystal, and for Gold and Silver the 72 that `dec c`
+## twice takes from `$90` to zero, plus their lead frame. The same number, by
+## different arithmetic.
+func test_both_games_take_the_same_number_of_frames() -> void:
+	assert_eq(Gen2BattleIntro.create(true).frames(), Gen2BattleIntro.CRYSTAL_FRAMES)
+	assert_eq(Gen2BattleIntro.create(false).frames(), Gen2BattleIntro.CRYSTAL_FRAMES)
+	assert_eq(_settle(Gen2BattleIntro.create(true)), Gen2BattleIntro.CRYSTAL_FRAMES)
+	assert_eq(_settle(Gen2BattleIntro.create(false)), Gen2BattleIntro.CRYSTAL_FRAMES)
+
+
+## Neither game's walk lands on zero. Crystal's `e` runs past the end of a byte
+## and wraps to 2; Gold's `c` is a frame behind and stops at 4. What settles the
+## screen is `InitBattleDisplay`'s own `xor a` / `ldh [hSCX], a` after the call.
+func test_the_last_frame_is_short_and_the_settle_is_the_caller_s() -> void:
+	var crystal := Gen2BattleIntro.create(true)
+	var last: PackedInt32Array = _frame(crystal, Gen2BattleIntro.CRYSTAL_FRAMES - 1)
+	assert_eq(last[0], 0, "Crystal's top band does reach home")
+	assert_eq(last[70], 2, "its middle one wraps to 2 rather than reaching it")
+
+	var gold := Gen2BattleIntro.create(false)
+	var gold_last: PackedInt32Array = _frame(gold, Gen2BattleIntro.CRYSTAL_FRAMES - 1)
+	assert_eq(gold_last[0], 4, "Gold's top band is still four out")
+	assert_eq(gold_last[80], 254, "and its middle one two, the other way round")
+
+	for intro: Gen2BattleIntro in [crystal, gold]:
+		intro.advance_frame()
+		assert_true(intro.finished())
+		var settled: PackedInt32Array = intro.offsets()
+		assert_eq(settled[0], 0)
+		assert_eq(settled[80], 0)
+		assert_false(intro.advance_frame(), "a finished intro never ticks")
+
+
+## The offsets are read straight back through [Gen2Raster], so a band edge falls
+## where the walk says it does rather than where a layer happens to end.
+func test_the_middle_band_cuts_through_the_player_panel() -> void:
+	# The player's panel runs from its name row to the bottom of its exp bar.
+	var top: int = Gen2BattleHud.PLAYER_NAME.y * Gen2BattleHud.TILE
+	var bottom: int = (Gen2BattleHud.PLAYER_EXP.y + 1) * Gen2BattleHud.TILE
+
+	for crystal: bool in [true, false]:
+		var edge: int = Gen2BattleIntro.CRYSTAL_TOP_ROWS if crystal \
+			else Gen2BattleIntro.GOLD_TOP_ROWS
+		assert_between(edge, top + 1, bottom - 1, "the band edge is inside the panel")
+
+		var offsets: PackedInt32Array = _frame(Gen2BattleIntro.create(crystal), 4)
+		assert_ne(
+			offsets[top], offsets[bottom - 1],
+			"so one panel is drawn in two places at once, which is why this is per scanline"
+		)

--- a/tests/unit/test_battle_intro.gd.uid
+++ b/tests/unit/test_battle_intro.gd.uid
@@ -1,0 +1,1 @@
+uid://bgeeq2kkp0v4b

--- a/tests/unit/test_raster.gd
+++ b/tests/unit/test_raster.gd
@@ -1,0 +1,88 @@
+extends GutTest
+
+## A background scrolled per scanline, over a map wider than the screen.
+
+const WIDTH: int = Gen2Screen.WIDTH
+const HEIGHT: int = Gen2Screen.HEIGHT
+const MAP: int = Gen2BattleIntro.MAP_WIDTH
+
+
+## Every column is its own colour, so where a pixel came from can be read back
+## off the pixel.
+func _numbered() -> Image:
+	var image: Image = Image.create_empty(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
+	for y: int in HEIGHT:
+		for x: int in WIDTH:
+			image.set_pixel(x, y, Color8(x, 0, 0, 255))
+	return image
+
+
+func _flat(offset: int) -> PackedInt32Array:
+	var out: PackedInt32Array = PackedInt32Array()
+	out.resize(HEIGHT)
+	out.fill(offset)
+	return out
+
+
+## Which source column a screen column is showing, or -1 for the map's blank.
+func _source_column(image: Image, x: int, y: int = 0) -> int:
+	var pixel: Color = image.get_pixel(x, y)
+	return -1 if pixel.a <= 0.0 else int(round(pixel.r8))
+
+
+func test_no_offset_leaves_the_image_alone() -> void:
+	var out: Image = Gen2Raster.scroll(_numbered(), _flat(0), MAP)
+	assert_eq(_source_column(out, 0), 0)
+	assert_eq(_source_column(out, WIDTH - 1), WIDTH - 1)
+
+
+## An offset is a distance to look right into the map, so the drawn content
+## moves left and the map's blank columns follow it in.
+func test_an_offset_pushes_the_drawn_content_left_and_brings_blank_in() -> void:
+	var out: Image = Gen2Raster.scroll(_numbered(), _flat(40), MAP)
+	assert_eq(_source_column(out, 0), 40, "screen 0 shows map column 40")
+	assert_eq(_source_column(out, WIDTH - 41), WIDTH - 1, "the last drawn column, moved left")
+	assert_eq(_source_column(out, WIDTH - 40), -1, "and blank map behind it")
+	assert_eq(_source_column(out, WIDTH - 1), -1)
+
+
+## Past the map's own width the offset wraps, which is what brings the drawn
+## content back in on the other side. `BattleIntroSlidingPics` starts at $90,
+## which is already past the point where that happens.
+func test_an_offset_past_the_map_wraps_the_content_back_in() -> void:
+	var out: Image = Gen2Raster.scroll(_numbered(), _flat(0x90), MAP)
+	assert_eq(_source_column(out, 0), 0x90, "the right end of the drawn content")
+	assert_eq(_source_column(out, WIDTH - 0x90 - 1), WIDTH - 1, "up to its last column")
+	assert_eq(_source_column(out, WIDTH - 0x90), -1, "then the map's blank")
+
+	# 256 - 144 = 112: from there the map has come round to its own column 0.
+	assert_eq(_source_column(out, MAP - 0x90 - 1), -1)
+	assert_eq(_source_column(out, MAP - 0x90), 0, "and the content is back")
+	assert_eq(_source_column(out, WIDTH - 1), WIDTH - 1 - (MAP - 0x90))
+
+
+## An offset of the whole map is no offset at all.
+func test_an_offset_of_a_whole_map_is_the_image_itself() -> void:
+	var out: Image = Gen2Raster.scroll(_numbered(), _flat(MAP), MAP)
+	assert_eq(_source_column(out, 0), 0)
+	assert_eq(_source_column(out, WIDTH - 1), WIDTH - 1)
+
+
+## The point of doing this per scanline rather than per layer: two rows of the
+## same image can be in different places at once.
+func test_each_scanline_takes_its_own_offset() -> void:
+	var offsets: PackedInt32Array = _flat(0)
+	for row: int in HEIGHT:
+		offsets[row] = 8 if row < 10 else 24
+	var out: Image = Gen2Raster.scroll(_numbered(), offsets, MAP)
+	assert_eq(_source_column(out, 0, 0), 8)
+	assert_eq(_source_column(out, 0, 9), 8)
+	assert_eq(_source_column(out, 0, 10), 24)
+	assert_eq(_source_column(out, 0, HEIGHT - 1), 24)
+
+
+## A caller that has no offsets for every row gets its image back rather than a
+## partly scrolled one.
+func test_a_short_offset_list_scrolls_nothing() -> void:
+	var out: Image = Gen2Raster.scroll(_numbered(), PackedInt32Array([4, 4]), MAP)
+	assert_eq(_source_column(out, 0), 0)

--- a/tests/unit/test_raster.gd.uid
+++ b/tests/unit/test_raster.gd.uid
@@ -1,0 +1,1 @@
+uid://c30lbcym6d77c


### PR DESCRIPTION
`BattleIntroSlidingPics` does not move an object. It scrolls the background itself in horizontal bands, and it is the one part of the battle presentation the two games do not share: Crystal writes `wLYOverrides`, an HBlank table with a value per scanline, in runs of 62, 34 and 48 rows; pokegold busy-waits on `rLY` and writes `rSCX` at 64 and 96, after a lead frame Crystal has no counterpart for.

A band edge falls inside the player's own status panel in both games, so one panel is drawn in two places at once. `Gen2Raster` is the offset applied: the map is 256 pixels wide against the screen's 160 and `.BlankBGMap` leaves the rest blank, so an offset wraps and blank is what scrolls in. Every layer is part of that plane and takes the same offsets, the text box included.

`InitBattleDisplay` returns before `BattleStartMessage`, so a battle says nothing and reads no press until the pics are in place, and `PlaceGraphic` puts the player's back pic up only after the slide.