### PR TITLE
Read every move's animation out of the cartridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ to check without writing.
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
 | Wild encounters | Normal/swarm grass and water, 13 fishing groups with day/night substitutions, 16-row roaming graph, map-linked rates and slots, time-of-day selection, surf variance and repel checks |
 | World services | Referenced menus, mart inventories, phone contacts, special calls, bounded scripts/text, music, SFX, cries and shared waveform assets |
+| Battle animations | All 278 animation scripts, the 188 objects, 185 framesets and 216 OAM sets they are drawn from, and 39 decompressed graphics sheets |
 
 Sprites remain colour indices and receive a palette at draw time, so shiny
 rendering needs no duplicate images.
@@ -296,6 +297,7 @@ Headless tools, all against a real imported cache:
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
+| `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, and the 39 graphics sheets, in all three games |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -1,0 +1,322 @@
+class_name Gen2BattleAnimScript
+extends RefCounted
+
+## The battle animation command interpreter
+## (engine/battle_anims/anim_commands.asm).
+##
+## Scene-free like the rest of the battle layer: the screen ticks this once per
+## hardware frame and reads back the commands that ran, the way it ticks the
+## bars and the intro. Nothing here draws, plays a sound or touches a palette;
+## the commands are reported and whoever is drawing decides what they look like.
+##
+## A script is a byte stream in one bank. Anything below
+## [constant FIRST_COMMAND] is not a command at all: `RunBattleAnimCommand`
+## stores it in `wBattleAnimDelay` and `.CheckTimer` then decrements it once a
+## frame and runs nothing while it is non-zero, so `anim_wait N` is exactly N
+## frames of pause. Everything from [constant FIRST_COMMAND] up dispatches
+## through `BattleAnimCommands`, which is what [constant COMMANDS] is.
+##
+## The control-flow state is the cartridge's, which means one level of nesting
+## and no more: `anim_call` saves the return address in the single
+## `wBattleAnimParent` word and `anim_loop` counts in the single
+## `wBattleAnimLoops` byte, so a call inside a call or a loop inside a loop
+## loses the outer one. Both are reproduced rather than generalised.
+##
+## `wBattleAnimParam` is an input the battle engine writes before playing
+## (engine/battle/effect_commands.asm), and `wBattleAnimVar` is animation-local:
+## `ClearBattleAnims` zeroes `wLYOverrides` through `wBattleAnimEnd`, which
+## covers the var and not the param.
+
+## `FIRST_BATTLE_ANIM_CMD` (macros/scripts/battle_anims.asm). Every byte under it
+## is a delay.
+const FIRST_COMMAND: int = 0xD0
+
+## `BattleAnimCommands` in order, from [constant FIRST_COMMAND].
+##
+## The names are the jumptable's, not the macros': `$d9` assembles from
+## `anim_battlergfx_2row` but dispatches to `BattleAnimCmd_BattlerGFX_1Row`, and
+## `$da` the other way round. The routines are what run, so they are what the
+## commands are called here; the two are genuinely crosswise in both pins.
+##
+## `operands` is how many bytes follow the command byte. `target` is where the
+## low byte of a jump address sits inside them, or -1 for a command that never
+## branches.
+const COMMANDS: Array[Dictionary] = [
+	{"name": &"obj", "operands": 4, "target": -1},
+	{"name": &"gfx_1", "operands": 1, "target": -1},
+	{"name": &"gfx_2", "operands": 2, "target": -1},
+	{"name": &"gfx_3", "operands": 3, "target": -1},
+	{"name": &"gfx_4", "operands": 4, "target": -1},
+	{"name": &"gfx_5", "operands": 5, "target": -1},
+	{"name": &"inc_obj", "operands": 1, "target": -1},
+	{"name": &"set_obj", "operands": 2, "target": -1},
+	{"name": &"inc_bg_effect", "operands": 1, "target": -1},
+	{"name": &"battler_gfx_1row", "operands": 0, "target": -1},
+	{"name": &"battler_gfx_2row", "operands": 0, "target": -1},
+	{"name": &"check_pokeball", "operands": 0, "target": -1},
+	{"name": &"transform", "operands": 0, "target": -1},
+	{"name": &"raise_sub", "operands": 0, "target": -1},
+	{"name": &"drop_sub", "operands": 0, "target": -1},
+	{"name": &"reset_obp0", "operands": 0, "target": -1},
+	{"name": &"sound", "operands": 2, "target": -1},
+	{"name": &"cry", "operands": 1, "target": -1},
+	{"name": &"minimize_opp", "operands": 0, "target": -1},
+	{"name": &"oam_on", "operands": 0, "target": -1},
+	{"name": &"oam_off", "operands": 0, "target": -1},
+	{"name": &"clear_objs", "operands": 0, "target": -1},
+	{"name": &"beat_up", "operands": 0, "target": -1},
+	{"name": &"e7", "operands": 0, "target": -1},
+	{"name": &"update_actor_pic", "operands": 0, "target": -1},
+	{"name": &"minimize", "operands": 0, "target": -1},
+	{"name": &"ea", "operands": 0, "target": -1},
+	{"name": &"eb", "operands": 0, "target": -1},
+	{"name": &"ec", "operands": 0, "target": -1},
+	{"name": &"ed", "operands": 0, "target": -1},
+	{"name": &"if_param_and", "operands": 3, "target": 1},
+	{"name": &"jump_until", "operands": 2, "target": 0},
+	{"name": &"bg_effect", "operands": 4, "target": -1},
+	{"name": &"bgp", "operands": 1, "target": -1},
+	{"name": &"obp0", "operands": 1, "target": -1},
+	{"name": &"obp1", "operands": 1, "target": -1},
+	{"name": &"keep_sprites", "operands": 0, "target": -1},
+	{"name": &"f5", "operands": 0, "target": -1},
+	{"name": &"f6", "operands": 0, "target": -1},
+	{"name": &"f7", "operands": 0, "target": -1},
+	{"name": &"if_param_equal", "operands": 3, "target": 1},
+	{"name": &"set_var", "operands": 1, "target": -1},
+	{"name": &"inc_var", "operands": 0, "target": -1},
+	{"name": &"if_var_equal", "operands": 3, "target": 1},
+	{"name": &"jump", "operands": 2, "target": 0},
+	{"name": &"loop", "operands": 3, "target": 1},
+	{"name": &"call", "operands": 2, "target": 0},
+	{"name": &"ret", "operands": 0, "target": -1},
+]
+
+## The name a delay byte is reported under. Not a `BattleAnimCommands` entry:
+## `.RunScript` never reaches the jumptable for one.
+const WAIT: StringName = &"wait"
+
+const OBJ: StringName = &"obj"
+const SOUND: StringName = &"sound"
+const CRY: StringName = &"cry"
+const JUMP: StringName = &"jump"
+const LOOP: StringName = &"loop"
+const CALL: StringName = &"call"
+const RET: StringName = &"ret"
+const JUMP_UNTIL: StringName = &"jump_until"
+const IF_PARAM_AND: StringName = &"if_param_and"
+const IF_PARAM_EQUAL: StringName = &"if_param_equal"
+const IF_VAR_EQUAL: StringName = &"if_var_equal"
+const SET_VAR: StringName = &"set_var"
+const INC_VAR: StringName = &"inc_var"
+
+## How many commands one frame may run before the script is abandoned.
+##
+## The cartridge has no such limit: `.RunScript` loops until a delay byte or a
+## top-level `anim_ret`, and a script that does neither hangs the hardware. This
+## is ours, so a malformed cached region or a mod's own script costs a refused
+## animation rather than a frozen game. The worst shipped frame across all three
+## dumps runs seventeen commands.
+const MAX_COMMANDS_PER_FRAME: int = 256
+
+## Where the cached region starts, as the cartridge addresses it, and the bytes
+## themselves. Every pointer inside a script is bank-local and every byte is read
+## through `BANK(BattleAnimations)` (home/battle.asm, `GetBattleAnimByte`), so an
+## address resolves by subtraction and nothing has to model banking.
+var _region: PackedByteArray = PackedByteArray()
+var _base_address: int = 0
+
+var _address: int = 0
+var _parent: int = 0
+var _in_subroutine: bool = false
+var _in_loop: bool = false
+var _loops: int = 0
+var _delay: int = 0
+var _var: int = 0
+var _param: int = 0
+var _stopped: bool = false
+var _failed: bool = false
+
+
+## An interpreter positioned at [param address] inside [param region], which
+## starts at [param base_address].
+##
+## [param param] is `wBattleAnimParam`, which the caller sets before playing;
+## `wBattleAnimVar` starts at zero because `ClearBattleAnims` clears it.
+static func create(
+	region: PackedByteArray, base_address: int, address: int, param: int = 0
+) -> Gen2BattleAnimScript:
+	var script := Gen2BattleAnimScript.new()
+	script._region = region
+	script._base_address = base_address
+	script._address = address
+	script._param = param & 0xFF
+	script._stopped = not script._holds(address)
+	script._failed = script._stopped
+	return script
+
+
+## Decodes one command at [param address]. Returns
+## [code]{ ok, name, byte, operands, size, target }[/code]; `target` is the
+## address a branch would take, or -1. A delay byte answers [constant WAIT] with
+## its own value as its single operand.
+##
+## Shared with [Gen2BattleAnimImporter], which walks every body with it, so the
+## vocabulary is stated once.
+static func decode_command(
+	region: PackedByteArray, base_address: int, address: int
+) -> Dictionary:
+	var at: int = address - base_address
+	if at < 0 or at >= region.size():
+		return {"ok": false}
+	var byte: int = region[at]
+	if byte < FIRST_COMMAND:
+		return {
+			"ok": true, "name": WAIT, "byte": byte, "operands": [byte],
+			"size": 1, "target": -1,
+		}
+	var command: Dictionary = COMMANDS[byte - FIRST_COMMAND]
+	var count: int = int(command["operands"])
+	if at + 1 + count > region.size():
+		return {"ok": false}
+	var operands: Array[int] = []
+	for index: int in count:
+		operands.append(region[at + 1 + index])
+	var target: int = -1
+	var target_at: int = int(command["target"])
+	if target_at >= 0:
+		target = operands[target_at] | (operands[target_at + 1] << 8)
+	return {
+		"ok": true, "name": command["name"], "byte": byte, "operands": operands,
+		"size": 1 + count, "target": target,
+	}
+
+
+func finished() -> bool:
+	return _stopped
+
+
+## True when the script ran off the region or past
+## [constant MAX_COMMANDS_PER_FRAME]. A failed script is also finished.
+func failed() -> bool:
+	return _failed
+
+
+## Frames still owed before the next command runs: `wBattleAnimDelay`.
+func delay() -> int:
+	return _delay
+
+
+## Where the next byte will be read from, as the cartridge addresses it.
+func address() -> int:
+	return _address
+
+
+## `wBattleAnimVar`.
+func variable() -> int:
+	return _var
+
+
+## One hardware frame of `RunBattleAnimCommand`, as an Array of the commands it
+## ran, each [code]{ name, byte, operands }[/code].
+##
+## Empty while a delay is counting down, which is most frames, and empty once
+## the script has stopped. A frame that runs commands ends either on the delay
+## byte that set the next pause or on the `anim_ret` that ended the script, and
+## that terminating command is in the Array: `.RunScript` executed it.
+func advance_frame() -> Array:
+	if _stopped:
+		return []
+	if _delay > 0:
+		_delay -= 1
+		return []
+
+	var ran: Array = []
+	for _step: int in MAX_COMMANDS_PER_FRAME:
+		var command: Dictionary = decode_command(_region, _base_address, _address)
+		if not bool(command.get("ok", false)):
+			_fail()
+			return ran
+		_address += int(command["size"])
+		ran.append({
+			"name": command["name"], "byte": command["byte"], "operands": command["operands"],
+		})
+		if _execute(command):
+			return ran
+	_fail()
+	return ran
+
+
+## Runs one decoded command. Answers whether the frame ends here, which is what
+## a delay byte and a top-level `anim_ret` do.
+func _execute(command: Dictionary) -> bool:
+	var name: StringName = command["name"]
+	var operands: Array = command["operands"]
+	match name:
+		WAIT:
+			_delay = int(operands[0])
+			return true
+		RET:
+			# `.RunScript` reaches `BattleAnimCmd_Ret` only inside a subroutine;
+			# at the top level it sets BATTLEANIM_STOP_F without dispatching.
+			if _in_subroutine:
+				_in_subroutine = false
+				_address = _parent
+				return false
+			_stopped = true
+			return true
+		CALL:
+			_parent = _address
+			_in_subroutine = true
+			_address = int(command["target"])
+		JUMP:
+			_address = int(command["target"])
+		LOOP:
+			_run_loop(int(operands[0]), int(command["target"]))
+		JUMP_UNTIL:
+			# Spends `wBattleAnimParam` rather than keeping a counter of its own,
+			# so the caller decides how many times this goes round.
+			if _param > 0:
+				_param -= 1
+				_address = int(command["target"])
+		IF_PARAM_AND:
+			if (_param & int(operands[0])) != 0:
+				_address = int(command["target"])
+		IF_PARAM_EQUAL:
+			if int(operands[0]) == _param:
+				_address = int(command["target"])
+		IF_VAR_EQUAL:
+			if int(operands[0]) == _var:
+				_address = int(command["target"])
+		SET_VAR:
+			_var = int(operands[0])
+		INC_VAR:
+			_var = (_var + 1) & 0xFF
+	return false
+
+
+## `BattleAnimCmd_Loop`. A count of zero loops forever without ever claiming the
+## loop flag, so it re-reads its own zero every time round; any other count is
+## stored one lower, which is why `anim_loop 1` falls straight through.
+func _run_loop(count: int, target: int) -> void:
+	if not _in_loop:
+		if count == 0:
+			_address = target
+			return
+		_loops = count - 1
+		_in_loop = true
+	if _loops > 0:
+		_loops -= 1
+		_address = target
+		return
+	_in_loop = false
+
+
+func _holds(address: int) -> bool:
+	var at: int = address - _base_address
+	return at >= 0 and at < _region.size()
+
+
+func _fail() -> void:
+	_failed = true
+	_stopped = true

--- a/game/battle/battle_anim_script.gd.uid
+++ b/game/battle/battle_anim_script.gd.uid
@@ -1,0 +1,1 @@
+uid://bctvmeaakklpy

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -68,6 +68,7 @@ var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
 var _world_phone: Dictionary = {}
 var _world_audio: Dictionary = {}
+var _battle_anims_section: Dictionary = {}
 ## Which of the sections above have been read. A section that is genuinely empty
 ## is indistinguishable from one that has not been read yet, so the answer is
 ## recorded rather than inferred from the value.
@@ -405,6 +406,98 @@ func world_encounter_count(method: StringName) -> int:
 	var table_name: String = "water" if method == &"surf" else String(method)
 	var table: Variant = _encounters().get(table_name, {})
 	return (table as Dictionary).size() if table is Dictionary else 0
+
+
+## One battle animation region: the cached bytes plus the bank and address the
+## cartridge holds them at, so an in-bank pointer resolves by subtraction.
+##
+## [param name] is `scripts`, `objects`, `framesets` or `oam_sets`. Answers
+## [code]{ bank, address, count, data }[/code], empty when the section is absent
+## or the name is not one of the four.
+func battle_anim_region(name: StringName) -> Dictionary:
+	var value: Variant = _battle_anims().get(String(name), null)
+	if not value is Dictionary:
+		return {}
+	var region: Dictionary = value
+	return {
+		"bank": int(region.get("bank", -1)),
+		"address": int(region.get("address", -1)),
+		"count": int(region.get("count", 0)),
+		"data": _payload_bytes(region, _blob("battle_anims")),
+	}
+
+
+## Where one animation's script starts, as the cartridge addresses it, or -1
+## when the index is outside `BattleAnimations`.
+##
+## The table is the first bytes of the scripts region, so this reads it rather
+## than a copy: index 0 is `BattleAnim_Dummy` and the rest are move numbers.
+func battle_anim_address(index: int) -> int:
+	var region: Dictionary = battle_anim_region(&"scripts")
+	if region.is_empty() or index < 0 or index >= int(region["count"]):
+		return -1
+	var data: PackedByteArray = region["data"]
+	var at: int = index * 2
+	if at + 2 > data.size():
+		return -1
+	return data[at] | (data[at + 1] << 8)
+
+
+## One `battleanimobj` row as
+## [code]{ flags, y_fix, frameset, function, palette, gfx }[/code], empty when
+## the index is outside `BattleAnimObjects`.
+func battle_anim_object(index: int) -> Dictionary:
+	var region: Dictionary = battle_anim_region(&"objects")
+	if region.is_empty() or index < 0 or index >= int(region["count"]):
+		return {}
+	var data: PackedByteArray = region["data"]
+	var at: int = index * RomLayout.BATTLE_ANIM_OBJECT_SIZE
+	if at + RomLayout.BATTLE_ANIM_OBJECT_SIZE > data.size():
+		return {}
+	return {
+		"flags": data[at + Gen2BattleAnimImporter.OBJECT_FLAGS],
+		"y_fix": data[at + Gen2BattleAnimImporter.OBJECT_Y_FIX],
+		"frameset": data[at + Gen2BattleAnimImporter.OBJECT_FRAMESET],
+		"function": data[at + Gen2BattleAnimImporter.OBJECT_FUNCTION],
+		"palette": data[at + Gen2BattleAnimImporter.OBJECT_PALETTE],
+		"gfx": data[at + Gen2BattleAnimImporter.OBJECT_GFX],
+	}
+
+
+## One `AnimObjGFX` row as [code]{ tiles, bank, address, sheet }[/code]. `sheet`
+## is false for the three rows that name no graphics: index 0, which no
+## `anim_*gfx` reaches, and the two `NULL` rows the battler-graphics commands
+## fill in from the battler's own pic.
+func battle_anim_gfx(index: int) -> Dictionary:
+	var rows: Variant = _battle_anims().get("object_gfx", [])
+	if not rows is Array or index < 0 or index >= (rows as Array).size():
+		return {}
+	var row: Variant = (rows as Array)[index]
+	if not row is Dictionary:
+		return {}
+	return {
+		"tiles": int((row as Dictionary).get("tiles", 0)),
+		"bank": int((row as Dictionary).get("bank", 0)),
+		"address": int((row as Dictionary).get("address", 0)),
+		"sheet": bool((row as Dictionary).get("sheet", false)),
+	}
+
+
+func battle_anim_gfx_count() -> int:
+	var rows: Variant = _battle_anims().get("object_gfx", [])
+	return (rows as Array).size() if rows is Array else 0
+
+
+## Indexed pixels for one decompressed `AnimObjGFX` sheet, loaded on demand.
+func battle_anim_gfx_indices(index: int) -> PackedByteArray:
+	var key: String = "battle_anim_gfx/%d" % index
+	if _indices.has(key):
+		return _indices[key]
+	var data: PackedByteArray = RomCache.read_indices(
+		RomCache.battle_anim_gfx_path(directory, index)
+	)
+	_indices[key] = data
+	return data
 
 
 ## Metadata for one cartridge overworld sprite, indexed by the source sprite
@@ -1007,6 +1100,8 @@ func _section_json_path(section: String) -> String:
 			return RomCache.world_command_queues_path(directory)
 		"audio":
 			return RomCache.world_audio_path(directory)
+		"battle_anims":
+			return RomCache.battle_anims_path(directory)
 	return ""
 
 
@@ -1121,6 +1216,12 @@ func _audio() -> Dictionary:
 	if _claim_section("audio"):
 		_world_audio = _read_section(RomCache.world_audio_path(directory), false)
 	return _world_audio
+
+
+func _battle_anims() -> Dictionary:
+	if _claim_section("battle_anims"):
+		_battle_anims_section = _read_section(RomCache.battle_anims_path(directory), false)
+	return _battle_anims_section
 
 
 func _read_array(path: String) -> Array:

--- a/game/import/battle_anim_importer.gd
+++ b/game/import/battle_anim_importer.gd
@@ -1,0 +1,512 @@
+class_name Gen2BattleAnimImporter
+extends RefCounted
+
+## Imports the battle animation data layer: `BattleAnimations`
+## (data/moves/animations.asm) and the four tables in data/battle_anims that the
+## objects it spawns are built from.
+##
+## Each of the five is a pointer table immediately followed by the data it points
+## at, and every pointer inside one is bank-local, so each is cached as a whole
+## region rather than entry by entry: the bytes stay the cartridge's own and a
+## cached address resolves by subtraction. Nothing is rewritten on the way in.
+##
+## The three regions in bank $33 are contiguous and do not overlap: the frameset
+## streams end where `BattleAnimOAMData` begins and its sprite data ends where
+## `AnimObjGFX` begins. Each region is still measured from its own table's
+## pointers rather than from its neighbour, so a profile that moved one would
+## still import.
+##
+## Validation walks what it stores. Every script is run to a top-level
+## `anim_ret`, every frameset stream to its terminator and every table index is
+## range-checked before anything is written, which is what makes a wrong offset
+## a refused import rather than a screen full of noise.
+##
+## The object graphics are the exception: they are LZ streams reached by far
+## pointer, so they are decoded into tile strips the way the pics and the trainer
+## card's sheets are.
+
+## `BattleAnim_Pound` whole, the anchor the script table was located from. Held
+## here rather than in [RomLayout] because it is a check, not an offset: the
+## first entry of `BattleAnimations` is `BattleAnim_Dummy`, which is a bare
+## `anim_ret` and proves nothing.
+const POUND_BYTES: Array[int] = [
+	0xD1, 0x01, 0xE0, 0x01, 0x31, 0xD0, 0x08, 0x88, 0x38, 0x00,
+	0x06, 0xD0, 0x01, 0x88, 0x38, 0x00, 0x10, 0xFF,
+]
+## Which entry of `BattleAnimations` [constant POUND_BYTES] belongs to: POUND is
+## move 1, and the table is indexed by move number.
+const POUND_INDEX: int = 1
+
+## Runaway guards. Neither is the cartridge's, which walks both of these without
+## a limit; both sit well past the longest run in any of the three dumps, which
+## are a 185-byte animation body and a 31-byte frameset stream.
+const MAX_BODY_BYTES: int = 1024
+const MAX_FRAMESET_BYTES: int = 256
+
+## `oam_anims.asm`'s own commands. `FIRST_OAM_CMD` is $fc, so anything below it
+## is an `oamframe`'s OAM set id.
+const OAM_DELETE: int = 0xFC
+const OAM_WAIT: int = 0xFD
+const OAM_RESTART: int = 0xFE
+const OAM_END: int = 0xFF
+const FIRST_OAM_COMMAND: int = OAM_DELETE
+
+## Byte positions inside one `battleanimobj` row.
+const OBJECT_FLAGS: int = 0
+const OBJECT_Y_FIX: int = 1
+const OBJECT_FRAMESET: int = 2
+const OBJECT_FUNCTION: int = 3
+const OBJECT_PALETTE: int = 4
+const OBJECT_GFX: int = 5
+
+## Byte positions inside one `battleanimoam` row: vtile offset, sprite count,
+## then a two-byte pointer to that many `dbsprite` records.
+const OAM_SET_VTILE: int = 0
+const OAM_SET_LENGTH: int = 1
+const OAM_SET_POINTER: int = 2
+
+## Byte positions inside one `anim_obj_gfx` row: a tile count, then a `dba`.
+const GFX_TILES: int = 0
+const GFX_POINTER: int = 1
+
+## `NUM_BATTLE_ANIM_FUNCS` (constants/battle_anim_constants.asm), the callback
+## jumptable an object row indexes. The only part of that constants file the two
+## pins disagree on is `BATTLE_BG_EFFECT_*` from $25 on, which no table here
+## indexes, so all five counts are shared.
+const FUNCTION_COUNT: int = 80
+
+## `PAL_BATTLE_OB_*`, the eight object palettes a row can name.
+const PALETTE_COUNT: int = 8
+
+
+static func verify_layout(rom: RomFile) -> Dictionary:
+	var result: Dictionary = read_battle_anims(rom, RomLayout.for_id(rom.id))
+	if not bool(result.get("ok", false)):
+		return {
+			"ok": false,
+			"message": String(result.get("message", "Battle animation data failed validation.")),
+		}
+	return {"ok": true, "message": ""}
+
+
+static func import_to_cache(
+	rom: RomFile, layout: Dictionary, directory: String
+) -> Dictionary:
+	var result: Dictionary = read_battle_anims(rom, layout)
+	if not bool(result.get("ok", false)):
+		return result
+
+	var sheets: Dictionary = _decode_sheets(rom, result["anims"]["object_gfx"])
+	if not bool(sheets.get("ok", false)):
+		return sheets
+	for number: int in sheets["strips"]:
+		if not RomCache.write_indices(
+			RomCache.battle_anim_gfx_path(directory, number), sheets["strips"][number]
+		):
+			return {"ok": false, "message": "Could not write battle animation graphics."}
+
+	if not RomCache.write_section(
+		RomCache.battle_anims_path(directory),
+		RomCache.blob_path(RomCache.battle_anims_path(directory)),
+		result["anims"]
+	):
+		return {"ok": false, "message": "Could not write battle animation data."}
+
+	return {
+		"ok": true,
+		"scripts": int(result["counts"]["scripts"]),
+		"objects": int(result["counts"]["objects"]),
+		"framesets": int(result["counts"]["framesets"]),
+		"oam_sets": int(result["counts"]["oam_sets"]),
+		"gfx_sheets": int(sheets["sheets"]),
+		"gfx_tiles": int(sheets["tiles"]),
+	}
+
+
+## Reads and validates the whole layer. Returns
+## [code]{ ok, message, anims, counts }[/code].
+static func read_battle_anims(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if layout.is_empty():
+		return {"ok": false, "message": "No battle animation layout for %s." % rom.id}
+	var configured: Variant = layout.get("battle_anims", null)
+	if not configured is Dictionary:
+		return {"ok": false, "message": "Battle animation offsets are missing for %s." % rom.id}
+	var anim_layout: Dictionary = configured
+
+	var scripts: Dictionary = _read_scripts(rom, int(anim_layout["scripts"]))
+	if not bool(scripts.get("ok", false)):
+		return scripts
+
+	var framesets: Dictionary = _read_framesets(rom, int(anim_layout["framesets"]))
+	if not bool(framesets.get("ok", false)):
+		return framesets
+
+	var oam_sets: Dictionary = _read_oam_sets(rom, int(anim_layout["oam_sets"]))
+	if not bool(oam_sets.get("ok", false)):
+		return oam_sets
+
+	var object_gfx: Dictionary = _read_object_gfx(rom, int(anim_layout["object_gfx"]))
+	if not bool(object_gfx.get("ok", false)):
+		return object_gfx
+
+	var objects: Dictionary = _read_objects(rom, int(anim_layout["objects"]))
+	if not bool(objects.get("ok", false)):
+		return objects
+
+	return {
+		"ok": true,
+		"message": "",
+		"anims": {
+			"scripts": scripts["region"],
+			"objects": objects["region"],
+			"framesets": framesets["region"],
+			"oam_sets": oam_sets["region"],
+			"object_gfx": object_gfx["rows"],
+		},
+		"counts": {
+			"scripts": RomLayout.BATTLE_ANIM_SCRIPT_COUNT,
+			"objects": RomLayout.BATTLE_ANIM_OBJECT_COUNT,
+			"framesets": RomLayout.BATTLE_ANIM_FRAMESET_COUNT,
+			"oam_sets": RomLayout.BATTLE_ANIM_OAM_SET_COUNT,
+		},
+	}
+
+
+## `BattleAnimations` and every body it reaches, as one region.
+##
+## The walk follows calls and branches the way [Gen2BattleAnimScript] does, so a
+## body only some other body jumps into is still measured, and refuses anything
+## that leaves the bank or never reaches a top-level `anim_ret`.
+static func _read_scripts(rom: RomFile, table: int) -> Dictionary:
+	var count: int = RomLayout.BATTLE_ANIM_SCRIPT_COUNT
+	if not rom.in_bounds(table, count * 2):
+		return {"ok": false, "message": "Battle animation script table is outside the cartridge."}
+
+	var bank: int = table / RomFile.BANK_SIZE
+	var base: int = 0x4000 + (table % RomFile.BANK_SIZE)
+	var addresses: Array[int] = []
+	for index: int in count:
+		var address: int = rom.u16le(table + index * 2)
+		if address < 0x4000 or address >= 0x8000:
+			return {
+				"ok": false,
+				"message": "Battle animation %d points at $%04X, outside the bank." % [
+					index, address,
+				],
+			}
+		addresses.append(address)
+
+	# The whole bank, so a walk can reach anything the table can and the extent
+	# is measured rather than assumed. Only the reached span is kept.
+	var bank_bytes: PackedByteArray = rom.slice(bank * RomFile.BANK_SIZE, RomFile.BANK_SIZE)
+	if bank_bytes.size() != RomFile.BANK_SIZE:
+		return {"ok": false, "message": "Battle animation bank is outside the cartridge."}
+
+	# Content the offset is only trustworthy against: a table of the right shape
+	# in the wrong place still walks, because almost any byte run decodes as
+	# commands. POUND's animation is the same eighteen bytes in all three dumps.
+	var pound: int = addresses[POUND_INDEX] - 0x4000
+	if pound + POUND_BYTES.size() > bank_bytes.size():
+		return {"ok": false, "message": "Battle animation %d runs past the bank." % POUND_INDEX}
+	for index: int in POUND_BYTES.size():
+		if bank_bytes[pound + index] != POUND_BYTES[index]:
+			return {
+				"ok": false,
+				"message": "Battle animation %d is not POUND's: byte %d is $%02X, expected $%02X." % [
+					POUND_INDEX, index, bank_bytes[pound + index], POUND_BYTES[index],
+				],
+			}
+
+	var lowest: int = base
+	var highest: int = base + count * 2
+	var walked: Dictionary = {}
+	var pending: Array[int] = addresses.duplicate()
+	while not pending.is_empty():
+		var address: int = pending.pop_back()
+		if walked.has(address):
+			continue
+		walked[address] = true
+		var body: Dictionary = _walk_body(bank_bytes, address)
+		if not bool(body.get("ok", false)):
+			return body
+		lowest = mini(lowest, address)
+		highest = maxi(highest, int(body["end"]))
+		for target: int in body["targets"]:
+			pending.append(target)
+
+	return {
+		"ok": true,
+		"region": {
+			"bank": bank,
+			"address": lowest,
+			"count": count,
+			"bytes": _region_bytes(bank_bytes, lowest, highest),
+		},
+	}
+
+
+## One animation body, from [param address] to its `anim_ret`. Returns
+## [code]{ ok, end, targets }[/code], `end` being the address just past the ret.
+static func _walk_body(bank_bytes: PackedByteArray, address: int) -> Dictionary:
+	var targets: Array[int] = []
+	var at: int = address
+	var read: int = 0
+	while true:
+		read += 1
+		if read > MAX_BODY_BYTES:
+			return {
+				"ok": false,
+				"message": "Battle animation body at $%04X never ends." % address,
+			}
+		var command: Dictionary = Gen2BattleAnimScript.decode_command(bank_bytes, 0x4000, at)
+		if not bool(command.get("ok", false)):
+			return {
+				"ok": false,
+				"message": "Battle animation body at $%04X runs past the bank." % address,
+			}
+		at += int(command["size"])
+		var target: int = int(command["target"])
+		if target >= 0:
+			if target < 0x4000 or target >= 0x8000:
+				return {
+					"ok": false,
+					"message": "Battle animation body at $%04X branches to $%04X, outside the bank." % [
+						address, target,
+					],
+				}
+			targets.append(target)
+		if command["name"] == Gen2BattleAnimScript.RET:
+			break
+	return {"ok": true, "end": at, "targets": targets}
+
+
+## `BattleAnimObjects`, whose rows carry no pointers, so the region is the table
+## and nothing else.
+static func _read_objects(rom: RomFile, table: int) -> Dictionary:
+	var count: int = RomLayout.BATTLE_ANIM_OBJECT_COUNT
+	var size: int = count * RomLayout.BATTLE_ANIM_OBJECT_SIZE
+	if not rom.in_bounds(table, size):
+		return {"ok": false, "message": "Battle animation object table is outside the cartridge."}
+
+	for index: int in count:
+		var row: int = table + index * RomLayout.BATTLE_ANIM_OBJECT_SIZE
+		var frameset: int = rom.u8(row + OBJECT_FRAMESET)
+		if frameset >= RomLayout.BATTLE_ANIM_FRAMESET_COUNT:
+			return {
+				"ok": false,
+				"message": "Battle animation object %d names frameset %d, past the table." % [
+					index, frameset,
+				],
+			}
+		var function: int = rom.u8(row + OBJECT_FUNCTION)
+		if function >= FUNCTION_COUNT:
+			return {
+				"ok": false,
+				"message": "Battle animation object %d names callback %d, past the table." % [
+					index, function,
+				],
+			}
+		var palette: int = rom.u8(row + OBJECT_PALETTE)
+		if palette >= PALETTE_COUNT:
+			return {
+				"ok": false,
+				"message": "Battle animation object %d names palette %d, past the eight." % [
+					index, palette,
+				],
+			}
+		var gfx: int = rom.u8(row + OBJECT_GFX)
+		if gfx >= RomLayout.BATTLE_ANIM_GFX_COUNT:
+			return {
+				"ok": false,
+				"message": "Battle animation object %d names graphics %d, past the table." % [
+					index, gfx,
+				],
+			}
+
+	return {
+		"ok": true,
+		"region": {
+			"bank": table / RomFile.BANK_SIZE,
+			"address": 0x4000 + (table % RomFile.BANK_SIZE),
+			"count": count,
+			"bytes": _bytes_of(rom.slice(table, size)),
+		},
+	}
+
+
+## `BattleAnimFrameData` and the `oamframe` streams it points at, as one region.
+static func _read_framesets(rom: RomFile, table: int) -> Dictionary:
+	var count: int = RomLayout.BATTLE_ANIM_FRAMESET_COUNT
+	if not rom.in_bounds(table, count * 2):
+		return {"ok": false, "message": "Battle animation frameset table is outside the cartridge."}
+
+	var bank: int = table / RomFile.BANK_SIZE
+	var base: int = 0x4000 + (table % RomFile.BANK_SIZE)
+	var bank_bytes: PackedByteArray = rom.slice(bank * RomFile.BANK_SIZE, RomFile.BANK_SIZE)
+	if bank_bytes.size() != RomFile.BANK_SIZE:
+		return {"ok": false, "message": "Battle animation frameset bank is outside the cartridge."}
+
+	var lowest: int = base
+	var highest: int = base + count * 2
+	for index: int in count:
+		var address: int = rom.u16le(table + index * 2)
+		if address < 0x4000 or address >= 0x8000:
+			return {
+				"ok": false,
+				"message": "Frameset %d points at $%04X, outside the bank." % [index, address],
+			}
+		var stream: Dictionary = _walk_frameset(bank_bytes, address)
+		if not bool(stream.get("ok", false)):
+			return stream
+		lowest = mini(lowest, address)
+		highest = maxi(highest, int(stream["end"]))
+
+	return {
+		"ok": true,
+		"region": {
+			"bank": bank,
+			"address": lowest,
+			"count": count,
+			"bytes": _region_bytes(bank_bytes, lowest, highest),
+		},
+	}
+
+
+## One `oamframe` stream, to whichever of the three terminators ends it.
+##
+## An `oamframe` and an `oamwait` are both two bytes, because `.GetPointer`
+## indexes frames by `frame * 2`. The three terminators are one byte each in the
+## macros and the byte after them belongs to the next frameset, which the
+## cartridge reads and discards: `.next_frame` stores it as a duration for
+## `oamdelete` and never for `oamend` or `oamrestart`, and the object is deleted
+## before that duration can be counted.
+static func _walk_frameset(bank_bytes: PackedByteArray, address: int) -> Dictionary:
+	var at: int = address - 0x4000
+	for _step: int in MAX_FRAMESET_BYTES:
+		if at < 0 or at >= bank_bytes.size():
+			return {"ok": false, "message": "Frameset stream at $%04X runs past the bank." % address}
+		var byte: int = bank_bytes[at]
+		if byte == OAM_END or byte == OAM_RESTART or byte == OAM_DELETE:
+			return {"ok": true, "end": 0x4000 + at + 1}
+		if byte < FIRST_OAM_COMMAND and byte >= RomLayout.BATTLE_ANIM_OAM_SET_COUNT:
+			return {
+				"ok": false,
+				"message": "Frameset stream at $%04X names OAM set %d, past the table." % [
+					address, byte,
+				],
+			}
+		at += 2
+	return {"ok": false, "message": "Frameset stream at $%04X never ends." % address}
+
+
+## `BattleAnimOAMData` and the `dbsprite` records it points at, as one region.
+static func _read_oam_sets(rom: RomFile, table: int) -> Dictionary:
+	var count: int = RomLayout.BATTLE_ANIM_OAM_SET_COUNT
+	var size: int = count * RomLayout.BATTLE_ANIM_OAM_SET_SIZE
+	if not rom.in_bounds(table, size):
+		return {"ok": false, "message": "Battle animation OAM table is outside the cartridge."}
+
+	var bank: int = table / RomFile.BANK_SIZE
+	var base: int = 0x4000 + (table % RomFile.BANK_SIZE)
+	var bank_bytes: PackedByteArray = rom.slice(bank * RomFile.BANK_SIZE, RomFile.BANK_SIZE)
+	if bank_bytes.size() != RomFile.BANK_SIZE:
+		return {"ok": false, "message": "Battle animation OAM bank is outside the cartridge."}
+
+	var lowest: int = base
+	var highest: int = base + size
+	for index: int in count:
+		var row: int = table + index * RomLayout.BATTLE_ANIM_OAM_SET_SIZE
+		var length: int = rom.u8(row + OAM_SET_LENGTH)
+		if length <= 0:
+			return {"ok": false, "message": "OAM set %d holds no sprites." % index}
+		var address: int = rom.u16le(row + OAM_SET_POINTER)
+		var span: int = length * RomLayout.BATTLE_ANIM_OAM_SPRITE_SIZE
+		if address < 0x4000 or address + span > 0x8000:
+			return {
+				"ok": false,
+				"message": "OAM set %d points at $%04X for %d sprites, outside the bank." % [
+					index, address, length,
+				],
+			}
+		lowest = mini(lowest, address)
+		highest = maxi(highest, address + span)
+
+	return {
+		"ok": true,
+		"region": {
+			"bank": bank,
+			"address": lowest,
+			"count": count,
+			"bytes": _region_bytes(bank_bytes, lowest, highest),
+		},
+	}
+
+
+## `AnimObjGFX`, kept as rows rather than a region: its pointers are far ones
+## into the compressed graphics banks, so nothing follows the table.
+static func _read_object_gfx(rom: RomFile, table: int) -> Dictionary:
+	var count: int = RomLayout.BATTLE_ANIM_GFX_COUNT
+	var size: int = count * RomLayout.BATTLE_ANIM_GFX_SIZE
+	if not rom.in_bounds(table, size):
+		return {"ok": false, "message": "Battle animation graphics table is outside the cartridge."}
+
+	var rows: Array = []
+	for index: int in count:
+		var row: int = table + index * RomLayout.BATTLE_ANIM_GFX_SIZE
+		var pointer: Dictionary = rom.far_pointer(row + GFX_POINTER)
+		var sheet: bool = index >= RomLayout.BATTLE_ANIM_GFX_FIRST_SHEET \
+			and index <= RomLayout.BATTLE_ANIM_GFX_LAST_SHEET
+		if sheet and not rom.in_bounds(
+			RomFile.linear(int(pointer["bank"]), int(pointer["address"]))
+		):
+			return {
+				"ok": false,
+				"message": "Battle animation graphics %d point outside the cartridge." % index,
+			}
+		rows.append({
+			"tiles": rom.u8(row + GFX_TILES),
+			"bank": pointer["bank"],
+			"address": pointer["address"],
+			"sheet": sheet,
+		})
+
+	return {"ok": true, "rows": rows}
+
+
+## Decompresses every row that has a sheet into a tile strip. Returns
+## [code]{ ok, strips, sheets, tiles }[/code].
+static func _decode_sheets(rom: RomFile, rows: Array) -> Dictionary:
+	var lz := Gen2Lz.new()
+	var strips: Dictionary = {}
+	var tiles: int = 0
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		if not bool(row["sheet"]):
+			continue
+		var count: int = int(row["tiles"])
+		var start: int = RomFile.linear(int(row["bank"]), int(row["address"]))
+		var raw: PackedByteArray = lz.decompress(rom.bytes(), start)
+		if lz.failed or raw.size() < count * Gen2Tiles.TILE_BYTES:
+			return {
+				"ok": false,
+				"message": "Battle animation graphics %d decompressed to %d bytes, short of %d." % [
+					index, raw.size(), count * Gen2Tiles.TILE_BYTES,
+				],
+			}
+		strips[index] = Gen2Tiles.decode_2bpp_strip(raw, 0, count)
+		tiles += count
+	return {"ok": true, "strips": strips, "sheets": strips.size(), "tiles": tiles}
+
+
+## The slice of a bank between two of its own addresses, as an Array the cache
+## moves into the section blob.
+static func _region_bytes(bank_bytes: PackedByteArray, from: int, to: int) -> Array:
+	return _bytes_of(bank_bytes.slice(from - 0x4000, to - 0x4000))
+
+
+static func _bytes_of(data: PackedByteArray) -> Array:
+	var out: Array = []
+	out.resize(data.size())
+	for index: int in data.size():
+		out[index] = data[index]
+	return out

--- a/game/import/battle_anim_importer.gd.uid
+++ b/game/import/battle_anim_importer.gd.uid
@@ -1,0 +1,1 @@
+uid://bjgepojaatbov

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -45,6 +45,8 @@ const WORLD_MENUS: String = "world_menus.json"
 const WORLD_MARTS: String = "world_marts.json"
 const WORLD_PHONE: String = "world_phone.json"
 const WORLD_AUDIO: String = "world_audio.json"
+const BATTLE_ANIMS: String = "battle_anims.json"
+const BATTLE_ANIM_GFX_DIR: String = "battle_anim_gfx"
 
 ## The key a payload span is stored under, and how many numbers it holds. A
 ## cartridge byte run written inline as JSON decimals costs about four bytes on
@@ -57,7 +59,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 28
+const FORMAT_VERSION: int = 29
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -182,6 +184,18 @@ static func world_audio_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_AUDIO]
 
 
+## The battle animation scripts and the four tables their objects are built
+## from, each as a whole cartridge region; see [Gen2BattleAnimImporter].
+static func battle_anims_path(directory: String) -> String:
+	return "%s/%s" % [directory, BATTLE_ANIMS]
+
+
+## One decompressed `AnimObjGFX` sheet, by its own table index. Kept out of the
+## JSON for the reason every other tile strip is: it is pixels, not records.
+static func battle_anim_gfx_path(directory: String, number: int) -> String:
+	return "%s/%s/%02d.idx" % [directory, BATTLE_ANIM_GFX_DIR, number]
+
+
 static func pic_path(directory: String, name: String) -> String:
 	return "%s/%s/%s.idx" % [directory, PICS_DIR, name]
 
@@ -203,7 +217,9 @@ static func overworld_sprite_path(directory: String, number: int) -> String:
 
 
 static func prepare(directory: String) -> bool:
-	for sub: String in [PICS_DIR, TILES_DIR, WORLD_TILES_DIR, OVERWORLD_SPRITES_DIR]:
+	for sub: String in [
+		PICS_DIR, TILES_DIR, WORLD_TILES_DIR, OVERWORLD_SPRITES_DIR, BATTLE_ANIM_GFX_DIR,
+	]:
 		if DirAccess.make_dir_recursive_absolute("%s/%s" % [directory, sub]) != OK:
 			return false
 	return true

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -260,6 +260,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not services["ok"]:
 		return services
 
+	var battle_anims: Dictionary = Gen2BattleAnimImporter.verify_layout(rom)
+	if not battle_anims["ok"]:
+		return battle_anims
+
 	return {"ok": true, "message": "Layout verified."}
 
 
@@ -1445,6 +1449,8 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"phone_scripts": 0,
 		"music": 0,
 		"sfx": 0,
+		"battle_anims": 0,
+		"battle_anim_gfx_tiles": 0,
 		"elapsed_ms": 0,
 	}
 
@@ -1507,6 +1513,12 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	)
 	if not bool(services.get("ok", false)):
 		result["message"] = String(services.get("message", "Could not import world service data."))
+		return result
+	var battle_anims: Dictionary = Gen2BattleAnimImporter.import_to_cache(rom, layout, directory)
+	if not bool(battle_anims.get("ok", false)):
+		result["message"] = String(
+			battle_anims.get("message", "Could not import battle animation data.")
+		)
 		return result
 
 	if not RomCache.write_json(RomCache.species_path(directory), species):
@@ -1574,6 +1586,14 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"world_phone_script_count": int(services["phone_scripts"]),
 		"world_music_count": int(services["music"]),
 		"world_sfx_count": int(services["sfx"]),
+		"battle_anim_script_count": int(battle_anims["scripts"]),
+		"battle_anim_object_count": int(battle_anims["objects"]),
+		"battle_anim_frameset_count": int(battle_anims["framesets"]),
+		"battle_anim_oam_set_count": int(battle_anims["oam_sets"]),
+		"battle_anim_gfx": {
+			"sheets": int(battle_anims["gfx_sheets"]),
+			"tiles": int(battle_anims["gfx_tiles"]),
+		},
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
 		"atlases": pics,
@@ -1611,6 +1631,8 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	result["phone_scripts"] = int(services["phone_scripts"])
 	result["music"] = int(services["music"])
 	result["sfx"] = int(services["sfx"])
+	result["battle_anims"] = int(battle_anims["scripts"])
+	result["battle_anim_gfx_tiles"] = int(battle_anims["gfx_tiles"])
 	result["evolutions"] = evolutions
 	result["learnset_moves"] = learnset_moves
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
@@ -1621,6 +1643,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		+ "and %d overworld sprites, "
 		+ "%d menus, %d marts, %d phone contacts, %d phone script resources, "
 		+ "%d music tracks and %d sound effects, "
+		+ "%d battle animations over %d graphics tiles, "
 		+ "%d evolutions and %d level-up moves in %d ms.") % [
 		species.size(), moves.size(), items.size(), matchups.size(), trainers.size(),
 		trainer_party_count, int(world["maps"]), int(world["tilesets"]),
@@ -1632,6 +1655,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		int(services["menus"]), int(services["marts"]), int(services["phone_contacts"]),
 		int(services["phone_scripts"]),
 		int(services["music"]), int(services["sfx"]),
+		int(battle_anims["scripts"]), int(battle_anims["gfx_tiles"]),
 		evolutions, learnset_moves, result["elapsed_ms"],
 	]
 	return result

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -454,6 +454,39 @@ const CARD_PALETTE_CLASSES: Array[int] = [0, 1, 3, 2, 4, 7, 6, 5]
 ## is stored whole.
 const CARD_BADGE_PALETTE_COLORS: int = 4
 
+## The battle animation data layer: the per-move scripts and the four tables the
+## objects they spawn are built from.
+##
+## Every one of the five is stored as a contiguous region rather than entry by
+## entry, because each is a pointer table immediately followed by the data it
+## points at, and every pointer inside it is bank-local. Keeping the region whole
+## means a cached address resolves by subtraction and the bytes are the
+## cartridge's own; see [Gen2BattleAnimImporter].
+##
+## `BattleAnimations` (data/moves/animations.asm) is indexed by move number, so
+## entry 0 is `BattleAnim_Dummy` and 1 is `BattleAnim_Pound`. Entries past
+## [constant MOVE_COUNT] are the four the table pads to $100 with and then the
+## non-move animations, which `wFXAnimID`'s high byte reaches.
+const BATTLE_ANIM_SCRIPT_COUNT: int = 278
+const BATTLE_ANIM_OBJECT_COUNT: int = 188
+const BATTLE_ANIM_OBJECT_SIZE: int = 6
+const BATTLE_ANIM_FRAMESET_COUNT: int = 185
+const BATTLE_ANIM_OAM_SET_COUNT: int = 216
+const BATTLE_ANIM_OAM_SET_SIZE: int = 4
+## `dbsprite`: y, x, tile, attributes.
+const BATTLE_ANIM_OAM_SPRITE_SIZE: int = 4
+## `AnimObjGFX` is `const_def 1`, so index 0 is a slot no `anim_*gfx` names and
+## the table is one longer than [code]NUM_BATTLE_ANIM_GFX[/code].
+const BATTLE_ANIM_GFX_COUNT: int = 42
+const BATTLE_ANIM_GFX_SIZE: int = 4
+## `AnimObjGFX`'s last two rows are `anim_obj_gfx 1, NULL`:
+## `BATTLE_ANIM_GFX_PLAYERHEAD` and `..._ENEMYFEET` are written into
+## `wBattleAnimTileDict` by `BattleAnimCmd_BattlerGFX_1Row`/`_2Row` off the
+## battler's own pic, and are named by no `anim_*gfx` command, so neither row
+## has a sheet to decode.
+const BATTLE_ANIM_GFX_FIRST_SHEET: int = 1
+const BATTLE_ANIM_GFX_LAST_SHEET: int = 39
+
 ## The four palettes a battle draws its bars with: the HP bar in green, yellow
 ## or red depending on how much is left, and the exp bar in blue. They are two
 ## colours each like a species' palette, white and black being implied, and they
@@ -740,6 +773,19 @@ const GOLD_SILVER: Dictionary = {
 		"order_alpha": 0x40C65,
 		"order_new": 0x40D60,
 	},
+	# Battle animations. `BattleAnimations` was located by matching
+	# `BattleAnim_Pound` whole (d1 01 e0 01 31 d0 08 88 38 00 06 d0 01 88 38 00
+	# 10 ff), then finding the run of 278 in-bank pointers whose second entry is
+	# its address; the other four tables were located by assembling the pinned
+	# data/battle_anims files and matching the bytes. Each hit is unique in the
+	# dump. Nested for the same reason trainer_card is.
+	"battle_anims": {
+		"scripts": 0xC900A,
+		"objects": 0xCCAA5,
+		"framesets": 0xCE7A3,
+		"oam_sets": 0xCEDF3,
+		"object_gfx": 0xCFC3B,
+	},
 	"trainer_pic_pointers": 0x80000,
 	"trainer_palettes": 0xB53D,
 	"trainer_class_names": 0x1B0955,
@@ -896,6 +942,16 @@ const CRYSTAL: Dictionary = {
 		"entry_banks": [0x60, 0x6E, 0x73, 0x74],
 		"order_alpha": 0x40C65,
 		"order_new": 0x40D60,
+	},
+	# Battle animations; see the Gold and Silver block above for how these were
+	# located. All five tables sit in the same two banks in every dump and only
+	# the addresses within them move.
+	"battle_anims": {
+		"scripts": 0xC906F,
+		"objects": 0xCCB56,
+		"framesets": 0xCE85E,
+		"oam_sets": 0xCEEAE,
+		"object_gfx": 0xCFCF6,
 	},
 	"trainer_pic_pointers": 0x128000,
 	"trainer_palettes": 0xB0CE,

--- a/tests/unit/test_battle_anim_importer.gd
+++ b/tests/unit/test_battle_anim_importer.gd
@@ -1,0 +1,265 @@
+extends GutTest
+
+## The battle animation layout checks, against dumps this test builds.
+##
+## No cartridge is opened here, for the reason `test_rom_importer.gd` states:
+## where the tables are is only settled by a real dump and
+## `tools/validate_battle_anims.gd`, and what is worth testing is that the
+## checks would notice if they were somewhere else.
+
+## Everything is put in bank 1, so an in-bank address is the file offset plus
+## nothing and the dump stays two banks long.
+const BANK: int = 1
+const DUMP_SIZE: int = 0x8000
+
+const SCRIPTS: int = 0x4000
+const POUND_BODY: int = 0x4300
+const DUMMY_BODY: int = 0x4400
+const OBJECTS: int = 0x5000
+const FRAMESETS: int = 0x6000
+const FRAMESET_STREAM: int = 0x6200
+const OAM_SETS: int = 0x6400
+const OAM_SPRITES: int = 0x6800
+const OBJECT_GFX: int = 0x7000
+## Somewhere inside the dump for an `AnimObjGFX` row to point at. Nothing
+## decompresses it: only `import_to_cache` reads the stream.
+const GFX_DATA: int = 0x0100
+
+var _dump: PackedByteArray = PackedByteArray()
+
+
+func before_each() -> void:
+	_dump = PackedByteArray()
+	_dump.resize(DUMP_SIZE)
+	_write_scripts()
+	_write_objects()
+	_write_framesets()
+	_write_oam_sets()
+	_write_object_gfx()
+
+
+## A plausible `BattleAnimations`: POUND at entry 1 and a bare `anim_ret`
+## everywhere else.
+func _write_scripts() -> void:
+	for index: int in RomLayout.BATTLE_ANIM_SCRIPT_COUNT:
+		_word(SCRIPTS + index * 2, POUND_BODY if index == 1 else DUMMY_BODY)
+	for index: int in Gen2BattleAnimImporter.POUND_BYTES.size():
+		_dump[POUND_BODY + index] = Gen2BattleAnimImporter.POUND_BYTES[index]
+	_dump[DUMMY_BODY] = 0xFF
+
+
+## 188 rows whose four table indexes are all in range.
+func _write_objects() -> void:
+	for index: int in RomLayout.BATTLE_ANIM_OBJECT_COUNT:
+		var row: int = OBJECTS + index * RomLayout.BATTLE_ANIM_OBJECT_SIZE
+		_dump[row + Gen2BattleAnimImporter.OBJECT_FLAGS] = 0x01
+		_dump[row + Gen2BattleAnimImporter.OBJECT_Y_FIX] = 0xFF
+		_dump[row + Gen2BattleAnimImporter.OBJECT_FRAMESET] = 0
+		_dump[row + Gen2BattleAnimImporter.OBJECT_FUNCTION] = 0
+		_dump[row + Gen2BattleAnimImporter.OBJECT_PALETTE] = 2
+		_dump[row + Gen2BattleAnimImporter.OBJECT_GFX] = 1
+
+
+## Every frameset pointing at one `oamframe` and an `oamend`.
+func _write_framesets() -> void:
+	for index: int in RomLayout.BATTLE_ANIM_FRAMESET_COUNT:
+		_word(FRAMESETS + index * 2, FRAMESET_STREAM)
+	_dump[FRAMESET_STREAM] = 0x00
+	_dump[FRAMESET_STREAM + 1] = 0x06
+	_dump[FRAMESET_STREAM + 2] = Gen2BattleAnimImporter.OAM_END
+
+
+## Every OAM set naming one sprite.
+func _write_oam_sets() -> void:
+	for index: int in RomLayout.BATTLE_ANIM_OAM_SET_COUNT:
+		var row: int = OAM_SETS + index * RomLayout.BATTLE_ANIM_OAM_SET_SIZE
+		_dump[row + Gen2BattleAnimImporter.OAM_SET_VTILE] = 0
+		_dump[row + Gen2BattleAnimImporter.OAM_SET_LENGTH] = 1
+		_word(row + Gen2BattleAnimImporter.OAM_SET_POINTER, OAM_SPRITES)
+
+
+func _write_object_gfx() -> void:
+	for index: int in RomLayout.BATTLE_ANIM_GFX_COUNT:
+		var row: int = OBJECT_GFX + index * RomLayout.BATTLE_ANIM_GFX_SIZE
+		_dump[row + Gen2BattleAnimImporter.GFX_TILES] = 1
+		_dump[row + Gen2BattleAnimImporter.GFX_POINTER] = 0
+		_word(row + Gen2BattleAnimImporter.GFX_POINTER + 1, GFX_DATA)
+
+
+func _word(at: int, value: int) -> void:
+	_dump[at] = value & 0xFF
+	_dump[at + 1] = (value >> 8) & 0xFF
+
+
+func _layout() -> Dictionary:
+	return {
+		"battle_anims": {
+			"scripts": SCRIPTS,
+			"objects": OBJECTS,
+			"framesets": FRAMESETS,
+			"oam_sets": OAM_SETS,
+			"object_gfx": OBJECT_GFX,
+		},
+	}
+
+
+func _read(layout: Dictionary = _layout()) -> Dictionary:
+	return Gen2BattleAnimImporter.read_battle_anims(
+		RomFile.from_bytes(_dump, RomRegistry.GOLD), layout
+	)
+
+
+func test_a_plausible_layer_verifies() -> void:
+	var result: Dictionary = _read()
+	assert_true(bool(result["ok"]), String(result.get("message", "")))
+	assert_eq(int(result["counts"]["scripts"]), RomLayout.BATTLE_ANIM_SCRIPT_COUNT)
+	assert_eq(int(result["counts"]["objects"]), RomLayout.BATTLE_ANIM_OBJECT_COUNT)
+	assert_eq(int(result["counts"]["framesets"]), RomLayout.BATTLE_ANIM_FRAMESET_COUNT)
+	assert_eq(int(result["counts"]["oam_sets"]), RomLayout.BATTLE_ANIM_OAM_SET_COUNT)
+
+
+## The region runs from the table to the end of the last body it reaches, and
+## the pointer table is its own first bytes.
+func test_the_script_region_starts_at_the_table_and_ends_at_the_last_body() -> void:
+	var region: Dictionary = _read()["anims"]["scripts"]
+	assert_eq(int(region["bank"]), BANK)
+	assert_eq(int(region["address"]), SCRIPTS)
+	assert_eq(int((region["bytes"] as Array).size()), DUMMY_BODY + 1 - SCRIPTS)
+	assert_eq(int((region["bytes"] as Array)[2]), POUND_BODY & 0xFF)
+	assert_eq(int((region["bytes"] as Array)[3]), POUND_BODY >> 8)
+
+
+## An animation is only trustworthy against content, because almost any byte run
+## decodes as commands: a table of the right shape in the wrong place walks.
+func test_an_entry_that_is_not_pounds_fails() -> void:
+	_dump[POUND_BODY + 4] = 0x30
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "not POUND's")
+
+
+func test_a_script_pointer_outside_the_bank_fails() -> void:
+	_word(SCRIPTS + 8, 0x3FFF)
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "outside the bank")
+
+
+## A body with no `anim_ret` in it walks to the guard rather than off the bank.
+func test_a_body_that_never_returns_fails() -> void:
+	for at: int in range(DUMMY_BODY, DUMMY_BODY + Gen2BattleAnimImporter.MAX_BODY_BYTES + 2):
+		_dump[at] = 0xFA  # anim_incvar, which never ends anything
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "never ends")
+
+
+## A branch is followed, so a body only some other body jumps into is measured
+## too, and one that jumps out of the bank is refused.
+func test_a_branch_out_of_the_bank_fails() -> void:
+	_dump[DUMMY_BODY] = 0xFC  # anim_jump
+	_word(DUMMY_BODY + 1, 0x8000)
+	_dump[DUMMY_BODY + 3] = 0xFF
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "branches to")
+
+
+func test_a_called_body_joins_the_region() -> void:
+	var called: int = DUMMY_BODY + 0x40
+	_dump[DUMMY_BODY] = 0xFE  # anim_call
+	_word(DUMMY_BODY + 1, called)
+	_dump[DUMMY_BODY + 3] = 0xFF
+	_dump[called] = 0xFF
+	var region: Dictionary = _read()["anims"]["scripts"]
+	assert_eq(int((region["bytes"] as Array).size()), called + 1 - SCRIPTS)
+
+
+func test_an_object_naming_a_frameset_past_the_table_fails() -> void:
+	_dump[OBJECTS + Gen2BattleAnimImporter.OBJECT_FRAMESET] = \
+		RomLayout.BATTLE_ANIM_FRAMESET_COUNT
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "names frameset")
+
+
+func test_an_object_naming_a_ninth_palette_fails() -> void:
+	_dump[OBJECTS + Gen2BattleAnimImporter.OBJECT_PALETTE] = \
+		Gen2BattleAnimImporter.PALETTE_COUNT
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "names palette")
+
+
+## `oamframe` and `oamwait` are both two bytes and the three terminators are
+## one, so a stream with no terminator strides past the guard.
+func test_a_frameset_stream_that_never_ends_fails() -> void:
+	for at: int in range(
+		FRAMESET_STREAM, FRAMESET_STREAM + Gen2BattleAnimImporter.MAX_FRAMESET_BYTES * 2 + 4
+	):
+		_dump[at] = 0x00
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "never ends")
+
+
+func test_a_frameset_naming_an_oam_set_past_the_table_fails() -> void:
+	_dump[FRAMESET_STREAM] = RomLayout.BATTLE_ANIM_OAM_SET_COUNT
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "names OAM set")
+
+
+## An `oamwait` is not a terminator: the stream carries on past it.
+func test_an_oam_wait_does_not_end_a_stream() -> void:
+	_dump[FRAMESET_STREAM] = Gen2BattleAnimImporter.OAM_WAIT
+	_dump[FRAMESET_STREAM + 1] = 0x04
+	_dump[FRAMESET_STREAM + 2] = 0x00
+	_dump[FRAMESET_STREAM + 3] = 0x06
+	_dump[FRAMESET_STREAM + 4] = Gen2BattleAnimImporter.OAM_END
+	var region: Dictionary = _read()["anims"]["framesets"]
+	assert_eq(int((region["bytes"] as Array).size()), FRAMESET_STREAM + 5 - FRAMESETS)
+
+
+func test_an_oam_set_whose_sprites_leave_the_bank_fails() -> void:
+	_dump[OAM_SETS + Gen2BattleAnimImporter.OAM_SET_LENGTH] = 0xFF
+	_word(OAM_SETS + Gen2BattleAnimImporter.OAM_SET_POINTER, 0x7FF0)
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "outside the bank")
+
+
+func test_an_oam_set_with_no_sprites_fails() -> void:
+	_dump[OAM_SETS + Gen2BattleAnimImporter.OAM_SET_LENGTH] = 0
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "holds no sprites")
+
+
+## Only rows 1 to 39 carry a sheet. Index 0 is the slot no `anim_*gfx` reaches
+## and the last two are the `NULL` rows the battler-graphics commands fill in.
+func test_three_graphics_rows_carry_no_sheet() -> void:
+	var rows: Array = _read()["anims"]["object_gfx"]
+	assert_eq(rows.size(), RomLayout.BATTLE_ANIM_GFX_COUNT)
+	assert_false(bool(rows[0]["sheet"]))
+	assert_true(bool(rows[RomLayout.BATTLE_ANIM_GFX_FIRST_SHEET]["sheet"]))
+	assert_true(bool(rows[RomLayout.BATTLE_ANIM_GFX_LAST_SHEET]["sheet"]))
+	assert_false(bool(rows[RomLayout.BATTLE_ANIM_GFX_LAST_SHEET + 1]["sheet"]))
+	assert_false(bool(rows[RomLayout.BATTLE_ANIM_GFX_COUNT - 1]["sheet"]))
+
+
+func test_a_layout_without_the_section_fails_rather_than_reading_zero() -> void:
+	var result: Dictionary = _read({})
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "No battle animation layout")
+
+	var empty: Dictionary = _read({"trainer_classes": 66})
+	assert_false(bool(empty["ok"]))
+	assert_string_contains(String(empty["message"]), "offsets are missing")
+
+
+func test_a_dump_too_short_to_hold_the_tables_fails_rather_than_reading_past_it() -> void:
+	_dump.resize(SCRIPTS + 4)
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "outside the cartridge")

--- a/tests/unit/test_battle_anim_importer.gd.uid
+++ b/tests/unit/test_battle_anim_importer.gd.uid
@@ -1,0 +1,1 @@
+uid://dsgbpgq3c3s3w

--- a/tests/unit/test_battle_anim_script.gd
+++ b/tests/unit/test_battle_anim_script.gd
@@ -1,0 +1,252 @@
+extends GutTest
+
+## The battle animation command interpreter
+## (engine/battle_anims/anim_commands.asm), against hand-built regions.
+##
+## The real cartridges are `tools/validate_battle_anims.gd`'s job; what is here
+## is the vocabulary and the control flow, including the shapes no shipped
+## animation uses.
+
+## Where a built region starts, so nothing passes by accident on a zero base.
+const BASE: int = 0x5000
+
+
+## Assembles a region from a flat byte list. Addresses inside it are
+## [constant BASE] plus the position.
+func _region(bytes: Array) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(bytes.size())
+	for index: int in bytes.size():
+		out[index] = int(bytes[index]) & 0xFF
+	return out
+
+
+func _script(bytes: Array, param: int = 0, at: int = BASE) -> Gen2BattleAnimScript:
+	return Gen2BattleAnimScript.create(_region(bytes), BASE, at, param)
+
+
+## Every command a frame ran, as [code][name, operands][/code] pairs.
+func _names(ran: Array) -> Array:
+	return ran.map(func(command: Dictionary) -> Array:
+		return [command["name"], Array(command["operands"])])
+
+
+## Runs to a stop, collecting each frame's commands separately.
+func _frames(script: Gen2BattleAnimScript, limit: int = 512) -> Array:
+	var out: Array = []
+	var frames: int = 0
+	while not script.finished() and frames < limit:
+		frames += 1
+		out.append(_names(script.advance_frame()))
+	return out
+
+
+## `BattleAnim_Pound`, the same eighteen bytes in all three cartridges, decoded
+## command by command. `anim_sound 0, 1, SFX_POUND` packs its duration and track
+## mask into one byte, `(0 << 2) | 1`, which is why the operand is $01 and not
+## a pair.
+func test_pound_decodes_to_its_seven_commands() -> void:
+	var script: Gen2BattleAnimScript = _script(Gen2BattleAnimImporter.POUND_BYTES)
+	var frames: Array = _frames(script)
+	assert_true(script.finished())
+	assert_false(script.failed())
+
+	var ran: Array = []
+	for frame: Array in frames:
+		ran.append_array(frame)
+	assert_eq(ran, [
+		[&"gfx_1", [0x01]],
+		[&"sound", [0x01, 0x31]],
+		[&"obj", [0x08, 136, 56, 0x00]],
+		[&"wait", [6]],
+		[&"obj", [0x01, 136, 56, 0x00]],
+		[&"wait", [16]],
+		[&"ret", []],
+	])
+
+
+## `RunBattleAnimCommand.CheckTimer` decrements the delay and runs nothing while
+## it is non-zero, so `anim_wait N` costs exactly N frames and the command that
+## set it is on the frame before them.
+func test_a_wait_costs_its_own_number_of_frames() -> void:
+	var script: Gen2BattleAnimScript = _script([0xE9, 0x03, 0xFF])
+	assert_eq(_names(script.advance_frame()), [[&"minimize", []], [&"wait", [3]]])
+	assert_eq(script.delay(), 3)
+	for frame: int in 3:
+		assert_eq(script.advance_frame(), [], "frame %d of the wait runs nothing" % frame)
+	assert_eq(_names(script.advance_frame()), [[&"ret", []]])
+	assert_true(script.finished())
+
+
+## `.RunScript` loops until a delay byte or a top-level `anim_ret`, so a run of
+## commands with no wait between them all happens on one frame.
+func test_commands_without_a_wait_share_one_frame() -> void:
+	var frames: Array = _frames(_script([0xFA, 0xFA, 0xFA, 0xFF]))
+	assert_eq(frames.size(), 1)
+	assert_eq(frames[0], [[&"inc_var", []], [&"inc_var", []], [&"inc_var", []], [&"ret", []]])
+
+
+## A byte below $d0 is not a command at all: `.not_done_with_anim` stores it and
+## returns before the jumptable is reached.
+func test_the_command_table_starts_at_d0() -> void:
+	assert_eq(Gen2BattleAnimScript.FIRST_COMMAND, 0xD0)
+	assert_eq(Gen2BattleAnimScript.COMMANDS.size(), 0x100 - 0xD0)
+	var script: Gen2BattleAnimScript = _script([0xCF, 0xFF])
+	assert_eq(_names(script.advance_frame()), [[&"wait", [0xCF]]])
+
+
+## `$d9` assembles from `anim_battlergfx_2row` and dispatches to
+## `BattleAnimCmd_BattlerGFX_1Row`; `$da` is the other way round. The routine is
+## what runs, so the routine is what the command is called.
+func test_the_two_battler_graphics_commands_are_named_for_their_routines() -> void:
+	var frames: Array = _frames(_script([0xD9, 0xDA, 0xFF]))
+	assert_eq(frames[0], [
+		[&"battler_gfx_1row", []], [&"battler_gfx_2row", []], [&"ret", []],
+	])
+
+
+## `BattleAnimCmd_Ret` returns to the single `wBattleAnimParent` word inside a
+## subroutine and sets BATTLEANIM_STOP_F at the top level.
+func test_a_call_returns_and_the_top_level_ret_stops() -> void:
+	# call $5005, inc_var, ret | (at $5005) inc_var, ret
+	var script: Gen2BattleAnimScript = _script([0xFE, 0x05, 0x50, 0xFA, 0xFF, 0xFA, 0xFF])
+	var frames: Array = _frames(script)
+	assert_eq(frames.size(), 1)
+	assert_eq(frames[0], [
+		[&"call", [0x05, 0x50]],
+		[&"inc_var", []],
+		[&"ret", []],
+		[&"inc_var", []],
+		[&"ret", []],
+	], "the subroutine's ret continues the frame, the outer one ends it")
+	assert_eq(script.variable(), 2)
+	assert_true(script.finished())
+
+
+## There is no stack: `wBattleAnimParent` is one word, so a call inside a call
+## loses the outer return address and the second ret walks on into whatever
+## follows. Reproduced rather than generalised.
+func test_a_nested_call_loses_the_outer_return() -> void:
+	var script: Gen2BattleAnimScript = _script([
+		0xFE, 0x06, 0x50,  # $5000 call $5006
+		0xFF,              # $5003 ret       (never reached)
+		0xFA, 0xFF,        # $5004 inc_var, ret
+		0xFE, 0x04, 0x50,  # $5006 call $5004
+		0xFF,              # $5009 ret
+	])
+	_frames(script)
+	# The inner call overwrote the parent with $5009, so the first ret lands
+	# there and the second is the one that stops.
+	assert_true(script.finished())
+	assert_false(script.failed())
+	assert_eq(script.variable(), 1)
+
+
+## `BattleAnimCmd_Loop`: the count is stored one lower, so `anim_loop 1` never
+## jumps and `anim_loop 3` jumps twice. `.return_from_loop` clears the flag and
+## skips the address rather than reading it.
+func test_a_loop_runs_its_count_and_then_falls_through() -> void:
+	# inc_var, loop 3 -> $5000, ret
+	var script: Gen2BattleAnimScript = _script([0xFA, 0xFD, 0x03, 0x00, 0x50, 0xFF])
+	_frames(script)
+	assert_eq(script.variable(), 3, "three passes over the body")
+	assert_true(script.finished())
+
+	var once: Gen2BattleAnimScript = _script([0xFA, 0xFD, 0x01, 0x00, 0x50, 0xFF])
+	_frames(once)
+	assert_eq(once.variable(), 1, "a count of one falls straight through")
+
+
+## A count of zero never claims the loop flag, so it re-reads its own zero and
+## jumps forever. The cartridge hangs here; [constant MAX_COMMANDS_PER_FRAME] is
+## ours and turns it into a refused animation.
+func test_a_perpetual_loop_fails_rather_than_hanging() -> void:
+	var script: Gen2BattleAnimScript = _script([0xFD, 0x00, 0x00, 0x50, 0xFF])
+	var ran: Array = script.advance_frame()
+	assert_eq(ran.size(), Gen2BattleAnimScript.MAX_COMMANDS_PER_FRAME)
+	assert_true(script.failed())
+	assert_true(script.finished(), "a failed script is finished")
+
+
+## `BattleAnimCmd_JumpUntil` spends `wBattleAnimParam` down rather than keeping
+## a counter of its own, so the caller's own value decides how many times it
+## goes round. That is what the multi-hit animations are.
+func test_jump_until_spends_the_param() -> void:
+	# inc_var, jumpuntil $5000, ret
+	var bytes: Array = [0xFA, 0xEF, 0x00, 0x50, 0xFF]
+	var twice: Gen2BattleAnimScript = _script(bytes, 2)
+	_frames(twice)
+	assert_eq(twice.variable(), 3, "the body runs once more than the param")
+
+	var none: Gen2BattleAnimScript = _script(bytes, 0)
+	_frames(none)
+	assert_eq(none.variable(), 1)
+
+
+## The three conditional jumps, each of which skips its own two address bytes
+## when it does not take the branch.
+func test_the_conditional_jumps_read_the_param_and_the_var() -> void:
+	# if_param_and $06 -> $5006, inc_var, ret | ($5006) set_var $09, ret
+	var bytes: Array = [0xEE, 0x06, 0x06, 0x50, 0xFA, 0xFF, 0xF9, 0x09, 0xFF]
+	var hit: Gen2BattleAnimScript = _script(bytes, 0x04)
+	_frames(hit)
+	assert_eq(hit.variable(), 0x09, "a shared bit takes the branch")
+
+	var missed: Gen2BattleAnimScript = _script(bytes, 0x01)
+	_frames(missed)
+	assert_eq(missed.variable(), 1, "no shared bit falls through")
+
+	# if_param_equal $02 -> $5006 over the same tail.
+	var equal: Gen2BattleAnimScript = _script(
+		[0xF8, 0x02, 0x06, 0x50, 0xFA, 0xFF, 0xF9, 0x09, 0xFF], 0x02
+	)
+	_frames(equal)
+	assert_eq(equal.variable(), 0x09)
+
+	# set_var $07, if_var_equal $07 -> $5008, inc_var, ret | ($5008) set_var $01, ret
+	var by_var: Gen2BattleAnimScript = _script(
+		[0xF9, 0x07, 0xFB, 0x07, 0x08, 0x50, 0xFA, 0xFF, 0xF9, 0x01, 0xFF]
+	)
+	_frames(by_var)
+	assert_eq(by_var.variable(), 0x01)
+
+
+## `wBattleAnimVar` starts at zero because `ClearBattleAnims` zeroes
+## `wLYOverrides` through `wBattleAnimEnd`; `wBattleAnimParam` sits outside that
+## run and is the caller's input.
+func test_the_var_starts_at_zero_and_the_param_is_given() -> void:
+	var script: Gen2BattleAnimScript = _script([0xFF], 0x1F)
+	assert_eq(script.variable(), 0)
+	assert_eq(script.address(), BASE)
+
+
+## An address outside the region, and a command whose operands run past its end.
+## Both are refused rather than read out of whatever is next in memory.
+func test_a_script_outside_its_region_fails_at_once() -> void:
+	var outside: Gen2BattleAnimScript = _script([0xFF], 0, BASE + 8)
+	assert_true(outside.failed())
+	assert_true(outside.finished())
+	assert_eq(outside.advance_frame(), [])
+
+	var truncated: Gen2BattleAnimScript = _script([0xD0, 0x08, 0x88])
+	assert_eq(truncated.advance_frame(), [], "anim_obj wants four operands and has three")
+	assert_true(truncated.failed())
+
+
+## The shared decoder, which the importer walks every body with. A branch
+## command reports where it would go; everything else reports -1.
+func test_decode_command_reports_operands_and_branch_targets() -> void:
+	var region: PackedByteArray = _region([0xFC, 0x34, 0x12, 0xE0, 0x01, 0x31])
+	var jump: Dictionary = Gen2BattleAnimScript.decode_command(region, BASE, BASE)
+	assert_eq(jump["name"], &"jump")
+	assert_eq(jump["size"], 3)
+	assert_eq(jump["target"], 0x1234)
+
+	var sound: Dictionary = Gen2BattleAnimScript.decode_command(region, BASE, BASE + 3)
+	assert_eq(sound["name"], &"sound")
+	assert_eq(Array(sound["operands"]), [0x01, 0x31])
+	assert_eq(sound["target"], -1)
+
+	assert_false(
+		bool(Gen2BattleAnimScript.decode_command(region, BASE, BASE - 1).get("ok", false))
+	)

--- a/tests/unit/test_battle_anim_script.gd.uid
+++ b/tests/unit/test_battle_anim_script.gd.uid
@@ -1,0 +1,1 @@
+uid://ctbr44hhysvv0

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -90,6 +90,7 @@ func _write_cache(complete: bool = true) -> void:
 	RomCache.write_json(RomCache.dex_orders_path(_directory), {
 		"new": _dex_order(true), "alpha": _dex_order(false),
 	})
+	_write_battle_anims()
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "testgame",
@@ -105,6 +106,46 @@ func _write_cache(complete: bool = true) -> void:
 		},
 		"complete": complete,
 	})
+
+
+## Two animation regions, the way the importer writes them: a pointer table with
+## its bodies immediately after it, addressed by the region's own base.
+##
+## The script region holds two entries, one at $4004 and one at $4005, and the
+## bodies are `anim_ret` and `anim_inc_var, anim_ret`. The object region is one
+## `battleanimobj` row.
+const _ANIM_BASE: int = 0x4000
+const _ANIM_BANK: int = 0x32
+
+
+func _write_battle_anims() -> void:
+	RomCache.write_section(
+		RomCache.battle_anims_path(_directory),
+		RomCache.blob_path(RomCache.battle_anims_path(_directory)),
+		{
+			"scripts": {
+				"bank": _ANIM_BANK, "address": _ANIM_BASE, "count": 2,
+				"bytes": [0x04, 0x40, 0x05, 0x40, 0xFF, 0xFA, 0xFF],
+			},
+			"objects": {
+				"bank": _ANIM_BANK, "address": _ANIM_BASE, "count": 1,
+				"bytes": [0x01, 0xFF, 0x02, 0x03, 0x04, 0x05],
+			},
+			"object_gfx": [
+				{"tiles": 0, "bank": 0x21, "address": 0x4A2E, "sheet": false},
+				{"tiles": 1, "bank": 0x21, "address": 0x4A2E, "sheet": true},
+			],
+		}
+	)
+	RomCache.write_indices(
+		RomCache.battle_anim_gfx_path(_directory, 1), _blank_tile()
+	)
+
+
+func _blank_tile() -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(Gen2Tiles.TILE_PIXELS)
+	return out
 
 
 ## A full-length order table, since GameData drops one that is not: the two
@@ -166,6 +207,17 @@ func test_a_missing_cache_does_not_open() -> void:
 	assert_null(GameData.open_directory("user://nothing_here"))
 
 
+## A cache written by an older importer is discarded rather than migrated, which
+## is what a format bump is for. Written against the version rather than a
+## number so the next bump does not have to edit this.
+func test_a_cache_from_an_older_format_does_not_open() -> void:
+	_write_cache()
+	var manifest: Dictionary = RomCache.read_manifest(_directory)
+	manifest["format_version"] = RomCache.FORMAT_VERSION - 1
+	RomCache.write_json(RomCache.manifest_path(_directory), manifest)
+	assert_null(GameData.open_directory(_directory))
+
+
 func test_numbers_come_back_as_ints_not_floats() -> void:
 	# JSON has one number type. Coercing here, once, is the whole reason this
 	# class exists rather than callers reading the JSON themselves.
@@ -204,6 +256,66 @@ func test_world_service_records_are_read_from_the_cache() -> void:
 	assert_eq(data.world_service_counts(), {
 		"menus": 1, "marts": 1, "phone_contacts": 1, "music": 1, "sfx": 1, "cries": 0,
 	})
+
+
+## A region comes back with its bank and address, so an in-bank pointer resolves
+## by subtraction, and its bytes come out of the section blob rather than the
+## JSON.
+func test_a_battle_anim_region_carries_its_own_base_address() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var region: Dictionary = data.battle_anim_region(&"scripts")
+	assert_eq(int(region["bank"]), _ANIM_BANK)
+	assert_eq(int(region["address"]), _ANIM_BASE)
+	assert_eq(int(region["count"]), 2)
+	assert_eq((region["data"] as PackedByteArray).size(), 7)
+	assert_true(data.battle_anim_region(&"nothing").is_empty())
+
+
+## The pointer table is the first bytes of the scripts region rather than a copy
+## beside it, which is what makes a cached address and the bytes it names one
+## thing.
+func test_a_battle_anim_address_is_read_out_of_the_region_itself() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.battle_anim_address(0), 0x4004)
+	assert_eq(data.battle_anim_address(1), 0x4005)
+	assert_eq(data.battle_anim_address(2), -1, "past the table")
+	assert_eq(data.battle_anim_address(-1), -1)
+
+	var region: Dictionary = data.battle_anim_region(&"scripts")
+	var script := Gen2BattleAnimScript.create(
+		region["data"], int(region["address"]), data.battle_anim_address(1)
+	)
+	var ran: Array = script.advance_frame()
+	assert_eq(ran.size(), 2)
+	assert_eq(ran[1]["name"], Gen2BattleAnimScript.RET)
+	assert_eq(script.variable(), 1)
+	assert_true(script.finished())
+
+
+func test_a_battle_anim_object_row_reads_back_as_ints() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.battle_anim_object(0), {
+		"flags": 1, "y_fix": 0xFF, "frameset": 2, "function": 3, "palette": 4, "gfx": 5,
+	})
+	assert_true(data.battle_anim_object(1).is_empty(), "past the table")
+
+
+## Only the rows that name graphics have a sheet: index 0 is the slot no
+## `anim_*gfx` reaches, and the two `NULL` rows belong to the battler-graphics
+## commands.
+func test_only_the_rows_with_graphics_carry_a_sheet() -> void:
+	_write_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.battle_anim_gfx_count(), 2)
+	assert_false(bool(data.battle_anim_gfx(0)["sheet"]))
+	assert_eq(data.battle_anim_gfx(1), {
+		"tiles": 1, "bank": 0x21, "address": 0x4A2E, "sheet": true,
+	})
+	assert_eq(data.battle_anim_gfx_indices(1).size(), Gen2Tiles.TILE_PIXELS)
+	assert_true(data.battle_anim_gfx(2).is_empty())
 
 
 func test_a_matchup_the_chart_does_not_list_is_neutral() -> void:

--- a/tools/validate_battle_anims.gd
+++ b/tools/validate_battle_anims.gd
@@ -1,0 +1,303 @@
+extends SceneTree
+
+## Runs every battle animation out of a freshly imported real cache, on all
+## three cartridges, and checks the four tables behind them.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## data/moves/animations.asm's BattleAnimations, data/battle_anims/objects.asm,
+## framesets.asm, oam.asm and object_gfx.asm, and
+## engine/battle_anims/anim_commands.asm's own interpreter.
+##
+## The real-cartridge counterpart to tests/unit/test_battle_anim_script.gd. What
+## pins it is running all 278 to completion rather than spot checking: an
+## operand width that is wrong by one byte still decodes, and only walking every
+## body past every branch makes it fall over.
+##
+##   Godot --headless --path . -s res://tools/validate_battle_anims.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## `assert_table_length` in each pinned data file. All five are shared by the
+## two pins: the only thing data/battle_anims differs on is nothing, and
+## animations.asm differs only inside eight bodies.
+const EXPECTED_COUNTS: Dictionary = {
+	&"scripts": RomLayout.BATTLE_ANIM_SCRIPT_COUNT,
+	&"objects": RomLayout.BATTLE_ANIM_OBJECT_COUNT,
+	&"framesets": RomLayout.BATTLE_ANIM_FRAMESET_COUNT,
+	&"oam_sets": RomLayout.BATTLE_ANIM_OAM_SET_COUNT,
+}
+
+## `BattleAnim_Pound`, decoded. The seven commands `anim_1gfx`, `anim_sound`,
+## `anim_obj`, `anim_wait 6`, `anim_obj`, `anim_wait 16`, `anim_ret`, as
+## [code][name, operands][/code].
+const EXPECTED_POUND: Array = [
+	[&"gfx_1", [0x01]],
+	[&"sound", [0x01, 0x31]],
+	[&"obj", [0x08, 136, 56, 0x00]],
+	[&"wait", [6]],
+	[&"obj", [0x01, 136, 56, 0x00]],
+	[&"wait", [16]],
+	[&"ret", []],
+]
+
+## `BattleAnim_Dummy`, which entry 0 and three of the four padding entries share.
+const DUMMY_INDEX: int = 0
+const POUND_INDEX: int = 1
+
+## Both shapes the profile split in data/moves/animations.asm takes, as the
+## whole `anim_bgeffect` sequence of the animation that shows each. Neither is
+## reachable without following the animation properly: every one of these
+## sequences opens and closes inside a subroutine.
+##
+## TACKLE shows the split in which routine is called: Crystal calls
+## `BattleAnim_TargetObj_2Row` and Gold and Silver `..._1Row`, and the two
+## differ only in the effect they run, `BATTLE_BG_EFFECT_BATTLEROBJ_2ROW` ($12)
+## against `..._1ROW` ($11). Its own `BATTLE_BG_EFFECT_TACKLE` ($24) and the
+## closing `BattleAnim_ShowMon_0`'s `..._SHOW_MON` ($0a) are shared.
+const TACKLE_INDEX: int = 0x21
+const TACKLE_BG_EFFECTS: Dictionary = {
+	&"gold": [0x11, 0x24, 0x0A],
+	&"silver": [0x11, 0x24, 0x0A],
+	&"crystal": [0x12, 0x24, 0x0A],
+}
+
+## BODY SLAM shows the other shape, the same call on both profiles running a
+## different constant: `BATTLE_BG_EFFECT_BODY_SLAM` ($25) is Crystal's and
+## pokegold does not have that constant at all, so it runs
+## `BATTLE_BG_EFFECT_TACKLE` ($24). That is where
+## constants/battle_anim_constants.asm starts to diverge, and it is why a bg
+## effect id is profile-local and is never normalised across the two.
+const BODY_SLAM_INDEX: int = 0x22
+const BODY_SLAM_BG_EFFECTS: Dictionary = {
+	&"gold": [0x12, 0x22, 0x24, 0x0A],
+	&"silver": [0x12, 0x22, 0x24, 0x0A],
+	&"crystal": [0x12, 0x22, 0x25, 0x0A],
+}
+
+## What `_decode_sheets` decompressed: `AnimObjGFX` rows 1 to 39, whose tile
+## counts sum to this in every dump. Rows 0, 40 and 41 have no sheet.
+const EXPECTED_GFX_SHEETS: int = 39
+const EXPECTED_GFX_TILES: int = 659
+
+## Well past the longest shipped animation, which is 365 frames.
+const MAX_FRAMES: int = 4096
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_regions(game_id, data)
+		_verify_pound(game_id, data)
+		_verify_profile_split(game_id, data)
+		_verify_objects(game_id, data)
+		_verify_gfx(game_id, data)
+		_run_every_animation(game_id, data)
+	_finish()
+
+
+func _verify_regions(game_id: StringName, data: GameData) -> void:
+	for name: StringName in EXPECTED_COUNTS:
+		var region: Dictionary = data.battle_anim_region(name)
+		if not _check(not region.is_empty(), "%s: no %s region in the cache." % [game_id, name]):
+			continue
+		_check(
+			int(region["count"]) == int(EXPECTED_COUNTS[name]),
+			"%s: %s holds %d entries, not the pinned %d." % [
+				game_id, name, int(region["count"]), int(EXPECTED_COUNTS[name]),
+			]
+		)
+		_check(
+			(region["data"] as PackedByteArray).size() > 0,
+			"%s: %s region is empty." % [game_id, name]
+		)
+	print("%s: four regions, %d scripts over %d bytes." % [
+		game_id,
+		int(data.battle_anim_region(&"scripts")["count"]),
+		(data.battle_anim_region(&"scripts")["data"] as PackedByteArray).size(),
+	])
+
+
+## Entry 1 command by command, and entry 0 as the bare `anim_ret` the table pads
+## itself with.
+func _verify_pound(game_id: StringName, data: GameData) -> void:
+	var ran: Array = _run(data, POUND_INDEX)
+	if not _check(
+		ran.size() == EXPECTED_POUND.size(),
+		"%s: POUND ran %d commands, not the pinned %d." % [
+			game_id, ran.size(), EXPECTED_POUND.size(),
+		]
+	):
+		return
+	for index: int in ran.size():
+		var got: Dictionary = ran[index]
+		var want: Array = EXPECTED_POUND[index]
+		_check(
+			got["name"] == want[0] and Array(got["operands"]) == Array(want[1]),
+			"%s: POUND command %d is %s %s, not %s %s." % [
+				game_id, index, got["name"], got["operands"], want[0], want[1],
+			]
+		)
+
+	var dummy: Array = _run(data, DUMMY_INDEX)
+	_check(
+		dummy.size() == 1 and dummy[0]["name"] == Gen2BattleAnimScript.RET,
+		"%s: animation %d is not a bare anim_ret." % [game_id, DUMMY_INDEX]
+	)
+	print("%s: POUND decodes to its seven commands." % game_id)
+
+
+func _verify_profile_split(game_id: StringName, data: GameData) -> void:
+	_verify_bg_effects(game_id, data, "TACKLE", TACKLE_INDEX, TACKLE_BG_EFFECTS[game_id])
+	_verify_bg_effects(
+		game_id, data, "BODY SLAM", BODY_SLAM_INDEX, BODY_SLAM_BG_EFFECTS[game_id]
+	)
+
+
+func _verify_bg_effects(
+	game_id: StringName, data: GameData, name: String, index: int, expected: Array
+) -> void:
+	var found: Array = []
+	for command: Dictionary in _run(data, index):
+		if command["name"] == &"bg_effect":
+			found.append(int((command["operands"] as Array)[0]))
+	_check(
+		found == expected,
+		"%s: %s runs bg effects %s, not the pinned %s." % [game_id, name, found, expected]
+	)
+	print("%s: %s runs %d bg effects, %s." % [
+		game_id, name, found.size(), ", ".join(found.map(func(v: int) -> String: return "$%02X" % v)),
+	])
+
+
+## Every object row's four table indexes, which is what a wrong stride would
+## break first.
+func _verify_objects(game_id: StringName, data: GameData) -> void:
+	var count: int = int(data.battle_anim_region(&"objects")["count"])
+	var framesets: int = int(data.battle_anim_region(&"framesets")["count"])
+	var used_gfx: Dictionary = {}
+	for index: int in count:
+		var row: Dictionary = data.battle_anim_object(index)
+		if not _check(not row.is_empty(), "%s: object %d is missing." % [game_id, index]):
+			return
+		_check(
+			int(row["frameset"]) < framesets,
+			"%s: object %d names frameset %d of %d." % [
+				game_id, index, int(row["frameset"]), framesets,
+			]
+		)
+		_check(
+			int(row["palette"]) < Gen2BattleAnimImporter.PALETTE_COUNT,
+			"%s: object %d names palette %d." % [game_id, index, int(row["palette"])]
+		)
+		used_gfx[int(row["gfx"])] = true
+	print("%s: %d objects reference %d of the %d graphics rows." % [
+		game_id, count, used_gfx.size(), data.battle_anim_gfx_count(),
+	])
+
+
+func _verify_gfx(game_id: StringName, data: GameData) -> void:
+	var sheets: int = 0
+	var tiles: int = 0
+	for index: int in data.battle_anim_gfx_count():
+		var row: Dictionary = data.battle_anim_gfx(index)
+		if not bool(row["sheet"]):
+			continue
+		sheets += 1
+		tiles += int(row["tiles"])
+		var indices: PackedByteArray = data.battle_anim_gfx_indices(index)
+		_check(
+			indices.size() == int(row["tiles"]) * Gen2Tiles.TILE_PIXELS,
+			"%s: graphics %d decoded %d pixels for %d tiles." % [
+				game_id, index, indices.size(), int(row["tiles"]),
+			]
+		)
+	_check(
+		sheets == EXPECTED_GFX_SHEETS and tiles == EXPECTED_GFX_TILES,
+		"%s: %d graphics sheets over %d tiles, not the pinned %d over %d." % [
+			game_id, sheets, tiles, EXPECTED_GFX_SHEETS, EXPECTED_GFX_TILES,
+		]
+	)
+	print("%s: %d graphics sheets, %d tiles." % [game_id, sheets, tiles])
+
+
+## All 278, run to a top-level `anim_ret`. Nothing may fail, and nothing may
+## reach [constant MAX_FRAMES].
+func _run_every_animation(game_id: StringName, data: GameData) -> void:
+	var region: Dictionary = data.battle_anim_region(&"scripts")
+	var count: int = int(region["count"])
+	var commands: int = 0
+	var longest: int = 0
+	var longest_index: int = -1
+	var sounds: int = 0
+	for index: int in count:
+		var script: Gen2BattleAnimScript = _script(data, index)
+		if not _check(script != null, "%s: animation %d has no address." % [game_id, index]):
+			continue
+		var frames: int = 0
+		while not script.finished() and frames < MAX_FRAMES:
+			frames += 1
+			for command: Dictionary in script.advance_frame():
+				commands += 1
+				if command["name"] == Gen2BattleAnimScript.SOUND:
+					sounds += 1
+		_check(
+			not script.failed(),
+			"%s: animation %d ran off its region." % [game_id, index]
+		)
+		_check(
+			script.finished(),
+			"%s: animation %d never reached anim_ret in %d frames." % [
+				game_id, index, MAX_FRAMES,
+			]
+		)
+		if frames > longest:
+			longest = frames
+			longest_index = index
+	print("%s: %d animations ran %d commands, %d of them anim_sound; longest %d frames (%d)." % [
+		game_id, count, commands, sounds, longest, longest_index,
+	])
+
+
+func _run(data: GameData, index: int) -> Array:
+	var script: Gen2BattleAnimScript = _script(data, index)
+	if script == null:
+		return []
+	var out: Array = []
+	var frames: int = 0
+	while not script.finished() and frames < MAX_FRAMES:
+		frames += 1
+		out.append_array(script.advance_frame())
+	return out
+
+
+func _script(data: GameData, index: int) -> Gen2BattleAnimScript:
+	var region: Dictionary = data.battle_anim_region(&"scripts")
+	var address: int = data.battle_anim_address(index)
+	if region.is_empty() or address < 0:
+		return null
+	return Gen2BattleAnimScript.create(region["data"], int(region["address"]), address)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS battle anims: every animation ran, four tables and the graphics verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_battle_anims.gd.uid
+++ b/tools/validate_battle_anims.gd.uid
@@ -1,0 +1,1 @@
+uid://i51lejr0cwh5


### PR DESCRIPTION
The command interpreter and the five tables behind it, at cache format 29. Each table is cached as one contiguous region rather than entry by entry, because each is a pointer table immediately followed by the data it points at and every pointer inside one is bank-local: the bytes stay the cartridge's own and an address resolves by subtraction.

All 278 scripts run to a top-level anim_ret on all three cartridges. Nothing is drawn yet.