### PR TITLE
Move the objects a battle animation spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ to check without writing.
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
 | Wild encounters | Normal/swarm grass and water, 13 fishing groups with day/night substitutions, 16-row roaming graph, map-linked rates and slots, time-of-day selection, surf variance and repel checks |
 | World services | Referenced menus, mart inventories, phone contacts, special calls, bounded scripts/text, music, SFX, cries and shared waveform assets |
-| Battle animations | All 278 animation scripts, the 188 objects, 185 framesets and 216 OAM sets they are drawn from, and 39 decompressed graphics sheets |
+| Battle animations | All 278 animation scripts, the 188 objects, 185 framesets and 216 OAM sets they are drawn from, 39 decompressed graphics sheets and the sine table the motion callbacks scale with |
 
 Sprites remain colour indices and receive a palette at draw time, so shiny
 rendering needs no duplicate images.
@@ -297,7 +297,7 @@ Headless tools, all against a real imported cache:
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
-| `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, and the 39 graphics sheets, in all three games |
+| `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, the sine table the motion callbacks scale with, and the 39 graphics sheets, in all three games |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |

--- a/game/battle/battle_anim_data.gd
+++ b/game/battle/battle_anim_data.gd
@@ -19,6 +19,7 @@ const OBJECT_FIELDS: Array[StringName] = [
 
 var _regions: Dictionary = {}
 var _gfx: Array = []
+var _sine: PackedByteArray = PackedByteArray()
 
 
 ## Built from a cache. Returns null when the cache carries no animation layer,
@@ -35,14 +36,27 @@ static func from_game_data(data: GameData) -> Gen2BattleAnimData:
 	var gfx: Array = []
 	for index: int in data.battle_anim_gfx_count():
 		gfx.append(data.battle_anim_gfx(index))
-	return create(regions, gfx)
+	return create(regions, gfx, data.battle_anim_sine())
 
 
-static func create(regions: Dictionary, gfx: Array) -> Gen2BattleAnimData:
+static func create(
+	regions: Dictionary, gfx: Array, sine: PackedByteArray = PackedByteArray()
+) -> Gen2BattleAnimData:
 	var out := Gen2BattleAnimData.new()
 	out._regions = regions
 	out._gfx = gfx
+	out._sine = sine
 	return out
+
+
+## One `BattleAnimSineWave` word, which is the amplitude `BattleAnim_Sine`
+## multiplies. Entry 16 is $0100, so the table is not eight-bit and is read
+## rather than derived. Out of range answers zero, the way [method byte_at] does.
+func sine_word(index: int) -> int:
+	var at: int = index * 2
+	if at < 0 or at + 2 > _sine.size():
+		return 0
+	return _sine[at] | (_sine[at + 1] << 8)
 
 
 func region(name: StringName) -> Dictionary:

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -1,0 +1,1775 @@
+class_name Gen2BattleAnimFunctions
+extends RefCounted
+
+## The eighty motion callbacks `DoBattleAnimFrame` dispatches
+## (engine/battle_anims/functions.asm), plus the five helpers they are built
+## from.
+##
+## An object row names one of these and the `anim_obj` that spawned it supplies
+## the parameter it reads. Nearly every one is a `BattleAnim_AnonJumptable` over
+## two to four states, which is a match on the object's own `jumptable_index`,
+## and the arithmetic is on that object's coordinates, offsets and two spare
+## bytes. Every value here is a cartridge byte and wraps like one.
+##
+## Scene-free: a callback moves an object and nothing else. The three that reach
+## past the object, the ball palette, the Sky Attack `wOBP0` cycle and Surf's
+## scanline window, write player state a renderer reads rather than drawing.
+
+## `BattleAnimSineWave` has 32 samples over half a turn, so the full turn is 64
+## and `BattleAnim_Sine` masks its argument with $3f.
+const SINE_HALF: int = 0x20
+const SINE_MASK: int = 0x3F
+
+## `BattleAnim_Cosine` is `add %010000` and then the sine, a quarter turn on.
+const COSINE_OFFSET: int = 0x10
+
+## `BallColors` (data/battle_anims/ball_colors.asm), as item number to
+## `PAL_BATTLE_OB_*`. The `-1` row is the terminator `GetBallAnimPal` falls out
+## on, so an item that is not a ball is drawn grey.
+const BALL_COLORS: Array = [
+	[0x01, 5], [0x02, 3], [0x04, 6], [0x05, 4], [0x9D, 2], [0x9F, 7],
+	[0xA0, 6], [0xA1, 6], [0xA4, 3], [0xA5, 2], [0xA6, 4],
+]
+const BALL_COLOR_DEFAULT: int = 2
+
+## `BattleAnimFunc_Gust.GustOffsets`, the circle width it wobbles through.
+const GUST_OFFSETS: Array[int] = [8, 6, 5, 4, 5, 6, 8, 12, 16]
+
+## `BattleAnimFunc_Amnesia.AmnesiaOffsets`, one y offset per parameter.
+const AMNESIA_OFFSETS: Array[int] = [0xEC, 0xF8, 0x00]
+
+## `BattleAnimFunc_SkyAttack.GBCPals`. The `.SGBPals` beside it is unreachable
+## here: `hSGB` is zero on the Color hardware this project draws for, which is
+## the same branch every `_CGB_*` layout takes.
+const SKY_ATTACK_PALS: Array[int] = [0xFF, 0xAA, 0x55, 0xAA]
+
+## Framesets a callback names by number rather than by an object row
+## (constants/battle_anim_constants.asm).
+const FRAMESET_POKE_BALL_1: int = 0x09
+const FRAMESET_POKE_BALL_2: int = 0x0A
+const FRAMESET_POKE_BALL_3: int = 0x0B
+const FRAMESET_POKE_BALL_4: int = 0x0C
+const FRAMESET_POKE_BALL_5: int = 0x0D
+const FRAMESET_FLAMETHROWER: int = 0x0F
+const FRAMESET_EMBER: int = 0x10
+const FRAMESET_BURNED: int = 0x11
+const FRAMESET_RAZOR_LEAF_1: int = 0x16
+const FRAMESET_RAZOR_LEAF_2: int = 0x17
+const FRAMESET_BIG_ROCK: int = 0x19
+const FRAMESET_SLUDGE_BUBBLE_BURST: int = 0x20
+const FRAMESET_PULSING_BUBBLE: int = 0x22
+const FRAMESET_MUSIC_NOTE_1: int = 0x24
+const FRAMESET_WATER_GUN_2: int = 0x28
+const FRAMESET_WATER_GUN_3: int = 0x29
+const FRAMESET_BITE_1: int = 0x3C
+const FRAMESET_BITE_2: int = 0x3D
+const FRAMESET_EGG_WOBBLE: int = 0x4E
+const FRAMESET_EGG_CRACKED_TOP: int = 0x4F
+const FRAMESET_EGG_CRACKED_BOTTOM: int = 0x50
+const FRAMESET_LEECH_SEED_2: int = 0x57
+const FRAMESET_LEECH_SEED_3: int = 0x58
+const FRAMESET_SOUND_1: int = 0x59
+const FRAMESET_CONFUSE_RAY_1: int = 0x5D
+const FRAMESET_AMNESIA_1: int = 0x63
+const FRAMESET_STRING_SHOT_1: int = 0x6A
+const FRAMESET_PARALYZED_FLIPPED: int = 0x6E
+const FRAMESET_SPEED_LINE_1: int = 0x81
+const FRAMESET_THUNDER_WAVE_EXTRA: int = 0x35
+
+## `LOW(rSCY)`, which is what Surf puts in `hLCDCPointer` so its scanline window
+## scrolls the background vertically.
+const LCDC_POINTER_SCY: int = 0x42
+
+
+## `DoBattleAnimFrame`. Answers false when [param object]'s callback is outside
+## the jumptable, which the importer's own range check makes unreachable with
+## cartridge data and which a hand-built object can still ask for.
+static func run(
+	player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject
+) -> bool:
+	var data: Gen2BattleAnimData = player.data()
+	match object.function:
+		0x00: _null(object)
+		0x01: _user_to_target(object)
+		0x02: _user_to_target_disappear(object)
+		0x03: _move_in_circle(data, object)
+		0x04: _wave_to_target(data, object)
+		0x05: _throw_to_target(data, object)
+		0x06: _throw_to_target_disappear(data, object)
+		0x07: _drop(data, object)
+		0x08: _user_to_target_spin(data, object)
+		0x09: _shake(object)
+		0x0A: _fire_blast(data, object)
+		0x0B: _razor_leaf(data, object)
+		0x0C: _bubble(object)
+		0x0D: _surf(player, data, object)
+		0x0E: _sing(data, object)
+		0x0F: _water_gun(data, object)
+		0x10: _ember(object)
+		0x11: _powder(object)
+		0x12: _poke_ball(player, data, object)
+		0x13: _poke_ball_blocked(player, data, object)
+		0x14: _recover(data, object)
+		0x15: _thunder_wave(object)
+		0x16: _clamp_encore(data, object)
+		0x17: _bite(data, object)
+		0x18: _solar_beam(data, object)
+		0x19: _gust(data, object)
+		0x1A: _razor_wind(data, object)
+		0x1B: _kick(data, object)
+		0x1C: _absorb(object)
+		0x1D: _egg(data, object)
+		0x1E: _move_up(object)
+		0x1F: _wrap(object)
+		0x20: _leech_seed(data, object)
+		0x21: _sound(player, data, object)
+		0x22: _confuse_ray(data, object)
+		0x23: _dizzy(data, object)
+		0x24: _amnesia(object)
+		0x25: _float_up(data, object)
+		0x26: _dig(data, object)
+		0x27: _string(object)
+		0x28: _paralyzed(object)
+		0x29: _spiral_descent(data, object)
+		0x2A: _poison_gas(data, object)
+		0x2B: _horn(data, object)
+		0x2C: _needle(data, object)
+		0x2D: _petal_dance(data, object)
+		0x2E: _thief_payday(data, object)
+		0x2F: _absorb_circle(data, object)
+		0x30: _bonemerang(data, object)
+		0x31: _shiny(data, object)
+		0x32: _sky_attack(player, object)
+		0x33: _growth_swords_dance(data, object)
+		0x34: _smoke_flame_wheel(data, object)
+		0x35: _present_smokescreen(data, object)
+		0x36: _strength_seismic_toss(object)
+		0x37: _speed_line(object)
+		0x38: _sludge(object)
+		0x39: _metronome_hand(data, object)
+		0x3A: _metronome_sparkle_sketch(data, object)
+		0x3B: _agility(object)
+		0x3C: _sacred_fire(data, object)
+		0x3D: _safeguard_protect(data, object)
+		0x3E: _lock_on_mind_reader(data, object)
+		0x3F: _spikes(data, object)
+		0x40: _heal_bell_notes(data, object)
+		0x41: _baton_pass(data, object)
+		0x42: _conversion(data, object)
+		0x43: _encore_belly_drum(data, object)
+		0x44: _swagger_morning_sun(data, object)
+		0x45: _hidden_power(data, object)
+		0x46: _curse(object)
+		0x47: _perish_song(data, object)
+		0x48: _rapid_spin(object)
+		0x49: _beta_pursuit(object)
+		0x4A: _rain_sandstorm(object)
+		0x4B: _anim_obj_b0(object)
+		0x4C: _psych_up(data, object)
+		0x4D: _ancient_power(data, object)
+		0x4E: _rock_smash(data, object)
+		0x4F: _cotton(data, object)
+		_: return false
+	return true
+
+
+# ---------------------------------------------------------------- helpers ----
+
+## `BattleAnim_IncAnonJumptableIndex`.
+static func _inc(object: Gen2BattleAnimObject) -> void:
+	object.jumptable_index = (object.jumptable_index + 1) & 0xFF
+
+
+## `ReinitBattleAnimFrameset` (engine/battle_anims/helpers.asm): the frameset is
+## restarted rather than continued, which is why the frame goes back to -1.
+static func _reinit(object: Gen2BattleAnimObject, frameset: int) -> void:
+	object.frameset = frameset & 0xFF
+	object.duration = 0
+	object.frame = 0xFF
+
+
+## `sra`, which keeps the sign bit rather than shifting a zero in.
+static func _sra(value: int) -> int:
+	return ((value >> 1) | (value & 0x80)) & 0xFF
+
+
+## `BattleAnim_Sine`: [code]a = d * sin(a * pi/32)[/code], as the high byte of
+## the sixteen-bit product and negated over the second half of the turn.
+static func _sine(data: Gen2BattleAnimData, a: int, d: int) -> int:
+	var index: int = a & SINE_MASK
+	if index < SINE_HALF:
+		return _amplitude(data, index, d)
+	return (-_amplitude(data, index & (SINE_HALF - 1), d)) & 0xFF
+
+
+static func _amplitude(data: Gen2BattleAnimData, index: int, d: int) -> int:
+	return (((d & 0xFF) * data.sine_word(index)) >> 8) & 0xFF
+
+
+## `BattleAnim_Cosine`, which is the sine a quarter turn on. The quarter is added
+## as a byte before the mask, so a parameter near $ff wraps into the first turn.
+static func _cosine(data: Gen2BattleAnimData, a: int, d: int) -> int:
+	return _sine(data, (a + COSINE_OFFSET) & 0xFF, d)
+
+
+## `BattleAnim_StepToTarget`: the low nybble of [param a] rightwards and half of
+## it upwards.
+##
+## The vertical half is a `dec`/`jr nz` loop, so a nybble under two runs it 256
+## times rather than none and the object does not move up at all.
+static func _step_to_target(object: Gen2BattleAnimObject, a: int) -> void:
+	var step: int = a & 0xF
+	object.x = (object.x + step) & 0xFF
+	var count: int = step >> 1
+	object.y = (object.y - (count if count != 0 else 0x100)) & 0xFF
+
+
+## `BattleAnim_StepCircle`: a circle whose height is a quarter of its width.
+static func _step_circle(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject, a: int, d: int
+) -> void:
+	object.y_offset = _sra(_sra(_sine(data, a, d)))
+	object.x_offset = _cosine(data, a, d)
+
+
+## `BattleAnim_StepThrownToTarget`: a parabola towards the other side, whose two
+## halves are the parameter's two nybbles. Entered with [param a] holding var2's
+## value from before its own decrement, the way both callers leave it.
+static func _step_thrown_to_target(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject, a: int
+) -> void:
+	object.var2 = (object.var2 - 1) & 0xFF
+	object.y_offset = _sine(data, a, 0x20)
+	object.y_fix = (object.y_fix + 2) & 0xFF
+
+	var de: int = (object.x << 8) | object.var1
+	var hl: int = (((object.param & 0xF0) >> 4) << 8) | ((object.param & 0xF) << 4)
+	hl = (hl + de) & 0xFFFF
+	object.var1 = hl & 0xFF
+	object.x = hl >> 8
+
+	if (object.var2 & 1) != 0:
+		return
+	object.y = (object.y - 1) & 0xFF
+
+
+## `GetBallAnimPal`: the thrown ball's own colour, off `wCurItem`.
+static func _ball_palette(player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject) -> void:
+	for row: Variant in BALL_COLORS:
+		if int((row as Array)[0]) == player.cur_item:
+			object.palette = int((row as Array)[1])
+			return
+	object.palette = BALL_COLOR_DEFAULT
+
+
+# -------------------------------------------------------------- callbacks ----
+
+## `BattleAnimFunc_Null`, which is not a no-op: its second state deletes the
+## object, and that is how `anim_incobj` retires the sixty-two rows that use it.
+static func _null(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 1:
+		object.deinit()
+
+
+static func _user_to_target(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index != 0:
+		object.deinit()
+		return
+	if object.x >= 0x84:
+		return
+	_step_to_target(object, object.param)
+
+
+static func _user_to_target_disappear(object: Gen2BattleAnimObject) -> void:
+	if object.x >= 0x84:
+		object.deinit()
+		return
+	_step_to_target(object, object.param)
+
+
+## Bit 7 of the parameter starts the object on the other side of the circle and
+## is then cleared, since the rest of the byte is the radius.
+static func _move_in_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x00 if (object.param & 0x80) == 0 else 0x20
+		object.param &= 0x7F
+	object.y_offset = _sine(data, object.var1, object.param)
+	object.x_offset = _cosine(data, object.var1, object.param)
+	object.var1 = (object.var1 + 1) & 0xFF
+
+
+static func _wave_to_target(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.x >= 0x88:
+		object.deinit()
+		return
+	object.x = (object.x + 2) & 0xFF
+	object.y = (object.y - 1) & 0xFF
+	var a: int = object.var1
+	object.var1 = (object.var1 + 4) & 0xFF
+	object.y_offset = _sine(data, a, 0x10)
+	object.x_offset = _sra(_sra(_sra(_sra(_cosine(data, a, 0x10)))))
+
+
+## `BattleAnimFunc_ThrowFromUserToTarget`, whose carry flag is its answer: false
+## once the object has reached the far side, which is what the disappearing
+## variant and the Poke Ball both branch on.
+static func _throw_to_target(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> bool:
+	if object.x >= 0x88:
+		return false
+	object.x = (object.x + 2) & 0xFF
+	object.y = (object.y - 1) & 0xFF
+	var a: int = object.var1
+	object.var1 = (object.var1 - 1) & 0xFF
+	object.y_offset = _sine(data, a, object.param)
+	return true
+
+
+static func _throw_to_target_disappear(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	if _throw_to_target(data, object):
+		return
+	object.deinit()
+
+
+static func _drop(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x30
+		object.var2 = 0x48
+	object.y_offset = _sine(data, object.var1, object.var2)
+	object.var1 = (object.var1 + 1) & 0xFF
+	if (object.var1 & 0x3F) != 0:
+		return
+	object.var1 = 0x20
+	var left: int = object.var2 - object.param
+	if left <= 0:
+		object.deinit()
+		return
+	object.var2 = left
+
+
+static func _user_to_target_spin(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	if object.jumptable_index == 0:
+		if object.x < 0x80:
+			# `.SetCoords` is `BattleAnim_StepToTarget` written out again, the
+			# 256-step vertical loop included.
+			_step_to_target(object, object.param)
+			return
+		_inc(object)
+	if object.jumptable_index == 1:
+		_inc(object)
+		object.var1 = 0x00
+	if object.jumptable_index == 2:
+		if object.var1 < 0x40:
+			object.y_offset = _sra((_cosine(data, object.var1, 0x18) - 0x18) & 0xFF)
+			object.x_offset = _sine(data, object.var1, 0x18)
+			object.var1 = (object.var1 + (object.param & 0xF)) & 0xFF
+			return
+		# One more lap while the parameter's high nybble has laps left in it.
+		var laps: int = object.param & 0xF0
+		if laps != 0:
+			object.param = (object.param & 0xF) | (laps - 0x10)
+			object.jumptable_index = (object.jumptable_index - 1) & 0xFF
+			return
+		_inc(object)
+	if object.x >= 0xB0:
+		object.deinit()
+		return
+	_step_to_target(object, object.param)
+
+
+static func _shake(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var1 = 0x00
+			object.x_offset = object.param & 0xF
+			_shake_step(object)
+		1:
+			_shake_step(object)
+		2:
+			object.deinit()
+
+
+static func _shake_step(object: Gen2BattleAnimObject) -> void:
+	if object.var1 != 0:
+		object.var1 = (object.var1 - 1) & 0xFF
+		return
+	object.var1 = (object.param >> 4) & 0xF
+	object.x_offset = (-object.x_offset) & 0xFF
+
+
+## The parameter is the state to start in, so one object row draws nine
+## different flames.
+static func _fire_blast(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		object.jumptable_index = object.param
+		if object.jumptable_index != 7:
+			_reinit(object, FRAMESET_BURNED)
+			return
+	match object.jumptable_index:
+		1:
+			object.y_offset = (object.y_offset - 1) & 0xFF
+		2:
+			object.x_offset = (object.x_offset - 1) & 0xFF
+		3:
+			object.x_offset = (object.x_offset + 1) & 0xFF
+		4:
+			object.y_offset = (object.y_offset + 1) & 0xFF
+			object.x_offset = (object.x_offset - 1) & 0xFF
+		5:
+			object.y_offset = (object.y_offset + 1) & 0xFF
+			object.x_offset = (object.x_offset + 1) & 0xFF
+		6:
+			pass
+		7:
+			if object.x >= 0x88:
+				_inc(object)
+				_reinit(object, FRAMESET_EMBER)
+				_fire_blast_circle(data, object)
+				return
+			object.x = (object.x + 2) & 0xFF
+			object.y = (object.y - 1) & 0xFF
+		8:
+			_fire_blast_circle(data, object)
+		9:
+			object.deinit()
+
+
+static func _fire_blast_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	object.y_offset = _sine(data, object.var1, 0x10)
+	object.x_offset = _cosine(data, object.var1, 0x10)
+	object.var1 = (object.var1 + 1) & 0xFF
+
+
+static func _razor_leaf(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var1 = 0x40
+			_razor_leaf_fall(data, object)
+		1:
+			_razor_leaf_fall(data, object)
+		2:
+			if object.y_offset == 0x20:
+				object.deinit()
+				return
+			object.x_offset = _sine(data, object.var1, 0x10)
+			if (object.param & 0x40) != 0:
+				object.var1 = (object.var1 - 1) & 0xFF
+			else:
+				object.var1 = (object.var1 + 1) & 0xFF
+			var hl: int = (((object.y_offset << 8) | object.var2) + 0x80) & 0xFFFF
+			object.y_offset = hl >> 8
+			object.var2 = hl & 0xFF
+		3:
+			_reinit(object, FRAMESET_RAZOR_LEAF_1)
+			object.oam_flags &= ~Gen2BattleAnimObject.OAM_XFLIP & 0xFF
+			_inc(object)
+		4, 5, 6, 7:
+			_inc(object)
+		8:
+			if object.x >= 0xC0:
+				return
+			_step_to_target(object, 0x8)
+
+
+## The first state of both leaf callbacks: the arc down, and the switch to the
+## second frameset once it has fallen far enough.
+static func _razor_leaf_fall(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.var1 < 0x30:
+		_inc(object)
+		object.var1 = 0x00
+		object.var2 = 0x00
+		_reinit(object, FRAMESET_RAZOR_LEAF_2)
+		if (object.param & 0x40) == 0:
+			return
+		object.frame = 0x5
+		return
+	_arc_horizontal(data, object)
+
+
+## The half `BattleAnimFunc_RazorLeaf` and `..._RockSmash` share: a sine on the
+## y offset and a sixteen-bit horizontal step whose low byte lives in var2.
+static func _arc_horizontal(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.var1
+	object.var1 = (object.var1 - 1) & 0xFF
+	object.y_offset = _sine(data, a, object.param & 0x3F)
+	var hl: int = (((object.x << 8) | object.var2) + _scatter_horizontal(object.param)) & 0xFFFF
+	object.x = hl >> 8
+	object.var2 = hl & 0xFF
+
+
+## `BattleAnim_ScatterHorizontal`: how far sideways one frame of that arc is,
+## with bit 7 of the parameter deciding which way.
+static func _scatter_horizontal(param: int) -> int:
+	if (param & 0x80) != 0:
+		var negative: int = param & 0x3F
+		if negative >= 0x20:
+			return -0x100
+		if negative >= 0x18:
+			return -0x180
+		return -0x200
+	if param >= 0x20:
+		return 0x100
+	if param >= 0x18:
+		return 0x180
+	return 0x200
+
+
+static func _bubble(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var1 = 0xC
+			_bubble_approach(object)
+		1:
+			_bubble_approach(object)
+		2:
+			_bubble_rise(object)
+
+
+static func _bubble_approach(object: Gen2BattleAnimObject) -> void:
+	if object.var1 != 0:
+		object.var1 = (object.var1 - 1) & 0xFF
+		_step_to_target(object, object.param)
+		return
+	_inc(object)
+	object.var1 = 0x00
+	_reinit(object, FRAMESET_PULSING_BUBBLE)
+	_bubble_rise(object)
+
+
+static func _bubble_rise(object: Gen2BattleAnimObject) -> void:
+	if object.x < 0x98:
+		var horizontal: int = (((object.x << 8) | object.var1) + 0x60) & 0xFFFF
+		object.var1 = horizontal & 0xFF
+		object.x = horizontal >> 8
+	if object.y < 0x20:
+		return
+	var vertical: int = (((object.y << 8) | object.var2) + 0xFF00 + (object.param & 0xF0)) & 0xFFFF
+	object.var2 = vertical & 0xFF
+	object.y = vertical >> 8
+
+
+## The one callback that owns a scanline window: `hLYOverrideStart` follows the
+## wave down the screen and is handed back when it reaches the bottom.
+static func _surf(
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			player.lcdc_pointer = LCDC_POINTER_SCY
+			player.ly_override_start = 0x58
+			player.ly_override_end = 0x5E
+		1:
+			if object.y < object.param:
+				_inc(object)
+				player.ly_override_start = 0
+				return
+			object.y = (object.y - 1) & 0xFF
+			var wave: int = _sine(data, object.var1, 0x10)
+			object.y_offset = wave
+			var line: int = ((wave + object.y) & 0xFF) - 0x10
+			if line < 0:
+				return
+			player.ly_override_start = line
+			object.x_offset = (object.x_offset + 1) & 0x7
+			object.var1 = (object.var1 + 2) & 0xFF
+		2:
+			pass
+		3:
+			if object.y < 0x70:
+				object.y = (object.y + 2) & 0xFF
+				var below: int = object.y - 0x10
+				if below < 0:
+					return
+				player.ly_override_start = below
+				return
+			player.lcdc_pointer = 0
+			player.ly_override_start = 0
+			player.ly_override_end = 0
+			object.deinit()
+		4:
+			object.deinit()
+
+
+static func _sing(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		_reinit(object, FRAMESET_MUSIC_NOTE_1 + object.param)
+	if object.x >= 0xB8:
+		object.deinit()
+		return
+	_step_to_target(object, 0x2)
+	var a: int = object.var1
+	object.var1 = (object.var1 - 1) & 0xFF
+	object.y_offset = _sine(data, a, 0x8)
+
+
+static func _water_gun(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+	match object.jumptable_index:
+		1:
+			if object.y >= 0x30:
+				_step_to_target(object, 0x2)
+				var a: int = object.var1
+				object.var1 = (object.var1 - 1) & 0xFF
+				object.y_offset = _sine(data, a, 0x8)
+				return
+			_inc(object)
+			_reinit(object, FRAMESET_WATER_GUN_2)
+			object.y_offset = 0x00
+			object.y = 0x30
+			object.oam_flags &= Gen2BattleAnimObject.OAM_FLAGS_FIX_COORDS
+			_water_gun_splash(object)
+		2:
+			_water_gun_splash(object)
+		3:
+			pass
+
+
+static func _water_gun_splash(object: Gen2BattleAnimObject) -> void:
+	if object.y_offset < 0x18:
+		object.y_offset = (object.y_offset + 1) & 0xFF
+		return
+	_inc(object)
+	_reinit(object, FRAMESET_WATER_GUN_3)
+
+
+static func _ember(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			object.jumptable_index = (object.param >> 4) & 0xF
+		1:
+			if object.x >= 0x88:
+				return
+			_step_to_target(object, object.param)
+		2:
+			object.deinit()
+		3:
+			_inc(object)
+			_reinit(object, FRAMESET_FLAMETHROWER)
+		4:
+			pass
+
+
+static func _powder(object: Gen2BattleAnimObject) -> void:
+	if object.y_offset >= 0x38:
+		object.deinit()
+		return
+	var fall: int = (((object.y_offset << 8) | object.var1) + 0x80) & 0xFFFF
+	object.var1 = fall & 0xFF
+	object.y_offset = fall >> 8
+	object.x_offset ^= 0x10
+
+
+static func _poke_ball(
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	match object.jumptable_index:
+		0:
+			_ball_palette(player, object)
+			_inc(object)
+		1:
+			if _throw_to_target(data, object):
+				return
+			object.y = (object.y + object.y_offset) & 0xFF
+			_reinit(object, FRAMESET_POKE_BALL_3)
+			_inc(object)
+		2, 5, 9:
+			pass
+		3:
+			_inc(object)
+			_reinit(object, FRAMESET_POKE_BALL_1)
+			object.var1 = 0x00
+			object.var2 = 0x10
+			_poke_ball_bounce(data, object)
+		4:
+			_poke_ball_bounce(data, object)
+		6:
+			_reinit(object, FRAMESET_POKE_BALL_5)
+			object.jumptable_index = (object.jumptable_index - 1) & 0xFF
+		7:
+			_ball_palette(player, object)
+			_reinit(object, FRAMESET_POKE_BALL_2)
+			_inc(object)
+			object.var2 = 0x20
+			_poke_ball_wobble(data, object)
+		8, 10:
+			_poke_ball_wobble(data, object)
+		11:
+			object.deinit()
+
+
+## The ball settling: a shrinking bounce whose amplitude drops four at a time.
+static func _poke_ball_bounce(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	object.y_offset = _sine(data, object.var1, object.var2)
+	object.var1 = (object.var1 - 1) & 0xFF
+	# The masked value is written back, so a var1 of $20 or $40 lands on zero
+	# rather than keeping its high bits.
+	if (object.var1 & 0x1F) != 0:
+		return
+	object.var1 = 0x00
+	object.var2 = (object.var2 - 4) & 0xFF
+	if object.var2 != 0:
+		return
+	_reinit(object, FRAMESET_POKE_BALL_4)
+	_inc(object)
+
+
+## The three wobbles, each ending on the state after it.
+static func _poke_ball_wobble(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	object.y_offset = _sine(data, object.var1, object.var2)
+	object.var1 = (object.var1 - 1) & 0xFF
+	if (object.var1 & 0x1F) == 0:
+		object.deinit()
+		return
+	if (object.var1 & 0xF) != 0:
+		return
+	_inc(object)
+
+
+static func _poke_ball_blocked(
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	match object.jumptable_index:
+		0:
+			_ball_palette(player, object)
+			_inc(object)
+		1:
+			if object.x < 0x70:
+				_throw_to_target(data, object)
+				return
+			_inc(object)
+			_poke_ball_fall(object)
+		2:
+			_poke_ball_fall(object)
+
+
+static func _poke_ball_fall(object: Gen2BattleAnimObject) -> void:
+	if object.y >= 0x80:
+		object.deinit()
+		return
+	object.y = (object.y + 4) & 0xFF
+	object.x = (object.x - 2) & 0xFF
+
+
+## The parameter is both the starting angle and the radius, and the radius is
+## what runs out: the object is deleted once the circle has closed.
+static func _recover(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var2 = object.param & 0xF0
+		object.var1 = ((object.param & 0xF) << 3) & 0xFF
+		object.param = 0x1
+	if object.var2 == 0:
+		object.deinit()
+		return
+	var a: int = object.var1
+	object.var1 = (object.var1 + 1) & 0xFF
+	object.y_offset = _sine(data, a, object.var2)
+	object.x_offset = _cosine(data, a, object.var2)
+	object.param ^= 0x1
+	if object.param == 0:
+		return
+	object.var2 = (object.var2 - 1) & 0xFF
+
+
+static func _thunder_wave(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		1:
+			_inc(object)
+			_reinit(object, FRAMESET_THUNDER_WAVE_EXTRA)
+		3:
+			object.deinit()
+
+
+## Two hands clapped together twice. The parameter is the distance from the
+## centre, and its bit 7 picks the mirrored frameset of the pair.
+static func _clamp_encore(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var2 = object.frameset
+		object.var1 = 0x30 if (object.param & 0x80) != 0 else 0x10
+		object.param &= 0x7F
+	match object.jumptable_index:
+		1:
+			var step: int = _sine(data, object.var1, object.param)
+			object.x_offset = step
+			_reinit(object, object.var2 if (step & 0x80) != 0 else object.var2 + 1)
+			object.var1 = (object.var1 + 1) & 0xFF
+			if (object.var1 & 0x1F) != 0:
+				return
+			_inc(object)
+		2, 3, 4, 5:
+			_inc(object)
+		6:
+			object.jumptable_index = 0x1
+
+
+static func _bite(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x30 if (object.param & 0x80) != 0 else 0x10
+		object.param &= 0x7F
+	match object.jumptable_index:
+		1:
+			var step: int = _sine(data, object.var1, object.param)
+			object.y_offset = step
+			_reinit(object, FRAMESET_BITE_1 if (step & 0x80) != 0 else FRAMESET_BITE_2)
+			object.var1 = (object.var1 + 2) & 0xFF
+			if (object.var1 & 0x1F) != 0:
+				return
+			_inc(object)
+		2, 3, 4, 5:
+			_inc(object)
+		6:
+			object.jumptable_index = 0x1
+
+
+static func _solar_beam(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x28
+		object.var2 = 0x00
+	object.y_offset = _sine(data, object.param, object.var1)
+	object.x_offset = _cosine(data, object.param, object.var1)
+	if object.var1 == 0:
+		object.deinit()
+		return
+	var shrink: int = (((object.var1 << 8) | object.var2) - 0x80) & 0xFFFF
+	object.var2 = shrink & 0xFF
+	object.var1 = shrink >> 8
+
+
+static func _gust(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.param = 0
+			_gust_wobble(data, object)
+		1, 3:
+			_gust_wobble(data, object)
+		2:
+			if object.x < 0x88:
+				_gust_move(data, object)
+				return
+			_inc(object)
+		4:
+			if object.x < 0xB8:
+				_gust_move(data, object)
+				return
+			object.deinit()
+
+
+static func _gust_move(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	_gust_wobble(data, object)
+	object.x = (object.x + 1) & 0xFF
+	if (object.x & 0x1) != 0:
+		return
+	object.y = (object.y - 1) & 0xFF
+
+
+## A circle whose width comes from a nine-entry list and whose height is a
+## sixteenth of it. The list is never indexed past its end: var2 only climbs
+## while the parameter counts down from $ff to $c2, which is seven steps.
+static func _gust_wobble(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var radius: int = GUST_OFFSETS[object.var2] if object.var2 < GUST_OFFSETS.size() else 0
+	var a: int = object.var1
+	object.y_offset = (_sra(_sra(_sra(_sra(_sine(data, a, radius))))) + object.param) & 0xFF
+	object.x_offset = _cosine(data, a, radius)
+	object.var1 = (object.var1 - 0x8) & 0xFF
+
+	if object.param != 0 and object.param < 0xC2:
+		object.var2 = 0
+		object.param = 0
+		object.x_offset = 0
+		object.y_offset = 0
+		return
+	object.param = (object.param - 1) & 0xFF
+	if (object.param & 0x7) != 0:
+		return
+	object.var2 = (object.var2 + 1) & 0xFF
+
+
+static func _razor_wind(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	_move_in_circle(data, object)
+	object.var1 = (object.var1 + 0xF) & 0xFF
+
+
+static func _kick(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			pass
+		1:
+			if object.y < 0x30:
+				object.y = (object.y + 4) & 0xFF
+				return
+			object.jumptable_index = 0x0
+		2:
+			if object.x >= 0x98:
+				return
+			object.x = (object.x + 2) & 0xFF
+			object.oam_flags |= Gen2BattleAnimObject.OAM_FLAGS_FIX_COORDS
+			object.y_fix = 0x90
+			object.frame = 0x0
+			object.duration = 0x2
+			object.y = (object.y - 1) & 0xFF
+		3:
+			_inc(object)
+			object.var1 = 0x2C
+			object.frame = 0x0
+			object.duration = 0x80
+			_rolling_kick(data, object)
+		4:
+			_rolling_kick(data, object)
+
+
+static func _rolling_kick(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.x >= 0x98:
+		return
+	object.x = (object.x + 2) & 0xFF
+	var a: int = object.var1
+	object.var1 = (object.var1 + 1) & 0xFF
+	object.y_offset = _sine(data, a, 0x8)
+
+
+## The mirror of [method _user_to_target_disappear]: back towards the user, with
+## the same 256-step vertical loop when the nybble is under two.
+static func _absorb(object: Gen2BattleAnimObject) -> void:
+	if object.x < 0x30:
+		object.deinit()
+		return
+	var step: int = object.param & 0xF
+	object.x = (object.x - step) & 0xFF
+	var count: int = step >> 1
+	object.y = (object.y + (count if count != 0 else 0x100)) & 0xFF
+
+
+## Egg Bomb and Softboiled share fourteen states; the parameter picks which one
+## the object starts on.
+static func _egg(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			object.var1 = 0x28
+			object.var2 = 0x10
+			object.jumptable_index = object.param
+		1:
+			if object.x < 0x40:
+				object.x = (object.x + 1) & 0xFF
+			_egg_wave(data, object)
+		2:
+			if object.x >= 0x88:
+				object.jumptable_index = (object.jumptable_index + 2) & 0xFF
+				return
+			if (object.x & 0xF) != 0:
+				_egg_step(object)
+				return
+			object.var2 = 0x10
+			_inc(object)
+		3:
+			if object.var2 != 0:
+				object.var2 = (object.var2 - 1) & 0xFF
+				return
+			object.jumptable_index = (object.jumptable_index - 1) & 0xFF
+			_egg_step(object)
+		4, 10, 13:
+			pass
+		5:
+			object.deinit()
+		6:
+			if object.x < 0x4B:
+				object.x = (object.x + 1) & 0xFF
+			_egg_wave(data, object)
+		7:
+			_reinit(object, FRAMESET_EGG_WOBBLE)
+			_inc(object)
+		8:
+			var a: int = object.var1
+			object.var1 = (object.var1 + 2) & 0xFF
+			object.x_offset = _sine(data, a, 0x2)
+		9:
+			_reinit(object, FRAMESET_EGG_CRACKED_BOTTOM)
+			object.y_offset = 0x4
+			_inc(object)
+		11:
+			_reinit(object, FRAMESET_EGG_CRACKED_TOP)
+			_inc(object)
+			object.var1 = 0x40
+		12:
+			object.y_offset = _sine(data, object.var1, 0x20)
+			if object.var1 < 0x30:
+				_inc(object)
+				return
+			object.var1 = (object.var1 - 1) & 0xFF
+
+
+static func _egg_step(object: Gen2BattleAnimObject) -> void:
+	object.x = (object.x + 1) & 0xFF
+	var rise: int = (((object.y << 8) | object.var1) - 0x80) & 0xFFFF
+	object.y = rise >> 8
+	object.var1 = rise & 0xFF
+
+
+## `.EggVerticalWaveMotion`, whose amplitude drops eight at a time and whose
+## running out is what moves the object on to the next state.
+static func _egg_wave(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	object.y_offset = _sine(data, object.var1, object.var2)
+	object.var1 = (object.var1 + 1) & 0xFF
+	if (object.var1 & 0x3F) != 0:
+		return
+	object.var1 = 0x20
+	object.var2 = (object.var2 - 0x8) & 0xFF
+	if object.var2 != 0:
+		return
+	object.var1 = 0x00
+	object.var2 = 0x00
+	_inc(object)
+
+
+static func _move_up(object: Gen2BattleAnimObject) -> void:
+	if object.y_offset != 0 and object.y_offset < 0xD8:
+		object.deinit()
+		return
+	object.y_offset = (object.y_offset - object.param) & 0xFF
+
+
+static func _wrap(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index != 1:
+		return
+	_reinit(object, object.frameset + 1)
+	_inc(object)
+	object.var1 = 0x8
+
+
+static func _leech_seed(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var2 = 0x40
+		1:
+			if object.var2 >= 0x20:
+				_step_thrown_to_target(data, object, object.var2)
+				return
+			object.var2 = 0x40
+			_reinit(object, FRAMESET_LEECH_SEED_2)
+			_inc(object)
+		2:
+			if object.var2 != 0:
+				object.var2 = (object.var2 - 1) & 0xFF
+				return
+			_inc(object)
+			_reinit(object, FRAMESET_LEECH_SEED_3)
+
+
+## Growl, Snore and Kinesis. The angle is mirrored on the enemy's turn, which is
+## the one callback that reads `hBattleTurn` for anything but a palette.
+static func _sound(
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	if object.jumptable_index == 0:
+		if player.enemy_turn():
+			object.param = (~object.param + 3) & 0xFF
+		_inc(object)
+		object.var1 = 0x8
+		_reinit(object, FRAMESET_SOUND_1 + object.param)
+		return
+	if object.var1 == 0:
+		object.deinit()
+		return
+	object.var1 = (object.var1 - 1) & 0xFF
+
+	var a: int = object.var2
+	object.var2 = (object.var2 + 2) & 0xFF
+	var step: int = _sine(data, a, 0x10)
+	object.x_offset = step
+	if object.param == 0:
+		object.y_offset = (-step) & 0xFF
+		return
+	if object.param == 1:
+		return
+	object.y_offset = step
+
+
+static func _confuse_ray(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var2 = object.param & 0x3F
+		object.param = 1 if (object.param & 0x80) != 0 else 0
+		_reinit(object, FRAMESET_CONFUSE_RAY_1 + object.param)
+		return
+
+	var radius: int = ((object.param << 4) | (object.param >> 4)) & 0xFF
+	var a: int = object.var2
+	object.var2 = (object.var2 + 1) & 0xFF
+	object.y_offset = _sine(data, a, radius)
+	object.x_offset = _cosine(data, a, radius)
+	if object.x >= 0x80:
+		return
+	var phase: int = object.var2 & 0x3
+	if phase == 0:
+		object.y = (object.y - 1) & 0xFF
+	if (phase & 0x1) != 0:
+		return
+	object.x = (object.x + 1) & 0xFF
+
+
+static func _dizzy(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = object.frameset
+		_reinit(object, object.var1 + (1 if (object.param & 0x80) != 0 else 0))
+		object.param &= 0x7F
+
+	object.y_offset = _sra(_sra(_sine(data, object.param, 0x10)))
+	object.x_offset = _cosine(data, object.param, 0x10)
+	var phase: int = object.param & 0x3F
+	object.param = (object.param + 1) & 0xFF
+	if phase == 0:
+		_reinit(object, object.var1)
+		return
+	if (phase & 0x1F) != 0:
+		return
+	_reinit(object, object.var1 + 1)
+
+
+static func _amnesia(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			_reinit(object, FRAMESET_AMNESIA_1 + object.param)
+			object.y_offset = AMNESIA_OFFSETS[object.param] \
+				if object.param < AMNESIA_OFFSETS.size() else 0
+		2:
+			object.deinit()
+
+
+static func _float_up(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.var1
+	object.var1 = (object.var1 + 2) & 0xFF
+	object.x_offset = _sine(data, a, 0x4)
+	var rise: int = (((object.y_offset << 8) | object.var2) + 0xFFA0) & 0xFFFF
+	object.y_offset = rise >> 8
+	object.var2 = rise & 0xFF
+
+
+static func _dig(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.var1
+	object.var1 = (object.var1 - 2) & 0xFF
+	object.y_offset = _sine(data, a, 0x10)
+	object.x = (object.x + 1) & 0xFF
+
+
+static func _string(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index != 0:
+		return
+	_inc(object)
+	if object.param == 0:
+		object.oam_flags |= Gen2BattleAnimObject.OAM_YFLIP
+	_reinit(object, FRAMESET_STRING_SHOT_1 + object.param)
+
+
+## Bit 7 of the parameter picks the mirrored frameset and is then gone: the two
+## nybbles left are how long between switches and how far each way.
+static func _paralyzed(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x00
+		var param: int = object.param
+		object.param = (param & 0x70) >> 4
+		if (param & 0x80) != 0:
+			object.x_offset = (-(param & 0xF)) & 0xFF
+			_reinit(object, FRAMESET_PARALYZED_FLIPPED)
+		else:
+			object.x_offset = param & 0xF
+		return
+	if object.var1 != 0:
+		object.var1 = (object.var1 - 1) & 0xFF
+		return
+	object.var1 = object.param
+	object.x_offset = (-object.x_offset) & 0xFF
+
+
+static func _spiral_descent(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	_descend(data, object, 0x7)
+
+
+static func _petal_dance(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	_descend(data, object, 0x3)
+
+
+## The spiral `BattleAnimFunc_SpiralDescent` and `..._PetalDance` share: they
+## differ only in how often the object sinks a pixel.
+static func _descend(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject, mask: int
+) -> void:
+	var a: int = object.var1
+	object.y_offset = (_sra(_sra(_sra(_sine(data, a, 0x18)))) + object.var2) & 0xFF
+	object.x_offset = _cosine(data, a, 0x18)
+	object.var1 = (object.var1 + 1) & 0xFF
+	if (object.var1 & mask) != 0:
+		return
+	if object.var2 >= 0x28:
+		object.deinit()
+		return
+	object.var2 = (object.var2 + 1) & 0xFF
+
+
+static func _poison_gas(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index != 0:
+		_spiral_descent(data, object)
+		return
+	if object.x >= 0x84:
+		_inc(object)
+		return
+	object.x = (object.x + 1) & 0xFF
+	var a: int = object.var1
+	object.var1 = (object.var1 + 1) & 0xFF
+	object.x_offset = _cosine(data, a, 0x18)
+	if (object.x & 0x1) != 0:
+		return
+	object.y = (object.y - 1) & 0xFF
+
+
+static func _horn(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			object.jumptable_index = object.param
+			object.var1 = object.y
+		1:
+			if object.x >= 0x58:
+				return
+			_step_to_target(object, 0x2)
+		2:
+			if object.var2 >= 0x20:
+				object.deinit()
+				return
+			_horn_sweep(data, object)
+		3:
+			_horn_sweep(data, object)
+
+
+static func _horn_sweep(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var step: int = _sine(data, object.var2, 0x8)
+	object.x_offset = step
+	object.y = (((-_sra(step)) & 0xFF) + object.var1) & 0xFF
+	object.var2 = (object.var2 + 0x8) & 0xFF
+
+
+## The parameter's high nybble picks the state and its low nybble the speed, so
+## one row is both the straight needle and the arcing one.
+static func _needle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			object.jumptable_index = (object.param & 0xF0) >> 4
+		2:
+			var arc: int = _sine(data, object.var1, 0x10)
+			# Only the negative half of the sine is stored, so the arc is one
+			# hump rather than a wave.
+			if (arc & 0x80) != 0:
+				object.y_offset = arc
+			object.var1 = (object.var1 - 4) & 0xFF
+			_needle_advance(object)
+		1:
+			_needle_advance(object)
+
+
+static func _needle_advance(object: Gen2BattleAnimObject) -> void:
+	if object.x >= 0x84:
+		object.deinit()
+		return
+	_step_to_target(object, object.param)
+
+
+static func _thief_payday(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x28
+		object.var2 = (object.y - 0x28) & 0xFF
+	object.y_offset = _sine(data, object.var1, object.var2)
+	if (object.var1 & object.param) == 0:
+		object.x = (object.x - 1) & 0xFF
+	object.var1 = (object.var1 + 1) & 0xFF
+	if (object.var1 & 0x3F) != 0:
+		return
+	object.var1 = 0x20
+	object.var2 >>= 1
+
+
+## A ring that widens on the way in and closes on the way out, the object going
+## when its radius reaches zero.
+static func _absorb_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	object.y_offset = _sine(data, object.param, object.var1)
+	object.x_offset = _cosine(data, object.param, object.var1)
+	object.param = (object.param + 1) & 0xFF
+	if (object.param & 0x1) == 0:
+		object.x = (object.x - 1) & 0xFF
+	if (object.param & 0x3) == 0:
+		object.y = (object.y + 1) & 0xFF
+	if object.x >= 0x5A:
+		object.var1 = (object.var1 + 1) & 0xFF
+		return
+	if object.var1 == 0:
+		object.deinit()
+		return
+	object.var1 = (object.var1 - 1) & 0xFF
+
+
+static func _bonemerang(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var2 = object.y
+	object.y = (_sine(data, object.param, 0x30) + object.var2) & 0xFF
+	object.x_offset = _cosine(data, (object.param + 0x8) & 0xFF, 0x30)
+	object.param = (object.param + 1) & 0xFF
+
+
+static func _shiny(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index != 0:
+		return
+	_inc(object)
+	object.y_offset = _sine(data, object.param, 0x10)
+	object.x_offset = _cosine(data, object.param, 0x10)
+	object.var2 = 0xF
+
+
+static func _sky_attack(player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var1 = 0xCC if player.enemy_turn() else 0xF0
+		1:
+			_sky_attack_palette(player, object)
+		2:
+			_sky_attack_palette(player, object)
+			if object.x >= 0x84:
+				return
+			_step_to_target(object, 0x4)
+		3:
+			_sky_attack_palette(player, object)
+			if object.x >= 0xD0:
+				object.deinit()
+				return
+			_step_to_target(object, 0x4)
+
+
+## `.SkyAttack_CyclePalette`, which flashes `wOBP0`. That register is a DMG
+## object palette, so on the Color hardware the write lands and shows nothing;
+## it is kept because dropping it would lose the one thing this state does.
+static func _sky_attack_palette(
+	player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject
+) -> void:
+	var phase: int = object.var2 & 0x7
+	object.var2 = (object.var2 + 1) & 0xFF
+	player.obp0 = SKY_ATTACK_PALS[phase >> 1] & object.var1
+
+
+static func _growth_swords_dance(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	object.y_offset = (_sra(_sra(_sra(_sine(data, object.param, 0x18)))) + object.var2) & 0xFF
+	object.x_offset = _cosine(data, object.param, 0x18)
+	object.param = (object.param + 1) & 0xFF
+	object.var2 = (object.var2 - 2) & 0xFF
+
+
+static func _smoke_flame_wheel(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	_rise_in_circle(data, object, 0x7, 0xE8, 1)
+
+
+static func _sacred_fire(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	_rise_in_circle(data, object, 0x3, 0xD0, 2)
+
+
+## The spiral `BattleAnimFunc_SmokeFlameWheel` and `..._SacredFire` share: they
+## differ in how often the object rises, how far, and where it stops.
+static func _rise_in_circle(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject,
+	mask: int, limit: int, step: int
+) -> void:
+	object.y_offset = (_sra(_sra(_sra(_sine(data, object.param, 0x18)))) + object.var2) & 0xFF
+	object.x_offset = _cosine(data, object.param, 0x18)
+	object.param = (object.param + 2) & 0xFF
+	if (object.param & mask) != 0:
+		return
+	if object.var2 == limit:
+		object.deinit()
+		return
+	object.var2 = (object.var2 - step) & 0xFF
+
+
+static func _present_smokescreen(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var1 = 0x34
+			object.var2 = 0x10
+			_present_bounce(data, object)
+		1:
+			_present_bounce(data, object)
+		2:
+			object.deinit()
+
+
+static func _present_bounce(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.x >= 0x6C:
+		return
+	_step_to_target(object, 0x2)
+	var height: int = _sine(data, object.var1, object.var2)
+	if (height & 0x80) == 0:
+		height = (-height) & 0xFF
+	object.y_offset = height
+	object.var1 = (object.var1 - 0x4) & 0xFF
+	# `and $1f` then `cp $20` can never match, so the halving below it is
+	# unreachable and the bounce never loses height. The cartridge's own.
+
+
+static func _strength_seismic_toss(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			if object.y_offset == 0xE0:
+				_inc(object)
+				object.var1 = 0x2
+				return
+			var rise: int = (((object.y_offset << 8) | object.var1) - 0x80) & 0xFFFF
+			object.y_offset = rise >> 8
+			object.var1 = rise & 0xFF
+		1:
+			if object.var2 != 0:
+				object.var2 = (object.var2 - 1) & 0xFF
+				return
+			object.var2 = 0x4
+			object.var1 = (-object.var1) & 0xFF
+			object.y_offset = (object.var1 + object.y_offset) & 0xFF
+		2:
+			if object.x >= 0x84:
+				object.deinit()
+				return
+			_step_to_target(object, 0x4)
+
+
+static func _speed_line(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		_reinit(object, FRAMESET_SPEED_LINE_1 + (object.param & 0x7F))
+	if (object.param & 0x80) != 0:
+		object.x_offset = (object.x_offset - 1) & 0xFF
+		return
+	object.x_offset = (object.x_offset + 1) & 0xFF
+
+
+static func _sludge(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var1 = 0xC
+		1:
+			if object.var1 != 0:
+				object.var1 = (object.var1 - 1) & 0xFF
+				return
+			_inc(object)
+			_reinit(object, FRAMESET_SLUDGE_BUBBLE_BURST)
+			object.y_offset = (object.y_offset - 1) & 0xFF
+		2:
+			object.y_offset = (object.y_offset - 1) & 0xFF
+
+
+static func _metronome_hand(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.var1
+	object.var1 = (object.var1 + 2) & 0xFF
+	object.y_offset = _sine(data, a, 0x2)
+	object.x_offset = _cosine(data, a, 0x8)
+
+
+static func _metronome_sparkle_sketch(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	if object.y_offset >= 0x20:
+		object.deinit()
+		return
+	object.x_offset = _cosine(data, object.param, 0x8)
+	object.param = (object.param + 2) & 0xFF
+	if (object.param & 0x7) != 0:
+		return
+	object.y_offset = (object.y_offset + 1) & 0xFF
+
+
+static func _agility(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index != 0:
+		object.deinit()
+		return
+	object.x = (object.x + object.param) & 0xFF
+
+
+static func _safeguard_protect(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	object.y_offset = _sine(data, object.param, 0x18)
+	object.x_offset = _sra(_cosine(data, object.param, 0x18))
+	object.param = (object.param + 1) & 0xFF
+
+
+## Four objects converging on one point, then a wait, then gone. The parameter's
+## low nybble picks which of the four framesets this one is.
+static func _lock_on_mind_reader(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		object.var1 = 0x28
+		_reinit(object, (object.param & 0xF) + object.frameset)
+		object.param = (object.param & 0xF0) | 0x8
+	match object.jumptable_index:
+		1:
+			if object.var1 != 0:
+				var radius: int = object.var1
+				object.var1 = (object.var1 - 1) & 0xFF
+				object.y_offset = _sine(data, object.param, (radius + 0x8) & 0xFF)
+				object.x_offset = _cosine(data, object.param, (radius + 0x8) & 0xFF)
+				return
+			object.var1 = 0x10
+			_inc(object)
+			_lock_on_wait(object)
+		2:
+			_lock_on_wait(object)
+
+
+static func _lock_on_wait(object: Gen2BattleAnimObject) -> void:
+	var left: int = object.var1
+	object.var1 = (object.var1 - 1) & 0xFF
+	if left != 0:
+		return
+	object.deinit()
+
+
+static func _spikes(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			_inc(object)
+			object.var2 = 0x40
+		1:
+			if object.var2 >= 0x20:
+				_step_thrown_to_target(data, object, object.var2)
+				return
+			_inc(object)
+
+
+static func _heal_bell_notes(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		_inc(object)
+		_reinit(object, FRAMESET_MUSIC_NOTE_1 + object.param)
+	if object.y_offset >= 0x38:
+		object.deinit()
+		return
+	object.y_offset = (object.y_offset + 1) & 0xFF
+	var a: int = object.var1
+	object.var1 = (object.var1 + 1) & 0xFF
+	object.x_offset = _cosine(data, a, 0x18)
+	if (object.y & 0x1) != 0:
+		return
+	object.x = (object.x - 1) & 0xFF
+
+
+static func _baton_pass(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.param == 0:
+		return
+	var a: int = object.var1
+	object.var1 = (object.var1 + 1) & 0xFF
+	var height: int = _sine(data, a, object.param)
+	if (height & 0x80) == 0:
+		height = (-height) & 0xFF
+	object.y_offset = height
+	if (object.var1 & 0x1F) != 0:
+		return
+	object.param >>= 1
+
+
+static func _conversion(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.param
+	object.param = (object.param + 1) & 0xFF
+	object.y_offset = _sine(data, a, object.var1)
+	object.x_offset = _cosine(data, a, object.var1)
+	var age: int = object.var2
+	object.var2 = (object.var2 + 1) & 0xFF
+	if age < 0x40:
+		object.var1 = (object.var1 + 1) & 0xFF
+		return
+	var radius: int = object.var1
+	object.var1 = (object.var1 - 1) & 0xFF
+	if radius != 0:
+		return
+	object.deinit()
+
+
+static func _encore_belly_drum(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.var1 >= 0x10:
+		object.deinit()
+		return
+	var radius: int = object.var1
+	object.var1 = (object.var1 + 2) & 0xFF
+	object.y_offset = _sine(data, object.param, radius)
+	object.x_offset = _cosine(data, object.param, radius)
+
+
+## The parameter's top two bits are the speed and the rest is the angle, and the
+## radius is whatever var1 has grown to.
+static func _swagger_morning_sun(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	var radius: int = object.var1
+	object.var1 = (radius + ((object.param & 0xC0) >> 6)) & 0xFF
+	var angle: int = object.param & 0x3F
+	object.y_offset = _sine(data, angle, radius)
+	object.x_offset = _cosine(data, angle, radius)
+
+
+static func _hidden_power(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			var a: int = object.param
+			object.param = (object.param + 1) & 0xFF
+			_step_circle(data, object, a, 0x18)
+		1:
+			_inc(object)
+			object.var1 = 0x18
+			_hidden_power_expand(data, object)
+		2:
+			_hidden_power_expand(data, object)
+
+
+static func _hidden_power_expand(
+	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	if object.var1 >= 0x80:
+		object.deinit()
+		return
+	var radius: int = object.var1
+	object.var1 = (object.var1 + 0x8) & 0xFF
+	_step_circle(data, object, object.param, radius)
+
+
+static func _curse(object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		return
+	if object.x < 0x30:
+		object.deinit()
+		return
+	object.x = (object.x - 2) & 0xFF
+	object.y = (object.y + 2) & 0xFF
+
+
+static func _perish_song(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.param
+	object.param = (object.param + 2) & 0xFF
+	object.y_offset = (_sra(_sra(_sine(data, a, 0x50))) + object.var1) & 0xFF
+	object.var1 = (object.var1 + 1) & 0xFF
+	object.x_offset = _cosine(data, a, 0x50)
+
+
+static func _rapid_spin(object: Gen2BattleAnimObject) -> void:
+	if object.y_offset == 0xD0:
+		object.deinit()
+		return
+	object.y_offset = (object.y_offset - 4) & 0xFF
+
+
+static func _beta_pursuit(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			if object.param != 0:
+				object.jumptable_index = (object.jumptable_index + 2) & 0xFF
+				_beta_pursuit_up(object)
+				return
+			_inc(object)
+			object.y_offset = 0xEC
+			_beta_pursuit_down(object)
+		1:
+			_beta_pursuit_down(object)
+		2:
+			_beta_pursuit_up(object)
+		3:
+			object.deinit()
+
+
+static func _beta_pursuit_down(object: Gen2BattleAnimObject) -> void:
+	if object.y_offset == 0x4:
+		object.deinit()
+		return
+	object.y_offset = (object.y_offset + 4) & 0xFF
+
+
+static func _beta_pursuit_up(object: Gen2BattleAnimObject) -> void:
+	if object.y_offset == 0xD8:
+		return
+	object.y_offset = (object.y_offset - 4) & 0xFF
+
+
+static func _rain_sandstorm(object: Gen2BattleAnimObject) -> void:
+	match object.jumptable_index:
+		0:
+			object.jumptable_index = object.param
+			_inc(object)
+		1:
+			_rain_step(object, 2)
+		2:
+			_rain_step(object, 8)
+		3:
+			_rain_step(object, 4)
+
+
+static func _rain_step(object: Gen2BattleAnimObject, sideways: int) -> void:
+	var fall: int = (object.y_offset + 0x4) & 0xFF
+	object.y_offset = fall if fall < 0x70 else 0x00
+	object.x_offset = (object.x_offset + sideways) & 0xFF
+
+
+## `BattleAnimFunc_AnimObjB0`, which no shipped animation reaches: object $b0 is
+## in no `anim_obj`. Ported because the jumptable dispatches to it.
+static func _anim_obj_b0(object: Gen2BattleAnimObject) -> void:
+	var de: int = (object.x << 8) | object.var1
+	var high: int = (object.param & 0xF0) | ((object.param & 0xF0) >> 4)
+	var hl: int = ((high << 8) | ((object.param & 0xF) << 4)) & 0xFFFF
+	hl = (hl + de) & 0xFFFF
+	object.x = hl >> 8
+	object.var1 = hl & 0xFF
+
+
+static func _psych_up(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.param
+	object.param = (object.param + 1) & 0xFF
+	_step_circle(data, object, a, 0x18)
+
+
+static func _ancient_power(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.var1 >= 0x20:
+		object.deinit()
+		return
+	var a: int = object.var1
+	object.var1 = (object.var1 + 1) & 0xFF
+	object.y_offset = (-_sine(data, a, object.param)) & 0xFF
+
+
+static func _rock_smash(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	if object.jumptable_index == 0:
+		# Written straight into the struct rather than through
+		# `ReinitBattleAnimFrameset`, so the frame and duration are not reset.
+		object.frameset = (FRAMESET_BIG_ROCK + ((object.param & 0x40) >> 6)) & 0xFF
+		_inc(object)
+		object.var1 = 0x40
+	if object.var1 < 0x30:
+		object.deinit()
+		return
+	_arc_horizontal(data, object)
+
+
+static func _cotton(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+	var a: int = object.var2
+	object.var2 = (object.var2 + 1) & 0xFF
+	_step_circle(data, object, ((a >> 1) + object.param) & 0xFF, 0x18)

--- a/game/battle/battle_anim_functions.gd.uid
+++ b/game/battle/battle_anim_functions.gd.uid
@@ -1,0 +1,1 @@
+uid://db2l51dyec14k

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -13,11 +13,10 @@ extends RefCounted
 ## answers with sprites, a tile window and the palette each sprite wants, and
 ## whoever is drawing decides what that looks like.
 ##
-## Two of `.playframe`'s five steps are not here yet and are named rather than
-## quietly skipped: `_ExecuteBGEffects`, and the per-object motion callback
-## `DoBattleAnimFrame` dispatches. [method unimplemented] reports both, so a
-## caller can tell an animation that ran whole from one that ran without its
-## motion.
+## One of `.playframe`'s five steps is not here yet and is named rather than
+## quietly skipped: `_ExecuteBGEffects`. [method unimplemented] reports what an
+## animation asked for and did not get, so a caller can tell one that ran whole
+## from one that ran without its background.
 
 ## `NUM_BATTLE_ANIM_STRUCTS`: ten slots, and an eleventh object is simply not
 ## spawned.
@@ -73,6 +72,23 @@ var _keep_sprites: bool = false
 var _sprites: Array = []
 var _unimplemented: Dictionary = {}
 
+## `wCurItem`, which `GetBallAnimPal` reads to colour a thrown ball. Nothing but
+## a ball animation asks, and an item that is not a ball falls out of
+## `BallColors` on its own terminator.
+var cur_item: int = 0
+
+## `wOBP0`, the DMG object palette `BattleAnimFunc_SkyAttack` flashes. Kept
+## because the write is the whole of that state; the Color hardware draws
+## objects from `wOBPals1` instead, so nothing shows.
+var obp0: int = 0
+
+## `hLCDCPointer`, `hLYOverrideStart` and `hLYOverrideEnd`: the scanline window
+## `BattleAnimFunc_Surf` opens over `rSCY` and hands back when the wave has
+## crossed the screen. It is the only callback that reaches the raster.
+var lcdc_pointer: int = 0
+var ly_override_start: int = 0
+var ly_override_end: int = 0
+
 
 ## Starts [param index] of `BattleAnimations`. Answers null when the cache has no
 ## such animation, which is what an unimported layer looks like.
@@ -102,6 +118,16 @@ static func create(
 		region["data"], int(region["address"]), address, param
 	)
 	return player
+
+
+## `hBattleTurn`, which two callbacks and the enemy-side coordinate fix read.
+func enemy_turn() -> bool:
+	return _enemy_turn
+
+
+## The imported tables the callbacks resolve their sine and framesets through.
+func data() -> Gen2BattleAnimData:
+	return _data
 
 
 func finished() -> bool:
@@ -305,18 +331,13 @@ func _update_oam() -> void:
 		_sprites.append_array(sprites)
 
 
-## `DoBattleAnimFrame`: the object's own motion callback.
-##
-## `BattleAnimFunc_Null` is here because it is not a no-op: it deletes the object
-## once something has bumped its jumptable index, which is how `anim_incobj` ends
-## an object the script spawned. The other seventy-eight are not built and are
-## reported by [method unimplemented].
+## `DoBattleAnimFrame`: the object's own motion callback, in
+## [Gen2BattleAnimFunctions]. A callback outside the jumptable is reported rather
+## than run, which the importer's own range check makes unreachable from a
+## cartridge and a hand-built object can still ask for.
 func _do_battle_anim_frame(object: Gen2BattleAnimObject) -> void:
-	if object.function != 0:
+	if not Gen2BattleAnimFunctions.run(self, object):
 		_note(&"functions", object.function)
-		return
-	if object.jumptable_index == 1:
-		object.deinit()
 
 
 ## `BattleAnim_ClearOAM`. Keeping the sprites does not keep their colours: every

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -445,6 +445,15 @@ func battle_anim_address(index: int) -> int:
 	return data[at] | (data[at + 1] << 8)
 
 
+## `BattleAnimSineWave` as its own 64 cartridge bytes, or empty when the section
+## is absent. Thirty-two little-endian words, read rather than computed.
+func battle_anim_sine() -> PackedByteArray:
+	var value: Variant = _battle_anims().get("sine", null)
+	if not value is Dictionary:
+		return PackedByteArray()
+	return _payload_bytes(value, _blob("battle_anims"))
+
+
 ## One `battleanimobj` row as
 ## [code]{ flags, y_fix, frameset, function, palette, gfx }[/code], empty when
 ## the index is outside `BattleAnimObjects`.

--- a/game/import/battle_anim_importer.gd
+++ b/game/import/battle_anim_importer.gd
@@ -137,6 +137,10 @@ static func read_battle_anims(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if not bool(scripts.get("ok", false)):
 		return scripts
 
+	var sine: Dictionary = _read_sine(rom, int(anim_layout["sine"]))
+	if not bool(sine.get("ok", false)):
+		return sine
+
 	var framesets: Dictionary = _read_framesets(rom, int(anim_layout["framesets"]))
 	if not bool(framesets.get("ok", false)):
 		return framesets
@@ -162,6 +166,7 @@ static func read_battle_anims(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"framesets": framesets["region"],
 			"oam_sets": oam_sets["region"],
 			"object_gfx": object_gfx["rows"],
+			"sine": sine["region"],
 		},
 		"counts": {
 			"scripts": RomLayout.BATTLE_ANIM_SCRIPT_COUNT,
@@ -278,6 +283,26 @@ static func _walk_body(bank_bytes: PackedByteArray, address: int) -> Dictionary:
 		if command["name"] == Gen2BattleAnimScript.RET:
 			break
 	return {"ok": true, "end": at, "targets": targets}
+
+
+## `BattleAnimSineWave`, the table `BattleAnim_Sine` reads.
+##
+## The bytes are the check as well as the content: 64 identical bytes appear
+## several times in a dump, so the offset is only trustworthy against the values,
+## and this is the one copy in the animation bank.
+static func _read_sine(rom: RomFile, table: int) -> Dictionary:
+	if not rom.in_bounds(table, RomLayout.BATTLE_ANIM_SINE_BYTES):
+		return {"ok": false, "message": "Battle animation sine table is outside the cartridge."}
+	var data: PackedByteArray = rom.slice(table, RomLayout.BATTLE_ANIM_SINE_BYTES)
+	for index: int in RomLayout.BATTLE_ANIM_SINE_BYTES:
+		if data[index] != RomLayout.BATTLE_ANIM_SINE_WAVE[index]:
+			return {
+				"ok": false,
+				"message": "Battle animation sine table byte %d is $%02X, expected $%02X." % [
+					index, data[index], RomLayout.BATTLE_ANIM_SINE_WAVE[index],
+				],
+			}
+	return {"ok": true, "region": {"bytes": _bytes_of(data)}}
 
 
 ## `BattleAnimObjects`, whose rows carry no pointers, so the region is the table

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -59,7 +59,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 30
+const FORMAT_VERSION: int = 31
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -487,6 +487,24 @@ const BATTLE_ANIM_GFX_SIZE: int = 4
 const BATTLE_ANIM_GFX_FIRST_SHEET: int = 1
 const BATTLE_ANIM_GFX_LAST_SHEET: int = 39
 
+## `BattleAnimSineWave`, the 32-word table `BattleAnim_Sine` and `..._Cosine`
+## multiply an amplitude by (engine/battle_anims/functions.asm). It sits in the
+## same bank as the four tables above, immediately before `BattleAnimFrameData`.
+const BATTLE_ANIM_SINE_SAMPLES: int = 32
+const BATTLE_ANIM_SINE_BYTES: int = BATTLE_ANIM_SINE_SAMPLES * 2
+
+## What that table holds, pinned the way [constant BAR_PALETTES] pins the bars'
+## colours: the values are the check for the offset. It is `sine_table 32`, which
+## rgbasm evaluates at assembly time, and entry 16 is why it is imported rather
+## than re-derived: sin(pi/2) is 1.0, which lands on $0100 and not the $00FF an
+## eight-bit derivation produces. The same 64 bytes are in all three dumps.
+const BATTLE_ANIM_SINE_WAVE: Array[int] = [
+	0x00, 0x00, 0x19, 0x00, 0x32, 0x00, 0x4A, 0x00, 0x62, 0x00, 0x79, 0x00, 0x8E, 0x00, 0xA2, 0x00,
+	0xB5, 0x00, 0xC6, 0x00, 0xD5, 0x00, 0xE2, 0x00, 0xED, 0x00, 0xF5, 0x00, 0xFB, 0x00, 0xFF, 0x00,
+	0x00, 0x01, 0xFF, 0x00, 0xFB, 0x00, 0xF5, 0x00, 0xED, 0x00, 0xE2, 0x00, 0xD5, 0x00, 0xC6, 0x00,
+	0xB5, 0x00, 0xA2, 0x00, 0x8E, 0x00, 0x79, 0x00, 0x62, 0x00, 0x4A, 0x00, 0x32, 0x00, 0x19, 0x00,
+]
+
 ## The eight `PAL_BATTLE_OB_*` object palettes an animation object's palette byte
 ## indexes, and which of them the cartridge stores.
 ##
@@ -809,10 +827,14 @@ const GOLD_SILVER: Dictionary = {
 	# 10 ff), then finding the run of 278 in-bank pointers whose second entry is
 	# its address; the other four tables were located by assembling the pinned
 	# data/battle_anims files and matching the bytes. Each hit is unique in the
-	# dump. Nested for the same reason trainer_card is.
+	# dump. `sine` is the one that is not: the same 64 bytes appear four or five
+	# times per dump, so it was located from `calc_sine_wave`'s own operand, the
+	# `ld hl` at the end of the copy sharing this bank with the four tables, and
+	# only that hit lies in the bank. Nested for the same reason trainer_card is.
 	"battle_anims": {
 		"scripts": 0xC900A,
 		"objects": 0xCCAA5,
+		"sine": 0xCE6C4,
 		"framesets": 0xCE7A3,
 		"oam_sets": 0xCEDF3,
 		"object_gfx": 0xCFC3B,
@@ -984,6 +1006,7 @@ const CRYSTAL: Dictionary = {
 	"battle_anims": {
 		"scripts": 0xC906F,
 		"objects": 0xCCB56,
+		"sine": 0xCE77F,
 		"framesets": 0xCE85E,
 		"oam_sets": 0xCEEAE,
 		"object_gfx": 0xCFCF6,

--- a/tests/unit/test_battle_anim_functions.gd
+++ b/tests/unit/test_battle_anim_functions.gd
@@ -1,0 +1,275 @@
+extends GutTest
+
+## The motion callbacks `DoBattleAnimFrame` dispatches
+## (engine/battle_anims/functions.asm) and the five helpers they are built from.
+##
+## Objects are built by hand rather than spawned by a script, because what is
+## worth checking here is the arithmetic: which byte a state writes, where it
+## wraps, and which of the source's own dead branches stays dead.
+## `tools/validate_battle_anims.gd` is the counterpart that runs all eighty
+## against real cartridge data.
+
+const BASE: int = 0x4000
+const RET: int = 0xFF
+
+var _player: Gen2BattleAnimPlayer = null
+
+
+func before_each() -> void:
+	_player = _make_player()
+
+
+## A player with the real sine table behind it and nothing else: no object is
+## spawned, so the pool stays empty and the callbacks are called directly.
+func _make_player(enemy_turn: bool = false) -> Gen2BattleAnimPlayer:
+	var sine := PackedByteArray()
+	for value: int in RomLayout.BATTLE_ANIM_SINE_WAVE:
+		sine.append(value)
+	var data: Gen2BattleAnimData = Gen2BattleAnimData.create({
+		&"scripts": {
+			"bank": 0x32, "address": BASE, "count": 1,
+			"data": PackedByteArray([(BASE + 2) & 0xFF, (BASE + 2) >> 8, RET]),
+		},
+		&"objects": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+		&"framesets": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+		&"oam_sets": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+	}, [], sine)
+	return Gen2BattleAnimPlayer.create(data, 0, enemy_turn)
+
+
+## One object with a chosen callback, at a chosen place, with a chosen parameter.
+func _object(function: int, x: int = 0x40, y: int = 0x40, param: int = 0) -> Gen2BattleAnimObject:
+	return Gen2BattleAnimObject.create(
+		1, {&"flags": 0x00, &"y_fix": 0x90, &"frameset": 0x10, &"function": function,
+			&"palette": 0x02, &"gfx": 0x01},
+		0, x, y, param
+	)
+
+
+func _run(object: Gen2BattleAnimObject) -> void:
+	assert_true(Gen2BattleAnimFunctions.run(_player, object))
+
+
+# ---------------------------------------------------------------- helpers ----
+
+## `BattleAnim_Sine` at the quarter turn is the whole amplitude, because
+## `BattleAnimSineWave`'s sixteenth entry is $0100 and not $00ff. An eight-bit
+## re-derivation of the table is short by one here and everywhere it is scaled.
+func test_the_quarter_turn_is_the_whole_amplitude() -> void:
+	var object: Gen2BattleAnimObject = _object(0x03, 0x40, 0x40, 0x50)
+	object.jumptable_index = 1
+	object.var1 = 0x10
+	_run(object)
+	assert_eq(object.y_offset, 0x50, "sin(pi/2) * $50 is $50, not $4f")
+
+
+## The second half of the turn is the first half negated, which is what makes an
+## offset a signed byte.
+func test_the_second_half_of_the_turn_is_negative() -> void:
+	var rising: Gen2BattleAnimObject = _object(0x03, 0x40, 0x40, 0x40)
+	rising.jumptable_index = 1
+	rising.var1 = 0x08
+	_run(rising)
+
+	var falling: Gen2BattleAnimObject = _object(0x03, 0x40, 0x40, 0x40)
+	falling.jumptable_index = 1
+	falling.var1 = 0x28
+	_run(falling)
+	assert_eq(falling.y_offset, (-rising.y_offset) & 0xFF)
+
+
+## `BattleAnim_Cosine` is the sine a quarter turn on, so a cosine at zero is the
+## amplitude and the two offsets are a quarter apart.
+func test_the_cosine_leads_the_sine_by_a_quarter_turn() -> void:
+	var object: Gen2BattleAnimObject = _object(0x03, 0x40, 0x40, 0x30)
+	object.jumptable_index = 1
+	object.var1 = 0x00
+	_run(object)
+	assert_eq(object.y_offset, 0x00)
+	assert_eq(object.x_offset, 0x30)
+
+
+## `BattleAnim_StepToTarget`'s vertical half is a `dec`/`jr nz` loop, so a low
+## nybble under two runs it 256 times and the object does not rise at all.
+func test_a_step_of_one_moves_sideways_and_not_up() -> void:
+	var object: Gen2BattleAnimObject = _object(0x02, 0x40, 0x40, 0x01)
+	_run(object)
+	assert_eq(object.x, 0x41)
+	assert_eq(object.y, 0x40, "256 decrements are no decrement at all")
+
+	var stepped: Gen2BattleAnimObject = _object(0x02, 0x40, 0x40, 0x04)
+	_run(stepped)
+	assert_eq(stepped.x, 0x44)
+	assert_eq(stepped.y, 0x3E)
+
+
+## Coordinates are single cartridge bytes, and several animations walk an object
+## off one side and rely on the wrap.
+func test_a_coordinate_wraps_rather_than_clamping() -> void:
+	var object: Gen2BattleAnimObject = _object(0x3B, 0xF8, 0x40, 0x10)  # Agility
+	_run(object)
+	assert_eq(object.x, 0x08)
+
+
+# -------------------------------------------------------------- callbacks ----
+
+## `BattleAnimFunc_Null` is not a no-op: its second state deletes the object,
+## which is how `anim_incobj` retires the sixty-two rows that use it.
+func test_the_null_callback_deletes_on_its_second_state() -> void:
+	var object: Gen2BattleAnimObject = _object(0x00)
+	_run(object)
+	assert_true(object.active())
+	object.jumptable_index = 1
+	_run(object)
+	assert_false(object.active())
+
+
+## Bit 7 of `BattleAnimFunc_MoveInCircle`'s parameter starts the object on the
+## far side of the circle and is then cleared, since the rest is the radius.
+func test_move_in_circle_reads_bit_seven_as_a_starting_position() -> void:
+	var near: Gen2BattleAnimObject = _object(0x03, 0x40, 0x40, 0x20)
+	_run(near)
+	assert_eq(near.var1, 0x01, "started at zero and stepped one")
+	assert_eq(near.param, 0x20)
+
+	var far: Gen2BattleAnimObject = _object(0x03, 0x40, 0x40, 0xA0)
+	_run(far)
+	assert_eq(far.var1, 0x21, "started half a turn round")
+	assert_eq(far.param, 0x20, "the radius is what is left of the byte")
+
+
+## `BattleAnimFunc_Drop`'s parameter is how much height each bounce loses, and
+## the object goes when it has none left.
+func test_drop_loses_height_each_bounce_and_then_goes() -> void:
+	var object: Gen2BattleAnimObject = _object(0x07, 0x40, 0x40, 0x40)
+	_run(object)
+	assert_eq(object.var1, 0x31)
+	assert_eq(object.var2, 0x48)
+
+	object.var1 = 0x3F
+	_run(object)
+	assert_eq(object.var1, 0x20, "the bounce restarts")
+	assert_eq(object.var2, 0x08, "and is $40 shorter")
+
+	object.var1 = 0x3F
+	_run(object)
+	assert_false(object.active(), "a bounce it cannot afford ends the object")
+
+
+## `BattleAnimFunc_PokeBall`'s settling writes the masked value back, so a var1
+## of $20 lands on zero rather than keeping its high bit.
+func test_the_ball_settles_by_zeroing_its_own_counter() -> void:
+	var object: Gen2BattleAnimObject = _object(0x12)
+	object.jumptable_index = 4
+	object.var1 = 0x21
+	object.var2 = 0x10
+	_run(object)
+	assert_eq(object.var1, 0x00)
+	assert_eq(object.var2, 0x0C)
+
+
+## `GetBallAnimPal` colours a thrown ball off `wCurItem`, and an item that is not
+## a ball falls out on `BallColors`' own `-1` row.
+func test_the_thrown_ball_takes_its_own_colour() -> void:
+	_player.cur_item = 0x02  # ULTRA_BALL
+	var ultra: Gen2BattleAnimObject = _object(0x12)
+	_run(ultra)
+	assert_eq(ultra.palette, 3, "PAL_BATTLE_OB_YELLOW")
+
+	_player.cur_item = 0x14  # a potion, which is in no row
+	var other: Gen2BattleAnimObject = _object(0x12)
+	_run(other)
+	assert_eq(other.palette, 2, "the terminator's PAL_BATTLE_OB_GRAY")
+
+
+## `BattleAnimFunc_Sound` mirrors its angle on the enemy's turn, which is one of
+## only two places a callback reads `hBattleTurn`.
+func test_a_sound_wave_is_mirrored_on_the_enemys_turn() -> void:
+	var player: Gen2BattleAnimObject = _object(0x21, 0x40, 0x40, 0x02)
+	_run(player)
+	assert_eq(player.param, 0x02)
+
+	_player = _make_player(true)
+	var enemy: Gen2BattleAnimObject = _object(0x21, 0x40, 0x40, 0x02)
+	_run(enemy)
+	assert_eq(enemy.param, 0x00, "$ff - param + 3")
+
+
+## `BattleAnimFunc_Surf` is the one callback that reaches the raster: it opens a
+## scanline window over `rSCY` and hands it back when the wave has crossed.
+func test_surf_opens_and_closes_its_scanline_window() -> void:
+	var object: Gen2BattleAnimObject = _object(0x0D, 0x40, 0x60, 0x30)
+	_run(object)
+	assert_eq(_player.lcdc_pointer, Gen2BattleAnimFunctions.LCDC_POINTER_SCY)
+	assert_eq(_player.ly_override_start, 0x58)
+	assert_eq(_player.ly_override_end, 0x5E)
+
+	object.jumptable_index = 3
+	object.y = 0x70
+	_run(object)
+	assert_eq(_player.lcdc_pointer, 0)
+	assert_eq(_player.ly_override_end, 0)
+	assert_false(object.active())
+
+
+## `BattleAnimFunc_SkyAttack` flashes `wOBP0`, which the Color hardware never
+## draws from. The write is kept because it is the whole of that state.
+func test_sky_attack_cycles_the_dmg_object_palette() -> void:
+	var object: Gen2BattleAnimObject = _object(0x32)
+	_run(object)
+	assert_eq(object.var1, 0xF0, "the player's side")
+	_run(object)
+	assert_eq(_player.obp0, 0xF0)
+	_run(object)
+	assert_eq(_player.obp0, 0xF0)
+	_run(object)
+	assert_eq(_player.obp0, 0xA0, "$aa masked by the side's own byte")
+
+
+## `BattleAnimFunc_RockSmash` writes the frameset straight into the struct rather
+## than through `ReinitBattleAnimFrameset`, so the frame it is on is not reset.
+func test_rock_smash_swaps_its_frameset_without_restarting_it() -> void:
+	var object: Gen2BattleAnimObject = _object(0x4E, 0x40, 0x40, 0x40)
+	object.frame = 0x03
+	object.duration = 0x05
+	_run(object)
+	assert_eq(object.frameset, Gen2BattleAnimFunctions.FRAMESET_BIG_ROCK + 1)
+	assert_eq(object.frame, 0x03)
+	assert_eq(object.duration, 0x05)
+
+
+## `BattleAnimFunc_PresentSmokescreen` masks with $1f and then compares against
+## $20, which can never match, so the halving under it is unreachable and the
+## bounce keeps its height. The cartridge's own dead branch.
+func test_the_present_bounce_never_loses_its_height() -> void:
+	var object: Gen2BattleAnimObject = _object(0x35, 0x40, 0x40)
+	_run(object)
+	assert_eq(object.var1, 0x30)
+	assert_eq(object.var2, 0x10)
+	for _frame: int in 16:
+		_run(object)
+	assert_eq(object.var2, 0x10, "the srl below the cp is never reached")
+
+
+## `BattleAnim_ScatterHorizontal` steps a leaf sideways by one of three amounts,
+## and bit 7 of the parameter is which way.
+func test_a_leaf_scatters_the_way_its_parameter_says() -> void:
+	var right: Gen2BattleAnimObject = _object(0x0B, 0x40, 0x40, 0x10)
+	right.jumptable_index = 1
+	right.var1 = 0x40
+	_run(right)
+	assert_eq(right.x, 0x42, "$200 over a byte and a half is two pixels")
+
+	var left: Gen2BattleAnimObject = _object(0x0B, 0x40, 0x40, 0x90)
+	left.jumptable_index = 1
+	left.var1 = 0x40
+	_run(left)
+	assert_eq(left.x, 0x3E)
+
+
+## The importer refuses an object row naming a callback past the jumptable, so
+## only a hand-built object reaches this, and it is reported rather than run.
+func test_a_callback_past_the_jumptable_is_refused() -> void:
+	var object: Gen2BattleAnimObject = _object(Gen2BattleAnimImporter.FUNCTION_COUNT)
+	assert_false(Gen2BattleAnimFunctions.run(_player, object))
+	assert_true(object.active())

--- a/tests/unit/test_battle_anim_functions.gd.uid
+++ b/tests/unit/test_battle_anim_functions.gd.uid
@@ -1,0 +1,1 @@
+uid://b4tpy2cxrk40f

--- a/tests/unit/test_battle_anim_importer.gd
+++ b/tests/unit/test_battle_anim_importer.gd
@@ -21,6 +21,7 @@ const FRAMESET_STREAM: int = 0x6200
 const OAM_SETS: int = 0x6400
 const OAM_SPRITES: int = 0x6800
 const OBJECT_GFX: int = 0x7000
+const SINE: int = 0x7400
 ## Somewhere inside the dump for an `AnimObjGFX` row to point at. Nothing
 ## decompresses it: only `import_to_cache` reads the stream.
 const GFX_DATA: int = 0x0100
@@ -36,6 +37,7 @@ func before_each() -> void:
 	_write_framesets()
 	_write_oam_sets()
 	_write_object_gfx()
+	_write_sine()
 
 
 ## A plausible `BattleAnimations`: POUND at entry 1 and a bare `anim_ret`
@@ -86,6 +88,11 @@ func _write_object_gfx() -> void:
 		_word(row + Gen2BattleAnimImporter.GFX_POINTER + 1, GFX_DATA)
 
 
+func _write_sine() -> void:
+	for index: int in RomLayout.BATTLE_ANIM_SINE_BYTES:
+		_dump[SINE + index] = RomLayout.BATTLE_ANIM_SINE_WAVE[index]
+
+
 func _word(at: int, value: int) -> void:
 	_dump[at] = value & 0xFF
 	_dump[at + 1] = (value >> 8) & 0xFF
@@ -99,6 +106,7 @@ func _layout() -> Dictionary:
 			"framesets": FRAMESETS,
 			"oam_sets": OAM_SETS,
 			"object_gfx": OBJECT_GFX,
+			"sine": SINE,
 		},
 	}
 
@@ -116,6 +124,24 @@ func test_a_plausible_layer_verifies() -> void:
 	assert_eq(int(result["counts"]["objects"]), RomLayout.BATTLE_ANIM_OBJECT_COUNT)
 	assert_eq(int(result["counts"]["framesets"]), RomLayout.BATTLE_ANIM_FRAMESET_COUNT)
 	assert_eq(int(result["counts"]["oam_sets"]), RomLayout.BATTLE_ANIM_OAM_SET_COUNT)
+
+
+## The sine table is stored as the cartridge's own bytes, quarter turn included:
+## $0100 is what says it was read rather than derived in eight bits.
+func test_the_sine_table_keeps_its_sixteen_bit_quarter_turn() -> void:
+	var bytes: Array = _read()["anims"]["sine"]["bytes"]
+	assert_eq(bytes.size(), RomLayout.BATTLE_ANIM_SINE_BYTES)
+	assert_eq(int(bytes[32]), 0x00)
+	assert_eq(int(bytes[33]), 0x01)
+
+
+## Sixty-four identical bytes appear several times in a dump, so the values are
+## the whole check for this offset.
+func test_a_sine_table_of_the_wrong_shape_fails() -> void:
+	_dump[SINE + 33] = 0x00
+	var result: Dictionary = _read()
+	assert_false(bool(result["ok"]))
+	assert_string_contains(String(result["message"]), "sine table byte 33")
 
 
 ## The region runs from the table to the end of the last body it reaches, and

--- a/tests/unit/test_battle_anim_player.gd
+++ b/tests/unit/test_battle_anim_player.gd
@@ -199,17 +199,22 @@ func test_keepsprites_keeps_the_sprites_and_takes_their_colour() -> void:
 
 
 ## What the animation asked for and did not get is reported rather than passed
-## over, so a caller can tell a whole animation from one missing its motion.
-func test_an_unbuilt_callback_or_bg_effect_is_reported() -> void:
+## over, so a caller can tell a whole animation from one missing its background.
+##
+## A callback past the jumptable is reported the same way. The importer refuses
+## such a row, so only a hand-built object reaches it.
+func test_an_unbuilt_bg_effect_or_an_unknown_callback_is_reported() -> void:
 	var player: Gen2BattleAnimPlayer = _player(
-		SPAWN + [0xF0, 0x22, 0x00, 0x00, 0x00] + [0x01] + RET, 2, 0x09
+		SPAWN + [0xF0, 0x22, 0x00, 0x00, 0x00] + [0x01] + RET,
+		2, Gen2BattleAnimImporter.FUNCTION_COUNT
 	)
 	player.advance_frame()
 	var missing: Dictionary = player.unimplemented()
-	assert_eq(missing["functions"], [0x09])
+	assert_eq(missing["functions"], [Gen2BattleAnimImporter.FUNCTION_COUNT])
 	assert_eq(missing["bg_effects"], [0x22])
 
-	var whole: Gen2BattleAnimPlayer = _player(SPAWN + [0x01] + RET)
+	# Callback 9 is `BattleAnimFunc_Shake`, which is built and moves the object.
+	var whole: Gen2BattleAnimPlayer = _player(SPAWN + [0x01] + RET, 2, 0x09)
 	whole.advance_frame()
 	assert_eq(whole.unimplemented(), {"bg_effects": [], "functions": []})
 

--- a/tools/validate_battle_anims.gd
+++ b/tools/validate_battle_anims.gd
@@ -82,6 +82,12 @@ const EXPECTED_GFX_TILES: int = 659
 ## Well past the longest shipped animation, which is 365 frames.
 const MAX_FRAMES: int = 4096
 
+## The `BattleAnimSineWave` entry that pins the table as imported: a quarter turn
+## is sin(pi/2), which `sine_table 32` evaluates to a full $0100. Any eight-bit
+## re-derivation answers $00ff here and is wrong by one everywhere it is used.
+const SINE_QUARTER: int = 16
+const SINE_ONE: int = 0x0100
+
 var _failures: PackedStringArray = []
 
 
@@ -92,6 +98,7 @@ func _initialize() -> void:
 			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
 			continue
 		_verify_regions(game_id, data)
+		_verify_sine(game_id, data)
 		_verify_pound(game_id, data)
 		_verify_profile_split(game_id, data)
 		_verify_objects(game_id, data)
@@ -135,9 +142,10 @@ func _play_every_animation(game_id: StringName, data: GameData) -> void:
 				not player.failed(),
 				"%s: animation %d ran off its region." % [game_id, index]
 			)
-			# Every object the script spawns should be gone by the end, either
-			# through its own `oamdelete` or through `anim_incobj`. One that is
-			# not is an object whose motion callback would have retired it.
+			# How many objects are still standing at the top-level `anim_ret`.
+			# Not expected to be zero: `PlayBattleAnim` returns with the structs
+			# as they are and the next animation's `ClearBattleAnims` zeroes
+			# them, so an object nothing retired outlives its own script.
 			leaked = maxi(leaked, player.objects().size())
 			var missing: Dictionary = player.unimplemented()
 			for id: int in missing["functions"]:
@@ -154,6 +162,12 @@ func _play_every_animation(game_id: StringName, data: GameData) -> void:
 		sprites <= Gen2BattleAnimPlayer.MAX_SPRITES,
 		"%s: %d sprites at once, past the hardware's %d." % [
 			game_id, sprites, Gen2BattleAnimPlayer.MAX_SPRITES,
+		]
+	)
+	_check(
+		functions.is_empty(),
+		"%s: %d motion callbacks are still unbuilt: %s." % [
+			game_id, functions.size(), functions.keys(),
 		]
 	)
 	print("%s: played %d animations both ways; at most %d objects and %d sprites at once." % [
@@ -183,6 +197,37 @@ func _verify_regions(game_id: StringName, data: GameData) -> void:
 		game_id,
 		int(data.battle_anim_region(&"scripts")["count"]),
 		(data.battle_anim_region(&"scripts")["data"] as PackedByteArray).size(),
+	])
+
+
+## `BattleAnimSineWave` as it was imported, and the one entry that says it was
+## imported rather than derived: sin(pi/2) is a full $0100 and not $00ff.
+func _verify_sine(game_id: StringName, data: GameData) -> void:
+	var table: PackedByteArray = data.battle_anim_sine()
+	if not _check(
+		table.size() == RomLayout.BATTLE_ANIM_SINE_BYTES,
+		"%s: sine table holds %d bytes, not %d." % [
+			game_id, table.size(), RomLayout.BATTLE_ANIM_SINE_BYTES,
+		]
+	):
+		return
+	for index: int in table.size():
+		if not _check(
+			table[index] == int(RomLayout.BATTLE_ANIM_SINE_WAVE[index]),
+			"%s: sine byte %d is $%02X, not the pinned $%02X." % [
+				game_id, index, table[index], int(RomLayout.BATTLE_ANIM_SINE_WAVE[index]),
+			]
+		):
+			return
+	var anims: Gen2BattleAnimData = Gen2BattleAnimData.create({}, [], table)
+	_check(
+		anims.sine_word(SINE_QUARTER) == SINE_ONE,
+		"%s: sine quarter turn is $%04X, not the $%04X only the cartridge's own table gives." % [
+			game_id, anims.sine_word(SINE_QUARTER), SINE_ONE,
+		]
+	)
+	print("%s: %d-sample sine table, quarter turn $%04X." % [
+		game_id, RomLayout.BATTLE_ANIM_SINE_SAMPLES, anims.sine_word(SINE_QUARTER),
 	])
 
 


### PR DESCRIPTION
Port DoBattleAnimFrame's eighty motion callbacks and the five helpers under them. Nearly every one is a BattleAnim_AnonJumptable over two to four states, which becomes a match on the object's own jumptable index plus arithmetic on its coordinates and two spare bytes.

BattleAnimSineWave is imported rather than derived: sine_table 32's quarter turn is a full $0100, so an eight-bit re-derivation is short by one wherever an amplitude is scaled. Those 64 bytes are not unique in a dump, so the offset comes from calc_sine_wave's own operand in the animation bank and the pinned values are the check. Cache format 31.

Five source quirks kept: StepToTarget's 256-step vertical loop for a nybble under two, PresentSmokescreen's mask-then-compare that can never match, RockSmash writing its frameset past ReinitBattleAnimFrameset, PokeBall storing its masked counter back, and objects outliving their own script.

validate_battle_anims now reports 0 motion callbacks still to build on all three cartridges, and checks the sine table against its pinned bytes.