### PR TITLE
Draw the background a battle animation moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Headless tools, all against a real imported cache:
 | `validate_surf.gd` | the surf sprites and music record, the surf-entry cell census, and New Bark Town's east shore, in all three games |
 | `validate_whirlpool.gd` | the whirlpool block table, the forced-tile cell census, and Dragon's Den B1F's whirlpool, in all three games |
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push, in all three games |
-| `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, the sine table the motion callbacks scale with, and the 39 graphics sheets, in all three games |
+| `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, the sine table the motion callbacks scale with, the 39 graphics sheets, and every motion callback and background effect a real animation reaches, in all three games |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census, in all three games |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script, in all three games |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse, in all three games |

--- a/game/battle/battle_anim_background.gd
+++ b/game/battle/battle_anim_background.gd
@@ -1,0 +1,250 @@
+class_name Gen2BattleAnimBackground
+extends RefCounted
+
+## The video state a battle animation's background effects write, and the
+## primitives they write it with (engine/battle_anims/bg_effects.asm).
+##
+## A bg effect does not draw: it edits the scanline tables, the screen scroll,
+## the DMG palette bytes the CGB palettes are remapped from, and the tilemap the
+## battler's picture sits in. This holds all four, so an effect stays arithmetic
+## the way a motion callback does and a renderer reads the result.
+##
+## Scene-free like the rest of the layer.
+
+const SCREEN_WIDTH: int = 20
+const SCREEN_HEIGHT: int = 18
+## `SCREEN_HEIGHT_PX`, the scanlines a table entry can be read for.
+const SCREEN_LINES: int = 144
+
+## `wLYOverrides` and `wLYOverridesBackup` are each `align 8`, and every routine
+## that indexes one loads only the low byte (`ld h, HIGH(...)` then `ld l, a`),
+## so the addressable table is the whole 256-byte page. Only the first
+## [constant SCREEN_LINES] entries are ever read as scanlines.
+const LY_PAGE: int = 256
+
+## `BattleBGEffects_SetLYOverrides` writes `$99` bytes to a 144-byte table and
+## `$91` to another. Both overruns are the cartridge's and land in padding, so
+## they are kept rather than clamped to the table.
+const LY_CLEAR_LIVE: int = 0x99
+const LY_CLEAR_BACKUP: int = 0x91
+
+## `' '`, which is what `ClearBox` fills with.
+const BLANK_TILE: int = 0x7F
+
+## What `hLCDCPointer` names: the register the scanline table is written into.
+## Zero is the table switched off, which is what `PushLYOverrides` checks.
+const LCDC_OFF: int = 0x00
+const LCDC_SCY: int = 0x42
+const LCDC_SCX: int = 0x43
+const LCDC_BGP: int = 0x47
+
+## `%11100100`, the DMG palette that maps every colour to itself.
+const PALETTE_IDENTITY: int = 0xE4
+
+## `NUM_PALS`: eight background and eight object palettes.
+const PALETTE_COUNT: int = 8
+## `PAL_BATTLE_BG_*` and `PAL_BATTLE_OB_*` slots the effects name.
+const PAL_BG_PLAYER: int = 0
+const PAL_BG_ENEMY: int = 1
+const PAL_OB_ENEMY: int = 0
+const PAL_OB_PLAYER: int = 1
+const PAL_OB_GRAY: int = 2
+
+## `wSurfWaveBGEffect`, the 64-entry wave `BattleBGEffect_Surf` rotates.
+const SURF_WAVE_LENGTH: int = 0x40
+
+## `wLYOverrides`, what the hardware reads, and `wLYOverridesBackup`, what an
+## effect writes. `PushLYOverrides` is the copy between them.
+var ly_overrides: PackedByteArray = PackedByteArray()
+var ly_overrides_backup: PackedByteArray = PackedByteArray()
+
+var lcdc_pointer: int = LCDC_OFF
+var ly_override_start: int = 0
+var ly_override_end: int = 0
+
+## `hSCX` and `hSCY`, the whole-screen scroll three effects shake.
+var scx: int = 0
+var scy: int = 0
+
+## `wBGP`, `wOBP0` and `wOBP1`, plus the `rBGP`/`rOBP0` they are compared
+## against. On the Color hardware these registers draw nothing themselves;
+## `BattleAnimRequestPals` is what turns a change into a CGB palette remap.
+var bgp: int = PALETTE_IDENTITY
+var obp0: int = PALETTE_IDENTITY
+var obp1: int = PALETTE_IDENTITY
+var r_bgp: int = PALETTE_IDENTITY
+var r_obp0: int = PALETTE_IDENTITY
+
+## Which permutation of its own four colours each palette is drawn with, as the
+## DMG palette byte `CopyPals` was handed.
+##
+## `CopyPals` always reads the pristine `wBGPals2`/`wOBPals2`, never the live
+## copy, so a remap is never compounded and the byte is the whole state. A
+## renderer applies it to whatever colours the battle actually loaded.
+var bg_palette_maps: PackedByteArray = PackedByteArray()
+var ob_palette_maps: PackedByteArray = PackedByteArray()
+
+## `hCGBPalUpdate`.
+var palettes_dirty: bool = false
+
+## `wTilemap`, the 20x18 screen the battler pictures are drawn into. Effects
+## clear boxes in it, shift its rows and stamp resized pictures over it.
+var bg_map: PackedByteArray = PackedByteArray()
+## `hBGMapMode` and `hBGMapThird`: whether the tilemap is being pushed to VRAM,
+## and which third of it.
+var bg_map_mode: int = 0
+var bg_map_third: int = 0
+
+## `wSurfWaveBGEffect`.
+var surf_wave: PackedByteArray = PackedByteArray()
+
+
+func _init() -> void:
+	ly_overrides.resize(LY_PAGE)
+	ly_overrides_backup.resize(LY_PAGE)
+	surf_wave.resize(SURF_WAVE_LENGTH)
+	bg_map.resize(SCREEN_WIDTH * SCREEN_HEIGHT)
+	bg_map.fill(BLANK_TILE)
+	bg_palette_maps.resize(PALETTE_COUNT)
+	bg_palette_maps.fill(PALETTE_IDENTITY)
+	ob_palette_maps.resize(PALETTE_COUNT)
+	ob_palette_maps.fill(PALETTE_IDENTITY)
+
+
+## Seeds the tilemap a battle is already showing, so the effects that clear and
+## resize a picture edit the real screen rather than a blank one.
+func set_bg_map(tiles: PackedByteArray) -> void:
+	if tiles.size() != bg_map.size():
+		return
+	bg_map = tiles.duplicate()
+
+
+## `BattleBGEffects_ClearLYOverrides` and `..._SetLYOverrides`.
+func set_ly_overrides(value: int) -> void:
+	for index: int in LY_CLEAR_LIVE:
+		ly_overrides[index & (LY_PAGE - 1)] = value & 0xFF
+	for index: int in LY_CLEAR_BACKUP:
+		ly_overrides_backup[index & (LY_PAGE - 1)] = value & 0xFF
+
+
+## `BGEffect_FillLYOverridesBackup`: one value across the whole window.
+##
+## The loop is a `dec`/`jr nz`, so a window of no height writes the whole page
+## rather than nothing.
+func fill_ly_backup(value: int) -> void:
+	var at: int = ly_override_start & 0xFF
+	var count: int = (ly_override_end - ly_override_start) & 0xFF
+	for _step: int in (count if count != 0 else LY_PAGE):
+		ly_overrides_backup[at] = value & 0xFF
+		at = (at + 1) & (LY_PAGE - 1)
+
+
+## `BGEffect_DisplaceLYOverridesBackup`: [param value] scanlines pushed off the
+## screen with `$90`, then the rest holding the negated displacement.
+func displace_ly_backup(value: int) -> void:
+	var at: int = ly_override_start & 0xFF
+	var pushed: int = value & 0xFF
+	var rest: int = (ly_override_end - ly_override_start - pushed) & 0xFF
+	for _step: int in (pushed if pushed != 0 else LY_PAGE):
+		ly_overrides_backup[at] = 0x90
+		at = (at + 1) & (LY_PAGE - 1)
+	var held: int = (~pushed) & 0xFF
+	for _step: int in (rest if rest != 0 else LY_PAGE):
+		ly_overrides_backup[at] = held
+		at = (at + 1) & (LY_PAGE - 1)
+
+
+## `PushLYOverrides`, which only runs while a register is named.
+func push_ly_overrides() -> void:
+	if lcdc_pointer == LCDC_OFF:
+		return
+	for line: int in SCREEN_LINES:
+		ly_overrides[line] = ly_overrides_backup[line]
+
+
+## `BattleAnimRequestPals`: a changed DMG palette byte is what asks for the CGB
+## palettes to be remapped, which is how the effects that only write `wBGP` show
+## on the Color hardware at all.
+func request_pals() -> void:
+	if bgp != r_bgp:
+		set_bg_pals(bgp)
+	if obp0 != r_obp0:
+		set_ob_pals(obp0)
+
+
+## `BattleAnim_SetBGPals`: seven background palettes and the two battler object
+## ones.
+func set_bg_pals(value: int) -> void:
+	r_bgp = value & 0xFF
+	for slot: int in 7:
+		bg_palette_maps[slot] = value & 0xFF
+	for slot: int in 2:
+		ob_palette_maps[slot] = value & 0xFF
+	palettes_dirty = true
+
+
+## `BattleAnim_SetOBPals`: the two object palettes from `PAL_BATTLE_OB_GRAY` on.
+func set_ob_pals(value: int) -> void:
+	r_obp0 = value & 0xFF
+	for slot: int in 2:
+		ob_palette_maps[PAL_OB_GRAY + slot] = value & 0xFF
+	palettes_dirty = true
+
+
+## `BGEffects_LoadPlayerPals` and `..._LoadEnemyPals`: one background palette and
+## one object palette each, which is how a fade reaches one side of the field.
+func load_player_pals(value: int) -> void:
+	bg_palette_maps[PAL_BG_PLAYER] = value & 0xFF
+	ob_palette_maps[PAL_OB_PLAYER] = value & 0xFF
+	palettes_dirty = true
+
+
+func load_enemy_pals(value: int) -> void:
+	bg_palette_maps[PAL_BG_ENEMY] = value & 0xFF
+	ob_palette_maps[PAL_OB_ENEMY] = value & 0xFF
+	palettes_dirty = true
+
+
+## `BattleAnim_ResetLCDStatCustom` without its `EndBattleBGEffect`, which the
+## caller owns.
+func reset_lcd_stat_custom() -> void:
+	ly_override_start = 0
+	ly_override_end = 0
+	set_ly_overrides(0)
+	lcdc_pointer = LCDC_OFF
+
+
+## `BattleBGEffects_ResetVideoHRAM`.
+func reset_video_hram() -> void:
+	lcdc_pointer = LCDC_OFF
+	r_bgp = PALETTE_IDENTITY
+	bgp = PALETTE_IDENTITY
+	obp1 = PALETTE_IDENTITY
+	ly_override_start = 0
+	ly_override_end = 0
+	set_ly_overrides(0)
+
+
+## `ClearBox`: a [param rows] by [param columns] box of blanks at a tile coord.
+func clear_box(x: int, y: int, rows: int, columns: int) -> void:
+	for row: int in rows:
+		var line: int = y + row
+		if line < 0 or line >= SCREEN_HEIGHT:
+			continue
+		for column: int in columns:
+			var at: int = x + column
+			if at < 0 or at >= SCREEN_WIDTH:
+				continue
+			bg_map[line * SCREEN_WIDTH + at] = BLANK_TILE
+
+
+func tile_at(x: int, y: int) -> int:
+	if x < 0 or x >= SCREEN_WIDTH or y < 0 or y >= SCREEN_HEIGHT:
+		return BLANK_TILE
+	return bg_map[y * SCREEN_WIDTH + x]
+
+
+func set_tile(x: int, y: int, tile: int) -> void:
+	if x < 0 or x >= SCREEN_WIDTH or y < 0 or y >= SCREEN_HEIGHT:
+		return
+	bg_map[y * SCREEN_WIDTH + x] = tile & 0xFF

--- a/game/battle/battle_anim_background.gd.uid
+++ b/game/battle/battle_anim_background.gd.uid
@@ -1,0 +1,1 @@
+uid://b2kvxxp6fd5w8

--- a/game/battle/battle_anim_bg_effect.gd
+++ b/game/battle/battle_anim_bg_effect.gd
@@ -1,0 +1,37 @@
+class_name Gen2BattleAnimBgEffect
+extends RefCounted
+
+## One `battle_bg_effect` (macros/ram.asm): the four bytes a `wActiveBGEffects`
+## slot holds.
+##
+## `id` is `BG_EFFECT_STRUCT_FUNCTION`, and zero is what frees the slot, the way
+## a zero index frees an animation object. It stays the cartridge's own effect
+## number and is never normalised across the profiles: pokegold has no
+## `BATTLE_BG_EFFECT_BODY_SLAM` and its list runs one lower from $25 on, so the
+## same byte names a different effect in the two games.
+
+var id: int = 0
+var jumptable_index: int = 0
+## `BG_EFFECT_STRUCT_BATTLE_TURN`, which starts as `BG_EFFECT_TARGET` or
+## `BG_EFFECT_USER` and is then reused as working state by most effects.
+var battle_turn: int = 0
+var param: int = 0
+
+
+static func create(id: int, jumptable_index: int, battle_turn: int, param: int
+) -> Gen2BattleAnimBgEffect:
+	var out := Gen2BattleAnimBgEffect.new()
+	out.id = id & 0xFF
+	out.jumptable_index = jumptable_index & 0xFF
+	out.battle_turn = battle_turn & 0xFF
+	out.param = param & 0xFF
+	return out
+
+
+## `EndBattleBGEffect`: zeroing the id is what frees the slot.
+func end() -> void:
+	id = 0
+
+
+func active() -> bool:
+	return id != 0

--- a/game/battle/battle_anim_bg_effect.gd.uid
+++ b/game/battle/battle_anim_bg_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://cnmeox41kfj5b

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -1,0 +1,1499 @@
+class_name Gen2BattleAnimBgEffects
+extends RefCounted
+
+## The `BATTLE_BG_EFFECT_*` jumptable and the routines it dispatches
+## (engine/battle_anims/bg_effects.asm).
+##
+## A bg effect is the half of an animation that is not an object: the screen
+## shakes, the scanline deformations, the palette fades and the tilemap edits
+## that hide, shrink and slide a battler's picture. Five run at once, each a
+## four-byte `battle_bg_effect` the script queues with `anim_bgeffect`.
+##
+## **An effect id is profile-local and is never normalised.** pokegold ships no
+## `BATTLE_BG_EFFECT_BODY_SLAM`, so its list is 53 long against Crystal's 54 and
+## every id from $25 on names a different effect in the two games. The two
+## jumptables are kept whole here for that reason, and dispatch is by name.
+##
+## The Color hardware's branch is the one taken wherever the source asks `hCGB`
+## or `hSGB`, which is the same choice every `_CGB_*` layout in this project
+## makes. The DMG halves of `BGEffect_RapidCyclePals` and
+## `BattleBGEffect_FadeMonsToBlackRepeating` are therefore not built; the effects
+## that write `wBGP` unconditionally still reach the screen, because
+## `BattleAnimRequestPals` turns that byte into a CGB palette remap.
+
+## `BattleBGEffects`, Crystal's own order. The index is the cartridge's effect
+## id and entry 0 is `BattleBGEffect_End`, which is also the free-slot marker.
+const EFFECTS_CRYSTAL: Array[StringName] = [
+	&"end", &"flash_inverted", &"flash_white", &"white_hues", &"black_hues",
+	&"alternate_hues", &"cycle_ob_pals_gray_and_yellow",
+	&"cycle_mid_ob_pals_gray_and_yellow", &"cycle_bg_pals_inverted",
+	&"hide_mon", &"show_mon", &"enter_mon", &"return_mon", &"surf",
+	&"whirlpool", &"teleport", &"night_shade", &"battler_obj_1row",
+	&"battler_obj_2row", &"double_team", &"acid_armor", &"rapid_flash",
+	&"fade_mon_to_light", &"fade_mon_to_black", &"fade_mon_to_light_repeating",
+	&"fade_mon_to_black_repeating", &"cycle_mon_light_dark_repeating",
+	&"flash_mon_repeating", &"fade_mons_to_black_repeating",
+	&"fade_mon_to_white_wait_fade_back", &"fade_mon_from_white",
+	&"shake_screen_x", &"shake_screen_y", &"withdraw", &"bounce_down", &"dig",
+	&"tackle", &"body_slam", &"wobble_mon", &"remove_mon", &"wave_deform_mon",
+	&"psychic", &"beta_send_out_mon1", &"beta_send_out_mon2", &"flail",
+	&"beta_pursuit", &"rollout", &"vital_throw", &"start_water", &"water",
+	&"end_water", &"vibrate_mon", &"wobble_player", &"wobble_screen",
+]
+
+## pokegold's own table, which is Crystal's without `body_slam`. Everything from
+## $25 on therefore sits one lower, and `BATTLE_BG_EFFECT_ROLLOUT` is $2d here
+## against Crystal's $2e.
+const EFFECTS_GOLD: Array[StringName] = [
+	&"end", &"flash_inverted", &"flash_white", &"white_hues", &"black_hues",
+	&"alternate_hues", &"cycle_ob_pals_gray_and_yellow",
+	&"cycle_mid_ob_pals_gray_and_yellow", &"cycle_bg_pals_inverted",
+	&"hide_mon", &"show_mon", &"enter_mon", &"return_mon", &"surf",
+	&"whirlpool", &"teleport", &"night_shade", &"battler_obj_1row",
+	&"battler_obj_2row", &"double_team", &"acid_armor", &"rapid_flash",
+	&"fade_mon_to_light", &"fade_mon_to_black", &"fade_mon_to_light_repeating",
+	&"fade_mon_to_black_repeating", &"cycle_mon_light_dark_repeating",
+	&"flash_mon_repeating", &"fade_mons_to_black_repeating",
+	&"fade_mon_to_white_wait_fade_back", &"fade_mon_from_white",
+	&"shake_screen_x", &"shake_screen_y", &"withdraw", &"bounce_down", &"dig",
+	&"tackle", &"wobble_mon", &"remove_mon", &"wave_deform_mon",
+	&"psychic", &"beta_send_out_mon1", &"beta_send_out_mon2", &"flail",
+	&"beta_pursuit", &"rollout", &"vital_throw", &"start_water", &"water",
+	&"end_water", &"vibrate_mon", &"wobble_player", &"wobble_screen",
+]
+
+## `NUM_BG_EFFECTS`.
+const MAX_EFFECTS: int = 5
+
+## `BATTLE_ANIM_OBJ_*`, the four battler-shaped objects `battler_obj_1row` and
+## `..._2row` spawn.
+const OBJ_ENEMYFEET_1ROW: int = 0xB8
+const OBJ_PLAYERHEAD_1ROW: int = 0xB9
+const OBJ_ENEMYFEET_2ROW: int = 0xBA
+const OBJ_PLAYERHEAD_2ROW: int = 0xBB
+
+## The DMG palette lists the flash and fade effects walk. `$ff` ends one and
+## `$fe` sends it back to the start, which is what makes a fade repeat.
+const PALS_END: int = 0xFF
+const PALS_LOOP: int = 0xFE
+
+const PALS_FLASH_INVERTED: Array[int] = [0xE4, 0x1B]
+const PALS_FLASH_WHITE: Array[int] = [0xE4, 0x00]
+const PALS_WHITE_HUES: Array[int] = [0xE4, 0xE0, 0xD0, 0xFF]
+const PALS_BLACK_HUES: Array[int] = [0xE4, 0xF4, 0xF8, 0xFF]
+const PALS_ALTERNATE_HUES: Array[int] = [
+	0xE4, 0xF8, 0xFC, 0xF8, 0xE4, 0x90, 0x40, 0x90, 0xFE,
+]
+const PALS_OB_GRAY_YELLOW: Array[int] = [0xE4, 0x90, 0xFE]
+const PALS_MID_OB_GRAY_YELLOW: Array[int] = [0xE4, 0xD8, 0xFE]
+const PALS_BG_INVERTED: Array[int] = [0x1B, 0x63, 0x87, 0xFE]
+const PALS_RAPID_FLASH: Array[int] = [0xE4, 0x6C, 0xFE]
+const PALS_TO_LIGHT: Array[int] = [0xE4, 0x90, 0x40, 0xFF]
+const PALS_TO_BLACK: Array[int] = [0xE4, 0xF8, 0xFC, 0xFF]
+const PALS_TO_LIGHT_REPEATING: Array[int] = [0xE4, 0x90, 0x40, 0x90, 0xFE]
+const PALS_TO_BLACK_REPEATING: Array[int] = [0xE4, 0xF8, 0xFC, 0xF8, 0xFE]
+const PALS_LIGHT_DARK_REPEATING: Array[int] = [
+	0xE4, 0xF8, 0xFC, 0xF8, 0xE4, 0x90, 0x40, 0x90, 0xFE,
+]
+const PALS_FLASH_MON_REPEATING: Array[int] = [0xE4, 0xFC, 0xE4, 0x00, 0xFE]
+const PALS_TO_WHITE_WAIT_BACK: Array[int] = [
+	0xE4, 0x90, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x90, 0xE4, 0xFF,
+]
+const PALS_FROM_WHITE: Array[int] = [0x00, 0x40, 0x90, 0xE4, 0xFF]
+
+## `BattleBGEffect_FadeMonsToBlackRepeating.CGB_DMGEnemyData`, four pairs the
+## `.cgb` branch reads for both sides.
+const FADE_MONS_PAIRS: Array[int] = [0xE4, 0xE4, 0xF8, 0x90, 0xFC, 0x40, 0xF8, 0x90]
+
+## `BattleBGEffect_BetaSendOutMon1.data`.
+const BETA_SEND_OUT_STEPS: Array[int] = [0x00, 0x40, 0x90, 0xE4, 0xFF]
+
+## `BattleBGEffect_RunPicResizeScript.Coords`, as tile coordinates.
+const RESIZE_COORDS: Array = [
+	[2, 6], [3, 8], [4, 10], [12, 0], [13, 2], [14, 4],
+]
+
+## `.BGSquares`: how big each square is, in `BGSQUARE_*` order.
+const RESIZE_SIZES: Array[int] = [6, 4, 2, 7, 5, 3]
+
+## The six squares themselves, each a row-major list of tile offsets added to the
+## row's own base tile. They are the cartridge's own subsamplings of the 7x7
+## picture, which is why a shrunk picture drops rows rather than scaling.
+const RESIZE_SQUARES: Array = [
+	[  # BGSQUARE_SIX
+		0x00, 0x06, 0x0C, 0x12, 0x18, 0x1E,
+		0x01, 0x07, 0x0D, 0x13, 0x19, 0x1F,
+		0x02, 0x08, 0x0E, 0x14, 0x1A, 0x20,
+		0x03, 0x09, 0x0F, 0x15, 0x1B, 0x21,
+		0x04, 0x0A, 0x10, 0x16, 0x1C, 0x22,
+		0x05, 0x0B, 0x11, 0x17, 0x1D, 0x23,
+	],
+	[  # BGSQUARE_FOUR
+		0x00, 0x0C, 0x12, 0x1E,
+		0x02, 0x0E, 0x14, 0x20,
+		0x03, 0x0F, 0x15, 0x21,
+		0x05, 0x11, 0x17, 0x23,
+	],
+	[0x00, 0x1E, 0x05, 0x23],  # BGSQUARE_TWO
+	[  # BGSQUARE_SEVEN
+		0x00, 0x07, 0x0E, 0x15, 0x1C, 0x23, 0x2A,
+		0x01, 0x08, 0x0F, 0x16, 0x1D, 0x24, 0x2B,
+		0x02, 0x09, 0x10, 0x17, 0x1E, 0x25, 0x2C,
+		0x03, 0x0A, 0x11, 0x18, 0x1F, 0x26, 0x2D,
+		0x04, 0x0B, 0x12, 0x19, 0x20, 0x27, 0x2E,
+		0x05, 0x0C, 0x13, 0x1A, 0x21, 0x28, 0x2F,
+		0x06, 0x0D, 0x14, 0x1B, 0x22, 0x29, 0x30,
+	],
+	[  # BGSQUARE_FIVE
+		0x00, 0x07, 0x15, 0x23, 0x2A,
+		0x01, 0x08, 0x16, 0x24, 0x2B,
+		0x03, 0x0A, 0x18, 0x26, 0x2D,
+		0x05, 0x0C, 0x1A, 0x28, 0x2F,
+		0x06, 0x0D, 0x1B, 0x29, 0x30,
+	],
+	[  # BGSQUARE_THREE
+		0x00, 0x15, 0x2A,
+		0x03, 0x18, 0x2D,
+		0x06, 0x1B, 0x30,
+	],
+]
+
+## The three pic-resize scripts, as rows of
+## [code][square, base tile, coord][/code]. A square of -1 ends the script, -2
+## clears a box whose size is the packed second byte, and -3 skips a frame.
+const RESIZE_SHOW_PLAYER: Array = [[0, 0x31, 0], [-1, 0, 0]]
+const RESIZE_SHOW_ENEMY: Array = [[3, 0x00, 3], [-1, 0, 0]]
+const RESIZE_ENTER_PLAYER: Array = [
+	[2, 0x31, 2], [1, 0x31, 1], [0, 0x31, 0], [-1, 0, 0],
+]
+const RESIZE_ENTER_ENEMY: Array = [
+	[5, 0x00, 5], [4, 0x00, 4], [3, 0x00, 3], [-1, 0, 0],
+]
+const RESIZE_RETURN_PLAYER: Array = [
+	[0, 0x31, 0], [-2, 0x66, 0], [1, 0x31, 1], [-2, 0x44, 1],
+	[2, 0x31, 2], [-2, 0x22, 2], [-3, 0x00, 0], [-1, 0, 0],
+]
+const RESIZE_RETURN_ENEMY: Array = [
+	[3, 0x00, 3], [-2, 0x77, 3], [4, 0x00, 4], [-2, 0x55, 4],
+	[5, 0x00, 5], [-2, 0x33, 5], [-3, 0x00, 0], [-1, 0, 0],
+]
+
+
+## The effect table this profile ships. pokegold's is one shorter; nothing
+## normalises between them.
+static func names_for(profile: StringName) -> Array[StringName]:
+	return EFFECTS_CRYSTAL if profile == &"crystal" else EFFECTS_GOLD
+
+
+## `DoBattleBGEffectFunction`. Answers false when the id is past this profile's
+## own table, which cartridge data never asks for.
+static func run(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> bool:
+	var names: Array[StringName] = names_for(player.profile())
+	if effect.id < 0 or effect.id >= names.size():
+		return false
+	var background: Gen2BattleAnimBackground = player.background()
+	match names[effect.id]:
+		&"end":
+			effect.end()
+		&"flash_inverted":
+			_flash(background, effect, PALS_FLASH_INVERTED)
+		&"flash_white":
+			_flash(background, effect, PALS_FLASH_WHITE)
+		&"white_hues":
+			_hues(background, effect, PALS_WHITE_HUES, false)
+		&"black_hues":
+			_hues(background, effect, PALS_BLACK_HUES, false)
+		&"alternate_hues":
+			_hues(background, effect, PALS_ALTERNATE_HUES, true)
+		&"cycle_ob_pals_gray_and_yellow":
+			background.obp0 = _nth_dmg_pal(effect, PALS_OB_GRAY_YELLOW)
+		&"cycle_mid_ob_pals_gray_and_yellow":
+			background.obp0 = _nth_dmg_pal(effect, PALS_MID_OB_GRAY_YELLOW)
+		&"cycle_bg_pals_inverted":
+			background.bgp = _nth_dmg_pal(effect, PALS_BG_INVERTED)
+		&"hide_mon":
+			_hide_mon(player, effect)
+		&"show_mon":
+			_show_mon(player, effect)
+		&"enter_mon":
+			_enter_mon(player, effect)
+		&"return_mon":
+			_return_mon(player, effect)
+		&"surf":
+			_surf(background, effect)
+		&"whirlpool":
+			_whirlpool(player, effect)
+		&"teleport":
+			_teleport(player, effect)
+		&"night_shade":
+			_night_shade(player, effect)
+		&"battler_obj_1row":
+			_battler_obj(player, effect, false)
+		&"battler_obj_2row":
+			_battler_obj(player, effect, true)
+		&"double_team":
+			_double_team(player, effect)
+		&"acid_armor":
+			_acid_armor(player, effect)
+		&"rapid_flash":
+			_rapid_cycle_pals(player, effect, PALS_RAPID_FLASH)
+		&"fade_mon_to_light":
+			_rapid_cycle_pals(player, effect, PALS_TO_LIGHT)
+		&"fade_mon_to_black":
+			_rapid_cycle_pals(player, effect, PALS_TO_BLACK)
+		&"fade_mon_to_light_repeating":
+			_rapid_cycle_pals(player, effect, PALS_TO_LIGHT_REPEATING)
+		&"fade_mon_to_black_repeating":
+			_rapid_cycle_pals(player, effect, PALS_TO_BLACK_REPEATING)
+		&"cycle_mon_light_dark_repeating":
+			_rapid_cycle_pals(player, effect, PALS_LIGHT_DARK_REPEATING)
+		&"flash_mon_repeating":
+			_rapid_cycle_pals(player, effect, PALS_FLASH_MON_REPEATING)
+		&"fade_mons_to_black_repeating":
+			_fade_mons_to_black_repeating(player, effect)
+		&"fade_mon_to_white_wait_fade_back":
+			_rapid_cycle_pals(player, effect, PALS_TO_WHITE_WAIT_BACK)
+		&"fade_mon_from_white":
+			_rapid_cycle_pals(player, effect, PALS_FROM_WHITE)
+		&"shake_screen_x":
+			background.scx = _shake_amount(background, effect)
+		&"shake_screen_y":
+			background.scy = _shake_amount(background, effect)
+		&"withdraw":
+			_withdraw(player, effect)
+		&"bounce_down":
+			_bounce_down(player, effect)
+		&"dig":
+			_dig(player, effect)
+		&"tackle":
+			_tackle(player, effect, false)
+		&"body_slam":
+			_tackle(player, effect, true)
+		&"wobble_mon":
+			_wobble_mon(player, effect)
+		&"remove_mon":
+			_remove_mon(player, effect)
+		&"wave_deform_mon":
+			_wave_deform_mon(player, effect)
+		&"psychic":
+			_psychic(player, effect)
+		&"beta_send_out_mon1":
+			_beta_send_out_mon1(player, effect)
+		&"beta_send_out_mon2":
+			_beta_send_out_mon2(player, effect)
+		&"flail":
+			_flail(player, effect)
+		&"beta_pursuit":
+			_beta_pursuit(player, effect)
+		&"rollout":
+			_rollout(player, effect)
+		&"vital_throw":
+			_vital_throw(player, effect)
+		&"start_water":
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(player, effect, Gen2BattleAnimBackground.LCDC_SCY, false)
+			effect.end()
+		&"water":
+			_water(player, effect)
+		&"end_water":
+			background.reset_lcd_stat_custom()
+			effect.end()
+		&"vibrate_mon":
+			_vibrate_mon(player, effect)
+		&"wobble_player":
+			_wobble_player(player, effect)
+		&"wobble_screen":
+			_wobble_screen(player, effect)
+		_:
+			return false
+	return true
+
+
+# ---------------------------------------------------------------- helpers ----
+
+## `BattleBGEffects_IncAnonJumptableIndex`.
+static func _inc(effect: Gen2BattleAnimBgEffect) -> void:
+	effect.jumptable_index = (effect.jumptable_index + 1) & 0xFF
+
+
+## `BGEffect_CheckBattleTurn`: `hBattleTurn` against the effect's own turn byte.
+## Non-zero is the player's side, which is what every `.player_side` branch is.
+static func _check_battle_turn(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> int:
+	return ((1 if player.enemy_turn() else 0) ^ effect.battle_turn) & 0xFF
+
+
+static func _player_side(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> bool:
+	return _check_battle_turn(player, effect) != 0
+
+
+## `BattleBGEffect_SetLCDStatCustoms1` and `..._Customs2`, which differ only in
+## where the player's own window starts. Crystal alone ships the second, and
+## `body_slam` and `bounce_down` are the only two that ask for it.
+static func _set_lcd_stat_customs(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect,
+	pointer: int, second: bool
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	background.lcdc_pointer = pointer
+	if _player_side(player, effect):
+		background.ly_override_start = 0x2D if second else 0x2F
+		background.ly_override_end = 0x5E
+		return
+	background.ly_override_start = 0x00
+	background.ly_override_end = 0x36
+
+
+## `BattleAnim_ResetLCDStatCustom`, which ends the effect as well.
+static func _reset_lcd_stat_custom(
+	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect
+) -> void:
+	background.reset_lcd_stat_custom()
+	effect.end()
+
+
+## `BattleBGEffects_Sine` and `..._Cosine`, which are `BattleAnim_Sine_e` far
+## called, so they read the same imported `BattleAnimSineWave`.
+static func _sine(player: Gen2BattleAnimPlayer, a: int, d: int) -> int:
+	return Gen2BattleAnimFunctions.sine_of(player.data(), a, d)
+
+
+static func _cosine(player: Gen2BattleAnimPlayer, a: int, d: int) -> int:
+	return Gen2BattleAnimFunctions.cosine_of(player.data(), a, d)
+
+
+## `BattleBGEffect_GetNextDMGPal`. Answers -1 for the `$ff` that ends a list;
+## `$fe` restarts it and answers the first entry.
+static func _next_dmg_pal(
+	effect: Gen2BattleAnimBgEffect, pals: Array[int], index: int
+) -> int:
+	var value: int = pals[index] if index >= 0 and index < pals.size() else PALS_END
+	if value == PALS_END:
+		return -1
+	if value == PALS_LOOP:
+		effect.param = 0
+		return pals[0]
+	return value
+
+
+## `BattleBGEffect_GetFirstDMGPal`: the entry the parameter names, and the
+## parameter stepped on.
+static func _first_dmg_pal(effect: Gen2BattleAnimBgEffect, pals: Array[int]) -> int:
+	var index: int = effect.param
+	effect.param = (effect.param + 1) & 0xFF
+	return _next_dmg_pal(effect, pals, index)
+
+
+## `BattleBGEffect_GetNthDMGPal`: the jumptable index is a countdown between
+## steps and the turn byte is how long each step lasts.
+static func _nth_dmg_pal(effect: Gen2BattleAnimBgEffect, pals: Array[int]) -> int:
+	if effect.jumptable_index != 0:
+		effect.jumptable_index = (effect.jumptable_index - 1) & 0xFF
+		return _next_dmg_pal(effect, pals, effect.param)
+	effect.jumptable_index = effect.battle_turn
+	return _first_dmg_pal(effect, pals)
+
+
+## `DeformScreen`: a sine down the scanline window, sampled every
+## [param offset] of a turn.
+static func _deform_screen(
+	player: Gen2BattleAnimPlayer, amplitude: int, offset: int
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var progress: int = 0
+	for line: int in 0x80:
+		if background.ly_override_start < line and background.ly_override_end >= line:
+			background.ly_overrides_backup[line] = _sine(player, progress, amplitude)
+		progress = (progress + offset) & 0xFF
+
+
+## `InitSurfWaves`: the 64-entry wave the Surf effect then rotates past the
+## window one entry a frame.
+static func _init_surf_waves(
+	player: Gen2BattleAnimPlayer, amplitude: int, offset: int
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var progress: int = 0
+	for index: int in Gen2BattleAnimBackground.SURF_WAVE_LENGTH:
+		background.surf_wave[index] = _sine(player, progress, amplitude)
+		progress = (progress + offset) & 0xFF
+
+
+## `DeformWater`: a wave that grows outwards from one line in both directions,
+## stopping at whichever end of the window it reaches first.
+static func _deform_water(
+	player: Gen2BattleAnimPlayer, timer: int, amplitude: int, offset: int,
+	progress: int
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	var down: int = (background.ly_override_start + progress) & 0xFF
+	var up: int = down
+	var step: int = offset
+	var left: int = timer
+	while left != 0:
+		left -= 1
+		var value: int = _sine(player, step, amplitude)
+		if background.ly_override_end >= down:
+			background.ly_overrides_backup[down] = value
+			down = (down + 1) & (page - 1)
+		if background.ly_override_start < up:
+			background.ly_overrides_backup[up] = value
+			up = (up - 1) & (page - 1)
+		step = (step + 4) & 0xFF
+
+
+## `BattleBGEffect_WavyScreenFX`: the window rotated up one line, the top line
+## coming back round to the bottom.
+static func _wavy_screen_fx(background: Gen2BattleAnimBackground) -> void:
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	var at: int = background.ly_override_start & 0xFF
+	var count: int = (background.ly_override_end - background.ly_override_start) & 0xFF
+	if count == 0:
+		return
+	var first: int = background.ly_overrides_backup[at]
+	var from: int = (at + 1) & (page - 1)
+	for _step: int in count:
+		background.ly_overrides_backup[at] = background.ly_overrides_backup[from]
+		at = (at + 1) & (page - 1)
+		from = (from + 1) & (page - 1)
+	background.ly_overrides_backup[at] = first
+
+
+# -------------------------------------------------------- palette effects ----
+
+## `BattleBGEffect_FlashContinue`: the turn byte is how long a flash lasts and
+## the parameter how many are left.
+static func _flash(
+	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect,
+	pals: Array[int]
+) -> void:
+	if effect.jumptable_index != 0:
+		effect.jumptable_index = (effect.jumptable_index - 1) & 0xFF
+		return
+	effect.jumptable_index = effect.battle_turn
+	if effect.param == 0:
+		effect.end()
+		return
+	effect.param = (effect.param - 1) & 0xFF
+	background.bgp = pals[effect.param & 1]
+
+
+## The three hue walks, which end when their list does. `alternate_hues` is the
+## one that takes the object palette with it.
+static func _hues(
+	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect,
+	pals: Array[int], with_objects: bool
+) -> void:
+	var value: int = _nth_dmg_pal(effect, pals)
+	if value < 0:
+		effect.end()
+		return
+	background.bgp = value
+	if with_objects:
+		background.obp1 = value
+
+
+## `BGEffect_RapidCyclePals`, the Color branch: one side of the field at a time,
+## and the enemy's own states are the two above the player's.
+##
+## Nothing here ends the walk. The list's own `$ff` only stalls it; the effect is
+## retired by the script's `anim_incbgeffect`, which is what steps it onto the
+## state that puts the palette back.
+static func _rapid_cycle_pals(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect, pals: Array[int]
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			if not _player_side(player, effect):
+				_inc(effect)
+				_inc(effect)
+			_inc(effect)
+			effect.battle_turn = effect.param
+			effect.param = 0
+		1:
+			_rapid_cycle_step(effect, pals, background, true)
+		2:
+			background.load_player_pals(Gen2BattleAnimBackground.PALETTE_IDENTITY)
+			effect.end()
+		3:
+			_rapid_cycle_step(effect, pals, background, false)
+		4:
+			background.load_enemy_pals(Gen2BattleAnimBackground.PALETTE_IDENTITY)
+			effect.end()
+
+
+## One step of that walk. The turn byte's low nybble counts the frames between
+## steps and its high nybble is what reloads it.
+static func _rapid_cycle_step(
+	effect: Gen2BattleAnimBgEffect, pals: Array[int],
+	background: Gen2BattleAnimBackground, player_side: bool
+) -> void:
+	if (effect.battle_turn & 0xF) != 0:
+		effect.battle_turn = (effect.battle_turn - 1) & 0xFF
+		return
+	effect.battle_turn = ((effect.battle_turn >> 4) | effect.battle_turn) & 0xFF
+	var value: int = _first_dmg_pal(effect, pals)
+	if value < 0:
+		effect.param = (effect.param - 1) & 0xFF
+		return
+	if player_side:
+		background.load_player_pals(value)
+		return
+	background.load_enemy_pals(value)
+
+
+## `BattleBGEffect_FadeMonsToBlackRepeating`, the Color branch: both sides at
+## once, the far one taking the other half of each pair.
+static func _fade_mons_to_black_repeating(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			effect.param = 0
+		1:
+			var step: int = effect.param
+			effect.param = (effect.param + 1) & 0xFF
+			if (step & 0x7) != 0:
+				return
+			var row: int = ((step & 0x18) >> 3) * 2
+			var near: int = FADE_MONS_PAIRS[row]
+			var far: int = FADE_MONS_PAIRS[row + 1]
+			if _player_side(player, effect):
+				background.load_player_pals(near)
+				background.load_enemy_pals(far)
+				return
+			background.load_enemy_pals(near)
+			background.load_player_pals(far)
+		2:
+			background.load_player_pals(Gen2BattleAnimBackground.PALETTE_IDENTITY)
+			background.load_enemy_pals(Gen2BattleAnimBackground.PALETTE_IDENTITY)
+			effect.end()
+
+
+# -------------------------------------------------------- tilemap effects ----
+
+## `BattleBGEffect_HideMon`: the battler's own box blanked, then four frames of
+## nothing while the tilemap reaches VRAM.
+static func _hide_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			if _player_side(player, effect):
+				background.clear_box(2, 6, 6, 6)
+			else:
+				background.clear_box(12, 0, 7, 7)
+			# Crystal alone rewinds the push; pokegold leaves whichever third
+			# was in flight.
+			if player.profile() == &"crystal":
+				background.bg_map_third = 0
+			background.bg_map_mode = 1
+		1, 2, 3:
+			_inc(effect)
+		4:
+			background.bg_map_mode = 0
+			effect.end()
+
+
+## `BattleBGEffect_ShowMon`, which does nothing at all for a battler that is
+## off the field mid-Fly or mid-Dig.
+static func _show_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	if player.fly_dig_status(_player_side(player, effect)):
+		effect.end()
+		return
+	_run_pic_resize_script(
+		player, effect,
+		RESIZE_SHOW_PLAYER if _player_side(player, effect) else RESIZE_SHOW_ENEMY
+	)
+
+
+static func _enter_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	_run_pic_resize_script(
+		player, effect,
+		RESIZE_ENTER_PLAYER if _player_side(player, effect) else RESIZE_ENTER_ENEMY
+	)
+
+
+static func _return_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	_run_pic_resize_script(
+		player, effect,
+		RESIZE_RETURN_PLAYER if _player_side(player, effect) else RESIZE_RETURN_ENEMY
+	)
+
+
+## `BattleBGEffect_RunPicResizeScript`: one row of the script a frame, with two
+## idle frames between so the tilemap reaches VRAM before the next one.
+static func _run_pic_resize_script(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect, script: Array
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			# `.clear` loops back into this state with the parameter already
+			# stepped on, so one frame can clear a box and place the next square.
+			for _step: int in script.size() + 1:
+				var index: int = effect.param
+				effect.param = (effect.param + 1) & 0xFF
+				var row: Array = script[index] if index < script.size() else [-1, 0, 0]
+				var square: int = int(row[0])
+				if square == -1:
+					background.bg_map_mode = 0
+					effect.end()
+					return
+				if square == -2:
+					_resize_clear_box(background, int(row[1]), int(row[2]))
+					continue
+				if square != -3:
+					_resize_place_graphic(background, square, int(row[1]), int(row[2]))
+				_inc(effect)
+				background.bg_map_mode = 1
+				return
+		1, 2:
+			_inc(effect)
+		3:
+			background.bg_map_mode = 0
+			effect.jumptable_index = 0
+		4:
+			background.bg_map_mode = 0
+			effect.end()
+
+
+## `.ClearBox`: the size is one packed byte, rows in the high nybble.
+static func _resize_clear_box(
+	background: Gen2BattleAnimBackground, size: int, coord: int
+) -> void:
+	var at: Array = RESIZE_COORDS[coord]
+	background.clear_box(int(at[0]), int(at[1]), (size >> 4) & 0xF, size & 0xF)
+
+
+## `.PlaceGraphic`: one `BGSquare` stamped at a coordinate, its own offsets added
+## to the row's base tile.
+static func _resize_place_graphic(
+	background: Gen2BattleAnimBackground, square: int, base: int, coord: int
+) -> void:
+	var side: int = RESIZE_SIZES[square]
+	var tiles: Array = RESIZE_SQUARES[square]
+	var at: Array = RESIZE_COORDS[coord]
+	for row: int in side:
+		for column: int in side:
+			background.set_tile(
+				int(at[0]) + column, int(at[1]) + row,
+				(base + int(tiles[row * side + column])) & 0xFF
+			)
+
+
+## `BattleBGEffect_BattlerObj_1Row` and `..._2Row`: an object standing in for the
+## row of the picture the tilemap is about to lose.
+static func _battler_obj(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect, two_row: bool
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var player_side: bool = _player_side(player, effect)
+	match effect.jumptable_index:
+		0:
+			if player.fly_dig_status(player_side):
+				# The index is stepped on anyway, so the object this effect did
+				# not spawn still costs a number.
+				player.bump_object_index()
+				effect.end()
+				return
+			_inc(effect)
+			var row: int = 0
+			var x: int = 0
+			if player_side:
+				row = OBJ_PLAYERHEAD_2ROW if two_row else OBJ_PLAYERHEAD_1ROW
+				x = 6 * 8
+			else:
+				row = OBJ_ENEMYFEET_2ROW if two_row else OBJ_ENEMYFEET_1ROW
+				x = 16 * 8 + 4
+			player.queue_object(row, x, 8 * 8, 0)
+		1:
+			_inc(effect)
+			if player_side:
+				background.clear_box(2, 6, 2 if two_row else 1, 6)
+			elif two_row:
+				background.clear_box(12, 5, 2, 7)
+			else:
+				background.clear_box(12, 6, 1, 7)
+			background.bg_map_mode = 1
+		2, 3, 4:
+			_inc(effect)
+		5:
+			background.bg_map_mode = 0
+			effect.end()
+
+
+## `BattleBGEffect_RemoveMon`: the picture shifted off its own side of the
+## screen a column at a time.
+static func _remove_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			# `BGEffect_CheckBattleTurn` leaves the pointer on the turn byte, so
+			# the answer is written back over it before it is read again.
+			effect.battle_turn = _check_battle_turn(player, effect)
+			effect.param = 0x8 if effect.battle_turn == 0 else 0x9
+		1:
+			if effect.battle_turn == 0:
+				for row: int in 7:
+					for column: int in 8:
+						background.set_tile(
+							19 - column, row, background.tile_at(18 - column, row)
+						)
+			else:
+				for row: int in 6:
+					for column: int in 8:
+						background.set_tile(
+							column, 6 + row, background.tile_at(column + 1, 6 + row)
+						)
+			background.bg_map_third = 0
+			background.bg_map_mode = 1
+			_inc(effect)
+			effect.param = (effect.param - 1) & 0xFF
+		2, 3:
+			_inc(effect)
+		4:
+			background.bg_map_mode = 0
+			if effect.param == 0:
+				effect.end()
+				return
+			effect.jumptable_index = 0x1
+
+
+# ------------------------------------------------------- scanline effects ----
+
+## `BattleBGEffect_Surf`, which opens no window of its own: it rides the one
+## `start_water` set, and does nothing until it exists.
+static func _surf(
+	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect
+) -> void:
+	match effect.jumptable_index:
+		2:
+			background.reset_lcd_stat_custom()
+			effect.end()
+		_:
+			if effect.jumptable_index == 0:
+				_inc(effect)
+			if background.lcdc_pointer == Gen2BattleAnimBackground.LCDC_OFF:
+				return
+			_rotate_surf_wave(background)
+
+
+## `.RotatewSurfWaveBGEffect`: the wave stepped round one entry, then laid over
+## the window from its start.
+static func _rotate_surf_wave(background: Gen2BattleAnimBackground) -> void:
+	var length: int = Gen2BattleAnimBackground.SURF_WAVE_LENGTH
+	var first: int = background.surf_wave[0]
+	for index: int in length - 1:
+		background.surf_wave[index] = background.surf_wave[index + 1]
+	background.surf_wave[length - 1] = first
+
+	var wave: int = 0
+	for line: int in 0x5F:
+		var value: int = 0
+		if background.ly_override_start < line:
+			value = background.surf_wave[wave]
+		background.ly_overrides_backup[line] = value
+		wave = (wave + 1) & (length - 1)
+
+
+static func _whirlpool(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCY
+			background.ly_override_start = 0x00
+			background.ly_override_end = 0x5E
+			_deform_screen(player, 2, 2)
+		1:
+			_wavy_screen_fx(background)
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+static func _teleport(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+			)
+			_deform_screen(player, 6, 5)
+		1:
+			_wavy_screen_fx(background)
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+static func _night_shade(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCY, false
+			)
+			_deform_screen(player, 2, effect.param)
+		1:
+			_wavy_screen_fx(background)
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_Psychic`, which is hard-coded to the opponent's window and
+## rotates it only every fourth frame.
+static func _psychic(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCX
+			background.ly_override_start = 0x00
+			background.ly_override_end = 0x5F
+			_deform_screen(player, 6, 5)
+			effect.param = 0x0
+		1:
+			var step: int = effect.param
+			effect.param = (effect.param + 1) & 0xFF
+			if (step & 0x3) != 0:
+				return
+			_wavy_screen_fx(background)
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_DoubleTeam`: the window split into alternating lines pulled
+## opposite ways, so one battler is drawn twice.
+static func _double_team(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.battle_turn = 0x0
+		1:
+			if effect.param >= 0x10:
+				_inc(effect)
+				return
+			var spread: int = effect.param
+			effect.param = (effect.param + 1) & 0xFF
+			_double_team_lines(background, spread)
+		2:
+			var step: int = _sine(player, effect.battle_turn, 0x2)
+			_double_team_lines(background, (step + effect.param) & 0xFF)
+			effect.battle_turn = (effect.battle_turn + 0x4) & 0xFF
+		3:
+			if effect.param == 0xFF:
+				_inc(effect)
+				return
+			var spread: int = effect.param
+			effect.param = (effect.param - 1) & 0xFF
+			_double_team_lines(background, spread)
+		4:
+			pass
+		5:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `.UpdateLYOverrides`: every other line pulled one way and the rest the other.
+static func _double_team_lines(background: Gen2BattleAnimBackground, spread: int) -> void:
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	var at: int = background.ly_override_start & 0xFF
+	var span: int = (background.ly_override_end - background.ly_override_start) & 0xFF
+	var pairs: int = span >> 1
+	var odd: bool = (span & 1) != 0
+	var right: int = spread & 0xFF
+	var left: int = (-spread) & 0xFF
+	for _step: int in (pairs if pairs != 0 else page):
+		background.ly_overrides_backup[at] = right
+		at = (at + 1) & (page - 1)
+		background.ly_overrides_backup[at] = left
+		at = (at + 1) & (page - 1)
+	if odd:
+		background.ly_overrides_backup[at] = right
+
+
+## `BattleBGEffect_AcidArmor`: the window's lines pushed down one a frame, with
+## the two at the far end held clear so the picture melts rather than smears.
+static func _acid_armor(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCY, false
+			)
+			_deform_screen(player, 2, effect.param)
+			background.ly_overrides_backup[background.ly_override_end & 0xFF] = 0x0
+			background.ly_overrides_backup[
+				(background.ly_override_end - 1) & (page - 1)
+			] = 0x0
+		1:
+			var at: int = background.ly_override_end & 0xFF
+			while true:
+				background.ly_overrides_backup[at] = \
+					background.ly_overrides_backup[(at - 1) & (page - 1)]
+				at = (at - 1) & (page - 1)
+				if background.ly_override_start == at:
+					break
+			background.ly_overrides_backup[at] = 0x90
+
+			var last: int = background.ly_override_end & 0xFF
+			var value: int = background.ly_overrides_backup[last]
+			if value >= 0x1 and value != 0x90:
+				background.ly_overrides_backup[last] = 0x0
+			last = (last - 1) & (page - 1)
+			value = background.ly_overrides_backup[last]
+			if value < 0x2 or value == 0x90:
+				return
+			background.ly_overrides_backup[last] = 0x0
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_Withdraw`: the window's top pushed off the screen a little
+## further each frame, at a speed the parameter's top two bits set.
+static func _withdraw(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCY, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.battle_turn = 0x1
+		1:
+			if effect.battle_turn >= (effect.param & 0x3F):
+				return
+			background.displace_ly_backup(effect.battle_turn)
+			effect.battle_turn = (
+				effect.battle_turn + ((effect.param >> 6) & 0x3)
+			) & 0xFF
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_Dig`: the same push, but it steps back a state every eighth
+## line so the battler sinks and rises rather than only sinking.
+static func _dig(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCY, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.battle_turn = 0x2
+			effect.param = 0x0
+		1:
+			if effect.param != 0:
+				effect.param = (effect.param - 1) & 0xFF
+				return
+			effect.param = 0x10
+			_inc(effect)
+			_dig_step(background, effect)
+		2:
+			_dig_step(background, effect)
+		3:
+			_reset_lcd_stat_custom(background, effect)
+
+
+static func _dig_step(
+	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var span: int = (
+		background.ly_override_end - background.ly_override_start - 1
+	) & 0xFF
+	if span < effect.battle_turn:
+		return
+	if (effect.battle_turn & 0x7) == 0:
+		effect.jumptable_index = (effect.jumptable_index - 1) & 0xFF
+	background.displace_ly_backup(effect.battle_turn)
+	effect.battle_turn = (effect.battle_turn + 2) & 0xFF
+
+
+## `BattleBGEffect_Tackle` and `..._BodySlam`, which differ only in which
+## `SetLCDStatCustoms` they open the window with. pokegold has no BODY SLAM
+## effect at all, so `anim_bgeffect $25` there is `wobble_mon`.
+static func _tackle(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect, body_slam: bool
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, body_slam
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.param = 0
+			# `BGEffect_CheckBattleTurn` moves the pointer onto the turn byte, so
+			# the speed lands there and not on the parameter the `ld [hl], 0`
+			# above it just cleared.
+			effect.battle_turn = 0xFE if _player_side(player, effect) else 0x02
+		1:
+			_tackle_move_forward(player, effect)
+		2:
+			_tackle_return_move(player, effect)
+		3:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `Tackle_MoveForward`: eight pixels towards the other side, then the state
+## that brings the battler back.
+static func _tackle_move_forward(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var moved: int = effect.param
+	if moved == 0xF8 or moved == 0x08:
+		_inc(effect)
+	_rollout_fill_ly_backup(player, moved)
+	effect.param = (effect.battle_turn + effect.param) & 0xFF
+
+
+## `Tackle_ReturnMove`: the same distance negated, which is why the speed byte
+## is not written back.
+static func _tackle_return_move(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var moved: int = effect.param
+	if moved == 0:
+		_inc(effect)
+	_rollout_fill_ly_backup(player, moved)
+	effect.param = (((-effect.battle_turn) & 0xFF) + effect.param) & 0xFF
+
+
+## `Rollout_FillLYOverridesBackup`: the ordinary fill, unless the animation
+## running is ROLLOUT, whose own screen shake has already moved `hSCY` and whose
+## window therefore has to be measured from where the screen now is.
+static func _rollout_fill_ly_backup(player: Gen2BattleAnimPlayer, value: int) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	if player.anim_index() != Gen2BattleAnimPlayer.ROLLOUT:
+		background.fill_ly_backup(value)
+		return
+
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	var span: int = (background.ly_override_end - background.ly_override_start) & 0xFF
+	if background.scy == 0:
+		if background.ly_override_start != 0:
+			background.ly_overrides_backup[
+				(background.ly_override_start - 1) & (page - 1)
+			] = 0x0
+	else:
+		background.ly_overrides_backup[
+			(background.ly_override_end - 1) & (page - 1)
+		] = 0x0
+
+	var at: int = background.ly_override_start - background.scy
+	if at < 0:
+		at = 0
+		span = (span - 1) & 0xFF
+	for _step: int in (span if span != 0 else page):
+		background.ly_overrides_backup[at & (page - 1)] = value & 0xFF
+		at = (at + 1) & (page - 1)
+
+
+## `VitalThrow_MoveBackwards`: Tackle's opening with the sign the other way
+## round, so the battler is knocked back rather than lunging.
+static func _vital_throw_move_backwards(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	_inc(effect)
+	background.set_ly_overrides(0)
+	_set_lcd_stat_customs(player, effect, Gen2BattleAnimBackground.LCDC_SCX, false)
+	background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+	effect.param = 0x0
+	effect.battle_turn = 0x02 if _player_side(player, effect) else 0xFE
+
+
+static func _vital_throw(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	match effect.jumptable_index:
+		0:
+			_vital_throw_move_backwards(player, effect)
+		1:
+			_tackle_move_forward(player, effect)
+		2:
+			pass
+		3:
+			_tackle_return_move(player, effect)
+		4:
+			player.background().reset_lcd_stat_custom()
+			effect.end()
+
+
+static func _beta_pursuit(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	match effect.jumptable_index:
+		0:
+			_vital_throw_move_backwards(player, effect)
+		1:
+			_tackle_move_forward(player, effect)
+		2:
+			_tackle_return_move(player, effect)
+		3:
+			_reset_lcd_stat_custom(player.background(), effect)
+
+
+static func _wobble_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.param = 0x0
+		1:
+			background.fill_ly_backup(_sine(player, effect.param, 0x8))
+			effect.param = (effect.param + 0x4) & 0xFF
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_Flail`: two sines at once, a wide slow one and a narrow fast
+## one, so the battler wobbles rather than swinging.
+static func _flail(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.battle_turn = 0
+			effect.param = 0
+		1:
+			var wide: int = _sine(player, effect.param, 0x6)
+			var narrow: int = _sine(player, effect.battle_turn, 0x2)
+			background.fill_ly_backup((wide + narrow) & 0xFF)
+			effect.battle_turn = (effect.battle_turn + 0x8) & 0xFF
+			effect.param = (effect.param + 0x2) & 0xFF
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_WaveDeformMon`: the deformation wound up to $20 and then back
+## down again, with `anim_incbgeffect` between the two halves.
+static func _wave_deform_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+			)
+		1:
+			if effect.param >= 0x20:
+				return
+			var amplitude: int = effect.param
+			effect.param = (effect.param + 1) & 0xFF
+			_deform_screen(player, amplitude, 4)
+		2:
+			if effect.param == 0:
+				_reset_lcd_stat_custom(background, effect)
+				return
+			var amplitude: int = effect.param
+			effect.param = (effect.param - 1) & 0xFF
+			_deform_screen(player, amplitude, 4)
+
+
+## `BattleBGEffect_BounceDown`, the other effect Crystal alone opens with
+## `SetLCDStatCustoms2`.
+static func _bounce_down(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCY,
+				player.profile() == &"crystal"
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.battle_turn = 0x1
+			effect.param = 0x20
+		1:
+			if effect.battle_turn >= 0x38:
+				return
+			var height: int = (_cosine(player, effect.param, 0x10) + 0x10) & 0xFF
+			background.displace_ly_backup((effect.battle_turn + height) & 0xFF)
+			effect.param = (effect.param + 2) & 0xFF
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+static func _vibrate_mon(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			effect.battle_turn = 0x1
+			effect.param = 0x20
+		1:
+			if effect.param == 0:
+				_reset_lcd_stat_custom(background, effect)
+				return
+			var left: int = effect.param
+			effect.param = (effect.param - 1) & 0xFF
+			if (left & 0x1) != 0:
+				return
+			effect.battle_turn = (-effect.battle_turn) & 0xFF
+			background.fill_ly_backup(effect.battle_turn)
+
+
+## `BattleBGEffect_WobblePlayer`, whose window is the player's whatever the turn
+## is, and which stops on its own rather than on `anim_incbgeffect`.
+static func _wobble_player(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(0)
+			background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCX
+			background.ly_override_start = 0x00
+			background.ly_override_end = 0x37
+			effect.param = 0x0
+		1:
+			if effect.param >= 0x40:
+				_reset_lcd_stat_custom(background, effect)
+				return
+			background.fill_ly_backup(_sine(player, effect.param, 0x6))
+			effect.param = (effect.param + 0x2) & 0xFF
+		2:
+			_reset_lcd_stat_custom(background, effect)
+
+
+## `BattleBGEffect_WobbleScreen`, which scrolls the whole screen rather than a
+## window and never ends: it settles at zero and stays in its slot until the
+## next animation clears it.
+static func _wobble_screen(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	if effect.param >= 0x40:
+		background.scx = 0
+		return
+	background.scx = _sine(player, effect.param, 0x6)
+	effect.param = (effect.param + 0x2) & 0xFF
+
+
+## `BattleBGEffects_GetShakeAmount`: how far the screen is thrown this frame.
+## The jumptable index counts the frames left and the parameter's low nybble the
+## frames between reversals, reloaded from its own high nybble.
+static func _shake_amount(
+	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect
+) -> int:
+	if effect.jumptable_index == 0:
+		effect.end()
+		return 0
+	effect.jumptable_index = (effect.jumptable_index - 1) & 0xFF
+	if (effect.param & 0xF) != 0:
+		effect.param = (effect.param - 1) & 0xFF
+		return effect.battle_turn
+	effect.param = ((effect.param >> 4) | effect.param) & 0xFF
+	effect.battle_turn = (-effect.battle_turn) & 0xFF
+	return effect.battle_turn
+
+
+## `BattleBGEffect_Rollout`: the screen shaken vertically, with the first
+## animation object moved the opposite way so the ball it draws stays put.
+##
+## The source waits a frame here rather than at the bottom of `.playframe`;
+## in a player stepped once per frame that is the same one frame either way.
+static func _rollout(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var ended: bool = effect.jumptable_index == 0
+	var amount: int = _shake_amount(background, effect)
+	if ended or (amount & 0x80) != 0:
+		amount = 0
+	background.scy = amount
+	player.set_first_object_y_offset((-amount) & 0xFF)
+
+
+static func _water(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var offset: int = effect.param
+	effect.param = (effect.param + 0x4) & 0xFF
+	var amplitude: int = ((~((effect.battle_turn & 0xF0) >> 4)) + 4) & 0xFF
+	var progress: int = effect.jumptable_index
+	var timer: int = effect.battle_turn
+	if timer >= 0x20:
+		background.set_ly_overrides(0)
+		effect.end()
+		return
+	effect.battle_turn = (effect.battle_turn + 2) & 0xFF
+	_deform_water(player, timer, amplitude, offset, progress)
+
+
+## `BattleBGEffect_BetaSendOutMon1`, unused: a four-step palette walk laid over
+## alternating scanlines through `rBGP`.
+static func _beta_send_out_mon1(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	match effect.jumptable_index:
+		0:
+			_inc(effect)
+			background.set_ly_overrides(Gen2BattleAnimBackground.PALETTE_IDENTITY)
+			_set_lcd_stat_customs(
+				player, effect, Gen2BattleAnimBackground.LCDC_BGP, false
+			)
+			background.ly_override_end = (background.ly_override_end + 1) & 0xFF
+			var at: int = background.ly_override_start & 0xFF
+			while background.ly_override_end != at:
+				background.ly_overrides_backup[at] = 0
+				at = (at + 1) & (page - 1)
+			effect.param = 0x0
+		1, 4:
+			pass
+		2:
+			var step: int = _beta_send_out_step(effect)
+			if step < 0:
+				effect.param = 0x0
+				background.ly_override_start = \
+					(background.ly_override_start + 1) & 0xFF
+				_inc(effect)
+				return
+			_beta_send_out_lines(background, step)
+		3:
+			var step: int = _beta_send_out_step(effect)
+			if step < 0:
+				_inc(effect)
+				return
+			_beta_send_out_lines(background, step)
+			background.ly_overrides_backup[
+				(background.ly_override_end - 1) & (page - 1)
+			] = step
+		5:
+			background.reset_video_hram()
+
+
+## `.GetLYOverride`: one entry of the walk every eight frames, -1 past its end.
+static func _beta_send_out_step(effect: Gen2BattleAnimBgEffect) -> int:
+	var index: int = effect.param >> 3
+	effect.param = (effect.param + 1) & 0xFF
+	var value: int = BETA_SEND_OUT_STEPS[index] \
+		if index < BETA_SEND_OUT_STEPS.size() else 0xFF
+	return -1 if value == 0xFF else value
+
+
+## `.SetLYOverridesBackup`: every other line of the window.
+static func _beta_send_out_lines(
+	background: Gen2BattleAnimBackground, value: int
+) -> void:
+	var page: int = Gen2BattleAnimBackground.LY_PAGE
+	var at: int = background.ly_override_start & 0xFF
+	var pairs: int = (
+		(background.ly_override_end - background.ly_override_start) & 0xFF
+	) >> 1
+	for _step: int in (pairs if pairs != 0 else page):
+		background.ly_overrides_backup[at] = value & 0xFF
+		at = (at + 2) & (page - 1)
+
+
+## `BattleBGEffect_BetaSendOutMon2`, unused: a deformation that shrinks to
+## nothing over $40 frames.
+static func _beta_send_out_mon2(
+	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
+) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
+	if effect.jumptable_index == 0:
+		_inc(effect)
+		background.set_ly_overrides(0)
+		_set_lcd_stat_customs(
+			player, effect, Gen2BattleAnimBackground.LCDC_SCX, false
+		)
+		effect.battle_turn = 0x40
+		return
+	if effect.battle_turn == 0:
+		_reset_lcd_stat_custom(background, effect)
+		return
+	var size: int = effect.battle_turn
+	effect.battle_turn = (effect.battle_turn - 1) & 0xFF
+	var deform: int = (size >> 3) & 0xF
+	_deform_screen(player, deform, deform)

--- a/game/battle/battle_anim_bg_effects.gd.uid
+++ b/game/battle/battle_anim_bg_effects.gd.uid
@@ -1,0 +1,1 @@
+uid://cweiifhxd2h2o

--- a/game/battle/battle_anim_data.gd
+++ b/game/battle/battle_anim_data.gd
@@ -20,6 +20,7 @@ const OBJECT_FIELDS: Array[StringName] = [
 var _regions: Dictionary = {}
 var _gfx: Array = []
 var _sine: PackedByteArray = PackedByteArray()
+var _profile: StringName = &"crystal"
 
 
 ## Built from a cache. Returns null when the cache carries no animation layer,
@@ -36,17 +37,26 @@ static func from_game_data(data: GameData) -> Gen2BattleAnimData:
 	var gfx: Array = []
 	for index: int in data.battle_anim_gfx_count():
 		gfx.append(data.battle_anim_gfx(index))
-	return create(regions, gfx, data.battle_anim_sine())
+	return create(regions, gfx, data.battle_anim_sine(), data.id)
 
 
 static func create(
-	regions: Dictionary, gfx: Array, sine: PackedByteArray = PackedByteArray()
+	regions: Dictionary, gfx: Array, sine: PackedByteArray = PackedByteArray(),
+	profile: StringName = &"crystal"
 ) -> Gen2BattleAnimData:
 	var out := Gen2BattleAnimData.new()
 	out._regions = regions
 	out._gfx = gfx
 	out._sine = sine
+	out._profile = profile
 	return out
+
+
+## Which cartridge this came from. Only the bg effect table reads it, and only
+## because pokegold's is one entry shorter than Crystal's; nothing else in the
+## layer is profile split.
+func profile() -> StringName:
+	return _profile
 
 
 ## One `BattleAnimSineWave` word, which is the amplitude `BattleAnim_Sine`

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -76,9 +76,8 @@ const FRAMESET_PARALYZED_FLIPPED: int = 0x6E
 const FRAMESET_SPEED_LINE_1: int = 0x81
 const FRAMESET_THUNDER_WAVE_EXTRA: int = 0x35
 
-## `LOW(rSCY)`, which is what Surf puts in `hLCDCPointer` so its scanline window
-## scrolls the background vertically.
-const LCDC_POINTER_SCY: int = 0x42
+## `LOW(rSCY)`: Surf's scanline window scrolls the background vertically.
+const LCDC_POINTER_SCY: int = Gen2BattleAnimBackground.LCDC_SCY
 
 
 ## `DoBattleAnimFrame`. Answers false when [param object]'s callback is outside
@@ -191,6 +190,16 @@ static func _reinit(object: Gen2BattleAnimObject, frameset: int) -> void:
 ## `sra`, which keeps the sign bit rather than shifting a zero in.
 static func _sra(value: int) -> int:
 	return ((value >> 1) | (value & 0x80)) & 0xFF
+
+
+## `BattleAnim_Sine_e` and `..._Cosine_e`, the far-callable pair
+## `BattleBGEffects_Sine` reaches, so a bg effect scales with the same table.
+static func sine_of(data: Gen2BattleAnimData, a: int, d: int) -> int:
+	return _sine(data, a, d)
+
+
+static func cosine_of(data: Gen2BattleAnimData, a: int, d: int) -> int:
+	return _cosine(data, a, d)
 
 
 ## `BattleAnim_Sine`: [code]a = d * sin(a * pi/32)[/code], as the high byte of
@@ -561,16 +570,17 @@ static func _bubble_rise(object: Gen2BattleAnimObject) -> void:
 static func _surf(
 	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
+	var background: Gen2BattleAnimBackground = player.background()
 	match object.jumptable_index:
 		0:
 			_inc(object)
-			player.lcdc_pointer = LCDC_POINTER_SCY
-			player.ly_override_start = 0x58
-			player.ly_override_end = 0x5E
+			background.lcdc_pointer = LCDC_POINTER_SCY
+			background.ly_override_start = 0x58
+			background.ly_override_end = 0x5E
 		1:
 			if object.y < object.param:
 				_inc(object)
-				player.ly_override_start = 0
+				background.ly_override_start = 0
 				return
 			object.y = (object.y - 1) & 0xFF
 			var wave: int = _sine(data, object.var1, 0x10)
@@ -578,7 +588,7 @@ static func _surf(
 			var line: int = ((wave + object.y) & 0xFF) - 0x10
 			if line < 0:
 				return
-			player.ly_override_start = line
+			background.ly_override_start = line
 			object.x_offset = (object.x_offset + 1) & 0x7
 			object.var1 = (object.var1 + 2) & 0xFF
 		2:
@@ -589,11 +599,11 @@ static func _surf(
 				var below: int = object.y - 0x10
 				if below < 0:
 					return
-				player.ly_override_start = below
+				background.ly_override_start = below
 				return
-			player.lcdc_pointer = 0
-			player.ly_override_start = 0
-			player.ly_override_end = 0
+			background.lcdc_pointer = 0
+			background.ly_override_start = 0
+			background.ly_override_end = 0
 			object.deinit()
 		4:
 			object.deinit()
@@ -1360,15 +1370,15 @@ static func _sky_attack(player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObje
 			_step_to_target(object, 0x4)
 
 
-## `.SkyAttack_CyclePalette`, which flashes `wOBP0`. That register is a DMG
-## object palette, so on the Color hardware the write lands and shows nothing;
-## it is kept because dropping it would lose the one thing this state does.
+## `.SkyAttack_CyclePalette`, which flashes `wOBP0`. `BattleAnimRequestPals`
+## watches that byte, so on the Color hardware the write becomes a remap of the
+## two object palettes from `PAL_BATTLE_OB_GRAY` on.
 static func _sky_attack_palette(
 	player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject
 ) -> void:
 	var phase: int = object.var2 & 0x7
 	object.var2 = (object.var2 + 1) & 0xFF
-	player.obp0 = SKY_ATTACK_PALS[phase >> 1] & object.var1
+	player.background().obp0 = SKY_ATTACK_PALS[phase >> 1] & object.var1
 
 
 static func _growth_swords_dance(

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -13,10 +13,9 @@ extends RefCounted
 ## answers with sprites, a tile window and the palette each sprite wants, and
 ## whoever is drawing decides what that looks like.
 ##
-## One of `.playframe`'s five steps is not here yet and is named rather than
-## quietly skipped: `_ExecuteBGEffects`. [method unimplemented] reports what an
-## animation asked for and did not get, so a caller can tell one that ran whole
-## from one that ran without its background.
+## All five of `.playframe`'s steps are here. [method unimplemented] reports what
+## an animation asked for and did not get, which cartridge data no longer
+## produces and a hand-built region still can.
 
 ## `NUM_BATTLE_ANIM_STRUCTS`: ten slots, and an eleventh object is simply not
 ## spawned.
@@ -51,8 +50,12 @@ const MAX_TILES: int = 128 - Gen2BattleAnimObject.BASE_TILE
 ## `wBattleAnimFlags` bits (constants/ram_constants.asm).
 const FLAG_KEEP_SPRITES: int = 1 << 3
 
-## `ROLLOUT`, whose animation runs without waiting a frame while its own bg
-## effect is active.
+## `NUM_BG_EFFECTS`: five background effects run at once, and a sixth is simply
+## not queued, the way an eleventh object is not spawned.
+const MAX_BG_EFFECTS: int = Gen2BattleAnimBgEffects.MAX_EFFECTS
+
+## `ROLLOUT`, the move `Rollout_FillLYOverridesBackup` and `.playframe`'s own
+## frame-delay branch both check `wFXAnimID` against.
 const ROLLOUT: int = 0xCD
 
 var _data: Gen2BattleAnimData = null
@@ -71,23 +74,20 @@ var _tiles: Array = []
 var _keep_sprites: bool = false
 var _sprites: Array = []
 var _unimplemented: Dictionary = {}
+## `wActiveBGEffects`: five `battle_bg_effect` slots.
+var _bg_effects: Array[Gen2BattleAnimBgEffect] = []
+## The video state the bg effects and `BattleAnimFunc_Surf` share.
+var _background: Gen2BattleAnimBackground = null
 
 ## `wCurItem`, which `GetBallAnimPal` reads to colour a thrown ball. Nothing but
 ## a ball animation asks, and an item that is not a ball falls out of
 ## `BallColors` on its own terminator.
 var cur_item: int = 0
 
-## `wOBP0`, the DMG object palette `BattleAnimFunc_SkyAttack` flashes. Kept
-## because the write is the whole of that state; the Color hardware draws
-## objects from `wOBPals1` instead, so nothing shows.
-var obp0: int = 0
-
-## `hLCDCPointer`, `hLYOverrideStart` and `hLYOverrideEnd`: the scanline window
-## `BattleAnimFunc_Surf` opens over `rSCY` and hands back when the wave has
-## crossed the screen. It is the only callback that reaches the raster.
-var lcdc_pointer: int = 0
-var ly_override_start: int = 0
-var ly_override_end: int = 0
+## `wPlayerSubStatus3` and `wEnemySubStatus3`'s Fly and Dig bits, which three bg
+## effects check before they touch a battler that is not on the field.
+var player_off_field: bool = false
+var enemy_off_field: bool = false
 
 
 ## Starts [param index] of `BattleAnimations`. Answers null when the cache has no
@@ -114,6 +114,10 @@ static func create(
 	# empty on each animation rather than carrying over from the last one.
 	player._objects.resize(MAX_OBJECTS)
 	player._tile_dict.resize(TILE_DICT_ENTRIES)
+	player._bg_effects.resize(MAX_BG_EFFECTS)
+	for slot: int in MAX_BG_EFFECTS:
+		player._bg_effects[slot] = Gen2BattleAnimBgEffect.new()
+	player._background = Gen2BattleAnimBackground.new()
 	player._script = Gen2BattleAnimScript.create(
 		region["data"], int(region["address"]), address, param
 	)
@@ -128,6 +132,59 @@ func enemy_turn() -> bool:
 ## The imported tables the callbacks resolve their sine and framesets through.
 func data() -> Gen2BattleAnimData:
 	return _data
+
+
+## Which cartridge this animation came from, which only the bg effect table asks.
+func profile() -> StringName:
+	return _data.profile()
+
+
+## `wFXAnimID`, which two routines compare against `ROLLOUT`.
+func anim_index() -> int:
+	return _anim_index
+
+
+## The video state the background effects write: scanline tables, screen scroll,
+## palette remaps and the tilemap.
+func background() -> Gen2BattleAnimBackground:
+	return _background
+
+
+## The live `wActiveBGEffects` slots, for a caller that wants more than the
+## screen they produced.
+func bg_effects() -> Array:
+	var out: Array = []
+	for effect: Gen2BattleAnimBgEffect in _bg_effects:
+		if effect.active():
+			out.append(effect)
+	return out
+
+
+## `BGEffect_CheckFlyDigStatus`: whether the battler on [param player_side] is
+## off the field mid-Fly or mid-Dig, which is what stops three effects touching
+## a picture that is not there.
+func fly_dig_status(player_side: bool) -> bool:
+	return player_off_field if player_side else enemy_off_field
+
+
+## `wLastAnimObjectIndex` stepped on without an object being built, which is what
+## a battler-object effect does when the battler is off the field.
+func bump_object_index() -> void:
+	_last_object_index = (_last_object_index + 1) & 0xFF
+
+
+## `_QueueBattleAnimation`, which a battler-object effect calls with the same
+## four values `anim_obj` supplies.
+func queue_object(row: int, x: int, y: int, param: int) -> void:
+	_queue_object([row, x, y, param])
+
+
+## `wAnimObject1YOffset`, which `BattleBGEffect_Rollout` writes straight into the
+## first struct whether or not a live object is standing in it.
+func set_first_object_y_offset(value: int) -> void:
+	if _objects[0] == null:
+		_objects[0] = Gen2BattleAnimObject.new()
+	_objects[0].y_offset = value & 0xFF
 
 
 func finished() -> bool:
@@ -176,21 +233,24 @@ func unimplemented() -> Dictionary:
 	return out
 
 
-## One hardware frame of `.playframe`: the script, then the bg effects, then
-## every object. Answers whether the animation is still running.
+## One hardware frame of `.playframe`, in its own order: the script, the bg
+## effects, every object, the scanline table and the palettes. Answers whether
+## the animation is still running.
+##
+## `.playframe` skips its own `BattleAnimDelayFrame` while Rollout's bg effect is
+## live, because that effect waits a frame itself. Both paths spend exactly one
+## frame, so a player stepped once per frame runs its body once either way and
+## there is nothing here for the check to decide.
 func advance_frame() -> bool:
 	if finished():
 		_finish()
 		return false
 
-	# `.playframe` runs its body again without waiting a frame while Rollout's
-	# own bg effect is up, which is what makes that animation twice as quick.
-	for _repeat: int in 2:
-		_run_commands()
-		_execute_bg_effects()
-		_update_oam()
-		if not _rollout_running():
-			break
+	_run_commands()
+	_execute_bg_effects()
+	_update_oam()
+	_background.push_ly_overrides()
+	_background.request_pals()
 	if finished():
 		_finish()
 	return true
@@ -221,9 +281,22 @@ func _run_commands() -> void:
 			&"keep_sprites":
 				_keep_sprites = true
 			&"bg_effect":
-				_note(&"bg_effects", int((command["operands"] as Array)[0]))
+				_queue_bg_effect(command["operands"])
 			&"inc_bg_effect":
-				_note(&"bg_effects", int((command["operands"] as Array)[0]))
+				var live: Gen2BattleAnimBgEffect = _bg_effect_with_id(
+					int((command["operands"] as Array)[0])
+				)
+				if live != null:
+					live.jumptable_index = (live.jumptable_index + 1) & 0xFF
+			&"bgp":
+				_background.bgp = int((command["operands"] as Array)[0])
+			&"obp0":
+				_background.obp0 = int((command["operands"] as Array)[0])
+			&"obp1":
+				_background.obp1 = int((command["operands"] as Array)[0])
+			&"reset_obp0":
+				# `hSGB`'s $f0 is the branch the Color hardware does not take.
+				_background.obp0 = 0xE0
 
 
 ## `QueueBattleAnimation`: the first free slot, or nothing at all. The index
@@ -294,18 +367,33 @@ func _clear_objects() -> void:
 			_objects[slot].deinit()
 
 
-## `_ExecuteBGEffects`. The effects themselves are not built; the ids the script
-## asked for are recorded by [method _run_commands] as it reads them.
+## `QueueBGEffect`: the first free slot, or nothing at all. Unlike an object, a
+## refused effect leaves no trace: there is no index counter to step on.
+func _queue_bg_effect(operands: Array) -> void:
+	for slot: int in MAX_BG_EFFECTS:
+		if _bg_effects[slot].active():
+			continue
+		_bg_effects[slot] = Gen2BattleAnimBgEffect.create(
+			int(operands[0]), int(operands[1]), int(operands[2]), int(operands[3])
+		)
+		return
+
+
+func _bg_effect_with_id(id: int) -> Gen2BattleAnimBgEffect:
+	for effect: Gen2BattleAnimBgEffect in _bg_effects:
+		if effect.id == id:
+			return effect
+	return null
+
+
+## `_ExecuteBGEffects`: every live slot in order. An id past this profile's own
+## table is reported rather than run, which cartridge data never produces.
 func _execute_bg_effects() -> void:
-	pass
-
-
-## `.playframe`'s Rollout check: the frame delay is skipped while
-## `BATTLE_BG_EFFECT_ROLLOUT` is one of the five live effects. No effect is live
-## until they are built, so this answers false the way it does for every other
-## animation.
-func _rollout_running() -> bool:
-	return false
+	for effect: Gen2BattleAnimBgEffect in _bg_effects:
+		if not effect.active():
+			continue
+		if not Gen2BattleAnimBgEffects.run(self, effect):
+			_note(&"bg_effects", effect.id)
 
 
 ## `BattleAnim_UpdateOAM_All`: every live object stepped and drawn, in slot

--- a/tests/unit/test_battle_anim_bg_effects.gd
+++ b/tests/unit/test_battle_anim_bg_effects.gd
@@ -1,0 +1,392 @@
+extends GutTest
+
+## The `BATTLE_BG_EFFECT_*` jumptable and the video state it writes
+## (engine/battle_anims/bg_effects.asm).
+##
+## Effects are built and stepped by hand, the way the motion callbacks are: what
+## is worth checking here is which byte of the scanline table, the tilemap or the
+## palette map a state writes, and where the two profiles' own tables part
+## company. `tools/validate_battle_anims.gd` is the counterpart that runs every
+## effect a real animation reaches, on all three cartridges.
+
+const BASE: int = 0x4000
+const RET: int = 0xFF
+
+## Effect ids, Crystal's own numbering.
+const HIDE_MON: int = 0x09
+const SHAKE_SCREEN_X: int = 0x1F
+const WITHDRAW: int = 0x21
+const TACKLE: int = 0x24
+const BODY_SLAM: int = 0x25
+const REMOVE_MON: int = 0x27
+const ROLLOUT: int = 0x2E
+const WHITE_HUES: int = 0x03
+const ALTERNATE_HUES: int = 0x05
+
+var _player: Gen2BattleAnimPlayer = null
+
+
+func before_each() -> void:
+	_player = _make_player()
+
+
+func _make_player(
+	profile: StringName = &"crystal", enemy_turn: bool = false
+) -> Gen2BattleAnimPlayer:
+	var sine := PackedByteArray()
+	for value: int in RomLayout.BATTLE_ANIM_SINE_WAVE:
+		sine.append(value)
+	var data: Gen2BattleAnimData = Gen2BattleAnimData.create({
+		&"scripts": {
+			"bank": 0x32, "address": BASE, "count": 1,
+			"data": PackedByteArray([(BASE + 2) & 0xFF, (BASE + 2) >> 8, RET]),
+		},
+		&"objects": {
+			"bank": 0x33, "address": BASE, "count": 1,
+			"data": PackedByteArray([0x00, 0x90, 0x00, 0x00, 0x02, 0x01]),
+		},
+		&"framesets": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+		&"oam_sets": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+	}, [], sine, profile)
+	return Gen2BattleAnimPlayer.create(data, 0, enemy_turn)
+
+
+func _effect(
+	id: int, jumptable_index: int = 0, battle_turn: int = 0, param: int = 0
+) -> Gen2BattleAnimBgEffect:
+	return Gen2BattleAnimBgEffect.create(id, jumptable_index, battle_turn, param)
+
+
+func _run(effect: Gen2BattleAnimBgEffect) -> void:
+	assert_true(Gen2BattleAnimBgEffects.run(_player, effect))
+
+
+func _background() -> Gen2BattleAnimBackground:
+	return _player.background()
+
+
+# --------------------------------------------------------- the profile split ----
+
+## pokegold ships no `BATTLE_BG_EFFECT_BODY_SLAM`, so its list is one shorter and
+## every id from $25 on names a different effect. Nothing normalises between the
+## two, which is why both tables are held whole.
+func test_the_two_profiles_keep_their_own_effect_tables() -> void:
+	var crystal: Array[StringName] = Gen2BattleAnimBgEffects.names_for(&"crystal")
+	var gold: Array[StringName] = Gen2BattleAnimBgEffects.names_for(&"gold")
+	assert_eq(crystal.size(), 54)
+	assert_eq(gold.size(), 53)
+	assert_eq(crystal[BODY_SLAM], &"body_slam")
+	assert_eq(gold[BODY_SLAM], &"wobble_mon")
+	assert_eq(crystal[ROLLOUT], &"rollout")
+	assert_eq(gold[0x2D], &"rollout", "one lower on Gold and Silver")
+	for id: int in BODY_SLAM:
+		assert_eq(crystal[id], gold[id], "the two lists agree below $25")
+
+
+## The same byte therefore runs a different routine in the two games: on Crystal
+## $25 opens a scanline window, on Gold and Silver it starts a wobble.
+func test_the_same_id_runs_a_different_effect_in_each_game() -> void:
+	var crystal: Gen2BattleAnimBgEffect = _effect(BODY_SLAM)
+	_run(crystal)
+	assert_eq(
+		_background().ly_override_start, 0x00,
+		"body_slam opens the enemy window over rSCX"
+	)
+	assert_eq(_background().lcdc_pointer, Gen2BattleAnimBackground.LCDC_SCX)
+
+	_player = _make_player(&"gold")
+	var gold: Gen2BattleAnimBgEffect = _effect(BODY_SLAM)
+	_run(gold)
+	assert_eq(_background().lcdc_pointer, Gen2BattleAnimBackground.LCDC_SCX)
+	assert_eq(gold.param, 0x0, "wobble_mon clears its own parameter instead")
+
+
+## Crystal alone ships `BattleBGEffect_SetLCDStatCustoms2`, and `bounce_down` is
+## one of the two effects that ask for it. Its window starts two lines higher.
+func test_only_crystal_has_the_second_lcd_stat_window() -> void:
+	var crystal: Gen2BattleAnimBgEffect = _effect(0x22, 0, 1)
+	_run(crystal)
+	assert_eq(_background().ly_override_start, 0x2D)
+
+	_player = _make_player(&"gold")
+	var gold: Gen2BattleAnimBgEffect = _effect(0x22, 0, 1)
+	_run(gold)
+	assert_eq(_background().ly_override_start, 0x2F)
+
+
+## The other code-level split: Crystal rewinds the tilemap push and pokegold
+## leaves whichever third was in flight.
+func test_only_crystal_rewinds_the_tilemap_push() -> void:
+	_background().bg_map_third = 2
+	_run(_effect(HIDE_MON))
+	assert_eq(_background().bg_map_third, 0)
+
+	_player = _make_player(&"gold")
+	_background().bg_map_third = 2
+	_run(_effect(HIDE_MON))
+	assert_eq(_background().bg_map_third, 2)
+
+
+# ------------------------------------------------------------------ the pool ----
+
+## `QueueBGEffect` takes the first free slot and a sixth effect simply is not
+## queued, the way an eleventh object is not spawned.
+func test_five_effects_run_at_once_and_a_sixth_is_refused() -> void:
+	var body: Array = []
+	for queued: int in 6:
+		body.append_array([0xF0, SHAKE_SCREEN_X, 0x10, 0x01, 0x11])
+	body.append_array([0x01, RET])
+	var player: Gen2BattleAnimPlayer = _script_player(body)
+	player.advance_frame()
+	assert_eq(player.bg_effects().size(), Gen2BattleAnimPlayer.MAX_BG_EFFECTS)
+
+
+## `EndBattleBGEffect` zeroes the id, which is what frees the slot.
+func test_an_ended_effect_frees_its_slot() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(SHAKE_SCREEN_X, 0x0, 0x01, 0x11)
+	assert_true(effect.active())
+	_run(effect)
+	assert_false(effect.active(), "a shake with no frames left ends at once")
+
+
+## `anim_incbgeffect` finds a live effect by its id and steps its state, which is
+## how a fade is told to put the palette back.
+func test_incbgeffect_finds_a_live_effect_by_its_id() -> void:
+	var player: Gen2BattleAnimPlayer = _script_player(
+		[0xF0, WITHDRAW, 0x00, 0x00, 0x08] + [0x01] + [0xD8, WITHDRAW] + [0x01, RET]
+	)
+	player.advance_frame()
+	var effects: Array = player.bg_effects()
+	assert_eq(effects.size(), 1)
+	var effect: Gen2BattleAnimBgEffect = effects[0]
+	var before: int = effect.jumptable_index
+	player.advance_frame()
+	player.advance_frame()
+	assert_eq(effect.jumptable_index, before + 1)
+
+
+# ---------------------------------------------------------------- the screen ----
+
+## `BGEffect_FillLYOverridesBackup` writes one value across the window and
+## nothing outside it.
+func test_a_fill_covers_the_window_and_stops() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	background.ly_override_start = 0x10
+	background.ly_override_end = 0x14
+	background.fill_ly_backup(0x33)
+	assert_eq(background.ly_overrides_backup[0x0F], 0)
+	assert_eq(background.ly_overrides_backup[0x10], 0x33)
+	assert_eq(background.ly_overrides_backup[0x13], 0x33)
+	assert_eq(background.ly_overrides_backup[0x14], 0)
+
+
+## `BGEffect_DisplaceLYOverridesBackup` pushes the first lines off the screen
+## with `$90` and holds the rest at the negated displacement.
+func test_a_displacement_pushes_lines_off_and_holds_the_rest() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	background.ly_override_start = 0x00
+	background.ly_override_end = 0x08
+	background.displace_ly_backup(0x03)
+	assert_eq(background.ly_overrides_backup[0x00], 0x90)
+	assert_eq(background.ly_overrides_backup[0x02], 0x90)
+	assert_eq(background.ly_overrides_backup[0x03], 0xFC, "-3 as a byte")
+	assert_eq(background.ly_overrides_backup[0x07], 0xFC)
+
+
+## `PushLYOverrides` only copies while a register is named, so a table left over
+## from a finished effect does not reach the hardware.
+func test_the_scanline_table_is_only_pushed_while_a_register_is_named() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	background.ly_overrides_backup[0x20] = 0x44
+	background.push_ly_overrides()
+	assert_eq(background.ly_overrides[0x20], 0, "no register named")
+
+	background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCX
+	background.push_ly_overrides()
+	assert_eq(background.ly_overrides[0x20], 0x44)
+
+
+## `BattleAnim_ResetLCDStatCustom` hands the window back and ends the effect in
+## one go, which is what every `.two` state is.
+func test_resetting_the_window_ends_the_effect() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(0x0E, 2)  # whirlpool
+	_run(effect)
+	assert_eq(_background().lcdc_pointer, Gen2BattleAnimBackground.LCDC_OFF)
+	assert_eq(_background().ly_override_end, 0)
+	assert_false(effect.active())
+
+
+## `BattleBGEffects_GetShakeAmount` reloads its frame counter from the
+## parameter's own high nybble, which is what makes a shake reverse on a beat.
+func test_a_shake_reverses_on_its_parameters_own_beat() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(SHAKE_SCREEN_X, 0x10, 0x04, 0x30)
+	_run(effect)
+	assert_eq(_background().scx, 0xFC, "-4, and the low nybble is reloaded to 3")
+	assert_eq(effect.param, 0x33)
+	_run(effect)
+	assert_eq(_background().scx, 0xFC, "held while the counter runs down")
+	assert_eq(effect.param, 0x32)
+
+
+## `BattleBGEffect_Rollout` shakes the screen vertically and moves the first
+## animation object the other way, so what it draws stays where it was.
+func test_rollout_moves_the_first_object_against_the_screen() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(ROLLOUT, 0x10, 0x04, 0x30)
+	_run(effect)
+	assert_eq(_background().scy, 0x00, "a negative shake is dropped")
+	var objects: Array = _player.objects()
+	assert_eq(objects.size(), 0, "the effect writes the struct, it does not spawn")
+
+	var upward: Gen2BattleAnimBgEffect = _effect(ROLLOUT, 0x10, 0xFC, 0x30)
+	_run(upward)
+	assert_eq(_background().scy, 0x04)
+
+
+# --------------------------------------------------------------- the palettes ----
+
+## The hue walks end when their list does, and `alternate_hues` is the one that
+## takes an object palette with it.
+func test_a_hue_walk_ends_on_its_own_list() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(WHITE_HUES, 0, 0, 0)
+	_run(effect)
+	assert_eq(_background().bgp, 0xE4)
+	_run(effect)
+	assert_eq(_background().bgp, 0xE0)
+	_run(effect)
+	assert_eq(_background().bgp, 0xD0)
+	_run(effect)
+	assert_false(effect.active(), "the $ff at the end of the list")
+
+
+func test_alternate_hues_moves_the_object_palette_too() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(ALTERNATE_HUES, 0, 0, 1)
+	_run(effect)
+	assert_eq(_background().bgp, 0xF8)
+	assert_eq(_background().obp1, 0xF8)
+
+
+## A list ending in `$fe` restarts rather than stopping, which is what makes a
+## fade repeat until `anim_incbgeffect` retires it.
+func test_a_looping_list_restarts_rather_than_ending() -> void:
+	var effect: Gen2BattleAnimBgEffect = _effect(0x08, 0, 0, 0)  # cycle_bg_pals_inverted
+	for _step: int in 3:
+		_run(effect)
+	assert_true(effect.active())
+	_run(effect)
+	assert_eq(_background().bgp, 0x1B, "back to the first entry")
+	assert_eq(effect.param, 0, "$fe rewinds the parameter as well")
+
+
+## `BattleAnimRequestPals` is what turns a changed DMG palette byte into a remap
+## of the Color palettes, which is the only reason those effects show at all.
+func test_a_changed_dmg_byte_remaps_the_colour_palettes() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	background.bgp = 0xF8
+	background.request_pals()
+	assert_eq(background.bg_palette_maps[0], 0xF8)
+	assert_eq(background.bg_palette_maps[6], 0xF8)
+	assert_eq(
+		background.bg_palette_maps[7], Gen2BattleAnimBackground.PALETTE_IDENTITY,
+		"seven palettes, not eight"
+	)
+	assert_eq(background.ob_palette_maps[1], 0xF8)
+	assert_true(background.palettes_dirty)
+
+	background.palettes_dirty = false
+	background.request_pals()
+	assert_false(background.palettes_dirty, "an unchanged byte asks for nothing")
+
+
+## `BGEffects_LoadPlayerPals` and `..._LoadEnemyPals` reach one side of the field
+## each, which is how a fade darkens one battler and not the other.
+func test_a_fade_reaches_one_side_of_the_field() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	background.load_player_pals(0x40)
+	assert_eq(background.bg_palette_maps[Gen2BattleAnimBackground.PAL_BG_PLAYER], 0x40)
+	assert_eq(background.ob_palette_maps[Gen2BattleAnimBackground.PAL_OB_PLAYER], 0x40)
+	assert_eq(
+		background.bg_palette_maps[Gen2BattleAnimBackground.PAL_BG_ENEMY],
+		Gen2BattleAnimBackground.PALETTE_IDENTITY
+	)
+
+
+# ---------------------------------------------------------------- the tilemap ----
+
+## `BattleBGEffect_HideMon` blanks the battler's own box and then spends four
+## frames doing nothing while the tilemap reaches VRAM.
+func test_hiding_a_mon_blanks_its_box_and_then_waits() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	for y: int in 7:
+		for x: int in 7:
+			background.set_tile(12 + x, y, 0x20)
+	var effect: Gen2BattleAnimBgEffect = _effect(HIDE_MON)
+	_run(effect)
+	assert_eq(background.tile_at(12, 0), Gen2BattleAnimBackground.BLANK_TILE)
+	assert_eq(background.tile_at(18, 6), Gen2BattleAnimBackground.BLANK_TILE)
+	assert_eq(background.bg_map_mode, 1)
+	for _step: int in 3:
+		_run(effect)
+		assert_true(effect.active())
+	_run(effect)
+	assert_eq(background.bg_map_mode, 0)
+	assert_false(effect.active())
+
+
+## `BattleBGEffect_RemoveMon` slides the picture off its own side of the screen a
+## column at a time, and the parameter is how many columns are left.
+func test_removing_a_mon_slides_its_columns_off_the_screen() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	background.set_tile(18, 0, 0x55)
+	var effect: Gen2BattleAnimBgEffect = _effect(REMOVE_MON)
+	_run(effect)
+	assert_eq(effect.param, 0x8, "the enemy's own eight columns")
+	_run(effect)
+	assert_eq(background.tile_at(19, 0), 0x55, "shifted one column right")
+	assert_eq(effect.param, 0x7)
+
+
+## `BattleBGEffect_EnterMon` stamps the picture at three growing sizes, one row
+## of its script a frame with two idle frames between.
+func test_a_mon_entering_is_stamped_at_three_sizes() -> void:
+	var background: Gen2BattleAnimBackground = _background()
+	var effect: Gen2BattleAnimBgEffect = _effect(0x0B)  # enter_mon
+	_run(effect)
+	assert_eq(
+		background.tile_at(14, 4), 0x00,
+		"the three-by-three square at the enemy's third coordinate"
+	)
+	assert_eq(background.tile_at(16, 6), 0x30, "its own bottom-right offset")
+	assert_eq(background.bg_map_mode, 1)
+	# Three idle states between rows, so a stamp lands every fourth frame.
+	for _step: int in 4:
+		_run(effect)
+	assert_eq(background.tile_at(13, 2), 0x00, "then the five-by-five")
+	for _step: int in 4:
+		_run(effect)
+	assert_eq(background.tile_at(12, 0), 0x00, "then the whole seven-by-seven")
+	assert_eq(background.tile_at(18, 6), 0x30)
+
+
+# ------------------------------------------------------------------- helpers ----
+
+## A player whose script is [param body], so the queueing commands can be driven
+## through the interpreter rather than called directly.
+func _script_player(body: Array) -> Gen2BattleAnimPlayer:
+	var bytes := PackedByteArray()
+	bytes.append((BASE + 2) & 0xFF)
+	bytes.append((BASE + 2) >> 8)
+	for value: int in body:
+		bytes.append(value & 0xFF)
+	var sine := PackedByteArray()
+	for value: int in RomLayout.BATTLE_ANIM_SINE_WAVE:
+		sine.append(value)
+	var data: Gen2BattleAnimData = Gen2BattleAnimData.create({
+		&"scripts": {"bank": 0x32, "address": BASE, "count": 1, "data": bytes},
+		&"objects": {
+			"bank": 0x33, "address": BASE, "count": 1,
+			"data": PackedByteArray([0x00, 0x90, 0x00, 0x00, 0x02, 0x01]),
+		},
+		&"framesets": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+		&"oam_sets": {"bank": 0x33, "address": BASE, "count": 0, "data": PackedByteArray()},
+	}, [], sine)
+	return Gen2BattleAnimPlayer.create(data, 0)

--- a/tests/unit/test_battle_anim_bg_effects.gd.uid
+++ b/tests/unit/test_battle_anim_bg_effects.gd.uid
@@ -1,0 +1,1 @@
+uid://bcooed4rcy8xg

--- a/tests/unit/test_battle_anim_functions.gd
+++ b/tests/unit/test_battle_anim_functions.gd
@@ -200,15 +200,15 @@ func test_a_sound_wave_is_mirrored_on_the_enemys_turn() -> void:
 func test_surf_opens_and_closes_its_scanline_window() -> void:
 	var object: Gen2BattleAnimObject = _object(0x0D, 0x40, 0x60, 0x30)
 	_run(object)
-	assert_eq(_player.lcdc_pointer, Gen2BattleAnimFunctions.LCDC_POINTER_SCY)
-	assert_eq(_player.ly_override_start, 0x58)
-	assert_eq(_player.ly_override_end, 0x5E)
+	assert_eq(_player.background().lcdc_pointer, Gen2BattleAnimFunctions.LCDC_POINTER_SCY)
+	assert_eq(_player.background().ly_override_start, 0x58)
+	assert_eq(_player.background().ly_override_end, 0x5E)
 
 	object.jumptable_index = 3
 	object.y = 0x70
 	_run(object)
-	assert_eq(_player.lcdc_pointer, 0)
-	assert_eq(_player.ly_override_end, 0)
+	assert_eq(_player.background().lcdc_pointer, 0)
+	assert_eq(_player.background().ly_override_end, 0)
 	assert_false(object.active())
 
 
@@ -219,11 +219,11 @@ func test_sky_attack_cycles_the_dmg_object_palette() -> void:
 	_run(object)
 	assert_eq(object.var1, 0xF0, "the player's side")
 	_run(object)
-	assert_eq(_player.obp0, 0xF0)
+	assert_eq(_player.background().obp0, 0xF0)
 	_run(object)
-	assert_eq(_player.obp0, 0xF0)
+	assert_eq(_player.background().obp0, 0xF0)
 	_run(object)
-	assert_eq(_player.obp0, 0xA0, "$aa masked by the side's own byte")
+	assert_eq(_player.background().obp0, 0xA0, "$aa masked by the side's own byte")
 
 
 ## `BattleAnimFunc_RockSmash` writes the frameset straight into the struct rather

--- a/tests/unit/test_battle_anim_player.gd
+++ b/tests/unit/test_battle_anim_player.gd
@@ -198,23 +198,25 @@ func test_keepsprites_keeps_the_sprites_and_takes_their_colour() -> void:
 	)
 
 
-## What the animation asked for and did not get is reported rather than passed
-## over, so a caller can tell a whole animation from one missing its background.
-##
-## A callback past the jumptable is reported the same way. The importer refuses
-## such a row, so only a hand-built object reaches it.
-func test_an_unbuilt_bg_effect_or_an_unknown_callback_is_reported() -> void:
+## A callback or an effect past the end of its own table is reported rather than
+## passed over. The importer refuses such an object row and no cartridge script
+## names such an effect, so only hand-built data reaches either.
+func test_a_callback_or_effect_past_its_table_is_reported() -> void:
+	var unknown: int = Gen2BattleAnimBgEffects.EFFECTS_CRYSTAL.size()
 	var player: Gen2BattleAnimPlayer = _player(
-		SPAWN + [0xF0, 0x22, 0x00, 0x00, 0x00] + [0x01] + RET,
+		SPAWN + [0xF0, unknown, 0x00, 0x00, 0x00] + [0x01] + RET,
 		2, Gen2BattleAnimImporter.FUNCTION_COUNT
 	)
 	player.advance_frame()
 	var missing: Dictionary = player.unimplemented()
 	assert_eq(missing["functions"], [Gen2BattleAnimImporter.FUNCTION_COUNT])
-	assert_eq(missing["bg_effects"], [0x22])
+	assert_eq(missing["bg_effects"], [unknown])
 
-	# Callback 9 is `BattleAnimFunc_Shake`, which is built and moves the object.
-	var whole: Gen2BattleAnimPlayer = _player(SPAWN + [0x01] + RET, 2, 0x09)
+	# Callback 9 is `BattleAnimFunc_Shake` and effect $22 `BattleBGEffect_BounceDown`,
+	# both built.
+	var whole: Gen2BattleAnimPlayer = _player(
+		SPAWN + [0xF0, 0x22, 0x00, 0x00, 0x00] + [0x01] + RET, 2, 0x09
+	)
 	whole.advance_frame()
 	assert_eq(whole.unimplemented(), {"bg_effects": [], "functions": []})
 

--- a/tools/validate_battle_anims.gd
+++ b/tools/validate_battle_anims.gd
@@ -79,6 +79,15 @@ const BODY_SLAM_BG_EFFECTS: Dictionary = {
 const EXPECTED_GFX_SHEETS: int = 39
 const EXPECTED_GFX_TILES: int = 659
 
+## `NUM_BATTLE_BG_EFFECTS` in each pin, and the id the two lists part company on.
+## pokegold ships no `BATTLE_BG_EFFECT_BODY_SLAM`, so from here its own list runs
+## one lower and `..._ROLLOUT` sits at $2d rather than $2e.
+const BG_EFFECTS_CRYSTAL: int = 54
+const BG_EFFECTS_GOLD: int = 53
+const BODY_SLAM_EFFECT: int = 0x25
+const ROLLOUT_EFFECT_CRYSTAL: int = 0x2E
+const ROLLOUT_EFFECT_GOLD: int = 0x2D
+
 ## Well past the longest shipped animation, which is 365 frames.
 const MAX_FRAMES: int = 4096
 
@@ -124,6 +133,11 @@ func _play_every_animation(game_id: StringName, data: GameData) -> void:
 	var leaked: int = 0
 	var functions: Dictionary = {}
 	var effects: Dictionary = {}
+	var live: int = 0
+	var reached: int = 0
+	var windows: int = 0
+	var remaps: int = 0
+	var edits: int = 0
 	for index: int in anims.count(&"scripts"):
 		for enemy_turn: bool in [false, true]:
 			var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create(
@@ -133,11 +147,24 @@ func _play_every_animation(game_id: StringName, data: GameData) -> void:
 				player != null, "%s: animation %d would not start." % [game_id, index]
 			):
 				continue
+			var blank: PackedByteArray = player.background().bg_map.duplicate()
+			var opened: bool = false
+			var remapped: bool = false
 			var frames: int = 0
 			while player.advance_frame() and frames < MAX_FRAMES:
 				frames += 1
 				objects = maxi(objects, player.objects().size())
 				sprites = maxi(sprites, player.sprites().size())
+				live = maxi(live, player.bg_effects().size())
+				reached += player.bg_effects().size()
+				opened = opened \
+					or player.background().lcdc_pointer != 0 \
+					or player.background().scx != 0 \
+					or player.background().scy != 0
+				remapped = remapped or player.background().palettes_dirty
+			windows += 1 if opened else 0
+			remaps += 1 if remapped else 0
+			edits += 1 if player.background().bg_map != blank else 0
 			_check(
 				not player.failed(),
 				"%s: animation %d ran off its region." % [game_id, index]
@@ -170,6 +197,21 @@ func _play_every_animation(game_id: StringName, data: GameData) -> void:
 			game_id, functions.size(), functions.keys(),
 		]
 	)
+	_check(
+		effects.is_empty(),
+		"%s: %d bg effects are still unbuilt: %s." % [
+			game_id, effects.size(), effects.keys(),
+		]
+	)
+	_check(
+		reached > 0 and windows > 0 and remaps > 0 and edits > 0,
+		"%s: the bg effects ran but produced nothing: %d queued, %d scanline windows, %d palette remaps, %d tilemap edits." % [
+			game_id, reached, windows, remaps, edits,
+		]
+	)
+	print("%s: %d bg effect slots used at once; %d animations opened a scanline window, %d remapped a palette, %d edited the tilemap." % [
+		game_id, live, windows, remaps, edits,
+	])
 	print("%s: played %d animations both ways; at most %d objects and %d sprites at once." % [
 		game_id, anims.count(&"scripts"), objects, sprites,
 	])
@@ -265,6 +307,35 @@ func _verify_profile_split(game_id: StringName, data: GameData) -> void:
 	_verify_bg_effects(
 		game_id, data, "BODY SLAM", BODY_SLAM_INDEX, BODY_SLAM_BG_EFFECTS[game_id]
 	)
+	_verify_bg_effect_table(game_id)
+
+
+## The other half of that split: the same id names a different effect in the two
+## games from $25 on, so the two `BattleBGEffects` tables are kept whole and
+## nothing is normalised between them.
+func _verify_bg_effect_table(game_id: StringName) -> void:
+	var names: Array[StringName] = Gen2BattleAnimBgEffects.names_for(game_id)
+	var crystal: bool = game_id == &"crystal"
+	_check(
+		names.size() == (BG_EFFECTS_CRYSTAL if crystal else BG_EFFECTS_GOLD),
+		"%s: the bg effect table is %d long." % [game_id, names.size()]
+	)
+	_check(
+		names[BODY_SLAM_EFFECT] == (&"body_slam" if crystal else &"wobble_mon"),
+		"%s: bg effect $%02X is %s." % [game_id, BODY_SLAM_EFFECT, names[BODY_SLAM_EFFECT]]
+	)
+	_check(
+		names[ROLLOUT_EFFECT_CRYSTAL if crystal else ROLLOUT_EFFECT_GOLD] == &"rollout",
+		"%s: BATTLE_BG_EFFECT_ROLLOUT is not where the constants put it." % game_id
+	)
+	for id: int in BODY_SLAM_EFFECT:
+		_check(
+			names[id] == Gen2BattleAnimBgEffects.EFFECTS_CRYSTAL[id],
+			"%s: bg effect $%02X differs below the split." % [game_id, id]
+		)
+	print("%s: %d bg effects, $%02X is %s." % [
+		game_id, names.size(), BODY_SLAM_EFFECT, names[BODY_SLAM_EFFECT],
+	])
 
 
 func _verify_bg_effects(


### PR DESCRIPTION
Stacked on #143. Merge that first; GitHub retargets this onto `main` when it lands.

Ports `BattleBGEffects`' jumptable and the routines under it: the screen shakes, the scanline deformations, the palette fades and the tilemap edits that hide, shrink and slide a battler's picture. Five run at once over their own `wActiveBGEffects` slots.

`Gen2BattleAnimBackground` is the video state they write, which is what the cartridge edits rather than a drawing surface: the two scanline tables and their window, `hSCX`/`hSCY`, the DMG palette bytes, and `wTilemap` as a 20x18 grid. `BattleAnimFunc_Surf` writes the same window, so the two share it.

A bg effect id stays profile-local. pokegold ships no `BodySlam`, so its table is 53 against Crystal's 54 and every id from `$25` on names a different routine; both tables are kept whole and dispatch is by name. Its two other code-level differences, `BounceDown`'s LCD-stat window and `HideMon`'s `hBGMapThird` write, are reproduced as well.

Where the source asks `hCGB` or `hSGB` the Color branch is the one built, as every `_CGB_` layout here already does. The palette bytes still reach the screen: `BattleAnimRequestPals` turns a changed `wBGP` or `wOBP0` into a `CopyPals` remap, and `CopyPals` always reads the pristine copy, so the byte per slot is the whole state.

### One correction to an earlier assumption

`.playframe`'s Rollout branch is not built, because it decides nothing in a player stepped once per frame: `BattleBGEffect_Rollout` waits a frame itself, so skipping `BattleAnimDelayFrame` leaves the same one VBlank per iteration. The seam that ran the frame body twice was wrong and has gone. Rollout runs at the same speed as everything else; the skip is what keeps it there rather than at half speed.

### Verification

- GUT: 101 scripts, 1941 tests, 1941 passing, 14945 assertions (from 100/1920/1920/14789).
- `import_rom --verify` 3/3, `import_rom` 3/3, boot smoke test ok. Cache format unchanged at 31: this step imports nothing new.
- `validate_battle_anims`: PASS. Bg effects still to build 44/44/45 -> 0/0/0. It now also pins both effect tables and their split, and asserts the effects produced output rather than merely running: 142 animations open a scanline window, 222 remap a palette, 140 edit the tilemap, at most 3 of the 5 slots live at once.