### PR TITLE
Show the bubbles a status leaves on its target

### DIFF
--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -77,6 +77,17 @@ const AFTER_ANIM_ENEMY_STAT_DOWN: int = 0x110 - BATTLE_AFTERANIMS
 const AFTER_ANIM_PLAYER_DAMAGE: int = 0x112 - BATTLE_AFTERANIMS
 const AFTER_ANIM_WOBBLE: int = 0x113 - BATTLE_AFTERANIMS
 
+## The status animations `PlayOpponentBattleAnim` plays on the target, past
+## `wFXAnimID`'s low byte and so reached by `BattleAnimRunScript`'s `.not_move`
+## branch. Only these five of the non-move block are named, because only these
+## five have a caller: `constants/move_constants.asm`'s `ANIM_SLP` and `ANIM_SAP`
+## sit among them and nothing in either pin ever asks for one.
+const ANIM_CONFUSED: int = 0x103
+const ANIM_BRN: int = 0x105
+const ANIM_PSN: int = 0x106
+const ANIM_FRZ: int = 0x108
+const ANIM_PAR: int = 0x109
+
 var _data: Gen2BattleAnimData = null
 var _script: Gen2BattleAnimScript = null
 var _anim_index: int = 0

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -927,6 +927,14 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 	else:
 		defender.status |= flag
 
+	# The status is on before the animation plays, which is the order all four
+	# `*Target` commands use: the status bit, `UpdateOpponentInParty` and any
+	# `Apply*Effect` call, then `PlayOpponentBattleAnim`, then `RefreshBattleHuds`
+	# and the text.
+	var opponent_anim: int = _status_target_anim(turn, flag)
+	if opponent_anim >= 0:
+		_play_opponent_battle_anim(turn, opponent_anim)
+
 	turn.emit(Gen2Battle.STATUS_INFLICTED, {
 		"target": turn.target,
 		"status": defender.status,
@@ -951,7 +959,9 @@ static func _toxic_target(turn: Gen2Turn) -> void:
 	if defender.is_fainted() or Gen2Status.is_afflicted(defender.status):
 		return
 
-	# `BattleCommand_Poison`'s `.toxic` branch reaches the same `.apply_poison`.
+	# `BattleCommand_Poison`'s `.toxic` branch reaches the same `.apply_poison`,
+	# so Toxic animates from inside the command and never reaches
+	# `PlayOpponentBattleAnim`: no `ANIM_PSN` follows it.
 	_animate_current_move(turn)
 	defender.status |= Gen2Status.POISON
 	defender.toxic_counter = 1
@@ -988,13 +998,19 @@ static func _confuse_target(turn: Gen2Turn) -> void:
 	if defender.is_fainted() or Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED):
 		return
 
-	# `BattleCommand_FinishConfusingTarget`'s `.got_effect` skips the animation
-	# for the three effects that already played one of their own.
+	defender.substatus |= Gen2Substatus.CONFUSED
+	defender.confusion_turns = Gen2Substatus.roll_confusion(turn.rng())
+
+	# `BattleCommand_FinishConfusingTarget`'s `.got_effect` skips the move's own
+	# animation for the three effects that already played one. Only
+	# `EFFECT_CONFUSE_HIT` is checked, because `EFFECT_SNORE` and
+	# `EFFECT_SWAGGER` are unwritten and no move here carries either.
 	if turn.effect() != Gen2MoveEffect.CONFUSE_HIT:
 		_animate_current_move(turn)
 
-	defender.substatus |= Gen2Substatus.CONFUSED
-	defender.confusion_turns = Gen2Substatus.roll_confusion(turn.rng())
+	# Unconditional, and past `.got_effect`: a confusion animates on its target
+	# whichever way the move reached here.
+	_play_opponent_battle_anim(turn, Gen2BattleAnimPlayer.ANIM_CONFUSED)
 
 	# Not [constant Gen2Battle.STATUS_INFLICTED]: that event's [code]status[/code]
 	# field is the status byte, and confusion never touches it.
@@ -1570,17 +1586,40 @@ static func _skip_sun_charge(turn: Gen2Turn) -> void:
 
 ## `PlayFXAnimID`. Nothing is drawn here: the animation is written down as an
 ## event at its own place in the turn and the screen is what spends frames on it.
+##
+## [param on_opponent] is `PlayOpponentBattleAnim`'s pair of
+## `BattleCommand_SwitchTurn` calls: the same event with `hBattleTurn` inverted
+## for the length of the animation, so it plays on the target rather than on
+## whoever is acting.
 static func _play_fx_anim(
-	turn: Gen2Turn, index: int, after_anim: int, restore_user_pic: bool = false
+	turn: Gen2Turn, index: int, after_anim: int, restore_user_pic: bool = false,
+	on_opponent: bool = false
 ) -> void:
+	var enemy_turn: bool = turn.side == Gen2Battle.ENEMY
 	turn.emit(Gen2Battle.ANIMATION, {
 		"index": index,
 		"param": turn.battle.battle_anim_param,
 		"after_anim": after_anim,
-		"enemy_turn": turn.side == Gen2Battle.ENEMY,
+		"enemy_turn": enemy_turn != on_opponent,
 		"effectiveness": turn.effectiveness,
 		"restore_user_pic": restore_user_pic,
 	})
+
+
+## `PlayOpponentBattleAnim`, the fifth route an animation reaches the screen by
+## and the only one that is not the move's own: `wFXAnimID` set from `de`,
+## `wBattleAfterAnim` cleared, and `PlayBattleAnim` run between two
+## `BattleCommand_SwitchTurn` calls.
+##
+## `wBattleAnimParam` is not written, so whatever the move's own animation left
+## stands, the way it does across [method _animate_current_move].
+##
+## Five commands call it, all secondary-effect ones, and all five ids are past
+## `wFXAnimID`'s low byte: `BattleAnimRunScript` therefore takes `.not_move`,
+## which skips `CheckBattleScene`, both hud calls and the after-anim. A status
+## animation plays with the battle-scene option turned off.
+static func _play_opponent_battle_anim(turn: Gen2Turn, index: int) -> void:
+	_play_fx_anim(turn, index, Gen2BattleAnimPlayer.AFTER_ANIM_NONE, false, true)
 
 
 ## `BattleCommand_MoveAnimNoSub`: the damage flash aimed at whoever was hit, the
@@ -1643,6 +1682,34 @@ static func _status_move_animates(turn: Gen2Turn, flag: int) -> bool:
 		Gen2Status.PARALYSIS:
 			return turn.effect() == Gen2MoveEffect.PARALYZE
 	return false
+
+
+## Which status animation `PlayOpponentBattleAnim` plays on the target, or -1.
+##
+## The four secondary-effect commands each play one, and the primary status
+## moves' own commands play none: `BattleCommand_SleepTarget` ends at
+## `AnimateCurrentMove`, `BattleCommand_Poison`'s `.apply_poison` is
+## `AnimateCurrentMove`, `PoisonOpponent`, `RefreshBattleHuds`, and
+## `BattleCommand_Paralyze` the same. Toxic reaches that same `.apply_poison`, so
+## [method _toxic_target] plays none either.
+##
+## That makes this the exact inverse of [method _status_move_animates] rather
+## than a second rule: burn and freeze have no status move of their own to be the
+## primary shape of, and sleep is the one status whose primary command is the
+## only shape there is.
+static func _status_target_anim(turn: Gen2Turn, flag: int) -> int:
+	if _status_move_animates(turn, flag):
+		return -1
+	match flag:
+		Gen2Status.POISON:
+			return Gen2BattleAnimPlayer.ANIM_PSN
+		Gen2Status.BURN:
+			return Gen2BattleAnimPlayer.ANIM_BRN
+		Gen2Status.FREEZE:
+			return Gen2BattleAnimPlayer.ANIM_FRZ
+		Gen2Status.PARALYSIS:
+			return Gen2BattleAnimPlayer.ANIM_PAR
+	return -1
 
 
 ## `AnimateCurrentMove`, which is `LoadMoveAnim` between a `lowersub` and a

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -110,6 +110,28 @@ func test_the_battle_scene_option_skips_the_move_animation() -> void:
 	assert_false(hidden)
 
 
+func test_a_status_animation_leaves_the_hud_up() -> void:
+	# `BattleAnimRunScript` takes `.not_move` on an id past `wFXAnimID`'s low
+	# byte, which skips `BattleAnimClearHud` and `BattleAnimRestoreHuds` alike,
+	# so a status animation leaves the panels where they are. The move id in
+	# [method test_a_move_animation_takes_the_hud_off_and_puts_it_back] is the
+	# same event with the same battle-scene setting and does take them off, so
+	# the id is what decides.
+	await _open_battle()
+	_screen._begin_animation(_animation_event({
+		"index": Gen2BattleAnimPlayer.ANIM_BRN,
+		"after_anim": Gen2BattleAnimPlayer.AFTER_ANIM_NONE,
+		"enemy_turn": true,
+	}))
+	var hidden: bool = false
+	var guard: int = 4000
+	while _screen.animation_running() and guard > 0:
+		hidden = hidden or not bool(_screen.animation_snapshot()["hud_visible"])
+		_screen.advance_frame()
+		guard -= 1
+	assert_false(hidden, ".not_move reaches neither hud call")
+
+
 func test_the_tilemap_is_the_battle_it_is_seeded_from() -> void:
 	await _open_battle()
 	var map: PackedByteArray = _screen._bg_map

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -45,6 +45,16 @@ const EMBER_BURNS: int = 92
 const NEVER_BURNS: int = 93
 const FLAME_WHEEL: int = 172
 
+## The other three secondary statuses, each on a real row with a chance the roll
+## cannot fail, so all four `*Target` commands can be reached without a seed.
+## Burn already has [constant EMBER_BURNS]; sleep has no secondary shape, since
+## `EFFECT_SLEEP` is the whole of every move that carries it. Invented numbers
+## and `_ALWAYS` names, the way [constant THUNDER_ALWAYS_PARALYZES] is one: the
+## chance is the only byte that is not the cartridge's.
+const SLUDGE_BOMB_ALWAYS_POISONS: int = 275
+const ICE_BEAM_ALWAYS_FREEZES: int = 276
+const BODY_SLAM_ALWAYS_PARALYZES: int = 277
+
 ## The stat-changing moves, in the shapes the effect bytes come in: a pure raise,
 ## a pure drop, a raise on hit, and a drop on hit that always rolls or never
 ## does, the same trick [constant EMBER_BURNS] and [constant NEVER_BURNS] already
@@ -158,7 +168,7 @@ const SYNTHESIS: int = 235
 const MOONLIGHT: int = 236
 
 ## The highest move number this table fills. Grown as new moves are added.
-const MAX_MOVE: int = THUNDER_ALWAYS_PARALYZES
+const MAX_MOVE: int = BODY_SLAM_ALWAYS_PARALYZES
 const BERRY_ITEM: int = 0xAD
 
 ## The highest item number this table fills.
@@ -212,6 +222,7 @@ const WATER: int = 0x15
 const GRASS: int = 0x16
 const ELECTRIC: int = 0x17
 const PSYCHIC_TYPE: int = 0x18
+const ICE: int = 0x19
 const POISON: int = 0x03
 const FLYING: int = 0x02
 const DRAGON: int = 0x1A
@@ -365,6 +376,17 @@ static func _moves() -> Array:
 		EMBER_BURNS: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 256],
 		NEVER_BURNS: ["EMBER", 40, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 0],
 		FLAME_WHEEL: ["FLAME WHEEL", 60, FIRE, 255, 25, Gen2MoveEffect.BURN_HIT, 0],
+		# The other three secondary statuses, power, type and PP as the cartridge
+		# has them and only the chance forced past failing.
+		SLUDGE_BOMB_ALWAYS_POISONS: [
+			"SLUDGE BOMB", 90, POISON, 255, 10, Gen2MoveEffect.POISON_HIT, 256,
+		],
+		ICE_BEAM_ALWAYS_FREEZES: [
+			"ICE BEAM", 95, ICE, 255, 10, Gen2MoveEffect.FREEZE_HIT, 256,
+		],
+		BODY_SLAM_ALWAYS_PARALYZES: [
+			"BODY SLAM", 85, NORMAL, 255, 15, Gen2MoveEffect.PARALYZE_HIT, 256,
+		],
 		# Attack up by two, on the user, with no roll to miss.
 		SWORDS_DANCE: ["SWORDS DANCE", 0, NORMAL, 255, 30, Gen2MoveEffect.STAT_UP_2_BASE, 0],
 		# Defense down by two, on the foe, which can still miss.

--- a/tests/unit/test_battle_animation_commands.gd
+++ b/tests/unit/test_battle_animation_commands.gd
@@ -1,12 +1,14 @@
 extends GutTest
 
-## The four routes a move's animation reaches the screen by.
+## The five routes an animation reaches the screen by.
 ##
 ## `moveanim` and `moveanimnosub` sit in the effect lists, `statupanim` and
 ## `statdownanim` between a stat change and its message, and `AnimateCurrentMove`
-## inside individual command bodies rather than in any list at all. All four
-## write the same event, since the engine is scene-free and the screen is what
-## spends the frames.
+## inside individual command bodies rather than in any list at all. Those four
+## are the move's own animation. `PlayOpponentBattleAnim` is the fifth and is
+## not: five secondary-effect commands play a status animation on the target,
+## with `hBattleTurn` inverted for its length. All five write the same event,
+## since the engine is scene-free and the screen is what spends the frames.
 
 const Fixture := preload("res://tests/unit/battle_fixture.gd")
 
@@ -153,11 +155,15 @@ func test_a_status_move_with_no_animation_command_still_animates() -> void:
 	assert_eq(int(animations[0]["after_anim"]), Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
 
 
-func test_a_secondary_paralysis_does_not_animate_a_second_time() -> void:
-	# `BattleCommand_ParalyzeTarget` has no `AnimateCurrentMove`: the move that
-	# carried it played its own `moveanim` already.
+func test_a_secondary_status_does_not_play_the_move_a_second_time() -> void:
+	# `BattleCommand_BurnTarget` has no `AnimateCurrentMove`: the move that
+	# carried it played its own `moveanim` already. What follows it is the status
+	# animation, not the move again.
 	var events: Array = _run_move(_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
-	assert_eq(_animations(events).size(), 1)
+	var animations: Array = _animations(events)
+	assert_eq(animations.size(), 2)
+	assert_eq(int(animations[0]["index"]), Fixture.EMBER_BURNS)
+	assert_eq(int(animations[1]["index"]), Gen2BattleAnimPlayer.ANIM_BRN)
 
 
 func test_a_multi_hit_animates_every_hit_and_flashes_only_the_last() -> void:
@@ -196,3 +202,148 @@ func test_haze_animates_from_inside_its_own_command() -> void:
 		_index_of(events, Gen2Battle.ANIMATION), _index_of(events, Gen2Battle.STAGES_CLEARED),
 		"AnimateCurrentMove runs before EliminatedStatsText"
 	)
+
+
+## `PlayOpponentBattleAnim`, the fifth route.
+
+func test_each_secondary_status_plays_its_own_animation_on_the_target() -> void:
+	# The four `*Target` commands that reach `PlayOpponentBattleAnim`, with the
+	# ids `constants/move_constants.asm` gives them.
+	var expected: Dictionary = {
+		Fixture.EMBER_BURNS: Gen2BattleAnimPlayer.ANIM_BRN,
+		Fixture.SLUDGE_BOMB_ALWAYS_POISONS: Gen2BattleAnimPlayer.ANIM_PSN,
+		Fixture.ICE_BEAM_ALWAYS_FREEZES: Gen2BattleAnimPlayer.ANIM_FRZ,
+		Fixture.BODY_SLAM_ALWAYS_PARALYZES: Gen2BattleAnimPlayer.ANIM_PAR,
+	}
+	for move: int in expected:
+		var events: Array = _run_move(_battle([move]), move)
+		var animations: Array = _animations(events)
+		assert_eq(animations.size(), 2, "move %d plays its own and the status's" % move)
+		assert_eq(int(animations[1]["index"]), int(expected[move]))
+		# `PlayOpponentBattleAnim` clears `wBattleAfterAnim`, so no damage flash
+		# chains off a status animation.
+		assert_eq(
+			int(animations[1]["after_anim"]), Gen2BattleAnimPlayer.AFTER_ANIM_NONE
+		)
+		assert_false(bool(animations[1]["restore_user_pic"]))
+
+
+func test_a_status_animation_plays_on_the_target_rather_than_the_user() -> void:
+	# The two `BattleCommand_SwitchTurn` calls `PlayOpponentBattleAnim` wraps
+	# `PlayBattleAnim` in: `hBattleTurn` is inverted for its length.
+	var player: Array = _animations(
+		_run_move(_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
+	)
+	assert_false(bool(player[0]["enemy_turn"]), "the move plays on the user")
+	assert_true(bool(player[1]["enemy_turn"]), "the status plays on the target")
+
+	var enemy: Array = _animations(_run_move(
+		_battle([Fixture.TACKLE], [Fixture.EMBER_BURNS]),
+		Fixture.EMBER_BURNS, Gen2Battle.ENEMY
+	))
+	assert_true(bool(enemy[0]["enemy_turn"]))
+	assert_false(bool(enemy[1]["enemy_turn"]))
+
+
+func test_a_status_animation_runs_before_the_line_that_reports_it() -> void:
+	# `PlayOpponentBattleAnim`, `RefreshBattleHuds`, then `StdBattleTextbox`.
+	var events: Array = _run_move(_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
+	var animations: Array = _animations(events)
+	assert_eq(animations.size(), 2)
+	assert_lt(
+		_index_of(events, Gen2Battle.STATUS_INFLICTED),
+		events.size(),
+		"the burn landed"
+	)
+	var last: int = -1
+	for index: int in events.size():
+		if StringName(events[index]["type"]) == Gen2Battle.ANIMATION:
+			last = index
+	assert_lt(last, _index_of(events, Gen2Battle.STATUS_INFLICTED))
+
+
+func test_the_status_moves_own_commands_play_no_second_animation() -> void:
+	# `BattleCommand_SleepTarget` ends at `AnimateCurrentMove`;
+	# `BattleCommand_Poison`'s `.apply_poison` and `BattleCommand_Paralyze` are
+	# `AnimateCurrentMove` and the status. None of the three reaches
+	# `PlayOpponentBattleAnim`, so `ANIM_SLP` is played by nothing at all.
+	for move: int in [
+		Fixture.SLEEP_POWDER, Fixture.POISON_POWDER, Fixture.THUNDER_WAVE
+	]:
+		var animations: Array = _animations(_run_move(_battle([move]), move))
+		assert_eq(animations.size(), 1, "move %d animates once" % move)
+		assert_eq(int(animations[0]["index"]), move)
+
+
+func test_toxic_animates_from_its_own_command_and_plays_no_status_animation() -> void:
+	# `.toxic` reaches the same `.apply_poison` the ordinary branch does.
+	var animations: Array = _animations(_run_move(_battle([Fixture.TOXIC]), Fixture.TOXIC))
+	assert_eq(animations.size(), 1)
+	assert_eq(int(animations[0]["index"]), Fixture.TOXIC)
+
+
+func test_a_confusion_animates_on_its_target_whichever_way_it_was_reached() -> void:
+	# `BattleCommand_FinishConfusingTarget` plays `ANIM_CONFUSED` past
+	# `.got_effect`, so both shapes reach it. Supersonic adds its own
+	# `AnimateCurrentMove` in front; Confusion's `moveanim` is what it skips for.
+	var supersonic: Array = _animations(
+		_run_move(_battle([Fixture.SUPERSONIC]), Fixture.SUPERSONIC)
+	)
+	assert_eq(supersonic.size(), 2)
+	assert_eq(int(supersonic[0]["index"]), Fixture.SUPERSONIC)
+	assert_eq(int(supersonic[1]["index"]), Gen2BattleAnimPlayer.ANIM_CONFUSED)
+	assert_true(bool(supersonic[1]["enemy_turn"]))
+
+	var confusion: Array = _animations(
+		_run_move(_battle([Fixture.CONFUSION_ALWAYS]), Fixture.CONFUSION_ALWAYS)
+	)
+	assert_eq(confusion.size(), 2)
+	assert_eq(int(confusion[0]["index"]), Fixture.CONFUSION_ALWAYS)
+	assert_eq(int(confusion[1]["index"]), Gen2BattleAnimPlayer.ANIM_CONFUSED)
+
+
+func test_a_confusion_that_does_not_land_plays_no_status_animation() -> void:
+	var battle: Gen2Battle = _battle([Fixture.SUPERSONIC])
+	battle.enemy.substatus |= Gen2Substatus.CONFUSED
+	assert_eq(_animations(_run_move(battle, Fixture.SUPERSONIC)).size(), 0)
+
+
+func test_a_freeze_refused_by_the_sun_plays_nothing() -> void:
+	# `BattleCommand_FreezeTarget` returns on `WEATHER_SUN` before the status is
+	# set, so the animation behind it is never reached.
+	var battle: Gen2Battle = _battle([Fixture.ICE_BEAM_ALWAYS_FREEZES])
+	battle.weather = Gen2Weather.SUN
+	battle.weather_turns = Gen2Weather.TURNS
+	var animations: Array = _animations(_run_move(battle, Fixture.ICE_BEAM_ALWAYS_FREEZES))
+	assert_eq(animations.size(), 1)
+	assert_eq(int(animations[0]["index"]), Fixture.ICE_BEAM_ALWAYS_FREEZES)
+
+
+func test_a_status_refused_by_one_already_there_plays_nothing() -> void:
+	var battle: Gen2Battle = _battle([Fixture.EMBER_BURNS])
+	battle.enemy.status = Gen2Status.PARALYSIS
+	assert_eq(_animations(_run_move(battle, Fixture.EMBER_BURNS)).size(), 1)
+
+
+func test_a_status_animation_carries_the_param_the_move_left() -> void:
+	# `PlayOpponentBattleAnim` never writes `wBattleAnimParam`, so the status
+	# animation reads whatever the move's own animation put there.
+	var battle: Gen2Battle = _battle([Fixture.EMBER_BURNS])
+	battle.battle_anim_param = 1
+	var animations: Array = _animations(_run_move(battle, Fixture.EMBER_BURNS))
+	assert_eq(int(animations[0]["param"]), 0, "moveanim clears it")
+	assert_eq(int(animations[1]["param"]), 0)
+	assert_eq(battle.battle_anim_param, 0)
+
+
+func test_every_status_animation_is_past_the_move_ids() -> void:
+	# `BattleAnimRunScript` tells a move from a status animation by
+	# `wFXAnimID`'s high byte, so all five must sit past it or they would take
+	# the hud-and-after-anim branch instead.
+	for index: int in [
+		Gen2BattleAnimPlayer.ANIM_CONFUSED, Gen2BattleAnimPlayer.ANIM_BRN,
+		Gen2BattleAnimPlayer.ANIM_PSN, Gen2BattleAnimPlayer.ANIM_FRZ,
+		Gen2BattleAnimPlayer.ANIM_PAR,
+	]:
+		assert_gt(index, 0xFF)
+		assert_lt(index, RomLayout.BATTLE_ANIM_SCRIPT_COUNT)


### PR DESCRIPTION
PlayOpponentBattleAnim is the fifth and last route an animation reaches the screen by, and the only one that is not the move's own. Five secondary-effect commands play a status animation on the target: PoisonTarget ANIM_PSN, BurnTarget ANIM_BRN, FreezeTarget ANIM_FRZ, ParalyzeTarget ANIM_PAR and FinishConfusingTarget ANIM_CONFUSED past its own .got_effect. Each sets wFXAnimID, clears wBattleAfterAnim and runs PlayBattleAnim between two SwitchTurn calls, so it is one more ANIMATION event with enemy_turn inverted and wBattleAnimParam left alone.

The status moves' own commands reach none of it: SleepTarget ends at AnimateCurrentMove, and Poison's .apply_poison, which Toxic also reaches, is AnimateCurrentMove and PoisonOpponent. So ANIM_SLP and ANIM_SAP have no caller at all and a Toxic plays no ANIM_PSN. All five ids sit past wFXAnimID's low byte, so BattleAnimRunScript takes .not_move: no CheckBattleScene, neither hud call and no after-anim.

Confusion also sets its substatus and rolls its counter before the animation now, which is the order the source uses.