### PR TITLE
Let a freeze end, and let a type refuse a status

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -46,6 +46,10 @@ const OHKO: StringName = &"ohko"
 ## [code]&"recharge"[/code].
 const CANNOT_MOVE: StringName = &"cannot_move"
 const WOKE_UP: StringName = &"woke_up"
+## A freeze cleared, from any of the three places one is. `side` is whoever
+## thawed, not whoever acted: the user through a Flame Wheel or Sacred Fire, the
+## target through `BattleCommand_BurnTarget`'s `Defrost`, or either through
+## `HandleDefrost`'s end-of-turn roll.
 const THAWED: StringName = &"thawed"
 ## A status put on a Pokémon, and a slice taken off by one it already had.
 const STATUS_INFLICTED: StringName = &"status_inflicted"
@@ -334,6 +338,13 @@ var player_used_moves: Array[int] = []
 ## its low bit from whatever the last hit left.
 var battle_anim_param: int = 0
 
+## `wPlayerJustGotFrozen` and `wEnemyJustGotFrozen`, keyed by side: whether this
+## side was frozen during the turn now ending. `HandleDefrost` refuses to thaw
+## one that was, so a freeze always costs its target at least the turn it landed
+## on. Cleared at the top of every turn, the way `BattleTurn.loop` clears both
+## bytes before either side chooses.
+var _just_got_frozen: Dictionary = {PLAYER: false, ENEMY: false}
+
 ## Set once the player has run. The battle is over with no winner, which is the
 ## DRAW `wBattleResult` the cartridge writes.
 var _fled: bool = false
@@ -448,6 +459,12 @@ func mon(side: int) -> Gen2BattleMon:
 
 func opponent_of(side: int) -> int:
 	return ENEMY if side == PLAYER else PLAYER
+
+
+## `BattleCommand_FreezeTarget`'s own tail, which writes the flag on the side it
+## just froze so [method _tick_defrost] leaves that one alone this turn.
+func mark_just_got_frozen(side: int) -> void:
+	_just_got_frozen[side] = true
 
 
 ## Clears the damage that Counter and Mirror Coat are allowed to remember.
@@ -755,6 +772,7 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 		return events
 
 	reset_damage_taken()
+	_just_got_frozen = {PLAYER: false, ENEMY: false}
 
 	if _is_run(player_action):
 		var attempt: Dictionary = run_odds()
@@ -955,18 +973,45 @@ func _tick_wrap(events: Array) -> void:
 ##
 ## The three do not agree on an order. The first two are `SetPlayerTurn` then
 ## `SetEnemyTurn` reading `GetUserItem`, so the player is handled first; the
-## third is the same two calls reading `GetOpponentItem`, so the enemy is. The
-## two skipped between them, `HandleDefrost` and `HandleSafeguard`/`HandleScreens`,
-## are not item effects.
+## third is the same two calls reading `GetOpponentItem`, so the enemy is.
+## `HandleDefrost` runs between the second and the third and is not an item
+## effect at all; `HandleSafeguard` and `HandleScreens` sit behind it and are
+## still out, since neither has a screens byte to read.
 func _tick_held_items(events: Array) -> void:
 	for side: int in [PLAYER, ENEMY]:
 		_use_leftovers(side, events)
 	for side: int in [PLAYER, ENEMY]:
 		_use_pp_berry(side, events)
+	_tick_defrost(events)
 	for side: int in [ENEMY, PLAYER]:
 		use_hp_berry(side, events)
 		use_status_berry(side, events)
 		use_confusion_berry(side, events)
+
+
+## `HandleDefrost`: each frozen side thaws on its own roll at the end of a turn,
+## which is the only thing that makes a Generation 2 freeze temporary. Without
+## it a freeze lasts until a Flame Wheel, a Sacred Fire or an item, which is
+## Generation 1's rule.
+##
+## Player first, then enemy: the branch that reverses them is the
+## `USING_EXTERNAL_CLOCK` one, and this project has no link play. Nothing is
+## rolled for a side that is not frozen, since `bit FRZ` comes before
+## `BattleRandom`, so a battle with no freeze in it draws no randomness here.
+func _tick_defrost(events: Array) -> void:
+	for side: int in [PLAYER, ENEMY]:
+		var current: Gen2BattleMon = mon(side)
+		if not Gen2Status.has(current.status, Gen2Status.FREEZE):
+			continue
+		if bool(_just_got_frozen[side]):
+			continue
+		if not Gen2Status.rolls_thaw(rng):
+			continue
+		# `xor a / ld [wBattleMonStatus], a` clears the whole byte rather than
+		# the bit, which is the same thing: a freeze is never on it with anything
+		# else.
+		current.status = Gen2Status.NONE
+		events.append({"type": THAWED, "side": side})
 
 
 ## `HandleLeftovers`: a sixteenth back every turn, and nothing at all on a

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1814,7 +1814,10 @@ func _describe(event: Dictionary) -> String:
 		Gen2Battle.WOKE_UP:
 			return "%s woke up!" % _battler_name(side)
 		Gen2Battle.THAWED:
-			return "%s thawed out!" % _battler_name(side)
+			# `WasDefrostedText` and `DefrostedOpponentText` are the same line
+			# under two names, differing only in whether it is the user or the
+			# target that is named.
+			return "%s was defrosted!" % _battler_name(side)
 		Gen2Battle.STATUS_INFLICTED:
 			return "%s %s" % [
 				_battler_name(int(event["target"])),

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -906,17 +906,33 @@ static func _effect_chance(turn: Gen2Turn) -> void:
 ## One status at a time: a Pokémon that already has something on its byte is
 ## refused rather than added to, and so is one whose type makes it immune. A
 ## sleep is rolled for how long it lasts; the rest are a flag.
+##
+## The checks are in the four `*Target` commands' own order, which every one of
+## them shares: the target's existing status, the weather, its type, and only
+## then `wEffectFailed`. Ordering `wEffectFailed` last is not cosmetic, because
+## the first step is the one that does something besides refuse: a burn whose
+## roll failed still reaches `Defrost`.
 static func _status_target(turn: Gen2Turn, flag: int) -> void:
-	if turn.failed_chance:
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.is_fainted():
 		return
 
-	var defender: Gen2BattleMon = turn.defender()
-	if defender.is_fainted() or Gen2Status.is_afflicted(defender.status):
+	if Gen2Status.is_afflicted(defender.status):
+		# `BattleCommand_BurnTarget` is the one that does not simply return here:
+		# its `jp nz, Defrost` thaws a frozen target instead.
+		if flag == Gen2Status.BURN:
+			_defrost(turn, defender)
 		return
 
 	# `BattleCommand_FreezeTarget` refuses outright in sun. It is the only one of
 	# the five statuses the weather has anything to say about.
 	if flag == Gen2Status.FREEZE and turn.battle.weather == Gen2Weather.SUN:
+		return
+
+	if _status_type_refuses(turn, flag):
+		return
+
+	if turn.failed_chance:
 		return
 
 	if _status_move_animates(turn, flag):
@@ -946,6 +962,55 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 	# for the end of the turn.
 	turn.battle.use_status_berry(turn.target, turn.events)
 
+	# `BattleCommand_FreezeTarget`'s own tail, and behind the berry the way the
+	# source puts it behind `UseHeldStatusHealingItem`'s `ret nz`: a freeze a
+	# berry has already cured never sets the flag, so it does not stop a thaw
+	# that is no longer needed.
+	if flag == Gen2Status.FREEZE \
+		and Gen2Status.has(defender.status, Gen2Status.FREEZE):
+		turn.battle.mark_just_got_frozen(turn.target)
+
+
+## Whether the target's own type refuses this status, which two of the five ask
+## and three do not.
+##
+## Poison asks `CheckIfTargetIsPoisonType`, which compares the target's two types
+## against POISON itself rather than against the move's: a Poison-type is refused
+## whatever poisons it. Burn and freeze ask `CheckMoveTypeMatchesTarget`, which
+## compares the *move's* type against the target's two, so a Fire-type shrugs off
+## a Fire-type burn and an Ice-type an Ice-type freeze. Its `.normal` branch
+## returns non-zero without comparing anything, so a Normal-type move matches
+## nobody and Tri Attack can burn and freeze anything.
+##
+## Sleep and paralysis ask neither, which is why a Ground-type is paralysed by
+## Body Slam and an Electric-type by Thunder Wave: the type immunities those two
+## statuses have are a later generation's.
+static func _status_type_refuses(turn: Gen2Turn, flag: int) -> bool:
+	var types: Array = turn.defender().types()
+	if flag == Gen2Status.POISON:
+		return types.has(RomLayout.TYPE_POISON)
+	if flag != Gen2Status.BURN and flag != Gen2Status.FREEZE:
+		return false
+
+	var move_type: int = int(turn.move.get("type", RomLayout.TYPE_NORMAL))
+	if move_type == RomLayout.TYPE_NORMAL:
+		return false
+	return types.has(move_type)
+
+
+## `Defrost`, which `BattleCommand_BurnTarget` jumps to instead of returning when
+## the target already carries a status. Only a freeze is cleared; any other
+## status reaches its own `ret z` and stays.
+##
+## So a Fire-type move with a burn behind it thaws whoever it hits, and it does
+## so before `wEffectFailed` is read, which means the burn's own roll failing
+## does not stop the thaw.
+static func _defrost(turn: Gen2Turn, defender: Gen2BattleMon) -> void:
+	if not Gen2Status.has(defender.status, Gen2Status.FREEZE):
+		return
+	defender.status = Gen2Status.NONE
+	turn.emit(Gen2Battle.THAWED, {"side": turn.target})
+
 
 ## Poisons the target the way [constant POISON_TARGET] does, and starts the
 ## counter that makes it Toxic rather than an ordinary poison: see
@@ -957,6 +1022,12 @@ static func _toxic_target(turn: Gen2Turn) -> void:
 
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.is_fainted() or Gen2Status.is_afflicted(defender.status):
+		return
+
+	# Toxic is `BattleCommand_Poison` with a different branch at the end, so it
+	# passes that command's own `CheckIfTargetIsPoisonType` on the way in: a
+	# Poison-type is no more badly poisoned than ordinarily poisoned.
+	if _status_type_refuses(turn, Gen2Status.POISON):
 		return
 
 	# `BattleCommand_Poison`'s `.toxic` branch reaches the same `.apply_poison`,

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -48,6 +48,11 @@ const PARALYSIS_SPEED_SHIFT: int = 2
 const PARALYSIS_CHANCE: int = 64
 const CHANCE_RANGE: int = 256
 
+## `HandleDefrost`'s own `cp 10 percent`, which is 25 and not 26: the `percent`
+## macro (macros/data.asm) is `* $ff / 100`, so ten of them truncate to 25 out of
+## 256 rather than to a tenth of the range.
+const THAW_CHANCE: int = 25
+
 ## Burn and poison cost an eighth of the maximum, never less than one.
 const RESIDUAL_DIVISOR: int = 8
 
@@ -92,6 +97,13 @@ static func roll_sleep(rng: RandomNumberGenerator) -> int:
 ## Whether a paralysed Pokémon cannot move this turn.
 static func rolls_full_paralysis(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, CHANCE_RANGE - 1) < PARALYSIS_CHANCE
+
+
+## Whether a frozen Pokémon thaws on its own at the end of a turn, which is
+## `HandleDefrost`'s roll. Without it a freeze is permanent, the way Generation
+## 1's is; this is the whole of what makes Generation 2's temporary.
+static func rolls_thaw(rng: RandomNumberGenerator) -> bool:
+	return rng.randi_range(0, CHANCE_RANGE - 1) < THAW_CHANCE
 
 
 ## The Attack a burned Pokémon attacks with, and the Speed a paralysed one moves

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -450,7 +450,8 @@ func test_a_frozen_pokemon_does_not_move() -> void:
 	battle.player.status = Gen2Status.FREEZE
 	var events: Array = battle.take_turn(0, 0)
 	assert_eq(_first(events, Gen2Battle.CANNOT_MOVE)["reason"], &"freeze")
-	assert_eq(battle.player.status, Gen2Status.FREEZE, "and stays frozen")
+	# Whether it is still frozen afterwards is `HandleDefrost`'s roll and belongs
+	# to the thaw tests below, not to this one.
 
 
 func test_flame_wheel_is_used_through_a_freeze_and_thaws_it() -> void:
@@ -465,6 +466,155 @@ func test_flame_wheel_is_used_through_a_freeze_and_thaws_it() -> void:
 	assert_eq(_of_type(events, Gen2Battle.THAWED).size(), 1)
 	assert_eq(_of_type(events, Gen2Battle.CANNOT_MOVE).size(), 0)
 	assert_eq(battle.player.status, Gen2Status.NONE)
+
+
+func test_a_freeze_thaws_on_its_own_before_long() -> void:
+	# `HandleDefrost` is the whole of what makes a Generation 2 freeze temporary.
+	# Bounded rather than seeded: 25 in 256 a turn means holding out for 300 turns
+	# is a one-in-ten-trillion event, so this cannot go the other way by luck.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	battle.player.status = Gen2Status.FREEZE
+	var thawed_on: int = -1
+	for turn: int in 300:
+		var events: Array = battle.take_turn(0, 0)
+		if not _of_type(events, Gen2Battle.THAWED).is_empty():
+			thawed_on = turn
+			break
+	assert_gt(thawed_on, -1, "a freeze does not last forever")
+	assert_eq(battle.player.status, Gen2Status.NONE)
+
+
+func test_a_pokemon_frozen_this_turn_does_not_thaw_on_the_same_turn() -> void:
+	# `wEnemyJustGotFrozen`, which `HandleDefrost` reads before it rolls. No seed
+	# is involved: the flag refuses before `BattleRandom` is reached at all.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.ICE_BEAM_ALWAYS_FREEZES]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.FREEZE, "the freeze landed")
+	assert_eq(_of_type(events, Gen2Battle.THAWED).size(), 0)
+
+
+func test_the_just_frozen_flag_only_holds_for_the_turn_that_set_it() -> void:
+	# Slot 1 is Growl, so the turns after the freeze do no damage: the target has
+	# to survive long enough to be given the chance to thaw.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.ICE_BEAM_ALWAYS_FREEZES, Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.FREEZE)
+	var thawed_on: int = -1
+	for turn: int in 300:
+		if not _of_type(battle.take_turn(1, 0), Gen2Battle.THAWED).is_empty():
+			thawed_on = turn
+			break
+	assert_gt(thawed_on, -1, "the flag is cleared at the top of every turn")
+
+
+func test_a_turn_with_nobody_frozen_rolls_nothing_for_thawing() -> void:
+	# `bit FRZ` comes before `BattleRandom`, so adding the defrost tick did not
+	# move any other roll in the game along.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	battle.rng.seed = 99
+	battle.take_turn(0, 0)
+	var with_no_freeze: int = battle.rng.state
+
+	var again: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	again.rng.seed = 99
+	again.take_turn(0, 0)
+	assert_eq(int(again.rng.state), with_no_freeze)
+
+
+func test_a_fire_type_is_not_burned_by_a_fire_move() -> void:
+	# `CheckMoveTypeMatchesTarget`, which compares the move's type against the
+	# target's two. Charmander is Fire/Fire and Ember is Fire.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.EMBER_BURNS]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.NONE)
+
+
+func test_a_normal_move_burns_anything_it_hits() -> void:
+	# `.normal` returns non-zero without comparing anything, which is Tri
+	# Attack's case: a Normal-type move matches no target type at all.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.BODY_SLAM_ALWAYS_PARALYZES]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.PARALYSIS, "an Electric-type is still paralysed")
+
+
+func test_a_poison_type_is_not_poisoned_by_anything() -> void:
+	# `CheckIfTargetIsPoisonType` compares the target against POISON itself
+	# rather than against the move's type, so it refuses whatever the move is.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SLUDGE_BOMB_ALWAYS_POISONS]),
+		_mon(Fixture.BULBASAUR, 50, [Fixture.GROWL])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.NONE, "Bulbasaur is Grass/Poison")
+
+
+func test_a_non_poison_type_is_still_poisoned() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.SLUDGE_BOMB_ALWAYS_POISONS]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.POISON)
+
+
+func test_a_poison_type_is_not_badly_poisoned_either() -> void:
+	# Toxic is `BattleCommand_Poison` with a different tail, so the same
+	# `CheckIfTargetIsPoisonType` refuses it.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TOXIC]),
+		_mon(Fixture.BULBASAUR, 50, [Fixture.GROWL])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.enemy.status, Gen2Status.NONE)
+	assert_eq(battle.enemy.toxic_counter, 0)
+
+
+func test_a_burn_move_defrosts_a_frozen_target_instead_of_burning_it() -> void:
+	# `BattleCommand_BurnTarget`'s `jp nz, Defrost`: the target already carries a
+	# status, so the burn cannot land, and a freeze is cleared rather than kept.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.EMBER_BURNS]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	battle.enemy.status = Gen2Status.FREEZE
+	var events: Array = battle.take_turn(0, 0)
+	var thawed: Dictionary = _first(events, Gen2Battle.THAWED)
+	assert_false(thawed.is_empty(), "the target was defrosted")
+	assert_eq(int(thawed["side"]), Gen2Battle.ENEMY, "the target, not the user")
+	assert_eq(battle.enemy.status, Gen2Status.NONE, "and not burned either")
+
+
+func test_a_burn_move_leaves_any_other_status_on_the_target() -> void:
+	# `Defrost`'s own `and 1 << FRZ / ret z`: only a freeze is cleared.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.EMBER_BURNS]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+	battle.enemy.status = Gen2Status.PARALYSIS
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.THAWED).size(), 0)
+	assert_eq(battle.enemy.status, Gen2Status.PARALYSIS)
 
 
 func test_a_burn_takes_an_eighth_at_the_end_of_the_turn() -> void:

--- a/tests/unit/test_battle_animation_commands.gd
+++ b/tests/unit/test_battle_animation_commands.gd
@@ -28,13 +28,25 @@ func after_each() -> void:
 	RomCache.clear(_directory)
 
 
-func _battle(player_moves: Array, enemy_moves: Array = [Fixture.TACKLE]) -> Gen2Battle:
+## Charmander is the default target, and is Fire/Fire. A burn test has to name
+## another: `CheckMoveTypeMatchesTarget` refuses to burn a target that shares the
+## move's type, so Ember cannot burn a Charmander at all. Geodude is Rock/Ground
+## and can be burned, frozen or poisoned by anything here.
+func _battle(
+	player_moves: Array, enemy_moves: Array = [Fixture.TACKLE],
+	enemy_species: int = Fixture.CHARMANDER
+) -> Gen2Battle:
 	return Gen2Battle.create(
 		_data,
 		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, player_moves),
-		Gen2BattleMon.create(_data, Fixture.CHARMANDER, 50, enemy_moves),
+		Gen2BattleMon.create(_data, enemy_species, 50, enemy_moves),
 		_rng
 	)
+
+
+## The default battle with a target nothing here is immune to.
+func _burnable_battle(player_moves: Array) -> Gen2Battle:
+	return _battle(player_moves, [Fixture.TACKLE], Fixture.GEODUDE)
 
 
 func _run_move(battle: Gen2Battle, move_number: int, side: int = Gen2Battle.PLAYER) -> Array:
@@ -159,7 +171,7 @@ func test_a_secondary_status_does_not_play_the_move_a_second_time() -> void:
 	# `BattleCommand_BurnTarget` has no `AnimateCurrentMove`: the move that
 	# carried it played its own `moveanim` already. What follows it is the status
 	# animation, not the move again.
-	var events: Array = _run_move(_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
+	var events: Array = _run_move(_burnable_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
 	var animations: Array = _animations(events)
 	assert_eq(animations.size(), 2)
 	assert_eq(int(animations[0]["index"]), Fixture.EMBER_BURNS)
@@ -216,7 +228,9 @@ func test_each_secondary_status_plays_its_own_animation_on_the_target() -> void:
 		Fixture.BODY_SLAM_ALWAYS_PARALYZES: Gen2BattleAnimPlayer.ANIM_PAR,
 	}
 	for move: int in expected:
-		var events: Array = _run_move(_battle([move]), move)
+		# Geodude for all four: Rock/Ground shares a type with none of these
+		# moves and is not Poison-type, so no status here is refused outright.
+		var events: Array = _run_move(_burnable_battle([move]), move)
 		var animations: Array = _animations(events)
 		assert_eq(animations.size(), 2, "move %d plays its own and the status's" % move)
 		assert_eq(int(animations[1]["index"]), int(expected[move]))
@@ -232,7 +246,7 @@ func test_a_status_animation_plays_on_the_target_rather_than_the_user() -> void:
 	# The two `BattleCommand_SwitchTurn` calls `PlayOpponentBattleAnim` wraps
 	# `PlayBattleAnim` in: `hBattleTurn` is inverted for its length.
 	var player: Array = _animations(
-		_run_move(_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
+		_run_move(_burnable_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
 	)
 	assert_false(bool(player[0]["enemy_turn"]), "the move plays on the user")
 	assert_true(bool(player[1]["enemy_turn"]), "the status plays on the target")
@@ -247,7 +261,7 @@ func test_a_status_animation_plays_on_the_target_rather_than_the_user() -> void:
 
 func test_a_status_animation_runs_before_the_line_that_reports_it() -> void:
 	# `PlayOpponentBattleAnim`, `RefreshBattleHuds`, then `StdBattleTextbox`.
-	var events: Array = _run_move(_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
+	var events: Array = _run_move(_burnable_battle([Fixture.EMBER_BURNS]), Fixture.EMBER_BURNS)
 	var animations: Array = _animations(events)
 	assert_eq(animations.size(), 2)
 	assert_lt(
@@ -320,7 +334,7 @@ func test_a_freeze_refused_by_the_sun_plays_nothing() -> void:
 
 
 func test_a_status_refused_by_one_already_there_plays_nothing() -> void:
-	var battle: Gen2Battle = _battle([Fixture.EMBER_BURNS])
+	var battle: Gen2Battle = _burnable_battle([Fixture.EMBER_BURNS])
 	battle.enemy.status = Gen2Status.PARALYSIS
 	assert_eq(_animations(_run_move(battle, Fixture.EMBER_BURNS)).size(), 1)
 
@@ -328,7 +342,7 @@ func test_a_status_refused_by_one_already_there_plays_nothing() -> void:
 func test_a_status_animation_carries_the_param_the_move_left() -> void:
 	# `PlayOpponentBattleAnim` never writes `wBattleAnimParam`, so the status
 	# animation reads whatever the move's own animation put there.
-	var battle: Gen2Battle = _battle([Fixture.EMBER_BURNS])
+	var battle: Gen2Battle = _burnable_battle([Fixture.EMBER_BURNS])
 	battle.battle_anim_param = 1
 	var animations: Array = _animations(_run_move(battle, Fixture.EMBER_BURNS))
 	assert_eq(int(animations[0]["param"]), 0, "moveanim clears it")

--- a/tests/unit/test_status.gd
+++ b/tests/unit/test_status.gd
@@ -87,6 +87,25 @@ func test_full_paralysis_is_about_a_quarter_of_the_time() -> void:
 	assert_between(stopped, 400, 600, "64 in 256, which is a quarter")
 
 
+func test_thawing_is_about_a_tenth_of_the_time() -> void:
+	var thawed: int = 0
+	for _roll: int in 2000:
+		if Gen2Status.rolls_thaw(_rng):
+			thawed += 1
+	assert_between(thawed, 130, 260, "25 in 256, just under a tenth")
+
+
+func test_the_thaw_chance_is_the_truncated_percent_macro() -> void:
+	# `cp 10 percent`, and `percent` is `* $ff / 100` (macros/data.asm): 2550/100
+	# truncates to 25. So the roll is 25 out of 256, a shade under a tenth rather
+	# than the 26 a rounded tenth of the range would give.
+	assert_eq(Gen2Status.THAW_CHANCE, 25)
+	assert_lt(
+		float(Gen2Status.THAW_CHANCE) / Gen2Status.CHANCE_RANGE, 0.1,
+		"under a tenth, not over"
+	)
+
+
 func test_the_name_of_a_status_is_what_is_on_it() -> void:
 	assert_eq(Gen2Status.name_of(Gen2Status.BURN), &"burn")
 	assert_eq(Gen2Status.name_of(Gen2Status.POISON), &"poison")


### PR DESCRIPTION
The five status commands were missing three of the checks the source runs and one whole routine behind them.

HandleDefrost never existed, so a freeze lasted until a Flame Wheel, a Sacred Fire or an item, which is Generation 1's rule. Each frozen side now rolls 25 in 256 at the end of a turn, between HandleMysteryberry and HandleHealingItems. 25 and not 26, since percent is `* $ff / 100` and ten of them truncate. wPlayerJustGotFrozen and wEnemyJustGotFrozen stop a Pokemon frozen this turn from thawing on the same turn, and are cleared at the top of every turn. Nothing is rolled for a side that is not frozen, because bit FRZ comes before BattleRandom, so no existing roll moved.

CheckIfTargetIsPoisonType and CheckMoveTypeMatchesTarget had no counterpart, so a Fire-type burned, an Ice-type froze and a Poison-type poisoned. The first compares the target against POISON itself and gates Toxic as well, since Toxic is BattleCommand_Poison with a different tail; the second compares the move's type against the target's two and returns early for a Normal-type move, which is why Tri Attack still burns and freezes anything. Sleep and paralysis ask neither.

BurnTarget's `jp nz, Defrost` thaws a frozen target rather than returning, and sits in front of wEffectFailed, so a burn whose roll failed still defrosts. That is why the checks are now in the commands' own order with the chance last. Only a freeze is cleared; any other status stays.

THAWED carries whichever side thawed and now reads the cartridge's own "was defrosted!" rather than an invented line.