### PR TITLE
Walk Gold and Silver as far as the Plain Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Headless tools, all against a real imported cache:
 | `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
+| `validate_story_map_ids.gd` | the four maps the story route names by id rather than by cell, each against the map its number holds on the other profile, in all three games |
 | `validate_crystal_route30_trainer.gd` | trainer record, sight line, approach, battle request, beaten flag, later interaction |
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |
 | `validate_side_walls.gd` | the side-wall/side-buoy codes, their face masks and map census, in both games; Celadon Mansion Roof's fence and staircase landings on Crystal |

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -820,6 +820,22 @@ const EVENT_TELEPORT_GUY: int = 1916
 const EVENT_RIVAL_SPROUT_TOWER: int = 1732
 const EVENT_RED_IN_MT_SILVER: int = 1890
 
+## Maps this walk names by id rather than by cell, where the two profiles
+## disagree (`constants/map_constants.asm`). A map number counts from its
+## group's first entry, so a map pokegold does not ship shifts every later
+## number in that group: group 3 runs eight lower from `UNION_CAVE_1F` on,
+## because pokecrystal inserts eight Ruins of Alph word and item rooms, and
+## group 11 shifts around `GOLDENROD_POKECENTER_1F` and the absent
+## `GOLDENROD_DEPT_STORE_ROOF`. Only the ids this walk resolves are listed;
+## everything else it reaches is found by the cell it stands on, which no
+## renumbering moves.
+const MAP_IDS: Dictionary = {
+	&"ILEX_FOREST": {&"crystal": Vector2i(3, 52), &"gold": Vector2i(3, 44)},
+	&"MAHOGANY_MART_1F": {&"crystal": Vector2i(3, 48), &"gold": Vector2i(3, 40)},
+	&"TEAM_ROCKET_BASE_B2F": {&"crystal": Vector2i(3, 50), &"gold": Vector2i(3, 42)},
+	&"TEAM_ROCKET_BASE_B3F": {&"crystal": Vector2i(3, 51), &"gold": Vector2i(3, 43)},
+}
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
@@ -1946,7 +1962,8 @@ func _plain_badge_path(
 	var _gate_entry: Dictionary = _drain_story(
 		world, world.dispatch_map_entry(), save, random, data
 	)
-	var forest: Dictionary = _warp_step(world, 3, 52)
+	var ilex: Vector2i = _map_id(data, &"ILEX_FOREST")
+	var forest: Dictionary = _warp_step(world, ilex.x, ilex.y)
 	if not bool(forest.get("ok", false)):
 		return {"ok": false, "path": path, "reason": "Ilex Forest warp failed"}
 	var forest_entry: Dictionary = _drain_story(
@@ -2780,6 +2797,9 @@ func _glacier_badge_path(
 	data: GameData,
 	path: Array,
 ) -> Dictionary:
+	var mahogany_mart: Vector2i = _map_id(data, &"MAHOGANY_MART_1F")
+	var rocket_b2f: Vector2i = _map_id(data, &"TEAM_ROCKET_BASE_B2F")
+	var rocket_b3f: Vector2i = _map_id(data, &"TEAM_ROCKET_BASE_B3F")
 	var leaving_gym: Dictionary = _warp_step(world, 1, 14)
 	if not bool(leaving_gym.get("ok", false)):
 		return {"ok": false, "path": path, "reason": "Olivine Gym exit warp failed"}
@@ -2959,7 +2979,7 @@ func _glacier_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": lance.get("run", {}),
-		"mart_scene": world.state.map_scene(3, 48),
+		"mart_scene": world.state.map_scene(mahogany_mart.x, mahogany_mart.y),
 	})
 	if not bool(lance.get("ok", false)):
 		return {
@@ -3055,7 +3075,7 @@ func _glacier_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"encounters": heal.get("encounters", []),
-		"scene": world.state.map_scene(3, 50),
+		"scene": world.state.map_scene(rocket_b2f.x, rocket_b2f.y),
 	})
 	if not bool(heal.get("ok", false)):
 		return {
@@ -3081,7 +3101,7 @@ func _glacier_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": password_scene,
-		"scene": world.state.map_scene(3, 51),
+		"scene": world.state.map_scene(rocket_b3f.x, rocket_b3f.y),
 	})
 	if not bool(password_scene.get("terminal", false)):
 		return {
@@ -3151,7 +3171,7 @@ func _glacier_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"encounters": rival.get("encounters", []),
-		"scene": world.state.map_scene(3, 51),
+		"scene": world.state.map_scene(rocket_b3f.x, rocket_b3f.y),
 	})
 	if not bool(rival.get("ok", false)):
 		return {
@@ -3180,7 +3200,7 @@ func _glacier_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"encounters": executive.get("encounters", []),
-		"scene": world.state.map_scene(3, 51),
+		"scene": world.state.map_scene(rocket_b3f.x, rocket_b3f.y),
 	})
 	if not bool(executive.get("ok", false)):
 		return {
@@ -3245,13 +3265,13 @@ func _glacier_badge_path(
 	# electrodes, so the walk is expected not to reach its own target: what says
 	# the executive happened is the scene moving on.
 	var boss_f: Dictionary = _walk_cell_resolving(world, Vector2i(14, 11), save, random, data)
-	var electrodes_armed: bool = world.state.map_scene(3, 50) == 2
+	var electrodes_armed: bool = world.state.map_scene(rocket_b2f.x, rocket_b2f.y) == 2
 	path.append({
 		"step": "rocket_base_b2f_executive",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"encounters": boss_f.get("encounters", []),
-		"scene": world.state.map_scene(3, 50),
+		"scene": world.state.map_scene(rocket_b2f.x, rocket_b2f.y),
 	})
 	if not electrodes_armed:
 		return {
@@ -9412,6 +9432,12 @@ func _walk_cell_resolving(
 				"details": run.get("reason", ""),
 			}
 	return {"ok": false, "reason": "walk to %s did not settle" % target, "encounters": runs}
+
+
+## The [constant MAP_IDS] row for [param name] on this cartridge's profile.
+func _map_id(data: GameData, name: StringName) -> Vector2i:
+	var row: Dictionary = MAP_IDS[name]
+	return row[&"crystal"] if Gen2WorldState.is_crystal_profile(data) else row[&"gold"]
 
 
 func _warp_to(map: Gen2WorldMap, group: int, number: int) -> Dictionary:

--- a/tools/validate_story_map_ids.gd
+++ b/tools/validate_story_map_ids.gd
@@ -1,0 +1,119 @@
+extends SceneTree
+
+## Verifies the profile map ids `tools/preview_world_story.gd` resolves by name
+## against freshly imported real caches, for both command profiles.
+##
+## A map number counts from its group's first entry, so a map pokegold does not
+## ship shifts every later number in that group: group 3 runs eight lower from
+## UNION_CAVE_1F on, because pokecrystal inserts eight Ruins of Alph word and
+## item rooms (constants/map_constants.asm). The route walker names only the
+## maps it reaches by id rather than by cell, and only Ilex Forest is on a
+## walked leg today; the other three are read by the Mahogany and Rocket Base
+## legs, which no Gold walk reaches yet, so a wrong number there would be
+## silent. That is what this file is for.
+##
+## Each row carries the map's own block dimensions from its `map_const`, which
+## is what makes a wrong number loud: every number in this table resolves to a
+## differently sized map on the other profile.
+##
+##   Godot --headless --path . -s res://tools/validate_story_map_ids.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## name: [crystal id, gold id, block width, block height]. The dimensions are
+## the same on both profiles; only the number moves.
+const MAP_IDS: Dictionary = {
+	&"ILEX_FOREST": [Vector2i(3, 52), Vector2i(3, 44), 15, 27],
+	&"MAHOGANY_MART_1F": [Vector2i(3, 48), Vector2i(3, 40), 4, 4],
+	&"TEAM_ROCKET_BASE_B2F": [Vector2i(3, 50), Vector2i(3, 42), 15, 9],
+	&"TEAM_ROCKET_BASE_B3F": [Vector2i(3, 51), Vector2i(3, 43), 15, 9],
+}
+
+## What the wrong profile's number resolves to on this cartridge, pinned so the
+## split is proved rather than assumed: a wrong number is a wrong map, not a
+## missing one, and would otherwise read a scene off whatever sits there.
+## name: [dimensions on a Gold or Silver cache, dimensions on a Crystal cache].
+const WRONG_PROFILE_MAPS: Dictionary = {
+	# MOUNT_MORTAR_B1F on Gold and Silver, OLIVINE_LIGHTHOUSE_3F on Crystal
+	&"ILEX_FOREST": [Vector2i(20, 18), Vector2i(10, 9)],
+	# GOLDENROD_UNDERGROUND_WAREHOUSE, SLOWPOKE_WELL_B1F
+	&"MAHOGANY_MART_1F": [Vector2i(10, 9), Vector2i(10, 9)],
+	# MOUNT_MORTAR_1F_INSIDE, OLIVINE_LIGHTHOUSE_1F
+	&"TEAM_ROCKET_BASE_B2F": [Vector2i(20, 27), Vector2i(10, 9)],
+	# MOUNT_MORTAR_2F_INSIDE, OLIVINE_LIGHTHOUSE_2F
+	&"TEAM_ROCKET_BASE_B3F": [Vector2i(20, 18), Vector2i(10, 9)],
+}
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		for name: StringName in MAP_IDS:
+			_verify_row(game_id, data, crystal, name)
+	_finish()
+
+
+func _verify_row(
+	game_id: StringName, data: GameData, crystal: bool, name: StringName
+) -> void:
+	var row: Array = MAP_IDS[name]
+	var id: Vector2i = row[0] if crystal else row[1]
+	var other: Vector2i = row[1] if crystal else row[0]
+	var map: Gen2WorldMap = data.world_map(id.x, id.y)
+	if not _check(
+		map != null, "%s: %s is missing at %d/%d." % [game_id, name, id.x, id.y]
+	):
+		return
+	_check(
+		map.width_blocks == int(row[2]) and map.height_blocks == int(row[3]),
+		"%s: %s at %d/%d is %dx%d blocks, not the pinned %dx%d." % [
+			game_id, name, id.x, id.y,
+			map.width_blocks, map.height_blocks, int(row[2]), int(row[3]),
+		]
+	)
+	## The other profile's number has to resolve to the pinned other map, which
+	## is what proves the split rather than merely asserting one exists.
+	var wrong: Gen2WorldMap = data.world_map(other.x, other.y)
+	var expected: Vector2i = WRONG_PROFILE_MAPS[name][1 if crystal else 0]
+	if not _check(
+		wrong != null,
+		"%s: %d/%d, which is %s on the other profile, is missing." % [
+			game_id, other.x, other.y, name,
+		]
+	):
+		return
+	_check(
+		Vector2i(wrong.width_blocks, wrong.height_blocks) == expected,
+		"%s: %d/%d is %dx%d blocks, not the %dx%d the other profile's %s number holds." % [
+			game_id, other.x, other.y,
+			wrong.width_blocks, wrong.height_blocks, expected.x, expected.y, name,
+		]
+	)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS story map ids: %d rows verified on %d caches." % [
+			MAP_IDS.size(), GAME_IDS.size(),
+		])
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_story_map_ids.gd.uid
+++ b/tools/validate_story_map_ids.gd.uid
@@ -1,0 +1,1 @@
+uid://c4ur2xoaq2n4v


### PR DESCRIPTION
A map number counts from its group's first entry, so a map pokegold does not ship shifts every later number in that group: group 3 runs eight lower from UNION_CAVE_1F on, because pokecrystal inserts eight Ruins of Alph word and item rooms, and group 11 shifts around GOLDENROD_POKECENTER_1F and the absent GOLDENROD_DEPT_STORE_ROOF. Sixty-seven maps move.

The story walk finds almost everything by the cell it stands on, which no renumbering touches, so this cost it exactly one step: the warp into Ilex Forest, which it asked for by id. MAP_IDS now owns the four maps it names that way, and validate_story_map_ids.gd pins each of them against the map its number holds on the other profile, since the three Mahogany and Rocket Base reads are on a leg no Gold walk reaches yet and a wrong number there would be silent.

Gold and Silver now run 69 steps, identical to each other, through Ilex Forest, Goldenrod and the Plain Badge, and stop at Route 36's Floria, who is Crystal-only. Crystal's own run is unchanged, byte for byte.