### PR TITLE
Walk Gold and Silver to Red

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   entry, and replace the world or battle renderer, which is what a 3D or HD
 >   view needs.
 >
-> The real-data story preview walks the Crystal route from Elm's lab through
+> The real-data story preview walks all three cartridges from Elm's lab through
 > Route 29, Cherrygrove, Route 30 and Mr. Pokémon's Mystery Egg event to the
 > Zephyr Badge, then on through the Togepi egg, Route 32, Union Cave, Route 33,
 > Kurt and Slowpoke Well to the Hive Badge, and through Ilex Forest's Farfetch'd
@@ -63,8 +63,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > Red Gyarados and Lance, the Rocket hideout's three floors and Pryce to the
 > Glacier Badge, back west for the Goldenrod Radio Tower's basement and card
 > keys and its Rocket boss, then Route 44 and the Ice Path to Blackthorn, its
-> gym's boulder puzzle and Clair, and the Dragon Shrine's quiz for the Rising
-> Badge.
+> gym's boulder puzzle and Clair, and the Rising Badge: the Dragon Shrine's quiz
+> on Crystal, the Dragon's Den ball Clair follows you to on Gold and Silver.
+> Kanto follows, all sixteen badges and Red on Mt. Silver.
 > Missing: full story state, the dex, the remaining special-call branches and
 > story-driven permanent contacts.
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -862,6 +862,11 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 				int(_request.get("map_group", 0)), int(_request.get("map_number", 0))
 			)
 			_staged_scenes[map_key] = int(command["scene"])
+		Gen2WorldScript.CHECKVER:
+			## Script_checkver answers GS_VERSION, which
+			## `constants/misc_constants.asm` defines as 0 for Gold and 1 for
+			## Silver; pokecrystal defines it 0 unconditionally.
+			_script_value = 1 if data != null and data.id == &"silver" else 0
 		Gen2WorldScript.SETVAL:
 			_script_value = int(command["value"])
 		Gen2WorldScript.ADDVAL:
@@ -1037,6 +1042,7 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 	var handled_base: Array = [
 		Gen2WorldScript.CHECKMAPSCENE, Gen2WorldScript.SETMAPSCENE,
 		Gen2WorldScript.CHECKSCENE, Gen2WorldScript.SETSCENE,
+		Gen2WorldScript.CHECKVER,
 		Gen2WorldScript.SETVAL, Gen2WorldScript.ADDVAL, Gen2WorldScript.RANDOM,
 		Gen2WorldScript.CHECKEVENT, Gen2WorldScript.CLEAREVENT, Gen2WorldScript.SETEVENT,
 		Gen2WorldScript.CHECKFLAG, Gen2WorldScript.CLEARFLAG, Gen2WorldScript.SETFLAG,

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -28,6 +28,9 @@ const TEMPORARY_MAP_RELOAD_FLAGS: Array[int] = [0, 1, 2, 3, 4, 5, 6, 7]
 ## lower there.
 const ENGINE_CREDITS_SKIP: int = 15
 const ENGINE_HALL_OF_FAME: int = ENGINE_CREDITS_SKIP
+## The one entry pokegold does not ship, and so the index every profile split in
+## this table is measured from. See engine_flag().
+const ENGINE_MOBILE_SYSTEM: int = 16
 ## The three wPokegearFlags/wStatusFlags bits the radio card reads
 ## (data/events/engine_flags.asm). Only the last is profile split, since it sits
 ## in the wStatusFlags2 run after Crystal's extra entry.
@@ -361,6 +364,19 @@ func bargain_merchant_closed(crystal: bool = true) -> bool:
 static func badge_flag(badge: int, crystal: bool = true) -> int:
 	var flags: Array[int] = BADGE_ENGINE_FLAGS if crystal else BADGE_ENGINE_FLAGS_GOLD_SILVER
 	return flags[badge] if badge >= 0 and badge < flags.size() else -1
+
+
+## [param crystal_index] resolved onto the table [param crystal] selects. The
+## two tables differ only in that pokegold ships no ENGINE_MOBILE_SYSTEM, so
+## everything past that one index sits one lower there. The named pairs above
+## are this same shift written out for the flags a runtime path reads; a caller
+## holding a Crystal index and no pair asks here. ENGINE_MOBILE_SYSTEM itself
+## answers -1 off Crystal, which is_engine_flag_active() reads as inactive,
+## since Gold and Silver have no flag to map it onto.
+static func engine_flag(crystal_index: int, crystal: bool = true) -> int:
+	if crystal or crystal_index < ENGINE_MOBILE_SYSTEM:
+		return crystal_index
+	return crystal_index - 1 if crystal_index > ENGINE_MOBILE_SYSTEM else -1
 
 
 ## The engine flag SetStrengthFlag sets and TryStrengthOW and

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -4072,10 +4072,12 @@ func _lake_crossing(
 
 ## Blackthorn City to the Rising Badge, on the same world, state and save.
 ##
-## The badge is not Clair's. `BlackthornGymClairScript` sets only
+## The badge is not won in the gym. `BlackthornGymClairScript` sets only
 ## `EVENT_BEAT_CLAIR` and swaps the two Blackthorn gramps so the Dragon's Den
-## door at (20,1) opens; `maps/DragonShrine.asm` is what runs
-## `setflag ENGINE_RISINGBADGE`, at the end of the elder's five-question quiz.
+## door at (20,1) opens. `maps/DragonShrine.asm` is what runs
+## `setflag ENGINE_RISINGBADGE` on Crystal, at the end of the elder's
+## five-question quiz; Gold and Silver have no shrine and put the same line in
+## `DragonsDenB1FDragonFangScript` (`maps/DragonsDenB1F.asm`).
 ##
 ## Appends to [param path] and answers only ok or the failure.
 func _rising_badge_path(
@@ -4274,6 +4276,9 @@ func _dragon_shrine_leg(
 			"reason": "Dragon's Den B1F unreachable: %s" % to_den.get("reason", ""),
 		}
 
+	if not Gen2WorldState.is_crystal_profile(data):
+		return _dragons_den_dragon_fang(world, save, random, data, path)
+
 	# B1F is a lake with the shrine on its far shore: the ladder's own land
 	# region has 271 cells and none of them touch the shrine, whose only landfall
 	# from the water is (14,31). The whirlpool on (10,20) sits in the way.
@@ -4347,6 +4352,92 @@ func _dragon_shrine_leg(
 	return {"ok": true}
 
 
+## Dragon's Den B1F's DRAGON_FANG ball, which is where Gold and Silver keep the
+## Rising Badge.
+##
+## pokegold ships no DRAGON_SHRINE map: `maps/DragonsDenB1F.asm` has one warp
+## rather than two and no coord event, and blocks (7..11, 13..15) of its `.blk`
+## wall the shrine mouth off, which is the whole difference between the two
+## grids. `DragonsDenB1FDragonFangScript` is the errand instead: the ball on
+## (35,16) gives the fang, then Clair walks in, runs `setflag ENGINE_RISINGBADGE`
+## and hands over TM24 in the same conversation Crystal splits between the elder
+## and a later coord event.
+##
+## The ball's land strip is (34..35, 16..21) and touches no other land, so the
+## lake is the only way onto it and (34,22) is its one shore: the water west of
+## the strip is a pocket of its own, sealed off by the COLL_BUOY column on
+## (30, 16..19), which `data/collision/collision_permissions.asm` gives
+## WALL_TILE. The whirlpool on (10,20) is on this route as much as on Crystal's,
+## since it is the only cell joining the ladder's own lake to the southern one.
+func _dragons_den_dragon_fang(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	random: RandomNumberGenerator,
+	data: GameData,
+	path: Array,
+) -> Dictionary:
+	var entered: Dictionary = _surf_at(
+		world, Vector2i(10, 7), Gen2WorldSprite.FACING_DOWN, save, random, data
+	)
+	if not bool(entered.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den surf entry failed: %s" % entered.get("reason", ""),
+		}
+	var cleared: Dictionary = _whirlpool_at(
+		world, Vector2i(10, 19), Gen2WorldSprite.FACING_DOWN, save, random, data
+	)
+	path.append({
+		"step": "dragons_den_whirlpool",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": cleared,
+	})
+	if not bool(cleared.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den whirlpool failed: %s" % cleared.get("reason", ""),
+		}
+	var crossing: Dictionary = _walk_cell_resolving(
+		world, Vector2i(34, 21), save, random, data, true
+	)
+	path.append({
+		"step": "dragons_den_crossing",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"movement_mode": String(world.movement_mode),
+	})
+	if not bool(crossing.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Dragon's Den crossing failed: %s" % crossing.get("reason", ""),
+		}
+
+	# Faced from the west, so `readvar VAR_FACING` takes the script's RIGHT
+	# branch and Clair walks up the strip from (34,21) rather than (35,22).
+	var fang: Dictionary = _talk_to(
+		world, Vector2i(34, 16), Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	path.append({
+		"step": "dragons_den_dragon_fang",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": fang.get("run", {}),
+		"badge_count": world.state.badge_count(false),
+		"items": _named_items(data, world.state.items()),
+	})
+	if not bool(fang.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "the Dragon Fang handoff failed: %s" % fang.get("reason", ""),
+		}
+	if not world.state.is_engine_flag_active(
+		Gen2WorldState.badge_flag(BADGE_RISING, false)
+	):
+		return {"ok": false, "path": path, "reason": "the Rising Badge was not given"}
+	return {"ok": true}
+
+
 ## The Dragon Shrine to Indigo Plateau, on the same world, state and save.
 ##
 ## `VictoryRoadGate`'s coord event at (10,11) is a `readvar VAR_BADGES` against
@@ -4387,12 +4478,13 @@ func _kanto_approach_path(
 	return _elite_four_leg(world, save, random, data, path)
 
 
-## The Dragon Shrine back to New Bark Town.
+## The Dragon's Den back to New Bark Town.
 ##
-## The way out of the den is the way in reversed, and the whirlpool with it:
-## `complete_whirlpool()` is a transient block override, so the warp to the
-## shrine restored (10,20) and the water south of it reaches the shrine's
-## landfall and nothing else.
+## The way out is the way in reversed. Crystal clears the whirlpool twice:
+## `complete_whirlpool()` is a transient block override, so the warp into the
+## shrine restored (10,20), and the water south of it reaches the shrine's
+## landfall and nothing else. Gold and Silver enter no map in between, so their
+## first clear still holds.
 ##
 ## Blackthorn's own exit is south, not west: Route 45 into Route 46 into the
 ## Route 29 gate. Route 46 is walked downhill only. Its ledges leave the region
@@ -4406,34 +4498,39 @@ func _blackthorn_departure(
 	data: GameData,
 	path: Array,
 ) -> Dictionary:
-	var to_den: Dictionary = _warp_chain(world, save, random, data, [Vector2i(4, 9)])
-	if not bool(to_den.get("ok", false)):
-		return {
-			"ok": false, "path": path,
-			"reason": "Dragon Shrine exit failed: %s" % to_den.get("reason", ""),
-		}
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	if crystal:
+		var to_den: Dictionary = _warp_chain(world, save, random, data, [Vector2i(4, 9)])
+		if not bool(to_den.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Dragon Shrine exit failed: %s" % to_den.get("reason", ""),
+			}
 
-	# The shrine armed SCENE_DRAGONSDENB1F_CLAIR_GIVES_TM (maps/DragonShrine.asm),
-	# so B1F's coord event at (19,30), one cell below the warp back, is Clair's
-	# TM24 gift. It is on the way out whether or not the walk asks for it.
-	var clair_tm: Dictionary = _walk_cell_resolving(
-		world, Vector2i(19, 30), save, random, data
-	)
-	path.append({
-		"step": "dragons_den_clair_tm",
-		"map": _map_value(world),
-		"cell": _cell_value(world),
-		"encounters": clair_tm.get("encounters", []),
-		"items": _named_items(data, world.state.items()),
-	})
-	if not bool(clair_tm.get("ok", false)):
-		return {
-			"ok": false, "path": path,
-			"reason": "Clair's TM scene failed: %s" % clair_tm.get("reason", ""),
-		}
+		# The shrine armed SCENE_DRAGONSDENB1F_CLAIR_GIVES_TM
+		# (maps/DragonShrine.asm), so B1F's coord event at (19,30), one cell below
+		# the warp back, is Clair's TM24 gift. It is on the way out whether or not
+		# the walk asks for it. Gold and Silver spent both on the Dragon Fang ball.
+		var clair_tm: Dictionary = _walk_cell_resolving(
+			world, Vector2i(19, 30), save, random, data
+		)
+		path.append({
+			"step": "dragons_den_clair_tm",
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"encounters": clair_tm.get("encounters", []),
+			"items": _named_items(data, world.state.items()),
+		})
+		if not bool(clair_tm.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Clair's TM scene failed: %s" % clair_tm.get("reason", ""),
+			}
 
 	var entered: Dictionary = _surf_at(
-		world, Vector2i(14, 31), Gen2WorldSprite.FACING_LEFT, save, random, data
+		world, Vector2i(14, 31) if crystal else Vector2i(34, 21),
+		Gen2WorldSprite.FACING_LEFT if crystal else Gen2WorldSprite.FACING_DOWN,
+		save, random, data
 	)
 	if not bool(entered.get("ok", false)):
 		return {
@@ -4467,20 +4564,21 @@ func _blackthorn_departure(
 			"reason": "WATERFALL could not be taught: %s" % taught.get("reason", ""),
 		}
 
-	var cleared: Dictionary = _whirlpool_at(
-		world, Vector2i(10, 21), Gen2WorldSprite.FACING_UP, save, random, data
-	)
-	path.append({
-		"step": "dragons_den_whirlpool_return",
-		"map": _map_value(world),
-		"cell": _cell_value(world),
-		"run": cleared,
-	})
-	if not bool(cleared.get("ok", false)):
-		return {
-			"ok": false, "path": path,
-			"reason": "Dragon's Den return whirlpool failed: %s" % cleared.get("reason", ""),
-		}
+	if crystal:
+		var cleared: Dictionary = _whirlpool_at(
+			world, Vector2i(10, 21), Gen2WorldSprite.FACING_UP, save, random, data
+		)
+		path.append({
+			"step": "dragons_den_whirlpool_return",
+			"map": _map_value(world),
+			"cell": _cell_value(world),
+			"run": cleared,
+		})
+		if not bool(cleared.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "Dragon's Den return whirlpool failed: %s" % cleared.get("reason", ""),
+			}
 	var back_ashore: Dictionary = _walk_cell_resolving(
 		world, Vector2i(10, 7), save, random, data, true
 	)
@@ -4994,7 +5092,7 @@ func _victory_road_leg(
 		"cell": _cell_value(world),
 		"encounters": plateau.get("encounters", []),
 		"mt_moon_rival": world.event_flag_active(EVENT_BEAT_RIVAL_IN_MT_MOON),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_INDIGO_PLATEAU),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_INDIGO_PLATEAU),
 		"badge_count": world.state.badge_count(),
 	})
 	if not bool(plateau.get("ok", false)):
@@ -5002,7 +5100,7 @@ func _victory_road_leg(
 			"ok": false, "path": path,
 			"reason": "Indigo Plateau Pokemon Center failed: %s" % plateau.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_INDIGO_PLATEAU):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_INDIGO_PLATEAU):
 		return {"ok": false, "path": path, "reason": "the Indigo Plateau flypoint was not set"}
 	return {"ok": true}
 
@@ -5697,9 +5795,9 @@ func _thunder_badge_path(
 		"step": "vermilion_city",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_VERMILION),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_VERMILION),
 	})
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_VERMILION):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_VERMILION):
 		return {"ok": false, "path": path, "reason": "the city's flypoint callback did not run"}
 
 	var tree: Dictionary = _cut_at(
@@ -5806,14 +5904,14 @@ func _marsh_badge_path(
 		"step": "saffron_city",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_SAFFRON),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_SAFFRON),
 	})
 	if not bool(gate.get("ok", false)):
 		return {
 			"ok": false, "path": path,
 			"reason": "the Saffron gate failed: %s" % gate.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_SAFFRON):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_SAFFRON):
 		return {"ok": false, "path": path, "reason": "Saffron's flypoint callback did not run"}
 
 	return _saffron_gym_leg(world, save, random, data, path)
@@ -5946,7 +6044,7 @@ func _rainbow_badge_path(
 		"step": "celadon_city",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_CELADON),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_CELADON),
 		"encounters": westward.get("encounters", []),
 		"run": city_entry,
 	})
@@ -5955,7 +6053,7 @@ func _rainbow_badge_path(
 			"ok": false, "path": path,
 			"reason": "the walk west to Celadon failed: %s" % westward.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_CELADON):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_CELADON):
 		return {"ok": false, "path": path, "reason": "Celadon's flypoint callback did not run"}
 
 	return _celadon_gym_leg(world, save, random, data, path)
@@ -6101,7 +6199,7 @@ func _cerulean_approach_path(
 		"step": "cerulean_city",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_CERULEAN),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_CERULEAN),
 		"encounters": northward.get("encounters", []),
 		"run": city_entry,
 	})
@@ -6110,7 +6208,7 @@ func _cerulean_approach_path(
 			"ok": false, "path": path,
 			"reason": "the walk north to Cerulean failed: %s" % northward.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_CERULEAN):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_CERULEAN):
 		return {"ok": false, "path": path, "reason": "Cerulean's flypoint callback did not run"}
 	return _machine_part_errand(world, save, random, data, path)
 
@@ -6310,7 +6408,7 @@ func _lavender_leg(
 		"step": "lavender_town",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_LAVENDER),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_LAVENDER),
 		"encounters": eastward.get("encounters", []),
 		"run": town_entry,
 	})
@@ -6319,7 +6417,7 @@ func _lavender_leg(
 			"ok": false, "path": path,
 			"reason": "the walk east to Lavender failed: %s" % eastward.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_LAVENDER):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_LAVENDER):
 		return {"ok": false, "path": path, "reason": "Lavender's flypoint callback did not run"}
 
 	var into_tower: Dictionary = _warp_chain(
@@ -6717,7 +6815,7 @@ func _fuchsia_leg(
 		"step": "fuchsia_city",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_FUCHSIA),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_FUCHSIA),
 		"encounters": to_city.get("encounters", []),
 	})
 	if not bool(to_city.get("ok", false)):
@@ -6725,7 +6823,7 @@ func _fuchsia_leg(
 			"ok": false, "path": path,
 			"reason": "the Route 15 gate failed: %s" % to_city.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_FUCHSIA):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_FUCHSIA):
 		return {"ok": false, "path": path, "reason": "Fuchsia's flypoint callback did not run"}
 
 	var into_gym: Dictionary = _warp_chain(world, save, random, data, [FUCHSIA_GYM_DOOR])
@@ -6896,7 +6994,7 @@ func _pewter_leg(
 		"step": "pewter_city",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_PEWTER),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_PEWTER),
 		"encounters": to_pewter.get("encounters", []),
 		"run": pewter_entry,
 	})
@@ -6905,7 +7003,7 @@ func _pewter_leg(
 			"ok": false, "path": path,
 			"reason": "the walk to Pewter failed: %s" % to_pewter.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_PEWTER):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_PEWTER):
 		return {"ok": false, "path": path, "reason": "Pewter's flypoint callback did not run"}
 
 	return _pewter_gym_leg(world, save, random, data, path)
@@ -7060,7 +7158,7 @@ func _cinnabar_leg(
 			"run": entry,
 		}
 		if leg.has("flypoint"):
-			step["flypoint"] = world.state.is_engine_flag_active(int(leg["flypoint"]))
+			step["flypoint"] = _engine_flag_set(world, data, int(leg["flypoint"]))
 		path.append(step)
 		if not bool(walked.get("ok", false)):
 			return {
@@ -7068,7 +7166,7 @@ func _cinnabar_leg(
 				"reason": "the walk to %s failed: %s" % [leg["step"], walked.get("reason", "")],
 			}
 		if leg.has("flypoint") \
-			and not world.state.is_engine_flag_active(int(leg["flypoint"])):
+			and not _engine_flag_set(world, data, int(leg["flypoint"])):
 			return {
 				"ok": false, "path": path,
 				"reason": "%s's flypoint callback did not run" % leg["step"],
@@ -7120,7 +7218,7 @@ func _cinnabar_leg(
 			"ok": false, "path": path,
 			"reason": "landing on Cinnabar failed: %s" % ashore.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_CINNABAR):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_CINNABAR):
 		return {"ok": false, "path": path, "reason": "Cinnabar's flypoint callback did not run"}
 
 	var blue: Dictionary = _talk_to(
@@ -7130,7 +7228,7 @@ func _cinnabar_leg(
 		"step": "cinnabar_blue",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_CINNABAR),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_CINNABAR),
 		"viridian_gym_blue": world.event_flag_active(EVENT_VIRIDIAN_GYM_BLUE),
 		"encounters": blue.get("encounters", []),
 		"run": blue.get("run", {}),
@@ -7473,7 +7571,7 @@ func _mt_silver_leg(
 		"step": "silver_cave_outside",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"flypoint": world.state.is_engine_flag_active(ENGINE_FLYPOINT_SILVER_CAVE),
+		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_SILVER_CAVE),
 		"encounters": westbound.get("encounters", []),
 		"run": outside_entry,
 	})
@@ -7482,7 +7580,7 @@ func _mt_silver_leg(
 			"ok": false, "path": path,
 			"reason": "the walk onto Silver Cave Outside failed: %s" % westbound.get("reason", ""),
 		}
-	if not world.state.is_engine_flag_active(ENGINE_FLYPOINT_SILVER_CAVE):
+	if not _engine_flag_set(world, data, ENGINE_FLYPOINT_SILVER_CAVE):
 		return {
 			"ok": false, "path": path,
 			"reason": "SilverCaveOutsideFlypointCallback did not run",
@@ -9370,6 +9468,14 @@ func _reachable_step(
 	if direct != warp_target and not world.warp_at(direct).is_empty() \
 		and Gen2WorldCollision.is_warp_tile(world.collision_code_at(direct)):
 		return Vector2i(-1, -1)
+	# A whirlpool traps rather than moves: .CheckTile answers
+	# PLAYERMOVEMENT_FORCE_TURN for the cell the player stands on, so a plan that
+	# crosses one never leaves it. Dragon's Den B1F's (10,20) is the first cell on
+	# a walked route where the shortest path runs through one.
+	if direct != warp_target and StringName(Gen2WorldCollision.forced_action(
+		world.collision_code_at(direct)
+	).get("kind", &"none")) == &"force_turn":
+		return Vector2i(-1, -1)
 	# move_result() calls can_walk_to() with the direction, which reads the
 	# leave/enter wall mask at the player's own cell; from a BFS frontier that
 	# has to be anchored on the frontier cell instead, or the plan crosses walls
@@ -9571,6 +9677,16 @@ func _walk_cell_resolving(
 				"details": run.get("reason", ""),
 			}
 	return {"ok": false, "reason": "walk to %s did not settle" % target, "encounters": runs}
+
+
+## An engine flag named by its Crystal index, read on the profile's own table.
+## Every ENGINE_FLYPOINT_* constant here is a Crystal index and all of them sit
+## past ENGINE_MOBILE_SYSTEM, so on Gold and Silver every one of them is a cell
+## lower; `Gen2WorldState.engine_flag()` owns that shift.
+func _engine_flag_set(world: Gen2WorldAPI, data: GameData, crystal_index: int) -> bool:
+	return world.state.is_engine_flag_active(Gen2WorldState.engine_flag(
+		crystal_index, Gen2WorldState.is_crystal_profile(data)
+	))
 
 
 ## The [constant MAP_IDS] row for [param name] on this cartridge's profile.


### PR DESCRIPTION
checkver was the wall in the Radio Tower's boss script: Script_checkver answers GS_VERSION, 0 on Gold and Crystal and 1 on Silver, which is what gives the director a Rainbow Wing or a Silver Wing to hand over. It is decoded but was never executed, so the boss script failed after the fight.

The Rising Badge is the last differently shaped errand. pokegold ships no Dragon Shrine, so B1F has one warp rather than two and its .blk walls the shrine mouth off; DragonsDenB1FDragonFangScript on the (35,16) ball sets ENGINE_RISINGBADGE and gives TM24 in one conversation. Its land strip is reached only from the water at (34,22), the pocket west of it being sealed by a COLL_BUOY column, and the whirlpool on (10,20) gates both profiles.

Two smaller things came with it. Every ENGINE_FLYPOINT_* the walk reads was a Crystal index, and pokegold's table has no ENGINE_MOBILE_SYSTEM, so all twelve sat a cell high on the other profiles; Gen2WorldState.engine_flag() owns that shift now. And the walk's planner routed through a whirlpool, which .CheckTile answers with PLAYERMOVEMENT_FORCE_TURN, stranding the run.

Gold and Silver now reach Red in 289 steps against Crystal's 292, and differ from each other in the wing alone. Crystal's output is unchanged.