### PR TITLE
Walk downstairs to Mom instead of teleporting to her

### DIFF
--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1226,6 +1226,60 @@ func test_gold_profile_specials_normalize_onto_the_crystal_handlers() -> void:
 	RomCache.clear(gold_directory)
 
 
+## Script_checkver answers GS_VERSION into wScriptVar, which
+## constants/misc_constants.asm defines as 0 for Gold and 1 for Silver;
+## pokecrystal defines it 0 unconditionally. RadioTower5FRocketBossScript is the
+## one script on the walked route that reads it, and its `iftrue` is what
+## chooses the Silver Wing over the Rainbow Wing, so the two profiles have to
+## disagree here and Crystal has to answer with Gold. The opcode is $18 in both
+## pins, below raw_opcode()'s $52 shift, so only `end` is profile split.
+func test_checkver_answers_the_cartridges_own_gs_version() -> void:
+	var address: int = 0xD1D8
+	for row: Array in [
+		["gold", 0, "0f1e2d3c4b5a6978"],
+		["silver", 1, "69780f1e2d3c4b5a"],
+		["", 0, ""],
+	]:
+		var game_id: String = String(row[0])
+		var expected: int = int(row[1])
+		var crystal: bool = game_id.is_empty()
+		var directory: String = _directory
+		var saved_directory: String = _directory
+		if not crystal:
+			directory = RomCache.directory_for(
+				StringName("testworldver%s" % game_id), String(row[2])
+			)
+			RomCache.clear(directory)
+			RomCache.prepare(directory)
+			_directory = directory
+			_write_cache(game_id)
+			_directory = saved_directory
+
+		var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+		scripts["48:6B00"] = [
+			Gen2WorldScript.CHECKVER,
+			Gen2WorldScript.WRITEMEM, address & 0xFF, address >> 8,
+			Gen2WorldScript.END if crystal else Gen2WorldScript.GOLD_END,
+		]
+		RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+
+		var data: GameData = GameData.open_directory(directory)
+		var state := Gen2WorldState.new()
+		var runner := Gen2WorldScriptRunner.begin(data, state, {
+			"kind": &"test", "bank": 48, "script": 0x6B00,
+		})
+		var result: Dictionary = runner.advance()
+		assert_eq(result["status"], &"complete", JSON.stringify(result))
+		## Written rather than branched on, so the value itself is pinned: an
+		## `iftrue` would pass for any non-zero answer.
+		assert_eq(
+			state.script_memory(address), expected,
+			"checkver on %s" % (game_id if not crystal else "crystal"),
+		)
+		if not crystal:
+			RomCache.clear(directory)
+
+
 func test_fade_out_to_white_is_presentation_on_both_profiles() -> void:
 	# Slowpoke Well's cleared script runs FadeOutToWhite before HealParty
 	# (maps/SlowpokeWellB1F.asm, TrainerGruntM1). It is index 46 in both pins,

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -2,6 +2,11 @@ extends GutTest
 
 ## World state has a JSON-safe representation independent of the map cache.
 
+## ENGINE_FLYPOINT_VERMILION's Crystal index (constants/engine_flags.asm). Named
+## here rather than on Gen2WorldState because nothing in game/ reads a flypoint;
+## the story walk does, and it holds Crystal indices.
+const FLYPOINT_VERMILION: int = 58
+
 
 func test_world_state_round_trips_persistent_overworld_fields() -> void:
 	var state := Gen2WorldState.new(
@@ -164,6 +169,54 @@ func test_is_crystal_profile_matches_the_game_id_and_defaults_true_for_no_data()
 	var silver_data := GameData.new()
 	silver_data.id = &"silver"
 	assert_false(Gen2WorldState.is_crystal_profile(silver_data))
+
+
+## engine_flag() is the same one-index shift the named *_GOLD_SILVER constants
+## spell out, for a caller holding a Crystal index and no pair. The three named
+## pairs are what pin the shift's direction here: a derived answer that
+## disagreed with any of them would be wrong in the same way twice.
+func test_engine_flag_maps_a_crystal_index_onto_the_gold_silver_table() -> void:
+	for index: int in [0, 3, 4, 15, Gen2WorldState.ENGINE_MOBILE_SYSTEM - 1]:
+		assert_eq(Gen2WorldState.engine_flag(index, true), index)
+		assert_eq(Gen2WorldState.engine_flag(index, false), index)
+
+	## ENGINE_MOBILE_SYSTEM is the entry pokegold does not ship, so it maps onto
+	## nothing there; -1 is what is_engine_flag_active() reads as inactive.
+	assert_eq(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_MOBILE_SYSTEM, true),
+		Gen2WorldState.ENGINE_MOBILE_SYSTEM
+	)
+	assert_eq(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_MOBILE_SYSTEM, false), -1
+	)
+
+	for pair: Array in [
+		[Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER,
+			Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER_GOLD_SILVER],
+		[Gen2WorldState.ENGINE_STRENGTH_ACTIVE,
+			Gen2WorldState.ENGINE_STRENGTH_ACTIVE_GOLD_SILVER],
+		[Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED,
+			Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER],
+	]:
+		assert_eq(Gen2WorldState.engine_flag(pair[0], true), pair[0])
+		assert_eq(Gen2WorldState.engine_flag(pair[0], false), pair[1])
+
+	for badge: int in Gen2WorldState.BADGE_ENGINE_FLAGS.size():
+		assert_eq(
+			Gen2WorldState.engine_flag(Gen2WorldState.badge_flag(badge, true), false),
+			Gen2WorldState.badge_flag(badge, false)
+		)
+
+	## The read a caller actually makes: a Crystal index resolved on the Gold
+	## table must find a Gold write and miss a Crystal one.
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.engine_flag(FLYPOINT_VERMILION, false))
+	assert_true(state.is_engine_flag_active(
+		Gen2WorldState.engine_flag(FLYPOINT_VERMILION, false)
+	))
+	assert_false(state.is_engine_flag_active(
+		Gen2WorldState.engine_flag(FLYPOINT_VERMILION, true)
+	))
 
 
 func test_badge_flags_survive_round_trip_and_daily_or_map_reload_resets() -> void:

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -570,6 +570,9 @@ const LAVENDER_RADIO_TOWER_DOOR: Vector2i = Vector2i(14, 5)
 const LAVENDER_RADIO_TOWER_EXIT: Vector2i = Vector2i(2, 7)
 const RADIO_TOWER_GENTLEMAN_FACE: Vector2i = Vector2i(9, 2)
 const ENGINE_EXPN_CARD: int = 3
+## `MeetMomScript`'s own `setflag ENGINE_POKEGEAR`, four in both pins and so in
+## wPokegearFlags with the card above, which is what says the scene really ran.
+const ENGINE_POKEGEAR: int = 4
 
 ## Fuchsia City, four connected routes south of Lavender with one gate at the
 ## end (`data/maps/attributes.asm`, `maps/Route15.asm` warps 1 and 2 into
@@ -991,21 +994,36 @@ func _story_path(data: GameData) -> Dictionary:
 		return {"ok": false, "reason": "stair warp failed", "transition": _transition_value(transition)}
 	path.append({"map": _map_value(world), "cell": _cell_value(world)})
 
-	var mom_results: Array = []
-	for event_cell: Vector2i in [Vector2i(8, 4), Vector2i(9, 4)]:
-		world.player_cell = event_cell
-		mom_results = world.dispatch_script_events(event_cell)
-		if not mom_results.is_empty():
-			break
-	var mom_run: Dictionary = _drain_story(world, mom_results, save, random)
+	# The stair warp lands on (9,0) and the two profiles run Mom from opposite
+	# ends (`maps/PlayersHouse1F.asm`). Gold and Silver ship no coord event at
+	# all: scene 0 is `PlayersHouse1FMeetMomScene`, an `sdefer MeetMomScript`, and
+	# the script's own first command walks the player downstairs. Crystal's two
+	# scene scripts are noops and its `(8,4)`/`(9,4)` coord events are the
+	# trigger, so there the walk has to go down to one.
+	var mom_run: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	if Gen2WorldState.is_crystal_profile(data):
+		var stepped: Dictionary = _coord_event_step(
+			world, Vector2i(9, 3), Vector2i(9, 4), save, random, data
+		)
+		if not bool(stepped.get("ok", false)):
+			return {
+				"ok": false, "path": path,
+				"reason": "the Mom coord event failed: %s" % stepped.get("reason", ""),
+			}
+		mom_run = stepped.get("run", mom_run)
 	path.append({
 		"step": "players_house_1f_mom",
 		"trigger_cell": _cell_value(world),
 		"run": mom_run,
+		"pokegear": world.state.is_engine_flag_active(ENGINE_POKEGEAR),
 		"clock": world.world_clock(),
 		"dst_enabled": world.daylight_saving_time_enabled(),
 		"engine_flags": world.state.engine_flags(),
 	})
+	if not world.state.is_engine_flag_active(ENGINE_POKEGEAR):
+		return {"ok": false, "path": path, "reason": "Mom never handed over the Pokegear"}
 
 	var town_warp: Dictionary = _warp_to(world.current_map, 24, 4)
 	if town_warp.is_empty():


### PR DESCRIPTION
The story walk put the player on Crystal's (8,4) coord event by hand and called dispatch_script_events() there, which on Gold and Silver is a cell with no coord event on it and nobody had walked to. Both profiles now run Mom from their own trigger: pokegold's scene 0 is an sdefer on MeetMomScript and the script's own first command walks the player downstairs, so the map entry is the whole thing; pokecrystal's scene scripts are noops and its (8,4)/(9,4) coord events are the trigger, so the walk goes down column 9 from the stairs onto (9,4). That is MeetMomRightScript's .OnRight branch, which is the one a player coming down the stairs actually gets.

The step now reports and asserts ENGINE_POKEGEAR, so a scene that found nothing to run fails rather than passing quietly.

checkver and Gen2WorldState.engine_flag() had no check but the walk. Both are pinned now: checkver writes its answer through writemem on a gold, a silver and a crystal cache, so the value is pinned rather than a branch on it, and engine_flag() is checked against all three named *_GOLD_SILVER pairs, every badge and the flag pokegold does not ship.

GUT 1,989 to 1,991, all passing. All three walks stay ok: Crystal 292, Gold and Silver 289. The one changed path entry is the Mom step, whose trigger cell moves from (8,4) to (9,4).