### PR TITLE
Put Reflect, Light Screen and Safeguard on the field

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -200,9 +200,9 @@ never quietly change what every move in the game does.
 A registered effect replaces the cartridge's list for that byte, which is how a
 mod rewrites Sleep rather than only adding to the table.
 `Gen2MoveEffect.RESERVED_EFFECTS` is the exception: the multi-hit, fixed-damage,
-Rollout, Selfdestruct and time-based heal bytes are read back off the turn by
-their own commands, so replacing one would leave that command answering for a
-list it is no longer in.
+Rollout, Selfdestruct, time-based heal and the two screen bytes are read back off
+the turn by their own commands, so replacing one would leave that command
+answering for a list it is no longer in.
 
 ## Watching what happens
 

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -28,7 +28,8 @@ Save format version 2 stores:
 
 Derived battle stats are recalculated on load. Volatile state, including stages,
 confusion, recharge, Disable, Encore, trapping, Fly, Dig, Rollout and rampage,
-is never saved, and neither is the battle's own weather. A held item is not
+is never saved, and neither is the battle's own weather or its screens. A held
+item is not
 volatile: a berry eaten in a battle is gone from the party afterwards.
 The validator checks the selected `GameData`. Slots live under
 `user://save_slots` per game revision and are created on demand rather than

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -58,6 +58,14 @@ const STALL_MOVE_NUMBERS: Array = [
 	115, 116, 117, 133, 144, 150, 151, 159, 160, 164, 172,
 ]
 
+## The screen each of the three screen moves would raise, which is the whole of
+## `AI_Redundant`'s `.LightScreen`, `.Reflect` and `.Safeguard`.
+const SCREEN_FOR_EFFECT: Dictionary = {
+	Gen2MoveEffect.LIGHT_SCREEN: Gen2Screens.LIGHT_SCREEN,
+	Gen2MoveEffect.REFLECT: Gen2Screens.REFLECT,
+	Gen2MoveEffect.SAFEGUARD: Gen2Screens.SAFEGUARD,
+}
+
 ## The weather each of the three weather moves would set, which is the whole of
 ## `AI_Redundant`'s `.RainDance`, `.SunnyDay` and `.Sandstorm`: a move that would
 ## set the weather already up is a wasted turn.
@@ -154,7 +162,11 @@ static func _locked_in(mon: Gen2BattleMon) -> bool:
 ## when the cartridge's AI reads them too. Every handler that wants them wants
 ## the same thing: whether this is the Pokémon's first turn out.
 ##
-## [param weather] is [member Gen2Battle.weather].
+## [param weather] is [member Gen2Battle.weather], and the two screen words are
+## [member Gen2Battle.screens] for each side. [param attacker_screens] is the
+## AI's own, which is the `wEnemyScreens` every `AI_Redundant` screen row reads;
+## [param defender_screens] is the player's, which is what its Confuse row and
+## its damage estimate read.
 ##
 ## Always returns a slot in range: [method Gen2Battle.move_for] turns an
 ## unusable slot into Struggle, so no empty-moveset case is needed here.
@@ -166,7 +178,9 @@ static func choose_slot(
 	rng: RandomNumberGenerator,
 	attacker_turns_taken: int = 0,
 	defender_turns_taken: int = 0,
-	weather: int = Gen2Weather.NONE
+	weather: int = Gen2Weather.NONE,
+	attacker_screens: int = Gen2Screens.NONE,
+	defender_screens: int = Gen2Screens.NONE
 ) -> int:
 	var scores: Array = []
 	for slot: int in Gen2BattleMon.MAX_MOVES:
@@ -175,52 +189,62 @@ static func choose_slot(
 	if ai_move_weights & RomLayout.AI_BASIC:
 		_apply_basic(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_SETUP:
 		_apply_setup(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_TYPES:
 		_apply_types(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_OFFENSIVE:
 		_apply_offensive(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_SMART:
 		_apply_smart(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_OPPORTUNIST:
 		_apply_opportunist(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_AGGRESSIVE:
 		_apply_aggressive(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_CAUTIOUS:
 		_apply_cautious(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_STATUS:
 		_apply_status(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 	if ai_move_weights & RomLayout.AI_RISKY:
 		_apply_risky(
 			scores, attacker, defender, data, rng,
-			attacker_turns_taken, defender_turns_taken, weather
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens
 		)
 
 	return _pick_lowest(scores, attacker, rng)
@@ -303,12 +327,14 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 ## already-statused target, confusion against a confused one, Disable or Encore
 ## against a locked one, Attract against a target already in love or of the same
 ## or unknown gender, and a second Mist or Focus Energy, which is why those two
-## read the attacker rather than the defender. `AI_Redundant`'s remaining rows
-## (Light Screen already up, a standing Substitute) read state this engine does
-## not carry, so they never fire and read as "not redundant".
+## read the attacker rather than the defender, and a screen the attacker's own
+## side already holds. `AI_Redundant`'s one remaining row, a standing Substitute,
+## reads state this engine does not carry, so it never fires and reads as "not
+## redundant".
 static func _apply_basic(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	attacker_screens: int = Gen2Screens.NONE, defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -316,7 +342,10 @@ static func _apply_basic(
 		var effect: int = _effect(_move_at(attacker, data, slot))
 		var redundant: bool = false
 		if effect == Gen2MoveEffect.CONFUSE:
-			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED)
+			# `.Confuse` is the one row with two clauses: already confused, or
+			# behind the player's own Safeguard.
+			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED) \
+				or Gen2Screens.has(defender_screens, Gen2Screens.SAFEGUARD)
 		elif STATUS_ONLY_EFFECTS.has(effect):
 			redundant = Gen2Status.is_afflicted(defender.status)
 		elif effect == Gen2MoveEffect.DISABLE:
@@ -336,6 +365,11 @@ static func _apply_basic(
 		elif effect == Gen2MoveEffect.MEAN_LOOK:
 			# `.MeanLook` reads the user's own flag, the side the trap sits on.
 			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.CANT_RUN)
+		elif SCREEN_FOR_EFFECT.has(effect):
+			# `.LightScreen`, `.Reflect` and `.Safeguard` all read
+			# `wEnemyScreens`, the AI's own side: a screen it already holds is
+			# the wasted turn, not one the player holds.
+			redundant = Gen2Screens.has(attacker_screens, int(SCREEN_FOR_EFFECT[effect]))
 		elif WEATHER_FOR_EFFECT.has(effect):
 			redundant = weather == int(WEATHER_FOR_EFFECT[effect])
 		if redundant:
@@ -347,7 +381,8 @@ static func _apply_basic(
 ## defender's; past that both are heavily discouraged.
 static func _apply_setup(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int
+	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -381,7 +416,8 @@ static func _in_run(effect: int, base: int) -> bool:
 ## unless it is the only type of damage on offer.
 static func _apply_types(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -416,7 +452,8 @@ static func _apply_types(
 ## for a class whose whole strategy is to attack.
 static func _apply_offensive(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -429,7 +466,8 @@ static func _apply_offensive(
 ## See the constant above this function for which effects have a handler.
 static func _apply_smart(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int
+	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -719,7 +757,8 @@ static func _smart_psych_up(
 ## once its own HP is low, more insistently the lower it is.
 static func _apply_opportunist(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	if _above_half(attacker):
 		return
@@ -745,7 +784,8 @@ static func _apply_opportunist(
 ## hard they rank, not which move is strongest.
 static func _apply_aggressive(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	var best_slot: int = -1
 	var best_damage: int = -1
@@ -755,7 +795,7 @@ static func _apply_aggressive(
 		var move: Dictionary = _move_at(attacker, data, slot)
 		if _power(move) <= 0:
 			continue
-		var damage: int = _estimate_damage(attacker, defender, move)
+		var damage: int = _estimate_damage(attacker, defender, move, _defender_screens)
 		if damage >= best_damage:
 			best_damage = damage
 			best_slot = slot
@@ -774,9 +814,16 @@ static func _apply_aggressive(
 		_discourage(scores, slot, 1)
 
 
-static func _estimate_damage(attacker: Gen2BattleMon, defender: Gen2BattleMon, move: Dictionary) -> int:
+## The AI's own damage prediction, which is `EnemyAttackDamage` and
+## `BattleCommand_DamageCalc` themselves rather than an approximation of them, so
+## it reads the player's screens exactly as a real hit would.
+static func _estimate_damage(
+	attacker: Gen2BattleMon, defender: Gen2BattleMon, move: Dictionary,
+	defender_screens: int = Gen2Screens.NONE
+) -> int:
 	return int(Gen2Damage.calculate_with(
-		attacker, defender, move, false, Gen2Damage.MAX_VARIATION
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, defender_screens
 	)["damage"])
 
 
@@ -789,7 +836,8 @@ static func _estimate_damage(attacker: Gen2BattleMon, defender: Gen2BattleMon, m
 ## fix, the same call [code]Gen2EffectCommands._belly_drum[/code] makes.
 static func _apply_cautious(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int, weather: int
+	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	if atk_turns == 0:
 		return
@@ -807,7 +855,8 @@ static func _apply_cautious(
 ## [constant RomLayout.MATCHUP_NO_EFFECT] out of the real chart.
 static func _apply_status(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -828,7 +877,8 @@ static func _apply_status(
 ## back on unless the attacker is already hurt.
 static func _apply_risky(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int
+	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -843,5 +893,5 @@ static func _apply_risky(
 			if _roll(rng, 79):
 				continue
 
-		if _estimate_damage(attacker, defender, move) >= defender.hp:
+		if _estimate_damage(attacker, defender, move, _defender_screens) >= defender.hp:
 			_encourage(scores, slot, 5)

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -169,6 +169,17 @@ const WEATHER_CONTINUES: StringName = &"weather_continues"
 const WEATHER_ENDED: StringName = &"weather_ended"
 const HURT_BY_SANDSTORM: StringName = &"hurt_by_sandstorm"
 
+## Reflect, Light Screen and Safeguard going up and running out.
+## [code]screen[/code] on all three is the [Gen2Screens] flag, so one pair of
+## events covers the three moves. [constant SCREEN_SET] carries the side that put
+## it up, which is also the side it protects; [constant SCREEN_FADED] the side it
+## is leaving. [constant SAFEGUARD_PROTECTED] is `BattleCommand_CheckSafeguard`'s
+## own line, the one a status move gets when it is refused outright rather than
+## quietly, and it carries the `target` it failed against.
+const SCREEN_SET: StringName = &"screen_set"
+const SCREEN_FADED: StringName = &"screen_faded"
+const SAFEGUARD_PROTECTED: StringName = &"safeguard_protected"
+
 ## A trainer spent one of its two items on whoever it has out. [code]item[/code]
 ## is what was spent and [code]effect[/code] is [method Gen2AIItems.apply]'s own
 ## answer, so a screen can follow the bar or the stage without asking the battle
@@ -311,6 +322,14 @@ var flee_attempts: int = 0
 ## weather, so a fresh [Gen2Battle] starts clear.
 var weather: int = Gen2Weather.NONE
 var weather_turns: int = 0
+
+## `wPlayerScreens`/`wEnemyScreens` and the three counters beside each, keyed by
+## side. Field state, not Pokémon state: nothing clears these on a switch, so a
+## Reflect outlives whoever put it up and only its own count ends it.
+var screens: Dictionary = {PLAYER: Gen2Screens.NONE, ENEMY: Gen2Screens.NONE}
+var light_screen_turns: Dictionary = {PLAYER: 0, ENEMY: 0}
+var reflect_turns: Dictionary = {PLAYER: 0, ENEMY: 0}
+var safeguard_turns: Dictionary = {PLAYER: 0, ENEMY: 0}
 
 ## `wTimeOfDay`, which only the three time-based heals read. It holds
 ## `MORN_F`/`DAY_F`/`NITE_F` (engine/rtc/rtc.asm, `GetTimeOfDay`), the bit
@@ -975,14 +994,16 @@ func _tick_wrap(events: Array) -> void:
 ## `SetEnemyTurn` reading `GetUserItem`, so the player is handled first; the
 ## third is the same two calls reading `GetOpponentItem`, so the enemy is.
 ## `HandleDefrost` runs between the second and the third and is not an item
-## effect at all; `HandleSafeguard` and `HandleScreens` sit behind it and are
-## still out, since neither has a screens byte to read.
+## effect at all; `HandleSafeguard` and `HandleScreens` sit behind it in that
+## order, and are not item effects either.
 func _tick_held_items(events: Array) -> void:
 	for side: int in [PLAYER, ENEMY]:
 		_use_leftovers(side, events)
 	for side: int in [PLAYER, ENEMY]:
 		_use_pp_berry(side, events)
 	_tick_defrost(events)
+	_tick_safeguard(events)
+	_tick_screens(events)
 	for side: int in [ENEMY, PLAYER]:
 		use_hp_berry(side, events)
 		use_status_berry(side, events)
@@ -1012,6 +1033,51 @@ func _tick_defrost(events: Array) -> void:
 		# else.
 		current.status = Gen2Status.NONE
 		events.append({"type": THAWED, "side": side})
+
+
+## `HandleSafeguard`: one turn off each side's count, and the line when it runs
+## out. Player first, then enemy, the same order [method _tick_defrost] uses and
+## for the same reason: the branch that reverses them is the link one.
+##
+## The count is read only while the flag is up, so a side without a Safeguard
+## rolls nothing and prints nothing.
+func _tick_safeguard(events: Array) -> void:
+	for side: int in [PLAYER, ENEMY]:
+		if not Gen2Screens.has(screens[side], Gen2Screens.SAFEGUARD):
+			continue
+		safeguard_turns[side] = int(safeguard_turns[side]) - 1
+		if int(safeguard_turns[side]) > 0:
+			continue
+		screens[side] &= ~Gen2Screens.SAFEGUARD
+		safeguard_turns[side] = 0
+		events.append({
+			"type": SCREEN_FADED, "side": side, "screen": Gen2Screens.SAFEGUARD,
+		})
+
+
+## `HandleScreens`: Light Screen before Reflect on each side, which is the order
+## `.TickScreens` tests the two bits in, and the player's side before the
+## enemy's.
+##
+## Unlike Safeguard there is no shared count: `wPlayerLightScreenCount` and the
+## Reflect count beside it are separate bytes, so a side can hold both at once
+## and lose them on different turns.
+func _tick_screens(events: Array) -> void:
+	for side: int in [PLAYER, ENEMY]:
+		for row: Array in [
+			[Gen2Screens.LIGHT_SCREEN, light_screen_turns],
+			[Gen2Screens.REFLECT, reflect_turns],
+		]:
+			var flag: int = int(row[0])
+			var counts: Dictionary = row[1]
+			if not Gen2Screens.has(screens[side], flag):
+				continue
+			counts[side] = int(counts[side]) - 1
+			if int(counts[side]) > 0:
+				continue
+			screens[side] &= ~flag
+			counts[side] = 0
+			events.append({"type": SCREEN_FADED, "side": side, "screen": flag})
 
 
 ## `HandleLeftovers`: a sixteenth back every turn, and nothing at all on a

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -116,6 +116,22 @@ const WEATHER_ENDED_TEXT: Dictionary = {
 	Gen2Weather.SANDSTORM: "The SANDSTORM subsided.",
 }
 
+## The two lines each screen has. The set lines are `BattleCommand_Screen`'s and
+## `BattleCommand_Safeguard`'s own, which describe the stat rather than the
+## screen. The faded lines are `HandleScreens`', and they name the side rather
+## than the Pokémon: `.Copy` fills `wStringBuffer1` with "Your" or "Enemy" ahead
+## of " #MON's", which is the wording that fits a screen outliving whoever put it
+## up. `HandleSafeguard`'s is the odd one and is a plain `<USER>`.
+const SCREEN_SET_TEXT: Dictionary = {
+	Gen2Screens.LIGHT_SCREEN: "%s's SPCL.DEF rose!",
+	Gen2Screens.REFLECT: "%s's DEFENSE rose!",
+	Gen2Screens.SAFEGUARD: "%s's covered by a veil!",
+}
+const SCREEN_FADED_TEXT: Dictionary = {
+	Gen2Screens.LIGHT_SCREEN: "%s's LIGHT SCREEN fell!",
+	Gen2Screens.REFLECT: "%s's REFLECT faded!",
+}
+
 var _data: GameData = null
 var _injected_data: GameData = null
 ## Whatever the mod host supplies. Typed as Node because a registered renderer
@@ -1279,7 +1295,8 @@ func _enemy_slot() -> int:
 	return Gen2BattleAI.choose_slot(
 		_battle.mon(Gen2Battle.ENEMY), _battle.mon(Gen2Battle.PLAYER), _data, weights, _rng,
 		_battle.mon(Gen2Battle.ENEMY).turns_taken, _battle.mon(Gen2Battle.PLAYER).turns_taken,
-		_battle.weather
+		_battle.weather,
+		_battle.screens[Gen2Battle.ENEMY], _battle.screens[Gen2Battle.PLAYER]
 	)
 
 
@@ -1951,6 +1968,17 @@ func _describe(event: Dictionary) -> String:
 			return "%s can't escape now!" % _battler_name(int(event["target"]))
 		Gen2Battle.SWITCH_BLOCKED:
 			return "%s can't be recalled!" % _battler_name(side)
+		Gen2Battle.SCREEN_SET:
+			return SCREEN_SET_TEXT.get(int(event["screen"]), "") % _battler_name(side)
+		Gen2Battle.SCREEN_FADED:
+			var faded: int = int(event["screen"])
+			if faded == Gen2Screens.SAFEGUARD:
+				return "%s's SAFEGUARD faded!" % _battler_name(side)
+			return SCREEN_FADED_TEXT.get(faded, "") % (
+				"Enemy #MON" if side == Gen2Battle.ENEMY else "Your #MON"
+			)
+		Gen2Battle.SAFEGUARD_PROTECTED:
+			return "%s is protected by SAFEGUARD!" % _battler_name(int(event["target"]))
 		Gen2Battle.MIST_SET:
 			return "%s is shrouded in mist!" % _battler_name(side)
 		Gen2Battle.FOCUS_ENERGY_SET:

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -54,6 +54,13 @@ const STAB_DENOMINATOR: int = 2
 ## there is no STAB and no matchup, and it is never a critical.
 const CONFUSION_POWER: int = 40
 
+## `TruncateHL_BC` holds the attack in `hl` and the defense in `bc` and shifts
+## both right by two until each fits in a byte, flooring each at one. The pair is
+## shifted together, so the ratio survives and the magnitude does not, which is
+## what the formula's own multiply by the attack then reads.
+const STAT_BYTE_MAX: int = 0xFF
+const TRUNCATE_SHIFT: int = 4
+
 
 ## A hit, rolled. Returns what [method calculate_with] returns.
 static func calculate(
@@ -64,14 +71,16 @@ static func calculate(
 	focus_energy: bool = false,
 	defense_halved: bool = false,
 	damage_multiplier: int = 1,
-	weather: int = Gen2Weather.NONE
+	weather: int = Gen2Weather.NONE,
+	defender_screens: int = Gen2Screens.NONE
 ) -> Dictionary:
 	var scope_lens: bool = attacker != null \
 		and Gen2HeldItem.effect_of(attacker.data, attacker.item) == Gen2HeldItem.CRITICAL_UP
 	return calculate_with(
 		attacker, defender, move,
 		roll_critical(move, rng, focus_energy, scope_lens),
-		roll_variation(rng), defense_halved, damage_multiplier, weather
+		roll_variation(rng), defense_halved, damage_multiplier, weather,
+		defender_screens
 	)
 
 
@@ -90,7 +99,8 @@ static func calculate_with(
 	variation: int,
 	defense_halved: bool = false,
 	damage_multiplier: int = 1,
-	weather: int = Gen2Weather.NONE
+	weather: int = Gen2Weather.NONE,
+	defender_screens: int = Gen2Screens.NONE
 ) -> Dictionary:
 	var out: Dictionary = {
 		"damage": 0, "critical": critical, "effectiveness": RomLayout.MATCHUP_EFFECTIVE,
@@ -118,13 +128,19 @@ static func calculate_with(
 				break
 		return out
 
-	var defense: int = _defense_stat(attacker, defender, move_type, critical)
+	# `TruncateHL_BC` runs at the end of `damagestats`, so the pair reaches
+	# `BattleCommand_DamageCalc` already byte-sized and Selfdestruct's halving
+	# lands on the truncated value rather than the raw one.
+	var truncated: Array = truncate_stats(
+		_attack_stat(attacker, defender, move_type, critical),
+		_defense_stat(attacker, defender, move_type, critical, defender_screens),
+		Gen2WorldState.is_crystal_profile(attacker.data)
+	)
+	var defense: int = int(truncated[1])
 	if defense_halved:
 		@warning_ignore("integer_division")
 		defense = maxi(defense / 2, 1)
-	var damage: int = base_damage(
-		attacker.level, power, _attack_stat(attacker, defender, move_type, critical), defense
-	)
+	var damage: int = base_damage(attacker.level, power, int(truncated[0]), defense)
 
 	# The type-boosting items land here, on the finished base damage and ahead of
 	# the critical multiplier, which is where `PlayerAttackDamage` applies them:
@@ -182,6 +198,9 @@ static func calculate_with(
 ##
 ## A defense of zero would divide by zero on the hardware too, so the cartridge
 ## floors it at one and so does this.
+##
+## [param attack] and [param defense] arrive already truncated by
+## [method truncate_stats]; nothing here shifts them again.
 static func base_damage(level: int, power: int, attack: int, defense: int) -> int:
 	@warning_ignore("integer_division")
 	var out: int = level * 2 / 5 + 2
@@ -189,6 +208,33 @@ static func base_damage(level: int, power: int, attack: int, defense: int) -> in
 	@warning_ignore("integer_division")
 	out = out / maxi(defense, 1) / 50
 	return out
+
+
+## `TruncateHL_BC`: the attack and the defense shifted right together, two bits
+## at a time, until both fit in a byte, each flooring at one rather than at zero.
+##
+## Not cosmetic, and not a ratio: `base_damage` multiplies by the attack before
+## it divides by the defense, so shifting both changes the answer. A Reflect
+## doubling a 200 Defense to 400 is the common way past a byte, which is why this
+## and the screens landed together, but a +6 stage, a Thick Club or a Light Ball
+## reach it without one.
+##
+## [param crystal] is the single-player fix. `.finish` re-checks and loops back
+## only when `wLinkMode` is not `LINK_COLOSSEUM`; pokegold has no such check at
+## all, so on Gold and Silver one pass is all a value gets and anything still
+## over a byte wraps, which is `docs/bugs_and_glitches.md`'s "Reflect and Light
+## Screen can make (Special) Defense wrap around above 1024".
+static func truncate_stats(attack: int, defense: int, crystal: bool = true) -> Array:
+	var out_attack: int = attack
+	var out_defense: int = defense
+	while out_attack > STAT_BYTE_MAX or out_defense > STAT_BYTE_MAX:
+		@warning_ignore("integer_division")
+		out_defense = maxi(out_defense / TRUNCATE_SHIFT, 1)
+		@warning_ignore("integer_division")
+		out_attack = maxi(out_attack / TRUNCATE_SHIFT, 1)
+		if not crystal:
+			break
+	return [out_attack & STAT_BYTE_MAX, out_defense & STAT_BYTE_MAX]
 
 
 ## The random spread, applied last. A hit of one is left alone: there is nothing
@@ -237,8 +283,23 @@ static func roll_variation(rng: RandomNumberGenerator) -> int:
 ## against its own Defense, with the stages and any burn applied exactly as an
 ## ordinary physical hit would read them, but no STAB, no type matchup and no
 ## critical, because the hit is not really an attack at all.
-static func confusion_damage(mon: Gen2BattleMon, rng: RandomNumberGenerator) -> int:
-	var damage: int = base_damage(mon.level, CONFUSION_POWER, mon.stat("attack"), mon.stat("defense"))
+##
+## [param screens] is the confused Pokémon's own side's, which is the side being
+## hit: `HitSelfInConfusion` picks `wPlayerScreens` for the player's turn and
+## doubles the Defense off it exactly as `PlayerAttackDamage` does, so a Reflect
+## halves what confusion takes out of the Pokémon that put it up.
+static func confusion_damage(
+	mon: Gen2BattleMon, rng: RandomNumberGenerator, screens: int = Gen2Screens.NONE
+) -> int:
+	var defense: int = mon.stat("defense")
+	if Gen2Screens.has(screens, Gen2Screens.REFLECT):
+		defense *= Gen2Screens.DEFENCE_MULTIPLIER
+	var truncated: Array = truncate_stats(
+		mon.stat("attack"), defense, Gen2WorldState.is_crystal_profile(mon.data)
+	)
+	var damage: int = base_damage(
+		mon.level, CONFUSION_POWER, int(truncated[0]), int(truncated[1])
+	)
 	damage = mini(damage, DAMAGE_CAP) + MIN_DAMAGE
 	return apply_variation(damage, roll_variation(rng))
 
@@ -279,14 +340,24 @@ static func _attack_stat(
 	return out
 
 
-## The defending stat, half again if `DittoMetalPowder` answers: the Pokémon
-## being hit is a Ditto holding Metal Powder.
+## The defending stat, doubled by the defender's own screen and half again if
+## `DittoMetalPowder` answers: the Pokémon being hit is a Ditto holding Metal
+## Powder.
+##
+## The screen is applied to the boosted stat and only there. `PlayerAttackDamage`
+## doubles the pair before `CheckDamageStatsCritical`, and a critical that
+## reaches `.thickclub`'s no-carry branch reloads the unmodified stat over it, so
+## the same critical that ignores the defender's stages ignores its screen with
+## them.
 static func _defense_stat(
-	attacker: Gen2BattleMon, defender: Gen2BattleMon, move_type: int, critical: bool
+	attacker: Gen2BattleMon, defender: Gen2BattleMon, move_type: int, critical: bool,
+	defender_screens: int = Gen2Screens.NONE
 ) -> int:
 	var key: String = "defense" if is_physical(move_type) else "sp_defense"
-	var out: int = defender.unmodified_stat(key) \
-		if _ignores_stages(attacker, defender, move_type, critical) else defender.stat(key)
+	var ignores: bool = _ignores_stages(attacker, defender, move_type, critical)
+	var out: int = defender.unmodified_stat(key) if ignores else defender.stat(key)
+	if not ignores and Gen2Screens.doubles_defence(defender_screens, move_type):
+		out *= Gen2Screens.DEFENCE_MULTIPLIER
 	if Gen2HeldItem.boosts_defence(defender.species, defender.item):
 		out = Gen2HeldItem.metal_powder_defence(out)
 	return out

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -197,6 +197,21 @@ const START_RAIN: StringName = &"startrain"
 const START_SUN: StringName = &"startsun"
 const START_SANDSTORM: StringName = &"startsandstorm"
 
+## `BattleCommand_Screen`, which is Light Screen and Reflect both: one command
+## that reads the move's own effect byte to decide which bit it is setting.
+## Fails, without restarting the count, on a second use of the same one.
+const SCREEN: StringName = &"screen"
+
+## `BattleCommand_Safeguard`, the same shape a side at a time: sets the flag for
+## [constant Gen2Screens.TURNS] and fails on a second use.
+const SAFEGUARD: StringName = &"safeguard"
+
+## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
+## moves that carry it end on `SafeguardProtectText`; the six secondary effects
+## that reach `SafeCheckSafeguard` instead are refused with nothing said, which
+## is why that is a check inside each of them rather than a step of its own.
+const CHECK_SAFEGUARD: StringName = &"checksafeguard"
+
 ## Recover, Softboiled, Milk Drink and Rest, and separately the three heals that
 ## read the clock. Both refuse at full HP, and both spend the turn doing it.
 const HEAL: StringName = &"heal"
@@ -479,6 +494,12 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_start_weather(turn, Gen2Weather.SUN)
 		START_SANDSTORM:
 			_start_weather(turn, Gen2Weather.SANDSTORM)
+		SCREEN:
+			_screen(turn)
+		SAFEGUARD:
+			_safeguard(turn)
+		CHECK_SAFEGUARD:
+			_check_safeguard(turn)
 		HEAL:
 			_heal(turn)
 		TIMED_HEAL:
@@ -551,7 +572,8 @@ static func _damage_calc(turn: Gen2Turn) -> void:
 		Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.FOCUS_ENERGY),
 		turn.effect() == Gen2MoveEffect.SELFDESTRUCT,
 		rollout_multiplier,
-		turn.battle.weather
+		turn.battle.weather,
+		turn.battle.screens[turn.target]
 	)
 	turn.damage = int(result["damage"])
 	turn.critical = bool(result["critical"])
@@ -859,7 +881,9 @@ static func _check_status(turn: Gen2Turn) -> void:
 			turn.emit(Gen2Battle.CONFUSED)
 			if Gen2Substatus.rolls_confusion_hit(turn.rng()):
 				_cancel_charge(mon)
-				var dealt: int = mon.take_damage(Gen2Damage.confusion_damage(mon, turn.rng()))
+				var dealt: int = mon.take_damage(Gen2Damage.confusion_damage(
+					mon, turn.rng(), turn.battle.screens[turn.side]
+				))
 				turn.emit(Gen2Battle.HURT_ITSELF, {
 					"amount": dealt, "hp": mon.hp, "max_hp": mon.max_hp(),
 				})
@@ -933,6 +957,12 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 		return
 
 	if turn.failed_chance:
+		return
+
+	# `SafeCheckSafeguard`, last of the four `*Target` commands' checks and behind
+	# `wEffectFailed`. Nothing is said: a Safeguard stops a secondary status the
+	# way a held item does, and only `BattleCommand_CheckSafeguard` speaks.
+	if _safeguard_refuses(turn, turn.target):
 		return
 
 	if _status_move_animates(turn, flag):
@@ -1065,6 +1095,11 @@ static func _confuse_target(turn: Gen2Turn) -> void:
 	if turn.failed_chance:
 		return
 
+	# `BattleCommand_ConfuseTarget`'s own `SafeCheckSafeguard`, ahead of the
+	# substitute and already-confused checks and silent like the four statuses'.
+	if _safeguard_refuses(turn, turn.target):
+		return
+
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.is_fainted() or Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED):
 		return
@@ -1128,7 +1163,7 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 		if hit > 0:
 			var result: Dictionary = Gen2Damage.calculate(
 				attacker, defender, turn.move, turn.rng(), focus_energy,
-				false, 1, turn.battle.weather
+				false, 1, turn.battle.weather, turn.battle.screens[turn.target]
 			)
 			turn.damage = int(result["damage"])
 			turn.critical = bool(result["critical"])
@@ -1317,8 +1352,12 @@ static func _rampage(turn: Gen2Turn) -> void:
 		if mon.rampage_turns <= 0:
 			mon.substatus &= ~Gen2Substatus.RAMPAGING
 			mon.rampage_move = 0
-			mon.confusion_turns = Gen2Substatus.roll_rampage_confusion(turn.rng())
-			mon.substatus |= Gen2Substatus.CONFUSED
+			# `BattleCommand_Rampage` switches turn around its own
+			# `SafeCheckSafeguard` and back, so the Safeguard that matters is the
+			# rampaging Pokémon's own: it is the one about to be confused.
+			if not _safeguard_refuses(turn, turn.side):
+				mon.confusion_turns = Gen2Substatus.roll_rampage_confusion(turn.rng())
+				mon.substatus |= Gen2Substatus.CONFUSED
 		return
 
 	mon.substatus |= Gen2Substatus.RAMPAGING
@@ -1556,6 +1595,60 @@ static func _start_weather(turn: Gen2Turn, weather: int) -> void:
 	turn.battle.weather_turns = Gen2Weather.TURNS
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.WEATHER_STARTED, {"weather": weather})
+
+
+## `BattleCommand_Screen`: Light Screen and Reflect, one command told apart by
+## the move's own effect byte.
+##
+## The flag goes on the user's side, which is the side being defended, and
+## survives every switch that side makes. A second use fails outright rather than
+## restarting the count, the way Sandstorm does and Rain Dance does not.
+static func _screen(turn: Gen2Turn) -> void:
+	var flag: int = Gen2Screens.LIGHT_SCREEN \
+		if turn.effect() == Gen2MoveEffect.LIGHT_SCREEN else Gen2Screens.REFLECT
+	var counts: Dictionary = turn.battle.light_screen_turns \
+		if flag == Gen2Screens.LIGHT_SCREEN else turn.battle.reflect_turns
+	_raise_screen(turn, flag, counts)
+
+
+## `BattleCommand_Safeguard`, which is [method _screen] with one bit and one
+## count of its own.
+static func _safeguard(turn: Gen2Turn) -> void:
+	_raise_screen(turn, Gen2Screens.SAFEGUARD, turn.battle.safeguard_turns)
+
+
+## The half all three share: refuse if it is already up, otherwise set the bit,
+## load the count and say so.
+static func _raise_screen(turn: Gen2Turn, flag: int, counts: Dictionary) -> void:
+	if Gen2Screens.has(turn.battle.screens[turn.side], flag):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	turn.battle.screens[turn.side] |= flag
+	counts[turn.side] = Gen2Screens.TURNS
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.SCREEN_SET, {"screen": flag})
+
+
+## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status
+## move outright, with `SafeguardProtectText` and the move ended.
+##
+## `wAttackMissed` is set before the text, so everything behind this in the list
+## is skipped and the move counts as a miss for whatever reads that back.
+static func _check_safeguard(turn: Gen2Turn) -> void:
+	if not Gen2Screens.has(turn.battle.screens[turn.target], Gen2Screens.SAFEGUARD):
+		return
+	turn.missed = true
+	turn.emit(Gen2Battle.SAFEGUARD_PROTECTED, {"target": turn.target})
+	turn.end()
+
+
+## `SafeCheckSafeguard`: the quiet half, which every secondary status effect asks
+## before it writes anything. Reads the side opposite whoever is acting, so a
+## rampage confusing its own user has to ask about the user's side and the
+## caller switches turn around it the way `BattleCommand_Rampage` does.
+static func _safeguard_refuses(turn: Gen2Turn, side: int) -> bool:
+	return Gen2Screens.has(turn.battle.screens[side], Gen2Screens.SAFEGUARD)
 
 
 ## `BattleCommand_Heal`: Recover, Softboiled and Milk Drink take back half the

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -170,6 +170,13 @@ const RAIN_DANCE: int = 136
 const SUNNY_DAY: int = 137
 const THUNDER: int = 152
 
+## The three side-of-the-field screens. Light Screen and Reflect share
+## `BattleCommand_Screen`, which tells them apart by this byte, so the two are
+## one command and two lists that read the same.
+const LIGHT_SCREEN: int = 35
+const REFLECT: int = 65
+const SAFEGUARD: int = 124
+
 ## An ordinary attack: say it, spend it, work it out, roll it, apply it, and see
 ## who is standing. Everything else is this with steps moved.
 const NORMAL_HIT: Array = [
@@ -250,6 +257,7 @@ const SLEEP_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.CHECK_SAFEGUARD,
 	Gen2EffectCommands.SLEEP_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -260,6 +268,7 @@ const POISON_SEQUENCE: Array = [
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_SAFEGUARD,
 	Gen2EffectCommands.POISON_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -272,6 +281,7 @@ const TOXIC_SEQUENCE: Array = [
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_SAFEGUARD,
 	Gen2EffectCommands.TOXIC_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -285,6 +295,7 @@ const PARALYZE_SEQUENCE: Array = [
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.CHECK_SAFEGUARD,
 	Gen2EffectCommands.PARALYZE_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -295,6 +306,7 @@ const CONFUSE_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.CHECK_SAFEGUARD,
 	Gen2EffectCommands.CONFUSE_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -549,6 +561,24 @@ const START_SANDSTORM_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.START_SANDSTORM,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## The three screens, which are the weather moves' shape with a different
+## command. `LightScreen:` and `Reflect:` are one label with two entries in
+## `data/moves/effects.asm`, so both point here; none of the three rolls
+## accuracy.
+const SCREEN_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.SCREEN,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const SAFEGUARD_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.SAFEGUARD,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -873,6 +903,9 @@ static func _sequences() -> Dictionary:
 		RAIN_DANCE: START_RAIN_SEQUENCE,
 		SUNNY_DAY: START_SUN_SEQUENCE,
 		SANDSTORM: START_SANDSTORM_SEQUENCE,
+		LIGHT_SCREEN: SCREEN_SEQUENCE,
+		REFLECT: SCREEN_SEQUENCE,
+		SAFEGUARD: SAFEGUARD_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,
@@ -922,6 +955,7 @@ static func is_written(effect: int) -> bool:
 const RESERVED_EFFECTS: Array[int] = [
 	MULTI_HIT, DOUBLE_HIT, TWINEEDLE, SUPER_FANG, STATIC_DAMAGE, LEVEL_DAMAGE,
 	PSYWAVE, ROLLOUT, SELFDESTRUCT, MORNING_SUN, SYNTHESIS, MOONLIGHT,
+	LIGHT_SCREEN, REFLECT,
 ]
 
 

--- a/game/battle/screens.gd
+++ b/game/battle/screens.gd
@@ -1,0 +1,50 @@
+class_name Gen2Screens
+extends RefCounted
+
+## `wPlayerScreens` and `wEnemyScreens`: the flags that belong to a side of the
+## field rather than to whoever is standing on it.
+##
+## Nothing clears these on a switch, which is the whole difference between them
+## and [Gen2Substatus]: a Reflect put up by one Pokémon still halves damage for
+## the one sent out behind it. Only the counters ending them do, in
+## [method Gen2Battle._tick_screens] and [method Gen2Battle._tick_safeguard].
+##
+## Pure arithmetic and no state, the same shape as [Gen2Weather]; the flags and
+## the three counters live on [Gen2Battle], one of each per side.
+
+## `constants/battle_constants.asm`'s bit numbers, kept rather than renumbered so
+## a `bit SCREENS_REFLECT` in the source reads across. Bit 1 is skipped there and
+## SCREENS_UNUSED is exactly what its name says.
+const SPIKES: int = 1 << 0
+const SAFEGUARD: int = 1 << 2
+const LIGHT_SCREEN: int = 1 << 3
+const REFLECT: int = 1 << 4
+
+const NONE: int = 0
+
+## What `BattleCommand_Screen` and `BattleCommand_Safeguard` all write. Each
+## handler decrements before it looks, so this is four turns and a fifth that
+## ends it, the setting turn counting as the first, exactly as
+## [constant Gen2Weather.TURNS] does.
+const TURNS: int = 5
+
+## What a screen does to the defending stat: `sla c` / `rl b` on the sixteen-bit
+## value, before the critical-hit check that may discard it.
+const DEFENCE_MULTIPLIER: int = 2
+
+
+static func has(screens: int, flags: int) -> bool:
+	return screens & flags != 0
+
+
+## Which screen guards [param move_type], which is the whole of the split
+## between the two: Reflect sits on the physical branch of `PlayerAttackDamage`
+## and Light Screen on the special one. Answers [constant NONE] for neither.
+static func guarding_flag(move_type: int) -> int:
+	return REFLECT if Gen2Damage.is_physical(move_type) else LIGHT_SCREEN
+
+
+## Whether a hit of [param move_type] against a side holding [param screens] has
+## its defending stat doubled.
+static func doubles_defence(screens: int, move_type: int) -> bool:
+	return has(screens, guarding_flag(move_type))

--- a/game/battle/screens.gd.uid
+++ b/game/battle/screens.gd.uid
@@ -1,0 +1,1 @@
+uid://day062pxq3yfk

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -109,6 +109,13 @@ const SUNNY_DAY: int = 241
 const SANDSTORM: int = 201
 const THUNDER_ALWAYS_PARALYZES: int = 274
 
+## The three screens, real numbers off `data/moves/moves.asm`. All three are
+## powerless status moves whose accuracy is never rolled, the same shape the
+## weather rows above have.
+const LIGHT_SCREEN: int = 113
+const REFLECT: int = 115
+const SAFEGUARD: int = 219
+
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
 ## the cartridge.
@@ -453,6 +460,9 @@ static func _moves() -> Array:
 		RAIN_DANCE: ["RAIN DANCE", 0, WATER, 229, 5, Gen2MoveEffect.RAIN_DANCE, 0],
 		SUNNY_DAY: ["SUNNY DAY", 0, FIRE, 229, 5, Gen2MoveEffect.SUNNY_DAY, 0],
 		SANDSTORM: ["SANDSTORM", 0, ROCK, 255, 10, Gen2MoveEffect.SANDSTORM, 0],
+		LIGHT_SCREEN: ["LIGHT SCREEN", 0, PSYCHIC_TYPE, 255, 30, Gen2MoveEffect.LIGHT_SCREEN, 0],
+		REFLECT: ["REFLECT", 0, PSYCHIC_TYPE, 255, 20, Gen2MoveEffect.REFLECT, 0],
+		SAFEGUARD: ["SAFEGUARD", 0, NORMAL, 255, 25, Gen2MoveEffect.SAFEGUARD, 0],
 		# Thunder with a paralysis chance the roll cannot fail, so the secondary
 		# behind its own effect can be seen without a seed. The accuracy byte is
 		# still the real 178, since that is what the weather rewrites.

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -2612,3 +2612,157 @@ func test_an_enemy_switch_leaves_the_used_move_list_alone() -> void:
 	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.switch_to(1))
 
 	assert_eq(battle.player_used_moves, [Fixture.TACKLE] as Array[int])
+
+
+## `BattleCommand_Screen` sets the bit on the user's own side and loads five,
+## and `HandleScreens` takes one off on that same turn, so a Reflect covers the
+## turn it went up and four more.
+func test_a_screen_lasts_five_turns_counting_the_one_that_set_it() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.REFLECT, Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+
+	var setting: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_eq(_first(setting, Gen2Battle.SCREEN_SET)["screen"], Gen2Screens.REFLECT)
+	assert_true(Gen2Screens.has(battle.screens[Gen2Battle.PLAYER], Gen2Screens.REFLECT))
+	assert_eq(battle.reflect_turns[Gen2Battle.PLAYER], Gen2Screens.TURNS - 1)
+	assert_eq(battle.screens[Gen2Battle.ENEMY], Gen2Screens.NONE, "one side only")
+
+	var faded: Dictionary = {}
+	var turns: int = 0
+	for _turn: int in 10:
+		var events: Array = battle.take_actions(Gen2Battle.use_move(1), Gen2Battle.use_move(0))
+		turns += 1
+		faded = _first(events, Gen2Battle.SCREEN_FADED)
+		if not faded.is_empty():
+			break
+
+	assert_eq(turns, Gen2Screens.TURNS - 1, "four more turns after the one that set it")
+	assert_eq(faded["screen"], Gen2Screens.REFLECT)
+	assert_eq(battle.screens[Gen2Battle.PLAYER], Gen2Screens.NONE)
+	assert_eq(battle.reflect_turns[Gen2Battle.PLAYER], 0)
+
+
+## Reflect and Light Screen have counts of their own rather than sharing one, so
+## a side can hold both and lose them on different turns.
+func test_the_two_screens_run_down_separately() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.REFLECT, Fixture.LIGHT_SCREEN, Fixture.GROWL]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	battle.take_actions(Gen2Battle.use_move(1), Gen2Battle.use_move(0))
+
+	assert_eq(battle.reflect_turns[Gen2Battle.PLAYER], Gen2Screens.TURNS - 2)
+	assert_eq(battle.light_screen_turns[Gen2Battle.PLAYER], Gen2Screens.TURNS - 1)
+	assert_true(Gen2Screens.has(
+		battle.screens[Gen2Battle.PLAYER], Gen2Screens.REFLECT | Gen2Screens.LIGHT_SCREEN
+	))
+
+	var reflect_fell_on: int = -1
+	var light_screen_fell_on: int = -1
+	for turn: int in 8:
+		var events: Array = battle.take_actions(Gen2Battle.use_move(2), Gen2Battle.use_move(0))
+		for event: Dictionary in _of_type(events, Gen2Battle.SCREEN_FADED):
+			if int(event["screen"]) == Gen2Screens.REFLECT:
+				reflect_fell_on = turn
+			else:
+				light_screen_fell_on = turn
+
+	assert_eq(reflect_fell_on, 2)
+	assert_eq(light_screen_fell_on, 3, "one turn behind, the turn it was put up later")
+
+
+## A second use fails outright rather than restarting the count, which is
+## `BattleCommand_Screen`'s `.failed` branch and not Rain Dance's behaviour.
+func test_a_second_screen_fails_without_restarting_the_count() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.REFLECT]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])
+	)
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var again: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_false(_first(again, Gen2Battle.MOVE_FAILED).is_empty(), JSON.stringify(again))
+	assert_eq(_of_type(again, Gen2Battle.SCREEN_SET).size(), 0)
+	assert_eq(battle.reflect_turns[Gen2Battle.PLAYER], Gen2Screens.TURNS - 2)
+
+
+## The screen belongs to the side, not to the Pokémon: nothing clears it on a
+## switch, which is the whole difference between it and a [Gen2Substatus] flag.
+func test_a_screen_outlives_the_pokemon_that_put_it_up() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.create([
+			_mon(Fixture.PIKACHU, 50, [Fixture.REFLECT]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 50, [Fixture.GROWL])), _rng, true
+	)
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+
+	assert_true(Gen2Screens.has(battle.screens[Gen2Battle.PLAYER], Gen2Screens.REFLECT))
+
+
+## `BattleCommand_CheckSafeguard` is the loud half: the move is refused with
+## `SafeguardProtectText` and ends there.
+func test_safeguard_refuses_a_status_move_and_says_so() -> void:
+	# Pikachu is the faster of the two, so the veil goes up on its own turn
+	# first and the status move is tried against it on the next.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL, Fixture.THUNDER_WAVE]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.SAFEGUARD])
+	)
+
+	var raising: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var events: Array = battle.take_actions(Gen2Battle.use_move(1), Gen2Battle.use_move(0))
+
+	assert_eq(_first(raising, Gen2Battle.SCREEN_SET)["screen"], Gen2Screens.SAFEGUARD)
+	var protected: Dictionary = _first(events, Gen2Battle.SAFEGUARD_PROTECTED)
+	assert_false(protected.is_empty(), JSON.stringify(events))
+	assert_eq(protected["target"], Gen2Battle.ENEMY)
+	assert_eq(battle.enemy.status, Gen2Status.NONE)
+
+
+## `SafeCheckSafeguard` is the quiet half: a secondary status is refused with
+## nothing said, because only the four moves carrying `checksafeguard` speak.
+func test_safeguard_refuses_a_secondary_status_silently() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.EMBER_BURNS]),
+		_mon(Fixture.BULBASAUR, 50, [Fixture.GROWL])
+	)
+	battle.screens[Gen2Battle.ENEMY] = Gen2Screens.SAFEGUARD
+	battle.safeguard_turns[Gen2Battle.ENEMY] = Gen2Screens.TURNS
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_eq(_of_type(events, Gen2Battle.STATUS_INFLICTED).size(), 0, JSON.stringify(events))
+	assert_eq(_of_type(events, Gen2Battle.SAFEGUARD_PROTECTED).size(), 0, "nothing is said")
+	assert_eq(battle.enemy.status, Gen2Status.NONE)
+	assert_false(_first(events, Gen2Battle.HIT).is_empty(), "the hit itself still lands")
+
+
+## `HandleSafeguard` runs ahead of `HandleScreens` and off a count of its own.
+func test_safeguard_runs_down_and_stops_protecting() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.THUNDER_WAVE]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.screens[Gen2Battle.ENEMY] = Gen2Screens.SAFEGUARD
+	battle.safeguard_turns[Gen2Battle.ENEMY] = 1
+
+	var ending: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_false(_first(ending, Gen2Battle.SAFEGUARD_PROTECTED).is_empty(), "still up this turn")
+	assert_eq(_first(ending, Gen2Battle.SCREEN_FADED)["screen"], Gen2Screens.SAFEGUARD)
+	assert_eq(battle.screens[Gen2Battle.ENEMY], Gen2Screens.NONE)
+
+	var after: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_eq(_of_type(after, Gen2Battle.SAFEGUARD_PROTECTED).size(), 0)
+	assert_true(Gen2Status.has(battle.enemy.status, Gen2Status.PARALYSIS))

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -365,3 +365,116 @@ func test_the_scope_lens_makes_criticals_more_common() -> void:
 		if Gen2Damage.roll_critical(_data.move(Fixture.TACKLE), rng, false, true):
 			lensed += 1
 	assert_gt(lensed, plain * 3 / 2, "level 1 is 32 in 256 against level 0's 17")
+
+
+## The screen doubles the defending stat inside the formula rather than halving
+## the finished damage, so it lands before the divide and before STAB.
+##
+## Pikachu's Thunderbolt on Bulbasaur is 22 * 95 * 70 / 85 / 50 = 34 without
+## one; with Reflect the defence is 170, giving 17, then +2 = 19, x1.5 STAB = 28
+## and halved by Grass = 14. Reflect is the physical screen, so a special move
+## reads Light Screen and nothing else.
+func test_light_screen_doubles_the_special_defence_a_special_move_divides_by() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU)
+	var defender: Gen2BattleMon = _mon(Fixture.BULBASAUR)
+	var move: Dictionary = _data.move(Fixture.THUNDERBOLT)
+
+	var bare: Dictionary = Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION
+	)
+	var screened: Dictionary = Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+	)
+	var wrong_screen: Dictionary = Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, Gen2Screens.REFLECT
+	)
+
+	assert_eq(bare["damage"], 27)
+	assert_eq(screened["damage"], 14)
+	assert_eq(wrong_screen["damage"], 27, "the physical screen guards nothing special")
+
+
+func test_reflect_is_the_physical_screen_and_light_screen_guards_nothing_physical() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.GEODUDE)
+	var defender: Gen2BattleMon = _mon(Fixture.CHARMANDER)
+	var move: Dictionary = _data.move(Fixture.TACKLE)
+
+	var bare: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION
+	)["damage"])
+	var reflected: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, Gen2Screens.REFLECT
+	)["damage"])
+	var light: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+	)["damage"])
+
+	assert_lt(reflected, bare)
+	assert_eq(light, bare)
+
+
+## `PlayerAttackDamage` doubles the pair before `CheckDamageStatsCritical`, and
+## the no-carry branch reloads the unmodified stat over it, so the same critical
+## that ignores the defender's stages ignores its screen with them. A critical
+## against a defender whose stages are no better than the attacker's keeps both.
+func test_a_critical_that_ignores_the_stages_ignores_the_screen_with_them() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU)
+	var defender: Gen2BattleMon = _mon(Fixture.BULBASAUR)
+	var move: Dictionary = _data.move(Fixture.THUNDERBOLT)
+
+	# Nothing has moved, so the two stages are equal and the critical takes the
+	# `.specialcrit` branch that discards the screen.
+	var critical_bare: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, true, Gen2Damage.MAX_VARIATION
+	)["damage"])
+	var critical_screened: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, true, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+	)["damage"])
+
+	assert_eq(critical_screened, critical_bare, "the critical went through the screen")
+
+	# Raise the attacker's own stage so `CheckDamageStatsCritical` carries and
+	# keeps the loaded pair, screen included.
+	attacker.change_stage("sp_attack", 2)
+	var kept_bare: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, true, Gen2Damage.MAX_VARIATION
+	)["damage"])
+	var kept_screened: int = int(Gen2Damage.calculate_with(
+		attacker, defender, move, true, Gen2Damage.MAX_VARIATION,
+		false, 1, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+	)["damage"])
+
+	assert_lt(kept_screened, kept_bare, "this critical kept the screen")
+
+
+## `TruncateHL_BC` shifts the attack and the defence together, two bits at a
+## time, until both fit in a byte, flooring each at one. A screened defence is
+## the common way past a byte.
+func test_truncate_stats_shifts_both_until_each_fits_in_a_byte() -> void:
+	assert_eq(Gen2Damage.truncate_stats(200, 255), [200, 255], "nothing to do")
+	assert_eq(Gen2Damage.truncate_stats(100, 400), [25, 100], "one pass of four")
+	assert_eq(Gen2Damage.truncate_stats(999, 999), [249, 249])
+	# Three passes: 5000 to 1250 to 312 to 78, and the partner floors at one
+	# rather than at zero on the first of them, which is `inc c`.
+	assert_eq(Gen2Damage.truncate_stats(3, 5000), [1, 78], "the floor is one, not zero")
+	assert_eq(Gen2Damage.truncate_stats(1, 1), [1, 1])
+
+
+## The single-player fix is Crystal's alone: pokegold has no `wLinkMode` check at
+## all, so one pass is all a value gets there and anything still over a byte
+## wraps. `docs/bugs_and_glitches.md` calls it "Reflect and Light Screen can make
+## (Special) Defense wrap around above 1024".
+func test_gold_and_silver_wrap_a_screened_defence_above_1024() -> void:
+	# 1200 / 4 is 300, which does not fit; Crystal shifts again to 75, Gold keeps
+	# 300 and hands back its low byte, 44.
+	assert_eq(Gen2Damage.truncate_stats(100, 1200, true), [6, 75])
+	assert_eq(Gen2Damage.truncate_stats(100, 1200, false), [25, 44])
+	# Under the threshold the two agree, since one pass is enough for both.
+	assert_eq(
+		Gen2Damage.truncate_stats(100, 1000, true), Gen2Damage.truncate_stats(100, 1000, false)
+	)


### PR DESCRIPTION
Stacked on #151. Merge that one first; this diff is the screens commit alone.

All three sit on the same wPlayerScreens/wEnemyScreens byte, so they land together. Gen2Screens is the flags and the arithmetic; the byte and the three counters are per side on Gen2Battle. Field state, not Pokemon state: nothing in the pinned sources clears the byte on a switch, so a Reflect outlives whoever put it up and only its own count ends it.

Reflect and Light Screen are one command told apart by the move's effect byte, with a count each, so a side can hold both and lose them on different turns. All three refuse a second use outright rather than restarting. HandleSafeguard then HandleScreens run behind HandleDefrost. Safeguard has two halves: BattleCommand_CheckSafeguard, which the four checksafeguard lists carry and which refuses loudly, and SafeCheckSafeguard, which the four *Target commands, ConfuseTarget and Rampage ask and which refuses with nothing said. Rampage reads the user's own side, since the source switches turn around the call and back.

A screen doubles the defending stat inside the formula, before CheckDamageStatsCritical, so the same critical that ignores the defender's stages ignores its screen. That made TruncateHL_BC load bearing and it was missing: the attack and the defence are shifted right together until both fit in a byte, and base_damage multiplies by the attack before it divides by the defence, so the magnitude is read as well as the ratio. It is profile split, since pokegold has no wLinkMode check and one pass is all a value gets there; the wraparound above 1024 is kept, not fixed. That gap predates the screens, since a +6 stage, a Thick Club or a Light Ball all reach a byte without one.

The AI reads the byte too, which is three AI_Redundant rows plus the Safeguard clause on its Confuse row, and its damage estimate now sees the player's screens the way EnemyAttackDamage does.

Recorded and not chased: Metal Powder is still applied before the truncation rather than after it, which differs only for a Ditto above 255 Defense.

GUT 1,991 to 2,003, all passing. All three story walks are byte-identical to before.