### PR TITLE
Let Perish Song run its count down, and fix the new-slot button

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -168,6 +168,14 @@ static func _locked_in(mon: Gen2BattleMon) -> bool:
 ## [param defender_screens] is the player's, which is what its Confuse row and
 ## its damage estimate read.
 ##
+## [param has_bench] and [param matchup_score] are the two routines the smart
+## layer farcalls out of a handler rather than reads off a battler:
+## `FindAliveEnemyMons`, which is whether the AI has anybody left to send, and
+## `CheckPlayerMoveTypeMatchups`, which is `wEnemyAISwitchScore` and is
+## [method Gen2AISwitch.matchup_score] here. Both are supplied the way
+## [param weather] is, since this routine scores a pairing rather than a battle;
+## the defaults are the neutral states, a lone Pokémon and an unnudged score.
+##
 ## Always returns a slot in range: [method Gen2Battle.move_for] turns an
 ## unusable slot into Struggle, so no empty-moveset case is needed here.
 static func choose_slot(
@@ -180,7 +188,9 @@ static func choose_slot(
 	defender_turns_taken: int = 0,
 	weather: int = Gen2Weather.NONE,
 	attacker_screens: int = Gen2Screens.NONE,
-	defender_screens: int = Gen2Screens.NONE
+	defender_screens: int = Gen2Screens.NONE,
+	has_bench: bool = false,
+	matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> int:
 	var scores: Array = []
 	for slot: int in Gen2BattleMon.MAX_MOVES:
@@ -190,61 +200,61 @@ static func choose_slot(
 		_apply_basic(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_SETUP:
 		_apply_setup(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_TYPES:
 		_apply_types(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_OFFENSIVE:
 		_apply_offensive(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_SMART:
 		_apply_smart(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_OPPORTUNIST:
 		_apply_opportunist(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_AGGRESSIVE:
 		_apply_aggressive(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_CAUTIOUS:
 		_apply_cautious(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_STATUS:
 		_apply_status(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 	if ai_move_weights & RomLayout.AI_RISKY:
 		_apply_risky(
 			scores, attacker, defender, data, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
-			attacker_screens, defender_screens
+			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 
 	return _pick_lowest(scores, attacker, rng)
@@ -334,7 +344,9 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 static func _apply_basic(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	attacker_screens: int = Gen2Screens.NONE, defender_screens: int = Gen2Screens.NONE
+	attacker_screens: int = Gen2Screens.NONE, defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -362,6 +374,10 @@ static func _apply_basic(
 			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.MIST)
 		elif effect == Gen2MoveEffect.FOCUS_ENERGY:
 			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY)
+		elif effect == Gen2MoveEffect.PERISH_SONG:
+			# `.PerishSong` reads `wPlayerSubStatus1`, the target's: a second song
+			# over one already counting down would reset nothing.
+			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.PERISH)
 		elif effect == Gen2MoveEffect.MEAN_LOOK:
 			# `.MeanLook` reads the user's own flag, the side the trap sits on.
 			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.CANT_RUN)
@@ -382,7 +398,9 @@ static func _apply_basic(
 static func _apply_setup(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -417,7 +435,9 @@ static func _in_run(effect: int, base: int) -> bool:
 static func _apply_types(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -453,7 +473,9 @@ static func _apply_types(
 static func _apply_offensive(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -467,7 +489,9 @@ static func _apply_offensive(
 static func _apply_smart(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	has_bench: bool = false,
+	matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -515,6 +539,8 @@ static func _apply_smart(
 			Gen2MoveEffect.HEAL, Gen2MoveEffect.MORNING_SUN, Gen2MoveEffect.SYNTHESIS, \
 			Gen2MoveEffect.MOONLIGHT:
 				_smart_heal(scores, slot, attacker, rng)
+			Gen2MoveEffect.PERISH_SONG:
+				_smart_perish_song(scores, slot, defender, rng, has_bench, matchup_score)
 
 
 ## `AI_Smart_Solarbeam`: 80% to encourage it greatly in sun, where it needs no
@@ -720,6 +746,37 @@ static func _smart_heal(
 		_discourage(scores, slot, 1)
 
 
+## `AI_Smart_PerishSong`: worth singing when the player cannot leave, not worth
+## singing when the AI has nobody to leave for.
+##
+## Three branches in the source's own order. `.no`, with nobody on the bench, is
+## the only one that moves a score without a roll: five points against, since a
+## song the AI cannot walk away from kills it too. A player held by Mean Look or
+## Spider Web is `.yes`, 50% to encourage. Otherwise the AI only bothers when the
+## matchup is one it is not losing: `CheckPlayerMoveTypeMatchups` below
+## [constant Gen2AISwitch.BASE_SCORE] returns with nothing said, and at or above
+## it is 50% to discourage. Reading that as "sing when things are going badly"
+## has it backwards; the branch that says yes is the trapped one.
+static func _smart_perish_song(
+	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator,
+	has_bench: bool, matchup_score: int
+) -> void:
+	if not has_bench:
+		_discourage(scores, slot, 5)
+		return
+
+	if Gen2Substatus.has(defender.substatus, Gen2Substatus.CANT_RUN):
+		if not _skip_50_50(rng):
+			_encourage(scores, slot, 1)
+		return
+
+	if matchup_score < Gen2AISwitch.BASE_SCORE:
+		return
+	if _skip_50_50(rng):
+		return
+	_discourage(scores, slot, 1)
+
+
 static func _smart_belly_drum(scores: Array, slot: int, attacker: Gen2BattleMon) -> void:
 	if attacker.stage("attack") >= 3:
 		_discourage(scores, slot, 5)
@@ -758,7 +815,9 @@ static func _smart_psych_up(
 static func _apply_opportunist(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	if _above_half(attacker):
 		return
@@ -785,7 +844,9 @@ static func _apply_opportunist(
 static func _apply_aggressive(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	var best_slot: int = -1
 	var best_damage: int = -1
@@ -837,7 +898,9 @@ static func _estimate_damage(
 static func _apply_cautious(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	if atk_turns == 0:
 		return
@@ -856,7 +919,9 @@ static func _apply_cautious(
 static func _apply_status(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
@@ -878,7 +943,9 @@ static func _apply_status(
 static func _apply_risky(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
-	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE
+	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
+	_has_bench: bool = false,
+	_matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):

--- a/game/battle/ai_switch.gd
+++ b/game/battle/ai_switch.gd
@@ -14,12 +14,6 @@ extends RefCounted
 ## every scan keeps party order, and every place the cartridge converts a mask to
 ## an index it takes the lowest index set, which is what every scan here answers
 ## with too.
-##
-## One branch is missing. `CheckAbleToSwitch` opens with a Perish Song check that
-## switches at [constant TIER_HIGH] whatever the matchups say, and Perish Song is
-## not implemented, so nothing here can reach that tier. The tier and its three
-## chances are still named, because they are what the source's three frequency
-## routines are each a third of.
 
 ## `BASE_AI_SWITCH_SCORE`, where [method matchup_score] starts before anything
 ## nudges it.
@@ -91,6 +85,10 @@ static func evaluate(battle: Gen2Battle) -> Dictionary:
 	if alive.is_empty():
 		return _stay()
 
+	var perish: Dictionary = _perish_choice(battle, alive)
+	if not perish.is_empty():
+		return perish
+
 	if matchup_score(battle) >= COMFORTABLE_SCORE:
 		return _stay()
 
@@ -101,6 +99,32 @@ static func evaluate(battle: Gen2Battle) -> Dictionary:
 			return _counter_choice(battle, immune)
 
 	return _no_counter_choice(battle, alive)
+
+
+## `CheckAbleToSwitch`'s opening branch: the turn before Perish Song finishes
+## the Pokémon that is out, get somebody else in. Empty means the branch did not
+## apply and the matchup half decides instead.
+##
+## Only a count of exactly one qualifies. Two is too early and zero has already
+## killed, so a Pokémon that will survive the song is left to fight.
+##
+## The tier is [constant TIER_HIGH] either way, which is the whole point of the
+## branch: what the shortlist changes is who comes in, not how much the AI wants
+## the switch. With a super-effective answer standing it is that Pokémon; without
+## one, `.not_2` walks the alive mask from the top and takes the first bit, which
+## is the lowest party index still standing, shortlist or no shortlist.
+static func _perish_choice(battle: Gen2Battle, alive: Array) -> Dictionary:
+	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	if not Gen2Substatus.has(enemy.substatus, Gen2Substatus.PERISH):
+		return {}
+	if enemy.perish_count != 1:
+		return {}
+
+	var shortlist: Array = _resisting(battle, _at_least_quarter_hp(battle, alive))
+	var best: Dictionary = _best_answer(battle, shortlist)
+	if int(best["quality"]) == 2:
+		return {"tier": TIER_HIGH, "index": int(best["index"])}
+	return {"tier": TIER_HIGH, "index": int(alive[0])}
 
 
 ## `.no_perish`'s tail, and `.no_last_counter_move`: the AI is losing the type
@@ -223,6 +247,12 @@ static func _enemy_move_adjustment(
 	if threat < WEIGHT_SUPER_EFFECTIVE:
 		return 0
 	return 1
+
+
+## `FindAliveEnemyMons`' carry flag, which is the only part of it three of the
+## smart-scoring handlers want: whether the AI has anybody left to send in.
+static func has_bench(battle: Gen2Battle) -> bool:
+	return not _alive_others(battle).is_empty()
 
 
 ## `FindAliveEnemyMons`: every party index still standing except the one that is

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -180,6 +180,14 @@ const SCREEN_SET: StringName = &"screen_set"
 const SCREEN_FADED: StringName = &"screen_faded"
 const SAFEGUARD_PROTECTED: StringName = &"safeguard_protected"
 
+## Perish Song. [constant PERISH_SONG_STARTED] is `StartPerishText`, which names
+## both Pokémon rather than either side, so its [code]side[/code] is only whoever
+## sang. [constant PERISH_COUNT] carries the [code]side[/code] it is counting down
+## and the [code]count[/code] just reached, including the zero that kills, since
+## `HandlePerishSong` prints on every tick.
+const PERISH_SONG_STARTED: StringName = &"perish_song_started"
+const PERISH_COUNT: StringName = &"perish_count"
+
 ## A trainer spent one of its two items on whoever it has out. [code]item[/code]
 ## is what was spent and [code]effect[/code] is [method Gen2AIItems.apply]'s own
 ## answer, so a screen can follow the bar or the stage without asking the battle
@@ -847,6 +855,7 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	_residual_damage(acting, events)
 	_tick_weather(events)
 	_tick_wrap(events)
+	_tick_perish(events)
 	_tick_held_items(events)
 	_tick_encore(acting, events)
 	_award_experience(events)
@@ -984,6 +993,35 @@ func _tick_wrap(events: Array) -> void:
 		})
 		if current.is_fainted():
 			events.append({"type": FAINTED, "side": side})
+
+
+## `HandlePerishSong`: one off each side's count, said out loud, and whoever
+## reaches zero is finished where it stands.
+##
+## Behind [method _tick_wrap] and ahead of the leftovers block, which is where
+## `HandleBetweenTurnEffects` calls it, and player first for the same reason
+## every other handler here is: the order that reverses them is the link one.
+##
+## The line prints on every tick including the last, since `HandlePerishSong`
+## decrements, prints, and only then looks at whether the count came out zero.
+## The kill is `xor a` straight into the HP word rather than damage, so nothing
+## about it is a sixteenth of anything and no held item can answer it.
+func _tick_perish(events: Array) -> void:
+	for side: int in [PLAYER, ENEMY]:
+		var current: Gen2BattleMon = mon(side)
+		if current.is_fainted():
+			continue
+		if not Gen2Substatus.has(current.substatus, Gen2Substatus.PERISH):
+			continue
+
+		current.perish_count -= 1
+		events.append({"type": PERISH_COUNT, "side": side, "count": current.perish_count})
+		if current.perish_count > 0:
+			continue
+
+		current.substatus &= ~Gen2Substatus.PERISH
+		current.hp = 0
+		events.append({"type": FAINTED, "side": side})
 
 
 ## The leftovers block of `HandleBetweenTurnEffects`: `HandleLeftovers`,

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -107,6 +107,10 @@ var encore_turns: int = 0
 var trapped_turns: int = 0
 var trapping_move: int = 0
 
+## `wPlayerPerishCount`: how many turn ends this Pokémon has left before Perish
+## Song finishes it. Read only while [constant Gen2Substatus.PERISH] is set.
+var perish_count: int = 0
+
 ## `wPlayerTurnsTaken`: how many turns this Pokémon has actually acted on since
 ## it came out. `BattleCommand_DoTurn` is the one place it rises, behind the same
 ## charging check that decides whether PP is spent, so a two-turn release does
@@ -259,6 +263,7 @@ func reset_volatile() -> void:
 	encore_turns = 0
 	trapped_turns = 0
 	trapping_move = 0
+	perish_count = 0
 	turns_taken = 0
 	last_move_used = 0
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1296,7 +1296,8 @@ func _enemy_slot() -> int:
 		_battle.mon(Gen2Battle.ENEMY), _battle.mon(Gen2Battle.PLAYER), _data, weights, _rng,
 		_battle.mon(Gen2Battle.ENEMY).turns_taken, _battle.mon(Gen2Battle.PLAYER).turns_taken,
 		_battle.weather,
-		_battle.screens[Gen2Battle.ENEMY], _battle.screens[Gen2Battle.PLAYER]
+		_battle.screens[Gen2Battle.ENEMY], _battle.screens[Gen2Battle.PLAYER],
+		Gen2AISwitch.has_bench(_battle), Gen2AISwitch.matchup_score(_battle)
 	)
 
 
@@ -1979,6 +1980,13 @@ func _describe(event: Dictionary) -> String:
 			)
 		Gen2Battle.SAFEGUARD_PROTECTED:
 			return "%s is protected by SAFEGUARD!" % _battler_name(int(event["target"]))
+		Gen2Battle.PERISH_SONG_STARTED:
+			# StartPerishText names neither Pokémon, since the song caught both.
+			return "Both #MON will faint in 3 turns!"
+		Gen2Battle.PERISH_COUNT:
+			return "%s's PERISH count is %d!" % [
+				_battler_name(side), int(event["count"]),
+			]
 		Gen2Battle.MIST_SET:
 			return "%s is shrouded in mist!" % _battler_name(side)
 		Gen2Battle.FOCUS_ENERGY_SET:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -203,6 +203,10 @@ const SCREEN: StringName = &"screen"
 ## [constant Gen2Screens.TURNS] and fails on a second use.
 const SAFEGUARD: StringName = &"safeguard"
 
+## `BattleCommand_PerishSong`: the song both sides hear, whoever sang it. Fails
+## only when both are already counting down.
+const PERISH_SONG: StringName = &"perishsong"
+
 ## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
 ## moves that carry it end on `SafeguardProtectText`; the six secondary effects
 ## that reach `SafeCheckSafeguard` instead are refused with nothing said, which
@@ -495,6 +499,8 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_screen(turn)
 		SAFEGUARD:
 			_safeguard(turn)
+		PERISH_SONG:
+			_perish_song(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -1625,6 +1631,35 @@ static func _raise_screen(turn: Gen2Turn, flag: int, counts: Dictionary) -> void
 	counts[turn.side] = Gen2Screens.TURNS
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.SCREEN_SET, {"screen": flag})
+
+
+## `BattleCommand_PerishSong`: four turns on the clock for both Pokémon on the
+## field, whichever of them sang.
+##
+## The one command that names `wPlayerSubStatus1` and `wEnemySubStatus1` outright
+## instead of the user and the target, so it reads the same either way round. A
+## side already counting down is left with the count it has rather than given a
+## fresh four, and the move fails only when that is true of both.
+static func _perish_song(turn: Gen2Turn) -> void:
+	var battle: Gen2Battle = turn.battle
+	var already: Dictionary = {}
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		already[side] = Gen2Substatus.has(
+			battle.mon(side).substatus, Gen2Substatus.PERISH
+		)
+	if bool(already[Gen2Battle.PLAYER]) and bool(already[Gen2Battle.ENEMY]):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		if bool(already[side]):
+			continue
+		var hearer: Gen2BattleMon = battle.mon(side)
+		hearer.substatus |= Gen2Substatus.PERISH
+		hearer.perish_count = Gen2Substatus.PERISH_TURNS
+
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.PERISH_SONG_STARTED)
 
 
 ## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -177,6 +177,10 @@ const LIGHT_SCREEN: int = 35
 const REFLECT: int = 65
 const SAFEGUARD: int = 124
 
+## Perish Song, which is neither a screen nor a status: a count on each Pokémon
+## on the field that a switch escapes.
+const PERISH_SONG: int = 114
+
 ## An ordinary attack: say it, spend it, work it out, roll it, apply it, and see
 ## who is standing. Everything else is this with steps moved.
 const NORMAL_HIT: Array = [
@@ -582,6 +586,15 @@ const SAFEGUARD_SEQUENCE: Array = [
 	Gen2EffectCommands.END_MOVE,
 ]
 
+## Perish Song, the same four steps again. Its own accuracy byte is 100 and no
+## list step rolls against it, so the song never misses.
+const PERISH_SONG_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.PERISH_SONG,
+	Gen2EffectCommands.END_MOVE,
+]
+
 ## Thunder: a paralysis chance behind the hit, with its own accuracy step ahead
 ## of the roll. Without that step Thunder would be an ordinary attack, which is
 ## what it was here before the weather existed to read.
@@ -906,6 +919,7 @@ static func _sequences() -> Dictionary:
 		LIGHT_SCREEN: SCREEN_SEQUENCE,
 		REFLECT: SCREEN_SEQUENCE,
 		SAFEGUARD: SAFEGUARD_SEQUENCE,
+		PERISH_SONG: PERISH_SONG_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -56,6 +56,17 @@ const CANT_RUN: int = 1 << 14
 ## AI sets it here, since the player's pack has no X items yet.
 const X_ACCURACY: int = 1 << 15
 
+## `SUBSTATUS_PERISH`, `wPlayerSubStatus1` bit 4 on the cartridge and a bit of
+## its own here, since bit 4 of this int is the reserved one above. It sits on
+## each Pokémon that heard the song, with
+## [member Gen2BattleMon.perish_count] beside it.
+##
+## A switch cures it. `NewBattleMonStatus` and `NewEnemyMonStatus` zero all five
+## substatus bytes on a send-out and leave `wPlayerPerishCount` alone, but every
+## read of the count is behind the flag, so clearing both in
+## [method Gen2BattleMon.reset_volatile] is the same behavior.
+const PERISH: int = 1 << 16
+
 const NONE: int = 0
 
 ## How many turns a confused Pokémon stays that way, rolled the same shape as
@@ -98,6 +109,11 @@ const MAX_TRAP_TURNS: int = 6
 ## What a bound Pokémon loses each turn, `GetSixteenthMaxHP`'s at-least-one
 ## sixteenth (engine/battle/core.asm).
 const TRAP_DIVISOR: int = 16
+
+## What `BattleCommand_PerishSong` loads into each side's count. `HandlePerishSong`
+## decrements before it prints, so the four counts printed are 3, 2, 1 and 0, and
+## the song's own line says three turns.
+const PERISH_TURNS: int = 4
 
 ## Whether an attracted Pokémon is too smitten to move, out of 256: the
 ## cartridge's own 128 in 256, a coin flip, rolled fresh every turn it tries to

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -167,6 +167,10 @@ func save_screen_snapshot() -> Dictionary:
 		"game_id": String(_data.id) if _data != null else "",
 		"selected_slot": _selected_slot,
 		"new_game": _new_game_visible,
+		# Whether the name form is actually on screen, which is not the same
+		# question as whether it was asked for: a details pane that refused to
+		# draw leaves the flag up and the form absent.
+		"new_game_form": is_instance_valid(_name_input),
 		"status": _status_label.text if _status_label != null else "",
 		"detail": _status_detail.text if _status_detail != null else "",
 		"slots": _slots.duplicate(true),
@@ -350,9 +354,14 @@ func _refresh_details() -> void:
 	_slots_container.visible = not _new_game_visible
 	for child: Node in _details_box.get_children():
 		child.free()
-	var row: Dictionary = _row_for(_selected_slot)
-	if _data == null or row.is_empty():
+	if _data == null or _selected_slot < 0:
 		return
+	# A slot targeted for a new game has no row yet, since slots_for answers only
+	# what is on disk. Describing it as empty is what lets the form open on it;
+	# bailing here is what kept the "New slot" button from doing anything.
+	var row: Dictionary = _row_for(_selected_slot)
+	if row.is_empty():
+		row = Gen2SaveStore.empty_slot_row(_selected_slot)
 
 	var panel: Gen2LauncherCard = Gen2LauncherCard.create(_palette, Gen2LauncherTheme.RADIUS_MD, 22)
 	_details_box.add_child(panel)
@@ -391,7 +400,10 @@ func _refresh_details() -> void:
 	body.add_child(actions)
 	actions.add_child(_action("New game", Gen2LauncherButton.Variant.PRIMARY, &"plus", _request_new_game))
 	actions.add_child(_action("Import .sav", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_import))
-	_add_slot_management(body)
+	# Renaming, exporting or deleting a slot with no file behind it can only
+	# report failure, so a free slot is offered none of it.
+	if bool(row["exists"]):
+		_add_slot_management(body)
 
 
 ## Naming, export, deletion and the editor. Kept below the play actions,
@@ -521,7 +533,7 @@ func _build_new_game_form(body: VBoxContainer) -> void:
 	var actions: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
 	body.add_child(actions)
 	actions.add_child(_action("Create save", Gen2LauncherButton.Variant.PRIMARY, &"check", _create_from_form))
-	actions.add_child(_action("Cancel", Gen2LauncherButton.Variant.NEUTRAL, &"", _cancel_new_game))
+	actions.add_child(_action("Cancel", Gen2LauncherButton.Variant.NEUTRAL, &"", cancel_new_game))
 
 
 func _add_party_summary(body: VBoxContainer, save: Gen2SaveData) -> void:
@@ -593,11 +605,14 @@ func _on_replace_confirmed() -> void:
 
 
 func _create_from_form() -> void:
-	if _name_input != null:
+	# The field belongs to a details pane that is rebuilt whole, so the reference
+	# outlives the node it points at.
+	if is_instance_valid(_name_input):
 		create_new_game(_name_input.text)
 
 
-func _cancel_new_game() -> void:
+## Closes the new-game form, leaving the slot it was opened on selected.
+func cancel_new_game() -> void:
 	_new_game_visible = false
 	_refresh_details()
 

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -125,6 +125,21 @@ static func slots_for(game_id: StringName, rom_sha1: String, data: GameData) -> 
 	return out
 
 
+## The same row shape [method slots_for] returns, for a slot number with nothing
+## on disk. [method slots_for] answers only what exists, so this is what a caller
+## targeting a free slot describes it with, and it is the one row whose
+## [code]exists[/code] is false.
+static func empty_slot_row(slot: int) -> Dictionary:
+	return {
+		"slot": slot,
+		"exists": false,
+		"valid": false,
+		"label": "",
+		"player_name": "",
+		"message": "Empty",
+	}
+
+
 ## Slot numbers with a primary or backup copy on disk, ascending. Reads the
 ## directory rather than probing every number, so an empty game costs one
 ## listing instead of MAX_SLOTS existence checks.

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -116,6 +116,10 @@ const LIGHT_SCREEN: int = 113
 const REFLECT: int = 115
 const SAFEGUARD: int = 219
 
+## Perish Song, the same shape again: a real move number, no power, and an
+## accuracy its own sequence never rolls.
+const PERISH_SONG: int = 195
+
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
 ## the cartridge.
@@ -463,6 +467,7 @@ static func _moves() -> Array:
 		LIGHT_SCREEN: ["LIGHT SCREEN", 0, PSYCHIC_TYPE, 255, 30, Gen2MoveEffect.LIGHT_SCREEN, 0],
 		REFLECT: ["REFLECT", 0, PSYCHIC_TYPE, 255, 20, Gen2MoveEffect.REFLECT, 0],
 		SAFEGUARD: ["SAFEGUARD", 0, NORMAL, 255, 25, Gen2MoveEffect.SAFEGUARD, 0],
+		PERISH_SONG: ["PERISH SONG", 0, NORMAL, 255, 5, Gen2MoveEffect.PERISH_SONG, 0],
 		# Thunder with a paralysis chance the roll cannot fail, so the secondary
 		# behind its own effect can be seen without a seed. The accuracy byte is
 		# still the real 178, since that is what the weather rewrites.

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -503,3 +503,89 @@ func test_smart_heal_is_encouraged_once_the_ai_is_nearly_out() -> void:
 		if Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_SMART, _rng) == 0:
 			chose_heal += 1
 	assert_gt(chose_heal, 10, "the 90% branch should dominate twenty seeds")
+
+
+## `AI_Redundant.PerishSong` reads `wPlayerSubStatus1`, the target's own: a song
+## over a target already counting down restarts nothing, so it is a wasted turn.
+func test_basic_treats_a_second_perish_song_as_redundant() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.substatus |= Gen2Substatus.PERISH
+
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
+		)
+		assert_eq(slot, 1, "singing over a running count is the redundant move")
+
+
+## `.no`: with nobody left to send in, the song kills the AI too. Five points
+## against, and the only branch of the handler that rolls nothing.
+func test_smart_discourages_perish_song_with_nobody_on_the_bench() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+
+	for seed: int in 10:
+		_rng.seed = seed
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
+		)
+		assert_eq(slot, 1, "a lone Pokémon has no reason to start a clock on itself")
+
+
+## `.yes`: a player held by Mean Look or Spider Web cannot escape the count, so
+## the song is encouraged half the time.
+func test_smart_encourages_perish_song_against_a_player_that_cannot_run() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.substatus |= Gen2Substatus.CANT_RUN
+
+	var encouraged: bool = false
+	var left_alone: bool = false
+	for seed: int in 100:
+		_rng.seed = seed
+		var scores: Array = [20, 20, 20, 20]
+		Gen2BattleAI._apply_smart(
+			scores, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE,
+			Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE
+		)
+		if int(scores[0]) < 20:
+			encouraged = true
+		elif int(scores[0]) == 20:
+			left_alone = true
+	assert_true(encouraged, "half the time a trapped player is worth singing at")
+	assert_true(left_alone, "and half the time the coin says nothing")
+
+
+## The last branch, and the one that reads backwards: a matchup the AI is losing
+## (`CheckPlayerMoveTypeMatchups` under `BASE_AI_SWITCH_SCORE`) leaves the score
+## alone, while one it is winning is discouraged half the time.
+func test_smart_discourages_perish_song_only_while_the_matchup_holds() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+
+	for seed: int in 100:
+		_rng.seed = seed
+		var losing: Array = [20, 20, 20, 20]
+		Gen2BattleAI._apply_smart(
+			losing, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE,
+			Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE - 1
+		)
+		assert_eq(int(losing[0]), 20, "a losing matchup neither rolls nor nudges")
+
+	var discouraged: bool = false
+	var left_alone: bool = false
+	for seed: int in 100:
+		_rng.seed = seed
+		var scores: Array = [20, 20, 20, 20]
+		Gen2BattleAI._apply_smart(
+			scores, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE,
+			Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE
+		)
+		if int(scores[0]) > 20:
+			discouraged = true
+		elif int(scores[0]) == 20:
+			left_alone = true
+	assert_true(discouraged, "a matchup worth keeping is worth not ending")
+	assert_true(left_alone)

--- a/tests/unit/test_ai_switch.gd
+++ b/tests/unit/test_ai_switch.gd
@@ -217,3 +217,61 @@ func test_a_wild_battle_never_switches_or_uses_an_item() -> void:
 	var action: Dictionary = Gen2BattleAI.choose_action(battle, OFTEN, 0, _rng)
 
 	assert_eq(StringName(action["type"]), Gen2Battle.ACTION_MOVE)
+
+
+## `CheckAbleToSwitch` opens on Perish Song, ahead of every matchup check: with
+## one turn left on the count the AI leaves at [constant Gen2AISwitch.TIER_HIGH]
+## however well the fight is going, since staying is death.
+func test_the_last_turn_of_perish_song_forces_a_switch() -> void:
+	var battle: Gen2Battle = _comfortable()
+	battle.enemy.substatus |= Gen2Substatus.PERISH
+	battle.enemy.perish_count = 1
+
+	var choice: Dictionary = Gen2AISwitch.evaluate(battle)
+
+	assert_eq(int(choice["tier"]), Gen2AISwitch.TIER_HIGH, "the comfort check is never reached")
+	assert_eq(int(choice["index"]), 1, "the one Pokémon behind it")
+
+
+## Only a count of exactly one qualifies. Two is early enough to keep fighting,
+## so the matchup half decides as usual.
+func test_perish_song_with_two_turns_left_leaves_the_matchup_to_decide() -> void:
+	var battle: Gen2Battle = _comfortable()
+	battle.enemy.substatus |= Gen2Substatus.PERISH
+	battle.enemy.perish_count = 2
+
+	assert_eq(int(Gen2AISwitch.evaluate(battle)["tier"]), 0, "still comfortable, so it stays")
+
+
+## `.not_2`: with no super-effective answer on the bench the tier is unchanged
+## and the shortlist is discarded, the mask walk taking the lowest party index
+## still standing.
+func test_perish_song_without_a_good_answer_takes_the_lowest_alive_slot() -> void:
+	# Neither bench Pokémon has anything super effective against the Pikachu
+	# that is out, and the first of them is on one hit point, so the quarter-HP
+	# and resistance scans cannot be what chose it.
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, [Fixture.THUNDERBOLT]),
+		[
+			_mon(Fixture.CHARMANDER, [Fixture.GROWL]),
+			_mon(Fixture.BULBASAUR, [Fixture.TACKLE]),
+			_mon(Fixture.GEODUDE, [Fixture.TACKLE]),
+		]
+	)
+	battle.party(Gen2Battle.ENEMY).at(1).hp = 1
+	battle.enemy.substatus |= Gen2Substatus.PERISH
+	battle.enemy.perish_count = 1
+
+	var choice: Dictionary = Gen2AISwitch.evaluate(battle)
+
+	assert_eq(int(choice["tier"]), Gen2AISwitch.TIER_HIGH)
+	assert_eq(int(choice["index"]), 1, "the lowest index alive, hurt or not")
+
+
+## The flag without the count, and the count without the flag, are both nothing:
+## the source reads the count only behind `bit SUBSTATUS_PERISH`.
+func test_a_perish_count_without_the_flag_changes_nothing() -> void:
+	var battle: Gen2Battle = _comfortable()
+	battle.enemy.perish_count = 1
+
+	assert_eq(int(Gen2AISwitch.evaluate(battle)["tier"]), 0)

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -2766,3 +2766,144 @@ func test_safeguard_runs_down_and_stops_protecting() -> void:
 
 	assert_eq(_of_type(after, Gen2Battle.SAFEGUARD_PROTECTED).size(), 0)
 	assert_true(Gen2Status.has(battle.enemy.status, Gen2Status.PARALYSIS))
+
+
+## `BattleCommand_PerishSong` names `wPlayerSubStatus1` and `wEnemySubStatus1`
+## rather than the user and the target, so the singer is caught by its own song.
+## The count is four and the first tick spends one of them, which is why the
+## line promises three turns.
+func test_perish_song_catches_both_sides_and_starts_at_three() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_eq(_of_type(events, Gen2Battle.PERISH_SONG_STARTED).size(), 1, JSON.stringify(events))
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		assert_true(
+			Gen2Substatus.has(battle.mon(side).substatus, Gen2Substatus.PERISH),
+			"side %d heard it" % side,
+		)
+		assert_eq(battle.mon(side).perish_count, 3)
+
+	var counted: Array = _of_type(events, Gen2Battle.PERISH_COUNT)
+	assert_eq(counted.size(), 2, "both sides are counted down, player first")
+	assert_eq(counted[0]["side"], Gen2Battle.PLAYER)
+	assert_eq(counted[0]["count"], 3)
+	assert_eq(counted[1]["side"], Gen2Battle.ENEMY)
+
+
+## `.failed` is reached only when both sides already carry the flag: the song
+## fails outright rather than restarting either count.
+func test_perish_song_fails_when_both_are_already_counting_down() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var again: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_false(_first(again, Gen2Battle.MOVE_FAILED).is_empty(), JSON.stringify(again))
+	assert_eq(_of_type(again, Gen2Battle.PERISH_SONG_STARTED).size(), 0)
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		assert_eq(battle.mon(side).perish_count, 2, "the second song reset nothing")
+
+
+## `.ok` sets the flag on each side that lacks it and leaves the count of a side
+## that already has one alone, so the two clocks stay out of step.
+func test_perish_song_catches_only_the_side_that_missed_it() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.enemy.substatus |= Gen2Substatus.PERISH
+	battle.enemy.perish_count = 2
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	assert_false(_first(events, Gen2Battle.PERISH_SONG_STARTED).is_empty(), JSON.stringify(events))
+	assert_eq(battle.player.perish_count, 3, "the singer starts a fresh four")
+	assert_eq(battle.enemy.perish_count, 1, "the count already running is not restarted")
+
+
+## The zero tick clears the flag and empties the HP word outright, which is not
+## damage: nothing rolls, nothing is a fraction of anything, and both sides go
+## down on the same turn end.
+func test_perish_song_finishes_both_on_the_fourth_turn_end() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+
+	var last: Array = []
+	for turn: int in 4:
+		last = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+
+	var counted: Array = _of_type(last, Gen2Battle.PERISH_COUNT)
+	assert_eq(counted.size(), 2)
+	assert_eq(counted[0]["count"], 0, "the line prints on the tick that kills too")
+	assert_eq(_of_type(last, Gen2Battle.FAINTED).size(), 2, JSON.stringify(last))
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		assert_eq(battle.mon(side).hp, 0)
+		assert_true(battle.mon(side).is_fainted())
+		assert_false(Gen2Substatus.has(battle.mon(side).substatus, Gen2Substatus.PERISH))
+
+
+## `NewBattleMonStatus` clears all five substatus bytes on a send-out, so the
+## Pokémon that comes in has heard nothing. The count behind the flag goes with
+## it, which is what [method Gen2BattleMon.reset_volatile] is for.
+func test_a_switch_escapes_perish_song() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.create([
+			_mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG]),
+			_mon(Fixture.BULBASAUR, 50, [Fixture.GROWL]),
+		]),
+		Gen2Party.of(_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])), _rng, true
+	)
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var switching: Array = battle.take_actions(
+		Gen2Battle.switch_to(1), Gen2Battle.use_move(0)
+	)
+
+	assert_false(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PERISH),
+		"the Pokémon sent out never heard the song",
+	)
+	assert_eq(battle.player.perish_count, 0)
+	var counted: Array = _of_type(switching, Gen2Battle.PERISH_COUNT)
+	assert_eq(counted.size(), 1, "only the enemy is still counting")
+	assert_eq(counted[0]["side"], Gen2Battle.ENEMY)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.PERISH))
+
+
+## `HandleBetweenTurnEffects` runs `HandleWrap`, then `HandlePerishSong`, then
+## its leftovers block, of which `HandleSafeguard` is a part.
+func test_perish_song_ticks_after_wrap_and_before_the_leftovers_block() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.player.substatus |= Gen2Substatus.PERISH
+	battle.player.perish_count = 3
+	battle.player.trapped_turns = 3
+	battle.player.trapping_move = Fixture.WRAP
+	battle.screens[Gen2Battle.PLAYER] = Gen2Screens.SAFEGUARD
+	battle.safeguard_turns[Gen2Battle.PLAYER] = 1
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var order: Array = events.map(func(event: Dictionary) -> StringName: return event["type"])
+
+	assert_true(order.has(Gen2Battle.HURT_BY_TRAP), JSON.stringify(events))
+	assert_true(order.has(Gen2Battle.SCREEN_FADED), JSON.stringify(events))
+	assert_lt(
+		order.find(Gen2Battle.HURT_BY_TRAP), order.find(Gen2Battle.PERISH_COUNT),
+		"the wrap tick comes first",
+	)
+	assert_lt(
+		order.find(Gen2Battle.PERISH_COUNT), order.find(Gen2Battle.SCREEN_FADED),
+		"the leftovers block, Safeguard included, comes after",
+	)

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -59,11 +59,15 @@ func test_launcher_opens_on_the_shelf_and_moves_between_its_pages() -> void:
 func test_switching_appearance_rebuilds_the_launcher_and_keeps_its_status() -> void:
 	await _open_launcher()
 	var before: Dictionary = _launcher.launcher_snapshot()
-	assert_eq(before["theme"], "light")
+	# Whichever appearance this machine's options file holds. Naming one would
+	# assert the tester's own preference rather than the switch.
+	var opened := StringName(before["theme"])
+	assert_true(Gen2LauncherTheme.MODES.has(opened), String(opened))
 
-	_launcher.preview_theme(&"dark")
+	var wanted: StringName = Gen2LauncherTheme.for_mode(opened).other_mode()
+	_launcher.preview_theme(wanted)
 	var after: Dictionary = _launcher.launcher_snapshot()
-	assert_eq(after["theme"], "dark")
+	assert_eq(after["theme"], String(wanted))
 	# The shelf is rebuilt whole, so the message on it has to be carried over.
 	assert_eq(after["status"], before["status"])
 	assert_eq(after["detail"], before["detail"])

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -224,10 +224,47 @@ func test_the_screen_opens_a_new_slot_at_the_lowest_free_number() -> void:
 	await _open_save_screen()
 
 	assert_true(_screen.open_new_slot())
+	var snapshot: Dictionary = _screen.save_screen_snapshot()
 	assert_eq(
-		_screen.save_screen_snapshot()["selected_slot"], 0,
+		snapshot["selected_slot"], 0,
 		"slot 1 is taken, so the new one is slot 0",
 	)
+	# The slot number alone is not the button working. A free slot has no row in
+	# `slots_for`, and a details pane that refuses to draw one leaves the player
+	# looking at an empty screen with no way to name a save.
+	assert_true(snapshot["new_game"], "the form is asked for")
+	assert_true(snapshot["new_game_form"], "and is actually on screen")
+
+
+## A free slot is not a file, so the four things that act on the file are not
+## offered on one. Cancelling back onto it leaves the slot described rather than
+## blank.
+func test_cancelling_a_new_slot_describes_it_instead_of_blanking_the_pane() -> void:
+	assert_true(Gen2SaveStore.save(_save(), _data)["ok"])
+	await _open_save_screen()
+
+	assert_true(_screen.open_new_slot())
+	_screen.cancel_new_game()
+	var snapshot: Dictionary = _screen.save_screen_snapshot()
+
+	assert_false(snapshot["new_game"])
+	assert_false(snapshot["new_game_form"])
+	assert_eq(snapshot["selected_slot"], 0, "still pointing at the free slot")
+
+
+## The form opens on a game with no saves at all, which is the only way into a
+## first playthrough from the launcher.
+func test_a_game_with_no_saves_can_still_open_the_new_game_form() -> void:
+	await _open_save_screen()
+	assert_eq(_screen.save_screen_snapshot()["selected_slot"], -1, "nothing to select")
+
+	assert_true(_screen.open_new_slot())
+	var snapshot: Dictionary = _screen.save_screen_snapshot()
+
+	assert_eq(snapshot["selected_slot"], 0)
+	assert_true(snapshot["new_game_form"])
+	assert_true(_screen.create_new_game("ASH"))
+	assert_true(Gen2SaveStore.exists(_data.id, _data.sha1, 0))
 
 
 func test_creating_a_new_game_with_nothing_selected_takes_a_free_slot() -> void:


### PR DESCRIPTION
Perish Song is `SUBSTATUS_PERISH` and a count on each Pokémon on the field rather than a screen or a status, so a switch escapes it the way `NewBattleMonStatus` zeroing all five substatus bytes does. `BattleCommand_PerishSong` names both sides outright instead of the user and the target, so the singer is caught too, a side already counting down keeps the count it has, and the move fails only when that is true of both. `HandlePerishSong` ticks between the wrap and the leftovers block, player first, prints on every tick including the last, and empties the HP word at zero rather than dealing damage.

`CheckAbleToSwitch`'s opening branch answers with it, so `TIER_HIGH` and its three frequencies are reachable and a trainer makes the panicked switch on the last turn of the count. `AI_Redundant.PerishSong` and `AI_Smart_PerishSong` come with it, the second reading `FindAliveEnemyMons` and `CheckPlayerMoveTypeMatchups` through two new flat parameters on `choose_slot`, supplied the way the weather and the two screen words already are.

Two defects met on the way. The launcher's "New slot" button drew nothing at all: a free slot has no row in `slots_for`, and the details pane returned before building anything, leaving the pane blank with no way to name a save. `Gen2SaveStore.empty_slot_row()` describes it instead, which is what the three `not row["exists"]` branches were already written for, and the four file actions are withheld from a slot with no file. And the appearance test asserted the machine's own saved `ui_theme` rather than the switch.