### PR TITLE
Stop the toast from swallowing the shelf's own buttons

### DIFF
--- a/game/launcher/launcher_toast.gd
+++ b/game/launcher/launcher_toast.gd
@@ -35,6 +35,10 @@ func _build() -> void:
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 	set_anchors_and_offsets_preset(Control.PRESET_BOTTOM_WIDE)
 	modulate.a = 0.0
+	# A toast that has faded out is gone, not merely transparent. Alpha alone
+	# leaves the card in the hit test over whatever the page put at the bottom
+	# of the screen, which on the shelf is Play and the cache button.
+	visible = false
 
 	var centre := CenterContainer.new()
 	centre.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
@@ -43,7 +47,9 @@ func _build() -> void:
 
 	_card = Gen2LauncherCard.floating(_theme, Gen2LauncherTheme.RADIUS_MD, 16, 20)
 	_card.custom_minimum_size = Vector2(360, 0)
-	_card.mouse_filter = Control.MOUSE_FILTER_STOP
+	# Nothing in here is clickable, so nothing in here takes a click. The card
+	# is the width of the shelf's action row and sits exactly on top of it.
+	_card.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	centre.add_child(_card)
 
 	var column: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
@@ -66,6 +72,8 @@ func _build() -> void:
 	_progress.show_percentage = false
 	_progress.custom_minimum_size = Vector2(0, 5)
 	_progress.visible = false
+	# A bar that reports progress is read, never dragged.
+	_progress.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	column.add_child(_progress)
 
 
@@ -116,13 +124,16 @@ func hide_message() -> void:
 	set_progress(false)
 	if not is_inside_tree():
 		modulate.a = 0.0
+		visible = false
 		return
 	_fade = _restart_fade()
 	_fade.tween_property(self, "modulate:a", 0.0, 0.20)
 	_fade.tween_property(_card, "position:y", _card.position.y + 12.0, 0.20)
+	_fade.chain().tween_callback(func() -> void: visible = false)
 
 
 func _raise() -> void:
+	visible = true
 	if _shown or not is_inside_tree():
 		modulate.a = 1.0
 		_shown = true

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -200,3 +200,45 @@ func test_index_install_requires_the_download_to_be_the_listed_mod() -> void:
 	assert_true(right["ok"], JSON.stringify(right))
 	assert_eq(right["id"], PROBE_MOD_ID)
 	assert_string_contains(dialog.status_text(), "Installed")
+
+
+## A toast with nothing to say occupies nothing: not drawn, and not in the hit
+## test either.
+func test_a_silent_toast_is_not_on_screen_at_all() -> void:
+	await _open_launcher()
+	var toast: Gen2LauncherToast = _find_toast(_launcher)
+	assert_not_null(toast)
+
+	assert_false(toast.visible, "an empty toast is gone rather than transparent")
+	toast.show_message(&"error", "Something", "happened")
+	assert_true(toast.visible)
+
+
+## And it never takes a click, shown or not. The toast is drawn over the bottom
+## centre of every launcher page, which is where the shelf puts Play and the
+## cache button; a card that stopped the mouse left both of them dead.
+func test_a_toast_never_takes_a_click_from_what_is_under_it() -> void:
+	await _open_launcher()
+	var toast: Gen2LauncherToast = _find_toast(_launcher)
+	toast.show_message(&"error", "Something", "happened")
+
+	var stopping: Array[String] = []
+	_mouse_stoppers(toast, stopping)
+	assert_eq(stopping, [] as Array[String], "nothing in a toast is clickable")
+
+
+func _mouse_stoppers(node: Node, out: Array[String]) -> void:
+	if node is Control and node.mouse_filter == Control.MOUSE_FILTER_STOP:
+		out.append("%s %s" % [node.get_class(), node.name])
+	for child: Node in node.get_children():
+		_mouse_stoppers(child, out)
+
+
+func _find_toast(node: Node) -> Gen2LauncherToast:
+	if node is Gen2LauncherToast:
+		return node
+	for child: Node in node.get_children():
+		var found: Gen2LauncherToast = _find_toast(child)
+		if found != null:
+			return found
+	return null

--- a/tools/validate_clickable.gd
+++ b/tools/validate_clickable.gd
@@ -1,0 +1,146 @@
+extends SceneTree
+
+## Checks that every button a launcher screen shows can actually be pressed.
+##
+##   Godot --path . -s res://tools/validate_clickable.gd
+##
+## A button that is wired correctly and drawn in the right place is still dead
+## if something transparent is sitting on top of it, and nothing in the scene
+## tree says so: the overlay is visible, the button is visible, and only the
+## viewport's own hit test knows which one a click reaches. So this asks the
+## viewport, one button at a time, through the same path a mouse takes.
+##
+## Not a GUT test. These screens lay themselves out against the window, and the
+## test harness gives them neither its size nor a real hit test, so under GUT
+## every rect falls outside the viewport and the walk finds nothing to check.
+## `test_launcher.gd` keeps the half that is checkable headlessly, which is that
+## a toast contains nothing a click can land on.
+
+## The size the launcher is designed against. A window this size puts every
+## screen's own actions on screen without scrolling.
+const WINDOW := Vector2i(1280, 800)
+
+const SCREENS: Array[String] = [
+	"res://game/main/main.tscn",
+	"res://game/save/save_screen.tscn",
+]
+
+var _screen: Node = null
+var _step: int = 0
+var _settle: int = 0
+var _pending: Array = []
+var _checking: Gen2LauncherButton = null
+## Frames to let a motion event reach the viewport's hover state before it is
+## read back. One is not always enough.
+var _aimed: int = 0
+var _problems: int = 0
+var _checked: int = 0
+
+
+func _initialize() -> void:
+	DisplayServer.window_set_size(WINDOW)
+	root.set_content_scale_size(WINDOW)
+	root.size = WINDOW
+	# The save screen needs a cartridge and a slot to have anything to draw.
+	var runtime: Node = root.get_node_or_null(NodePath("GameRuntime"))
+	for game_id: StringName in RomRegistry.ORDER:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			continue
+		runtime.call("select_game", game_id)
+		var slots: Array = Gen2SaveStore.slots_for(data.id, data.sha1, data)
+		if not slots.is_empty():
+			runtime.call("select_save_slot", game_id, int(slots[0]["slot"]))
+		break
+
+
+func _process(_delta: float) -> bool:
+	if _checking != null:
+		_aimed += 1
+		if _aimed < 3:
+			return false
+		_aimed = 0
+		_report(_checking)
+		_checking = null
+		if _pending.is_empty():
+			_screen.free()
+			_screen = null
+		return false
+
+	if not _pending.is_empty():
+		_checking = _pending.pop_front()
+		_aim_at(_checking)
+		return false
+
+	if _screen != null:
+		_settle += 1
+		if _settle < 20:
+			return false
+		_settle = 0
+		_collect(_screen, _pending)
+		if _pending.is_empty():
+			print("  no visible buttons")
+			_screen.free()
+			_screen = null
+		return false
+
+	_settle += 1
+	if _settle < 20:
+		return false
+	_settle = 0
+	if _step < SCREENS.size():
+		print(SCREENS[_step])
+		_screen = load(SCREENS[_step]).instantiate()
+		root.add_child(_screen)
+		_step += 1
+		return false
+
+	print("%d buttons checked, %d unreachable" % [_checked, _problems])
+	quit(1 if _problems > 0 else 0)
+	return true
+
+
+func _report(button: Gen2LauncherButton) -> void:
+	_checked += 1
+	var hovered: Control = root.gui_get_hovered_control()
+	var label: String = button.text if not button.text.is_empty() \
+		else "<icon at %s>" % button.get_global_rect().position
+	if hovered != button:
+		_problems += 1
+		print("  UNREACHABLE  %-24s a click lands on %s instead" % [
+			label, hovered.get_class() if hovered != null else "nothing",
+		])
+		return
+	# One connection is [Gen2LauncherButton]'s own press sound, so a button
+	# carrying only that one reaches nothing when it is pressed.
+	if button.pressed.get_connections().size() <= 1:
+		_problems += 1
+		print("  DEAD         %-24s nothing is connected to pressed" % label)
+
+
+func _aim_at(button: Control) -> void:
+	var motion := InputEventMouseMotion.new()
+	motion.position = button.get_global_rect().get_center()
+	motion.global_position = motion.position
+	Input.parse_input_event(motion)
+
+
+## Every button a player can see: on screen, and inside every clipping ancestor.
+## One scrolled below a fold is out of view rather than broken, so it is left
+## out; the point of the check is the buttons that look pressable.
+func _collect(node: Node, out: Array) -> void:
+	if node is Gen2LauncherButton and node.is_visible_in_tree() and _on_screen(node):
+		out.append(node)
+	for child: Node in node.get_children():
+		_collect(child, out)
+
+
+func _on_screen(button: Control) -> bool:
+	var rect: Rect2 = button.get_global_rect()
+	var parent: Node = button.get_parent()
+	while parent is Control:
+		var ancestor: Control = parent
+		if ancestor.clip_contents and not ancestor.get_global_rect().encloses(rect):
+			return false
+		parent = ancestor.get_parent()
+	return Rect2(Vector2.ZERO, Vector2(WINDOW)).encloses(rect)

--- a/tools/validate_clickable.gd.uid
+++ b/tools/validate_clickable.gd.uid
@@ -1,0 +1,1 @@
+uid://ri5s1rxrsola


### PR DESCRIPTION
The launcher's toast is anchored across the bottom of every page and its card is the width of the shelf's action row, sitting exactly on top of Play and the cache button. The card stopped the mouse and the toast hid itself by fading alpha alone, so a faded toast stayed in the hit test and both buttons were dead: correctly wired, plainly visible, impossible to press. Clicking a cartridge still worked, which is why only those two looked broken.

Nothing inside a toast is clickable now, the progress bar included, and a toast with nothing to say leaves the tree's hit test rather than going transparent in it.

`tools/validate_clickable.gd` aims a real motion event at every visible button on the launcher and the save screen and asks the viewport which control a click would reach, since no property on either node says this is happening. A GUT test covers the half that survives the harness, which is that a toast contains nothing a click can land on.