### PR TITLE
Give a battle renderer the place, and walk the sprites

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ all three games unless its row says otherwise:
 | `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
+| `preview_collision.gd <game> <group> <number> <png>` | one whole map as drawn, with every walk cell's permission checkerboarded over it: red is wall, blue is water. For a report that the player can stand where they should not |
+| `preview_overworld_sprites.gd <game> <png>` | every overworld sprite in a cache as one contact sheet, four facings across by four frames down, for eyeballing offsets, mirroring and frame order |
 | `validate_story_map_ids.gd` | the four maps the story route names by id rather than by cell, each against the map its number holds on the other profile |
 | `validate_crystal_route30_trainer.gd` | trainer record, sight line, approach, battle request, beaten flag, later interaction |
 | `validate_ledge_hops.gd` | the eight hop codes, accepted directions, Route 30's ledge record and the two-cell landing, in both games |

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -358,6 +358,26 @@ Registration uses the same refusal rules as a world renderer, and shares both
 optional methods (`uses_hardware_viewport()`, `set_native_size()`) and the `V`
 cycle, bound in `Gen2BattleScreen` the way `Gen2WorldScreen` binds it.
 
+A battle renderer has one optional method of its own:
+
+| Method | Effect |
+|---|---|
+| `set_world_context(context: Gen2BattleWorldContext)` | Where the battle is being fought, once per battle, after `set_battle_data` and before the first view |
+
+`view` says what is on the field and nothing about the place, which is right for
+the cartridge's white field and leaves a renderer staging the fight on the map
+with nowhere to stage it. `Gen2BattleWorldContext` is that place, and it carries
+`map_id` (group and number), `tileset`, `player_cell`, `player_facing` and
+`time_of_day`, the last being the row the world was *drawn* with rather than the
+clock's, so a battle entered from an unlit cave is staged in the dark.
+
+It is a copy taken when the battle starts, not a handle on the world: a renderer
+cannot reach live world state through it, and the two screens stay independent.
+The map and tileset are numbers, which is what `GameData.world_map()` and
+`world_tileset()` take, so a renderer resolves whatever records it wants through
+the `GameData` it already has. A battle started outside the world, which is
+every development driver, supplies none and the method is not called.
+
 ## Logical world state and optional mod pose
 
 The game stays logically grid-based. The player and NPCs occupy walk cells,
@@ -406,27 +426,37 @@ Supported by the contract above:
   commits at the start of the step; the fraction is presentation only and never
   reaches collision, events or the world snapshot.
   `mods/examples/voxel_preview/` reads both;
+- scripted movement progress, on the same two calls. An `applymovement` applies
+  its whole stream at once, so every cell of the path commits together and the
+  offset is as many cells behind as there are left to draw.
+  `advance_scripted_steps(delta)` drains that trail and is the one mover a
+  screen keeps calling while a script runs, since that is when a script runs
+  one. Each step lasts its own command's duration: 16 frames for the slow
+  commands, 8 for the plain ones, 4 for the bike-speed ones;
+- a walking sprite. `Gen2WorldObject.frame` and `Gen2WorldAPI.player_walk_frame()`
+  are the cartridge's `Facings` index, 0 to 3: two standing drawings and two
+  walking ones, changing every four frames of a step the way
+  `SetFacingStepAction` does. `Gen2WorldSprite.image_for()` composes the frame,
+  and `frame_is_mirrored()` says when it is drawn flipped;
 - a camera of its own, through `player_position_cells()` and
   `visible_origin_cells()` above, without inheriting the tile page's framing;
 - steering that camera, through `handle_world_input`. `mods/examples/voxel_preview/`
   puts pitch on `Q` and `E`, two keys the world screen does not read.
 
-What is still missing, in the order it blocks work:
+What is still missing:
 
-1. **Per-tile height.** Extruded height is a guess from the collision
-   permission, which cannot tell a tree from a cliff from a building. Gen II
-   has no height data, so a renderer needs a per-block table it supplies
-   itself, and the host should let a mod attach one rather than have every
-   renderer hard-code Johto.
-2. **Interiors are not renderer-owned.** Only the overworld and battle are
-   registered; a 3D interior view has no equivalent boundary here.
-3. **Scripted movement does not interpolate.** `applymovement` streams, and the
-   jump, teleport and boulder step types, still place objects a whole cell at a
-   time. The wandering, spinning, following, player and trainer-approach paths
-   all carry the sub-cell offset.
+1. **The teleport, skyfall and dig step types.** `teleport_from`,
+   `teleport_to`, `skyfall` and `step_dig` reach the caller as a
+   `movement_command_requested` event and change nothing. None of them moves a
+   cell on the cartridge either: each is a spin, a rise or a fall over a fixed
+   count of frames (`StepFunction_TeleportFrom` and its neighbours in
+   `engine/overworld/map_objects.asm`), so each is a pose a renderer has to be
+   told about rather than an offset it can read.
 
-All three are presentation boundaries that do not exist yet; none of them
-changes the world's own data.
+**Per-block height is deliberately not a host boundary.** A renderer resolves
+shape from the collision permissions, the block grid and the tileset, all of
+which are already public, and keeps whatever table it needs beside its own
+resolver. A host-side one would be a second place for the same facts.
 
 ## Adding a menu entry
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -177,6 +177,10 @@ var _frame_elapsed: float = 0.0
 ## that read it. Only the world path supplies one; the development drivers below
 ## leave [Gen2Battle] at its own midday default.
 var _time_of_day: int = Gen2WorldPalette.TIME_DAY
+## Where the battle is being fought, for a renderer that draws the place rather
+## than a white field. Null unless the caller supplied one; see
+## [method set_world_context].
+var _world_context: Gen2BattleWorldContext = null
 var _capture_balls: Array[int] = []
 var _capture_quantities: Dictionary = {}
 var _capture_ball_index: int = 0
@@ -1052,6 +1056,21 @@ func battle_snapshot() -> Dictionary:
 ## started; a battle begun without it stands at midday.
 func set_time_of_day(value: int) -> void:
 	_time_of_day = value
+
+
+## Supplies where the battle is being fought, for a renderer that stages it on
+## the map. Set before the scene enters the tree, the way the data source is:
+## the renderer is built in _ready() and is handed this straight after
+## [method Gen2BattleRenderer.set_battle_data]. Nothing in the battle itself
+## reads it.
+func set_world_context(context: Gen2BattleWorldContext) -> void:
+	_world_context = context
+	_push_world_context()
+
+
+## What a renderer was handed, or null for a battle started outside the world.
+func world_context() -> Gen2BattleWorldContext:
+	return _world_context
 
 
 ## Supplies the wild battle with the supported balls currently owned by the
@@ -2185,7 +2204,19 @@ func _build_renderer() -> void:
 		_screen.native_size_changed.connect(_on_native_size_changed)
 		_on_native_size_changed(_screen.native_size())
 	_renderer_ready = bool(_renderer.set_battle_data(_data))
+	_push_world_context()
 	_push_view()
+
+
+## Hands the renderer where the battle is being fought, when the caller supplied
+## it and the renderer asked for it. After set_battle_data() and before the first
+## view, so a renderer that builds the place once has it before it draws; a
+## renderer swapped in mid-battle gets it again here.
+func _push_world_context() -> void:
+	if not _renderer_ready or _world_context == null:
+		return
+	if _renderer.has_method(Gen2ModHost.RENDERER_WORLD_CONTEXT_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_WORLD_CONTEXT_METHOD, _world_context)
 
 
 func _on_native_size_changed(size_pixels: Vector2i) -> void:

--- a/game/battle/battle_world_context.gd
+++ b/game/battle/battle_world_context.gd
@@ -1,0 +1,64 @@
+class_name Gen2BattleWorldContext
+extends RefCounted
+
+## Where a battle is being fought, as the world was when it started.
+##
+## [Gen2BattleScreen] hands a battle renderer display values and nothing else,
+## which is all the cartridge's own battle needs. A renderer staging the fight on
+## the map instead of on a white field needs the place as well, so this carries
+## it: the map and its tileset, the player's cell and facing, and the time of day
+## the world was drawn with.
+##
+## It is a copy taken at battle start, not a handle on the world: a renderer
+## cannot reach live world state through it and the two screens stay
+## independent. The map and tileset are named by number, which is what
+## [method GameData.world_map] and [method GameData.world_tileset] take, so a
+## renderer resolves the records it wants through the [GameData] it was already
+## given.
+
+## Group and number, the pair every map is addressed by, as
+## [member Gen2WorldSnapshot.map_id] holds it.
+var map_id: Vector2i = Vector2i(-1, -1)
+var tileset: int = -1
+var player_cell: Vector2i = Vector2i.ZERO
+var player_facing: int = Gen2WorldSprite.FACING_DOWN
+## The row the world was drawn with rather than the hour: a dark cave is night
+## until Flash is used. See [method Gen2WorldPalette.map_time_of_day].
+var time_of_day: int = Gen2WorldPalette.TIME_DAY
+
+
+## The world's own values, read once. [param drawn_time_of_day] is the caller's,
+## because the palette row a screen draws with is the screen's answer and not
+## the world's; passing -1 takes the world's map row.
+static func capture(
+	world: Gen2WorldAPI, drawn_time_of_day: int = -1
+) -> Gen2BattleWorldContext:
+	if world == null or world.current_map == null:
+		return null
+	var out := Gen2BattleWorldContext.new()
+	out.map_id = Vector2i(world.current_map.group, world.current_map.number)
+	out.tileset = world.current_map.tileset
+	out.player_cell = world.player_cell
+	out.player_facing = world.player_facing
+	out.time_of_day = clampi(
+		drawn_time_of_day if drawn_time_of_day >= 0 else world.map_time_of_day(), 0, 3
+	)
+	return out
+
+
+func map_group() -> int:
+	return map_id.x
+
+
+func map_number() -> int:
+	return map_id.y
+
+
+func to_dictionary() -> Dictionary:
+	return {
+		"map_id": map_id,
+		"tileset": tileset,
+		"player_cell": player_cell,
+		"player_facing": player_facing,
+		"time_of_day": time_of_day,
+	}

--- a/game/battle/battle_world_context.gd.uid
+++ b/game/battle/battle_world_context.gd.uid
@@ -1,0 +1,1 @@
+uid://dw6i4s6cuufhi

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -61,7 +61,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 33
+const FORMAT_VERSION: int = 34
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1106,7 +1106,13 @@ const CRYSTAL: Dictionary = {
 	"tileset_palette_bank": 0x13,
 	"world_palette_offset": 0xB319,
 	"overworld_sprites": 0x14736,
-	"overworld_sprite_count": 99,
+	## NUM_OVERWORLD_SPRITES (constants/sprite_constants.asm), which is the last
+	## constant's own value: SPRITE_STANDING_YOUNGSTER is $66. Crystal's four rows
+	## past pokegold's SPRITE_SILVER_TROPHY are Kris, Kris on a bike, Kurt
+	## outside, the three beasts and the standing youngster. Reading 99 stopped at
+	## SPRITE_SUICUNE and left thirteen map objects with no sprite, which is also
+	## no collision: see Gen2WorldAPI.object_at().
+	"overworld_sprite_count": 102,
 	"overworld_sprite_palettes": 0xB469,
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -392,11 +392,20 @@ static func _read_overworld_sprites(rom: RomFile, layout: Dictionary) -> Diction
 		if default_palette < 0 or default_palette >= RomLayout.OVERWORLD_SPRITE_PALETTE_COUNT:
 			return _error("Overworld sprite %d has palette %d." % [number, default_palette])
 
+		# A walking sprite's record names half its graphics. GetUsedSprite
+		# (engine/overworld/overworld.asm, identical in both pins) copies the
+		# recorded length to vTiles0 and then the same length again, from
+		# straight after it, to vTiles1: the standing drawings and the walking
+		# ones. Only a still sprite is skipped, by _DoesSpriteHaveFacings, and a
+		# standing sprite's second half is whatever follows it, which nothing
+		# ever draws because a standing sprite never steps.
+		var read_size: int = byte_size * 2 if sprite_type == Gen2WorldSprite.TYPE_WALKING \
+			else byte_size
 		var graphics_offset: int = RomFile.linear(bank, address)
-		var raw: PackedByteArray = rom.slice(graphics_offset, byte_size)
-		if raw.size() != byte_size:
+		var raw: PackedByteArray = rom.slice(graphics_offset, read_size)
+		if raw.size() != read_size:
 			return _error("Overworld sprite %d graphics are truncated." % number)
-		var tiles: int = floori(float(byte_size) / float(Gen2Tiles.TILE_BYTES))
+		var tiles: int = floori(float(read_size) / float(Gen2Tiles.TILE_BYTES))
 		var pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(raw, 0, tiles)
 		if pixels.size() != tiles * Gen2Tiles.TILE_PIXELS:
 			return _error("Overworld sprite %d graphics did not decode." % number)
@@ -405,7 +414,7 @@ static func _read_overworld_sprites(rom: RomFile, layout: Dictionary) -> Diction
 			"number": number,
 			"address": address,
 			"bank": bank,
-			"bytes": byte_size,
+			"bytes": read_size,
 			"tiles": tiles,
 			"type": sprite_type,
 			"palette": default_palette,

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -45,6 +45,12 @@ const RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
 ## created and whenever the window changes it. Only reached by a renderer that
 ## asked for the native layer. Shared by both renderer kinds.
 const RENDERER_RESIZE_METHOD: String = "set_native_size"
+## Optional, battle renderers only. Called with a [Gen2BattleWorldContext] once
+## per battle, before the first [code]set_view[/code], when the battle was
+## entered from the world. It is where the fight is happening: a renderer staging
+## it on the map needs that, and one drawing the cartridge's white field ignores
+## it. A development battle started outside the world passes null.
+const RENDERER_WORLD_CONTEXT_METHOD: String = "set_world_context"
 ## Optional, world renderers only. Offered every input event the world screen
 ## chose not to use, so a renderer can own camera pitch, first person or
 ## free-roam. Answering true consumes the event.

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -35,6 +35,25 @@ const STEP_FRAMES_NPC_WALK: int = 16
 ## MovementFunction_Strength calls InitStep with `direction | 0`, so a pushed
 ## boulder indexes that same slow row and slides at a wandering NPC's speed.
 const STEP_FRAMES_BOULDER_PUSH: int = STEP_FRAMES_NPC_WALK
+## StepVectors' fast row: 4 pixels per frame for 4 frames, which the bike-speed
+## movement commands reach through `STEP_BIKE`.
+const STEP_FRAMES_FAST: int = 4
+## How long each scripted step command takes, from the `STEP_*` speed it passes
+## to `InitStep` (engine/overworld/movement.asm) and that row of `StepVectors`.
+## `turn_step` is the one that indexes no row: `TurnStep` sets STEP_TYPE_TURN,
+## whose two halves are two frames each (`StepFunction_Turn`).
+const SCRIPTED_STEP_FRAMES: Dictionary = {
+	&"turn_step": 4,
+	&"slow_step": STEP_FRAMES_NPC_WALK,
+	&"step": STEP_FRAMES_WALK,
+	&"big_step": STEP_FRAMES_FAST,
+	&"slow_slide_step": STEP_FRAMES_NPC_WALK,
+	&"slide_step": STEP_FRAMES_WALK,
+	&"fast_slide_step": STEP_FRAMES_FAST,
+	&"slow_jump_step": STEP_FRAMES_NPC_WALK,
+	&"jump_step": STEP_FRAMES_WALK,
+	&"fast_jump_step": STEP_FRAMES_FAST,
+}
 ## RandomStepDuration_Slow and _Fast mask the source random byte before storing
 ## it as the wait preceding the next movement decision.
 const IDLE_MASK_SLOW: int = 0x7F
@@ -152,9 +171,17 @@ var _player_step_direction: Vector2i = Vector2i.ZERO
 var _player_step_frames_total: int = 0
 var _player_step_frames_remaining: int = 0
 var _player_step_accumulator: float = 0.0
+## The rest of a scripted movement stream the player still has to be drawn
+## walking, the way Gen2WorldObject.queued_steps holds an object's.
+var _player_queued_steps: Array = []
+## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
+var _player_step_frame: int = 0
 ## Real time banked toward the next hardware frame of object movement, held
 ## beside the player's own accumulator so the two stay in phase after a stall.
 var _object_step_accumulator: float = 0.0
+## The same for the presentation trail a scripted movement leaves, which is
+## drained by its own driver because that one runs while a script does.
+var _scripted_step_accumulator: float = 0.0
 ## Read-only mirror of the selected save's party, refreshed by the screen
 ## whenever the save or party changes. Gen2WorldAPI does not own a save, so
 ## this stays optional; a script that reads it while empty fails rather than
@@ -390,14 +417,40 @@ func player_step_in_progress() -> bool:
 ## from 1.0 cell behind player_cell down to zero, so a renderer that does not
 ## think in hardware pixels (a 3D or free-roam mod) can still smooth against
 ## it without reverse-engineering CELL_PIXELS.
+##
+## A scripted movement commits its whole path at once, so while its trail drains
+## this is as many cells behind as the player has left to be drawn walking.
 func player_step_offset_cells() -> Vector2:
-	if _player_step_frames_remaining <= 0 or _player_step_frames_total <= 0:
-		return Vector2.ZERO
-	var fraction: float = float(_player_step_frames_remaining) / float(_player_step_frames_total)
-	return Vector2(-_player_step_direction.x, -_player_step_direction.y) * fraction
+	var behind := Vector2.ZERO
+	for entry: Dictionary in _player_queued_steps:
+		behind -= Vector2(entry["direction"] as Vector2i)
+	if _player_step_frames_remaining > 0 and _player_step_frames_total > 0:
+		behind -= Vector2(_player_step_direction) \
+			* (float(_player_step_frames_remaining) / float(_player_step_frames_total))
+	return behind
+
+
+## The player's `Facings` frame, 0 to 3. `Gen2WorldObject.walk_frame()` for an
+## object; the player's own step is paced here rather than on a record.
+func player_walk_frame() -> int:
+	return (_player_step_frame >> 2) & 3
 
 
 func _start_player_step(direction: Vector2i, frames: int) -> void:
+	_player_queued_steps.clear()
+	_begin_player_step(direction, frames)
+
+
+## One step of a scripted stream, behind whatever the player is already walking.
+## See Gen2WorldObject.queue_step().
+func _queue_player_step(direction: Vector2i, frames: int) -> void:
+	if _player_step_frames_remaining > 0:
+		_player_queued_steps.append({"direction": direction, "frames": maxi(0, frames)})
+		return
+	_begin_player_step(direction, frames)
+
+
+func _begin_player_step(direction: Vector2i, frames: int) -> void:
 	_player_step_direction = direction
 	_player_step_frames_total = maxi(0, frames)
 	_player_step_frames_remaining = _player_step_frames_total
@@ -408,6 +461,8 @@ func _clear_player_step() -> void:
 	_player_step_frames_total = 0
 	_player_step_frames_remaining = 0
 	_player_step_accumulator = 0.0
+	_player_queued_steps.clear()
+	_player_step_frame = 0
 
 
 ## Advances the player's walk-step offset by real elapsed time, at
@@ -426,7 +481,11 @@ func advance_player_step(delta: float) -> bool:
 	while _player_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS \
 		and _player_step_frames_remaining > 0:
 		_player_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
+		_player_step_frame = (_player_step_frame + 1) & 0x0F
 		_player_step_frames_remaining -= 1
+		if _player_step_frames_remaining <= 0 and not _player_queued_steps.is_empty():
+			var next: Dictionary = _player_queued_steps.pop_front()
+			_begin_player_step(next["direction"], int(next["frames"]))
 		changed = true
 	return changed
 
@@ -1817,10 +1876,29 @@ func event_flag_active(flag: int) -> bool:
 	return state.is_event_flag_active(flag)
 
 
+## The objects a renderer can draw: active, not deleted, and with graphics this
+## build imported. Drawing is the only thing that may ask for a sprite; see
+## [method active_objects] for everything else.
 func visible_objects() -> Array:
 	var out: Array = []
 	for object: Gen2WorldObject in objects:
 		if object.active and not object.deleted and object.sprite != null:
+			out.append(object)
+	return out
+
+
+## Every object that is really there, whether or not this build can draw it.
+##
+## `ReadObjectEvents` builds `wMapObjects` from the map's own event data and
+## `LoadSpriteGFX` fills VRAM afterwards, so on the cartridge an object exists
+## before, and independently of, its graphics. Collision, interaction, sight and
+## NPC movement all walk the object table and none of them asks what loaded.
+## Keeping the two apart here is what stops a missing sprite from quietly
+## deleting an object out of the world as well as off the screen.
+func active_objects() -> Array:
+	var out: Array = []
+	for object: Gen2WorldObject in objects:
+		if object.active and not object.deleted:
 			out.append(object)
 	return out
 
@@ -1832,8 +1910,7 @@ func object_at(cell: Vector2i, visible_only: bool = true) -> Gen2WorldObject:
 	for object: Gen2WorldObject in objects:
 		if not object.occupies(cell) or object.deleted or (visible_only and not object.active):
 			continue
-		if object.sprite != null:
-			return object
+		return object
 	return null
 
 
@@ -2979,16 +3056,17 @@ func _apply_object_movement(event: Dictionary) -> Array:
 		if kind == &"turn_away":
 			object.apply_direction(-_movement_direction(int(command.get("direction", 0))))
 			continue
-		if kind in [
-			&"turn_step", &"slow_step", &"step", &"big_step", &"slow_slide_step",
-			&"slide_step", &"fast_slide_step", &"slow_jump_step", &"jump_step",
-			&"fast_jump_step",
-		]:
+		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			object.apply_direction(direction)
 			var destination: Vector2i = object.cell + direction
 			if _cell_in_bounds(destination):
 				object.cell = destination
+				# The cell commits here, as it does for every other step in this
+				# runtime; only the drawing trails. A stream applies in one call,
+				# so the whole path is queued and drawn a step at a time by
+				# advance_scripted_steps().
+				object.queue_step(direction, int(SCRIPTED_STEP_FRAMES[kind]))
 			else:
 				generated.append({
 					"type": &"movement_blocked", "object_index": object_index,
@@ -3062,16 +3140,13 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			var away: Vector2i = -_movement_direction(int(command.get("direction", 0)))
 			player_facing = _facing_for_direction(away)
 			continue
-		if kind in [
-			&"turn_step", &"slow_step", &"step", &"big_step", &"slow_slide_step",
-			&"slide_step", &"fast_slide_step", &"slow_jump_step", &"jump_step",
-			&"fast_jump_step",
-		]:
+		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			player_facing = _facing_for_direction(direction)
 			var destination: Vector2i = player_cell + direction
 			if _cell_in_bounds(destination):
 				player_cell = destination
+				_queue_player_step(direction, int(SCRIPTED_STEP_FRAMES[kind]))
 			else:
 				generated.append({
 					"type": &"movement_blocked", "player": true, "cell": destination,
@@ -3449,7 +3524,7 @@ func can_object_walk_to(
 		return false
 	for object: Gen2WorldObject in objects:
 		if object != moving and object.active and not object.deleted \
-			and object.sprite != null and object.cell == cell:
+			and object.cell == cell:
 			return false
 	return cell != player_cell
 
@@ -3523,7 +3598,12 @@ func advance_object_steps(delta: float, random: RandomNumberGenerator) -> bool:
 	while _object_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS:
 		_object_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
 		for object: Gen2WorldObject in objects:
-			if not object.active or object.deleted or object.sprite == null:
+			if not object.active or object.deleted:
+				continue
+			# A scripted trail belongs to advance_scripted_steps(), which runs
+			# while a script does. Draining it here as well would walk it at
+			# twice the speed on every frame both drivers run.
+			if object.scripted_steps:
 				continue
 			# A step in flight is drained whatever put it there, so a pushed
 			# boulder slides even though its template never decides anything.
@@ -3550,6 +3630,37 @@ func advance_object_steps(delta: float, random: RandomNumberGenerator) -> bool:
 				changed = true
 			elif object.facing != facing_before:
 				_remember_object_position(object)
+				changed = true
+	return changed
+
+
+## Drains the presentation trail an `applymovement` left on the objects it moved,
+## and nothing else.
+##
+## Separate from [method advance_object_steps] because that one decides movement
+## and a caller stops calling it while a script runs, which is exactly when a
+## scripted stream needs drawing. This decides nothing, rolls nothing and writes
+## no cell: every cell the stream names committed when it was applied. Returns
+## true when something a renderer draws moved.
+func advance_scripted_steps(delta: float) -> bool:
+	if delta <= 0.0 or objects.is_empty():
+		return false
+	var walking: Array = []
+	for object: Gen2WorldObject in objects:
+		if object.scripted_steps and not object.deleted:
+			walking.append(object)
+	if walking.is_empty():
+		_scripted_step_accumulator = 0.0
+		return false
+	_scripted_step_accumulator = minf(
+		_scripted_step_accumulator + delta,
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
+	)
+	var changed: bool = false
+	while _scripted_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS:
+		_scripted_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
+		for object: Gen2WorldObject in walking:
+			if object.tick_step():
 				changed = true
 	return changed
 
@@ -4007,8 +4118,9 @@ func _apply_map(
 	_apply_map_setup_player_state()
 	_clear_player_step()
 	# _load_objects() rebuilds every record, so in-flight object steps end with
-	# the objects that owned them; only the shared frame accumulator survives.
+	# the objects that owned them; only the shared frame accumulators survive.
 	_object_step_accumulator = 0.0
+	_scripted_step_accumulator = 0.0
 	_load_objects()
 	# The cartridge moves roaming Pokémon in map setup, not on a timer, so a
 	# player who stands still does not watch them cross Johto.
@@ -4102,7 +4214,7 @@ func _find_sight_request() -> Dictionary:
 	var bank: int = int(current_map.events.get("bank", 0))
 	var rows: Array = current_map.events.get("objects", [])
 	for object: Gen2WorldObject in objects:
-		if not object.active or object.sprite == null \
+		if not object.active \
 			or object.object_type != Gen2WorldObject.OBJECTTYPE_TRAINER \
 			or object.sight_range <= 0 or object.event_script <= 0:
 			continue

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -63,7 +63,13 @@ var event_script: int = 0
 var event_flag: int = 0
 var trainer_data: Dictionary = {}
 var facing: int = Gen2WorldSprite.FACING_DOWN
+## The `Facings` frame this object is drawn on, 0 to 3: two standing and two
+## walking. Derived from step_frame; see walk_frame().
 var frame: int = 0
+## OBJECT_STEP_FRAME. `SetFacingStepAction` (engine/overworld/map_object_action.asm)
+## increments it once per hardware frame of a step and masks it to four bits, and
+## the drawn frame is its two high bits, so the drawing changes every four frames.
+var step_frame: int = 0
 var active: bool = false
 var deleted: bool = false
 var emote_id: int = -1
@@ -75,6 +81,16 @@ var emote_remaining: int = 0
 var step_direction: Vector2i = Vector2i.ZERO
 var step_frames_total: int = 0
 var step_frames_remaining: int = 0
+## The rest of a scripted movement stream, still to be drawn. An applymovement
+## commits every cell of its path at once, so the whole path is behind the
+## committed cell until these drain; each entry is one `{direction, frames}`
+## step of it, in stream order.
+var queued_steps: Array = []
+## True while the trail above belongs to a script rather than to the movement
+## templates, which is what tells the two drivers apart:
+## Gen2WorldAPI.advance_object_steps() decides movement and is refused while a
+## script runs, advance_scripted_steps() only draws and is not.
+var scripted_steps: bool = false
 ## Frames this object waits before its movement template decides again. The
 ## source keeps this in OBJECT_STEP_DURATION while the object sits in
 ## STEP_TYPE_SLEEP (engine/overworld/map_objects.asm, StepFunction_Sleep).
@@ -263,6 +279,23 @@ func tick_emote() -> bool:
 ## caller-side so a slow trainer approach and an ordinary walk can share this
 ## helper without this class knowing which one is running.
 func start_step(direction: Vector2i, frames: int) -> void:
+	queued_steps.clear()
+	scripted_steps = false
+	_begin_step(direction, frames)
+
+
+## Adds one step of a scripted stream to the trail. The first one starts at
+## once and the rest wait their turn, so a five-step applymovement is drawn as
+## five steps rather than as one arrival.
+func queue_step(direction: Vector2i, frames: int) -> void:
+	scripted_steps = true
+	if step_frames_remaining > 0:
+		queued_steps.append({"direction": direction, "frames": maxi(0, frames)})
+		return
+	_begin_step(direction, frames)
+
+
+func _begin_step(direction: Vector2i, frames: int) -> void:
 	step_direction = direction
 	step_frames_total = maxi(0, frames)
 	step_frames_remaining = step_frames_total
@@ -274,12 +307,32 @@ func start_step(direction: Vector2i, frames: int) -> void:
 func tick_step() -> bool:
 	if step_frames_remaining <= 0:
 		return false
+	advance_walk_frame()
 	step_frames_remaining -= 1
+	if step_frames_remaining <= 0:
+		if queued_steps.is_empty():
+			scripted_steps = false
+		else:
+			var next: Dictionary = queued_steps.pop_front()
+			_begin_step(next["direction"], int(next["frames"]))
 	return true
 
 
 func is_stepping() -> bool:
 	return step_frames_remaining > 0
+
+
+## One hardware frame of `SetFacingStepAction`. The counter is never cleared
+## here: `EndSpriteMovement` is what zeroes it on the cartridge, and every step
+## duration is a multiple of four, so a stopped object is already standing on
+## frame 0 or 2 without one. Frames 1 and 3 are the two walking drawings.
+func advance_walk_frame() -> void:
+	step_frame = (step_frame + 1) & 0x0F
+	frame = walk_frame()
+
+
+func walk_frame() -> int:
+	return (step_frame >> 2) & 3
 
 
 ## Starts the wait a movement template takes before deciding again. The source
@@ -305,20 +358,23 @@ func is_idle() -> bool:
 ## Pixel offset from the committed cell back toward where the step began,
 ## shrinking to zero as step_frames_remaining reaches zero.
 func step_offset(cell_pixels: int) -> Vector2i:
-	if step_frames_remaining <= 0 or step_frames_total <= 0:
-		return Vector2i.ZERO
-	var behind: int = int(round(
-		float(step_frames_remaining) / float(step_frames_total) * float(cell_pixels)
-	))
-	return Vector2i(-step_direction.x, -step_direction.y) * behind
+	var offset: Vector2 = step_offset_cells() * float(cell_pixels)
+	return Vector2i(int(round(offset.x)), int(round(offset.y)))
 
 
-## The same offset in fractional walk cells, from one cell behind the committed
-## cell down to zero. A renderer that does not think in hardware pixels reads
+## The same offset in fractional walk cells, from where the sprite is drawn back
+## to the committed cell. A renderer that does not think in hardware pixels reads
 ## this instead of step_offset(), exactly as a renderer reads the player's
 ## Gen2WorldAPI.player_step_offset_cells().
+##
+## One in-flight step is at most a cell behind. A scripted stream commits its
+## whole path at once, so its trail is as many cells behind as it has left to
+## draw.
 func step_offset_cells() -> Vector2:
-	if step_frames_remaining <= 0 or step_frames_total <= 0:
-		return Vector2.ZERO
-	var fraction: float = float(step_frames_remaining) / float(step_frames_total)
-	return Vector2(-step_direction.x, -step_direction.y) * fraction
+	var behind := Vector2.ZERO
+	for entry: Dictionary in queued_steps:
+		behind -= Vector2(entry["direction"] as Vector2i)
+	if step_frames_remaining > 0 and step_frames_total > 0:
+		behind -= Vector2(step_direction) \
+			* (float(step_frames_remaining) / float(step_frames_total))
+	return behind

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -150,7 +150,8 @@ func _draw() -> void:
 
 	var player: Vector2i = _world.player_pixel_position()
 	var player_texture: Texture2D = _actor_texture(
-		_world.player_sprite(), _world.player_palette(), _world.player_facing, 0
+		_world.player_sprite(), _world.player_palette(), _world.player_facing,
+		_world.player_walk_frame()
 	)
 	if player_texture != null:
 		draw_texture(player_texture, Vector2(player))

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -286,6 +286,10 @@ func _process(delta: float) -> void:
 	if _objects_may_move() and _world.advance_object_steps(delta, _object_random) \
 		and _renderer != null:
 		_renderer.refresh()
+	# Not gated on _objects_may_move(): an applymovement is drawn while the
+	# script that ran it is still going, which is when a script runs one.
+	if _world != null and _world.advance_scripted_steps(delta) and _renderer != null:
+		_renderer.refresh()
 	if not _trainer_approach.is_empty():
 		_advance_trainer_approach()
 	if _world != null and _world.phone_ring_active():
@@ -1156,6 +1160,10 @@ func _start_battle_request(request: Dictionary) -> void:
 	var host: Gen2BattleScreen = BATTLE_SCENE.instantiate() as Gen2BattleScreen
 	host.set_data(_data)
 	host.set_time_of_day(time_of_day)
+	# The clock's row is what the battle's own heals read; the drawn row is what
+	# a renderer staging the fight on this map has to match, so the context
+	# carries that one.
+	host.set_world_context(Gen2BattleWorldContext.capture(_world, _render_time_of_day()))
 	if _world != null and not tutorial:
 		host.set_capture_balls(
 			Gen2WorldPartyHost.owned_capture_balls(_world), _world.state.items()

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -15,6 +15,11 @@ const FACING_UP: int = 1
 const FACING_LEFT: int = 2
 const FACING_RIGHT: int = 3
 
+## Tiles in one half of a walking or standing sprite's strip: three facings of
+## four. It is what `OverworldSprites` records as the whole length, because
+## `GetUsedSprite` copies that many twice; see [method frame_tile_offset].
+const WALKING_HALF_TILES: int = 12
+
 ## data/sprites/player_sprites.asm's ChrisStateSprites and KrisStateSprites, the
 ## wPlayerState to sprite lookup GetPlayerSprite walks. ChrisStateSprites is
 ## identical in both pins and the numbers themselves
@@ -74,16 +79,42 @@ func is_walking() -> bool:
 	return sprite_type == TYPE_WALKING
 
 
-## Returns the first tile of a 4-tile frame in the source strip. The original
-## data has down, up and left facings in four-frame groups; right reuses left
-## with a horizontal flip in the renderer.
+## Returns the first tile of a 4-tile frame in the source strip.
+##
+## A walking sprite's strip is two halves of twelve tiles: down, up and left
+## standing, then the same three walking. `GetUsedSprite`
+## (engine/overworld/overworld.asm) copies the first half to `vTiles0` and the
+## second to `vTiles1`, which is the `$80` the walking rows of `Facings`
+## (data/sprites/facings.asm) add to the object's own base tile.
+##
+## `Facings` gives each direction four frames: 0 and 2 are the standing drawing,
+## 1 and 3 the walking one. Right reuses left, flipped by the renderer, and so
+## does frame 3 of down and up: `FacingStepDown3` is `FacingStepDown1` with
+## `OAM_XFLIP` on every tile and its two columns swapped.
 func frame_tile_offset(facing: int, frame: int) -> int:
 	if tiles <= 4 or sprite_type == TYPE_STILL:
 		return 0
 	var facing_index: int = clampi(facing, FACING_DOWN, FACING_RIGHT)
 	if facing_index == FACING_RIGHT:
 		facing_index = FACING_LEFT
-	return facing_index * 4 + clampi(frame, 0, 3)
+	var offset: int = facing_index * 4
+	if is_walking_frame(frame) and tiles >= WALKING_HALF_TILES * 2:
+		offset += WALKING_HALF_TILES
+	return offset
+
+
+## Whether [param frame] is one of the two walking drawings rather than one of
+## the two standing ones.
+static func is_walking_frame(frame: int) -> bool:
+	return (clampi(frame, 0, 3) & 1) == 1
+
+
+## Whether the whole 16x16 image is mirrored: right always is, since it reuses
+## left, and so is frame 3 of down and up.
+static func frame_is_mirrored(facing: int, frame: int) -> bool:
+	if facing == FACING_RIGHT:
+		return true
+	return clampi(frame, 0, 3) == 3 and facing in [FACING_DOWN, FACING_UP]
 
 
 ## Composes one 16x16 object image from the source's horizontal tile strip.
@@ -118,6 +149,6 @@ static func image_for(
 					color.a = 0.0
 				image.set_pixel(destination_x + x, destination_y + y, color)
 
-	if facing == FACING_RIGHT:
+	if frame_is_mirrored(facing, frame):
 		image.flip_x()
 	return image

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -92,6 +92,65 @@ func refresh() -> void:
 	assert_eq(int(view.get("player_max_hp", -1)), 4)
 
 
+## Where the fight is happening, for a renderer that stages it on the map. It is
+## optional on both sides: the screen only calls a renderer that defines it, and
+## a battle started outside the world supplies none.
+func test_a_registered_renderer_is_handed_the_world_the_battle_was_entered_from() -> void:
+	var script: GDScript = _stub_script("""extends Control
+
+var context = null
+
+func set_battle_data(_data) -> bool:
+	return true
+
+func set_world_context(value) -> void:
+	context = value
+
+func set_view(_view: Dictionary) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+""")
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"staged", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"staged")["ok"])
+
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(_data, 1, 1, Vector2i(4, 4))
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_battle_screen = packed.instantiate() as Gen2BattleScreen
+	_battle_screen.set_data(_data)
+	_battle_screen.set_world_context(
+		Gen2BattleWorldContext.capture(world, Gen2WorldPalette.TIME_NIGHT)
+	)
+	add_child(_battle_screen)
+	await get_tree().process_frame
+
+	assert_true(_battle_screen.is_ready())
+	var context: Gen2BattleWorldContext = _battle_screen._renderer.get("context")
+	assert_not_null(context, "the renderer defines the method, so it is called")
+	assert_eq(context.map_id, Vector2i(1, 1))
+	assert_eq(context.player_cell, Vector2i(4, 4))
+	assert_eq(context.player_facing, Gen2WorldSprite.FACING_LEFT)
+	assert_eq(context.time_of_day, Gen2WorldPalette.TIME_NIGHT)
+
+
+## The built-in renderer defines no such method and must still come up: the
+## cartridge's battle is a white field and has no place in it.
+func test_the_built_in_renderer_ignores_a_world_context() -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(_data, 1, 1, Vector2i(4, 4))
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_battle_screen = packed.instantiate() as Gen2BattleScreen
+	_battle_screen.set_data(_data)
+	_battle_screen.set_world_context(Gen2BattleWorldContext.capture(world, 0))
+	add_child(_battle_screen)
+	await get_tree().process_frame
+
+	assert_true(_battle_screen.is_ready())
+	assert_false(_battle_screen._renderer.has_method("set_world_context"))
+	assert_not_null(_battle_screen.world_context())
+
+
 func test_a_renderer_reporting_missing_data_leaves_the_screen_not_ready() -> void:
 	var script: GDScript = _stub_script("""extends Control
 

--- a/tests/unit/test_battle_world_context.gd
+++ b/tests/unit/test_battle_world_context.gd
@@ -1,0 +1,61 @@
+extends GutTest
+
+## The read-only snapshot a battle renderer is handed when the battle was
+## entered from the world. It is built from a real Gen2WorldAPI over the same
+## synthetic cache the rest of the world unit tests use.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+var _data: GameData = null
+
+
+func before_all() -> void:
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_all() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func _world() -> Gen2WorldAPI:
+	return Gen2WorldAPI.open(_data, 1, 1, Vector2i(4, 4))
+
+
+func test_capture_copies_the_map_tileset_cell_and_facing() -> void:
+	var world: Gen2WorldAPI = _world()
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var context: Gen2BattleWorldContext = Gen2BattleWorldContext.capture(
+		world, Gen2WorldPalette.TIME_NIGHT
+	)
+	assert_eq(context.map_id, Vector2i(1, 1))
+	assert_eq(context.map_group(), 1)
+	assert_eq(context.map_number(), 1)
+	assert_eq(context.tileset, world.current_map.tileset)
+	assert_eq(context.player_cell, Vector2i(4, 4))
+	assert_eq(context.player_facing, Gen2WorldSprite.FACING_LEFT)
+	assert_eq(context.time_of_day, Gen2WorldPalette.TIME_NIGHT)
+
+
+## A copy, not a handle: the whole point is that a renderer cannot reach world
+## state through it once the fight has started.
+func test_the_snapshot_does_not_follow_the_world_it_was_taken_from() -> void:
+	var world: Gen2WorldAPI = _world()
+	var context: Gen2BattleWorldContext = Gen2BattleWorldContext.capture(world, 0)
+	world.player_cell = Vector2i(6, 6)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(context.player_cell, Vector2i(4, 4))
+	assert_eq(context.player_facing, Gen2WorldSprite.FACING_DOWN)
+
+
+## The world's own row when the caller does not name one, which is the map's
+## rather than the clock's: a dark cave is night until Flash is used.
+func test_an_unnamed_time_of_day_falls_back_to_the_maps_own_row() -> void:
+	var world: Gen2WorldAPI = _world()
+	world.set_object_time(22, Gen2WorldPalette.TIME_NIGHT)
+	var context: Gen2BattleWorldContext = Gen2BattleWorldContext.capture(world)
+	assert_eq(context.time_of_day, world.map_time_of_day())
+
+
+func test_a_world_without_a_map_answers_nothing() -> void:
+	assert_null(Gen2BattleWorldContext.capture(null))

--- a/tests/unit/test_battle_world_context.gd.uid
+++ b/tests/unit/test_battle_world_context.gd.uid
@@ -1,0 +1,1 @@
+uid://c54bw72ug6sn

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3178,6 +3178,97 @@ func test_script_movement_steps_through_a_wall_the_way_normal_step_does() -> voi
 	assert_eq(world.player_cell, Vector2i(9, 6))
 
 
+## An applymovement applies its whole stream in one call, so every cell of the
+## path commits at once and the drawing is what trails. Presentation only: the
+## cells below are already the stream's last one while the offset is still two
+## behind it.
+func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var object: Gen2WorldObject = world.objects[0]
+	var start: Vector2i = object.cell
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+
+	assert_eq(object.cell, start + Vector2i(2, 0), "both cells commit at once")
+	assert_eq(object.step_offset_cells(), Vector2(-2.0, 0.0), "and the drawing is behind both")
+
+	# STEP_FRAMES_WALK is 8 and MAX_CATCHUP_FRAMES caps a call at four.
+	for _call: int in 2:
+		assert_true(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0))
+	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0), "one step drawn, one to go")
+	assert_eq(object.cell, start + Vector2i(2, 0), "and no cell moved with it")
+
+	for _call: int in 2:
+		world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+	assert_false(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS))
+
+
+## The two drivers own different objects. advance_object_steps() decides
+## movement and a screen stops calling it while a script runs, which is exactly
+## when a scripted trail has to keep being drawn, so draining it there as well
+## would walk it at twice the speed.
+func test_the_movement_driver_leaves_a_scripted_trail_to_its_own_driver() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var object: Gen2WorldObject = world.objects[0]
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_true(object.scripted_steps)
+
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0, random)
+	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0), "untouched by the other driver")
+
+	assert_true(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0))
+	assert_eq(object.step_offset_cells(), Vector2(-0.5, 0.0))
+
+
+## The player's half of the same thing, plus the walk frame that goes with it.
+## OBJECT_STEP_FRAME advances once per hardware frame and its two high bits pick
+## the drawing, so the frame changes every four.
+func test_a_scripted_player_stream_trails_and_advances_the_walk_frame() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6110": [0x0D, 0x0D, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 0, 0x10, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+
+	assert_eq(world.player_cell, Vector2i(7, 4), "both cells commit at once")
+	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 2.0))
+	assert_eq(world.player_walk_frame(), 0)
+
+	for _call: int in 2:
+		assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0))
+	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 1.0), "one step drawn")
+	# Eight frames in, the counter is on its third drawing: stand, walk, stand.
+	assert_eq(world.player_walk_frame(), 2)
+
+	for _call: int in 2:
+		world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
+	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+	assert_eq(world.player_cell, Vector2i(7, 4))
+
+
 func test_script_movement_still_refuses_a_step_off_the_map() -> void:
 	RomCache.write_json(RomCache.world_movements_path(_directory), {
 		"48:6100": [0x0F, 0x47],
@@ -3583,6 +3674,36 @@ func test_an_unassigned_variable_sprite_still_occupies_and_is_talkable() -> void
 
 	assert_not_null(standing, "an unassigned variable sprite left the cell empty")
 	assert_false(world.can_walk_to(Vector2i(7, 5)), "it did not occupy its cell")
+
+
+## `ReadObjectEvents` builds wMapObjects from map data and `LoadSpriteGFX` fills
+## VRAM afterwards, so an object exists before its graphics do and none of
+## IsNPCAtCoord, CheckFacingObject or CanObjectMoveInDirection asks what loaded.
+## A sprite this build cannot draw, a Pokemon sprite among them, therefore has to
+## keep blocking and keep answering A: Vermilion's SPRITE_MACHOP and Celadon's
+## SPRITE_POLIWAG were both walked straight through while that was not true.
+func test_an_object_whose_sprite_is_missing_still_blocks_and_is_talkable() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var objects: Array = world.current_map.events["objects"]
+	# Well past the fixture's one-sprite table, and below SPRITE_VARS, so it
+	# resolves to nothing at all rather than to the variable-sprite fallback.
+	objects[0]["sprite"] = 0x9A
+	objects[0]["x"] = 7
+	objects[0]["y"] = 5
+	world.reload_current_map()
+
+	var standing: Gen2WorldObject = world.object_at(Vector2i(7, 5))
+	assert_not_null(standing, "a missing sprite emptied the cell")
+	assert_null(standing.sprite, "and the fixture really cannot draw it")
+	assert_false(world.can_walk_to(Vector2i(7, 5)), "it did not occupy its cell")
+
+	# Drawing is the one thing that may ask for a sprite.
+	assert_eq(world.visible_objects().size(), 0)
+	assert_eq(world.active_objects().size(), 1)
+
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_false(world.interact().is_empty(), "and it could not be talked to")
 
 
 ## constants/event_flags.asm, the flag Oak sets on the sixteen-badge branch.

--- a/tests/unit/test_world_data.gd
+++ b/tests/unit/test_world_data.gd
@@ -105,7 +105,10 @@ func test_layout_carries_verified_world_table_shapes() -> void:
 	assert_eq(RomLayout.tileset_count(crystal), 37)
 	assert_eq(RomLayout.tileset_block_count(gold, 4), 64)
 	assert_eq(RomLayout.tileset_block_count(crystal, 31), 40)
+	# NUM_OVERWORLD_SPRITES, which is the last SPRITE_* constant's own value:
+	# pokegold ends at SPRITE_SILVER_TROPHY ($5f) and pokecrystal at
+	# SPRITE_STANDING_YOUNGSTER ($66), the three beasts among the rows between.
 	assert_eq(RomLayout.overworld_sprite_count(gold), 95)
-	assert_eq(RomLayout.overworld_sprite_count(crystal), 99)
+	assert_eq(RomLayout.overworld_sprite_count(crystal), 102)
 	assert_eq(RomLayout.overworld_sprite_offset(gold, 1), 0x147DE)
 	assert_eq(RomLayout.overworld_sprite_offset(crystal, 1), 0x14736)

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -76,6 +76,66 @@ func test_step_offset_starts_a_full_cell_behind_and_reaches_zero() -> void:
 	assert_false(object.tick_step())
 
 
+func test_a_queued_stream_is_drawn_a_step_at_a_time_in_stream_order() -> void:
+	var object: Gen2WorldObject = _object()
+	object.queue_step(Vector2i.RIGHT, 8)
+	object.queue_step(Vector2i.DOWN, 8)
+	assert_true(object.scripted_steps)
+	# Both cells committed when the stream applied, so the drawing starts two
+	# steps behind, and it walks them in the order the stream named them.
+	assert_eq(object.step_offset_cells(), Vector2(-1.0, -1.0))
+
+	for _frame: int in 8:
+		assert_true(object.tick_step())
+	assert_eq(object.step_offset_cells(), Vector2(0.0, -1.0), "the right step is drawn")
+
+	for _frame: int in 4:
+		assert_true(object.tick_step())
+	assert_eq(object.step_offset_cells(), Vector2(0.0, -0.5))
+
+	for _frame: int in 4:
+		assert_true(object.tick_step())
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+	assert_false(object.scripted_steps)
+	assert_false(object.tick_step())
+
+
+## An ordinary step supersedes a trail rather than joining it: the two never
+## overlap on the cartridge either, since a scripted movement owns the object
+## until its stream ends.
+func test_an_ordinary_step_replaces_a_queued_stream() -> void:
+	var object: Gen2WorldObject = _object()
+	object.queue_step(Vector2i.RIGHT, 8)
+	object.queue_step(Vector2i.RIGHT, 8)
+	object.start_step(Vector2i.LEFT, 8)
+	assert_false(object.scripted_steps)
+	assert_eq(object.step_offset_cells(), Vector2(1.0, 0.0))
+
+
+## SetFacingStepAction increments OBJECT_STEP_FRAME once per frame of a step and
+## the drawing is its two high bits, so it changes every four frames and frames
+## 1 and 3 are the two walking pictures.
+func test_the_walk_frame_changes_every_four_frames_of_a_step() -> void:
+	var object: Gen2WorldObject = _object()
+	assert_eq(object.walk_frame(), 0)
+	object.start_step(Vector2i.RIGHT, 16)
+
+	for _frame: int in 4:
+		object.tick_step()
+	assert_eq(object.walk_frame(), 1)
+	assert_eq(object.frame, 1, "and the drawn frame follows the counter")
+
+	for _frame: int in 4:
+		object.tick_step()
+	assert_eq(object.walk_frame(), 2)
+
+	for _frame: int in 8:
+		object.tick_step()
+	# Sixteen frames is one full cycle, so a slow step both starts and ends on
+	# the standing picture without anything having to clear the counter.
+	assert_eq(object.walk_frame(), 0)
+
+
 func test_step_offset_direction_matches_the_committed_movement() -> void:
 	var object: Gen2WorldObject = _object()
 	object.start_step(Vector2i.UP, 16)

--- a/tests/unit/test_world_sprite.gd
+++ b/tests/unit/test_world_sprite.gd
@@ -3,7 +3,7 @@ extends GutTest
 
 func _sprite() -> Gen2WorldSprite:
 	return Gen2WorldSprite.from_cache({
-		"number": 1, "bytes": 192, "tiles": 12,
+		"number": 1, "bytes": 384, "tiles": 24,
 		"type": Gen2WorldSprite.TYPE_WALKING, "palette": 0,
 	})
 
@@ -14,6 +14,48 @@ func test_walking_frames_use_down_up_left_and_flipped_right_groups() -> void:
 	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_UP, 0), 4)
 	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_LEFT, 0), 8)
 	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_RIGHT, 0), 8)
+
+
+## Facings gives each direction two standing frames and two walking ones, and
+## the walking ones come from the second half of the strip: GetUsedSprite copies
+## that half to vTiles1, which is the $80 those rows add to the base tile.
+func test_the_two_walking_frames_come_from_the_second_half_of_the_strip() -> void:
+	var sprite: Gen2WorldSprite = _sprite()
+	for facing: int in [
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_LEFT,
+	]:
+		var standing: int = sprite.frame_tile_offset(facing, 0)
+		assert_eq(sprite.frame_tile_offset(facing, 2), standing)
+		assert_eq(sprite.frame_tile_offset(facing, 1), standing + 12)
+		assert_eq(sprite.frame_tile_offset(facing, 3), standing + 12)
+	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_RIGHT, 1), 20)
+
+
+## FacingStepDown3 is FacingStepDown1 with OAM_XFLIP on every tile and its two
+## columns swapped, which mirrors the whole 16x16. Left and right have no such
+## pair: FacingStepLeft1 and FacingStepLeft3 are one label.
+func test_frame_three_mirrors_down_and_up_but_not_left_or_right() -> void:
+	assert_false(Gen2WorldSprite.frame_is_mirrored(Gen2WorldSprite.FACING_DOWN, 1))
+	assert_true(Gen2WorldSprite.frame_is_mirrored(Gen2WorldSprite.FACING_DOWN, 3))
+	assert_true(Gen2WorldSprite.frame_is_mirrored(Gen2WorldSprite.FACING_UP, 3))
+	assert_false(Gen2WorldSprite.frame_is_mirrored(Gen2WorldSprite.FACING_LEFT, 3))
+	assert_true(Gen2WorldSprite.frame_is_mirrored(Gen2WorldSprite.FACING_RIGHT, 0))
+	assert_true(Gen2WorldSprite.frame_is_mirrored(Gen2WorldSprite.FACING_RIGHT, 3))
+
+
+## A still sprite is one four-tile picture whatever it is asked for, and a
+## standing sprite has no walking half to reach.
+func test_a_still_sprite_answers_one_picture_for_every_frame() -> void:
+	var still: Gen2WorldSprite = Gen2WorldSprite.from_cache({
+		"number": 2, "bytes": 64, "tiles": 4,
+		"type": Gen2WorldSprite.TYPE_STILL, "palette": 0,
+	})
+	assert_eq(still.frame_tile_offset(Gen2WorldSprite.FACING_UP, 3), 0)
+	var standing: Gen2WorldSprite = Gen2WorldSprite.from_cache({
+		"number": 3, "bytes": 192, "tiles": 12,
+		"type": Gen2WorldSprite.TYPE_STANDING, "palette": 0,
+	})
+	assert_eq(standing.frame_tile_offset(Gen2WorldSprite.FACING_UP, 1), 4)
 
 
 func test_image_composition_applies_palette_and_transparency() -> void:

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -1,0 +1,97 @@
+extends SceneTree
+
+## Draws a whole map as the game draws it, with every walk cell's permission
+## checkerboarded over the top: red for WALL, blue for WATER, nothing for LAND.
+##
+## For a report that a player can stand somewhere they should not. The art and
+## the permission come from the same two sources the runtime reads, the map's
+## block grid and the tileset's four-bytes-per-block collision table, so a wall
+## drawn without a red square is a real disagreement between what is drawn and
+## what is walked, rather than a rendering offset.
+##
+## Objects are not drawn: this is the map's own answer. Use
+## `Gen2WorldAPI.active_objects()` for who is standing on it.
+##
+##   Godot --headless --path . -s res://tools/preview_collision.gd -- crystal 26 2 /tmp/route31.png
+
+const SCALE: int = 3
+const WALL_TINT: Color = Color(1.0, 0.0, 0.0, 0.75)
+const WATER_TINT: Color = Color(0.1, 0.3, 1.0, 0.35)
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 4:
+		push_error("Usage: -s tools/preview_collision.gd -- <game> <group> <number> <output.png>")
+		quit(1)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+	var group: int = int(args[1])
+	var number: int = int(args[2])
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, Vector2i.ZERO)
+	if world == null:
+		push_error("No map %d/%d in %s." % [group, number, args[0]])
+		quit(1)
+		return
+
+	var map: Gen2WorldMap = world.current_map
+	var tileset: Gen2WorldTileset = world.current_tileset
+	var indices: PackedByteArray = data.world_tileset_indices(tileset.number)
+	var palettes: Array = Gen2WorldPalette.tile_palettes(
+		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1
+	)
+	var strip_width: int = tileset.tile_count * Gen2Tiles.TILE_WIDTH
+	var image := Image.create(
+		map.collision_width * 16, map.collision_height * 16, false, Image.FORMAT_RGBA8
+	)
+
+	for tile_y: int in map.height_blocks * RomLayout.MAP_BLOCK_TILE_WIDTH:
+		for tile_x: int in map.width_blocks * RomLayout.MAP_BLOCK_TILE_WIDTH:
+			@warning_ignore("integer_division")
+			var block: int = map.block_at(
+				tile_x / RomLayout.MAP_BLOCK_TILE_WIDTH, tile_y / RomLayout.MAP_BLOCK_TILE_WIDTH
+			)
+			var tile: int = tileset.tile_index(
+				block, (tile_y % 4) * RomLayout.MAP_BLOCK_TILE_WIDTH + (tile_x % 4)
+			)
+			var palette: PackedColorArray = palettes[tile] if tile < palettes.size() \
+				else PackedColorArray()
+			for y: int in Gen2Tiles.TILE_HEIGHT:
+				for x: int in Gen2Tiles.TILE_WIDTH:
+					var index: int = int(indices[y * strip_width + tile * 8 + x])
+					image.set_pixel(
+						tile_x * 8 + x, tile_y * 8 + y,
+						palette[index] if index < palette.size() else Color.MAGENTA
+					)
+
+	for cell_y: int in map.collision_height:
+		for cell_x: int in map.collision_width:
+			var permission: int = world.collision_permission_at(Vector2i(cell_x, cell_y))
+			var tint := Color(0, 0, 0, 0)
+			if permission == Gen2WorldCollision.WALL_TILE:
+				tint = WALL_TINT
+			elif permission == Gen2WorldCollision.WATER_TILE:
+				tint = WATER_TINT
+			if tint.a == 0.0:
+				continue
+			for y: int in 16:
+				for x: int in 16:
+					# A four-pixel checker, so the art underneath stays readable.
+					if ((x >> 2) + (y >> 2)) % 2 != 0:
+						continue
+					var at := Vector2i(cell_x * 16 + x, cell_y * 16 + y)
+					image.set_pixel(at.x, at.y, image.get_pixel(at.x, at.y).lerp(tint, tint.a))
+
+	image.resize(image.get_width() * SCALE, image.get_height() * SCALE, Image.INTERPOLATE_NEAREST)
+	if image.save_png(args[3]) != OK:
+		push_error("Could not write %s" % args[3])
+		quit(1)
+		return
+	print("%s map %d/%d: %d by %d cells." % [
+		args[0], group, number, map.collision_width, map.collision_height,
+	])
+	quit(0)

--- a/tools/preview_collision.gd.uid
+++ b/tools/preview_collision.gd.uid
@@ -1,0 +1,1 @@
+uid://bgrxbwcbldmah

--- a/tools/preview_overworld_sprites.gd
+++ b/tools/preview_overworld_sprites.gd
@@ -1,0 +1,73 @@
+extends SceneTree
+
+## Draws every overworld sprite a cache holds as one contact sheet, so a human
+## can see at a glance whether the strip was read at the right offset and the
+## frames were composed the right way round.
+##
+## Each sprite is a four-by-four block: the four facings across, in
+## `Gen2WorldSprite`'s down/up/left/right order, and the four `Facings` frames
+## down. Frames 0 and 2 are the standing drawing and 1 and 3 the walking one, so
+## a correct walking sprite reads as two poses alternating down the block, with
+## the right column mirroring the left.
+##
+## A still sprite draws the same picture sixteen times, which is right. A big
+## object (`SPRITE_BIG_SNORLAX`, `SPRITE_BIG_ONIX`, the dolls) draws as a
+## scramble, which is a known gap: those use `FacingBigDollSymmetric` and
+## `..._Asymmetric`, sixteen and fourteen tiles in a 32x32 square, and
+## `Gen2WorldSprite.image_for()` only knows the four-tile layout.
+##
+##   Godot --headless --path . -s res://tools/preview_overworld_sprites.gd -- crystal /tmp/sprites.png
+
+const CELL: int = 16
+const COLUMNS: int = 8
+const SCALE: int = 2
+## Four facings across, four frames down, plus a one-pixel gutter.
+const TILE_W: int = CELL * 4 + 2
+const TILE_H: int = CELL * 4 + 2
+const BACKGROUND: Color = Color(0.15, 0.15, 0.2, 1.0)
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: -s tools/preview_overworld_sprites.gd -- <game> <output.png>")
+		quit(1)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var count: int = data.overworld_sprite_count()
+	var rows: int = ceili(float(count) / float(COLUMNS))
+	var sheet := Image.create(COLUMNS * TILE_W, rows * TILE_H, false, Image.FORMAT_RGBA8)
+	sheet.fill(BACKGROUND)
+	for number: int in range(1, count + 1):
+		var sprite: Gen2WorldSprite = data.overworld_sprite(number)
+		if sprite == null:
+			continue
+		var indices: PackedByteArray = data.overworld_sprite_indices(number)
+		var palette: PackedColorArray = data.overworld_sprite_palette(
+			sprite.default_palette, Gen2WorldPalette.TIME_DAY
+		)
+		var at := Vector2i(
+			((number - 1) % COLUMNS) * TILE_W + 1,
+			((number - 1) / COLUMNS) * TILE_H + 1
+		)
+		for facing: int in 4:
+			for frame: int in 4:
+				sheet.blit_rect(
+					Gen2WorldSprite.image_for(sprite, indices, palette, facing, frame),
+					Rect2i(0, 0, CELL, CELL),
+					at + Vector2i(facing * CELL, frame * CELL)
+				)
+	sheet.resize(sheet.get_width() * SCALE, sheet.get_height() * SCALE, Image.INTERPOLATE_NEAREST)
+	if sheet.save_png(args[1]) != OK:
+		push_error("Could not write %s" % args[1])
+		quit(1)
+		return
+	print("%s: %d sprites, %d per row, facings across and frames down." % [
+		args[0], count, COLUMNS,
+	])
+	quit(0)

--- a/tools/preview_overworld_sprites.gd.uid
+++ b/tools/preview_overworld_sprites.gd.uid
@@ -1,0 +1,1 @@
+uid://dmeax2ennc0bj

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -1576,7 +1576,7 @@ func _story_path(data: GameData) -> Dictionary:
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": falkner_run,
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 	})
 	if not bool(falkner_run.get("terminal", false)):
@@ -1640,7 +1640,7 @@ func _story_path(data: GameData) -> Dictionary:
 		"party": party_summary,
 		"event_flags": world.state.event_flags(),
 		"map_scenes": world.state.to_dict().get("map_scenes", {}),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 	}
 
 
@@ -1926,7 +1926,7 @@ func _hive_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": bugsy_run,
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 	})
 	if not bool(bugsy_run.get("terminal", false)):
@@ -2217,7 +2217,7 @@ func _plain_badge_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": badge_run,
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 	})
 	if not bool(badge_run.get("terminal", false)):
@@ -2653,7 +2653,7 @@ func _fog_badge_path(
 		"cell": _cell_value(world),
 		"entry_statuses": gym_entry.get("statuses", []),
 		"run": morty.get("run", {}),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 	})
 	if not bool(morty.get("ok", false)):
@@ -2892,7 +2892,7 @@ func _mineral_badge_path(
 		"cell": _cell_value(world),
 		"entry_statuses": gym_entry.get("statuses", []),
 		"run": jasmine.get("run", {}),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 		"items": _named_items(data, world.state.items()),
 	})
@@ -3486,7 +3486,7 @@ func _glacier_badge_path(
 		"cell": _cell_value(world),
 		"entry_statuses": gym_entry.get("statuses", []),
 		"run": pryce.get("run", {}),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 		"items": _named_items(data, world.state.items()),
 		# The badge is not all Pryce commits. `readvar VAR_BADGES` then
@@ -4355,7 +4355,7 @@ func _dragon_shrine_leg(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": quiz,
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"answered_wrong": world.event_flag_active(EVENT_ANSWERED_DRAGON_MASTER_QUIZ_WRONG),
 	})
 	if not bool(quiz.get("terminal", false)):
@@ -4441,7 +4441,7 @@ func _dragons_den_dragon_fang(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": fang.get("run", {}),
-		"badge_count": world.state.badge_count(false),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"items": _named_items(data, world.state.items()),
 	})
 	if not bool(fang.get("ok", false)):
@@ -4998,7 +4998,7 @@ func _victory_road_gate_leg(
 		"step": "victory_road_gate_badge_check",
 		"map": _map_value(world),
 		"cell": _cell_value(world),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"encounters": checked.get("encounters", []),
 	})
 	if not bool(checked.get("ok", false)):
@@ -5111,7 +5111,7 @@ func _victory_road_leg(
 		"encounters": plateau.get("encounters", []),
 		"mt_moon_rival": world.event_flag_active(EVENT_BEAT_RIVAL_IN_MT_MOON),
 		"flypoint": _engine_flag_set(world, data, ENGINE_FLYPOINT_INDIGO_PLATEAU),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 	})
 	if not bool(plateau.get("ok", false)):
 		return {
@@ -5301,7 +5301,7 @@ func _hall_of_fame_leg(
 		"red_in_mt_silver": world.event_flag_active(EVENT_RED_IN_MT_SILVER),
 		"hall_of_fame_events": presentations,
 		"hall_of_fame_flag": world.state.hall_of_fame(),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 	})
 	if not bool(run.get("terminal", false)):
 		return {
@@ -8269,7 +8269,7 @@ func _blackthorn_path(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"party": _party_species(save),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 	})
 	return {"ok": true}
 
@@ -8537,7 +8537,7 @@ func _storm_badge_leg(
 		"map": _map_value(world),
 		"cell": _cell_value(world),
 		"run": chuck.get("run", {}),
-		"badge_count": world.state.badge_count(),
+		"badge_count": world.state.badge_count(Gen2WorldState.is_crystal_profile(data)),
 		"engine_flags": world.state.engine_flags(),
 		"items": _named_items(data, world.state.items()),
 	})

--- a/tools/validate_celadon.gd
+++ b/tools/validate_celadon.gd
@@ -59,7 +59,12 @@ const GYM_DOOR_APPROACH: Vector2i = Vector2i(10, 30)
 const GYM_TREE: Vector2i = Vector2i(28, 35)
 const GYM_TREE_APPROACH: Vector2i = Vector2i(28, 34)
 const GYM_TREE_RETURN: Vector2i = Vector2i(27, 35)
-const CITY_CELLS: int = 619
+## One cell fewer than this pin held until 2026-08-10. The cell is (27,11),
+## where `maps/CeladonCity.asm` stands a `SPRITE_POLIWAG` object: a Pokemon
+## sprite, which this build cannot draw yet, and which stopped occupying its
+## cell as well until Gen2WorldAPI.object_at() was separated from
+## visible_objects(). It blocks on the cartridge, so 618 is the real count.
+const CITY_CELLS: int = 618
 const GYM_YARD_CELLS: int = 70
 
 ## engine/overworld/tile_events.asm's CheckCutCollision entry for a tree, the

--- a/tools/validate_fuchsia.gd
+++ b/tools/validate_fuchsia.gd
@@ -14,7 +14,8 @@ extends SceneTree
 ## cells in turn shows that Crystal owes two of Route 13's five and nothing at
 ## all on Routes 12, 14 and 15, while Gold and Silver owe a different set on
 ## three profile-split routes. And Fuchsia Gym is a maze rather than a gate: its
-## fifty wall cells leave 128 walkable ones, none of its six objects is an
+## fifty wall cells leave 130 walkable ones and its six objects stand on six of
+## them, so the door reaches 124; none of those six is an
 ## OBJECTTYPE_TRAINER, and Janine sets her four disguised trainers' flags herself.
 ##
 ##   Godot --headless --path . -s res://tools/validate_fuchsia.gd
@@ -71,7 +72,13 @@ const FUCHSIA_GYM_DOOR: Vector2i = Vector2i(8, 27)
 
 ## The gym: its own door, its wall count, Janine and the cell she is faced from.
 const GYM_LANDING: Vector2i = Vector2i(4, 17)
-const GYM_CELLS: int = 128
+## Collision alone leaves 130 land cells; the six objects stand on six of them
+## and the flood is `can_walk_to`, so 124 is what the door reaches. The pin was
+## 128 while Janine's four disguised trainers did not occupy anything: they carry
+## SPRITE_FUCHSIA_GYM_1 to _4, which are `SPRITE_VARS` rows no script assigns, and
+## `GetMonSprite.NoBreedmon` answers WALKING_SPRITE for an unassigned one rather
+## than nothing, so all four stand in the maze.
+const GYM_CELLS: int = 124
 const GYM_WALL_CELLS: int = 50
 const JANINE_INDEX: int = 0
 const JANINE_CELL: Vector2i = Vector2i(1, 10)

--- a/tools/validate_radio.gd
+++ b/tools/validate_radio.gd
@@ -35,7 +35,11 @@ const CAVE_MOUTH: Vector2i = Vector2i(34, 7)
 const SNORLAX_CELL: Vector2i = Vector2i(34, 8)
 const SNORLAX_OBJECT: int = 4
 const TALK_FROM: Vector2i = Vector2i(34, 10)
-const CITY_CELLS: int = 319
+## One cell fewer than this pin held until 2026-08-10, for the reason
+## `tools/validate_celadon.gd`'s own count records: (26,7) carries a
+## `SPRITE_MACHOP` object, which this build cannot draw and which used to be
+## walked through as well.
+const CITY_CELLS: int = 318
 
 ## engine/events/specials.asm's SnorlaxAwake.ProximityCoords, in source order:
 ## every walkable cell adjacent to the two-by-two body, which its own comments

--- a/tools/validate_surf.gd
+++ b/tools/validate_surf.gd
@@ -84,9 +84,12 @@ func _verify_surf_sprites(game_id: StringName, data: GameData) -> void:
 				game_id, number, sprite.sprite_type,
 			]
 		)
+		# Twice what sprites.asm declares: GetUsedSprite copies the recorded
+		# twelve tiles and the twelve after them, the standing drawings and the
+		# walking ones, so a walking sprite is cached whole.
 		_check(
-			sprite.tiles == 12,
-			"%s: overworld sprite %d has %d tiles, not the 12 sprites.asm declares." % [
+			sprite.tiles == Gen2WorldSprite.WALKING_HALF_TILES * 2,
+			"%s: overworld sprite %d has %d tiles, not the 24 a walking sprite draws." % [
 				game_id, number, sprite.tiles,
 			]
 		)


### PR DESCRIPTION
## What changed

**A battle renderer can be told where the fight is.** A renderer registered through `Gen2ModHost` was handed what is on the field and nothing about where the battle is happening, which is right for a white background and useless to one staging the fight on the map. `Gen2BattleWorldContext` carries the map, tileset, player cell, facing and drawn time of day. It is copied once at battle start and pushed to any renderer that defines `set_world_context`, after `set_battle_data` and before the first view. A copy rather than a handle, so a renderer cannot reach world state mid-battle.

**Walking sprites use their second half.** A walking sprite's record names half its graphics: `GetUsedSprite` copies the recorded twelve tiles to `vTiles0` and the twelve after them to `vTiles1`, which is the `$80` the walking rows of `Facings` add to a base tile. The importer now reads 24 tiles for a walking sprite and the recorded length for the other two types, and `frame_tile_offset` crosses into the second half for the walking drawings. Three of the sixteen facing combinations are drawn mirrored, not only the right-facing four.

**Scripted movement paces its own trail.** Every step queues behind the last at its own command's duration out of `StepVectors`, and `advance_scripted_steps` drains it on a driver separate from the object one, because a screen stops calling that while a script runs. The player carries the same queue and its own step frame.

## Checks

- GUT: 2121 tests, all passing
- `docs/MODS.md` documents the new optional renderer method