### PR TITLE
Expose trainer info & battle renderer input

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -302,12 +302,21 @@ a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
 | `refresh()` | The renderer should redraw its current view |
 
 `view` carries `enemy_species`, `player_species`, `enemy_name`, `player_name`,
-`enemy_level`, `player_level`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
+`enemy_level`, `player_level`, `battle_kind`, `trainer_class`, `trainer_index`,
+`trainer_name`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
 `player_max_hp`, `exp_pixels`, `raster_scx`, `raster_scy`, `player_pic_visible`,
 `bg_map`, `bg_palette_maps`, `ob_palette_maps`, `anim_sprites`, `anim_tiles` and
 `hud_visible`: plain values read out of a resolved battle event, never the
 battle engine itself, the same rule `Gen2BattleScreen`'s own setters already
-followed. `exp_pixels` is a
+followed.
+
+`battle_kind` is `wild` or `trainer` and the three fields after it say who the
+fight is against, which the species and levels do not. A wild battle carries
+class 0, index 0 and an empty name, the way `wOtherTrainerClass` is zero there.
+A class number is what `GameData.trainer_pic()` and `trainer_name()` take, so a
+renderer standing the opponent behind their Pokémon draws the cartridge's own
+picture of them; `trainer_name` is the trainer's own name from the party record,
+not the class name. `exp_pixels` is a
 count out of 64, which is `PlaceExpBar`'s own unit; the exp bar is never a
 ratio, because `CalcExpBar` has already done the division and rounded it the
 cartridge's way.
@@ -358,11 +367,23 @@ Registration uses the same refusal rules as a world renderer, and shares both
 optional methods (`uses_hardware_viewport()`, `set_native_size()`) and the `V`
 cycle, bound in `Gen2BattleScreen` the way `Gen2WorldScreen` binds it.
 
-A battle renderer has one optional method of its own:
+A battle renderer has two optional methods of its own:
 
 | Method | Effect |
 |---|---|
 | `set_world_context(context: Gen2BattleWorldContext)` | Where the battle is being fought, once per battle, after `set_battle_data` and before the first view |
+| `handle_battle_input(event: InputEvent) -> bool` | Every input event the battle screen did not use. Answering true consumes it |
+
+`handle_battle_input` is `handle_world_input`'s twin and follows the same rule:
+the screen claims what it needs and offers the rest, so a renderer can steer a
+camera and can never take a gameplay press. A `Gen2Button` is routed to whatever
+owns the screen before this is reached, on both sides, so the text box, the
+forget-move list and ball selection each take their press first and what arrives
+here is pointer and stick motion. Ball selection and the forget prompt also
+withhold everything else while they are up, because a press there means
+something by itself. A draining bar, the opening slide and a move animation do
+not: none of them reads input, and a camera that stalls whenever a bar drains is
+not a camera.
 
 `view` says what is on the field and nothing about the place, which is right for
 the cartridge's white field and leaves a renderer staging the fight on the map

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -204,6 +204,9 @@ var _forget_confirm_cursor: int = 0
 ## flags of its own to read: it falls back to [method _random_slot], same as
 ## before this existed. Reset by both, set only by [method show_trainer].
 var _enemy_trainer_class: int = 0
+## Which trainer of that class, for the view. Both are zero in a wild battle,
+## which is what `wOtherTrainerClass` holds there too.
+var _enemy_trainer_index: int = 0
 
 var _enemy: int = 1
 var _player: int = 1
@@ -345,6 +348,7 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 	_save_written = false
 	_source_save = null
 	_enemy_trainer_class = 0
+	_enemy_trainer_index = 0
 	_battle = Gen2Battle.create_parties(
 		_data, _party_from(_player, _player_level), _party_from(_enemy, _enemy_level), _rng
 	)
@@ -385,6 +389,7 @@ func show_trainer(
 	_save_written = false
 	_source_save = null
 	_enemy_trainer_class = trainer_class
+	_enemy_trainer_index = index
 	_battle = Gen2Battle.create_parties(
 		_data, _party_from(_player, _player_level), enemy_party, _rng, true
 	)
@@ -423,6 +428,7 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 	_save_written = false
 	_source_save = save
 	_enemy_trainer_class = 0
+	_enemy_trainer_index = 0
 	_player = player_lead.species
 	_player_level = player_lead.level
 	_enemy = enemy_lead.species
@@ -466,6 +472,7 @@ func start_world_battle(request: Dictionary, save: Gen2SaveData = null) -> bool:
 	_save_written = false
 	_source_save = save
 	_enemy_trainer_class = int(prepared.get("trainer_class", 0))
+	_enemy_trainer_index = int(prepared.get("trainer_index", 0))
 	_battle = prepared["battle"]
 	_battle.time_of_day = _time_of_day
 	_battle.load_trainer_items(_enemy_trainer_class)
@@ -2117,6 +2124,26 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	if event.is_pressed() and _handle_debug_key(event):
 		accept_event()
+		return
+	# Everything the screen wants has been claimed above, so what reaches here is
+	# what a renderer may have a use for. Gen2WorldScreen offers its own renderer
+	# the same leftovers for the same reason: a renderer that composes its own
+	# shot has to be able to let someone steer it.
+	if _renderer_input_free() \
+		and Gen2ModHost.renderer_handles_battle_input(_renderer, event):
+		accept_event()
+
+
+## Whether the battle itself is idle enough to pass an event on.
+##
+## The two modal input states are the ones that mean something by themselves: the
+## forget-move prompt and ball selection. A draining bar, the opening slide and a
+## move animation are deliberately not on that list. None of them reads input,
+## and a camera that stops answering every time a bar drains is not a camera; the
+## presses they do swallow are swallowed in [method _handle_button], which runs
+## first and never reaches here.
+func _renderer_input_free() -> bool:
+	return is_ready() and _forget_stage == &"" and not _capture_selecting
 
 
 func _handle_button(button: int) -> bool:
@@ -2247,6 +2274,20 @@ func cycle_battle_renderer() -> Dictionary:
 	return select_battle_renderer(ids[posmod(at + 1, ids.size())])
 
 
+## `wild` or `trainer`, decided the way the battle itself decides it: a trainer
+## class of zero is a wild battle, which is what `wOtherTrainerClass` holds and
+## what `Gen2Battle.trainer_battle` was built from.
+func _battle_kind() -> StringName:
+	return &"trainer" if _enemy_trainer_class > 0 else &"wild"
+
+
+## The trainer's own name from the imported party record, not the class name.
+func _enemy_trainer_name() -> String:
+	if _enemy_trainer_class <= 0 or _data == null:
+		return ""
+	return String(_data.trainer_party(_enemy_trainer_class, _enemy_trainer_index).get("name", ""))
+
+
 ## Pushes the current display values to the renderer. Plain values only, never
 ## the battle engine: a turn resolves at once and is then shown an event at a
 ## time, so what is drawn deliberately lags where the battle has got to.
@@ -2257,6 +2298,15 @@ func _push_view() -> void:
 		"enemy_species": _enemy, "player_species": _player,
 		"enemy_name": _name_of(_enemy), "player_name": _name_of(_player),
 		"enemy_level": _enemy_level, "player_level": _player_level,
+		## Who the fight is against, which the values above do not say. A wild
+		## battle carries class 0 and an empty name, the way `wOtherTrainerClass`
+		## is zero there; a class is what `GameData.trainer_pic()` and
+		## `trainer_name()` take, so a renderer standing the opponent on the field
+		## draws the cartridge's own picture of them.
+		"battle_kind": _battle_kind(),
+		"trainer_class": _enemy_trainer_class,
+		"trainer_index": _enemy_trainer_index,
+		"trainer_name": _enemy_trainer_name(),
 		## The bars draw whatever the animation is on rather than the committed
 		## HP, which is what makes them drain. Everything else, including
 		## [method battle_snapshot], keeps reading the committed value.

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -65,6 +65,15 @@ const RENDERER_WORLD_CONTEXT_METHOD: String = "set_world_context"
 ## the screen decides what it needs, so reading them directly races the gameplay
 ## keys instead of taking what is left.
 const RENDERER_INPUT_METHOD: String = "handle_world_input"
+## Optional, battle renderers only. The same seam on the battle side: every event
+## [Gen2BattleScreen] did not claim, so a renderer composing its own shot can let
+## someone steer it. Answering true consumes the event.
+##
+## A [Gen2Button] never arrives here, on either side. The screen routes every one
+## of them to whatever owns it first, so a text box, the forget-move list and
+## ball selection all take their press before a renderer could see it, and what
+## is left is pointer and stick motion the screen has no opinion about.
+const RENDERER_BATTLE_INPUT_METHOD: String = "handle_battle_input"
 ## The id of the built-in 2D renderer, which is always registered for both
 ## renderer kinds.
 const BUILT_IN_RENDERER: StringName = &"gen2"
@@ -390,14 +399,23 @@ static func renderer_uses_hardware_viewport(renderer: Node) -> bool:
 	return bool(renderer.call(RENDERER_SURFACE_METHOD))
 
 
-## Offers [param event] to [param renderer], returning whether it was consumed.
-## See [constant RENDERER_INPUT_METHOD]; a renderer that does not take input
-## leaves every event where it was.
+## Offers [param event] to a world [param renderer], returning whether it was
+## consumed. See [constant RENDERER_INPUT_METHOD]; a renderer that does not take
+## input leaves every event where it was.
 static func renderer_handles_input(renderer: Node, event: InputEvent) -> bool:
-	if renderer == null or event == null \
-		or not renderer.has_method(RENDERER_INPUT_METHOD):
+	return _renderer_takes_input(renderer, RENDERER_INPUT_METHOD, event)
+
+
+## The same for a battle renderer. See
+## [constant RENDERER_BATTLE_INPUT_METHOD].
+static func renderer_handles_battle_input(renderer: Node, event: InputEvent) -> bool:
+	return _renderer_takes_input(renderer, RENDERER_BATTLE_INPUT_METHOD, event)
+
+
+static func _renderer_takes_input(renderer: Node, method: String, event: InputEvent) -> bool:
+	if renderer == null or event == null or not renderer.has_method(method):
 		return false
-	return bool(renderer.call(RENDERER_INPUT_METHOD, event))
+	return bool(renderer.call(method, event))
 
 
 ## Reads every installed mod's manifest without running any of them. The

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -40,10 +40,17 @@ const STEP_FRAMES_BOULDER_PUSH: int = STEP_FRAMES_NPC_WALK
 const STEP_FRAMES_FAST: int = 4
 ## How long each scripted step command takes, from the `STEP_*` speed it passes
 ## to `InitStep` (engine/overworld/movement.asm) and that row of `StepVectors`.
-## `turn_step` is the one that indexes no row: `TurnStep` sets STEP_TYPE_TURN,
-## whose two halves are two frames each (`StepFunction_Turn`).
+##
+## Every command here moves one cell, because every one of them reaches
+## `InitStep`: `NormalStep`, `SlideStep`, `JumpStep` and `TurningStep` all call
+## it and differ only in the `OBJECT_ACTION` they set over the top, a spin for
+## the three turning rows and a jump arc for the three jumping ones. The turning
+## rows keep the direction the command names; `turn_away` does not reverse it.
+##
+## `turn_step` is the one command that is not here: `TurnStep` sets
+## STEP_TYPE_TURN, never calls `InitStep`, and `StepFunction_Turn` is two frames
+## of standing and two of the new facing. It is filed with `turn_head` below.
 const SCRIPTED_STEP_FRAMES: Dictionary = {
-	&"turn_step": 4,
 	&"slow_step": STEP_FRAMES_NPC_WALK,
 	&"step": STEP_FRAMES_WALK,
 	&"big_step": STEP_FRAMES_FAST,
@@ -53,7 +60,13 @@ const SCRIPTED_STEP_FRAMES: Dictionary = {
 	&"slow_jump_step": STEP_FRAMES_NPC_WALK,
 	&"jump_step": STEP_FRAMES_WALK,
 	&"fast_jump_step": STEP_FRAMES_FAST,
+	&"turn_away": STEP_FRAMES_NPC_WALK,
+	&"turn_in": STEP_FRAMES_WALK,
+	&"turn_waterfall": STEP_FRAMES_FAST,
 }
+## The commands that only change a facing. `TurnHead` writes the direction and
+## stands; `TurnStep` writes it two frames in and stands for two more.
+const SCRIPTED_TURN_KINDS: Array[StringName] = [&"turn_head", &"turn_step"]
 ## RandomStepDuration_Slow and _Fast mask the source random byte before storing
 ## it as the wait preceding the next movement decision.
 const IDLE_MASK_SLOW: int = 0x7F
@@ -3050,11 +3063,8 @@ func _apply_object_movement(event: Dictionary) -> Array:
 	var object: Gen2WorldObject = objects[object_index]
 	for command: Dictionary in decoded.get("commands", []):
 		var kind: StringName = StringName(command.get("kind", &""))
-		if kind in [&"turn_head", &"turn_in", &"turn_waterfall"]:
+		if kind in SCRIPTED_TURN_KINDS:
 			object.apply_direction(_movement_direction(int(command.get("direction", 0))))
-			continue
-		if kind == &"turn_away":
-			object.apply_direction(-_movement_direction(int(command.get("direction", 0))))
 			continue
 		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
@@ -3131,14 +3141,10 @@ func _apply_player_movement(event: Dictionary) -> Array:
 		}]
 	for command: Dictionary in decoded.get("commands", []):
 		var kind: StringName = StringName(command.get("kind", &""))
-		if kind in [&"turn_head", &"turn_in", &"turn_waterfall"]:
+		if kind in SCRIPTED_TURN_KINDS:
 			player_facing = _facing_for_direction(
 				_movement_direction(int(command.get("direction", 0)))
 			)
-			continue
-		if kind == &"turn_away":
-			var away: Vector2i = -_movement_direction(int(command.get("direction", 0)))
-			player_facing = _facing_for_direction(away)
 			continue
 		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -151,6 +151,107 @@ func test_the_built_in_renderer_ignores_a_world_context() -> void:
 	assert_not_null(_battle_screen.world_context())
 
 
+## The battle side of Gen2WorldScreen's own renderer-input seam. A Gen2Button is
+## claimed by the screen before this and never arrives, so what a renderer is
+## offered is the motion the screen has no opinion about.
+func test_a_battle_renderer_is_offered_the_input_the_screen_did_not_claim() -> void:
+	var script: GDScript = _stub_script("""extends Control
+
+var seen: Array = []
+var consume: bool = true
+
+func set_battle_data(_data) -> bool:
+	return true
+
+func set_view(_view: Dictionary) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func handle_battle_input(event) -> bool:
+	seen.append(event)
+	return consume
+""")
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"steered", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"steered")["ok"])
+	await _open_battle()
+	assert_true(_battle_screen.is_ready())
+	var renderer: Node = _battle_screen._renderer
+
+	var motion := InputEventMouseMotion.new()
+	motion.relative = Vector2(4.0, 0.0)
+	_battle_screen._unhandled_input(motion)
+	assert_eq((renderer.get("seen") as Array).size(), 1, "the renderer was not offered it")
+
+	# A button belongs to whatever owns the screen, so it never reaches here.
+	var press := InputEventAction.new()
+	press.action = Gen2Button.ACTIONS[Gen2Button.A]
+	press.pressed = true
+	_battle_screen._unhandled_input(press)
+	assert_eq((renderer.get("seen") as Array).size(), 1, "a button reached the renderer")
+
+	# Ball selection is a modal state: it means something by itself, so the
+	# renderer is not offered anything while it is up. Set directly rather than
+	# through begin_capture(), which needs a whole hosted wild battle behind it
+	# and would test that instead of this.
+	_battle_screen._capture_selecting = true
+	_battle_screen._unhandled_input(motion)
+	assert_eq((renderer.get("seen") as Array).size(), 1, "a modal state let it through")
+	_battle_screen._capture_selecting = false
+	_battle_screen._unhandled_input(motion)
+	assert_eq((renderer.get("seen") as Array).size(), 2, "and it stayed shut afterwards")
+
+
+## A renderer that defines nothing keeps working, and one that answers false
+## leaves the event where it was.
+func test_a_battle_renderer_without_the_method_changes_nothing() -> void:
+	await _open_battle()
+	assert_false(_battle_screen._renderer.has_method("handle_battle_input"))
+	var motion := InputEventMouseMotion.new()
+	_battle_screen._unhandled_input(motion)
+	assert_false(motion.is_echo(), "the built-in renderer must not crash on one")
+
+
+## `view` says what is on the field; this says who it is against, which a
+## renderer standing the opponent behind their Pokemon needs. A wild battle
+## carries class 0, the way `wOtherTrainerClass` is zero there.
+func test_the_view_names_the_trainer_the_battle_is_against() -> void:
+	var script: GDScript = _stub_script("""extends Control
+
+var last_view: Dictionary = {}
+
+func set_battle_data(_data) -> bool:
+	return true
+
+func set_view(view: Dictionary) -> void:
+	last_view = view
+
+func refresh() -> void:
+	pass
+""")
+	assert_true(Gen2ModHost.instance().register_battle_renderer(&"named", script)["ok"])
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"named")["ok"])
+	await _open_battle()
+	var renderer: Node = _battle_screen._renderer
+
+	_battle_screen.show_matchup(16, 155, 5, 5)
+	var wild: Dictionary = renderer.get("last_view")
+	assert_eq(StringName(wild.get("battle_kind", &"")), &"wild")
+	assert_eq(int(wild.get("trainer_class", -1)), 0)
+	assert_eq(String(wild.get("trainer_name", "x")), "")
+
+	_battle_screen.show_trainer(Fixture.TRAINER_CLASS, 0)
+	var trainer: Dictionary = renderer.get("last_view")
+	assert_eq(StringName(trainer.get("battle_kind", &"")), &"trainer")
+	assert_eq(int(trainer.get("trainer_class", -1)), Fixture.TRAINER_CLASS)
+	assert_eq(int(trainer.get("trainer_index", -1)), 0)
+	assert_eq(
+		String(trainer.get("trainer_name", "")),
+		String(_data.trainer_party(Fixture.TRAINER_CLASS, 0).get("name", "")),
+	)
+
+
 func test_a_renderer_reporting_missing_data_leaves_the_screen_not_ready() -> void:
 	var script: GDScript = _stub_script("""extends Control
 

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -21,6 +21,8 @@ const SEEN_TEXT: int = 0x6FF0
 const WIN_TEXT: int = 0x7000
 const LOSS_TEXT: int = 0x7010
 const TRAINER_FLAG: int = 8
+## The fixture ships one trainer class, numbered 1, holding one trainer.
+const TRAINER_CLASS: int = 1
 const TRAINER_SPECIES: int = 16
 const TRAINER_SPRITE: int = 1
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3182,6 +3182,38 @@ func test_script_movement_steps_through_a_wall_the_way_normal_step_does() -> voi
 ## path commits at once and the drawing is what trails. Presentation only: the
 ## cells below are already the stream's last one while the offset is still two
 ## behind it.
+## The four turning commands, which are not what their names suggest.
+## `TurnStep` sets STEP_TYPE_TURN and never calls `InitStep`, so it only turns;
+## `turn_away`, `turn_in` and `turn_waterfall` all reach `TurningStep`, which
+## does call it, so each steps one cell in the direction it names and only the
+## spin over the top tells them from a plain step. `turn_away` does not reverse
+## anything. `engine/events/forced_movement.asm` is the case that shows it: a
+## whirlpool spins the player, `turn_in` steps them back off the tile, and they
+## would stand on it for good if it turned in place.
+func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		# turn_step down, then turn_in up.
+		"48:6110": [0x04, 0x25, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 0, 0x10, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+
+	# turn_step faced down and moved nothing; turn_in stepped one cell up and
+	# left the player facing the way it named.
+	assert_eq(world.player_cell, Vector2i(7, 5))
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
+	# One cell of trail, at turn_in's own STEP_WALK duration.
+	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 1.0))
+	for _call: int in 2:
+		world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
+	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+
+
 func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -> void:
 	RomCache.write_json(RomCache.world_movements_path(_directory), {
 		"48:6100": [0x0F, 0x0F, 0x47],


### PR DESCRIPTION
Add trainer identity and input routing so battle renderers can know who the fight is against and receive leftover input events. Docs (docs/MODS.md) describe new view fields and the optional handle_battle_input(renderer) method. Gen2BattleScreen (game/battle/battle_screen.gd) now tracks enemy trainer index, exposes battle_kind/trainer_class/trainer_index/trainer_name in the pushed view, and offers leftover input to renderers when the screen is idle. A small helper and a new constant were added in game/mods/mod_host.gd to route both world and battle renderer input (_renderer_takes_input, RENDERER_BATTLE_INPUT_METHOD). World scripting behaviour clarified and simplified in game/world/world_api.gd: added comments, SCRIPTED_TURN_KINDS, and cleaned turn/step handling. Tests updated/added to cover battle renderer input, view trainer fields, and turning movement; fixture adjusted to include a trainer class. These changes let custom renderers compose/steer battle views safely and correctly.