### PR TITLE
Put a doll in front of the Pokemon, and a seed under it

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -338,9 +338,12 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 ## against a locked one, Attract against a target already in love or of the same
 ## or unknown gender, and a second Mist or Focus Energy, which is why those two
 ## read the attacker rather than the defender, and a screen the attacker's own
-## side already holds. `AI_Redundant`'s one remaining row, a standing Substitute,
-## reads state this engine does not carry, so it never fires and reads as "not
-## redundant".
+## side already holds. A standing Substitute reads the attacker for the same
+## reason; Leech Seed, Nightmare and Spikes read the target.
+##
+## `AI_Redundant`'s rows for the effects this engine does not carry yet
+## (Transform, Sleep Talk, Foresight, Teleport, Future Sight) are the remainder,
+## and read as "not redundant" because no move here reaches them.
 static func _apply_basic(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
@@ -386,6 +389,20 @@ static func _apply_basic(
 			# `wEnemyScreens`, the AI's own side: a screen it already holds is
 			# the wasted turn, not one the player holds.
 			redundant = Gen2Screens.has(attacker_screens, int(SCREEN_FOR_EFFECT[effect]))
+		elif effect == Gen2MoveEffect.SUBSTITUTE:
+			# `.Substitute` reads `wEnemySubStatus4`, the AI's own.
+			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.SUBSTITUTE)
+		elif effect == Gen2MoveEffect.LEECH_SEED:
+			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.LEECH_SEED)
+		elif effect == Gen2MoveEffect.NIGHTMARE:
+			# `.Nightmare` treats *no* status as the redundant case, so a target
+			# carrying any status stays encouraged even when it is awake and cannot
+			# have one. The source marks that as a bug; reproduced, not fixed.
+			redundant = not Gen2Status.is_afflicted(defender.status) \
+				or Gen2Substatus.has(defender.substatus, Gen2Substatus.NIGHTMARE)
+		elif effect == Gen2MoveEffect.SPIKES:
+			# `.Spikes` reads `wPlayerScreens`, the side they would land on.
+			redundant = Gen2Screens.has(defender_screens, Gen2Screens.SPIKES)
 		elif WEATHER_FOR_EFFECT.has(effect):
 			redundant = weather == int(WEATHER_FOR_EFFECT[effect])
 		if redundant:

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -250,6 +250,45 @@ const SWITCH_BLOCKED: StringName = &"switch_blocked"
 const MIST_SET: StringName = &"mist_set"
 const FOCUS_ENERGY_SET: StringName = &"focus_energy_set"
 
+## Substitute. The two refusals are separate events because the cartridge chooses
+## between `HasSubstituteText` and `TooWeakSubText` on which precondition failed.
+## The last two name the Pokémon behind the doll and carry no amount, since
+## `SubTookDamageText` reports no number and the real health never moved.
+const SUBSTITUTE_MADE: StringName = &"substitute_made"
+const SUBSTITUTE_ALREADY: StringName = &"substitute_already"
+const SUBSTITUTE_TOO_WEAK: StringName = &"substitute_too_weak"
+const SUBSTITUTE_TOOK_DAMAGE: StringName = &"substitute_took_damage"
+const SUBSTITUTE_FADED: StringName = &"substitute_faded"
+
+## Leech Seed, on the Pokémon that was seeded rather than the one that seeded it.
+## [constant LEECH_SEED_SAPPED] carries the healed side under `to`, `to_amount`,
+## `to_hp` and `to_max_hp`, since one event moves health across the field.
+const WAS_SEEDED: StringName = &"was_seeded"
+const LEECH_SEED_SAPPED: StringName = &"leech_seed_sapped"
+
+## Nightmare and Curse, both quarters and both on the sufferer.
+## [constant CURSE_SET] carries the user's own `hp` after the half it cut.
+const NIGHTMARE_STARTED: StringName = &"nightmare_started"
+const HURT_BY_NIGHTMARE: StringName = &"hurt_by_nightmare"
+const CURSE_SET: StringName = &"curse_set"
+const HURT_BY_CURSE: StringName = &"hurt_by_curse"
+
+## Spikes, which are field state on the side they were scattered onto.
+const SPIKES_SET: StringName = &"spikes_set"
+const HURT_BY_SPIKES: StringName = &"hurt_by_spikes"
+
+## `BattleCommand_ClearHazards`' own three lines, all about the user's own side.
+## [constant RELEASED_BY] is not [constant RELEASED_FROM_TRAP]: `HandleWrap`'s
+## release names the move that let go and this one names the Pokémon that spun
+## out of it, so the two texts are two events.
+const SHED_LEECH_SEED: StringName = &"shed_leech_seed"
+const BLEW_SPIKES: StringName = &"blew_spikes"
+const RELEASED_BY: StringName = &"released_by"
+
+## `EvadedText`, which only `BattleCommand_LeechSeed` prints. Not
+## [constant MISSED], which is `GetFailureResultText`'s own line.
+const EVADED: StringName = &"evaded"
+
 ## A stat drop blocked by the target's own Mist. Not [constant STAT_CHANGE_FAILED]:
 ## the cartridge prints a line of its own ("It's protected by mist!") rather
 ## than the generic "won't go any lower" a drop already at its floor gets, and a
@@ -753,7 +792,33 @@ func send_out(side: int, index: int) -> Array:
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
 	})
 	(_participants[side] as Dictionary)[index] = true
+	_spikes_damage(side, events)
 	return events
+
+
+## `SpikesDamage`, which every entrance runs behind its own `SetPlayerTurn` or
+## `SetEnemyTurn`: the spikes read are the ones lying on the side walking in.
+##
+## Every reachable call site is an entrance this method already is
+## (`DetermineMoveOrder`, `PlayerPartyMonEntrance`, `EnemyPartyMonEntrance`,
+## `EnemyMonEntrance`, `ForcePlayerMonChoice`). `DoBattle`'s two run before the
+## move can have been used, and `BattleCommand_ForceSwitch`'s two belong to an
+## effect this engine does not have yet.
+func _spikes_damage(side: int, events: Array) -> void:
+	if not Gen2Screens.has(screens[side], Gen2Screens.SPIKES):
+		return
+
+	var entering: Gen2BattleMon = mon(side)
+	if entering.is_fainted() or Gen2Screens.spikes_spare(entering.types()):
+		return
+
+	var taken: int = entering.take_damage(Gen2Screens.spikes_damage(entering.max_hp()))
+	events.append({
+		"type": HURT_BY_SPIKES, "side": side, "amount": taken,
+		"hp": entering.hp, "max_hp": entering.max_hp(),
+	})
+	if entering.is_fainted():
+		events.append({"type": FAINTED, "side": side})
 
 
 ## `UpdateUsedMoves`: a move the player throws is remembered once, and the list
@@ -891,42 +956,120 @@ func take_turn(player_slot: int, enemy_slot: int) -> Array:
 	return take_actions(use_move(player_slot), use_move(enemy_slot))
 
 
-## What a burn or a poison takes at the end of the turn, from each side in the
-## order it acted.
+## `ResidualDamage`: what a burn, a poison, a Leech Seed, a Nightmare and a Curse
+## take from each side at the end of the turn, in that order and in the order the
+## sides acted.
 ##
 ## After both moves rather than after each, skipping whoever is already down, so
 ## a Pokémon that faints to its burn does so here rather than mid-move.
 ##
+## The four steps are four routines' worth of `HasUserFainted` between them: a
+## Pokémon that goes down to its poison pays neither the seed nor the nightmare.
+func _residual_damage(acting: Array, events: Array) -> void:
+	for side: int in acting:
+		if mon(side).is_fainted():
+			continue
+		_residual_status(side, events)
+		if mon(side).is_fainted():
+			continue
+		_residual_leech_seed(side, events)
+		if mon(side).is_fainted():
+			continue
+		_residual_nightmare(side, events)
+		if mon(side).is_fainted():
+			continue
+		_residual_curse(side, events)
+
+
 ## A running [member Gen2BattleMon.toxic_counter] means Toxic, which ramps
 ## instead of taking the flat eighth. The counter rises here, once a turn, so the
 ## turn it was inflicted counts as the first.
-func _residual_damage(acting: Array, events: Array) -> void:
-	for side: int in acting:
-		var current: Gen2BattleMon = mon(side)
-		if current.is_fainted():
-			continue
-		if not Gen2Status.has(current.status, Gen2Status.BURN | Gen2Status.POISON):
-			continue
+func _residual_status(side: int, events: Array) -> void:
+	var current: Gen2BattleMon = mon(side)
+	if not Gen2Status.has(current.status, Gen2Status.BURN | Gen2Status.POISON):
+		return
 
-		var amount: int
-		if Gen2Status.has(current.status, Gen2Status.POISON) and current.toxic_counter > 0:
-			amount = Gen2Status.toxic_damage(current.max_hp(), current.toxic_counter)
-			current.toxic_counter += 1
-		else:
-			amount = Gen2Status.residual_damage(current.max_hp())
+	var amount: int
+	if Gen2Status.has(current.status, Gen2Status.POISON) and current.toxic_counter > 0:
+		amount = Gen2Status.toxic_damage(current.max_hp(), current.toxic_counter)
+		current.toxic_counter += 1
+	else:
+		amount = Gen2Status.residual_damage(current.max_hp())
 
-		var taken: int = current.take_damage(amount)
-		events.append({
-			"type": HURT_BY_STATUS,
-			"side": side,
-			"status": current.status,
-			"name": Gen2Status.name_of(current.status),
-			"amount": taken,
-			"hp": current.hp,
-			"max_hp": current.max_hp(),
-		})
-		if current.is_fainted():
-			events.append({"type": FAINTED, "side": side})
+	var taken: int = current.take_damage(amount)
+	events.append({
+		"type": HURT_BY_STATUS,
+		"side": side,
+		"status": current.status,
+		"name": Gen2Status.name_of(current.status),
+		"amount": taken,
+		"hp": current.hp,
+		"max_hp": current.max_hp(),
+	})
+	if current.is_fainted():
+		events.append({"type": FAINTED, "side": side})
+
+
+## An eighth off the seeded Pokémon and onto the one across from it, capped by
+## `RestoreHP`. What is healed is what `SubtractHP` left in `bc`: the eighth
+## normally, and the seeded Pokémon's whole remaining health when the eighth
+## would have taken it below zero, so
+## [method Gen2BattleMon.take_damage]'s own answer is the figure to hand on.
+##
+## A fainted receiver cannot happen on the cartridge, where `ResidualDamage` runs
+## behind a faint check inside each side's own move; it can here, because this
+## runs once after both. Nothing is moved in that case.
+func _residual_leech_seed(side: int, events: Array) -> void:
+	var current: Gen2BattleMon = mon(side)
+	if not Gen2Substatus.has(current.substatus, Gen2Substatus.LEECH_SEED):
+		return
+
+	var sapper: Gen2BattleMon = mon(opponent_of(side))
+	var taken: int = current.take_damage(Gen2Substatus.leech_seed_damage(current.max_hp()))
+	var healed: int = 0 if sapper.is_fainted() else sapper.heal(taken)
+	events.append({
+		"type": LEECH_SEED_SAPPED,
+		"side": side,
+		"amount": taken,
+		"hp": current.hp,
+		"max_hp": current.max_hp(),
+		"to": opponent_of(side),
+		"to_amount": healed,
+		"to_hp": sapper.hp,
+		"to_max_hp": sapper.max_hp(),
+	})
+	if current.is_fainted():
+		events.append({"type": FAINTED, "side": side})
+
+
+## Nothing here asks whether the sufferer is still asleep, because waking is what
+## clears the flag.
+func _residual_nightmare(side: int, events: Array) -> void:
+	var current: Gen2BattleMon = mon(side)
+	if not Gen2Substatus.has(current.substatus, Gen2Substatus.NIGHTMARE):
+		return
+
+	var taken: int = current.take_damage(Gen2Substatus.quarter_damage(current.max_hp()))
+	events.append({
+		"type": HURT_BY_NIGHTMARE, "side": side, "amount": taken,
+		"hp": current.hp, "max_hp": current.max_hp(),
+	})
+	if current.is_fainted():
+		events.append({"type": FAINTED, "side": side})
+
+
+func _residual_curse(side: int, events: Array) -> void:
+	var current: Gen2BattleMon = mon(side)
+	if not Gen2Substatus.has(current.substatus, Gen2Substatus.CURSE):
+		return
+
+	var taken: int = current.take_damage(Gen2Substatus.quarter_damage(current.max_hp()))
+	events.append({
+		"type": HURT_BY_CURSE, "side": side, "amount": taken,
+		"hp": current.hp, "max_hp": current.max_hp(),
+	})
+	if current.is_fainted():
+		events.append({"type": FAINTED, "side": side})
 
 
 ## `HandleWeather`: one turn off the count, the line that goes with it, and a

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -115,6 +115,12 @@ var trapping_move: int = 0
 ## Song finishes it. Read only while [constant Gen2Substatus.PERISH] is set.
 var perish_count: int = 0
 
+## `wPlayerSubstituteHP`: what the doll in front of this Pokémon has left. Read
+## only while [constant Gen2Substatus.SUBSTITUTE] is set, which is why clearing
+## both in [method reset_volatile] matches a cartridge that clears the flag and
+## leaves the byte, the way [member perish_count] already does.
+var substitute_hp: int = 0
+
 ## `wPlayerTurnsTaken`: how many turns this Pokémon has actually acted on since
 ## it came out. `BattleCommand_DoTurn` is the one place it rises, behind the same
 ## charging check that decides whether PP is spent, so a two-turn release does
@@ -249,6 +255,16 @@ func stage(key: String) -> int:
 	return int(stages.get(key, 0))
 
 
+## Whether [method change_stage] would move anything, asked without moving it:
+## `BattleCommand_StatUp` and `..._StatDown` both settle "already at the end" on
+## the way in, ahead of the checks that refuse for another reason.
+func can_change_stage(key: String, by: int) -> bool:
+	if not STAGED_STATS.has(key) and not STAGED_ODDS.has(key):
+		return false
+	var before: int = int(stages.get(key, 0))
+	return clampi(before + by, Gen2Stats.MIN_STAGE, Gen2Stats.MAX_STAGE) != before
+
+
 ## Moves a stage, and answers whether it actually moved: at the top or the bottom
 ## the cartridge says so rather than silently doing nothing.
 func change_stage(key: String, by: int) -> bool:
@@ -285,6 +301,7 @@ func reset_volatile() -> void:
 	trapped_turns = 0
 	trapping_move = 0
 	perish_count = 0
+	substitute_hp = 0
 	turns_taken = 0
 	last_move_used = 0
 	fury_cutter_count = 0

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -87,6 +87,9 @@ const STAT_NAMES: Dictionary = {
 	"sp_defense": "SP.DEF",
 	"accuracy": "ACCURACY",
 	"evasion": "EVASIVENESS",
+	# `StatNames`' eighth row, which no stat uses: `BattleCommand_Curse` names it
+	# when neither Attack nor Defense can rise.
+	"ability": "ABILITY",
 }
 
 ## The three trapping moves whose landing line spells the move out, since
@@ -2027,6 +2030,47 @@ func _describe(event: Dictionary) -> String:
 		Gen2Battle.PERISH_COUNT:
 			return "%s's PERISH count is %d!" % [
 				_battler_name(side), int(event["count"]),
+			]
+		Gen2Battle.SUBSTITUTE_MADE:
+			return "%s made a SUBSTITUTE!" % _battler_name(side)
+		Gen2Battle.SUBSTITUTE_ALREADY:
+			return "%s has a SUBSTITUTE!" % _battler_name(side)
+		Gen2Battle.SUBSTITUTE_TOO_WEAK:
+			# TooWeakSubText names nobody at all.
+			return "Too weak to make a SUBSTITUTE!"
+		Gen2Battle.SUBSTITUTE_TOOK_DAMAGE:
+			return "The SUBSTITUTE took damage for %s!" % _battler_name(int(event["target"]))
+		Gen2Battle.SUBSTITUTE_FADED:
+			return "%s's SUBSTITUTE faded!" % _battler_name(int(event["target"]))
+		Gen2Battle.WAS_SEEDED:
+			return "%s was seeded!" % _battler_name(int(event["target"]))
+		Gen2Battle.LEECH_SEED_SAPPED:
+			return "LEECH SEED saps %s!" % _battler_name(side)
+		Gen2Battle.EVADED:
+			return "%s evaded the attack!" % _battler_name(int(event["target"]))
+		Gen2Battle.NIGHTMARE_STARTED:
+			return "%s started to have a NIGHTMARE!" % _battler_name(int(event["target"]))
+		Gen2Battle.HURT_BY_NIGHTMARE:
+			return "%s has a NIGHTMARE!" % _battler_name(side)
+		Gen2Battle.CURSE_SET:
+			# PutACurseText is one text with a paragraph break in it, so the two
+			# halves are one line here rather than two events.
+			return "%s cut its own HP and put a CURSE on %s!" % [
+				_battler_name(side), _battler_name(int(event["target"])),
+			]
+		Gen2Battle.HURT_BY_CURSE:
+			return "%s's hurt by the CURSE!" % _battler_name(side)
+		Gen2Battle.SPIKES_SET:
+			return "SPIKES scattered all around %s!" % _battler_name(int(event["target"]))
+		Gen2Battle.HURT_BY_SPIKES:
+			return "%s's hurt by SPIKES!" % _battler_name(side)
+		Gen2Battle.SHED_LEECH_SEED:
+			return "%s shed LEECH SEED!" % _battler_name(side)
+		Gen2Battle.BLEW_SPIKES:
+			return "%s blew away SPIKES!" % _battler_name(side)
+		Gen2Battle.RELEASED_BY:
+			return "%s was released by %s!" % [
+				_battler_name(side), _battler_name(int(event["target"])),
 			]
 		Gen2Battle.MIST_SET:
 			return "%s is shrouded in mist!" % _battler_name(side)

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -113,6 +113,12 @@ const CONTINUES_AFTER_MISS: Array[int] = [
 	Gen2MoveEffect.SELFDESTRUCT, Gen2MoveEffect.ROLLOUT, Gen2MoveEffect.FURY_CUTTER,
 ]
 
+## The two effects `BattleCommand_CheckHit`'s `.DrainSub` turns into a miss when
+## the target is behind a Substitute, and the whole of what that branch names.
+const DRAINING_EFFECTS: Array[int] = [
+	Gen2MoveEffect.LEECH_HIT, Gen2MoveEffect.DREAM_EATER,
+]
+
 ## Counter and Mirror Coat do not roll their own accuracy. They validate the
 ## move that just hit the user, then leave the doubled damage for APPLY_DAMAGE.
 const COUNTER: StringName = &"counter"
@@ -288,6 +294,16 @@ const SAFEGUARD: StringName = &"safeguard"
 ## only when both are already counting down.
 const PERISH_SONG: StringName = &"perishsong"
 
+## A doll in front of the user, the three residuals `ResidualDamage` charges, the
+## hazard `SpikesDamage` charges, and the one command that clears any of them.
+## Each handler below owns its own rules.
+const SUBSTITUTE: StringName = &"substitute"
+const LEECH_SEED: StringName = &"leechseed"
+const NIGHTMARE: StringName = &"nightmare"
+const CURSE: StringName = &"curse"
+const SPIKES: StringName = &"spikes"
+const CLEAR_HAZARDS: StringName = &"clearhazards"
+
 ## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
 ## moves that carry it end on `SafeguardProtectText`; the six secondary effects
 ## that reach `SafeCheckSafeguard` instead are refused with nothing said, which
@@ -320,8 +336,8 @@ const SKIP_SUN_CHARGE: StringName = &"skipsuncharge"
 ## off `wBattleAfterAnim` behind it.
 ##
 ## `BattleCommand_MoveAnim` is `lowersub`, `moveanimnosub`, `raisesub`. Both subs
-## return at once without `SUBSTATUS_SUBSTITUTE`, which this engine does not
-## have, so the two names are one command here.
+## only drop and restore the doll's picture, which this project does not draw, so
+## the two names are one command here.
 const MOVE_ANIM: StringName = &"moveanim"
 const MOVE_ANIM_NO_SUB: StringName = &"moveanimnosub"
 
@@ -629,6 +645,18 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_safeguard(turn)
 		PERISH_SONG:
 			_perish_song(turn)
+		SUBSTITUTE:
+			_substitute(turn)
+		LEECH_SEED:
+			_leech_seed(turn)
+		NIGHTMARE:
+			_nightmare(turn)
+		CURSE:
+			_curse(turn)
+		SPIKES:
+			_spikes(turn)
+		CLEAR_HAZARDS:
+			_clear_hazards(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -984,6 +1012,13 @@ static func _switch_turn(turn: Gen2Turn) -> void:
 	turn.target = was
 
 
+## `CheckSubstituteOpp`: whether the Pokémon opposite whoever is acting is
+## standing behind a doll. Eighteen commands ask it and every one of them refuses
+## on a yes.
+static func _substitute_refuses(turn: Gen2Turn) -> bool:
+	return Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.SUBSTITUTE)
+
+
 static func _check_immune(turn: Gen2Turn) -> void:
 	if not turn.immune:
 		return
@@ -1014,6 +1049,16 @@ static func _check_hit(turn: Gen2Turn) -> void:
 
 	if turn.effect() == Gen2MoveEffect.DREAM_EATER \
 		and not Gen2Status.is_asleep(turn.defender().status):
+		turn.missed = true
+		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
+		if not CONTINUES_AFTER_MISS.has(turn.effect()):
+			turn.end()
+		return
+
+	# `.DrainSub`, third: nothing can be drained out of a doll, so the two effects
+	# that heal off what they deal read as a miss rather than as a hit that heals
+	# nothing. Every other move goes through the doll normally.
+	if _substitute_refuses(turn) and turn.effect() in DRAINING_EFFECTS:
 		turn.missed = true
 		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
 		if not CONTINUES_AFTER_MISS.has(turn.effect()):
@@ -1089,29 +1134,39 @@ static func _jump_kick_crash(turn: Gen2Turn) -> void:
 ## and a band that fires calls `BattleCommand_FalseSwipe`, which is what leaves
 ## the Pokémon on one hit point. The roll happens whether or not the hit would
 ## have been lethal, and only the survival shows.
+##
+## The band sits in front of the substitute routing, which is the source's order
+## and not a tidying opportunity: `FalseSwipe` clamps against the *real* health
+## whatever is standing in front of it, so a band can fire, cut the figure down,
+## and have the doll spend the cut figure with "hung on" printed anyway.
+## `.update_damage_taken` then returns early against a doll, which is what stops
+## Counter and Mirror Coat answering a hit it took.
 static func _apply_damage(turn: Gen2Turn) -> void:
 	if turn.missed or turn.damage <= 0:
 		return
 	var defender: Gen2BattleMon = turn.defender()
-	turn.battle.record_damage_taken(
-		turn.target, turn.side, turn.move_number, turn.effect(), turn.damage
-	)
 
+	# Ahead of `.damage`, so everything behind reads the cut figure: what Counter
+	# remembers, what a drain heals off and what a recoil costs are all
+	# `wCurDamage` after this.
 	var band: bool = Gen2HeldItem.effect_of(turn.data(), defender.item) == Gen2HeldItem.FOCUS_BAND \
 		and Gen2HeldItem.rolls_under(
 			turn.rng(), Gen2HeldItem.parameter_of(turn.data(), defender.item)
 		)
-	if band and turn.damage >= defender.hp:
-		turn.dealt = defender.take_damage(defender.hp - 1)
-		turn.emit(Gen2Battle.HIT, {
-			"target": turn.target,
-			"amount": turn.dealt,
-			"critical": turn.critical,
-			"effectiveness": turn.effectiveness,
-			"hp": defender.hp,
-			"max_hp": defender.max_hp(),
-		})
-		turn.emit(Gen2Battle.ENDURED, {"target": turn.target, "item": defender.item})
+	var endured: bool = band and turn.damage >= defender.hp
+	if endured:
+		turn.damage = maxi(defender.hp - 1, 0)
+
+	var behind_sub: bool = _substitute_refuses(turn)
+	if not behind_sub:
+		turn.battle.record_damage_taken(
+			turn.target, turn.side, turn.move_number, turn.effect(), turn.damage
+		)
+
+	if behind_sub:
+		_substitute_damage(turn)
+		if endured:
+			turn.emit(Gen2Battle.ENDURED, {"target": turn.target, "item": defender.item})
 		return
 
 	turn.dealt = defender.take_damage(turn.damage)
@@ -1123,6 +1178,45 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		"hp": defender.hp,
 		"max_hp": defender.max_hp(),
 	})
+	if endured:
+		turn.emit(Gen2Battle.ENDURED, {"target": turn.target, "item": defender.item})
+
+
+## `DoSubstituteDamage`: the doll spends the hit and the Pokémon's own health is
+## never touched.
+##
+## The damage is a sixteen-bit word against a one-byte counter, so anything from
+## 256 up breaks the doll without arithmetic, and the subtraction breaks it on a
+## result of exactly zero as well as on a borrow. `xor a / ld [hl], a` over the
+## move's own effect byte then makes the rest of the list read as an ordinary
+## attack; five effects are exempted. `ResetDamage` closes both branches, so
+## nothing behind this applies the hit again.
+static func _substitute_damage(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	turn.emit(Gen2Battle.SUBSTITUTE_TOOK_DAMAGE, {"target": turn.target})
+
+	var broke: bool = turn.damage > 0xFF
+	if not broke:
+		# Written back before it is tested, and as the byte the cartridge leaves.
+		broke = defender.substitute_hp - turn.damage <= 0
+		defender.substitute_hp = (defender.substitute_hp - turn.damage) & 0xFF
+
+	if broke:
+		defender.substatus &= ~Gen2Substatus.SUBSTITUTE
+		turn.emit(Gen2Battle.SUBSTITUTE_FADED, {"target": turn.target})
+		if not SUBSTITUTE_KEEPS_EFFECT.has(turn.effect()):
+			turn.effect_override = Gen2MoveEffect.NORMAL_HIT_EFFECT
+
+	turn.dealt = 0
+	turn.damage = 0
+
+
+## The five whose own command reads the effect byte back to decide how many hits
+## it is partway through. Beat Up is among them and is not written here.
+const SUBSTITUTE_KEEPS_EFFECT: Array[int] = [
+	Gen2MoveEffect.MULTI_HIT, Gen2MoveEffect.DOUBLE_HIT, Gen2MoveEffect.TWINEEDLE,
+	Gen2MoveEffect.TRIPLE_KICK, Gen2MoveEffect.BEAT_UP,
+]
 
 
 static func _counter(turn: Gen2Turn, mirror_coat: bool) -> void:
@@ -1358,6 +1452,16 @@ static func _check_status(turn: Gen2Turn) -> void:
 ## already landed. A chance of zero never fires, which is what the cartridge's
 ## comparison does too: zero means never, not "unspecified".
 static func _effect_chance(turn: Gen2Turn) -> void:
+	# `xor a / ld [wEffectFailed], a` opens the routine, so a second
+	# `effectchance` clears what the first decided. Only `DefenseDownHit` has two.
+	turn.failed_chance = false
+
+	# `CheckSubstituteOpp` next, jumping straight to `.failed`, so a secondary
+	# effect aimed at a doll draws no roll at all.
+	if _substitute_refuses(turn):
+		turn.failed_chance = true
+		return
+
 	var chance: int = int(turn.move.get("effect_chance", 0))
 	if turn.rng().randi_range(0, Gen2Status.CHANCE_RANGE - 1) >= chance:
 		turn.failed_chance = true
@@ -1379,6 +1483,15 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 	if defender.is_fainted():
 		return
 
+	# The four secondary `*Target` commands open on `CheckSubstituteOpp`, ahead of
+	# the status check, so a doll stops even the thaw a burn would have given. The
+	# three primary commands ask after theirs. Everything between the two
+	# positions is a refusal that says nothing here, so `Defrost` is the only
+	# place the split shows.
+	var primary: bool = _status_move_animates(turn, flag)
+	if not primary and _substitute_refuses(turn):
+		return
+
 	if Gen2Status.is_afflicted(defender.status):
 		# `BattleCommand_BurnTarget` is the one that does not simply return here:
 		# its `jp nz, Defrost` thaws a frozen target instead.
@@ -1392,6 +1505,9 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 		return
 
 	if _status_type_refuses(turn, flag):
+		return
+
+	if primary and _substitute_refuses(turn):
 		return
 
 	if turn.failed_chance:
@@ -1498,6 +1614,11 @@ static func _toxic_target(turn: Gen2Turn) -> void:
 	if _status_type_refuses(turn, Gen2Status.POISON):
 		return
 
+	# `.dont_sample_failure`, which is where that command asks about the doll:
+	# behind the type and status checks rather than in front of them.
+	if _substitute_refuses(turn):
+		return
+
 	# `BattleCommand_Poison`'s `.toxic` branch reaches the same `.apply_poison`,
 	# so Toxic animates from inside the command and never reaches
 	# `PlayOpponentBattleAnim`: no `ANIM_PSN` follows it.
@@ -1518,6 +1639,11 @@ static func _flinch_target(turn: Gen2Turn) -> void:
 	if turn.failed_chance:
 		return
 
+	# `BattleCommand_FlinchTarget` opens on `CheckSubstituteOpp`: there is nobody
+	# to startle behind a doll.
+	if _substitute_refuses(turn):
+		return
+
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.is_fainted():
 		return
@@ -1536,6 +1662,12 @@ static func _confuse_target(turn: Gen2Turn) -> void:
 	# `BattleCommand_ConfuseTarget`'s own `SafeCheckSafeguard`, ahead of the
 	# substitute and already-confused checks and silent like the four statuses'.
 	if _safeguard_refuses(turn, turn.target):
+		return
+
+	# Where `..._ConfuseTarget` asks it. `..._Confuse` asks one step later, after
+	# the already-confused check, and both refusals are silent, so the two orders
+	# cannot be told apart here.
+	if _substitute_refuses(turn):
 		return
 
 	var defender: Gen2BattleMon = turn.defender()
@@ -1612,14 +1744,11 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 		# carries the damage flash.
 		_multi_hit_anim(turn, hit == hits - 1)
 
-		turn.dealt = defender.take_damage(turn.damage)
-		turn.battle.record_damage_taken(
-			turn.target, turn.side, turn.move_number, turn.effect(), turn.damage
-		)
-		turn.emit(Gen2Battle.HIT, {
-			"target": turn.target, "amount": turn.dealt, "critical": turn.critical,
-			"effectiveness": turn.effectiveness, "hp": defender.hp, "max_hp": defender.max_hp(),
-		})
+		# `applydamage` is inside the loop too, so each hit goes through the whole
+		# of it, Focus Band and Substitute included. That is why
+		# `DoSubstituteDamage` exempts this effect from stamping
+		# `EFFECT_NORMAL_HIT`: the loop reads the byte back on the next pass.
+		_apply_damage(turn)
 
 		if defender.is_fainted():
 			_check_faint(turn)
@@ -2013,12 +2142,16 @@ static func _focus_energy(turn: Gen2Turn) -> void:
 ## `BattleCommand_TrapTarget`'s own three refusals, in its order: a missed move,
 ## a target that is already bound, and a target behind a Substitute. The first is
 ## structural here, since [method _check_hit] ends the move before this step is
-## reached, and the third has nothing to read until Substitute exists. An
-## already-bound target is silent rather than a [constant Gen2Battle.MOVE_FAILED],
-## because the cartridge returns without printing anything.
+## reached. All three are silent rather than a
+## [constant Gen2Battle.MOVE_FAILED], because the cartridge returns without
+## printing anything. The doll check sits in front of `BattleRandom`, so a bind
+## aimed at one draws no roll.
 static func _trap_target(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if defender.trapped_turns > 0:
+		return
+
+	if _substitute_refuses(turn):
 		return
 
 	defender.trapped_turns = Gen2Substatus.roll_trap_turns(turn.rng())
@@ -2125,6 +2258,175 @@ static func _perish_song(turn: Gen2Turn) -> void:
 
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.PERISH_SONG_STARTED)
+
+
+## `BattleCommand_Substitute`. Paying is exact rather than clamped, so the test is
+## a borrow *or* a result of zero: a user sitting on exactly a quarter fails
+## rather than making a doll and fainting. Success zeroes the user's own wrap
+## counter and nothing on the other side of the field.
+static func _substitute(turn: Gen2Turn) -> void:
+	var user: Gen2BattleMon = turn.attacker()
+	if Gen2Substatus.has(user.substatus, Gen2Substatus.SUBSTITUTE):
+		turn.emit(Gen2Battle.SUBSTITUTE_ALREADY)
+		return
+
+	# Written before the affordability test, as the source writes it: a refused
+	# Substitute leaves the byte set and the flag clear.
+	var cost: int = Gen2Substatus.substitute_hp_for(user.max_hp())
+	user.substitute_hp = cost
+	if user.hp <= cost:
+		turn.emit(Gen2Battle.SUBSTITUTE_TOO_WEAK)
+		return
+
+	user.hp -= cost
+	user.substatus |= Gen2Substatus.SUBSTITUTE
+	user.trapped_turns = 0
+	user.trapping_move = 0
+
+	# `xor a / ld [wBattleAnimParam], a` before `LoadAnim`: param 0 is the doll
+	# going up, where `lowersub` and `raisesub` pass 1 and 2.
+	turn.battle.battle_anim_param = 0
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.SUBSTITUTE_MADE, {
+		"amount": cost, "hp": user.hp, "max_hp": user.max_hp(),
+		"substitute_hp": user.substitute_hp,
+	})
+
+
+## The seed [method Gen2Battle._residual_leech_seed] reads back every turn.
+##
+## Refusals in the source's order: a Substitute and an already-seeded target both
+## say `EvadedText`, a Grass-type says `DoesntAffectText`. The missed branch in
+## front of them is structural here, since [method _check_hit] ends the move.
+## Every refusal reaches `AnimateFailedMove`, which is a forty-frame wait between
+## two doll calls and plays no animation, so only a seed that lands is drawn.
+static func _leech_seed(turn: Gen2Turn) -> void:
+	if _substitute_refuses(turn):
+		turn.emit(Gen2Battle.EVADED, {"target": turn.target})
+		return
+
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.types().has(RomLayout.TYPE_GRASS):
+		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+		return
+
+	if Gen2Substatus.has(defender.substatus, Gen2Substatus.LEECH_SEED):
+		turn.emit(Gen2Battle.EVADED, {"target": turn.target})
+		return
+
+	defender.substatus |= Gen2Substatus.LEECH_SEED
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.WAS_SEEDED, {"target": turn.target})
+
+
+## Four refusals, all `PrintButItFailed`: a target out of sight, one behind a
+## doll, one that is not asleep, and one already having a nightmare.
+static func _nightmare(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if _is_hidden(defender.substatus) or _substitute_refuses(turn) \
+		or not Gen2Status.is_asleep(defender.status) \
+		or Gen2Substatus.has(defender.substatus, Gen2Substatus.NIGHTMARE):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	defender.substatus |= Gen2Substatus.NIGHTMARE
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.NIGHTMARE_STARTED, {"target": turn.target})
+
+
+## Two moves sharing a byte and telling themselves apart by the *user's* own
+## types: a Ghost curses the target for half its own maximum, everybody else
+## trades a stage of Speed for one of Attack and one of Defense.
+##
+## Those three are `LowerStat` and `BattleCommand_AttackUp`/`..._DefenseUp`, which
+## act on the user's own stages with no Mist, Substitute or `wEffectFailed` check
+## between them, so they are stage moves here rather than [method _stat_change]
+## calls. `ResetMiss` between them is what stops a Speed that could not fall from
+## swallowing the two raises.
+static func _curse(turn: Gen2Turn) -> void:
+	var user: Gen2BattleMon = turn.attacker()
+	if user.types().has(RomLayout.TYPE_GHOST):
+		_curse_ghost(turn, user)
+		return
+
+	# `.cantraise` names `GetStatName`'s eighth entry rather than either stat it
+	# just looked at: `ld b, ABILITY + 1` is what `StatNames`' "ABILITY" row exists
+	# for, and the line reads "<USER>'s ABILITY won't rise anymore!".
+	if not user.can_change_stage("attack", 1) and not user.can_change_stage("defense", 1):
+		turn.emit(Gen2Battle.STAT_CHANGE_FAILED, {
+			"target": turn.side, "stat": CURSE_FAILED_STAT, "by": 1,
+		})
+		return
+
+	# `ld a, $1 / ld [wBattleAnimParam], a` ahead of `AnimateCurrentMove`.
+	turn.battle.battle_anim_param = 1
+	_animate_current_move(turn)
+	_curse_stage(turn, user, "speed", -1)
+	_curse_stage(turn, user, "attack", 1)
+	_curse_stage(turn, user, "defense", 1)
+
+
+static func _curse_stage(turn: Gen2Turn, user: Gen2BattleMon, key: String, by: int) -> void:
+	turn.stat_key = key
+	turn.stat_by = by
+	turn.stat_target = turn.side
+	turn.stat_mist_blocked = false
+	turn.stat_moved = user.change_stage(key, by)
+	_stat_message(turn)
+
+
+## `.ghost`: `GetHalfMaxHP` and `SubtractHPFromUser` with nothing between them, so
+## a user on less than half its maximum goes down to its own move.
+static func _curse_ghost(turn: Gen2Turn, user: Gen2BattleMon) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if _is_hidden(defender.substatus) or _substitute_refuses(turn) \
+		or Gen2Substatus.has(defender.substatus, Gen2Substatus.CURSE):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	defender.substatus |= Gen2Substatus.CURSE
+	_animate_current_move(turn)
+	var taken: int = user.take_damage(Gen2Substatus.half_damage(user.max_hp()))
+	turn.emit(Gen2Battle.CURSE_SET, {
+		"target": turn.target, "amount": taken, "hp": user.hp, "max_hp": user.max_hp(),
+	})
+
+	# `Curse:` carries no `checkfaint`: the cartridge's turn loop asks
+	# `HasPlayerFainted` behind every move, and this engine has no such step, so
+	# whoever took the health reports it, as `_residual_damage` already does.
+	if user.is_fainted():
+		turn.emit(Gen2Battle.FAINTED)
+
+
+## Field state [method Gen2Battle._spikes_damage] charges to whoever walks onto
+## it. Nothing stops it but spikes already there, and that is `FailMove` rather
+## than a quiet return.
+static func _spikes(turn: Gen2Turn) -> void:
+	if Gen2Screens.has(turn.battle.screens[turn.target], Gen2Screens.SPIKES):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	turn.battle.screens[turn.target] |= Gen2Screens.SPIKES
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.SPIKES_SET, {"target": turn.target})
+
+
+## All three are the user's own state, never the target's, and the wrap half
+## zeroes the counter without clearing [member Gen2BattleMon.trapping_move],
+## which is what the source leaves alone.
+static func _clear_hazards(turn: Gen2Turn) -> void:
+	var user: Gen2BattleMon = turn.attacker()
+	if Gen2Substatus.has(user.substatus, Gen2Substatus.LEECH_SEED):
+		user.substatus &= ~Gen2Substatus.LEECH_SEED
+		turn.emit(Gen2Battle.SHED_LEECH_SEED)
+
+	if Gen2Screens.has(turn.battle.screens[turn.side], Gen2Screens.SPIKES):
+		turn.battle.screens[turn.side] &= ~Gen2Screens.SPIKES
+		turn.emit(Gen2Battle.BLEW_SPIKES)
+
+	if user.trapped_turns > 0:
+		user.trapped_turns = 0
+		turn.emit(Gen2Battle.RELEASED_BY, {"target": turn.target})
 
 
 ## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status
@@ -2391,10 +2693,14 @@ static func _animate_current_move(turn: Gen2Turn) -> void:
 ## The `wAttackMissed` guard is structural here, since [method _check_hit] ends
 ## the move on a miss and [method _check_faint] ends it on a KO, so this step is
 ## only ever reached by a hit that left the target standing. The Substitute check
-## has nothing to read yet.
+## sits between the item and the roll, exactly where `BattleCommand_HeldFlinch`
+## puts it, so a King's Rock aimed at a doll draws no roll.
 static func _kings_rock(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	if Gen2HeldItem.effect_of(turn.data(), attacker.item) != Gen2HeldItem.FLINCH:
+		return
+
+	if _substitute_refuses(turn):
 		return
 	if not Gen2HeldItem.rolls_under(
 		turn.rng(), Gen2HeldItem.parameter_of(turn.data(), attacker.item)
@@ -2415,6 +2721,11 @@ static func _kings_rock(turn: Gen2Turn) -> void:
 ## (`entry[2]` false), which is exactly what Mist blocks. A rise always targets
 ## the user and is never checked, matching [code]CheckMist[/code] gating only the
 ## "down" and "down2" effect-byte ranges.
+##
+## The order is `BattleCommand_StatDown`'s: `CheckMist`, then the stage that
+## cannot move, then `.DidntMiss`'s `CheckSubstituteOpp` and `wEffectFailed`. Each
+## sets a different `wFailedMessage`, so a drop that failed its secondary roll
+## against a Misted or already-floored target still says the specific line.
 static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	var entry: Array = STAT_COMMANDS[command]
 	var stat_key: String = String(entry[0])
@@ -2426,14 +2737,19 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	turn.stat_by = amount
 	turn.stat_target = side
 	turn.stat_mist_blocked = false
-
-	if turn.failed_chance:
-		turn.stat_moved = false
-		return
+	turn.stat_moved = false
 
 	if not targets_user and Gen2Substatus.has(turn.battle.mon(side).substatus, Gen2Substatus.MIST):
-		turn.stat_moved = false
 		turn.stat_mist_blocked = true
+		return
+
+	if not turn.battle.mon(side).can_change_stage(stat_key, amount):
+		return
+
+	if not targets_user and _substitute_refuses(turn):
+		return
+
+	if turn.failed_chance:
 		return
 
 	turn.stat_moved = turn.battle.mon(side).change_stage(stat_key, amount)
@@ -2449,6 +2765,10 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 ## Minimize's move number, which is the whole of what `MinimizeDropSub` compares
 ## against and what makes a Stomp hurt twice as much.
 const MINIMIZE_MOVE: int = 107
+
+## `StatNames`' eighth row, which exists only so `BattleCommand_Curse` has
+## something to name when neither of the two stats it raises can move.
+const CURSE_FAILED_STAT: String = "ability"
 
 
 ## Ancientpower's roll: the user's five real stats, all at once, reported as one

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -181,6 +181,28 @@ const SAFEGUARD: int = 124
 ## on the field that a switch escapes.
 const PERISH_SONG: int = 114
 
+## Substitute: a quarter of the user's own health standing in front of it, with
+## hit points of its own on [member Gen2BattleMon.substitute_hp]. Eighteen
+## commands ask whether one is up and every one of them refuses on a yes.
+const SUBSTITUTE: int = 79
+
+## The three residuals `ResidualDamage` charges behind burn and poison, and
+## Spikes, which is field state on [member Gen2Battle.screens] instead. Rapid Spin
+## is the only move that undoes any of them.
+const LEECH_SEED: int = 84
+const NIGHTMARE: int = 107
+const CURSE: int = 109
+const SPIKES: int = 112
+const RAPID_SPIN: int = 129
+
+## `EFFECT_NORMAL_HIT` as a byte rather than [constant NORMAL_HIT]'s list:
+## `DoSubstituteDamage` stamps it over the move's own once a doll has broken.
+const NORMAL_HIT_EFFECT: int = 0
+
+## Beat Up, named for that command's exemption list alone. The effect itself is
+## unwritten.
+const BEAT_UP: int = 154
+
 ## Swift, Faint Attack and Vital Throw, which point at `NormalHit` like any other
 ## attack: their whole difference is one comparison inside
 ## [method Gen2EffectCommands._check_hit], so this byte has no list.
@@ -697,6 +719,68 @@ const PERISH_SONG_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.PERISH_SONG,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Substitute, Nightmare, Curse and Spikes: the same four steps
+## [constant PERISH_SONG_SEQUENCE] has. None of them rolls accuracy, so the 100%
+## all four carry in the move table is never read.
+const SUBSTITUTE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.SUBSTITUTE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const NIGHTMARE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.NIGHTMARE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const CURSE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CURSE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const SPIKES_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.SPIKES,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## The same list with a roll in front: `LeechSeed` is the one of the five that
+## carries `checkhit`, and its 90% is the only accuracy byte among them read.
+const LEECH_SEED_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.LEECH_SEED,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## [constant NORMAL_HIT] with `clearhazards` between the damage and the faint
+## check, which is where the source puts it: a spin that knocks its target out
+## still sheds the seed, the spikes and the bind on its own side.
+const RAPID_SPIN_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CRITICAL,
+	Gen2EffectCommands.DAMAGE_STATS,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.MOVE_ANIM,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CLEAR_HAZARDS,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1223,6 +1307,10 @@ const STAT_DOWN_2_BASE: int = 58
 const STAT_DOWN_HIT_BASE: int = 68
 const STAT_RUN_LENGTH: int = 7
 
+## The second of that run, `EFFECT_DEFENSE_DOWN_HIT`, which is the only one whose
+## list differs from its six neighbours.
+const DEFENSE_DOWN_HIT: int = STAT_DOWN_HIT_BASE + 1
+
 ## The two effect bytes a run does not reach. Metal Claw raises the user's
 ## Attack on a roll and Ancientpower raises all five of them, and neither sits
 ## in a run of its own: 139 falls where an eighth "down by one, on a hit" stat
@@ -1298,9 +1386,17 @@ static func _stat_sequences() -> Dictionary:
 		out[STAT_UP_2_BASE + offset] = _stat_up_sequence(STAT_UP_2_COMMANDS[offset])
 		out[STAT_DOWN_BASE + offset] = _stat_down_sequence(STAT_DOWN_COMMANDS[offset])
 		out[STAT_DOWN_2_BASE + offset] = _stat_down_sequence(STAT_DOWN_2_COMMANDS[offset])
-		out[STAT_DOWN_HIT_BASE + offset] = _secondary([
+		# `DefenseDownHit` is the one row of the seven that rolls twice, with the
+		# second roll behind `applydamage`. Nothing reads `wEffectFailed` between
+		# them, so only the second decides, and by then a doll the hit broke is
+		# gone: `docs/bugs_and_glitches.md`'s "Moves that lower Defense can do so
+		# after breaking a Substitute", kept rather than fixed.
+		var trailing: Array = [
 			STAT_DOWN_COMMANDS[offset], Gen2EffectCommands.STAT_DOWN_MESSAGE,
-		])
+		]
+		if STAT_DOWN_HIT_BASE + offset == DEFENSE_DOWN_HIT:
+			trailing.push_front(Gen2EffectCommands.EFFECT_CHANCE)
+		out[STAT_DOWN_HIT_BASE + offset] = _secondary(trailing)
 	out[ATTACK_UP_HIT] = _secondary([
 		STAT_UP_COMMANDS[0], Gen2EffectCommands.STAT_UP_MESSAGE,
 	])
@@ -1375,6 +1471,12 @@ static func _sequences() -> Dictionary:
 		REFLECT: SCREEN_SEQUENCE,
 		SAFEGUARD: SAFEGUARD_SEQUENCE,
 		PERISH_SONG: PERISH_SONG_SEQUENCE,
+		SUBSTITUTE: SUBSTITUTE_SEQUENCE,
+		LEECH_SEED: LEECH_SEED_SEQUENCE,
+		NIGHTMARE: NIGHTMARE_SEQUENCE,
+		CURSE: CURSE_SEQUENCE,
+		SPIKES: SPIKES_SEQUENCE,
+		RAPID_SPIN: RAPID_SPIN_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,

--- a/game/battle/screens.gd
+++ b/game/battle/screens.gd
@@ -32,6 +32,10 @@ const TURNS: int = 5
 ## value, before the critical-hit check that may discard it.
 const DEFENCE_MULTIPLIER: int = 2
 
+## `SpikesDamage`'s own `GetEighthMaxHP`, paid by whoever walks onto the side the
+## spikes are lying on.
+const SPIKES_DIVISOR: int = 8
+
 
 static func has(screens: int, flags: int) -> bool:
 	return screens & flags != 0
@@ -48,3 +52,14 @@ static func guarding_flag(move_type: int) -> int:
 ## its defending stat doubled.
 static func doubles_defence(screens: int, move_type: int) -> bool:
 	return has(screens, guarding_flag(move_type))
+
+
+static func spikes_damage(max_hp: int) -> int:
+	@warning_ignore("integer_division")
+	return maxi(max_hp / SPIKES_DIVISOR, 1)
+
+
+## Whether `SpikesDamage` skips the Pokémon walking in: a Flying-type in either
+## slot, and nothing else.
+static func spikes_spare(types: Array) -> bool:
+	return types.has(RomLayout.TYPE_FLYING)

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -67,6 +67,20 @@ const X_ACCURACY: int = 1 << 15
 ## [method Gen2BattleMon.reset_volatile] is the same behavior.
 const PERISH: int = 1 << 16
 
+## `SUBSTATUS_SUBSTITUTE`, `wPlayerSubStatus4` bit 4. The doll's own hit points
+## sit beside it on [member Gen2BattleMon.substitute_hp].
+const SUBSTITUTE: int = 1 << 17
+
+## `SUBSTATUS_LEECH_SEED`, `wPlayerSubStatus4` bit 7. It sits on the Pokémon that
+## was seeded rather than on the one that seeded it, which is why
+## `BattleCommand_ClearHazards` reads the user's own flag.
+const LEECH_SEED: int = 1 << 18
+
+## `SUBSTATUS_NIGHTMARE` and `SUBSTATUS_CURSE`, `wPlayerSubStatus1` bits 0 and 1.
+## Both cost a quarter at the end of the turn and both sit on the sufferer.
+const NIGHTMARE: int = 1 << 19
+const CURSE: int = 1 << 20
+
 const NONE: int = 0
 
 ## How many turns a confused Pokémon stays that way, rolled the same shape as
@@ -109,6 +123,13 @@ const MAX_TRAP_TURNS: int = 6
 ## What a bound Pokémon loses each turn, `GetSixteenthMaxHP`'s at-least-one
 ## sixteenth (engine/battle/core.asm).
 const TRAP_DIVISOR: int = 16
+
+## `GetEighthMaxHP`, `GetQuarterMaxHP` and `GetHalfMaxHP`: what Leech Seed moves
+## across the field, what a Nightmare and a Curse each cost their sufferer, and
+## what a Ghost-type Curse cuts off its own user.
+const LEECH_SEED_DIVISOR: int = 8
+const QUARTER_DIVISOR: int = 4
+const HALF_DIVISOR: int = 2
 
 ## What `BattleCommand_PerishSong` loads into each side's count. `HandlePerishSong`
 ## decrements before it prints, so the four counts printed are 3, 2, 1 and 0, and
@@ -180,3 +201,26 @@ static func roll_trap_turns(rng: RandomNumberGenerator) -> int:
 static func trap_damage(max_hp: int) -> int:
 	@warning_ignore("integer_division")
 	return maxi(max_hp / TRAP_DIVISOR, 1)
+
+
+static func leech_seed_damage(max_hp: int) -> int:
+	@warning_ignore("integer_division")
+	return maxi(max_hp / LEECH_SEED_DIVISOR, 1)
+
+
+static func quarter_damage(max_hp: int) -> int:
+	@warning_ignore("integer_division")
+	return maxi(max_hp / QUARTER_DIVISOR, 1)
+
+
+static func half_damage(max_hp: int) -> int:
+	@warning_ignore("integer_division")
+	return maxi(max_hp / HALF_DIVISOR, 1)
+
+
+## Not [method quarter_damage]: `BattleCommand_Substitute` shifts the maximum
+## right twice by hand and stores the low byte, with no `GetQuarterMaxHP` and so
+## no floor at one, which is why a maximum under four makes a doll with no hit
+## points at all rather than a one-point one.
+static func substitute_hp_for(max_hp: int) -> int:
+	return (max_hp >> 2) & 0xFF

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -51,6 +51,11 @@ var defense_stat: int = 0
 var power_override: int = -1
 var type_override: int = -1
 
+## The same per-turn copy one field along, with one writer: `DoSubstituteDamage`
+## stamps `EFFECT_NORMAL_HIT` over `wPlayerMoveStruct + MOVE_EFFECT` once a doll
+## has broken, so the steps behind the break read an ordinary attack.
+var effect_override: int = -1
+
 ## What was actually taken off, which is not the same as [member damage]: a
 ## Pokémon with three hit points left takes three from a hit worth forty.
 var dealt: int = 0
@@ -127,6 +132,8 @@ func rng() -> RandomNumberGenerator:
 
 
 func effect() -> int:
+	if effect_override >= 0:
+		return effect_override
 	return int(move.get("effect", -1))
 
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -83,6 +83,14 @@ func _battle_host() -> Gen2BattleScreen:
 	return null
 
 
+## The wild this fixture ships, named out of the cache rather than spelled out.
+## Which species number `TRAINER_SPECIES` lands on, and so whether that row
+## carries a name of its own or the filler one, is the world fixture's business
+## and not something these four messages should pin.
+func _wild_name() -> String:
+	return String(_data.species(Fixture.TRAINER_SPECIES).get("name", ""))
+
+
 func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	await _open_world()
 	var before: Dictionary = _world_screen.world_snapshot()
@@ -296,7 +304,7 @@ func test_resolved_wild_encounter_reaches_the_real_battle_overlay() -> void:
 	assert_not_null(host)
 	assert_true(host.is_ready())
 	assert_eq(host.battle_snapshot()["enemy"], Fixture.TRAINER_SPECIES)
-	assert_eq(host.battle_snapshot()["message"], "Wild FILLER appeared!")
+	assert_eq(host.battle_snapshot()["message"], "Wild %s appeared!" % _wild_name())
 
 
 func test_catch_tutorial_uses_the_real_battle_overlay_without_persistent_capture() -> void:
@@ -367,13 +375,13 @@ func test_master_ball_capture_runs_through_the_real_battle_overlay() -> void:
 		host.finish()
 		host.advance()
 
-	assert_eq(host.battle_snapshot()["message"], "Gotcha! FILLER was caught!")
+	assert_eq(host.battle_snapshot()["message"], "Gotcha! %s was caught!" % _wild_name())
 	host.finish()
 	host.advance()
 	await get_tree().process_frame
 	assert_null(_battle_host())
 	assert_eq(_world_screen._world.state.item_quantity(Gen2WorldPartyHost.ITEM_MASTER_BALL), 0)
-	assert_eq(_world_screen.world_snapshot()["script_prompt"], "Caught FILLER")
+	assert_eq(_world_screen.world_snapshot()["script_prompt"], "Caught %s" % _wild_name())
 
 
 func test_failed_capture_shows_break_free_and_returns_to_battle() -> void:
@@ -397,7 +405,7 @@ func test_failed_capture_shows_break_free_and_returns_to_battle() -> void:
 	for _message: int in 5:
 		host.finish()
 		host.advance()
-		if host.battle_snapshot()["message"] == "FILLER broke free!":
+		if host.battle_snapshot()["message"] == "%s broke free!" % _wild_name():
 			saw_break_free = true
 
 	assert_true(saw_break_free)

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -24,6 +24,15 @@ const CUBONE: int = 104
 const MAROWAK: int = 105
 const DITTO: int = 132
 
+## The two species whose *type* is the whole point of them. `BattleCommand_Curse`
+## picks its branch off the user being a Ghost-type and `SpikesDamage` spares a
+## Flying-type, so neither rule can be reached with the eight above. Real numbers
+## and real base stats, like every other row here. Hoothoot's 163 is a species
+## number and shares nothing but its value with [constant SLASH]'s move number and
+## [constant LIGHT_BALL]'s item number.
+const GASTLY: int = 92
+const HOOTHOOT: int = 163
+
 ## The highest species number this table fills.
 const MAX_SPECIES: int = MAGCARGO
 
@@ -121,6 +130,20 @@ const SAFEGUARD: int = 219
 ## Perish Song, the same shape again: a real move number, no power, and an
 ## accuracy its own sequence never rolls.
 const PERISH_SONG: int = 195
+
+## Substitute and the three residuals, at their real move numbers with their real
+## rows. Curse has to be real twice over: `BattleCommand_Curse` reads the user's
+## own type, and the move is the only carrier of `CURSE_TYPE`. Leech Seed is the
+## one of the five that rolls accuracy, so its 90% is a real byte rather than the
+## 255 the others carry.
+const SUBSTITUTE: int = 164
+const LEECH_SEED: int = 73
+const NIGHTMARE: int = 171
+const CURSE: int = 174
+const SPIKES: int = 191
+
+## Rapid Spin, the only move that undoes any of the three.
+const RAPID_SPIN: int = 229
 
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
@@ -267,6 +290,9 @@ const POISON: int = 0x03
 const FLYING: int = 0x02
 const DRAGON: int = 0x1A
 const DARK: int = 0x1B
+## `constants/type_constants.asm`'s own `CURSE_TYPE`, which sits in the unused
+## run at 19 and belongs to exactly one move.
+const CURSE_TYPE: int = 0x13
 
 ## Only the matchups the battle tests use, not the whole chart. The chart itself
 ## is the importer's business and is tested there; what matters here is that the
@@ -348,6 +374,14 @@ static func _species() -> Array:
 		DITTO: [
 			"DITTO", [48, 48, 48, 48, 48, 48], [NORMAL, NORMAL],
 			Gen2Experience.GROWTH_MEDIUM_FAST, 61, [], GENDER_UNKNOWN,
+		],
+		GASTLY: [
+			"GASTLY", [30, 35, 30, 80, 100, 35], [GHOST, POISON],
+			Gen2Experience.GROWTH_MEDIUM_SLOW, 95, [], GENDER_F50,
+		],
+		HOOTHOOT: [
+			"HOOTHOOT", [60, 30, 30, 50, 36, 56], [NORMAL, FLYING],
+			Gen2Experience.GROWTH_MEDIUM_FAST, 58, [], GENDER_F50,
 		],
 	}
 
@@ -497,6 +531,14 @@ static func _moves() -> Array:
 		REFLECT: ["REFLECT", 0, PSYCHIC_TYPE, 255, 20, Gen2MoveEffect.REFLECT, 0],
 		SAFEGUARD: ["SAFEGUARD", 0, NORMAL, 255, 25, Gen2MoveEffect.SAFEGUARD, 0],
 		PERISH_SONG: ["PERISH SONG", 0, NORMAL, 255, 5, Gen2MoveEffect.PERISH_SONG, 0],
+		# Leech Seed's 229 is its real 90% as a byte (`x percent` is `x * 255 / 100`);
+		# the other four never roll theirs.
+		SUBSTITUTE: ["SUBSTITUTE", 0, NORMAL, 255, 10, Gen2MoveEffect.SUBSTITUTE, 0],
+		LEECH_SEED: ["LEECH SEED", 0, GRASS, 229, 10, Gen2MoveEffect.LEECH_SEED, 0],
+		NIGHTMARE: ["NIGHTMARE", 0, GHOST, 255, 15, Gen2MoveEffect.NIGHTMARE, 0],
+		CURSE: ["CURSE", 0, CURSE_TYPE, 255, 10, Gen2MoveEffect.CURSE, 0],
+		SPIKES: ["SPIKES", 0, GROUND, 255, 20, Gen2MoveEffect.SPIKES, 0],
+		RAPID_SPIN: ["RAPID SPIN", 20, NORMAL, 255, 40, Gen2MoveEffect.RAPID_SPIN, 0],
 		# Thunder with a paralysis chance the roll cannot fail, so the secondary
 		# behind its own effect can be seen without a seed. The accuracy byte is
 		# still the real 178, since that is what the weather rewrites.

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -589,3 +589,81 @@ func test_smart_discourages_perish_song_only_while_the_matchup_holds() -> void:
 			left_alone = true
 	assert_true(discouraged, "a matchup worth keeping is worth not ending")
 	assert_true(left_alone)
+
+
+## `AI_Redundant.Substitute` reads `wEnemySubStatus4`, the AI's own: a second doll
+## while the first is standing is the wasted turn.
+func test_basic_treats_a_second_substitute_as_redundant() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SUBSTITUTE, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	pikachu.substatus |= Gen2Substatus.SUBSTITUTE
+
+	for seed: int in 10:
+		_rng.seed = seed
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_BASIC, _rng), 1
+		)
+
+
+## `.LeechSeed` reads the target's own flag, since that is where the seed sits.
+func test_basic_treats_a_second_leech_seed_as_redundant() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.LEECH_SEED, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.substatus |= Gen2Substatus.LEECH_SEED
+
+	for seed: int in 10:
+		_rng.seed = seed
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_BASIC, _rng), 1
+		)
+
+
+## `.Spikes` reads `wPlayerScreens`, the side the spikes would land on.
+func test_basic_treats_a_second_spikes_as_redundant() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SPIKES, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+
+	for seed: int in 10:
+		_rng.seed = seed
+		assert_eq(
+			Gen2BattleAI.choose_slot(
+				pikachu, geodude, _data, RomLayout.AI_BASIC, _rng, 0, 0,
+				Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.SPIKES
+			),
+			1
+		)
+
+
+## `.Nightmare` calls a target with *no* status the redundant case and stops
+## there, so a target with any status at all is left encouraged even when it is
+## awake and cannot have one. The source names that as a bug of its own and this
+## reproduces it rather than fixing it.
+func test_basic_reproduces_the_nightmare_redundancy_bug() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.NIGHTMARE, Fixture.TACKLE])
+	var awake: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+
+	for seed: int in 10:
+		_rng.seed = seed
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, awake, _data, RomLayout.AI_BASIC, _rng), 1,
+			"an unstatused target really is the redundant case"
+		)
+
+	var burned: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	burned.status = Gen2Status.BURN
+	var kept: int = 0
+	for seed: int in 20:
+		_rng.seed = seed
+		if Gen2BattleAI.choose_slot(pikachu, burned, _data, RomLayout.AI_BASIC, _rng) == 0:
+			kept += 1
+	assert_gt(kept, 0, "a burn is not sleep, and the AI is not discouraged anyway")
+
+	var dreaming: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	dreaming.status = Gen2Status.BURN
+	dreaming.substatus |= Gen2Substatus.NIGHTMARE
+	for seed: int in 10:
+		_rng.seed = seed
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, dreaming, _data, RomLayout.AI_BASIC, _rng), 1,
+			"a target already dreaming is redundant on the second clause"
+		)

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -2907,3 +2907,166 @@ func test_perish_song_ticks_after_wrap_and_before_the_leftovers_block() -> void:
 		order.find(Gen2Battle.PERISH_COUNT), order.find(Gen2Battle.SCREEN_FADED),
 		"the leftovers block, Safeguard included, comes after",
 	)
+
+
+## `ResidualDamage` runs poison, then Leech Seed, then Nightmare, then Curse,
+## with a `HasUserFainted` between each pair.
+func test_the_three_residuals_run_behind_poison_in_the_sources_order() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.player.status = Gen2Status.POISON
+	battle.player.substatus |= Gen2Substatus.LEECH_SEED \
+		| Gen2Substatus.NIGHTMARE | Gen2Substatus.CURSE
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var order: Array = events.map(func(event: Dictionary) -> StringName: return event["type"])
+
+	assert_lt(order.find(Gen2Battle.HURT_BY_STATUS), order.find(Gen2Battle.LEECH_SEED_SAPPED))
+	assert_lt(order.find(Gen2Battle.LEECH_SEED_SAPPED), order.find(Gen2Battle.HURT_BY_NIGHTMARE))
+	assert_lt(order.find(Gen2Battle.HURT_BY_NIGHTMARE), order.find(Gen2Battle.HURT_BY_CURSE))
+
+
+## The `HasUserFainted` between them is not decoration: a Pokémon that goes down
+## to its poison pays none of the three behind it.
+func test_a_faint_to_poison_stops_the_residuals_behind_it() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.player.status = Gen2Status.POISON
+	battle.player.substatus |= Gen2Substatus.LEECH_SEED | Gen2Substatus.CURSE
+	battle.player.hp = 1
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	assert_true(battle.player.is_fainted())
+	assert_eq(_of_type(events, Gen2Battle.LEECH_SEED_SAPPED).size(), 0)
+	assert_eq(_of_type(events, Gen2Battle.HURT_BY_CURSE).size(), 0)
+
+
+## An eighth off the seeded Pokémon and the same figure onto the one opposite,
+## which `RestoreHP` caps at that one's maximum.
+func test_leech_seed_moves_an_eighth_across_the_field() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.player.substatus |= Gen2Substatus.LEECH_SEED
+	var eighth: int = Gen2Substatus.leech_seed_damage(battle.player.max_hp())
+	var sapper_full: int = battle.enemy.max_hp()
+	battle.enemy.hp = sapper_full - eighth - 5
+	var seeded_before: int = battle.player.hp
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	var sapped: Dictionary = _first(events, Gen2Battle.LEECH_SEED_SAPPED)
+
+	assert_eq(battle.player.hp, seeded_before - eighth)
+	assert_eq(battle.enemy.hp, sapper_full - 5)
+	assert_eq(int(sapped["amount"]), eighth)
+	assert_eq(int(sapped["to"]), Gen2Battle.ENEMY)
+
+
+## `SubtractHP` leaves the pre-hit health in `bc` when the eighth would have gone
+## below zero, so what the sapper takes is what the seed actually got.
+func test_leech_seed_hands_on_only_what_it_could_take() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.player.substatus |= Gen2Substatus.LEECH_SEED
+	battle.player.hp = 2
+	battle.enemy.hp = 1
+
+	var events: Array = battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	assert_true(battle.player.is_fainted())
+	assert_eq(battle.enemy.hp, 3, "two taken, two given")
+	assert_eq(int(_first(events, Gen2Battle.LEECH_SEED_SAPPED)["to_amount"]), 2)
+
+
+func test_a_nightmare_and_a_curse_each_cost_a_quarter() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	battle.player.substatus |= Gen2Substatus.NIGHTMARE
+	battle.enemy.substatus |= Gen2Substatus.CURSE
+	var player_full: int = battle.player.hp
+	var enemy_full: int = battle.enemy.hp
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	assert_eq(battle.player.hp, player_full - Gen2Substatus.quarter_damage(battle.player.max_hp()))
+	assert_eq(battle.enemy.hp, enemy_full - Gen2Substatus.quarter_damage(battle.enemy.max_hp()))
+
+
+## `SpikesDamage` runs behind every entrance's own `SetPlayerTurn`, so the flag
+## read is the one lying on the side walking in.
+func test_spikes_are_paid_by_whoever_walks_onto_them() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+	)
+	battle.screens[Gen2Battle.PLAYER] |= Gen2Screens.SPIKES
+
+	var events: Array = battle.send_out(Gen2Battle.PLAYER, 1)
+	var entering: Gen2BattleMon = battle.player
+	assert_eq(
+		entering.hp,
+		entering.max_hp() - Gen2Screens.spikes_damage(entering.max_hp())
+	)
+	assert_eq(_of_type(events, Gen2Battle.HURT_BY_SPIKES).size(), 1)
+
+
+## Field state, so the same spikes charge every entrance rather than one.
+func test_spikes_outlive_the_pokemon_that_walked_into_them() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+	)
+	battle.screens[Gen2Battle.PLAYER] |= Gen2Screens.SPIKES
+
+	battle.send_out(Gen2Battle.PLAYER, 1)
+	var second: Array = battle.send_out(Gen2Battle.PLAYER, 0)
+	assert_eq(_of_type(second, Gen2Battle.HURT_BY_SPIKES).size(), 1)
+	assert_true(Gen2Screens.has(battle.screens[Gen2Battle.PLAYER], Gen2Screens.SPIKES))
+
+
+func test_a_flying_type_walks_over_spikes() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.HOOTHOOT, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+	)
+	battle.screens[Gen2Battle.PLAYER] |= Gen2Screens.SPIKES
+
+	var events: Array = battle.send_out(Gen2Battle.PLAYER, 1)
+	assert_eq(battle.player.hp, battle.player.max_hp())
+	assert_eq(_of_type(events, Gen2Battle.HURT_BY_SPIKES).size(), 0)
+
+
+## The other side's spikes are the other side's: `SpikesDamage` never reads them.
+func test_spikes_on_one_side_do_not_charge_the_other() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+	)
+	battle.screens[Gen2Battle.ENEMY] |= Gen2Screens.SPIKES
+
+	var events: Array = battle.send_out(Gen2Battle.PLAYER, 1)
+	assert_eq(battle.player.hp, battle.player.max_hp())
+	assert_eq(_of_type(events, Gen2Battle.HURT_BY_SPIKES).size(), 0)
+
+
+## A doll is `SUBSTATUS_SUBSTITUTE` and nothing else, so `NewBattleMonStatus`
+## zeroing the substatus block is what a switch costs it.
+func test_a_switch_leaves_the_substitute_behind() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])]
+	)
+	var leaving: Gen2BattleMon = battle.player
+	leaving.substatus |= Gen2Substatus.SUBSTITUTE
+	leaving.substitute_hp = 40
+
+	battle.send_out(Gen2Battle.PLAYER, 1)
+	assert_false(Gen2Substatus.has(leaving.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_eq(leaving.substitute_hp, 0)

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -2473,6 +2473,576 @@ func test_every_effect_this_tranche_wrote_has_a_list_of_its_own() -> void:
 		Gen2MoveEffect.FRUSTRATION, Gen2MoveEffect.MAGNITUDE,
 		Gen2MoveEffect.HIDDEN_POWER, Gen2MoveEffect.DEFENSE_UP_HIT,
 		Gen2MoveEffect.TWISTER, Gen2MoveEffect.STOMP, Gen2MoveEffect.GUST,
-		Gen2MoveEffect.EARTHQUAKE,
+		Gen2MoveEffect.EARTHQUAKE, Gen2MoveEffect.SUBSTITUTE,
+		Gen2MoveEffect.LEECH_SEED, Gen2MoveEffect.NIGHTMARE,
+		Gen2MoveEffect.CURSE, Gen2MoveEffect.SPIKES, Gen2MoveEffect.RAPID_SPIN,
 	]:
 		assert_true(Gen2MoveEffect.is_written(effect), "effect %d" % effect)
+
+
+## A Gastly, which is the only Ghost-type this fixture has and so the only user
+## that reaches `BattleCommand_Curse`'s other branch.
+func _ghost_battle() -> Gen2Battle:
+	return Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.GASTLY, 50, [Fixture.CURSE]),
+		Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+		_rng
+	)
+
+
+## Puts a doll in front of the enemy without running the move, for the fifteen
+## commands whose whole question is what happens when one is standing.
+func _raise_enemy_substitute(battle: Gen2Battle) -> void:
+	battle.enemy.substatus |= Gen2Substatus.SUBSTITUTE
+	battle.enemy.substitute_hp = Gen2Substatus.substitute_hp_for(battle.enemy.max_hp())
+
+
+func test_a_substitute_costs_a_quarter_of_the_users_own_maximum() -> void:
+	var battle: Gen2Battle = _battle()
+	var user: Gen2BattleMon = battle.player
+	var full: int = user.max_hp()
+	var turn: Gen2Turn = _run_move(battle, Fixture.SUBSTITUTE)
+
+	assert_eq(user.hp, full - (full >> 2))
+	assert_eq(user.substitute_hp, full >> 2)
+	assert_true(Gen2Substatus.has(user.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_eq(int(_first(turn.events, Gen2Battle.SUBSTITUTE_MADE)["amount"]), full >> 2)
+
+
+## The cost is a bare `srl a / rr b` twice with no `GetQuarterMaxHP` behind it,
+## so it is never floored at one the way every residual in the game is.
+func test_the_substitute_cost_is_the_unfloored_shift() -> void:
+	assert_eq(Gen2Substatus.substitute_hp_for(100), 25)
+	assert_eq(Gen2Substatus.substitute_hp_for(3), 0, "no floor at one")
+	assert_eq(Gen2Substatus.quarter_damage(3), 1, "unlike every quarter that has one")
+
+
+func test_a_second_substitute_says_the_first_is_still_standing() -> void:
+	var battle: Gen2Battle = _battle()
+	_run_move(battle, Fixture.SUBSTITUTE)
+	var before: int = battle.player.hp
+	var turn: Gen2Turn = _run_move(battle, Fixture.SUBSTITUTE)
+
+	assert_eq(battle.player.hp, before, "and costs nothing")
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_ALREADY).size(), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_MADE).size(), 0)
+
+
+## `jr c` on the borrow *or* `or e / jr z` on a result of zero, so a user sitting
+## on exactly a quarter fails rather than making a doll and fainting.
+func test_a_user_on_exactly_a_quarter_is_too_weak_to_make_one() -> void:
+	var battle: Gen2Battle = _battle()
+	var user: Gen2BattleMon = battle.player
+	user.hp = user.max_hp() >> 2
+	var turn: Gen2Turn = _run_move(battle, Fixture.SUBSTITUTE)
+
+	assert_eq(user.hp, user.max_hp() >> 2, "still standing on it")
+	assert_false(Gen2Substatus.has(user.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_TOO_WEAK).size(), 1)
+
+
+func test_one_more_than_a_quarter_is_enough() -> void:
+	var battle: Gen2Battle = _battle()
+	var user: Gen2BattleMon = battle.player
+	user.hp = (user.max_hp() >> 2) + 1
+	_run_move(battle, Fixture.SUBSTITUTE)
+
+	assert_eq(user.hp, 1)
+	assert_true(Gen2Substatus.has(user.substatus, Gen2Substatus.SUBSTITUTE))
+
+
+## The doll steps out of whatever was binding the Pokémon behind it. Its own
+## side only: nothing here frees the opponent.
+func test_making_a_substitute_frees_its_user_from_a_bind() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.trapped_turns = 4
+	battle.player.trapping_move = Fixture.WRAP
+	battle.enemy.trapped_turns = 3
+
+	_run_move(battle, Fixture.SUBSTITUTE)
+	assert_eq(battle.player.trapped_turns, 0)
+	assert_eq(battle.player.trapping_move, 0)
+	assert_eq(battle.enemy.trapped_turns, 3, "the other side's bind is not the doll's business")
+
+
+func test_a_hit_is_spent_on_the_doll_and_not_on_the_pokemon() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	# Big enough that a Tackle cannot break it, so this is about where the damage
+	# went rather than about the break.
+	battle.enemy.substitute_hp = 250
+	var before: int = battle.enemy.hp
+	var turn: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+
+	assert_eq(battle.enemy.hp, before, "the real health never moves")
+	assert_lt(battle.enemy.substitute_hp, 250)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_TOOK_DAMAGE).size(), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 0)
+	assert_eq(turn.dealt, 0)
+
+
+func test_a_doll_taken_to_exactly_zero_breaks() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	var turn: Gen2Turn = _turn(battle)
+	battle.enemy.substitute_hp = 20
+	turn.damage = 20
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_FADED).size(), 1)
+
+
+func test_a_doll_taken_below_zero_breaks_and_one_short_survives() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	var turn: Gen2Turn = _turn(battle)
+	battle.enemy.substitute_hp = 20
+	turn.damage = 19
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_eq(battle.enemy.substitute_hp, 1)
+
+	var second: Gen2Turn = _turn(battle)
+	second.damage = 2
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, second)
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.SUBSTITUTE))
+
+
+## `ld a, [hli] / and a / jr nz, .broke`: the damage is a word against a one-byte
+## counter, so anything from 256 up breaks the doll with no arithmetic at all.
+func test_a_hit_of_two_hundred_and_fifty_six_breaks_any_doll() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	battle.enemy.substitute_hp = 255
+	var turn: Gen2Turn = _turn(battle)
+	turn.damage = 256
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.SUBSTITUTE))
+
+
+## `xor a / ld [hl], a` over `wPlayerMoveStruct + MOVE_EFFECT`, so everything
+## behind the break reads an ordinary attack.
+func test_a_broken_doll_stamps_normal_hit_over_the_moves_effect() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	battle.enemy.substitute_hp = 1
+	var turn: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, Fixture.EMBER_BURNS,
+		_data.move(Fixture.EMBER_BURNS), []
+	)
+	turn.damage = 5
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+	assert_eq(turn.effect(), Gen2MoveEffect.NORMAL_HIT_EFFECT)
+
+
+## The five the source exempts, because each one's own command reads the byte
+## back to know how many hits it is partway through.
+func test_a_broken_doll_leaves_a_multi_hit_effect_alone() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	battle.enemy.substitute_hp = 1
+	var turn: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, Fixture.DOUBLE_HIT_MOVE,
+		_data.move(Fixture.DOUBLE_HIT_MOVE), []
+	)
+	turn.damage = 5
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+	assert_eq(turn.effect(), Gen2MoveEffect.DOUBLE_HIT)
+
+
+## `.update_damage_taken` returns before it records anything when the target has
+## a doll, which is what stops Counter answering a hit the doll took.
+func test_counter_cannot_answer_a_hit_a_doll_took() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	_run_move(battle, Fixture.TACKLE)
+
+	assert_true(battle.last_damage_taken(Gen2Battle.ENEMY).is_empty())
+
+
+## `.DrainSub`, which is the one place a Substitute reads as a miss rather than
+## as a hit that did nothing.
+func test_a_drain_move_reads_as_a_miss_against_a_doll() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	var doll: int = battle.enemy.substitute_hp
+	var turn: Gen2Turn = _run_move(battle, Fixture.DRAIN_MOVE)
+
+	assert_true(turn.missed)
+	assert_eq(battle.enemy.substitute_hp, doll, "not even the doll is touched")
+	assert_eq(_of_type(turn.events, Gen2Battle.DRAINED).size(), 0)
+
+
+func test_an_ordinary_attack_still_reaches_a_doll() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	var turn: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+	assert_false(turn.missed, "only the two draining effects read as a miss")
+
+
+## `BattleCommand_EffectChance` jumps to `.failed` before `BattleRandom`, so a
+## secondary effect aimed at a doll costs no randomness at all.
+func test_a_secondary_effect_against_a_doll_draws_no_roll() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	var turn: Gen2Turn = _turn(battle, Fixture.EMBER_BURNS)
+	var before: int = _rng.state
+	Gen2EffectCommands.run(Gen2EffectCommands.EFFECT_CHANCE, turn)
+
+	assert_true(turn.failed_chance)
+	assert_eq(_rng.state, before, "the roll was never drawn")
+
+
+func test_a_doll_refuses_a_status_a_flinch_a_confusion_and_a_bind() -> void:
+	for pair: Array in [
+		[Fixture.EMBER_BURNS, Gen2EffectCommands.BURN_TARGET],
+		[Fixture.ROLLING_KICK_ALWAYS, Gen2EffectCommands.FLINCH_TARGET],
+		[Fixture.CONFUSION_ALWAYS, Gen2EffectCommands.CONFUSE_TARGET],
+		[Fixture.WRAP, Gen2EffectCommands.TRAP_TARGET],
+	]:
+		var battle: Gen2Battle = _battle()
+		_raise_enemy_substitute(battle)
+		var turn: Gen2Turn = _turn(battle, int(pair[0]))
+		var before: int = _rng.state
+		Gen2EffectCommands.run(StringName(pair[1]), turn)
+
+		assert_eq(battle.enemy.status, Gen2Status.NONE, "move %d" % int(pair[0]))
+		assert_eq(battle.enemy.substatus & ~Gen2Substatus.SUBSTITUTE, Gen2Substatus.NONE)
+		assert_eq(battle.enemy.trapped_turns, 0)
+		assert_eq(_rng.state, before, "and none of the four rolled")
+
+
+## `BattleCommand_BurnTarget`'s `CheckSubstituteOpp` is in front of the status
+## check, so a doll stops even the thaw a burn move would otherwise have given.
+func test_a_doll_stops_a_burn_move_thawing_the_pokemon_behind_it() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	battle.enemy.status = Gen2Status.FREEZE
+	var turn: Gen2Turn = _turn(battle, Fixture.EMBER_BURNS)
+	Gen2EffectCommands.run(Gen2EffectCommands.BURN_TARGET, turn)
+
+	assert_true(Gen2Status.has(battle.enemy.status, Gen2Status.FREEZE))
+
+
+## `BattleCommand_StatDown`'s `.DidntMiss`, and `BattleCommand_HeldFlinch`'s
+## check between the item and the roll.
+func test_a_doll_refuses_a_stat_drop_and_a_kings_rock() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	var turn: Gen2Turn = _turn(battle, Fixture.SCREECH)
+	Gen2EffectCommands.run(Gen2EffectCommands.DEFENSE_DOWN_2, turn)
+	assert_eq(battle.enemy.stage("defense"), 0)
+	assert_false(turn.stat_moved)
+
+	battle.player.item = Fixture.KINGS_ROCK
+	var rock: Gen2Turn = _turn(battle)
+	var before: int = _rng.state
+	Gen2EffectCommands.run(Gen2EffectCommands.KINGS_ROCK, rock)
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.FLINCHED))
+	assert_eq(_rng.state, before)
+
+
+## The Focus Band is in front of the doll rather than behind it, so it rolls, it
+## clamps against the *real* health, and the clamped figure is what the doll
+## spends. "Hung on" is printed over a Pokémon that was never in danger.
+func test_a_focus_band_still_fires_in_front_of_a_doll() -> void:
+	var fired: int = 0
+	for seed: int in 200:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed
+		_raise_enemy_substitute(battle)
+		battle.enemy.substitute_hp = 200
+		battle.enemy.item = Fixture.FOCUS_BAND
+		battle.enemy.hp = 10
+		var turn: Gen2Turn = _turn(battle)
+		turn.damage = 300
+		Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+		if _of_type(turn.events, Gen2Battle.ENDURED).is_empty():
+			# No band, so the word is over a byte and the doll goes outright.
+			assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.SUBSTITUTE))
+			continue
+
+		fired += 1
+		assert_eq(battle.enemy.hp, 10, "the real health never moved")
+		assert_eq(
+			battle.enemy.substitute_hp, 200 - 9,
+			"the clamp is against the real health and the doll pays the clamped figure"
+		)
+
+	assert_between(fired, 5, 50, "roughly thirty in 256")
+
+
+## Leech Seed is the one of the five that carries `checkhit`, so every test of
+## what it does behind the roll overrides its real 90% up to the 255 that skips
+## the roll entirely.
+const ALWAYS: Dictionary = {"accuracy": 255}
+
+
+func test_a_seed_lands_and_a_grass_type_shrugs_it_off() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.LEECH_SEED, false, ALWAYS)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LEECH_SEED))
+	assert_eq(_of_type(turn.events, Gen2Battle.WAS_SEEDED).size(), 1)
+
+	var grass: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.LEECH_SEED]),
+		Gen2BattleMon.create(_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE]),
+		_rng
+	)
+	var refused: Gen2Turn = _run_move(grass, Fixture.LEECH_SEED, false, ALWAYS)
+	assert_false(Gen2Substatus.has(grass.enemy.substatus, Gen2Substatus.LEECH_SEED))
+	assert_eq(_of_type(refused.events, Gen2Battle.NO_EFFECT).size(), 1)
+
+
+func test_a_second_seed_and_a_seed_at_a_doll_both_evade() -> void:
+	var battle: Gen2Battle = _battle()
+	_run_move(battle, Fixture.LEECH_SEED, false, ALWAYS)
+	var again: Gen2Turn = _run_move(battle, Fixture.LEECH_SEED, false, ALWAYS)
+	assert_eq(_of_type(again.events, Gen2Battle.EVADED).size(), 1)
+
+	var walled: Gen2Battle = _battle()
+	_raise_enemy_substitute(walled)
+	var turn: Gen2Turn = _run_move(walled, Fixture.LEECH_SEED, false, ALWAYS)
+	assert_false(Gen2Substatus.has(walled.enemy.substatus, Gen2Substatus.LEECH_SEED))
+	assert_eq(_of_type(turn.events, Gen2Battle.EVADED).size(), 1)
+
+
+func test_a_nightmare_needs_a_sleeping_target_and_lands_once() -> void:
+	var battle: Gen2Battle = _battle()
+	var awake: Gen2Turn = _run_move(battle, Fixture.NIGHTMARE)
+	assert_eq(_of_type(awake.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+	battle.enemy.status = Gen2Status.roll_sleep(_rng)
+	var landed: Gen2Turn = _run_move(battle, Fixture.NIGHTMARE)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.NIGHTMARE))
+	assert_eq(_of_type(landed.events, Gen2Battle.NIGHTMARE_STARTED).size(), 1)
+
+	var again: Gen2Turn = _run_move(battle, Fixture.NIGHTMARE)
+	assert_eq(_of_type(again.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+func test_a_nightmare_is_refused_by_a_doll_and_by_a_target_out_of_sight() -> void:
+	var walled: Gen2Battle = _battle()
+	_raise_enemy_substitute(walled)
+	walled.enemy.status = Gen2Status.roll_sleep(_rng)
+	_run_move(walled, Fixture.NIGHTMARE)
+	assert_false(Gen2Substatus.has(walled.enemy.substatus, Gen2Substatus.NIGHTMARE))
+
+	var flying: Gen2Battle = _battle()
+	flying.enemy.status = Gen2Status.roll_sleep(_rng)
+	flying.enemy.substatus |= Gen2Substatus.FLYING
+	_run_move(flying, Fixture.NIGHTMARE)
+	assert_false(Gen2Substatus.has(flying.enemy.substatus, Gen2Substatus.NIGHTMARE))
+
+
+## The non-Ghost branch, which reads the *user's* own types and moves the user's
+## own three stages.
+func test_curse_trades_the_users_speed_for_its_attack_and_defense() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.CURSE)
+
+	assert_eq(battle.player.stage("speed"), -1)
+	assert_eq(battle.player.stage("attack"), 1)
+	assert_eq(battle.player.stage("defense"), 1)
+	assert_eq(battle.enemy.stage("speed"), 0, "the user's stages, never the target's")
+	assert_eq(_of_type(turn.events, Gen2Battle.STAT_CHANGED).size(), 3)
+
+
+## `.cantraise` needs *both* to be at the top, and names `StatNames`' eighth row
+## rather than either stat it looked at.
+func test_curse_fails_only_when_attack_and_defense_are_both_at_the_top() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.change_stage("attack", 6)
+	var one: Gen2Turn = _run_move(battle, Fixture.CURSE)
+	assert_eq(battle.player.stage("defense"), 1, "Defense could still rise")
+	assert_eq(_of_type(one.events, Gen2Battle.STAT_CHANGE_FAILED).size(), 0)
+
+	battle.player.change_stage("defense", 6)
+	var both: Gen2Turn = _run_move(battle, Fixture.CURSE)
+	var failed: Dictionary = _first(both.events, Gen2Battle.STAT_CHANGE_FAILED)
+	assert_eq(String(failed["stat"]), Gen2EffectCommands.CURSE_FAILED_STAT)
+	assert_eq(int(failed["by"]), 1, "so the line reads 'won't rise anymore'")
+
+
+## A Speed already at the floor says nothing and swallows nothing: `ResetMiss`
+## between the three is what keeps the two raises coming.
+func test_curse_still_raises_when_the_speed_cannot_fall() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.change_stage("speed", -6)
+	var turn: Gen2Turn = _run_move(battle, Fixture.CURSE)
+
+	assert_eq(battle.player.stage("attack"), 1)
+	assert_eq(battle.player.stage("defense"), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.STAT_CHANGED).size(), 2)
+
+
+func test_a_ghost_curse_cuts_half_its_own_health_and_lands_a_curse() -> void:
+	var battle: Gen2Battle = _ghost_battle()
+	var user: Gen2BattleMon = battle.player
+	var full: int = user.max_hp()
+	var turn: Gen2Turn = _run_move(battle, Fixture.CURSE)
+
+	assert_eq(user.hp, full - Gen2Substatus.half_damage(full))
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.CURSE))
+	assert_eq(int(_first(turn.events, Gen2Battle.CURSE_SET)["target"]), Gen2Battle.ENEMY)
+	assert_eq(battle.player.stage("attack"), 0, "the other branch never ran")
+
+
+## `GetHalfMaxHP` and `SubtractHPFromUser` with nothing between them: a Ghost on
+## less than half its maximum goes down to its own move.
+func test_a_ghost_curse_can_faint_its_own_user() -> void:
+	var battle: Gen2Battle = _ghost_battle()
+	battle.player.hp = 3
+	var turn: Gen2Turn = _run_move(battle, Fixture.CURSE)
+
+	assert_true(battle.player.is_fainted())
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.CURSE))
+	assert_eq(int(_first(turn.events, Gen2Battle.FAINTED)["side"]), Gen2Battle.PLAYER)
+
+
+func test_a_ghost_curse_is_refused_twice_and_by_a_doll() -> void:
+	var battle: Gen2Battle = _ghost_battle()
+	_run_move(battle, Fixture.CURSE)
+	var before: int = battle.player.hp
+	var again: Gen2Turn = _run_move(battle, Fixture.CURSE)
+	assert_eq(battle.player.hp, before, "and it costs nothing to fail")
+	assert_eq(_of_type(again.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+	var walled: Gen2Battle = _ghost_battle()
+	_raise_enemy_substitute(walled)
+	_run_move(walled, Fixture.CURSE)
+	assert_false(Gen2Substatus.has(walled.enemy.substatus, Gen2Substatus.CURSE))
+
+
+func test_spikes_land_on_the_far_side_and_refuse_a_second_time() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.SPIKES)
+
+	assert_true(Gen2Screens.has(battle.screens[Gen2Battle.ENEMY], Gen2Screens.SPIKES))
+	assert_false(Gen2Screens.has(battle.screens[Gen2Battle.PLAYER], Gen2Screens.SPIKES))
+	assert_eq(int(_first(turn.events, Gen2Battle.SPIKES_SET)["target"]), Gen2Battle.ENEMY)
+
+	var again: Gen2Turn = _run_move(battle, Fixture.SPIKES)
+	assert_eq(_of_type(again.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## All three of `BattleCommand_ClearHazards`, in its own order, and all three on
+## the user's own side.
+func test_rapid_spin_sheds_the_seed_the_spikes_and_the_bind() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.LEECH_SEED
+	battle.screens[Gen2Battle.PLAYER] |= Gen2Screens.SPIKES
+	battle.screens[Gen2Battle.ENEMY] |= Gen2Screens.SPIKES
+	battle.player.trapped_turns = 3
+	battle.player.trapping_move = Fixture.WRAP
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.RAPID_SPIN)
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.LEECH_SEED))
+	assert_false(Gen2Screens.has(battle.screens[Gen2Battle.PLAYER], Gen2Screens.SPIKES))
+	assert_true(
+		Gen2Screens.has(battle.screens[Gen2Battle.ENEMY], Gen2Screens.SPIKES),
+		"the other side's spikes are not the spinner's business"
+	)
+	assert_eq(battle.player.trapped_turns, 0)
+	assert_eq(
+		battle.player.trapping_move, Fixture.WRAP,
+		"`clearhazards` zeroes the counter and leaves the move byte alone"
+	)
+
+	var types: Array = turn.events.map(func(event: Dictionary) -> StringName: return event["type"])
+	assert_true(types.find(Gen2Battle.SHED_LEECH_SEED) < types.find(Gen2Battle.BLEW_SPIKES))
+	assert_true(types.find(Gen2Battle.BLEW_SPIKES) < types.find(Gen2Battle.RELEASED_BY))
+
+
+## `clearhazards` sits in front of `checkfaint`, so a spin that knocks its target
+## out still clears the spinner's own side.
+func test_rapid_spin_clears_even_when_the_hit_was_lethal() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.LEECH_SEED
+	battle.enemy.hp = 1
+
+	var turn: Gen2Turn = _run_move(battle, Fixture.RAPID_SPIN)
+	assert_true(battle.enemy.is_fainted())
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.LEECH_SEED))
+	assert_eq(_of_type(turn.events, Gen2Battle.SHED_LEECH_SEED).size(), 1)
+
+
+## `DefenseDownHit` is the one row of the seven that rolls twice, which is what
+## lets its drop land on a Pokémon whose doll the same hit broke.
+func test_only_the_defense_drop_on_hit_carries_two_rolls() -> void:
+	for offset: int in Gen2MoveEffect.STAT_RUN_LENGTH:
+		var effect: int = Gen2MoveEffect.STAT_DOWN_HIT_BASE + offset
+		var rolls: int = Gen2MoveEffect.sequence_for(effect).count(
+			Gen2EffectCommands.EFFECT_CHANCE
+		)
+		assert_eq(rolls, 2 if effect == Gen2MoveEffect.DEFENSE_DOWN_HIT else 1,
+			"effect %d" % effect)
+
+
+## And the second roll is what clears the first one's failure, since
+## `BattleCommand_EffectChance` opens by zeroing `wEffectFailed`.
+func test_a_second_effect_chance_clears_the_first_ones_failure() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _turn(battle, Fixture.NEVER_BURNS)
+	Gen2EffectCommands.run(Gen2EffectCommands.EFFECT_CHANCE, turn)
+	assert_true(turn.failed_chance)
+
+	turn.move = _data.move(Fixture.EMBER_BURNS)
+	Gen2EffectCommands.run(Gen2EffectCommands.EFFECT_CHANCE, turn)
+	assert_false(turn.failed_chance)
+
+
+## `BattleCommand_StatDown`'s order: Mist and the stage that cannot move are both
+## settled before `wEffectFailed` is read, so each keeps its own line.
+func test_a_stat_drop_names_its_own_reason_even_when_the_roll_failed() -> void:
+	var misted: Gen2Battle = _battle()
+	misted.enemy.substatus |= Gen2Substatus.MIST
+	var turn: Gen2Turn = _turn(misted, Fixture.PSYCHIC_NEVER)
+	turn.failed_chance = true
+	Gen2EffectCommands.run(Gen2EffectCommands.SP_DEFENSE_DOWN, turn)
+	assert_true(turn.stat_mist_blocked)
+
+	var floored: Gen2Battle = _battle()
+	floored.enemy.change_stage("sp_defense", -6)
+	var bottom: Gen2Turn = _turn(floored, Fixture.PSYCHIC_NEVER)
+	bottom.failed_chance = true
+	Gen2EffectCommands.run(Gen2EffectCommands.SP_DEFENSE_DOWN, bottom)
+	assert_false(bottom.stat_mist_blocked)
+	assert_false(bottom.stat_moved)
+
+
+## `applydamage` is inside `MultiHit`'s own loop, so every hit is spent on the
+## doll and the doll can break partway through a move.
+func test_a_multi_hit_spends_every_hit_on_the_doll() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	battle.enemy.substitute_hp = 250
+	var before: int = battle.enemy.hp
+	var turn: Gen2Turn = _run_move(battle, Fixture.DOUBLE_HIT_MOVE)
+
+	assert_eq(battle.enemy.hp, before, "the real health never moves")
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_TOOK_DAMAGE).size(), 2)
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 0)
+
+
+## And a doll broken by the first hit lets the second through to the Pokémon,
+## which is only true because the effect byte survived the break.
+func test_a_doll_broken_by_the_first_hit_lets_the_second_through() -> void:
+	var battle: Gen2Battle = _battle()
+	_raise_enemy_substitute(battle)
+	battle.enemy.substitute_hp = 1
+	var before: int = battle.enemy.hp
+	var turn: Gen2Turn = _run_move(battle, Fixture.DOUBLE_HIT_MOVE)
+
+	assert_eq(_of_type(turn.events, Gen2Battle.SUBSTITUTE_FADED).size(), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 1, "the second hit lands")
+	assert_lt(battle.enemy.hp, before)
+	assert_eq(turn.effect(), Gen2MoveEffect.DOUBLE_HIT, "and the loop kept its own byte")


### PR DESCRIPTION
Substitute, Leech Seed, Nightmare, Curse, Spikes and Rapid Spin, read off the pinned effect lists rather than from memory.

The doll is the engine's widest rule: CheckSubstituteOpp is asked by eighteen commands and every one refuses on a yes, so the damage step, the secondary-effect roll, all five statuses, the flinch, the confusion, the bind, the stat drop and the King's Rock each learn where to ask. Its cost is the one quarter in the game that is not GetQuarterMaxHP, and paying is exact, so a user on precisely a quarter is too weak rather than dead. DoSubstituteDamage spends the hit on the doll, breaks it on a word of 256 or on a result of zero, and stamps EFFECT_NORMAL_HIT over the move unless the move is one of the five counting its own hits.

Leech Seed, Nightmare and Curse are ResidualDamage's own three, behind burn and poison with a faint check between each pair, not the between-turn block. Spikes are field state paid at every entrance, so send_out is the one seam. Rapid Spin sheds all three on its own side, in front of the faint check.

Fixed on the way: DefenseDownHit rolls its chance twice, which is the cartridge's own Substitute bug and now reproducible; effectchance clears wEffectFailed on the way in; a stat drop settles Mist and its own floor before the roll, as StatDown does; multi-hit stopped open-coding its damage application, so every hit goes through the Focus Band and the doll; and the Focus Band clamps in front of the doll rather than behind it.