### PR TITLE
Let a Pokemon guard itself, brace for a hit, and take one with it

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -276,6 +276,15 @@ miss/immunity or its fifth hit, and doubles with Defense Curl. Thrash, Petal
 Dance and Outrage continue for their rolled duration, then confuse. A status
 interruption cancels chains; rampage remains active after a miss.
 
+Fury Cutter's and Protect's counters are chains of a different kind: they are
+kept only while the move feeding them is the move being used, so
+`Gen2Battle._reset_action_counters` empties them on every other action, which is
+what `ParsePlayerAction` and `ParseEnemyAction` do. Protect, Detect and Endure
+share one counter. `Gen2Battle.opponent_went_first` is `CheckOpponentWentFirst`,
+and each action runs inside an open/close pair that clears the mover's own
+Destiny Bond in front and the opponent's Protect, Endure and Destiny Bond behind;
+the player's pair runs on every action and the enemy's only on a move.
+
 Switches happen before priority, so the incoming Pokémon takes the other
 side's move. A fainted replacement is caller policy: the turn stops at
 `must_replace` until `send_out`. A full moveset similarly uses
@@ -289,13 +298,14 @@ Trainer details:
   walked in class order, not sorted. Class 10 is intentionally empty because its
   pointer equals class 11. One packed DVs word covers each class's whole party;
 - `Gen2BattleAI` picks the lowest-scored move with random tie-breaking, matching
-  the result rather than the byte-level decrement race, and never switches or
-  uses items. Only implemented `AI_Smart` handlers exist; unsupported effects use
-  generic scoring, and weather-sensitive Razor Wind, Solar Beam and Fly are
-  absent;
+  the result rather than the byte-level decrement race, and switches and uses
+  items through `Gen2AISwitch` and `Gen2AIItems`. Only implemented `AI_Smart`
+  handlers exist; unsupported effects use generic scoring, and Razor Wind and the
+  Fly handlers are absent;
 - experience uses six growth curves and level 1 is zero, even for Medium Slow,
-  whose literal formula underflows. Experience is not divided among
-  participants, stat experience is, and only the player side receives it.
+  whose literal formula underflows. Experience and stat experience are both
+  divided among participants, since the division lands on the base EXP byte
+  inside the same block as the base stats, and only the player side receives it.
   Participants were sent out since the current opponent arrived, excluding
   members fainted at award time. Levels process one at a time, and a level-up
   adds the max-HP difference rather than refilling.

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -528,9 +528,16 @@ static func _apply_smart(
 				_smart_paralyze(scores, slot, attacker, defender, rng)
 			Gen2MoveEffect.RECHARGE_HIT: # Hyper Beam
 				_smart_hyper_beam(scores, slot, attacker, rng)
-			Gen2MoveEffect.SKULL_BASH:
+			# `AI_Smart_DestinyBond`, `AI_Smart_Reversal` and `AI_Smart_SkullBash`
+			# are one label and one body in the source, so they are one arm here.
+			Gen2MoveEffect.SKULL_BASH, Gen2MoveEffect.REVERSAL, \
+			Gen2MoveEffect.DESTINY_BOND:
 				if _above_quarter(attacker):
 					_discourage(scores, slot, 1)
+			Gen2MoveEffect.PROTECT:
+				_smart_protect(scores, slot, attacker, defender, rng)
+			Gen2MoveEffect.ENDURE:
+				_smart_endure(scores, slot, attacker, data, rng)
 			Gen2MoveEffect.BELLY_DRUM:
 				_smart_belly_drum(scores, slot, attacker)
 			Gen2MoveEffect.PSYCH_UP:
@@ -792,6 +799,103 @@ static func _smart_perish_song(
 	if _skip_50_50(rng):
 		return
 	_discourage(scores, slot, 1)
+
+
+## `AI_Smart_Protect`: one ladder of tests, first match winning, and the two exits
+## are asymmetric. `.encourage` is an 80% roll and one point off; `.discourage` is
+## a two-point penalty that an 8% roll skips outright, and `.greatly_discourage`
+## adds a point and falls into it, so the worst case is three.
+##
+## The source's second test, a player that has locked on, is missing here and only
+## here: `SUBSTATUS_LOCK_ON` does not exist yet, since `EFFECT_LOCK_ON` is
+## unwritten. Its branch would `.discourage`, so the omission can only make the
+## enemy readier to protect, never less ready.
+static func _smart_protect(
+	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
+	rng: RandomNumberGenerator
+) -> void:
+	if attacker.protect_count != 0:
+		_smart_protect_discourage(scores, slot, rng, true)
+		return
+
+	var encourage: bool = defender.fury_cutter_count >= PROTECT_FURY_CUTTER_COUNT \
+		or Gen2Substatus.has(defender.substatus, Gen2Substatus.CHARGING) \
+		or defender.toxic_counter > 0 \
+		or Gen2Substatus.has(defender.substatus, Gen2Substatus.LEECH_SEED) \
+		or Gen2Substatus.has(defender.substatus, Gen2Substatus.CURSE)
+
+	if not encourage:
+		# The Rollout test is the fall-through, and it is two refusals in one: a
+		# player not rolling at all discourages, and one rolling under three
+		# discourages as well. Only a boosted Rollout reaches `.encourage`.
+		if not Gen2Substatus.has(defender.substatus, Gen2Substatus.ROLLOUT) \
+			or defender.rollout_count < PROTECT_ROLLOUT_COUNT:
+			_smart_protect_discourage(scores, slot, rng, false)
+			return
+
+	if _skip_80_20(rng):
+		return
+	_encourage(scores, slot, 1)
+
+
+## `cp 3` on both counts: what makes a Fury Cutter or a Rollout worth sitting out.
+const PROTECT_FURY_CUTTER_COUNT: int = 3
+const PROTECT_ROLLOUT_COUNT: int = 3
+
+
+## `.greatly_discourage` falls into `.discourage`, so the extra point is added in
+## front of the roll that can skip the other two.
+static func _smart_protect_discourage(
+	scores: Array, slot: int, rng: RandomNumberGenerator, greatly: bool
+) -> void:
+	if greatly:
+		_discourage(scores, slot, 1)
+	if _roll(rng, PROTECT_DISCOURAGE_SKIP_PERCENT):
+		return
+	_discourage(scores, slot, 2)
+
+
+## `cp 8 percent; ret c`: the one-in-twelve chance the penalty is not applied.
+const PROTECT_DISCOURAGE_SKIP_PERCENT: int = 8
+
+
+## `AI_Smart_Endure`: the same opening test as Protect, then health, then the one
+## reason to want to survive on a single point.
+##
+## Reversal is looked for by effect rather than by move number, which is
+## `AIHasMoveEffect`, and Flail carries the same byte, so either move answers.
+## The source's last branch, an enemy that has locked on, is absent for the same
+## reason [method _smart_protect]'s is.
+static func _smart_endure(
+	scores: Array, slot: int, attacker: Gen2BattleMon, data: GameData,
+	rng: RandomNumberGenerator
+) -> void:
+	if attacker.protect_count != 0 or _at_max_hp(attacker):
+		_discourage(scores, slot, 2)
+		return
+	if _above_quarter(attacker):
+		_discourage(scores, slot, 1)
+		return
+	if not _has_move_effect(attacker, data, Gen2MoveEffect.REVERSAL):
+		return
+	if _skip_80_20(rng):
+		return
+	_encourage(scores, slot, 3)
+
+
+## `AIHasMoveEffect`: whether this Pokémon knows any move carrying [param effect].
+##
+## An empty slot ends the search rather than being skipped, which is the source's
+## own `and a / jr z, .no`, and PP and Disable are not asked about at all. The
+## first costs nothing on a packed move list and is kept because the list is only
+## packed by convention.
+static func _has_move_effect(mon: Gen2BattleMon, data: GameData, effect: int) -> bool:
+	for slot: int in Gen2BattleMon.MAX_MOVES:
+		if slot >= mon.moves.size() or int(mon.moves[slot]) == 0:
+			return false
+		if _effect(_move_at(mon, data, slot)) == effect:
+			return true
+	return false
 
 
 static func _smart_belly_drum(scores: Array, slot: int, attacker: Gen2BattleMon) -> void:

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -157,8 +157,29 @@ const ITEM_HEALED_CONFUSION: StringName = &"item_healed_confusion"
 
 ## A Focus Band held the Pokémon on one hit point through what would have
 ## finished it. [code]item[/code] is what did it, since the cartridge's line
-## names the item rather than the effect.
+## names the item rather than the effect. This is `HungOnText`; Endure's own line
+## is [constant ENDURED_HIT], and the two are separate texts for separate
+## reasons, so neither stands in for the other.
 const ENDURED: StringName = &"endured"
+
+## Protect and Detect: `ProtectedItselfText` when the flag goes up, and
+## `ProtectingItselfText` on every move it then turns away, which is printed
+## ahead of that move's own [constant MISSED].
+const PROTECTED_ITSELF: StringName = &"protected_itself"
+const PROTECTING_ITSELF: StringName = &"protecting_itself"
+
+## Endure: `BracedItselfText` when the flag goes up and `EnduredText` on each hit
+## it survives. A hit can be clamped more than once a turn, since nothing spends
+## the flag.
+const BRACED_ITSELF: StringName = &"braced_itself"
+const ENDURED_HIT: StringName = &"endured_hit"
+
+## Destiny Bond: `DestinyBondEffectText` when it is used, and `TookDownWithItText`
+## when it collects. [code]target[/code] on the second is the Pokémon that went
+## down holding it; [code]side[/code] is the attacker it takes with it, and the
+## two [constant FAINTED] events follow in that order.
+const DESTINY_BOND_SET: StringName = &"destiny_bond_set"
+const TOOK_DOWN_WITH_IT: StringName = &"took_down_with_it"
 
 ## Rain Dance, Sunny Day and Sandstorm. [code]weather[/code] on all four is the
 ## [Gen2Weather] value, so a screen names it without being told twice.
@@ -354,12 +375,12 @@ const FLEE_ODDS_RANGE: int = 256
 ## which the cache already carries.
 const BASE_PRIORITY: int = 1
 const EFFECT_PRIORITIES: Dictionary = {
-	0x6F: 3,  # Protect
-	0x74: 3,  # Endure
+	Gen2MoveEffect.PROTECT: 3,
+	Gen2MoveEffect.ENDURE: 3,
 	0x67: 2,  # Quick Attack, Extreme Speed, Mach Punch
 	0x1C: 0,  # Whirlwind and Roar
-	0x59: 0,  # Counter
-	0x90: 0,  # Mirror Coat
+	Gen2MoveEffect.COUNTER: 0,
+	Gen2MoveEffect.MIRROR_COAT: 0,
 }
 
 ## Vital Throw is slower than everything and says so in the move itself rather
@@ -430,6 +451,13 @@ var battle_anim_param: int = 0
 ## on. Cleared at the top of every turn, the way `BattleTurn.loop` clears both
 ## bytes before either side chooses.
 var _just_got_frozen: Dictionary = {PLAYER: false, ENEMY: false}
+
+## `wEnemyGoesFirst`, written once per turn by `DetermineMoveOrder` and read by
+## `CheckOpponentWentFirst`. It is exactly what [method order] already decides, so
+## this is that answer kept rather than a second decision:
+## [method opponent_went_first] is the `wEnemyGoesFirst XOR hBattleTurn` the three
+## commands that ask are given.
+var enemy_goes_first: bool = false
 
 ## Set once the player has run. The battle is over with no winner, which is the
 ## DRAW `wBattleResult` the cartridge writes.
@@ -923,19 +951,32 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	}
 
 	var acting: Array = order(chosen, actions)
+	enemy_goes_first = int(acting[0]) == ENEMY
 	for side: int in acting:
-		if _is_run(actions[side]):
-			continue
-		if _is_switch(actions[side]):
-			events.append_array(send_out(side, int(actions[side].get("index", -1))))
-			continue
-		if _is_item(actions[side]):
-			_use_trainer_item(side, int(actions[side].get("item", 0)), events)
-			continue
-		if mon(side).is_fainted() or mon(opponent_of(side)).is_fainted():
+		var action: Dictionary = actions[side]
+		var moving: bool = not (_is_run(action) or _is_switch(action) or _is_item(action))
+		# The faint check is the source's own `HasPlayerFainted`/`HasEnemyFainted`
+		# between the two halves of the turn, and it gates the whole of the second
+		# half rather than only its move. It is asked before the bracket below
+		# opens for that reason. A switching or item-using side is always
+		# [method order]'s first, so this is only ever asked of a move.
+		if moving and (mon(side).is_fainted() or mon(opponent_of(side)).is_fainted()):
 			break
-		var slot: int = effective_slot(side, int(actions[side].get("slot", 0)))
-		_act(side, slot, move_for(side, slot), events)
+		_open_turn_bracket(side, action)
+		if not moving:
+			# `.reset_rage` for a switch and `.reset_bide` for an item or a failed
+			# run, both of which fall into `.locked_in`'s unconditional zeroing.
+			# `AI_TryItem` does the same on the enemy's side. -1 is no move's
+			# effect, so both counters go.
+			_reset_action_counters(side, -1)
+		if _is_switch(action):
+			events.append_array(send_out(side, int(action.get("index", -1))))
+		elif _is_item(action):
+			_use_trainer_item(side, int(action.get("item", 0)), events)
+		elif moving:
+			var slot: int = effective_slot(side, int(action.get("slot", 0)))
+			_act(side, slot, move_for(side, slot), events)
+		_close_turn_bracket(side, action)
 
 	_residual_damage(acting, events)
 	_tick_weather(events)
@@ -948,6 +989,76 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	if is_over():
 		events.append({"type": OVER, "winner": winner()})
 	return events
+
+
+## `CheckOpponentWentFirst`, which is `wEnemyGoesFirst XOR hBattleTurn`: whether
+## the Pokémon opposite [param side] has already moved this turn.
+##
+## Protect and Endure both fail outright on a yes, which is what makes two
+## Protects in one turn a question of speed and what makes a Protect behind a
+## switch fail: a switching side is `.player_first` or `wEnemyGoesFirst`, so the
+## other side is always second.
+func opponent_went_first(side: int) -> bool:
+	return (side == PLAYER) == enemy_goes_first
+
+
+## `EndUserDestinyBond`, the front half of the wrapper each side's action runs
+## inside (`PlayerTurn_EndOpponentProtectEndureDestinyBond`,
+## engine/battle/core.asm). It is in front of `DoPlayerTurn`, so a Pokémon that
+## cannot move still loses the bond it put up.
+func _open_turn_bracket(side: int, action: Dictionary) -> void:
+	if not _brackets_turn(side, action):
+		return
+	mon(side).substatus &= ~Gen2Substatus.DESTINY_BOND
+
+
+## `EndOpponentProtectEndureDestinyBond`, the back half: the three flags that only
+## an opposing action ends. A Protect therefore covers exactly one opposing
+## action, and outlives the turn it was used on when it was used going second.
+func _close_turn_bracket(side: int, action: Dictionary) -> void:
+	if not _brackets_turn(side, action):
+		return
+	var other: Gen2BattleMon = mon(opponent_of(side))
+	other.substatus &= ~(
+		Gen2Substatus.PROTECT | Gen2Substatus.ENDURE | Gen2Substatus.DESTINY_BOND
+	)
+
+
+## Whether an action runs inside that wrapper, and the two sides do not agree.
+##
+## The player's runs on everything it spends the turn on: `Battle_PlayerFirst` and
+## `Battle_EnemyFirst` both call `PlayerTurn_End...` unconditionally, and
+## `DoPlayerTurn`'s own `ret nz` for a switch, an item or a failed run skips only
+## the move, not the two clears around it. The enemy's is skipped outright when
+## `AI_SwitchOrTryItem` answers, which is the `.switch_item` and
+## `.switched_or_used_item` jump past `EnemyTurn_End...`.
+##
+## So a Protect the player put up survives an enemy switch and blocks the move
+## after it, where an enemy's does not survive a player switch.
+func _brackets_turn(side: int, action: Dictionary) -> bool:
+	return side == PLAYER or not (_is_switch(action) or _is_item(action))
+
+
+## `ParsePlayerAction` and `ParseEnemyAction`: the two counters a chain keeps only
+## while the chain is the move being used. Both are zeroed unless this move is the
+## one that feeds them, and Protect and Endure share a counter, so alternating the
+## two does not reset it.
+##
+## The source has a second, unconditional reset behind `CheckPlayerLockedIn` and
+## `CheckEnemyLockedIn`, for a Pokémon locked into a recharge, a charge, a rampage
+## or a Rollout. It is not modelled separately because it can never disagree: none
+## of Fury Cutter, Protect and Endure sets any of those four flags, so a locked-in
+## Pokémon's forced move always fails the effect test below anyway.
+##
+## [param effect] is the move's own byte rather than [method Gen2Turn.effect],
+## which a broken Substitute can overwrite part way through a move that has
+## already been counted.
+func _reset_action_counters(side: int, effect: int) -> void:
+	var actor: Gen2BattleMon = mon(side)
+	if effect != Gen2MoveEffect.FURY_CUTTER:
+		actor.fury_cutter_count = 0
+	if effect != Gen2MoveEffect.PROTECT and effect != Gen2MoveEffect.ENDURE:
+		actor.protect_count = 0
 
 
 ## Both sides use a move slot, which is the common case and the whole of a battle
@@ -1462,9 +1573,11 @@ func _award_share(
 ## The item is gone whether or not it changed anything: `AI_TryItem` clears the
 ## slot the moment a check said yes, and the checks are what decide that, not
 ## the effect. Bide, Fury Cutter, Protect, Rage and `wLastEnemyCounterMove` are
-## cleared alongside it on the cartridge. Of those only the counter move exists
-## here, and [method reset_damage_taken] has already cleared it at the top of
-## this action pair, so there is nothing left for a clear here to do.
+## cleared alongside it on the cartridge. The two counters are cleared by
+## [method _reset_action_counters], which the caller runs for every action that is
+## not a move; the counter move was already cleared by
+## [method reset_damage_taken] at the top of this action pair; and Bide and Rage
+## do not exist here yet.
 func _use_trainer_item(side: int, item: int, events: Array) -> void:
 	if item == 0:
 		return
@@ -1705,6 +1818,8 @@ func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 	var move: Dictionary = data.move(move_number)
 	if move.is_empty():
 		return
+
+	_reset_action_counters(side, int(move.get("effect", -1)))
 
 	var turn: Gen2Turn = Gen2Turn.create(self, side, slot, move_number, move, events)
 	# The release turn of a two-turn move, or any Rollout/rampage continuation:

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -139,8 +139,16 @@ var last_move_used: int = 0
 var item: int = 0
 
 ## `wPlayerFuryCutterCount`: how many times in a row Fury Cutter has connected.
-## Zeroed on a switch and by a miss, which is `ResetFuryCutterCount`.
+## Zeroed on a switch, by a miss (`ResetFuryCutterCount`) and by choosing any
+## other move, which is `ParsePlayerAction`'s own `cp EFFECT_FURY_CUTTER`:
+## see [method Gen2Battle._reset_action_counters].
 var fury_cutter_count: int = 0
+
+## `wPlayerProtectCount`: how many times in a row this Pokémon has used Protect,
+## Detect or Endure. `ProtectChance` halves the odds once per count and refuses
+## outright at eight, and the same counter serves all three moves, so alternating
+## Protect and Endure does not reset it.
+var protect_count: int = 0
 
 ## `wPlayerMinimized`: whether this Pokémon has used Minimize since it came out,
 ## which is the whole of what Stomp's doubled damage reads. Set by
@@ -305,6 +313,7 @@ func reset_volatile() -> void:
 	turns_taken = 0
 	last_move_used = 0
 	fury_cutter_count = 0
+	protect_count = 0
 	minimized = false
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1999,6 +1999,20 @@ func _describe(event: Dictionary) -> String:
 			return "%s hung on with %s!" % [
 				_battler_name(int(event["target"])), _data.item_name(int(event["item"])),
 			]
+		Gen2Battle.PROTECTED_ITSELF:
+			return "%s PROTECTED itself!" % _battler_name(side)
+		Gen2Battle.PROTECTING_ITSELF:
+			return "%s's PROTECTING itself!" % _battler_name(int(event["target"]))
+		Gen2Battle.BRACED_ITSELF:
+			return "%s braced itself!" % _battler_name(side)
+		Gen2Battle.ENDURED_HIT:
+			return "%s ENDURED the hit!" % _battler_name(int(event["target"]))
+		Gen2Battle.DESTINY_BOND_SET:
+			return "%s's trying to take its opponent with it!" % _battler_name(side)
+		Gen2Battle.TOOK_DOWN_WITH_IT:
+			return "%s took down with it, %s!" % [
+				_battler_name(int(event["target"])), _battler_name(side),
+			]
 		Gen2Battle.TRAPPED:
 			return _trapped_text(event)
 		Gen2Battle.HURT_BY_TRAP:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -304,6 +304,13 @@ const CURSE: StringName = &"curse"
 const SPIKES: StringName = &"spikes"
 const CLEAR_HAZARDS: StringName = &"clearhazards"
 
+## Protect, Endure and Destiny Bond. The first two are one routine and one
+## counter, told apart only by the flag they set: `BattleCommand_Endure` is
+## `call ProtectChance / ret c` and nothing else.
+const PROTECT: StringName = &"protect"
+const ENDURE: StringName = &"endure"
+const DESTINY_BOND: StringName = &"destinybond"
+
 ## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
 ## moves that carry it end on `SafeguardProtectText`; the six secondary effects
 ## that reach `SafeCheckSafeguard` instead are refused with nothing said, which
@@ -657,6 +664,12 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_spikes(turn)
 		CLEAR_HAZARDS:
 			_clear_hazards(turn)
+		PROTECT:
+			_protect(turn)
+		ENDURE:
+			_endure(turn)
+		DESTINY_BOND:
+			_destiny_bond(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -1055,6 +1068,23 @@ static func _check_hit(turn: Gen2Turn) -> void:
 			turn.end()
 		return
 
+	# `.Protect`, second in `BattleCommand_CheckHit` and ahead of everything but
+	# the Dream Eater question. One gate for the whole game: 47 of the lists here
+	# carry `checkhit`, so a Protect turns away a damaging move, a status move and
+	# a stat drop alike without any of them knowing about it.
+	#
+	# The project already runs `.FlyDigMoves` in front of `.DreamEater` where the
+	# source runs it behind this, so between those three only the order of two
+	# refusal messages differs, never which of them refuses.
+	if Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.PROTECT):
+		turn.missed = true
+		turn.emit(Gen2Battle.PROTECTING_ITSELF, {"target": turn.target})
+		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
+		_jump_kick_crash(turn)
+		if not CONTINUES_AFTER_MISS.has(turn.effect()):
+			turn.end()
+		return
+
 	# `.DrainSub`, third: nothing can be drained out of a doll, so the two effects
 	# that heal off what they deal read as a miss rather than as a hit that heals
 	# nothing. Every other move goes through the doll normally.
@@ -1149,13 +1179,24 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 	# Ahead of `.damage`, so everything behind reads the cut figure: what Counter
 	# remembers, what a drain heals off and what a recoil costs are all
 	# `wCurDamage` after this.
-	var band: bool = Gen2HeldItem.effect_of(turn.data(), defender.item) == Gen2HeldItem.FOCUS_BAND \
+	#
+	# Endure is the front branch and the band is its `else`, which is the source's
+	# `jr z, .focus_band` and not a tidying opportunity: an enduring target never
+	# reaches the band's roll, so it draws no randomness there. Endure is read
+	# rather than spent, so every hit of a multi-hit move is clamped.
+	var enduring: bool = Gen2Substatus.has(defender.substatus, Gen2Substatus.ENDURE)
+	var band: bool = not enduring \
+		and Gen2HeldItem.effect_of(turn.data(), defender.item) == Gen2HeldItem.FOCUS_BAND \
 		and Gen2HeldItem.rolls_under(
 			turn.rng(), Gen2HeldItem.parameter_of(turn.data(), defender.item)
 		)
-	var endured: bool = band and turn.damage >= defender.hp
-	if endured:
+	# `BattleCommand_FalseSwipe` reports whether it clamped, which is what decides
+	# between the two lines; the test itself is the same for both.
+	var clamped: bool = (enduring or band) and turn.damage >= defender.hp
+	if clamped:
 		turn.damage = maxi(defender.hp - 1, 0)
+	var endured: bool = clamped and not enduring
+	var braced: bool = clamped and enduring
 
 	var behind_sub: bool = _substitute_refuses(turn)
 	if not behind_sub:
@@ -1165,6 +1206,8 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 
 	if behind_sub:
 		_substitute_damage(turn)
+		if braced:
+			turn.emit(Gen2Battle.ENDURED_HIT, {"target": turn.target})
 		if endured:
 			turn.emit(Gen2Battle.ENDURED, {"target": turn.target, "item": defender.item})
 		return
@@ -1178,6 +1221,8 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		"hp": defender.hp,
 		"max_hp": defender.max_hp(),
 	})
+	if braced:
+		turn.emit(Gen2Battle.ENDURED_HIT, {"target": turn.target})
 	if endured:
 		turn.emit(Gen2Battle.ENDURED, {"target": turn.target, "item": defender.item})
 
@@ -1256,10 +1301,17 @@ static func _counter(turn: Gen2Turn, mirror_coat: bool) -> void:
 ## Selfdestruct's command clears the user's status and sets its HP to zero.
 ## The faint event itself remains in CHECK_FAINT so the target is still reported
 ## first when the explosion also brings it down.
+##
+## Two flags go with it, and they are on opposite sides: the user loses its own
+## Leech Seed, which nothing can read off a Pokémon at zero, and the *target*
+## loses its Destiny Bond (`BATTLE_VARS_SUBSTATUS5_OPP`), which is what stops an
+## explosion being answered by one.
 static func _selfdestruct(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	attacker.status = Gen2Status.NONE
 	attacker.substatus &= ~(Gen2Substatus.CHARGING | Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
+	attacker.substatus &= ~Gen2Substatus.LEECH_SEED
+	turn.defender().substatus &= ~Gen2Substatus.DESTINY_BOND
 	attacker.take_damage(attacker.hp)
 
 
@@ -1322,11 +1374,35 @@ static func _recoil(turn: Gen2Turn) -> void:
 ## lists that have no faint step at all, Twineedle's among them, can still reach
 ## one through [constant MULTI_HIT].
 static func _check_faint(turn: Gen2Turn) -> void:
+	_destiny_bond_takes_user(turn)
 	for side: int in [turn.target, turn.side]:
 		if turn.battle.mon(side).is_fainted():
 			turn.events.append({"type": Gen2Battle.FAINTED, "side": side})
 	if turn.battle.mon(turn.target).is_fainted():
 		turn.end()
+
+
+## The Destiny Bond half of `BattleCommand_CheckFaint`, which is the one reader
+## of the flag and reads the *target's*, not the user's.
+##
+## The health is emptied outright rather than damaged: the source zeroes both
+## bytes of `wBattleMonHP` by hand, so no held item, no Endure and no Focus Band
+## stands between the bond and the attacker. Sitting in front of the loop below
+## is what reports the target's faint before the attacker's, which is the order
+## the source's own two `HandleMonFaint` calls take them in.
+##
+## A user already down asks nothing extra and is not exempted, because the source
+## exempts it nowhere: `recoil` runs in front of `checkfaint` in `RecoilHit`, so a
+## user that killed itself on the same hit still prints the line.
+static func _destiny_bond_takes_user(turn: Gen2Turn) -> void:
+	var target: Gen2BattleMon = turn.battle.mon(turn.target)
+	if not target.is_fainted():
+		return
+	if not Gen2Substatus.has(target.substatus, Gen2Substatus.DESTINY_BOND):
+		return
+	turn.emit(Gen2Battle.TOOK_DOWN_WITH_IT, {"target": turn.target})
+	var user: Gen2BattleMon = turn.attacker()
+	user.take_damage(user.hp)
 
 
 ## CantMove on the cartridge cancels a pending two-turn move, Rollout or
@@ -2427,6 +2503,79 @@ static func _clear_hazards(turn: Gen2Turn) -> void:
 	if user.trapped_turns > 0:
 		user.trapped_turns = 0
 		turn.emit(Gen2Battle.RELEASED_BY, {"target": turn.target})
+
+
+## `ProtectChance`, which Protect, Detect and Endure all are: three gates, then a
+## roll whose odds halve once per consecutive use. Answers whether the flag goes
+## up, and has already reported the failure when it says no.
+##
+## The two gates in front of the ladder are easy to get backwards. Going second
+## fails outright, which is what makes two Protects in one turn a question of
+## speed. And the Substitute it refuses is the *user's own*
+## (`BATTLE_VARS_SUBSTATUS4`, not `_OPP`), so a Pokémon behind its own doll cannot
+## protect; nothing about the target is asked.
+static func _protect_chance(turn: Gen2Turn) -> bool:
+	var user: Gen2BattleMon = turn.attacker()
+	if turn.battle.opponent_went_first(turn.side):
+		return _protect_failed(turn, user)
+	if Gen2Substatus.has(user.substatus, Gen2Substatus.SUBSTITUTE):
+		return _protect_failed(turn, user)
+
+	# `ld b, $ff` shifted right once per count, failing outright the moment it
+	# reaches zero: 255, 127, 63, 31, 15, 7, 3, 1, then nothing at eight.
+	var ceiling: int = 0xFF
+	for _step: int in user.protect_count:
+		ceiling >>= 1
+		if ceiling == 0:
+			return _protect_failed(turn, user)
+
+	# `.rand` rerolls a zero, so the draw is 1..255 rather than 0..255, and the
+	# comparison is on `roll - 1`. That is why a count of zero, with the ceiling
+	# still at 255, cannot fail: every one of the 255 values it can draw passes.
+	var roll: int = turn.rng().randi_range(1, PROTECT_ROLL_RANGE)
+	if roll - 1 >= ceiling:
+		return _protect_failed(turn, user)
+
+	user.protect_count += 1
+	return true
+
+
+## What the ladder draws against, `BattleRandom` with its zero rerolled away.
+const PROTECT_ROLL_RANGE: int = 0xFF
+
+
+## `.failed`: the count goes back to nothing and the move says so. The animation
+## the source plays here is `AnimateFailedMove`, which this engine spends no
+## frames on anywhere.
+static func _protect_failed(turn: Gen2Turn, user: Gen2BattleMon) -> bool:
+	user.protect_count = 0
+	turn.emit(Gen2Battle.MOVE_FAILED)
+	return false
+
+
+static func _protect(turn: Gen2Turn) -> void:
+	if not _protect_chance(turn):
+		return
+	turn.attacker().substatus |= Gen2Substatus.PROTECT
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.PROTECTED_ITSELF)
+
+
+static func _endure(turn: Gen2Turn) -> void:
+	if not _protect_chance(turn):
+		return
+	turn.attacker().substatus |= Gen2Substatus.ENDURE
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.BRACED_ITSELF)
+
+
+## `BattleCommand_DestinyBond`: the flag and the line, with nothing in front of
+## them. It rolls nothing, refuses nothing and cannot fail, which is why a second
+## use in a row is not a failure the way a second Protect can be.
+static func _destiny_bond(turn: Gen2Turn) -> void:
+	turn.attacker().substatus |= Gen2Substatus.DESTINY_BOND
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.DESTINY_BOND_SET)
 
 
 ## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -195,6 +195,17 @@ const CURSE: int = 109
 const SPIKES: int = 112
 const RAPID_SPIN: int = 129
 
+## Protect and Detect are one effect byte under two move numbers, and Endure is
+## the byte beside it: `BattleCommand_Endure` is `ProtectChance` and a different
+## flag. Both carry priority 3 in `MoveEffectPriorities`, which is why
+## [constant Gen2Battle.EFFECT_PRIORITIES] named them before either was written.
+const PROTECT: int = 111
+const ENDURE: int = 116
+
+## Destiny Bond, which rolls nothing and never fails: the flag goes up and the
+## opponent's own `BattleCommand_CheckFaint` reads it.
+const DESTINY_BOND: int = 98
+
 ## `EFFECT_NORMAL_HIT` as a byte rather than [constant NORMAL_HIT]'s list:
 ## `DoSubstituteDamage` stamps it over the move's own once a doll has broken.
 const NORMAL_HIT_EFFECT: int = 0
@@ -781,6 +792,30 @@ const RAPID_SPIN_SEQUENCE: Array = [
 	Gen2EffectCommands.CLEAR_HAZARDS,
 	Gen2EffectCommands.CHECK_FAINT,
 	Gen2EffectCommands.KINGS_ROCK,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Protect, Detect, Endure and Destiny Bond: four moves whose whole list is one
+## command, the shape `HEAL_SEQUENCE` above already has. None of the three rolls
+## accuracy, so the 100% each stores is never read.
+const PROTECT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.PROTECT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const ENDURE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.ENDURE,
+	Gen2EffectCommands.END_MOVE,
+]
+
+const DESTINY_BOND_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.DESTINY_BOND,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1477,6 +1512,9 @@ static func _sequences() -> Dictionary:
 		CURSE: CURSE_SEQUENCE,
 		SPIKES: SPIKES_SEQUENCE,
 		RAPID_SPIN: RAPID_SPIN_SEQUENCE,
+		PROTECT: PROTECT_SEQUENCE,
+		ENDURE: ENDURE_SEQUENCE,
+		DESTINY_BOND: DESTINY_BOND_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -81,6 +81,21 @@ const LEECH_SEED: int = 1 << 18
 const NIGHTMARE: int = 1 << 19
 const CURSE: int = 1 << 20
 
+## `SUBSTATUS_PROTECT` and `SUBSTATUS_ENDURE`, `wPlayerSubStatus1` bits 2 and 5.
+## Both sit on the Pokémon that used the move, and neither is spent by the hit it
+## answers: `BattleCommand_CheckHit`'s `.Protect` and `BattleCommand_ApplyDamage`
+## only read them, so every hit of a multi-hit move is turned away or clamped.
+## What ends them is `EndOpponentProtectEndureDestinyBond`, behind the opponent's
+## own action (engine/battle/core.asm).
+const PROTECT: int = 1 << 21
+const ENDURE: int = 1 << 22
+
+## `SUBSTATUS_DESTINY_BOND`, `wPlayerSubStatus5` bit 6. On its user, and read by
+## the *opponent's* `BattleCommand_CheckFaint`, which is the only reader.
+## `EndUserDestinyBond` clears it in front of its user's own next action, so it
+## covers exactly the opponent's next move.
+const DESTINY_BOND: int = 1 << 23
+
 const NONE: int = 0
 
 ## How many turns a confused Pokémon stays that way, rolled the same shape as

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -145,6 +145,15 @@ const SPIKES: int = 191
 ## Rapid Spin, the only move that undoes any of the three.
 const RAPID_SPIN: int = 229
 
+## Protect, Detect, Endure and Destiny Bond, at their real move numbers. Protect
+## and Detect have to be two numbers over one effect byte, since one shared
+## [member Gen2BattleMon.protect_count] is the whole point of the pair; the other
+## two are real for company, and all four fit under [constant MAX_MOVE].
+const PROTECT: int = 182
+const DESTINY_BOND: int = 194
+const DETECT: int = 197
+const ENDURE: int = 203
+
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
 ## the cartridge.
@@ -539,6 +548,14 @@ static func _moves() -> Array:
 		CURSE: ["CURSE", 0, CURSE_TYPE, 255, 10, Gen2MoveEffect.CURSE, 0],
 		SPIKES: ["SPIKES", 0, GROUND, 255, 20, Gen2MoveEffect.SPIKES, 0],
 		RAPID_SPIN: ["RAPID SPIN", 20, NORMAL, 255, 40, Gen2MoveEffect.RAPID_SPIN, 0],
+		# Real rows. All four store 100% as the 255 that skips a roll, and none of
+		# their lists rolls accuracy anyway.
+		PROTECT: ["PROTECT", 0, NORMAL, 255, 10, Gen2MoveEffect.PROTECT, 0],
+		DETECT: ["DETECT", 0, FIGHTING, 255, 5, Gen2MoveEffect.PROTECT, 0],
+		ENDURE: ["ENDURE", 0, NORMAL, 255, 10, Gen2MoveEffect.ENDURE, 0],
+		DESTINY_BOND: [
+			"DESTINY BOND", 0, GHOST, 255, 5, Gen2MoveEffect.DESTINY_BOND, 0,
+		],
 		# Thunder with a paralysis chance the roll cannot fail, so the secondary
 		# behind its own effect can be seen without a seed. The accuracy byte is
 		# still the real 178, since that is what the weather rewrites.

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -667,3 +667,162 @@ func test_basic_reproduces_the_nightmare_redundancy_bug() -> void:
 			Gen2BattleAI.choose_slot(pikachu, dreaming, _data, RomLayout.AI_BASIC, _rng), 1,
 			"a target already dreaming is redundant on the second clause"
 		)
+
+
+## `AI_Smart_Protect` and `AI_Smart_Endure`, both of which open on
+## `wEnemyProtectCount` and both of which are called directly, since every branch
+## of either is behind a roll.
+func _smart_scores(
+	attacker: Gen2BattleMon, defender: Gen2BattleMon, seed_value: int
+) -> Array:
+	_rng.seed = seed_value
+	var scores: Array = [20, 20, 20, 20]
+	Gen2BattleAI._apply_smart(
+		scores, attacker, defender, _data, _rng, 0, 0, Gen2Weather.NONE,
+		Gen2Screens.NONE, Gen2Screens.NONE, false, Gen2AISwitch.BASE_SCORE
+	)
+	return scores
+
+
+## How often the first slot was nudged each way over a hundred seeds, as
+## [encouraged, discouraged, untouched].
+func _smart_spread(attacker: Gen2BattleMon, defender: Gen2BattleMon) -> Array:
+	var out: Array = [0, 0, 0]
+	for seed_value: int in 100:
+		var score: int = int(_smart_scores(attacker, defender, seed_value)[0])
+		if score < 20:
+			out[0] += 1
+		elif score > 20:
+			out[1] += 1
+		else:
+			out[2] += 1
+	return out
+
+
+## `.greatly_discourage`: a Protect already used is worth three points against,
+## which only the 8% skip inside `.discourage` can soften to one.
+func test_smart_greatly_discourages_a_second_protect() -> void:
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.PROTECT, Fixture.TACKLE])
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	geodude.protect_count = 1
+
+	var spread: Array = _smart_spread(geodude, pikachu)
+	assert_eq(int(spread[0]), 0, "nothing here can encourage it")
+	assert_gt(int(spread[1]), 80, "and it is nearly always penalised")
+	assert_eq(
+		int(_smart_scores(geodude, pikachu, 0)[1]), 20,
+		"the Tackle beside it is untouched"
+	)
+
+
+## The four states that reach `.encourage`, each on its own: a boosted Fury
+## Cutter, a charged two-turn move, and a player already losing health to Toxic,
+## Leech Seed or a Curse.
+func test_smart_encourages_protect_against_something_worth_sitting_out() -> void:
+	var states: Array[Callable] = [
+		func(mon: Gen2BattleMon) -> void: mon.fury_cutter_count = 3,
+		func(mon: Gen2BattleMon) -> void: mon.substatus |= Gen2Substatus.CHARGING,
+		func(mon: Gen2BattleMon) -> void: mon.toxic_counter = 1,
+		func(mon: Gen2BattleMon) -> void: mon.substatus |= Gen2Substatus.LEECH_SEED,
+		func(mon: Gen2BattleMon) -> void: mon.substatus |= Gen2Substatus.CURSE,
+	]
+
+	for index: int in states.size():
+		var geodude: Gen2BattleMon = _mon(
+			Fixture.GEODUDE, 50, [Fixture.PROTECT, Fixture.TACKLE]
+		)
+		var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+		states[index].call(pikachu)
+
+		var spread: Array = _smart_spread(geodude, pikachu)
+		assert_gt(int(spread[0]), 60, "state %d encourages roughly four times in five" % index)
+		assert_eq(int(spread[1]), 0, "and never penalises")
+
+
+## The fall-through is two refusals in one: a player not rolling at all is
+## discouraged, and so is one whose Rollout has not built up yet.
+func test_smart_discourages_protect_against_an_unboosted_rollout() -> void:
+	for count: int in [0, 2]:
+		var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.PROTECT, Fixture.TACKLE])
+		var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+		if count > 0:
+			pikachu.substatus |= Gen2Substatus.ROLLOUT
+			pikachu.rollout_count = count
+
+		var spread: Array = _smart_spread(geodude, pikachu)
+		assert_eq(int(spread[0]), 0, "rollout count %d is not worth sitting out" % count)
+		assert_gt(int(spread[1]), 80)
+
+
+func test_smart_encourages_protect_against_a_boosted_rollout() -> void:
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.PROTECT, Fixture.TACKLE])
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	pikachu.substatus |= Gen2Substatus.ROLLOUT
+	pikachu.rollout_count = 3
+
+	var spread: Array = _smart_spread(geodude, pikachu)
+	assert_gt(int(spread[0]), 60, "three hits in is worth one turn of Protect")
+	assert_eq(int(spread[1]), 0)
+
+
+## `AI_Smart_Endure`: full health and a spent Protect chain are both two points
+## against, and anything above a quarter is one.
+func test_smart_discourages_endure_at_health_it_does_not_need_it() -> void:
+	var full: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.ENDURE, Fixture.TACKLE])
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	assert_eq(int(_smart_scores(full, pikachu, 0)[0]), 22, "full health is greatly discouraged")
+
+	var spent: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.ENDURE, Fixture.TACKLE])
+	spent.hp = spent.max_hp() / 8
+	spent.protect_count = 1
+	assert_eq(int(_smart_scores(spent, pikachu, 0)[0]), 22, "so is a spent chain")
+
+	var half: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.ENDURE, Fixture.TACKLE])
+	half.hp = half.max_hp() / 2
+	assert_eq(int(_smart_scores(half, pikachu, 0)[0]), 21, "above a quarter is one point")
+
+
+## Under a quarter with nothing to spend the survival on, the handler does
+## nothing at all: its last branch reads a lock-on this engine has no flag for.
+func test_smart_leaves_endure_alone_under_a_quarter_with_no_reversal() -> void:
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.ENDURE, Fixture.TACKLE])
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	geodude.hp = geodude.max_hp() / 8
+
+	var spread: Array = _smart_spread(geodude, pikachu)
+	assert_eq(int(spread[2]), 100, "untouched on every seed")
+
+
+## `AIHasMoveEffect` for `EFFECT_REVERSAL`: three points on, which is the
+## strongest single nudge either handler makes.
+func test_smart_greatly_encourages_endure_with_reversal_in_the_set() -> void:
+	var geodude: Gen2BattleMon = _mon(
+		Fixture.GEODUDE, 50, [Fixture.ENDURE, Fixture.REVERSAL]
+	)
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	geodude.hp = geodude.max_hp() / 8
+
+	var encouraged: int = 0
+	for seed_value: int in 100:
+		if int(_smart_scores(geodude, pikachu, seed_value)[0]) == 17:
+			encouraged += 1
+	assert_gt(encouraged, 60, "three points off, roughly four times in five")
+
+
+## `AI_Smart_DestinyBond` shares `AI_Smart_SkullBash`'s body, and so does
+## `AI_Smart_Reversal`: one point against while there is health to spare.
+func test_smart_discourages_destiny_bond_and_reversal_above_a_quarter() -> void:
+	for move_number: int in [Fixture.DESTINY_BOND, Fixture.REVERSAL]:
+		var healthy: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [move_number, Fixture.TACKLE])
+		var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+		assert_eq(
+			int(_smart_scores(healthy, pikachu, 0)[0]), 21,
+			"move %d is discouraged with health to spare" % move_number
+		)
+
+		var hurt: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [move_number, Fixture.TACKLE])
+		hurt.hp = hurt.max_hp() / 8
+		assert_eq(
+			int(_smart_scores(hurt, pikachu, 0)[0]), 20,
+			"and left alone under a quarter"
+		)

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3070,3 +3070,227 @@ func test_a_switch_leaves_the_substitute_behind() -> void:
 	battle.send_out(Gen2Battle.PLAYER, 1)
 	assert_false(Gen2Substatus.has(leaving.substatus, Gen2Substatus.SUBSTITUTE))
 	assert_eq(leaving.substitute_hp, 0)
+
+
+## `wEnemyGoesFirst`, and the wrapper each side's action runs inside.
+##
+## [method Gen2Battle.opponent_went_first] is what Protect and Endure read, and
+## it is [method Gen2Battle.order]'s own answer rather than a second decision, so
+## every branch of the order has to leave it right.
+func test_who_went_first_is_recorded_for_every_branch_of_the_order() -> void:
+	var fast: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	fast.take_turn(0, 0)
+	assert_false(fast.enemy_goes_first, "110 Speed against 30")
+	assert_false(fast.opponent_went_first(Gen2Battle.PLAYER))
+	assert_true(fast.opponent_went_first(Gen2Battle.ENEMY))
+
+	# Priority beats speed: Protect is 3 and Tackle is 1.
+	var priority: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.PROTECT])
+	)
+	priority.take_turn(0, 0)
+	assert_true(priority.enemy_goes_first, "priority 3 beats a faster Tackle")
+
+	# A switching side is settled first whatever its speed.
+	var switching: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])]
+	)
+	switching.take_actions(Gen2Battle.use_move(0), Gen2Battle.switch_to(1))
+	assert_true(switching.enemy_goes_first, "the enemy's switch settles before the move")
+
+
+## `EndOpponentProtectEndureDestinyBond` behind the opponent's own action: a
+## Protect covers exactly one opposing move and is gone after it.
+func test_a_protect_is_cleared_by_the_move_it_turned_away() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PROTECT]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var first: Array = battle.take_turn(0, 0)
+
+	assert_eq(_of_type(first, Gen2Battle.PROTECTED_ITSELF).size(), 1)
+	assert_eq(_of_type(first, Gen2Battle.PROTECTING_ITSELF).size(), 1, "the Tackle was turned away")
+	assert_eq(_of_type(first, Gen2Battle.HIT).size(), 0)
+	assert_false(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT),
+		"and the enemy's own move cleared it behind itself"
+	)
+
+
+## The player's half of the wrapper runs on every action it spends the turn on,
+## because `DoPlayerTurn`'s `ret nz` skips only the move and not the two clears
+## around it. So a player switch ends an enemy's Protect.
+func test_a_player_switch_ends_the_enemys_protect() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.enemy.substatus |= Gen2Substatus.PROTECT
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.PROTECT))
+
+
+## The enemy's half is skipped outright when it switches instead of moving, which
+## is `.switched_or_used_item` jumping past `EnemyTurn_End...`. So the player's
+## own Protect outlives an enemy switch and is still up for the move after it.
+func test_a_player_protect_outlives_an_enemy_switch() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])]
+	)
+	battle.player.substatus |= Gen2Substatus.PROTECT
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.switch_to(1))
+
+	assert_true(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT),
+		"nothing on the enemy's side of the turn clears it"
+	)
+
+
+## A bond covers exactly the opponent's next move, and the two brackets are what
+## decide which move that is.
+##
+## A user that goes first is answered on the same turn and its bond is cleared
+## behind the reply, so the interesting arrangement is the slow one: the bond
+## goes up after the opponent has already moved and is still up when the
+## opponent moves again.
+func test_a_destiny_bond_from_a_slow_user_survives_into_the_next_turn() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.GEODUDE, 50, [Fixture.DESTINY_BOND]),
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	)
+	battle.take_turn(0, 0)
+	assert_true(battle.enemy_goes_first, "110 Speed against 30")
+	assert_true(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.DESTINY_BOND),
+		"the enemy had already moved, so nothing was left to clear it"
+	)
+
+	battle.player.hp = 1
+	var events: Array = battle.take_turn(0, 0)
+	assert_true(battle.player.is_fainted())
+	assert_true(battle.enemy.is_fainted(), "and the bond collected on the next move")
+	assert_eq(_of_type(events, Gen2Battle.TOOK_DOWN_WITH_IT).size(), 1)
+
+
+## A user that goes first is answered the same turn, and its own bond is cleared
+## behind the answer rather than left standing.
+func test_a_destiny_bond_from_a_fast_user_is_cleared_by_the_reply() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.DESTINY_BOND]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.take_turn(0, 0)
+
+	assert_false(battle.enemy_goes_first)
+	assert_false(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.DESTINY_BOND),
+		"the enemy's own move cleared it behind itself"
+	)
+
+
+## A switch clears all three flags and both counters, since they sit inside the
+## five substatus bytes `NewBattleMonStatus` zeroes.
+func test_a_switch_clears_the_three_flags_and_the_protect_count() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	var leaving: Gen2BattleMon = battle.player
+	leaving.substatus |= (
+		Gen2Substatus.PROTECT | Gen2Substatus.ENDURE | Gen2Substatus.DESTINY_BOND
+	)
+	leaving.protect_count = 4
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+	battle.send_out(Gen2Battle.PLAYER, 0)
+
+	assert_eq(battle.player.substatus & (
+		Gen2Substatus.PROTECT | Gen2Substatus.ENDURE | Gen2Substatus.DESTINY_BOND
+	), 0)
+	assert_eq(battle.player.protect_count, 0)
+
+
+## `ParsePlayerAction`'s `cp EFFECT_FURY_CUTTER`: the chain is kept only while
+## Fury Cutter is the move being used, so any other move in between breaks it.
+func test_another_move_breaks_the_fury_cutter_chain() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.FURY_CUTTER, Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.fury_cutter_count, 1)
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.fury_cutter_count, 2, "two in a row keeps counting")
+
+	battle.take_turn(1, 0)
+	assert_eq(battle.player.fury_cutter_count, 0, "a Tackle in between resets it")
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.fury_cutter_count, 1, "so the next one starts over")
+
+
+## The same rule on Protect's own counter, and Endure does not break it because
+## the two share one.
+##
+## The shared ladder is read at the count that cannot roll rather than by
+## counting a success, so no seed decides the answer: an Endure behind a spent
+## Protect chain has to fail, where an Endure with a ladder of its own would be a
+## first use and could not.
+func test_another_move_breaks_the_protect_chain_but_endure_does_not() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.PROTECT, Fixture.TACKLE, Fixture.ENDURE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.protect_count = 8
+	battle.take_turn(2, 0)
+	assert_false(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.ENDURE),
+		"Endure inherited Protect's spent ladder"
+	)
+
+	battle.take_turn(1, 0)
+	assert_eq(battle.player.protect_count, 0, "a Tackle in between resets it")
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.protect_count, 1, "so the next Protect starts over and lands")
+
+
+## `.reset_bide` falls into `.locked_in`, so a failed run empties both counters
+## the way any other spent turn does.
+func test_a_failed_run_empties_both_counters() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 1, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 100, [Fixture.TACKLE])
+	)
+	battle.player.protect_count = 3
+	battle.player.fury_cutter_count = 3
+	var events: Array = battle.take_actions(Gen2Battle.run_away(), Gen2Battle.use_move(0))
+
+	assert_eq(
+		_of_type(events, Gen2Battle.RUN_FAILED).size(), 1,
+		"a level 1 Pikachu does not outrun a level 100 Geodude: %s" % JSON.stringify(events)
+	)
+	assert_eq(battle.player.protect_count, 0)
+	assert_eq(battle.player.fury_cutter_count, 0)
+
+
+## `AI_TryItem` does the same on the enemy's side.
+func test_a_trainer_item_empties_both_counters() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])), _rng, true
+	)
+	battle.enemy_items = [Gen2AIItems.MAX_POTION]
+	battle.enemy.hp = 1
+	battle.enemy.protect_count = 5
+	battle.enemy.fury_cutter_count = 5
+	battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.use_item(Gen2AIItems.MAX_POTION)
+	)
+
+	assert_eq(battle.enemy.protect_count, 0)
+	assert_eq(battle.enemy.fury_cutter_count, 0)

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -161,6 +161,14 @@ func test_every_volatile_field_clears() -> void:
 	mon.encored_slot = 2
 	mon.encore_turns = 3
 	mon.last_move_used = Fixture.TACKLE
+	mon.trapped_turns = 3
+	mon.trapping_move = Fixture.TACKLE
+	mon.perish_count = 2
+	mon.substitute_hp = 25
+	mon.turns_taken = 6
+	mon.fury_cutter_count = 4
+	mon.protect_count = 5
+	mon.minimized = true
 
 	mon.reset_volatile()
 
@@ -176,6 +184,14 @@ func test_every_volatile_field_clears() -> void:
 	assert_eq(mon.encored_slot, -1)
 	assert_eq(mon.encore_turns, 0)
 	assert_eq(mon.last_move_used, 0)
+	assert_eq(mon.trapped_turns, 0)
+	assert_eq(mon.trapping_move, 0)
+	assert_eq(mon.perish_count, 0)
+	assert_eq(mon.substitute_hp, 0)
+	assert_eq(mon.turns_taken, 0)
+	assert_eq(mon.fury_cutter_count, 0)
+	assert_eq(mon.protect_count, 0)
+	assert_false(mon.minimized)
 
 
 ## Attract's "opposite gender" rule reads [method Gen2BattleMon.gender], which

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -3046,3 +3046,307 @@ func test_a_doll_broken_by_the_first_hit_lets_the_second_through() -> void:
 	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 1, "the second hit lands")
 	assert_lt(battle.enemy.hp, before)
 	assert_eq(turn.effect(), Gen2MoveEffect.DOUBLE_HIT, "and the loop kept its own byte")
+
+
+## Protect, Detect, Endure and Destiny Bond.
+##
+## The first three are `ProtectChance` under two flags and one counter; the
+## fourth rolls nothing at all. `_run_move` leaves
+## [member Gen2Battle.enemy_goes_first] false, so the player is first and the
+## went-first gate passes unless a test says otherwise.
+func test_protect_and_detect_share_one_effect_and_one_count() -> void:
+	assert_eq(
+		int(_data.move(Fixture.DETECT).get("effect", -1)),
+		int(_data.move(Fixture.PROTECT).get("effect", -1)),
+		"one effect byte under two move numbers"
+	)
+
+	var battle: Gen2Battle = _battle()
+	_run_move(battle, Fixture.PROTECT)
+	assert_eq(battle.player.protect_count, 1)
+	_run_move(battle, Fixture.DETECT)
+	assert_eq(battle.player.protect_count, 2, "Detect counts against Protect's own ladder")
+
+
+## A count of zero cannot fail: `ld b, $ff` against a draw of 1..255 leaves no
+## value that loses.
+func test_the_first_protect_of_a_chain_always_lands() -> void:
+	for seed_value: int in range(0, 40):
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed_value
+		var turn: Gen2Turn = _run_move(battle, Fixture.PROTECT)
+		assert_true(
+			Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT),
+			"seed %d" % seed_value
+		)
+		assert_eq(_of_type(turn.events, Gen2Battle.PROTECTED_ITSELF).size(), 1)
+		assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0)
+
+
+## The ladder halves once per consecutive use and runs out at eight, which is the
+## one count that cannot roll at all.
+##
+## `srl b` from $ff gives 127, 63, 31, 15, 7, 3, 1 and then nothing, and the draw
+## it is compared against is 1..255, so the share that lands is the ceiling over
+## 255. The four counts checked against a figure are the four whose ceiling is
+## large enough for the sample to say anything.
+const PROTECT_LADDER_SAMPLES: int = 510
+const PROTECT_LADDER_CEILINGS: Array[int] = [255, 127, 63, 31, 15, 7, 3, 1, 0]
+
+
+func test_the_protect_ladder_halves_and_runs_out_at_eight() -> void:
+	var battle: Gen2Battle = _battle()
+	var landed: Array[int] = []
+	for count: int in PROTECT_LADDER_CEILINGS.size():
+		var hits: int = 0
+		for seed_value: int in PROTECT_LADDER_SAMPLES:
+			battle.rng.seed = seed_value
+			battle.player.protect_count = count
+			battle.player.substatus &= ~Gen2Substatus.PROTECT
+			_run_move(battle, Fixture.PROTECT)
+			if Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT):
+				hits += 1
+		landed.append(hits)
+
+	assert_eq(landed[0], PROTECT_LADDER_SAMPLES, "a ceiling of 255 against a draw of 1..255")
+	assert_eq(landed[8], 0, "the eighth shift empties the ceiling before any roll")
+	for count: int in range(1, landed.size()):
+		assert_lte(landed[count], landed[count - 1], "count %d is no likelier than %d" % [
+			count, count - 1,
+		])
+	for count: int in range(1, 5):
+		var expected: int = PROTECT_LADDER_SAMPLES * PROTECT_LADDER_CEILINGS[count] / 255
+		assert_almost_eq(
+			landed[count], expected, expected / 5,
+			"count %d lands about %d times in %d" % [count, expected, PROTECT_LADDER_SAMPLES]
+		)
+
+
+## And the count that cannot land draws nothing: `.failed` is reached before
+## `.rand`, so a chain that has run out spends no randomness.
+func test_a_protect_that_has_run_out_draws_no_randomness() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.protect_count = 8
+	var before: int = battle.rng.state
+	_run_move(battle, Fixture.PROTECT)
+	assert_eq(battle.rng.state, before)
+
+
+## A failure puts the count back to nothing, so the Protect after a failed one is
+## a first Protect again.
+func test_a_failed_protect_empties_its_own_count() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.protect_count = 8
+	var turn: Gen2Turn = _run_move(battle, Fixture.PROTECT)
+
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT))
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+	assert_eq(battle.player.protect_count, 0)
+
+
+## `CheckOpponentWentFirst`: going second fails outright, in front of the ladder.
+func test_protect_fails_outright_for_a_side_that_moved_second() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy_goes_first = true
+	var turn: Gen2Turn = _run_move(battle, Fixture.PROTECT)
+
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT))
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## And the Substitute it refuses is the user's own, not the target's.
+func test_protect_refuses_a_user_behind_its_own_doll() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.SUBSTITUTE
+	battle.player.substitute_hp = 20
+	assert_false(
+		Gen2Substatus.has(_run_move(battle, Fixture.PROTECT).battle.player.substatus,
+		Gen2Substatus.PROTECT)
+	)
+
+	var opposite: Gen2Battle = _battle()
+	opposite.enemy.substatus |= Gen2Substatus.SUBSTITUTE
+	opposite.enemy.substitute_hp = 20
+	_run_move(opposite, Fixture.PROTECT)
+	assert_true(
+		Gen2Substatus.has(opposite.player.substatus, Gen2Substatus.PROTECT),
+		"a doll on the other side is not asked about"
+	)
+
+
+## `BattleCommand_CheckHit`'s `.Protect` is one gate for every list that carries
+## `checkhit`, which is why a status move and a stat drop are turned away as
+## surely as an attack.
+##
+## Thunder Wave is run against the Charmander rather than the default Geodude:
+## `checkimmune` stands in for `failuretext` here and sits in front of
+## `checkhit`, so a Ground-type would end the move before the gate is reached.
+## That ordering is the standing divergence rather than anything about Protect.
+func test_a_protect_turns_away_an_attack_a_status_move_and_a_stat_drop() -> void:
+	for move_number: int in [Fixture.TACKLE, Fixture.THUNDER_WAVE, Fixture.GROWL]:
+		var battle: Gen2Battle = _electric_battle()
+		battle.enemy.substatus |= Gen2Substatus.PROTECT
+		var before: int = battle.enemy.hp
+		var turn: Gen2Turn = _run_move(battle, move_number)
+
+		assert_eq(
+			_of_type(turn.events, Gen2Battle.PROTECTING_ITSELF).size(), 1,
+			"move %d says so" % move_number
+		)
+		assert_eq(_of_type(turn.events, Gen2Battle.MISSED).size(), 1)
+		assert_eq(battle.enemy.hp, before)
+		assert_eq(battle.enemy.status, Gen2Status.NONE)
+		assert_eq(battle.enemy.stage("attack"), 0)
+
+
+## The refusal is printed before the miss, since `.Protect` prints inside
+## `CheckHit` and `failuretext` comes later.
+func test_the_protect_line_comes_before_the_miss() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.PROTECT
+	var types: Array = []
+	for event: Dictionary in _run_move(battle, Fixture.TACKLE).events:
+		types.append(StringName(event["type"]))
+
+	assert_lt(
+		types.find(Gen2Battle.PROTECTING_ITSELF), types.find(Gen2Battle.MISSED),
+		"protecting itself, then the attack missed"
+	)
+
+
+func test_endure_sets_its_own_flag_off_the_shared_count() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.ENDURE)
+
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.ENDURE))
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT))
+	assert_eq(_of_type(turn.events, Gen2Battle.BRACED_ITSELF).size(), 1)
+	assert_eq(battle.player.protect_count, 1)
+
+	_run_move(battle, Fixture.PROTECT)
+	assert_eq(battle.player.protect_count, 2, "one ladder for all three moves")
+
+
+func test_endure_leaves_its_holder_on_one_hit_point() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.ENDURE
+	battle.enemy.hp = 12
+	var turn: Gen2Turn = _turn(battle)
+	turn.damage = 400
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+	assert_eq(battle.enemy.hp, 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.ENDURED_HIT).size(), 1)
+	assert_eq(
+		_of_type(turn.events, Gen2Battle.ENDURED).size(), 0,
+		"the Focus Band's own line is a different text and did not fire"
+	)
+
+
+## `FalseSwipe` reports whether it clamped, so a hit that was never lethal says
+## nothing at all.
+func test_a_survivable_hit_against_an_enduring_target_says_nothing() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.ENDURE
+	battle.enemy.hp = 100
+	var turn: Gen2Turn = _turn(battle)
+	turn.damage = 10
+	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+
+	assert_eq(battle.enemy.hp, 90)
+	assert_eq(_of_type(turn.events, Gen2Battle.ENDURED_HIT).size(), 0)
+
+
+## Nothing spends the flag, so a multi-hit move is clamped on every hit rather
+## than only the first.
+func test_endure_clamps_every_hit_of_a_multi_hit_move() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.ENDURE
+	battle.enemy.hp = 1
+	var turn: Gen2Turn = _run_move(battle, Fixture.DOUBLE_HIT_MOVE)
+
+	assert_eq(battle.enemy.hp, 1, "still standing after both")
+	assert_eq(_of_type(turn.events, Gen2Battle.ENDURED_HIT).size(), 2)
+
+
+## `jr z, .focus_band`: an enduring target never reaches the band, so it draws no
+## randomness there. Counting the draws is the only way to see that.
+func test_an_enduring_target_never_rolls_its_focus_band() -> void:
+	var drawn: Dictionary = {}
+	for enduring: bool in [false, true]:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = 99
+		battle.enemy.item = Fixture.FOCUS_BAND
+		battle.enemy.hp = 40
+		if enduring:
+			battle.enemy.substatus |= Gen2Substatus.ENDURE
+		var turn: Gen2Turn = _turn(battle)
+		turn.damage = 5
+		Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+		drawn[enduring] = battle.rng.state
+
+	assert_ne(
+		int(drawn[false]), int(drawn[true]),
+		"the band's roll is drawn only when Endure did not answer first"
+	)
+
+
+func test_destiny_bond_goes_up_with_no_roll_and_never_fails() -> void:
+	var battle: Gen2Battle = _battle()
+	for _use: int in 3:
+		var turn: Gen2Turn = _run_move(battle, Fixture.DESTINY_BOND)
+		assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.DESTINY_BOND))
+		assert_eq(_of_type(turn.events, Gen2Battle.DESTINY_BOND_SET).size(), 1)
+		assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0)
+	assert_eq(battle.player.protect_count, 0, "it is not on Protect's ladder")
+
+
+## `BattleCommand_CheckFaint` reads the *target's* flag, and empties the
+## attacker's health outright rather than damaging it.
+func test_destiny_bond_takes_the_attacker_down_with_its_holder() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.DESTINY_BOND
+	battle.enemy.hp = 1
+	var turn: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+
+	assert_true(battle.enemy.is_fainted())
+	assert_true(battle.player.is_fainted(), "the attacker goes with it")
+
+	var types: Array = []
+	for event: Dictionary in turn.events:
+		types.append(StringName(event["type"]))
+	assert_eq(_of_type(turn.events, Gen2Battle.TOOK_DOWN_WITH_IT).size(), 1)
+	assert_lt(
+		types.find(Gen2Battle.TOOK_DOWN_WITH_IT), types.find(Gen2Battle.FAINTED),
+		"the line comes before either faint"
+	)
+	var faints: Array = _of_type(turn.events, Gen2Battle.FAINTED)
+	assert_eq(faints.size(), 2)
+	assert_eq(int(faints[0]["side"]), Gen2Battle.ENEMY, "the holder is reported first")
+	assert_eq(int(faints[1]["side"]), Gen2Battle.PLAYER)
+
+
+func test_a_destiny_bond_holder_that_survives_takes_nobody_with_it() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.DESTINY_BOND
+	var turn: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+
+	assert_false(battle.enemy.is_fainted())
+	assert_false(battle.player.is_fainted())
+	assert_eq(_of_type(turn.events, Gen2Battle.TOOK_DOWN_WITH_IT).size(), 0)
+
+
+## Selfdestruct clears the *target's* bond before its damage lands
+## (`BATTLE_VARS_SUBSTATUS5_OPP`), which is what stops an explosion being
+## answered by one.
+func test_selfdestruct_clears_the_targets_destiny_bond_before_it_lands() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.DESTINY_BOND
+	battle.enemy.hp = 1
+	var turn: Gen2Turn = _run_move(battle, Fixture.SELFDESTRUCT)
+
+	assert_true(battle.enemy.is_fainted())
+	assert_eq(
+		_of_type(turn.events, Gen2Battle.TOOK_DOWN_WITH_IT).size(), 0,
+		"the bond was cleared, so nothing collected"
+	)


### PR DESCRIPTION
Protect, Detect, Endure and Destiny Bond: three effect bytes over four moves, leaving 22 bytes over 24. Protect, Detect and Endure are one routine and one counter, so alternating them does not reset the ladder that halves their odds; Destiny Bond rolls nothing and is read only by the opponent's own faint check.

The three needed two pieces of turn state the engine had never had, and the rest of the effect table keeps asking for both. wEnemyGoesFirst is kept from the order that was already decided rather than decided twice, which is what CheckOpponentWentFirst answers and what makes two Protects in one turn a question of speed. And every action now runs inside the cartridge's own open/close pair, clearing the mover's Destiny Bond in front and the opponent's three flags behind. The two sides do not agree there: the player's pair runs on every action it spends the turn on, the enemy's only on a move, so a player's Protect outlives an enemy switch and an enemy's does not outlive a player's.

Endure sits in front of the Focus Band rather than beside it, so an enduring target draws no band roll, and nothing spends the flag, so every hit of a multi-hit move is clamped. One gate inside checkhit covers all 47 lists that roll to connect, a status move and a stat drop among them.

Fixed on the way: Fury Cutter's chain survived an intervening move, where the cartridge keeps it only while Fury Cutter is the move being used; a trainer item and a failed run left both counters standing; Selfdestruct cleared neither its user's Leech Seed nor its target's Destiny Bond; the AI had no Reversal arm though the cartridge shares one body between Reversal, Skull Bash and Destiny Bond; and the volatile-reset test claimed to cover every field while missing eight. Two contributor notes were stale and now match the code: the AI does switch and use items, and experience is divided among participants.