### PR TITLE
Blow a Pokemon out of the battle, or drag one into it

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -285,6 +285,13 @@ and each action runs inside an open/close pair that clears the mover's own
 Destiny Bond in front and the opponent's Protect, Endure and Destiny Bond behind;
 the player's pair runs on every action and the enemy's only on a move.
 
+`Gen2Battle.send_out` is the one entrance, and a command can call it: Whirlwind
+and Roar drag the target's side out through it, and `BreakAttraction` inside it
+clears the flag on both sides rather than only the incoming Pokémon's. In a wild
+battle the same two moves end the battle instead, through
+`Gen2Battle.force_out`, which is `wForcedSwitch` and `SetBattleDraw` together
+and leaves both parties standing with no winner.
+
 Switches happen before priority, so the incoming Pokémon takes the other
 side's move. A fainted replacement is caller policy: the turn stops at
 `must_replace` until `send_out`. A full moveset similarly uses

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -534,6 +534,12 @@ static func _apply_smart(
 			Gen2MoveEffect.DESTINY_BOND:
 				if _above_quarter(attacker):
 					_discourage(scores, slot, 1)
+			# `AI_Smart_ForceSwitch`: discourage blowing the player away unless
+			# `CheckPlayerMoveTypeMatchups` says the pairing is going badly, which
+			# is the same score `AI_Smart_PerishSong` reads.
+			Gen2MoveEffect.FORCE_SWITCH:
+				if matchup_score >= Gen2AISwitch.BASE_SCORE:
+					_discourage(scores, slot, 1)
 			Gen2MoveEffect.PROTECT:
 				_smart_protect(scores, slot, attacker, defender, rng)
 			Gen2MoveEffect.ENDURE:

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -181,6 +181,22 @@ const ENDURED_HIT: StringName = &"endured_hit"
 const DESTINY_BOND_SET: StringName = &"destiny_bond_set"
 const TOOK_DOWN_WITH_IT: StringName = &"took_down_with_it"
 
+## Whirlwind and Roar against a trainer: `DraggedOutText`, printed after the
+## replacement is out and before it walks into any spikes.
+##
+## The cartridge's line is `<USER>`, which is the Pokémon that *used* the move
+## rather than the one dragged out, in both directions. That is mirrored rather
+## than corrected, so [code]side[/code] here is the user and the Pokémon dragged
+## out is the one on [code]target[/code].
+const DRAGGED_OUT: StringName = &"dragged_out"
+
+## The same pair against a wild, where the battle ends instead:
+## `FledInFearText` for Roar and `BlownAwayText` for Whirlwind, told apart by the
+## move number. [code]target[/code] is whoever left, which is the wild when the
+## player used it and the player's own Pokémon when the wild did.
+const FLED_IN_FEAR: StringName = &"fled_in_fear"
+const BLOWN_AWAY: StringName = &"blown_away"
+
 ## Rain Dance, Sunny Day and Sandstorm. [code]weather[/code] on all four is the
 ## [Gen2Weather] value, so a screen names it without being told twice.
 ## [constant WEATHER_CONTINUES] is the line printed on every turn the weather
@@ -378,7 +394,7 @@ const EFFECT_PRIORITIES: Dictionary = {
 	Gen2MoveEffect.PROTECT: 3,
 	Gen2MoveEffect.ENDURE: 3,
 	0x67: 2,  # Quick Attack, Extreme Speed, Mach Punch
-	0x1C: 0,  # Whirlwind and Roar
+	Gen2MoveEffect.FORCE_SWITCH: 0,
 	Gen2MoveEffect.COUNTER: 0,
 	Gen2MoveEffect.MIRROR_COAT: 0,
 }
@@ -462,6 +478,14 @@ var enemy_goes_first: bool = false
 ## Set once the player has run. The battle is over with no winner, which is the
 ## DRAW `wBattleResult` the cartridge writes.
 var _fled: bool = false
+
+## `wForcedSwitch`, the other way a battle ends in that same DRAW: Whirlwind or
+## Roar in a wild battle blows one side out of it rather than switching anybody.
+## `BattleTurn`'s `ld a, [wForcedSwitch] / jr nz, .quit` is what ends it, and
+## `SetBattleDraw` beside it is why [method winner] answers nobody.
+var _forced_out: bool = false
+## Which side was blown out, for a screen that has to say who left.
+var _forced_out_side: int = -1
 
 ## The two sides, keyed by [constant PLAYER] and [constant ENEMY].
 var parties: Dictionary = {}
@@ -609,7 +633,31 @@ func last_damage_taken(side: int) -> Dictionary:
 ## A battle is lost when a whole party is down, not when the Pokémon that is out
 ## has fainted. One of those is a defeat and the other is a Pokémon to replace.
 func is_over() -> bool:
-	return _fled or party(PLAYER).is_wiped() or party(ENEMY).is_wiped()
+	return _fled or _forced_out or party(PLAYER).is_wiped() or party(ENEMY).is_wiped()
+
+
+## `wForcedSwitch` and `SetBattleDraw` together: Whirlwind or Roar blowing
+## [param side] out of a wild battle, which ends it with nobody beaten.
+##
+## Nothing is switched and nobody faints, so both parties are left exactly as
+## they stand; [method winner] answers null the way it does for a run.
+func force_out(side: int) -> void:
+	if is_over():
+		return
+	_forced_out = true
+	_forced_out_side = side
+
+
+## Which side Whirlwind or Roar blew out, or -1 if neither did.
+func forced_out_side() -> int:
+	return _forced_out_side
+
+
+## Whether Whirlwind or Roar ended this battle by blowing a side out of it.
+## Separate from [method has_fled] because the two print different lines and only
+## one of them was the player's own decision, though both are the same DRAW.
+func was_forced_out() -> bool:
+	return _forced_out
 
 
 ## Whether the player has run from this battle. The parties are both still
@@ -696,7 +744,8 @@ func winner() -> Variant:
 	if not is_over():
 		return null
 	# Running is a DRAW: both parties are still standing and nobody beat anybody.
-	if _fled:
+	# `SetBattleDraw` makes Whirlwind and Roar the same answer for the same reason.
+	if _fled or _forced_out:
 		return null
 	if party(PLAYER).is_wiped() and party(ENEMY).is_wiped():
 		return null
@@ -790,7 +839,12 @@ func decline_move(side: int) -> Array:
 ## Sends a side's [param index] out, whether as a replacement or between turns.
 ## Returns the events, which is one event or none: a switch that cannot be made
 ## is refused rather than approximated.
-func send_out(side: int, index: int) -> Array:
+##
+## [param dragged_by] is the side that used Whirlwind or Roar, or -1 for an
+## ordinary switch. It exists because `DraggedOutText` is printed between
+## `ForceEnemySwitch` and `SpikesDamage`, so the line has to land inside this
+## method rather than around it.
+func send_out(side: int, index: int, dragged_by: int = -1) -> Array:
 	var events: Array = []
 	if is_over():
 		return events
@@ -802,6 +856,11 @@ func send_out(side: int, index: int) -> Array:
 	if not current.send_out(index):
 		return events
 	_clear_trapping()
+	# `BreakAttraction`, which every entrance calls and which clears the flag on
+	# *both* sides rather than only the incoming Pokémon's: whoever the Pokémon
+	# that left was in love with is not on the field any more either.
+	mon(PLAYER).substatus &= ~Gen2Substatus.ATTRACTED
+	mon(ENEMY).substatus &= ~Gen2Substatus.ATTRACTED
 	# `NewBattleMonStatus`, which clears the used-move list beside the rest of
 	# the incoming Pokémon's volatile state. The enemy's send-out leaves it
 	# alone: the list describes what the player has shown, not what it is facing.
@@ -820,6 +879,8 @@ func send_out(side: int, index: int) -> Array:
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
 	})
 	(_participants[side] as Dictionary)[index] = true
+	if dragged_by >= 0:
+		events.append({"type": DRAGGED_OUT, "side": dragged_by, "target": side})
 	_spikes_damage(side, events)
 	return events
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2013,6 +2013,14 @@ func _describe(event: Dictionary) -> String:
 			return "%s took down with it, %s!" % [
 				_battler_name(int(event["target"])), _battler_name(side),
 			]
+		Gen2Battle.DRAGGED_OUT:
+			# `DraggedOutText` is `<USER>`, so it names the Pokemon that used the
+			# move rather than the one dragged out. Mirrored, not corrected.
+			return "%s was dragged out!" % _battler_name(side)
+		Gen2Battle.FLED_IN_FEAR:
+			return "%s fled in fear!" % _battler_name(int(event["target"]))
+		Gen2Battle.BLOWN_AWAY:
+			return "%s was blown away!" % _battler_name(int(event["target"]))
 		Gen2Battle.TRAPPED:
 			return _trapped_text(event)
 		Gen2Battle.HURT_BY_TRAP:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -311,6 +311,9 @@ const PROTECT: StringName = &"protect"
 const ENDURE: StringName = &"endure"
 const DESTINY_BOND: StringName = &"destinybond"
 
+## Whirlwind and Roar, which switch the side opposite whoever used them.
+const FORCE_SWITCH: StringName = &"forceswitch"
+
 ## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
 ## moves that carry it end on `SafeguardProtectText`; the six secondary effects
 ## that reach `SafeCheckSafeguard` instead are refused with nothing said, which
@@ -670,6 +673,8 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_endure(turn)
 		DESTINY_BOND:
 			_destiny_bond(turn)
+		FORCE_SWITCH:
+			_force_switch(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -2576,6 +2581,119 @@ static func _destiny_bond(turn: Gen2Turn) -> void:
 	turn.attacker().substatus |= Gen2Substatus.DESTINY_BOND
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.DESTINY_BOND_SET)
+
+
+## `BattleCommand_ForceSwitch`: Whirlwind and Roar, which have two endings and
+## share almost nothing between them.
+##
+## Against a trainer the target's side switches to a random standing party
+## member. Against a wild the battle *ends*, in either direction: the wild is
+## blown out of it or the player's own Pokémon is, and `SetBattleDraw` makes both
+## a draw with nobody beaten.
+##
+## The two halves of the source, `.trainer` and `.vs_trainer`, are one routine
+## here because every difference between them is which side is read. Written out,
+## both say: the user's level against the target's, the user having moved second,
+## and a random member of the target's party.
+static func _force_switch(turn: Gen2Turn) -> void:
+	if FORCE_SWITCH_REFUSED_TYPES.has(turn.battle.battle_type) or turn.missed:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	if turn.battle.is_trainer_battle:
+		_force_switch_trainer(turn)
+		return
+	_force_switch_wild(turn)
+
+
+## The four `wBattleType` values that refuse outright, before anything else is
+## asked. All four are scripted encounters the story needs to keep on the field.
+const FORCE_SWITCH_REFUSED_TYPES: Array[int] = [
+	Gen2Battle.BATTLETYPE_FORCESHINY, Gen2Battle.BATTLETYPE_TRAP,
+	Gen2Battle.BATTLETYPE_CELEBI, Gen2Battle.BATTLETYPE_SUICUNE,
+]
+
+
+## `.trainer` and `.vs_trainer`: drag a random standing party member out.
+##
+## The went-first gate is the non-obvious half. Both branches refuse unless the
+## *opponent* moved first, which is `wEnemyGoesFirst` read from each side's own
+## point of view, so a Whirlwind that somehow moved first does nothing. Priority
+## 0 makes that rare rather than impossible: a slower opponent using Counter,
+## Mirror Coat or a force switch of its own shares the same priority.
+static func _force_switch_trainer(turn: Gen2Turn) -> void:
+	var party: Gen2Party = turn.battle.party(turn.target)
+	if _standing_others(party).is_empty():
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+	if not turn.battle.opponent_went_first(turn.side):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	turn.battle.battle_anim_param = FORCE_SWITCH_ANIM_PARAM
+	_animate_current_move(turn)
+	var picked: int = _roll_dragged_index(turn, party)
+	turn.events.append_array(turn.battle.send_out(turn.target, picked, turn.side))
+
+
+## `ld a, $1 / ld [wBattleAnimParam], a`, which both endings set in front of
+## their own `AnimateCurrentMove`.
+const FORCE_SWITCH_ANIM_PARAM: int = 1
+
+
+## `.random_loop_trainer`, which is a rejection sample rather than a range: three
+## bits of a random byte, rerolled while the value is past the party's end, is the
+## member already out, or is one that has fainted. `CheckAnyOtherAlivePartyMons`
+## has already answered that one of the six will do, so it terminates.
+static func _roll_dragged_index(turn: Gen2Turn, party: Gen2Party) -> int:
+	var standing: Array[int] = _standing_others(party)
+	var picked: int = party.active
+	while not standing.has(picked):
+		picked = turn.rng().randi_range(0, FORCE_SWITCH_ROLL_MASK)
+	return picked
+
+
+## `and $7`: the roll is masked to three bits, so a party is only ever reached
+## through the eight values that mask leaves.
+const FORCE_SWITCH_ROLL_MASK: int = 7
+
+
+## Every member of [param party] that is standing and is not the one out, which
+## is `CheckAnyOtherAlivePartyMons` and `FindAliveEnemyMons` both.
+static func _standing_others(party: Gen2Party) -> Array[int]:
+	var out: Array[int] = []
+	for index: int in party.size():
+		if index != party.active and not party.at(index).is_fainted():
+			out.append(index)
+	return out
+
+
+## `.wild_force_flee` and `.wild_succeed_playeristarget`, which are the same
+## comparison written twice: the user's level against the target's.
+##
+## A user at or above the target's level always succeeds. Below it, the roll is
+## drawn out of the two levels summed and one more, and it succeeds unless it
+## lands under a quarter of the target's level, so a much weaker user usually
+## fails. `srl b` twice is that quarter, and it truncates.
+static func _force_switch_wild(turn: Gen2Turn) -> void:
+	var user_level: int = turn.attacker().level
+	var target_level: int = turn.defender().level
+
+	if user_level < target_level:
+		var span: int = user_level + target_level + 1
+		var roll: int = turn.rng().randi_range(0, span - 1)
+		if roll < target_level >> 2:
+			turn.emit(Gen2Battle.MOVE_FAILED)
+			return
+
+	turn.battle.force_out(turn.target)
+	turn.battle.battle_anim_param = FORCE_SWITCH_ANIM_PARAM
+	_animate_current_move(turn)
+	# `.succeed` reads the move's animation byte back and compares it against
+	# ROAR, and every move here animates as itself.
+	var line: StringName = Gen2Battle.FLED_IN_FEAR if turn.move_number == Gen2MoveEffect.ROAR_MOVE \
+		else Gen2Battle.BLOWN_AWAY
+	turn.emit(line, {"target": turn.target})
 
 
 ## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -206,6 +206,17 @@ const ENDURE: int = 116
 ## opponent's own `BattleCommand_CheckFaint` reads it.
 const DESTINY_BOND: int = 98
 
+## Whirlwind and Roar, which are one effect byte and two endings: against a
+## trainer they drag a random party member out, and against a wild they end the
+## battle outright. Priority 0, so the user almost always moves second, which the
+## command then requires of itself.
+const FORCE_SWITCH: int = 28
+
+## Roar's own move number. `.succeed` picks between the two lines by comparing
+## the move's animation byte against `ROAR`, and every move here animates as
+## itself, so the number is what tells the pair apart.
+const ROAR_MOVE: int = 46
+
 ## `EFFECT_NORMAL_HIT` as a byte rather than [constant NORMAL_HIT]'s list:
 ## `DoSubstituteDamage` stamps it over the move's own once a doll has broken.
 const NORMAL_HIT_EFFECT: int = 0
@@ -816,6 +827,22 @@ const DESTINY_BOND_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.DESTINY_BOND,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Whirlwind and Roar. `checkhit` is the one thing in front of the command.
+##
+## The list carries no `failuretext`, so on the cartridge a missed Whirlwind
+## reaches `forceswitch`, takes `.missed` and says "But it failed!" with no miss
+## line at all. Here `checkhit` ends the move and announces the miss, which is
+## the standing `failuretext` divergence and not a second one: nothing switches
+## either way, only the line differs. Every other list without a `failuretext`,
+## `DoParalyze` among them, already reads this way.
+const FORCE_SWITCH_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.FORCE_SWITCH,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1515,6 +1542,7 @@ static func _sequences() -> Dictionary:
 		PROTECT: PROTECT_SEQUENCE,
 		ENDURE: ENDURE_SEQUENCE,
 		DESTINY_BOND: DESTINY_BOND_SEQUENCE,
+		FORCE_SWITCH: FORCE_SWITCH_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -154,6 +154,12 @@ const DESTINY_BOND: int = 194
 const DETECT: int = 197
 const ENDURE: int = 203
 
+## Whirlwind and Roar, which have to be real numbers twice over: they share one
+## effect byte, and `.succeed` picks between "fled in fear" and "was blown away"
+## by comparing the move against ROAR.
+const WHIRLWIND: int = 18
+const ROAR: int = 46
+
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
 ## the cartridge.
@@ -556,6 +562,8 @@ static func _moves() -> Array:
 		DESTINY_BOND: [
 			"DESTINY BOND", 0, GHOST, 255, 5, Gen2MoveEffect.DESTINY_BOND, 0,
 		],
+		WHIRLWIND: ["WHIRLWIND", 0, NORMAL, 255, 20, Gen2MoveEffect.FORCE_SWITCH, 0],
+		ROAR: ["ROAR", 0, NORMAL, 255, 20, Gen2MoveEffect.FORCE_SWITCH, 0],
 		# Thunder with a paralysis chance the roll cannot fail, so the secondary
 		# behind its own effect can be seen without a seed. The accuracy byte is
 		# still the real 178, since that is what the weather rewrites.

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -826,3 +826,25 @@ func test_smart_discourages_destiny_bond_and_reversal_above_a_quarter() -> void:
 			int(_smart_scores(hurt, pikachu, 0)[0]), 20,
 			"and left alone under a quarter"
 		)
+
+
+## `AI_Smart_ForceSwitch`: blowing the player away is worth a point against while
+## the pairing is going well, and left alone once `CheckPlayerMoveTypeMatchups`
+## says it is not.
+func test_smart_discourages_a_force_switch_while_the_matchup_is_holding() -> void:
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.WHIRLWIND, Fixture.TACKLE])
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+
+	var scores: Array = [20, 20, 20, 20]
+	Gen2BattleAI._apply_smart(
+		scores, geodude, pikachu, _data, _rng, 0, 0, Gen2Weather.NONE,
+		Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE
+	)
+	assert_eq(int(scores[0]), 21, "a neutral pairing is no reason to blow it away")
+
+	var losing: Array = [20, 20, 20, 20]
+	Gen2BattleAI._apply_smart(
+		losing, geodude, pikachu, _data, _rng, 0, 0, Gen2Weather.NONE,
+		Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE - 1
+	)
+	assert_eq(int(losing[0]), 20, "a pairing going badly is left alone")

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3294,3 +3294,64 @@ func test_a_trainer_item_empties_both_counters() -> void:
 
 	assert_eq(battle.enemy.protect_count, 0)
 	assert_eq(battle.enemy.fury_cutter_count, 0)
+
+
+## Whirlwind and Roar through a whole turn, which is where the went-first gate
+## stops being something a test has to arrange: priority 0 puts them second.
+func test_a_trainers_roar_drags_the_players_pokemon_out() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 50, [Fixture.ROAR])), _rng, true
+	)
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_true(battle.enemy_goes_first == false, "Pikachu outspeeds Geodude")
+	assert_eq(
+		battle.party(Gen2Battle.PLAYER).active, 1,
+		"Roar is priority 0, so it moved second and the gate passed: %s" % JSON.stringify(events)
+	)
+	assert_eq(_of_type(events, Gen2Battle.DRAGGED_OUT).size(), 1)
+	assert_false(battle.is_over())
+
+
+## The same move in a wild battle ends it rather than switching anybody, and the
+## parties are left exactly as they stood.
+func test_a_wild_roar_ends_the_battle_with_both_sides_standing() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.ROAR])
+	)
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_true(battle.is_over())
+	assert_true(battle.was_forced_out())
+	assert_false(battle.has_fled(), "it was not the player's own decision")
+	assert_eq(battle.forced_out_side(), Gen2Battle.PLAYER)
+	assert_null(battle.winner())
+	assert_eq(_of_type(events, Gen2Battle.FLED_IN_FEAR).size(), 1)
+	assert_false(_first(events, Gen2Battle.OVER).is_empty())
+	assert_false(battle.player.is_fainted())
+	assert_false(battle.enemy.is_fainted())
+
+
+## `BreakAttraction` runs on every entrance and clears the flag on both sides,
+## not only the incoming Pokemon's: whoever was in love has nothing left to be in
+## love with.
+func test_a_switch_breaks_attraction_on_both_sides() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.player.substatus |= Gen2Substatus.ATTRACTED
+	battle.enemy.substatus |= Gen2Substatus.ATTRACTED
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.ATTRACTED))
+	assert_false(
+		Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED),
+		"the side that did not switch loses it too"
+	)

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -3350,3 +3350,161 @@ func test_selfdestruct_clears_the_targets_destiny_bond_before_it_lands() -> void
 		_of_type(turn.events, Gen2Battle.TOOK_DOWN_WITH_IT).size(), 0,
 		"the bond was cleared, so nothing collected"
 	)
+
+
+## Whirlwind and Roar: one effect byte, two endings.
+##
+## `_run_move` leaves [member Gen2Battle.enemy_goes_first] false, which is the
+## player having moved first, and the trainer half refuses that outright. Every
+## trainer case below therefore sets it, which is what priority 0 does in a real
+## turn anyway.
+func _trainer_battle(player: Array, enemy: Array) -> Gen2Battle:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.create(player), Gen2Party.create(enemy), _rng, true
+	)
+	battle.enemy_goes_first = true
+	return battle
+
+
+func _party_of(species: Array) -> Array:
+	var out: Array = []
+	for number: int in species:
+		out.append(Gen2BattleMon.create(_data, number, 50, [Fixture.TACKLE]))
+	return out
+
+
+func test_a_force_switch_drags_out_a_standing_party_member() -> void:
+	var battle: Gen2Battle = _trainer_battle(
+		_party_of([Fixture.PIKACHU]),
+		_party_of([Fixture.GEODUDE, Fixture.CHARMANDER])
+	)
+	var turn: Gen2Turn = _run_move(battle, Fixture.WHIRLWIND)
+
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1, "the other member is out")
+	assert_eq(_of_type(turn.events, Gen2Battle.DRAGGED_OUT).size(), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0)
+
+
+## `DraggedOutText` is printed once the replacement is out and before it walks
+## into anything, so the three events are in that order.
+func test_the_dragged_out_line_sits_between_the_entrance_and_the_spikes() -> void:
+	var battle: Gen2Battle = _trainer_battle(
+		_party_of([Fixture.PIKACHU]),
+		_party_of([Fixture.GEODUDE, Fixture.CHARMANDER])
+	)
+	battle.screens[Gen2Battle.ENEMY] |= Gen2Screens.SPIKES
+	var types: Array = []
+	for event: Dictionary in _run_move(battle, Fixture.WHIRLWIND).events:
+		types.append(StringName(event["type"]))
+
+	assert_lt(types.find(Gen2Battle.SENT_OUT), types.find(Gen2Battle.DRAGGED_OUT))
+	assert_lt(types.find(Gen2Battle.DRAGGED_OUT), types.find(Gen2Battle.HURT_BY_SPIKES))
+
+
+## `FindAliveEnemyMons` and `CheckPlayerHasMonToSwitchTo`: a lone Pokemon, or a
+## bench that is all down, has nothing to drag out.
+func test_a_force_switch_fails_with_nobody_left_to_drag_out() -> void:
+	var lone: Gen2Battle = _trainer_battle(
+		_party_of([Fixture.PIKACHU]), _party_of([Fixture.GEODUDE])
+	)
+	assert_eq(_of_type(_run_move(lone, Fixture.WHIRLWIND).events,
+		Gen2Battle.MOVE_FAILED).size(), 1, "a lone Pokemon")
+
+	var downed: Gen2Battle = _trainer_battle(
+		_party_of([Fixture.PIKACHU]),
+		_party_of([Fixture.GEODUDE, Fixture.CHARMANDER])
+	)
+	var bench: Gen2BattleMon = downed.party(Gen2Battle.ENEMY).at(1)
+	bench.take_damage(bench.max_hp())
+	assert_eq(_of_type(_run_move(downed, Fixture.WHIRLWIND).events,
+		Gen2Battle.MOVE_FAILED).size(), 1, "a bench that is all down")
+
+
+## The went-first gate: both halves of the source refuse unless the opponent
+## moved first, so a force switch that somehow moved first does nothing.
+func test_a_force_switch_that_moved_first_does_nothing() -> void:
+	var battle: Gen2Battle = _trainer_battle(
+		_party_of([Fixture.PIKACHU]),
+		_party_of([Fixture.GEODUDE, Fixture.CHARMANDER])
+	)
+	battle.enemy_goes_first = false
+	var turn: Gen2Turn = _run_move(battle, Fixture.WHIRLWIND)
+
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 0, "nobody moved")
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## Only the target's side is dragged out, and only ever to somebody standing.
+func test_a_force_switch_only_ever_picks_a_standing_member_of_the_targets_party() -> void:
+	for seed_value: int in 60:
+		var battle: Gen2Battle = _trainer_battle(
+			_party_of([Fixture.PIKACHU, Fixture.CHARMANDER]),
+			_party_of([Fixture.GEODUDE, Fixture.CHARMANDER, Fixture.BULBASAUR])
+		)
+		battle.rng.seed = seed_value
+		var fainted: Gen2BattleMon = battle.party(Gen2Battle.ENEMY).at(1)
+		fainted.take_damage(fainted.max_hp())
+		_run_move(battle, Fixture.ROAR)
+
+		assert_eq(battle.party(Gen2Battle.ENEMY).active, 2, "the only one standing")
+		assert_eq(battle.party(Gen2Battle.PLAYER).active, 0, "the user's side never moves")
+
+
+## Against a wild the battle ends instead, with nobody beaten. A user at or above
+## the target's level always succeeds, so this needs no seed.
+func test_a_force_switch_ends_a_wild_battle_as_a_draw() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.WHIRLWIND)
+
+	assert_true(battle.is_over())
+	assert_true(battle.was_forced_out())
+	assert_eq(battle.forced_out_side(), Gen2Battle.ENEMY)
+	assert_null(battle.winner(), "SetBattleDraw: nobody beat anybody")
+	assert_false(battle.player.is_fainted())
+	assert_false(battle.enemy.is_fainted())
+	assert_eq(_of_type(turn.events, Gen2Battle.BLOWN_AWAY).size(), 1)
+
+
+## Roar and Whirlwind are the same effect and differ only in that line.
+func test_roar_and_whirlwind_print_different_lines() -> void:
+	var roared: Gen2Turn = _run_move(_battle(), Fixture.ROAR)
+	assert_eq(_of_type(roared.events, Gen2Battle.FLED_IN_FEAR).size(), 1)
+	assert_eq(_of_type(roared.events, Gen2Battle.BLOWN_AWAY).size(), 0)
+
+	var blown: Gen2Turn = _run_move(_battle(), Fixture.WHIRLWIND)
+	assert_eq(_of_type(blown.events, Gen2Battle.BLOWN_AWAY).size(), 1)
+	assert_eq(_of_type(blown.events, Gen2Battle.FLED_IN_FEAR).size(), 0)
+
+
+## Below the target's level it goes on the dice, and a quarter of the target's
+## level is the share that fails. A level 4 user against a level 50 target fails
+## whenever the roll lands under 12, out of the 55 it is drawn from.
+func test_a_weaker_user_rolls_against_a_quarter_of_the_targets_level() -> void:
+	var failures: int = 0
+	var samples: int = 200
+	for seed_value: int in samples:
+		var battle: Gen2Battle = Gen2Battle.create(
+			_data,
+			Gen2BattleMon.create(_data, Fixture.PIKACHU, 4, [Fixture.TACKLE]),
+			Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+			_rng
+		)
+		battle.rng.seed = seed_value
+		if _of_type(_run_move(battle, Fixture.WHIRLWIND).events,
+			Gen2Battle.MOVE_FAILED).size() > 0:
+			failures += 1
+
+	var expected: int = samples * 12 / 55
+	assert_almost_eq(failures, expected, expected / 3,
+		"roughly twelve of the fifty-five values it can draw")
+
+
+## And the four scripted encounters refuse before any of that is asked.
+func test_the_four_scripted_battle_types_refuse_a_force_switch() -> void:
+	for battle_type: int in Gen2EffectCommands.FORCE_SWITCH_REFUSED_TYPES:
+		var battle: Gen2Battle = _battle()
+		battle.battle_type = battle_type
+		var turn: Gen2Turn = _run_move(battle, Fixture.WHIRLWIND)
+
+		assert_false(battle.is_over(), "battle type %d" % battle_type)
+		assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)


### PR DESCRIPTION
Whirlwind and Roar: one effect byte over two moves, leaving 21 bytes over 22. The two endings share almost nothing. Against a trainer the target's side switches to a random standing party member, rejection-sampled out of three bits the way the cartridge's own loop does it. Against a wild the battle ends instead, in either direction, with nobody switched, nobody fainted and nobody beaten: wForcedSwitch and SetBattleDraw together, which is the same draw a run already produced.

Both halves refuse unless the opponent moved first, which is the went-first record the protect family landed last time, read from each side's own point of view. Priority 0 makes that the ordinary case rather than a rare one. Below the target's level the wild half goes on the dice, drawn out of the two levels summed plus one and failing under a quarter of the target's level, and the four scripted battle types refuse in front of all of it.

The second seam the effect table keeps asking for comes with it: send_out is now callable from inside a move and takes the side that dragged its target out, because DraggedOutText is printed between the entrance and the spikes. That line names the Pokemon that used the move rather than the one dragged out, in both directions; mirrored rather than corrected, and recorded as worth checking against hardware.

Fixed on the way: BreakAttraction runs on every entrance and clears the flag on both sides, where send_out only ever cleared the incoming Pokemon's, so a Pokemon stayed in love with something that had left the field.