### PR TITLE
Hand the next Pokemon everything the last one had

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -292,9 +292,16 @@ battle the same two moves end the battle instead, through
 `Gen2Battle.force_out`, which is `wForcedSwitch` and `SetBattleDraw` together
 and leaves both parties standing with no winner.
 
+Baton Pass is the one move that stops a turn part way: the player's target is a
+menu the cartridge opens inside the move, so `take_actions` leaves the rest of
+the turn standing and `Gen2Battle.pass_to` finishes it, asked through
+`awaiting_baton_pass`. Everything the battle position was carrying moves with it
+(`Gen2BattleMon.capture_passed_state`, whose field list is `reset_volatile`'s
+plus the stages); `ResetBatonPassStatus` names the few things that do not.
+
 Switches happen before priority, so the incoming Pokémon takes the other
 side's move. A fainted replacement is caller policy: the turn stops at
-`must_replace` until `send_out`. A full moveset similarly uses
+`must_replace` until `send_out`, and a Baton Pass target the same way. A full moveset similarly uses
 `must_learn_move`, `learn_move` and `decline_move`; the development screen
 declines automatically.
 

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -537,7 +537,9 @@ static func _apply_smart(
 			# `AI_Smart_ForceSwitch`: discourage blowing the player away unless
 			# `CheckPlayerMoveTypeMatchups` says the pairing is going badly, which
 			# is the same score `AI_Smart_PerishSong` reads.
-			Gen2MoveEffect.FORCE_SWITCH:
+			# `AI_Smart_BatonPass` is the same body under a second label, so the
+			# two share an arm the way Destiny Bond shares Skull Bash's.
+			Gen2MoveEffect.FORCE_SWITCH, Gen2MoveEffect.BATON_PASS:
 				if matchup_score >= Gen2AISwitch.BASE_SCORE:
 					_discourage(scores, slot, 1)
 			Gen2MoveEffect.PROTECT:

--- a/game/battle/ai_switch.gd
+++ b/game/battle/ai_switch.gd
@@ -78,6 +78,23 @@ static func decide(battle: Gen2Battle, flags: int, rng: RandomNumberGenerator) -
 	return {"switch": true, "index": int(choice["index"])}
 
 
+## `FindMonInOTPartyToSwitchIntoBattle`: who the AI would rather have in, with no
+## opinion about whether it should switch at all.
+##
+## [method decide] is the ordinary route and answers both questions at once.
+## Baton Pass is the one caller that has already settled the first, so it needs
+## the pick on its own. Nobody standing answers -1; a shortlist that resists
+## nothing falls back to the lowest index still up, which is `.not_2` walking the
+## alive mask from the top.
+static func pick_target(battle: Gen2Battle) -> int:
+	var alive: Array = _alive_others(battle)
+	if alive.is_empty():
+		return -1
+	var best: Dictionary = _best_answer(battle, alive)
+	var index: int = int(best["index"])
+	return index if index >= 0 else int(alive[0])
+
+
 ## `CheckAbleToSwitch`: how badly the AI wants out and who it would rather have
 ## in, as [code]{"tier": int, "index": int}[/code]. A tier of zero is "stay".
 static func evaluate(battle: Gen2Battle) -> Dictionary:

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -487,6 +487,17 @@ var _forced_out: bool = false
 ## Which side was blown out, for a screen that has to say who left.
 var _forced_out_side: int = -1
 
+## The half-run turn a Baton Pass stopped, as
+## [code]{"acting": Array, "actions": Dictionary, "index": int}[/code], or empty
+## when no turn is part way through. [method _run_turn] reads it and
+## [method pass_to] is what lets it finish.
+var _pending_turn: Dictionary = {}
+
+## The side owing a Baton Pass target, or -1. `ForcePickSwitchMonInBattle` is a
+## menu the player cannot back out of, so this is answered rather than optional
+## and everything else is refused until it is.
+var _pending_baton_pass: int = -1
+
 ## The two sides, keyed by [constant PLAYER] and [constant ENEMY].
 var parties: Dictionary = {}
 
@@ -764,6 +775,98 @@ func awaiting_replacement() -> bool:
 	return must_replace(PLAYER) or must_replace(ENEMY)
 
 
+## Which side owes a Baton Pass target, or -1. The turn is standing still until
+## [method pass_to] answers, the same refusal-until-answered shape
+## [method must_replace] uses, except that this one stops a turn part way rather
+## than between two.
+func awaiting_baton_pass() -> int:
+	return _pending_baton_pass
+
+
+## Answers a pending Baton Pass by sending [param index] out, then finishes the
+## turn that was waiting on it and returns everything that happened after.
+##
+## Refuses an index the party would refuse anyway, leaving the question standing,
+## because `ForcePickSwitchMonInBattle` redisplays its list rather than accepting
+## a Pokémon that cannot come in.
+func pass_to(index: int) -> Array:
+	var side: int = _pending_baton_pass
+	if side < 0 or not party(side).can_send_out(index):
+		return []
+
+	var events: Array = []
+	_pending_baton_pass = -1
+	events.append_array(baton_pass_send_out(side, index))
+	_close_turn_bracket(side, (_pending_turn["actions"] as Dictionary)[side])
+	_pending_turn["index"] = int(_pending_turn["index"]) + 1
+	return _run_turn(events)
+
+
+## Stops the turn and asks [param side] for a Baton Pass target.
+## [method Gen2EffectCommands._baton_pass] is the only caller.
+func request_baton_pass(side: int) -> void:
+	_pending_baton_pass = side
+
+
+## `FindMonInOTPartyToSwitchIntoBattle`, which `EnemySwitch_SetMode` reaches
+## because Baton Pass zeroes `wEnemySwitchMonIndex` rather than naming anybody:
+## the AI's own type-matchup pick, asked without asking whether it wants to
+## switch at all, since the move has already decided that.
+func baton_pass_target(side: int) -> int:
+	if side == ENEMY:
+		return Gen2AISwitch.pick_target(self)
+	return party(side).first_healthy()
+
+
+## `PassedBattleMonEntrance` and the enemy's `EnemySwitch_SetMode`: an entrance
+## that keeps what it is handed.
+##
+## Neither calls `NewBattleMonStatus` or resets the stat levels, which is the
+## only difference from [method send_out] and the only reason Baton Pass exists.
+## The state is captured before the switch and put back after it, so the Pokémon
+## walking back to its ball still loses everything, exactly as it would on the
+## cartridge where none of it was ever its own.
+func baton_pass_send_out(side: int, index: int) -> Array:
+	var passed: Dictionary = mon(side).capture_passed_state()
+	var events: Array = send_out(side, index)
+	if events.is_empty():
+		return events
+	mon(side).apply_passed_state(passed)
+	_reset_baton_pass_status(side)
+	return events
+
+
+## `ResetBatonPassStatus`: the five things a pass does not carry.
+##
+## Nightmare is the odd one and is easy to get backwards. The check runs after
+## the entrance, so the sleep it reads is the *arriving* Pokémon's, not the one
+## that left: a Nightmare survives a pass only into somebody already asleep.
+##
+## Attraction and the wrap counters are cleared on *both* sides, since the
+## Pokémon that was loved or bound is not on the field any more either.
+func _reset_baton_pass_status(side: int) -> void:
+	var arriving: Gen2BattleMon = mon(side)
+	if not Gen2Status.is_asleep(arriving.status):
+		arriving.substatus &= ~Gen2Substatus.NIGHTMARE
+
+	arriving.disabled_slot = -1
+	arriving.disable_turns = 0
+
+	mon(PLAYER).substatus &= ~Gen2Substatus.ATTRACTED
+	mon(ENEMY).substatus &= ~Gen2Substatus.ATTRACTED
+
+	# `SUBSTATUS_TRANSFORMED` goes with these two and has nothing to clear yet.
+	arriving.substatus &= ~Gen2Substatus.ENCORED
+	arriving.encored_slot = -1
+	arriving.encore_turns = 0
+
+	arriving.last_move_used = 0
+
+	for each: int in [PLAYER, ENEMY]:
+		mon(each).trapped_turns = 0
+		mon(each).trapping_move = 0
+
+
 ## Whether [param side] has a move waiting on [method learn_move] or
 ## [method decline_move]: every slot already held something when a level
 ## taught it a new one, so nothing was learned without asking, the same
@@ -962,6 +1065,10 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	var events: Array = []
 	if is_over() or awaiting_replacement() or awaiting_move_learn():
 		return events
+	# A turn already part way through cannot be started again: the one standing
+	# is finished by [method pass_to] and by nothing else.
+	if _pending_baton_pass >= 0:
+		return events
 
 	# Settled before anything is spent, because `TryPlayerSwitch` runs at menu
 	# time: the refusal jumps back to `BattleMenuPKMN_Loop` with no turn taken.
@@ -1013,7 +1120,22 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 
 	var acting: Array = order(chosen, actions)
 	enemy_goes_first = int(acting[0]) == ENEMY
-	for side: int in acting:
+	_pending_turn = {"acting": acting, "actions": actions, "index": 0}
+	return _run_turn(events)
+
+
+## The per-side loop and the end-of-turn tail, run from wherever the turn last
+## stopped. Ordinarily that is the beginning and it runs to the end in one call.
+##
+## Baton Pass is the one thing that stops it part way: the cartridge opens a
+## switch menu inside `DoPlayerTurn` and waits, so the turn is left standing with
+## its remaining half in [member _pending_turn] until [method pass_to] answers.
+func _run_turn(events: Array) -> Array:
+	var acting: Array = _pending_turn["acting"]
+	var actions: Dictionary = _pending_turn["actions"]
+
+	while int(_pending_turn["index"]) < acting.size():
+		var side: int = int(acting[int(_pending_turn["index"])])
 		var action: Dictionary = actions[side]
 		var moving: bool = not (_is_run(action) or _is_switch(action) or _is_item(action))
 		# The faint check is the source's own `HasPlayerFainted`/`HasEnemyFainted`
@@ -1037,8 +1159,14 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 		elif moving:
 			var slot: int = effective_slot(side, int(action.get("slot", 0)))
 			_act(side, slot, move_for(side, slot), events)
+		# The move asked for a Baton Pass target and nothing behind it can happen
+		# until there is one, the bracket around it included.
+		if _pending_baton_pass >= 0:
+			return events
 		_close_turn_bracket(side, action)
+		_pending_turn["index"] = int(_pending_turn["index"]) + 1
 
+	_pending_turn = {}
 	_residual_damage(acting, events)
 	_tick_weather(events)
 	_tick_wrap(events)

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -290,6 +290,40 @@ func reset_stages() -> void:
 		stages[key] = 0
 
 
+## What Baton Pass hands to whoever comes in behind it.
+##
+## On the cartridge none of this is the Pokémon's: `wPlayerSubStatus1` through
+## `5` and every counter beside them are battle-position state, and an ordinary
+## entrance clears them only because `NewBattleMonStatus` says so.
+## `PassedBattleMonEntrance` and `EnemySwitch_SetMode` do not, which is the whole
+## of what Baton Pass is. Here the same state is per-Pokémon, so it is copied
+## across instead, and `ResetBatonPassStatus` then names the few things that do
+## not survive the trip: see [method Gen2Battle._reset_baton_pass_status].
+##
+## The list is exactly [method reset_volatile]'s, plus the stages, which is why
+## the two sit together: a field added to one belongs in the other.
+const PASSED_FIELDS: Array[String] = [
+	"substatus", "confusion_turns", "charged_move", "rollout_count",
+	"rampage_turns", "rampage_move", "toxic_counter", "disabled_slot",
+	"disable_turns", "encored_slot", "encore_turns", "trapped_turns",
+	"trapping_move", "perish_count", "substitute_hp", "turns_taken",
+	"last_move_used", "fury_cutter_count", "protect_count", "minimized",
+]
+
+
+func capture_passed_state() -> Dictionary:
+	var out: Dictionary = {"stages": stages.duplicate()}
+	for key: String in PASSED_FIELDS:
+		out[key] = get(key)
+	return out
+
+
+func apply_passed_state(state: Dictionary) -> void:
+	stages = (state["stages"] as Dictionary).duplicate()
+	for key: String in PASSED_FIELDS:
+		set(key, state[key])
+
+
 ## Clears everything [Gen2Substatus] holds, and the counters that go with it.
 ## Called on a switch, alongside but separately from [method reset_stages]:
 ## Haze resets the stages on both sides without touching either one's

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1559,6 +1559,8 @@ func advance() -> void:
 	## replacement, so the offer is answered first.
 	if _open_move_learn():
 		return
+	if _answer_baton_pass():
+		return
 	if _replace_the_fallen():
 		return
 	if _battle != null and _battle.is_over():
@@ -1687,6 +1689,29 @@ func _prepare_world_battle_recovery() -> bool:
 	_world_battle_recovery = {
 		"ok": true, "source": &"save", "slot": _source_save.slot,
 	}
+	return true
+
+
+## Answers a Baton Pass that stopped the turn, and whether there was one.
+##
+## `ForcePickSwitchMonInBattle` is a menu, and this screen has none, so it takes
+## the first Pokémon standing exactly as [method _replace_the_fallen] does for a
+## faint. The engine keeps the choice open either way; what is missing is a
+## screen to make it with, not the seam.
+##
+## It is answered before a replacement, because a turn left standing here has not
+## finished and nothing behind it can be asked yet.
+func _answer_baton_pass() -> bool:
+	if _battle == null:
+		return false
+	var side: int = _battle.awaiting_baton_pass()
+	if side < 0:
+		return false
+	var next: int = _next_healthy(side)
+	if next < 0:
+		return false
+	_pending = _battle.pass_to(next)
+	_show_next_event()
 	return true
 
 

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -314,6 +314,9 @@ const DESTINY_BOND: StringName = &"destinybond"
 ## Whirlwind and Roar, which switch the side opposite whoever used them.
 const FORCE_SWITCH: StringName = &"forceswitch"
 
+## Baton Pass, which switches the side that used it and hands everything over.
+const BATON_PASS: StringName = &"batonpass"
+
 ## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
 ## moves that carry it end on `SafeguardProtectText`; the six secondary effects
 ## that reach `SafeCheckSafeguard` instead are refused with nothing said, which
@@ -675,6 +678,8 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_destiny_bond(turn)
 		FORCE_SWITCH:
 			_force_switch(turn)
+		BATON_PASS:
+			_baton_pass(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -2694,6 +2699,45 @@ static func _force_switch_wild(turn: Gen2Turn) -> void:
 	var line: StringName = Gen2Battle.FLED_IN_FEAR if turn.move_number == Gen2MoveEffect.ROAR_MOVE \
 		else Gen2Battle.BLOWN_AWAY
 	turn.emit(line, {"target": turn.target})
+
+
+## `BattleCommand_BatonPass`: switch, and hand the new arrival everything the
+## position was carrying.
+##
+## The two halves differ in one thing only, and it is the reason this is the
+## first effect that cannot be resolved in one go. The enemy's target is picked
+## for it, by the same routine that picks an ordinary AI switch. The player's is
+## `ForcePickSwitchMonInBattle`, a menu opened inside the move and impossible to
+## back out of, so the turn stops here and [method Gen2Battle.pass_to] is what
+## finishes it. Committing a target before the turn would be the easy way and the
+## wrong one: a Baton Pass that moves second is picked once the opponent's move
+## has already landed, so the player chooses knowing something an earlier
+## commitment could not.
+##
+## `AnimateCurrentMove` is in front of both, which is why it runs before the
+## question rather than after the answer.
+static func _baton_pass(turn: Gen2Turn) -> void:
+	var battle: Gen2Battle = turn.battle
+	var side: int = turn.side
+
+	# `.Enemy`'s own first line: a wild Pokémon has no party behind it.
+	if side == Gen2Battle.ENEMY and not battle.is_trainer_battle:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+	# `CheckAnyOtherAlivePartyMons`, the same question `.trainer` asks of the
+	# other side before dragging anybody out.
+	if _standing_others(battle.party(side)).is_empty():
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	_animate_current_move(turn)
+
+	if side == Gen2Battle.PLAYER:
+		battle.request_baton_pass(side)
+		return
+	turn.events.append_array(
+		battle.baton_pass_send_out(side, battle.baton_pass_target(side))
+	)
 
 
 ## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -217,6 +217,10 @@ const FORCE_SWITCH: int = 28
 ## itself, so the number is what tells the pair apart.
 const ROAR_MOVE: int = 46
 
+## Baton Pass, the one effect whose player half cannot be resolved inside the
+## turn that started it.
+const BATON_PASS: int = 127
+
 ## `EFFECT_NORMAL_HIT` as a byte rather than [constant NORMAL_HIT]'s list:
 ## `DoSubstituteDamage` stamps it over the move's own once a doll has broken.
 const NORMAL_HIT_EFFECT: int = 0
@@ -827,6 +831,15 @@ const DESTINY_BOND_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.DESTINY_BOND,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Baton Pass: the command is the whole move, and `endmove` behind it does
+## nothing, which is what lets the turn stop inside it and pick up later.
+const BATON_PASS_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.BATON_PASS,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1543,6 +1556,7 @@ static func _sequences() -> Dictionary:
 		ENDURE: ENDURE_SEQUENCE,
 		DESTINY_BOND: DESTINY_BOND_SEQUENCE,
 		FORCE_SWITCH: FORCE_SWITCH_SEQUENCE,
+		BATON_PASS: BATON_PASS_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -160,6 +160,9 @@ const ENDURE: int = 203
 const WHIRLWIND: int = 18
 const ROAR: int = 46
 
+## Baton Pass, at its real number for company: nothing about it reads the number.
+const BATON_PASS: int = 226
+
 ## Rollout, its Defense Curl partner and the three rampage moves keep their real
 ## move numbers so the state can be forced through the same number-based path as
 ## the cartridge.
@@ -564,6 +567,7 @@ static func _moves() -> Array:
 		],
 		WHIRLWIND: ["WHIRLWIND", 0, NORMAL, 255, 20, Gen2MoveEffect.FORCE_SWITCH, 0],
 		ROAR: ["ROAR", 0, NORMAL, 255, 20, Gen2MoveEffect.FORCE_SWITCH, 0],
+		BATON_PASS: ["BATON PASS", 0, NORMAL, 255, 40, Gen2MoveEffect.BATON_PASS, 0],
 		# Thunder with a paralysis chance the roll cannot fail, so the secondary
 		# behind its own effect can be seen without a seed. The accuracy byte is
 		# still the real 178, since that is what the weather rewrites.

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3355,3 +3355,193 @@ func test_a_switch_breaks_attraction_on_both_sides() -> void:
 		Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED),
 		"the side that did not switch loses it too"
 	)
+
+
+## Baton Pass, which is the first move that hands the Pokemon behind it
+## everything the position was carrying, and the first that can stop a turn part
+## way through.
+func _pass_party(moves: Array) -> Gen2Battle:
+	return _party_battle(
+		[_mon(Fixture.PIKACHU, 50, moves), _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+
+
+func test_a_players_baton_pass_stops_the_turn_until_it_is_answered() -> void:
+	var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS])
+	var opened: Array = battle.take_turn(0, 0)
+
+	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0, "nobody has come in yet")
+	assert_eq(
+		_of_type(opened, Gen2Battle.HIT).size(), 0,
+		"and the enemy has not moved either: %s" % JSON.stringify(opened)
+	)
+
+	assert_eq(
+		battle.take_turn(0, 0), [] as Array,
+		"a turn already standing cannot be started again"
+	)
+
+	var finished: Array = battle.pass_to(1)
+	assert_eq(battle.awaiting_baton_pass(), -1)
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1)
+	assert_eq(_of_type(finished, Gen2Battle.SENT_OUT).size(), 1)
+	assert_eq(
+		_of_type(finished, Gen2Battle.HIT).size(), 1,
+		"the rest of the turn ran once it was answered: %s" % JSON.stringify(finished)
+	)
+
+
+## `ForcePickSwitchMonInBattle` redisplays its list rather than taking somebody
+## who cannot come in, so a refused answer leaves the question standing.
+func test_a_refused_baton_pass_target_leaves_the_question_standing() -> void:
+	var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS])
+	battle.take_turn(0, 0)
+
+	var bench: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	bench.take_damage(bench.max_hp())
+	assert_eq(battle.pass_to(1), [] as Array, "a fainted target")
+	assert_eq(battle.pass_to(0), [] as Array, "the Pokemon already out")
+	assert_eq(battle.pass_to(9), [] as Array, "nobody at all")
+	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
+
+
+## The stat stages are the point of the move, and they are position state on the
+## cartridge rather than the Pokemon's, so they move across and the Pokemon that
+## left keeps none of them.
+func test_a_pass_carries_the_stages_and_leaves_the_passer_with_none() -> void:
+	var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS])
+	var passer: Gen2BattleMon = battle.player
+	passer.stages["attack"] = 4
+	passer.stages["speed"] = -2
+	battle.take_turn(0, 0)
+	battle.pass_to(1)
+
+	assert_eq(battle.player.stage("attack"), 4, "the newcomer is handed them")
+	assert_eq(battle.player.stage("speed"), -2)
+	assert_eq(passer.stage("attack"), 0, "and the passer keeps nothing")
+
+
+## So do the substatus flags and the counters beside them: a doll, a seed and a
+## perish count all survive the switch that would ordinarily end them.
+func test_a_pass_carries_the_doll_the_seed_and_the_perish_count() -> void:
+	var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS])
+	var passer: Gen2BattleMon = battle.player
+	passer.substatus |= (
+		Gen2Substatus.SUBSTITUTE | Gen2Substatus.LEECH_SEED | Gen2Substatus.PERISH
+	)
+	# A doll big enough to survive the Tackle that lands behind the pass, since
+	# the enemy still gets its move once the turn resumes.
+	passer.substitute_hp = 250
+	passer.perish_count = 2
+	battle.take_turn(0, 0)
+	battle.pass_to(1)
+
+	var arriving: Gen2BattleMon = battle.player
+	assert_true(Gen2Substatus.has(arriving.substatus, Gen2Substatus.SUBSTITUTE))
+	assert_lt(arriving.substitute_hp, 250, "the doll took the Tackle behind the pass")
+	assert_gt(arriving.substitute_hp, 0, "and survived it")
+	assert_true(Gen2Substatus.has(arriving.substatus, Gen2Substatus.LEECH_SEED))
+	# The count carried and then the end-of-turn tick spent one of it, which is
+	# what a count that did not carry could never do: a fresh Pokemon has none.
+	assert_true(Gen2Substatus.has(arriving.substatus, Gen2Substatus.PERISH))
+	assert_eq(arriving.perish_count, 1)
+
+
+## `ResetBatonPassStatus` names what does not survive: Disable, Encore, the last
+## move used, attraction on both sides and both wrap counters.
+func test_a_pass_drops_what_reset_baton_pass_status_names() -> void:
+	# Baton Pass is in slot 0, so the disabled slot has to be the other one:
+	# a disabled slot 0 would answer Struggle and never reach the pass at all.
+	var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS, Fixture.TACKLE])
+	var passer: Gen2BattleMon = battle.player
+	passer.disabled_slot = 1
+	passer.disable_turns = 3
+	passer.substatus |= Gen2Substatus.ENCORED
+	passer.encored_slot = 0
+	passer.encore_turns = 2
+	passer.last_move_used = Fixture.TACKLE
+	passer.trapped_turns = 3
+	battle.enemy.trapped_turns = 3
+	battle.take_turn(0, 0)
+	battle.pass_to(1)
+
+	var arriving: Gen2BattleMon = battle.player
+	assert_eq(arriving.disabled_slot, -1)
+	assert_eq(arriving.disable_turns, 0)
+	assert_false(Gen2Substatus.has(arriving.substatus, Gen2Substatus.ENCORED))
+	assert_eq(arriving.encored_slot, -1)
+	assert_eq(arriving.last_move_used, 0)
+	assert_eq(arriving.trapped_turns, 0)
+	assert_eq(battle.enemy.trapped_turns, 0, "the wrap counters go on both sides")
+
+
+## Attraction goes with them, on both sides, and is asked of the entrance
+## directly: an attracted passer has a coin flip in front of its own move, and
+## `ResetBatonPassStatus` is what this is about rather than `CheckTurn`.
+func test_a_pass_breaks_attraction_on_both_sides() -> void:
+	var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS])
+	battle.player.substatus |= Gen2Substatus.ATTRACTED
+	battle.enemy.substatus |= Gen2Substatus.ATTRACTED
+	battle.baton_pass_send_out(Gen2Battle.PLAYER, 1)
+
+	assert_false(
+		Gen2Substatus.has(battle.player.substatus, Gen2Substatus.ATTRACTED),
+		"the arriving Pokemon is not handed the passer's"
+	)
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED))
+
+
+## Nightmare is the one that reads the *arriving* Pokemon, because
+## `ResetBatonPassStatus` runs behind the entrance: it survives a pass only into
+## somebody already asleep.
+func test_a_nightmare_survives_a_pass_only_into_a_sleeping_pokemon() -> void:
+	for asleep: bool in [false, true]:
+		var battle: Gen2Battle = _pass_party([Fixture.BATON_PASS])
+		battle.player.substatus |= Gen2Substatus.NIGHTMARE
+		if asleep:
+			battle.party(Gen2Battle.PLAYER).at(1).status = 3
+		battle.take_turn(0, 0)
+		battle.pass_to(1)
+
+		assert_eq(
+			Gen2Substatus.has(battle.player.substatus, Gen2Substatus.NIGHTMARE), asleep,
+			"arriving asleep: %s" % asleep
+		)
+
+
+## The enemy's half needs no answer at all: its target is picked for it, so the
+## turn runs straight through.
+func test_an_enemy_baton_pass_resolves_inside_the_turn() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])),
+		Gen2Party.create([
+			_mon(Fixture.GEODUDE, 50, [Fixture.BATON_PASS]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		]), _rng, true
+	)
+	battle.enemy.stages["defense"] = 3
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_eq(battle.awaiting_baton_pass(), -1, "nothing was asked")
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+	assert_eq(battle.enemy.stage("defense"), 3, "and the stages went with it")
+	assert_false(_first(events, Gen2Battle.SENT_OUT).is_empty())
+
+
+## A wild Pokemon has no party behind it, and neither has a lone one.
+func test_a_baton_pass_with_nobody_behind_it_fails() -> void:
+	var wild: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.BATON_PASS])
+	)
+	assert_eq(_of_type(wild.take_turn(0, 0), Gen2Battle.MOVE_FAILED).size(), 1)
+	assert_eq(wild.awaiting_baton_pass(), -1)
+
+	var lone: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.BATON_PASS]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	assert_eq(_of_type(lone.take_turn(0, 0), Gen2Battle.MOVE_FAILED).size(), 1)
+	assert_eq(lone.awaiting_baton_pass(), -1, "and no question was asked")


### PR DESCRIPTION
Baton Pass: one effect byte over one move, leaving 20 bytes over 21. It is the first move that hands anything over and the first that can stop a turn part way through, and both follow from the same fact about the cartridge. Nothing in the five substatus bytes or the counters beside them belongs to a Pokemon; it belongs to the position, and an ordinary entrance clears it only because NewBattleMonStatus says so. The two entrances a pass uses do not call it. Here that state is per-Pokemon, so it is copied across and the Pokemon walking back to its ball still loses everything, which is the same outcome by a different route. ResetBatonPassStatus names what does not survive: Disable, Encore, the last move used, and attraction and both wrap counters on both sides. Nightmare is the odd one, since its check runs behind the entrance and so reads the arriving Pokemon's sleep rather than the passer's.

The player's half is why take_actions can now stop and resume. The cartridge opens a switch menu inside the move and waits on it, so the rest of the turn is left standing until pass_to answers, which awaiting_baton_pass is how a caller asks. Committing a target before the turn would have been simpler and wrong: a pass that moves second is picked once the opponent's move has already landed, so the player chooses knowing something an earlier commitment could not. The enemy's half needs none of that, since wEnemySwitchMonIndex is zeroed rather than named and the AI's own type-matchup pick answers.

The battle screen takes the first Pokemon standing, exactly as it already does for a replacement it has no menu for either. The engine keeps the choice open; what is missing is a screen to make it with, not the seam.