### PR TITLE
Take an item, split the pain, and set the whole party on one foe

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -192,6 +192,33 @@ static func choose_slot(
 	has_bench: bool = false,
 	matchup_score: int = Gen2AISwitch.BASE_SCORE
 ) -> int:
+	return _pick_lowest(
+		score_slots(
+			attacker, defender, data, ai_move_weights, rng,
+			attacker_turns_taken, defender_turns_taken, weather,
+			attacker_screens, defender_screens, has_bench, matchup_score
+		),
+		attacker, rng
+	)
+
+
+## What every layer named in [param ai_move_weights] leaves each of the four slots
+## at, before the argmin. The same arguments [method choose_slot] takes, and the
+## half of it a single handler can be read off.
+static func score_slots(
+	attacker: Gen2BattleMon,
+	defender: Gen2BattleMon,
+	data: GameData,
+	ai_move_weights: int,
+	rng: RandomNumberGenerator,
+	attacker_turns_taken: int = 0,
+	defender_turns_taken: int = 0,
+	weather: int = Gen2Weather.NONE,
+	attacker_screens: int = Gen2Screens.NONE,
+	defender_screens: int = Gen2Screens.NONE,
+	has_bench: bool = false,
+	matchup_score: int = Gen2AISwitch.BASE_SCORE
+) -> Array:
 	var scores: Array = []
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		scores.append(DEFAULT_SCORE if attacker.can_use(slot) else UNUSABLE_SCORE)
@@ -257,7 +284,7 @@ static func choose_slot(
 			attacker_screens, defender_screens, has_bench, matchup_score
 		)
 
-	return _pick_lowest(scores, attacker, rng)
+	return scores
 
 
 static func _pick_lowest(scores: Array, attacker: Gen2BattleMon, rng: RandomNumberGenerator) -> int:
@@ -320,7 +347,18 @@ static func _faster(a: Gen2BattleMon, b: Gen2BattleMon) -> bool:
 ## True with roughly [param percent] chance, the cartridge's own "X percent"
 ## macro: a threshold out of 255, truncated.
 static func _roll(rng: RandomNumberGenerator, percent: int) -> bool:
-	return rng.randi_range(0, 255) < percent * 255 / 100
+	return _rolls_under(rng, percent * 255 / 100)
+
+
+## The same roll against a threshold written out rather than as a percentage.
+## `39 percent + 1` is a macro result with a byte added to it, which no percentage
+## reproduces, so the sites that use it name the number.
+static func _rolls_under(rng: RandomNumberGenerator, threshold: int) -> bool:
+	return rng.randi_range(0, 255) < threshold
+
+
+## `39 percent + 1`, which is 100. Five `AI_Smart` branches roll against it.
+const AI_39_PERCENT_PLUS_ONE: int = 100
 
 
 ## [code]AI_50_50[/code] and [code]AI_80_20[/code]: named for the "do nothing"
@@ -342,8 +380,8 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 ## reason; Leech Seed, Nightmare and Spikes read the target.
 ##
 ## `AI_Redundant`'s rows for the effects this engine does not carry yet
-## (Transform, Sleep Talk, Foresight, Teleport, Future Sight) are the remainder,
-## and read as "not redundant" because no move here reaches them.
+## (Transform, Sleep Talk, Future Sight) are the remainder, and read as "not
+## redundant" because no move here reaches them.
 static func _apply_basic(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
 	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
@@ -403,6 +441,12 @@ static func _apply_basic(
 		elif effect == Gen2MoveEffect.SPIKES:
 			# `.Spikes` reads `wPlayerScreens`, the side they would land on.
 			redundant = Gen2Screens.has(defender_screens, Gen2Screens.SPIKES)
+		elif effect == Gen2MoveEffect.FORESIGHT:
+			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
+		elif effect == Gen2MoveEffect.TELEPORT:
+			# `.Teleport` is a label on `.Redundant` itself, so it is redundant
+			# unconditionally: a trainer's Pokémon is refused by the move anyway.
+			redundant = true
 		elif WEATHER_FOR_EFFECT.has(effect):
 			redundant = weather == int(WEATHER_FOR_EFFECT[effect])
 		if redundant:
@@ -461,7 +505,13 @@ static func _apply_types(
 			continue
 		var move: Dictionary = _move_at(attacker, data, slot)
 		var move_type: int = int(move.get("type", RomLayout.TYPE_NORMAL))
-		var effectiveness: int = data.type_effectiveness(move_type, defender.types())
+		# `AI_Types` sets `hBattleTurn` to the enemy before every
+		# `BattleCheckTypeMatchup`, so the Foresight flag it reads is the player's:
+		# the defender's from the side doing the scoring.
+		var effectiveness: int = data.type_effectiveness(
+			move_type, defender.types(),
+			Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
+		)
 
 		if effectiveness == RomLayout.MATCHUP_NO_EFFECT:
 			_discourage(scores, slot)
@@ -573,6 +623,18 @@ static func _apply_smart(
 				_smart_heal(scores, slot, attacker, rng)
 			Gen2MoveEffect.PERISH_SONG:
 				_smart_perish_song(scores, slot, defender, rng, has_bench, matchup_score)
+			Gen2MoveEffect.PAIN_SPLIT:
+				_smart_pain_split(scores, slot, attacker, defender)
+			Gen2MoveEffect.LOCK_ON:
+				_smart_lock_on(scores, slot, attacker, defender, data, rng)
+			Gen2MoveEffect.SPITE:
+				_smart_spite(scores, slot, attacker, defender, rng)
+			Gen2MoveEffect.THIEF:
+				_discourage(scores, slot, THIEF_PENALTY)
+			Gen2MoveEffect.FORESIGHT:
+				_smart_foresight(scores, slot, attacker, defender, rng)
+			Gen2MoveEffect.PURSUIT:
+				_smart_pursuit(scores, slot, defender, rng)
 
 
 ## `AI_Smart_Solarbeam`: 80% to encourage it greatly in sun, where it needs no
@@ -669,9 +731,9 @@ static func _good_weather_type(
 ## against one that is losing health anyway or has only just come out, provided
 ## the user has enough left to hold it there.
 ##
-## Two of the five states the cartridge encourages on are missing, because
-## neither exists here yet: `SUBSTATUS_IDENTIFIED` (Foresight) and
-## `SUBSTATUS_NIGHTMARE`. The other three are Toxic, Attract and Rollout.
+## The five states it encourages on are Toxic and the four bits
+## `and 1 << SUBSTATUS_IN_LOVE | 1 << SUBSTATUS_ROLLOUT | 1 << SUBSTATUS_IDENTIFIED
+## | 1 << SUBSTATUS_NIGHTMARE` tests in one instruction.
 static func _smart_trap_target(
 	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
 	def_turns: int, rng: RandomNumberGenerator
@@ -679,7 +741,9 @@ static func _smart_trap_target(
 	var worth_it: bool = defender.trapped_turns <= 0 and (
 		defender.toxic_counter > 0
 		or Gen2Substatus.has(
-			defender.substatus, Gen2Substatus.ATTRACTED | Gen2Substatus.ROLLOUT
+			defender.substatus,
+			Gen2Substatus.ATTRACTED | Gen2Substatus.ROLLOUT
+			| Gen2Substatus.IDENTIFIED | Gen2Substatus.NIGHTMARE
 		)
 		or def_turns == 0
 	)
@@ -809,21 +873,199 @@ static func _smart_perish_song(
 	_discourage(scores, slot, 1)
 
 
+## `AI_Smart_PainSplit`: pointless while the enemy is the healthier of the two,
+## which is `enemy hp * 2 > player hp` rather than a comparison of fractions.
+static func _smart_pain_split(
+	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon
+) -> void:
+	if attacker.hp * 2 > defender.hp:
+		_discourage(scores, slot, 1)
+
+
+## `AI_Smart_LockOn`, whose two halves ask opposite questions.
+##
+## With the player already locked on, aiming again is wasted: every inaccurate
+## move the enemy knows is encouraged instead, and Lock On itself is dismissed.
+## The walk stops at the first empty slot, which is `.dismiss`.
+##
+## Without it, the ladder is health, then speed, then whether the accuracy is
+## actually a problem: a sharply raised evasion or a sharply lowered accuracy is
+## worth aiming for, a mild one is not worth a turn, and past both it comes down
+## to whether any move in the list is inaccurate enough to want the help and at
+## least neutral against the target.
+static func _smart_lock_on(
+	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
+	data: GameData, rng: RandomNumberGenerator
+) -> void:
+	if Gen2Substatus.has(defender.substatus, Gen2Substatus.LOCK_ON):
+		for other: int in Gen2BattleMon.MAX_MOVES:
+			if other >= attacker.moves.size() or int(attacker.moves[other]) == 0:
+				break
+			var known: Dictionary = _move_at(attacker, data, other)
+			if int(known.get("accuracy", Gen2Accuracy.ALWAYS_HITS)) < LOCK_ON_WANTED_ACCURACY:
+				_encourage(scores, other, 2)
+		_discourage(scores, slot)
+		return
+
+	if not _above_quarter(attacker):
+		_discourage(scores, slot, 1)
+		return
+	if not _above_half(attacker) and not _faster(attacker, defender):
+		_discourage(scores, slot, 1)
+		return
+
+	# `.skip_speed_check`'s ladder, in its order: the first test that matches wins.
+	var evasion: int = defender.stage("evasion")
+	var accuracy: int = attacker.stage("accuracy")
+	var wanted: bool = evasion >= 3
+	if not wanted:
+		if evasion >= 1:
+			return
+		wanted = accuracy < -2
+	if not wanted:
+		if accuracy < 0:
+			return
+		if _lock_on_has_wanting_move(attacker, defender, data):
+			return
+		_discourage(scores, slot, 1)
+		return
+
+	if _skip_50_50(rng):
+		return
+	_encourage(scores, slot, 2)
+
+
+## `.checkmove`: whether any move in the list is inaccurate enough to want the
+## help and at least neutral against the target. Everything accurate is passed
+## over, and running out of slots, or reaching an empty one, answers no.
+static func _lock_on_has_wanting_move(
+	attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData
+) -> bool:
+	for slot: int in Gen2BattleMon.MAX_MOVES:
+		if slot >= attacker.moves.size() or int(attacker.moves[slot]) == 0:
+			return false
+		var move: Dictionary = _move_at(attacker, data, slot)
+		if int(move.get("accuracy", Gen2Accuracy.ALWAYS_HITS)) >= LOCK_ON_WANTED_ACCURACY:
+			continue
+		if data.type_effectiveness(
+			int(move.get("type", RomLayout.TYPE_NORMAL)), defender.types(),
+			Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
+		) >= RomLayout.MATCHUP_EFFECTIVE:
+			return true
+	return false
+
+
+## `cp 71 percent - 1`, which is 180: the accuracy byte at or above which a move
+## does not need the help.
+const LOCK_ON_WANTED_ACCURACY: int = 180
+
+
+## `AI_Smart_Spite`: worth it against a move the target is nearly out of, wasted
+## against one it has plenty of.
+##
+## The target has not moved yet in the first branch, so there is nothing to drain
+## and the question is only whether the enemy would get to see a move first.
+static func _smart_spite(
+	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
+	rng: RandomNumberGenerator
+) -> void:
+	var last_move: int = defender.last_move_used
+	if last_move == 0:
+		if _faster(attacker, defender):
+			_discourage(scores, slot)
+			return
+		if _skip_50_50(rng):
+			return
+		_discourage(scores, slot, 1)
+		return
+
+	# `.moveloop`, which walks the target's own list and returns without scoring
+	# when the move is not in it.
+	var drained: int = defender.moves.find(last_move)
+	if drained < 0:
+		return
+
+	var left: int = defender.pp_left(drained)
+	if left < SPITE_WANTED_PP:
+		if _rolls_under(rng, AI_39_PERCENT_PLUS_ONE):
+			return
+		_encourage(scores, slot, 2)
+		return
+	if left < SPITE_PLENTY_PP and not _rolls_under(rng, AI_39_PERCENT_PLUS_ONE):
+		return
+	_discourage(scores, slot, 1)
+
+
+## `cp 6` and `cp 15`: below the first is worth draining, at or above the second
+## is not, and between them a roll decides.
+const SPITE_WANTED_PP: int = 6
+const SPITE_PLENTY_PP: int = 15
+
+
+## `AI_Smart_Thief`: `add $1e`, and nothing else. Thirty points is past every
+## other move on the list, so Thief is thrown only when there is nothing else.
+const THIEF_PENALTY: int = 30
+
+
+## `AI_Smart_Foresight`: worth it against a sharply raised evasion, a sharply
+## lowered accuracy of its own, or a Ghost, which is the only target the flag
+## opens a type matchup against. Otherwise almost always discouraged.
+static func _smart_foresight(
+	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
+	rng: RandomNumberGenerator
+) -> void:
+	var wanted: bool = attacker.stage("accuracy") < -2 \
+		or defender.stage("evasion") >= 3 \
+		or defender.types().has(RomLayout.TYPE_GHOST)
+	if not wanted:
+		if _roll(rng, FORESIGHT_DISCOURAGE_SKIP_PERCENT):
+			return
+		_discourage(scores, slot, 1)
+		return
+
+	if _rolls_under(rng, AI_39_PERCENT_PLUS_ONE):
+		return
+	_encourage(scores, slot, 2)
+
+
+## `cp 8 percent; ret c`: the one-in-twelve chance the penalty is not applied, the
+## same roll [constant PROTECT_DISCOURAGE_SKIP_PERCENT] names.
+const FORESIGHT_DISCOURAGE_SKIP_PERCENT: int = 8
+
+
+## `AI_Smart_Pursuit`: worth two points against a target nearly down, discouraged
+## against one that is not, since a Pokémon with health left is unlikely to run.
+static func _smart_pursuit(
+	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator
+) -> void:
+	if not _above_quarter(defender):
+		if _skip_50_50(rng):
+			return
+		_encourage(scores, slot, 2)
+		return
+	if _skip_80_20(rng):
+		return
+	_discourage(scores, slot, 1)
+
+
 ## `AI_Smart_Protect`: one ladder of tests, first match winning, and the two exits
 ## are asymmetric. `.encourage` is an 80% roll and one point off; `.discourage` is
 ## a two-point penalty that an 8% roll skips outright, and `.greatly_discourage`
 ## adds a point and falls into it, so the worst case is three.
 ##
-## The source's second test, a player that has locked on, is missing here and only
-## here: `SUBSTATUS_LOCK_ON` does not exist yet, since `EFFECT_LOCK_ON` is
-## unwritten. Its branch would `.discourage`, so the omission can only make the
-## enemy readier to protect, never less ready.
 static func _smart_protect(
 	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
 	rng: RandomNumberGenerator
 ) -> void:
 	if attacker.protect_count != 0:
 		_smart_protect_discourage(scores, slot, rng, true)
+		return
+
+	# The second test reads `wPlayerSubStatus5`, the flag a Lock On the enemy used
+	# left on the player: with a guaranteed hit already lined up, sitting the turn
+	# out wastes it.
+	if Gen2Substatus.has(defender.substatus, Gen2Substatus.LOCK_ON):
+		_smart_protect_discourage(scores, slot, rng, false)
 		return
 
 	var encourage: bool = defender.fury_cutter_count >= PROTECT_FURY_CUTTER_COUNT \
@@ -872,8 +1114,10 @@ const PROTECT_DISCOURAGE_SKIP_PERCENT: int = 8
 ##
 ## Reversal is looked for by effect rather than by move number, which is
 ## `AIHasMoveEffect`, and Flail carries the same byte, so either move answers.
-## The source's last branch, an enemy that has locked on, is absent for the same
-## reason [method _smart_protect]'s is.
+##
+## `.no_reversal` is the other reason: `wEnemySubStatus5`, the flag a Lock On the
+## *player* used left on the enemy. A guaranteed incoming hit is exactly what
+## surviving on one point is for.
 static func _smart_endure(
 	scores: Array, slot: int, attacker: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator
@@ -885,6 +1129,11 @@ static func _smart_endure(
 		_discourage(scores, slot, 1)
 		return
 	if not _has_move_effect(attacker, data, Gen2MoveEffect.REVERSAL):
+		if not Gen2Substatus.has(attacker.substatus, Gen2Substatus.LOCK_ON):
+			return
+		if _skip_50_50(rng):
+			return
+		_encourage(scores, slot, 2)
 		return
 	if _skip_80_20(rng):
 		return

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -197,6 +197,34 @@ const DRAGGED_OUT: StringName = &"dragged_out"
 const FLED_IN_FEAR: StringName = &"fled_in_fear"
 const BLOWN_AWAY: StringName = &"blown_away"
 
+## `FledFromBattleText`: Teleport, which takes its own user out rather than the
+## other side. Named for `<USER>`, so [code]side[/code] is who left.
+const FLED_FROM_BATTLE: StringName = &"fled_from_battle"
+
+## Foresight and Lock On, whose flags sit on [code]target[/code] rather than on
+## the Pokémon that used the move. `TookAimText` names only the aimer, which is
+## why [constant TOOK_AIM] carries nothing beyond the side.
+const IDENTIFIED_SET: StringName = &"identified_set"
+const TOOK_AIM: StringName = &"took_aim"
+
+## Spite, carrying the [code]slot[/code] drained, the [code]move[/code] in it and
+## the [code]amount[/code] taken, which is the number `SpiteEffectText` prints.
+const PP_REDUCED: StringName = &"pp_reduced"
+
+## Pain Split, which names neither Pokémon. Both sides' health is on the event
+## because both moved: [code]hp[/code] is the user's and [code]target_hp[/code] the
+## other's.
+const SHARED_PAIN: StringName = &"shared_pain"
+
+## Thief, carrying the [code]item[/code] that moved. `StoleText` names the thief
+## and the item and calls the loser "its foe", so nothing else is needed.
+const STOLE_ITEM: StringName = &"stole_item"
+
+## `BeatUpAttackText`, once per party member Beat Up sends in. [code]index[/code]
+## is that member's party slot, or -1 for a wild Pokémon, which has no party and
+## swings once as itself.
+const BEAT_UP_ATTACK: StringName = &"beat_up_attack"
+
 ## Rain Dance, Sunny Day and Sandstorm. [code]weather[/code] on all four is the
 ## [Gen2Weather] value, so a screen names it without being told twice.
 ## [constant WEATHER_CONTINUES] is the line printed on every turn the weather
@@ -497,6 +525,12 @@ var _pending_turn: Dictionary = {}
 ## menu the player cannot back out of, so this is answered rather than optional
 ## and everything else is refused until it is.
 var _pending_baton_pass: int = -1
+
+## The side whose Pursuit already ran, in front of the switch it answered, or -1.
+## `PursuitSwitch` writes `CANNOT_MOVE` over that side's move once it has, and
+## `CheckTurn` reads the byte back and ends the turn, so the action it would have
+## taken later this turn is spent.
+var _pursuit_spent: int = -1
 
 ## The two sides, keyed by [constant PLAYER] and [constant ENEMY].
 var parties: Dictionary = {}
@@ -1120,6 +1154,7 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 
 	var acting: Array = order(chosen, actions)
 	enemy_goes_first = int(acting[0]) == ENEMY
+	_pursuit_spent = -1
 	_pending_turn = {"acting": acting, "actions": actions, "index": 0}
 	return _run_turn(events)
 
@@ -1153,10 +1188,11 @@ func _run_turn(events: Array) -> Array:
 			# effect, so both counters go.
 			_reset_action_counters(side, -1)
 		if _is_switch(action):
+			_pursuit_before_switch(side, actions, events)
 			events.append_array(send_out(side, int(action.get("index", -1))))
 		elif _is_item(action):
 			_use_trainer_item(side, int(action.get("item", 0)), events)
-		elif moving:
+		elif moving and side != _pursuit_spent:
 			var slot: int = effective_slot(side, int(action.get("slot", 0)))
 			_act(side, slot, move_for(side, slot), events)
 		# The move asked for a Baton Pass target and nothing behind it can happen
@@ -1164,6 +1200,14 @@ func _run_turn(events: Array) -> Array:
 		if _pending_baton_pass >= 0:
 			return events
 		_close_turn_bracket(side, action)
+		# `ld a, [wForcedSwitch] / and a / ret nz`, which `Battle_PlayerFirst` and
+		# `Battle_EnemyFirst` each ask twice, behind each side's own wrapper. A
+		# Pokémon blown or teleported out of a wild battle ends the turn where it
+		# stands: no second move, and none of the end-of-turn tail below.
+		if was_forced_out():
+			_pending_turn = {}
+			events.append({"type": OVER, "winner": winner()})
+			return events
 		_pending_turn["index"] = int(_pending_turn["index"]) + 1
 
 	_pending_turn = {}
@@ -1178,6 +1222,51 @@ func _run_turn(events: Array) -> Array:
 	if is_over():
 		events.append({"type": OVER, "winner": winner()})
 	return events
+
+
+## `wPlayerIsSwitching` and `wEnemyIsSwitching`: whether [param side] is recalling
+## a Pokémon this turn. Both are zeroed at the top of `BattleTurn`, which is what
+## rebuilding [member _pending_turn] every turn already does.
+##
+## An enemy item is not a switch here even though [method order] treats it as one
+## for ordering: `AI_TryItem` sets no flag, only `AI_Switch` does, and
+## [method Gen2EffectCommands._pursuit] is the reader.
+func is_switching(side: int) -> bool:
+	if _pending_turn.is_empty():
+		return false
+	var actions: Dictionary = _pending_turn["actions"]
+	return _is_switch(actions.get(side, {}))
+
+
+## `PursuitSwitch`, which the cartridge calls from `BattleMonEntrance` and from
+## `AI_Switch`, both in front of the recall: a side that chose Pursuit takes its
+## whole turn now, against the Pokémon on its way out, and then has nothing left
+## to spend later in the turn.
+##
+## No speed or priority test. The switch is settled first whatever the speeds, so
+## the pursuer always gets the early hit; `EFFECT_PURSUIT` carries no priority
+## entry and does not need one.
+##
+## The effect byte is read here rather than inside a command because the trigger
+## belongs to the byte rather than to the list, the same way
+## [constant EFFECT_PRIORITIES] reads bytes from outside every list.
+##
+## Called from a chosen switch only. The cartridge's two call sites are the two
+## entrances a switch action reaches; `PassedBattleMonEntrance`,
+## `PlayerPartyMonEntrance` and `ForcePlayerMonChoice` call neither, so a Baton
+## Pass and a post-faint replacement are not pursued.
+func _pursuit_before_switch(side: int, actions: Dictionary, events: Array) -> void:
+	var other: int = opponent_of(side)
+	var action: Dictionary = actions.get(other, {})
+	if _is_switch(action) or _is_run(action) or _is_item(action):
+		return
+	var slot: int = effective_slot(other, int(action.get("slot", 0)))
+	var move_number: int = move_for(other, slot)
+	if int(data.move(move_number).get("effect", -1)) != Gen2MoveEffect.PURSUIT:
+		return
+
+	_act(other, slot, move_number, events)
+	_pursuit_spent = other
 
 
 ## `CheckOpponentWentFirst`, which is `wEnemyGoesFirst XOR hBattleTurn`: whether

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2046,6 +2046,31 @@ func _describe(event: Dictionary) -> String:
 			return "%s fled in fear!" % _battler_name(int(event["target"]))
 		Gen2Battle.BLOWN_AWAY:
 			return "%s was blown away!" % _battler_name(int(event["target"]))
+		Gen2Battle.FLED_FROM_BATTLE:
+			return "%s fled from battle!" % _battler_name(side)
+		Gen2Battle.IDENTIFIED_SET:
+			return "%s identified %s!" % [
+				_battler_name(side), _battler_name(int(event["target"])),
+			]
+		Gen2Battle.TOOK_AIM:
+			return "%s took aim!" % _battler_name(side)
+		Gen2Battle.PP_REDUCED:
+			return "%s's %s was reduced by %d!" % [
+				_battler_name(int(event["target"])),
+				String(_data.move(int(event["move"])).get("name", "")),
+				int(event["amount"]),
+			]
+		Gen2Battle.SHARED_PAIN:
+			# SharedPainText names neither Pokemon, since both were levelled.
+			return "The battlers shared pain!"
+		Gen2Battle.STOLE_ITEM:
+			return "%s stole %s from its foe!" % [
+				_battler_name(side), _data.item_name(int(event["item"])),
+			]
+		Gen2Battle.BEAT_UP_ATTACK:
+			# BeatUpAttackText names the party member that is swinging, which is
+			# only sometimes the Pokemon on the field.
+			return "%s's attack!" % _name_of(int(event["species"]))
 		Gen2Battle.TRAPPED:
 			return _trapped_text(event)
 		Gen2Battle.HURT_BY_TRAP:

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -74,14 +74,15 @@ static func calculate(
 	focus_energy: bool = false,
 	defense_halved: bool = false,
 	weather: int = Gen2Weather.NONE,
-	defender_screens: int = Gen2Screens.NONE
+	defender_screens: int = Gen2Screens.NONE,
+	foresight: bool = false
 ) -> Dictionary:
 	var scope_lens: bool = attacker != null \
 		and Gen2HeldItem.effect_of(attacker.data, attacker.item) == Gen2HeldItem.CRITICAL_UP
 	return calculate_with(
 		attacker, defender, move,
 		roll_critical(move, rng, focus_energy, scope_lens),
-		roll_variation(rng), defense_halved, weather, defender_screens
+		roll_variation(rng), defense_halved, weather, defender_screens, foresight
 	)
 
 
@@ -109,7 +110,8 @@ static func calculate_with(
 	variation: int,
 	defense_halved: bool = false,
 	weather: int = Gen2Weather.NONE,
-	defender_screens: int = Gen2Screens.NONE
+	defender_screens: int = Gen2Screens.NONE,
+	foresight: bool = false
 ) -> Dictionary:
 	var out: Dictionary = {
 		"damage": 0, "critical": critical, "effectiveness": RomLayout.MATCHUP_EFFECTIVE,
@@ -127,7 +129,9 @@ static func calculate_with(
 		defense_halved, move_type, critical
 	)
 
-	var stabbed: Dictionary = stab_damage(attacker, defender, move, damage, weather)
+	var stabbed: Dictionary = stab_damage(
+		attacker, defender, move, damage, weather, foresight
+	)
 	out["stab"] = stabbed["stab"]
 	out["immune"] = stabbed["immune"]
 	out["effectiveness"] = stabbed["effectiveness"]
@@ -168,6 +172,11 @@ static func damage_stats(
 ## than with the minimum two. `EFFECT_MULTI_HIT` and `EFFECT_CONVERSION` are the
 ## two the source lets past that check, because both can carry a power of zero
 ## and have it filled in by the time this runs.
+##
+## [param level] is the level the formula multiplies, or -1 for the attacker's
+## own. `BattleCommand_BeatUp` is the one caller that needs the parameter: it
+## loads `e` with a party member's level rather than the level of whoever is on
+## the field.
 static func damage_calc(
 	attacker: Gen2BattleMon,
 	power: int,
@@ -175,7 +184,8 @@ static func damage_calc(
 	defense: int,
 	defense_halved: bool,
 	move_type: int,
-	critical: bool = false
+	critical: bool = false,
+	level: int = -1
 ) -> int:
 	if attacker == null or power <= 0:
 		return 0
@@ -184,7 +194,9 @@ static func damage_calc(
 		@warning_ignore("integer_division")
 		used_defense = maxi(used_defense / 2, 1)
 
-	var damage: int = base_damage(attacker.level, power, attack, used_defense)
+	var damage: int = base_damage(
+		attacker.level if level < 0 else level, power, attack, used_defense
+	)
 
 	# The type-boosting items land here, on the finished base damage and ahead of
 	# the critical multiplier, which is where `PlayerAttackDamage` applies them:
@@ -210,12 +222,17 @@ static func damage_calc(
 ## `cp STRUGGLE / ret z` is the routine's first two instructions.
 ##
 ## Returns { damage, stab, immune, effectiveness }.
+##
+## [param foresight] is the defender's own `SUBSTATUS_IDENTIFIED`, which drops the
+## matchup rows the cartridge keeps past its `-2` marker: Normal and Fighting
+## against a Ghost stop being immunities.
 static func stab_damage(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
 	move: Dictionary,
 	damage: int,
-	weather: int = Gen2Weather.NONE
+	weather: int = Gen2Weather.NONE,
+	foresight: bool = false
 ) -> Dictionary:
 	var out: Dictionary = {
 		"damage": damage, "stab": false, "immune": false,
@@ -229,7 +246,7 @@ static func stab_damage(
 	var data: GameData = attacker.data
 	var move_type: int = int(move.get("type", RomLayout.TYPE_NORMAL))
 	var defending: Array = defender.types()
-	out["effectiveness"] = data.type_effectiveness(move_type, defending)
+	out["effectiveness"] = data.type_effectiveness(move_type, defending, foresight)
 
 	var worked: int = damage
 
@@ -249,7 +266,7 @@ static func stab_damage(
 		if applied.has(defending_type):
 			continue
 		applied.append(defending_type)
-		var multiplier: int = data.type_matchup(move_type, defending_type)
+		var multiplier: int = data.type_matchup(move_type, defending_type, foresight)
 		if multiplier == RomLayout.MATCHUP_NO_EFFECT:
 			out["immune"] = true
 			out["damage"] = 0

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -119,6 +119,17 @@ const DRAINING_EFFECTS: Array[int] = [
 	Gen2MoveEffect.LEECH_HIT, Gen2MoveEffect.DREAM_EATER,
 ]
 
+## The three moves `BattleCommand_CheckHit`'s `.LockOn` names by number: a
+## locked-on target that is flying is still out of reach of the three that only
+## strike downwards.
+##
+## Fissure is named and unreachable, here and on the cartridge: `OHKOHit` carries
+## no `checkhit`, so no `EFFECT_OHKO` move ever reads the flag.
+const LOCK_ON_GROUND_MOVES: Array[int] = [
+	Gen2MoveEffect.EARTHQUAKE_MOVE, Gen2MoveEffect.FISSURE_MOVE,
+	Gen2MoveEffect.MAGNITUDE_MOVE,
+]
+
 ## Counter and Mirror Coat do not roll their own accuracy. They validate the
 ## move that just hit the user, then leave the doubled damage for APPLY_DAMAGE.
 const COUNTER: StringName = &"counter"
@@ -316,6 +327,31 @@ const FORCE_SWITCH: StringName = &"forceswitch"
 
 ## Baton Pass, which switches the side that used it and hands everything over.
 const BATON_PASS: StringName = &"batonpass"
+
+## Teleport, which takes its own user out of a wild battle and ends it as a draw.
+const TELEPORT: StringName = &"teleport"
+
+## Foresight and Lock On, the two flags one side leaves on the other for the
+## accuracy step to read. Neither is spent by the move that set it: Foresight's
+## lasts until a switch and Lock On's is spent by the next hit check against it.
+const FORESIGHT: StringName = &"foresight"
+const LOCK_ON: StringName = &"lockon"
+
+## Spite, which takes two to five PP off the slot holding the target's last move.
+const SPITE: StringName = &"spite"
+
+## Pain Split, which writes the average of the two Pokémon's health into both.
+const PAIN_SPLIT: StringName = &"painsplit"
+
+## Thief, which moves the target's held item onto a thief carrying none.
+const THIEF: StringName = &"thief"
+
+## Pursuit, which doubles the finished figure against a side that is leaving.
+const PURSUIT: StringName = &"pursuit"
+
+## Beat Up, whose own body is the `startloop`/`endloop` pair around one hit per
+## party member, as [constant MULTI_HIT]'s is around one hit per roll.
+const BEAT_UP: StringName = &"beatup"
 
 ## `BattleCommand_CheckSafeguard`, the loud half of Safeguard. The four status
 ## moves that carry it end on `SafeguardProtectText`; the six secondary effects
@@ -680,6 +716,22 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_force_switch(turn)
 		BATON_PASS:
 			_baton_pass(turn)
+		TELEPORT:
+			_teleport(turn)
+		FORESIGHT:
+			_foresight(turn)
+		LOCK_ON:
+			_lock_on(turn)
+		SPITE:
+			_spite(turn)
+		PAIN_SPLIT:
+			_pain_split(turn)
+		THIEF:
+			_thief(turn)
+		PURSUIT:
+			_pursuit(turn)
+		BEAT_UP:
+			_beat_up(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -775,7 +827,8 @@ static func _damage_calc(turn: Gen2Turn) -> void:
 		turn.attacker(), int(effective.get("power", 0)),
 		turn.attack_stat, turn.defense_stat,
 		turn.effect() == Gen2MoveEffect.SELFDESTRUCT,
-		int(effective.get("type", RomLayout.TYPE_NORMAL)), turn.critical
+		int(effective.get("type", RomLayout.TYPE_NORMAL)), turn.critical,
+		turn.level_override
 	)
 
 
@@ -785,7 +838,8 @@ static func _damage_calc(turn: Gen2Turn) -> void:
 static func _stab(turn: Gen2Turn) -> void:
 	var result: Dictionary = Gen2Damage.stab_damage(
 		turn.attacker(), turn.defender(), turn.effective_move(), turn.damage,
-		turn.battle.weather
+		turn.battle.weather,
+		Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.IDENTIFIED)
 	)
 	turn.damage = int(result["damage"])
 	turn.effectiveness = int(result["effectiveness"])
@@ -1061,15 +1115,7 @@ static func _check_hit(turn: Gen2Turn) -> void:
 			turn.end()
 		return
 
-	if _is_hidden(turn.defender().substatus) \
-		and not _can_hit_hidden(turn.move_number, turn.defender().substatus):
-		turn.missed = true
-		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
-		_jump_kick_crash(turn)
-		if not CONTINUES_AFTER_MISS.has(turn.effect()):
-			turn.end()
-		return
-
+	# `.DreamEater`, first.
 	if turn.effect() == Gen2MoveEffect.DREAM_EATER \
 		and not Gen2Status.is_asleep(turn.defender().status):
 		turn.missed = true
@@ -1078,14 +1124,11 @@ static func _check_hit(turn: Gen2Turn) -> void:
 			turn.end()
 		return
 
-	# `.Protect`, second in `BattleCommand_CheckHit` and ahead of everything but
-	# the Dream Eater question. One gate for the whole game: 47 of the lists here
-	# carry `checkhit`, so a Protect turns away a damaging move, a status move and
-	# a stat drop alike without any of them knowing about it.
-	#
-	# The project already runs `.FlyDigMoves` in front of `.DreamEater` where the
-	# source runs it behind this, so between those three only the order of two
-	# refusal messages differs, never which of them refuses.
+	# `.Protect`, second, and ahead of everything but the Dream Eater question.
+	# One gate for the whole game: 47 of the lists here carry `checkhit`, so a
+	# Protect turns away a damaging move, a status move and a stat drop alike
+	# without any of them knowing about it. Ahead of `.LockOn`, so a Protect
+	# turns a locked-on move away *and* leaves the flag standing for the next one.
 	if Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.PROTECT):
 		turn.missed = true
 		turn.emit(Gen2Battle.PROTECTING_ITSELF, {"target": turn.target})
@@ -1101,6 +1144,33 @@ static func _check_hit(turn: Gen2Turn) -> void:
 	if _substitute_refuses(turn) and turn.effect() in DRAINING_EFFECTS:
 		turn.missed = true
 		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
+		if not CONTINUES_AFTER_MISS.has(turn.effect()):
+			turn.end()
+		return
+
+	# `.LockOn`, fourth. The flag is spent on every hit check whether it was set or
+	# not, which is `res SUBSTATUS_LOCK_ON, [hl]` sitting in front of `ret z`, and
+	# it is the target's flag rather than the aimer's.
+	#
+	# A locked-on target that is flying is still missed by the three moves that
+	# only reach a target underground. `CheckHiddenOpponent` has no such list,
+	# which is `docs/bugs_and_glitches.md`'s "Lock-On and Mind Reader don't always
+	# bypass Fly and Dig": mirrored, not fixed.
+	var aimed_at: Gen2BattleMon = turn.defender()
+	var locked_on: bool = Gen2Substatus.has(aimed_at.substatus, Gen2Substatus.LOCK_ON)
+	aimed_at.substatus &= ~Gen2Substatus.LOCK_ON
+	if locked_on and not (
+		Gen2Substatus.has(aimed_at.substatus, Gen2Substatus.FLYING)
+		and LOCK_ON_GROUND_MOVES.has(turn.move_number)
+	):
+		return
+
+	# `.FlyDigMoves`, fifth, and behind the lock-on question for that reason.
+	if _is_hidden(turn.defender().substatus) \
+		and not _can_hit_hidden(turn.move_number, turn.defender().substatus):
+		turn.missed = true
+		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
+		_jump_kick_crash(turn)
 		if not CONTINUES_AFTER_MISS.has(turn.effect()):
 			turn.end()
 		return
@@ -1123,10 +1193,14 @@ static func _check_hit(turn: Gen2Turn) -> void:
 	if turn.effect() == Gen2MoveEffect.ALWAYS_HIT:
 		return
 
+	# `.StatModifiers`, whose Foresight branch returns before it multiplies
+	# anything: an identified target whose evasion is at least the attacker's
+	# accuracy has the whole stage block skipped, and the stored byte stands.
 	var chance: int = Gen2Accuracy.chance(
 		turn.accuracy if turn.accuracy >= 0 \
 			else int(turn.move.get("accuracy", Gen2Accuracy.ALWAYS_HITS)),
-		turn.attacker().stage("accuracy"), turn.defender().stage("evasion")
+		turn.attacker().stage("accuracy"), turn.defender().stage("evasion"),
+		Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.IDENTIFIED)
 	)
 
 	# `.BrightPowder`, after the stat modifiers and before the roll: the item's
@@ -1819,7 +1893,8 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 		if hit > 0:
 			var result: Dictionary = Gen2Damage.calculate(
 				attacker, defender, turn.effective_move(), turn.rng(), focus_energy,
-				false, turn.battle.weather, turn.battle.screens[turn.target]
+				false, turn.battle.weather, turn.battle.screens[turn.target],
+				Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
 			)
 			turn.damage = int(result["damage"])
 			turn.critical = bool(result["critical"])
@@ -2738,6 +2813,278 @@ static func _baton_pass(turn: Gen2Turn) -> void:
 	turn.events.append_array(
 		battle.baton_pass_send_out(side, battle.baton_pass_target(side))
 	)
+
+
+## `BattleCommand_Teleport`: the user takes itself out of a wild battle, which
+## ends it as a draw with nobody beaten. `wForcedSwitch` and `SetBattleDraw` are
+## [method Gen2Battle.force_out], the same pair Whirlwind and Roar reach, except
+## that the side leaving is the user's rather than the target's.
+##
+## Four refusals in the source's order: the four scripted `wBattleType` values,
+## the opponent holding the user with Mean Look or Spider Web, a trainer battle,
+## and the level comparison. The comparison is `BattleCommand_ForceSwitch`'s: a
+## user at or above the other's level always gets away, and below it the roll is
+## drawn out of the two levels summed and one more and fails only under a quarter
+## of the other's level.
+##
+## The enemy's half draws that roll and then throws it away: `cp b / jr nc,
+## .run_away` falls straight into `.run_away`, so a wild Pokémon always
+## teleports. That is `docs/bugs_and_glitches.md`'s "Wild Pokémon can always
+## Teleport regardless of level difference", mirrored rather than fixed, and the
+## roll is still drawn so the generator moves the same way.
+static func _teleport(turn: Gen2Turn) -> void:
+	if FORCE_SWITCH_REFUSED_TYPES.has(turn.battle.battle_type) \
+		or Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.CANT_RUN) \
+		or turn.battle.is_trainer_battle:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	var user_level: int = turn.attacker().level
+	var other_level: int = turn.defender().level
+	if user_level < other_level:
+		var span: int = user_level + other_level + 1
+		var roll: int = turn.rng().randi_range(0, span - 1)
+		if turn.side == Gen2Battle.PLAYER and roll < other_level >> 2:
+			turn.emit(Gen2Battle.MOVE_FAILED)
+			return
+
+	turn.battle.force_out(turn.side)
+	turn.battle.battle_anim_param = FORCE_SWITCH_ANIM_PARAM
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.FLED_FROM_BATTLE)
+
+
+## `BattleCommand_Foresight`: the flag that drops the target's evasion out of the
+## accuracy sum and opens the two Ghost immunities the matchup table keeps past
+## its own `-2` marker. It sits on the target and nothing but a switch clears it.
+##
+## Two refusals: a target that is flying or underground, and one already
+## identified. Only the second is reached through the cartridge's own list, on the
+## cartridge as well as here, since `checkhit` in front of the command has already
+## turned a hidden target away. The first is kept for a registered list that
+## carries no `checkhit`.
+static func _foresight(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if _is_hidden(defender.substatus) \
+		or Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
+	defender.substatus |= Gen2Substatus.IDENTIFIED
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.IDENTIFIED_SET, {"target": turn.target})
+
+
+## `BattleCommand_LockOn`: Lock On and Mind Reader, one command. The flag goes on
+## the target, and [method _check_hit] spends it on the next hit check made
+## against that Pokémon, whoever makes it.
+##
+## The one refusal is a target behind a doll, and it prints
+## `PrintDidntAffect` rather than "But it failed!".
+static func _lock_on(turn: Gen2Turn) -> void:
+	if _substitute_refuses(turn):
+		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+		return
+
+	turn.defender().substatus |= Gen2Substatus.LOCK_ON
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.TOOK_AIM)
+
+
+## `BattleCommand_Spite`: two to five PP off the slot holding the target's last
+## move, or as much as that slot has left.
+##
+## The slot is found by searching the target's own move list, the way
+## [method _disable] finds Disable's, and the guard for a move no longer in that
+## list is this project's rather than the cartridge's: `.loop` there has no bound
+## and would run off the end of the list. It is reachable only through a
+## mid-battle level up replacing a slot.
+##
+## Four refusals, all `PrintDidntAffect2`: a target that has not moved, a last
+## move of Struggle, a slot already empty of PP, and the missing slot above.
+static func _spite(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	var last_move: int = defender.last_move_used
+	if last_move == 0 or last_move == Gen2Damage.STRUGGLE:
+		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+		return
+
+	var slot: int = defender.moves.find(last_move)
+	if slot < 0 or defender.pp_left(slot) <= 0:
+		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+		return
+
+	var amount: int = mini(_roll_spite_pp(turn.rng()), defender.pp_left(slot))
+	defender.pp[slot] = int(defender.pp[slot]) - amount
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.PP_REDUCED, {
+		"target": turn.target, "slot": slot, "move": last_move, "amount": amount,
+	})
+
+
+## `call BattleRandom / and %11 / inc a / inc a`: two bits of a random byte and
+## two added, so two through five.
+static func _roll_spite_pp(rng: RandomNumberGenerator) -> int:
+	return rng.randi_range(0, 3) + SPITE_MIN_PP
+
+
+const SPITE_MIN_PP: int = 2
+
+
+## `BattleCommand_PainSplit`: both Pokémon end on the average of the two current
+## totals, floored, and neither goes above its own maximum.
+##
+## The health words are written by hand, so nothing stands between this and
+## either Pokémon: no doll takes it, no Focus Band fires and no Endure clamps it.
+## Both are standing when this runs, so the average is at least one and the move
+## cannot faint anybody.
+##
+## Two refusals, both `PrintDidntAffect2`: a miss, which `checkhit` has already
+## turned into an ended move, and a target behind a doll.
+static func _pain_split(turn: Gen2Turn) -> void:
+	if _substitute_refuses(turn):
+		turn.emit(Gen2Battle.NO_EFFECT, {"target": turn.target})
+		return
+
+	var attacker: Gen2BattleMon = turn.attacker()
+	var defender: Gen2BattleMon = turn.defender()
+	@warning_ignore("integer_division")
+	var shared: int = (attacker.hp + defender.hp) / 2
+	_animate_current_move(turn)
+	attacker.hp = mini(shared, attacker.max_hp())
+	defender.hp = mini(shared, defender.max_hp())
+	turn.emit(Gen2Battle.SHARED_PAIN, {
+		"target": turn.target,
+		"hp": attacker.hp, "max_hp": attacker.max_hp(),
+		"target_hp": defender.hp, "target_max_hp": defender.max_hp(),
+	})
+
+
+## `BattleCommand_Thief`: the target's held item, onto a thief carrying none.
+##
+## The cartridge writes both the battle struct and the party struct, because they
+## are two copies of one Pokémon; here [method Gen2Battle.mon] hands back the
+## party member itself, so one write is both and a stolen item is gone for good
+## on either side without anything extra.
+##
+## Four refusals in the source's order, every one of them silent: the thief
+## already holds something, the target holds nothing, the item is mail, and the
+## move's own chance came up short. The chance is read last, which costs nothing
+## since `effectchance` drew its roll earlier in the list.
+static func _thief(turn: Gen2Turn) -> void:
+	var attacker: Gen2BattleMon = turn.attacker()
+	var defender: Gen2BattleMon = turn.defender()
+	if attacker.item != 0 or defender.item == 0:
+		return
+	if Gen2HeldItem.is_mail(defender.item) or turn.failed_chance:
+		return
+
+	var stolen: int = defender.item
+	defender.item = 0
+	attacker.item = stolen
+	turn.emit(Gen2Battle.STOLE_ITEM, {"target": turn.target, "item": stolen})
+
+
+## `BattleCommand_Pursuit`: twice the finished figure against a side that is
+## leaving, saturating at a word rather than wrapping.
+##
+## The doubling is all this command is. What makes Pursuit hit the Pokémon on its
+## way out is `PursuitSwitch`, which runs the whole move in front of the switch;
+## see [method Gen2Battle.take_actions].
+static func _pursuit(turn: Gen2Turn) -> void:
+	if not turn.battle.is_switching(turn.target):
+		return
+	turn.damage = mini(turn.damage * 2, 0xFFFF)
+
+
+## `BattleCommand_BeatUp` with `startloop` and `endloop` around it: one hit per
+## member of the user's own party, in party order, each worked out from that
+## member's species base Attack and its own level.
+##
+## The loop is inside this command as [method _multi_hit]'s is inside that one,
+## because `endloop` jumps back to `critical` rather than to the top of the list:
+## `checkhit` is outside it and rolls once for the whole move.
+##
+## `damagecalc` is handed base stats rather than real ones and never sees
+## `damagestats`, so no item, no screen, no stage and no truncation touches
+## either figure. There is no `stab` either, so no same-type bonus, no weather
+## and no matchup: `CheckTurn` leaves the type modifier at `EFFECTIVE` for the
+## whole turn and `supereffectivetext` says nothing.
+##
+## `.beatup_fail` skips a member with no health or with any status at all and
+## lets the loop carry on, which is `SkipToBattleCommand buildopponentrage`, and
+## `endloop` prints no "hit N times" line for this effect (`.beat_up_2`).
+static func _beat_up(turn: Gen2Turn) -> void:
+	var battle: Gen2Battle = turn.battle
+	var party: Gen2Party = battle.party(turn.side)
+	var defender: Gen2BattleMon = turn.defender()
+
+	# `.wild`, which has no party to walk: `EnemyAttackDamage` gives the wild
+	# Pokémon one ordinary hit off its own real stats, and `endloop`'s
+	# `.check_ot_beat_up` then falls into `.only_one_beatup`. Nothing on that path
+	# ever set `wBeatUpHitAtLeastOnce`, so the hit lands and "But it failed!" is
+	# printed behind it anyway.
+	if turn.side == Gen2Battle.ENEMY and not battle.is_trainer_battle:
+		turn.emit(Gen2Battle.BEAT_UP_ATTACK, {"index": -1, "species": turn.attacker().species})
+		_damage_stats(turn)
+		_beat_up_hit(turn)
+		if defender.is_fainted():
+			_check_faint(turn)
+		else:
+			turn.emit(Gen2Battle.MOVE_FAILED)
+		turn.end()
+		return
+
+	var struck: bool = false
+	for index: int in party.size():
+		var member: Gen2BattleMon = party.at(index)
+		if not member.is_fainted() and member.status == Gen2Status.NONE:
+			struck = true
+			turn.emit(Gen2Battle.BEAT_UP_ATTACK, {
+				"index": index, "species": member.species,
+			})
+			turn.attack_stat = _base_stat(turn, member.species, "attack")
+			turn.defense_stat = _base_stat(turn, defender.species, "defense")
+			turn.level_override = member.level
+			turn.power_override = int(turn.move.get("power", 0))
+			_beat_up_hit(turn)
+			if defender.is_fainted():
+				_check_faint(turn)
+				turn.end()
+				return
+
+		# `.only_one_beatup`, which the whole party reaches on `cp 1`: the loop
+		# flag is cleared and the move ends outright, so `kingsrock` behind it
+		# never runs. `docs/bugs_and_glitches.md`'s "Beat Up works incorrectly
+		# with only one Pokémon in the party", mirrored rather than fixed.
+		if party.size() == 1:
+			if not struck:
+				turn.emit(Gen2Battle.MOVE_FAILED)
+			turn.end()
+			return
+
+	# `beatupfailtext`, which says nothing when any member landed a hit.
+	if not struck:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+
+
+## One pass of the loop: `critical`, `beatup`'s own numbers, `damagecalc`,
+## `damagevariation`, `moveanimnosub` and `applydamage`.
+##
+## `clearmissdamage` is structural, since the one `checkhit` sits outside the loop
+## and has already ended the move on a miss.
+static func _beat_up_hit(turn: Gen2Turn) -> void:
+	_critical(turn)
+	_damage_calc(turn)
+	_damage_variation(turn)
+	_move_anim(turn)
+	_apply_damage(turn)
+
+
+## A species' own base Attack or base Defense, which is what `GetBaseData` leaves
+## in `wBaseAttack` and `wBaseDefense` for `BattleCommand_BeatUp` to load.
+static func _base_stat(turn: Gen2Turn, species: int, key: String) -> int:
+	return int(turn.data().species(species).get("stats", {}).get(key, 0))
 
 
 ## `BattleCommand_CheckSafeguard`: the target's own Safeguard refusing a status

--- a/game/battle/held_item.gd
+++ b/game/battle/held_item.gd
@@ -113,6 +113,12 @@ const PIKACHU: int = 25
 const METAL_POWDER_ITEM: int = 35
 const DITTO: int = 132
 
+## `MailItems` (data/items/mail_items.asm), which `ItemIsMail` walks. Pinned here
+## rather than imported: the table has no locator, the way `RadioChannels` in
+## `game/world/world_radio.gd` has none. `BattleCommand_Thief` is its only reader,
+## and no mail model exists.
+const MAIL_ITEMS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]
+
 ## What Metal Powder does to the defence it is read against: half again, floored
 ## the way the cartridge's `srl a; add c` floors it.
 const METAL_POWDER_NUMERATOR: int = 3
@@ -234,6 +240,11 @@ static func boosts_defence(species: int, item: int) -> bool:
 static func metal_powder_defence(defence: int) -> int:
 	@warning_ignore("integer_division")
 	return defence * METAL_POWDER_NUMERATOR / METAL_POWDER_DENOMINATOR
+
+
+## `ItemIsMail`: whether Thief has to leave this item where it is.
+static func is_mail(item: int) -> bool:
+	return MAIL_ITEMS.has(item)
 
 
 ## Whether a roll out of 256 came in under an item's own parameter, which is

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -225,9 +225,39 @@ const BATON_PASS: int = 127
 ## `DoSubstituteDamage` stamps it over the move's own once a doll has broken.
 const NORMAL_HIT_EFFECT: int = 0
 
-## Beat Up, named for that command's exemption list alone. The effect itself is
-## unwritten.
+## Beat Up: one hit per standing, healthy member of the user's own party, each
+## worked out from that member's base Attack and level rather than the field
+## Pokémon's. The one list with no `stab`, so no same-type bonus, no weather and
+## no matchup.
 const BEAT_UP: int = 154
+
+## Pain Split, which averages the two Pokémon's health rather than moving damage
+## across the field.
+const PAIN_SPLIT: int = 91
+
+## Lock On and Mind Reader, one byte: a flag on the *target* that makes the
+## aimer's next move connect, read and spent by
+## [method Gen2EffectCommands._check_hit].
+const LOCK_ON: int = 94
+
+## Spite, which takes two to five PP off the slot holding the target's last move.
+const SPITE: int = 100
+
+## Thief, which takes the target's held item when the thief has none of its own.
+const THIEF: int = 105
+
+## Foresight, whose flag drops the target's evasion out of the accuracy sum and
+## opens the two Ghost immunities the matchup table keeps past its own marker.
+const FORESIGHT: int = 113
+
+## Pursuit, which doubles against a side that is leaving. Two halves: the command
+## reads the switching flag, and [method Gen2Battle.take_actions] is what runs
+## this move early, in front of the switch it answers.
+const PURSUIT: int = 128
+
+## Teleport, which ends a wild battle as a draw with the user out of it. Refused
+## outright in a trainer battle, since there is nowhere to teleport away from.
+const TELEPORT: int = 153
 
 ## Swift, Faint Attack and Vital Throw, which point at `NormalHit` like any other
 ## attack: their whole difference is one comparison inside
@@ -856,6 +886,87 @@ const FORCE_SWITCH_SEQUENCE: Array = [
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.FORCE_SWITCH,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Pain Split, Lock On, Mind Reader, Spite and Foresight: four lists that are the
+## same five steps with one command swapped, which is why they are written as one
+## helper rather than four constants.
+static func _status_command_sequence(command: StringName) -> Array:
+	return [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.CHECK_HIT,
+		command,
+		Gen2EffectCommands.END_MOVE,
+	]
+
+
+## Teleport, the one of the five with no `checkhit` at all: the move spends its PP
+## and then decides for itself, out of the two levels, whether the user gets away.
+const TELEPORT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.TELEPORT,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Thief: [constant NORMAL_HIT] with the move's own chance behind the roll and the
+## steal between the damage and the faint check, where `thief` sits.
+const THIEF_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CRITICAL,
+	Gen2EffectCommands.DAMAGE_STATS,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.EFFECT_CHANCE,
+	Gen2EffectCommands.MOVE_ANIM,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.THIEF,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.KINGS_ROCK,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Pursuit: [constant NORMAL_HIT] with the doubling between the spread and the
+## roll, which is the one place the finished figure can still be multiplied.
+const PURSUIT_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CRITICAL,
+	Gen2EffectCommands.DAMAGE_STATS,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.PURSUIT,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.MOVE_ANIM,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.KINGS_ROCK,
+	Gen2EffectCommands.END_MOVE,
+]
+
+## Beat Up. The `startloop`/`endloop` pair is inside
+## [constant Gen2EffectCommands.BEAT_UP], as [constant Gen2EffectCommands.MULTI_HIT]
+## already holds its own, and `endloop` jumps back to `critical` rather than to
+## the top, so `checkhit` is outside the loop and rolls once for the whole move.
+##
+## No `damagestats` and no `stab`: the command loads the formula's two stats
+## itself, from base stats rather than from either Pokémon's real ones, and
+## nothing multiplies the result by a matchup. `CheckTurn` leaves `wTypeModifier`
+## at `EFFECTIVE` for the whole turn, so `supereffectivetext` says nothing.
+const BEAT_UP_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.BEAT_UP,
+	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1557,6 +1668,14 @@ static func _sequences() -> Dictionary:
 		DESTINY_BOND: DESTINY_BOND_SEQUENCE,
 		FORCE_SWITCH: FORCE_SWITCH_SEQUENCE,
 		BATON_PASS: BATON_PASS_SEQUENCE,
+		PAIN_SPLIT: _status_command_sequence(Gen2EffectCommands.PAIN_SPLIT),
+		LOCK_ON: _status_command_sequence(Gen2EffectCommands.LOCK_ON),
+		SPITE: _status_command_sequence(Gen2EffectCommands.SPITE),
+		FORESIGHT: _status_command_sequence(Gen2EffectCommands.FORESIGHT),
+		TELEPORT: TELEPORT_SEQUENCE,
+		THIEF: THIEF_SEQUENCE,
+		PURSUIT: PURSUIT_SEQUENCE,
+		BEAT_UP: BEAT_UP_SEQUENCE,
 		THUNDER: THUNDER_SEQUENCE,
 		LEECH_HIT: DRAIN_SEQUENCE,
 		DREAM_EATER: DREAM_EATER_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -96,6 +96,23 @@ const ENDURE: int = 1 << 22
 ## covers exactly the opponent's next move.
 const DESTINY_BOND: int = 1 << 23
 
+## `SUBSTATUS_IDENTIFIED`, `wPlayerSubStatus1` bit 3. Foresight sets it on the
+## Pokémon it identified, not on its user: `BattleCommand_Foresight` writes
+## `BATTLE_VARS_SUBSTATUS1_OPP`. Three readers, all of the target's flag:
+## `BattleCommand_CheckHit`'s `.StatModifiers`, `BattleCommand_Stab`'s matchup
+## walk and `CheckTypeMatchup`'s.
+const IDENTIFIED: int = 1 << 24
+
+## `SUBSTATUS_LOCK_ON`, `wPlayerSubStatus5` bit 5. On the Pokémon that was aimed
+## at rather than the one that aimed, so `BattleCommand_CheckHit`'s `.LockOn`
+## reads `BATTLE_VARS_SUBSTATUS5_OPP` and consumes it.
+##
+## The cartridge's other four readers are the 25% chance an AI status move fails
+## anyway (`engine/battle/effect_commands.asm`'s `.CheckAIRandomFail`,
+## `.dont_sample_failure` twice and `.ComputerMiss`). This engine models no such
+## failure, so there is nothing here for the flag to bypass.
+const LOCK_ON: int = 1 << 25
+
 const NONE: int = 0
 
 ## How many turns a confused Pokémon stays that way, rolled the same shape as

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -51,6 +51,12 @@ var defense_stat: int = 0
 var power_override: int = -1
 var type_override: int = -1
 
+## The level `damagecalc` multiplies, or -1 for the attacker's own. The one field
+## here with no `wPlayerMoveStruct` counterpart: `BattleCommand_BeatUp` hands the
+## formula a party member's level in `e`, and the Pokémon on the field is only
+## one of the six it walks.
+var level_override: int = -1
+
 ## The same per-turn copy one field along, with one writer: `DoSubstituteDamage`
 ## stamps `EFFECT_NORMAL_HIT` over `wPlayerMoveStruct + MOVE_EFFECT` once a doll
 ## has broken, so the steps behind the break read an ordinary attack.

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -85,7 +85,10 @@ const ROLLING_KICK_ALWAYS: int = 247
 const ROLLING_KICK_NEVER: int = 248
 const CONFUSION_ALWAYS: int = 249
 const CONFUSION_NEVER: int = 250
-const SUPERSONIC: int = 251
+## Parked past every other row rather than on 251, which is Beat Up's own number
+## and is now filled with that row. Supersonic really is move 48, and this entry
+## is not it: its accuracy is forced to 255 so a confusion test needs no seed.
+const SUPERSONIC: int = 280
 const HYPER_BEAM: int = 252
 
 ## The three move families this fixture keeps at their real Generation 2 move
@@ -247,8 +250,22 @@ const MINIMIZE: int = 107
 const SPLASH: int = 150
 const SWAGGER: int = 207
 
+## The last row of the effects table, all nine at their real move numbers with
+## their real bytes. Lock On and Mind Reader have to be two numbers over one
+## effect byte the way Protect and Detect do, and Beat Up's power of 10 is the
+## whole of what its own command hands the formula.
+const TELEPORT: int = 100
+const THIEF: int = 168
+const MIND_READER: int = 170
+const SPITE: int = 180
+const FORESIGHT: int = 193
+const LOCK_ON: int = 199
+const PAIN_SPLIT: int = 220
+const PURSUIT: int = 228
+const BEAT_UP: int = 251
+
 ## The highest move number this table fills. Grown as new moves are added.
-const MAX_MOVE: int = PSYCHIC_NEVER
+const MAX_MOVE: int = SUPERSONIC
 const BERRY_ITEM: int = 0xAD
 
 ## The highest item number this table fills.
@@ -277,6 +294,10 @@ const MYSTERYBERRY: int = 150
 const PSNCUREBERRY: int = 74
 const MIRACLEBERRY: int = 109
 const BITTER_BERRY: int = 83
+
+## `MailItems`' first entry, at its real number. The one item Thief has to leave
+## where it is, and it carries no held effect: `ItemIsMail` checks the number.
+const FLOWER_MAIL: int = 158
 
 ## Exp. Share, at its real number. It carries no held effect at all: the routine
 ## that finds it checks the item number, so the default row is the whole of what
@@ -321,11 +342,13 @@ const MATCHUPS: Array = [
 	[FIRE, GRASS, 20], [FIRE, WATER, 5], [FIRE, FIRE, 5], [FIRE, ROCK, 5],
 	[GRASS, ROCK, 20], [GRASS, GROUND, 20], [GRASS, POISON, 5], [GRASS, GRASS, 5],
 	[NORMAL, ROCK, 5], [NORMAL, STEEL, 5],
-	[FIGHTING, GHOST, 0], [PSYCHIC_TYPE, DARK, 0],
+	[PSYCHIC_TYPE, DARK, 0],
 ]
 
-## The two the cartridge keeps past the Foresight marker.
-const FORESIGHT_MATCHUPS: Array = [[NORMAL, GHOST, 0]]
+## The two the cartridge keeps past the Foresight marker, and the only place
+## either appears: `data/types/type_matchups.asm` lists Normal and Fighting
+## against Ghost after `db -2` and nowhere before it.
+const FORESIGHT_MATCHUPS: Array = [[NORMAL, GHOST, 0], [FIGHTING, GHOST, 0]]
 
 
 ## Writes a cache at [param directory] and opens it.
@@ -631,6 +654,22 @@ static func _moves() -> Array:
 		MINIMIZE: ["MINIMIZE", 0, NORMAL, 255, 20, Gen2MoveEffect.STAT_UP_BASE + 6, 0],
 		SPLASH: ["SPLASH", 0, NORMAL, 255, 40, Gen2MoveEffect.SPLASH, 0],
 		SWAGGER: ["SWAGGER", 0, NORMAL, 229, 15, Gen2MoveEffect.SWAGGER, 255],
+		# The last row of the effects table. All nine store an accuracy of 255, so
+		# `checkhit` never rolls one, and Thief's `100 percent` chance is a roll
+		# `effectchance` cannot fail.
+		TELEPORT: ["TELEPORT", 0, PSYCHIC_TYPE, 255, 20, Gen2MoveEffect.TELEPORT, 0],
+		THIEF: ["THIEF", 40, DARK, 255, 10, Gen2MoveEffect.THIEF, 256],
+		MIND_READER: [
+			"MIND READER", 0, NORMAL, 255, 5, Gen2MoveEffect.LOCK_ON, 0,
+		],
+		SPITE: ["SPITE", 0, GHOST, 255, 10, Gen2MoveEffect.SPITE, 0],
+		FORESIGHT: ["FORESIGHT", 0, NORMAL, 255, 40, Gen2MoveEffect.FORESIGHT, 0],
+		LOCK_ON: ["LOCK-ON", 0, NORMAL, 255, 5, Gen2MoveEffect.LOCK_ON, 0],
+		PAIN_SPLIT: [
+			"PAIN SPLIT", 0, NORMAL, 255, 20, Gen2MoveEffect.PAIN_SPLIT, 0,
+		],
+		PURSUIT: ["PURSUIT", 40, DARK, 255, 20, Gen2MoveEffect.PURSUIT, 0],
+		BEAT_UP: ["BEAT UP", 10, DARK, 255, 10, Gen2MoveEffect.BEAT_UP, 0],
 	}
 
 	var out: Array = []

--- a/tests/unit/test_accuracy.gd
+++ b/tests/unit/test_accuracy.gd
@@ -81,3 +81,25 @@ func test_foresight_drops_the_stages_only_when_they_are_against_the_attacker() -
 func test_a_stage_past_the_ends_is_clamped() -> void:
 	assert_eq(Gen2Accuracy.apply_stage(100, 99), Gen2Accuracy.apply_stage(100, Gen2Stats.MAX_STAGE))
 	assert_eq(Gen2Accuracy.apply_stage(100, -99), Gen2Accuracy.apply_stage(100, Gen2Stats.MIN_STAGE))
+
+
+## `.StatModifiers`' Foresight branch: `cp b / jr c, .skip_foresight_check` puts it
+## behind a comparison, then `ret nz` returns before the multipliers, so the
+## stored byte stands and neither stage is applied.
+func test_foresight_drops_both_stages_when_the_evasion_is_the_higher() -> void:
+	# 90% cut by a +4 evasion, then the same pair identified.
+	assert_eq(Gen2Accuracy.chance(229, 0, 4), 98)
+	assert_eq(Gen2Accuracy.chance(229, 0, 4, true), 229)
+	# Equal stages still take the branch, since the comparison is "at least".
+	assert_lt(Gen2Accuracy.chance(229, 2, 2), 229)
+	assert_eq(Gen2Accuracy.chance(229, 2, 2, true), 229)
+
+
+## And it cannot undo an accuracy the attacker raised: the branch is only reached
+## when the evasion is at least the accuracy.
+func test_foresight_leaves_a_higher_accuracy_alone() -> void:
+	assert_eq(
+		Gen2Accuracy.chance(100, 4, 0, true), Gen2Accuracy.chance(100, 4, 0),
+		"the accuracy is the higher stage, so the branch is skipped"
+	)
+	assert_gt(Gen2Accuracy.chance(100, 4, 0), 100)

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -848,3 +848,245 @@ func test_smart_discourages_a_force_switch_while_the_matchup_is_holding() -> voi
 		Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE - 1
 	)
 	assert_eq(int(losing[0]), 20, "a pairing going badly is left alone")
+
+
+## `AI_Redundant`'s `.Foresight`: identifying an already-identified target is a
+## wasted turn.
+func test_basic_discourages_foresight_against_an_identified_target() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.FORESIGHT, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.substatus = Gen2Substatus.IDENTIFIED
+	for seed_value: int in 10:
+		_rng.seed = seed_value
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_BASIC, _rng),
+			1, "a second Foresight identifies nothing"
+		)
+
+
+## `.Teleport` is a label on `.Redundant` itself, so a trainer never throws it.
+func test_basic_always_discourages_teleport() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TELEPORT, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	for seed_value: int in 10:
+		_rng.seed = seed_value
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_BASIC, _rng),
+			1, "there is nowhere to teleport away from a trainer"
+		)
+
+
+## `AI_Types` sets `hBattleTurn` to the enemy before `BattleCheckTypeMatchup`, so
+## the flag it reads is the target's: an identified Ghost stops being immune and
+## the Normal move stops being dismissed.
+func test_types_reads_the_targets_foresight_flag() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.THUNDERBOLT])
+	var gastly: Gen2BattleMon = _mon(Fixture.GASTLY, 50, [Fixture.TACKLE])
+	for seed_value: int in 10:
+		_rng.seed = seed_value
+		assert_eq(
+			Gen2BattleAI.choose_slot(pikachu, gastly, _data, RomLayout.AI_TYPES, _rng),
+			1, "Normal cannot touch a Ghost, so the Electric move wins"
+		)
+
+	gastly.substatus = Gen2Substatus.IDENTIFIED
+	var identified: Array = _scores(pikachu, gastly, RomLayout.AI_TYPES)
+	assert_eq(int(identified[0]), Gen2BattleAI.DEFAULT_SCORE,
+		"identified, the Normal move is not dismissed any more"
+	)
+
+
+## `AI_Smart_Thief`: `add $1e` and nothing else, which puts it past every other
+## move on the list.
+func test_smart_puts_thief_thirty_points_behind() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.THIEF, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var scores: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+	assert_eq(int(scores[0]), Gen2BattleAI.DEFAULT_SCORE + Gen2BattleAI.THIEF_PENALTY)
+	assert_eq(int(scores[1]), Gen2BattleAI.DEFAULT_SCORE)
+
+
+## `AI_Smart_PainSplit`: pointless while the user is the healthier of the two,
+## which is `enemy hp * 2 > player hp` rather than a comparison of fractions.
+func test_smart_discourages_pain_split_while_the_user_is_healthier() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PAIN_SPLIT, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+
+	var healthier: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+	assert_eq(int(healthier[0]), Gen2BattleAI.DEFAULT_SCORE + 1)
+
+	pikachu.hp = 1
+	var hurt: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+	assert_eq(int(hurt[0]), Gen2BattleAI.DEFAULT_SCORE, "worth it once the user is behind")
+
+
+## `AI_Smart_Pursuit`: two points off against a target nearly down, and discouraged
+## against one with health left. Both branches roll, so both are sampled.
+func test_smart_pursuit_prefers_a_target_that_is_nearly_down() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PURSUIT, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.hp = 1
+
+	var encouraged: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_true(encouraged.has(Gen2BattleAI.DEFAULT_SCORE - 2), "the 50% that encourages")
+	assert_true(encouraged.has(Gen2BattleAI.DEFAULT_SCORE), "and the half that does not")
+
+	geodude.hp = geodude.max_hp()
+	var discouraged: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_true(discouraged.has(Gen2BattleAI.DEFAULT_SCORE + 1), "the 20% that discourages")
+	assert_true(discouraged.has(Gen2BattleAI.DEFAULT_SCORE))
+
+
+## `AI_Smart_Foresight`: worth it against a Ghost, which is the only target the
+## flag opens a matchup against, and almost always discouraged otherwise.
+func test_smart_foresight_wants_a_ghost() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.FORESIGHT, Fixture.TACKLE])
+	var gastly: Gen2BattleMon = _mon(Fixture.GASTLY, 50, [Fixture.TACKLE])
+	var against_ghost: Dictionary = _score_spread(pikachu, gastly, RomLayout.AI_SMART, 0)
+	assert_true(against_ghost.has(Gen2BattleAI.DEFAULT_SCORE - 2))
+
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var against_rock: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_false(against_rock.has(Gen2BattleAI.DEFAULT_SCORE - 2),
+		"nothing to open, so it is never encouraged"
+	)
+	assert_true(against_rock.has(Gen2BattleAI.DEFAULT_SCORE + 1), "the 92% that discourages")
+
+	# A sharply raised evasion is the other way in.
+	geodude.stages["evasion"] = 3
+	var against_evasion: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_true(against_evasion.has(Gen2BattleAI.DEFAULT_SCORE - 2))
+
+
+## `AI_Smart_Spite`: below six PP is worth draining, fifteen or more is not, and a
+## target that has not moved yet is judged on speed instead.
+func test_smart_spite_reads_the_pp_of_the_move_it_would_drain() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SPITE, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.last_move_used = Fixture.TACKLE
+
+	geodude.pp[0] = 5
+	var nearly_out: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_true(nearly_out.has(Gen2BattleAI.DEFAULT_SCORE - 2))
+
+	geodude.pp[0] = 20
+	var plenty: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_eq(plenty.keys(), [Gen2BattleAI.DEFAULT_SCORE + 1],
+		"fifteen or more discourages without a roll"
+	)
+
+
+## A target that has not moved is judged on speed: the faster user dismisses it
+## outright, since it would never see a move to drain.
+func test_smart_spite_dismisses_itself_when_the_user_is_faster() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SPITE, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var scores: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+	assert_eq(
+		int(scores[0]),
+		Gen2BattleAI.DEFAULT_SCORE + Gen2BattleAI.DISCOURAGE_MOVE
+	)
+
+
+## `AI_Smart_LockOn`'s `.player_locked_on`: with the target already aimed at,
+## every inaccurate move is encouraged and Lock On itself is dismissed.
+func test_smart_lock_on_dismisses_itself_once_the_target_is_aimed_at() -> void:
+	var pikachu: Gen2BattleMon = _mon(
+		Fixture.PIKACHU, 50, [Fixture.LOCK_ON, Fixture.DISABLE_MOVE, Fixture.SCREECH]
+	)
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.substatus = Gen2Substatus.LOCK_ON
+	var scores: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+
+	assert_eq(
+		int(scores[0]),
+		Gen2BattleAI.DEFAULT_SCORE + Gen2BattleAI.DISCOURAGE_MOVE,
+		"aiming again is wasted"
+	)
+	assert_eq(int(scores[1]), Gen2BattleAI.DEFAULT_SCORE - 2,
+		"Disable stores 140, under the 180 the threshold compares against"
+	)
+	assert_eq(int(scores[2]), Gen2BattleAI.DEFAULT_SCORE,
+		"Screech stores 216 and never needed the help"
+	)
+
+
+## The other half: aiming is worth it against a sharply raised evasion and not
+## worth a turn while the user is nearly down.
+func test_smart_lock_on_reads_health_then_evasion() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.LOCK_ON, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.stages["evasion"] = 3
+	var wanted: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_true(wanted.has(Gen2BattleAI.DEFAULT_SCORE - 2))
+
+	pikachu.hp = 1
+	var nearly_down: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+	assert_eq(int(nearly_down[0]), Gen2BattleAI.DEFAULT_SCORE + 1,
+		"below a quarter it is not worth the turn"
+	)
+
+
+## `AI_Smart_Protect`'s second test: with a guaranteed hit already lined up,
+## sitting the turn out wastes it.
+func test_smart_protect_is_discouraged_while_the_player_is_locked_on() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PROTECT, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	geodude.substatus = Gen2Substatus.LOCK_ON
+	var spread: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+
+	assert_true(spread.has(Gen2BattleAI.DEFAULT_SCORE + 2), "the two-point penalty")
+	assert_true(spread.has(Gen2BattleAI.DEFAULT_SCORE), "and the 8% that skips it")
+	assert_false(spread.has(Gen2BattleAI.DEFAULT_SCORE - 1), "never encouraged")
+
+
+## `AI_Smart_Endure`'s `.no_reversal`: a guaranteed incoming hit is exactly what
+## surviving on one point is for, even with no Reversal to answer with.
+func test_smart_endure_wants_to_survive_a_locked_on_hit() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.ENDURE, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	pikachu.hp = 1
+
+	var unaimed: Array = _scores(pikachu, geodude, RomLayout.AI_SMART)
+	assert_eq(int(unaimed[0]), Gen2BattleAI.DEFAULT_SCORE, "nothing to survive")
+
+	pikachu.substatus |= Gen2Substatus.LOCK_ON
+	var aimed: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
+	assert_true(aimed.has(Gen2BattleAI.DEFAULT_SCORE - 2))
+	assert_true(aimed.has(Gen2BattleAI.DEFAULT_SCORE), "the half that does nothing")
+
+
+## `AI_Smart_TrapTarget` encourages on five states, and two of them are the flags
+## Foresight and Nightmare leave behind.
+func test_smart_trap_target_encourages_on_a_foresight_or_a_nightmare() -> void:
+	for flag: int in [Gen2Substatus.IDENTIFIED, Gen2Substatus.NIGHTMARE]:
+		var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.WRAP, Fixture.TACKLE])
+		var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+		geodude.substatus = flag
+		var spread: Dictionary = _score_spread(
+			pikachu, geodude, RomLayout.AI_SMART, 0, 1, 1
+		)
+		assert_true(spread.has(Gen2BattleAI.DEFAULT_SCORE - 2), "flag %d" % flag)
+
+
+## One scoring pass, with the seed left where the test set it.
+func _scores(
+	attacker: Gen2BattleMon, defender: Gen2BattleMon, flags: int,
+	attacker_turns: int = 1, defender_turns: int = 1
+) -> Array:
+	return Gen2BattleAI.score_slots(
+		attacker, defender, _data, flags, _rng, attacker_turns, defender_turns
+	)
+
+
+## The set of scores one slot takes across enough seeds to see both sides of a
+## roll, for the handlers whose branches are probabilistic.
+func _score_spread(
+	attacker: Gen2BattleMon, defender: Gen2BattleMon, flags: int, slot: int,
+	attacker_turns: int = 1, defender_turns: int = 1
+) -> Dictionary:
+	var seen: Dictionary = {}
+	for seed_value: int in 60:
+		_rng.seed = seed_value
+		seen[int(_scores(attacker, defender, flags, attacker_turns, defender_turns)[slot])] = true
+	return seen

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3545,3 +3545,138 @@ func test_a_baton_pass_with_nobody_behind_it_fails() -> void:
 	)
 	assert_eq(_of_type(lone.take_turn(0, 0), Gen2Battle.MOVE_FAILED).size(), 1)
 	assert_eq(lone.awaiting_baton_pass(), -1, "and no question was asked")
+
+
+## `PursuitSwitch`, which the cartridge calls from `BattleMonEntrance` and from
+## `AI_Switch`: the side that chose Pursuit takes its whole turn in front of the
+## recall, against the Pokémon on its way out.
+func test_pursuit_hits_the_pokemon_on_its_way_out() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[
+			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		],
+		[_mon(Fixture.PIKACHU, 50, [Fixture.PURSUIT])]
+	)
+	var leaving: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(0)
+	var events: Array = battle.take_actions(
+		Gen2Battle.switch_to(1), Gen2Battle.use_move(0)
+	)
+
+	var types: Array = events.map(func(event: Dictionary) -> StringName: return event["type"])
+	assert_true(types.has(Gen2Battle.HIT), "the pursuer landed a hit")
+	assert_lt(
+		types.find(Gen2Battle.HIT), types.find(Gen2Battle.WITHDREW),
+		"in front of the recall, which is where `PursuitSwitch` sits"
+	)
+	assert_lt(leaving.hp, leaving.max_hp(), "the Pokemon that left took it")
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the switch still happened")
+	# `ld a, CANNOT_MOVE`: the pursuer has nothing left to spend this turn.
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 1)
+
+
+## `wPlayerIsSwitching` is what `pursuit` reads, so the doubling only happens on
+## the turn the other side is leaving.
+func test_pursuit_doubles_only_against_a_side_that_is_leaving() -> void:
+	var against_switch: int = _pursuit_damage(true)
+	var against_move: int = _pursuit_damage(false)
+
+	assert_gt(against_switch, against_move)
+	# Twice the figure, and the spread was already applied when `pursuit` ran, so
+	# the two are exactly double with the same seed.
+	assert_eq(against_switch, against_move * 2)
+
+
+## One Pursuit against a side that either switches or stands and fights, with the
+## same seed so only the doubling can differ.
+func _pursuit_damage(switching: bool) -> int:
+	var battle: Gen2Battle = _party_battle(
+		[
+			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		],
+		[_mon(Fixture.PIKACHU, 50, [Fixture.PURSUIT])]
+	)
+	battle.rng.seed = 4242
+	var target: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(0)
+	var before: int = target.hp
+	battle.take_actions(
+		Gen2Battle.switch_to(1) if switching else Gen2Battle.use_move(0),
+		Gen2Battle.use_move(0)
+	)
+	return before - target.hp
+
+
+## `PassedBattleMonEntrance` calls no `PursuitSwitch`, so a Baton Pass is not
+## pursued even though it is a switch made from inside a move.
+func test_a_baton_pass_is_not_pursued() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[
+			_mon(Fixture.GEODUDE, 50, [Fixture.BATON_PASS]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		],
+		[_mon(Fixture.PIKACHU, 50, [Fixture.PURSUIT])]
+	)
+	var leaving: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(0)
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
+	var full: int = leaving.hp
+	battle.pass_to(1)
+
+	assert_eq(leaving.hp, full, "nothing hit it on the way out")
+
+
+## `ForcePlayerMonChoice` calls none either: a replacement after a faint is not a
+## chosen switch and nothing pursues it.
+func test_a_replacement_after_a_faint_is_not_pursued() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[
+			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+			_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		],
+		[_mon(Fixture.PIKACHU, 50, [Fixture.PURSUIT])]
+	)
+	_faint(battle.party(Gen2Battle.PLAYER).at(0))
+	var arriving: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	battle.send_out(Gen2Battle.PLAYER, 1)
+
+	assert_eq(arriving.hp, arriving.max_hp())
+	assert_false(battle.is_switching(Gen2Battle.PLAYER),
+		"no turn is in flight, so no flag is up")
+
+
+## Teleport in a whole turn: the wild battle ends and the turn stops where it is,
+## the same shape a Whirlwind against a wild takes.
+func test_teleport_ends_the_turn_and_the_battle() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TELEPORT]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_true(battle.is_over())
+	assert_eq(battle.forced_out_side(), Gen2Battle.PLAYER)
+	assert_null(battle.winner())
+	assert_eq(_of_type(events, Gen2Battle.FLED_FROM_BATTLE).size(), 1)
+	assert_eq(_of_type(events, Gen2Battle.OVER).size(), 1)
+	# Pikachu at 50 outruns Geodude, so the enemy's own move is what does not run.
+	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 1)
+
+
+## The same `ret nz` a Whirlwind against a wild reaches, which is the end-of-turn
+## tail rather than the other side's move here: Whirlwind's priority of 0 puts it
+## second against an ordinary attack, so both Pokémon have already moved.
+func test_a_wild_force_switch_skips_the_end_of_turn_tail() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.WHIRLWIND]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.weather = Gen2Weather.SANDSTORM
+	battle.weather_turns = Gen2Weather.TURNS
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_true(battle.was_forced_out())
+	assert_eq(_of_type(events, Gen2Battle.HURT_BY_SANDSTORM).size(), 0,
+		"`ResidualDamage` sits behind the `ret nz`")
+	assert_eq(battle.weather_turns, Gen2Weather.TURNS, "and so does the weather count")
+	assert_eq(_of_type(events, Gen2Battle.OVER).size(), 1)

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -478,3 +478,56 @@ func test_gold_and_silver_wrap_a_screened_defence_above_1024() -> void:
 	assert_eq(
 		Gen2Damage.truncate_stats(100, 1000, true), Gen2Damage.truncate_stats(100, 1000, false)
 	)
+
+
+## `BattleCommand_Stab`'s matchup walk skips the rows past the `-2` marker unless
+## the target has been identified, and those two rows are Ghost's immunities.
+func test_foresight_opens_a_ghost_to_normal_damage() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU)
+	var defender: Gen2BattleMon = _mon(Fixture.GASTLY)
+	var move: Dictionary = _data.move(Fixture.TACKLE)
+
+	var blocked: Dictionary = Gen2Damage.stab_damage(attacker, defender, move, 40)
+	assert_true(blocked["immune"])
+	assert_eq(blocked["damage"], 0)
+
+	var opened: Dictionary = Gen2Damage.stab_damage(
+		attacker, defender, move, 40, Gen2Weather.NONE, true
+	)
+	assert_false(opened["immune"])
+	assert_eq(opened["damage"], 40, "neutral, so the figure is untouched")
+	assert_eq(opened["effectiveness"], RomLayout.MATCHUP_EFFECTIVE)
+
+
+## Nothing else moves: the flag cancels the two Ghost rows and no other.
+func test_foresight_leaves_every_other_matchup_alone() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU)
+	var defender: Gen2BattleMon = _mon(Fixture.GEODUDE)
+	var move: Dictionary = _data.move(Fixture.THUNDERBOLT)
+
+	var blocked: Dictionary = Gen2Damage.stab_damage(attacker, defender, move, 40)
+	var identified: Dictionary = Gen2Damage.stab_damage(
+		attacker, defender, move, 40, Gen2Weather.NONE, true
+	)
+	assert_true(blocked["immune"])
+	assert_true(identified["immune"], "Ground still shrugs off Electric")
+
+
+## `BattleCommand_BeatUp` hands `damagecalc` a party member's level in `e`, which
+## is the one figure the formula does not read off the Pokémon on the field.
+func test_damage_calc_takes_a_level_of_its_own() -> void:
+	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU, 50)
+	# Beat Up's power of 10 against Gastly's base Defense of 30, from Pikachu's own
+	# base Attack of 55. At level 50: 22 * 10 * 55 / 30 / 50 = 8, +2 = 10.
+	assert_eq(
+		Gen2Damage.damage_calc(attacker, 10, 55, 30, false, Fixture.DARK, false, 50), 10
+	)
+	# At level 10 the first term is 4 + 2 = 6: 6 * 10 * 55 / 30 / 50 = 2, +2 = 4.
+	assert_eq(
+		Gen2Damage.damage_calc(attacker, 10, 55, 30, false, Fixture.DARK, false, 10), 4
+	)
+	# -1 is the attacker's own, which is what every other caller passes.
+	assert_eq(
+		Gen2Damage.damage_calc(attacker, 10, 55, 30, false, Fixture.DARK, false, -1),
+		Gen2Damage.damage_calc(attacker, 10, 55, 30, false, Fixture.DARK, false, 50)
+	)

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -229,3 +229,42 @@ func test_every_refusal_reason_the_mod_layer_produces_has_player_wording() -> vo
 		assert_false(text.is_empty())
 	# An unworded reason still names something a search finds.
 	assert_string_contains(Gen2ModRefusal.text({"reason": &"brand_new"}), "brand_new")
+
+
+## The eight steps the last row of the effects table added are engine steps like
+## every other: a mod can name them in a list of its own and cannot take them over.
+func test_the_last_rows_steps_are_engine_steps_a_mod_can_name() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var steps: Array = [
+		Gen2EffectCommands.TELEPORT, Gen2EffectCommands.FORESIGHT,
+		Gen2EffectCommands.LOCK_ON, Gen2EffectCommands.SPITE,
+		Gen2EffectCommands.PAIN_SPLIT, Gen2EffectCommands.THIEF,
+		Gen2EffectCommands.PURSUIT, Gen2EffectCommands.BEAT_UP,
+	]
+	for step: StringName in steps:
+		assert_true(Gen2EffectCommands.is_engine_command(step), String(step))
+		assert_eq(
+			StringName(host.register_effect_command(MOD, step, _note)["reason"]),
+			&"reserved_effect_command", String(step)
+		)
+
+	var result: Dictionary = host.register_move_effect(MOD, NEW_EFFECT, [
+		Gen2EffectCommands.USED_MOVE_TEXT, Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.CHECK_HIT, Gen2EffectCommands.LOCK_ON,
+		Gen2EffectCommands.END_MOVE,
+	])
+	assert_true(bool(result["ok"]), JSON.stringify(result))
+	assert_true(Gen2MoveEffect.is_written(NEW_EFFECT))
+
+
+## None of the eight reads its own effect byte back, so none of them joins the
+## list a mod cannot rewrite.
+func test_the_last_rows_effects_stay_replaceable() -> void:
+	for effect: int in [
+		Gen2MoveEffect.PAIN_SPLIT, Gen2MoveEffect.LOCK_ON, Gen2MoveEffect.SPITE,
+		Gen2MoveEffect.THIEF, Gen2MoveEffect.FORESIGHT, Gen2MoveEffect.PURSUIT,
+		Gen2MoveEffect.TELEPORT, Gen2MoveEffect.BEAT_UP,
+	]:
+		assert_true(bool(Gen2ModHost.instance().register_move_effect(
+			MOD, effect, [Gen2EffectCommands.END_MOVE]
+		)["ok"]), "effect %d" % effect)

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -3508,3 +3508,600 @@ func test_the_four_scripted_battle_types_refuse_a_force_switch() -> void:
 
 		assert_false(battle.is_over(), "battle type %d" % battle_type)
 		assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## The last row of `data/moves/effects.asm`, which is where the count of unwritten
+## effect bytes stood before these landed.
+func test_the_last_row_of_the_effects_table_is_written() -> void:
+	for effect: int in [
+		Gen2MoveEffect.PAIN_SPLIT, Gen2MoveEffect.LOCK_ON, Gen2MoveEffect.SPITE,
+		Gen2MoveEffect.THIEF, Gen2MoveEffect.FORESIGHT, Gen2MoveEffect.PURSUIT,
+		Gen2MoveEffect.TELEPORT, Gen2MoveEffect.BEAT_UP,
+	]:
+		assert_true(Gen2MoveEffect.is_written(effect), "effect %d" % effect)
+		assert_ne(Gen2MoveEffect.sequence_for(effect), Gen2MoveEffect.NORMAL_HIT,
+			"effect %d has a list of its own" % effect)
+
+
+## Thief inserts two steps into the ordinary list and Pursuit one, each where the
+## cartridge puts it.
+func test_thief_and_pursuit_are_the_ordinary_list_with_steps_in_it() -> void:
+	var thief: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.THIEF)
+	assert_eq(thief.size(), Gen2MoveEffect.NORMAL_HIT.size() + 2)
+	# The steal is behind the damage and in front of the faint check, so a Pokémon
+	# knocked out by Thief still loses its item.
+	assert_lt(
+		thief.find(Gen2EffectCommands.APPLY_DAMAGE),
+		thief.find(Gen2EffectCommands.THIEF)
+	)
+	assert_lt(
+		thief.find(Gen2EffectCommands.THIEF),
+		thief.find(Gen2EffectCommands.CHECK_FAINT)
+	)
+
+	var pursuit: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.PURSUIT)
+	assert_eq(pursuit.size(), Gen2MoveEffect.NORMAL_HIT.size() + 1)
+	# Between the spread and the roll, which is the last point the finished figure
+	# can still be multiplied.
+	assert_lt(
+		pursuit.find(Gen2EffectCommands.DAMAGE_VARIATION),
+		pursuit.find(Gen2EffectCommands.PURSUIT)
+	)
+	assert_lt(
+		pursuit.find(Gen2EffectCommands.PURSUIT),
+		pursuit.find(Gen2EffectCommands.CHECK_HIT)
+	)
+
+
+## Beat Up carries no `damagestats` and no `stab`, which is what makes it hit for
+## base stats and never for a matchup.
+func test_beat_up_carries_neither_damage_stats_nor_stab() -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.BEAT_UP)
+	assert_false(sequence.has(Gen2EffectCommands.DAMAGE_STATS))
+	assert_false(sequence.has(Gen2EffectCommands.STAB))
+	assert_false(sequence.has(Gen2EffectCommands.CHECK_IMMUNE))
+	# One accuracy roll for the whole move: `endloop` jumps back to `critical`, so
+	# `checkhit` sits outside the loop.
+	assert_lt(
+		sequence.find(Gen2EffectCommands.CHECK_HIT),
+		sequence.find(Gen2EffectCommands.BEAT_UP)
+	)
+
+
+func test_foresight_identifies_the_target_and_refuses_a_second() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.FORESIGHT)
+
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.IDENTIFIED),
+		"the flag sits on the Pokemon that was identified")
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.IDENTIFIED))
+	assert_eq(_of_type(turn.events, Gen2Battle.IDENTIFIED_SET).size(), 1)
+
+	var again: Gen2Turn = _run_move(battle, Fixture.FORESIGHT)
+	assert_eq(_of_type(again.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## A target out of sight is not identified. Foresight's own `CheckHiddenOpponent`
+## is not what refuses it: `checkhit` sits in front of the command and sets
+## `wAttackMissed` first, which is the standing `failuretext` divergence, so the
+## line is the miss rather than "But it failed!".
+func test_foresight_refuses_a_target_that_is_out_of_sight() -> void:
+	for flag: int in [Gen2Substatus.FLYING, Gen2Substatus.UNDERGROUND]:
+		var battle: Gen2Battle = _battle()
+		battle.enemy.substatus |= flag
+		var turn: Gen2Turn = _run_move(battle, Fixture.FORESIGHT)
+
+		assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.IDENTIFIED))
+		assert_true(turn.missed)
+		assert_eq(_of_type(turn.events, Gen2Battle.MISSED).size(), 1)
+
+
+## `.StatModifiers`' Foresight branch returns before it multiplies anything, and
+## only when the evasion stage is at least the accuracy stage: it cannot undo an
+## accuracy the attacker raised.
+func test_an_identified_target_loses_the_evasion_it_had_raised() -> void:
+	var raised: int = Gen2Accuracy.chance(229, 0, 4)
+	assert_lt(raised, 229, "a raised evasion cuts a 90% move down")
+	assert_eq(Gen2Accuracy.chance(229, 0, 4, true), 229,
+		"identified, the stored byte stands")
+	# The attacker's own raise survives, since the branch is behind `jr c`.
+	assert_eq(
+		Gen2Accuracy.chance(100, 4, 0, true), Gen2Accuracy.chance(100, 4, 0),
+		"an accuracy above the evasion is multiplied either way"
+	)
+
+
+## `BattleCommand_Stab`'s matchup walk skips the rows past the `-2` marker unless
+## the target has been identified, and those two rows are Ghost's immunities.
+func test_an_identified_ghost_can_be_hit_by_normal_and_fighting() -> void:
+	for attacking: int in [Fixture.NORMAL, Fixture.FIGHTING]:
+		assert_eq(_data.type_matchup(attacking, Fixture.GHOST), 0,
+			"immune while unidentified")
+		assert_eq(
+			_data.type_matchup(attacking, Fixture.GHOST, true),
+			RomLayout.MATCHUP_EFFECTIVE,
+			"identified, the immunity is gone"
+		)
+	# Nothing else moves: Psychic against Dark is not a Ghost immunity.
+	assert_eq(_data.type_matchup(Fixture.PSYCHIC_TYPE, Fixture.DARK, true), 0)
+
+
+func test_a_tackle_reaches_an_identified_gastly() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		Gen2BattleMon.create(_data, Fixture.GASTLY, 50, [Fixture.TACKLE]),
+		_rng
+	)
+	var blocked: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+	assert_true(blocked.immune, "Normal cannot touch a Ghost")
+
+	battle.enemy.substatus |= Gen2Substatus.IDENTIFIED
+	var reaches: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+	assert_false(reaches.immune)
+	assert_gt(reaches.damage, 0)
+
+
+func test_lock_on_marks_the_target_and_the_next_hit_check_spends_it() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.LOCK_ON)
+
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON),
+		"the flag sits on the Pokemon that was aimed at")
+	assert_eq(_of_type(turn.events, Gen2Battle.TOOK_AIM).size(), 1)
+
+	# `res SUBSTATUS_LOCK_ON` runs on every hit check, set or not, so one move
+	# spends it.
+	_run_move(battle, Fixture.TACKLE)
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON))
+
+
+## Mind Reader is the same effect byte and the same command.
+func test_mind_reader_is_lock_on() -> void:
+	assert_eq(
+		int(_data.move(Fixture.MIND_READER)["effect"]),
+		int(_data.move(Fixture.LOCK_ON)["effect"])
+	)
+	var battle: Gen2Battle = _battle()
+	_run_move(battle, Fixture.MIND_READER)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON))
+
+
+func test_lock_on_is_refused_by_a_substitute() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.SUBSTITUTE
+	battle.enemy.substitute_hp = 20
+	var turn: Gen2Turn = _run_move(battle, Fixture.LOCK_ON)
+
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON))
+	assert_eq(_of_type(turn.events, Gen2Battle.NO_EFFECT).size(), 1)
+
+
+## A locked-on move connects whatever the accuracy says, which is what makes an
+## otherwise unwinnable roll certain.
+func test_a_locked_on_move_cannot_miss() -> void:
+	for seed_value: int in 40:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed_value
+		battle.enemy.substatus |= Gen2Substatus.LOCK_ON
+		# Evasion at the ceiling, which would otherwise cut a 90% move to a third.
+		battle.enemy.stages["evasion"] = 6
+		var turn: Gen2Turn = _run_move(battle, Fixture.SCREECH)
+		assert_false(turn.missed, "seed %d" % seed_value)
+
+
+## `.LockOn` names three moves that still cannot reach a target above them, and
+## `.FlyDigMoves` behind it is what turns them away.
+##
+## Only two of the three are reachable. `OHKOHit` carries no `checkhit` at all, so
+## Fissure never reads the flag and the branch naming it is source no move gets
+## to; the test below owns that half.
+func test_a_locked_on_flying_target_is_still_missed_by_the_ground_moves() -> void:
+	for move: int in [Fixture.EARTHQUAKE, Fixture.MAGNITUDE]:
+		var battle: Gen2Battle = _battle()
+		battle.enemy.substatus |= Gen2Substatus.LOCK_ON | Gen2Substatus.FLYING
+		var turn: Gen2Turn = _run_move(battle, move)
+		assert_true(turn.missed, "move %d" % move)
+
+	# The same target is reached by anything else, since the lock-on is read in
+	# front of the hidden check.
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.LOCK_ON | Gen2Substatus.FLYING
+	assert_false(_run_move(battle, Fixture.TACKLE).missed)
+
+
+## Fissure's own list has no `checkhit`, so the flag it is named against is
+## neither read nor spent by it.
+func test_fissure_never_reaches_the_lock_on_read() -> void:
+	assert_false(
+		Gen2MoveEffect.sequence_for(Gen2MoveEffect.OHKO).has(Gen2EffectCommands.CHECK_HIT),
+		"`OHKOHit` rolls its own accuracy instead"
+	)
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.LOCK_ON
+	_run_move(battle, Fixture.FISSURE)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON))
+
+
+## `.Protect` is asked before `.LockOn`, so a Protect turns a locked-on move away
+## and the flag is left standing for the move behind it.
+func test_a_protect_turns_a_locked_on_move_away_without_spending_the_flag() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.LOCK_ON | Gen2Substatus.PROTECT
+	var turn: Gen2Turn = _run_move(battle, Fixture.TACKLE)
+
+	assert_true(turn.missed)
+	assert_eq(_of_type(turn.events, Gen2Battle.PROTECTING_ITSELF).size(), 1)
+	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON),
+		"`res` sits behind the Protect branch, so the flag survives it")
+
+
+func test_spite_takes_two_to_five_pp_off_the_targets_last_move() -> void:
+	var seen: Dictionary = {}
+	for seed_value: int in 60:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed_value
+		battle.enemy.last_move_used = Fixture.TACKLE
+		var turn: Gen2Turn = _run_move(battle, Fixture.SPITE)
+
+		var event: Dictionary = _first(turn.events, Gen2Battle.PP_REDUCED)
+		var amount: int = int(event["amount"])
+		assert_between(amount, 2, 5, "seed %d" % seed_value)
+		assert_eq(int(event["slot"]), 0)
+		assert_eq(int(event["move"]), Fixture.TACKLE)
+		assert_eq(battle.enemy.pp_left(0), 35 - amount)
+		seen[amount] = true
+
+	assert_eq(seen.size(), 4, "all four of the two-bit roll's values come up")
+
+
+## `cp b / jr nc` keeps the roll only while the slot has that much: a slot with one
+## PP left loses one.
+func test_spite_clamps_to_the_pp_that_is_there() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.last_move_used = Fixture.TACKLE
+	battle.enemy.pp[0] = 1
+	var turn: Gen2Turn = _run_move(battle, Fixture.SPITE)
+
+	assert_eq(battle.enemy.pp_left(0), 0)
+	assert_eq(int(_first(turn.events, Gen2Battle.PP_REDUCED)["amount"]), 1)
+
+
+func test_spite_refuses_a_target_with_nothing_to_drain() -> void:
+	# Nothing used yet.
+	var fresh: Gen2Battle = _battle()
+	assert_eq(_of_type(_run_move(fresh, Fixture.SPITE).events,
+		Gen2Battle.NO_EFFECT).size(), 1)
+
+	# Struggle, which is not in any list to drain.
+	var struggled: Gen2Battle = _battle()
+	struggled.enemy.last_move_used = Gen2Damage.STRUGGLE
+	assert_eq(_of_type(_run_move(struggled, Fixture.SPITE).events,
+		Gen2Battle.NO_EFFECT).size(), 1)
+
+	# A slot already empty.
+	var spent: Gen2Battle = _battle()
+	spent.enemy.last_move_used = Fixture.TACKLE
+	spent.enemy.pp[0] = 0
+	assert_eq(_of_type(_run_move(spent, Fixture.SPITE).events,
+		Gen2Battle.NO_EFFECT).size(), 1)
+
+	# A move no longer in the list, which the cartridge's own unbounded loop would
+	# have run off the end of.
+	var replaced: Gen2Battle = _battle()
+	replaced.enemy.last_move_used = Fixture.SLASH
+	assert_eq(_of_type(_run_move(replaced, Fixture.SPITE).events,
+		Gen2Battle.NO_EFFECT).size(), 1)
+
+
+func test_pain_split_averages_both_totals() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.hp = 10
+	battle.enemy.hp = 40
+	var turn: Gen2Turn = _run_move(battle, Fixture.PAIN_SPLIT)
+
+	assert_eq(battle.player.hp, 25)
+	assert_eq(battle.enemy.hp, 25)
+	assert_eq(_of_type(turn.events, Gen2Battle.SHARED_PAIN).size(), 1)
+	# Floored, not rounded: the sixteen-bit sum is shifted right once.
+	var odd: Gen2Battle = _battle()
+	odd.player.hp = 10
+	odd.enemy.hp = 11
+	_run_move(odd, Fixture.PAIN_SPLIT)
+	assert_eq(odd.player.hp, 10)
+	assert_eq(odd.enemy.hp, 10)
+
+
+## `.EnemyShareHP`'s `jr nc, .skip` keeps the maximum when the average is past it,
+## so a Pokémon with a small maximum is filled rather than overfilled.
+func test_pain_split_clamps_each_side_to_its_own_maximum() -> void:
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data,
+		Gen2BattleMon.create(_data, Fixture.GASTLY, 5, [Fixture.PAIN_SPLIT]),
+		Gen2BattleMon.create(_data, Fixture.GEODUDE, 80, [Fixture.TACKLE]),
+		_rng
+	)
+	var small: int = battle.player.max_hp()
+	battle.player.hp = 1
+	assert_gt(battle.enemy.hp / 2, small, "the average is past the small maximum")
+
+	_run_move(battle, Fixture.PAIN_SPLIT)
+	assert_eq(battle.player.hp, small, "filled, not overfilled")
+
+
+## The health words are written by hand, so no doll stands in the way and there is
+## nothing for one to take.
+func test_pain_split_is_refused_by_a_substitute() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.hp = 10
+	battle.enemy.substatus |= Gen2Substatus.SUBSTITUTE
+	battle.enemy.substitute_hp = 20
+	var turn: Gen2Turn = _run_move(battle, Fixture.PAIN_SPLIT)
+
+	assert_eq(battle.player.hp, 10, "nothing moved")
+	assert_eq(_of_type(turn.events, Gen2Battle.NO_EFFECT).size(), 1)
+
+
+func test_thief_takes_the_targets_item() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.item = Fixture.MAGNET
+	var turn: Gen2Turn = _run_move(battle, Fixture.THIEF)
+
+	assert_eq(battle.player.item, Fixture.MAGNET)
+	assert_eq(battle.enemy.item, 0)
+	assert_eq(int(_first(turn.events, Gen2Battle.STOLE_ITEM)["item"]), Fixture.MAGNET)
+	# The party member and the Pokemon on the field are one object here, which is
+	# what makes a stolen item gone for good.
+	assert_eq(battle.party(Gen2Battle.PLAYER).at(0).item, Fixture.MAGNET)
+
+
+func test_thief_refuses_a_thief_that_is_already_carrying_something() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.item = Fixture.LEFTOVERS
+	battle.enemy.item = Fixture.MAGNET
+	var turn: Gen2Turn = _run_move(battle, Fixture.THIEF)
+
+	assert_eq(battle.player.item, Fixture.LEFTOVERS)
+	assert_eq(battle.enemy.item, Fixture.MAGNET)
+	assert_eq(_of_type(turn.events, Gen2Battle.STOLE_ITEM).size(), 0)
+	# Silently: every one of Thief's refusals is a bare `ret`.
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0)
+
+
+func test_thief_leaves_mail_where_it_is() -> void:
+	assert_true(Gen2HeldItem.is_mail(Fixture.FLOWER_MAIL))
+	assert_false(Gen2HeldItem.is_mail(Fixture.MAGNET))
+
+	var battle: Gen2Battle = _battle()
+	battle.enemy.item = Fixture.FLOWER_MAIL
+	var turn: Gen2Turn = _run_move(battle, Fixture.THIEF)
+
+	assert_eq(battle.enemy.item, Fixture.FLOWER_MAIL)
+	assert_eq(battle.player.item, 0)
+	assert_eq(_of_type(turn.events, Gen2Battle.STOLE_ITEM).size(), 0)
+	# The hit still landed: the steal is behind `applydamage`.
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 1)
+
+
+func test_teleport_takes_its_own_user_out_of_a_wild_battle() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.TELEPORT)
+
+	assert_true(battle.is_over())
+	assert_true(battle.was_forced_out())
+	assert_eq(battle.forced_out_side(), Gen2Battle.PLAYER, "the user is who left")
+	assert_null(battle.winner(), "SetBattleDraw: nobody beat anybody")
+	assert_eq(_of_type(turn.events, Gen2Battle.FLED_FROM_BATTLE).size(), 1)
+
+
+func test_teleport_is_refused_in_a_trainer_battle() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.TELEPORT])]),
+		Gen2Party.create([Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE])]),
+		_rng, true
+	)
+	var turn: Gen2Turn = _run_move(battle, Fixture.TELEPORT)
+
+	assert_false(battle.is_over())
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+func test_teleport_is_refused_by_the_four_scripted_battle_types() -> void:
+	for battle_type: int in Gen2EffectCommands.FORCE_SWITCH_REFUSED_TYPES:
+		var battle: Gen2Battle = _battle()
+		battle.battle_type = battle_type
+		var turn: Gen2Turn = _run_move(battle, Fixture.TELEPORT)
+
+		assert_false(battle.is_over(), "battle type %d" % battle_type)
+		assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## `wEnemySubStatus5`'s own `SUBSTATUS_CANT_RUN`, which is what Mean Look and
+## Spider Web leave on the Pokemon doing the holding.
+func test_teleport_is_refused_while_the_opponent_holds_the_user() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.enemy.substatus |= Gen2Substatus.CANT_RUN
+	var turn: Gen2Turn = _run_move(battle, Fixture.TELEPORT)
+
+	assert_false(battle.is_over())
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## Below the other's level the player's half goes on the dice, drawn out of the two
+## levels summed and one more, and fails under a quarter of the other's level. A
+## level 4 user against a level 50 fails on the twelve values under 12, out of 55.
+func test_a_weaker_player_rolls_for_teleport() -> void:
+	var failures: int = 0
+	var samples: int = 200
+	for seed_value: int in samples:
+		var battle: Gen2Battle = Gen2Battle.create(
+			_data,
+			Gen2BattleMon.create(_data, Fixture.PIKACHU, 4, [Fixture.TELEPORT]),
+			Gen2BattleMon.create(_data, Fixture.GEODUDE, 50, [Fixture.TACKLE]),
+			_rng
+		)
+		battle.rng.seed = seed_value
+		if _of_type(_run_move(battle, Fixture.TELEPORT).events,
+			Gen2Battle.MOVE_FAILED).size() > 0:
+			failures += 1
+
+	var expected: int = samples * 12 / 55
+	assert_almost_eq(failures, expected, expected / 3,
+		"roughly twelve of the fifty-five values it can draw")
+
+
+## `docs/bugs_and_glitches.md`: the enemy's own `jr nc, .run_away` falls into
+## `.run_away`, so the roll it draws decides nothing and a wild Pokemon always
+## teleports. The roll is still drawn.
+func test_a_wild_pokemon_always_teleports_and_still_draws_the_roll() -> void:
+	for seed_value: int in 40:
+		var battle: Gen2Battle = Gen2Battle.create(
+			_data,
+			Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+			Gen2BattleMon.create(_data, Fixture.GEODUDE, 4, [Fixture.TELEPORT]),
+			_rng
+		)
+		battle.rng.seed = seed_value
+		var before: int = battle.rng.state
+		var turn: Gen2Turn = _run_enemy_move(battle, Fixture.TELEPORT)
+
+		assert_true(battle.is_over(), "seed %d" % seed_value)
+		assert_eq(battle.forced_out_side(), Gen2Battle.ENEMY)
+		assert_eq(_of_type(turn.events, Gen2Battle.FLED_FROM_BATTLE).size(), 1)
+		assert_ne(battle.rng.state, before, "the roll is drawn and thrown away")
+
+
+## `pursuit` reads the other side's switching flag and doubles nothing without it.
+## The flag itself is [method Gen2Battle.is_switching], which only a turn in
+## flight can raise; test_battle.gd owns the switch-time half.
+func test_pursuit_doubles_nothing_outside_a_switch() -> void:
+	var battle: Gen2Battle = _battle()
+	assert_false(battle.is_switching(Gen2Battle.ENEMY),
+		"nothing is switching between turns")
+
+	var turn: Gen2Turn = _turn(battle, Fixture.PURSUIT)
+	turn.damage = 100
+	Gen2EffectCommands.run(Gen2EffectCommands.PURSUIT, turn)
+	assert_eq(turn.damage, 100)
+
+
+## One swing per party member, in party order, each named.
+func test_beat_up_swings_once_per_party_member() -> void:
+	var battle: Gen2Battle = _beat_up_battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.BEAT_UP)
+
+	var swings: Array = _of_type(turn.events, Gen2Battle.BEAT_UP_ATTACK)
+	assert_eq(swings.size(), 3)
+	assert_eq(int(swings[0]["index"]), 0)
+	assert_eq(int(swings[1]["index"]), 1)
+	assert_eq(int(swings[2]["index"]), 2)
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 3)
+	# `.beat_up_2` skips `endloop`'s summary line for this effect alone.
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT_TIMES).size(), 0)
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0)
+
+
+## `damagecalc` is handed the member's own base Attack and level and the target's
+## base Defense, none of them touched by a stage, an item or the truncation
+## `damagestats` would have done.
+func test_beat_up_uses_base_stats_and_each_members_own_level() -> void:
+	var battle: Gen2Battle = _beat_up_battle()
+	# A stage the formula must not see, since there is no `damagestats` to read it.
+	battle.player.stages["attack"] = 6
+	var turn: Gen2Turn = _run_move(battle, Fixture.BEAT_UP)
+
+	# The last member's numbers are what the turn is left holding: Bulbasaur's own
+	# base Attack of 49 at level 10, against Gastly's base Defense of 30.
+	assert_eq(turn.attack_stat, 49)
+	assert_eq(turn.defense_stat, 30)
+	assert_eq(turn.level_override, 10)
+	assert_eq(turn.power_override, 10, "the move's own power, not a stat")
+	# No `stab`, so no matchup and no immunity however the chart reads.
+	assert_eq(turn.effectiveness, RomLayout.MATCHUP_EFFECTIVE)
+	assert_false(turn.immune)
+
+
+## `.beatup_fail` skips that member's hit and lets the loop carry on.
+func test_beat_up_skips_a_fainted_or_statused_member() -> void:
+	var battle: Gen2Battle = _beat_up_battle()
+	battle.party(Gen2Battle.PLAYER).at(1).status = Gen2Status.PARALYSIS
+	battle.party(Gen2Battle.PLAYER).at(2).hp = 0
+	var turn: Gen2Turn = _run_move(battle, Fixture.BEAT_UP)
+
+	var swings: Array = _of_type(turn.events, Gen2Battle.BEAT_UP_ATTACK)
+	assert_eq(swings.size(), 1)
+	assert_eq(int(swings[0]["index"]), 0)
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0,
+		"one member landed a hit, so `beatupfailtext` says nothing")
+
+
+func test_beat_up_says_it_failed_when_no_member_could_swing() -> void:
+	var battle: Gen2Battle = _beat_up_battle()
+	for index: int in 3:
+		battle.party(Gen2Battle.PLAYER).at(index).status = Gen2Status.PARALYSIS
+	var turn: Gen2Turn = _run_move(battle, Fixture.BEAT_UP)
+
+	assert_eq(_of_type(turn.events, Gen2Battle.BEAT_UP_ATTACK).size(), 0)
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## `.only_one_beatup`, which `docs/bugs_and_glitches.md` records: the one hit lands
+## and then `jp EndMoveEffect` takes the rest of the list with it.
+func test_beat_up_with_one_party_member_ends_before_kings_rock() -> void:
+	var alone: Array = _commands_run(_battle(), Fixture.BEAT_UP)
+	assert_true(alone.has(Gen2EffectCommands.BEAT_UP))
+	assert_false(alone.has(Gen2EffectCommands.KINGS_ROCK),
+		"`.only_one_beatup` takes the rest of the list with it")
+
+	# A party of three falls out of the loop instead and reaches the item.
+	var party: Array = _commands_run(_beat_up_battle(), Fixture.BEAT_UP)
+	assert_true(party.has(Gen2EffectCommands.KINGS_ROCK))
+
+
+## `.wild`: no party to walk, so one ordinary hit off the wild Pokemon's own real
+## stats, and `.only_one_beatup` prints "But it failed!" behind a hit that landed.
+func test_a_wild_beat_up_swings_once_and_says_it_failed_anyway() -> void:
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_enemy_move(battle, Fixture.BEAT_UP)
+
+	var swings: Array = _of_type(turn.events, Gen2Battle.BEAT_UP_ATTACK)
+	assert_eq(swings.size(), 1)
+	assert_eq(int(swings[0]["index"]), -1, "a wild Pokemon has no party slot")
+	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 1)
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+	assert_eq(turn.level_override, -1, "its own level, through the ordinary steps")
+	assert_gt(turn.attack_stat, 0, "`damagestats` ran, so these are real stats")
+
+
+## Three party members over two levels, against a target whose base Defense is low
+## enough for a power of 10 to show.
+func _beat_up_battle() -> Gen2Battle:
+	return Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [Fixture.BEAT_UP]),
+			Gen2BattleMon.create(_data, Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+			Gen2BattleMon.create(_data, Fixture.BULBASAUR, 10, [Fixture.TACKLE]),
+		]),
+		Gen2Party.create([
+			Gen2BattleMon.create(_data, Fixture.GASTLY, 60, [Fixture.TACKLE]),
+		]),
+		_rng, true
+	)
+
+
+## Which steps a move actually reached, for the two effects that end their own
+## list part way and so leave the commands behind them unrun.
+func _commands_run(battle: Gen2Battle, move_number: int) -> Array:
+	var turn: Gen2Turn = Gen2Turn.create(
+		battle, Gen2Battle.PLAYER, 0, move_number, _data.move(move_number), []
+	)
+	var ran: Array = []
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	for command: StringName in Gen2MoveEffect.sequence_for(turn.effect()):
+		if turn.ended:
+			break
+		ran.append(command)
+		Gen2EffectCommands.run(command, turn)
+	return ran


### PR DESCRIPTION
The last row of effects.asm: Thief, Pain Split, Spite, Foresight, Lock On, Mind Reader, Pursuit, Beat Up and Teleport. Eight effect bytes over nine moves, leaving 12 bytes over 12 moves, all of them Bide's, Mimic's or Metronome's kind of problem plus Pay Day, which stays out because no battle here pays prize money.

Two flags, both sitting on the Pokemon they were aimed at rather than the one that aimed. SUBSTATUS_IDENTIFIED drops the target's evasion out of the accuracy sum, and only when the evasion is at least the attacker's accuracy, so it cannot undo an accuracy somebody raised; it also opens the two rows the type chart keeps past its own -2 marker, which are Normal and Fighting against a Ghost. SUBSTATUS_LOCK_ON is spent by the next hit check made against that Pokemon whether it was set or not, since the res sits in front of the ret z. Both readers were written before either flag was: Gen2Accuracy.chance's foresight argument and GameData.type_matchup's had no caller until now, and the importer has been keeping the two negated rows apart the whole time.

Ordering inside check_hit had to go back to the cartridge's. Lock-on beats Fly and Dig but must not beat Protect or the drain-substitute check, so the hidden test moves behind it, which is where BattleCommand_CheckHit has always had it. Fissure is named in that branch and unreachable through it, here and on the cartridge: OHKOHit carries no checkhit at all.

Pursuit is two halves. The command doubles a finished figure against a side that is leaving; PursuitSwitch is what runs the whole move early, in front of the recall, out of BattleMonEntrance and AI_Switch and out of neither of the two entrances a Baton Pass or a replacement uses. The pursuer then has nothing left to spend, which is CANNOT_MOVE written over its move and CheckTurn reading it back.

Beat Up hits from base stats. No damagestats and no stab in its list, so the formula is handed a party member's base Attack, the target's base Defense and that member's own level, untruncated, and nothing multiplies the result by a matchup or the weather. A level is the one figure wPlayerMoveStruct has no counterpart for, so Gen2Turn carries it. Both of its recorded bugs are mirrored: a party of one ends the move before kingsrock, and a wild Pokemon swings once and says it failed anyway, because the wild branch never sets the flag the fail text reads.

Found on the way and fixed here. wForcedSwitch ended nothing: Battle_PlayerFirst and Battle_EnemyFirst each ask it behind their own wrapper and ret nz, so a Whirlwind against a wild should stop the turn dead, and instead the other side still moved and the residuals, the weather, the perish count and the held items all still ticked. Teleport reaches the same pair, with the side leaving being its own user. AI_Smart_TrapTarget was two of its five states short and its comment said the flags did not exist; Nightmare's has for some time. The test fixture had Fighting against Ghost as a permanent immunity, where the cartridge lists it only past the Foresight marker, and had parked a synthetic Supersonic on 251, which is Beat Up's own number.