### PR TITLE
Turn on the spot, blink the arrow, and face the way the intro faces

### DIFF
--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -106,3 +106,28 @@ static func _lookup(palette: PackedColorArray, transparent_background: bool) -> 
 			else int(roundf(clampf(color.a, 0.0, 1.0) * 255.0))
 
 	return out
+
+
+## `PlaceGraphic`'s `.right` branch, which `wBoxAlignment` selects.
+##
+## It walks the tile columns from the right rather than the left
+## (`engine/gfx/place_graphic.asm`: `dec hl` against `inc hl`), so the pic's
+## first tile column lands in the box's last. The tiles themselves are not
+## flipped, which is why this reverses eight-pixel strips rather than mirroring
+## pixels. `PrepMonFrontpic` is the one caller that sets the flag, and the Oak
+## speech is the one screen that reaches it, so the intro's Pokemon faces the
+## other way from its own front pic.
+static func column_reversed(image: Image, tile: int = 8) -> Image:
+	if image == null or tile <= 0:
+		return image
+	var columns: int = image.get_width() / tile
+	if columns <= 1:
+		return image
+	var out: Image = Image.create_empty(
+		image.get_width(), image.get_height(), false, image.get_format()
+	)
+	for column: int in columns:
+		var from := Rect2i(column * tile, 0, tile, image.get_height())
+		var to := Vector2i((columns - 1 - column) * tile, 0)
+		out.blit_rect(image, from, to)
+	return out

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -38,6 +38,13 @@ const LINE_SPACING: int = 2
 ## `PromptText` all load it before `PromptButton` and unload it after.
 const CURSOR_CODE: int = 0xEE
 const CURSOR_COLUMN: int = 18
+## `PromptButton.blink_cursor` reads `hVBlankCounter` and `and 1 << 4`, so the
+## arrow is up for sixteen frames and the border's own '─' is back for the
+## next sixteen (`home/joypad.asm`). Counted in seconds rather than frames for
+## the reason [member reveal_speed] is a rate: the period is the same either
+## way and this does not assume 60 Hz.
+const CURSOR_BLINK_FRAMES: int = 16
+const FRAME_SECONDS: float = 1.0 / 60.0
 
 const TILE: int = Gen2Font.TILE
 
@@ -76,6 +83,7 @@ var _page: int = 0
 var _lines: Array = []
 var _tiles_on_page: int = 0
 var _shown: float = 0.0
+var _blink: float = 0.0
 
 
 func _ready() -> void:
@@ -85,12 +93,18 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	if _shown >= float(_tiles_on_page):
+	if _shown < float(_tiles_on_page):
+		_shown = minf(_shown + delta * reveal_speed, float(_tiles_on_page))
+		_redraw()
+		return
+	if _pages.is_empty():
 		set_process(false)
 		return
-
-	_shown = minf(_shown + delta * reveal_speed, float(_tiles_on_page))
-	_redraw()
+	# Waiting: only the arrow changes, and only when it crosses a half period.
+	var was_up: bool = _cursor_up()
+	_blink = fmod(_blink + delta, FRAME_SECONDS * float(CURSOR_BLINK_FRAMES) * 2.0)
+	if _cursor_up() != was_up:
+		_redraw()
 
 
 ## Puts the box where the games put it: flush to the left, six rows up from the
@@ -179,7 +193,8 @@ func _start_page() -> void:
 			_tiles_on_page += codes.size()
 
 	_shown = 0.0
-	set_process(reveal_speed > 0.0 and _tiles_on_page > 0)
+	_blink = 0.0
+	set_process(_tiles_on_page > 0)
 	if reveal_speed <= 0.0:
 		_shown = float(_tiles_on_page)
 	_redraw()
@@ -213,6 +228,13 @@ func _redraw() -> void:
 	size = Vector2(width, height)
 
 
+## Which half of the blink the box is in. `UnloadBlinkingCursor` puts the
+## border's '─' back rather than a blank, and the border is redrawn under the
+## arrow anyway, so the off half simply does not draw.
+func _cursor_up() -> bool:
+	return _blink < FRAME_SECONDS * float(CURSOR_BLINK_FRAMES)
+
+
 func _draw_border(indices: PackedByteArray, width: int) -> void:
 	font.draw_box(frame_style, indices, width, 0, 0, columns, rows)
 
@@ -220,7 +242,7 @@ func _draw_border(indices: PackedByteArray, width: int) -> void:
 ## The arrow, drawn only while the box is actually waiting: a page still
 ## revealing has not reached its `PromptButton` yet.
 func _draw_cursor(indices: PackedByteArray, width: int) -> void:
-	if _pages.is_empty() or is_revealing():
+	if _pages.is_empty() or is_revealing() or not _cursor_up():
 		return
 	if CURSOR_COLUMN >= columns or rows <= 0:
 		return

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -185,7 +185,11 @@ func _show_pic(kind: int) -> void:
 		Gen2OakSpeech.Pic.OAK:
 			image = _trainer_image(Gen2OakSpeech.POKEMON_PROF)
 		Gen2OakSpeech.Pic.MON:
-			image = _species_image(Gen2OakSpeech.intro_species(_data))
+			# `PrepMonFrontpic` sets wBoxAlignment before `PlaceGraphic`, and
+			# `Intro_PrepTrainerPic` does not, so only this beat is reversed.
+			image = Gen2PicImage.column_reversed(
+				_species_image(Gen2OakSpeech.intro_species(_data))
+			)
 	if image == null:
 		return
 	_pic.texture = ImageTexture.create_from_image(image)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -38,6 +38,10 @@ const STEP_FRAMES_BOULDER_PUSH: int = STEP_FRAMES_NPC_WALK
 ## StepVectors' fast row: 4 pixels per frame for 4 frames, which the bike-speed
 ## movement commands reach through `STEP_BIKE`.
 const STEP_FRAMES_FAST: int = 4
+## `StepFunction_Turn` (engine/overworld/map_objects.asm): two frames standing,
+## then the new facing is written and two more, so a turn on the spot costs
+## four frames and no cell.
+const STEP_FRAMES_TURN: int = 4
 ## How long each scripted step command takes, from the `STEP_*` speed it passes
 ## to `InitStep` (engine/overworld/movement.asm) and that row of `StepVectors`.
 ##
@@ -3761,6 +3765,39 @@ func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictiona
 
 ## Moves one cell or enters a neighboring map when the step leaves a connected
 ## map edge. The legacy boolean move() wrapper remains available to callers.
+## `DoPlayerMovement`, which is what a button press reaches: `.CheckTurning`
+## and then [method move_result]'s `.TryStep`.
+##
+## `.CheckTurning`'s own comment is "This also lets the player change facing
+## without moving by tapping a direction". It runs before any collision check,
+## so a direction that differs from the current facing turns on the spot even
+## into a wall, and the walk happens on the next poll, once the facing agrees.
+## It guards on `wPlayerTurningDirection`, which `.StandInPlace` clears, so a
+## turn is only ever taken from a standstill.
+##
+## Only the input path has it. `applymovement` drives an object through
+## `engine/overworld/movement.asm` and never reaches `DoPlayerMovement`, which
+## is why a scripted walk turns nothing and [method move_result] stays the
+## step on its own.
+func player_input_move(direction: Vector2i) -> Dictionary:
+	if abs(direction.x) + abs(direction.y) != 1:
+		return {"ok": false, "kind": &"move", "reason": &"invalid_direction"}
+	if player_step_in_progress():
+		return {"ok": false, "kind": &"move", "reason": &"step_in_progress"}
+	## `.CheckTile` overwrites the pressed direction, so a forced walk is not a
+	## turn however the facing sits; move_result owns that branch.
+	var forced: StringName = StringName(forced_movement().get("kind", &"none"))
+	if forced == &"none":
+		var pressed_facing: int = _facing_for_direction(direction)
+		if pressed_facing != player_facing:
+			player_facing = pressed_facing
+			_start_player_step(Vector2i.ZERO, STEP_FRAMES_TURN)
+			return {
+				"ok": true, "kind": &"turn", "facing": player_facing, "cell": player_cell,
+			}
+	return move_result(direction)
+
+
 func move_result(direction: Vector2i) -> Dictionary:
 	if phone_ring_active():
 		return {"ok": false, "kind": &"move", "reason": &"phone_ring_active"}

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -558,7 +558,7 @@ func move_player(direction: Vector2i) -> bool:
 		or _field_move_text or _world.phone_ring_active() \
 		or not _trainer_approach.is_empty() or _world.player_step_in_progress():
 		return false
-	var movement: Dictionary = _world.move_result(direction)
+	var movement: Dictionary = _world.player_input_move(direction)
 	if not bool(movement.get("ok", false)):
 		## A push bumps the player and starts the boulder, so the step reports
 		## blocked while the map still changed. MovementFunction_Strength plays
@@ -571,6 +571,13 @@ func move_player(direction: Vector2i) -> bool:
 		return false
 	## A whirlpool spins the player rather than moving them, so nothing a completed
 	## step owes applies: no warp, no encounter, no repel step.
+	## A turn on the spot costs a facing and four frames and nothing else, so it
+	## owes none of what a completed step owes.
+	if movement.get("kind", &"") == &"turn":
+		if _renderer != null:
+			_renderer.refresh()
+		_refresh_labels()
+		return true
 	if movement.get("kind", &"") == &"forced_turn":
 		if _renderer != null:
 			_renderer.refresh()

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -326,7 +326,13 @@ func test_choosing_cut_shows_the_message_and_defers_the_block_change() -> void:
 	assert_false(_world_screen._field_move_text)
 	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE_CUT)
 	assert_true(world.can_walk_to(TREE_CELL))
-	assert_true(_world_screen.move_player(Vector2i.DOWN))
+	## `.CheckTurning` turns on the spot first when the pressed direction is not
+	## the one faced, so the walk is the press after it.
+	_world_screen.move_player(Vector2i.DOWN)
+	while world.player_step_in_progress():
+		world.advance_player_step(1.0)
+	if world.player_cell != TREE_CELL:
+		assert_true(_world_screen.move_player(Vector2i.DOWN))
 	assert_eq(world.player_cell, TREE_CELL)
 
 
@@ -408,7 +414,13 @@ func test_stepping_back_onto_land_stops_surfing_through_the_screen() -> void:
 	# before the screen accepts input again.
 	while world.player_step_in_progress():
 		world.advance_player_step(1.0)
-	assert_true(_world_screen.move_player(Vector2i.UP))
+	## `.CheckTurning` turns on the spot first when the pressed direction is not
+	## the one faced, so the walk is the press after it.
+	_world_screen.move_player(Vector2i.UP)
+	while world.player_step_in_progress():
+		world.advance_player_step(1.0)
+	if world.player_cell != SHORE_CELL:
+		assert_true(_world_screen.move_player(Vector2i.UP))
 	assert_eq(world.player_cell, SHORE_CELL)
 	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
 	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -91,6 +91,11 @@ func test_a_renderer_receives_the_input_the_screen_does_not_use() -> void:
 func test_a_renderer_never_receives_a_movement_or_interaction_button() -> void:
 	var renderer: Node = await _open_world_with_renderer()
 	var before: Vector2i = _world_screen._world.player_cell
+	## The first press is `.CheckTurning`'s turn on the spot, since the player
+	## spawns facing down; the walk is the press after it.
+	_world_screen._unhandled_input(_press(KEY_RIGHT))
+	while _world_screen._world.player_step_in_progress():
+		_world_screen._world.advance_player_step(1.0)
 	_world_screen._unhandled_input(_press(KEY_RIGHT))
 	_world_screen._unhandled_input(_press(KEY_SPACE))
 	# The screen claimed both: the player moved, and neither key was offered on.

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -54,8 +54,23 @@ func _open_world(with_save: bool = false) -> void:
 	await get_tree().process_frame
 
 
+## One cell, however many presses the cartridge needs for it. The player spawns
+## facing down, so a press in any other direction is `.CheckTurning`'s turn on the
+## spot first and the walk is the press after it; a press in the direction already
+## faced walks straight away.
+func _walk_one(direction: Vector2i) -> void:
+	var before: Vector2i = _world_screen._world.player_cell
+	assert_true(_world_screen.move_player(direction))
+	for _frame: int in 16:
+		await get_tree().process_frame
+		if not _world_screen._world.player_step_in_progress():
+			break
+	if _world_screen._world.player_cell == before:
+		assert_true(_world_screen.move_player(direction))
+
+
 func _trigger_trainer() -> void:
-	assert_true(_world_screen.move_player(Vector2i.RIGHT))
+	await _walk_one(Vector2i.RIGHT)
 	for _frame: int in 80:
 		await get_tree().process_frame
 		if _battle_host() != null:
@@ -121,7 +136,7 @@ func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 ## presentation offset eases toward zero instead of snapping.
 func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 	await _open_world()
-	assert_true(_world_screen.move_player(Vector2i.RIGHT))
+	await _walk_one(Vector2i.RIGHT)
 
 	var object := _world_screen._world.objects[0] as Gen2WorldObject
 	var saw_step: bool = false

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3130,6 +3130,41 @@ func test_connection_requires_the_player_to_be_on_the_requested_edge() -> void:
 	assert_eq(world.player_cell, Vector2i(8, 6))
 
 
+## `.CheckTurning` sits between `.CheckTile` and `.TryStep` in
+## `DoPlayerMovement`, and its own comment is "This also lets the player change
+## facing without moving by tapping a direction". It runs before any collision
+## check, and `StepFunction_Turn` costs four frames and no cell.
+func test_a_press_in_a_new_direction_turns_on_the_spot_before_it_walks() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(4, 4))
+	var from: Vector2i = world.player_cell
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_DOWN)
+
+	var turn: Dictionary = world.player_input_move(Vector2i.RIGHT)
+	assert_true(turn["ok"])
+	assert_eq(turn["kind"], &"turn")
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_RIGHT)
+	assert_eq(world.player_cell, from, "a turn costs no cell")
+	assert_true(world.player_step_in_progress(), "and it costs four frames")
+
+	while world.player_step_in_progress():
+		world.advance_player_step(1.0)
+	var walk: Dictionary = world.player_input_move(Vector2i.RIGHT)
+	assert_true(walk["ok"])
+	assert_ne(walk["kind"], &"turn", "the facing already agrees, so this one walks")
+	assert_eq(world.player_cell, from + Vector2i.RIGHT)
+
+
+## A scripted `applymovement` drives the object through
+## `engine/overworld/movement.asm` and never reaches `DoPlayerMovement`, so it
+## turns nothing: only the input path has the check.
+func test_a_programmatic_step_does_not_turn_first() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(4, 4))
+	var from: Vector2i = world.player_cell
+	var moved: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_true(moved["ok"])
+	assert_eq(world.player_cell, from + Vector2i.RIGHT)
+
+
 func test_invalid_directions_and_map_edges_do_not_move_player() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(0, 0))
 	assert_false(world.move(Vector2i.ZERO))


### PR DESCRIPTION
.CheckTurning sits between .CheckTile and .TryStep in DoPlayerMovement, and its own comment says it "lets the player change facing without moving by tapping a direction". It runs before any collision check, so a press that differs from the current facing turns even into a wall, and StepFunction_Turn costs four frames and no cell. Only the input path has it: applymovement drives an object through movement.asm and never reaches DoPlayerMovement, which is why player_input_move owns the check and move_result stays the step on its own.

PromptButton.blink_cursor reads hVBlankCounter and masks 1 << 4, so the arrow is up for sixteen frames and the border's own dash is back for the next sixteen. It was drawn once and left there.

PrepMonFrontpic sets wBoxAlignment before PlaceGraphic and Intro_PrepTrainerPic does not, so the speech's Pokemon is the one pic drawn through the .right branch, which walks the tile columns from the right rather than the left. It faces the other way from its own front pic, and it was drawn unreversed.