### PR TITLE
Import both of a tileset's graphics blocks

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -289,6 +289,25 @@ tree is offered events before the screen decides what it needs, so a renderer
 reading them directly races the gameplay keys instead of taking what is left of
 them.
 
+### The tileset atlas
+
+`GameData.world_tileset_indices(number)` is one tileset's graphics as a single
+indexed strip, `Gen2WorldTileset.tile_count` tiles wide and eight tall, one byte
+of colour index per pixel. Every number a block can name indexes it directly:
+`Gen2WorldTileset.tile_index(block, tile)` is the strip slot, and
+`Gen2WorldPalette.tile_palettes()` answers one palette per slot in the same
+order.
+
+The cartridge loads a tileset's graphics as two blocks of 96 tiles into separate
+VRAM banks, and a metatile byte with the high bit set names the second. The strip
+carries both, at the cartridge's own numbering: block 0 at 0 to 95, block 1 at
+128 to 223, and the 32 tiles between them are the font's, always blank here. A
+tileset that ships only one block leaves 128 to 223 blank. Nothing needs to know
+which block a tile came from; the number is enough.
+
+`Gen2WorldAnimation` rewrites slots in this strip, so a renderer texturing from
+it follows water and flowers without knowing an animation ran.
+
 ## Framing the view
 
 `Gen2WorldAPI` offers a camera; it does not impose one.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -619,7 +619,11 @@ func world_animation_asset(name: String) -> PackedByteArray:
 	return out
 
 
-## Indexed 2bpp pixels for one tileset's 96 overworld tiles, loaded on demand.
+## Indexed 2bpp pixels for one tileset's overworld tiles, loaded on demand.
+##
+## The strip is [constant RomLayout.TILESET_TILE_COUNT] tiles wide and is indexed
+## by the metatile byte itself, so both graphics blocks are addressable; see that
+## constant for what sits where.
 func world_tileset_indices(number: int) -> PackedByteArray:
 	var key: String = "world_tiles/%d" % number
 	if _indices.has(key):

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -61,7 +61,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 35
+const FORMAT_VERSION: int = 36
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -96,11 +96,25 @@ const ASLEEP_TREEMON_MAX_ROWS: int = 16
 ## values are the source's integer `$FF / 100 * percent` expressions.
 const WILD_SURF_LEVEL_THRESHOLDS: Array[int] = [89, 165, 216, 242]
 
-## The graphics stream supplies the 96 tiles loaded by the overworld. Metatile
-## and collision tables are shorter for tilesets that never use all 128 blocks;
-## unused metatile entries may still contain $FF placeholders.
+## The graphics stream supplies two blocks of 96 tiles: `LoadTilesetGFX`
+## (home/map.asm) copies the first to vTiles2 in VRAM bank 0 and the second to
+## vTiles5 in bank 1, at the same tile numbers. A metatile byte with the high bit
+## set names the second block, because `_LoadOverworldAttrmapPals`
+## (engine/tilesets/map_palettes.asm) reads the palette map at the full byte,
+## takes bit 3 of the nibble as the VRAM bank, then clears bit 7 of the tile
+## number. So the addressable span is 224: block 0 at 0..95, the 32 font tiles
+## `_LoadFontsExtra1` owns at 96..127, and block 1 at 128..223. The strip carries
+## all 224 with the font gap blank, so a metatile byte indexes it directly.
+##
+## Eight tilesets compress only one block; the cartridge copies whatever follows
+## into bank 1 and no block of theirs ever names it, so the import blanks it.
+## Metatile and collision tables are shorter for tilesets that never use all 128
+## blocks; unused metatile entries may still contain $FF placeholders, which is
+## why a tile number past the span resolves to 0 rather than to a read.
 const TILESET_RECORD_SIZE: int = 15
-const TILESET_TILE_COUNT: int = 96
+const TILESET_TILE_COUNT: int = 224
+const TILESET_BLOCK_TILES: int = 96
+const TILESET_BLOCK_STRIDE: int = 128
 const TILESET_META_BYTES_PER_BLOCK: int = 16
 const TILESET_COLLISION_BYTES_PER_BLOCK: int = 4
 

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -440,9 +440,9 @@ static func _read_tileset(rom: RomFile, layout: Dictionary, number: int) -> Dict
 
 	var lz := Gen2Lz.new()
 	var raw_graphics: PackedByteArray = lz.decompress(rom.bytes(), gfx_offset)
-	var expected_graphics: int = RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_BYTES
-	if lz.failed or raw_graphics.size() < expected_graphics:
-		return _error("Tileset %d graphics decoded to %d bytes, expected at least %d." % [number, raw_graphics.size(), expected_graphics])
+	var block_bytes: int = RomLayout.TILESET_BLOCK_TILES * Gen2Tiles.TILE_BYTES
+	if lz.failed or raw_graphics.size() < block_bytes:
+		return _error("Tileset %d graphics decoded to %d bytes, expected at least %d." % [number, raw_graphics.size(), block_bytes])
 
 	var meta_size: int = block_count * RomLayout.TILESET_META_BYTES_PER_BLOCK
 	var collision_size: int = block_count * RomLayout.TILESET_COLLISION_BYTES_PER_BLOCK
@@ -473,8 +473,30 @@ static func _read_tileset(rom: RomFile, layout: Dictionary, number: int) -> Dict
 		"palette_map_pointer": rom.u16le(table + 13),
 		"palette_map": Array(palette_map),
 		"animation_commands": animation["commands"],
-		"pixels": Gen2Tiles.decode_2bpp_strip(raw_graphics, 0, RomLayout.TILESET_TILE_COUNT),
+		"pixels": _tileset_strip(raw_graphics),
 	}
+
+
+## One tileset's graphics as a 224-tile indexed strip addressed by the metatile
+## byte itself: see [constant RomLayout.TILESET_TILE_COUNT] for the layout.
+static func _tileset_strip(raw_graphics: PackedByteArray) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
+	var block_bytes: int = RomLayout.TILESET_BLOCK_TILES * Gen2Tiles.TILE_BYTES
+	var row_pixels: int = RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_WIDTH
+	var block_pixels: int = RomLayout.TILESET_BLOCK_TILES * Gen2Tiles.TILE_WIDTH
+	for block: int in 2:
+		var at: int = block * block_bytes
+		if raw_graphics.size() < at + block_bytes:
+			break
+		var pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+			raw_graphics, at, RomLayout.TILESET_BLOCK_TILES
+		)
+		var left: int = block * RomLayout.TILESET_BLOCK_STRIDE * Gen2Tiles.TILE_WIDTH
+		for y: int in Gen2Tiles.TILE_HEIGHT:
+			for x: int in block_pixels:
+				out[y * row_pixels + left + x] = pixels[y * block_pixels + x]
+	return out
 
 
 static func _read_world_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -35,8 +35,8 @@ var _frame_seconds: float = 0.0
 var _changed: bool = false
 ## Which tiles a run of commands rewrote, and whether a palette row moved. A
 ## renderer that keeps a texture only has to redo these tiles: the sequence
-## touches one or two of the ninety-six per frame, and a palette change is the
-## only thing that invalidates the rest.
+## touches one or two tiles per frame, and a palette change is the only thing
+## that invalidates the rest.
 var _changed_tiles: Dictionary = {}
 var _palette_changed: bool = false
 

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -114,10 +114,10 @@ static func palette_slots(environment: int, time_of_day: int) -> Array:
 
 ## One palette per tile of [param tileset], in tile order.
 ##
-## A tileset's ninety-six tiles share eight palette slots, so the eight are
-## resolved once and the same one is handed to every tile that uses it. This runs
-## again on every frame an animated tileset changes a tile, and building
-## ninety-six copies of eight palettes was most of that frame's cost.
+## Every tile of the strip shares eight palette slots, so the eight are resolved
+## once and the same one is handed to every tile that uses it. This runs again on
+## every frame an animated tileset changes a tile, and building one palette copy
+## per tile was most of that frame's cost.
 static func tile_palettes(
 	data: GameData,
 	map: Gen2WorldMap,

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -39,8 +39,8 @@ func set_time_of_day(time_of_day: int) -> void:
 
 ## Repaints the tiles the last animation frame rewrote.
 ##
-## The sequence touches one or two of a tileset's ninety-six tiles per frame, so
-## recolouring the whole strip was almost all of the frame's cost. A palette
+## The sequence touches one or two of a tileset's tiles per frame, so recolouring
+## the whole strip was almost all of the frame's cost. A palette
 ## command is the exception: it changes every tile drawn with that row, so it
 ## still rebuilds.
 func refresh_animation() -> void:

--- a/game/world/world_tileset.gd
+++ b/game/world/world_tileset.gd
@@ -35,11 +35,19 @@ static func from_cache(value: Dictionary) -> Gen2WorldTileset:
 	return out
 
 
+## Which tile of the strip one of a block's sixteen positions draws, in the
+## metatile byte's own numbering: 0..95 is the first graphics block and 128..223
+## the second. A byte past the strip is an unused block's $FF placeholder and
+## resolves to 0, so a caller can index [method GameData.world_tileset_indices]
+## with the answer.
 func tile_index(block: int, tile: int) -> int:
 	if block < 0 or block >= block_count or tile < 0 or tile >= RomLayout.MAP_BLOCK_TILE_WIDTH * RomLayout.MAP_BLOCK_TILE_WIDTH:
 		return 0
 	var at: int = block * RomLayout.TILESET_META_BYTES_PER_BLOCK + tile
-	return meta[at] if at < meta.size() else 0
+	if at >= meta.size():
+		return 0
+	var index: int = meta[at]
+	return index if index < tile_count else 0
 
 
 func collision_index(block: int, cell_x: int, cell_y: int) -> int:
@@ -49,8 +57,12 @@ func collision_index(block: int, cell_x: int, cell_y: int) -> int:
 	return collision[at] if at < collision.size() else -1
 
 
-## Palette maps store two tile assignments per byte, low nibble first. The
-## first 96 entries address the tiles loaded by the overworld renderer.
+## Which of the eight background palette slots a tile of the strip draws with.
+##
+## Palette maps store two assignments per byte, low nibble first, over the whole
+## 224-tile span. Bit 3 of a nibble is the VRAM bank the cartridge draws that
+## tile from and is dropped here: the strip is flat, so the tile number already
+## says which graphics block it came from.
 func palette_index(tile: int) -> int:
 	if tile < 0 or tile >= tile_count:
 		return 0
@@ -58,4 +70,5 @@ func palette_index(tile: int) -> int:
 	if at >= palette_map.size():
 		return 0
 	var packed: int = palette_map[at]
-	return packed & 0x0F if (tile & 1) == 0 else packed >> 4
+	var nibble: int = packed & 0x0F if (tile & 1) == 0 else packed >> 4
+	return nibble & 0x07

--- a/tests/unit/test_world_data.gd
+++ b/tests/unit/test_world_data.gd
@@ -81,6 +81,39 @@ func test_tileset_palette_map_reads_low_nibble_first() -> void:
 	assert_eq(tileset.palette_index(5), 6)
 
 
+func test_a_block_names_the_second_graphics_block_and_a_placeholder_names_nothing() -> void:
+	var meta: Array = []
+	meta.resize(16)
+	meta.fill(0)
+	meta[0] = 211
+	meta[1] = 0xFF
+	var tileset := Gen2WorldTileset.from_cache({
+		"number": 7,
+		"block_count": 1,
+		"meta": meta,
+	})
+
+	assert_eq(tileset.tile_count, RomLayout.TILESET_TILE_COUNT)
+	assert_eq(tileset.tile_index(0, 0), 211)
+	assert_eq(tileset.tile_index(0, 1), 0)
+
+
+func test_a_second_block_palette_nibble_drops_the_vram_bank_bit() -> void:
+	var palette_map: Array = []
+	palette_map.resize(RomLayout.WORLD_PALETTE_MAP_BYTES)
+	palette_map.fill(0)
+	palette_map[64] = 0x0B
+	palette_map[111] = 0xC0
+	var tileset := Gen2WorldTileset.from_cache({
+		"number": 2,
+		"block_count": 1,
+		"palette_map": palette_map,
+	})
+
+	assert_eq(tileset.palette_index(128), 3)
+	assert_eq(tileset.palette_index(223), 4)
+
+
 func test_world_palette_environment_rows_match_the_cartridge_table() -> void:
 	assert_eq(
 		Gen2WorldPalette.palette_slots(Gen2WorldMap.new().environment, Gen2WorldPalette.TIME_MORNING),

--- a/tests/unit/test_world_importer.gd
+++ b/tests/unit/test_world_importer.gd
@@ -67,3 +67,36 @@ func test_a_conditional_background_event_collects_the_script_behind_it() -> void
 		rom, bank, {"type": 0, "script": record}, read_only, {}, {}
 	)
 	assert_true(read_only.is_empty(), "a plain BGEVENT_READ points straight at its script")
+
+
+func test_the_tileset_strip_places_the_second_graphics_block_at_its_own_index() -> void:
+	var block_bytes: int = RomLayout.TILESET_BLOCK_TILES * Gen2Tiles.TILE_BYTES
+	var raw := PackedByteArray()
+	raw.resize(block_bytes * 2)
+	raw.fill(0)
+	# Two solid tiles, colour 1 in the first block and colour 3 in the second.
+	for byte: int in Gen2Tiles.TILE_BYTES:
+		raw[byte] = 0xFF if byte % 2 == 0 else 0x00
+		raw[block_bytes + byte] = 0xFF
+
+	var strip: PackedByteArray = Gen2WorldImporter._tileset_strip(raw)
+	var width: int = RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_WIDTH
+	assert_eq(strip.size(), width * Gen2Tiles.TILE_HEIGHT)
+	assert_eq(strip[0], 1)
+	assert_eq(strip[RomLayout.TILESET_BLOCK_STRIDE * Gen2Tiles.TILE_WIDTH], 3)
+	assert_eq(
+		strip[RomLayout.TILESET_BLOCK_TILES * Gen2Tiles.TILE_WIDTH], 0,
+		"the font tiles between the two blocks are never a tileset's own"
+	)
+
+
+func test_a_tileset_shipping_one_graphics_block_leaves_the_second_blank() -> void:
+	var block_bytes: int = RomLayout.TILESET_BLOCK_TILES * Gen2Tiles.TILE_BYTES
+	var raw := PackedByteArray()
+	raw.resize(block_bytes)
+	raw.fill(0xFF)
+
+	var strip: PackedByteArray = Gen2WorldImporter._tileset_strip(raw)
+	assert_eq(strip.size(), RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
+	assert_eq(strip[0], 3)
+	assert_eq(strip[RomLayout.TILESET_BLOCK_STRIDE * Gen2Tiles.TILE_WIDTH], 0)


### PR DESCRIPTION
A tileset's blocks reference tile numbers past the 96 the import produced, and
nothing could draw them. Measured over every map in Crystal: 18 tilesets place a
number of 128 or higher across 40 maps, the numbers run 128 to 223 with up to 96
distinct ones in a single tileset, and nothing is ever placed in 96..127.

This was visible in the built-in 2D view, not only to a renderer mod. Mahogany's
gym (16/7) drew as a floor stripe on an empty field, because
`world_renderer.gd:_draw` skips any tile at or past `tile_count`. Goldenrod's
store floors and every gym with statues were the same.

## The cartridge's shape

`LoadTilesetGFX` (home/map.asm) decompresses up to `$c0` tiles and copies the
first `$60` to `vTiles2` in VRAM bank 0 and the second `$60` to `vTiles5` in
bank 1, at the same tile numbers. `_LoadOverworldAttrmapPals`
(engine/tilesets/map_palettes.asm) reads the palette map at the full metatile
byte, takes bit 3 of the nibble as the VRAM bank, then clears bit 7 of the tile
number. So `128 + i` is bank 1 tile `i`, and the 32 numbers between the blocks
belong to the font `_LoadFontsExtra1` loads at `vTiles2 tile $60`, which is what
the palette map's 16 bytes of `$ff` filler cover.

## What changed

- `RomLayout.TILESET_TILE_COUNT` is 224, joined by `TILESET_BLOCK_TILES` (96)
  and `TILESET_BLOCK_STRIDE` (128).
- `world_tileset_indices` returns one 224-tile strip in the cartridge's own
  numbering: block 0 at 0..95, blank font gap at 96..127, block 1 at 128..223.
  A metatile byte indexes it directly, so no renderer has to know how the
  hardware banked it.
- `tile_count` and the palette map cover all 224. `palette_index()` drops the
  nibble's bank bit, redundant once the strip is flat; without that every
  bank-1 tile resolved to slot 8..15 and fell to the fallback palette.
- `tile_index()` returns 0 for a byte past the span. Eight Crystal tilesets
  compress only one block and a few unused blocks carry `$ff` placeholders
  reaching 240 and 255; none is ever placed on a map, and a one-block tileset
  gets a blank second block.
- No animation change: no tileset animation touches VRAM bank 1 (no `rVBK` in
  engine/tilesets), and the animation layer already sizes itself from
  `tile_count`.

`docs/MODS.md` documents the strip under "The tileset atlas".

## Cache format 36

Every existing cache is re-imported once.

## Verification

- Full GUT suite 2382/2382, with new coverage for the strip layout, a one-block
  tileset, a second-block metatile byte, a placeholder byte and a bank-1
  palette nibble.
- Boot smoke test clean; all three cartridges import clean.
- Gyms and store interiors draw fully on Crystal and Gold, through both
  `tools/preview_world.gd` and the live `Gen2WorldRenderer`; unaffected outdoor
  maps are unchanged.