### PR TITLE
Add Gen2AppVersion and use in update/about

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -157,7 +157,7 @@ script_export_mode=2
 
 [preset.4.options]
 
-application/app_store_team_id=""
+application/app_store_team_id="ZFNL78SF72"
 application/bundle_identifier="io.github.decryptu.pokerecomp"
 application/signature=""
 application/short_version="0.1.0"

--- a/game/launcher/about_page.gd
+++ b/game/launcher/about_page.gd
@@ -32,7 +32,7 @@ func _build() -> void:
 
 	var build: VBoxContainer = _card(column, "This build")
 	build.add_child(Gen2LauncherUI.body(
-		_theme, "pokerecomp %s" % Gen2UpdateCheck.current_version()
+		_theme, "pokerecomp %s" % Gen2AppVersion.display()
 	))
 	build.add_child(Gen2LauncherUI.muted(
 		_theme,

--- a/game/main/app_version.gd
+++ b/game/main/app_version.gd
@@ -1,0 +1,10 @@
+class_name Gen2AppVersion
+extends RefCounted
+
+## Host application version. Keep this numeric value aligned with export metadata.
+const VERSION: String = "0.1.0"
+const CHANNEL: String = "development"
+
+
+static func display() -> String:
+	return "%s (%s)" % [VERSION, CHANNEL]

--- a/game/main/app_version.gd.uid
+++ b/game/main/app_version.gd.uid
@@ -1,0 +1,1 @@
+uid://cidcf7p6f0gyo

--- a/game/main/update_check.gd
+++ b/game/main/update_check.gd
@@ -24,10 +24,10 @@ enum Status {
 }
 
 
-## The running build, from `application/config/version` in project.godot so the
-## exported binary and this check cannot disagree.
+## The running build, kept in code so the launcher can identify development
+## builds before a GitHub release exists.
 static func current_version() -> String:
-	return String(ProjectSettings.get_setting("application/config/version", "0.0.0"))
+	return Gen2AppVersion.VERSION
 
 
 ## Splits a version into comparable integers. A leading "v" is accepted because

--- a/tests/unit/test_update_check.gd
+++ b/tests/unit/test_update_check.gd
@@ -7,6 +7,8 @@ extends GutTest
 func test_the_project_declares_a_version() -> void:
 	assert_false(Gen2UpdateCheck.current_version().is_empty())
 	assert_false(Gen2UpdateCheck.parse_version(Gen2UpdateCheck.current_version()).is_empty())
+	assert_eq(Gen2UpdateCheck.current_version(), Gen2AppVersion.VERSION)
+	assert_string_contains(Gen2AppVersion.display(), Gen2AppVersion.CHANNEL)
 
 
 func test_a_tag_may_carry_a_leading_v() -> void:


### PR DESCRIPTION
Introduce Gen2AppVersion (game/main/app_version.gd + .uid) with VERSION, CHANNEL and display(). Gen2UpdateCheck.current_version() now returns Gen2AppVersion.VERSION so development builds can be identified before a GitHub release. about_page.gd switched to Gen2AppVersion.display(). Unit test updated to assert current_version matches the new constant and that display() contains the channel. Also set application/app_store_team_id in export_presets.cfg.