### PR TITLE
Add issue templates, PR template and ROM-free CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,154 @@
+name: Bug report
+description: Something is broken, wrong, or does not behave like the original game.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A screenshot is worth more than any description. If you can grab one, grab one.
+        If you genuinely can't, the details below need to be thorough enough that
+        someone can find the bug without ever seeing your screen.
+
+        If the game refuses your cartridge dump or the import fails, check
+        [roms/README.md](https://github.com/Decryptu/pokerecomp/blob/main/roms/README.md)
+        first. Never attach ROM data, save files containing it, or the import cache.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One line summary
+      description: What's broken, in a sentence.
+      placeholder: Surfing off the Route 34 coast walks the player onto land instead of stopping
+    validations:
+      required: true
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Which game were you playing
+      description: Pick every version you saw the bug in. Use N/A if it isn't game-specific.
+      multiple: true
+      options:
+        - Gold
+        - Silver
+        - Crystal
+        - N/A
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Which build are you running
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Android
+        - iOS
+        - Godot editor (from source)
+        - Multiple platforms
+    validations:
+      required: true
+
+  - type: dropdown
+    id: mods_enabled
+    attributes:
+      label: Were any mods on
+      description: The launcher lists what loaded. Check there if you're not sure.
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true
+
+  - type: input
+    id: mods_which
+    attributes:
+      label: Which mods (if any were on)
+      description: List the enabled mod ids and versions. Leave blank if none were on.
+      placeholder: nuzlocke 1.0.0, hd-world 0.3
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The release you downloaded, or the commit hash if you built it yourself.
+      placeholder: 0.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: discord
+    attributes:
+      label: Discord username (optional)
+      description: >
+        So maintainers can ping you for a quick follow-up. Leave blank if you'd
+        rather keep everything on GitHub.
+      placeholder: yourname
+    validations:
+      required: false
+
+  - type: input
+    id: location
+    attributes:
+      label: Where in the game
+      description: >
+        Be specific. Route, town, building, floor, menu, battle, launcher screen.
+        If it's a map transition, say which side you came in from.
+      placeholder: Ilex Forest, north exit into Route 34
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot, or a detailed description if you couldn't take one
+      description: >
+        Drag the image straight into this box. If you couldn't get a screenshot,
+        write "no screenshot" and describe exactly what was on screen: where the
+        player sprite was, the tiles around it, any text, whether anything was
+        frozen or flickering.
+      placeholder: |
+        Drop the image here.
+
+        Or, with no screenshot:
+        Player kept the surf sprite while standing on the grass tile north of the
+        gate, facing up. No text box. Surf music kept playing instead of the
+        Route 34 track.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: How to make it happen
+      description: Numbered steps, starting from a point someone else can get to.
+      placeholder: |
+        1. New game, get to Cherrygrove and take the Route 34 path
+        2. Surf south from the first water tile
+        3. Press A facing the shore
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened
+      description: If you know what the original cartridge does here, say so.
+      placeholder: Should step onto the shore tile and drop the surf sprite, facing up.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: >
+        Does it happen every time or only sometimes. Did it start after a
+        specific release. Anything you were doing right before it. Console output
+        if you ran it from the editor. Leave blank if nothing comes to mind.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/twkrHkHprk
+    about: Questions, help getting a build running, or anything that isn't a tracked issue.
+  - name: ROM setup and verification
+    url: https://github.com/Decryptu/pokerecomp/blob/main/roms/README.md
+    about: Read this before reporting an import or "no cartridge found" problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,102 @@
+name: Feature request
+description: Ask for something new in the engine, launcher, or platform layer, not a gameplay mod.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for **engine / launcher / platform** work: ports, export targets,
+        video and control options, save tooling, import speed, mod API seams, docs.
+
+        If what you want is a gameplay, cosmetic, audio or QoL change that a mod
+        could ship (alternate sprites, running shoes, shiny indicators, soundtrack
+        packs, a 3D renderer), open a
+        **[Mod request](https://github.com/Decryptu/pokerecomp/issues/new?template=mod_request.yml)**
+        instead. If the game already does the thing but does it differently from the
+        cartridge, that's a
+        **[Source accuracy report](https://github.com/Decryptu/pokerecomp/issues/new?template=source_accuracy.yml)**.
+
+        "Can we add X" on its own is hard to act on. Say what you want, why, and how
+        you picture it working.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One line summary
+      placeholder: Add a Linux AppImage export next to the macOS and Windows builds
+    validations:
+      required: true
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Which game is this about
+      description: Pick every version it applies to. Use N/A if it isn't game-specific.
+      multiple: true
+      options:
+        - Gold
+        - Silver
+        - Crystal
+        - N/A
+    validations:
+      required: true
+
+  - type: input
+    id: discord
+    attributes:
+      label: Discord username (optional)
+      placeholder: yourname
+    validations:
+      required: false
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What do you want
+      description: >
+        What is it, where does it live (launcher, options, engine, export), what does
+        the player see or do. If it changes something that exists, say what it does
+        today and what it should do instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this worth doing
+      description: >
+        What's annoying or missing right now. If it's just because you think it would
+        be fun, say that, it's a real answer.
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How should it work
+      description: >
+        The specifics. Which menu, what happens in the edge cases. If you don't know,
+        say what you'd expect as a player and leave the rest open.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Does this change how the original game plays
+      description: >
+        Both answers are fine, it just helps to know which one you're asking for.
+      options:
+        - Quality of life, original game is untouched
+        - Changes how the game plays
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Reference screenshots, how another project does it, related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/mod_request.yml
+++ b/.github/ISSUE_TEMPLATE/mod_request.yml
@@ -1,0 +1,115 @@
+name: Mod request
+description: Ask for a gameplay, cosmetic, audio, or QoL change that belongs in a mod.
+labels: ["mod request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This is for ideas that should ship as **mods** rather than core engine work:
+        alternate sprites, running shoes, shiny indicators, soundtrack packs,
+        rebalanced species or moves, new trainer classes, a 3D or HD world view.
+
+        A mod is interpreted GDScript under `user://mods/`. What it can reach is
+        described in [docs/MODS.md](https://github.com/Decryptu/pokerecomp/blob/main/docs/MODS.md):
+        adding or rebalancing species, moves, items and trainer classes, registering
+        move effects, watching the world and battle event channels, adding a menu
+        entry, and replacing the world or battle renderer.
+
+        Use a **Feature request** for launcher, ports, export, save tooling, or a new
+        API seam the mod layer doesn't expose yet.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One line summary
+      description: What the mod should do, in a sentence.
+      placeholder: Hold B to run at bike speed on the overworld
+    validations:
+      required: true
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Which game is this for
+      multiple: true
+      options:
+        - Gold
+        - Silver
+        - Crystal
+        - N/A
+    validations:
+      required: true
+
+  - type: input
+    id: discord
+    attributes:
+      label: Discord username (optional)
+      placeholder: yourname
+    validations:
+      required: false
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What should the mod do
+      description: >
+        The player-facing behavior. What changes, where, what does the player see or
+        press. If it toggles from Options or a START-menu entry, say so.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this worth doing as a mod
+      description: Why optional rather than core. Who wants it on, who wants vanilla left alone.
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How should it work
+      description: >
+        Buttons, menus, edge cases, whether it needs new art or audio. If you know
+        which part of the mod API fits (a registry, an event channel, a renderer
+        replacement), mention it. Otherwise leave it open.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: vanilla
+    attributes:
+      label: With the mod off, is vanilla unchanged
+      options:
+        - Yes, parity when disabled
+        - No, it would replace something always-on
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Best-fit category
+      options:
+        - Gameplay / QoL
+        - Graphics / renderer
+        - Audio
+        - Balance / ruleset
+        - Content (species, moves, trainers, encounters)
+        - UI / tool
+        - Total conversion
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: >
+        Reference screenshots, other projects or hacks that do it, related issues, or
+        "I'd like to try writing this myself."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/source_accuracy.yml
+++ b/.github/ISSUE_TEMPLATE/source_accuracy.yml
@@ -1,0 +1,93 @@
+name: Source accuracy report
+description: The game runs fine but diverges from what the original Gen 2 code does.
+labels: ["source accuracy"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when nothing crashes but the behavior is wrong against the
+        cartridge: damage off by one, wrong turn order, a text box that pauses for
+        the wrong number of frames, an encounter rate that feels off.
+
+        The useful part of this report is the source reference. Behavior is
+        re-derived from the `pokecrystal` and `pokegold` disassemblies, so a
+        pointer to the routine or table you're comparing against is worth more
+        than any amount of description.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One line summary
+      description: What diverges, in a sentence.
+      placeholder: Critical hits use the base speed table but ignore the Focus Energy branch
+    validations:
+      required: true
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Which game
+      multiple: true
+      options:
+        - Gold
+        - Silver
+        - Crystal
+        - N/A
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which system
+      options:
+        - Battle
+        - Overworld
+        - Menus and items
+        - NPC and scripts
+        - Audio
+        - Graphics and palettes
+        - Saves and PC storage
+        - ROM import
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: What this project does
+      description: Exact numbers where you have them. Values, frame counts, RNG seeds, party state.
+      placeholder: |
+        L20 Quilava Ember vs L18 Bellsprout, no crit: 34 damage.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What the original does
+      description: How you established it. Hardware, emulator, disassembly reading, a documented table.
+      placeholder: |
+        Same setup on a real Crystal cartridge: 37 damage.
+    validations:
+      required: true
+
+  - type: input
+    id: source_ref
+    attributes:
+      label: Source reference
+      description: >
+        Path plus symbol in `pokecrystal` or `pokegold`, if you have one. This is
+        what makes the report actionable.
+      placeholder: engine/battle/effect_commands.asm, BattleCommand_DamageCalc
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Screenshots, save state details, related issues. Leave blank if nothing comes to mind.
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## What this changes
+
+<!-- One or two sentences. What behaves differently after this merges. -->
+
+## Source references
+
+<!--
+Behavior is re-derived from the pokecrystal / pokegold disassemblies. For
+anything that reproduces cartridge behavior, cite path plus symbol, one per line:
+
+  engine/battle/core.asm, DetermineMoveOrder
+
+Write "not source-derived" for tooling, docs, launcher or export work.
+-->
+
+## How it was verified
+
+- [ ] `--headless --editor --quit` scan passes (required after adding scripts)
+- [ ] GUT suite passes
+- [ ] Screenshot attached (required for visual changes)
+- [ ] Boot smoke test passes
+
+<!-- Paste the GUT summary line, and drag any screenshots in here. -->
+
+## Checklist
+
+- [ ] No ROM-derived, generated, cache or local-only file is staged
+- [ ] `git diff --cached --check` is clean
+- [ ] `HANDOFF.md` updated if deliberate behavior, scaffolding or known breaks changed
+- [ ] Defects met along the way are fixed here or recorded in `HANDOFF.md` open work
+- [ ] Docs updated if a contract in `docs/` changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+# The ROM-free test run. CI has no cartridge and never will: no ROM bytes and
+# nothing derived from them is committed. The suite runs against the fixtures in
+# tests/, so it needs no ROM, no display and no imported cache.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  GODOT_VERSION: 4.8-dev2
+
+jobs:
+  tests:
+    name: editor scan and GUT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache Godot binary
+        id: godot-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/godot
+          key: godot-${{ env.GODOT_VERSION }}-linux-x86_64
+
+      - name: Install Godot
+        if: steps.godot-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/godot
+          url="https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/Godot_v${GODOT_VERSION}_linux.x86_64.zip"
+          curl -fsSL "$url" -o /tmp/godot.zip
+          unzip -q /tmp/godot.zip -d ~/godot
+          mv ~/godot/Godot_v${GODOT_VERSION}_linux.x86_64 ~/godot/godot
+          chmod +x ~/godot/godot
+
+      - name: Import and resolve class_name
+        run: ~/godot/godot --headless --editor --path . --quit
+
+      - name: GUT
+        run: |
+          ~/godot/godot --headless --path . \
+            -s res://addons/gut/gut_cmdln.gd \
+            -gdir=res://tests -ginclude_subdirs -gexit
+
+      - name: Boot smoke test
+        run: ~/godot/godot --headless --path . --quit-after 30


### PR DESCRIPTION
## What this changes

Adds the `.github/` set the repo was missing, plus a CI run that needs no cartridge.

- **Issue forms**: bug report, source accuracy report, feature request, mod request. Each carries a Gold/Silver/Crystal selector. Blank issues are off; the chooser links Discord and `roms/README.md`.
- **Source accuracy** is its own form: the game running fine but diverging from `pokegold`/`pokecrystal` is a different triage path from a bug, and the form asks for a `path, symbol` reference.
- **Mod request** is written against the GDScript mod host and the registries in `docs/MODS.md`.
- **PR template**: source references, the verify steps from the contributing guide, and the staging check for ROM-derived and generated files.
- **CI**: caches a Godot 4.8-dev2 Linux build, then runs the editor scan, GUT and the boot smoke test. The suite runs on committed fixtures, so no ROM is involved.
- **Dependabot**: weekly GitHub Actions updates.

Labels were applied directly to the repository, not in this diff: `source accuracy`, `mod request`, eleven `area:` labels tracking the `game/` subdirectories, `version: gold|silver|crystal`, and the `DIFFICULTY-*` set.

## How it was verified

- Every YAML file parses.
- No em-dash punctuation.
- Only `.github/` is staged; `git diff --cached --check` is clean.

CI has not run yet, so the workflow is unproven until this PR triggers it.