### PR TITLE
Repair Gen II audio timeline and decoding

### DIFF
--- a/game/audio/gen2_audio_decoder.gd
+++ b/game/audio/gen2_audio_decoder.gd
@@ -36,7 +36,7 @@ static func decode(
 	var bytes: PackedByteArray = _bytes(record.get("bytes", []))
 	if bytes.size() < 3:
 		return _failure(&"audio_record_truncated")
-	var kind: StringName = request_kind
+	var kind: StringName = &"cry" if request_kind == &"cries" else request_kind
 	if kind == &"cry":
 		return _decode_cry(record, bytes)
 	return _decode_music(record, bytes, kind, assets)
@@ -55,6 +55,10 @@ static func _decode_music(
 		return _failure(&"audio_invalid_channel_count")
 	var tracks: Array = []
 	var warnings: Array[StringName] = []
+	# Music_Tempo and Music_TempoRelative call SetGlobalTempo. The cartridge
+	# writes that value to every channel in the current group, so a channel
+	# decoded after the command must inherit it rather than starting at $100.
+	var tempo_context: Dictionary = {"tempo": 0x100}
 	for _channel: int in channel_count:
 		if header_at + 2 >= bytes.size():
 			return _failure(&"audio_channel_header_truncated")
@@ -65,7 +69,7 @@ static func _decode_music(
 		if stream_at < 0 or stream_at >= bytes.size():
 			return _failure(&"audio_channel_pointer_outside_record")
 		var track_result: Dictionary = _decode_track(
-			bytes, stream_at, channel_id, request_kind, origin, assets
+			bytes, stream_at, channel_id, request_kind, origin, assets, {}, tempo_context
 		)
 		if not bool(track_result.get("ok", false)):
 			var details: Dictionary = track_result.get("details", {})
@@ -134,7 +138,7 @@ static func _decode_cry(record: Dictionary, bytes: PackedByteArray) -> Dictionar
 			return _failure(&"audio_channel_pointer_outside_record")
 		var track_result: Dictionary = _decode_track(
 			bytes, stream_at, channel_id, &"cry", origin, {},
-			{"cry_pitch": pitch, "cry_length": length}
+			{"cry_pitch": pitch, "cry_length": length}, {}
 		)
 		if not bool(track_result.get("ok", false)):
 			return track_result
@@ -157,13 +161,13 @@ static func _decode_cry(record: Dictionary, bytes: PackedByteArray) -> Dictionar
 
 static func _decode_track(
 	bytes: PackedByteArray, start: int, channel_id: int, request_kind: StringName,
-	origin: int, assets: Dictionary, cry: Dictionary = {}
+	origin: int, assets: Dictionary, cry: Dictionary = {}, tempo_context: Dictionary = {}
 ) -> Dictionary:
 	var state: Dictionary = {
 		"at": start,
 		"time": 0,
 		"duration_modifier": 0,
-		"tempo": 0x100,
+		"tempo": int(tempo_context.get("tempo", 0x100)),
 		"note_length": 1,
 		"octave": 4,
 		"transpose": 0,
@@ -195,6 +199,7 @@ static func _decode_track(
 		"calls": [],
 		"steps": 0,
 		"origin": origin,
+		"tempo_context": tempo_context,
 	}
 	var events: Array = []
 	var warnings: Array[StringName] = []
@@ -459,6 +464,7 @@ static func _command(
 			# `tempo 144` decodes as $9000 and every note lasts 256 times too
 			# long, which is what drove whole streams past MAX_FRAMES.
 			state["tempo"] = _u16_be(bytes, at)
+			(state["tempo_context"] as Dictionary)["tempo"] = int(state["tempo"])
 			state["duration_modifier"] = 0
 			at += 2
 		0xDB:
@@ -565,18 +571,27 @@ static func _command(
 				return _failure(&"audio_tempo_relative_truncated")
 			var relative: int = _signed_8(bytes[at])
 			state["tempo"] = (int(state["tempo"]) + relative) & 0xFFFF
+			(state["tempo_context"] as Dictionary)["tempo"] = int(state["tempo"])
 			at += 1
 		0xEA:
 			if not _has(bytes, at, 2):
 				return _failure(&"audio_restart_truncated")
-			var restart_stream: int = _audio_address(_u16(bytes, at))
+			var restart_header: int = _audio_address(_u16(bytes, at))
 			at += 2
+			var restart_header_at: int = restart_header - int(state.get("origin", 0))
+			if restart_header_at < 0 or restart_header_at + 2 >= bytes.size():
+				return _failure(&"audio_restart_header_outside_record", {
+					"header": restart_header,
+					"origin": int(state.get("origin", 0)),
+				})
+			var restart_stream: int = _audio_address(_u16(bytes, restart_header_at + 1))
 			at = restart_stream - int(state.get("origin", 0))
 			if at < 0 or at >= bytes.size():
 				return _failure(&"audio_restart_outside_record", {
 					"stream": restart_stream,
 					"origin": int(state.get("origin", 0)),
 				})
+			_reset_channel_state(state)
 		0xEB:
 			args = 2
 		0xEC:
@@ -671,6 +686,43 @@ static func _set_note_duration(state: Dictionary, duration_code: int) -> int:
 	var duration: int = total >> 8
 	state["duration_modifier"] = total & 0xFF
 	return maxi(duration, 1)
+
+
+static func _reset_channel_state(state: Dictionary) -> void:
+	# Music_RestartChannel calls LoadChannel/StartChannel, which runs
+	# ChannelInit before loading the new stream pointer. Preserve elapsed time
+	# (the restarted channel does not rewind the other channels), but clear the
+	# per-channel format, modulation, loop and mixer state it would clear on the
+	# cartridge.
+	state["duration_modifier"] = 0
+	state["tempo"] = 0x100
+	state["note_length"] = 1
+	state["octave"] = 4
+	state["transpose"] = 0
+	state["pitch_offset"] = 0
+	state["pitch_sweep"] = {}
+	state["vibrato_delay"] = 0
+	state["vibrato_above"] = 0
+	state["vibrato_below"] = 0
+	state["vibrato_rate"] = 0
+	state["pitch_slide_target"] = -1
+	state["pitch_slide_duration"] = 0
+	state["volume_envelope"] = 0xC0
+	state["duty"] = 2
+	state["duty_pattern"] = []
+	state["noise"] = false
+	state["sfx"] = false
+	state["sfx_priority"] = false
+	state["drumkit"] = 0
+	state["condition"] = 0
+	state["master_left"] = 7
+	state["master_right"] = 7
+	state["pan_left"] = 1
+	state["pan_right"] = 1
+	state["frame_at_offset"] = {}
+	state["loop_states"] = {}
+	state["calls"] = []
+	state["event_number"] = 0
 
 
 static func _offset_frequency(base: int, offset: int) -> int:

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -9,7 +9,10 @@ const AUDIO_DECODER := preload("res://game/audio/gen2_audio_decoder.gd")
 const AUDIO_RENDERER := preload("res://game/audio/gen2_audio_renderer.gd")
 
 const MUSIC_CACHE_LIMIT: int = 4
-const MUSIC_CHUNK_FRAMES: int = 16
+## Keep each refill below the generator's 0.25 second capacity. Sixteen source
+## frames requested 5,880 output frames against a 5,512-frame buffer, so the
+## refill loop never ran and live audio starved from startup.
+const MUSIC_CHUNK_FRAMES: int = 4
 
 var _music_player: AudioStreamPlayer = null
 var _music_key: String = ""
@@ -21,6 +24,7 @@ var _music_decoded: Dictionary = {}
 var _music_assets: Dictionary = {}
 var _music_source_frame: int = 0
 var _music_render_state: Dictionary = {}
+var _music_draining: bool = false
 
 
 func _ready() -> void:
@@ -96,13 +100,14 @@ func fade_out(frames: int = 0) -> bool:
 	if _music_player == null or not _music_player.playing:
 		return false
 	_stop_fade()
-	var seconds: float = maxf(0.01, float(frames) / 60.0)
+	var seconds: float = maxf(0.01, float(frames) / AUDIO_RENDERER.SOURCE_FRAME_RATE)
 	if frames <= 0:
 		_music_player.stop()
 		_music_player.volume_db = 0.0
 		_music_key = ""
 		_music_decoded = {}
 		_music_render_state = {}
+		_music_draining = false
 		return true
 	_fade_tween = create_tween()
 	_fade_tween.tween_property(_music_player, "volume_db", -80.0, seconds)
@@ -119,6 +124,7 @@ func stop_all() -> void:
 	_music_playback = null
 	_music_generator = null
 	_music_render_state = {}
+	_music_draining = false
 
 
 func effect_playing() -> bool:
@@ -185,6 +191,7 @@ func _finish_fade() -> void:
 	_music_playback = null
 	_music_generator = null
 	_music_render_state = {}
+	_music_draining = false
 	_fade_tween = null
 
 
@@ -204,6 +211,7 @@ func _start_music_generator(prepared: Dictionary, assets: Dictionary) -> void:
 	_music_assets = assets.duplicate(true)
 	_music_source_frame = 0
 	_music_render_state = AUDIO_RENDERER.create_shared_state(_music_decoded, _music_assets)
+	_music_draining = false
 	_music_player.play()
 	_music_playback = _music_player.get_stream_playback() as AudioStreamGeneratorPlayback
 
@@ -217,9 +225,27 @@ func _ensure_generator(assets: Dictionary) -> void:
 
 
 func _service_timeline() -> void:
-	if _music_playback == null or _music_render_state.is_empty() or _music_player == null or not _music_player.playing:
+	if _music_player == null or _music_render_state.is_empty() or not _music_player.playing:
 		return
-	var chunk_samples: int = MUSIC_CHUNK_FRAMES * AUDIO_RENDERER.SAMPLE_RATE / 60
+	if _music_playback == null:
+		_music_playback = _music_player.get_stream_playback() as AudioStreamGeneratorPlayback
+		if _music_playback == null:
+			return
+	var chunk_samples: int = ceili(
+		float(MUSIC_CHUNK_FRAMES) * AUDIO_RENDERER.SAMPLE_RATE
+		/ AUDIO_RENDERER.SOURCE_FRAME_RATE
+	)
+	var buffer_capacity: int = ceili(
+		float(_music_generator.mix_rate) * _music_generator.buffer_length
+	)
+	if _music_draining and not AUDIO_RENDERER.shared_effect_playing(_music_render_state):
+		if _music_playback.get_frames_available() >= maxi(0, buffer_capacity - 1):
+			_music_player.stop()
+			_music_key = ""
+			_music_playback = null
+			_music_render_state = {}
+			_music_draining = false
+		return
 	while _music_playback.get_frames_available() >= chunk_samples:
 		var frames: int = MUSIC_CHUNK_FRAMES
 		if not _music_decoded.is_empty():
@@ -231,11 +257,8 @@ func _service_timeline() -> void:
 				else:
 					_music_decoded = {}
 					_music_render_state["music_tracks"] = []
-					if not AUDIO_RENDERER.shared_effect_playing(_music_render_state):
-						_music_player.stop()
-						_music_key = ""
-						_music_playback = null
-						return
+					_music_draining = true
+					break
 			frames = mini(MUSIC_CHUNK_FRAMES, duration - _music_source_frame)
 		var chunk: Dictionary = AUDIO_RENDERER.render_shared_chunk_stateful(
 			_music_render_state, frames, _music_assets
@@ -248,3 +271,5 @@ func _service_timeline() -> void:
 		_music_playback.push_buffer(chunk["buffer"])
 		if not _music_decoded.is_empty():
 			_music_source_frame += frames
+		elif not AUDIO_RENDERER.shared_effect_playing(_music_render_state):
+			_music_draining = true

--- a/game/audio/gen2_audio_renderer.gd
+++ b/game/audio/gen2_audio_renderer.gd
@@ -9,6 +9,10 @@ const MAX_RENDER_FRAMES: int = 60 * 60 * 30
 const ENVELOPE_STEPS_PER_SECOND: float = 64.0
 const MAX_NOISE_CLOCKS_PER_SAMPLE: int = 64
 const GB_CLOCK: float = 4194304.0
+const FRAME_CLOCKS: int = 70224
+## _UpdateSound runs once per LCD VBlank, so a source frame is the DMG clock
+## divided by 70,224 clocks rather than an idealized 60 Hz.
+const SOURCE_FRAME_RATE: float = GB_CLOCK / float(FRAME_CLOCKS)
 # Four independent DMG channels can be simultaneously full-scale before the
 # analog stage. Keep the reference filter response but leave 6 dB of mixer
 # headroom so a valid multi-channel record never reaches the digital clamp.
@@ -33,6 +37,10 @@ static func duty_pattern(duty: int) -> Array:
 
 static func register_frequency(register: int, hardware_channel: int) -> float:
 	return _register_to_hz(register, hardware_channel)
+
+
+static func frame_sample(frame: int) -> int:
+	return _frame_sample(frame)
 
 
 static func render(decoded: Dictionary, assets: Dictionary = {}) -> Dictionary:
@@ -243,7 +251,7 @@ static func _sample(decoded: Dictionary, state: Dictionary, assets: Dictionary) 
 				var duty: int = int(event.get("duty", 0))
 				var duty_sequence: Variant = event.get("duty_pattern", [])
 				if duty_sequence is Array and not (duty_sequence as Array).is_empty():
-					var duty_frame: int = int(floor(float(age) * 60.0 / SAMPLE_RATE))
+					var duty_frame: int = int(floor(float(age) * SOURCE_FRAME_RATE / SAMPLE_RATE))
 					duty = int((duty_sequence as Array)[duty_frame % (duty_sequence as Array).size()])
 				var duty_pattern: Array = DUTY_PATTERNS[clampi(duty, 0, 3)]
 				value = 1.0 if duty_pattern[int(phase * 8.0) & 7] != 0 else 0.0
@@ -280,12 +288,12 @@ static func _event_at(track: Dictionary, sample: int, hint: int) -> int:
 
 static func _modulated_register(event: Dictionary, age_samples: int) -> int:
 	var base: int = int(event.get("frequency", 0)) & 0x7FF
-	var age_frame: int = int(floor(float(age_samples) * 60.0 / SAMPLE_RATE))
+	var age_frame: int = int(floor(float(age_samples) * SOURCE_FRAME_RATE / SAMPLE_RATE))
 	var sweep: Dictionary = event.get("pitch_sweep", {})
 	if not sweep.is_empty() and int(sweep.get("shift", 0)) > 0:
 		var pace: int = int(sweep.get("pace", 0))
 		if pace > 0:
-			var iterations: int = int(floor(float(age_samples) * 60.0 / SAMPLE_RATE * 128.0 / float(pace)))
+			var iterations: int = int(floor(float(age_samples) * SOURCE_FRAME_RATE / SAMPLE_RATE * 128.0 / float(pace)))
 			for _iteration: int in iterations:
 				var delta: int = base >> int(sweep.get("shift", 0))
 				base = base - delta if bool(sweep.get("subtract", false)) else base + delta
@@ -396,7 +404,7 @@ static func _register_to_hz(value: int, hardware_channel: int) -> float:
 
 
 static func _frame_sample(frame: int) -> int:
-	return int(floor(float(maxi(frame, 0)) * SAMPLE_RATE / 60.0))
+	return int(floor(float(maxi(frame, 0)) * SAMPLE_RATE / SOURCE_FRAME_RATE))
 
 
 static func _wave_bytes(assets: Dictionary) -> PackedByteArray:
@@ -669,7 +677,7 @@ static func _shared_event_sample(
 		var duty: int = int(event.get("duty", 2))
 		var sequence: Variant = event.get("duty_pattern", [])
 		if sequence is Array and not (sequence as Array).is_empty():
-			var duty_frame: int = int(floor(float(age) * 60.0 / SAMPLE_RATE))
+			var duty_frame: int = int(floor(float(age) * SOURCE_FRAME_RATE / SAMPLE_RATE))
 			duty = int((sequence as Array)[duty_frame % (sequence as Array).size()])
 		var pattern: Array = DUTY_PATTERNS[clampi(duty, 0, 3)]
 		value = 1.0 if pattern[int(phase * 8.0) & 7] != 0 else 0.0

--- a/game/world/world_audio_host.gd
+++ b/game/world/world_audio_host.gd
@@ -1,11 +1,13 @@
 class_name Gen2WorldAudioHost
 extends RefCounted
 
-## Scene-free boundary between imported audio records and the Godot playback
-## node. Decoding/rendering stays pure here, while an owning scene decides when
-## to attach the returned stream to an AudioStreamPlayer.
+## Scene-free inspection boundary for imported audio records.
+##
+## Runtime playback belongs exclusively to Gen2AudioPlayer. This host is used by
+## the service overlay to prove that a record resolves and decodes; it must not
+## create a second WAV renderer that can diverge from the shared hardware lane.
 
-const BACKEND_WAV: StringName = &"godot_audio_stream_wav"
+const BACKEND_DECODE_ONLY: StringName = &"decode_only_shared_runtime"
 
 
 static func play(
@@ -20,24 +22,15 @@ static func play(
 		return {
 			"ok": false,
 			"played": false,
-			"backend": BACKEND_WAV,
+			"backend": BACKEND_DECODE_ONLY,
 			"reason": decoded.get("reason", &"audio_decode_failed"),
-			"byte_count": byte_count,
-		}
-	var rendered: Dictionary = Gen2AudioRenderer.render(decoded, assets)
-	if not bool(rendered.get("ok", false)):
-		return {
-			"ok": false,
-			"played": false,
-			"backend": BACKEND_WAV,
-			"reason": rendered.get("reason", &"audio_render_failed"),
 			"byte_count": byte_count,
 		}
 	return {
 		"ok": true,
 		"played": false,
 		"ready": true,
-		"backend": BACKEND_WAV,
+		"backend": BACKEND_DECODE_ONLY,
 		"request_kind": request_kind,
 		"index": int(record.get("index", -1)),
 		"bank": int(record.get("bank", -1)),
@@ -45,8 +38,7 @@ static func play(
 		"byte_count": byte_count,
 		"decoded": decoded,
 		"sfx_priority": _has_sfx_priority(decoded),
-		"stream": rendered["stream"],
-		"frame_count": int(rendered.get("frame_count", 0)),
+		"frame_count": int(decoded.get("duration_frames", 0)),
 	}
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -405,7 +405,9 @@ func _open_audio(request: Dictionary, record: Dictionary) -> void:
 		String(kind), int(record.get("bank", -1)), int(record.get("address", -1)),
 		int(record.get("byte_count", 0)),
 	]
-	_status.text = "Playback backend: %s" % String(playback.get("backend", "unavailable"))
+	_status.text = "Audio resolved for shared runtime: %s" % String(
+		playback.get("backend", "unavailable")
+	)
 	_footer.text = "A: continue    B: stop"
 	_render_options(["Continue"])
 

--- a/tests/unit/test_audio_decoder.gd
+++ b/tests/unit/test_audio_decoder.gd
@@ -30,6 +30,12 @@ func test_music_header_and_note_duration_follow_the_cartridge_math() -> void:
 	assert_gt(track["events"][0]["frequency"], 0)
 
 
+func test_source_audio_clock_is_the_game_boy_vblank_rate() -> void:
+	assert_almost_eq(Renderer.SOURCE_FRAME_RATE, 4194304.0 / 70224.0, 0.000001)
+	var expected_samples: int = int(floor(2.0 * Renderer.SAMPLE_RATE / Renderer.SOURCE_FRAME_RATE))
+	assert_eq(Renderer.frame_sample(2), expected_samples)
+
+
 func test_counted_loop_jumps_to_the_source_pointer_and_then_exits() -> void:
 	var record := {
 		"address": 0x4000,
@@ -49,6 +55,43 @@ func test_counted_loop_jumps_to_the_source_pointer_and_then_exits() -> void:
 	assert_eq(events[3]["start_frame"], 3)
 	assert_eq(decoded["duration_frames"], 4)
 	assert_false(decoded["looped"])
+
+
+func test_restart_channel_reloads_the_target_header_and_clears_channel_state() -> void:
+	var record := {
+		"address": 0x4000,
+		"bytes": [
+			0x00, 0x06, 0x40,
+			0x00, 0x11, 0x40,
+			0xD4, 0xD8, 0x01, 0xF1, 0x11, 0xEA, 0x03, 0x40,
+			0x00, 0x00, 0x00,
+			0xD5, 0xD8, 0x02, 0xF1, 0x11, 0xFF,
+		],
+	}
+	var decoded: Dictionary = Decoder.decode(record)
+	assert_true(decoded["ok"], JSON.stringify(decoded))
+	var events: Array = decoded["tracks"][0]["events"]
+	assert_eq(events.size(), 2)
+	assert_eq(events[0]["duration_frames"], 2)
+	assert_eq(events[1]["start_frame"], 2)
+	assert_eq(events[1]["duration_frames"], 4)
+
+
+func test_global_tempo_is_inherited_by_channels_decoded_after_the_command() -> void:
+	var record := {
+		"address": 0x4000,
+		"bytes": [
+			0x40, 0x06, 0x40, 0x00, 0x10, 0x40,
+			0xDA, 0x02, 0x00, 0xD8, 0x01, 0xF1, 0x11, 0xFF,
+			0x00, 0x00,
+			0xD8, 0x01, 0xF1, 0x11, 0xFF,
+		],
+	}
+	var decoded: Dictionary = Decoder.decode(record)
+	assert_true(decoded["ok"], JSON.stringify(decoded))
+	assert_eq(decoded["tracks"].size(), 2)
+	assert_eq(decoded["tracks"][0]["events"][0]["duration_frames"], 4)
+	assert_eq(decoded["tracks"][1]["events"][0]["duration_frames"], 4)
 
 
 func test_sfx_starts_in_fixed_mode_then_toggle_sfx_restores_music_notes() -> void:
@@ -74,9 +117,26 @@ func test_sfx_kind_alias_starts_in_the_same_fixed_mode_as_sound() -> void:
 		],
 	}
 	var decoded: Dictionary = Decoder.decode(record, &"sfx")
+	var sound_decoded: Dictionary = Decoder.decode(record, &"sound")
 	assert_true(decoded["ok"])
-	assert_eq(decoded["tracks"][0]["events"].size(), 1)
-	assert_eq(decoded["tracks"][0]["events"][0]["duration_frames"], 2)
+	assert_eq(decoded["tracks"], sound_decoded["tracks"])
+	assert_eq(decoded["duration_frames"], sound_decoded["duration_frames"])
+
+
+func test_plural_cry_kind_aliases_the_same_fixed_stream() -> void:
+	var record := {
+		"address": 0x7000,
+		"bytes": [
+			0x44, 0x06, 0x70, 0x07, 0x0D, 0x70,
+			0xDE, 0x1B, 1, 0xF8, 0x20, 0x03, 0xFF,
+			2, 0xA1, 0x6C, 0xFF,
+		],
+	}
+	var singular: Dictionary = Decoder.decode(record, &"cry")
+	var plural: Dictionary = Decoder.decode(record, &"cries")
+	assert_true(singular["ok"])
+	assert_eq(plural["tracks"], singular["tracks"])
+	assert_eq(plural["duration_frames"], singular["duration_frames"])
 
 
 func test_sfx_priority_commands_are_carried_on_source_events() -> void:
@@ -175,7 +235,7 @@ func test_renderer_builds_a_playable_stream_from_decoded_events() -> void:
 	var rendered: Dictionary = Renderer.render(decoded)
 	assert_true(rendered["ok"])
 	assert_not_null(rendered["stream"])
-	assert_eq(rendered["stream"].data.size(), 2 * Renderer.SAMPLE_RATE * 4 / 60)
+	assert_eq(rendered["stream"].data.size(), Renderer.frame_sample(2) * 4)
 	assert_ne(rendered["stream"].data[0], 0)
 	assert_false(rendered["stream"].loop_mode == AudioStreamWAV.LOOP_FORWARD)
 
@@ -198,7 +258,7 @@ func test_renderer_resets_the_oscillator_phase_at_each_source_note() -> void:
 	assert_true(rendered["ok"])
 	var data: PackedByteArray = rendered["stream"].data
 	var first: int = _sample(data, 0)
-	var second: int = _sample(data, Renderer.SAMPLE_RATE / 60)
+	var second: int = _sample(data, Renderer.frame_sample(1))
 	assert_eq(second, first, "a new note retriggers the channel phase")
 
 
@@ -235,7 +295,7 @@ func test_renderer_exposes_bounded_chunk_buffers() -> void:
 	var chunk: Dictionary = Renderer.render_chunk(decoded, 60, 4)
 	assert_true(chunk["ok"])
 	assert_eq(chunk["frame_count"], 4)
-	assert_eq(chunk["buffer"].size(), 4 * Renderer.SAMPLE_RATE / 60)
+	assert_eq(chunk["buffer"].size(), Renderer.frame_sample(64) - Renderer.frame_sample(60))
 
 
 func test_adjacent_music_chunks_keep_a_note_continuous() -> void:
@@ -255,7 +315,7 @@ func test_adjacent_music_chunks_keep_a_note_continuous() -> void:
 	var full_data: PackedByteArray = full["stream"].data
 	var second_buffer: PackedVector2Array = second["buffer"]
 	var second_first: int = int(roundf(second_buffer[0].x * 32768.0))
-	assert_eq(second_first, _sample(full_data, 4 * Renderer.SAMPLE_RATE / 60))
+	assert_eq(second_first, _sample(full_data, Renderer.frame_sample(4)))
 
 
 func test_audio_exact_dmg_duty_patterns_are_not_thresholds() -> void:
@@ -302,7 +362,7 @@ func test_audio_noise_lfsr_and_filter_state_match_across_chunks() -> void:
 	for index: int in second_data.size():
 		assert_eq(
 			int(roundf(second_data[index].x * 32767.0)),
-			_sample_signed(full_data, 4 * Renderer.SAMPLE_RATE / 60 + index),
+			_sample_signed(full_data, Renderer.frame_sample(4) + index),
 			"noise chunk state at sample %d" % index,
 		)
 

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -27,6 +27,18 @@ func _record(bank: int, address: int = 0x4000) -> Dictionary:
 	}
 
 
+func _loop_record(bank: int) -> Dictionary:
+	return {
+		"bank": bank,
+		"address": 0x4000,
+		"bytes": [
+			0x00, 0x03, 0x40,
+			0xD8, 0x01, 0xF1, 0x11,
+			0xFC, 0x03, 0x40,
+		],
+	}
+
+
 func test_music_already_playing_is_continued_rather_than_started_again() -> void:
 	var first: Dictionary = _player.play_record(_record(2), &"map_music")
 	assert_true(first["ok"])
@@ -64,3 +76,13 @@ func test_kept_music_streams_are_bounded_and_never_drop_what_is_playing() -> voi
 		_record(Player.MUSIC_CACHE_LIMIT + 2), &"map_music"
 	)
 	assert_true(current["continued"])
+
+
+func test_generator_refill_pushes_audio_within_its_output_capacity() -> void:
+	var result: Dictionary = _player.play_record(_loop_record(99), &"map_music")
+	assert_true(result["ok"])
+	_player._service_timeline()
+	var available: int = _player._music_playback.get_frames_available()
+	var capacity: int = ceili(float(_player._music_generator.mix_rate) * _player._music_generator.buffer_length)
+	assert_gt(available, 0)
+	assert_lt(available, capacity)

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -296,14 +296,15 @@ func test_outgoing_phone_uses_imported_same_map_and_out_of_area_scripts() -> voi
 	assert_eq(out_of_area["script"]["address"], 0x6600)
 
 
-func test_audio_host_renders_the_real_record() -> void:
+func test_audio_host_decodes_the_real_record_without_a_second_renderer() -> void:
 	var record: Dictionary = _data.world_audio(&"music", 0)
 	var result: Dictionary = Gen2WorldAudioHost.play(record, &"music")
 	assert_true(result["ok"])
 	assert_false(result["played"])
-	assert_eq(result["backend"], Gen2WorldAudioHost.BACKEND_WAV)
+	assert_eq(result["backend"], Gen2WorldAudioHost.BACKEND_DECODE_ONLY)
 	assert_true(result["ready"])
 	assert_eq(result["byte_count"], 6)
+	assert_false(result.has("stream"))
 
 
 func test_menu_input_can_be_cancelled_without_selecting_an_option() -> void:


### PR DESCRIPTION
## Summary

- Fix AudioStreamGenerator starvation by using bounded source-frame refills.
- Use the Game Boy LCD VBlank clock (59.7275 Hz) for rendering and fade timing.
- Repair cry aliases, global tempo propagation, restart-channel state reset, and shared-channel restoration.
- Remove the stale standalone WAV playback backend so runtime audio uses one shared Gen II hardware timeline.

## Validation

- Full GUT: 2,504/2,504 tests, 22,272 assertions.
- Focused audio suite: 24/24.
- Gold/Silver/Crystal corpus audit: 1,076 rows, 0 failures, 0 warnings, completed in 3.5 seconds.
- Opening-lane validator: valid for all three games.
- World-script validator: completed with existing unsupported/truncated-source diagnostics.
- Headless project boot smoke: passed.
- Manual music, SFX, and cry WAV captures inspected.,