### PR TITLE
world: hold a script for the movement and the delays it waits on

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ all three games unless its row says otherwise:
 | `preview_world_services.gd <png>` | mart overlay, deterministic integration cache |
 | `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
 | `preview_intro.gd <game> <png> [gender\|speech\|beat] [steps]` | the new game's opening screens at hardware resolution: the gender question, and any frame of `OakSpeech` by source frame or by button press, so a fade or a pic move can be looked at one frame at a time |
-| `preview_mom_scene.gd <game> [png]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up |
+| `preview_mom_scene.gd <game> [png] [frame]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up. `frame` picks which one the `png` is of, so the emote, the walk and the box can each be looked at |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
 | `preview_collision.gd <game> <group> <number> <png>` | one whole map as drawn, with every walk cell's permission checkerboarded over it: red is wall, blue is water. For a report that the player can stand where they should not |

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -17,6 +17,8 @@ const TEXT_DELAY_FAST: int = 1
 const TEXT_DELAY_MED: int = 3
 const TEXT_DELAY_SLOW: int = 5
 const TEXT_DELAY_MASK: int = 0b111
+## The delays above are frame counts, so a rate needs the frame.
+const FRAME_SECONDS: float = 1.0 / 60.0
 const TEXT_DELAYS: Array[int] = [TEXT_DELAY_FAST, TEXT_DELAY_MED, TEXT_DELAY_SLOW]
 
 ## Both of these read backwards: `options_menu.asm` `Options_BattleScene`
@@ -104,6 +106,22 @@ func to_source_bytes() -> PackedByteArray:
 	]
 	bytes[OFFSET_OPTIONS2] = (1 << BIT_MENU_ACCOUNT) if menu_account else 0
 	return bytes
+
+
+## Frames `PrintLetterDelay` waits between two characters: the low three bits of
+## `wOptions`, unless `wTextboxFlags`' FAST_TEXT_DELAY bit is clear, which is the
+## routine's own `.fast` branch and overrides the row with one frame
+## (`home/print_text.asm`).
+func text_delay_frames() -> int:
+	if not fast_text_delay:
+		return TEXT_DELAY_FAST
+	return TEXT_DELAYS[clampi(text_speed, 0, TEXT_DELAYS.size() - 1)]
+
+
+## The same thing as a rate, which is what a text box driven by elapsed time
+## needs: 60, 20 or 12 characters a second. See [member Gen2TextBox.reveal_speed].
+func text_reveal_speed() -> float:
+	return 1.0 / (FRAME_SECONDS * float(text_delay_frames()))
 
 
 ## Reads a cartridge block back. A short block is refused rather than padded,

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -200,6 +200,10 @@ var _player_step_accumulator: float = 0.0
 ## The rest of a scripted movement stream the player still has to be drawn
 ## walking, the way Gen2WorldObject.queued_steps holds an object's.
 var _player_queued_steps: Array = []
+## Whether the trail above belongs to a scripted stream rather than to a walk
+## the player asked for. Gen2WorldObject.scripted_steps for the player, and what
+## keeps an ordinary step in flight out of scripted_movement_in_progress().
+var _player_scripted_steps: bool = false
 ## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
 var _player_step_frame: int = 0
 ## Real time banked toward the next hardware frame of object movement, held
@@ -208,6 +212,10 @@ var _object_step_accumulator: float = 0.0
 ## The same for the presentation trail a scripted movement leaves, which is
 ## drained by its own driver because that one runs while a script does.
 var _scripted_step_accumulator: float = 0.0
+var _script_wait_accumulator: float = 0.0
+## Frames left of the counted wait a script is standing in, -1 while it is not
+## standing in one or has not started counting.
+var _script_wait_frames: int = -1
 ## Read-only mirror of the selected save's party, refreshed by the screen
 ## whenever the save or party changes. Gen2WorldAPI does not own a save, so
 ## this stays optional; a script that reads it while empty fails rather than
@@ -480,12 +488,14 @@ func player_walk_frame() -> int:
 
 func _start_player_step(direction: Vector2i, frames: int) -> void:
 	_player_queued_steps.clear()
+	_player_scripted_steps = false
 	_begin_player_step(direction, frames)
 
 
 ## One step of a scripted stream, behind whatever the player is already walking.
 ## See Gen2WorldObject.queue_step().
 func _queue_player_step(direction: Vector2i, frames: int) -> void:
+	_player_scripted_steps = true
 	if _player_step_frames_remaining > 0:
 		_player_queued_steps.append({"direction": direction, "frames": maxi(0, frames)})
 		return
@@ -504,6 +514,7 @@ func _clear_player_step() -> void:
 	_player_step_frames_remaining = 0
 	_player_step_accumulator = 0.0
 	_player_queued_steps.clear()
+	_player_scripted_steps = false
 	_player_step_frame = 0
 
 
@@ -525,9 +536,12 @@ func advance_player_step(delta: float) -> bool:
 		_player_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
 		_player_step_frame = (_player_step_frame + 1) & 0x0F
 		_player_step_frames_remaining -= 1
-		if _player_step_frames_remaining <= 0 and not _player_queued_steps.is_empty():
-			var next: Dictionary = _player_queued_steps.pop_front()
-			_begin_player_step(next["direction"], int(next["frames"]))
+		if _player_step_frames_remaining <= 0:
+			if _player_queued_steps.is_empty():
+				_player_scripted_steps = false
+			else:
+				var next: Dictionary = _player_queued_steps.pop_front()
+				_begin_player_step(next["direction"], int(next["frames"]))
 		changed = true
 	return changed
 
@@ -2390,6 +2404,14 @@ func pending_script_input() -> Dictionary:
 	return _active_script.pending_input() if _active_script != null else {}
 
 
+## The frame wait a running script is standing in, empty when it is not standing
+## in one. Distinct from [method pending_script_input] and
+## [method pending_runtime_request] because no host answers it: only frames do,
+## through [method advance_script_wait].
+func pending_script_wait() -> Dictionary:
+	return _active_script.pending_wait() if _active_script != null else {}
+
+
 ## Starts one callback type from the current map's callback table. A type of -1
 ## runs all callbacks in their stored order.
 func dispatch_callbacks(callback_type: int = -1) -> Array:
@@ -2563,7 +2585,7 @@ func run_event_queue(acknowledge: bool = false, choice: int = -1) -> Array:
 		accept = false
 		selected_choice = -1
 		if StringName(result.get("status", &"")) == &"waiting":
-			results.append(result)
+			results.append(_apply_result_events(result))
 			break
 		results.append(_finish_script_result(result))
 		_active_script = null
@@ -2584,7 +2606,7 @@ func cancel_script_input() -> Array:
 	var results: Array = []
 	var advanced: Dictionary = _active_script.cancel_input()
 	if StringName(advanced.get("status", &"")) == &"waiting":
-		results.append(advanced)
+		results.append(_apply_result_events(advanced))
 		return results
 	results.append_array(_resume_after(advanced))
 	return results
@@ -2599,7 +2621,7 @@ func complete_runtime_request(result: Dictionary) -> Array:
 	var results: Array = []
 	var advanced: Dictionary = _active_script.complete_runtime_request(result)
 	if StringName(advanced.get("status", &"")) == &"waiting":
-		results.append(advanced)
+		results.append(_apply_result_events(advanced))
 		return results
 	if StringName(advanced.get("status", &"")) == &"recovered":
 		results.append(advanced)
@@ -2649,7 +2671,7 @@ func _drain_script_queue() -> Array:
 		)
 		var next: Dictionary = _active_script.advance()
 		if StringName(next.get("status", &"")) == &"waiting":
-			results.append(next)
+			results.append(_apply_result_events(next))
 			break
 		results.append(_finish_script_result(next) if bool(next.get("ok", false)) else next)
 		_active_script = null
@@ -3197,7 +3219,7 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 					)
 				reload_objects = true
 	if reload_objects and current_map != null:
-		_load_objects()
+		_load_objects(true)
 	return generated
 
 
@@ -3265,6 +3287,11 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				object.set_emote(object.emote_id, true)
 			&"hide_emote":
 				object.set_emote(object.emote_id, false)
+			&"step_sleep":
+				## STEP_TYPE_SLEEP counts OBJECT_STEP_DURATION down one frame at a
+				## time before the stream reads its next command, so a sleep is part
+				## of what an applymovement wait waits for.
+				object.queue_wait(int(command.get("length", 0)))
 			&"step_stop":
 				break
 			&"tree_shake":
@@ -3279,7 +3306,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 					"object_index": object_index,
 					"cell": object.cell,
 				})
-			&"step_sleep", &"set_sliding", &"remove_sliding", &"fix_facing", &"remove_fixed_facing":
+			&"set_sliding", &"remove_sliding", &"fix_facing", &"remove_fixed_facing":
 				pass
 			_:
 				generated.append({
@@ -3349,8 +3376,15 @@ func _apply_player_movement(event: Dictionary) -> Array:
 				"source": &"player_movement",
 			})
 			continue
+		if kind == &"step_sleep":
+			# The player's half of the same wait: Script_earthquake's own stream is
+			# `step_shake` and then a sleep, and the sleep is all of its duration.
+			_queue_player_step(
+				Vector2i.ZERO, Gen2WorldObject.sleep_frames(int(command.get("length", 0)))
+			)
+			continue
 		if kind in [
-			&"step_sleep", &"step_wait_end", &"set_sliding", &"remove_sliding",
+			&"step_wait_end", &"set_sliding", &"remove_sliding",
 			&"fix_facing", &"remove_fixed_facing",
 		]:
 			continue
@@ -3411,6 +3445,19 @@ func _validate_script_warp(map_group: int, map_number: int, cell: Vector2i) -> D
 	return {"ok": true}
 
 
+## Applies what a script emitted before it stopped, whether it stopped for good
+## or only to pause. A pause is a resume point rather than an ending in the
+## source: `applymovement` yields the frame it has queued the stream, and the
+## object has to be walking while the script waits for it. The runner drains its
+## own event list per result, so nothing here is applied twice.
+func _apply_result_events(result: Dictionary) -> Dictionary:
+	if not result.has("events"):
+		return result
+	for generated: Dictionary in _apply_script_object_events(result.get("events", [])):
+		result["events"].append(generated)
+	return result
+
+
 func _finish_script_result(result: Dictionary) -> Dictionary:
 	if not bool(result.get("ok", false)):
 		return result
@@ -3423,9 +3470,7 @@ func _finish_script_result(result: Dictionary) -> Dictionary:
 		)
 	if result.has("dst_enabled"):
 		set_daylight_saving_time_enabled(bool(result.get("dst_enabled", false)))
-	var generated_events: Array = _apply_script_object_events(result.get("events", []))
-	for generated: Dictionary in generated_events:
-		result["events"].append(generated)
+	_apply_result_events(result)
 	var warp: Variant = result.get("warp", {})
 	if warp is Dictionary and not (warp as Dictionary).is_empty():
 		var transition: Dictionary = _apply_script_warp(warp as Dictionary)
@@ -3899,6 +3944,88 @@ func advance_scripted_steps(delta: float) -> bool:
 			if object.tick_step():
 				changed = true
 	return changed
+
+
+## Spends the frames a script is waiting on and resumes it the frame its wait
+## ends, returning whatever that produced.
+##
+## The two waits are `ScriptEvents`'s own: SCRIPT_WAIT_MOVEMENT, which ends when
+## the stream an `applymovement` started has been drawn, and the counted delay
+## `pause`, `wait`, `deactivatefacing` and `showemote` spend. A host calls this
+## once per frame beside [method advance_scripted_steps], which is what draws
+## the movement the first one waits for.
+func advance_script_wait(delta: float) -> Array:
+	var wait: Dictionary = pending_script_wait()
+	if wait.is_empty():
+		_script_wait_accumulator = 0.0
+		_script_wait_frames = -1
+		return []
+	if StringName(wait.get("wait", &"")) == Gen2WorldScriptRunner.WAIT_MOVEMENT:
+		if scripted_movement_in_progress():
+			return []
+		return _complete_script_wait()
+	if _script_wait_frames < 0:
+		_script_wait_frames = maxi(0, int(wait.get("frames", 0)))
+		_script_wait_accumulator = 0.0
+	_script_wait_accumulator = minf(
+		_script_wait_accumulator + maxf(delta, 0.0),
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
+	)
+	while _script_wait_accumulator >= Gen2WorldAnimation.FRAME_SECONDS \
+		and _script_wait_frames > 0:
+		_script_wait_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
+		_script_wait_frames -= 1
+	if _script_wait_frames > 0:
+		return []
+	return _complete_script_wait()
+
+
+## Whether anything a script set walking is still being drawn. This is
+## wStateFlags' SCRIPTED_MOVEMENT_STATE_F: one flag for all of them, cleared by
+## whichever stream reaches its own `step_end`.
+func scripted_movement_in_progress() -> bool:
+	if _player_scripted_steps and player_step_in_progress():
+		return true
+	for object: Gen2WorldObject in objects:
+		if object.scripted_steps and not object.deleted:
+			return true
+	return false
+
+
+func _complete_script_wait() -> Array:
+	_script_wait_accumulator = 0.0
+	_script_wait_frames = -1
+	if _active_script == null:
+		return []
+	var advanced: Dictionary = _active_script.complete_wait()
+	if StringName(advanced.get("status", &"")) == &"waiting":
+		return [_apply_result_events(advanced)]
+	return _resume_after(advanced)
+
+
+## One hardware frame of every presentation a script waits on, for a caller with
+## no render loop of its own: the trails and then the wait that is watching them.
+## A screen calls the three parts itself, in the order it already draws them.
+func advance_script_presentation(delta: float) -> Array:
+	advance_player_step(delta)
+	advance_scripted_steps(delta)
+	return advance_script_wait(delta)
+
+
+## Spends whole waits at the hardware frame rate until the script is no longer
+## standing in one, and returns what resuming it produced last. The entry point
+## for a headless caller that has nothing to draw; [param frame_limit] bounds a
+## wait nothing can end rather than hanging on it, so a caller checks
+## [method pending_script_wait] afterwards to tell a spent wait from a stuck one.
+func finish_script_waits(frame_limit: int = 1024) -> Array:
+	var results: Array = []
+	for _frame: int in frame_limit:
+		if pending_script_wait().is_empty():
+			break
+		var spent: Array = advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS)
+		if not spent.is_empty():
+			results = spent
+	return results
 
 
 ## Keeps a moved or turned object's live cell and facing across the map reloads
@@ -4448,7 +4575,11 @@ func _on_world_state_changed() -> void:
 	set_object_time(object_hour, object_time_of_day)
 
 
-func _load_objects() -> void:
+## [param carry_presentation] keeps the live emote and movement trail of the
+## records being replaced, for the reloads that happen inside one visit to a map
+## rather than on the way into it. See Gen2WorldObject.carry_presentation_from().
+func _load_objects(carry_presentation: bool = false) -> void:
+	var previous: Array = objects if carry_presentation else []
 	objects = []
 	if current_map == null or data == null:
 		return
@@ -4483,6 +4614,8 @@ func _load_objects() -> void:
 			object.cell = _object_position_overrides[key]
 		if _object_facing_overrides.has(key):
 			object.facing = int(_object_facing_overrides[key])
+		if index < previous.size():
+			object.carry_presentation_from(previous[index] as Gen2WorldObject)
 		objects.append(object)
 	set_object_time(object_hour, object_time_of_day)
 

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -125,6 +125,32 @@ static func from_event(
 	return out
 
 
+## Carries the live presentation of the object this one replaces at the same
+## index on the same map: the emote it is showing, the trail it is still being
+## drawn walking, and whether a movement stream deleted it.
+##
+## The cartridge never rebuilds an object struct for any of the reasons this
+## project rebuilds a record: `ApplyObjectFacing`, `CopyDECoordsToMapObject` and
+## the variable-sprite table all write into the struct that is already there.
+## Without this, a `turnobject` between a `showemote` and its `applymovement`
+## takes the emote down and empties the trail the script is waiting on.
+func carry_presentation_from(previous: Gen2WorldObject) -> void:
+	if previous == null:
+		return
+	emote_id = previous.emote_id
+	emote_visible = previous.emote_visible
+	emote_remaining = previous.emote_remaining
+	step_direction = previous.step_direction
+	step_frames_total = previous.step_frames_total
+	step_frames_remaining = previous.step_frames_remaining
+	queued_steps = previous.queued_steps.duplicate(true)
+	scripted_steps = previous.scripted_steps
+	step_frame = previous.step_frame
+	frame = previous.frame
+	idle_frames_remaining = previous.idle_frames_remaining
+	deleted = previous.deleted
+
+
 func initial_facing() -> int:
 	match movement:
 		MOVEMENT_FIXED_UP:
@@ -310,6 +336,19 @@ func queue_step(direction: Vector2i, frames: int) -> void:
 	_begin_step(direction, frames)
 
 
+## Adds a `step_sleep` to the same trail: frames the stream spends standing.
+## STEP_TYPE_SLEEP writes STANDING into OBJECT_WALKING, so this walks nothing
+## and moves nothing, but the script waiting on the stream still waits for it.
+func queue_wait(frames: int) -> void:
+	queue_step(Vector2i.ZERO, sleep_frames(frames))
+
+
+## `StepFunction_Sleep` decrements OBJECT_STEP_DURATION before testing it, so a
+## zero-length sleep wraps a whole byte instead of ending at once.
+static func sleep_frames(length: int) -> int:
+	return length if length > 0 else 0x100
+
+
 func _begin_step(direction: Vector2i, frames: int) -> void:
 	step_direction = direction
 	step_frames_total = maxi(0, frames)
@@ -322,7 +361,8 @@ func _begin_step(direction: Vector2i, frames: int) -> void:
 func tick_step() -> bool:
 	if step_frames_remaining <= 0:
 		return false
-	advance_walk_frame()
+	if step_direction != Vector2i.ZERO:
+		advance_walk_frame()
 	step_frames_remaining -= 1
 	if step_frames_remaining <= 0:
 		if queued_steps.is_empty():

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -198,10 +198,7 @@ func _build_world() -> void:
 	_play_current_map_music()
 	_text_box = Gen2TextBox.new()
 	_text_box.font = Gen2Font.from_data(_data)
-	## wTextboxFrame, which `Textbox` reads on every box it draws and the OPTION
-	## menu's FRAME row writes.
-	_text_box.set_frame_style(Gen2OptionsStore.current().textbox_frame)
-	_text_box.reveal_speed = 0.0
+	_apply_text_box_options()
 	_text_box.place_at_bottom()
 	_text_box.visible = false
 	_text_box.item_rect_changed.connect(_push_text_box_rect)
@@ -324,6 +321,12 @@ func _process(delta: float) -> void:
 	# script that ran it is still going, which is when a script runs one.
 	if _world != null and _world.advance_scripted_steps(delta) and _renderer != null:
 		_renderer.refresh()
+	# After the trail, because the frame it finishes drawing is the frame the
+	# script waiting on it resumes.
+	if _world != null and not _world.pending_script_wait().is_empty():
+		var wait_results: Array = _world.advance_script_wait(delta)
+		if not wait_results.is_empty():
+			_show_script_results(wait_results)
 	if not _trainer_approach.is_empty():
 		_advance_trainer_approach()
 	if _world != null and _world.phone_ring_active():
@@ -493,8 +496,24 @@ func _handle_button(button: int) -> bool:
 	return false
 
 
+## The two OPTION rows a box reads, applied on every box rather than once:
+## `Textbox` reads wTextboxFrame and `PrintLetterDelay` reads the text speed as
+## each one is drawn, and the OPTION menu commits both on the press that changes
+## them.
+func _apply_text_box_options() -> void:
+	if _text_box == null:
+		return
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+
+
 ## The A press that clears whatever a running script is waiting on.
 func _advance_script_pause() -> void:
+	## Except a frame wait, which nothing but frames ends: the source is inside
+	## WaitScriptMovement or a DelayFrames loop and reads no input there.
+	if not _world.pending_script_wait().is_empty():
+		return
 	if _text_box != null and _text_box.visible:
 		_advance_script_input()
 		return
@@ -1882,6 +1901,7 @@ func _strength_refusal(reason: StringName) -> String:
 func _show_field_move_text(text: String) -> void:
 	_field_move_text = true
 	if _text_box != null and _text_box.font != null:
+		_apply_text_box_options()
 		_text_box.show_text(text)
 		_text_box.visible = true
 	_script_prompt = "A: continue"
@@ -2078,6 +2098,7 @@ func _show_script_results(results: Array) -> void:
 			var event: Dictionary = result.get("event", {})
 			var event_type: StringName = StringName(event.get("type", &""))
 			if event_type == &"text" and _text_box != null and _text_box.font != null:
+				_apply_text_box_options()
 				_text_box.show_text(String(event.get("text", "")))
 				_text_box.visible = true
 				_script_prompt = "A: advance text"
@@ -2085,6 +2106,8 @@ func _show_script_results(results: Array) -> void:
 				if _text_box != null:
 					_text_box.visible = true
 				_script_prompt = "A: continue script"
+			elif event_type == &"wait":
+				_script_prompt = "Script waiting on %s" % String(event.get("wait", &"frames"))
 			elif event_type in [&"choice", &"menu"]:
 				_open_service_host()
 				break

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -796,7 +796,7 @@ static func command_at(
 				command["block"] = int(data[offset + 3])
 			0x7C, 0x7E, 0x8C, 0x8E, 0x94, 0x97, 0x9B:
 				command["address"] = read_u16(data, offset + 1)
-			0x7D, 0x89:
+			0x7D, 0x89, 0x8A, 0x8B:
 				command["value"] = int(data[offset + 1])
 			0x80:
 				command["value"] = read_u16(data, offset + 1)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -46,6 +46,10 @@ var _failure: Dictionary = {}
 var _finish_after_pending: bool = false
 var _loaded_menu: Dictionary = {}
 var _loaded_emote: int = -1
+## wScriptDelay. `Script_pause` reuses whatever is in it when its own operand is
+## zero, which is how `Script_showemote` sets the emote's duration: it writes the
+## delay and then calls `ShowEmoteScript`, whose middle command is `pause 0`.
+var _script_delay: int = 0
 var _trainer_intro_approach_pending: bool = false
 ## Set while RockSmashScript's `playsound SFX_STRENGTH` is out with the host, so
 ## its acknowledge continues into the earthquake, the disappear and the roll.
@@ -175,6 +179,18 @@ const BATTLE_RESULT_WIN: int = 0
 const BATTLE_RESULT_LOSE: int = 1
 const BATTLE_RESULT_DRAW: int = 2
 const TEXT_STRING_BUFFER: int = 0x14
+## The two waits `ScriptEvents` spends frames in rather than asking for anything
+## (`engine/overworld/scripting.asm`). WAIT_MOVEMENT is SCRIPT_WAIT_MOVEMENT,
+## which runs until the stream an `applymovement` started clears
+## SCRIPTED_MOVEMENT_STATE_F; WAIT_FRAMES is the counted delay `Script_pause`,
+## `Script_wait` and `Script_deactivatefacing` spend. Neither takes a button, so
+## both resolve through complete_wait() rather than through advance().
+const WAIT_MOVEMENT: StringName = &"movement"
+const WAIT_FRAMES: StringName = &"frames"
+## `Script_pause` delays `DelayFrames 2` per counted unit and `Script_wait`
+## delays six.
+const PAUSE_FRAMES_PER_UNIT: int = 2
+const WAIT_FRAMES_PER_UNIT: int = 6
 const WEEKDAY_NAMES: Array[StringName] = [
 	&"Sunday", &"Monday", &"Tuesday", &"Wednesday", &"Thursday", &"Friday", &"Saturday",
 ]
@@ -287,6 +303,10 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		var pending_request: Dictionary = _pending.get("request", {})
 		if _pending.get("type", &"") == &"runtime_request" \
 			and StringName(pending_request.get("kind", &"")) == &"battle_requested":
+			return _waiting_result()
+		## Only frames end a wait, so a button press cannot: the source is inside
+		## WaitScriptMovement or a DelayFrames loop, which read no input at all.
+		if _pending.get("type", &"") == &"wait":
 			return _waiting_result()
 		if not acknowledge:
 			return _waiting_result()
@@ -482,7 +502,10 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		if _pending:
 			return _waiting_result()
 		if _completed:
-			return _complete_result()
+			## A terminal command returns _complete()'s own result, which has
+			## already drained the events; asking for a second one would hand the
+			## caller an empty list in its place.
+			return outcome if outcome.has("status") else _complete_result()
 
 	return _complete()
 
@@ -727,6 +750,36 @@ func pending_input() -> Dictionary:
 	return _pending.duplicate(true)
 
 
+## The frame wait this invocation is standing in, empty when it is not standing
+## in one. A caller spends the frames and calls [method complete_wait]; nothing
+## else ends it.
+func pending_wait() -> Dictionary:
+	if StringName(_pending.get("type", &"")) != &"wait":
+		return {}
+	return _pending.duplicate(true)
+
+
+## Resumes after the wait above. `ShowEmoteScript`'s trailing
+## `applymovementlasttalked .Hide` is the one continuation a wait carries: the
+## emote is put up by the script the source calls and taken down by the same
+## script, so the hide belongs to the end of the pause rather than to a host.
+func complete_wait() -> Dictionary:
+	if StringName(_pending.get("type", &"")) != &"wait":
+		return {
+			"ok": false, "status": &"failed", "reason": &"script_wait_not_pending",
+		}
+	var hide_emote_object: int = int(_pending.get("hide_emote_object", -1))
+	_pending = {}
+	if hide_emote_object >= 0:
+		_emit_object_event(&"object_emote", {
+			"object_index": hide_emote_object,
+			"emote_id": _loaded_emote,
+			"visible": false,
+			"duration": 0,
+		})
+	return advance()
+
+
 ## Cancels a pending menu or choice without inventing a cartridge option. The
 ## script receives zero, matching the false branch used by yes/no commands.
 func cancel_input() -> Dictionary:
@@ -778,9 +831,9 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		_emit_runtime_event(&"script_timing_requested", {
 			"kind": &"wait",
 			"value": int(command.get("value", 0)),
-			"frames": int(command.get("value", 0)) * 6,
+			"frames": int(command.get("value", 0)) * WAIT_FRAMES_PER_UNIT,
 		})
-		return {"ok": true}
+		return _stage_frame_wait(int(command.get("value", 0)) * WAIT_FRAMES_PER_UNIT)
 	if opcode == 0x9F and _crystal_commands():
 		## Crystal inserts verbosegiveitemvar at this raw byte. Normalizing first
 		## turns it into pokegold's swarm command.
@@ -1233,19 +1286,46 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 				_loaded_emote = _script_value
 			_emit_runtime_event(&"emote_loaded", {"emote_id": _loaded_emote})
 		0x74:
+			## Script_showemote is `ScriptCall ShowEmoteScript`: loademote, an
+			## applymovement that shows the emote, `pause 0` over the delay this
+			## command just wrote, and an applymovement that hides it again. The two
+			## one-command movements are folded into the emote event and its hide;
+			## the pause is the wait, and it is what the operand measures.
 			var emote_id: int = int(command.get("value", _loaded_emote))
 			if emote_id == 0xFF:
 				emote_id = _loaded_emote
+			_loaded_emote = emote_id
+			## `cp LAST_TALKED / jr z` keeps hLastTalked as it was only when the
+			## operand is LAST_TALKED itself; every other id becomes the new one,
+			## which is what the two `applymovementlasttalked`s inside
+			## ShowEmoteScript then move.
+			var emote_object_id: int = int(command.get("object_id", 0))
+			if emote_object_id != LAST_TALKED:
+				_last_talked_object_index = _object_index_from_id(emote_object_id)
+			var emote_object: int = _object_index_from_id(emote_object_id)
+			_script_delay = int(command.get("value_2", 0))
 			_emit_object_event(&"object_emote", {
-				"object_index": _object_index_from_id(int(command.get("object_id", 0))),
+				"object_index": emote_object,
 				"emote_id": emote_id,
 				"visible": true,
-				"duration": int(command.get("value_2", 0)),
+				## Zero is "until the hide", not "for no time": the source takes the
+				## emote down from ShowEmoteScript's last command, not on a counter.
+				"duration": 0,
 			})
+			return _stage_frame_wait(
+				_script_delay * PAUSE_FRAMES_PER_UNIT,
+				{"hide_emote_object": emote_object, "emote_id": emote_id}
+			)
 		0x77:
+			## Script_earthquake is `ScriptCall` on `applymovement PLAYER,
+			## wEarthquakeMovementDataBuffer`, whose stream is `step_shake n` then
+			## `step_sleep (n & %00111111)`. The shake starts and the movement wait
+			## is that sleep, since step_shake itself reaches
+			## ContinueReadingMovement without spending a frame.
 			_emit_runtime_event(&"earthquake_requested", {
 				"strength": int(command.get("value", 0)),
 			})
+			return _stage_frame_wait(int(command.get("value", 0)) & 0x3F)
 		0x78:
 			_emit_runtime_event(&"map_blocks_requested", {
 				"bank": bank, "address": int(command.get("address", 0)),
@@ -1303,10 +1383,22 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 				"sprite": int(command.get("value_2", 0)),
 			})
 		0x8A, 0x8B:
+			## Both write wScriptDelay when their operand is nonzero and reuse
+			## whatever is in it when it is zero. `Script_pause` then spends
+			## `DelayFrames 2` per unit inside the command; `Script_deactivatefacing`
+			## hands the same count to SCRIPT_WAIT, which WaitScript decrements once
+			## per frame.
+			var delay_operand: int = int(command.get("value", 0))
+			if delay_operand != 0:
+				_script_delay = delay_operand
+			var delay_frames: int = _script_delay * PAUSE_FRAMES_PER_UNIT \
+				if source_opcode == 0x8A else _script_delay
 			_emit_runtime_event(&"script_timing_requested", {
 				"kind": &"pause" if source_opcode == 0x8A else &"deactivate_facing",
-				"value": int(command.get("value", 0)),
+				"value": delay_operand,
+				"frames": delay_frames,
 			})
+			return _stage_frame_wait(delay_frames)
 		0x8C:
 			if not _push_frame(bank, int(command.get("address", 0))):
 				return {
@@ -1405,11 +1497,14 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 			_events.append({"type": &"credits_requested"})
 		0xA1:
 			return _stage_warp_facing_request(command)
+	## The commands whose case above falls out of the match rather than returning
+	## a result of its own. The four that now wait (`showemote`, `earthquake`,
+	## `pause` and `deactivatefacing`) return from inside it and are not here.
 	var handled_sources: Array = [
 		0x55, 0x56, 0x57, 0x58, 0x5B, 0x5C, 0x5D, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64,
-		0x65, 0x66, 0x7F, 0x81, 0x82, 0x85, 0x8A, 0x8B, 0x8D, 0x98,
+		0x65, 0x66, 0x7F, 0x81, 0x82, 0x85, 0x8D, 0x98,
 		0x8C,
-		0x6C, 0x73, 0x74, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
+		0x6C, 0x73, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
 		0xA0, 0x89,
 	]
 	if source_opcode in handled_sources:
@@ -1428,17 +1523,19 @@ func _execute_object_command(source_opcode: int, command: Dictionary) -> Diction
 				"bank": int(_request.get("bank", 0)),
 				"address": int(command.get("address", 0)),
 			}
+			var moved_index: int = -1
 			if movement_event_type == &"object_movement_requested":
-				movement_values["object_index"] = _object_index_from_id(
-					int(command.get("object_id", 0))
-				)
+				moved_index = _object_index_from_id(int(command.get("object_id", 0)))
+				movement_values["object_index"] = moved_index
 			_emit_object_event(movement_event_type, movement_values)
+			return _stage_movement_wait({"object_index": moved_index})
 		0x69:
 			_emit_object_event(&"object_movement_requested", {
 				"object_index": _last_talked_object_index,
 				"bank": int(_request.get("bank", 0)),
 				"address": int(command.get("address", 0)),
 			})
+			return _stage_movement_wait({"object_index": _last_talked_object_index})
 		0x6A:
 			if _last_talked_object_index >= 0:
 				_emit_object_event(&"object_face_player", {
@@ -1669,6 +1766,36 @@ func _stage_phone_choice(contact: int) -> Dictionary:
 		"contact": contact,
 		"source": _request.duplicate(true),
 	}
+	return {"ok": true}
+
+
+## Holds the script until the stream an `applymovement` just queued has been
+## drawn. The cells committed when the command applied, exactly as the source
+## commits them in `InitStep`; what is left is the drawing, and the source waits
+## for it (`WaitScriptMovement`).
+func _stage_movement_wait(values: Dictionary = {}) -> Dictionary:
+	var wait: Dictionary = {
+		"type": &"wait",
+		"wait": WAIT_MOVEMENT,
+		"source": _request.duplicate(true),
+	}
+	for key: Variant in values:
+		wait[key] = values[key]
+	_pending = wait
+	return {"ok": true}
+
+
+## Holds it for a counted number of hardware frames.
+func _stage_frame_wait(frames: int, values: Dictionary = {}) -> Dictionary:
+	var wait: Dictionary = {
+		"type": &"wait",
+		"wait": WAIT_FRAMES,
+		"frames": maxi(0, frames),
+		"source": _request.duplicate(true),
+	}
+	for key: Variant in values:
+		wait[key] = values[key]
+	_pending = wait
 	return {"ok": true}
 
 
@@ -2930,7 +3057,7 @@ func _complete_result() -> Dictionary:
 	var result: Dictionary = {
 		"ok": true,
 		"status": &"complete",
-		"events": _events.duplicate(true),
+		"events": _drain_events(),
 		"source": _request.duplicate(true),
 		"warp": _staged_warp.duplicate(true),
 		"commands": _command_count,
@@ -2950,7 +3077,7 @@ func _recovered_result(recovery: Dictionary) -> Dictionary:
 	return {
 		"ok": true,
 		"status": &"recovered",
-		"events": _events.duplicate(true),
+		"events": _drain_events(),
 		"source": _request.duplicate(true),
 		"recovery": recovery.duplicate(true),
 		"commands": _command_count,
@@ -3028,12 +3155,22 @@ func _battle_request_values() -> Dictionary:
 	return out
 
 
+## The events emitted since the last result, and only those. An invocation that
+## stops four times hands each event to its caller once, because a caller applies
+## and reacts to what a result carries: repeating the list would move an object
+## twice and start a screen shake on every later pause.
+func _drain_events() -> Array:
+	var drained: Array = _events.duplicate(true)
+	_events.clear()
+	return drained
+
+
 func _waiting_result() -> Dictionary:
 	return {
 		"ok": true,
 		"status": &"waiting",
 		"event": _pending.duplicate(true),
-		"events": _events.duplicate(true),
+		"events": _drain_events(),
 		"source": _request.duplicate(true),
 		"commands": _command_count,
 	}
@@ -3051,7 +3188,7 @@ func _failure_result() -> Dictionary:
 		"status": &"failed",
 		"reason": _failure.get("reason", &"script_failed"),
 		"details": _failure.get("details", {}),
-		"events": _events.duplicate(true),
+		"events": _drain_events(),
 		"source": _request.duplicate(true),
 		"commands": _command_count,
 	}

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -205,6 +205,9 @@ func test_pending_special_call_dispatches_the_imported_script() -> void:
 	assert_null(_world_screen._service_host)
 	assert_true(_world_screen._world.script_input_waiting())
 	assert_eq(_world_screen._world.pending_script_input()["text"], "PHONE SCRIPT")
+	## The first press completes the revealing page, as holding A does in
+	## `PrintLetterDelay`; the second acknowledges it.
+	_world_screen._advance_script_input()
 	_world_screen._advance_script_input()
 	await get_tree().process_frame
 	assert_false(_world_screen._world.script_input_waiting())

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -295,6 +295,10 @@ func test_production_world_entry_and_facing_object_story_persist_separate_flags(
 	assert_false(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_false(_world_screen._world.state.hall_of_fame())
 
+	## Two presses, not one: the box reveals at the OPTION menu's TEXT SPEED now,
+	## and the first press completes the page the way holding A does in
+	## `PrintLetterDelay`. The second is the one that acknowledges it.
+	_world_screen._advance_script_input()
 	_world_screen._advance_script_input()
 	assert_true(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_true(_world_screen._world.state.hall_of_fame())

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -54,6 +54,32 @@ func test_text_speed_round_trips_through_the_source_delays() -> void:
 		assert_eq(restored.text_speed, index)
 
 
+## `PrintLetterDelay` waits the low three bits of wOptions between two
+## characters, so the row is one, three or five frames a character and a box
+## driven by elapsed time wants that as a rate.
+func test_text_speed_is_a_per_character_frame_count() -> void:
+	var options := Gen2Options.new()
+	for index: int in Gen2Options.TEXT_DELAYS.size():
+		options.text_speed = index
+		assert_eq(options.text_delay_frames(), Gen2Options.TEXT_DELAYS[index])
+		assert_almost_eq(
+			options.text_reveal_speed(),
+			1.0 / (Gen2Options.FRAME_SECONDS * float(Gen2Options.TEXT_DELAYS[index])),
+			0.001
+		)
+	options.text_speed = 2
+	assert_almost_eq(options.text_reveal_speed(), 12.0, 0.001, "slow is five frames")
+
+
+## `.fast`: the branch taken when wTextboxFlags' FAST_TEXT_DELAY bit is clear
+## overrides the row with TEXT_DELAY_FAST.
+func test_a_cleared_fast_text_delay_bit_overrides_the_speed_row() -> void:
+	var options := Gen2Options.new()
+	options.text_speed = 2
+	options.fast_text_delay = false
+	assert_eq(options.text_delay_frames(), Gen2Options.TEXT_DELAY_FAST)
+
+
 func test_an_unlisted_text_delay_reads_as_medium() -> void:
 	var bytes: PackedByteArray = Gen2Options.new().to_source_bytes()
 	bytes[0] = (bytes[0] & ~Gen2Options.TEXT_DELAY_MASK) | 0b111

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -298,6 +298,44 @@ func _world(
 	return Gen2WorldAPI.open(data, 1, 1, start, world_state)
 
 
+## Spends the frames a script's own waits ask for and returns every result the
+## run produced, the dispatched ones first. A script that moves anything stops
+## at the movement it started, so a test that only wants the end of one drives
+## it through here rather than reading the first result.
+func _run_script(world: Gen2WorldAPI, dispatched: Array) -> Array:
+	var results: Array = dispatched.duplicate()
+	for _frame: int in 1024:
+		if world.pending_script_wait().is_empty():
+			break
+		results.append_array(
+			world.advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS)
+		)
+	return results
+
+
+func _final_status(results: Array) -> StringName:
+	if results.is_empty():
+		return &""
+	return StringName((results[results.size() - 1] as Dictionary).get("status", &""))
+
+
+## Every event the whole run emitted. The runner hands each one to its caller
+## once, on the result that follows it, so a script with waits in it spreads
+## them over several results.
+func _all_events(results: Array) -> Array:
+	var events: Array = []
+	for result: Dictionary in results:
+		events.append_array(result.get("events", []))
+	return events
+
+
+func _event_types(results: Array) -> Array[StringName]:
+	var types: Array[StringName] = []
+	for event: Dictionary in _all_events(results):
+		types.append(StringName(event.get("type", &"")))
+	return types
+
+
 func _write_service_cache() -> void:
 	RomCache.write_json(RomCache.world_marts_path(_directory), {
 		"marts": [{"index": 0, "bank": 48, "address": 0x4000, "items": [7]}],
@@ -3328,9 +3366,11 @@ func test_script_applymovement_executes_imported_object_and_player_streams() -> 
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
-	var results: Array = world.dispatch_script_events()
-	assert_eq(results.size(), 1)
-	assert_eq(results[0]["status"], &"complete")
+	var dispatched: Array = world.dispatch_script_events()
+	assert_eq(dispatched.size(), 1)
+	assert_eq(dispatched[0]["status"], &"waiting", "the first stream holds the script")
+	assert_eq(dispatched[0]["event"]["wait"], Gen2WorldScriptRunner.WAIT_MOVEMENT)
+	assert_eq(_final_status(_run_script(world, dispatched)), &"complete")
 	assert_eq((world.objects[0] as Gen2WorldObject).cell, Vector2i(6, 6))
 	assert_eq(world.player_cell, Vector2i(7, 5))
 
@@ -3352,13 +3392,10 @@ func test_script_movement_publishes_source_shake_effects() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
-	var results: Array = world.dispatch_script_events()
-	assert_eq(results.size(), 1)
-	assert_eq(results[0]["status"], &"complete")
-	var events: Array = results[0]["events"]
-	var types: Array[StringName] = []
-	for event: Dictionary in events:
-		types.append(StringName(event.get("type", &"")))
+	var results: Array = _run_script(world, world.dispatch_script_events())
+	assert_eq(_final_status(results), &"complete")
+	var events: Array = _all_events(results)
+	var types: Array[StringName] = _event_types(results)
 	assert_true(types.has(&"screen_shake_requested"))
 	assert_true(types.has(&"tree_shake_requested"))
 	assert_true(types.has(&"rock_smash_effect_requested"))
@@ -3381,9 +3418,8 @@ func test_script_movement_steps_through_a_wall_the_way_normal_step_does() -> voi
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
 	assert_false(world.can_walk_to(Vector2i(9, 6)), "the fixture wall moved")
-	var results: Array = world.dispatch_script_events(Vector2i(7, 6))
-	assert_eq(results.size(), 1)
-	assert_eq(results[0]["status"], &"complete")
+	var results: Array = _run_script(world, world.dispatch_script_events(Vector2i(7, 6)))
+	assert_eq(_final_status(results), &"complete")
 	assert_eq(world.player_cell, Vector2i(9, 6))
 
 
@@ -3410,7 +3446,8 @@ func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> v
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
-	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	var dispatched: Array = world.dispatch_script_events()
+	assert_eq(dispatched[0]["status"], &"waiting", "the stream holds the script")
 
 	# turn_step faced down and moved nothing; turn_in stepped one cell up and
 	# left the player facing the way it named.
@@ -3421,6 +3458,7 @@ func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> v
 	for _call: int in 2:
 		world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+	assert_eq(_final_status(_run_script(world, dispatched)), &"complete")
 
 
 func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -> void:
@@ -3435,7 +3473,7 @@ func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
 	var object: Gen2WorldObject = world.objects[0]
 	var start: Vector2i = object.cell
-	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
 
 	assert_eq(object.cell, start + Vector2i(2, 0), "both cells commit at once")
 	assert_eq(object.step_offset_cells(), Vector2(-2.0, 0.0), "and the drawing is behind both")
@@ -3450,6 +3488,153 @@ func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -
 		world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
 	assert_eq(object.step_offset_cells(), Vector2.ZERO)
 	assert_false(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS))
+
+
+## `Script_applymovement` sets SCRIPT_WAIT_MOVEMENT and StopScript, and
+## `WaitScriptMovement` holds the script until the stream clears
+## SCRIPTED_MOVEMENT_STATE_F, which `Movement_step_end` is what does. So the
+## command after it does not run until the object has been drawn walking, which
+## is what kept a text box off the top of Mom's walk.
+func test_applymovement_holds_the_script_until_the_trail_has_been_drawn() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		# applymovement, then the fixture text the wait must not reach.
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x4C, 0x00, 0x70, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var object: Gen2WorldObject = world.objects[0]
+
+	var dispatched: Array = world.dispatch_script_events()
+	assert_eq(dispatched[0]["status"], &"waiting")
+	assert_eq(dispatched[0]["event"]["type"], &"wait")
+	assert_eq(dispatched[0]["event"]["wait"], Gen2WorldScriptRunner.WAIT_MOVEMENT)
+	assert_true(world.scripted_movement_in_progress())
+	assert_true(world.pending_runtime_request().is_empty(), "no host answers a wait")
+
+	# Two `step` commands, so the wait outlasts the first one's frames.
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		assert_true(
+			world.advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS).is_empty()
+		)
+	assert_false(world.pending_script_wait().is_empty(), "one step still to draw")
+	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0))
+
+	var resumed: Array = world.finish_script_waits()
+	assert_false(object.scripted_steps)
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+	assert_eq(StringName((resumed[0] as Dictionary).get("status", &"")), &"waiting")
+	assert_eq((resumed[0] as Dictionary)["event"]["text"], "AB")
+
+
+## `Movement_step_sleep_common` puts the object in STEP_TYPE_SLEEP for its own
+## count before the stream reads on, so a sleep is part of what the wait waits
+## for even though nothing moves.
+func test_a_movement_sleep_holds_the_wait_without_moving_anything() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		# step_sleep 8, step_end.
+		"48:6100": [0x45, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var object: Gen2WorldObject = world.objects[0]
+	var start: Vector2i = object.cell
+
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+	for _frame: int in 7:
+		world.advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS)
+	assert_false(world.pending_script_wait().is_empty(), "eight frames of sleep")
+	assert_eq(object.cell, start)
+	assert_eq(object.walk_frame(), 0, "STEP_TYPE_SLEEP stands still")
+
+	assert_eq(_final_status(world.finish_script_waits()), &"complete")
+	assert_eq(object.cell, start)
+
+
+## `Script_pause` delays two frames per counted unit inside the command, and
+## `Script_deactivatefacing` hands the same count to SCRIPT_WAIT, which
+## `WaitScript` spends one a frame. Both write wScriptDelay only when their
+## operand is nonzero, which is what makes `pause 0` reuse it.
+func test_pause_and_deactivatefacing_spend_their_own_frame_counts() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# pause 3, deactivatefacing 0, end.
+	scripts["48:6160"] = [0x8B, 3, 0x8C, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6160,
+	})
+
+	assert_eq(runner.advance()["status"], &"waiting")
+	assert_eq(runner.pending_wait()["frames"], 6, "three units of two frames")
+
+	assert_eq(runner.complete_wait()["status"], &"waiting")
+	assert_eq(
+		runner.pending_wait()["frames"], 3,
+		"a zero operand reuses wScriptDelay, and WaitScript spends one a frame"
+	)
+	assert_eq(runner.complete_wait()["status"], &"complete")
+
+
+## `Script_earthquake` is `ScriptCall` on `applymovement PLAYER,
+## wEarthquakeMovementDataBuffer`, whose stream shakes and then sleeps the low
+## six bits of the operand.
+func test_earthquake_waits_out_the_sleep_its_own_movement_carries() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6170"] = [0x78, 84, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6170,
+	})
+
+	var result: Dictionary = runner.advance()
+
+	assert_eq(result["status"], &"waiting")
+	assert_eq(runner.pending_wait()["frames"], 84 & 0x3F)
+	assert_true(result["events"].any(func(event: Dictionary) -> bool:
+		return event.get("type", &"") == &"earthquake_requested" \
+			and int(event.get("strength", 0)) == 84
+	), JSON.stringify(result["events"]))
+	assert_eq(runner.complete_wait()["status"], &"complete")
+
+
+## An event is handed to its caller once. The runner drains its list on every
+## result, because the caller is what applies a movement and starts a screen
+## shake: repeating the list on the next pause would do both twice.
+func test_a_script_hands_each_event_to_its_caller_once() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# earthquake 4, pause 1, end.
+	scripts["48:6180"] = [0x78, 4, 0x8B, 1, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6180,
+	})
+
+	var shaken: Dictionary = runner.advance()
+	assert_eq(_types_of(shaken).count(&"earthquake_requested"), 1)
+
+	var paused: Dictionary = runner.complete_wait()
+	assert_eq(paused["status"], &"waiting")
+	assert_eq(
+		_types_of(paused).count(&"earthquake_requested"), 0,
+		"the shake was already delivered"
+	)
+
+
+func _types_of(result: Dictionary) -> Array[StringName]:
+	var types: Array[StringName] = []
+	for event: Dictionary in result.get("events", []):
+		types.append(StringName(event.get("type", &"")))
+	return types
 
 
 ## The two drivers own different objects. advance_object_steps() decides
@@ -3467,7 +3652,7 @@ func test_the_movement_driver_leaves_a_scripted_trail_to_its_own_driver() -> voi
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
 	var object: Gen2WorldObject = world.objects[0]
-	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
 	assert_true(object.scripted_steps)
 
 	var random := RandomNumberGenerator.new()
@@ -3492,7 +3677,7 @@ func test_a_scripted_player_stream_trails_and_advances_the_walk_frame() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
-	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
 
 	assert_eq(world.player_cell, Vector2i(7, 4), "both cells commit at once")
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 2.0))
@@ -3521,10 +3706,10 @@ func test_script_movement_still_refuses_a_step_off_the_map() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(15, 6))
-	var results: Array = world.dispatch_script_events(Vector2i(7, 6))
-	assert_eq(results.size(), 1)
-	assert_eq(results[0]["status"], &"complete")
+	var results: Array = _run_script(world, world.dispatch_script_events(Vector2i(7, 6)))
+	assert_eq(_final_status(results), &"complete")
 	assert_eq(world.player_cell, Vector2i(15, 6))
+	assert_true(_event_types(results).has(&"movement_blocked"))
 
 
 func test_follow_command_moves_the_follower_after_a_player_step() -> void:
@@ -3833,13 +4018,17 @@ func test_wait_is_timing_only_and_reports_its_frame_count() -> void:
 
 	var result: Dictionary = runner.advance()
 
-	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(runner.pending_wait()["wait"], Gen2WorldScriptRunner.WAIT_FRAMES)
+	assert_eq(runner.pending_wait()["frames"], 120, "twenty units of six frames")
 	assert_eq(state.event_flags().size(), 0)
 	assert_true(result["events"].any(func(event: Dictionary) -> bool:
 		return event.get("type", &"") == &"script_timing_requested" \
 			and event.get("kind", &"") == &"wait" \
 			and int(event.get("frames", 0)) == 120
 	), JSON.stringify(result["events"]))
+	assert_eq(runner.advance(true)["status"], &"waiting", "a button does not end it")
+	assert_eq(runner.complete_wait()["status"], &"complete")
 
 
 ## Script_newloadmap sets hMapEntryMethod and re-enters the map, then yields
@@ -4666,7 +4855,9 @@ func test_movement_remove_object_is_live_until_the_next_map_reload() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6130
 	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
-	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(
+		_final_status(_run_script(world, world.dispatch_script_events())), &"complete"
+	)
 	assert_eq(world.visible_objects().size(), 0)
 
 	world.reload_current_map()
@@ -4709,19 +4900,31 @@ func test_scripted_change_block_refresh_and_command_queue_state_are_explicit() -
 	assert_eq(world.block_at(7, 1), 1)
 
 
-func test_scripted_emote_is_visible_for_its_bounded_duration() -> void:
+## Script_showemote is `ScriptCall ShowEmoteScript`, whose middle command is
+## `pause 0` over the delay this one just wrote into wScriptDelay. So the third
+## operand holds the script rather than counting down on the object, and the
+## emote comes back down from the same script's last command.
+func test_scripted_emote_holds_the_script_for_its_own_pause() -> void:
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
 		"48:6150": [0x75, 1, 2, 2, 0x91],
 	})
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6150
 	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
-	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	var dispatched: Array = world.dispatch_script_events()
+	assert_eq(dispatched[0]["status"], &"waiting")
+	assert_eq(dispatched[0]["event"]["frames"], 4, "two units of two frames")
 	var object: Gen2WorldObject = world.objects[0]
 	assert_true(object.emote_visible)
 	assert_eq(object.emote_id, 1)
-	assert_false(world.tick())
-	assert_true(world.tick())
+
+	for _frame: int in 3:
+		assert_true(world.advance_script_wait(Gen2WorldAnimation.FRAME_SECONDS).is_empty())
+	assert_true(object.emote_visible, "still up while the pause runs")
+	assert_false(world.tick(), "and not on a countdown of its own")
+
+	var finished: Array = world.advance_script_wait(Gen2WorldAnimation.FRAME_SECONDS)
+	assert_eq(_final_status(finished), &"complete")
 	assert_false(object.emote_visible)
 
 

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -236,3 +236,43 @@ func test_a_smashable_rock_is_in_neither_movement_set() -> void:
 	var rock: Gen2WorldObject = _object(Gen2WorldObject.MOVEMENT_SMASHABLE_ROCK)
 	assert_false(rock.movement_supported())
 	assert_false(rock.movement_advances())
+
+
+## The cartridge never rebuilds an object struct: `ApplyObjectFacing` and the
+## variable-sprite table write into the one that is already there. This project
+## rebuilds a record for both, so the live presentation has to survive it, or a
+## `turnobject` between a `showemote` and its `applymovement` takes the emote
+## down and empties the trail the script is waiting on.
+func test_a_rebuilt_record_keeps_the_emote_and_the_trail_it_replaces() -> void:
+	var previous: Gen2WorldObject = _object()
+	previous.set_emote(3, true)
+	previous.queue_step(Vector2i.RIGHT, 8)
+	previous.queue_step(Vector2i.RIGHT, 8)
+	previous.tick_step()
+	previous.deleted = false
+
+	var rebuilt: Gen2WorldObject = _object()
+	rebuilt.carry_presentation_from(previous)
+
+	assert_true(rebuilt.emote_visible)
+	assert_eq(rebuilt.emote_id, 3)
+	assert_true(rebuilt.scripted_steps)
+	assert_true(rebuilt.is_stepping())
+	assert_eq(rebuilt.step_offset_cells(), previous.step_offset_cells())
+	assert_eq(rebuilt.queued_steps.size(), 1)
+
+
+## `StepFunction_Sleep` decrements OBJECT_STEP_DURATION before testing it, so a
+## zero-length sleep wraps a whole byte rather than ending at once, and a stream
+## that asks for one is not a stream with nothing in it.
+func test_a_zero_length_sleep_wraps_a_whole_byte() -> void:
+	assert_eq(Gen2WorldObject.sleep_frames(0), 0x100)
+	assert_eq(Gen2WorldObject.sleep_frames(1), 1)
+
+	var object: Gen2WorldObject = _object()
+	object.queue_wait(2)
+	assert_true(object.scripted_steps)
+	assert_true(object.tick_step())
+	assert_eq(object.walk_frame(), 0, "a sleep stands still")
+	assert_true(object.tick_step())
+	assert_false(object.scripted_steps, "and the stream is done after its own count")

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -302,6 +302,22 @@ func test_command_parser_reads_scripted_overworld_feature_operands() -> void:
 	assert_eq(delete_queue["name"], &"delcmdqueue")
 	assert_eq(delete_queue["value"], 2)
 
+	## Both are two bytes wide, and the operand is the delay they spend: without
+	## it every pause in the corpus read as zero.
+	var pause: Dictionary = Gen2WorldScript.command_at(
+		PackedByteArray([0x8B, 15]), 0, true
+	)
+	assert_true(pause["ok"])
+	assert_eq(pause["name"], &"pause")
+	assert_eq(pause["value"], 15)
+
+	var deactivate: Dictionary = Gen2WorldScript.command_at(
+		PackedByteArray([0x8C, 4]), 0, true
+	)
+	assert_true(deactivate["ok"])
+	assert_eq(deactivate["name"], &"deactivatefacing")
+	assert_eq(deactivate["value"], 4)
+
 
 ## macros/scripts/maps.asm's `cmdqueue`: a type byte, a two-byte data pointer,
 ## then two filler bytes. A null type is the empty slot the cartridge leaves

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -2,14 +2,15 @@ extends SceneTree
 
 ## Traces `MeetMomRightScript` through the world screen, frame by frame.
 ##
-##   Godot --headless --path . -s res://tools/preview_mom_scene.gd -- <game> [png]
+##   Godot --headless --path . -s res://tools/preview_mom_scene.gd -- <game> [png] [frame]
 ##
 ## The story walker already proves the script's own results on [Gen2WorldAPI];
 ## what it cannot say is whether the presentation runs. This drives the real
 ## screen at the source frame rate from the cell the coord event sits on and
 ## reports, per frame: the script's state, the object `applymovement` is walking,
-## and whether the text box is up. A `png` argument writes the frame the walk
-## ends on.
+## and whether the text box is up. A `png` argument writes a frame, the last one
+## traced unless a `frame` number names an earlier one, so the emote, the walk
+## and the box can each be looked at.
 ##
 ## `maps/PlayersHouse1F.asm`: the two coord events at (8,4) and (9,4) are
 ## Crystal's trigger. Gold and Silver ship none; their scene 0 is an `sdefer` of
@@ -29,6 +30,7 @@ const TRIGGER_CELL := Vector2i(9, 4)
 
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
+var _capture_frame: int = TRACE_FRAMES
 var _frames: int = 0
 var _started: bool = false
 var _trace: Array[Dictionary] = []
@@ -37,12 +39,14 @@ var _trace: Array[Dictionary] = []
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.is_empty():
-		push_error("Usage: preview_mom_scene.gd -- <game> [out.png]")
+		push_error("Usage: preview_mom_scene.gd -- <game> [out.png] [frame]")
 		quit(1)
 		return
 	var game: StringName = StringName(args[0])
 	if args.size() > 1:
 		_output_path = args[1]
+	if args.size() > 2:
+		_capture_frame = maxi(1, int(args[2]))
 
 	var sha1: String = RomRegistry.sha1_for(game)
 	var directory: String = RomCache.directory_for(game, sha1) if not sha1.is_empty() else ""
@@ -95,6 +99,13 @@ func _sample() -> Dictionary:
 func _process(_delta: float) -> bool:
 	_frames += 1
 	if _frames < 3:
+		# The development caption and hint are drawn over a 160x144 window, so a
+		# capture of the game itself loses them. Done from here because the
+		# screen's own nodes are not resolved until it has run a frame.
+		for label: StringName in [&"Caption", &"Hint"]:
+			var node: CanvasItem = _screen.get_node_or_null(NodePath(label)) as CanvasItem
+			if node != null:
+				node.visible = false
 		return false
 	# The clock is the trace's, not the renderer's, so the report is the same on
 	# every run.
@@ -104,12 +115,12 @@ func _process(_delta: float) -> bool:
 		_screen.move_player(Vector2i(0, 1))
 	_screen._process(FRAME)
 	_trace.append(_sample())
-	if _frames < TRACE_FRAMES:
+	if _frames == _capture_frame and not _output_path.is_empty():
+		root.get_texture().get_image().save_png(_output_path)
+		print("Wrote %s at frame %d" % [_output_path, _frames])
+	if _frames < maxi(TRACE_FRAMES, _capture_frame):
 		return false
 	_report()
-	if not _output_path.is_empty():
-		root.get_texture().get_image().save_png(_output_path)
-		print("Wrote %s" % _output_path)
 	quit(0)
 	return true
 

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -4336,7 +4336,10 @@ func _dragon_shrine_leg(
 			"reason": "Dragon's Den crossing failed: %s" % den_crossing.get("reason", ""),
 		}
 
-	var to_shrine: Dictionary = _warp_chain(world, save, random, data, [Vector2i(19, 29)])
+	# _warp_chain, not used here: it drains the destination's own map entry with
+	# default answers, and the shrine's map entry is the quiz. One entry, one
+	# quiz, driven below by this leg's own answers.
+	var to_shrine: Dictionary = _warp_walk(world, Vector2i(19, 29), save, random, data)
 	if not bool(to_shrine.get("ok", false)):
 		return {
 			"ok": false, "path": path,
@@ -9191,6 +9194,7 @@ func _drain_story(
 	var last_reason: String = ""
 	var last_details: String = ""
 	var pending_trace: Array[String] = []
+	var waits_spent: int = 0
 	var battles: Array = []
 	var catch_tutorials: int = 0
 	var hall_of_fame: int = _hall_of_fame_events(results)
@@ -9212,6 +9216,16 @@ func _drain_story(
 			results = _drain_phone_ring(world)
 			if results.is_empty():
 				last_reason = "phone ring did not finish"
+				break
+		elif input_type == &"wait":
+			## A movement or a counted delay. Nothing answers it, so the walk
+			## spends the frames the way the screen does.
+			var standing_in: Dictionary = world.pending_script_wait()
+			results = world.finish_script_waits()
+			waits_spent += 1
+			if not world.pending_script_wait().is_empty():
+				last_reason = "a script wait never ended"
+				last_details = JSON.stringify(standing_in)
 				break
 		elif input_type in [&"text", &"button"]:
 			results = world.run_event_queue(true)
@@ -9387,6 +9401,7 @@ func _drain_story(
 	return {
 		"statuses": statuses,
 		"waits": waits,
+		"waits_spent": waits_spent,
 		"pending_trace": pending_trace,
 		"battles": battles,
 		"purchases": purchases,

--- a/tools/validate_command_queues.gd
+++ b/tools/validate_command_queues.gd
@@ -73,6 +73,9 @@ func _verify_map(data: GameData, game_id: StringName, name: String, id: Array) -
 	# callbacks is what puts it on the world. Nothing else writes one.
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
+		if not world.pending_script_wait().is_empty():
+			world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		world.run_event_queue(true)
@@ -192,6 +195,9 @@ func _drive_blackthorn(data: GameData, game_id: StringName) -> void:
 
 	var results: Array = world.run_event_queue(false)
 	for _step: int in 16:
+		if not world.pending_script_wait().is_empty():
+			results = world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		results = world.run_event_queue(true)

--- a/tools/validate_elite_four.gd
+++ b/tools/validate_elite_four.gd
@@ -123,6 +123,9 @@ func _verify_pokecenter(data: GameData, game_id: StringName) -> void:
 
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
+		if not world.pending_script_wait().is_empty():
+			world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		world.run_event_queue(true)

--- a/tools/validate_item_balls.gd
+++ b/tools/validate_item_balls.gd
@@ -257,6 +257,9 @@ func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:
 		return null
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
+		if not world.pending_script_wait().is_empty():
+			world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		world.run_event_queue(true)

--- a/tools/validate_lavender.gd
+++ b/tools/validate_lavender.gd
@@ -321,6 +321,9 @@ func _talk(world: Gen2WorldAPI) -> Array:
 			return statuses
 		if status != &"waiting":
 			return []
+		if not world.pending_script_wait().is_empty():
+			results = world.finish_script_waits()
+			continue
 		results = world.run_event_queue(true)
 	return []
 

--- a/tools/validate_radio.gd
+++ b/tools/validate_radio.gd
@@ -423,6 +423,9 @@ func _drain(world: Gen2WorldAPI, results: Array, data: GameData) -> Dictionary:
 				waiting = true
 		if not waiting:
 			return out
+		if not world.pending_script_wait().is_empty():
+			results = world.finish_script_waits()
+			continue
 		var request: Dictionary = world.pending_runtime_request()
 		if StringName(request.get("kind", &"")) == &"battle_requested":
 			var values: Dictionary = request.get("values", {})

--- a/tools/validate_radio_tower.gd
+++ b/tools/validate_radio_tower.gd
@@ -243,6 +243,9 @@ func _open(data: GameData, id: Array, cell: Vector2i, flags: Array) -> Gen2World
 	# own callbacks have to run before anything is read off the grid.
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
+		if not world.pending_script_wait().is_empty():
+			world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		world.run_event_queue(true)

--- a/tools/validate_rising_badge.gd
+++ b/tools/validate_rising_badge.gd
@@ -265,6 +265,9 @@ func _open(data: GameData, id: Array, cell: Vector2i, flags: Array) -> Gen2World
 		return null
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
+		if not world.pending_script_wait().is_empty():
+			world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		world.run_event_queue(true)

--- a/tools/validate_route_27.gd
+++ b/tools/validate_route_27.gd
@@ -326,6 +326,9 @@ func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:
 	_field_move_party(world)
 	var _entry: Array = world.dispatch_map_entry()
 	for _step: int in 8:
+		if not world.pending_script_wait().is_empty():
+			world.finish_script_waits()
+			continue
 		if world.pending_script_input().is_empty():
 			break
 		world.run_event_queue(true)

--- a/tools/validate_ss_aqua.gd
+++ b/tools/validate_ss_aqua.gd
@@ -227,6 +227,9 @@ func _drive_sealed_corridor(data: GameData, game_id: StringName) -> void:
 		):
 			return
 		for _attempt: int in 16:
+			if not world.pending_script_wait().is_empty():
+				results = world.finish_script_waits()
+				continue
 			if world.pending_script_input().is_empty():
 				break
 			results = world.run_event_queue(true)


### PR DESCRIPTION
`ScriptEvents` has two waits and this project had neither, so a text box was already up while the objects it had just moved walked under it.

- `applymovement` and `applymovementlasttalked` stage a movement wait, SCRIPT_WAIT_MOVEMENT, which ends when the trail the stream left has been drawn. `showemote`, `earthquake`, `pause`, `deactivatefacing` and Crystal's `wait` stage a counted one, at their own source frame rates: two frames a unit for a pause, one for a deactivatefacing, six for a wait, and the low six bits of an earthquake's operand.
- Neither takes a button, since the source is inside `WaitScriptMovement` or a `DelayFrames` loop. `Gen2WorldAPI.advance_script_wait()` spends the frames and resumes; `finish_script_waits()` is the headless caller's version.
- The runner drains its event list per result, and the world API applies a result's events when the script pauses rather than only when it ends: an object has to be walking while the script waits for it. That also stops a screen shake or a Hall of Fame request being delivered again on every later pause.
- wScriptDelay is modelled, because `pause 0` reuses it and that is how `Script_showemote` sets the emote's duration: `showemote EMOTE_SHOCK, MOM1, 15` is thirty frames, then the emote comes down from the same script.
- TEXT SPEED reaches the overworld's text boxes as the 1, 3 or 5 frames a character `PrintLetterDelay` waits.

Fixed along the way: `pause` and `deactivatefacing` never decoded their operand, so every delay read as zero; `showemote` did not write hLastTalked, which is what its own two movements target; a record rebuilt by a `turnobject` or a variable sprite dropped the live emote and the trail, which the cartridge never does; and a movement `step_sleep` was skipped rather than spent.

Tools spend the new waits: the story walker still reaches Red on all three cartridges, and the Dragon Shrine leg warps without draining its own map entry, which was running the quiz twice.