### PR TITLE
world: give the overworld one clock and make a walk replayable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   object lifecycle, followers, block edits, emotes, surf, ledge hops, grass,
 >   fishing, roaming, repel and wild encounters. The service overlay covers
 >   menu selection, mart dialog variants and quantity purchases, source-timed
->   phone dispatch and bounded music, effects and cries.
+>   phone dispatch and bounded music, effects and cries. Everything the overworld
+>   times is a hardware frame count spent by one clock, so a seed, an input log
+>   and a frame number reproduce a walk exactly, on any display.
 > - **Saves.** Three slots, `.sav` import, and a 14-box PC model with 20 slots
 >   per box. Gifts, eggs, NPC trades, HP/status items, repel and captures commit
 >   through a validated candidate save; a full party routes into the first free
@@ -284,9 +286,10 @@ all three games unless its row says otherwise:
 | `preview_world_services.gd <png>` | mart overlay, deterministic integration cache |
 | `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
 | `preview_intro.gd <game> <png> [copyright\|gender\|speech\|beat] [steps]` | the new game's opening screens at hardware resolution: the copyright screen by source frame, the gender question, and any frame of `OakSpeech` by source frame or by button press, so a fade or a pic move can be looked at one frame at a time |
-| `preview_mom_scene.gd <game> [png] [frame]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up. `frame` picks which one the `png` is of, so the emote, the walk and the box can each be looked at |
+| `preview_mom_scene.gd <game> [png] [frame]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up. The frames the emote, the walk and the box first appear on are pinned per profile, so a run that moves one exits non-zero. `frame` picks which one the `png` is of |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
+| `replay_world.gd [game ...] [frames]` | records `(frame, button)` from a run of the real world screen and replays it into a fresh world, over every map of the spawn group on each cartridge. The same seed and log must reach the same `Gen2WorldSnapshot` byte for byte, and must reach it whether the frames were pumped at 30 fps or at 144 |
 | `preview_collision.gd <game> <group> <number> <png>` | one whole map as drawn, with every walk cell's permission checkerboarded over it: red is wall, blue is water. For a report that the player can stand where they should not |
 | `preview_overworld_sprites.gd <game> <png>` | every overworld sprite in a cache as one contact sheet, four facings across by four frames down, for eyeballing offsets, mirroring and frame order |
 | `render_audio.gd <game> <music\|sfx\|cry\|mon_cry> <id\|all> <frames> <prefix> [stereo]` | one record, or the whole table, run through the sound driver and the APU: a WAV to listen to and a per-frame hardware-register trace to diff |

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -496,16 +496,16 @@ Supported by the contract above:
   without the renderer knowing an animation ran;
 - movement progress. `Gen2WorldAPI.player_step_offset_cells()` and
   `Gen2WorldObject.step_offset_cells()` return an in-flight step as a fractional
-  cell, from one cell behind the committed cell down to zero, paced by
-  `advance_player_step(delta)` and `advance_object_steps()` at the hardware
-  frame rate and stall cap `Gen2WorldAnimation` uses. The logical cell still
+  cell, from one cell behind the committed cell down to zero, spent by
+  `advance_player_step_frame()` and `advance_object_steps_frame()` on the
+  screen's own hardware frame. The logical cell still
   commits at the start of the step; the fraction is presentation only and never
   reaches collision, events or the world snapshot.
   `mods/examples/voxel_preview/` reads both;
 - scripted movement progress, on the same two calls. An `applymovement` applies
   its whole stream at once, so every cell of the path commits together and the
   offset is as many cells behind as there are left to draw.
-  `advance_scripted_steps(delta)` drains that trail and is the one mover a
+  `advance_scripted_steps_frame()` drains that trail and is the one mover a
   screen keeps calling while a script runs, since that is when a script runs
   one. Each step lasts its own command's duration: 16 frames for the slow
   commands, 8 for the plain ones, 4 for the bike-speed ones;

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -250,7 +250,12 @@ func _process(delta: float) -> void:
 	if not frames_running():
 		_frame_elapsed = 0.0
 		return
-	_frame_elapsed += delta
+	## Capped the way [method Gen2WorldScreen._process] caps it: a stall should
+	## drop animation frames, not run a second of them in one host frame.
+	_frame_elapsed = minf(
+		_frame_elapsed + delta,
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
+	)
 	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and frames_running():
 		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
 		advance_frame()

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -120,6 +120,8 @@ signal option_changed(id: StringName, key: StringName, value: Variant)
 static var _instance: Gen2ModHost = null
 
 var _manifests: Dictionary = {}
+## Mod id to version for every entry script that ran. See [method loaded_mods].
+var _loaded: Dictionary = {}
 var _options: Dictionary = {}
 var _world_renderers: Dictionary = {}
 var _selected_world_renderer: StringName = BUILT_IN_RENDERER
@@ -785,7 +787,19 @@ func load_mod(manifest: Gen2ModManifest) -> Dictionary:
 	if mod == null or not mod.has_method("register"):
 		return _refuse_load(manifest, &"entry_has_no_register", path)
 	mod.call("register", self, manifest)
+	_loaded[manifest.id] = manifest.version
 	return {"ok": true, "id": manifest.id}
+
+
+## Every mod whose entry script ran, as `id` and `version` pairs in id order.
+## What a save records so a crash report or a replay can name what was loaded.
+func loaded_mods() -> Array:
+	var out: Array = []
+	var ids: Array = _loaded.keys()
+	ids.sort()
+	for id: StringName in ids:
+		out.append({"id": String(id), "version": String(_loaded[id])})
+	return out
 
 
 func _refuse_load(manifest: Gen2ModManifest, reason: StringName, path: String) -> Dictionary:

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -45,6 +45,12 @@ var world: Gen2WorldSnapshot = null
 ## Per-slot, per-mod JSON objects. Installation-wide options stay in their own
 ## user file; this namespace travels with the save.
 var mods: Dictionary = {}
+## What names the run beside the state it produced: the seed the world's
+## generators are built from and the mods that were loaded when the slot was
+## last written (`Gen2ModHost.loaded_mods`). Zero and empty read as "not
+## recorded", which is what every slot written before this existed says.
+var run_seed: int = 0
+var run_mods: Array = []
 var boxes_shape_valid: bool = true
 
 
@@ -75,6 +81,7 @@ func to_dict() -> Dictionary:
 		"boxes": saved_boxes,
 		"world": world.to_dict() if world != null else {},
 		"mods": mods.duplicate(true),
+		"run": {"seed": run_seed, "mods": run_mods.duplicate(true)},
 	}
 
 
@@ -126,6 +133,17 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 			var value: Variant = raw_mods[raw_id]
 			if _valid_mod_id(id) and value is Dictionary:
 				out.mods[StringName(id)] = (value as Dictionary).duplicate(true)
+	var raw_run: Variant = source.get("run", {})
+	if raw_run is Dictionary:
+		out.run_seed = int((raw_run as Dictionary).get("seed", 0))
+		var raw_run_mods: Variant = (raw_run as Dictionary).get("mods", [])
+		if raw_run_mods is Array:
+			for entry: Variant in raw_run_mods as Array:
+				if entry is Dictionary and _valid_mod_id(String((entry as Dictionary).get("id", ""))):
+					out.run_mods.append({
+						"id": String((entry as Dictionary).get("id", "")),
+						"version": String((entry as Dictionary).get("version", "")),
+					})
 	return out
 
 
@@ -140,6 +158,10 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 ## Version 4 had neither gender nor a play timer; both migrate to the value a
 ## new game starts with, male and 0:00, since neither can be recovered.
 ## Version 5 had no per-mod namespace.
+##
+## The `run` block joined version 6 after it shipped and is not a version of its
+## own: it defaults to no seed and no mod list, which is the truth about a slot
+## written before it existed rather than a value worth inventing.
 static func migrate_dict(raw: Variant) -> Dictionary:
 	if not raw is Dictionary:
 		return {"ok": false, "message": "save data is not an object"}
@@ -230,6 +252,8 @@ func copy_from(source: Gen2SaveData) -> bool:
 	boxes = copied.boxes
 	world = copied.world
 	mods = copied.mods.duplicate(true)
+	run_seed = copied.run_seed
+	run_mods = copied.run_mods.duplicate(true)
 	boxes_shape_valid = copied.boxes_shape_valid
 	return true
 

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -305,7 +305,14 @@ static func create_new_game(
 	new_save.slot = slot
 	new_save.player_name = player_name
 	new_save.player_id = generator.randi_range(0, 0xFFFF)
+	# Rolled beside wPlayerID and never changed after, so a run is reproducible
+	# from its first frame. Zero would read as "unseeded", so it is rerolled.
+	while new_save.run_seed == 0:
+		new_save.run_seed = generator.randi()
+	new_save.run_mods = Gen2ModHost.instance().loaded_mods()
 	new_save.world = Gen2WorldSpawn.new_game_snapshot(data)
+	if new_save.world != null:
+		new_save.world.random_seed = new_save.run_seed
 	return new_save
 
 

--- a/game/world/phone_ring.gd
+++ b/game/world/phone_ring.gd
@@ -8,7 +8,6 @@ extends RefCounted
 ## hardware frames in each of the three waits inside one ring, then repeats
 ## the ring once more.
 
-const FRAME_SECONDS: float = 1.0 / 59.7275
 const RING_COUNT: int = 2
 const WAITS_PER_RING: int = 3
 const WAIT_FRAMES: int = 20
@@ -16,7 +15,6 @@ const RING_FRAMES: int = WAITS_PER_RING * WAIT_FRAMES
 const TOTAL_FRAMES: int = RING_COUNT * RING_FRAMES
 
 var _elapsed_frames: int = 0
-var _fractional_frames: float = 0.0
 var _lead_frames: int = 0
 
 
@@ -24,13 +22,8 @@ func _init(lead_frames: int = 0) -> void:
 	_lead_frames = maxi(0, lead_frames)
 
 
-func advance(delta: float) -> Dictionary:
-	if delta > 0.0:
-		_fractional_frames += delta / FRAME_SECONDS
-		var whole_frames: int = floori(_fractional_frames)
-		if whole_frames > 0:
-			_fractional_frames -= float(whole_frames)
-			_elapsed_frames = mini(_elapsed_frames + whole_frames, total_frames())
+func advance_frame() -> Dictionary:
+	_elapsed_frames = mini(_elapsed_frames + 1, total_frames())
 	return snapshot()
 
 

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -8,12 +8,12 @@ extends RefCounted
 ## the indexed tile strip held by GameData.
 
 const TILE_BYTES: int = Gen2Tiles.TILE_BYTES
-## One command runs per hardware VBlank, so the sequence has to be paced by
-## elapsed time rather than by rendered frames. Stepping it once per drawn frame
-## makes water flow at the monitor's refresh rate instead of the cartridge's.
+## The hardware VBlank, and the project's one definition of it: every overworld
+## timer is counted in these, and [method Gen2WorldScreen.advance_frame] is the
+## single place real time is converted into them.
 const FRAME_SECONDS: float = 1.0 / 59.7275
-## The most catch-up frames one call will run. A stall should drop animation
-## frames, not spend the recovery frame walking thousands of commands.
+## The most catch-up frames one host frame will run. A stall should drop frames,
+## not spend the recovery frame walking thousands of commands.
 const MAX_CATCHUP_FRAMES: int = 4
 const TIMER_WATER_FRAMES: Array = [0, 1, 2, 3]
 const TIMER_FOUNTAIN_FRAMES: Array = [0, 1, 2, 3, 2, 3, 4, 0]
@@ -31,7 +31,6 @@ var _timer: int = 0
 var _water_color: int = -1
 var _cave_color: int = -1
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
-var _frame_seconds: float = 0.0
 var _changed: bool = false
 ## Which tiles a run of commands rewrote, and whether a palette row moved. A
 ## renderer that keeps a texture only has to redo these tiles: the sequence
@@ -50,7 +49,6 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 	_timer = 0
 	_water_color = -1
 	_cave_color = -1
-	_frame_seconds = 0.0
 	_changed = false
 	_changed_tiles = {}
 	_palette_changed = false
@@ -63,30 +61,24 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 	_commands = tileset.animation_commands.duplicate(true)
 
 
-## Runs the commands that [param delta] seconds of real time are worth and
-## reports whether the tile strip or a palette row actually changed.
+## Runs one hardware frame's command and reports whether the tile strip or a
+## palette row actually changed.
 ##
 ## Most commands are waits and timer bumps that draw nothing new, so the return
 ## value is what a renderer should gate its atlas rebuild on; [method tick] is
 ## the single-command step the sequence is defined in.
-func advance(delta: float) -> bool:
-	if _commands.is_empty() or tileset == null or delta <= 0.0:
+func advance_frame() -> bool:
+	if _commands.is_empty() or tileset == null:
 		return false
-	_frame_seconds = minf(
-		_frame_seconds + delta, FRAME_SECONDS * float(MAX_CATCHUP_FRAMES)
-	)
-	var changed: bool = false
 	_changed_tiles = {}
 	_palette_changed = false
-	while _frame_seconds >= FRAME_SECONDS:
-		_frame_seconds -= FRAME_SECONDS
-		_changed = false
-		tick()
-		changed = changed or _changed
-	return changed
+	_changed = false
+	tick()
+	return _changed
 
 
-## The tiles rewritten by the most recent [method advance], in ascending order.
+## The tiles rewritten by the most recent [method advance_frame], in ascending
+## order.
 func changed_tiles() -> PackedInt32Array:
 	var out := PackedInt32Array()
 	for tile: int in _changed_tiles:
@@ -95,8 +87,8 @@ func changed_tiles() -> PackedInt32Array:
 	return out
 
 
-## Whether the most recent [method advance] moved a palette row, which changes
-## every tile drawn with it rather than only the ones it rewrote.
+## Whether the most recent [method advance_frame] moved a palette row, which
+## changes every tile drawn with it rather than only the ones it rewrote.
 func palette_changed() -> bool:
 	return _palette_changed
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -20,7 +20,11 @@ const MOVEMENT_SURF: StringName = &"surf"
 ## for a variable sprite no script has assigned yet.
 const SPRITE_CHRIS: int = 1
 const TRAINER_SHOCK_EMOTE: int = 0
-const TRAINER_SHOCK_FRAMES: int = 30
+## `SeenByTrainerScript`'s `showemote EMOTE_SHOCK, LAST_TALKED, 30`
+## (engine/events/trainer_scripts.asm), read the way every other `showemote` is:
+## the operand is `wScriptDelay` and `ShowEmoteScript`'s `pause 0` spends
+## two frames a unit (`Gen2WorldScriptRunner.PAUSE_FRAMES_PER_UNIT`).
+const TRAINER_SHOCK_FRAMES: int = 60
 ## StepVectors' normal-speed row: 2 pixels per frame for 8 frames, the source
 ## duration for ordinary player walking (engine/overworld/map_objects.asm). The
 ## trainer approach shares it: see advance_trainer_approach_step().
@@ -190,6 +194,15 @@ var script_random: RandomNumberGenerator = null
 ## other two so seeding NPC motion cannot shift an encounter, a phone roll or a
 ## script's RANDOM result.
 var object_random: RandomNumberGenerator = null
+## The seed the three generators above were built from, mirrored here so a
+## snapshot records what a run can be reproduced with. Zero means nothing seeded
+## them and the run is not reproducible.
+var random_seed: int = 0
+## Hardware frames this world has been advanced by, monotonic from the frame the
+## snapshot it was opened from recorded. Every overworld timer is a countdown
+## spent by the same pump, so a seed, an input log and this number are what make
+## a run replayable. Advanced only by [method advance_frame_counter].
+var frame_number: int = 0
 var _last_schedule: Dictionary = {}
 var _phone_ring: Gen2WorldPhoneRing = null
 var _phone_ring_request: Dictionary = {}
@@ -200,7 +213,6 @@ var _phone_ring_request: Dictionary = {}
 var _player_step_direction: Vector2i = Vector2i.ZERO
 var _player_step_frames_total: int = 0
 var _player_step_frames_remaining: int = 0
-var _player_step_accumulator: float = 0.0
 ## The rest of a scripted movement stream the player still has to be drawn
 ## walking, the way Gen2WorldObject.queued_steps holds an object's.
 var _player_queued_steps: Array = []
@@ -210,13 +222,6 @@ var _player_queued_steps: Array = []
 var _player_scripted_steps: bool = false
 ## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
 var _player_step_frame: int = 0
-## Real time banked toward the next hardware frame of object movement, held
-## beside the player's own accumulator so the two stay in phase after a stall.
-var _object_step_accumulator: float = 0.0
-## The same for the presentation trail a scripted movement leaves, which is
-## drained by its own driver because that one runs while a script does.
-var _scripted_step_accumulator: float = 0.0
-var _script_wait_accumulator: float = 0.0
 ## Frames left of the counted wait a script is standing in, -1 while it is not
 ## standing in one or has not started counting.
 var _script_wait_frames: int = -1
@@ -283,6 +288,8 @@ static func open_snapshot(game_data: GameData, world_snapshot: Gen2WorldSnapshot
 	out.world_hour = world_snapshot.world_hour
 	out.world_minute = world_snapshot.world_minute
 	out.dst_enabled = world_snapshot.dst_enabled
+	out.random_seed = world_snapshot.random_seed
+	out.frame_number = world_snapshot.frame_number
 	return out
 
 
@@ -516,38 +523,28 @@ func _clear_player_step() -> void:
 	_player_step_direction = Vector2i.ZERO
 	_player_step_frames_total = 0
 	_player_step_frames_remaining = 0
-	_player_step_accumulator = 0.0
 	_player_queued_steps.clear()
 	_player_scripted_steps = false
 	_player_step_frame = 0
 
 
-## Advances the player's walk-step offset by real elapsed time, at
-## Gen2WorldAnimation's hardware-frame rate and stall catch-up cap, so both stay
-## in phase after a pause. This only shrinks a presentation offset that starts
-## and ends at player_cell; it never changes player_cell, collision or event
-## results, and a caller that never starts a step sees no difference.
-func advance_player_step(delta: float) -> bool:
-	if _player_step_frames_remaining <= 0 or delta <= 0.0:
+## Spends one hardware frame of the player's walk-step offset.
+##
+## This only shrinks a presentation offset that starts and ends at player_cell;
+## it never changes player_cell, collision or event results, and a caller that
+## never starts a step sees no difference.
+func advance_player_step_frame() -> bool:
+	if _player_step_frames_remaining <= 0:
 		return false
-	_player_step_accumulator = minf(
-		_player_step_accumulator + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
-	)
-	var changed: bool = false
-	while _player_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS \
-		and _player_step_frames_remaining > 0:
-		_player_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
-		_player_step_frame = (_player_step_frame + 1) & 0x0F
-		_player_step_frames_remaining -= 1
-		if _player_step_frames_remaining <= 0:
-			if _player_queued_steps.is_empty():
-				_player_scripted_steps = false
-			else:
-				var next: Dictionary = _player_queued_steps.pop_front()
-				_begin_player_step(next["direction"], int(next["frames"]))
-		changed = true
-	return changed
+	_player_step_frame = (_player_step_frame + 1) & 0x0F
+	_player_step_frames_remaining -= 1
+	if _player_step_frames_remaining <= 0:
+		if _player_queued_steps.is_empty():
+			_player_scripted_steps = false
+		else:
+			var next: Dictionary = _player_queued_steps.pop_front()
+			_begin_player_step(next["direction"], int(next["frames"]))
+	return true
 
 
 ## GetPlayerSprite: the sprite for the player's current state, not a fixed one.
@@ -1575,10 +1572,10 @@ func pending_phone_ring() -> Dictionary:
 ## Advances the source ring timing and starts the imported phone script when
 ## both rings have completed. A phone ring is transient runtime state and is
 ## intentionally absent from world snapshots.
-func advance_phone_ring(delta: float) -> Array:
+func advance_phone_ring_frame() -> Array:
 	if _phone_ring == null:
 		return []
-	var progress: Dictionary = _phone_ring.advance(delta)
+	var progress: Dictionary = _phone_ring.advance_frame()
 	if not bool(progress.get("finished", false)):
 		return []
 	var request: Dictionary = _phone_ring_request.duplicate(true)
@@ -1798,7 +1795,15 @@ func _fishing_context(rod: StringName) -> Dictionary:
 	}
 
 
-func tick() -> bool:
+## Counts one hardware frame, ahead of the advance_*_frame() calls that spend it.
+## [method Gen2WorldScreen.advance_frame] is the only caller.
+func advance_frame_counter() -> int:
+	frame_number += 1
+	return frame_number
+
+
+## One hardware frame of every object's emote countdown.
+func advance_emotes_frame() -> bool:
 	var changed: bool = false
 	for object: Gen2WorldObject in objects:
 		changed = object.tick_emote() or changed
@@ -3270,7 +3275,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				# The cell commits here, as it does for every other step in this
 				# runtime; only the drawing trails. A stream applies in one call,
 				# so the whole path is queued and drawn a step at a time by
-				# advance_scripted_steps().
+				# advance_scripted_steps_frame().
 				object.queue_step(direction, int(SCRIPTED_STEP_FRAMES[kind]))
 			else:
 				generated.append({
@@ -3828,8 +3833,8 @@ func _object_landing_cells(
 ## advance after each successful player step.
 ##
 ## One movement decision per eligible object per call. A caller wanting the
-## source's pacing uses advance_object_steps(), which spends the step and idle
-## durations this records.
+## source's pacing uses advance_object_steps_frame(), which spends the step and
+## idle durations this records.
 func advance_objects(random: RandomNumberGenerator) -> int:
 	var moved: int = 0
 	for object: Gen2WorldObject in objects:
@@ -3872,90 +3877,67 @@ func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenera
 	return true
 
 
-## Paces the data-driven movement templates by real elapsed time, at the same
-## hardware-frame rate and stall catch-up cap the player's own walk step and
-## Gen2WorldAnimation use.
+## One hardware frame of the data-driven movement templates.
 ##
 ## Per frame an object spends one frame of an in-flight step, one frame of its
 ## wait, or takes a new decision: the source's STEP_TYPE_CONTINUE_WALK,
 ## STEP_TYPE_SLEEP and STEP_TYPE_FROM_MOVEMENT cycle. The cell commits when the
 ## step starts, matching InitStep and the player path, and only the presentation
 ## offset trails. Returns true when something a renderer draws changed.
-func advance_object_steps(delta: float, random: RandomNumberGenerator) -> bool:
-	if delta <= 0.0 or random == null or objects.is_empty():
+func advance_object_steps_frame(random: RandomNumberGenerator) -> bool:
+	if random == null or objects.is_empty():
 		return false
-	_object_step_accumulator = minf(
-		_object_step_accumulator + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
-	)
 	var changed: bool = false
-	while _object_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS:
-		_object_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
-		for object: Gen2WorldObject in objects:
-			if not object.active or object.deleted:
-				continue
-			# A scripted trail belongs to advance_scripted_steps(), which runs
-			# while a script does. Draining it here as well would walk it at
-			# twice the speed on every frame both drivers run.
-			if object.scripted_steps:
-				continue
-			# A step in flight is drained whatever put it there, so a pushed
-			# boulder slides even though its template never decides anything.
-			# StepFunction_StrengthBoulder ends by standing the boulder back up
-			# without rolling a wait, which is why only a template that decides
-			# reaches start_idle below.
-			if object.is_stepping():
-				if object.tick_step():
-					changed = true
-					if not object.is_stepping() and object.movement_advances():
-						# StepFunction_ContinueWalk rolls a new wait the moment
-						# the step duration reaches zero, so a wandering object
-						# pauses between steps instead of walking without
-						# stopping.
-						object.start_idle(random.randi() & IDLE_MASK_SLOW)
-				continue
-			if not object.movement_advances():
-				continue
-			if object.tick_idle():
-				continue
-			var facing_before: int = object.facing
-			if _decide_object_movement(object, random):
-				_remember_object_position(object)
+	for object: Gen2WorldObject in objects:
+		if not object.active or object.deleted:
+			continue
+		# A scripted trail belongs to advance_scripted_steps_frame(), which runs
+		# while a script does. Draining it here as well would walk it at twice
+		# the speed on every frame both drivers run.
+		if object.scripted_steps:
+			continue
+		# A step in flight is drained whatever put it there, so a pushed
+		# boulder slides even though its template never decides anything.
+		# StepFunction_StrengthBoulder ends by standing the boulder back up
+		# without rolling a wait, which is why only a template that decides
+		# reaches start_idle below.
+		if object.is_stepping():
+			if object.tick_step():
 				changed = true
-			elif object.facing != facing_before:
-				_remember_object_position(object)
-				changed = true
+				if not object.is_stepping() and object.movement_advances():
+					# StepFunction_ContinueWalk rolls a new wait the moment
+					# the step duration reaches zero, so a wandering object
+					# pauses between steps instead of walking without
+					# stopping.
+					object.start_idle(random.randi() & IDLE_MASK_SLOW)
+			continue
+		if not object.movement_advances():
+			continue
+		if object.tick_idle():
+			continue
+		var facing_before: int = object.facing
+		if _decide_object_movement(object, random):
+			_remember_object_position(object)
+			changed = true
+		elif object.facing != facing_before:
+			_remember_object_position(object)
+			changed = true
 	return changed
 
 
 ## Drains the presentation trail an `applymovement` left on the objects it moved,
 ## and nothing else.
 ##
-## Separate from [method advance_object_steps] because that one decides movement
-## and a caller stops calling it while a script runs, which is exactly when a
-## scripted stream needs drawing. This decides nothing, rolls nothing and writes
-## no cell: every cell the stream names committed when it was applied. Returns
-## true when something a renderer draws moved.
-func advance_scripted_steps(delta: float) -> bool:
-	if delta <= 0.0 or objects.is_empty():
-		return false
-	var walking: Array = []
-	for object: Gen2WorldObject in objects:
-		if object.scripted_steps and not object.deleted:
-			walking.append(object)
-	if walking.is_empty():
-		_scripted_step_accumulator = 0.0
-		return false
-	_scripted_step_accumulator = minf(
-		_scripted_step_accumulator + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
-	)
+## Separate from [method advance_object_steps_frame] because that one decides
+## movement and a caller stops calling it while a script runs, which is exactly
+## when a scripted stream needs drawing. This decides nothing, rolls nothing and
+## writes no cell: every cell the stream names committed when it was applied.
+## Returns true when something a renderer draws moved.
+func advance_scripted_steps_frame() -> bool:
 	var changed: bool = false
-	while _scripted_step_accumulator >= Gen2WorldAnimation.FRAME_SECONDS:
-		_scripted_step_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
-		for object: Gen2WorldObject in walking:
-			if object.tick_step():
-				changed = true
+	for object: Gen2WorldObject in objects:
+		if object.scripted_steps and not object.deleted and object.tick_step():
+			changed = true
 	return changed
 
 
@@ -3965,12 +3947,11 @@ func advance_scripted_steps(delta: float) -> bool:
 ## The two waits are `ScriptEvents`'s own: SCRIPT_WAIT_MOVEMENT, which ends when
 ## the stream an `applymovement` started has been drawn, and the counted delay
 ## `pause`, `wait`, `deactivatefacing` and `showemote` spend. A host calls this
-## once per frame beside [method advance_scripted_steps], which is what draws
-## the movement the first one waits for.
-func advance_script_wait(delta: float) -> Array:
+## once per frame beside [method advance_scripted_steps_frame], which is what
+## draws the movement the first one waits for.
+func advance_script_wait_frame() -> Array:
 	var wait: Dictionary = pending_script_wait()
 	if wait.is_empty():
-		_script_wait_accumulator = 0.0
 		_script_wait_frames = -1
 		return []
 	if StringName(wait.get("wait", &"")) == Gen2WorldScriptRunner.WAIT_MOVEMENT:
@@ -3979,14 +3960,7 @@ func advance_script_wait(delta: float) -> Array:
 		return _complete_script_wait()
 	if _script_wait_frames < 0:
 		_script_wait_frames = maxi(0, int(wait.get("frames", 0)))
-		_script_wait_accumulator = 0.0
-	_script_wait_accumulator = minf(
-		_script_wait_accumulator + maxf(delta, 0.0),
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
-	)
-	while _script_wait_accumulator >= Gen2WorldAnimation.FRAME_SECONDS \
-		and _script_wait_frames > 0:
-		_script_wait_accumulator -= Gen2WorldAnimation.FRAME_SECONDS
+	if _script_wait_frames > 0:
 		_script_wait_frames -= 1
 	if _script_wait_frames > 0:
 		return []
@@ -4006,7 +3980,6 @@ func scripted_movement_in_progress() -> bool:
 
 
 func _complete_script_wait() -> Array:
-	_script_wait_accumulator = 0.0
 	_script_wait_frames = -1
 	if _active_script == null:
 		return []
@@ -4019,10 +3992,10 @@ func _complete_script_wait() -> Array:
 ## One hardware frame of every presentation a script waits on, for a caller with
 ## no render loop of its own: the trails and then the wait that is watching them.
 ## A screen calls the three parts itself, in the order it already draws them.
-func advance_script_presentation(delta: float) -> Array:
-	advance_player_step(delta)
-	advance_scripted_steps(delta)
-	return advance_script_wait(delta)
+func advance_script_presentation_frame() -> Array:
+	advance_player_step_frame()
+	advance_scripted_steps_frame()
+	return advance_script_wait_frame()
 
 
 ## Spends whole waits at the hardware frame rate until the script is no longer
@@ -4035,7 +4008,7 @@ func finish_script_waits(frame_limit: int = 1024) -> Array:
 	for _frame: int in frame_limit:
 		if pending_script_wait().is_empty():
 			break
-		var spent: Array = advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS)
+		var spent: Array = advance_script_presentation_frame()
 		if not spent.is_empty():
 			results = spent
 	return results
@@ -4542,9 +4515,7 @@ func _apply_map(
 	_apply_map_setup_player_state()
 	_clear_player_step()
 	# _load_objects() rebuilds every record, so in-flight object steps end with
-	# the objects that owned them; only the shared frame accumulators survive.
-	_object_step_accumulator = 0.0
-	_scripted_step_accumulator = 0.0
+	# the objects that owned them.
 	_load_objects()
 	# The cartridge moves roaming Pokémon in map setup, not on a timer, so a
 	# player who stands still does not watch them cross Johto.

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -6,6 +6,14 @@ extends RefCounted
 ## each completed game minute, while time-of-day changes use the cartridge's
 ## 04:00, 10:00 and 18:00 boundaries.
 ##
+## Seconds, not hardware frames, on purpose. Everything else in the overworld is
+## a countdown spent by [method Gen2WorldScreen.advance_frame]; the cartridge
+## reads a real-time clock for the day cycle, so this one takes wall time and
+## [method Gen2WorldScreen._advance_day_cycle] is the only caller that hands it
+## `delta`. A test or a replay reaches any boundary by asking for the seconds
+## rather than by waiting for them
+## ([method Gen2WorldScreen.advance_world_time]).
+##
 ## The clock does not move roaming Pokémon: the cartridge advances those during
 ## map setup, so [method Gen2WorldAPI.advance_schedule] is driven by a map change
 ## rather than elapsed time.

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -5,13 +5,9 @@ extends RefCounted
 ## hardware frames. The renderer owns the pixels; this class owns the source
 ## duration, amplitude and deterministic offsets.
 
-const FRAME_SECONDS: float = 1.0 / 59.7275
-const MAX_CATCHUP_FRAMES: int = 4
-
 var _frame: int = 0
 var _duration: int = 0
 var _amplitude: int = 0
-var _elapsed: float = 0.0
 var _kind: StringName = &"none"
 var _source: Dictionary = {}
 
@@ -21,7 +17,6 @@ func start_screen_shake(packed_value: int, kind: StringName = &"screen_shake", s
 	_duration = value & 0x3F
 	_amplitude = 1 << ((value >> 6) & 0x03) if _duration > 0 else 0
 	_frame = 0
-	_elapsed = 0.0
 	_kind = kind if _duration > 0 else &"none"
 	_source = source.duplicate(true)
 	return snapshot()
@@ -32,19 +27,14 @@ func start_tree_shake(source: Dictionary = {}) -> Dictionary:
 	return start_screen_shake(32, &"tree_shake", source)
 
 
-func advance(delta: float) -> bool:
-	if not active() or delta <= 0.0:
+func advance_frame() -> bool:
+	if not active():
 		return false
-	_elapsed = minf(_elapsed + delta, FRAME_SECONDS * float(MAX_CATCHUP_FRAMES))
-	var changed: bool = false
-	while _elapsed >= FRAME_SECONDS and active():
-		_elapsed -= FRAME_SECONDS
-		_frame += 1
-		changed = true
+	_frame += 1
 	if not active():
 		_kind = &"none"
 		_source = {}
-	return changed
+	return true
 
 
 func active() -> bool:

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -88,8 +88,8 @@ var step_frames_remaining: int = 0
 var queued_steps: Array = []
 ## True while the trail above belongs to a script rather than to the movement
 ## templates, which is what tells the two drivers apart:
-## Gen2WorldAPI.advance_object_steps() decides movement and is refused while a
-## script runs, advance_scripted_steps() only draws and is not.
+## Gen2WorldAPI.advance_object_steps_frame() decides movement and is refused while a
+## script runs, advance_scripted_steps_frame() only draws and is not.
 var scripted_steps: bool = false
 ## Frames this object waits before its movement template decides again. The
 ## source keeps this in OBJECT_STEP_DURATION while the object sits in

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -74,8 +74,6 @@ var _pokedex_host: Gen2PokedexScreen = null
 ## dex closing and reopening for as long as the game runs, the way the start
 ## menu cursor below survives its own screen.
 var _pokedex_prev_entry: int = 0
-## Leftover of a frame the play timer has not counted yet.
-var _game_time_seconds: float = 0.0
 var _service_host: Gen2WorldServiceScreen = null
 var _pc_host: Gen2BoxScreen = null
 var _start_menu_host: Gen2StartMenuScreen = null
@@ -99,9 +97,23 @@ var _encounter_random := RandomNumberGenerator.new()
 ## encounters and script results however long the player stands watching.
 var _object_random := RandomNumberGenerator.new()
 var _selected_rod: StringName = Gen2WorldEncounter.METHOD_OLD_ROD
-## Paces the held-direction poll at the hardware's frame rate rather than the
-## host's. See [method _advance_held_direction].
-var _walk_accumulator: float = 0.0
+## Real time banked toward the next hardware frame. The overworld's one clock:
+## see [method _process].
+var _frame_elapsed: float = 0.0
+## `(frame, button)` input, recorded from a run and played back into another.
+## Both are opt-in and off in play. A replay applies a log's entries on the frame
+## that recorded them, from inside the pump, so a host that owes two frames
+## delivers the input of both rather than only of the later one; that is what
+## makes a replay independent of the frame rate it was recorded at.
+var _input_recording: Array = []
+var _recording_input: bool = false
+var _input_replay: Dictionary = {}
+var _replaying_input: bool = false
+## What a replay is holding down, in place of the runtime's own poll.
+var _replay_held_direction: int = Gen2Button.NONE
+## Whether a frame is being spent right now, which is what tells a press
+## delivered from inside the pump from one that arrived between two frames.
+var _spending_frame: bool = false
 var _screen_base_position: Vector2 = Vector2.ZERO
 
 @onready var _screen: Gen2Screen = %Screen
@@ -131,6 +143,30 @@ func set_data(data: GameData) -> void:
 ## Normal gameplay still reads the selected slot from GameRuntime.
 func set_save(save: Gen2SaveData) -> void:
 	_injected_save = save
+
+
+## The run's seed, in the order a run can claim one: the slot that recorded it,
+## the snapshot it was opened from, the scene's own development export, then a
+## fresh roll. Whatever wins is written back to the slot, so a run is
+## reproducible from the frame it started rather than from the next save.
+func _resolve_run_seed(save: Gen2SaveData) -> int:
+	var value: int = 0
+	if save != null and save.run_seed != 0:
+		value = save.run_seed
+	elif _world.random_seed != 0:
+		value = _world.random_seed
+	elif encounter_seed != 0:
+		value = encounter_seed
+	else:
+		var rolled := RandomNumberGenerator.new()
+		rolled.randomize()
+		while value == 0:
+			value = rolled.randi()
+	if save != null:
+		save.run_seed = value
+		if save.run_mods.is_empty():
+			save.run_mods = Gen2ModHost.instance().loaded_mods()
+	return value
 
 
 func _build_world() -> void:
@@ -170,12 +206,12 @@ func _build_world() -> void:
 		_hint.text = "Choose an imported map and starting cell in the scene settings."
 		return
 	_refresh_party_summary()
-	if encounter_seed != 0:
-		_encounter_random.seed = encounter_seed
-		_object_random.seed = encounter_seed + 1
-	else:
-		_encounter_random.randomize()
-		_object_random.randomize()
+	var run_seed: int = _resolve_run_seed(selected_save)
+	_encounter_random.seed = run_seed
+	## One seed, two streams: the second is offset so the object generator is not
+	## a replay of the encounter one.
+	_object_random.seed = run_seed + 1
+	_world.random_seed = run_seed
 
 	_world.schedule_random = _encounter_random
 	_world.script_random = _encounter_random
@@ -301,52 +337,73 @@ func cycle_world_renderer() -> Dictionary:
 	return select_world_renderer(ids[posmod(at + 1, ids.size())])
 
 
+## Real time becomes hardware frames here and nowhere else in the overworld.
+## Everything that counts frames is spent by [method advance_frame]; the day
+## cycle underneath it is the one deliberate reader of `delta`, because Gen II
+## keeps a real-time clock and a wall-clock reading is what the day cycle wants.
 func _process(delta: float) -> void:
-	_advance_game_time(delta)
+	_frame_elapsed = minf(
+		_frame_elapsed + delta,
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
+	)
+	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_frame()
+	_advance_day_cycle(delta)
+
+
+## Spends [param count] hardware frames. Public beside [method advance_frame] so
+## a test, a preview tool or a replay settles the world on the frames it owes
+## rather than on a clock.
+func advance_frames(count: int) -> void:
+	for _frame: int in maxi(0, count):
+		advance_frame()
+
+
+## One hardware frame of the overworld, in the order the frame is drawn in.
+##
+## Every countdown below is spent exactly once here, so each is a function of
+## [member Gen2WorldAPI.frame_number] and not of banked real time.
+func advance_frame() -> void:
+	_spending_frame = true
+	if _world != null:
+		_world.advance_frame_counter()
+		if _replaying_input:
+			_apply_replayed_input(_world.frame_number)
+	_advance_game_time_frame()
 	if _effects != null:
-		_effects.advance(delta)
+		_effects.advance_frame()
 		_apply_world_effect_offset()
-	if _animation != null and _animation.advance(delta) and _renderer != null:
+	if _animation != null and _animation.advance_frame() and _renderer != null:
 		_renderer.refresh_animation()
-	if _world != null and _world.advance_player_step(delta) and _renderer != null:
+	if _world != null and _world.advance_player_step_frame() and _renderer != null:
 		_renderer.refresh()
-	if _world != null and _world.tick() and _renderer != null:
+	if _world != null and _world.advance_emotes_frame() and _renderer != null:
 		_renderer.refresh()
 	_advance_forced_movement()
-	_advance_held_direction(delta)
-	if _objects_may_move() and _world.advance_object_steps(delta, _object_random) \
+	_advance_held_direction()
+	if _objects_may_move() and _world.advance_object_steps_frame(_object_random) \
 		and _renderer != null:
 		_renderer.refresh()
 	# Not gated on _objects_may_move(): an applymovement is drawn while the
 	# script that ran it is still going, which is when a script runs one.
-	if _world != null and _world.advance_scripted_steps(delta) and _renderer != null:
+	if _world != null and _world.advance_scripted_steps_frame() and _renderer != null:
 		_renderer.refresh()
 	# After the trail, because the frame it finishes drawing is the frame the
 	# script waiting on it resumes.
 	if _world != null and not _world.pending_script_wait().is_empty():
-		var wait_results: Array = _world.advance_script_wait(delta)
+		var wait_results: Array = _world.advance_script_wait_frame()
 		if not wait_results.is_empty():
 			_show_script_results(wait_results)
 	if not _trainer_approach.is_empty():
 		_advance_trainer_approach()
 	if _world != null and _world.phone_ring_active():
-		var ring_results: Array = _world.advance_phone_ring(delta)
+		var ring_results: Array = _world.advance_phone_ring_frame()
 		if not ring_results.is_empty():
 			_show_script_results(ring_results)
 		_refresh_labels()
-	if _clock != null and _world != null:
-		var ticks: Array = _clock.advance(delta, _world)
-		_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
-		if not ticks.is_empty():
-			_update_time_of_day()
-			if not _overlay_open() and not _world.script_input_waiting():
-				var phone_schedule: Dictionary = _world.advance_phone_schedule(
-					ticks.size(), _encounter_random
-				)
-				var phone_results: Array = phone_schedule.get("results", [])
-				if bool(phone_schedule.get("attempted", false)) and not phone_results.is_empty():
-					_show_script_results(phone_results)
-			_refresh_labels()
+	# The condition is the audio device's, not a counter's, but the request it
+	# completes is a script's, so it lands on a frame like every other resume.
 	if _audio_waiting and _audio_player != null and not _audio_player.effect_playing():
 		_audio_waiting = false
 		var audio_result: Dictionary = Gen2WorldHost.complete_runtime_request(
@@ -354,6 +411,66 @@ func _process(delta: float) -> void:
 		)
 		if bool(audio_result.get("ok", false)):
 			_show_script_results(audio_result.get("results", []))
+	_spending_frame = false
+
+
+## Starts recording every button the world consumes, discarding any earlier log.
+## What a run has to be replayable beside its seed: see [method replay_input] and
+## `tools/replay_world.gd`.
+func record_input() -> void:
+	_input_recording = []
+	_recording_input = true
+
+
+## The recorded `(frame, kind, button)` entries, in the order they were consumed.
+func input_recording() -> Array:
+	return _input_recording.duplicate(true)
+
+
+## Plays a recorded log back into this world instead of reading the input
+## runtime. Every entry is applied on the frame it names, from inside the pump.
+func replay_input(log: Array) -> void:
+	_input_replay = {}
+	for raw: Variant in log:
+		if not raw is Dictionary:
+			continue
+		var entry: Dictionary = raw
+		var frame: int = int(entry.get("frame", 0))
+		var at: Dictionary = _input_replay.get(frame, {"hold": Gen2Button.NONE, "presses": []})
+		if String(entry.get("kind", "")) == "hold":
+			at["hold"] = int(entry.get("button", Gen2Button.NONE))
+		else:
+			(at["presses"] as Array).append(int(entry.get("button", Gen2Button.NONE)))
+		_input_replay[frame] = at
+	_replaying_input = true
+
+
+func _apply_replayed_input(frame: int) -> void:
+	var at: Dictionary = _input_replay.get(frame, {})
+	_replay_held_direction = int(at.get("hold", Gen2Button.NONE))
+	for button: int in at.get("presses", []) as Array:
+		press_button(button)
+
+
+## The Generation 2 day cycle, which is the one thing here that is not a frame
+## count: the cartridge reads a real-time clock, so [Gen2WorldClock] takes real
+## seconds and a replay holds it rather than converting it.
+func _advance_day_cycle(delta: float) -> void:
+	if _clock == null or _world == null:
+		return
+	var ticks: Array = _clock.advance(delta, _world)
+	_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
+	if ticks.is_empty():
+		return
+	_update_time_of_day()
+	if not _overlay_open() and not _world.script_input_waiting():
+		var phone_schedule: Dictionary = _world.advance_phone_schedule(
+			ticks.size(), _encounter_random
+		)
+		var phone_results: Array = phone_schedule.get("results", [])
+		if bool(phone_schedule.get("attempted", false)) and not phone_results.is_empty():
+			_show_script_results(phone_results)
+	_refresh_labels()
 
 
 ## .CheckTile's forced walk, which the source polls every frame with no input:
@@ -384,18 +501,18 @@ func _advance_forced_movement() -> void:
 ## hardware. The poll runs once per hardware frame, which is what the source
 ## did, and [method move_player] refuses while a step is still in flight, which
 ## is what turns sixty polls a second into one step every sixteen frames.
-func _advance_held_direction(delta: float) -> void:
-	_walk_accumulator = minf(
-		_walk_accumulator + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
-	)
-	if _walk_accumulator < Gen2WorldAnimation.FRAME_SECONDS:
-		return
-	_walk_accumulator = fmod(_walk_accumulator, Gen2WorldAnimation.FRAME_SECONDS)
+func _advance_held_direction() -> void:
+	## Polled before the pauses below rather than after, so a recording is what
+	## was held rather than what the world did with it.
+	var direction: int = _replay_held_direction if _replaying_input \
+		else Gen2InputRuntime.instance().held_direction()
+	if _recording_input and _world != null and direction != Gen2Button.NONE:
+		_input_recording.append({
+			"frame": _world.frame_number, "kind": "hold", "button": direction,
+		})
 	if not _objects_may_move() or _world.script_input_waiting() \
 		or _world.player_step_in_progress():
 		return
-	var direction: int = Gen2InputRuntime.instance().held_direction()
 	if direction != Gen2Button.NONE:
 		move_player(Gen2Button.vector(direction))
 
@@ -431,7 +548,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	var button: int = Gen2Button.pressed_in(event)
 	if button != Gen2Button.NONE:
-		if _handle_button(button):
+		if press_button(button):
 			accept_event()
 		return
 	if event.is_pressed() and _handle_debug_key(event):
@@ -442,6 +559,21 @@ func _unhandled_input(event: InputEvent) -> void:
 	# motion, and the screen has no opinion about either.
 	if _renderer_input_free() and Gen2ModHost.renderer_handles_input(_renderer, event):
 		accept_event()
+
+
+## One button, from whichever device produced it or from a replay, and the one
+## place a press is recorded. A press between two frames is consumed by the world
+## at the start of the next one, which is the frame the log names.
+func press_button(button: int) -> bool:
+	if _world == null or button == Gen2Button.NONE:
+		return false
+	if _recording_input:
+		_input_recording.append({
+			"frame": _world.frame_number if _spending_frame else _world.frame_number + 1,
+			"kind": "press",
+			"button": button,
+		})
+	return _handle_button(button)
 
 
 ## Routes one button to whatever owns the screen, and reports whether anything
@@ -747,23 +879,13 @@ func persist_world_snapshot() -> Dictionary:
 ## is cleared for `Script_halloffame` alone (engine/overworld/scripting.asm:2318)
 ## and `wGameLogicPaused` is set by Bill's PC (engine/pokemon/bills_pc.asm:2000)
 ## and by saving, which costs no frames here.
-##
-## Catch-up is capped the way [method Gen2WorldAnimation.advance] caps it, so a
-## stalled host cannot hand the timer a minute of frames at once.
-func _advance_game_time(delta: float) -> void:
+func _advance_game_time_frame() -> void:
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	if save == null or save.game_time == null:
 		return
 	if _hall_of_fame_host != null or _pc_host != null:
 		return
-	_game_time_seconds += minf(
-		delta, Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES)
-	)
-	var frames: int = int(_game_time_seconds / Gen2WorldAnimation.FRAME_SECONDS)
-	if frames <= 0:
-		return
-	_game_time_seconds -= float(frames) * Gen2WorldAnimation.FRAME_SECONDS
-	save.game_time.advance_frames(frames)
+	save.game_time.advance_frames(1)
 
 
 ## Deterministic driver for tests and screenshot tooling. The live scene uses
@@ -1344,12 +1466,11 @@ func _start_trainer_approach(request: Dictionary) -> void:
 	_refresh_labels()
 
 
-## Paced by call count rather than delta time, matching the emote and
-## movement-delay counters beside it and staying independent of real frame
-## timing. The object's step_frames_remaining (set by
-## [method Gen2WorldAPI.advance_trainer_approach_step]) is consumed one per call
-## like those counters, while step_offset() still gives the renderer 16-frame
-## interpolation.
+## One hardware frame of `SeenByTrainerScript`'s presentation: the shock emote's
+## own count, the movement delay, then one planned cell at a time. The object's
+## step_frames_remaining (set by
+## [method Gen2WorldAPI.advance_trainer_approach_step]) is spent by the same
+## frame, while step_offset() still gives the renderer 16-frame interpolation.
 func _advance_trainer_approach() -> void:
 	if _world == null:
 		_trainer_approach = {}

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -16,6 +16,12 @@ var world_day: int = 0
 var world_hour: int = 6
 var world_minute: int = 0
 var dst_enabled: bool = false
+## What a replay needs beside the state: the seed the world's generators were
+## built from and how many hardware frames it has been pumped for. Both are zero
+## in a snapshot written before either existed, which reads as "not reproducible"
+## rather than as frame zero of a seeded run.
+var random_seed: int = 0
+var frame_number: int = 0
 var world_state: Gen2WorldState = Gen2WorldState.new()
 
 
@@ -33,6 +39,8 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.world_hour = int(clock.get("hour", 6))
 	out.world_minute = int(clock.get("minute", 0))
 	out.dst_enabled = world.daylight_saving_time_enabled()
+	out.random_seed = world.random_seed
+	out.frame_number = world.frame_number
 	out.world_state = Gen2WorldState.from_dict(world.state.to_dict())
 	return out
 
@@ -47,6 +55,8 @@ func to_dict() -> Dictionary:
 		"player_sprite_number": player_sprite_number,
 		"clock": [world_day, world_hour, world_minute],
 		"dst_enabled": dst_enabled,
+		"random_seed": random_seed,
+		"frame_number": frame_number,
 		"world_state": world_state.to_dict() if world_state != null else {},
 	}
 
@@ -75,6 +85,8 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 		out.world_hour = int(clock[1])
 		out.world_minute = int(clock[2])
 	out.dst_enabled = bool(source.get("dst_enabled", false))
+	out.random_seed = int(source.get("random_seed", 0))
+	out.frame_number = maxi(0, int(source.get("frame_number", 0)))
 	out.world_state = Gen2WorldState.from_dict(source.get("world_state", {}))
 	return out
 

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -14,9 +14,6 @@ extends GutTest
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
-## One source VBlank, which is what the step accumulator counts in.
-const FRAME: float = 1.0 / 59.7275
-
 var _world: Gen2WorldAPI = null
 
 
@@ -50,9 +47,9 @@ func test_the_step_durations_are_the_source_rows() -> void:
 func test_a_walk_step_costs_exactly_eight_frames() -> void:
 	_world._start_player_step(Vector2i(1, 0), _walk_frames())
 	for _frame: int in _walk_frames() - 1:
-		_world.advance_player_step(FRAME)
+		_world.advance_player_step_frame()
 		assert_true(_world.player_step_in_progress(), "still walking")
-	_world.advance_player_step(FRAME)
+	_world.advance_player_step_frame()
 	assert_false(_world.player_step_in_progress(), "the eighth frame ends it")
 
 
@@ -62,12 +59,12 @@ func test_a_queued_step_starts_on_the_frame_the_last_one_ends() -> void:
 	_world._start_player_step(Vector2i(1, 0), _walk_frames())
 	_world._queue_player_step(Vector2i(1, 0), _walk_frames())
 	for _frame: int in _walk_frames():
-		_world.advance_player_step(FRAME)
+		_world.advance_player_step_frame()
 	assert_true(_world.player_step_in_progress(), "the second step took over")
 	for _frame: int in _walk_frames() - 1:
-		_world.advance_player_step(FRAME)
+		_world.advance_player_step_frame()
 		assert_true(_world.player_step_in_progress())
-	_world.advance_player_step(FRAME)
+	_world.advance_player_step_frame()
 	assert_false(_world.player_step_in_progress(), "and cost the same eight")
 
 
@@ -76,10 +73,10 @@ func test_a_queued_step_starts_on_the_frame_the_last_one_ends() -> void:
 func test_the_offset_covers_one_cell() -> void:
 	_world._start_player_step(Vector2i(1, 0), _walk_frames())
 	for _frame: int in _walk_frames() - 1:
-		_world.advance_player_step(FRAME)
+		_world.advance_player_step_frame()
 	assert_ne(
 		_world.player_step_offset_cells(), Vector2.ZERO,
 		"the pic is still short of the cell"
 	)
-	_world.advance_player_step(FRAME)
+	_world.advance_player_step_frame()
 	assert_eq(_world.player_step_offset_cells(), Vector2.ZERO, "and lands on it")

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -330,7 +330,7 @@ func test_choosing_cut_shows_the_message_and_defers_the_block_change() -> void:
 	## the one faced, so the walk is the press after it.
 	_world_screen.move_player(Vector2i.DOWN)
 	while world.player_step_in_progress():
-		world.advance_player_step(1.0)
+		world.advance_player_step_frame()
 	if world.player_cell != TREE_CELL:
 		assert_true(_world_screen.move_player(Vector2i.DOWN))
 	assert_eq(world.player_cell, TREE_CELL)
@@ -413,12 +413,12 @@ func test_stepping_back_onto_land_stops_surfing_through_the_screen() -> void:
 	# The entry step is a slow_step, so the presentation offset has to run out
 	# before the screen accepts input again.
 	while world.player_step_in_progress():
-		world.advance_player_step(1.0)
+		world.advance_player_step_frame()
 	## `.CheckTurning` turns on the spot first when the pressed direction is not
 	## the one faced, so the walk is the press after it.
 	_world_screen.move_player(Vector2i.UP)
 	while world.player_step_in_progress():
-		world.advance_player_step(1.0)
+		world.advance_player_step_frame()
 	if world.player_cell != SHORE_CELL:
 		assert_true(_world_screen.move_player(Vector2i.UP))
 	assert_eq(world.player_cell, SHORE_CELL)

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -1,0 +1,149 @@
+extends GutTest
+
+## The overworld's one clock. `Gen2WorldScreen._process` is the only place real
+## time becomes hardware frames, and `advance_frame()` is the only place a frame
+## is spent, so nothing downstream banks a remainder of its own.
+##
+## The fixture is synthetic; the screen, the world API and the play timer are the
+## production paths.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const FRAME: float = Gen2WorldAnimation.FRAME_SECONDS
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	_data = Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+func _open_world(seed_value: int = 4242) -> Gen2WorldScreen:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	screen.map_group = Fixture.MAP_GROUP
+	screen.map_number = Fixture.MAP_NUMBER
+	screen.start_cell = Vector2i(4, 5)
+	screen.encounter_seed = seed_value
+	screen.set_data(_data)
+	add_child(screen)
+	await get_tree().process_frame
+	## The host's own frames belong to the host; every case here spends the
+	## world's, so the numbers are the same on any machine. The one frame the
+	## tree ran above left a remainder banked, which is the state a case that
+	## counts frames has to start from zero.
+	screen.set_process(false)
+	screen._frame_elapsed = 0.0
+	return screen
+
+
+func test_a_partial_frame_of_real_time_spends_no_hardware_frame() -> void:
+	_world_screen = await _open_world()
+	var before: int = _world_screen._world.frame_number
+
+	# A display faster than the hardware cannot make the world run faster.
+	_world_screen._process(FRAME * 0.5)
+	assert_eq(_world_screen._world.frame_number, before)
+
+	# The remainder carries over: two half frames are one whole one.
+	_world_screen._process(FRAME * 0.5)
+	assert_eq(_world_screen._world.frame_number, before + 1)
+
+
+## One stall must not hand the world a minute of frames at once, which is what
+## every one of the accumulators this replaced capped separately.
+func test_a_stall_drops_frames_instead_of_running_the_backlog() -> void:
+	_world_screen = await _open_world()
+	var before: int = _world_screen._world.frame_number
+	_world_screen._process(10.0)
+	assert_eq(
+		_world_screen._world.frame_number - before,
+		Gen2WorldAnimation.MAX_CATCHUP_FRAMES
+	)
+
+
+## The play timer, the tile animation, the walk step and the emote counters are
+## all spent from the same call, so one world frame is one of each.
+func test_one_world_frame_is_one_frame_of_everything_that_counts_them() -> void:
+	_world_screen = await _open_world()
+	var save := Gen2SaveData.new()
+	_world_screen.set_save(save)
+	var before: int = _world_screen._world.frame_number
+
+	_world_screen.advance_frames(30)
+	assert_eq(_world_screen._world.frame_number, before + 30)
+	assert_eq(save.game_time.frames, 30, "the play timer counted the same thirty")
+
+
+## The frame number is what makes a snapshot comparable at all, so it travels
+## with one and comes back with it.
+func test_the_frame_number_survives_a_snapshot_round_trip() -> void:
+	_world_screen = await _open_world()
+	_world_screen.advance_frames(17)
+	var snapshot: Gen2WorldSnapshot = _world_screen._world.snapshot()
+	assert_eq(snapshot.frame_number, _world_screen._world.frame_number)
+	assert_eq(snapshot.random_seed, 4242)
+
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
+		_data, Gen2WorldSnapshot.from_dict(snapshot.to_dict())
+	)
+	assert_not_null(restored)
+	assert_eq(restored.frame_number, snapshot.frame_number)
+	assert_eq(restored.random_seed, 4242)
+
+
+## The artefact this refactor is finished by, in miniature: the same seed and the
+## same frame count reach the same world whatever the host's frame rate was.
+## tools/replay_world.gd is the same comparison over real cartridge routes.
+func test_the_same_seed_and_frame_count_reach_the_same_world_at_any_frame_rate() -> void:
+	var snapshots: Array = []
+	for host_fps: float in [30.0, 60.0, 144.0]:
+		var screen: Gen2WorldScreen = await _open_world()
+		var delta: float = 1.0 / host_fps
+		var guard: int = 0
+		while screen._world.frame_number < 120 and guard < 4096:
+			screen._process(delta)
+			guard += 1
+		assert_eq(screen._world.frame_number, 120, "%d fps reached the frame" % host_fps)
+		snapshots.append(JSON.stringify(screen._world.snapshot().to_dict()))
+		screen.free()
+	assert_eq(snapshots[0], snapshots[1], "30 fps and 60 fps disagree")
+	assert_eq(snapshots[1], snapshots[2], "60 fps and 144 fps disagree")
+
+
+## `Gen2WorldClock` is deliberately not converted: Generation 2 keeps a
+## real-time clock, so the day cycle reads wall time and only the day cycle does.
+func test_the_day_cycle_stays_on_real_seconds() -> void:
+	_world_screen = await _open_world()
+	var before: Dictionary = _world_screen._world.world_clock()
+	_world_screen.advance_frames(600)
+	assert_eq(
+		_world_screen._world.world_clock(), before,
+		"ten seconds of frames move no clock, because frames are not what it reads"
+	)
+	_world_screen._process(Gen2WorldClock.SECONDS_PER_MINUTE)
+	assert_eq(
+		int(_world_screen._world.world_clock()["minute"]),
+		(int(before["minute"]) + 1) % Gen2WorldClock.MINUTES_PER_HOUR,
+		"a minute of real time is a cartridge minute"
+	)
+
+	## And a boundary is asked for rather than waited for, which is what keeps a
+	## day cycle testable while it stays on wall time.
+	var day: int = int(_world_screen._world.world_clock()["day"])
+	_world_screen.advance_world_time(
+		float(Gen2WorldClock.HOURS_PER_DAY) * 3600.0
+	)
+	assert_eq(
+		int(_world_screen._world.world_clock()["day"]),
+		(day + 1) % Gen2WorldClock.DAYS_PER_WEEK
+	)

--- a/tests/integration/test_world_frame_pump.gd.uid
+++ b/tests/integration/test_world_frame_pump.gd.uid
@@ -1,0 +1,1 @@
+uid://cy1qc7md86kwx

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -95,7 +95,7 @@ func test_a_renderer_never_receives_a_movement_or_interaction_button() -> void:
 	## spawns facing down; the walk is the press after it.
 	_world_screen._unhandled_input(_press(KEY_RIGHT))
 	while _world_screen._world.player_step_in_progress():
-		_world_screen._world.advance_player_step(1.0)
+		_world_screen._world.advance_player_step_frame()
 	_world_screen._unhandled_input(_press(KEY_RIGHT))
 	_world_screen._unhandled_input(_press(KEY_SPACE))
 	# The screen claimed both: the player moved, and neither key was offered on.

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -199,8 +199,9 @@ func test_pending_special_call_dispatches_the_imported_script() -> void:
 	assert_true(attempt["attempted"])
 	_world_screen._show_script_results(attempt["results"])
 	await get_tree().process_frame
-	var resumed: Array = _world_screen._world.advance_phone_ring(3.0)
-	_world_screen._show_script_results(resumed)
+	## The screen's own pump is what spends the two rings and shows what
+	## finishing them produced.
+	_world_screen.advance_frames(4 * Gen2WorldPhoneRing.TOTAL_FRAMES)
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_true(_world_screen._world.script_input_waiting())
@@ -250,8 +251,9 @@ func test_phone_list_starts_the_source_timed_outgoing_ring() -> void:
 	assert_null(_world_screen._service_host)
 	assert_true(_world_screen._world.phone_ring_active())
 	assert_true(_world_screen._caption.text.contains("PHONE RING"))
-	var resumed: Array = _world_screen._world.advance_phone_ring(3.0)
-	_world_screen._show_script_results(resumed)
+	## The screen's own pump is what spends the two rings and shows what
+	## finishing them produced.
+	_world_screen.advance_frames(4 * Gen2WorldPhoneRing.TOTAL_FRAMES)
 	await get_tree().process_frame
 	assert_true(_world_screen._world.script_input_waiting())
 	assert_eq(_world_screen._world.pending_script_input()["text"], "PHONE SCRIPT")

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -707,11 +707,11 @@ func test_player_opens_the_trainer_card_and_b_reopens_the_start_menu() -> void:
 func test_the_play_timer_counts_while_the_world_runs() -> void:
 	await _open_world()
 	## The fixture drives an injected save, which is the one the timer counts on
-	## too: _advance_game_time() prefers it exactly as the card does.
+	## too: the pump prefers it exactly as the card does.
 	var save: Gen2SaveData = _world_screen._injected_save
 	assert_not_null(save)
 	save.game_time = Gen2GameTime.new()
-	_world_screen._advance_game_time(Gen2WorldAnimation.FRAME_SECONDS * 3.0)
+	_world_screen.advance_frames(3)
 	assert_eq(save.game_time.frames, 3)
 
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -62,23 +62,35 @@ func _walk_one(direction: Vector2i) -> void:
 	var before: Vector2i = _world_screen._world.player_cell
 	assert_true(_world_screen.move_player(direction))
 	for _frame: int in 16:
-		await get_tree().process_frame
 		if not _world_screen._world.player_step_in_progress():
 			break
+		_world_screen.advance_frame()
+	await get_tree().process_frame
 	if _world_screen._world.player_cell == before:
 		assert_true(_world_screen.move_player(direction))
 
 
+## Spends the world's own frames rather than the host's, so the shock emote and
+## the approach cost what `SeenByTrainerScript` says they cost however fast this
+## machine runs the suite.
 func _trigger_trainer() -> void:
 	await _walk_one(Vector2i.RIGHT)
-	for _frame: int in 80:
-		await get_tree().process_frame
-		if _battle_host() != null:
-			return
+	for _frame: int in 400:
+		_world_screen.advance_frame()
+		if _battle_child() != null:
+			break
 		var pending: Dictionary = _world_screen._world.pending_script_input()
 		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
+	await get_tree().process_frame
 	assert_not_null(_battle_host())
+
+
+func _battle_child() -> Gen2BattleScreen:
+	for child: Node in _world_screen.get_children():
+		if child is Gen2BattleScreen:
+			return child as Gen2BattleScreen
+	return null
 
 
 ## The battle overlay, with its opening slide walked to the end.
@@ -87,15 +99,14 @@ func _trigger_trainer() -> void:
 ## nothing until the pics are in place. In play the screen's own frames spend
 ## that; a test that read the box without it would read an empty one.
 func _battle_host() -> Gen2BattleScreen:
-	for child: Node in _world_screen.get_children():
-		if child is Gen2BattleScreen:
-			var host: Gen2BattleScreen = child as Gen2BattleScreen
-			var guard: int = 4000
-			while host.frames_running() and guard > 0:
-				host.advance_frame()
-				guard -= 1
-			return host
-	return null
+	var host: Gen2BattleScreen = _battle_child()
+	if host == null:
+		return null
+	var guard: int = 4000
+	while host.frames_running() and guard > 0:
+		host.advance_frame()
+		guard -= 1
+	return host
 
 
 ## The wild this fixture ships, named out of the cache rather than spelled out.
@@ -129,11 +140,8 @@ func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	assert_eq(snapshot["world_battle_active"], true)
 
 
-## The approach still takes the same number of process frames it did before
-## sub-cell interpolation existed (proven by every other case in this file
-## reaching the battle overlay through the same _trigger_trainer budget);
-## this only checks that while the trainer object is mid-step, its
-## presentation offset eases toward zero instead of snapping.
+## While the trainer object is mid-step, its presentation offset eases toward
+## zero instead of snapping.
 func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 	await _open_world()
 	await _walk_one(Vector2i.RIGHT)
@@ -143,9 +151,9 @@ func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 	var was_stepping: bool = false
 	var previous_magnitude: int = -1
 	var lowest_magnitude: int = Gen2WorldAPI.CELL_PIXELS
-	for _frame: int in 80:
-		await get_tree().process_frame
-		if _battle_host() != null:
+	for _frame: int in 400:
+		_world_screen.advance_frame()
+		if _battle_child() != null:
 			break
 		if object.is_stepping():
 			var offset: Vector2i = object.step_offset(Gen2WorldAPI.CELL_PIXELS)
@@ -168,10 +176,11 @@ func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 		var pending: Dictionary = _world_screen._world.pending_script_input()
 		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
+	await get_tree().process_frame
 	assert_not_null(_battle_host())
 	assert_true(saw_step)
-	# tick_step() decrements once per process call, the same rate the emote
-	# and movement-delay counters already use; the offset eases down to one
+	# tick_step() spends one hardware frame, the same one the emote and
+	# movement-delay counters are spent by; the offset eases down to one
 	# STEP_FRAMES_WALK-th of a cell on the frame before the step formally ends.
 	assert_eq(lowest_magnitude, Gen2WorldAPI.CELL_PIXELS / Gen2WorldAPI.STEP_FRAMES_WALK)
 

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -232,6 +232,31 @@ func test_mod_save_namespaces_refuse_bad_ids_and_large_documents() -> void:
 	)
 
 
+## The seed and the mod list a crash report or a replay would name, beside the
+## per-mod namespace rather than inside it.
+func test_the_run_block_round_trips_and_refuses_an_invented_mod_id() -> void:
+	var save: Gen2SaveData = _save()
+	save.run_seed = 0x0BADF00D
+	save.run_mods = [
+		{"id": "weather_plus", "version": "1.2.0"},
+		{"id": "Bad Id", "version": "9"},
+	]
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	assert_eq(restored.run_seed, 0x0BADF00D)
+	assert_eq(restored.run_mods, [{"id": "weather_plus", "version": "1.2.0"}])
+
+
+## A slot written before the block existed says so rather than claiming frame
+## zero of a seeded run.
+func test_a_save_without_a_run_block_records_no_seed() -> void:
+	var raw: Dictionary = _save().to_dict()
+	raw.erase("run")
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(raw)
+	assert_not_null(restored)
+	assert_eq(restored.run_seed, 0)
+	assert_eq(restored.run_mods, [])
+
+
 func test_format_five_migrates_to_an_empty_mod_namespace() -> void:
 	var raw: Dictionary = _save().to_dict()
 	raw["format_version"] = 5

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -91,34 +91,18 @@ func test_water_command_writes_the_imported_frame_and_done_loops() -> void:
 	assert_eq(animation.current_indices()[0], 1)
 
 
-func test_advance_paces_commands_by_elapsed_time_not_by_rendered_frames() -> void:
+func test_advance_frame_reports_no_redraw_when_the_command_changes_nothing() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
 	var animation := Gen2WorldAnimation.new()
 	animation.configure(world)
 
-	# A frame shorter than one hardware frame runs no command at all, so a fast
-	# display cannot make the sequence run faster than the cartridge does.
-	assert_false(animation.advance(Gen2WorldAnimation.FRAME_SECONDS * 0.5))
-	assert_eq(animation.current_indices()[0], 0)
-
-	# The remainder carries over: two half frames are one whole one.
-	assert_true(animation.advance(Gen2WorldAnimation.FRAME_SECONDS * 0.5))
-	assert_eq(animation.current_indices()[0], 1)
-
-
-func test_advance_reports_no_redraw_when_the_command_changes_nothing() -> void:
-	var data: GameData = GameData.open_directory(_directory)
-	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
-	var animation := Gen2WorldAnimation.new()
-	animation.configure(world)
-
-	assert_true(animation.advance(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_true(animation.advance_frame())
 	# "done" only rewinds the command index, so nothing new is drawn and the
 	# renderer must not rebuild its atlas for it.
-	assert_false(animation.advance(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_false(animation.advance_frame())
 	# The water command runs again, but writes the frame that is already there.
-	assert_false(animation.advance(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_false(animation.advance_frame())
 
 
 func test_changed_tiles_reports_exactly_the_tiles_a_frame_rewrote() -> void:
@@ -131,7 +115,7 @@ func test_changed_tiles_reports_exactly_the_tiles_a_frame_rewrote() -> void:
 	# stale tile on screen and an over-report costs the work this replaced.
 	for _frame: int in 240:
 		var before: PackedByteArray = animation.current_indices().duplicate()
-		var redraw: bool = animation.advance(Gen2WorldAnimation.FRAME_SECONDS)
+		var redraw: bool = animation.advance_frame()
 		var after: PackedByteArray = animation.current_indices()
 		var actually_changed: Array = []
 		var width: int = RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_WIDTH
@@ -145,15 +129,3 @@ func test_changed_tiles_reports_exactly_the_tiles_a_frame_rewrote() -> void:
 					break
 		assert_eq(Array(animation.changed_tiles()), actually_changed)
 		assert_eq(redraw, not actually_changed.is_empty() or animation.palette_changed())
-
-
-func test_advance_drops_frames_after_a_stall_instead_of_running_the_backlog() -> void:
-	var data: GameData = GameData.open_directory(_directory)
-	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
-	var animation := Gen2WorldAnimation.new()
-	animation.configure(world)
-
-	# Ten seconds of stall is close to 600 hardware frames. Only the capped
-	# catch-up runs, so recovery costs a bounded amount of work.
-	animation.advance(10.0)
-	assert_lt(animation.command_index(), Gen2WorldAnimation.MAX_CATCHUP_FRAMES + 1)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -308,7 +308,7 @@ func _run_script(world: Gen2WorldAPI, dispatched: Array) -> Array:
 		if world.pending_script_wait().is_empty():
 			break
 		results.append_array(
-			world.advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS)
+			world.advance_script_presentation_frame()
 		)
 	return results
 
@@ -410,6 +410,17 @@ func test_world_host_resolves_imported_mart_audio_and_phone_records() -> void:
 	assert_eq(special_world.state.pending_special_phone_call(), 1)
 
 
+## Spends [param frames] hardware frames of the two-ring sequence and returns
+## whatever finishing it produced.
+func _spend_phone_ring(world: Gen2WorldAPI, frames: int) -> Array:
+	var results: Array = []
+	for _frame: int in frames:
+		var spent: Array = world.advance_phone_ring_frame()
+		if not spent.is_empty():
+			results = spent
+	return results
+
+
 func test_phone_ring_runs_before_the_imported_incoming_script() -> void:
 	_write_service_cache()
 	var data: GameData = GameData.open_directory(_directory)
@@ -421,8 +432,11 @@ func test_phone_ring_runs_before_the_imported_incoming_script() -> void:
 	assert_true(world.phone_ring_active())
 	assert_true(world.pending_runtime_request().is_empty())
 	assert_eq(world.move_result(Vector2i.RIGHT)["reason"], &"phone_ring_active")
-	assert_true(world.advance_phone_ring(1.0).is_empty())
-	var resumed: Array = world.advance_phone_ring(2.0)
+	assert_true(
+		_spend_phone_ring(world, Gen2WorldPhoneRing.TOTAL_FRAMES - 1).is_empty(),
+		"the last of the two rings has not been spent yet"
+	)
+	var resumed: Array = _spend_phone_ring(world, 1)
 	assert_false(world.phone_ring_active())
 	assert_eq(resumed[0]["status"], &"waiting", JSON.stringify(resumed))
 	assert_eq(world.pending_script_input()["type"], &"text")
@@ -437,7 +451,7 @@ func test_phone_ring_runs_before_the_imported_outgoing_script() -> void:
 	var started: Array = world.request_outgoing_phone_call(0)
 	assert_eq(started[0]["status"], &"phone_ring")
 	assert_eq(started[0]["event"]["kind"], &"phone_outgoing")
-	var resumed: Array = world.advance_phone_ring(3.0)
+	var resumed: Array = _spend_phone_ring(world, 4 * Gen2WorldPhoneRing.TOTAL_FRAMES)
 	assert_eq(resumed[0]["status"], &"waiting", JSON.stringify(resumed))
 	assert_eq(world.pending_script_input()["type"], &"text")
 
@@ -818,8 +832,7 @@ func test_ledge_hop_crosses_two_cells_after_an_ordinary_step_is_blocked() -> voi
 	# uses with a magnitude-2 direction.
 	assert_true(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2(0, -2))
-	for _tick: int in 4:
-		world.advance_player_step(1000.0)
+	_finish_player_step(world)
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 
@@ -932,7 +945,7 @@ func test_strength_push_slides_the_boulder_over_the_slow_step_duration() -> void
 	var random := RandomNumberGenerator.new()
 	random.seed = 7
 	for _frame: int in Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH:
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
 	assert_false(boulder.is_stepping())
 	assert_false(boulder.is_idle())
 	assert_eq(boulder.cell, BOULDER_LANDING)
@@ -1883,13 +1896,12 @@ func test_the_interpolated_camera_origin_does_not_pan_a_step_early() -> void:
 	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(4.0, 2.0))
 
-	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_true(world.advance_player_step_frame())
 	assert_eq(world.player_position_cells(), Vector2(7.875, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(3.875, 2.0))
 
 	# The step lands on the committed cell, where the two agree again.
-	assert_true(world.advance_player_step(1000.0))
-	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 3.0))
+	_finish_player_step(world)
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_position_cells(), Vector2(7.0, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(world.visible_screen_origin_cell()))
@@ -1903,29 +1915,30 @@ func test_the_interpolated_camera_origin_runs_off_the_map_like_the_page_does() -
 	assert_eq(top_left.visible_origin_cells(), Vector2(-4.0, -4.0))
 
 
-func test_advance_player_step_consumes_hardware_frames_and_caps_catchup() -> void:
+## One call, one hardware frame, whatever the host's frame rate is. The stall
+## cap lives on the pump that feeds this
+## (tests/integration/test_world_frame_pump.gd), not on the countdown.
+func test_advance_player_step_spends_exactly_one_frame_per_call() -> void:
 	var world: Gen2WorldAPI = _world()
 	assert_true(world.move(Vector2i.LEFT))
 	assert_eq(world.player_cell, Vector2i(7, 6))
 
-	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_true(world.advance_player_step_frame())
 	assert_eq(world.player_step_offset_cells(), Vector2(0.875, 0.0))
 
-	# A huge delta advances at most Gen2WorldAnimation.MAX_CATCHUP_FRAMES
-	# hardware frames per call, the same stall cap the tile animation uses, so
-	# a pause drops step frames instead of snapping the sprite to its
-	# destination. STEP_FRAMES_WALK is 8: one frame already consumed above,
-	# four more are capped here, leaving three of eight.
-	assert_true(world.advance_player_step(1000.0))
+	# STEP_FRAMES_WALK is 8, one of which is spent above.
+	for _frame: int in 4:
+		assert_true(world.advance_player_step_frame())
 	assert_eq(world.player_step_offset_cells(), Vector2(3.0 / 8.0, 0.0))
 	assert_eq(world.player_cell, Vector2i(7, 6))
 
-	assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 3.0))
+	for _frame: int in 3:
+		assert_true(world.advance_player_step_frame())
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(world.player_cell, Vector2i(7, 6))
 	assert_eq(world.player_walk_frame(), 0, "SetFacingStanding restores the resting cel")
-	assert_false(world.advance_player_step(1.0))
+	assert_false(world.advance_player_step_frame())
 
 
 func test_player_step_does_not_affect_cell_collision_or_events() -> void:
@@ -1937,8 +1950,7 @@ func test_player_step_does_not_affect_cell_collision_or_events() -> void:
 	var during_permission: int = world.collision_permission_at(world.player_cell)
 	var during_walkable: bool = world.can_walk_to(Vector2i(6, 6))
 
-	assert_true(world.advance_player_step(1000.0))
-	assert_true(world.advance_player_step(1000.0))
+	_finish_player_step(world)
 	assert_false(world.player_step_in_progress())
 
 	# A presentation offset in flight never changes what resolves off the
@@ -1982,8 +1994,7 @@ func test_snapshot_ignores_transient_player_step() -> void:
 	assert_true(world.player_step_in_progress())
 	var mid_step: Dictionary = world.snapshot().to_dict()
 
-	assert_true(world.advance_player_step(1000.0))
-	assert_true(world.advance_player_step(1000.0))
+	_finish_player_step(world)
 	assert_false(world.player_step_in_progress())
 	var finished: Dictionary = world.snapshot().to_dict()
 
@@ -2017,7 +2028,17 @@ func _advance_object_frames(
 	world: Gen2WorldAPI, frames: int, random: RandomNumberGenerator
 ) -> void:
 	for _frame: int in frames:
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
+
+
+## Spends the frames the player's step still owes. Bounded rather than a while
+## loop so a step that never ends fails the assertion after it instead of
+## hanging the suite.
+func _finish_player_step(world: Gen2WorldAPI) -> void:
+	for _frame: int in 64:
+		if not world.player_step_in_progress():
+			return
+		world.advance_player_step_frame()
 
 
 func test_wander_object_commits_its_cell_and_eases_over_the_slow_step() -> void:
@@ -2028,7 +2049,7 @@ func test_wander_object_commits_its_cell_and_eases_over_the_slow_step() -> void:
 	var start: Vector2i = object.cell
 
 	# The first frame is the object's turn at the movement function.
-	assert_true(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	assert_true(world.advance_object_steps_frame(random))
 	assert_true(object.is_stepping())
 	# StepVectors' slow row is 16 frames, half the player's walking speed.
 	assert_eq(object.step_frames_total, Gen2WorldAPI.STEP_FRAMES_NPC_WALK)
@@ -2102,7 +2123,7 @@ func test_a_swim_wander_object_moves_across_its_pond_within_its_radius() -> void
 
 	var visited: Dictionary = {object.cell: true}
 	for _frame: int in 1024:
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
 		visited[object.cell] = true
 	assert_eq(
 		visited.keys().size(), 2,
@@ -2142,7 +2163,7 @@ func test_blocked_wander_object_keeps_its_cell_and_waits() -> void:
 	random.seed = 77
 	var start: Vector2i = object.cell
 
-	assert_false(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	assert_false(world.advance_object_steps_frame(random))
 	assert_eq(object.cell, start)
 	assert_false(object.is_stepping())
 	# _RandomWalkContinue's .new_duration branch waits again rather than
@@ -2163,7 +2184,7 @@ func test_wander_object_never_leaves_its_source_radius() -> void:
 	var strayed: Vector2i = Vector2i.MAX
 	var visited: Dictionary = {}
 	for _frame: int in 2000:
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
 		visited[object.cell] = true
 		if abs(object.cell.x - origin.x) > 1 or abs(object.cell.y - origin.y) > 1:
 			strayed = object.cell
@@ -2203,25 +2224,27 @@ func test_standing_objects_are_never_moved_by_the_driver() -> void:
 	var facing: int = object.facing
 
 	for _frame: int in 300:
-		assert_false(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+		assert_false(world.advance_object_steps_frame(random))
 	assert_eq(object.cell, start)
 	assert_eq(object.facing, facing)
 
 
-func test_object_driver_caps_catchup_after_a_stall() -> void:
+## One call, one frame. The stall cap is the pump's
+## (tests/integration/test_world_frame_pump.gd), so this driver cannot be handed
+## a hundred frames by a slow host either.
+func test_object_driver_spends_exactly_one_frame_per_call() -> void:
 	var world: Gen2WorldAPI = _wandering_world()
 	var object: Gen2WorldObject = world.objects[0]
 	var random := RandomNumberGenerator.new()
 	random.seed = 90210
 
-	assert_true(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random))
+	# The deciding frame starts the step without spending one of its frames.
+	assert_true(world.advance_object_steps_frame(random))
 	assert_eq(object.step_frames_remaining, Gen2WorldAPI.STEP_FRAMES_NPC_WALK)
-	# A huge delta spends at most MAX_CATCHUP_FRAMES frames, the same stall cap
-	# the tile animation and the player's walk step use.
-	assert_true(world.advance_object_steps(1000.0, random))
+	for _frame: int in 4:
+		assert_true(world.advance_object_steps_frame(random))
 	assert_eq(
-		object.step_frames_remaining,
-		Gen2WorldAPI.STEP_FRAMES_NPC_WALK - Gen2WorldAnimation.MAX_CATCHUP_FRAMES
+		object.step_frames_remaining, Gen2WorldAPI.STEP_FRAMES_NPC_WALK - 4
 	)
 
 
@@ -2237,7 +2260,7 @@ func test_object_steps_do_not_survive_a_map_transition() -> void:
 	for _frame: int in 600:
 		if object.is_stepping():
 			break
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
 	assert_true(object.is_stepping())
 
 	var result: Dictionary = world.try_warp()
@@ -2275,7 +2298,7 @@ func test_object_driver_ignores_a_missing_generator() -> void:
 	var world: Gen2WorldAPI = _wandering_world()
 	var object: Gen2WorldObject = world.objects[0]
 	var start: Vector2i = object.cell
-	assert_false(world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, null))
+	assert_false(world.advance_object_steps_frame(null))
 	assert_eq(object.cell, start)
 	assert_false(object.is_stepping())
 
@@ -3355,7 +3378,7 @@ func test_a_press_in_a_new_direction_turns_on_the_spot_before_it_walks() -> void
 	assert_eq(world.player_walk_frame(), 0, "StepFunction_Turn stays standing")
 
 	while world.player_step_in_progress():
-		world.advance_player_step(1.0)
+		world.advance_player_step_frame()
 	assert_eq(world.player_walk_frame(), 0, "the completed turn stays standing")
 	var walk: Dictionary = world.player_input_move(Vector2i.RIGHT)
 	assert_true(walk["ok"])
@@ -3490,8 +3513,8 @@ func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> v
 	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
 	# One cell of trail, at turn_in's own STEP_WALK duration.
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 1.0))
-	for _call: int in 2:
-		world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_player_step_frame()
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(_final_status(_run_script(world, dispatched)), &"complete")
 
@@ -3513,16 +3536,16 @@ func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -
 	assert_eq(object.cell, start + Vector2i(2, 0), "both cells commit at once")
 	assert_eq(object.step_offset_cells(), Vector2(-2.0, 0.0), "and the drawing is behind both")
 
-	# STEP_FRAMES_WALK is 8 and MAX_CATCHUP_FRAMES caps a call at four.
-	for _call: int in 2:
-		assert_true(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0))
+	# Each of the two cells costs STEP_FRAMES_WALK frames.
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		assert_true(world.advance_scripted_steps_frame())
 	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0), "one step drawn, one to go")
 	assert_eq(object.cell, start + Vector2i(2, 0), "and no cell moved with it")
 
-	for _call: int in 2:
-		world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_scripted_steps_frame()
 	assert_eq(object.step_offset_cells(), Vector2.ZERO)
-	assert_false(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS))
+	assert_false(world.advance_scripted_steps_frame())
 
 
 ## `Script_applymovement` sets SCRIPT_WAIT_MOVEMENT and StopScript, and
@@ -3553,7 +3576,7 @@ func test_applymovement_holds_the_script_until_the_trail_has_been_drawn() -> voi
 	# Two `step` commands, so the wait outlasts the first one's frames.
 	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
 		assert_true(
-			world.advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS).is_empty()
+			world.advance_script_presentation_frame().is_empty()
 		)
 	assert_false(world.pending_script_wait().is_empty(), "one step still to draw")
 	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0))
@@ -3584,7 +3607,7 @@ func test_a_movement_sleep_holds_the_wait_without_moving_anything() -> void:
 
 	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
 	for _frame: int in 7:
-		world.advance_script_presentation(Gen2WorldAnimation.FRAME_SECONDS)
+		world.advance_script_presentation_frame()
 	assert_false(world.pending_script_wait().is_empty(), "eight frames of sleep")
 	assert_eq(object.cell, start)
 	assert_eq(object.walk_frame(), 0, "STEP_TYPE_SLEEP stands still")
@@ -3672,7 +3695,7 @@ func _types_of(result: Dictionary) -> Array[StringName]:
 	return types
 
 
-## The two drivers own different objects. advance_object_steps() decides
+## The two drivers own different objects. advance_object_steps_frame() decides
 ## movement and a screen stops calling it while a script runs, which is exactly
 ## when a scripted trail has to keep being drawn, so draining it there as well
 ## would walk it at twice the speed.
@@ -3692,10 +3715,14 @@ func test_the_movement_driver_leaves_a_scripted_trail_to_its_own_driver() -> voi
 
 	var random := RandomNumberGenerator.new()
 	random.seed = 7
-	world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0, random)
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_object_steps_frame(random)
 	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0), "untouched by the other driver")
 
-	assert_true(world.advance_scripted_steps(Gen2WorldAnimation.FRAME_SECONDS * 4.0))
+	@warning_ignore("integer_division")
+	var half: int = Gen2WorldAPI.STEP_FRAMES_WALK / 2
+	for _frame: int in half:
+		assert_true(world.advance_scripted_steps_frame())
 	assert_eq(object.step_offset_cells(), Vector2(-0.5, 0.0))
 
 
@@ -3718,14 +3745,14 @@ func test_a_scripted_player_stream_trails_and_advances_the_walk_frame() -> void:
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 2.0))
 	assert_eq(world.player_walk_frame(), 0)
 
-	for _call: int in 2:
-		assert_true(world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0))
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		assert_true(world.advance_player_step_frame())
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 1.0), "one step drawn")
 	# Eight frames in, the counter is on its third drawing: stand, walk, stand.
 	assert_eq(world.player_walk_frame(), 2)
 
-	for _call: int in 2:
-		world.advance_player_step(Gen2WorldAnimation.FRAME_SECONDS * 4.0)
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_player_step_frame()
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(world.player_cell, Vector2i(7, 4))
 	assert_eq(world.player_walk_frame(), 0, "EndSpriteMovement leaves the player standing")
@@ -4464,9 +4491,9 @@ func test_real_trainer_metadata_runs_seen_text_battle_and_beaten_flag() -> void:
 	assert_eq(plan["path"], [Vector2i.UP])
 	assert_eq(world.objects[0].emote_remaining, Gen2WorldAPI.TRAINER_SHOCK_FRAMES)
 	for _frame: int in Gen2WorldAPI.TRAINER_SHOCK_FRAMES - 1:
-		world.tick()
+		world.advance_emotes_frame()
 	assert_true(world.objects[0].emote_visible)
-	assert_true(world.tick())
+	assert_true(world.advance_emotes_frame())
 	assert_false(world.objects[0].emote_visible)
 	var step: Dictionary = world.advance_trainer_approach_step(0, Vector2i.UP)
 	assert_true(step["ok"])
@@ -4954,11 +4981,11 @@ func test_scripted_emote_holds_the_script_for_its_own_pause() -> void:
 	assert_eq(object.emote_id, 1)
 
 	for _frame: int in 3:
-		assert_true(world.advance_script_wait(Gen2WorldAnimation.FRAME_SECONDS).is_empty())
+		assert_true(world.advance_script_wait_frame().is_empty())
 	assert_true(object.emote_visible, "still up while the pause runs")
-	assert_false(world.tick(), "and not on a countdown of its own")
+	assert_false(world.advance_emotes_frame(), "and not on a countdown of its own")
 
-	var finished: Array = world.advance_script_wait(Gen2WorldAnimation.FRAME_SECONDS)
+	var finished: Array = world.advance_script_wait_frame()
 	assert_eq(_final_status(finished), &"complete")
 	assert_false(object.emote_visible)
 

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -10,10 +10,11 @@ func test_source_packed_screen_shake_uses_duration_and_amplitude_bits() -> void:
 	assert_eq(started["offset"], Vector2(-2, 0))
 
 	for _frame: int in 19:
-		effects.advance(Gen2WorldEffects.FRAME_SECONDS)
+		assert_true(effects.advance_frame())
 	assert_true(effects.active())
-	effects.advance(Gen2WorldEffects.FRAME_SECONDS)
+	assert_true(effects.advance_frame())
 	assert_false(effects.active())
+	assert_false(effects.advance_frame(), "a spent effect costs no more frames")
 	assert_eq(effects.offset(), Vector2.ZERO)
 
 
@@ -22,6 +23,7 @@ func test_tree_shake_is_a_short_source_timed_effect() -> void:
 	effects.start_tree_shake({"object_index": 3})
 	assert_eq(effects.snapshot()["kind"], &"tree_shake")
 	assert_eq(effects.snapshot()["duration"], 32)
-	effects.advance(Gen2WorldEffects.FRAME_SECONDS * 2.0)
+	effects.advance_frame()
+	effects.advance_frame()
 	assert_eq(effects.snapshot()["frame"], 2)
 	assert_true(effects.snapshot()["source"].has("object_index"))

--- a/tests/unit/test_world_phone_ring.gd
+++ b/tests/unit/test_world_phone_ring.gd
@@ -1,17 +1,22 @@
 extends GutTest
 
 
+func _spend(ring: Gen2WorldPhoneRing, frames: int) -> void:
+	for _frame: int in frames:
+		ring.advance_frame()
+
+
 func test_source_ring_has_two_three_wait_cycles() -> void:
 	var ring := Gen2WorldPhoneRing.new()
 	assert_eq(ring.total_frames(), 120)
 	assert_eq(ring.snapshot()["phase"], &"ringing")
-	ring.advance(20.0 * Gen2WorldPhoneRing.FRAME_SECONDS)
+	_spend(ring, 20)
 	assert_eq(ring.snapshot()["phase"], &"caller_name")
-	ring.advance(40.0 * Gen2WorldPhoneRing.FRAME_SECONDS)
+	_spend(ring, 40)
 	assert_eq(ring.snapshot()["ring"], 2)
 	assert_eq(ring.snapshot()["phase"], &"ringing")
 	assert_false(ring.is_finished())
-	ring.advance(60.0 * Gen2WorldPhoneRing.FRAME_SECONDS)
+	_spend(ring, 60)
 	assert_true(ring.is_finished())
 	assert_eq(ring.snapshot()["elapsed_frames"], 120)
 
@@ -20,6 +25,6 @@ func test_special_call_lead_precedes_the_same_two_rings() -> void:
 	var ring := Gen2WorldPhoneRing.new(30)
 	assert_eq(ring.total_frames(), 150)
 	assert_eq(ring.snapshot()["phase"], &"pre_ring")
-	ring.advance(30.0 * Gen2WorldPhoneRing.FRAME_SECONDS)
+	_spend(ring, 30)
 	assert_eq(ring.snapshot()["phase"], &"ringing")
 	assert_eq(ring.snapshot()["ring"], 1)

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -14,12 +14,28 @@ extends SceneTree
 ##
 ## `maps/PlayersHouse1F.asm`: the two coord events at (8,4) and (9,4) are
 ## Crystal's trigger. Gold and Silver ship none; their scene 0 is an `sdefer` of
-## the same script, so the trace there starts from the map entry instead.
+## the same script, so the trace there starts from the map entry instead, which
+## is why its three checkpoints sit later than Crystal's.
+##
+## It is a regression test, not only a report: the three frames the emote, the
+## walk and the box first appear on are pinned in [constant CHECKPOINTS] and a
+## run that moves one of them exits non-zero. Change those numbers only with a
+## reading of the asm that says why.
 
 const WINDOW_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 const FRAME: float = 1.0 / 59.7275
 ## Long enough for the walk, the emote's fifteen frames and the text to appear.
 const TRACE_FRAMES: int = 600
+
+## The frame the emote, Mom's first drawn step and the text box each first
+## appear on, per profile. Every interval between them is the source's:
+## `showemote EMOTE_SHOCK, MOM1, 15` is 30 frames of emote, and the walk is
+## `MomWalksToPlayerMovement`'s own steps.
+const CHECKPOINTS: Dictionary = {
+	&"crystal": {&"emote": 3, &"walk": 32, &"text": 48},
+	&"gold": {&"emote": 10, &"walk": 40, &"text": 88},
+	&"silver": {&"emote": 10, &"walk": 40, &"text": 88},
+}
 
 ## `constants/map_constants.asm`, and `Gen2WorldSpawn`'s own group.
 const PLAYERS_HOUSE_1F: int = 6
@@ -28,6 +44,7 @@ const MOM_OBJECT: int = 0
 const APPROACH_CELL := Vector2i(9, 3)
 const TRIGGER_CELL := Vector2i(9, 4)
 
+var _game: StringName = &""
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
 var _capture_frame: int = TRACE_FRAMES
@@ -43,6 +60,7 @@ func _initialize() -> void:
 		quit(1)
 		return
 	var game: StringName = StringName(args[0])
+	_game = game
 	if args.size() > 1:
 		_output_path = args[1]
 	if args.size() > 2:
@@ -72,6 +90,10 @@ func _initialize() -> void:
 	save.world = world.snapshot()
 	_screen.set_data(data)
 	_screen.set_save(save)
+	## The trace owns the clock. Without this the screen spends host frames of
+	## its own before the trace starts, and the row an event lands on moves by
+	## one from run to run.
+	_screen.process_mode = Node.PROCESS_MODE_DISABLED
 	root.add_child(_screen)
 	current_scene = _screen
 
@@ -107,9 +129,6 @@ func _process(_delta: float) -> bool:
 			if node != null:
 				node.visible = false
 		return false
-	# The clock is the trace's, not the renderer's, so the report is the same on
-	# every run.
-	_screen.set_process(false)
 	if not _started:
 		_started = true
 		_screen.move_player(Vector2i(0, 1))
@@ -121,8 +140,38 @@ func _process(_delta: float) -> bool:
 	if _frames < maxi(TRACE_FRAMES, _capture_frame):
 		return false
 	_report()
-	quit(0)
+	quit(0 if _checkpoints_hold() else 1)
 	return true
+
+
+## The first frame each of the three checkpoints appears on, against the pinned
+## row. Reported as a line per checkpoint so a shift names itself.
+func _checkpoints_hold() -> bool:
+	var expected: Dictionary = CHECKPOINTS.get(_game, {})
+	if expected.is_empty():
+		print("no pinned checkpoints for %s" % _game)
+		return true
+	var held: bool = true
+	for name: StringName in [&"emote", &"walk", &"text"]:
+		var at: int = _first_frame(name)
+		var want: int = int(expected[name])
+		if at != want:
+			printerr("%s %s first appears on frame %d, not %d" % [_game, name, at, want])
+			held = false
+	print("%s checkpoints %s" % [_game, "hold" if held else "MOVED"])
+	return held
+
+
+func _first_frame(name: StringName) -> int:
+	for row: Dictionary in _trace:
+		var showing: bool = false
+		match name:
+			&"emote": showing = bool(row["emote"])
+			&"walk": showing = row["mom_offset"] != Vector2.ZERO
+			_: showing = bool(row["text"])
+		if showing:
+			return int(row["frame"])
+	return -1
 
 
 ## Prints only where something changed, which is what makes a stall readable.

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -8166,7 +8166,7 @@ func _push_boulder_run(
 
 ## Spends hardware frames until no object is mid-step. A pushed boulder slides
 ## for STEP_FRAMES_BOULDER_PUSH frames and refuses a second push until it stands
-## again, and advance_object_steps() caps its own catch-up, so this has to tick.
+## again, so this has to spend the frames rather than ask for them at once.
 func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) -> void:
 	for _frame: int in OBJECT_STEP_FRAME_BUDGET:
 		var stepping: bool = false
@@ -8176,7 +8176,7 @@ func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) ->
 				break
 		if not stepping:
 			return
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
 
 
 ## Mahogany Town east to Blackthorn City, on the same world, state and save.
@@ -9151,7 +9151,7 @@ func _drain_phone_ring(world: Gen2WorldAPI) -> Array:
 	for _frame: int in PHONE_RING_FRAME_BUDGET:
 		if not world.phone_ring_active():
 			return []
-		var results: Array = world.advance_phone_ring(Gen2WorldPhoneRing.FRAME_SECONDS)
+		var results: Array = world.advance_phone_ring_frame()
 		if not results.is_empty():
 			return results
 	return []
@@ -9308,7 +9308,7 @@ func _drain_story(
 					last_details = JSON.stringify(plan)
 					break
 				for _frame: int in int(plan.get("emote_frames", 0)):
-					world.tick()
+					world.advance_emotes_frame()
 				var approach_failed: bool = false
 				for path_step: Vector2i in plan.get("path", []):
 					var stepped: Dictionary = world.advance_trainer_approach_step(

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -1,0 +1,262 @@
+extends SceneTree
+
+## Records `(frame, button)` from a run of the real world screen and replays it
+## into a fresh world, then diffs the two worlds.
+##
+##   Godot --headless --path . -s res://tools/replay_world.gd -- [game ...] [frames]
+##
+## A seed, an input log and a frame number should reproduce a world exactly.
+## That is what `Gen2WorldScreen.advance_frame()` is for, and this is the
+## artefact it is proved by: the compared value is `Gen2WorldSnapshot` JSON plus
+## the play timer, which either matches byte for byte or does not.
+##
+## Four runs per route, all from the same seed and the same log:
+##
+## | Run | Driven by | Proves |
+## |---|---|---|
+## | record | `advance_frames`, a generated input program | the log the world consumed |
+## | replay | `advance_frames`, the recorded log | a log alone reproduces the run |
+## | 30 fps | `_process(1/30)`, the recorded log | the pump, not the host, spends frames |
+## | 144 fps | `_process(1/144)` , the recorded log | the same, from the other side |
+##
+## The two `_process` runs top up the last frame or two with `advance_frame()`,
+## because a host slower than the hardware cannot land on every frame; the run is
+## otherwise entirely theirs. They also feed `Gen2WorldClock` real seconds, which
+## is deliberate (`Gen2WorldScreen._advance_day_cycle`), so a route stays under a
+## cartridge minute and the day cycle cannot move under one run and not another.
+
+const GAMES: Array[StringName] = [&"gold", &"silver", &"crystal"]
+## Twenty seconds of hardware frames: long enough for several walks, a script
+## and a wild roll, short enough that no run crosses a clock minute.
+const DEFAULT_FRAMES: int = 1200
+const DIRECTIONS: Array[int] = [
+	Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT
+]
+## `Gen2WorldSpawn`'s own group, whose map numbering is the same on all three
+## cartridges, so one route list sweeps every profile.
+const ROUTE_GROUP: int = Gen2WorldSpawn.NEW_BARK_GROUP
+const ROUTE_MAPS: int = 8
+
+var _failures: int = 0
+var _routes: int = 0
+
+
+func _initialize() -> void:
+	_sweep.call_deferred()
+
+
+## The screen's own nodes do not resolve until the tree has run a frame, so every
+## run waits for one before touching the world it opened.
+func _sweep() -> void:
+	await process_frame
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	var games: Array[StringName] = []
+	var frames: int = DEFAULT_FRAMES
+	for argument: String in args:
+		if argument.is_valid_int():
+			frames = maxi(1, int(argument))
+		else:
+			games.append(StringName(argument))
+	if games.is_empty():
+		games = GAMES
+
+	for game: StringName in games:
+		var data: GameData = GameData.open(game)
+		if data == null:
+			print("%-8s no imported cache, skipped" % game)
+			continue
+		for route: Dictionary in _routes_for(data):
+			_failures += await _check_route(data, route, frames)
+
+	print("%d routes, %d failures" % [_routes, _failures])
+	quit(1 if _failures > 0 else 0)
+
+
+## Every map in the spawn group the cache ships, entered on a cell the cartridge
+## itself warps onto, plus the new game's own spawn. A route list rather than one
+## map, because a walk that never leaves an empty bedroom proves the pump on
+## nothing.
+func _routes_for(data: GameData) -> Array:
+	var out: Array = [{"name": "new_game_spawn", "spawn": true}]
+	for number: int in range(1, ROUTE_MAPS + 1):
+		var map: Gen2WorldMap = data.world_map(ROUTE_GROUP, number)
+		if map == null:
+			continue
+		var warps: Array = map.events.get("warps", [])
+		if warps.is_empty():
+			continue
+		var first: Dictionary = warps[0]
+		out.append({
+			"name": "map_%d_%d" % [ROUTE_GROUP, number],
+			"group": ROUTE_GROUP,
+			"number": number,
+			"cell": Vector2i(int(first.get("x", 0)), int(first.get("y", 0))),
+		})
+	return out
+
+
+func _check_route(data: GameData, route: Dictionary, frames: int) -> int:
+	_routes += 1
+	var failures: int = 0
+	var seed_value: int = _route_seed(data, route)
+	var program: Array = _program(seed_value, frames)
+
+	var recorded: Dictionary = await _run(data, route, seed_value, frames, program, true)
+	if not bool(recorded.get("ok", false)):
+		_report(data, route, "open", String(recorded.get("reason", "unavailable")))
+		return 1
+	var log: Array = recorded["log"]
+	var expected: String = recorded["state"]
+	## A route the input never moved would pass every comparison below on a world
+	## that did nothing, which is the same trap `_drain_story`'s require_events
+	## closes in the story walker.
+	if String(recorded["world"]) == String(recorded["initial"]):
+		_report(data, route, "record", "the run moved no world state, so it proves nothing")
+		return 1
+
+	for label: String in ["replay", "30fps", "144fps"]:
+		var host_fps: float = 0.0
+		if label == "30fps":
+			host_fps = 30.0
+		elif label == "144fps":
+			host_fps = 144.0
+		var run: Dictionary = await _run(data, route, seed_value, frames, log, false, host_fps)
+		if not bool(run.get("ok", false)):
+			_report(data, route, label, String(run.get("reason", "unavailable")))
+			failures += 1
+			continue
+		if String(run["state"]) != expected:
+			_report(data, route, label, _first_difference(expected, String(run["state"])))
+			failures += 1
+			continue
+		if label == "replay" and JSON.stringify(run["log"]) != JSON.stringify(log):
+			_report(data, route, label, "the replay consumed a different log")
+			failures += 1
+			continue
+		print("%-8s %-16s %-7s %d frames, %d input entries" % [
+			data.id, route["name"], label, frames, log.size()
+		])
+	return failures
+
+
+## One run of the real screen. [param host_fps] of zero spends the frames
+## directly; anything else pumps them through `_process` at that rate, which is
+## the whole point of the comparison.
+func _run(
+	data: GameData,
+	route: Dictionary,
+	seed_value: int,
+	frames: int,
+	log: Array,
+	recording: bool,
+	host_fps: float = 0.0,
+) -> Dictionary:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if save == null:
+		screen.free()
+		return {"ok": false, "reason": "no development save"}
+	save.run_seed = seed_value
+	if bool(route.get("spawn", false)):
+		save.world = Gen2WorldSpawn.new_game_snapshot(data)
+	else:
+		screen.map_group = int(route["group"])
+		screen.map_number = int(route["number"])
+		screen.start_cell = route["cell"]
+		save.world = null
+	screen.set_data(data)
+	screen.set_save(save)
+	## The host's frames belong to the host: every frame below is spent by this
+	## tool, so the screen never runs one of its own.
+	screen.process_mode = Node.PROCESS_MODE_DISABLED
+	root.add_child(screen)
+	await process_frame
+	if screen._world == null:
+		var why: String = "%s / %s" % [screen._caption.text, screen._hint.text]
+		root.remove_child(screen)
+		screen.free()
+		return {"ok": false, "reason": why}
+	screen.set_process(false)
+
+	var initial: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
+	screen.replay_input(log)
+	if recording:
+		screen.record_input()
+	if host_fps <= 0.0:
+		screen.advance_frames(frames)
+	else:
+		var delta: float = 1.0 / host_fps
+		var guard: int = frames * 8
+		while screen._world.frame_number < frames - 1 and guard > 0:
+			screen._process(delta)
+			guard -= 1
+		screen.advance_frames(frames - screen._world.frame_number)
+
+	var state: String = _state(screen, save)
+	var world: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
+	var consumed: Array = screen.input_recording()
+	root.remove_child(screen)
+	screen.free()
+	return {
+		"ok": true,
+		"state": state,
+		"initial": initial,
+		"world": world,
+		"log": log if not recording else consumed,
+	}
+
+
+## The compared artefact: the world snapshot the save would carry, the play timer
+## beside it and the frame both are read at.
+func _state(screen: Gen2WorldScreen, save: Gen2SaveData) -> String:
+	return JSON.stringify({
+		"frame": screen._world.frame_number,
+		"game_time": save.game_time.to_dict(),
+		"world": screen._world.snapshot().to_dict(),
+	}, "\t")
+
+
+## The input a run is driven by: a direction held for a while, an occasional A,
+## and nothing else the cartridge's own controller does not have. Deterministic
+## in the route's seed, so the generated program is itself reproducible.
+func _program(seed_value: int, frames: int) -> Array:
+	var random := RandomNumberGenerator.new()
+	random.seed = seed_value
+	var log: Array = []
+	var frame: int = 1
+	while frame <= frames:
+		if random.randi_range(0, 9) == 0:
+			log.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
+			frame += random.randi_range(2, 8)
+			continue
+		var direction: int = DIRECTIONS[random.randi_range(0, DIRECTIONS.size() - 1)]
+		for _held: int in random.randi_range(4, 40):
+			if frame > frames:
+				break
+			log.append({"frame": frame, "kind": "hold", "button": direction})
+			frame += 1
+	return log
+
+
+## `String.hash()` moves by one between two names that differ in their last
+## character, so it is mixed before the low bit is set: without that, every
+## second route on a cartridge draws the seed of the one before it.
+func _route_seed(data: GameData, route: Dictionary) -> int:
+	var mixed: int = ("%s/%s" % [data.id, route["name"]]).hash() * 2654435761
+	return (mixed & 0x7FFFFFFF) | 1
+
+
+func _first_difference(expected: String, actual: String) -> String:
+	var left: PackedStringArray = expected.split("\n")
+	var right: PackedStringArray = actual.split("\n")
+	for line: int in maxi(left.size(), right.size()):
+		var a: String = left[line] if line < left.size() else "<end>"
+		var b: String = right[line] if line < right.size() else "<end>"
+		if a != b:
+			return "line %d: %s != %s" % [line + 1, a.strip_edges(), b.strip_edges()]
+	return "the two states differ in length only"
+
+
+func _report(data: GameData, route: Dictionary, label: String, reason: String) -> void:
+	printerr("%-8s %-16s %-7s FAILED %s" % [data.id, route["name"], label, reason])

--- a/tools/replay_world.gd.uid
+++ b/tools/replay_world.gd.uid
@@ -1,0 +1,1 @@
+uid://c5x0o2ef6avr2

--- a/tools/validate_crystal_route30_trainer.gd
+++ b/tools/validate_crystal_route30_trainer.gd
@@ -135,10 +135,10 @@ func _verify_runtime_flow(data: GameData, trainer_record: Dictionary) -> void:
 		"Joey's shock-emote duration is wrong."
 	)
 	for _frame: int in Gen2WorldAPI.TRAINER_SHOCK_FRAMES - 1:
-		world.tick()
+		world.advance_emotes_frame()
 	_check(joey.emote_visible, "Joey's shock emote ended early.")
-	world.tick()
-	_check(not joey.emote_visible, "Joey's shock emote exceeded 30 frames.")
+	world.advance_emotes_frame()
+	_check(not joey.emote_visible, "Joey's shock emote outlasted its own count.")
 
 	var step: Dictionary = world.advance_trainer_approach_step(
 		TRAINER_OBJECT_INDEX, Vector2i.RIGHT

--- a/tools/validate_gold_route30_trainer.gd
+++ b/tools/validate_gold_route30_trainer.gd
@@ -138,10 +138,10 @@ func _verify_runtime_flow(data: GameData, trainer_record: Dictionary) -> void:
 		"Joey's shock-emote duration is wrong."
 	)
 	for _frame: int in Gen2WorldAPI.TRAINER_SHOCK_FRAMES - 1:
-		world.tick()
+		world.advance_emotes_frame()
 	_check(joey.emote_visible, "Joey's shock emote ended early.")
-	world.tick()
-	_check(not joey.emote_visible, "Joey's shock emote exceeded 30 frames.")
+	world.advance_emotes_frame()
+	_check(not joey.emote_visible, "Joey's shock emote outlasted its own count.")
 
 	var step: Dictionary = world.advance_trainer_approach_step(
 		TRAINER_OBJECT_INDEX, Vector2i.LEFT

--- a/tools/validate_surf.gd
+++ b/tools/validate_surf.gd
@@ -328,7 +328,7 @@ func _verify_swimming_objects(game_id: StringName, data: GameData, crystal: bool
 	random.seed = 17
 	var visited: Dictionary = {lapras.cell: true}
 	for _frame: int in LAPRAS_STEP_FRAME_BUDGET:
-		world.advance_object_steps(Gen2WorldAnimation.FRAME_SECONDS, random)
+		world.advance_object_steps_frame(random)
 		visited[lapras.cell] = true
 	var reached: Array = visited.keys()
 	var expected: Array = allowed.keys()


### PR DESCRIPTION
`Gen2WorldScreen._process` was nine independent readers of `delta` over five accumulators, and two counters were not frame paced at all. It is now one pump: `delta` becomes hardware frames and `advance_frame()` spends exactly one of each. Every `Gen2WorldAPI.advance_*(delta)` is an `advance_*_frame()`, the four accumulators are gone, and `Gen2WorldAnimation`, `Gen2WorldEffects` and `Gen2WorldPhoneRing` count frames rather than seconds.

The trainer approach and the object emote countdown ran at the display's rate and now cost one hardware frame each. `TRAINER_SHOCK_FRAMES` is 60, not 30: `SeenByTrainerScript`'s `showemote EMOTE_SHOCK, LAST_TALKED, 30` is read the way every other `showemote` is, since `ShowEmoteScript`'s `pause 0` spends two frames a unit.

`Gen2WorldAPI` owns a monotonic frame number and the seed its generators were built from; both travel in the snapshot. A save records the seed and the loaded mod list beside its per-mod namespace, so a run names itself. `Gen2WorldClock` stays on real seconds on purpose and says so at the seam: the cartridge reads a real-time clock for the day cycle.

`tools/replay_world.gd` is the artefact. It records `(frame, button)` from a run of the real screen and replays it into a fresh world: 27 routes over the three cartridges reach byte-identical `Gen2WorldSnapshot` JSON from the same seed and log, frame by frame and pumped at 30 fps and at 144.

Also fixed along the way: `preview_mom_scene.gd` let the screen spend two host frames before its trace began, so a checkpoint moved by up to five rows between runs; it now owns every frame and pins the three checkpoints per profile. `Gen2BattleScreen._process` did not cap catch-up, so a stall would have run a second of animation frames in one host frame.