### PR TITLE
world: give Kurt his apricorns, from the bag list to the saved quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   with imported win/loss text, map reloads, save-safe blackout recovery,
 >   object lifecycle, followers, block edits, emotes, surf, ledge hops, grass,
 >   fishing, roaming, repel and wild encounters. The service overlay covers
->   menu selection, mart dialog variants and quantity purchases, source-timed
+>   menu selection, mart dialog variants and quantity purchases, Kurt's Apricorn
+>   errand, source-timed
 >   phone dispatch and bounded music, effects and cries. Everything the overworld
 >   times is a hardware frame count spent by one clock, so a seed, an input log
 >   and a frame number reproduce a walk exactly, on any display.
@@ -286,7 +287,7 @@ all three games unless its row says otherwise:
 
 | Tool | Checks |
 |---|---|
-| `preview_world_services.gd <png>` | mart overlay, deterministic integration cache |
+| `preview_world_services.gd <png> [mart\|apricorn] [presses]` | the mart or Kurt's Apricorn overlay, over a deterministic integration cache. `presses` is a comma-separated button list driven into the overlay before the shot, which is how the second box is photographed |
 | `preview_fishing.gd <png> [game map]` | fishing, for example `silver 2 5`; one-argument form is a fixture smoke test |
 | `preview_intro.gd <game> <png> [copyright\|gender\|speech\|beat] [steps]` | the new game's opening screens at hardware resolution: the copyright screen by source frame, the gender question, and any frame of `OakSpeech` by source frame or by button press, so a fade or a pic move can be looked at one frame at a time |
 | `preview_mom_scene.gd <game> [png] [frame]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up. The frames the emote, the walk and the box first appear on are pinned per profile, so a run that moves one exits non-zero. `frame` picks which one the `png` is of |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -117,7 +117,11 @@ than a text one, and `trainer_card_screen.gd` colours it through
 `world_pack.gd` groups owned items into the four cartridge pockets by the item
 type byte `GameData` imports under the confusingly-named `pocket` field. It is
 presentation only: item counts stay a flat map on `Gen2WorldState` and pocket
-capacities are not enforced. `start_menu_screen.gd` is the overlay, owning Pack,
+capacities are not enforced. `world_apricorn.gd` is `SelectApricornForKurt`'s
+own state machine over `FindApricornsInBag`, and `world_quantity_prompt.gd` is
+`BuySellToss_InterpretJoypad`, the dial every source quantity box shares;
+`world_apricorn_host.gd` takes the apricorns through the same validated
+candidate save the mart buys through. `start_menu_screen.gd` is the overlay, owning Pack,
 a Save confirmation and the OPTION menu as internal modes the way
 `world_service_screen.gd` owns a mart mode, and delegating Pokemon and Pokegear
 to the existing screens. `Gen2PartyScreen` and `Gen2BoxScreen` share one

--- a/game/world/world_apricorn.gd
+++ b/game/world/world_apricorn.gd
@@ -1,0 +1,191 @@
+class_name Gen2WorldApricorn
+extends RefCounted
+
+## `SelectApricornForKurt` (`engine/events/kurt.asm`) as a scene-free state
+## machine: `FindApricornsInBag`'s list, `Kurt_SelectApricorn`'s scrolling menu,
+## and the loop that puts the player back on the list when
+## `Kurt_SelectQuantity` is backed out of. The screen owns the two boxes; this
+## owns the cursor and the answer. [Gen2WorldApricornHost] owns the transaction.
+
+## `data/items/apricorn_balls.asm`. Kurt's list order is this table's, not the
+## item numbers'. The second column is the ball each apricorn becomes, which is
+## what `KurtsHouse.asm`'s seven `verbosegiveitemvar` branches hand back.
+## Both columns hold the same numbers on all three cartridges.
+const APRICORN_BALLS: Array[Array] = [
+	[0x55, 0x9F], # RED, LEVEL_BALL
+	[0x59, 0xA0], # BLU, LURE_BALL
+	[0x5C, 0xA5], # YLW, MOON_BALL
+	[0x5D, 0xA4], # GRN, FRIEND_BALL
+	[0x61, 0xA1], # WHT, FAST_BALL
+	[0x63, 0x9D], # BLK, HEAVY_BALL
+	[0x65, 0xA6], # PNK, LOVE_BALL
+]
+
+## `Kurt_GetQuantityOfApricorn`'s own ceiling, which is not the pocket's.
+const MAX_QUANTITY: int = 99
+
+## `.MenuData`'s `db 4, 7`: four visible rows, seven characters to the quantity
+## column. Only the height decides selection.
+const MENU_HEIGHT: int = 4
+
+const SELECT_APRICORN: StringName = &"select_apricorn"
+const SELECT_QUANTITY: StringName = &"select_quantity"
+const DONE: StringName = &"done"
+
+var entries: Array = []
+## `wMenuScrollPosition`, which `SelectApricornForKurt` zeroes once and then
+## leaves alone, so a backed-out quantity reopens the list where it was.
+var scroll: int = 0
+## `wMenuCursorY`, the 1-based row inside the window rather than an index.
+var cursor_y: int = 1
+var phase: StringName = DONE
+var prompt: Gen2WorldQuantityPrompt = null
+var selected_item: int = 0
+var selected_quantity: int = 0
+
+
+static func open(data: GameData, state: Gen2WorldState) -> Gen2WorldApricorn:
+	var selection := Gen2WorldApricorn.new()
+	selection.entries = find_in_bag(data, state)
+	## `FindApricornsInBag` returns carry on an empty list, which
+	## `Kurt_SelectApricorn` turns into the same zero a B press gives.
+	if not selection.entries.is_empty():
+		selection._open_list(1)
+	return selection
+
+
+## `FindApricornsInBag` (`engine/menus/menu_2.asm`): the `ApricornBalls` table
+## filtered by `CheckItem`, in table order.
+static func find_in_bag(data: GameData, state: Gen2WorldState) -> Array:
+	var out: Array = []
+	if data == null or state == null:
+		return out
+	for row: Array in APRICORN_BALLS:
+		var item: int = int(row[0])
+		if state.item_quantity(item) <= 0:
+			continue
+		out.append({
+			"item": item,
+			"ball": int(row[1]),
+			"name": data.item_name(item),
+			"quantity": quantity_of(state, item),
+		})
+	return out
+
+
+## `Kurt_GetQuantityOfApricorn`. The source walks every stack of the item and
+## clamps the total; the flat item model holds one stack, so only the clamp is
+## left. See HANDOFF's item-stack divergence.
+static func quantity_of(state: Gen2WorldState, item: int) -> int:
+	if state == null:
+		return 0
+	return mini(state.item_quantity(item), MAX_QUANTITY)
+
+
+static func is_apricorn(item: int) -> bool:
+	for row: Array in APRICORN_BALLS:
+		if int(row[0]) == item:
+			return true
+	return false
+
+
+func is_done() -> bool:
+	return phase == DONE
+
+
+## The visible rows `ScrollingMenu_InitFlags` asks `_2DMenu` for: the window's
+## own height, or the whole list plus the CANCEL row when it is shorter.
+func rows() -> int:
+	return MENU_HEIGHT if MENU_HEIGHT <= entries.size() else entries.size() + 1
+
+
+## `ScrollingMenu_GetListItemCoordAndFunctionArgs`' index. An index at or past
+## the list is the `-1` the item buffer is filled with, drawn as CANCEL.
+func selected_index() -> int:
+	return scroll + cursor_y - 1
+
+
+func selected_entry() -> Dictionary:
+	var index: int = selected_index()
+	return entries[index] if index >= 0 and index < entries.size() else {}
+
+
+func press(button: int) -> void:
+	match phase:
+		SELECT_APRICORN:
+			_press_list(button)
+		SELECT_QUANTITY:
+			_press_quantity(button)
+
+
+## The answer `wScriptVar` and `wKurtApricornQuantity` carry once the special
+## returns. Backing out of either box is `wScriptVar = 0`.
+func result() -> Dictionary:
+	return {"item": selected_item, "quantity": selected_quantity}
+
+
+func _press_list(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			## `_2DMenu` moves inside the window and hands the edge to
+			## `ScrollingMenuJoyAction`, which scrolls instead of wrapping.
+			if cursor_y > 1:
+				cursor_y -= 1
+			elif scroll > 0:
+				scroll -= 1
+		Gen2Button.DOWN:
+			if cursor_y < rows():
+				cursor_y += 1
+			elif scroll + MENU_HEIGHT <= entries.size():
+				scroll += 1
+		Gen2Button.A:
+			var entry: Dictionary = selected_entry()
+			if entry.is_empty():
+				_cancel()
+				return
+			selected_item = int(entry.get("item", 0))
+			var available: int = int(entry.get("quantity", 0))
+			## `Kurt_SelectQuantity` leaves without carry when the bag holds
+			## none, which is the same path a backed-out box takes.
+			if available <= 0:
+				_open_list(cursor_y)
+				return
+			prompt = Gen2WorldQuantityPrompt.open(available)
+			phase = SELECT_QUANTITY
+		Gen2Button.B:
+			_cancel()
+
+
+func _press_quantity(button: int) -> void:
+	if prompt == null:
+		_cancel()
+		return
+	match prompt.press(button):
+		Gen2WorldQuantityPrompt.CONFIRMED:
+			selected_quantity = prompt.value
+			prompt = null
+			phase = DONE
+		Gen2WorldQuantityPrompt.CANCELLED:
+			prompt = null
+			_open_list(cursor_y)
+
+
+## `InitScrollingMenuCursor` then `ScrollingMenu_InitFlags`' cursor placement,
+## over the row `SelectApricornForKurt` carries back into `wMenuSelection`.
+func _open_list(position: int) -> void:
+	var end: int = entries.size() + 1
+	if end < MENU_HEIGHT + scroll:
+		scroll = maxi(0, end - MENU_HEIGHT)
+	var next_position: int = position
+	if end < scroll + next_position:
+		scroll = 0
+		next_position = 1
+	cursor_y = next_position if next_position >= 1 and next_position <= rows() else 1
+	phase = SELECT_APRICORN
+
+
+func _cancel() -> void:
+	selected_item = 0
+	selected_quantity = 0
+	prompt = null
+	phase = DONE

--- a/game/world/world_apricorn.gd.uid
+++ b/game/world/world_apricorn.gd.uid
@@ -1,0 +1,1 @@
+uid://deqsk7b55nwsd

--- a/game/world/world_apricorn_host.gd
+++ b/game/world/world_apricorn_host.gd
@@ -1,0 +1,111 @@
+class_name Gen2WorldApricornHost
+extends RefCounted
+
+## `Kurt_GiveUpSelectedQuantityOfSelectedApricorn` (`engine/events/kurt.asm`) as
+## a validated candidate-save transaction. The selection itself is
+## [Gen2WorldApricorn]; this only takes the apricorns and resumes the script.
+##
+## The source routine collects every bag stack of the item, sorts them and
+## empties them in turn ("Compatible with multiple stacks"). The flat item model
+## holds one stack per item, so the walk collapses to a single `Kurt_GetRidOfItem`.
+## HANDOFF's item-stack divergence covers it.
+
+static func complete_runtime_request(
+	world: Gen2WorldAPI,
+	result: Dictionary,
+	save: Gen2SaveData = null,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return _failure(&"missing_world", {})
+	var item: int = int(result.get("item", 0))
+	var quantity: int = int(result.get("quantity", 0))
+	if item == 0:
+		return _resume(world, {"ok": true, "item": 0, "quantity": 0})
+	if not Gen2WorldApricorn.is_apricorn(item):
+		return _failure(&"invalid_apricorn", {"item": item})
+	if quantity < 1 or quantity > Gen2WorldApricorn.quantity_of(world.state, item):
+		return _failure(&"invalid_apricorn_quantity", {
+			"item": item, "quantity": quantity,
+			"owned": world.state.item_quantity(item),
+		})
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {item: world.state.item_quantity(item) - quantity},
+	})
+	if not bool(applied.get("ok", false)):
+		return _failure(&"apricorn_state_failed", applied)
+	var resumed: Dictionary = _resume(world, {
+		"ok": true, "item": item, "quantity": quantity,
+	})
+	if not bool(resumed.get("ok", false)):
+		world.state.restore_from_dict(before.world_state.to_dict())
+		return resumed
+	if save == null:
+		return resumed
+	var committed: Dictionary = _commit(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return resumed
+
+
+## The same boundary every party- or bag-owned transaction here commits through:
+## validate the save, rebuild it around the resumed world and write it, putting
+## the live state back when any of the three refuses.
+static func _commit(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	before: Gen2WorldSnapshot,
+	persist: bool
+) -> Dictionary:
+	var validation: Dictionary = Gen2SaveValidator.validate(save, world.data)
+	if not bool(validation.get("ok", false)):
+		world.state.restore_from_dict(before.world_state.to_dict())
+		return _failure(&"invalid_save", {"message": validation.get("message", "")})
+	var candidate: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	candidate.world = world.snapshot()
+	var candidate_validation: Dictionary = Gen2SaveValidator.validate(candidate, world.data)
+	if not bool(candidate_validation.get("ok", false)):
+		world.state.restore_from_dict(before.world_state.to_dict())
+		return _failure(&"candidate_save_invalid", candidate_validation)
+	if persist:
+		var write_result: Dictionary = Gen2SaveStore.save(candidate, world.data)
+		if not bool(write_result.get("ok", false)):
+			world.state.restore_from_dict(before.world_state.to_dict())
+			return _failure(&"save_failed", write_result)
+	_copy_save(save, candidate)
+	return {"ok": true}
+
+
+static func _resume(world: Gen2WorldAPI, completion: Dictionary) -> Dictionary:
+	var resumed: Array = world.complete_runtime_request(completion)
+	if resumed.is_empty() or not bool(resumed[0].get("ok", false)):
+		return _failure(&"apricorn_request_failed", {"results": resumed})
+	return {
+		"ok": true,
+		"handled": true,
+		"item": int(completion.get("item", 0)),
+		"quantity": int(completion.get("quantity", 0)),
+		"results": resumed,
+	}
+
+
+static func _copy_save(target: Gen2SaveData, source: Gen2SaveData) -> void:
+	target.format_version = source.format_version
+	target.game_id = source.game_id
+	target.rom_sha1 = source.rom_sha1
+	target.slot = source.slot
+	target.player_name = source.player_name
+	target.party = source.party.duplicate(true)
+	target.boxes = source.boxes
+	target.world = source.world
+
+
+static func _failure(reason: StringName, details: Dictionary) -> Dictionary:
+	return {
+		"ok": false,
+		"handled": false,
+		"status": &"host_unavailable",
+		"reason": reason,
+		"details": details.duplicate(true),
+	}

--- a/game/world/world_apricorn_host.gd.uid
+++ b/game/world/world_apricorn_host.gd.uid
@@ -1,0 +1,1 @@
+uid://cgwyhjh8xtyvk

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -26,6 +26,8 @@ static func complete_runtime_request(
 		)
 	if kind == &"party_heal_requested":
 		return Gen2WorldPartyHost.heal_party(world, save, persist)
+	if kind == &"apricorn_selection_requested":
+		return Gen2WorldApricornHost.complete_runtime_request(world, result, save, persist)
 	if kind == &"rival_name_requested":
 		var completion: Dictionary = {"ok": true}
 		for key: Variant in result:
@@ -132,6 +134,8 @@ static func _reason_for(kind: StringName) -> StringName:
 			return &"party_host_unavailable"
 		&"town_map_requested":
 			return &"town_map_host_unavailable"
+		&"apricorn_selection_requested":
+			return &"apricorn_data_unavailable"
 	return &"runtime_host_unavailable"
 
 
@@ -157,6 +161,15 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 				"data": {
 					"mart": mart_result["mart"], "mart_id": mart_id,
 					"dialog": dialog_id,
+				},
+			}
+		&"apricorn_selection_requested":
+			## `FindApricornsInBag` is the whole of the request's data: an empty
+			## bag is the source's own refusal, not a missing host.
+			return {
+				"ok": true,
+				"data": {
+					"apricorns": Gen2WorldApricorn.find_in_bag(world.data, world.state),
 				},
 			}
 		&"special_phone_call_requested":

--- a/game/world/world_quantity_prompt.gd
+++ b/game/world/world_quantity_prompt.gd
@@ -1,0 +1,68 @@
+class_name Gen2WorldQuantityPrompt
+extends RefCounted
+
+## `BuySellToss_InterpretJoypad` (`engine/items/buy_sell_toss.asm`), the dial
+## every source quantity prompt reads its joypad through. It owns
+## `wItemQuantity` (the ceiling) and `wItemQuantityChange` (the shown value) and
+## nothing else; the caller owns the box the number is drawn in.
+##
+## `Kurt_SelectQuantity` is the first caller here. `SelectQuantityToToss` and the
+## mart's own prompt are the same routine over their own headers, so the pack's
+## TOSS needs this model and a box rather than a second dial.
+
+const PAGE_STEP: int = 10
+
+const PENDING: StringName = &"pending"
+const CONFIRMED: StringName = &"confirmed"
+const CANCELLED: StringName = &"cancelled"
+
+## `wItemQuantity`, the ceiling the caller loaded before opening the box.
+var maximum: int = 1
+## `wItemQuantityChange`, which every caller opens on 1.
+var value: int = 1
+
+
+static func open(available: int) -> Gen2WorldQuantityPrompt:
+	var prompt := Gen2WorldQuantityPrompt.new()
+	prompt.maximum = maxi(1, available)
+	prompt.value = 1
+	return prompt
+
+
+func press(button: int) -> StringName:
+	match button:
+		Gen2Button.A:
+			return CONFIRMED
+		Gen2Button.B:
+			return CANCELLED
+		Gen2Button.UP:
+			_step_up()
+		Gen2Button.DOWN:
+			_step_down()
+		Gen2Button.LEFT:
+			_page_down()
+		Gen2Button.RIGHT:
+			_page_up()
+	return PENDING
+
+
+## `.down` decrements, and the byte reaching zero is what wraps it to the
+## ceiling rather than a comparison against 1.
+func _step_down() -> void:
+	value -= 1
+	if value == 0:
+		value = maximum
+
+
+func _step_up() -> void:
+	value += 1
+	if value > maximum:
+		value = 1
+
+
+func _page_down() -> void:
+	value = 1 if value - PAGE_STEP <= 0 else value - PAGE_STEP
+
+
+func _page_up() -> void:
+	value = mini(value + PAGE_STEP, maximum)

--- a/game/world/world_quantity_prompt.gd.uid
+++ b/game/world/world_quantity_prompt.gd.uid
@@ -1,0 +1,1 @@
+uid://ciw8vqxfvk7po

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2272,6 +2272,7 @@ func _show_script_results(results: Array) -> void:
 				if StringName(request.get("kind", &"")) in [
 					&"mart_requested", &"phone_call_requested",
 					&"special_phone_call_requested", &"town_map_requested",
+					&"apricorn_selection_requested",
 				]:
 					_open_service_host()
 					break

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -31,6 +31,8 @@ var _staged_swarm: Dictionary = {}
 var _has_staged_swarm: bool = false
 var _has_staged_special_phone_call: bool = false
 var _staged_special_phone_call: int = 0
+var _has_staged_kurt_apricorn_quantity: bool = false
+var _staged_kurt_apricorn_quantity: int = 0
 var _reset_phone_receive_timer: bool = false
 var _events: Array = []
 var _pending: Dictionary = {}
@@ -105,6 +107,10 @@ const SPECIAL_SNORLAX_AWAKE: int = 96
 const SNORLAX_PROXIMITY_CELLS: Array[Vector2i] = [
 	Vector2i(33, 8), Vector2i(34, 10), Vector2i(35, 10), Vector2i(36, 8), Vector2i(36, 9),
 ]
+## SelectApricornForKurt, 86 in Crystal and 85 in Gold/Silver, which
+## special_index() already normalizes. maps/KurtsHouse.asm's `.AskApricorn`
+## branches on wScriptVar afterwards, one label per apricorn.
+const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
 const SPECIAL_RANDOM_UNSEEN_WILD_MON: int = 91
 const SPECIAL_RANDOM_PHONE_WILD_MON: int = 92
 const SPECIAL_RANDOM_PHONE_MON: int = 93
@@ -595,6 +601,33 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 			int(phone_script.get("bank", -1)), int(phone_script.get("address", -1))
 		):
 			return _fail(&"phone_script_missing", phone_script)
+		return advance()
+	if kind == &"apricorn_selection_requested":
+		if not bool(result.get("ok", false)):
+			return _fail(
+				StringName(result.get("reason", &"apricorn_selection_failed")), result
+			)
+		var apricorn: int = int(result.get("item", 0))
+		var apricorn_quantity: int = int(result.get("quantity", 0))
+		if apricorn != 0 and not Gen2WorldApricorn.is_apricorn(apricorn):
+			return _fail(&"invalid_apricorn", result)
+		## `SelectApricornForKurt` zeroes wKurtApricornQuantity on entry and
+		## writes it only past `Kurt_SelectQuantity`'s carry, so a cancelled
+		## selection leaves both bytes at zero.
+		if apricorn == 0:
+			apricorn_quantity = 0
+		elif apricorn_quantity < 1 or apricorn_quantity > Gen2WorldApricorn.MAX_QUANTITY:
+			return _fail(&"invalid_apricorn_quantity", result)
+		_script_value = apricorn
+		_staged_kurt_apricorn_quantity = apricorn_quantity
+		_has_staged_kurt_apricorn_quantity = true
+		_events.append({
+			"type": &"runtime_request_completed",
+			"kind": kind,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
 		return advance()
 	if kind == &"trainer_approach_requested":
 		if not bool(result.get("ok", false)):
@@ -1885,14 +1918,10 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 		0x14: # VAR_SPECIALPHONECALL
 			_script_value = _current_special_phone_call()
 		0x16: # VAR_KURT_APRICORNS
-			## _GetVarAction reads wKurtApricornQuantity. SelectApricornForKurt is
-			## the writer; its host mirrors that byte on the invocation request.
-			if not _request.has("kurt_apricorn_quantity"):
-				return {
-					"ok": false, "reason": &"missing_kurt_apricorn_quantity",
-					"variable": variable,
-				}
-			_script_value = clampi(int(_request["kurt_apricorn_quantity"]), 0, 0xFF)
+			## _GetVarAction reads wKurtApricornQuantity, saved player data whose
+			## only writer is SelectApricornForKurt. A selection made inside this
+			## invocation shadows the committed byte, as the WRAM write does.
+			_script_value = _kurt_apricorn_quantity()
 		0x17: # VAR_CALLERID
 			_script_value = int(_phone_context.get("caller_id", -1))
 		_:
@@ -1945,6 +1974,14 @@ func _current_special_phone_call() -> int:
 		if int(request_value) != 0:
 			return int(request_value)
 	return state.pending_special_phone_call() if state != null else 0
+
+
+func _kurt_apricorn_quantity() -> int:
+	if _has_staged_kurt_apricorn_quantity:
+		return _staged_kurt_apricorn_quantity
+	if _request.has("kurt_apricorn_quantity"):
+		return clampi(int(_request["kurt_apricorn_quantity"]), 0, 0xFF)
+	return state.kurt_apricorn_quantity() if state != null else 0
 
 
 func _clock_hour() -> int:
@@ -2074,6 +2111,13 @@ func _execute_special(special: int) -> Dictionary:
 			_emit_runtime_event(&"roaming_mons_initialized", {
 				"special": special,
 				"count": state.roaming_mons().size() if state != null else 0,
+			})
+		SPECIAL_SELECT_APRICORN_FOR_KURT:
+			## Both of the special's boxes are the host's; it answers with the
+			## chosen apricorn and how many of it, and a backed-out box is the
+			## source's own `wScriptVar = 0`.
+			return _stage_runtime_request(&"apricorn_selection_requested", {
+				"special": special,
 			})
 		SPECIAL_ACTIVATE_FISHING_SWARM:
 			_emit_runtime_event(&"phone_special_requested", {
@@ -3021,6 +3065,8 @@ func _complete() -> Dictionary:
 		runtime_changes["swarm"] = _staged_swarm.duplicate()
 	if _has_staged_special_phone_call:
 		runtime_changes["pending_special_phone_call"] = _staged_special_phone_call
+	if _has_staged_kurt_apricorn_quantity:
+		runtime_changes["kurt_apricorn_quantity"] = _staged_kurt_apricorn_quantity
 	if not _staged_engine_flags.is_empty():
 		runtime_changes["engine_flags"] = _staged_engine_flags.duplicate()
 	if _reset_phone_receive_timer:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -16,7 +16,7 @@ const ACCENT: Color = Color("#f3c969")
 const SUCCESS: Color = Color("#7bd89a")
 const ERROR: Color = Color("#ef8a8a")
 
-enum MODE { MENU, MART, PHONE, PHONE_LIST, AUDIO, POKEGEAR, RADIO, TOWN_MAP, CLOCK }
+enum MODE { MENU, MART, PHONE, PHONE_LIST, AUDIO, POKEGEAR, RADIO, TOWN_MAP, CLOCK, APRICORN }
 
 ## engine/pokegear/pokegear.asm's card order. Each is behind its own
 ## wPokegearFlags bit, named here by the engine flag that carries it, since that
@@ -44,6 +44,7 @@ var _cursor: int = 0
 var _mart_entries: Array = []
 var _mart_quantity: int = 1
 var _mart_purchased: bool = false
+var _apricorns: Gen2WorldApricorn = null
 var _phone_entries: Array = []
 var _pokegear_cards: Array = []
 var _town_map: Gen2TownMapScreen = null
@@ -104,6 +105,9 @@ func open_pending(
 		&"audio_requested":
 			_open_audio(request, resolved.get("data", {}).get("audio", {}))
 			return true
+		&"apricorn_selection_requested":
+			_open_apricorns()
+			return true
 	_show_error("No scene host for %s." % String(request.get("kind", "request")))
 	return false
 
@@ -162,6 +166,9 @@ func open_pokegear(
 func handle_button(button: int) -> bool:
 	if not is_active():
 		return false
+	if _mode == MODE.APRICORN:
+		_press_apricorns(button)
+		return true
 	if Gen2Button.is_direction(button):
 		_move_direction(Gen2Button.vector(button))
 		return true
@@ -248,6 +255,69 @@ func _open_mart(mart: Dictionary) -> void:
 		else "Select an item. Left and right change the quantity."
 	_footer.text = "D-pad: move and quantity    A: buy    B: leave"
 	_render_options()
+
+
+## `SelectApricornForKurt`'s two boxes. The model owns both cursors and the loop
+## between them, so this only draws whichever one it is on.
+func _open_apricorns() -> void:
+	_mode = MODE.APRICORN
+	_apricorns = Gen2WorldApricorn.open(_world.data, _world.state)
+	_title.text = "APRICORNS"
+	if _apricorns.is_done():
+		## FindApricornsInBag's own refusal. Kurt only asks with one in the bag,
+		## so this is the guard rather than a branch a player reaches.
+		_finish_apricorns()
+		return
+	_render_apricorns()
+
+
+func _render_apricorns() -> void:
+	if _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY:
+		_cursor = 0
+		var chosen: Dictionary = _apricorns.selected_entry()
+		_summary.text = "How many should I make?"
+		## `PlaceApricornQuantity` draws the name and `×NN` under it; the
+		## ceiling is this host's own, since nothing here draws a bag page.
+		_status.text = "x%d    of %d" % [
+			_apricorns.prompt.value, _apricorns.prompt.maximum,
+		]
+		_status.add_theme_color_override("font_color", TEXT)
+		_footer.text = "Up/down: one    Left/right: ten    A: give    B: back"
+		_render_options([String(chosen.get("name", ""))])
+		return
+	_summary.text = "Which APRICORN should I use?"
+	_status.text = ""
+	_footer.text = "D-pad: move    A: choose    B: leave"
+	_render_options(_apricorn_rows())
+
+
+## The four-row window the scrolling menu shows, CANCEL included when the list
+## is short enough for it. `_cursor` is the row inside that window.
+func _apricorn_rows() -> Array:
+	var rows: Array = []
+	for row: int in _apricorns.rows():
+		var index: int = _apricorns.scroll + row
+		if index >= _apricorns.entries.size():
+			rows.append("CANCEL")
+			break
+		var entry: Dictionary = _apricorns.entries[index]
+		rows.append("%-12s x%2d" % [String(entry.get("name", "")), int(entry.get("quantity", 0))])
+	_cursor = _apricorns.cursor_y - 1
+	return rows
+
+
+func _press_apricorns(button: int) -> void:
+	_apricorns.press(button)
+	if _apricorns.is_done():
+		_finish_apricorns()
+		return
+	_render_apricorns()
+
+
+func _finish_apricorns() -> void:
+	var answer: Dictionary = _apricorns.result()
+	_apricorns = null
+	_finish_runtime({"ok": true, "item": answer["item"], "quantity": answer["quantity"]})
 
 
 func _open_phone(request: Dictionary, data: Dictionary) -> void:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -43,6 +43,10 @@ const ENGINE_ROCKETS_IN_RADIO_TOWER: int = 19
 const ENGINE_ROCKETS_IN_RADIO_TOWER_GOLD_SILVER: int = 18
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 86
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER: int = 85
+## The first entry in the same `wDailyFlags1` byte. `KurtsHouse.asm` sets it
+## when the apricorns are handed over and reads it to decide whether the ball is
+## ready, so the day boundary is the whole of the errand's wait.
+const ENGINE_KURT_MAKING_BALLS: int = 80
 
 ## wBikeFlags' BIKEFLAGS_STRENGTH_ACTIVE_F, three engine flags ahead of the badge
 ## section and so profile split the same way. Nothing in the pinned engine/ or
@@ -127,6 +131,10 @@ var _last_dex_mode: int = RomLayout.DEXMODE_NEW
 ## wDecoBed, wDecoCarpet, wDecoPlant and wDecoPoster. Values are decoration
 ## ids from data/decorations/decorations.asm, not the blocks they stamp.
 var _maptile_decorations: Dictionary = {}
+## `wKurtApricornQuantity`. Saved player data, not scratch: `SelectApricornForKurt`
+## writes it and `VAR_KURT_APRICORNS` is read a day later, by a different script
+## invocation, to size the balls Kurt hands back.
+var _kurt_apricorn_quantity: int = 0
 
 
 func _init(
@@ -222,6 +230,7 @@ func to_dict() -> Dictionary:
 		"radio_channel": _radio_channel,
 		"last_dex_mode": _last_dex_mode,
 		"maptile_decorations": _maptile_decorations.duplicate(),
+		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
 	}
 
 
@@ -259,6 +268,7 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored.set_radio_knob(int(source.get("radio_knob", Gen2WorldRadio.KNOB_MIN)))
 	restored._radio_channel = int(source.get("radio_channel", -1))
 	restored.set_last_dex_mode(int(source.get("last_dex_mode", RomLayout.DEXMODE_NEW)))
+	restored.set_kurt_apricorn_quantity(int(source.get("kurt_apricorn_quantity", 0)))
 	return restored
 
 
@@ -292,6 +302,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_radio_channel = restored._radio_channel
 	_last_dex_mode = restored._last_dex_mode
 	_maptile_decorations = restored._maptile_decorations.duplicate()
+	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
 	changed.emit()
 
 
@@ -387,7 +398,9 @@ func set_hall_of_fame(active: bool = true) -> void:
 ## numbers were written against; pass [method is_crystal_profile] with the
 ## active GameData. Defaults to Crystal, matching every existing caller.
 func bargain_merchant_closed(crystal: bool = true) -> bool:
-	return is_engine_flag_active(_merchant_closed_flag(crystal))
+	return is_engine_flag_active(
+		engine_flag(ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED, crystal)
+	)
 
 
 ## The engine flag one badge occupies on the table [param crystal] selects,
@@ -441,9 +454,21 @@ func badge_mask(crystal: bool = true) -> int:
 
 ## Clears only source daily engine flags. Story flags such as Hall of Fame
 ## survive the day boundary.
+##
+## `CheckDailyResetTimer` (`engine/overworld/time.asm`) zeroes the whole
+## `wDailyFlags1` byte, so every flag in it goes together. Listed by Crystal
+## index because only the ones this project writes are modelled; add a flag
+## here as soon as something sets it, or it survives the day the cartridge
+## clears it on.
+const DAILY_ENGINE_FLAGS: Array[int] = [
+	ENGINE_KURT_MAKING_BALLS, ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED,
+]
+
+
 func reset_daily_flags(crystal: bool = true) -> bool:
 	var did_change: bool = false
-	for flag: int in [_merchant_closed_flag(crystal)]:
+	for crystal_index: int in DAILY_ENGINE_FLAGS:
+		var flag: int = engine_flag(crystal_index, crystal)
 		if not _engine_flags.has(flag):
 			continue
 		_engine_flags.erase(flag)
@@ -451,11 +476,6 @@ func reset_daily_flags(crystal: bool = true) -> bool:
 	if did_change:
 		changed.emit()
 	return did_change
-
-
-func _merchant_closed_flag(crystal: bool) -> int:
-	return ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED if crystal \
-		else ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
 
 
 ## True unless [param data] is a verified Gold or Silver cache, matching
@@ -678,6 +698,18 @@ func set_repel_steps(steps: int) -> void:
 	if next_steps == _repel_steps:
 		return
 	_repel_steps = next_steps
+	changed.emit()
+
+
+func kurt_apricorn_quantity() -> int:
+	return _kurt_apricorn_quantity
+
+
+func set_kurt_apricorn_quantity(quantity: int) -> void:
+	var next_quantity: int = clampi(quantity, 0, 0xFF)
+	if next_quantity == _kurt_apricorn_quantity:
+		return
+	_kurt_apricorn_quantity = next_quantity
 	changed.emit()
 
 
@@ -957,6 +989,11 @@ func apply_changes(
 	var next_repel_steps: int = int(runtime_changes.get("repel_steps", _repel_steps))
 	if next_repel_steps < 0:
 		return {"ok": false, "reason": &"invalid_repel_steps"}
+	var next_kurt_apricorns: int = int(
+		runtime_changes.get("kurt_apricorn_quantity", _kurt_apricorn_quantity)
+	)
+	if next_kurt_apricorns < 0 or next_kurt_apricorns > 0xFF:
+		return {"ok": false, "reason": &"invalid_kurt_apricorn_quantity"}
 	var seen_changes: Dictionary = runtime_changes.get("seen_species", {})
 	if not seen_changes is Dictionary:
 		return {"ok": false, "reason": &"invalid_seen_species"}
@@ -1059,7 +1096,8 @@ func apply_changes(
 		or next_receive_cycle != _phone_receive_cycle \
 		or next_receive_minutes != _phone_receive_minutes \
 		or next_special_phone_call != _pending_special_phone_call \
-		or next_script_memory != _script_memory
+		or next_script_memory != _script_memory \
+		or next_kurt_apricorns != _kurt_apricorn_quantity
 	_event_flags = next_flags
 	_engine_flags = next_engine_flags
 	_map_scenes = next_scenes
@@ -1077,6 +1115,7 @@ func apply_changes(
 	_phone_receive_minutes = next_receive_minutes
 	_pending_special_phone_call = next_special_phone_call
 	_script_memory = next_script_memory
+	_kurt_apricorn_quantity = next_kurt_apricorns
 	if did_change:
 		changed.emit()
 	return {"ok": true, "changed": did_change}

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -6,6 +6,9 @@ extends GutTest
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
+const APRICORN_RED: int = 0x55
+const APRICORN_BLU: int = 0x59
+
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
 
@@ -23,13 +26,13 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory())
 
 
-func _open_world() -> void:
+func _open_world(items: Dictionary = {7: 1}) -> void:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
 	_world_screen.map_number = Fixture.MAP_NUMBER
 	_world_screen.start_cell = Vector2i(7, 6)
-	var state := Gen2WorldState.new({}, {}, {7: 1}, {0: 500})
+	var state := Gen2WorldState.new({}, {}, items, {0: 500})
 	var world := Gen2WorldAPI.open(
 		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6), state
 	)
@@ -393,6 +396,53 @@ func _write_phone_request() -> void:
 
 func _write_audio_request() -> void:
 	_write_request_script([0x7F, 0x00, 0x40, 0x91], 0x6320)
+
+
+func _write_apricorn_request() -> void:
+	_write_request_script([
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_SELECT_APRICORN_FOR_KURT, 0x00,
+		Gen2WorldScript.END,
+	], 0x6320)
+
+
+func test_apricorn_overlay_gives_kurt_the_chosen_quantity_and_resumes() -> void:
+	_write_apricorn_request()
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world({APRICORN_RED: 4, APRICORN_BLU: 2})
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_eq(host._title.text, "APRICORNS")
+	assert_true(host.handle_button(Gen2Button.DOWN))
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.UP))
+	assert_true(host.handle_button(Gen2Button.A))
+	await get_tree().process_frame
+
+	assert_null(_world_screen._service_host)
+	assert_false(_world_screen._world.script_input_waiting())
+	assert_eq(_world_screen._world.state.item_quantity(APRICORN_BLU), 0)
+	assert_eq(_world_screen._world.state.item_quantity(APRICORN_RED), 4)
+	assert_eq(_world_screen._world.state.kurt_apricorn_quantity(), 2)
+
+
+func test_apricorn_overlay_cancel_takes_nothing_and_resumes() -> void:
+	_write_apricorn_request()
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world({APRICORN_RED: 4})
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_true(host.handle_button(Gen2Button.B))
+	await get_tree().process_frame
+
+	assert_null(_world_screen._service_host)
+	assert_false(_world_screen._world.script_input_waiting())
+	assert_eq(_world_screen._world.state.item_quantity(APRICORN_RED), 4)
+	assert_eq(_world_screen._world.state.kurt_apricorn_quantity(), 0)
 
 
 func _write_request_script(script: Array, address: int) -> void:

--- a/tests/unit/test_world_apricorn.gd
+++ b/tests/unit/test_world_apricorn.gd
@@ -1,0 +1,175 @@
+extends GutTest
+
+## Gen2WorldApricorn is SelectApricornForKurt's own state machine
+## (engine/events/kurt.asm) and Gen2WorldQuantityPrompt is
+## BuySellToss_InterpretJoypad's dial (engine/items/buy_sell_toss.asm). Both are
+## scene-free, so every case here presses buttons and reads the model.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const RED: int = 0x55
+const BLU: int = 0x59
+const YLW: int = 0x5C
+const GRN: int = 0x5D
+const WHT: int = 0x61
+const BLK: int = 0x63
+const PNK: int = 0x65
+const ALL_SEVEN: Array[int] = [RED, BLU, YLW, GRN, WHT, BLK, PNK]
+
+var _data: GameData = null
+
+
+func before_each() -> void:
+	_data = Fixture.build()
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func _state(items: Dictionary) -> Gen2WorldState:
+	return Gen2WorldState.new({}, {}, items)
+
+
+func _all_seven(quantity: int = 5) -> Gen2WorldState:
+	var items: Dictionary = {}
+	for item: int in ALL_SEVEN:
+		items[item] = quantity
+	return _state(items)
+
+
+func test_the_bag_list_keeps_apricorn_balls_order_and_drops_what_is_not_held() -> void:
+	var selection: Array = Gen2WorldApricorn.find_in_bag(
+		_data, _state({PNK: 2, RED: 1, 7: 9, YLW: 4})
+	)
+	assert_eq(selection.size(), 3)
+	assert_eq(selection[0]["item"], RED)
+	assert_eq(selection[1]["item"], YLW)
+	assert_eq(selection[2]["item"], PNK)
+	assert_eq(selection[1]["quantity"], 4)
+	## The second ApricornBalls column, which KurtsHouse.asm hands back a day on.
+	assert_eq(selection[0]["ball"], 0x9F)
+	assert_eq(selection[2]["ball"], 0xA6)
+
+
+func test_the_quantity_of_an_apricorn_clamps_at_the_source_ceiling() -> void:
+	var state: Gen2WorldState = _state({RED: 99, BLU: 40})
+	assert_eq(Gen2WorldApricorn.quantity_of(state, RED), 99)
+	assert_eq(Gen2WorldApricorn.quantity_of(state, BLU), 40)
+	assert_eq(Gen2WorldApricorn.quantity_of(state, YLW), 0)
+
+
+func test_an_empty_bag_finishes_the_selection_on_the_source_refusal() -> void:
+	var selection: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _state({7: 4}))
+	assert_true(selection.is_done())
+	assert_eq(selection.result(), {"item": 0, "quantity": 0})
+
+
+func test_a_short_list_shows_the_cancel_row_and_a_full_one_scrolls_to_it() -> void:
+	var two: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _state({RED: 1, BLU: 1}))
+	assert_eq(two.rows(), 3)
+	two.press(Gen2Button.DOWN)
+	two.press(Gen2Button.DOWN)
+	assert_eq(two.cursor_y, 3)
+	assert_eq(two.scroll, 0)
+	assert_true(two.selected_entry().is_empty())
+
+	var seven: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _all_seven())
+	assert_eq(seven.rows(), Gen2WorldApricorn.MENU_HEIGHT)
+	for press: int in 7:
+		seven.press(Gen2Button.DOWN)
+	assert_eq(seven.cursor_y, 4)
+	assert_eq(seven.scroll, 4)
+	assert_eq(seven.selected_index(), 7)
+	assert_true(seven.selected_entry().is_empty())
+	## `.d_down` stops once the window has reached the sentinel.
+	seven.press(Gen2Button.DOWN)
+	assert_eq(seven.scroll, 4)
+
+
+func test_the_cursor_walks_the_window_before_the_list_scrolls() -> void:
+	var selection: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _all_seven())
+	selection.press(Gen2Button.DOWN)
+	assert_eq(selection.scroll, 0)
+	assert_eq(selection.selected_entry()["item"], BLU)
+	selection.press(Gen2Button.UP)
+	assert_eq(selection.cursor_y, 1)
+	## Up at the top edge with nothing scrolled away does nothing at all.
+	selection.press(Gen2Button.UP)
+	assert_eq(selection.cursor_y, 1)
+	assert_eq(selection.scroll, 0)
+
+
+func test_choosing_an_apricorn_opens_the_quantity_box_on_one() -> void:
+	var selection: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _state({GRN: 6}))
+	selection.press(Gen2Button.A)
+	assert_eq(selection.phase, Gen2WorldApricorn.SELECT_QUANTITY)
+	assert_eq(selection.prompt.value, 1)
+	assert_eq(selection.prompt.maximum, 6)
+	selection.press(Gen2Button.A)
+	assert_true(selection.is_done())
+	assert_eq(selection.result(), {"item": GRN, "quantity": 1})
+
+
+func test_backing_out_of_the_quantity_box_returns_to_the_same_row() -> void:
+	var selection: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _all_seven())
+	for press: int in 5:
+		selection.press(Gen2Button.DOWN)
+	var row: int = selection.cursor_y
+	var scrolled: int = selection.scroll
+	var chosen: int = int(selection.selected_entry()["item"])
+	selection.press(Gen2Button.A)
+	assert_eq(selection.phase, Gen2WorldApricorn.SELECT_QUANTITY)
+	selection.press(Gen2Button.B)
+	assert_eq(selection.phase, Gen2WorldApricorn.SELECT_APRICORN)
+	assert_eq(selection.cursor_y, row)
+	assert_eq(selection.scroll, scrolled)
+	assert_eq(int(selection.selected_entry()["item"]), chosen)
+	## wScriptVar is only what the last pass through the loop wrote.
+	selection.press(Gen2Button.B)
+	assert_true(selection.is_done())
+	assert_eq(selection.result(), {"item": 0, "quantity": 0})
+
+
+func test_the_cancel_row_answers_with_the_same_zero_a_b_press_does() -> void:
+	var selection: Gen2WorldApricorn = Gen2WorldApricorn.open(_data, _state({WHT: 3}))
+	selection.press(Gen2Button.DOWN)
+	assert_true(selection.selected_entry().is_empty())
+	selection.press(Gen2Button.A)
+	assert_true(selection.is_done())
+	assert_eq(selection.result(), {"item": 0, "quantity": 0})
+
+
+func test_the_quantity_dial_wraps_at_both_ends() -> void:
+	var prompt: Gen2WorldQuantityPrompt = Gen2WorldQuantityPrompt.open(4)
+	assert_eq(prompt.value, 1)
+	prompt.press(Gen2Button.DOWN)
+	assert_eq(prompt.value, 4)
+	prompt.press(Gen2Button.UP)
+	assert_eq(prompt.value, 1)
+	prompt.press(Gen2Button.UP)
+	assert_eq(prompt.value, 2)
+
+
+func test_the_quantity_dial_pages_by_ten_and_stops_at_the_ceiling() -> void:
+	var prompt: Gen2WorldQuantityPrompt = Gen2WorldQuantityPrompt.open(25)
+	prompt.press(Gen2Button.RIGHT)
+	assert_eq(prompt.value, 11)
+	prompt.press(Gen2Button.RIGHT)
+	assert_eq(prompt.value, 21)
+	prompt.press(Gen2Button.RIGHT)
+	assert_eq(prompt.value, 25)
+	prompt.press(Gen2Button.LEFT)
+	assert_eq(prompt.value, 15)
+	prompt.press(Gen2Button.LEFT)
+	assert_eq(prompt.value, 5)
+	## `.left` lands on one rather than wrapping, borrow or zero alike.
+	prompt.press(Gen2Button.LEFT)
+	assert_eq(prompt.value, 1)
+
+
+func test_the_quantity_dial_reports_its_two_terminals() -> void:
+	var prompt: Gen2WorldQuantityPrompt = Gen2WorldQuantityPrompt.open(9)
+	assert_eq(prompt.press(Gen2Button.UP), Gen2WorldQuantityPrompt.PENDING)
+	assert_eq(prompt.press(Gen2Button.A), Gen2WorldQuantityPrompt.CONFIRMED)
+	assert_eq(prompt.press(Gen2Button.B), Gen2WorldQuantityPrompt.CANCELLED)

--- a/tests/unit/test_world_apricorn.gd.uid
+++ b/tests/unit/test_world_apricorn.gd.uid
@@ -1,0 +1,1 @@
+uid://7j4s612iycrc

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -5,6 +5,10 @@ extends GutTest
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
+const APRICORN_RED: int = 0x55
+const APRICORN_PNK: int = 0x65
+const BALL_LEVEL: int = 0x9F
+
 var _data: GameData = null
 var _world: Gen2WorldAPI = null
 var _save: Gen2SaveData = null
@@ -391,6 +395,118 @@ func _write_bargain_schedule_script() -> void:
 	]
 	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
 	_data = GameData.open_directory(Fixture.directory())
+
+
+## `special SelectApricornForKurt` behind a coord event, over a bag holding
+## whichever apricorns the case needs.
+func _set_apricorn_script(items: Dictionary) -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6300)] = [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_SELECT_APRICORN_FOR_KURT, 0x00,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	var maps: Array = RomCache.read_json(RomCache.world_maps_path(Fixture.directory()))
+	for raw: Dictionary in maps:
+		if int(raw.get("group", -1)) != Fixture.MAP_GROUP \
+		or int(raw.get("number", -1)) != Fixture.MAP_NUMBER:
+			continue
+		var events: Dictionary = raw.get("events", {})
+		events["coord_events"] = [{"x": 7, "y": 6, "script": 0x6300}]
+		raw["events"] = events
+	RomCache.write_json(RomCache.world_maps_path(Fixture.directory()), maps)
+	_data = GameData.open_directory(Fixture.directory())
+	_world = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6),
+		Gen2WorldState.new({}, {}, items)
+	)
+	_save = Gen2SaveStore.create_development_save(_data, 0)
+	_save.world = _world.snapshot()
+
+
+func _open_apricorn_request() -> Dictionary:
+	var waiting: Array = _world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+	return _world.pending_runtime_request()
+
+
+func test_kurts_special_stages_a_request_carrying_the_bag_list() -> void:
+	_set_apricorn_script({APRICORN_RED: 4, APRICORN_PNK: 2, 7: 1})
+	var request: Dictionary = _open_apricorn_request()
+	assert_eq(request["kind"], &"apricorn_selection_requested")
+
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_true(resolved["ok"], JSON.stringify(resolved))
+	var apricorns: Array = resolved["data"]["apricorns"]
+	assert_eq(apricorns.size(), 2)
+	assert_eq(apricorns[0]["item"], APRICORN_RED)
+	assert_eq(apricorns[0]["quantity"], 4)
+	assert_eq(apricorns[1]["item"], APRICORN_PNK)
+
+
+func test_giving_kurt_apricorns_takes_them_and_commits_the_quantity() -> void:
+	_set_apricorn_script({APRICORN_RED: 4})
+	assert_eq(_open_apricorn_request()["kind"], &"apricorn_selection_requested")
+
+	var completed: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"ok": true, "item": APRICORN_RED, "quantity": 3}, _save, false
+	)
+	assert_true(completed["ok"], JSON.stringify(completed))
+	assert_eq(completed["results"][0]["status"], &"complete")
+	assert_eq(_world.state.item_quantity(APRICORN_RED), 1)
+	assert_eq(_world.state.kurt_apricorn_quantity(), 3)
+	assert_eq(_save.world.world_state.item_quantity(APRICORN_RED), 1)
+	assert_eq(_save.world.world_state.kurt_apricorn_quantity(), 3)
+
+
+func test_backing_out_of_kurts_selection_answers_zero_and_takes_nothing() -> void:
+	_set_apricorn_script({APRICORN_RED: 4})
+	assert_eq(_open_apricorn_request()["kind"], &"apricorn_selection_requested")
+
+	var completed: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"ok": true, "item": 0, "quantity": 0}, _save, false
+	)
+	assert_true(completed["ok"], JSON.stringify(completed))
+	assert_eq(_world.state.item_quantity(APRICORN_RED), 4)
+	assert_eq(_world.state.kurt_apricorn_quantity(), 0)
+
+
+func test_kurts_host_refuses_more_apricorns_than_the_bag_holds() -> void:
+	_set_apricorn_script({APRICORN_RED: 2})
+	assert_eq(_open_apricorn_request()["kind"], &"apricorn_selection_requested")
+
+	var completed: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"ok": true, "item": APRICORN_RED, "quantity": 3}, _save, false
+	)
+	assert_false(completed["ok"], JSON.stringify(completed))
+	assert_eq(completed["reason"], &"invalid_apricorn_quantity")
+	assert_eq(_world.state.item_quantity(APRICORN_RED), 2)
+	assert_eq(_world.pending_runtime_request()["kind"], &"apricorn_selection_requested")
+
+
+## The committed byte is what a later day's `verbosegiveitemvar BALL,
+## VAR_KURT_APRICORNS` sizes the ball stack from, in its own invocation.
+func test_the_saved_quantity_sizes_a_later_verbosegiveitemvar() -> void:
+	_set_apricorn_script({APRICORN_RED: 4})
+	assert_eq(_open_apricorn_request()["kind"], &"apricorn_selection_requested")
+	var completed: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"ok": true, "item": APRICORN_RED, "quantity": 3}, _save, false
+	)
+	assert_true(completed["ok"], JSON.stringify(completed))
+
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6400)] = [
+		0x9F, BALL_LEVEL, 0x16, Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	var later := Gen2WorldScriptRunner.begin(
+		GameData.open_directory(Fixture.directory()), _world.state,
+		{"kind": &"test", "bank": Fixture.BANK, "script": 0x6400}
+	)
+	var result: Dictionary = later.advance()
+	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	assert_eq(_world.state.item_quantity(BALL_LEVEL), 3)
 
 
 func _write_menu_script() -> void:

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -179,6 +179,31 @@ func test_reset_daily_flags_clears_the_matching_profiles_merchant_flag_only() ->
 	assert_false(gold_state.bargain_merchant_closed(false))
 
 
+## CheckDailyResetTimer zeroes the whole wDailyFlags1 byte, so Kurt's flag goes
+## with the merchant's. Without it he never finishes a ball.
+func test_reset_daily_flags_clears_kurts_flag_on_both_profiles() -> void:
+	for crystal: bool in [true, false]:
+		var state := Gen2WorldState.new()
+		var flag: int = Gen2WorldState.engine_flag(
+			Gen2WorldState.ENGINE_KURT_MAKING_BALLS, crystal
+		)
+		state.set_engine_flag(flag)
+		assert_false(state.reset_daily_flags(not crystal))
+		assert_true(state.is_engine_flag_active(flag))
+		assert_true(state.reset_daily_flags(crystal))
+		assert_false(state.is_engine_flag_active(flag))
+
+
+func test_the_saved_kurt_quantity_survives_a_snapshot_round_trip() -> void:
+	var state := Gen2WorldState.new()
+	state.set_kurt_apricorn_quantity(7)
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.kurt_apricorn_quantity(), 7)
+	## Absent in a state written before the errand existed, and zero is what a
+	## fresh SelectApricornForKurt writes anyway.
+	assert_eq(Gen2WorldState.from_dict({}).kurt_apricorn_quantity(), 0)
+
+
 ## Gen2WorldState.is_crystal_profile mirrors
 ## Gen2WorldScriptRunner._crystal_commands(): only a verified Gold or Silver
 ## cache is treated as the shorter engine flag table.

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -3,13 +3,27 @@ extends SceneTree
 ## Captures the production world-service overlay with a deterministic cache.
 ##
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/mart.png
+##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/kurt.png apricorn
+##
+## `presses` drives the overlay with its own buttons before the shot, which is
+## how the apricorn mode's second box is photographed.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
+## The seven ApricornBalls rows, named so a capture reads as the cartridge's
+## list rather than as the fixture's ITEM<number> placeholders.
+const APRICORNS: Dictionary = {
+	0x55: "RED APRICORN", 0x59: "BLU APRICORN", 0x5C: "YLW APRICORN",
+	0x5D: "GRN APRICORN", 0x61: "WHT APRICORN", 0x63: "BLK APRICORN",
+	0x65: "PNK APRICORN",
+}
+
 var _screen: Gen2WorldScreen = null
 var _data: GameData = null
 var _output_path: String = ""
+var _kind: StringName = &"mart"
+var _presses: Array[int] = []
 var _fixture_directory: String = ""
 var _frames: int = 0
 
@@ -17,10 +31,15 @@ var _frames: int = 0
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.is_empty():
-		push_error("Usage: preview_world_services.gd -- <output.png>")
+		push_error("Usage: preview_world_services.gd -- <output.png> [mart|apricorn] [presses]")
 		quit(1)
 		return
 	_output_path = args[0]
+	if args.size() > 1:
+		_kind = StringName(args[1])
+	if args.size() > 2:
+		for name: String in args[2].split(",", false):
+			_presses.append(_button(name))
 	_fixture_directory = Fixture.directory()
 	_data = Fixture.build()
 	_write_service_cache()
@@ -32,7 +51,11 @@ func _initialize() -> void:
 	_screen.map_group = Fixture.MAP_GROUP
 	_screen.map_number = Fixture.MAP_NUMBER
 	_screen.start_cell = Vector2i(7, 6)
-	var state := Gen2WorldState.new({}, {}, {7: 1}, {0: 500})
+	var items: Dictionary = {7: 1}
+	if _kind == &"apricorn":
+		for item: int in [0x55, 0x59, 0x5C, 0x5D, 0x61]:
+			items[item] = 6
+	var state := Gen2WorldState.new({}, {}, items, {0: 500})
 	var world := Gen2WorldAPI.open(
 		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6), state
 	)
@@ -49,6 +72,8 @@ func _process(_delta: float) -> bool:
 	if _frames == 3:
 		var waiting: Array = _screen._world.dispatch_script_events(Vector2i(7, 6))
 		_screen._show_script_results(waiting)
+		for button: int in _presses:
+			_screen._service_host.handle_button(button)
 	if _frames < 18:
 		return false
 	var image: Image = root.get_texture().get_image()
@@ -63,12 +88,26 @@ func _process(_delta: float) -> bool:
 	return true
 
 
+static func _button(name: String) -> int:
+	match name.to_lower():
+		"up": return Gen2Button.UP
+		"down": return Gen2Button.DOWN
+		"left": return Gen2Button.LEFT
+		"right": return Gen2Button.RIGHT
+		"a": return Gen2Button.A
+		"b": return Gen2Button.B
+	return Gen2Button.NONE
+
+
 func _write_service_cache() -> void:
 	var items: Array = RomCache.read_json(RomCache.items_path(_fixture_directory))
 	for raw: Dictionary in items:
-		if int(raw.get("number", 0)) == 7:
+		var number: int = int(raw.get("number", 0))
+		if number == 7:
 			raw["name"] = "ITEM7"
 			raw["price"] = 120
+		elif APRICORNS.has(number):
+			raw["name"] = String(APRICORNS[number])
 	RomCache.write_json(RomCache.items_path(_fixture_directory), items)
 	RomCache.write_json(RomCache.world_marts_path(_fixture_directory), {
 		"marts": [{"index": 0, "bank": Fixture.BANK, "address": 0x4000, "items": [7]}],
@@ -78,6 +117,10 @@ func _write_service_cache() -> void:
 		RomCache.world_scripts_path(_fixture_directory)
 	)
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6320)] = [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_SELECT_APRICORN_FOR_KURT, 0x00,
+		Gen2WorldScript.END,
+	] if _kind == &"apricorn" else [
 		0x94, 0, 0x00, 0x40, 0x91,
 	]
 	RomCache.write_json(RomCache.world_scripts_path(_fixture_directory), scripts)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -44,6 +44,8 @@ const ITEM_HM_WATERFALL: int = 0xF9
 ## TM08, the `add_tm ROCK_SMASH` row in the same file. Gold and Silver need it
 ## to finish the Burned Tower; no Crystal leg does.
 const ITEM_TM_ROCK_SMASH: int = 0xC7
+## The apricorn Azalea Town's own fruit tree bears.
+const APRICORN_WHT: int = 0x61
 ## Ice Path 1F's HM07 ball stands on (31,7) in both games, on the same region as
 ## the Route 44 door and the first staircase (`maps/IcePath1F.asm`). Three of its
 ## four neighbours are wall, so (30,7) facing right is the only approach.
@@ -1885,6 +1887,41 @@ func _hive_badge_path(
 		"cell": _cell_value(world),
 		"run": after_well,
 	})
+
+	# The apricorn errand. Azalea Town's own fruit tree bears WHT_APRICORN
+	# (data/items/fruit_trees.asm), but `fruittree` reaches no host, so the walk
+	# puts the tree's fruit in the bag rather than picking it. See HANDOFF.
+	var picked: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {APRICORN_WHT: 4},
+	})
+	if not bool(picked.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "apricorn grant failed"}
+	# Kurt1 is back at (3,2) with EVENT_CLEARED_SLOWPOKE_WELL set, and the warp
+	# already left the player on his cell. `.ClearedSlowpokeWell` hands over the
+	# LURE_BALL, then `.CheckApricorns` finds the white one and asks.
+	var errand: Dictionary = _talk_to(
+		world, Vector2i(3, 3), Gen2WorldSprite.FACING_UP, save, random, data, [],
+		{"item": APRICORN_WHT, "quantity": 2}
+	)
+	path.append({
+		"step": "kurts_apricorn_errand",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"given": errand.get("run", {}).get("apricorns_given", []),
+		"apricorns_left": world.state.item_quantity(APRICORN_WHT),
+		"kurt_quantity": world.state.kurt_apricorn_quantity(),
+		"making_balls": world.state.is_engine_flag_active(Gen2WorldState.engine_flag(
+			Gen2WorldState.ENGINE_KURT_MAKING_BALLS, Gen2WorldState.is_crystal_profile(data)
+		)),
+		"run": errand,
+	})
+	if not bool(errand.get("ok", false)):
+		return {
+			"ok": false, "path": path,
+			"reason": "Kurt's apricorn errand failed: %s" % errand.get("reason", ""),
+		}
+	if world.state.kurt_apricorn_quantity() != 2 or world.state.item_quantity(APRICORN_WHT) != 2:
+		return {"ok": false, "path": path, "reason": "Kurt took the wrong apricorns"}
 
 	var back_to_azalea: Dictionary = _warp_step(world, 8, 7)
 	if not bool(back_to_azalea.get("ok", false)):
@@ -9051,13 +9088,14 @@ func _talk_to(
 	random: RandomNumberGenerator,
 	data: GameData,
 	answers: Array[int] = [],
+	apricorn: Dictionary = {},
 ) -> Dictionary:
 	var walked: Dictionary = _walk_cell_resolving(world, cell, save, random, data)
 	if not bool(walked.get("ok", false)):
 		return walked
 	world.player_facing = facing
 	var run: Dictionary = _drain_story(
-		world, world.interact(), save, random, data, true, answers
+		world, world.interact(), save, random, data, true, answers, {}, apricorn
 	)
 	return {
 		"ok": bool(run.get("terminal", false)),
@@ -9172,12 +9210,17 @@ func _drain_story(
 	require_events: bool = false,
 	answers: Array[int] = [],
 	purchase: Dictionary = {},
+	apricorn: Dictionary = {},
 ) -> Dictionary:
 	var pending_answers: Array[int] = answers.duplicate()
 	## What to buy if a `pokemart` opens while this drain runs. Cleared once it
 	## is spent, so one standing order buys once.
 	var pending_purchase: Dictionary = purchase.duplicate()
 	var purchases: Array = []
+	## The same standing order for `special SelectApricornForKurt`. An empty one
+	## backs out of the box, which is the source's own cancel.
+	var pending_apricorn: Dictionary = apricorn.duplicate()
+	var apricorns_given: Array = []
 	if require_events and initial.is_empty():
 		return {
 			"statuses": [],
@@ -9375,6 +9418,27 @@ func _drain_story(
 						break
 					pending_purchase = {}
 				results = world.complete_runtime_request({"ok": true})
+			elif request_kind == &"apricorn_selection_requested":
+				# Kurt's two boxes are a runtime pause the same way a mart is.
+				# Gen2WorldApricornHost takes the apricorns and resumes, so the
+				# walk proves the transaction rather than only the request.
+				var given: Dictionary = Gen2WorldHost.complete_runtime_request(
+					world, {
+						"ok": true,
+						"item": int(pending_apricorn.get("item", 0)),
+						"quantity": int(pending_apricorn.get("quantity", 0)),
+					}, save, false
+				)
+				if not bool(given.get("ok", false)):
+					last_reason = String(given.get("reason", "apricorn host failed"))
+					last_details = JSON.stringify(given)
+					break
+				apricorns_given.append({
+					"item": int(given.get("item", 0)),
+					"quantity": int(given.get("quantity", 0)),
+				})
+				pending_apricorn = {}
+				results = given.get("results", [])
 			elif request_kind == &"audio_requested":
 				results = world.complete_runtime_request({"ok": true})
 			else:
@@ -9405,6 +9469,7 @@ func _drain_story(
 		"pending_trace": pending_trace,
 		"battles": battles,
 		"purchases": purchases,
+		"apricorns_given": apricorns_given,
 		"catch_tutorials": catch_tutorials,
 		"hall_of_fame": hall_of_fame,
 		"credits": credits,


### PR DESCRIPTION
`special SelectApricornForKurt` reached no handler, so Kurt's house stopped dead. Its two boxes are now scene-free models beside the other source menus, answered by a host request in the shape the mart already uses.

- `Gen2WorldApricorn` is the special's own state machine: FindApricornsInBag's list, Kurt_SelectApricorn's scrolling window, and the loop that puts the player back on the list when the quantity box is backed out of.
- `Gen2WorldQuantityPrompt` is BuySellToss_InterpretJoypad itself, which SelectQuantityToToss and the mart share, so the pack's TOSS needs a box rather than a second dial.
- `Gen2WorldApricornHost` takes the apricorns through the same validated candidate save every other bag-owned transaction commits through.
- `wKurtApricornQuantity` becomes saved world state, since the ball Kurt hands back a day later reads it from a different script invocation.

Kurt's flag lives in the wDailyFlags1 byte CheckDailyResetTimer zeroes whole, and the day boundary is the whole of the errand's wait, so the daily reset now clears every daily flag this project models rather than the merchant's alone.

The walked route carries the errand on all three cartridges.