### PR TITLE
world: let a fruit tree bear its fruit, once a day

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ to check without writing.
 | Battle HUD | HP/EXP bars, panel borders and colours |
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
 | Wild encounters | Normal/swarm grass and water, 13 fishing groups with day/night substitutions, 16-row roaming graph, map-linked rates and slots, time-of-day selection, surf variance and repel checks |
-| World services | Referenced menus, mart inventories, phone contacts, special calls, bounded scripts/text, music, SFX, cries and shared waveform assets |
+| World services | Referenced menus, mart inventories, the thirty fruit trees' fruit, phone contacts, special calls, bounded scripts/text, music, SFX, cries and shared waveform assets |
 | Battle animations | All 278 animation scripts, the 188 objects, 185 framesets and 216 OAM sets they are drawn from, 39 decompressed graphics sheets and the sine table the motion callbacks scale with |
 
 Sprites remain colour indices and receive a palette at draw time, so shiny
@@ -269,6 +269,10 @@ runs the whole column in one command and ends on the first cell above it that is
 not a waterfall. Standing on a whirlpool, waterfall, door, staircase or cave
 tile overrides the pressed direction as the cartridge does, which is also how a
 waterfall is ridden back down.
+
+A fruit tree bears its own berry or apricorn once a day, refilling for every
+tree at once the first time one is touched after the day turns, which is how
+Kurt gets his Apricorns.
 
 Poké Balls on the ground are picked up by facing them, and so are the items
 hidden in scenery: neither pointer is a script, so each is decoded and its item

--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -49,11 +49,16 @@ var _pads: Array[Control] = []
 static var _instance: Gen2InputRuntime = null
 
 
+## Named relative to the root rather than as `/root/InputRuntime`: a script
+## handed to `-s` runs outside the active scene tree, where an absolute path
+## makes even `get_node_or_null` push an error before returning null. The
+## no-runtime answer is the intended one for every headless run, so it has to be
+## silent.
 static func instance() -> Gen2InputRuntime:
 	if _instance == null:
 		var loop: SceneTree = Engine.get_main_loop() as SceneTree
 		if loop != null:
-			_instance = loop.root.get_node_or_null("/root/InputRuntime") as Gen2InputRuntime
+			_instance = loop.root.get_node_or_null(^"InputRuntime") as Gen2InputRuntime
 	return _instance
 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -366,6 +366,7 @@ Because wrong offsets can decode plausible neighboring data,
 | Trainers | Class name/pic/palette numbering, ends and pic pointers. Parties walk to the next class pointer, including empty class 10, checking counts and endpoints (Falkner's level 7 Pidgey and level 9 Pidgeotto, the last class's first name). Attributes validate defined flags and class 1 bytes; DVs anchor both ends and match the published tables byte-for-byte |
 | Evolutions, learnsets | Pointers address the banked window; methods, species, moves and levels valid, levels ascending except Muk, evolution count known. `EVOLVE_STAT` is four bytes, not three |
 | Growth | Growth rate and base EXP for all 251 species in all three games |
+| Fruit trees | Thirty rows of one item byte, identified by content because the table has no header and no terminator: rows 17 to 23 are the seven apricorns and no other row bears one, and the four Johto berry trees ahead of them share a berry |
 | World services | Source counts, pointer widths, banked addresses, mart terminators, phone sizes, non-trainer caller-name pointer tables, packed audio headers, cry pointers, shared waves, drumkits and bounded bank-window payloads. Menu headers need valid data pointers and command-derived shape; the script collector validates `phonecall` text pointers, leaves `memcall`/`memjump` to runtime memory snapshots, and ignores malformed candidates |
 
 When adding an offset, add its check. Find data by searching a dump for

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -76,6 +76,7 @@ var _overworld_sprite_palettes: Array = []
 var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
 var _world_phone: Dictionary = {}
+var _world_fruit_trees: Array = []
 var _world_audio: Dictionary = {}
 var _battle_anims_section: Dictionary = {}
 ## Which of the sections above have been read. A section that is genuinely empty
@@ -196,6 +197,15 @@ func world_mart(index: int) -> Dictionary:
 		return _coerce_service_dictionary((rows as Array)[index])
 	var default_value: Variant = _marts().get("default", {})
 	return _coerce_service_dictionary(default_value)
+
+
+## `GetFruitTreeItem`: the item a tree bears, by the `fruittree` command's own
+## one-based tree id. Zero for an id no cartridge tree carries.
+func world_fruit_tree_item(tree_id: int) -> int:
+	var rows: Array = _fruit_trees()
+	if tree_id < 1 or tree_id > rows.size():
+		return 0
+	return int(rows[tree_id - 1])
 
 
 ## One imported priced or special mart list. The source keeps these lists apart
@@ -1405,6 +1415,14 @@ func _marts() -> Dictionary:
 	if _claim_section("marts"):
 		_world_marts = _read_section(RomCache.world_marts_path(directory), false)
 	return _world_marts
+
+
+func _fruit_trees() -> Array:
+	if _claim_section("fruit_trees"):
+		_world_fruit_trees = _read_section(
+			RomCache.world_fruit_trees_path(directory), true
+		)
+	return _world_fruit_trees
 
 
 func _phone() -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -49,6 +49,7 @@ const WORLD_MENUS: String = "world_menus.json"
 const WORLD_MARTS: String = "world_marts.json"
 const WORLD_PHONE: String = "world_phone.json"
 const WORLD_AUDIO: String = "world_audio.json"
+const WORLD_FRUIT_TREES: String = "world_fruit_trees.json"
 const BATTLE_ANIMS: String = "battle_anims.json"
 const BATTLE_ANIM_GFX_DIR: String = "battle_anim_gfx"
 
@@ -63,7 +64,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 41
+const FORMAT_VERSION: int = 42
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -201,6 +202,10 @@ static func world_phone_path(directory: String) -> String:
 
 static func world_audio_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_AUDIO]
+
+
+static func world_fruit_trees_path(directory: String) -> String:
+	return "%s/%s" % [directory, WORLD_FRUIT_TREES]
 
 
 ## The battle animation scripts and the four tables their objects are built

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -141,6 +141,16 @@ const MART_COUNT: int = 34
 const MART_POINTER_SIZE: int = 2
 const MART_RECORD_MAX_ITEMS: int = 16
 const MART_TERMINATOR: int = 0xFF
+## `NUM_FRUIT_TREES` (`constants/script_constants.asm`). `FruitTreeItems` is one
+## item byte per tree, indexed by the `fruittree` command's operand less one, and
+## both pins ship the same thirty rows.
+const FRUIT_TREE_COUNT: int = 30
+## The seven apricorn items, ascending, and where their run starts in the table.
+## Rows 17 to 23 are `FRUITTREE_ROUTE_37_1` through `FRUITTREE_ROUTE_42_3`, and
+## no other row bears one; both pins agree. Used to identify the table by
+## content, since it has no header and no terminator.
+const FRUIT_TREE_APRICORNS: Array[int] = [0x55, 0x59, 0x5C, 0x5D, 0x61, 0x63, 0x65]
+const FRUIT_TREE_FIRST_APRICORN: int = 16
 const PHONE_CONTACT_COUNT: int = 38
 const PHONE_CONTACT_SIZE: int = 12
 const SPECIAL_PHONE_CALL_COUNT: int = 8
@@ -1022,6 +1032,7 @@ const GOLD_SILVER: Dictionary = {
 	"mart_table": 0x162FE,
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
+	"fruit_trees": 0x44091,
 	"rooftop_mart_count": 0,
 	"rooftop_mart_1": 0,
 	"rooftop_mart_2": 0,
@@ -1230,6 +1241,7 @@ const CRYSTAL: Dictionary = {
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,
+	"fruit_trees": 0x44097,
 	"rooftop_mart_count": 2,
 	"rooftop_mart_1": 0x15AEE,
 	"rooftop_mart_2": 0x15AFF,

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -42,6 +42,10 @@ static func import_to_cache(
 		return _error("Could not write world mart data.")
 	if not RomCache.write_json(RomCache.world_phone_path(directory), result["phone"]):
 		return _error("Could not write world phone data.")
+	if not RomCache.write_json(
+		RomCache.world_fruit_trees_path(directory), result["fruit_trees"]
+	):
+		return _error("Could not write world fruit tree data.")
 	if not RomCache.write_section(
 		RomCache.world_audio_path(directory),
 		RomCache.blob_path(RomCache.world_audio_path(directory)),
@@ -75,6 +79,7 @@ static func import_to_cache(
 		"sfx": (result["audio"].get("sfx", []) as Array).size(),
 		"cries": (result["audio"].get("cries", []) as Array).size(),
 		"mon_cries": (result["audio"].get("mon_cries", []) as Array).size(),
+		"fruit_trees": (result["fruit_trees"] as Array).size(),
 	}
 
 
@@ -95,6 +100,9 @@ static func read_services(
 	var audio: Dictionary = _read_audio(rom, layout)
 	if not bool(audio.get("ok", false)):
 		return audio
+	var fruit_trees: Dictionary = read_fruit_trees(rom, layout)
+	if not bool(fruit_trees.get("ok", false)):
+		return fruit_trees
 	var menus: Dictionary = _read_menus(rom, scripts, standard_scripts)
 	if not bool(menus.get("ok", false)):
 		return menus
@@ -107,6 +115,7 @@ static func read_services(
 		"marts": marts["data"],
 		"phone": phone["data"],
 		"audio": audio["data"],
+		"fruit_trees": fruit_trees["items"],
 		"phone_scripts": phone_scripts,
 	}
 
@@ -163,6 +172,40 @@ static func _read_marts(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"special": special,
 		},
 	}
+
+
+## `FruitTreeItems` (`data/items/fruit_trees.asm`): thirty item bytes, one per
+## `FRUITTREE_*` constant, read by `GetFruitTreeItem` at the tree id less one.
+## No terminator and no pointer, so the count is the whole of its shape and the
+## table has to identify itself by content instead.
+static func read_fruit_trees(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var offset: int = int(layout.get("fruit_trees", 0))
+	if offset <= 0 or not rom.in_bounds(offset, RomLayout.FRUIT_TREE_COUNT):
+		return _error("Fruit tree item table is outside the cartridge.")
+	var items: Array = []
+	for index: int in RomLayout.FRUIT_TREE_COUNT:
+		var item: int = rom.u8(offset + index)
+		if item <= 0 or item == RomLayout.MART_TERMINATOR:
+			return _error("Fruit tree %d holds invalid item %d." % [index + 1, item])
+		items.append(item)
+	## Rows 17 to 23 are the seven apricorns and are the only apricorns in the
+	## table, and the four Johto berry trees ahead of them all bear the same
+	## fruit. Either alone could match neighbouring data; together they do not.
+	var apricorns: Array = items.slice(
+		RomLayout.FRUIT_TREE_FIRST_APRICORN, RomLayout.FRUIT_TREE_FIRST_APRICORN + 7
+	)
+	apricorns.sort()
+	if apricorns != RomLayout.FRUIT_TREE_APRICORNS:
+		return _error("Fruit tree rows 17 to 23 are not the seven apricorns.")
+	for index: int in RomLayout.FRUIT_TREE_COUNT:
+		var is_apricorn: bool = RomLayout.FRUIT_TREE_APRICORNS.has(int(items[index]))
+		var in_run: bool = index >= RomLayout.FRUIT_TREE_FIRST_APRICORN \
+			and index < RomLayout.FRUIT_TREE_FIRST_APRICORN + 7
+		if is_apricorn != in_run:
+			return _error("Fruit tree %d breaks the apricorn run." % (index + 1))
+	if items.slice(0, 4).any(func(item: Variant) -> bool: return int(item) != int(items[0])):
+		return _error("The first four fruit trees do not share one berry.")
+	return {"ok": true, "items": items}
 
 
 static func _read_mart_list(rom: RomFile, bank: int, address: int, _priced: bool) -> Dictionary:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -33,6 +33,7 @@ var _has_staged_special_phone_call: bool = false
 var _staged_special_phone_call: int = 0
 var _has_staged_kurt_apricorn_quantity: bool = false
 var _staged_kurt_apricorn_quantity: int = 0
+var _staged_fruit_trees: Dictionary = {}
 var _reset_phone_receive_timer: bool = false
 var _events: Array = []
 var _pending: Dictionary = {}
@@ -176,7 +177,17 @@ const FIELD_MOVE_PROMPT_FRAME: int = RomFile.BANK_SIZE
 ## data/text/common_2.asm's _FoundItemText, less its <PLAYER>; see
 ## _stage_item_ball(). The source line break sits before the item name.
 const FOUND_ITEM_TEXT: String = "Found\n%s!"
-const NO_SPACE_ITEM_TEXT: String = "Found\n%s!\n\nBut you have\nno space left."
+## Two source boxes, so four lines and no blank between them: the box is two
+## rows, and a blank line would spend a third page drawing nothing.
+const NO_SPACE_ITEM_TEXT: String = "Found\n%s!\nBut you have\nno space left."
+## data/text/common_1.asm's four fruit tree texts, paired the same way.
+## `_HeyItsFruitText` and `_ObtainedFruitText` are one staged text because the
+## source's `giveitem` sits between them and has nothing to show; they still
+## paginate into the two boxes the cartridge draws.
+const FRUIT_TREE_TEXT: String = "It's a fruit-\nbearing tree."
+const FRUIT_TREE_EMPTY_TEXT: String = "There's nothing\nhere…"
+const FRUIT_TREE_OBTAINED_TEXT: String = "Hey! It's\n%s!\nObtained\n%s!"
+const FRUIT_TREE_FULL_TEXT: String = "Hey! It's\n%s!\nBut the PACK is\nfull…"
 ## The `disappear LAST_TALKED` operand (constants/map_object_constants.asm).
 const LAST_TALKED: int = 0xFE
 ## wBattleResult, which startbattle copies into wScriptVar
@@ -366,6 +377,16 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			if choice != 0:
 				return _complete()
 			_stage_strength_used(chosen_slot)
+			return _waiting_result()
+		## FruitTreeScript's promptbutton, behind which its two callasms sit.
+		if pending_type == &"text" and _pending.get("special", &"") == &"fruit_tree":
+			var fruit_tree: int = int(_pending.get("tree_id", 0))
+			var fruit_item: int = int(_pending.get("item", 0))
+			_pending = {}
+			_finish_after_pending = false
+			var picked: Dictionary = _resolve_fruit_tree(fruit_tree, fruit_item)
+			if not bool(picked.get("ok", false)):
+				return _fail(StringName(picked.get("reason", &"fruit_tree_failed")), picked)
 			return _waiting_result()
 		## Script_UsedStrength's second writetext, _MoveBoulderText.
 		if pending_type == &"text" and _pending.get("special", &"") == &"strength_used":
@@ -1480,9 +1501,7 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 		0x99:
 			return _stage_decoration_description(int(command.get("value", 0)))
 		0x9A:
-			return _stage_runtime_request(&"fruit_tree_requested", {
-				"tree_id": int(command.get("value", 0)),
-			})
+			return _stage_fruit_tree(int(command.get("value", 0)))
 		0x9B:
 			## The cartridge uses specialphonecall to store the pending special
 			## call. Imported phone scripts also use SPECIALCALL_NONE to clear it.
@@ -2538,6 +2557,67 @@ func _stage_item_ball() -> Dictionary:
 	return _stage_internal_text(FOUND_ITEM_TEXT % item_name, true)
 
 
+## `FruitTreeScript` (`engine/events/fruit_trees.asm`). Like an item ball it is
+## a script rather than a host request: `fruittree` is the whole of the object's
+## own script, and the routine below it is text, a flag and a `giveitem`.
+##
+## The first pause is `FruitBearingTreeText`; `TryResetFruitTrees` and
+## `CheckFruitTree` run on its acknowledge, since the source's own `callasm`s sit
+## behind the `promptbutton`.
+func _stage_fruit_tree(tree_id: int) -> Dictionary:
+	if data == null:
+		return _fail(&"missing_world_data", {"tree_id": tree_id})
+	var item: int = data.world_fruit_tree_item(tree_id)
+	if item <= 0:
+		return _fail(&"invalid_fruit_tree", {"tree_id": tree_id, "item": item})
+	_pending = {
+		"type": &"text",
+		"text": FRUIT_TREE_TEXT,
+		"internal_text": true,
+		"special": &"fruit_tree",
+		"tree_id": tree_id,
+		"item": item,
+		"source": _request.duplicate(true),
+	}
+	return {"ok": true}
+
+
+## The second half, run once the tree's own line has been acknowledged.
+func _resolve_fruit_tree(tree_id: int, item: int) -> Dictionary:
+	_stage_fruit_tree_reset()
+	if _fruit_tree_picked(tree_id):
+		return _stage_internal_text(FRUIT_TREE_EMPTY_TEXT, true)
+	var item_name: String = data.item_name(item)
+	if item_name.is_empty():
+		item_name = "FRUIT"
+	var received: Dictionary = _stage_item_delta(item, 1)
+	if not bool(received.get("accepted", true)):
+		return _stage_internal_text(FRUIT_TREE_FULL_TEXT % item_name, true)
+	## PickedFruitTree, which the source runs after the item is in the bag.
+	_staged_fruit_trees[tree_id] = true
+	return _stage_internal_text(FRUIT_TREE_OBTAINED_TEXT % [item_name, item_name], true)
+
+
+## `TryResetFruitTrees`: `ResetFruitTrees` refills every tree at once and sets
+## ENGINE_ALL_FRUIT_TREES behind itself, so it runs once per day, on whichever
+## tree the player touches first after the daily reset cleared that flag.
+func _stage_fruit_tree_reset() -> void:
+	var all_trees: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_ALL_FRUIT_TREES, _crystal_commands()
+	)
+	if bool(_staged_engine_flags.get(all_trees, state.is_engine_flag_active(all_trees))):
+		return
+	for raw_tree: Variant in state.picked_fruit_trees():
+		_staged_fruit_trees[int(raw_tree)] = false
+	_staged_engine_flags[all_trees] = true
+
+
+func _fruit_tree_picked(tree_id: int) -> bool:
+	if _staged_fruit_trees.has(tree_id):
+		return bool(_staged_fruit_trees[tree_id])
+	return state.fruit_tree_picked(tree_id)
+
+
 ## HiddenItemScript, the BGEVENT_ITEM half of the same source area. The pointer
 ## is the `hiddenitem` macro's `dwb event, item`, which `.itemifset` copies into
 ## wHiddenItemData, so Gen2WorldAPI hands the decoded flag and item over the way
@@ -3067,6 +3147,8 @@ func _complete() -> Dictionary:
 		runtime_changes["pending_special_phone_call"] = _staged_special_phone_call
 	if _has_staged_kurt_apricorn_quantity:
 		runtime_changes["kurt_apricorn_quantity"] = _staged_kurt_apricorn_quantity
+	if not _staged_fruit_trees.is_empty():
+		runtime_changes["fruit_trees"] = _staged_fruit_trees.duplicate()
 	if not _staged_engine_flags.is_empty():
 		runtime_changes["engine_flags"] = _staged_engine_flags.duplicate()
 	if _reset_phone_receive_timer:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -47,6 +47,10 @@ const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER: int = 85
 ## when the apricorns are handed over and reads it to decide whether the ball is
 ## ready, so the day boundary is the whole of the errand's wait.
 const ENGINE_KURT_MAKING_BALLS: int = 80
+## Also `wDailyFlags1`. Not "every tree has fruit" but "the trees have already
+## been refilled today": `TryResetFruitTrees` refills them only while this is
+## clear, and `ResetFruitTrees` sets it behind itself.
+const ENGINE_ALL_FRUIT_TREES: int = 84
 
 ## wBikeFlags' BIKEFLAGS_STRENGTH_ACTIVE_F, three engine flags ahead of the badge
 ## section and so profile split the same way. Nothing in the pinned engine/ or
@@ -135,6 +139,10 @@ var _maptile_decorations: Dictionary = {}
 ## writes it and `VAR_KURT_APRICORNS` is read a day later, by a different script
 ## invocation, to size the balls Kurt hands back.
 var _kurt_apricorn_quantity: int = 0
+## `wFruitTreeFlags`, one bit per `FRUITTREE_*` constant, set by `PickedFruitTree`
+## and cleared for every tree at once by `ResetFruitTrees`. Kept as the set of
+## picked tree ids because the source's own question is per tree.
+var _picked_fruit_trees: Dictionary = {}
 
 
 func _init(
@@ -231,6 +239,7 @@ func to_dict() -> Dictionary:
 		"last_dex_mode": _last_dex_mode,
 		"maptile_decorations": _maptile_decorations.duplicate(),
 		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
+		"picked_fruit_trees": _picked_fruit_trees.duplicate(),
 	}
 
 
@@ -269,6 +278,11 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored._radio_channel = int(source.get("radio_channel", -1))
 	restored.set_last_dex_mode(int(source.get("last_dex_mode", RomLayout.DEXMODE_NEW)))
 	restored.set_kurt_apricorn_quantity(int(source.get("kurt_apricorn_quantity", 0)))
+	var picked: Variant = source.get("picked_fruit_trees", {})
+	if picked is Dictionary:
+		for raw_tree: Variant in picked as Dictionary:
+			if int(raw_tree) > 0 and bool((picked as Dictionary)[raw_tree]):
+				restored._picked_fruit_trees[int(raw_tree)] = true
 	return restored
 
 
@@ -303,6 +317,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_last_dex_mode = restored._last_dex_mode
 	_maptile_decorations = restored._maptile_decorations.duplicate()
 	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
+	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
 	changed.emit()
 
 
@@ -461,7 +476,8 @@ func badge_mask(crystal: bool = true) -> int:
 ## here as soon as something sets it, or it survives the day the cartridge
 ## clears it on.
 const DAILY_ENGINE_FLAGS: Array[int] = [
-	ENGINE_KURT_MAKING_BALLS, ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED,
+	ENGINE_KURT_MAKING_BALLS, ENGINE_ALL_FRUIT_TREES,
+	ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED,
 ]
 
 
@@ -711,6 +727,14 @@ func set_kurt_apricorn_quantity(quantity: int) -> void:
 		return
 	_kurt_apricorn_quantity = next_quantity
 	changed.emit()
+
+
+func fruit_tree_picked(tree_id: int) -> bool:
+	return bool(_picked_fruit_trees.get(tree_id, false))
+
+
+func picked_fruit_trees() -> Dictionary:
+	return _picked_fruit_trees.duplicate()
 
 
 func consume_repel_step() -> void:
@@ -994,6 +1018,12 @@ func apply_changes(
 	)
 	if next_kurt_apricorns < 0 or next_kurt_apricorns > 0xFF:
 		return {"ok": false, "reason": &"invalid_kurt_apricorn_quantity"}
+	var fruit_tree_changes: Dictionary = runtime_changes.get("fruit_trees", {})
+	if not fruit_tree_changes is Dictionary:
+		return {"ok": false, "reason": &"invalid_fruit_trees"}
+	for raw_tree: Variant in fruit_tree_changes:
+		if int(raw_tree) < 1 or int(raw_tree) > RomLayout.FRUIT_TREE_COUNT:
+			return {"ok": false, "reason": &"invalid_fruit_trees"}
 	var seen_changes: Dictionary = runtime_changes.get("seen_species", {})
 	if not seen_changes is Dictionary:
 		return {"ok": false, "reason": &"invalid_seen_species"}
@@ -1081,6 +1111,13 @@ func apply_changes(
 			next_script_memory[address] = value
 	if next_script_memory.size() > SCRIPT_MEMORY_CAPACITY:
 		return {"ok": false, "reason": &"script_memory_capacity"}
+	var next_fruit_trees: Dictionary = _picked_fruit_trees.duplicate()
+	for raw_tree: Variant in fruit_tree_changes:
+		var tree: int = int(raw_tree)
+		if bool(fruit_tree_changes[raw_tree]):
+			next_fruit_trees[tree] = true
+		else:
+			next_fruit_trees.erase(tree)
 	var next_just_battled: bool = bool(
 		runtime_changes.get("just_battled", _just_battled)
 	)
@@ -1097,7 +1134,8 @@ func apply_changes(
 		or next_receive_minutes != _phone_receive_minutes \
 		or next_special_phone_call != _pending_special_phone_call \
 		or next_script_memory != _script_memory \
-		or next_kurt_apricorns != _kurt_apricorn_quantity
+		or next_kurt_apricorns != _kurt_apricorn_quantity \
+		or next_fruit_trees != _picked_fruit_trees
 	_event_flags = next_flags
 	_engine_flags = next_engine_flags
 	_map_scenes = next_scenes
@@ -1116,6 +1154,7 @@ func apply_changes(
 	_pending_special_phone_call = next_special_phone_call
 	_script_memory = next_script_memory
 	_kurt_apricorn_quantity = next_kurt_apricorns
+	_picked_fruit_trees = next_fruit_trees
 	if did_change:
 		changed.emit()
 	return {"ok": true, "changed": did_change}

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -110,9 +110,15 @@ func test_the_same_seed_and_frame_count_reach_the_same_world_at_any_frame_rate()
 		var screen: Gen2WorldScreen = await _open_world()
 		var delta: float = 1.0 / host_fps
 		var guard: int = 0
-		while screen._world.frame_number < 120 and guard < 4096:
+		## Pumped to just short of the frame and topped up exactly, the way
+		## tools/replay_world.gd does it, because a host frame spends two or more
+		## hardware frames at once and cannot be asked to land on a given one. A
+		## loop running to 120 lands on 121 whenever an earlier call spent an odd
+		## number, which is what made this assertion flake under load.
+		while screen._world.frame_number < 120 - 1 and guard < 4096:
 			screen._process(delta)
 			guard += 1
+		screen.advance_frames(maxi(0, 120 - screen._world.frame_number))
 		assert_eq(screen._world.frame_number, 120, "%d fps reached the frame" % host_fps)
 		snapshots.append(JSON.stringify(screen._world.snapshot().to_dict()))
 		screen.free()

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5632,3 +5632,96 @@ func test_the_page_is_fully_drawn_even_when_the_map_is_smaller_than_it() -> void
 
 	assert_eq(page.size(), 20 * 18)
 	assert_false(page.has(-1), "no tile of the page is left undrawn")
+
+
+## FruitTreeScript (engine/events/fruit_trees.asm) runs inline the way an item
+## ball's does: the tree's own line, then TryResetFruitTrees, CheckFruitTree and
+## the give. FRUITTREE_AZALEA_TOWN is row 20 and bears WHT_APRICORN.
+const FRUIT_TREE_AZALEA: int = 20
+const FRUIT_TREE_ITEM: int = 0x61
+
+
+func _write_fruit_tree_cache() -> void:
+	var rows: Array = []
+	for index: int in RomLayout.FRUIT_TREE_COUNT:
+		rows.append(FRUIT_TREE_ITEM if index == FRUIT_TREE_AZALEA - 1 else 0xAD)
+	RomCache.write_json(RomCache.world_fruit_trees_path(_directory), rows)
+	var items: Array = RomCache.read_json(RomCache.items_path(_directory))
+	while items.size() < FRUIT_TREE_ITEM:
+		items.append({"number": items.size() + 1, "name": "ITEM%d" % (items.size() + 1), "pocket": 1})
+	items[FRUIT_TREE_ITEM - 1] = {
+		"number": FRUIT_TREE_ITEM, "name": "WHT APRICORN", "pocket": 1,
+	}
+	RomCache.write_json(RomCache.items_path(_directory), items)
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	## `fruittree` is $9a in pokegold's table and one byte higher in the raw
+	## Crystal stream; this fixture is a Crystal-profile cache.
+	scripts["48:6280"] = [
+		Gen2WorldScript.raw_opcode(0x9A), FRUIT_TREE_AZALEA, Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+
+
+func _pick_fruit_tree(data: GameData, state: Gen2WorldState) -> Dictionary:
+	var runner := Gen2WorldScriptRunner.begin(data, state, {
+		"kind": &"test", "bank": 48, "script": 0x6280,
+	})
+	var opened: Dictionary = runner.advance()
+	if StringName(opened.get("status", &"")) != &"waiting":
+		return opened
+	var second: Dictionary = runner.advance(true)
+	if StringName(second.get("status", &"")) != &"waiting":
+		return second
+	return runner.advance(true)
+
+
+func test_a_fruit_tree_gives_its_fruit_once_and_is_bare_until_the_day_turns() -> void:
+	_write_fruit_tree_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	var all_trees: int = Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_ALL_FRUIT_TREES)
+
+	var picked: Dictionary = _pick_fruit_tree(data, state)
+	assert_eq(picked["status"], &"complete", JSON.stringify(picked))
+	assert_eq(state.item_quantity(FRUIT_TREE_ITEM), 1)
+	assert_true(state.fruit_tree_picked(FRUIT_TREE_AZALEA))
+	## ResetFruitTrees sets ENGINE_ALL_FRUIT_TREES behind itself, so the refill
+	## happens on the first tree touched after the day turned and not again.
+	assert_true(state.is_engine_flag_active(all_trees))
+
+	var again: Dictionary = _pick_fruit_tree(data, state)
+	assert_eq(again["status"], &"complete", JSON.stringify(again))
+	assert_eq(state.item_quantity(FRUIT_TREE_ITEM), 1)
+
+	assert_true(state.reset_daily_flags())
+	assert_false(state.is_engine_flag_active(all_trees))
+	var tomorrow: Dictionary = _pick_fruit_tree(data, state)
+	assert_eq(tomorrow["status"], &"complete", JSON.stringify(tomorrow))
+	assert_eq(state.item_quantity(FRUIT_TREE_ITEM), 2)
+	assert_true(state.fruit_tree_picked(FRUIT_TREE_AZALEA))
+
+
+func test_a_full_stack_leaves_the_fruit_on_the_tree() -> void:
+	_write_fruit_tree_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new({}, {}, {FRUIT_TREE_ITEM: Gen2WorldPack.MAX_ITEM_STACK})
+
+	var refused: Dictionary = _pick_fruit_tree(data, state)
+	assert_eq(refused["status"], &"complete", JSON.stringify(refused))
+	assert_eq(state.item_quantity(FRUIT_TREE_ITEM), Gen2WorldPack.MAX_ITEM_STACK)
+	## The source sets the tree's flag only past `giveitem`, so a full pack
+	## leaves the fruit hanging.
+	assert_false(state.fruit_tree_picked(FRUIT_TREE_AZALEA))
+
+
+func test_the_picked_fruit_trees_survive_a_snapshot_round_trip() -> void:
+	var state := Gen2WorldState.new()
+	state.apply_changes({}, {}, {"fruit_trees": {FRUIT_TREE_AZALEA: true, 1: true}})
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_true(restored.fruit_tree_picked(FRUIT_TREE_AZALEA))
+	assert_true(restored.fruit_tree_picked(1))
+	assert_false(restored.fruit_tree_picked(2))
+	## A tree id outside the source table is refused rather than stored.
+	var bad: Dictionary = state.apply_changes({}, {}, {"fruit_trees": {0: true}})
+	assert_false(bad["ok"])
+	assert_eq(bad["reason"], &"invalid_fruit_trees")

--- a/tests/unit/test_world_services_importer.gd
+++ b/tests/unit/test_world_services_importer.gd
@@ -15,6 +15,7 @@ func test_marts_phone_audio_and_referenced_menu_are_imported() -> void:
 	_write_phone(data)
 	_write_audio(data)
 	_write_menu(data)
+	_write_fruit_trees(data)
 
 	var scripts: Dictionary = {
 		"5:7000": [
@@ -82,12 +83,70 @@ func test_mart_terminator_is_required() -> void:
 	var data := PackedByteArray()
 	data.resize(0x200000)
 	_write_marts(data)
+	_write_fruit_trees(data)
 	data[RomFile.linear(5, 0x7000) + 3] = 0x00
 	var result: Dictionary = Gen2WorldServicesImporter.read_services(
 		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
 	)
 	assert_false(result["ok"])
 	assert_true(String(result["message"]).contains("Mart 0"))
+
+
+## FruitTreeItems' own thirty rows, since the importer identifies the table by
+## the apricorn run and the four matching berries rather than by a header.
+func _write_fruit_trees(data: PackedByteArray) -> void:
+	var offset: int = int(_layout["fruit_trees"])
+	var rows: Array[int] = [
+		0xAD, 0xAD, 0xAD, 0xAD, 0x4A, 0x4A, 0x53, 0x53, 0x4E, 0x4E,
+		0x96, 0x96, 0x50, 0x50, 0x54, 0x4F,
+		0x55, 0x59, 0x63, 0x61, 0x65, 0x5D, 0x5C,
+		0xAD, 0x4A, 0x53, 0x4E, 0x50, 0x54, 0x4F,
+	]
+	for index: int in rows.size():
+		data[offset + index] = rows[index]
+
+
+func test_a_fruit_tree_table_without_its_apricorn_run_is_refused() -> void:
+	var data := PackedByteArray()
+	data.resize(0x200000)
+	_write_marts(data)
+	_write_phone(data)
+	_write_audio(data)
+	_write_fruit_trees(data)
+	## A berry where the seventh apricorn belongs: in bounds, plausible, wrong.
+	data[int(_layout["fruit_trees"]) + 22] = 0xAD
+	var result: Dictionary = Gen2WorldServicesImporter.read_fruit_trees(
+		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
+	)
+	assert_false(result["ok"])
+	assert_true(String(result["message"]).contains("apricorns"), String(result["message"]))
+
+
+func test_a_fruit_tree_table_whose_first_berries_disagree_is_refused() -> void:
+	var data := PackedByteArray()
+	data.resize(0x200000)
+	_write_fruit_trees(data)
+	data[int(_layout["fruit_trees"]) + 3] = 0x4A
+	var result: Dictionary = Gen2WorldServicesImporter.read_fruit_trees(
+		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
+	)
+	assert_false(result["ok"])
+	assert_true(String(result["message"]).contains("one berry"), String(result["message"]))
+
+
+func test_the_fruit_tree_table_reads_thirty_rows_in_source_order() -> void:
+	var data := PackedByteArray()
+	data.resize(0x200000)
+	_write_fruit_trees(data)
+	var result: Dictionary = Gen2WorldServicesImporter.read_fruit_trees(
+		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
+	)
+	assert_true(result["ok"], String(result.get("message", "")))
+	var items: Array = result["items"]
+	assert_eq(items.size(), RomLayout.FRUIT_TREE_COUNT)
+	## FRUITTREE_AZALEA_TOWN is row 20 and bears the apricorn Kurt asks for.
+	assert_eq(int(items[19]), 0x61)
+	assert_eq(int(items[0]), 0xAD)
 
 
 func _write_marts(data: PackedByteArray) -> void:

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -1888,20 +1888,43 @@ func _hive_badge_path(
 		"run": after_well,
 	})
 
-	# The apricorn errand. Azalea Town's own fruit tree bears WHT_APRICORN
-	# (data/items/fruit_trees.asm), but `fruittree` reaches no host, so the walk
-	# puts the tree's fruit in the bag rather than picking it. See HANDOFF.
-	var picked: Dictionary = world.state.apply_changes({}, {}, {
-		"items": {APRICORN_WHT: 4},
+	var back_to_azalea: Dictionary = _warp_step(world, 8, 7)
+	if not bool(back_to_azalea.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Kurt's house exit after the well failed"}
+	var _azalea_after_well: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+
+	# The apricorn errand, which is two maps. WhiteApricornTree stands on (8,2)
+	# in both pins and is the only source of the apricorn Kurt asks for, so the
+	# walk picks it rather than being handed one.
+	var tree: Dictionary = _talk_to(
+		world, Vector2i(8, 3), Gen2WorldSprite.FACING_UP, save, random, data
+	)
+	path.append({
+		"step": "azalea_white_apricorn_tree",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"apricorns": world.state.item_quantity(APRICORN_WHT),
+		"run": tree,
 	})
-	if not bool(picked.get("ok", false)):
-		return {"ok": false, "path": path, "reason": "apricorn grant failed"}
-	# Kurt1 is back at (3,2) with EVENT_CLEARED_SLOWPOKE_WELL set, and the warp
-	# already left the player on his cell. `.ClearedSlowpokeWell` hands over the
-	# LURE_BALL, then `.CheckApricorns` finds the white one and asks.
+	if not bool(tree.get("ok", false)) or world.state.item_quantity(APRICORN_WHT) != 1:
+		return {
+			"ok": false, "path": path,
+			"reason": "the white apricorn tree bore nothing: %s" % tree.get("reason", ""),
+		}
+
+	var back_to_kurt: Dictionary = _warp_step(world, 8, 4)
+	if not bool(back_to_kurt.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Kurt's house re-entry failed"}
+	var _kurt_errand_entry: Dictionary = _drain_story(
+		world, world.dispatch_map_entry(), save, random, data
+	)
+	# Kurt1 is at (3,2) with EVENT_CLEARED_SLOWPOKE_WELL set. `.GotLureBall`
+	# falls through to `.CheckApricorns`, which finds the white one and asks.
 	var errand: Dictionary = _talk_to(
 		world, Vector2i(3, 3), Gen2WorldSprite.FACING_UP, save, random, data, [],
-		{"item": APRICORN_WHT, "quantity": 2}
+		{"item": APRICORN_WHT, "quantity": 1}
 	)
 	path.append({
 		"step": "kurts_apricorn_errand",
@@ -1920,13 +1943,13 @@ func _hive_badge_path(
 			"ok": false, "path": path,
 			"reason": "Kurt's apricorn errand failed: %s" % errand.get("reason", ""),
 		}
-	if world.state.kurt_apricorn_quantity() != 2 or world.state.item_quantity(APRICORN_WHT) != 2:
+	if world.state.kurt_apricorn_quantity() != 1 or world.state.item_quantity(APRICORN_WHT) != 0:
 		return {"ok": false, "path": path, "reason": "Kurt took the wrong apricorns"}
 
-	var back_to_azalea: Dictionary = _warp_step(world, 8, 7)
-	if not bool(back_to_azalea.get("ok", false)):
-		return {"ok": false, "path": path, "reason": "Kurt's house exit after the well failed"}
-	var _azalea_after_well: Dictionary = _drain_story(
+	var leaving_kurt_again: Dictionary = _warp_step(world, 8, 7)
+	if not bool(leaving_kurt_again.get("ok", false)):
+		return {"ok": false, "path": path, "reason": "Kurt's house exit after the errand failed"}
+	var _azalea_after_errand: Dictionary = _drain_story(
 		world, world.dispatch_map_entry(), save, random, data
 	)
 	var gym_door: Dictionary = _warp_walk(world, Vector2i(10, 15), save, random, data)


### PR DESCRIPTION
`fruittree` staged a request nothing answered, and `data/items/fruit_trees.asm` is the only source of an apricorn or a berry in either pin, so Kurt's errand was finished but unreachable in play.

- `FruitTreeItems` is located in bank $11 of all three dumps by its own bytes and imported as thirty item rows. It has no header and no terminator, so the layout check identifies it by content: rows 17 to 23 are the seven apricorns and no other row bears one, and the four Johto berry trees ahead of them share a berry.
- `wFruitTreeFlags` becomes saved world state, and `ENGINE_ALL_FRUIT_TREES` joins the daily reset, which is what refills every tree at once on the first one touched after the day turns.
- `FruitTreeScript` runs inline the way an item ball's does rather than through a host: `fruittree` is the whole of the object's own script.

Two defects fixed along the way. `Gen2InputRuntime.instance()` named the autoload by an absolute path, which makes even `get_node_or_null` push an error from outside the active scene tree, so every headless run that registered a mod's controls printed one per call. And the no-space item text spent a third page drawing a blank line, where the source shows two boxes; the fruit tree texts are paired the same way.

`tests/integration/test_world_frame_pump.gd` asked a host frame to land on a given hardware frame, which it cannot: it now pumps to just short and tops up exactly, as `tools/replay_world.gd` already did.

Cache format 42. The walked route picks Azalea's white apricorn from the tree before handing it to Kurt, on all three cartridges.