### PR TITLE
battle: let the player answer a switch, in the cartridge's own two boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   host resolves all of it without reopening the ROM.
 > - **Battles.** Parties, switching, running, stats, damage, accuracy, turn
 >   order, status and substatus effects, trainer AI, experience, levelling, move
->   learning and capture input on a real 160x144 screen.
+>   learning and capture input on a real 160x144 screen. In SHIFT a trainer's
+>   switch asks whether you want one too, and both that yes/no and the party
+>   list behind it are drawn on the hardware tile grid.
 > - **Overworld.** Real maps, map connections, script requests, trainer battles
 >   with imported win/loss text, map reloads, save-safe blackout recovery,
 >   object lifecycle, followers, block edits, emotes, surf, ledge hops, grass,
@@ -228,9 +230,10 @@ only, along with the map and cell readout above and below the screen. A release
 export offers the eight buttons and nothing else; the methods behind each
 shortcut stay public, which is how `tools/preview_*.gd` drives them.
 
-Battle-screen moves are random and a full move set declines the learn offer; use
-`show_trainer(trainer_class)` for a real party and trainer AI, or `show_matchup`
-for a fallback pairing.
+Battle-screen moves are random; use `show_trainer(trainer_class)` for a real
+party and trainer AI, or `show_matchup` for a fallback pairing. A full move set,
+a trainer's switch under SHIFT and a Baton Pass each stop and ask, in the
+cartridge's own boxes.
 
 The world screen's start menu wires every source entry: Pokedex, Pokemon, Pack,
 Pokegear, Player, Save, Options and Exit.
@@ -304,6 +307,7 @@ all three games unless its row says otherwise:
 | `preview_intro.gd <game> <png> [copyright\|presents\|gender\|speech\|beat] [steps]` | the new game's opening screens at hardware resolution: the copyright screen and the GameFreak animation by source frame, the gender question, and any frame of `OakSpeech` by source frame or by button press, so a fade, a bounce or a pic move can be looked at one frame at a time |
 | `preview_mom_scene.gd <game> [png] [frame]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up. The frames the emote, the walk and the box first appear on are pinned per profile, so a run that moves one exits non-zero. `frame` picks which one the `png` is of |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
+| `preview_battle_switch.gd <game> <png> [offer\|pick] [presses]` | a real trainer's switch under SHIFT: `OfferSwitch`'s yes/no box over the field, or the party list behind it. `presses` is a `u,d,l,r,a,b` list driven into the menu first, which is how a refusal is photographed |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
 | `replay_world.gd [game ...] [frames]` | records `(frame, button)` from a run of the real world screen and replays it into a fresh world, over every map of the spawn group on each cartridge. The same seed and log must reach the same `Gen2WorldSnapshot` byte for byte, and must reach it whether the frames were pumped at 30 fps or at 144 |
 | `preview_collision.gd <game> <group> <number> <png>` | one whole map as drawn, with every walk cell's permission checkerboarded over it: red is wall, blue is water. For a report that the player can stand where they should not |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -185,6 +185,7 @@ the contract and why a renderer must not write world state.
 | `render/text_box.gd` | Bordered text window |
 | `render/battle_tiles.gd` | Hardware-order battle tile page |
 | `render/battle_hud.gd` | Status panels on the tile grid |
+| `render/party_menu_page.gd` | `WritePartyMenuTilemap`'s party list |
 
 `Gen2Screen` is a `Control` with a 160x144 `SubViewport` at integer scale;
 surrounding UI uses window resolution. Project-wide stretch blurs menus and
@@ -327,9 +328,16 @@ plus the stages); `ResetBatonPassStatus` names the few things that do not.
 
 Switches happen before priority, so the incoming Pokémon takes the other
 side's move. A fainted replacement is caller policy: the turn stops at
-`must_replace` until `send_out`, and a Baton Pass target the same way. A full moveset similarly uses
-`must_learn_move`, `learn_move` and `decline_move`; the development screen
-declines automatically.
+`must_replace` until `send_out`, and a Baton Pass target the same way. A full
+moveset similarly uses `must_learn_move`, `learn_move` and `decline_move`.
+
+Three of those four questions are asked rather than answered for the player.
+`Gen2BattleSwitchMenu` is `PickSwitchMonInBattle` and its forced variant: the
+rows, the wrapping cursor and the already-out and no-energy refusals, with
+`Gen2PartyMenuPage` drawing `WritePartyMenuTilemap`'s columns and
+`Gen2MenuPage.render` drawing `PlaceYesNoBox` over the field. `must_replace` is
+the one still taken by the screen, because `ForcePlayerMonChoice` sits behind
+`AskUseNextPokemon`, whose NO runs away outside a turn.
 
 Trainer details:
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -202,6 +202,15 @@ var _forget_moves: Array = []
 var _forget_cursor: int = 0
 var _forget_confirm_cursor: int = 0
 
+## Where a switch has got to. [code]&"offer"[/code] is `OfferSwitch`'s
+## `PlaceYesNoBox` and [code]&"pick"[/code] the party menu
+## `SetUpBattlePartyMenu` puts up behind it, which Baton Pass opens straight
+## into. Empty when neither is on screen.
+var _switch_stage: StringName = &""
+var _switch_menu: Gen2BattleSwitchMenu = null
+## The yes/no box's own cursor, which is a two-row `VerticalMenu`.
+var _switch_offer: Gen2WorldMenu = null
+
 ## The trainer class behind the enemy's own moves, or zero for
 ## [method show_matchup]'s invented pairing, which has no class and so no AI
 ## flags of its own to read: it falls back to [method _random_slot], same as
@@ -223,6 +232,15 @@ var _player_max_hp: int = 0
 var _exp: int = 0
 
 var _box: Gen2TextBox = null
+
+## The two menus a switch is made with, and the one layer both are drawn on:
+## `PlaceYesNoBox`'s frame over the field, or the whole party page in place of
+## it, which is what `SetUpBattlePartyMenu` clearing the screen amounts to.
+var _menu_page: Gen2MenuPage = null
+var _party_page: Gen2PartyMenuPage = null
+var _menu_layer: TextureRect = null
+## What the layer currently holds, so a per-frame refresh redraws nothing.
+var _menu_drawn: String = ""
 
 ## `wTilemap` as this battle leaves it, which is what an animation edits and
 ## what the renderer draws both pictures out of.
@@ -247,6 +265,10 @@ var _audio_player: Gen2AudioPlayer = null
 ## step `HPBarAnim_BGMapUpdate` waits and `BattleIntroSlidingPics`' own
 ## `DelayFrame` are both hardware frame counts.
 func _process(delta: float) -> void:
+	## The yes/no box appears when the question above it has finished printing,
+	## and the box prints on its own clock rather than on a press.
+	if _switch_stage != &"":
+		_refresh_menu_layer()
 	if not frames_running():
 		_frame_elapsed = 0.0
 		return
@@ -289,6 +311,16 @@ func _ready() -> void:
 	_audio_player.name = "AudioPlayer"
 	add_child(_audio_player)
 	_anim_data = Gen2BattleAnimData.from_game_data(_data)
+
+	## Under the text box, because the refusals a switch list is answered with are
+	## `StdBattleTextbox` drawn over the party menu rather than into it. The
+	## yes/no box sits above the box's own rows and never meets it.
+	_menu_page = Gen2MenuPage.from_data(_data)
+	_party_page = Gen2PartyMenuPage.from_data(_data)
+	_menu_layer = TextureRect.new()
+	_menu_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu_layer.visible = false
+	_screen.display(_menu_layer)
 
 	_box = Gen2TextBox.new()
 	_box.font = Gen2Font.from_data(_data)
@@ -687,6 +719,7 @@ func _init_battle_display() -> void:
 	## reading the options file itself, since it is scene-free; this is the one
 	## place every battle here passes through.
 	_battle.battle_style_set = Gen2OptionsStore.current().battle_style_set
+	_close_switch()
 	_reseed_bg_map()
 	set_hp(
 		_battle.enemy.hp, _battle.enemy.max_hp(),
@@ -1121,6 +1154,12 @@ func battle_snapshot() -> Dictionary:
 		"player": _player,
 		"message": _last_message,
 		"completion_sent": _world_battle_completion_sent,
+		"switch_stage": _switch_stage,
+		"switch_cursor": (
+			_switch_offer.selected_index() if _switch_offer != null
+			else (_switch_menu.cursor if _switch_menu != null else -1)
+		),
+		"switch_forced": _switch_menu != null and _switch_menu.forced,
 		"capture_selecting": _capture_selecting,
 		"capture_waiting": _capture_waiting,
 		"capture_ball": _selected_capture_ball(),
@@ -1772,10 +1811,10 @@ func _prepare_world_battle_recovery() -> bool:
 
 ## Answers a Baton Pass that stopped the turn, and whether there was one.
 ##
-## `ForcePickSwitchMonInBattle` is a menu, and this screen has none, so it takes
-## the first Pokémon standing exactly as [method _replace_the_fallen] does for a
-## faint. The engine keeps the choice open either way; what is missing is a
-## screen to make it with, not the seam.
+## The player's target is `ForcePickSwitchMonInBattle`, which is the party menu
+## with no way out of it, so the list is opened and the turn stays standing until
+## a row answers it. The enemy's is `FindMonInOTPartyToSwitchIntoBattle`, the
+## AI's own type-matchup pick, which [method Gen2Battle.baton_pass_target] makes.
 ##
 ## It is answered before a replacement, because a turn left standing here has not
 ## finished and nothing behind it can be asked yet.
@@ -1785,7 +1824,11 @@ func _answer_baton_pass() -> bool:
 	var side: int = _battle.awaiting_baton_pass()
 	if side < 0:
 		return false
-	var next: int = _next_healthy(side)
+	if side == Gen2Battle.PLAYER:
+		if _switch_stage == &"":
+			_open_switch_pick(true)
+		return true
+	var next: int = _battle.baton_pass_target(side)
 	if next < 0:
 		return false
 	_pending = _battle.pass_to(next)
@@ -1793,27 +1836,265 @@ func _answer_baton_pass() -> bool:
 	return true
 
 
-## Answers `OfferSwitch`'s yes/no, which only SHIFT ever reaches, and whether
-## there was one to answer.
-##
-## `PlaceYesNoBox` is a menu and this screen has none, so it declines: the
-## trainer's Pokémon comes in and the player's stays, which is what SET would
-## have done without asking. The engine keeps the choice open; what is missing
-## is a screen to make it with, the same gap [method _answer_baton_pass] has.
+## Opens `OfferSwitch`'s yes/no, which only SHIFT ever reaches, and answers
+## whether there was a question to put up.
 ##
 ## Answered before a replacement for the same reason a Baton Pass is: the turn it
 ## stopped has not finished, and nothing behind it can be asked yet.
 func _answer_switch_offer() -> bool:
 	if _battle == null or _battle.awaiting_switch_offer() < 0:
 		return false
-	_pending = _battle.answer_switch_offer(-1)
-	_show_next_event()
+	if _switch_stage == &"":
+		_open_switch_offer()
 	return true
 
 
+## `OfferSwitch`'s own `lb bc, 1, 7` through `_YesNoBox`, which stores the left
+## and top coordinates it is handed and adds five and four for the other two
+## (`home/menu.asm`). The flags, the two options and the `db 1` that opens the
+## cursor on YES are `YesNoMenuHeader`'s. `InterpretTwoOptionMenu`'s fifteen
+## frames between the answer and the box coming down are not spent, the way no
+## other menu delay here is.
+const YES_NO_LEFT: int = 1
+const YES_NO_TOP: int = 7
+const YES_NO_SPAN: Vector2i = Vector2i(5, 4)
+const YES_NO_OPTIONS: Array[String] = ["YES", "NO"]
+const YES_NO_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR \
+	| Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+
+
+## Puts `OfferSwitch`'s question and its yes/no box up. The enemy's Pokémon is
+## named while it is still on its way in, which is the whole point of asking
+## before `ShowSetEnemyMonAndSendOutAnimation`.
+func _open_switch_offer() -> void:
+	var incoming: Gen2BattleMon = _battle.party(Gen2Battle.ENEMY).at(
+		_battle.awaiting_switch_offer()
+	)
+	show_message(Gen2BattleSwitchMenu.offer_text(
+		_enemy_label(), incoming.name_text() if incoming != null else "", _player_label()
+	))
+	_switch_offer = Gen2WorldMenu.new()
+	_switch_offer.options = YES_NO_OPTIONS.duplicate()
+	_switch_offer.flags = YES_NO_FLAGS
+	_switch_offer.rows = YES_NO_OPTIONS.size()
+	_switch_offer.cursor = 0
+	_switch_stage = &"offer"
+	_reopen_menu_layer()
+
+
+## `SetUpBattlePartyMenu` and the list behind it. [param forced] is the Baton
+## Pass variant, which cannot be backed out of.
+func _open_switch_pick(forced: bool) -> void:
+	_switch_menu = Gen2BattleSwitchMenu.for_party(_battle.party(Gen2Battle.PLAYER), forced)
+	_switch_offer = null
+	_switch_stage = &"pick"
+	## The party menu is the whole screen rather than a box on it, so the battle's
+	## own box goes with the field it belongs to.
+	if _box != null:
+		_box.visible = false
+	_reopen_menu_layer()
+
+
+func _close_switch() -> void:
+	_switch_stage = &""
+	_switch_menu = null
+	_switch_offer = null
+	if _box != null:
+		_box.visible = true
+	_reopen_menu_layer()
+
+
+## What a press does while either menu is up.
+func _answer_switch(button: int) -> void:
+	match _switch_stage:
+		&"offer":
+			_answer_switch_offer_button(button)
+		&"pick":
+			_answer_switch_pick(button)
+		&"refused":
+			## `StdBattleTextbox` blocks on a button and `jr .loop` reopens the
+			## list behind it.
+			if _box != null and _box.advance():
+				return
+			_open_switch_pick(_switch_menu != null and _switch_menu.forced)
+
+
+## `InterpretTwoOptionMenu` over `YesNoMenuHeader`: two rows that do not wrap,
+## and a B that is the same answer as NO.
+func _answer_switch_offer_button(button: int) -> void:
+	## The question is two paragraphs, so a press reads it before it answers
+	## anything, the way [method _answer_forget] does. The box is not up on
+	## hardware until the text is either.
+	if _offer_still_reading():
+		if button == Gen2Button.A:
+			_box.advance()
+			_refresh_menu_layer()
+		return
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN:
+			_switch_offer.move(Vector2i(0, 1 if button == Gen2Button.DOWN else -1))
+			_refresh_menu_layer()
+		Gen2Button.A:
+			if _switch_offer.selected_index() == 0:
+				_open_switch_pick(false)
+			else:
+				_decline_switch_offer()
+		Gen2Button.B:
+			_decline_switch_offer()
+
+
+## Whether `StdBattleTextbox` is still printing the question the box belongs to.
+func _offer_still_reading() -> bool:
+	return _box != null and (_box.is_revealing() or _box.has_pages_left())
+
+
+## `PartyMenuSelect`'s own joypad filter: the cursor, A and B, with everything
+## else ignored.
+func _answer_switch_pick(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			_switch_menu.move(-1)
+			_refresh_menu_layer()
+		Gen2Button.DOWN:
+			_switch_menu.move(1)
+			_refresh_menu_layer()
+		Gen2Button.A:
+			_resolve_switch(_switch_menu.confirm())
+		Gen2Button.B:
+			_resolve_switch(_switch_menu.cancel())
+
+
+func _resolve_switch(answer: Dictionary) -> void:
+	match StringName(answer.get("result", &"")):
+		Gen2BattleSwitchMenu.CHOSEN:
+			_play_anim_sound(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+			_commit_switch(int(answer.get("index", -1)))
+		Gen2BattleSwitchMenu.CANCELLED:
+			_play_anim_sound(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+			## `OfferSwitch.canceled_switch` falls into `.said_no`: backing out of
+			## the list is the same answer as NO.
+			_decline_switch_offer()
+		Gen2BattleSwitchMenu.CANNOT_CANCEL:
+			_play_anim_sound(int(answer.get("sfx", 0)))
+		_:
+			_show_switch_refusal(String(answer.get("text", "")))
+
+
+## The chosen row, which finishes whichever question the list was opened for.
+func _commit_switch(index: int) -> void:
+	var forced: bool = _switch_menu != null and _switch_menu.forced
+	_close_switch()
+	_pending = _battle.pass_to(index) if forced else _battle.answer_switch_offer(index)
+	_show_next_event()
+
+
+func _decline_switch_offer() -> void:
+	_close_switch()
+	_pending = _battle.answer_switch_offer(-1)
+	_show_next_event()
+
+
+## `BattleText_MonIsAlreadyOut` and `BattleText_TheresNoWillToBattle`, which the
+## source prints in a battle text box over the party menu and then redraws the
+## list behind.
+func _show_switch_refusal(text: String) -> void:
+	_switch_stage = &"refused"
+	if _box != null:
+		_box.visible = true
+	show_message(text)
+	_reopen_menu_layer()
+
+
+## `PlaceEnemysName`: the opponent's class name, a space, and their own name.
+func _enemy_label() -> String:
+	if _enemy_trainer_class <= 0 or _data == null:
+		return _name_of(_enemy)
+	return "%s %s" % [_data.trainer_name(_enemy_trainer_class), _enemy_trainer_name()]
+
+
+## `<PLAYER>`. A development battle has no save to read a name off, so
+## `NewGame`'s own default stands in rather than a blank in the middle of a
+## sentence.
+func _player_label() -> String:
+	if _source_save != null and not _source_save.player_name.is_empty():
+		return _source_save.player_name
+	return Gen2OakSpeech.DEFAULT_MALE
+
+
+## Redraws the menu layer even when nothing about the cursor moved, which is what
+## opening a list has to do: the same stage and cursor can be looking at a
+## different party.
+func _reopen_menu_layer() -> void:
+	_menu_drawn = ""
+	_refresh_menu_layer()
+
+
+## The yes/no frame over the field, or the whole party page in place of it.
+## Cheap to call every frame: it rebuilds only when what it would draw changed.
+func _refresh_menu_layer() -> void:
+	if _menu_layer == null:
+		return
+	var signature: String = "%s|%d|%d" % [
+		_switch_stage,
+		_switch_offer.selected_index() if _switch_offer != null else (
+			_switch_menu.cursor if _switch_menu != null else -1
+		),
+		int(_offer_still_reading()),
+	]
+	if signature == _menu_drawn:
+		return
+	_menu_drawn = signature
+
+	match _switch_stage:
+		&"offer":
+			_draw_yes_no_box()
+		&"pick", &"refused":
+			_draw_party_page()
+		_:
+			_menu_layer.visible = false
+
+
+func _draw_yes_no_box() -> void:
+	if _menu_page == null or _offer_still_reading():
+		_menu_layer.visible = false
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		YES_NO_LEFT, YES_NO_TOP,
+		YES_NO_LEFT + YES_NO_SPAN.x, YES_NO_TOP + YES_NO_SPAN.y, YES_NO_FLAGS
+	)
+	_show_menu_image(
+		_menu_page.render(box, YES_NO_OPTIONS, _switch_offer.selected_index()),
+		box.border_position() * Gen2Font.TILE
+	)
+
+
+func _draw_party_page() -> void:
+	if _party_page == null or _switch_menu == null:
+		_menu_layer.visible = false
+		return
+	_show_menu_image(
+		_party_page.render(
+			_switch_menu.rows, _switch_menu.cursor, Gen2BattleSwitchMenu.prompt_text()
+		),
+		Vector2i.ZERO
+	)
+
+
+func _show_menu_image(image: Image, at: Vector2i) -> void:
+	_menu_layer.texture = ImageTexture.create_from_image(image)
+	_menu_layer.position = Vector2(at)
+	_menu_layer.size = Vector2(image.get_size())
+	_menu_layer.visible = true
+
+
 ## Sends out the first Pokémon standing on any side that owes one, and answers
-## whether it had to. Choosing which is a menu on the player's side and an AI on
-## the enemy's; this screen has neither, so it takes the first.
+## whether it had to.
+##
+## Still the only place that picks for the player rather than asking. The list is
+## the same one [method _open_switch_pick] opens, but `ForcePlayerMonChoice` is
+## reached through `AskUseNextPokemon`, whose NO runs away outside a turn, and
+## the enemy's own replacement is `FindPkmnInOTPartyToSwitchIntoBattle` rather
+## than the first standing. Both are engine work rather than a missing menu.
 func _replace_the_fallen() -> bool:
 	if _battle == null:
 		return false
@@ -2401,19 +2682,24 @@ func _unhandled_input(event: InputEvent) -> void:
 
 ## Whether the battle itself is idle enough to pass an event on.
 ##
-## The two modal input states are the ones that mean something by themselves: the
-## forget-move prompt and ball selection. A draining bar, the opening slide and a
-## move animation are deliberately not on that list. None of them reads input,
-## and a camera that stops answering every time a bar drains is not a camera; the
-## presses they do swallow are swallowed in [method _handle_button], which runs
-## first and never reaches here.
+## The modal input states are the ones that mean something by themselves: the
+## forget-move prompt, a switch's yes/no or list, and ball selection. A draining
+## bar, the opening slide and a move animation are deliberately not on that list.
+## None of them reads input, and a camera that stops answering every time a bar
+## drains is not a camera; the presses they do swallow are swallowed in
+## [method _handle_button], which runs first and never reaches here.
 func _renderer_input_free() -> bool:
-	return is_ready() and _forget_stage == &"" and not _capture_selecting
+	return is_ready() and _forget_stage == &"" and _switch_stage == &"" \
+		and not _capture_selecting
 
 
 func _handle_button(button: int) -> bool:
 	if _forget_stage != &"":
 		_answer_forget(button)
+		return true
+
+	if _switch_stage != &"":
+		_answer_switch(button)
 		return true
 
 	if _capture_selecting:

--- a/game/battle/battle_switch_menu.gd
+++ b/game/battle/battle_switch_menu.gd
@@ -1,0 +1,155 @@
+class_name Gen2BattleSwitchMenu
+extends RefCounted
+
+## Choosing who comes in next, from inside a battle
+## (`PickSwitchMonInBattle` and `ForcePickSwitchMonInBattle`,
+## `engine/battle/core.asm`).
+##
+## Two callers, one list. `OfferSwitch`'s YES reaches the first, which the player
+## can back out of; Baton Pass reaches the second through
+## `ForcePickPartyMonInBattle`, which cannot be backed out of and answers a
+## refusal with `SFX_WRONG` and the list again.
+##
+## Both wrap `PickPartyMonInBattle`, so both make the same two checks on the row
+## that was chosen and print the same two lines:
+##
+## - `CheckIfCurPartyMonIsFitToFight`: a fainted Pokémon prints
+##   `BattleText_TheresNoWillToBattle`;
+## - `SwitchMonAlreadyOut`: the Pokémon already standing prints
+##   `BattleText_MonIsAlreadyOut`.
+##
+## Scene-free: the rows and the cursor rules live here, [Gen2PartyMenuPage] draws
+## them and the battle screen owns the presses. `SetUpBattlePartyMenu` always
+## goes through `InitPartyMenuWithCancel`, so CANCEL is a row in both variants;
+## in the forced one choosing it is refused rather than absent.
+
+## `PartyMenu2DMenuData`'s `_2DMENU_WRAP_UP_DOWN`, which is the only movement
+## flag the party menu sets: the list wraps and there is one column.
+const WRAPS: bool = true
+
+## `InitPartyMenuWithCancel` writes `wMenuCursorY` 1, which is the first member.
+const DEFAULT_CURSOR: int = 0
+
+## `SFX_WRONG`, which `ForcePickPartyMonInBattle` plays when the pick it cannot
+## refuse is refused anyway, and `SFX_READ_TEXT_2`, which `PartyMenuSelect` plays
+## on both of its own ways out (`constants/sfx_constants.asm`).
+const SFX_WRONG: int = 0x19
+const SFX_READ_TEXT_2: int = 0x08
+
+## What [method confirm] and [method cancel] answer with.
+const CHOSEN: StringName = &"chosen"
+const CANCELLED: StringName = &"cancelled"
+const ALREADY_OUT: StringName = &"already_out"
+const NO_ENERGY: StringName = &"no_energy"
+const CANNOT_CANCEL: StringName = &"cannot_cancel"
+
+## One row per party member, in party order:
+## `{index, name, level, hp, max_hp, status, fainted}`. [Gen2PartyMenuPage] draws
+## exactly these fields and nothing reads the battle behind them.
+var rows: Array = []
+
+## `ForcePickSwitchMonInBattle` rather than `PickSwitchMonInBattle`.
+var forced: bool = false
+
+## The party slot already on the field, which `SwitchMonAlreadyOut` compares
+## against.
+var active: int = -1
+
+## Zero-based over [method item_count], the CANCEL row last.
+var cursor: int = DEFAULT_CURSOR
+
+
+static func for_party(party: Gen2Party, is_forced: bool = false) -> Gen2BattleSwitchMenu:
+	var menu := Gen2BattleSwitchMenu.new()
+	menu.forced = is_forced
+	if party == null:
+		return menu
+	menu.active = party.active
+	for index: int in party.size():
+		var mon: Gen2BattleMon = party.at(index)
+		if mon == null:
+			continue
+		menu.rows.append({
+			"index": index,
+			"name": mon.name_text(),
+			"level": mon.level,
+			"hp": mon.hp,
+			"max_hp": mon.max_hp(),
+			"status": mon.status,
+			"fainted": mon.is_fainted(),
+		})
+	return menu
+
+
+## `w2DMenuNumRows`: the party plus CANCEL.
+func item_count() -> int:
+	return rows.size() + 1
+
+
+func is_cancel(index: int) -> bool:
+	return index == rows.size()
+
+
+## `_2DMENU_WRAP_UP_DOWN` over one column. Answers whether the cursor moved,
+## which it always does on a list of more than one row.
+func move(delta: int) -> bool:
+	if delta == 0 or item_count() <= 1:
+		return false
+	cursor = wrapi(cursor + delta, 0, item_count())
+	return true
+
+
+## A is `PartyMenuSelect` returning the row, then `PickPartyMonInBattle`'s and
+## `PickSwitchMonInBattle`'s two checks over it. A refusal leaves the list
+## standing, which is what both `jr z, .loop` and `jr c, .pick` do.
+func confirm() -> Dictionary:
+	if is_cancel(cursor):
+		return cancel()
+	if cursor < 0 or cursor >= rows.size():
+		return {"result": CANNOT_CANCEL, "sfx": SFX_WRONG}
+	var row: Dictionary = rows[cursor]
+	# The source also refuses an EGG (`BattleText_AnEGGCantBattle`). A battle
+	# party here is built from Pokémon that fight, so that branch has no way to
+	# be reached and is not modelled.
+	if bool(row.get("fainted", false)):
+		return {"result": NO_ENERGY, "text": no_energy_text()}
+	if int(row.get("index", -1)) == active:
+		return {"result": ALREADY_OUT, "text": already_out_text(String(row.get("name", "")))}
+	return {"result": CHOSEN, "index": int(row.get("index", -1))}
+
+
+## B, and the CANCEL row, which `PartyMenuSelect` sets carry for alike.
+## `ForcePickPartyMonInBattle` swallows that carry, so the forced list refuses.
+func cancel() -> Dictionary:
+	if forced:
+		return {"result": CANNOT_CANCEL, "sfx": SFX_WRONG}
+	return {"result": CANCELLED}
+
+
+## `PartyMenuStrings`' `WhichPKMNString`, which `PARTYMENUACTION_SWITCH` picks
+## and `PlacePartyMenuText` prints in the box along the bottom.
+static func prompt_text() -> String:
+	return "Which PKMN?"
+
+
+## `PlacePartyNicknames`' own `.CancelString`, printed two columns left of the
+## nicknames on the row below the last one.
+static func cancel_label() -> String:
+	return "CANCEL"
+
+
+## `BattleText_TheresNoWillToBattle`.
+static func no_energy_text() -> String:
+	return "There's no will to battle!"
+
+
+## `BattleText_MonIsAlreadyOut`.
+static func already_out_text(name: String) -> String:
+	return "%s is already out." % name
+
+
+## `BattleText_EnemyIsAboutToUseWillPlayerChangeMon`, the question `OfferSwitch`
+## puts up before the trainer's Pokémon is on the field. [param trainer] is
+## `Battle_GetTrainerName`'s answer and [param mon] the one about to come in.
+static func offer_text(trainer: String, mon: String, player: String) -> String:
+	return "%s is about to use %s. Will %s change PKMN?" % [trainer, mon, player]

--- a/game/battle/battle_switch_menu.gd.uid
+++ b/game/battle/battle_switch_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://c3w1xysrfof2m

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -85,8 +85,8 @@ func draw_enemy(
 	into: PackedByteArray, width: int, name: String, level: int
 ) -> void:
 	font.draw_text(name, into, width, ENEMY_NAME.x * TILE, ENEMY_NAME.y * TILE)
-	_draw_level(into, width, ENEMY_LEVEL, level)
-	_draw_bar_frame(into, width, ENEMY_BAR, Gen2BattleTiles.HP_BAR_END)
+	draw_level(into, width, ENEMY_LEVEL, level)
+	draw_bar_frame(into, width, ENEMY_BAR, Gen2BattleTiles.HP_BAR_END)
 
 	# The edge, which starts beside the bar and turns under it.
 	var left: int = ENEMY_EDGE.x * TILE
@@ -106,8 +106,8 @@ func draw_player(
 	into: PackedByteArray, width: int, name: String, level: int, hp: int, max_hp: int
 ) -> void:
 	font.draw_text(name, into, width, PLAYER_NAME.x * TILE, PLAYER_NAME.y * TILE)
-	_draw_level(into, width, PLAYER_LEVEL, level)
-	_draw_bar_frame(into, width, PLAYER_BAR, Gen2BattleTiles.HP_BAR_END + 1)
+	draw_level(into, width, PLAYER_LEVEL, level)
+	draw_bar_frame(into, width, PLAYER_BAR, Gen2BattleTiles.HP_BAR_END + 1)
 
 	# Right-aligned in a fixed field, as the games print any number in a panel:
 	# the digits line up and the leading spaces draw nothing.
@@ -170,14 +170,14 @@ func draw_exp_bar(into: PackedByteArray, width: int, pixels: int) -> void:
 
 ## The level symbol and the number, left-aligned after it, which is how a level
 ## is written everywhere in these games.
-func _draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> void:
+func draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> void:
 	tiles.draw(Gen2BattleTiles.LEVEL, into, width, at.x * TILE, at.y * TILE)
 	font.draw_text("%d" % level, into, width, (at.x + 1) * TILE, at.y * TILE)
 
 
 ## "HP:", the empty bar and the cap that closes it: everything about a bar that
 ## does not depend on how full it is.
-func _draw_bar_frame(into: PackedByteArray, width: int, at: Vector2i, cap: int) -> void:
+func draw_bar_frame(into: PackedByteArray, width: int, at: Vector2i, cap: int) -> void:
 	var left: int = at.x * TILE
 	var top: int = at.y * TILE
 	tiles.draw(Gen2BattleTiles.HP_LABEL, into, width, left, top)

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -63,6 +63,27 @@ func draw(
 		font.draw_code(CURSOR_CODE, indices, width, arrow.x * TILE, arrow.y * TILE)
 
 
+## The same menu as an image of its own frame alone, for a screen that composes
+## layers rather than one page: the box is drawn into a screen-sized buffer at
+## its own coordinates and then cropped back to it, so [method draw]'s absolute
+## placement stays the one piece of arithmetic.
+##
+## Opaque, because `MenuBox` fills its interior: a menu over the battle field
+## covers what is behind it.
+func render(
+	box: Gen2MenuBox, options: Array, cursor: int,
+	title: String = "", title_indent: int = 0
+) -> Image:
+	var width: int = Gen2Screen.WIDTH
+	var indices: PackedByteArray = PackedByteArray()
+	indices.resize(width * Gen2Screen.HEIGHT)
+	draw(box, options, cursor, indices, width, title, title_indent)
+	return Gen2PicImage.from_indices(
+		indices, width, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	).get_region(Rect2i(box.border_position() * TILE, box.border_size() * TILE))
+
+
 ## `Textbox`'s own `ClearBox` over the interior, so a menu drawn over a filled
 ## page does not show that page through its options. The blank the source fills
 ## with is $7f, which sits below the font and draws as index 0.

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -1,0 +1,180 @@
+class_name Gen2PartyMenuPage
+extends RefCounted
+
+## The party menu as the hardware draws it: `WritePartyMenuTilemap`'s
+## `PARTYMENUACTION_SWITCH` quality set plus `PlacePartyMenuText`
+## (`engine/pokemon/party_menu.asm`).
+##
+## `SetUpBattlePartyMenu` clears the battle off the screen and puts this in its
+## place, so the page is the whole 160x144 rather than a box over the field.
+## Every column below is `hlcoord`'s own, and each quality steps two rows per
+## member because `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`.
+##
+## [Gen2BattleSwitchMenu] owns the rows and the cursor; this is presentation
+## only, and node-free, so the page can be read back headless.
+##
+## Not drawn: `InitPartyMenuGFX`'s menu mon icons, which are sprite animations
+## over columns 1 and 2 and need `gfx/icons`, and the eggs `PartyMenuCheckEgg`
+## skips every quality for, which a battle party cannot contain.
+
+const TILE: int = Gen2Font.TILE
+
+## `hlcoord` columns and the first row of each quality, from
+## `PlacePartyNicknames`, `PlacePartyHPBar`, `PlacePartyMenuHPDigits`,
+## `PlacePartyMonLevel` and `PlacePartyMonStatus`.
+const NICKNAME: Vector2i = Vector2i(3, 1)
+const HP_BAR: Vector2i = Vector2i(11, 2)
+const HP_DIGITS: Vector2i = Vector2i(13, 1)
+const LEVEL: Vector2i = Vector2i(8, 2)
+const STATUS: Vector2i = Vector2i(5, 2)
+
+## `PlacePartyNicknames.end` steps back two columns from the row below the last
+## nickname, which is where CANCEL prints.
+const CANCEL_COLUMN: int = NICKNAME.x - 2
+
+## `Place2DMenuCursor`'s column, `PartyMenu2DMenuData`'s `db 1, 0`.
+const CURSOR_COLUMN: int = 0
+
+## Rows per member, `dn 2, 0`.
+const ROW_STEP: int = 2
+
+## `PlacePartyMenuText`: `hlcoord 0, 14` with `lb bc, 2, 18`, so the frame spans
+## the full width and four rows, and the string prints at `hlcoord 1, 16`.
+const TEXTBOX: Vector2i = Vector2i(0, 14)
+const TEXTBOX_COLUMNS: int = 20
+const TEXTBOX_ROWS: int = 4
+const PROMPT: Vector2i = Vector2i(1, 16)
+
+## Both HP numbers print through `PrintNum` three digits wide, space padded.
+const HP_NUMBER_DIGITS: int = 3
+
+## `PlaceStatusString`'s three-letter strings, in the order
+## `PlaceNonFaintStatus` tests them. FNT comes first because
+## `PlaceStatusString` checks the health before it ever looks at the byte.
+const STATUS_STRINGS: Dictionary = {
+	&"poison": "PSN", &"burn": "BRN", &"freeze": "FRZ",
+	&"paralysis": "PAR", &"sleep": "SLP",
+}
+const FAINTED_STRING: String = "FNT"
+
+var font: Gen2Font = null
+var hud: Gen2BattleHud = null
+var data: GameData = null
+
+## `Textbox` draws with wTextboxFrame, so the bottom box wears whichever frame
+## the player chose, as every other box here does.
+var frame_style: int = 0
+
+
+static func from_data(source: GameData) -> Gen2PartyMenuPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(source)
+	var panels: Gen2BattleHud = Gen2BattleHud.from_data(source)
+	if glyphs == null or panels == null:
+		return null
+	var out := Gen2PartyMenuPage.new()
+	out.font = glyphs
+	out.hud = panels
+	out.data = source
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	return out
+
+
+## The whole screen, with the arrow on [param cursor] counting CANCEL as the row
+## after the last member. [param rows] is [member Gen2BattleSwitchMenu.rows].
+func render(rows: Array, cursor: int, prompt: String) -> Image:
+	var width: int = Gen2Screen.WIDTH
+	var height: int = Gen2Screen.HEIGHT
+	var page: PackedByteArray = PackedByteArray()
+	page.resize(width * height)
+
+	for index: int in rows.size():
+		_draw_member(page, width, index, rows[index])
+	font.draw_text(
+		Gen2BattleSwitchMenu.cancel_label(), page, width,
+		CANCEL_COLUMN * TILE, (NICKNAME.y + rows.size() * ROW_STEP) * TILE
+	)
+	_draw_cursor(page, width, cursor)
+	_draw_prompt(page, width, prompt)
+
+	var image: Image = Gen2PicImage.from_indices(
+		page, width, height, Gen2Palette.pic_palette(
+			PackedColorArray([Color.WHITE, Color.BLACK])
+		)
+	)
+	for index: int in rows.size():
+		_blend_bar(image, index, rows[index])
+	return image
+
+
+func _draw_member(page: PackedByteArray, width: int, index: int, row: Dictionary) -> void:
+	var step: int = index * ROW_STEP
+	var hp: int = int(row.get("hp", 0))
+	var max_hp: int = int(row.get("max_hp", 0))
+
+	font.draw_text(
+		String(row.get("name", "")), page, width,
+		NICKNAME.x * TILE, (NICKNAME.y + step) * TILE
+	)
+	font.draw_text(
+		"%s/%s" % [
+			str(hp).lpad(HP_NUMBER_DIGITS), str(max_hp).lpad(HP_NUMBER_DIGITS),
+		],
+		page, width, HP_DIGITS.x * TILE, (HP_DIGITS.y + step) * TILE
+	)
+	hud.draw_bar_frame(
+		page, width, Vector2i(HP_BAR.x, HP_BAR.y + step), Gen2BattleTiles.HP_BAR_END
+	)
+	hud.draw_level(page, width, Vector2i(LEVEL.x, LEVEL.y + step), int(row.get("level", 0)))
+	font.draw_text(
+		_status_string(row), page, width, STATUS.x * TILE, (STATUS.y + step) * TILE
+	)
+
+
+## The fill of one bar, blended over the page in its own colour: the hardware
+## gives every tile its own palette, and one index buffer carries one.
+func _blend_bar(image: Image, index: int, row: Dictionary) -> void:
+	var width: int = Gen2Screen.WIDTH
+	var buffer: PackedByteArray = PackedByteArray()
+	buffer.resize(width * Gen2Screen.HEIGHT)
+	var hp: int = int(row.get("hp", 0))
+	var max_hp: int = int(row.get("max_hp", 0))
+	var top: int = HP_BAR.y + index * ROW_STEP
+	hud.draw_hp_bar(buffer, width, Vector2i(HP_BAR.x, top), hp, max_hp)
+
+	var lit: int = Gen2BattleHud.bar_pixels(
+		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE
+	)
+	var fill: Image = Gen2PicImage.from_indices(
+		buffer, width, Gen2Screen.HEIGHT,
+		data.bar_palette(GameData.hp_bar_palette_name(lit)), true
+	)
+	var at := Vector2i((HP_BAR.x + 2) * TILE, top * TILE)
+	image.blend_rect(
+		fill, Rect2i(at, Vector2i(Gen2BattleHud.HP_BAR_TILES * TILE, TILE)), at
+	)
+
+
+## `PlaceStatusString`: FNT for no health left, otherwise the first flag on the
+## byte, or nothing at all for a Pokémon with none.
+func _status_string(row: Dictionary) -> String:
+	if bool(row.get("fainted", false)):
+		return FAINTED_STRING
+	var name: StringName = Gen2Status.name_of(int(row.get("status", 0)))
+	return String(STATUS_STRINGS.get(name, ""))
+
+
+func _draw_cursor(page: PackedByteArray, width: int, cursor: int) -> void:
+	if cursor < 0:
+		return
+	font.draw_code(
+		Gen2MenuPage.CURSOR_CODE, page, width,
+		CURSOR_COLUMN * TILE, (NICKNAME.y + cursor * ROW_STEP) * TILE
+	)
+
+
+func _draw_prompt(page: PackedByteArray, width: int, prompt: String) -> void:
+	font.draw_box(
+		frame_style, page, width, TEXTBOX.x * TILE, TEXTBOX.y * TILE,
+		TEXTBOX_COLUMNS, TEXTBOX_ROWS
+	)
+	font.draw_text(prompt, page, width, PROMPT.x * TILE, PROMPT.y * TILE)

--- a/game/render/party_menu_page.gd.uid
+++ b/game/render/party_menu_page.gd.uid
@@ -1,0 +1,1 @@
+uid://diuqdm7m3q2mj

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -133,6 +133,14 @@ func is_revealing() -> bool:
 	return _shown < float(_tiles_on_page)
 
 
+## Whether a page after this one is still waiting, which is what the blinking
+## arrow means. A screen putting a menu over the box waits for both this and
+## [method is_revealing] to be false, since the cartridge prints the whole text
+## before it opens one.
+func has_pages_left() -> bool:
+	return _page + 1 < _pages.size()
+
+
 ## Reveals the rest of the current page at once.
 func finish() -> void:
 	_shown = float(_tiles_on_page)

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -1,0 +1,311 @@
+extends GutTest
+
+## Scene integration for the two questions a battle asks about switching:
+## `OfferSwitch`'s yes/no, which SHIFT is the whole point of, and the forced
+## party list Baton Pass opens (`engine/battle/core.asm`).
+##
+## The cache is synthetic; the battle screen, its text box, the two menus and
+## [Gen2Battle] are the production paths. Both used to be answered by the screen
+## because there was nothing to answer them with.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
+
+var _data: GameData = null
+var _screen: Gen2BattleScreen = null
+var _rng := RandomNumberGenerator.new()
+
+
+func before_each() -> void:
+	Gen2ModHost.reset()
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+	_rng.seed = 5
+
+
+func after_each() -> void:
+	if is_instance_valid(_screen):
+		_screen.free()
+		_screen = null
+	RomCache.clear(Fixture.directory())
+	Gen2ModHost.reset()
+
+
+func _mon(species: int, moves: Array) -> Gen2BattleMon:
+	return Gen2BattleMon.create(_data, species, 20, moves)
+
+
+func _open(battle: Gen2Battle, actions: Array) -> void:
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_screen = packed.instantiate() as Gen2BattleScreen
+	_screen.set_data(_data)
+	add_child(_screen)
+	await get_tree().process_frame
+	_screen.show_matchup(BattleFixture.GEODUDE, BattleFixture.PIKACHU, 20, 20)
+	_screen.set("_battle", battle)
+	_screen.set("_pending", battle.take_actions(actions[0], actions[1]))
+	await get_tree().process_frame
+
+
+## A trainer battle with a bench on both sides, which is what
+## `CheckWhetherToAskSwitch` needs before it asks anything.
+func _trainer_battle(shift: bool) -> Gen2Battle:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(BattleFixture.PIKACHU, [BattleFixture.TACKLE]),
+			_mon(BattleFixture.BULBASAUR, [BattleFixture.TACKLE]),
+		]),
+		Gen2Party.create([
+			_mon(BattleFixture.GEODUDE, [BattleFixture.TACKLE]),
+			_mon(BattleFixture.CHARMANDER, [BattleFixture.TACKLE]),
+		]),
+		_rng, true
+	)
+	battle.battle_style_set = not shift
+	return battle
+
+
+func _settle_bars() -> void:
+	var guard: int = 4000
+	while _screen.frames_running() and guard > 0:
+		_screen.advance_frame()
+		guard -= 1
+
+
+func _stage() -> String:
+	return String(_screen.battle_snapshot()["switch_stage"])
+
+
+func _cursor() -> int:
+	return int(_screen.battle_snapshot()["switch_cursor"])
+
+
+func _layer() -> TextureRect:
+	return _screen.get("_menu_layer")
+
+
+func _advance_to(stage: String, limit: int = 40) -> void:
+	for _press: int in limit:
+		if _stage() == stage:
+			return
+		_settle_bars()
+		_screen.finish()
+		_screen.advance()
+		await get_tree().process_frame
+
+
+## Reads the question to its last page without advancing off it, which is what a
+## player does before a yes/no box is up to answer.
+func _read_question() -> void:
+	var box: Gen2TextBox = _screen.get("_box")
+	while box != null and (box.is_revealing() or box.has_pages_left()):
+		box.finish()
+		if box.has_pages_left():
+			box.advance()
+	_screen._refresh_menu_layer()
+	await get_tree().process_frame
+
+
+func _press(button: int) -> void:
+	_settle_bars()
+	_screen._handle_button(button)
+	await get_tree().process_frame
+
+
+## `OfferSwitch` prints the question and only then places the box, so the two
+## paragraphs cannot be answered before they have been read.
+func test_shift_puts_the_question_up_before_its_yes_no_box() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer")
+
+	assert_eq(_stage(), "offer")
+	assert_true(
+		String(_screen.battle_snapshot()["message"]).contains("change PKMN"),
+		String(_screen.battle_snapshot()["message"])
+	)
+	assert_false(_layer().visible, "the box is not up while the question is printing")
+
+	await _read_question()
+	assert_true(_layer().visible, "and is once it has been read")
+	assert_eq(_cursor(), 0, "YesNoMenuHeader opens on YES")
+
+
+## NO is `.said_no`: the trainer's Pokémon comes in and the player's stays,
+## which is what SET would have done without asking.
+func test_no_sends_the_trainer_out_and_leaves_the_player_standing() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer")
+	await _read_question()
+
+	await _press(Gen2Button.DOWN)
+	assert_eq(_cursor(), 1)
+	await _press(Gen2Button.A)
+
+	assert_eq(_stage(), "", "the question is answered")
+	assert_eq(battle.awaiting_switch_offer(), -1)
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0)
+	assert_false(_layer().visible)
+
+
+## `InterpretTwoOptionMenu` returns carry on B, which `OfferSwitch` reads as no.
+func test_b_is_the_same_answer_as_no() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer")
+	await _read_question()
+
+	await _press(Gen2Button.B)
+	assert_eq(_stage(), "")
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0)
+
+
+## YES is `SetUpBattlePartyMenu` and `PickSwitchMonInBattle`: the party list, and
+## the row chosen there is the switch.
+func test_yes_opens_the_party_list_and_the_chosen_row_switches() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer")
+	await _read_question()
+
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick")
+	assert_true(_layer().visible)
+	assert_eq(_layer().position, Vector2.ZERO, "the list is the whole screen")
+	assert_false((_screen.get("_box") as Gen2TextBox).visible, "and the battle's box is not")
+
+	await _press(Gen2Button.DOWN)
+	assert_eq(_cursor(), 1)
+	await _press(Gen2Button.A)
+
+	assert_eq(_stage(), "")
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the player switched too")
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+	assert_true((_screen.get("_box") as Gen2TextBox).visible)
+
+
+## `SwitchMonAlreadyOut` is `jr c, .pick`: the line is printed over the list and
+## the list comes back rather than the question being answered.
+func test_the_one_already_out_is_refused_and_the_list_comes_back() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer")
+	await _read_question()
+	await _press(Gen2Button.A)
+
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "refused")
+	assert_true(
+		String(_screen.battle_snapshot()["message"]).contains("is already out"),
+		String(_screen.battle_snapshot()["message"])
+	)
+	assert_eq(battle.awaiting_switch_offer(), 1, "and nothing was answered")
+
+	## The first press finishes the line the box is still revealing, as it does
+	## anywhere else; the second is the one `StdBattleTextbox` was waiting for.
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "refused")
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick", "the list is redrawn")
+	assert_true(_layer().visible)
+
+
+## CANCEL is `OfferSwitch.canceled_switch`, which falls into `.said_no`.
+func test_cancelling_the_list_is_the_same_answer_as_no() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer")
+	await _read_question()
+	await _press(Gen2Button.A)
+
+	await _press(Gen2Button.B)
+	assert_eq(_stage(), "")
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0)
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+
+
+## SET is the whole of `CheckWhetherToAskSwitch`'s third refusal, so no menu is
+## ever opened and the turn runs on.
+func test_set_never_opens_a_menu() -> void:
+	var battle: Gen2Battle = _trainer_battle(false)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	await _advance_to("offer", 20)
+	assert_eq(_stage(), "")
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+
+
+func _baton_pass_battle() -> Gen2Battle:
+	return Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(BattleFixture.PIKACHU, [BattleFixture.BATON_PASS]),
+			_mon(BattleFixture.BULBASAUR, [BattleFixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(BattleFixture.GEODUDE, [BattleFixture.TACKLE])),
+		_rng, false
+	)
+
+
+## `ForcePickSwitchMonInBattle` cannot be backed out of: neither B nor the CANCEL
+## row leaves the list, and the turn stays standing behind it.
+func test_baton_pass_opens_a_list_that_cannot_be_backed_out_of() -> void:
+	var battle: Gen2Battle = _baton_pass_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to("pick")
+
+	assert_eq(_stage(), "pick")
+	assert_true(bool(_screen.battle_snapshot()["switch_forced"]))
+	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
+
+	await _press(Gen2Button.B)
+	assert_eq(_stage(), "pick", "B is swallowed")
+	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
+
+	## Two rows and CANCEL, so two presses down reach it.
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.DOWN)
+	assert_eq(_cursor(), 2)
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick", "and so is the CANCEL row")
+
+	await _press(Gen2Button.UP)
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "")
+	assert_eq(battle.awaiting_baton_pass(), -1)
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the pass landed on the row chosen")
+
+
+## The enemy's own Baton Pass is `FindMonInOTPartyToSwitchIntoBattle`, the AI's
+## pick, and opens no menu at all.
+func test_the_enemys_baton_pass_is_answered_by_its_own_ai() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.of(_mon(BattleFixture.PIKACHU, [BattleFixture.TACKLE])),
+		Gen2Party.create([
+			_mon(BattleFixture.GEODUDE, [BattleFixture.BATON_PASS]),
+			_mon(BattleFixture.CHARMANDER, [BattleFixture.TACKLE]),
+		]),
+		_rng, true
+	)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to("pick", 20)
+
+	assert_eq(_stage(), "", "no menu was opened for the other side")
+	assert_eq(battle.awaiting_baton_pass(), -1)
+	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
+
+
+## A mod's renderer is offered the leftovers only while the screen is not asking
+## a question of its own, the way it is for the forget prompt and ball selection.
+func test_a_renderer_is_not_offered_input_while_a_menu_is_up() -> void:
+	var battle: Gen2Battle = _trainer_battle(true)
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
+	assert_true(_screen._renderer_input_free())
+	await _advance_to("offer")
+	assert_false(_screen._renderer_input_free())
+	await _read_question()
+	await _press(Gen2Button.B)
+	assert_true(_screen._renderer_input_free())

--- a/tests/integration/test_battle_switch_screen.gd.uid
+++ b/tests/integration/test_battle_switch_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dng2us4ii3ljw

--- a/tests/unit/test_battle_switch_menu.gd
+++ b/tests/unit/test_battle_switch_menu.gd
@@ -1,0 +1,136 @@
+extends GutTest
+
+## `PickSwitchMonInBattle` and `ForcePickSwitchMonInBattle`
+## (`engine/battle/core.asm`): the rows, the wrapping cursor and the two
+## refusals both variants share.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
+var _directory: String = ""
+var _data: GameData = null
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"switchmenutest", "0123456789abcdef")
+	_data = Fixture.build(_directory)
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _mon(species: int, level: int = 20) -> Gen2BattleMon:
+	return Gen2BattleMon.create(_data, species, level, [Fixture.TACKLE])
+
+
+## Three standing, the first one out, which is what a battle party looks like
+## when `OfferSwitch` asks.
+func _party() -> Gen2Party:
+	return Gen2Party.create([
+		_mon(Fixture.PIKACHU), _mon(Fixture.BULBASAUR), _mon(Fixture.GEODUDE),
+	])
+
+
+func _menu(forced: bool = false) -> Gen2BattleSwitchMenu:
+	return Gen2BattleSwitchMenu.for_party(_party(), forced)
+
+
+func test_the_list_is_the_party_and_one_cancel_row() -> void:
+	var menu: Gen2BattleSwitchMenu = _menu()
+	assert_eq(menu.rows.size(), 3)
+	assert_eq(menu.item_count(), 4, "w2DMenuNumRows is wPartyCount + 1")
+	assert_true(menu.is_cancel(3))
+	assert_false(menu.is_cancel(2))
+	assert_eq(menu.cursor, Gen2BattleSwitchMenu.DEFAULT_CURSOR)
+
+
+## Every field [Gen2PartyMenuPage] draws comes off the row rather than out of the
+## battle, so the page never reaches back into one.
+func test_a_row_carries_everything_the_page_draws() -> void:
+	var party: Gen2Party = _party()
+	party.at(1).take_damage(3)
+	party.at(1).status = Gen2Status.POISON
+	var row: Dictionary = Gen2BattleSwitchMenu.for_party(party).rows[1]
+	assert_eq(int(row["index"]), 1)
+	assert_eq(String(row["name"]), party.at(1).name_text())
+	assert_eq(int(row["level"]), 20)
+	assert_eq(int(row["hp"]), party.at(1).hp)
+	assert_eq(int(row["max_hp"]), party.at(1).max_hp())
+	assert_eq(int(row["status"]), Gen2Status.POISON)
+	assert_false(bool(row["fainted"]))
+
+
+## `PartyMenu2DMenuData`'s `_2DMENU_WRAP_UP_DOWN`, over the CANCEL row as well.
+func test_the_cursor_wraps_through_cancel() -> void:
+	var menu: Gen2BattleSwitchMenu = _menu()
+	assert_true(menu.move(-1))
+	assert_eq(menu.cursor, 3, "up from the first row reaches CANCEL")
+	assert_true(menu.move(1))
+	assert_eq(menu.cursor, 0)
+	for _step: int in 3:
+		menu.move(1)
+	assert_eq(menu.cursor, 3)
+	menu.move(1)
+	assert_eq(menu.cursor, 0)
+
+
+func test_a_standing_bench_member_is_the_answer() -> void:
+	var menu: Gen2BattleSwitchMenu = _menu()
+	menu.cursor = 1
+	var answer: Dictionary = menu.confirm()
+	assert_eq(answer["result"], Gen2BattleSwitchMenu.CHOSEN)
+	assert_eq(int(answer["index"]), 1)
+
+
+## `SwitchMonAlreadyOut` prints `BattleText_MonIsAlreadyOut` and jumps back to
+## `.pick`, so the row is refused with a line rather than accepted.
+func test_the_one_already_out_is_refused_by_name() -> void:
+	var menu: Gen2BattleSwitchMenu = _menu()
+	menu.cursor = 0
+	var answer: Dictionary = menu.confirm()
+	assert_eq(answer["result"], Gen2BattleSwitchMenu.ALREADY_OUT)
+	assert_true(String(answer["text"]).contains("is already out"), String(answer["text"]))
+	assert_true(String(answer["text"]).begins_with(menu.rows[0]["name"]))
+
+
+## `CheckIfCurPartyMonIsFitToFight` prints `BattleText_TheresNoWillToBattle` and
+## is `jr z, .loop` inside `PickPartyMonInBattle`, in front of the already-out
+## check, so a fainted Pokémon is refused whichever variant asked.
+func test_a_fainted_row_is_refused() -> void:
+	var party: Gen2Party = _party()
+	party.at(2).take_damage(party.at(2).max_hp())
+	for forced: bool in [false, true]:
+		var menu: Gen2BattleSwitchMenu = Gen2BattleSwitchMenu.for_party(party, forced)
+		menu.cursor = 2
+		var answer: Dictionary = menu.confirm()
+		assert_eq(answer["result"], Gen2BattleSwitchMenu.NO_ENERGY)
+		assert_eq(String(answer["text"]), Gen2BattleSwitchMenu.no_energy_text())
+
+
+func test_cancel_backs_out_of_the_offer_list() -> void:
+	var menu: Gen2BattleSwitchMenu = _menu()
+	assert_eq(menu.cancel()["result"], Gen2BattleSwitchMenu.CANCELLED)
+	menu.cursor = 3
+	assert_eq(menu.confirm()["result"], Gen2BattleSwitchMenu.CANCELLED, "the CANCEL row")
+
+
+## `ForcePickPartyMonInBattle` swallows the carry, plays `SFX_WRONG` and picks
+## again, so neither B nor CANCEL leaves the Baton Pass list.
+func test_the_forced_list_cannot_be_backed_out_of() -> void:
+	var menu: Gen2BattleSwitchMenu = _menu(true)
+	for answer: Dictionary in [menu.cancel(), _at(menu, 3).confirm()]:
+		assert_eq(answer["result"], Gen2BattleSwitchMenu.CANNOT_CANCEL)
+		assert_eq(int(answer["sfx"]), Gen2BattleSwitchMenu.SFX_WRONG)
+
+
+func _at(menu: Gen2BattleSwitchMenu, cursor: int) -> Gen2BattleSwitchMenu:
+	menu.cursor = cursor
+	return menu
+
+
+func test_a_party_of_one_is_a_list_of_one_and_cancel() -> void:
+	var menu: Gen2BattleSwitchMenu = Gen2BattleSwitchMenu.for_party(
+		Gen2Party.of(_mon(Fixture.PIKACHU))
+	)
+	assert_eq(menu.item_count(), 2)
+	assert_eq(menu.confirm()["result"], Gen2BattleSwitchMenu.ALREADY_OUT)

--- a/tests/unit/test_battle_switch_menu.gd.uid
+++ b/tests/unit/test_battle_switch_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://de4o6cjo77opq

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -1,0 +1,202 @@
+extends GutTest
+
+## `WritePartyMenuTilemap`'s `PARTYMENUACTION_SWITCH` columns and
+## `PlacePartyMenuText`'s box (`engine/pokemon/party_menu.asm`), checked by where
+## the ink lands rather than by eye.
+##
+## Every sheet in the cache is filled with one index, so a glyph is a solid tile
+## and a column that drew something can be told from one that did not. That is
+## the whole claim here: the page is geometry, and the drawing under it is
+## [Gen2Font]'s and [Gen2BattleHud]'s own.
+##
+## The battle-extra strip is filled with a different index from the rest, since
+## the bars come off it and are the one thing on the page drawn through a palette
+## that is not black on white.
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(&"partypagetest", "0123456789abcdef")
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func _write_cache() -> void:
+	var sheets: Dictionary = {}
+	var written: Dictionary = {
+		"exp_bar": RomLayout.EXP_BAR_TILES,
+		"battle_font": RomLayout.BATTLE_FONT_TILES,
+		"enemy_hud": RomLayout.ENEMY_HUD_TILES,
+		"player_hud": RomLayout.PLAYER_HUD_TILES,
+		"font": RomLayout.FONT_TILES,
+		"frames": RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES,
+	}
+	var first_codes: Dictionary = {
+		"font": RomLayout.FONT_FIRST_CODE, "frames": RomLayout.FRAME_FIRST_CODE,
+	}
+	for name: String in written:
+		var tiles: int = written[name]
+		var indices: PackedByteArray = PackedByteArray()
+		indices.resize(tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
+		indices.fill(2 if name == "battle_font" else 3)
+		RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
+		sheets[name] = {
+			"width": tiles * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": tiles,
+			"first_code": int(first_codes.get(name, 0)),
+			"bits": 1,
+		}
+
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "partypagetest",
+		"sha1": "0123456789abcdef",
+		"tiles": sheets,
+		"bar_palettes": {
+			"hp_green": [0x02E0, 0x02E0],
+			"hp_yellow": [0x02BF, 0x02BF],
+			"hp_red": [0x001F, 0x001F],
+			"exp": [0x7E24, 0x7E24],
+		},
+		"complete": true,
+	})
+
+
+func _page() -> Gen2PartyMenuPage:
+	return Gen2PartyMenuPage.from_data(GameData.open_directory(_directory))
+
+
+func _rows(count: int = 2) -> Array:
+	var out: Array = []
+	for index: int in count:
+		out.append({
+			"index": index, "name": "PIKACHU", "level": 20,
+			"hp": 18, "max_hp": 20, "status": 0, "fainted": false,
+		})
+	return out
+
+
+func _render(rows: Array, cursor: int = 0) -> Image:
+	return _page().render(rows, cursor, Gen2BattleSwitchMenu.prompt_text())
+
+
+## Anything that is not the white the page is cleared to.
+func _ink_in_tile(image: Image, column: int, row: int) -> int:
+	var out: int = 0
+	for y: int in Gen2Font.TILE:
+		for x: int in Gen2Font.TILE:
+			if image.get_pixel(column * Gen2Font.TILE + x, row * Gen2Font.TILE + y) != Color.WHITE:
+				out += 1
+	return out
+
+
+func test_the_page_needs_a_cache_it_can_draw_from() -> void:
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "partypagetest", "sha1": "0123456789abcdef", "complete": true,
+	})
+	assert_null(Gen2PartyMenuPage.from_data(GameData.open_directory(_directory)))
+
+
+func test_the_page_is_the_whole_screen() -> void:
+	var image: Image = _render(_rows())
+	assert_eq(image.get_size(), Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT))
+
+
+## `hlcoord 3, 1` for the nicknames, stepping `2 * SCREEN_WIDTH` a member, with
+## columns 1 and 2 left for the menu mon icons nothing here draws.
+func test_each_member_prints_two_rows_below_the_last() -> void:
+	var image: Image = _render(_rows())
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x, 1), 0, "the first nickname")
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x, 3), 0, "the second")
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x - 1, 1), 0, "the icon column")
+
+
+## `PlacePartyNicknames.end` steps two columns back from the row below the last
+## nickname, which is the row CANCEL prints on.
+func test_cancel_prints_below_the_last_member() -> void:
+	for count: int in [1, 2, 3]:
+		var image: Image = _render(_rows(count))
+		var row: int = Gen2PartyMenuPage.NICKNAME.y + count * Gen2PartyMenuPage.ROW_STEP
+		assert_ne(
+			_ink_in_tile(image, Gen2PartyMenuPage.CANCEL_COLUMN, row), 0,
+			"CANCEL under %d members" % count
+		)
+
+
+## The four qualities `.Default` asks for, each in its own column on the row
+## under the nickname, except the HP numbers which share the nickname's.
+func test_every_quality_lands_in_its_own_column() -> void:
+	var image: Image = _render(_rows(1))
+	## `PrintNum`'s three digits are right-aligned and space-padded, so 18 out of
+	## 20 leaves the first of them blank.
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.HP_DIGITS.x, 1), 0, "the padding")
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.HP_DIGITS.x + 1, 1), 0, "the HP numbers")
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.LEVEL.x, 2), 0, "the level symbol")
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.HP_BAR.x, 2), 0, "HP: and the bar")
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.STATUS.x, 2), 0, "a healthy status is blank")
+
+
+## `PlaceStatusString` checks the health before it looks at the byte, so FNT wins
+## over anything on it.
+func test_a_status_prints_and_fainting_wins_over_it() -> void:
+	var rows: Array = _rows(1)
+	rows[0]["status"] = Gen2Status.POISON
+	assert_ne(
+		_ink_in_tile(_render(rows), Gen2PartyMenuPage.STATUS.x, 2), 0, "PSN is drawn"
+	)
+	rows[0]["hp"] = 0
+	rows[0]["fainted"] = true
+	assert_ne(
+		_ink_in_tile(_render(rows), Gen2PartyMenuPage.STATUS.x, 2), 0, "FNT is drawn"
+	)
+
+
+## The bar is the one thing on the page that is not black on white, so it is
+## blended in its own colour rather than drawn as ink.
+func test_the_bar_is_drawn_in_the_colour_its_fill_earns() -> void:
+	var rows: Array = _rows(1)
+	var fill_at := Vector2i(
+		(Gen2PartyMenuPage.HP_BAR.x + 2) * Gen2Font.TILE,
+		Gen2PartyMenuPage.HP_BAR.y * Gen2Font.TILE + 4
+	)
+	var green: Color = _render(rows).get_pixelv(fill_at)
+	rows[0]["hp"] = 1
+	var red: Color = _render(rows).get_pixelv(fill_at)
+	assert_ne(green, Color.WHITE, "a full bar is lit")
+	assert_ne(green, Color.BLACK, "and not in the page's own ink")
+	assert_ne(green, red, "a bar about to empty is a different colour")
+	rows[0]["hp"] = 0
+	rows[0]["fainted"] = true
+	assert_eq(
+		_render(rows).get_pixelv(fill_at), Color.BLACK,
+		"and a fainted one has no fill over the empty bar at all"
+	)
+
+
+## `Place2DMenuCursor`'s column, on the member's own row.
+func test_the_cursor_sits_left_of_the_row_it_is_on() -> void:
+	var image: Image = _render(_rows(), 1)
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.CURSOR_COLUMN, 1), 0)
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.CURSOR_COLUMN, 3), 0)
+
+
+## `hlcoord 0, 14` with `lb bc, 2, 18`, and the string at `hlcoord 1, 16`.
+func test_the_prompt_box_covers_the_bottom_four_rows() -> void:
+	var image: Image = _render(_rows())
+	assert_ne(_ink_in_tile(image, 0, Gen2PartyMenuPage.TEXTBOX.y), 0, "the frame's corner")
+	assert_ne(
+		_ink_in_tile(image, 19, Gen2PartyMenuPage.TEXTBOX.y + Gen2PartyMenuPage.TEXTBOX_ROWS - 1),
+		0, "and the far one"
+	)
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.PROMPT.x, Gen2PartyMenuPage.PROMPT.y), 0)
+	assert_eq(_ink_in_tile(image, 0, Gen2PartyMenuPage.TEXTBOX.y - 1), 0, "nothing above it")

--- a/tests/unit/test_party_menu_page.gd.uid
+++ b/tests/unit/test_party_menu_page.gd.uid
@@ -1,0 +1,1 @@
+uid://cwpoa8kxnlfji

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -1,0 +1,152 @@
+extends SceneTree
+
+## Captures the two menus a battle switches through, against a real imported
+## cache: `OfferSwitch`'s yes/no box over the field, and the party list
+## `PickSwitchMonInBattle` opens behind it.
+##
+##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses]
+##
+## [stage] is `offer`, the default, or `pick`; [presses] is a `u,d,l,r,a,b` list
+## driven into the menu before the shot, so a cursor row or a refusal can be
+## photographed. The battle is a real trainer's party out of the cache with the
+## player on a bench of three, since a switch needs somebody to switch to.
+
+const WINDOW_SIZE := Vector2i(1152, 648)
+## Enough frames for the scene to lay out and for the hardware viewport to hold
+## what the menus were driven to; the intro and the turn are settled by hand
+## below rather than by waiting. A shorter run photographs the composite as it
+## was a few frames before the presses.
+const SETTLE_FRAMES: int = 30
+
+## Falkner, and three of the player's own, all at a level where nothing faints
+## before the question is asked.
+const TRAINER_CLASS: int = 1
+const PLAYER_SPECIES: Array[int] = [155, 152, 158]
+const PLAYER_LEVEL: int = 30
+
+var _screen: Gen2BattleScreen = null
+var _output_path: String = ""
+var _stage: String = "offer"
+var _presses: PackedStringArray = PackedStringArray()
+var _frames: int = 0
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_battle_switch.gd -- <game> <output.png> [stage] [presses]")
+		quit(1)
+		return
+	_output_path = args[1]
+	_stage = args[2] if args.size() > 2 else "offer"
+	if args.size() > 3:
+		_presses = args[3].split(",", false)
+
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	root.set_content_scale_size(WINDOW_SIZE)
+	root.size = WINDOW_SIZE
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_screen = packed.instantiate() as Gen2BattleScreen
+	_screen.set_data(data)
+	root.add_child(_screen)
+	current_scene = _screen
+
+
+func _process(_delta: float) -> bool:
+	_frames += 1
+	if _frames == 3:
+		_open()
+	if _frames < SETTLE_FRAMES:
+		return false
+
+	var image: Image = root.get_texture().get_image()
+	var error: Error = image.save_png(_output_path)
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [_output_path, error])
+		quit(1)
+		return true
+	print("Wrote %s, stage %s" % [_output_path, _screen.battle_snapshot()["switch_stage"]])
+	quit(0)
+	return true
+
+
+## The trainer's second Pokémon coming in, which is what `OfferSwitch` asks
+## about. SHIFT is forced on rather than read out of the options file, since the
+## question is the thing being photographed.
+func _open() -> void:
+	var data: GameData = _screen.get("_data")
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 3
+
+	var members: Array = []
+	for species: int in PLAYER_SPECIES:
+		members.append(Gen2BattleMon.create(data, species, PLAYER_LEVEL, [33]))
+	var enemy: Gen2Party = Gen2TrainerParty.build(data, TRAINER_CLASS, 0)
+	if enemy == null or enemy.size() < 2:
+		push_error("Trainer class %d has no bench to switch from" % TRAINER_CLASS)
+		quit(1)
+		return
+
+	_screen.show_trainer(TRAINER_CLASS, 0, PLAYER_SPECIES[0], PLAYER_LEVEL)
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		data, Gen2Party.create(members), enemy, rng, true
+	)
+	battle.battle_style_set = false
+	_screen.set("_battle", battle)
+	_screen.set("_pending", battle.take_actions(
+		Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
+	))
+
+	_drain()
+	if _stage == "pick":
+		_read_question()
+		_screen._handle_button(Gen2Button.A)
+	for press: String in _presses:
+		_screen._handle_button(_button(press))
+	if _stage == "offer":
+		_read_question()
+	## A refusal is a line the box is still revealing, and the capture does not
+	## wait on real time.
+	_screen.finish()
+
+
+## Every queued event shown and pressed past, which is what reaches the question.
+func _drain() -> void:
+	for _press: int in 60:
+		if String(_screen.battle_snapshot()["switch_stage"]) != "":
+			return
+		_settle()
+		_screen.finish()
+		_screen.advance()
+
+
+func _settle() -> void:
+	var guard: int = 4000
+	while _screen.frames_running() and guard > 0:
+		_screen.advance_frame()
+		guard -= 1
+
+
+## Reads the question to its last page, which is where the yes/no box appears.
+func _read_question() -> void:
+	var box: Gen2TextBox = _screen.get("_box")
+	while box != null and (box.is_revealing() or box.has_pages_left()):
+		box.finish()
+		if box.has_pages_left():
+			box.advance()
+	_screen._refresh_menu_layer()
+
+
+func _button(name: String) -> int:
+	match name.strip_edges().to_lower():
+		"u": return Gen2Button.UP
+		"d": return Gen2Button.DOWN
+		"l": return Gen2Button.LEFT
+		"r": return Gen2Button.RIGHT
+		"b": return Gen2Button.B
+		_: return Gen2Button.A

--- a/tools/preview_battle_switch.gd.uid
+++ b/tools/preview_battle_switch.gd.uid
@@ -1,0 +1,1 @@
+uid://nook7s6q55ng


### PR DESCRIPTION
`OfferSwitch`'s yes/no and the party list behind it were both answered by the screen because there was no menu to answer them with. Both are now asked.

- `Gen2BattleSwitchMenu` is `PickSwitchMonInBattle` and its forced variant: the rows, `_2DMENU_WRAP_UP_DOWN`'s cursor over the party and CANCEL, and the already-out and no-energy refusals, each with the line the source prints.
- `Gen2PartyMenuPage` draws `WritePartyMenuTilemap`'s `PARTYMENUACTION_SWITCH` columns and `PlacePartyMenuText`'s box on the hardware tile grid, with each bar blended in the colour its own fill earns. The menu mon icons want `gfx/icons` and are the one thing on it not drawn.
- `Gen2MenuPage.render` gives `PlaceYesNoBox` an image of its own frame, so a screen composing layers can put one over the field.

The enemy's Baton Pass now takes `FindMonInOTPartyToSwitchIntoBattle`'s pick rather than the first Pokemon standing, which is what `Gen2Battle.baton_pass_target` was always for.

`tools/preview_battle_switch.gd` photographs either menu against a real cache.