### PR TITLE
opening: the title screen, on all three cartridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ to check without writing.
 | Sprites | Front/back for 251 species and all 26 Unown forms |
 | Font and borders | 128 glyphs and eight six-tile text-box frames |
 | Splash screen | The copyright graphic and its tile-code string, `GameFreakLogoGFX`'s two words and logo, Gold and Silver's star and sparkles, Crystal's compressed Ditto sheet, and the three palettes the three are drawn through |
+| Title screen | Crystal's Suicune strip, logo and crystal with its sixteen palettes; Gold and Silver's two logo halves, their `$FF`-terminated tilemap, the trail and the Ho-Oh or Lugia behind it, and both palette runs |
 | Battle HUD | HP/EXP bars, panel borders and colours |
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
 | Wild encounters | Normal/swarm grass and water, 13 fishing groups with day/night substitutions, 16-row roaming graph, map-linked rates and slots, time-of-day selection, surf variance and repel checks |
@@ -164,8 +165,8 @@ battle, plus a save editor for party, boxes, bag, flags, position and dex that
 cannot produce a save the game will not load. A new game opens on the
 cartridge's own splash: the copyright screen for the hundred and ten frames
 `SplashScreen` gives it, then the GameFreak animation, which is Crystal's
-bouncing Ditto turning into the logo or Gold and Silver's star and sparkles, and
-then the gender question and Oak's speech; it starts with an empty
+bouncing Ditto turning into the logo or Gold and Silver's star and sparkles, then
+the title screen, and then the gender question and Oak's speech; it starts with an empty
 party at the Crystal home spawn with source starting money, and Elm's imported
 lab scripts offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry.
 Continue enters the overworld, and the start menu's SAVE writes its map,
@@ -307,6 +308,7 @@ all three games unless its row says otherwise:
 | `preview_party.gd <game> <png> [party\|box] [presses]` | the party and PC-box overlays as the overworld stacks them, over a development save. `presses` is a `u,d,l,r,a,b` list driven in before the shot, and several lists separated by `;` write one file each |
 | `preview_intro.gd <game> <png> [copyright\|presents\|gender\|speech\|beat] [steps]` | the new game's opening screens at hardware resolution: the copyright screen and the GameFreak animation by source frame, the gender question, and any frame of `OakSpeech` by source frame or by button press, so a fade, a bounce or a pic move can be looked at one frame at a time |
 | `preview_mom_scene.gd <game> [png] [frame]` | `MeetMomRightScript` through the real world screen, frame by frame: the script's state, the object `applymovement` is walking and whether the text box is up. The frames the emote, the walk and the box first appear on are pinned per profile, so a run that moves one exits non-zero. `frame` picks which one the `png` is of |
+| `preview_title.gd <game> <png> [frame;frame]` | the title screen at any source frame: Crystal's twenty-eight-frame interlaced entrance and its falling crystal, the Suicune cycle, Gold's Ho-Oh and Silver's Lugia over the scrolling clouds with the trail streaming behind |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache; `page` is how many panels to advance past |
 | `preview_battle_switch.gd <game> <png> [offer\|pick\|use_next\|replace] [presses]` | the boxes a battle switches through: `OfferSwitch`'s yes/no over the field under SHIFT, the party list behind it, `AskUseNextPokemon`'s wild question, and `ForcePlayerMonChoice`'s list after a faint. `presses` is a `u,d,l,r,a,b` list driven into the menu first, which is how a refusal is photographed |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,6 +97,17 @@ lists contacts and dispatches calls, with the world runner executing the
 imported caller/callee script at the same transaction boundary. Audio stays
 behind bounded decoder, renderer and player layers.
 
+`title_scene.gd` and `render/title_page.gd` are `engine/movie/title.asm` and
+`TitleScreenScene`: the scene owns `TitleScreenEntrance`'s scroll and falling
+crystal, `SuicuneFrameIterator`, the bird's frameset and sine, the trail
+particles `UpdateTitleTrailSprite` spawns, `ScrollTitleScreenClouds` and the
+timer, and answers with the source's own `wTitleScreenSelectedOption`; the page
+builds the BG map at its own 256 pixels and samples it through `hSCX` and
+`wLYOverrides`, because that map wraps and a cloud walking left brings its right
+columns back round. `Gen2SplashScreen` hosts the phase and is the one screen here
+that reads a held button rather than a press, since both of
+`TitleScreenMain`'s chords are three buttons at once.
+
 `world_start_menu.gd` models `engine/menus/start_menu.asm`'s item list: source
 Pokedex/Pokemon/Pokegear gating and the `STATICMENU_WRAP` cursor.
 `pokedex.gd` models `engine/pokedex/pokedex.asm`'s listing: the three orderings
@@ -186,6 +197,7 @@ the contract and why a renderer must not write world state.
 | `render/battle_tiles.gd` | Hardware-order battle tile page |
 | `render/battle_hud.gd` | Status panels on the tile grid |
 | `render/party_menu_page.gd` | `WritePartyMenuTilemap`'s party list |
+| `render/title_page.gd` | `_TitleScreen`'s and `TitleScreen`'s two screens |
 
 `Gen2Screen` is a `Control` with a 160x144 `SubViewport` at integer scale;
 surrounding UI uses window resolution. Project-wide stretch blurs menus and
@@ -386,6 +398,7 @@ Because wrong offsets can decode plausible neighboring data,
 | Evolutions, learnsets | Pointers address the banked window; methods, species, moves and levels valid, levels ascending except Muk, evolution count known. `EVOLVE_STAT` is four bytes, not three |
 | Growth | Growth rate and base EXP for all 251 species in all three games |
 | Menu text | The start menu's nine `.MenuDesc` strings, pinned by the first and last of the run and by nine terminators between them, and the pack's five `text_far` texts, each by its own `text` macro byte and opening words |
+| Title | Crystal's three LZ runs and its palettes are one contiguous section, so each pins the next: a run decompressing to the wrong tile count, or one whose neighbour does not follow it inside a few bytes, is not the one being looked for. The crystal opens on a blank corner and every one of `.Frames`' four Suicune bases has ink under it. Gold and Silver's logo halves pin their tilemap the same way, the bottom half's last tile is drawn on because `--trim-whitespace` took the blanks off it, the trail's first four tiles are inked and Gold's own last four are blank, and the bird starts exactly where the trail's tiles stop. Both palette runs are contiguous, the background's opens on white and the objects' carries `title_fg.pal`'s three identical greys |
 | Splash | The copyright pair above, and `GameFreakPresents`' four graphics and three palettes, each identified by content: the word strip is inked in every tile and clear across the top two rows of the six that spell "PRESENTS", the logo's first tile is the blank one "GAME FREAK" borrows as its space, the sparkles close in on their own centre one row at a time, the Ditto decompresses to exactly 256 tiles with every OAM base landing on a drawn one, and the sixteen-step fade opens on the Ditto's own colour and runs pink to orange. The star strip and the fade palette are pinned to the logo graphic they sit against |
 | Fruit trees | Thirty rows of one item byte, identified by content because the table has no header and no terminator: rows 17 to 23 are the seven apricorns and no other row bears one, and the four Johto berry trees ahead of them share a berry |
 | World services | Source counts, pointer widths, banked addresses, mart terminators, phone sizes, non-trainer caller-name pointer tables, packed audio headers, cry pointers, shared waves, drumkits and bounded bank-window payloads. Menu headers need valid data pointers and command-derived shape; the script collector validates `phonecall` text pointers, leaves `memcall`/`memjump` to runtime memory snapshots, and ignores malformed candidates |

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -162,6 +162,9 @@ var _world_battle_recovery: Dictionary = {}
 var _last_message: String = ""
 ## A running [Gen2HpBarAnimation] per side. A side with no entry is not moving.
 var _bars: Dictionary = {}
+## `MonFaintedAnimation`s still running, oldest first. A double faint runs two,
+## one after the other, the way the source's two calls do.
+var _faints: Array[Dictionary] = []
 ## The running [Gen2ExpBarAnimation], or null when the exp bar is not filling.
 var _exp_bar: Gen2ExpBarAnimation = null
 ## The running [Gen2BattleIntro], or null once the pics have slid into place.
@@ -293,7 +296,7 @@ func _process(delta: float) -> void:
 ## [method advance_frame] so a test or a screenshot driver can settle the screen
 ## without waiting on real time.
 func frames_running() -> bool:
-	return bars_animating() or _intro != null or animation_running()
+	return bars_animating() or _intro != null or animation_running() or fainting()
 
 
 ## One hardware frame of everything that counts them. Public through
@@ -302,7 +305,41 @@ func frames_running() -> bool:
 func advance_frame() -> bool:
 	var moved: bool = advance_intro()
 	moved = advance_bars() or moved
+	moved = advance_faint() or moved
 	return advance_animation() or moved
+
+
+## Whether a picture is still sinking off its square.
+func fainting() -> bool:
+	return not _faints.is_empty()
+
+
+## One hardware frame of `MonFaintedAnimation`. Public so a test or a screenshot
+## driver can settle or step one without waiting on real time.
+func advance_faint() -> bool:
+	if _faints.is_empty():
+		return false
+	var faint: Dictionary = _faints[0]
+	faint["delay"] = int(faint["delay"]) - 1
+	if int(faint["delay"]) > 0:
+		return true
+	faint["delay"] = Gen2BattleScreenMap.FAINT_STEP_FRAMES
+	faint["step"] = int(faint["step"]) + 1
+	Gen2BattleScreenMap.faint_step(_bg_map, bool(faint["player_side"]))
+	if int(faint["step"]) >= Gen2BattleScreenMap.FAINT_STEPS:
+		_faints.remove_at(0)
+	_push_view()
+	return true
+
+
+## `PlayerMonFaintedAnimation` or `EnemyMonFaintedAnimation`, which
+## `FaintYourPokemon` and `FaintEnemyPokemon` run before their own text box.
+func _begin_faint(side: int) -> void:
+	_faints.append({
+		"player_side": side == Gen2Battle.PLAYER,
+		"step": 0,
+		"delay": Gen2BattleScreenMap.FAINT_STEP_FRAMES,
+	})
 
 
 func _ready() -> void:
@@ -785,7 +822,7 @@ func advance_bars() -> bool:
 	if moved:
 		_push_view()
 
-	if not _held_message.is_empty() and _bars.is_empty():
+	if not _held_message.is_empty() and _bars.is_empty() and not fainting():
 		var text: String = _held_message
 		_held_message = ""
 		show_message(text)
@@ -1045,6 +1082,7 @@ func _audio_assets() -> Dictionary:
 ## that took a picture off it leaves it off until something stamps it back.
 func _reseed_bg_map() -> void:
 	_bg_map = Gen2BattleScreenMap.seeded()
+	_faints.clear()
 
 
 ## How full the exp bar is, in `PlaceExpBar`'s own pixels. The committed value:
@@ -1651,7 +1689,7 @@ func advance() -> void:
 	## A bar the source is still animating has not printed its message yet, so
 	## there is nothing for a press to advance past. Without this the press
 	## would pop the next event and the held line would never be shown.
-	if bars_animating():
+	if bars_animating() or fainting():
 		return
 	## An animation is a run of unconditional delays, the way the intro is, so a
 	## press during one reaches nothing.
@@ -2218,7 +2256,7 @@ func _show_next_event() -> void:
 			## `applydamage` animates the bar and only then does `criticaltext`
 			## print, so a message caused by an event that moved a bar waits for
 			## it rather than racing it.
-			if not _bars.is_empty():
+			if not _bars.is_empty() or fainting():
 				_held_message = text
 			else:
 				show_message(text)
@@ -2266,6 +2304,10 @@ func _apply_event_state(event: Dictionary) -> void:
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
+		Gen2Battle.FAINTED:
+			# `FaintYourPokemon` and `FaintEnemyPokemon` sink the picture before
+			# either prints, so the line waits on the animation.
+			_begin_faint(int(event["side"]))
 		Gen2Battle.SENT_OUT:
 			# The pic and the panel both change, and both come out of the event
 			# rather than out of the party, for the same reason every other number

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -34,6 +34,18 @@ const PLAYER_BASE_TILE: int = 0x31
 const BLANK_TILE: int = Gen2BattleAnimBackground.BLANK_TILE
 
 
+## `MonFaintedAnimation`'s own block, which is not the picture's: seven columns
+## from one left of it, and seven rows ending one below, so the picture sinks
+## through a margin rather than out of its own frame.
+## `PlayerMonFaintedAnimation` and `EnemyMonFaintedAnimation` name the two.
+const FAINT_AT: Dictionary = {false: Vector2i(12, 0), true: Vector2i(1, 5)}
+const FAINT_COLUMNS: int = 7
+const FAINT_ROWS: int = 7
+## `ld b, 7` outer, each spending `ld c, 2 / DelayFrames`.
+const FAINT_STEPS: int = 7
+const FAINT_STEP_FRAMES: int = 2
+
+
 ## The map a battle sits at: both pictures whole, blank everywhere else.
 static func seeded() -> PackedByteArray:
 	var out: PackedByteArray = PackedByteArray()
@@ -42,6 +54,30 @@ static func seeded() -> PackedByteArray:
 	stamp(out, false)
 	stamp(out, true)
 	return out
+
+
+## One outer step of `MonFaintedAnimation`: the block's rows each take the one
+## above, and its top row is blanked with the routine's own seven spaces. Seven
+## of these sink the whole picture off its square.
+static func faint_step(map: PackedByteArray, player_side: bool) -> void:
+	if map.size() != COLUMNS * ROWS:
+		return
+	var at: Vector2i = FAINT_AT[player_side]
+	for index: int in FAINT_ROWS - 1:
+		var row: int = at.y + FAINT_ROWS - 1 - index
+		var above: int = row - 1
+		for column: int in FAINT_COLUMNS:
+			var x: int = at.x + column
+			if x < 0 or x >= COLUMNS or row < 0 or row >= ROWS:
+				continue
+			map[row * COLUMNS + x] = (
+				map[above * COLUMNS + x] if above >= 0 else BLANK_TILE
+			)
+	for column: int in FAINT_COLUMNS:
+		var x: int = at.x + column
+		if x < 0 or x >= COLUMNS or at.y < 0 or at.y >= ROWS:
+			continue
+		map[at.y * COLUMNS + x] = BLANK_TILE
 
 
 ## `PlaceGraphic` over one battler's box: a tile is

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -54,6 +54,7 @@ var _copyright_string: Array = []
 var _copyright_palette: Array = []
 var _text_bg_palette: Array = []
 var _presents_palettes: Dictionary = {}
+var _title: Dictionary = {}
 var _menu_text: Dictionary = {}
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
@@ -122,6 +123,8 @@ static func open_directory(path: String) -> GameData:
 	data._battle_object_palettes = manifest.get("battle_object_palettes", {})
 	var presents_palettes: Variant = manifest.get("presents_palettes", {})
 	data._presents_palettes = presents_palettes if presents_palettes is Dictionary else {}
+	var title: Variant = manifest.get("title", {})
+	data._title = title if title is Dictionary else {}
 	var menu_text: Variant = manifest.get("menu_text", {})
 	data._menu_text = menu_text if menu_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
@@ -1082,6 +1085,37 @@ func presents_palette(name: String) -> PackedColorArray:
 	for packed: Variant in stored as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
+
+
+## One of the title screen's palette runs, four colours to a palette:
+## [code]palettes[/code] is Crystal's sixteen, and [code]bg_palettes[/code] and
+## [code]ob_palettes[/code] are Gold and Silver's five and two. Empty for a run
+## this profile does not ship, which is how the two screens are told apart.
+func title_palettes(name: String) -> Array[PackedColorArray]:
+	var stored: Variant = _title.get(name, [])
+	var out: Array[PackedColorArray] = []
+	if not stored is Array:
+		return out
+	var packed: Array = stored
+	for first: int in range(0, packed.size(), RomLayout.TITLE_PALETTE_COLORS):
+		var colors := PackedColorArray()
+		for index: int in RomLayout.TITLE_PALETTE_COLORS:
+			colors.append(Gen2Palette.from_packed(int(packed[first + index])))
+		out.append(colors)
+	return out
+
+
+## `TitleScreenTilemap`, the `$FF`-terminated run `LoadTitleScreenTilemap` writes
+## straight into the BG map. Empty on Crystal, which draws its title screen with
+## `DrawTitleGraphic` instead of a stored map.
+func title_tilemap() -> PackedByteArray:
+	var stored: Variant = _title.get("tilemap", [])
+	var out := PackedByteArray()
+	if not stored is Array:
+		return out
+	for code: Variant in stored as Array:
+		out.append(int(code))
+	return out
 
 
 ## `PREDEFPAL_CGB_BADGE`, stored whole rather than as a pair.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -64,7 +64,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 44
+const FORMAT_VERSION: int = 45
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -296,6 +296,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not presents["ok"]:
 		return presents
 
+	var title: Dictionary = verify_title(rom, layout)
+	if not title["ok"]:
+		return title
+
 	var menu_text: Dictionary = verify_menu_text(rom, layout)
 	if not menu_text["ok"]:
 		return menu_text
@@ -575,6 +579,220 @@ static func _verify_presents_palettes(rom: RomFile, entry: Dictionary) -> Dictio
 			}
 		last = Vector2i(green, blue)
 	return {"ok": true, "message": "Splash palettes verified."}
+
+
+## `GSTitleOBPals` (`gfx/title/title_fg.pal`), which Gold and Silver share: a
+## white and three copies of one dark grey, then the yellow pair the bird is
+## drawn in. Three identical colours in a row is what makes it unmistakable.
+const TITLE_OB_COLORS: Array[int] = [
+	0x7FFF, 0x0CC7, 0x0CC7, 0x0CC7, 0x7FFF, 0x03FF, 0x02DA, 0x0000,
+]
+
+## The first colour of `GSTitleBGPals`, which is white on both profiles, and of
+## Crystal's own `TitleScreenPalettes`, which is not: its first palette is the
+## copyright line's, black on a black background.
+const TITLE_BG_FIRST_COLOR: int = 0x7FFF
+const TITLE_CRYSTAL_FIRST_COLORS: Array[int] = [0x0000, 0x0013, 0x7D0F, 0x7D0F]
+
+## How far past the end of an LZ run its neighbour may start. The INCBIN'd `.lz`
+## files carry a few bytes past the terminator `Decompress` stops on, so the
+## symbols in a section are consecutive without being flush.
+const TITLE_RUN_GAP_MAX: int = 16
+
+
+## The title screen's art, which is two different screens under one key.
+##
+## Crystal's three LZ runs and its palettes are one contiguous section in
+## `engine/movie/title.asm`'s INCBIN order, so each pins the next: a run that
+## decompresses to the wrong number of tiles, or whose neighbour does not follow
+## it, is not the one being looked for. Gold and Silver's logo halves pin their
+## tilemap the same way, and their trail pins the bird behind it.
+static func verify_title(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("title", {})
+	if entry.is_empty():
+		return {"ok": true, "message": "No title screen art on this cartridge."}
+	if int(entry.get("suicune", -1)) >= 0:
+		return _verify_crystal_title(rom, entry)
+	return _verify_gs_title(rom, entry)
+
+
+## `TitleSuicuneGFX`, `TitleLogoGFX`, `TitleCrystalGFX` and
+## `TitleScreenPalettes`, in that order and nothing between them.
+static func _verify_crystal_title(rom: RomFile, entry: Dictionary) -> Dictionary:
+	var runs: Array = [
+		["suicune", int(entry["suicune"]), RomLayout.TITLE_SUICUNE_TILES],
+		["logo", int(entry["logo"]), RomLayout.TITLE_LOGO_TILES],
+		["crystal", int(entry["crystal"]), RomLayout.TITLE_CRYSTAL_TILES],
+	]
+	var sheets: Dictionary = {}
+	for run: Array in runs:
+		var unpacked: Dictionary = _verify_title_run(rom, String(run[0]), int(run[1]), int(run[2]))
+		if not unpacked["ok"]:
+			return unpacked
+		sheets[run[0]] = unpacked["sheet"]
+		var next: int = int(unpacked["end"])
+		var follows: int = int(entry["palettes"]) if run[0] == "crystal" else int(
+			entry["logo"] if run[0] == "suicune" else entry["crystal"]
+		)
+		if follows < next or follows - next > TITLE_RUN_GAP_MAX:
+			return {
+				"ok": false,
+				"message": "The title %s run does not end in front of the next symbol." % run[0],
+			}
+
+	# `InitializeBackground` builds thirty 8x16 objects out of the crystal, so
+	# the sheet is a column with blank corners rather than a rectangle.
+	var crystal: PackedByteArray = sheets["crystal"]
+	if _sheet_tile_lit(crystal, 0) != 0 or _sheet_tile_lit(crystal, 1) == 0:
+		return {"ok": false, "message": "The title crystal does not open on a blank corner."}
+
+	var suicune: PackedByteArray = sheets["suicune"]
+	# `LoadSuicuneFrame` draws six rows of eight from each of `.Frames`' bases,
+	# which are two sheets of 128 tiles apart. Every frame has to be drawn on.
+	for base: int in [0x00, 0x08, 0x80, 0x88]:
+		var ink: bool = false
+		for row: int in 6:
+			for column: int in 8:
+				if _sheet_tile_lit(suicune, base + row * 16 + column) > 0:
+					ink = true
+					break
+			if ink:
+				break
+		if not ink:
+			return {"ok": false, "message": "The Suicune sheet is blank at frame $%02X." % base}
+
+	var palettes: int = int(entry["palettes"])
+	var size: int = Gen2Palette.COLOR_BYTES
+	if not rom.in_bounds(palettes, RomLayout.TITLE_PALETTES * RomLayout.TITLE_PALETTE_COLORS * size):
+		return {"ok": false, "message": "The title palettes are outside the cartridge."}
+	for index: int in TITLE_CRYSTAL_FIRST_COLORS.size():
+		var stored: int = rom.u16le(palettes + index * size)
+		if stored != TITLE_CRYSTAL_FIRST_COLORS[index]:
+			return {
+				"ok": false,
+				"message": "Title colour %d is $%04X, expected $%04X." % [
+					index, stored, TITLE_CRYSTAL_FIRST_COLORS[index],
+				],
+			}
+	return {"ok": true, "message": "Title screen verified."}
+
+
+## `TitleScreenGFX1` and `GFX2` over `TitleScreenTilemap`, and `GFX3`'s raw trail
+## in front of `GFX4`'s bird.
+static func _verify_gs_title(rom: RomFile, entry: Dictionary) -> Dictionary:
+	var bottom: Dictionary = _verify_title_run(
+		rom, "logo bottom", int(entry["logo_bottom"]), RomLayout.TITLE_LOGO_BOTTOM_TILES
+	)
+	if not bottom["ok"]:
+		return bottom
+	var top_at: int = int(entry["logo_top"])
+	if top_at < int(bottom["end"]) or top_at - int(bottom["end"]) > TITLE_RUN_GAP_MAX:
+		return {"ok": false, "message": "The title logo's halves are not consecutive."}
+	var top: Dictionary = _verify_title_run(
+		rom, "logo top", top_at, RomLayout.TITLE_LOGO_TOP_TILES
+	)
+	if not top["ok"]:
+		return top
+	# `--trim-whitespace` takes the bottom half down from 120 tiles to 112 by
+	# dropping blank tiles off the end, so its last tile is drawn on. A run of the
+	# right length whose tail is blank is a different graphic.
+	if _sheet_tile_lit(bottom["sheet"], RomLayout.TITLE_LOGO_BOTTOM_TILES - 1) == 0:
+		return {"ok": false, "message": "The title logo's bottom half ends on a blank tile."}
+
+	var tilemap_at: int = int(entry["tilemap"])
+	if tilemap_at < int(top["end"]) or tilemap_at - int(top["end"]) > TITLE_RUN_GAP_MAX:
+		return {"ok": false, "message": "The title tilemap does not follow the logo."}
+	var tilemap: PackedByteArray = read_title_tilemap(rom, {"title": entry})
+	if tilemap.is_empty():
+		return {"ok": false, "message": "The title tilemap has no terminator in range."}
+	if tilemap.size() % RomLayout.TITLE_TILEMAP_COLUMNS != 0:
+		return {
+			"ok": false,
+			"message": "The title tilemap is %d bytes, not whole rows." % tilemap.size(),
+		}
+
+	var trail: int = int(entry["trail"])
+	var trail_tiles: int = int(entry["trail_tiles"])
+	if not rom.in_bounds(trail, trail_tiles * Gen2Tiles.TILE_BYTES):
+		return {"ok": false, "message": "The title trail is outside the cartridge."}
+	for tile: int in RomLayout.TITLE_TRAIL_DRAWN_TILES:
+		if _tile_2bpp_lit(rom, trail, tile) == 0:
+			return {"ok": false, "message": "Title trail tile %d is blank." % tile}
+	# Gold's own run is eight tiles, and the four past the trail are the
+	# whitespace the source names at its `FarCopyBytes`.
+	for index: int in trail_tiles - RomLayout.TITLE_TRAIL_DRAWN_TILES:
+		var tile: int = RomLayout.TITLE_TRAIL_DRAWN_TILES + index
+		if _tile_2bpp_lit(rom, trail, tile) != 0:
+			return {"ok": false, "message": "Title trail tile %d is not blank." % tile}
+	# The bird starts where the trail's own tiles stop, which is what pins it.
+	var bird_at: int = trail + trail_tiles * Gen2Tiles.TILE_BYTES
+	if int(entry["bird"]) != bird_at:
+		return {"ok": false, "message": "The title bird is not behind the trail."}
+	var bird: Dictionary = _verify_title_run(
+		rom, "bird", bird_at, int(entry["bird_tiles"])
+	)
+	if not bird["ok"]:
+		return bird
+
+	var size: int = Gen2Palette.COLOR_BYTES
+	var bg: int = int(entry["bg_palette"])
+	var ob: int = int(entry["ob_palette"])
+	if not rom.in_bounds(bg, RomLayout.TITLE_BG_PALETTES * RomLayout.TITLE_PALETTE_COLORS * size):
+		return {"ok": false, "message": "The title palettes are outside the cartridge."}
+	if ob != bg + RomLayout.TITLE_BG_PALETTES * RomLayout.TITLE_PALETTE_COLORS * size:
+		return {"ok": false, "message": "The title object palettes do not follow the background's."}
+	if rom.u16le(bg) != TITLE_BG_FIRST_COLOR:
+		return {"ok": false, "message": "The title background palette does not open on white."}
+	for index: int in TITLE_OB_COLORS.size():
+		var stored: int = rom.u16le(ob + index * size)
+		if stored != TITLE_OB_COLORS[index]:
+			return {
+				"ok": false,
+				"message": "Title object colour %d is $%04X, expected $%04X." % [
+					index, stored, TITLE_OB_COLORS[index],
+				],
+			}
+	return {"ok": true, "message": "Title screen verified."}
+
+
+## One LZ run, checked for decompressing to exactly [param tiles] tiles.
+## Answers the decompressed sheet and the offset one past the run's terminator,
+## which is what pins whatever the section puts behind it.
+static func _verify_title_run(
+	rom: RomFile, name: String, at: int, tiles: int
+) -> Dictionary:
+	if at < 0:
+		return {"ok": false, "message": "The title %s has no address." % name}
+	var lz := Gen2Lz.new()
+	var sheet: PackedByteArray = lz.decompress(rom.bytes(), at)
+	var wanted: int = tiles * Gen2Tiles.TILE_BYTES
+	if sheet.size() != wanted:
+		return {
+			"ok": false,
+			"message": "The title %s decompressed to %d bytes, wanted %d." % [
+				name, sheet.size(), wanted,
+			],
+		}
+	return {"ok": true, "sheet": sheet, "end": at + lz.consumed}
+
+
+## `LoadTitleScreenTilemap`'s own loop: bytes until `-1`, which is not copied.
+## Empty when no terminator is reached inside the bounded window, which is what a
+## wrong offset produces.
+static func read_title_tilemap(rom: RomFile, layout: Dictionary) -> PackedByteArray:
+	var entry: Dictionary = layout.get("title", {})
+	var at: int = int(entry.get("tilemap", -1))
+	if at < 0:
+		return PackedByteArray()
+	var out: PackedByteArray = PackedByteArray()
+	for step: int in RomLayout.TITLE_TILEMAP_MAX:
+		if not rom.in_bounds(at + step, 1):
+			return PackedByteArray()
+		var byte: int = rom.u8(at + step)
+		if byte == RomLayout.TITLE_TILEMAP_TERMINATOR:
+			return out
+		out.append(byte)
+	return PackedByteArray()
 
 
 static func _tile_1bpp_has_ink(rom: RomFile, offset: int, tile: int) -> bool:
@@ -2350,6 +2568,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"copyright_string": _import_copyright_string(rom, layout),
 		"copyright_palette": _import_copyright_palette(rom, layout),
 		"presents_palettes": _import_presents_palettes(rom, layout),
+		"title": _import_title(rom, layout),
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
 		"battle_object_palettes": _import_battle_object_palettes(rom, layout),
 		"atlases": pics,
@@ -2972,6 +3191,90 @@ func _import_shrink_pics(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
+## The title screen's palettes and, on Gold and Silver, its tilemap. The
+## graphics themselves go through [method _import_title_sheets] with the rest of
+## the tile strips.
+##
+## Crystal's sixteen palettes are one run `_TitleScreen` copies whole into both
+## buffers; Gold and Silver's are five background and two object palettes that
+## `GetSGBLayout` and `LoadTitleScreenPals` load separately, so they are kept
+## apart under the names the source gives them.
+func _import_title(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("title", {})
+	if entry.is_empty():
+		return {}
+	if int(entry.get("palettes", -1)) >= 0:
+		return {
+			"palettes": _packed_palette(
+				rom, int(entry["palettes"]),
+				RomLayout.TITLE_PALETTES * RomLayout.TITLE_PALETTE_COLORS
+			),
+		}
+	return {
+		"bg_palettes": _packed_palette(
+			rom, int(entry["bg_palette"]),
+			RomLayout.TITLE_BG_PALETTES * RomLayout.TITLE_PALETTE_COLORS
+		),
+		"ob_palettes": _packed_palette(
+			rom, int(entry["ob_palette"]),
+			RomLayout.TITLE_OB_PALETTES * RomLayout.TITLE_PALETTE_COLORS
+		),
+		"tilemap": Array(read_title_tilemap(rom, layout)),
+	}
+
+
+## The title screen's graphics, each as one strip of tiles.
+##
+## Every one but the trail is an LZ run, so they cannot go through the fixed
+## table [method _import_tiles] uses: each is decompressed first and the strip
+## written from the result. The names are the source's own symbols with the
+## profile split dropped, since a cache only ever holds one cartridge's.
+func _import_title_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("title", {})
+	if entry.is_empty():
+		return {}
+	var runs: Array = []
+	if int(entry.get("suicune", -1)) >= 0:
+		runs = [
+			["title_suicune", int(entry["suicune"]), RomLayout.TITLE_SUICUNE_TILES],
+			["title_logo", int(entry["logo"]), RomLayout.TITLE_LOGO_TILES],
+			["title_crystal", int(entry["crystal"]), RomLayout.TITLE_CRYSTAL_TILES],
+		]
+	else:
+		runs = [
+			[
+				"title_logo_bottom", int(entry["logo_bottom"]),
+				RomLayout.TITLE_LOGO_BOTTOM_TILES,
+			],
+			["title_logo_top", int(entry["logo_top"]), RomLayout.TITLE_LOGO_TOP_TILES],
+			["title_bird", int(entry["bird"]), int(entry["bird_tiles"])],
+		]
+
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var out: Dictionary = {}
+	for run: Array in runs:
+		var name: String = String(run[0])
+		var tiles: int = int(run[2])
+		var raw: PackedByteArray = _lz.decompress(rom.bytes(), int(run[1]))
+		if _lz.failed or raw.size() < tiles * Gen2Tiles.TILE_BYTES:
+			return {}
+		var indices: PackedByteArray = Gen2Tiles.decode_2bpp_strip(raw, 0, tiles)
+		if not RomCache.write_indices(RomCache.tile_path(directory, name), indices):
+			return {}
+		out[name] = _title_sheet_entry(tiles)
+	return out
+
+
+func _title_sheet_entry(tiles: int) -> Dictionary:
+	return {
+		"width": tiles * Gen2Tiles.TILE_WIDTH,
+		"height": Gen2Tiles.TILE_HEIGHT,
+		"tiles": tiles,
+		"first_code": 0,
+		"bits": 2,
+	}
+
+
 ## `GameFreakDittoGFX`, the one LZ run in the splash. `GameFreakPresentsInit`
 ## splits it over `vTiles0` and `vTiles1` as 128 tiles each, and the OAM sets
 ## index the result with a stride of $10, so it is kept as one strip of 256 and
@@ -3186,8 +3489,21 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"bits": 2,
 		}
 
+	## `TitleScreenGFX3`, the one title graphic that is not compressed: Gold and
+	## Silver only, and Gold's own four blank tiles behind it are kept, since
+	## `TitleScreen` copies eight tiles whatever the trail's own length is.
+	var title: Dictionary = layout.get("title", {})
+	if int(title.get("trail", -1)) >= 0:
+		sheets["title_trail"] = {
+			"offset": int(title["trail"]),
+			"tiles": int(title["trail_tiles"]),
+			"first_code": 0,
+			"bits": 2,
+		}
+
 	var written: Dictionary = _import_shrink_pics(rom, layout)
 	written.merge(_import_ditto_sheet(rom, layout), true)
+	written.merge(_import_title_sheets(rom, layout), true)
 	var done: int = 0
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -573,6 +573,54 @@ const PRESENTS_DITTO_FADE_COLORS: int = 16
 ## `PREDEFPAL_GAMEFREAK_LOGO_BG`, which is the copyright screen's own palette.
 const PRESENTS_OBJECT_PALETTE_COLORS: int = 4
 
+## The title screen (`_TitleScreen` on Crystal, `TitleScreen` on Gold and Silver,
+## `engine/movie/title.asm`). Two different screens sharing a phase: Crystal
+## decompresses three graphics and holds sixteen palettes of its own, while Gold
+## and Silver decompress two halves of a logo over one `$FF`-terminated tilemap
+## and animate a bird sprite behind a raw trail.
+##
+## Every offset was located the way the splash's were: the pinned PNG encoded as
+## cartridge 2bpp and matched, or, for an LZ run, every offset in the bank
+## decompressed and the one reproducing the PNG exactly kept. Each hits once.
+const TITLE_SUICUNE_TILES: int = 256
+## `--trim-end 4`: `DrawTitleGraphic` places 7 rows of 20 from `vTiles1`, and the
+## four tiles past them are whitespace the build drops.
+const TITLE_LOGO_TILES: int = 156
+## `--interleave`, so the sheet is a column of 8x16 objects rather than rows:
+## `InitializeBackground` walks five columns of six sprites, stepping the tile
+## number by two each time.
+const TITLE_CRYSTAL_TILES: int = 60
+const TITLE_CRYSTAL_SPRITE_COLUMNS: int = 5
+const TITLE_CRYSTAL_SPRITE_ROWS: int = 6
+## `TitleScreenPalettes` (`gfx/title/title.pal`), copied whole into both buffers.
+const TITLE_PALETTES: int = 16
+const TITLE_PALETTE_COLORS: int = 4
+
+## Gold and Silver's own halves. `TitleScreenGFX1` is `--trim-whitespace`, which
+## takes the bottom of the logo from 120 tiles to 112.
+const TITLE_LOGO_BOTTOM_TILES: int = 112
+const TITLE_LOGO_TOP_TILES: int = 60
+## `TitleScreenTilemap`, read a byte at a time until `-1`. Long enough for either
+## pin's run; one that reaches this has not found its terminator.
+const TITLE_TILEMAP_TERMINATOR: int = 0xFF
+const TITLE_TILEMAP_MAX: int = 1024
+## `debgcoord 0, 0`: the run is written straight into the BG map rather than into
+## the tilemap a screen is drawn from, so a row is `TILEMAP_WIDTH` and not
+## `SCREEN_WIDTH`. The twelve bytes past column 19 are off the right of the
+## screen and are blanks.
+const TITLE_TILEMAP_COLUMNS: int = 32
+const TITLE_TILEMAP_VISIBLE_COLUMNS: int = 20
+## `TitleScreenGFX3` is four drawn tiles on both profiles, but `TitleScreen`
+## copies eight whatever it is: Gold ships four blank tiles behind its trail and
+## Silver's four come off the head of the compressed Lugia, loaded into VRAM and
+## never shown. The source says so at the `FarCopyBytes`.
+const TITLE_TRAIL_DRAWN_TILES: int = 4
+const TITLE_TRAIL_COPIED_TILES: int = 8
+
+## `GSTitleBGPals` and `GSTitleOBPals`, contiguous in `engine/gfx/color.asm`.
+const TITLE_BG_PALETTES: int = 5
+const TITLE_OB_PALETTES: int = 2
+
 ## `engine/menus/start_menu.asm`'s `.PokedexDesc` through `.QuitDesc`, one
 ## contiguous run of `PlaceString` strings in the order they are defined, which
 ## is not the order `.Items` lists them in. MENU ACCOUNT is what draws one.
@@ -1049,6 +1097,26 @@ const GOLD_SILVER: Dictionary = {
 		"ditto_fade": -1,
 		"object_palette": 0xA4CD,
 	},
+	# `TitleScreen`. Gold's numbers; Silver's three differences are patched in
+	# `for_id`. `GSTitleOBPals` also appears in Crystal, which keeps the unused
+	# Gold and Silver title screen's copy at a different address; that is a
+	# leftover rather than a second candidate for this one. Nested the way
+	# trainer_card is, so Crystal's -1s stay out of the flat offset checks.
+	"title": {
+		"logo_bottom": 0x98000,
+		"logo_top": 0x98476,
+		"tilemap": 0x98616,
+		"trail": 0xE41E0,
+		"trail_tiles": 8,
+		"bird": 0xE4260,
+		"bird_tiles": 88,
+		"bg_palette": 0xBB36,
+		"ob_palette": 0xBB5E,
+		"suicune": -1,
+		"logo": -1,
+		"crystal": -1,
+		"palettes": -1,
+	},
 	"intro_player": {"pic_male": -1, "pic_female": -1},
 	"gender_screen": {"tile": -1, "palette": -1},
 	# `ShrinkPlayer`'s two intermediate pictures. Located from the routine's own
@@ -1284,6 +1352,25 @@ const CRYSTAL: Dictionary = {
 		"ditto_fade": 0xE47AC,
 		"object_palette": 0xA05E,
 	},
+	# `_TitleScreen`. A different screen from Gold and Silver's, so the two
+	# halves of this entry have nothing in common but the key: the three LZ runs
+	# and the sixteen palettes sit contiguous in `engine/movie/title.asm`'s own
+	# INCBIN order, ending on the palettes.
+	"title": {
+		"suicune": 0x10EF46,
+		"logo": 0x10F326,
+		"crystal": 0x10FCEE,
+		"palettes": 0x10FEDE,
+		"logo_bottom": -1,
+		"logo_top": -1,
+		"tilemap": -1,
+		"trail": -1,
+		"trail_tiles": 0,
+		"bird": -1,
+		"bird_tiles": 0,
+		"bg_palette": -1,
+		"ob_palette": -1,
+	},
 	# `engine/gfx/player_gfx.asm`: ChrisPic and KrisPic. Located by converting
 	# the pinned 56x56 PNGs with rgbgfx --columns and matching the full runs.
 	"intro_player": {"pic_male": 0x888A9, "pic_female": 0x88BB9},
@@ -1466,6 +1553,18 @@ static func for_id(id: StringName) -> Dictionary:
 			presents["gfx"] = 0xE49C9
 			presents["stars"] = 0xE4AA9
 			silver["game_freak_presents"] = presents
+			# Silver's logo bottom sits at Gold's address and its top 34 bytes
+			# later. Its trail is four tiles rather than eight, which is why the
+			# Lugia behind it starts 64 bytes earlier: `TitleScreen` copies 8
+			# tiles either way, so Silver's last four are the head of the
+			# compressed Lugia, loaded into VRAM and never drawn.
+			var title: Dictionary = (silver["title"] as Dictionary).duplicate()
+			title["logo_top"] = 0x98498
+			title["tilemap"] = 0x9862A
+			title["trail_tiles"] = 4
+			title["bird"] = 0xE4220
+			title["bird_tiles"] = 128
+			silver["title"] = title
 			return silver
 		RomRegistry.CRYSTAL:
 			return CRYSTAL

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -1,0 +1,434 @@
+class_name Gen2TitlePage
+extends RefCounted
+
+## The title screen, on the tile grid the hardware uses.
+##
+## Two screens under one name, the way [Gen2TitleScene] is. Crystal draws its
+## logo with `DrawTitleGraphic`, keeps a strip of Suicune under it that
+## `LoadSuicuneFrame` re-points every eighth frame, and stands the crystal in
+## front as thirty 8x16 objects. Gold and Silver write `TitleScreenTilemap`
+## straight into the BG map and fly one bird over it.
+##
+## [Gen2TitleScene] owns the frames and the positions; this owns the pixels.
+## Node-free like the other `render/*_page.gd`.
+
+const TILE: int = Gen2Tiles.TILE_WIDTH
+const COLUMNS: int = 20
+const ROWS: int = 18
+## A sprite never draws its first colour.
+const TRANSPARENT_INDEX: int = 0
+## Shadow OAM counts from (8, 16), so a coordinate reaches the screen eight less
+## across and sixteen less down.
+const OAM_ORIGIN := Vector2i(8, 16)
+## `TILEMAP_WIDTH_PX`: the BG map is 32 tiles across and wraps.
+const MAP_WIDTH: int = RomLayout.TITLE_TILEMAP_COLUMNS * Gen2Tiles.TILE_WIDTH
+## `set B_LCDC_OBJ_SIZE`: every object on this screen is two tiles tall.
+const OBJECT_HEIGHT: int = 2
+
+## `hlcoord 0, 3` with `lb bc, 7, 20` and a stride of 20: the Pokemon logo, and
+## `TitleLogoGFX` is loaded at `vTiles1`, which the BG addresses from $80.
+const CRYSTAL_LOGO_AT := Vector2i(0, 3)
+const CRYSTAL_LOGO_COLUMNS: int = 20
+const CRYSTAL_LOGO_ROWS: int = 7
+const CRYSTAL_LOGO_FIRST_TILE: int = 0x80
+
+## `TitleScreenPalettes` is sixteen palettes, and the attribute map picks one per
+## row: the logo takes a gradient down its seven rows and the Suicune strip takes
+## the first. `_TitleScreen` fills lines 3-4 with 2, then 3, 4, 5, and 8-9 with
+## 6, so the seven rows read as the run below.
+const CRYSTAL_LOGO_PALETTES: Array[int] = [2, 2, 3, 4, 5, 6, 6]
+const CRYSTAL_VERSION_ROW: int = 9
+const CRYSTAL_VERSION_AT: int = 5
+const CRYSTAL_VERSION_TILES: int = 11
+const CRYSTAL_VERSION_PALETTE: int = 1
+const CRYSTAL_SUICUNE_PALETTE: int = 0
+## The hardware has eight of each, and `_TitleScreen` fills both sets from one
+## sixteen-palette run.
+const CRYSTAL_BG_PALETTES: int = 8
+
+## `.OAMData_GSIntroHoOh1` through `5`, as `dbsprite` tile-and-pixel pairs
+## already worked out: `(x, y, tile)` in pixels, with the 8x16 objects stepping
+## the tile number by two.
+const BIRD_OAM: Array[Array] = [
+	[
+		Vector3i(-32, -8, 0x00), Vector3i(-24, -16, 0x02), Vector3i(-24, 0, 0x04),
+		Vector3i(-16, -24, 0x06), Vector3i(-16, -8, 0x08), Vector3i(-16, 8, 0x0A),
+		Vector3i(-8, -24, 0x0C), Vector3i(-8, -8, 0x0E), Vector3i(-8, 8, 0x10),
+		Vector3i(0, -24, 0x12), Vector3i(0, -8, 0x14), Vector3i(0, 8, 0x16),
+		Vector3i(8, -24, 0x18), Vector3i(8, -8, 0x1A), Vector3i(8, 8, 0x1C),
+		Vector3i(16, -8, 0x1E), Vector3i(16, 8, 0x20),
+		Vector3i(24, -16, 0x22), Vector3i(24, 0, 0x24),
+	],
+	[
+		Vector3i(-32, -8, 0x00), Vector3i(-24, -16, 0x02), Vector3i(-24, 0, 0x04),
+		Vector3i(-16, -8, 0x26), Vector3i(-16, 8, 0x0A),
+		Vector3i(-8, -24, 0x28), Vector3i(-8, -8, 0x2A), Vector3i(-8, 8, 0x10),
+		Vector3i(0, -8, 0x2C), Vector3i(0, 8, 0x16),
+		Vector3i(8, -8, 0x30), Vector3i(8, 8, 0x1C),
+		Vector3i(16, -8, 0x1E), Vector3i(16, 8, 0x20),
+		Vector3i(24, -16, 0x22), Vector3i(24, 0, 0x24),
+	],
+	[
+		Vector3i(-32, -8, 0x00), Vector3i(-24, -16, 0x02), Vector3i(-24, 0, 0x32),
+		Vector3i(-16, -8, 0x34), Vector3i(-16, 8, 0x36),
+		Vector3i(-8, -8, 0x38), Vector3i(-8, 8, 0x3A),
+		Vector3i(0, -8, 0x3C), Vector3i(0, 8, 0x3E),
+		Vector3i(8, -8, 0x30), Vector3i(8, 8, 0x1C),
+		Vector3i(16, -8, 0x1E), Vector3i(16, 8, 0x20),
+		Vector3i(24, -16, 0x22), Vector3i(24, 0, 0x24),
+	],
+	[
+		Vector3i(-32, -8, 0x00), Vector3i(-24, -16, 0x02), Vector3i(-24, 0, 0x04),
+		Vector3i(-16, -8, 0x40), Vector3i(-16, 8, 0x42), Vector3i(-16, 24, 0x44),
+		Vector3i(-8, -8, 0x46), Vector3i(-8, 8, 0x48), Vector3i(-8, 24, 0x4A),
+		Vector3i(0, -8, 0x4C), Vector3i(0, 8, 0x4E),
+		Vector3i(8, -8, 0x30), Vector3i(8, 8, 0x1C),
+		Vector3i(16, -8, 0x1E), Vector3i(16, 8, 0x20),
+		Vector3i(24, -16, 0x22), Vector3i(24, 0, 0x24),
+	],
+	[
+		Vector3i(-32, -8, 0x00), Vector3i(-24, -16, 0x02), Vector3i(-24, 0, 0x04),
+		Vector3i(-16, -8, 0x50), Vector3i(-16, 8, 0x0A),
+		Vector3i(-8, -24, 0x52), Vector3i(-8, -8, 0x54), Vector3i(-8, 8, 0x10),
+		Vector3i(0, -24, 0x56), Vector3i(0, -8, 0x2E), Vector3i(0, 8, 0x16),
+		Vector3i(8, -8, 0x30), Vector3i(8, 8, 0x1C),
+		Vector3i(16, -8, 0x1E), Vector3i(16, 8, 0x20),
+		Vector3i(24, -16, 0x22), Vector3i(24, 0, 0x24),
+	],
+]
+## `.OAMData_GSIntroLugia1` and `2`, which are what Silver's five sets are drawn
+## from: the same two pictures at four `spriteanimoam` vtile offsets, so the
+## sheet is cycled rather than the shape.
+const LUGIA_OAM: Array[Array] = [
+	[
+		Vector3i(-40, -16, 0x00), Vector3i(-40, 0, 0x02),
+		Vector3i(-32, -16, 0x04), Vector3i(-32, 0, 0x06),
+		Vector3i(-24, -8, 0x08), Vector3i(-16, -8, 0x0A),
+		Vector3i(-8, -16, 0x0C), Vector3i(-8, 0, 0x0E),
+		Vector3i(0, -16, 0x10), Vector3i(0, 0, 0x12),
+		Vector3i(8, -16, 0x14), Vector3i(8, 0, 0x16),
+		Vector3i(16, -16, 0x18), Vector3i(16, 0, 0x1A),
+		Vector3i(24, -8, 0x1C), Vector3i(32, -8, 0x1E),
+	],
+	[
+		Vector3i(-40, -16, 0x00), Vector3i(-40, 0, 0x02),
+		Vector3i(-32, -16, 0x04), Vector3i(-32, 0, 0x06),
+		Vector3i(-24, -8, 0x08), Vector3i(-16, -8, 0x0A),
+		Vector3i(-8, -16, 0x0C), Vector3i(-8, 0, 0x0E),
+		Vector3i(0, -16, 0x10), Vector3i(0, 0, 0x12),
+		Vector3i(8, -16, 0x14), Vector3i(8, 0, 0x16),
+		Vector3i(16, -16, 0x18), Vector3i(16, 0, 0x1A),
+		Vector3i(24, -16, 0x1C), Vector3i(32, -16, 0x1E),
+	],
+]
+## `SpriteAnimOAMData`'s own rows for the five sets: which picture, and the
+## `spriteanimoam` vtile offset added to every tile in it. Gold's five are five
+## pictures at offset zero; Silver's are two pictures at four offsets.
+const BIRD_SETS_GOLD: Array[Vector2i] = [
+	Vector2i(0, 0x00), Vector2i(1, 0x00), Vector2i(2, 0x00),
+	Vector2i(3, 0x00), Vector2i(4, 0x00),
+]
+const BIRD_SETS_SILVER: Array[Vector2i] = [
+	Vector2i(0, 0x00), Vector2i(0, 0x20), Vector2i(1, 0x40),
+	Vector2i(1, 0x60), Vector2i(0, 0x00),
+]
+
+## `.OAMData_GSTitleTrail`: one 8x16 object a tile up and left of the struct's
+## own coordinate, drawn through object palette 1. `SPRITE_ANIM_OAMSET_GS_TITLE_TRAIL_1`
+## and `_2` are the same picture at vtile $f8 and $fa, and `TitleScreen` copies
+## the trail into `vTiles1 tile $78`, which is where those two land.
+const TRAIL_AT := Vector3i(-8, -8, 0x00)
+const TRAIL_TILES: Array[int] = [0x00, 0x02]
+## `TitleScreen` copies the trail into `vTiles1 tile $78`, which the object
+## layer addresses as tile $78 of the second sheet.
+const TRAIL_PALETTE: int = 1
+
+## `TitleScreenGFX2` is loaded at `vTiles1` and `GFX1` at `vTiles2`, so a
+## tilemap code below $80 is the top half and one at or above it the bottom.
+const GS_TOP_FIRST_TILE: int = 0x80
+## `FillTitleScreenPals`: attribute 1 over the top seven rows, 3 over the ten
+## tiles of "VERSION" on row 6, and 4 over rows 12 and down. Everything else is
+## palette 0.
+const GS_TOP_ROWS: int = 7
+const GS_TOP_PALETTE: int = 1
+const GS_VERSION_ROW: int = 6
+const GS_VERSION_AT: int = 5
+const GS_VERSION_TILES: int = 10
+const GS_VERSION_PALETTE: int = 3
+const GS_BOTTOM_ROW: int = 12
+const GS_BOTTOM_PALETTE: int = 4
+
+var _profile: StringName = &"gold"
+## Crystal's three strips, or Gold and Silver's four.
+var _sheets: Dictionary = {}
+var _widths: Dictionary = {}
+var _background: Array[PackedColorArray] = []
+var _object: Array[PackedColorArray] = []
+var _tilemap: PackedByteArray = PackedByteArray()
+var _drawn: PackedByteArray = PackedByteArray()
+var _map: Image = null
+var _map_indices: PackedByteArray = PackedByteArray()
+
+
+## Null on a cache with no title art, which is the caller's cue to skip the
+## phase rather than to run it blank.
+static func from_data(data: GameData) -> Gen2TitlePage:
+	if data == null:
+		return null
+	var out := Gen2TitlePage.new()
+	out._profile = data.id
+	var names: Array[String] = ["title_logo_bottom", "title_logo_top", "title_trail", "title_bird"]
+	if data.id == RomRegistry.CRYSTAL:
+		names = ["title_suicune", "title_logo", "title_crystal"]
+	for name: String in names:
+		var sheet: Dictionary = data.tile_sheet(name)
+		var indices: PackedByteArray = data.tile_indices(name)
+		if sheet.is_empty() or indices.is_empty():
+			return null
+		out._sheets[name] = indices
+		out._widths[name] = int(sheet.get("width", 0))
+
+	if data.id == RomRegistry.CRYSTAL:
+		# `CopyBytes` writes sixteen palettes from `wBGPals1`, and `wOBPals1` is
+		# the eight straight after it, so the run is the background's eight and
+		# then the objects'.
+		var all: Array[PackedColorArray] = data.title_palettes("palettes")
+		out._background = all.slice(0, CRYSTAL_BG_PALETTES)
+		out._object = all.slice(CRYSTAL_BG_PALETTES)
+	else:
+		out._background = data.title_palettes("bg_palettes")
+		out._object = data.title_palettes("ob_palettes")
+		out._tilemap = data.title_tilemap()
+		if out._tilemap.is_empty():
+			return null
+	if out._background.is_empty() or out._object.is_empty():
+		return null
+	return out
+
+
+## The whole 160x144 screen for one frame of [param scene].
+##
+## The background is built at the BG map's own 256 pixels across and then
+## sampled through the scroll, because that map wraps: a cloud band walking left
+## brings the map's own right-hand columns back round rather than leaving a gap.
+func draw(scene: Gen2TitleScene) -> Image:
+	var width: int = COLUMNS * TILE
+	var height: int = ROWS * TILE
+	var image: Image = Image.create_empty(width, height, false, Image.FORMAT_RGBA8)
+	var blank: Color = _background[0][0] if not _background[0].is_empty() else Color.BLACK
+	image.fill(blank)
+	# What colour index each pixel of the background ended up as, which is the
+	# only thing `OAM_PRIO` reads: a sprite behind the background shows through
+	# colour 0 and nowhere else.
+	_drawn.resize(width * height)
+	_drawn.fill(0)
+	if scene == null:
+		return image
+
+	_map = Image.create_empty(MAP_WIDTH, height, false, Image.FORMAT_RGBA8)
+	_map.fill(blank)
+	_map_indices.resize(MAP_WIDTH * height)
+	_map_indices.fill(0)
+	if _profile == RomRegistry.CRYSTAL:
+		_draw_crystal_background(scene)
+	else:
+		_draw_gs_background()
+	_compose(image, scene)
+
+	for sprite: Dictionary in scene.sprites():
+		_draw_sprite(image, scene, sprite)
+	return image
+
+
+## The BG map through `hSCX` and whatever `wLYOverrides` is writing over it, one
+## scanline at a time.
+func _compose(image: Image, scene: Gen2TitleScene) -> void:
+	var offsets: PackedInt32Array = scene.line_offsets()
+	var base: int = scene.scroll_x()
+	for y: int in image.get_height():
+		var shift: int = offsets[y] if y < offsets.size() else base
+		for x: int in image.get_width():
+			var from: int = posmod(x + shift, MAP_WIDTH)
+			image.set_pixel(x, y, _map.get_pixel(from, y))
+			_drawn[y * image.get_width() + x] = _map_indices[y * MAP_WIDTH + from]
+
+
+## `DrawTitleGraphic` over the logo, then `LoadSuicuneFrame`'s own six rows of
+## eight. `hSCX` is the entrance's own scroll and moves the whole background.
+func _draw_crystal_background(scene: Gen2TitleScene) -> void:
+	for row: int in CRYSTAL_LOGO_ROWS:
+		var palette: PackedColorArray = _palette(
+			_background, CRYSTAL_LOGO_PALETTES[row]
+		)
+		for column: int in CRYSTAL_LOGO_COLUMNS:
+			_blit_background(
+				"title_logo", row * CRYSTAL_LOGO_COLUMNS + column,
+				Vector2i(CRYSTAL_LOGO_AT.x + column, CRYSTAL_LOGO_AT.y + row) * TILE,
+				palette
+			)
+	# The eleven tiles of "CRYSTAL VERSION" sit on the logo's last row and take a
+	# palette of their own.
+	for index: int in CRYSTAL_VERSION_TILES:
+		var column: int = CRYSTAL_VERSION_AT + index
+		_blit_background(
+			"title_logo",
+			(CRYSTAL_VERSION_ROW - CRYSTAL_LOGO_AT.y) * CRYSTAL_LOGO_COLUMNS + column,
+			Vector2i(column, CRYSTAL_VERSION_ROW) * TILE,
+			_palette(_background, CRYSTAL_VERSION_PALETTE)
+		)
+	for placed: Vector3i in scene.suicune_tiles():
+		_blit_background(
+			"title_suicune", placed.z, Vector2i(placed.x, placed.y) * TILE,
+			_palette(_background, CRYSTAL_SUICUNE_PALETTE)
+		)
+
+
+## `LoadTitleScreenTilemap` and `FillTitleScreenPals`: the stored map straight
+## into the BG, and one palette per band of rows.
+func _draw_gs_background() -> void:
+	for row: int in ROWS:
+		for column: int in RomLayout.TITLE_TILEMAP_COLUMNS:
+			var at: int = row * RomLayout.TITLE_TILEMAP_COLUMNS + column
+			if at >= _tilemap.size():
+				continue
+			var code: int = _tilemap[at]
+			var name: String = "title_logo_bottom"
+			var tile: int = code
+			if code >= GS_TOP_FIRST_TILE:
+				name = "title_logo_top"
+				tile = code - GS_TOP_FIRST_TILE
+			_blit_background(
+				name, tile, Vector2i(column, row) * TILE,
+				_palette(_background, _gs_palette(row, column))
+			)
+
+
+func _gs_palette(row: int, column: int) -> int:
+	if row == GS_VERSION_ROW and column >= GS_VERSION_AT \
+			and column < GS_VERSION_AT + GS_VERSION_TILES:
+		return GS_VERSION_PALETTE
+	if row < GS_TOP_ROWS:
+		return GS_TOP_PALETTE
+	if row >= GS_BOTTOM_ROW:
+		return GS_BOTTOM_PALETTE
+	return 0
+
+
+## One object's whole OAM set, positioned by its shadow-OAM coordinate and drawn
+## through an object palette, whose first colour is transparent.
+func _draw_sprite(image: Image, scene: Gen2TitleScene, sprite: Dictionary) -> void:
+	var palette: PackedColorArray = _palette(_object, int(sprite.get("palette", 0)))
+	if palette.size() <= TRANSPARENT_INDEX:
+		return
+	var at: Vector2i = sprite["at"]
+	for part: Vector3i in _oam_set(StringName(sprite["kind"]), int(sprite.get("tile", 0))):
+		var name: String = _sprite_sheet(StringName(sprite["kind"]))
+		# `UpdateAnimFrame` builds every position with `add`, so an offset past
+		# the screen wraps rather than clamping.
+		var to := Vector2i(
+			((at.x + part.x) & 0xFF) - OAM_ORIGIN.x,
+			((at.y + part.y) & 0xFF) - OAM_ORIGIN.y,
+		)
+		var base: int = int(sprite.get("tile", 0)) if name == "title_crystal" else part.z
+		for half: int in OBJECT_HEIGHT:
+			_blit_sprite_tile(
+				image, palette, name, base + half,
+				Vector2i(to.x, to.y + half * TILE),
+				bool(sprite.get("behind", false))
+			)
+
+
+func _sprite_sheet(kind: StringName) -> String:
+	match kind:
+		Gen2TitleScene.SPRITE_CRYSTAL:
+			return "title_crystal"
+		Gen2TitleScene.SPRITE_TRAIL:
+			return "title_trail"
+		_:
+			return "title_bird"
+
+
+## The `dbsprite` run behind one object. The crystal's is a single 8x16 part,
+## the trail's the one `.OAMData_GSTitleTrail` names, and the bird's whichever of
+## the five `.OAMData_GSIntroHoOh*` sets its frameset has reached.
+func _oam_set(kind: StringName, frame: int) -> Array[Vector3i]:
+	match kind:
+		Gen2TitleScene.SPRITE_CRYSTAL:
+			return [Vector3i(0, 0, 0)] as Array[Vector3i]
+		Gen2TitleScene.SPRITE_TRAIL:
+			return [TRAIL_AT] as Array[Vector3i]
+		_:
+			var sets: Array[Vector2i] = (
+				BIRD_SETS_GOLD if _profile == RomRegistry.GOLD else BIRD_SETS_SILVER
+			)
+			var pictures: Array[Array] = (
+				BIRD_OAM if _profile == RomRegistry.GOLD else LUGIA_OAM
+			)
+			var row: Vector2i = sets[clampi(frame, 0, sets.size() - 1)]
+			var out: Array[Vector3i] = []
+			for part: Vector3i in pictures[row.x]:
+				out.append(Vector3i(part.x, part.y, part.z + row.y))
+			return out
+
+
+func _palette(run: Array[PackedColorArray], index: int) -> PackedColorArray:
+	if index < 0 or index >= run.size():
+		return PackedColorArray()
+	return run[index]
+
+
+## One tile into the BG map, through the palette its attribute names. The map is
+## what wraps and what the scroll is applied to; nothing here knows the screen.
+func _blit_background(
+	name: String, tile: int, at: Vector2i, palette: PackedColorArray
+) -> void:
+	var tiles: PackedByteArray = _sheets.get(name, PackedByteArray())
+	var stride: int = int(_widths.get(name, 0))
+	if stride <= 0 or tile < 0 or palette.is_empty():
+		return
+	for y: int in TILE:
+		var target_y: int = at.y + y
+		if target_y < 0 or target_y >= _map.get_height():
+			continue
+		for x: int in TILE:
+			var target_x: int = at.x + x
+			if target_x < 0 or target_x >= MAP_WIDTH:
+				continue
+			var from: int = y * stride + tile * TILE + x
+			if from < 0 or from >= tiles.size():
+				continue
+			var value: int = tiles[from]
+			if value >= palette.size():
+				continue
+			_map.set_pixel(target_x, target_y, palette[value])
+			_map_indices[target_y * MAP_WIDTH + target_x] = value
+
+
+## One object tile onto the drawn screen, clipped per axis so a sprite hanging
+## off an edge cannot wrap onto the opposite one. [param behind] is `OAM_PRIO`,
+## which lets the background's colours 1 to 3 cover the object.
+func _blit_sprite_tile(
+	image: Image, palette: PackedColorArray, name: String, tile: int, at: Vector2i,
+	behind: bool = false
+) -> void:
+	var tiles: PackedByteArray = _sheets.get(name, PackedByteArray())
+	var stride: int = int(_widths.get(name, 0))
+	if stride <= 0 or tile < 0:
+		return
+	for y: int in TILE:
+		var target_y: int = at.y + y
+		if target_y < 0 or target_y >= image.get_height():
+			continue
+		for x: int in TILE:
+			var target_x: int = at.x + x
+			if target_x < 0 or target_x >= image.get_width():
+				continue
+			var from: int = y * stride + tile * TILE + x
+			if from < 0 or from >= tiles.size():
+				continue
+			var value: int = tiles[from]
+			if value == TRANSPARENT_INDEX or value >= palette.size():
+				continue
+			if behind and _drawn[target_y * image.get_width() + target_x] != 0:
+				continue
+			image.set_pixel(target_x, target_y, palette[value])

--- a/game/render/title_page.gd.uid
+++ b/game/render/title_page.gd.uid
@@ -1,0 +1,1 @@
+uid://cpd73185incqf

--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -36,6 +36,8 @@ var _intro_scene_lengths: Array[int] = []
 ## `GameFreakPresentsScene` and the sprite beside it, which own every frame of
 ## the presents phase. Null until that phase is entered.
 var _presents: Gen2GameFreakPresents = null
+## `TitleScreenScene`'s own state while the title phase is up, null outside it.
+var _title: Gen2TitleScene = null
 ## The `BattleAnimSineWave` the presents phase reads its motion out of, handed
 ## in by the host that has a cache open.
 var _sine: Gen2BattleAnimData = null
@@ -58,6 +60,7 @@ func start(
 	_profile = profile
 	_sine = sine
 	_presents = null
+	_title = null
 	_intro_scene_lengths = _validated_intro_lengths(intro_scene_lengths)
 	_available = available.duplicate()
 	if not is_available(PHASE_COPYRIGHT):
@@ -114,7 +117,7 @@ func drain_events() -> Array[Dictionary]:
 ## Advances exactly one 59.7275 Hz source frame. A sound wait is released only
 ## through complete_sound(), so a slow or failed device cannot be mistaken for
 ## a fixed presentation delay.
-func advance_frame() -> Array[Dictionary]:
+func advance_frame(held: Array = []) -> Array[Dictionary]:
 	if _phase.is_empty() or _phase == PHASE_FINISHED or not _waiting_sound.is_empty():
 		return drain_events()
 	_frame += 1
@@ -127,10 +130,49 @@ func advance_frame() -> Array[Dictionary]:
 		PHASE_INTRO_MOVIE:
 			_advance_intro()
 		PHASE_TITLE:
-			pass
+			_advance_title(held)
 		PHASE_NEW_GAME:
 			pass
 	return drain_events()
+
+
+## `RunTitleScreen`'s own loop, one frame of it. The screen answers on its own
+## through `wTitleScreenSelectedOption`, so the two chords and the timeout land
+## here rather than waiting on the host; only the main-menu answer is left for
+## [method select_title], since what it opens is the host's business.
+func _advance_title(held: Array) -> void:
+	if _title == null:
+		_enter_after(PHASE_TITLE)
+		return
+	_title.advance_frame(held)
+	if not _title.finished():
+		return
+	var option: int = _title.selected_option()
+	match option:
+		Gen2TitleScene.OPTION_RESTART:
+			# `TitleScreenEnd` fades the music out and jumps back to
+			# `IntroSequence`, which is the whole opening again.
+			_emit(&"play_music", {"music": &"none", "restart": true})
+			_emit(&"restart_opening", {"profile": _profile})
+			start(_profile, _intro_scene_lengths, _available, _sine)
+		Gen2TitleScene.OPTION_DELETE_SAVE_DATA, Gen2TitleScene.OPTION_RESET_CLOCK:
+			_emit(&"title_chord", {
+				"option": option,
+				"kind": (
+					&"delete_save_data"
+					if option == Gen2TitleScene.OPTION_DELETE_SAVE_DATA
+					else &"reset_clock"
+				),
+			})
+			_title = Gen2TitleScene.create(_profile, _sine)
+		_:
+			_emit(&"title_menu", {"profile": _profile})
+
+
+## The live title screen, so a host can read the sprites and scroll it is
+## drawing. Null outside the title phase.
+func title() -> Gen2TitleScene:
+	return _title
 
 
 func wait_sound(token: StringName) -> void:
@@ -250,6 +292,11 @@ func _enter_after(phase: StringName) -> void:
 				_emit(&"play_music", {"music": &"gold_silver_opening", "restart": false})
 				_emit(&"show_image", {"id": &"intro_scene", "scene": _intro_scene})
 			PHASE_TITLE:
+				# `_TitleScreen` draws the whole screen and plays
+				# `SFX_TITLE_SCREEN_ENTRANCE` before the loop's first frame;
+				# Crystal's music waits for its entrance to finish, so the
+				# request is the same either way and the host owns the delay.
+				_title = Gen2TitleScene.create(_profile, _sine)
 				_emit(&"open_title", {"profile": _profile})
 				_emit(&"play_music", {"music": &"title", "restart": false})
 		return

--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -151,10 +151,11 @@ func _advance_title(held: Array) -> void:
 	match option:
 		Gen2TitleScene.OPTION_RESTART:
 			# `TitleScreenEnd` fades the music out and jumps back to
-			# `IntroSequence`, which is the whole opening again.
-			_emit(&"play_music", {"music": &"none", "restart": true})
-			_emit(&"restart_opening", {"profile": _profile})
+			# `IntroSequence`, which is the whole opening again. The restart runs
+			# first because [method start] empties the queue, and its own
+			# `play_music none` is the fade landing.
 			start(_profile, _intro_scene_lengths, _available, _sine)
+			_emit(&"restart_opening", {"profile": _profile})
 		Gen2TitleScene.OPTION_DELETE_SAVE_DATA, Gen2TitleScene.OPTION_RESET_CLOCK:
 			_emit(&"title_chord", {
 				"option": option,

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -72,6 +72,12 @@ func _unhandled_input(event: InputEvent) -> void:
 	var button: int = Gen2Button.pressed_in(event)
 	if button != 0 and handle_button(button):
 		get_viewport().set_input_as_handled()
+		return
+	## The title screen is the one screen here that reads `hJoyDown` rather than
+	## a press: its two chords are three buttons at once, which no press can say.
+	var released: int = Gen2Button.released_in(event)
+	if released != 0 and release_button(released):
+		get_viewport().set_input_as_handled()
 
 
 ## Sub-screens draw in the 160x144 space, so they go inside the hardware
@@ -107,6 +113,15 @@ func gender() -> int:
 func handle_button(button: int) -> bool:
 	var screen: Control = current()
 	return screen.handle_button(button) if screen != null else false
+
+
+## The release half, which only the splash's title phase has anything to do
+## with. Answers whether it was taken.
+func release_button(button: int) -> bool:
+	if _splash == null:
+		return false
+	_splash.release_button(button)
+	return true
 
 
 ## `SplashScreen` first, which is the copyright screen and nothing else until

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -157,10 +157,23 @@ func _apply(events: Array[Dictionary]) -> void:
 					_visible_id = &""
 			&"open_title":
 				_visible_id = &"title"
+			&"restart_opening":
+				# `TitleScreenEnd` jumps back to `IntroSequence`, which clears
+				# the screen before the copyright's own ten blank frames.
+				_visible_id = &""
 			&"title_menu":
 				# `Intro_MainMenu` is the launcher and the save screen here, so
 				# the answer this project has for the screen is New Game.
 				_cinema.select_title(&"new_game")
+			&"open_new_game":
+				# `NewGame` is the screen behind this one, so the opening is over
+				# and nothing else here spends a frame: without this the
+				# coordinator sits in its new-game phase and never finishes.
+				_cinema.finish_new_game()
+				_visible_id = &""
+				_refresh()
+				_finish()
+				return
 			&"play_sfx":
 				_play_sfx(int(event.get("sfx", 0)))
 			&"finish_intro":

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -4,16 +4,19 @@ extends Control
 ## `SplashScreen` (`engine/movie/splash.asm`), as far as this project has the art
 ## for it.
 ##
-## The source runs three things before a new game: the copyright screen, the
-## GameFreak logo animation and, on Crystal, the intro movie. The first two are
-## imported, so [Gen2BootCinema] is started with those phases and the movie is
-## skipped rather than held on a blank screen for the frames it would have taken.
+## The source runs four things before a new game: the copyright screen, the
+## GameFreak logo animation, on Crystal the intro movie, and the title screen.
+## Every one but the movie is imported, so [Gen2BootCinema] is started with those
+## phases and the movie is skipped rather than held on a blank screen for the
+## frames it would have taken.
 ##
 ## The pacing is the source's throughout. The copyright half is ten frames of
 ## blank and the screen for a hundred, with no button read at all, since
 ## `DelayFrames` does not look at the joypad; the GameFreak half is
 ## `GameFreakPresentsScene` and its sprite, which do read one, and a press there
-## ends the animation early through [method Gen2BootCinema.skip_presents].
+## ends the animation early through [method Gen2BootCinema.skip_presents]. The
+## title screen reads a held button rather than a press, because every branch of
+## `TitleScreenMain` is `hJoyDown`.
 
 ## Emitted once the last phase this host can draw has finished.
 signal closed()
@@ -24,6 +27,10 @@ var _cinema: Gen2BootCinema = null
 var _data: GameData = null
 var _page: Gen2CopyrightPage = null
 var _presents_page: Gen2GameFreakPresentsPage = null
+var _title_page: Gen2TitlePage = null
+## What `hJoyDown` holds this frame. `TitleScreenMain` reads the held state, and
+## its two chords cannot be expressed as presses.
+var _held: Array[int] = []
 var _background: TextureRect = null
 var _audio: Gen2AudioPlayer = null
 var _image: Image = null
@@ -43,9 +50,12 @@ func open(data: GameData) -> bool:
 		_page.draw(), Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _palette()
 	)
 	_presents_page = Gen2GameFreakPresentsPage.from_data(data)
+	_title_page = Gen2TitlePage.from_data(data)
 	var phases: Array[StringName] = [Gen2BootCinema.PHASE_COPYRIGHT]
 	if _presents_page != null:
 		phases.append(Gen2BootCinema.PHASE_PRESENTS)
+	if _title_page != null:
+		phases.append(Gen2BootCinema.PHASE_TITLE)
 	_cinema = Gen2BootCinema.new()
 	_cinema.start(
 		data.id if data != null else &"gold", [], phases, _sine_table(data)
@@ -84,18 +94,31 @@ func advance_frames(count: int) -> void:
 		if _closed or _cinema.phase() == Gen2BootCinema.PHASE_FINISHED:
 			_finish()
 			return
-		_apply(_cinema.advance_frame())
+		_apply(_cinema.advance_frame(_held))
 
 
 ## `.joy_loop`'s `and PAD_BUTTONS`: only the GameFreak animation reads one, and
 ## a press there still spends `GameFreakPresentsEnd`'s sixteen frames.
 func handle_button(button: int) -> bool:
-	if _cinema == null or button in [
+	if _cinema == null:
+		return true
+	if _cinema.phase() == Gen2BootCinema.PHASE_TITLE:
+		# The title screen has no press of its own: a chord is a held state, so a
+		# press only adds a button and the release below takes it away.
+		if not _held.has(button):
+			_held.append(button)
+		return true
+	if button in [
 		Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT
 	]:
 		return true
 	_cinema.skip_presents()
 	return true
+
+
+## The other half of `hJoyDown`, which a press-only host has no way to say.
+func release_button(button: int) -> void:
+	_held.erase(button)
 
 
 ## How many frames the splash still owes, so a driver can settle it with a loop
@@ -104,6 +127,11 @@ func handle_button(button: int) -> bool:
 func frames_left() -> int:
 	if _cinema == null or _cinema.phase() == Gen2BootCinema.PHASE_FINISHED:
 		return 0
+	if _cinema.phase() == Gen2BootCinema.PHASE_TITLE:
+		# `TitleScreenMain` waits on a button or on its own timer, so what is
+		# left is however much of that timer is still standing.
+		var title: Gen2TitleScene = _cinema.title()
+		return maxi(title.timer(), 1) if title != null else 1
 	if _cinema.phase() != Gen2BootCinema.PHASE_COPYRIGHT:
 		return 1
 	return Gen2BootCinema.COPYRIGHT_PRELUDE_FRAMES \
@@ -127,6 +155,12 @@ func _apply(events: Array[Dictionary]) -> void:
 			&"hide_image":
 				if StringName(event.get("id", &"")) == _visible_id:
 					_visible_id = &""
+			&"open_title":
+				_visible_id = &"title"
+			&"title_menu":
+				# `Intro_MainMenu` is the launcher and the save screen here, so
+				# the answer this project has for the screen is New Game.
+				_cinema.select_title(&"new_game")
 			&"play_sfx":
 				_play_sfx(int(event.get("sfx", 0)))
 			&"finish_intro":
@@ -158,6 +192,8 @@ func _frame_image() -> Image:
 		return _image
 	if _visible_id == &"game_freak_presents" and _presents_page != null:
 		return _presents_page.draw(_cinema.presents())
+	if _visible_id == &"title" and _title_page != null:
+		return _title_page.draw(_cinema.title())
 	return _blank()
 
 

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -1,0 +1,450 @@
+class_name Gen2TitleScene
+extends RefCounted
+
+## The title screen's own scene machine (`TitleScreenScene`,
+## `engine/menus/intro_menu.asm`), one source frame at a time.
+##
+## Two screens under one name. Crystal opens on `TitleScreenEntrance`, which
+## walks `hSCX` in from 112 while the crystal falls into place and the interlaced
+## `wLYOverrides` pull the logo together; Gold and Silver have no entrance at all
+## and go straight to the timer with a bird flying on its own sine.
+##
+## Scene-free: this owns the frames, the scroll, the sprites and the option the
+## screen answers with. [Gen2TitlePage] owns the pixels and a host owns the
+## device. What it never owns is the decision behind the answer: the caller reads
+## [method selected_option] once [method finished] holds.
+
+## `.scenes`. Crystal's table opens on the entrance and Gold and Silver's does
+## not, so the phase is named rather than numbered here.
+const SCENE_ENTRANCE: StringName = &"entrance"
+const SCENE_TIMER: StringName = &"timer"
+const SCENE_MAIN: StringName = &"main"
+const SCENE_END: StringName = &"end"
+
+## `TITLESCREENOPTION_*`, in the source's own const order. `RESTART` and
+## `UNUSED` are reachable only from the main menu behind this screen.
+const OPTION_MAIN_MENU: int = 0
+const OPTION_DELETE_SAVE_DATA: int = 1
+## `TitleScreenEnd`'s own answer once the timer has run out and the music has
+## faded: `.dw`'s third entry is `IntroSequence`, so a screen nobody pressed
+## starts the whole opening again.
+const OPTION_RESTART: int = 2
+const OPTION_RESET_CLOCK: int = 4
+
+## `TitleScreenTimer`'s own `ld de`: 84 * 60 + 16 on Gold, 73 * 60 + 36 on
+## Silver and on Crystal. A timer that runs out is the intro movie's cue.
+const TIMER_GOLD: int = 84 * 60 + 16
+const TIMER_DEFAULT: int = 73 * 60 + 36
+
+## `TitleScreenEntrance`: `hSCX` starts at +112 and comes off four a frame, and
+## `AnimateTitleCrystal` moves thirty sprites down two a frame until the first
+## one's y reaches 6 + two tiles. Both take the same twenty-eight frames, which
+## is why neither has to wait for the other.
+const ENTRANCE_SCX: int = 112
+const ENTRANCE_SCX_STEP: int = 4
+## The interlaced band is the logo's height, and only its odd lines take the
+## opposite sign.
+const ENTRANCE_LINES: int = 8 * 10
+const CRYSTAL_START_Y: int = -0x22
+const CRYSTAL_END_Y: int = 6 + 2 * Gen2Tiles.TILE_HEIGHT
+const CRYSTAL_STEP: int = 2
+
+## `SuicuneFrameIterator`: the counter rises every frame and the frame it names
+## changes on every eighth, walking `.Frames`' four bases.
+const SUICUNE_FRAME_MASK: int = 0b111
+const SUICUNE_FRAMES: Array[int] = [0x80, 0x88, 0x00, 0x08]
+## `LoadSuicuneFrame` draws six rows of eight from whichever base it is handed.
+const SUICUNE_COLUMNS: int = 8
+const SUICUNE_ROWS: int = 6
+const SUICUNE_AT := Vector2i(6, 12)
+## `Decompress` puts the sheet at `vTiles4`, which is tile $80 of the bank the
+## Suicune strip is read through, and a tile number is a byte: `.Frames`' last
+## two bases are written as `vTiles5` $00 and $08 because $180 and $188 have
+## wrapped. Subtracting the sheet's own start as a byte undoes both.
+const SUICUNE_VRAM_FIRST_TILE: int = 0x80
+
+## `InitializeBackground`: thirty 8x16 objects as five rows of six. Its
+## `.InitColumn` keeps `d` for the whole run and walks `b` by eight, so what it
+## calls a column is a row of sprites across; `d` rises by $10, one object's
+## height, between them. The tile number steps by two throughout.
+const CRYSTAL_ROWS: int = 5
+const CRYSTAL_COLUMNS: int = 6
+const CRYSTAL_ROW_STEP: int = 0x10
+const CRYSTAL_FIRST_X: int = 0x40
+const CRYSTAL_X_STEP: int = 8
+
+## `depixel 12, 11`, the bird's own struct coordinate. `_InitSpriteAnimStruct`
+## takes x in e and y in d, and `ldpixel` loads the first operand into the high
+## byte, so the pair reads (y, x) however the macro's own comment names them.
+const BIRD_AT := Vector2i(11 * Gen2Tiles.TILE_WIDTH, 12 * Gen2Tiles.TILE_HEIGHT)
+## `AnimSeq_GSIntroHoOhLugia`: Gold counts its sine input up and scales by two,
+## Silver counts down and scales by eight, and the answer is the y offset.
+const BIRD_SINE_GOLD: int = 2
+const BIRD_SINE_SILVER: int = 8
+
+## `.Frameset_GSIntroHoOhLugia`, as [code](oam set, frames)[/code] pairs in each
+## profile's own order. `oamframe X, n` lasts n + 1 frames and `oamrestart`
+## takes the sequence back to the top, so both loop rather than settling.
+const BIRD_FRAMESET_GOLD: Array[Vector2i] = [
+	Vector2i(0, 11), Vector2i(1, 10), Vector2i(2, 11),
+	Vector2i(3, 11), Vector2i(2, 10), Vector2i(4, 11),
+]
+const BIRD_FRAMESET_SILVER: Array[Vector2i] = [
+	Vector2i(1, 4), Vector2i(0, 8), Vector2i(1, 8), Vector2i(2, 8),
+	Vector2i(2, 8), Vector2i(3, 8), Vector2i(3, 8), Vector2i(2, 8),
+	Vector2i(1, 4),
+]
+
+## `UpdateTitleTrailSprite`, which spawns a trail behind the bird on every
+## fourth frame of the timer. Gold picks the spawn from `.TitleTrailCoords` by
+## the bird's own frame and the timer's bit 2, and a row of zeroes means that
+## frame drops no trail; Silver spawns from one fixed place.
+const TRAIL_SPAWN_MASK: int = 0b11
+const TRAIL_SPAWN_ALTERNATE: int = 0b100
+## `dbpixel x, y, 4, 0` per entry, as (x, y) pixel pairs and (-1, -1) for the
+## `trail_coords 0, 0` rows the routine returns on.
+const TRAIL_COORDS_GOLD: Array[Array] = [
+	[Vector2i(92, 80), Vector2i(-1, -1)],
+	[Vector2i(92, 104), Vector2i(92, 88)],
+	[Vector2i(92, 104), Vector2i(92, 120)],
+	[Vector2i(92, 136), Vector2i(92, 120)],
+	[Vector2i(-1, -1), Vector2i(92, 120)],
+	[Vector2i(-1, -1), Vector2i(92, 88)],
+]
+## `depixel 15, 11, 4, 0`.
+const TRAIL_AT_SILVER := Vector2i(88, 124)
+## `AnimSeq_GSTitleTrail`: four pixels right and one down a frame, gone once its
+## x reaches $a4, with Gold riding a sine of its own three steps at a time.
+const TRAIL_X_STEP: int = 4
+const TRAIL_Y_STEP: int = 1
+const TRAIL_X_END: int = 0xA4
+const TRAIL_SINE_STEP: int = 3
+const TRAIL_SINE_AMPLITUDE: int = 2
+
+## `ScrollTitleScreenClouds`: forty scanlines from line $5f take one shared
+## offset that falls by one, on every eighth frame on Gold and on every frame on
+## Silver.
+const CLOUD_FIRST_LINE: int = 0x5F
+const CLOUD_LINES: int = 0x28
+const CLOUD_GOLD_MASK: int = 0b111
+
+## `NUM_SPRITE_ANIM_STRUCTS`: `_InitSpriteAnimStruct` walks ten slots and returns
+## carry rather than making an eleventh, so a burst of trails simply stops.
+const MAX_SPRITE_STRUCTS: int = 10
+
+## What [method sprites] answers with.
+const SPRITE_CRYSTAL: StringName = &"crystal"
+const SPRITE_BIRD: StringName = &"bird"
+const SPRITE_TRAIL: StringName = &"trail"
+
+var _profile: StringName = &"gold"
+var _scene: StringName = SCENE_TIMER
+var _frame: int = 0
+var _timer: int = 0
+var _scx: int = 0
+var _crystal_y: int = 0
+var _suicune_counter: int = 0
+var _bird_var: int = 0
+var _bird_frame: int = 0
+var _selected: int = -1
+var _sine: Gen2BattleAnimData = null
+## The live trail particles, each `{ at, var1 }`. `_InitSpriteAnimStruct` has ten
+## slots and refuses an eleventh, which is what caps this too.
+var _trails: Array[Dictionary] = []
+var _cloud_scroll: int = 0
+
+
+## [param sine] is `BattleAnimSineWave`, which the bird's own callback scales.
+## Gold and Silver hold still without one rather than inventing a curve.
+static func create(profile: StringName, sine: Gen2BattleAnimData = null) -> Gen2TitleScene:
+	var out := Gen2TitleScene.new()
+	out._profile = profile
+	out._sine = sine
+	out._scene = SCENE_ENTRANCE if profile == RomRegistry.CRYSTAL else SCENE_TIMER
+	out._scx = ENTRANCE_SCX if profile == RomRegistry.CRYSTAL else 0
+	out._crystal_y = CRYSTAL_START_Y & 0xFF
+	return out
+
+
+func profile() -> StringName:
+	return _profile
+
+
+func scene() -> StringName:
+	return _scene
+
+
+func frame() -> int:
+	return _frame
+
+
+func timer() -> int:
+	return _timer
+
+
+## `hSCX`, which only Crystal's entrance moves.
+func scroll_x() -> int:
+	return _scx
+
+
+## `wLYOverrides`, one signed scroll per scanline, empty when nothing is
+## overriding `hSCX`.
+##
+## Crystal's is `TitleScreenEntrance`: the logo's eighty lines take the scroll
+## with the odd ones negated, which is the interlaced pull-together, and `.done`
+## clears the pointer so nothing overrides after it. Gold and Silver's is
+## `ScrollTitleScreenClouds`, forty lines of cloud walking left for the whole
+## screen's life.
+func line_offsets() -> PackedInt32Array:
+	var out := PackedInt32Array()
+	if _profile == RomRegistry.CRYSTAL:
+		if _scene != SCENE_ENTRANCE or _scx == 0:
+			return out
+		for line: int in ENTRANCE_LINES:
+			out.append(_scx if line % 2 == 0 else -_scx)
+		return out
+	out.resize(CLOUD_FIRST_LINE + CLOUD_LINES)
+	out.fill(0)
+	for index: int in CLOUD_LINES:
+		out[CLOUD_FIRST_LINE + index] = _cloud_scroll
+	return out
+
+
+## Whether the screen has answered. The caller reads [method selected_option]
+## and moves on: a timer that ran out answers nothing and is the intro movie's
+## cue instead.
+func finished() -> bool:
+	return _scene == SCENE_END
+
+
+## `wTitleScreenSelectedOption`, or -1 before the screen has answered.
+func selected_option() -> int:
+	return _selected
+
+
+## One source frame. [param held] is the buttons down this frame, as
+## [Gen2Button] values, since `GetJoypad`'s `hJoyDown` is what every branch here
+## reads rather than a press.
+func advance_frame(held: Array = []) -> void:
+	if _scene == SCENE_END:
+		return
+	_frame += 1
+	_advance_animation()
+	match _scene:
+		SCENE_ENTRANCE:
+			_advance_entrance()
+		SCENE_TIMER:
+			# `TitleScreenTimer` spends a frame doing nothing but arming itself.
+			_timer = TIMER_GOLD if _profile == RomRegistry.GOLD else TIMER_DEFAULT
+			_scene = SCENE_MAIN
+		SCENE_MAIN:
+			_advance_main(held)
+
+
+## `SuicuneFrameIterator` and `AnimSeq_GSIntroHoOhLugia`, both of which run on
+## every frame of every scene rather than inside one.
+func _advance_animation() -> void:
+	if _profile == RomRegistry.CRYSTAL:
+		_suicune_counter = (_suicune_counter + 1) & 0xFF
+		return
+	# The struct's own VAR1, counted the way each profile counts it. A byte, so
+	# Silver's countdown wraps rather than going negative.
+	_bird_var = (_bird_var + (1 if _profile == RomRegistry.GOLD else -1)) & 0xFF
+	_bird_frame += 1
+	_advance_clouds()
+	_advance_trails()
+
+
+## `ScrollTitleScreenClouds`, whose `dec a` walks one shared offset off the left.
+func _advance_clouds() -> void:
+	if _profile == RomRegistry.GOLD and (_frame & CLOUD_GOLD_MASK) != 0:
+		return
+	_cloud_scroll = (_cloud_scroll - 1) & 0xFF
+
+
+## `AnimSeq_GSTitleTrail` over every live particle, then
+## `UpdateTitleTrailSprite`'s own spawn. The move runs first because
+## `PlaySpriteAnimations` does, and the spawn is the call behind it.
+func _advance_trails() -> void:
+	var alive: Array[Dictionary] = []
+	for trail: Dictionary in _trails:
+		var at: Vector2i = trail["at"]
+		if at.x >= TRAIL_X_END:
+			continue
+		at.x += TRAIL_X_STEP
+		at.y = (at.y + TRAIL_Y_STEP) & 0xFF
+		trail["at"] = at
+		trail["var1"] = (int(trail["var1"]) + TRAIL_SINE_STEP) & 0xFF
+		alive.append(trail)
+	_trails = alive
+	if (_timer & TRAIL_SPAWN_MASK) != 0 or _trails.size() >= MAX_SPRITE_STRUCTS:
+		return
+	var at: Vector2i = TRAIL_AT_SILVER
+	if _profile == RomRegistry.GOLD:
+		var row: Array = TRAIL_COORDS_GOLD[_bird_entry()]
+		at = row[1 if (_timer & TRAIL_SPAWN_ALTERNATE) != 0 else 0]
+		if at.x < 0:
+			return
+	_trails.append({"at": at, "var1": 0})
+
+
+## `TitleScreenEntrance`. Its `.done` is what starts the music and drops the
+## window, and this is the frame the crystal stops falling on as well.
+func _advance_entrance() -> void:
+	if _scx == 0:
+		_scene = SCENE_TIMER
+		return
+	_scx = maxi(_scx - ENTRANCE_SCX_STEP, 0)
+	if _crystal_y != CRYSTAL_END_Y:
+		_crystal_y = (_crystal_y + CRYSTAL_STEP) & 0xFF
+
+
+## `TitleScreenMain`: the timer down a frame, then the three chords. The button
+## checks run before the timer is looked at again, so the last frame of the
+## count can still be answered.
+func _advance_main(held: Array) -> void:
+	if _timer <= 0:
+		# `.end` into `TitleScreenEnd`, which fades the music out and then answers
+		# RESTART: a screen nobody pressed runs the opening again.
+		_answer(OPTION_RESTART)
+		return
+	_timer -= 1
+	if _chord(held, [Gen2Button.UP, Gen2Button.B, Gen2Button.SELECT]):
+		_answer(OPTION_DELETE_SAVE_DATA)
+		return
+	if _chord(held, [Gen2Button.DOWN, Gen2Button.B, Gen2Button.SELECT]):
+		_answer(OPTION_RESET_CLOCK)
+		return
+	if held.has(Gen2Button.START) or held.has(Gen2Button.A):
+		_answer(OPTION_MAIN_MENU)
+
+
+func _answer(option: int) -> void:
+	_selected = option
+	_scene = SCENE_END
+
+
+static func _chord(held: Array, buttons: Array) -> bool:
+	for button: int in buttons:
+		if not held.has(button):
+			return false
+	return true
+
+
+## `LoadSuicuneFrame`'s own base for this frame, as a tile in the imported
+## 256-tile strip. -1 on a profile with no Suicune.
+func suicune_base() -> int:
+	if _profile != RomRegistry.CRYSTAL:
+		return -1
+	var base: int = SUICUNE_FRAMES[(_suicune_counter >> 3) & 0x03]
+	return (base - SUICUNE_VRAM_FIRST_TILE) & 0xFF
+
+
+## Where `LoadSuicuneFrame` writes, and how much: six rows of eight tiles read
+## straight out of the strip, sixteen apart because the sheet is 16 wide.
+func suicune_tiles() -> Array[Vector3i]:
+	var out: Array[Vector3i] = []
+	var base: int = suicune_base()
+	if base < 0:
+		return out
+	for row: int in SUICUNE_ROWS:
+		for column: int in SUICUNE_COLUMNS:
+			out.append(Vector3i(
+				SUICUNE_AT.x + column, SUICUNE_AT.y + row,
+				base + row * SUICUNE_COLUMNS + column
+			))
+	return out
+
+
+## The screen's objects for this frame, as
+## [code]{ kind, at, tile, palette }[/code] in shadow-OAM coordinates. Crystal's
+## thirty crystal parts, or Gold and Silver's bird and the trail behind it.
+func sprites() -> Array[Dictionary]:
+	if _profile == RomRegistry.CRYSTAL:
+		return _crystal_sprites()
+	return _bird_sprites()
+
+
+## `InitializeBackground` and `AnimateTitleCrystal` together: the column of
+## 8x16 objects as it stands this frame.
+func _crystal_sprites() -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	var tile: int = 0
+	for row: int in CRYSTAL_ROWS:
+		var y: int = (_crystal_y + row * CRYSTAL_ROW_STEP) & 0xFF
+		var x: int = CRYSTAL_FIRST_X
+		for _column: int in CRYSTAL_COLUMNS:
+			# `0 | OAM_PRIO`: the crystal sits behind the logo and shows only
+			# where the background is drawing its own colour 0.
+			out.append({
+				"kind": SPRITE_CRYSTAL, "at": Vector2i(x, y), "tile": tile,
+				"palette": 0, "behind": true,
+			})
+			x = (x + CRYSTAL_X_STEP) & 0xFF
+			tile += 2
+	return out
+
+
+## The bird's own frameset and the trail sprite under it. The y offset is
+## `AnimSeqs_Sine` over `BattleAnimSineWave`, which is the same table every
+## battle animation reads.
+func _bird_sprites() -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	# The trails were spawned before the bird and so hold the lower struct slots,
+	# which is what puts them behind it.
+	for trail: Dictionary in _trails:
+		var trail_at: Vector2i = trail["at"]
+		var lift: int = 0
+		if _profile == RomRegistry.GOLD and _sine != null:
+			lift = Gen2BattleAnimFunctions.sine_of(
+				_sine, int(trail["var1"]), TRAIL_SINE_AMPLITUDE
+			)
+		out.append({
+			"kind": SPRITE_TRAIL,
+			"at": Vector2i(trail_at.x, (trail_at.y + lift) & 0xFF),
+			"tile": 0, "palette": 1,
+		})
+
+	var amplitude: int = BIRD_SINE_GOLD if _profile == RomRegistry.GOLD else BIRD_SINE_SILVER
+	var offset: int = 0
+	if _sine != null:
+		offset = Gen2BattleAnimFunctions.sine_of(_sine, _bird_var, amplitude)
+	# `UpdateAnimFrame` adds the offset to the coordinate as a byte, so a sprite
+	# pushed past the screen wraps rather than clamping.
+	out.append({
+		"kind": SPRITE_BIRD,
+		"at": Vector2i(BIRD_AT.x, (BIRD_AT.y + offset) & 0xFF),
+		"tile": bird_frame(), "palette": 0,
+	})
+	return out
+
+
+## Which of `.Frameset_GSIntroHoOhLugia`'s OAM sets is up. -1 on Crystal.
+func bird_frame() -> int:
+	if _profile == RomRegistry.CRYSTAL:
+		return -1
+	return int(_bird_frameset()[_bird_entry()].x)
+
+
+## `SPRITEANIMSTRUCT_FRAME`, which is the entry of the frameset rather than the
+## OAM set it names: Gold's list reaches set 2 twice, and `.TitleTrailCoords` is
+## indexed by the entry, not by the picture.
+func _bird_entry() -> int:
+	var frameset: Array[Vector2i] = _bird_frameset()
+	var total: int = 0
+	for entry: Vector2i in frameset:
+		total += entry.y
+	if total <= 0:
+		return 0
+	var at: int = _bird_frame % total
+	for index: int in frameset.size():
+		if at < frameset[index].y:
+			return index
+		at -= frameset[index].y
+	return 0
+
+
+func _bird_frameset() -> Array[Vector2i]:
+	if _profile == RomRegistry.GOLD:
+		return BIRD_FRAMESET_GOLD
+	return BIRD_FRAMESET_SILVER

--- a/game/world/title_scene.gd.uid
+++ b/game/world/title_scene.gd.uid
@@ -1,0 +1,1 @@
+uid://ds8pl3624uoib

--- a/tests/unit/test_boot_cinema.gd
+++ b/tests/unit/test_boot_cinema.gd
@@ -138,3 +138,65 @@ func test_a_skipped_copyright_starts_on_the_next_phase_the_host_names() -> void:
 	assert_true(boot.drain_events().any(func(event: Dictionary) -> bool:
 		return event["type"] == &"open_title"
 	))
+
+
+## `RunTitleScreen` runs the screen rather than holding the phase: a held START
+## answers it, and the answer is what reaches the host.
+func test_the_title_phase_runs_its_own_screen_and_answers_the_host() -> void:
+	var boot := Boot.new()
+	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	assert_eq(boot.phase(), Boot.PHASE_TITLE)
+	assert_not_null(boot.title())
+
+	boot.drain_events()
+	for _frame: int in 20:
+		boot.advance_frame()
+	assert_eq(boot.phase(), Boot.PHASE_TITLE, "and it waits for a button")
+
+	var answered: Array[Dictionary] = boot.advance_frame([Gen2Button.START])
+	assert_true(answered.any(func(event: Dictionary) -> bool:
+		return event["type"] == &"title_menu"
+	))
+	assert_true(boot.select_title(&"new_game"))
+	assert_eq(boot.phase(), Boot.PHASE_NEW_GAME)
+
+
+## `TitleScreenEnd` jumps back to `IntroSequence`, so a screen nobody pressed
+## starts the whole opening again rather than standing still.
+func test_a_title_screen_nobody_presses_restarts_the_opening() -> void:
+	var boot := Boot.new()
+	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	var restarted: bool = false
+	for _frame: int in Gen2TitleScene.TIMER_GOLD + 4:
+		for event: Dictionary in boot.advance_frame():
+			if event["type"] == &"restart_opening":
+				restarted = true
+		if restarted:
+			break
+	assert_true(restarted)
+	## The order starts again from the top, which with only this phase drawable
+	## is this phase, on a screen that has not been answered.
+	assert_eq(boot.phase(), Boot.PHASE_TITLE)
+	assert_false(boot.title().finished())
+
+
+## The two chords answer without leaving the screen, because what they open is
+## the host's business and `Init` comes back to the title afterwards.
+func test_a_chord_is_reported_and_the_screen_stays_up() -> void:
+	var boot := Boot.new()
+	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	boot.drain_events()
+	for _frame: int in 4:
+		boot.advance_frame()
+	var chord: Array[Dictionary] = boot.advance_frame([
+		Gen2Button.UP, Gen2Button.B, Gen2Button.SELECT,
+	])
+	var reported: Array = chord.filter(func(event: Dictionary) -> bool:
+		return event["type"] == &"title_chord"
+	)
+	assert_eq(reported.size(), 1)
+	assert_eq(reported[0]["kind"], &"delete_save_data")
+	assert_eq(boot.phase(), Boot.PHASE_TITLE)
+	assert_false(boot.title().finished())
+	boot.advance_frame()
+	assert_eq(boot.title().timer(), Gen2TitleScene.TIMER_GOLD, "on a fresh timer")

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -23,7 +23,7 @@ func test_gold_and_silver_share_their_common_layout() -> void:
 	for key: String in gold:
 		if key in [
 			"item_attributes", "item_status_actions", "item_healing_hp",
-			"overworld_icons", "copyright", "game_freak_presents",
+			"overworld_icons", "copyright", "game_freak_presents", "title",
 		]:
 			continue
 		assert_eq(gold[key], silver[key], "Gold/Silver layout differs at %s" % key)
@@ -37,6 +37,23 @@ func test_gold_and_silver_share_their_common_layout() -> void:
 	assert_ne(gold_copyright["string"], silver_copyright["string"])
 	# The splash graphics are the same pictures 440 bytes apart in the same bank,
 	# and the object palette they are drawn through does not move at all.
+	# The title screen's two halves each move on their own: the logo's bottom and
+	# the trail sit at the same address on both, while the logo's top, the
+	# tilemap and the bird move with the compressed run in front of them. Both
+	# palette runs stay put, since neither is inside a graphic.
+	var gold_title: Dictionary = gold["title"]
+	var silver_title: Dictionary = silver["title"]
+	for shared: String in ["logo_bottom", "trail", "bg_palette", "ob_palette"]:
+		assert_eq(gold_title[shared], silver_title[shared], shared)
+	for moved: String in ["logo_top", "tilemap", "bird", "trail_tiles", "bird_tiles"]:
+		assert_ne(gold_title[moved], silver_title[moved], moved)
+	# `TitleScreen` copies eight tiles of trail whatever the run holds, so
+	# Silver's bird starts where its own four end.
+	assert_eq(
+		int(silver_title["bird"]) - int(silver_title["trail"]),
+		int(silver_title["trail_tiles"]) * 16
+	)
+
 	var gold_presents: Dictionary = gold["game_freak_presents"]
 	var silver_presents: Dictionary = silver["game_freak_presents"]
 	assert_ne(gold_presents["gfx"], silver_presents["gfx"])

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -1,0 +1,215 @@
+extends GutTest
+
+## `TitleScreenScene` (`engine/menus/intro_menu.asm`) and the two animations
+## that run under it, frame by frame.
+##
+## Scene-free: [Gen2TitleScene] owns the frames and answers with the source's
+## own `wTitleScreenSelectedOption`, so every case here is a count or a chord
+## rather than a picture.
+
+
+func _scene(profile: StringName) -> Gen2TitleScene:
+	return Gen2TitleScene.create(profile)
+
+
+func _spend(scene: Gen2TitleScene, frames: int, held: Array = []) -> void:
+	for _frame: int in frames:
+		scene.advance_frame(held)
+
+
+## Crystal opens on `TitleScreenEntrance` and Gold and Silver's `.scenes` table
+## has no entrance in it at all.
+func test_only_crystal_opens_on_an_entrance() -> void:
+	assert_eq(_scene(RomRegistry.CRYSTAL).scene(), Gen2TitleScene.SCENE_ENTRANCE)
+	assert_eq(_scene(RomRegistry.GOLD).scene(), Gen2TitleScene.SCENE_TIMER)
+	assert_eq(_scene(RomRegistry.SILVER).scene(), Gen2TitleScene.SCENE_TIMER)
+
+
+## `hSCX` starts at 112 and comes off four a frame, so the entrance is
+## twenty-eight frames and the crystal's own fall is the same twenty-eight.
+func test_the_entrance_walks_the_scroll_in_over_twenty_eight_frames() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	assert_eq(scene.scroll_x(), Gen2TitleScene.ENTRANCE_SCX)
+
+	_spend(scene, 14)
+	assert_eq(scene.scroll_x(), Gen2TitleScene.ENTRANCE_SCX / 2)
+	assert_eq(scene.scene(), Gen2TitleScene.SCENE_ENTRANCE)
+
+	_spend(scene, 14)
+	assert_eq(scene.scroll_x(), 0)
+	## The frame that lands on zero is still the entrance; the next one is what
+	## `.done` runs on.
+	_spend(scene, 1)
+	assert_eq(scene.scene(), Gen2TitleScene.SCENE_TIMER)
+
+
+## `wLYOverrides` over the logo's eighty lines, the odd ones negated, which is
+## what pulls the two halves together.
+func test_the_entrance_is_interlaced() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	_spend(scene, 4)
+	var lines: PackedInt32Array = scene.line_offsets()
+	assert_eq(lines.size(), Gen2TitleScene.ENTRANCE_LINES)
+	assert_eq(lines[0], scene.scroll_x())
+	assert_eq(lines[1], -scene.scroll_x())
+
+	_spend(scene, 40)
+	assert_eq(scene.line_offsets().size(), 0, "and nothing overrides after it")
+
+
+## `TitleScreenTimer`'s own `ld de`, which is the one value Gold does not share.
+func test_each_profile_arms_its_own_timer() -> void:
+	for row: Array in [
+		[RomRegistry.GOLD, Gen2TitleScene.TIMER_GOLD],
+		[RomRegistry.SILVER, Gen2TitleScene.TIMER_DEFAULT],
+	]:
+		var scene: Gen2TitleScene = _scene(row[0])
+		_spend(scene, 1)
+		assert_eq(scene.scene(), Gen2TitleScene.SCENE_MAIN)
+		assert_eq(scene.timer(), int(row[1]), String(row[0]))
+
+
+## `PAD_START | PAD_A`, and nothing else on its own.
+func test_start_or_a_answers_the_main_menu() -> void:
+	for button: int in [Gen2Button.START, Gen2Button.A]:
+		var scene: Gen2TitleScene = _scene(RomRegistry.GOLD)
+		_spend(scene, 4)
+		assert_false(scene.finished())
+		scene.advance_frame([button])
+		assert_true(scene.finished())
+		assert_eq(scene.selected_option(), Gen2TitleScene.OPTION_MAIN_MENU)
+
+	var ignored: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	_spend(ignored, 8, [Gen2Button.LEFT])
+	assert_false(ignored.finished())
+
+
+## The two chords, which are held states rather than presses: three buttons at
+## once, and a partial one answers nothing.
+func test_the_two_chords_are_answered_whole() -> void:
+	var deleting: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	_spend(deleting, 2)
+	deleting.advance_frame([Gen2Button.UP, Gen2Button.B, Gen2Button.SELECT])
+	assert_eq(deleting.selected_option(), Gen2TitleScene.OPTION_DELETE_SAVE_DATA)
+
+	var clock: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	_spend(clock, 2)
+	clock.advance_frame([Gen2Button.DOWN, Gen2Button.B, Gen2Button.SELECT])
+	assert_eq(clock.selected_option(), Gen2TitleScene.OPTION_RESET_CLOCK)
+
+	var partial: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	_spend(partial, 4, [Gen2Button.UP, Gen2Button.B])
+	assert_false(partial.finished(), "two of the three is not the chord")
+
+
+## `TitleScreenEnd` answers RESTART, which `.dw` sends back to `IntroSequence`.
+func test_the_timer_running_out_answers_restart() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.SILVER)
+	_spend(scene, Gen2TitleScene.TIMER_DEFAULT + 1)
+	assert_false(scene.finished(), "the last frame of the count is still answerable")
+	_spend(scene, 1)
+	assert_true(scene.finished())
+	assert_eq(scene.selected_option(), Gen2TitleScene.OPTION_RESTART)
+
+
+## `SuicuneFrameIterator` moves on every eighth frame and walks four bases, the
+## last two of which are a sheet on from the first two.
+func test_the_suicune_frame_changes_every_eighth_frame() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	var seen: Array[int] = []
+	for step: int in 4:
+		seen.append(scene.suicune_base())
+		_spend(scene, 8)
+	## `.Frames`' four bases are $80, $88, $00 and $08, which are tiles 0, 8, 128
+	## and 136 of the strip: the sheet starts at VRAM tile $80 and the last two
+	## numbers have wrapped a byte.
+	assert_eq(seen, [0x00, 0x08, 0x80, 0x88] as Array[int])
+	assert_eq(scene.suicune_base(), 0x00, "and then it comes round again")
+	assert_eq(_scene(RomRegistry.GOLD).suicune_base(), -1, "Gold has no Suicune")
+
+
+## `LoadSuicuneFrame` writes six rows of eight from the base it is handed.
+func test_the_suicune_strip_is_six_rows_of_eight() -> void:
+	var placed: Array[Vector3i] = _scene(RomRegistry.CRYSTAL).suicune_tiles()
+	assert_eq(placed.size(), Gen2TitleScene.SUICUNE_ROWS * Gen2TitleScene.SUICUNE_COLUMNS)
+	assert_eq(placed[0], Vector3i(6, 12, 0x00))
+	assert_eq(placed[8], Vector3i(6, 13, 0x08), "the next row is eight tiles on")
+
+
+## `InitializeBackground`: thirty 8x16 objects, five rows of six, all behind the
+## background's own colours.
+func test_the_crystal_is_thirty_objects_behind_the_logo() -> void:
+	var sprites: Array[Dictionary] = _scene(RomRegistry.CRYSTAL).sprites()
+	assert_eq(sprites.size(), 30)
+	assert_true(bool(sprites[0]["behind"]))
+	assert_eq(sprites[0]["at"], Vector2i(0x40, Gen2TitleScene.CRYSTAL_START_Y & 0xFF))
+	assert_eq(sprites[1]["at"].x, 0x48, "the next is eight across")
+	assert_eq(sprites[6]["at"].y, (Gen2TitleScene.CRYSTAL_START_Y + 0x10) & 0xFF)
+	assert_eq(int(sprites[1]["tile"]), 2, "and two tiles on, because they are 8x16")
+
+
+## `AnimateTitleCrystal` stops at `6 + 2 * TILE_WIDTH` rather than running on.
+func test_the_crystal_falls_to_its_own_stop() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	_spend(scene, 28)
+	assert_eq(
+		(scene.sprites()[0]["at"] as Vector2i).y, Gen2TitleScene.CRYSTAL_END_Y
+	)
+	_spend(scene, 60)
+	assert_eq(
+		(scene.sprites()[0]["at"] as Vector2i).y, Gen2TitleScene.CRYSTAL_END_Y,
+		"and stays there"
+	)
+
+
+## `.Frameset_GSIntroHoOhLugia`, whose `oamframe X, n` lasts n + 1 frames and
+## whose `oamrestart` takes it back to the top.
+func test_the_birds_frameset_loops() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	assert_eq(scene.bird_frame(), 0)
+	_spend(scene, 11)
+	assert_eq(scene.bird_frame(), 1, "the first entry lasts its own eleven frames")
+	var total: int = 0
+	for entry: Vector2i in Gen2TitleScene.BIRD_FRAMESET_GOLD:
+		total += entry.y
+	_spend(scene, total - 11)
+	assert_eq(scene.bird_frame(), 0, "and the sequence restarts")
+
+
+## `UpdateTitleTrailSprite` spawns on every fourth frame of the timer, and
+## `AnimSeq_GSTitleTrail` walks each particle right until it is gone.
+func test_trails_are_spawned_behind_the_bird_and_fly_off() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	_spend(scene, 40)
+	var trails: Array = scene.sprites().filter(
+		func(sprite: Dictionary) -> bool:
+			return StringName(sprite["kind"]) == Gen2TitleScene.SPRITE_TRAIL
+	)
+	assert_gt(trails.size(), 0, "the screen is dropping trails")
+	assert_lte(trails.size(), Gen2TitleScene.MAX_SPRITE_STRUCTS)
+	## `cp $a4 / jr nc, .delete` runs before the move, so the frame a particle
+	## lands on the edge is still drawn and the next one takes it away.
+	for trail: Dictionary in trails:
+		assert_lte((trail["at"] as Vector2i).x, Gen2TitleScene.TRAIL_X_END)
+
+	## Crystal has no bird and so no trail at all.
+	var crystal: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	_spend(crystal, 40)
+	for sprite: Dictionary in crystal.sprites():
+		assert_eq(StringName(sprite["kind"]), Gen2TitleScene.SPRITE_CRYSTAL)
+
+
+## `ScrollTitleScreenClouds`, which Gold runs on every eighth frame and Silver
+## on every one.
+func test_the_clouds_scroll_at_each_profiles_own_rate() -> void:
+	## `wLYOverrides` is bytes and `dec a` wraps in one, which is a left scroll
+	## because the map it moves is 256 wide.
+	var gold: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	_spend(gold, 8)
+	assert_eq(gold.line_offsets()[Gen2TitleScene.CLOUD_FIRST_LINE], 0xFF)
+
+	var silver: Gen2TitleScene = _scene(RomRegistry.SILVER)
+	_spend(silver, 8)
+	assert_eq(silver.line_offsets()[Gen2TitleScene.CLOUD_FIRST_LINE], 0xF8)
+	assert_eq(silver.line_offsets()[Gen2TitleScene.CLOUD_FIRST_LINE - 1], 0,
+		"and only the band it names moves")

--- a/tests/unit/test_title_scene.gd.uid
+++ b/tests/unit/test_title_scene.gd.uid
@@ -1,0 +1,1 @@
+uid://ckrnc0kv6leyi

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -111,11 +111,15 @@ func _open() -> void:
 	_screen.set("_battle", battle)
 	if _stage in ["use_next", "replace"]:
 		## Through the screen's own quarter, so the HUD in the picture is the HUD
-		## the faint left rather than the one the intro drew.
+		## the faint left rather than the one the intro drew, and then the
+		## engine's own FAINTED event, which is what runs `MonFaintedAnimation`.
 		for _quarter: int in 8:
 			if battle.player.is_fainted():
 				break
 			_screen.hurt_player()
+		_screen.set("_pending", [
+			{"type": Gen2Battle.FAINTED, "side": Gen2Battle.PLAYER},
+		])
 	else:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.switch_to(1)

--- a/tools/preview_title.gd
+++ b/tools/preview_title.gd
@@ -1,0 +1,60 @@
+extends SceneTree
+
+## Captures the title screen against a real imported cache, one source frame at
+## a time.
+##
+##   Godot --headless --path . -s res://tools/preview_title.gd -- crystal /tmp/t.png [frame]
+##
+## [frame] is how many source frames to spend before the shot, so Crystal's
+## twenty-eight-frame entrance, its Suicune cycle and Gold's bird can each be
+## looked at where they actually are. Several frames separated by `;` write one
+## file each, numbered.
+##
+## Headless: the page is drawn into an [Image] rather than through a viewport, so
+## no window and no settle are needed.
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_title.gd -- <game> <output.png> [frame;frame;...]")
+		quit(1)
+		return
+
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var page: Gen2TitlePage = Gen2TitlePage.from_data(data)
+	if page == null:
+		push_error("The %s cache holds no title screen art." % args[0])
+		quit(1)
+		return
+
+	var frames: Array = []
+	for step: String in (args[2] if args.size() > 2 else "0").split(";", false):
+		frames.append(maxi(int(step.strip_edges()), 0))
+	frames.sort()
+
+	var scene: Gen2TitleScene = Gen2TitleScene.create(data.id, Gen2BattleAnimData.from_game_data(data))
+	var spent: int = 0
+	var written: int = 0
+	for wanted: int in frames:
+		while spent < wanted:
+			scene.advance_frame()
+			spent += 1
+		var path: String = args[1]
+		if frames.size() > 1:
+			path = "%s-%d.%s" % [args[1].get_basename(), wanted, args[1].get_extension()]
+		var error: Error = page.draw(scene).save_png(path)
+		if error != OK:
+			push_error("Could not write %s (error %d)" % [path, error])
+			quit(1)
+			return
+		print("Wrote %s, frame %d, scene %s, scroll %d, timer %d" % [
+			path, wanted, scene.scene(), scene.scroll_x(), scene.timer(),
+		])
+		written += 1
+	quit(0 if written > 0 else 1)

--- a/tools/preview_title.gd.uid
+++ b/tools/preview_title.gd.uid
@@ -1,0 +1,1 @@
+uid://de71xi8bs0rj8


### PR DESCRIPTION
The last phase `Gen2BootCinema` had and nothing drew. Two different screens
under one name, both live: Crystal's Suicune, logo and crystal, and Gold and
Silver's logo over a tilemap with a bird flying across it.

## Import

Every address was located the way the GameFreak Presents art was: the pinned
PNG encoded as cartridge 2bpp and matched, or, for an LZ run, every offset in
the bank decompressed and the one reproducing the PNG exactly kept. Each hits
once per dump.

Three traps worth knowing, since nothing about them is guessable:

- rgbgfx maps a grayscale PNG by shade rather than by rank, so `$FF` is index 0
  whatever subset of the four a picture uses. Ranking instead finds Gold's
  three-shade trail and misses Silver's two-shade one.
- `--interleave` is pret's own `tools/gfx.c` pass over the finished 2bpp, not an
  rgbgfx flag.
- `logo_bottom` is `--trim-whitespace` and Crystal's `logo` is `--trim-end 4`;
  without either the run is the wrong length and matches nothing.

`verify_title` identifies each by content rather than by address. Crystal's
three runs and its palettes are one contiguous section, so each pins the next
and a run decompressing to the wrong tile count is refused; the crystal opens on
a blank corner and all four of `.Frames`' Suicune bases have ink under them.
Gold and Silver's logo halves pin their tilemap, the trimmed half's last tile is
drawn on, the trail's first four tiles are inked and Gold's own last four are
blank, and the bird starts exactly where the trail's tiles stop.

Cache format 45; all three re-import.

## The screen

`Gen2TitleScene` is `TitleScreenScene` whole: `TitleScreenEntrance`'s
twenty-eight-frame interlaced scroll and falling crystal, `SuicuneFrameIterator`,
both birds' framesets and their sine, the particles `UpdateTitleTrailSprite`
spawns, `ScrollTitleScreenClouds`, each profile's own timer, and the source's
`wTitleScreenSelectedOption`, including both three-button chords and the
timeout that restarts the whole opening.

`Gen2TitlePage` builds the BG map at its own 256 pixels and samples it through
`hSCX` and `wLYOverrides`, because that map wraps: a cloud band walking left has
to bring the map's right-hand columns back round rather than leave a gap.

## Two joins that were missing

- Nothing answered the coordinator's `open_new_game`, so a real cache reached
  the title screen and the boot stopped there. The synthetic test fixture has no
  title art, so the phase never ran in the suite and this only showed up driving
  the actual opening.
- `Gen2BootCinema.start` empties the event queue, so the `restart_opening` a
  timed-out screen emits was wiped before the host could read it and the title
  graphic stayed up through the copyright's blank prelude.

## Also here

`MonFaintedAnimation`, which nothing modelled: a fainted Pokemon's picture stood
through its own message and through the replacement question behind it, on both
sides. Seven steps of two frames now sink the block `FaintYourPokemon` and
`FaintEnemyPokemon` each name, and the line waits on it the way a drained bar's
already does.

## Checks

- GUT 2,717 over 139 scripts, green.
- 36 of 37 `validate_*.gd`; `validate_clickable` needs a display.
- `replay_world.gd`: 27 routes, 0 failures.
- Story walk reaches Red on all three: 294 steps on Crystal, 291 on Gold and
  Silver, 16 badges each.
- The opening driven end to end on all three real caches, both with a press and
  left alone.
- `tools/preview_title.gd` photographs any source frame of it.

## Known limits, recorded rather than papered over

- Not yet diffed against a running cartridge. Shadow OAM per frame is the
  comparable artefact and `Gen2TitleScene.sprites()` already produces it.
- Silver's trail flies flat: `AnimSeq_GSTitleTrail`'s Silver branch scales its
  sine by `wIntroSceneTimer`, which the title screen never writes. Gold's reads
  its own VAR1 and is reproduced.