### PR TITLE
world: the credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > a Union Cave Geodude taught HM04 Strength for Cianwood Gym's boulders, the
 > Lake of Rage, both Rocket hideouts, Blackthorn's boulder puzzle, and the
 > Rising Badge by Crystal's Dragon Shrine quiz or Gold and Silver's Dragon's Den
-> ball), then Kanto, all sixteen badges and Red.
+> ball), then Kanto, all sixteen badges and Red. Either ending closes the way the
+> cartridge's does: the Hall of Fame's induction panels with Prof Oak's rating
+> printed into the last of them, and then the credits.
 > Missing: full story state, the dex, the remaining special-call branches and
 > story-driven permanent contacts.
 
@@ -120,6 +122,7 @@ to check without writing.
 | Title screen | Crystal's Suicune strip, logo and crystal with its sixteen palettes; Gold and Silver's two logo halves, their `$FF`-terminated tilemap, the trail and the Ho-Oh or Lugia behind it, and both palette runs |
 | Region map | The Pokegear's three graphics sheets, the Fast Ship's icon and the dex's nest marker, both region tilemaps, the per-tile palette map and its six palettes, and the ninety-six landmarks with their coordinates and names |
 | Prof Oak's PC | The nineteen `OakRatings` rows, each a caught-count threshold, the sound it plays and the rating it prints, and the four texts around them |
+| Credits | `CreditsScript`'s whole command stream, every name and heading it prints, the four scene palettes, the border strip, "The End" and the four mons the banner animates |
 | Battle HUD | HP/EXP bars, panel borders and colours |
 | Overworld | Maps, tilesets, collisions, events, scripts, movement, palettes, animation and object sprites |
 | Wild encounters | Normal/swarm grass and water, 13 fishing groups with day/night substitutions, 16-row roaming graph, map-linked rates and slots, time-of-day selection, surf variance and repel checks |
@@ -320,6 +323,7 @@ all three games unless its row says otherwise:
 | `preview_prof_oaks_pc.gd <game> [caught]` | Prof Oak's PC against a real cache: every rating band and both its ends, or the three pages `ProfOaksPCBoot` shows for one owned count |
 | `preview_town_map.gd <game> <png> [landmark] [town_map\|card\|area:<species>] [presses]` | the region map against a real cache: the Johto or Kanto map the landmark picks, `_TownMap`'s corner box, the Pokegear card's icon row or the dex's `<MON>'S NEST` screen, and the cursor after a `u,d,b` press list. `hof` in that list opens the whole Kanto window rather than the Victory Road one, `sel` and `rel` hold and release the dex area's SELECT, and `f<n>` spends n frames, which is what the nest blink is caught with |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache, ending on the player's own with Prof Oak's rating printed into it; `page` is how many panels to advance past |
+| `preview_credits.gd <game> <png> [frame;frame]` | the credits at any source frame: the banner's four mons, the scrolling border bands, each batch of names on its own scene palette, the copyright and "The End". A `CREDITS_WAIT` tick is thirteen frames, so the batches land a long way apart; a frame suffixed `b` holds B down for the skip a replay allows |
 | `preview_battle_switch.gd <game> <png> [offer\|pick\|use_next\|replace] [presses]` | the boxes a battle switches through: `OfferSwitch`'s yes/no over the field under SHIFT, the party list behind it, `AskUseNextPokemon`'s wild question, and `ForcePlayerMonChoice`'s list after a faint. `presses` is a `u,d,l,r,a,b` list driven into the menu first, which is how a refusal is photographed |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
 | `replay_world.gd [game ...] [frames]` | records `(frame, button)` from a run of the real world screen and replays it into a fresh world, over every map of the spawn group on each cartridge. The same seed and log must reach the same `Gen2WorldSnapshot` byte for byte, and must reach it whether the frames were pumped at 30 fps or at 144 |
@@ -340,6 +344,7 @@ all three games unless its row says otherwise:
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push |
 | `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, the sine table the motion callbacks scale with, the 39 graphics sheets, and every motion callback and background effect a real animation reaches |
 | `validate_town_map.gd` | the landmark tables and the one-landmark split `BATTLE TOWER` causes, both region tilemaps against `TownMapGFX`, the palette map and its two city palettes, the Johto and Kanto cursor windows either side of the Hall of Fame, all three frames composing, and every species' nests staying inside their own region and under shadow OAM's forty sprites |
+| `validate_credits.gd` | every credits string decoding into codes the screen can draw, the four scene palettes and every `Credits_LoadBorderGFX.Frames` block, and both whole scripts run frame by frame to `CREDITS_END` with nothing printed reaching either border band |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script |
 | `validate_radio_tower.gd` | Blackthorn Gym's door and its only approach, Radio Tower 2F's stairs and 3F's card-key shutter, and the switch room's eleven doors and the one chain to the warehouse |

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -57,6 +57,7 @@ var _presents_palettes: Dictionary = {}
 var _title: Dictionary = {}
 var _town_map: Dictionary = {}
 var _oak_ratings: Dictionary = {}
+var _credits: Dictionary = {}
 var _menu_text: Dictionary = {}
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
@@ -131,6 +132,8 @@ static func open_directory(path: String) -> GameData:
 	data._town_map = town_map if town_map is Dictionary else {}
 	var oak_ratings: Variant = manifest.get("oak_ratings", {})
 	data._oak_ratings = oak_ratings if oak_ratings is Dictionary else {}
+	var credits: Variant = manifest.get("credits", {})
+	data._credits = credits if credits is Dictionary else {}
 	var menu_text: Variant = manifest.get("menu_text", {})
 	data._menu_text = menu_text if menu_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
@@ -1150,6 +1153,68 @@ func oak_pc_text(name: String) -> String:
 func oak_ratings() -> Array:
 	var stored: Variant = _oak_ratings.get("ratings", [])
 	return stored if stored is Array else []
+
+
+## `CreditsScript`, terminator included. Empty on a cache imported without the
+## credits, which is the caller's cue not to open them.
+func credits_script() -> PackedByteArray:
+	var stored: Variant = _credits.get("script", [])
+	var out := PackedByteArray()
+	if not stored is Array:
+		return out
+	for command: Variant in stored as Array:
+		out.append(int(command) & 0xFF)
+	return out
+
+
+## One `CreditsStringsPointers` entry, as the tile codes `PlaceString` writes:
+## letters and `<NEXT>` for a name or a heading, `CopyrightGFX`'s own tile
+## numbers for the copyright.
+func credits_string(index: int) -> PackedByteArray:
+	var stored: Variant = _credits.get("strings", [])
+	var out := PackedByteArray()
+	if not stored is Array or index < 0 or index >= (stored as Array).size():
+		return out
+	for code: Variant in (stored as Array)[index] as Array:
+		out.append(int(code) & 0xFF)
+	return out
+
+
+## The two `CreditsScript` indices `ParseCredits` branches on: `staff` is the
+## first heading, below which every index is a name, and `copyright` the one
+## string printed from column 2. -1 on a cache without the credits.
+func credits_index(name: String) -> int:
+	return int(_credits.get(name, -1))
+
+
+## `CreditsPalettes` for one scene: three palettes on Crystal (the banner, the
+## border and the text region) and one on Gold and Silver, which gives the same
+## four colours to the first two slots.
+func credits_palette(scene: int, slot: int = 0) -> PackedColorArray:
+	var stored: Variant = _credits.get("palettes", [])
+	var per_scene: int = int(_credits.get("scene_palettes", 0))
+	var colors := PackedColorArray()
+	if not stored is Array or per_scene <= 0 or scene < 0:
+		return colors
+	var packed: Array = stored
+	var first: int = (
+		scene * per_scene + mini(slot, per_scene - 1)
+	) * RomLayout.CREDITS_PALETTE_COLORS
+	if first + RomLayout.CREDITS_PALETTE_COLORS > packed.size():
+		return colors
+	for index: int in RomLayout.CREDITS_PALETTE_COLORS:
+		colors.append(Gen2Palette.from_packed(int(packed[first + index])))
+	return colors
+
+
+## `Credits_LoadBorderGFX.Frames`: which sixteen-tile block of the mon run one
+## scene's frame draws. -1 outside the table.
+func credits_frame_block(scene: int, frame: int) -> int:
+	var stored: Variant = _credits.get("frames", [])
+	var at: int = scene * RomLayout.CREDITS_SCENE_FRAMES + frame
+	if not stored is Array or at < 0 or at >= (stored as Array).size():
+		return -1
+	return int((stored as Array)[at])
 
 
 ## `JohtoMap` or `KantoMap`: one tile number per cell of the whole screen, in

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -64,7 +64,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 47
+const FORMAT_VERSION: int = 48
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -308,6 +308,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not oak_ratings["ok"]:
 		return oak_ratings
 
+	var credits: Dictionary = verify_credits(rom, layout)
+	if not credits["ok"]:
+		return credits
+
 	var menu_text: Dictionary = verify_menu_text(rom, layout)
 	if not menu_text["ok"]:
 		return menu_text
@@ -998,6 +1002,211 @@ static func read_oak_text(rom: RomFile, layout: Dictionary, stub: int) -> String
 	if not bool(decoded.get("ok", false)):
 		return ""
 	return String(decoded["text"])
+
+
+## The credits (`engine/movie/credits.asm`), whose five runs each pin the next.
+##
+## `CreditsBorderGFX` is the only pinned graphics offset: the four mon sheets
+## follow it and `CreditsScript` follows them, so the run's own length is what
+## says the offset is right. The script's terminator then puts
+## `CreditsStringsPointers` where the layout claims it is, and the string the
+## `copyright` index names has to be the copyright screen's own, which the layout
+## pins separately in another bank. Content, not neighbours, identifies the two
+## uncompressed graphics and the palettes.
+static func verify_credits(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("credits", {})
+	if entry.is_empty():
+		return {"ok": true, "message": "No credits on this cartridge."}
+
+	var palettes: Dictionary = _verify_credits_palettes(rom, entry)
+	if not palettes["ok"]:
+		return palettes
+
+	var graphics: Dictionary = _verify_credits_gfx(rom, layout, entry)
+	if not graphics["ok"]:
+		return graphics
+
+	var script: PackedByteArray = read_credits_script(rom, layout)
+	if script.is_empty():
+		return {"ok": false, "message": "The credits script has no terminator."}
+	if int(entry["script"]) + script.size() != int(entry["strings"]):
+		return {
+			"ok": false,
+			"message": "The credits string table does not follow the script.",
+		}
+	var walked: Dictionary = _verify_credits_script(script, entry)
+	if not walked["ok"]:
+		return walked
+
+	return _verify_credits_strings(rom, layout, entry)
+
+
+## `CreditsPalettes`. Structural, plus the one colour every scene shares: each
+## opens a scene's first palette and closes it on RGB 07,07,07 in all three
+## dumps, so a run of four that does not is not this table.
+static func _verify_credits_palettes(rom: RomFile, entry: Dictionary) -> Dictionary:
+	var at: int = int(entry["palettes"])
+	var stride: int = int(entry["scene_palettes"]) * RomLayout.CREDITS_PALETTE_COLORS
+	var length: int = RomLayout.CREDITS_SCENES * stride * 2
+	if not rom.in_bounds(at, length):
+		return {"ok": false, "message": "The credits palettes are outside the cartridge."}
+	if at >= int(entry["gfx"]):
+		return {"ok": false, "message": "The credits palettes are behind the graphics."}
+	for colour: int in RomLayout.CREDITS_SCENES * stride:
+		if rom.u16le(at + colour * 2) & 0x8000:
+			return {"ok": false, "message": "A credits palette colour is not 15-bit."}
+	for scene: int in RomLayout.CREDITS_SCENES:
+		var last: int = at + (scene * stride + RomLayout.CREDITS_PALETTE_COLORS - 1) * 2
+		if rom.u16le(last) != RomLayout.CREDITS_PALETTE_LAST_COLOR:
+			return {
+				"ok": false,
+				"message": "Credits scene %d's palette does not close on RGB 07,07,07." % scene,
+			}
+	return {"ok": true, "message": "Credits palettes verified."}
+
+
+## The two uncompressed graphics, each by content. The border is a dither drawn
+## in colours 0 and 2 alone, so every low-plane byte in it is zero and its last
+## tile is colour 2 whole; "The End" uses colours 0, 1 and 3 alone, so no
+## high-plane bit in it stands without the low-plane bit under it.
+static func _verify_credits_gfx(
+	rom: RomFile, layout: Dictionary, entry: Dictionary
+) -> Dictionary:
+	var at: int = int(entry["gfx"])
+	var tiles: int = RomLayout.CREDITS_BORDER_TILES + RomLayout.credits_mon_tiles(layout)
+	if not rom.in_bounds(at, tiles * Gen2Tiles.TILE_BYTES):
+		return {"ok": false, "message": "The credits graphics are outside the cartridge."}
+	if at + tiles * Gen2Tiles.TILE_BYTES != int(entry["script"]):
+		return {"ok": false, "message": "The credits script does not follow the graphics."}
+	for row: int in RomLayout.CREDITS_BORDER_TILES * Gen2Tiles.TILE_HEIGHT:
+		if rom.u8(at + row * 2) != 0:
+			return {"ok": false, "message": "The credits border is not drawn in colour 2."}
+	var solid: int = at + (RomLayout.CREDITS_BORDER_TILES - 1) * Gen2Tiles.TILE_BYTES
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		if rom.u8(solid + row * 2 + 1) != 0xFF:
+			return {"ok": false, "message": "The credits border's last tile is not solid."}
+
+	var the_end: int = int(entry["the_end"])
+	if not rom.in_bounds(the_end, RomLayout.CREDITS_THE_END_TILES * Gen2Tiles.TILE_BYTES):
+		return {"ok": false, "message": "The End graphic is outside the cartridge."}
+	var ink: int = 0
+	for row: int in RomLayout.CREDITS_THE_END_TILES * Gen2Tiles.TILE_HEIGHT:
+		var low: int = rom.u8(the_end + row * 2)
+		var high: int = rom.u8(the_end + row * 2 + 1)
+		if high & ~low & 0xFF:
+			return {"ok": false, "message": "The End graphic uses colour 2."}
+		ink |= low
+	if ink == 0:
+		return {"ok": false, "message": "The End graphic is blank."}
+	return {"ok": true, "message": "Credits graphics verified."}
+
+
+## `ParseCredits`' own walk. A byte that is not one of the seven commands is a
+## string index, so a run that is not `CreditsScript` names one past the table
+## almost at once; the two indices the layout pins are checked against the walk
+## rather than trusted.
+static func _verify_credits_script(script: PackedByteArray, entry: Dictionary) -> Dictionary:
+	var count: int = int(entry["string_count"])
+	if script[0] != RomLayout.CREDITS_CLEAR:
+		return {"ok": false, "message": "The credits script does not open on a clear."}
+	var highest: int = -1
+	var first_string: int = -1
+	var step: int = 0
+	var terminated: bool = false
+	while step < script.size():
+		var command: int = script[step]
+		step += 1
+		if command == RomLayout.CREDITS_END:
+			terminated = true
+			break
+		if command >= RomLayout.CREDITS_THEEND:
+			if command in RomLayout.CREDITS_OPERAND_COMMANDS:
+				step += 1
+			continue
+		if command >= count:
+			return {
+				"ok": false,
+				"message": "The credits script names string %d of %d." % [command, count],
+			}
+		if first_string < 0:
+			first_string = command
+		highest = maxi(highest, command)
+		## A string is followed by the line it prints on, which is never a
+		## command byte.
+		step += 1
+	if not terminated or step != script.size():
+		return {"ok": false, "message": "The credits script's last command is cut short."}
+	if highest != count - 1:
+		return {
+			"ok": false,
+			"message": "The credits script's highest string is %d, not %d." % [
+				highest, count - 1,
+			],
+		}
+	if first_string != int(entry["staff"]):
+		return {
+			"ok": false,
+			"message": "The credits script opens on string %d, not STAFF %d." % [
+				first_string, int(entry["staff"]),
+			],
+		}
+	return {"ok": true, "message": "Credits script verified."}
+
+
+## `CreditsStringsPointers`. Every entry has to terminate inside the strings'
+## own bank, and the `copyright` one has to be the copyright screen's string:
+## `data/copyright.asm` is INCLUDEd once for each and the layout pins the two
+## addresses independently, so they check each other.
+static func _verify_credits_strings(
+	rom: RomFile, layout: Dictionary, entry: Dictionary
+) -> Dictionary:
+	var bank: int = int(entry["strings_bank"])
+	for index: int in int(entry["string_count"]):
+		var at: int = RomLayout.credits_string_offset(rom, layout, index)
+		if RomLayout.bank_of(at) != bank:
+			return {"ok": false, "message": "Credits string %d leaves bank $%02X." % [index, bank]}
+		if read_credits_string(rom, layout, index).is_empty():
+			return {"ok": false, "message": "Credits string %d has no terminator." % index}
+	var copyright: PackedByteArray = read_credits_string(
+		rom, layout, int(entry["copyright"])
+	)
+	var screen: PackedByteArray = read_copyright_string(rom, layout)
+	if copyright != screen:
+		return {
+			"ok": false,
+			"message": "The credits copyright string is not the copyright screen's.",
+		}
+	return {"ok": true, "message": "Credits verified."}
+
+
+## `CreditsScript` whole, terminator included. Empty when it does not terminate.
+static func read_credits_script(rom: RomFile, layout: Dictionary) -> PackedByteArray:
+	var at: int = int((layout.get("credits", {}) as Dictionary).get("script", -1))
+	if at < 0:
+		return PackedByteArray()
+	for length: int in range(1, RomLayout.CREDITS_SCRIPT_MAX_BYTES + 1):
+		if not rom.in_bounds(at + length - 1, 1):
+			break
+		if rom.u8(at + length - 1) == RomLayout.CREDITS_END:
+			return rom.slice(at, length)
+	return PackedByteArray()
+
+
+## One credits string as the tile codes `PlaceString` writes, the `@` dropped.
+## Empty when it does not terminate, which is what an index outside the table
+## produces.
+static func read_credits_string(
+	rom: RomFile, layout: Dictionary, index: int
+) -> PackedByteArray:
+	var at: int = RomLayout.credits_string_offset(rom, layout, index)
+	if at < 0:
+		return PackedByteArray()
+	for length: int in RomLayout.CREDITS_STRING_MAX_BYTES:
+		if not rom.in_bounds(at + length, 1):
+			break
+		if rom.u8(at + length) == Gen2Text.TERMINATOR:
+			return rom.slice(at, length)
+	return PackedByteArray()
 
 
 ## `FillTownMap`'s own loop: tile numbers until `-1`, which is not copied.
@@ -2813,6 +3022,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"title": _import_title(rom, layout),
 		"town_map": _import_town_map(rom, layout),
 		"oak_ratings": _import_oak_ratings(rom, layout),
+		"credits": _import_credits(rom, layout),
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
 		"battle_object_palettes": _import_battle_object_palettes(rom, layout),
 		"atlases": pics,
@@ -3375,6 +3585,39 @@ func _import_presents_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
+## The credits: `CreditsScript`, every `CreditsStringsPointers` entry as the tile
+## codes it is, `CreditsPalettes` and `.Frames`' block indices.
+##
+## The strings stay codes rather than text for the same reason the copyright
+## screen's does: `CreditsStringsPointers.Copyright` is nothing but tile numbers
+## into `CopyrightGFX`, which `Credits` loads over $60 the way `Copyright` does.
+func _import_credits(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("credits", {})
+	if entry.is_empty():
+		return {}
+	var script: Array = []
+	for command: int in read_credits_script(rom, layout):
+		script.append(command)
+	var strings: Array = []
+	for index: int in int(entry["string_count"]):
+		var codes: Array = []
+		for code: int in read_credits_string(rom, layout, index):
+			codes.append(code)
+		strings.append(codes)
+	var scene_colors: int = int(entry["scene_palettes"]) * RomLayout.CREDITS_PALETTE_COLORS
+	return {
+		"script": script,
+		"strings": strings,
+		"staff": int(entry["staff"]),
+		"copyright": int(entry["copyright"]),
+		"scene_palettes": int(entry["scene_palettes"]),
+		"palettes": _packed_palette(
+			rom, int(entry["palettes"]), RomLayout.CREDITS_SCENES * scene_colors
+		),
+		"frames": RomLayout.credits_frames(layout).duplicate(),
+	}
+
+
 func _packed_palette(rom: RomFile, at: int, colors: int) -> Array:
 	if at < 0:
 		return []
@@ -3778,6 +4021,30 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"column_major": bool(card["pic_columns"]),
 		},
 	}
+	## `Credits`' own three requests. `CreditsBorderGFX` goes to `vTiles2 tile
+	## $20` and `TheEndGFX` to `$40`, so each carries its own first_code and a
+	## tile number resolves straight into a strip; the mon sheets are addressed
+	## by `.Frames`' block rather than by tile number and stay one run.
+	var credits: Dictionary = layout.get("credits", {})
+	if not credits.is_empty():
+		sheets["credits_border"] = {
+			"offset": int(credits["gfx"]),
+			"tiles": RomLayout.CREDITS_BORDER_TILES,
+			"first_code": RomLayout.CREDITS_BORDER_FIRST_CODE,
+			"bits": 2,
+		}
+		sheets["credits_the_end"] = {
+			"offset": int(credits["the_end"]),
+			"tiles": RomLayout.CREDITS_THE_END_TILES,
+			"first_code": RomLayout.CREDITS_THE_END_FIRST_CODE,
+			"bits": 2,
+		}
+		sheets["credits_mons"] = {
+			"offset": RomLayout.credits_mon_gfx_offset(layout),
+			"tiles": RomLayout.credits_mon_tiles(layout),
+			"first_code": 0,
+			"bits": 2,
+		}
 	## Crystal only: pokegold ships neither a Kris pic nor the right corner, and
 	## says so with the -1 every layout uses for data a profile does not carry.
 	if int(card["pic_female"]) >= 0:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -705,6 +705,55 @@ const TOWN_MAP_PALETTE_COLORS: int = 4
 ## run: RGB 28,31,20.
 const TOWN_MAP_PALETTE_FIRST_COLOR: int = 0x53FC
 
+## The credits (`engine/movie/credits.asm`).
+##
+## `CreditsScript`'s commands, `const_def -1, -1`: the byte a command is not is a
+## `CreditsStringsPointers` index.
+const CREDITS_END: int = 0xFF
+const CREDITS_WAIT: int = 0xFE
+const CREDITS_SCENE: int = 0xFD
+const CREDITS_CLEAR: int = 0xFC
+const CREDITS_MUSIC: int = 0xFB
+const CREDITS_WAIT2: int = 0xFA
+const CREDITS_THEEND: int = 0xF9
+## The commands that take one operand; the rest are one byte.
+const CREDITS_OPERAND_COMMANDS: Array[int] = [
+	CREDITS_WAIT, CREDITS_WAIT2, CREDITS_SCENE,
+]
+
+## `CreditsBorderGFX`, then the four `Credits*GFX` mon sheets, uncompressed and
+## contiguous in that order, and `CreditsScript` directly behind them. So one
+## pinned offset locates all six and the run's own length pins the script.
+const CREDITS_BORDER_TILES: int = 9
+## `Credits_LoadBorderGFX.Frames` steps in 16-tile blocks, which is the 4x4 cell
+## the banner is five copies of.
+const CREDITS_MON_FRAME_TILES: int = 16
+const CREDITS_SCENES: int = 4
+const CREDITS_SCENE_FRAMES: int = 4
+## `TheEndGFX` (gfx/misc.asm), eight tiles across and two down.
+const CREDITS_THE_END_TILES: int = 16
+const CREDITS_THE_END_COLUMNS: int = 8
+
+## `Credits`' own VRAM window: the current mon frame's sixteen tiles at
+## `vTiles2`, the border at tile $20, "The End" at $40 and `CopyrightGFX` at $60,
+## which is where `LoadFontsBattleExtra` would put its strip. Letters are $80 and
+## up and are untouched.
+const CREDITS_BORDER_FIRST_CODE: int = 0x20
+const CREDITS_THE_END_FIRST_CODE: int = 0x40
+
+## `CreditsPalettes` (gfx/credits/credits.pal). Crystal copies 24 bytes per
+## scene, which is BG palettes 0, 1 and 2; Gold and Silver copy 8 twice, so
+## palettes 0 and 1 are the same four colours.
+const CREDITS_PALETTE_COLORS: int = 4
+## Every scene's first palette closes on RGB 07,07,07 in all three dumps, which
+## is what identifies the run.
+const CREDITS_PALETTE_LAST_COLOR: int = 0x1CE7
+
+## Long enough for either script and either longest string; one that reaches
+## these has not terminated.
+const CREDITS_SCRIPT_MAX_BYTES: int = 1024
+const CREDITS_STRING_MAX_BYTES: int = 64
+
 ## `OakRatings` (data/events/pokedex_ratings.asm): nineteen `rating` rows of a
 ## caught-count threshold, an sfx word and a text pointer, which `FindOakRating`
 ## walks until the count fits. The five texts around it are located from the
@@ -1172,6 +1221,35 @@ const GOLD_SILVER: Dictionary = {
 	# of five, which hit once per dump. Everything else Prof Oak's PC says is
 	# reached through the table's own text pointers.
 	"oak_ratings": 0x2685B,
+	# The credits. `gfx` was located by converting the pinned gfx/credits PNGs
+	# and matching the bytes: the border and the four mon sheets are one
+	# contiguous run in `credits.asm`'s own INCBIN order and `CreditsScript`
+	# follows it, so the run's length pins the script and the script's own
+	# terminator pins `CreditsStringsPointers`. `palettes` is
+	# gfx/credits/credits.pal assembled and matched, and `the_end` the same for
+	# gfx/credits/theend.png. Each hits once per dump. Nested the way
+	# trainer_card is.
+	"credits": {
+		"palettes": 0x86C1C,
+		"gfx": 0x86CA6,
+		"the_end": 0xCBCBD,
+		"script": 0x87A36,
+		"strings": 0x87B65,
+		# `PlaceFarString`, so the strings are not in the table's own bank.
+		"strings_bank": 0x70,
+		# NUM_CREDITS_STRINGS, STAFF and COPYRIGHT
+		# (constants/credits_constants.asm). All three are checked against the
+		# script and the copyright screen rather than trusted.
+		"string_count": 76,
+		"staff": 51,
+		"copyright": 71,
+		# `GetCreditsPalette.UpdatePals` copies eight bytes twice into the same
+		# two slots, so a scene is one palette rather than Crystal's three.
+		"scene_palettes": 1,
+		# `Credits_LoadBorderGFX.Frames`, as 16-tile blocks into the mon run.
+		# The first three scenes ship three frames each and repeat the first.
+		"frames": [0, 1, 0, 2, 3, 4, 3, 5, 6, 7, 6, 8, 9, 10, 11, 12],
+	},
 	# The copyright screen (`Copyright`, engine/menus/intro_menu.asm). The
 	# graphic was located by encoding the pinned gfx/splash/copyright.png as
 	# 2bpp and matching it, which hits once per dump; the string by assembling
@@ -1452,6 +1530,23 @@ const CRYSTAL: Dictionary = {
 	# See the Gold and Silver block above; the table is byte identical and only
 	# its address moves.
 	"oak_ratings": 0x2667F,
+	# See the Gold and Silver block above for how these were located. Crystal's
+	# strings sit in the pointer table's own bank, since it prints them with
+	# `PlaceString` rather than `PlaceFarString`, and each of its four scenes is
+	# three palettes rather than one.
+	"credits": {
+		"palettes": 0x109B6A,
+		"gfx": 0x109C24,
+		"the_end": 0xCBD2E,
+		"script": 0x10ACB4,
+		"strings": 0x10AE13,
+		"strings_bank": 0x42,
+		"string_count": 103,
+		"staff": 72,
+		"copyright": 98,
+		"scene_palettes": 3,
+		"frames": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+	},
 	# See the Gold and Silver block above for how this was located.
 	"copyright": {"gfx": 0xE4000, "tiles": 29, "string": 0x63FD, "palette": 0xA066},
 	# See the Gold and Silver block above for how these were located. Crystal
@@ -1975,6 +2070,45 @@ static func oak_text_stub_offset(rom: RomFile, layout: Dictionary, name: String)
 		return -1
 	var first: int = rom.u16le(table + 3) + int(OAK_TEXT_STUBS[name]) * OAK_TEXT_STUB_SIZE
 	return RomFile.linear(bank_of(table), first)
+
+
+## `Credits_LoadBorderGFX.Frames`, as 16-tile block indices into the mon run.
+static func credits_frames(layout: Dictionary) -> Array:
+	var stored: Variant = (layout.get("credits", {}) as Dictionary).get("frames", [])
+	return stored if stored is Array else []
+
+
+## How many tiles the four mon sheets occupy together, which is what the highest
+## block `.Frames` names says. Zero for a cartridge with no credits.
+static func credits_mon_tiles(layout: Dictionary) -> int:
+	var frames: Array = credits_frames(layout)
+	if frames.is_empty():
+		return 0
+	var highest: int = 0
+	for block: Variant in frames:
+		highest = maxi(highest, int(block))
+	return (highest + 1) * CREDITS_MON_FRAME_TILES
+
+
+## Where `CreditsPichuGFX` and its three neighbours start: directly behind
+## `CreditsBorderGFX`, which is the one offset pinned. -1 without a credits entry.
+static func credits_mon_gfx_offset(layout: Dictionary) -> int:
+	var at: int = int((layout.get("credits", {}) as Dictionary).get("gfx", -1))
+	return at + CREDITS_BORDER_TILES * Gen2Tiles.TILE_BYTES if at >= 0 else -1
+
+
+## The dump offset `CreditsStringsPointers` entry [param index] names. Its bank
+## is the strings' own rather than the table's, since Gold and Silver reach them
+## with `PlaceFarString`.
+static func credits_string_offset(rom: RomFile, layout: Dictionary, index: int) -> int:
+	var entry: Dictionary = layout.get("credits", {})
+	var table: int = int(entry.get("strings", -1))
+	if table < 0 or index < 0 or index >= int(entry.get("string_count", 0)):
+		return -1
+	var at: int = table + index * 2
+	if not rom.in_bounds(at, 2):
+		return -1
+	return RomFile.linear(int(entry.get("strings_bank", 0)), rom.u16le(at))
 
 
 ## `PokedexNestIconGFX`, which `INCBIN`s directly behind `kanto.bin` in the same

--- a/game/render/credits_page.gd
+++ b/game/render/credits_page.gd
@@ -1,0 +1,174 @@
+class_name Gen2CreditsPage
+extends RefCounted
+
+## The credits screen, on the tile grid the hardware uses.
+##
+## [Gen2Credits] owns the BG map and the attribute map, because
+## `ConstructCreditsTilemap` and `ParseCredits` are what write them; this
+## resolves a tile number to pixels and colours it through `CreditsPalettes`.
+##
+## `Credits`' own VRAM window:
+##
+## | Tiles | Contents |
+## |---|---|
+## | $00-$0f | the banner's current 4x4 mon cell, out of `CreditsMonsGFX` |
+## | $20-$28 | `CreditsBorderGFX` |
+## | $40-$4f | `TheEndGFX` |
+## | $60-$7c | `CopyrightGFX`, where `LoadFontsBattleExtra` would put its strip |
+## | $80+ | the font, untouched |
+##
+## The two border bands are the only thing that scrolls: `hLCDCPointer` is
+## LOW(rSCX) and `Credits_LYOverride` fills eight scanlines of `wLYOverrides` per
+## band, so those rows are sampled through an offset that walks two pixels a
+## cycle.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = Gen2Credits.COLUMNS
+const ROWS: int = Gen2Credits.ROWS
+const WIDTH: int = COLUMNS * TILE
+
+const BLANK_TILE: int = Gen2Credits.BLANK_TILE
+## The banner cell is addressed by `Credits_LoadBorderGFX.Frames`' block rather
+## than by tile number, so these sixteen are resolved against the block the frame
+## is drawing and not against a strip position.
+const BANNER_TILES: int = RomLayout.CREDITS_MON_FRAME_TILES
+
+var font: Gen2Font = null
+## The VRAM window, as one indices strip per tile number.
+var _tiles: Dictionary = {}
+## `CreditsMonsGFX` whole, which a block indexes into.
+var _mons: PackedByteArray = PackedByteArray()
+var _mons_width: int = 0
+
+
+## Null on a cache with no credits graphics, which is the caller's cue not to
+## open the screen.
+static func from_data(data: GameData) -> Gen2CreditsPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null or data == null:
+		return null
+	var out := Gen2CreditsPage.new()
+	out.font = glyphs
+	out._load_sheet(data, "credits_border", RomLayout.CREDITS_BORDER_FIRST_CODE)
+	out._load_sheet(data, "credits_the_end", RomLayout.CREDITS_THE_END_FIRST_CODE)
+	out._load_sheet(data, "copyright", RomLayout.COPYRIGHT_FIRST_CODE)
+	out._mons = data.tile_indices("credits_mons")
+	out._mons_width = out._mons.size() / TILE if out._mons.size() > 0 else 0
+	return out
+
+
+func ready() -> bool:
+	return font != null and _mons_width > 0 \
+		and _tiles.has(RomLayout.CREDITS_BORDER_FIRST_CODE) \
+		and _tiles.has(RomLayout.CREDITS_THE_END_FIRST_CODE)
+
+
+## The whole 160x144 screen. [param state] is [method Gen2Credits.frame_state].
+func image(data: GameData, state: Dictionary) -> Image:
+	var map: PackedInt32Array = state.get("map", PackedInt32Array())
+	var slots: PackedInt32Array = state.get("attributes", PackedInt32Array())
+	var indices: PackedByteArray = compose(map, int(state.get("block", -1)))
+	var out := Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
+	if map.size() < COLUMNS * ROWS or slots.size() < COLUMNS * ROWS:
+		return out
+	var scene: int = int(state.get("scene", 0))
+	var palettes: Array = []
+	for slot: int in [
+		Gen2Credits.PALETTE_BANNER, Gen2Credits.PALETTE_BORDER, Gen2Credits.PALETTE_TEXT,
+	]:
+		palettes.append(palette(data, scene, slot))
+	var scroll: int = int(state.get("scroll", 0))
+	var scrolled: Array = state.get("scroll_rows", [])
+	for row: int in ROWS:
+		var shift: int = scroll if row in scrolled else 0
+		for column: int in COLUMNS:
+			var palette_colors: PackedColorArray = palettes[
+				clampi(slots[row * COLUMNS + column], 0, palettes.size() - 1)
+			]
+			if palette_colors.is_empty():
+				continue
+			for y: int in TILE:
+				for x: int in TILE:
+					var at_x: int = column * TILE + x
+					var at_y: int = row * TILE + y
+					out.set_pixel(at_x, at_y, palette_colors[
+						indices[at_y * WIDTH + (at_x + shift) % WIDTH]
+					])
+	return out
+
+
+## `GetCreditsPalette`, whose Gold and Silver branch copies one four-colour
+## palette into both of the slots it uses and then blacks out the border and text
+## slot's last colour, which is the one the font's ink lands on.
+func palette(data: GameData, scene: int, slot: int) -> PackedColorArray:
+	var colors: PackedColorArray = data.credits_palette(scene, slot)
+	if colors.size() < RomLayout.CREDITS_PALETTE_COLORS:
+		return colors
+	if slot == Gen2Credits.PALETTE_BORDER and not Gen2WorldState.is_crystal_profile(data):
+		colors[RomLayout.CREDITS_PALETTE_COLORS - 1] = Color.BLACK
+	return colors
+
+
+## Resolves every tile number to pixels: the banner cell out of the mon run, the
+## other three graphics out of the VRAM window, everything else out of the font.
+func compose(map: PackedInt32Array, block: int) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * ROWS * TILE)
+	if map.size() < COLUMNS * ROWS:
+		return indices
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var tile: int = map[row * COLUMNS + column]
+			var at := Vector2i(column * TILE, row * TILE)
+			if tile < BANNER_TILES:
+				_blit_banner(indices, block, tile, at)
+			elif _tiles.has(tile):
+				_blit(indices, _tiles[tile], at)
+			elif tile != BLANK_TILE:
+				font.draw_code(tile, indices, WIDTH, at.x, at.y, Gen2Text.FONT_MAIN)
+	return indices
+
+
+## `wCreditsBlankFrame2bpp` is sixteen tiles of solid colour 2, which is the
+## background the four border mons are drawn on, so a cleared banner is that
+## colour rather than blank.
+func _blit_banner(
+	indices: PackedByteArray, block: int, tile: int, at: Vector2i
+) -> void:
+	if block < 0:
+		_fill(indices, at, Gen2Credits.BLANK_FRAME_INDEX)
+		return
+	var slot: int = block * BANNER_TILES + tile
+	if (slot + 1) * TILE > _mons_width:
+		return
+	for y: int in TILE:
+		for x: int in TILE:
+			indices[(at.y + y) * WIDTH + at.x + x] = _mons[y * _mons_width + slot * TILE + x]
+
+
+func _load_sheet(data: GameData, name: String, first_tile: int) -> void:
+	var indices: PackedByteArray = data.tile_indices(name)
+	if indices.is_empty():
+		return
+	var width: int = indices.size() / TILE
+	@warning_ignore("integer_division")
+	var count: int = width / TILE
+	for tile: int in count:
+		var cell := PackedByteArray()
+		cell.resize(TILE * TILE)
+		for y: int in TILE:
+			for x: int in TILE:
+				cell[y * TILE + x] = indices[y * width + tile * TILE + x]
+		_tiles[first_tile + tile] = cell
+
+
+func _blit(indices: PackedByteArray, cell: PackedByteArray, at: Vector2i) -> void:
+	for y: int in TILE:
+		for x: int in TILE:
+			indices[(at.y + y) * WIDTH + at.x + x] = cell[y * TILE + x]
+
+
+func _fill(indices: PackedByteArray, at: Vector2i, index: int) -> void:
+	for y: int in TILE:
+		for x: int in TILE:
+			indices[(at.y + y) * WIDTH + at.x + x] = index

--- a/game/render/credits_page.gd.uid
+++ b/game/render/credits_page.gd.uid
@@ -1,0 +1,1 @@
+uid://bcnn3vwgduei4

--- a/game/world/credits.gd
+++ b/game/world/credits.gd
@@ -1,0 +1,443 @@
+class_name Gen2Credits
+extends RefCounted
+
+## The credits (`engine/movie/credits.asm`), as the frame-driven state machine
+## they are.
+##
+## `Credits_Jumptable` runs one entry per frame and loops back after thirteen, so
+## a `CREDITS_WAIT` tick is thirteen frames and not one: `ParseCredits` is the
+## first entry and spends a tick each time it comes round. The rest of the cycle
+## is what moves. `Credits_UpdateGFXRequestPath` steps the banner's frame, twice
+## a cycle on Crystal and once on Gold and Silver;`Credits_LYOverride` walks the
+## two border bands sideways two pixels, down on Crystal and up on the other two;
+## and the three `Credits_Next` entries behind a wait are the frames
+## `UpdateBGMap` spends copying the tilemap to the BG map a third at a time.
+##
+## That copy is why this owns two maps rather than one. `.parse` clears the text
+## region and places the next batch into `wTilemap` with `hBGMapMode` off, and
+## only `CREDITS_WAIT` turns the copy back on: a batch ending on `CREDITS_WAIT2`
+## or on `CREDITS_END` is written and never shown. The End stays on screen for
+## exactly that reason, since the clear in front of `CREDITS_END` is never
+## pushed.
+##
+## [Gen2CreditsPage] turns [method bg_map] into pixels; nothing here draws.
+
+## `MUSIC_CREDITS` and the `MUSIC_POST_CREDITS` `.end` fades into, both the same
+## number on all three cartridges.
+const MUSIC_CREDITS: int = 0x24
+const MUSIC_POST_CREDITS: int = 0x5C
+## `ld a, 32 / ld [wMusicFade], a`.
+const POST_CREDITS_FADE_FRAMES: int = 32
+
+const COLUMNS: int = 20
+const ROWS: int = 18
+## `UpdateBGMap` copies `SCREEN_HEIGHT / 3` rows a frame, and `hBGMapThird`
+## wraps, so a cycle whose wait leaves the copy on for four frames re-copies the
+## top rows rather than stopping.
+const THIRDS: int = 3
+const THIRD_ROWS: int = ROWS / THIRDS
+
+## `.Jumptable`'s own length, which is what makes a tick thirteen frames.
+const CYCLE_FRAMES: int = 13
+## `ParseCredits`, always the entry the cycle opens on.
+const STEP_PARSE: int = 0
+## The entries running `Credits_UpdateGFXRequestPath`.
+const GFX_STEPS: Array[int] = [4, 10]
+const GFX_STEPS_GOLD_SILVER: Array[int] = [5]
+## `Credits_LYOverride` and its `dec a / dec a`, which Gold and Silver replace
+## with `inc a / inc a`.
+const LY_STEP: int = 6
+const LY_STEP_GOLD_SILVER: int = 7
+const LY_DELTA: int = -2
+const LY_DELTA_GOLD_SILVER: int = 2
+
+## `ConstructCreditsTilemap`. The screen is a banner of five 4x4 mon cells, a
+## border band, the text region and a second border; Gold and Silver put a second
+## banner under the lower border where Crystal gives the text four more rows.
+const BANNER_ROWS: int = 4
+const BANNER_COLUMNS: int = 4
+const BLANK_TILE: int = 0x7F
+## `DrawCreditsBorder`'s two bases, four tiles repeated five times across.
+const BORDER_TOP_TILE: int = 0x24
+const BORDER_BOTTOM_TILE: int = 0x20
+const BORDER_TILES: int = 4
+const BORDER_TOP_ROW: int = 4
+const BORDER_BOTTOM_ROW: int = 17
+const BORDER_BOTTOM_ROW_GOLD_SILVER: int = 13
+
+## `.parse`'s `hlcoord 0, 5` and the rows it fills.
+const TEXT_FIRST_ROW: int = 5
+## `hlcoord 0, 6` plus `SCREEN_WIDTH * 2` per line, so a batch's lines sit two
+## rows apart.
+const TEXT_TOP_ROW: int = 6
+const TEXT_LINE_SPACING: int = 2
+## `.copyright`'s own `hlcoord 2, 6`; every other string starts at column 0.
+const COPYRIGHT_COLUMN: int = 2
+
+## `Credits_TheEnd`, sixteen tiles from $40 laid out eight across and two down.
+const THE_END_TILE: int = 0x40
+const THE_END_COLUMNS: int = 8
+const THE_END_AT: Vector2i = Vector2i(6, 9)
+const THE_END_AT_GOLD_SILVER: Vector2i = Vector2i(6, 8)
+
+## `wAttrmap`'s three slots: the banner, the border bands and the text region.
+## Gold and Silver give the border and the text one slot between them and the
+## banners the other.
+const PALETTE_BANNER: int = 0
+const PALETTE_BORDER: int = 1
+const PALETTE_TEXT: int = 2
+
+## `PlacePOKe`, which prints `PlacePOKeText` rather than a tile: "#" is a
+## dictionary entry in `PlaceNextChar`, not a glyph.
+const CODE_POKE: int = 0x54
+const POKE_TEXT: String = "POKé"
+## `NextLineChar`, which drops two rows at the string's own starting column.
+const CODE_NEXT_LINE: int = 0x4E
+
+## `wCreditsBorderFrame`'s $ff, which `Credits_LoadBorderGFX.init` answers with
+## the blank frame and leaves alone, so a cleared banner stays cleared.
+const BLANK_FRAME: int = -1
+## `ld de, `22222222`: the blank frame is sixteen tiles of colour 2, which is the
+## background the four border mons are drawn on rather than an empty cell.
+const BLANK_FRAME_INDEX: int = 2
+
+## `Credits_HandleBButton`: the skip refuses until `wCreditsPos` has passed the
+## header, so the version screen cannot be jumped over even on a replay.
+const SKIP_FROM_POSITION: int = 0x0D
+
+var _data: GameData = null
+var _script: PackedByteArray = PackedByteArray()
+var _copyright_index: int = -1
+var _crystal: bool = true
+## `wJumptableIndex`'s low nibble and its JUMPTABLE_EXIT_F.
+var _step: int = STEP_PARSE
+var _finished: bool = false
+## `wCreditsPos` and `wCreditsTimer`.
+var _position: int = 0
+var _timer: int = 0
+## `wCreditsBorderMon` and `wCreditsBorderFrame`.
+var _scene: int = 0
+var _frame: int = BLANK_FRAME
+## Which sixteen-tile block of the mon run the banner draws, or -1 for
+## `wCreditsBlankFrame2bpp`.
+var _block: int = -1
+## `wCreditsLYOverride`, the rSCX the two border bands are sampled through.
+var _scroll: int = 0
+## `wTilemap`, `wAttrmap` and the BG map the first is copied into.
+var _tilemap := PackedInt32Array()
+var _attributes := PackedInt32Array()
+var _bg_map := PackedInt32Array()
+## `hBGMapMode` and `hBGMapThird`.
+var _copying: bool = false
+var _third: int = 0
+## `bit STATUSFLAGS_HALL_OF_FAME_F, b`: the credits cannot be skipped the first
+## time they are watched.
+var _skippable: bool = false
+
+
+## [param skippable] is `STATUSFLAGS_HALL_OF_FAME_F`, which is set by the time
+## the induction it follows has been through once. Null when the cache carries no
+## credits script.
+static func create(data: GameData, skippable: bool = false) -> Gen2Credits:
+	if data == null:
+		return null
+	var script: PackedByteArray = data.credits_script()
+	if script.is_empty():
+		return null
+	var out := Gen2Credits.new()
+	out._data = data
+	out._script = script
+	out._copyright_index = data.credits_index("copyright")
+	out._crystal = Gen2WorldState.is_crystal_profile(data)
+	out._skippable = skippable
+	out._construct()
+	return out
+
+
+func scene() -> int:
+	return _scene
+
+
+## The mon run block the banner draws this frame, or -1 while `CREDITS_CLEAR`
+## holds it blank.
+func banner_block() -> int:
+	return _block
+
+
+## The BG map, which is what is on screen: one tile number per cell.
+func bg_map() -> PackedInt32Array:
+	return _bg_map.duplicate()
+
+
+## `wTilemap`, which is what has been written but not necessarily shown.
+func tilemap() -> PackedInt32Array:
+	return _tilemap.duplicate()
+
+
+## `wAttrmap`, one palette slot per cell. Fixed by `ConstructCreditsTilemap` and
+## never written again.
+func attributes() -> PackedInt32Array:
+	return _attributes.duplicate()
+
+
+## The two rows `Credits_LYOverride` fills scanlines for, which are the border
+## bands. The source's fills sit one scanline higher than the tile row, since the
+## override for a line is written during the one before it.
+func scroll_rows() -> Array[int]:
+	return [BORDER_TOP_ROW, _bottom_border_row()]
+
+
+## Whether `CREDITS_END` has run. The source keeps looping here until A is held,
+## which is what [method may_finish] answers.
+func finished() -> bool:
+	return _finished
+
+
+func scroll() -> int:
+	return _scroll
+
+
+func position() -> int:
+	return _position
+
+
+func timer() -> int:
+	return _timer
+
+
+func skippable() -> bool:
+	return _skippable
+
+
+## What [Gen2CreditsPage] needs to draw one frame.
+func frame_state() -> Dictionary:
+	return {
+		"map": bg_map(),
+		"attributes": attributes(),
+		"scene": _scene,
+		"block": _block,
+		"scroll": _scroll,
+		"scroll_rows": scroll_rows(),
+	}
+
+
+## One frame of `.execution_loop`: the B skip, the jumptable entry, then the
+## VBlank behind `DelayFrame`.
+##
+## [param held] is `hJoypadDown`, since both of the loop's buttons are held
+## states rather than presses. Returns the events the frame asked for, which is
+## the two `PlayMusic` calls and nothing else.
+func advance_frame(held: Array = []) -> Array:
+	var events: Array = []
+	if Gen2Button.B in held:
+		_skip()
+	var step: int = _step
+	_step = STEP_PARSE if step >= CYCLE_FRAMES - 1 else step + 1
+	if step == STEP_PARSE:
+		events = _parse()
+	elif step in _gfx_steps():
+		_load_banner()
+		## `Credits_UpdateGFXRequestPath` and `Credits_RequestGFX` both clear
+		## `hBGMapMode`, which is what stops the copy after its three thirds.
+		_copying = false
+	elif step == _ly_step():
+		_scroll = (_scroll + _ly_delta()) & 0xFF
+	elif step == _prep_step():
+		_copying = false
+	_copy_third()
+	return events
+
+
+## Whether holding A now leaves, which `Credits_HandleAButton` only allows once
+## the script has run out.
+func may_finish(held: Array = []) -> bool:
+	return _finished and Gen2Button.A in held
+
+
+## `Credits_HandleBButton`, which burns one tick of the wait a frame rather than
+## jumping anywhere.
+func _skip() -> void:
+	if not _skippable or _position < SKIP_FROM_POSITION or _timer <= 0:
+		return
+	_timer -= 1
+
+
+## `UpdateBGMap.Tiles`, one third of the rows per VBlank while `hBGMapMode` is on.
+func _copy_third() -> void:
+	if not _copying:
+		return
+	var first: int = _third * THIRD_ROWS * COLUMNS
+	for cell: int in THIRD_ROWS * COLUMNS:
+		_bg_map[first + cell] = _tilemap[first + cell]
+	_third = (_third + 1) % THIRDS
+
+
+## `Credits_LoadBorderGFX`: the block the banner draws is the frame the counter
+## holds, and the counter moves on afterwards. A cleared banner neither draws nor
+## counts.
+func _load_banner() -> void:
+	if _frame == BLANK_FRAME:
+		_block = -1
+		return
+	_block = _data.credits_frame_block(_scene, _frame)
+	_frame = (_frame + 1) % RomLayout.CREDITS_SCENE_FRAMES
+
+
+## `ParseCredits`. A tick is spent here, or the whole batch up to the next wait is
+## read at once, which is why the strings between two waits appear together.
+func _parse() -> Array:
+	if _finished:
+		return []
+	if _timer > 0:
+		_timer -= 1
+		return []
+	_clear_text()
+	var events: Array = []
+	while true:
+		var command: int = _next()
+		match command:
+			RomLayout.CREDITS_END:
+				_finished = true
+				events.append({
+					"type": &"music_fade_requested",
+					"music": MUSIC_POST_CREDITS,
+					"frames": POST_CREDITS_FADE_FRAMES,
+				})
+				return events
+			RomLayout.CREDITS_WAIT:
+				_timer = _next()
+				_copying = true
+				_third = 0
+				return events
+			RomLayout.CREDITS_WAIT2:
+				## The same wait with no BG map update behind it, so the batch it
+				## closes is written and never shown.
+				_timer = _next()
+				return events
+			RomLayout.CREDITS_SCENE:
+				_scene = _next() % RomLayout.CREDITS_SCENES
+				_frame = 0
+			RomLayout.CREDITS_CLEAR:
+				_frame = BLANK_FRAME
+			RomLayout.CREDITS_MUSIC:
+				events.append({"type": &"music_requested", "music": MUSIC_CREDITS})
+			RomLayout.CREDITS_THEEND:
+				_draw_the_end()
+			_:
+				_place_string(command, _next())
+	return events
+
+
+## `.get`, which walks `wCreditsPos` a byte at a time and never turns back. A
+## fixture that runs off its own end reads as `CREDITS_END`, so the parse loop
+## always terminates; the importer refuses a script that does.
+func _next() -> int:
+	if _position >= _script.size():
+		return RomLayout.CREDITS_END
+	var byte: int = _script[_position]
+	_position += 1
+	return byte
+
+
+## `.print`: the string's own column, [param line] lines down from row 6.
+func _place_string(index: int, line: int) -> void:
+	var column: int = COPYRIGHT_COLUMN if index == _copyright_index else 0
+	var at := Vector2i(column, TEXT_TOP_ROW + line * TEXT_LINE_SPACING)
+	for code: int in _data.credits_string(index):
+		if code == CODE_NEXT_LINE:
+			at = Vector2i(column, at.y + TEXT_LINE_SPACING)
+			continue
+		if code == CODE_POKE:
+			for glyph: int in Gen2Text.encode(POKE_TEXT):
+				_put(at, glyph)
+				at.x += 1
+			continue
+		_put(at, code)
+		at.x += 1
+
+
+func _clear_text() -> void:
+	for row: int in range(TEXT_FIRST_ROW, _bottom_border_row()):
+		for column: int in COLUMNS:
+			## `ld a, ' '`, which is the same $7f the region opened blank in.
+			_put(Vector2i(column, row), BLANK_TILE)
+
+
+func _draw_the_end() -> void:
+	var at: Vector2i = THE_END_AT if _crystal else THE_END_AT_GOLD_SILVER
+	for tile: int in RomLayout.CREDITS_THE_END_TILES:
+		@warning_ignore("integer_division")
+		var row: int = tile / THE_END_COLUMNS
+		_put(
+			at + Vector2i(tile % THE_END_COLUMNS, row),
+			THE_END_TILE + tile
+		)
+
+
+## `ConstructCreditsTilemap`, run once: the banner cells, the two border bands,
+## the blank text region and the attribute map, then a full copy to the BG map.
+func _construct() -> void:
+	_tilemap.resize(COLUMNS * ROWS)
+	_attributes.resize(COLUMNS * ROWS)
+	_tilemap.fill(BLANK_TILE)
+	_attributes.fill(PALETTE_TEXT if _crystal else PALETTE_BORDER)
+	_draw_banner(0)
+	_draw_border(BORDER_TOP_ROW, BORDER_TOP_TILE)
+	_draw_border(_bottom_border_row(), BORDER_BOTTOM_TILE)
+	for row: int in BANNER_ROWS:
+		_fill_attributes(row, PALETTE_BANNER)
+	_fill_attributes(BORDER_TOP_ROW, PALETTE_BORDER)
+	_fill_attributes(_bottom_border_row(), PALETTE_BORDER)
+	if not _crystal:
+		var second: int = _bottom_border_row() + 1
+		_draw_banner(second)
+		for row: int in BANNER_ROWS:
+			_fill_attributes(second + row, PALETTE_BANNER)
+	_bg_map = _tilemap.duplicate()
+
+
+## `.InitTopPortion`: five copies of one 4x4 cell, numbered across then down.
+func _draw_banner(first_row: int) -> void:
+	for row: int in BANNER_ROWS:
+		for column: int in COLUMNS:
+			_put(
+				Vector2i(column, first_row + row),
+				row * BANNER_COLUMNS + column % BANNER_COLUMNS
+			)
+
+
+func _draw_border(row: int, base: int) -> void:
+	for column: int in COLUMNS:
+		_put(Vector2i(column, row), base + column % BORDER_TILES)
+
+
+func _fill_attributes(row: int, slot: int) -> void:
+	for column: int in COLUMNS:
+		_attributes[row * COLUMNS + column] = slot
+
+
+func _put(at: Vector2i, tile: int) -> void:
+	if at.x < 0 or at.y < 0 or at.x >= COLUMNS or at.y >= ROWS:
+		return
+	_tilemap[at.y * COLUMNS + at.x] = tile
+
+
+func _bottom_border_row() -> int:
+	return BORDER_BOTTOM_ROW if _crystal else BORDER_BOTTOM_ROW_GOLD_SILVER
+
+
+func _gfx_steps() -> Array[int]:
+	return GFX_STEPS if _crystal else GFX_STEPS_GOLD_SILVER
+
+
+func _ly_step() -> int:
+	return LY_STEP if _crystal else LY_STEP_GOLD_SILVER
+
+
+func _ly_delta() -> int:
+	return LY_DELTA if _crystal else LY_DELTA_GOLD_SILVER
+
+
+## `Credits_PrepBGMapUpdate`, the entry in front of the first graphics request.
+func _prep_step() -> int:
+	return _gfx_steps()[0] - 1

--- a/game/world/credits.gd.uid
+++ b/game/world/credits.gd.uid
@@ -1,0 +1,1 @@
+uid://b6hlxumam8ahw

--- a/game/world/credits_screen.gd
+++ b/game/world/credits_screen.gd
@@ -1,0 +1,130 @@
+class_name Gen2CreditsScreen
+extends Control
+
+## The credits, embedded in the overworld the way the Hall of Fame is.
+##
+## [Gen2Credits] owns `Credits`' whole loop and [Gen2CreditsPage] draws it; this
+## spends the frames and reads the two buttons `.execution_loop` reads. Both are
+## held states rather than presses (`hJoypadDown`), so the host has to say when
+## each is let go: A only leaves once the script has run out, and B burns a tick
+## of the current wait per frame and only on a replay.
+##
+## The two `PlayMusic` calls are the overworld's rather than this screen's, the
+## same way the Hall of Fame's rating sound is.
+
+signal closed()
+signal music_requested(music: int)
+## `.end`'s `wMusicFade`, which fades whatever is playing into MUSIC_POST_CREDITS
+## over its own frame count.
+signal music_fade_requested(music: int, frames: int)
+
+var _data: GameData = null
+var _credits: Gen2Credits = null
+var _page: Gen2CreditsPage = null
+var _view: TextureRect = null
+var _held: Array = []
+## Leftover of a hardware frame this screen has not counted yet.
+var _elapsed: float = 0.0
+
+
+## [param skippable] is `STATUSFLAGS_HALL_OF_FAME_F`. False leaves the credits
+## unskippable, which is what the first run through them is.
+##
+## Answers false when the cache has no credits, so a caller that has already
+## added the node is left with nothing rather than an empty rectangle.
+func set_context(data: GameData, skippable: bool = false) -> bool:
+	_data = data
+	_page = Gen2CreditsPage.from_data(data)
+	_credits = Gen2Credits.create(data, skippable)
+	if _page == null or not _page.ready() or _credits == null:
+		_page = null
+		_credits = null
+		visible = false
+		return false
+	return true
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _credits == null:
+		closed.emit()
+		return
+	_view = TextureRect.new()
+	_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	add_child(_view)
+	_refresh()
+
+
+func credits() -> Gen2Credits:
+	return _credits
+
+
+## A press is also a hold, so A is answered where it lands as well as on the
+## frame after it: the script may run out while the button is already down.
+func handle_button(button: int) -> bool:
+	if _credits == null:
+		return false
+	if not button in _held:
+		_held.append(button)
+	if _credits.may_finish(_held):
+		close()
+	return true
+
+
+## The other half of `hJoypadDown`, which a press-only host cannot say.
+func release_button(button: int) -> void:
+	_held.erase(button)
+
+
+func advance_frame() -> void:
+	if _credits == null:
+		return
+	for event: Dictionary in _credits.advance_frame(_held):
+		if StringName(event.get("type", &"")) == &"music_requested":
+			music_requested.emit(int(event["music"]))
+		else:
+			music_fade_requested.emit(int(event["music"]), int(event["frames"]))
+	if _credits.may_finish(_held):
+		close()
+		return
+	_refresh()
+
+
+func advance_frames(count: int) -> void:
+	for _step: int in count:
+		if _credits == null:
+			return
+		advance_frame()
+
+
+func close() -> void:
+	if _credits == null:
+		return
+	_credits = null
+	closed.emit()
+
+
+## The whole 160x144 screen, for a preview or a test that wants pixels rather
+## than a viewport.
+func render() -> Image:
+	if _page == null or _credits == null:
+		return Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
+	return _page.image(_data, _credits.frame_state())
+
+
+func _process(delta: float) -> void:
+	if _credits == null:
+		return
+	_elapsed += delta
+	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_frame()
+
+
+func _refresh() -> void:
+	if _view == null:
+		return
+	_view.texture = ImageTexture.create_from_image(render())

--- a/game/world/credits_screen.gd.uid
+++ b/game/world/credits_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://c7nvsp2d6xoy3

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -79,6 +79,7 @@ var _pc_host: Gen2BoxScreen = null
 var _start_menu_host: Gen2StartMenuScreen = null
 var _party_host: Gen2PartyScreen = null
 var _hall_of_fame_host: Gen2HallOfFameScreen = null
+var _credits_host: Gen2CreditsScreen = null
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
@@ -529,7 +530,7 @@ func _overlay_open() -> bool:
 	return _battle_host != null or _service_host != null or _pc_host != null \
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
-		or _pokedex_host != null
+		or _pokedex_host != null or _credits_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -555,11 +556,16 @@ func _unhandled_input(event: InputEvent) -> void:
 		if press_button(button):
 			accept_event()
 		return
-	## The dex area's SELECT is a held state rather than a press, and the Pokedex
-	## is the only overlay here with anything to do with a release.
+	## The dex area's SELECT and the credits' A and B are held states rather than
+	## presses, and those two overlays are the only ones with anything to do with
+	## a release.
 	var released: int = Gen2Button.released_in(event)
 	if released != Gen2Button.NONE and _pokedex_host != null:
 		_pokedex_host.release_button(released)
+		accept_event()
+		return
+	if released != Gen2Button.NONE and _credits_host != null:
+		_credits_host.release_button(released)
 		accept_event()
 		return
 	if event.is_pressed() and _handle_debug_key(event):
@@ -610,6 +616,9 @@ func _handle_button(button: int) -> bool:
 	## to until it has finished, and it takes no cancel.
 	if _hall_of_fame_host != null:
 		_hall_of_fame_host.handle_button(button)
+		return true
+	if _credits_host != null:
+		_credits_host.handle_button(button)
 		return true
 	if _pc_host != null:
 		if button == Gen2Button.B:
@@ -1727,6 +1736,10 @@ func _on_hall_of_fame_closed() -> void:
 	if _renderer != null:
 		_renderer.refresh()
 	_refresh_labels()
+	## `AnimateHallOfFame` is followed by `farcall Credits` with the `wStatusFlags`
+	## byte pushed before the Hall of Fame bit went into it, so this pair is never
+	## skippable however many times it has been seen.
+	open_credits(false)
 
 
 ## `ProfOaksPCRating`'s tail: `PlayMusic MUSIC_NONE` stops the induction music
@@ -1736,6 +1749,61 @@ func _on_hall_of_fame_rating(sfx: int) -> void:
 	if _audio_player != null:
 		_audio_player.fade_out()
 	_play_sfx(sfx)
+
+
+## `Script_credits`, which farcalls `RedCredits` and then ends the script.
+##
+## [param skippable] is the `wStatusFlags` byte `Credits` is handed: `RedCredits`
+## passes the live one, which by Red has the Hall of Fame bit in it, while
+## `HallOfFame` pushes the byte before setting that bit, so the induction's own
+## credits cannot be skipped even on a second run.
+func open_credits(skippable: bool = true) -> void:
+	if _credits_host != null or _world == null or _data == null:
+		return
+	var host := Gen2CreditsScreen.new()
+	if not host.set_context(_data, skippable):
+		host.free()
+		_script_prompt = "The credits are not in this cache"
+		_refresh_labels()
+		return
+	host.closed.connect(_on_credits_closed)
+	host.music_requested.connect(_play_credits_music)
+	host.music_fade_requested.connect(_fade_credits_music)
+	_credits_host = host
+	_screen.display(host)
+	_script_prompt = "Credits"
+	_refresh_labels()
+
+
+func _on_credits_closed() -> void:
+	var host: Gen2CreditsScreen = _credits_host
+	_credits_host = null
+	if host != null:
+		host.queue_free()
+	_play_current_map_music()
+	if _renderer != null:
+		_renderer.refresh()
+	_script_prompt = ""
+	_refresh_labels()
+
+
+## `.music`, whose `PlayMusic MUSIC_NONE` and `DelayFrame` in front of the real
+## call are what stop the induction's own track first.
+func _play_credits_music(music: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	_audio_player.fade_out()
+	var record: Dictionary = _data.world_audio(&"music", music)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
+## `.end`'s `wMusicFade`, which the overworld's own player owns the way it owns
+## the Hall of Fame rating's sound.
+func _fade_credits_music(_music: int, frames: int) -> void:
+	if _audio_player != null:
+		_audio_player.fade_out(frames)
 
 
 func _play_hall_of_fame_music() -> void:
@@ -2452,6 +2520,8 @@ func _show_script_results(results: Array) -> void:
 				## and runs on, and the source's own `end` is the next command,
 				## so nothing is waiting to be resumed when this opens.
 				open_hall_of_fame()
+			elif result_event.get("type", &"") == &"credits_requested":
+				open_credits()
 			elif result_event.get("type", &"") == &"field_move_confirmed":
 				## `iftrue Script_Cut` and its four counterparts. The move is the
 				## host's, and it is the same staged request and acknowledge the

--- a/tests/integration/test_credits.gd
+++ b/tests/integration/test_credits.gd
@@ -1,0 +1,317 @@
+extends GutTest
+
+## `Credits` and `ParseCredits` (`engine/movie/credits.asm`) over a fixture
+## cache, and [Gen2CreditsPage] over the same one.
+##
+## The model is scene-free but data-driven: the script, the strings, the palettes
+## and `.Frames` all come out of a cache, so the fixture is what makes a case
+## here say anything.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+## The fixture script's waits, as ticks: STAFF then 2, the music beat 1 and 1,
+## the two names 2, the copyright 1, The End 1.
+const FIRST_WAIT: int = 2
+
+var _data: GameData = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func _gold() -> GameData:
+	Fixture.build(RomRegistry.GOLD)
+	return GameData.open_directory(Fixture.directory(RomRegistry.GOLD))
+
+
+func _spend(credits: Gen2Credits, frames: int, held: Array = []) -> Array:
+	var events: Array = []
+	for _frame: int in frames:
+		events.append_array(credits.advance_frame(held))
+	return events
+
+
+func _cell(map: PackedInt32Array, column: int, row: int) -> int:
+	return map[row * Gen2Credits.COLUMNS + column]
+
+
+## `ConstructCreditsTilemap`: the banner is five copies of one 4x4 cell, so the
+## tile at a column is its position within that cell.
+func test_the_banner_is_five_copies_of_one_four_by_four_cell() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	var map: PackedInt32Array = credits.bg_map()
+	for row: int in Gen2Credits.BANNER_ROWS:
+		for column: int in Gen2Credits.COLUMNS:
+			assert_eq(
+				_cell(map, column, row),
+				row * Gen2Credits.BANNER_COLUMNS + column % Gen2Credits.BANNER_COLUMNS
+			)
+
+
+## `DrawCreditsBorder`'s two bases, and the row each band sits on, which is where
+## the two profiles part: Crystal gives the text four more rows and Gold and
+## Silver a second banner.
+func test_the_two_border_bands_sit_where_the_profile_puts_them() -> void:
+	var crystal: PackedInt32Array = Gen2Credits.create(_data).bg_map()
+	assert_eq(
+		_cell(crystal, 5, Gen2Credits.BORDER_TOP_ROW),
+		Gen2Credits.BORDER_TOP_TILE + 1
+	)
+	assert_eq(
+		_cell(crystal, 0, Gen2Credits.BORDER_BOTTOM_ROW), Gen2Credits.BORDER_BOTTOM_TILE
+	)
+
+	var gold: PackedInt32Array = Gen2Credits.create(_gold()).bg_map()
+	assert_eq(
+		_cell(gold, 0, Gen2Credits.BORDER_BOTTOM_ROW_GOLD_SILVER),
+		Gen2Credits.BORDER_BOTTOM_TILE
+	)
+	assert_eq(
+		_cell(gold, 0, Gen2Credits.BORDER_BOTTOM_ROW_GOLD_SILVER + 1), 0,
+		"and the second banner starts under it"
+	)
+
+
+## `wAttrmap`: the banner, the two bands and the text region. Gold and Silver
+## give the bands and the text one slot and both banners the other.
+func test_the_attribute_map_is_the_three_slots_the_profile_uses() -> void:
+	var crystal: PackedInt32Array = Gen2Credits.create(_data).attributes()
+	assert_eq(_cell(crystal, 0, 0), Gen2Credits.PALETTE_BANNER)
+	assert_eq(_cell(crystal, 0, Gen2Credits.BORDER_TOP_ROW), Gen2Credits.PALETTE_BORDER)
+	assert_eq(_cell(crystal, 0, Gen2Credits.TEXT_TOP_ROW), Gen2Credits.PALETTE_TEXT)
+	assert_eq(_cell(crystal, 0, Gen2Credits.BORDER_BOTTOM_ROW), Gen2Credits.PALETTE_BORDER)
+
+	var gold: PackedInt32Array = Gen2Credits.create(_gold()).attributes()
+	assert_eq(_cell(gold, 0, 0), Gen2Credits.PALETTE_BANNER)
+	assert_eq(_cell(gold, 0, Gen2Credits.TEXT_TOP_ROW), Gen2Credits.PALETTE_BORDER)
+	assert_eq(
+		_cell(gold, 0, Gen2Credits.BORDER_BOTTOM_ROW_GOLD_SILVER + 1),
+		Gen2Credits.PALETTE_BANNER
+	)
+
+
+## `.Jumptable` is thirteen entries and `ParseCredits` is the first, so one
+## `CREDITS_WAIT` tick costs thirteen frames.
+func test_a_wait_tick_is_a_whole_jumptable_cycle() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	_spend(credits, 1)
+	assert_eq(credits.timer(), FIRST_WAIT)
+
+	_spend(credits, Gen2Credits.CYCLE_FRAMES - 1)
+	assert_eq(credits.timer(), FIRST_WAIT, "and nothing else in the cycle spends one")
+
+	_spend(credits, 1)
+	assert_eq(credits.timer(), FIRST_WAIT - 1)
+
+
+## `.print`: the string's line operand is two rows per step from row 6, and
+## `NextLineChar` drops two more at the string's own starting column.
+func test_a_string_prints_two_rows_a_line_and_wraps_at_its_own_column() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	_spend(credits, Gen2Credits.CYCLE_FRAMES * (FIRST_WAIT + 1))
+	var map: PackedInt32Array = credits.bg_map()
+	## `db CREDITS_STAFF, 1`, whose string is "#", a letter, `<NEXT>`, a letter.
+	var row: int = Gen2Credits.TEXT_TOP_ROW + Gen2Credits.TEXT_LINE_SPACING
+	var poke: PackedByteArray = Gen2Text.encode(Gen2Credits.POKE_TEXT)
+	for index: int in poke.size():
+		assert_eq(_cell(map, index, row), poke[index], "# is a string, not a tile")
+	assert_eq(_cell(map, poke.size(), row), 0x85)
+	assert_eq(_cell(map, 0, row + Gen2Credits.TEXT_LINE_SPACING), 0x86)
+
+
+## `.copyright`'s own `hlcoord 2, 6`, the one string that does not start at
+## column 0.
+func test_the_copyright_string_starts_two_columns_in() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	## Past the staff wait, the music beat's two waits and the two names' wait.
+	_spend(credits, Gen2Credits.CYCLE_FRAMES * 11)
+	var map: PackedInt32Array = credits.bg_map()
+	var row: int = Gen2Credits.TEXT_TOP_ROW + Gen2Credits.TEXT_LINE_SPACING
+	assert_eq(
+		_cell(map, Gen2Credits.COPYRIGHT_COLUMN, row), RomLayout.COPYRIGHT_FIRST_CODE
+	)
+	assert_eq(
+		_cell(map, Gen2Credits.COPYRIGHT_COLUMN, row + Gen2Credits.TEXT_LINE_SPACING),
+		RomLayout.COPYRIGHT_FIRST_CODE + 2,
+		"and its <NEXT> keeps that column"
+	)
+
+
+## `CREDITS_WAIT2` leaves `hBGMapMode` off, so the batch it closes is written to
+## the tilemap and never copied to the BG map.
+func test_a_wait2_batch_is_written_and_never_shown() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	## The staff batch, then the one holding `CREDITS_MUSIC` and `CREDITS_WAIT2`.
+	_spend(credits, Gen2Credits.CYCLE_FRAMES * (FIRST_WAIT + 1) + 1)
+	var row: int = Gen2Credits.TEXT_TOP_ROW + Gen2Credits.TEXT_LINE_SPACING
+	assert_eq(
+		_cell(credits.tilemap(), 0, row), Gen2Credits.BLANK_TILE,
+		"the tilemap has been cleared"
+	)
+	assert_ne(
+		_cell(credits.bg_map(), 0, row), Gen2Credits.BLANK_TILE,
+		"and the staff batch is still on screen"
+	)
+
+
+## `.end` clears the text region and returns without turning the copy back on,
+## which is the whole reason "The End" stays up.
+func test_the_end_survives_the_clear_in_front_of_credits_end() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	_spend(credits, Gen2Credits.CYCLE_FRAMES * 40)
+	assert_true(credits.finished())
+	assert_eq(
+		_cell(credits.bg_map(), Gen2Credits.THE_END_AT.x, Gen2Credits.THE_END_AT.y),
+		Gen2Credits.THE_END_TILE
+	)
+	assert_eq(
+		_cell(credits.tilemap(), Gen2Credits.THE_END_AT.x, Gen2Credits.THE_END_AT.y),
+		Gen2Credits.BLANK_TILE,
+		"and the tilemap under it was cleared"
+	)
+
+
+## `Credits_LoadBorderGFX` draws the frame the counter holds and steps it
+## afterwards, and `.init` neither draws nor steps while the banner is cleared.
+func test_the_banner_steps_once_per_graphics_request() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	_spend(credits, Gen2Credits.CYCLE_FRAMES)
+	assert_eq(credits.banner_block(), -1, "CREDITS_CLEAR holds it blank")
+
+	## Past the two names' `CREDITS_SCENE, 1`, which is the fixture's own scene.
+	_spend(credits, Gen2Credits.CYCLE_FRAMES * 7)
+	var blocks: Array = []
+	for _cycle: int in 3:
+		_spend(credits, Gen2Credits.CYCLE_FRAMES)
+		blocks.append(credits.banner_block())
+	assert_eq(blocks.size(), 3)
+	assert_ne(blocks[0], blocks[1], "and it is a different frame each cycle")
+
+
+## Crystal requests graphics twice a cycle and Gold and Silver once, so the same
+## number of cycles walks the banner twice as far on Crystal.
+func test_crystal_steps_the_banner_twice_a_cycle() -> void:
+	assert_eq(Gen2Credits.GFX_STEPS.size(), 2)
+	assert_eq(Gen2Credits.GFX_STEPS_GOLD_SILVER.size(), 1)
+
+
+## `Credits_LYOverride`'s `dec a / dec a`, which Gold and Silver replace with
+## `inc a / inc a`. It is a byte, so Crystal's first step wraps.
+func test_the_border_scroll_walks_two_pixels_a_cycle_each_way() -> void:
+	var crystal: Gen2Credits = Gen2Credits.create(_data)
+	_spend(crystal, Gen2Credits.CYCLE_FRAMES)
+	assert_eq(crystal.scroll(), 0xFE)
+
+	var gold: Gen2Credits = Gen2Credits.create(_gold())
+	_spend(gold, Gen2Credits.CYCLE_FRAMES)
+	assert_eq(gold.scroll(), 2)
+
+
+## `.music`'s two `PlayMusic` calls, which the screen hands to the overworld's
+## own player, and `.end`'s fade into MUSIC_POST_CREDITS.
+func test_the_script_asks_for_its_music_and_fades_into_the_next() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	var events: Array = _spend(credits, Gen2Credits.CYCLE_FRAMES * 40)
+	var kinds: Array = []
+	for event: Dictionary in events:
+		kinds.append([StringName(event["type"]), int(event["music"])])
+	assert_eq(kinds, [
+		[&"music_requested", Gen2Credits.MUSIC_CREDITS],
+		[&"music_fade_requested", Gen2Credits.MUSIC_POST_CREDITS],
+	])
+
+
+## `Credits_HandleBButton`, which refuses until the script has passed its header
+## and refuses entirely without STATUSFLAGS_HALL_OF_FAME_F.
+func test_b_only_skips_on_a_replay_and_only_past_the_header() -> void:
+	var first: Gen2Credits = Gen2Credits.create(_data, false)
+	_spend(first, Gen2Credits.CYCLE_FRAMES * 2, [Gen2Button.B])
+	assert_eq(first.timer(), FIRST_WAIT - 1, "an unskippable run spends one tick a cycle")
+
+	var replay: Gen2Credits = Gen2Credits.create(_data, true)
+	_spend(replay, 1, [Gen2Button.B])
+	assert_lt(
+		replay.position(), Gen2Credits.SKIP_FROM_POSITION,
+		"the header is still under the skip's own position"
+	)
+	assert_eq(replay.timer(), FIRST_WAIT, "so nothing was burned yet")
+
+	_spend(replay, Gen2Credits.CYCLE_FRAMES * 7, [Gen2Button.B])
+	assert_gt(replay.position(), Gen2Credits.SKIP_FROM_POSITION)
+	var standing: int = replay.timer()
+	_spend(replay, 2, [Gen2Button.B])
+	assert_eq(replay.timer(), standing - 2, "and past it a held B burns a tick a frame")
+
+
+## `Credits_HandleAButton` tests JUMPTABLE_EXIT_F, so A does nothing until the
+## script has run out.
+func test_a_only_leaves_once_the_script_has_run_out() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	assert_false(credits.may_finish([Gen2Button.A]))
+	_spend(credits, Gen2Credits.CYCLE_FRAMES * 40)
+	assert_true(credits.finished())
+	assert_false(credits.may_finish([]), "and it is a held button, not a state")
+	assert_true(credits.may_finish([Gen2Button.A]))
+
+
+## The page resolves a banner tile through `.Frames`' block rather than through
+## the strip's own position, which is what makes one sheet four animations.
+func test_the_page_draws_the_banner_out_of_the_block_the_frame_names() -> void:
+	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(_data)
+	assert_true(page.ready())
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	var map: PackedInt32Array = credits.bg_map()
+	for block: int in [0, 1, 2]:
+		var indices: PackedByteArray = page.compose(map, block)
+		assert_eq(
+			indices[0], block % Fixture.CREDITS_BLOCK_INDEXES,
+			"block %d draws its own tiles" % block
+		)
+	assert_eq(
+		page.compose(map, -1)[0], Gen2Credits.BLANK_FRAME_INDEX,
+		"and a cleared banner is the solid frame, not an empty cell"
+	)
+
+
+## `GetCreditsPalette`'s Gold and Silver branch blacks out the last colour of the
+## slot the border and the text share, which is the one the font's ink lands on.
+func test_gold_blacks_out_the_text_slots_last_colour() -> void:
+	var gold: GameData = _gold()
+	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(gold)
+	var border: PackedColorArray = page.palette(gold, 0, Gen2Credits.PALETTE_BORDER)
+	assert_eq(border[RomLayout.CREDITS_PALETTE_COLORS - 1], Color.BLACK)
+	assert_ne(
+		page.palette(gold, 0, Gen2Credits.PALETTE_BANNER)[
+			RomLayout.CREDITS_PALETTE_COLORS - 1
+		],
+		Color.BLACK,
+		"and the banner keeps its own"
+	)
+
+	var crystal_page: Gen2CreditsPage = Gen2CreditsPage.from_data(_data)
+	assert_ne(
+		crystal_page.palette(_data, 0, Gen2Credits.PALETTE_BORDER)[
+			RomLayout.CREDITS_PALETTE_COLORS - 1
+		],
+		Color.BLACK,
+		"and Crystal's three palettes are left alone"
+	)
+
+
+## `hLCDCPointer` is LOW(rSCX) and `Credits_LYOverride` fills only the two border
+## bands, so nothing else on the screen moves with it.
+func test_only_the_border_rows_are_scrolled() -> void:
+	var credits: Gen2Credits = Gen2Credits.create(_data)
+	assert_eq(credits.scroll_rows(), [
+		Gen2Credits.BORDER_TOP_ROW, Gen2Credits.BORDER_BOTTOM_ROW,
+	])
+	assert_eq(
+		Gen2Credits.create(_gold()).scroll_rows(),
+		[Gen2Credits.BORDER_TOP_ROW, Gen2Credits.BORDER_BOTTOM_ROW_GOLD_SILVER]
+	)

--- a/tests/integration/test_credits.gd.uid
+++ b/tests/integration/test_credits.gd.uid
@@ -1,0 +1,1 @@
+uid://d136n1oddueig

--- a/tests/integration/test_world_credits_screen.gd
+++ b/tests/integration/test_world_credits_screen.gd
@@ -1,0 +1,136 @@
+extends GutTest
+
+## Scene integration for the credits: the overlay `credits` opens, the input it
+## blocks while it runs, the two held buttons it reads and the induction that
+## ends into it. Driven through the production world screen.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const PLAYER_CELL: Vector2i = Vector2i(2, 2)
+## `Script_credits` is Crystal $a2, one past `halloffame`.
+const CREDITS_COMMAND: int = 0xA2
+const SCRIPT_ADDRESS: int = 0x7000
+## Long enough for the fixture script to reach `CREDITS_END`.
+const WHOLE_SCRIPT_FRAMES: int = Gen2Credits.CYCLE_FRAMES * 40
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+
+
+func after_each() -> void:
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+func _open_world() -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = PLAYER_CELL
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, Gen2WorldState.new()
+	)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	save.world = world.snapshot()
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+
+
+func _host() -> Gen2CreditsScreen:
+	return _world_screen._credits_host
+
+
+## `Script_credits` farcalls `RedCredits` and falls into `Script_endall`, so the
+## overlay opens off the drained results the way `halloffame`'s does.
+func test_the_credits_command_opens_the_overlay() -> void:
+	await _open_world()
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts["%d:7000" % Fixture.BANK] = [CREDITS_COMMAND, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+	_data = GameData.open_directory(directory)
+
+	var world: Gen2WorldAPI = _world_screen._world
+	world.data = _data
+	world.current_map.events["coord_events"][0]["script"] = SCRIPT_ADDRESS
+	world.player_cell = Vector2i(
+		int(world.current_map.events["coord_events"][0]["x"]),
+		int(world.current_map.events["coord_events"][0]["y"])
+	)
+	_world_screen._show_script_results(world.dispatch_script_events())
+	await get_tree().process_frame
+
+	assert_not_null(_host())
+	assert_false(_host().credits().finished())
+
+
+## The overlay hides the map, so the overworld must not move under it.
+func test_the_overworld_does_not_move_while_the_credits_run() -> void:
+	await _open_world()
+	_world_screen.open_credits()
+	await get_tree().process_frame
+	var before: Vector2i = _world_screen._world.player_cell
+	assert_false(_world_screen.move_player(Vector2i.DOWN))
+	assert_false(_world_screen.interact())
+	assert_eq(_world_screen._world.player_cell, before)
+
+
+## `Credits_HandleAButton` tests JUMPTABLE_EXIT_F first, so A is swallowed until
+## the script has run out and then leaves.
+func test_a_leaves_only_once_the_script_has_run_out() -> void:
+	await _open_world()
+	_world_screen.open_credits()
+	await get_tree().process_frame
+	_world_screen.press_button(Gen2Button.A)
+	assert_not_null(_host(), "and the press is still swallowed rather than refused")
+	_world_screen._credits_host.release_button(Gen2Button.A)
+
+	_host().advance_frames(WHOLE_SCRIPT_FRAMES)
+	assert_true(_host().credits().finished())
+	_world_screen.press_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_null(_host())
+	assert_true(_world_screen.move_player(Vector2i.DOWN))
+
+
+## Both of `.execution_loop`'s buttons are held states, so the world screen has
+## to hand the overlay the release as well as the press.
+func test_a_release_reaches_the_overlay() -> void:
+	await _open_world()
+	_world_screen.open_credits(true)
+	await get_tree().process_frame
+	_world_screen.press_button(Gen2Button.B)
+	## Past the header, which is the only place `Credits_HandleBButton` skips.
+	_host().advance_frames(Gen2Credits.CYCLE_FRAMES * 8)
+	var skipped: int = _host().credits().timer()
+	_host().advance_frames(1)
+	assert_lt(_host().credits().timer(), skipped, "B is burning the wait down")
+
+	_host().release_button(Gen2Button.B)
+	var standing: int = _host().credits().timer()
+	_host().advance_frames(1)
+	assert_eq(_host().credits().timer(), standing, "and letting go stops it")
+
+
+## `HallOfFame` calls `AnimateHallOfFame` and then `farcall Credits`, so the
+## induction ends into them; it pushes `wStatusFlags` before setting the Hall of
+## Fame bit, so that pair is never skippable.
+func test_the_hall_of_fame_runs_into_unskippable_credits() -> void:
+	await _open_world()
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	while _world_screen._hall_of_fame_host != null:
+		_world_screen._hall_of_fame_host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_not_null(_host())
+	assert_false(_host().credits().skippable())

--- a/tests/integration/test_world_credits_screen.gd.uid
+++ b/tests/integration/test_world_credits_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://4ynhu34psnsq

--- a/tests/integration/test_world_hall_of_fame_screen.gd
+++ b/tests/integration/test_world_hall_of_fame_screen.gd
@@ -86,6 +86,13 @@ func test_a_key_walks_the_pages_and_the_last_one_closes_the_overlay() -> void:
 	_advance_to_the_end()
 	await get_tree().process_frame
 	assert_null(_world_screen._hall_of_fame_host)
+	## `AnimateHallOfFame` is followed by `farcall Credits`, so the induction ends
+	## into them rather than back onto the map.
+	assert_not_null(_world_screen._credits_host)
+	assert_false(_world_screen.move_player(Vector2i.DOWN))
+
+	_world_screen._credits_host.close()
+	await get_tree().process_frame
 	assert_true(_world_screen.move_player(Vector2i.DOWN))
 
 

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -48,6 +48,17 @@ const OAK_THRESHOLDS: Array[int] = [
 	239, 248, 255,
 ]
 const OAK_FIRST_SFX: int = 40
+## The fixture's `CreditsStringsPointers`: two names, the copyright and the
+## heading, which is the smallest table `ParseCredits`' two branches both need.
+const CREDITS_NAME_A: int = 0
+const CREDITS_NAME_B: int = 1
+const CREDITS_COPYRIGHT: int = 2
+const CREDITS_STAFF: int = 3
+const CREDITS_STRING_COUNT: int = 4
+## The banner strip is filled so a tile's index is the block it belongs to,
+## modulo the four an index can hold, which is how a page test says which frame
+## is on screen.
+const CREDITS_BLOCK_INDEXES: int = 4
 ## The fixture ships one trainer class, numbered 1, holding one trainer.
 const TRAINER_CLASS: int = 1
 const TRAINER_SPECIES: int = 16
@@ -75,6 +86,7 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_battle_graphics(directory, manifest)
 	_write_splash_graphics(directory, manifest, game_id == RomRegistry.CRYSTAL)
 	_write_menu_text(manifest)
+	_write_credits(directory, manifest, crystal_commands)
 	_write_name_input_chars(directory)
 	_write_intro_text(directory, crystal_commands)
 	manifest["game_id"] = String(game_id)
@@ -358,6 +370,97 @@ static func _write_menu_text(manifest: Dictionary) -> void:
 		"toss_ask_quantity": "Throw away <NUM_D009>\n<RAM_CF7E>(S)?",
 		"toss_threw": "Threw away\n<RAM_CF7E>(S).",
 	}
+
+
+## A short `CreditsScript` reaching every command, its four strings, the four
+## scene palettes and `Credits_LoadBorderGFX.Frames`. The two profiles differ the
+## way the cartridges do: Crystal gives a scene three palettes and sixteen banner
+## blocks, Gold and Silver one palette and thirteen.
+static func _write_credits(
+	directory: String, manifest: Dictionary, crystal: bool
+) -> void:
+	var frames: Array = []
+	if crystal:
+		for block: int in RomLayout.CREDITS_SCENES * RomLayout.CREDITS_SCENE_FRAMES:
+			frames.append(block)
+	else:
+		for scene: int in RomLayout.CREDITS_SCENES - 1:
+			frames.append_array([scene * 3, scene * 3 + 1, scene * 3, scene * 3 + 2])
+		frames.append_array([9, 10, 11, 12])
+	## `GetCreditsPalette.UpdatePals` copies 24 bytes on Crystal and 8 twice on
+	## the other two, which is three palettes against one.
+	var scene_palettes: int = 3 if crystal else 1
+	var palettes: Array = []
+	for colour: int in RomLayout.CREDITS_SCENES * scene_palettes \
+		* RomLayout.CREDITS_PALETTE_COLORS:
+		palettes.append(0x0400 * (colour % 4) + colour)
+	manifest["credits"] = {
+		"script": [
+			RomLayout.CREDITS_CLEAR,
+			CREDITS_STAFF, 1,
+			RomLayout.CREDITS_WAIT, 2,
+			RomLayout.CREDITS_MUSIC,
+			RomLayout.CREDITS_WAIT2, 1,
+			RomLayout.CREDITS_WAIT, 1,
+			RomLayout.CREDITS_SCENE, 1,
+			CREDITS_NAME_A, 0,
+			CREDITS_NAME_B, 2,
+			RomLayout.CREDITS_WAIT, 2,
+			CREDITS_COPYRIGHT, 1,
+			RomLayout.CREDITS_WAIT, 1,
+			RomLayout.CREDITS_THEEND,
+			RomLayout.CREDITS_WAIT, 1,
+			RomLayout.CREDITS_END,
+		],
+		"strings": [
+			[0x80, 0x81, 0x82],
+			[0x83, 0x84],
+			## The copyright is the one string drawn out of `CopyrightGFX` and
+			## the one printed from column 2.
+			[
+				RomLayout.COPYRIGHT_FIRST_CODE, RomLayout.COPYRIGHT_FIRST_CODE + 1,
+				Gen2Credits.CODE_NEXT_LINE,
+				RomLayout.COPYRIGHT_FIRST_CODE + 2,
+			],
+			## `#` and a `<NEXT>`, which are the two things `PlaceString` does
+			## that placing a code does not.
+			[Gen2Credits.CODE_POKE, 0x85, Gen2Credits.CODE_NEXT_LINE, 0x86],
+		],
+		"staff": CREDITS_STAFF,
+		"copyright": CREDITS_COPYRIGHT,
+		"scene_palettes": scene_palettes,
+		"palettes": palettes,
+		"frames": frames,
+	}
+	var sheets: Dictionary = manifest.get("tiles", {})
+	var blocks: int = int(frames.max()) + 1
+	for entry: Array in [
+		["credits_border", RomLayout.CREDITS_BORDER_TILES, RomLayout.CREDITS_BORDER_FIRST_CODE],
+		["credits_the_end", RomLayout.CREDITS_THE_END_TILES, RomLayout.CREDITS_THE_END_FIRST_CODE],
+		["credits_mons", blocks * RomLayout.CREDITS_MON_FRAME_TILES, 0],
+	]:
+		var count: int = int(entry[1])
+		var indices := PackedByteArray()
+		indices.resize(count * Gen2Tiles.TILE_PIXELS)
+		for tile: int in count:
+			@warning_ignore("integer_division")
+			var block: int = tile / RomLayout.CREDITS_MON_FRAME_TILES
+			var index: int = block % CREDITS_BLOCK_INDEXES if entry[0] == "credits_mons" else 2
+			for pixel: int in Gen2Tiles.TILE_PIXELS:
+				## The strips are strips, so a tile's pixels are a column of the
+				## row rather than a run of it.
+				var y: int = pixel / Gen2Tiles.TILE_WIDTH
+				indices[y * count * Gen2Tiles.TILE_WIDTH
+					+ tile * Gen2Tiles.TILE_WIDTH + pixel % Gen2Tiles.TILE_WIDTH] = index
+		RomCache.write_indices(RomCache.tile_path(directory, String(entry[0])), indices)
+		sheets[String(entry[0])] = {
+			"width": count * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": count,
+			"first_code": int(entry[2]),
+			"bits": 2,
+		}
+	manifest["tiles"] = sheets
 
 
 ## `GameFreakLogoGFX` and whichever object sheet the profile carries, as flat

--- a/tools/preview_credits.gd
+++ b/tools/preview_credits.gd
@@ -1,0 +1,136 @@
+extends SceneTree
+
+## Captures the credits against a real imported cache, one source frame at a
+## time.
+##
+##   Godot --headless --path . -s res://tools/preview_credits.gd -- crystal /tmp/c.png [frame] [live]
+##
+## [frame] is how many source frames to spend before the shot. A `CREDITS_WAIT`
+## tick is thirteen frames, so the batches land a long way apart; several frames
+## separated by `;` write one file each, numbered. A frame suffixed `b` holds B
+## down for it, which is the skip a replay allows.
+##
+## `live` drives the production world screen's own overlay instead of the page
+## directly, which is what says `open_credits` reaches it. One frame only, since
+## the screen owns its own clock.
+##
+## Headless either way: the page draws into an [Image] rather than through a
+## viewport, so no window and no settle are needed.
+
+var _screen: Gen2WorldScreen = null
+var _output_path: String = ""
+var _frames: int = 0
+var _spent: int = 0
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_credits.gd -- <game> <output.png> [frame;frame;...] [live]")
+		quit(1)
+		return
+
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var held: bool = false
+	var frames: Array = []
+	for step: String in (args[2] if args.size() > 2 else "0").split(";", false):
+		var text: String = step.strip_edges()
+		if text.ends_with("b"):
+			held = true
+			text = text.substr(0, text.length() - 1)
+		frames.append(maxi(int(text), 0))
+	frames.sort()
+
+	_output_path = args[1]
+	if args.size() > 3 and args[3] == "live":
+		_spent = int(frames[frames.size() - 1])
+		_open_world(data)
+		return
+
+	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(data)
+	var credits: Gen2Credits = Gen2Credits.create(data, true)
+	if page == null or not page.ready() or credits == null:
+		push_error("The %s cache holds no credits." % args[0])
+		quit(1)
+		return
+
+	var buttons: Array = [Gen2Button.B] if held else []
+	var spent: int = 0
+	for wanted: int in frames:
+		while spent < wanted:
+			credits.advance_frame(buttons)
+			spent += 1
+		var path: String = args[1]
+		if frames.size() > 1:
+			path = "%s-%d.%s" % [args[1].get_basename(), wanted, args[1].get_extension()]
+		if not _write(page.image(data, credits.frame_state()), path):
+			return
+		print("frame %d, scene %d, block %d, scroll %d, pos %d, timer %d%s" % [
+			wanted, credits.scene(), credits.banner_block(), credits.scroll(),
+			credits.position(), credits.timer(), ", finished" if credits.finished() else "",
+		])
+	quit(0)
+
+
+## The live path: a real world screen at the new game's own spawn, with
+## `open_credits` doing what `Script_credits` does to it.
+func _open_world(data: GameData) -> void:
+	var spawn: Gen2WorldSnapshot = Gen2WorldSpawn.new_game_snapshot(data)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if spawn == null or save == null:
+		push_error("Missing new-game spawn or development save")
+		quit(1)
+		return
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_screen = packed.instantiate() as Gen2WorldScreen
+	_screen.map_group = spawn.map_id.x
+	_screen.map_number = spawn.map_id.y
+	_screen.start_cell = spawn.player_cell
+	save.world = spawn
+	_screen.set_data(data)
+	_screen.set_save(save)
+	root.add_child(_screen)
+	current_scene = _screen
+
+
+func _process(_delta: float) -> bool:
+	if _screen == null:
+		return true
+	_frames += 1
+	if _frames < 2:
+		return false
+	_screen.open_credits()
+	var host: Gen2CreditsScreen = _screen._credits_host
+	if host == null:
+		push_error("open_credits() reached no overlay")
+		quit(1)
+		return true
+	host.advance_frames(_spent)
+	if not _write(host.render(), _output_path):
+		return true
+	print("live frame %d, %s" % [
+		_spent, "finished" if host.credits().finished() else "running",
+	])
+	## `quit` from inside `_process` would leave the screen standing, so its own
+	## teardown never runs.
+	current_scene = null
+	root.remove_child(_screen)
+	_screen.free()
+	_screen = null
+	quit(0)
+	return true
+
+
+func _write(image: Image, path: String) -> bool:
+	var error: Error = image.save_png(path)
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [path, error])
+		quit(1)
+		return false
+	print("Wrote %s" % path)
+	return true

--- a/tools/preview_credits.gd.uid
+++ b/tools/preview_credits.gd.uid
@@ -1,0 +1,1 @@
+uid://bjc8jgwu1iglc

--- a/tools/validate_credits.gd
+++ b/tools/validate_credits.gd
@@ -1,0 +1,194 @@
+extends SceneTree
+
+## Verifies the credits against freshly imported real caches, for both command
+## profiles.
+##
+## The whole script is run to `CREDITS_END` rather than sampled: every command it
+## carries, every string it names and every scene it selects is exercised once,
+## which is the sweep tests/integration/test_credits.gd's four-string fixture
+## cannot be. The expected values come from pokecrystal and pokegold's
+## engine/movie/credits.asm, data/credits_script.asm and credits_strings.asm.
+##
+##   Godot --headless --path . -s res://tools/validate_credits.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+
+## Long enough for either script, whose own totals are pinned below.
+const FRAME_CAP: int = 20000
+
+## Census of the real caches, pinned so a cache change is loud: the frames the
+## script takes to reach `CREDITS_END`, how many strings the table holds, and how
+## many frames the BG map changes on, which is three per `CREDITS_WAIT` batch
+## since `UpdateBGMap` copies it a third at a time.
+const EXPECTED: Dictionary = {
+	# game id: [frames to CREDITS_END, strings in the table, frames the BG map moves]
+	&"gold": [6956, 76, 55],
+	&"silver": [6956, 76, 55],
+	&"crystal": [6982, 103, 83],
+}
+
+## `PlaceString`'s own vocabulary in these strings: a space, `<NEXT>`, `#` and
+## the letters. Anything else is `CopyrightGFX`'s and belongs to one string.
+const SPACE_CODE: int = 0x7F
+const FIRST_LETTER: int = 0x80
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_strings(game_id, data)
+		_verify_palettes_and_frames(game_id, data)
+		_run(game_id, data)
+	_finish()
+
+
+## Every string in the table, whose codes have to be ones the screen can draw:
+## the font's, `<NEXT>`, `#`, or `CopyrightGFX`'s, which only the copyright
+## string is allowed to name.
+func _verify_strings(game_id: StringName, data: GameData) -> void:
+	var copyright: int = data.credits_index("copyright")
+	var count: int = 0
+	while not data.credits_string(count).is_empty():
+		count += 1
+	_check(
+		count == int(EXPECTED[game_id][1]),
+		"%s: %d credits strings decode, not the pinned %d." % [
+			game_id, count, int(EXPECTED[game_id][1]),
+		]
+	)
+	for index: int in count:
+		for code: int in data.credits_string(index):
+			if code >= FIRST_LETTER or code == SPACE_CODE \
+				or code == Gen2Credits.CODE_NEXT_LINE or code == Gen2Credits.CODE_POKE:
+				continue
+			_check(
+				index == copyright and code >= RomLayout.COPYRIGHT_FIRST_CODE,
+				"%s: credits string %d carries code $%02X, which is not a glyph." % [
+					game_id, index, code,
+				]
+			)
+
+
+## The four scenes' palettes and `Credits_LoadBorderGFX.Frames`, every entry of
+## which has to name a block the imported mon run actually holds.
+func _verify_palettes_and_frames(game_id: StringName, data: GameData) -> void:
+	var strip: PackedByteArray = data.tile_indices("credits_mons")
+	var blocks: int = 0
+	if not strip.is_empty():
+		@warning_ignore("integer_division")
+		blocks = strip.size() / Gen2Tiles.TILE_HEIGHT / Gen2Tiles.TILE_WIDTH \
+			/ RomLayout.CREDITS_MON_FRAME_TILES
+	for scene: int in RomLayout.CREDITS_SCENES:
+		for slot: int in [
+			Gen2Credits.PALETTE_BANNER, Gen2Credits.PALETTE_BORDER, Gen2Credits.PALETTE_TEXT,
+		]:
+			_check(
+				data.credits_palette(scene, slot).size() \
+					== RomLayout.CREDITS_PALETTE_COLORS,
+				"%s: credits scene %d has no palette in slot %d." % [game_id, scene, slot]
+			)
+		for frame: int in RomLayout.CREDITS_SCENE_FRAMES:
+			var block: int = data.credits_frame_block(scene, frame)
+			_check(
+				block >= 0 and block < blocks,
+				"%s: credits scene %d frame %d names block %d of %d." % [
+					game_id, scene, frame, block, blocks,
+				]
+			)
+
+
+## The whole script, frame by frame through the real page. Every batch it draws
+## is checked for staying inside the text region, and the run has to reach
+## `CREDITS_END` on the pinned frame with "The End" still on the BG map.
+func _run(game_id: StringName, data: GameData) -> void:
+	var page: Gen2CreditsPage = Gen2CreditsPage.from_data(data)
+	if page == null or not page.ready():
+		_fail("%s: the cache carries no credits graphics." % game_id)
+		return
+	var credits: Gen2Credits = Gen2Credits.create(data, true)
+	if credits == null:
+		_fail("%s: the cache carries no credits script." % game_id)
+		return
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	var bottom: int = Gen2Credits.BORDER_BOTTOM_ROW if crystal \
+		else Gen2Credits.BORDER_BOTTOM_ROW_GOLD_SILVER
+	var batches: int = 0
+	var frames: int = 0
+	var previous := PackedInt32Array()
+	while frames < FRAME_CAP and not credits.finished():
+		credits.advance_frame()
+		frames += 1
+		var map: PackedInt32Array = credits.bg_map()
+		if map != previous:
+			previous = map
+			batches += 1
+			_verify_region(game_id, map, bottom)
+	_check(
+		frames == int(EXPECTED[game_id][0]),
+		"%s: the credits ran %d frames to CREDITS_END, not the pinned %d." % [
+			game_id, frames, int(EXPECTED[game_id][0]),
+		]
+	)
+	_check(
+		batches == int(EXPECTED[game_id][2]),
+		"%s: the BG map moved on %d frames, not the pinned %d." % [
+			game_id, batches, int(EXPECTED[game_id][2]),
+		]
+	)
+	var the_end: Vector2i = Gen2Credits.THE_END_AT if crystal \
+		else Gen2Credits.THE_END_AT_GOLD_SILVER
+	_check(
+		credits.bg_map()[the_end.y * Gen2Credits.COLUMNS + the_end.x] \
+			== Gen2Credits.THE_END_TILE,
+		"%s: The End is not on screen when the script ends." % game_id
+	)
+	## The live path, not the model: a page that cannot resolve a tile the script
+	## placed draws a hole rather than failing.
+	var image: Image = page.image(data, credits.frame_state())
+	_check(
+		image.get_width() == Gen2Screen.WIDTH and image.get_height() == Gen2Screen.HEIGHT,
+		"%s: the credits page did not draw a hardware screen." % game_id
+	)
+
+
+## `.parse` fills rows 5 to the lower border, and nothing it prints may reach
+## either band: a string longer than the region would run into the border, which
+## `PlaceString` has no clip to stop.
+func _verify_region(game_id: StringName, map: PackedInt32Array, bottom: int) -> void:
+	for column: int in Gen2Credits.COLUMNS:
+		var within: int = column % Gen2Credits.BORDER_TILES
+		_check(
+			map[Gen2Credits.BORDER_TOP_ROW * Gen2Credits.COLUMNS + column] \
+				== Gen2Credits.BORDER_TOP_TILE + within,
+			"%s: the credits text reached the upper border band." % game_id
+		)
+		_check(
+			map[bottom * Gen2Credits.COLUMNS + column] \
+				== Gen2Credits.BORDER_BOTTOM_TILE + within,
+			"%s: the credits text reached the lower border band." % game_id
+		)
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS credits: the strings, the palettes, the frames and both scripts verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_credits.gd.uid
+++ b/tools/validate_credits.gd.uid
@@ -1,0 +1,1 @@
+uid://ds6ef83rj1f6b


### PR DESCRIPTION
`credits_requested` was emitted by the script runner and answered by nothing, so
Red's script ran to `end` with the screen blank. This is the screen behind it.

## The state machine

`Credits` and `ParseCredits` (`engine/movie/credits.asm`) are ported whole
rather than approximated:

- `Credits_Jumptable` runs one entry per frame and loops back after thirteen, so
  a `CREDITS_WAIT` tick is thirteen frames and not one.
- `Credits_UpdateGFXRequestPath` steps the banner's frame twice a cycle on
  Crystal and once on Gold and Silver, and `Credits_LoadBorderGFX` draws the
  frame the counter holds before stepping it.
- `Credits_LYOverride` walks the two border bands sideways two pixels a cycle,
  down on Crystal and up on the other two.
- The screen owns a tilemap and a BG map, because `.parse` writes the next batch
  with `hBGMapMode` off and only `CREDITS_WAIT` turns the copy back on. A
  `CREDITS_WAIT2` batch is written and never shown, and "The End" stays up
  because the clear in front of `CREDITS_END` is never pushed.
- Both of `.execution_loop`'s buttons are held states: A leaves only once the
  script has run out, and B burns a tick of the current wait per frame, only
  past the header and only on a replay.

`HallOfFame` calls `AnimateHallOfFame` and then `farcall Credits`, so the
induction ends into them; it pushes `wStatusFlags` before setting its own bit,
so that pair is never skippable however many times it has been seen.

## Import

`CreditsScript`, every `CreditsStringsPointers` entry as the tile codes it is,
the four scene palettes, the border strip, "The End" and the four mons the
banner animates. One pinned graphics offset locates all five runs: the border
and the four sheets are contiguous, the run's own length pins the script and the
script's terminator pins the string table. The string the copyright index names
has to be the copyright screen's own, which the layout pins separately in
another bank, so the two check each other. Cache format 48, which means
re-importing all three cartridges.

## Divergence

The hardware samples the two border bands out of a BG map 256 pixels wide, of
which the credits only ever write the leftmost 160; the page wraps within the
160 it has. The band is a four-tile pattern repeated, so both wraps land on the
same 32-pixel phase.

## Proof

- GUT 2,777 tests over 146 scripts, green (was 2,755 over 144).
- `tools/validate_credits.gd`: both whole scripts run frame by frame to
  `CREDITS_END` on all three cartridges, with every string, palette and
  `.Frames` block checked and nothing printed reaching either border band.
  38 of 39 `validate_*` pass; `validate_clickable` needs a display.
- `tools/preview_credits.gd <game> <png> [frame;frame] [live]`, headless, with a
  `live` mode that drives the production world screen's own overlay.
- `replay_world.gd` 27 routes, 0 failures; the three-profile story walk still
  reaches Red with 16 badges on 294, 291 and 291 steps.