### PR TITLE
world: the intro movie, ported scene by scene from CrystalIntro

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ to check without writing.
 | Font and borders | 128 glyphs and eight six-tile text-box frames |
 | Splash screen | The copyright graphic and its tile-code string, `GameFreakLogoGFX`'s two words and logo, Gold and Silver's star and sparkles, Crystal's compressed Ditto sheet, and the three palettes the three are drawn through |
 | Title screen | Crystal's Suicune strip, logo and crystal with its sixteen palettes; Gold and Silver's two logo halves, their `$FF`-terminated tilemap, the trail and the Ho-Oh or Lugia behind it, and both palette runs |
+| Intro movie | Crystal only: the thirty-five entries of `CrystalIntro`'s art section, which is the Unown, pulse, panorama, Pichu/Wooper, grass and four Suicune sheets, their four BG maps with attribute planes, five sixteen-palette runs, and the fade and Unown palettes inside the code |
 | Region map | The Pokegear's three graphics sheets, the Fast Ship's icon and the dex's nest marker, both region tilemaps, the per-tile palette map and its six palettes, and the ninety-six landmarks with their coordinates and names |
 | Prof Oak's PC | The nineteen `OakRatings` rows, each a caught-count threshold, the sound it plays and the rating it prints, and the four texts around them |
 | Credits | `CreditsScript`'s whole command stream, every name and heading it prints, the four scene palettes, the border strip, "The End" and the four mons the banner animates |
@@ -171,6 +172,7 @@ cannot produce a save the game will not load. A new game opens on the
 cartridge's own splash: the copyright screen for the hundred and ten frames
 `SplashScreen` gives it, then the GameFreak animation, which is Crystal's
 bouncing Ditto turning into the logo or Gold and Silver's star and sparkles, then
+on Crystal the twenty-eight-scene intro movie, then
 the title screen, and then the gender question and Oak's speech; it starts with an empty
 party at the Crystal home spawn with source starting money, and Elm's imported
 lab scripts offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry.
@@ -323,6 +325,7 @@ all three games unless its row says otherwise:
 | `preview_prof_oaks_pc.gd <game> [caught]` | Prof Oak's PC against a real cache: every rating band and both its ends, or the three pages `ProfOaksPCBoot` shows for one owned count |
 | `preview_town_map.gd <game> <png> [landmark] [town_map\|card\|area:<species>] [presses]` | the region map against a real cache: the Johto or Kanto map the landmark picks, `_TownMap`'s corner box, the Pokegear card's icon row or the dex's `<MON>'S NEST` screen, and the cursor after a `u,d,b` press list. `hof` in that list opens the whole Kanto window rather than the Victory Road one, `sel` and `rel` hold and release the dex area's SELECT, and `f<n>` spends n frames, which is what the nest blink is caught with |
 | `preview_hall_of_fame.gd <game> <png> [page]` | the Hall of Fame induction panel against a real cache, ending on the player's own with Prof Oak's rating printed into it; `page` is how many panels to advance past |
+| `preview_intro_movie.gd <game> [png] [frame;frame]` | the intro movie at any source frame: the Unown fading in and bursting, the scrolling panorama with Suicune running across it, Wooper and Pichu in the rustling grass, the leap, the close-up, and C R Y S T A L spelled out in Unown. With no png it runs the whole movie and prints the frame each of the twenty-eight scenes starts on |
 | `preview_credits.gd <game> <png> [frame;frame]` | the credits at any source frame: the banner's four mons, the scrolling border bands, each batch of names on its own scene palette, the copyright and "The End". A `CREDITS_WAIT` tick is thirteen frames, so the batches land a long way apart; a frame suffixed `b` holds B down for the skip a replay allows |
 | `preview_battle_switch.gd <game> <png> [offer\|pick\|use_next\|replace] [presses]` | the boxes a battle switches through: `OfferSwitch`'s yes/no over the field under SHIFT, the party list behind it, `AskUseNextPokemon`'s wild question, and `ForcePlayerMonChoice`'s list after a faint. `presses` is a `u,d,l,r,a,b` list driven into the menu first, which is how a refusal is photographed |
 | `preview_world_story.gd` | map entry callbacks, event-flag visibility, facing interactions and the story route |
@@ -344,6 +347,7 @@ all three games unless its row says otherwise:
 | `validate_strength.gd` | the strength-boulder census and Cianwood Gym's corridor push |
 | `validate_battle_anims.gd` | all 278 battle animation scripts run to their own `anim_ret`, POUND command by command, both shapes of the profile split in TACKLE and BODY SLAM, the object, frameset and OAM tables, the sine table the motion callbacks scale with, the 39 graphics sheets, and every motion callback and background effect a real animation reaches |
 | `validate_town_map.gd` | the landmark tables and the one-landmark split `BATTLE TOWER` causes, both region tilemaps against `TownMapGFX`, the palette map and its two city palettes, the Johto and Kanto cursor windows either side of the Hall of Fame, all three frames composing, and every species' nests staying inside their own region and under shadow OAM's forty sprites |
+| `validate_intro_movie.gd` | every entry of the intro art section at the size the routine loading it asks VRAM for, every BG map cell naming a tile its own sheet holds and every attribute byte a palette its own run has, and the whole movie run frame by frame to `JUMPTABLE_EXIT_F`: the frame each scene starts on, every sound it asks for resolving on the cache, and no frame asking shadow OAM for more than forty sprites |
 | `validate_credits.gd` | every credits string decoding into codes the screen can draw, the four scene palettes and every `Credits_LoadBorderGFX.Frames` block, and both whole scripts run frame by frame to `CREDITS_END` with nothing printed reaching either border band |
 | `validate_tmhm.gd` | the TM/HM move table, the item-number mapping past its two dummy items, the seven moves an HM teaches, and the whole species compatibility census |
 | `validate_command_queues.gd` | the two `stonetable` command queues, their pit warps and boulders, and a real Blackthorn Gym 2F push firing its fall script |

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -58,6 +58,7 @@ var _title: Dictionary = {}
 var _town_map: Dictionary = {}
 var _oak_ratings: Dictionary = {}
 var _credits: Dictionary = {}
+var _intro_movie: Dictionary = {}
 var _menu_text: Dictionary = {}
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
@@ -134,6 +135,8 @@ static func open_directory(path: String) -> GameData:
 	data._oak_ratings = oak_ratings if oak_ratings is Dictionary else {}
 	var credits: Variant = manifest.get("credits", {})
 	data._credits = credits if credits is Dictionary else {}
+	var intro_movie: Variant = manifest.get("intro_movie", {})
+	data._intro_movie = intro_movie if intro_movie is Dictionary else {}
 	var menu_text: Variant = manifest.get("menu_text", {})
 	data._menu_text = menu_text if menu_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
@@ -1185,6 +1188,31 @@ func credits_string(index: int) -> PackedByteArray:
 ## string printed from column 2. -1 on a cache without the credits.
 func credits_index(name: String) -> int:
 	return int(_credits.get(name, -1))
+
+
+## Whether this cache carries `CrystalIntro`'s art. False on Gold and Silver,
+## which ship a different movie that is not imported.
+func has_intro_movie() -> bool:
+	return not (_intro_movie.get("maps", []) as Array).is_empty()
+
+
+## One of the intro movie's 32x32 BG maps or attribute planes, by the name
+## `RomLayout.INTRO_SECTION` gives it. Empty on a cache without the movie.
+func intro_map(name: String) -> PackedByteArray:
+	return tile_indices("intro_%s" % name)
+
+
+## One of the intro movie's palette runs, by the name
+## `RomLayout.INTRO_SECTION` gives it, plus `fade` and `unown`. Sixteen
+## palettes for a scene's own run, eight for the fade and two for the Unown.
+func intro_palette(name: String) -> PackedColorArray:
+	var stored: Variant = (_intro_movie.get("palettes", {}) as Dictionary).get(name, [])
+	var colors := PackedColorArray()
+	if not stored is Array:
+		return colors
+	for packed: Variant in stored as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
 
 
 ## `CreditsPalettes` for one scene: three palettes on Crystal (the banner, the

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -64,7 +64,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 48
+const FORMAT_VERSION: int = 49
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -308,6 +308,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not oak_ratings["ok"]:
 		return oak_ratings
 
+	var intro_movie: Dictionary = verify_intro_movie(rom, layout)
+	if not intro_movie["ok"]:
+		return intro_movie
+
 	var credits: Dictionary = verify_credits(rom, layout)
 	if not credits["ok"]:
 		return credits
@@ -1002,6 +1006,131 @@ static func read_oak_text(rom: RomFile, layout: Dictionary, stub: int) -> String
 	if not bool(decoded.get("ok", false)):
 		return ""
 	return String(decoded["text"])
+
+
+## `CrystalIntro`'s art section, walked whole from its one pinned address.
+##
+## Every entry is decompressed and its length checked against what the routine
+## that loads it asks VRAM for, then the next entry's address is that length
+## rounded up to [constant RomLayout.INTRO_ENTRY_ALIGN]. Thirty-five entries in a
+## row landing on their exact sizes is what says the address is right; a walk
+## that starts anywhere else fails inside the first two.
+##
+## Returns {name: PackedByteArray} in `INTRO_SECTION` order, or an empty
+## Dictionary if any entry does not decompress to its own size.
+static func read_intro_section(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("intro_movie", {})
+	var at: int = int(entry.get("section", -1))
+	if at < 0:
+		return {}
+	var lz := Gen2Lz.new()
+	var out: Dictionary = {}
+	for row: Array in RomLayout.INTRO_SECTION:
+		var name: String = String(row[0])
+		var kind: String = String(row[1])
+		var wanted: int = _intro_entry_bytes(kind, int(row[2]))
+		var raw: PackedByteArray = PackedByteArray()
+		var consumed: int = 0
+		if kind == "pal" or kind == "raw":
+			if not rom.in_bounds(at, wanted):
+				return {}
+			raw = rom.slice(at, wanted)
+			consumed = wanted
+		else:
+			raw = lz.decompress(rom.bytes(), at)
+			consumed = lz.consumed
+			if lz.failed or raw.size() != wanted:
+				return {}
+		out[name] = raw
+		at += _aligned(consumed, RomLayout.INTRO_ENTRY_ALIGN)
+	return out
+
+
+static func _intro_entry_bytes(kind: String, tiles: int) -> int:
+	match kind:
+		"map", "attr":
+			return RomLayout.INTRO_MAP_BYTES
+		"pal":
+			return RomLayout.INTRO_PALETTES * RomLayout.INTRO_PALETTE_COLORS \
+				* Gen2Palette.COLOR_BYTES
+		_:
+			return tiles * Gen2Tiles.TILE_BYTES
+
+
+static func _aligned(value: int, to: int) -> int:
+	return ((value + to - 1) / to) * to
+
+
+## The intro movie. The section walk above is most of the check; what is left is
+## content, and the two palette runs INCLUDEd inside the code rather than in it.
+##
+## `unown_1.pal` is byte-identical to the first palette of `fade.pal`, which is
+## the same "two INCLUDEs of one picture check each other" the copyright string
+## gives the credits: the two are pinned independently, so each confirms the
+## other's address for nothing.
+static func verify_intro_movie(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("intro_movie", {})
+	if entry.is_empty() or int(entry.get("section", -1)) < 0:
+		return {"ok": true, "message": "No intro movie on this cartridge."}
+
+	var section: Dictionary = read_intro_section(rom, layout)
+	if section.is_empty():
+		return {"ok": false, "message": "The intro movie section does not walk."}
+
+	# `IntroScene3` puts the background sheet's 128 tiles at `vTiles2`, which is
+	# where a BG tile number below $80 reads from, so no cell of its map may name
+	# a tile the sheet does not hold.
+	for cell: int in RomLayout.INTRO_MAP_BYTES:
+		if int((section["background_map"] as PackedByteArray)[cell]) >= 0x80:
+			return {
+				"ok": false,
+				"message": "The intro background map names a tile outside its sheet.",
+			}
+	# `IntroScene1` and `IntroScene26` both open on a cleared screen and fade the
+	# Unown in: the first eight palettes of the Unown run are black and of the
+	# crystal run white, which is what each scene fades away from.
+	var unown_check: Dictionary = _verify_intro_palette_run(
+		section["unowns_palette"], 0x0000, "Unown"
+	)
+	if not unown_check["ok"]:
+		return unown_check
+	var crystal_check: Dictionary = _verify_intro_palette_run(
+		section["crystal_unowns_palette"], 0x7FFF, "crystal Unown"
+	)
+	if not crystal_check["ok"]:
+		return crystal_check
+
+	var fade: int = int(entry.get("fade", -1))
+	var pals: int = int(entry.get("unown_pals", -1))
+	var fade_bytes: int = RomLayout.INTRO_FADE_PALETTES \
+		* RomLayout.INTRO_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
+	var pal_bytes: int = RomLayout.INTRO_UNOWN_PALETTES \
+		* RomLayout.INTRO_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
+	if not rom.in_bounds(fade, fade_bytes) or not rom.in_bounds(pals, pal_bytes):
+		return {"ok": false, "message": "The intro fade palettes are outside the cartridge."}
+	for colour: int in RomLayout.INTRO_PALETTE_COLORS:
+		var offset: int = colour * Gen2Palette.COLOR_BYTES
+		if rom.u16le(fade + offset) != rom.u16le(pals + offset):
+			return {
+				"ok": false,
+				"message": "The intro fade does not open on the first Unown palette.",
+			}
+	return {"ok": true, "message": "Intro movie verified."}
+
+
+## Eight palettes of one repeated colour, which is what a scene fades out of.
+static func _verify_intro_palette_run(
+	raw: PackedByteArray, colour: int, name: String
+) -> Dictionary:
+	var colors: int = RomLayout.INTRO_FADE_PALETTES * RomLayout.INTRO_PALETTE_COLORS
+	for index: int in colors:
+		var at: int = index * Gen2Palette.COLOR_BYTES
+		if raw[at] | (raw[at + 1] << 8) != colour:
+			return {
+				"ok": false,
+				"message": "The intro %s palettes do not open on one colour." % name,
+			}
+	return {"ok": true, "message": ""}
 
 
 ## The credits (`engine/movie/credits.asm`), whose five runs each pin the next.
@@ -3021,6 +3150,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"presents_palettes": _import_presents_palettes(rom, layout),
 		"title": _import_title(rom, layout),
 		"town_map": _import_town_map(rom, layout),
+		"intro_movie": _import_intro_movie(rom, layout),
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"credits": _import_credits(rom, layout),
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
@@ -3649,6 +3779,81 @@ func _import_copyright_palette(rom: RomFile, layout: Dictionary) -> Array:
 	return out
 
 
+## The intro movie's tile strips and its four BG maps with their attribute
+## planes, all out of one walk of the section.
+##
+## A map is a byte run keyed by a name, so it is written the way a strip is and
+## read back with `GameData.intro_map()`; it is not a sheet and gets no entry in
+## the manifest's tile table. `Intro_LoadTilemap` copies the top-left 20x18 of
+## one into `wTilemap`, which is why the whole 32x32 is kept rather than a
+## screen.
+func _import_intro_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_intro_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var out: Dictionary = {}
+	for row: Array in RomLayout.INTRO_SECTION:
+		var name: String = String(row[0])
+		var kind: String = String(row[1])
+		var raw: PackedByteArray = section[name]
+		var path: String = RomCache.tile_path(directory, "intro_%s" % name)
+		match kind:
+			"pal":
+				continue
+			"map", "attr":
+				if not RomCache.write_indices(path, raw):
+					return {}
+			_:
+				var tiles: int = int(row[2])
+				if not RomCache.write_indices(
+					path, Gen2Tiles.decode_2bpp_strip(raw, 0, tiles)
+				):
+					return {}
+				out["intro_%s" % name] = _strip_sheet_entry(tiles)
+	return out
+
+
+## The intro movie's palettes: the five sixteen-palette runs inside the section,
+## `Intro_Scene24_ApplyPaletteFade`'s eight and `Intro_Scene20_AppearUnown`'s
+## two, plus the names of the maps written beside the sheets.
+##
+## The fades `CrystalIntro_UnownFade` and `Intro_FadeUnownWordPals` run through
+## are `for hue, 32` tables the assembler generates, not cartridge data, so they
+## are computed in [Gen2IntroMovie] rather than imported.
+func _import_intro_movie(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_intro_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var entry: Dictionary = layout["intro_movie"]
+	var palettes: Dictionary = {}
+	var maps: Array = []
+	for row: Array in RomLayout.INTRO_SECTION:
+		var name: String = String(row[0])
+		match String(row[1]):
+			"pal":
+				palettes[name] = _unpacked_words(section[name])
+			"map", "attr":
+				maps.append(name)
+	palettes["fade"] = _packed_palette(
+		rom, int(entry["fade"]),
+		RomLayout.INTRO_FADE_PALETTES * RomLayout.INTRO_PALETTE_COLORS
+	)
+	palettes["unown"] = _packed_palette(
+		rom, int(entry["unown_pals"]),
+		RomLayout.INTRO_UNOWN_PALETTES * RomLayout.INTRO_PALETTE_COLORS
+	)
+	return {"palettes": palettes, "maps": maps}
+
+
+static func _unpacked_words(raw: PackedByteArray) -> Array:
+	var out: Array = []
+	for index: int in raw.size() / Gen2Palette.COLOR_BYTES:
+		var at: int = index * Gen2Palette.COLOR_BYTES
+		out.append(raw[at] | (raw[at + 1] << 8))
+	return out
+
+
 ## `ShrinkPlayer`'s two pictures, which are LZ runs rather than tile strips and
 ## are laid out by `PlaceGraphic` the way every 7x7 pic is: as one 56x56 buffer
 ## per picture, so a screen draws them the way it draws the player's own.
@@ -4134,6 +4339,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_ditto_sheet(rom, layout), true)
 	written.merge(_import_title_sheets(rom, layout), true)
 	written.merge(_import_town_map_sheets(rom, layout), true)
+	written.merge(_import_intro_sheets(rom, layout), true)
 	var done: int = 0
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -754,6 +754,78 @@ const CREDITS_PALETTE_LAST_COLOR: int = 0x1CE7
 const CREDITS_SCRIPT_MAX_BYTES: int = 1024
 const CREDITS_STRING_MAX_BYTES: int = 64
 
+## The intro movie (`CrystalIntro`, engine/movie/intro.asm).
+##
+## Every graphic, tilemap, attrmap and palette the movie draws is one contiguous
+## section behind the code, in the INCBIN order below, and each entry starts on a
+## sixteen-byte boundary from the first. So one pinned offset walks all
+## thirty-five: decompress an entry, round its length up to
+## [constant INTRO_ENTRY_ALIGN], and that is where the next one starts.
+const INTRO_ENTRY_ALIGN: int = 16
+## `IntroScene28`'s own count, which the movie ends on.
+const INTRO_SCENES: int = 28
+## The tilemaps and attrmaps are whole 32x32 BG maps, not screens.
+const INTRO_MAP_COLUMNS: int = 32
+const INTRO_MAP_ROWS: int = 32
+const INTRO_MAP_BYTES: int = INTRO_MAP_COLUMNS * INTRO_MAP_ROWS
+## Every `ld bc, 16 palettes` the movie copies into `wBGPals1`/`wBGPals2`.
+const INTRO_PALETTES: int = 16
+const INTRO_PALETTE_COLORS: int = 4
+## `Intro_Scene24_ApplyPaletteFade.FadePals` (gfx/intro/fade.pal): eight
+## palettes, one of which is copied over all eight BG palettes at a time.
+const INTRO_FADE_PALETTES: int = 8
+## `Intro_Scene20_AppearUnown`'s `.pal1` and `.pal2`, one palette each and
+## contiguous, so the first pins the second.
+const INTRO_UNOWN_PALETTES: int = 2
+## The section's entries, as (cache name, kind, tiles). `map` is a 32x32 BG map,
+## `attr` its attribute plane, `pal` a raw [constant INTRO_PALETTES] run and
+## `raw` uncompressed tiles; everything else is an LZ tile strip of that many
+## tiles. The order is `engine/movie/intro.asm`'s own INCBIN order and is what
+## the walk depends on.
+const INTRO_SECTION: Array[Array] = [
+	["suicune_run", "lz", 192],
+	["pichu_wooper", "lz", 128],
+	["background", "lz", 128],
+	["background_map", "map", 0],
+	["background_attr", "attr", 0],
+	["background_palette", "pal", 0],
+	["unowns", "lz", 128],
+	["pulse", "lz", 16],
+	["unown_a_map", "map", 0],
+	["unown_a_attr", "attr", 0],
+	["unown_hi_map", "map", 0],
+	["unown_hi_attr", "attr", 0],
+	["unowns_map", "map", 0],
+	["unowns_attr", "attr", 0],
+	["unowns_palette", "pal", 0],
+	["crystal_unowns", "lz", 32],
+	["crystal_unowns_map", "map", 0],
+	["crystal_unowns_attr", "attr", 0],
+	["crystal_unowns_palette", "pal", 0],
+	["suicune_close", "lz", 256],
+	["suicune_close_map", "map", 0],
+	["suicune_close_attr", "attr", 0],
+	["suicune_close_palette", "pal", 0],
+	["suicune_jump", "lz", 128],
+	["suicune_back", "lz", 128],
+	["suicune_jump_map", "map", 0],
+	["suicune_jump_attr", "attr", 0],
+	["suicune_back_map", "map", 0],
+	["suicune_back_attr", "attr", 0],
+	["suicune_palette", "pal", 0],
+	["unown_back", "lz", 48],
+	["grass_1", "raw", 4],
+	["grass_2", "raw", 4],
+	["grass_3", "raw", 4],
+	["grass_4", "raw", 1],
+]
+## `Intro_RustleGrass` swaps four tiles at `vTiles2 tile $09` between three of
+## the grass strips; `IntroScene15` and `IntroScene19` load the fourth as a
+## single sprite tile.
+const INTRO_GRASS_FIRST_TILE: int = 0x09
+## The blank the two Suicune scenes park in the sprite tile the dict points at.
+const INTRO_GRASS_BLANK: String = "grass_4"
+
 ## `OakRatings` (data/events/pokedex_ratings.asm): nineteen `rating` rows of a
 ## caught-count threshold, an sfx word and a text pointer, which `FindOakRating`
 ## walks until the count fits. The five texts around it are located from the
@@ -1292,6 +1364,10 @@ const GOLD_SILVER: Dictionary = {
 		"crystal": -1,
 		"palettes": -1,
 	},
+	# `GoldSilverIntro` is a different movie again (water, grass and fire rather
+	# than Unown and Suicune) and is not imported yet; see HANDOFF.md for the
+	# addresses its own section sits at.
+	"intro_movie": {"section": -1, "fade": -1, "unown_pals": -1},
 	"intro_player": {"pic_male": -1, "pic_female": -1},
 	"gender_screen": {"tile": -1, "palette": -1},
 	# `ShrinkPlayer`'s two intermediate pictures. Located from the routine's own
@@ -1583,6 +1659,14 @@ const CRYSTAL: Dictionary = {
 		"bg_palette": -1,
 		"ob_palette": -1,
 	},
+	# `CrystalIntro`'s art section. `IntroSuicuneRunGFX` is the only pinned
+	# address: the section is contiguous and sixteen-byte aligned, so the walk in
+	# `INTRO_SECTION` reaches the other thirty-four. Found by decompressing at
+	# every offset in the dump and keeping the one that produced the pinned
+	# gfx/intro/suicune_run.png exactly. `fade` and `unown_pals` are INCLUDEd
+	# inside the code rather than in that section; both are unique byte runs, and
+	# `unown_1.pal` pins `unown_2.pal` directly behind it.
+	"intro_movie": {"section": 0xE555D, "fade": 0xE519C, "unown_pals": 0xE538D},
 	# `engine/gfx/player_gfx.asm`: ChrisPic and KrisPic. Located by converting
 	# the pinned 56x56 PNGs with rgbgfx --columns and matching the full runs.
 	"intro_player": {"pic_male": 0x888A9, "pic_female": 0x88BB9},

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -1,0 +1,392 @@
+class_name Gen2IntroMoviePage
+extends RefCounted
+
+## The intro movie's screen, on the tile grid the hardware uses.
+##
+## [Gen2IntroMovie] owns the BG map, the attribute plane, the palettes, the
+## scroll and the sprite structs; this turns a tile number into pixels. The
+## split is the credits' and the title screen's.
+##
+## Two things here are not a plain tilemap draw:
+##
+## - The BG map is 32 tiles wide and wraps. `hSCX` and `hSCY` are bytes, the
+##   panorama scenes scroll past both edges, and `hLCDCPointer` = LOW(rSCX)
+##   gives every scanline its own `hSCX`, which is what
+##   `Intro_PerspectiveScrollBG` uses to run the grass and the trees at
+##   different speeds. So the screen is sampled scanline by scanline rather than
+##   blitted tile by tile.
+## - A BG tile number below $80 reads from `vTiles2` and $80 and up from
+##   `vTiles1`, which are two different sheets in the scenes that load both.
+##
+## An object is drawn through the palette its own `dbsprite` attribute names,
+## which is one of the eight a scene's palette run wrote past the background
+## buffer's end.
+##
+## Shadow OAM holds forty sprites and `UpdateAnimFrame` stops filling it at
+## `wShadowOAMEnd`, so a frame that asks for more loses the last of them rather
+## than growing. `IntroScene10` is the one frame that does: Wooper's sixteen and
+## Pichu's twenty-five come to forty-one, and Pichu's last tile is not drawn.
+
+const TILE: int = Gen2Tiles.TILE_WIDTH
+const WIDTH: int = Gen2Screen.WIDTH
+const HEIGHT: int = Gen2Screen.HEIGHT
+const MAP_COLUMNS: int = RomLayout.INTRO_MAP_COLUMNS
+const MAP_ROWS: int = RomLayout.INTRO_MAP_ROWS
+## The screen `Intro_LoadTilemap` copies into `wTilemap`, which is the part of
+## the BG map the two Suicune scenes rewrite in place.
+const COLUMNS: int = Gen2IntroMovie.COLUMNS
+const ROWS: int = Gen2IntroMovie.ROWS
+
+## Shadow OAM counts from (8, 16).
+const OAM_ORIGIN := Vector2i(8, 16)
+## A sprite never draws its first colour.
+const TRANSPARENT_INDEX: int = 0
+## `Intro_RustleGrass` writes its four tiles at `vTiles2 tile $09`.
+const GRASS_FIRST_TILE: int = RomLayout.INTRO_GRASS_FIRST_TILE
+const GRASS_TILES: int = 4
+## Where a BG tile number stops reading from the low sheet and starts reading
+## from the one at `vTiles1`.
+const HIGH_TILE: int = 0x80
+
+## `wShadowOAM`, which is forty `SPRITEOAMSTRUCT`s and no more.
+const SHADOW_OAM_SPRITES: int = 40
+
+## `dbsprite`'s attribute byte.
+const ATTR_PALETTE: int = 0x07
+const ATTR_BANK1: int = 0x08
+const ATTR_XFLIP: int = 0x20
+const ATTR_YFLIP: int = 0x40
+
+const OAM_SETS: Array[Dictionary] = [
+	# 0: SPRITE_ANIM_OAMSET_INTRO_SUICUNE_1 (.OAMData_IntroSuicune1, 36 sprites)
+	{"vtile": 0x00, "parts": [
+		[-24, 8, 0x05, 0x00], [-24, 16, 0x06, 0x00], [-24, 24, 0x07, 0x00],
+		[-16, -24, 0x11, 0x00], [-16, -16, 0x12, 0x00], [-16, -8, 0x13, 0x00],
+		[-16, 0, 0x14, 0x00], [-16, 8, 0x15, 0x00], [-16, 16, 0x16, 0x00],
+		[-16, 24, 0x17, 0x00], [-8, -32, 0x20, 0x00], [-8, -24, 0x21, 0x00],
+		[-8, -16, 0x22, 0x00], [-8, -8, 0x23, 0x00], [-8, 0, 0x24, 0x00],
+		[-8, 8, 0x25, 0x00], [-8, 16, 0x26, 0x00], [-8, 24, 0x27, 0x00],
+		[0, -32, 0x30, 0x00], [0, -24, 0x31, 0x00], [0, -16, 0x32, 0x00],
+		[0, -8, 0x33, 0x00], [0, 0, 0x34, 0x00], [0, 8, 0x35, 0x00], [0, 16, 0x36, 0x00],
+		[8, -32, 0x40, 0x00], [8, -24, 0x41, 0x00], [8, -16, 0x42, 0x00],
+		[8, -8, 0x43, 0x00], [8, 0, 0x44, 0x00], [8, 8, 0x45, 0x00], [8, 16, 0x46, 0x00],
+		[8, 24, 0x47, 0x00], [16, -32, 0x50, 0x00], [16, -24, 0x51, 0x00],
+		[16, 24, 0x57, 0x00]
+	]},
+	# 1: SPRITE_ANIM_OAMSET_INTRO_SUICUNE_2 (.OAMData_IntroSuicune2, 28 sprites)
+	{"vtile": 0x08, "parts": [
+		[-24, 0, 0x04, 0x00], [-24, 8, 0x05, 0x00], [-24, 16, 0x06, 0x00],
+		[-16, -24, 0x11, 0x00], [-16, -16, 0x12, 0x00], [-16, -8, 0x13, 0x00],
+		[-16, 0, 0x14, 0x00], [-16, 8, 0x15, 0x00], [-16, 16, 0x16, 0x00],
+		[-8, -24, 0x21, 0x00], [-8, -16, 0x22, 0x00], [-8, -8, 0x23, 0x00],
+		[-8, 0, 0x24, 0x00], [-8, 8, 0x25, 0x00], [-8, 16, 0x26, 0x00],
+		[0, -32, 0x30, 0x00], [0, -24, 0x31, 0x00], [0, -16, 0x32, 0x00],
+		[0, -8, 0x33, 0x00], [0, 0, 0x34, 0x00], [0, 8, 0x35, 0x00], [8, -16, 0x42, 0x00],
+		[8, -8, 0x43, 0x00], [8, 0, 0x44, 0x00], [8, 8, 0x45, 0x00], [16, -8, 0x53, 0x00],
+		[16, 0, 0x54, 0x00], [16, 8, 0x55, 0x00]
+	]},
+	# 2: SPRITE_ANIM_OAMSET_INTRO_SUICUNE_3 (.OAMData_IntroSuicune3, 30 sprites)
+	{"vtile": 0x60, "parts": [
+		[-24, 0, 0x04, 0x00], [-24, 8, 0x05, 0x00], [-16, -24, 0x11, 0x00],
+		[-16, -16, 0x12, 0x00], [-16, -8, 0x13, 0x00], [-16, 0, 0x14, 0x00],
+		[-16, 8, 0x15, 0x00], [-16, 16, 0x16, 0x00], [-16, 24, 0x17, 0x00],
+		[-8, -32, 0x20, 0x00], [-8, -24, 0x21, 0x00], [-8, -16, 0x22, 0x00],
+		[-8, -8, 0x23, 0x00], [-8, 0, 0x24, 0x00], [-8, 8, 0x25, 0x00],
+		[-8, 16, 0x26, 0x00], [0, -32, 0x30, 0x00], [0, -24, 0x31, 0x00],
+		[0, -16, 0x32, 0x00], [0, -8, 0x33, 0x00], [0, 0, 0x34, 0x00], [0, 8, 0x35, 0x00],
+		[8, -16, 0x42, 0x00], [8, -8, 0x43, 0x00], [8, 0, 0x44, 0x00], [8, 8, 0x45, 0x00],
+		[16, -16, 0x52, 0x00], [16, -8, 0x53, 0x00], [16, 0, 0x54, 0x00],
+		[16, 8, 0x55, 0x00]
+	]},
+	# 3: SPRITE_ANIM_OAMSET_INTRO_SUICUNE_4 (.OAMData_IntroSuicune4, 31 sprites)
+	{"vtile": 0x68, "parts": [
+		[-16, -24, 0x11, 0x00], [-16, -16, 0x12, 0x00], [-16, -8, 0x13, 0x00],
+		[-16, 0, 0x14, 0x00], [-16, 8, 0x15, 0x00], [-16, 16, 0x16, 0x00],
+		[-16, 24, 0x17, 0x00], [-8, -32, 0x20, 0x00], [-8, -24, 0x21, 0x00],
+		[-8, -16, 0x22, 0x00], [-8, -8, 0x23, 0x00], [-8, 0, 0x24, 0x00],
+		[-8, 8, 0x25, 0x00], [-8, 16, 0x26, 0x00], [-8, 24, 0x27, 0x00],
+		[0, -32, 0x30, 0x00], [0, -24, 0x31, 0x00], [0, -16, 0x32, 0x00],
+		[0, -8, 0x33, 0x00], [0, 0, 0x34, 0x00], [0, 8, 0x35, 0x00], [0, 16, 0x36, 0x00],
+		[8, -24, 0x41, 0x00], [8, -16, 0x42, 0x00], [8, -8, 0x43, 0x00],
+		[8, 0, 0x44, 0x00], [8, 8, 0x45, 0x00], [16, -24, 0x51, 0x00],
+		[16, -16, 0x52, 0x00], [16, 0, 0x54, 0x00], [16, 8, 0x55, 0x00]
+	]},
+	# 4: SPRITE_ANIM_OAMSET_INTRO_PICHU_1 (.OAMData_IntroPichu, 25 sprites)
+	{"vtile": 0x00, "parts": [
+		[-20, -20, 0x00, 0x09], [-20, -12, 0x01, 0x09], [-20, -4, 0x02, 0x09],
+		[-20, 4, 0x03, 0x09], [-20, 12, 0x04, 0x09], [-12, -20, 0x10, 0x09],
+		[-12, -12, 0x11, 0x09], [-12, -4, 0x12, 0x09], [-12, 4, 0x13, 0x09],
+		[-12, 12, 0x14, 0x09], [-4, -20, 0x20, 0x09], [-4, -12, 0x21, 0x09],
+		[-4, -4, 0x22, 0x09], [-4, 4, 0x23, 0x09], [-4, 12, 0x24, 0x09],
+		[4, -20, 0x30, 0x09], [4, -12, 0x31, 0x09], [4, -4, 0x32, 0x09],
+		[4, 4, 0x33, 0x09], [4, 12, 0x34, 0x09], [12, -20, 0x40, 0x09],
+		[12, -12, 0x41, 0x09], [12, -4, 0x42, 0x09], [12, 4, 0x43, 0x09],
+		[12, 12, 0x44, 0x09]
+	]},
+	# 5: SPRITE_ANIM_OAMSET_INTRO_PICHU_2 (.OAMData_IntroPichu, 25 sprites)
+	{"vtile": 0x05, "parts": [
+		[-20, -20, 0x00, 0x09], [-20, -12, 0x01, 0x09], [-20, -4, 0x02, 0x09],
+		[-20, 4, 0x03, 0x09], [-20, 12, 0x04, 0x09], [-12, -20, 0x10, 0x09],
+		[-12, -12, 0x11, 0x09], [-12, -4, 0x12, 0x09], [-12, 4, 0x13, 0x09],
+		[-12, 12, 0x14, 0x09], [-4, -20, 0x20, 0x09], [-4, -12, 0x21, 0x09],
+		[-4, -4, 0x22, 0x09], [-4, 4, 0x23, 0x09], [-4, 12, 0x24, 0x09],
+		[4, -20, 0x30, 0x09], [4, -12, 0x31, 0x09], [4, -4, 0x32, 0x09],
+		[4, 4, 0x33, 0x09], [4, 12, 0x34, 0x09], [12, -20, 0x40, 0x09],
+		[12, -12, 0x41, 0x09], [12, -4, 0x42, 0x09], [12, 4, 0x43, 0x09],
+		[12, 12, 0x44, 0x09]
+	]},
+	# 6: SPRITE_ANIM_OAMSET_INTRO_PICHU_3 (.OAMData_IntroPichu, 25 sprites)
+	{"vtile": 0x0A, "parts": [
+		[-20, -20, 0x00, 0x09], [-20, -12, 0x01, 0x09], [-20, -4, 0x02, 0x09],
+		[-20, 4, 0x03, 0x09], [-20, 12, 0x04, 0x09], [-12, -20, 0x10, 0x09],
+		[-12, -12, 0x11, 0x09], [-12, -4, 0x12, 0x09], [-12, 4, 0x13, 0x09],
+		[-12, 12, 0x14, 0x09], [-4, -20, 0x20, 0x09], [-4, -12, 0x21, 0x09],
+		[-4, -4, 0x22, 0x09], [-4, 4, 0x23, 0x09], [-4, 12, 0x24, 0x09],
+		[4, -20, 0x30, 0x09], [4, -12, 0x31, 0x09], [4, -4, 0x32, 0x09],
+		[4, 4, 0x33, 0x09], [4, 12, 0x34, 0x09], [12, -20, 0x40, 0x09],
+		[12, -12, 0x41, 0x09], [12, -4, 0x42, 0x09], [12, 4, 0x43, 0x09],
+		[12, 12, 0x44, 0x09]
+	]},
+	# 7: SPRITE_ANIM_OAMSET_INTRO_WOOPER (.OAMData_IntroWooper, 16 sprites)
+	{"vtile": 0x50, "parts": [
+		[-16, -20, 0x00, 0x0A], [-16, -12, 0x01, 0x0A], [-16, -4, 0x02, 0x0A],
+		[-16, 4, 0x03, 0x0A], [-8, -20, 0x04, 0x0A], [-8, -12, 0x05, 0x0A],
+		[-8, -4, 0x06, 0x0A], [-8, 4, 0x07, 0x0A], [0, -20, 0x08, 0x0A],
+		[0, -12, 0x09, 0x0A], [0, -4, 0x0A, 0x0A], [0, 4, 0x0B, 0x0A],
+		[8, -20, 0x0C, 0x0A], [8, -12, 0x0D, 0x0A], [8, -4, 0x0E, 0x0A],
+		[8, 4, 0x0F, 0x0A]
+	]},
+	# 8: SPRITE_ANIM_OAMSET_INTRO_UNOWN_1 (.OAMData_IntroUnown1, 1 sprites)
+	{"vtile": 0x00, "parts": [
+		[-4, -4, 0x00, 0x00]
+	]},
+	# 9: SPRITE_ANIM_OAMSET_INTRO_UNOWN_2 (.OAMData_IntroUnown2, 3 sprites)
+	{"vtile": 0x01, "parts": [
+		[0, -8, 0x00, 0x00], [-8, -8, 0x01, 0x00], [-8, 0, 0x02, 0x00]
+	]},
+	# 10: SPRITE_ANIM_OAMSET_INTRO_UNOWN_3 (.OAMData_IntroUnown3, 7 sprites)
+	{"vtile": 0x04, "parts": [
+		[8, -16, 0x00, 0x00], [0, -16, 0x01, 0x00], [-8, -16, 0x02, 0x00],
+		[-8, -8, 0x03, 0x00], [-16, -8, 0x04, 0x00], [-16, 0, 0x05, 0x00],
+		[-16, 8, 0x06, 0x00]
+	]},
+	# 11: SPRITE_ANIM_OAMSET_INTRO_UNOWN_F_2_1 (.OAMData_IntroUnownF2_1, 4 sprites)
+	{"vtile": 0x00, "parts": [
+		[-8, -8, 0x00, 0x00], [-8, 0, 0x00, 0x20], [0, -8, 0x00, 0x40], [0, 0, 0x00, 0x60]
+	]},
+	# 12: SPRITE_ANIM_OAMSET_INTRO_UNOWN_F_2_2 (.OAMData_IntroUnownF2_2, 8 sprites)
+	{"vtile": 0x01, "parts": [
+		[-8, -16, 0x00, 0x00], [-8, -8, 0x01, 0x00], [-8, 0, 0x01, 0x20],
+		[-8, 8, 0x00, 0x20], [0, -16, 0x00, 0x40], [0, -8, 0x01, 0x40], [0, 0, 0x01, 0x60],
+		[0, 8, 0x00, 0x60]
+	]},
+	# 13: SPRITE_ANIM_OAMSET_INTRO_UNOWN_F_2_3 (.OAMData_IntroUnownF2_3, 12 sprites)
+	{"vtile": 0x03, "parts": [
+		[-24, -8, 0x00, 0x00], [-16, -8, 0x01, 0x00], [-8, -8, 0x02, 0x00],
+		[-24, 0, 0x00, 0x20], [-16, 0, 0x01, 0x20], [-8, 0, 0x02, 0x20],
+		[0, -8, 0x02, 0x40], [8, -8, 0x01, 0x40], [16, -8, 0x00, 0x40], [0, 0, 0x02, 0x60],
+		[8, 0, 0x01, 0x60], [16, 0, 0x00, 0x60]
+	]},
+	# 14: SPRITE_ANIM_OAMSET_INTRO_UNOWN_F_2_4 (.OAMData_IntroUnownF2_4_5, 20 sprites)
+	{"vtile": 0x08, "parts": [
+		[-20, -16, 0x00, 0x00], [-20, -8, 0x01, 0x00], [-20, 0, 0x02, 0x00],
+		[-20, 8, 0x03, 0x00], [-12, -16, 0x04, 0x00], [-12, -8, 0x05, 0x00],
+		[-12, 0, 0x06, 0x00], [-12, 8, 0x07, 0x00], [-4, -16, 0x08, 0x00],
+		[-4, -8, 0x09, 0x00], [-4, 0, 0x0A, 0x00], [-4, 8, 0x0B, 0x00],
+		[4, -16, 0x0C, 0x00], [4, -8, 0x0D, 0x00], [4, 0, 0x0E, 0x00], [4, 8, 0x0F, 0x00],
+		[12, -16, 0x10, 0x00], [12, -8, 0x11, 0x00], [12, 0, 0x12, 0x00],
+		[12, 8, 0x13, 0x00]
+	]},
+	# 15: SPRITE_ANIM_OAMSET_INTRO_UNOWN_F_2_5 (.OAMData_IntroUnownF2_4_5, 20 sprites)
+	{"vtile": 0x1C, "parts": [
+		[-20, -16, 0x00, 0x00], [-20, -8, 0x01, 0x00], [-20, 0, 0x02, 0x00],
+		[-20, 8, 0x03, 0x00], [-12, -16, 0x04, 0x00], [-12, -8, 0x05, 0x00],
+		[-12, 0, 0x06, 0x00], [-12, 8, 0x07, 0x00], [-4, -16, 0x08, 0x00],
+		[-4, -8, 0x09, 0x00], [-4, 0, 0x0A, 0x00], [-4, 8, 0x0B, 0x00],
+		[4, -16, 0x0C, 0x00], [4, -8, 0x0D, 0x00], [4, 0, 0x0E, 0x00], [4, 8, 0x0F, 0x00],
+		[12, -16, 0x10, 0x00], [12, -8, 0x11, 0x00], [12, 0, 0x12, 0x00],
+		[12, 8, 0x13, 0x00]
+	]},
+	# 16: SPRITE_ANIM_OAMSET_INTRO_SUICUNE_AWAY (.OAMData_IntroSuicuneAway, 20 sprites)
+	{"vtile": 0x80, "parts": [
+		[0, 8, 0x00, 0x81], [8, 16, 0x00, 0x81], [16, 24, 0x00, 0x81],
+		[24, 32, 0x00, 0x81], [32, 40, 0x00, 0x81], [24, 48, 0x00, 0x81],
+		[16, 56, 0x00, 0x81], [8, 64, 0x00, 0x81], [0, 72, 0x00, 0x81],
+		[8, 80, 0x00, 0x81], [16, 88, 0x00, 0x81], [24, 96, 0x00, 0x81],
+		[32, 104, 0x00, 0x81], [24, 112, 0x00, 0x81], [16, 120, 0x00, 0x81],
+		[8, -128, 0x00, 0x81], [0, -120, 0x00, 0x81], [8, -112, 0x00, 0x81],
+		[16, -104, 0x00, 0x81], [24, -96, 0x00, 0x81]
+	]},
+]
+
+
+var _data: GameData = null
+## One tile-index strip per sheet name, read once.
+var _sheets: Dictionary = {}
+
+
+## Null on a cache without the intro movie's art, which is the caller's cue to
+## skip the phase rather than to run it blank.
+static func from_data(data: GameData) -> Gen2IntroMoviePage:
+	if data == null or not data.has_intro_movie():
+		return null
+	var out := Gen2IntroMoviePage.new()
+	out._data = data
+	return out
+
+
+## The whole 160x144 screen for one frame of [param movie].
+func draw(movie: Gen2IntroMovie) -> Image:
+	var image := Image.create(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
+	if movie == null:
+		return image
+	_draw_background(image, movie)
+	var room: int = SHADOW_OAM_SPRITES
+	for sprite: Dictionary in movie.sprites():
+		room -= _draw_sprite(image, movie, sprite, room)
+		if room <= 0:
+			break
+	return image
+
+
+## The BG map, sampled through `hSCY` and the scanline's own `hSCX`. Both are
+## bytes and the map is 256 pixels square, so the sampling wraps rather than
+## clipping.
+func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
+	var map: PackedByteArray = movie.bg_map()
+	var attr: PackedByteArray = movie.bg_attr()
+	if map.size() < RomLayout.INTRO_MAP_BYTES:
+		return
+	var screen: PackedByteArray = movie.screen_tilemap()
+	var palettes: Array[PackedColorArray] = []
+	for slot: int in Gen2IntroMovie.BG_PALETTES:
+		palettes.append(movie.palette(slot))
+	var low: PackedByteArray = _sheet(movie, movie.sheet("bg"))
+	var low_first: int = movie.sheet_first_tile("bg")
+	var high: PackedByteArray = _sheet(movie, movie.sheet("bg_high"))
+	var high_first: int = movie.sheet_first_tile("bg_high")
+	var grass: PackedByteArray = _sheet(movie, movie.grass_sheet())
+	var scy: int = movie.scroll().y
+	for y: int in HEIGHT:
+		var scx: int = movie.scroll_x_at(y)
+		var map_y: int = (y + scy) & 0xFF
+		var row: int = (map_y / TILE) % MAP_ROWS
+		var in_tile_y: int = map_y % TILE
+		for x: int in WIDTH:
+			var map_x: int = (x + scx) & 0xFF
+			var column: int = (map_x / TILE) % MAP_COLUMNS
+			var cell: int = row * MAP_COLUMNS + column
+			var tile: int = map[cell]
+			# `hBGMapMode` 1 pushes `wTilemap` over the map's own top-left
+			# screen, which is the only part `Intro_ColoredSuicuneFrameSwap`
+			# changes.
+			if not screen.is_empty() and column < COLUMNS and row < ROWS:
+				tile = screen[row * COLUMNS + column]
+			var byte: int = attr[cell] if cell < attr.size() else 0
+			var strip: PackedByteArray = low
+			var index: int = tile + low_first
+			if tile >= HIGH_TILE:
+				strip = high
+				index = tile - HIGH_TILE + high_first
+			elif tile >= GRASS_FIRST_TILE and tile < GRASS_FIRST_TILE + GRASS_TILES \
+					and not grass.is_empty():
+				strip = grass
+				index = tile - GRASS_FIRST_TILE
+			var palette: PackedColorArray = palettes[byte & ATTR_PALETTE]
+			if palette.is_empty():
+				continue
+			var pixel: int = _pixel(
+				strip, index, map_x % TILE, in_tile_y,
+				bool(byte & ATTR_XFLIP), bool(byte & ATTR_YFLIP)
+			)
+			image.set_pixel(x, y, palette[pixel])
+
+
+## One sprite-anim struct's whole OAM set. Every position is worked out as a
+## byte and then clipped, because `UpdateAnimFrame` builds them with `add`: an
+## offset past the screen wraps rather than clamping.
+## Returns how many shadow-OAM entries it took, which is what the next struct has
+## fewer of.
+func _draw_sprite(
+	image: Image, movie: Gen2IntroMovie, sprite: Dictionary, room: int
+) -> int:
+	var set: Dictionary = OAM_SETS[int(sprite["set"])] if int(sprite["set"]) < OAM_SETS.size() \
+		else {}
+	if set.is_empty():
+		return 0
+	var parts: Array = (set["parts"] as Array).slice(0, room)
+	var strip: PackedByteArray = _sheet(
+		movie, movie.sheet("obj_bank1" if bool(sprite["bank1"]) else "obj")
+	)
+	if strip.is_empty():
+		return parts.size()
+	var at: Vector2i = sprite["at"]
+	var flip_x: bool = bool(sprite["flip_x"])
+	var flip_y: bool = bool(sprite["flip_y"])
+	for part: Array in parts:
+		var dy: int = int(part[0])
+		var dx: int = int(part[1])
+		var attrs: int = int(part[3])
+		var part_x: bool = bool(attrs & ATTR_XFLIP) != flip_x
+		var part_y: bool = bool(attrs & ATTR_YFLIP) != flip_y
+		# `AddOrSubtractX`/`_Y`: a flipped frameset turns a part's own offset
+		# into -8 - offset before it is added.
+		if flip_x:
+			dx = -TILE - dx
+		if flip_y:
+			dy = -TILE - dy
+		var tile: int = (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF
+		var palette: PackedColorArray = movie.object_palette(attrs & ATTR_PALETTE)
+		if palette.size() <= TRANSPARENT_INDEX:
+			continue
+		_blit_sprite_tile(
+			image, strip, palette, tile,
+			Vector2i(
+				((at.x + dx) & 0xFF) - OAM_ORIGIN.x,
+				((at.y + dy) & 0xFF) - OAM_ORIGIN.y,
+			),
+			part_x, part_y
+		)
+	return parts.size()
+
+
+func _blit_sprite_tile(
+	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
+	at: Vector2i, flip_x: bool, flip_y: bool
+) -> void:
+	for row: int in TILE:
+		var y: int = at.y + row
+		if y < 0 or y >= HEIGHT:
+			continue
+		for column: int in TILE:
+			var x: int = at.x + column
+			if x < 0 or x >= WIDTH:
+				continue
+			var pixel: int = _pixel(strip, tile, column, row, flip_x, flip_y)
+			if pixel == TRANSPARENT_INDEX:
+				continue
+			image.set_pixel(x, y, palette[pixel])
+
+
+## One pixel of a tile in a horizontal strip of tile indices.
+func _pixel(
+	strip: PackedByteArray, tile: int, x: int, y: int, flip_x: bool, flip_y: bool
+) -> int:
+	if strip.is_empty():
+		return 0
+	var width: int = strip.size() / TILE
+	var column: int = tile * TILE + ((TILE - 1 - x) if flip_x else x)
+	var row: int = (TILE - 1 - y) if flip_y else y
+	if column < 0 or column >= width:
+		return 0
+	return strip[row * width + column]
+
+
+func _sheet(movie: Gen2IntroMovie, name: String) -> PackedByteArray:
+	if name.is_empty() or _data == null:
+		return PackedByteArray()
+	if _sheets.has(name):
+		return _sheets[name]
+	var strip: PackedByteArray = _data.tile_indices("intro_%s" % name)
+	_sheets[name] = strip
+	return strip

--- a/game/render/intro_movie_page.gd.uid
+++ b/game/render/intro_movie_page.gd.uid
@@ -1,0 +1,1 @@
+uid://62tnrlyij0e7

--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -12,7 +12,6 @@ extends RefCounted
 const FRAME_RATE: float = 59.7275
 const COPYRIGHT_PRELUDE_FRAMES: int = 10
 const COPYRIGHT_HOLD_FRAMES: int = 100
-const INTRO_TOTAL_FRAMES: int = 2335
 
 const PHASE_COPYRIGHT: StringName = &"copyright"
 const PHASE_PRESENTS: StringName = &"presents"
@@ -30,9 +29,10 @@ var _profile: StringName = &"gold"
 var _phase: StringName = &""
 var _frame: int = 0
 var _phase_frame: int = 0
-var _intro_scene: int = 0
-var _intro_scene_frame: int = 0
-var _intro_scene_lengths: Array[int] = []
+## `CrystalIntro`'s own state while the movie phase is up, null outside it.
+var _movie: Gen2IntroMovie = null
+## The cache the movie reads its art out of, handed in by the host.
+var _data: GameData = null
 ## `GameFreakPresentsScene` and the sprite beside it, which own every frame of
 ## the presents phase. Null until that phase is entered.
 var _presents: Gen2GameFreakPresents = null
@@ -53,15 +53,16 @@ var _available: Array[StringName] = []
 ## every phase, which is a host with the whole opening imported.
 func start(
 	profile: StringName = &"gold",
-	intro_scene_lengths: Array[int] = [],
+	data: GameData = null,
 	available: Array[StringName] = [],
 	sine: Gen2BattleAnimData = null,
 ) -> void:
 	_profile = profile
 	_sine = sine
+	_data = data
 	_presents = null
 	_title = null
-	_intro_scene_lengths = _validated_intro_lengths(intro_scene_lengths)
+	_movie = null
 	_available = available.duplicate()
 	if not is_available(PHASE_COPYRIGHT):
 		_phase = PHASE_COPYRIGHT
@@ -74,8 +75,6 @@ func start(
 	_phase = PHASE_COPYRIGHT
 	_frame = 0
 	_phase_frame = 0
-	_intro_scene = 0
-	_intro_scene_frame = 0
 	_waiting_sound = &""
 	_events.clear()
 	_emit(&"play_music", {"music": &"none", "restart": true})
@@ -101,7 +100,13 @@ func phase_frame() -> int:
 
 
 func intro_scene() -> int:
-	return _intro_scene
+	return _movie.scene() if _movie != null else 0
+
+
+## The live movie, so a host can read the screen it is drawing. Null outside the
+## intro phase.
+func movie() -> Gen2IntroMovie:
+	return _movie
 
 
 func waiting_sound() -> StringName:
@@ -154,7 +159,7 @@ func _advance_title(held: Array) -> void:
 			# `IntroSequence`, which is the whole opening again. The restart runs
 			# first because [method start] empties the queue, and its own
 			# `play_music none` is the fade landing.
-			start(_profile, _intro_scene_lengths, _available, _sine)
+			start(_profile, _data, _available, _sine)
 			_emit(&"restart_opening", {"profile": _profile})
 		Gen2TitleScene.OPTION_DELETE_SAVE_DATA, Gen2TitleScene.OPTION_RESET_CLOCK:
 			_emit(&"title_chord", {
@@ -250,23 +255,23 @@ func skip_presents() -> bool:
 	return _presents != null and _presents.cancel()
 
 
+## The movie spends whatever `CrystalIntro` spends: the sequence is asked for a
+## frame and the phase ends when its jumptable sets `JUMPTABLE_EXIT_F`.
 func _advance_intro() -> void:
-	_intro_scene_frame += 1
-	if _intro_scene >= _intro_scene_lengths.size():
-		return
-	if _intro_scene_frame < _intro_scene_lengths[_intro_scene]:
-		_emit(&"intro_frame", {
-			"scene": _intro_scene,
-			"frame": _intro_scene_frame,
-			"total_frame": _phase_frame,
-		})
-		return
-	_intro_scene += 1
-	_intro_scene_frame = 0
-	if _intro_scene >= _intro_scene_lengths.size():
+	if _movie == null:
 		_enter_after(PHASE_INTRO_MOVIE)
-	else:
-		_emit(&"show_image", {"id": &"intro_scene", "scene": _intro_scene})
+		return
+	var scene: int = _movie.scene()
+	for event: Dictionary in _movie.advance_frame():
+		var values: Dictionary = event.duplicate()
+		for key: String in ["type", "frame", "scene"]:
+			values.erase(key)
+		_emit(StringName(event.get("type", &"")), values)
+	if _movie.scene() != scene:
+		_emit(&"show_image", {"id": &"intro_movie", "scene": _movie.scene()})
+	if _movie.finished():
+		_emit(&"hide_image", {"id": &"intro_movie"})
+		_enter_after(PHASE_INTRO_MOVIE)
 
 
 ## Enters the first phase after [param phase] the host can draw, with that
@@ -288,10 +293,10 @@ func _enter_after(phase: StringName) -> void:
 				_presents.start(_profile, _sine)
 				_emit(&"show_image", {"id": &"game_freak_presents"})
 			PHASE_INTRO_MOVIE:
-				_intro_scene = 0
-				_intro_scene_frame = 0
-				_emit(&"play_music", {"music": &"gold_silver_opening", "restart": false})
-				_emit(&"show_image", {"id": &"intro_scene", "scene": _intro_scene})
+				# `CrystalIntro` starts on a cleared screen and plays no music
+				# until `IntroScene13`, so the phase opens with the art alone.
+				_movie = Gen2IntroMovie.create(_data, _sine)
+				_emit(&"show_image", {"id": &"intro_movie", "scene": 0})
 			PHASE_TITLE:
 				# `_TitleScreen` draws the whole screen and plays
 				# `SFX_TITLE_SCREEN_ENTRANCE` before the loop's first frame;
@@ -315,43 +320,3 @@ func _emit(type: StringName, values: Dictionary) -> void:
 	}
 	event.merge(values, true)
 	_events.append(event)
-
-
-func _validated_intro_lengths(lengths: Array[int]) -> Array[int]:
-	if lengths.is_empty():
-		# The source movie is one frame-stepped 28-scene sequence. The fixed
-		# scene budgets keep the coordinator deterministic; imported intro data
-		# may replace them with the per-scene budgets used by its renderer.
-		var defaults: Array[int] = []
-		for _scene: int in 28:
-			defaults.append(1)
-		defaults[1] = 128
-		defaults[2] = 800
-		defaults[3] = 96
-		defaults[4] = 80
-		defaults[6] = 255
-		defaults[7] = 255
-		defaults[8] = 64
-		defaults[10] = 128
-		defaults[11] = 16
-		defaults[12] = 128
-		defaults[13] = 4
-		defaults[14] = 64
-		defaults[15] = 128
-		defaults[16] = 64
-		defaults[5] = 112
-		var remainder: int = INTRO_TOTAL_FRAMES
-		for value: int in defaults:
-			remainder -= value
-		defaults[5] += maxi(remainder, 0)
-		return defaults
-	var out: Array[int] = []
-	var total: int = 0
-	for value: int in lengths:
-		if value <= 0:
-			return _validated_intro_lengths([])
-		out.append(value)
-		total += value
-	if out.size() != 28 or total != INTRO_TOTAL_FRAMES:
-		return _validated_intro_lengths([])
-	return out

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -1,0 +1,1097 @@
+class_name Gen2IntroMovie
+extends RefCounted
+
+## `CrystalIntro` (engine/movie/intro.asm): the movie between the GameFreak logo
+## and the title screen.
+##
+## Twenty-eight scenes behind one jumptable, stepped once per hardware frame.
+## Half of them are setup: they load a graphics sheet, a 32x32 BG map and its
+## attribute plane, copy a palette run into `wBGPals1` and `wBGPals2`, and call
+## `NextIntroScene`. The other half animate for a fixed number of frames by
+## writing the palettes, `hSCX`, `hSCY`, `wLYOverrides` and a handful of sprite
+## animation structs, then hand on.
+##
+## This owns all of that state; [Gen2IntroMoviePage] turns it into pixels. The
+## split is the credits': a per-frame jumptable, a tilemap the state machine
+## owns, and a page that only turns tile numbers into colours.
+##
+## Crystal only. Gold and Silver's `GoldSilverIntro` is a different movie and is
+## not built.
+
+## `wBGPals2` and the `wOBPals2` behind it, which is what the screen shows.
+##
+## Every scene's `ld bc, 16 palettes` runs off the end of the background
+## buffer and into the object one, which is where the sprites get their colours:
+## the Unown's purple, Pichu's yellow and Wooper's blue are all in the second
+## half of a run whose first half is a scene's backgrounds.
+const BG_PALETTES: int = 8
+const PALETTES: int = RomLayout.INTRO_PALETTES
+const PALETTE_COLORS: int = RomLayout.INTRO_PALETTE_COLORS
+## `ClearPalettes` fills both buffers with $ffff rather than blanking them.
+const WHITE: int = 0xFFFF
+
+## `SCREEN_WIDTH`/`SCREEN_HEIGHT` and the BG map behind them.
+const COLUMNS: int = 20
+const ROWS: int = 18
+const MAP_COLUMNS: int = RomLayout.INTRO_MAP_COLUMNS
+const MAP_ROWS: int = RomLayout.INTRO_MAP_ROWS
+const SCREEN_HEIGHT_PX: int = 144
+
+## The sound effects the movie asks for, as their `SFX_*` numbers.
+const SFX_INTRO_UNOWN_1: int = 0xB6
+const SFX_INTRO_UNOWN_2: int = 0xB8
+const SFX_INTRO_UNOWN_3: int = 0xB9
+const SFX_INTRO_SUICUNE_2: int = 0xB7
+const SFX_INTRO_SUICUNE_3: int = 0xBA
+const SFX_INTRO_SUICUNE_4: int = 0xBB
+const SFX_INTRO_WHOOSH: int = 0xBC
+const SFX_INTRO_PICHU: int = 0xBD
+## `MUSIC_CRYSTAL_OPENING`, started by `IntroScene13` rather than at the top.
+const MUSIC_CRYSTAL_OPENING: int = 0x25
+
+## The six `SpriteAnimObjects` rows the movie spawns, as (frameset, function).
+const OBJ_INTRO_SUICUNE: StringName = &"suicune"
+const OBJ_INTRO_PICHU: StringName = &"pichu"
+const OBJ_INTRO_WOOPER: StringName = &"wooper"
+const OBJ_INTRO_UNOWN: StringName = &"unown"
+const OBJ_INTRO_UNOWN_F: StringName = &"unown_f"
+const OBJ_INTRO_SUICUNE_AWAY: StringName = &"suicune_away"
+
+## The framesets, as (OAM set, duration, attributes) plus how the run ends.
+## `oamframe X, n` lasts n + 1 frames; `oamend` repeats its last entry forever,
+## `oamdelete` takes the struct away and `oamrestart` goes round again.
+const FRAMESET_END: StringName = &"end"
+const FRAMESET_DELETE: StringName = &"delete"
+const FRAMESET_RESTART: StringName = &"restart"
+const FRAMESET_WAIT: StringName = &"wait"
+
+## `B_OAM_XFLIP` and `B_OAM_YFLIP` on a frameset entry, which flip each tile
+## where it stands rather than mirroring the square.
+const FLIP_X: int = 1
+const FLIP_Y: int = 2
+
+const FRAMESETS: Dictionary = {
+	&"intro_suicune": {
+		"frames": [[0, 3, 0], [1, 3, 0], [2, 3, 0], [3, 3, 0]], "end": FRAMESET_RESTART,
+	},
+	&"intro_suicune_2": {"frames": [[3, 3, 0], [0, 7, 0]], "end": FRAMESET_END},
+	&"intro_pichu": {
+		"frames": [[4, 32, 0], [5, 7, 0], [6, 7, 0]], "end": FRAMESET_END,
+	},
+	&"intro_wooper": {"frames": [[7, 3, 0]], "end": FRAMESET_END},
+	&"intro_unown_1": {
+		"frames": [[8, 3, 0], [9, 3, 0], [10, 7, 0]], "end": FRAMESET_DELETE,
+	},
+	&"intro_unown_2": {
+		"frames": [[8, 3, FLIP_X], [9, 3, FLIP_X], [10, 7, FLIP_X]],
+		"end": FRAMESET_DELETE,
+	},
+	&"intro_unown_3": {
+		"frames": [[8, 3, FLIP_Y], [9, 3, FLIP_Y], [10, 7, FLIP_Y]],
+		"end": FRAMESET_DELETE,
+	},
+	&"intro_unown_4": {
+		"frames": [
+			[8, 3, FLIP_X | FLIP_Y], [9, 3, FLIP_X | FLIP_Y], [10, 7, FLIP_X | FLIP_Y],
+		],
+		"end": FRAMESET_DELETE,
+	},
+	&"intro_unown_f": {"frames": [], "end": FRAMESET_WAIT},
+	&"intro_unown_f_2": {
+		"frames": [[11, 3, 0], [12, 3, 0], [13, 3, 0], [14, 7, 0], [15, 7, 0]],
+		"end": FRAMESET_END,
+	},
+	&"intro_suicune_away": {"frames": [[16, 3, 0]], "end": FRAMESET_END},
+}
+
+## The `SpriteAnimObjects` rows: the frameset a struct starts on and the
+## `SPRITE_ANIM_FUNC_*` that moves it. Every one of them takes
+## `SPRITE_ANIM_DICT_DEFAULT`, so the tile a struct draws from is whatever the
+## scene wrote into `wSpriteAnimDict`'s first value.
+const OBJECTS: Dictionary = {
+	OBJ_INTRO_SUICUNE: {"frameset": &"intro_suicune", "func": &"suicune"},
+	OBJ_INTRO_PICHU: {"frameset": &"intro_pichu", "func": &"pichu_wooper"},
+	OBJ_INTRO_WOOPER: {"frameset": &"intro_wooper", "func": &"pichu_wooper"},
+	OBJ_INTRO_UNOWN: {"frameset": &"intro_unown_1", "func": &"unown"},
+	OBJ_INTRO_UNOWN_F: {"frameset": &"intro_unown_f", "func": &"unown_f"},
+	OBJ_INTRO_SUICUNE_AWAY: {
+		"frameset": &"intro_suicune_away", "func": &"suicune_away",
+	},
+}
+
+## `CrystalIntro_InitUnownAnim`'s four structs, as (VAR1, frameset). VAR1 is the
+## angle `SpriteAnimFunc_IntroUnown` reads its sine and cosine at, so the four
+## fly out along four directions while the amplitude grows.
+const UNOWN_BURST: Array[Array] = [
+	[0x08, &"intro_unown_4"], [0x18, &"intro_unown_3"],
+	[0x28, &"intro_unown_1"], [0x38, &"intro_unown_2"],
+]
+
+## `IntroScene12`'s `.UnownSounds`, as (frame counter, sfx).
+const UNOWN_SOUNDS: Array[Array] = [
+	[0x00, SFX_INTRO_UNOWN_3], [0x20, SFX_INTRO_UNOWN_2], [0x40, SFX_INTRO_UNOWN_1],
+	[0x60, SFX_INTRO_UNOWN_2], [0x80, SFX_INTRO_UNOWN_3], [0x90, SFX_INTRO_UNOWN_2],
+	[0xA0, SFX_INTRO_UNOWN_1], [0xB0, SFX_INTRO_UNOWN_2],
+]
+
+## What each setup scene loads, keyed by its scene index. `bg` is the sheet BG
+## tile numbers below $80 read from, `bg_first` how far into it that half starts,
+## and `bg_high` the sheet $80 and up reads from; `obj` is the sheet a sprite
+## tile reads from and `obj_bank1` the one an `OAM_BANK1` sprite does. `map` and
+## `attr` name the 32x32 BG maps.
+##
+## The names are `RomLayout.INTRO_SECTION`'s. A missing key keeps what the scene
+## before it left in that part of VRAM, which is what the source's own
+## `Intro_DecompressRequest2bpp_*` calls do.
+const SCENE_VRAM: Dictionary = {
+	0: {
+		"bg": "unowns", "map": "unown_a_map", "attr": "unown_a_attr", "obj": "pulse",
+	},
+	2: {"bg": "background", "map": "background_map", "attr": "background_attr"},
+	4: {
+		"bg": "unowns", "map": "unown_hi_map", "attr": "unown_hi_attr", "obj": "pulse",
+	},
+	6: {
+		"bg": "background", "map": "background_map", "attr": "background_attr",
+		"obj": "suicune_run", "obj_bank1": "pichu_wooper",
+	},
+	10: {"bg": "unowns", "map": "unowns_map", "attr": "unowns_attr"},
+	12: {
+		"bg": "background", "map": "background_map", "attr": "background_attr",
+		"obj": "suicune_run",
+	},
+	14: {
+		"bg": "suicune_jump", "map": "suicune_jump_map", "attr": "suicune_jump_attr",
+		"obj": "unown_back",
+	},
+	# `Intro_DecompressRequest2bpp_255Tiles` from `vTiles1` runs 255 tiles past
+	# the end of that bank, so the close-up's first 128 land where a BG tile
+	# number $80 and up reads and the rest in `vTiles2`, where one below $80
+	# does. One sheet, both halves of the window, which is why its own map names
+	# thirty-three tiles below $80.
+	16: {
+		"bg": "suicune_close", "bg_first": 128, "bg_high": "suicune_close",
+		"map": "suicune_close_map", "attr": "suicune_close_attr",
+	},
+	18: {
+		"bg": "suicune_back", "bg_high": "unowns", "map": "suicune_back_map",
+		"attr": "suicune_back_attr",
+	},
+	25: {
+		"bg": "crystal_unowns", "map": "crystal_unowns_map",
+		"attr": "crystal_unowns_attr",
+	},
+}
+
+## The palette run each setup scene copies into both buffers.
+const SCENE_PALETTE: Dictionary = {
+	0: "unowns_palette", 2: "background_palette", 4: "unowns_palette",
+	6: "background_palette", 10: "unowns_palette", 12: "background_palette",
+	14: "suicune_palette", 16: "suicune_close_palette", 18: "suicune_palette",
+	25: "crystal_unowns_palette",
+}
+
+## `IntroScene26`, the one setup scene whose palette clear is `ClearBGPalettes`.
+const SCENE_CRYSTAL_UNOWNS: int = 25
+
+## `Intro_RustleGrass`'s `.RustlingGrassPointers`, four tiles at `vTiles2 tile
+## $09` swapped every four frames for the first thirty-six of `IntroScene10`.
+const GRASS_FRAMES: Array[String] = ["grass_1", "grass_2", "grass_3", "grass_2"]
+const GRASS_RUSTLE_FRAMES: int = 36
+
+var _data: GameData = null
+var _sine: Gen2BattleAnimData = null
+
+## `wJumptableIndex` and its `JUMPTABLE_EXIT_F`.
+var _scene: int = 0
+var _exit: bool = false
+## `wIntroSceneFrameCounter` and `wIntroSceneTimer`, which share their addresses
+## with the slot machine's bytes; see [method _sprite_unown_f].
+var _counter: int = 0
+var _timer: int = 0
+
+var _scx: int = 0
+var _scy: int = 0
+## `wLYOverrides` under `hLCDCPointer` = LOW(rSCX): one `hSCX` per scanline. Off
+## when [member _ly_active] is false, which is `hLCDCPointer` zero.
+var _ly: PackedByteArray = PackedByteArray()
+var _ly_active: bool = false
+
+## `wBGPals2`, eight palettes of four packed colours.
+var _palettes: PackedInt32Array = PackedInt32Array()
+## `wSpriteAnimDict`'s first value, the tile a `SPRITE_ANIM_DICT_DEFAULT` struct
+## counts its OAM sets from.
+var _sprite_vtile: int = 0
+var _global_x_offset: int = 0
+
+## Which sheet and map each part of VRAM currently holds, built up by the setup
+## scenes out of [constant SCENE_VRAM].
+var _vram: Dictionary = {}
+## `wTilemap`, which only `Intro_LoadTilemap` fills and only
+## `Intro_ColoredSuicuneFrameSwap` reads. Empty until a scene loads it.
+var _tilemap: PackedByteArray = PackedByteArray()
+## The attribute plane `IntroScene9` writes over the loaded one, or empty.
+var _attr_override: PackedByteArray = PackedByteArray()
+var _grass_frame: int = 0
+
+var _actors: Array[Dictionary] = []
+## Frames a scene spends inside `DelayFrames`, during which neither the
+## jumptable nor `PlaySpriteAnimations` runs.
+var _delay: int = 0
+var _frame: int = 0
+var _events: Array[Dictionary] = []
+
+
+## [param sine] is `BattleAnimSineWave`, which every motion callback here scales.
+## Without one the sprites sit still and the frame counts do not move, so a
+## caller with no animation layer still spends the right frames.
+static func create(data: GameData, sine: Gen2BattleAnimData = null) -> Gen2IntroMovie:
+	var out := Gen2IntroMovie.new()
+	out._data = data
+	out._sine = sine
+	out._ly.resize(SCREEN_HEIGHT_PX)
+	out._palettes.resize(PALETTES * PALETTE_COLORS)
+	return out
+
+
+## Whether [param data] carries the art the movie draws. A cache without it is
+## the caller's cue to skip the phase rather than to run it blank.
+static func available(data: GameData) -> bool:
+	return data != null and data.has_intro_movie()
+
+
+func scene() -> int:
+	return _scene
+
+
+func finished() -> bool:
+	return _exit
+
+
+func frame() -> int:
+	return _frame
+
+
+func counter() -> int:
+	return _counter
+
+
+## `wIntroSceneTimer`, which `AnimSeq_GSTitleTrail` reads on Gold and Silver and
+## `CrystalIntro_UnownFade` writes here.
+func timer() -> int:
+	return _timer
+
+
+func scroll() -> Vector2i:
+	return Vector2i(_scx, _scy)
+
+
+## The `hSCX` for one scanline, which is `wLYOverrides` while `hLCDCPointer`
+## points at rSCX and plain `hSCX` otherwise.
+func scroll_x_at(line: int) -> int:
+	if not _ly_active or line < 0 or line >= _ly.size():
+		return _scx
+	return _ly[line]
+
+
+## One background palette, as colours a page can draw with.
+func palette(index: int) -> PackedColorArray:
+	return _palette_at(index)
+
+
+## One object palette, which is the same run's second half.
+func object_palette(index: int) -> PackedColorArray:
+	return _palette_at(BG_PALETTES + index)
+
+
+func _palette_at(index: int) -> PackedColorArray:
+	var out := PackedColorArray()
+	if index < 0 or index >= PALETTES:
+		return out
+	for colour: int in PALETTE_COLORS:
+		out.append(Gen2Palette.from_packed(_palettes[index * PALETTE_COLORS + colour]))
+	return out
+
+
+## Which sheet [param part] of VRAM holds: `bg`, `bg_high`, `obj` or
+## `obj_bank1`. Empty before a scene has loaded one.
+func sheet(part: String) -> String:
+	return String(_vram.get(part, ""))
+
+
+## How far into that sheet the half starts, which is only ever the close-up's
+## own 255-tile load spilling out of `vTiles1`.
+func sheet_first_tile(part: String) -> int:
+	return int(_vram.get("%s_first" % part, 0))
+
+
+## The tile the four rustling-grass tiles at $09 currently show, as a sheet name.
+func grass_sheet() -> String:
+	return GRASS_FRAMES[_grass_frame]
+
+
+## The 32x32 BG map and its attribute plane, as the cache holds them.
+func bg_map() -> PackedByteArray:
+	return _data.intro_map(String(_vram.get("map", ""))) if _data != null \
+		else PackedByteArray()
+
+
+func bg_attr() -> PackedByteArray:
+	if not _attr_override.is_empty():
+		return _attr_override
+	return _data.intro_map(String(_vram.get("attr", ""))) if _data != null \
+		else PackedByteArray()
+
+
+## `wTilemap`, which `Intro_ColoredSuicuneFrameSwap` rewrites in place. Empty
+## outside the two scenes that load it, and a page draws the BG map then.
+func screen_tilemap() -> PackedByteArray:
+	return _tilemap
+
+
+## Every live sprite-anim struct as the shadow OAM it produces, in struct order,
+## which is the z-order: `_InitSpriteAnimStruct` takes the first free slot and
+## `PlaySpriteAnimations` walks them in order.
+func sprites() -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for actor: Dictionary in _actors:
+		var entry: Array = _actor_frame(actor)
+		if entry.is_empty():
+			continue
+		out.append({
+			"at": Vector2i(
+				(int(actor["x"]) + int(actor["x_offset"]) + _global_x_offset) & 0xFF,
+				(int(actor["y"]) + int(actor["y_offset"])) & 0xFF,
+			),
+			"set": int(entry[0]),
+			"flip_x": bool(int(entry[2]) & FLIP_X),
+			"flip_y": bool(int(entry[2]) & FLIP_Y),
+			"vtile": int(actor["vtile"]),
+			"bank1": StringName(actor["object"]) in [OBJ_INTRO_PICHU, OBJ_INTRO_WOOPER],
+		})
+	return out
+
+
+func drain_events() -> Array[Dictionary]:
+	var out: Array[Dictionary] = _events.duplicate(true)
+	_events.clear()
+	return out
+
+
+## One `.loop` pass: `IntroSceneJumper` and then `PlaySpriteAnimations`, in the
+## order Crystal's loop calls them. A scene that spent `DelayFrames` inside its
+## own body holds both off until the debt is paid.
+func advance_frame() -> Array[Dictionary]:
+	if _exit:
+		return drain_events()
+	_frame += 1
+	if _delay > 0:
+		_delay -= 1
+		return drain_events()
+	_run_scene()
+	_run_sprites()
+	return drain_events()
+
+
+## The button `.ShutOffMusic` reads: any of A, B, START or SELECT ends the whole
+## movie and stops the music, which is the only skip it has.
+func cancel() -> bool:
+	if _exit:
+		return false
+	_exit = true
+	_emit(&"play_music", {"music": 0})
+	return true
+
+
+func _run_scene() -> void:
+	match _scene:
+		0:
+			_setup_scene()
+		1:
+			_scene_unown_a()
+		2:
+			_setup_scene()
+			_reset_ly_overrides()
+		3:
+			_scene_perspective_scroll()
+		4:
+			_setup_scene()
+			_ly_active = false
+		5:
+			_scene_unown_hi()
+		6:
+			_setup_scene()
+			_reset_ly_overrides()
+			_spawn(OBJ_INTRO_SUICUNE, Vector2i(27 * 8 + 0, 13 * 8 + 4))
+			_global_x_offset = 0xF0
+		7:
+			_scene_suicune_runs_in()
+		8:
+			_scene_attribute_bands()
+		9:
+			_scene_pichu_and_wooper()
+		10:
+			_setup_scene()
+			_ly_active = false
+		11:
+			_scene_many_unown()
+		12:
+			_setup_scene()
+			_spawn(OBJ_INTRO_SUICUNE, Vector2i(11 * 8 + 0, 13 * 8 + 4))
+			_emit(&"play_music", {"music": MUSIC_CRYSTAL_OPENING})
+			_global_x_offset = 0
+		13:
+			_scene_suicune_jumps()
+		14:
+			_setup_scene()
+			_load_tilemap()
+			_scy = SCREEN_HEIGHT_PX
+			_spawn(OBJ_INTRO_UNOWN_F, Vector2i(5 * 8, 8 * 8))
+			_spawn(OBJ_INTRO_SUICUNE_AWAY, Vector2i(0, 12 * 8))
+		15:
+			_scene_suicune_face()
+		16:
+			_setup_scene()
+		17:
+			_scene_suicune_close()
+		18:
+			_setup_scene()
+			_load_tilemap()
+			# `ld a, -5 * TILE_WIDTH`, which is a byte and stays one.
+			_scy = (-5 * 8) & 0xFF
+			# The grass tile parked at `vTiles1 tile $7f`, which is what the
+			# struct's own OAM set counts from.
+			_sprite_vtile = 0x7F
+			_spawn(OBJ_INTRO_SUICUNE_AWAY, Vector2i(0, 12 * 8))
+		19:
+			_scene_suicune_away()
+		20:
+			_colored_suicune_frame_swap()
+			_delay = 3
+			_counter = 0
+			_timer = 0
+			_next_scene()
+		21:
+			_scene_deinit_sprites()
+		22:
+			_counter = 0
+			_next_scene()
+		23:
+			_scene_fade_to_white()
+		24:
+			_scene_wait()
+		25:
+			_setup_scene()
+		26:
+			_scene_spell_crystal()
+		27:
+			_scene_end()
+
+
+## The half of a setup scene every one of them shares: clear the palettes, the
+## sprites and the tilemap, load this scene's own VRAM and palette run, put the
+## scroll back at the origin and hand on.
+##
+## `Intro_ClearBGPals` spends two `DelayFrame`s of its own, which is why a setup
+## scene is not free.
+func _setup_scene() -> void:
+	var vram: Dictionary = SCENE_VRAM.get(_scene, {})
+	for part: String in vram:
+		_vram[part] = vram[part]
+	# A sheet reloaded without an offset starts at its own first tile again.
+	for part: String in ["bg", "bg_high"]:
+		if vram.has(part) and not vram.has("%s_first" % part):
+			_vram.erase("%s_first" % part)
+	_actors.clear()
+	_tilemap = PackedByteArray()
+	_attr_override = PackedByteArray()
+	_sprite_vtile = 0
+	_grass_frame = 0
+	_scx = 0
+	_scy = 0
+	var name: String = String(SCENE_PALETTE.get(_scene, ""))
+	if not name.is_empty() and _data != null:
+		_load_palettes(name)
+	# `Intro_ClearBGPals` spends two `DelayFrame`s. `IntroScene26` is the one
+	# setup scene that calls `ClearBGPalettes` instead, whose `WaitBGMap` tail
+	# spends four.
+	_delay = 4 if _scene == SCENE_CRYSTAL_UNOWNS else 2
+	_counter = 0
+	_timer = 0
+	_next_scene()
+
+
+func _load_palettes(name: String) -> void:
+	var packed: PackedInt32Array = _packed(name)
+	for index: int in mini(packed.size(), _palettes.size()):
+		_palettes[index] = packed[index]
+
+
+## The cache holds a palette run as colours; the movie's own fades work on the
+## cartridge's packed 15-bit values, so they are read back as those.
+func _packed(name: String) -> PackedInt32Array:
+	var out := PackedInt32Array()
+	if _data == null:
+		return out
+	for colour: Color in _data.intro_palette(name):
+		out.append(
+			int(round(colour.r * 31.0))
+			| (int(round(colour.g * 31.0)) << 5)
+			| (int(round(colour.b * 31.0)) << 10)
+		)
+	return out
+
+
+func _next_scene() -> void:
+	_scene += 1
+
+
+## `IntroScene2`: the first Unown fades in, pulses and fades out over $80
+## frames, with the burst spawned two thirds of the way through.
+func _scene_unown_a() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x80:
+		_next_scene()
+		return
+	if value == 0x60:
+		_init_unown_burst(Vector2i(11 * 8, 11 * 8))
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_UNOWN_1})
+	_timer = value
+	_unown_fade(0)
+
+
+## `IntroScene6`: two more Unown, the second on the palette the first leaves.
+func _scene_unown_hi() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x80:
+		_next_scene()
+		return
+	if value == 0x60:
+		_init_unown_burst(Vector2i(6 * 8, 14 * 8))
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_UNOWN_1})
+		_timer = value
+		_unown_fade(1)
+		return
+	if value >= 0x40:
+		_timer = value
+		_unown_fade(1)
+		return
+	if value == 0x20:
+		_init_unown_burst(Vector2i(15 * 8, 7 * 8))
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_UNOWN_2})
+	_timer = value
+	_unown_fade(0)
+
+
+## `IntroScene4`: `Intro_PerspectiveScrollBG` for $80 frames.
+func _scene_perspective_scroll() -> void:
+	_perspective_scroll()
+	if _counter == 0x80:
+		_next_scene()
+		return
+	_counter = (_counter + 1) & 0xFF
+
+
+## `IntroScene8`: the panorama scrolls for $40 frames, then Suicune runs in from
+## the right as `wGlobalAnimXOffset` falls to zero.
+func _scene_suicune_runs_in() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value < 0x40:
+		_perspective_scroll()
+		return
+	if value == 0x40:
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_SUICUNE_3})
+	if _global_x_offset == 0:
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_SUICUNE_2})
+		_actors.clear()
+		_next_scene()
+		return
+	_global_x_offset = (_global_x_offset - 8) & 0xFF
+
+
+## `IntroScene9`: twelve rows of palette 1, three of 2 and three of 3, pushed
+## twice with `hBGMapAddress` twelve tiles apart so the whole 32-wide map is
+## covered rather than the twenty visible columns. Six `DelayFrame`s in all.
+func _scene_attribute_bands() -> void:
+	_ly_active = false
+	var attr := PackedByteArray()
+	attr.resize(RomLayout.INTRO_MAP_BYTES)
+	for row: int in MAP_ROWS:
+		var value: int = 1 if row < 12 else (2 if row < 15 else 3)
+		for column: int in MAP_COLUMNS:
+			attr[row * MAP_COLUMNS + column] = value
+	_attr_override = attr
+	_delay = 6
+	_global_x_offset = 0
+	_counter = 0
+	_next_scene()
+
+
+## `IntroScene10`: the grass rustles while Wooper and then Pichu hop in.
+func _scene_pichu_and_wooper() -> void:
+	_rustle_grass()
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	match value:
+		0xC0:
+			_next_scene()
+		0x20:
+			_spawn(OBJ_INTRO_WOOPER, Vector2i(6 * 8, 22 * 8))
+			_emit(&"play_sfx", {"sfx": SFX_INTRO_PICHU})
+		0x40:
+			_spawn(OBJ_INTRO_PICHU, Vector2i(16 * 8, 21 * 8 + 1))
+			_emit(&"play_sfx", {"sfx": SFX_INTRO_PICHU})
+
+
+## `IntroScene12`: the whole screen of Unown, fading twice as fast over the
+## second half, with eight sound effects along the way.
+func _scene_many_unown() -> void:
+	_play_unown_sound()
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0xC0:
+		_next_scene()
+		return
+	if value >= 0x80:
+		_timer = ((value & 0x0F) << 2) & 0xFF
+		_unown_fade(_swap_nybbles((value & 0x70) | 0x40))
+		return
+	_timer = ((value & 0x1F) << 1) & 0xFF
+	_unown_fade(_swap_nybbles((value & 0xE0) >> 1))
+
+
+func _play_unown_sound() -> void:
+	for row: Array in UNOWN_SOUNDS:
+		if int(row[0]) == _counter:
+			_emit(&"play_sfx", {"sfx": int(row[1]), "channels_off": true})
+			return
+
+
+## `IntroScene14`: the background scrolls ten pixels a frame while Suicune runs,
+## jumps at $60 and leaves.
+func _scene_suicune_jumps() -> void:
+	_scx = (_scx - 10) & 0xFF
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value == 0x80:
+		_next_scene()
+		return
+	if value == 0x60:
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_SUICUNE_4})
+	if value >= 0x60:
+		_timer = 1
+		if _global_x_offset < 0x88:
+			_actors.clear()
+			return
+		_global_x_offset = (_global_x_offset - 8) & 0xFF
+		return
+	if value >= 0x40:
+		_global_x_offset = (_global_x_offset - 2) & 0xFF
+
+
+## `IntroScene16`: Suicune's face rises into frame while an Unown appears in
+## front of it.
+func _scene_suicune_face() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x80:
+		_next_scene()
+		return
+	_animate_suicune_frame_swap()
+	if _scy == 0:
+		return
+	_scy = (_scy + 8) & 0xFF
+
+
+## `Intro_Scene16_AnimateSuicune`: the two-frame colour swap every fourth frame.
+func _animate_suicune_frame_swap() -> void:
+	if _counter & 0x03 == 0:
+		_colored_suicune_frame_swap()
+
+
+## `IntroScene18`: the close-up pans right eight pixels a frame until $60.
+func _scene_suicune_close() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x60:
+		_next_scene()
+		return
+	if _scx == 0x60:
+		return
+	_scx = (_scx + 8) & 0xFF
+
+
+## `IntroScene20`: Suicune runs away up the screen and Unown appear behind it.
+func _scene_suicune_away() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x98:
+		_next_scene()
+		return
+	if value >= 0x58:
+		return
+	if value >= 0x40:
+		var step: int = value - 0x18
+		if step & 0x03 != 0x03:
+			return
+		_timer = (step & 0x1C) >> 2
+		_appear_unown(0)
+		return
+	if value >= 0x28:
+		return
+	_scy = (_scy + 1) & 0xFF
+
+
+## `IntroScene22`: eight frames, then the sprites go.
+func _scene_deinit_sprites() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value < 0x08:
+		return
+	_actors.clear()
+	_next_scene()
+
+
+## `IntroScene24`: `.FadePals` over all eight palettes, one step every fourth
+## frame for $20 frames.
+func _scene_fade_to_white() -> void:
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x20:
+		_counter = 0x40
+		_next_scene()
+		return
+	if value & 0x03 != 0:
+		return
+	_apply_palette_fade(((value & 0x1C) << 1) & 0xFF)
+
+
+## `IntroScene25`: $40 frames of nothing.
+func _scene_wait() -> void:
+	_counter = (_counter - 1) & 0xFF
+	if _counter == 0:
+		_next_scene()
+
+
+## `IntroScene27`: C R Y S T A L spelled out in Unown, one palette pair fading
+## per sixteen frames.
+func _scene_spell_crystal() -> void:
+	_timer = (_timer + 1) & 0xFF
+	var value: int = _counter
+	_counter = (_counter + 1) & 0xFF
+	if value >= 0x80:
+		_next_scene()
+		_counter = 0x80
+		return
+	_timer = value & 0x0F
+	_fade_unown_word_pals(_swap_nybbles(value & 0x70))
+
+
+## `IntroScene28`: count $80 down, whoosh at 8, clear the palettes at $18, and
+## set the exit bit when it runs out.
+func _scene_end() -> void:
+	if _counter == 0:
+		_exit = true
+		return
+	var value: int = _counter
+	_counter = (_counter - 1) & 0xFF
+	if value == 0x18:
+		# `ClearBGPalettes` makes every palette white, both halves.
+		for index: int in _palettes.size():
+			_palettes[index] = WHITE
+		return
+	if value == 0x08:
+		_emit(&"play_sfx", {"sfx": SFX_INTRO_WHOOSH})
+
+
+## `Intro_PerspectiveScrollBG`: the trees scroll one pixel every other frame and
+## the grass two every frame, which is what makes the ground look nearer.
+func _perspective_scroll() -> void:
+	if _counter & 0x01 != 0:
+		var trees: int = (_ly[0] + 1) & 0xFF
+		for line: int in 0x5F:
+			_ly[line] = trees
+	var grass: int = (_ly[0x5F] + 2) & 0xFF
+	for offset: int in 0x31:
+		_ly[0x5F + offset] = grass
+	_scx = _ly[0]
+
+
+func _reset_ly_overrides() -> void:
+	for line: int in _ly.size():
+		_ly[line] = 0
+	_ly_active = true
+
+
+## `Intro_RustleGrass`: four tiles at `vTiles2 tile $09` cycle through three of
+## the grass strips for the scene's first thirty-six frames.
+func _rustle_grass() -> void:
+	if _counter >= GRASS_RUSTLE_FRAMES:
+		return
+	_grass_frame = (_counter & 0x0C) >> 2
+
+
+## `Intro_LoadTilemap`: the top-left 20x18 of the decompressed BG map, copied
+## into `wTilemap` so `Intro_ColoredSuicuneFrameSwap` has something to rewrite.
+func _load_tilemap() -> void:
+	var map: PackedByteArray = bg_map()
+	if map.size() < RomLayout.INTRO_MAP_BYTES:
+		return
+	var out := PackedByteArray()
+	out.resize(COLUMNS * ROWS)
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			out[row * COLUMNS + column] = map[row * MAP_COLUMNS + column]
+	_tilemap = out
+
+
+## `Intro_ColoredSuicuneFrameSwap`: every drawn tile below $80 swaps bit 3,
+## which is the two-frame run cycle held in the tile numbers themselves.
+func _colored_suicune_frame_swap() -> void:
+	for index: int in _tilemap.size():
+		var tile: int = _tilemap[index]
+		if tile == 0 or tile >= 0x80:
+			continue
+		_tilemap[index] = tile ^ 0x08
+
+
+## `CrystalIntro_UnownFade`: black out all eight palettes, then write three
+## colours into palette [param slot] from the three fade ramps, at the point
+## `wIntroSceneTimer` has reached. The ramp folds back on itself past half way,
+## which is what makes one counter fade in and out again.
+func _unown_fade(slot: int) -> void:
+	var step: int = _timer & 0x3F
+	if step > 0x1F:
+		step = 0x3F - step
+	# `ld bc, 8 palettes`: the background half only, so the Unown's own object
+	# colours survive the blank.
+	for index: int in BG_PALETTES * PALETTE_COLORS:
+		_palettes[index] = 0
+	var base: int = (slot * PALETTE_COLORS) & 0xFF
+	if base + 3 >= _palettes.size():
+		return
+	_palettes[base + 1] = _grey_ramp(step)
+	_palettes[base + 2] = _light_blue_ramp(step)
+	_palettes[base + 3] = _blue_ramp(step)
+
+
+## The three `for hue, 32` tables the assembler builds behind
+## `CrystalIntro_UnownFade`: black to white, black to light blue, black to blue.
+static func _grey_ramp(hue: int) -> int:
+	return hue | (hue << 5) | (hue << 10)
+
+
+static func _light_blue_ramp(hue: int) -> int:
+	return ((hue / 2) << 5) | (hue << 10)
+
+
+static func _blue_ramp(hue: int) -> int:
+	return hue << 10
+
+
+## `Intro_Scene20_AppearUnown`: one palette of `unown_1.pal` or `unown_2.pal`
+## copied into the slot `wIntroSceneTimer` names.
+func _appear_unown(which: int) -> void:
+	var run: PackedInt32Array = _packed("unown")
+	var slot: int = (_timer & 0x07) * PALETTE_COLORS
+	for colour: int in PALETTE_COLORS:
+		var source: int = which * PALETTE_COLORS + colour
+		if slot + colour >= _palettes.size() or source >= run.size():
+			return
+		_palettes[slot + colour] = run[source]
+
+
+## `Intro_Scene24_ApplyPaletteFade`: the [param at]th byte of `fade.pal`, which
+## is one palette, copied over all eight.
+func _apply_palette_fade(at: int) -> void:
+	var run: PackedInt32Array = _packed("fade")
+	var first: int = at / Gen2Palette.COLOR_BYTES
+	if first + PALETTE_COLORS > run.size():
+		return
+	for slot: int in BG_PALETTES:
+		for colour: int in PALETTE_COLORS:
+			_palettes[slot * PALETTE_COLORS + colour] = run[first + colour]
+
+
+## `Intro_FadeUnownWordPals`: the third and fourth colours of palette
+## [param slot], taken from a fast and a slow grey ramp at `wIntroSceneTimer`.
+func _fade_unown_word_pals(slot: int) -> void:
+	var base: int = slot * PALETTE_COLORS + 2
+	if base + 1 >= _palettes.size():
+		return
+	var step: int = _timer & 0x0F
+	# `.FastFadePalettes` steps 31, 30, 28, 27, 25 ...; `.SlowFadePalettes` one
+	# hue at a time from 31.
+	var fast: int = 31 - (step / 2) * 3 - (step & 1)
+	var slow: int = 31 - step
+	_palettes[base] = _grey_ramp(maxi(fast, 0))
+	_palettes[base + 1] = _grey_ramp(maxi(slow, 0))
+
+
+## `swap a` on a byte, which the two Unown scenes use to turn the counter's high
+## nybble into a palette slot.
+static func _swap_nybbles(value: int) -> int:
+	return ((value & 0x0F) << 4) | ((value & 0xF0) >> 4)
+
+
+## `CrystalIntro_InitUnownAnim`: four structs at one point, each on its own
+## frameset and its own angle.
+func _init_unown_burst(at: Vector2i) -> void:
+	for row: Array in UNOWN_BURST:
+		var actor: Dictionary = _spawn(OBJ_INTRO_UNOWN, at)
+		if actor.is_empty():
+			return
+		actor["var1"] = int(row[0])
+		_reinit_frameset(actor, StringName(row[1]))
+
+
+## `_InitSpriteAnimStruct`, which takes the first free slot. [param at] is the
+## shadow-OAM pixel the `depixel` pair names, x then y.
+func _spawn(object: StringName, at: Vector2i) -> Dictionary:
+	var actor: Dictionary = {
+		"object": object,
+		"frameset": StringName((OBJECTS[object] as Dictionary)["frameset"]),
+		"func": StringName((OBJECTS[object] as Dictionary)["func"]),
+		"vtile": _sprite_vtile,
+		"x": at.x, "y": at.y,
+		"x_offset": 0, "y_offset": 0,
+		"duration": 0, "frame": -1,
+		"jumptable": 0, "var1": 0, "var2": 0,
+	}
+	_actors.append(actor)
+	return actor
+
+
+## `ReinitSpriteAnimFrame`: a new frameset, back at its first entry.
+func _reinit_frameset(actor: Dictionary, frameset: StringName) -> void:
+	actor["frameset"] = frameset
+	actor["frame"] = -1
+	actor["duration"] = 0
+
+
+## `PlaySpriteAnimations`: each struct's own callback, then its frame counter.
+func _run_sprites() -> void:
+	for actor: Dictionary in _actors.duplicate():
+		match StringName(actor["func"]):
+			&"suicune":
+				_sprite_suicune(actor)
+			&"pichu_wooper":
+				_sprite_pichu_wooper(actor)
+			&"unown":
+				_sprite_unown(actor)
+			&"unown_f":
+				_sprite_unown_f(actor)
+			&"suicune_away":
+				_sprite_suicune_away(actor)
+	var kept: Array[Dictionary] = []
+	for actor: Dictionary in _actors:
+		if _advance_actor(actor):
+			kept.append(actor)
+	_actors = kept
+
+
+## `SpriteAnimFunc_IntroSuicune`: still until `wIntroSceneTimer` is set, then a
+## jump on a sine of amplitude 32 and the second frameset under it.
+func _sprite_suicune(actor: Dictionary) -> void:
+	if _timer == 0:
+		return
+	actor["var2"] = (int(actor["var2"]) + 2) & 0xFF
+	actor["y_offset"] = _sine_at(-int(actor["var2"]) & 0xFF, 32)
+	if StringName(actor["frameset"]) != &"intro_suicune_2":
+		_reinit_frameset(actor, &"intro_suicune_2")
+
+
+## `SpriteAnimFunc_IntroPichuWooper`: one hop, ten steps of a sine of
+## amplitude 32, then still.
+func _sprite_pichu_wooper(actor: Dictionary) -> void:
+	var var1: int = int(actor["var1"])
+	if var1 >= 20:
+		return
+	var1 += 2
+	actor["var1"] = var1
+	actor["y_offset"] = _sine_at(-var1 & 0xFF, 32)
+
+
+## `SpriteAnimFunc_IntroUnown`: the struct's own angle, at an amplitude that
+## grows three a frame, so the four fly apart along four directions.
+func _sprite_unown(actor: Dictionary) -> void:
+	var amplitude: int = int(actor["jumptable"])
+	actor["jumptable"] = (amplitude + 3) & 0xFF
+	var angle: int = int(actor["var1"])
+	actor["y_offset"] = _sine_at(angle, amplitude)
+	actor["x_offset"] = _cosine_at(angle, amplitude)
+
+
+## `SpriteAnimFunc_IntroUnownF`: reads `wSlotsDelay`, which is the same WRAM
+## byte as `wIntroSceneFrameCounter` (both are in the union at `wJumptableIndex`
+## + 1), so the Unown in front of Suicune's face appears on the one frame
+## `IntroScene16`'s counter reaches $40 and not because of the slot machine.
+func _sprite_unown_f(actor: Dictionary) -> void:
+	if _counter != 0x40:
+		return
+	_reinit_frameset(actor, &"intro_unown_f_2")
+
+
+## `SpriteAnimFunc_IntroSuicuneAway`: sixteen pixels down the screen a frame, on
+## a coordinate that is a byte and wraps rather than clamping.
+func _sprite_suicune_away(actor: Dictionary) -> void:
+	actor["y"] = (int(actor["y"]) + 16) & 0xFF
+
+
+## `GetSpriteAnimFrame` and the end of a frameset. Returns false when the struct
+## is deleted.
+func _advance_actor(actor: Dictionary) -> bool:
+	var frameset: Dictionary = FRAMESETS[StringName(actor["frameset"])]
+	var frames: Array = frameset["frames"]
+	if int(actor["duration"]) > 0:
+		actor["duration"] = int(actor["duration"]) - 1
+		return true
+	var next: int = int(actor["frame"]) + 1
+	if next >= frames.size():
+		match StringName(frameset["end"]):
+			FRAMESET_DELETE:
+				return false
+			FRAMESET_RESTART:
+				next = 0
+			_:
+				# `oamend` winds back two and re-reads the last entry forever;
+				# `oamwait` holds the struct with nothing drawn.
+				next = maxi(frames.size() - 1, 0)
+	if frames.is_empty():
+		actor["frame"] = -1
+		return true
+	actor["frame"] = next
+	actor["duration"] = int((frames[next] as Array)[1])
+	return true
+
+
+## The frameset entry a struct is showing, or empty while it draws nothing.
+func _actor_frame(actor: Dictionary) -> Array:
+	var frames: Array = (FRAMESETS[StringName(actor["frameset"])] as Dictionary)["frames"]
+	var at: int = int(actor["frame"])
+	if at < 0 or at >= frames.size():
+		return []
+	return frames[at]
+
+
+## `Sprites_Sine`: a = d * sin(a * pi/32), read out of `BattleAnimSineWave`
+## rather than derived, and zero without one.
+func _sine_at(angle: int, amplitude: int) -> int:
+	if _sine == null:
+		return 0
+	return Gen2BattleAnimFunctions.sine_of(_sine, angle, amplitude)
+
+
+func _cosine_at(angle: int, amplitude: int) -> int:
+	if _sine == null:
+		return 0
+	return Gen2BattleAnimFunctions.cosine_of(_sine, angle, amplitude)
+
+
+func _emit(type: StringName, values: Dictionary) -> void:
+	var event: Dictionary = {"type": type, "frame": _frame, "scene": _scene}
+	event.merge(values, true)
+	_events.append(event)

--- a/game/world/intro_movie.gd.uid
+++ b/game/world/intro_movie.gd.uid
@@ -1,0 +1,1 @@
+uid://rdlwrgpodqbi

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -6,9 +6,9 @@ extends Control
 ##
 ## The source runs four things before a new game: the copyright screen, the
 ## GameFreak logo animation, on Crystal the intro movie, and the title screen.
-## Every one but the movie is imported, so [Gen2BootCinema] is started with those
-## phases and the movie is skipped rather than held on a blank screen for the
-## frames it would have taken.
+## [Gen2BootCinema] is started with the phases this cache has art for; a phase it
+## has none for is skipped rather than held on a blank screen for the frames it
+## would have taken, which is what Gold and Silver's `GoldSilverIntro` still is.
 ##
 ## The pacing is the source's throughout. The copyright half is ten frames of
 ## blank and the screen for a hundred, with no button read at all, since
@@ -27,6 +27,7 @@ var _cinema: Gen2BootCinema = null
 var _data: GameData = null
 var _page: Gen2CopyrightPage = null
 var _presents_page: Gen2GameFreakPresentsPage = null
+var _movie_page: Gen2IntroMoviePage = null
 var _title_page: Gen2TitlePage = null
 ## What `hJoyDown` holds this frame. `TitleScreenMain` reads the held state, and
 ## its two chords cannot be expressed as presses.
@@ -50,15 +51,18 @@ func open(data: GameData) -> bool:
 		_page.draw(), Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _palette()
 	)
 	_presents_page = Gen2GameFreakPresentsPage.from_data(data)
+	_movie_page = Gen2IntroMoviePage.from_data(data)
 	_title_page = Gen2TitlePage.from_data(data)
 	var phases: Array[StringName] = [Gen2BootCinema.PHASE_COPYRIGHT]
 	if _presents_page != null:
 		phases.append(Gen2BootCinema.PHASE_PRESENTS)
+	if _movie_page != null:
+		phases.append(Gen2BootCinema.PHASE_INTRO_MOVIE)
 	if _title_page != null:
 		phases.append(Gen2BootCinema.PHASE_TITLE)
 	_cinema = Gen2BootCinema.new()
 	_cinema.start(
-		data.id if data != null else &"gold", [], phases, _sine_table(data)
+		data.id if data != null else &"gold", data, phases, _sine_table(data)
 	)
 	if is_inside_tree():
 		_refresh()
@@ -111,6 +115,13 @@ func handle_button(button: int) -> bool:
 	if button in [
 		Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT
 	]:
+		return true
+	if _cinema.phase() == Gen2BootCinema.PHASE_INTRO_MOVIE:
+		# `.ShutOffMusic`: any of A, B, START or SELECT ends the whole movie and
+		# stops the music with it.
+		var movie: Gen2IntroMovie = _cinema.movie()
+		if movie != null:
+			movie.cancel()
 		return true
 	_cinema.skip_presents()
 	return true
@@ -205,6 +216,8 @@ func _frame_image() -> Image:
 		return _image
 	if _visible_id == &"game_freak_presents" and _presents_page != null:
 		return _presents_page.draw(_cinema.presents())
+	if _visible_id == &"intro_movie" and _movie_page != null:
+		return _movie_page.draw(_cinema.movie())
 	if _visible_id == &"title" and _title_page != null:
 		return _title_page.draw(_cinema.title())
 	return _blank()

--- a/tests/unit/test_boot_cinema.gd
+++ b/tests/unit/test_boot_cinema.gd
@@ -2,6 +2,9 @@ extends GutTest
 
 const Boot := preload("res://game/world/boot_cinema.gd")
 
+## Longer than the movie, whose own total tests/unit/test_intro_movie.gd pins.
+const FRAME_CAP: int = 20000
+
 
 func test_boot_starts_with_source_ordered_copyright_events() -> void:
 	var boot := Boot.new()
@@ -26,30 +29,39 @@ func test_boot_starts_with_source_ordered_copyright_events() -> void:
 	))
 
 
-func test_boot_keeps_intro_music_continuous_and_opens_title_after_28_scenes() -> void:
-	var lengths: Array[int] = []
-	for _scene: int in 28:
-		lengths.append(1)
-	lengths[0] = 2308
+## The movie phase spends what `CrystalIntro` spends rather than a budget of the
+## coordinator's, so it is driven until its own jumptable sets the exit bit.
+## `IntroScene13` is what starts the music, part way in and not at the top;
+## tests/unit/test_intro_movie.gd pins the scene budgets themselves.
+func test_boot_runs_the_whole_movie_and_opens_the_title_behind_it() -> void:
 	var boot := Boot.new()
-	boot.start(&"crystal", lengths)
+	boot.start(&"crystal", null, [
+		Boot.PHASE_COPYRIGHT, Boot.PHASE_PRESENTS, Boot.PHASE_INTRO_MOVIE,
+		Boot.PHASE_TITLE,
+	])
 	boot.drain_events()
 	# The GameFreak animation spends what `GameFreakPresentsScene` spends rather
 	# than a budget of the coordinator's, so the movie is reached by driving to
 	# it. tests/unit/test_game_freak_presents.gd pins the count itself.
-	var movie_start: Array[Dictionary] = []
 	for _frame: int in 10 + 100 + 500:
-		movie_start.append_array(boot.advance_frame())
+		boot.advance_frame()
 		if boot.phase() == Boot.PHASE_INTRO_MOVIE:
 			break
 	assert_eq(boot.phase(), Boot.PHASE_INTRO_MOVIE)
-	assert_true(movie_start.any(func(event: Dictionary) -> bool:
-		return event["type"] == &"play_music" and event["music"] == &"gold_silver_opening"
-	))
 
 	var title: Array[Dictionary] = []
-	for _frame: int in 2335:
-		title.append_array(boot.advance_frame())
+	var music: Array[Dictionary] = []
+	var frames: int = 0
+	while boot.phase() == Boot.PHASE_INTRO_MOVIE and frames < FRAME_CAP:
+		var events: Array[Dictionary] = boot.advance_frame()
+		frames += 1
+		title.append_array(events)
+		music.append_array(events.filter(func(event: Dictionary) -> bool:
+			return event["type"] == &"play_music" \
+				and event["phase"] == Boot.PHASE_INTRO_MOVIE
+		))
+	assert_eq(music.size(), 1, "one `PlayMusic`, which is `IntroScene13`'s")
+	assert_eq(int(music[0]["music"]), Gen2IntroMovie.MUSIC_CRYSTAL_OPENING)
 	assert_eq(boot.phase(), Boot.PHASE_TITLE)
 	assert_true(title.any(func(event: Dictionary) -> bool:
 		return event["type"] == &"open_title"
@@ -80,7 +92,7 @@ func test_boot_sound_wait_is_explicit_and_does_not_consume_frames() -> void:
 ## do not cross over: the coordinator's are the ones a caller reads.
 func test_the_gamefreak_sounds_reach_the_host() -> void:
 	var boot := Boot.new()
-	boot.start(&"crystal", [], [Boot.PHASE_COPYRIGHT, Boot.PHASE_PRESENTS])
+	boot.start(&"crystal", null, [Boot.PHASE_COPYRIGHT, Boot.PHASE_PRESENTS])
 	boot.drain_events()
 	var sounds: Array[int] = []
 	var frames: Array[int] = []
@@ -106,7 +118,7 @@ func test_the_gamefreak_sounds_reach_the_host() -> void:
 ## frames they would have taken.
 func test_a_host_without_the_movie_art_runs_only_the_phases_it_names() -> void:
 	var boot := Boot.new()
-	boot.start(&"crystal", [], [Boot.PHASE_COPYRIGHT])
+	boot.start(&"crystal", null, [Boot.PHASE_COPYRIGHT])
 	boot.drain_events()
 	assert_true(boot.is_available(Boot.PHASE_COPYRIGHT))
 	assert_false(boot.is_available(Boot.PHASE_PRESENTS))
@@ -133,7 +145,7 @@ func test_a_host_without_the_movie_art_runs_only_the_phases_it_names() -> void:
 ## opening events, rather than spending its hundred and ten frames blank.
 func test_a_skipped_copyright_starts_on_the_next_phase_the_host_names() -> void:
 	var boot := Boot.new()
-	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	boot.start(&"gold", null, [Boot.PHASE_TITLE])
 	assert_eq(boot.phase(), Boot.PHASE_TITLE)
 	assert_true(boot.drain_events().any(func(event: Dictionary) -> bool:
 		return event["type"] == &"open_title"
@@ -144,7 +156,7 @@ func test_a_skipped_copyright_starts_on_the_next_phase_the_host_names() -> void:
 ## answers it, and the answer is what reaches the host.
 func test_the_title_phase_runs_its_own_screen_and_answers_the_host() -> void:
 	var boot := Boot.new()
-	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	boot.start(&"gold", null, [Boot.PHASE_TITLE])
 	assert_eq(boot.phase(), Boot.PHASE_TITLE)
 	assert_not_null(boot.title())
 
@@ -165,7 +177,7 @@ func test_the_title_phase_runs_its_own_screen_and_answers_the_host() -> void:
 ## starts the whole opening again rather than standing still.
 func test_a_title_screen_nobody_presses_restarts_the_opening() -> void:
 	var boot := Boot.new()
-	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	boot.start(&"gold", null, [Boot.PHASE_TITLE])
 	var restarted: bool = false
 	for _frame: int in Gen2TitleScene.TIMER_GOLD + 4:
 		for event: Dictionary in boot.advance_frame():
@@ -184,7 +196,7 @@ func test_a_title_screen_nobody_presses_restarts_the_opening() -> void:
 ## the host's business and `Init` comes back to the title afterwards.
 func test_a_chord_is_reported_and_the_screen_stays_up() -> void:
 	var boot := Boot.new()
-	boot.start(&"gold", [], [Boot.PHASE_TITLE])
+	boot.start(&"gold", null, [Boot.PHASE_TITLE])
 	boot.drain_events()
 	for _frame: int in 4:
 		boot.advance_frame()

--- a/tests/unit/test_intro_movie.gd
+++ b/tests/unit/test_intro_movie.gd
@@ -1,0 +1,129 @@
+extends GutTest
+
+## `CrystalIntro`'s jumptable, driven without a cache.
+##
+## Every frame count here is the source's own: the scenes count in
+## `wIntroSceneFrameCounter` and spend `DelayFrames`, neither of which depends on
+## the art being imported, so the whole movie runs and lands on the same frame
+## with no [GameData] at all. tools/validate_intro_movie.gd is what checks the
+## art it draws with.
+
+## Longer than the movie, whose own total is asserted below.
+const FRAME_CAP: int = 20000
+
+## `IntroScene28` sets `JUMPTABLE_EXIT_F` on this frame.
+const MOVIE_FRAMES: int = 1784
+## The frame each of the twenty-eight scenes starts on.
+const SCENE_STARTS: Array[int] = [
+	0, 1, 132, 133, 264, 265, 396, 397, 494, 495, 694, 695, 890, 891, 1022, 1023,
+	1154, 1155, 1254, 1255, 1410, 1411, 1423, 1424, 1457, 1521, 1522, 1655,
+]
+
+
+func _movie() -> Gen2IntroMovie:
+	return Gen2IntroMovie.create(null, null)
+
+
+## The budget the boot cinema spends, and the scene it spends each frame in.
+func test_the_movie_runs_every_scene_and_sets_its_own_exit_bit() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	var starts: Array[int] = [0]
+	var scene: int = 0
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+		if movie.scene() != scene:
+			scene = movie.scene()
+			starts.append(movie.frame())
+	assert_true(movie.finished())
+	assert_eq(movie.frame(), MOVIE_FRAMES)
+	assert_eq(starts, SCENE_STARTS)
+	assert_eq(starts.size(), RomLayout.INTRO_SCENES)
+
+
+## `IntroScene13` is the only `PlayMusic` in the movie, so the GameFreak logo's
+## silence runs a third of the way in before the opening theme starts.
+func test_the_music_starts_part_way_in_and_only_once() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	var music: Array[Dictionary] = []
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		for event: Dictionary in movie.advance_frame():
+			if event["type"] == &"play_music":
+				music.append(event)
+	assert_eq(music.size(), 1)
+	assert_eq(int(music[0]["music"]), Gen2IntroMovie.MUSIC_CRYSTAL_OPENING)
+	assert_eq(int(music[0]["frame"]), SCENE_STARTS[12] + 1)
+
+
+## The eight `.UnownSounds` rows plus the nine the scenes play directly, in the
+## order the movie asks for them.
+func test_every_scene_asks_for_its_own_sounds() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	var sfx: Array[int] = []
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		for event: Dictionary in movie.advance_frame():
+			if event["type"] == &"play_sfx":
+				sfx.append(int(event["sfx"]))
+	assert_eq(sfx, [
+		Gen2IntroMovie.SFX_INTRO_UNOWN_1,
+		Gen2IntroMovie.SFX_INTRO_UNOWN_2, Gen2IntroMovie.SFX_INTRO_UNOWN_1,
+		Gen2IntroMovie.SFX_INTRO_SUICUNE_3, Gen2IntroMovie.SFX_INTRO_SUICUNE_2,
+		Gen2IntroMovie.SFX_INTRO_PICHU, Gen2IntroMovie.SFX_INTRO_PICHU,
+		Gen2IntroMovie.SFX_INTRO_UNOWN_3, Gen2IntroMovie.SFX_INTRO_UNOWN_2,
+		Gen2IntroMovie.SFX_INTRO_UNOWN_1, Gen2IntroMovie.SFX_INTRO_UNOWN_2,
+		Gen2IntroMovie.SFX_INTRO_UNOWN_3, Gen2IntroMovie.SFX_INTRO_UNOWN_2,
+		Gen2IntroMovie.SFX_INTRO_UNOWN_1, Gen2IntroMovie.SFX_INTRO_UNOWN_2,
+		Gen2IntroMovie.SFX_INTRO_SUICUNE_4, Gen2IntroMovie.SFX_INTRO_WHOOSH,
+	])
+
+
+## `CrystalIntro_InitUnownAnim` spawns four structs at one point, each on its own
+## frameset, and `Frameset_IntroUnown1` ends on `oamdelete`, so the burst takes
+## itself away rather than standing there.
+func test_the_unown_burst_is_four_structs_that_delete_themselves() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	var most: int = 0
+	while movie.scene() < 2 and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+		most = maxi(most, movie.sprites().size())
+	assert_eq(most, Gen2IntroMovie.UNOWN_BURST.size())
+	assert_eq(movie.sprites().size(), 0, "and none of them survives the scene")
+
+
+## `SpriteAnimFunc_IntroSuicuneAway` moves its struct sixteen pixels a frame on a
+## coordinate that is a byte, so it wraps rather than clamping and comes back
+## round the top of the screen.
+func test_a_sprite_coordinate_wraps_rather_than_clamping() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	while movie.scene() < 19 and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+	var seen: Array[int] = []
+	for _frame: int in 20:
+		movie.advance_frame()
+		for sprite: Dictionary in movie.sprites():
+			seen.append((sprite["at"] as Vector2i).y)
+	assert_true(seen.size() > 0, "the scene has a sprite in it")
+	for y: int in seen:
+		assert_between(y, 0, 0xFF)
+	assert_true(seen.min() < seen[0], "and it has come back round the top")
+
+
+## `.ShutOffMusic`: a button ends the whole movie and stops the music with it.
+func test_a_button_ends_the_movie_and_the_music() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	for _frame: int in 40:
+		movie.advance_frame()
+	movie.drain_events()
+	assert_true(movie.cancel())
+	var events: Array[Dictionary] = movie.drain_events()
+	assert_eq(events.size(), 1)
+	assert_eq(events[0]["type"], &"play_music")
+	assert_eq(int(events[0]["music"]), 0)
+	assert_true(movie.finished())
+	assert_false(movie.cancel(), "and it only ends once")
+
+
+## A cache without the art is what Gold and Silver are: the movie is not offered
+## rather than run blank.
+func test_a_cache_without_the_art_does_not_offer_the_movie() -> void:
+	assert_false(Gen2IntroMovie.available(null))
+	assert_null(Gen2IntroMoviePage.from_data(null))

--- a/tests/unit/test_intro_movie.gd.uid
+++ b/tests/unit/test_intro_movie.gd.uid
@@ -1,0 +1,1 @@
+uid://dh017hkxdopd3

--- a/tools/preview_intro_movie.gd
+++ b/tools/preview_intro_movie.gd
@@ -1,0 +1,89 @@
+extends SceneTree
+
+## Captures the intro movie against a real imported cache, one source frame at a
+## time.
+##
+##   Godot --headless --path . -s res://tools/preview_intro_movie.gd -- crystal /tmp/i.png [frame;frame]
+##
+## [frame] is how many source frames to spend before the shot; several separated
+## by `;` write one file each, numbered. With no frame list the tool runs the
+## whole movie and prints the frame each scene starts on, which is what pins the
+## budgets.
+##
+## Headless: the page draws into an [Image] rather than through a viewport, so
+## there is no window and no settle.
+
+const MAX_FRAMES: int = 20000
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 1:
+		push_error("Usage: preview_intro_movie.gd -- <game> [output.png] [frame;frame;...]")
+		quit(1)
+		return
+
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+	if not Gen2IntroMovie.available(data):
+		push_error("The %s cache holds no intro movie." % args[0])
+		quit(1)
+		return
+
+	var sine: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(data)
+	var movie: Gen2IntroMovie = Gen2IntroMovie.create(data, sine)
+	if args.size() < 2:
+		_report(movie)
+		quit(0)
+		return
+
+	var page: Gen2IntroMoviePage = Gen2IntroMoviePage.from_data(data)
+	if page == null:
+		push_error("The %s cache holds no intro movie art." % args[0])
+		quit(1)
+		return
+
+	var frames: Array = []
+	for step: String in (args[2] if args.size() > 2 else "0").split(";", false):
+		frames.append(maxi(int(step.strip_edges()), 0))
+	frames.sort()
+
+	var spent: int = 0
+	for wanted: int in frames:
+		while spent < wanted and not movie.finished():
+			movie.advance_frame()
+			spent += 1
+		var path: String = args[1]
+		if frames.size() > 1:
+			path = "%s-%d.%s" % [args[1].get_basename(), wanted, args[1].get_extension()]
+		var error: Error = page.draw(movie).save_png(path)
+		if error != OK:
+			push_error("Could not write %s (%d)." % [path, error])
+			quit(1)
+			return
+		print("frame %d, scene %d, counter %d -> %s" % [
+			spent, movie.scene(), movie.counter(), path,
+		])
+	quit(0)
+
+
+## The whole movie, printing the frame each scene starts on and every sound it
+## asks for. This is the budget the boot cinema spends.
+func _report(movie: Gen2IntroMovie) -> void:
+	var scene: int = movie.scene()
+	print("scene 0 starts at frame 0")
+	var frames: int = 0
+	while not movie.finished() and frames < MAX_FRAMES:
+		for event: Dictionary in movie.advance_frame():
+			print("  frame %d: %s %s" % [
+				movie.frame(), event["type"],
+				event.get("sfx", event.get("music", "")),
+			])
+		frames += 1
+		if movie.scene() != scene:
+			scene = movie.scene()
+			print("scene %d starts at frame %d" % [scene, movie.frame()])
+	print("%d frames, %d scenes" % [movie.frame(), movie.scene()])

--- a/tools/preview_intro_movie.gd.uid
+++ b/tools/preview_intro_movie.gd.uid
@@ -1,0 +1,1 @@
+uid://b3w044mgka0ot

--- a/tools/validate_intro_movie.gd
+++ b/tools/validate_intro_movie.gd
@@ -1,0 +1,253 @@
+extends SceneTree
+
+## Verifies the intro movie against freshly imported real caches, on all three
+## cartridges.
+##
+## The whole movie is run to `JUMPTABLE_EXIT_F` rather than sampled: every scene
+## of the jumptable, every sprite it spawns and every sound it asks for is
+## exercised once. The expected values come from pokecrystal's
+## engine/movie/intro.asm and data/sprite_anims/.
+##
+## Gold and Silver carry `GoldSilverIntro`, a different movie that is not
+## imported, so they are checked for saying so rather than for running.
+##
+##   Godot --headless --path . -s res://tools/validate_intro_movie.gd
+
+const GAME_IDS: Array[StringName] = [&"gold", &"silver", &"crystal"]
+const MOVIE_GAMES: Array[StringName] = [&"crystal"]
+
+## Long enough for the movie, whose own total is pinned below.
+const FRAME_CAP: int = 20000
+
+## Census of the real Crystal cache, pinned so a change is loud: the frames the
+## jumptable takes to set its exit bit, the frame each scene starts on, and how
+## many sounds the movie asks for.
+const EXPECTED_FRAMES: int = 1784
+const EXPECTED_SCENE_STARTS: Array[int] = [
+	0, 1, 132, 133, 264, 265, 396, 397, 494, 495, 694, 695, 890, 891, 1022, 1023,
+	1154, 1155, 1254, 1255, 1410, 1411, 1423, 1424, 1457, 1521, 1522, 1655,
+]
+const EXPECTED_SFX: int = 17
+const EXPECTED_MUSIC: int = 1
+
+## `IntroScene10` is the one frame that asks shadow OAM for more than it holds:
+## Wooper's sixteen and Pichu's twenty-five come to forty-one, one past
+## `wShadowOAMEnd`, so the page drops the last of them the way `UpdateAnimFrame`
+## does. Pinned rather than bounded, because the overflow is the finding.
+const PEAK_SPRITES: int = 41
+
+var _failures: PackedStringArray = []
+
+
+func _initialize() -> void:
+	for game_id: StringName in GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		if not MOVIE_GAMES.has(game_id):
+			_check(
+				not Gen2IntroMovie.available(data),
+				"%s reports an intro movie it does not ship." % game_id
+			)
+			continue
+		if not _check(
+			Gen2IntroMovie.available(data), "%s carries no intro movie art." % game_id
+		):
+			continue
+		_verify_section(game_id, data)
+		_run(game_id, data)
+	_finish()
+
+
+## Every entry of the section, at the size the routine that loads it asks VRAM
+## for. The walk is what says the one pinned address is right, so a cache whose
+## sheets are the wrong length has been imported from the wrong offset.
+func _verify_section(game_id: StringName, data: GameData) -> void:
+	for row: Array in RomLayout.INTRO_SECTION:
+		var name: String = String(row[0])
+		match String(row[1]):
+			"pal":
+				_check(
+					data.intro_palette(name).size()
+						== RomLayout.INTRO_PALETTES * RomLayout.INTRO_PALETTE_COLORS,
+					"%s: intro palette run %s is not sixteen palettes." % [game_id, name]
+				)
+			"map", "attr":
+				_check(
+					data.intro_map(name).size() == RomLayout.INTRO_MAP_BYTES,
+					"%s: intro map %s is not a whole BG map." % [game_id, name]
+				)
+			_:
+				var strip: PackedByteArray = data.tile_indices("intro_%s" % name)
+				_check(
+					strip.size() == int(row[2]) * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT,
+					"%s: intro sheet %s is not %d tiles." % [game_id, name, int(row[2])]
+				)
+	for name: String in ["fade", "unown"]:
+		_check(
+			not data.intro_palette(name).is_empty(),
+			"%s: the intro %s palettes are missing." % [game_id, name]
+		)
+
+
+## One pixel per tile the screen covers, plus its last one, which is the extra
+## tile a scroll that is not a multiple of eight reaches into.
+static func _steps(size: int) -> Array[int]:
+	var out: Array[int] = []
+	for step: int in size / Gen2Tiles.TILE_WIDTH:
+		out.append(step * Gen2Tiles.TILE_WIDTH)
+	out.append(size - 1)
+	return out
+
+
+func _sheet_tiles(data: GameData, name: String) -> int:
+	if name.is_empty():
+		return 0
+	return int(data.tile_sheet("intro_%s" % name).get("tiles", 0))
+
+
+## Every BG cell the movie actually samples has to name a tile the sheet that
+## part of VRAM currently holds, and every attribute byte a palette its own run
+## has. Sampled rather than whole, because only 360 of a map's 1,024 cells are
+## the picture: the rest of the Unown maps is $ff, which nothing scrolls onto and
+## no scene has loaded a sheet for.
+##
+## This is what says `SCENE_VRAM` pairs a map with a sheet the way the setup
+## scenes do, and that the halves a scene does not reload carry forward: the
+## close-up's own map names thirty-three tiles below $80, which read the leaping
+## Suicune `IntroScene15` left in `vTiles2`.
+func _verify_sampled_tiles(game_id: StringName, movie: Gen2IntroMovie, data: GameData) -> bool:
+	var map: PackedByteArray = movie.bg_map()
+	var attr: PackedByteArray = movie.bg_attr()
+	if map.size() != RomLayout.INTRO_MAP_BYTES:
+		return true
+	var screen: PackedByteArray = movie.screen_tilemap()
+	var low: int = _sheet_tiles(data, movie.sheet("bg")) - movie.sheet_first_tile("bg")
+	var high: int = _sheet_tiles(data, movie.sheet("bg_high")) \
+		- movie.sheet_first_tile("bg_high")
+	var scy: int = movie.scroll().y
+	for line: int in _steps(Gen2Screen.HEIGHT):
+		var scx: int = movie.scroll_x_at(line)
+		var map_row: int = (((line + scy) & 0xFF) / Gen2Tiles.TILE_HEIGHT) % RomLayout.INTRO_MAP_ROWS
+		for x: int in _steps(Gen2Screen.WIDTH):
+			var map_column: int = ((((x + scx) & 0xFF)
+				/ Gen2Tiles.TILE_WIDTH) % RomLayout.INTRO_MAP_COLUMNS)
+			var cell: int = map_row * RomLayout.INTRO_MAP_COLUMNS + map_column
+			var tile: int = map[cell]
+			if not screen.is_empty() and map_column < Gen2IntroMovie.COLUMNS \
+					and map_row < Gen2IntroMovie.ROWS:
+				tile = screen[map_row * Gen2IntroMovie.COLUMNS + map_column]
+			var held: int = high if tile >= 0x80 else low
+			if not _check(
+				(tile - 0x80 if tile >= 0x80 else tile) < held,
+				"%s: frame %d, scene %d draws BG tile $%02X, past its own sheet." % [
+					game_id, movie.frame(), movie.scene(), tile,
+				]
+			):
+				return false
+			if not _check(
+				attr[cell] & 0x07 < Gen2IntroMovie.BG_PALETTES,
+				"%s: frame %d names a background palette past the eighth." % [
+					game_id, movie.frame(),
+				]
+			):
+				return false
+	return true
+
+
+## The whole movie, frame by frame: the scene starts, the sounds and the sprite
+## count. Every sound record it names has to resolve on the cache as well, since
+## a `PlaySFX` the driver cannot answer is a silent scene rather than an error.
+func _run(game_id: StringName, data: GameData) -> void:
+	var movie: Gen2IntroMovie = Gen2IntroMovie.create(
+		data, Gen2SplashScreen._sine_table(data)
+	)
+	var page: Gen2IntroMoviePage = Gen2IntroMoviePage.from_data(data)
+	_check(page != null, "%s: the intro movie page will not build." % game_id)
+	var starts: Array[int] = [0]
+	var scene: int = 0
+	var sfx: int = 0
+	var music: int = 0
+	var most: int = 0
+	var sampled: bool = true
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		for event: Dictionary in movie.advance_frame():
+			match StringName(event.get("type", &"")):
+				&"play_sfx":
+					sfx += 1
+					_check(
+						not data.world_audio(&"sfx", int(event["sfx"])).is_empty(),
+						"%s: intro sfx %d resolves to no record." % [
+							game_id, int(event["sfx"]),
+						]
+					)
+				&"play_music":
+					music += 1
+					_check(
+						not data.world_audio(&"music", int(event["music"])).is_empty(),
+						"%s: intro music %d resolves to no record." % [
+							game_id, int(event["music"]),
+						]
+					)
+		if movie.scene() != scene:
+			scene = movie.scene()
+			starts.append(movie.frame())
+		most = maxi(most, _sprite_count(movie))
+		if sampled and not _verify_sampled_tiles(game_id, movie, data):
+			sampled = false
+	_check(
+		movie.finished(),
+		"%s: the intro movie never set its exit bit." % game_id
+	)
+	_check(
+		movie.frame() == EXPECTED_FRAMES,
+		"%s: the intro movie ran %d frames, not the pinned %d." % [
+			game_id, movie.frame(), EXPECTED_FRAMES,
+		]
+	)
+	_check(
+		starts == EXPECTED_SCENE_STARTS,
+		"%s: the intro scenes start on %s, not the pinned starts." % [game_id, starts]
+	)
+	_check(
+		sfx == EXPECTED_SFX and music == EXPECTED_MUSIC,
+		"%s: the intro asked for %d effects and %d songs, not %d and %d." % [
+			game_id, sfx, music, EXPECTED_SFX, EXPECTED_MUSIC,
+		]
+	)
+	_check(
+		most == PEAK_SPRITES,
+		"%s: the intro's busiest frame asked for %d sprites, not the pinned %d." % [
+			game_id, most, PEAK_SPRITES,
+		]
+	)
+
+
+## How many shadow-OAM entries this frame's structs add up to.
+func _sprite_count(movie: Gen2IntroMovie) -> int:
+	var total: int = 0
+	for sprite: Dictionary in movie.sprites():
+		var set: Dictionary = Gen2IntroMoviePage.OAM_SETS[int(sprite["set"])]
+		total += (set["parts"] as Array).size()
+	return total
+
+
+func _check(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+	return condition
+
+
+func _fail(message: String) -> void:
+	_failures.append(message)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("PASS intro movie: the section, the maps, the frames and every scene verified.")
+		quit(0)
+		return
+	for message: String in _failures:
+		print("FAIL %s" % message)
+	quit(1)

--- a/tools/validate_intro_movie.gd.uid
+++ b/tools/validate_intro_movie.gd.uid
@@ -1,0 +1,1 @@
+uid://bisr574hcbofa


### PR DESCRIPTION
The last phase of the opening. `Gen2IntroMovie` is `CrystalIntro`'s
twenty-eight-scene jumptable stepped once per hardware frame, `Gen2IntroMoviePage`
turns the state it owns into pixels, and `Gen2SplashScreen` names
`PHASE_INTRO_MOVIE` when the cache carries the art, so a new game now runs
copyright, GameFreak, movie and title with no gap. 1,784 frames over 28 scenes,
which is the source's own budget and not an invented one.

Gold and Silver ship `GoldSilverIntro`, a different movie, and are unchanged:
the phase is skipped rather than held blank, which is what the coordinator
already did for every phase a host has no art for.

## Locating the art

Every graphic, tilemap, attrmap and palette the movie draws is one contiguous
section behind the code, and each entry starts on a sixteen-byte boundary from
the first. So `IntroSuicuneRunGFX` is the only pinned address: the walk
decompresses each of the thirty-five entries at the size the routine that loads
it asks VRAM for, and thirty-five in a row landing exactly is what says the
address is right. `fade.pal` and the two Unown palettes are INCLUDEd inside the
code instead; the first of those is byte-identical to `fade.pal`'s opening
palette, so the two pinned offsets confirm each other for nothing, the way the
copyright string does for the credits.

## Two readings the port turns on

- A scene's `ld bc, 16 palettes` runs off the end of `wBGPals1` into `wOBPals1`.
  That is where the sprites get their colours: the Unown's purple, Pichu's
  yellow and Wooper's blue are the second half of runs whose first half is a
  scene's backgrounds. Read as eight, every sprite wears whatever the splash
  left behind.
- `wSlotsDelay` shares its address with `wIntroSceneFrameCounter`, so
  `SpriteAnimFunc_IntroUnownF`'s `cp $40` is reading the intro's own counter and
  the Unown really does appear in front of Suicune's face on that frame.
- `Intro_DecompressRequest2bpp_255Tiles` from `vTiles1` runs past the end of
  that bank, so the close-up's one sheet fills both halves of the BG window,
  which is why its map names thirty-three tiles below $80.

## Proof

- `tools/validate_intro_movie.gd`, new, sweeps all three cartridges: every
  section entry at its own size, every BG cell the movie samples naming a tile
  the sheet that part of VRAM holds, every attribute byte a palette its own run
  has, and the whole movie run to `JUMPTABLE_EXIT_F` with its scene starts, its
  seventeen effects, the one song and the one frame that asks shadow OAM for
  forty-one sprites and has its forty-first dropped.
- `tools/preview_intro_movie.gd`, new, photographs any source frame headless, or
  prints the frame each scene starts on.
- `tests/unit/test_intro_movie.gd`, seven cases over the budgets, the sounds,
  the Unown burst deleting itself, a byte coordinate wrapping and the button
  that ends the movie.
- GUT 2,784 tests over 147 scripts, green. All 39 `validate_*` pass except
  `validate_clickable`, which needs a display. `replay_world.gd` 27 routes,
  0 failures. The story walk reaches Red on all three: 294 steps on Crystal,
  291 on Gold and Silver, 16 badges each.

Cache format 49, so all three cartridges need re-importing; each reports
`layout: Layout verified.`