### PR TITLE
Silver's own title trail, and the sound and pocket box behind every item receipt

### DIFF
--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -113,13 +113,26 @@ const TRAIL_COORDS_GOLD: Array[Array] = [
 ]
 ## `depixel 15, 11, 4, 0`.
 const TRAIL_AT_SILVER := Vector2i(88, 124)
-## `AnimSeq_GSTitleTrail`: four pixels right and one down a frame, gone once its
-## x reaches $a4, with Gold riding a sine of its own three steps at a time.
+## `AnimSeq_GSTitleTrail`: four pixels right a frame, gone once its x reaches
+## $a4. The rest of it is two routines under one name. Only Gold's `.one` has the
+## `inc [hl]` that walks the y coordinate down, and only Gold's `.zero` seeds
+## VAR1 from the struct's own index and then reaches
+## `AnimSeqs_IncAnonJumptableIndex`, so its sine is set up once and stepped by
+## three a frame from there.
 const TRAIL_X_STEP: int = 4
 const TRAIL_Y_STEP: int = 1
 const TRAIL_X_END: int = 0xA4
 const TRAIL_SINE_STEP: int = 3
 const TRAIL_SINE_AMPLITUDE: int = 2
+## Silver's `.zero` runs every frame, and both numbers it wants come from
+## `wIntroSceneTimer`, which the union at `wJumptableIndex + 2` gives to
+## `LOW(wTitleScreenTimer)`: the byte the screen itself is counting down. Masked
+## and swapped it is 0 to 3, which is an amplitude of 3 to 6 and a step of 7 to
+## 10.
+const TRAIL_SILVER_TIMER_MASK: int = 0x30
+const TRAIL_SILVER_TIMER_SHIFT: int = 4
+const TRAIL_SILVER_AMPLITUDE_BASE: int = 3
+const TRAIL_SILVER_STEP_BASE: int = 7
 
 ## `ScrollTitleScreenClouds`: forty scanlines from line $5f take one shared
 ## offset that falls by one, on every eighth frame on Gold and on every frame on
@@ -129,8 +142,10 @@ const CLOUD_LINES: int = 0x28
 const CLOUD_GOLD_MASK: int = 0b111
 
 ## `NUM_SPRITE_ANIM_STRUCTS`: `_InitSpriteAnimStruct` walks ten slots and returns
-## carry rather than making an eleventh, so a burst of trails simply stops.
+## carry rather than making an eleventh, so a burst of trails simply stops. The
+## bird holds one of the ten for the whole screen's life, which leaves nine.
 const MAX_SPRITE_STRUCTS: int = 10
+const MAX_TRAILS: int = MAX_SPRITE_STRUCTS - 1
 
 ## What [method sprites] answers with.
 const SPRITE_CRYSTAL: StringName = &"crystal"
@@ -148,9 +163,16 @@ var _bird_var: int = 0
 var _bird_frame: int = 0
 var _selected: int = -1
 var _sine: Gen2BattleAnimData = null
-## The live trail particles, each `{ at, var1 }`. `_InitSpriteAnimStruct` has ten
-## slots and refuses an eleventh, which is what caps this too.
+## The live trail particles, each `{ at, var1, yoffset, fresh }`, capped the way
+## `_InitSpriteAnimStruct` caps them. `fresh` is a struct that has not had a
+## `PlaySpriteAnimations` pass yet: `UpdateTitleTrailSprite` spawns behind that
+## call, so a new trail neither runs its `.zero` nor reaches shadow OAM until the
+## next frame.
 var _trails: Array[Dictionary] = []
+## `wSpriteAnimCount`, which `_InitSpriteAnimStruct` raises on every spawn and
+## which every struct keeps as its own `SPRITEANIMSTRUCT_INDEX`. `TitleScreen`
+## spawns the bird before any trail, so the count opens at one.
+var _anim_count: int = 1
 var _cloud_scroll: int = 0
 
 
@@ -229,7 +251,10 @@ func advance_frame(held: Array = []) -> void:
 	if _scene == SCENE_END:
 		return
 	_frame += 1
-	_advance_animation()
+	# `RunTitleScreen`'s own order: the clouds, then the scene, which is what
+	# counts the timer down, then the sprites and the spawn behind them, both of
+	# which read that timer after the count.
+	_advance_clouds()
 	match _scene:
 		SCENE_ENTRANCE:
 			_advance_entrance()
@@ -239,6 +264,7 @@ func advance_frame(held: Array = []) -> void:
 			_scene = SCENE_MAIN
 		SCENE_MAIN:
 			_advance_main(held)
+	_advance_animation()
 
 
 ## `SuicuneFrameIterator` and `AnimSeq_GSIntroHoOhLugia`, both of which run on
@@ -251,12 +277,14 @@ func _advance_animation() -> void:
 	# Silver's countdown wraps rather than going negative.
 	_bird_var = (_bird_var + (1 if _profile == RomRegistry.GOLD else -1)) & 0xFF
 	_bird_frame += 1
-	_advance_clouds()
 	_advance_trails()
 
 
 ## `ScrollTitleScreenClouds`, whose `dec a` walks one shared offset off the left.
+## Crystal's own loop has no clouds in it.
 func _advance_clouds() -> void:
+	if _profile == RomRegistry.CRYSTAL:
+		return
 	if _profile == RomRegistry.GOLD and (_frame & CLOUD_GOLD_MASK) != 0:
 		return
 	_cloud_scroll = (_cloud_scroll - 1) & 0xFF
@@ -268,24 +296,57 @@ func _advance_clouds() -> void:
 func _advance_trails() -> void:
 	var alive: Array[Dictionary] = []
 	for trail: Dictionary in _trails:
+		if bool(trail["fresh"]):
+			trail["fresh"] = false
+			if _profile == RomRegistry.GOLD:
+				# Gold's `.zero`: VAR1 is the struct's own index masked to two bits
+				# and swapped, so four consecutive spawns open a quarter turn apart.
+				trail["var1"] = (int(trail["index"]) & 0x3) << 4
+		if _profile == RomRegistry.SILVER:
+			# Silver's `.zero` runs ahead of the move on every frame, because it
+			# never reaches `AnimSeqs_IncAnonJumptableIndex`.
+			var scale: int = (_timer & TRAIL_SILVER_TIMER_MASK) >> TRAIL_SILVER_TIMER_SHIFT
+			trail["var1"] = (
+				int(trail["var1"]) + scale + TRAIL_SILVER_STEP_BASE
+			) & 0xFF
+			trail["yoffset"] = _lift(
+				int(trail["var1"]), scale + TRAIL_SILVER_AMPLITUDE_BASE
+			)
 		var at: Vector2i = trail["at"]
 		if at.x >= TRAIL_X_END:
 			continue
 		at.x += TRAIL_X_STEP
-		at.y = (at.y + TRAIL_Y_STEP) & 0xFF
+		if _profile == RomRegistry.GOLD:
+			at.y = (at.y + TRAIL_Y_STEP) & 0xFF
+			trail["var1"] = (int(trail["var1"]) + TRAIL_SINE_STEP) & 0xFF
+			trail["yoffset"] = _lift(int(trail["var1"]), TRAIL_SINE_AMPLITUDE)
 		trail["at"] = at
-		trail["var1"] = (int(trail["var1"]) + TRAIL_SINE_STEP) & 0xFF
 		alive.append(trail)
 	_trails = alive
-	if (_timer & TRAIL_SPAWN_MASK) != 0 or _trails.size() >= MAX_SPRITE_STRUCTS:
+	if (_timer & TRAIL_SPAWN_MASK) != 0 or _trails.size() >= MAX_TRAILS:
 		return
-	var at: Vector2i = TRAIL_AT_SILVER
+	var spawn: Vector2i = TRAIL_AT_SILVER
 	if _profile == RomRegistry.GOLD:
 		var row: Array = TRAIL_COORDS_GOLD[_bird_entry()]
-		at = row[1 if (_timer & TRAIL_SPAWN_ALTERNATE) != 0 else 0]
-		if at.x < 0:
+		spawn = row[1 if (_timer & TRAIL_SPAWN_ALTERNATE) != 0 else 0]
+		if spawn.x < 0:
 			return
-	_trails.append({"at": at, "var1": 0})
+	# `_InitSpriteAnimStruct` steps `wSpriteAnimCount` past zero rather than
+	# through it, so no struct is ever indexed nothing.
+	_anim_count = (_anim_count + 1) & 0xFF
+	if _anim_count == 0:
+		_anim_count = 1
+	_trails.append(
+		{"at": spawn, "var1": 0, "yoffset": 0, "fresh": true, "index": _anim_count}
+	)
+
+
+## `AnimSeqs_Sine` over `BattleAnimSineWave`, as the byte `UpdateAnimFrame` adds
+## to a coordinate. Zero without the table rather than an invented curve.
+func _lift(a: int, amplitude: int) -> int:
+	if _sine == null:
+		return 0
+	return Gen2BattleAnimFunctions.sine_of(_sine, a, amplitude)
 
 
 ## `TitleScreenEntrance`. Its `.done` is what starts the music and drops the
@@ -390,25 +451,22 @@ func _crystal_sprites() -> Array[Dictionary]:
 ## battle animation reads.
 func _bird_sprites() -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
-	# The trails were spawned before the bird and so hold the lower struct slots,
-	# which is what puts them behind it.
+	# `TitleScreen` spawns the bird into the first free slot and then copies the
+	# struct into `wSpriteAnim10` and clears the first, so the bird holds the last
+	# slot however late a trail is spawned: the trails are drawn first and the
+	# bird over them.
 	for trail: Dictionary in _trails:
+		if bool(trail["fresh"]):
+			continue
 		var trail_at: Vector2i = trail["at"]
-		var lift: int = 0
-		if _profile == RomRegistry.GOLD and _sine != null:
-			lift = Gen2BattleAnimFunctions.sine_of(
-				_sine, int(trail["var1"]), TRAIL_SINE_AMPLITUDE
-			)
 		out.append({
 			"kind": SPRITE_TRAIL,
-			"at": Vector2i(trail_at.x, (trail_at.y + lift) & 0xFF),
+			"at": Vector2i(trail_at.x, (trail_at.y + int(trail["yoffset"])) & 0xFF),
 			"tile": 0, "palette": 1,
 		})
 
 	var amplitude: int = BIRD_SINE_GOLD if _profile == RomRegistry.GOLD else BIRD_SINE_SILVER
-	var offset: int = 0
-	if _sine != null:
-		offset = Gen2BattleAnimFunctions.sine_of(_sine, _bird_var, amplitude)
+	var offset: int = _lift(_bird_var, amplitude)
 	# `UpdateAnimFrame` adds the offset to the coordinate as a byte, so a sprite
 	# pushed past the screen wraps rather than clamping.
 	out.append({

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -37,6 +37,15 @@ const POCKET_NAMES: Dictionary = {
 	TYPE_KEY_ITEM: "Key Items",
 	TYPE_TM_HM: "TMs/HMs",
 }
+## `ItemPocketNames` (`data/items/pocket_names.asm`), which is a different set of
+## strings from the pack's own headers above: these are what `GetPocketName`
+## copies into wStringBuffer3 for `itemnotify` and `pocketisfull` to print.
+const SOURCE_POCKET_NAMES: Dictionary = {
+	TYPE_ITEM: "ITEM POCKET",
+	TYPE_KEY_ITEM: "KEY POCKET",
+	TYPE_BALL: "BALL POCKET",
+	TYPE_TM_HM: "TM POCKET",
+}
 
 ## `ITEMATTR_PERMISSIONS` bits and the field-menu nibble `CheckItemMenu` returns,
 ## named here in this file's own terms but valued from the import layer, so the
@@ -136,6 +145,16 @@ static func pocket_order() -> Array[int]:
 		if pocket > 0 and not order.has(pocket):
 			order.append(pocket)
 	return order
+
+
+## The name a script prints. `GetPocketName` masks the pocket to two bits, which
+## no cartridge item reaches past; a mod pocket keeps its own label instead of
+## wrapping onto a cartridge one.
+static func source_pocket_name(data: GameData, item: int) -> String:
+	var pocket: int = int(data.item(item).get("pocket", 0)) if data != null else 0
+	if SOURCE_POCKET_NAMES.has(pocket):
+		return String(SOURCE_POCKET_NAMES[pocket])
+	return pocket_name(pocket)
 
 
 static func pocket_name(pocket_type: int) -> String:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -58,6 +58,10 @@ var _trainer_intro_approach_pending: bool = false
 ## its acknowledge continues into the earthquake, the disappear and the roll.
 ## The same shape _trainer_intro_approach_pending has for encounter music.
 var _rock_smash_after_sound: bool = false
+## Set while a receipt's own `specialsound` is out with the host, so its
+## completion continues into `itemnotify`'s box. `{ item, finish }`, the same
+## shape _rock_smash_after_sound has.
+var _item_notify_after_sound: Dictionary = {}
 var _battle_setup: Dictionary = {}
 var _loaded_battle_type: int = -1
 var _phone_context: Dictionary = {}
@@ -180,6 +184,19 @@ const FOUND_ITEM_TEXT: String = "Found\n%s!"
 ## Two source boxes, so four lines and no blank between them: the box is two
 ## rows, and a blank line would spend a third page drawing nothing.
 const NO_SPACE_ITEM_TEXT: String = "Found\n%s!\nBut you have\nno space left."
+## data/text/common_2.asm's `_ReceivedItemText`, `_PutItemInPocketText` and
+## `_PocketIsFullText`, each less its `<PLAYER>` for the reason FOUND_ITEM_TEXT
+## drops it: nothing writes `wPlayerName` yet. `GiveItemScript` prints the first
+## two around every `verbosegiveitem`, and `itemnotify` the second on its own.
+const RECEIVED_ITEM_TEXT: String = "Received\n%s."
+## The pocket line's own `cont` is a scroll rather than a page, so the item it
+## names is still on screen above it.
+const PUT_ITEM_TEXT: String = "Put the\n%s in" + Gen2TextStream.SCROLL_BREAK + "the %s."
+const POCKET_FULL_TEXT: String = "The %s\nis full…"
+## constants/sfx_constants.asm. `FindItemInBallScript` plays SFX_ITEM by name
+## rather than through `specialsound`, so a TM lying in a ball gets the ordinary
+## item jingle and the same TM handed over by an NPC gets SFX_GET_TM.
+const SFX_ITEM: int = 0x01
 ## data/text/common_1.asm's four fruit tree texts, paired the same way.
 ## `_HeyItsFruitText` and `_ObtainedFruitText` are one staged text because the
 ## source's `giveitem` sits between them and has nothing to show; they still
@@ -387,6 +404,24 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			var picked: Dictionary = _resolve_fruit_tree(fruit_tree, fruit_item)
 			if not bool(picked.get("ok", false)):
 				return _fail(StringName(picked.get("reason", &"fruit_tree_failed")), picked)
+			return _waiting_result()
+		## The tail every item receipt shares behind its own line: the sound, and
+		## then `itemnotify`'s box once the host has played it.
+		if pending_type == &"text" and _pending.get("special", &"") == &"item_received":
+			var receipt_item: int = int(_pending.get("item", 0))
+			var receipt_sfx: int = int(_pending.get("sfx", 0))
+			var receipt_finish: bool = bool(_pending.get("finish", false))
+			_pending = {}
+			_finish_after_pending = false
+			_stage_receipt_tail(receipt_item, receipt_sfx, receipt_finish)
+			return _waiting_result()
+		## `GiveItemScript.Full`, whose `promptbutton` is the acknowledge above.
+		if pending_type == &"text" and _pending.get("special", &"") == &"pocket_is_full":
+			var full_item: int = int(_pending.get("item", 0))
+			var full_finish: bool = bool(_pending.get("finish", false))
+			_pending = {}
+			_finish_after_pending = false
+			_stage_pocket_is_full(full_item, full_finish)
 			return _waiting_result()
 		## Script_UsedStrength's second writetext, _MoveBoulderText.
 		if pending_type == &"text" and _pending.get("special", &"") == &"strength_used":
@@ -683,6 +718,8 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		var smash_after_sound: bool = kind == &"audio_requested" \
 			and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
 			== &"sound" and _rock_smash_after_sound
+		var notify_after_sound: Dictionary = _item_notify_after_sound \
+			if kind == &"audio_requested" else {}
 		_pending = {}
 		if approach_after_audio:
 			_trainer_intro_approach_pending = false
@@ -690,6 +727,12 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		if smash_after_sound:
 			_rock_smash_after_sound = false
 			_stage_rock_smashed()
+		if not notify_after_sound.is_empty():
+			_item_notify_after_sound = {}
+			_stage_item_notify(
+				int(notify_after_sound.get("item", 0)),
+				bool(notify_after_sound.get("finish", false))
+			)
 		return advance()
 	if kind == &"rival_name_requested":
 		if not bool(result.get("ok", false)):
@@ -897,13 +940,15 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		if not bool(quantity_result.get("ok", false)):
 			return quantity_result
 		var variable_item: int = int(command.get("item", 0))
+		var variable_name: String = data.item_name(variable_item) if data != null else ""
 		_set_text_buffer(
-			RomLayout.STRING_BUFFER_4,
-			data.item_name(variable_item) if data != null else "",
-			&"item_name",
+			RomLayout.STRING_BUFFER_4, variable_name, &"item_name",
 			{"item": variable_item}
 		)
-		return _stage_item_delta(variable_item, _script_value)
+		var variable_given: Dictionary = _stage_item_delta(variable_item, _script_value)
+		if not bool(variable_given.get("ok", true)):
+			return variable_given
+		return _stage_give_item_script(variable_item, variable_name)
 	var source: int = Gen2WorldScript.source_opcode(opcode, _crystal_commands())
 	var object_result: Dictionary = _execute_object_command(source, command)
 	if not object_result.is_empty():
@@ -1150,6 +1195,12 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 			return _stage_warp(command)
 		Gen2WorldScript.OPENTEXT, Gen2WorldScript.REANCHORMAP, Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE, Gen2WorldScript.CLOSEWINDOW:
 			pass
+		Gen2WorldScript.ITEMNOTIFY:
+			## `CurItemName` reads wCurItem, which whichever `giveitem` came
+			## before this wrote.
+			return _stage_item_notify(_last_item, false)
+		Gen2WorldScript.POCKETISFULL:
+			return _stage_pocket_is_full(_last_item, false)
 		Gen2WorldScript.WRITETEXT:
 			return _show_text(bank, int(command["address"]), false)
 		Gen2WorldScript.FARWRITETEXT:
@@ -1210,7 +1261,6 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.OPENTEXT, Gen2WorldScript.REANCHORMAP,
 		Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE,
 		Gen2WorldScript.CLOSEWINDOW,
-		Gen2WorldScript.ITEMNOTIFY,
 		Gen2WorldScript.LOADMENU,
 		Gen2WorldScript.GETMONEY, Gen2WorldScript.GETCOINS, Gen2WorldScript.GETNUM,
 		Gen2WorldScript.GETMONNAME, Gen2WorldScript.GETITEMNAME,
@@ -1525,13 +1575,17 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 			## _ReceivedItemText then prints as `text_ram wStringBuffer4`. Staging
 			## the item without filling the buffer leaves that text unresolved.
 			var verbose_item: int = int(command.get("item", 0))
+			var verbose_name: String = data.item_name(verbose_item) if data != null else ""
 			_set_text_buffer(
-				RomLayout.STRING_BUFFER_4,
-				data.item_name(verbose_item) if data != null else "",
-				&"item_name",
+				RomLayout.STRING_BUFFER_4, verbose_name, &"item_name",
 				{"item": verbose_item}
 			)
-			return _stage_item_delta(verbose_item, int(command.get("quantity", 1)))
+			var given: Dictionary = _stage_item_delta(
+				verbose_item, int(command.get("quantity", 1))
+			)
+			if not bool(given.get("ok", true)):
+				return given
+			return _stage_give_item_script(verbose_item, verbose_name)
 		0x9E:
 			return _stage_runtime_request(&"swarm_requested", {
 				"map_group": int(command.get("map_group", 0)),
@@ -2531,8 +2585,10 @@ func _stage_strength_boulder() -> Dictionary:
 ## the body is replayed here the way AskStrengthScript's is.
 ##
 ## Source order is receive, `disappear LAST_TALKED`, then the text, so the ball
-## is already gone when the box is drawn. `itemnotify` is the `item_changed`
-## event _stage_item_delta() emits.
+## is already gone when the box is drawn. Behind that text the script plays
+## SFX_ITEM by name rather than through `specialsound` and then runs
+## `itemnotify`; its own `pause 60` is the acknowledge here, since nothing draws
+## a text box that closes itself.
 ##
 ## The receive seam preserves the source's no-room branch without committing
 ## the item, hiding the ball, or setting its event flag.
@@ -2555,7 +2611,9 @@ func _stage_item_ball() -> Dictionary:
 	var item_name: String = data.item_name(item) if data != null else ""
 	if item_name.is_empty():
 		item_name = "ITEM"
-	return _stage_internal_text(FOUND_ITEM_TEXT % item_name, true)
+	return _stage_internal_text(FOUND_ITEM_TEXT % item_name, false, {
+		"special": &"item_received", "item": item, "sfx": SFX_ITEM, "finish": true,
+	})
 
 
 ## `FruitTreeScript` (`engine/events/fruit_trees.asm`). Like an item ball it is
@@ -2594,9 +2652,13 @@ func _resolve_fruit_tree(tree_id: int, item: int) -> Dictionary:
 	var received: Dictionary = _stage_item_delta(item, 1)
 	if not bool(received.get("accepted", true)):
 		return _stage_internal_text(FRUIT_TREE_FULL_TEXT % item_name, true)
-	## PickedFruitTree, which the source runs after the item is in the bag.
+	## PickedFruitTree, which the source runs after the item is in the bag, then
+	## its own `specialsound` and `itemnotify`.
 	_staged_fruit_trees[tree_id] = true
-	return _stage_internal_text(FRUIT_TREE_OBTAINED_TEXT % [item_name, item_name], true)
+	return _stage_internal_text(
+		FRUIT_TREE_OBTAINED_TEXT % [item_name, item_name], false,
+		{"special": &"item_received", "item": item, "finish": true}
+	)
 
 
 ## `TryResetFruitTrees`: `ResetFruitTrees` refills every tree at once and sets
@@ -2630,9 +2692,9 @@ func _fruit_tree_picked(tree_id: int) -> bool:
 ## object's. `_PlayerFoundItemText` is `_FoundItemText`'s wording, so the two
 ## share FOUND_ITEM_TEXT and its <PLAYER> boundary.
 ##
-## The source writes the text before `giveitem` and sets the flag after it. The
-## A full pocket leaves both the item and the event flag untouched, then shows
-## the source's no-space branch in one scene-free text pause.
+## The source writes the text before `giveitem` and sets the flag after it. A
+## full pocket leaves both the item and the event flag untouched, then shows the
+## source's no-space branch in one scene-free text pause.
 func _stage_hidden_item() -> Dictionary:
 	var item: int = int(_request.get("item", 0))
 	var flag: int = int(_request.get("flag", -1))
@@ -2646,7 +2708,9 @@ func _stage_hidden_item() -> Dictionary:
 	var item_name: String = data.item_name(item) if data != null else ""
 	if item_name.is_empty():
 		item_name = "ITEM"
-	return _stage_internal_text(FOUND_ITEM_TEXT % item_name, true)
+	return _stage_internal_text(FOUND_ITEM_TEXT % item_name, false, {
+		"special": &"item_received", "item": item, "finish": true,
+	})
 
 
 ## CheckPartyMove: the first slot whose move list carries [param move], or -1.
@@ -2867,13 +2931,60 @@ func _rock_encounter() -> Dictionary:
 	return Gen2WorldTreemon.rock_encounter(data.treemon_set(set_number), _random)
 
 
-func _stage_internal_text(text: String, finish_after: bool) -> Dictionary:
-	_pending = {
+## `Script_itemnotify`: `GetPocketName` and `CurItemName` into
+## `PutItemInPocketText`, which `MapTextbox` prints and the script resumes
+## behind. Every receipt in the source ends on this box.
+func _stage_item_notify(item: int, finish_after: bool) -> Dictionary:
+	var item_name: String = data.item_name(item) if data != null else ""
+	if item_name.is_empty():
+		item_name = "ITEM"
+	return _stage_internal_text(
+		PUT_ITEM_TEXT % [item_name, Gen2WorldPack.source_pocket_name(data, item)],
+		finish_after
+	)
+
+
+## `Script_pocketisfull`, which is the same box with only the pocket in it.
+func _stage_pocket_is_full(item: int, finish_after: bool) -> Dictionary:
+	return _stage_internal_text(
+		POCKET_FULL_TEXT % Gen2WorldPack.source_pocket_name(data, item), finish_after
+	)
+
+
+## `GiveItemScript`, which is the whole of `verbosegiveitem` past the receive:
+## the received line, and then either the sound and `itemnotify` or, on a full
+## pack, `pocketisfull`. The line is printed either way, because the source's
+## `iffalse` sits behind its own `writetext`. Both boxes resume the caller.
+func _stage_give_item_script(item: int, item_name: String) -> Dictionary:
+	var named: String = item_name if not item_name.is_empty() else "ITEM"
+	return _stage_internal_text(RECEIVED_ITEM_TEXT % named, false, {
+		"special": &"item_received" if _script_value != 0 else &"pocket_is_full",
+		"item": item,
+	})
+
+
+## The tail a receipt shares once its own line has been read: the sound, and
+## then `itemnotify` behind it. [param sfx] is the id a script plays by name,
+## or 0 for `specialsound`'s own pocket-dependent choice.
+func _stage_receipt_tail(item: int, sfx: int, finish_after: bool) -> Dictionary:
+	_item_notify_after_sound = {"item": item, "finish": finish_after}
+	if sfx > 0:
+		return _stage_audio_request(&"sound", {"address": sfx})
+	return _stage_audio_request(&"special_sound", {"item": item})
+
+
+func _stage_internal_text(
+	text: String, finish_after: bool, values: Dictionary = {}
+) -> Dictionary:
+	var pending: Dictionary = {
 		"type": &"text",
 		"text": text,
 		"internal_text": true,
 		"source": _request.duplicate(true),
 	}
+	for key: Variant in values:
+		pending[key] = values[key]
+	_pending = pending
 	_finish_after_pending = finish_after
 	return {"ok": true}
 

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -12,6 +12,27 @@ func _scene(profile: StringName) -> Gen2TitleScene:
 	return Gen2TitleScene.create(profile)
 
 
+## `BattleAnimSineWave`, hand-built rather than imported: `sine_table 32` is
+## `sin(x * pi / 32) * $100`.
+func _sine() -> Gen2BattleAnimData:
+	var bytes := PackedByteArray()
+	for index: int in 0x20:
+		var value: int = int(round(sin(float(index) * PI / 32.0) * 256.0))
+		bytes.append(value & 0xFF)
+		bytes.append((value >> 8) & 0xFF)
+	return Gen2BattleAnimData.create({}, [], bytes, &"gold")
+
+
+## Every trail on screen this frame, oldest first, as the shadow-OAM positions
+## [Gen2TitlePage] draws them at.
+func _trails(scene: Gen2TitleScene) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for sprite: Dictionary in scene.sprites():
+		if StringName(sprite["kind"]) == Gen2TitleScene.SPRITE_TRAIL:
+			out.append(sprite["at"])
+	return out
+
+
 func _spend(scene: Gen2TitleScene, frames: int, held: Array = []) -> void:
 	for _frame: int in frames:
 		scene.advance_frame(held)
@@ -186,7 +207,8 @@ func test_trails_are_spawned_behind_the_bird_and_fly_off() -> void:
 			return StringName(sprite["kind"]) == Gen2TitleScene.SPRITE_TRAIL
 	)
 	assert_gt(trails.size(), 0, "the screen is dropping trails")
-	assert_lte(trails.size(), Gen2TitleScene.MAX_SPRITE_STRUCTS)
+	## The bird holds the tenth struct for the whole screen, so nine is the cap.
+	assert_lte(trails.size(), Gen2TitleScene.MAX_TRAILS)
 	## `cp $a4 / jr nc, .delete` runs before the move, so the frame a particle
 	## lands on the edge is still drawn and the next one takes it away.
 	for trail: Dictionary in trails:
@@ -197,6 +219,96 @@ func test_trails_are_spawned_behind_the_bird_and_fly_off() -> void:
 	_spend(crystal, 40)
 	for sprite: Dictionary in crystal.sprites():
 		assert_eq(StringName(sprite["kind"]), Gen2TitleScene.SPRITE_CRYSTAL)
+
+
+## `UpdateTitleTrailSprite` reads the timer `TitleScreenScene` has already
+## counted down this frame, and `InitSpriteAnimStruct` runs behind
+## `PlaySpriteAnimations`, so a struct spawned now is not in shadow OAM until the
+## next frame. The timer is armed on frame 1 with its low two bits clear.
+func test_a_trail_is_drawn_the_frame_after_it_is_spawned() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.SILVER)
+	var grew: Array[int] = []
+	var count: int = 0
+	for frame: int in range(1, 13):
+		scene.advance_frame()
+		if _trails(scene).size() > count:
+			count = _trails(scene).size()
+			grew.append(frame)
+	assert_eq(grew, [2, 6, 10] as Array[int])
+
+
+## `AnimSeq_GSTitleTrail`'s Silver branch is a different routine under the same
+## name: no `inc [hl]` on the y coordinate, and no
+## `AnimSeqs_IncAnonJumptableIndex`, so `.zero` recomputes the sine every frame
+## off `wIntroSceneTimer`, which the union at `wJumptableIndex + 2` gives to
+## `LOW(wTitleScreenTimer)`.
+func test_silvers_trail_flies_level_on_a_sine_off_the_live_timer() -> void:
+	var scene := Gen2TitleScene.create(RomRegistry.SILVER, _sine())
+	var seen: Array[int] = []
+	var first := Vector2i(0, 0)
+	for _frame: int in 10:
+		scene.advance_frame()
+		var trails: Array[Vector2i] = _trails(scene)
+		if trails.is_empty():
+			continue
+		if seen.is_empty():
+			first = trails[0]
+		seen.append(trails[0].y)
+		assert_eq(trails[0].x, first.x + 4 * (seen.size() - 1), "four pixels a frame")
+
+	## `wIntroSceneTimer & $30` swapped is 0 to 3, so the amplitude is 3 to 6 and
+	## the trail stays inside that band of its own spawn row rather than falling.
+	var high: int = Gen2TitleScene.TRAIL_AT_SILVER.y + 6
+	for y: int in seen:
+		assert_between(y, Gen2TitleScene.TRAIL_AT_SILVER.y - 6, high)
+	assert_gt(_distinct(seen), 1, "and it is a sine rather than a straight line")
+
+	## Gold's own branch is the one that falls: its y coordinate takes an
+	## `inc [hl]` a frame under a sine of two.
+	var gold := Gen2TitleScene.create(RomRegistry.GOLD, _sine())
+	var gold_seen: Array[int] = []
+	for _frame: int in 10:
+		gold.advance_frame()
+		var trails: Array[Vector2i] = _trails(gold)
+		if not trails.is_empty():
+			gold_seen.append(trails[0].y)
+	assert_gt(gold_seen.size(), 4)
+	assert_between(
+		gold_seen[-1] - gold_seen[0], gold_seen.size() - 3, gold_seen.size() + 1,
+		"a pixel a frame, give or take the sine"
+	)
+
+
+## Gold's `.zero` seeds VAR1 with `SPRITEANIMSTRUCT_INDEX`, which is
+## `wSpriteAnimCount` at the spawn: four consecutive trails open a quarter turn
+## apart rather than all on the same phase.
+func test_golds_trails_open_on_their_own_phase() -> void:
+	var scene := Gen2TitleScene.create(RomRegistry.GOLD, _sine())
+	## Every Gold spawn row shares an x, and each trail moves four a frame, so the
+	## frame a trail was spawned on names it for as long as it is up.
+	var paths: Dictionary = {}
+	for frame: int in 40:
+		scene.advance_frame()
+		for at: Vector2i in _trails(scene):
+			var key: int = at.x - Gen2TitleScene.TRAIL_X_STEP * frame
+			if not paths.has(key):
+				paths[key] = [at.y]
+				continue
+			(paths[key] as Array).append(at.y - int((paths[key] as Array)[0]))
+	var shapes: Array[Array] = []
+	for key: int in paths:
+		var path: Array = (paths[key] as Array).slice(1, 12)
+		if path.size() == 11 and not shapes.has(path):
+			shapes.append(path)
+	assert_gt(shapes.size(), 1, "consecutive spawns ride the sine from different places")
+
+
+func _distinct(values: Array[int]) -> int:
+	var seen: Array[int] = []
+	for value: int in values:
+		if not seen.has(value):
+			seen.append(value)
+	return seen.size()
 
 
 ## `ScrollTitleScreenClouds`, which Gold runs on every eighth frame and Silver

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -596,12 +596,16 @@ func test_crystal_verbosegiveitemvar_reads_kurts_quantity_without_staging_a_swar
 		"kurt_apricorn_quantity": 3,
 	})
 	var result: Dictionary = runner.advance()
-	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	## `ScriptCall GiveItemScript`'s received line, not the swarm request a
+	## misread of this opcode would stage.
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(StringName(result["event"]["type"]), &"text", JSON.stringify(result))
+	assert_string_contains(String(result["event"]["text"]), data.item_name(1))
+
+	var finished: Dictionary = _drain_receipt(runner, runner.advance(true))
+	assert_eq(finished["status"], &"complete", JSON.stringify(finished))
 	assert_eq(state.item_quantity(1), 3)
 	assert_eq(state.swarm_map(), Vector2i(-1, -1))
-	assert_false(result["events"].any(func(event: Dictionary) -> bool:
-		return event.get("type", &"") == &"runtime_request"
-	))
 
 
 func test_random_unseen_wild_mon_uses_morning_rare_slots_and_seen_species() -> void:
@@ -5306,7 +5310,13 @@ func test_an_item_ball_is_dispatched_from_its_two_data_bytes() -> void:
 	assert_eq(results[0]["status"], &"waiting", JSON.stringify(results[0]))
 	assert_eq(results[0]["event"]["text"], "Found\n%s!" % _item_name(3))
 
-	var finished: Array = world.run_event_queue(true)
+	# `playsound SFX_ITEM` by name, not `specialsound`, and then `itemnotify`.
+	var notified: Array = _receipt_sound(world, &"sound")
+	assert_eq(
+		int(notified[0]["event"]["request"]["values"]["address"]),
+		Gen2WorldScriptRunner.SFX_ITEM
+	)
+	var finished: Array = _receipt_notify(world, 3)
 	assert_eq(finished[0]["status"], &"complete", JSON.stringify(finished[0]))
 	assert_eq(world.state.items().get(3, 0), 2)
 	# `disappear LAST_TALKED` writes the ball's own event flag, so it stays gone.
@@ -5384,7 +5394,10 @@ func test_a_hidden_item_is_dispatched_from_its_three_data_bytes() -> void:
 	# _PlayerFoundItemText is _FoundItemText's wording, so both share one string.
 	assert_eq(results[0]["event"]["text"], "Found\n%s!" % _item_name(3))
 
-	var finished: Array = world.run_event_queue(true)
+	# HiddenItemScript's own `specialsound` and `itemnotify`, which name the
+	# pocket the item landed in.
+	_receipt_sound(world, &"special_sound")
+	var finished: Array = _receipt_notify(world, 3)
 	assert_eq(finished[0]["status"], &"complete", JSON.stringify(finished[0]))
 	assert_eq(world.state.items().get(3, 0), 1)
 	# `callasm SetMemEvent` writes the record's own flag, not an object's.
@@ -5437,7 +5450,8 @@ func test_a_hidden_item_answers_only_while_its_flag_is_clear() -> void:
 
 	world.clear_event_flag(21)
 	assert_eq(world.interact().size(), 1)
-	assert_eq(world.run_event_queue(true)[0]["status"], &"complete")
+	_receipt_sound(world, &"special_sound")
+	assert_eq(_receipt_notify(world, 3)[0]["status"], &"complete")
 	assert_eq(world.state.items().get(3, 0), 1)
 	# And the flag it just wrote closes it again, so a second A press is inert.
 	assert_true(world.interact().is_empty())
@@ -5463,6 +5477,24 @@ func test_a_hidden_item_with_no_item_byte_fails_instead_of_running_data() -> voi
 
 func _item_name(number: int) -> String:
 	return GameData.open_directory(_directory).item_name(number)
+
+
+## `GiveItemScript`'s tail, which every item receipt now ends on. Acknowledging
+## the receipt's own line is what puts the sound out with the host.
+func _receipt_sound(world: Gen2WorldAPI, kind: StringName) -> Array:
+	var sound: Array = world.run_event_queue(true)
+	assert_eq(
+		StringName(sound[0]["event"]["request"]["values"]["kind"]), kind,
+		JSON.stringify(sound)
+	)
+	return sound
+
+
+## `itemnotify` behind the sound: one box naming the item and its pocket.
+func _receipt_notify(world: Gen2WorldAPI, item: int) -> Array:
+	var notified: Array = world.complete_runtime_request({"ok": true})
+	assert_string_contains(String(notified[0]["event"]["text"]), _item_name(item))
+	return world.run_event_queue(true)
 
 
 ## S2: `?RAM?CFA4?` was the text engine faithfully reporting an unresolved
@@ -5493,6 +5525,79 @@ func test_verbosegiveitem_fills_the_buffer_its_text_reads_by_address() -> void:
 		String(context["buffers"][RomLayout.STRING_BUFFER_4]), data.item_name(1),
 		"the same value is still reachable by text_buffer number"
 	)
+
+
+## `GiveItemScript`, which every `verbosegiveitem` calls: the received line, the
+## sound and `itemnotify`'s box, and on a full pack the same line followed by
+## `pocketisfull` instead. The line is printed either way, because the source's
+## `iffalse` sits behind its own `writetext`.
+func test_a_verbose_give_prints_the_line_the_pocket_and_the_full_branch() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6420"] = [
+		Gen2WorldScript.raw_opcode(0x9D, true), 1, 1, Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	## One pocket for the given item and the twenty that fill it, so
+	## `GetPocketName` has the same answer either way.
+	var items: Array = RomCache.read_json(RomCache.items_path(_directory))
+	for raw: Dictionary in items:
+		if int(raw.get("number", 0)) <= Gen2WorldPack.MAX_ITEMS + 1:
+			raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+	RomCache.write_json(RomCache.items_path(_directory), items)
+	var data: GameData = GameData.open_directory(_directory)
+	var request: Dictionary = {"kind": &"script", "bank": 48, "script": 0x6420}
+
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.from_dict({}), request)
+	assert_eq(runner.advance()["event"]["text"], "Received\n%s." % data.item_name(1))
+	var sound: Dictionary = runner.advance(true)
+	assert_eq(
+		StringName(sound["event"]["request"]["values"]["kind"]), &"special_sound",
+		JSON.stringify(sound)
+	)
+	var notified: Dictionary = runner.complete_runtime_request({"ok": true})
+	## `cont`, so the box scrolls one line and the item name stays under it.
+	assert_eq(
+		notified["event"]["text"],
+		"Put the\n%s in%sthe ITEM POCKET." % [
+			data.item_name(1), Gen2TextStream.SCROLL_BREAK,
+		]
+	)
+	assert_eq(runner.advance(true)["status"], &"complete")
+
+	## A pack with no room for it: `ReceiveItem` returns false, the line is still
+	## printed, and `pocketisfull` names the pocket that had no room.
+	var owned: Dictionary = {}
+	for number: int in range(2, 2 + Gen2WorldPack.MAX_ITEMS):
+		owned[number] = 1
+	var full := Gen2WorldState.new({}, {}, owned)
+	var refused := Gen2WorldScriptRunner.begin(data, full, request)
+	assert_eq(refused.advance()["event"]["text"], "Received\n%s." % data.item_name(1))
+	var pocket: Dictionary = refused.advance(true)
+	assert_eq(pocket["event"]["text"], "The ITEM POCKET\nis full…", JSON.stringify(pocket))
+	assert_eq(refused.advance(true)["status"], &"complete")
+	assert_eq(full.item_quantity(1), 0, "and nothing was received")
+
+
+## The command on its own, which seventy-nine scripts across the three cartridges
+## run after a plain `giveitem`. `CurItemName` reads wCurItem, so the box names
+## whatever that give wrote and the script runs on behind it.
+func test_itemnotify_names_the_item_the_give_before_it_wrote() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6430"] = [
+		Gen2WorldScript.GIVEITEM, 1, 1,
+		Gen2WorldScript.ITEMNOTIFY, Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	var runner := Gen2WorldScriptRunner.begin(data, state, {
+		"kind": &"script", "bank": 48, "script": 0x6430,
+	})
+	var notified: Dictionary = runner.advance()
+	assert_string_contains(String(notified["event"]["text"]), data.item_name(1))
+	assert_string_contains(String(notified["event"]["text"]), "POCKET")
+	assert_eq(runner.advance(true)["status"], &"complete")
+	assert_eq(state.item_quantity(1), 1)
 
 
 func test_text_ram_resolves_through_the_cartridges_own_pointer_table() -> void:
@@ -5672,6 +5777,21 @@ func _pick_fruit_tree(data: GameData, state: Gen2WorldState) -> Dictionary:
 	var second: Dictionary = runner.advance(true)
 	if StringName(second.get("status", &"")) != &"waiting":
 		return second
+	return _drain_receipt(runner, runner.advance(true))
+
+
+## The `specialsound` and `itemnotify` behind a successful give, which a full
+## pack or a bare tree never reaches: whatever the caller was already looking at
+## is returned untouched in that case.
+func _drain_receipt(runner: Gen2WorldScriptRunner, result: Dictionary) -> Dictionary:
+	if StringName(result.get("status", &"")) != &"waiting":
+		return result
+	var event: Dictionary = result.get("event", {})
+	if StringName(event.get("type", &"")) != &"runtime_request":
+		return result
+	var sounded: Dictionary = runner.complete_runtime_request({"ok": true})
+	if StringName(sounded.get("status", &"")) != &"waiting":
+		return sounded
 	return runner.advance(true)
 
 

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -504,8 +504,19 @@ func test_the_saved_quantity_sizes_a_later_verbosegiveitemvar() -> void:
 		GameData.open_directory(Fixture.directory()), _world.state,
 		{"kind": &"test", "bank": Fixture.BANK, "script": 0x6400}
 	)
+	## GiveItemScript's received line, its sound and its `itemnotify` box, which
+	## every verbose give ends on.
 	var result: Dictionary = later.advance()
-	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	var sounded: Dictionary = later.advance(true)
+	assert_eq(
+		StringName(sounded["event"]["request"]["kind"]), &"audio_requested",
+		JSON.stringify(sounded)
+	)
+	assert_eq(
+		later.complete_runtime_request({"ok": true})["status"], &"waiting"
+	)
+	assert_eq(later.advance(true)["status"], &"complete")
 	assert_eq(_world.state.item_quantity(BALL_LEVEL), 3)
 
 

--- a/tools/checks/item_balls.gd
+++ b/tools/checks/item_balls.gd
@@ -130,7 +130,7 @@ func _verify_hm07(data: GameData, game_id: StringName) -> void:
 		"%s: the HM07 ball did not pause on its found-item text." % game_id
 	)
 
-	var finished: Array = world.run_event_queue(true)
+	var finished: Array = _finish_receipt(world, world.run_event_queue(true))
 	_r.check(
 		not finished.is_empty()
 			and StringName(finished[0].get("status", &"")) == &"complete",
@@ -230,7 +230,7 @@ func _verify_hidden_items(data: GameData, game_id: StringName) -> void:
 			StringName(results[0].get("status", &"")) == &"waiting",
 			"%s: the hidden item on %s did not pause on its found-item text." % [game_id, cell]
 		)
-		var finished: Array = world.run_event_queue(true)
+		var finished: Array = _finish_receipt(world, world.run_event_queue(true))
 		_r.check(
 			not finished.is_empty()
 				and StringName(finished[0].get("status", &"")) == &"complete",
@@ -263,6 +263,20 @@ func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:
 			break
 		world.run_event_queue(true)
 	return world
+
+
+## `GiveItemScript`'s tail, which both receipts end on: the sound, which a host
+## answers, and then `itemnotify`'s own box.
+func _finish_receipt(world: Gen2WorldAPI, results: Array) -> Array:
+	if results.is_empty():
+		return results
+	if StringName(results[0].get("event", {}).get("type", &"")) != &"runtime_request":
+		return results
+	if world.complete_runtime_request({"ok": true}).is_empty():
+		return []
+	return world.run_event_queue(true)
+
+
 func _find_kind(results: Array, kind: StringName) -> Array:
 	var matching: Array = []
 	for result: Dictionary in results:


### PR DESCRIPTION
## Silver's title trail

`AnimSeq_GSTitleTrail` is two routines under one name, and only Gold's was
modelled. Silver's `.zero` never reaches `AnimSeqs_IncAnonJumptableIndex`, so it
runs every frame, and both numbers it wants come from `wIntroSceneTimer`, which
the union at `wJumptableIndex + 2` gives to `LOW(wTitleScreenTimer)`: the byte
the screen is counting down. Masked and swapped that is an amplitude of 3 to 6
and an angle step of 7 to 10. Silver's `.one` also has no `inc [hl]` on the y
coordinate, so its trails fly level on a live sine instead of falling on Gold's.

Three defects in the same routine, fixed here rather than filed:

- `UpdateTitleTrailSprite` reads the timer *after* `TitleScreenScene` has counted
  it down, so the spawn was one frame early.
- A struct spawned behind `PlaySpriteAnimations` reaches shadow OAM on the next
  frame, not this one.
- Gold's `.zero` seeds VAR1 from `wSpriteAnimCount`, so four consecutive trails
  open a quarter turn apart; they all shared one phase.

`TitleScreen` spawns the bird, copies the struct into `wSpriteAnim10` and clears
the slot it came from, which is what puts every later trail under the bird and
caps the trails at nine of the ten slots.

## Every item receipt

`GiveItemScript` was not modelled, so all 207 `verbosegiveitem`s in the corpus
handed over an item and printed nothing. It is now the received line, then the
sound and `itemnotify`'s pocket box, or `pocketisfull` on a full pack; the line
is printed either way, because the source's `iffalse` sits behind its own
`writetext`. The item ball, the hidden item and the fruit tree run the same tail,
each with the sound its own script plays: a ball uses `playsound SFX_ITEM` by
name, so a TM lying in one gets the ordinary jingle while the same TM handed over
by an NPC gets SFX_GET_TM. `itemnotify` and `pocketisfull` also answer as
commands now, for the 79 and 15 scripts that run them directly.

On a real cache, Ice Path 1F's ball reads `Found HM07!`, SFX_ITEM, `Put the HM07
in / the TM POCKET.`, the second box keeping the item name above the pocket
because the source's `cont` is a scroll rather than a page.

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 2,804 over 148 scripts, green |
| `validate.gd -- all` | exit 0, byte-identical to before |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk, three profiles | reaches Red on all three |
| Boot smoke | clean |