### PR TITLE
Diff the GameFreak logo against a running cartridge, and fix what it found

### DIFF
--- a/game/render/game_freak_presents_page.gd
+++ b/game/render/game_freak_presents_page.gd
@@ -25,6 +25,8 @@ const TRANSPARENT_INDEX: int = 0
 ## Shadow OAM counts from (8, 16), so a coordinate reaches the screen eight less
 ## across and sixteen less down.
 const OAM_ORIGIN := Vector2i(8, 16)
+## `wShadowOAM` holds forty sprites, the name the other opening pages use.
+const SHADOW_OAM_SPRITES: int = 40
 
 ## `.OAMData_GameFreakLogo1_3` and `.OAMData_GameFreakLogo4_11`, as
 ## (x, y, tile) with the `dbsprite` bytes already worked out. Crystal's Ditto is
@@ -58,6 +60,9 @@ const GOLD_SPARKLE_AT := Vector2i(-4, -4)
 ## `SPRITE_ANIM_DICT_GS_SPLASH` is $8d, the first tile of `gamefreak_logo.1bpp`,
 ## so a sprite tile past the logo's fifteen is one of the star sheet's five.
 const GOLD_SPRITE_FIRST_TILE: int = RomLayout.PRESENTS_WORD_TILES
+## The VRAM tile the dictionary maps those objects to, which is what a shadow-OAM
+## byte holds. Crystal decompresses the Ditto to `vTiles0` and counts from zero.
+const GOLD_SPRITE_VRAM_BASE: int = 0x8D
 
 var _profile: StringName = &"gold"
 var _background: PackedColorArray = PackedColorArray()
@@ -116,10 +121,46 @@ func draw(phase: Gen2GameFreakPresents) -> Image:
 	if phase != null:
 		_draw_words(indices, width, phase)
 	var image: Image = Gen2PicImage.from_indices(indices, width, height, _background)
-	if phase != null:
-		for sprite: Dictionary in phase.sprites():
-			_draw_sprite(image, phase, sprite)
+	for entry: Dictionary in shadow_oam(phase):
+		_draw_sprite(image, phase, entry)
 	return image
+
+
+## Every live struct expanded into the shadow OAM the hardware would hold, in
+## struct order, which is the z-order `PlaySpriteAnimations` walks. One entry
+## per drawn tile, `y` and `x` the OAM bytes and `tile` the byte `dbsprite`
+## writes, so a trace of this compares to a cartridge's own buffer line for
+## line. [method draw] blits this same list rather than re-deriving it.
+func shadow_oam(phase: Gen2GameFreakPresents) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	if phase == null:
+		return out
+	for sprite: Dictionary in phase.sprites():
+		var kind: StringName = StringName(sprite["kind"])
+		var at: Vector2i = sprite["at"]
+		var flip_y: bool = bool(sprite.get("flip_y", false))
+		for part: Dictionary in _oam_set(kind, int(sprite["set"])):
+			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing, so
+			# a busier frame loses its last sprites. No frame here reaches it.
+			if out.size() >= SHADOW_OAM_SPRITES:
+				return out
+			var offset: Vector2i = part["at"]
+			# `dbsprite`'s own OAM_XFLIP flips the tile where it stands. Only the
+			# struct's flip moves anything: `AddOrSubtractY` turns its offset into
+			# -8 - offset, added to the coordinate as a byte, so the position is
+			# worked out mod 256 and then clipped. Applying that to a per-tile
+			# attribute drew the star's two halves on top of each other.
+			if flip_y:
+				offset.y = -TILE - offset.y
+			out.append({
+				"y": (at.y + offset.y) & 0xFF,
+				"x": (at.x + offset.x) & 0xFF,
+				"tile": (_vram_base() + int(part["tile"])) & 0xFF,
+				"flip_x": bool(part.get("flip_x", false)),
+				"flip_y": flip_y,
+				"logo": kind == Gen2GameFreakPresents.SPRITE_LOGO,
+			})
+	return out
 
 
 ## `GameFreakPresents_PlaceGameFreak` and `_PlacePresents`, whichever of the two
@@ -142,40 +183,22 @@ func _draw_words(
 			column += 1
 
 
-## One sprite-anim struct's whole OAM set, positioned by its shadow-OAM
-## coordinate and drawn through the object palette, whose first colour is
+## One shadow-OAM entry, drawn through the object palette whose first colour is
 ## transparent.
 func _draw_sprite(
-	image: Image, phase: Gen2GameFreakPresents, sprite: Dictionary
+	image: Image, phase: Gen2GameFreakPresents, entry: Dictionary
 ) -> void:
 	# `dbsprite`'s attribute byte names the object palette. Only Gold's logo is
 	# drawn through palette 1, which is the one the rotation moves.
-	var palette: PackedColorArray = _object_palette(
-		phase, StringName(sprite["kind"]) == Gen2GameFreakPresents.SPRITE_LOGO
-	)
+	var palette: PackedColorArray = _object_palette(phase, bool(entry["logo"]))
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
-	var at: Vector2i = sprite["at"]
-	var flip_y: bool = bool(sprite.get("flip_y", false))
-	for part: Dictionary in _oam_set(StringName(sprite["kind"]), int(sprite["set"])):
-		var offset: Vector2i = part["at"]
-		var flip_x: bool = bool(part.get("flip_x", false))
-		# `AddOrSubtractY` and `AddOrSubtractX`: a flipped sprite's own offset
-		# becomes -8 - offset, and both are added to the struct's coordinate as
-		# bytes, so the whole position is worked out mod 256 and then clipped.
-		if flip_y:
-			offset.y = -TILE - offset.y
-		if flip_x:
-			offset.x = -TILE - offset.x
-		_blit_sprite_tile(
-			image, palette,
-			int(part["tile"]),
-			Vector2i(
-				((at.x + offset.x) & 0xFF) - OAM_ORIGIN.x,
-				((at.y + offset.y) & 0xFF) - OAM_ORIGIN.y,
-			),
-			flip_x, flip_y
-		)
+	_blit_sprite_tile(
+		image, palette,
+		int(entry["tile"]) - _vram_base(),
+		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
+		bool(entry["flip_x"]), bool(entry["flip_y"])
+	)
 
 
 ## The palette a sprite is drawn through: Crystal's Ditto colours with the
@@ -205,6 +228,11 @@ func _rotated_object_palette(order: int) -> PackedColorArray:
 	for index: int in _object.size():
 		out.append(_object[(order >> (index * 2)) & 0x03])
 	return out
+
+
+## Where the profile's sprite sheet sits in VRAM, which shadow OAM counts from.
+func _vram_base() -> int:
+	return 0 if _profile == RomRegistry.CRYSTAL else GOLD_SPRITE_VRAM_BASE
 
 
 ## `.OAMData_*` for one set, as [code]{ at, tile, flip_x }[/code] with the tile

--- a/game/world/game_freak_presents.gd
+++ b/game/world/game_freak_presents.gd
@@ -42,6 +42,13 @@ const SFX_GAME_FREAK_PRESENTS: int = 0xC9
 ## `GameFreakPresentsEnd` on Crystal and `.finish` on Gold: the same
 ## `ld c, 16 / call DelayFrames` after the tilemap and the sprites are cleared.
 const CLEANUP_FRAMES: int = 16
+## `GameFreakPresentsEnd` reaches `ClearSprites` only after `ClearTilemap`, whose
+## `WaitBGMap` spends `ld c, 4 / call DelayFrames`. `ClearSpriteAnims` in front
+## of it takes the structs away without writing shadow OAM, so the buffer holds
+## its last frame and the sprite stays up over the cleared tilemap for those
+## four. Measured against a cartridge: the Ditto is in OAM for four frames past
+## the pass that sets the exit bit.
+const CLEAR_TILEMAP_FRAMES: int = 4
 
 ## The two `PlaceString`s. Crystal writes them with `CopyBytes` at (5,10) and
 ## (7,11); Gold places them a row lower at (5,12) and (7,13). The codes are the
@@ -50,6 +57,13 @@ const WORD_GAME_FREAK: Array[int] = [0, 1, 2, 3, 13, 4, 5, 3, 1, 6]
 const WORD_PRESENTS: Array[int] = [7, 8, 9, 10, 11, 12]
 const WORD_AT_CRYSTAL: Array[Vector2i] = [Vector2i(5, 10), Vector2i(7, 11)]
 const WORD_AT_GOLD: Array[Vector2i] = [Vector2i(5, 12), Vector2i(7, 13)]
+
+## `NUM_SPRITE_ANIM_STRUCTS`. `_InitSpriteAnimStruct` walks the array for the
+## first free slot and returns carry when there is none, so a spawn past the
+## tenth does not happen at all: Gold's sparkles stop at nine because the logo
+## holds the other slot. Measured against a cartridge, which sits at twenty-four
+## sprites through the whole spray.
+const SPRITE_ANIM_STRUCTS: int = 10
 
 ## `OAM_YCOORD_HIDDEN`, which `GameFreakPresentsInit` parks the Ditto at until
 ## `GameFreakLogo_Bounce` writes a real offset.
@@ -109,6 +123,11 @@ var _finished: bool = false
 ## the top of the loop, never where they are set.
 var _exit: bool = false
 var _cleanup: int = 0
+## `ClearTilemap`'s frames still to spend before `ClearSprites` empties the
+## buffer, so the sprite stays up over the cleared tilemap.
+var _retain: int = 0
+## `wShadowOAM`, which only a sprite pass writes and only `ClearSprites` empties.
+var _shadow: Array[Dictionary] = []
 var _frame: int = 0
 var _words: int = 0
 var _events: Array[Dictionary] = []
@@ -117,8 +136,10 @@ var _events: Array[Dictionary] = []
 ## `GameFreakPresents_PlaceLogo` waits for.
 var _star_done: bool = false
 
-## One sprite-anim struct, of which the splash needs at most a Ditto or a star
-## and a logo, plus Gold's sparkles.
+## `wSpriteAnimationStructs`, ten slots of which an empty Dictionary is a free
+## one. Fixed rather than compacted: the slot is the z-order, so a sparkle that
+## dies leaves a hole the next one takes, and a spawn with nothing free is
+## dropped.
 var _actors: Array[Dictionary] = []
 var _logo_register: int = LOGO_REGISTER_FIRST
 var _logo_palette: int = OBJECT_PALETTE_ORDER
@@ -138,19 +159,23 @@ func start(profile: StringName, sine: Gen2BattleAnimData = null) -> void:
 	_finished = false
 	_exit = false
 	_cleanup = 0
+	_retain = 0
 	_star_done = false
 	_logo_register = LOGO_REGISTER_FIRST
 	_logo_palette = OBJECT_PALETTE_ORDER
 	_actors.clear()
+	for _slot: int in SPRITE_ANIM_STRUCTS:
+		_actors.append({})
+	_shadow.clear()
 	_events.clear()
 	if _is_crystal():
 		# `GameFreakPresentsInit` puts the Ditto up before the loop starts,
 		# parked off screen with its jump height and sine offset loaded.
-		_actors.append({
+		_actors[0] = {
 			"kind": SPRITE_DITTO, "at": SPRITE_AT, "offset": Vector2i(0, Y_HIDDEN),
 			"scene": 0, "var1": 96, "var2": 48, "frame": -1, "duration": 0,
 			"set": 0, "flip_y": false,
-		})
+		}
 
 
 func profile() -> StringName:
@@ -180,27 +205,27 @@ func word_positions() -> Array[Vector2i]:
 	return WORD_AT_CRYSTAL if _is_crystal() else WORD_AT_GOLD
 
 
-## Every sprite the frame draws, as
+## What the last `PlaySpriteAnimations` pass left in shadow OAM, as
 ## [code]{ kind, at, set, flip_y }[/code] in shadow-OAM coordinates.
+##
+## The buffer, not the live structs: `GameFreakPresentsInit` spawns one without
+## writing shadow OAM, and a struct the scene half of a pass spawns is only drawn
+## by the sprite half, which on Gold and Silver runs first and so does not see it
+## until the pass after. Nothing else clears the buffer, so it also survives
+## `ClearSpriteAnims` until `ClearSprites` reaches it.
 func sprites() -> Array[Dictionary]:
-	var out: Array[Dictionary] = []
-	for actor: Dictionary in _actors:
-		if not bool(actor.get("visible", true)):
-			continue
-		out.append({
-			"kind": actor["kind"],
-			"at": _oam_at(actor["at"], actor["offset"]),
-			"set": int(actor["set"]),
-			"flip_y": bool(actor.get("flip_y", false)),
-		})
-	return out
+	return _shadow.duplicate(true)
 
 
 ## Which `GameFreakDittoPaletteFade` colour the Ditto is wearing, or -1 before
 ## `GameFreakLogo_Transform` has written one.
+##
+## Applied in the pass that computes it, like the shadow OAM beside it:
+## `hCGBPalUpdate` and hDMATransfer are both serviced by the same VBlank, so the
+## palette and the sprites reach the screen together and neither is delayed here.
 func fade_step() -> int:
 	for actor: Dictionary in _actors:
-		if actor["kind"] == SPRITE_DITTO:
+		if actor.get("kind", SPRITE_NONE) == SPRITE_DITTO:
 			return int(actor.get("fade", -1))
 	return -1
 
@@ -230,6 +255,12 @@ func advance_frame() -> bool:
 	if _cleanup == 0 and _exit:
 		_enter_cleanup()
 	if _cleanup > 0:
+		# `ClearTilemap` spends its four frames with the buffer untouched, and
+		# `ClearSprites` empties it on the frame after the last of them.
+		if _retain > 0:
+			_retain -= 1
+		else:
+			_shadow.clear()
 		_cleanup -= 1
 		if _cleanup == 0:
 			_finished = true
@@ -257,9 +288,11 @@ func _is_crystal() -> bool:
 
 
 func _enter_cleanup() -> void:
-	_actors.clear()
+	# `ClearSpriteAnims` takes the structs away without touching the buffer.
+	_free_all()
 	_words = 0
-	_cleanup = CLEANUP_FRAMES
+	_retain = CLEAR_TILEMAP_FRAMES
+	_cleanup = CLEAR_TILEMAP_FRAMES + CLEANUP_FRAMES
 	_emit(&"clear", {})
 
 
@@ -307,13 +340,13 @@ func _advance_gold_scene() -> void:
 	match _scene:
 		0:
 			_star_done = false
-			_actors.append(_new_actor(SPRITE_STAR, SPRITE_AT, {"var1": 0x80, "angle": 0}))
+			_spawn(_new_actor(SPRITE_STAR, SPRITE_AT, {"var1": 0x80, "angle": 0}))
 			_emit(&"play_sfx", {"sfx": SFX_LOGO_GS})
 			_scene += 1
 		1:
 			if not _star_done:
 				return
-			_actors.append(_new_actor(SPRITE_LOGO, SPRITE_AT, {}))
+			_spawn(_new_actor(SPRITE_LOGO, SPRITE_AT, {}))
 			_scene += 1
 			_timer = 128
 		2:
@@ -345,9 +378,24 @@ func _spawn_sparkle(timer: int) -> void:
 	if timer & 1:
 		return
 	var vector: Vector2i = SPARKLE_VECTORS[(timer >> 1) & 0x0F]
-	_actors.append(_new_actor(SPRITE_SPARKLE, SPARKLE_AT, {
+	_spawn(_new_actor(SPRITE_SPARKLE, SPARKLE_AT, {
 		"angle": vector.x, "speed": vector.y << 8, "radius": 0,
 	}))
+
+
+## `_InitSpriteAnimStruct`: the first free slot takes it, and a full array
+## returns carry, which drops the spawn.
+func _spawn(actor: Dictionary) -> void:
+	for slot: int in _actors.size():
+		if (_actors[slot] as Dictionary).is_empty():
+			_actors[slot] = actor
+			return
+
+
+## `ClearSpriteAnims`, which zeroes every struct without writing shadow OAM.
+func _free_all() -> void:
+	for slot: int in _actors.size():
+		_actors[slot] = {}
 
 
 func _new_actor(kind: StringName, at: Vector2i, extra: Dictionary) -> Dictionary:
@@ -363,13 +411,28 @@ func _new_actor(kind: StringName, at: Vector2i, extra: Dictionary) -> Dictionary
 ## `DoNextFrameForAllSprites`, which runs each struct's own sequence and then
 ## advances its frameset.
 func _advance_sprites() -> void:
-	var live: Array[Dictionary] = []
-	for actor: Dictionary in _actors:
-		if not _advance_actor(actor):
+	_shadow = []
+	for slot: int in _actors.size():
+		var actor: Dictionary = _actors[slot]
+		if actor.is_empty():
 			continue
+		if not _advance_actor(actor):
+			# `DeinitSpriteAnimStruct` zeroes the slot, so the next pass skips
+			# it. This one does not: `DoNextFrameForAllSprites` calls
+			# `UpdateAnimFrame` whether or not the function deinitialised the
+			# struct, so a sprite that dies is drawn one last time. Measured
+			# against a cartridge: Gold's star is in OAM for a frame after it
+			# has gone, and every sparkle in the spray is.
+			_actors[slot] = {}
 		_advance_frameset(actor)
-		live.append(actor)
-	_actors = live
+		if not bool(actor.get("visible", true)):
+			continue
+		_shadow.append({
+			"kind": actor["kind"],
+			"at": _oam_at(actor["at"], actor["offset"]),
+			"set": int(actor["set"]),
+			"flip_y": bool(actor.get("flip_y", false)),
+		})
 
 
 func _advance_actor(actor: Dictionary) -> bool:

--- a/tests/unit/test_game_freak_presents.gd
+++ b/tests/unit/test_game_freak_presents.gd
@@ -10,12 +10,12 @@ const Presents := preload("res://game/world/game_freak_presents.gd")
 ## frame of `GameFreakLogo_Init`, fifty of `_Bounce`, thirty-three of `_Ditto`,
 ## sixty-five of `_Transform`, then thirty-three, sixty-five and a hundred and
 ## twenty-nine of `GameFreakPresentsScene`, the frame that reads the exit bit,
-## and `GameFreakPresentsEnd`'s sixteen. Gold is one frame of `_Star`, sixty-five
-## waiting for it, two runs of a hundred and twenty-nine either side of
-## `_PlacePresents`, the frame that sets the flag, the frame that reads it, and
-## the same sixteen.
-const CRYSTAL_FRAMES: int = 392
-const GOLD_FRAMES: int = 342
+## and `GameFreakPresentsEnd`'s four of `ClearTilemap` plus sixteen. Gold is one
+## frame of `_Star`, sixty-five waiting for it, two runs of a hundred and
+## twenty-nine either side of `_PlacePresents`, the frame that sets the flag, the
+## frame that reads it, and the same twenty.
+const CRYSTAL_FRAMES: int = 396
+const GOLD_FRAMES: int = 346
 
 
 func _run(profile: StringName, frames: int = 0) -> Gen2GameFreakPresents:
@@ -140,13 +140,18 @@ func test_the_transform_walks_every_fade_colour_and_then_starts_the_words() -> v
 
 ## Gold's `GameFreakPresents_PlaceLogo` waits on `wIntroSceneFrameCounter`, which
 ## only `AnimSeq_GSGameFreakLogoStar` sets, so the two are joined through the
-## sprite layer rather than by a count: the star is gone on exactly the frame the
-## logo arrives.
+## sprite layer rather than by a count. The star draws once more on the frame it
+## dies, because `DoNextFrameForAllSprites` calls `UpdateAnimFrame` whether or
+## not the sequence deinitialised the struct, so the logo arrives the frame
+## after that.
 func test_the_gold_logo_arrives_when_the_star_does_not_and_not_before() -> void:
 	var before: Gen2GameFreakPresents = _run(&"gold", 65)
 	assert_eq(_kinds(before), [Presents.SPRITE_STAR])
 
-	var after: Gen2GameFreakPresents = _run(&"gold", 66)
+	var dying: Gen2GameFreakPresents = _run(&"gold", 66)
+	assert_eq(_kinds(dying), [Presents.SPRITE_STAR], "drawn once after it is freed")
+
+	var after: Gen2GameFreakPresents = _run(&"gold", 67)
 	assert_eq(_kinds(after), [Presents.SPRITE_LOGO])
 
 
@@ -167,8 +172,11 @@ func test_the_gold_logo_rotates_its_palette_three_times_and_then_holds() -> void
 
 
 ## `GameFreakPresents_Sparkle` runs on every second frame of the sparkle timer,
-## so a hundred and twenty-eight frames produce sixty-four sparks, each living
-## its own vector's distance times sixteen frames.
+## which asks for sixty-four sparks over a hundred and twenty-eight frames. Most
+## of them never exist: `_InitSpriteAnimStruct` returns carry when all ten
+## `wSpriteAnimationStructs` are taken, and the logo holds one of them, so the
+## spray sits at nine and a spawn with nothing free is dropped. Measured against
+## a cartridge, whose busiest sparkle frame is twenty-four sprites.
 func test_gold_sprays_a_sparkle_every_other_frame_and_each_expires() -> void:
 	var phase := Presents.new()
 	phase.start(&"gold", _sine())
@@ -180,8 +188,8 @@ func test_gold_sprays_a_sparkle_every_other_frame_and_each_expires() -> void:
 		var now: int = _kinds(phase).count(Presents.SPRITE_SPARKLE)
 		spawned += maxi(now - before, 0)
 		most = maxi(most, now)
-	assert_eq(spawned, 64)
-	assert_gt(most, 0)
+	assert_eq(spawned, 27, "the rest find no free struct")
+	assert_eq(most, Presents.SPRITE_ANIM_STRUCTS - 1, "the logo holds the tenth")
 	assert_eq(_kinds(phase), [], "and none outlives the phase")
 
 
@@ -194,25 +202,37 @@ func test_a_button_cancels_it_and_still_spends_the_cleanup_frames() -> void:
 		assert_true(phase.cancel())
 		assert_false(phase.cancel(), "the bit is already set")
 		assert_false(phase.finished())
-		for _frame: int in Presents.CLEANUP_FRAMES - 1:
+		for _frame: int in Presents.CLEAR_TILEMAP_FRAMES + Presents.CLEANUP_FRAMES - 1:
 			phase.advance_frame()
 		assert_false(phase.finished(), "%s" % profile)
 		phase.advance_frame()
 		assert_true(phase.finished())
-		assert_eq(phase.frame(), 40 + Presents.CLEANUP_FRAMES)
+		assert_eq(
+			phase.frame(),
+			40 + Presents.CLEAR_TILEMAP_FRAMES + Presents.CLEANUP_FRAMES
+		)
 		assert_eq(phase.words(), 0, "ClearTilemap")
 		assert_eq(_kinds(phase), [], "ClearSpriteAnims")
 
 
-## The last sixteen frames are spent with the screen already cleared, which is
-## `GameFreakPresentsEnd`'s own order: clear, then `DelayFrames`.
-func test_the_screen_is_cleared_before_the_last_sixteen_frames() -> void:
-	var phase: Gen2GameFreakPresents = _run(
+## `GameFreakPresentsEnd`'s own order: `ClearSpriteAnims` and `ClearTilemap`
+## first, so the words go at once and the sprite stays up for the four frames
+## `WaitBGMap` spends, and only then does `ClearSprites` empty the buffer for the
+## last sixteen. Measured against a cartridge, which holds the Ditto in OAM for
+## four frames past the pass that sets the exit bit.
+func test_the_sprite_outlasts_the_words_by_the_cleartilemap_frames() -> void:
+	var last: Gen2GameFreakPresents = _run(
+		RomRegistry.CRYSTAL, CRYSTAL_FRAMES - Presents.CLEANUP_FRAMES
+	)
+	assert_false(last.finished())
+	assert_eq(last.words(), 0, "ClearTilemap has already run")
+	assert_eq(_kinds(last), [Presents.SPRITE_DITTO], "ClearSprites has not")
+
+	var cleared: Gen2GameFreakPresents = _run(
 		RomRegistry.CRYSTAL, CRYSTAL_FRAMES - Presents.CLEANUP_FRAMES + 1
 	)
-	assert_false(phase.finished())
-	assert_eq(phase.words(), 0)
-	assert_eq(_kinds(phase), [])
+	assert_false(cleared.finished())
+	assert_eq(_kinds(cleared), [])
 
 
 ## Without an imported sine table the phase still spends the cartridge's frames;

--- a/tests/unit/test_game_freak_presents_page.gd
+++ b/tests/unit/test_game_freak_presents_page.gd
@@ -29,6 +29,29 @@ func _run(game_id: StringName, frames: int) -> Gen2GameFreakPresents:
 	return phase
 
 
+## `.OAMData_GSGameFreakLogoStar` draws two tiles and their X flips, and
+## `dbsprite`'s own OAM_XFLIP flips a tile where it stands. Only a struct's flip
+## moves anything, so the four entries sit in a 16x16 square rather than two on
+## top of two. Measured against a cartridge, whose star is at x 191 and 199 on
+## the frame it is thrown.
+func test_the_stars_flipped_halves_sit_beside_the_ones_they_mirror() -> void:
+	var page: Gen2GameFreakPresentsPage = _page(&"gold")
+	# The scene half of a pass spawns it and the sprite half, which runs first on
+	# Gold, only reaches it on the pass after.
+	var star: Gen2GameFreakPresents = _run(&"gold", 2)
+	var entries: Array[Dictionary] = page.shadow_oam(star)
+	assert_eq(entries.size(), 4, "the star's whole set")
+	var flipped: Array = entries.filter(func(e: Dictionary) -> bool: return e["flip_x"])
+	assert_eq(flipped.size(), 2, "two of the four are the mirrored halves")
+	var columns: Array = []
+	for entry: Dictionary in entries:
+		if not columns.has(entry["x"]):
+			columns.append(entry["x"])
+	columns.sort()
+	assert_eq(columns.size(), 2, "two columns, not one")
+	assert_eq(int(columns[1]) - int(columns[0]), 8, "a tile apart")
+
+
 ## `ClearTilemap` runs before anything else and the words are placed onto it, so
 ## the screen opens black and stays black everywhere the two strings are not.
 func test_the_screen_opens_cleared_and_the_words_land_on_their_own_rows() -> void:

--- a/tests/unit/test_splash_screen.gd
+++ b/tests/unit/test_splash_screen.gd
@@ -77,7 +77,10 @@ func test_only_the_gamefreak_half_reads_a_button() -> void:
 	_splash.advance_frames(Gen2BootCinema.COPYRIGHT_HOLD_FRAMES + 20)
 	assert_eq(_splash.visible_image(), &"game_freak_presents")
 	assert_true(_splash.handle_button(Gen2Button.A))
-	_splash.advance_frames(Gen2GameFreakPresents.CLEANUP_FRAMES - 1)
+	_splash.advance_frames(
+		Gen2GameFreakPresents.CLEAR_TILEMAP_FRAMES
+		+ Gen2GameFreakPresents.CLEANUP_FRAMES - 1
+	)
 	assert_eq(_closed, 0)
 	_splash.advance_frames(1)
 	assert_eq(_closed, 1)

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -1,0 +1,112 @@
+extends SceneTree
+
+## Dumps the opening's shadow OAM, one line per sprite per frame, against a real
+## cache.
+##
+##   Godot --headless --path . -s res://tools/trace_opening_oam.gd -- <game> <phase> [out.txt]
+##
+## `phase` is `presents` today. The artefact is the one `.claude/verification.md`
+## step 2 asks for: two faithful implementations of `PlaySpriteAnimations` put
+## the same sprites in the same slots on the same frames, so a `diff` against a
+## cartridge running under an emulator settles the port rather than a frame count
+## measured from the port itself. `tools/render_audio.gd` is the same shape for
+## the driver's register writes.
+##
+## A line is `frame slot y x tile`, with `y` and `x` the OAM bytes: a cartridge's
+## own buffer is read at the frame boundary, where hDMATransfer copies it.
+##
+## A fourth argument writes the page's own picture for those frames, named after
+## each, so the frame a diff points at can be looked at beside the emulator's.
+## The page draws into an `Image`, so this stays headless;
+## `tools/preview_intro.gd` photographs the same screen through the boot
+## cinema, whose frames count from the copyright rather than from this phase.
+
+const PHASES: Array[String] = ["presents"]
+
+## Frames to write a PNG for, beside the trace's own output path.
+var _shots: Dictionary = {}
+var _shot_prefix: String = "res://presents"
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2 or not PHASES.has(args[1]):
+		push_error(
+			"Usage: trace_opening_oam.gd -- <game> <%s> [out.txt]"
+			% "|".join(PHASES)
+		)
+		quit(1)
+		return
+	var data: GameData = _open(StringName(args[0]))
+	if data == null:
+		quit(1)
+		return
+	if args.size() > 2:
+		_shot_prefix = args[2].get_basename()
+	if args.size() > 3:
+		for value: String in args[3].split(","):
+			_shots[int(value)] = true
+	var lines: PackedStringArray = _trace_presents(data)
+	if args.size() > 2:
+		var file := FileAccess.open(args[2], FileAccess.WRITE)
+		if file == null:
+			push_error("Could not write %s." % args[2])
+			quit(1)
+			return
+		file.store_string("\n".join(lines) + "\n")
+		print("%d lines to %s" % [lines.size(), args[2]])
+	else:
+		print("\n".join(lines))
+	quit(0)
+
+
+## `GameFreakPresentsScene` from its first frame to the one it sets its own exit
+## bit on, which is what the phase's pinned budget counts.
+func _trace_presents(data: GameData) -> PackedStringArray:
+	var page: Gen2GameFreakPresentsPage = Gen2GameFreakPresentsPage.from_data(data)
+	if page == null:
+		push_error("%s has no GameFreak Presents art." % data.id)
+		return PackedStringArray()
+	var phase := Gen2GameFreakPresents.new()
+	phase.start(data.id, Gen2BattleAnimData.from_game_data(data))
+	var out := PackedStringArray()
+	var frame: int = 0
+	var words: int = -1
+	while not phase.finished():
+		_append_frame(out, frame, page.shadow_oam(phase))
+		if _shots.has(frame):
+			var image: Image = page.draw(phase)
+			if image != null:
+				image.save_png("%s_f%d.png" % [_shot_prefix, frame])
+		# The words are background, so they are not in the trace; printing the
+		# frame each is placed on is what aligns it, since a cartridge's own
+		# tilemap says the same thing.
+		if phase.words() != words:
+			words = phase.words()
+			print("frame %d: words %d" % [frame, words])
+		phase.advance_frame()
+		frame += 1
+	_append_frame(out, frame, page.shadow_oam(phase))
+	print("frame %d: finished" % frame)
+	return out
+
+
+func _append_frame(out: PackedStringArray, frame: int, entries: Array[Dictionary]) -> void:
+	var slot: int = 0
+	for entry: Dictionary in entries:
+		out.append("%d %d %d %d %d" % [
+			frame, slot, int(entry["y"]), int(entry["x"]), int(entry["tile"]),
+		])
+		slot += 1
+
+
+func _open(game: StringName) -> GameData:
+	var sha1: String = RomRegistry.sha1_for(game)
+	var directory: String = RomCache.directory_for(game, sha1) if not sha1.is_empty() else ""
+	if directory.is_empty() or not RomCache.is_usable(directory):
+		push_error("No cache for %s. Run tools/import_rom.gd first." % game)
+		return null
+	var data: GameData = GameData.open_directory(directory)
+	if data == null:
+		push_error("Could not open the cache for %s." % game)
+	return data

--- a/tools/trace_opening_oam.gd.uid
+++ b/tools/trace_opening_oam.gd.uid
@@ -1,0 +1,1 @@
+uid://bgtrqnedrkoax


### PR DESCRIPTION
The opening was ported frame by frame from `GameFreakPresentsScene` but never
diffed against a real dump, so its pinned budgets only ever proved the port
self-consistent. This adds the comparable artefact and fixes what comparing
found.

`tools/trace_opening_oam.gd` dumps the phase's shadow OAM, one line per sprite
per frame, against a real cache. That is the visual equivalent of
`tools/render_audio.gd`'s register trace: two faithful implementations of
`PlaySpriteAnimations` put the same sprites in the same slots on the same
frames. `Gen2GameFreakPresentsPage.shadow_oam()` builds it and `draw()` blits
that same list, so the trace is what gets drawn rather than a second
derivation of it.

## What the diff found

| Defect | Source |
|---|---|
| Shadow OAM was the live struct list, not the buffer | only a sprite pass writes it, only `ClearSprites` empties it |
| The struct pool was unbounded | `_InitSpriteAnimStruct` returns carry when all ten `wSpriteAnimationStructs` are taken |
| A struct that died vanished immediately | `DoNextFrameForAllSprites` calls `UpdateAnimFrame` whether or not the sequence deinitialised it |
| A per-tile `OAM_XFLIP` moved its tile | only a struct flip does; the star's two halves were drawn on top of each other |

Gold asks for sixty-four sparkles and gets twenty-seven, because the logo holds
one of the ten slots and the spray sits at nine.

## Result

- Crystal: all 380 sprite frames identical, slot for slot, tile bytes included.
- Crystal, pixels: 375 of those 380 frames identical when the page's own render
  is compared against the emulator's framebuffer. The five that are not are the
  frames a word is placed or cleared, where `UpdateBGMap` copies a third of the
  rows per frame and this port writes the tilemap in one act.
- Gold and Silver: all 257 distinct buffer states identical, in order. The
  cartridge additionally drops about five frames where the sparkle spray
  overruns VBlank, which is CPU load this port does not model.
- The phase costs 396 frames on Crystal and 346 on Gold and Silver, four more
  than before: `GameFreakPresentsEnd` clears the tilemap first, and
  `ClearTilemap` spends `WaitBGMap`'s four frames before `ClearSprites` reaches
  the buffer, so the sprite stays up over a cleared screen for those four.

## Checks

- Unit tier 2,485 green; full tiered suite 2,805 green over 148 scripts, no orphans.
- `tools/validate.gd -- all`: 40 topics pass on all three cartridges.
- Boot smoke clean.