### PR TITLE
Diff the title screen against a running cartridge, and fix the trail

### DIFF
--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -20,6 +20,8 @@ const TRANSPARENT_INDEX: int = 0
 ## Shadow OAM counts from (8, 16), so a coordinate reaches the screen eight less
 ## across and sixteen less down.
 const OAM_ORIGIN := Vector2i(8, 16)
+## `wShadowOAM` holds forty sprites.
+const SHADOW_OAM_SPRITES: int = 40
 ## `TILEMAP_WIDTH_PX`: the BG map is 32 tiles across and wraps.
 const MAP_WIDTH: int = RomLayout.TITLE_TILEMAP_COLUMNS * Gen2Tiles.TILE_WIDTH
 ## `set B_LCDC_OBJ_SIZE`: every object on this screen is two tiles tall.
@@ -142,6 +144,10 @@ const TRAIL_TILES: Array[int] = [0x00, 0x02]
 ## `TitleScreen` copies the trail into `vTiles1 tile $78`, which the object
 ## layer addresses as tile $78 of the second sheet.
 const TRAIL_PALETTE: int = 1
+## `spriteanimoam $f8` and `$fa`: where those two tiles land in the object
+## layer's own numbering, which is what a shadow-OAM byte holds. The bird and
+## Crystal's crystal are both at the bottom of VRAM and count from zero.
+const TRAIL_VRAM_BASE: int = 0xF8
 
 ## `TitleScreenGFX2` is loaded at `vTiles1` and `GFX1` at `vTiles2`, so a
 ## tilemap code below $80 is the top half and one at or above it the bottom.
@@ -235,9 +241,41 @@ func draw(scene: Gen2TitleScene) -> Image:
 		_draw_gs_background()
 	_compose(image, scene)
 
-	for sprite: Dictionary in scene.sprites():
-		_draw_sprite(image, scene, sprite)
+	for entry: Dictionary in shadow_oam(scene):
+		_draw_sprite(image, entry)
 	return image
+
+
+## Every object expanded into the shadow OAM the hardware would hold, in struct
+## order, which is the z-order `PlaySpriteAnimations` walks. `y` and `x` are the
+## OAM bytes and `tile` the byte `dbsprite` writes; the screen is in 8x16 mode,
+## so one entry is two tiles and the second is `tile + 1`. [method draw] blits
+## this same list rather than re-deriving it, and a trace of it compares to a
+## cartridge's own buffer line for line.
+func shadow_oam(scene: Gen2TitleScene) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	if scene == null:
+		return out
+	for sprite: Dictionary in scene.sprites():
+		var kind: StringName = StringName(sprite["kind"])
+		var at: Vector2i = sprite["at"]
+		var name: String = _sprite_sheet(kind)
+		for part: Vector3i in _oam_set(kind, int(sprite.get("tile", 0))):
+			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
+			if out.size() >= SHADOW_OAM_SPRITES:
+				return out
+			var tile: int = int(sprite.get("tile", 0)) if name == "title_crystal" else part.z
+			out.append({
+				# `UpdateAnimFrame` builds every position with `add`, so an
+				# offset past the screen wraps rather than clamping.
+				"y": (at.y + part.y) & 0xFF,
+				"x": (at.x + part.x) & 0xFF,
+				"tile": (_vram_base(name) + tile) & 0xFF,
+				"palette": int(sprite.get("palette", 0)),
+				"behind": bool(sprite.get("behind", false)),
+				"sheet": name,
+			})
+	return out
 
 
 ## The BG map through `hSCX` and whatever `wLYOverrides` is writing over it, one
@@ -314,28 +352,26 @@ func _gs_palette(row: int, column: int) -> int:
 	return 0
 
 
-## One object's whole OAM set, positioned by its shadow-OAM coordinate and drawn
-## through an object palette, whose first colour is transparent.
-func _draw_sprite(image: Image, scene: Gen2TitleScene, sprite: Dictionary) -> void:
-	var palette: PackedColorArray = _palette(_object, int(sprite.get("palette", 0)))
+## One shadow-OAM entry, drawn through an object palette whose first colour is
+## transparent. The screen is in 8x16 mode, so the entry's tile is the top half
+## and the one after it the bottom.
+func _draw_sprite(image: Image, entry: Dictionary) -> void:
+	var palette: PackedColorArray = _palette(_object, int(entry["palette"]))
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
-	var at: Vector2i = sprite["at"]
-	for part: Vector3i in _oam_set(StringName(sprite["kind"]), int(sprite.get("tile", 0))):
-		var name: String = _sprite_sheet(StringName(sprite["kind"]))
-		# `UpdateAnimFrame` builds every position with `add`, so an offset past
-		# the screen wraps rather than clamping.
-		var to := Vector2i(
-			((at.x + part.x) & 0xFF) - OAM_ORIGIN.x,
-			((at.y + part.y) & 0xFF) - OAM_ORIGIN.y,
+	var to := Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y)
+	var sheet: String = String(entry["sheet"])
+	for half: int in OBJECT_HEIGHT:
+		_blit_sprite_tile(
+			image, palette, sheet, int(entry["tile"]) - _vram_base(sheet) + half,
+			Vector2i(to.x, to.y + half * TILE), bool(entry["behind"])
 		)
-		var base: int = int(sprite.get("tile", 0)) if name == "title_crystal" else part.z
-		for half: int in OBJECT_HEIGHT:
-			_blit_sprite_tile(
-				image, palette, name, base + half,
-				Vector2i(to.x, to.y + half * TILE),
-				bool(sprite.get("behind", false))
-			)
+
+
+## Where a sheet sits in the object layer's numbering, which shadow OAM counts
+## from and the sheets themselves do not.
+func _vram_base(sheet: String) -> int:
+	return TRAIL_VRAM_BASE if sheet == "title_trail" else 0
 
 
 func _sprite_sheet(kind: StringName) -> String:
@@ -356,7 +392,11 @@ func _oam_set(kind: StringName, frame: int) -> Array[Vector3i]:
 		Gen2TitleScene.SPRITE_CRYSTAL:
 			return [Vector3i(0, 0, 0)] as Array[Vector3i]
 		Gen2TitleScene.SPRITE_TRAIL:
-			return [TRAIL_AT] as Array[Vector3i]
+			# The frameset's own two sets, which are one picture each.
+			return [Vector3i(
+				TRAIL_AT.x, TRAIL_AT.y,
+				TRAIL_TILES[clampi(frame, 0, TRAIL_TILES.size() - 1)]
+			)] as Array[Vector3i]
 		_:
 			var sets: Array[Vector2i] = (
 				BIRD_SETS_GOLD if _profile == RomRegistry.GOLD else BIRD_SETS_SILVER

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -131,6 +131,12 @@ const TRAIL_SINE_AMPLITUDE: int = 2
 ## 10.
 const TRAIL_SILVER_TIMER_MASK: int = 0x30
 const TRAIL_SILVER_TIMER_SHIFT: int = 4
+## `.Frameset_GSTitleTrail`, as (OAM set, duration) pairs. Gold alternates the
+## two `spriteanimoam` vtiles and `oamrestart`s, so each picture is up for two
+## frames; Silver holds the first and `oamend`s, which repeats it forever. A
+## frame lasts its duration plus one, the way `GetSpriteAnimFrame` counts.
+const TRAIL_FRAMESET_GOLD: Array[Vector2i] = [Vector2i(0, 1), Vector2i(1, 1)]
+const TRAIL_FRAMESET_SILVER: Array[Vector2i] = [Vector2i(0, 32)]
 const TRAIL_SILVER_AMPLITUDE_BASE: int = 3
 const TRAIL_SILVER_STEP_BASE: int = 7
 
@@ -321,6 +327,7 @@ func _advance_trails() -> void:
 			trail["var1"] = (int(trail["var1"]) + TRAIL_SINE_STEP) & 0xFF
 			trail["yoffset"] = _lift(int(trail["var1"]), TRAIL_SINE_AMPLITUDE)
 		trail["at"] = at
+		_advance_trail_frameset(trail)
 		alive.append(trail)
 	_trails = alive
 	if (_timer & TRAIL_SPAWN_MASK) != 0 or _trails.size() >= MAX_TRAILS:
@@ -336,9 +343,28 @@ func _advance_trails() -> void:
 	_anim_count = (_anim_count + 1) & 0xFF
 	if _anim_count == 0:
 		_anim_count = 1
-	_trails.append(
-		{"at": spawn, "var1": 0, "yoffset": 0, "fresh": true, "index": _anim_count}
-	)
+	_trails.append({
+		"at": spawn, "var1": 0, "yoffset": 0, "fresh": true, "index": _anim_count,
+		"set": 0, "frame": -1, "duration": 0,
+	})
+
+
+## `GetSpriteAnimFrame` for one trail. The counter starts at -1 and the duration
+## is loaded on the pass that reads an entry, so an `oamframe X, n` is drawn
+## n + 1 times; Gold `oamrestart`s to the first entry and Silver `oamend`s, which
+## repeats the last for as long as the sprite is up.
+func _advance_trail_frameset(trail: Dictionary) -> void:
+	var frames: Array[Vector2i] = TRAIL_FRAMESET_GOLD if _profile == RomRegistry.GOLD \
+		else TRAIL_FRAMESET_SILVER
+	if int(trail["duration"]) > 0:
+		trail["duration"] = int(trail["duration"]) - 1
+		return
+	var at: int = int(trail["frame"]) + 1
+	if at >= frames.size():
+		at = 0 if _profile == RomRegistry.GOLD else frames.size() - 1
+	trail["frame"] = at
+	trail["set"] = frames[at].x
+	trail["duration"] = frames[at].y
 
 
 ## `AnimSeqs_Sine` over `BattleAnimSineWave`, as the byte `UpdateAnimFrame` adds
@@ -462,7 +488,7 @@ func _bird_sprites() -> Array[Dictionary]:
 		out.append({
 			"kind": SPRITE_TRAIL,
 			"at": Vector2i(trail_at.x, (trail_at.y + int(trail["yoffset"])) & 0xFF),
-			"tile": 0, "palette": 1,
+			"tile": int(trail["set"]), "palette": 1,
 		})
 
 	var amplitude: int = BIRD_SINE_GOLD if _profile == RomRegistry.GOLD else BIRD_SINE_SILVER

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -54,7 +54,11 @@ const CRYSTAL_STEP: int = 2
 const SUICUNE_FRAME_MASK: int = 0b111
 const SUICUNE_FRAMES: Array[int] = [0x80, 0x88, 0x00, 0x08]
 ## `LoadSuicuneFrame` draws six rows of eight from whichever base it is handed.
+## Its `d` rises by one across each of the eight columns and then by eight more
+## at the end of the row, so a row starts sixteen tiles past the one above it:
+## the sheet is sixteen wide and only its left half is on screen.
 const SUICUNE_COLUMNS: int = 8
+const SUICUNE_ROW_STRIDE: int = 16
 const SUICUNE_ROWS: int = 6
 const SUICUNE_AT := Vector2i(6, 12)
 ## `Decompress` puts the sheet at `vTiles4`, which is tile $80 of the bank the
@@ -438,7 +442,7 @@ func suicune_tiles() -> Array[Vector3i]:
 		for column: int in SUICUNE_COLUMNS:
 			out.append(Vector3i(
 				SUICUNE_AT.x + column, SUICUNE_AT.y + row,
-				base + row * SUICUNE_COLUMNS + column
+				base + row * SUICUNE_ROW_STRIDE + column
 			))
 	return out
 

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -149,12 +149,17 @@ func test_the_suicune_frame_changes_every_eighth_frame() -> void:
 	assert_eq(_scene(RomRegistry.GOLD).suicune_base(), -1, "Gold has no Suicune")
 
 
-## `LoadSuicuneFrame` writes six rows of eight from the base it is handed.
+## `LoadSuicuneFrame` writes six rows of eight from the base it is handed, and
+## its `d` takes eight more at the end of each row than the eight it stepped
+## across, so the sheet it reads is sixteen wide and only its left half is drawn.
+## Measured against a cartridge: at a stride of eight the strip is torn, tiles
+## from one row of the sheet landing in the next.
 func test_the_suicune_strip_is_six_rows_of_eight() -> void:
 	var placed: Array[Vector3i] = _scene(RomRegistry.CRYSTAL).suicune_tiles()
 	assert_eq(placed.size(), Gen2TitleScene.SUICUNE_ROWS * Gen2TitleScene.SUICUNE_COLUMNS)
 	assert_eq(placed[0], Vector3i(6, 12, 0x00))
-	assert_eq(placed[8], Vector3i(6, 13, 0x08), "the next row is eight tiles on")
+	assert_eq(placed[7], Vector3i(13, 12, 0x07), "eight across")
+	assert_eq(placed[8], Vector3i(6, 13, 0x10), "and sixteen on to the next row")
 
 
 ## `InitializeBackground`: thirty 8x16 objects, five rows of six, all behind the

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -237,6 +237,41 @@ func test_a_trail_is_drawn_the_frame_after_it_is_spawned() -> void:
 	assert_eq(grew, [2, 6, 10] as Array[int])
 
 
+## `.Frameset_GSTitleTrail`: Gold alternates the two `spriteanimoam` vtiles and
+## `oamrestart`s, so each of the trail's two pictures is up for two frames, and
+## Silver holds the first and `oamend`s, which repeats it for as long as the
+## sprite is up. Measured against a cartridge, whose trail entries carry tile
+## $f8 and $fa on Gold and only $f8 on Silver.
+func test_golds_trail_alternates_its_two_pictures_and_silvers_does_not() -> void:
+	var gold := Gen2TitleScene.create(RomRegistry.GOLD, _sine())
+	var sets: Array[int] = []
+	for _frame: int in 20:
+		gold.advance_frame()
+		for sprite: Dictionary in gold.sprites():
+			if StringName(sprite["kind"]) != Gen2TitleScene.SPRITE_TRAIL:
+				continue
+			var set: int = int(sprite["tile"])
+			if sets.is_empty() or sets[sets.size() - 1] != set:
+				sets.append(set)
+			break
+	# Every trail on screen is on the same phase, since they are spawned on a
+	# four-frame cadence and the frameset's cycle is four frames long.
+	assert_eq(
+		sets, [0, 1, 0, 1, 0, 1, 0, 1, 0, 1] as Array[int],
+		"two frames each, then oamrestart"
+	)
+
+	var silver := Gen2TitleScene.create(RomRegistry.SILVER, _sine())
+	var held: Array[int] = []
+	for _frame: int in 20:
+		silver.advance_frame()
+		for sprite: Dictionary in silver.sprites():
+			if StringName(sprite["kind"]) == Gen2TitleScene.SPRITE_TRAIL \
+					and not held.has(int(sprite["tile"])):
+				held.append(int(sprite["tile"]))
+	assert_eq(held, [0] as Array[int], "oamend repeats the first")
+
+
 ## `AnimSeq_GSTitleTrail`'s Silver branch is a different routine under the same
 ## name: no `inc [hl]` on the y coordinate, and no
 ## `AnimSeqs_IncAnonJumptableIndex`, so `.zero` recomputes the sine every frame

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -5,7 +5,7 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/trace_opening_oam.gd -- <game> <phase> [out.txt]
 ##
-## `phase` is `presents` today. The artefact is the one `.claude/verification.md`
+## `phase` is `presents` or `title`. The artefact is the one `.claude/verification.md`
 ## step 2 asks for: two faithful implementations of `PlaySpriteAnimations` put
 ## the same sprites in the same slots on the same frames, so a `diff` against a
 ## cartridge running under an emulator settles the port rather than a frame count
@@ -21,7 +21,11 @@ extends SceneTree
 ## `tools/preview_intro.gd` photographs the same screen through the boot
 ## cinema, whose frames count from the copyright rather than from this phase.
 
-const PHASES: Array[String] = ["presents"]
+const PHASES: Array[String] = ["presents", "title"]
+
+## The title screen runs until its own timeout, which is longer than anything
+## worth diffing; this is well past `TitleScreenEnd`'s own count.
+const TITLE_FRAME_CAP: int = 4000
 
 ## Frames to write a PNG for, beside the trace's own output path.
 var _shots: Dictionary = {}
@@ -46,7 +50,8 @@ func _initialize() -> void:
 	if args.size() > 3:
 		for value: String in args[3].split(","):
 			_shots[int(value)] = true
-	var lines: PackedStringArray = _trace_presents(data)
+	var lines: PackedStringArray = _trace_presents(data) if args[1] == "presents" \
+		else _trace_title(data)
 	if args.size() > 2:
 		var file := FileAccess.open(args[2], FileAccess.WRITE)
 		if file == null:
@@ -87,6 +92,35 @@ func _trace_presents(data: GameData) -> PackedStringArray:
 		phase.advance_frame()
 		frame += 1
 	_append_frame(out, frame, page.shadow_oam(phase))
+	print("frame %d: finished" % frame)
+	return out
+
+
+## `TitleScreenScene` from its first frame, which is the entrance scrolling the
+## screen in, to the one that answers. Driven with no buttons held, the way a
+## cartridge left alone runs it, so the timeout is what ends it.
+func _trace_title(data: GameData) -> PackedStringArray:
+	var page: Gen2TitlePage = Gen2TitlePage.from_data(data)
+	if page == null:
+		push_error("%s has no title screen art." % data.id)
+		return PackedStringArray()
+	var scene: Gen2TitleScene = Gen2TitleScene.create(
+		data.id, Gen2BattleAnimData.from_game_data(data)
+	)
+	var out := PackedStringArray()
+	var frame: int = 0
+	var where: StringName = &""
+	while not scene.finished() and frame < TITLE_FRAME_CAP:
+		_append_frame(out, frame, page.shadow_oam(scene))
+		if _shots.has(frame):
+			var image: Image = page.draw(scene)
+			if image != null:
+				image.save_png("%s_f%d.png" % [_shot_prefix, frame])
+		if scene.scene() != where:
+			where = scene.scene()
+			print("frame %d: %s" % [frame, where])
+		scene.advance_frame()
+		frame += 1
 	print("frame %d: finished" % frame)
 	return out
 


### PR DESCRIPTION
The second phase of the opening, through the same seam as the GameFreak logo:
`tools/trace_opening_oam.gd` learns `title`, and `Gen2TitlePage.shadow_oam()`
builds the buffer that `draw()` blits, so the trace is what gets drawn.

## Crystal's sprites

Exact. 4,000 consecutive frames of shadow OAM against a real dump, slot for
slot and tile byte for tile byte.

## Three defects

| Defect | Source |
|---|---|
| Gold's trail never animated | `.Frameset_GSTitleTrail` alternates two `spriteanimoam` vtiles every two frames and `oamrestart`s under `_GOLD`, holds the first and `oamend`s under `_SILVER`. One symbol, two framesets. |
| The trail's shadow-OAM tile was 0 | the object layer holds `$f8`/`$fa`; the page now reports the hardware byte and maps back to its own sheet when drawing |
| The Suicune strip was torn | `LoadSuicuneFrame` steps eight across a row and then adds eight more, so rows are sixteen apart; this walked it eight at a time and drew each row from halfway through the one above. The comment beside it already said sixteen. |

## What cannot be aligned, and why

Gold and Silver's bird matches its OAM set sequence 600 of 600 frames at one
offset, and its `AnimSeqs_Sine` bob 600 of 600 at another ten frames away. Both
sequences are right and they cannot be aligned at once.

That is the cartridge's own doing. `TitleScreen` spawns the bird and copies it
into `wSpriteAnim10` with `ld bc, NUM_SPRITE_ANIM_STRUCTS` where the struct is
`SPRITEANIMSTRUCT_LENGTH` - ten bytes of sixteen. INDEX through DURATIONOFFSET
are copied; **FRAME, JUMPTABLE_INDEX and VAR1 are not**, and arrive as whatever
the intro movie left in that slot. The bird's wing counter and its sine phase
are leftovers rather than zeroes. Recorded rather than guessed at; Crystal's
Suicune strip has the same inherited phase.

## Still open, and now measured

The background is not verified by a sprite trace. Rendering the screen beside
the dump puts the remaining difference at about 7,000 pixels of 23,040 on a
sampled frame, almost all of it two things: Crystal's copyright line is drawn
nowhere here (`hlbgcoord 3, 0, vBGMap1`, one row of 13 tiles from $0c), and
rows 3 to 9 differ where the crystal shows through the logo's own colour 0.
Both are in HANDOFF.

## Checks

- Unit tier 2,486 green; full tiered suite 2,806 green over 148 scripts, no orphans.
- `tools/validate.gd -- all`: 40 topics pass on all three cartridges.