### PR TITLE
Diff both intro movies against a running cartridge

### DIFF
--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -292,12 +292,48 @@ func draw(movie: Gen2GoldSilverIntro) -> Image:
 	if movie == null:
 		return image
 	_draw_background(image, movie)
-	var room: int = SHADOW_OAM_SPRITES
-	for sprite: Dictionary in movie.sprites():
-		room -= _draw_sprite(image, movie, sprite, room)
-		if room <= 0:
-			break
+	for entry: Dictionary in shadow_oam(movie):
+		_draw_sprite(image, movie, entry)
 	return image
+
+
+## Every live struct expanded into the shadow OAM the hardware would hold, in
+## struct order, which is the z-order `PlaySpriteAnimations` walks. `y` and `x`
+## are the OAM bytes and `tile` the byte `dbsprite` writes. [method draw] blits
+## this same list rather than re-deriving it, so a trace of it compares to a
+## cartridge's own buffer line for line.
+func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	if movie == null:
+		return out
+	for sprite: Dictionary in movie.sprites():
+		var index: int = int(sprite["set"])
+		if index < 0 or index >= OAM_SETS.size():
+			continue
+		var set: Dictionary = OAM_SETS[index]
+		var at: Vector2i = sprite["at"]
+		var flip_x: bool = bool(sprite["flip_x"])
+		for part: Array in set["parts"]:
+			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
+			if out.size() >= SHADOW_OAM_SPRITES:
+				return out
+			var dx: int = int(part[1])
+			var attrs: int = int(part[3])
+			# `AddOrSubtractX`: a flipped frameset turns a part's own offset into
+			# -8 - offset before it is added.
+			if flip_x:
+				dx = -TILE - dx
+			out.append({
+				# `UpdateAnimFrame` builds every position with `add`, so an
+				# offset past the screen wraps rather than clamping.
+				"y": (at.y + int(part[0])) & 0xFF,
+				"x": (at.x + dx) & 0xFF,
+				"tile": (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF,
+				"palette": 1 if attrs & ATTR_PALETTE else 0,
+				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
+				"flip_y": bool(attrs & ATTR_YFLIP),
+			})
+	return out
 
 
 ## The BG map, sampled through `hSCX` and the scanline's own `hSCY`. Both are
@@ -333,47 +369,19 @@ func _draw_background(image: Image, movie: Gen2GoldSilverIntro) -> void:
 			)
 
 
-## One sprite-anim struct's whole OAM set. Every position is worked out as a
-## byte and then clipped, because `UpdateAnimFrame` builds them with `add`: an
-## offset past the screen wraps rather than clamping.
-## Returns how many shadow-OAM entries it took, which is what the next struct
-## has fewer of.
-func _draw_sprite(
-	image: Image, movie: Gen2GoldSilverIntro, sprite: Dictionary, room: int
-) -> int:
-	var index: int = int(sprite["set"])
-	if index < 0 or index >= OAM_SETS.size():
-		return 0
-	var set: Dictionary = OAM_SETS[index]
-	var parts: Array = (set["parts"] as Array).slice(0, room)
-	var strip: PackedByteArray = _sheet(
-		String((CUTSCENE_SHEETS.get(movie.cutscene(), {}) as Dictionary).get("obj", ""))
+## One shadow-OAM entry, off the cutscene's own object sheet. The position is
+## already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
+func _draw_sprite(image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary) -> void:
+	var palette: PackedColorArray = movie.object_palette(int(entry["palette"]))
+	if palette.size() <= TRANSPARENT_INDEX:
+		return
+	_blit_sprite_tile(
+		image,
+		_sheet(String((CUTSCENE_SHEETS.get(movie.cutscene(), {}) as Dictionary).get("obj", ""))),
+		palette, int(entry["tile"]),
+		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
+		bool(entry["flip_x"]), bool(entry["flip_y"])
 	)
-	var at: Vector2i = sprite["at"]
-	var flip_x: bool = bool(sprite["flip_x"])
-	for part: Array in parts:
-		var dy: int = int(part[0])
-		var dx: int = int(part[1])
-		var attrs: int = int(part[3])
-		# `AddOrSubtractX`: a flipped frameset turns a part's own offset into
-		# -8 - offset before it is added.
-		if flip_x:
-			dx = -TILE - dx
-		var tile: int = (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF
-		var palette: PackedColorArray = movie.object_palette(
-			1 if attrs & ATTR_PALETTE else 0
-		)
-		if palette.size() <= TRANSPARENT_INDEX:
-			continue
-		_blit_sprite_tile(
-			image, strip, palette, tile,
-			Vector2i(
-				((at.x + dx) & 0xFF) - OAM_ORIGIN.x,
-				((at.y + dy) & 0xFF) - OAM_ORIGIN.y,
-			),
-			bool(attrs & ATTR_XFLIP) != flip_x, bool(attrs & ATTR_YFLIP)
-		)
-	return parts.size()
 
 
 func _blit_sprite_tile(

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -241,12 +241,53 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	if movie == null:
 		return image
 	_draw_background(image, movie)
-	var room: int = SHADOW_OAM_SPRITES
-	for sprite: Dictionary in movie.sprites():
-		room -= _draw_sprite(image, movie, sprite, room)
-		if room <= 0:
-			break
+	for entry: Dictionary in shadow_oam(movie):
+		_draw_sprite(image, movie, entry)
 	return image
+
+
+## Every live struct expanded into the shadow OAM the hardware would hold, in
+## struct order, which is the z-order `PlaySpriteAnimations` walks. `y` and `x`
+## are the OAM bytes and `tile` the byte `dbsprite` writes. [method draw] blits
+## this same list rather than re-deriving it, so a trace of it compares to a
+## cartridge's own buffer line for line.
+func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	if movie == null:
+		return out
+	for sprite: Dictionary in movie.sprites():
+		var index: int = int(sprite["set"])
+		if index < 0 or index >= OAM_SETS.size():
+			continue
+		var set: Dictionary = OAM_SETS[index]
+		var at: Vector2i = sprite["at"]
+		var flip_x: bool = bool(sprite["flip_x"])
+		var flip_y: bool = bool(sprite["flip_y"])
+		for part: Array in set["parts"]:
+			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
+			if out.size() >= SHADOW_OAM_SPRITES:
+				return out
+			var dy: int = int(part[0])
+			var dx: int = int(part[1])
+			var attrs: int = int(part[3])
+			# `AddOrSubtractX`/`_Y`: a flipped frameset turns a part's own offset
+			# into -8 - offset before it is added.
+			if flip_x:
+				dx = -TILE - dx
+			if flip_y:
+				dy = -TILE - dy
+			out.append({
+				# `UpdateAnimFrame` builds every position with `add`, so an
+				# offset past the screen wraps rather than clamping.
+				"y": (at.y + dy) & 0xFF,
+				"x": (at.x + dx) & 0xFF,
+				"tile": (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF,
+				"palette": attrs & ATTR_PALETTE,
+				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
+				"flip_y": bool(attrs & ATTR_YFLIP) != flip_y,
+				"bank1": bool(sprite["bank1"]),
+			})
+	return out
 
 
 ## The BG map, sampled through `hSCY` and the scanline's own `hSCX`. Both are
@@ -302,52 +343,22 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
 			image.set_pixel(x, y, palette[pixel])
 
 
-## One sprite-anim struct's whole OAM set. Every position is worked out as a
-## byte and then clipped, because `UpdateAnimFrame` builds them with `add`: an
-## offset past the screen wraps rather than clamping.
-## Returns how many shadow-OAM entries it took, which is what the next struct has
-## fewer of.
-func _draw_sprite(
-	image: Image, movie: Gen2IntroMovie, sprite: Dictionary, room: int
-) -> int:
-	var set: Dictionary = OAM_SETS[int(sprite["set"])] if int(sprite["set"]) < OAM_SETS.size() \
-		else {}
-	if set.is_empty():
-		return 0
-	var parts: Array = (set["parts"] as Array).slice(0, room)
+## One shadow-OAM entry, off the sheet its struct was loaded into. The position
+## is already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
+func _draw_sprite(image: Image, movie: Gen2IntroMovie, entry: Dictionary) -> void:
 	var strip: PackedByteArray = _sheet(
-		movie, movie.sheet("obj_bank1" if bool(sprite["bank1"]) else "obj")
+		movie, movie.sheet("obj_bank1" if bool(entry["bank1"]) else "obj")
 	)
 	if strip.is_empty():
-		return parts.size()
-	var at: Vector2i = sprite["at"]
-	var flip_x: bool = bool(sprite["flip_x"])
-	var flip_y: bool = bool(sprite["flip_y"])
-	for part: Array in parts:
-		var dy: int = int(part[0])
-		var dx: int = int(part[1])
-		var attrs: int = int(part[3])
-		var part_x: bool = bool(attrs & ATTR_XFLIP) != flip_x
-		var part_y: bool = bool(attrs & ATTR_YFLIP) != flip_y
-		# `AddOrSubtractX`/`_Y`: a flipped frameset turns a part's own offset
-		# into -8 - offset before it is added.
-		if flip_x:
-			dx = -TILE - dx
-		if flip_y:
-			dy = -TILE - dy
-		var tile: int = (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF
-		var palette: PackedColorArray = movie.object_palette(attrs & ATTR_PALETTE)
-		if palette.size() <= TRANSPARENT_INDEX:
-			continue
-		_blit_sprite_tile(
-			image, strip, palette, tile,
-			Vector2i(
-				((at.x + dx) & 0xFF) - OAM_ORIGIN.x,
-				((at.y + dy) & 0xFF) - OAM_ORIGIN.y,
-			),
-			part_x, part_y
-		)
-	return parts.size()
+		return
+	var palette: PackedColorArray = movie.object_palette(int(entry["palette"]))
+	if palette.size() <= TRANSPARENT_INDEX:
+		return
+	_blit_sprite_tile(
+		image, strip, palette, int(entry["tile"]),
+		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
+		bool(entry["flip_x"]), bool(entry["flip_y"])
+	)
 
 
 func _blit_sprite_tile(

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -106,10 +106,19 @@ const STARTERS: Dictionary = {
 
 ## `Intro_InitBubble.pixel_table`, read `ld e, [hl] / inc hl / ld d, [hl]`, so
 ## each row is (x, y) rather than the (y, x) every `depixel` in the file is.
+##
+## The index is `(wIntroFrameCounter1 & $70) swap 4`, which runs 0 to 7 over a
+## table of six: rows 6 and 7 are the first four bytes of `Intro_InitMagikarps`
+## read as coordinates. `depixel 8, 7, 0, 7` assembles to `ld de, $403f`, so
+## those bytes are $11 $3f $40 and then the `ldh a, [hSGB]` opcode $f0. The
+## counter opens at $80 and is decremented before the spawn, so 7 is the first
+## row the scene reaches and the two overread bubbles are the two the cartridge
+## shows first.
 const BUBBLE_AT: Array[Vector2i] = [
 	Vector2i(6 * 8, 14 * 8 + 4), Vector2i(14 * 8, 18 * 8 + 4),
 	Vector2i(10 * 8, 16 * 8 + 4), Vector2i(12 * 8, 15 * 8),
 	Vector2i(4 * 8, 13 * 8), Vector2i(8 * 8, 17 * 8),
+	Vector2i(0x11, 0x3F), Vector2i(0x40, 0xF0),
 ]
 
 ## `Intro_InitMagikarps`' two alternating triples, as `depixel` (y, x) pairs
@@ -230,7 +239,16 @@ var _bg_map: PackedByteArray = PackedByteArray()
 var _meta_at: int = 0
 var _bg_map_at: int = 0
 
-var _actors: Array[Dictionary] = []
+## `wSpriteAnimationStructs`: ten slots, an empty one free. Slot order is
+## z-order, and `_InitSpriteAnimStruct` takes the first free one, so a struct
+## spawned into the gap a deleted one left draws under everything spawned before
+## it.
+var _actors: Array[Dictionary] = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]
+## `wSpriteAnimCount`, which is `SPRITEANIMSTRUCT_INDEX` and a spawn counter
+## rather than a slot number. `ClearSpriteAnims` zeroes it with the structs.
+var _anim_count: int = 0
+## `wShadowOAM`, written by the sprite pass alone. See [method sprites].
+var _shadow: Array[Dictionary] = []
 ## Frames a scene spends inside `DelayFrames`, during which neither the
 ## jumptable nor `PlaySpriteAnimations` runs.
 var _delay: int = 0
@@ -334,25 +352,13 @@ func _reordered(run: PackedInt32Array, index: int, order: int) -> PackedColorArr
 	return out
 
 
-## Every live sprite-anim struct as the shadow OAM it produces, in struct order,
-## which is the z-order: `_InitSpriteAnimStruct` takes the first free slot and
-## `PlaySpriteAnimations` walks them in order.
+## `wShadowOAM` as `PlaySpriteAnimations` last left it, which is a buffer rather
+## than a view of the live structs. `.PlayFrame` writes it before the scene body
+## runs, so a `wGlobalAnimYOffset` a scene moves reaches the screen on the pass
+## after the one that moved it; reading the structs here instead would put every
+## global offset a pass early.
 func sprites() -> Array[Dictionary]:
-	var out: Array[Dictionary] = []
-	for actor: Dictionary in _actors:
-		var entry: Array = _actor_frame(actor)
-		if entry.is_empty():
-			continue
-		out.append({
-			"at": Vector2i(
-				(int(actor["x"]) + int(actor["x_offset"]) + _global_x) & 0xFF,
-				(int(actor["y"]) + int(actor["y_offset"]) + _global_y) & 0xFF,
-			),
-			"set": int(entry[0]),
-			"flip_x": bool(int(entry[2]) & FLIP_X),
-			"vtile": int(actor["vtile"]),
-		})
-	return out
+	return _shadow
 
 
 func drain_events() -> Array[Dictionary]:
@@ -733,7 +739,7 @@ func _scene_end() -> void:
 ## for the fire cutscene, which blanks the map instead of drawing one.
 func _load_cutscene(name: StringName, first_row: int) -> void:
 	_cutscene = name
-	_actors.clear()
+	_clear_sprite_anims()
 	_bg_map.fill(0)
 	_bg_map_at = 0
 	if first_row < 0:
@@ -971,7 +977,7 @@ func _animate_fireball() -> void:
 func _init_bubble() -> void:
 	if _counter1 & 0x0F != 0:
 		return
-	_spawn(&"bubble", BUBBLE_AT[((_counter1 & 0x70) >> 4) % BUBBLE_AT.size()])
+	_spawn(&"bubble", BUBBLE_AT[(_counter1 & 0x70) >> 4])
 
 
 ## `Intro_InitShellders`: three `depixel`s falling one into the next, so only the
@@ -1022,10 +1028,28 @@ func _init_pikachu() -> void:
 	_spawn(&"pikachu_tail", Vector2i(24 * 8, 14 * 8))
 
 
-## `_InitSpriteAnimStruct`, which takes the first free slot. [param at] is the
-## shadow-OAM pixel as (x, y), which is the order the struct stores.
+## `ClearSpriteAnims`, which zeroes the whole of `wSpriteAnimData`: the structs
+## and the spawn counter their index field is taken from.
+func _clear_sprite_anims() -> void:
+	for slot: int in _actors.size():
+		_actors[slot] = {}
+	_anim_count = 0
+
+
+## `_InitSpriteAnimStruct`, which takes the first free slot and returns carry
+## when there is none, dropping the spawn. [param at] is the shadow-OAM pixel as
+## (x, y), which is the order the struct stores.
 func _spawn(object: StringName, at: Vector2i) -> Dictionary:
+	var slot: int = _actors.find({})
+	if slot < 0:
+		return {}
+	# `inc [hl]` and then a skip past zero, so the count never wraps to the byte
+	# a free slot is recognised by.
+	_anim_count = (_anim_count + 1) & 0xFF
+	if _anim_count == 0:
+		_anim_count = 1
 	var actor: Dictionary = {
+		"index": _anim_count,
 		"object": object,
 		"frameset": StringName((OBJECTS[object] as Dictionary)["frameset"]),
 		"func": StringName((OBJECTS[object] as Dictionary)["func"]),
@@ -1035,7 +1059,7 @@ func _spawn(object: StringName, at: Vector2i) -> Dictionary:
 		"duration": 0, "frame": -1,
 		"jumptable": 0, "var1": 0, "var2": 0,
 	}
-	_actors.append(actor)
+	_actors[slot] = actor
 	return actor
 
 
@@ -1048,8 +1072,16 @@ func _reinit_frameset(actor: Dictionary, frameset: StringName) -> void:
 
 ## `PlaySpriteAnimations`: each struct's own callback, then its frame counter.
 func _run_sprites() -> void:
-	var deleted: Array[Dictionary] = []
+	# `DeinitializeSprite` clears the struct's index and nothing else, and
+	# `DoNextFrameForAllSprites` reaches `UpdateAnimFrame` whether or not the
+	# sequence called it, so a sprite that deletes itself is drawn one last
+	# time; the pass after it is the one that skips the slot.
+	for slot: int in _actors.size():
+		if bool((_actors[slot] as Dictionary).get("deinit", false)):
+			_actors[slot] = {}
 	for actor: Dictionary in _actors.duplicate():
+		if actor.is_empty():
+			continue
 		var alive: bool = true
 		match StringName(actor["func"]):
 			&"bubble":
@@ -1075,14 +1107,31 @@ func _run_sprites() -> void:
 			&"cyndaquil":
 				_sprite_starter(actor, 0x30, 0x10)
 		if not alive:
-			deleted.append(actor)
-	var kept: Array[Dictionary] = []
-	for actor: Dictionary in _actors:
-		if actor in deleted:
+			actor["deinit"] = true
+	# `UpdateAnimFrame` writes each struct's OAM as it is reached, and
+	# `PlaySpriteAnimations` blanks whatever the last pass left past the end.
+	_shadow = []
+	for slot: int in _actors.size():
+		var actor: Dictionary = _actors[slot]
+		if actor.is_empty():
 			continue
-		if _advance_actor(actor):
-			kept.append(actor)
-	_actors = kept
+		if not _advance_actor(actor):
+			# `oamdelete` takes the struct away without reaching the OAM write,
+			# unlike a sequence deinitialising itself.
+			_actors[slot] = {}
+			continue
+		var entry: Array = _actor_frame(actor)
+		if entry.is_empty():
+			continue
+		_shadow.append({
+			"at": Vector2i(
+				(int(actor["x"]) + int(actor["x_offset"]) + _global_x) & 0xFF,
+				(int(actor["y"]) + int(actor["y_offset"]) + _global_y) & 0xFF,
+			),
+			"set": int(entry[0]),
+			"flip_x": bool(int(entry[2]) & FLIP_X),
+			"vtile": int(actor["vtile"]),
+		})
 
 
 ## `AnimSeq_GSIntroBubble`: up one pixel a frame on a sine of amplitude 8, gone
@@ -1109,9 +1158,9 @@ func _sprite_shellder(actor: Dictionary) -> bool:
 func _sprite_magikarp(actor: Dictionary) -> bool:
 	if int(actor["jumptable"]) == 0:
 		actor["jumptable"] = 1
-		# `SPRITEANIMSTRUCT_INDEX and $3, swapped`, which is the slot's own place
-		# in the triple turned into a starting angle.
-		actor["var1"] = ((_actors.find(actor) & 0x03) << 4) & 0xFF
+		# `SPRITEANIMSTRUCT_INDEX and $3, swapped`: the struct's own spawn number
+		# turned into a starting angle, which is what spreads the triple.
+		actor["var1"] = ((int(actor["index"]) & 0x03) << 4) & 0xFF
 	var offset: int = int(actor["x_offset"])
 	if offset >= 0xF0:
 		return false
@@ -1164,7 +1213,7 @@ func _lapras_bob(actor: Dictionary) -> bool:
 func _sprite_note(actor: Dictionary) -> bool:
 	if int(actor["jumptable"]) == 0:
 		actor["jumptable"] = 1
-		actor["var1"] = ((_actors.find(actor) & 0x01) << 5) & 0xFF
+		actor["var1"] = ((int(actor["index"]) & 0x01) << 5) & 0xFF
 	var offset: int = int(actor["x_offset"])
 	if offset >= 0x80:
 		return false
@@ -1260,8 +1309,8 @@ func _sprite_pikachu_tail(actor: Dictionary) -> bool:
 func _sprite_fireball(actor: Dictionary) -> void:
 	if int(actor["jumptable"]) == 0:
 		actor["jumptable"] = 1
-		var slot: int = _actors.find(actor)
-		actor["var1"] = (((slot & 0x04) << 1) + ((slot & 0x03) << 4)) & 0xFF
+		var index: int = int(actor["index"])
+		actor["var1"] = (((index & 0x04) << 1) + ((index & 0x03) << 4)) & 0xFF
 		return
 	actor["x"] = (int(actor["x"]) - 4) & 0xFF
 	var amplitude: int = int(actor["var2"])

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -194,6 +194,22 @@ const SCENE_PALETTE: Dictionary = {
 ## `IntroScene26`, the one setup scene whose palette clear is `ClearBGPalettes`.
 const SCENE_CRYSTAL_UNOWNS: int = 25
 
+## The tiles each setup scene's `Intro_DecompressRequest2bpp_*` calls ask for, in
+## order. `Request2bpp` is what makes a setup scene expensive: it hands VBlank
+## `TILES_PER_CYCLE` tiles at a time and spends a `DelayFrame` on each, so a
+## 128-tile sheet costs seventeen frames and the 255-tile one thirty-two. Half
+## the movie's length is these waits.
+const SCENE_REQUESTS: Dictionary = {
+	0: [64, 128, 128, 64], 2: [64, 128, 64], 4: [64, 128, 128, 64],
+	6: [64, 128, 255, 128, 64], 10: [64, 128, 64], 12: [64, 255, 128, 64],
+	14: [64, 128, 128, 64], 16: [64, 255, 64], 18: [64, 128, 128, 64],
+	25: [64, 128, 64],
+}
+## `TILES_PER_CYCLE` (home/gfx.asm).
+const TILES_PER_CYCLE: int = 8
+## `ClearTilemap`'s `WaitBGMap` tail, which every setup scene pays.
+const CLEAR_TILEMAP_FRAMES: int = 4
+
 ## `Intro_RustleGrass`'s `.RustlingGrassPointers`, four tiles at `vTiles2 tile
 ## $09` swapped every four frames for the first thirty-six of `IntroScene10`.
 const GRASS_FRAMES: Array[String] = ["grass_1", "grass_2", "grass_3", "grass_2"]
@@ -503,6 +519,10 @@ func _setup_scene() -> void:
 		if vram.has(part) and not vram.has("%s_first" % part):
 			_vram.erase("%s_first" % part)
 	_actors.clear()
+	# `wGlobalAnimXOffset` lives inside `wSpriteAnimData`, so `ClearSpriteAnims`
+	# takes it with the structs: the offset the jump scene walked to $80 does not
+	# survive into the scene after it.
+	_global_x_offset = 0
 	_tilemap = PackedByteArray()
 	_attr_override = PackedByteArray()
 	_sprite_vtile = 0
@@ -514,8 +534,13 @@ func _setup_scene() -> void:
 		_load_palettes(name)
 	# `Intro_ClearBGPals` spends two `DelayFrame`s. `IntroScene26` is the one
 	# setup scene that calls `ClearBGPalettes` instead, whose `WaitBGMap` tail
-	# spends four.
-	_delay = 4 if _scene == SCENE_CRYSTAL_UNOWNS else 2
+	# spends four. `ClearTilemap` then spends four of its own, and every sheet
+	# the scene asks for is a `Request2bpp` wait on top.
+	_delay = CLEAR_TILEMAP_FRAMES + (4 if _scene == SCENE_CRYSTAL_UNOWNS else 2)
+	for tiles: int in SCENE_REQUESTS.get(_scene, []):
+		# `.cycle` spends a frame per `TILES_PER_CYCLE`, and the remainder below
+		# one cycle spends a last one whether or not there is anything left.
+		_delay += tiles / TILES_PER_CYCLE + 1
 	_counter = 0
 	_timer = 0
 	_next_scene()
@@ -995,13 +1020,17 @@ func _run_sprites() -> void:
 
 ## `SpriteAnimFunc_IntroSuicune`: still until `wIntroSceneTimer` is set, then a
 ## jump on a sine of amplitude 32 and the second frameset under it.
+##
+## The reinit is unconditional in the source and has to stay that way:
+## `_ReinitSpriteAnimFrame` puts FRAME back to -1 and DURATION to 0 every frame,
+## so the jump holds `.Frameset_IntroSuicune2`'s first entry for the whole leap
+## rather than reaching its second.
 func _sprite_suicune(actor: Dictionary) -> void:
 	if _timer == 0:
 		return
 	actor["var2"] = (int(actor["var2"]) + 2) & 0xFF
 	actor["y_offset"] = _sine_at(-int(actor["var2"]) & 0xFF, 32)
-	if StringName(actor["frameset"]) != &"intro_suicune_2":
-		_reinit_frameset(actor, &"intro_suicune_2")
+	_reinit_frameset(actor, &"intro_suicune_2")
 
 
 ## `SpriteAnimFunc_IntroPichuWooper`: one hop, ten steps of a sine of

--- a/tests/unit/test_intro_movie.gd
+++ b/tests/unit/test_intro_movie.gd
@@ -11,12 +11,13 @@ extends GutTest
 ## Longer than the movie, whose own total is asserted below.
 const FRAME_CAP: int = 20000
 
-## `IntroScene28` sets `JUMPTABLE_EXIT_F` on this frame.
-const MOVIE_FRAMES: int = 1784
+## `IntroScene28` sets `JUMPTABLE_EXIT_F` on this frame. Over half of it is the
+## setup scenes' `Request2bpp` waits, which spend a frame per eight tiles.
+const MOVIE_FRAMES: int = 2338
 ## The frame each of the twenty-eight scenes starts on.
 const SCENE_STARTS: Array[int] = [
-	0, 1, 132, 133, 264, 265, 396, 397, 494, 495, 694, 695, 890, 891, 1022, 1023,
-	1154, 1155, 1254, 1255, 1410, 1411, 1423, 1424, 1457, 1521, 1522, 1655,
+	0, 1, 188, 189, 359, 360, 547, 548, 733, 734, 933, 934, 1168, 1169, 1371,
+	1372, 1559, 1560, 1713, 1714, 1925, 1926, 1938, 1939, 1972, 2036, 2037, 2209,
 ]
 
 
@@ -94,10 +95,13 @@ func test_the_unown_burst_is_four_structs_that_delete_themselves() -> void:
 ## round the top of the screen.
 func test_a_sprite_coordinate_wraps_rather_than_clamping() -> void:
 	var movie: Gen2IntroMovie = _movie()
-	while movie.scene() < 19 and movie.frame() < FRAME_CAP:
+	# The scene index moves as its setup runs, and the setup then spends its own
+	# `Request2bpp` waits, so the sprite is looked for rather than counted to.
+	while movie.frame() < FRAME_CAP \
+			and (movie.scene() < 19 or movie.sprites().is_empty()):
 		movie.advance_frame()
 	var seen: Array[int] = []
-	for _frame: int in 20:
+	while movie.scene() == 19 and movie.frame() < FRAME_CAP:
 		movie.advance_frame()
 		for sprite: Dictionary in movie.sprites():
 			seen.append((sprite["at"] as Vector2i).y)

--- a/tools/checks/intro_movie.gd
+++ b/tools/checks/intro_movie.gd
@@ -23,10 +23,10 @@ const FRAME_CAP: int = 20000
 ## Census of the real Crystal cache, pinned so a change is loud: the frames the
 ## jumptable takes to set its exit bit, the frame each scene starts on, and how
 ## many sounds the movie asks for.
-const EXPECTED_FRAMES: int = 1784
+const EXPECTED_FRAMES: int = 2338
 const EXPECTED_SCENE_STARTS: Array[int] = [
-	0, 1, 132, 133, 264, 265, 396, 397, 494, 495, 694, 695, 890, 891, 1022, 1023,
-	1154, 1155, 1254, 1255, 1410, 1411, 1423, 1424, 1457, 1521, 1522, 1655,
+	0, 1, 188, 189, 359, 360, 547, 548, 733, 734, 933, 934, 1168, 1169, 1371,
+	1372, 1559, 1560, 1713, 1714, 1925, 1926, 1938, 1939, 1972, 2036, 2037, 2209,
 ]
 const EXPECTED_SFX: int = 17
 const EXPECTED_MUSIC: int = 1

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -5,7 +5,8 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/trace_opening_oam.gd -- <game> <phase> [out.txt]
 ##
-## `phase` is `presents` or `title`. The artefact is the one `.claude/verification.md`
+## `phase` is `presents`, `intro` (Crystal's movie), `gs_intro` (Gold and
+## Silver's) or `title`. The artefact is the one `.claude/verification.md`
 ## step 2 asks for: two faithful implementations of `PlaySpriteAnimations` put
 ## the same sprites in the same slots on the same frames, so a `diff` against a
 ## cartridge running under an emulator settles the port rather than a frame count
@@ -21,11 +22,13 @@ extends SceneTree
 ## `tools/preview_intro.gd` photographs the same screen through the boot
 ## cinema, whose frames count from the copyright rather than from this phase.
 
-const PHASES: Array[String] = ["presents", "title"]
+const PHASES: Array[String] = ["presents", "intro", "gs_intro", "title"]
 
 ## The title screen runs until its own timeout, which is longer than anything
 ## worth diffing; this is well past `TitleScreenEnd`'s own count.
 const TITLE_FRAME_CAP: int = 4000
+## Either movie ends itself; this only stops a run that never does.
+const MOVIE_FRAME_CAP: int = 4000
 
 ## Frames to write a PNG for, beside the trace's own output path.
 var _shots: Dictionary = {}
@@ -50,8 +53,16 @@ func _initialize() -> void:
 	if args.size() > 3:
 		for value: String in args[3].split(","):
 			_shots[int(value)] = true
-	var lines: PackedStringArray = _trace_presents(data) if args[1] == "presents" \
-		else _trace_title(data)
+	var lines: PackedStringArray
+	match args[1]:
+		"presents":
+			lines = _trace_presents(data)
+		"intro":
+			lines = _trace_intro(data)
+		"gs_intro":
+			lines = _trace_gs_intro(data)
+		_:
+			lines = _trace_title(data)
 	if args.size() > 2:
 		var file := FileAccess.open(args[2], FileAccess.WRITE)
 		if file == null:
@@ -92,6 +103,57 @@ func _trace_presents(data: GameData) -> PackedStringArray:
 		phase.advance_frame()
 		frame += 1
 	_append_frame(out, frame, page.shadow_oam(phase))
+	print("frame %d: finished" % frame)
+	return out
+
+
+## `CrystalIntro` from its first frame to the one it sets its own exit bit on,
+## driven with no buttons held so nothing skips it.
+func _trace_intro(data: GameData) -> PackedStringArray:
+	var page: Gen2IntroMoviePage = Gen2IntroMoviePage.from_data(data)
+	if page == null:
+		push_error("%s has no intro movie art." % data.id)
+		return PackedStringArray()
+	var movie: Gen2IntroMovie = Gen2IntroMovie.create(
+		data, Gen2BattleAnimData.from_game_data(data)
+	)
+	var out := PackedStringArray()
+	var frame: int = 0
+	var scene: int = -1
+	while not movie.finished() and frame < MOVIE_FRAME_CAP:
+		_append_frame(out, frame, page.shadow_oam(movie))
+		if _shots.has(frame):
+			page.draw(movie).save_png("%s_f%d.png" % [_shot_prefix, frame])
+		if movie.scene() != scene:
+			scene = movie.scene()
+			print("frame %d: scene %d" % [frame, scene])
+		movie.advance_frame()
+		frame += 1
+	print("frame %d: finished" % frame)
+	return out
+
+
+## `GoldSilverIntro`, the same way.
+func _trace_gs_intro(data: GameData) -> PackedStringArray:
+	var page: Gen2GoldSilverIntroPage = Gen2GoldSilverIntroPage.from_data(data)
+	if page == null:
+		push_error("%s has no intro movie art." % data.id)
+		return PackedStringArray()
+	var movie: Gen2GoldSilverIntro = Gen2GoldSilverIntro.create(
+		data, Gen2BattleAnimData.from_game_data(data)
+	)
+	var out := PackedStringArray()
+	var frame: int = 0
+	var scene: int = -1
+	while not movie.finished() and frame < MOVIE_FRAME_CAP:
+		_append_frame(out, frame, page.shadow_oam(movie))
+		if _shots.has(frame):
+			page.draw(movie).save_png("%s_f%d.png" % [_shot_prefix, frame])
+		if movie.scene() != scene:
+			scene = movie.scene()
+			print("frame %d: scene %d" % [frame, scene])
+		movie.advance_frame()
+		frame += 1
 	print("frame %d: finished" % frame)
 	return out
 


### PR DESCRIPTION
The GameFreak animation and the title screen were settled against a real dump; both intro movies were still pinned from the port alone. This extends `tools/trace_opening_oam.gd` to `CrystalIntro` and `GoldSilverIntro`, and gives both intro pages the `shadow_oam()` seam the title page already had, so a movie can be compared with a cartridge slot for slot.

**Crystal's movie now matches exactly**: 475 of 475 distinct shadow-OAM states, in order, over all 28 scenes, and every sampled frame of its first three scenes is identical pixel for pixel. Gold and Silver's matches for its first 401 states of 1,227 and then diverges by one magikarp in the water scene.

Six defects, none of which a frame count could have caught:

| Defect | Effect |
|---|---|
| `Request2bpp` spends a `DelayFrame` per eight tiles | A setup scene loading four sheets costs fifty frames, not two: the movie was 1,784 frames and is 2,338, and every scene landed early |
| `SpriteAnimFunc_IntroSuicune` reinitialises the frameset every frame | Suicune's leap held its second frameset entry instead of its first |
| `ClearSpriteAnims` zeroes `wGlobalAnimXOffset` | The jump scene's offset of $80 leaked into the scene after it, moving every sprite there 128 pixels |
| `Intro_InitBubble` overreads its six-row table | The two bubbles the cartridge shows first were drawn in the wrong places |
| A struct is drawn once more after its own sequence deletes it | Gold and Silver's bubbles vanished a frame early |
| Gold and Silver's structs are ten reusable slots, not a list, and shadow OAM is a buffer the sprite pass fills | Z-order after a deletion, the `INDEX and $3` motion seeds, and a one-pass lag on every global offset |

Two measured divergences are recorded rather than modelled, both hardware timing rather than source behaviour: each of Crystal's setup scenes takes 3 to 12 frames longer on the cartridge than its waits account for, which is `Decompress` overrunning VBlank, and Gold and Silver's movie runs at half rate throughout for the same reason.

Green: `tests/unit` 2,486, the full tiered suite 2,806, and `tools/validate.gd -- all`.