### PR TITLE
Make Gold and Silver's intro movie exact, and Crystal's screen

### DIFF
--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -380,15 +380,19 @@ func _draw_sprite(image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary) -
 		_sheet(String((CUTSCENE_SHEETS.get(movie.cutscene(), {}) as Dictionary).get("obj", ""))),
 		palette, int(entry["tile"]),
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
-		bool(entry["flip_x"]), bool(entry["flip_y"])
+		bool(entry["flip_x"]), bool(entry["flip_y"]),
+		# Only the fire cutscene has `Intro_GetMonFrontpic`'s three pics in
+		# `vTiles0`. The water scene's own sprites cover the same tile numbers,
+		# and Lapras alone spans all three of those runs.
+		movie.cutscene() == Gen2GoldSilverIntro.CUTSCENE_FIRE
 	)
 
 
 func _blit_sprite_tile(
 	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
-	at: Vector2i, flip_x: bool, flip_y: bool
+	at: Vector2i, flip_x: bool, flip_y: bool, starters: bool
 ) -> void:
-	var starter: Dictionary = _starter_for(tile)
+	var starter: Dictionary = _starter_for(tile) if starters else {}
 	for row: int in TILE:
 		var y: int = at.y + row
 		if y < 0 or y >= HEIGHT:

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -41,9 +41,6 @@ const ROWS: int = Gen2IntroMovie.ROWS
 const OAM_ORIGIN := Vector2i(8, 16)
 ## A sprite never draws its first colour.
 const TRANSPARENT_INDEX: int = 0
-## `Intro_RustleGrass` writes its four tiles at `vTiles2 tile $09`.
-const GRASS_FIRST_TILE: int = RomLayout.INTRO_GRASS_FIRST_TILE
-const GRASS_TILES: int = 4
 ## Where a BG tile number stops reading from the low sheet and starts reading
 ## from the one at `vTiles1`.
 const HIGH_TILE: int = 0x80
@@ -306,7 +303,14 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
 	var low_first: int = movie.sheet_first_tile("bg")
 	var high: PackedByteArray = _sheet(movie, movie.sheet("bg_high"))
 	var high_first: int = movie.sheet_first_tile("bg_high")
-	var grass: PackedByteArray = _sheet(movie, movie.grass_sheet())
+	# A bare `Request2bpp` writes over whichever sheet the tile number would
+	# otherwise read, so the run it covers is looked at before either of them.
+	var overlay: Array = movie.tile_overlay()
+	var overlay_strip: PackedByteArray = _sheet(
+		movie, String(overlay[2])
+	) if overlay.size() == 3 else PackedByteArray()
+	var overlay_first: int = int(overlay[0]) if overlay.size() == 3 else 0
+	var overlay_count: int = int(overlay[1]) if overlay.size() == 3 else 0
 	var scy: int = movie.scroll().y
 	for y: int in HEIGHT:
 		var scx: int = movie.scroll_x_at(y)
@@ -326,13 +330,13 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
 			var byte: int = attr[cell] if cell < attr.size() else 0
 			var strip: PackedByteArray = low
 			var index: int = tile + low_first
-			if tile >= HIGH_TILE:
+			if not overlay_strip.is_empty() and tile >= overlay_first \
+					and tile < overlay_first + overlay_count:
+				strip = overlay_strip
+				index = tile - overlay_first
+			elif tile >= HIGH_TILE:
 				strip = high
 				index = tile - HIGH_TILE + high_first
-			elif tile >= GRASS_FIRST_TILE and tile < GRASS_FIRST_TILE + GRASS_TILES \
-					and not grass.is_empty():
-				strip = grass
-				index = tile - GRASS_FIRST_TILE
 			var palette: PackedColorArray = palettes[byte & ATTR_PALETTE]
 			if palette.is_empty():
 				continue
@@ -346,16 +350,28 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
 ## One shadow-OAM entry, off the sheet its struct was loaded into. The position
 ## is already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
 func _draw_sprite(image: Image, movie: Gen2IntroMovie, entry: Dictionary) -> void:
+	var tile: int = int(entry["tile"])
 	var strip: PackedByteArray = _sheet(
 		movie, movie.sheet("obj_bank1" if bool(entry["bank1"]) else "obj")
 	)
+	# A sprite tile counts from `vTiles0`, so $80 and up is the `vTiles1` half of
+	# the window, which the last two Suicune scenes load a sheet of their own
+	# into. A bare `Request2bpp` on top of either half wins over both.
+	var overlay: Array = movie.tile_overlay()
+	if overlay.size() == 3 and tile >= int(overlay[0]) \
+			and tile < int(overlay[0]) + int(overlay[1]):
+		strip = _sheet(movie, String(overlay[2]))
+		tile -= int(overlay[0])
+	elif tile >= HIGH_TILE:
+		strip = _sheet(movie, movie.sheet("obj_high"))
+		tile -= HIGH_TILE
 	if strip.is_empty():
 		return
 	var palette: PackedColorArray = movie.object_palette(int(entry["palette"]))
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
 	_blit_sprite_tile(
-		image, strip, palette, int(entry["tile"]),
+		image, strip, palette, tile,
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
 		bool(entry["flip_x"]), bool(entry["flip_y"])
 	)

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -143,6 +143,19 @@ const FRAMESET_RESTART: StringName = &"restart"
 ## `B_OAM_XFLIP` on a frameset entry, which flips each tile where it stands.
 const FLIP_X: int = 1
 
+## `wShadowOAM`, which is forty `SPRITEOAMSTRUCT`s and no more.
+const SHADOW_OAM_SPRITES: int = 40
+## How many of those each OAM set takes, which is the `db` count each
+## `.OAMData_*` opens with. The geometry is [Gen2GoldSilverIntroPage]'s; only the
+## count belongs here, because a full buffer stops the sprite pass:
+## `UpdateAnimFrame` returns carry at `wShadowOAMEnd` and
+## `DoNextFrameForAllSprites` answers it with `jr c, .done`, so every struct in a
+## later slot loses its own sequence for that frame as well as its picture.
+const OAM_SET_SIZES: Array[int] = [
+	1, 1, 4, 4, 6, 6, 27, 27, 29, 2, 1, 16, 16, 16, 16, 16, 16, 16, 5, 5, 5, 4,
+	16, 36, 25, 25, 25,
+]
+
 const FRAMESETS: Dictionary = {
 	&"bubble": {"frames": [[0, 8, 0], [1, 8, 0]], "end": FRAMESET_RESTART},
 	&"shellder": {"frames": [[2, 8, 0], [3, 8, 0]], "end": FRAMESET_RESTART},
@@ -954,10 +967,12 @@ func _load_mon_palette(name: StringName) -> void:
 
 
 func _spawn_starter(name: StringName, at: Vector2i) -> void:
+	# The struct's own tile offset is zero: `SPRITE_ANIM_DICT_GS_INTRO_2` is in no
+	# `wSpriteAnimDict` pair this movie writes, so `GetSpriteAnimVTile` falls out
+	# of its loop with `xor a`. Each starter's vtile is its OAM set's own
+	# `spriteanimoam $10`/`$29`/`$42`, which is [Gen2GoldSilverIntroPage]'s.
 	_emit(&"play_sfx", {"sfx": SFX_GS_INTRO_POKEMON_APPEARS})
-	var actor: Dictionary = _spawn(name, at)
-	if not actor.is_empty():
-		actor["vtile"] = int((STARTERS[name] as Dictionary)["vtile"])
+	_spawn(name, at)
 
 
 ## `Intro_AnimateFireball`: a fireball every fourth frame, with the screen
@@ -1040,7 +1055,16 @@ func _clear_sprite_anims() -> void:
 ## when there is none, dropping the spawn. [param at] is the shadow-OAM pixel as
 ## (x, y), which is the order the struct stores.
 func _spawn(object: StringName, at: Vector2i) -> Dictionary:
-	var slot: int = _actors.find({})
+	# A struct whose sequence deleted itself this pass is already free:
+	# `DeinitializeSprite` clears its index there and then, and the OAM write it
+	# still gets has happened by the time a scene body spawns anything. So
+	# Pikachu takes the slot a note gave up on the same frame.
+	var slot: int = -1
+	for index: int in _actors.size():
+		var held: Dictionary = _actors[index]
+		if held.is_empty() or bool(held.get("deinit", false)):
+			slot = index
+			break
 	if slot < 0:
 		return {}
 	# `inc [hl]` and then a skip past zero, so the count never wraps to the byte
@@ -1079,7 +1103,12 @@ func _run_sprites() -> void:
 	for slot: int in _actors.size():
 		if bool((_actors[slot] as Dictionary).get("deinit", false)):
 			_actors[slot] = {}
-	for actor: Dictionary in _actors.duplicate():
+	# `UpdateAnimFrame` writes each struct's OAM as it is reached, and
+	# `PlaySpriteAnimations` blanks whatever the last pass left past the end.
+	_shadow = []
+	var room: int = SHADOW_OAM_SPRITES
+	for slot: int in _actors.size():
+		var actor: Dictionary = _actors[slot]
 		if actor.is_empty():
 			continue
 		var alive: bool = true
@@ -1108,13 +1137,6 @@ func _run_sprites() -> void:
 				_sprite_starter(actor, 0x30, 0x10)
 		if not alive:
 			actor["deinit"] = true
-	# `UpdateAnimFrame` writes each struct's OAM as it is reached, and
-	# `PlaySpriteAnimations` blanks whatever the last pass left past the end.
-	_shadow = []
-	for slot: int in _actors.size():
-		var actor: Dictionary = _actors[slot]
-		if actor.is_empty():
-			continue
 		if not _advance_actor(actor):
 			# `oamdelete` takes the struct away without reaching the OAM write,
 			# unlike a sequence deinitialising itself.
@@ -1132,6 +1154,9 @@ func _run_sprites() -> void:
 			"flip_x": bool(int(entry[2]) & FLIP_X),
 			"vtile": int(actor["vtile"]),
 		})
+		room -= OAM_SET_SIZES[int(entry[0])]
+		if room <= 0:
+			return
 
 
 ## `AnimSeq_GSIntroBubble`: up one pixel a frame on a sine of amplitude 8, gone
@@ -1220,7 +1245,10 @@ func _sprite_note(actor: Dictionary) -> bool:
 	actor["x_offset"] = (offset + 1) & 0xFF
 	actor["var1"] = (int(actor["var1"]) + 2) & 0xFF
 	actor["y_offset"] = _sine_at(int(actor["var1"]), 4)
-	if int(actor["var1"]) & 0x02 == 0:
+	# The `ld hl, SPRITEANIMSTRUCT_VAR1` in front of the `and $2` is dead: `ld hl`
+	# leaves `a` alone, so the bit tested is the sine's own, not VAR1's, and the
+	# note rises on the offset rather than on the angle.
+	if int(actor["y_offset"]) & 0x02 == 0:
 		return true
 	actor["y"] = (int(actor["y"]) - 1) & 0xFF
 	return true
@@ -1331,8 +1359,10 @@ func _sprite_starter(actor: Dictionary, first: int, second: int) -> void:
 	var angle: int = int(actor["var1"])
 	if angle >= 0x3C:
 		return
+	# The two `inc [hl]` leave `a` alone, so both halves take the angle from
+	# before the step, unlike `AnimSeq_GSIntroNote`'s `add 2 / ld [hl], a`.
 	actor["var1"] = (angle + 2) & 0xFF
-	actor["y_offset"] = _sine_at(actor["var1"], 0x90)
+	actor["y_offset"] = _sine_at(angle, 0x90)
 	var cosine: int = int(actor["var2"])
 	actor["var2"] = (cosine + 2) & 0xFF
 	actor["x_offset"] = _cosine_at(cosine, 0x90)

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -70,6 +70,18 @@ const FRAMESET_WAIT: StringName = &"wait"
 const FLIP_X: int = 1
 const FLIP_Y: int = 2
 
+## `wShadowOAM`, which is forty `SPRITEOAMSTRUCT`s and no more, and how many of
+## them each OAM set takes. The geometry is [Gen2IntroMoviePage]'s; only the
+## count belongs here, because a full buffer stops the sprite pass:
+## `UpdateAnimFrame` returns carry at `wShadowOAMEnd` and
+## `DoNextFrameForAllSprites` answers it with `jr c, .done`, so a struct behind
+## the overflow loses its own sequence for that frame as well as its picture.
+## `IntroScene10` is where this movie reaches it, at forty-one.
+const SHADOW_OAM_SPRITES: int = 40
+const OAM_SET_SIZES: Array[int] = [
+	36, 28, 30, 31, 25, 25, 25, 16, 1, 3, 7, 4, 8, 12, 20, 20, 20,
+]
+
 const FRAMESETS: Dictionary = {
 	&"intro_suicune": {
 		"frames": [[0, 3, 0], [1, 3, 0], [2, 3, 0], [3, 3, 0]], "end": FRAMESET_RESTART,
@@ -164,6 +176,7 @@ const SCENE_VRAM: Dictionary = {
 		"bg": "suicune_jump", "map": "suicune_jump_map", "attr": "suicune_jump_attr",
 		"obj": "unown_back",
 	},
+
 	# `Intro_DecompressRequest2bpp_255Tiles` from `vTiles1` runs 255 tiles past
 	# the end of that bank, so the close-up's first 128 land where a BG tile
 	# number $80 and up reads and the rest in `vTiles2`, where one below $80
@@ -175,7 +188,7 @@ const SCENE_VRAM: Dictionary = {
 	},
 	18: {
 		"bg": "suicune_back", "bg_high": "unowns", "map": "suicune_back_map",
-		"attr": "suicune_back_attr",
+		"attr": "suicune_back_attr", "obj_high": "unowns",
 	},
 	25: {
 		"bg": "crystal_unowns", "map": "crystal_unowns_map",
@@ -202,7 +215,7 @@ const SCENE_CRYSTAL_UNOWNS: int = 25
 const SCENE_REQUESTS: Dictionary = {
 	0: [64, 128, 128, 64], 2: [64, 128, 64], 4: [64, 128, 128, 64],
 	6: [64, 128, 255, 128, 64], 10: [64, 128, 64], 12: [64, 255, 128, 64],
-	14: [64, 128, 128, 64], 16: [64, 255, 64], 18: [64, 128, 128, 64],
+	14: [64, 128, 128, 1, 64], 16: [64, 255, 64], 18: [64, 128, 128, 1, 64],
 	25: [64, 128, 64],
 }
 ## `TILES_PER_CYCLE` (home/gfx.asm).
@@ -214,6 +227,19 @@ const CLEAR_TILEMAP_FRAMES: int = 4
 ## $09` swapped every four frames for the first thirty-six of `IntroScene10`.
 const GRASS_FRAMES: Array[String] = ["grass_1", "grass_2", "grass_3", "grass_2"]
 const GRASS_RUSTLE_FRAMES: int = 36
+const GRASS_FIRST_TILE: int = RomLayout.INTRO_GRASS_FIRST_TILE
+const GRASS_TILES: int = 4
+
+## The bare `Request2bpp` a setup scene makes on top of its own sheets, as
+## (first tile, count, sheet). Both are `IntroGrass4GFX`'s single tile, and both
+## land in `vTiles1`, which a sprite reads as tile $80 and up: `IntroScene15`
+## parks it at `vTiles1 tile $00`, so tile $80 is the blade, and `IntroScene19`
+## at `vTiles1 tile $7f`, so tile $ff is. The wave of grass the last two scenes
+## run Suicune through is twenty sprites of that one tile.
+const SCENE_OVERLAY: Dictionary = {
+	14: [0x80, 1, RomLayout.INTRO_GRASS_BLANK],
+	18: [0xFF, 1, RomLayout.INTRO_GRASS_BLANK],
+}
 
 var _data: GameData = null
 var _sine: Gen2BattleAnimData = null
@@ -249,6 +275,12 @@ var _tilemap: PackedByteArray = PackedByteArray()
 ## The attribute plane `IntroScene9` writes over the loaded one, or empty.
 var _attr_override: PackedByteArray = PackedByteArray()
 var _grass_frame: int = 0
+## The one run of BG tiles a `Request2bpp` has written over the scene's own
+## sheets, as (first tile, count, sheet): `Intro_RustleGrass`'s four at
+## `vTiles2 tile $09`, or the single `IntroGrass4GFX` tile the two Suicune scenes
+## park in `vTiles1`. It lasts until a scene decompresses a sheet over it, which
+## every setup scene does.
+var _overlay: Array = []
 
 var _actors: Array[Dictionary] = []
 ## Frames a scene spends inside `DelayFrames`, during which neither the
@@ -341,9 +373,10 @@ func sheet_first_tile(part: String) -> int:
 	return int(_vram.get("%s_first" % part, 0))
 
 
-## The tile the four rustling-grass tiles at $09 currently show, as a sheet name.
-func grass_sheet() -> String:
-	return GRASS_FRAMES[_grass_frame]
+## The BG tiles a bare `Request2bpp` has written over the scene's own sheets, as
+## (first tile, count, sheet name), or empty.
+func tile_overlay() -> Array:
+	return _overlay
 
 
 ## The 32x32 BG map and its attribute plane, as the cache holds them.
@@ -527,6 +560,7 @@ func _setup_scene() -> void:
 	_attr_override = PackedByteArray()
 	_sprite_vtile = 0
 	_grass_frame = 0
+	_overlay = SCENE_OVERLAY.get(_scene, []) as Array
 	_scx = 0
 	_scy = 0
 	var name: String = String(SCENE_PALETTE.get(_scene, ""))
@@ -857,6 +891,7 @@ func _rustle_grass() -> void:
 	if _counter >= GRASS_RUSTLE_FRAMES:
 		return
 	_grass_frame = (_counter & 0x0C) >> 2
+	_overlay = [GRASS_FIRST_TILE, GRASS_TILES, GRASS_FRAMES[_grass_frame]]
 
 
 ## `Intro_LoadTilemap`: the top-left 20x18 of the decompressed BG map, copied
@@ -999,7 +1034,15 @@ func _reinit_frameset(actor: Dictionary, frameset: StringName) -> void:
 
 ## `PlaySpriteAnimations`: each struct's own callback, then its frame counter.
 func _run_sprites() -> void:
+	var kept: Array[Dictionary] = []
+	var room: int = SHADOW_OAM_SPRITES
 	for actor: Dictionary in _actors.duplicate():
+		if room <= 0:
+			# `jr c, .done`: a struct behind a full buffer is not deinitialised,
+			# it is simply never reached this frame, so neither its own sequence
+			# nor its frameset runs.
+			kept.append(actor)
+			continue
 		match StringName(actor["func"]):
 			&"suicune":
 				_sprite_suicune(actor)
@@ -1011,10 +1054,12 @@ func _run_sprites() -> void:
 				_sprite_unown_f(actor)
 			&"suicune_away":
 				_sprite_suicune_away(actor)
-	var kept: Array[Dictionary] = []
-	for actor: Dictionary in _actors:
-		if _advance_actor(actor):
-			kept.append(actor)
+		if not _advance_actor(actor):
+			continue
+		kept.append(actor)
+		var entry: Array = _actor_frame(actor)
+		if not entry.is_empty():
+			room -= OAM_SET_SIZES[int(entry[0])]
 	_actors = kept
 
 

--- a/tests/unit/test_intro_movie.gd
+++ b/tests/unit/test_intro_movie.gd
@@ -13,11 +13,11 @@ const FRAME_CAP: int = 20000
 
 ## `IntroScene28` sets `JUMPTABLE_EXIT_F` on this frame. Over half of it is the
 ## setup scenes' `Request2bpp` waits, which spend a frame per eight tiles.
-const MOVIE_FRAMES: int = 2338
+const MOVIE_FRAMES: int = 2340
 ## The frame each of the twenty-eight scenes starts on.
 const SCENE_STARTS: Array[int] = [
 	0, 1, 188, 189, 359, 360, 547, 548, 733, 734, 933, 934, 1168, 1169, 1371,
-	1372, 1559, 1560, 1713, 1714, 1925, 1926, 1938, 1939, 1972, 2036, 2037, 2209,
+	1372, 1560, 1561, 1714, 1715, 1927, 1928, 1940, 1941, 1974, 2038, 2039, 2211,
 ]
 
 

--- a/tools/checks/gs_intro.gd
+++ b/tools/checks/gs_intro.gd
@@ -48,10 +48,13 @@ const EXPECTED_MUSIC: int = 3
 
 ## The water scene asks shadow OAM for more than the forty it holds: Lapras is
 ## twenty-seven sprites on its own and the magikarp triple six each, so
-## `UpdateAnimFrame` drops the last seven rather than growing, the way
+## `UpdateAnimFrame` drops the last five rather than growing, the way
 ## `IntroScene10` drops Pichu's last tile on Crystal. Pinned rather than
-## bounded, because the overflow is the finding.
-const PEAK_SPRITES: int = 47
+## bounded, because the overflow is the finding. The count is what the structs
+## the loop reaches ask for: a full buffer returns carry and
+## `DoNextFrameForAllSprites` stops there, so the structs behind it are never
+## asked at all.
+const PEAK_SPRITES: int = 45
 
 ## Each cartridge's section, so the two that carry one can be compared.
 var _sections: Dictionary = {}

--- a/tools/checks/intro_movie.gd
+++ b/tools/checks/intro_movie.gd
@@ -23,10 +23,10 @@ const FRAME_CAP: int = 20000
 ## Census of the real Crystal cache, pinned so a change is loud: the frames the
 ## jumptable takes to set its exit bit, the frame each scene starts on, and how
 ## many sounds the movie asks for.
-const EXPECTED_FRAMES: int = 2338
+const EXPECTED_FRAMES: int = 2340
 const EXPECTED_SCENE_STARTS: Array[int] = [
 	0, 1, 188, 189, 359, 360, 547, 548, 733, 734, 933, 934, 1168, 1169, 1371,
-	1372, 1559, 1560, 1713, 1714, 1925, 1926, 1938, 1939, 1972, 2036, 2037, 2209,
+	1372, 1560, 1561, 1714, 1715, 1927, 1928, 1940, 1941, 1974, 2038, 2039, 2211,
 ]
 const EXPECTED_SFX: int = 17
 const EXPECTED_MUSIC: int = 1


### PR DESCRIPTION
Follow-on from #221, which left Gold and Silver's movie matching for 401 of 1,227 states and Crystal's scenes 17 to 19 unaligned in pixels.

**Both movies' sprites are now exact against a running cartridge.** `GoldSilverIntro` matches 1,229 of 1,229 distinct shadow-OAM states, in order, on Gold and on Silver, with no cartridge state unaccounted for; `CrystalIntro` stays at 475 of 475. Sampled pixels: 8 of 10 Gold frames identical, and 6 of 11 Crystal frames, up from 3.

| Defect | Effect |
|---|---|
| A full shadow OAM stops the whole sprite pass, not just the drawing | A struct behind the overflow froze on the cartridge and kept moving here; it looked like a magikarp spawning seven passes late |
| `_InitSpriteAnimStruct` reuses the slot a struct freed on the same pass | Pikachu drew over the notes it should have drawn under |
| `AnimSeq_GSIntroNote` tests `and $2` on the sine result, not the VAR1 it just addressed | The note rose a frame early, every fourth frame |
| `AnimSeq_GSIntroChikoritaTotodile` takes its sine from before its two `inc [hl]` | Each starter's flash was a step ahead |
| A starter's vtile is its OAM set's own, not the struct's | All three starters drew from 16 tiles further into VRAM than the cartridge |
| `Intro_GetMonFrontpic`'s pics are the fire cutscene's alone | Lapras spans all three pic runs, so the whole water scene drew it out of the pic atlas |
| `Intro_RustleGrass`'s four tiles last until a sheet is loaded over them | Four tiles of grass smeared across the Suicune close-up for the rest of the movie |
| A sprite tile counts from `vTiles0`, so $80 and up reads `vTiles1` | The wave of grass Suicune runs through in the last two scenes was not drawn at all |

The two one-tile `Request2bpp` calls the Suicune scenes make cost a frame each, so the movie is 2,340 frames rather than 2,338; the pins moved with it.

What is left is the screen rather than the buffer. Crystal's remaining sampled differences are all `UpdateBGMap` copying a third of the rows a frame while this port writes a tilemap in one, which is the splash's own recorded divergence met again. Gold and Silver's are the three rows of the water surface, where a scanline lands on a different map row than the cartridge's.

Green: `tests/unit` 2,486, the full tiered suite 2,806, and `tools/validate.gd -- all` over its 40 topics.