### PR TITLE
Make the opening's pixels match a running cartridge

### DIFF
--- a/game/render/game_freak_presents_page.gd
+++ b/game/render/game_freak_presents_page.gd
@@ -121,8 +121,12 @@ func draw(phase: Gen2GameFreakPresents) -> Image:
 	if phase != null:
 		_draw_words(indices, width, phase)
 	var image: Image = Gen2PicImage.from_indices(indices, width, height, _background)
+	# The lower OAM index wins a pixel, so a slot only paints where no earlier
+	# one did.
+	var taken := PackedByteArray()
+	taken.resize(width * height)
 	for entry: Dictionary in shadow_oam(phase):
-		_draw_sprite(image, phase, entry)
+		_draw_sprite(image, phase, entry, taken)
 	return image
 
 
@@ -186,7 +190,8 @@ func _draw_words(
 ## One shadow-OAM entry, drawn through the object palette whose first colour is
 ## transparent.
 func _draw_sprite(
-	image: Image, phase: Gen2GameFreakPresents, entry: Dictionary
+	image: Image, phase: Gen2GameFreakPresents, entry: Dictionary,
+	taken: PackedByteArray
 ) -> void:
 	# `dbsprite`'s attribute byte names the object palette. Only Gold's logo is
 	# drawn through palette 1, which is the one the rotation moves.
@@ -197,7 +202,7 @@ func _draw_sprite(
 		image, palette,
 		int(entry["tile"]) - _vram_base(),
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
-		bool(entry["flip_x"]), bool(entry["flip_y"])
+		bool(entry["flip_x"]), bool(entry["flip_y"]), taken
 	)
 
 
@@ -306,9 +311,10 @@ func _blit_tile(
 
 ## One object tile onto the drawn screen, clipped per axis so a sprite hanging
 ## off an edge cannot wrap onto the opposite one.
+## [param taken] marks the pixels an earlier slot has already claimed.
 func _blit_sprite_tile(
 	image: Image, palette: PackedColorArray, tile: int, at: Vector2i,
-	flip_x: bool, flip_y: bool
+	flip_x: bool, flip_y: bool, taken: PackedByteArray
 ) -> void:
 	var tiles: PackedByteArray = _sprite_tiles
 	var stride: int = _sprite_width
@@ -340,4 +346,8 @@ func _blit_sprite_tile(
 			var value: int = tiles[from]
 			if value == TRANSPARENT_INDEX or value >= palette.size():
 				continue
+			var at_pixel: int = target_y * image.get_width() + target_x
+			if taken[at_pixel] != 0:
+				continue
+			taken[at_pixel] = 1
 			image.set_pixel(target_x, target_y, palette[value])

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -40,6 +40,10 @@ const SHADOW_OAM_SPRITES: int = 40
 const ATTR_PALETTE: int = 0x07
 const ATTR_XFLIP: int = 0x20
 const ATTR_YFLIP: int = 0x40
+## `OAM_PRIO`: the background wins wherever its own colour is not 0. Lapras's
+## three sets carry it on every tile from its waterline down, which is what puts
+## the ocean's wave tiles over its body.
+const ATTR_PRIORITY: int = 0x80
 
 ## Which sheet each cutscene puts where: `bg` is what a tile below $80 reads,
 ## `bg_high` what one $80 and up reads, and `obj` what a sprite reads.
@@ -291,9 +295,14 @@ func draw(movie: Gen2GoldSilverIntro) -> Image:
 	var image := Image.create(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
 	if movie == null:
 		return image
-	_draw_background(image, movie)
+	var behind: PackedByteArray = _draw_background(image, movie)
+	# The lower OAM index wins a pixel, so a slot only paints where no earlier
+	# one did: Charizard's small fireball sits behind the big one it is spawned
+	# after, and the note behind Pikachu.
+	var taken := PackedByteArray()
+	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):
-		_draw_sprite(image, movie, entry)
+		_draw_sprite(image, movie, entry, behind, taken)
 	return image
 
 
@@ -332,20 +341,24 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 				"palette": 1 if attrs & ATTR_PALETTE else 0,
 				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
 				"flip_y": bool(attrs & ATTR_YFLIP),
+				"priority": bool(attrs & ATTR_PRIORITY),
 			})
 	return out
 
 
 ## The BG map, sampled through `hSCX` and the scanline's own `hSCY`. Both are
 ## bytes and the map is 256 pixels square, so the sampling wraps rather than
-## clipping.
-func _draw_background(image: Image, movie: Gen2GoldSilverIntro) -> void:
+## clipping. Returns each pixel's own colour index, which is what an `OAM_PRIO`
+## sprite is drawn against.
+func _draw_background(image: Image, movie: Gen2GoldSilverIntro) -> PackedByteArray:
+	var behind := PackedByteArray()
 	var map: PackedByteArray = movie.bg_map()
 	if map.size() < MAP_COLUMNS * MAP_ROWS:
-		return
+		return behind
 	var palette: PackedColorArray = movie.palette()
 	if palette.is_empty():
-		return
+		return behind
+	behind.resize(WIDTH * HEIGHT)
 	var sheets: Dictionary = CUTSCENE_SHEETS.get(movie.cutscene(), {})
 	var low: PackedByteArray = _sheet(String(sheets.get("bg", "")))
 	var high: PackedByteArray = _sheet(String(sheets.get("bg_high", "")))
@@ -364,14 +377,18 @@ func _draw_background(image: Image, movie: Gen2GoldSilverIntro) -> void:
 			if tile >= HIGH_TILE:
 				strip = high
 				index = tile - HIGH_TILE
-			image.set_pixel(
-				x, y, palette[_pixel(strip, index, map_x % TILE, in_tile_y, false, false)]
-			)
+			var pixel: int = _pixel(strip, index, map_x % TILE, in_tile_y, false, false)
+			behind[y * WIDTH + x] = pixel
+			image.set_pixel(x, y, palette[pixel])
+	return behind
 
 
 ## One shadow-OAM entry, off the cutscene's own object sheet. The position is
 ## already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
-func _draw_sprite(image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary) -> void:
+func _draw_sprite(
+	image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary,
+	behind: PackedByteArray, taken: PackedByteArray
+) -> void:
 	var palette: PackedColorArray = movie.object_palette(int(entry["palette"]))
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
@@ -380,7 +397,8 @@ func _draw_sprite(image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary) -
 		_sheet(String((CUTSCENE_SHEETS.get(movie.cutscene(), {}) as Dictionary).get("obj", ""))),
 		palette, int(entry["tile"]),
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
-		bool(entry["flip_x"]), bool(entry["flip_y"]),
+		bool(entry["flip_x"]), bool(entry["flip_y"]), taken,
+		behind if bool(entry.get("priority", false)) else PackedByteArray(),
 		# Only the fire cutscene has `Intro_GetMonFrontpic`'s three pics in
 		# `vTiles0`. The water scene's own sprites cover the same tile numbers,
 		# and Lapras alone spans all three of those runs.
@@ -388,9 +406,14 @@ func _draw_sprite(image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary) -
 	)
 
 
+## [param taken] marks the pixels an earlier slot has already claimed, and
+## [param behind] is the background's own colour indices when the entry carries
+## `OAM_PRIO` and empty otherwise. The claim comes first: a sprite that loses the
+## pixel to the background still wins it against the sprites behind it.
 func _blit_sprite_tile(
 	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
-	at: Vector2i, flip_x: bool, flip_y: bool, starters: bool
+	at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,
+	behind: PackedByteArray, starters: bool
 ) -> void:
 	var starter: Dictionary = _starter_for(tile) if starters else {}
 	for row: int in TILE:
@@ -405,6 +428,12 @@ func _blit_sprite_tile(
 				if not starter.is_empty() \
 				else _pixel(strip, tile, column, row, flip_x, flip_y)
 			if pixel == TRANSPARENT_INDEX:
+				continue
+			var at_pixel: int = y * WIDTH + x
+			if taken[at_pixel] != 0:
+				continue
+			taken[at_pixel] = 1
+			if not behind.is_empty() and behind[at_pixel] != TRANSPARENT_INDEX:
 				continue
 			image.set_pixel(x, y, palette[pixel])
 

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -53,6 +53,9 @@ const ATTR_PALETTE: int = 0x07
 const ATTR_BANK1: int = 0x08
 const ATTR_XFLIP: int = 0x20
 const ATTR_YFLIP: int = 0x40
+## `OAM_PRIO`: the background wins wherever its own colour is not 0. Only
+## `.OAMData_IntroSuicuneAway` carries it, on all twenty of its tiles.
+const ATTR_PRIORITY: int = 0x80
 
 const OAM_SETS: Array[Dictionary] = [
 	# 0: SPRITE_ANIM_OAMSET_INTRO_SUICUNE_1 (.OAMData_IntroSuicune1, 36 sprites)
@@ -237,9 +240,13 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	var image := Image.create(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
 	if movie == null:
 		return image
-	_draw_background(image, movie)
+	var behind: PackedByteArray = _draw_background(image, movie)
+	# The lower OAM index wins a pixel, so a slot only paints where no earlier
+	# one did.
+	var taken := PackedByteArray()
+	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):
-		_draw_sprite(image, movie, entry)
+		_draw_sprite(image, movie, entry, behind, taken)
 	return image
 
 
@@ -282,6 +289,7 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 				"palette": attrs & ATTR_PALETTE,
 				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
 				"flip_y": bool(attrs & ATTR_YFLIP) != flip_y,
+				"priority": bool(attrs & ATTR_PRIORITY),
 				"bank1": bool(sprite["bank1"]),
 			})
 	return out
@@ -290,11 +298,13 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 ## The BG map, sampled through `hSCY` and the scanline's own `hSCX`. Both are
 ## bytes and the map is 256 pixels square, so the sampling wraps rather than
 ## clipping.
-func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
+func _draw_background(image: Image, movie: Gen2IntroMovie) -> PackedByteArray:
+	var behind := PackedByteArray()
 	var map: PackedByteArray = movie.bg_map()
 	var attr: PackedByteArray = movie.bg_attr()
 	if map.size() < RomLayout.INTRO_MAP_BYTES:
-		return
+		return behind
+	behind.resize(WIDTH * HEIGHT)
 	var screen: PackedByteArray = movie.screen_tilemap()
 	var palettes: Array[PackedColorArray] = []
 	for slot: int in Gen2IntroMovie.BG_PALETTES:
@@ -344,12 +354,17 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> void:
 				strip, index, map_x % TILE, in_tile_y,
 				bool(byte & ATTR_XFLIP), bool(byte & ATTR_YFLIP)
 			)
+			behind[y * WIDTH + x] = pixel
 			image.set_pixel(x, y, palette[pixel])
+	return behind
 
 
 ## One shadow-OAM entry, off the sheet its struct was loaded into. The position
 ## is already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
-func _draw_sprite(image: Image, movie: Gen2IntroMovie, entry: Dictionary) -> void:
+func _draw_sprite(
+	image: Image, movie: Gen2IntroMovie, entry: Dictionary,
+	behind: PackedByteArray, taken: PackedByteArray
+) -> void:
 	var tile: int = int(entry["tile"])
 	var strip: PackedByteArray = _sheet(
 		movie, movie.sheet("obj_bank1" if bool(entry["bank1"]) else "obj")
@@ -373,13 +388,19 @@ func _draw_sprite(image: Image, movie: Gen2IntroMovie, entry: Dictionary) -> voi
 	_blit_sprite_tile(
 		image, strip, palette, tile,
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
-		bool(entry["flip_x"]), bool(entry["flip_y"])
+		bool(entry["flip_x"]), bool(entry["flip_y"]), taken,
+		behind if bool(entry.get("priority", false)) else PackedByteArray()
 	)
 
 
+## [param taken] marks the pixels an earlier slot has already claimed, and
+## [param behind] is the background's own colour indices when the entry carries
+## `OAM_PRIO` and empty otherwise. The claim comes first: a sprite that loses the
+## pixel to the background still wins it against the sprites behind it.
 func _blit_sprite_tile(
 	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
-	at: Vector2i, flip_x: bool, flip_y: bool
+	at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,
+	behind: PackedByteArray
 ) -> void:
 	for row: int in TILE:
 		var y: int = at.y + row
@@ -391,6 +412,12 @@ func _blit_sprite_tile(
 				continue
 			var pixel: int = _pixel(strip, tile, column, row, flip_x, flip_y)
 			if pixel == TRANSPARENT_INDEX:
+				continue
+			var at_pixel: int = y * WIDTH + x
+			if taken[at_pixel] != 0:
+				continue
+			taken[at_pixel] = 1
+			if not behind.is_empty() and behind[at_pixel] != TRANSPARENT_INDEX:
 				continue
 			image.set_pixel(x, y, palette[pixel])
 

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -22,8 +22,10 @@ const TRANSPARENT_INDEX: int = 0
 const OAM_ORIGIN := Vector2i(8, 16)
 ## `wShadowOAM` holds forty sprites.
 const SHADOW_OAM_SPRITES: int = 40
-## `TILEMAP_WIDTH_PX`: the BG map is 32 tiles across and wraps.
+## `TILEMAP_WIDTH_PX`/`TILEMAP_HEIGHT_PX`: the BG map is 32 tiles square and
+## wraps, and Crystal's `hSCY` of 8 is what makes the height matter.
 const MAP_WIDTH: int = RomLayout.TITLE_TILEMAP_COLUMNS * Gen2Tiles.TILE_WIDTH
+const MAP_HEIGHT: int = RomLayout.TITLE_TILEMAP_COLUMNS * Gen2Tiles.TILE_HEIGHT
 ## `set B_LCDC_OBJ_SIZE`: every object on this screen is two tiles tall.
 const OBJECT_HEIGHT: int = 2
 
@@ -43,6 +45,16 @@ const CRYSTAL_VERSION_ROW: int = 9
 const CRYSTAL_VERSION_AT: int = 5
 const CRYSTAL_VERSION_TILES: int = 11
 const CRYSTAL_VERSION_PALETTE: int = 1
+## `hlbgcoord 3, 0, vBGMap1` with `lb bc, 1, 13` from tile $0c: the copyright
+## line, in the window rather than in the background. `TitleLogoGFX` is 160 tiles
+## and only its first 140 are the logo, so tile $0c of `vTiles2` is the sheet's
+## own 140th: the decompress runs past `vTiles1` into the half the BG addresses
+## from $00.
+const CRYSTAL_COPYRIGHT_TILE: int = CRYSTAL_LOGO_COLUMNS * CRYSTAL_LOGO_ROWS
+const CRYSTAL_COPYRIGHT_TILES: int = 13
+const CRYSTAL_COPYRIGHT_AT: int = 3
+## `hlbgcoord 0, 0, vBGMap3` fills the window's own row with palette 7.
+const CRYSTAL_COPYRIGHT_PALETTE: int = 7
 const CRYSTAL_SUICUNE_PALETTE: int = 0
 ## The hardware has eight of each, and `_TitleScreen` fills both sets from one
 ## sixteen-palette run.
@@ -172,6 +184,8 @@ var _background: Array[PackedColorArray] = []
 var _object: Array[PackedColorArray] = []
 var _tilemap: PackedByteArray = PackedByteArray()
 var _drawn: PackedByteArray = PackedByteArray()
+## Which pixels an object has already claimed this frame.
+var _taken: PackedByteArray = PackedByteArray()
 var _map: Image = null
 var _map_indices: PackedByteArray = PackedByteArray()
 
@@ -231,16 +245,22 @@ func draw(scene: Gen2TitleScene) -> Image:
 	if scene == null:
 		return image
 
-	_map = Image.create_empty(MAP_WIDTH, height, false, Image.FORMAT_RGBA8)
+	_map = Image.create_empty(MAP_WIDTH, MAP_HEIGHT, false, Image.FORMAT_RGBA8)
 	_map.fill(blank)
-	_map_indices.resize(MAP_WIDTH * height)
+	_map_indices.resize(MAP_WIDTH * MAP_HEIGHT)
 	_map_indices.fill(0)
 	if _profile == RomRegistry.CRYSTAL:
 		_draw_crystal_background(scene)
 	else:
 		_draw_gs_background()
 	_compose(image, scene)
+	_draw_copyright_window(image, scene)
 
+	# The lower OAM index wins a pixel, so a slot only paints where no earlier
+	# one did: Gold's bird is copied into the last struct, so every trail spawned
+	# after it still takes a lower slot and covers it.
+	_taken.resize(width * height)
+	_taken.fill(0)
 	for entry: Dictionary in shadow_oam(scene):
 		_draw_sprite(image, entry)
 	return image
@@ -283,12 +303,35 @@ func shadow_oam(scene: Gen2TitleScene) -> Array[Dictionary]:
 func _compose(image: Image, scene: Gen2TitleScene) -> void:
 	var offsets: PackedInt32Array = scene.line_offsets()
 	var base: int = scene.scroll_x()
+	var scy: int = scene.scroll_y()
 	for y: int in image.get_height():
-		var shift: int = offsets[y] if y < offsets.size() else base
+		# `LCD` fires on `STAT_MODE_0` and writes `wLYOverrides[rLY]` to rSCX,
+		# which the line after it is drawn with; `VBlank_Cutscene` writes entry
+		# zero, so the first two lines share it.
+		var line: int = maxi(y - 1, 0)
+		var shift: int = offsets[line] if line < offsets.size() else base
+		var row: int = posmod(y + scy, MAP_HEIGHT)
 		for x: int in image.get_width():
 			var from: int = posmod(x + shift, MAP_WIDTH)
-			image.set_pixel(x, y, _map.get_pixel(from, y))
-			_drawn[y * image.get_width() + x] = _map_indices[y * MAP_WIDTH + from]
+			image.set_pixel(x, y, _map.get_pixel(from, row))
+			_drawn[y * image.get_width() + x] = _map_indices[row * MAP_WIDTH + from]
+
+
+## The window layer, which on this screen is the copyright line and nothing
+## else: one row of `vBGMap1` at `hWX` 7, so it starts at column 0 and covers
+## whatever the background left under it.
+func _draw_copyright_window(image: Image, scene: Gen2TitleScene) -> void:
+	var top: int = scene.window_y()
+	if top >= image.get_height():
+		return
+	var palette: PackedColorArray = _palette(_background, CRYSTAL_COPYRIGHT_PALETTE)
+	if palette.is_empty():
+		return
+	for index: int in CRYSTAL_COPYRIGHT_TILES:
+		_blit_window_tile(
+			image, palette, CRYSTAL_COPYRIGHT_TILE + index,
+			Vector2i((CRYSTAL_COPYRIGHT_AT + index) * TILE, top)
+		)
 
 
 ## `DrawTitleGraphic` over the logo, then `LoadSuicuneFrame`'s own six rows of
@@ -444,6 +487,33 @@ func _blit_background(
 			_map_indices[target_y * MAP_WIDTH + target_x] = value
 
 
+## One window tile straight onto the screen. The window is drawn over the
+## background and under nothing, so it needs neither the map's wrap nor a claim
+## on [member _taken].
+func _blit_window_tile(
+	image: Image, palette: PackedColorArray, tile: int, at: Vector2i
+) -> void:
+	var tiles: PackedByteArray = _sheets.get("title_logo", PackedByteArray())
+	var stride: int = int(_widths.get("title_logo", 0))
+	if stride <= 0:
+		return
+	for y: int in TILE:
+		var target_y: int = at.y + y
+		if target_y < 0 or target_y >= image.get_height():
+			continue
+		for x: int in TILE:
+			var target_x: int = at.x + x
+			if target_x < 0 or target_x >= image.get_width():
+				continue
+			var from: int = y * stride + tile * TILE + x
+			if from < 0 or from >= tiles.size():
+				continue
+			var value: int = tiles[from]
+			if value >= palette.size():
+				continue
+			image.set_pixel(target_x, target_y, palette[value])
+
+
 ## One object tile onto the drawn screen, clipped per axis so a sprite hanging
 ## off an edge cannot wrap onto the opposite one. [param behind] is `OAM_PRIO`,
 ## which lets the background's colours 1 to 3 cover the object.
@@ -469,6 +539,12 @@ func _blit_sprite_tile(
 			var value: int = tiles[from]
 			if value == TRANSPARENT_INDEX or value >= palette.size():
 				continue
-			if behind and _drawn[target_y * image.get_width() + target_x] != 0:
+			var at_pixel: int = target_y * image.get_width() + target_x
+			if _taken[at_pixel] != 0:
+				continue
+			# The claim comes first: an object that loses the pixel to the
+			# background still wins it against the objects behind it.
+			_taken[at_pixel] = 1
+			if behind and _drawn[at_pixel] != 0:
 				continue
 			image.set_pixel(target_x, target_y, palette[value])

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -50,6 +50,11 @@ const LY_FLAT_LINES: int = 0x10
 const LY_SINE_LINES: int = 0x80
 const LY_SINE_AMPLITUDE: int = 4
 
+## `vBGMap0 tile $1e` is `vBGMap0 + TILE_SIZE * $1e` (`macros/gfx.asm`), which is
+## byte 480 of the map: the whole of row 15, and never the byte $1e that reading
+## the operand as an offset gives.
+const WAVE_ROW: int = 15
+
 ## The sounds and songs the movie asks for.
 const MUSIC_NONE: int = 0x00
 const MUSIC_GS_OPENING: int = 0x52
@@ -64,6 +69,10 @@ const DMG_IDENTITY: int = 0xE4
 const DMG_SILHOUETTE: int = 0x3F
 ## `%11111111`, the object order the silhouette scene hides its sprites behind.
 const DMG_OBJECT_HIDDEN: int = 0xFF
+## `%11100000`, which `IntroScene1`'s `depixel 28, 28` assembles to: colour 1 is
+## taken from colour 0, so the shellders and the bubbles are white underwater
+## until `.scene3_1`'s `depixel 28, 28, 4, 4` puts the order back.
+const DMG_OBJECT_UNDERWATER: int = 0xE0
 
 ## `IntroScene5.palettes` and `IntroScene9.palettes`, the two water and grass
 ## fade-outs, and `IntroScene16.palettes`, the fireball's. Each is walked by a
@@ -320,11 +329,14 @@ func scroll() -> Vector2i:
 
 
 ## The `hSCY` for one scanline, which is `wLYOverrides` while `hLCDCPointer`
-## points at rSCY and plain `hSCY` otherwise.
+## points at rSCY and plain `hSCY` otherwise. `LCD` fires on `STAT_MODE_0` and
+## writes the entry `rLY` names, so the line after it is the one drawn with it;
+## `VBlank_Cutscene` writes entry zero, which is why the first two lines share
+## it.
 func scroll_y_at(line: int) -> int:
 	if not _ly_active or line < 0 or line >= _ly.size():
 		return _scy
-	return _ly[line]
+	return _ly[maxi(line - 1, 0)]
 
 
 ## Which cutscene's sheets are loaded, as the `RomLayout.GS_INTRO_SECTION` name
@@ -470,8 +482,8 @@ func _scene_water_setup() -> void:
 	_sprite_flag = false
 	_load_layout(CUTSCENE_WATER)
 	_bgp = DMG_IDENTITY
-	_obp0 = DMG_IDENTITY
-	_obp1 = DMG_IDENTITY
+	_obp0 = DMG_OBJECT_UNDERWATER
+	_obp1 = DMG_OBJECT_UNDERWATER
 	_init_shellders()
 	_emit(&"play_music", {"music": MUSIC_GS_OPENING})
 	_delay = 9
@@ -801,15 +813,14 @@ func _update_tilemap_and_bg_map() -> void:
 
 
 ## `Intro_AnimateOceanWaves`: four tiles cycled through four sets, copied over
-## the BG map from `vBGMap0 tile $1e`. The request the source queues for VBlank
-## is applied here directly, which lands the same bytes on the same frame.
+## the whole of [constant WAVE_ROW]. The request the source queues for VBlank is
+## applied here directly, which lands the same bytes on the same frame.
 func _animate_ocean_waves() -> void:
 	if _counter2 & 0x03 == 0x03:
 		return
 	var set: int = (_counter2 & 0x30) >> 4
-	for index: int in 32:
-		var cell: int = (0x1E + index) & (MAP_BYTES - 1)
-		_bg_map[cell] = 0x70 + set * 4 + (index & 0x03)
+	for column: int in MAP_COLUMNS:
+		_bg_map[WAVE_ROW * MAP_COLUMNS + column] = 0x70 + set * 4 + (column & 0x03)
 
 
 ## `Intro_InitSineLYOverrides`: `BattleAnim_Sine_e` at amplitude 4, one entry per

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -335,11 +335,14 @@ func scroll() -> Vector2i:
 
 
 ## The `hSCX` for one scanline, which is `wLYOverrides` while `hLCDCPointer`
-## points at rSCX and plain `hSCX` otherwise.
+## points at rSCX and plain `hSCX` otherwise. `LCD` fires on `STAT_MODE_0` and
+## writes the entry `rLY` names, so the line after it is the one drawn with it;
+## `VBlank_Cutscene` writes entry zero, which is why the first two lines share
+## it.
 func scroll_x_at(line: int) -> int:
 	if not _ly_active or line < 0 or line >= _ly.size():
 		return _scx
-	return _ly[line]
+	return _ly[maxi(line - 1, 0)]
 
 
 ## One background palette, as colours a page can draw with.

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -45,6 +45,14 @@ const ENTRANCE_SCX_STEP: int = 4
 ## The interlaced band is the logo's height, and only its odd lines take the
 ## opposite sign.
 const ENTRANCE_LINES: int = 8 * 10
+## `_TitleScreen`'s own `ld a, 8 / ldh [hSCY]`, which Gold and Silver's zeroes
+## instead: Crystal's whole background sits eight pixels up the BG map.
+const CRYSTAL_SCY: int = 8
+## `hWY`. `_TitleScreen` parks the copyright window off the bottom at -112 and
+## `TitleScreenEntrance.done` brings it to $88, which is the one row of
+## `vBGMap1` the screen ever shows.
+const WINDOW_OFF_Y: int = 144
+const WINDOW_Y: int = 0x88
 const CRYSTAL_START_Y: int = -0x22
 const CRYSTAL_END_Y: int = 6 + 2 * Gen2Tiles.TILE_HEIGHT
 const CRYSTAL_STEP: int = 2
@@ -53,6 +61,9 @@ const CRYSTAL_STEP: int = 2
 ## changes on every eighth, walking `.Frames`' four bases.
 const SUICUNE_FRAME_MASK: int = 0b111
 const SUICUNE_FRAMES: Array[int] = [0x80, 0x88, 0x00, 0x08]
+## `_TitleScreen`'s own `ld d, $0`, which is the strip the screen opens on
+## before the iterator has re-pointed it once.
+const SUICUNE_FIRST_BASE: int = 0x00
 ## `LoadSuicuneFrame` draws six rows of eight from whichever base it is handed.
 ## Its `d` rises by one across each of the eight columns and then by eight more
 ## at the end of the row, so a row starts sixteen tiles past the one above it:
@@ -169,6 +180,10 @@ var _timer: int = 0
 var _scx: int = 0
 var _crystal_y: int = 0
 var _suicune_counter: int = 0
+## `LoadSuicuneFrame`'s live base, which the iterator re-points rather than the
+## page deriving it: the counter is read before it is raised, so the write lands
+## a frame later than a derivation from the raised counter would put it.
+var _suicune_base: int = SUICUNE_FIRST_BASE
 var _bird_var: int = 0
 var _bird_frame: int = 0
 var _selected: int = -1
@@ -219,6 +234,19 @@ func scroll_x() -> int:
 	return _scx
 
 
+## `hSCY`, a constant on each profile.
+func scroll_y() -> int:
+	return CRYSTAL_SCY if _profile == RomRegistry.CRYSTAL else 0
+
+
+## `hWY`: the row the copyright window starts on, or off the bottom of the
+## screen while it is parked there. Gold and Silver draw no window at all.
+func window_y() -> int:
+	if _profile != RomRegistry.CRYSTAL or _scene == SCENE_ENTRANCE:
+		return WINDOW_OFF_Y
+	return WINDOW_Y
+
+
 ## `wLYOverrides`, one signed scroll per scanline, empty when nothing is
 ## overriding `hSCX`.
 ##
@@ -232,8 +260,18 @@ func line_offsets() -> PackedInt32Array:
 	if _profile == RomRegistry.CRYSTAL:
 		if _scene != SCENE_ENTRANCE or _scx == 0:
 			return out
+		# `wLYOverrides` is read by the LCD interrupt where it stands rather than
+		# copied at VBlank, so the screen this state's sprites reach carries the
+		# *next* pass's fill: `TitleScreenEntrance` writes it before the frame it
+		# opened is drawn. Everything else here is a frame behind it.
+		var scx: int = _scx - ENTRANCE_SCX_STEP
+		# Only the logo's own eighty lines are written; `_TitleScreen` zeroed
+		# the rest of the buffer and nothing rewrites them, so the strip below
+		# the logo stands still while the logo comes in.
+		out.resize(Gen2Screen.HEIGHT)
+		out.fill(0)
 		for line: int in ENTRANCE_LINES:
-			out.append(_scx if line % 2 == 0 else -_scx)
+			out[line] = scx if line % 2 == 0 else -scx
 		return out
 	out.resize(CLOUD_FIRST_LINE + CLOUD_LINES)
 	out.fill(0)
@@ -281,7 +319,10 @@ func advance_frame(held: Array = []) -> void:
 ## every frame of every scene rather than inside one.
 func _advance_animation() -> void:
 	if _profile == RomRegistry.CRYSTAL:
-		_suicune_counter = (_suicune_counter + 1) & 0xFF
+		var value: int = _suicune_counter
+		_suicune_counter = (value + 1) & 0xFF
+		if value & SUICUNE_FRAME_MASK == 0:
+			_suicune_base = SUICUNE_FRAMES[(value >> 3) & 0x03]
 		return
 	# The struct's own VAR1, counted the way each profile counts it. A byte, so
 	# Silver's countdown wraps rather than going negative.
@@ -427,8 +468,7 @@ static func _chord(held: Array, buttons: Array) -> bool:
 func suicune_base() -> int:
 	if _profile != RomRegistry.CRYSTAL:
 		return -1
-	var base: int = SUICUNE_FRAMES[(_suicune_counter >> 3) & 0x03]
-	return (base - SUICUNE_VRAM_FIRST_TILE) & 0xFF
+	return (_suicune_base - SUICUNE_VRAM_FIRST_TILE) & 0xFF
 
 
 ## Where `LoadSuicuneFrame` writes, and how much: six rows of eight tiles read

--- a/tests/unit/test_gold_silver_intro.gd
+++ b/tests/unit/test_gold_silver_intro.gd
@@ -121,3 +121,30 @@ func test_the_spawn_points_are_byte_coordinates() -> void:
 func test_every_scy_event_is_reachable_from_the_scenes_own_start() -> void:
 	for scy: int in Gen2GoldSilverIntro.SCY_EVENTS:
 		assert_between(int(scy), 0x80, 0xFF)
+
+
+## `Intro_AnimateOceanWaves` copies to `vBGMap0 tile $1e`, which is the map's
+## byte 480 and so the whole of row 15, never the byte $1e that reading the
+## operand as an offset gives. Its four tiles repeat across all thirty-two
+## columns and the set steps with `wIntroFrameCounter2`.
+func test_the_ocean_waves_fill_one_whole_map_row() -> void:
+	var movie: Gen2GoldSilverIntro = Gen2GoldSilverIntro.create(null)
+	for _frame: int in 700:
+		movie.advance_frame()
+	var map: PackedByteArray = movie.bg_map()
+	var first: int = Gen2GoldSilverIntro.WAVE_ROW * Gen2GoldSilverIntro.MAP_COLUMNS
+	for column: int in Gen2GoldSilverIntro.MAP_COLUMNS:
+		assert_between(map[first + column], 0x70, 0x7F)
+		assert_eq(map[first + column] & 0x03, column & 0x03, "four tiles repeated")
+	assert_eq(map[0x1E], 0, "and not the byte $1e the operand reads as an offset")
+
+
+## `IntroScene1`'s `depixel 28, 28` is `%11100000`, which takes colour 1 from
+## colour 0: the shellders and bubbles are white until `.scene3_1`'s
+## `depixel 28, 28, 4, 4` puts the identity order back.
+func test_the_underwater_objects_open_on_a_flooded_first_colour() -> void:
+	var order: int = Gen2GoldSilverIntro.DMG_OBJECT_UNDERWATER
+	var taken: Array[int] = []
+	for colour: int in 4:
+		taken.append((order >> (2 * colour)) & 0x03)
+	assert_eq(taken, [0, 0, 2, 3] as Array[int], "colour 1 comes from colour 0")

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -65,17 +65,36 @@ func test_the_entrance_walks_the_scroll_in_over_twenty_eight_frames() -> void:
 
 
 ## `wLYOverrides` over the logo's eighty lines, the odd ones negated, which is
-## what pulls the two halves together.
+## what pulls the two halves together. The buffer is read by the LCD interrupt
+## where it stands rather than copied at VBlank, so it is a pass ahead of
+## `hSCX`; everything below the logo stands still, because `_TitleScreen` zeroed
+## the rest of the buffer and nothing rewrites it.
 func test_the_entrance_is_interlaced() -> void:
 	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
 	_spend(scene, 4)
 	var lines: PackedInt32Array = scene.line_offsets()
-	assert_eq(lines.size(), Gen2TitleScene.ENTRANCE_LINES)
-	assert_eq(lines[0], scene.scroll_x())
-	assert_eq(lines[1], -scene.scroll_x())
+	assert_eq(lines.size(), Gen2Screen.HEIGHT)
+	var ahead: int = scene.scroll_x() - Gen2TitleScene.ENTRANCE_SCX_STEP
+	assert_eq(lines[0], ahead)
+	assert_eq(lines[1], -ahead)
+	assert_eq(lines[Gen2TitleScene.ENTRANCE_LINES], 0, "the strip below is not moved")
 
 	_spend(scene, 40)
 	assert_eq(scene.line_offsets().size(), 0, "and nothing overrides after it")
+
+
+## `_TitleScreen`'s own `ld a, 8 / ldh [hSCY]`, and the copyright window
+## `TitleScreenEntrance.done` brings up behind it.
+func test_only_crystal_scrolls_down_and_shows_a_copyright_window() -> void:
+	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	assert_eq(scene.scroll_y(), Gen2TitleScene.CRYSTAL_SCY)
+	assert_eq(scene.window_y(), Gen2TitleScene.WINDOW_OFF_Y, "parked off the bottom")
+	_spend(scene, Gen2TitleScene.ENTRANCE_SCX / Gen2TitleScene.ENTRANCE_SCX_STEP + 1)
+	assert_eq(scene.scene(), Gen2TitleScene.SCENE_TIMER)
+	assert_eq(scene.window_y(), Gen2TitleScene.WINDOW_Y)
+	var gold: Gen2TitleScene = _scene(RomRegistry.GOLD)
+	assert_eq(gold.scroll_y(), 0)
+	assert_eq(gold.window_y(), Gen2TitleScene.WINDOW_OFF_Y, "and never draws one")
 
 
 ## `TitleScreenTimer`'s own `ld de`, which is the one value Gold does not share.
@@ -137,14 +156,18 @@ func test_the_timer_running_out_answers_restart() -> void:
 ## last two of which are a sheet on from the first two.
 func test_the_suicune_frame_changes_every_eighth_frame() -> void:
 	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	# `_TitleScreen`'s own `ld d, $0`, before the iterator has re-pointed the
+	# strip once.
+	assert_eq(scene.suicune_base(), 0x80, "the base the screen is built with")
 	var seen: Array[int] = []
 	for step: int in 4:
-		seen.append(scene.suicune_base())
 		_spend(scene, 8)
+		seen.append(scene.suicune_base())
 	## `.Frames`' four bases are $80, $88, $00 and $08, which are tiles 0, 8, 128
 	## and 136 of the strip: the sheet starts at VRAM tile $80 and the last two
 	## numbers have wrapped a byte.
 	assert_eq(seen, [0x00, 0x08, 0x80, 0x88] as Array[int])
+	_spend(scene, 8)
 	assert_eq(scene.suicune_base(), 0x00, "and then it comes round again")
 	assert_eq(_scene(RomRegistry.GOLD).suicune_base(), -1, "Gold has no Suicune")
 
@@ -155,7 +178,9 @@ func test_the_suicune_frame_changes_every_eighth_frame() -> void:
 ## Measured against a cartridge: at a stride of eight the strip is torn, tiles
 ## from one row of the sheet landing in the next.
 func test_the_suicune_strip_is_six_rows_of_eight() -> void:
-	var placed: Array[Vector3i] = _scene(RomRegistry.CRYSTAL).suicune_tiles()
+	var scene: Gen2TitleScene = _scene(RomRegistry.CRYSTAL)
+	_spend(scene, 1)
+	var placed: Array[Vector3i] = scene.suicune_tiles()
 	assert_eq(placed.size(), Gen2TitleScene.SUICUNE_ROWS * Gen2TitleScene.SUICUNE_COLUMNS)
 	assert_eq(placed[0], Vector3i(6, 12, 0x00))
 	assert_eq(placed[7], Vector3i(13, 12, 0x07), "eight across")


### PR DESCRIPTION
Six defects in the opening's rendering, all found by diffing rendered frames against a real dump rather than against pinned numbers.

| Fix | Symptom |
|---|---|
| `vBGMap0 tile $1e` is `+ TILE_SIZE * $1e`, so the wave tiles fill map row 15 | Gold and Silver's ocean surface was a straight line where the cartridge's is ragged |
| The lower OAM index wins a pixel, in all four opening pages | Charizard's small fireball drew over the big one it is spawned after; Gold's splash sparkles stacked the wrong way |
| `OAM_PRIO` carried into both intro pages | Lapras's body was not covered by the wave row it surfaces through |
| `LCD` on `STAT_MODE_0` writes the entry `rLY` names, so the *next* line is drawn with it | The water sine and the title entrance's interlace were one scanline out |
| `IntroScene1`'s `depixel 28, 28` is `%11100000` | Shellders and bubbles were grey underwater instead of white |
| The title's `hSCY` of 8, its copyright window, and `SuicuneFrameIterator` reading its counter before raising it | The whole Crystal title was eight pixels low, had no copyright line, and changed Suicune's frame a frame early |

Measured against the dump:

| Phase | Sampled frames identical |
|---|---|
| Gold and Silver's movie | 158/160 on each |
| Crystal's title | 432/440 |
| Gold's splash | 116/116 |
| Crystal's splash | 76/76 |

What still differs is `UpdateBGMap` copying a third of the rows a frame while this port writes the tilemap in one, and the title entrance's first scanlines, which are a raster race against the CPU's own fill.

GUT 2,809 over 148 scripts green, `validate.gd -- all` green, 27 replay routes with no failures, and the three-profile story walk unchanged.