### PR TITLE
Give and take held items, and register one to SELECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,10 @@ screen over the same values the launcher's settings edit, so the two cannot
 disagree. Pokedex has the three source orderings, type search and the
 `<MON>'S NEST` area map. Pokegear has the clock, map, phone and radio cards, and
 a tuned station keeps playing after it closes, which is how the Poke Flute
-channel wakes Vermilion's Snorlax. Pack opens each item's own submenu, and the
-party submenu offers all eight field moves to a Pokemon that knows one.
+channel wakes Vermilion's Snorlax. Pack opens each item's own submenu: USE,
+GIVE, TOSS and SEL, which registers an item to the SELECT button and uses it
+from the map. The party submenu offers all eight field moves to a Pokemon that
+knows one, and ITEM gives or takes what it holds.
 
 Facing something and pressing A is the other way to every field move: a cut
 tree, a whirlpool, a waterfall, a headbutt tree and open water each offer their

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -141,8 +141,15 @@ func select_game(game_id: StringName) -> bool:
 func _retarget_mods(game_id: StringName) -> void:
 	if Gen2ModHost.instance().target_game() == game_id:
 		return
+	reload_mods(game_id)
+
+
+## The same reload for a list that changed rather than a cartridge that did: a
+## mod switched on or off, or one deleted. One rule covers both, so a switch
+## applies where it was thrown instead of at the next launch.
+func reload_mods(game_id: StringName = selected_game_id) -> Array:
 	Gen2ModHost.reset()
-	load_mods(game_id)
+	return load_mods(game_id)
 
 
 func has_selected_game() -> bool:

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -106,7 +106,9 @@ leaving them behind.
 
 Mods load the same way in an exported build as in the editor: the entry script
 is plain GDScript read at runtime, even though the game's own scripts ship as
-binary tokens. An installed mod loads immediately, without a restart.
+binary tokens. An installed mod loads immediately, without a restart, and so
+does a change to the list: switching one on or off, deleting one, or choosing a
+different cartridge reloads every mod against a fresh host.
 
 `user://mods/` is the platform's `app_userdata/pokerecomp/mods` on desktop, the
 app's `Documents/mods` on iOS (reachable in the Files app, since the export sets

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -3,13 +3,13 @@ extends VBoxContainer
 
 ## Installed mods, with an on/off switch and a delete beside each.
 ##
-## Switching one off takes effect on the next start, which the page says rather
-## than pretending a running registration can be withdrawn: a mod has already
-## registered its content and renderers by the time this is reachable.
+## A change to the list is applied where it is made: the host is reset and every
+## entry script runs again, which is the same reload a cartridge change already
+## did. Nothing here can withdraw one registration on its own, so the whole list
+## is reloaded rather than half of it.
 
 signal install_requested
 signal index_requested
-signal mods_changed
 
 var _theme: Gen2LauncherTheme = null
 var _list: VBoxContainer = null
@@ -168,20 +168,30 @@ func _set_enabled(manifest: Gen2ModManifest, on: bool) -> void:
 	if not Gen2ModState.set_enabled(manifest.id, on):
 		_fail("That switch could not be written to %s." % Gen2ModState.PATH)
 		return
-	_note.text = "%s is %s. Restart to apply." % [manifest.name, "on" if on else "off"]
-	mods_changed.emit()
+	_reload()
+	## After the list, which rewrites the note with where mods are loaded from.
+	refresh()
+	_note.text = "%s is %s." % [manifest.name, "on" if on else "off"]
 
 
 func _delete(manifest: Gen2ModManifest) -> void:
 	if not bool(Gen2ModInstaller.uninstall(manifest.id).get("ok", false)):
 		_fail("%s could not be removed." % manifest.name)
 		return
-	# Rediscover so the deleted mod leaves the list. What it already registered
-	# this session stays until restart, which the message says.
-	Gen2ModHost.instance().discover()
-	_note.text = "%s was removed. Restart to apply." % manifest.name
+	_reload()
 	refresh()
-	mods_changed.emit()
+	_note.text = "%s was removed." % manifest.name
+
+
+## The host reload behind either change. Without a runtime there is no host to
+## reload and rediscovering is all the list needs, which is what a page built by
+## a test or a preview gets.
+func _reload() -> void:
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	if runtime == null:
+		Gen2ModHost.instance().discover()
+		return
+	runtime.reload_mods()
 
 
 func _fail(message: String) -> void:

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -27,6 +27,9 @@ const OPTION_SWITCH: StringName = &"switch"
 const OPTION_ITEM: StringName = &"item"
 const OPTION_CANCEL: StringName = &"cancel"
 const OPTION_MOVE: StringName = &"move"
+## `GiveTakeItemMenuData`'s own two rows, which ITEM opens rather than answers.
+const OPTION_GIVE: StringName = &"give"
+const OPTION_TAKE: StringName = &"take"
 ## engine/pokemon/mon_submenu.asm's NUM_MONMENU_ITEMS: a list already this long
 ## drops CANCEL rather than growing.
 const MAX_SUBMENU_ITEMS: int = 8
@@ -49,6 +52,9 @@ var _submenu: VBoxContainer = null
 var _submenu_items: Array = []
 var _submenu_cursor: int = 0
 var _submenu_open: bool = false
+## Whether the rows on screen are ITEM's GIVE/TAKE box rather than the mon's own
+## submenu, which is what B goes back to.
+var _item_menu_open: bool = false
 
 
 func _ready() -> void:
@@ -74,6 +80,7 @@ func set_context(data: GameData, save: Gen2SaveData, embedded: bool = false) -> 
 	_save = save
 	_member_cursor = 0
 	_submenu_open = false
+	_item_menu_open = false
 	_submenu_items = []
 	_submenu_cursor = 0
 	if is_inside_tree() and _cards != null:
@@ -130,14 +137,26 @@ static func submenu_items_for(data: GameData, mon: Gen2SaveMon) -> Array:
 	items.append(_option_entry(OPTION_STATS, "STATS"))
 	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
 	items.append(_option_entry(OPTION_MOVE, "MOVE"))
-	items.append(_option_entry(OPTION_ITEM, "ITEM"))
+	items.append(_option_entry(OPTION_ITEM, "ITEM", true))
 	if items.size() < MAX_SUBMENU_ITEMS:
 		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
 	return items
 
 
-static func _option_entry(option: StringName, label: String) -> Dictionary:
-	return {"kind": &"option", "option": option, "label": label, "available": false}
+static func _option_entry(
+	option: StringName, label: String, available: bool = false
+) -> Dictionary:
+	return {"kind": &"option", "option": option, "label": label, "available": available}
+
+
+## `GiveTakeItemMenuData`, the two-row box ITEM opens. Both answers need the live
+## world the overworld owns, so each is reported rather than run here, the way a
+## field move is.
+static func item_menu_items() -> Array:
+	return [
+		{"kind": &"mon_item", "option": OPTION_GIVE, "label": "GIVE", "available": true},
+		{"kind": &"mon_item", "option": OPTION_TAKE, "label": "TAKE", "available": true},
+	]
 
 
 func _party_size() -> int:
@@ -192,21 +211,43 @@ func _confirm() -> void:
 		_status.text = "%s is not available yet." % String(entry.get("label", ""))
 		_status.add_theme_color_override("font_color", MUTED)
 		return
-	if StringName(entry.get("kind", &"")) != &"field_move":
-		return
-	action_chosen.emit({
-		"kind": &"field_move",
-		"move": int(entry.get("move", 0)),
-		"slot": _member_cursor,
-		"name": _display_name(_save.party[_member_cursor]),
-	})
+	match StringName(entry.get("kind", &"")):
+		&"field_move":
+			action_chosen.emit({
+				"kind": &"field_move",
+				"move": int(entry.get("move", 0)),
+				"slot": _member_cursor,
+				"name": _display_name(_save.party[_member_cursor]),
+			})
+		&"mon_item":
+			action_chosen.emit({
+				"kind": &"mon_item",
+				"option": StringName(entry.get("option", &"")),
+				"slot": _member_cursor,
+				"name": _display_name(_save.party[_member_cursor]),
+			})
+		&"option":
+			if StringName(entry.get("option", &"")) == OPTION_ITEM:
+				_open_item_menu()
 
 
 func _cancel() -> void:
+	## `GiveTakePartyMonItem`'s own `VerticalMenu` carry is `.cancel`, which
+	## returns to the submenu it opened over rather than closing the party menu.
+	if _item_menu_open:
+		_open_submenu()
+		return
 	if _submenu_open:
 		_close_submenu()
 		return
 	close_embedded()
+
+
+func _open_item_menu() -> void:
+	_submenu_items = item_menu_items()
+	_submenu_cursor = 0
+	_item_menu_open = true
+	_refresh()
 
 
 func _open_submenu() -> void:
@@ -215,11 +256,13 @@ func _open_submenu() -> void:
 	_submenu_items = submenu_items_for(_data, _save.party[_member_cursor])
 	_submenu_cursor = 0
 	_submenu_open = not _submenu_items.is_empty()
+	_item_menu_open = false
 	_refresh()
 
 
 func _close_submenu() -> void:
 	_submenu_open = false
+	_item_menu_open = false
 	_submenu_items = []
 	_submenu_cursor = 0
 	_refresh()
@@ -229,6 +272,7 @@ func _close_submenu() -> void:
 func submenu_snapshot() -> Dictionary:
 	return {
 		"open": _submenu_open,
+		"item_menu": _item_menu_open,
 		"cursor": _submenu_cursor,
 		"member": _member_cursor,
 		"items": _submenu_items.duplicate(true),

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -20,7 +20,7 @@ signal closed
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
 	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING,
-	PACK_TOSS_QUANTITY, PACK_TOSS_CONFIRM,
+	PACK_TOSS_QUANTITY, PACK_TOSS_CONFIRM, PACK_GIVE_SWAP,
 	PACK_RESULT, SAVE_CONFIRM, OPTIONS, MODS, MOD_OPTIONS,
 }
 
@@ -79,6 +79,21 @@ var _teaching: bool = false
 var _toss_prompt: Gen2WorldQuantityPrompt = null
 var _toss_confirm_cursor: int = 0
 
+## GIVE's two directions. `_giving` is the pack's own: the item is chosen and the
+## party list picks who holds it. `_give_target` is `GiveTakePartyMonItem`'s,
+## where the Pokemon is already chosen and the pack list is `DepositSellPack`,
+## which acts on the item rather than opening a submenu over it.
+var _giving: bool = false
+var _give_target: int = -1
+## `PokemonAskSwapItemText`'s yes/no and who it is about.
+var _swap_cursor: int = 0
+var _swap_target: int = -1
+## Whether the USE running is `UseRegisteredItem`'s rather than the pack's own,
+## which is the one thing the two jumptables disagree about: their refusals.
+var _using_registered: bool = false
+## An entry point asked for before the panel was built, run once it is.
+var _pending_entry: Callable = Callable()
+
 ## ForgetMove's list and the two yes/no boxes around it. The party index is held
 ## because the second teach_tm_hm() call has to name the same Pokémon the first
 ## one refused.
@@ -113,6 +128,10 @@ func _ready() -> void:
 	_build_ui()
 	if _menu != null:
 		_open_list_mode()
+	if _pending_entry.is_valid():
+		var entry: Callable = _pending_entry
+		_pending_entry = Callable()
+		entry.call()
 
 
 ## `save_action` is called with no arguments and must return a Dictionary
@@ -151,6 +170,60 @@ func set_party_context(save: Gen2SaveData, persist: bool = true) -> void:
 ## way the source's wBattleMenuCursorPosition survives a reopen.
 func cursor() -> int:
 	return _menu.cursor if _menu != null else 0
+
+
+## `GiveTakePartyMonItem`'s GIVE, which opens the pack over a Pokemon the player
+## has already chosen. [method open] and [method set_party_context] come first,
+## the same way the start menu's own pack does.
+func open_give(party_index: int) -> void:
+	_give_target = party_index
+	if _defer_entry(open_give.bind(party_index)):
+		return
+	_open_pack_mode()
+
+
+## `SelectMenu`. `CheckRegisteredItem` answers first, and its `.NotRegistered`
+## carry is `MayRegisterItemText` rather than a pack at all; otherwise
+## `UseRegisteredItem` runs `CheckItemMenu`'s jumptable over the registered item,
+## which is the same one the pack's own USE reads.
+func open_registered_item() -> void:
+	if _defer_entry(open_registered_item):
+		return
+	var item: int = Gen2WorldBagHost.registered_item(_world)
+	_open_pack_mode()
+	_using_registered = true
+	if item <= 0:
+		_show_pack_result(Gen2WorldPack.may_register_text(), false)
+		return
+	if not _select_pack_item(item):
+		_show_pack_result(Gen2WorldPack.may_register_text(), false)
+		return
+	_confirm_use()
+
+
+## Holds an entry point until the panel exists, the way [method open] holds the
+## list. A caller that opens this screen before adding it to the tree is a
+## preview or a test; the overworld adds it first.
+func _defer_entry(entry: Callable) -> bool:
+	if is_inside_tree() and _options != null:
+		return false
+	_pending_entry = entry
+	return true
+
+
+## Puts the pack cursor on one item, which is what `CheckRegisteredItem` finding
+## the entry in its pocket amounts to here.
+func _select_pack_item(item: int) -> bool:
+	for pocket_index: int in _pack_pockets.size():
+		var items: Array = (_pack_pockets[pocket_index] as Dictionary).get("items", [])
+		for index: int in items.size():
+			if int((items[index] as Dictionary).get("item", 0)) != item:
+				continue
+			_pack_pocket_index = pocket_index
+			_pack_cursor = index
+			_render_pack()
+			return true
+	return false
 
 
 func handle_button(button: int) -> bool:
@@ -211,6 +284,10 @@ func _move(direction: Vector2i) -> void:
 			if direction.y != 0 or direction.x != 0:
 				_toss_confirm_cursor = 1 - _toss_confirm_cursor
 				_render_toss_confirm()
+		Mode.PACK_GIVE_SWAP:
+			if direction.y != 0 or direction.x != 0:
+				_swap_cursor = 1 - _swap_cursor
+				_render_give_swap()
 		Mode.PACK_TARGET:
 			if direction.y != 0 and not _party_targets().is_empty():
 				_target_cursor = wrapi(
@@ -250,7 +327,13 @@ func _confirm() -> void:
 		Mode.LIST:
 			_confirm_list()
 		Mode.PACK:
-			if not _current_pocket_items().is_empty():
+			if _current_pocket_items().is_empty():
+				return
+			## `DepositSellPack` acts on the item it is given rather than
+			## opening a submenu over it, which is the pack `.GiveItem` opens.
+			if _give_target >= 0:
+				_give_selected_item(_give_target)
+			else:
 				_open_item_mode()
 		Mode.PACK_ITEM:
 			_confirm_item_action()
@@ -264,13 +347,22 @@ func _confirm() -> void:
 			_confirm_stop_learning()
 		Mode.PACK_TOSS_CONFIRM:
 			_confirm_toss()
+		Mode.PACK_GIVE_SWAP:
+			_confirm_give_swap()
 		Mode.PACK_TARGET:
 			if _teaching:
 				_teach_selected_item(_target_cursor)
+			elif _giving:
+				_give_selected_item(_target_cursor)
 			else:
 				_use_selected_item(_target_cursor)
+		## A pack opened over one Pokemon has no menu behind it to go back to:
+		## the party screen closed when it asked for this one.
 		Mode.PACK_RESULT:
-			_open_pack_mode(false)
+			if _give_target >= 0:
+				closed.emit()
+			else:
+				_open_pack_mode(false)
 		Mode.SAVE_CONFIRM:
 			_confirm_save()
 		## Options_Cancel is the only handler that reads A.
@@ -292,9 +384,17 @@ func _cancel() -> void:
 		Mode.LIST:
 			closed.emit()
 		Mode.PACK:
-			_open_list_mode()
-		Mode.PACK_ITEM, Mode.PACK_RESULT, Mode.PACK_TEACH:
+			if _give_target >= 0:
+				closed.emit()
+			else:
+				_open_list_mode()
+		Mode.PACK_ITEM, Mode.PACK_TEACH:
 			_open_pack_mode(false)
+		Mode.PACK_RESULT:
+			if _give_target >= 0:
+				closed.emit()
+			else:
+				_open_pack_mode(false)
 		## B at ForgetMove's ask is YesNoBox's no, and B in the move list is its
 		## own .cancel's scf. Both are the carry LearnMove.cancel tests.
 		Mode.PACK_FORGET_ASK, Mode.PACK_FORGET:
@@ -307,7 +407,7 @@ func _cancel() -> void:
 		## B at the yes/no is `YesNoBox`'s no, which is the carry `TossMenu`
 		## returns on. The submenu is already closed by then, so it lands back on
 		## the pocket list rather than on the item's own menu.
-		Mode.PACK_TOSS_CONFIRM:
+		Mode.PACK_TOSS_CONFIRM, Mode.PACK_GIVE_SWAP:
 			_open_pack_mode(false)
 		Mode.SAVE_CONFIRM:
 			_open_list_mode()
@@ -504,6 +604,9 @@ func _adjust_mod_option(rows: Array, delta: int) -> void:
 ## same way. The item list is always rebuilt, since a USE changed a quantity.
 func _open_pack_mode(reset: bool = true) -> void:
 	_mode = Mode.PACK
+	_giving = false
+	_teaching = false
+	_using_registered = false
 	_pack_pockets = Gen2WorldPack.build(_data, _world.state) if _world != null else []
 	if reset:
 		_pack_pocket_index = 0
@@ -511,7 +614,9 @@ func _open_pack_mode(reset: bool = true) -> void:
 	_pack_pocket_index = clampi(_pack_pocket_index, 0, maxi(_pack_pockets.size() - 1, 0))
 	_pack_cursor = clampi(_pack_cursor, 0, maxi(_current_pocket_items().size() - 1, 0))
 	_status.text = ""
-	_footer.text = "Left and right: pocket    Up and down: move    A: choose    B: back"
+	_footer.text = "Left and right: pocket    Up and down: move    A: %s    B: back" % (
+		"give" if _give_target >= 0 else "choose"
+	)
 	_render_pack()
 
 
@@ -543,7 +648,7 @@ func _move_pack_cursor(delta: int) -> void:
 
 func _render_pack() -> void:
 	var pocket: Dictionary = _current_pocket()
-	_title.text = "PACK"
+	_title.text = "GIVE" if _give_target >= 0 else "PACK"
 	_summary.text = String(pocket.get("name", ""))
 	var items: Array = pocket.get("items", [])
 	if items.is_empty():
@@ -568,6 +673,11 @@ func _open_item_mode() -> void:
 	if item.is_empty():
 		return
 	_mode = Mode.PACK_ITEM
+	## Both are answers the party list ahead is still waiting to give. Leaving
+	## either set here is what let a TM's cancelled ChooseMonToLearnTMHM teach
+	## itself from the next item's own `.Party` list.
+	_teaching = false
+	_giving = false
 	_item_actions = Gen2WorldPack.item_submenu(_data, int(item.get("item", 0)))
 	_item_cursor = 0
 	_status.text = ""
@@ -578,28 +688,137 @@ func _open_item_mode() -> void:
 
 func _render_item_menu() -> void:
 	_title.text = "PACK"
-	_render_options(_item_actions, _item_cursor, func(entry: Dictionary) -> String:
-		var label: String = String(entry.get("label", ""))
-		return label if bool(entry.get("available", false)) else "%s (unavailable)" % label
+	_render_options(_item_actions, _item_cursor,
+		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
 	)
 
 
 func _confirm_item_action() -> void:
 	if _item_cursor < 0 or _item_cursor >= _item_actions.size():
 		return
-	var entry: Dictionary = _item_actions[_item_cursor]
-	var action: StringName = StringName(entry.get("action", &""))
-	if action == Gen2WorldPack.ACTION_QUIT:
+	var action: StringName = StringName(
+		(_item_actions[_item_cursor] as Dictionary).get("action", &"")
+	)
+	match action:
+		Gen2WorldPack.ACTION_QUIT:
+			_open_pack_mode(false)
+		Gen2WorldPack.ACTION_TOSS:
+			_open_toss_quantity()
+		Gen2WorldPack.ACTION_GIVE:
+			_open_give_target()
+		Gen2WorldPack.ACTION_SELECT:
+			_register_selected_item()
+		_:
+			_confirm_use()
+
+
+## `GiveItem`'s own party list, which `.NoPokemon` answers when there is none.
+func _open_give_target() -> void:
+	if _party_targets().is_empty():
+		_show_pack_result(_pack_text(TEXT_NO_MON), false)
+		return
+	_giving = true
+	_open_target_mode()
+
+
+## `RegisterItem`. `CheckSelectableItem` has already decided whether SEL is in
+## the submenu at all, so the refusal here is only reachable from a caller that
+## is not that submenu.
+func _register_selected_item() -> void:
+	var item: Dictionary = _selected_item()
+	if item.is_empty():
+		return
+	if _world == null:
+		_show_pack_result("No world is loaded.", false)
+		return
+	var result: Dictionary = Gen2WorldBagHost.register(
+		_world, _pack_save, int(item.get("item", 0)), _pack_persist
+	)
+	if not bool(result.get("ok", false)):
+		if StringName(result.get("reason", &"")) == &"item_cannot_be_registered":
+			_show_pack_result(Gen2WorldPack.cant_register_text(), false)
+			return
+		_show_pack_result(
+			"Could not register that (%s)." % String(result.get("reason", "")), false
+		)
+		return
+	_show_pack_result(Gen2WorldPack.registered_text(String(result.get("name", ""))), true)
+
+
+## `TryGiveItemToPartymon`, from either direction: the pack's GIVE names the
+## Pokemon last and `GiveTakePartyMonItem`'s GIVE names the item last. A hand
+## that is already full stops at `PokemonAskSwapItemText` with nothing written.
+func _give_selected_item(party_index: int, swap: bool = false) -> void:
+	var item: Dictionary = _selected_item()
+	if item.is_empty():
+		return
+	if _pack_save == null or _world == null:
+		_show_pack_result("No save is loaded.", false)
+		return
+	var number: int = int(item.get("item", 0))
+	if not Gen2WorldPack.can_hold(_data, number):
+		_show_pack_result(Gen2WorldPack.cant_hold_text(), false)
+		return
+	var result: Dictionary = Gen2WorldBagHost.give_to_party(
+		_world, _pack_save, number, party_index, swap, _pack_persist
+	)
+	if bool(result.get("ok", false)):
+		var name: String = _target_name(party_index)
+		var held_name: String = String(result.get("held_name", ""))
+		_show_pack_result(
+			Gen2WorldPack.swap_text(name, held_name, String(result.get("name", ""))) \
+				if int(result.get("held", 0)) > 0 \
+				else Gen2WorldPack.hold_text(name, String(result.get("name", ""))),
+			true
+		)
+		return
+	var reason: StringName = StringName(result.get("reason", &""))
+	if reason == &"already_holding":
+		_open_give_swap(party_index, String(
+			(result.get("details", {}) as Dictionary).get("held_name", "")
+		))
+		return
+	_show_pack_result(_give_refusal(reason, party_index), false)
+
+
+func _give_refusal(reason: StringName, party_index: int) -> String:
+	match reason:
+		&"cannot_hold_egg":
+			return Gen2WorldPack.egg_cant_hold_text()
+		&"item_cannot_be_held":
+			return Gen2WorldPack.cant_hold_text()
+		&"bag_full":
+			return Gen2WorldPack.storage_full_text()
+		&"insufficient_item_quantity":
+			return "You have none of those."
+	return "%s could not be given that (%s)." % [_target_name(party_index), String(reason)]
+
+
+func _open_give_swap(party_index: int, held_name: String) -> void:
+	_mode = Mode.PACK_GIVE_SWAP
+	_swap_cursor = 0
+	_swap_target = party_index
+	_status.text = ""
+	_footer.text = "Up and down: move    A: choose    B: back"
+	_render_give_swap(held_name)
+
+
+func _render_give_swap(held_name: String = "") -> void:
+	_title.text = "GIVE"
+	if not held_name.is_empty():
+		_summary.text = Gen2WorldPack.ask_swap_text(_target_name(_swap_target), held_name)
+	_render_options([{"label": "YES"}, {"label": "NO"}], _swap_cursor,
+		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
+	)
+
+
+## The answer to `PokemonAskSwapItemText`. Its no is `.abort`, which leaves both
+## items where they were.
+func _confirm_give_swap() -> void:
+	if _swap_cursor != 0:
 		_open_pack_mode(false)
 		return
-	if not bool(entry.get("available", false)):
-		_status.text = "%s is not available yet." % String(entry.get("label", ""))
-		_status.add_theme_color_override("font_color", MUTED)
-		return
-	if action == Gen2WorldPack.ACTION_TOSS:
-		_open_toss_quantity()
-		return
-	_confirm_use()
+	_give_selected_item(_swap_target, true)
 
 
 ## `UseItem`'s jumptable: `.Oak` refuses, `.Current` and `.Field` apply straight
@@ -848,12 +1067,12 @@ func _open_target_mode() -> void:
 	_mode = Mode.PACK_TARGET
 	_target_cursor = clampi(_target_cursor, 0, maxi(_party_targets().size() - 1, 0))
 	_status.text = ""
-	_footer.text = "Up and down: move    A: use    B: back"
+	_footer.text = "Up and down: move    A: %s    B: back" % ("give" if _giving else "use")
 	_render_targets()
 
 
 func _render_targets() -> void:
-	_title.text = "USE ON"
+	_title.text = "GIVE TO" if _giving else "USE ON"
 	_summary.text = String(_selected_item().get("name", ""))
 	_render_options(_party_targets(), 0 if _party_targets().is_empty() else _target_cursor,
 		func(entry: Dictionary) -> String:
@@ -878,7 +1097,7 @@ func _use_selected_item(party_index: int) -> void:
 		_world, _pack_save, number, party_index, _pack_persist
 	)
 	if not bool(result.get("ok", false)):
-		_show_pack_result(_use_refusal(StringName(result.get("reason", &""))), false)
+		_show_pack_result(_use_refusal(StringName(result.get("reason", &"")), number), false)
 		return
 	_show_pack_result(_use_summary(item, result), true)
 
@@ -899,12 +1118,19 @@ func _use_summary(item: Dictionary, result: Dictionary) -> String:
 	return "%s was used." % name
 
 
-func _use_refusal(reason: StringName) -> String:
+## `UseItem` and `UseRegisteredItem` refuse the same item in two words: the
+## pack's `.Field` falls through to `.Oak` when the effect did nothing, and
+## SELECT's `.Overworld` reaches `CantUseItem` instead.
+func _use_refusal(reason: StringName, item: int) -> String:
+	if _using_registered:
+		return Gen2WorldPack.cant_use_text()
 	match reason:
 		&"item_has_no_effect":
 			return "It won't have any effect."
 		&"insufficient_item_quantity":
 			return "You have none of those."
+	if Gen2WorldPack.field_use_kind(_data, item) == Gen2WorldPack.ITEMMENU_CLOSE:
+		return _pack_text(TEXT_OAK)
 	return "Can't use that here: %s" % String(reason)
 
 

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -2,7 +2,8 @@ class_name Gen2WorldBagHost
 extends RefCounted
 
 ## Bag-only transactions: what the pack changes without a party, a mart or a
-## script behind it. `TossItem` (`home/item.asm`, `_TossItem`) is the first.
+## script behind it. `TossItem` (`home/item.asm`, `_TossItem`), the two halves of
+## `GiveTakePartyMonItem` and `RegisterItem`.
 ##
 ## The source routine walks `_TossItem`'s pocket jumptable to find which packed
 ## array the item lives in and calls `RemoveItemFromPocket` on it. The flat item
@@ -52,3 +53,161 @@ static func toss(
 		"quantity": quantity,
 		"remaining": owned - quantity,
 	}
+
+
+## `TryGiveItemToPartymon`, which the pack's GIVE and the party submenu's ITEM
+## both reach. [param swap] is the answer to `PokemonAskSwapItemText`: without it
+## a Pokemon already holding something is refused with nothing written, which is
+## where the source stops to ask.
+##
+## `ItemIsMail` has no counterpart here, so `.please_remove_mail` and
+## `ComposeMailMessage` are unreachable and no item is refused for being mail.
+static func give_to_party(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	item: int,
+	party_index: int,
+	swap: bool = false,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return Gen2WorldTransaction.failure(&"missing_world", {})
+	var definition: Dictionary = world.data.item(item)
+	if definition.is_empty():
+		return Gen2WorldTransaction.failure(&"unknown_item", {"item": item})
+	if not Gen2WorldPack.can_hold(world.data, item):
+		return Gen2WorldTransaction.failure(&"item_cannot_be_held", {"item": item})
+	var owned: int = world.state.item_quantity(item)
+	if owned <= 0:
+		return Gen2WorldTransaction.failure(&"insufficient_item_quantity", {"item": item})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return opened
+	var candidate: Gen2SaveData = opened["candidate"]
+	var mon: Gen2SaveMon = _party_member(candidate, party_index)
+	if mon == null:
+		return Gen2WorldTransaction.failure(&"unknown_party_member", {"party_index": party_index})
+	if mon.is_egg:
+		return Gen2WorldTransaction.failure(&"cannot_hold_egg", {"party_index": party_index})
+	var held: int = mon.item
+	if held > 0 and not swap:
+		return Gen2WorldTransaction.failure(&"already_holding", {
+			"party_index": party_index, "held": held,
+			"held_name": world.data.item_name(held),
+		})
+	var changes: Dictionary = {item: owned - 1}
+	if held > 0:
+		## `GiveItemToPokemon` runs before `ReceiveItemFromPokemon`, so the entry
+		## the outgoing item just freed is there for the one coming back.
+		var remaining: Dictionary = world.state.items()
+		remaining[item] = owned - 1
+		if int(remaining[item]) <= 0:
+			remaining.erase(item)
+		var room: Dictionary = Gen2WorldPack.receive_check(world.data, remaining, held, 1)
+		if not bool(room.get("ok", false)):
+			return Gen2WorldTransaction.failure(&"bag_full", room)
+		changes[held] = int(remaining.get(held, 0)) + 1
+	mon.item = item
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {"items": changes})
+	if not bool(applied.get("ok", false)):
+		return Gen2WorldTransaction.failure(&"give_state_failed", applied)
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {
+		"ok": true,
+		"item": item,
+		"name": String(definition.get("name", "UNKNOWN")),
+		"party_index": party_index,
+		"held": held,
+		"held_name": world.data.item_name(held) if held > 0 else "",
+	}
+
+
+## `TakePartyItem`. An empty hand and a full pack are both refusals with their
+## own text, so neither is folded into the other.
+static func take_from_party(
+	world: Gen2WorldAPI, save: Gen2SaveData, party_index: int, persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return Gen2WorldTransaction.failure(&"missing_world", {})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return opened
+	var candidate: Gen2SaveData = opened["candidate"]
+	var mon: Gen2SaveMon = _party_member(candidate, party_index)
+	if mon == null:
+		return Gen2WorldTransaction.failure(&"unknown_party_member", {"party_index": party_index})
+	var held: int = mon.item
+	if held <= 0:
+		return Gen2WorldTransaction.failure(&"not_holding", {"party_index": party_index})
+	var room: Dictionary = Gen2WorldPack.receive_check(world.data, world.state.items(), held, 1)
+	if not bool(room.get("ok", false)):
+		return Gen2WorldTransaction.failure(&"bag_full", room)
+	mon.item = 0
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {held: world.state.item_quantity(held) + 1},
+	})
+	if not bool(applied.get("ok", false)):
+		return Gen2WorldTransaction.failure(&"take_state_failed", applied)
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {
+		"ok": true,
+		"item": held,
+		"name": world.data.item_name(held),
+		"party_index": party_index,
+	}
+
+
+## `RegisterItem`. `wWhichRegisteredItem` packs the pocket and the item's number
+## within it so `CheckRegisteredItem` can find the entry again; with one stack
+## per item that number is the item, and the ownership it stood for is what
+## [method registered_item] tests.
+static func register(
+	world: Gen2WorldAPI, save: Gen2SaveData, item: int, persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return Gen2WorldTransaction.failure(&"missing_world", {})
+	var definition: Dictionary = world.data.item(item)
+	if definition.is_empty():
+		return Gen2WorldTransaction.failure(&"unknown_item", {"item": item})
+	if not Gen2WorldPack.can_select(world.data, item):
+		return Gen2WorldTransaction.failure(&"item_cannot_be_registered", {"item": item})
+	if world.state.item_quantity(item) <= 0:
+		return Gen2WorldTransaction.failure(&"insufficient_item_quantity", {"item": item})
+	var before: Gen2WorldSnapshot = world.snapshot()
+	world.state.set_registered_item(item)
+	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {"ok": true, "item": item, "name": String(definition.get("name", "UNKNOWN"))}
+
+
+## `CheckRegisteredItem`, which is what SELECT asks first: a registration is only
+## good while the pack still holds the item, and the check clears it where it
+## does not. The clear is written straight onto the live state, the way the
+## source writes `wRegisteredItem` outside any save.
+static func registered_item(world: Gen2WorldAPI) -> int:
+	if world == null or world.data == null or world.state == null:
+		return 0
+	var item: int = world.state.registered_item()
+	if item <= 0:
+		return 0
+	if world.state.item_quantity(item) > 0 and Gen2WorldPack.can_select(world.data, item):
+		return item
+	world.state.set_registered_item(0)
+	return 0
+
+
+static func _party_member(save: Gen2SaveData, party_index: int) -> Gen2SaveMon:
+	if save == null or party_index < 0 or party_index >= save.party.size():
+		return null
+	return save.party[party_index] as Gen2SaveMon

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -97,11 +97,6 @@ const ACTION_LABELS: Dictionary = {
 	ACTION_QUIT: "QUIT",
 }
 
-## GIVE needs a held-item model and SEL the Select-button registration; neither
-## exists yet, so both keep their source position and are marked unavailable, the
-## way the party submenu carries STATS, SWITCH and MOVE.
-const IMPLEMENTED_ACTIONS: Array[StringName] = [ACTION_USE, ACTION_TOSS, ACTION_QUIT]
-
 
 ## One entry per pocket in source display order, each carrying only the items
 ## currently owned in that pocket. An unknown item number, or a quantity of
@@ -178,9 +173,8 @@ static func item_submenu(data: GameData, item: int) -> Array:
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
 		return []
-	var permissions: int = int(definition.get("permissions", 0))
 	var tossable: bool = can_toss(data, item)
-	var can_select: bool = (permissions & CANT_SELECT) == 0
+	var selectable: bool = can_select(data, item)
 	# CheckItemMenu tests the nibble against zero, not against ITEMMENU_CURRENT,
 	# so a value of 1 to 3 would offer USE and then reach .Oak's refusal. No
 	# cartridge item carries one; all 256 rows are NOUSE, CURRENT, PARTY or CLOSE.
@@ -189,18 +183,14 @@ static func item_submenu(data: GameData, item: int) -> Array:
 	if int(definition.get("pocket", 0)) == TYPE_TM_HM:
 		actions = SUBMENU_USE_QUIT if not tossable else SUBMENU_TMHM_USE_GIVE_QUIT
 	elif not tossable:
-		actions = SUBMENU_USE_QUIT if not can_select else SUBMENU_USE_SELECT_QUIT
-	elif not can_select:
+		actions = SUBMENU_USE_QUIT if not selectable else SUBMENU_USE_SELECT_QUIT
+	elif not selectable:
 		actions = SUBMENU_USE_GIVE_TOSS_QUIT if can_use else SUBMENU_GIVE_TOSS_QUIT
 	else:
 		actions = SUBMENU_USE_GIVE_TOSS_SELECT_QUIT if can_use else SUBMENU_GIVE_TOSS_SELECT_QUIT
 	var entries: Array = []
 	for action: StringName in actions:
-		entries.append({
-			"action": action,
-			"label": String(ACTION_LABELS.get(action, "")),
-			"available": IMPLEMENTED_ACTIONS.has(action),
-		})
+		entries.append({"action": action, "label": String(ACTION_LABELS.get(action, ""))})
 	return entries
 
 
@@ -214,6 +204,26 @@ static func can_toss(data: GameData, item: int) -> bool:
 	if definition.is_empty():
 		return false
 	return (int(definition.get("permissions", 0)) & CANT_TOSS) == 0
+
+
+## `CheckSelectableItem`, which `RegisterItem` asks before it writes
+## `wRegisteredItem`. The bit is set on an item that *cannot* be registered.
+static func can_select(data: GameData, item: int) -> bool:
+	if data == null:
+		return false
+	var definition: Dictionary = data.item(item)
+	if definition.is_empty():
+		return false
+	return (int(definition.get("permissions", 0)) & CANT_SELECT) == 0
+
+
+## Whether a Pokemon may be handed this item. `.GiveItem`'s loop refuses the key
+## item pocket and then whatever `CheckTossableItem` refuses, which is the same
+## pair of tests that decides GIVE is in the submenu at all.
+static func can_hold(data: GameData, item: int) -> bool:
+	if not can_toss(data, item):
+		return false
+	return pocket_for(data, item) != TYPE_KEY_ITEM
 
 
 ## `UseItem`'s jumptable index: which of `.Oak`, `.Current`, `.Party` and
@@ -271,3 +281,62 @@ static func receive_check(
 		if entries >= capacity:
 			return {"ok": false, "reason": &"pocket_full", "pocket": pocket}
 	return {"ok": true, "quantity": current + quantity}
+
+
+## `GiveTakePartyMonItem`'s own wording (`data/text/common_2.asm`), shared by the
+## pack's GIVE, the party submenu's ITEM and SELECT's registration, none of which
+## can see the others' copy. Each source text is one box; the line breaks are
+## where its box ended, so they are not reproduced here.
+static func hold_text(mon_name: String, item_name: String) -> String:
+	return "Made %s hold %s." % [mon_name, item_name]
+
+
+## `PokemonAskSwapItemText`, the yes/no in front of the swap.
+static func ask_swap_text(mon_name: String, held_name: String) -> String:
+	return "%s is already holding %s. Switch items?" % [mon_name, held_name]
+
+
+static func swap_text(mon_name: String, held_name: String, item_name: String) -> String:
+	return "Took %s's %s and made it hold %s." % [mon_name, held_name, item_name]
+
+
+static func took_text(mon_name: String, item_name: String) -> String:
+	return "Took %s from %s." % [item_name, mon_name]
+
+
+static func not_holding_text(mon_name: String) -> String:
+	return "%s isn't holding anything." % mon_name
+
+
+## `ItemStorageFullText`, which is what a refused `ReceiveItemFromPokemon` says
+## on either half of the swap.
+static func storage_full_text() -> String:
+	return "Item storage space full."
+
+
+static func egg_cant_hold_text() -> String:
+	return "An EGG can't hold an item."
+
+
+## `ItemCantHeldText`, `.GiveItem`'s answer for a key item or an untossable one.
+static func cant_hold_text() -> String:
+	return "This item can't be held."
+
+
+## `CantUseItemText`, which is what `UseRegisteredItem` answers with where the
+## pack's own USE would reach `.Oak`.
+static func cant_use_text() -> String:
+	return "Can't use that here."
+
+
+static func registered_text(item_name: String) -> String:
+	return "Registered the %s." % item_name
+
+
+static func cant_register_text() -> String:
+	return "You can't register that item."
+
+
+## `MayRegisterItemText`, `SelectMenu`'s answer when nothing is registered.
+static func may_register_text() -> String:
+	return "An item in your PACK may be registered for use on SELECT Button."

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -652,6 +652,9 @@ func _handle_button(button: int) -> bool:
 		Gen2Button.START:
 			_open_start_menu()
 			return true
+		Gen2Button.SELECT:
+			open_select_menu()
+			return true
 	if Gen2Button.is_direction(button):
 		move_player(Gen2Button.vector(button))
 		return true
@@ -1767,6 +1770,13 @@ func _play_hall_of_fame_music() -> void:
 ## _open_service_host()'s shape. The START branch in _handle_button() is the
 ## normal path.
 func _open_start_menu() -> void:
+	_open_start_menu_host(Callable())
+
+
+## `SelectMenu` and `GiveTakePartyMonItem`'s GIVE both open the pack this screen
+## already hosts, so they share its opener and hand it their own entry point.
+## [param entry] is called with the host once it is on screen.
+func _open_start_menu_host(entry: Callable) -> void:
 	if _world == null or _data == null or _overlay_open() or _field_move_text \
 		or not _oak_pc_pages.is_empty() \
 		or not _trainer_approach.is_empty() or _world.script_busy() \
@@ -1797,7 +1807,17 @@ func _open_start_menu() -> void:
 	host.closed.connect(_on_start_menu_closed)
 	_start_menu_host = host
 	_script_prompt = "Start menu open"
+	if entry.is_valid():
+		entry.call(host)
 	_refresh_labels()
+
+
+## `SelectMenu`, which is the whole of what the SELECT button does in the
+## overworld: the registered item, or the text saying one may be registered.
+func open_select_menu() -> void:
+	_open_start_menu_host(func(host: Gen2StartMenuScreen) -> void:
+		host.open_registered_item()
+	)
 
 
 func _on_start_menu_action(kind: StringName) -> void:
@@ -2042,7 +2062,13 @@ func _on_party_action(action: Dictionary) -> void:
 	# `PokemonActionSubmenu`'s `.quit` reaches `ExitAllMenus`, so a field move
 	# leaves the overworld rather than reopening the menu behind it.
 	_reopen_start_menu = false
-	if _world == null or StringName(action.get("kind", &"")) != &"field_move":
+	if _world == null:
+		_refresh_labels()
+		return
+	if StringName(action.get("kind", &"")) == &"mon_item":
+		_run_mon_item_action(action)
+		return
+	if StringName(action.get("kind", &"")) != &"field_move":
 		_refresh_labels()
 		return
 	match int(action.get("move", 0)):
@@ -2191,6 +2217,37 @@ func _strength_refusal(reason: StringName) -> String:
 	if reason == &"badge_required":
 		return "Sorry! A new BADGE is required."
 	return "Can't use that here."
+
+
+## `GiveTakePartyMonItem`'s two answers. TAKE is a bag transaction and says so in
+## the map's own text box; GIVE needs an item, which is `.GiveItem`'s pack over
+## the Pokemon already chosen.
+func _run_mon_item_action(action: Dictionary) -> void:
+	var slot: int = int(action.get("slot", -1))
+	if StringName(action.get("option", &"")) == Gen2PartyScreen.OPTION_GIVE:
+		_open_start_menu_host(func(host: Gen2StartMenuScreen) -> void:
+			host.open_give(slot)
+		)
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	var result: Dictionary = Gen2WorldBagHost.take_from_party(
+		_world, save, slot, _injected_save == null
+	)
+	var name: String = String(action.get("name", ""))
+	if bool(result.get("ok", false)):
+		_show_field_move_text(Gen2WorldPack.took_text(name, String(result.get("name", ""))))
+		return
+	match StringName(result.get("reason", &"")):
+		&"not_holding":
+			_show_field_move_text(Gen2WorldPack.not_holding_text(name))
+		&"bag_full":
+			_show_field_move_text(Gen2WorldPack.storage_full_text())
+		_:
+			_show_field_move_text(
+				"%s could not hand that over (%s)." % [
+					name, String(result.get("reason", "")),
+				]
+			)
 
 
 func _show_field_move_text(text: String) -> void:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -151,6 +151,11 @@ var _kurt_apricorn_quantity: int = 0
 ## and cleared for every tree at once by `ResetFruitTrees`. Kept as the set of
 ## picked tree ids because the source's own question is per tree.
 var _picked_fruit_trees: Dictionary = {}
+## `wRegisteredItem`. `wWhichRegisteredItem`'s pocket and slot number have no
+## counterpart in the flat item model: `CheckRegisteredItem` uses them to find
+## the entry again in its packed pocket array and clears both when the item is
+## not there, which here is the quantity the item number already answers.
+var _registered_item: int = 0
 
 
 func _init(
@@ -249,6 +254,7 @@ func to_dict() -> Dictionary:
 		"maptile_decorations": _maptile_decorations.duplicate(),
 		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
 		"picked_fruit_trees": _picked_fruit_trees.duplicate(),
+		"registered_item": _registered_item,
 	}
 
 
@@ -300,6 +306,7 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 		for raw_tree: Variant in picked as Dictionary:
 			if int(raw_tree) > 0 and bool((picked as Dictionary)[raw_tree]):
 				restored._picked_fruit_trees[int(raw_tree)] = true
+	restored.set_registered_item(int(source.get("registered_item", 0)))
 	return restored
 
 
@@ -336,6 +343,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_maptile_decorations = restored._maptile_decorations.duplicate()
 	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
 	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
+	_registered_item = restored._registered_item
 	changed.emit()
 
 
@@ -740,6 +748,21 @@ func set_repel_steps(steps: int) -> void:
 	if next_steps == _repel_steps:
 		return
 	_repel_steps = next_steps
+	changed.emit()
+
+
+## The item SELECT uses, or zero for none. `RegisterItem` writes the number and
+## `CheckRegisteredItem` clears it again the moment the pack no longer holds it,
+## which is why the ownership test lives with the reader rather than here.
+func registered_item() -> int:
+	return _registered_item
+
+
+func set_registered_item(item: int) -> void:
+	var next_item: int = item if item > 0 else 0
+	if next_item == _registered_item:
+		return
+	_registered_item = next_item
 	changed.emit()
 
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -5,6 +5,9 @@ extends GutTest
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
+## `ITEM_REPEL`, whose effect `UseItem` keys on the item number for.
+const REPEL: int = 0x14
+
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
 
@@ -29,16 +32,24 @@ func after_each() -> void:
 
 
 ## Item 7 carries POTION's real ItemAttributes row, so the pack builds the
-## source's own USE/GIVE/TOSS/QUIT submenu for it and USE reaches .Party.
+## source's own USE/GIVE/TOSS/QUIT submenu for it and USE reaches .Party. Item
+## $14 is REPEL's, which is the number `UseItem`'s own effect keys on: it carries
+## no permission bit at all, so it is the row that reaches SEL.
 func _write_pack_item() -> void:
 	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
 	for raw: Dictionary in items:
-		if int(raw.get("number", 0)) == 7:
-			raw["name"] = "POTION"
-			raw["pocket"] = Gen2WorldPack.TYPE_ITEM
-			raw["permissions"] = Gen2WorldPack.CANT_SELECT
-			raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
-			raw["heal_amount"] = 20
+		match int(raw.get("number", 0)):
+			7:
+				raw["name"] = "POTION"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
+				raw["heal_amount"] = 20
+			REPEL:
+				raw["name"] = "REPEL"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = 0
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 
 
@@ -984,3 +995,128 @@ func test_a_dex_search_reaches_its_results_and_back() -> void:
 	dex.handle_button(Gen2Button.B)
 	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH)
 	assert_eq(model.search_type_1, 1, "the search screen re-initialises its rows")
+
+
+## `GiveItem`: the party list, then `TryGiveItemToPartymon`'s
+## `.give_item_to_mon`. The item leaves the bag on the same press.
+func test_give_hands_the_item_to_the_chosen_party_member() -> void:
+	await _open_world()
+	var host: Gen2StartMenuScreen = await _open_pack()
+	_choose_action(host, Gen2WorldPack.ACTION_GIVE)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+	assert_eq(host.get("_title").text, "GIVE TO")
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	var save: Gen2SaveData = _world_screen._injected_save
+	assert_eq((save.party[0] as Gen2SaveMon).item, 7)
+	assert_eq(_world_screen._world.state.item_quantity(7), 0)
+	assert_eq(
+		String(host.get("_pack_result")),
+		Gen2WorldPack.hold_text(_first_member_name(save), "POTION")
+	)
+
+
+## `PokemonAskSwapItemText` and its yes/no. `.abort` is the no, and it leaves
+## both items where they were.
+func test_a_full_hand_asks_before_the_swap_and_no_takes_nothing() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {7: 1, REPEL: 1}})
+	var save: Gen2SaveData = _world_screen._injected_save
+	(save.party[0] as Gen2SaveMon).item = REPEL
+	var host: Gen2StartMenuScreen = await _open_pack()
+	_choose_action(host, Gen2WorldPack.ACTION_GIVE)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_GIVE_SWAP)
+	assert_eq(
+		host.get("_summary").text,
+		Gen2WorldPack.ask_swap_text(_first_member_name(save), "REPEL")
+	)
+
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
+	assert_eq((save.party[0] as Gen2SaveMon).item, REPEL)
+	assert_eq(_world_screen._world.state.item_quantity(7), 1)
+
+	_choose_action(host, Gen2WorldPack.ACTION_GIVE)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	assert_eq((save.party[0] as Gen2SaveMon).item, 7)
+	assert_eq(_world_screen._world.state.item_quantity(REPEL), 2, "the old one came back")
+
+
+## The party submenu's ITEM: `GiveTakeItemMenuData`'s two rows, TAKE running
+## `TakePartyItem` against the live world and saying so in the map's own box.
+func test_the_party_submenu_takes_a_held_item_back() -> void:
+	await _open_world()
+	var save: Gen2SaveData = _world_screen._injected_save
+	(save.party[0] as Gen2SaveMon).item = 7
+	_world_screen._open_embedded_party()
+	await get_tree().process_frame
+	var party: Gen2PartyScreen = _world_screen._party_host
+	party.handle_button(Gen2Button.A)
+	var items: Array = (party.submenu_snapshot()["items"] as Array)
+	for index: int in items.size():
+		if StringName((items[index] as Dictionary).get("option", &"")) \
+			== Gen2PartyScreen.OPTION_ITEM:
+			party.set("_submenu_cursor", index)
+			break
+	party.handle_button(Gen2Button.A)
+	assert_true(bool(party.submenu_snapshot()["item_menu"]))
+
+	party.handle_button(Gen2Button.DOWN)
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_null(_world_screen._party_host)
+	assert_eq((save.party[0] as Gen2SaveMon).item, 0)
+	assert_eq(_world_screen._world.state.item_quantity(7), 2)
+
+
+## `SelectMenu`: `CheckRegisteredItem` answers first, and `MayRegisterItemText`
+## is the whole of what an unregistered SELECT does.
+func test_select_says_an_item_may_be_registered_when_none_is() -> void:
+	await _open_world()
+	_world_screen.open_select_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(String(host.get("_pack_result")), Gen2WorldPack.may_register_text())
+
+
+## `RegisterItem` and `UseRegisteredItem`'s `.Current`, which is the whole
+## journey a registered REPEL makes from the pack to the SELECT button.
+func test_a_registered_item_is_used_by_the_select_button() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {REPEL: 1}})
+	var host: Gen2StartMenuScreen = await _open_pack()
+	host.set("_pack_cursor", 1)
+	_choose_action(host, Gen2WorldPack.ACTION_SELECT)
+	assert_eq(String(host.get("_pack_result")), Gen2WorldPack.registered_text("REPEL"))
+	assert_eq(_world_screen._world.state.registered_item(), REPEL)
+
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.B)
+	host.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+	assert_null(_world_screen._start_menu_host)
+
+	assert_true(_world_screen.press_button(Gen2Button.SELECT))
+	await get_tree().process_frame
+	var select_host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_eq(select_host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(_world_screen._world.state.repel_steps(), 100)
+	assert_eq(_world_screen._world.state.item_quantity(REPEL), 0)
+	assert_eq(
+		_world_screen._world.state.registered_item(), REPEL,
+		"the registration is only cleared where the check looks"
+	)
+
+
+## What the party list shows for the first member: `GetCurNickname`, which falls
+## back to the species name the fixture gave it.
+func _first_member_name(save: Gen2SaveData) -> String:
+	var mon: Gen2SaveMon = save.party[0]
+	if not mon.nickname.is_empty():
+		return mon.nickname
+	return String(_data.species(mon.species).get("name", ""))

--- a/tests/unit/test_world_bag_host.gd
+++ b/tests/unit/test_world_bag_host.gd
@@ -207,3 +207,76 @@ func test_an_empty_party_cannot_open_the_pokemon_centers_pc() -> void:
 	assert_true(Gen2WorldPC.can_open(_save))
 	_save.party.clear()
 	assert_false(Gen2WorldPC.can_open(_save))
+
+
+## `TryGiveItemToPartymon`'s `.give_item_to_mon`: one out of the bag, one into
+## the hand.
+func test_giving_an_item_takes_it_out_of_the_bag() -> void:
+	var result: Dictionary = Gen2WorldBagHost.give_to_party(_world, _save, POTION, 0, false, false)
+	assert_true(bool(result["ok"]), str(result))
+	assert_eq(result["held"], 0)
+	assert_eq(_world.state.item_quantity(POTION), 4)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, POTION)
+
+
+## The refusal `PokemonAskSwapItemText` is asked over: the source stops to ask
+## before it writes anything, so an unanswered swap leaves both items alone.
+func test_a_full_hand_is_refused_until_the_swap_is_answered() -> void:
+	(_save.party[0] as Gen2SaveMon).item = KEY_ITEM
+	var asked: Dictionary = Gen2WorldBagHost.give_to_party(_world, _save, POTION, 0, false, false)
+	assert_false(bool(asked["ok"]))
+	assert_eq(asked["reason"], &"already_holding")
+	assert_eq(int((asked["details"] as Dictionary)["held"]), KEY_ITEM)
+	assert_eq(_world.state.item_quantity(POTION), 5)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, KEY_ITEM)
+
+	var swapped: Dictionary = Gen2WorldBagHost.give_to_party(_world, _save, POTION, 0, true, false)
+	assert_true(bool(swapped["ok"]), str(swapped))
+	assert_eq(swapped["held"], KEY_ITEM)
+	assert_eq(_world.state.item_quantity(POTION), 4)
+	assert_eq(_world.state.item_quantity(KEY_ITEM), 2)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, POTION)
+
+
+## `.GiveItem` refuses the key item pocket before `TryGiveItemToPartymon` ever
+## runs, and an egg is refused by `GiveItem`'s own `cp EGG`.
+func test_a_key_item_and_an_egg_are_both_refused() -> void:
+	var key: Dictionary = Gen2WorldBagHost.give_to_party(_world, _save, KEY_ITEM, 0, false, false)
+	assert_false(bool(key["ok"]))
+	assert_eq(key["reason"], &"item_cannot_be_held")
+
+	(_save.party[0] as Gen2SaveMon).is_egg = true
+	var egg: Dictionary = Gen2WorldBagHost.give_to_party(_world, _save, POTION, 0, false, false)
+	assert_false(bool(egg["ok"]))
+	assert_eq(egg["reason"], &"cannot_hold_egg")
+	assert_eq(_world.state.item_quantity(POTION), 5)
+
+
+## `TakePartyItem`, and `PokemonNotHoldingText` for an empty hand.
+func test_taking_an_item_puts_it_back_in_the_bag() -> void:
+	assert_eq(
+		StringName(Gen2WorldBagHost.take_from_party(_world, _save, 0, false)["reason"]),
+		&"not_holding"
+	)
+	(_save.party[0] as Gen2SaveMon).item = POTION
+	var result: Dictionary = Gen2WorldBagHost.take_from_party(_world, _save, 0, false)
+	assert_true(bool(result["ok"]), str(result))
+	assert_eq(result["name"], "POTION")
+	assert_eq(_world.state.item_quantity(POTION), 6)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, 0)
+
+
+## `RegisterItem` checks `CheckSelectableItem`, and `CheckRegisteredItem` clears
+## a registration the pack can no longer answer.
+func test_a_registration_lasts_while_the_item_is_owned() -> void:
+	var refused: Dictionary = Gen2WorldBagHost.register(_world, _save, POTION, false)
+	assert_false(bool(refused["ok"]))
+	assert_eq(refused["reason"], &"item_cannot_be_registered")
+
+	assert_true(bool(Gen2WorldBagHost.register(_world, _save, KEY_ITEM, false)["ok"]))
+	assert_eq(_world.state.registered_item(), KEY_ITEM)
+	assert_eq(Gen2WorldBagHost.registered_item(_world), KEY_ITEM)
+
+	_world.state.apply_changes({}, {}, {"items": {KEY_ITEM: 0}})
+	assert_eq(Gen2WorldBagHost.registered_item(_world), 0)
+	assert_eq(_world.state.registered_item(), 0, "the check clears it where it looks")

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -190,19 +190,23 @@ func test_the_tm_pocket_has_its_own_submenu() -> void:
 	])
 
 
-## GIVE and SEL keep their source position and are marked unavailable, the way
-## the party submenu carries STATS, SWITCH and MOVE. TOSS is built.
-func test_only_give_and_sel_are_unavailable() -> void:
-	for entry: Dictionary in Gen2WorldPack.item_submenu(_data, ITEM_POTION):
-		var action: StringName = StringName(entry.get("action", &""))
-		assert_eq(
-			bool(entry.get("available", false)),
-			action in [
-				Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_TOSS,
-				Gen2WorldPack.ACTION_QUIT,
-			],
-			"action %s" % action
-		)
+## `.GiveItem`'s loop refuses the key item pocket and whatever `CheckTossableItem`
+## refuses, which is the pair that also decides GIVE is in a submenu at all.
+func test_a_key_item_cannot_be_held() -> void:
+	assert_true(Gen2WorldPack.can_hold(_data, ITEM_POTION))
+	assert_true(Gen2WorldPack.can_hold(_data, ITEM_TM01))
+	assert_false(Gen2WorldPack.can_hold(_data, ITEM_BICYCLE))
+	assert_false(Gen2WorldPack.can_hold(_data, 250))
+	assert_false(Gen2WorldPack.can_hold(null, ITEM_POTION))
+
+
+## `CheckSelectableItem`: the permission bit is set on an item that cannot be
+## registered, which is every fixture row but the unclassified one.
+func test_only_a_selectable_item_can_be_registered() -> void:
+	assert_false(Gen2WorldPack.can_select(_data, ITEM_POTION))
+	assert_true(Gen2WorldPack.can_select(_data, ITEM_UNCLASSIFIED))
+	assert_false(Gen2WorldPack.can_select(_data, 250))
+	assert_false(Gen2WorldPack.can_select(null, ITEM_UNCLASSIFIED))
 
 
 func test_an_unknown_item_has_no_submenu() -> void:

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -1,0 +1,117 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the pack submenu's three permission tests against freshly imported
+## real caches, over every item row rather than a sampled one.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `engine/items/pack.asm`'s `.ItemBallsKey_LoadSubmenu`, which asks
+## `_CheckTossableItem`, `CheckSelectableItem` and `CheckItemMenu` in that order,
+## `RegisterItem`, and `engine/pokemon/mon_menu.asm`'s `.GiveItem`, whose loop
+## refuses the key item pocket and then whatever `CheckTossableItem` refuses.
+## `data/items/attributes.asm` is byte identical between the pins, so nothing
+## here is profile split.
+##
+## The point of sweeping all 256 rows is that a permission bit read the wrong way
+## round is invisible on the one item a screen test picks: the bit is set on the
+## item that *cannot* do the thing, so an inverted read offers TOSS on every key
+## item and SEL on none.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- pack
+
+## `constants/item_constants.asm`'s own hex comment column. The five key items
+## whose `item_attribute` is `CANT_TOSS` alone, which is the whole of what a
+## player can hand the SELECT button on all three cartridges: every other key
+## item is `CANT_SELECT | CANT_TOSS`, the CARD KEY and the SQUIRTBOTTLE included.
+const REGISTERABLE_KEY_ITEMS: Dictionary = {
+	0x07: "BICYCLE",
+	0x37: "ITEMFINDER",
+	0x3A: "OLD ROD",
+	0x3B: "GOOD ROD",
+	0x3D: "SUPER ROD",
+}
+
+## `ItemAttributes` is 256 rows on both pins, the last of which is the terminator
+## the item list never reaches.
+const ITEM_ROWS: int = 255
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_registerable(game_id, data)
+		_verify_submenus(game_id, data)
+
+
+## `CheckSelectableItem` over the real rows. The eight named key items are the
+## whole of what a player can register; the unused `NO_LIMITS` rows carry no bit
+## either, which is faithful and is what the census counts separately.
+func _verify_registerable(game_id: StringName, data: GameData) -> void:
+	var key_items: Array[int] = []
+	var total: int = 0
+	for number: int in range(1, ITEM_ROWS + 1):
+		if data.item(number).is_empty() or not Gen2WorldPack.can_select(data, number):
+			continue
+		total += 1
+		if Gen2WorldPack.pocket_for(data, number) == Gen2WorldPack.TYPE_KEY_ITEM:
+			key_items.append(number)
+	for number: int in REGISTERABLE_KEY_ITEMS:
+		_r.check(
+			key_items.has(number),
+			"%s: $%02X (%s) cannot be registered." % [
+				game_id, number, String(REGISTERABLE_KEY_ITEMS[number]),
+			]
+		)
+	_r.check(
+		key_items.size() == REGISTERABLE_KEY_ITEMS.size(),
+		"%s: %d key items are registerable, not the pinned %d." % [
+			game_id, key_items.size(), REGISTERABLE_KEY_ITEMS.size(),
+		]
+	)
+	print("%s: %d rows are registerable, %d of them key items." % [
+		game_id, total, key_items.size(),
+	])
+
+
+## The submenu each row builds, against the permissions it was built from. GIVE
+## and SEL are the two the screens act on, so each is checked both ways: an
+## action offered that the transaction would refuse is the bug worth catching.
+func _verify_submenus(game_id: StringName, data: GameData) -> void:
+	var holdable: int = 0
+	for number: int in range(1, ITEM_ROWS + 1):
+		if data.item(number).is_empty():
+			continue
+		var actions: Array[StringName] = []
+		for entry: Dictionary in Gen2WorldPack.item_submenu(data, number):
+			actions.append(StringName(entry.get("action", &"")))
+		var name: String = data.item_name(number)
+		_r.check(
+			actions.has(Gen2WorldPack.ACTION_QUIT),
+			"%s: $%02X (%s) has a submenu with no QUIT." % [game_id, number, name]
+		)
+		if Gen2WorldPack.can_hold(data, number):
+			holdable += 1
+		else:
+			_r.check(
+				not actions.has(Gen2WorldPack.ACTION_GIVE),
+				"%s: $%02X (%s) offers GIVE but cannot be held." % [game_id, number, name]
+			)
+		_r.check(
+			not actions.has(Gen2WorldPack.ACTION_SELECT)
+				or Gen2WorldPack.can_select(data, number),
+			"%s: $%02X (%s) offers SEL but cannot be registered." % [game_id, number, name]
+		)
+		## `.ItemBallsKey_LoadSubmenu` reaches a header with SEL only from the
+		## tossable branch or the untossable one, never from the TM/HM pocket's
+		## own two.
+		_r.check(
+			not actions.has(Gen2WorldPack.ACTION_SELECT)
+				or Gen2WorldPack.pocket_for(data, number) != Gen2WorldPack.TYPE_TM_HM,
+			"%s: $%02X (%s) is a TM or HM offering SEL." % [game_id, number, name]
+		)
+	print("%s: %d rows can be held by a Pokemon." % [game_id, holdable])

--- a/tools/checks/pack.gd.uid
+++ b/tools/checks/pack.gd.uid
@@ -1,0 +1,1 @@
+uid://c6kxalvnsret5

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -1,16 +1,18 @@
 extends SceneTree
 
-## Captures the party and PC-box overlays against a real cache.
+## Captures the window-resolution save overlays against a real cache: the party,
+## the PC boxes and the start menu's pack.
 ##
-##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> [party|box] [presses]
+##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> [party|box|pack|select] [presses]
 ##
 ## `presses` is a comma-separated button list driven into the overlay before the
 ## shot, the way `preview_world_services.gd` photographs a second page: `d` is
 ## down, `u` up, `l` left, `r` right, `a` and `b` the two buttons. Several
 ## comma-separated lists write one file each.
 ##
-## Both screens are built directly rather than through the overworld, which is
-## what makes this a screen test rather than a world one. They reach the runtime
+## Each is built directly rather than through the overworld, which is what makes
+## this a screen test rather than a world one; the pack is given a world of its
+## own because its transactions read one. They reach the runtime
 ## through `Gen2GameRuntime`, so they compile under `-s` where naming the
 ## autoload by identifier would not.
 ##
@@ -18,6 +20,12 @@ extends SceneTree
 ## other than the project's own.
 
 const FRAMES_BEFORE_CAPTURE: int = 6
+
+## Item numbers from `constants/item_constants.asm`, the three rows the pack's
+## own submenu split is worth photographing.
+const ITEM_POTION: int = 0x12
+const ITEM_BICYCLE: int = 0x07
+const ITEM_REPEL: int = 0x14
 
 const BUTTONS: Dictionary = {
 	"u": Gen2Button.UP, "d": Gen2Button.DOWN, "l": Gen2Button.LEFT,
@@ -35,7 +43,7 @@ var _elapsed: int = 0
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 2:
-		push_error("Usage: preview_party.gd -- <game> <out.png> [party|box] [presses]")
+		push_error("Usage: preview_party.gd -- <game> <out.png> [party|box|pack|select]")
 		quit(1)
 		return
 	var game: StringName = StringName(args[0])
@@ -81,9 +89,38 @@ func _build(data: GameData) -> Control:
 		var boxes := Gen2BoxScreen.new()
 		boxes.set_context(data, save, false, true)
 		return boxes
+	if _what == "pack" or _what == "select":
+		return _build_pack(data, save)
 	var party := Gen2PartyScreen.new()
 	party.set_context(data, save, true)
 	return party
+
+
+## The start menu over a world holding one of each pack row the submenu splits
+## on: a POTION (USE/GIVE/TOSS), a REPEL (which also reaches SEL) and the
+## BICYCLE, whose key-item row offers neither GIVE nor TOSS.
+func _build_pack(data: GameData, save: Gen2SaveData) -> Control:
+	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 3, ITEM_REPEL: 2, ITEM_BICYCLE: 1})
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, Gen2WorldSpawn.NEW_BARK_GROUP, Gen2WorldSpawn.PLAYERS_HOUSE_2F,
+		Gen2WorldSpawn.HOME_CELL, state
+	)
+	if world == null:
+		push_error("Could not open a world for %s." % data.id)
+		return null
+	save.world = world.snapshot()
+	var menu := Gen2StartMenuScreen.new()
+	## No slot on disk, so nothing this photographs is written anywhere.
+	menu.set_party_context(save, false)
+	if not menu.open(world, data, func() -> Dictionary: return {"ok": true}):
+		push_error("Could not open the start menu for %s." % data.id)
+		return null
+	## `SelectMenu` over a BICYCLE already registered, which is what the button
+	## reaches in the overworld and what no button driven into this screen can.
+	if _what == "select":
+		state.set_registered_item(ITEM_BICYCLE)
+		menu.open_registered_item()
+	return menu
 
 
 func _drive(program: String) -> void:

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -34,6 +34,7 @@ const GROUPS: Dictionary = {
 	&"art": [&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims"],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
+		&"pack",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
The pack's GIVE and SEL were the two submenu rows nothing answered, and the party submenu's ITEM was unavailable behind them.

**GIVE** runs `TryGiveItemToPartymon` from either direction: the pack names the item and its party list names who holds it, and `GiveTakePartyMonItem`'s own GIVE opens the pack over a Pokemon already chosen. A full hand stops at `PokemonAskSwapItemText` with nothing written; the swap puts the old item back into the entry `GiveItemToPokemon`'s removal just freed, and refuses with `ItemStorageFullText` when it does not fit. **TAKE** is `TakePartyItem`. Both commit through `Gen2WorldTransaction`, beside TOSS.

**SEL** is `RegisterItem` over `wRegisteredItem`, kept in the world state next to the bag it names; `CheckRegisteredItem` clears a registration the pack can no longer answer. SELECT in the overworld is `SelectMenu`: `MayRegisterItemText` when nothing is registered, otherwise `UseRegisteredItem`'s jumptable over the same USE the pack runs, whose refusal is `CantUseItemText` where the pack's own reaches `.Oak`.

Met on the way, fixed here: a cancelled `ChooseMonToLearnTMHM` left the teach flag set, so the next item's `.Party` list taught the TM instead of using the item. The mods page said "Restart to apply" while a cartridge change already reloaded the host, so a list change now reloads it the same way, and its note is no longer overwritten by the refresh under it.

## Proof

| Check | Result |
|---|---|
| GUT, both tiers | 2,828 tests over 148 scripts, green (2,817 before) |
| `validate.gd -- all` | 42 topics pass on Gold, Silver and Crystal, exit 0 |
| `tools/checks/pack.gd` (new) | 256 item rows per cartridge: 5 registerable key items on each, 230/230/226 holdable, no row offers GIVE it cannot be held for |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk, three profiles | 16 badges, 291/291/294 steps |

Real-cache screens are in `preview_party.gd`'s new `pack` and `select` targets: BICYCLE's submenu is USE/SEL/QUIT, registering it says "Registered the BICYCLE.", and SELECT then answers "Can't use that here." because no `ITEMMENU_CLOSE` item has a field effect yet.