### PR TITLE
Draw the overworld's own effect sprites from the cartridge's art

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -81,6 +81,7 @@ var _world_palettes: Array = []
 var _decoded_palettes: Dictionary = {}
 var _world_animation_assets: Dictionary = {}
 var _overworld_sprites: Array = []
+var _overworld_effects: Array = []
 var _overworld_sprite_palettes: Array = []
 var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
@@ -636,6 +637,26 @@ func overworld_sprite_indices(number: int) -> PackedByteArray:
 	)
 	_indices[key] = data
 	return data
+
+
+## One of the sprites the engine draws over an object rather than as one, by the
+## name `data/sprites/emotes.asm` gives it plus ShakeHeadbuttTree's own sheet:
+## { tiles, vtile, indices }, empty when the cache does not hold it.
+func overworld_effect(name: String) -> Dictionary:
+	for row: Variant in _overworld_effect_records():
+		if not row is Dictionary or String((row as Dictionary).get("name", "")) != name:
+			continue
+		var record: Dictionary = row as Dictionary
+		return {
+			"name": name,
+			"tiles": int(record.get("tiles", 0)),
+			"vtile": int(record.get("vtile", 0)),
+			"indices": _payload_bytes(
+				record if record.has(RomCache.PAYLOAD_KEY) else record.get("bytes", []),
+				_blob("overworld_effects"),
+			),
+		}
+	return {}
 
 
 ## The reusable icon strip indexed by constants/icon_constants.asm.
@@ -1654,6 +1675,8 @@ func _section_json_path(section: String) -> String:
 			return RomCache.world_audio_path(directory)
 		"battle_anims":
 			return RomCache.battle_anims_path(directory)
+		"overworld_effects":
+			return RomCache.overworld_effects_path(directory)
 	return ""
 
 
@@ -1736,6 +1759,12 @@ func _sprites() -> Array:
 	if _claim_section("sprites"):
 		_overworld_sprites = _read_section(RomCache.overworld_sprites_path(directory), true)
 	return _overworld_sprites
+
+
+func _overworld_effect_records() -> Array:
+	if _claim_section("overworld_effects"):
+		_overworld_effects = _read_section(RomCache.overworld_effects_path(directory), true)
+	return _overworld_effects
 
 
 func _sprite_palettes() -> Array:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -41,6 +41,7 @@ const WORLD_ENCOUNTERS: String = "world_encounters.json"
 const WORLD_PALETTES: String = "world_palettes.json"
 const WORLD_ANIMATION_ASSETS: String = "world_animation_assets.json"
 const WORLD_TILES_DIR: String = "world_tiles"
+const OVERWORLD_EFFECTS: String = "overworld_effects.json"
 const OVERWORLD_SPRITES: String = "overworld_sprites.json"
 const OVERWORLD_SPRITE_PALETTES: String = "overworld_sprite_palettes.json"
 const OVERWORLD_SPRITES_DIR: String = "overworld_sprites"
@@ -64,7 +65,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 51
+const FORMAT_VERSION: int = 52
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -178,6 +179,10 @@ static func world_palettes_path(directory: String) -> String:
 
 static func world_animation_assets_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_ANIMATION_ASSETS]
+
+
+static func overworld_effects_path(directory: String) -> String:
+	return "%s/%s" % [directory, OVERWORLD_EFFECTS]
 
 
 static func overworld_sprites_path(directory: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3317,6 +3317,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"world_rock_map_count": int(encounters["rock_maps"]),
 		"world_treemon_set_count": int(encounters["treemon_sets"]),
 		"overworld_sprite_count": int(world["overworld_sprites"]),
+		"overworld_effect_count": int(world["overworld_effects"]),
 		"world_menu_count": int(services["menus"]),
 		"world_mart_count": int(services["marts"]),
 		"world_phone_contact_count": int(services["phone_contacts"]),

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -128,6 +128,21 @@ const OVERWORLD_SPRITE_PALETTE_GROUP_BYTES: int = 8
 const OVERWORLD_SPRITE_PALETTE_BYTES: int = OVERWORLD_SPRITE_PALETTE_GROUP_COUNT * OVERWORLD_SPRITE_PALETTE_GROUP_BYTES
 const OVERWORLD_SPRITE_TYPES: Array = [1, 2, 3]
 const OVERWORLD_SPRITE_PALETTE_COUNT: int = 8
+## data/sprites/emotes.asm's `emote` macro: CPU address, byte length, ROM bank,
+## and the VRAM address the sheet is loaded to. Twelve entries, in
+## constants/script_constants.asm's EMOTE_* order, and the last four are the
+## engine's own overlays rather than showemote arguments: a jump shadow, the
+## fishing rod, Strength's boulder dust and the tall-grass rustle.
+const EMOTE_RECORD_SIZE: int = 6
+const EMOTE_COUNT: int = 12
+## The `vTiles0 tile n` an emote record's last field holds. A sprite tile counts
+## from here, so the tile number is the distance in tiles from it.
+const VTILES0: int = 0x8000
+const EMOTE_NAMES: Array[String] = [
+	"shock", "question", "happy", "sad", "heart", "bolt", "sleep", "fish",
+	"shadow", "rod", "boulder_dust", "grass_rustle",
+]
+
 ## IconPointers has one null entry followed by the 38 reusable overworld icon
 ## shapes in constants/icon_constants.asm. The null entry is not graphic data.
 const MON_ICON_COUNT: int = 38
@@ -1558,6 +1573,11 @@ const GOLD_SILVER: Dictionary = {
 	"overworld_sprite_count": 95,
 	"overworld_sprite_palettes": 0xB8AE,
 	"overworld_icons": 0x8EABE,
+	"emotes": 0x143C1,
+	## ShakeHeadbuttTree's eight-tile sheet. CutTreeGFX and CutGrassGFX follow it
+	## in the same bank; neither is imported because nothing draws Cut's own
+	## animation yet.
+	"headbutt_tree_gfx": 0x8CB0B,
 	"mart_table": 0x162FE,
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
@@ -1866,6 +1886,8 @@ const CRYSTAL: Dictionary = {
 	"overworld_sprite_count": 102,
 	"overworld_sprite_palettes": 0xB469,
 	"overworld_icons": 0x8EC0D,
+	"emotes": 0x1444D,
+	"headbutt_tree_gfx": 0x8C893,
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,
@@ -2189,6 +2211,10 @@ static func overworld_sprite_offset(layout: Dictionary, number: int) -> int:
 
 static func overworld_sprite_count(layout: Dictionary) -> int:
 	return int(layout.get("overworld_sprite_count", 0))
+
+
+static func emote_offset(layout: Dictionary, index: int) -> int:
+	return int(layout.get("emotes", -1)) + index * EMOTE_RECORD_SIZE
 
 
 static func overworld_icon_offset(layout: Dictionary, number: int) -> int:

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -51,6 +51,12 @@ static func import_to_cache(
 		RomCache.overworld_sprite_palettes_path(directory), result["sprite_palettes"]
 	):
 		return {"ok": false, "message": "Could not write overworld sprite palettes."}
+	if not RomCache.write_section(
+		RomCache.overworld_effects_path(directory),
+		RomCache.blob_path(RomCache.overworld_effects_path(directory)),
+		result["effects"],
+	):
+		return {"ok": false, "message": "Could not write overworld effect sprites."}
 	if not RomCache.write_json(RomCache.world_tilesets_path(directory), tilesets):
 		return {"ok": false, "message": "Could not write overworld tileset data."}
 	if not RomCache.write_json(RomCache.world_palettes_path(directory), result["palettes"]):
@@ -114,6 +120,7 @@ static func import_to_cache(
 		"tilesets": tilesets.size(),
 		"overworld_sprites": result["sprites"].size(),
 		"overworld_icons": icon_graphics.size(),
+		"overworld_effects": (result["effects"] as Array).size(),
 		# The service importer scans and extends these. Handing back what was
 		# just decoded keeps them raw byte runs; reading them off disk again
 		# would hand it the spans the cache stores instead.
@@ -136,6 +143,9 @@ static func read_world(
 	var icons: Dictionary = _read_overworld_icons(rom, layout)
 	if not bool(icons.get("ok", false)):
 		return icons
+	var effects: Dictionary = _read_overworld_effects(rom, layout)
+	if not bool(effects.get("ok", false)):
+		return effects
 
 	var palettes: Dictionary = _read_world_palettes(rom, layout)
 	if not bool(palettes.get("ok", false)):
@@ -210,6 +220,7 @@ static func read_world(
 		"sprite_palettes": sprites["palettes"],
 		"sprite_graphics": sprites["graphics"],
 		"icon_graphics": icons["graphics"],
+		"effects": effects["effects"],
 	}
 
 
@@ -454,6 +465,81 @@ static func _read_overworld_icons(rom: RomFile, layout: Dictionary) -> Dictionar
 			return _error("Overworld mon icon %d did not decode." % number)
 		graphics[number] = pixels
 	return {"ok": true, "graphics": graphics}
+
+
+## The sprites the engine draws over an object rather than as one: the eight
+## showemote bubbles, the jump shadow, the fishing rod, Strength's boulder dust
+## and the tall-grass rustle, plus ShakeHeadbuttTree's own sheet.
+##
+## The emote table pins its own entries: LoadEmote copies each sheet to the VRAM
+## address the record carries, and the twelve tile numbers are the layout
+## FacingEmote ($f8, four tiles), FacingShadow and the fishing rod ($fc) and
+## FacingBoulderDust1/FacingGrass1 ($fe) index. A record naming any other tile
+## is a wrong table rather than a cartridge difference: all three ship this one
+## byte identical.
+const EMOTE_TILE_LAYOUT: Array = [
+	[4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8],
+	[1, 0xFC], [2, 0xFC], [2, 0xFE], [1, 0xFE],
+]
+
+## HeadbuttTreeGFX's first tile row. The sheet has no table to pin it, and a
+## wrong offset in this bank decodes the routine beside it as art.
+const HEADBUTT_TREE_TILES: int = 8
+const HEADBUTT_TREE_SIGNATURE: Array = [0x01, 0x01, 0x02, 0x02, 0x02, 0x02, 0x07, 0x04]
+
+static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var table: int = int(layout.get("emotes", -1))
+	if not rom.in_bounds(table, RomLayout.EMOTE_COUNT * RomLayout.EMOTE_RECORD_SIZE):
+		return _error("Emote table is outside the cartridge.")
+
+	var effects: Array = []
+	for index: int in RomLayout.EMOTE_COUNT:
+		var at: int = RomLayout.emote_offset(layout, index)
+		var address: int = rom.u16le(at)
+		var byte_size: int = rom.u8(at + 2)
+		var bank: int = rom.u8(at + 3)
+		var destination: int = rom.u16le(at + 4)
+		var tiles: int = int(float(byte_size) / float(Gen2Tiles.TILE_BYTES))
+		var vtile: int = int(float(destination - RomLayout.VTILES0) / float(Gen2Tiles.TILE_BYTES))
+		var expected: Array = EMOTE_TILE_LAYOUT[index]
+		if not _valid_cpu_address(address):
+			return _error("Emote %d has an invalid CPU address." % index)
+		if byte_size % Gen2Tiles.TILE_BYTES != 0 or tiles != int(expected[0]):
+			return _error("Emote %d is %d bytes, not %d tiles." % [index, byte_size, expected[0]])
+		if vtile != int(expected[1]):
+			return _error("Emote %d loads to tile $%02X, not $%02X." % [index, vtile, expected[1]])
+		var pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+			rom.slice(RomFile.linear(bank, address), byte_size), 0, tiles
+		)
+		if pixels.size() != tiles * Gen2Tiles.TILE_PIXELS:
+			return _error("Emote %d graphics did not decode." % index)
+		effects.append({
+			"name": RomLayout.EMOTE_NAMES[index],
+			"tiles": tiles,
+			"vtile": vtile,
+			"bytes": Array(pixels),
+		})
+
+	var headbutt: int = int(layout.get("headbutt_tree_gfx", -1))
+	var headbutt_bytes: int = HEADBUTT_TREE_TILES * Gen2Tiles.TILE_BYTES
+	if not rom.in_bounds(headbutt, headbutt_bytes):
+		return _error("Headbutt tree graphics are outside the cartridge.")
+	if Array(rom.slice(headbutt, HEADBUTT_TREE_SIGNATURE.size())) != HEADBUTT_TREE_SIGNATURE:
+		return _error("Headbutt tree graphics do not start with the sheet's first row.")
+	var headbutt_pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		rom.slice(headbutt, headbutt_bytes), 0, HEADBUTT_TREE_TILES
+	)
+	if headbutt_pixels.size() != HEADBUTT_TREE_TILES * Gen2Tiles.TILE_PIXELS:
+		return _error("Headbutt tree graphics did not decode.")
+	effects.append({
+		"name": "headbutt_tree",
+		"tiles": HEADBUTT_TREE_TILES,
+		## FIELDMOVE_TREE, which ShakeHeadbuttTree writes into the struct's own
+		## tile field rather than reading from a table.
+		"vtile": 0x84,
+		"bytes": Array(headbutt_pixels),
+	})
+	return {"ok": true, "effects": effects}
 
 
 static func _read_tileset(rom: RomFile, layout: Dictionary, number: int) -> Dictionary:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -45,6 +45,11 @@ const RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
 ## created and whenever the window changes it. Only reached by a renderer that
 ## asked for the native layer. Shared by both renderer kinds.
 const RENDERER_RESIZE_METHOD: String = "set_native_size"
+## Optional, world renderers only. Called with the screen's [Gen2WorldEffects]
+## when the renderer is built. It holds the sprites the engine draws over the
+## map rather than as objects, all of them presentation with no world state
+## behind them, so a renderer that draws its own effects can ignore it.
+const RENDERER_EFFECTS_METHOD: String = "set_effects"
 ## Optional, battle renderers only. Called with a [Gen2BattleWorldContext] once
 ## per battle, before the first [code]set_view[/code], when the battle was
 ## entered from the world. It is where the fight is happening: a renderer staging

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -43,6 +43,8 @@ const STEP_FRAMES_NPC_WALK: int = 16
 ## MovementFunction_Strength calls InitStep with `direction | 0`, so a pushed
 ## boulder indexes that same slow row and slides at a wandering NPC's speed.
 const STEP_FRAMES_BOULDER_PUSH: int = STEP_FRAMES_NPC_WALK
+## `Movement_tree_shake`'s own `ld a, 24`, spent as a STEP_TYPE_SLEEP.
+const TREE_SHAKE_FRAMES: int = 24
 ## StepVectors' fast row: 4 pixels per frame for 4 frames, which the bike-speed
 ## movement commands reach through `STEP_BIKE`.
 const STEP_FRAMES_FAST: int = 4
@@ -213,6 +215,8 @@ var _phone_ring_request: Dictionary = {}
 var _player_step_direction: Vector2i = Vector2i.ZERO
 var _player_step_frames_total: int = 0
 var _player_step_frames_remaining: int = 0
+## Gen2WorldObject.step_began for the player.
+var _player_step_began: bool = false
 ## The rest of a scripted movement stream the player still has to be drawn
 ## walking, the way Gen2WorldObject.queued_steps holds an object's.
 var _player_queued_steps: Array = []
@@ -517,9 +521,11 @@ func _begin_player_step(direction: Vector2i, frames: int) -> void:
 	_player_step_direction = direction
 	_player_step_frames_total = maxi(0, frames)
 	_player_step_frames_remaining = _player_step_frames_total
+	_player_step_began = direction != Vector2i.ZERO
 
 
 func _clear_player_step() -> void:
+	_player_step_began = false
 	_player_step_direction = Vector2i.ZERO
 	_player_step_frames_total = 0
 	_player_step_frames_remaining = 0
@@ -1808,6 +1814,43 @@ func advance_emotes_frame() -> bool:
 	for object: Gen2WorldObject in objects:
 		changed = object.tick_emote() or changed
 	return changed
+
+
+## The grass rustles `NormalStep` spawned this frame, taken once.
+##
+## `ShakeGrass` runs where a step starts, for whichever object is stepping and
+## for the player alike, when the tile that step commits to is grass by
+## `SetTallGrassFlags`' own test. The temporary object it spawns lives one frame
+## less than the step (`MovementFunction_ShakingGrass`), tracks the object that
+## spawned it, and is drawn over that object's own sprite.
+##
+## Returned rather than emitted because nothing in the world reads it: it is
+## presentation, and [Gen2WorldEffects] is what holds it while it runs. Object
+## index -1 is the player.
+func take_grass_rustles() -> Array:
+	var out: Array = []
+	if _player_step_began:
+		_player_step_began = false
+		if Gen2WorldCollision.is_grass(collision_code_at(player_cell)):
+			out.append({
+				"object_index": -1,
+				"cell": player_cell,
+				"frames": maxi(0, _player_step_frames_total - 1),
+			})
+	for object: Gen2WorldObject in objects:
+		if not object.step_began:
+			continue
+		object.step_began = false
+		if not object.active or object.deleted:
+			continue
+		if not Gen2WorldCollision.is_grass(collision_code_at(object.cell)):
+			continue
+		out.append({
+			"object_index": object.index,
+			"cell": object.cell,
+			"frames": maxi(0, object.step_frames_total - 1),
+		})
+	return out
 
 
 ## Builds the source trainer approach path. The cartridge's
@@ -3344,10 +3387,16 @@ func _apply_object_movement(event: Dictionary) -> Array:
 			&"step_stop":
 				break
 			&"tree_shake":
+				## `Movement_tree_shake` shakes the object, not the screen: the
+				## stream sleeps 24 frames while OBJECT_ACTION_WEIRD_TREE cycles
+				## its drawing. The event stays for a host that plays a sound
+				## over it; nothing else is asked of it.
+				object.queue_tree_shake(TREE_SHAKE_FRAMES)
 				generated.append({
 					"type": &"tree_shake_requested",
 					"object_index": object_index,
 					"cell": object.cell,
+					"frames": TREE_SHAKE_FRAMES,
 				})
 			&"rock_smash":
 				generated.append({

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -4,12 +4,39 @@ extends RefCounted
 ## Scene-free presentation state for effects that the overworld engine paces in
 ## hardware frames. The renderer owns the pixels; this class owns the source
 ## duration, amplitude and deterministic offsets.
+##
+## Two shapes live here. `ShakeScreen` is one packed byte of duration and
+## amplitude. The rest are the sprites the engine draws over the map rather than
+## as map objects: `SpawnStrengthBoulderDust`, `ShakeGrass` and
+## `ShakeHeadbuttTree`, each its own frameset over one of the sheets
+## GameData.overworld_effect() holds.
 
 var _frame: int = 0
 var _duration: int = 0
 var _amplitude: int = 0
 var _kind: StringName = &"none"
 var _source: Dictionary = {}
+var _sprites: Array = []
+
+## The three effect sprites, by the sheet each draws from.
+const SPRITE_BOULDER_DUST: StringName = &"boulder_dust"
+const SPRITE_GRASS_RUSTLE: StringName = &"grass_rustle"
+const SPRITE_HEADBUTT_TREE: StringName = &"headbutt_tree"
+
+## constants/sprite_data_constants.asm. Every emote-object spawn names its
+## palette: PAL_OW_EMOTE for the dust and the emote bubbles, PAL_OW_TREE for the
+## grass and for `.OAMData_Tree`.
+const PAL_OW_EMOTE: int = 5
+const PAL_OW_TREE: int = 6
+
+## ShakeHeadbuttTree's `ld a, 32 / ld [wFrameCounter], a`.
+const HEADBUTT_TREE_FRAMES: int = 32
+
+## `MovementFunction_BoulderDust`'s `.dust_coords`, indexed by the boulder's own
+## walking direction in the source's DOWN, UP, LEFT, RIGHT order.
+const DUST_OFFSETS: Array[Vector2i] = [
+	Vector2i(0, -4), Vector2i(0, 8), Vector2i(6, 2), Vector2i(-6, 2),
+]
 
 
 func start_screen_shake(packed_value: int, kind: StringName = &"screen_shake", source: Dictionary = {}) -> Dictionary:
@@ -22,14 +49,61 @@ func start_screen_shake(packed_value: int, kind: StringName = &"screen_shake", s
 	return snapshot()
 
 
-func start_tree_shake(source: Dictionary = {}) -> Dictionary:
-	## ShakeHeadbuttTree runs for eight tile steps at four frames each.
-	return start_screen_shake(32, &"tree_shake", source)
+## `ShakeHeadbuttTree` over the cell the player is facing: the tree's four tiles
+## are replaced with the tileset's own grass tile and an eight-tile sheet is
+## animated in front of them for 32 frames.
+func start_headbutt_tree(cell: Vector2i) -> void:
+	_sprites.append({
+		"kind": SPRITE_HEADBUTT_TREE,
+		"cell": cell,
+		"object_index": -2,
+		"palette": PAL_OW_TREE,
+		"frame": 0,
+		"duration": HEADBUTT_TREE_FRAMES,
+	})
+
+
+## `ShakeGrass`, spawned where a step onto grass starts and tracking whoever
+## took it. [param frames] is the step's own duration less one.
+func start_grass_rustle(object_index: int, cell: Vector2i, frames: int) -> void:
+	if frames <= 0:
+		return
+	_sprites.append({
+		"kind": SPRITE_GRASS_RUSTLE,
+		"cell": cell,
+		"object_index": object_index,
+		"palette": PAL_OW_TREE,
+		"frame": 0,
+		"duration": frames,
+	})
+
+
+## `SpawnStrengthBoulderDust`, spawned where the boulder starts sliding.
+## `MovementFunction_BoulderDust` spends `(step duration + 1) * 2` frames, so the
+## dust outlives the push.
+func start_boulder_dust(object_index: int, cell: Vector2i, direction: Vector2i, step_frames: int) -> void:
+	_sprites.append({
+		"kind": SPRITE_BOULDER_DUST,
+		"cell": cell,
+		"object_index": object_index,
+		"palette": PAL_OW_EMOTE,
+		"frame": 0,
+		"duration": (maxi(0, step_frames) + 1) * 2,
+		"direction": _direction_index(direction),
+	})
 
 
 func advance_frame() -> bool:
+	var moved: bool = false
+	var running: Array = []
+	for sprite: Dictionary in _sprites:
+		sprite["frame"] = int(sprite["frame"]) + 1
+		if int(sprite["frame"]) < int(sprite["duration"]):
+			running.append(sprite)
+		moved = true
+	_sprites = running
 	if not active():
-		return false
+		return moved
 	_frame += 1
 	if not active():
 		_kind = &"none"
@@ -39,6 +113,11 @@ func advance_frame() -> bool:
 
 func active() -> bool:
 	return _frame < _duration and _duration > 0
+
+
+## Whether any effect sprite is still on screen.
+func sprites_active() -> bool:
+	return not _sprites.is_empty()
 
 
 func offset() -> Vector2:
@@ -52,6 +131,44 @@ func offset() -> Vector2:
 		_: return Vector2(0.0, magnitude)
 
 
+## What a renderer draws this frame: one record per live sprite, each carrying
+## the sheet it reads, the palette row it wears and the tiles `Facings` or the
+## frameset places, as pixel offsets from the anchor.
+##
+## The anchor is the cell for the headbutt tree, whose sprite stands still, and
+## the tracked object's own drawn position for the other two, which are
+## STEP_TYPE_TRACKING_OBJECT and follow whatever spawned them.
+func sprites() -> Array:
+	var out: Array = []
+	for sprite: Dictionary in _sprites:
+		out.append({
+			"kind": sprite["kind"],
+			"cell": sprite["cell"],
+			"object_index": int(sprite["object_index"]),
+			"palette": int(sprite["palette"]),
+			"frame": int(sprite["frame"]),
+			"tiles": _tiles_for(sprite),
+		})
+	return out
+
+
+## The cells a live effect takes the map's own tiles away from.
+## `HideHeadbuttTree` writes the tileset's grass tile over the tree's four
+## graphics tiles while the animation runs, which is what stops the tree drawing
+## through it.
+func hidden_tree_cells() -> Array:
+	var out: Array = []
+	for sprite: Dictionary in _sprites:
+		if StringName(sprite["kind"]) == SPRITE_HEADBUTT_TREE:
+			out.append(sprite["cell"])
+	return out
+
+
+## The tile the four hidden ones are replaced with, which the source's own
+## comment pins: "Assumes any tileset with headbutt trees has grass at tile $05".
+const HEADBUTT_TREE_HIDDEN_TILE: int = 0x05
+
+
 func snapshot() -> Dictionary:
 	return {
 		"active": active(),
@@ -61,4 +178,67 @@ func snapshot() -> Dictionary:
 		"amplitude": _amplitude,
 		"offset": offset(),
 		"source": _source.duplicate(true),
+		"sprites": sprites(),
 	}
+
+
+## One sprite's tiles this frame: [{ offset, tile, flip_x }], where `tile` is an
+## index into the sheet the kind names.
+static func _tiles_for(sprite: Dictionary) -> Array:
+	var frame: int = int(sprite["frame"])
+	match StringName(sprite["kind"]):
+		SPRITE_HEADBUTT_TREE:
+			## `.Frameset_HeadbuttTree` is four `oamframe`s of two, which last
+			## three frames each: tiles 0-3, tiles 4-7, tiles 0-3, then tiles 4-7
+			## with each tile flipped where it stands.
+			var step: int = int(float(frame % 12) / 3.0)
+			var base: int = 0 if step == 0 or step == 2 else 4
+			var flip: bool = step == 3
+			var tiles: Array = []
+			for index: int in 4:
+				tiles.append({
+					"offset": Vector2i((index & 1) * 8, (index >> 1) * 8),
+					"tile": base + index,
+					"flip_x": flip,
+				})
+			return tiles
+		SPRITE_GRASS_RUSTLE:
+			## `SetFacingGrassShake` swaps FACING_GRASS_1 and FACING_GRASS_2 on
+			## bit 2 of the step frame, so each is up for four frames, and the
+			## second sits one pixel down and one out on each side.
+			if frame & 4 == 0:
+				return [
+					{"offset": Vector2i(0, 8), "tile": 0, "flip_x": false},
+					{"offset": Vector2i(8, 8), "tile": 0, "flip_x": true},
+				]
+			return [
+				{"offset": Vector2i(-1, 9), "tile": 0, "flip_x": false},
+				{"offset": Vector2i(9, 9), "tile": 0, "flip_x": true},
+			]
+		SPRITE_BOULDER_DUST:
+			## `SetFacingBoulderDust` swaps FACING_BOULDER_DUST_1 and _2 on bit 1
+			## of the step frame, and each draws its one tile four times in a
+			## 16x16 square at the direction's own offset.
+			var dust_tile: int = 0 if frame & 2 == 0 else 1
+			var at: Vector2i = DUST_OFFSETS[int(sprite.get("direction", 0))]
+			var dust: Array = []
+			for index: int in 4:
+				dust.append({
+					"offset": at + Vector2i((index & 1) * 8, (index >> 1) * 8),
+					"tile": dust_tile,
+					"flip_x": false,
+				})
+			return dust
+	return []
+
+
+## The source's DOWN, UP, LEFT, RIGHT order, which is what `.dust_coords` is
+## indexed by.
+static func _direction_index(direction: Vector2i) -> int:
+	if direction == Vector2i.UP:
+		return 1
+	if direction == Vector2i.LEFT:
+		return 2
+	if direction == Vector2i.RIGHT:
+		return 3
+	return 0

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -81,6 +81,12 @@ var emote_remaining: int = 0
 var step_direction: Vector2i = Vector2i.ZERO
 var step_frames_total: int = 0
 var step_frames_remaining: int = 0
+## Set on the frame a step starts and cleared by whoever reads it, which is the
+## grass rustle `NormalStep` spawns there.
+var step_began: bool = false
+## OBJECT_ACTION_WEIRD_TREE, while the sleep a `tree_shake` queued runs. See
+## queue_tree_shake().
+var weird_tree: bool = false
 ## The rest of a scripted movement stream, still to be drawn. An applymovement
 ## commits every cell of its path at once, so the whole path is behind the
 ## committed cell until these drain; each entry is one `{direction, frames}`
@@ -336,6 +342,17 @@ func queue_step(direction: Vector2i, frames: int) -> void:
 	_begin_step(direction, frames)
 
 
+## `Movement_tree_shake`: 24 frames of STEP_TYPE_SLEEP with OBJECT_ACTION_WEIRD_TREE.
+##
+## Nothing moves and nothing shakes but this object's own drawing:
+## `SetFacingWeirdTree` steps the frame counter every frame and takes its two
+## high bits, which is `walk_frame()` again, so Sudowoodo wobbles between its
+## standing drawing and its two walking ones where it stands.
+func queue_tree_shake(frames: int) -> void:
+	weird_tree = true
+	queue_wait(frames)
+
+
 ## Adds a `step_sleep` to the same trail: frames the stream spends standing.
 ## STEP_TYPE_SLEEP writes STANDING into OBJECT_WALKING, so this walks nothing
 ## and moves nothing, but the script waiting on the stream still waits for it.
@@ -353,6 +370,10 @@ func _begin_step(direction: Vector2i, frames: int) -> void:
 	step_direction = direction
 	step_frames_total = maxi(0, frames)
 	step_frames_remaining = step_frames_total
+	## `NormalStep` calls `ShakeGrass` where it starts the step, and a queued
+	## stream starts its later steps here rather than at a call site, so the flag
+	## is raised here and read once by Gen2WorldAPI.take_grass_rustles().
+	step_began = direction != Vector2i.ZERO
 
 
 ## Consumes one frame of an in-flight step. Returns true when a frame was
@@ -361,10 +382,16 @@ func _begin_step(direction: Vector2i, frames: int) -> void:
 func tick_step() -> bool:
 	if step_frames_remaining <= 0:
 		return false
-	if step_direction != Vector2i.ZERO:
+	if step_direction != Vector2i.ZERO or weird_tree:
 		advance_walk_frame()
 	step_frames_remaining -= 1
 	if step_frames_remaining <= 0:
+		if weird_tree:
+			## The 24 frames are not a multiple of the four-frame cycle, so
+			## unlike a step this one has to be stood back up by hand.
+			weird_tree = false
+			step_frame = 0
+			frame = 0
 		if queued_steps.is_empty():
 			scripted_steps = false
 		else:

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -10,6 +10,7 @@ const FALLBACK_BACKGROUND: Color = Color("#f5f1d8")
 
 var _world: Gen2WorldAPI = null
 var _animation: Gen2WorldAnimation = null
+var _effects: Gen2WorldEffects = null
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var _atlas: ImageTexture = null
 ## Kept beside the texture so an animation frame can repaint the one or two
@@ -17,13 +18,26 @@ var _atlas: ImageTexture = null
 var _atlas_image: Image = null
 var _background_color: Color = FALLBACK_BACKGROUND
 var _actor_textures: Dictionary = {}
+var _priority_atlas: ImageTexture = null
+var _priority_indices: PackedByteArray = PackedByteArray()
+var _effect_sheets: Dictionary = {}
+var _effect_textures: Dictionary = {}
 
 
 func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> void:
 	_world = world
 	_animation = animation
 	_actor_textures.clear()
+	_effect_textures.clear()
 	_rebuild_atlas()
+	queue_redraw()
+
+
+## Gen2ModHost.RENDERER_EFFECTS_METHOD: the emote bubbles, boulder dust, grass
+## rustle and headbutt tree this view draws over the map. Presentation only, so a
+## renderer may be handed null and draw none of them.
+func set_effects(effects: Gen2WorldEffects) -> void:
+	_effects = effects
 	queue_redraw()
 
 
@@ -33,6 +47,7 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 func set_time_of_day(time_of_day: int) -> void:
 	_time_of_day = clampi(time_of_day, 0, 3)
 	_actor_textures.clear()
+	_effect_textures.clear()
 	_rebuild_atlas()
 	queue_redraw()
 
@@ -57,6 +72,8 @@ func refresh_animation() -> void:
 	for tile: int in changed:
 		_paint_tile(_atlas_image, indices, palettes, tile)
 	_atlas.update(_atlas_image)
+	_priority_indices = indices
+	_priority_atlas = null
 	queue_redraw()
 
 
@@ -82,6 +99,9 @@ func _rebuild_atlas() -> void:
 	for tile: int in tile_count:
 		_paint_tile(_atlas_image, indices, palettes, tile)
 	_atlas = ImageTexture.create_from_image(_atlas_image)
+	# Built on demand: only an object standing in grass reads it.
+	_priority_indices = indices
+	_priority_atlas = null
 
 
 func _tile_palettes() -> Array:
@@ -136,9 +156,12 @@ func _draw() -> void:
 	)
 	var window_size: Vector2i = Gen2WorldAPI.VIEW_TILES + Vector2i.ONE
 	var page: PackedInt32Array = _world.tile_indices_in_window(tile_origin, window_size)
+	var hidden: Dictionary = _hidden_tree_tiles()
 	for y: int in window_size.y:
 		for x: int in window_size.x:
 			var tile: int = page[y * window_size.x + x]
+			if hidden.has(tile_origin + Vector2i(x, y)):
+				tile = Gen2WorldEffects.HEADBUTT_TREE_HIDDEN_TILE
 			if _atlas == null or tile < 0 or tile >= _world.current_tileset.tile_count:
 				continue
 			draw_texture_rect_region(
@@ -160,8 +183,11 @@ func _draw() -> void:
 		)
 		if texture != null:
 			draw_texture(texture, pixel)
+		if _in_grass(object.cell):
+			_draw_grass_over(pixel, page, tile_origin, tile_offset, window_size)
 		if object.emote_visible:
 			_draw_emote(object.emote_id, pixel)
+		_draw_effect_sprites(object.index, pixel)
 
 	var player: Vector2 = Vector2(_world.player_pixel_position())
 	var player_texture: Texture2D = _actor_texture(
@@ -170,11 +196,24 @@ func _draw() -> void:
 	)
 	if player_texture != null:
 		draw_texture(player_texture, player)
+		if _in_grass(_world.player_cell):
+			_draw_grass_over(player, page, tile_origin, tile_offset, window_size)
 	else:
 		var marker := Rect2(Vector2(player.x, player.y), Vector2(16, 16))
 		draw_rect(marker, PLAYER_COLOR, false, 1.0)
 		draw_line(marker.position, marker.end, PLAYER_COLOR, 1.0)
 		draw_line(Vector2(marker.end.x, marker.position.y), Vector2(marker.position.x, marker.end.y), PLAYER_COLOR, 1.0)
+	_draw_effect_sprites(-1, player)
+	## The tree sprite stands over its own cell rather than over an object, and
+	## the source draws every one of these from `wShadowOAMSprite36` up, which is
+	## past every map object.
+	for sprite: Dictionary in _effect_sprites():
+		if int(sprite["object_index"]) != -2:
+			continue
+		_draw_effect_sprite(
+			sprite,
+			Vector2((sprite["cell"] as Vector2i) * Gen2WorldAPI.CELL_PIXELS) - camera_pixels,
+		)
 
 
 func _actor_texture(
@@ -210,21 +249,170 @@ func _sort_objects(first: Gen2WorldObject, second: Gen2WorldObject) -> bool:
 	return first.cell.y < second.cell.y
 
 
+## `SpawnEmote`: four tiles of the emote's own sheet, two rows above the object
+## the source's `MovementFunction_Emote` writes `-2 * TILE_WIDTH` for.
 func _draw_emote(emote_id: int, pixel: Vector2) -> void:
-	var bubble := Rect2(pixel + Vector2(4, -10), Vector2(8, 8))
-	draw_rect(bubble, Color("#fff8d6"), true)
-	draw_rect(bubble, Color("#18243a"), false, 1.0)
-	draw_colored_polygon(
-		PackedVector2Array([
-			pixel + Vector2(6, -2), pixel + Vector2(8, 2), pixel + Vector2(10, -2),
-		]),
-		Color("#fff8d6")
+	if emote_id < 0 or emote_id >= RomLayout.EMOTE_NAMES.size():
+		return
+	var sheet: Dictionary = _effect_sheet(RomLayout.EMOTE_NAMES[emote_id])
+	if sheet.is_empty():
+		return
+	for index: int in 4:
+		_draw_effect_tile(
+			sheet,
+			index,
+			Gen2WorldEffects.PAL_OW_EMOTE,
+			false,
+			pixel + Vector2((index & 1) * 8, (index >> 1) * 8 - 16),
+		)
+
+
+## `SetTallGrassFlags` sets IN_GRASS_F on an object standing in either kind of
+## grass, and `.InitSprite` turns that into OAM_PRIO on the two tiles carrying
+## RELATIVE_ATTRIBUTES, which are the bottom half of every facing: the grass in
+## front of the object covers its legs.
+func _in_grass(cell: Vector2i) -> bool:
+	return _world != null and _world.current_map != null \
+		and Gen2WorldCollision.is_grass(_world.collision_code_at(cell))
+
+
+## Redraws the map over the bottom half of a sprite drawn at [param pixel], with
+## the transparent index left out, which is what OAM_PRIO amounts to here.
+func _draw_grass_over(
+	pixel: Vector2,
+	page: PackedInt32Array,
+	tile_origin: Vector2i,
+	tile_offset: Vector2,
+	window_size: Vector2i,
+) -> void:
+	if _priority_atlas == null:
+		_build_priority_atlas()
+	if _priority_atlas == null:
+		return
+	var over := Rect2(
+		pixel + Vector2(0, Gen2Tiles.TILE_HEIGHT),
+		Vector2(Gen2WorldAPI.CELL_PIXELS, Gen2Tiles.TILE_HEIGHT),
 	)
-	var style: int = posmod(emote_id, 3)
-	if style == 0:
-		draw_circle(pixel + Vector2(8, -6), 2.0, Color("#d34a5a"))
-	elif style == 1:
-		draw_line(pixel + Vector2(6, -8), pixel + Vector2(10, -4), Color("#3d6fd6"), 1.5)
-		draw_line(pixel + Vector2(10, -8), pixel + Vector2(6, -4), Color("#3d6fd6"), 1.5)
-	else:
-		draw_rect(Rect2(pixel + Vector2(6, -8), Vector2(4, 4)), Color("#d69b2f"), true)
+	for y: int in window_size.y:
+		for x: int in window_size.x:
+			var at := Rect2(
+				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT) - tile_offset,
+				Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT),
+			)
+			var covered: Rect2 = at.intersection(over)
+			if covered.size.x <= 0.0 or covered.size.y <= 0.0:
+				continue
+			var tile: int = page[y * window_size.x + x]
+			if tile < 0 or tile >= _world.current_tileset.tile_count:
+				continue
+			draw_texture_rect_region(
+				_priority_atlas,
+				covered,
+				Rect2(
+					Vector2(tile * Gen2Tiles.TILE_WIDTH, 0) + (covered.position - at.position),
+					covered.size,
+				),
+			)
+
+
+## The same strip as the atlas with the cartridge's transparent index left out,
+## for the tiles that are drawn over a sprite rather than under it.
+func _build_priority_atlas() -> void:
+	if _atlas_image == null:
+		return
+	var image: Image = _atlas_image.duplicate()
+	var width: int = image.get_width()
+	if _priority_indices.size() < width * Gen2Tiles.TILE_HEIGHT:
+		return
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in width:
+			if int(_priority_indices[y * width + x]) == 0:
+				image.set_pixel(x, y, Color(0, 0, 0, 0))
+	_priority_atlas = ImageTexture.create_from_image(image)
+
+
+func _effect_sprites() -> Array:
+	return _effects.sprites() if _effects != null else []
+
+
+## The tiles a live effect takes from the map, as a set of absolute tile
+## coordinates. See Gen2WorldEffects.hidden_tree_cells().
+func _hidden_tree_tiles() -> Dictionary:
+	var out: Dictionary = {}
+	if _effects == null:
+		return out
+	for cell: Vector2i in _effects.hidden_tree_cells():
+		var origin: Vector2i = cell * RomLayout.MAP_BLOCK_CELL_WIDTH
+		for y: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
+			for x: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
+				out[origin + Vector2i(x, y)] = true
+	return out
+
+
+## Whatever [param object_index] is carrying this frame, drawn over it: the dust
+## and the grass rustle are STEP_TYPE_TRACKING_OBJECT and follow the object that
+## spawned them, so their anchor is where that object is drawn. -1 is the player.
+func _draw_effect_sprites(object_index: int, pixel: Vector2) -> void:
+	for sprite: Dictionary in _effect_sprites():
+		if int(sprite["object_index"]) == object_index:
+			_draw_effect_sprite(sprite, pixel)
+
+
+func _draw_effect_sprite(sprite: Dictionary, anchor: Vector2) -> void:
+	var sheet: Dictionary = _effect_sheet(String(sprite["kind"]))
+	if sheet.is_empty():
+		return
+	for tile: Dictionary in sprite["tiles"]:
+		_draw_effect_tile(
+			sheet,
+			int(tile["tile"]),
+			int(sprite["palette"]),
+			bool(tile["flip_x"]),
+			anchor + Vector2(tile["offset"] as Vector2i),
+		)
+
+
+func _effect_sheet(name: String) -> Dictionary:
+	if _world == null or _world.data == null:
+		return {}
+	if _effect_sheets.has(name):
+		return _effect_sheets[name]
+	var sheet: Dictionary = _world.data.overworld_effect(name)
+	_effect_sheets[name] = sheet
+	return sheet
+
+
+## One 8x8 tile of an effect sheet. Index 0 is the transparent colour here, as it
+## is for every object: these are sprites, not background.
+func _draw_effect_tile(
+	sheet: Dictionary, tile: int, palette_index: int, flip_x: bool, at: Vector2
+) -> void:
+	var key: String = "%s:%d:%d:%d:%d" % [
+		sheet["name"], tile, palette_index, int(flip_x), _time_of_day,
+	]
+	var texture: Texture2D = _effect_textures.get(key, null)
+	if texture == null:
+		var indices: PackedByteArray = sheet["indices"]
+		var tiles: int = int(sheet["tiles"])
+		if tile < 0 or tile >= tiles or indices.size() < tiles * Gen2Tiles.TILE_PIXELS:
+			return
+		var palette: PackedColorArray = _world.data.overworld_sprite_palette(
+			palette_index, _time_of_day
+		)
+		var image := Image.create(
+			Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT, false, Image.FORMAT_RGBA8
+		)
+		var width: int = tiles * Gen2Tiles.TILE_WIDTH
+		for y: int in Gen2Tiles.TILE_HEIGHT:
+			for x: int in Gen2Tiles.TILE_WIDTH:
+				var color_index: int = int(indices[y * width + tile * Gen2Tiles.TILE_WIDTH + x])
+				var color: Color = palette[color_index] if color_index < palette.size() \
+					else Color.MAGENTA
+				if color_index == 0:
+					color.a = 0.0
+				image.set_pixel(x, y, color)
+		if flip_x:
+			image.flip_x()
+		texture = ImageTexture.create_from_image(image)
+		_effect_textures[key] = texture
+	draw_texture(texture, at)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -59,6 +59,8 @@ var _world: Gen2WorldAPI = null
 var _renderer: Node = null
 var _animation: Gen2WorldAnimation = null
 var _effects: Gen2WorldEffects = null
+## The headbutt result waiting for ShakeHeadbuttTree's 32 frames to be spent.
+var _pending_headbutt_finish: Dictionary = {}
 var _text_box: Gen2TextBox = null
 var _clock: Gen2WorldClock = null
 var _audio_player: Gen2AudioPlayer = null
@@ -273,6 +275,8 @@ func _build_renderer() -> void:
 		_screen.display_native(_renderer)
 		_screen.native_size_changed.connect(_on_native_size_changed)
 		_on_native_size_changed(_screen.native_size())
+	if _renderer.has_method(Gen2ModHost.RENDERER_EFFECTS_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_EFFECTS_METHOD, _effects)
 	_renderer.set_world(_world, _animation)
 	_renderer.set_time_of_day(_render_time_of_day())
 	_apply_renderer_interface_style()
@@ -375,7 +379,8 @@ func advance_frame() -> void:
 			_apply_replayed_input(_world.frame_number)
 	_advance_game_time_frame()
 	if _effects != null:
-		_effects.advance_frame()
+		if _effects.advance_frame() and _renderer != null:
+			_renderer.refresh()
 		_apply_world_effect_offset()
 	if _animation != null and _animation.advance_frame() and _renderer != null:
 		_renderer.refresh_animation()
@@ -392,6 +397,13 @@ func advance_frame() -> void:
 	# script that ran it is still going, which is when a script runs one.
 	if _world != null and _world.advance_scripted_steps_frame() and _renderer != null:
 		_renderer.refresh()
+	# After both trails: `ShakeGrass` is called where the step starts, so a
+	# rustle taken now belongs to a step begun on this frame.
+	_spawn_grass_rustles()
+	if not _pending_headbutt_finish.is_empty() and (_effects == null or not _effects.sprites_active()):
+		var headbutt: Dictionary = _pending_headbutt_finish
+		_pending_headbutt_finish = {}
+		_finish_headbutt(headbutt)
 	# After the trail, because the frame it finishes drawing is the frame the
 	# script waiting on it resumes.
 	if _world != null and not _world.pending_script_wait().is_empty():
@@ -764,6 +776,14 @@ func move_player(direction: Vector2i) -> bool:
 		## SFX_STRENGTH here, not the menu that set the flag.
 		if movement.has("boulder_pushed"):
 			_play_sfx(SFX_STRENGTH)
+			var pushed: Dictionary = movement["boulder_pushed"]
+			if _effects != null:
+				## SpawnStrengthBoulderDust runs where MovementFunction_Strength
+				## starts the slide, and the dust tracks the boulder from there.
+				_effects.start_boulder_dust(
+					int(pushed["index"]), pushed["to_cell"], pushed["direction"],
+					Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH,
+				)
 			if _renderer != null:
 				_renderer.refresh()
 			_refresh_labels()
@@ -961,19 +981,34 @@ func _update_time_of_day() -> void:
 		_renderer.set_time_of_day(_render_time_of_day())
 
 
-## Public screenshot driver for the scripted emote state and renderer path.
-func preview_emote() -> void:
+## Public screenshot driver for every sprite the engine draws over an object
+## rather than as one: the scripted emote, `SpawnStrengthBoulderDust`,
+## `ShakeGrass` and `ShakeHeadbuttTree`. Each is started through the call the
+## game makes, so this photographs the renderer's own path.
+func preview_effect_sprites() -> void:
 	if _world == null or _renderer == null:
 		return
-	var actors: Array = _world.visible_objects()
-	if actors.is_empty():
-		_script_prompt = "No visible object for emote preview"
-		_refresh_labels()
-		return
-	var object: Gen2WorldObject = actors[0]
-	object.set_emote(0, true)
+	if _effects != null:
+		_effects.start_headbutt_tree(_world.player_cell + Vector2i(1, 0))
+		_effects.start_boulder_dust(
+			-1, _world.player_cell, Vector2i.DOWN, Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH
+		)
+		_effects.start_grass_rustle(
+			-1, _world.player_cell, Gen2WorldAPI.STEP_FRAMES_WALK - 1
+		)
+	## The nearest object rather than the first, so the emote lands inside the
+	## view a capture photographs.
+	var nearest: Gen2WorldObject = null
+	for object: Gen2WorldObject in _world.visible_objects():
+		if nearest == null or object.cell.distance_squared_to(_world.player_cell) \
+			< nearest.cell.distance_squared_to(_world.player_cell):
+			nearest = object
+	if nearest == null:
+		_script_prompt = "No visible object for the emote"
+	else:
+		nearest.set_emote(0, true)
+		_script_prompt = "Debug effect sprite preview"
 	_renderer.refresh()
-	_script_prompt = "Debug emote preview"
 	_refresh_labels()
 
 
@@ -2329,6 +2364,8 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 					_animation.configure(_world, _render_time_of_day())
 			&"headbutt_applied":
 				_play_sfx(SFX_HEADBUTT_TREE)
+				if _effects != null:
+					_effects.start_headbutt_tree(applied.get("cell", Vector2i.ZERO))
 			&"rock_smash_applied":
 				_play_sfx(SFX_STRENGTH)
 			_:
@@ -2337,7 +2374,11 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 			_renderer.refresh()
 		_script_prompt = label
 		if StringName(applied.get("kind", &"")) == &"headbutt_applied":
-			_finish_headbutt(applied)
+			## HeadbuttScript's `callasm ShakeHeadbuttTree` spends its 32 frames
+			## before `callasm TreeMonEncounter`, so the roll's own result waits
+			## for the animation rather than opening a battle over it.
+			_pending_headbutt_finish = applied.duplicate(true)
+			_refresh_labels()
 			return
 		if StringName(applied.get("kind", &"")) == &"rock_smash_applied":
 			_finish_rock_smash(applied)
@@ -2543,9 +2584,9 @@ func _show_script_results(results: Array) -> void:
 					)
 				_apply_world_effect_offset()
 			elif result_event.get("type", &"") == &"tree_shake_requested":
-				if _effects != null:
-					_effects.start_tree_shake(result_event)
-				_apply_world_effect_offset()
+				## The object animates itself for the frames the stream sleeps;
+				## there is nothing for a host to start.
+				pass
 			elif result_event.get("type", &"") in [
 				&"rock_smash_effect_requested",
 				&"movement_command_requested",
@@ -2589,6 +2630,19 @@ func _show_script_results(results: Array) -> void:
 		else:
 			_renderer.refresh()
 	_refresh_labels()
+
+
+## One frame's worth of `ShakeGrass`, for the player and for every object that
+## started a step onto grass on it.
+func _spawn_grass_rustles() -> void:
+	if _world == null or _effects == null:
+		return
+	for rustle: Dictionary in _world.take_grass_rustles():
+		_effects.start_grass_rustle(
+			int(rustle["object_index"]), rustle["cell"], int(rustle["frames"])
+		)
+	if _renderer != null and _effects.sprites_active():
+		_renderer.refresh()
 
 
 func _apply_world_effect_offset() -> void:

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -698,6 +698,12 @@ func _headbutt_with(player_id: int, seed_value: int) -> void:
 	# being pinned.
 	_world_screen._encounter_random.seed = seed_value
 	_world_screen._acknowledge_field_move_text()
+	## HeadbuttScript spends ShakeHeadbuttTree's 32 frames between the text and
+	## `callasm TreeMonEncounter`. The screen counts hardware frames off
+	## wall-clock delta, so this takes its processing away and spends them.
+	_world_screen.set_process(false)
+	for _frame: int in Gen2WorldEffects.HEADBUTT_TREE_FRAMES + 1:
+		_world_screen.advance_frame()
 	await get_tree().process_frame
 
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -283,13 +283,15 @@ func test_defeat_displays_imported_loss_text_and_uses_save_recovery() -> void:
 	assert_false(world["just_battled"])
 
 
-func test_emote_preview_reaches_the_production_world_renderer() -> void:
+func test_effect_sprite_preview_reaches_the_production_world_renderer() -> void:
 	await _open_world()
-	_world_screen.preview_emote()
+	_world_screen.preview_effect_sprites()
 	await get_tree().process_frame
 
-	assert_eq(_world_screen.world_snapshot()["script_prompt"], "Debug emote preview")
+	assert_eq(_world_screen.world_snapshot()["script_prompt"], "Debug effect sprite preview")
 	assert_true((_world_screen._world.objects[0] as Gen2WorldObject).emote_visible)
+	assert_eq(_world_screen._effects.sprites().size(), 3,
+		"the dust, the rustle and the tree are all staged")
 
 
 func test_production_world_entry_and_facing_object_story_persist_separate_flags() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -123,6 +123,11 @@ func _write_cache(game_id: String = "testworld") -> void:
 	collision[11 * 16 + 11] = 0x29  # COLL_WATER
 	collision[11 * 16 + 12] = 0x29  # COLL_WATER
 
+	# A tall-grass cell at (5,10) for SetTallGrassFlags and the rustle ShakeGrass
+	# spawns on a step into it. LAND_TILE permission, so an ordinary step reaches
+	# it and nothing else in the fixture changes.
+	collision[10 * 16 + 5] = 0x18  # COLL_TALL_GRASS
+
 	var source_events: Dictionary = {
 		"bank": 48,
 		"warps": [{
@@ -2640,6 +2645,28 @@ func test_background_events_honor_source_direction_and_conditional_pointer_recor
 	assert_true(world.event_flag_active(11))
 
 
+## `NormalStep` calls `ShakeGrass` where it starts the step, and
+## `MovementFunction_ShakingGrass` gives the temporary object one frame less
+## than that step, so the rustle belongs to the step rather than to the cell.
+func test_a_step_into_grass_takes_one_rustle_per_step() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(5, 11))
+	assert_true(world.take_grass_rustles().is_empty(), "standing still shakes nothing")
+
+	assert_true(bool(world.move_result(Vector2i.UP).get("ok", false)))
+	var rustles: Array = world.take_grass_rustles()
+	assert_eq(rustles.size(), 1)
+	assert_eq(rustles[0]["object_index"], -1, "the player is index -1")
+	assert_eq(rustles[0]["cell"], Vector2i(5, 10))
+	assert_eq(rustles[0]["frames"], Gen2WorldAPI.STEP_FRAMES_WALK - 1)
+	assert_true(world.take_grass_rustles().is_empty(), "the flag is taken once")
+
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_player_step_frame()
+	assert_true(bool(world.move_result(Vector2i.UP).get("ok", false)))
+	assert_true(world.take_grass_rustles().is_empty(), "the cell left behind is not grass")
+
+
 ## CheckTileEvent (engine/overworld/events.asm) runs warps, coord events, the
 ## step count and encounters. TryBGEvent is behind CheckAPressOW, so walking
 ## onto a background event's own cell runs nothing; only interact() reaches it.
@@ -3464,6 +3491,11 @@ func test_script_movement_publishes_source_shake_effects() -> void:
 	for event: Dictionary in events:
 		if event.get("type", &"") == &"screen_shake_requested":
 			assert_eq(event["strength"], 16)
+	## `Movement_tree_shake` shakes the object, not the screen: 24 frames of
+	## OBJECT_ACTION_WEIRD_TREE on the object the stream was applied to.
+	for event: Dictionary in events:
+		if event.get("type", &"") == &"tree_shake_requested":
+			assert_eq(event["frames"], Gen2WorldAPI.TREE_SHAKE_FRAMES)
 
 
 ## Every step command reaches NormalStep (engine/overworld/movement.asm), which

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -18,12 +18,68 @@ func test_source_packed_screen_shake_uses_duration_and_amplitude_bits() -> void:
 	assert_eq(effects.offset(), Vector2.ZERO)
 
 
-func test_tree_shake_is_a_short_source_timed_effect() -> void:
+func test_the_headbutt_tree_runs_its_frameset_for_thirty_two_frames() -> void:
 	var effects := Gen2WorldEffects.new()
-	effects.start_tree_shake({"object_index": 3})
-	assert_eq(effects.snapshot()["kind"], &"tree_shake")
-	assert_eq(effects.snapshot()["duration"], 32)
+	effects.start_headbutt_tree(Vector2i(4, 7))
+	var sprite: Dictionary = effects.sprites()[0]
+	assert_eq(sprite["kind"], Gen2WorldEffects.SPRITE_HEADBUTT_TREE)
+	assert_eq(sprite["cell"], Vector2i(4, 7))
+	assert_eq(effects.hidden_tree_cells(), [Vector2i(4, 7)])
+	## Each oamframe lasts three frames: tiles 0-3, tiles 4-7, tiles 0-3, then
+	## tiles 4-7 flipped, and then the frameset restarts.
+	var bases: Array = []
+	var flips: Array = []
+	for frame: int in 12:
+		var tiles: Array = (effects.sprites()[0] as Dictionary)["tiles"]
+		bases.append(int((tiles[0] as Dictionary)["tile"]))
+		flips.append(bool((tiles[0] as Dictionary)["flip_x"]))
+		effects.advance_frame()
+	assert_eq(bases, [0, 0, 0, 4, 4, 4, 0, 0, 0, 4, 4, 4])
+	assert_eq(flips.slice(9), [true, true, true])
+	assert_eq(int((effects.sprites()[0] as Dictionary)["tiles"][0]["tile"]), 0,
+		"oamrestart takes the frameset back to its first entry")
+
+	for _frame: int in 19:
+		effects.advance_frame()
+	assert_true(effects.sprites_active())
 	effects.advance_frame()
+	assert_false(effects.sprites_active(), "wFrameCounter is 32")
+	assert_eq(effects.hidden_tree_cells(), [])
+
+
+func test_a_grass_rustle_swaps_its_two_facings_every_four_frames() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_grass_rustle(-1, Vector2i(2, 2), 7)
+	var first: Array = (effects.sprites()[0] as Dictionary)["tiles"]
+	assert_eq(first.size(), 2)
+	assert_eq((first[0] as Dictionary)["offset"], Vector2i(0, 8))
+	assert_true(bool((first[1] as Dictionary)["flip_x"]), "FacingGrass1 mirrors its right tile")
+	for _frame: int in 4:
+		effects.advance_frame()
+	assert_eq(
+		((effects.sprites()[0] as Dictionary)["tiles"][0] as Dictionary)["offset"],
+		Vector2i(-1, 9),
+	)
+	for _frame: int in 3:
+		effects.advance_frame()
+	assert_false(effects.sprites_active(), "a rustle is one frame shorter than its step")
+
+
+func test_boulder_dust_takes_its_offset_from_the_push_direction() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_boulder_dust(2, Vector2i(5, 5), Vector2i.LEFT, 16)
+	var sprite: Dictionary = effects.sprites()[0]
+	assert_eq(sprite["object_index"], 2)
+	assert_eq((sprite["tiles"][0] as Dictionary)["offset"], Vector2i(6, 2))
+	assert_eq(sprite["tiles"].size(), 4, "one tile drawn four times in a 16x16 square")
+	## `SetFacingBoulderDust` swaps the two tiles on bit 1 of the frame counter.
 	effects.advance_frame()
-	assert_eq(effects.snapshot()["frame"], 2)
-	assert_true(effects.snapshot()["source"].has("object_index"))
+	assert_eq(int((effects.sprites()[0] as Dictionary)["tiles"][0]["tile"]), 0)
+	effects.advance_frame()
+	assert_eq(int((effects.sprites()[0] as Dictionary)["tiles"][0]["tile"]), 1)
+	## (step duration + 1) * 2 frames, so the dust outlives the push.
+	for _frame: int in 31:
+		effects.advance_frame()
+	assert_true(effects.sprites_active())
+	effects.advance_frame()
+	assert_false(effects.sprites_active())

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -276,3 +276,22 @@ func test_a_zero_length_sleep_wraps_a_whole_byte() -> void:
 	assert_eq(object.walk_frame(), 0, "a sleep stands still")
 	assert_true(object.tick_step())
 	assert_false(object.scripted_steps, "and the stream is done after its own count")
+
+
+## `Movement_tree_shake` is a 24-frame STEP_TYPE_SLEEP under
+## OBJECT_ACTION_WEIRD_TREE: nothing moves, and `SetFacingWeirdTree` takes the
+## two high bits of the frame counter, so the drawing changes every four frames
+## and the object is stood back up at the end.
+func test_a_tree_shake_wobbles_where_it_stands() -> void:
+	var object: Gen2WorldObject = _object()
+	var cell: Vector2i = object.cell
+	object.queue_tree_shake(Gen2WorldAPI.TREE_SHAKE_FRAMES)
+	var frames: Array = []
+	for _frame: int in Gen2WorldAPI.TREE_SHAKE_FRAMES:
+		assert_true(object.tick_step())
+		frames.append(object.frame)
+	assert_eq(frames.slice(0, 8), [0, 0, 0, 1, 1, 1, 1, 2])
+	assert_eq(object.cell, cell, "a shake walks nothing")
+	assert_false(object.weird_tree)
+	assert_eq(object.frame, 0, "24 frames is not a whole cycle, so it is stood up by hand")
+	assert_false(object.tick_step())

--- a/tools/checks/headbutt.gd
+++ b/tools/checks/headbutt.gd
@@ -90,8 +90,8 @@ func _verify_map_tables(game_id: StringName, data: GameData, crystal: bool) -> v
 			int(EXPECTED_ILEX_SET[game_id]),
 		]
 	)
-	# RockMonMaps is imported for Rock Smash, which is not implemented; the
-	# four rows are checked here so the table cannot rot unnoticed.
+	# RockMonMaps' four rows, checked beside the tree tables because both come
+	# out of the same importer pass; Rock Smash's own behaviour is its topic.
 	var rock_maps: Array = [
 		Vector2i(22, 3), Vector2i(22, 1), Vector2i(3, 78 if crystal else 70),
 		Vector2i(3, 40 if crystal else 32),

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -1,0 +1,76 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the sprites the overworld draws over an object rather than as one,
+## against freshly imported real caches: `data/sprites/emotes.asm`'s twelve
+## sheets and ShakeHeadbuttTree's own.
+##
+## Every expectation comes from the pinned sources: the emote table's tile
+## numbers are `Facings`' own ($f8 for the four-tile bubbles, $fc for the jump
+## shadow and the fishing rod, $fe for the boulder dust and the grass rustle),
+## and all three cartridges ship the art itself byte identical, which is what
+## the cross-cartridge comparison checks. A sheet read at the wrong offset
+## decodes neighbouring code into legal-looking pixels, so shape alone would not
+## catch it.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- overworld_effects
+
+## The names Gen2WorldImporter writes, with the tile count and VRAM tile each
+## record must name.
+const EXPECTED: Array = [
+	["shock", 4, 0xF8], ["question", 4, 0xF8], ["happy", 4, 0xF8], ["sad", 4, 0xF8],
+	["heart", 4, 0xF8], ["bolt", 4, 0xF8], ["sleep", 4, 0xF8], ["fish", 4, 0xF8],
+	["shadow", 1, 0xFC], ["rod", 2, 0xFC], ["boulder_dust", 2, 0xFE],
+	["grass_rustle", 1, 0xFE], ["headbutt_tree", 8, 0x84],
+]
+
+var _first: Dictionary = {}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_first = {}
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var lit: int = 0
+	for row: Array in EXPECTED:
+		var name: String = String(row[0])
+		var sheet: Dictionary = _r.data.overworld_effect(name)
+		if not _r.check(not sheet.is_empty(), "the %s sheet is not in the cache." % name):
+			continue
+		_r.check(
+			int(sheet["tiles"]) == int(row[1]),
+			"%s is %d tiles, not the source's %d." % [name, int(sheet["tiles"]), int(row[1])]
+		)
+		_r.check(
+			int(sheet["vtile"]) == int(row[2]),
+			"%s loads to tile $%02X, not $%02X." % [name, int(sheet["vtile"]), int(row[2])]
+		)
+		var indices: PackedByteArray = sheet["indices"]
+		if not _r.check(
+			indices.size() == int(row[1]) * Gen2Tiles.TILE_PIXELS,
+			"%s decoded %d pixels, not %d." % [
+				name, indices.size(), int(row[1]) * Gen2Tiles.TILE_PIXELS,
+			]
+		):
+			continue
+		var drawn: int = 0
+		for index: int in indices:
+			_r.check(index <= 3, "%s holds colour index %d." % [name, index])
+			if index != 0:
+				drawn += 1
+		# Index 0 is the transparent one, so a sheet of nothing but zeroes is a
+		# sheet that would draw nothing at all.
+		_r.check(drawn > 0, "%s is blank." % name)
+		lit += drawn
+		if _first.has(name):
+			_r.check(
+				_first[name] == indices,
+				"%s differs from the same sheet on the other cartridges." % name
+			)
+		else:
+			_first[name] = indices
+	_r.note("overworld effects: %d sheets, %d drawn pixels." % [EXPECTED.size(), lit])

--- a/tools/checks/overworld_effects.gd.uid
+++ b/tools/checks/overworld_effects.gd.uid
@@ -1,0 +1,1 @@
+uid://ck8jsoo7wv8od

--- a/tools/preview_controls.gd
+++ b/tools/preview_controls.gd
@@ -75,6 +75,11 @@ func _build() -> void:
 	_screen.set_save(save)
 	root.add_child(_screen)
 	current_scene = _screen
+	## The frames before the capture belong to the layout, not to the world: a
+	## screen left processing spends them on its own clock, and a long first
+	## frame could cross a cartridge minute and dispatch a phone call over the
+	## controller being photographed.
+	_screen.set_process(false)
 
 
 func _process(_delta: float) -> bool:

--- a/tools/preview_overworld_sprites.gd
+++ b/tools/preview_overworld_sprites.gd
@@ -40,7 +40,7 @@ func _initialize() -> void:
 		return
 
 	var count: int = data.overworld_sprite_count()
-	var rows: int = ceili(float(count) / float(COLUMNS))
+	var rows: int = ceili(float(count) / float(COLUMNS)) + 1
 	var sheet := Image.create(COLUMNS * TILE_W, rows * TILE_H, false, Image.FORMAT_RGBA8)
 	sheet.fill(BACKGROUND)
 	for number: int in range(1, count + 1):
@@ -62,6 +62,35 @@ func _initialize() -> void:
 					Rect2i(0, 0, CELL, CELL),
 					at + Vector2i(facing * CELL, frame * CELL)
 				)
+	## The last row is the effect sheets, tile by tile in the order
+	## data/sprites/emotes.asm lists them, with the headbutt tree's eight after
+	## them. They are drawn over an object rather than as one, so they have no
+	## facings and no frames: a wrong offset shows up as noise here.
+	var effects_top: int = (rows - 1) * TILE_H + 1
+	var at_x: int = 1
+	for name: String in RomLayout.EMOTE_NAMES + ["headbutt_tree"] as Array[String]:
+		var effect: Dictionary = data.overworld_effect(name)
+		if effect.is_empty():
+			continue
+		var palette: PackedColorArray = data.overworld_sprite_palette(
+			Gen2WorldEffects.PAL_OW_TREE if name in ["grass_rustle", "headbutt_tree"]
+			else Gen2WorldEffects.PAL_OW_EMOTE,
+			Gen2WorldPalette.TIME_DAY,
+		)
+		var indices: PackedByteArray = effect["indices"]
+		var tiles: int = int(effect["tiles"])
+		for tile: int in tiles:
+			for y: int in Gen2Tiles.TILE_HEIGHT:
+				for x: int in Gen2Tiles.TILE_WIDTH:
+					var index: int = int(indices[
+						y * tiles * Gen2Tiles.TILE_WIDTH + tile * Gen2Tiles.TILE_WIDTH + x
+					])
+					sheet.set_pixel(
+						at_x + x, effects_top + y,
+						palette[index] if index < palette.size() else Color.MAGENTA
+					)
+			at_x += Gen2Tiles.TILE_WIDTH
+		at_x += 2
 	sheet.resize(sheet.get_width() * SCALE, sheet.get_height() * SCALE, Image.INTERPOLATE_NEAREST)
 	if sheet.save_png(args[1]) != OK:
 		push_error("Could not write %s" % args[1])

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -3,15 +3,48 @@ extends SceneTree
 ## Renders one imported map's expanded 4x4-tile blocks to a PNG.
 ##
 ##   Godot --headless --path . -s res://tools/preview_world.gd -- gold 1 1 /tmp/world.png
+##
+## A fifth `live` argument photographs the real screen on that map instead, with
+## the sprites the engine draws over an object staged on it: an emote over the
+## first visible object, the boulder dust, the grass rustle and the headbutt
+## tree. That mode drives the screen's own path and needs a display, so it runs
+## without `--headless`:
+##
+##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/effects.png live 6 10
+##
+## The two optional numbers are the cell the player stands on, which is how the
+## grass a standing object is drawn behind is photographed.
+
+const WINDOW_SIZE := Vector2i(1152, 648)
+## Hardware frames spent after the sprites are staged. Two puts the grass rustle
+## on its first facing and the boulder dust on its second, so every one of them
+## is up and none is on the frame it was spawned.
+const STAGED_FRAMES: int = 2
+
+var _screen: Gen2WorldScreen = null
+var _output_path: String = ""
+var _frames: int = 0
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 4:
-		push_error("Usage: preview_world.gd -- <game> <group> <map> <output.png>")
+		push_error("Usage: preview_world.gd -- <game> <group> <map> <output.png> [live]")
 		quit(1)
 		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
+	if args.size() >= 5 and args[4] == "live":
+		if data == null:
+			push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+			quit(1)
+			return
+		_output_path = args[3]
+		_build_live(
+			data, int(args[1]), int(args[2]),
+			Vector2i(int(args[5]), int(args[6])) if args.size() >= 7 else Vector2i(-1, -1),
+		)
+		return
 	var map: Gen2WorldMap = data.world_map(int(args[1]), int(args[2])) if data != null else null
 	var tileset: Gen2WorldTileset = data.world_tileset(map.tileset) if map != null else null
 	if data == null or map == null or tileset == null:
@@ -32,6 +65,52 @@ func _initialize() -> void:
 		(map.events.get("objects", []) as Array).size(),
 	])
 	quit(0)
+
+
+## The production screen on a real map, with every effect sprite running at
+## once. Each is started through the same call the game makes, so what is
+## photographed is the renderer's own path rather than a drawing of it.
+func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> void:
+	root.set_content_scale_size(WINDOW_SIZE)
+	root.size = WINDOW_SIZE
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_screen = packed.instantiate() as Gen2WorldScreen
+	_screen.map_group = group
+	_screen.map_number = number
+	if cell.x >= 0:
+		_screen.start_cell = cell
+	## Pinned so two captures of the same map are the same picture: the seed the
+	## screen resolves is what a wandering NPC's own generator is built from.
+	_screen.encounter_seed = 1
+	_screen.set_data(data)
+	root.add_child(_screen)
+	current_scene = _screen
+	## The screen counts hardware frames off wall-clock delta, so a capture that
+	## let it run would photograph a different frame of each animation every
+	## time. It owns none of them here: the staged frames below are spent by
+	## hand.
+	_screen.set_process(false)
+
+
+func _process(_delta: float) -> bool:
+	if _screen == null:
+		return false
+	_frames += 1
+	if _frames == 2:
+		_screen.preview_effect_sprites()
+		for _frame: int in STAGED_FRAMES:
+			_screen.advance_frame()
+	if _frames < 18:
+		return false
+	var image: Image = root.get_texture().get_image()
+	var error: Error = image.save_png(_output_path)
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [_output_path, error])
+		quit(1)
+		return true
+	print("Wrote %s (%dx%d)" % [_output_path, image.get_width(), image.get_height()])
+	quit(0)
+	return true
 
 
 func _render(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Image:

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -31,7 +31,10 @@ const GROUPS: Dictionary = {
 		&"vermilion", &"saffron", &"celadon", &"cerulean", &"lavender", &"fuchsia",
 		&"pewter", &"cinnabar", &"radio", &"elite_four", &"ss_aqua", &"mt_silver",
 	],
-	&"art": [&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims"],
+	&"art": [
+		&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims",
+		&"overworld_effects",
+	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack",


### PR DESCRIPTION
The emote bubble was a hand-drawn placeholder and Strength's dust, the tall-grass
rustle and the headbutt tree were not drawn at all. This imports the twelve-entry
`Emotes` table and `ShakeHeadbuttTree`'s own sheet, and gives the world renderer
the sprites the engine draws over an object rather than as one.

`Gen2WorldEffects` holds them beside the screen shake it already owned, each with
the source's own frameset:

| Sprite | Source | Frames |
|---|---|---|
| Headbutt tree | `ShakeHeadbuttTree`, `.Frameset_HeadbuttTree` | 32, four `oamframe`s of three, tree tiles replaced by grass underneath |
| Grass rustle | `ShakeGrass`, `SetFacingGrassShake` | the step's duration less one, two facings swapping every four |
| Boulder dust | `SpawnStrengthBoulderDust`, `SetFacingBoulderDust` | `(push + 1) * 2`, two tiles alternating on bit 1 |
| Emote | `SpawnEmote`, `FacingEmote` | four tiles two rows above the object |

An object standing in grass draws its lower half behind it, which is what
`IN_GRASS_F` and the `OAM_PRIO` on the two `RELATIVE_ATTRIBUTES` tiles amount to.

Two bugs met on the way, fixed here. Movement command `$56` was modelled as a
32-frame screen shake; `Movement_tree_shake` shakes nothing but the object
itself, for 24 frames of `OBJECT_ACTION_WEIRD_TREE`. And `HeadbuttScript` spends
`ShakeHeadbuttTree`'s frames before `callasm TreeMonEncounter`, so the roll's
result now waits for the animation rather than opening a battle over it.

Two previews stopped photographing a different picture each run: they take the
screen's processing away and pin the run seed, so a wandering NPC cannot move
between two captures of the same map.

Cache format 52.

| Check | Result |
|---|---|
| Import, three cartridges | 3/3, `layout: Layout verified.` on each |
| GUT, unit tier | 2,507 passing |
| GUT, with scene integration | 2,832 passing over 148 scripts |
| `validate.gd -- all` | exit 0, new `overworld_effects` topic: 13 sheets byte identical across the three |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | Red reached on gold, silver and crystal, 0 failures |