### PR TITLE
Draw Cut's animation, the ledge hop's arc and the fishing rod

### DIFF
--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -65,7 +65,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 52
+const FORMAT_VERSION: int = 53
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1574,10 +1574,11 @@ const GOLD_SILVER: Dictionary = {
 	"overworld_sprite_palettes": 0xB8AE,
 	"overworld_icons": 0x8EABE,
 	"emotes": 0x143C1,
-	## ShakeHeadbuttTree's eight-tile sheet. CutTreeGFX and CutGrassGFX follow it
-	## in the same bank; neither is imported because nothing draws Cut's own
-	## animation yet.
+	## The three sheets engine/events/field_moves.asm loads by name.
+	## CutGrassGFX follows CutTreeGFX, so one wrong offset shows on both.
 	"headbutt_tree_gfx": 0x8CB0B,
+	"cut_tree_gfx": 0x8CC04,
+	"cut_grass_gfx": 0x8CC44,
 	"mart_table": 0x162FE,
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
@@ -1888,6 +1889,8 @@ const CRYSTAL: Dictionary = {
 	"overworld_icons": 0x8EC0D,
 	"emotes": 0x1444D,
 	"headbutt_tree_gfx": 0x8C893,
+	"cut_tree_gfx": 0x8C98C,
+	"cut_grass_gfx": 0x8C9CC,
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -482,10 +482,23 @@ const EMOTE_TILE_LAYOUT: Array = [
 	[1, 0xFC], [2, 0xFC], [2, 0xFE], [1, 0xFE],
 ]
 
-## HeadbuttTreeGFX's first tile row. The sheet has no table to pin it, and a
-## wrong offset in this bank decodes the routine beside it as art.
-const HEADBUTT_TREE_TILES: int = 8
-const HEADBUTT_TREE_SIGNATURE: Array = [0x01, 0x01, 0x02, 0x02, 0x02, 0x02, 0x07, 0x04]
+## The three sheets `engine/events/field_moves.asm` loads by name rather than
+## through a table: name, layout key, tiles, the tile they are loaded to, and the
+## first tile row each one starts with. None has a table to pin it, and a wrong
+## offset in this bank decodes the routine beside it as legal-looking art, so the
+## signature is the check. CutTreeGFX and CutGrassGFX are adjacent, which is what
+## makes one wrong offset show up on two sheets.
+const FIELD_MOVE_SHEETS: Array = [
+	## FIELDMOVE_TREE, which ShakeHeadbuttTree and Cut_SpawnAnimateTree write
+	## into the struct's own tile field rather than reading from a table.
+	["headbutt_tree", "headbutt_tree_gfx", 8, 0x84,
+		[0x01, 0x01, 0x02, 0x02, 0x02, 0x02, 0x07, 0x04]],
+	["cut_tree", "cut_tree_gfx", 4, 0x84,
+		[0x00, 0x00, 0x00, 0x00, 0x28, 0x28, 0x54, 0x7C]],
+	## FIELDMOVE_GRASS, the leaves' own tile.
+	["cut_grass", "cut_grass_gfx", 4, 0x80,
+		[0x00, 0x00, 0x3C, 0x3C, 0x7E, 0x42, 0xE3, 0x9D]],
+]
 
 static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var table: int = int(layout.get("emotes", -1))
@@ -520,25 +533,26 @@ static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Diction
 			"bytes": Array(pixels),
 		})
 
-	var headbutt: int = int(layout.get("headbutt_tree_gfx", -1))
-	var headbutt_bytes: int = HEADBUTT_TREE_TILES * Gen2Tiles.TILE_BYTES
-	if not rom.in_bounds(headbutt, headbutt_bytes):
-		return _error("Headbutt tree graphics are outside the cartridge.")
-	if Array(rom.slice(headbutt, HEADBUTT_TREE_SIGNATURE.size())) != HEADBUTT_TREE_SIGNATURE:
-		return _error("Headbutt tree graphics do not start with the sheet's first row.")
-	var headbutt_pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
-		rom.slice(headbutt, headbutt_bytes), 0, HEADBUTT_TREE_TILES
-	)
-	if headbutt_pixels.size() != HEADBUTT_TREE_TILES * Gen2Tiles.TILE_PIXELS:
-		return _error("Headbutt tree graphics did not decode.")
-	effects.append({
-		"name": "headbutt_tree",
-		"tiles": HEADBUTT_TREE_TILES,
-		## FIELDMOVE_TREE, which ShakeHeadbuttTree writes into the struct's own
-		## tile field rather than reading from a table.
-		"vtile": 0x84,
-		"bytes": Array(headbutt_pixels),
-	})
+	for sheet: Array in FIELD_MOVE_SHEETS:
+		var name: String = String(sheet[0])
+		var offset: int = int(layout.get(String(sheet[1]), -1))
+		var sheet_tiles: int = int(sheet[2])
+		var signature: Array = sheet[4]
+		if not rom.in_bounds(offset, sheet_tiles * Gen2Tiles.TILE_BYTES):
+			return _error("%s graphics are outside the cartridge." % name)
+		if Array(rom.slice(offset, signature.size())) != signature:
+			return _error("%s graphics do not start with the sheet's first row." % name)
+		var sheet_pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+			rom.slice(offset, sheet_tiles * Gen2Tiles.TILE_BYTES), 0, sheet_tiles
+		)
+		if sheet_pixels.size() != sheet_tiles * Gen2Tiles.TILE_PIXELS:
+			return _error("%s graphics did not decode." % name)
+		effects.append({
+			"name": name,
+			"tiles": sheet_tiles,
+			"vtile": int(sheet[3]),
+			"bytes": Array(sheet_pixels),
+		})
 	return {"ok": true, "effects": effects}
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -217,6 +217,9 @@ var _player_step_frames_total: int = 0
 var _player_step_frames_remaining: int = 0
 ## Gen2WorldObject.step_began for the player.
 var _player_step_began: bool = false
+## Whether the step in flight is a ledge hop, which is the only one the source
+## gives a jump arc. See player_jump_offset().
+var _player_jumping: bool = false
 ## The rest of a scripted movement stream the player still has to be drawn
 ## walking, the way Gen2WorldObject.queued_steps holds an object's.
 var _player_queued_steps: Array = []
@@ -473,6 +476,25 @@ func player_step_in_progress() -> bool:
 	return _player_step_frames_remaining > 0
 
 
+## `UpdateJumpPosition`'s `.y_offsets`: the pixel a jumping sprite is drawn above
+## its own cell, one entry per frame of the hop. The accumulator the source
+## indexes it with is stepped by the step vector and halved, which over a hop's
+## two STEP_WALK halves is one entry a frame.
+const JUMP_OFFSETS: Array[int] = [
+	-4, -6, -8, -10, -11, -12, -12, -12, -11, -10, -9, -8, -6, -4, 0, 0,
+]
+
+
+## How far above its cell the player is drawn this frame, zero unless a ledge hop
+## is in flight. Presentation only: `player_cell` committed to the landing cell
+## when the hop started.
+func player_jump_offset() -> int:
+	if not _player_jumping or _player_step_frames_total <= 0:
+		return 0
+	var spent: int = _player_step_frames_total - _player_step_frames_remaining
+	return JUMP_OFFSETS[clampi(spent, 0, JUMP_OFFSETS.size() - 1)]
+
+
 ## The in-flight walk step's presentation offset in fractional walk cells,
 ## from 1.0 cell behind player_cell down to zero, so a renderer that does not
 ## think in hardware pixels (a 3D or free-roam mod) can still smooth against
@@ -526,6 +548,7 @@ func _begin_player_step(direction: Vector2i, frames: int) -> void:
 
 func _clear_player_step() -> void:
 	_player_step_began = false
+	_player_jumping = false
 	_player_step_direction = Vector2i.ZERO
 	_player_step_frames_total = 0
 	_player_step_frames_remaining = 0
@@ -639,7 +662,13 @@ func fishing_busy() -> bool:
 
 
 func facing_cell() -> Vector2i:
-	return player_cell + _direction_for_facing(player_facing)
+	return player_cell + facing_direction()
+
+
+## The unit step the player's own facing points at, which is what every table
+## keyed by `wPlayerDirection` is indexed by.
+func facing_direction() -> Vector2i:
+	return _direction_for_facing(player_facing)
 
 
 ## The cell CheckFacingObject searches, which is the faced one doubled away when
@@ -4440,6 +4469,7 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	state.consume_repel_step()
 	_advance_followers(from_cell, previous_cells)
 	_start_player_step(direction * 2, STEP_FRAMES_HOP)
+	_player_jumping = true
 	return {
 		"ok": true,
 		"kind": &"ledge_hop",

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -7,9 +7,9 @@ extends RefCounted
 ##
 ## Two shapes live here. `ShakeScreen` is one packed byte of duration and
 ## amplitude. The rest are the sprites the engine draws over the map rather than
-## as map objects: `SpawnStrengthBoulderDust`, `ShakeGrass` and
-## `ShakeHeadbuttTree`, each its own frameset over one of the sheets
-## GameData.overworld_effect() holds.
+## as map objects: `SpawnStrengthBoulderDust`, `ShakeGrass`, `ShakeHeadbuttTree`,
+## `OWCutAnimation` and `SpawnShadow`, each its own frameset over one of the
+## sheets GameData.overworld_effect() holds.
 
 var _frame: int = 0
 var _duration: int = 0
@@ -18,10 +18,13 @@ var _kind: StringName = &"none"
 var _source: Dictionary = {}
 var _sprites: Array = []
 
-## The three effect sprites, by the sheet each draws from.
+## The effect sprites, each named for the sheet it draws from.
 const SPRITE_BOULDER_DUST: StringName = &"boulder_dust"
 const SPRITE_GRASS_RUSTLE: StringName = &"grass_rustle"
 const SPRITE_HEADBUTT_TREE: StringName = &"headbutt_tree"
+const SPRITE_CUT_TREE: StringName = &"cut_tree"
+const SPRITE_CUT_LEAF: StringName = &"cut_grass"
+const SPRITE_SHADOW: StringName = &"shadow"
 
 ## constants/sprite_data_constants.asm. Every emote-object spawn names its
 ## palette: PAL_OW_EMOTE for the dust and the emote bubbles, PAL_OW_TREE for the
@@ -29,8 +32,64 @@ const SPRITE_HEADBUTT_TREE: StringName = &"headbutt_tree"
 const PAL_OW_EMOTE: int = 5
 const PAL_OW_TREE: int = 6
 
-## ShakeHeadbuttTree's `ld a, 32 / ld [wFrameCounter], a`.
+## ShakeHeadbuttTree's `ld a, 32 / ld [wFrameCounter], a`, and OWCutAnimation's
+## own, which both branches of its jumptable write.
 const HEADBUTT_TREE_FRAMES: int = 32
+const CUT_FRAMES: int = 32
+
+## `.Frameset_CutTree`, as [first frame, tile offsets] pairs. `oamframe X, n`
+## lasts n + 1 frames and `oamwait n` draws nothing for n + 1, which is what puts
+## the two gaps in: the tree stands for three frames, splits for seventeen, and
+## then its halves slide apart in two steps of two. `oamdelete` ends it four
+## frames before the counter does.
+const CUT_TREE_STEPS: Array = [
+	[0, [Vector2i(0, 0), Vector2i(8, 0), Vector2i(0, 8), Vector2i(8, 8)]],
+	[3, [Vector2i(-2, 0), Vector2i(10, 0), Vector2i(-2, 8), Vector2i(10, 8)]],
+	[20, []],
+	[22, [Vector2i(-4, 0), Vector2i(12, 0), Vector2i(-4, 8), Vector2i(12, 8)]],
+	[24, []],
+	[26, [Vector2i(-8, 0), Vector2i(16, 0), Vector2i(-8, 8), Vector2i(16, 8)]],
+	[28, []],
+]
+
+## `Cut_GetLeafSpawnCoords`, as pixel offsets from where the player is drawn.
+## Its own table is screen coordinates, indexed by the facing and then by which
+## quarter of the block the player stands in, because Cut clears the whole block
+## and the leaves are spawned over it. Order is the source's: DOWN, UP, LEFT,
+## RIGHT, each with top-left, top-right, bottom-left, bottom-right.
+const CUT_LEAF_ORIGINS: Array[Vector2i] = [
+	Vector2i(16, 16), Vector2i(0, 16), Vector2i(16, 32), Vector2i(0, 32),
+	Vector2i(16, -16), Vector2i(0, -16), Vector2i(16, 0), Vector2i(0, 0),
+	Vector2i(-16, 16), Vector2i(0, 16), Vector2i(-16, 0), Vector2i(0, 0),
+	Vector2i(16, 16), Vector2i(32, 16), Vector2i(16, 0), Vector2i(32, 0),
+]
+
+## `Cut_SpawnAnimateLeaves` spawns four leaves an eighth of a turn apart, and
+## `SpriteAnimFunc_CutLeaves` steps each angle by three a frame while the radius
+## it is multiplied by grows by half a pixel.
+const CUT_LEAF_ANGLES: Array[int] = [0x00, 0x10, 0x20, 0x30]
+const CUT_LEAF_ANGLE_STEP: int = 3
+const CUT_LEAF_RADIUS_STEP: int = 0x80
+## `.OAMData_Leaf`'s single `dbsprite -1, -1, 4, 4`.
+const CUT_LEAF_OFFSET := Vector2i(-4, -4)
+
+## The rod tile `FacingFishDown` and its three siblings add to the player's own
+## four, in Gen2WorldSprite's DOWN, UP, LEFT, RIGHT order: offset, which of the
+## two rod tiles, and whether it is mirrored. The player picture itself is the
+## standing one, so the rod is the whole difference.
+const FISHING_ROD_TILES: Array = [
+	{"offset": Vector2i(0, 16), "tile": 0, "flip_x": false},
+	{"offset": Vector2i(0, -8), "tile": 0, "flip_x": false},
+	{"offset": Vector2i(-8, 5), "tile": 1, "flip_x": true},
+	{"offset": Vector2i(16, 5), "tile": 1, "flip_x": false},
+]
+
+
+## `MovementFunction_Shadow`: y offset 14 along the axis the jump is on and 12
+## across it, x offset zero, in the source's DOWN, UP, LEFT, RIGHT order.
+const SHADOW_OFFSETS: Array[Vector2i] = [
+	Vector2i(0, 14), Vector2i(0, 14), Vector2i(0, 12), Vector2i(0, 12),
+]
 
 ## `MovementFunction_BoulderDust`'s `.dust_coords`, indexed by the boulder's own
 ## walking direction in the source's DOWN, UP, LEFT, RIGHT order.
@@ -60,6 +119,57 @@ func start_headbutt_tree(cell: Vector2i) -> void:
 		"palette": PAL_OW_TREE,
 		"frame": 0,
 		"duration": HEADBUTT_TREE_FRAMES,
+	})
+
+
+## `OWCutAnimation`, over the cell the block being cut is faced from. Index 0 is
+## the splitting tree and index 1 the four leaves (`Gen2WorldFieldMove`'s
+## ANIMATION_TREE and ANIMATION_GRASS), which is the byte
+## `CheckOverworldTileArrays` returns beside the replacement block.
+##
+## [param player_cell] is where the player stands, which is what picks the
+## leaves' own corner of the block.
+func start_cut(
+	cell: Vector2i, animation: int, direction: Vector2i, player_cell: Vector2i
+) -> void:
+	if animation == 0:
+		_sprites.append({
+			"kind": SPRITE_CUT_TREE,
+			"cell": cell,
+			"object_index": -2,
+			"palette": PAL_OW_TREE,
+			"frame": 0,
+			"duration": CUT_FRAMES,
+		})
+		return
+	var origin: Vector2i = CUT_LEAF_ORIGINS[
+		_direction_index(direction) * 4 + (player_cell.x & 1) + (player_cell.y & 1) * 2
+	]
+	for angle: int in CUT_LEAF_ANGLES:
+		_sprites.append({
+			"kind": SPRITE_CUT_LEAF,
+			"cell": cell,
+			"object_index": -1,
+			"palette": PAL_OW_TREE,
+			"frame": 0,
+			"duration": CUT_FRAMES,
+			"origin": origin,
+			"angle": angle,
+		})
+
+
+## `SpawnShadow`, under a jumping object for twice the jump it was spawned in.
+## Tracks whoever is jumping, and sits below them because the jump is an offset
+## on the sprite alone.
+func start_jump_shadow(object_index: int, cell: Vector2i, direction: Vector2i, step_frames: int) -> void:
+	_sprites.append({
+		"kind": SPRITE_SHADOW,
+		"cell": cell,
+		"object_index": object_index,
+		"palette": PAL_OW_EMOTE,
+		"frame": 0,
+		"duration": (int(float(maxi(0, step_frames)) / 2.0) + 1) * 2,
+		"direction": _direction_index(direction),
 	})
 
 
@@ -184,7 +294,7 @@ func snapshot() -> Dictionary:
 
 ## One sprite's tiles this frame: [{ offset, tile, flip_x }], where `tile` is an
 ## index into the sheet the kind names.
-static func _tiles_for(sprite: Dictionary) -> Array:
+func _tiles_for(sprite: Dictionary) -> Array:
 	var frame: int = int(sprite["frame"])
 	match StringName(sprite["kind"]):
 		SPRITE_HEADBUTT_TREE:
@@ -215,6 +325,39 @@ static func _tiles_for(sprite: Dictionary) -> Array:
 				{"offset": Vector2i(-1, 9), "tile": 0, "flip_x": false},
 				{"offset": Vector2i(9, 9), "tile": 0, "flip_x": true},
 			]
+		SPRITE_CUT_TREE:
+			## The frameset's own steps, held until the next one starts and gone
+			## once `oamdelete` is reached.
+			var tree: Array = []
+			for step: Array in CUT_TREE_STEPS:
+				if frame < int(step[0]):
+					break
+				tree = step[1]
+			var cut: Array = []
+			for index: int in tree.size():
+				cut.append({"offset": tree[index], "tile": index, "flip_x": false})
+			return cut
+		SPRITE_CUT_LEAF:
+			## `SpriteAnimFunc_CutLeaves`: the leaf sits on a circle whose angle
+			## steps by three a frame and whose radius is the high byte of a
+			## sixteen-bit accumulator growing by $80, so it widens every second
+			## frame. `AnimSeqs_Sine` is the y offset and `AnimSeqs_Cosine` the x.
+			var radius: int = int(float(frame * CUT_LEAF_RADIUS_STEP) / 256.0)
+			var angle: int = (int(sprite["angle"]) + frame * CUT_LEAF_ANGLE_STEP) & 0xFF
+			return [{
+				"offset": (sprite["origin"] as Vector2i) + CUT_LEAF_OFFSET + Vector2i(
+					_signed(_cosine(angle, radius)), _signed(_sine(angle, radius))
+				),
+				"tile": 0,
+				"flip_x": false,
+			}]
+		SPRITE_SHADOW:
+			## `FacingShadow`: one tile drawn twice, the second mirrored.
+			var at: Vector2i = SHADOW_OFFSETS[int(sprite.get("direction", 0))]
+			return [
+				{"offset": at, "tile": 0, "flip_x": false},
+				{"offset": at + Vector2i(8, 0), "tile": 0, "flip_x": true},
+			]
 		SPRITE_BOULDER_DUST:
 			## `SetFacingBoulderDust` swaps FACING_BOULDER_DUST_1 and _2 on bit 1
 			## of the step frame, and each draws its one tile four times in a
@@ -230,6 +373,35 @@ static func _tiles_for(sprite: Dictionary) -> Array:
 				})
 			return dust
 	return []
+
+
+## `BattleAnim_Sine` and `..._Cosine` over `BattleAnimSineWave`, which is what
+## `AnimSeqs_Sine` reaches. The table is cartridge data rather than a derivation
+## (entry 16 is $0100), so a caller with no cache draws no leaves rather than
+## drawing them on a table of its own.
+var _sine_table: Gen2BattleAnimData = null
+
+
+## Hands this the sine table the cut leaves ride on. Called once by the screen
+## that owns the effects; nothing else here needs a cache.
+func set_sine_table(sine: Gen2BattleAnimData) -> void:
+	_sine_table = sine
+
+
+func _sine(angle: int, amplitude: int) -> int:
+	return Gen2BattleAnimFunctions.sine_of(_sine_table, angle, amplitude) \
+		if _sine_table != null else 0
+
+
+func _cosine(angle: int, amplitude: int) -> int:
+	return Gen2BattleAnimFunctions.cosine_of(_sine_table, angle, amplitude) \
+		if _sine_table != null else 0
+
+
+## A sprite offset is a byte the cartridge adds; a renderer drawing at a signed
+## pixel needs the same byte read as a two's complement offset.
+static func _signed(value: int) -> int:
+	return value - 0x100 if value >= 0x80 else value
 
 
 ## The source's DOWN, UP, LEFT, RIGHT order, which is what `.dust_coords` is

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -190,14 +190,19 @@ func _draw() -> void:
 		_draw_effect_sprites(object.index, pixel)
 
 	var player: Vector2 = Vector2(_world.player_pixel_position())
+	## The jump arc is a sprite offset, not a position: the shadow and the grass
+	## the hop leaves behind stay on the ground.
+	var jump: Vector2 = Vector2(0, _world.player_jump_offset())
 	var player_texture: Texture2D = _actor_texture(
 		_world.player_sprite(), _world.player_palette(), _world.player_facing,
 		_world.player_walk_frame()
 	)
 	if player_texture != null:
-		draw_texture(player_texture, player)
+		draw_texture(player_texture, player + jump)
 		if _in_grass(_world.player_cell):
-			_draw_grass_over(player, page, tile_origin, tile_offset, window_size)
+			_draw_grass_over(player + jump, page, tile_origin, tile_offset, window_size)
+		if _world.fishing_busy():
+			_draw_fishing_rod(player + jump)
 	else:
 		var marker := Rect2(Vector2(player.x, player.y), Vector2(16, 16))
 		draw_rect(marker, PLAYER_COLOR, false, 1.0)
@@ -329,6 +334,21 @@ func _build_priority_atlas() -> void:
 			if int(_priority_indices[y * width + x]) == 0:
 				image.set_pixel(x, y, Color(0, 0, 0, 0))
 	_priority_atlas = ImageTexture.create_from_image(image)
+
+
+## `FacingFishDown` and its three siblings: the standing player plus one tile of
+## the rod sheet, which is what `Script_FishCastRod`'s `fish_cast_rod` puts up
+## and `PutTheRodAway` takes down.
+func _draw_fishing_rod(pixel: Vector2) -> void:
+	var sheet: Dictionary = _effect_sheet("rod")
+	if sheet.is_empty():
+		return
+	var facing: int = clampi(_world.player_facing, 0, Gen2WorldEffects.FISHING_ROD_TILES.size() - 1)
+	var tile: Dictionary = Gen2WorldEffects.FISHING_ROD_TILES[facing]
+	_draw_effect_tile(
+		sheet, int(tile["tile"]), Gen2WorldEffects.PAL_OW_EMOTE, bool(tile["flip_x"]),
+		pixel + Vector2(tile["offset"] as Vector2i),
+	)
 
 
 func _effect_sprites() -> Array:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -225,6 +225,9 @@ func _build_world() -> void:
 	time_of_day = _clock.time_of_day()
 	_animation = Gen2WorldAnimation.new()
 	_effects = Gen2WorldEffects.new()
+	## The cut leaves ride BattleAnimSineWave, which is cartridge data rather
+	## than a table this could derive.
+	_effects.set_sine_table(Gen2BattleAnimData.from_game_data(_data))
 	_world.set_world_clock(initial_day, initial_hour, initial_minute)
 	_world.set_object_time(initial_hour, time_of_day)
 	var rods: Array[StringName] = _world.available_fishing_rods()
@@ -812,6 +815,13 @@ func move_player(direction: Vector2i) -> bool:
 func _after_player_move(movement: Dictionary) -> bool:
 	if movement.get("kind", &"") == &"ledge_hop":
 		_play_ledge_hop_sfx()
+		if _effects != null:
+			## `JumpStep` spawns the shadow where the hop starts, and it tracks
+			## the player over both cells of it.
+			_effects.start_jump_shadow(
+				-1, _world.player_cell, _world.facing_direction(),
+				Gen2WorldAPI.STEP_FRAMES_HOP,
+			)
 	## .ExitWater calls PlayMapMusic before the step, which is what drops the
 	## surfing track once the player is walking again.
 	if movement.get("kind", &"") == &"exit_water":
@@ -981,12 +991,27 @@ func _update_time_of_day() -> void:
 		_renderer.set_time_of_day(_render_time_of_day())
 
 
-## Public screenshot driver for every sprite the engine draws over an object
-## rather than as one: the scripted emote, `SpawnStrengthBoulderDust`,
-## `ShakeGrass` and `ShakeHeadbuttTree`. Each is started through the call the
-## game makes, so this photographs the renderer's own path.
-func preview_effect_sprites() -> void:
+## Public screenshot driver for the sprites the engine draws over an object
+## rather than as one. `effects` is the scripted emote, `SpawnStrengthBoulderDust`,
+## `ShakeGrass` and `ShakeHeadbuttTree`; `cut` is `OWCutAnimation`'s two halves
+## and the jump shadow. Each is started through the call the game makes, so this
+## photographs the renderer's own path.
+func preview_effect_sprites(kind: StringName = &"effects") -> void:
 	if _world == null or _renderer == null:
+		return
+	if kind == &"cut":
+		if _effects != null:
+			## Both halves of `OWCutAnimation` at once, over the cell Cut would
+			## clear, plus the shadow `JumpStep` spawns under a ledge hop.
+			_effects.start_cut(_world.facing_cell(), 0, _world.facing_direction(), _world.player_cell)
+			_effects.start_cut(_world.facing_cell(), 1, _world.facing_direction(), _world.player_cell)
+			_effects.start_jump_shadow(
+				-1, _world.player_cell, _world.facing_direction(),
+				Gen2WorldAPI.STEP_FRAMES_HOP,
+			)
+		_script_prompt = "Debug cut animation preview"
+		_renderer.refresh()
+		_refresh_labels()
 		return
 	if _effects != null:
 		_effects.start_headbutt_tree(_world.player_cell + Vector2i(1, 0))
@@ -2369,7 +2394,16 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 			&"rock_smash_applied":
 				_play_sfx(SFX_STRENGTH)
 			_:
+				## `OWCutAnimation` plays it, which is why the sound and the
+				## animation start together.
 				_play_sfx(SFX_CUT)
+				if _effects != null and StringName(applied.get("kind", &"")) == &"cut_applied":
+					_effects.start_cut(
+						applied.get("cell", Vector2i.ZERO),
+						int(applied.get("animation", 0)),
+						_world.facing_direction(),
+						_world.player_cell,
+					)
 		if _renderer != null:
 			_renderer.refresh()
 		_script_prompt = label

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -846,6 +846,25 @@ func test_ledge_hop_crosses_two_cells_after_an_ordinary_step_is_blocked() -> voi
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 
 
+## `UpdateJumpPosition`'s own `.y_offsets`, spent one entry per frame of the
+## hop: the sprite rises to twelve pixels above its cell and is back on it two
+## frames before the step ends. An ordinary walk has no arc at all.
+func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(3, 2))
+	assert_eq(world.player_jump_offset(), 0, "standing still is on the ground")
+	assert_eq(world.move_result(Vector2i.DOWN)["kind"], &"ledge_hop")
+	var arc: Array = []
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_HOP:
+		arc.append(world.player_jump_offset())
+		world.advance_player_step_frame()
+	assert_eq(arc, Gen2WorldAPI.JUMP_OFFSETS)
+	assert_eq(world.player_jump_offset(), 0, "and the arc ends with the step")
+
+	var walker: Gen2WorldAPI = _world(Vector2i(5, 11))
+	assert_true(bool(walker.move_result(Vector2i.UP).get("ok", false)))
+	assert_eq(walker.player_jump_offset(), 0)
+
+
 func test_ledge_hop_refuses_a_direction_the_code_does_not_allow() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(3, 2))
 	assert_false(world.can_walk_to(Vector2i(2, 2)))

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -83,3 +83,77 @@ func test_boulder_dust_takes_its_offset_from_the_push_direction() -> void:
 	assert_true(effects.sprites_active())
 	effects.advance_frame()
 	assert_false(effects.sprites_active())
+
+
+## `.Frameset_CutTree` splits the tree and slides the halves apart, and its
+## `oamdelete` ends the sprite four frames before OWCutAnimation's own counter.
+func test_the_cut_tree_splits_and_then_deletes_itself() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_cut(Vector2i(3, 3), 0, Vector2i.DOWN, Vector2i(2, 3))
+	var sprite: Dictionary = effects.sprites()[0]
+	assert_eq(sprite["kind"], Gen2WorldEffects.SPRITE_CUT_TREE)
+	assert_eq((sprite["tiles"][0] as Dictionary)["offset"], Vector2i(0, 0),
+		"the first three frames are the tree standing")
+	for _frame: int in 3:
+		effects.advance_frame()
+	assert_eq(
+		((effects.sprites()[0] as Dictionary)["tiles"][0] as Dictionary)["offset"],
+		Vector2i(-2, 0),
+	)
+	for _frame: int in 17:
+		effects.advance_frame()
+	assert_true((effects.sprites()[0] as Dictionary)["tiles"].is_empty(),
+		"oamwait draws nothing at all")
+	for _frame: int in 8:
+		effects.advance_frame()
+	assert_true((effects.sprites()[0] as Dictionary)["tiles"].is_empty(),
+		"and oamdelete is four frames before the counter runs out")
+	for _frame: int in 4:
+		effects.advance_frame()
+	assert_false(effects.sprites_active())
+
+
+## `Cut_SpawnAnimateLeaves` spawns four leaves an eighth of a turn apart over the
+## quarter of the block the player stands in, and each spirals outwards.
+func test_cut_leaves_spawn_four_deep_and_spiral() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.set_sine_table(Gen2BattleAnimData.create({}, [], _sine_bytes()))
+	effects.start_cut(Vector2i(3, 3), 1, Vector2i.DOWN, Vector2i(2, 3))
+	var sprites: Array = effects.sprites()
+	assert_eq(sprites.size(), 4)
+	var first: Dictionary = (sprites[0] as Dictionary)["tiles"][0]
+	## Facing down, an even x and an odd y is the block's bottom left.
+	assert_eq(first["offset"], Vector2i(16, 32) + Vector2i(-4, -4),
+		"a leaf opens at its own corner with no radius yet")
+	var offsets: Array = []
+	for _frame: int in 8:
+		effects.advance_frame()
+		offsets.append(((effects.sprites()[0] as Dictionary)["tiles"][0] as Dictionary)["offset"])
+	assert_true(offsets[7] != offsets[0], "the radius grows every second frame")
+	assert_eq(effects.sprites().size(), 4, "all four last the whole animation")
+
+
+## `SpawnShadow` from `JumpStep`: one tile drawn twice under whoever is jumping,
+## for twice the half-hop it was spawned in.
+func test_a_jump_shadow_is_two_mirrored_tiles_under_the_jumper() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_jump_shadow(-1, Vector2i(4, 4), Vector2i.DOWN, Gen2WorldAPI.STEP_FRAMES_HOP)
+	var sprite: Dictionary = effects.sprites()[0]
+	assert_eq(sprite["kind"], Gen2WorldEffects.SPRITE_SHADOW)
+	assert_eq(sprite["tiles"].size(), 2)
+	assert_eq((sprite["tiles"][0] as Dictionary)["offset"], Vector2i(0, 14))
+	assert_true(bool((sprite["tiles"][1] as Dictionary)["flip_x"]))
+	for _frame: int in 17:
+		effects.advance_frame()
+	assert_true(effects.sprites_active(), "(8 + 1) * 2 frames, so it outlasts the hop")
+	effects.advance_frame()
+	assert_false(effects.sprites_active())
+
+
+## `BattleAnimSineWave` as the cartridge stores it, which is what a leaf's
+## offsets are read out of rather than derived from.
+func _sine_bytes() -> PackedByteArray:
+	var out := PackedByteArray()
+	for value: int in RomLayout.BATTLE_ANIM_SINE_WAVE:
+		out.append(value)
+	return out

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -22,7 +22,8 @@ const EXPECTED: Array = [
 	["shock", 4, 0xF8], ["question", 4, 0xF8], ["happy", 4, 0xF8], ["sad", 4, 0xF8],
 	["heart", 4, 0xF8], ["bolt", 4, 0xF8], ["sleep", 4, 0xF8], ["fish", 4, 0xF8],
 	["shadow", 1, 0xFC], ["rod", 2, 0xFC], ["boulder_dust", 2, 0xFE],
-	["grass_rustle", 1, 0xFE], ["headbutt_tree", 8, 0x84],
+	["grass_rustle", 1, 0xFE], ["headbutt_tree", 8, 0x84], ["cut_tree", 4, 0x84],
+	["cut_grass", 4, 0x80],
 ]
 
 var _first: Dictionary = {}

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -10,20 +10,25 @@ extends SceneTree
 ## tree. That mode drives the screen's own path and needs a display, so it runs
 ## without `--headless`:
 ##
-##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/effects.png live 6 10
+##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y]
 ##
-## The two optional numbers are the cell the player stands on, which is how the
-## grass a standing object is drawn behind is photographed.
+## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree) or
+## `cut` (`OWCutAnimation`'s two halves and the jump shadow). The two numbers are
+## the cell the player stands on, which is how the grass a standing object is
+## drawn behind is photographed.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Hardware frames spent after the sprites are staged. Two puts the grass rustle
 ## on its first facing and the boulder dust on its second, so every one of them
-## is up and none is on the frame it was spawned.
+## is up and none is on the frame it was spawned. Cut needs more: its tree stands
+## for three frames before it splits, and its leaves open on top of each other.
 const STAGED_FRAMES: int = 2
+const STAGED_FRAMES_CUT: int = 12
 
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
 var _frames: int = 0
+var _kind: StringName = &"effects"
 
 
 func _initialize() -> void:
@@ -40,9 +45,10 @@ func _initialize() -> void:
 			quit(1)
 			return
 		_output_path = args[3]
+		_kind = StringName(args[5]) if args.size() >= 6 else &"effects"
 		_build_live(
 			data, int(args[1]), int(args[2]),
-			Vector2i(int(args[5]), int(args[6])) if args.size() >= 7 else Vector2i(-1, -1),
+			Vector2i(int(args[6]), int(args[7])) if args.size() >= 8 else Vector2i(-1, -1),
 		)
 		return
 	var map: Gen2WorldMap = data.world_map(int(args[1]), int(args[2])) if data != null else null
@@ -97,8 +103,8 @@ func _process(_delta: float) -> bool:
 		return false
 	_frames += 1
 	if _frames == 2:
-		_screen.preview_effect_sprites()
-		for _frame: int in STAGED_FRAMES:
+		_screen.preview_effect_sprites(_kind)
+		for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
 			_screen.advance_frame()
 	if _frames < 18:
 		return false


### PR DESCRIPTION
The three sheets `engine/events/field_moves.asm` loads by name are now all
imported and all drawn, which closes the last of the overworld's effect sprites.

| Animation | Source | What it does |
|---|---|---|
| Cut, tree | `Cut_SpawnAnimateTree`, `.Frameset_CutTree` | stands for three frames, splits for seventeen, then slides its halves apart in two steps, `oamdelete` four frames before the counter |
| Cut, leaves | `Cut_SpawnAnimateLeaves`, `SpriteAnimFunc_CutLeaves` | four leaves an eighth of a turn apart, angle +3 a frame, radius +$80, over the quarter of the block the player stands in |
| Ledge hop | `UpdateJumpPosition` | sixteen y offsets lifting the sprite while its cell stays where it committed |
| Jump shadow | `SpawnShadow`, `MovementFunction_Shadow` | two mirrored tiles under the jumper for `(half hop + 1) * 2` frames |
| Fishing rod | `FacingFishDown` and its three siblings | the standing player plus one absolute rod tile at the facing's offset |

`EMOTE_SHADOW` and `EMOTE_ROD` were imported and unused; both now have a drawer,
so nothing in the effect section is dead data. The leaves ride
`BattleAnimSineWave`, which is cartridge data rather than a table this could
derive, so the screen hands `Gen2WorldEffects` the same one the battle animations
read.

`preview_world.gd -- <game> <group> <map> <out> live cut` photographs both halves
of Cut and the shadow at once; the rod shows up in `preview_fishing.gd`.

Cache format 53.

| Check | Result |
|---|---|
| Import, three cartridges | 3/3, `layout: Layout verified.` on each |
| GUT, unit tier | 2,511 passing |
| GUT, with scene integration | 2,836 passing over 148 scripts |
| `validate.gd -- all` | exit 0; `overworld_effects` now sweeps 15 sheets, byte identical across the three |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | Red reached on gold, silver and crystal, 0 failures |