### PR TITLE
Gate wild encounters on the standing tile, and give the battle its own menu

### DIFF
--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -1,0 +1,160 @@
+class_name Gen2BattleMenu
+extends RefCounted
+
+## What the player is asked on their own turn: `BattleMenu`'s FIGHT/PKMN/PACK/RUN
+## and `MoveSelectionScreen`'s move list (`engine/battle/core.asm`,
+## `engine/battle/menu.asm`).
+##
+## Scene-free, like [Gen2BattleSwitchMenu]: the geometry is [Gen2MenuBox]'s, the
+## rows and the cursor rules are here, and the battle screen owns the presses and
+## the drawing. Nothing here reads a battle; a caller builds the move rows from
+## the Pokemon that is out.
+
+## `wBattleMenuCursorPosition`, which `BattleMenu.next` compares against: the
+## menu's own 1-based position, counted along the rows.
+const FIGHT: int = 1
+const PKMN: int = 2
+const PACK: int = 3
+const RUN: int = 4
+
+## `BattleMenuHeader`: `menu_coords 8, 12, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1`,
+## `STATICMENU_CURSOR | STATICMENU_DISABLE_B`, `dn 2, 2` and `db 6`. No
+## STATICMENU_WRAP, so neither axis wraps (`_2DMenuInterpretJoypad`).
+const MAIN_LEFT: int = 8
+const MAIN_TOP: int = 12
+const MAIN_RIGHT: int = 19
+const MAIN_BOTTOM: int = 17
+const MAIN_ROWS: int = 2
+const MAIN_COLUMNS: int = 2
+const MAIN_SPACING: int = 6
+const MAIN_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_DISABLE_B
+## `.Text`, in its own order. `<PKMN>` is charmap's $4a, one byte the printer
+## expands to those four letters, so the four tiles are what is written here.
+const MAIN_OPTIONS: Array[String] = ["FIGHT", "PKMN", "PACK", "RUN"]
+
+## `MoveSelectionScreen`'s own `Textbox` rather than a menu header:
+## `hlcoord 4, 17 - NUM_MOVES - 1` with `b, 4` and `c, 14`, its list placed from
+## `hlcoord 6, 17 - NUM_MOVES` with `wListMovesLineSpacing` one whole row, and
+## its cursor started at `w2DMenuCursorInitX` 5. That is the same box with
+## STATICMENU_NO_TOP_SPACING and a row step of one.
+const MOVE_LEFT: int = 4
+const MOVE_TOP: int = 12
+const MOVE_RIGHT: int = 19
+const MOVE_BOTTOM: int = 17
+const MOVE_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR \
+	| Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+## `w2DMenuFlags1` is written `STATICMENU_ENABLE_LEFT_RIGHT | ENABLE_START |
+## WRAP` outright, so unlike the menu above this list wraps top to bottom.
+const MOVE_WRAPS: bool = true
+
+## `MoveInfoBox`: `hlcoord 0, 8` with `b, 3` and `c, 9`, "TYPE/" at (1,9), the
+## type name at (2,10) and the PP pair at (5,11) either side of a '/' at (7,11).
+const INFO_LEFT: int = 0
+const INFO_TOP: int = 8
+const INFO_RIGHT: int = 10
+const INFO_BOTTOM: int = 12
+const INFO_TYPE_LABEL_AT := Vector2i(1, 9)
+const INFO_TYPE_AT := Vector2i(2, 10)
+const INFO_PP_AT := Vector2i(5, 11)
+const INFO_TYPE_LABEL: String = "TYPE/"
+## `MoveInfoBox`' own `.Disabled`, printed at (1,10) in place of the type and PP
+## while the cursor is on the disabled slot.
+const INFO_DISABLED_AT := Vector2i(1, 10)
+const INFO_DISABLED: String = "Disabled!"
+
+## `BattleText_TheresNoPPLeftForThisMove` and `BattleText_TheMoveIsDisabled`,
+## which `.use_move` prints over the list and then reopens it behind.
+const NO_PP_TEXT: String = "There's no PP left for this move!"
+const DISABLED_TEXT: String = "The move is disabled!"
+
+
+static func main_box() -> Gen2MenuBox:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		MAIN_LEFT, MAIN_TOP, MAIN_RIGHT, MAIN_BOTTOM, MAIN_FLAGS
+	)
+	box.columns = MAIN_COLUMNS
+	box.column_spacing = MAIN_SPACING
+	return box
+
+
+static func move_box() -> Gen2MenuBox:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		MOVE_LEFT, MOVE_TOP, MOVE_RIGHT, MOVE_BOTTOM, MOVE_FLAGS
+	)
+	box.row_step = 1
+	return box
+
+
+static func info_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		INFO_LEFT, INFO_TOP, INFO_RIGHT, INFO_BOTTOM, 0
+	)
+
+
+## `_2DMenuInterpretJoypad` over the main menu's own two-by-two: a press that
+## would leave the grid is ignored, since it sets no wrap flag and no exit one.
+## [param position] and the answer are `wBattleMenuCursorPosition`.
+static func main_moved(position: int, button: int) -> int:
+	var index: int = clampi(position, FIGHT, RUN) - 1
+	var column: int = index % MAIN_COLUMNS
+	var row: int = index / MAIN_COLUMNS
+	match button:
+		Gen2Button.LEFT:
+			column = maxi(0, column - 1)
+		Gen2Button.RIGHT:
+			column = mini(MAIN_COLUMNS - 1, column + 1)
+		Gen2Button.UP:
+			row = maxi(0, row - 1)
+		Gen2Button.DOWN:
+			row = mini(MAIN_ROWS - 1, row + 1)
+	return row * MAIN_COLUMNS + column + 1
+
+
+## `ListMoves`' rows for the Pokemon that is out: the move name, its own PP pair
+## and whether the slot can be chosen at all. `wNumMoves` is the row count, so a
+## Pokemon with two moves has a two-row list rather than four with dashes: the
+## dashes are the party summary's, which lists a fixed four.
+static func move_rows(mon: Gen2BattleMon, data: GameData) -> Array:
+	var out: Array = []
+	if mon == null or data == null:
+		return out
+	for slot: int in mon.moves.size():
+		var number: int = int(mon.moves[slot])
+		if number <= 0:
+			continue
+		var record: Dictionary = data.move(number)
+		out.append({
+			"slot": slot,
+			"move": number,
+			"name": String(record.get("name", "")),
+			"type": int(record.get("type", 0)),
+			"pp": mon.pp_left(slot),
+			## `GetMaxPPOfMove` reads the party struct's PP Up bits, which no
+			## Pokemon in this battle model carries, so the base is the maximum.
+			"max_pp": int(record.get("pp", 0)),
+			"disabled": slot == mon.disabled_slot,
+		})
+	return out
+
+
+## The cursor after [param button], zero-based over [param rows]. Wraps both
+## ways, which is the flag `MoveSelectionScreen` writes.
+static func move_cursor_moved(cursor: int, button: int, rows: int) -> int:
+	if rows <= 0:
+		return 0
+	match button:
+		Gen2Button.UP:
+			return (cursor + rows - 1) % rows
+		Gen2Button.DOWN:
+			return (cursor + 1) % rows
+	return clampi(cursor, 0, rows - 1)
+
+
+## `.use_move`'s two refusals, in its order: no PP first, then the disabled
+## slot. An empty string is a row that may be chosen.
+static func refusal_for(row: Dictionary) -> String:
+	if int(row.get("pp", 0)) <= 0:
+		return NO_PP_TEXT
+	if bool(row.get("disabled", false)):
+		return DISABLED_TEXT
+	return ""

--- a/game/battle/battle_menu.gd.uid
+++ b/game/battle/battle_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://bxxg2ohmh0f8s

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -220,6 +220,24 @@ var _switch_menu: Gen2BattleSwitchMenu = null
 ## The yes/no box's own cursor, which is a two-row `VerticalMenu`.
 var _switch_offer: Gen2WorldMenu = null
 
+## `BattleMenu`'s own loop: [code]&"main"[/code] is FIGHT/PKMN/PACK/RUN,
+## [code]&"move"[/code] `MoveSelectionScreen`'s list and [code]&"refused"[/code]
+## the line it prints over that list before reopening it.
+var _menu_stage: StringName = &""
+## `wBattleMenuCursorPosition`, which is written back after every visit and so
+## opens on whatever was chosen last.
+var _menu_position: int = Gen2BattleMenu.FIGHT
+## `wListMoves_MoveIndicesBuffer` as [method Gen2BattleMenu.move_rows] shapes it,
+## rebuilt every time the list is opened because PP and Disable move under it.
+var _move_rows: Array = []
+## `wCurMoveNum`, which the list opens its cursor on.
+var _move_cursor: int = 0
+## `MoveInfoBox`, which is its own `Textbox` beside the list rather than part of
+## it, so it is drawn into a layer of its own.
+var _info_layer: TextureRect = null
+## The menu itself, which unlike [member _menu_layer] sits over the text box.
+var _battle_menu_layer: TextureRect = null
+
 ## The trainer class behind the enemy's own moves, or zero for
 ## [method show_matchup]'s invented pairing, which has no class and so no AI
 ## flags of its own to read: it falls back to [method _random_slot], same as
@@ -383,6 +401,18 @@ func _ready() -> void:
 	_box.visibility_changed.connect(_push_text_box_rect)
 	_screen.display(_box)
 	_box.place_at_bottom()
+	## Over the text box, unlike the two above: `LoadBattleMenu` draws its box
+	## into the tilemap after `EmptyBattleTextbox` has drawn that one, so the
+	## menu covers the box's right-hand half and `MoveSelectionScreen`'s list
+	## covers all of it.
+	_battle_menu_layer = TextureRect.new()
+	_battle_menu_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_battle_menu_layer.visible = false
+	_screen.display(_battle_menu_layer)
+	_info_layer = TextureRect.new()
+	_info_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_info_layer.visible = false
+	_screen.display(_info_layer)
 	_apply_renderer_interface_style()
 
 	var world_meta: Variant = get_meta("world_battle_request", {})
@@ -1212,6 +1242,10 @@ func battle_snapshot() -> Dictionary:
 		),
 		"switch_forced": _switch_menu != null and _switch_menu.forced,
 		"switch_reason": _switch_reason,
+		"menu_stage": _menu_stage,
+		"menu_position": _menu_position,
+		"move_cursor": _move_cursor,
+		"move_rows": _move_rows.duplicate(true),
 		"capture_selecting": _capture_selecting,
 		"capture_waiting": _capture_waiting,
 		"capture_ball": _selected_capture_ball(),
@@ -1704,6 +1738,11 @@ func advance() -> void:
 		return
 	if _box.advance():
 		return
+	## The battle menu is answered with A, which is what this call is: the source
+	## reads one joypad for the box and for the menu over it.
+	if _menu_stage != &"":
+		_answer_menu(Gen2Button.A)
+		return
 	if _capture_selecting or _capture_waiting:
 		return
 	if _world_battle_tutorial:
@@ -1747,7 +1786,7 @@ func advance() -> void:
 		if _save_battle_result() and _world_battle_active:
 			_finish_world_battle()
 		return
-	take_turn()
+	_open_battle_menu()
 
 
 ## Writes back only after every event from a finished battle has been shown.
@@ -1899,6 +1938,134 @@ func _answer_baton_pass() -> bool:
 	return true
 
 
+## `BattleMenu`: what the player is asked once the turn before it has finished
+## being shown. `EmptyBattleTextbox` first, so the menu opens over a clear box
+## rather than over the last line of the turn.
+##
+## `CheckPlayerHasUsableMoves` runs inside `MoveSelectionScreen` rather than
+## here, so a Pokemon with nothing left still opens the menu and Struggle is
+## chosen when FIGHT is.
+func _open_battle_menu() -> void:
+	if _battle == null or _battle.is_over() or not _pending.is_empty():
+		return
+	if _battle.awaiting_move_learn() or _battle.must_replace(Gen2Battle.PLAYER):
+		return
+	_menu_stage = &"main"
+	show_message("")
+	_reopen_menu_layer()
+
+
+func _close_battle_menu() -> void:
+	_menu_stage = &""
+	_move_rows = []
+	_reopen_menu_layer()
+
+
+## `MoveSelectionScreen`. `wCurMoveNum` opens the cursor, and a Pokemon with no
+## usable move at all does not get a list: `CheckPlayerHasUsableMoves` returns
+## before the box is drawn and the turn is spent on Struggle.
+func _open_move_menu() -> void:
+	var mon: Gen2BattleMon = _battle.mon(Gen2Battle.PLAYER)
+	_move_rows = Gen2BattleMenu.move_rows(mon, _data)
+	if _move_rows.is_empty() or mon.is_out_of_pp():
+		_close_battle_menu()
+		_take_turn_with_slot(0)
+		return
+	_move_cursor = clampi(_move_cursor, 0, _move_rows.size() - 1)
+	_menu_stage = &"move"
+	show_message("")
+	_reopen_menu_layer()
+
+
+## What a press does while one of the two menus is up.
+func _answer_menu(button: int) -> void:
+	match _menu_stage:
+		&"main":
+			_answer_battle_menu(button)
+		&"move":
+			_answer_move_menu(button)
+		&"refused":
+			## `.place_textbox_start_over` blocks on the line and then jumps back
+			## to `MoveSelectionScreen`, which redraws the list.
+			if _box != null and _box.advance():
+				return
+			_open_move_menu()
+
+
+## `BattleMenu.loop`: the cursor moves, A picks, and B is disabled by the
+## header's own STATICMENU_DISABLE_B.
+func _answer_battle_menu(button: int) -> void:
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT:
+			var moved: int = Gen2BattleMenu.main_moved(_menu_position, button)
+			if moved == _menu_position:
+				return
+			_menu_position = moved
+			_refresh_menu_layer()
+		Gen2Button.A:
+			_choose_battle_menu()
+
+
+func _choose_battle_menu() -> void:
+	match _menu_position:
+		Gen2BattleMenu.FIGHT:
+			_open_move_menu()
+		Gen2BattleMenu.PKMN:
+			## `BattleMenu_PKMN`'s list, whose SWITCH row is the only one of its
+			## three this screen answers: STATS is the summary screen and CANCEL
+			## comes back here.
+			_close_battle_menu()
+			_open_switch_pick(&"player")
+		Gen2BattleMenu.PACK:
+			## `BattleMenu_Pack` opens the whole pack; the only item this screen
+			## can use is a ball, so a wild battle reaches ball selection and a
+			## trainer battle is told what `.UseItem`'s own `wWildMon` test would
+			## have refused anyway.
+			_close_battle_menu()
+			if _is_wild_battle():
+				begin_capture()
+				return
+			show_message("No item can be used here.")
+		Gen2BattleMenu.RUN:
+			_close_battle_menu()
+			run_from_battle()
+
+
+## `.interpret_joypad`: the cursor wraps, B leaves the list for the menu behind
+## it, and A either refuses the slot or spends the turn on it.
+func _answer_move_menu(button: int) -> void:
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN:
+			_move_cursor = Gen2BattleMenu.move_cursor_moved(
+				_move_cursor, button, _move_rows.size()
+			)
+			_refresh_menu_layer()
+		Gen2Button.B:
+			_menu_stage = &"main"
+			_reopen_menu_layer()
+		Gen2Button.A:
+			var row: Dictionary = _move_rows[_move_cursor]
+			var refusal: String = Gen2BattleMenu.refusal_for(row)
+			if not refusal.is_empty():
+				_menu_stage = &"refused"
+				show_message(refusal)
+				_reopen_menu_layer()
+				return
+			_close_battle_menu()
+			_take_turn_with_slot(int(row.get("slot", 0)))
+
+
+## The turn `BattleMenu_Fight` leads to, with the slot the list chose. The
+## enemy's own action is picked here rather than in the menu, the way
+## `wEnemyAction` is decided after the player's choice.
+func _take_turn_with_slot(slot: int) -> void:
+	if _battle == null or _battle.is_over() or not _pending.is_empty():
+		return
+	_move_cursor = slot
+	_pending = _battle.take_actions(Gen2Battle.use_move(slot), _enemy_action())
+	_show_next_event()
+
+
 ## Opens `OfferSwitch`'s yes/no, which only SHIFT ever reaches, and answers
 ## whether there was a question to put up.
 ##
@@ -1959,8 +2126,11 @@ func _open_yes_no(stage: StringName, question: String) -> void:
 ## the row will answer; every one but `OfferSwitch`'s is a list with no way out.
 func _open_switch_pick(reason: StringName) -> void:
 	_switch_reason = reason
+	## `PickSwitchMonInBattle` rather than `ForcePickSwitchMonInBattle` for the
+	## two the player opened themselves: `OfferSwitch`'s YES and the battle
+	## menu's own PKMN, both of which can be backed out of.
 	_switch_menu = Gen2BattleSwitchMenu.for_party(
-		_battle.party(Gen2Battle.PLAYER), reason != &"offer"
+		_battle.party(Gen2Battle.PLAYER), reason not in [&"offer", &"player"]
 	)
 	_switch_offer = null
 	_switch_stage = &"pick"
@@ -2083,6 +2253,12 @@ func _resolve_switch(answer: Dictionary) -> void:
 			_commit_switch(int(answer.get("index", -1)))
 		Gen2BattleSwitchMenu.CANCELLED:
 			_play_anim_sound(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+			## `BattleMenuPKMN_Loop`'s `.Cancel` is a `jp BattleMenu`: the list
+			## the player opened themselves goes back to the menu it came from.
+			if _switch_reason == &"player":
+				_close_switch()
+				_open_battle_menu()
+				return
 			## `OfferSwitch.canceled_switch` falls into `.said_no`: backing out of
 			## the list is the same answer as NO.
 			_decline_switch_offer()
@@ -2101,6 +2277,13 @@ func _commit_switch(index: int) -> void:
 			_pending = _battle.pass_to(index)
 		&"replace":
 			_pending = _battle.replace_fallen(index)
+		&"player":
+			## `TryPlayerSwitch` spends the turn: the switch is the player's
+			## action and the enemy answers it, which is what makes a free switch
+			## cost a hit.
+			_pending = _battle.take_actions(
+				Gen2Battle.switch_to(index), _enemy_action()
+			)
 		_:
 			_pending = _battle.answer_switch_offer(index)
 	_show_next_event()
@@ -2152,22 +2335,34 @@ func _reopen_menu_layer() -> void:
 func _refresh_menu_layer() -> void:
 	if _menu_layer == null:
 		return
-	var signature: String = "%s|%d|%d" % [
-		_switch_stage,
+	var signature: String = "%s|%s|%d|%d|%d" % [
+		_switch_stage, _menu_stage,
 		_switch_offer.selected_index() if _switch_offer != null else (
 			_switch_menu.cursor if _switch_menu != null else -1
 		),
 		int(_offer_still_reading()),
+		_menu_position * 8 + _move_cursor,
 	]
 	if signature == _menu_drawn:
 		return
 	_menu_drawn = signature
 
+	if _info_layer != null:
+		_info_layer.visible = false
+	if _battle_menu_layer != null:
+		_battle_menu_layer.visible = false
 	match _switch_stage:
 		&"offer", &"use_next":
 			_draw_yes_no_box()
+			return
 		&"pick", &"refused":
 			_draw_party_page()
+			return
+	match _menu_stage:
+		&"main":
+			_draw_battle_menu()
+		&"move":
+			_draw_move_menu()
 		_:
 			_menu_layer.visible = false
 
@@ -2186,6 +2381,65 @@ func _draw_yes_no_box() -> void:
 	)
 
 
+## `BattleMenuHeader`'s two-by-two, drawn where its own `menu_coords` put it.
+func _draw_battle_menu() -> void:
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2BattleMenu.main_box()
+	_show_layer_image(
+		_battle_menu_layer,
+		_menu_page.render(box, Gen2BattleMenu.MAIN_OPTIONS, _menu_position - 1),
+		box.border_position() * Gen2Font.TILE
+	)
+
+
+## `MoveSelectionScreen`'s list and the `MoveInfoBox` beside it.
+func _draw_move_menu() -> void:
+	if _menu_page == null or _move_rows.is_empty():
+		return
+	var names: Array = []
+	for row: Dictionary in _move_rows:
+		names.append(String(row.get("name", "")))
+	var box: Gen2MenuBox = Gen2BattleMenu.move_box()
+	_show_layer_image(
+		_battle_menu_layer,
+		_menu_page.render(box, names, _move_cursor),
+		box.border_position() * Gen2Font.TILE
+	)
+	_draw_move_info(_move_rows[_move_cursor])
+
+
+## `MoveInfoBox`: the type and the PP pair of the row the cursor is on, or its
+## `.Disabled` line in place of both.
+func _draw_move_info(row: Dictionary) -> void:
+	var box: Gen2MenuBox = Gen2BattleMenu.info_box()
+	var extras: Array = []
+	if bool(row.get("disabled", false)):
+		extras.append({
+			"text": Gen2BattleMenu.INFO_DISABLED,
+			"at": Gen2BattleMenu.INFO_DISABLED_AT,
+		})
+	else:
+		extras.append({
+			"text": Gen2BattleMenu.INFO_TYPE_LABEL,
+			"at": Gen2BattleMenu.INFO_TYPE_LABEL_AT,
+		})
+		extras.append({
+			"text": _data.type_name(int(row.get("type", 0))),
+			"at": Gen2BattleMenu.INFO_TYPE_AT,
+		})
+		## `PrintNum` with `lb bc, 1, 2`: two digits, space padded, either side
+		## of the '/' the routine writes itself.
+		extras.append({
+			"text": "%2d/%2d" % [int(row.get("pp", 0)), int(row.get("max_pp", 0))],
+			"at": Gen2BattleMenu.INFO_PP_AT,
+		})
+	_show_layer_image(
+		_info_layer, _menu_page.render(box, [], -1, "", 0, extras),
+		box.border_position() * Gen2Font.TILE
+	)
+
+
 func _draw_party_page() -> void:
 	if _party_page == null or _switch_menu == null:
 		_menu_layer.visible = false
@@ -2199,10 +2453,16 @@ func _draw_party_page() -> void:
 
 
 func _show_menu_image(image: Image, at: Vector2i) -> void:
-	_menu_layer.texture = ImageTexture.create_from_image(image)
-	_menu_layer.position = Vector2(at)
-	_menu_layer.size = Vector2(image.get_size())
-	_menu_layer.visible = true
+	_show_layer_image(_menu_layer, image, at)
+
+
+func _show_layer_image(layer: TextureRect, image: Image, at: Vector2i) -> void:
+	if layer == null:
+		return
+	layer.texture = ImageTexture.create_from_image(image)
+	layer.position = Vector2(at)
+	layer.size = Vector2(image.get_size())
+	layer.visible = true
 
 
 ## `HandlePlayerMonFaint` and `HandleEnemyMonFaint`'s replacement tail put on
@@ -2815,7 +3075,7 @@ func _unhandled_input(event: InputEvent) -> void:
 ## [method _handle_button], which runs first and never reaches here.
 func _renderer_input_free() -> bool:
 	return is_ready() and _forget_stage == &"" and _switch_stage == &"" \
-		and not _capture_selecting
+		and _menu_stage == &"" and not _capture_selecting
 
 
 func _handle_button(button: int) -> bool:
@@ -2825,6 +3085,10 @@ func _handle_button(button: int) -> bool:
 
 	if _switch_stage != &"":
 		_answer_switch(button)
+		return true
+
+	if _menu_stage != &"":
+		_answer_menu(button)
 		return true
 
 	if _capture_selecting:
@@ -2842,12 +3106,6 @@ func _handle_button(button: int) -> bool:
 				return false
 		return true
 
-	## B opens ball selection and closes it again. The source reaches a ball
-	## through the PACK, which this screen has no menu for yet; until it does,
-	## the one button with nothing else to do here carries it.
-	if button == Gen2Button.B and _is_wild_battle():
-		begin_capture()
-		return true
 	if button == Gen2Button.A:
 		advance()
 		return true

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -39,9 +39,14 @@ static func from_data(data: GameData) -> Gen2MenuPage:
 ## The box's interior is not cleared: `MenuBox` calls `Textbox`, which fills its
 ## own interior with blanks, and every caller here draws onto a buffer it has
 ## already filled.
+## [param extras] are `PlaceString` calls the box's own caller makes at absolute
+## tile coordinates, as [code]{"text": String, "at": Vector2i}[/code]: the
+## battle's `MoveInfoBox` writes its type and PP into a plain `Textbox` that way
+## rather than as menu items.
 func draw(
 	box: Gen2MenuBox, options: Array, cursor: int,
-	indices: PackedByteArray, width: int, title: String = "", title_indent: int = 0
+	indices: PackedByteArray, width: int, title: String = "", title_indent: int = 0,
+	extras: Array = []
 ) -> void:
 	if font == null or box == null:
 		return
@@ -58,6 +63,13 @@ func draw(
 		var item: Vector2i = box.item_position(index)
 		font.draw_text(String(options[index]), indices, width, item.x * TILE, item.y * TILE)
 
+	for extra: Dictionary in extras:
+		var extra_at: Vector2i = extra.get("at", Vector2i.ZERO)
+		font.draw_text(
+			String(extra.get("text", "")), indices, width,
+			extra_at.x * TILE, extra_at.y * TILE
+		)
+
 	if cursor >= 0 and cursor < options.size() and box.has_flag(Gen2MenuBox.STATICMENU_CURSOR):
 		var arrow: Vector2i = box.cursor_position(cursor)
 		font.draw_code(CURSOR_CODE, indices, width, arrow.x * TILE, arrow.y * TILE)
@@ -72,12 +84,12 @@ func draw(
 ## covers what is behind it.
 func render(
 	box: Gen2MenuBox, options: Array, cursor: int,
-	title: String = "", title_indent: int = 0
+	title: String = "", title_indent: int = 0, extras: Array = []
 ) -> Image:
 	var width: int = Gen2Screen.WIDTH
 	var indices: PackedByteArray = PackedByteArray()
 	indices.resize(width * Gen2Screen.HEIGHT)
-	draw(box, options, cursor, indices, width, title, title_indent)
+	draw(box, options, cursor, indices, width, title, title_indent, extras)
 	return Gen2PicImage.from_indices(
 		indices, width, Gen2Screen.HEIGHT,
 		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -32,6 +32,14 @@ var top: int = 0
 var right: int = 0
 var bottom: int = 0
 var flags: int = 0
+## `dn rows, columns` and the `db spacing` beside it in a menu's own data
+## (`Place2DMenuItemStrings`, `Get2DMenuNumberOfColumns`). One column and no
+## spacing is `PlaceVerticalMenuItems`, which is every list menu here.
+var columns: int = 1
+var column_spacing: int = 0
+## `w2DMenuCursorOffsets`' high nybble, which is `ROW_STEP` for every menu built
+## from a header and one for `MoveSelectionScreen`'s own hand-built list.
+var row_step: int = ROW_STEP
 
 
 static func from_coords(x1: int, y1: int, x2: int, y2: int, menu_flags: int) -> Gen2MenuBox:
@@ -90,14 +98,22 @@ func cursor_start() -> Vector2i:
 	return Vector2i(left + 1, text_start().y)
 
 
-## Where item [param index] prints, zero-based.
+## Where item [param index] prints, zero-based. `Place2DMenuItemStrings` walks
+## the columns of a row before moving on, so an index counts along the row.
 func item_position(index: int) -> Vector2i:
-	return text_start() + Vector2i(0, index * ROW_STEP)
+	return text_start() + _item_offset(index)
 
 
 ## Where the cursor sits for item [param index], zero-based.
 func cursor_position(index: int) -> Vector2i:
-	return cursor_start() + Vector2i(0, index * ROW_STEP)
+	return cursor_start() + _item_offset(index)
+
+
+func _item_offset(index: int) -> Vector2i:
+	var per_row: int = maxi(1, columns)
+	return Vector2i(
+		(index % per_row) * column_spacing, (index / per_row) * row_step
+	)
 
 
 ## `PlaceMenuStrings`' title, which prints on the box's own top row indented by

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -315,6 +315,9 @@ func _init(
 	current_map = map
 	current_tileset = tileset
 	player_cell = _clamp_cell(start_cell)
+	# Opening a world is `StartMap`, which falls into `EnterMap`: the five-step
+	# cooldown is set here for the same reason _apply_map() sets it on a warp.
+	state.set_wild_encounter_cooldown(Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS)
 	_load_objects()
 	_apply_map_music()
 
@@ -1449,12 +1452,35 @@ static func _strength_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"strength_failed", "reason": reason}
 
 
+## Environments a wild encounter is rolled on any tile of. `CAVE` and `DUNGEON`
+## jump straight to the ice test, which is what puts encounters on a cave floor
+## rather than only on its grass.
+const ENVIRONMENT_CAVE: int = 4
+const ENVIRONMENT_DUNGEON: int = 7
+
+
+## `CanEncounterWildMon`: the whole condition on the tile the player is standing
+## on, before the rate is even read. Without it every step on open ground rolls,
+## which is both an encounter outside the grass and, over a walk, several times
+## the rate the cartridge has.
+func can_encounter_wild_mon() -> bool:
+	if state.wild_encounters_off():
+		return false
+	var code: int = collision_code_at(player_cell)
+	var environment: int = current_map.environment if current_map != null else 0
+	if environment != ENVIRONMENT_CAVE and environment != ENVIRONMENT_DUNGEON \
+		and not Gen2WorldCollision.gates_encounter(code):
+		return false
+	return not Gen2WorldCollision.is_ice(code)
+
+
 ## Rolls an encounter from the current map. Auto mode preserves the existing
 ## terrain behavior; an explicit rod method uses the map header's fishing
 ## group. The caller supplies the generator so tests can reproduce a result.
 func encounter_request(
 	random: RandomNumberGenerator = null, force_encounter: bool = false,
-	method: StringName = &"auto", lead_level: int = -1
+	method: StringName = &"auto", lead_level: int = -1,
+	cleanse_tag: bool = false
 ) -> Dictionary:
 	if current_map == null or data == null:
 		return {}
@@ -1489,6 +1515,15 @@ func encounter_request(
 		Gen2WorldEncounter.METHOD_GRASS, Gen2WorldEncounter.METHOD_SURF,
 	]:
 		return {}
+	## `RandomEncounter`'s own two gates, in its order: the cooldown a map entry
+	## set, then `CanEncounterWildMon`. A forced request is a preview or a story
+	## walk asking for the table's answer rather than the step's, so it skips
+	## both the way it already skips the rate roll.
+	if not force_encounter:
+		if state.consume_wild_encounter_cooldown():
+			return {}
+		if not can_encounter_wild_mon():
+			return {}
 	var permission: int = collision_permission_at(player_cell)
 	var terrain_method: StringName = method
 	if terrain_method == &"auto" and permission == Gen2WorldCollision.WATER_TILE:
@@ -1515,6 +1550,8 @@ func encounter_request(
 			"map_number": current_map.number,
 			"repel_steps": state.repel_steps(),
 			"lead_level": lead_level,
+			"map_music": state.map_music(),
+			"cleanse_tag": cleanse_tag,
 		}
 	)
 	if resolved.is_empty():
@@ -3211,6 +3248,13 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 		if event_type == &"map_reload_requested":
 			generated.append(reload_current_map())
 			continue
+		if event_type == &"wild_encounters_changed":
+			var wild_enabled: bool = bool(event.get("enabled", true))
+			state.set_wild_encounters_off(not wild_enabled)
+			generated.append({
+				"type": &"wild_encounters_changed", "enabled": wild_enabled,
+			})
+			continue
 		if event_type == &"variable_sprite_changed":
 			var variable_sprite: int = int(event.get("variable_sprite", -1))
 			var sprite: int = int(event.get("sprite", 0))
@@ -4608,6 +4652,9 @@ func _apply_map(
 	# are live-map changes, so only those overrides expire on a map load.
 	_clear_transient_object_visibility_overrides()
 	state.reset_map_reload_flags()
+	# EnterMap's own SetUpFiveStepWildEncounterCooldown, which is why the first
+	# steps out of a door are quiet.
+	state.set_wild_encounter_cooldown(Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS)
 	# ResetFlashIfOutOfCave, which runs in map setup: stepping out into a route
 	# or a town puts the light out, and a cave to cave doorway does not.
 	state.clear_flash_if_outdoors(target_map.environment)
@@ -4662,6 +4709,10 @@ func reload_current_map() -> Dictionary:
 	_pending_flash.clear()
 	_clear_transient_object_visibility_overrides()
 	state.reset_map_reload_flags()
+	# `Script_reloadmap` asks for MAPSTATUS_ENTER, so a battle's own reload runs
+	# EnterMap and takes its five-step cooldown with it: that is what stops a
+	# second wild the step after the first.
+	state.set_wild_encounter_cooldown(Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS)
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}
 

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -111,6 +111,37 @@ static func is_long_grass(collision_code: int) -> bool:
 	return collision_code == COLL_LONG_GRASS or collision_code == COLL_LONG_GRASS_1C
 
 
+## engine/overworld/tile_events.asm's CheckGrassCollision: the ten codes it
+## searches, in its own order. This is the encounter gate, which is why it is a
+## list rather than the nybble test grass_kind() uses: COLL_WATER is on it, so
+## one routine gates a surf roll too, and COLL_TALL_GRASS_10 is not, so the
+## unused tall-grass code carries tufts without carrying encounters.
+const COLL_WATER: int = 0x29
+const ENCOUNTER_TILE_CODES: Array[int] = [
+	0x08,             # COLL_CUT_08
+	0x18,             # COLL_TALL_GRASS
+	COLL_LONG_GRASS,
+	0x28,             # COLL_CUT_28
+	COLL_WATER,
+	0x48, 0x49, 0x4A, 0x4B, 0x4C,  # COLL_GRASS_48..COLL_GRASS_4C
+]
+## home/map_objects.asm's CheckIceTile, which CanEncounterWildMon reads after
+## the grass test and a cave or dungeon reads instead of it.
+const COLL_ICE: int = 0x23
+const COLL_ICE_2B: int = 0x2B
+
+
+## CheckGrassCollision: whether standing on [param collision_code] is a tile a
+## wild encounter can be rolled on at all.
+static func gates_encounter(collision_code: int) -> bool:
+	return ENCOUNTER_TILE_CODES.has(collision_code)
+
+
+## CheckIceTile: ice refuses an encounter wherever it is, cave included.
+static func is_ice(collision_code: int) -> bool:
+	return collision_code == COLL_ICE or collision_code == COLL_ICE_2B
+
+
 ## CheckGrassTile, nybble for nybble. Its water branch is a copy of its grass
 ## branch, which the source itself notes ("For some reason, the above code is
 ## duplicated down here"), so $20 and $28 answer grass here as they do there.

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -45,6 +45,9 @@ static func resolve(
 		generator.randomize()
 
 	var rate: int = _rate(record, method, time_of_day)
+	rate = _apply_music_effect(rate, int(options.get("map_music", 0)))
+	if bool(options.get("cleanse_tag", false)):
+		rate >>= 1
 	if rate <= 0:
 		return {}
 	var encounter_roll: int = -1
@@ -271,6 +274,22 @@ static func _rate(record: Dictionary, method: StringName, time_of_day: int) -> i
 		return 0
 	var index: int = mini(2, maxi(0, time_of_day))
 	return int((rates as Array)[index]) if index < (rates as Array).size() else 0
+
+
+## `ApplyMusicEffectOnEncounterRate`: the two radio-shaped tracks double the rate
+## and Pokemon Lullaby halves it. Both shifts are on the byte the source holds
+## the rate in, so a doubled rate above 127 wraps rather than saturating.
+const MUSIC_RUINS_OF_ALPH_RADIO: int = 0x4B
+const MUSIC_POKEMON_LULLABY: int = 0x50
+const MUSIC_POKEMON_MARCH: int = 0x51
+
+
+static func _apply_music_effect(rate: int, map_music: int) -> int:
+	if map_music == MUSIC_POKEMON_MARCH or map_music == MUSIC_RUINS_OF_ALPH_RADIO:
+		return (rate << 1) & 0xFF
+	if map_music == MUSIC_POKEMON_LULLABY:
+		return rate >> 1
+	return rate
 
 
 static func _slots(record: Dictionary, method: StringName, time_of_day: int) -> Array:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -859,7 +859,9 @@ func _after_player_move(movement: Dictionary) -> bool:
 		_show_script_results(phone_results)
 		return true
 	_show_script_results([])
-	var encounter: Dictionary = _world.encounter_request(_encounter_random)
+	var encounter: Dictionary = _world.encounter_request(
+		_encounter_random, false, &"auto", _repel_lead_level(), _party_holds_cleanse_tag()
+	)
 	if not encounter.is_empty():
 		_start_battle_request({
 			"kind": &"battle_requested",
@@ -867,6 +869,32 @@ func _after_player_move(movement: Dictionary) -> bool:
 			"encounter": encounter.duplicate(true),
 		})
 	return true
+
+
+## `CheckRepelEffect`'s own lead: the first party member that is not fainted, or
+## -1 when there is no party to read, which is what a repel compares a wild
+## level against. The party lives in the save rather than in the world API, so
+## the screen is the one place that can answer it.
+func _repel_lead_level() -> int:
+	var save: Gen2SaveData = _selected_runtime_save()
+	if save == null:
+		return -1
+	for mon: Gen2SaveMon in save.party:
+		if mon.hp > 0:
+			return mon.level
+	return -1
+
+
+## `ApplyCleanseTagEffectOnEncounterRate` walks the whole party, fainted members
+## included, and halves the rate on the first Cleanse Tag it finds.
+func _party_holds_cleanse_tag() -> bool:
+	var save: Gen2SaveData = _selected_runtime_save()
+	if save == null:
+		return false
+	for mon: Gen2SaveMon in save.party:
+		if mon.item == Gen2HeldItem.CLEANSE_TAG:
+			return true
+	return false
 
 
 ## Public driver for the production NPC/object interaction path.
@@ -1551,6 +1579,13 @@ func _on_battle_finished(result: Dictionary) -> void:
 		}})
 	var resumed: Array = _world.complete_runtime_request(result)
 	if resumed.is_empty():
+		## `WildBattleScript` is `randomwildmon`, `startbattle`,
+		## `reloadmapafterbattle`, `end`: a wild encounter reloads the map on the
+		## way out even though no script was suspended, and that reload is what
+		## puts the five-step cooldown back so the next step cannot roll another.
+		_world.reload_current_map()
+		if _renderer != null:
+			_renderer.refresh()
 		if StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_CAUGHT:
 			var capture: Dictionary = result.get("capture", {})
 			var species: Dictionary = _data.species(int(capture.get("species", 0)))

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1191,6 +1191,14 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 			_staged_engine_flags[int(command["flag"])] = true
 		Gen2WorldScript.CHECKFLAG:
 			_script_value = 1 if _engine_flag_active(int(command["flag"])) else 0
+		## `Script_wildon` and `Script_wildoff`, which write
+		## `STATUSFLAGS_NO_WILD_ENCOUNTERS_F` outright rather than through a
+		## staged flag: it is scratch the next map entry does not clear, and the
+		## scripts that turn it off all turn it back on themselves.
+		Gen2WorldScript.WILDON:
+			_emit_runtime_event(&"wild_encounters_changed", {"enabled": true})
+		Gen2WorldScript.WILDOFF:
+			_emit_runtime_event(&"wild_encounters_changed", {"enabled": false})
 		Gen2WorldScript.WARP:
 			return _stage_warp(command)
 		Gen2WorldScript.OPENTEXT, Gen2WorldScript.REANCHORMAP, Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE, Gen2WorldScript.CLOSEWINDOW:
@@ -1251,6 +1259,7 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.SETVAL, Gen2WorldScript.ADDVAL, Gen2WorldScript.RANDOM,
 		Gen2WorldScript.CHECKEVENT, Gen2WorldScript.CLEAREVENT, Gen2WorldScript.SETEVENT,
 		Gen2WorldScript.CHECKFLAG, Gen2WorldScript.CLEARFLAG, Gen2WorldScript.SETFLAG,
+		Gen2WorldScript.WILDON, Gen2WorldScript.WILDOFF,
 		Gen2WorldScript.READMEM,
 		Gen2WorldScript.READVAR, Gen2WorldScript.LOADVAR,
 		Gen2WorldScript.CHECKTIME, Gen2WorldScript.SPECIAL,

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -111,6 +111,15 @@ var _coins: int = 0
 var _phone_contacts: Dictionary = {}
 var _just_battled: bool = false
 var _repel_steps: int = 0
+## `wWildEncounterCooldown`, which `EnterMap` sets to five and every step
+## decrements. Scratch on the cartridge rather than saved data, kept here
+## because this is where the world's own per-step counters live; a state written
+## before it existed restores as zero, which is the value a walk reaches after
+## its first four steps anyway.
+var _wild_encounter_cooldown: int = 0
+## `wStatusFlags`' `STATUSFLAGS_NO_WILD_ENCOUNTERS_F`, which `wildoff` sets and
+## `wildon` clears around a scripted sequence.
+var _wild_encounters_off: bool = false
 var _swarm_map: Vector2i = Vector2i(-1, -1)
 var _fishing_swarm_species: int = 0
 var _roaming_mons: Array = []
@@ -238,6 +247,8 @@ func to_dict() -> Dictionary:
 		"phone_contacts": _phone_contacts.duplicate(),
 		"just_battled": _just_battled,
 		"repel_steps": _repel_steps,
+		"wild_encounter_cooldown": _wild_encounter_cooldown,
+		"wild_encounters_off": _wild_encounters_off,
 		"swarm_map": [_swarm_map.x, _swarm_map.y],
 		"fishing_swarm_species": _fishing_swarm_species,
 		"roaming_mons": _copy_roaming_mons(_roaming_mons),
@@ -307,6 +318,8 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 			if int(raw_tree) > 0 and bool((picked as Dictionary)[raw_tree]):
 				restored._picked_fruit_trees[int(raw_tree)] = true
 	restored.set_registered_item(int(source.get("registered_item", 0)))
+	restored.set_wild_encounter_cooldown(int(source.get("wild_encounter_cooldown", 0)))
+	restored.set_wild_encounters_off(bool(source.get("wild_encounters_off", false)))
 	return restored
 
 
@@ -327,6 +340,8 @@ func restore_from_dict(raw: Variant) -> void:
 	_phone_contacts = restored._phone_contacts.duplicate()
 	_just_battled = restored._just_battled
 	_repel_steps = restored._repel_steps
+	_wild_encounter_cooldown = restored._wild_encounter_cooldown
+	_wild_encounters_off = restored._wild_encounters_off
 	_swarm_map = restored._swarm_map
 	_fishing_swarm_species = restored._fishing_swarm_species
 	_roaming_mons = _copy_roaming_mons(restored._roaming_mons)
@@ -736,6 +751,44 @@ func set_radio_channel(channel: int) -> void:
 	if next_channel == _radio_channel:
 		return
 	_radio_channel = next_channel
+	changed.emit()
+
+
+func wild_encounter_cooldown() -> int:
+	return _wild_encounter_cooldown
+
+
+## `SetUpFiveStepWildEncounterCooldown`'s own write, which `EnterMap` makes on
+## every map entry, `reloadmapafterbattle` included.
+const WILD_ENCOUNTER_COOLDOWN_STEPS: int = 5
+
+
+func set_wild_encounter_cooldown(steps: int) -> void:
+	var next_steps: int = clampi(steps, 0, 0xFF)
+	if next_steps == _wild_encounter_cooldown:
+		return
+	_wild_encounter_cooldown = next_steps
+	changed.emit()
+
+
+## `CheckWildEncounterCooldown`: zero lets the step through, and so does the step
+## that takes the counter to zero. Answers whether this step is blocked.
+func consume_wild_encounter_cooldown() -> bool:
+	if _wild_encounter_cooldown <= 0:
+		return false
+	_wild_encounter_cooldown -= 1
+	changed.emit()
+	return _wild_encounter_cooldown > 0
+
+
+func wild_encounters_off() -> bool:
+	return _wild_encounters_off
+
+
+func set_wild_encounters_off(value: bool) -> void:
+	if _wild_encounters_off == value:
+		return
+	_wild_encounters_off = value
 	changed.emit()
 
 

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -422,6 +422,173 @@ func test_shift_offers_a_switch_when_the_trainer_replaces_its_own_faint() -> voi
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0, "and the player stayed")
 
 
+## `BattleMenu` and the `MoveSelectionScreen` behind FIGHT: what the player is
+## asked on their own turn, which the screen used to answer itself with a random
+## slot.
+func _menu_stage() -> String:
+	return String(_screen.battle_snapshot()["menu_stage"])
+
+
+func _menu_layer() -> TextureRect:
+	return _screen.get("_battle_menu_layer")
+
+
+func _advance_to_menu(limit: int = 40) -> void:
+	for _press: int in limit:
+		if _menu_stage() != "":
+			return
+		_settle_bars()
+		_screen.finish()
+		_screen.advance()
+		await get_tree().process_frame
+
+
+## A wild battle whose player has two moves, so the list has two rows and a
+## second one to move the cursor onto.
+func _menu_battle() -> Gen2Battle:
+	return Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(BattleFixture.PIKACHU, [BattleFixture.TACKLE, BattleFixture.GROWL]),
+			_mon(BattleFixture.BULBASAUR, [BattleFixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(BattleFixture.GEODUDE, [BattleFixture.TACKLE])),
+		_rng, false
+	)
+
+
+## The turn ends on the menu rather than on another turn, and `BattleMenuHeader`
+## opens on FIGHT.
+func test_the_end_of_a_turn_opens_the_battle_menu() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+
+	assert_eq(_menu_stage(), "main")
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.FIGHT)
+	assert_true(_menu_layer().visible)
+	assert_false(_screen._renderer_input_free(), "the menu owns the joypad")
+
+
+## `_2DMenuInterpretJoypad` with neither wrap flag: a press off the grid is
+## ignored, and the four positions are the source's own order.
+func test_the_battle_menu_walks_its_two_by_two_and_does_not_wrap() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+
+	await _press(Gen2Button.LEFT)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.FIGHT)
+	await _press(Gen2Button.RIGHT)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PKMN)
+	await _press(Gen2Button.DOWN)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.RUN)
+	await _press(Gen2Button.DOWN)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.RUN)
+	await _press(Gen2Button.LEFT)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PACK)
+
+
+## FIGHT is `MoveSelectionScreen`: the Pokemon's own moves, and the row chosen
+## there is the move the turn is spent on.
+func test_fight_opens_the_move_list_and_the_chosen_row_is_the_move_used() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+
+	await _press(Gen2Button.A)
+	assert_eq(_menu_stage(), "move")
+	var rows: Array = _screen.battle_snapshot()["move_rows"]
+	assert_eq(rows.size(), 2, "two moves, two rows")
+	assert_eq(int((rows[0] as Dictionary)["move"]), BattleFixture.TACKLE)
+
+	await _press(Gen2Button.DOWN)
+	assert_eq(int(_screen.battle_snapshot()["move_cursor"]), 1)
+	var before: int = battle.mon(Gen2Battle.PLAYER).pp_left(1)
+	await _press(Gen2Button.A)
+
+	assert_eq(_menu_stage(), "", "the list is gone once the turn is taken")
+	assert_eq(battle.mon(Gen2Battle.PLAYER).pp_left(1), before - 1, "GROWL was used")
+
+
+## `.pressed_up` and `.pressed_down` under the WRAP flag the screen writes.
+func test_the_move_cursor_wraps_and_b_goes_back_to_the_menu() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	await _press(Gen2Button.A)
+
+	await _press(Gen2Button.UP)
+	assert_eq(int(_screen.battle_snapshot()["move_cursor"]), 1, "wrapped to the last row")
+	await _press(Gen2Button.DOWN)
+	assert_eq(int(_screen.battle_snapshot()["move_cursor"]), 0)
+
+	await _press(Gen2Button.B)
+	assert_eq(_menu_stage(), "main", "B leaves the list for the menu behind it")
+
+
+## `.no_pp_left`: the line is printed over the list and the list comes back on
+## the press that reads it, with the turn still unspent.
+func test_a_move_with_no_pp_is_refused_and_the_list_comes_back() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	battle.mon(Gen2Battle.PLAYER).pp[0] = 0
+
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.A)
+	assert_eq(_menu_stage(), "refused")
+	assert_true(
+		String(_screen.battle_snapshot()["message"]).contains("no PP left"),
+		String(_screen.battle_snapshot()["message"])
+	)
+
+	var box: Gen2TextBox = _screen.get("_box")
+	while box.is_revealing() or box.has_pages_left():
+		box.finish()
+		if box.has_pages_left():
+			box.advance()
+	await _press(Gen2Button.A)
+	assert_eq(_menu_stage(), "move", "and the list is back")
+
+
+## RUN is `BattleMenu_Run`, which settles before the turn does.
+func test_run_leaves_the_wild_battle() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.RIGHT)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.RUN)
+	await _press(Gen2Button.A)
+	assert_eq(_menu_stage(), "")
+	assert_false(_screen.get("_pending").is_empty(), "the run is a turn's worth of events")
+
+
+## PKMN is `BattleMenu_PKMN`: the same party list a switch offer opens, backed
+## out of into the menu it came from, and the row chosen there spends the turn.
+func test_pkmn_opens_a_party_list_that_can_be_cancelled_back_to_the_menu() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+
+	await _press(Gen2Button.RIGHT)
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick")
+	assert_eq(String(_screen.battle_snapshot()["switch_reason"]), "player")
+	assert_false(bool(_screen.battle_snapshot()["switch_forced"]), "and it can be left")
+
+	await _press(Gen2Button.B)
+	assert_eq(_stage(), "")
+	assert_eq(_menu_stage(), "main", "cancelling is a jp BattleMenu")
+
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.A)
+	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the bench member came in")
+
+
 ## A mod's renderer is offered the leftovers only while the screen is not asking
 ## a question of its own, the way it is for the forget prompt and ball selection.
 func test_a_renderer_is_not_offered_input_while_a_menu_is_up() -> void:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -174,7 +174,7 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 	var collision: Array = []
 	collision.resize(MAP_WIDTH_CELLS * MAP_HEIGHT_CELLS)
 	collision.fill(0)
-	collision[7 * MAP_WIDTH_CELLS + 8] = 0x20
+	collision[7 * MAP_WIDTH_CELLS + 8] = 0x29
 
 	var objects: Array = [{
 		"sprite": TRAINER_SPRITE,

--- a/tests/unit/test_menu_box.gd
+++ b/tests/unit/test_menu_box.gd
@@ -93,3 +93,35 @@ func test_world_menu_shares_this_flag_set() -> void:
 	assert_eq(
 		Gen2WorldMenu.STATICMENU_ENABLE_LEFT_RIGHT, Gen2MenuBox.STATICMENU_ENABLE_LEFT_RIGHT
 	)
+
+
+## `BattleMenuHeader`'s own `dn 2, 2` and `db 6`, which is the one two-column
+## menu here: FIGHT and PACK share a column, PKMN and RUN sit six to the right,
+## and the rows are two apart like every other menu's.
+func test_a_two_column_menu_walks_its_row_before_dropping() -> void:
+	var box: Gen2MenuBox = Gen2BattleMenu.main_box()
+	assert_eq(box.text_start(), Vector2i(10, 14))
+	assert_eq(box.item_position(0), Vector2i(10, 14), "FIGHT")
+	assert_eq(box.item_position(1), Vector2i(16, 14), "PKMN")
+	assert_eq(box.item_position(2), Vector2i(10, 16), "PACK")
+	assert_eq(box.item_position(3), Vector2i(16, 16), "RUN")
+	assert_eq(box.cursor_position(3), Vector2i(15, 16))
+	assert_eq(box.border_size(), Vector2i(12, 6))
+
+
+## `MoveSelectionScreen`'s own `Textbox`: `hlcoord 4, 12` with `b, 4` and
+## `c, 14`, its rows one apart rather than two, and its cursor column 5.
+func test_the_move_list_is_a_one_row_step_box() -> void:
+	var box: Gen2MenuBox = Gen2BattleMenu.move_box()
+	assert_eq(box.interior(), Vector2i(14, 4))
+	assert_eq(box.item_position(0), Vector2i(6, 13))
+	assert_eq(box.item_position(3), Vector2i(6, 16))
+	assert_eq(box.cursor_position(0), Vector2i(5, 13))
+
+
+## `MoveInfoBox`'s `hlcoord 0, 8` with `b, 3` and `c, 9`.
+func test_the_move_info_box_is_the_source_rectangle() -> void:
+	var box: Gen2MenuBox = Gen2BattleMenu.info_box()
+	assert_eq(box.interior(), Vector2i(9, 3))
+	assert_eq(box.border_position(), Vector2i(0, 8))
+	assert_eq(box.border_size(), Vector2i(11, 5))

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -49,7 +49,7 @@ func _write_cache(game_id: String = "testworld") -> void:
 		"block_count": 2,
 		"tile_count": RomLayout.TILESET_TILE_COUNT,
 		"meta": meta,
-		"collision": [0, 0, 0, 0, 0x20, 0x20, 0x20, 0x20],
+		"collision": [0, 0, 0, 0, 0x29, 0x29, 0x29, 0x29],
 	}])
 
 	var blocks: Array = []
@@ -61,7 +61,7 @@ func _write_cache(game_id: String = "testworld") -> void:
 	for index: int in collision.size():
 		collision[index] = 0
 	collision[6 * 16 + 9] = 0x07
-	collision[7 * 16 + 8] = 0x20
+	collision[7 * 16 + 8] = 0x29
 	collision[6 * 16 + 6] = 0x70
 
 	# Ledge fixture, rows 2-4: a plain hop-down at (3,2) with a wall below it
@@ -127,6 +127,10 @@ func _write_cache(game_id: String = "testworld") -> void:
 	# spawns on a step into it. LAND_TILE permission, so an ordinary step reaches
 	# it and nothing else in the fixture changes.
 	collision[10 * 16 + 5] = 0x18  # COLL_TALL_GRASS
+
+	# An ice cell beside it, which CanEncounterWildMon refuses on every
+	# environment including the cave branch that skips the grass test.
+	collision[10 * 16 + 6] = 0x23  # COLL_ICE
 
 	var source_events: Dictionary = {
 		"bank": 48,
@@ -806,7 +810,7 @@ func test_movement_uses_raw_collision_codes_without_mutating_them() -> void:
 	assert_false(world.move(Vector2i.RIGHT))
 	assert_eq(world.player_cell, Vector2i(8, 6))
 
-	assert_eq(world.collision_code_at(Vector2i(8, 7)), 0x20)
+	assert_eq(world.collision_code_at(Vector2i(8, 7)), 0x29)
 	assert_false(world.can_walk_to(Vector2i(8, 7)))
 	assert_false(world.move(Vector2i.DOWN))
 
@@ -4988,7 +4992,7 @@ func test_change_block_updates_tiles_and_collision_from_the_tileset_block() -> v
 	assert_eq(world.change_block(0, 0, 1)["ok"], true)
 	assert_eq(world.block_at(0, 0), 1)
 	assert_eq(world.tile_index_at(0, 0), 16)
-	assert_eq(world.collision_code_at(Vector2i(0, 0)), 0x20)
+	assert_eq(world.collision_code_at(Vector2i(0, 0)), 0x29)
 	assert_eq(world.change_block(0, 0, 0)["ok"], true)
 	assert_eq(world.collision_code_at(Vector2i(0, 0)), 0)
 
@@ -5052,6 +5056,10 @@ func test_surf_movement_accepts_water_and_exposes_an_encounter_request() -> void
 	assert_true(movement["ok"])
 	assert_eq(movement["kind"], &"water_move")
 	assert_eq(world.collision_permission_at(world.player_cell), Gen2WorldCollision.WATER_TILE)
+	## EnterMap's five-step cooldown: the map this world opened on set it, and
+	## every request spends one step of it before the tile is even looked at.
+	for step: int in Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS - 1:
+		assert_true(world.encounter_request().is_empty(), "cooldown step %d" % step)
 	var encounter: Dictionary = world.encounter_request()
 	assert_eq(encounter["kind"], &"wild_encounter_requested")
 	assert_eq(encounter["fish_group"], 1)
@@ -5268,6 +5276,82 @@ func test_repel_blocks_lower_level_candidates_and_counts_down_on_steps() -> void
 		null, true, &"auto", 5
 	)
 	assert_false(allowed.is_empty())
+
+
+## `CanEncounterWildMon`: outdoors it is `CheckGrassCollision` on the standing
+## tile alone, so open ground rolls nothing however high the map's rate is.
+func test_an_unforced_encounter_needs_the_grass_the_source_checks_for() -> void:
+	var world := _world(Vector2i(5, 10))
+	world.state.set_wild_encounter_cooldown(0)
+	assert_true(world.can_encounter_wild_mon(), "COLL_TALL_GRASS")
+	assert_false(world.encounter_request(_seeded()).is_empty())
+
+	world.player_cell = Vector2i(5, 9)
+	assert_eq(world.collision_code_at(world.player_cell), 0, "plain land")
+	assert_false(world.can_encounter_wild_mon())
+	assert_true(world.encounter_request(_seeded()).is_empty())
+
+
+## The `CAVE`/`DUNGEON` branch skips the grass test, and the ice test is the one
+## thing both branches share.
+func test_a_cave_rolls_on_any_tile_and_ice_refuses_on_every_environment() -> void:
+	var world := _world(Vector2i(5, 9))
+	world.state.set_wild_encounter_cooldown(0)
+	world.current_map.environment = Gen2WorldAPI.ENVIRONMENT_CAVE
+	assert_true(world.can_encounter_wild_mon(), "a cave floor is not grass")
+	world.current_map.environment = Gen2WorldAPI.ENVIRONMENT_DUNGEON
+	assert_true(world.can_encounter_wild_mon())
+
+	world.player_cell = Vector2i(6, 10)
+	assert_eq(world.collision_code_at(world.player_cell), Gen2WorldCollision.COLL_ICE)
+	for environment: int in [
+		Gen2WorldAPI.ENVIRONMENT_CAVE, Gen2WorldAPI.ENVIRONMENT_DUNGEON, 2,
+	]:
+		world.current_map.environment = environment
+		assert_false(world.can_encounter_wild_mon(), "ice in environment %d" % environment)
+
+
+## `wildoff` and `wildon`, the one thing that turns the whole roll off from a
+## script.
+func test_wildoff_stops_every_roll_until_wildon_puts_it_back() -> void:
+	var world := _world(Vector2i(5, 10))
+	world.state.set_wild_encounter_cooldown(0)
+	world.state.set_wild_encounters_off(true)
+	assert_false(world.can_encounter_wild_mon())
+	assert_true(world.encounter_request(_seeded()).is_empty())
+	world.state.set_wild_encounters_off(false)
+	assert_false(world.encounter_request(_seeded()).is_empty())
+
+
+## `CheckWildEncounterCooldown`: five steps are written on map entry and the
+## fifth is the one that rolls, since the step taking the counter to zero is let
+## through.
+func test_a_map_entry_costs_four_steps_of_wild_encounters() -> void:
+	var world := _world(Vector2i(5, 10))
+	assert_eq(
+		world.state.wild_encounter_cooldown(),
+		Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS
+	)
+	for step: int in Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS - 1:
+		assert_true(world.encounter_request(_seeded()).is_empty(), "step %d" % step)
+	assert_false(world.encounter_request(_seeded()).is_empty())
+	assert_eq(world.state.wild_encounter_cooldown(), 0)
+
+	## `Script_reloadmap` re-enters the map, which is what a finished battle
+	## does, so the counter is back up afterwards.
+	assert_true(world.reload_current_map()["ok"])
+	assert_eq(
+		world.state.wild_encounter_cooldown(),
+		Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS
+	)
+
+
+## A generator whose first roll is under every fixture rate, so a request that
+## reaches the roll resolves and one that does not is the gate's answer.
+func _seeded() -> RandomNumberGenerator:
+	var random := RandomNumberGenerator.new()
+	random.seed = 1
+	return random
 
 
 func _event_value(

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5058,9 +5058,12 @@ func test_surf_movement_accepts_water_and_exposes_an_encounter_request() -> void
 	assert_eq(world.collision_permission_at(world.player_cell), Gen2WorldCollision.WATER_TILE)
 	## EnterMap's five-step cooldown: the map this world opened on set it, and
 	## every request spends one step of it before the tile is even looked at.
+	## The generator is seeded because the fixture's rate is 255 and one roll in
+	## 256 is the one that refuses: unseeded, this case failed about that often.
+	var random: RandomNumberGenerator = _seeded()
 	for step: int in Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS - 1:
-		assert_true(world.encounter_request().is_empty(), "cooldown step %d" % step)
-	var encounter: Dictionary = world.encounter_request()
+		assert_true(world.encounter_request(random).is_empty(), "cooldown step %d" % step)
+	var encounter: Dictionary = world.encounter_request(random)
 	assert_eq(encounter["kind"], &"wild_encounter_requested")
 	assert_eq(encounter["fish_group"], 1)
 	assert_eq(encounter["values"]["kind"], &"wild")

--- a/tests/unit/test_world_encounters.gd
+++ b/tests/unit/test_world_encounters.gd
@@ -114,6 +114,30 @@ func test_swarm_source_and_repel_are_resolved_after_the_candidate_roll() -> void
 	assert_eq(allowed["source"], Gen2WorldEncounter.SOURCE_SWARM)
 
 
+## `ApplyMusicEffectOnEncounterRate` then `ApplyCleanseTagEffectOnEncounterRate`,
+## both `sla b`/`srl b` on the rate byte: a rate of 200 doubled is 144, not 255.
+func test_the_rate_is_shifted_by_the_map_music_and_by_a_cleanse_tag() -> void:
+	var slots: Array = []
+	for _slot: int in RomLayout.WILD_GRASS_SLOT_COUNT:
+		slots.append({"level": 4, "species": 16})
+	var record: Dictionary = {"rates": [200, 200, 200], "slots": [slots, slots, slots]}
+	var cases: Array = [
+		[0, false, 200],
+		[Gen2WorldEncounter.MUSIC_POKEMON_MARCH, false, 144],
+		[Gen2WorldEncounter.MUSIC_RUINS_OF_ALPH_RADIO, false, 144],
+		[Gen2WorldEncounter.MUSIC_POKEMON_LULLABY, false, 100],
+		[0, true, 100],
+		[Gen2WorldEncounter.MUSIC_POKEMON_LULLABY, true, 50],
+	]
+	for case: Array in cases:
+		var result: Dictionary = Gen2WorldEncounter.resolve(
+			record, Gen2WorldEncounter.METHOD_GRASS, Gen2WorldPalette.TIME_DAY,
+			RandomNumberGenerator.new(), true,
+			{"map_music": case[0], "cleanse_tag": case[1]}
+		)
+		assert_eq(result["rate"], case[2], "music %d cleanse %s" % [case[0], case[1]])
+
+
 func test_roaming_selection_uses_the_land_roll_before_normal_slots() -> void:
 	var slots: Array = []
 	for _time_of_day: int in RomLayout.WILD_TIME_COUNT:

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -1,0 +1,150 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies where a wild encounter can be rolled at all, against freshly
+## imported real caches, for all three cartridges.
+##
+## The expected shape comes from engine/overworld/events.asm's RandomEncounter,
+## CanEncounterWildMon and CheckWildEncounterCooldown,
+## engine/overworld/tile_events.asm's CheckGrassCollision and
+## home/map_objects.asm's CheckIceTile. The real-cartridge counterpart to the
+## gate cases in tests/unit/test_world_api.gd, which use a hand-built map.
+##
+## The census is the point: an encounter cell is a small minority of a map's
+## walkable cells, and the defect this topic exists to catch was every land cell
+## rolling. A route whose grass moves, or a collision code that stops being read
+## as grass, moves these counts.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- wild_encounters
+
+## Census of the real caches, pinned so a cache or a rule change is loud.
+## Per game: encounter cells, maps holding one, and cells refused for ice.
+const EXPECTED_CENSUS: Dictionary = {
+	&"gold": [39058, 138, 775],
+	&"silver": [39058, 138, 775],
+	&"crystal": [40156, 146, 779],
+}
+
+## Route 29, the first grass a new game walks into, and the same map number in
+## all three games (constants/map_constants.asm, group 24).
+const ROUTE_29_GROUP: int = 24
+const ROUTE_29_NUMBER: int = 3
+
+## Union Cave 1F, whose whole floor rolls because its environment is CAVE.
+## pokecrystal inserts eight Ruins of Alph rooms ahead of it in group 3.
+const UNION_CAVE_GROUP: int = 3
+const UNION_CAVE_NUMBER_CRYSTAL: int = 37
+const UNION_CAVE_NUMBER_GOLD_SILVER: int = 29
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		_verify_route_29()
+		_verify_union_cave()
+		_census()
+	)
+
+
+## An outdoor map: only the tiles CheckGrassCollision names roll, and the path
+## between them does not.
+func _verify_route_29() -> void:
+	var world: Gen2WorldAPI = _r.open_world(
+		ROUTE_29_GROUP, ROUTE_29_NUMBER, Vector2i.ZERO
+	)
+	if world == null:
+		return
+	world.state.set_wild_encounter_cooldown(0)
+	var counts: Dictionary = _map_counts(world)
+	_r.check(
+		world.current_map.environment == Gen2WorldPhoneHost.ENVIRONMENT_ROUTE,
+		"Route 29 is environment %d, not ROUTE." % world.current_map.environment
+	)
+	_r.check(
+		int(counts["encounter"]) > 0,
+		"Route 29 offers no encounter cell at all."
+	)
+	_r.check(
+		int(counts["encounter"]) < int(counts["walkable"]),
+		"Route 29 rolls on all %d of its walkable cells." % int(counts["walkable"])
+	)
+	_r.note("Route 29: %d encounter cells of %d walkable." % [
+		int(counts["encounter"]), int(counts["walkable"]),
+	])
+
+
+## A CAVE map: every walkable cell rolls, which is the branch that skips
+## CheckGrassCollision entirely.
+func _verify_union_cave() -> void:
+	var number: int = UNION_CAVE_NUMBER_CRYSTAL if _r.crystal \
+		else UNION_CAVE_NUMBER_GOLD_SILVER
+	var world: Gen2WorldAPI = _r.open_world(UNION_CAVE_GROUP, number, Vector2i.ZERO)
+	if world == null:
+		return
+	world.state.set_wild_encounter_cooldown(0)
+	if not _r.check(
+		world.current_map.environment == Gen2WorldAPI.ENVIRONMENT_CAVE,
+		"Union Cave 1F is environment %d, not CAVE." % world.current_map.environment
+	):
+		return
+	var counts: Dictionary = _map_counts(world)
+	_r.check(
+		int(counts["encounter"]) == int(counts["walkable"]),
+		"Union Cave 1F rolls on %d of its %d walkable cells." % [
+			int(counts["encounter"]), int(counts["walkable"]),
+		]
+	)
+	_r.note("Union Cave 1F: %d cells, all of them CAVE." % int(counts["encounter"]))
+
+
+## Every map in the cache, so a rule change is one number rather than one map.
+func _census() -> void:
+	var cells: int = 0
+	var maps: Dictionary = {}
+	var iced: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+		if tileset == null:
+			continue
+		var world := Gen2WorldAPI.new(
+			_r.data, map, tileset, Vector2i.ZERO, Gen2WorldState.new()
+		)
+		world.state.set_wild_encounter_cooldown(0)
+		var counts: Dictionary = _map_counts(world)
+		cells += int(counts["encounter"])
+		iced += int(counts["ice"])
+		if int(counts["encounter"]) > 0:
+			maps[map.group * 256 + map.number] = true
+	var found: Array = [cells, maps.size(), iced]
+	_r.note("encounter cells %d over %d maps, %d refused for ice." % [
+		cells, maps.size(), iced,
+	])
+	var expected: Array = EXPECTED_CENSUS[_r.game_id]
+	_r.check(
+		found == expected,
+		"census is %s, not the pinned %s." % [str(found), str(expected)]
+	)
+
+
+## What one map offers: walkable cells, cells CanEncounterWildMon accepts, and
+## cells it would have accepted but for the ice test.
+func _map_counts(world: Gen2WorldAPI) -> Dictionary:
+	var walkable: int = 0
+	var encounter: int = 0
+	var ice: int = 0
+	var map: Gen2WorldMap = world.current_map
+	for y: int in map.collision_height:
+		for x: int in map.collision_width:
+			var cell := Vector2i(x, y)
+			var permission: int = world.collision_permission_at(cell)
+			if permission != Gen2WorldCollision.LAND_TILE \
+				and permission != Gen2WorldCollision.WATER_TILE:
+				continue
+			walkable += 1
+			world.player_cell = cell
+			if world.can_encounter_wild_mon():
+				encounter += 1
+			elif Gen2WorldCollision.is_ice(world.collision_code_at(cell)):
+				ice += 1
+	return {"walkable": walkable, "encounter": encounter, "ice": ice}

--- a/tools/checks/wild_encounters.gd.uid
+++ b/tools/checks/wild_encounters.gd.uid
@@ -1,0 +1,1 @@
+uid://dudfbaphd0wbr

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -1,12 +1,14 @@
 extends SceneTree
 
-## Captures the menus a battle switches through, against a real imported cache:
-## `OfferSwitch`'s yes/no box over the field, `AskUseNextPokemon`'s box in the
-## same place, and the party list both of them open behind.
+## Captures the menus a battle is answered through, against a real imported
+## cache: `BattleMenu`'s own FIGHT/PKMN/PACK/RUN and the `MoveSelectionScreen`
+## behind FIGHT, `OfferSwitch`'s yes/no box over the field,
+## `AskUseNextPokemon`'s box in the same place, and the party list they open.
 ##
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses]
 ##
-## [stage] is one of `offer` (the default), `pick`, `use_next` and `replace`;
+## [stage] is one of `offer` (the default), `menu`, `move`, `pick`, `use_next`
+## and `replace`;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
 ## cursor row or a refusal can be photographed. The battle is a real trainer's
 ## party out of the cache with the player on a bench of three, since both a
@@ -28,6 +30,9 @@ const SETTLE_FRAMES: int = 30
 const TRAINER_CLASS: int = 1
 const PLAYER_SPECIES: Array[int] = [155, 152, 158]
 const PLAYER_LEVEL: int = 30
+## Four moves on the lead, so `MoveSelectionScreen`'s list is a full one:
+## TACKLE, GROWL, TAIL_WHIP and BITE (constants/move_constants.asm).
+const LEAD_MOVES: Array[int] = [33, 45, 39, 44]
 
 var _screen: Gen2BattleScreen = null
 var _output_path: String = ""
@@ -76,8 +81,9 @@ func _process(_delta: float) -> bool:
 		quit(1)
 		return true
 	var snapshot: Dictionary = _screen.battle_snapshot()
-	print("Wrote %s, stage %s, answering %s" % [
+	print("Wrote %s, switch stage %s answering %s, menu stage %s at %d/%d" % [
 		_output_path, snapshot["switch_stage"], snapshot["switch_reason"],
+		snapshot["menu_stage"], snapshot["menu_position"], snapshot["move_cursor"],
 	])
 	quit(0)
 	return true
@@ -94,7 +100,10 @@ func _open() -> void:
 
 	var members: Array = []
 	for species: int in PLAYER_SPECIES:
-		members.append(Gen2BattleMon.create(data, species, PLAYER_LEVEL, [33]))
+		members.append(Gen2BattleMon.create(
+			data, species, PLAYER_LEVEL,
+			LEAD_MOVES.duplicate() if members.is_empty() else [33]
+		))
 	var enemy: Gen2Party = Gen2TrainerParty.build(data, TRAINER_CLASS, 0)
 	if enemy == null or enemy.size() < 2:
 		push_error("Trainer class %d has no bench to switch from" % TRAINER_CLASS)
@@ -120,10 +129,21 @@ func _open() -> void:
 		_screen.set("_pending", [
 			{"type": Gen2Battle.FAINTED, "side": Gen2Battle.PLAYER},
 		])
-	else:
+	elif _stage not in ["menu", "move"]:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
 		))
+
+	## Both menu stages are what the intro leads into with nothing else staged,
+	## which is `BattleMenu`'s own first opening.
+	if _stage in ["menu", "move"]:
+		_drain_to_menu()
+		if _stage == "move":
+			_screen._handle_button(Gen2Button.A)
+		for press: String in _presses:
+			_screen._handle_button(_button(press))
+		_screen.finish()
+		return
 
 	_drain()
 	if _stage == "pick":
@@ -136,6 +156,16 @@ func _open() -> void:
 	## A refusal is a line the box is still revealing, and the capture does not
 	## wait on real time.
 	_screen.finish()
+
+
+## The same drain, stopping at `BattleMenu` rather than at a switch question.
+func _drain_to_menu() -> void:
+	for _press: int in 60:
+		if String(_screen.battle_snapshot()["menu_stage"]) != "":
+			return
+		_settle()
+		_screen.finish()
+		_screen.advance()
 
 
 ## Every queued event shown and pressed past, which is what reaches the question.


### PR DESCRIPTION
Three defects the same walk hits, all reported from play.

## Wild encounters fired anywhere, far too often

`RandomEncounter`'s two gates were missing, so every completed step on
any land cell rolled the map's rate.

- `CanEncounterWildMon`: `CheckGrassCollision`'s ten codes on the tile
  the player stands on, skipped on a CAVE or DUNGEON map, with
  `CheckIceTile` refusing on every environment, and
  `STATUSFLAGS_NO_WILD_ENCOUNTERS_F` in front of all of it.
- `CheckWildEncounterCooldown`: `EnterMap`'s five steps, written on
  opening a world, on a warp and on the reload a finished battle runs,
  and spent one per step. That reload is `WildBattleScript`'s own
  `reloadmapafterbattle`, which nothing ran before.
- `wildon` and `wildoff` now reach that flag instead of falling through.
- `ApplyMusicEffectOnEncounterRate` and
  `ApplyCleanseTagEffectOnEncounterRate`, both shifts on the rate byte,
  and `CheckRepelEffect`'s lead level, which was never being passed.

Measured on Route 29 of a real Crystal cache, 4,000 steps a side:

| Where | Encounters | Steps per encounter |
|---|---|---|
| Its 160 grass cells | 285 | 14.0 |
| Its 355 path cells | 0 | never |

The map's rate is 25 of 256, which is one step in 10.2, and the
four-step cooldown after each battle accounts for the rest.

`tools/checks/wild_encounters.gd` sweeps every map of all three caches
and pins the counts: 39,058 encounter cells over 138 maps on Gold and
Silver, 40,156 over 146 on Crystal.

## The battle chose the player's move for them

A turn was taken by pressing A, which spent it on a random usable slot:
there was no `BattleMenu`, so the screen answered the question itself.

- `BattleMenuHeader`'s two-by-two at its own `menu_coords`, walked by
  `_2DMenuInterpretJoypad`'s rules, which wrap in neither axis.
- `MoveSelectionScreen` behind FIGHT: `ListMoves`' rows, a cursor that
  wraps, `MoveInfoBox` beside it with the type and PP pair, and
  `.use_move`'s two refusals printed over the list.
- PKMN opens the party list already built for a switch offer and the row
  chosen spends the turn; RUN is `BattleMenu_Run`; PACK reaches ball
  selection, which the B shortcut used to carry on its own.

## Proof

GUT 2,851 over 148 scripts green (was 2,836), `validate.gd -- all` 44
topics pass, `replay_world.gd` 27 routes 0 failures, and the story walk
still reaches Red at 291 steps on Gold and Silver and 294 on Crystal.

One test fixture changed: its water cells carried collision `$20`, which
is a grass code on the cartridge and not an encounter tile. They are now
the `$29` real maps use, which is also the explanation for the one
intermittent GUT failure in `test_world_api.gd`: the fixture rate is 255
and an unseeded roll of 255 refuses.