### PR TITLE
Build the Bug Catching Contest

### DIFF
--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -68,13 +68,28 @@ const NO_PP_TEXT: String = "There's no PP left for this move!"
 const DISABLED_TEXT: String = "The move is disabled!"
 
 
-static func main_box() -> Gen2MenuBox:
+## `ContestBattleMenuHeader`: the same two-by-two four columns further left, with
+## twelve of spacing, and PARKBALL where PACK is. Its ball count is printed by
+## the header's own `.PrintParkBallsRemaining` at (13,16) rather than as part of
+## the row.
+const CONTEST_LEFT: int = 2
+const CONTEST_SPACING: int = 12
+const CONTEST_OPTIONS: Array[String] = ["FIGHT", "PKMN", "PARKBALL×", "RUN"]
+const CONTEST_BALLS_AT := Vector2i(13, 16)
+
+
+static func main_box(contest: bool = false) -> Gen2MenuBox:
 	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
-		MAIN_LEFT, MAIN_TOP, MAIN_RIGHT, MAIN_BOTTOM, MAIN_FLAGS
+		CONTEST_LEFT if contest else MAIN_LEFT,
+		MAIN_TOP, MAIN_RIGHT, MAIN_BOTTOM, MAIN_FLAGS
 	)
 	box.columns = MAIN_COLUMNS
-	box.column_spacing = MAIN_SPACING
+	box.column_spacing = CONTEST_SPACING if contest else MAIN_SPACING
 	return box
+
+
+static func main_options(contest: bool = false) -> Array[String]:
+	return CONTEST_OPTIONS.duplicate() if contest else MAIN_OPTIONS.duplicate()
 
 
 static func move_box() -> Gen2MenuBox:

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1409,6 +1409,12 @@ func _is_wild_battle() -> bool:
 	return values is Dictionary and StringName((values as Dictionary).get("kind", &"")) == &"wild"
 
 
+## `wBattleType` being BATTLETYPE_CONTEST, which is what makes the menu the
+## contest's own and the ball a Park Ball.
+func _is_bug_contest_battle() -> bool:
+	return _battle != null and _battle.battle_type == Gen2Battle.BATTLETYPE_CONTEST
+
+
 func _capture_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "reason": reason}
 
@@ -1751,6 +1757,11 @@ func advance() -> void:
 		_show_next_capture_message()
 		return
 	if _capture_terminal:
+		## `BugContest_SetCaughtContestMon` asks before replacing the Pokemon
+		## already caught, over the same `PlaceYesNoBox` a switch offer uses.
+		if bool(_capture_result.get("replace_offer", false)) and _switch_stage == &"":
+			_open_yes_no(&"contest_replace", CONTEST_REPLACE_TEXT)
+			return
 		var capture: Dictionary = _capture_result.duplicate(true)
 		_clear_capture_action()
 		_finish_world_capture(capture)
@@ -2020,8 +2031,13 @@ func _choose_battle_menu() -> void:
 			## `BattleMenu_Pack` opens the whole pack; the only item this screen
 			## can use is a ball, so a wild battle reaches ball selection and a
 			## trainer battle is told what `.UseItem`'s own `wWildMon` test would
-			## have refused anyway.
+			## have refused anyway. Its `.contest` branch skips the pack outright
+			## and throws the one ball a contest has.
 			_close_battle_menu()
+			if _is_bug_contest_battle():
+				if bool(begin_capture().get("ok", false)):
+					throw_capture_ball()
+				return
 			if _is_wild_battle():
 				begin_capture()
 				return
@@ -2160,12 +2176,40 @@ func _answer_switch(button: int) -> void:
 			_answer_use_next_button(button)
 		&"pick":
 			_answer_switch_pick(button)
+		&"contest_replace":
+			_answer_contest_replace(button)
 		&"refused":
 			## `StdBattleTextbox` blocks on a button and `jr .loop` reopens the
 			## list behind it.
 			if _box != null and _box.advance():
 				return
 			_open_switch_pick(_switch_reason)
+
+
+## `BugContest_SetCaughtContestMon`'s own `PlaceYesNoBox`, which `ret c` reads as
+## keeping the Pokemon already caught. The answer rides out on the capture
+## result, since what it decides is world state rather than battle state.
+const CONTEST_REPLACE_TEXT: String = "Replace the one you caught?"
+
+
+func _answer_contest_replace(button: int) -> void:
+	if _offer_still_reading():
+		if button == Gen2Button.A:
+			_box.advance()
+			_refresh_menu_layer()
+		return
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN:
+			_switch_offer.move(Vector2i(0, 1 if button == Gen2Button.DOWN else -1))
+			_refresh_menu_layer()
+		Gen2Button.A, Gen2Button.B:
+			var replace: bool = button == Gen2Button.A \
+				and _switch_offer.selected_index() == 0
+			_close_switch()
+			var capture: Dictionary = _capture_result.duplicate(true)
+			capture["replace"] = replace
+			_clear_capture_action()
+			_finish_world_capture(capture)
 
 
 ## `InterpretTwoOptionMenu` over `YesNoMenuHeader`: two rows that do not wrap,
@@ -2352,7 +2396,7 @@ func _refresh_menu_layer() -> void:
 	if _battle_menu_layer != null:
 		_battle_menu_layer.visible = false
 	match _switch_stage:
-		&"offer", &"use_next":
+		&"offer", &"use_next", &"contest_replace":
 			_draw_yes_no_box()
 			return
 		&"pick", &"refused":
@@ -2385,10 +2429,22 @@ func _draw_yes_no_box() -> void:
 func _draw_battle_menu() -> void:
 	if _menu_page == null:
 		return
-	var box: Gen2MenuBox = Gen2BattleMenu.main_box()
+	var contest: bool = _is_bug_contest_battle()
+	var box: Gen2MenuBox = Gen2BattleMenu.main_box(contest)
+	var extras: Array = []
+	if contest:
+		## `.PrintParkBallsRemaining`, which prints the count beside the row
+		## rather than inside it.
+		extras.append({
+			"text": "%2d" % _capture_quantity(Gen2WorldPartyHost.ITEM_PARK_BALL),
+			"at": Gen2BattleMenu.CONTEST_BALLS_AT,
+		})
 	_show_layer_image(
 		_battle_menu_layer,
-		_menu_page.render(box, Gen2BattleMenu.MAIN_OPTIONS, _menu_position - 1),
+		_menu_page.render(
+			box, Gen2BattleMenu.main_options(contest), _menu_position - 1,
+			"", 0, extras
+		),
 		box.border_position() * Gen2Font.TILE
 	)
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -488,6 +488,27 @@ func treemon_set(index: int) -> Dictionary:
 	return value.duplicate(true) if value is Dictionary else {}
 
 
+## `ContestMons`, the eleven `%, species, min, max` rows
+## `ChooseWildEncounter_BugContest` walks. All three cartridges ship the same
+## table.
+func bug_contest_mons() -> Array:
+	return _bug_contest_table("mons")
+
+
+## `BugContestantPointers`' ten AI contestants, each `db class, id` and three
+## `dbw mon, score` placings. The player's own entry zero is not among them.
+func bug_contestants() -> Array:
+	return _bug_contest_table("contestants")
+
+
+func _bug_contest_table(key: String) -> Array:
+	var contest: Variant = _encounters().get("bug_contest", {})
+	if not contest is Dictionary:
+		return []
+	var value: Variant = (contest as Dictionary).get(key, [])
+	return (value as Array).duplicate(true) if value is Array else []
+
+
 ## CheckSleepingTreeMon's list for one time of day. Empty on Gold and Silver,
 ## which import no such lists because pokegold ships none.
 func asleep_treemons(time_of_day: int) -> Array:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -65,7 +65,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 53
+const FORMAT_VERSION: int = 54
 
 
 static func directory_for(id: StringName, sha1: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3316,6 +3316,8 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"world_tree_map_count": int(encounters["tree_maps"]),
 		"world_rock_map_count": int(encounters["rock_maps"]),
 		"world_treemon_set_count": int(encounters["treemon_sets"]),
+		"world_bug_contest_mon_count": int(encounters["bug_contest_mons"]),
+		"world_bug_contestant_count": int(encounters["bug_contestants"]),
 		"overworld_sprite_count": int(world["overworld_sprites"]),
 		"overworld_effect_count": int(world["overworld_effects"]),
 		"world_menu_count": int(services["menus"]),
@@ -3376,6 +3378,8 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	result["tree_maps"] = int(encounters["tree_maps"])
 	result["rock_maps"] = int(encounters["rock_maps"])
 	result["treemon_sets"] = int(encounters["treemon_sets"])
+	result["bug_contest_mons"] = int(encounters["bug_contest_mons"])
+	result["bug_contestants"] = int(encounters["bug_contestants"])
 	result["overworld_sprites"] = int(world["overworld_sprites"])
 	result["menus"] = int(services["menus"])
 	result["marts"] = int(services["marts"])

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1660,6 +1660,15 @@ const GOLD_SILVER: Dictionary = {
 		"treemon_sets": 0xBA470,
 		"treemon_set_count": 6,
 		"asleep_treemons": {},
+		# data/wild/bug_contest_mons.asm's ContestMons and
+		# data/events/bug_contest_winners.asm's BugContestantPointers, both
+		# located by their own bytes, which are unique in every dump: the
+		# eleven `%, species, min, max` rows and the pointer entry pokegold and
+		# pokecrystal both repeat for BUG_CONTEST_PLAYER.
+		"bug_contest_mons": 0x97BB8,
+		"bug_contest_mon_count": 11,
+		"bug_contestants": 0x13B3F,
+		"bug_contestant_count": 10,
 	},
 	# Gold and Silver patch three bank numbers and pass the rest through. The
 	# stored value is what the linker assigned before three pic sections were
@@ -1977,6 +1986,11 @@ const CRYSTAL: Dictionary = {
 		# CheckSleepingTreeMon and data/wild/treemons_asleep.asm are Crystal
 		# only; pokegold ships neither. File order is Nite, Day, Morn.
 		"asleep_treemons": {"nite": 0x3EB5D, "day": 0x3EB69, "morn": 0x3EB6F},
+		# See the Gold and Silver block above for how these two were located.
+		"bug_contest_mons": 0x97D87,
+		"bug_contest_mon_count": 11,
+		"bug_contestants": 0x13783,
+		"bug_contestant_count": 10,
 	},
 	# Crystal's equivalent table is a contiguous $48-$5F, so the whole remap
 	# collapses to a constant: PICS_FIX in pokecrystal.

--- a/game/import/world_encounter_importer.gd
+++ b/game/import/world_encounter_importer.gd
@@ -97,6 +97,8 @@ static func import_to_cache(
 		"tree_maps": int(result["counts"]["tree_maps"]),
 		"rock_maps": int(result["counts"]["rock_maps"]),
 		"treemon_sets": int(result["counts"]["treemon_sets"]),
+		"bug_contest_mons": int(result["counts"]["bug_contest_mons"]),
+		"bug_contestants": int(result["counts"]["bug_contestants"]),
 	}
 
 
@@ -145,6 +147,9 @@ static func read_world_encounters(rom: RomFile, layout: Dictionary) -> Dictionar
 	var treemon_result: Dictionary = read_treemons(rom, layout, wild_layout)
 	if not bool(treemon_result.get("ok", false)):
 		return treemon_result
+	var contest_result: Dictionary = read_bug_contest(rom, wild_layout)
+	if not bool(contest_result.get("ok", false)):
+		return contest_result
 
 	return {
 		"ok": true,
@@ -156,6 +161,7 @@ static func read_world_encounters(rom: RomFile, layout: Dictionary) -> Dictionar
 			"fishing": fish_result["fishing"],
 			"roaming": roam_result["roaming"],
 			"treemons": treemon_result["treemons"],
+			"bug_contest": contest_result["bug_contest"],
 			"probabilities": {
 				"grass": RomLayout.WILD_GRASS_PROBABILITIES,
 				"water": RomLayout.WILD_WATER_PROBABILITIES,
@@ -171,8 +177,123 @@ static func read_world_encounters(rom: RomFile, layout: Dictionary) -> Dictionar
 			"tree_maps": int(treemon_result["tree_maps"]),
 			"rock_maps": int(treemon_result["rock_maps"]),
 			"treemon_sets": int(treemon_result["sets"]),
+			"bug_contest_mons": int(contest_result["mon_count"]),
+			"bug_contestants": int(contest_result["contestant_count"]),
 		},
 	}
+
+
+## `ContestMons` and `BugContestantPointers`, the Bug Catching Contest's own two
+## tables. Both ship byte identical on all three cartridges; they are read
+## rather than constants because they are cartridge data with a locator, unlike
+## `RadioChannelSongs`.
+##
+## A contestant record is `db class, id` then three `dbw mon, score` placings,
+## which `ComputeAIContestantScores` picks one of at random and then perturbs.
+## Entry zero of the pointer table is the player's own slot (`BUG_CONTEST_PLAYER`
+## is 1), and the source repeats the first real entry there, so the ten that
+## follow are what is read.
+static func read_bug_contest(rom: RomFile, configured: Dictionary) -> Dictionary:
+	var mons_offset: int = int(configured.get("bug_contest_mons", -1))
+	var mon_count: int = int(configured.get("bug_contest_mon_count", -1))
+	var pointer_offset: int = int(configured.get("bug_contestants", -1))
+	var contestant_count: int = int(configured.get("bug_contestant_count", -1))
+	if mons_offset < 0 or mon_count <= 0 or pointer_offset < 0 or contestant_count <= 0:
+		return _error("Bug Contest layout is incomplete.")
+
+	var mons: Array = []
+	for index: int in mon_count:
+		var at: int = mons_offset + index * 4
+		if not rom.in_bounds(at, 4):
+			return _error("ContestMons row %d is outside the ROM." % index)
+		var percent: int = rom.u8(at)
+		var species: int = rom.u8(at + 1)
+		var min_level: int = rom.u8(at + 2)
+		var max_level: int = rom.u8(at + 3)
+		var last: bool = index == mon_count - 1
+		# The last row's percentage is `db -1`, which is what stops
+		# ChooseWildEncounter_BugContest's walk however the earlier rows fall.
+		if last != (percent == 0xFF):
+			return _error("ContestMons row %d ends the table in the wrong place." % index)
+		if species < 1 or species > RomLayout.SPECIES_COUNT \
+			or min_level < 1 or max_level < min_level or max_level > RomLayout.MAX_LEVEL:
+			return _error("ContestMons row %d is out of range." % index)
+		mons.append({
+			"percent": percent, "species": species,
+			"min_level": min_level, "max_level": max_level,
+		})
+
+	var bank: int = floori(float(pointer_offset) / float(RomFile.BANK_SIZE))
+	var contestants: Array = []
+	for index: int in contestant_count:
+		# Entry zero is the player's, so the ten AI contestants start at one.
+		var entry: int = pointer_offset + (index + 1) * 2
+		if not rom.in_bounds(entry, 2):
+			return _error("BugContestantPointers entry %d is outside the ROM." % index)
+		var pointer: int = rom.u16le(entry)
+		if pointer < 0x4000 or pointer > 0x7FFF:
+			return _error("BugContestantPointers entry %d is not a banked pointer." % index)
+		var at: int = RomFile.linear(bank, pointer)
+		if not rom.in_bounds(at, 11):
+			return _error("Bug contestant %d is outside the ROM." % index)
+		var placings: Array = []
+		for placing: int in 3:
+			var species: int = rom.u8(at + 2 + placing * 3)
+			if species < 1 or species > RomLayout.SPECIES_COUNT:
+				return _error("Bug contestant %d placing %d is out of range." % [index, placing])
+			placings.append({
+				"species": species,
+				"score": rom.u16le(at + 3 + placing * 3),
+			})
+		contestants.append({
+			"trainer_class": rom.u8(at),
+			"trainer": rom.u8(at + 1),
+			"placings": placings,
+		})
+
+	var anchor: Dictionary = _validate_bug_contest(mons, contestants)
+	if not bool(anchor.get("ok", false)):
+		return anchor
+	return {
+		"ok": true,
+		"bug_contest": {"mons": mons, "contestants": contestants},
+		"mon_count": mons.size(),
+		"contestant_count": contestants.size(),
+	}
+
+
+## The first and last row of each table, which all three cartridges ship the
+## same: `db 20, CATERPIE, 7, 18` and `db -1, VENOMOTH, 30, 40`, and
+## `BugContestant_BugCatcherDon`'s `dbw KAKUNA, 300` through
+## `BugContestant_SchoolboyKipp`'s `dbw KAKUNA, 259`.
+const _CONTEST_MON_ANCHORS: Dictionary = {
+	"first": {"percent": 20, "species": 10, "min_level": 7, "max_level": 18},
+	"last": {"percent": 0xFF, "species": 49, "min_level": 30, "max_level": 40},
+}
+const _CONTESTANT_ANCHORS: Dictionary = {
+	"first": [[14, 300], [11, 285], [10, 226]],
+	"last": [[48, 267], [46, 254], [14, 259]],
+}
+
+
+static func _validate_bug_contest(mons: Array, contestants: Array) -> Dictionary:
+	for edge: String in _CONTEST_MON_ANCHORS:
+		var row: Dictionary = mons[0] if edge == "first" else mons[mons.size() - 1]
+		var expected: Dictionary = _CONTEST_MON_ANCHORS[edge]
+		for field: String in expected:
+			if int(row.get(field, -1)) != int(expected[field]):
+				return _error("ContestMons %s row does not match the source." % edge)
+	for edge: String in _CONTESTANT_ANCHORS:
+		var entry: Dictionary = contestants[0] if edge == "first" \
+			else contestants[contestants.size() - 1]
+		var placings: Array = entry.get("placings", [])
+		var expected_placings: Array = _CONTESTANT_ANCHORS[edge]
+		for index: int in expected_placings.size():
+			var placing: Dictionary = placings[index]
+			if int(placing["species"]) != int(expected_placings[index][0]) \
+				or int(placing["score"]) != int(expected_placings[index][1]):
+				return _error("Bug contestant %s record does not match the source." % edge)
+	return {"ok": true}
 
 
 static func _read_map_table(

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -605,9 +605,12 @@ func set_movement_mode(mode: StringName) -> Dictionary:
 ## [param eggs] marks which slots are eggs, because `CheckPartyMove` skips them:
 ## an egg carries the moves it will hatch with and would otherwise answer for a
 ## move no usable party member knows.
+## [param extra] carries the few party facts a script asks about that are not
+## per-slot: `lead_fainted` for `ContestDropOffMons`, `second_species` for the
+## byte it stashes, and `storage_full` for `CheckPartyFullAfterContest`.
 func set_party_summary(
 	count: int, has_pokerus: bool, species: Array[int] = [] as Array[int],
-	moves: Array = [], names: Array = [], eggs: Array = []
+	moves: Array = [], names: Array = [], eggs: Array = [], extra: Dictionary = {}
 ) -> Dictionary:
 	if count < 0:
 		return {"ok": false, "reason": &"invalid_party_summary", "count": count}
@@ -616,6 +619,8 @@ func set_party_summary(
 		"moves": moves.duplicate(true), "names": names.duplicate(),
 		"eggs": eggs.duplicate(),
 	}
+	for key: Variant in extra:
+		_party_summary[key] = extra[key]
 	return {"ok": true}
 
 
@@ -1459,6 +1464,108 @@ const ENVIRONMENT_CAVE: int = 4
 const ENVIRONMENT_DUNGEON: int = 7
 
 
+## Whether `ENGINE_BUG_CONTEST_TIMER` is set, which is the one thing that says a
+## contest is running (`CheckTimeEvents`, `RandomEncounter`).
+func bug_contest_active() -> bool:
+	return state.bug_contest_active(Gen2WorldState.is_crystal_profile(data))
+
+
+## `StartBugContestTimer` and `GiveParkBalls`: twenty balls, no caught Pokemon
+## and the clock the contest is counted from. The flag itself is the script's
+## own `setflag`, which runs before this.
+func start_bug_contest() -> Dictionary:
+	state.set_contest_mon({})
+	state.set_park_balls(Gen2WorldBugContest.BALLS)
+	state.set_bug_contest_started(world_clock())
+	return {
+		"ok": true,
+		"kind": &"bug_contest_started",
+		"park_balls": state.park_balls(),
+		"minutes": Gen2WorldBugContest.MINUTES,
+	}
+
+
+## `CheckBugContestTimer` as `CheckTimeEvents` calls it: how many minutes are
+## left, and whether this reading is the one that ends the contest. Answers zero
+## minutes when no contest is running, which is what `VAR_BUGCONTEST_MINS_REMAINING`
+## reads there too.
+func bug_contest_minutes_remaining() -> int:
+	if not bug_contest_active():
+		return 0
+	return Gen2WorldBugContest.minutes_remaining(
+		state.bug_contest_started(), world_clock()
+	)
+
+
+## `BugContestResultsWarpScript`'s index in `StdScripts`, the same 22 in both
+## pins the way `StrengthBoulderScript` is the same 14. It warps to the results
+## gate and falls into `BugContestResultsScript`, which is what clears
+## `ENGINE_BUG_CONTEST_TIMER` and runs the judging.
+const STD_BUG_CONTEST_RESULTS_WARP: int = 22
+
+
+## `CheckTimeEvents`' contest branch: the timer is read once a step, and the
+## reading that runs out queues `BugCatchingContestOverScript`, which is the
+## sound, the line and the warp back to the gate. Out of balls reaches the same
+## warp through `BugCatchingContestOutOfBallsScript`, so both are one answer.
+##
+## Answers the queued results, or an empty Array while the contest runs on.
+func check_bug_contest_timer() -> Array:
+	if not bug_contest_active():
+		return []
+	var over: StringName = &""
+	if bug_contest_minutes_remaining() <= 0:
+		over = &"time_up"
+	elif state.park_balls() <= 0:
+		over = &"out_of_balls"
+	if over == &"":
+		return []
+	var entry: Dictionary = data.world_standard_script(STD_BUG_CONTEST_RESULTS_WARP)
+	if entry.is_empty():
+		return []
+	_enqueue_script({
+		"kind": &"bug_contest_over",
+		"reason": over,
+		"map_group": current_map.group if current_map != null else -1,
+		"map_number": current_map.number if current_map != null else -1,
+		"cell": player_cell,
+		"bank": int(entry.get("bank", -1)),
+		"script": int(entry.get("address", -1)),
+	})
+	return run_event_queue(false)
+
+
+## `BugContestResultsWarpScript`'s own tail: the flag is cleared, the balls and
+## the timer go with it, and the Pokemon that was caught stays for the judging
+## the results gate runs.
+func end_bug_contest() -> Dictionary:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	state.set_engine_flag(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_BUG_CONTEST_TIMER, crystal), false
+	)
+	state.set_park_balls(0)
+	state.set_bug_contest_started({})
+	return {"ok": true, "kind": &"bug_contest_ended"}
+
+
+## `_BugContestJudging`: the player's own score against the five contestants who
+## turned up, and where that placed them.
+func judge_bug_contest(random: RandomNumberGenerator) -> Dictionary:
+	var caught: Dictionary = state.contest_mon()
+	var result: Dictionary = Gen2WorldBugContest.judge(
+		int(caught.get("species", 0)),
+		Gen2WorldBugContest.score(caught),
+		data.bug_contestants(),
+		state.withdrawn_bug_contestants(),
+		random if random != null else RandomNumberGenerator.new()
+	)
+	result["ok"] = true
+	result["kind"] = &"bug_contest_judged"
+	result["score"] = Gen2WorldBugContest.score(caught)
+	result["caught"] = caught
+	return result
+
+
 ## `CanEncounterWildMon`: the whole condition on the tile the player is standing
 ## on, before the rate is even read. Without it every step on open ground rolls,
 ## which is both an encounter outside the grass and, over a walk, several times
@@ -1532,6 +1639,27 @@ func encounter_request(
 		terrain_method = Gen2WorldEncounter.METHOD_GRASS
 	if terrain_method not in [Gen2WorldEncounter.METHOD_GRASS, Gen2WorldEncounter.METHOD_SURF]:
 		return {}
+	## `RandomEncounter`'s Bug Contest branch, which replaces the map's own
+	## tables with `ContestMons` and the rate with the standing tile's own.
+	if bug_contest_active():
+		var contest: Dictionary = Gen2WorldBugContest.resolve(
+			data.bug_contest_mons(),
+			Gen2WorldCollision.is_long_grass(collision_code_at(player_cell)),
+			random if random != null else RandomNumberGenerator.new(),
+			force_encounter,
+			{
+				"map_music": state.map_music(),
+				"cleanse_tag": cleanse_tag,
+				"repel_steps": state.repel_steps(),
+				"lead_level": lead_level,
+			}
+		)
+		if contest.is_empty():
+			return {}
+		contest["map"] = map_id()
+		contest["cell"] = player_cell
+		contest["movement"] = movement_mode
+		return contest
 	var source: StringName = Gen2WorldEncounter.SOURCE_NORMAL
 	var record: Dictionary = data.world_encounter(terrain_method, current_map.group, current_map.number)
 	if state.swarm_active_on(current_map.group, current_map.number):
@@ -3247,6 +3375,34 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 			continue
 		if event_type == &"map_reload_requested":
 			generated.append(reload_current_map())
+			continue
+		if event_type == &"bug_contest_started":
+			generated.append(start_bug_contest())
+			continue
+		if event_type == &"bug_contestants_selected":
+			var withdrawn: Dictionary = Gen2WorldBugContest.select_withdrawn(
+				schedule_random if schedule_random != null else RandomNumberGenerator.new()
+			)
+			for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
+				state.set_event_flag(
+					Gen2WorldState.EVENT_BUG_CATCHING_CONTESTANT_FIRST + index,
+					bool(withdrawn.get(index, false))
+				)
+			generated.append({
+				"type": &"bug_contestants_selected",
+				"withdrawn": withdrawn.keys(),
+			})
+			continue
+		if event_type == &"contest_mons_dropped_off":
+			state.set_contest_second_party_species(int(event.get("second_species", 0)))
+			generated.append({
+				"type": &"contest_mons_dropped_off",
+				"second_species": state.contest_second_party_species(),
+			})
+			continue
+		if event_type == &"contest_mons_returned":
+			state.set_contest_second_party_species(0)
+			generated.append({"type": &"contest_mons_returned"})
 			continue
 		if event_type == &"wild_encounters_changed":
 			var wild_enabled: bool = bool(event.get("enabled", true))

--- a/game/world/world_bug_contest.gd
+++ b/game/world/world_bug_contest.gd
@@ -1,0 +1,258 @@
+class_name Gen2WorldBugContest
+extends RefCounted
+
+## The Bug Catching Contest: its own encounter roll, its score, and its judging
+## (`engine/events/bug_contest/`, `engine/overworld/events.asm`'s
+## `TryWildEncounter_BugContest` and `ChooseWildEncounter_BugContest`).
+##
+## Scene-free and stateless, like [Gen2WorldTreemon]: the tables are the cache's
+## (`GameData.bug_contest_mons`, `GameData.bug_contestants`), the live counters
+## are [Gen2WorldState]'s, and every roll takes the caller's generator so a
+## contest is reproducible.
+
+## constants/script_constants.asm.
+const BALLS: int = 20
+const MINUTES: int = 20
+const SECONDS: int = 0
+const PLAYER_ID: int = 1
+const NUM_CONTESTANTS: int = 10
+## `ContestMons`' own eleven rows, the last of which is the `db -1` sentinel.
+const NUM_CONTEST_MONS: int = 11
+## `SelectRandomBugContestContestants` sets five of the ten flags, and a set
+## flag is a contestant who is *not* in this contest: `ComputeAIContestantScores`
+## skips the ones whose flag answers nz.
+const CONTESTANTS_WITHDRAWN: int = 5
+
+## `macros/data.asm`'s `percent`, which is `* $ff / 100`, so these are the two
+## `TryWildEncounter_BugContest` loads rather than 40 and 20.
+const RATE_LONG_GRASS: int = 40 * 0xFF / 100
+const RATE_ELSEWHERE: int = 20 * 0xFF / 100
+
+## `ChooseWildEncounter_BugContest`'s own `cp 100 << 1`: the roll is taken over
+## 0-199 and halved, so the walk down the percentages is uniform over 0-99.
+const CHOICE_LIMIT: int = 200
+
+
+## `TryWildEncounter_BugContest` then `ChooseWildEncounter_BugContest`: the rate
+## is the standing tile's, the two rate modifiers are the ordinary ones, and the
+## table is walked by percentage. Answers the same shape
+## [method Gen2WorldEncounter.resolve] does, or an empty Dictionary.
+static func resolve(
+	mons: Array,
+	long_grass: bool,
+	random: RandomNumberGenerator,
+	force_encounter: bool = false,
+	options: Dictionary = {},
+) -> Dictionary:
+	if mons.is_empty() or random == null:
+		return {}
+	var rate: int = RATE_LONG_GRASS if long_grass else RATE_ELSEWHERE
+	rate = Gen2WorldEncounter.apply_music_effect(rate, int(options.get("map_music", 0)))
+	if bool(options.get("cleanse_tag", false)):
+		rate >>= 1
+	var encounter_roll: int = -1
+	if not force_encounter:
+		encounter_roll = random.randi_range(0, 255)
+		if encounter_roll >= rate:
+			return {}
+
+	var choice_roll: int = -1
+	for _attempt: int in 128:
+		var roll: int = random.randi_range(0, 255)
+		if roll < CHOICE_LIMIT:
+			choice_roll = roll >> 1
+			break
+	if choice_roll < 0:
+		return {}
+
+	var remaining: int = choice_roll
+	var chosen: Dictionary = {}
+	for row: Dictionary in mons:
+		remaining -= int(row.get("percent", 0))
+		if remaining < 0:
+			chosen = row
+			break
+	if chosen.is_empty():
+		return {}
+
+	var level: int = _level(chosen, random)
+	if int(options.get("repel_steps", 0)) > 0 and int(options.get("lead_level", -1)) > 0 \
+		and level < int(options["lead_level"]):
+		return {}
+	return {
+		"kind": &"wild_encounter_requested",
+		"method": Gen2WorldEncounter.METHOD_GRASS,
+		"source": SOURCE_CONTEST,
+		"slot": -1,
+		"pokemon": int(chosen.get("species", 0)),
+		"level": level,
+		"rate": rate,
+		"encounter_roll": encounter_roll,
+		"choice_roll": choice_roll,
+		"forced": force_encounter,
+		"battle_type": BATTLE_TYPE,
+		"values": {
+			"kind": &"wild", "pokemon": int(chosen.get("species", 0)), "level": level,
+			## `loadvar VAR_BATTLETYPE, BATTLETYPE_CONTEST`, which
+			## `BugCatchingContestBattleScript` sets before `startbattle`.
+			"battle_type": BATTLE_TYPE,
+		},
+	}
+
+
+## The encounter's own source name, beside [Gen2WorldEncounter]'s five. The
+## battle type is the engine's own constant rather than a second copy of it.
+const SOURCE_CONTEST: StringName = &"bug_contest"
+const BATTLE_TYPE: int = Gen2Battle.BATTLETYPE_CONTEST
+
+
+## `.RandomLevel`: a level between the row's own two, taken as
+## `Random % (max - min + 1) + min`, which `SimpleDivide`'s remainder is. Equal
+## bounds skip the roll entirely, so a Venomoth costs no draw.
+static func _level(row: Dictionary, random: RandomNumberGenerator) -> int:
+	var low: int = int(row.get("min_level", 1))
+	var high: int = int(row.get("max_level", low))
+	if high <= low:
+		return low
+	return low + random.randi_range(0, 255) % (high - low + 1)
+
+
+## `ContestScore`: the tally the player's caught Pokemon is judged on. Every
+## term is the *low* byte of a big-endian word, which is the stat itself for
+## anything a contest Pokemon can reach, and the whole runs 16 bit with carry.
+##
+## [param mon] is the caught Pokemon as [Gen2WorldState] keeps it:
+## `max_hp`, `hp`, `attack`, `defense`, `speed`, `special_attack`,
+## `special_defense`, `dvs` and `item`.
+static func score(mon: Dictionary) -> int:
+	if int(mon.get("species", 0)) <= 0:
+		return 0
+	var total: int = 0
+	for _copy: int in 4:
+		total += int(mon.get("max_hp", 0)) & 0xFF
+	for stat: String in [
+		"attack", "defense", "speed", "special_attack", "special_defense",
+	]:
+		total += int(mon.get(stat, 0)) & 0xFF
+	total += _dv_score(int(mon.get("dvs", 0)))
+	total += (int(mon.get("hp", 0)) & 0xFF) >> 3
+	if int(mon.get("item", 0)) > 0:
+		total += 1
+	return total & 0xFFFF
+
+
+## The DV term, bit for bit. Only bit 1 of each of the four DVs is read, which
+## is the same bit `CheckShininess` reads, and each is weighted differently:
+## attack twice, defense four times, speed a half and special twice, the whole
+## then doubled twice by the two `add d`s.
+static func _dv_score(dvs: int) -> int:
+	var attack: int = (dvs >> 12) & 0x0F
+	var defense: int = (dvs >> 8) & 0x0F
+	var speed: int = (dvs >> 4) & 0x0F
+	var special: int = dvs & 0x0F
+	var first: int = ((attack & 0x02) << 1) + ((defense & 0x02) << 2)
+	var second: int = ((speed & 0x02) >> 1) + ((special & 0x02) << 1)
+	return (second + first * 2) & 0xFF
+
+
+## `BugContest_JudgeContestants`: the AI contestants are scored first and the
+## player is inserted last, which is why the player takes a place on a tie.
+##
+## [param withdrawn] is the set of contestant indices whose event flag is set,
+## which `SelectRandomBugContestContestants` chose and who therefore do not
+## compete. Answers `{"placings": [...], "player_place": 0..3}` with the placings
+## first to third, each `{"id", "species", "score"}` and an id of
+## [constant PLAYER_ID] for the player.
+static func judge(
+	player_species: int,
+	player_score: int,
+	contestants: Array,
+	withdrawn: Dictionary,
+	random: RandomNumberGenerator,
+) -> Dictionary:
+	var placings: Array = []
+	for index: int in mini(NUM_CONTESTANTS, contestants.size()):
+		if bool(withdrawn.get(index, false)):
+			continue
+		var entry: Dictionary = contestants[index]
+		var rows: Array = entry.get("placings", [])
+		if rows.is_empty():
+			continue
+		var pick: int = -1
+		for _attempt: int in 128:
+			var roll: int = random.randi_range(0, 255) & 0x03
+			if roll != 3:
+				pick = roll
+				break
+		if pick < 0 or pick >= rows.size():
+			continue
+		var row: Dictionary = rows[pick]
+		_insert(placings, {
+			## `ld a, e / inc a / inc a`: the player is 1, so contestant zero is 2.
+			"id": index + 2,
+			"species": int(row.get("species", 0)),
+			## The score is perturbed upward by `Random and %111`, never down.
+			"score": (int(row.get("score", 0)) + (random.randi_range(0, 255) & 0x07)) & 0xFFFF,
+		})
+	_insert(placings, {
+		"id": PLAYER_ID, "species": player_species, "score": player_score,
+	})
+	var player_place: int = 0
+	for index: int in placings.size():
+		if int(placings[index].get("id", 0)) == PLAYER_ID:
+			player_place = index + 1
+			break
+	return {"placings": placings, "player_place": player_place}
+
+
+## `DetermineContestWinners`: three slots, each entry compared against first,
+## then second, then third, and the ones below it pushed down. `CompareBytes`
+## answers carry only when the newcomer is *lower*, so an equal score takes the
+## place.
+static func _insert(placings: Array, entry: Dictionary) -> void:
+	for index: int in 3:
+		if index >= placings.size():
+			placings.append(entry)
+			return
+		if int(entry["score"]) >= int(placings[index].get("score", 0)):
+			placings.insert(index, entry)
+			if placings.size() > 3:
+				placings.resize(3)
+			return
+
+
+## `CheckBugContestTimer`, in the minutes the world clock keeps: the contest
+## runs [constant MINUTES] from the minute it started and the counter is what
+## `VAR_BUGCONTEST_MINS_REMAINING` reads. The source also counts the seconds
+## down inside the minute; nothing here has seconds, and no script reads them.
+static func minutes_remaining(started: Dictionary, now: Dictionary) -> int:
+	if started.is_empty():
+		return 0
+	var elapsed: int = _minute_of_week(now) - _minute_of_week(started)
+	if elapsed < 0:
+		elapsed += Gen2WorldClock.DAYS_PER_WEEK \
+			* Gen2WorldClock.HOURS_PER_DAY * Gen2WorldClock.MINUTES_PER_HOUR
+	return maxi(0, MINUTES - elapsed)
+
+
+static func _minute_of_week(clock: Dictionary) -> int:
+	return ((int(clock.get("day", 0)) * Gen2WorldClock.HOURS_PER_DAY
+		+ int(clock.get("hour", 0))) * Gen2WorldClock.MINUTES_PER_HOUR
+		+ int(clock.get("minute", 0)))
+
+
+## `SelectRandomBugContestContestants`: five of the ten flags set, chosen by a
+## rejection roll that refuses a flag it has already set. Answers the set of
+## indices, which is what `ComputeAIContestantScores` skips.
+static func select_withdrawn(random: RandomNumberGenerator) -> Dictionary:
+	var out: Dictionary = {}
+	if random == null:
+		return out
+	while out.size() < CONTESTANTS_WITHDRAWN:
+		## `cp $ff / NUM_BUG_CONTESTANTS * NUM_BUG_CONTESTANTS` is 250, and the
+		## divisor is 25, so the roll is uniform over the ten.
+		var roll: int = random.randi_range(0, 255)
+		if roll >= 250:
+			continue
+		out[roll / 25] = true
+	return out

--- a/game/world/world_bug_contest.gd.uid
+++ b/game/world/world_bug_contest.gd.uid
@@ -1,0 +1,1 @@
+uid://c60piy4cs8yqc

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -45,7 +45,7 @@ static func resolve(
 		generator.randomize()
 
 	var rate: int = _rate(record, method, time_of_day)
-	rate = _apply_music_effect(rate, int(options.get("map_music", 0)))
+	rate = apply_music_effect(rate, int(options.get("map_music", 0)))
 	if bool(options.get("cleanse_tag", false)):
 		rate >>= 1
 	if rate <= 0:
@@ -284,7 +284,7 @@ const MUSIC_POKEMON_LULLABY: int = 0x50
 const MUSIC_POKEMON_MARCH: int = 0x51
 
 
-static func _apply_music_effect(rate: int, map_music: int) -> int:
+static func apply_music_effect(rate: int, map_music: int) -> int:
 	if map_music == MUSIC_POKEMON_MARCH or map_music == MUSIC_RUINS_OF_ALPH_RADIO:
 		return (rate << 1) & 0xFF
 	if map_music == MUSIC_POKEMON_LULLABY:

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -18,6 +18,9 @@ const ITEM_MASTER_BALL: int = 0x01
 const ITEM_ULTRA_BALL: int = 0x02
 const ITEM_GREAT_BALL: int = 0x04
 const ITEM_POKE_BALL: int = 0x05
+## The Bug Contest's own ball. It is never in the bag: `wParkBallsRemaining` is
+## what holds it and `BattleMenu_Pack`'s contest branch loads it by name.
+const ITEM_PARK_BALL: int = 0xB1
 
 const CAPTURE_BALLS: Array[int] = [
 	ITEM_POKE_BALL, ITEM_GREAT_BALL, ITEM_ULTRA_BALL, ITEM_MASTER_BALL,
@@ -647,6 +650,64 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 	}
 
 
+## A Park Ball thrown inside the Bug Catching Contest, which is a different
+## transaction from [method capture_wild]: the ball comes out of
+## `wParkBallsRemaining` rather than the bag, and what is caught goes to
+## `wContestMon` rather than to the party or a box, so no save is touched and
+## nothing can be refused for a full party.
+##
+## `BugContest_SetCaughtContestMon` asks before replacing a Pokemon already
+## caught, so a hit while one is held answers `replace_offer` and leaves the
+## state alone until the caller comes back with [method set_contest_mon].
+static func capture_contest(
+	world: Gen2WorldAPI, wild: Gen2BattleMon, random: RandomNumberGenerator = null
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null or wild == null:
+		return _failure(&"missing_capture_context", {})
+	if world.state.park_balls() <= 0:
+		return _failure(&"no_park_balls", {"ball": ITEM_PARK_BALL})
+	var generator: RandomNumberGenerator = random if random != null else RandomNumberGenerator.new()
+	if random == null:
+		generator.randomize()
+	world.state.set_park_balls(world.state.park_balls() - 1)
+	var outcome: Dictionary = _capture_outcome(world.data, wild, ITEM_PARK_BALL, generator)
+	var result: Dictionary = {
+		"ok": true,
+		"ball": ITEM_PARK_BALL,
+		"quantity": world.state.park_balls(),
+		"caught": bool(outcome["caught"]),
+		"catch_rate": int(outcome["catch_rate"]),
+		"wobbles": int(outcome["wobbles"]),
+		"contest": true,
+	}
+	if not bool(outcome["caught"]):
+		return result
+	result["mon"] = contest_mon_from(wild)
+	result["replace_offer"] = not world.state.contest_mon().is_empty()
+	if not bool(result["replace_offer"]):
+		world.state.set_contest_mon(result["mon"])
+	return result
+
+
+## `.generatestats`: the caught Pokemon as `ContestScore` reads it. The stats
+## and DVs are the ones the wild was standing there with, which is what
+## `GeneratePartyMonStats` builds for a `WILDMON`.
+static func contest_mon_from(wild: Gen2BattleMon) -> Dictionary:
+	return {
+		"species": wild.species,
+		"level": wild.level,
+		"hp": wild.hp,
+		"max_hp": wild.max_hp(),
+		"attack": int(wild.stats.get("attack", 0)),
+		"defense": int(wild.stats.get("defense", 0)),
+		"speed": int(wild.stats.get("speed", 0)),
+		"special_attack": int(wild.stats.get("sp_attack", 0)),
+		"special_defense": int(wild.stats.get("sp_defense", 0)),
+		"dvs": wild.dvs,
+		"item": wild.item,
+	}
+
+
 static func _capture_outcome(
 	data: GameData, wild: Gen2BattleMon, ball: int, random: RandomNumberGenerator
 ) -> Dictionary:
@@ -657,7 +718,9 @@ static func _capture_outcome(
 	match ball:
 		ITEM_ULTRA_BALL:
 			catch_rate = mini(catch_rate * 2, 255)
-		ITEM_GREAT_BALL:
+		## `GreatBallMultiplier` and `ParkBallMultiplier` are the same routine
+		## written twice: catch rate times one and a half.
+		ITEM_GREAT_BALL, ITEM_PARK_BALL:
 			catch_rate = mini(catch_rate + int(catch_rate / 2.0), 255)
 		ITEM_POKE_BALL:
 			pass

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -858,6 +858,13 @@ func _after_player_move(movement: Dictionary) -> bool:
 	if bool(phone_attempt.get("attempted", false)) and not phone_results.is_empty():
 		_show_script_results(phone_results)
 		return true
+	## `CheckTimeEvents`' contest branch, which is read a step at a time and
+	## takes the whole turn when it runs out: no encounter is rolled on the step
+	## the contest ends.
+	var contest_over: Array = _world.check_bug_contest_timer()
+	if not contest_over.is_empty():
+		_show_script_results(contest_over)
+		return true
 	_show_script_results([])
 	var encounter: Dictionary = _world.encounter_request(
 		_encounter_random, false, &"auto", _repel_lead_level(), _party_holds_cleanse_tag()
@@ -869,6 +876,25 @@ func _after_player_move(movement: Dictionary) -> bool:
 			"encounter": encounter.duplicate(true),
 		})
 	return true
+
+
+## The three placings as one line. `_BugContestJudging` prints them as three
+## texts of its own, which no script points at and so nothing imports; the
+## placings themselves are the source's.
+func _bug_contest_placings_text(judged: Dictionary) -> String:
+	var parts: PackedStringArray = []
+	var places: Array[String] = ["1st", "2nd", "3rd"]
+	var placings: Array = judged.get("placings", [])
+	for index: int in placings.size():
+		var entry: Dictionary = placings[index]
+		var who: String = "You" if int(entry.get("id", 0)) == Gen2WorldBugContest.PLAYER_ID \
+			else "Contestant %d" % int(entry.get("id", 0))
+		parts.append("%s %s, %s (%d)" % [
+			places[index], who,
+			String(_data.species(int(entry.get("species", 0))).get("name", "-")),
+			int(entry.get("score", 0)),
+		])
+	return "Bug Contest: %s" % ", ".join(parts)
 
 
 ## `CheckRepelEffect`'s own lead: the first party member that is not fainted, or
@@ -1518,9 +1544,17 @@ func _start_battle_request(request: Dictionary) -> void:
 	# carries that one.
 	host.set_world_context(Gen2BattleWorldContext.capture(_world, _render_time_of_day()))
 	if _world != null and not tutorial:
-		host.set_capture_balls(
-			Gen2WorldPartyHost.owned_capture_balls(_world), _world.state.items()
-		)
+		## `BattleMenu_Pack`'s contest branch loads PARK_BALL and nothing else,
+		## and the count is `wParkBallsRemaining` rather than the bag.
+		if _world.bug_contest_active():
+			host.set_capture_balls(
+				[Gen2WorldPartyHost.ITEM_PARK_BALL],
+				{Gen2WorldPartyHost.ITEM_PARK_BALL: _world.state.park_balls()}
+			)
+		else:
+			host.set_capture_balls(
+				Gen2WorldPartyHost.owned_capture_balls(_world), _world.state.items()
+			)
 	host.set_meta("world_battle_request", {
 		"request": request.duplicate(true),
 		"save": save,
@@ -1558,8 +1592,14 @@ func _on_capture_requested(ball: int) -> void:
 		_active_battle_save = save
 		_active_battle_persist = false
 	var target: Gen2BattleMon = _battle_host.capture_target()
-	var result: Dictionary = Gen2WorldPartyHost.capture_wild(
-		_world, save, target, ball, _encounter_random, 0, _active_battle_persist
+	## A contest throw is its own transaction: the ball is the contest's, the
+	## catch goes to wContestMon and no save is touched.
+	var result: Dictionary = (
+		Gen2WorldPartyHost.capture_contest(_world, target, _encounter_random)
+		if _world.bug_contest_active()
+		else Gen2WorldPartyHost.capture_wild(
+			_world, save, target, ball, _encounter_random, 0, _active_battle_persist
+		)
 	)
 	_battle_host.complete_capture(result)
 	_refresh_labels()
@@ -1588,8 +1628,21 @@ func _on_battle_finished(result: Dictionary) -> void:
 			_renderer.refresh()
 		if StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_CAUGHT:
 			var capture: Dictionary = result.get("capture", {})
-			var species: Dictionary = _data.species(int(capture.get("species", 0)))
-			_script_prompt = "Caught %s" % String(species.get("name", "UNKNOWN"))
+			if bool(capture.get("contest", false)):
+				## The catch is only kept when the question the battle asked was
+				## answered YES, or when there was nothing to replace, which the
+				## host already stored.
+				var caught_mon: Dictionary = capture.get("mon", {})
+				if bool(capture.get("replace", false)) and not caught_mon.is_empty():
+					_world.state.set_contest_mon(caught_mon)
+				var held: Dictionary = _world.state.contest_mon()
+				_script_prompt = "Contest: holding %s, %d PARK BALLs left" % [
+					String(_data.species(int(held.get("species", 0))).get("name", "nothing")),
+					_world.state.park_balls(),
+				]
+			else:
+				var species: Dictionary = _data.species(int(capture.get("species", 0)))
+				_script_prompt = "Caught %s" % String(species.get("name", "UNKNOWN"))
 		else:
 			_script_prompt = "Battle finished: %s" % String(
 				result.get("outcome", result.get("reason", "unknown"))
@@ -2588,6 +2641,19 @@ func _show_script_results(results: Array) -> void:
 				if StringName(request.get("kind", &"")) == &"catch_tutorial_requested":
 					_start_battle_request(request)
 					break
+				if StringName(request.get("kind", &"")) == &"bug_contest_judging_requested":
+					## `_BugContestJudging` scores the player, ranks them against
+					## the contestants who turned up and leaves the placing in
+					## wScriptVar, which the results script branches on.
+					var judged: Dictionary = _world.judge_bug_contest(_encounter_random)
+					var judged_results: Array = _world.complete_runtime_request({
+						"ok": true,
+						"script_value": int(judged.get("player_place", 0)),
+						"judging": judged.duplicate(true),
+					})
+					_script_prompt = _bug_contest_placings_text(judged)
+					_show_script_results(judged_results)
+					return
 				if StringName(request.get("kind", &"")) == &"swarm_requested":
 					var values: Dictionary = request.get("values", {})
 					var swarm_results: Array = _world.complete_runtime_request({
@@ -2946,7 +3012,20 @@ func _refresh_party_summary() -> void:
 			moves.append(mon_moves)
 			names.append(_mon_display_name(mon))
 			eggs.append(mon.is_egg)
-	_world.set_party_summary(save.party.size(), has_pokerus, species, moves, names, eggs)
+	## The three party facts the Bug Contest's own scripts ask about, which are
+	## not per-slot: whether the lead can be entered at all, the byte
+	## `ContestDropOffMons` stashes, and whether what is caught can be taken home.
+	var lead: Gen2SaveMon = save.party[0] if not save.party.is_empty() else null
+	var second: Gen2SaveMon = save.party[1] if save.party.size() > 1 else null
+	_world.set_party_summary(
+		save.party.size(), has_pokerus, species, moves, names, eggs,
+		{
+			"lead_fainted": lead == null or lead.hp <= 0,
+			"second_species": int(second.species) if second != null else 0,
+			"storage_full": save.party.size() >= Gen2SaveData.MAX_PARTY \
+				and not bool(save.first_empty_box_slot().get("ok", false)),
+		}
+	)
 
 
 ## GetPartyNickname's answer for one slot, following the party screen's own rule:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -83,6 +83,15 @@ var _random := RandomNumberGenerator.new()
 const PHONE_CONTACT_GOT: int = 0
 const PHONE_CONTACTS_FULL: int = 1
 const PHONE_CONTACT_REFUSED: int = 2
+## The Bug Catching Contest's own six, all below the index where Gold and
+## Silver's table diverges except the contestant draw, which special_index()
+## normalizes (engine/events/special_pointers.asm).
+const SPECIAL_BUG_CONTEST_JUDGING: int = 20
+const SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST: int = 21
+const SPECIAL_CONTEST_DROP_OFF_MONS: int = 22
+const SPECIAL_CONTEST_RETURN_MONS: int = 23
+const SPECIAL_GIVE_PARK_BALLS: int = 24
+const SPECIAL_SELECT_RANDOM_BUG_CONTESTANTS: int = 71
 const SPECIAL_ACTIVATE_FISHING_SWARM: int = 72
 const SPECIAL_TOGGLE_MAPTILE_DECORATIONS: int = 73
 const SPECIAL_TOGGLE_DECORATIONS_VISIBILITY: int = 74
@@ -700,6 +709,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 	if kind in [
 		&"mart_requested", &"audio_requested", &"pokemon_requested", &"trade_requested",
 		&"pc_requested", &"party_heal_requested", &"town_map_requested",
+		## `BugContestJudging` answers with the placing, which the results script
+		## reads out of wScriptVar exactly as the marts and the PC do.
+		&"bug_contest_judging_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -2171,7 +2183,7 @@ func _execute_special(special: int) -> Dictionary:
 			_script_value = 1 if state != null \
 				and state.map_music() == Gen2WorldRadio.MUSIC_POKE_FLUTE_CHANNEL \
 				and cell in SNORLAX_PROXIMITY_CELLS else 0
-		46, 48, 49, 50, 51, 94, 95, 157, 158:
+		46, 48, 49, 50, 51, 52, 53, 94, 95, 157, 158:
 			## Fade, sprite reload and the dummied trainer-ranking bookkeeping
 			## affect presentation or source-only counters, not scene-free state.
 			## `FadeOutToWhite` is 46 in both pins, since Crystal's inserted
@@ -2182,6 +2194,10 @@ func _execute_special(special: int) -> Dictionary:
 			## `RefreshSprites` (158) reload the sprite set a `variablesprite`
 			## just changed. `PlaySlowCry` (95) is the cry player with its pitch
 			## and tempo lowered, so it plays audio and reads nothing.
+			## `ClearBGPalettes` (52) and `UpdateTimePals` (53) are the palette
+			## pair `BugContestResultsWarpScript` and the day/night scripts open
+			## with; the renderer takes its palettes from the map and the clock,
+			## so both are presentation here too.
 			_emit_runtime_event(&"presentation_special_applied", {"special": special})
 		SPECIAL_INIT_ROAM_MONS:
 			## InitRoamMons seeds the roam structs with Raikou and Entei at
@@ -2200,6 +2216,44 @@ func _execute_special(special: int) -> Dictionary:
 			## chosen apricorn and how many of it, and a backed-out box is the
 			## source's own `wScriptVar = 0`.
 			return _stage_runtime_request(&"apricorn_selection_requested", {
+				"special": special,
+			})
+		SPECIAL_GIVE_PARK_BALLS:
+			## `GiveParkBalls` clears wContestMon, loads twenty balls and starts
+			## the timer. The flag itself is the script's own `setflag`, which
+			## has already run by here.
+			_emit_runtime_event(&"bug_contest_started", {"special": special})
+		SPECIAL_SELECT_RANDOM_BUG_CONTESTANTS:
+			## Five of the ten contestant flags set, which is both who competes
+			## in the judging and which sprites the park does not draw.
+			_emit_runtime_event(&"bug_contestants_selected", {"special": special})
+		SPECIAL_CONTEST_DROP_OFF_MONS:
+			## `ContestDropOffMons` answers 1 when the lead is fainted, which is
+			## the one branch its callers read, and otherwise masks the party to
+			## its first member.
+			var contest_party: Dictionary = _request.get("party", {})
+			if contest_party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			var lead_fainted: bool = bool(contest_party.get("lead_fainted", false))
+			_script_value = 1 if lead_fainted else 0
+			if not lead_fainted:
+				_emit_runtime_event(&"contest_mons_dropped_off", {
+					"special": special,
+					"second_species": int(contest_party.get("second_species", 0)),
+				})
+		SPECIAL_CONTEST_RETURN_MONS:
+			_emit_runtime_event(&"contest_mons_returned", {"special": special})
+		SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST:
+			## `CheckPartyFullAfterContest` answers whether the Pokemon caught in
+			## the contest can be taken home, which is a party slot or a box slot.
+			var after_party: Dictionary = _request.get("party", {})
+			if after_party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			_script_value = 1 if bool(after_party.get("storage_full", false)) else 0
+		SPECIAL_BUG_CONTEST_JUDGING:
+			## The judging prints three placings and leaves the player's own in
+			## wScriptVar, which the results script branches on.
+			return _stage_runtime_request(&"bug_contest_judging_requested", {
 				"special": special,
 			})
 		SPECIAL_ACTIVATE_FISHING_SWARM:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -120,6 +120,19 @@ var _wild_encounter_cooldown: int = 0
 ## `wStatusFlags`' `STATUSFLAGS_NO_WILD_ENCOUNTERS_F`, which `wildoff` sets and
 ## `wildon` clears around a scripted sequence.
 var _wild_encounters_off: bool = false
+## The Bug Catching Contest's own counters. `wParkBallsRemaining` and the clock
+## reading `StartBugContestTimer` copies to `wBugContestStartTime`; whether a
+## contest is running at all is `ENGINE_BUG_CONTEST_TIMER`, which is an engine
+## flag and lives with the rest of them.
+var _park_balls: int = 0
+var _bug_contest_started: Dictionary = {}
+## `wContestMon`, the party-struct-shaped Pokemon `BugContest_SetCaughtContestMon`
+## generates. Kept as the fields `ContestScore` reads rather than a whole
+## [Gen2BattleMon], because judging is all anything does with it.
+var _contest_mon: Dictionary = {}
+## `wBugContestSecondPartySpecies`: the byte `ContestDropOffMons` moves out of
+## the way so the party is one Pokemon long, and `ContestReturnMons` puts back.
+var _contest_second_party_species: int = 0
 var _swarm_map: Vector2i = Vector2i(-1, -1)
 var _fishing_swarm_species: int = 0
 var _roaming_mons: Array = []
@@ -249,6 +262,10 @@ func to_dict() -> Dictionary:
 		"repel_steps": _repel_steps,
 		"wild_encounter_cooldown": _wild_encounter_cooldown,
 		"wild_encounters_off": _wild_encounters_off,
+		"park_balls": _park_balls,
+		"bug_contest_started": _bug_contest_started.duplicate(),
+		"contest_mon": _contest_mon.duplicate(),
+		"contest_second_party_species": _contest_second_party_species,
 		"swarm_map": [_swarm_map.x, _swarm_map.y],
 		"fishing_swarm_species": _fishing_swarm_species,
 		"roaming_mons": _copy_roaming_mons(_roaming_mons),
@@ -320,6 +337,16 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored.set_registered_item(int(source.get("registered_item", 0)))
 	restored.set_wild_encounter_cooldown(int(source.get("wild_encounter_cooldown", 0)))
 	restored.set_wild_encounters_off(bool(source.get("wild_encounters_off", false)))
+	restored.set_park_balls(int(source.get("park_balls", 0)))
+	var started: Variant = source.get("bug_contest_started", {})
+	if started is Dictionary:
+		restored._bug_contest_started = _clock_dict(started as Dictionary)
+	var caught: Variant = source.get("contest_mon", {})
+	if caught is Dictionary and int((caught as Dictionary).get("species", 0)) > 0:
+		restored._contest_mon = (caught as Dictionary).duplicate()
+	restored.set_contest_second_party_species(
+		int(source.get("contest_second_party_species", 0))
+	)
 	return restored
 
 
@@ -342,6 +369,10 @@ func restore_from_dict(raw: Variant) -> void:
 	_repel_steps = restored._repel_steps
 	_wild_encounter_cooldown = restored._wild_encounter_cooldown
 	_wild_encounters_off = restored._wild_encounters_off
+	_park_balls = restored._park_balls
+	_bug_contest_started = restored._bug_contest_started.duplicate()
+	_contest_mon = restored._contest_mon.duplicate()
+	_contest_second_party_species = restored._contest_second_party_species
 	_swarm_map = restored._swarm_map
 	_fishing_swarm_species = restored._fishing_swarm_species
 	_roaming_mons = _copy_roaming_mons(restored._roaming_mons)
@@ -779,6 +810,89 @@ func consume_wild_encounter_cooldown() -> bool:
 	_wild_encounter_cooldown -= 1
 	changed.emit()
 	return _wild_encounter_cooldown > 0
+
+
+## `ENGINE_BUG_CONTEST_TIMER`, the flag `Route35NationalParkGate` sets on the
+## way in and `BugContestResultsWarpScript` clears on the way out. It is
+## `wStatusFlags2`' own bit, so it sits past `ENGINE_MOBILE_SYSTEM` and shifts on
+## Gold and Silver like every other flag there.
+const ENGINE_BUG_CONTEST_TIMER: int = 17
+## `ENGINE_DAILY_BUG_CONTEST`, the once-a-day flag the officer checks.
+const ENGINE_DAILY_BUG_CONTEST: int = 81
+## `BugCatchingContestantEventFlagTable`, whose ten entries are the same numbers
+## in both pins. A set flag is a contestant who is not in this contest.
+const EVENT_BUG_CATCHING_CONTESTANT_FIRST: int = 1814
+
+
+## [param crystal] the way every other profile-shifted flag takes it: the state
+## holds no GameData of its own, so the caller resolves the profile.
+func bug_contest_active(crystal: bool = true) -> bool:
+	return is_engine_flag_active(engine_flag(ENGINE_BUG_CONTEST_TIMER, crystal))
+
+
+func park_balls() -> int:
+	return _park_balls
+
+
+func set_park_balls(count: int) -> void:
+	var next_count: int = clampi(count, 0, 0xFF)
+	if next_count == _park_balls:
+		return
+	_park_balls = next_count
+	changed.emit()
+
+
+## The clock `StartBugContestTimer` copied, as `{day, hour, minute}`, or an empty
+## Dictionary when no contest has been started.
+func bug_contest_started() -> Dictionary:
+	return _bug_contest_started.duplicate()
+
+
+func set_bug_contest_started(clock: Dictionary) -> void:
+	_bug_contest_started = _clock_dict(clock)
+	changed.emit()
+
+
+static func _clock_dict(clock: Dictionary) -> Dictionary:
+	if clock.is_empty():
+		return {}
+	return {
+		"day": int(clock.get("day", 0)),
+		"hour": int(clock.get("hour", 0)),
+		"minute": int(clock.get("minute", 0)),
+	}
+
+
+func contest_mon() -> Dictionary:
+	return _contest_mon.duplicate()
+
+
+func set_contest_mon(mon: Dictionary) -> void:
+	_contest_mon = mon.duplicate() if int(mon.get("species", 0)) > 0 else {}
+	changed.emit()
+
+
+func contest_second_party_species() -> int:
+	return _contest_second_party_species
+
+
+func set_contest_second_party_species(species: int) -> void:
+	var next_species: int = clampi(species, 0, 0xFF)
+	if next_species == _contest_second_party_species:
+		return
+	_contest_second_party_species = next_species
+	changed.emit()
+
+
+## Which of the ten contestants are not in this contest, as
+## `{index: true}`, read off the event flags
+## `SelectRandomBugContestContestants` set.
+func withdrawn_bug_contestants() -> Dictionary:
+	var out: Dictionary = {}
+	for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
+		if is_event_flag_active(EVENT_BUG_CATCHING_CONTESTANT_FIRST + index):
+			out[index] = true
+	return out
 
 
 func wild_encounters_off() -> bool:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -225,6 +225,19 @@ func _write_cache(game_id: String = "testworld") -> void:
 					{"level": 5, "species": 16}],
 			},
 		},
+		"bug_contest": {
+			"mons": [
+				{"percent": 50, "species": 10, "min_level": 7, "max_level": 18},
+				{"percent": 50, "species": 13, "min_level": 9, "max_level": 9},
+				{"percent": 255, "species": 49, "min_level": 30, "max_level": 40},
+			],
+			"contestants": [
+				{"trainer_class": 36, "trainer": 1, "placings": [
+					{"species": 10, "score": 300}, {"species": 11, "score": 285},
+					{"species": 12, "score": 226},
+				]},
+			],
+		},
 		"swarm_grass": {
 			"1:1": {
 				"map": "1:1", "rates": [255, 255, 255],
@@ -262,6 +275,9 @@ func _write_cache(game_id: String = "testworld") -> void:
 	})
 	RomCache.write_json(RomCache.world_standard_scripts_path(_directory), {
 		"0": {"bank": 48, "address": 0x6020, "bytes": [0x4C, 0x00, 0x70, 0x91]},
+		# BugContestResultsWarpScript's own index, so the contest can end the way
+		# CheckTimeEvents ends it: through the std script, not a special case.
+		"22": {"bank": 48, "address": 0x6020, "bytes": [0x4C, 0x00, 0x70, 0x91]},
 	})
 	RomCache.write_json(RomCache.world_text_path(_directory), {
 		"48:7000": [0x00, 0x80, 0x81, Gen2WorldScript.TEXT_TERMINATOR],
@@ -5983,3 +5999,111 @@ func test_the_picked_fruit_trees_survive_a_snapshot_round_trip() -> void:
 	var bad: Dictionary = state.apply_changes({}, {}, {"fruit_trees": {0: true}})
 	assert_false(bad["ok"])
 	assert_eq(bad["reason"], &"invalid_fruit_trees")
+
+
+## The Bug Catching Contest, from the officer's specials to the encounter and
+## the timer (engine/events/bug_contest/, engine/overworld/events.asm).
+func _contest_world(cell: Vector2i = Vector2i(5, 10)) -> Gen2WorldAPI:
+	var world := _world(cell)
+	world.state.set_wild_encounter_cooldown(0)
+	## The officer's own `setflag ENGINE_BUG_CONTEST_TIMER`, resolved for the
+	## profile the way every flag past ENGINE_MOBILE_SYSTEM has to be.
+	world.state.set_engine_flag(Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
+		Gen2WorldState.is_crystal_profile(world.data)
+	))
+	return world
+
+
+func test_a_contest_replaces_the_maps_own_tables_with_contest_mons() -> void:
+	var world := _contest_world()
+	assert_true(world.bug_contest_active())
+	var encounter: Dictionary = world.encounter_request(_seeded(), true)
+	assert_eq(encounter["source"], Gen2WorldBugContest.SOURCE_CONTEST)
+	assert_eq(encounter["rate"], Gen2WorldBugContest.RATE_ELSEWHERE)
+	assert_ne(int(encounter["pokemon"]), 16, "not the fixture map's own slot")
+	assert_eq(int(encounter["battle_type"]), Gen2WorldBugContest.BATTLE_TYPE)
+
+	## Its own rate rather than the map's 255, so a walk in the grass draws some
+	## of the time instead of every step.
+	var random: RandomNumberGenerator = _seeded()
+	var drawn: int = 0
+	for _step: int in 200:
+		world.state.set_wild_encounter_cooldown(0)
+		if not world.encounter_request(random).is_empty():
+			drawn += 1
+	assert_between(drawn, 1, 199, "the contest rate is neither never nor always")
+
+	## `CanEncounterWildMon` still gates it: a contest rolls nothing off grass.
+	world.player_cell = Vector2i(5, 9)
+	world.state.set_wild_encounter_cooldown(0)
+	assert_true(world.encounter_request(_seeded()).is_empty())
+
+
+func test_giving_park_balls_starts_the_timer_and_the_count() -> void:
+	var world := _contest_world()
+	var started: Dictionary = world.start_bug_contest()
+	assert_eq(int(started["park_balls"]), Gen2WorldBugContest.BALLS)
+	assert_eq(world.bug_contest_minutes_remaining(), Gen2WorldBugContest.MINUTES)
+	assert_eq(world.state.bug_contest_started()["hour"], world.world_hour)
+	assert_true(world.check_bug_contest_timer().is_empty(), "twenty minutes left")
+
+	## `CheckTimeEvents` ends it on the reading that runs out, and running out of
+	## balls reaches the same warp.
+	world.set_world_clock(
+		world.world_day, world.world_hour, world.world_minute + Gen2WorldBugContest.MINUTES
+	)
+	assert_eq(world.bug_contest_minutes_remaining(), 0)
+	assert_false(world.check_bug_contest_timer().is_empty())
+
+
+func test_the_contest_ends_when_the_park_balls_run_out() -> void:
+	var world := _contest_world()
+	world.start_bug_contest()
+	world.state.set_park_balls(0)
+	assert_false(world.check_bug_contest_timer().is_empty())
+
+
+func test_ending_the_contest_clears_the_flag_and_keeps_what_was_caught() -> void:
+	var world := _contest_world()
+	world.start_bug_contest()
+	world.state.set_contest_mon({"species": 10, "level": 12, "max_hp": 30})
+	assert_true(world.end_bug_contest()["ok"])
+	assert_false(world.bug_contest_active())
+	assert_eq(world.state.park_balls(), 0)
+	assert_eq(int(world.state.contest_mon()["species"]), 10, "judging still needs it")
+
+
+func test_the_judging_reads_the_contestants_that_turned_up() -> void:
+	var world := _contest_world()
+	for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
+		world.state.set_event_flag(
+			Gen2WorldState.EVENT_BUG_CATCHING_CONTESTANT_FIRST + index,
+			index >= Gen2WorldBugContest.CONTESTANTS_WITHDRAWN
+		)
+	assert_eq(
+		world.state.withdrawn_bug_contestants().size(),
+		Gen2WorldBugContest.NUM_CONTESTANTS - Gen2WorldBugContest.CONTESTANTS_WITHDRAWN
+	)
+	world.state.set_contest_mon({
+		"species": 10, "level": 12, "max_hp": 30, "hp": 30,
+		"attack": 12, "defense": 13, "speed": 14,
+		"special_attack": 15, "special_defense": 16, "dvs": 0, "item": 0,
+	})
+	var judged: Dictionary = world.judge_bug_contest(_seeded())
+	assert_eq(int(judged["score"]), 193)
+	assert_true(judged["placings"].size() > 0)
+
+
+## The park balls and what was caught survive a save and come back, since a
+## contest can be walked out of and resumed.
+func test_contest_state_round_trips_through_the_state_dictionary() -> void:
+	var world := _contest_world()
+	world.start_bug_contest()
+	world.state.set_contest_mon({"species": 13, "level": 9, "max_hp": 22})
+	world.state.set_contest_second_party_species(155)
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(world.state.to_dict())
+	assert_eq(restored.park_balls(), Gen2WorldBugContest.BALLS)
+	assert_eq(int(restored.contest_mon()["species"]), 13)
+	assert_eq(restored.contest_second_party_species(), 155)
+	assert_eq(restored.bug_contest_started(), world.state.bug_contest_started())

--- a/tests/unit/test_world_encounters.gd
+++ b/tests/unit/test_world_encounters.gd
@@ -399,3 +399,139 @@ class TestNests:
 			}]),
 			[]
 		)
+
+
+## The Bug Catching Contest's own encounter, score and judging
+## (engine/events/bug_contest/, engine/overworld/events.asm). The tables are the
+## cartridge's; these are built by hand the way every other case here is.
+const CONTEST_MONS: Array[Dictionary] = [
+	{"percent": 20, "species": 10, "min_level": 7, "max_level": 18},
+	{"percent": 20, "species": 13, "min_level": 7, "max_level": 18},
+	{"percent": 10, "species": 11, "min_level": 9, "max_level": 18},
+	{"percent": 10, "species": 14, "min_level": 9, "max_level": 18},
+	{"percent": 5, "species": 12, "min_level": 12, "max_level": 15},
+	{"percent": 5, "species": 15, "min_level": 12, "max_level": 15},
+	{"percent": 10, "species": 48, "min_level": 10, "max_level": 16},
+	{"percent": 10, "species": 46, "min_level": 10, "max_level": 17},
+	{"percent": 5, "species": 123, "min_level": 13, "max_level": 14},
+	{"percent": 5, "species": 127, "min_level": 13, "max_level": 14},
+	{"percent": 0xFF, "species": 49, "min_level": 30, "max_level": 40},
+]
+
+
+## `TryWildEncounter_BugContest`: `40 percent` in the long grass and
+## `20 percent` on anything else, which are $ff/100 scaled rather than 40 and 20.
+func test_the_contest_rate_is_the_two_percent_macros() -> void:
+	assert_eq(Gen2WorldBugContest.RATE_LONG_GRASS, 102)
+	assert_eq(Gen2WorldBugContest.RATE_ELSEWHERE, 51)
+	var random := RandomNumberGenerator.new()
+	random.seed = 3
+	var forced: Dictionary = Gen2WorldBugContest.resolve(
+		CONTEST_MONS, true, random, true
+	)
+	assert_eq(forced["rate"], Gen2WorldBugContest.RATE_LONG_GRASS)
+	assert_eq(forced["source"], Gen2WorldBugContest.SOURCE_CONTEST)
+	assert_eq(forced["battle_type"], Gen2WorldBugContest.BATTLE_TYPE)
+
+
+## `ChooseWildEncounter_BugContest` walks the percentages with a roll halved into
+## 0-99, so every draw lands on a row of the table and inside its own levels.
+func test_every_contest_draw_is_a_table_row_at_its_own_level() -> void:
+	var random := RandomNumberGenerator.new()
+	random.seed = 11
+	var seen: Dictionary = {}
+	for _draw: int in 400:
+		var result: Dictionary = Gen2WorldBugContest.resolve(
+			CONTEST_MONS, false, random, true
+		)
+		assert_false(result.is_empty())
+		var row: Dictionary = {}
+		for candidate: Dictionary in CONTEST_MONS:
+			if int(candidate["species"]) == int(result["pokemon"]):
+				row = candidate
+				break
+		assert_false(row.is_empty(), "species %d is not in the table" % int(result["pokemon"]))
+		assert_between(int(result["level"]), int(row["min_level"]), int(row["max_level"]))
+		seen[int(result["pokemon"])] = true
+	## Venomoth's row is the `db -1` terminator, which the walk can never reach.
+	assert_false(seen.has(49), "the -1 row is the sentinel, not a draw")
+	assert_true(seen.size() >= 8, "the common rows all come up")
+
+
+## `ContestScore`: max HP four times, the five stats, the DV term, an eighth of
+## the remaining HP and one for a held item.
+func test_the_contest_score_is_the_source_tally() -> void:
+	var mon: Dictionary = {
+		"species": 10, "max_hp": 30, "hp": 16, "attack": 12, "defense": 13,
+		"speed": 14, "special_attack": 15, "special_defense": 16,
+		"dvs": 0, "item": 0,
+	}
+	assert_eq(Gen2WorldBugContest.score(mon), 192)
+	mon["dvs"] = 0x2222
+	assert_eq(Gen2WorldBugContest.score(mon), 192 + 29, "the DV term")
+	mon["item"] = 1
+	assert_eq(Gen2WorldBugContest.score(mon), 192 + 29 + 1)
+	assert_eq(Gen2WorldBugContest.score({"species": 0}), 0, "nothing caught scores nothing")
+
+
+## `BugContest_JudgeContestants` scores the AI first and inserts the player last,
+## and `DetermineContestWinners` only pushes a place down on a *lower* score, so
+## the player takes a place they tie.
+func test_the_player_is_judged_last_and_takes_a_tie() -> void:
+	var contestants: Array = []
+	for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
+		contestants.append({
+			"trainer_class": 36, "trainer": index,
+			"placings": [
+				{"species": 10, "score": 200},
+				{"species": 10, "score": 200},
+				{"species": 10, "score": 200},
+			],
+		})
+	## One competitor, so the only score to beat is 200 plus its own `and %111`
+	## perturbation, which is 0 to 7 whatever the seed.
+	var withdrawn: Dictionary = {}
+	for index: int in range(1, Gen2WorldBugContest.NUM_CONTESTANTS):
+		withdrawn[index] = true
+	var random := RandomNumberGenerator.new()
+	for seed_value: int in 12:
+		random.seed = seed_value
+		var won: Dictionary = Gen2WorldBugContest.judge(
+			12, 207, contestants, withdrawn, random
+		)
+		assert_eq(won["placings"].size(), 2, "one contestant and the player")
+		assert_eq(int(won["player_place"]), 1, "an equal score still wins")
+		random.seed = seed_value
+		var lost: Dictionary = Gen2WorldBugContest.judge(
+			12, 199, contestants, withdrawn, random
+		)
+		assert_eq(int(lost["player_place"]), 2, "one under the lowest roll loses")
+		assert_eq(
+			int((lost["placings"][0] as Dictionary)["id"]), 2,
+			"contestant zero is id 2, since the player is 1"
+		)
+
+
+## `SelectRandomBugContestContestants`: five of the ten, each set once.
+func test_five_contestants_are_withdrawn_and_no_index_twice() -> void:
+	var random := RandomNumberGenerator.new()
+	for seed_value: int in 20:
+		random.seed = seed_value
+		var withdrawn: Dictionary = Gen2WorldBugContest.select_withdrawn(random)
+		assert_eq(withdrawn.size(), Gen2WorldBugContest.CONTESTANTS_WITHDRAWN)
+		for index: Variant in withdrawn:
+			assert_between(int(index), 0, Gen2WorldBugContest.NUM_CONTESTANTS - 1)
+
+
+## `CheckBugContestTimer` in the minutes the world clock keeps, including the
+## midnight the source's own day counter would have caught.
+func test_the_contest_timer_counts_the_minutes_down_across_midnight() -> void:
+	var started: Dictionary = {"day": 0, "hour": 23, "minute": 55}
+	assert_eq(Gen2WorldBugContest.minutes_remaining(started, started), 20)
+	assert_eq(Gen2WorldBugContest.minutes_remaining(
+		started, {"day": 1, "hour": 0, "minute": 5}
+	), 10)
+	assert_eq(Gen2WorldBugContest.minutes_remaining(
+		started, {"day": 1, "hour": 0, "minute": 15}
+	), 0)
+	assert_eq(Gen2WorldBugContest.minutes_remaining({}, started), 0)

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -43,8 +43,265 @@ func run(r: RefCounted) -> void:
 	_r.each_game(func() -> void:
 		_verify_route_29()
 		_verify_union_cave()
+		_verify_bug_contest()
+		_verify_gate_errand()
 		_census()
 	)
+
+
+## The National Park gate, where a contest is entered. Same ids on both
+## profiles: group 3 shifts only from Union Cave on, and group 10's gates sit
+## ahead of Goldenrod's own inserts.
+const GATE_GROUP: int = 10
+const GATE_NUMBER: int = 15
+const PARK_CONTEST_GROUP: int = 3
+const PARK_CONTEST_NUMBER: int = 16
+## `Route35OfficerScriptContest` refuses on Sunday, Monday, Wednesday and
+## Friday, so the walk is done on a Tuesday.
+const CONTEST_WEEKDAY: int = 2
+## Route 36's gate, where `BugContestResultsWarpScript` warps to.
+const RESULTS_GATE_GROUP: int = 10
+const RESULTS_GATE_NUMBER: int = 17
+
+
+## `Route35OfficerScriptContest` through to `GiveParkBalls`: the errand a player
+## actually walks, on the real map with the real script, rather than the specials
+## called by hand.
+func _verify_gate_errand() -> void:
+	var world: Gen2WorldAPI = _r.open_world(GATE_GROUP, GATE_NUMBER, Vector2i.ZERO)
+	if world == null:
+		return
+	world.set_world_clock(CONTEST_WEEKDAY, 12, 0)
+	_r.field_move_party(world)
+	var talked: Array = _talk_to_officer(world)
+	if not _r.check(not talked.is_empty(), "no object at the gate asks about the contest."):
+		return
+
+	## The officer's question, then its `yesorno`, then the balls.
+	var answered: Array = _drain_to_choice(world, talked)
+	if not _r.check(not answered.is_empty(), "the officer never asked a yes/no."):
+		return
+	world.choose_script_input(0)
+	var _entered: Dictionary = _drain_script(world)
+	_r.check(
+		world.bug_contest_active(),
+		"ENGINE_BUG_CONTEST_TIMER is not set after saying yes."
+	)
+	_r.check(
+		world.state.park_balls() == Gen2WorldBugContest.BALLS,
+		"the officer handed %d park balls." % world.state.park_balls()
+	)
+	_r.check(
+		world.state.withdrawn_bug_contestants().size()
+			== Gen2WorldBugContest.CONTESTANTS_WITHDRAWN,
+		"%d contestants withdrew, not five." % world.state.withdrawn_bug_contestants().size()
+	)
+	_r.check(
+		world.map_id() == Vector2i(PARK_CONTEST_GROUP, PARK_CONTEST_NUMBER),
+		"the errand ended on map %s, not the contest park." % str(world.map_id())
+	)
+	_r.check(
+		world.bug_contest_minutes_remaining() == Gen2WorldBugContest.MINUTES,
+		"the timer opened on %d minutes." % world.bug_contest_minutes_remaining()
+	)
+	_r.note("gate errand: %d park balls, %d minutes, %d contestants withdrawn." % [
+		world.state.park_balls(), world.bug_contest_minutes_remaining(),
+		world.state.withdrawn_bug_contestants().size(),
+	])
+
+	## `CheckTimeEvents`: twenty minutes on, the contest is over and
+	## `BugContestResultsWarpScript` takes the player to the results gate.
+	world.set_world_clock(
+		CONTEST_WEEKDAY, 12, Gen2WorldBugContest.MINUTES
+	)
+	## Something caught, so the judging has a score to rank.
+	world.state.set_contest_mon({
+		"species": 10, "level": 15, "max_hp": 40, "hp": 40, "attack": 20,
+		"defense": 20, "speed": 25, "special_attack": 20, "special_defense": 20,
+		"dvs": 0xFFFF, "item": 0,
+	})
+	var over: Array = world.check_bug_contest_timer()
+	_r.check(not over.is_empty(), "the timer running out queued nothing.")
+	var judged: Dictionary = _drain_script(world)
+	_r.check(not judged.is_empty(), "the results script never asked for a judging.")
+	if not judged.is_empty():
+		_r.check(
+			(judged["placings"] as Array).size() == 3,
+			"the judging placed %d." % (judged["placings"] as Array).size()
+		)
+		_r.note("judging: score %d, placed %d, first is %s." % [
+			int(judged["score"]), int(judged["player_place"]),
+			str((judged["placings"] as Array)[0]),
+		])
+	_r.check(
+		not world.bug_contest_active(),
+		"BugContestResultsScript left the contest flag set."
+	)
+	## `BugContestResultsWarpScript`'s own `warp ROUTE_36_NATIONAL_PARK_GATE`,
+	## which it falls into `BugContestResultsScript` past: the same script clears
+	## the flag, judges and hands out the prize.
+	_r.check(
+		world.map_id() == Vector2i(RESULTS_GATE_GROUP, RESULTS_GATE_NUMBER),
+		"the contest ended on map %s, not the results gate." % str(world.map_id())
+	)
+	_r.note("the contest ended on map %s." % str(world.map_id()))
+
+
+## The step each facing looks along, in FACING_* order.
+const FACING_STEPS: Array[Vector2i] = [
+	Vector2i.DOWN, Vector2i.UP, Vector2i.LEFT, Vector2i.RIGHT,
+]
+
+
+## Every object on the map faced and talked to, answering with the first one
+## whose script says anything. The officer's cell is not pinned: the two gates
+## differ between the profiles in nothing else, and a hand-named cell is what
+## `HANDOFF.md`'s route habits warn about.
+func _talk_to_officer(world: Gen2WorldAPI) -> Array:
+	for index: int in world.objects.size():
+		var object: Gen2WorldObject = world.objects[index]
+		for facing: int in [
+			Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_UP,
+			Gen2WorldSprite.FACING_LEFT, Gen2WorldSprite.FACING_RIGHT,
+		]:
+			var direction: Vector2i = FACING_STEPS[facing]
+			var stand: Vector2i = object.cell - direction
+			if stand.x < 0 or stand.y < 0 \
+				or stand.x >= world.current_map.collision_width \
+				or stand.y >= world.current_map.collision_height:
+				continue
+			world.player_cell = stand
+			world.player_facing = facing
+			var results: Array = world.interact()
+			if not results.is_empty():
+				return results
+	return []
+
+
+## The script run to its end: every text acknowledged and every movement frame
+## the applymovements ask for spent, which is what the world screen does a frame
+## at a time.
+func _drain_script(world: Gen2WorldAPI) -> Dictionary:
+	var judged: Dictionary = {}
+	var random := RandomNumberGenerator.new()
+	random.seed = 13
+	for _step: int in 4000:
+		if not world.pending_script_wait().is_empty():
+			world.advance_script_presentation_frame()
+			continue
+		if not world.script_busy():
+			return judged
+		## The one request this errand makes of its host: `BugContestJudging`
+		## leaves the placing in wScriptVar, which the script branches on.
+		var request: Dictionary = world.pending_runtime_request()
+		if StringName(request.get("kind", &"")) == &"bug_contest_judging_requested":
+			judged = world.judge_bug_contest(random)
+			world.complete_runtime_request({
+				"ok": true, "script_value": int(judged.get("player_place", 0)),
+			})
+			continue
+		world.run_event_queue(true)
+	return judged
+
+
+## Runs the script on until it is waiting on a choice, which is the officer's
+## own `yesorno`.
+func _drain_to_choice(world: Gen2WorldAPI, results: Array) -> Array:
+	var out: Array = results.duplicate()
+	for _step: int in 40:
+		for entry: Dictionary in out:
+			var event: Dictionary = entry.get("event", {})
+			if StringName(event.get("type", &"")) == &"choice":
+				return out
+		if not world.script_busy():
+			return []
+		out = world.run_event_queue(true)
+	return []
+
+
+## `ContestMons` and `BugContestantPointers` as imported, and the contest's own
+## encounter over the whole table. All three cartridges ship both byte
+## identical, which is why the expected values are not per game.
+const CONTEST_SPECIES: Array[int] = [10, 13, 11, 14, 12, 15, 48, 46, 123, 127, 49]
+const CONTEST_PERCENTS: Array[int] = [20, 20, 10, 10, 5, 5, 10, 10, 5, 5, 0xFF]
+## `BugContestant_BugCatcherDon` and `BugContestant_SchoolboyKipp`, the first and
+## last records, as `[class, trainer]`.
+const CONTESTANT_EDGES: Array = [[36, 1], [23, 2]]
+
+
+func _verify_bug_contest() -> void:
+	var mons: Array = _r.data.bug_contest_mons()
+	if not _r.check(
+		mons.size() == Gen2WorldBugContest.NUM_CONTEST_MONS,
+		"ContestMons has %d rows, not %d." % [
+			mons.size(), Gen2WorldBugContest.NUM_CONTEST_MONS,
+		]
+	):
+		return
+	var total: int = 0
+	for index: int in mons.size():
+		var row: Dictionary = mons[index]
+		_r.check(
+			int(row["species"]) == CONTEST_SPECIES[index]
+				and int(row["percent"]) == CONTEST_PERCENTS[index],
+			"ContestMons row %d is %d at %d percent." % [
+				index, int(row["species"]), int(row["percent"]),
+			]
+		)
+		if int(row["percent"]) != 0xFF:
+			total += int(row["percent"])
+	_r.check(total == 100, "ContestMons' percentages add to %d, not 100." % total)
+
+	var contestants: Array = _r.data.bug_contestants()
+	if not _r.check(
+		contestants.size() == Gen2WorldBugContest.NUM_CONTESTANTS,
+		"BugContestantPointers has %d records, not %d." % [
+			contestants.size(), Gen2WorldBugContest.NUM_CONTESTANTS,
+		]
+	):
+		return
+	for edge: int in CONTESTANT_EDGES.size():
+		var entry: Dictionary = contestants[0 if edge == 0 else contestants.size() - 1]
+		_r.check(
+			int(entry["trainer_class"]) == int(CONTESTANT_EDGES[edge][0])
+				and int(entry["trainer"]) == int(CONTESTANT_EDGES[edge][1]),
+			"contestant edge %d is class %d trainer %d." % [
+				edge, int(entry["trainer_class"]), int(entry["trainer"]),
+			]
+		)
+		_r.check(
+			(entry["placings"] as Array).size() == 3,
+			"contestant edge %d has %d placings." % [edge, (entry["placings"] as Array).size()]
+		)
+
+	## Every draw the walk can produce, over the whole table: a row of it, at a
+	## level between that row's own two, and never the `db -1` sentinel.
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	var drawn: Dictionary = {}
+	for _draw: int in 2000:
+		var result: Dictionary = Gen2WorldBugContest.resolve(mons, true, random, true)
+		if not _r.check(not result.is_empty(), "a contest draw answered nothing."):
+			return
+		var species: int = int(result["pokemon"])
+		drawn[species] = int(drawn.get(species, 0)) + 1
+		for row: Dictionary in mons:
+			if int(row["species"]) != species:
+				continue
+			_r.check(
+				int(result["level"]) >= int(row["min_level"])
+					and int(result["level"]) <= int(row["max_level"]),
+				"a level %d %d is outside its row." % [int(result["level"]), species]
+			)
+			break
+	_r.check(
+		not drawn.has(CONTEST_SPECIES[CONTEST_SPECIES.size() - 1]),
+		"the sentinel row was drawn."
+	)
+	_r.check(drawn.size() == mons.size() - 1, "only %d of the ten rows came up." % drawn.size())
+	_r.note("bug contest: %d rows, %d contestants, %d species drawn in 2000." % [
+		mons.size(), contestants.size(), drawn.size(),
+	])
 
 
 ## An outdoor map: only the tiles CheckGrassCollision names roll, and the path

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -7,8 +7,8 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses]
 ##
-## [stage] is one of `offer` (the default), `menu`, `move`, `pick`, `use_next`
-## and `replace`;
+## [stage] is one of `offer` (the default), `menu`, `move`, `contest`, `pick`,
+## `use_next` and `replace`;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
 ## cursor row or a refusal can be photographed. The battle is a real trainer's
 ## party out of the cache with the player on a bench of three, since both a
@@ -129,14 +129,24 @@ func _open() -> void:
 		_screen.set("_pending", [
 			{"type": Gen2Battle.FAINTED, "side": Gen2Battle.PLAYER},
 		])
-	elif _stage not in ["menu", "move"]:
+	elif _stage not in ["menu", "move", "contest"]:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
 		))
 
+	## `ContestBattleMenuHeader` in place of the ordinary one, which is
+	## wBattleType alone. The balls are the contest's own count rather than the
+	## bag's, exactly as the world screen hands them over.
+	if _stage == "contest":
+		battle.battle_type = Gen2Battle.BATTLETYPE_CONTEST
+		_screen.set_capture_balls(
+			[Gen2WorldPartyHost.ITEM_PARK_BALL],
+			{Gen2WorldPartyHost.ITEM_PARK_BALL: Gen2WorldBugContest.BALLS}
+		)
+
 	## Both menu stages are what the intro leads into with nothing else staged,
 	## which is `BattleMenu`'s own first opening.
-	if _stage in ["menu", "move"]:
+	if _stage in ["menu", "move", "contest"]:
 		_drain_to_menu()
 		if _stage == "move":
 			_screen._handle_button(Gen2Button.A)


### PR DESCRIPTION
The wild-encounter gate left one branch of `RandomEncounter` unmodelled,
because there was no contest for it to belong to. There is now.

## Imported, cache format 54

`data/wild/bug_contest_mons.asm`'s `ContestMons` and
`data/events/bug_contest_winners.asm`'s ten contestant records. Both were
located by their own bytes, which are unique in every dump, and both ship
byte identical on all three cartridges, so the anchors are not per game.
Re-imported all three: `layout: Layout verified.` on each.

## Built

- **The encounter.** `TryWildEncounter_BugContest`'s two rates (`40 percent`
  and `20 percent`, which are `$ff/100` scaled, so 102 and 51), through the
  same music and Cleanse Tag shifts as any other roll, then
  `ChooseWildEncounter_BugContest`'s walk down the percentages and its level
  between the row's own two. `CanEncounterWildMon` still gates it.
- **The errand.** `GiveParkBalls`, `ContestDropOffMons`, `ContestReturnMons`,
  `SelectRandomBugContestContestants`, `CheckPartyFullAfterContest` and
  `BugContestJudging`, so the National Park gate's own scripts drive it.
- **The timer.** `StartBugContestTimer` and `CheckBugContestTimer` as
  `CheckTimeEvents` reads them, a step at a time; running out queues
  `StdScripts`' own `BugContestResultsWarpScript`, and so does running out of
  balls.
- **The judging.** `ContestScore` bit for bit, DV term included, and
  `DetermineContestWinners`' insertion order, which is why the player takes a
  place they tie: the AI is scored first.
- **The battle.** A Park Ball throw as its own transaction (the ball is
  `wParkBallsRemaining`, the catch is `wContestMon`), the replace question
  `BugContest_SetCaughtContestMon` asks, and `ContestBattleMenuHeader` in
  place of the ordinary menu with its own ball count.

Two fixes fell out of driving it: `ClearBGPalettes` and `UpdateTimePals`
were unhandled specials, and a runtime request whose kind no host answers
fails the script and takes its own staged warp with it.

## Proof

`tools/checks/wild_encounters.gd` now walks the whole errand on all three
caches, with the cartridge's own scripts and no cell named by hand:

| | Gold | Silver | Crystal |
|---|---|---|---|
| ContestMons rows / contestants | 11 / 10 | 11 / 10 | 11 / 10 |
| Species drawn in 2,000 rolls | 10 of 10 | 10 of 10 | 10 of 10 |
| Park balls, minutes, withdrawn | 20, 20, 5 | 20, 20, 5 | 20, 20, 5 |
| Entered / left on map | (3,16) / (10,17) | (3,16) / (10,17) | (3,16) / (10,17) |

The judging ranks against the real table: a 299-point Caterpie places
second or third behind Nick's Scyther at 357 and William's Pinsir at 332,
which are the ROM's own scores plus the `and %111` each gets.

GUT 2,863 over 148 scripts green (was 2,851), `validate.gd -- all` 44
topics pass, `replay_world.gd` 27 routes 0 failures, and the story walk
still reaches Red at 291 steps on Gold and Silver and 294 on Crystal.