### PR TITLE
Draw the party menu's mon icons

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -179,6 +179,10 @@ var _intro_message: String = ""
 var _held_message: String = ""
 ## Leftover of a hardware frame the bars and the intro have not counted yet.
 var _frame_elapsed: float = 0.0
+## The same, for the party page's icons. Kept apart because they animate while
+## nothing else does, and [method frames_running] must stay false there: a
+## caller draining frames to a terminal state would never reach one.
+var _icon_elapsed: float = 0.0
 ## What the overworld clock said when the battle started, for the three heals
 ## that read it. Only the world path supplies one; the development drivers below
 ## leave [Gen2Battle] at its own midday default.
@@ -295,6 +299,7 @@ func _process(delta: float) -> void:
 	## The yes/no box appears when the question above it has finished printing,
 	## and the box prints on its own clock rather than on a press.
 	if _switch_stage != &"":
+		_advance_party_icons(delta)
 		_refresh_menu_layer()
 	if not frames_running():
 		_frame_elapsed = 0.0
@@ -2150,6 +2155,11 @@ func _open_switch_pick(reason: StringName) -> void:
 	)
 	_switch_offer = null
 	_switch_stage = &"pick"
+	## `InitPartyMenuGFX` spawns the icons where the list is built, so a reopened
+	## list opens on the first frame of their animation rather than resuming.
+	if _party_page != null:
+		_party_page.reset(_switch_menu.rows)
+	_icon_elapsed = 0.0
 	## The party menu is the whole screen rather than a box on it, so the battle's
 	## own box goes with the field it belongs to.
 	if _box != null:
@@ -2379,13 +2389,16 @@ func _reopen_menu_layer() -> void:
 func _refresh_menu_layer() -> void:
 	if _menu_layer == null:
 		return
-	var signature: String = "%s|%s|%d|%d|%d" % [
+	var signature: String = "%s|%s|%d|%d|%d|%s" % [
 		_switch_stage, _menu_stage,
 		_switch_offer.selected_index() if _switch_offer != null else (
 			_switch_menu.cursor if _switch_menu != null else -1
 		),
 		int(_offer_still_reading()),
 		_menu_position * 8 + _move_cursor,
+		## The icons move on their own clock, so the cursor alone does not say
+		## whether the page still draws what the layer is holding.
+		_party_page.animation_signature() if _party_page != null else "",
 	]
 	if signature == _menu_drawn:
 		return
@@ -2494,6 +2507,31 @@ func _draw_move_info(row: Dictionary) -> void:
 		_info_layer, _menu_page.render(box, [], -1, "", 0, extras),
 		box.border_position() * Gen2Font.TILE
 	)
+
+
+## `PlaySpriteAnimations` over the party page's icons, on the hardware clock the
+## bars use. Capped the same way, so a stall drops passes rather than running a
+## second of them at once.
+func _advance_party_icons(delta: float) -> void:
+	if _party_page == null or _switch_menu == null or _switch_stage not in [&"pick", &"refused"]:
+		_icon_elapsed = 0.0
+		return
+	_icon_elapsed = minf(
+		_icon_elapsed + delta,
+		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
+	)
+	while _icon_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+		_icon_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_party_icons()
+
+
+## One pass of the party page's icons. Public with [method advance_frame] so a
+## test or a screenshot driver can step them without waiting on real time.
+func advance_party_icons() -> bool:
+	if _party_page == null or _switch_menu == null:
+		return false
+	_party_page.advance(_switch_menu.rows, _switch_menu.cursor)
+	return true
 
 
 func _draw_party_page() -> void:

--- a/game/battle/battle_switch_menu.gd
+++ b/game/battle/battle_switch_menu.gd
@@ -48,8 +48,9 @@ const NO_ENERGY: StringName = &"no_energy"
 const CANNOT_CANCEL: StringName = &"cannot_cancel"
 
 ## One row per party member, in party order:
-## `{index, name, level, hp, max_hp, status, fainted}`. [Gen2PartyMenuPage] draws
-## exactly these fields and nothing reads the battle behind them.
+## `{index, species, item, name, level, hp, max_hp, status, fainted}`.
+## [Gen2PartyMenuPage] draws exactly these fields and nothing reads the battle
+## behind them; the species and the held item are what its menu mon icon needs.
 var rows: Array = []
 
 ## `ForcePickSwitchMonInBattle` rather than `PickSwitchMonInBattle`.
@@ -75,6 +76,8 @@ static func for_party(party: Gen2Party, is_forced: bool = false) -> Gen2BattleSw
 			continue
 		menu.rows.append({
 			"index": index,
+			"species": mon.species,
+			"item": mon.item,
 			"name": mon.name_text(),
 			"level": mon.level,
 			"hp": mon.hp,

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -83,6 +83,7 @@ var _world_animation_assets: Dictionary = {}
 var _overworld_sprites: Array = []
 var _overworld_effects: Array = []
 var _overworld_sprite_palettes: Array = []
+var _party_menu_icon_palette_rows: Array = []
 var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
 var _world_phone: Dictionary = {}
@@ -696,6 +697,50 @@ func overworld_icon_indices(icon_number: int) -> PackedByteArray:
 	)
 	_indices[key] = data
 	return data
+
+
+## `ReadMonMenuIcon`: the icon a species is drawn with in a party menu, or zero
+## when the cache does not hold the table. Its `cp EGG` answer is not modelled
+## because nothing here holds an egg; a mod species numbered past the
+## cartridge's own range has no row and answers zero for the same reason
+## `Gen2ContentOverlay.defined_numbers()` reaches no dex order.
+func mon_menu_icon(species: int) -> int:
+	var table: PackedByteArray = mon_menu_icon_table()
+	if species < 1 or species > table.size():
+		return 0
+	return table[species - 1]
+
+
+func mon_menu_icon_table() -> PackedByteArray:
+	var key: String = "overworld_icons/species"
+	if _indices.has(key):
+		return _indices[key]
+	var data: PackedByteArray = RomCache.read_indices(RomCache.mon_menu_icons_path(directory))
+	_indices[key] = data
+	return data
+
+
+## `HeldItemIcons`, two tiles' worth of colour indices: the mail marker and the
+## item one, in that order.
+func held_item_icon_indices() -> PackedByteArray:
+	var key: String = "overworld_icons/held_item"
+	if _indices.has(key):
+		return _indices[key]
+	var data: PackedByteArray = RomCache.read_indices(RomCache.held_item_icon_path(directory))
+	_indices[key] = data
+	return data
+
+
+## One of `PartyMenuOBPals`' two palettes, colour 0 first. Colour 0 is an object
+## palette's transparent index; the caller decides that, not this.
+func party_menu_icon_palette(index: int = 0) -> PackedColorArray:
+	var palettes: Array = _party_menu_icon_palettes()
+	if index < 0 or index >= palettes.size() or not palettes[index] is Array:
+		return PackedColorArray()
+	var out := PackedColorArray()
+	for packed: Variant in palettes[index] as Array:
+		out.append(Gen2Palette.from_packed(int(packed)))
+	return out
 
 
 ## One of the eight overworld object palette kinds for a time-of-day group.
@@ -1440,15 +1485,25 @@ func card_badge_palette() -> PackedColorArray:
 	return colors
 
 
+## The three bar palettes in `GetHPPal`'s own order.
+const HP_BAR_PALETTE_NAMES: Array[String] = ["hp_green", "hp_yellow", "hp_red"]
+
+
 ## Which HP bar palette a bar of [param lit] pixels is drawn in. The colour
 ## follows what is drawn rather than the numbers behind it, which is why a bar
 ## can turn red on a Pokémon that still has a good few hit points.
 static func hp_bar_palette_name(lit: int) -> String:
+	return HP_BAR_PALETTE_NAMES[hp_bar_palette_index(lit)]
+
+
+## `GetHPPal`'s own answer, HP_GREEN, HP_YELLOW or HP_RED, for the callers that
+## index a table with it rather than naming a palette.
+static func hp_bar_palette_index(lit: int) -> int:
 	if lit >= RomLayout.HP_GREEN_PIXELS:
-		return "hp_green"
+		return 0
 	if lit >= RomLayout.HP_YELLOW_PIXELS:
-		return "hp_yellow"
-	return "hp_red"
+		return 1
+	return 2
 
 
 func trainer_count() -> int:
@@ -1786,6 +1841,14 @@ func _overworld_effect_records() -> Array:
 	if _claim_section("overworld_effects"):
 		_overworld_effects = _read_section(RomCache.overworld_effects_path(directory), true)
 	return _overworld_effects
+
+
+func _party_menu_icon_palettes() -> Array:
+	if _claim_section("party_menu_icon_palettes"):
+		_party_menu_icon_palette_rows = _read_section(
+			RomCache.party_menu_icon_palettes_path(directory), true
+		)
+	return _party_menu_icon_palette_rows
 
 
 func _sprite_palettes() -> Array:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -46,6 +46,9 @@ const OVERWORLD_SPRITES: String = "overworld_sprites.json"
 const OVERWORLD_SPRITE_PALETTES: String = "overworld_sprite_palettes.json"
 const OVERWORLD_SPRITES_DIR: String = "overworld_sprites"
 const OVERWORLD_ICONS_DIR: String = "overworld_icons"
+const MON_MENU_ICONS: String = "species.idx"
+const HELD_ITEM_ICONS: String = "held_item.idx"
+const PARTY_MENU_ICON_PALETTES: String = "palettes.json"
 const WORLD_MENUS: String = "world_menus.json"
 const WORLD_MARTS: String = "world_marts.json"
 const WORLD_PHONE: String = "world_phone.json"
@@ -65,7 +68,7 @@ const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
 ## importer is discarded rather than migrated.
-const FORMAT_VERSION: int = 54
+const FORMAT_VERSION: int = 55
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -247,6 +250,23 @@ static func overworld_sprite_path(directory: String, number: int) -> String:
 
 static func overworld_icon_path(directory: String, number: int) -> String:
 	return "%s/%s/%02d.idx" % [directory, OVERWORLD_ICONS_DIR, number]
+
+
+## `MonMenuIcons`: which of the icons above each species is drawn with. One byte
+## per species, so it is an index run rather than JSON like the tables beside it.
+static func mon_menu_icons_path(directory: String) -> String:
+	return "%s/%s/%s" % [directory, OVERWORLD_ICONS_DIR, MON_MENU_ICONS]
+
+
+## `HeldItemIcons`, the two tiles a party menu icon wears instead of its own
+## bottom-left one.
+static func held_item_icon_path(directory: String) -> String:
+	return "%s/%s/%s" % [directory, OVERWORLD_ICONS_DIR, HELD_ITEM_ICONS]
+
+
+## `PartyMenuOBPals`, which is the only palette a menu mon icon is drawn in.
+static func party_menu_icon_palettes_path(directory: String) -> String:
+	return "%s/%s/%s" % [directory, OVERWORLD_ICONS_DIR, PARTY_MENU_ICON_PALETTES]
 
 
 static func prepare(directory: String) -> bool:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -144,10 +144,29 @@ const EMOTE_NAMES: Array[String] = [
 ]
 
 ## IconPointers has one null entry followed by the 38 reusable overworld icon
-## shapes in constants/icon_constants.asm. The null entry is not graphic data.
+## shapes in constants/icon_constants.asm. The null entry is not graphic data:
+## `NullIcon` and `PoliwagIcon` are the same address, which is what makes the
+## table NUM_ICONS + 1 entries long and its first two entries equal.
 const MON_ICON_COUNT: int = 38
 const MON_ICON_TILES: int = 8
 const MON_ICON_BYTES: int = MON_ICON_TILES * Gen2Tiles.TILE_BYTES
+const ICON_POINTER_COUNT: int = MON_ICON_COUNT + 1
+const ICON_POINTER_SIZE: int = 2
+
+## `HeldItemIcons` is `gfx/stats/mail.2bpp` and `gfx/stats/item.2bpp`, the two
+## tiles `GetIconGFX` loads behind every icon's eight. The mail one is drawn by
+## no party menu here: nothing imports `data/items/mail_items.asm`, so
+## `ItemIsMail` is never true and `SPRITE_ANIM_FRAMESET_PARTY_MON_WITH_MAIL` is
+## unreachable.
+const HELD_ITEM_ICON_TILES: int = 2
+const HELD_ITEM_ICON_MAIL: int = 0
+const HELD_ITEM_ICON_ITEM: int = 1
+
+## `InitPartyMenuOBPals` copies two of the eight palettes at `PartyMenuOBPals`
+## into wOBPals1. Every party icon's OAM set is PAL_OW_RED, so the first is the
+## one an icon wears; the second is the run's only different row.
+const PARTY_MENU_OB_PALETTE_COUNT: int = 2
+const PARTY_MENU_OB_PALETTE_BYTES: int = 8
 
 ## Global overworld service tables. The source keeps these apart from map data:
 ## marts are an index table of item lists, phone contacts are fixed records,
@@ -1573,6 +1592,10 @@ const GOLD_SILVER: Dictionary = {
 	"overworld_sprite_count": 95,
 	"overworld_sprite_palettes": 0xB8AE,
 	"overworld_icons": 0x8EABE,
+	## `HeldItemIcons`, in front of `MonMenuIcons` in the same bank but behind
+	## `GetIconGFX`'s own code, so the icons' offset does not pin it.
+	"held_item_icons": 0x8E8DB,
+	"party_menu_ob_palettes": 0xBAC6,
 	"emotes": 0x143C1,
 	## The three sheets engine/events/field_moves.asm loads by name.
 	## CutGrassGFX follows CutTreeGFX, so one wrong offset shows on both.
@@ -1896,6 +1919,8 @@ const CRYSTAL: Dictionary = {
 	"overworld_sprite_count": 102,
 	"overworld_sprite_palettes": 0xB469,
 	"overworld_icons": 0x8EC0D,
+	"held_item_icons": 0x8E9F7,
+	"party_menu_ob_palettes": 0xB681,
 	"emotes": 0x1444D,
 	"headbutt_tree_gfx": 0x8C893,
 	"cut_tree_gfx": 0x8C98C,
@@ -2006,9 +2031,10 @@ static func for_id(id: StringName) -> Dictionary:
 			return GOLD_SILVER
 		RomRegistry.SILVER:
 			var silver: Dictionary = GOLD_SILVER.duplicate(true)
-			# Gold and Silver share the icon format but their banks differ by ten
-			# bytes at this table.
+			# Silver's copy of the icon bank sits twenty-six bytes lower than
+			# Gold's, so both offsets into it move together.
 			silver["overworld_icons"] = 0x8EAA4
+			silver["held_item_icons"] = 0x8E8C1
 			silver["item_attributes"] = 0x6866
 			silver["item_status_actions"] = 0xF0C5
 			silver["item_healing_hp"] = 0xF403
@@ -2237,6 +2263,18 @@ static func emote_offset(layout: Dictionary, index: int) -> int:
 static func overworld_icon_offset(layout: Dictionary, number: int) -> int:
 	return int(layout.get("overworld_icons", -1)) \
 		+ (number - 1) * MON_ICON_BYTES
+
+
+## `IconPointers`, which `engine/gfx/mon_icons.asm` INCLUDEs immediately in front
+## of `gfx/icons.asm`, so the icons' own offset pins it.
+static func icon_pointers_offset(layout: Dictionary) -> int:
+	return int(layout.get("overworld_icons", -1)) - ICON_POINTER_COUNT * ICON_POINTER_SIZE
+
+
+## `MonMenuIcons`, one icon number per species, INCLUDEd in front of
+## `IconPointers` by the same file and pinned by the same offset.
+static func mon_menu_icons_offset(layout: Dictionary) -> int:
+	return icon_pointers_offset(layout) - SPECIES_COUNT
 
 
 ## Trainer pics have no back half and no size of their own, so unlike the

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -113,6 +113,18 @@ static func import_to_cache(
 			RomCache.overworld_icon_path(directory, number), icon_graphics[number]
 		):
 			return {"ok": false, "message": "Could not write overworld icon %d." % number}
+	if not RomCache.write_indices(
+		RomCache.mon_menu_icons_path(directory), result["menu_icons"]
+	):
+		return {"ok": false, "message": "Could not write the species icon table."}
+	if not RomCache.write_indices(
+		RomCache.held_item_icon_path(directory), result["held_item_pixels"]
+	):
+		return {"ok": false, "message": "Could not write the held item icons."}
+	if not RomCache.write_json(
+		RomCache.party_menu_icon_palettes_path(directory), result["icon_palettes"]
+	):
+		return {"ok": false, "message": "Could not write the party menu icon palettes."}
 
 	return {
 		"ok": true,
@@ -220,6 +232,9 @@ static func read_world(
 		"sprite_palettes": sprites["palettes"],
 		"sprite_graphics": sprites["graphics"],
 		"icon_graphics": icons["graphics"],
+		"menu_icons": icons["menu_icons"],
+		"held_item_pixels": icons["held_item_pixels"],
+		"icon_palettes": icons["icon_palettes"],
 		"effects": effects["effects"],
 	}
 
@@ -447,7 +462,13 @@ static func _read_overworld_sprites(rom: RomFile, layout: Dictionary) -> Diction
 
 ## LoadOverworldMonIcon reads the contiguous eight-tile IconPointers region.
 ## The pointer table is redundant for this use: every icon is 8 tiles and the
-## source stores them in the same order as constants/icon_constants.asm.
+## source stores them in the same order as constants/icon_constants.asm. It is
+## read anyway, as the check on the offset: `IconPointers` sits immediately in
+## front of the art and its entries walk it eight tiles at a time.
+##
+## `MonMenuIcons` is in front of that again (`ReadMonMenuIcon`), which is what
+## turns a species into one of the 38 shapes, and `HeldItemIcons` and
+## `PartyMenuOBPals` are the other two things a party menu icon needs.
 static func _read_overworld_icons(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var offset: int = int(layout.get("overworld_icons", -1))
 	var size: int = RomLayout.MON_ICON_COUNT * RomLayout.MON_ICON_BYTES
@@ -464,7 +485,124 @@ static func _read_overworld_icons(rom: RomFile, layout: Dictionary) -> Dictionar
 		if pixels.size() != RomLayout.MON_ICON_TILES * Gen2Tiles.TILE_PIXELS:
 			return _error("Overworld mon icon %d did not decode." % number)
 		graphics[number] = pixels
-	return {"ok": true, "graphics": graphics}
+
+	var pointers: Dictionary = _check_icon_pointers(rom, layout)
+	if not bool(pointers.get("ok", false)):
+		return pointers
+	var menu_icons: Dictionary = _read_mon_menu_icons(rom, layout)
+	if not bool(menu_icons.get("ok", false)):
+		return menu_icons
+	var held: Dictionary = _read_held_item_icons(rom, layout)
+	if not bool(held.get("ok", false)):
+		return held
+	var palettes: Dictionary = _read_party_menu_ob_palettes(rom, layout)
+	if not bool(palettes.get("ok", false)):
+		return palettes
+
+	return {
+		"ok": true,
+		"graphics": graphics,
+		"menu_icons": menu_icons["numbers"],
+		"held_item_pixels": held["pixels"],
+		"icon_palettes": palettes["palettes"],
+	}
+
+
+## The art's own offset read back through the table in front of it. Entry 0 is
+## `NullIcon`, which is `PoliwagIcon`, so the first two entries are the base
+## itself and every entry after that is eight tiles on from the one before.
+static func _check_icon_pointers(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var table: int = RomLayout.icon_pointers_offset(layout)
+	var span: int = RomLayout.ICON_POINTER_COUNT * RomLayout.ICON_POINTER_SIZE
+	if table < 0 or not rom.in_bounds(table, span):
+		return _error("IconPointers is outside the cartridge.")
+	var base: int = int(layout["overworld_icons"])
+	for index: int in RomLayout.ICON_POINTER_COUNT:
+		var address: int = rom.u16le(table + index * RomLayout.ICON_POINTER_SIZE)
+		var expected: int = RomFile.linear(RomLayout.bank_of(base), address)
+		var wanted: int = base + maxi(index - 1, 0) * RomLayout.MON_ICON_BYTES
+		if not _valid_cpu_address(address) or expected != wanted:
+			return _error(
+				"IconPointers entry %d names $%04X, which is not icon %d." % [
+					index, address, index,
+				]
+			)
+	return {"ok": true}
+
+
+## `MonMenuIcons`, one ICON_* number per species. EGG is not in the table:
+## `ReadMonMenuIcon` answers it before the lookup, which is why the run is
+## exactly NUM_POKEMON long.
+static func _read_mon_menu_icons(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var offset: int = RomLayout.mon_menu_icons_offset(layout)
+	if offset < 0 or not rom.in_bounds(offset, RomLayout.SPECIES_COUNT):
+		return _error("MonMenuIcons is outside the cartridge.")
+	var numbers: PackedByteArray = rom.slice(offset, RomLayout.SPECIES_COUNT)
+	for species: int in RomLayout.SPECIES_COUNT:
+		var icon: int = numbers[species]
+		if icon < 1 or icon > RomLayout.MON_ICON_COUNT:
+			return _error(
+				"MonMenuIcons entry %d is icon %d, which is not one of the %d." % [
+					species + 1, icon, RomLayout.MON_ICON_COUNT,
+				]
+			)
+	return {"ok": true, "numbers": numbers}
+
+
+## `HeldItemIcons`. Both tiles are a box drawn to their own edges, so the first
+## and last row of each is solid colour 3; a neighbouring sheet or a run of code
+## read here is not.
+static func _read_held_item_icons(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var offset: int = int(layout.get("held_item_icons", -1))
+	var size: int = RomLayout.HELD_ITEM_ICON_TILES * Gen2Tiles.TILE_BYTES
+	if offset < 0 or not rom.in_bounds(offset, size):
+		return _error("HeldItemIcons is outside the cartridge.")
+	var pixels: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		rom.slice(offset, size), 0, RomLayout.HELD_ITEM_ICON_TILES
+	)
+	if pixels.size() != RomLayout.HELD_ITEM_ICON_TILES * Gen2Tiles.TILE_PIXELS:
+		return _error("HeldItemIcons did not decode.")
+	# Both tiles are one strip, so a row of one is eight pixels into the row of
+	# the whole rather than sixty-four into the buffer.
+	var width: int = RomLayout.HELD_ITEM_ICON_TILES * Gen2Tiles.TILE_WIDTH
+	for tile: int in RomLayout.HELD_ITEM_ICON_TILES:
+		var at: int = tile * Gen2Tiles.TILE_WIDTH
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			var top: int = pixels[at + column]
+			var bottom: int = pixels[(Gen2Tiles.TILE_HEIGHT - 1) * width + at + column]
+			if top != 3 or bottom != 3:
+				return _error("HeldItemIcons tile %d is not a bordered box." % tile)
+	return {"ok": true, "pixels": pixels}
+
+
+## `PartyMenuOBPals`, of which `InitPartyMenuOBPals` copies two. The run is
+## eight rows that share colours 0, 1 and 3 and differ only in the second row's
+## colour 2, which is the shape checked here: colour data with bit 15 clear,
+## black in the last slot of each, and one differing colour between the two.
+static func _read_party_menu_ob_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var offset: int = int(layout.get("party_menu_ob_palettes", -1))
+	var count: int = RomLayout.PARTY_MENU_OB_PALETTE_COUNT
+	if offset < 0 or not rom.in_bounds(offset, count * RomLayout.PARTY_MENU_OB_PALETTE_BYTES):
+		return _error("PartyMenuOBPals is outside the cartridge.")
+	var palettes: Array = []
+	for index: int in count:
+		var packed: Array = []
+		for slot: int in Gen2Palette.COLORS_PER_PIC:
+			var color: int = rom.u16le(
+				offset + index * RomLayout.PARTY_MENU_OB_PALETTE_BYTES
+					+ slot * Gen2Palette.COLOR_BYTES
+			)
+			if color & 0x8000:
+				return _error("PartyMenuOBPals colour %d/%d is not colour data." % [index, slot])
+			packed.append(color)
+		if packed[Gen2Palette.COLORS_PER_PIC - 1] != 0:
+			return _error("PartyMenuOBPals palette %d does not end in black." % index)
+		palettes.append(packed)
+	var first: Array = palettes[0]
+	var second: Array = palettes[1]
+	if first[0] != second[0] or first[1] != second[1] or first[2] == second[2]:
+		return _error("PartyMenuOBPals' two palettes are not the source's pair.")
+	return {"ok": true, "palettes": palettes}
 
 
 ## The sprites the engine draws over an object rather than as one: the eight

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -11,11 +11,13 @@ extends RefCounted
 ## member because `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`.
 ##
 ## [Gen2BattleSwitchMenu] owns the rows and the cursor; this is presentation
-## only, and node-free, so the page can be read back headless.
+## only, and node-free, so the page can be read back headless. The one thing it
+## owns itself is `InitPartyMenuGFX`'s icons, because the sprite anim structs
+## behind them are per-frame state and nothing else here holds it: [method
+## advance] is one pass of `PlaySpriteAnimations` over them.
 ##
-## Not drawn: `InitPartyMenuGFX`'s menu mon icons, which are sprite animations
-## over columns 1 and 2 and need `gfx/icons`, and the eggs `PartyMenuCheckEgg`
-## skips every quality for, which a battle party cannot contain.
+## Not drawn: the eggs `PartyMenuCheckEgg` skips every quality for, which a
+## battle party cannot contain.
 
 const TILE: int = Gen2Font.TILE
 
@@ -48,6 +50,40 @@ const PROMPT: Vector2i = Vector2i(1, 16)
 ## Both HP numbers print through `PrintNum` three digits wide, space padded.
 const HP_NUMBER_DIGITS: int = 3
 
+## Shadow OAM's own origin, which every sprite here is placed through.
+const OAM_ORIGIN := Vector2i(8, 16)
+
+## `InitPartyMenuIcon`'s spawn: `add $1c` over the slot number shifted four, and
+## `ld e, $10`. The icon is the four `.OAMData_RedWalk` tiles at (-8,-8) from
+## there, so its top-left corner is the coordinate less a tile and the origin.
+const ICON_FIRST_Y: int = 0x1C
+const ICON_ROW_STEP: int = 16
+const ICON_TILE: int = Gen2Font.TILE
+
+## `SpriteAnimFunc_PartyMon`'s two columns: `8 * 2` for a row the cursor is not
+## on and `8 * 3` for the one it is, which is what frees column 0 for the arrow.
+const ICON_X: int = 8 * 2
+const ICON_SELECTED_X: int = 8 * 3
+
+## `.Frameset_PartyMon`: two OAM sets of eight, which is nine passes each
+## (`GetSpriteAnimFrame` returns the entry on the pass that loads the duration
+## too), then `oamrestart`. The second set is the same four tiles four on.
+const ICON_FRAME_DURATION: int = 8
+const ICON_FRAMES: int = 2
+const ICON_FRAME_TILES: int = 4
+
+## `SetPartyMonIconAnimSpeed`'s `.speeds`, added to every frame's duration, and
+## the same byte rotated twice into VAR2. A hurt Pokémon's icon steps and bobs
+## more slowly; a red one does neither.
+const ICON_SPEEDS: Array[int] = [0x00, 0x40, 0x80]
+const ICON_BOBS: Array[int] = [-2, -1, 0]
+
+## `.SpawnItemIcon`'s marker, `HeldItemIcons`' second tile, over the icon's own
+## bottom-left one. Its mail sibling is unreachable here (see
+## [constant RomLayout.HELD_ITEM_ICON_MAIL]).
+const ICON_ITEM_TILE: int = RomLayout.HELD_ITEM_ICON_ITEM
+const ICON_ITEM_QUADRANT: int = 2
+
 ## `PlaceStatusString`'s three-letter strings, in the order
 ## `PlaceNonFaintStatus` tests them. FNT comes first because
 ## `PlaceStatusString` checks the health before it ever looks at the byte.
@@ -60,6 +96,11 @@ const FAINTED_STRING: String = "FNT"
 var font: Gen2Font = null
 var hud: Gen2BattleHud = null
 var data: GameData = null
+
+## One sprite anim struct per member, in party order:
+## `{icon, item, speed, frame, duration, var1, x, y_offset}`. Empty until
+## [method advance] has been given rows to build it from.
+var _icons: Array = []
 
 ## `Textbox` draws with wTextboxFrame, so the bottom box wears whichever frame
 ## the player chose, as every other box here does.
@@ -103,7 +144,139 @@ func render(rows: Array, cursor: int, prompt: String) -> Image:
 	)
 	for index: int in rows.size():
 		_blend_bar(image, index, rows[index])
+	_blend_icons(image, rows.size())
 	return image
+
+
+## One pass of `PlaySpriteAnimations` over `InitPartyMenuGFX`'s structs: the
+## sequence first and then the frameset, which is the order
+## `DoNextFrameForAllSprites` calls them in. Called once per hardware frame by
+## whoever owns the screen; the structs are rebuilt when the party behind them
+## changes, the way a reopened menu respawns them.
+func advance(rows: Array, cursor: int) -> void:
+	if _icons.size() != rows.size():
+		reset(rows)
+	for index: int in _icons.size():
+		var icon: Dictionary = _icons[index]
+		_step_icon_sequence(icon, index == cursor)
+		_step_icon_frame(icon)
+
+
+## `InitPartyMenuGFX`: one struct per member, spawned in party order. FRAME
+## opens at -1 and DURATION at zero, so the first pass shows the first entry.
+func reset(rows: Array) -> void:
+	_icons = []
+	for row: Variant in rows:
+		var member: Dictionary = row as Dictionary
+		var speed: int = GameData.hp_bar_palette_index(Gen2BattleHud.bar_pixels(
+			int(member.get("hp", 0)), int(member.get("max_hp", 0)),
+			Gen2BattleHud.HP_BAR_TILES * TILE
+		))
+		_icons.append({
+			"icon": data.mon_menu_icon(int(member.get("species", 0))) if data != null else 0,
+			"item": int(member.get("item", 0)) != 0,
+			"speed": speed,
+			"frame": -1,
+			"duration": 0,
+			"var1": 0,
+			"x": ICON_X,
+			"y_offset": 0,
+		})
+
+
+## What the icons would draw right now, so a host caching its layer knows when
+## the picture behind that cache has moved.
+func animation_signature() -> String:
+	var parts: PackedStringArray = []
+	for icon: Dictionary in _icons:
+		parts.append("%d:%d:%d" % [int(icon["frame"]), int(icon["x"]), int(icon["y_offset"])])
+	return ",".join(parts)
+
+
+## `SpriteAnimFunc_PartyMon`, which hands the cursor's own row to
+## `SpriteAnimFunc_PartyMonSwitch`. VAR1 counts only while a row is the chosen
+## one, and the offset it picks changes every sixteenth pass.
+func _step_icon_sequence(icon: Dictionary, selected: bool) -> void:
+	if not selected:
+		icon["x"] = ICON_X
+		icon["y_offset"] = 0
+		return
+	icon["x"] = ICON_SELECTED_X
+	var counter: int = int(icon["var1"])
+	icon["var1"] = (counter + 1) & 0xFF
+	if counter & 0x0F != 0:
+		return
+	icon["y_offset"] = ICON_BOBS[int(icon["speed"])] if counter & 0x10 != 0 else 0
+
+
+## `GetSpriteAnimFrame` over `.Frameset_PartyMon`: count the duration down, and
+## on the pass it runs out step to the next entry and load its own.
+func _step_icon_frame(icon: Dictionary) -> void:
+	if int(icon["duration"]) > 0:
+		icon["duration"] = int(icon["duration"]) - 1
+		return
+	icon["frame"] = (int(icon["frame"]) + 1) % ICON_FRAMES
+	icon["duration"] = (ICON_FRAME_DURATION + ICON_SPEEDS[int(icon["speed"])]) & 0xFF
+
+
+## The icons over the page, in the one palette `InitPartyMenuOBPals` gives them.
+## They are objects rather than tiles, so colour 0 is transparent and they are
+## blended on top rather than written into the index buffer.
+func _blend_icons(image: Image, count: int) -> void:
+	if data == null or _icons.is_empty():
+		return
+	var colors: PackedColorArray = data.party_menu_icon_palette()
+	if colors.size() != Gen2Palette.COLORS_PER_PIC:
+		return
+	var held: PackedByteArray = data.held_item_icon_indices()
+	for index: int in mini(count, _icons.size()):
+		var icon: Dictionary = _icons[index]
+		## Shadow OAM holds nothing for a struct `UpdateAnimFrame` has not
+		## reached yet, which is why FRAME opens at -1 rather than at zero.
+		if int(icon["frame"]) < 0:
+			continue
+		var strip: PackedByteArray = data.overworld_icon_indices(int(icon["icon"]))
+		if strip.is_empty():
+			continue
+		var at := Vector2i(
+			int(icon["x"]) - ICON_TILE - OAM_ORIGIN.x,
+			ICON_FIRST_Y + index * ICON_ROW_STEP + int(icon["y_offset"])
+				- ICON_TILE - OAM_ORIGIN.y
+		)
+		var first: int = int(icon["frame"]) * ICON_FRAME_TILES
+		for quadrant: int in ICON_FRAME_TILES:
+			var source: PackedByteArray = strip
+			var tile: int = first + quadrant
+			if quadrant == ICON_ITEM_QUADRANT and bool(icon["item"]) and not held.is_empty():
+				source = held
+				tile = ICON_ITEM_TILE
+			_blend_tile(
+				image, source, tile, colors,
+				at + Vector2i((quadrant & 1) * ICON_TILE, (quadrant >> 1) * ICON_TILE)
+			)
+
+
+## One 8x8 tile of an index strip, clipped to the screen.
+func _blend_tile(
+	image: Image, strip: PackedByteArray, tile: int, colors: PackedColorArray, at: Vector2i
+) -> void:
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / Gen2Tiles.TILE_HEIGHT
+	var left: int = tile * Gen2Tiles.TILE_WIDTH
+	if left + Gen2Tiles.TILE_WIDTH > width:
+		return
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		var y: int = at.y + row
+		if y < 0 or y >= Gen2Screen.HEIGHT:
+			continue
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			var x: int = at.x + column
+			if x < 0 or x >= Gen2Screen.WIDTH:
+				continue
+			var index: int = strip[row * width + left + column]
+			if index == 0:
+				continue
+			image.set_pixel(x, y, colors[index])
 
 
 func _draw_member(page: PackedByteArray, width: int, index: int, row: Dictionary) -> void:

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -11,7 +11,18 @@ extends GutTest
 ##
 ## The battle-extra strip is filled with a different index from the rest, since
 ## the bars come off it and are the one thing on the page drawn through a palette
-## that is not black on white.
+## that is not black on white. The icons are the other: one fixture shape whose
+## two frames carry different indices, so which pass is on screen and where it
+## landed can both be read off the picture.
+
+## The fixture's one icon shape and the species that names it, plus the two
+## colours its frames are drawn in.
+const FIXTURE_ICON: int = 3
+const FIXTURE_SPECIES: int = 25
+const ICON_FIRST_PACKED: int = 0x03E0
+const ICON_SECOND_PACKED: int = 0x001F
+## The four tiles of the shape's first frame, which is half the strip.
+const HALF_ICON_COLUMNS: int = 4 * Gen2Tiles.TILE_WIDTH
 
 var _directory: String = ""
 
@@ -54,6 +65,8 @@ func _write_cache() -> void:
 			"bits": 1,
 		}
 
+	_write_icons()
+
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "partypagetest",
@@ -69,6 +82,33 @@ func _write_cache() -> void:
 	})
 
 
+## One icon shape whose first frame is index 1 and second index 2, the held item
+## marker in index 3, and the two palettes `InitPartyMenuOBPals` copies.
+func _write_icons() -> void:
+	var strip: PackedByteArray = PackedByteArray()
+	strip.resize(RomLayout.MON_ICON_TILES * Gen2Tiles.TILE_PIXELS)
+	var width: int = RomLayout.MON_ICON_TILES * Gen2Tiles.TILE_WIDTH
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		for column: int in width:
+			strip[row * width + column] = 1 if column < HALF_ICON_COLUMNS else 2
+	RomCache.write_indices(RomCache.overworld_icon_path(_directory, FIXTURE_ICON), strip)
+
+	var held: PackedByteArray = PackedByteArray()
+	held.resize(RomLayout.HELD_ITEM_ICON_TILES * Gen2Tiles.TILE_PIXELS)
+	held.fill(3)
+	RomCache.write_indices(RomCache.held_item_icon_path(_directory), held)
+
+	var species: PackedByteArray = PackedByteArray()
+	species.resize(RomLayout.SPECIES_COUNT)
+	species[FIXTURE_SPECIES - 1] = FIXTURE_ICON
+	RomCache.write_indices(RomCache.mon_menu_icons_path(_directory), species)
+
+	RomCache.write_json(RomCache.party_menu_icon_palettes_path(_directory), [
+		[0x7FFF, ICON_FIRST_PACKED, ICON_SECOND_PACKED, 0x0000],
+		[0x7FFF, ICON_FIRST_PACKED, 0x0000, 0x0000],
+	])
+
+
 func _page() -> Gen2PartyMenuPage:
 	return Gen2PartyMenuPage.from_data(GameData.open_directory(_directory))
 
@@ -77,10 +117,21 @@ func _rows(count: int = 2) -> Array:
 	var out: Array = []
 	for index: int in count:
 		out.append({
-			"index": index, "name": "PIKACHU", "level": 20,
+			"index": index, "species": FIXTURE_SPECIES, "item": 0,
+			"name": "PIKACHU", "level": 20,
 			"hp": 18, "max_hp": 20, "status": 0, "fainted": false,
 		})
 	return out
+
+
+## The page after [param passes] passes of `PlaySpriteAnimations`, which is what
+## [Gen2BattleScreen] spends one of a hardware frame.
+func _animated(rows: Array, cursor: int, passes: int) -> Image:
+	var page: Gen2PartyMenuPage = _page()
+	page.reset(rows)
+	for _pass: int in passes:
+		page.advance(rows, cursor)
+	return page.render(rows, cursor, Gen2BattleSwitchMenu.prompt_text())
 
 
 func _render(rows: Array, cursor: int = 0) -> Image:
@@ -113,12 +164,84 @@ func test_the_page_is_the_whole_screen() -> void:
 
 
 ## `hlcoord 3, 1` for the nicknames, stepping `2 * SCREEN_WIDTH` a member, with
-## columns 1 and 2 left for the menu mon icons nothing here draws.
+## columns 0 to 2 left for the icons, which are sprites rather than tilemap.
 func test_each_member_prints_two_rows_below_the_last() -> void:
 	var image: Image = _render(_rows())
 	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x, 1), 0, "the first nickname")
 	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x, 3), 0, "the second")
 	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x - 1, 1), 0, "the icon column")
+
+
+## `InitPartyMenuGFX` spawns a struct per member and `UpdateAnimFrame` writes
+## shadow OAM on the pass after, so a page that has not been stepped yet has no
+## icons on it at all.
+func test_no_icon_is_drawn_before_the_first_sprite_pass() -> void:
+	var page: Gen2PartyMenuPage = _page()
+	page.reset(_rows(1))
+	var image: Image = page.render(_rows(1), -1, "")
+	assert_eq(_ink_in_tile(image, 0, 1), 0, "nothing under the first member")
+
+
+## `InitPartyMenuIcon`'s `ld e, $10` less a tile and shadow OAM's own origin,
+## which puts an unselected icon over columns 0 and 1; the cursor's own row is
+## `SpriteAnimFunc_PartyMonSwitch`'s `8 * 3`, a column further right, which is
+## what leaves column 0 for the arrow.
+func test_the_chosen_row_moves_its_icon_out_of_the_cursor_column() -> void:
+	var rows: Array = _rows(2)
+	## Column 2 of the second member's own rows, which only a shifted icon
+	## reaches. The fixture's glyphs are solid tiles, so the picture is read
+	## where nothing else is drawn rather than where the arrow is.
+	var right := Vector2i(2 * Gen2Font.TILE + 1, 3 * Gen2Font.TILE + 2)
+	assert_eq(
+		_animated(rows, -1, 1).get_pixelv(right), Color.WHITE,
+		"an unselected icon stops at column 1"
+	)
+	assert_eq(
+		_animated(rows, 1, 1).get_pixelv(right), Gen2Palette.from_packed(ICON_FIRST_PACKED),
+		"and the chosen row's reaches column 2"
+	)
+
+
+## `.Frameset_PartyMon` is two OAM sets of eight, so the first entry is up for
+## nine passes and the second for the nine after it.
+func test_the_icon_steps_to_its_second_frame_after_nine_passes() -> void:
+	var rows: Array = _rows(1)
+	var at := Vector2i(Gen2Font.TILE, 1 * Gen2Font.TILE)
+	assert_eq(
+		_animated(rows, -1, 9).get_pixelv(at), Gen2Palette.from_packed(ICON_FIRST_PACKED),
+		"the first frame lasts nine passes"
+	)
+	assert_eq(
+		_animated(rows, -1, 10).get_pixelv(at), Gen2Palette.from_packed(ICON_SECOND_PACKED),
+		"and the second follows it"
+	)
+
+
+## `SpriteAnimFunc_PartyMonSwitch` moves YOFFSET on every sixteenth pass, and
+## `.speeds` picks how far by the bar's own colour: two pixels on a green one.
+func test_the_chosen_icon_bobs_on_its_own_counter() -> void:
+	var rows: Array = _rows(1)
+	## Two pixels above where the first icon rests, which nothing else draws on.
+	var above := Vector2i(2 * Gen2Font.TILE, 2)
+	assert_eq(
+		_animated(rows, 0, 16).get_pixelv(above), Color.WHITE, "the icon rests where it spawned"
+	)
+	assert_ne(
+		_animated(rows, 0, 17).get_pixelv(above), Color.WHITE,
+		"and stands two pixels higher once the counter passes sixteen"
+	)
+
+
+## `.SpawnItemIcon`: a member holding anything wears `HeldItemIcons`' second
+## tile in place of the icon's own bottom-left one.
+func test_a_held_item_replaces_the_icons_bottom_left_tile() -> void:
+	var rows: Array = _rows(1)
+	var quadrant := Vector2i(0, 1 * Gen2Font.TILE + 4)
+	var bare: Color = _animated(rows, -1, 1).get_pixelv(quadrant)
+	rows[0]["item"] = 1
+	var held: Color = _animated(rows, -1, 1).get_pixelv(quadrant)
+	assert_eq(bare, Gen2Palette.from_packed(ICON_FIRST_PACKED), "the icon's own tile")
+	assert_eq(held, Color.BLACK, "and the marker's, which the fixture fills with index 3")
 
 
 ## `PlacePartyNicknames.end` steps two columns back from the row below the last

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -23,12 +23,19 @@ func test_gold_and_silver_share_their_common_layout() -> void:
 	for key: String in gold:
 		if key in [
 			"item_attributes", "item_status_actions", "item_healing_hp",
-			"overworld_icons", "copyright", "game_freak_presents", "title",
+			"overworld_icons", "held_item_icons",
+			"copyright", "game_freak_presents", "title",
 			"gs_intro",
 		]:
 			continue
 		assert_eq(gold[key], silver[key], "Gold/Silver layout differs at %s" % key)
 	assert_ne(gold["item_attributes"], silver["item_attributes"])
+	# Both offsets into the icon bank move together: Silver's copy of it sits
+	# twenty-six bytes lower than Gold's.
+	assert_eq(
+		int(gold["overworld_icons"]) - int(silver["overworld_icons"]),
+		int(gold["held_item_icons"]) - int(silver["held_item_icons"])
+	)
 	# The copyright screen is the same graphic in the same place; only the
 	# string's own address moves, sixty bytes apart in bank 1.
 	var gold_copyright: Dictionary = gold["copyright"]

--- a/tools/checks/party_icons.gd
+++ b/tools/checks/party_icons.gd
@@ -1,0 +1,124 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the menu mon icons a party page draws, against freshly imported real
+## caches: `MonMenuIcons` (one of the 38 `ICON_*` shapes per species),
+## `IconPointers`' art behind it, `HeldItemIcons` and `PartyMenuOBPals`.
+##
+## The whole corpus rather than a sample: every species on all three cartridges
+## resolves to an icon whose eight tiles decode and carry ink. The table is a
+## plain byte run, so a wrong offset lands on neighbouring data that still reads
+## as numbers; what says it is the right run is that every entry is in range,
+## that the first and last species are the shapes the source names, and that the
+## three cartridges agree entry for entry.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- party_icons
+
+## `constants/icon_constants.asm`, the entries the census names.
+const ICON_BULBASAUR: int = 22
+const ICON_HUMANSHAPE: int = 14
+const ICON_UNOWN: int = 25
+
+## `data/pokemon/menu_icons.asm`'s first and last rows, either side of the run.
+const FIRST_SPECIES: int = 1
+const LAST_SPECIES: int = 251
+const UNOWN: int = 201
+
+var _first_table: PackedByteArray = PackedByteArray()
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_first_table = PackedByteArray()
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var table: PackedByteArray = _r.data.mon_menu_icon_table()
+	if not _r.check(
+		table.size() == LAST_SPECIES,
+		"MonMenuIcons holds %d entries, not %d." % [table.size(), LAST_SPECIES]
+	):
+		return
+	_r.check(
+		_r.data.mon_menu_icon(FIRST_SPECIES) == ICON_BULBASAUR,
+		"BULBASAUR draws icon %d, not ICON_BULBASAUR." % _r.data.mon_menu_icon(FIRST_SPECIES)
+	)
+	_r.check(
+		_r.data.mon_menu_icon(LAST_SPECIES) == ICON_HUMANSHAPE,
+		"CELEBI draws icon %d, not ICON_HUMANSHAPE." % _r.data.mon_menu_icon(LAST_SPECIES)
+	)
+	_r.check(
+		_r.data.mon_menu_icon(UNOWN) == ICON_UNOWN,
+		"UNOWN draws icon %d, not ICON_UNOWN." % _r.data.mon_menu_icon(UNOWN)
+	)
+	# A species past the cartridge's own range is what a mod would number, and
+	# it has no row rather than a wrong one.
+	_r.check(
+		_r.data.mon_menu_icon(LAST_SPECIES + 1) == 0,
+		"a species past the table answers an icon anyway."
+	)
+	if _first_table.is_empty():
+		_first_table = table
+	else:
+		_r.check(
+			_first_table == table, "MonMenuIcons differs from the other cartridges."
+		)
+
+	var used: Dictionary = {}
+	for species: int in range(FIRST_SPECIES, LAST_SPECIES + 1):
+		used[_r.data.mon_menu_icon(species)] = true
+	var lit: int = 0
+	for icon: int in range(1, RomLayout.MON_ICON_COUNT + 1):
+		var strip: PackedByteArray = _r.data.overworld_icon_indices(icon)
+		if not _r.check(
+			strip.size() == RomLayout.MON_ICON_TILES * Gen2Tiles.TILE_PIXELS,
+			"icon %d decoded %d pixels." % [icon, strip.size()]
+		):
+			continue
+		var drawn: int = 0
+		for index: int in strip:
+			if index != 0:
+				drawn += 1
+		_r.check(drawn > 0, "icon %d is blank." % icon)
+		lit += drawn
+	_r.check(
+		used.size() == RomLayout.MON_ICON_COUNT - 1,
+		"%d of the %d shapes are used; only ICON_EGG should be spare." % [
+			used.size(), RomLayout.MON_ICON_COUNT,
+		]
+	)
+
+	_check_held_item_icons()
+	_check_palette()
+	_r.note("party icons: %d species over %d shapes, %d drawn pixels." % [
+		LAST_SPECIES, used.size(), lit,
+	])
+
+
+## `HeldItemIcons`, both tiles, though only the item one is ever drawn.
+func _check_held_item_icons() -> void:
+	var held: PackedByteArray = _r.data.held_item_icon_indices()
+	_r.check(
+		held.size() == RomLayout.HELD_ITEM_ICON_TILES * Gen2Tiles.TILE_PIXELS,
+		"HeldItemIcons decoded %d pixels." % held.size()
+	)
+
+
+## `PartyMenuOBPals`' first palette, the one every icon's OAM set names. Colour
+## 0 is the transparent index, so an icon drawn in a palette whose colour 0 is
+## not the light one the source ships would lose its outline instead of its
+## background.
+func _check_palette() -> void:
+	var colors: PackedColorArray = _r.data.party_menu_icon_palette()
+	if not _r.check(
+		colors.size() == Gen2Palette.COLORS_PER_PIC,
+		"the icon palette holds %d colours." % colors.size()
+	):
+		return
+	_r.check(colors[3] == Color.BLACK, "the icon palette does not end in black.")
+	_r.check(
+		colors[0].get_luminance() > colors[2].get_luminance(),
+		"the icon palette's transparent colour is darker than its third."
+	)

--- a/tools/checks/party_icons.gd.uid
+++ b/tools/checks/party_icons.gd.uid
@@ -1,0 +1,1 @@
+uid://b54u5o2op8orx

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -5,12 +5,15 @@ extends SceneTree
 ## behind FIGHT, `OfferSwitch`'s yes/no box over the field,
 ## `AskUseNextPokemon`'s box in the same place, and the party list they open.
 ##
-##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses]
+##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses] [passes]
 ##
 ## [stage] is one of `offer` (the default), `menu`, `move`, `contest`, `pick`,
 ## `use_next` and `replace`;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
-## cursor row or a refusal can be photographed. The battle is a real trainer's
+## cursor row or a refusal can be photographed; [passes] is how many sprite
+## passes the party page's icons are given, which is what moves the chosen row's
+## icon off its resting offset. The screen's own processing is taken away before
+## those are spent, so the same arguments photograph the same frame. The battle is a real trainer's
 ## party out of the cache with the player on a bench of three, since both a
 ## switch and a replacement need somebody to send.
 ##
@@ -38,6 +41,7 @@ var _screen: Gen2BattleScreen = null
 var _output_path: String = ""
 var _stage: String = "offer"
 var _presses: PackedStringArray = PackedStringArray()
+var _icon_passes: int = 0
 var _frames: int = 0
 
 
@@ -51,6 +55,8 @@ func _initialize() -> void:
 	_stage = args[2] if args.size() > 2 else "offer"
 	if args.size() > 3:
 		_presses = args[3].split(",", false)
+	if args.size() > 4:
+		_icon_passes = int(args[4])
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
@@ -153,6 +159,7 @@ func _open() -> void:
 		for press: String in _presses:
 			_screen._handle_button(_button(press))
 		_screen.finish()
+		_settle_icons()
 		return
 
 	_drain()
@@ -166,6 +173,17 @@ func _open() -> void:
 	## A refusal is a line the box is still revealing, and the capture does not
 	## wait on real time.
 	_screen.finish()
+	_settle_icons()
+
+
+## The icons animate on their own clock, so the screen keeps stepping them
+## across the frames this tool spends laying the scene out. Taking its
+## processing away first is what makes the shot the pass that was asked for.
+func _settle_icons() -> void:
+	_screen.set_process(false)
+	for _pass: int in _icon_passes:
+		_screen.advance_party_icons()
+	_screen._refresh_menu_layer()
 
 
 ## The same drain, stopping at `BattleMenu` rather than at a switch question.

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -26,6 +26,10 @@ const SPECIALCALL_ASSISTANT: int = 3
 ## the route at ten (maps/Route41.asm).
 const WALK_RESOLVE_ATTEMPTS: int = 16
 
+## How many of the objects standing against a failed walk's frontier its reason
+## names. A crowded map has more than a reader needs.
+const BLOCKING_OBJECTS_REPORTED: int = 4
+
 ## constants/item_constants.asm's add_hm list, whose comment column is hex.
 ## `maps/Route32.asm` warp 1 and `maps/Route32Pokecenter1F.asm` warp 1, the
 ## fishing guru on (1,4) faced from below, and the nearest shore cell the rod is
@@ -9536,7 +9540,13 @@ func _walk_to_connection(
 			previous[next] = {"cell": cell, "direction": step}
 			frontier.append(next)
 	if edge.x < 0:
-		return {"ok": false, "reason": "connection edge unreachable", "direction": direction_name}
+		return {
+			"ok": false,
+			"reason": "connection edge unreachable%s" % _objects_in_the_way(
+				world, Vector2i(-1, -1), previous
+			),
+			"direction": direction_name,
+		}
 
 	var steps: Array[Vector2i] = []
 	var cursor: Vector2i = edge
@@ -9681,9 +9691,10 @@ func _walk_to_story_cell(
 	if not found:
 		return {
 			"ok": false,
-			"reason": "target %s unreachable from %s on %s (collision $%02x, walkable %s)" % [
+			"reason": "target %s unreachable from %s on %s (collision $%02x, walkable %s)%s" % [
 				target, world.player_cell, _map_value(world),
 				world.collision_code_at(target), world.can_walk_to(target),
+				_objects_in_the_way(world, target, previous),
 			],
 			"target": _cell_value_from_vector(target),
 		}
@@ -9707,6 +9718,59 @@ func _walk_to_story_cell(
 		if not events.is_empty():
 			break
 	return {"ok": true, "steps": steps.size(), "events": events}
+
+
+## What a failed walk hit, when what it hit was somebody standing there.
+## `Gen2WorldAPI.can_walk_to()` refuses a cell an object holds exactly as it
+## refuses a wall, so without this a route blocked by an NPC or an item ball
+## reads the same as one blocked by the map, and both of Route 40's beach rocks
+## and the Lake of Rage's gramps cost a hand-routed detour to find.
+##
+## [param target] is the cell the walk wanted, or `(-1, -1)` for a connection
+## edge that has none; [param visited] is the frontier's own `previous` map.
+## Answers "" when nothing is in the way, so it appends to a reason.
+func _objects_in_the_way(
+	world: Gen2WorldAPI, target: Vector2i, visited: Dictionary
+) -> String:
+	var named: PackedStringArray = []
+	var standing: Gen2WorldObject = world.object_at(target) if target.x >= 0 else null
+	if standing != null:
+		named.append("%s stands on it" % _object_name(standing))
+	for object: Gen2WorldObject in world.objects:
+		if object == standing or object.deleted or not object.active:
+			continue
+		if not _plugs_the_frontier(world, object, visited):
+			continue
+		named.append("%s at %s" % [_object_name(object), object.cell])
+		if named.size() >= BLOCKING_OBJECTS_REPORTED:
+			break
+	if named.is_empty():
+		return ""
+	return ", blocked by %s" % ", ".join(named)
+
+
+## Whether [param object] is standing in a gap rather than in the open: the walk
+## reached one side of it and there is ground on the other it never got to. An
+## NPC in the middle of a town is next to the frontier too, and naming that one
+## would bury the one that matters.
+func _plugs_the_frontier(
+	world: Gen2WorldAPI, object: Gen2WorldObject, visited: Dictionary
+) -> bool:
+	if visited.has(object.cell):
+		return false
+	var reached: bool = false
+	var beyond: bool = false
+	for step: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+		var neighbour: Vector2i = object.cell + step
+		if visited.has(neighbour):
+			reached = true
+		elif world.can_walk_to(neighbour):
+			beyond = true
+	return reached and beyond
+
+
+func _object_name(object: Gen2WorldObject) -> String:
+	return "object %d (sprite %d)" % [object.index, object.sprite_number]
 
 
 ## The order Gen2WorldScreen uses after a successful step: a trainer who can

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -33,7 +33,7 @@ const GROUPS: Dictionary = {
 	],
 	&"art": [
 		&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims",
-		&"overworld_effects",
+		&"overworld_effects", &"party_icons",
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",


### PR DESCRIPTION
`InitPartyMenuGFX` spawns a sprite anim struct per party member and the battle's party list drew none of them, leaving its first two columns blank.

**Imported.** `MonMenuIcons` and `IconPointers` are INCLUDEd immediately in front of `gfx/icons.asm`, so the icon art's own offset pins both and neither needs a new per-game address; the pointer table is read back as the check on it. `HeldItemIcons` and `PartyMenuOBPals` take one pin each, checked structurally rather than by content: two bordered boxes, and two palettes sharing every colour but one.

**Drawn.** `Gen2PartyMenuPage.advance()` is one pass of `PlaySpriteAnimations` over the structs, the sequence then the frameset, which is the order `DoNextFrameForAllSprites` calls them in. So the icons step every ninth pass, the chosen row moves a column right to free the arrow's own and bobs on its counter, and `.speeds` slows both by the HP bar's colour. A member holding anything wears `HeldItemIcons`' marker over the icon's bottom-left tile.

Also: the story walker names the object standing in a failed walk's way when one is plugging a gap, instead of answering `unreachable` alone. The Victory Road Gate's two black belts now report themselves.

Cache format 55, so every existing cache is re-imported.

| Check | Result |
|---|---|
| `Layout verified.` | 3/3 cartridges |
| GUT unit | 2,536 tests, 120 scripts |
| GUT with scene integration | 2,868 tests, 148 scripts |
| `validate.gd -- all` | 45 topics, exit 0 |
| `party_icons` topic | 251 species over 37 shapes, 10,707 drawn pixels, on each cartridge |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | 291 steps on Gold and Silver, 294 on Crystal, 16 badges |