### PR TITLE
Draw the substitute's doll, and say which state a cache is in

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ godot --headless --path . -s res://tools/import_rom.gd
 A few seconds per game. The cache is keyed by game and hash and lives in Godot's
 `user://`, never in the project or an export. `--verify` checks without writing.
 
+A cache is never migrated. An update that changes its format discards the old
+one, and the launcher's manage sheet says so: import the same dump again. Saves
+live under their own root and are not touched.
+
 | Data | Contents |
 |---|---|
 | Species | Names, base stats, types, held items, egg groups, TM/HM flags |

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -168,6 +168,13 @@ func audio_status() -> Dictionary:
 
 func _exit_tree() -> void:
 	stop_all()
+	# Stopping the player is not enough to let go of its playback: the audio
+	# server holds one per stream, and only taking the stream off the player
+	# releases it. A headless tool that builds a world screen and exits reported
+	# one leaked `AudioStreamGeneratorPlayback` per screen without this.
+	if _player != null:
+		_player.stream = null
+	_generator = null
 
 
 func _is_music(request_kind: StringName) -> bool:

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -351,6 +351,13 @@ const SUBSTITUTE_TOO_WEAK: StringName = &"substitute_too_weak"
 const SUBSTITUTE_TOOK_DAMAGE: StringName = &"substitute_took_damage"
 const SUBSTITUTE_FADED: StringName = &"substitute_faded"
 
+## `BattleCommand_RaiseSubNoAnim` and `..._LowerSubNoAnim`: the doll put over a
+## battler's picture or taken off it with no animation and no frames, which is
+## what the two commands amount to once `WaitBGMap` is discounted. Carries `side`
+## and `raised`. Says nothing about the battle: it is the picture alone, which is
+## why an animated drop is the animation's own `anim_dropsub` instead.
+const SUBSTITUTE_PIC: StringName = &"substitute_pic"
+
 ## Leech Seed, on the Pokémon that was seeded rather than the one that seeded it.
 ## [constant LEECH_SEED_SAPPED] carries the healed side under `to`, `to_amount`,
 ## `to_hp` and `to_max_hp`, since one event moves health across the field.

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -98,6 +98,10 @@ const WAIT: StringName = &"wait"
 
 const OBJ: StringName = &"obj"
 const SOUND: StringName = &"sound"
+## The two that write a battler's own picture rather than an animation object:
+## `GetSubstitutePic` puts the doll over it and `DropPlayerSub` puts it back.
+const RAISE_SUB: StringName = &"raise_sub"
+const DROP_SUB: StringName = &"drop_sub"
 const CRY: StringName = &"cry"
 const JUMP: StringName = &"jump"
 const LOOP: StringName = &"loop"

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -58,12 +58,24 @@ var _player_bar: TextureRect = null
 var _exp_bar: TextureRect = null
 var _sprites: TextureRect = null
 
+## `SPRITE_MONSTER` (constants/sprite_constants.asm), the same number in both
+## pins. `GetSubstitutePic` builds the doll out of `MonsterSpriteGFX`, which is
+## that overworld sprite's own strip, so the battle draws a walking sprite.
+const SUBSTITUTE_SPRITE: int = 0x4C
+
+## Where `GetSubstitutePic` copies the four tiles: the enemy takes the sprite's
+## down-facing frame at columns 2 and 3, rows 5 and 6 of its 7x7 box, the player
+## the up-facing one a row higher in a 6x6 box. A tile index into either box is
+## `column * side + row`, which is what `sScratch + (2 * 7 + 5) tiles` says.
+const SUBSTITUTE_AT: Dictionary = {false: Vector2i(2, 5), true: Vector2i(2, 4)}
+const SUBSTITUTE_FIRST_TILE: Dictionary = {false: 0, true: 4}
+
 ## One 56x56 and one 48x48 index buffer, the two pics padded out to their own
-## boxes, rebuilt only when the species drawn changes.
+## boxes, rebuilt only when the picture drawn changes.
 var _enemy_pixels: PackedByteArray = PackedByteArray()
 var _player_pixels: PackedByteArray = PackedByteArray()
-var _enemy_pixels_species: int = -1
-var _player_pixels_species: int = -1
+var _enemy_pixels_key: Array = []
+var _player_pixels_key: Array = []
 
 ## Everything a pic layer is built out of. A draining bar moves the panels while
 ## the map, the species, the palette and the scroll all stand still, so the same
@@ -146,7 +158,7 @@ func _draw_pics() -> void:
 	var enemy_palette: PackedColorArray = _battler_palette(
 		enemy, Gen2BattleAnimBackground.PAL_BG_ENEMY
 	)
-	var enemy_key: Array = [map, enemy, enemy_palette, raster]
+	var enemy_key: Array = [map, enemy, _enemy_pixels_key, enemy_palette, raster]
 	if enemy_key != _enemy_pic_key:
 		_enemy_pic_key = enemy_key
 		_show_layer(
@@ -162,7 +174,7 @@ func _draw_pics() -> void:
 		var player_palette: PackedColorArray = _battler_palette(
 			player, Gen2BattleAnimBackground.PAL_BG_PLAYER
 		)
-		var player_key: Array = [map, player, player_palette, raster]
+		var player_key: Array = [map, player, _player_pixels_key, player_palette, raster]
 		if player_key != _player_pic_key:
 			_player_pic_key = player_key
 			_show_layer(
@@ -213,16 +225,63 @@ func _pic_layer(
 
 
 ## The two pics as index buffers padded out to their own boxes, so a tile id
-## indexes a fixed grid whatever size the species' own pic is.
+## indexes a fixed grid whatever size the species' own pic is. A side whose doll
+## is up is holding the substitute's picture instead, which is the same box with
+## a different four tiles in it.
 func _ensure_pixels() -> void:
-	var enemy: int = int(_view.get("enemy_species", 0))
-	if enemy != _enemy_pixels_species:
-		_enemy_pixels = _padded_pic(_data.species_pic(enemy), Gen2BattleScreenMap.ENEMY_SIDE)
-		_enemy_pixels_species = enemy
-	var player: int = int(_view.get("player_species", 0))
-	if player != _player_pixels_species:
-		_player_pixels = _padded_pic(_data.species_pic(player, true), Gen2BattleScreenMap.PLAYER_SIDE)
-		_player_pixels_species = player
+	var enemy_key: Array = [
+		int(_view.get("enemy_species", 0)), bool(_view.get("enemy_substitute", false)),
+	]
+	if enemy_key != _enemy_pixels_key:
+		_enemy_pixels = _substitute_pic(false) if bool(enemy_key[1]) \
+			else _padded_pic(_data.species_pic(int(enemy_key[0])), Gen2BattleScreenMap.ENEMY_SIDE)
+		_enemy_pixels_key = enemy_key
+	var player_key: Array = [
+		int(_view.get("player_species", 0)), bool(_view.get("player_substitute", false)),
+	]
+	if player_key != _player_pixels_key:
+		_player_pixels = _substitute_pic(true) if bool(player_key[1]) \
+			else _padded_pic(
+				_data.species_pic(int(player_key[0]), true), Gen2BattleScreenMap.PLAYER_SIDE
+			)
+		_player_pixels_key = player_key
+
+
+func _substitute_pic(player_side: bool) -> PackedByteArray:
+	return substitute_pixels(_data.overworld_sprite_indices(SUBSTITUTE_SPRITE), player_side)
+
+
+## `GetSubstitutePic`: a blank box with four tiles of [param strip], the monster
+## overworld sprite, copied into it. The doll wears whichever battler palette its
+## box sits in, since nothing writes one for it.
+##
+## Static because it is the whole of the picture and takes no screen: a check
+## sweeping three caches builds it the same way the renderer does.
+static func substitute_pixels(strip: PackedByteArray, player_side: bool) -> PackedByteArray:
+	var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+		else Gen2BattleScreenMap.ENEMY_SIDE
+	var box: int = side * TILE
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(box * box)
+
+	var first: int = int(SUBSTITUTE_FIRST_TILE[player_side])
+	# The strip is one tile row high, so its length is its width in pixels.
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / TILE
+	if width < (first + 4) * TILE:
+		return out
+
+	var at: Vector2i = SUBSTITUTE_AT[player_side]
+	for tile: int in 4:
+		var left: int = (at.x + (tile & 1)) * TILE
+		var top: int = (at.y + (tile >> 1)) * TILE
+		var from_x: int = (first + tile) * TILE
+		for row: int in TILE:
+			var from: int = row * width + from_x
+			var to: int = (top + row) * box + left
+			for column: int in TILE:
+				out[to + column] = strip[from + column]
+	return out
 
 
 func _padded_pic(pic: Dictionary, side: int) -> PackedByteArray:

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -889,6 +889,17 @@ const ANIM_WAIT_SFX: StringName = &"wait_sfx"
 const ANIM_HIT_SOUND: StringName = &"hit_sound"
 const ANIM_APPEAR_USER: StringName = &"appear_user"
 
+## Whose square is showing the substitute's doll rather than the mon itself,
+## keyed by [constant Gen2Battle.PLAYER] and [constant Gen2Battle.ENEMY].
+##
+## The cartridge keeps this in VRAM rather than in a variable: `GetSubstitutePic`
+## writes the doll over the battler's own tiles and `DropPlayerSub` writes the
+## picture back, so what is on the field is whatever was drawn there last. The
+## three writers are the animation's `anim_raisesub` and `anim_dropsub`, the two
+## `noanim` commands the battle-scene option reaches instead, and a send-out,
+## which draws a fresh picture either way.
+var _substitute_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: false}
+
 ## `wFXAnimID` is a word: an id past this is not a move and skips the whole
 ## battle-scene, hud and after-anim half of `BattleAnimRunScript`.
 const ANIM_MOVE_LIMIT: int = 0x100
@@ -953,6 +964,8 @@ func _begin_animation(event: Dictionary) -> void:
 			# `xor a / ldh [hSCX] / ldh [hSCY]`, a delay, then the huds.
 			_step(ANIM_DELAY, {"frames": 1})
 			_step(ANIM_RESTORE_HUD, {})
+		else:
+			_apply_sub_pic_no_anim(index, int(event.get("param", 0)))
 		if after != 0:
 			_step(ANIM_WAIT_SFX, {})
 			_step(ANIM_HIT_SOUND, {})
@@ -970,6 +983,30 @@ func _begin_animation(event: Dictionary) -> void:
 	if bool(event.get("restore_user_pic", false)):
 		_step(ANIM_APPEAR_USER, {})
 	_run_next_anim_step()
+
+
+## The doll the animation would have drawn, written straight into the picture
+## when the battle-scene option is off and the script never runs.
+##
+## `BattleCommand_LowerSub` and `..._RaiseSub` both branch to their own `noanim`
+## routine on `_CheckBattleScene`, and `BattleCommand_Substitute`'s own
+## `.no_anim` calls `RaiseSubNoAnim`, so the three animation parameters answer
+## the same two pictures with the scenes turned off as with them on.
+func _apply_sub_pic_no_anim(index: int, param: int) -> void:
+	if index != Gen2EffectCommands.SUBSTITUTE_MOVE:
+		return
+	_set_substitute_pic(
+		Gen2Battle.ENEMY if bool(_anim_event.get("enemy_turn", false)) else Gen2Battle.PLAYER,
+		param != Gen2EffectCommands.SUBSTITUTE_ANIM_DROP
+	)
+
+
+## Which picture one battler's square is holding, and the view behind it.
+func _set_substitute_pic(side: int, raised: bool) -> void:
+	if bool(_substitute_pic.get(side, false)) == raised:
+		return
+	_substitute_pic[side] = raised
+	_push_view()
 
 
 func _step(kind: StringName, values: Dictionary) -> void:
@@ -1009,11 +1046,13 @@ func _run_next_anim_step() -> void:
 					return
 			ANIM_APPEAR_USER:
 				# `AppearUserLowerSub`, which Fly and Dig reach after the
-				# animation: the user's own picture stamped back into the map it
-				# was taken out of.
-				Gen2BattleScreenMap.stamp(
-					_bg_map, not bool(_anim_event.get("enemy_turn", false))
+				# animation: `LowerSubNoAnim` writes the user's own picture and
+				# `AppearUser` stamps it back into the map it was taken out of.
+				var enemy_turn: bool = bool(_anim_event.get("enemy_turn", false))
+				_set_substitute_pic(
+					Gen2Battle.ENEMY if enemy_turn else Gen2Battle.PLAYER, false
 				)
+				Gen2BattleScreenMap.stamp(_bg_map, not enemy_turn)
 				_push_view()
 	_anim = null
 	_anim_event = {}
@@ -1049,6 +1088,15 @@ func _after_anim_frame() -> void:
 				_play_anim_sound(int((command["operands"] as Array)[1]))
 			Gen2BattleAnimScript.CRY:
 				_play_anim_cry()
+			Gen2BattleAnimScript.RAISE_SUB, Gen2BattleAnimScript.DROP_SUB:
+				# `BattleAnimCmd_RaiseSub` and `..._DropSub` write the actor's own
+				# tiles, and the actor is `hBattleTurn`, which is whose animation
+				# this is.
+				_set_substitute_pic(
+					Gen2Battle.ENEMY if bool(_anim_event.get("enemy_turn", false))
+						else Gen2Battle.PLAYER,
+					StringName(command["name"]) == Gen2BattleAnimScript.RAISE_SUB
+				)
 	_push_view()
 
 
@@ -2669,6 +2717,8 @@ func _apply_event_state(event: Dictionary) -> void:
 			# `FaintYourPokemon` and `FaintEnemyPokemon` sink the picture before
 			# either prints, so the line waits on the animation.
 			_begin_faint(int(event["side"]))
+		Gen2Battle.SUBSTITUTE_PIC:
+			_set_substitute_pic(int(event["side"]), bool(event["raised"]))
 		Gen2Battle.SENT_OUT:
 			# The pic and the panel both change, and both come out of the event
 			# rather than out of the party, for the same reason every other number
@@ -2683,6 +2733,10 @@ func _apply_event_state(event: Dictionary) -> void:
 				_player = int(event["species"])
 				_player_level = int(event["level"])
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
+			# A send-out draws a picture through `GetBattleMonBackpic` or
+			# `GetEnemyMonFrontpic`, and the doll it would answer with belongs to
+			# a Substitute that switching has already taken away.
+			_set_substitute_pic(int(event["side"]), false)
 			_reseed_bg_map()
 			_refresh_exp_bar()
 		Gen2Battle.EXP_GAINED:
@@ -3343,6 +3397,9 @@ func _push_view() -> void:
 		return
 	_renderer.set_view({
 		"enemy_species": _enemy, "player_species": _player,
+		## Whose picture is the substitute's doll rather than the Pokémon's own.
+		"enemy_substitute": bool(_substitute_pic[Gen2Battle.ENEMY]),
+		"player_substitute": bool(_substitute_pic[Gen2Battle.PLAYER]),
 		"enemy_name": _name_of(_enemy), "player_name": _name_of(_player),
 		"enemy_level": _enemy_level, "player_level": _player_level,
 		## Who the fight is against, which the values above do not say. A wild

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -431,11 +431,29 @@ const SKIP_SUN_CHARGE: StringName = &"skipsuncharge"
 ## The move's own animation, and the damage flash `BattleAnimRunScript` chains
 ## off `wBattleAfterAnim` behind it.
 ##
-## `BattleCommand_MoveAnim` is `lowersub`, `moveanimnosub`, `raisesub`. Both subs
-## only drop and restore the doll's picture, which this project does not draw, so
-## the two names are one command here.
+## `BattleCommand_MoveAnim` is `lowersub`, `moveanimnosub`, `raisesub`, so this
+## command is all three; the two subs are separate commands as well, because 35
+## lists carry them around an animation of their own.
 const MOVE_ANIM: StringName = &"moveanim"
 const MOVE_ANIM_NO_SUB: StringName = &"moveanimnosub"
+
+## The substitute's doll dropped out of the way of an animation and put back
+## after it. Both answer nothing when the user has no doll up.
+const LOWER_SUB: StringName = &"lowersub"
+const RAISE_SUB: StringName = &"raisesub"
+
+## The same two pictures written with no animation at all. Only Minimize and
+## Double Team's list carries one: `lowersubnoanim` sits between the raise
+## animation and the `raisesub` behind it, so the doll is off the field for the
+## one command that would otherwise draw it over a minimizing Pokémon.
+const LOWER_SUB_NO_ANIM: StringName = &"lowersubnoanim"
+
+## The five effects `BattleCommand_LowerSub` names, which is every two-turn move:
+## Fly and Dig share one byte, so the source's five are four here.
+const CHARGE_EFFECTS: Array[int] = [
+	Gen2MoveEffect.RAZOR_WIND, Gen2MoveEffect.SKY_ATTACK, Gen2MoveEffect.SKULL_BASH,
+	Gen2MoveEffect.SOLARBEAM, Gen2MoveEffect.FLY_OR_DIG,
+]
 
 ## The animation a stat move plays, between the change and its message.
 ## `BattleCommand_StatUpAnim` uses one animation for both sides;
@@ -821,8 +839,18 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_thunder_accuracy(turn)
 		SKIP_SUN_CHARGE:
 			_skip_sun_charge(turn)
-		MOVE_ANIM, MOVE_ANIM_NO_SUB:
+		MOVE_ANIM:
+			_lower_sub(turn)
 			_move_anim(turn)
+			_raise_sub(turn)
+		MOVE_ANIM_NO_SUB:
+			_move_anim(turn)
+		LOWER_SUB:
+			_lower_sub(turn)
+		RAISE_SUB:
+			_raise_sub(turn)
+		LOWER_SUB_NO_ANIM:
+			_sub_pic(turn, false)
 		STAT_UP_ANIM:
 			_stat_change_anim(turn, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
 		STAT_DOWN_ANIM:
@@ -1704,6 +1732,10 @@ static func _substitute_damage(turn: Gen2Turn) -> void:
 	if broke:
 		defender.substatus &= ~Gen2Substatus.SUBSTITUTE
 		turn.emit(Gen2Battle.SUBSTITUTE_FADED, {"target": turn.target})
+		# `SubFadedText` is followed by a `BattleCommand_LowerSubNoAnim` between
+		# two `SwitchTurn`s: the doll goes off the field the moment it breaks,
+		# rather than waiting for a `raisesub` that will now refuse.
+		turn.emit(Gen2Battle.SUBSTITUTE_PIC, {"side": turn.target, "raised": false})
 		if not SUBSTITUTE_KEEPS_EFFECT.has(turn.effect()):
 			turn.effect_override = Gen2MoveEffect.NORMAL_HIT_EFFECT
 
@@ -2275,9 +2307,11 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 			turn.critical = bool(result["critical"])
 			turn.effectiveness = int(result["effectiveness"])
 
-		# `moveanimnosub` sits inside the source loop, after `clearmissdamage`
-		# and before `applydamage`, so every hit animates and only the last one
-		# carries the damage flash.
+		# `lowersub` opens the source loop and `moveanimnosub` sits inside it,
+		# after `clearmissdamage` and before `applydamage`, so every hit drops
+		# the user's doll and animates, and only the last one carries the damage
+		# flash. The `raisesub` behind `endloop` is at the tail of this command.
+		_lower_sub(turn)
 		_multi_hit_anim(turn, hit == hits - 1)
 
 		# `applydamage` is inside the loop too, so each hit goes through the whole
@@ -2291,7 +2325,10 @@ static func _multi_hit(turn: Gen2Turn) -> void:
 			turn.end()
 			return
 
+	# `BattleCommand_EndLoop` says how many hits landed, and the `raisesub`
+	# behind `endloop` follows that line rather than leading it.
 	turn.emit(Gen2Battle.HIT_TIMES, {"target": turn.target, "times": hits})
+	_raise_sub(turn)
 
 
 const FIXED_TWO_HIT_EFFECTS: Array = [Gen2MoveEffect.DOUBLE_HIT, Gen2MoveEffect.TWINEEDLE]
@@ -2457,6 +2494,11 @@ static func _rollout_power(turn: Gen2Turn) -> void:
 	# opening SLP_MASK check leaves both the counter and damage untouched.
 	if Gen2Status.is_asleep(mon.status):
 		return
+
+	# Set ahead of the miss check and off the count before it is raised, so only
+	# the first Rollout of a chain says a rampage started here.
+	turn.someone_is_rampaging = turn.someone_is_rampaging or mon.rollout_count == 0
+
 	if turn.missed:
 		mon.substatus &= ~Gen2Substatus.ROLLOUT
 		return
@@ -2500,6 +2542,7 @@ static func _rampage(turn: Gen2Turn) -> void:
 	mon.substatus |= Gen2Substatus.RAMPAGING
 	mon.rampage_move = turn.move_number
 	mon.rampage_turns = Gen2Substatus.roll_rampage_turns(turn.rng())
+	turn.someone_is_rampaging = true
 
 
 ## Defense Curl's flag is independent of whether its Defense stage changed. It
@@ -2807,6 +2850,7 @@ static func _perish_song(turn: Gen2Turn) -> void:
 static func _substitute(turn: Gen2Turn) -> void:
 	var user: Gen2BattleMon = turn.attacker()
 	if Gen2Substatus.has(user.substatus, Gen2Substatus.SUBSTITUTE):
+		_refused_substitute_raises(turn)
 		turn.emit(Gen2Battle.SUBSTITUTE_ALREADY)
 		return
 
@@ -2815,6 +2859,7 @@ static func _substitute(turn: Gen2Turn) -> void:
 	var cost: int = Gen2Substatus.substitute_hp_for(user.max_hp())
 	user.substitute_hp = cost
 	if user.hp <= cost:
+		_refused_substitute_raises(turn)
 		turn.emit(Gen2Battle.SUBSTITUTE_TOO_WEAK)
 		return
 
@@ -2823,14 +2868,24 @@ static func _substitute(turn: Gen2Turn) -> void:
 	user.trapped_turns = 0
 	user.trapping_move = 0
 
-	# `xor a / ld [wBattleAnimParam], a` before `LoadAnim`: param 0 is the doll
-	# going up, where `lowersub` and `raisesub` pass 1 and 2.
-	turn.battle.battle_anim_param = 0
-	_animate_current_move(turn)
+	# `ld [wBattleAnimParam], a` before `LoadAnim`, and `LoadAnim` rather than
+	# `AnimateCurrentMove`: the move plays its own animation with no drop and no
+	# raise around it, and param 0 is the branch that makes the doll.
+	turn.battle.battle_anim_param = SUBSTITUTE_ANIM_MADE
+	_play_fx_anim(turn, SUBSTITUTE_MOVE, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
 	turn.emit(Gen2Battle.SUBSTITUTE_MADE, {
 		"amount": cost, "hp": user.hp, "max_hp": user.max_hp(),
 		"substitute_hp": user.substitute_hp,
 	})
+
+
+## `.already_has_sub` and `.too_weak_to_sub`, which both answer
+## `call CheckUserIsCharging / call nz, BattleCommand_RaiseSub`: a refusal puts
+## the doll back only for a user that is charging, since that is the one route
+## into this command with the doll already dropped.
+static func _refused_substitute_raises(turn: Gen2Turn) -> void:
+	if turn.locked or turn.called:
+		_raise_sub(turn)
 
 
 ## The seed [method Gen2Battle._residual_leech_seed] reads back every turn.
@@ -3442,9 +3497,11 @@ static func _beat_up(turn: Gen2Turn) -> void:
 			turn.end()
 			return
 
-	# `beatupfailtext`, which says nothing when any member landed a hit.
+	# `beatupfailtext`, which says nothing when any member landed a hit, and the
+	# `raisesub` the list puts behind it.
 	if not struck:
 		turn.emit(Gen2Battle.MOVE_FAILED)
+	_raise_sub(turn)
 
 
 ## One pass of the loop: `critical`, `beatup`'s own numbers, `damagecalc`,
@@ -3453,6 +3510,9 @@ static func _beat_up(turn: Gen2Turn) -> void:
 ## `clearmissdamage` is structural, since the one `checkhit` sits outside the loop
 ## and has already ended the move on a miss.
 static func _beat_up_hit(turn: Gen2Turn) -> void:
+	# `lowersub` is the first command of the loop body, so every member's hit
+	# drops the user's doll again.
+	_lower_sub(turn)
 	_critical(turn)
 	_damage_calc(turn)
 	_damage_variation(turn)
@@ -3638,6 +3698,59 @@ static func _move_anim(turn: Gen2Turn) -> void:
 	)
 
 
+## `BattleCommand_LowerSub`: the user's doll dropped out of the way of whatever
+## is about to be drawn, as the SUBSTITUTE animation's own `.dropsub` branch.
+##
+## Nothing is dropped for a user with no doll up, and nothing is dropped on the
+## turn a two-turn move is charging either: `CheckUserIsCharging` is what
+## [method _do_turn] reads as [member Gen2Turn.locked] or
+## [member Gen2Turn.called], and a doll already dropped by the charge turn is
+## still down.
+static func _lower_sub(turn: Gen2Turn) -> void:
+	if not Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.SUBSTITUTE):
+		return
+	if not _lower_sub_animates(turn):
+		return
+	turn.battle.battle_anim_param = SUBSTITUTE_ANIM_DROP
+	_play_fx_anim(turn, SUBSTITUTE_MOVE, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
+
+
+## The two ways past the charging check, in the source's own order: a two-turn
+## move that has not charged yet is starting its charge, so the doll comes down
+## for the charge animation, and `.Rampage` lets a Rollout or a rampage through
+## on every turn but the one it is started from by a called move.
+static func _lower_sub_animates(turn: Gen2Turn) -> bool:
+	var user: Gen2BattleMon = turn.attacker()
+	if not Gen2Substatus.has(user.substatus, Gen2Substatus.CHARGING) \
+			and turn.effect() in CHARGE_EFFECTS:
+		return true
+	# `.Rampage` answers zero when nothing started rampaging on this move, which
+	# is every continuation turn, and the turn one is started on is not a
+	# charging turn unless the move was called.
+	if turn.effect() in [Gen2MoveEffect.ROLLOUT, Gen2MoveEffect.RAMPAGE] \
+			and not turn.someone_is_rampaging:
+		return true
+	return not (turn.locked or turn.called)
+
+
+## `BattleCommand_LowerSubNoAnim` and `..._RaiseSubNoAnim`: the picture written
+## straight into the battler's tiles. Unconditional in the source, since a side
+## with no doll is drawn its own picture either way, and this project only has
+## the two pictures to choose between.
+static func _sub_pic(turn: Gen2Turn, raised: bool) -> void:
+	turn.emit(Gen2Battle.SUBSTITUTE_PIC, {"raised": raised})
+
+
+## `BattleCommand_RaiseSub`: the doll put back once whatever dropped it is over.
+## Unconditional past the flag, so a Substitute that faded during the move leaves
+## the picture the drop restored.
+static func _raise_sub(turn: Gen2Turn) -> void:
+	if not Gen2Substatus.has(turn.attacker().substatus, Gen2Substatus.SUBSTITUTE):
+		return
+	turn.battle.battle_anim_param = SUBSTITUTE_ANIM_RAISE
+	_play_fx_anim(turn, SUBSTITUTE_MOVE, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
+
+
 ## `.alternate_anim`, the branch the five multi-hit effects take instead of
 ## clearing the param: the low bit is flipped, and the damage flash is kept only
 ## for the hit `wPlayerRolloutCount`/`wEnemyRolloutCount` says is the last one,
@@ -3718,10 +3831,15 @@ static func _status_target_anim(turn: Gen2Turn, flag: int) -> int:
 ##
 ## Not a list command. Fifteen commands call it from inside their own bodies,
 ## and it is the whole animation of every move whose effect list carries no
-## animation command at all. `wBattleAnimParam` is pushed across the sub calls
-## rather than cleared, so whatever the last animation left stands.
+## animation command at all. `wBattleAnimParam` is pushed across the drop rather
+## than cleared, so whatever the last animation left stands; the raise behind it
+## is last and leaves its own 2 there.
 static func _animate_current_move(turn: Gen2Turn) -> void:
+	var param: int = turn.battle.battle_anim_param
+	_lower_sub(turn)
+	turn.battle.battle_anim_param = param
 	_play_fx_anim(turn, turn.move_number, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
+	_raise_sub(turn)
 
 
 ## `BattleCommand_HeldFlinch`: a King's Rock on the attacker makes an ordinary
@@ -3802,6 +3920,15 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 ## Minimize's move number, which is the whole of what `MinimizeDropSub` compares
 ## against and what makes a Stomp hurt twice as much.
 const MINIMIZE_MOVE: int = 107
+
+## Substitute's move number, and so the animation `lowersub`, `raisesub` and the
+## move itself all play. Which of its four branches runs is
+## [member Gen2Battle.battle_anim_param]: 0 makes the doll, 1 drops it and 2
+## raises it.
+const SUBSTITUTE_MOVE: int = 164
+const SUBSTITUTE_ANIM_MADE: int = 0
+const SUBSTITUTE_ANIM_DROP: int = 1
+const SUBSTITUTE_ANIM_RAISE: int = 2
 
 ## `StatNames`' eighth row, which exists only so `BattleCommand_Curse` has
 ## something to name when neither of the two stats it raises can move.

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -667,7 +667,9 @@ const DEFENSE_CURL_SEQUENCE: Array = [
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.DEFENSE_UP,
 	Gen2EffectCommands.CURL,
+	Gen2EffectCommands.LOWER_SUB,
 	Gen2EffectCommands.STAT_UP_ANIM,
+	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.STAT_UP_MESSAGE,
 	Gen2EffectCommands.STAT_UP_FAIL_TEXT,
 	Gen2EffectCommands.END_MOVE,
@@ -1388,6 +1390,9 @@ const FURY_CUTTER_SEQUENCE: Array = [
 const TRIPLE_KICK_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
+	# `lowersub` opens the source's loop body and its `raisesub` sits behind
+	# `endloop`, which is where both land in a list run once per kick.
+	Gen2EffectCommands.LOWER_SUB,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
@@ -1399,6 +1404,7 @@ const TRIPLE_KICK_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
 	Gen2EffectCommands.KICK_COUNTER,
+	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1607,7 +1613,9 @@ const SWAGGER_SEQUENCE: Array = [
 	Gen2EffectCommands.SWITCH_TURN,
 	Gen2EffectCommands.ATTACK_UP_2,
 	Gen2EffectCommands.SWITCH_TURN,
+	Gen2EffectCommands.LOWER_SUB,
 	Gen2EffectCommands.STAT_UP_ANIM,
+	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.SWITCH_TURN,
 	Gen2EffectCommands.STAT_UP_MESSAGE,
 	Gen2EffectCommands.SWITCH_TURN,
@@ -1656,6 +1664,10 @@ const STAT_RUN_LENGTH: int = 7
 ## list differs from its six neighbours.
 const DEFENSE_DOWN_HIT: int = STAT_DOWN_HIT_BASE + 1
 
+## `EFFECT_EVASION_UP`, the seventh of the raise run and the one list of the
+## twenty-eight whose doll commands are not where its neighbours put them.
+const EVASION_UP: int = STAT_UP_BASE + 6
+
 ## The two effect bytes a run does not reach. Metal Claw raises the user's
 ## Attack on a roll and Ancientpower raises all five of them, and neither sits
 ## in a run of its own: 139 falls where an eighth "down by one, on a hit" stat
@@ -1696,7 +1708,28 @@ static func _stat_up_sequence(command: StringName) -> Array:
 		Gen2EffectCommands.USED_MOVE_TEXT,
 		Gen2EffectCommands.DO_TURN,
 		command,
+		Gen2EffectCommands.LOWER_SUB,
 		Gen2EffectCommands.STAT_UP_ANIM,
+		Gen2EffectCommands.RAISE_SUB,
+		Gen2EffectCommands.STAT_UP_MESSAGE,
+		Gen2EffectCommands.STAT_UP_FAIL_TEXT,
+		Gen2EffectCommands.END_MOVE,
+	]
+
+
+## `EvasionUp`, the one row of the twenty-eight written differently: its
+## `lowersub` sits in front of the stat command rather than behind it, and a
+## `lowersubnoanim` takes the doll back off between the animation and the raise.
+## Minimize and Double Team are the only moves on it.
+static func _evasion_up_sequence(command: StringName) -> Array:
+	return [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.LOWER_SUB,
+		command,
+		Gen2EffectCommands.STAT_UP_ANIM,
+		Gen2EffectCommands.LOWER_SUB_NO_ANIM,
+		Gen2EffectCommands.RAISE_SUB,
 		Gen2EffectCommands.STAT_UP_MESSAGE,
 		Gen2EffectCommands.STAT_UP_FAIL_TEXT,
 		Gen2EffectCommands.END_MOVE,
@@ -1712,7 +1745,9 @@ static func _stat_down_sequence(command: StringName) -> Array:
 		Gen2EffectCommands.DO_TURN,
 		Gen2EffectCommands.CHECK_HIT,
 		command,
+		Gen2EffectCommands.LOWER_SUB,
 		Gen2EffectCommands.STAT_DOWN_ANIM,
+		Gen2EffectCommands.RAISE_SUB,
 		Gen2EffectCommands.STAT_DOWN_MESSAGE,
 		Gen2EffectCommands.STAT_DOWN_FAIL_TEXT,
 		Gen2EffectCommands.END_MOVE,
@@ -1727,7 +1762,9 @@ static func _stat_down_sequence(command: StringName) -> Array:
 static func _stat_sequences() -> Dictionary:
 	var out: Dictionary = {}
 	for offset: int in STAT_RUN_LENGTH:
-		out[STAT_UP_BASE + offset] = _stat_up_sequence(STAT_UP_COMMANDS[offset])
+		out[STAT_UP_BASE + offset] = _evasion_up_sequence(STAT_UP_COMMANDS[offset]) \
+			if STAT_UP_BASE + offset == EVASION_UP \
+			else _stat_up_sequence(STAT_UP_COMMANDS[offset])
 		out[STAT_UP_2_BASE + offset] = _stat_up_sequence(STAT_UP_2_COMMANDS[offset])
 		out[STAT_DOWN_BASE + offset] = _stat_down_sequence(STAT_DOWN_COMMANDS[offset])
 		out[STAT_DOWN_2_BASE + offset] = _stat_down_sequence(STAT_DOWN_2_COMMANDS[offset])

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -116,6 +116,12 @@ var stat_by: int = 0
 var stat_target: int = Gen2Battle.PLAYER
 var stat_moved: bool = false
 
+## `wSomeoneIsRampaging`, which `DoMove` clears before every move and only a
+## rampage or a Rollout being *started* sets. `BattleCommand_LowerSub` is the
+## one reader: a continuation turn drops the doll where a charging turn would
+## not have.
+var someone_is_rampaging: bool = false
+
 ## Set instead of moving a stat when a drop was blocked by the target's own
 ## Mist, so the fail-text step behind it can tell that apart from the ordinary
 ## "already at the bottom" failure and say the right thing.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -67,8 +67,20 @@ const PAYLOAD_SPAN: int = 2
 const BYTES_KEY: String = "bytes"
 
 ## Bumped whenever the on-disk shape changes. A cache written by an older
-## importer is discarded rather than migrated.
+## importer is discarded rather than migrated: every byte in it is derived from
+## a dump the owner still has, so re-importing costs a few seconds and a
+## migration would have to carry every past shape forever. Nothing but the cache
+## is thrown away, since saves live under their own root.
 const FORMAT_VERSION: int = 55
+
+## What [method state] answers. A stale cache is told from a missing one because
+## they need different things said to whoever is looking at it: one is a
+## cartridge that was never imported, the other one imported by an older build
+## and needing the same dump again.
+const STATE_MISSING: StringName = &"missing"
+const STATE_STALE: StringName = &"stale"
+const STATE_INCOMPLETE: StringName = &"incomplete"
+const STATE_USABLE: StringName = &"usable"
 
 
 static func directory_for(id: StringName, sha1: String) -> String:
@@ -281,11 +293,19 @@ static func prepare(directory: String) -> bool:
 
 ## True when [param directory] holds a complete cache this build can read.
 static func is_usable(directory: String) -> bool:
+	return state(directory) == STATE_USABLE
+
+
+## Why a cache cannot be read, for a caller that has to say so. An import writes
+## the manifest last and marks it complete last, so a run that was interrupted
+## leaves the directory behind and reads as incomplete rather than as stale.
+static func state(directory: String) -> StringName:
 	var manifest: Dictionary = read_manifest(directory)
 	if manifest.is_empty():
-		return false
-	return int(manifest.get("format_version", -1)) == FORMAT_VERSION \
-		and bool(manifest.get("complete", false))
+		return STATE_MISSING
+	if int(manifest.get("format_version", -1)) != FORMAT_VERSION:
+		return STATE_STALE
+	return STATE_USABLE if bool(manifest.get("complete", false)) else STATE_INCOMPLETE
 
 
 static func read_manifest(directory: String) -> Dictionary:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -268,23 +268,20 @@ func _on_update_response(
 func _open_manage_sheet(game_id: StringName) -> void:
 	if _importing:
 		return
-	var data: GameData = GameData.open(game_id)
+	var path: String = RomCache.directory_for(game_id, RomRegistry.sha1_for(game_id))
+	var state: StringName = RomCache.state(path)
 	var sheet: Gen2LauncherSheet = Gen2LauncherSheet.create(
 		_palette, RomRegistry.title_for(game_id)
 	)
 	var body: VBoxContainer = sheet.body()
-	body.add_child(Gen2LauncherUI.muted(
-		_palette,
-		"This cartridge is imported and verified." if data != null
-		else "No cache exists for this cartridge yet.",
-	))
-	var directory: Label = Gen2LauncherUI.muted(
-		_palette, RomCache.directory_for(game_id, RomRegistry.sha1_for(game_id))
-	)
+	body.add_child(Gen2LauncherUI.muted(_palette, cache_state_text(state)))
+	var directory: Label = Gen2LauncherUI.muted(_palette, path)
 	directory.add_theme_color_override("font_color", _palette.faint)
 	body.add_child(directory)
 
-	if data != null:
+	# Off the state rather than off the data: a stale or half-written cache is
+	# exactly the one worth opening or deleting, and neither can be read.
+	if state != RomCache.STATE_MISSING:
 		var open_folder: Gen2LauncherButton = Gen2LauncherButton.create(
 			_palette, "Open cache folder", Gen2LauncherButton.Variant.NEUTRAL, &"folder"
 		)
@@ -301,7 +298,7 @@ func _open_manage_sheet(game_id: StringName) -> void:
 
 	var reimport: Gen2LauncherButton = Gen2LauncherButton.create(
 		_palette,
-		"Re-import" if data != null else "Import",
+		"Re-import" if state != RomCache.STATE_MISSING else "Import",
 		Gen2LauncherButton.Variant.PRIMARY,
 		&"download",
 	)
@@ -312,6 +309,24 @@ func _open_manage_sheet(game_id: StringName) -> void:
 	)
 	sheet.add_action(reimport)
 	sheet.open(self)
+
+
+## What the manage sheet says about a cache in [param state]. Takes the state
+## rather than a cartridge so the four sentences can be asserted without a cache
+## on disk to put a build's own cartridges at risk.
+##
+## A cache is never migrated ([constant RomCache.FORMAT_VERSION]), so a build
+## that has moved on says so and asks for the dump again rather than reporting
+## the cartridge as never imported.
+static func cache_state_text(state: StringName) -> String:
+	match state:
+		RomCache.STATE_USABLE:
+			return "This cartridge is imported and verified."
+		RomCache.STATE_STALE:
+			return "This cache was written by an older build. Import the cartridge again."
+		RomCache.STATE_INCOMPLETE:
+			return "The last import did not finish. Import the cartridge again."
+	return "No cache exists for this cartridge yet."
 
 
 func _open_cache_folder(game_id: StringName) -> void:

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -180,3 +180,80 @@ func test_the_view_carries_the_tilemap_and_the_palette_maps() -> void:
 		assert_eq(value, Gen2BattleAnimBackground.PALETTE_IDENTITY)
 	assert_true(bool(view["hud_visible"]))
 	assert_eq((view["anim_sprites"] as Array).size(), 0)
+
+
+## Which picture a battler's square is showing. The synthetic cache resolves no
+## animation script, so what is driven here is the `noanim` half: the two
+## commands the battle-scene option reaches instead of the SUBSTITUTE animation,
+## and the events that write the picture outside one.
+
+func _substitute_event(param: int, enemy_turn: bool = false) -> Dictionary:
+	return _animation_event({
+		"index": Gen2EffectCommands.SUBSTITUTE_MOVE, "param": param,
+		"after_anim": Gen2BattleAnimPlayer.AFTER_ANIM_NONE, "enemy_turn": enemy_turn,
+	})
+
+
+func _view() -> Dictionary:
+	return (_screen._renderer as Gen2BattleRenderer)._view
+
+
+func test_the_doll_is_drawn_and_taken_off_with_the_battle_scene_turned_off() -> void:
+	await _open_battle()
+	var options: Gen2Options = Gen2OptionsStore.current()
+	options.battle_scene = false
+	Gen2OptionsStore.save(options)
+
+	assert_false(bool(_view()["player_substitute"]))
+	_screen._begin_animation(_substitute_event(Gen2EffectCommands.SUBSTITUTE_ANIM_MADE))
+	_settle_animation()
+	assert_true(bool(_view()["player_substitute"]), "`.no_anim` calls RaiseSubNoAnim")
+	assert_false(bool(_view()["enemy_substitute"]), "the actor's square alone")
+
+	_screen._begin_animation(_substitute_event(Gen2EffectCommands.SUBSTITUTE_ANIM_DROP))
+	_settle_animation()
+	assert_false(bool(_view()["player_substitute"]))
+
+	_screen._begin_animation(_substitute_event(Gen2EffectCommands.SUBSTITUTE_ANIM_RAISE, true))
+	_settle_animation()
+	assert_true(bool(_view()["enemy_substitute"]))
+	assert_false(bool(_view()["player_substitute"]))
+
+
+func test_a_move_animation_with_the_scene_off_leaves_the_doll_alone() -> void:
+	await _open_battle()
+	var options: Gen2Options = Gen2OptionsStore.current()
+	options.battle_scene = false
+	Gen2OptionsStore.save(options)
+
+	_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": true,
+	})
+	_screen._begin_animation(_animation_event())
+	_settle_animation()
+	assert_true(bool(_view()["player_substitute"]))
+
+
+func test_the_doll_comes_off_for_a_restored_user_picture() -> void:
+	await _open_battle()
+	# `AppearUserLowerSub`, which Fly and Dig reach: `LowerSubNoAnim` writes the
+	# user's own picture back before `AppearUser` stamps it into the map.
+	_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.ENEMY, "raised": true,
+	})
+	assert_true(bool(_view()["enemy_substitute"]))
+	_screen._begin_animation(_animation_event({"restore_user_pic": true, "enemy_turn": true}))
+	_settle_animation()
+	assert_false(bool(_view()["enemy_substitute"]))
+
+
+func test_a_send_out_draws_a_picture_rather_than_the_doll_the_last_one_had() -> void:
+	await _open_battle()
+	_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": true,
+	})
+	_screen._apply_event({
+		"type": Gen2Battle.SENT_OUT, "side": Gen2Battle.PLAYER, "species": 16,
+		"level": 5, "hp": 20, "max_hp": 20,
+	})
+	assert_false(bool(_view()["player_substitute"]))

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -490,3 +490,63 @@ func test_the_text_box_is_scrolled_with_the_rest_of_the_background() -> void:
 
 	_settle_intro()
 	assert_true(box.raster_scx.is_empty())
+
+
+## `GetSubstitutePic`: the doll is four tiles of the monster overworld sprite in
+## an otherwise empty box, at columns 2 and 3 of both boxes and one row higher in
+## the player's. What it draws from a real cache is swept by
+## `tools/checks/battle_anims.gd`; the placement is arithmetic and is pinned
+## here, against a strip whose every pixel says which tile it came from.
+func test_the_doll_takes_four_tiles_of_the_monster_sprite_into_a_blank_box() -> void:
+	var strip: PackedByteArray = PackedByteArray()
+	strip.resize(12 * Gen2Font.TILE * Gen2Font.TILE)
+	for index: int in strip.size():
+		strip[index] = 1 + (index % (12 * Gen2Font.TILE)) / Gen2Font.TILE
+
+	for player_side: bool in [false, true]:
+		var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+			else Gen2BattleScreenMap.ENEMY_SIDE
+		var box: int = side * Gen2Font.TILE
+		var pixels: PackedByteArray = Gen2BattleRenderer.substitute_pixels(strip, player_side)
+		assert_eq(pixels.size(), box * box)
+
+		# The down-facing frame for the enemy's front picture, the up-facing one
+		# for the player's back picture, laid out in reading order.
+		var first: int = int(Gen2BattleRenderer.SUBSTITUTE_FIRST_TILE[player_side])
+		var at: Vector2i = Gen2BattleRenderer.SUBSTITUTE_AT[player_side]
+		var lit: int = 0
+		for y: int in box:
+			for x: int in box:
+				var value: int = int(pixels[y * box + x])
+				var cell: Vector2i = Vector2i(x, y) / Gen2Font.TILE - at
+				if cell.x < 0 or cell.x > 1 or cell.y < 0 or cell.y > 1:
+					assert_eq(value, 0, "outside the doll at %d,%d" % [x, y])
+					continue
+				lit += 1
+				assert_eq(value, 1 + first + cell.y * 2 + cell.x, "tile at %d,%d" % [x, y])
+		assert_eq(lit, 16 * 16)
+
+
+func test_the_doll_is_what_a_substituted_side_draws() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+	var renderer: Gen2BattleRenderer = _battle_screen._renderer
+	var own: PackedByteArray = renderer._player_pixels.duplicate()
+
+	_battle_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": true,
+	})
+	assert_ne(renderer._player_pixels, own, "the doll replaced the picture")
+	assert_eq(
+		renderer._player_pixels,
+		Gen2BattleRenderer.substitute_pixels(
+			_data.overworld_sprite_indices(Gen2BattleRenderer.SUBSTITUTE_SPRITE), true
+		)
+	)
+	assert_eq(renderer._enemy_pixels_key[1], false, "and only that side's")
+
+	_battle_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": false,
+	})
+	assert_eq(renderer._player_pixels, own)

--- a/tests/unit/test_battle_animation_commands.gd
+++ b/tests/unit/test_battle_animation_commands.gd
@@ -361,3 +361,108 @@ func test_every_status_animation_is_past_the_move_ids() -> void:
 	]:
 		assert_gt(index, 0xFF)
 		assert_lt(index, RomLayout.BATTLE_ANIM_SCRIPT_COUNT)
+
+
+## The substitute's doll, which is the sixth route: `lowersub` and `raisesub`
+## play the SUBSTITUTE animation on their own parameters, and the two `noanim`
+## commands write the picture with no animation at all.
+
+func _with_substitute(battle: Gen2Battle, side: int = Gen2Battle.PLAYER) -> Gen2Battle:
+	var mon: Gen2BattleMon = battle.mon(side)
+	mon.substatus |= Gen2Substatus.SUBSTITUTE
+	mon.substitute_hp = Gen2Substatus.substitute_hp_for(mon.max_hp())
+	return battle
+
+
+func _params(animations: Array) -> Array:
+	var out: Array = []
+	for animation: Dictionary in animations:
+		out.append([int(animation["index"]), int(animation["param"])])
+	return out
+
+
+func test_a_move_by_a_substituted_pokemon_drops_the_doll_and_puts_it_back() -> void:
+	var battle: Gen2Battle = _with_substitute(_battle([Fixture.TACKLE]))
+	var animations: Array = _animations(_run_move(battle, Fixture.TACKLE))
+	assert_eq(_params(animations), [
+		[Gen2EffectCommands.SUBSTITUTE_MOVE, Gen2EffectCommands.SUBSTITUTE_ANIM_DROP],
+		[Fixture.TACKLE, 0],
+		[Gen2EffectCommands.SUBSTITUTE_MOVE, Gen2EffectCommands.SUBSTITUTE_ANIM_RAISE],
+	])
+	# Both play on the user, whose doll it is.
+	for animation: Dictionary in animations:
+		assert_false(bool(animation["enemy_turn"]))
+
+
+func test_a_user_with_no_doll_plays_neither() -> void:
+	var animations: Array = _animations(_run_move(_battle([Fixture.TACKLE]), Fixture.TACKLE))
+	assert_eq(animations.size(), 1)
+
+
+func test_a_stat_move_carries_the_pair_around_its_own_animation() -> void:
+	var battle: Gen2Battle = _with_substitute(_battle([Fixture.SWORDS_DANCE]))
+	# `BattleCommand_StatUpDownAnim` clears the param the drop just wrote.
+	assert_eq(_params(_animations(_run_move(battle, Fixture.SWORDS_DANCE))), [
+		[Gen2EffectCommands.SUBSTITUTE_MOVE, Gen2EffectCommands.SUBSTITUTE_ANIM_DROP],
+		[Fixture.SWORDS_DANCE, 0],
+		[Gen2EffectCommands.SUBSTITUTE_MOVE, Gen2EffectCommands.SUBSTITUTE_ANIM_RAISE],
+	])
+
+
+func test_substitute_itself_plays_one_animation_and_no_pair() -> void:
+	# `BattleCommand_Substitute` calls `LoadAnim` rather than
+	# `AnimateCurrentMove`, so nothing drops a doll that is only now being made.
+	var animations: Array = _animations(
+		_run_move(_battle([Fixture.SUBSTITUTE]), Fixture.SUBSTITUTE)
+	)
+	assert_eq(_params(animations), [
+		[Gen2EffectCommands.SUBSTITUTE_MOVE, Gen2EffectCommands.SUBSTITUTE_ANIM_MADE],
+	])
+
+
+func test_a_charging_turn_drops_the_doll_and_the_release_turn_does_not() -> void:
+	# `CheckUserIsCharging` is what [member Gen2Turn.locked] answers, and the
+	# doll a charge turn dropped is still down when the move lands.
+	var battle: Gen2Battle = _with_substitute(_battle([Fixture.TACKLE]))
+	for locked: bool in [false, true]:
+		var events: Array = []
+		var turn: Gen2Turn = Gen2Turn.create(
+			battle, Gen2Battle.PLAYER, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), events
+		)
+		turn.locked = locked
+		Gen2EffectCommands.run(Gen2EffectCommands.LOWER_SUB, turn)
+		assert_eq(_animations(events).size(), 0 if locked else 1)
+
+
+func test_a_broken_doll_is_taken_off_the_field_at_once() -> void:
+	var battle: Gen2Battle = _with_substitute(
+		_battle([Fixture.TACKLE], [Fixture.TACKLE]), Gen2Battle.ENEMY
+	)
+	battle.enemy.substitute_hp = 1
+	var events: Array = _run_move(battle, Fixture.TACKLE)
+	var faded: int = _index_of(events, Gen2Battle.SUBSTITUTE_FADED)
+	var picture: int = _index_of(events, Gen2Battle.SUBSTITUTE_PIC)
+	assert_gt(faded, -1)
+	assert_eq(picture, faded + 1, "SubFadedText is followed by lowersubnoanim")
+	assert_eq(int(events[picture]["side"]), Gen2Battle.ENEMY)
+	assert_false(bool(events[picture]["raised"]))
+	# The doll is gone, so the `raisesub` behind the animation refuses.
+	var animations: Array = _animations(events)
+	assert_eq(int(animations[-1]["index"]), Fixture.TACKLE)
+
+
+func test_minimize_takes_the_doll_off_between_the_animation_and_the_raise() -> void:
+	# `EvasionUp` is the one stat list written differently: `lowersubnoanim`
+	# sits between `statupanim` and `raisesub`.
+	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.EVASION_UP)
+	assert_eq(
+		sequence.slice(sequence.find(Gen2EffectCommands.STAT_UP_ANIM)),
+		[
+			Gen2EffectCommands.STAT_UP_ANIM,
+			Gen2EffectCommands.LOWER_SUB_NO_ANIM,
+			Gen2EffectCommands.RAISE_SUB,
+			Gen2EffectCommands.STAT_UP_MESSAGE,
+			Gen2EffectCommands.STAT_UP_FAIL_TEXT,
+			Gen2EffectCommands.END_MOVE,
+		]
+	)

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -242,3 +242,24 @@ func _find_toast(node: Node) -> Gen2LauncherToast:
 		if found != null:
 			return found
 	return null
+
+
+## There is no cache migration by design, so the one thing the launcher owes a
+## player whose cache a build has outgrown is a sentence saying which of the
+## four states it is in and that the dump is wanted again.
+func test_every_cache_state_says_something_different() -> void:
+	var main := preload("res://game/main/main.gd")
+	var said: Dictionary = {}
+	for state: StringName in [
+		RomCache.STATE_USABLE, RomCache.STATE_STALE,
+		RomCache.STATE_INCOMPLETE, RomCache.STATE_MISSING,
+	]:
+		var text: String = main.cache_state_text(state)
+		assert_false(text.is_empty(), "%s says nothing" % state)
+		assert_false(said.has(text), "%s repeats another state's line" % state)
+		said[text] = true
+	for state: StringName in [RomCache.STATE_STALE, RomCache.STATE_INCOMPLETE]:
+		assert_true(
+			main.cache_state_text(state).contains("Import the cartridge again"),
+			"%s asks for the dump" % state
+		)

--- a/tests/unit/test_rom_cache.gd
+++ b/tests/unit/test_rom_cache.gd
@@ -98,6 +98,10 @@ func test_reading_missing_index_data_yields_an_empty_buffer() -> void:
 func test_a_cache_without_a_manifest_is_not_usable() -> void:
 	RomCache.prepare(_directory)
 	assert_false(RomCache.is_usable(_directory))
+	# A directory with nothing readable in it is the same as no directory: both
+	# want the cartridge imported, and neither has anything to migrate.
+	assert_eq(RomCache.state(_directory), RomCache.STATE_MISSING)
+	assert_eq(RomCache.state("%s/absent" % _directory), RomCache.STATE_MISSING)
 
 
 func test_an_incomplete_cache_is_not_usable() -> void:
@@ -107,6 +111,7 @@ func test_an_incomplete_cache_is_not_usable() -> void:
 		"format_version": RomCache.FORMAT_VERSION, "complete": false,
 	})
 	assert_false(RomCache.is_usable(_directory))
+	assert_eq(RomCache.state(_directory), RomCache.STATE_INCOMPLETE)
 
 
 func test_a_cache_from_another_format_version_is_not_usable() -> void:
@@ -115,6 +120,9 @@ func test_a_cache_from_another_format_version_is_not_usable() -> void:
 		"format_version": RomCache.FORMAT_VERSION - 1, "complete": true,
 	})
 	assert_false(RomCache.is_usable(_directory))
+	# Told apart from a missing cache because there is no migration: what this
+	# needs said is that the dump is wanted again, not that it was never here.
+	assert_eq(RomCache.state(_directory), RomCache.STATE_STALE)
 
 
 func test_a_complete_current_cache_is_usable() -> void:
@@ -123,6 +131,7 @@ func test_a_complete_current_cache_is_usable() -> void:
 		"format_version": RomCache.FORMAT_VERSION, "complete": true,
 	})
 	assert_true(RomCache.is_usable(_directory))
+	assert_eq(RomCache.state(_directory), RomCache.STATE_USABLE)
 
 
 func test_clear_removes_subdirectories_too() -> void:

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -113,8 +113,54 @@ func run(r: RefCounted) -> void:
 		_verify_objects(game_id, data)
 		_verify_palettes(game_id, data)
 		_verify_gfx(game_id, data)
+		_verify_substitute_pic(game_id, data)
 		_run_every_animation(game_id, data)
 		_play_every_animation(game_id, data)
+
+
+## `GetSubstitutePic`, on both sides and all three cartridges: the doll is four
+## tiles of `MonsterSpriteGFX` in an otherwise empty box, at the one place the
+## routine copies them to. Nothing else in the box may carry ink, since the
+## routine zeroes it first and the battler's own picture is gone while it is up.
+func _verify_substitute_pic(game_id: StringName, data: GameData) -> void:
+	var strip: PackedByteArray = data.overworld_sprite_indices(
+		Gen2BattleRenderer.SUBSTITUTE_SPRITE
+	)
+	if not _r.check(
+		not strip.is_empty(),
+		"%s: no monster overworld sprite in the cache, so no doll." % game_id
+	):
+		return
+	for player_side: bool in [false, true]:
+		var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+			else Gen2BattleScreenMap.ENEMY_SIDE
+		var box: int = side * Gen2Font.TILE
+		var pixels: PackedByteArray = Gen2BattleRenderer.substitute_pixels(strip, player_side)
+		if not _r.check(
+			pixels.size() == box * box,
+			"%s: the doll's box is %d pixels, not %d." % [game_id, pixels.size(), box * box]
+		):
+			continue
+		var at: Vector2i = Gen2BattleRenderer.SUBSTITUTE_AT[player_side]
+		var doll := Rect2i(at * Gen2Font.TILE, Vector2i(16, 16))
+		var inside: int = 0
+		var outside: int = 0
+		for y: int in box:
+			for x: int in box:
+				if pixels[y * box + x] == 0:
+					continue
+				if doll.has_point(Vector2i(x, y)):
+					inside += 1
+				else:
+					outside += 1
+		_r.check(inside > 0, "%s: the doll drew nothing." % game_id)
+		_r.check(
+			outside == 0,
+			"%s: %d lit pixels outside the doll's own 16 by 16." % [game_id, outside]
+		)
+		print("%s: the %s doll is %d lit pixels at %s of a %dx%d box." % [
+			game_id, "player's" if player_side else "enemy's", inside, at, side, side,
+		])
 
 
 ## Every animation played through [Gen2BattleAnimPlayer], which is the script


### PR DESCRIPTION
## The battle doll

A Pokemon behind a Substitute is drawn as the doll. `GetSubstitutePic` builds a
battler's picture out of four tiles of the monster overworld sprite, in the
battler's own palette, since nothing writes one for it.

Which picture a square is holding belongs to the screen, the way it belongs to
VRAM on the cartridge: the animation's `anim_raisesub` and `anim_dropsub` write
it, the two `noanim` commands write it with the battle-scene option off, a
send-out draws a fresh one, `AppearUserLowerSub` puts the real picture back
after Fly and Dig, and a doll that breaks comes off where `SubFadedText` takes
it off.

`lowersub` and `raisesub` are effect commands of their own with that, since 35
lists carry them around an animation, and `BattleCommand_MoveAnim` and
`AnimateCurrentMove` are both all three. `wSomeoneIsRampaging` comes with them:
it is what lets a Rollout or a rampage continuation drop the doll where a
charging turn does not. Substitute itself now reaches `LoadAnim` rather than
`AnimateCurrentMove`, which is what the source calls, and its two refusals raise
the doll for a charging user.

## The cache format

A cache is never migrated: a format bump discards it and the same dump is
imported again. That was the decision; saying it was missing. `RomCache.state()`
tells a stale cache from a missing, half-written or usable one, the manage sheet
prints the sentence each deserves, and the folder and delete buttons are offered
for any cache that exists rather than only one this build can read.

`Gen2AudioPlayer._exit_tree` also takes the stream off its player, which is what
releases an `AudioStreamGeneratorPlayback`.

## Checks

| Check | Before | After |
|---|---|---|
| GUT, both tiers | 2,868 green | 2,882 green |
| `validate.gd -- all` | 45 topics pass | 45 topics pass, the doll swept on both sides of all three cartridges |
| `replay_world.gd` | 27 routes, 0 failures | 27 routes, 0 failures |
| Story walk, three profiles | 291 / 291 / 294 steps, 16 badges | 291 / 291 / 294 steps, 16 badges |
| Boot smoke | clean | clean |