### PR TITLE
Fly, Dig, Teleport, Sweet Scent, Softboiled and Milk Drink

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -88,6 +88,7 @@ var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
 var _world_phone: Dictionary = {}
 var _world_fruit_trees: Array = []
+var _world_spawns: Dictionary = {}
 var _world_audio: Dictionary = {}
 var _battle_anims_section: Dictionary = {}
 ## Which of the sections above have been read. A section that is genuinely empty
@@ -235,6 +236,49 @@ func world_fruit_tree_item(tree_id: int) -> int:
 	if tree_id < 1 or tree_id > rows.size():
 		return 0
 	return int(rows[tree_id - 1])
+
+
+## `SpawnPoints` row [param index]: `{ map_group, map_number, x, y }`, and empty
+## for an index no spawn carries. This is where a Fly, a Dig, a Teleport and a
+## blackout each put the player down.
+func spawn_point(index: int) -> Dictionary:
+	var rows: Variant = _spawns().get("spawns", [])
+	if not rows is Array or index < 0 or index >= (rows as Array).size():
+		return {}
+	var row: Variant = (rows as Array)[index]
+	if not row is Dictionary:
+		return {}
+	return {
+		"map_group": int((row as Dictionary).get("map_group", 0)),
+		"map_number": int((row as Dictionary).get("map_number", 0)),
+		"x": int((row as Dictionary).get("x", 0)),
+		"y": int((row as Dictionary).get("y", 0)),
+	}
+
+
+func spawn_point_count() -> int:
+	var rows: Variant = _spawns().get("spawns", [])
+	return (rows as Array).size() if rows is Array else 0
+
+
+## `Flypoints` row [param index]: `{ landmark, spawn }`. The index is a `FLY_*`
+## constant, which is what the fly map's cursor walks, not a landmark.
+func flypoint(index: int) -> Dictionary:
+	var rows: Variant = _spawns().get("flypoints", [])
+	if not rows is Array or index < 0 or index >= (rows as Array).size():
+		return {}
+	var row: Variant = (rows as Array)[index]
+	if not row is Dictionary:
+		return {}
+	return {
+		"landmark": int((row as Dictionary).get("landmark", 0)),
+		"spawn": int((row as Dictionary).get("spawn", 0)),
+	}
+
+
+func flypoint_count() -> int:
+	var rows: Variant = _spawns().get("flypoints", [])
+	return (rows as Array).size() if rows is Array else 0
 
 
 ## One imported priced or special mart list. The source keeps these lists apart
@@ -1877,6 +1921,12 @@ func _fruit_trees() -> Array:
 			RomCache.world_fruit_trees_path(directory), true
 		)
 	return _world_fruit_trees
+
+
+func _spawns() -> Dictionary:
+	if _claim_section("spawns"):
+		_world_spawns = _read_section(RomCache.world_spawns_path(directory), false)
+	return _world_spawns
 
 
 func _phone() -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -54,6 +54,9 @@ const WORLD_MARTS: String = "world_marts.json"
 const WORLD_PHONE: String = "world_phone.json"
 const WORLD_AUDIO: String = "world_audio.json"
 const WORLD_FRUIT_TREES: String = "world_fruit_trees.json"
+## `SpawnPoints` and `Flypoints` together: one file, because the fly map, the
+## two escape moves and a blackout all read both.
+const WORLD_SPAWNS: String = "world_spawns.json"
 const BATTLE_ANIMS: String = "battle_anims.json"
 const BATTLE_ANIM_GFX_DIR: String = "battle_anim_gfx"
 
@@ -71,7 +74,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 55
+const FORMAT_VERSION: int = 56
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a
@@ -226,6 +229,10 @@ static func world_audio_path(directory: String) -> String:
 
 static func world_fruit_trees_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_FRUIT_TREES]
+
+
+static func world_spawns_path(directory: String) -> String:
+	return "%s/%s" % [directory, WORLD_SPAWNS]
 
 
 ## The battle animation scripts and the four tables their objects are built

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -185,6 +185,45 @@ const FRUIT_TREE_COUNT: int = 30
 ## content, since it has no header and no terminator.
 const FRUIT_TREE_APRICORNS: Array[int] = [0x55, 0x59, 0x5C, 0x5D, 0x61, 0x63, 0x65]
 const FRUIT_TREE_FIRST_APRICORN: int = 16
+
+## `SpawnPoints` (`data/maps/spawn_points.asm`): `db group, number, x, y` per
+## `SPAWN_*` constant, then one row of `$FF` bytes. `NUM_SPAWNS` is 28 and both
+## pins ship the same rows, coordinates included; only the map numbers move,
+## since a group's numbering shifts with the maps pokegold does not have.
+const SPAWN_RECORD_SIZE: int = 4
+const SPAWN_COUNT: int = 28
+const SPAWN_TERMINATOR: int = 0xFF
+
+## The spawn coordinates, in table order, which is what identifies the table:
+## every entry's x and y at a stride of four is a run no other bytes in a dump
+## match. `SPAWN_HOME` is the bedroom, `SPAWN_DEBUG` the Viridian Pokecenter,
+## then Kanto and then Johto.
+const SPAWN_COORDINATES: Array[int] = [
+	3, 3, 5, 3,
+	5, 6, 23, 26, 13, 26, 19, 22, 11, 2, 9, 6, 5, 6, 9, 30, 29, 10, 19, 28, 11, 12, 9, 6,
+	13, 6, 29, 4, 31, 26, 11, 74, 15, 10, 23, 44, 15, 28, 13, 22, 23, 28, 15, 14,
+	21, 29, 21, 30, 23, 20, 6, 2,
+]
+
+## `SPAWN_*` indexes worth naming. `SPAWN_HOME` is where a new game's respawn
+## point starts and `SPAWN_INDIGO` is the one `FlyMap` tests before it will draw
+## Kanto at all.
+const SPAWN_HOME: int = 0
+const SPAWN_INDIGO: int = 13
+
+## `Flypoints` (`data/maps/flypoints.asm`): `db landmark, spawn` per `FLY_*`
+## constant, then `-1`. The twelve Johto rows come first and `KANTO_FLYPOINT` is
+## where Kanto starts, which is the whole of how `FlyMap` picks the region's
+## range. The spawn column is identical between the pins; the landmark column is
+## not, since Gold and Silver ship one landmark fewer.
+const FLYPOINT_RECORD_SIZE: int = 2
+const FLYPOINT_COUNT: int = 24
+const FLYPOINT_TERMINATOR: int = 0xFF
+const KANTO_FLYPOINT: int = 12
+const FLYPOINT_SPAWNS: Array[int] = [
+	14, 15, 16, 18, 20, 22, 21, 19, 23, 24, 25, 26,
+	2, 3, 4, 5, 7, 6, 8, 10, 9, 11, 12, 13,
+]
 const PHONE_CONTACT_COUNT: int = 38
 const PHONE_CONTACT_SIZE: int = 12
 const SPECIAL_PHONE_CALL_COUNT: int = 8
@@ -1606,6 +1645,12 @@ const GOLD_SILVER: Dictionary = {
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
 	"fruit_trees": 0x44091,
+	## `SpawnPoints` and `Flypoints`, each located by the byte column that is the
+	## same on all three dumps: the spawn coordinates at a stride of four, and
+	## the flypoints' spawn column at a stride of two ahead of its `-1`. Both hit
+	## once per dump.
+	"spawn_points": 0x15319,
+	"flypoints": 0x91BCC,
 	"rooftop_mart_count": 0,
 	"rooftop_mart_1": 0,
 	"rooftop_mart_2": 0,
@@ -1929,6 +1974,8 @@ const CRYSTAL: Dictionary = {
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,
 	"fruit_trees": 0x44097,
+	"spawn_points": 0x152AB,
+	"flypoints": 0x91C5E,
 	"rooftop_mart_count": 2,
 	"rooftop_mart_1": 0x15AEE,
 	"rooftop_mart_2": 0x15AFF,

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -46,6 +46,8 @@ static func import_to_cache(
 		RomCache.world_fruit_trees_path(directory), result["fruit_trees"]
 	):
 		return _error("Could not write world fruit tree data.")
+	if not RomCache.write_json(RomCache.world_spawns_path(directory), result["spawns"]):
+		return _error("Could not write world spawn data.")
 	if not RomCache.write_section(
 		RomCache.world_audio_path(directory),
 		RomCache.blob_path(RomCache.world_audio_path(directory)),
@@ -80,6 +82,8 @@ static func import_to_cache(
 		"cries": (result["audio"].get("cries", []) as Array).size(),
 		"mon_cries": (result["audio"].get("mon_cries", []) as Array).size(),
 		"fruit_trees": (result["fruit_trees"] as Array).size(),
+		"spawns": ((result["spawns"] as Dictionary)["spawns"] as Array).size(),
+		"flypoints": ((result["spawns"] as Dictionary)["flypoints"] as Array).size(),
 	}
 
 
@@ -103,6 +107,9 @@ static func read_services(
 	var fruit_trees: Dictionary = read_fruit_trees(rom, layout)
 	if not bool(fruit_trees.get("ok", false)):
 		return fruit_trees
+	var spawns: Dictionary = read_spawns(rom, layout)
+	if not bool(spawns.get("ok", false)):
+		return spawns
 	var menus: Dictionary = _read_menus(rom, scripts, standard_scripts)
 	if not bool(menus.get("ok", false)):
 		return menus
@@ -116,6 +123,7 @@ static func read_services(
 		"phone": phone["data"],
 		"audio": audio["data"],
 		"fruit_trees": fruit_trees["items"],
+		"spawns": spawns["data"],
 		"phone_scripts": phone_scripts,
 	}
 
@@ -206,6 +214,50 @@ static func read_fruit_trees(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if items.slice(0, 4).any(func(item: Variant) -> bool: return int(item) != int(items[0])):
 		return _error("The first four fruit trees do not share one berry.")
 	return {"ok": true, "items": items}
+
+
+## `SpawnPoints` and `Flypoints`, the two tables every escape from a map reads:
+## a spawn is `db group, number, x, y` and a flypoint is `db landmark, spawn`.
+##
+## Each identifies itself by the column that is the same on all three dumps, the
+## spawn coordinates and the flypoint spawn indexes, and each is checked to its
+## own terminator, so a shifted table fails rather than decoding its neighbour.
+static func read_spawns(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var spawn_offset: int = int(layout.get("spawn_points", 0))
+	var span: int = (RomLayout.SPAWN_COUNT + 1) * RomLayout.SPAWN_RECORD_SIZE
+	if spawn_offset <= 0 or not rom.in_bounds(spawn_offset, span):
+		return _error("Spawn point table is outside the cartridge.")
+	var spawns: Array = []
+	for index: int in RomLayout.SPAWN_COUNT:
+		var at: int = spawn_offset + index * RomLayout.SPAWN_RECORD_SIZE
+		var x: int = rom.u8(at + 2)
+		var y: int = rom.u8(at + 3)
+		if x != int(RomLayout.SPAWN_COORDINATES[index * 2]) \
+				or y != int(RomLayout.SPAWN_COORDINATES[index * 2 + 1]):
+			return _error("Spawn %d is not at the coordinates the table pins." % index)
+		spawns.append({
+			"map_group": rom.u8(at), "map_number": rom.u8(at + 1), "x": x, "y": y,
+		})
+	for byte: int in RomLayout.SPAWN_RECORD_SIZE:
+		if rom.u8(spawn_offset + RomLayout.SPAWN_COUNT * RomLayout.SPAWN_RECORD_SIZE + byte) \
+				!= RomLayout.SPAWN_TERMINATOR:
+			return _error("The spawn point table does not end where it should.")
+
+	var fly_offset: int = int(layout.get("flypoints", 0))
+	var fly_span: int = RomLayout.FLYPOINT_COUNT * RomLayout.FLYPOINT_RECORD_SIZE + 1
+	if fly_offset <= 0 or not rom.in_bounds(fly_offset, fly_span):
+		return _error("Flypoint table is outside the cartridge.")
+	var flypoints: Array = []
+	for index: int in RomLayout.FLYPOINT_COUNT:
+		var at: int = fly_offset + index * RomLayout.FLYPOINT_RECORD_SIZE
+		var spawn: int = rom.u8(at + 1)
+		if spawn != int(RomLayout.FLYPOINT_SPAWNS[index]):
+			return _error("Flypoint %d does not name the spawn the table pins." % index)
+		flypoints.append({"landmark": rom.u8(at), "spawn": spawn})
+	if rom.u8(fly_offset + RomLayout.FLYPOINT_COUNT * RomLayout.FLYPOINT_RECORD_SIZE) \
+			!= RomLayout.FLYPOINT_TERMINATOR:
+		return _error("The flypoint table does not end where it should.")
+	return {"ok": true, "data": {"spawns": spawns, "flypoints": flypoints}}
 
 
 static func _read_mart_list(rom: RomFile, bank: int, address: int, _priced: bool) -> Dictionary:

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -17,6 +17,12 @@ const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#2d4566")
 const TEXT: Color = Color("#f4f7fb")
 const MUTED: Color = Color("#9eacc0")
+
+## The two `MonMenuOptions` rows that open a second party list rather than
+## leaving the menu: `MonMenu_Softboiled_MilkDrink` serves both.
+const HEAL_TRANSFER_MOVES: Array[int] = [
+	Gen2WorldFieldMove.MOVE_SOFTBOILED, Gen2WorldFieldMove.MOVE_MILK_DRINK,
+]
 const ACCENT: Color = Color("#f3c969")
 const SUCCESS: Color = Color("#7bd89a")
 const ERROR: Color = Color("#ef8a8a")
@@ -55,6 +61,10 @@ var _submenu_open: bool = false
 ## Whether the rows on screen are ITEM's GIVE/TAKE box rather than the mon's own
 ## submenu, which is what B goes back to.
 var _item_menu_open: bool = false
+## `.SelectMilkDrinkRecipient`: which party member is giving its health away, and
+## which of the two moves asked. -1 and 0 when no recipient list is open.
+var _heal_user: int = -1
+var _heal_move: int = 0
 
 
 func _ready() -> void:
@@ -198,6 +208,9 @@ func _move_cursor(delta: int) -> void:
 
 
 func _confirm() -> void:
+	if _heal_user >= 0:
+		_choose_heal_target()
+		return
 	if not _submenu_open:
 		_open_submenu()
 		return
@@ -213,9 +226,13 @@ func _confirm() -> void:
 		return
 	match StringName(entry.get("kind", &"")):
 		&"field_move":
+			var move: int = int(entry.get("move", 0))
+			if move in HEAL_TRANSFER_MOVES:
+				_open_heal_target(move)
+				return
 			action_chosen.emit({
 				"kind": &"field_move",
-				"move": int(entry.get("move", 0)),
+				"move": move,
 				"slot": _member_cursor,
 				"name": _display_name(_save.party[_member_cursor]),
 			})
@@ -232,6 +249,13 @@ func _confirm() -> void:
 
 
 func _cancel() -> void:
+	## `.SelectMilkDrinkRecipient`'s own `.set_carry`: a B press over the
+	## recipient list gives up on the move and leaves the party menu standing.
+	if _heal_user >= 0:
+		_heal_user = -1
+		_heal_move = 0
+		_open_submenu()
+		return
 	## `GiveTakePartyMonItem`'s own `VerticalMenu` carry is `.cancel`, which
 	## returns to the submenu it opened over rather than closing the party menu.
 	if _item_menu_open:
@@ -241,6 +265,54 @@ func _cancel() -> void:
 		_close_submenu()
 		return
 	close_embedded()
+
+
+## `MonMenu_Softboiled_MilkDrink`'s own gate and then
+## `.SelectMilkDrinkRecipient`: a user with a fifth of its health or less says so
+## and stays on the submenu, and anything else opens the recipient list, which is
+## the party list again with the submenu closed.
+func _open_heal_target(move: int) -> void:
+	var user: Gen2SaveMon = _save.party[_member_cursor]
+	var fifth: int = Gen2WorldPartyHost.one_fifth_max_hp(_data, user)
+	if fifth <= 0 or user.hp <= fifth:
+		## `_PokemonNotEnoughHPText`.
+		_status.text = "Not enough HP…"
+		_status.add_theme_color_override("font_color", MUTED)
+		return
+	_heal_user = _member_cursor
+	_heal_move = move
+	_submenu_open = false
+	_item_menu_open = false
+	_submenu_items = []
+	_refresh()
+
+
+## One press over the recipient list. The three refusals stay on the list the way
+## `.cant_use` loops back to it; anything else is the caller's to apply, since
+## the health it moves belongs to a save the world owns.
+func _choose_heal_target() -> void:
+	if _member_cursor == _heal_user:
+		_status.text = "It won't have any effect."
+		_status.add_theme_color_override("font_color", MUTED)
+		return
+	var target: Gen2SaveMon = _save.party[_member_cursor]
+	var target_max: int = Gen2SaveBattleAdapter.to_battle_mon(_data, target).max_hp() \
+		if not target.is_egg else 0
+	if target.is_egg or target.hp <= 0 or target.hp >= target_max:
+		_status.text = "It won't have any effect."
+		_status.add_theme_color_override("font_color", MUTED)
+		return
+	var action: Dictionary = {
+		"kind": &"heal_transfer",
+		"move": _heal_move,
+		"slot": _heal_user,
+		"target_slot": _member_cursor,
+		"name": _display_name(_save.party[_heal_user]),
+		"target_name": _display_name(target),
+	}
+	_heal_user = -1
+	_heal_move = 0
+	action_chosen.emit(action)
 
 
 func _open_item_menu() -> void:

--- a/game/world/town_map.gd
+++ b/game/world/town_map.gd
@@ -30,6 +30,15 @@ const REGION_NAMES: Array[String] = ["johto", "kanto"]
 const SCREEN_TOWN_MAP: StringName = &"town_map"
 const SCREEN_POKEGEAR_CARD: StringName = &"pokegear_card"
 const SCREEN_DEX_AREA: StringName = &"dex_area"
+## `_FlyMap`, which is the same two maps with the cursor walking flypoints
+## instead of landmarks: `wTownMapPlayerIconLandmark` holds a `FLY_*` index there
+## rather than a landmark, and the up and down presses skip every flypoint the
+## player has not visited.
+const SCREEN_FLY: StringName = &"fly"
+
+## `FLY_INDIGO`, the last flypoint and Kanto's own default. It is also the one
+## `FlyMap` tests before it will draw Kanto at all.
+const FLY_INDIGO: int = RomLayout.FLYPOINT_COUNT - 1
 
 var crystal: bool = true
 var screen: StringName = SCREEN_TOWN_MAP
@@ -42,8 +51,44 @@ var cursor: int = JOHTO_LANDMARK
 ## `STATUSFLAGS_HALL_OF_FAME_F`, which the dex area reads on every right press
 ## rather than once.
 var hall_of_fame: bool = false
+## Which `FLY_*` indexes the player has visited, for the fly map's own walk.
+## Empty on every other screen, which reads none of it.
+var visited_flypoints: Array[int] = []
 var _first: int = JOHTO_LANDMARK
 var _last: int = JOHTO_LANDMARK
+
+
+## `FlyMap`: the fly map opened on whichever region the player is in, with the
+## cursor on that region's default flypoint.
+##
+## [param visited] is which `FLY_*` indexes `CheckIfVisitedFlypoint` answers for,
+## which is the `wVisitedSpawns` bit of each one's own spawn. Kanto is only drawn
+## once Indigo Plateau is among them: `.NoKanto` falls back to Johto's map
+## instead, which is what stops the source's own crash on a region with no
+## flypoint enabled.
+##
+## The default flypoint is on the map whether or not it has been visited, which
+## is the source's own quirk and is why New Bark can always be flown to.
+static func fly(
+	landmark: int, in_kanto: bool, visited: Array[int], is_crystal: bool
+) -> Gen2TownMap:
+	var out := Gen2TownMap.new()
+	out.crystal = is_crystal
+	out.screen = SCREEN_FLY
+	out.visited_flypoints = visited.duplicate()
+	# `.MapHud` hands `TownMapPlayerIcon` the landmark it popped, so the player
+	# icon still says where the player is standing while the cursor walks
+	# flypoints.
+	out.player_landmark = landmark
+	if in_kanto and visited.has(FLY_INDIGO):
+		out._first = RomLayout.KANTO_FLYPOINT
+		out._last = RomLayout.FLYPOINT_COUNT - 1
+		out.cursor = FLY_INDIGO
+	else:
+		out._first = 0
+		out._last = RomLayout.KANTO_FLYPOINT - 1
+		out.cursor = 0
+	return out
 
 
 ## `TownMap_GetCurrentLandmark` has already run: [param landmark] is the resolved
@@ -95,6 +140,10 @@ func _shift(landmark: int) -> int:
 func region() -> int:
 	if screen == SCREEN_DEX_AREA:
 		return cursor
+	# `FlyMap` fills one region's map and walks that region's flypoints, and
+	# `.NoKanto` is what puts a player standing in Kanto on Johto's.
+	if screen == SCREEN_FLY:
+		return REGION_KANTO if _first == RomLayout.KANTO_FLYPOINT else REGION_JOHTO
 	if screen == SCREEN_POKEGEAR_CARD \
 		and player_landmark == Gen2WorldRadio.fast_ship_landmark(crystal):
 		return REGION_JOHTO
@@ -148,8 +197,32 @@ func press(button: int) -> bool:
 	match button:
 		Gen2Button.UP:
 			cursor = _first if cursor >= _last else cursor + 1
+			_skip_unvisited(1)
 			return true
 		Gen2Button.DOWN:
 			cursor = _last if cursor == _first else cursor - 1
+			_skip_unvisited(-1)
 			return true
 	return false
+
+
+## `.ScrollNext` and `.ScrollPrev`'s own loop: a press keeps stepping while the
+## flypoint it lands on has not been visited, wrapping the way one press does.
+## The window is at most twelve wide and the default is always on it, so the walk
+## cannot run forever.
+func _skip_unvisited(step: int) -> void:
+	if screen != SCREEN_FLY:
+		return
+	for _guard: int in RomLayout.FLYPOINT_COUNT:
+		if visited_flypoints.has(cursor) or cursor == _default_flypoint():
+			return
+		if step > 0:
+			cursor = _first if cursor >= _last else cursor + 1
+		else:
+			cursor = _last if cursor == _first else cursor - 1
+
+
+## Which flypoint the map opened on, and so the one the source leaves reachable
+## whether or not it has been visited.
+func _default_flypoint() -> int:
+	return FLY_INDIGO if _first == RomLayout.KANTO_FLYPOINT else 0

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -74,6 +74,9 @@ var _open: bool = false
 var _field: Control = null
 var _background: TextureRect = null
 var _cursor_icon: TextureRect = null
+## `.pressedA`'s own answer, which `_FlyMap` returns in `e`: the chosen spawn, or
+## -1 for the `ld a, -1` a B press leaves.
+var _chosen_spawn: int = -1
 var _player_icon: TextureRect = null
 ## The dex area's own state: the species its header names, one landmark list per
 ## region and what the shadow OAM holds this frame.
@@ -159,12 +162,54 @@ func open_dex_area(
 	)
 
 
+## `_FlyMap`: the region map with the cursor walking the flypoints the player has
+## visited. [param in_kanto] is which map `FlyMap` opens, which is the region the
+## player is standing in, and [param visited] which `FLY_*` indexes
+## `CheckIfVisitedFlypoint` answers for.
+##
+## The answer is taken with [method chosen_spawn] once this closes: -1 for a
+## cancel, and the flypoint's own spawn for a choice, which is exactly the byte
+## `.pressedA` leaves in `e`.
+func open_fly(
+	data: GameData,
+	landmark: int,
+	in_kanto: bool,
+	visited: Array[int],
+	female: bool = false,
+	time_of_day: int = Gen2WorldPalette.TIME_MORNING,
+) -> bool:
+	_chosen_spawn = -1
+	if not open(
+		data, landmark, false, Gen2TownMap.SCREEN_FLY, [], female, time_of_day
+	):
+		return false
+	_map = Gen2TownMap.fly(
+		landmark, in_kanto, visited, Gen2WorldState.is_crystal_profile(_data)
+	)
+	if is_inside_tree() and _background != null:
+		_refresh()
+	return true
+
+
+## Which spawn the fly map was left on: -1 until one is chosen, and -1 for good
+## when B closed it.
+func chosen_spawn() -> int:
+	return _chosen_spawn
+
+
 func map() -> Gen2TownMap:
 	return _map
 
 
+## Where the cursor is drawn. The fly map's own cursor is a flypoint rather than
+## a landmark, and `Flypoints` is what turns one into the other.
 func cursor_landmark() -> int:
-	return _map.cursor if _map != null else 0
+	if _map == null:
+		return 0
+	if _map.screen != Gen2TownMap.SCREEN_FLY:
+		return _map.cursor
+	var row: Dictionary = _data.flypoint(_map.cursor) if _data != null else {}
+	return int(row.get("landmark", 0))
 
 
 func cursor_name() -> String:
@@ -179,6 +224,12 @@ func cursor_name() -> String:
 func handle_button(button: int) -> bool:
 	if not _open or _map == null:
 		return false
+	if button == Gen2Button.A and _map.screen == Gen2TownMap.SCREEN_FLY:
+		# `.pressedA` reads the flypoint's own spawn out of `Flypoints + 1`.
+		var row: Dictionary = _data.flypoint(_map.cursor) if _data != null else {}
+		_chosen_spawn = int(row.get("spawn", -1)) if not row.is_empty() else -1
+		close()
+		return true
 	if button == Gen2Button.B \
 		or (button == Gen2Button.A and _map.screen == Gen2TownMap.SCREEN_DEX_AREA):
 		close()
@@ -252,7 +303,7 @@ func render() -> Image:
 	if _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
 		return _render_dex_area(out)
 	for object: Array in [
-		[_cursor_image(), _map.cursor], [_player_image(), _map.player_landmark],
+		[_cursor_image(), cursor_landmark()], [_player_image(), _map.player_landmark],
 	]:
 		if not _has_landmark(int(object[1])):
 			continue
@@ -382,7 +433,7 @@ func _background_image() -> Image:
 ## and `.String_SNest` for the dex area.
 func _header_codes() -> PackedByteArray:
 	if _map.screen != Gen2TownMap.SCREEN_DEX_AREA:
-		return _data.landmark(_map.cursor).get("codes", PackedByteArray())
+		return _data.landmark(cursor_landmark()).get("codes", PackedByteArray())
 	var name: String = String(_data.species(_species).get("name", ""))
 	var out: PackedByteArray = Gen2Text.encode(name)
 	out.append_array(Gen2Text.encode(NEST_HEADER_SUFFIX))
@@ -394,7 +445,7 @@ func _header_codes() -> PackedByteArray:
 func _refresh_cursor() -> void:
 	if _cursor_icon == null or _map == null:
 		return
-	_place(_cursor_icon, _map.cursor)
+	_place(_cursor_icon, cursor_landmark())
 	_cursor_icon.texture = ImageTexture.create_from_image(_cursor_image())
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4970,6 +4970,52 @@ func warp_to_spawn(index: int) -> Dictionary:
 	}
 
 
+## `FlyFunction`'s `.TryFly`: the badge and the map, which is everything it can
+## refuse on before the region map is drawn. The choice itself belongs to
+## whoever draws that map; [method warp_to_spawn] is what answers it.
+func fly_request() -> Dictionary:
+	if current_map == null:
+		return _fly_failure(&"missing_map")
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_FLY) < 0:
+		return _fly_failure(&"move_not_known")
+	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_STORM, Gen2WorldState.is_crystal_profile(data)
+	)):
+		return _fly_failure(&"badge_required")
+	if not _is_outdoor(current_map.environment):
+		return _fly_failure(&"indoors")
+	return {
+		"ok": true,
+		"kind": &"fly_requested",
+		"move": Gen2WorldFieldMove.MOVE_FLY,
+		"in_kanto": Gen2WorldRadio.is_kanto_landmark(
+			landmark(), Gen2WorldState.is_crystal_profile(data)
+		),
+		"visited": visited_flypoints(),
+	}
+
+
+static func _fly_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"fly_failed", "reason": reason}
+
+
+## `CheckIfVisitedFlypoint` over the whole table: which `FLY_*` indexes the
+## player may fly to. The bit tested is `wVisitedSpawns` at the flypoint's own
+## spawn, which is what this project keeps as the `ENGINE_FLYPOINT_*` run.
+func visited_flypoints() -> Array[int]:
+	var out: Array[int] = []
+	if data == null:
+		return out
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	for index: int in data.flypoint_count():
+		var spawn: int = int(data.flypoint(index).get("spawn", -1))
+		if spawn < 0:
+			continue
+		if state.is_engine_flag_active(Gen2WorldState.flypoint_flag(spawn, crystal)):
+			out.append(index)
+	return out
+
+
 ## `SweetScentEncounter`, the whole of what the party submenu's SWEET SCENT row
 ## does: a wild appears where one could have been stepped into.
 ##

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4970,6 +4970,36 @@ func warp_to_spawn(index: int) -> Dictionary:
 	}
 
 
+## `SweetScentEncounter`, the whole of what the party submenu's SWEET SCENT row
+## does: a wild appears where one could have been stepped into.
+##
+## Its own gates, in the source's order: `CanEncounterWildMon` for the tile,
+## then the Bug Contest's own tables, then the map's rate and
+## `ChooseWildEncounter`. The rate is read but never rolled against, which is
+## what makes the move worth using; the five-step cooldown a map entry sets is
+## not consulted either, since nothing here is a step.
+func sweet_scent_request(random: RandomNumberGenerator = null) -> Dictionary:
+	if current_map == null or data == null:
+		return _sweet_scent_failure(&"missing_map")
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_SWEET_SCENT) < 0:
+		return _sweet_scent_failure(&"move_not_known")
+	if not can_encounter_wild_mon():
+		return _sweet_scent_failure(&"no_encounter")
+	var encounter: Dictionary = encounter_request(random, true)
+	if encounter.is_empty():
+		return _sweet_scent_failure(&"no_encounter")
+	return {
+		"ok": true,
+		"kind": &"sweet_scent_requested",
+		"move": Gen2WorldFieldMove.MOVE_SWEET_SCENT,
+		"encounter": encounter,
+	}
+
+
+static func _sweet_scent_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"sweet_scent_failed", "reason": reason}
+
+
 ## `TeleportFunction`: the outdoor-only escape to wherever the last Pokemon
 ## Center was. Its whole test is the map being outdoors and the last spawn map
 ## being a spawn point, and it checks no badge at all.

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -119,6 +119,15 @@ var movement_mode: StringName = MOVEMENT_WALK
 ## that state a renderer reads. movement_mode carries the rest; the two surfing
 ## states differ from each other here and nowhere else.
 var player_sprite_number: int = Gen2WorldSprite.SPRITE_PLAYER
+## `wLastSpawnMapGroup`/`wLastSpawnMapNumber`: the outdoor map the player last
+## walked into a Pokemon Center from, which is what a blackout and a Teleport
+## both turn back into a spawn. `(-1, -1)` is a game that has entered none, and
+## `GetWhiteoutSpawn`'s own answer for that is `SPAWN_HOME`.
+var last_spawn_map: Vector2i = Vector2i(-1, -1)
+## `wDigWarpNumber`, `wDigMapGroup` and `wDigMapNumber`: the warp and outdoor map
+## the player last came into a cave through, which is where Dig and an Escape
+## Rope put them back. Empty until one is walked.
+var dig_warp: Dictionary = {}
 var _script_queue: Array = []
 var _active_script: Gen2WorldScriptRunner = null
 var _map_entry_scene_pending: bool = false
@@ -297,6 +306,8 @@ static func open_snapshot(game_data: GameData, world_snapshot: Gen2WorldSnapshot
 	out.dst_enabled = world_snapshot.dst_enabled
 	out.random_seed = world_snapshot.random_seed
 	out.frame_number = world_snapshot.frame_number
+	out.last_spawn_map = world_snapshot.last_spawn_map
+	out.dig_warp = world_snapshot.dig_warp.duplicate()
 	return out
 
 
@@ -1460,8 +1471,27 @@ static func _strength_failure(reason: StringName) -> Dictionary:
 ## Environments a wild encounter is rolled on any tile of. `CAVE` and `DUNGEON`
 ## jump straight to the ice test, which is what puts encounters on a cave floor
 ## rather than only on its grass.
+const ENVIRONMENT_TOWN: int = 1
+const ENVIRONMENT_ROUTE: int = 2
+const ENVIRONMENT_INDOOR: int = 3
 const ENVIRONMENT_CAVE: int = 4
+const ENVIRONMENT_GATE: int = 6
 const ENVIRONMENT_DUNGEON: int = 7
+
+## `TILESET_POKECENTER` and `TILESET_POKECOM_CENTER`, the two `.SetSpawn`
+## respawns in. The second is Crystal's alone and its number is past the split,
+## so no profile of Gold or Silver has a map wearing it.
+const TILESET_POKECENTER: int = 0x07
+const TILESET_POKECENTER_GOLD_SILVER: int = 0x06
+const TILESET_POKECOM_CENTER: int = 0x15
+
+## `.SaveDigWarp`'s two refusals by name: Mount Moon Square and the Tin Tower
+## roof, outdoor maps reached from indoor ones, which Dig and an Escape Rope must
+## not put the player back on. Both sit in `GROUP_FAST_SHIP` at the same numbers
+## in both pins, since that group's rows do not move.
+const OUTDOOR_MAPS_INSIDE_INDOOR_ONES: Array[Vector2i] = [
+	Vector2i(15, 10), Vector2i(15, 12),
+]
 
 
 ## Whether `ENGINE_BUG_CONTEST_TIMER` is set, which is the one thing that says a
@@ -3885,7 +3915,13 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	var target_warp: Dictionary = (target_warps[destination_index] as Dictionary).duplicate(true)
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = cell
-	_apply_map(target_map, target_tileset, Vector2i(int(target_warp["x"]), int(target_warp["y"])))
+	# `wPrevWarp` is the warp walked through, which is what a Dig or an Escape
+	# Rope comes back out of.
+	_apply_map(
+		target_map, target_tileset,
+		Vector2i(int(target_warp["x"]), int(target_warp["y"])), false,
+		warp_index_at(cell)
+	)
 	return {
 		"ok": true,
 		"kind": &"warp",
@@ -4783,7 +4819,9 @@ func _apply_map(
 	target_tileset: Gen2WorldTileset,
 	target_cell: Vector2i,
 	custom_facing: bool = false,
+	from_warp: int = 0,
 ) -> void:
+	_record_escape_points(target_map, from_warp)
 	_block_overrides.clear()
 	_pending_cut.clear()
 	_pending_surf.clear()
@@ -4840,6 +4878,193 @@ func _apply_map(
 	_queue_map_callbacks(-1)
 	_map_entry_scene_pending = true
 	_map_entry_scene_ran = false
+
+
+## `.SaveDigWarp` and `.SetSpawn`, both of which run on a map change and both of
+## which only ever fire on the way from an outdoor map into an indoor one.
+##
+## The dig warp is the warp the player came through, so it is only recorded on
+## the path that used one; a scripted `warp` names a destination rather than a
+## warp number and leaves the last walked one standing, which is what the
+## cartridge's own `wPrevWarp` does. Mount Moon Square and the Tin Tower roof are
+## outdoor maps reached from indoor ones and are refused by name.
+func _record_escape_points(target_map: Gen2WorldMap, from_warp: int) -> void:
+	if current_map == null or not _is_outdoor(current_map.environment) \
+			or not _is_indoor(target_map.environment):
+		return
+	var from_map: Vector2i = map_id()
+	# One-based, as `warp_index_at` counts and as a `warp_event` destination is:
+	# zero is a map change that walked through no warp at all.
+	if from_warp > 0 and not OUTDOOR_MAPS_INSIDE_INDOOR_ONES.has(from_map):
+		dig_warp = {
+			"warp": from_warp, "map_group": from_map.x, "map_number": from_map.y,
+		}
+	var tileset: int = target_map.tileset
+	if tileset == pokecenter_tileset() or tileset == TILESET_POKECOM_CENTER:
+		last_spawn_map = from_map
+
+
+## `CheckOutdoorMap` and `CheckIndoorMap` (`home/map.asm`), which are what both
+## of the recorders above are gated on.
+static func _is_outdoor(environment: int) -> bool:
+	return environment in [ENVIRONMENT_TOWN, ENVIRONMENT_ROUTE]
+
+
+static func _is_indoor(environment: int) -> bool:
+	return environment in [
+		ENVIRONMENT_INDOOR, ENVIRONMENT_CAVE, ENVIRONMENT_DUNGEON, ENVIRONMENT_GATE,
+	]
+
+
+## `TILESET_POKECENTER`, which is one lower on Gold and Silver: pokegold ships no
+## `TILESET_BATTLE_TOWER_OUTSIDE`, so every tileset past it sits one down.
+func pokecenter_tileset() -> int:
+	return TILESET_POKECENTER if Gen2WorldState.is_crystal_profile(data) \
+		else TILESET_POKECENTER_GOLD_SILVER
+
+
+## `IsSpawnPoint`: which spawn a map is, or -1 for a map that is none.
+func spawn_index_of(map: Vector2i) -> int:
+	if data == null:
+		return -1
+	for index: int in data.spawn_point_count():
+		var point: Dictionary = data.spawn_point(index)
+		if int(point["map_group"]) == map.x and int(point["map_number"]) == map.y:
+			return index
+	return -1
+
+
+## `GetWhiteoutSpawn`: the spawn a blackout puts the player at. The last Pokemon
+## Center's own outdoor map when that map is a spawn point, and `SPAWN_HOME`
+## when it is not or when none has been entered.
+func whiteout_spawn() -> int:
+	var index: int = spawn_index_of(last_spawn_map)
+	return index if index >= 0 else RomLayout.SPAWN_HOME
+
+
+## `EnterMapSpawnPoint` plus the map load behind it: the player put down at
+## spawn [param index], facing the way a warp leaves them. Answers the same
+## record a warp does, or a refusal when the cache holds no such spawn.
+func warp_to_spawn(index: int) -> Dictionary:
+	var point: Dictionary = data.spawn_point(index) if data != null else {}
+	if point.is_empty():
+		return {"ok": false, "kind": &"spawn_warp", "reason": &"missing_spawn"}
+	var target_map: Gen2WorldMap = data.world_map(
+		int(point["map_group"]), int(point["map_number"])
+	)
+	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
+		if target_map != null else null
+	if target_map == null or target_tileset == null:
+		return {"ok": false, "kind": &"spawn_warp", "reason": &"missing_map"}
+	var from_map: Vector2i = map_id()
+	var from_cell: Vector2i = player_cell
+	_apply_map(target_map, target_tileset, Vector2i(int(point["x"]), int(point["y"])))
+	return {
+		"ok": true,
+		"kind": &"spawn_warp",
+		"spawn": index,
+		"from_map": from_map,
+		"from_cell": from_cell,
+		"to_map": map_id(),
+		"to_cell": player_cell,
+	}
+
+
+## `TeleportFunction`: the outdoor-only escape to wherever the last Pokemon
+## Center was. Its whole test is the map being outdoors and the last spawn map
+## being a spawn point, and it checks no badge at all.
+##
+## The warp is applied here rather than staged, because `.TeleportScript` is the
+## source's own script and everything in it but `WarpToSpawnPoint` is animation
+## this project has no frames for.
+func teleport_request() -> Dictionary:
+	if current_map == null:
+		return _teleport_failure(&"missing_map")
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_TELEPORT) < 0:
+		return _teleport_failure(&"move_not_known")
+	if not _is_outdoor(current_map.environment):
+		return _teleport_failure(&"not_outdoors")
+	var spawn: int = spawn_index_of(last_spawn_map)
+	if spawn < 0:
+		return _teleport_failure(&"no_spawn_point")
+	var warped: Dictionary = warp_to_spawn(spawn)
+	if not bool(warped.get("ok", false)):
+		return _teleport_failure(StringName(warped.get("reason", &"missing_spawn")))
+	return {
+		"ok": true,
+		"kind": &"teleport_requested",
+		"move": Gen2WorldFieldMove.MOVE_TELEPORT,
+		"warp": warped,
+	}
+
+
+static func _teleport_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"teleport_failed", "reason": reason}
+
+
+## `DigFunction`, which is `EscapeRopeOrDig` with the Dig half of its type byte:
+## a cave or a dungeon, and a recorded dig warp, and out through the warp the
+## player came in by.
+##
+## The source keeps three separate bytes and refuses when any is zero, which is
+## the same test as this project's record being empty.
+func dig_request() -> Dictionary:
+	if current_map == null:
+		return _dig_failure(&"missing_map")
+	if party_slot_with_move(Gen2WorldFieldMove.MOVE_DIG) < 0:
+		return _dig_failure(&"move_not_known")
+	if current_map.environment not in [ENVIRONMENT_CAVE, ENVIRONMENT_DUNGEON]:
+		return _dig_failure(&"not_in_a_cave")
+	if dig_warp.is_empty():
+		return _dig_failure(&"no_dig_warp")
+	var warped: Dictionary = warp_to_dig_point()
+	if not bool(warped.get("ok", false)):
+		return _dig_failure(StringName(warped.get("reason", &"no_dig_warp")))
+	return {
+		"ok": true,
+		"kind": &"dig_requested",
+		"move": Gen2WorldFieldMove.MOVE_DIG,
+		"warp": warped,
+	}
+
+
+static func _dig_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"dig_failed", "reason": reason}
+
+
+## `.DoDig`: the recorded dig warp copied into `wNextWarp` and walked out of, so
+## the player lands on the outdoor map's own warp tile. Shared by Dig and by an
+## Escape Rope, which is the same routine with a different type byte.
+func warp_to_dig_point() -> Dictionary:
+	if dig_warp.is_empty():
+		return {"ok": false, "kind": &"dig_warp", "reason": &"no_dig_warp"}
+	var target_map: Gen2WorldMap = data.world_map(
+		int(dig_warp["map_group"]), int(dig_warp["map_number"])
+	) if data != null else null
+	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
+		if target_map != null else null
+	if target_map == null or target_tileset == null:
+		return {"ok": false, "kind": &"dig_warp", "reason": &"missing_map"}
+	var warps: Array = target_map.events.get("warps", [])
+	var index: int = int(dig_warp["warp"]) - 1
+	if index < 0 or index >= warps.size():
+		return {"ok": false, "kind": &"dig_warp", "reason": &"missing_destination"}
+	var destination: Dictionary = warps[index]
+	var from_map: Vector2i = map_id()
+	var from_cell: Vector2i = player_cell
+	_apply_map(
+		target_map, target_tileset,
+		Vector2i(int(destination["x"]), int(destination["y"]))
+	)
+	return {
+		"ok": true,
+		"kind": &"dig_warp",
+		"warp": int(dig_warp["warp"]),
+		"from_map": from_map,
+		"from_cell": from_cell,
+		"to_map": map_id(),
+		"to_cell": player_cell,
+	}
 
 
 ## The schedule update produced by the most recent map change, for a host that

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -31,6 +31,10 @@ const MOVE_TELEPORT: int = 0x64
 ## The row that is neither a tile nor an escape: SWEET SCENT calls a wild
 ## encounter up out of the map the player is standing on.
 const MOVE_SWEET_SCENT: int = 0xE6
+## The two rows that move health between party members rather than touching the
+## map at all. `MonMenu_Softboiled_MilkDrink` is one routine for both.
+const MOVE_SOFTBOILED: int = 0x87
+const MOVE_MILK_DRINK: int = 0xD0
 
 ## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
 ## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
@@ -72,7 +76,7 @@ const MUSIC_SURF: int = 0x21
 const FIELD_MOVES: Array[int] = [
 	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
 	MOVE_HEADBUTT, MOVE_ROCK_SMASH, MOVE_DIG, MOVE_TELEPORT, MOVE_SWEET_SCENT,
-	MOVE_FLY,
+	MOVE_FLY, MOVE_SOFTBOILED, MOVE_MILK_DRINK,
 ]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -22,6 +22,12 @@ const MOVE_WATERFALL: int = 0x7F
 const MOVE_FLASH: int = 0x94
 const MOVE_HEADBUTT: int = 0x1D
 const MOVE_ROCK_SMASH: int = 0xF9
+## The rows whose own routine is an escape rather than a tile: Fly picks a spawn
+## off the region map, Teleport takes the last Pokemon Center's and Dig the warp
+## the player came into the cave through.
+const MOVE_FLY: int = 0x13
+const MOVE_DIG: int = 0x5B
+const MOVE_TELEPORT: int = 0x64
 
 ## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
 ## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
@@ -60,7 +66,7 @@ const MUSIC_SURF: int = 0x21
 ## the moment it leaves it.
 const FIELD_MOVES: Array[int] = [
 	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
-	MOVE_HEADBUTT, MOVE_ROCK_SMASH,
+	MOVE_HEADBUTT, MOVE_ROCK_SMASH, MOVE_DIG, MOVE_TELEPORT,
 ]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -46,6 +46,8 @@ const BADGE_HIVE: int = 1
 const BADGE_PLAIN: int = 2
 const BADGE_FOG: int = 3
 const BADGE_GLACIER: int = 6
+## `.TryFly`'s own `CheckBadge ENGINE_STORMBADGE`, the sixth badge.
+const BADGE_STORM: int = 5
 ## WaterfallFunction's .TryWaterfall, whose CheckBadge argument is
 ## ENGINE_RISINGBADGE: 34 in Crystal and 33 in Gold/Silver.
 const BADGE_RISING: int = 7
@@ -70,6 +72,7 @@ const MUSIC_SURF: int = 0x21
 const FIELD_MOVES: Array[int] = [
 	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
 	MOVE_HEADBUTT, MOVE_ROCK_SMASH, MOVE_DIG, MOVE_TELEPORT, MOVE_SWEET_SCENT,
+	MOVE_FLY,
 ]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -28,6 +28,9 @@ const MOVE_ROCK_SMASH: int = 0xF9
 const MOVE_FLY: int = 0x13
 const MOVE_DIG: int = 0x5B
 const MOVE_TELEPORT: int = 0x64
+## The row that is neither a tile nor an escape: SWEET SCENT calls a wild
+## encounter up out of the map the player is standing on.
+const MOVE_SWEET_SCENT: int = 0xE6
 
 ## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
 ## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
@@ -66,7 +69,7 @@ const MUSIC_SURF: int = 0x21
 ## the moment it leaves it.
 const FIELD_MOVES: Array[int] = [
 	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
-	MOVE_HEADBUTT, MOVE_ROCK_SMASH, MOVE_DIG, MOVE_TELEPORT,
+	MOVE_HEADBUTT, MOVE_ROCK_SMASH, MOVE_DIG, MOVE_TELEPORT, MOVE_SWEET_SCENT,
 ]
 
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -172,6 +172,79 @@ static func heal_party(
 	}
 
 
+## `Softboiled_MilkDrinkFunction`: a fifth of the user's own maximum health moved
+## from the user to another party member, as one candidate transaction.
+##
+## Both halves are the *user's* fifth. `GetOneFifthMaxHP` is called twice with
+## `wCurPartyMon` still holding the user, and only then is the recipient written
+## into it, so a big Pokemon heals a small one by a big number.
+##
+## The refusals are `.SelectMilkDrinkRecipient`'s own, in its order: the user
+## itself, a fainted recipient and one already at full health. The caller checks
+## the user's own health first, which is the `.CheckMonHasEnoughHP` this shares
+## with the party menu's line.
+static func transfer_health(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	from_index: int,
+	to_index: int,
+	persist: bool = true,
+) -> Dictionary:
+	if world == null or save == null or world.data == null:
+		return _failure(&"missing_save", {})
+	if from_index == to_index:
+		return _failure(&"same_member", {"party_index": to_index})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	var candidate: Gen2SaveData = opened["candidate"]
+	var user: Gen2SaveMon = _party_member(candidate, from_index)
+	var target: Gen2SaveMon = _party_member(candidate, to_index)
+	if user == null or target == null:
+		return _failure(&"unknown_party_member", {"party_index": to_index})
+	var amount: int = one_fifth_max_hp(world.data, user)
+	if amount <= 0 or user.hp <= amount:
+		return _failure(&"not_enough_health", {"party_index": from_index})
+	if target.is_egg or target.hp <= 0:
+		return _failure(&"fainted_member", {"party_index": to_index})
+	var target_max: int = _max_hp(world.data, target)
+	if target.hp >= target_max:
+		return _failure(&"already_full", {"party_index": to_index})
+
+	user.hp -= amount
+	var restored: int = mini(amount, target_max - target.hp)
+	target.hp += restored
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	return {
+		"ok": true,
+		"amount": amount,
+		"restored": restored,
+		"from": from_index,
+		"to": to_index,
+	}
+
+
+## `GetOneFifthMaxHP`, and so also `.CheckMonHasEnoughHP`'s own divisor: a
+## Pokemon may use Softboiled or Milk Drink only while it has more than this.
+static func one_fifth_max_hp(data: GameData, mon: Gen2SaveMon) -> int:
+	if data == null or mon == null or mon.is_egg:
+		return 0
+	@warning_ignore("integer_division")
+	return _max_hp(data, mon) / 5
+
+
+## A party member by index, or null when the slot is empty.
+static func _party_member(save: Gen2SaveData, index: int) -> Gen2SaveMon:
+	if save == null or index < 0 or index >= save.party.size():
+		return null
+	return save.party[index]
+
+
 ## Applies a field item to a save and the live world as one candidate transaction.
 ## The current slice covers source party item effects, including EvoStoneEffect's
 ## candidate evolution and the HP delta applied by EvolvePokemon.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2281,6 +2281,23 @@ func _on_party_action(action: Dictionary) -> void:
 				)
 				return
 			_show_field_move_text("%s used ROCK SMASH!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_DIG:
+			var dig: Dictionary = _world.dig_request()
+			if not bool(dig.get("ok", false)):
+				## `.CantUseDigText`, which every refusal of an escape shares.
+				_show_field_move_text("Can't use that here.")
+				return
+			_show_field_move_text("%s used DIG!" % String(action.get("name", "")))
+			_refresh_after_escape()
+		Gen2WorldFieldMove.MOVE_TELEPORT:
+			var teleport: Dictionary = _world.teleport_request()
+			if not bool(teleport.get("ok", false)):
+				_show_field_move_text("Can't use that here.")
+				return
+			## `_TeleportReturnText`, which names no Pokemon: the move says where
+			## it is going rather than who used it.
+			_show_field_move_text("Return to the last\n#MON CENTER.")
+			_refresh_after_escape()
 		_:
 			_show_field_move_text("Can't use that here.")
 
@@ -2764,6 +2781,21 @@ func _show_script_results(results: Array) -> void:
 			_play_current_map_music()
 		else:
 			_renderer.refresh()
+	_refresh_labels()
+
+
+## What a map change owes the screen once the world has already applied it: the
+## renderer, the animation and the music all belong to the map that is now under
+## the player. A warp reached through a script goes through the script result
+## instead; an escape move has no script here to carry it.
+func _refresh_after_escape() -> void:
+	if _world == null:
+		return
+	_animation.configure(_world, time_of_day)
+	if _renderer != null:
+		_renderer.set_world(_world, _animation)
+		_renderer.set_time_of_day(_render_time_of_day())
+	_play_current_map_music()
 	_refresh_labels()
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2281,6 +2281,21 @@ func _on_party_action(action: Dictionary) -> void:
 				)
 				return
 			_show_field_move_text("%s used ROCK SMASH!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_SWEET_SCENT:
+			var scent: Dictionary = _world.sweet_scent_request(_encounter_random)
+			if not bool(scent.get("ok", false)):
+				## `SweetScentNothing`, which is the one refusal the script has:
+				## a tile no wild could be stepped into on says the same thing a
+				## map with no table does.
+				_show_field_move_text("Looks like there's\nnothing here…")
+				return
+			_show_field_move_text("%s used SWEET SCENT!" % String(action.get("name", "")))
+			var found: Dictionary = scent["encounter"]
+			_start_battle_request({
+				"kind": &"battle_requested",
+				"values": found["values"],
+				"encounter": found.duplicate(true),
+			})
 		Gen2WorldFieldMove.MOVE_DIG:
 			var dig: Dictionary = _world.dig_request()
 			if not bool(dig.get("ok", false)):

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2281,6 +2281,15 @@ func _on_party_action(action: Dictionary) -> void:
 				)
 				return
 			_show_field_move_text("%s used ROCK SMASH!" % String(action.get("name", "")))
+		Gen2WorldFieldMove.MOVE_FLY:
+			var fly: Dictionary = _world.fly_request()
+			if not bool(fly.get("ok", false)):
+				## `.nostormbadge` says the badge line and `.indoors`
+				## `FieldMoveFailed`; neither is a text this project imports, so
+				## both get the refusal every field move shares.
+				_show_field_move_text("Can't use that here.")
+				return
+			_open_fly_map(fly)
 		Gen2WorldFieldMove.MOVE_SWEET_SCENT:
 			var scent: Dictionary = _world.sweet_scent_request(_encounter_random)
 			if not bool(scent.get("ok", false)):
@@ -2611,11 +2620,57 @@ func _open_service_overlay(kind: StringName) -> void:
 	_refresh_labels()
 
 
+## `_FlyMap` as its own overlay, and the warp its answer asks for. A cancel
+## leaves the player where they were, which is what `.illegal` does with the
+## `-1` a B press writes.
+func _open_fly_map(request: Dictionary) -> void:
+	if _service_host != null or _world == null or _data == null:
+		return
+	var host: Gen2WorldServiceScreen = SERVICE_SCENE.instantiate() as Gen2WorldServiceScreen
+	if host == null:
+		_script_prompt = "Region map scene unavailable"
+		_refresh_labels()
+		return
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	add_child(host)
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	if not host.open_fly_map(_world, _data, save, request):
+		host.queue_free()
+		_script_prompt = "Region map unavailable"
+		_refresh_labels()
+		return
+	host.completed.connect(_on_service_completed)
+	_service_host = host
+	_script_prompt = "Fly: choose a town"
+	_refresh_labels()
+
+
+## The fly map's own answer, which is not a script result: a spawn to warp to, or
+## -1 for a cancel.
+func _apply_fly_choice(results: Array) -> bool:
+	for result: Dictionary in results:
+		if StringName(result.get("kind", &"")) != &"fly_chosen":
+			continue
+		var spawn: int = int(result.get("spawn", -1))
+		if spawn < 0:
+			_refresh_labels()
+			return true
+		var warped: Dictionary = _world.warp_to_spawn(spawn)
+		if bool(warped.get("ok", false)):
+			_refresh_after_escape()
+		return true
+	return false
+
+
 func _on_service_completed(results: Array) -> void:
 	var host: Gen2WorldServiceScreen = _service_host
 	_service_host = null
 	if host != null:
 		host.queue_free()
+	if _apply_fly_choice(results):
+		return
 	# The radio card writes wMapMusic, so what plays after the Pokegear closes is
 	# whichever station was left tuned, or the map's own track when none was.
 	_play_current_map_music()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2216,6 +2216,9 @@ func _on_party_action(action: Dictionary) -> void:
 	if StringName(action.get("kind", &"")) == &"mon_item":
 		_run_mon_item_action(action)
 		return
+	if StringName(action.get("kind", &"")) == &"heal_transfer":
+		_run_heal_transfer(action)
+		return
 	if StringName(action.get("kind", &"")) != &"field_move":
 		_refresh_labels()
 		return
@@ -2437,6 +2440,21 @@ func _run_mon_item_action(action: Dictionary) -> void:
 					name, String(result.get("reason", "")),
 				]
 			)
+
+
+## `Softboiled_MilkDrinkFunction`'s two halves, once the party menu has picked
+## who is giving and who is receiving. The health moves through the world's own
+## transaction, since the party it changes is a save the world owns.
+func _run_heal_transfer(action: Dictionary) -> void:
+	var result: Dictionary = Gen2WorldPartyHost.transfer_health(
+		_world, _embedded_party_save(), int(action.get("slot", -1)),
+		int(action.get("target_slot", -1)), _injected_save == null
+	)
+	if not bool(result.get("ok", false)):
+		_show_field_move_text("It won't have any effect.")
+		return
+	## `PARTYMENUTEXT_HEAL_HP`, which is the line every healing item shares.
+	_show_field_move_text("%s\nrecovered health!" % String(action.get("target_name", "")))
 
 
 func _show_field_move_text(text: String) -> void:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -56,6 +56,9 @@ var _apricorns: Gen2WorldApricorn = null
 var _phone_entries: Array = []
 var _pokegear_cards: Array = []
 var _town_map: Gen2TownMapScreen = null
+## Whether the region map on screen is the fly map, which answers a spawn rather
+## than closing back into the card list.
+var _fly_map: bool = false
 var _town_map_from_request: bool = false
 ## `PokemonCenterPC` and the item PC behind it: which rows are on offer, which
 ## of the three item lists is open, and the box screen when BILL'S PC is.
@@ -677,6 +680,47 @@ func _time_of_day_label(hour24: int) -> String:
 	return "DAY"
 
 
+## `_FlyMap` opened as an overlay of its own: the region map with the flypoint
+## cursor, and nothing of the Pokegear around it.
+##
+## The chosen spawn is reported through [signal completed] as
+## `{ "kind": &"fly_chosen", "spawn": index }`, and a cancel reports -1, which is
+## the `ld a, -1` `.pressedB` leaves.
+func open_fly_map(
+	world: Gen2WorldAPI, data: GameData, save: Gen2SaveData, request: Dictionary
+) -> bool:
+	_world = world
+	_data = data
+	_save = save
+	_persist = false
+	if _world == null or _data == null:
+		_show_error("The region map has no world or cartridge cache.")
+		return false
+	_mode = MODE.TOWN_MAP
+	_town_map_from_request = false
+	_fly_map = true
+	_panel.visible = false
+	_town_map = Gen2TownMapScreen.new()
+	_town_map.z_index = 5
+	add_child(_town_map)
+	_town_map.closed.connect(_on_town_map_closed)
+	var visited: Array[int] = []
+	for index: Variant in request.get("visited", []):
+		visited.append(int(index))
+	var opened: bool = _town_map.open_fly(
+		_data,
+		_world.landmark(),
+		bool(request.get("in_kanto", false)),
+		visited,
+		_save != null and _save.gender == Gen2SaveData.GENDER_FEMALE,
+		_world.map_time_of_day(),
+	)
+	if not opened:
+		_on_town_map_closed()
+		return false
+	return true
+
+
 func _open_town_map(from_request: bool) -> void:
 	_mode = MODE.TOWN_MAP
 	_town_map_from_request = from_request
@@ -708,10 +752,16 @@ func _open_town_map(from_request: bool) -> void:
 
 
 func _on_town_map_closed() -> void:
+	var chosen: int = _town_map.chosen_spawn() if _town_map != null else -1
 	if _town_map != null:
 		_town_map.queue_free()
 		_town_map = null
 	_panel.visible = true
+	if _fly_map:
+		_fly_map = false
+		_mode = -1
+		completed.emit([{"kind": &"fly_chosen", "spawn": chosen}])
+		return
 	if _town_map_from_request:
 		_town_map_from_request = false
 		_finish_runtime({"ok": true, "script_value": 1})

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -22,6 +22,13 @@ var dst_enabled: bool = false
 ## rather than as frame zero of a seeded run.
 var random_seed: int = 0
 var frame_number: int = 0
+## Where a blackout, a Teleport, a Dig and an Escape Rope put the player: the
+## last Pokemon Center's own outdoor map, and the warp a cave was walked into
+## through. Both are saved player data on the cartridge (`wLastSpawnMapGroup`,
+## `wDigWarpNumber`), and a snapshot written before they existed carries neither,
+## which reads as a game that has entered no Pokemon Center and no cave.
+var last_spawn_map: Vector2i = Vector2i(-1, -1)
+var dig_warp: Dictionary = {}
 var world_state: Gen2WorldState = Gen2WorldState.new()
 
 
@@ -41,6 +48,8 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.dst_enabled = world.daylight_saving_time_enabled()
 	out.random_seed = world.random_seed
 	out.frame_number = world.frame_number
+	out.last_spawn_map = world.last_spawn_map
+	out.dig_warp = world.dig_warp.duplicate()
 	out.world_state = Gen2WorldState.from_dict(world.state.to_dict())
 	return out
 
@@ -57,6 +66,8 @@ func to_dict() -> Dictionary:
 		"dst_enabled": dst_enabled,
 		"random_seed": random_seed,
 		"frame_number": frame_number,
+		"last_spawn_map": [last_spawn_map.x, last_spawn_map.y],
+		"dig_warp": dig_warp.duplicate(),
 		"world_state": world_state.to_dict() if world_state != null else {},
 	}
 
@@ -87,6 +98,14 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 	out.dst_enabled = bool(source.get("dst_enabled", false))
 	out.random_seed = int(source.get("random_seed", 0))
 	out.frame_number = maxi(0, int(source.get("frame_number", 0)))
+	out.last_spawn_map = _vector_from_value(source.get("last_spawn_map", [-1, -1]))
+	var raw_dig: Variant = source.get("dig_warp", {})
+	if raw_dig is Dictionary and not (raw_dig as Dictionary).is_empty():
+		out.dig_warp = {
+			"warp": int((raw_dig as Dictionary).get("warp", 0)),
+			"map_group": int((raw_dig as Dictionary).get("map_group", 0)),
+			"map_number": int((raw_dig as Dictionary).get("map_number", 0)),
+		}
 	out.world_state = Gen2WorldState.from_dict(source.get("world_state", {}))
 	return out
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -512,6 +512,31 @@ static func engine_flag(crystal_index: int, crystal: bool = true) -> int:
 	return crystal_index - 1 if crystal_index > ENGINE_MOBILE_SYSTEM else -1
 
 
+## The `ENGINE_FLYPOINT_*` run, which is `wVisitedSpawns` a bit at a time: the
+## flag `CheckIfVisitedFlypoint` tests for spawn [param spawn], as a Crystal
+## index resolved onto [param crystal]'s own table.
+##
+## The rows are the spawns in order with one hole in them: `SPAWN_UNION_CAVE`
+## has no flag of its own (`data/events/engine_flags.asm`), so every spawn past
+## it sits one row lower than its own number. -1 for the Union Cave spawn and for
+## anything outside the run, which [method is_engine_flag_active] reads as
+## inactive.
+static func flypoint_flag(spawn: int, crystal: bool = true) -> int:
+	if spawn < 0 or spawn >= NUM_SPAWNS or spawn == SPAWN_UNION_CAVE:
+		return -1
+	var index: int = ENGINE_FLYPOINT_FIRST + spawn
+	if spawn > SPAWN_UNION_CAVE:
+		index -= 1
+	return engine_flag(index, crystal)
+
+
+## `ENGINE_FLYPOINT_PLAYERS_HOUSE`, where the run starts, and the one spawn the
+## run skips.
+const ENGINE_FLYPOINT_FIRST: int = 51
+const SPAWN_UNION_CAVE: int = 17
+const NUM_SPAWNS: int = RomLayout.SPAWN_COUNT
+
+
 ## The engine flag SetStrengthFlag sets and TryStrengthOW and
 ## DoPlayerMovement.CheckStrengthBoulder read, resolved for [param crystal] the
 ## way badge_flag() resolves a badge.

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -78,16 +78,17 @@ func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
 
 
 ## The overworld's field-move list is a different question, and neither list
-## contains the other. Fly is an HM this project does not act on; Headbutt and
-## Rock Smash are TMs it does, so they are field moves ForgetMove will happily
-## forget.
+## contains the other. Fly is an HM this project does not act on; Headbutt, Rock
+## Smash, Dig and Teleport are TMs and level-up moves it does, so they are field
+## moves ForgetMove will happily forget.
 const TM_FIELD_MOVES: Array[int] = [
 	Gen2WorldFieldMove.MOVE_HEADBUTT, Gen2WorldFieldMove.MOVE_ROCK_SMASH,
+	Gen2WorldFieldMove.MOVE_DIG, Gen2WorldFieldMove.MOVE_TELEPORT,
 ]
 
 
 func test_the_hm_list_and_the_overworld_field_moves_only_overlap() -> void:
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 8)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 10)
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
 		if TM_FIELD_MOVES.has(move):
 			continue

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -84,12 +84,13 @@ func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
 const TM_FIELD_MOVES: Array[int] = [
 	Gen2WorldFieldMove.MOVE_HEADBUTT, Gen2WorldFieldMove.MOVE_ROCK_SMASH,
 	Gen2WorldFieldMove.MOVE_DIG, Gen2WorldFieldMove.MOVE_TELEPORT,
-	Gen2WorldFieldMove.MOVE_SWEET_SCENT,
+	Gen2WorldFieldMove.MOVE_SWEET_SCENT, Gen2WorldFieldMove.MOVE_SOFTBOILED,
+	Gen2WorldFieldMove.MOVE_MILK_DRINK,
 ]
 
 
 func test_the_hm_list_and_the_overworld_field_moves_only_overlap() -> void:
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 12)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 14)
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
 		if TM_FIELD_MOVES.has(move):
 			continue

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -84,11 +84,12 @@ func test_is_hm_move_covers_every_hm_and_nothing_else() -> void:
 const TM_FIELD_MOVES: Array[int] = [
 	Gen2WorldFieldMove.MOVE_HEADBUTT, Gen2WorldFieldMove.MOVE_ROCK_SMASH,
 	Gen2WorldFieldMove.MOVE_DIG, Gen2WorldFieldMove.MOVE_TELEPORT,
+	Gen2WorldFieldMove.MOVE_SWEET_SCENT,
 ]
 
 
 func test_the_hm_list_and_the_overworld_field_moves_only_overlap() -> void:
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 10)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 11)
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
 		if TM_FIELD_MOVES.has(move):
 			continue

--- a/tests/unit/test_move_forget.gd
+++ b/tests/unit/test_move_forget.gd
@@ -89,7 +89,7 @@ const TM_FIELD_MOVES: Array[int] = [
 
 
 func test_the_hm_list_and_the_overworld_field_moves_only_overlap() -> void:
-	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 11)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 12)
 	for move: int in Gen2WorldFieldMove.FIELD_MOVES:
 		if TM_FIELD_MOVES.has(move):
 			continue
@@ -99,8 +99,8 @@ func test_the_hm_list_and_the_overworld_field_moves_only_overlap() -> void:
 			Gen2MoveForget.is_hm_move(move),
 			"TM02 HEADBUTT and TM08 ROCK SMASH are not protected by IsHMMove"
 		)
-	assert_true(Gen2MoveForget.is_hm_move(0x13), "FLY is an HM with no field effect here")
-	assert_false(Gen2WorldFieldMove.FIELD_MOVES.has(0x13))
+	assert_true(Gen2MoveForget.is_hm_move(Gen2WorldFieldMove.MOVE_FLY))
+	assert_true(Gen2WorldFieldMove.FIELD_MOVES.has(Gen2WorldFieldMove.MOVE_FLY))
 
 
 ## ListMoves walks the slots and stops at the first zero, so a padded slot is

--- a/tests/unit/test_town_map.gd
+++ b/tests/unit/test_town_map.gd
@@ -109,3 +109,56 @@ func test_the_dex_area_draws_the_player_only_in_their_own_region() -> void:
 	assert_false(kanto.player_in_region())
 	kanto.press(Gen2Button.RIGHT)
 	assert_true(kanto.player_in_region())
+
+
+## `_FlyMap`, whose cursor is a `FLY_*` index rather than a landmark and whose
+## walk skips every flypoint the player has not visited.
+
+func test_the_fly_map_opens_on_the_region_the_player_is_in() -> void:
+	var johto := Gen2TownMap.fly(Gen2TownMap.JOHTO_LANDMARK, false, [] as Array[int], true)
+	assert_eq(johto.region(), Gen2TownMap.REGION_JOHTO)
+	assert_eq(johto.cursor, 0, "New Bark is Johto's default")
+	assert_eq(johto.first_landmark(), 0)
+	assert_eq(johto.last_landmark(), RomLayout.KANTO_FLYPOINT - 1)
+
+	var kanto := Gen2TownMap.fly(
+		60, true, [Gen2TownMap.FLY_INDIGO] as Array[int], true
+	)
+	assert_eq(kanto.region(), Gen2TownMap.REGION_KANTO)
+	assert_eq(kanto.cursor, Gen2TownMap.FLY_INDIGO, "Indigo is Kanto's default")
+	assert_eq(kanto.first_landmark(), RomLayout.KANTO_FLYPOINT)
+	assert_eq(kanto.last_landmark(), RomLayout.FLYPOINT_COUNT - 1)
+	# The player icon still says where the player is standing.
+	assert_eq(kanto.player_landmark, 60)
+
+
+func test_kanto_falls_back_to_johtos_map_until_indigo_plateau() -> void:
+	# `.NoKanto`, which is what stops the source's own crash on a region with no
+	# flypoint enabled.
+	var map := Gen2TownMap.fly(60, true, [] as Array[int], true)
+	assert_eq(map.region(), Gen2TownMap.REGION_JOHTO)
+	assert_eq(map.cursor, 0)
+
+
+func test_the_fly_cursor_skips_every_flypoint_that_has_not_been_visited() -> void:
+	# Violet is flypoint 2 and Goldenrod 4; nothing between them is visited.
+	var map := Gen2TownMap.fly(
+		Gen2TownMap.JOHTO_LANDMARK, false, [2, 4] as Array[int], true
+	)
+	map.press(Gen2Button.UP)
+	assert_eq(map.cursor, 2)
+	map.press(Gen2Button.UP)
+	assert_eq(map.cursor, 4)
+	# Wrapping past the end lands back on the default, which is on the map
+	# whether or not it has been visited.
+	map.press(Gen2Button.UP)
+	assert_eq(map.cursor, 0)
+	map.press(Gen2Button.DOWN)
+	assert_eq(map.cursor, 4)
+
+
+func test_a_fly_map_with_nothing_visited_holds_its_default() -> void:
+	var map := Gen2TownMap.fly(Gen2TownMap.JOHTO_LANDMARK, false, [] as Array[int], true)
+	for press: int in [Gen2Button.UP, Gen2Button.DOWN, Gen2Button.UP]:
+		map.press(press)
+		assert_eq(map.cursor, 0)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -417,10 +417,11 @@ func test_the_eight_resolved_moves_are_the_field_moves_the_submenu_offers() -> v
 	assert_eq(Gen2WorldFieldMove.MOVE_TELEPORT, 0x64)
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SWEET_SCENT))
 	assert_eq(Gen2WorldFieldMove.MOVE_SWEET_SCENT, 0xE6)
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_FLY))
+	assert_eq(Gen2WorldFieldMove.MOVE_FLY, 0x13)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: FLY, SOFTBOILED and
-	# MILK_DRINK.
-	for move: int in [0x13, 0x87, 0xD0]:
+	# submenu would offer an entry nothing answers: SOFTBOILED and MILK_DRINK.
+	for move: int in [0x87, 0xD0]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 
@@ -1590,3 +1591,47 @@ func test_sweet_scent_needs_a_party_member_that_knows_it() -> void:
 	var world: Gen2WorldAPI = _scent_world()
 	world.set_party_summary(1, false, [1] as Array[int], [[]], ["MON"], [false])
 	assert_eq(StringName(world.sweet_scent_request()["reason"]), &"move_not_known")
+
+
+## `FlyFunction`'s `.TryFly`, which is everything the move can refuse on before
+## the region map is drawn.
+
+func test_fly_needs_the_storm_badge_the_move_and_an_outdoor_map() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var badged := Gen2WorldState.new()
+	badged.set_engine_flag(Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.BADGE_STORM, Gen2WorldState.is_crystal_profile(data)
+	))
+	var outdoors: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, ESCAPE_TOWN, SPAWN_CELL, badged)
+	_knowing_party(outdoors, Gen2WorldFieldMove.MOVE_FLY)
+	assert_true(bool(outdoors.fly_request().get("ok", false)))
+
+	var indoors: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, ESCAPE_POKECENTER, Vector2i(4, 4), badged
+	)
+	_knowing_party(indoors, Gen2WorldFieldMove.MOVE_FLY)
+	assert_eq(StringName(indoors.fly_request()["reason"]), &"indoors")
+
+	var unbadged: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, ESCAPE_TOWN, SPAWN_CELL, Gen2WorldState.new()
+	)
+	_knowing_party(unbadged, Gen2WorldFieldMove.MOVE_FLY)
+	assert_eq(StringName(unbadged.fly_request()["reason"]), &"badge_required")
+
+
+func test_the_visited_flypoints_are_the_engine_flags_of_their_own_spawns() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, ESCAPE_TOWN, SPAWN_CELL, state)
+	assert_eq(world.visited_flypoints(), [] as Array[int])
+
+	# The fixture's flypoint table is empty, so the mapping itself is what is
+	# asserted here: `SPAWN_UNION_CAVE` has no flag row of its own and every
+	# spawn past it sits one lower than its own number.
+	assert_eq(Gen2WorldState.flypoint_flag(0), 51)
+	assert_eq(Gen2WorldState.flypoint_flag(13), 64, "Indigo Plateau")
+	assert_eq(Gen2WorldState.flypoint_flag(17), -1, "Union Cave has no flypoint")
+	assert_eq(Gen2WorldState.flypoint_flag(26), 76, "Mt. Silver")
+	# Gold and Silver ship no ENGINE_MOBILE_SYSTEM, so the whole run sits one
+	# lower there.
+	assert_eq(Gen2WorldState.flypoint_flag(0, false), 50)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -145,7 +145,9 @@ func _write_cache() -> void:
 		RomCache.write_indices(RomCache.world_tile_path(_directory, number), pixels)
 
 	RomCache.write_json(RomCache.world_encounters_path(_directory), {
-		"grass": {}, "water": {}, "swarm_grass": {}, "swarm_water": {},
+		# One grass table, on map 1 alone, so SWEET SCENT has somewhere with a
+		# wild in it and somewhere without.
+		"grass": {"1:1": {"rates": [255, 255, 255], "slots": _grass_slots()}}, "water": {}, "swarm_grass": {}, "swarm_water": {},
 		"fishing": {"groups": [], "time_groups": []},
 		"roaming": {"maps": [], "mons": []},
 		"treemons": {
@@ -177,6 +179,18 @@ const TREEMON_RARE_SPECIES: int = 214
 ## One of the fixture's asleep species, so a tree encounter can be asserted
 ## both ways without depending on which row the roll lands on.
 const ASLEEP_SPECIES: int = 21
+
+
+## One grass table for map 1: three times of day of the source's seven slots,
+## all the same species, so a roll cannot pick a different answer.
+func _grass_slots() -> Array:
+	var out: Array = []
+	for time_of_day: int in 3:
+		var slots: Array = []
+		for slot: int in 7:
+			slots.append({"level": 5, "species": TREEMON_SPECIES})
+		out.append(slots)
+	return out
 
 
 func _treemon_sets() -> Array:
@@ -401,10 +415,12 @@ func test_the_eight_resolved_moves_are_the_field_moves_the_submenu_offers() -> v
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_TELEPORT))
 	assert_eq(Gen2WorldFieldMove.MOVE_DIG, 0x5B)
 	assert_eq(Gen2WorldFieldMove.MOVE_TELEPORT, 0x64)
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SWEET_SCENT))
+	assert_eq(Gen2WorldFieldMove.MOVE_SWEET_SCENT, 0xE6)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: FLY, SOFTBOILED, MILK_DRINK
-	# and SWEET_SCENT.
-	for move: int in [0x13, 0x87, 0xD0, 0xE6]:
+	# submenu would offer an entry nothing answers: FLY, SOFTBOILED and
+	# MILK_DRINK.
+	for move: int in [0x13, 0x87, 0xD0]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 
@@ -1534,3 +1550,43 @@ func test_a_snapshot_carries_both_escape_points_and_a_reopened_world_keeps_them(
 	var older: Gen2WorldSnapshot = Gen2WorldSnapshot.from_dict(old)
 	assert_true(older.dig_warp.is_empty())
 	assert_eq(older.last_spawn_map, Vector2i(-1, -1))
+
+
+## `SweetScentEncounter`: a wild where one could have been stepped into.
+
+func _scent_world(cell: Vector2i = GRASS_CELL, map_number: int = 1) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		GameData.open_directory(_directory), 1, map_number, cell, Gen2WorldState.new()
+	)
+	_knowing_party(world, Gen2WorldFieldMove.MOVE_SWEET_SCENT)
+	return world
+
+
+func test_sweet_scent_finds_a_wild_in_the_grass_without_rolling_the_rate() -> void:
+	var world: Gen2WorldAPI = _scent_world()
+	# The five-step cooldown a map entry sets is a step's gate, not this one.
+	assert_true(world.state.wild_encounter_cooldown() > 0)
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	var scent: Dictionary = world.sweet_scent_request(random)
+	assert_true(bool(scent.get("ok", false)), String(scent.get("reason", "")))
+	assert_eq(int((scent["encounter"] as Dictionary)["pokemon"]), TREEMON_SPECIES)
+
+
+func test_sweet_scent_says_nothing_is_here_off_the_grass_and_on_a_bare_map() -> void:
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	# `CanEncounterWildMon`: ordinary floor is where the source refuses first.
+	var on_floor: Gen2WorldAPI = _scent_world(Vector2i(1, 1))
+	assert_eq(StringName(on_floor.sweet_scent_request(random)["reason"]), &"no_encounter")
+
+	# And a map with no table of its own answers the same, which is
+	# `ChooseWildEncounter` refusing rather than the tile.
+	var bare: Gen2WorldAPI = _scent_world(GRASS_CELL, 2)
+	assert_eq(StringName(bare.sweet_scent_request(random)["reason"]), &"no_encounter")
+
+
+func test_sweet_scent_needs_a_party_member_that_knows_it() -> void:
+	var world: Gen2WorldAPI = _scent_world()
+	world.set_party_summary(1, false, [1] as Array[int], [[]], ["MON"], [false])
+	assert_eq(StringName(world.sweet_scent_request()["reason"]), &"move_not_known")

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -12,6 +12,20 @@ extends GutTest
 
 const TILESET_CUTTABLE: int = Gen2WorldFieldMove.TILESET_JOHTO
 const TILESET_NO_ENTRY: int = 5
+## The escape moves' own three maps. The cache is not tagged `gold` or `silver`,
+## so `TILESET_POKECENTER` is Crystal's number.
+const TILESET_POKECENTER: int = Gen2WorldAPI.TILESET_POKECENTER
+const ESCAPE_TOWN: int = 4
+const ESCAPE_CAVE: int = 5
+const ESCAPE_POKECENTER: int = 6
+const ENVIRONMENT_INDOOR: int = Gen2WorldAPI.ENVIRONMENT_INDOOR
+const ENVIRONMENT_CAVE: int = Gen2WorldAPI.ENVIRONMENT_CAVE
+## Where the town's own spawn puts the player down, which is not its warp tile.
+const SPAWN_CELL: Vector2i = Vector2i(1, 1)
+## The town's two doors and the one every indoor map here has back out.
+const ESCAPE_CAVE_DOOR: Vector2i = Vector2i(3, 1)
+const ESCAPE_CENTRE_DOOR: Vector2i = Vector2i(5, 1)
+const ESCAPE_INSIDE_DOOR: Vector2i = Vector2i(2, 2)
 const BLOCK_TREE: int = 0x5B
 const BLOCK_TREE_CUT: int = 0x3C
 const BLOCK_GRASS: int = 0x03
@@ -98,6 +112,7 @@ func _write_cache() -> void:
 
 	RomCache.write_json(RomCache.world_tilesets_path(_directory), [
 		_tileset(TILESET_CUTTABLE), _tileset(TILESET_NO_ENTRY),
+		_tileset(TILESET_POKECENTER),
 	])
 	RomCache.write_json(RomCache.world_maps_path(_directory), [
 		_map(1, TILESET_CUTTABLE), _map(2, TILESET_NO_ENTRY),
@@ -105,13 +120,28 @@ func _write_cache() -> void:
 		# DUNGEON environment, which is what keeps the light on when the player
 		# walks from it into another cave room.
 		_map(3, TILESET_CUTTABLE, Gen2WorldPalette.PALETTE_DARK, ENVIRONMENT_DUNGEON),
+		# The three the escape moves need: an outdoor town, the cave it leads
+		# into and a Pokemon Center, each warping back to the town. `.SaveDigWarp`
+		# and `.SetSpawn` only fire on the way from an outdoor map into an indoor
+		# one, so the town is where both walks start.
+		_map(ESCAPE_TOWN, TILESET_CUTTABLE, 0, ENVIRONMENT_TOWN),
+		_map(ESCAPE_CAVE, TILESET_NO_ENTRY, 0, ENVIRONMENT_CAVE),
+		_map(ESCAPE_POKECENTER, TILESET_POKECENTER, 0, ENVIRONMENT_INDOOR),
 	])
+	# `SpawnPoints`, with the town as the one spawn this cache carries.
+	RomCache.write_json(RomCache.world_spawns_path(_directory), {
+		"spawns": [{
+			"map_group": 1, "map_number": ESCAPE_TOWN,
+			"x": SPAWN_CELL.x, "y": SPAWN_CELL.y,
+		}],
+		"flypoints": [],
+	})
 
 	var pixels := PackedByteArray()
 	pixels.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
 	for index: int in pixels.size():
 		pixels[index] = index % 4
-	for number: int in [TILESET_CUTTABLE, TILESET_NO_ENTRY]:
+	for number: int in [TILESET_CUTTABLE, TILESET_NO_ENTRY, TILESET_POKECENTER]:
 		RomCache.write_indices(RomCache.world_tile_path(_directory, number), pixels)
 
 	RomCache.write_json(RomCache.world_encounters_path(_directory), {
@@ -230,6 +260,28 @@ func _map(number: int, tileset: int, palette: int = 0, environment: int = 0) -> 
 			"x": TRANSITION_PIT_CELL.x, "y": TRANSITION_PIT_CELL.y,
 			"destination": 1, "map_group": 1, "map_number": 1,
 		})
+	# The town's two doors and the one door back out of each of them, so a walk
+	# in records the warp it came through and a Dig walks back out of it.
+	if number == ESCAPE_TOWN:
+		collision[ESCAPE_CAVE_DOOR.y * 8 + ESCAPE_CAVE_DOOR.x] = COLL_PIT
+		collision[ESCAPE_CENTRE_DOOR.y * 8 + ESCAPE_CENTRE_DOOR.x] = COLL_PIT
+		warps = [
+			{
+				"x": ESCAPE_CAVE_DOOR.x, "y": ESCAPE_CAVE_DOOR.y, "destination": 1,
+				"map_group": 1, "map_number": ESCAPE_CAVE,
+			},
+			{
+				"x": ESCAPE_CENTRE_DOOR.x, "y": ESCAPE_CENTRE_DOOR.y, "destination": 1,
+				"map_group": 1, "map_number": ESCAPE_POKECENTER,
+			},
+		]
+	elif number in [ESCAPE_CAVE, ESCAPE_POKECENTER]:
+		collision[ESCAPE_INSIDE_DOOR.y * 8 + ESCAPE_INSIDE_DOOR.x] = COLL_PIT
+		warps = [{
+			"x": ESCAPE_INSIDE_DOOR.x, "y": ESCAPE_INSIDE_DOOR.y,
+			"destination": 1 if number == ESCAPE_CAVE else 2,
+			"map_group": 1, "map_number": ESCAPE_TOWN,
+		}]
 	return {
 		"group": 1,
 		"number": number,
@@ -345,10 +397,14 @@ func test_the_eight_resolved_moves_are_the_field_moves_the_submenu_offers() -> v
 	assert_eq(Gen2WorldFieldMove.MOVE_FLASH, 0x94)
 	assert_eq(Gen2WorldFieldMove.MOVE_HEADBUTT, 0x1D)
 	assert_eq(Gen2WorldFieldMove.MOVE_ROCK_SMASH, 0xF9)
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_DIG))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_TELEPORT))
+	assert_eq(Gen2WorldFieldMove.MOVE_DIG, 0x5B)
+	assert_eq(Gen2WorldFieldMove.MOVE_TELEPORT, 0x64)
 	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: FLY, DIG, TELEPORT,
-	# SOFTBOILED, MILK_DRINK and SWEET_SCENT.
-	for move: int in [0x13, 0x5B, 0x64, 0x87, 0xD0, 0xE6]:
+	# submenu would offer an entry nothing answers: FLY, SOFTBOILED, MILK_DRINK
+	# and SWEET_SCENT.
+	for move: int in [0x13, 0x87, 0xD0, 0xE6]:
 		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
 
 
@@ -1353,3 +1409,128 @@ func _headbutt_world(knows: bool = true, map_number: int = 1) -> Gen2WorldAPI:
 	if knows:
 		_knowing_party(world, Gen2WorldFieldMove.MOVE_HEADBUTT)
 	return world
+
+
+## `.SaveDigWarp` and `.SetSpawn`, and the two moves that read what they wrote.
+
+func _escape_world(map_number: int = ESCAPE_TOWN, cell: Vector2i = SPAWN_CELL) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		GameData.open_directory(_directory), 1, map_number, cell, Gen2WorldState.new()
+	)
+	world.set_party_summary(
+		1, false, [1] as Array[int],
+		[[Gen2WorldFieldMove.MOVE_DIG, Gen2WorldFieldMove.MOVE_TELEPORT]],
+		["MON"], [false]
+	)
+	return world
+
+
+func test_walking_into_a_cave_records_the_warp_and_nothing_else_does() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	assert_true(world.dig_warp.is_empty())
+	assert_eq(world.last_spawn_map, Vector2i(-1, -1))
+
+	world.player_cell = ESCAPE_CAVE_DOOR
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_CAVE))
+	# One-based, as the town's own warp list counts it.
+	assert_eq(world.dig_warp, {"warp": 1, "map_group": 1, "map_number": ESCAPE_TOWN})
+	assert_eq(world.last_spawn_map, Vector2i(-1, -1), "a cave is no respawn")
+
+	# Out again: the way back is not a walk from an outdoor map, so neither
+	# record moves.
+	world.player_cell = ESCAPE_INSIDE_DOOR
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
+	assert_eq(world.dig_warp, {"warp": 1, "map_group": 1, "map_number": ESCAPE_TOWN})
+
+
+func test_walking_into_a_pokemon_centre_records_the_spawn() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.player_cell = ESCAPE_CENTRE_DOOR
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_POKECENTER))
+	assert_eq(world.last_spawn_map, Vector2i(1, ESCAPE_TOWN))
+	# `.SetSpawn` records the map, and `IsSpawnPoint` is what turns it into the
+	# spawn a blackout and a Teleport share.
+	assert_eq(world.spawn_index_of(world.last_spawn_map), 0)
+	assert_eq(world.whiteout_spawn(), 0)
+	# `.SaveDigWarp` fires on any outdoor to indoor walk, a Pokemon Center's
+	# included, so both records move on this one: the door is the town's second.
+	assert_eq(world.dig_warp, {"warp": 2, "map_group": 1, "map_number": ESCAPE_TOWN})
+
+
+func test_a_blackout_with_no_pokemon_centre_behind_it_falls_back_to_home() -> void:
+	# `GetWhiteoutSpawn`'s own `xor a`: a game that has entered none goes home.
+	assert_eq(_escape_world().whiteout_spawn(), RomLayout.SPAWN_HOME)
+
+
+func test_dig_takes_the_warp_the_cave_was_entered_by() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.player_cell = ESCAPE_CAVE_DOOR
+	world.try_warp()
+	world.player_cell = Vector2i(4, 4)
+
+	var dug: Dictionary = world.dig_request()
+	assert_true(bool(dug.get("ok", false)), String(dug.get("reason", "")))
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
+	assert_eq(world.player_cell, ESCAPE_CAVE_DOOR)
+
+
+func test_dig_is_refused_outside_a_cave_and_with_no_warp_recorded() -> void:
+	var outdoors: Gen2WorldAPI = _escape_world()
+	assert_eq(StringName(outdoors.dig_request()["reason"]), &"not_in_a_cave")
+
+	var in_a_cave: Gen2WorldAPI = _escape_world(ESCAPE_CAVE, Vector2i(4, 4))
+	assert_eq(StringName(in_a_cave.dig_request()["reason"]), &"no_dig_warp")
+
+	var unknowing: Gen2WorldAPI = _escape_world(ESCAPE_CAVE, Vector2i(4, 4))
+	unknowing.set_party_summary(1, false, [1] as Array[int], [[]], ["MON"], [false])
+	assert_eq(StringName(unknowing.dig_request()["reason"]), &"move_not_known")
+
+
+func test_teleport_returns_to_the_last_pokemon_centre_from_outdoors() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.player_cell = ESCAPE_CENTRE_DOOR
+	world.try_warp()
+	# Out of the centre and away, so the return is somewhere to go.
+	world.player_cell = ESCAPE_INSIDE_DOOR
+	world.try_warp()
+	world.player_cell = Vector2i(6, 6)
+
+	var teleported: Dictionary = world.teleport_request()
+	assert_true(bool(teleported.get("ok", false)), String(teleported.get("reason", "")))
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
+	assert_eq(world.player_cell, SPAWN_CELL)
+
+
+func test_teleport_is_refused_indoors_and_with_no_pokemon_centre_behind_it() -> void:
+	var fresh: Gen2WorldAPI = _escape_world()
+	assert_eq(StringName(fresh.teleport_request()["reason"]), &"no_spawn_point")
+
+	var indoors: Gen2WorldAPI = _escape_world(ESCAPE_POKECENTER, Vector2i(4, 4))
+	indoors.last_spawn_map = Vector2i(1, ESCAPE_TOWN)
+	assert_eq(StringName(indoors.teleport_request()["reason"]), &"not_outdoors")
+
+
+func test_a_snapshot_carries_both_escape_points_and_a_reopened_world_keeps_them() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.player_cell = ESCAPE_CAVE_DOOR
+	world.try_warp()
+	var snapshot: Gen2WorldSnapshot = Gen2WorldSnapshot.from_world(world)
+	snapshot.last_spawn_map = Vector2i(1, ESCAPE_TOWN)
+
+	var reopened: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
+		GameData.open_directory(_directory),
+		Gen2WorldSnapshot.from_dict(snapshot.to_dict())
+	)
+	assert_eq(reopened.dig_warp, {"warp": 1, "map_group": 1, "map_number": ESCAPE_TOWN})
+	assert_eq(reopened.last_spawn_map, Vector2i(1, ESCAPE_TOWN))
+	# A snapshot written before either existed reads as a game that has entered
+	# neither, which is what their defaults say.
+	var old: Dictionary = snapshot.to_dict()
+	old.erase("dig_warp")
+	old.erase("last_spawn_map")
+	var older: Gen2WorldSnapshot = Gen2WorldSnapshot.from_dict(old)
+	assert_true(older.dig_warp.is_empty())
+	assert_eq(older.last_spawn_map, Vector2i(-1, -1))

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -419,10 +419,13 @@ func test_the_eight_resolved_moves_are_the_field_moves_the_submenu_offers() -> v
 	assert_eq(Gen2WorldFieldMove.MOVE_SWEET_SCENT, 0xE6)
 	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_FLY))
 	assert_eq(Gen2WorldFieldMove.MOVE_FLY, 0x13)
-	# MonMenuOptions rows this project does not act on yet must stay out, or the
-	# submenu would offer an entry nothing answers: SOFTBOILED and MILK_DRINK.
-	for move: int in [0x87, 0xD0]:
-		assert_false(Gen2WorldFieldMove.is_field_move(move), "move $%02x" % move)
+	# Every `MonMenu_*` field-move row is answered now, so the submenu offers no
+	# entry that nothing acts on.
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_SOFTBOILED))
+	assert_true(Gen2WorldFieldMove.is_field_move(Gen2WorldFieldMove.MOVE_MILK_DRINK))
+	assert_eq(Gen2WorldFieldMove.MOVE_SOFTBOILED, 0x87)
+	assert_eq(Gen2WorldFieldMove.MOVE_MILK_DRINK, 0xD0)
+	assert_eq(Gen2WorldFieldMove.FIELD_MOVES.size(), 14)
 
 
 ## .TryStrength is CheckBadge ENGINE_PLAINBADGE and nothing else, so a request

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -533,3 +533,62 @@ func _add_capture_metadata() -> void:
 		if int(raw["number"]) in [0x01, 0x02, 0x04, 0x05]:
 			raw["pocket"] = RomLayout.ITEM_POCKET_BALL
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+
+
+## `Softboiled_MilkDrinkFunction`: a fifth of the user's own maximum health moved
+## to another party member, and the three refusals `.SelectMilkDrinkRecipient`
+## loops on.
+
+func _fifth_of(index: int) -> int:
+	return Gen2WorldPartyHost.one_fifth_max_hp(_data, _save.party[index])
+
+
+func test_softboiled_moves_a_fifth_of_the_users_own_maximum() -> void:
+	var amount: int = _fifth_of(0)
+	assert_gt(amount, 0)
+	_save.party[1].hp = 1
+	var before: int = _save.party[0].hp
+
+	var result: Dictionary = Gen2WorldPartyHost.transfer_health(_world, _save, 0, 1, false)
+	assert_true(result["ok"], String(result.get("reason", "")))
+	assert_eq(int(result["amount"]), amount)
+	assert_eq(_save.party[0].hp, before - amount)
+	assert_eq(_save.party[1].hp, 1 + int(result["restored"]))
+
+
+func test_the_healed_member_is_never_taken_past_its_own_maximum() -> void:
+	# The user's fifth is what is spent whatever the recipient can hold, which is
+	# why the two numbers are reported separately.
+	var max_hp: int = Gen2SaveBattleAdapter.to_battle_mon(_data, _save.party[1]).max_hp()
+	_save.party[1].hp = max_hp - 1
+	var result: Dictionary = Gen2WorldPartyHost.transfer_health(_world, _save, 0, 1, false)
+	assert_true(result["ok"], String(result.get("reason", "")))
+	assert_eq(_save.party[1].hp, max_hp)
+	assert_eq(int(result["restored"]), 1)
+	assert_eq(int(result["amount"]), _fifth_of(0))
+
+
+func test_a_user_on_a_fifth_or_less_cannot_give_health_away() -> void:
+	# `.CheckMonHasEnoughHP` wants more than the fifth, not the fifth itself.
+	_save.party[1].hp = 1
+	_save.party[0].hp = _fifth_of(0)
+	var result: Dictionary = Gen2WorldPartyHost.transfer_health(_world, _save, 0, 1, false)
+	assert_false(bool(result.get("ok", false)))
+	assert_eq(StringName(result["reason"]), &"not_enough_health")
+	assert_eq(_save.party[1].hp, 1, "and nothing moved")
+
+
+func test_the_user_itself_a_fainted_member_and_a_full_one_are_all_refused() -> void:
+	assert_eq(
+		StringName(Gen2WorldPartyHost.transfer_health(_world, _save, 0, 0, false)["reason"]),
+		&"same_member"
+	)
+	assert_eq(
+		StringName(Gen2WorldPartyHost.transfer_health(_world, _save, 0, 1, false)["reason"]),
+		&"already_full"
+	)
+	_save.party[1].hp = 0
+	assert_eq(
+		StringName(Gen2WorldPartyHost.transfer_health(_world, _save, 0, 1, false)["reason"]),
+		&"fainted_member"
+	)

--- a/tests/unit/test_world_services_importer.gd
+++ b/tests/unit/test_world_services_importer.gd
@@ -16,6 +16,7 @@ func test_marts_phone_audio_and_referenced_menu_are_imported() -> void:
 	_write_audio(data)
 	_write_menu(data)
 	_write_fruit_trees(data)
+	_write_spawns(data)
 
 	var scripts: Dictionary = {
 		"5:7000": [
@@ -84,6 +85,7 @@ func test_mart_terminator_is_required() -> void:
 	data.resize(0x200000)
 	_write_marts(data)
 	_write_fruit_trees(data)
+	_write_spawns(data)
 	data[RomFile.linear(5, 0x7000) + 3] = 0x00
 	var result: Dictionary = Gen2WorldServicesImporter.read_services(
 		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
@@ -104,6 +106,65 @@ func _write_fruit_trees(data: PackedByteArray) -> void:
 	]
 	for index: int in rows.size():
 		data[offset + index] = rows[index]
+
+
+## The two tables in their own shape: coordinates and spawn indexes are what
+## identifies each, so the fixture writes the pinned columns and invents the
+## rest.
+func _write_spawns(data: PackedByteArray) -> void:
+	var offset: int = int(_layout["spawn_points"])
+	for index: int in RomLayout.SPAWN_COUNT:
+		var at: int = offset + index * RomLayout.SPAWN_RECORD_SIZE
+		data[at] = 1 + index % 3
+		data[at + 1] = index
+		data[at + 2] = int(RomLayout.SPAWN_COORDINATES[index * 2])
+		data[at + 3] = int(RomLayout.SPAWN_COORDINATES[index * 2 + 1])
+	for byte: int in RomLayout.SPAWN_RECORD_SIZE:
+		data[offset + RomLayout.SPAWN_COUNT * RomLayout.SPAWN_RECORD_SIZE + byte] = \
+			RomLayout.SPAWN_TERMINATOR
+
+	var fly: int = int(_layout["flypoints"])
+	for index: int in RomLayout.FLYPOINT_COUNT:
+		data[fly + index * RomLayout.FLYPOINT_RECORD_SIZE] = 1 + index
+		data[fly + index * RomLayout.FLYPOINT_RECORD_SIZE + 1] = \
+			int(RomLayout.FLYPOINT_SPAWNS[index])
+	data[fly + RomLayout.FLYPOINT_COUNT * RomLayout.FLYPOINT_RECORD_SIZE] = \
+		RomLayout.FLYPOINT_TERMINATOR
+
+
+func test_a_spawn_table_at_the_wrong_offset_is_refused() -> void:
+	var data := PackedByteArray()
+	data.resize(0x200000)
+	_write_marts(data)
+	_write_phone(data)
+	_write_audio(data)
+	_write_fruit_trees(data)
+	_write_spawns(data)
+	# One coordinate moved is a table that is not this one: every entry's x and y
+	# is what tells `SpawnPoints` from its neighbours.
+	data[int(_layout["spawn_points"]) + 2] += 1
+	var result: Dictionary = Gen2WorldServicesImporter.read_services(
+		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
+	)
+	assert_false(result["ok"])
+	assert_true(String(result["message"]).contains("Spawn 0"))
+
+
+func test_a_flypoint_table_without_its_terminator_is_refused() -> void:
+	var data := PackedByteArray()
+	data.resize(0x200000)
+	_write_marts(data)
+	_write_phone(data)
+	_write_audio(data)
+	_write_fruit_trees(data)
+	_write_spawns(data)
+	data[int(_layout["flypoints"])
+		+ RomLayout.FLYPOINT_COUNT * RomLayout.FLYPOINT_RECORD_SIZE] = 0x00
+	var result: Dictionary = Gen2WorldServicesImporter.read_services(
+		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
+	)
+	assert_false(result["ok"])
+	assert_true(String(result["message"]).contains("flypoint table"))
 
 
 func test_a_fruit_tree_table_without_its_apricorn_run_is_refused() -> void:
@@ -305,3 +366,26 @@ func _write_far(data: PackedByteArray, offset: int, bank: int, address: int) -> 
 func _write_u16(data: PackedByteArray, offset: int, value: int) -> void:
 	data[offset] = value & 0xFF
 	data[offset + 1] = (value >> 8) & 0xFF
+
+
+func test_the_spawn_and_flypoint_tables_read_in_source_order() -> void:
+	var data := PackedByteArray()
+	data.resize(0x200000)
+	_write_spawns(data)
+	var result: Dictionary = Gen2WorldServicesImporter.read_spawns(
+		RomFile.from_bytes(data, RomRegistry.GOLD), _layout
+	)
+	assert_true(result["ok"], String(result.get("message", "")))
+	var spawns: Array = (result["data"] as Dictionary)["spawns"]
+	var flypoints: Array = (result["data"] as Dictionary)["flypoints"]
+	assert_eq(spawns.size(), RomLayout.SPAWN_COUNT)
+	assert_eq(flypoints.size(), RomLayout.FLYPOINT_COUNT)
+	# `SPAWN_HOME` is the bedroom and carries the table's first coordinates.
+	assert_eq(int(spawns[RomLayout.SPAWN_HOME]["x"]), 3)
+	assert_eq(int(spawns[RomLayout.SPAWN_HOME]["y"]), 3)
+	# Johto first: flypoint 0 is New Bark and the Kanto half starts at 12.
+	assert_eq(int(flypoints[0]["spawn"]), int(RomLayout.FLYPOINT_SPAWNS[0]))
+	assert_eq(
+		int(flypoints[RomLayout.KANTO_FLYPOINT]["spawn"]),
+		int(RomLayout.FLYPOINT_SPAWNS[RomLayout.KANTO_FLYPOINT])
+	)

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -67,6 +67,47 @@ func run(r: RefCounted) -> void:
 ## The landmark column is the profile-split half, so this is where it is swept:
 ## Gold and Silver ship one landmark fewer, and a Crystal number read on either
 ## of them lands on the wrong city.
+## `_FlyMap`'s own walk on a real cache: with every flypoint visited, one press
+## per row reaches each of the region's twelve and comes back to where it
+## started, and every cursor lands on a landmark the region map draws an icon
+## for.
+func _verify_fly_walk(game_id: StringName, data: GameData) -> void:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	var visited: Array[int] = []
+	for index: int in data.flypoint_count():
+		visited.append(index)
+	for in_kanto: bool in [false, true]:
+		var map: Gen2TownMap = Gen2TownMap.fly(
+			Gen2TownMap.JOHTO_LANDMARK, in_kanto, visited, crystal
+		)
+		var opened: int = map.cursor
+		var seen: Dictionary = {}
+		for _press: int in RomLayout.KANTO_FLYPOINT:
+			seen[map.cursor] = true
+			var landmark: int = int(data.flypoint(map.cursor).get("landmark", -1))
+			var point: Dictionary = data.landmark(landmark)
+			_r.check(
+				not point.is_empty(),
+				"%s: flypoint %d names landmark %d, which the map cannot draw." % [
+					game_id, map.cursor, landmark,
+				]
+			)
+			map.press(Gen2Button.UP)
+		_r.check(
+			seen.size() == RomLayout.KANTO_FLYPOINT,
+			"%s: the %s fly walk reached %d flypoints, not %d." % [
+				game_id, "Kanto" if in_kanto else "Johto", seen.size(),
+				RomLayout.KANTO_FLYPOINT,
+			]
+		)
+		_r.check(
+			map.cursor == opened,
+			"%s: the %s fly walk did not wrap back to where it opened." % [
+				game_id, "Kanto" if in_kanto else "Johto",
+			]
+		)
+
+
 func _verify_flypoints(game_id: StringName, data: GameData) -> void:
 	if not _r.check(
 		data.flypoint_count() == RomLayout.FLYPOINT_COUNT,
@@ -123,6 +164,7 @@ func _verify_flypoints(game_id: StringName, data: GameData) -> void:
 				game_id, index, int(point["map_group"]), int(point["map_number"]),
 			]
 		)
+	_verify_fly_walk(game_id, data)
 	print("%s: %d flypoints over %d spawn points, %d of them Johto." % [
 		game_id, data.flypoint_count(), data.spawn_point_count(), RomLayout.KANTO_FLYPOINT,
 	])

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -57,6 +57,75 @@ func run(r: RefCounted) -> void:
 		_verify_cursor_walk(game_id, data, crystal)
 		_verify_page(game_id, data, crystal)
 		_verify_nests(game_id, data, crystal)
+		_verify_flypoints(game_id, data)
+
+
+## `Flypoints` and `SpawnPoints` against the cache they were imported beside:
+## every flypoint names a landmark the region map draws and a spawn the table
+## holds, and every spawn names a map this cartridge ships.
+##
+## The landmark column is the profile-split half, so this is where it is swept:
+## Gold and Silver ship one landmark fewer, and a Crystal number read on either
+## of them lands on the wrong city.
+func _verify_flypoints(game_id: StringName, data: GameData) -> void:
+	if not _r.check(
+		data.flypoint_count() == RomLayout.FLYPOINT_COUNT,
+		"%s: %d flypoints, not %d." % [
+			game_id, data.flypoint_count(), RomLayout.FLYPOINT_COUNT,
+		]
+	):
+		return
+	if not _r.check(
+		data.spawn_point_count() == RomLayout.SPAWN_COUNT,
+		"%s: %d spawn points, not %d." % [
+			game_id, data.spawn_point_count(), RomLayout.SPAWN_COUNT,
+		]
+	):
+		return
+
+	var seen: Dictionary = {}
+	for index: int in data.flypoint_count():
+		var row: Dictionary = data.flypoint(index)
+		var landmark: int = int(row["landmark"])
+		var spawn: int = int(row["spawn"])
+		_r.check(
+			landmark > 0 and landmark < data.landmark_count(),
+			"%s: flypoint %d names landmark %d, which this cartridge does not ship." % [
+				game_id, index, landmark,
+			]
+		)
+		_r.check(
+			not seen.has(landmark),
+			"%s: flypoint %d repeats landmark %d." % [game_id, index, landmark]
+		)
+		seen[landmark] = true
+		var point: Dictionary = data.spawn_point(spawn)
+		_r.check(
+			not point.is_empty() and data.world_map(
+				int(point["map_group"]), int(point["map_number"])
+			) != null,
+			"%s: flypoint %d lands on spawn %d, which names no map." % [
+				game_id, index, spawn,
+			]
+		)
+		# Johto first, Kanto behind it: `FlyMap` picks a region's cursor range
+		# off that split alone.
+		_r.check(
+			(landmark < Gen2WorldRadio.kanto_landmark(Gen2WorldState.is_crystal_profile(data)))
+				== (index < RomLayout.KANTO_FLYPOINT),
+			"%s: flypoint %d is on the wrong side of the region split." % [game_id, index]
+		)
+	for index: int in data.spawn_point_count():
+		var point: Dictionary = data.spawn_point(index)
+		_r.check(
+			data.world_map(int(point["map_group"]), int(point["map_number"])) != null,
+			"%s: spawn %d names map %d.%d, which this cartridge does not ship." % [
+				game_id, index, int(point["map_group"]), int(point["map_number"]),
+			]
+		)
+	print("%s: %d flypoints over %d spawn points, %d of them Johto." % [
+		game_id, data.flypoint_count(), data.spawn_point_count(), RomLayout.KANTO_FLYPOINT,
+	])
 
 
 func _verify_landmarks(game_id: StringName, data: GameData, crystal: bool) -> void:

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -3,12 +3,13 @@ extends SceneTree
 ## Captures the region map against a real imported cache.
 ##
 ##   Godot --headless --path . -s res://tools/preview_town_map.gd -- \
-##       crystal /tmp/map.png [landmark] [town_map|card|area:<species>] [presses]
+##       crystal /tmp/map.png [landmark] [town_map|card|area:<species>|fly[:all]] [presses]
 ##
 ## [landmark] is `TownMap_GetCurrentLandmark`'s answer, which picks the region and
 ## where the player icon stands; `card` draws the Pokegear's own MAP frame instead
-## of `_TownMap`'s corner box, and `area:19` draws `Pokedex_GetArea` for that
-## species. [presses] is a `u,d,l,r,a,b` list driven into the screen before the
+## of `_TownMap`'s corner box, `area:19` draws `Pokedex_GetArea` for that
+## species, and `fly` draws `_FlyMap` with its own cursor, `fly:all` with every
+## flypoint visited rather than none. [presses] is a `u,d,l,r,a,b` list driven into the screen before the
 ## shot, which is how a cursor walk is photographed. Three other tokens: `hof`
 ## opens with `STATUSFLAGS_HALL_OF_FAME_F` set, which widens the Kanto window past
 ## Victory Road and is what lets the dex area reach Kanto at all; `sel` and `rel`
@@ -30,7 +31,7 @@ func _initialize() -> void:
 	if args.size() < 2:
 		push_error(
 			"Usage: preview_town_map.gd -- <game> <output.png> [landmark] "
-			+ "[town_map|card|area:<species>] [presses]"
+			+ "[town_map|card|area:<species>|fly[:all]] [presses]"
 		)
 		quit(1)
 		return
@@ -99,6 +100,18 @@ func _open(
 	host: Gen2TownMapScreen, data: GameData, species: int, landmark: int,
 	hall_of_fame: bool, mode: String
 ) -> bool:
+	if mode.begins_with("fly"):
+		var visited: Array[int] = []
+		if mode == "fly:all":
+			for index: int in data.flypoint_count():
+				visited.append(index)
+		return host.open_fly(
+			data, landmark,
+			Gen2WorldRadio.is_kanto_landmark(
+				landmark, Gen2WorldState.is_crystal_profile(data)
+			),
+			visited
+		)
 	if species > 0:
 		var roaming: Array = data.world_roaming_mons()
 		var nests: Array = []


### PR DESCRIPTION
Every `MonMenuOptions` field-move row is answered now, so the party submenu
offers no entry that nothing acts on.

## The two tables behind the escapes

`SpawnPoints` is where every escape from a map puts the player down and
`Flypoints` is the fly map's own list. Each identifies itself by the column that
is the same on all three dumps: the spawn coordinates at a stride of four, and
the flypoint spawn indexes at a stride of two ahead of its `-1`. The landmark
column is the profile-split half, since Gold and Silver ship one landmark fewer.
Cache format 56.

## What writes the escape points

`.SaveDigWarp` and `.SetSpawn` both run on a map change and both only fire on the
way from an outdoor map into an indoor one: the first keeps the warp walked
through, the second the outdoor map a Pokemon Center was entered from. Mount Moon
Square and the Tin Tower roof are refused by name. A snapshot carries both, and
one written before they existed reads as a game that has entered neither.

## The rows

| Row | What it does |
|---|---|
| Fly | `_FlyMap`: the region map with the cursor walking flypoints, skipping every one whose spawn is unvisited; `.NoKanto` falls back to Johto until Indigo Plateau is visited |
| Dig | back out of the cave through the warp it was entered by |
| Teleport | back to the last Pokemon Center's own spawn, outdoors only |
| Sweet Scent | a wild where one could have been stepped into: the rate is read and never rolled against |
| Softboiled, Milk Drink | a fifth of the user's own maximum health moved to another party member, through the world's candidate transaction |

## Checks

| Check | Before | After |
|---|---|---|
| GUT, both tiers | 2,882 green | 2,906 green |
| `validate.gd -- all` | 45 topics pass | 45 topics pass, both new tables swept against the maps and landmarks they name, and both fly walks driven on all three cartridges |
| `replay_world.gd` | 27 routes, 0 failures | 27 routes, 0 failures |
| Story walk, three profiles | 291 / 291 / 294 steps, 16 badges | 291 / 291 / 294 steps, 16 badges |
| Import | three caches, layout verified | three caches, layout verified |