### PR TITLE
The pack's field items

### DIFF
--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -16,6 +16,11 @@ extends Control
 signal action_chosen(kind: StringName)
 ## Emitted on Exit or cancel from the top-level list.
 signal closed
+## `.Field`'s PACKSTATE_QUITRUNSCRIPT: an ITEMMENU_CLOSE item whose effect
+## succeeded, so the pack quits and the overworld runs what the effect queued.
+## The payload is the resolved effect, because the screen hosting the world is
+## the one that can cast a rod or draw a warp.
+signal field_item_used(request: Dictionary)
 
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
@@ -822,10 +827,10 @@ func _confirm_give_swap() -> void:
 
 
 ## `UseItem`'s jumptable: `.Oak` refuses, `.Current` and `.Field` apply straight
-## away, and `.Party` asks which Pokemon first. `.Field`'s extra
-## `PACKSTATE_QUITRUNSCRIPT` on success has no counterpart yet, because no
-## `ITEMMENU_CLOSE` item has an effect here: Escape Rope and Dig need the spawn
-## warp, so every one of them reaches `.Oak`'s refusal instead.
+## away, and `.Party` asks which Pokemon first. `.Field` runs the effect here and
+## quits the pack only when it succeeded, which is `wItemEffectSucceeded`; a CLOSE
+## item this project has no effect for leaves the byte clear and lands on `.Oak`
+## with every other refusal.
 func _confirm_use() -> void:
 	var item: Dictionary = _selected_item()
 	if item.is_empty():
@@ -842,10 +847,65 @@ func _confirm_use() -> void:
 				_show_pack_result(_pack_text(TEXT_NO_MON), false)
 				return
 			_open_target_mode()
-		Gen2WorldPack.ITEMMENU_CURRENT, Gen2WorldPack.ITEMMENU_CLOSE:
+		Gen2WorldPack.ITEMMENU_CURRENT:
 			_use_selected_item(-1)
+		Gen2WorldPack.ITEMMENU_CLOSE:
+			_use_field_item(number)
 		_:
 			_show_pack_result(_pack_text(TEXT_OAK), false)
+
+
+## `.Field`: `DoItemEffect` and then `wItemEffectSucceeded`. The effects that run
+## in the overworld are resolved here and reported to the host, which is what
+## `QueueScript` is on the cartridge; the pack itself only decides whether to
+## quit.
+func _use_field_item(item: int) -> void:
+	var request: Dictionary = _resolve_field_item(item) if _world != null else {}
+	if not bool(request.get("ok", false)):
+		## `.Field` says `.Oak` and `UseRegisteredItem`'s `.Overworld`
+		## `CantUseItem`, which is the one thing the two jumptables disagree on.
+		_show_pack_result(_use_refusal(&"item_effect_failed", item), false)
+		return
+	field_item_used.emit(request)
+
+
+## One `ItemEffects` entry each, in the order `Gen2WorldPack.FIELD_EFFECTS` names
+## them. A failure is `.Oak`, whatever the effect's own reason was: the source
+## reads one byte and cannot tell them apart either.
+func _resolve_field_item(item: int) -> Dictionary:
+	var effect: StringName = Gen2WorldPack.field_effect(_data, item)
+	var request: Dictionary = {"ok": true, "effect": effect, "item": item}
+	match effect:
+		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
+			var escaped: Dictionary = _world.escape_rope_request()
+			if not bool(escaped.get("ok", false)):
+				return {"ok": false}
+			## `UseDisposableItem`, which only the succeeding half reaches. The
+			## row was chosen out of the pack, so the pocket holds at least one.
+			if _world.inventory != null:
+				_world.inventory.change_item_quantity(item, -1)
+			request["warp"] = escaped
+		Gen2WorldPack.FIELD_EFFECT_ROD:
+			var rod: StringName = Gen2WorldInventory.rod_for_item(item)
+			if not bool(_world.fishing_check(rod).get("ok", false)):
+				return {"ok": false}
+			request["rod"] = rod
+		Gen2WorldPack.FIELD_EFFECT_ITEMFINDER:
+			request["found"] = _world.hidden_item_nearby()
+		Gen2WorldPack.FIELD_EFFECT_COIN_CASE:
+			request["coins"] = _world.state.coins() if _world.state != null else 0
+		Gen2WorldPack.FIELD_EFFECT_SACRED_ASH:
+			if _pack_save == null:
+				return {"ok": false}
+			var used: Dictionary = Gen2WorldPartyHost.use_item(
+				_world, _pack_save, item, -1, _pack_persist
+			)
+			if not bool(used.get("ok", false)):
+				return {"ok": false}
+			request["healed"] = int(used.get("healed", 0))
+		_:
+			return {"ok": false}
+	return request
 
 
 ## `.Party`'s party list. Reads the same save the USE will be applied to, so a
@@ -1124,13 +1184,15 @@ func _use_summary(item: Dictionary, result: Dictionary) -> String:
 func _use_refusal(reason: StringName, item: int) -> String:
 	if _using_registered:
 		return Gen2WorldPack.cant_use_text()
+	## `.Field` reads one byte and says `.Oak` for every way an effect can fail,
+	## so a CLOSE item is answered before the reasons `.Party`'s own effects give.
+	if Gen2WorldPack.field_use_kind(_data, item) == Gen2WorldPack.ITEMMENU_CLOSE:
+		return _pack_text(TEXT_OAK)
 	match reason:
 		&"item_has_no_effect":
 			return "It won't have any effect."
 		&"insufficient_item_quantity":
 			return "You have none of those."
-	if Gen2WorldPack.field_use_kind(_data, item) == Gen2WorldPack.ITEMMENU_CLOSE:
-		return _pack_text(TEXT_OAK)
 	return "Can't use that here: %s" % String(reason)
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5089,10 +5089,9 @@ func dig_request() -> Dictionary:
 		return _dig_failure(&"missing_map")
 	if party_slot_with_move(Gen2WorldFieldMove.MOVE_DIG) < 0:
 		return _dig_failure(&"move_not_known")
-	if current_map.environment not in [ENVIRONMENT_CAVE, ENVIRONMENT_DUNGEON]:
-		return _dig_failure(&"not_in_a_cave")
-	if dig_warp.is_empty():
-		return _dig_failure(&"no_dig_warp")
+	var checked: StringName = _check_can_dig()
+	if checked != &"":
+		return _dig_failure(checked)
 	var warped: Dictionary = warp_to_dig_point()
 	if not bool(warped.get("ok", false)):
 		return _dig_failure(StringName(warped.get("reason", &"no_dig_warp")))
@@ -5104,8 +5103,76 @@ func dig_request() -> Dictionary:
 	}
 
 
+## `EscapeRopeFunction`, which is `EscapeRopeOrDig` with the other type byte: the
+## same `.CheckCanDig` and the same `.DoDig`, without a move to know. The type
+## only picks which text the queued script says and whether `.FailDig` says
+## anything at all, so the refusal here is the item's silent one.
+func escape_rope_request() -> Dictionary:
+	if current_map == null:
+		return _escape_rope_failure(&"missing_map")
+	var checked: StringName = _check_can_dig()
+	if checked != &"":
+		return _escape_rope_failure(checked)
+	var warped: Dictionary = warp_to_dig_point()
+	if not bool(warped.get("ok", false)):
+		return _escape_rope_failure(StringName(warped.get("reason", &"no_dig_warp")))
+	return {
+		"ok": true,
+		"kind": &"escape_rope_requested",
+		"warp": warped,
+	}
+
+
+## `.CheckCanDig`: a cave or a dungeon, and all three bytes of the recorded dig
+## warp non-zero. Empty when it passes, otherwise the reason it did not.
+func _check_can_dig() -> StringName:
+	if current_map.environment not in [ENVIRONMENT_CAVE, ENVIRONMENT_DUNGEON]:
+		return &"not_in_a_cave"
+	if dig_warp.is_empty():
+		return &"no_dig_warp"
+	return &""
+
+
 static func _dig_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"dig_failed", "reason": reason}
+
+
+static func _escape_rope_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"escape_rope_failed", "reason": reason}
+
+
+## `CheckForHiddenItems`, which is the whole of the Itemfinder: a BGEVENT_ITEM
+## whose flag is still clear, inside the screen the player stands in the middle
+## of. The window is the source's own arithmetic on the bottom right corner,
+## `wXCoord + SCREEN_WIDTH / 4` and `wYCoord + SCREEN_HEIGHT / 4`, accepted while
+## the difference stays below half a screen: four cells up and left of the
+## player, four down and five right.
+func hidden_item_nearby() -> bool:
+	if current_map == null:
+		return false
+	for event: Variant in current_map.events.get("bg_events", []):
+		var bg_event: Dictionary = event
+		if int(bg_event.get("type", -1)) != BGEVENT_ITEM:
+			continue
+		var offset: Vector2i = player_cell - Vector2i(
+			int(bg_event.get("x", 0)), int(bg_event.get("y", 0))
+		)
+		if offset.x < -5 or offset.x > 4 or offset.y < -4 or offset.y > 4:
+			continue
+		var record: Dictionary = _hidden_item_record(bg_event)
+		if bool(record.get("ok", false)) and not event_flag_active(int(record["flag"])):
+			return true
+	return false
+
+
+## `.TryFish`'s own refusals, asked without casting: the pack has to know whether
+## `FishFunction` would reach `.FailFish` before it decides to close.
+func fishing_check(rod: StringName) -> Dictionary:
+	if current_map == null or data == null:
+		return {"ok": false, "reason": &"missing_map"}
+	var context: Dictionary = _fishing_context(rod)
+	return {"ok": true} if bool(context.get("ok", false)) \
+		else {"ok": false, "reason": StringName(context.get("reason", &"cannot_fish"))}
 
 
 ## `.DoDig`: the recorded dig warp copied into `wNextWarp` and walked out of, so

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -226,6 +226,40 @@ static func can_hold(data: GameData, item: int) -> bool:
 	return pocket_for(data, item) != TYPE_KEY_ITEM
 
 
+## The `ItemEffects` entries `.Field` reaches whose effect the overworld can run,
+## by the item number `data/items/attributes.asm` gives ITEMMENU_CLOSE. Every
+## other CLOSE item still falls through to `.Oak`; `HANDOFF.md` names what each
+## of those is waiting for.
+const FIELD_EFFECT_NONE: StringName = &""
+const FIELD_EFFECT_ESCAPE_ROPE: StringName = &"escape_rope"
+const FIELD_EFFECT_ROD: StringName = &"rod"
+const FIELD_EFFECT_COIN_CASE: StringName = &"coin_case"
+const FIELD_EFFECT_ITEMFINDER: StringName = &"itemfinder"
+const FIELD_EFFECT_SACRED_ASH: StringName = &"sacred_ash"
+const ITEM_ESCAPE_ROPE: int = 0x13
+const ITEM_COIN_CASE: int = 0x36
+const ITEM_ITEMFINDER: int = 0x37
+const ITEM_SACRED_ASH: int = 0x9C
+const FIELD_EFFECTS: Dictionary = {
+	ITEM_ESCAPE_ROPE: FIELD_EFFECT_ESCAPE_ROPE,
+	ITEM_COIN_CASE: FIELD_EFFECT_COIN_CASE,
+	ITEM_ITEMFINDER: FIELD_EFFECT_ITEMFINDER,
+	Gen2WorldInventory.ITEM_OLD_ROD: FIELD_EFFECT_ROD,
+	Gen2WorldInventory.ITEM_GOOD_ROD: FIELD_EFFECT_ROD,
+	Gen2WorldInventory.ITEM_SUPER_ROD: FIELD_EFFECT_ROD,
+	ITEM_SACRED_ASH: FIELD_EFFECT_SACRED_ASH,
+}
+
+
+## Which `.Field` effect a USE runs, or FIELD_EFFECT_NONE. The item's own menu
+## nibble decides, not the number: a mod repointing an item away from
+## ITEMMENU_CLOSE takes its field effect with it.
+static func field_effect(data: GameData, item: int) -> StringName:
+	if field_use_kind(data, item) != ITEMMENU_CLOSE:
+		return FIELD_EFFECT_NONE
+	return FIELD_EFFECTS.get(item, FIELD_EFFECT_NONE)
+
+
 ## `UseItem`'s jumptable index: which of `.Oak`, `.Current`, `.Party` and
 ## `.Field` a USE reaches. Everything below `ITEMMENU_CURRENT` is `.Oak`.
 static func field_use_kind(data: GameData, item: int) -> int:

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -651,6 +651,8 @@ static func _apply_item_effect(
 			"ok": true, "effect": &"repel",
 			"repel_steps": 100 if item == ITEM_REPEL else (200 if item == ITEM_SUPER_REPEL else 250),
 		}
+	if item == Gen2WorldPack.ITEM_SACRED_ASH:
+		return _apply_sacred_ash(data, save)
 	if party_index < 0 or party_index >= save.party.size():
 		return {"ok": false, "reason": &"party_member_required"}
 	var mon: Gen2SaveMon = save.party[party_index]
@@ -684,6 +686,33 @@ static func _apply_item_effect(
 		"ok": true, "effect": &"party_item", "healed": healed,
 		"status_cleared": cleared,
 	}
+
+
+## `_SacredAsh`: `CheckAnyFaintedMon` first, which skips eggs and stops at the
+## first zero, and then `SacredAshScript`'s `special HealParty` over the whole
+## party rather than over the fainted members alone.
+static func _apply_sacred_ash(data: GameData, save: Gen2SaveData) -> Dictionary:
+	var fainted: bool = false
+	for mon: Gen2SaveMon in save.party:
+		if mon != null and not mon.is_egg and mon.hp <= 0:
+			fainted = true
+			break
+	if not fainted:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	var healed: int = 0
+	for mon: Gen2SaveMon in save.party:
+		if mon == null or mon.is_egg:
+			continue
+		var max_hp: int = _max_hp(data, mon)
+		if max_hp <= 0:
+			return {"ok": false, "reason": &"invalid_party_member"}
+		healed += max_hp - mon.hp
+		mon.hp = max_hp
+		mon.status = Gen2Status.NONE
+		for slot: int in Gen2SaveMon.MAX_MOVES:
+			var move_number: int = int(mon.moves[slot])
+			mon.pp[slot] = int(data.move(move_number).get("pp", 0)) if move_number > 0 else 0
+	return {"ok": true, "effect": &"sacred_ash", "healed": healed}
 
 
 static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -> Dictionary:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1430,6 +1430,33 @@ func preview_wild_encounter() -> void:
 	})
 
 
+## Public screenshot driver for `.Field`: grants an ITEMFINDER on an injected
+## save, opens the pack on the key items and uses it, so what is photographed is
+## the world's own answer with the pack already closed behind it.
+func preview_field_item() -> void:
+	if _world == null or _data == null or _start_menu_host != null:
+		return
+	_injected_save = _embedded_party_save()
+	_world.state.apply_changes({}, {}, {"items": {Gen2WorldPack.ITEM_ITEMFINDER: 1}})
+	_open_start_menu()
+	if _start_menu_host == null:
+		return
+	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
+		_start_menu_host.handle_button(Gen2Button.DOWN)
+	_start_menu_host.handle_button(Gen2Button.A)
+	var pockets: Array = _start_menu_host.get("_pack_pockets")
+	while int(pockets[_start_menu_host.get("_pack_pocket_index")]["pocket"]) \
+		!= Gen2WorldPack.TYPE_KEY_ITEM:
+		_start_menu_host.handle_button(Gen2Button.RIGHT)
+	# The row's submenu, and then its first action, which for a key item is USE.
+	_start_menu_host.handle_button(Gen2Button.A)
+	_start_menu_host.handle_button(Gen2Button.A)
+	if _text_box != null:
+		# The box reveals a tile at a time off wall-clock delta, and a capture
+		# owning its own frames spends none on that.
+		_text_box.finish()
+
+
 ## Public screenshot and scene-test driver for the production fishing path.
 ## The caller can advance the cast and bite pauses with Space, Enter or Z.
 func preview_fishing() -> void:
@@ -1953,6 +1980,7 @@ func _open_start_menu_host(entry: Callable) -> void:
 	add_child(host)
 	host.action_chosen.connect(_on_start_menu_action)
 	host.closed.connect(_on_start_menu_closed)
+	host.field_item_used.connect(_on_field_item_used)
 	_start_menu_host = host
 	_script_prompt = "Start menu open"
 	if entry.is_valid():
@@ -2149,6 +2177,43 @@ func _on_start_menu_closed() -> void:
 		_start_menu_cursor = host.cursor()
 		host.queue_free()
 	_script_prompt = "Start menu closed"
+	_refresh_labels()
+
+
+## `PACKSTATE_QUITRUNSCRIPT`: the pack closes and the script the effect queued
+## runs in the overworld. The texts are the source's own words, host-authored the
+## way the field moves' are, because none of them is a text this project imports.
+## Each drops its `<PLAYER>` for the reason `FOUND_ITEM_TEXT` does: nothing
+## writes `wPlayerName` yet.
+func _on_field_item_used(request: Dictionary) -> void:
+	var host: Gen2StartMenuScreen = _start_menu_host
+	_start_menu_host = null
+	if host != null:
+		_start_menu_cursor = host.cursor()
+		host.queue_free()
+	## `.Field` reaches `ExitAllMenus`, so nothing reopens behind the effect.
+	_reopen_start_menu = false
+	if _world == null:
+		_refresh_labels()
+		return
+	match StringName(request.get("effect", &"")):
+		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
+			_show_field_move_text("Used an\nESCAPE ROPE.")
+			_refresh_after_escape()
+		Gen2WorldPack.FIELD_EFFECT_ROD:
+			var rods: Array[StringName] = _world.available_fishing_rods()
+			select_fishing_rod(rods.find(StringName(request.get("rod", &""))))
+			start_fishing()
+		Gen2WorldPack.FIELD_EFFECT_ITEMFINDER:
+			_show_field_move_text(
+				"Yes! ITEMFINDER\nindicates there's\nan item nearby." \
+				if bool(request.get("found", false)) \
+				else "Nope! ITEMFINDER\nisn't responding."
+			)
+		Gen2WorldPack.FIELD_EFFECT_COIN_CASE:
+			_show_field_move_text("Coins:\n%4d" % int(request.get("coins", 0)))
+		Gen2WorldPack.FIELD_EFFECT_SACRED_ASH:
+			_show_field_move_text("#MON were all\nhealed!")
 	_refresh_labels()
 
 
@@ -2473,6 +2538,12 @@ func _show_field_move_text(text: String) -> void:
 ## SurfStartStep after its waitbutton. A refusal has nothing staged and just
 ## closes.
 func _acknowledge_field_move_text() -> void:
+	## A text longer than the box is several `waitbutton`s, so a press with a page
+	## still behind it spends itself on the box rather than on the move. A
+	## one-page text closes on the first press, which is every other caller.
+	if _text_box != null and _text_box.has_pages_left():
+		_text_box.advance()
+		return
 	_field_move_text = false
 	if _text_box != null:
 		_text_box.visible = false

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -7,6 +7,12 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
 ## `ITEM_REPEL`, whose effect `UseItem` keys on the item number for.
 const REPEL: int = 0x14
+## ITEMMENU_CLOSE rows at their real numbers: two `.Field` runs here and one it
+## does not, which is what says the pack quits on the effect rather than on the
+## menu nibble.
+const ITEMFINDER: int = 0x37
+const CARD_KEY: int = 0x7F
+const OLD_ROD: int = Gen2WorldInventory.ITEM_OLD_ROD
 
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
@@ -50,6 +56,21 @@ func _write_pack_item() -> void:
 				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
 				raw["permissions"] = 0
 				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
+			ITEMFINDER:
+				raw["name"] = "ITEMFINDER"
+				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+			OLD_ROD:
+				raw["name"] = "OLD ROD"
+				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+			CARD_KEY:
+				raw["name"] = "CARD KEY"
+				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 
 
@@ -253,14 +274,90 @@ func test_tossing_the_last_of_a_stack_empties_the_pocket() -> void:
 	assert_eq((host.get("_pack_pockets")[0] as Dictionary)["items"], [])
 
 
-## Opens the pack on the items pocket with the cursor on the granted POTION.
-func _open_pack() -> Gen2StartMenuScreen:
+## `.Field`: `DoItemEffect` runs in the overworld and `PACKSTATE_QUITRUNSCRIPT`
+## closes the pack behind it, so the Itemfinder's answer is in the world's own
+## text box rather than in the pack's result line. A key item is not consumed.
+func test_a_field_item_closes_the_pack_and_answers_in_the_world() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {ITEMFINDER: 1}})
+	var scripts: Dictionary = RomCache.read_json(
+		RomCache.world_scripts_path(Fixture.directory())
+	)
+	scripts["48:61C0"] = [30, 0, 7, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_world_screen._world.current_map.events["bg_events"] = [
+		{"x": 7, "y": 5, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x61C0},
+	]
+	var host: Gen2StartMenuScreen = await _open_pack(Gen2WorldPack.TYPE_KEY_ITEM)
+
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	await get_tree().process_frame
+
+	assert_null(_world_screen._start_menu_host, "the pack quit")
+	assert_true(_world_screen.get("_field_move_text"))
+	assert_eq(_world_screen._world.state.item_quantity(ITEMFINDER), 1)
+
+
+## `UseRod`: the rod the pack chose is the one `FishFunction` casts, and a cast
+## it would refuse is `.FailFish`, which is `.Oak` with the pack still open.
+func test_a_rod_casts_from_the_pack_and_is_refused_away_from_water() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {OLD_ROD: 1}})
+
+	var away: Gen2StartMenuScreen = await _open_pack(Gen2WorldPack.TYPE_KEY_ITEM)
+	_choose_action(away, Gen2WorldPack.ACTION_USE)
+	await get_tree().process_frame
+	assert_not_null(_world_screen._start_menu_host, "no water in front of the player")
+	assert_eq(away.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	away.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+	_world_screen._start_menu_host.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+
+	_world_screen._position_for_fishing_preview()
+	var host: Gen2StartMenuScreen = await _open_pack(Gen2WorldPack.TYPE_KEY_ITEM)
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	await get_tree().process_frame
+
+	assert_null(_world_screen._start_menu_host, "the pack quit")
+	assert_true(_world_screen._world.fishing_busy())
+	assert_eq(
+		_world_screen.get("_selected_rod"), Gen2WorldEncounter.METHOD_OLD_ROD
+	)
+
+
+## An ITEMMENU_CLOSE row whose effect this project has no overworld for leaves
+## `wItemEffectSucceeded` clear, which is `.Oak` with every other refusal and a
+## pack still open behind it.
+func test_a_field_item_with_no_effect_stays_in_the_pack_on_oaks_refusal() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {CARD_KEY: 1}})
+	var host: Gen2StartMenuScreen = await _open_pack(Gen2WorldPack.TYPE_KEY_ITEM)
+
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	await get_tree().process_frame
+
+	assert_not_null(_world_screen._start_menu_host)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(
+		String(host.get("_pack_result")), host._pack_text(Gen2StartMenuScreen.TEXT_OAK)
+	)
+
+
+## Opens the pack on [param pocket], cursor on its first row, which for the
+## default items pocket is the granted POTION.
+func _open_pack(pocket: int = Gen2WorldPack.TYPE_ITEM) -> Gen2StartMenuScreen:
 	_world_screen._open_start_menu()
 	await get_tree().process_frame
 	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
 	_select(host, Gen2WorldStartMenu.ITEM_PACK)
 	host.handle_button(Gen2Button.A)
 	await get_tree().process_frame
+	var guard: int = host.get("_pack_pockets").size()
+	while int(host.get("_pack_pockets")[host.get("_pack_pocket_index")]["pocket"]) != pocket \
+		and guard > 0:
+		host.handle_button(Gen2Button.RIGHT)
+		guard -= 1
 	return host
 
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5629,6 +5629,43 @@ func test_a_hidden_item_with_no_item_byte_fails_instead_of_running_data() -> voi
 	assert_false(world.event_flag_active(22))
 
 
+## `CheckForHiddenItems`, the whole of the Itemfinder: the screen the player is
+## in the middle of, which is four cells up and left and four down and five
+## right, and only while the record's flag is clear.
+func test_the_itemfinder_answers_for_a_hidden_item_inside_the_screen() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:61C0"] = [23, 0, 3, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+	world.current_map.events["bg_events"] = [
+		{"x": 8, "y": 6, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x61C0},
+	]
+	assert_true(world.hidden_item_nearby())
+
+	# The window is asymmetric on x, because the bottom right corner is
+	# `wXCoord + SCREEN_WIDTH / 4` and the difference is compared against half a
+	# screen: the item may sit four cells left of the player and five right.
+	world.player_cell = Vector2i(12, 6)
+	assert_true(world.hidden_item_nearby(), "the item four cells left")
+	world.player_cell = Vector2i(13, 6)
+	assert_false(world.hidden_item_nearby())
+	world.player_cell = Vector2i(3, 6)
+	assert_true(world.hidden_item_nearby(), "the item five cells right")
+	world.player_cell = Vector2i(2, 6)
+	assert_false(world.hidden_item_nearby())
+	world.player_cell = Vector2i(8, 10)
+	assert_true(world.hidden_item_nearby(), "the item four cells up")
+	world.player_cell = Vector2i(8, 11)
+	assert_false(world.hidden_item_nearby())
+
+	# A found item is not a nearby one, which is the same flag check the read is
+	# gated on.
+	world.player_cell = Vector2i(8, 7)
+	world.set_event_flag(23)
+	assert_false(world.hidden_item_nearby())
+
+
 func _item_name(number: int) -> String:
 	return GameData.open_directory(_directory).item_name(number)
 

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1509,6 +1509,29 @@ func test_dig_is_refused_outside_a_cave_and_with_no_warp_recorded() -> void:
 	assert_eq(StringName(unknowing.dig_request()["reason"]), &"move_not_known")
 
 
+func test_an_escape_rope_takes_the_same_warp_dig_does_and_knows_no_move() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.player_cell = ESCAPE_CAVE_DOOR
+	world.try_warp()
+	world.player_cell = Vector2i(4, 4)
+	# `EscapeRopeOrDig` is one routine: the item half asks for no party move, so
+	# a party that knows nothing still gets out.
+	world.set_party_summary(1, false, [1] as Array[int], [[]], ["MON"], [false])
+
+	var escaped: Dictionary = world.escape_rope_request()
+	assert_true(bool(escaped.get("ok", false)), String(escaped.get("reason", "")))
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
+	assert_eq(world.player_cell, ESCAPE_CAVE_DOOR)
+
+
+func test_an_escape_rope_shares_dig_s_two_refusals() -> void:
+	var outdoors: Gen2WorldAPI = _escape_world()
+	assert_eq(StringName(outdoors.escape_rope_request()["reason"]), &"not_in_a_cave")
+
+	var in_a_cave: Gen2WorldAPI = _escape_world(ESCAPE_CAVE, Vector2i(4, 4))
+	assert_eq(StringName(in_a_cave.escape_rope_request()["reason"]), &"no_dig_warp")
+
+
 func test_teleport_returns_to_the_last_pokemon_centre_from_outdoors() -> void:
 	var world: Gen2WorldAPI = _escape_world()
 	world.player_cell = ESCAPE_CENTRE_DOOR

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -209,6 +209,33 @@ func test_only_a_selectable_item_can_be_registered() -> void:
 	assert_false(Gen2WorldPack.can_select(null, ITEM_UNCLASSIFIED))
 
 
+## `ItemEffects`' entries for the ITEMMENU_CLOSE items the overworld can run.
+## The menu nibble decides first, so a row moved off ITEMMENU_CLOSE takes its
+## field effect with it and a CLOSE row with no entry stays on `.Oak`.
+func test_the_field_effects_are_the_close_items_the_overworld_can_run() -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		if int(raw.get("number", 0)) in Gen2WorldPack.FIELD_EFFECTS:
+			raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	var data: GameData = GameData.open_directory(Fixture.directory())
+
+	assert_eq(
+		Gen2WorldPack.field_effect(data, 0x13), Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE
+	)
+	for rod: int in [0x3A, 0x3B, 0x3D]:
+		assert_eq(Gen2WorldPack.field_effect(data, rod), Gen2WorldPack.FIELD_EFFECT_ROD)
+	assert_eq(Gen2WorldPack.field_effect(data, 0x36), Gen2WorldPack.FIELD_EFFECT_COIN_CASE)
+	assert_eq(Gen2WorldPack.field_effect(data, 0x37), Gen2WorldPack.FIELD_EFFECT_ITEMFINDER)
+	assert_eq(Gen2WorldPack.field_effect(data, 0x9C), Gen2WorldPack.FIELD_EFFECT_SACRED_ASH)
+
+	# The Bicycle is ITEMMENU_CLOSE with no effect built, so it is `.Oak`, and so
+	# is a repointed Escape Rope.
+	assert_eq(Gen2WorldPack.field_effect(_data, ITEM_BICYCLE), Gen2WorldPack.FIELD_EFFECT_NONE)
+	assert_eq(Gen2WorldPack.field_effect(_data, 0x13), Gen2WorldPack.FIELD_EFFECT_NONE)
+	assert_eq(Gen2WorldPack.field_effect(null, 0x13), Gen2WorldPack.FIELD_EFFECT_NONE)
+
+
 func test_an_unknown_item_has_no_submenu() -> void:
 	assert_eq(Gen2WorldPack.item_submenu(_data, 250), [])
 	assert_eq(Gen2WorldPack.item_submenu(null, ITEM_POTION), [])

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -151,6 +151,37 @@ func test_item_with_no_effect_is_not_consumed() -> void:
 	assert_eq(_world.state.item_quantity(0x09), before_quantity)
 
 
+## `_SacredAsh`: `CheckAnyFaintedMon` first, and then `SacredAshScript`'s
+## `special HealParty`, which is the whole party rather than the fainted half.
+func test_sacred_ash_heals_the_whole_party_once_one_member_has_fainted() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x9C: 1}})
+	_save.party[0].hp = 0
+	_save.party[1].hp = 1
+	_save.party[1].status = Gen2Status.POISON
+	_save.party[1].pp[0] = 0
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x9C, -1, false)
+
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(result["effect"], &"sacred_ash")
+	assert_eq(_world.state.item_quantity(0x9C), 0)
+	for index: int in 2:
+		var mon: Gen2SaveMon = _save.party[index]
+		assert_eq(mon.hp, Gen2SaveBattleAdapter.to_battle_mon(_data, mon).max_hp())
+		assert_eq(mon.status, Gen2Status.NONE)
+	assert_eq(
+		_save.party[1].pp[0], int(_data.move(int(_save.party[1].moves[0])).get("pp", 0))
+	)
+
+
+func test_sacred_ash_is_refused_and_kept_while_nothing_has_fainted() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x9C: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x9C, -1, false)
+	assert_false(result["ok"])
+	assert_eq(StringName(result["reason"]), &"item_has_no_effect")
+	assert_eq(_world.state.item_quantity(0x9C), 1)
+
+
 func test_moon_stone_evolves_a_party_member_and_consumes_the_item() -> void:
 	var source: Gen2BattleMon = Gen2BattleMon.create(_data, 1, 5)
 	source.hp = maxi(source.max_hp() - 3, 1)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -12,10 +12,11 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y]
 ##
-## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree) or
-## `cut` (`OWCutAnimation`'s two halves and the jump shadow). The two numbers are
-## the cell the player stands on, which is how the grass a standing object is
-## drawn behind is photographed.
+## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
+## `cut` (`OWCutAnimation`'s two halves and the jump shadow) or `field_item` (the
+## pack's own USE on the Itemfinder, which closes the pack over the world's
+## answer). The two numbers are the cell the player stands on, which is how the
+## grass a standing object is drawn behind is photographed.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Hardware frames spent after the sprites are staged. Two puts the grass rustle
@@ -103,7 +104,10 @@ func _process(_delta: float) -> bool:
 		return false
 	_frames += 1
 	if _frames == 2:
-		_screen.preview_effect_sprites(_kind)
+		if _kind == &"field_item":
+			_screen.preview_field_item()
+		else:
+			_screen.preview_effect_sprites(_kind)
 		for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
 			_screen.advance_frame()
 	if _frames < 18:


### PR DESCRIPTION
`UseItem`'s `.Field` ran no effect at all: every `ITEMMENU_CLOSE` row fell through to `.Oak`'s refusal. It now runs the effect and quits the pack on `wItemEffectSucceeded`, which is `PACKSTATE_QUITRUNSCRIPT`.

| Item | Source |
|---|---|
| Escape Rope | `EscapeRopeOrDig` with the item's type byte: `.CheckCanDig` and `.DoDig` shared with Dig, consumed on success only |
| Old, Good and Super Rod | `FishFunction`, cast through the world screen's own fishing; `.TryFish`'s refusals asked before the pack closes |
| Itemfinder | `CheckForHiddenItems`: an unfound `BGEVENT_ITEM` inside the screen the player stands in the middle of |
| Coin Case | `_CoinCaseCountText`'s count |
| Sacred Ash | `_SacredAsh`'s `CheckAnyFaintedMon`, then `SacredAshScript`'s `special HealParty` over the whole party |

`UseRegisteredItem`'s `.Overworld` reaches the same effects through the same seam and keeps its own `CantUseItem` refusal where the pack says `.Oak`.

Met on the way: a field-move text longer than the box lost every page after the first, and a failed CLOSE effect answered with `.Party`'s reason instead of `.Oak`. Both fixed here.

GUT 2,915 over 148 scripts green (2,574 unit, 341 integration), `validate.gd -- all` 45 topics pass, `replay_world.gd` 27 routes 0 failures, and the story walk still reaches Red on all three profiles (291/291/294 steps, 16 badges).