### PR TITLE
The bag inside a battle, and the bicycle

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -480,8 +480,8 @@ A battle renderer has two optional methods of its own:
 the screen claims what it needs and offers the rest, so a renderer can steer a
 camera and can never take a gameplay press. A `Gen2Button` is routed to whatever
 owns the screen before this is reached, on both sides, so the text box, the
-forget-move list and ball selection each take their press first and what arrives
-here is pointer and stick motion. Ball selection and the forget prompt also
+forget-move list, the pack's own rows and ball selection each take their press
+first and what arrives here is pointer and stick motion. Those three also
 withhold everything else while they are up, because a press there means
 something by itself. A draining bar, the opening slide and a move animation do
 not: none of them reads input, and a camera that stalls whenever a bar drains is

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -421,6 +421,32 @@ const ACTION_RUN: StringName = &"run"
 ## speeds say. Only the enemy ever uses one; the player's pack is the overworld's.
 const ACTION_ITEM: StringName = &"item"
 
+## The battle half of `ItemEffects` that is not data in the cache already: the
+## two revives, the four PP restorers and the doll, at their cartridge numbers.
+## Everything else a party item does comes off the item's own `status_mask` and
+## `heal_amount` rows.
+const ITEM_POKE_DOLL: int = 0x25
+const ITEM_REVIVE: int = 0x27
+const ITEM_MAX_REVIVE: int = 0x28
+const ITEM_ETHER: int = 0x3F
+const ITEM_MAX_ETHER: int = 0x40
+const ITEM_ELIXER: int = 0x41
+const ITEM_MAX_ELIXER: int = 0x15
+const ITEM_MYSTERYBERRY: int = 0x96
+const REVIVE_ITEMS: Array[int] = [ITEM_REVIVE, ITEM_MAX_REVIVE]
+const PP_ITEMS: Array[int] = [
+	ITEM_ETHER, ITEM_MAX_ETHER, ITEM_ELIXER, ITEM_MAX_ELIXER, ITEM_MYSTERYBERRY,
+]
+## The three of them that fill one slot, which is what `.loop` asks about; the
+## two Elixers fill every slot and ask nothing.
+const SLOT_PP_ITEMS: Array[int] = [ITEM_ETHER, ITEM_MAX_ETHER, ITEM_MYSTERYBERRY]
+## `RestorePPEffect`'s own amounts: the Max pair fill the slot, and the other
+## three add five (`MYSTERYBERRY` and `ETHER` share it).
+const PP_ITEM_AMOUNTS: Dictionary = {
+	ITEM_ETHER: 10, ITEM_ELIXER: 10, ITEM_MYSTERYBERRY: 5,
+	ITEM_MAX_ETHER: 0, ITEM_MAX_ELIXER: 0,
+}
+
 ## `wBattleType`. Only the values `TryToRunAwayFromBattle` branches on are named;
 ## everything else reaches the ordinary speed check.
 const BATTLETYPE_NORMAL: int = 0
@@ -1466,7 +1492,11 @@ func _run_turn(events: Array) -> Array:
 				return events
 			events.append_array(send_out(side, int(action.get("index", -1))))
 		elif _is_item(action):
-			_use_trainer_item(side, int(action.get("item", 0)), events)
+			## The player's own item was spent in the menu, the way
+			## `BattleMenu_Pack` spends it before the turn resolves; only the
+			## enemy reaches into its bag inside the turn.
+			if side == ENEMY:
+				_use_trainer_item(side, int(action.get("item", 0)), events)
 		elif moving and side != _pursuit_spent:
 			var slot: int = effective_slot(side, int(action.get("slot", 0)))
 			_act(side, slot, move_for(side, slot), events)
@@ -2204,6 +2234,144 @@ func _use_trainer_item(side: int, item: int, events: Array) -> void:
 	})
 
 
+## `DoItemEffect` with `wBattleMode` set, which is what the pack's own USE runs
+## inside a battle. The player's item is applied here rather than in the turn
+## loop, exactly as the cartridge applies it in the menu and only then spends the
+## turn as `BATTLEPLAYERACTION_USEITEM`.
+##
+## [param target_index] is the party member `UseItem_SelectMon` picked, for the
+## ITEMMENU_PARTY items that ask; [param move_slot] is `RestorePPEffect`'s own
+## question. A refusal is every branch that leaves `wItemEffectSucceeded` clear,
+## and none of them spends the item or the turn.
+func use_bag_item(item: int, target_index: int = -1, move_slot: int = -1) -> Dictionary:
+	if data == null or is_over():
+		return _item_failure(&"battle_not_running")
+	var definition: Dictionary = data.item(item)
+	if definition.is_empty():
+		return _item_failure(&"unknown_item")
+	if item == ITEM_POKE_DOLL:
+		## `PokeDollEffect`: `wForcedSwitch` and a DRAW, which is
+		## [method force_out] with nobody blown out by a move.
+		if is_trainer_battle:
+			return _item_failure(&"item_has_no_effect")
+		force_out(PLAYER)
+		return {"ok": true, "kind": &"fled", "item": item}
+	if Gen2AIItems.X_STATS.has(item) or Gen2AIItems.X_SUBSTATUSES.has(item):
+		var applied: Dictionary = _apply_active_item(mon(PLAYER), item)
+		if not bool(applied.get("ok", false)):
+			return _item_failure(StringName(applied.get("reason", &"item_has_no_effect")))
+		return {"ok": true, "kind": &"active_item", "item": item, "effect": applied}
+	var target: Gen2BattleMon = party(PLAYER).at(target_index)
+	if target == null:
+		return _item_failure(&"party_member_required")
+	var result: Dictionary = _apply_party_item(
+		target, item, definition, move_slot, target_index == party(PLAYER).active
+	)
+	if not bool(result.get("ok", false)):
+		return _item_failure(StringName(result.get("reason", &"item_has_no_effect")))
+	## `RevivePokemon`'s own `wBattleParticipantsNotFainted` write: a revived
+	## Pokemon that had already taken part shares the experience again.
+	if bool(result.get("revived", false)):
+		(_participants[PLAYER] as Dictionary)[target_index] = true
+	return {
+		"ok": true, "kind": &"party_item", "item": item,
+		"target": target_index, "effect": result,
+	}
+
+
+## `XItemEffect`, `GuardSpecEffect` and `DireHitEffect`, which act on whoever is
+## out rather than on a party member. Each refuses when there is nothing to do:
+## a stage already at the cap, or a flag already set
+## (`WontHaveAnyEffect_NotUsedMessage`).
+func _apply_active_item(user: Gen2BattleMon, item: int) -> Dictionary:
+	if user == null or user.is_fainted():
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	if Gen2AIItems.X_SUBSTATUSES.has(item):
+		var flag: int = int(Gen2AIItems.X_SUBSTATUSES[item])
+		if Gen2Substatus.has(user.substatus, flag):
+			return {"ok": false, "reason": &"item_has_no_effect"}
+		user.substatus |= flag
+		return {"ok": true, "substatus": flag}
+	var stat: String = String(Gen2AIItems.X_STATS[item])
+	if user.stage(stat) >= Gen2Stats.MAX_STAGE:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	user.change_stage(stat, 1)
+	return {"ok": true, "stat": stat, "stages": 1}
+
+
+## The ITEMMENU_PARTY half of the table, which `UseItem_SelectMon` has already
+## chosen a target for. Every branch is the source's own refusal order: a fainted
+## target takes only a revive, a revive takes only a fainted one, and an item
+## that would change nothing is `WontHaveAnyEffect_NotUsedMessage`.
+##
+## [param active] is whether the target is the Pokemon that is out, which decides
+## the two things a benched member cannot have: `IsItemUsedOnConfusedMon`'s
+## confusion cure, and Full Restore's own.
+func _apply_party_item(
+	target: Gen2BattleMon, item: int, definition: Dictionary,
+	move_slot: int, active: bool
+) -> Dictionary:
+	if item in REVIVE_ITEMS:
+		if not target.is_fainted():
+			return {"ok": false, "reason": &"item_has_no_effect"}
+		target.hp = target.max_hp() if item == ITEM_MAX_REVIVE else maxi(target.max_hp() / 2, 1)
+		return {"ok": true, "revived": true, "healed": target.hp}
+	if target.is_fainted():
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	if item in PP_ITEMS:
+		return _restore_pp(target, item, move_slot)
+	var healed: int = 0
+	var heal_amount: int = int(definition.get("heal_amount", 0))
+	if heal_amount > 0:
+		healed = target.heal(
+			target.max_hp() if heal_amount >= Gen2Stats.MAX_STAT_VALUE else heal_amount
+		)
+	## `UseStatusHealer`: the mask decides, and only a `%11111111` one reaches
+	## `IsItemUsedOnConfusedMon`, which needs the target to be the one out.
+	var mask: int = int(definition.get("status_mask", 0))
+	var cured: int = target.status & mask
+	if cured != 0:
+		target.status = Gen2Status.NONE
+		target.toxic_counter = 0
+	var unconfused: bool = mask == 0xFF and active \
+		and Gen2Substatus.has(target.substatus, Gen2Substatus.CONFUSED)
+	if unconfused:
+		target.substatus &= ~Gen2Substatus.CONFUSED
+		target.confusion_turns = 0
+	if healed <= 0 and cured == 0 and not unconfused:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	return {
+		"ok": true, "healed": healed, "status_cleared": cured, "unconfused": unconfused,
+	}
+
+
+## `RestorePPEffect`: the Elixers fill every slot and the Ethers one, which is
+## the slot `.loop` asks for. Nothing is spent on a moveset already full.
+func _restore_pp(target: Gen2BattleMon, item: int, move_slot: int) -> Dictionary:
+	var amount: int = PP_ITEM_AMOUNTS.get(item, 0)
+	var slots: Array[int] = []
+	if item in [ITEM_ELIXER, ITEM_MAX_ELIXER]:
+		for slot: int in target.moves.size():
+			slots.append(slot)
+	elif move_slot >= 0 and move_slot < target.moves.size():
+		slots.append(move_slot)
+	var restored: int = 0
+	for slot: int in slots:
+		if int(target.moves[slot]) <= 0:
+			continue
+		var full: int = int(data.move(int(target.moves[slot])).get("pp", 0))
+		var target_pp: int = full if amount <= 0 else mini(full, target.pp_left(slot) + amount)
+		restored += maxi(0, target_pp - target.pp_left(slot))
+		target.pp[slot] = target_pp
+	if restored <= 0:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	return {"ok": true, "pp_restored": restored}
+
+
+static func _item_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"item_failed", "reason": reason}
+
+
 ## `IsAnyMonHoldingExpShare`: every living party index carrying one, in party
 ## order. A fainted holder is skipped and does not count towards the split, the
 ## same test the routine makes before it looks at the item at all.
@@ -2371,7 +2539,8 @@ func order(chosen: Dictionary, actions: Dictionary = {}) -> Array:
 	# cartridge spends the turn as BATTLEPLAYERACTION_USEITEM, which resolves at
 	# once and leaves the enemy's move behind it.
 	var player_switching: bool = _is_switch(actions.get(PLAYER, {})) \
-		or _is_run(actions.get(PLAYER, {}))
+		or _is_run(actions.get(PLAYER, {})) \
+		or _is_item(actions.get(PLAYER, {}))
 	# An enemy item is `wEnemyGoesFirst` for the same reason an enemy switch is,
 	# and both lose to a player switch, which was settled at menu time.
 	var enemy_switching: bool = _is_switch(actions.get(ENEMY, {})) \

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3,6 +3,9 @@ extends Control
 
 signal battle_finished(result: Dictionary)
 signal capture_requested(ball: int)
+## A bag item spent inside the battle, so the world takes one off the pocket.
+## `target` is the party index an ITEMMENU_PARTY item was used on, or -1.
+signal item_used(item: int, target: int)
 ## `LoadEnemyMon`'s own `wPokedexSeen` write (engine/battle/core.asm:6407). Every
 ## enemy sent out sets it, a trainer's party as much as a wild, so this is the
 ## event rather than the battle result. The host owns the flag, since the battle
@@ -191,6 +194,20 @@ var _time_of_day: int = Gen2WorldPalette.TIME_DAY
 ## than a white field. Null unless the caller supplied one; see
 ## [method set_world_context].
 var _world_context: Gen2BattleWorldContext = null
+## `BattlePack`'s own rows and cursor, and the item held while
+## `UseItem_SelectMon` picks a target for it.
+var _pack_rows: Array[int] = []
+var _pack_quantities: Dictionary = {}
+var _pack_index: int = 0
+var _pack_selecting: bool = false
+var _pack_item: int = 0
+## `RestorePPEffect`'s own `.loop`, which asks which move before it restores
+## anything. Only the three items that fill one slot ever open it.
+var _pack_move_slots: Array = []
+var _pack_move_index: int = 0
+var _pack_move_target: int = -1
+var _pack_move_selecting: bool = false
+
 var _capture_balls: Array[int] = []
 var _capture_quantities: Dictionary = {}
 var _capture_ball_index: int = 0
@@ -1329,6 +1346,153 @@ func world_context() -> Gen2BattleWorldContext:
 	return _world_context
 
 
+## `BattlePack`, which is the same pack with `wBattleMode` set: the bag rows the
+## world hands over, already filtered to what `CheckItemMenu`'s battle nibble
+## says can be used at all. Balls stay in the list and reach the ball selector,
+## since that is where the throw is drawn.
+func set_battle_pack(items: Array, quantities: Dictionary = {}) -> void:
+	_pack_rows.clear()
+	for raw_item: Variant in items:
+		var item: int = int(raw_item)
+		if item > 0 and not _pack_rows.has(item):
+			_pack_rows.append(item)
+	_pack_quantities = quantities.duplicate()
+	if _pack_index >= _pack_rows.size():
+		_pack_index = 0
+
+
+func battle_pack_items() -> Array[int]:
+	return _pack_rows.duplicate()
+
+
+## `BattleMenu_Pack`'s own list. A row is chosen with left and right, used with A
+## and left with B, the way ball selection already is.
+func open_battle_pack() -> Dictionary:
+	if _battle == null or _battle.is_over() or not _pending.is_empty():
+		return {"ok": false, "reason": &"battle_events_pending"}
+	if _pack_rows.is_empty():
+		show_message("You have no items to use!")
+		return {"ok": false, "reason": &"no_usable_items"}
+	_pack_selecting = true
+	_pack_index = mini(_pack_index, _pack_rows.size() - 1)
+	_show_pack_selection()
+	return {"ok": true, "item": selected_pack_item()}
+
+
+func selected_pack_item() -> int:
+	if _pack_rows.is_empty():
+		return 0
+	return int(_pack_rows[posmod(_pack_index, _pack_rows.size())])
+
+
+func select_pack_row(index: int) -> Dictionary:
+	if not _pack_selecting or _pack_rows.is_empty():
+		return {"ok": false, "reason": &"pack_not_open"}
+	_pack_index = posmod(index, _pack_rows.size())
+	_show_pack_selection()
+	return {"ok": true, "item": selected_pack_item()}
+
+
+func _show_pack_selection() -> void:
+	var item: int = selected_pack_item()
+	show_message("Use %s x%d. Left and right: choose, A: use, B: back" % [
+		_item_name(item), int(_pack_quantities.get(item, 1)),
+	])
+
+
+func close_battle_pack() -> void:
+	_pack_selecting = false
+	_pack_item = 0
+	_open_battle_menu()
+
+
+## `UseItem`'s jumptable inside a battle. A ball reaches the throw the screen
+## already draws, an ITEMMENU_PARTY row asks `UseItem_SelectMon` for a target
+## first, and everything else is applied to whoever is out.
+func use_selected_pack_item() -> Dictionary:
+	if not _pack_selecting or _battle == null:
+		return {"ok": false, "reason": &"pack_not_open"}
+	var item: int = selected_pack_item()
+	if _data != null and int(_data.item(item).get("pocket", 0)) == Gen2WorldPack.TYPE_BALL:
+		_pack_selecting = false
+		if not _is_wild_battle():
+			## `PokeBallEffect`'s `UseBallInTrainerBattle`, which spends neither
+			## the ball nor the turn.
+			show_message("The trainer blocked the BALL!
+Don't be a thief!")
+			return {"ok": false, "reason": &"ball_in_trainer_battle"}
+		var opened: Dictionary = begin_capture()
+		if bool(opened.get("ok", false)):
+			select_capture_ball(_capture_balls.find(item))
+		return opened
+	if _data != null \
+		and int(_data.item(item).get("battle_menu", 0)) == Gen2WorldPack.ITEMMENU_PARTY:
+		_pack_selecting = false
+		_pack_item = item
+		_open_switch_pick(&"item")
+		return {"ok": true, "status": &"choosing_target", "item": item}
+	return _use_pack_item(item, -1)
+
+
+## `RestorePPEffect`'s question: which of the target's moves the Ether goes on.
+## The Elixers fill every slot and never open this.
+func _open_pack_move(item: int, target: int) -> void:
+	var mon: Gen2BattleMon = _battle.party(Gen2Battle.PLAYER).at(target)
+	_pack_move_slots = []
+	if mon != null:
+		for slot: int in mon.moves.size():
+			if int(mon.moves[slot]) > 0:
+				_pack_move_slots.append(slot)
+	if _pack_move_slots.is_empty():
+		_use_pack_item(item, target)
+		return
+	_pack_item = item
+	_pack_move_target = target
+	_pack_move_index = 0
+	_pack_move_selecting = true
+	_show_pack_move_selection()
+
+
+func _show_pack_move_selection() -> void:
+	var mon: Gen2BattleMon = _battle.party(Gen2Battle.PLAYER).at(_pack_move_target)
+	var slot: int = int(_pack_move_slots[_pack_move_index])
+	var move: Dictionary = _data.move(int(mon.moves[slot])) if _data != null else {}
+	show_message("Restore %s %d PP. Left and right: choose, A: use, B: back" % [
+		String(move.get("name", "MOVE")), mon.pp_left(slot),
+	])
+
+
+func _close_pack_move() -> void:
+	_pack_move_selecting = false
+	_pack_move_slots = []
+	_pack_move_target = -1
+
+
+## The chosen row, applied and then paid for with the turn:
+## `BATTLEPLAYERACTION_USEITEM` leaves the enemy's own move behind it.
+func _use_pack_item(item: int, target: int, move_slot: int = -1) -> Dictionary:
+	_pack_selecting = false
+	_pack_item = 0
+	_close_pack_move()
+	var used: Dictionary = _battle.use_bag_item(item, target, move_slot)
+	if not bool(used.get("ok", false)):
+		## `.Field`'s battle twin: every refused effect is one line and the pack
+		## again, so nothing is spent and the turn is still the player's.
+		show_message("It won't have any effect.")
+		_pack_selecting = true
+		return used
+	item_used.emit(item, target)
+	## `ItemUsedText`, less its `<PLAYER>` the way every other host-authored line
+	## here drops one.
+	show_message("Used the %s." % _item_name(item))
+	if _battle.is_over():
+		## `PokeDollEffect`'s `wForcedSwitch`: the battle is already over, so no
+		## turn is taken and the terminal text is what follows this line.
+		return used
+	_pending = _battle.take_actions(Gen2Battle.use_item(item), _enemy_action())
+	return used
+
+
 ## Supplies the wild battle with the supported balls currently owned by the
 ## overworld. The battle scene never reads or mutates world inventory itself.
 func set_capture_balls(balls: Array, quantities: Dictionary = {}) -> void:
@@ -2091,6 +2255,11 @@ func _choose_battle_menu() -> void:
 				if bool(begin_capture().get("ok", false)):
 					throw_capture_ball()
 				return
+			if not _pack_rows.is_empty():
+				open_battle_pack()
+				return
+			## No bag was handed over, which is every battle outside the world
+			## host: a wild one still reaches the throw the screen owns.
 			if _is_wild_battle():
 				begin_capture()
 				return
@@ -2199,7 +2368,7 @@ func _open_switch_pick(reason: StringName) -> void:
 	## two the player opened themselves: `OfferSwitch`'s YES and the battle
 	## menu's own PKMN, both of which can be backed out of.
 	_switch_menu = Gen2BattleSwitchMenu.for_party(
-		_battle.party(Gen2Battle.PLAYER), reason not in [&"offer", &"player"]
+		_battle.party(Gen2Battle.PLAYER), reason not in [&"offer", &"player", &"item"]
 	)
 	_switch_offer = null
 	_switch_stage = &"pick"
@@ -2343,6 +2512,16 @@ func _answer_switch_pick(button: int) -> void:
 			_switch_menu.move(1)
 			_refresh_menu_layer()
 		Gen2Button.A:
+			## `UseItem_SelectMon` makes neither of `PickPartyMonInBattle`'s two
+			## checks: a fainted member is exactly what a Revive wants, and the
+			## one already out is what a potion usually goes on. The item's own
+			## effect is what refuses.
+			if _switch_reason == &"item" and not _switch_menu.is_cancel(_switch_menu.cursor):
+				_resolve_switch({
+					"result": Gen2BattleSwitchMenu.CHOSEN,
+					"index": int(_switch_menu.rows[_switch_menu.cursor].get("index", -1)),
+				})
+				return
 			_resolve_switch(_switch_menu.confirm())
 		Gen2Button.B:
 			_resolve_switch(_switch_menu.cancel())
@@ -2355,6 +2534,12 @@ func _resolve_switch(answer: Dictionary) -> void:
 			_commit_switch(int(answer.get("index", -1)))
 		Gen2BattleSwitchMenu.CANCELLED:
 			_play_anim_sound(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+			## A target list backed out of leaves the item where it was and
+			## reopens the pack it was chosen from.
+			if _switch_reason == &"item":
+				_close_switch()
+				open_battle_pack()
+				return
 			## `BattleMenuPKMN_Loop`'s `.Cancel` is a `jp BattleMenu`: the list
 			## the player opened themselves goes back to the menu it came from.
 			if _switch_reason == &"player":
@@ -2375,6 +2560,14 @@ func _commit_switch(index: int) -> void:
 	var reason: StringName = _switch_reason
 	_close_switch()
 	match reason:
+		&"item":
+			## `StatusHealer_Jumptable`'s way back: the pack is where a used item
+			## leaves the player, and where a cancelled one does too.
+			if _pack_item in Gen2Battle.SLOT_PP_ITEMS:
+				_open_pack_move(_pack_item, index)
+				return
+			_use_pack_item(_pack_item, index)
+			return
 		&"baton_pass":
 			_pending = _battle.pass_to(index)
 		&"replace":
@@ -3223,7 +3416,8 @@ func _unhandled_input(event: InputEvent) -> void:
 ## [method _handle_button], which runs first and never reaches here.
 func _renderer_input_free() -> bool:
 	return is_ready() and _forget_stage == &"" and _switch_stage == &"" \
-		and _menu_stage == &"" and not _capture_selecting
+		and _menu_stage == &"" and not _capture_selecting and not _pack_selecting \
+		and not _pack_move_selecting
 
 
 func _handle_button(button: int) -> bool:
@@ -3237,6 +3431,39 @@ func _handle_button(button: int) -> bool:
 
 	if _menu_stage != &"":
 		_answer_menu(button)
+		return true
+
+	if _pack_move_selecting:
+		match button:
+			Gen2Button.RIGHT:
+				_pack_move_index = posmod(_pack_move_index + 1, _pack_move_slots.size())
+				_show_pack_move_selection()
+			Gen2Button.LEFT:
+				_pack_move_index = posmod(_pack_move_index - 1, _pack_move_slots.size())
+				_show_pack_move_selection()
+			Gen2Button.A:
+				_use_pack_item(
+					_pack_item, _pack_move_target, int(_pack_move_slots[_pack_move_index])
+				)
+			Gen2Button.B:
+				_close_pack_move()
+				open_battle_pack()
+			_:
+				return false
+		return true
+
+	if _pack_selecting:
+		match button:
+			Gen2Button.RIGHT:
+				select_pack_row(_pack_index + 1)
+			Gen2Button.LEFT:
+				select_pack_row(_pack_index - 1)
+			Gen2Button.A:
+				use_selected_pack_item()
+			Gen2Button.B:
+				close_battle_pack()
+			_:
+				return false
 		return true
 
 	if _capture_selecting:

--- a/game/save/save_validator.gd
+++ b/game/save/save_validator.gd
@@ -73,7 +73,9 @@ static func _validate_world(world: Gen2WorldSnapshot, data: GameData) -> Diction
 	if world.player_facing < Gen2WorldSprite.FACING_DOWN \
 		or world.player_facing > Gen2WorldSprite.FACING_RIGHT:
 		return _failure("the saved player facing is invalid")
-	if world.movement_mode not in [Gen2WorldAPI.MOVEMENT_WALK, Gen2WorldAPI.MOVEMENT_SURF]:
+	if world.movement_mode not in [
+		Gen2WorldAPI.MOVEMENT_WALK, Gen2WorldAPI.MOVEMENT_SURF, Gen2WorldAPI.MOVEMENT_BIKE,
+	]:
 		return _failure("the saved movement mode is invalid")
 	if world.world_day < 0 or world.world_day >= Gen2WorldClock.DAYS_PER_WEEK \
 		or world.world_hour < 0 or world.world_hour >= Gen2WorldClock.HOURS_PER_DAY \

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -876,6 +876,11 @@ func _resolve_field_item(item: int) -> Dictionary:
 	var effect: StringName = Gen2WorldPack.field_effect(_data, item)
 	var request: Dictionary = {"ok": true, "effect": effect, "item": item}
 	match effect:
+		Gen2WorldPack.FIELD_EFFECT_BICYCLE:
+			var ridden: Dictionary = _world.bike_request()
+			if not bool(ridden.get("ok", false)):
+				return {"ok": false}
+			request["bike"] = ridden
 		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
 			var escaped: Dictionary = _world.escape_rope_request()
 			if not bool(escaped.get("ok", false)):

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -16,6 +16,7 @@ const CELL_PIXELS: int = Gen2Tiles.TILE_WIDTH * RomLayout.MAP_BLOCK_CELL_WIDTH
 const PLAYER_VIEW_CELL: Vector2i = Vector2i(4, 4)
 const MOVEMENT_WALK: StringName = &"walk"
 const MOVEMENT_SURF: StringName = &"surf"
+const MOVEMENT_BIKE: StringName = &"bike"
 ## constants/sprite_constants.asm's first real id, and what GetMonSprite answers
 ## for a variable sprite no script has assigned yet.
 const SPRITE_CHRIS: int = 1
@@ -284,7 +285,7 @@ static func open_snapshot(game_data: GameData, world_snapshot: Gen2WorldSnapshot
 	if world_snapshot.player_facing < Gen2WorldSprite.FACING_DOWN \
 		or world_snapshot.player_facing > Gen2WorldSprite.FACING_RIGHT:
 		return null
-	if world_snapshot.movement_mode not in [MOVEMENT_WALK, MOVEMENT_SURF]:
+	if world_snapshot.movement_mode not in [MOVEMENT_WALK, MOVEMENT_SURF, MOVEMENT_BIKE]:
 		return null
 	if world_snapshot.world_day < 0 or world_snapshot.world_day >= Gen2WorldClock.DAYS_PER_WEEK \
 		or world_snapshot.world_hour < 0 or world_snapshot.world_hour >= Gen2WorldClock.HOURS_PER_DAY \
@@ -351,6 +352,10 @@ func landmark() -> int:
 func map_music_track() -> int:
 	if movement_mode == MOVEMENT_SURF:
 		return Gen2WorldFieldMove.MUSIC_SURF
+	## `BikeFunction` writes `wMapMusic` itself rather than going through
+	## `SpecialMapMusic`, so the track is the bike's until the player gets off.
+	if movement_mode == MOVEMENT_BIKE:
+		return Gen2WorldFieldMove.MUSIC_BICYCLE
 	return current_map.music if current_map != null else Gen2WorldState.MUSIC_NONE
 
 
@@ -596,7 +601,7 @@ func player_sprite() -> Gen2WorldSprite:
 
 
 func set_movement_mode(mode: StringName) -> Dictionary:
-	if mode not in [MOVEMENT_WALK, MOVEMENT_SURF]:
+	if mode not in [MOVEMENT_WALK, MOVEMENT_SURF, MOVEMENT_BIKE]:
 		return {"ok": false, "reason": &"invalid_movement_mode", "mode": mode}
 	movement_mode = mode
 	return {"ok": true, "mode": movement_mode}
@@ -4530,7 +4535,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
 	_advance_followers(from_cell, previous_cells)
-	_start_player_step(direction, STEP_FRAMES_WALK)
+	_start_player_step(direction, _step_frames_for_movement())
 	return {
 		"ok": true,
 		"kind": kind,
@@ -5101,6 +5106,58 @@ func dig_request() -> Dictionary:
 		"move": Gen2WorldFieldMove.MOVE_DIG,
 		"warp": warped,
 	}
+
+
+## `DoPlayerMovement`'s own speed for a committed step: `STEP_BIKE` while riding,
+## which is `big_step` and so four frames, and `STEP_WALK`'s eight otherwise.
+## `.BikeCheck`'s downhill branch is not modelled: `BIKEFLAGS_DOWNHILL_F` is set
+## by nothing in either pin, so no map can ask for the slower non-down step.
+func _step_frames_for_movement() -> int:
+	return STEP_FRAMES_FAST if movement_mode == MOVEMENT_BIKE else STEP_FRAMES_WALK
+
+
+## `BikeFunction`'s `.TryBike`: `.CheckEnvironment` first, then the state the
+## player is in. Getting off is refused while `BIKEFLAGS_ALWAYS_ON_BIKE_F` is
+## set, which is `Script_CantGetOffBike`; the two get-on and get-off scripts are
+## the caller's, since both are text and a sprite update.
+func bike_request() -> Dictionary:
+	if current_map == null:
+		return _bike_failure(&"missing_map")
+	if not _can_ride_bike_here():
+		return _bike_failure(&"cannot_use_bike")
+	if movement_mode == MOVEMENT_WALK:
+		movement_mode = MOVEMENT_BIKE
+		player_sprite_number = Gen2WorldSprite.player_bike_sprite(_player_female)
+		return {
+			"ok": true, "kind": &"bike_on",
+			"music": Gen2WorldFieldMove.MUSIC_BICYCLE,
+			"sprite": player_sprite_number,
+		}
+	if movement_mode != MOVEMENT_BIKE:
+		return _bike_failure(&"cannot_use_bike")
+	if state.is_engine_flag_active(Gen2WorldState.always_on_bike_flag(data)):
+		return _bike_failure(&"always_on_bike")
+	movement_mode = MOVEMENT_WALK
+	player_sprite_number = _walking_sprite()
+	return {
+		"ok": true, "kind": &"bike_off",
+		"music": map_music_track(),
+		"sprite": player_sprite_number,
+	}
+
+
+## `.CheckEnvironment`: outdoors, a cave or a gate, and standing on a tile whose
+## permission's low nibble is `FLOOR_TILE`. Water and every wall code fail it, so
+## a surfing player can never be on a bike either.
+func _can_ride_bike_here() -> bool:
+	if not _is_outdoor(current_map.environment) \
+		and current_map.environment not in [ENVIRONMENT_CAVE, ENVIRONMENT_GATE]:
+		return false
+	return (collision_permission_at(player_cell) & 0x0F) == Gen2WorldCollision.LAND_TILE
+
+
+static func _bike_failure(reason: StringName) -> Dictionary:
+	return {"ok": false, "kind": &"bike_failed", "reason": reason}
 
 
 ## `EscapeRopeFunction`, which is `EscapeRopeOrDig` with the other type byte: the

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -68,6 +68,9 @@ const SPECIES_PIKACHU: int = 0x19
 ## it belongs to Surf rather than to any one map. Surf has no sound effect:
 ## UsedSurfScript never calls PlaySFX.
 const MUSIC_SURF: int = 0x21
+## `BikeFunction`'s own `ld de, MUSIC_BICYCLE`, which it writes to `wMapMusic` so
+## the track survives a map load the way `SpecialMapMusic` keeps MUSIC_SURF.
+const MUSIC_BICYCLE: int = 0x13
 
 ## The data/mon_menu.asm MonMenuOptions field-move rows this project acts on.
 ## Both pins ship the same rows, so this needs no profile split. IsFieldMove

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -231,16 +231,19 @@ static func can_hold(data: GameData, item: int) -> bool:
 ## other CLOSE item still falls through to `.Oak`; `HANDOFF.md` names what each
 ## of those is waiting for.
 const FIELD_EFFECT_NONE: StringName = &""
+const FIELD_EFFECT_BICYCLE: StringName = &"bicycle"
 const FIELD_EFFECT_ESCAPE_ROPE: StringName = &"escape_rope"
 const FIELD_EFFECT_ROD: StringName = &"rod"
 const FIELD_EFFECT_COIN_CASE: StringName = &"coin_case"
 const FIELD_EFFECT_ITEMFINDER: StringName = &"itemfinder"
 const FIELD_EFFECT_SACRED_ASH: StringName = &"sacred_ash"
+const ITEM_BICYCLE: int = 0x07
 const ITEM_ESCAPE_ROPE: int = 0x13
 const ITEM_COIN_CASE: int = 0x36
 const ITEM_ITEMFINDER: int = 0x37
 const ITEM_SACRED_ASH: int = 0x9C
 const FIELD_EFFECTS: Dictionary = {
+	ITEM_BICYCLE: FIELD_EFFECT_BICYCLE,
 	ITEM_ESCAPE_ROPE: FIELD_EFFECT_ESCAPE_ROPE,
 	ITEM_COIN_CASE: FIELD_EFFECT_COIN_CASE,
 	ITEM_ITEMFINDER: FIELD_EFFECT_ITEMFINDER,
@@ -249,6 +252,22 @@ const FIELD_EFFECTS: Dictionary = {
 	Gen2WorldInventory.ITEM_SUPER_ROD: FIELD_EFFECT_ROD,
 	ITEM_SACRED_ASH: FIELD_EFFECT_SACRED_ASH,
 }
+
+
+## The bag rows `BattlePack` can offer, in the pack's own pocket order: every
+## owned item whose battle nibble is not ITEMMENU_NOUSE. The balls are in it,
+## because the pack is where a throw is chosen from too.
+static func battle_items(data: GameData, state: Gen2WorldState) -> Array[int]:
+	var out: Array[int] = []
+	if data == null or state == null:
+		return out
+	for pocket: Dictionary in build(data, state):
+		var numbers: Array = pocket.get("items", [])
+		for row: Dictionary in numbers:
+			var item: int = int(row.get("item", 0))
+			if int(data.item(item).get("battle_menu", 0)) != ITEMMENU_NOUSE:
+				out.append(item)
+	return out
 
 
 ## Which `.Field` effect a USE runs, or FIELD_EFFECT_NONE. The item's own menu

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1430,14 +1430,14 @@ func preview_wild_encounter() -> void:
 	})
 
 
-## Public screenshot driver for `.Field`: grants an ITEMFINDER on an injected
+## Public screenshot driver for `.Field`: grants [param item] on an injected
 ## save, opens the pack on the key items and uses it, so what is photographed is
 ## the world's own answer with the pack already closed behind it.
-func preview_field_item() -> void:
+func preview_field_item(item: int = Gen2WorldPack.ITEM_ITEMFINDER) -> void:
 	if _world == null or _data == null or _start_menu_host != null:
 		return
 	_injected_save = _embedded_party_save()
-	_world.state.apply_changes({}, {}, {"items": {Gen2WorldPack.ITEM_ITEMFINDER: 1}})
+	_world.state.apply_changes({}, {}, {"items": {item: 1}})
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
@@ -1582,6 +1582,9 @@ func _start_battle_request(request: Dictionary) -> void:
 			host.set_capture_balls(
 				Gen2WorldPartyHost.owned_capture_balls(_world), _world.state.items()
 			)
+			host.set_battle_pack(
+				Gen2WorldPack.battle_items(_data, _world.state), _world.state.items()
+			)
 	host.set_meta("world_battle_request", {
 		"request": request.duplicate(true),
 		"save": save,
@@ -1596,6 +1599,7 @@ func _start_battle_request(request: Dictionary) -> void:
 	host.enemy_seen.connect(_on_enemy_seen)
 	if not tutorial:
 		host.capture_requested.connect(_on_capture_requested)
+		host.item_used.connect(_on_battle_item_used)
 	_battle_host = host
 	_script_prompt = "Battle in progress"
 	_refresh_labels()
@@ -1630,6 +1634,21 @@ func _on_capture_requested(ball: int) -> void:
 	)
 	_battle_host.complete_capture(result)
 	_refresh_labels()
+
+
+## `UseDisposableItem` inside a battle: the effect has already landed on the
+## party the battle owns, so all the world does is take the row down by one.
+func _on_battle_item_used(item: int, _target: int) -> void:
+	if _world == null or _world.inventory == null:
+		return
+	_world.inventory.change_item_quantity(item, -1)
+	if _battle_host != null:
+		_battle_host.set_battle_pack(
+			Gen2WorldPack.battle_items(_data, _world.state), _world.state.items()
+		)
+		_battle_host.set_capture_balls(
+			Gen2WorldPartyHost.owned_capture_balls(_world), _world.state.items()
+		)
 
 
 func _on_battle_finished(result: Dictionary) -> void:
@@ -2197,6 +2216,20 @@ func _on_field_item_used(request: Dictionary) -> void:
 		_refresh_labels()
 		return
 	match StringName(request.get("effect", &"")):
+		Gen2WorldPack.FIELD_EFFECT_BICYCLE:
+			## `Script_GetOnBike` and `Script_GetOffBike`, both of which are a
+			## line, a `waitbutton` and `special UpdatePlayerSprite`. The music is
+			## the function's own rather than either script's.
+			var on: bool = StringName(
+				(request.get("bike", {}) as Dictionary).get("kind", &"")
+			) == &"bike_on"
+			var bike_name: String = _data.item_name(int(request.get("item", 0)))
+			_show_field_move_text(
+				"Got on the\n%s." % bike_name if on else "Got off\nthe %s." % bike_name
+			)
+			_play_current_map_music()
+			if _renderer != null:
+				_renderer.refresh()
 		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
 			_show_field_move_text("Used an\nESCAPE ROPE.")
 			_refresh_after_escape()

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -60,6 +60,12 @@ static func player_normal_sprite(female: bool) -> int:
 	return SPRITE_KRIS if female else SPRITE_PLAYER
 
 
+## The same table's PLAYER_BIKE row, which `UpdatePlayerSprite` reads once
+## `VAR_MOVEMENT` is PLAYER_BIKE.
+static func player_bike_sprite(female: bool) -> int:
+	return SPRITE_KRIS_BIKE if female else SPRITE_PLAYER_BIKE
+
+
 ## `InitPlayerObject`'s `ln e, PAL_NPC_RED` and its female branch.
 static func player_palette(female: bool) -> int:
 	return PAL_NPC_BLUE if female else PAL_NPC_RED

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -61,6 +61,11 @@ const ENGINE_ALL_FRUIT_TREES: int = 84
 ## the save across maps, warps and snapshots.
 const ENGINE_STRENGTH_ACTIVE: int = 24
 const ENGINE_STRENGTH_ACTIVE_GOLD_SILVER: int = 23
+## The next flag in the same byte: `BIKEFLAGS_ALWAYS_ON_BIKE_F`, which is the
+## whole of `.CantGetOffBike`. `BIKEFLAGS_DOWNHILL_F` follows it and is read by
+## `DoPlayerMovement` alone, which no map ever sets.
+const ENGINE_ALWAYS_ON_BIKE: int = 25
+const ENGINE_ALWAYS_ON_BIKE_GOLD_SILVER: int = 24
 
 ## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array, and
 ## VAR_BADGES counts both bytes, not Johto alone. These are Crystal indices:
@@ -542,6 +547,13 @@ const NUM_SPAWNS: int = RomLayout.SPAWN_COUNT
 ## way badge_flag() resolves a badge.
 static func strength_active_flag(crystal: bool = true) -> int:
 	return ENGINE_STRENGTH_ACTIVE if crystal else ENGINE_STRENGTH_ACTIVE_GOLD_SILVER
+
+
+## `.GetOffBike`'s own `bit BIKEFLAGS_ALWAYS_ON_BIKE_F`, resolved for the profile
+## [param data] names the way strength_active_flag() resolves its own.
+static func always_on_bike_flag(data: GameData) -> int:
+	return ENGINE_ALWAYS_ON_BIKE if is_crystal_profile(data) \
+		else ENGINE_ALWAYS_ON_BIKE_GOLD_SILVER
 
 
 ## Mirrors _GetVarAction's .CountBadges: a popcount over both badge bytes.

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -600,3 +600,106 @@ func test_a_renderer_is_not_offered_input_while_a_menu_is_up() -> void:
 	await _read_question()
 	await _press(Gen2Button.B)
 	assert_true(_screen._renderer_input_free())
+
+
+## `BattleMenu_Pack`: PACK opens `BattlePack`'s own list, an ITEMMENU_PARTY row
+## asks `UseItem_SelectMon` for a target, and the item is spent before the turn
+## the enemy still gets.
+func test_the_pack_uses_an_item_on_the_chosen_member_and_spends_the_turn() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	_screen.set_battle_pack(
+		[BattleFixture.POTION], {BattleFixture.POTION: 2}
+	)
+	var spent: Array = []
+	_screen.item_used.connect(func(item: int, target: int) -> void:
+		spent.append([item, target])
+	)
+	var bench: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	bench.hp = 1
+
+	await _press(Gen2Button.DOWN)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PACK)
+	await _press(Gen2Button.A)
+	assert_true(bool(_screen.get("_pack_selecting")), "the pack list is up")
+	assert_eq(_screen.selected_pack_item(), BattleFixture.POTION)
+
+	# The party list `UseItem_SelectMon` opens, and the bench member on it.
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick")
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.A)
+
+	assert_eq(bench.hp, 21, "the potion landed on the bench member")
+	assert_eq(spent, [[BattleFixture.POTION, 1]], "and the world was told to spend it")
+	assert_false(bool(_screen.get("_pack_selecting")))
+
+
+## `UseItem_SelectMon` makes none of the switch list's own checks: the Pokemon
+## already out is exactly what a potion is usually used on, and backing out of
+## the list reopens the pack rather than the menu.
+func test_the_item_target_list_takes_the_one_out_and_backs_out_to_the_pack() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	_screen.set_battle_pack([BattleFixture.POTION], {BattleFixture.POTION: 1})
+	battle.mon(Gen2Battle.PLAYER).hp = 1
+
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick")
+	await _press(Gen2Button.B)
+	assert_eq(_stage(), "", "the list is gone")
+	assert_true(bool(_screen.get("_pack_selecting")), "and the pack is back")
+
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.A)
+	## Healed to 21 and then hit, because the item spends the turn and the enemy
+	## still moves in it.
+	assert_gt(battle.mon(Gen2Battle.PLAYER).hp, 1, "used on the one that is out")
+	assert_lt(battle.mon(Gen2Battle.PLAYER).hp, 21, "and the enemy answered it")
+
+
+## An ITEMMENU_CLOSE row is applied to whoever is out with no list in front of
+## it, and B leaves the pack for the menu it was opened from.
+func test_an_x_item_needs_no_target_and_b_closes_the_pack() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	_screen.set_battle_pack([BattleFixture.X_ATTACK], {BattleFixture.X_ATTACK: 1})
+
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.B)
+	assert_eq(_menu_stage(), "main", "B is a jp BattleMenu")
+
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.A)
+	assert_eq(battle.mon(Gen2Battle.PLAYER).stage("attack"), 1)
+	assert_eq(_stage(), "", "no target list for an item used on the one that is out")
+
+
+## `RestorePPEffect`'s `.loop`: an Ether asks which move after it has asked which
+## Pokemon, and the slot chosen there is the one that fills.
+func test_an_ether_asks_which_move_and_fills_that_slot() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	_screen.set_battle_pack([BattleFixture.ETHER], {BattleFixture.ETHER: 1})
+	var user: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+	user.pp[0] = 0
+	user.pp[1] = 0
+
+	await _press(Gen2Button.DOWN)
+	await _press(Gen2Button.A)
+	await _press(Gen2Button.A)
+	assert_eq(_stage(), "pick")
+	await _press(Gen2Button.A)
+	assert_true(bool(_screen.get("_pack_move_selecting")), "the move list is up")
+
+	await _press(Gen2Button.RIGHT)
+	await _press(Gen2Button.A)
+	assert_eq(user.pp_left(0), 0, "the slot it was not used on")
+	assert_gt(user.pp_left(1), 0, "and the one it was")

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -288,6 +288,36 @@ const MAX_ITEM: int = 174
 const SMOKE_BALL: int = 0x6A
 const HELD_ESCAPE: int = 72
 
+## The `ItemAttributes` rows `BattlePack` reads, at their real numbers: the
+## battle menu nibble, plus the `HealingHPAmounts` and `StatusHealingActions`
+## entries the cache carries beside it. Only the items a battle can use are here;
+## every other row is the plain placeholder above.
+const POTION: int = 0x12
+const FULL_RESTORE: int = 0x0E
+const FULL_HEAL: int = 0x26
+const REVIVE: int = 0x27
+const POKE_DOLL: int = 0x25
+const X_ATTACK: int = 0x31
+const GUARD_SPEC: int = 0x29
+const ETHER: int = 0x3F
+const ELIXER: int = 0x41
+const POKE_BALL: int = 0x05
+const BATTLE_ITEMS: Dictionary = {
+	POTION: {"name": "POTION", "battle_menu": 5, "pocket": 1, "heal_amount": 20},
+	FULL_RESTORE: {
+		"name": "FULL RESTORE", "battle_menu": 5, "pocket": 1,
+		"heal_amount": 999, "status_mask": 0xFF,
+	},
+	FULL_HEAL: {"name": "FULL HEAL", "battle_menu": 5, "pocket": 1, "status_mask": 0xFF},
+	REVIVE: {"name": "REVIVE", "battle_menu": 5, "pocket": 1},
+	POKE_DOLL: {"name": "POKE DOLL", "battle_menu": 6, "pocket": 1},
+	X_ATTACK: {"name": "X ATTACK", "battle_menu": 6, "pocket": 1},
+	GUARD_SPEC: {"name": "GUARD SPEC.", "battle_menu": 6, "pocket": 1},
+	ETHER: {"name": "ETHER", "battle_menu": 5, "pocket": 1},
+	ELIXER: {"name": "ELIXER", "battle_menu": 5, "pocket": 1},
+	POKE_BALL: {"name": "POKE BALL", "battle_menu": 6, "pocket": 3},
+}
+
 ## The held items the battle reads, at their real numbers with the real held
 ## effect and parameter bytes off the cartridge. Thick Club and Light Ball carry
 ## no held effect at all: `SpeciesItemBoost` checks them by number.
@@ -754,12 +784,15 @@ static func _items() -> Array:
 	var out: Array = []
 	for number: int in range(1, MAX_ITEM + 1):
 		var held: Array = HELD_ITEMS.get(number, [])
-		out.append({
+		var entry: Dictionary = {
 			"number": number,
 			"name": String(held[0]) if not held.is_empty() else "ITEM%d" % number,
 			"effect": int(held[1]) if not held.is_empty() else 0,
 			"parameter": int(held[2]) if not held.is_empty() else 0,
-		})
+		}
+		if BATTLE_ITEMS.has(number):
+			entry.merge(BATTLE_ITEMS[number] as Dictionary, true)
+		out.append(entry)
 	return out
 
 

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -2665,6 +2665,160 @@ func test_an_exp_share_halves_the_stat_experience_too() -> void:
 		})
 
 
+## `DoItemEffect` with `wBattleMode` set. The player's own bag: the effect lands
+## at menu time, and the turn it costs is spent afterwards.
+func test_a_bag_potion_heals_the_chosen_party_member() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+			_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])), _rng
+	)
+	var bench: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	bench.hp = 1
+
+	var used: Dictionary = battle.use_bag_item(Fixture.POTION, 1)
+
+	assert_true(bool(used.get("ok", false)), String(used.get("reason", "")))
+	assert_eq(int((used["effect"] as Dictionary)["healed"]), 20)
+	assert_eq(bench.hp, 21)
+	# A member already at full health is `WontHaveAnyEffect_NotUsedMessage`.
+	battle.mon(Gen2Battle.PLAYER).hp = battle.mon(Gen2Battle.PLAYER).max_hp()
+	var refused: Dictionary = battle.use_bag_item(Fixture.POTION, 0)
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(StringName(refused["reason"]), &"item_has_no_effect")
+
+
+## `UseStatusHealer`'s mask, and `IsItemUsedOnConfusedMon` behind it: only a
+## `%11111111` item cures confusion, and only on the Pokemon that is out.
+func test_a_full_heal_takes_the_status_and_the_confusion_of_the_one_out() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	var user: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+	user.status = Gen2Status.PARALYSIS
+	user.substatus |= Gen2Substatus.CONFUSED
+	user.confusion_turns = 3
+
+	var used: Dictionary = battle.use_bag_item(Fixture.FULL_HEAL, 0)
+
+	assert_true(bool(used.get("ok", false)), String(used.get("reason", "")))
+	assert_eq(user.status, Gen2Status.NONE)
+	assert_false(Gen2Substatus.has(user.substatus, Gen2Substatus.CONFUSED))
+	assert_true(bool((used["effect"] as Dictionary)["unconfused"]))
+
+
+## `RevivePokemon`: a revive is refused on anything still standing, and the one
+## it brings back joins the experience split again.
+func test_a_revive_only_answers_a_fainted_member_and_puts_it_back_on_the_split() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+			_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])), _rng
+	)
+	assert_eq(StringName(battle.use_bag_item(Fixture.REVIVE, 0)["reason"]), &"item_has_no_effect")
+
+	var bench: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	bench.hp = 0
+	var used: Dictionary = battle.use_bag_item(Fixture.REVIVE, 1)
+
+	assert_true(bool(used.get("ok", false)), String(used.get("reason", "")))
+	assert_eq(bench.hp, maxi(bench.max_hp() / 2, 1))
+
+
+## `XItemEffect` and `GuardSpecEffect` act on whoever is out, and each refuses
+## once there is nothing left to raise or set.
+func test_an_x_item_raises_the_stage_once_and_then_has_no_effect() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	var user: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+
+	assert_true(bool(battle.use_bag_item(Fixture.X_ATTACK).get("ok", false)))
+	assert_eq(user.stage("attack"), 1)
+
+	assert_true(bool(battle.use_bag_item(Fixture.GUARD_SPEC).get("ok", false)))
+	assert_true(Gen2Substatus.has(user.substatus, Gen2Substatus.MIST))
+	assert_eq(
+		StringName(battle.use_bag_item(Fixture.GUARD_SPEC)["reason"]), &"item_has_no_effect"
+	)
+
+	user.change_stage("attack", Gen2Stats.MAX_STAGE)
+	assert_eq(
+		StringName(battle.use_bag_item(Fixture.X_ATTACK)["reason"]), &"item_has_no_effect"
+	)
+
+
+## `PokeDollEffect`: a wild battle ends as a DRAW the moment it is used, and a
+## trainer battle leaves `wItemEffectSucceeded` clear.
+func test_a_poke_doll_ends_a_wild_battle_and_does_nothing_to_a_trainer() -> void:
+	var wild: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	assert_true(bool(wild.use_bag_item(Fixture.POKE_DOLL).get("ok", false)))
+	assert_true(wild.is_over())
+	assert_true(wild.was_forced_out())
+	assert_null(wild.winner())
+
+	var trainer: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE])),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])), _rng, true
+	)
+	assert_eq(
+		StringName(trainer.use_bag_item(Fixture.POKE_DOLL)["reason"]), &"item_has_no_effect"
+	)
+	assert_false(trainer.is_over())
+
+
+## `RestorePPEffect`: an Elixer fills every slot and an Ether the one it was
+## asked for, and neither is spent on a moveset that is already full.
+func test_the_pp_items_fill_one_slot_and_all_of_them() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE, Fixture.EMBER]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	var user: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+	assert_eq(StringName(battle.use_bag_item(Fixture.ELIXER, 0)["reason"]), &"item_has_no_effect")
+
+	var full: int = user.pp_left(0)
+	user.pp[0] = 0
+	user.pp[1] = 0
+	assert_true(bool(battle.use_bag_item(Fixture.ETHER, 0, 0).get("ok", false)))
+	assert_eq(user.pp_left(0), mini(full, 10))
+	assert_eq(user.pp_left(1), 0, "the slot the Ether was not used on")
+
+	assert_true(bool(battle.use_bag_item(Fixture.ELIXER, 0).get("ok", false)))
+	assert_eq(user.pp_left(1), mini(int(_data.move(Fixture.EMBER).get("pp", 0)), 10))
+
+
+## `BATTLEPLAYERACTION_USEITEM`: the item is already spent when the turn runs, so
+## the player takes no move and the enemy's own still lands.
+func test_a_bag_item_costs_the_turn_and_the_enemy_still_moves() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	var enemy_hp: int = battle.enemy.hp
+	battle.mon(Gen2Battle.PLAYER).hp = 5
+
+	assert_true(bool(battle.use_bag_item(Fixture.POTION, 0).get("ok", false)))
+	var events: Array = battle.take_actions(
+		Gen2Battle.use_item(Fixture.POTION), Gen2Battle.use_move(0)
+	)
+
+	assert_eq(battle.enemy.hp, enemy_hp, "the player threw nothing")
+	assert_eq(_of_type(events, Gen2Battle.HIT).size(), 1, JSON.stringify(events))
+	assert_eq(int((events[0] as Dictionary).get("side", -1)), Gen2Battle.ENEMY)
+
+
 ## A trainer's item is an action rather than a move: it costs the turn, it lands
 ## before the player's move whatever the speeds say, and the item is gone.
 func test_a_trainer_item_resolves_before_the_players_move_and_is_spent() -> void:

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1509,6 +1509,59 @@ func test_dig_is_refused_outside_a_cave_and_with_no_warp_recorded() -> void:
 	assert_eq(StringName(unknowing.dig_request()["reason"]), &"move_not_known")
 
 
+## `BikeFunction`: `.CheckEnvironment`, then the two directions of `.TryBike`.
+func test_the_bike_goes_on_and_off_outdoors_and_carries_its_own_music() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+
+	var on: Dictionary = world.bike_request()
+	assert_true(bool(on.get("ok", false)), String(on.get("reason", "")))
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER_BIKE)
+	assert_eq(world.map_music_track(), Gen2WorldFieldMove.MUSIC_BICYCLE)
+
+	var off: Dictionary = world.bike_request()
+	assert_true(bool(off.get("ok", false)), String(off.get("reason", "")))
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+	assert_ne(world.map_music_track(), Gen2WorldFieldMove.MUSIC_BICYCLE)
+
+
+## `.CheckEnvironment` again: a cave is a place to ride and an indoor map is not,
+## and `.GetOffBike` refuses while BIKEFLAGS_ALWAYS_ON_BIKE_F is set.
+func test_the_bike_is_refused_indoors_and_cannot_be_left_where_it_is_forced() -> void:
+	var indoors: Gen2WorldAPI = _escape_world(ESCAPE_POKECENTER, Vector2i(4, 4))
+	assert_eq(StringName(indoors.bike_request()["reason"]), &"cannot_use_bike")
+
+	var cave: Gen2WorldAPI = _escape_world(ESCAPE_CAVE, Vector2i(4, 4))
+	assert_true(bool(cave.bike_request().get("ok", false)), "a cave is rideable")
+
+	cave.state.set_engine_flag(Gen2WorldState.always_on_bike_flag(cave.data), true)
+	assert_eq(StringName(cave.bike_request()["reason"]), &"always_on_bike")
+	assert_eq(cave.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE, "still riding")
+
+
+## `DoPlayerMovement` picks `STEP_BIKE` for a committed step while riding, which
+## is `big_step` and so half the frames an ordinary walk spends.
+func test_a_step_on_the_bike_spends_half_the_frames() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	assert_true(bool(world.move_result(Vector2i.RIGHT).get("ok", false)))
+	var walking: int = _drain_player_step(world)
+
+	assert_true(bool(world.bike_request().get("ok", false)))
+	assert_true(bool(world.move_result(Vector2i.LEFT).get("ok", false)))
+	assert_eq(_drain_player_step(world), walking / 2)
+
+
+## How many frames the step in flight still owes, spent one at a time.
+func _drain_player_step(world: Gen2WorldAPI) -> int:
+	var frames: int = 0
+	while world.player_step_in_progress():
+		world.advance_player_step_frame()
+		frames += 1
+	return frames
+
+
 func test_an_escape_rope_takes_the_same_warp_dig_does_and_knows_no_move() -> void:
 	var world: Gen2WorldAPI = _escape_world()
 	world.player_cell = ESCAPE_CAVE_DOOR

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -40,6 +40,12 @@ func before_each() -> void:
 				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
 				raw["permissions"] = Gen2WorldPack.CANT_TOSS
 				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+			## The fixture's own row for this number is a real cartridge item, so
+			## the unclassified case says so rather than relying on its silence.
+			ITEM_UNCLASSIFIED:
+				raw["name"] = "ITEM5"
+				raw["pocket"] = 0
+				raw["battle_menu"] = 0
 			ITEM_TM01:
 				raw["name"] = "TM01"
 				raw["pocket"] = Gen2WorldPack.TYPE_TM_HM

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -7,8 +7,8 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses] [passes]
 ##
-## [stage] is one of `offer` (the default), `menu`, `move`, `contest`, `pick`,
-## `use_next` and `replace`;
+## [stage] is one of `offer` (the default), `menu`, `move`, `contest`, `pack`,
+## `pick`, `use_next` and `replace`;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
 ## cursor row or a refusal can be photographed; [passes] is how many sprite
 ## passes the party page's icons are given, which is what moves the chosen row's
@@ -27,6 +27,12 @@ const WINDOW_SIZE := Vector2i(1152, 648)
 ## below rather than by waiting. A shorter run photographs the composite as it
 ## was a few frames before the presses.
 const SETTLE_FRAMES: int = 30
+
+## `BattlePack`'s rows for the `pack` stage: a potion, a Full Heal and an X
+## Attack, which are one of each of `UseItem`'s three battle branches
+## (constants/item_constants.asm).
+const PACK_ITEMS: Array[int] = [0x12, 0x26, 0x31]
+const PACK_QUANTITIES: Dictionary = {0x12: 3, 0x26: 1, 0x31: 2}
 
 ## Falkner, and three of the player's own, all at a level where nothing faints
 ## before the question is asked.
@@ -135,7 +141,7 @@ func _open() -> void:
 		_screen.set("_pending", [
 			{"type": Gen2Battle.FAINTED, "side": Gen2Battle.PLAYER},
 		])
-	elif _stage not in ["menu", "move", "contest"]:
+	elif _stage not in ["menu", "move", "contest", "pack"]:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
 		))
@@ -152,9 +158,15 @@ func _open() -> void:
 
 	## Both menu stages are what the intro leads into with nothing else staged,
 	## which is `BattleMenu`'s own first opening.
-	if _stage in ["menu", "move", "contest"]:
+	if _stage in ["menu", "move", "contest", "pack"]:
 		_drain_to_menu()
 		if _stage == "move":
+			_screen._handle_button(Gen2Button.A)
+		## `BattlePack`'s own list, over the bag the world hands the battle. The
+		## rows are a real cache's items, so the picture reads as the pack.
+		if _stage == "pack":
+			_screen.set_battle_pack(PACK_ITEMS, PACK_QUANTITIES)
+			_screen._handle_button(Gen2Button.DOWN)
 			_screen._handle_button(Gen2Button.A)
 		for press: String in _presses:
 			_screen._handle_button(_button(press))

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -13,10 +13,11 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y]
 ##
 ## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
-## `cut` (`OWCutAnimation`'s two halves and the jump shadow) or `field_item` (the
+## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `field_item` (the
 ## pack's own USE on the Itemfinder, which closes the pack over the world's
-## answer). The two numbers are the cell the player stands on, which is how the
-## grass a standing object is drawn behind is photographed.
+## answer) or `bike` (the same USE on the Bicycle). The two numbers are the cell
+## the player stands on, which is how the grass a standing object is drawn behind
+## is photographed.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Hardware frames spent after the sprites are staged. Two puts the grass rustle
@@ -106,6 +107,8 @@ func _process(_delta: float) -> bool:
 	if _frames == 2:
 		if _kind == &"field_item":
 			_screen.preview_field_item()
+		elif _kind == &"bike":
+			_screen.preview_field_item(Gen2WorldPack.ITEM_BICYCLE)
 		else:
 			_screen.preview_effect_sprites(_kind)
 		for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):


### PR DESCRIPTION
Two halves of `DoItemEffect` that ran nothing.

**In battle.** `BattleMenu_Pack` reached ball selection alone and a trainer battle was refused outright. `BattlePack`'s rows are now offered on the battle's own text box, and `UseItem`'s jumptable runs against the party the battle owns:

| Branch | What it does |
|---|---|
| ITEMMENU_PARTY | `UseItem_SelectMon` through the switch party list: HP and status off the item's own `HealingHPAmounts`/`StatusHealingActions` rows, Full Restore's confusion cure behind `IsItemUsedOnConfusedMon`, `RevivePokemon`, and `RestorePPEffect` (an Ether asks which move, an Elixer fills every slot) |
| ITEMMENU_CLOSE | X items, Guard Spec and Dire Hit on whoever is out, each refusing when there is nothing left to raise or set; a Poke Doll is `wForcedSwitch` and its DRAW; a ball reaches the throw the screen already draws, and is refused in a trainer battle the way `UseBallInTrainerBattle` refuses it |

The effect lands at menu time and the turn is paid for with `BATTLEPLAYERACTION_USEITEM`, so the enemy still moves; a revived member rejoins `wBattleParticipantsNotFainted`.

**In the overworld.** `BikeFunction`: `.CheckEnvironment`'s outdoor/cave/gate test over a floor tile, `PLAYER_BIKE` with its own sprite row and `MUSIC_BICYCLE`, `STEP_BIKE`'s four frames a step against a walk's eight, and `.CantGetOffBike` behind `BIKEFLAGS_ALWAYS_ON_BIKE_F`.

GUT 2,929 over 148 scripts green (2,584 unit, 345 integration), `validate.gd -- all` 45 topics pass, `replay_world.gd` 27 routes 0 failures, and the story walk reaches Red on all three profiles (291/291/294 steps, 16 badges).