### PR TITLE
The last three key items, and a TM's happiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ live under their own root and are not touched.
 |---|---|
 | Species | Names, base stats, types, held items, egg groups, TM/HM flags |
 | Learnsets, evolutions | All 251 species' level-up moves in cartridge order; every evolution and its method |
-| Moves, TM/HM | Power, type, accuracy, PP, effect and chance; the 57 or 60 TM, HM and tutor rows |
+| Moves, TM/HM | Power, type, accuracy, PP, effect and chance; the 57 or 60 TM, HM and tutor rows; the happiness table teaching one moves |
 | Items, types | 255 items with prices, effects, pockets and healing metadata; 28 type names |
 | Type chart | Every matchup and the two Foresight-cancelled entries |
 | Trainers, NPC trades | Class names, pics, palettes, AI flags, DVs and parties; trade records with DVs and OT data |

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -29,6 +29,8 @@ var _moves: Array = []
 ## TMHMMoves in TMNUM order, restored to integers because JSON reads them back
 ## as floats.
 var _tmhm_moves: Array[int] = []
+## HappinessChanges, one row of three signed changes per HAPPINESS_* constant.
+var _happiness_changes: Array = []
 var _name_input_chars: Array = []
 ## StringBufferPointers as WRAM addresses, in `text_buffer` argument order.
 var _string_buffer_pointers: Array[int] = []
@@ -151,6 +153,7 @@ static func open_directory(path: String) -> GameData:
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
+	data._happiness_changes = data._read_array(RomCache.happiness_changes_path(path))
 	data._name_input_chars = data._read_array(RomCache.name_input_chars_path(path))
 	data._string_buffer_pointers = data._read_int_array(RomCache.text_buffers_path(path))
 	var intro: Variant = RomCache.read_json(RomCache.intro_text_path(path))
@@ -982,6 +985,19 @@ func tmhm_number_for_move(move_number: int) -> int:
 		return 0
 	var found: int = _tmhm_moves.find(move_number)
 	return found + 1 if found >= 0 else 0
+
+
+## `ChangeHappiness`'s own row lookup: the three changes HAPPINESS_[param kind]
+## makes, below 100, below 200 and above it. [param kind] is one-based the way
+## the source passes it. Empty for a row this cartridge does not carry, which is
+## HAPPINESS_GAINLEVELATHOME off Crystal, and a caller reads that as no change.
+func happiness_changes(kind: int) -> Array[int]:
+	var out: Array[int] = []
+	if kind < 1 or kind > _happiness_changes.size():
+		return out
+	for change: Variant in _happiness_changes[kind - 1]:
+		out.append(int(change))
+	return out
 
 
 ## One of data/text/name_input_chars.asm's four keyboards as rows of raw

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -19,6 +19,7 @@ const MANIFEST: String = "manifest.json"
 const SPECIES: String = "species.json"
 const MOVES: String = "moves.json"
 const TMHM_MOVES: String = "tmhm_moves.json"
+const HAPPINESS_CHANGES: String = "happiness_changes.json"
 const NAME_INPUT_CHARS: String = "name_input_chars.json"
 const INTRO_TEXT: String = "intro_text.json"
 const TEXT_BUFFERS: String = "text_buffers.json"
@@ -74,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 56
+const FORMAT_VERSION: int = 57
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a
@@ -104,6 +105,10 @@ static func moves_path(directory: String) -> String:
 
 static func tmhm_moves_path(directory: String) -> String:
 	return "%s/%s" % [directory, TMHM_MOVES]
+
+
+static func happiness_changes_path(directory: String) -> String:
+	return "%s/%s" % [directory, HAPPINESS_CHANGES]
 
 
 static func name_input_chars_path(directory: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3216,6 +3216,10 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	if tmhm_moves.is_empty():
 		result["message"] = "TM/HM move table is outside the cartridge or malformed."
 		return result
+	var happiness_changes: Array = _import_happiness_changes(rom, layout)
+	if happiness_changes.is_empty():
+		result["message"] = "Happiness change table is outside the cartridge or malformed."
+		return result
 	var name_input_chars: Array = _import_name_input_chars(rom, layout)
 	var string_buffers: Array = _import_string_buffer_pointers(rom, layout)
 	var intro_text: Dictionary = _import_intro_text(rom, layout)
@@ -3258,6 +3262,11 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		return result
 	if not RomCache.write_json(RomCache.tmhm_moves_path(directory), tmhm_moves):
 		result["message"] = "Could not write TM/HM move data."
+		return result
+	if not RomCache.write_json(
+		RomCache.happiness_changes_path(directory), happiness_changes
+	):
+		result["message"] = "Could not write happiness change data."
 		return result
 	if not RomCache.write_json(RomCache.name_input_chars_path(directory), name_input_chars):
 		result["message"] = "Could not write name input data."
@@ -3556,6 +3565,34 @@ func _import_tmhm_moves(rom: RomFile, layout: Dictionary) -> Array:
 	if int(out[RomLayout.TMHM_TM_COUNT]) != MOVE_CUT:
 		return []
 	return out
+
+
+## data/events/happiness_changes.asm's HappinessChanges, one row of three signed
+## changes per HAPPINESS_* constant. Empty on any layout or content failure.
+##
+## Checked rather than trusted: no change is larger than twenty either way, and
+## the first row has to be `+5, +3, +2`, which is what pins the table. Signed
+## because `ChangeHappiness` reads the byte as one: its `cp $64` puts everything
+## from 100 up on the subtracting branch.
+func _import_happiness_changes(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout.get("happiness_changes", -1))
+	var count: int = int(layout.get("happiness_change_count", 0))
+	var width: int = RomLayout.HAPPINESS_CHANGE_WIDTH
+	if count <= 0 or not rom.in_bounds(at, count * width):
+		return []
+	var out: Array = []
+	for row: int in count:
+		var changes: Array = []
+		for column: int in width:
+			var raw: int = rom.u8(at + row * width + column)
+			## `cp $64` is where the routine splits, so a byte from 100 up is
+			## the subtracting branch rather than a large rise.
+			var change: int = raw - 256 if raw >= 0x64 else raw
+			if absi(change) > 20:
+				return []
+			changes.append(change)
+		out.append(changes)
+	return out if out[0] == [5, 3, 2] else []
 
 
 ## data/text/name_input_chars.asm's four keyboards, each a list of 17-byte rows

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1299,6 +1299,18 @@ const TMHM_BYTES: int = 8
 ## identical between the pins; only Crystal's tutor rows follow.
 const TMHM_TM_COUNT: int = 50
 const TMHM_HM_COUNT: int = 7
+## data/events/happiness_changes.asm's HappinessChanges, one row per HAPPINESS_*
+## constant and three signed bytes a row: the change below 100, the change below
+## 200 and the change above it. `ChangeHappiness` takes its argument one-based,
+## so row n-1 is HAPPINESS_n. Crystal ends on HAPPINESS_GAINLEVELATHOME, which
+## pokegold does not ship; the eighteen rows before it are byte identical.
+const HAPPINESS_CHANGE_WIDTH: int = 3
+const HAPPINESS_CHANGE_COUNT_GOLD_SILVER: int = 18
+const HAPPINESS_CHANGE_COUNT: int = 19
+## `TeachTMHM`'s own `ld c, HAPPINESS_LEARNMOVE`, one-based the way the source
+## passes it. The only row anything here asks for: every other `ChangeHappiness`
+## caller is a routine this project does not run.
+const HAPPINESS_LEARNMOVE: int = 5
 ## data/text/name_input_chars.asm's four keyboards, one contiguous block in
 ## source order with every row 17 bytes wide. The block is byte identical in all
 ## three dumps, so only its offset is profile split.
@@ -1390,6 +1402,10 @@ const GOLD_SILVER: Dictionary = {
 	"move_data": 0x41AFE,
 	"tmhm_moves": 0x11A66,
 	"tmhm_move_count": 57,
+	# `HappinessChanges`, located by its own fifty-four signed bytes, which hit
+	# once per dump. Nothing near it is a table with the same shape.
+	"happiness_changes": 0x7300,
+	"happiness_change_count": HAPPINESS_CHANGE_COUNT_GOLD_SILVER,
 	"name_input_chars": 0x120B4,
 	"string_buffer_pointers": 0x24000,
 	## `data/text/common_2.asm`'s intro texts, each at its own `text_far` target.
@@ -1761,6 +1777,10 @@ const CRYSTAL: Dictionary = {
 	"move_data": 0x41AFB,
 	"tmhm_moves": 0x1167A,
 	"tmhm_move_count": 60,
+	# See the Gold and Silver block above; the first eighteen rows are byte
+	# identical and Crystal adds HAPPINESS_GAINLEVELATHOME after them.
+	"happiness_changes": 0x7221,
+	"happiness_change_count": HAPPINESS_CHANGE_COUNT,
 	"name_input_chars": 0x11CE7,
 	"string_buffer_pointers": 0x24000,
 	## See the Gold and Silver block above. Crystal moves `_OakText6` and
@@ -2085,6 +2105,7 @@ static func for_id(id: StringName) -> Dictionary:
 			silver["item_attributes"] = 0x6866
 			silver["item_status_actions"] = 0xF0C5
 			silver["item_healing_hp"] = 0xF403
+			silver["happiness_changes"] = 0x72C6
 			# `CopyrightString` sits in bank 1 on both, sixty bytes apart.
 			var copyright: Dictionary = (silver["copyright"] as Dictionary).duplicate()
 			copyright["string"] = 0x64D9

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -848,6 +848,12 @@ func _confirm_use() -> void:
 				return
 			_open_target_mode()
 		Gen2WorldPack.ITEMMENU_CURRENT:
+			## `CoinCaseEffect` is `MenuTextboxWaitButton` over
+			## `_CoinCaseCountText` and nothing else: the count is shown where the
+			## pack already prints, and the pack stays open behind it.
+			if number == Gen2WorldPack.ITEM_COIN_CASE:
+				_show_pack_result("Coins:\n%4d" % _coins(), true)
+				return
 			_use_selected_item(-1)
 		Gen2WorldPack.ITEMMENU_CLOSE:
 			_use_field_item(number)
@@ -897,8 +903,21 @@ func _resolve_field_item(item: int) -> Dictionary:
 			request["rod"] = rod
 		Gen2WorldPack.FIELD_EFFECT_ITEMFINDER:
 			request["found"] = _world.hidden_item_nearby()
-		Gen2WorldPack.FIELD_EFFECT_COIN_CASE:
-			request["coins"] = _world.state.coins() if _world.state != null else 0
+		Gen2WorldPack.FIELD_EFFECT_CARD_KEY:
+			var slot: Dictionary = _world.card_key_request()
+			if not bool(slot.get("ok", false)):
+				return {"ok": false}
+			request.merge(slot, true)
+		Gen2WorldPack.FIELD_EFFECT_BASEMENT_KEY:
+			var door: Dictionary = _world.basement_key_request()
+			if not bool(door.get("ok", false)):
+				return {"ok": false}
+			request.merge(door, true)
+		## The one effect that cannot fail: `_Squirtbottle` writes
+		## `wItemEffectSucceeded` before the script it queues decides anything,
+		## so the pack closes whether or not a Sudowoodo is in front.
+		Gen2WorldPack.FIELD_EFFECT_SQUIRTBOTTLE:
+			request.merge(_world.squirtbottle_request(), true)
 		Gen2WorldPack.FIELD_EFFECT_SACRED_ASH:
 			if _pack_save == null:
 				return {"ok": false}
@@ -1288,6 +1307,11 @@ func _press_toss_quantity(button: int) -> bool:
 		_:
 			_render_toss_quantity()
 	return true
+
+
+## `wCoins`, which only the Coin Case reads here.
+func _coins() -> int:
+	return _world.state.coins() if _world != null and _world.state != null else 0
 
 
 ## One of the pack's own texts, imported when the cache carries it. The lines

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5222,6 +5222,162 @@ func hidden_item_nearby() -> bool:
 	return false
 
 
+## The three maps `engine/events/card_key.asm`, `basement_key.asm` and
+## `squirtbottle.asm` name by constant before they do anything else. Each row is
+## the Crystal id and the Gold and Silver one; group 3 runs eight lower on
+## pokegold from `UNION_CAVE_1F`, which is what moves the underground.
+const KEY_ITEM_MAPS: Dictionary = {
+	&"RADIO_TOWER_3F": {&"crystal": Vector2i(3, 19), &"gold": Vector2i(3, 19)},
+	&"GOLDENROD_UNDERGROUND": {&"crystal": Vector2i(3, 53), &"gold": Vector2i(3, 45)},
+	&"ROUTE_36": {&"crystal": Vector2i(10, 3), &"gold": Vector2i(10, 3)},
+}
+
+## The two tiles `GetFacingTileCoord`'s results are compared against. The source
+## writes them in the object coordinate space, which is four cells ahead of the
+## map's own on each axis (`cp 18` / `cp 6` and `cp 22` / `cp 10`); both are the
+## cell the map's own `bg_event` for that door sits on.
+const CARD_KEY_SLOT_CELL: Vector2i = Vector2i(14, 2)
+const BASEMENT_DOOR_CELL: Vector2i = Vector2i(18, 6)
+
+
+func _is_on_key_item_map(name: StringName) -> bool:
+	if current_map == null:
+		return false
+	var row: Dictionary = KEY_ITEM_MAPS[name]
+	var id: Vector2i = row[&"crystal"] if Gen2WorldState.is_crystal_profile(data) \
+		else row[&"gold"]
+	return map_id() == id
+
+
+## `_CardKey`: the map, then `wPlayerDirection & %1100` against `OW_UP`, then the
+## faced tile. Everything it passes is `QueueScript` on a `farsjump` to
+## `CardKeySlotScript`, which no importer pins by name; the map's own
+## `bg_event 14, 2, BGEVENT_UP` is that script, and it is the tile the routine
+## already insists the player is facing.
+func card_key_request() -> Dictionary:
+	if not _is_on_key_item_map(&"RADIO_TOWER_3F"):
+		return {"ok": false, "kind": &"card_key_failed", "reason": &"wrong_map"}
+	if player_facing != Gen2WorldSprite.FACING_UP:
+		return {"ok": false, "kind": &"card_key_failed", "reason": &"not_facing_slot"}
+	if facing_cell() != CARD_KEY_SLOT_CELL:
+		return {"ok": false, "kind": &"card_key_failed", "reason": &"not_facing_slot"}
+	return _faced_bg_event_script_request(&"card_key_used", &"card_key_failed")
+
+
+## `_BasementKey`, which is `_CardKey` without the direction test: the door is a
+## `BGEVENT_READ`, so it answers whichever way the player is facing it from.
+func basement_key_request() -> Dictionary:
+	if not _is_on_key_item_map(&"GOLDENROD_UNDERGROUND"):
+		return {"ok": false, "kind": &"basement_key_failed", "reason": &"wrong_map"}
+	if facing_cell() != BASEMENT_DOOR_CELL:
+		return {"ok": false, "kind": &"basement_key_failed", "reason": &"not_facing_door"}
+	return _faced_bg_event_script_request(&"basement_key_used", &"basement_key_failed")
+
+
+## `_Squirtbottle`, which differs from the other two in never failing:
+## `wItemEffectSucceeded` is set before the script is queued, and
+## `.CheckCanUseSquirtbottle` only picks which half of it runs. So the refusal is
+## the queued script's own `_SquirtbottleNothingText` rather than `.Oak`.
+##
+## The test is `GetFacingObject` and `cp SPRITEMOVEDATA_SUDOWOODO`, the same
+## shape rock_smash_request() uses, behind the Route 36 map check.
+func squirtbottle_request() -> Dictionary:
+	var nothing: Dictionary = {"ok": true, "kind": &"squirtbottle_nothing"}
+	if not _is_on_key_item_map(&"ROUTE_36"):
+		return nothing
+	var tree: Gen2WorldObject = object_at(object_facing_cell())
+	if tree == null or not tree.is_sudowoodo():
+		return nothing
+	var script: Dictionary = _watered_weird_tree_script(tree.index)
+	if script.is_empty():
+		return nothing
+	script["ok"] = true
+	script["kind"] = &"squirtbottle_watered"
+	script["bank"] = int(current_map.events.get("bank", 0))
+	return script
+
+
+## `WateredWeirdTreeScript` is a label inside `SudowoodoScript` that no event
+## points at, so the cache carries no pointer of its own. Its position is
+## structural instead: the object's script opens `checkitem SQUIRTBOTTLE / iftrue
+## .Fight`, and the label sits just past the `closetext` that ends `.Fight`'s
+## yes/no ask. `.Fight` is a branch target and so is cached, which is why the
+## answer is that address and an offset into it rather than a bare address.
+## Empty for anything that does not decode that way.
+func _watered_weird_tree_script(object_index: int) -> Dictionary:
+	if data == null or current_map == null:
+		return {}
+	var rows: Array = current_map.events.get("objects", [])
+	if object_index < 0 or object_index >= rows.size():
+		return {}
+	var bank: int = int(current_map.events.get("bank", 0))
+	## Both opcodes sit below `$52`, where the two command tables still agree,
+	## so neither needs resolving through Gen2WorldScript.raw_opcode().
+	var branch: int = _script_command_end(
+		bank, int((rows[object_index] as Dictionary).get("script", 0)),
+		Gen2WorldScript.IFTRUE, true
+	)
+	if branch <= 0:
+		return {}
+	var offset: int = _script_command_end(bank, branch, Gen2WorldScript.CLOSETEXT, false)
+	return {"script": branch, "offset": offset} if offset > 0 else {}
+
+
+## Walks a script from [param address] to the first [param opcode]. Answers that
+## command's branch target when [param branch] is set, and otherwise how many
+## bytes in the command after it starts. 0 for a stream that ends or fails to
+## decode first, which is what leaves a caller with no label to jump to.
+func _script_command_end(bank: int, address: int, opcode: int, branch: bool) -> int:
+	var crystal: bool = data.id != &"gold" and data.id != &"silver"
+	var raw: PackedByteArray = data.world_script(bank, address)
+	var offset: int = 0
+	while offset < raw.size():
+		var command: Dictionary = Gen2WorldScript.command_at(raw, offset, crystal)
+		if not bool(command.get("ok", false)):
+			return 0
+		offset += int(command["width"])
+		if int(command["opcode"]) == opcode:
+			return int(command.get("address", 0)) if branch else offset
+	return 0
+
+
+## The `farsjump` the two key items end on: the script the faced cell's own
+## background event names, which is the label each routine jumps to.
+func _faced_bg_event_script_request(kind: StringName, failure: StringName) -> Dictionary:
+	for event: Dictionary in _active_events_at(facing_cell()):
+		if event.get("kind", &"") != &"bg_events":
+			continue
+		var script: int = _script_address_for_event(event)
+		if script <= 0:
+			continue
+		return {
+			"ok": true,
+			"kind": kind,
+			"bank": int(current_map.events.get("bank", 0)),
+			"script": script,
+			"cell": facing_cell(),
+		}
+	return {"ok": false, "kind": failure, "reason": &"missing_script"}
+
+
+## `QueueScript` for a resolved key-item effect: the request the pack answered
+## with is queued and run, so its script reaches the host exactly as an
+## interaction's does.
+func queue_item_script(request: Dictionary) -> Array:
+	if current_map == null or int(request.get("script", 0)) <= 0:
+		return []
+	_enqueue_script({
+		"kind": StringName(request.get("kind", &"item_script")),
+		"map_group": current_map.group,
+		"map_number": current_map.number,
+		"cell": player_cell,
+		"bank": int(request.get("bank", 0)),
+		"script": int(request.get("script", 0)),
+		"offset": int(request.get("offset", 0)),
+	})
+	return run_event_queue(false)
+
+
 ## `.TryFish`'s own refusals, asked without casting: the pack has to know whether
 ## `FishFunction` would reach `.FailFish` before it decides to close.
 func fishing_check(rod: StringName) -> Dictionary:

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -29,6 +29,10 @@ const MOVEMENT_STRENGTH_BOULDER: int = 0x19
 ## reacts to being smashed. Its flags1 are the boulder's, minus the palette bit
 ## and plus USE_OBP1, so nothing but the movement byte tells the two apart.
 const MOVEMENT_SMASHABLE_ROCK: int = 0x18
+## SPRITEMOVEDATA_SUDOWOODO, the row above the rock and in neither template set
+## for the same reason. Route 36's weird tree is the only object in either game
+## on it, and `.CheckCanUseSquirtbottle` is the only reader.
+const MOVEMENT_SUDOWOODO: int = 0x17
 const MOVEMENT_SWIM_WANDER: int = 0x24
 ## The three rows data/sprites/map_objects.asm gives BIG_OBJECT in their palette
 ## flags. Only two objects in either game use one: the player's bedroom big doll
@@ -182,6 +186,12 @@ func is_strength_boulder() -> bool:
 ## rather than a palette flag the row happens to carry.
 func is_smashable_rock() -> bool:
 	return movement == MOVEMENT_SMASHABLE_ROCK
+
+
+## `.CheckCanUseSquirtbottle`'s own test, read the same way: `GetFacingObject`
+## answers MAPOBJECT_MOVEMENT and the whole check is `cp SPRITEMOVEDATA_SUDOWOODO`.
+func is_sudowoodo() -> bool:
+	return movement == MOVEMENT_SUDOWOODO
 
 
 ## OBJECT_PALETTE bit SWIMMING, which CanObjectMoveInDirection reads to pick

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -226,31 +226,41 @@ static func can_hold(data: GameData, item: int) -> bool:
 	return pocket_for(data, item) != TYPE_KEY_ITEM
 
 
-## The `ItemEffects` entries `.Field` reaches whose effect the overworld can run,
-## by the item number `data/items/attributes.asm` gives ITEMMENU_CLOSE. Every
-## other CLOSE item still falls through to `.Oak`; `HANDOFF.md` names what each
-## of those is waiting for.
+## The `ItemEffects` entries `.Field` reaches, by the item number
+## `data/items/attributes.asm` gives ITEMMENU_CLOSE. Every CLOSE item in either
+## pin is here; anything else with that nibble is a mod's, and falls through to
+## `.Oak` because no effect answers for it.
 const FIELD_EFFECT_NONE: StringName = &""
 const FIELD_EFFECT_BICYCLE: StringName = &"bicycle"
 const FIELD_EFFECT_ESCAPE_ROPE: StringName = &"escape_rope"
 const FIELD_EFFECT_ROD: StringName = &"rod"
-const FIELD_EFFECT_COIN_CASE: StringName = &"coin_case"
 const FIELD_EFFECT_ITEMFINDER: StringName = &"itemfinder"
 const FIELD_EFFECT_SACRED_ASH: StringName = &"sacred_ash"
+const FIELD_EFFECT_CARD_KEY: StringName = &"card_key"
+const FIELD_EFFECT_BASEMENT_KEY: StringName = &"basement_key"
+const FIELD_EFFECT_SQUIRTBOTTLE: StringName = &"squirtbottle"
 const ITEM_BICYCLE: int = 0x07
 const ITEM_ESCAPE_ROPE: int = 0x13
+## `CoinCaseEffect` is the one key item on `.Current` rather than `.Field`: it
+## prints its count inside the pack and closes nothing, so it has no field
+## effect and the screen answers it where the other CURRENT rows are answered.
 const ITEM_COIN_CASE: int = 0x36
 const ITEM_ITEMFINDER: int = 0x37
 const ITEM_SACRED_ASH: int = 0x9C
+const ITEM_CARD_KEY: int = 0x7F
+const ITEM_BASEMENT_KEY: int = 0x85
+const ITEM_SQUIRTBOTTLE: int = 0xAF
 const FIELD_EFFECTS: Dictionary = {
 	ITEM_BICYCLE: FIELD_EFFECT_BICYCLE,
 	ITEM_ESCAPE_ROPE: FIELD_EFFECT_ESCAPE_ROPE,
-	ITEM_COIN_CASE: FIELD_EFFECT_COIN_CASE,
 	ITEM_ITEMFINDER: FIELD_EFFECT_ITEMFINDER,
 	Gen2WorldInventory.ITEM_OLD_ROD: FIELD_EFFECT_ROD,
 	Gen2WorldInventory.ITEM_GOOD_ROD: FIELD_EFFECT_ROD,
 	Gen2WorldInventory.ITEM_SUPER_ROD: FIELD_EFFECT_ROD,
+	ITEM_CARD_KEY: FIELD_EFFECT_CARD_KEY,
+	ITEM_BASEMENT_KEY: FIELD_EFFECT_BASEMENT_KEY,
 	ITEM_SACRED_ASH: FIELD_EFFECT_SACRED_ASH,
+	ITEM_SQUIRTBOTTLE: FIELD_EFFECT_SQUIRTBOTTLE,
 }
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -22,6 +22,11 @@ const ITEM_POKE_BALL: int = 0x05
 ## what holds it and `BattleMenu_Pack`'s contest branch loads it by name.
 const ITEM_PARK_BALL: int = 0xB1
 
+## HAPPINESS_THRESHOLD_1 and HAPPINESS_THRESHOLD_2
+## (constants/pokemon_data_constants.asm), which pick a HappinessChanges column.
+const HAPPINESS_THRESHOLD_1: int = 100
+const HAPPINESS_THRESHOLD_2: int = 200
+
 const CAPTURE_BALLS: Array[int] = [
 	ITEM_POKE_BALL, ITEM_GREAT_BALL, ITEM_ULTRA_BALL, ITEM_MASTER_BALL,
 ]
@@ -367,7 +372,14 @@ static func teach_tm_hm(
 	learner.pp[slot] = int(world.data.move(move).get("pp", 0))
 
 	var before: Gen2WorldSnapshot = world.snapshot()
+	## `IsHM` returns before both the happiness change and `ConsumeTM`, so an HM
+	## costs nothing and moves nothing; a TM does both, in that order.
 	var consumed: bool = not Gen2WorldTMHM.is_hm(item)
+	var happiness: int = learner.happiness
+	if consumed:
+		learner.happiness = change_happiness(
+			world.data, learner.happiness, RomLayout.HAPPINESS_LEARNMOVE
+		)
 	var applied: Dictionary = {"ok": true}
 	if consumed:
 		applied = world.state.apply_changes({}, {}, {
@@ -389,7 +401,28 @@ static func teach_tm_hm(
 		"forgot": forgot,
 		"pp": learner.pp[slot],
 		"consumed": consumed,
+		"happiness": learner.happiness,
+		"happiness_change": learner.happiness - happiness,
 	}
+
+
+## `ChangeHappiness` over the imported table, without the egg and battle-mon
+## halves: an egg cannot reach a caller here, and no caller runs inside a battle.
+##
+## The three rows are picked by HAPPINESS_THRESHOLD_1 and _2, and the sign of a
+## change is `cp $64`: a byte from 100 up is the subtracting branch, which is why
+## the table is read signed. Each branch answers the carry rather than clamping,
+## so a rise saturates at 255 and a fall at 0.
+static func change_happiness(data: GameData, happiness: int, kind: int) -> int:
+	var changes: Array[int] = []
+	if data != null:
+		changes = data.happiness_changes(kind)
+	if changes.size() < RomLayout.HAPPINESS_CHANGE_WIDTH:
+		return happiness
+	var row: int = 0 if happiness < HAPPINESS_THRESHOLD_1 \
+		else (1 if happiness < HAPPINESS_THRESHOLD_2 else 2)
+	return clampi(happiness + changes[row], 0, 255)
+
 
 
 ## Attempts to catch one wild battle mon and consumes the ball on either result.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1437,17 +1437,19 @@ func preview_field_item(item: int = Gen2WorldPack.ITEM_ITEMFINDER) -> void:
 	if _world == null or _data == null or _start_menu_host != null:
 		return
 	_injected_save = _embedded_party_save()
-	_world.state.apply_changes({}, {}, {"items": {item: 1}})
+	# The coins are for the Coin Case, which is the one row here whose own words
+	# are a number; every other item ignores them.
+	_world.state.apply_changes({}, {}, {"items": {item: 1}, "coins": 1234})
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
 	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
 		_start_menu_host.handle_button(Gen2Button.DOWN)
 	_start_menu_host.handle_button(Gen2Button.A)
-	var pockets: Array = _start_menu_host.get("_pack_pockets")
-	while int(pockets[_start_menu_host.get("_pack_pocket_index")]["pocket"]) \
-		!= Gen2WorldPack.TYPE_KEY_ITEM:
-		_start_menu_host.handle_button(Gen2Button.RIGHT)
+	# The row itself, rather than whichever one the pocket opens on: the save may
+	# already own other key items, and a capture has to photograph the named one.
+	if not bool(_start_menu_host.call("_select_pack_item", item)):
+		return
 	# The row's submenu, and then its first action, which for a key item is USE.
 	_start_menu_host.handle_button(Gen2Button.A)
 	_start_menu_host.handle_button(Gen2Button.A)
@@ -2243,10 +2245,19 @@ func _on_field_item_used(request: Dictionary) -> void:
 				if bool(request.get("found", false)) \
 				else "Nope! ITEMFINDER\nisn't responding."
 			)
-		Gen2WorldPack.FIELD_EFFECT_COIN_CASE:
-			_show_field_move_text("Coins:\n%4d" % int(request.get("coins", 0)))
 		Gen2WorldPack.FIELD_EFFECT_SACRED_ASH:
 			_show_field_move_text("#MON were all\nhealed!")
+		## `farsjump CardKeySlotScript` and `farsjump BasementDoorScript`, each
+		## `QueueScript`d by its own routine, so both run as any map script does.
+		Gen2WorldPack.FIELD_EFFECT_CARD_KEY, Gen2WorldPack.FIELD_EFFECT_BASEMENT_KEY:
+			_show_script_results(_world.queue_item_script(request))
+		## `.SquirtbottleScript`, whose `callasm` picks between the tree's own
+		## script and the line it says when nothing is in front of the player.
+		Gen2WorldPack.FIELD_EFFECT_SQUIRTBOTTLE:
+			if StringName(request.get("kind", &"")) == &"squirtbottle_watered":
+				_show_script_results(_world.queue_item_script(request))
+			else:
+				_show_field_move_text("Sprinkled water.\nBut nothing\nhappened…")
 	_refresh_labels()
 
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -330,6 +330,17 @@ static func begin(
 				runner._stage_hidden_item()
 	else:
 		started = runner._push_frame(bank, address)
+		## A label inside another script has no pointer of its own, so a caller
+		## that resolved one names the script containing it and how far in it
+		## starts. `WateredWeirdTreeScript` is the only one.
+		var offset: int = int(request.get("offset", 0))
+		if started and offset > 0:
+			var frame: Dictionary = runner._frames[runner._frames.size() - 1]
+			if offset >= (frame["data"] as PackedByteArray).size():
+				started = false
+			else:
+				frame["offset"] = offset
+				runner._frames[runner._frames.size() - 1] = frame
 	if not started:
 		runner._fail(&"missing_script", {"bank": bank, "address": address})
 	else:

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -280,8 +280,18 @@ const BEAT_UP: int = 251
 const MAX_MOVE: int = ROLLING_KICK_NEVER
 const BERRY_ITEM: int = 0xAD
 
-## The highest item number this table fills.
-const MAX_ITEM: int = 174
+## data/events/happiness_changes.asm, Crystal's nineteen rows verbatim, because
+## the three columns and their signs are what every happiness test asserts.
+const HAPPINESS_CHANGES: Array = [
+	[5, 3, 2], [5, 3, 2], [1, 1, 0], [3, 2, 1], [1, 1, 0], [-1, -1, -1],
+	[-5, -5, -10], [-5, -5, -10], [1, 1, 1], [3, 3, 1], [5, 5, 2], [1, 1, 1],
+	[3, 3, 1], [10, 10, 4], [-5, -5, -10], [-10, -10, -15], [-15, -15, -20],
+	[3, 3, 1], [10, 6, 4],
+]
+
+## The highest item number this table fills. The SQUIRTBOTTLE at $AF is the
+## last row anything reads, so the run stops there rather than at 255.
+const MAX_ITEM: int = 175
 ## The Smoke Ball and its held effect, both the cartridge's own numbers
 ## (constants/item_constants.asm, constants/item_data_constants.asm). It is the
 ## one item running reads.
@@ -405,6 +415,7 @@ static func build(directory: String) -> GameData:
 	RomCache.write_json(RomCache.types_path(directory), _types())
 	RomCache.write_json(RomCache.matchups_path(directory), _matchups())
 	RomCache.write_json(RomCache.trainers_path(directory), [])
+	RomCache.write_json(RomCache.happiness_changes_path(directory), HAPPINESS_CHANGES)
 	RomCache.write_json(RomCache.manifest_path(directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "testgame",

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -25,11 +25,14 @@ func test_gold_and_silver_share_their_common_layout() -> void:
 			"item_attributes", "item_status_actions", "item_healing_hp",
 			"overworld_icons", "held_item_icons",
 			"copyright", "game_freak_presents", "title",
-			"gs_intro",
+			"gs_intro", "happiness_changes",
 		]:
 			continue
 		assert_eq(gold[key], silver[key], "Gold/Silver layout differs at %s" % key)
 	assert_ne(gold["item_attributes"], silver["item_attributes"])
+	# `HappinessChanges` is the same eighteen rows in bank 1 at its own address on
+	# each, the way the copyright string is.
+	assert_ne(gold["happiness_changes"], silver["happiness_changes"])
 	# Both offsets into the icon bank move together: Silver's copy of it sits
 	# twenty-six bytes lower than Gold's.
 	assert_eq(

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5666,6 +5666,22 @@ func test_the_itemfinder_answers_for_a_hidden_item_inside_the_screen() -> void:
 	assert_false(world.hidden_item_nearby())
 
 
+## The map gate every key-item effect opens with. Only `_Squirtbottle` answers
+## anyway: it writes `wItemEffectSucceeded` before the script it queues decides
+## anything, so the pack closes and the queued script says the line instead.
+## Which script each of the three reaches on its own map is swept over all three
+## cartridges by `tools/checks/pack.gd`, since no synthetic map can carry them.
+func test_a_key_item_effect_refuses_off_its_own_map() -> void:
+	var world := Gen2WorldAPI.open(GameData.open_directory(_directory), 1, 1, Vector2i(8, 7))
+	assert_false(bool(world.card_key_request().get("ok", false)))
+	assert_false(bool(world.basement_key_request().get("ok", false)))
+
+	var nothing: Dictionary = world.squirtbottle_request()
+	assert_true(bool(nothing.get("ok", false)))
+	assert_eq(StringName(nothing.get("kind", &"")), &"squirtbottle_nothing")
+	assert_true(world.queue_item_script(nothing).is_empty())
+
+
 func _item_name(number: int) -> String:
 	return GameData.open_directory(_directory).item_name(number)
 

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -231,12 +231,22 @@ func test_the_field_effects_are_the_close_items_the_overworld_can_run() -> void:
 	)
 	for rod: int in [0x3A, 0x3B, 0x3D]:
 		assert_eq(Gen2WorldPack.field_effect(data, rod), Gen2WorldPack.FIELD_EFFECT_ROD)
-	assert_eq(Gen2WorldPack.field_effect(data, 0x36), Gen2WorldPack.FIELD_EFFECT_COIN_CASE)
 	assert_eq(Gen2WorldPack.field_effect(data, 0x37), Gen2WorldPack.FIELD_EFFECT_ITEMFINDER)
 	assert_eq(Gen2WorldPack.field_effect(data, 0x9C), Gen2WorldPack.FIELD_EFFECT_SACRED_ASH)
+	assert_eq(Gen2WorldPack.field_effect(data, 0x7F), Gen2WorldPack.FIELD_EFFECT_CARD_KEY)
+	assert_eq(
+		Gen2WorldPack.field_effect(data, 0x85), Gen2WorldPack.FIELD_EFFECT_BASEMENT_KEY
+	)
+	assert_eq(
+		Gen2WorldPack.field_effect(data, 0xAF), Gen2WorldPack.FIELD_EFFECT_SQUIRTBOTTLE
+	)
+	# `CoinCaseEffect` is on `.Current`, so the Coin Case has no field effect even
+	# with the nibble forced: nothing names it in FIELD_EFFECTS. `tools/checks/
+	# pack.gd` is what proves the real nibbles, which this fixture overwrites.
+	assert_eq(Gen2WorldPack.field_effect(data, 0x36), Gen2WorldPack.FIELD_EFFECT_NONE)
 
-	# The Bicycle is ITEMMENU_CLOSE with no effect built, so it is `.Oak`, and so
-	# is a repointed Escape Rope.
+	# A row off ITEMMENU_CLOSE takes its field effect with it, on the untouched
+	# fixture where neither the Bicycle nor the Escape Rope carries that nibble.
 	assert_eq(Gen2WorldPack.field_effect(_data, ITEM_BICYCLE), Gen2WorldPack.FIELD_EFFECT_NONE)
 	assert_eq(Gen2WorldPack.field_effect(_data, 0x13), Gen2WorldPack.FIELD_EFFECT_NONE)
 	assert_eq(Gen2WorldPack.field_effect(null, 0x13), Gen2WorldPack.FIELD_EFFECT_NONE)

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -313,6 +313,40 @@ func test_teaching_a_tm_consumes_it() -> void:
 	assert_eq(_world.state.item_quantity(TM_ITEM), 1)
 
 
+## `ld c, HAPPINESS_LEARNMOVE` sits between IsHM and ConsumeTM, so a TM moves
+## happiness and an HM does not. HAPPINESS_LEARNMOVE's row is `+1, +1, +0`, which
+## is the one row whose third column is zero: past 200 a TM changes nothing.
+func test_teaching_a_tm_raises_happiness_and_teaching_an_hm_does_not() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.happiness = 70
+	_world.state.apply_changes({}, {}, {"items": {TM_ITEM: 1, HM_ITEM: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, TM_ITEM, 0, -1, false)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(int(result["happiness_change"]), 1)
+	assert_eq(_save.party[0].happiness, 71)
+
+	_save.party[0].happiness = 240
+	var again: Dictionary = Gen2WorldPartyHost.teach_tm_hm(_world, _save, HM_ITEM, 0, -1, false)
+	assert_true(again["ok"], JSON.stringify(again))
+	assert_eq(int(again["happiness_change"]), 0)
+	assert_eq(_save.party[0].happiness, 240)
+
+
+## `ChangeHappiness` itself: the column HAPPINESS_THRESHOLD_1 and _2 pick, and
+## the two saturating branches. Row 6, "Lost to an enemy", is `-1` in all three
+## columns and row 14 `+10, +10, +4`, so one rise and one fall cover both ends.
+func test_a_happiness_change_picks_its_column_and_saturates() -> void:
+	assert_eq(Gen2WorldPartyHost.change_happiness(_data, 99, 14), 109)
+	assert_eq(Gen2WorldPartyHost.change_happiness(_data, 100, 14), 110)
+	assert_eq(Gen2WorldPartyHost.change_happiness(_data, 200, 14), 204)
+	assert_eq(Gen2WorldPartyHost.change_happiness(_data, 254, 14), 255, "no wrap past 255")
+	assert_eq(Gen2WorldPartyHost.change_happiness(_data, 0, 6), 0, "no wrap below 0")
+	# A row this cartridge does not carry, and no cache at all, both leave the
+	# byte alone rather than inventing a change.
+	assert_eq(Gen2WorldPartyHost.change_happiness(_data, 70, 99), 70)
+	assert_eq(Gen2WorldPartyHost.change_happiness(null, 70, 5), 70)
+
+
 ## The refusal order is CanLearnTMHMMove, then KnowsMove, then LearnMove's slot
 ## search. Each answers before anything is written.
 func test_teaching_refuses_an_incompatible_species_without_writing() -> void:

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -20,6 +20,39 @@ var _r: RefCounted = null
 ##
 ##   Godot --headless --path . -s res://tools/validate.gd -- pack
 
+## The ten rows whose field-menu nibble is ITEMMENU_CLOSE, byte identical
+## between the pins. The unit tier writes the nibble onto its own fixture, so
+## only a real cache can say which rows actually carry it: the Coin Case reads
+## like one and is ITEMMENU_CURRENT, printing its count inside the pack.
+const CLOSE_ITEMS: Dictionary = {
+	0x07: "BICYCLE",
+	0x13: "ESCAPE ROPE",
+	0x37: "ITEMFINDER",
+	0x3A: "OLD ROD",
+	0x3B: "GOOD ROD",
+	0x3D: "SUPER ROD",
+	0x7F: "CARD KEY",
+	0x85: "BASEMENT KEY",
+	0x9C: "SACRED ASH",
+	0xAF: "SQUIRTBOTTLE",
+}
+
+## The three maps and cells `card_key.asm`, `basement_key.asm` and
+## `squirtbottle.asm` name, with the cell the player stands on to face each.
+## Group 3 runs eight lower on pokegold from `UNION_CAVE_1F`, which moves the
+## underground and nothing else here.
+const RADIO_TOWER_3F := Vector2i(3, 19)
+const RADIO_TOWER_STAND := Vector2i(14, 3)
+const GOLDENROD_UNDERGROUND_CRYSTAL := Vector2i(3, 53)
+const GOLDENROD_UNDERGROUND_GOLD_SILVER := Vector2i(3, 45)
+const GOLDENROD_UNDERGROUND_STAND := Vector2i(18, 7)
+const ROUTE_36 := Vector2i(10, 3)
+const SUDOWOODO_CELL := Vector2i(35, 9)
+const SUDOWOODO_STAND := Vector2i(35, 10)
+## `.Fight` is `opentext`, `writetext`, `yesorno`, `iffalse` and `closetext`, so
+## `WateredWeirdTreeScript` starts nine bytes into it on all three cartridges.
+const WATERED_TREE_OFFSET: int = 9
+
 ## `constants/item_constants.asm`'s own hex comment column. The five key items
 ## whose `item_attribute` is `CANT_TOSS` alone, which is the whole of what a
 ## player can hand the SELECT button on all three cartridges: every other key
@@ -46,6 +79,8 @@ func run(r: RefCounted) -> void:
 			continue
 		_verify_registerable(game_id, data)
 		_verify_submenus(game_id, data)
+		_verify_field_effects(game_id, data)
+		_verify_key_item_effects(game_id, data)
 
 
 ## `CheckSelectableItem` over the real rows. The eight named key items are the
@@ -115,3 +150,186 @@ func _verify_submenus(game_id: StringName, data: GameData) -> void:
 			"%s: $%02X (%s) is a TM or HM offering SEL." % [game_id, number, name]
 		)
 	print("%s: %d rows can be held by a Pokemon." % [game_id, holdable])
+
+
+## `UseItem`'s jumptable over the real nibbles. Every ITEMMENU_CLOSE row has to
+## have a `.Field` effect and nothing else may claim one: a row named by
+## FIELD_EFFECTS that the cartridge puts on `.Current` or `.Party` is dead, and
+## a CLOSE row with no entry falls through to `.Oak` in silence.
+func _verify_field_effects(game_id: StringName, data: GameData) -> void:
+	var close_rows: Dictionary = {}
+	for number: int in range(1, ITEM_ROWS + 1):
+		if data.item(number).is_empty():
+			continue
+		if Gen2WorldPack.field_use_kind(data, number) == Gen2WorldPack.ITEMMENU_CLOSE:
+			close_rows[number] = true
+		_r.check(
+			not Gen2WorldPack.FIELD_EFFECTS.has(number)
+				or close_rows.has(number),
+			"%s: $%02X (%s) has a field effect but is not ITEMMENU_CLOSE." % [
+				game_id, number, data.item_name(number),
+			]
+		)
+	for number: int in CLOSE_ITEMS:
+		_r.check(
+			close_rows.has(number),
+			"%s: $%02X (%s) is not ITEMMENU_CLOSE on this cache." % [
+				game_id, number, String(CLOSE_ITEMS[number]),
+			]
+		)
+	_r.check(
+		close_rows.size() == CLOSE_ITEMS.size(),
+		"%s: %d rows are ITEMMENU_CLOSE, not the pinned %d." % [
+			game_id, close_rows.size(), CLOSE_ITEMS.size(),
+		]
+	)
+	for number: int in close_rows:
+		_r.check(
+			Gen2WorldPack.field_effect(data, number) != Gen2WorldPack.FIELD_EFFECT_NONE,
+			"%s: $%02X (%s) is ITEMMENU_CLOSE with no field effect." % [
+				game_id, number, data.item_name(number),
+			]
+		)
+	_r.check(
+		Gen2WorldPack.field_effect(data, Gen2WorldPack.ITEM_COIN_CASE)
+			== Gen2WorldPack.FIELD_EFFECT_NONE
+			and Gen2WorldPack.field_use_kind(data, Gen2WorldPack.ITEM_COIN_CASE)
+				== Gen2WorldPack.ITEMMENU_CURRENT,
+		"%s: the COIN CASE is not ITEMMENU_CURRENT." % game_id
+	)
+
+
+## The three key items whose effect is a `farsjump` at a named map script, each
+## driven on the map and cell its own routine insists on. The addresses come from
+## the maps rather than from a pin, which is the whole point: `CardKeySlotScript`
+## and `BasementDoorScript` are the faced cell's own background event, and
+## `WateredWeirdTreeScript` is walked out of `SudowoodoScript`.
+func _verify_key_item_effects(game_id: StringName, data: GameData) -> void:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	_verify_faced_script(
+		game_id, data, RADIO_TOWER_3F, RADIO_TOWER_STAND, Gen2WorldSprite.FACING_UP,
+		&"card_key", Gen2WorldAPI.CARD_KEY_SLOT_CELL
+	)
+	_verify_faced_script(
+		game_id, data,
+		GOLDENROD_UNDERGROUND_CRYSTAL if crystal else GOLDENROD_UNDERGROUND_GOLD_SILVER,
+		GOLDENROD_UNDERGROUND_STAND, Gen2WorldSprite.FACING_UP,
+		&"basement_key", Gen2WorldAPI.BASEMENT_DOOR_CELL
+	)
+	_verify_squirtbottle(game_id, data)
+
+
+## One key item's request, both ways round: the faced cell answers with the
+## background event's own script, and the cell beside it answers `.Oak`.
+func _verify_faced_script(
+	game_id: StringName,
+	data: GameData,
+	map: Vector2i,
+	stand: Vector2i,
+	facing: int,
+	item: StringName,
+	target: Vector2i
+) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, map.x, map.y, stand, Gen2WorldState.new()
+	)
+	if not _r.check(world != null, "%s: map %s is missing." % [game_id, map]):
+		return
+	world.player_facing = facing
+	if not _r.check(
+		world.facing_cell() == target,
+		"%s: %s stands facing %s, not %s." % [game_id, item, world.facing_cell(), target]
+	):
+		return
+	var expected: int = 0
+	for event: Variant in world.current_map.events.get("bg_events", []):
+		var row: Dictionary = event
+		if Vector2i(int(row.get("x", -1)), int(row.get("y", -1))) == target:
+			expected = int(row.get("script", 0))
+	var request: Dictionary = world.card_key_request() if item == &"card_key" \
+		else world.basement_key_request()
+	if not _r.check(
+		bool(request.get("ok", false)) and int(request.get("script", 0)) == expected
+			and expected > 0,
+		"%s: %s answered %s, not the background event's script $%04X." % [
+			game_id, item, request, expected,
+		]
+	):
+		return
+	## Both scripts open a text box, so a queued one that says nothing means the
+	## address decoded but the runner could not fetch it.
+	var events: Array = world.queue_item_script(request)
+	_r.check(
+		not events.is_empty()
+			and StringName((events[0] as Dictionary).get("status", &"")) == &"waiting"
+			and StringName(
+				((events[0] as Dictionary).get("event", {}) as Dictionary).get("type", &"")
+			) == &"text",
+		"%s: %s queued a script that said nothing: %s." % [game_id, item, events]
+	)
+	print("%s: %s reaches $%02X:$%04X and opens with its text." % [
+		game_id, item, int(request.get("bank", 0)), int(request.get("script", 0)),
+	])
+
+	# One cell to the side is the same map and not the faced tile, which is where
+	# both routines answer FALSE and the pack says `.Oak`.
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var refused: Dictionary = world.card_key_request() if item == &"card_key" \
+		else world.basement_key_request()
+	_r.check(
+		not bool(refused.get("ok", false)),
+		"%s: %s answered off its own tile: %s." % [game_id, item, refused]
+	)
+
+
+## `.CheckCanUseSquirtbottle`, which never refuses: the tree in front answers
+## with `WateredWeirdTreeScript` and anything else with the line the queued
+## script says instead.
+func _verify_squirtbottle(game_id: StringName, data: GameData) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ROUTE_36.x, ROUTE_36.y, SUDOWOODO_STAND, Gen2WorldState.new()
+	)
+	if not _r.check(world != null, "%s: Route 36 is missing." % game_id):
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var tree: Gen2WorldObject = world.object_at(SUDOWOODO_CELL)
+	if not _r.check(
+		tree != null and tree.is_sudowoodo(),
+		"%s: Route 36 %s is not the weird tree." % [game_id, SUDOWOODO_CELL]
+	):
+		return
+	var watered: Dictionary = world.squirtbottle_request()
+	if not _r.check(
+		StringName(watered.get("kind", &"")) == &"squirtbottle_watered"
+			and int(watered.get("offset", 0)) == WATERED_TREE_OFFSET,
+		"%s: the squirtbottle answered %s, not %d bytes into `.Fight`." % [
+			game_id, watered, WATERED_TREE_OFFSET,
+		]
+	):
+		return
+	## The address is only half of it: an interior label has no pointer of its
+	## own, so what proves the walk is that the runner reaches the tree's own
+	## text from it. `opentext` and `writetext` are the label's first two
+	## commands, so the first thing the queued script does is say them.
+	var events: Array = world.queue_item_script(watered)
+	_r.check(
+		not events.is_empty()
+			and StringName((events[0] as Dictionary).get("status", &"")) == &"waiting"
+			and StringName(
+				((events[0] as Dictionary).get("event", {}) as Dictionary).get("type", &"")
+			) == &"text",
+		"%s: the watered tree script did not open with its text: %s." % [game_id, events]
+	)
+	print("%s: squirtbottle reaches $%02X:$%04X + %d and opens with its text." % [
+		game_id, int(watered.get("bank", 0)), int(watered.get("script", 0)),
+		int(watered.get("offset", 0)),
+	])
+
+	# Facing away is the `.nope` branch, which is still an effect that succeeded.
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var nothing: Dictionary = world.squirtbottle_request()
+	_r.check(
+		bool(nothing.get("ok", false))
+			and StringName(nothing.get("kind", &"")) == &"squirtbottle_nothing",
+		"%s: the squirtbottle away from the tree answered %s." % [game_id, nothing]
+	)

--- a/tools/checks/tmhm.gd
+++ b/tools/checks/tmhm.gd
@@ -48,6 +48,21 @@ const EXPECTED_LEARNABLE_PAIRS: Dictionary = {
 	&"silver": 6372,
 	&"crystal": 6592,
 }
+## data/events/happiness_changes.asm verbatim. pokegold stops after Grooming;
+## Crystal adds HAPPINESS_GAINLEVELATHOME, and the eighteen rows before it are
+## byte identical.
+const EXPECTED_HAPPINESS_CHANGES: Array = [
+	[5, 3, 2], [5, 3, 2], [1, 1, 0], [3, 2, 1], [1, 1, 0], [-1, -1, -1],
+	[-5, -5, -10], [-5, -5, -10], [1, 1, 1], [3, 3, 1], [5, 5, 2], [1, 1, 1],
+	[3, 3, 1], [10, 10, 4], [-5, -5, -10], [-10, -10, -15], [-15, -15, -20],
+	[3, 3, 1], [10, 6, 4],
+]
+const EXPECTED_HAPPINESS_ROWS: Dictionary = {
+	&"gold": RomLayout.HAPPINESS_CHANGE_COUNT_GOLD_SILVER,
+	&"silver": RomLayout.HAPPINESS_CHANGE_COUNT_GOLD_SILVER,
+	&"crystal": RomLayout.HAPPINESS_CHANGE_COUNT,
+}
+
 ## Caterpie, Ditto, Kakuna, Magikarp, Metapod, Smeargle, Unown, Weedle and
 ## Wobbuffet, the same nine in both games.
 const EXPECTED_SPECIES_WITH_NONE: int = 9
@@ -64,6 +79,7 @@ func run(r: RefCounted) -> void:
 		_verify_item_numbers(game_id, data)
 		_verify_forget_move(game_id, data)
 		_census(game_id, data)
+		_verify_happiness_changes(game_id, data)
 
 
 ## home/hm_moves.asm's IsHMMove against the cartridge's own HM rows.
@@ -208,3 +224,34 @@ func _census(game_id: StringName, data: GameData) -> void:
 			game_id, species_with_none, EXPECTED_SPECIES_WITH_NONE,
 		]
 	)
+
+
+## data/events/happiness_changes.asm as the cache carries it, which is what
+## `TeachTMHM`'s `ld c, HAPPINESS_LEARNMOVE` reads. Every row is compared, not
+## only the one a TM uses: the table is one addressable block and a stride or a
+## sign read the wrong way is invisible on a single row of `+1, +1, +0`.
+func _verify_happiness_changes(game_id: StringName, data: GameData) -> void:
+	var rows: int = EXPECTED_HAPPINESS_ROWS.get(game_id, 0)
+	for row: int in rows:
+		_r.check(
+			data.happiness_changes(row + 1) == EXPECTED_HAPPINESS_CHANGES[row],
+			"%s: happiness row %d is %s, not the pinned %s." % [
+				game_id, row + 1, data.happiness_changes(row + 1),
+				EXPECTED_HAPPINESS_CHANGES[row],
+			]
+		)
+	_r.check(
+		data.happiness_changes(rows + 1).is_empty(),
+		"%s: happiness row %d exists; the table is %d rows." % [game_id, rows + 1, rows]
+	)
+	## `TeachTMHM`'s own row, named so the one the project actually runs is
+	## checked by constant rather than by index.
+	_r.check(
+		data.happiness_changes(RomLayout.HAPPINESS_LEARNMOVE) == [1, 1, 0],
+		"%s: HAPPINESS_LEARNMOVE is %s, not +1, +1, +0." % [
+			game_id, data.happiness_changes(RomLayout.HAPPINESS_LEARNMOVE),
+		]
+	)
+	print("%s: %d happiness rows, HAPPINESS_LEARNMOVE %s." % [
+		game_id, rows, data.happiness_changes(RomLayout.HAPPINESS_LEARNMOVE),
+	])

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -13,9 +13,11 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y]
 ##
 ## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
-## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `field_item` (the
-## pack's own USE on the Itemfinder, which closes the pack over the world's
-## answer) or `bike` (the same USE on the Bicycle). The two numbers are the cell
+## `cut` (`OWCutAnimation`'s two halves and the jump shadow), or one of
+## [constant FIELD_ITEMS]' own names, which is the pack's USE on that item: the
+## Itemfinder closes the pack over the world's answer, the Coin Case prints
+## inside the pack, and the three in [constant FACE_UP_FIRST] each need their own
+## map and the cell below their target. The two numbers are the cell
 ## the player stands on, which is how the grass a standing object is drawn behind
 ## is photographed.
 
@@ -24,6 +26,25 @@ const WINDOW_SIZE := Vector2i(1152, 648)
 ## on its first facing and the boulder dust on its second, so every one of them
 ## is up and none is on the frame it was spawned. Cut needs more: its tree stands
 ## for three frames before it splits, and its leaves open on top of each other.
+## The `kind`s that are a pack USE rather than a staged sprite, and the item
+## each one uses. Every one of them is driven through the pack's own key item
+## pocket, so the picture is the screen's answer and not a staged state.
+const FIELD_ITEMS: Dictionary = {
+	&"field_item": Gen2WorldPack.ITEM_ITEMFINDER,
+	&"bike": Gen2WorldPack.ITEM_BICYCLE,
+	&"coin_case": Gen2WorldPack.ITEM_COIN_CASE,
+	&"squirtbottle": Gen2WorldPack.ITEM_SQUIRTBOTTLE,
+	&"card_key": Gen2WorldPack.ITEM_CARD_KEY,
+	&"basement_key": Gen2WorldPack.ITEM_BASEMENT_KEY,
+}
+
+## The three whose effect reads what the player is facing. Each is photographed
+## from the cell below its own target, so one press turns without moving: the
+## tree, the slot and the door all block their own cell.
+const FACE_UP_FIRST: Array[StringName] = [
+	&"squirtbottle", &"card_key", &"basement_key",
+]
+
 const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_CUT: int = 12
 
@@ -105,10 +126,10 @@ func _process(_delta: float) -> bool:
 		return false
 	_frames += 1
 	if _frames == 2:
-		if _kind == &"field_item":
-			_screen.preview_field_item()
-		elif _kind == &"bike":
-			_screen.preview_field_item(Gen2WorldPack.ITEM_BICYCLE)
+		if FIELD_ITEMS.has(_kind):
+			if _kind in FACE_UP_FIRST:
+				_screen.move_up()
+			_screen.preview_field_item(int(FIELD_ITEMS[_kind]))
 		else:
 			_screen.preview_effect_sprites(_kind)
 		for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):


### PR DESCRIPTION
`_Squirtbottle`, `_CardKey` and `_BasementKey` were the whole of what still fell through to `.Oak`. Each tests a map and a `GetFacingTileCoord` result and then `farsjump`s at a label no importer pins, and each of those labels is already in the cache: the two door scripts are the faced cell's own background event, and `WateredWeirdTreeScript` is nine bytes into the branch `SudowoodoScript`'s `iftrue` takes. A script request can now name a containing script and an offset into it, which is what the runner needs to start partway in.

The Coin Case was on the field path and is not a field item: `data/items/attributes.asm` gives it `ITEMMENU_CURRENT`, so `CoinCaseEffect` prints inside the pack and the pack stays open. Its entry there was unreachable on a real cache; the count is now printed where `.Current` runs.

`HappinessChanges` is imported, so `TeachTMHM` spends its `ld c, HAPPINESS_LEARNMOVE` between `IsHM` and `ConsumeTM`: a TM moves the learner's happiness by its own column and an HM still costs nothing. The column is picked by `HAPPINESS_THRESHOLD_1` and `_2` and each branch answers the carry, so a rise saturates at 255 and a fall at 0. **Cache format 57: import the same dumps again.**

## Proving it

| Check | Result |
|---|---|
| `validate.gd -- all` | 45 topics PASS, exit 0 |
| `pack` topic | the three key items resolve and open their own text on Gold, Silver and Crystal; ten `ITEMMENU_CLOSE` rows, each with an effect |
| `tmhm` topic | 18 happiness rows on Gold and Silver, 19 on Crystal, every one compared |
| GUT | 2,932 over 148 scripts, green; unit tier 2,587 |
| `replay_world.gd` | 27 routes, 0 failures |
| story walk | Gold 291, Silver 291, Crystal 294 steps, 16 badges each |
| import | `layout: Layout verified.` on all three |