### PR TITLE
The Unown dex, and the words on the chamber walls

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -748,6 +748,18 @@ func opponent_of(side: int) -> int:
 	return ENEMY if side == PLAYER else PLAYER
 
 
+## Which Unown letter a Pokémon is, 1 being A, and zero for anything else.
+##
+## `_GetFrontpic` draws Unown out of `UnownPicPointers` by `wUnownLetter`, which
+## `GetUnownLetter` fills from the same DVs the stats came from. It is a display
+## value the way the level and the HP in an event are, so it travels with the
+## send-out rather than being read off the party by whatever draws the picture.
+static func unown_form_of(battler: Gen2BattleMon) -> int:
+	if battler == null or battler.species != RomLayout.UNOWN_SPECIES:
+		return 0
+	return Gen2Stats.unown_letter(battler.persistent_dvs())
+
+
 ## `BattleCommand_FreezeTarget`'s own tail, which writes the flag on the side it
 ## just froze so [method _tick_defrost] leaves that one alone this turn.
 func mark_just_got_frozen(side: int) -> void:
@@ -1318,6 +1330,7 @@ func send_out(
 		"type": SENT_OUT, "side": side, "index": index,
 		"species": current.active_mon().species, "level": current.active_mon().level,
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
+		"unown_form": unown_form_of(current.active_mon()),
 	})
 	(_participants[side] as Dictionary)[index] = true
 	if dragged_by >= 0:

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -231,20 +231,35 @@ func _pic_layer(
 func _ensure_pixels() -> void:
 	var enemy_key: Array = [
 		int(_view.get("enemy_species", 0)), bool(_view.get("enemy_substitute", false)),
+		int(_view.get("enemy_unown_form", 0)),
 	]
 	if enemy_key != _enemy_pixels_key:
 		_enemy_pixels = _substitute_pic(false) if bool(enemy_key[1]) \
-			else _padded_pic(_data.species_pic(int(enemy_key[0])), Gen2BattleScreenMap.ENEMY_SIDE)
+			else _padded_pic(
+				_battler_pic(int(enemy_key[0]), int(enemy_key[2]), false),
+				Gen2BattleScreenMap.ENEMY_SIDE
+			)
 		_enemy_pixels_key = enemy_key
 	var player_key: Array = [
 		int(_view.get("player_species", 0)), bool(_view.get("player_substitute", false)),
+		int(_view.get("player_unown_form", 0)),
 	]
 	if player_key != _player_pixels_key:
 		_player_pixels = _substitute_pic(true) if bool(player_key[1]) \
 			else _padded_pic(
-				_data.species_pic(int(player_key[0]), true), Gen2BattleScreenMap.PLAYER_SIDE
+				_battler_pic(int(player_key[0]), int(player_key[2]), true),
+				Gen2BattleScreenMap.PLAYER_SIDE
 			)
 		_player_pixels_key = player_key
+
+
+## `_GetFrontpic`'s own branch: Unown is drawn out of `UnownPicPointers` by
+## letter, and everything else out of the species table. The atlas is indexed
+## from zero and a letter counts from one, which is the subtraction here.
+func _battler_pic(species: int, unown_form: int, back: bool) -> Dictionary:
+	if species == RomLayout.UNOWN_SPECIES and unown_form > 0:
+		return _data.unown_pic(unown_form - 1, back)
+	return _data.species_pic(species, back)
 
 
 func _substitute_pic(player_side: bool) -> PackedByteArray:

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -270,6 +270,10 @@ var _enemy_trainer_index: int = 0
 
 var _enemy: int = 1
 var _player: int = 1
+## Which Unown letter each side's picture is, and zero for every other species.
+## Drawn values like the two above: they follow the events rather than the party.
+var _enemy_unown_form: int = 0
+var _player_unown_form: int = 0
 var _enemy_level: int = 5
 var _player_level: int = 5
 var _enemy_hp: int = 0
@@ -821,6 +825,10 @@ func _init_battle_display() -> void:
 	## reading the options file itself, since it is scene-free; this is the one
 	## place every battle here passes through.
 	_battle.battle_style_set = Gen2OptionsStore.current().battle_style_set
+	## `InitBattleDisplay` draws both pics, so the letters start from the party
+	## the same way the species above do; every later change is a send-out.
+	_enemy_unown_form = Gen2Battle.unown_form_of(_battle.enemy)
+	_player_unown_form = Gen2Battle.unown_form_of(_battle.player)
 	_close_switch()
 	_reseed_bg_map()
 	set_hp(
@@ -2920,10 +2928,12 @@ func _apply_event_state(event: Dictionary) -> void:
 			if int(event["side"]) == Gen2Battle.ENEMY:
 				enemy_seen.emit(int(event["species"]))
 				_enemy = int(event["species"])
+				_enemy_unown_form = int(event.get("unown_form", 0))
 				_enemy_level = int(event["level"])
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				_player = int(event["species"])
+				_player_unown_form = int(event.get("unown_form", 0))
 				_player_level = int(event["level"])
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
 			# A send-out draws a picture through `GetBattleMonBackpic` or
@@ -3624,6 +3634,8 @@ func _push_view() -> void:
 		return
 	_renderer.set_view({
 		"enemy_species": _enemy, "player_species": _player,
+		"enemy_unown_form": _enemy_unown_form,
+		"player_unown_form": _player_unown_form,
 		## Whose picture is the substitute's doll rather than the Pokémon's own.
 		"enemy_substitute": bool(_substitute_pic[Gen2Battle.ENEMY]),
 		"player_substitute": bool(_substitute_pic[Gen2Battle.PLAYER]),

--- a/game/battle/stats.gd
+++ b/game/battle/stats.gd
@@ -24,6 +24,9 @@ const MAX_STAT_VALUE: int = 999
 const MAX_DV: int = 15
 const MAX_STAT_EXP: int = 65535
 
+## `ld a, $ff / NUM_UNOWN + 1`, assembled rather than computed: 255 / 26 is 9.
+const UNOWN_LETTER_DIVISOR: int = 10
+
 ## The cartridge finds a square root by walking a table of squares, so it stops
 ## at the last entry rather than at the true root. Stat experience above 255
 ## squared is therefore wasted, and the most a full stat exp bar is worth is 63.
@@ -111,6 +114,22 @@ static func speed_dv(dvs: int) -> int:
 ## arrived in Generation 2 for base stats and stat experience but not for DVs.
 static func special_dv(dvs: int) -> int:
 	return (dvs >> DV_SPECIAL_SHIFT) & 0xF
+
+
+## Which of Unown's twenty-six letters a Pokémon with these DVs is, 1 being A.
+##
+## `GetUnownLetter` (engine/gfx/load_pics.asm) takes the middle two bits of each
+## DV in the order attack, defense, speed, special, packs them into one byte and
+## divides by `$ff / NUM_UNOWN + 1`, which is ten. So a letter is one more than a
+## byte that only ever holds those eight bits: the highest is $FF, which is Z.
+## Nothing stores the letter, here or on the cartridge; it is read off the DVs
+## every time the pic, the dex or a wild encounter needs it.
+static func unown_letter(dvs: int) -> int:
+	var packed: int = ((attack_dv(dvs) & 0x6) << 5) | ((defense_dv(dvs) & 0x6) << 3) \
+		| ((speed_dv(dvs) & 0x6) << 1) | ((special_dv(dvs) & 0x6) >> 1)
+	@warning_ignore("integer_division")
+	var letter: int = packed / UNOWN_LETTER_DIVISOR
+	return letter + 1
 
 
 ## Packs four DVs into the word the cartridge stores, which is what a caller

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -61,6 +61,7 @@ var _town_map: Dictionary = {}
 var _oak_ratings: Dictionary = {}
 var _pokecenter_pc: Dictionary = {}
 var _unown_words: PackedStringArray = PackedStringArray()
+var _unown_walls: PackedStringArray = PackedStringArray()
 var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _gs_intro: Dictionary = {}
@@ -147,6 +148,10 @@ static func open_directory(path: String) -> GameData:
 	if unown_words is Array:
 		for word: Variant in unown_words as Array:
 			data._unown_words.append(String(word))
+	var unown_walls: Variant = manifest.get("unown_walls", [])
+	if unown_walls is Array:
+		for wall: Variant in unown_walls as Array:
+			data._unown_walls.append(String(wall))
 	var credits: Variant = manifest.get("credits", {})
 	data._credits = credits if credits is Dictionary else {}
 	var intro_movie: Variant = manifest.get("intro_movie", {})
@@ -1351,6 +1356,15 @@ func unown_word(form: int) -> String:
 	if form < 1 or form > _unown_words.size():
 		return ""
 	return _unown_words[form - 1]
+
+
+## The word `DisplayUnownWords` spells on a chamber wall, by its own
+## `UNOWNWORDS_*` index. Empty for an index outside the four and on Gold and
+## Silver, which ship neither the words nor the special that draws them.
+func unown_wall_word(index: int) -> String:
+	if index < 0 or index >= _unown_walls.size():
+		return ""
+	return _unown_walls[index]
 
 
 ## `OakRatings`, as [code]{ threshold, sfx, text }[/code] rows in table order.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -60,6 +60,7 @@ var _title: Dictionary = {}
 var _town_map: Dictionary = {}
 var _oak_ratings: Dictionary = {}
 var _pokecenter_pc: Dictionary = {}
+var _unown_words: PackedStringArray = PackedStringArray()
 var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _gs_intro: Dictionary = {}
@@ -142,6 +143,10 @@ static func open_directory(path: String) -> GameData:
 	data._oak_ratings = oak_ratings if oak_ratings is Dictionary else {}
 	var pokecenter_pc: Variant = manifest.get("pokecenter_pc", {})
 	data._pokecenter_pc = pokecenter_pc if pokecenter_pc is Dictionary else {}
+	var unown_words: Variant = manifest.get("unown_words", [])
+	if unown_words is Array:
+		for word: Variant in unown_words as Array:
+			data._unown_words.append(String(word))
 	var credits: Variant = manifest.get("credits", {})
 	data._credits = credits if credits is Dictionary else {}
 	var intro_movie: Variant = manifest.get("intro_movie", {})
@@ -1338,6 +1343,14 @@ func pokecenter_pc_lists(players: bool = false) -> Array:
 func pokecenter_pc_text(name: String) -> String:
 	var texts: Variant = _pokecenter_pc.get("texts", {})
 	return String((texts as Dictionary).get(name, "")) if texts is Dictionary else ""
+
+
+## The word `PrintUnownWord` puts under Unown form [param form], A being 1.
+## Empty for a form outside the range or a cache imported without the table.
+func unown_word(form: int) -> String:
+	if form < 1 or form > _unown_words.size():
+		return ""
+	return _unown_words[form - 1]
 
 
 ## `OakRatings`, as [code]{ threshold, sfx, text }[/code] rows in table order.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 58
+const FORMAT_VERSION: int = 59
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 57
+const FORMAT_VERSION: int = 58
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -316,6 +316,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not unown_words["ok"]:
 		return unown_words
 
+	var unown_walls: Dictionary = verify_unown_walls(rom, layout)
+	if not unown_walls["ok"]:
+		return unown_walls
+
 	var intro_movie: Dictionary = verify_intro_movie(rom, layout)
 	if not intro_movie["ok"]:
 		return intro_movie
@@ -1081,6 +1085,53 @@ static func verify_unown_words(rom: RomFile, layout: Dictionary) -> Dictionary:
 				],
 			}
 	return {"ok": true, "message": "Unown words verified."}
+
+
+## `UnownWalls`, the four chamber words in `UNOWNWORDS_*` order. Empty on a dump
+## that does not ship them, which is Gold and Silver, and on any failure.
+static func read_unown_walls(rom: RomFile, layout: Dictionary) -> PackedStringArray:
+	var at: int = int(layout.get("unown_walls", -1))
+	if at < 0 or not rom.in_bounds(at, RomLayout.UNOWN_WALL_COUNT * RomLayout.UNOWN_WALL_MAX_LENGTH):
+		return PackedStringArray()
+	var out: PackedStringArray = PackedStringArray()
+	for wall: int in RomLayout.UNOWN_WALL_COUNT:
+		var word: String = ""
+		for step: int in RomLayout.UNOWN_WALL_MAX_LENGTH:
+			var code: int = rom.u8(at)
+			at += 1
+			if code == RomLayout.UNOWN_WALL_TERMINATOR:
+				break
+			var letter: String = RomLayout.unown_wall_letter(code)
+			if letter.is_empty():
+				return PackedStringArray()
+			word += letter
+		if word.is_empty():
+			return PackedStringArray()
+		out.append(word)
+	return out
+
+
+## The four words, by shape and by the one the Kabuto chamber's own `setval`
+## names. A dump without the table reads as none rather than as four wrong words.
+static func verify_unown_walls(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if int(layout.get("unown_walls", -1)) < 0:
+		return {"ok": true, "message": "No Unown walls in this dump."}
+	var walls: PackedStringArray = read_unown_walls(rom, layout)
+	if walls.size() != RomLayout.UNOWN_WALL_COUNT:
+		return {"ok": false, "message": "The Unown wall words did not decode."}
+	if walls[RomLayout.UNOWNWORDS_ESCAPE] != "ESCAPE":
+		return {
+			"ok": false,
+			"message": "The first Unown wall reads \"%s\", not the word UNOWNWORDS_ESCAPE names." % [
+				walls[RomLayout.UNOWNWORDS_ESCAPE],
+			],
+		}
+	var seen: Dictionary = {}
+	for word: String in walls:
+		if seen.has(word):
+			return {"ok": false, "message": "Two Unown walls read \"%s\"." % word}
+		seen[word] = true
+	return {"ok": true, "message": "Unown walls verified."}
 
 
 ## One of the two row runs, in the source's own order. Empty when the run is out
@@ -3409,6 +3460,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
 		"unown_words": Array(read_unown_words(rom, layout)),
+		"unown_walls": Array(read_unown_walls(rom, layout)),
 		"credits": _import_credits(rom, layout),
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
 		"battle_object_palettes": _import_battle_object_palettes(rom, layout),

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -312,6 +312,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not pokecenter_pc["ok"]:
 		return pokecenter_pc
 
+	var unown_words: Dictionary = verify_unown_words(rom, layout)
+	if not unown_words["ok"]:
+		return unown_words
+
 	var intro_movie: Dictionary = verify_intro_movie(rom, layout)
 	if not intro_movie["ok"]:
 		return intro_movie
@@ -1030,6 +1034,53 @@ static func verify_pokecenter_pc(rom: RomFile, layout: Dictionary) -> Dictionary
 				"message": "The Pokemon Center PC's %s text did not decode." % name,
 			}
 	return {"ok": true, "message": "The Pokemon Center PC verified."}
+
+
+## `UnownWords`, twenty-six words in form order, A first. Empty on any failure,
+## since a half table would give the dex a blank word rather than a wrong
+## address.
+static func read_unown_words(rom: RomFile, layout: Dictionary) -> PackedStringArray:
+	var out: PackedStringArray = PackedStringArray()
+	for form: int in range(1, RomLayout.UNOWN_WORD_ENTRIES):
+		var at: int = RomLayout.unown_word_offset(rom, layout, form)
+		if at < 0 or not rom.in_bounds(at, RomLayout.UNOWN_WORD_MAX_LENGTH):
+			return PackedStringArray()
+		var word: String = ""
+		for step: int in RomLayout.UNOWN_WORD_MAX_LENGTH:
+			var code: int = rom.u8(at + step)
+			if code == RomLayout.UNOWN_WORD_TERMINATOR:
+				break
+			var letter: int = code - RomLayout.FIRST_UNOWN_CHAR
+			if letter < 0 or letter >= RomLayout.UNOWN_FORMS:
+				return PackedStringArray()
+			word += char("A".unicode_at(0) + letter)
+		if word.is_empty():
+			return PackedStringArray()
+		out.append(word)
+	return out
+
+
+## The words, plus the two things that say the table is where the layout says:
+## its zeroth entry is form A's again, and the run starts where the table ends.
+static func verify_unown_words(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var words: PackedStringArray = read_unown_words(rom, layout)
+	if words.size() != RomLayout.UNOWN_FORMS:
+		return {"ok": false, "message": "The Unown words did not decode."}
+	var table: int = int(layout.get("unown_words", -1))
+	var first: int = RomLayout.unown_word_offset(rom, layout, 0)
+	if first != RomLayout.unown_word_offset(rom, layout, 1):
+		return {"ok": false, "message": "The Unown word table does not open on form A twice."}
+	if first != table + RomLayout.UNOWN_WORD_ENTRIES * RomLayout.UNOWN_WORD_POINTER_SIZE:
+		return {"ok": false, "message": "The Unown words do not follow their own table."}
+	for form: int in RomLayout.UNOWN_FORMS:
+		if not words[form].begins_with(char("A".unicode_at(0) + form)):
+			return {
+				"ok": false,
+				"message": "Unown word %d is \"%s\", which is not its own letter." % [
+					form, words[form],
+				],
+			}
+	return {"ok": true, "message": "Unown words verified."}
 
 
 ## One of the two row runs, in the source's own order. Empty when the run is out
@@ -3357,6 +3408,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"gs_intro": _import_gs_intro(rom, layout),
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
+		"unown_words": Array(read_unown_words(rom, layout)),
 		"credits": _import_credits(rom, layout),
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
 		"battle_object_palettes": _import_battle_object_palettes(rom, layout),

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -497,6 +497,23 @@ const UNSORTED_LEARNSET_SPECIES: int = 89
 const UNOWN_SPECIES: int = 201
 const UNOWN_FORMS: int = 26
 
+## `UnownWords` (data/pokemon/unown_words.asm): a pointer per form and then the
+## words themselves, laid down in the same order, so the table's own first entry
+## is where the run behind it starts. The table has one entry more than there are
+## forms because its zeroth is an unused duplicate of A's, and `PrintUnownWord`
+## indexes it by form number rather than by position.
+##
+## A word is not text: `unownword` stores each letter as `FIRST_UNOWN_CHAR + the
+## letter's rank`, which is the tile number of the Unown font
+## `Pokedex_LoadUnownFont` builds, and terminates with $FF. So it decodes with
+## the alphabet alone and never through [Gen2Text].
+const UNOWN_WORD_ENTRIES: int = UNOWN_FORMS + 1
+const UNOWN_WORD_POINTER_SIZE: int = 2
+const FIRST_UNOWN_CHAR: int = 0x40
+const UNOWN_WORD_TERMINATOR: int = 0xFF
+## Well past REASSURE, the longest at eight.
+const UNOWN_WORD_MAX_LENGTH: int = 16
+
 ## The font is indexed by character code, not by position in a sheet: its first
 ## tile is code $80 ("A") and its last is $FF ("9"). That is not a coincidence of
 ## ordering, it is how the hardware prints at all. The font is loaded so that a
@@ -1494,6 +1511,10 @@ const GOLD_SILVER: Dictionary = {
 	# both were located by matching the row run's own bytes, which are unique in
 	# a dump.
 	"pokecenter_pc": 0x158D1,
+	# `UnownWords`, located by encoding the twenty-six words in the Unown font's
+	# own codes and matching the whole run, which hits once per dump; the table
+	# is the fifty-four bytes in front of it.
+	"unown_words": 0xFBB64,
 	# The credits. `gfx` was located by converting the pinned gfx/credits PNGs
 	# and matching the bytes: the border and the four mon sheets are one
 	# contiguous run in `credits.asm`'s own INCBIN order and `CreditsScript`
@@ -1851,6 +1872,9 @@ const CRYSTAL: Dictionary = {
 	# See the Gold and Silver block above; the run is byte identical and only its
 	# address moves.
 	"pokecenter_pc": 0x155FA,
+	# See the Gold and Silver block above; the words are byte identical and only
+	# their address moves.
+	"unown_words": 0xFBA5A,
 	# See the Gold and Silver block above for how these were located. Crystal's
 	# strings sit in the pointer table's own bank, since it prints them with
 	# `PlaceString` rather than `PlaceFarString`, and each of its four scenes is
@@ -2444,6 +2468,19 @@ static func oak_text_stub_offset(rom: RomFile, layout: Dictionary, name: String)
 		return -1
 	var first: int = rom.u16le(table + 3) + int(OAK_TEXT_STUBS[name]) * OAK_TEXT_STUB_SIZE
 	return RomFile.linear(bank_of(table), first)
+
+
+## Where the word for Unown form [param form] starts, form 1 being A.
+##
+## The pointer is bank-local, so the table's own bank is the whole address.
+static func unown_word_offset(rom: RomFile, layout: Dictionary, form: int) -> int:
+	var table: int = int(layout.get("unown_words", -1))
+	if form < 0 or form >= UNOWN_WORD_ENTRIES:
+		return -1
+	if not rom.in_bounds(table, UNOWN_WORD_ENTRIES * UNOWN_WORD_POINTER_SIZE):
+		return -1
+	var pointer: int = rom.u16le(table + form * UNOWN_WORD_POINTER_SIZE)
+	return RomFile.linear(bank_of(table), pointer)
 
 
 ## Where the `text_far` stub [param name] names sits.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -514,6 +514,27 @@ const UNOWN_WORD_TERMINATOR: int = 0xFF
 ## Well past REASSURE, the longest at eight.
 const UNOWN_WORD_MAX_LENGTH: int = 16
 
+## `UnownWalls` (data/events/unown_walls.asm): the four words the Ruins of Alph
+## chamber walls spell, in `UNOWNWORDS_*` order, ending at $FF. Crystal only,
+## since Gold and Silver's chambers carry the puzzle sign where Crystal carries
+## the pattern.
+##
+## A letter is stored under the `unown` charmap rather than the ordinary one:
+## `$10 * (i / 8) + 2 * i` over "ABCDEFGHIJKLMNOPQRSTUVWXYZ-", which is the
+## top-left tile of that letter's 2x2 block in a sixteen-tile-wide font. So the
+## codes run 0-14, 32-46, 64-78 and 96-100, always even, and nothing else decodes.
+const UNOWN_WALL_COUNT: int = 4
+const UNOWN_WALL_MAX_LENGTH: int = 12
+const UNOWN_WALL_TERMINATOR: int = 0xFF
+## "ABCDEFGHIJKLMNOPQRSTUVWXYZ-", the charmap's own `PRINTABLE_UNOWN`.
+const UNOWN_WALL_ALPHABET: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+const UNOWN_WALL_BLOCK: int = 0x20
+const UNOWN_WALL_ROW_LETTERS: int = 8
+## The `UNOWNWORDS_*` argument `setval` puts in `wScriptVar` before the special.
+## Only the first is named: it is the one the Kabuto chamber's two wall patterns
+## ask for, and the check reads the word behind it rather than storing any.
+const UNOWNWORDS_ESCAPE: int = 0
+
 ## The font is indexed by character code, not by position in a sheet: its first
 ## tile is code $80 ("A") and its last is $FF ("9"). That is not a coincidence of
 ## ordering, it is how the hardware prints at all. The font is loaded so that a
@@ -1515,6 +1536,10 @@ const GOLD_SILVER: Dictionary = {
 	# own codes and matching the whole run, which hits once per dump; the table
 	# is the fifty-four bytes in front of it.
 	"unown_words": 0xFBB64,
+	# `UnownWalls` is Crystal's alone: the chamber wall patterns these four words
+	# belong to are Crystal bg events, where pokegold's cells carry the puzzle
+	# sign, and neither `DisplayUnownWords` nor the words are in the dump.
+	"unown_walls": -1,
 	# The credits. `gfx` was located by converting the pinned gfx/credits PNGs
 	# and matching the bytes: the border and the four mon sheets are one
 	# contiguous run in `credits.asm`'s own INCBIN order and `CreditsScript`
@@ -1875,6 +1900,9 @@ const CRYSTAL: Dictionary = {
 	# See the Gold and Silver block above; the words are byte identical and only
 	# their address moves.
 	"unown_words": 0xFBA5A,
+	# `UnownWalls`, located by encoding all four words in the `unown` charmap and
+	# matching the run, which hits once. `MenuHeaders_UnownWalls` follows it.
+	"unown_walls": 0x8AEBC,
 	# See the Gold and Silver block above for how these were located. Crystal's
 	# strings sit in the pointer table's own bank, since it prints them with
 	# `PlaceString` rather than `PlaceFarString`, and each of its four scenes is
@@ -2481,6 +2509,23 @@ static func unown_word_offset(rom: RomFile, layout: Dictionary, form: int) -> in
 		return -1
 	var pointer: int = rom.u16le(table + form * UNOWN_WORD_POINTER_SIZE)
 	return RomFile.linear(bank_of(table), pointer)
+
+
+## The letter [param code] spells under the `unown` charmap, or an empty string
+## when it is not a code that charmap can produce.
+static func unown_wall_letter(code: int) -> String:
+	if code < 0 or code % 2 != 0:
+		return ""
+	@warning_ignore("integer_division")
+	var block: int = code / UNOWN_WALL_BLOCK
+	@warning_ignore("integer_division")
+	var within: int = (code % UNOWN_WALL_BLOCK) / 2
+	if within >= UNOWN_WALL_ROW_LETTERS:
+		return ""
+	var index: int = block * UNOWN_WALL_ROW_LETTERS + within
+	if index >= UNOWN_WALL_ALPHABET.length():
+		return ""
+	return UNOWN_WALL_ALPHABET[index]
 
 
 ## Where the `text_far` stub [param name] names sits.

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -90,4 +90,8 @@ static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
 		"level": mon.level,
 		"ot_id": mon.ot_id,
 		"gender": Gen2BattleMon.gender_for(data, mon.species, mon.dvs),
+		## `DisplayHOFMon` draws the pic through `GetMonFrontpic`, which reads
+		## `wUnownLetter`: an Unown in the Hall of Fame is its own letter, not A.
+		"unown_form": Gen2Stats.unown_letter(mon.dvs) \
+			if mon.species == RomLayout.UNOWN_SPECIES else 0,
 	}

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -124,7 +124,9 @@ func _refresh_pic(page: Dictionary) -> void:
 	if _data == null or StringName(page.get("kind", &"")) != Gen2HallOfFame.PAGE_MON:
 		return
 	var species: int = int(page.get("species", 0))
-	var pic: Dictionary = _data.species_pic(species)
+	var unown_form: int = int(page.get("unown_form", 0))
+	var pic: Dictionary = _data.unown_pic(unown_form - 1) if unown_form > 0 \
+		else _data.species_pic(species)
 	if pic.is_empty():
 		return
 	var image: Image = Gen2PicImage.from_atlas(

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -29,10 +29,9 @@ const PAGE_1: int = 0
 const PAGE_2: int = 1
 
 ## `Pokedex_DrawOptionScreenBG.Modes`, verbatim, and the description
-## `Pokedex_DisplayModeDescription` prints under each. UNOWN is built in its
-## source position and refused, the way the start menu builds Pokedex: nothing
-## here tracks STATUSFLAGS_UNOWN_DEX_F, so `wUnlockedUnownMode` is always false
-## and `.NoUnownModeArrowCursorData`'s three rows are what the screen gets.
+## `Pokedex_DisplayModeDescription` prints under each. UNOWN is offered only once
+## `Pokedex_CheckUnlockedUnownMode` has read STATUSFLAGS_UNOWN_DEX_F; without it
+## `.NoUnownModeArrowCursorData`'s three rows are what the screen gets.
 const MODE_ROWS: Array[Dictionary] = [
 	{
 		"mode": RomLayout.DEXMODE_NEW,
@@ -123,6 +122,9 @@ var search_type_2: int = SEARCH_TYPE_NONE
 var search_cursor: int = SEARCH_ROW_TYPE_1
 ## `wDexSearchResultCount`.
 var search_result_count: int = 0
+
+## `wDexCurUnownIndex`, a position in the caught-forms list rather than a letter.
+var unown_cursor: int = 0
 
 var _data: GameData = null
 var _state: Gen2WorldState = null
@@ -264,6 +266,63 @@ func seen_count() -> int:
 
 func caught_count() -> int:
 	return _state.caught_count() if _state != null else 0
+
+
+## `wUnlockedUnownMode`, which is `Pokedex_CheckUnlockedUnownMode`'s reading of
+## the one engine flag the Ruins of Alph research centre sets.
+func unown_unlocked() -> bool:
+	return _state != null \
+		and _state.is_engine_flag_active(Gen2WorldState.ENGINE_UNOWN_DEX)
+
+
+## `Pokedex_DrawUnownModeBG`'s own walk: the forms caught, in catching order.
+## `wDexUnownCount` is its length.
+func unown_forms() -> Array[int]:
+	return _state.unown_dex() if _state != null else [] as Array[int]
+
+
+## `Pokedex_InitUnownMode`, which opens on the first form caught rather than on
+## the one last looked at.
+func open_unown_mode() -> void:
+	unown_cursor = 0
+
+
+## The form under the cursor, 1 being A, or zero when nothing has been caught:
+## `Pokedex_LoadUnownFrontpicTiles` reads `wUnownDex` at the cursor, and an empty
+## dex leaves it on a zero slot.
+func selected_unown_form() -> int:
+	var forms: Array[int] = unown_forms()
+	if unown_cursor < 0 or unown_cursor >= forms.size():
+		return 0
+	return forms[unown_cursor]
+
+
+## `PrintUnownWord`, which reads the word for the form under the cursor. Empty
+## for an empty dex, which is the blank row the fill leaves.
+func unown_word() -> String:
+	var form: int = selected_unown_form()
+	if form <= 0 or _data == null:
+		return ""
+	return _data.unown_word(form)
+
+
+## `Pokedex_UnownModeHandleDPadInput`: right and left only, no wrap at either
+## end, and the right edge is `wDexUnownCount` rather than twenty-six. Answers
+## whether the cursor moved.
+func move_unown(button: int) -> bool:
+	var count: int = unown_forms().size()
+	match button:
+		Gen2Button.RIGHT:
+			if unown_cursor + 1 >= count:
+				return false
+			unown_cursor += 1
+			return true
+		Gen2Button.LEFT:
+			if unown_cursor <= 0:
+				return false
+			unown_cursor -= 1
+			return true
+	return false
 
 
 ## `Pokedex_ListingHandleDPadInput`. Answers whether the position changed, which

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -10,10 +10,10 @@ extends Control
 ## tile-accurate listing with. Every rule the screen obeys is [Gen2Pokedex]'s,
 ## which is the source's own.
 ##
-## Five of the source's six states are here: the listing, the entry screen, the
-## OPTION screen, SEARCH and its results. The Unown dex is not, so the OPTION
-## screen draws `.NoUnownModeArrowCursorData`'s three rows, which is what the
-## cartridge draws while `wUnlockedUnownMode` is clear.
+## All six of the source's states are here: the listing, the entry screen, the
+## OPTION screen, SEARCH, its results and the Unown dex. The OPTION screen draws
+## `.NoUnownModeArrowCursorData`'s three rows until the Ruins of Alph research
+## centre has set the flag, which is what the cartridge draws too.
 ##
 ## The entry screen's AREA is the exception to the panel above: `Pokedex_GetArea`
 ## is the cartridge's own region map, so it opens [Gen2TownMapScreen], which
@@ -26,7 +26,7 @@ signal closed
 ## player: the overworld's own answers it, the way it answers a script's cry.
 signal cry_requested(species: int)
 
-enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA }
+enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA, UNOWN }
 
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#4f6f9e")
@@ -120,6 +120,8 @@ func handle_button(button: int) -> bool:
 			return _handle_search(button)
 		Mode.SEARCH_RESULTS:
 			return _handle_search_results(button)
+		Mode.UNOWN:
+			return _handle_unown(button)
 	return false
 
 
@@ -259,8 +261,15 @@ func _handle_option(button: int) -> bool:
 
 ## `.ChangeMode`, including the message it shows while the order is rebuilt.
 ## Choosing the mode already in use returns to the listing untouched.
+##
+## UNOWN is not one of them: `.MenuAction_UnownMode` never writes `wCurDexMode`,
+## it jumps straight to DEXSTATE_UNOWN_MODE, so the listing keeps the mode it
+## had and the Unown screen answers back to OPTION rather than to the listing.
 func _choose_mode() -> void:
 	var row: Dictionary = _mode_rows[_option_cursor]
+	if int(row["mode"]) == RomLayout.DEXMODE_UNOWN:
+		_open_unown_mode()
+		return
 	var changed: bool = _dex.change_mode(int(row["mode"]))
 	if changed:
 		_world.state.set_last_dex_mode(_dex.mode)
@@ -296,7 +305,7 @@ func _open_entry_mode() -> void:
 
 func _open_option_mode() -> void:
 	_mode = Mode.OPTION
-	_mode_rows = Gen2Pokedex.mode_rows()
+	_mode_rows = Gen2Pokedex.mode_rows(_dex.unown_unlocked())
 	_title.text = "OPTION"
 	_summary.text = ""
 	_status.text = ""
@@ -308,6 +317,48 @@ func _open_option_mode() -> void:
 		if int(_mode_rows[index]["mode"]) == _dex.mode:
 			_option_cursor = index
 	_render_option()
+
+
+## `Pokedex_UpdateUnownMode`: left and right walk the forms caught, and A or B
+## both leave. `.a_b` goes back to DEXSTATE_OPTION_SCR, not to the listing.
+func _handle_unown(button: int) -> bool:
+	match button:
+		Gen2Button.A, Gen2Button.B:
+			_open_option_mode()
+			return true
+		Gen2Button.LEFT, Gen2Button.RIGHT:
+			if _dex.move_unown(button):
+				_render_unown()
+			return true
+	return false
+
+
+## `Pokedex_InitUnownMode`, which opens on the first form caught.
+func _open_unown_mode() -> void:
+	_mode = Mode.UNOWN
+	_dex.open_unown_mode()
+	_title.text = "UNOWN MODE"
+	_status.text = ""
+	_footer.text = "Left/Right: form    A or B: back"
+	_render_unown()
+
+
+## `Pokedex_DrawUnownModeBG` and `PrintUnownWord`: the forms caught, in catching
+## order, with the cursor's own letter and its word underneath. The letters are
+## drawn with the alphabet rather than the Unown font, which is
+## `Pokedex_LoadUnownFont`'s inverted copy of the pic sheet and is not imported.
+func _render_unown() -> void:
+	var forms: Array[int] = _dex.unown_forms()
+	_summary.text = "CAUGHT %2d/%d" % [forms.size(), RomLayout.UNOWN_FORMS]
+	var letters: PackedStringArray = PackedStringArray()
+	for index: int in forms.size():
+		var letter: String = char("A".unicode_at(0) + forms[index] - 1)
+		letters.append(("[%s]" if index == _dex.unown_cursor else " %s ") % letter)
+	for child: Node in _options.get_children():
+		child.queue_free()
+	_add_line(" ".join(letters))
+	_add_line("")
+	_add_line(_dex.unown_word())
 
 
 ## `Pokedex_UpdateSearchScreen`: up and down move the four rows, left and right

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -97,6 +97,7 @@ static func complete_runtime_request(
 	## After the snapshot, so a refused transaction rolls the dex flag back with
 	## everything else the request wrote.
 	_register_caught(world, int(transaction.get("register_caught", 0)))
+	_register_unown(world, int(transaction.get("register_unown", 0)))
 	var completion_result: Dictionary = {
 		"ok": true,
 		"script_value": int(transaction.get("script_value", 0)),
@@ -478,6 +479,9 @@ static func capture_wild(
 	## save takes the dex flag back with the ball.
 	if bool(outcome.get("caught", false)):
 		_register_caught(world, wild.species)
+		_register_unown(world, _unown_form(
+			wild.species, wild.persistent_dvs(), destination
+		))
 	var next_quantity: int = world.state.item_quantity(ball) - 1
 	var item_result: Dictionary = world.state.apply_changes({}, {}, {"items": {ball: next_quantity}})
 	if not bool(item_result.get("ok", false)):
@@ -578,6 +582,11 @@ static func _apply_party_request(
 		return {
 			"ok": true, "accepted": true, "script_value": 1,
 			"register_caught": received.species,
+			## A trade lands in the party slot the given Pokemon left, which is
+			## the PARTYMON `GeneratePartyMonStats` registers.
+			"register_unown": _unown_form(
+				received.species, received.dvs, {"destination": &"party"}
+			),
 			"summary": {
 				"kind": &"trade", "accepted": true, "trade_id": trade_id,
 				"given_species": requested.species,
@@ -604,6 +613,7 @@ static func _append_mon(
 	return {
 		"ok": true, "accepted": true, "script_value": script_value,
 		"register_caught": 0 if StringName(summary.get("kind", &"")) == &"egg" else mon.species,
+		"register_unown": 0 if mon.is_egg else _unown_form(mon.species, mon.dvs, destination),
 		"summary": summary.merged({
 			"accepted": true, "destination": destination.duplicate(true),
 		}),
@@ -617,6 +627,27 @@ static func _register_caught(world: Gen2WorldAPI, species: int) -> void:
 	if world == null or world.state == null or species <= 0:
 		return
 	world.state.set_species_caught(species)
+
+
+## `GeneratePartyMonStats`' `.registerunowndex`. The form is read off the DVs
+## rather than stored, and only a Pokemon that reached the party registers: the
+## routine runs under `wMonType` PARTYMON alone, so an Unown caught with a full
+## party is caught without entering the Unown dex.
+static func _unown_form(species: int, dvs: int, destination: Dictionary) -> int:
+	if species != RomLayout.UNOWN_SPECIES:
+		return 0
+	if StringName(destination.get("destination", &"")) != &"party":
+		return 0
+	return Gen2Stats.unown_letter(dvs)
+
+
+## Written straight onto the live state beside [method _register_caught], and
+## for the same reason: the caller has already taken the snapshot a refused save
+## rolls back to.
+static func _register_unown(world: Gen2WorldAPI, form: int) -> void:
+	if world == null or world.state == null or form <= 0:
+		return
+	world.state.update_unown_dex(form)
 
 
 static func _new_mon(

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -125,6 +125,13 @@ const SNORLAX_PROXIMITY_CELLS: Array[Vector2i] = [
 ## special_index() already normalizes. maps/KurtsHouse.asm's `.AskApricorn`
 ## branches on wScriptVar afterwards, one label per apricorn.
 const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
+## DisplayUnownWords, which is Crystal's alone: pokegold's table stops well
+## before it, so no Gold or Silver script can reach this index and neither dump
+## ships the words. The four wall patterns are Crystal bg events, two per
+## chamber, where Gold and Silver's cells carry only the puzzle sign. A preceding
+## `setval` puts the `UNOWNWORDS_*` index in wScriptVar. Not to be read as 41,
+## which is `UnownPuzzle` on both and is the sliding puzzle itself.
+const SPECIAL_DISPLAY_UNOWN_WORDS: int = 135
 const SPECIAL_RANDOM_UNSEEN_WILD_MON: int = 91
 const SPECIAL_RANDOM_PHONE_WILD_MON: int = 92
 const SPECIAL_RANDOM_PHONE_MON: int = 93
@@ -2299,6 +2306,23 @@ func _execute_special(special: int) -> Dictionary:
 				"kind": &"toggle_decorations_visibility",
 				"defaults": true,
 			})
+		SPECIAL_DISPLAY_UNOWN_WORDS:
+			## The word the wall spells, in a menu box of its own that
+			## `JoyWaitAorB` holds until a button. Here it is the sign's own text
+			## box, acknowledged the same way, since `UnownFont`'s 2x2 letter
+			## blocks are not imported.
+			var wall_word: String = data.unown_wall_word(_script_value) if data != null \
+				else ""
+			if wall_word.is_empty():
+				return {
+					"ok": false,
+					"reason": &"unknown_unown_wall",
+					"special": special,
+					"wall": _script_value,
+				}
+			## `special` is a StringName tag on a pending text, not the index, so
+			## the wall is named under its own key.
+			return _stage_internal_text(wall_word, false, {"unown_wall": _script_value})
 		SPECIAL_RANDOM_UNSEEN_WILD_MON:
 			var rare_species: int = _phone_unseen_rare_species()
 			if rare_species <= 0:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -2018,6 +2018,11 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 			_script_value = int(_request.get("map_group", -1))
 		0x0D: # VAR_MAPNUMBER
 			_script_value = int(_request.get("map_number", -1))
+		0x0E: # VAR_UNOWNCOUNT
+			## `.count_unown` walks wUnownDex and stops at the first empty slot,
+			## which is the size of the list here. All three Ruins of Alph
+			## scientists and the Kabuto chamber's wall read it.
+			_script_value = state.unown_caught_count() if state != null else 0
 		0x0F: # VAR_ENVIRONMENT
 			_script_value = int(_request.get("environment", -1))
 		0x14: # VAR_SPECIALPHONECALL

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -31,6 +31,11 @@ const ENGINE_HALL_OF_FAME: int = ENGINE_CREDITS_SKIP
 ## `CheckReceivedDex`'s own flag, which is what the Pokemon Center PC's list
 ## selection reads before the Hall of Fame one.
 const ENGINE_POKEDEX: int = 11
+## The next bit of the same `wStatusFlags` byte, `STATUSFLAGS_UNOWN_DEX_F`, which
+## `Pokedex_CheckUnlockedUnownMode` reads and only the Ruins of Alph research
+## centre's scientist sets. Ahead of ENGINE_MOBILE_SYSTEM, so it is one index on
+## every profile.
+const ENGINE_UNOWN_DEX: int = 12
 ## The one entry pokegold does not ship, and so the index every profile split in
 ## this table is measured from. See engine_flag().
 const ENGINE_MOBILE_SYSTEM: int = 16
@@ -146,6 +151,11 @@ var _seen_species: Dictionary = {}
 ## seen array rather than derived from the party, because the cartridge's own
 ## flag survives releasing, trading away or boxing the Pokemon that set it.
 var _caught_species: Dictionary = {}
+## `wUnownDex`: the Unown forms caught, in catching order rather than by letter,
+## and only the ones that reached the party. Twenty-six slots on the cartridge,
+## where an empty one is a zero; here the list is as long as it is full, so its
+## size is `.count_unown`'s own answer.
+var _unown_dex: Array[int] = []
 var _phone_receive_cycle: int = 0
 var _phone_receive_minutes: int = PHONE_RECEIVE_DELAYS[0]
 var _pending_special_phone_call: int = 0
@@ -276,6 +286,7 @@ func to_dict() -> Dictionary:
 		"roaming_mons": _copy_roaming_mons(_roaming_mons),
 		"seen_species": _seen_species.duplicate(),
 		"caught_species": _caught_species.duplicate(),
+		"unown_dex": _unown_dex.duplicate(),
 		"phone_receive_cycle": _phone_receive_cycle,
 		"phone_receive_minutes": _phone_receive_minutes,
 		"pending_special_phone_call": _pending_special_phone_call,
@@ -339,6 +350,14 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 		for raw_tree: Variant in picked as Dictionary:
 			if int(raw_tree) > 0 and bool((picked as Dictionary)[raw_tree]):
 				restored._picked_fruit_trees[int(raw_tree)] = true
+	## Absent in a state written before the Unown dex, which reads as an empty
+	## one: the flag that unlocks the mode is an engine flag and survives on its
+	## own, so an old save shows the mode with nothing listed under it, which is
+	## what a player who has caught none would see anyway.
+	var stored_unown: Variant = source.get("unown_dex", [])
+	if stored_unown is Array:
+		for raw_form: Variant in stored_unown as Array:
+			restored.update_unown_dex(int(raw_form))
 	restored.set_registered_item(int(source.get("registered_item", 0)))
 	restored.set_wild_encounter_cooldown(int(source.get("wild_encounter_cooldown", 0)))
 	restored.set_wild_encounters_off(bool(source.get("wild_encounters_off", false)))
@@ -383,6 +402,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_roaming_mons = _copy_roaming_mons(restored._roaming_mons)
 	_seen_species = restored._seen_species.duplicate()
 	_caught_species = restored._caught_species.duplicate()
+	_unown_dex = restored._unown_dex.duplicate()
 	_phone_receive_cycle = restored._phone_receive_cycle
 	_phone_receive_minutes = restored._phone_receive_minutes
 	_pending_special_phone_call = restored._pending_special_phone_call
@@ -1070,6 +1090,32 @@ func set_species_caught(species: int, caught: bool = true) -> void:
 		set_species_seen(species, true)
 	else:
 		_caught_species.erase(species)
+
+
+## `UpdateUnownDex`: appends the form unless it is already listed. The walk stops
+## at the first empty slot, so a form only ever reaches the end of the list, and
+## a full twenty-six returns without writing anything.
+##
+## Its caller is what limits this, not the routine: `GeneratePartyMonStats` runs
+## it only for a PARTYMON, so an Unown that goes straight to the PC is caught
+## without entering the dex.
+func update_unown_dex(form: int) -> void:
+	if form < 1 or form > RomLayout.UNOWN_FORMS:
+		return
+	if form in _unown_dex or _unown_dex.size() >= RomLayout.UNOWN_FORMS:
+		return
+	_unown_dex.append(form)
+
+
+## The forms caught, in catching order. `Pokedex_DrawUnownModeBG` walks exactly
+## this and stops at the first empty slot.
+func unown_dex() -> Array[int]:
+	return _unown_dex.duplicate()
+
+
+## `_GetVarAction.UnownCaught`, which is `VAR_UNOWNCOUNT`.
+func unown_caught_count() -> int:
+	return _unown_dex.size()
 
 
 func has_seen_species(species: int) -> bool:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1046,6 +1046,41 @@ func test_the_chosen_dex_mode_survives_closing_the_dex() -> void:
 	assert_eq(reopened.get("_dex").mode, RomLayout.DEXMODE_OLD)
 
 
+## The Unown dex: `Pokedex_CheckUnlockedUnownMode` puts a fourth row on the
+## OPTION screen once the Ruins of Alph research centre has set the flag, and
+## `.MenuAction_UnownMode` answers back to OPTION rather than to the listing,
+## with the listing's own mode untouched.
+func test_unown_mode_is_offered_once_its_flag_is_set_and_returns_to_the_option_screen() -> void:
+	await _open_world()
+	var state: Gen2WorldState = _world_screen._world.state
+	state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX)
+	_world_screen._open_pokedex()
+	var dex: Gen2PokedexScreen = _world_screen._pokedex_host
+	dex.handle_button(Gen2Button.SELECT)
+	assert_eq(dex.get("_mode_rows").size(), 3, "three modes until the dex is upgraded")
+
+	state.set_engine_flag(Gen2WorldState.ENGINE_UNOWN_DEX)
+	state.update_unown_dex(3)
+	state.update_unown_dex(20)
+	dex.handle_button(Gen2Button.B)
+	dex.handle_button(Gen2Button.SELECT)
+	assert_eq(dex.get("_mode_rows").size(), 4)
+	for _row: int in 3:
+		dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.UNOWN)
+	assert_eq(dex.get("_dex").unown_word(), "CWORD")
+	dex.handle_button(Gen2Button.RIGHT)
+	assert_eq(dex.get("_dex").unown_word(), "TWORD")
+
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.OPTION)
+	assert_eq(
+		state.last_dex_mode(), RomLayout.DEXMODE_NEW,
+		"the listing keeps the mode it had"
+	)
+
+
 ## `Pokedex_UpdateMainScreen`'s START reaches the search screen, and its CANCEL
 ## row comes back to the listing.
 func test_the_dex_search_screen_opens_from_the_listing_and_cancels_back() -> void:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -87,6 +87,7 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_splash_graphics(directory, manifest, game_id == RomRegistry.CRYSTAL)
 	_write_menu_text(manifest)
 	_write_pokecenter_pc(manifest)
+	_write_unown_words(manifest)
 	_write_credits(directory, manifest, crystal_commands)
 	_write_name_input_chars(directory)
 	_write_intro_text(directory, crystal_commands)
@@ -375,6 +376,15 @@ static func _write_menu_text(manifest: Dictionary) -> void:
 
 ## `PokemonCenterPC`'s two row runs, its `.WhichPC` lists and the six texts the
 ## routine prints, as the cartridge words them.
+## One word per Unown form, each opening on its own letter the way
+## `UnownWords`' do, so a test can tell which form the dex is showing.
+static func _write_unown_words(manifest: Dictionary) -> void:
+	var words: Array = []
+	for form: int in RomLayout.UNOWN_FORMS:
+		words.append("%sWORD" % char("A".unicode_at(0) + form))
+	manifest["unown_words"] = words
+
+
 static func _write_pokecenter_pc(manifest: Dictionary) -> void:
 	manifest["pokecenter_pc"] = {
 		"rows": {

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -46,6 +46,15 @@ static func types_for(number: int) -> Array:
 	return [first, second]
 
 
+## One word per Unown form, each opening on its own letter the way the
+## cartridge's do, so a test can tell which form the dex is showing.
+static func unown_words() -> Array:
+	var out: Array = []
+	for form: int in RomLayout.UNOWN_FORMS:
+		out.append("%sWORD" % char("A".unicode_at(0) + form))
+	return out
+
+
 static func directory() -> String:
 	return RomCache.directory_for(GAME_ID, SHA1)
 
@@ -63,6 +72,7 @@ static func build() -> GameData:
 		"game_id": String(GAME_ID),
 		"sha1": SHA1,
 		"complete": true,
+		"unown_words": unown_words(),
 	})
 	return GameData.open_directory(path)
 

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -309,6 +309,31 @@ func test_sending_one_out_after_a_faint_calls_nobody_back() -> void:
 	assert_false(battle.must_replace(Gen2Battle.PLAYER))
 
 
+## `_GetFrontpic` draws Unown by `wUnownLetter`, so the letter travels with the
+## send-out the way the level and the HP do. Every other species carries zero.
+func test_a_send_out_carries_the_unown_letter_its_dvs_name() -> void:
+	var letter_dvs: int = Gen2Stats.pack_dvs(2, 0, 0, 0)
+	var battle: Gen2Battle = _party_battle(
+		[
+			_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+			Gen2BattleMon.create(
+				_data, RomLayout.UNOWN_SPECIES, 20, [Fixture.TACKLE], letter_dvs
+			),
+		],
+		[_mon(Fixture.CHARMANDER, 20, [Fixture.TACKLE])]
+	)
+	var sent: Dictionary = _first(
+		battle.send_out(Gen2Battle.PLAYER, 1), Gen2Battle.SENT_OUT
+	)
+	assert_eq(int(sent["unown_form"]), Gen2Stats.unown_letter(letter_dvs))
+	assert_gt(int(sent["unown_form"]), 1, "and it is not form A by default")
+	assert_eq(
+		int(_first(battle.send_out(Gen2Battle.PLAYER, 0), Gen2Battle.SENT_OUT)["unown_form"]),
+		0,
+		"anything else is not an Unown"
+	)
+
+
 ## `HandlePlayerMonFaint` and `HandleEnemyMonFaint`'s replacement tail, which is
 ## the only entry point besides a turn that moves a battle on.
 func _replacement_battle(player: Array, enemy: Array, trainer: bool) -> Gen2Battle:

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -262,7 +262,7 @@ func test_no_previous_entry_opens_at_the_top() -> void:
 
 
 ## `Pokedex_DrawOptionScreenBG` hides UNOWN MODE while wUnlockedUnownMode is
-## clear, which is the only state this project can be in.
+## clear, which is what `Pokedex_CheckUnlockedUnownMode` reads the flag for.
 func test_the_option_screen_lists_three_modes_without_the_unown_dex() -> void:
 	var rows: Array = Gen2Pokedex.mode_rows()
 	assert_eq(rows.size(), 3)
@@ -426,3 +426,53 @@ func test_the_results_listing_is_four_rows() -> void:
 	dex.begin_search()
 	dex.listing_height = Gen2Pokedex.SEARCH_RESULTS_HEIGHT
 	assert_eq(dex.rows().size(), 4)
+
+
+## `Pokedex_CheckUnlockedUnownMode` is the whole of the mode's gate, and
+## `Pokedex_DrawUnownModeBG` lists `wUnownDex` in catching order behind it.
+func test_unown_mode_is_unlocked_by_its_flag_and_lists_the_catching_order() -> void:
+	var state: Gen2WorldState = _state([])
+	var dex: Gen2Pokedex = Gen2Pokedex.open(_data, state, RomLayout.DEXMODE_NEW)
+	assert_false(dex.unown_unlocked())
+	assert_eq(Gen2Pokedex.mode_rows(dex.unown_unlocked()).size(), 3)
+
+	state.set_engine_flag(Gen2WorldState.ENGINE_UNOWN_DEX)
+	assert_true(dex.unown_unlocked())
+	assert_eq(Gen2Pokedex.mode_rows(dex.unown_unlocked()).size(), 4)
+
+	for form: int in [3, 26, 1]:
+		state.update_unown_dex(form)
+	dex.open_unown_mode()
+	assert_eq(dex.unown_forms(), [3, 26, 1] as Array[int])
+	assert_eq(dex.selected_unown_form(), 3)
+	assert_eq(dex.unown_word(), "CWORD")
+
+
+## `Pokedex_UnownModeHandleDPadInput` reads left and right only, stops at
+## `wDexUnownCount` rather than at twenty-six, and does not wrap at either end.
+func test_the_unown_cursor_stops_at_both_ends_of_what_has_been_caught() -> void:
+	var state: Gen2WorldState = _state([])
+	for form: int in [5, 9]:
+		state.update_unown_dex(form)
+	var dex: Gen2Pokedex = Gen2Pokedex.open(_data, state, RomLayout.DEXMODE_NEW)
+	dex.open_unown_mode()
+	assert_false(dex.move_unown(Gen2Button.LEFT), "the first form is the left edge")
+	assert_false(dex.move_unown(Gen2Button.UP), "up and down are not read at all")
+	assert_true(dex.move_unown(Gen2Button.RIGHT))
+	assert_eq(dex.selected_unown_form(), 9)
+	assert_eq(dex.unown_word(), "IWORD")
+	assert_false(dex.move_unown(Gen2Button.RIGHT), "the last form caught is the right edge")
+
+
+## An empty dex is a legal state: the flag is set by the research centre before
+## anything has been caught, and `Pokedex_LoadUnownFrontpicTiles` reads the zero
+## in the first slot.
+func test_an_empty_unown_dex_has_no_form_and_no_word() -> void:
+	var state: Gen2WorldState = _state([])
+	state.set_engine_flag(Gen2WorldState.ENGINE_UNOWN_DEX)
+	var dex: Gen2Pokedex = Gen2Pokedex.open(_data, state, RomLayout.DEXMODE_NEW)
+	dex.open_unown_mode()
+	assert_true(dex.unown_forms().is_empty())
+	assert_eq(dex.selected_unown_form(), 0)
+	assert_eq(dex.unown_word(), "")
+	assert_false(dex.move_unown(Gen2Button.RIGHT))

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -1153,3 +1153,71 @@ func test_a_copyright_palette_that_is_not_the_logo_palette_fails() -> void:
 	data[at] = 0x7F
 	data[at + 1] = 0x7F
 	assert_false(RomImporter.verify_copyright(_rom(data), _layout)["ok"])
+
+
+## `UnownWords`: a pointer table of NUM_UNOWN + 1 entries whose zeroth repeats
+## form A's, and the words themselves directly behind it, each letter stored as
+## its rank from `FIRST_UNOWN_CHAR` and terminated with $FF.
+func _unown_dump() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	var table: int = int(_layout["unown_words"])
+	var run: int = table + RomLayout.UNOWN_WORD_ENTRIES * RomLayout.UNOWN_WORD_POINTER_SIZE
+	var at: int = run
+	for form: int in RomLayout.UNOWN_FORMS:
+		var pointer: int = RomFile.BANK_SIZE + (at % RomFile.BANK_SIZE)
+		var entry: int = table + (form + 1) * RomLayout.UNOWN_WORD_POINTER_SIZE
+		data[entry] = pointer & 0xFF
+		data[entry + 1] = pointer >> 8
+		if form == 0:
+			data[table] = pointer & 0xFF
+			data[table + 1] = pointer >> 8
+		# Two letters each: the form's own, then A, which is enough for the
+		# check that every word opens on its own letter.
+		data[at] = RomLayout.FIRST_UNOWN_CHAR + form
+		data[at + 1] = RomLayout.FIRST_UNOWN_CHAR
+		data[at + 2] = RomLayout.UNOWN_WORD_TERMINATOR
+		at += 3
+	return data
+
+
+func test_a_plausible_unown_word_table_verifies() -> void:
+	var rom: RomFile = _rom(_unown_dump())
+	assert_true(RomImporter.verify_unown_words(rom, _layout)["ok"])
+	var words: PackedStringArray = RomImporter.read_unown_words(rom, _layout)
+	assert_eq(words.size(), RomLayout.UNOWN_FORMS)
+	assert_eq(words[0], "AA")
+	assert_eq(words[RomLayout.UNOWN_FORMS - 1], "ZA")
+
+
+## The table's zeroth entry is what says the address is the table's rather than
+## a run of plausible bytes in front of it.
+func test_a_table_that_does_not_open_on_form_a_twice_fails() -> void:
+	var data: PackedByteArray = _unown_dump()
+	var table: int = int(_layout["unown_words"])
+	data[table] = data[table + 2] + 3
+	assert_false(RomImporter.verify_unown_words(_rom(data), _layout)["ok"])
+
+
+## And the words following their own table is what says it is the right length.
+func test_words_that_do_not_follow_their_table_fail() -> void:
+	var data: PackedByteArray = _unown_dump()
+	var table: int = int(_layout["unown_words"])
+	for form: int in RomLayout.UNOWN_WORD_ENTRIES:
+		var entry: int = table + form * RomLayout.UNOWN_WORD_POINTER_SIZE
+		var moved: int = int(data[entry]) | (int(data[entry + 1]) << 8)
+		moved += RomLayout.UNOWN_WORD_POINTER_SIZE
+		data[entry] = moved & 0xFF
+		data[entry + 1] = moved >> 8
+	assert_false(RomImporter.verify_unown_words(_rom(data), _layout)["ok"])
+
+
+## A byte that is not a letter is what a wrong address reads, and it drops the
+## whole table rather than a word.
+func test_a_word_with_a_byte_outside_the_alphabet_fails() -> void:
+	var data: PackedByteArray = _unown_dump()
+	var run: int = int(_layout["unown_words"]) \
+		+ RomLayout.UNOWN_WORD_ENTRIES * RomLayout.UNOWN_WORD_POINTER_SIZE
+	data[run] = RomLayout.FIRST_UNOWN_CHAR + RomLayout.UNOWN_FORMS
+	assert_false(RomImporter.verify_unown_words(_rom(data), _layout)["ok"])
+	assert_true(RomImporter.read_unown_words(_rom(data), _layout).is_empty())

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -168,7 +168,10 @@ func test_every_offset_lands_inside_a_cartridge() -> void:
 	for id: StringName in RomRegistry.ORDER:
 		var layout: Dictionary = RomLayout.for_id(id)
 		for key: String in layout:
-			if layout[key] is int and key != "pic_bank_add":
+			## -1 is the table this dump does not ship, the way the nested
+			## `town_map.palette_female` and `unown_walls` are on Gold and
+			## Silver; every reader checks for it before addressing anything.
+			if layout[key] is int and key != "pic_bank_add" and int(layout[key]) != -1:
 				assert_between(int(layout[key]), 0, RomRegistry.EXPECTED_SIZE - 1, "%s.%s" % [id, key])
 
 

--- a/tests/unit/test_stats.gd
+++ b/tests/unit/test_stats.gd
@@ -69,6 +69,24 @@ func test_hp_dv_is_assembled_from_the_low_bit_of_the_other_four() -> void:
 	assert_eq(Gen2Stats.hp_dv(Gen2Stats.pack_dvs(14, 14, 14, 14)), 0, "even DVs contribute nothing")
 
 
+## `GetUnownLetter`: the middle two bits of each DV, in attack, defense, speed
+## and special order, over ten. The published letters for a few DV words, which
+## a shift in the wrong direction cannot reproduce.
+func test_the_unown_letter_is_the_middle_bits_of_every_dv_over_ten() -> void:
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(0, 0, 0, 0)), 1, "A")
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(15, 15, 15, 15)), 26, "Z")
+	# Only bits 2 and 1 of each DV are read: 1 and 8 are outside them, so a
+	# Pokémon whose DVs are all odd is still A.
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(9, 9, 9, 9)), 1)
+	# Attack's pair is the top of the byte, so it alone spans most of the range.
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(2, 0, 0, 0)), 7)
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(4, 0, 0, 0)), 13)
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(6, 0, 0, 0)), 20)
+	# And special's is the bottom, so it alone never leaves A.
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(0, 0, 0, 6)), 1)
+	assert_eq(Gen2Stats.unown_letter(Gen2Stats.pack_dvs(0, 0, 6, 6)), 2)
+
+
 func test_dvs_pack_into_the_word_the_cartridge_stores() -> void:
 	var packed: int = Gen2Stats.pack_dvs(1, 2, 3, 4)
 	assert_eq(Gen2Stats.attack_dv(packed), 1)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -308,6 +308,9 @@ func _write_cache(game_id: String = "testworld") -> void:
 		"game_id": game_id,
 		"sha1": "0123456789abcdef",
 		"complete": true,
+		## `UnownWalls`' four, since the special that draws one names them by
+		## index and a wrong index has to be told from a right one.
+		"unown_walls": ["WALLA", "WALLB", "WALLC", "WALLD"],
 	})
 
 
@@ -2867,6 +2870,41 @@ func test_readvar_partycount_reads_the_set_party_summary() -> void:
 	assert_eq(result.size(), 1)
 	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
 	assert_true(world.event_flag_active(41))
+
+
+## `DisplayUnownWords` draws the word a chamber wall spells and holds on
+## `JoyWaitAorB`; the `setval` in front of it is which word. The script carries
+## on into `closetext` once the box is acknowledged, and an index the table does
+## not have refuses rather than drawing a blank box.
+func test_the_unown_wall_special_says_the_word_its_setval_names() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:63B0"] = [
+		Gen2WorldScript.SETVAL, 2,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_DISPLAY_UNOWN_WORDS, 0x00,
+		Gen2WorldScript.END,
+	]
+	scripts["48:63C0"] = [
+		Gen2WorldScript.SETVAL, 9,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_DISPLAY_UNOWN_WORDS, 0x00,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x63B0,
+	})
+	var word: Dictionary = runner.advance()
+	assert_eq(word["status"], &"waiting", JSON.stringify(word))
+	assert_eq(word["event"]["type"], &"text")
+	assert_eq(word["event"]["text"], "WALLC")
+	assert_eq(runner.advance(true)["status"], &"complete")
+
+	var refused := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x63C0,
+	})
+	var failure: Dictionary = refused.advance()
+	assert_eq(failure["status"], &"failed", JSON.stringify(failure))
+	assert_eq(failure["reason"], &"unknown_unown_wall")
 
 
 ## `_GetVarAction.UnownCaught` counts `wUnownDex` up to its first empty slot.

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2869,6 +2869,29 @@ func test_readvar_partycount_reads_the_set_party_summary() -> void:
 	assert_true(world.event_flag_active(41))
 
 
+## `_GetVarAction.UnownCaught` counts `wUnownDex` up to its first empty slot.
+## All three Ruins of Alph scientists and the Kabuto chamber's wall open with
+## `readvar VAR_UNOWNCOUNT`, so an unsupported variable stops them talking.
+func test_readvar_unowncount_counts_the_unown_dex() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6390"] = [
+		Gen2WorldScript.READVAR, 0x0E,
+		Gen2WorldScript.IFEQUAL, 2, 0xA0, 0x63,
+		Gen2WorldScript.END,
+	]
+	scripts["48:63A0"] = [Gen2WorldScript.SETEVENT, 44, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.state.update_unown_dex(4)
+	world.state.update_unown_dex(19)
+	world.current_map.events["coord_events"][0]["script"] = 0x6390
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result.size(), 1)
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_true(world.event_flag_active(44))
+
+
 func test_checkpoke_answers_the_party_summary_species_and_fails_without_one() -> void:
 	# Route 39's TrainerPokefanmDerek and Route 43's PicnickerTiffany both ask
 	# checkpoke before offering a phone number. Script_checkpoke searches

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -501,6 +501,43 @@ func test_a_full_party_capture_uses_the_first_pc_box_slot() -> void:
 	assert_eq(result["destination"]["destination"], &"box")
 
 
+## `GeneratePartyMonStats`' `.registerunowndex`: the letter comes off the DVs
+## that were caught, and it is entered once however many of that form are caught.
+func test_catching_an_unown_into_the_party_enters_its_letter_in_the_unown_dex() -> void:
+	var dvs: int = Gen2Stats.pack_dvs(2, 0, 0, 0)
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, RomLayout.UNOWN_SPECIES, 5,
+		_data.moves_at_level(RomLayout.UNOWN_SPECIES, 5), dvs
+	)
+	assert_true(Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)["caught"])
+	assert_eq(_world.state.unown_dex(), [Gen2Stats.unown_letter(dvs)] as Array[int])
+
+	_world.state.apply_changes({}, {}, {"items": {0x01: 1}})
+	assert_true(Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)["caught"])
+	assert_eq(_world.state.unown_caught_count(), 1, "the same letter twice is one entry")
+
+
+## The routine runs under `wMonType` PARTYMON alone, so an Unown that goes
+## straight to the PC is caught without entering the Unown dex.
+func test_an_unown_caught_into_a_box_does_not_enter_the_unown_dex() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, RomLayout.UNOWN_SPECIES, 5,
+		_data.moves_at_level(RomLayout.UNOWN_SPECIES, 5), Gen2Stats.pack_dvs(2, 0, 0, 0)
+	)
+	var result: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)
+	assert_eq(result["destination"]["destination"], &"box")
+	assert_true(_world.state.has_caught_species(RomLayout.UNOWN_SPECIES))
+	assert_true(_world.state.unown_dex().is_empty())
+
+
 func test_full_storage_refuses_a_capture_before_consuming_the_ball() -> void:
 	while _save.party.size() < Gen2SaveData.MAX_PARTY:
 		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -445,3 +445,31 @@ func test_the_unown_dex_is_not_a_listing_mode() -> void:
 	var state := Gen2WorldState.new()
 	state.set_last_dex_mode(RomLayout.DEXMODE_UNOWN)
 	assert_eq(state.last_dex_mode(), RomLayout.DEXMODE_NEW)
+
+
+## `UpdateUnownDex` walks to the first empty slot: a form already listed keeps
+## its place, and the list only ever grows at the end.
+func test_the_unown_dex_appends_in_catching_order_and_never_twice() -> void:
+	var state := Gen2WorldState.new()
+	for form: int in [12, 3, 12, 26, 3]:
+		state.update_unown_dex(form)
+	assert_eq(state.unown_dex(), [12, 3, 26] as Array[int])
+	assert_eq(state.unown_caught_count(), 3)
+
+	# A form outside the twenty-six is not a slot the loop can reach.
+	state.update_unown_dex(0)
+	state.update_unown_dex(RomLayout.UNOWN_FORMS + 1)
+	assert_eq(state.unown_caught_count(), 3)
+
+	var restored := Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.unown_dex(), [12, 3, 26] as Array[int])
+
+
+## A snapshot written before the Unown dex existed restores as an empty one
+## rather than refusing, which is why no save format bump went with it.
+func test_a_state_without_an_unown_dex_restores_empty() -> void:
+	var state := Gen2WorldState.new()
+	state.update_unown_dex(4)
+	var raw: Dictionary = state.to_dict()
+	raw.erase("unown_dex")
+	assert_true(Gen2WorldState.from_dict(raw).unown_dex().is_empty())

--- a/tools/checks/unown_dex.gd
+++ b/tools/checks/unown_dex.gd
@@ -3,15 +3,16 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the Unown dex against freshly imported real caches: `UnownWords`, the
-## twenty-six pics `Pokedex_LoadUnownFrontpicTiles` draws from, and
-## `GetUnownLetter` over every DV word a Pokemon can carry.
+## twenty-six pics `Pokedex_LoadUnownFrontpicTiles` draws from, `GetUnownLetter`
+## over every DV word a Pokemon can carry, and `UnownWalls` on the eight Ruins of
+## Alph patterns that ask for one.
 ##
 ## The whole corpus rather than a sample: all 65,536 DV words on each cartridge,
-## every letter and every form's picture. The words are a plain byte run behind
-## their own pointer table, so a wrong offset lands on neighbouring data that
-## still reads as letters; what says it is the right run is that each word opens
-## on its own letter, that the run starts where the table ends, and that the
-## three cartridges agree word for word.
+## every letter, every form's picture and every chamber wall. The words are a
+## plain byte run behind their own pointer table, so a wrong offset lands on
+## neighbouring data that still reads as letters; what says it is the right run
+## is that each word opens on its own letter, that the run starts where the table
+## ends, and that the three cartridges agree word for word.
 ##
 ##   Godot --headless --path . -s res://tools/validate.gd -- unown_dex
 
@@ -23,6 +24,17 @@ const X_WORD: String = "XXXXX"
 
 ## Every DV word, which is what `GetUnownLetter` divides down to a letter.
 const DV_WORDS: int = 0x10000
+
+## The four Ruins of Alph chambers, which carry the same map numbers on all
+## three cartridges: the eight rooms pokecrystal inserts sit behind them, so the
+## group's shift is measured from further down. Each has a wall pattern either
+## side of its doorway, and `CHAMBER_STAND` is a walkable cell to open on.
+const CHAMBER_GROUP: int = 3
+const CHAMBER_MAPS: Array[int] = [23, 24, 25, 26]
+const CHAMBER_STAND := Vector2i(3, 3)
+const WALLS_PER_CHAMBER: int = 2
+## Enough acknowledgements to drain a sign's own text and the word behind it.
+const WALL_DRAIN_STEPS: int = 6
 
 var _first_words: PackedStringArray = PackedStringArray()
 
@@ -38,6 +50,7 @@ func _check_game() -> void:
 	_check_pics()
 	_check_letters()
 	_check_dex_order()
+	_check_walls()
 
 
 func _check_words() -> void:
@@ -138,6 +151,79 @@ func _check_letters() -> void:
 	# apart: every middle bit clear is A, every one set is Z.
 	_r.check(Gen2Stats.unown_letter(0x0000) == 1, "all-zero DVs are not A.")
 	_r.check(Gen2Stats.unown_letter(0xFFFF) == RomLayout.UNOWN_FORMS, "all-one DVs are not Z.")
+
+
+## `DisplayUnownWords` on the maps that ask for it: the four Ruins of Alph
+## chambers, both wall patterns of each. Crystal alone ships them, so this is
+## eight words there and none on Gold and Silver, whose cells carry the puzzle
+## sign instead.
+func _check_walls() -> void:
+	var said: PackedStringArray = PackedStringArray()
+	for number: int in CHAMBER_MAPS:
+		var chamber: Gen2WorldAPI = _r.open_world(
+			CHAMBER_GROUP, number, CHAMBER_STAND
+		)
+		if chamber == null:
+			continue
+		for event: Dictionary in chamber.current_map.events.get("bg_events", []):
+			var word: String = _wall_word(number, Vector2i(
+				int(event["x"]), int(event["y"])
+			))
+			if not word.is_empty():
+				said.append(word)
+	if not _r.crystal:
+		_r.check(said.is_empty(), "a Gold or Silver chamber said %s." % [said])
+		return
+	_r.check(
+		said.size() == CHAMBER_MAPS.size() * WALLS_PER_CHAMBER,
+		"the chambers said %d words, not %d." % [
+			said.size(), CHAMBER_MAPS.size() * WALLS_PER_CHAMBER,
+		]
+	)
+	var distinct: Dictionary = {}
+	for word: String in said:
+		distinct[word] = true
+	_r.check(
+		distinct.size() == RomLayout.UNOWN_WALL_COUNT,
+		"the four chambers said %d distinct words: %s." % [distinct.size(), said]
+	)
+	_r.note("unown walls: %s." % " ".join(said))
+
+
+## Faces the bg event at [param cell] and drains what it says, answering the
+## word the wall spelled or an empty string when it said none. A refusal is a
+## failure: every one of these cells is one a player walks up to and presses A on.
+func _wall_word(number: int, cell: Vector2i) -> String:
+	var world: Gen2WorldAPI = _r.open_world(
+		CHAMBER_GROUP, number, cell + Vector2i(0, 1)
+	)
+	if world == null:
+		return ""
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var results: Array = world.interact()
+	var word: String = ""
+	for step: int in WALL_DRAIN_STEPS:
+		if results.is_empty():
+			break
+		var status: StringName = StringName(results[0].get("status", &""))
+		if status == &"failed":
+			# The puzzle sign shares these maps and has no host; a wall pattern
+			# refusing is what this check exists to catch.
+			if StringName(results[0].get("reason", &"")) != &"unsupported_phone_special":
+				_r.fail("map %d's %s answered %s." % [
+					number, cell, String(results[0].get("reason", &"failed")),
+				])
+			break
+		if status != &"waiting":
+			break
+		var pending: Dictionary = world.pending_script_input()
+		if pending.is_empty() or StringName(pending.get("type", &"")) != &"text":
+			break
+		var text: String = String(pending.get("text", ""))
+		if pending.has("unown_wall"):
+			word = text
+		results = world.run_event_queue(true)
+	return word
 
 
 ## `UpdateUnownDex` and `Pokedex_DrawUnownModeBG` over a real state: catching

--- a/tools/checks/unown_dex.gd
+++ b/tools/checks/unown_dex.gd
@@ -1,0 +1,182 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the Unown dex against freshly imported real caches: `UnownWords`, the
+## twenty-six pics `Pokedex_LoadUnownFrontpicTiles` draws from, and
+## `GetUnownLetter` over every DV word a Pokemon can carry.
+##
+## The whole corpus rather than a sample: all 65,536 DV words on each cartridge,
+## every letter and every form's picture. The words are a plain byte run behind
+## their own pointer table, so a wrong offset lands on neighbouring data that
+## still reads as letters; what says it is the right run is that each word opens
+## on its own letter, that the run starts where the table ends, and that the
+## three cartridges agree word for word.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- unown_dex
+
+## `data/pokemon/unown_words.asm`'s first and last, either side of the run.
+const FIRST_WORD: String = "ANGRY"
+const LAST_WORD: String = "ZOOM"
+## `UnownWordX`, the one word that is not a word.
+const X_WORD: String = "XXXXX"
+
+## Every DV word, which is what `GetUnownLetter` divides down to a letter.
+const DV_WORDS: int = 0x10000
+
+var _first_words: PackedStringArray = PackedStringArray()
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_first_words = PackedStringArray()
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	_check_words()
+	_check_pics()
+	_check_letters()
+	_check_dex_order()
+
+
+func _check_words() -> void:
+	var words: PackedStringArray = PackedStringArray()
+	for form: int in range(1, RomLayout.UNOWN_FORMS + 1):
+		words.append(_r.data.unown_word(form))
+	if not _r.check(
+		words.size() == RomLayout.UNOWN_FORMS,
+		"the cache holds %d Unown words." % words.size()
+	):
+		return
+	for form: int in RomLayout.UNOWN_FORMS:
+		var letter: String = char("A".unicode_at(0) + form)
+		_r.check(
+			words[form].begins_with(letter),
+			"Unown %s's word is \"%s\"." % [letter, words[form]]
+		)
+	_r.check(words[0] == FIRST_WORD, "Unown A's word is \"%s\"." % words[0])
+	_r.check(
+		words[RomLayout.UNOWN_FORMS - 1] == LAST_WORD,
+		"Unown Z's word is \"%s\"." % words[RomLayout.UNOWN_FORMS - 1]
+	)
+	_r.check(words[23] == X_WORD, "Unown X's word is \"%s\"." % words[23])
+	# A form outside the range is what a caller reading an empty dex slot asks
+	# for, and it answers nothing rather than the neighbouring word.
+	_r.check(_r.data.unown_word(0).is_empty(), "form 0 answers a word.")
+	_r.check(
+		_r.data.unown_word(RomLayout.UNOWN_FORMS + 1).is_empty(),
+		"a form past Z answers a word."
+	)
+	if _first_words.is_empty():
+		_first_words = words
+	else:
+		_r.check(
+			_first_words == words, "the Unown words differ from the other cartridges."
+		)
+
+
+## The twenty-six front pics, since the dex draws one per form and the battle
+## now draws the letter a wild Unown's DVs name.
+func _check_pics() -> void:
+	var lit: int = 0
+	for form: int in RomLayout.UNOWN_FORMS:
+		for back: bool in [false, true]:
+			var pic: Dictionary = _r.data.unown_pic(form, back)
+			if not _r.check(not pic.is_empty(), "Unown form %d has no pic." % form):
+				continue
+			var indices: PackedByteArray = _r.data.atlas_indices(String(pic["atlas"]))
+			var atlas: Dictionary = _r.data.atlas(String(pic["atlas"]))
+			var cell: Dictionary = Gen2PicImage.atlas_cell(indices, atlas, pic)
+			if not _r.check(
+				not cell.is_empty(), "Unown form %d did not crop out of its atlas." % form
+			):
+				continue
+			var drawn: int = 0
+			for index: int in cell["indices"] as PackedByteArray:
+				if index != 0:
+					drawn += 1
+			_r.check(drawn > 0, "Unown form %d's %s pic is blank." % [
+				form, "back" if back else "front",
+			])
+			lit += drawn
+	_r.check(
+		_r.data.unown_pic(RomLayout.UNOWN_FORMS).is_empty(),
+		"a form past Z answers a pic."
+	)
+	_r.note("unown pics: %d forms, %d drawn pixels." % [RomLayout.UNOWN_FORMS, lit])
+
+
+## `GetUnownLetter` over every DV word: each answers a letter in range, and the
+## twenty-six bands are the divide's own, ten packed values each except Z's six.
+## Only the middle two bits of each DV are read, so the 65,536 words collapse to
+## 256 packed values and each letter is reached by 256 of them.
+func _check_letters() -> void:
+	var counts: Array[int] = []
+	counts.resize(RomLayout.UNOWN_FORMS + 1)
+	counts.fill(0)
+	for dvs: int in DV_WORDS:
+		var letter: int = Gen2Stats.unown_letter(dvs)
+		if letter < 1 or letter > RomLayout.UNOWN_FORMS:
+			_r.fail("DVs $%04X answer letter %d." % [dvs, letter])
+			return
+		counts[letter] += 1
+	for letter: int in range(1, RomLayout.UNOWN_FORMS):
+		_r.check(
+			counts[letter] == 10 * 256,
+			"letter %d is reached by %d DV words, not %d." % [
+				letter, counts[letter], 10 * 256,
+			]
+		)
+	_r.check(
+		counts[RomLayout.UNOWN_FORMS] == 6 * 256,
+		"Z is reached by %d DV words, not %d." % [
+			counts[RomLayout.UNOWN_FORMS], 6 * 256,
+		]
+	)
+	# The two ends, which say the packing is the source's rather than a shift
+	# apart: every middle bit clear is A, every one set is Z.
+	_r.check(Gen2Stats.unown_letter(0x0000) == 1, "all-zero DVs are not A.")
+	_r.check(Gen2Stats.unown_letter(0xFFFF) == RomLayout.UNOWN_FORMS, "all-one DVs are not Z.")
+
+
+## `UpdateUnownDex` and `Pokedex_DrawUnownModeBG` over a real state: catching
+## order, no duplicates, and the word the cursor lands on.
+func _check_dex_order() -> void:
+	var state := Gen2WorldState.new()
+	var dex: Gen2Pokedex = Gen2Pokedex.open(_r.data, state, RomLayout.DEXMODE_NEW)
+	_r.check(not dex.unown_unlocked(), "Unown mode is unlocked before the flag is set.")
+	state.set_engine_flag(Gen2WorldState.ENGINE_UNOWN_DEX)
+	_r.check(dex.unown_unlocked(), "the Unown dex flag does not unlock the mode.")
+	_r.check(
+		Gen2Pokedex.mode_rows(true).size() == Gen2Pokedex.MODE_ROWS.size(),
+		"an unlocked OPTION screen does not offer four modes."
+	)
+	for form: int in [7, 26, 7, 1]:
+		state.update_unown_dex(form)
+	var caught: Array[int] = [7, 26, 1]
+	_r.check(
+		state.unown_dex() == caught,
+		"the dex holds %s after G, Z, G, A." % [state.unown_dex()]
+	)
+	dex.open_unown_mode()
+	_r.check(dex.selected_unown_form() == 7, "the cursor does not open on the first form.")
+	_r.check(
+		dex.unown_word() == _r.data.unown_word(7),
+		"the cursor's word is \"%s\"." % dex.unown_word()
+	)
+	_r.check(dex.move_unown(Gen2Button.LEFT) == false, "the cursor moved left off the end.")
+	_r.check(dex.move_unown(Gen2Button.RIGHT), "the cursor did not move right.")
+	_r.check(dex.move_unown(Gen2Button.RIGHT), "the cursor did not reach the last form.")
+	_r.check(dex.move_unown(Gen2Button.RIGHT) == false, "the cursor moved right off the end.")
+	_r.check(
+		dex.selected_unown_form() == 1 and dex.unown_word() == _r.data.unown_word(1),
+		"the last form is %d." % dex.selected_unown_form()
+	)
+	# `.count_unown` stops at twenty-six however many times it is asked.
+	for form: int in range(1, RomLayout.UNOWN_FORMS + 1):
+		state.update_unown_dex(form)
+	_r.check(
+		state.unown_caught_count() == RomLayout.UNOWN_FORMS,
+		"a full dex counts %d." % state.unown_caught_count()
+	)

--- a/tools/checks/unown_dex.gd.uid
+++ b/tools/checks/unown_dex.gd.uid
@@ -1,0 +1,1 @@
+uid://ccklpvr5h37qt

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -9,6 +9,7 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/oak.png oak_pc
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc a,down,a
+##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/unown.png unown_dex
 ##
 ## `presses` drives the overlay with its own buttons before the shot, which is
 ## how the apricorn mode's second box is photographed.
@@ -18,6 +19,10 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
 ## The seven ApricornBalls rows, named so a capture reads as the cartridge's
 ## list rather than as the fixture's ITEM<number> placeholders.
+## The forms the Unown dex preview has caught, in catching order rather than
+## alphabetically, since that is the whole of what the screen lists.
+const UNOWN_CAUGHT: Array[int] = [6, 21, 1, 14, 26]
+
 const APRICORNS: Dictionary = {
 	0x55: "RED APRICORN", 0x59: "BLU APRICORN", 0x5C: "YLW APRICORN",
 	0x5D: "GRN APRICORN", 0x61: "WHT APRICORN", 0x63: "BLK APRICORN",
@@ -63,6 +68,13 @@ func _initialize() -> void:
 	var state := Gen2WorldState.new({}, {}, items, {0: 500})
 	if _kind == &"town_map":
 		state.set_engine_flag(Gen2WorldState.ENGINE_MAP_CARD, true)
+	if _kind == &"unown_dex":
+		state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+		## What the Ruins of Alph research centre leaves behind: the upgraded
+		## dex, and the forms caught since, in catching order.
+		state.set_engine_flag(Gen2WorldState.ENGINE_UNOWN_DEX, true)
+		for form: int in UNOWN_CAUGHT:
+			state.update_unown_dex(form)
 	var world := Gen2WorldAPI.open(
 		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6), state
 	)
@@ -87,6 +99,14 @@ func _process(_delta: float) -> bool:
 			_screen._open_trainer_card()
 		elif _kind == &"oak_pc":
 			_screen.open_prof_oaks_pc()
+		elif _kind == &"unown_dex":
+			# The live path: the dex's own OPTION screen, its fourth row.
+			_screen._open_pokedex()
+			for button: int in [
+				Gen2Button.SELECT, Gen2Button.DOWN, Gen2Button.DOWN,
+				Gen2Button.DOWN, Gen2Button.A,
+			]:
+				_screen._pokedex_host.handle_button(button)
 		else:
 			var waiting: Array = _screen._world.dispatch_script_events(Vector2i(7, 6))
 			_screen._show_script_results(waiting)
@@ -94,7 +114,9 @@ func _process(_delta: float) -> bool:
 			# The overlay owns the buttons when one is up; the trainer card and
 			# Prof Oak's PC are the world screen's own hosts, so they take theirs
 			# through the same entry point a key press does.
-			if _screen._service_host != null:
+			if _screen._pokedex_host != null:
+				_screen._pokedex_host.handle_button(button)
+			elif _screen._service_host != null:
 				_screen._service_host.handle_button(button)
 			else:
 				_screen.press_button(button)

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -37,7 +37,7 @@ const GROUPS: Dictionary = {
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
-		&"pack",
+		&"pack", &"unown_dex",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
Two things the Ruins of Alph owed, and one bug on the way.

## The Unown dex

`UnownWords` is imported: twenty-six words behind their own pointer table, each
letter stored as its rank from `FIRST_UNOWN_CHAR` rather than as a character, so
it decodes with the alphabet and never through `Gen2Text`. One pinned offset per
profile locates the lot, since the run starts where the table ends, and every
word opening on its own letter is what says the address is right.

`wUnownDex` is on `Gen2WorldState` as the forms caught in catching order rather
than as twenty-six slots: `UpdateUnownDex` walks to the first empty one, so the
list only grows at its end and a form already listed keeps its place. Its caller
is what limits it: `GeneratePartyMonStats` runs it under `wMonType` PARTYMON
alone, so an Unown caught with a full party is caught without entering the dex. A
snapshot written before this restores as an empty dex, so no save format bump
goes with it.

`VAR_UNOWNCOUNT` is `.count_unown` over the same list. All three Ruins of Alph
scientists and the Kabuto chamber's receptionist open with
`readvar VAR_UNOWNCOUNT` and could not be talked to before.

`Pokedex_CheckUnlockedUnownMode` reads `ENGINE_UNOWN_DEX`, which the research
centre's own script already sets, and puts `.ArrowCursorData`'s fourth row on the
OPTION screen. `.MenuAction_UnownMode` never writes `wCurDexMode`, so the listing
keeps the mode it had and A or B answers back to OPTION.

## The letter a wild Unown wears

`GetUnownLetter` is the middle two bits of each DV over ten, which nothing here
read before: every Unown was drawn as form A. `_GetFrontpic` picks the letter's
own pic instead, in the battle, where the letter travels with the send-out the
way the level and the HP do, and in the Hall of Fame.

## The chamber walls

Facing either wall pattern in any of the four chambers and pressing A failed the
script: `DisplayUnownWords` is special 135 and had no host. `UnownWalls` is
imported, under the `unown` charmap rather than the ordinary one, and the special
says the word its preceding `setval` names in the sign's own text box, held until
a button the way `JoyWaitAorB` holds it. Crystal's alone: pokegold's special
table stops well before 135 and neither dump ships the words.

## Proving it

Cache format 59, all three cartridges re-imported with `layout: Layout verified.`

| Check | Result |
|---|---|
| GUT, both tiers | 2,948 tests over 148 scripts, green |
| `validate.gd -- all` | every topic PASS, including the new `unown_dex` |
| `unown_dex` corpus | 26 words and 52 pics per cartridge, all 65,536 DV words, 8 chamber walls |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | Gold, Silver and Crystal reach Red and the credits |

The dex's Unown mode is a panel like the rest of the Pokedex here: it lists the
forms caught in catching order with the alphabet, where the cartridge draws them
in `Pokedex_LoadUnownFont`'s inverted copy of the pic sheet. A chamber wall's
word is said in the sign's text box for the same reason.