### PR TITLE
A mod's species in the dex order, and shorter comments in seven files

### DIFF
--- a/game/battle/battle_switch_menu.gd
+++ b/game/battle/battle_switch_menu.gd
@@ -1,42 +1,28 @@
 class_name Gen2BattleSwitchMenu
 extends RefCounted
 
-## Choosing who comes in next, from inside a battle
-## (`PickSwitchMonInBattle` and `ForcePickSwitchMonInBattle`,
-## `engine/battle/core.asm`).
+## `PickSwitchMonInBattle` and `ForcePickSwitchMonInBattle`
+## (`engine/battle/core.asm`).
 ##
-## Three callers, one list. `OfferSwitch`'s YES reaches the first, which the
-## player can back out of; Baton Pass reaches the second through
-## `ForcePickPartyMonInBattle`, which cannot be backed out of and answers a
-## refusal with `SFX_WRONG` and the list again. `ForcePlayerMonChoice`, the
-## replacement after a faint, is that same forced list one wrapper lower: it
-## stops at `ForcePickPartyMonInBattle` and so makes no `SwitchMonAlreadyOut`
-## check, which costs nothing because the slot it would refuse holds the Pokémon
-## that just fainted and `CheckIfCurPartyMonIsFitToFight` refuses it first.
+## Three callers, one list. `OfferSwitch`'s YES can be backed out of; Baton Pass
+## reaches `ForcePickPartyMonInBattle`, which cannot and answers a refusal with
+## `SFX_WRONG` and the list again; `ForcePlayerMonChoice` is that forced list one
+## wrapper lower, so it makes no `SwitchMonAlreadyOut` check, which costs nothing
+## because `CheckIfCurPartyMonIsFitToFight` refuses the fainted slot first. Both
+## wrap `PickPartyMonInBattle` and its two refusals.
 ##
-## Both wrap `PickPartyMonInBattle`, so both make the same two checks on the row
-## that was chosen and print the same two lines:
-##
-## - `CheckIfCurPartyMonIsFitToFight`: a fainted Pokémon prints
-##   `BattleText_TheresNoWillToBattle`;
-## - `SwitchMonAlreadyOut`: the Pokémon already standing prints
-##   `BattleText_MonIsAlreadyOut`.
-##
-## Scene-free: the rows and the cursor rules live here, [Gen2PartyMenuPage] draws
-## them and the battle screen owns the presses. `SetUpBattlePartyMenu` always
-## goes through `InitPartyMenuWithCancel`, so CANCEL is a row in both variants;
-## in the forced one choosing it is refused rather than absent.
+## Scene-free: [Gen2PartyMenuPage] draws the rows and the battle screen owns the
+## presses. `SetUpBattlePartyMenu` goes through `InitPartyMenuWithCancel`, so
+## CANCEL is a row in both variants and the forced one refuses rather than drops
+## it.
 
-## `PartyMenu2DMenuData`'s `_2DMENU_WRAP_UP_DOWN`, which is the only movement
-## flag the party menu sets: the list wraps and there is one column.
+## `PartyMenu2DMenuData`'s `_2DMENU_WRAP_UP_DOWN`, its only movement flag.
 const WRAPS: bool = true
 
-## `InitPartyMenuWithCancel` writes `wMenuCursorY` 1, which is the first member.
+## `InitPartyMenuWithCancel`'s `wMenuCursorY` 1: the first member.
 const DEFAULT_CURSOR: int = 0
 
-## `SFX_WRONG`, which `ForcePickPartyMonInBattle` plays when the pick it cannot
-## refuse is refused anyway, and `SFX_READ_TEXT_2`, which `PartyMenuSelect` plays
-## on both of its own ways out (`constants/sfx_constants.asm`).
+## `ForcePickPartyMonInBattle`'s refusal and `PartyMenuSelect`'s exits.
 const SFX_WRONG: int = 0x19
 const SFX_READ_TEXT_2: int = 0x08
 
@@ -48,16 +34,14 @@ const NO_ENERGY: StringName = &"no_energy"
 const CANNOT_CANCEL: StringName = &"cannot_cancel"
 
 ## One row per party member, in party order:
-## `{index, species, item, name, level, hp, max_hp, status, fainted}`.
-## [Gen2PartyMenuPage] draws exactly these fields and nothing reads the battle
-## behind them; the species and the held item are what its menu mon icon needs.
+## `{index, species, item, name, level, hp, max_hp, status, fainted}`, which is
+## exactly what [Gen2PartyMenuPage] draws and its icon needs.
 var rows: Array = []
 
 ## `ForcePickSwitchMonInBattle` rather than `PickSwitchMonInBattle`.
 var forced: bool = false
 
-## The party slot already on the field, which `SwitchMonAlreadyOut` compares
-## against.
+## What `SwitchMonAlreadyOut` compares against.
 var active: int = -1
 
 ## Zero-based over [method item_count], the CANCEL row last.
@@ -97,8 +81,7 @@ func is_cancel(index: int) -> bool:
 	return index == rows.size()
 
 
-## `_2DMENU_WRAP_UP_DOWN` over one column. Answers whether the cursor moved,
-## which it always does on a list of more than one row.
+## `_2DMENU_WRAP_UP_DOWN` over one column.
 func move(delta: int) -> bool:
 	if delta == 0 or item_count() <= 1:
 		return false
@@ -106,18 +89,16 @@ func move(delta: int) -> bool:
 	return true
 
 
-## A is `PartyMenuSelect` returning the row, then `PickPartyMonInBattle`'s and
-## `PickSwitchMonInBattle`'s two checks over it. A refusal leaves the list
-## standing, which is what both `jr z, .loop` and `jr c, .pick` do.
+## `PartyMenuSelect` returning the row, then the two checks over it; a refusal
+## leaves the list standing (`jr z, .loop`, `jr c, .pick`).
 func confirm() -> Dictionary:
 	if is_cancel(cursor):
 		return cancel()
 	if cursor < 0 or cursor >= rows.size():
 		return {"result": CANNOT_CANCEL, "sfx": SFX_WRONG}
 	var row: Dictionary = rows[cursor]
-	# The source also refuses an EGG (`BattleText_AnEGGCantBattle`). A battle
-	# party here is built from Pokémon that fight, so that branch has no way to
-	# be reached and is not modelled.
+		# `BattleText_AnEGGCantBattle` is unreachable: a battle party here holds
+		# only Pokémon that fight.
 	if bool(row.get("fainted", false)):
 		return {"result": NO_ENERGY, "text": no_energy_text()}
 	if int(row.get("index", -1)) == active:
@@ -125,22 +106,20 @@ func confirm() -> Dictionary:
 	return {"result": CHOSEN, "index": int(row.get("index", -1))}
 
 
-## B, and the CANCEL row, which `PartyMenuSelect` sets carry for alike.
-## `ForcePickPartyMonInBattle` swallows that carry, so the forced list refuses.
+## B and the CANCEL row both set carry, which `ForcePickPartyMonInBattle`
+## swallows.
 func cancel() -> Dictionary:
 	if forced:
 		return {"result": CANNOT_CANCEL, "sfx": SFX_WRONG}
 	return {"result": CANCELLED}
 
 
-## `PartyMenuStrings`' `WhichPKMNString`, which `PARTYMENUACTION_SWITCH` picks
-## and `PlacePartyMenuText` prints in the box along the bottom.
+## `PartyMenuStrings`' `WhichPKMNString`, which `PARTYMENUACTION_SWITCH` picks.
 static func prompt_text() -> String:
 	return "Which PKMN?"
 
 
-## `PlacePartyNicknames`' own `.CancelString`, printed two columns left of the
-## nicknames on the row below the last one.
+## `PlacePartyNicknames`' `.CancelString`, two columns left of the nicknames.
 static func cancel_label() -> String:
 	return "CANCEL"
 
@@ -155,15 +134,12 @@ static func already_out_text(name: String) -> String:
 	return "%s is already out." % name
 
 
-## `BattleText_UseNextMon`, the question `AskUseNextPokemon` puts up over the
-## same yes/no box `OfferSwitch` uses. Wild battles only: a trainer battle
-## returns from the routine before it prints.
+## `AskUseNextPokemon`'s question, wild battles only.
 static func use_next_text() -> String:
 	return "Use next PKMN?"
 
 
-## `BattleText_EnemyIsAboutToUseWillPlayerChangeMon`, the question `OfferSwitch`
-## puts up before the trainer's Pokémon is on the field. [param trainer] is
-## `Battle_GetTrainerName`'s answer and [param mon] the one about to come in.
+## `BattleText_EnemyIsAboutToUseWillPlayerChangeMon`, asked before the trainer's
+## Pokémon is out. [param trainer] is `Battle_GetTrainerName`'s.
 static func offer_text(trainer: String, mon: String, player: String) -> String:
 	return "%s is about to use %s. Will %s change PKMN?" % [trainer, mon, player]

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -3,69 +3,56 @@ extends RefCounted
 
 ## The damage formula, in the order and the arithmetic the hardware uses.
 ##
-## Every step truncates and the steps are not commutative, so this is a sequence,
-## not an expression: rearranging it changes the answer. Type matchups apply one
-## type at a time with a truncation between, the critical multiplier lands before
-## the cap and minimum, and the random spread after everything.
+## Every step truncates and none of them commute, so this is a sequence rather
+## than an expression: the matchup applies one type at a time with a truncation
+## between, the critical multiplier lands before the cap and minimum, and the
+## spread after everything.
 ##
-## The cartridge spends four commands on it, and this file is those four:
-## [method damage_stats], [method damage_calc], [method stab_damage] and
-## [method apply_variation]. [Gen2EffectCommands] runs them one at a time,
-## because half a dozen effects write something between two of them.
-## [method calculate] and [method calculate_with] are the composition, for a
-## caller that wants a whole hit and has no list to put steps in.
-## [constant MAX_VARIATION] with no critical is the highest a hit can go, the
-## number a damage calculator quotes.
+## The cartridge's four commands are [method damage_stats], [method damage_calc],
+## [method stab_damage] and [method apply_variation], run one at a time by
+## [Gen2EffectCommands] because half a dozen effects write between two of them.
+## [method calculate] and [method calculate_with] are the composition.
 
-## Where the formula's constants come from. The cap is applied before the
-## minimum is added, so a hit that would flatten the counter lands at 999 and
-## the smallest hit that connects at all is 2.
+## The cap lands before the minimum is added, so the biggest hit is 999 and the
+## smallest that connects at all is 2.
 const DAMAGE_CAP: int = 997
 const MIN_DAMAGE: int = 2
 
-## The random spread, out of 255. The cartridge rejects anything below 217 and
-## then divides, so a hit lands between 85% and 100% of its full value.
+## The spread, out of 255: rerolled under 217, so 85% to 100%.
 const MIN_VARIATION: int = 217
 const MAX_VARIATION: int = 255
 
-## What a critical hit multiplies by. Generation 2 doubles the damage rather than
-## recomputing it at a higher level, which is what Generation 1 did.
+## A critical doubles the damage here rather than recomputing it at a higher
+## level the way Generation 1 did.
 const CRITICAL_MULTIPLIER: int = 2
 
-## The chance of a critical at each critical level, out of 256. Level 0 is the
-## one in fifteen every hit has; the levels above it are what a high-critical
-## move and Focus Energy add.
+## The chance at each critical level, out of 256; level 0 is every hit's.
 const CRITICAL_CHANCES: Array = [17, 32, 64, 85, 128, 128, 128]
 
 ## Moves with a raised critical rate, worth two critical levels each.
 const HIGH_CRITICAL_MOVES: Array = [0x02, 0x0D, 0x4B, 0x98, 0xA3, 0xB1, 0xEE]
 
-## Focus Energy is worth one. It is here rather than in the move list because it
-## is a state the attacker is in, not a property of the move being used.
+## Focus Energy: a state the attacker is in, not a property of the move.
 const FOCUS_ENERGY_LEVELS: int = 1
 
-## Struggle is exempt from STAB and from the type chart alike: the cartridge
-## returns out of that step before either is looked at.
+## Exempt from STAB and the type chart: `BattleCommand_Stab` returns first.
 const STRUGGLE: int = 0xA5
 
 ## STAB is half again, truncated, not a multiply by 1.5.
 const STAB_NUMERATOR: int = 3
 const STAB_DENOMINATOR: int = 2
 
-## What a confused Pokémon hits itself for: a 40-power typeless physical hit
-## against its own Attack and Defense. Neither side's type comes into it, so
-## there is no STAB and no matchup, and it is never a critical.
+## A typeless physical hit against the Pokémon's own stats: no STAB, no matchup
+## and never a critical.
 const CONFUSION_POWER: int = 40
 
-## `TruncateHL_BC` holds the attack in `hl` and the defense in `bc` and shifts
-## both right by two until each fits in a byte, flooring each at one. The pair is
-## shifted together, so the ratio survives and the magnitude does not, which is
-## what the formula's own multiply by the attack then reads.
+## `TruncateHL_BC` shifts the pair right by two until both fit in a byte,
+## flooring at one: the ratio survives and the magnitude does not.
 const STAT_BYTE_MAX: int = 0xFF
 const TRUNCATE_SHIFT: int = 4
 
 
-## A hit, rolled. Returns what [method calculate_with] returns.
+## A hit, rolled.
 static func calculate(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -86,22 +73,16 @@ static func calculate(
 	)
 
 
-## A hit with both rolls decided. Deterministic, and the whole of the formula.
-##
-## The cartridge spends four commands on what this composes in one, and every
-## effect that reaches inside the formula does so between two of them: Present
-## sets the power between [method damage_stats] and [method damage_calc], Triple
-## Kick multiplies between [method damage_calc] and [method stab_damage], Fury
-## Cutter and Rollout between [method stab_damage] and [method apply_variation].
-## So the four are what the effect commands call and this is the composition,
-## kept because a caller wanting a whole hit at once (the AI, a test) should not
-## have to know the order.
+## A hit with both rolls decided: deterministic, and the whole formula, for a
+## caller (the AI, a test) that has no list to put the four steps in. Present,
+## Triple Kick, Fury Cutter and Rollout each write between two of them, which is
+## why the effect commands call the four rather than this.
 ##
 ## Returns { damage, critical, effectiveness, stab, immune }.
-## [code]effectiveness[/code] is in tenths and is the announced number, not always
-## the one damage used: see [method GameData.type_effectiveness].
-## [code]immune[/code] is a matchup of zero, which the cartridge treats as a miss
-## rather than a hit for nothing.
+## [code]effectiveness[/code] is in tenths and is the announced number, not
+## always the one damage used (see [method GameData.type_effectiveness]);
+## [code]immune[/code] is a matchup of zero, which is a miss rather than a hit
+## for nothing.
 static func calculate_with(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -141,13 +122,10 @@ static func calculate_with(
 	return out
 
 
-## `BattleCommand_DamageStats`, whose two halves are `PlayerAttackDamage` and
-## `EnemyAttackDamage`: pick the attacking and defending stats, apply the items
-## and the defender's screen, and hand the pair to `TruncateHL_BC`.
-##
-## Returns [attack, defense], already byte-sized, which is why Selfdestruct's
-## halving in [method damage_calc] lands on the truncated value rather than the
-## raw one.
+## `BattleCommand_DamageStats` (`PlayerAttackDamage`, `EnemyAttackDamage`): the
+## stats, the items and the screen, handed to `TruncateHL_BC`. The pair comes
+## back byte-sized, which is why Selfdestruct's halving in
+## [method damage_calc] lands on the truncated value.
 static func damage_stats(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -167,16 +145,10 @@ static func damage_stats(
 ## `BattleCommand_DamageCalc`: Selfdestruct's halved defense, the formula, the
 ## type-boosting item, the critical multiplier, the cap and the minimum.
 ##
-## A power of zero returns without writing anything, which is the routine's own
-## `ret z`, so a status move reaches [method stab_damage] with no damage rather
-## than with the minimum two. `EFFECT_MULTI_HIT` and `EFFECT_CONVERSION` are the
-## two the source lets past that check, because both can carry a power of zero
-## and have it filled in by the time this runs.
-##
-## [param level] is the level the formula multiplies, or -1 for the attacker's
-## own. `BattleCommand_BeatUp` is the one caller that needs the parameter: it
-## loads `e` with a party member's level rather than the level of whoever is on
-## the field.
+## Its `ret z` on a power of zero is why a status move reaches
+## [method stab_damage] with no damage rather than the minimum two.
+## [param level] is -1 for the attacker's own; `BattleCommand_BeatUp` is the one
+## caller that passes a party member's.
 static func damage_calc(
 	attacker: Gen2BattleMon,
 	power: int,
@@ -198,10 +170,9 @@ static func damage_calc(
 		attacker.level if level < 0 else level, power, attack, used_defense
 	)
 
-	# The type-boosting items land here, on the finished base damage and ahead of
-	# the critical multiplier, which is where `PlayerAttackDamage` applies them:
-	# after the divide by fifty and before `.CriticalMultiplier`. Struggle reaches
-	# this too, because that routine has no Struggle check of its own.
+	# Where `PlayerAttackDamage` applies them: after the divide by fifty and
+	# before `.CriticalMultiplier`. Struggle reaches this too, that routine
+	# having no check of its own.
 	var boost: int = Gen2HeldItem.effect_of(attacker.data, attacker.item)
 	if Gen2HeldItem.boosts_type(boost, move_type):
 		damage = Gen2HeldItem.apply_type_boost(
@@ -213,19 +184,13 @@ static func damage_calc(
 	return mini(damage, DAMAGE_CAP) + MIN_DAMAGE
 
 
-## `BattleCommand_Stab`: the weather, the same-type bonus and the type matchup,
-## in that order, over whatever damage [method damage_calc] left.
+## `BattleCommand_Stab`: weather, same-type bonus and matchup, in that order,
+## over whatever [method damage_calc] left. It runs for a powerless move too, and
+## has to: `DoPoison` and `DoParalyze` carry `stab` and no `damagecalc`, which is
+## how Thunder Wave learns it does nothing to a Ground type.
 ##
-## Runs for a move with no power too, and has to: `DoPoison` and `DoParalyze`
-## both carry `stab` and no `damagecalc`, which is how Thunder Wave learns it has
-## no effect on a Ground type. Struggle returns before any of it, since
-## `cp STRUGGLE / ret z` is the routine's first two instructions.
-##
-## Returns { damage, stab, immune, effectiveness }.
-##
-## [param foresight] is the defender's own `SUBSTATUS_IDENTIFIED`, which drops the
-## matchup rows the cartridge keeps past its `-2` marker: Normal and Fighting
-## against a Ghost stop being immunities.
+## Returns { damage, stab, immune, effectiveness }. [param foresight] is
+## `SUBSTATUS_IDENTIFIED`, which drops the rows past the chart's `-2` marker.
 static func stab_damage(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -250,8 +215,7 @@ static func stab_damage(
 
 	var worked: int = damage
 
-	# `DoWeatherModifiers` runs at the top of the command, ahead of STAB and of
-	# the matchup.
+	# `DoWeatherModifiers`, ahead of STAB and of the matchup.
 	worked = Gen2Weather.apply_damage_modifier(worked, Gen2Weather.damage_modifier(
 		weather, move_type, int(move.get("effect", -1))
 	))
@@ -274,9 +238,8 @@ static func stab_damage(
 			out["immune"] = true
 			out["damage"] = 0
 			return out
-		# One type at a time, truncating between them, and never down to nothing:
-		# a hit that has landed cannot be rounded away. A move with no power
-		# stays at nothing, since every step here is a multiply.
+		# One type at a time, never down to nothing: a hit that landed cannot be
+		# rounded away, and a powerless move stays at nothing regardless.
 		if worked > 0:
 			@warning_ignore("integer_division")
 			worked = maxi(worked * multiplier / RomLayout.MATCHUP_EFFECTIVE, 1)
@@ -285,14 +248,9 @@ static func stab_damage(
 	return out
 
 
-## The formula's core: level, power and the two stats, before the critical
-## multiplier, the cap and the minimum.
-##
-## A defense of zero would divide by zero on the hardware too, so the cartridge
-## floors it at one and so does this.
-##
-## [param attack] and [param defense] arrive already truncated by
-## [method truncate_stats]; nothing here shifts them again.
+## Level, power and the two stats, before the critical multiplier, the cap and
+## the minimum. The stats arrive truncated and the defense is floored at one, the
+## way the cartridge floors it.
 static func base_damage(level: int, power: int, attack: int, defense: int) -> int:
 	@warning_ignore("integer_division")
 	var out: int = level * 2 / 5 + 2
@@ -302,20 +260,15 @@ static func base_damage(level: int, power: int, attack: int, defense: int) -> in
 	return out
 
 
-## `TruncateHL_BC`: the attack and the defense shifted right together, two bits
-## at a time, until both fit in a byte, each flooring at one rather than at zero.
+## `TruncateHL_BC`: both stats shifted right two bits at a time until each fits
+## in a byte, flooring at one. Not cosmetic: `base_damage` multiplies by the
+## attack before it divides by the defense, so shifting both changes the answer.
 ##
-## Not cosmetic, and not a ratio: `base_damage` multiplies by the attack before
-## it divides by the defense, so shifting both changes the answer. A Reflect
-## doubling a 200 Defense to 400 is the common way past a byte, which is why this
-## and the screens landed together, but a +6 stage, a Thick Club or a Light Ball
-## reach it without one.
-##
-## [param crystal] is the single-player fix. `.finish` re-checks and loops back
-## only when `wLinkMode` is not `LINK_COLOSSEUM`; pokegold has no such check at
-## all, so on Gold and Silver one pass is all a value gets and anything still
-## over a byte wraps, which is `docs/bugs_and_glitches.md`'s "Reflect and Light
-## Screen can make (Special) Defense wrap around above 1024".
+## [param crystal] is the single-player fix, `.finish` looping back while
+## `wLinkMode` is not `LINK_COLOSSEUM`. pokegold has no such check, so one pass
+## is all a value gets and anything still over a byte wraps, which is
+## `docs/bugs_and_glitches.md`'s "Reflect and Light Screen can make (Special)
+## Defense wrap around above 1024".
 static func truncate_stats(attack: int, defense: int, crystal: bool = true) -> Array:
 	var out_attack: int = attack
 	var out_defense: int = defense
@@ -329,8 +282,7 @@ static func truncate_stats(attack: int, defense: int, crystal: bool = true) -> A
 	return [out_attack & STAT_BYTE_MAX, out_defense & STAT_BYTE_MAX]
 
 
-## The random spread, applied last. A hit of one is left alone: there is nothing
-## below it to reduce to.
+## The spread, applied last; a hit of one has nothing below it to reduce to.
 static func apply_variation(damage: int, variation: int) -> int:
 	if damage < MIN_DAMAGE:
 		return damage
@@ -338,8 +290,7 @@ static func apply_variation(damage: int, variation: int) -> int:
 	return damage * clampi(variation, MIN_VARIATION, MAX_VARIATION) / MAX_VARIATION
 
 
-## Whether this hit is a critical, at the critical level the move and the
-## attacker's state add up to.
+## `BattleCommand_Critical`'s roll, at the level below.
 static func roll_critical(
 	move: Dictionary, rng: RandomNumberGenerator, focus_energy: bool = false,
 	scope_lens: bool = false
@@ -351,9 +302,8 @@ static func roll_critical(
 	]
 
 
-## The critical level a hit is rolled at: two for a high-critical move, one for
-## Focus Energy, one for the Scope Lens, in the order `BattleCommand_Critical`
-## adds them.
+## Two for a high-critical move, one for Focus Energy, one for the Scope Lens,
+## in `BattleCommand_Critical`'s own order.
 static func critical_level(
 	move_number: int, focus_energy: bool = false, scope_lens: bool = false
 ) -> int:
@@ -371,15 +321,11 @@ static func roll_variation(rng: RandomNumberGenerator) -> int:
 	return rng.randi_range(MIN_VARIATION, MAX_VARIATION)
 
 
-## What a confused Pokémon does to itself instead of moving: its own Attack
-## against its own Defense, with the stages and any burn applied exactly as an
-## ordinary physical hit would read them, but no STAB, no type matchup and no
-## critical, because the hit is not really an attack at all.
+## `HitSelfInConfusion`: the Pokémon's own Attack against its own Defense, stages
+## and burn read as a physical hit would, and no STAB, matchup or critical.
 ##
-## [param screens] is the confused Pokémon's own side's, which is the side being
-## hit: `HitSelfInConfusion` picks `wPlayerScreens` for the player's turn and
-## doubles the Defense off it exactly as `PlayerAttackDamage` does, so a Reflect
-## halves what confusion takes out of the Pokémon that put it up.
+## [param screens] is the confused Pokémon's own side's, doubled off exactly as
+## `PlayerAttackDamage` doubles, so a Reflect halves what confusion takes.
 static func confusion_damage(
 	mon: Gen2BattleMon, rng: RandomNumberGenerator, screens: int = Gen2Screens.NONE
 ) -> int:
@@ -397,45 +343,38 @@ static func confusion_damage(
 
 
 ## `MagnitudePower` (`data/moves/magnitude_power.asm`), as [threshold, power,
-## magnitude number]. One byte is rolled and the first row whose threshold is at
-## or above it wins, so the thresholds are cumulative rather than per-row odds.
-## `percent` is `* $ff / 100` and truncates, which is why 5 percent + 1 is 13 and
-## not 14.
+## magnitude]. The first row at or above the rolled byte wins, so the thresholds
+## are cumulative; `percent` is `* $ff / 100` truncated, which is why 5 percent
+## + 1 is 13.
 const MAGNITUDE_POWER: Array = [
 	[13, 10, 4], [38, 30, 5], [89, 50, 6], [166, 70, 7],
 	[217, 90, 8], [242, 110, 9], [255, 150, 10],
 ]
 
-## `PresentPower` (`data/moves/present_power.asm`), read the same way, with the
-## `-1` terminator standing for the fourth outcome: no hit at all, and a quarter
-## of the target's health back instead. The terminator is tested before the
-## comparison, so every roll above the last threshold reaches it.
+## `PresentPower` (`data/moves/present_power.asm`), read the same way. Its `-1`
+## terminator is the fourth outcome, a quarter of the target's health back, and
+## is tested before the comparison, so every roll above the last row reaches it.
 const PRESENT_POWER: Array = [[102, 40], [179, 80], [204, 120]]
 
-## `FlailReversalPower` (`data/moves/flail_reversal_power.asm`), as
-## [hp bar pixels, power] with `HP_BAR_LENGTH_PX` at 48. The index is how many
-## of those 48 pixels of health are left, so the emptier the bar the earlier the
-## walk stops and the harder the hit.
+## `FlailReversalPower` (`data/moves/flail_reversal_power.asm`), as [hp bar
+## pixels, power]: the emptier the bar, the earlier the walk stops.
 const FLAIL_REVERSAL_POWER: Array = [
 	[1, 200], [4, 150], [9, 100], [16, 80], [32, 40], [48, 20],
 ]
 
-## `HP_BAR_LENGTH_PX`, which Flail and Reversal measure in rather than in a
-## percentage.
+## What Flail and Reversal measure in, rather than a percentage.
 const HP_BAR_LENGTH_PX: int = 48
 
-## Return and Frustration: `happiness * 10 / 25`, and the same over 255 minus the
-## happiness (`engine/battle/move_effects/return.asm`, `.../frustration.asm`).
-##
-## The two zero ends are the cartridge's own bug and are kept: a Return from a
-## Pokémon that hates its trainer and a Frustration from one that loves it both
-## work out to a power of zero, which `damagecalc` then refuses outright.
+## Return and Frustration: `happiness * 10 / 25`, and the same over 255 minus it
+## (`engine/battle/move_effects/return.asm`, `.../frustration.asm`). Both zero
+## ends are the cartridge's own bug, kept: a power of zero, which `damagecalc`
+## refuses outright.
 const HAPPINESS_NUMERATOR: int = 10
 const HAPPINESS_DENOMINATOR: int = 25
 const HAPPINESS_MAX: int = 255
 
 
-## The row of [constant MAGNITUDE_POWER] a rolled byte lands on.
+## The [constant MAGNITUDE_POWER] row a rolled byte lands on.
 static func magnitude_row(roll: int) -> Array:
 	for row: Array in MAGNITUDE_POWER:
 		if int(row[0]) >= roll:
@@ -458,13 +397,9 @@ static func happiness_power(happiness: int, inverted: bool = false) -> int:
 	return value * HAPPINESS_NUMERATOR / HAPPINESS_DENOMINATOR
 
 
-## Flail and Reversal's power, from how much of the health bar is left.
-##
-## The index is `hp * 48 / max_hp`, except that a maximum over a byte is divided
-## down first: `.reversal` shifts the product and the divisor right two bits each
-## before the divide, because the routine's divisor is one byte wide. Both are
-## integer divisions and the second loses the low bits of each, which is the
-## cartridge's answer rather than an approximation of it.
+## `hp * 48 / max_hp`, except that `.reversal` shifts product and divisor right
+## two bits each when the maximum is over a byte, its divisor being one byte
+## wide. Both divisions truncate, which is the cartridge's own answer.
 static func flail_reversal_power(hp: int, max_hp: int) -> int:
 	if max_hp <= 0:
 		return int(FLAIL_REVERSAL_POWER[0][1])
@@ -481,12 +416,10 @@ static func flail_reversal_power(hp: int, max_hp: int) -> int:
 	return int(FLAIL_REVERSAL_POWER[FLAIL_REVERSAL_POWER.size() - 1][1])
 
 
-## `HiddenPowerDamage`: the move's type and power, both out of the user's DVs.
-##
-## Returns { type, power }. The power takes the top bit of each of the four DVs
-## into a nibble, multiplies by five, adds the Special DV's low two bits, halves
-## and adds 31. The type is the Defense DV's low two bits under the Attack DV's,
-## stepped over `BIRD` and over the ten unused numbers between Steel and Fire.
+## `HiddenPowerDamage`, as { type, power }: the top bit of each DV into a nibble
+## times five, plus the Special DV's low two bits, halved and plus 31; the type
+## is the Defense DV's low two bits under the Attack DV's, stepped over `BIRD`
+## and the ten unused numbers between Steel and Fire.
 static func hidden_power(dvs: int) -> Dictionary:
 	var attack: int = Gen2Stats.attack_dv(dvs)
 	var defense: int = Gen2Stats.defense_dv(dvs)
@@ -507,30 +440,23 @@ static func hidden_power(dvs: int) -> Dictionary:
 	return {"type": move_type, "power": power}
 
 
-## Psywave: a random amount from one up to but excluding one and a half times the
-## user's level, the halving floored first. The cartridge rerolls a byte until it
-## lands in range rather than clamping, which is the same uniform pick. Level 1
-## has no such range and would spin forever on hardware, so it reads as a minimum
-## of one here.
+## Psywave: one up to but excluding one and a half times the level, the halving
+## floored first. The cartridge rerolls rather than clamping, which is the same
+## pick; level 1 has no range and would spin on hardware, so it reads as one.
 static func psywave_damage(level: int, rng: RandomNumberGenerator) -> int:
 	@warning_ignore("integer_division")
 	var upper: int = level / 2 + level
 	return rng.randi_range(1, maxi(upper - 1, 1))
 
 
-## Whether a move is worked out from Attack or from Special Attack.
-##
-## Generation 2 splits by type, not by move: every type below Fire is physical
-## and every type from Fire up special, which is why Hyper Beam is special and
-## Bite physical.
+## The split is by type, not by move: below Fire is physical and Fire up
+## special, which is why Hyper Beam is special and Bite physical.
 static func is_physical(move_type: int) -> bool:
 	return move_type < RomLayout.SPECIAL_TYPES_START
 
 
-## The attacking stat, doubled if the attacker is one of the two species holding
-## the item that answers for it: `ThickClubBoost` sits on the physical branch and
-## `LightBallBoost` on the special one, both after the stat has been chosen and
-## before it is truncated.
+## `ThickClubBoost` on the physical branch and `LightBallBoost` on the special
+## one, both after the stat is chosen and before it is truncated.
 static func _attack_stat(
 	attacker: Gen2BattleMon, defender: Gen2BattleMon, move_type: int, critical: bool
 ) -> int:
@@ -543,15 +469,13 @@ static func _attack_stat(
 	return out
 
 
-## The defending stat, doubled by the defender's own screen. Metal Powder is not
-## here: `DittoMetalPowder` runs past `TruncateHL_BC`, on the byte, which is
+## The defending stat, doubled by the defender's screen. Metal Powder is not
+## here: `DittoMetalPowder` runs past `TruncateHL_BC`, which is
 ## [method metal_powder_pair].
 ##
-## The screen is applied to the boosted stat and only there. `PlayerAttackDamage`
-## doubles the pair before `CheckDamageStatsCritical`, and a critical that
-## reaches `.thickclub`'s no-carry branch reloads the unmodified stat over it, so
-## the same critical that ignores the defender's stages ignores its screen with
-## them.
+## `PlayerAttackDamage` doubles before `CheckDamageStatsCritical`, and a critical
+## reaching `.thickclub`'s no-carry branch reloads the unmodified stat over it,
+## so a critical that ignores the defender's stages ignores its screen too.
 static func _defense_stat(
 	attacker: Gen2BattleMon, defender: Gen2BattleMon, move_type: int, critical: bool,
 	defender_screens: int = Gen2Screens.NONE
@@ -564,17 +488,13 @@ static func _defense_stat(
 	return out
 
 
-## `DittoMetalPowder`, which `BattleCommand_DamageStats` calls at `.done`, after
-## `TruncateHL_BC`: the half again lands on the byte-sized defence rather than on
-## the stat it was truncated from, so a defence a screen or a stage has pushed
-## past a byte is boosted from what the shift left of it.
+## `DittoMetalPowder`, called at `.done` after `TruncateHL_BC`, so the half again
+## lands on the byte rather than on the stat it was truncated from.
 ##
-## Its own overflow is reproduced, not corrected. `srl a / add c` carries for a
-## byte over 170, and the recovery halves the *attack* and shifts the carry back
-## into the defence, which is `docs/bugs_and_glitches.md`'s "Metal Powder can
-## increase damage taken with boosted (Special) Defense": the attacker loses a
-## bit of attack, and the defence lands at half the boosted value rather than
-## above it.
+## Its overflow is reproduced, not corrected: `srl a / add c` carries for a byte
+## over 170 and the recovery halves the *attack* and shifts the carry back into
+## the defence, which is `docs/bugs_and_glitches.md`'s "Metal Powder can increase
+## damage taken with boosted (Special) Defense".
 static func metal_powder_pair(defender: Gen2BattleMon, pair: Array) -> Array:
 	if defender == null or not Gen2HeldItem.boosts_defence(defender.species, defender.item):
 		return pair
@@ -588,13 +508,9 @@ static func metal_powder_pair(defender: Gen2BattleMon, pair: Array) -> Array:
 	return [attack, ((boosted & STAT_BYTE_MAX) >> 1) | ((STAT_BYTE_MAX + 1) >> 1)]
 
 
-## A critical hit ignores both sides' stages, but only when they are working
-## against the attacker.
-##
-## Narrower than usually described: the cartridge compares the two stages and
-## keeps them when the defender's is lower, so a critical from an attacker who
-## raised its Attack keeps the boost and one against a raised Defense ignores it.
-## The attacker's advantage either way.
+## A critical ignores both sides' stages, but only when they work against the
+## attacker: the cartridge keeps them while the defender's is lower, so a raised
+## Attack survives and a raised Defense does not.
 static func _ignores_stages(
 	attacker: Gen2BattleMon, defender: Gen2BattleMon, move_type: int, critical: bool
 ) -> bool:

--- a/game/battle/exp_bar_animation.gd
+++ b/game/battle/exp_bar_animation.gd
@@ -4,49 +4,35 @@ extends RefCounted
 ## The exp bar filling, one pixel at a time (`AnimateExpBar`,
 ## engine/battle/core.asm).
 ##
-## Scene-free like the rest of the battle layer: the screen ticks this once per
-## hardware frame and draws [method fraction].
+## Not the HP bar again: `.LoopLevels` fills to the end, raises the level and
+## refills from empty (`ld c, $40`, then `ld b, $0`), so this is a list of
+## segments, one per level crossed plus `.FinishExpBar`'s partial fill. Its text
+## ordering is the opposite of the HP bar's: `Text_MonGainedExpPoint` is printed
+## before `AnimateExpBar` and `BattleText_StringBuffer1GrewToLevel` inside the
+## loop, after that segment has reached the end.
 ##
-## It is not the HP bar again. `AnimateExpBar` walks over level boundaries
-## rather than between two values: the bar fills to the end, the level goes up,
-## and it refills from empty, which is what `.LoopLevels` does with `ld c, $40`
-## and then `ld b, $0` before it loops. So this is a list of segments, one per
-## level crossed plus the final partial fill `.FinishExpBar` computes.
-##
-## Its ordering against the text is the source's too, and it is the opposite of
-## the HP bar's on the way in: `Text_MonGainedExpPoint` is printed before
-## `call AnimateExpBar`, while `BattleText_StringBuffer1GrewToLevel` is printed
-## inside `.LoopLevels` after that level's segment has reached the end.
-##
-## The whole routine is byte identical between the pins but for three guards
-## Gold and Silver lack: the `$ffffff` exp clamp in `.NoOverflow`, the `cp e`
-## downward clamp after `CalcLevel`, and `.LoopLevels`' own `cp MAX_LEVEL`.
-## Crystal's top-of-routine level check is `cp MAX_LEVEL` / `jp nc` against
-## pokegold's `jp z`. None of them is reachable from a gain: a level only rises
-## and [method Gen2Experience.level_for_exp] stops at `MAX_LEVEL`, so nothing
-## here is profile split.
+## The three guards Gold and Silver lack (`.NoOverflow`'s `$ffffff` clamp, the
+## `cp e` after `CalcLevel`, `.LoopLevels`' `cp MAX_LEVEL`) are unreachable from
+## a gain, so nothing here is profile split.
 
-## `EXP_BAR_LENGTH * TILE_WIDTH`, the bar's full width in pixels. `CalcExpBar`
-## multiplies by 64 and returns `$40 - b`; `PlaceExpBar` draws eight tiles.
+## `EXP_BAR_LENGTH * TILE_WIDTH`: `CalcExpBar` returns `$40 - b` over eight
+## tiles.
 const LENGTH_PX: int = Gen2BattleHud.EXP_BAR_TILES * Gen2BattleHud.TILE
 
-## `.PlayExpBarSound`'s `ld c, 10` / `call DelayFrames`, spent before each
-## segment starts moving. The `SFX_EXP_BAR` beside it is the same boundary the
-## Poof's `SFX_SWITCH_POKEMON` is: no battle screen has an SFX route.
+## `.PlayExpBarSound`'s `ld c, 10`, spent before each segment moves. Its
+## `SFX_EXP_BAR` is the Poof's boundary: no battle screen has an SFX route.
 const LEAD_FRAMES: int = 10
 
-## `.LoopBarAnimation`'s `ld d, 3`, and its floor. The delay is spent twice per
-## value and then decremented, so a segment paces 3, 3, 2, 2, 1, 1, 1, 1 and on
-## at one frame a pixel. `ld d, 3` is inside the routine, which is called once
-## per segment, so every segment starts slow again.
+## `.LoopBarAnimation`'s `ld d, 3` and its floor: 3, 3, 2, 2, 1, 1 and on at a
+## frame a pixel. The load is inside the routine, so every segment starts slow.
 const START_DELAY: int = 3
 const MIN_DELAY: int = 1
 
 ## How many pixels each delay value is held for before it is decremented.
 const STEPS_PER_DELAY: int = 2
 
-## Where each segment ends, in pixels. All but the last are [constant LENGTH_PX],
-## since a level boundary is reached at the end of the bar.
+## Where each segment ends: [constant LENGTH_PX] but for the last, a level
+## boundary being the end of the bar.
 var _targets: Array[int] = []
 var _segment: int = 0
 var _pixels: int = 0
@@ -55,20 +41,15 @@ var _delay: int = START_DELAY
 var _held: int = 0
 var _frames: int = 0
 var _segment_ended: bool = false
-## Set when a level boundary has been reached and the bar is still showing it
-## full, cleared by the next segment's first draw.
+## A boundary reached with the bar still full, cleared by the next first draw.
 var _pending_reset: bool = false
 ## Stopped at a level boundary under the grew-to-level textbox.
 var _paused: bool = false
 
 
-## The bar's own pixel count for [param exp_points] at [param level], which is
-## `CalcExpBar`: 64 minus the exp still owed to the next level, scaled over the
-## span between the two levels.
-##
-## The subtraction is on that side on purpose. Scaling the exp already earned
-## instead floors the other way and answers one pixel high wherever the division
-## is inexact, which is most values.
+## `CalcExpBar`: 64 minus the exp still owed, scaled over the span between the
+## two levels. Scaling the exp already earned instead floors the other way and
+## answers a pixel high wherever the division is inexact, which is most values.
 static func pixels_for(growth_rate: int, level: int, exp_points: int) -> int:
 	if level >= Gen2Experience.MAX_LEVEL:
 		return LENGTH_PX
@@ -84,13 +65,9 @@ static func pixels_for(growth_rate: int, level: int, exp_points: int) -> int:
 	return clampi(LENGTH_PX - owed, 0, LENGTH_PX)
 
 
-## The walk from [param from_pixels] over [param targets], each of which is
-## where one segment ends.
-##
-## A segment that covers no distance is not skipped: `.LoopBarAnimation` draws
-## and waits before it compares, so a gain too small to move a pixel still costs
-## its lead and one delay, exactly as it does on the cartridge. Only an empty
-## [param targets] is finished on arrival.
+## A segment covering no distance is not skipped: `.LoopBarAnimation` draws and
+## waits before it compares, so a gain too small to move a pixel still costs its
+## lead and one delay. Only an empty [param targets] is finished on arrival.
 static func create(from_pixels: int, targets: Array[int]) -> Gen2ExpBarAnimation:
 	var animation := Gen2ExpBarAnimation.new()
 	animation._pixels = clampi(from_pixels, 0, LENGTH_PX)
@@ -109,22 +86,19 @@ func pixels() -> int:
 	return _pixels
 
 
-## Whether the last [method advance_frame] ended a segment, which is a level
-## boundary for every segment but the last. It is what prints the grew-to-level
-## line `.LoopLevels` prints once the bar has reached the end.
+## A segment ended, which is a level boundary for all but the last and is what
+## prints `.LoopLevels`' grew-to-level line.
 func segment_finished() -> bool:
 	return _segment_ended
 
 
-## Whether the bar is stopped at a level boundary waiting to be let go, which is
-## `.LoopLevels`' own `StdBattleTextbox`: that textbox blocks on a button before
-## the loop reaches `.PlayExpBarSound` again.
+## `.LoopLevels`' `StdBattleTextbox`, which blocks on a button before the loop
+## reaches `.PlayExpBarSound` again.
 func paused() -> bool:
 	return _paused
 
 
-## The press that dismisses the grew-to-level textbox, which is what lets
-## `.LoopLevels` run on into the next level's fill.
+## The press that dismisses that textbox and lets the next fill start.
 func resume() -> void:
 	if not _paused:
 		return
@@ -136,8 +110,7 @@ func resume() -> void:
 	_frames = 0
 
 
-## One hardware frame. Answers whether the bar moved, which is what tells the
-## screen to redraw.
+## One hardware frame; whether the bar moved is what asks for a redraw.
 func advance_frame() -> bool:
 	_segment_ended = false
 	if finished() or _paused:
@@ -147,10 +120,9 @@ func advance_frame() -> bool:
 		_lead -= 1
 		if _lead > 0 or not _pending_reset:
 			return false
-		# `ld b, $0` is set at the end of `.LoopLevels`, but nothing draws it
-		# until the next `.LoopBarAnimation` runs, which is after
-		# `.PlayExpBarSound`'s ten frames. So the full bar stays up under the
-		# grew-to-level textbox and empties on the new segment's first draw.
+			# `.LoopLevels`' `ld b, $0` is drawn by the next `.LoopBarAnimation`,
+			# ten frames later, so the full bar stays up under the textbox and
+			# empties on the new segment's first draw.
 		_pending_reset = false
 		_pixels = 0
 		return true
@@ -175,9 +147,8 @@ func advance_frame() -> bool:
 	return moved
 
 
-## `.LoopLevels`' own tail: the level goes up and its line is printed by a
-## textbox that blocks on a button, so the bar stops here full. [method resume]
-## is that button, and it is what empties the bar and starts the next fill.
+## `.LoopLevels`' tail: the level goes up and its textbox blocks on a button, so
+## the bar stops here full and [method resume] is that button.
 func _end_segment() -> void:
 	_segment_ended = true
 	_segment += 1

--- a/game/battle/held_item.gd
+++ b/game/battle/held_item.gd
@@ -1,31 +1,21 @@
 class_name Gen2HeldItem
 extends RefCounted
 
-## What a Pokémon is carrying, and what the battle does about it.
+## `ITEMATTR_EFFECT` and `ITEMATTR_PARAM` read: tables and arithmetic, the shape
+## [Gen2Status], [Gen2Substatus] and [Gen2Weather] have.
 ##
-## An item's held effect and its parameter are already on every row the importer
-## writes ([code]effect[/code] and [code]parameter[/code]), which is
-## `ITEMATTR_EFFECT` and `ITEMATTR_PARAM`. This class is the reading of them:
-## pure arithmetic and tables, the same shape [Gen2Status], [Gen2Substatus] and
-## [Gen2Weather] have.
-##
-## Only the effects a real item carries are named. `constants/item_data_constants.asm`
-## defines twenty more, and no item in any of the three games has one:
-## `HandleStatBoostingHeldItems` says so itself ("The effects handled here are
-## not used in-game"), and the same is true of every `HELD_PREVENT_*`.
-##
-## Two of the items here have no held effect at all. Thick Club and Light Ball
-## are checked by item number, through `SpeciesItemBoost`, because what they do
-## depends on who is holding them.
+## Only the effects a real item carries are named; the twenty more
+## `constants/item_data_constants.asm` defines reach no item, which
+## `HandleStatBoostingHeldItems`' own comment says. Thick Club and Light Ball
+## carry no held effect at all and are checked by number through
+## `SpeciesItemBoost`.
 
 const NONE: int = 0
 
-## Berry and Gold Berry restore [code]parameter[/code] HP once the holder drops
-## below half; Berry Juice is the same effect with a larger number.
+## Berry, Gold Berry and Berry Juice: [code]parameter[/code] HP under half.
 const BERRY: int = 1
 
-## A sixteenth of maximum HP every turn. Its own parameter is 10 and nothing
-## reads it.
+## A sixteenth of maximum HP a turn; its parameter of 10 is read by nothing.
 const LEFTOVERS: int = 3
 
 ## Mysteryberry, which refills the first move that ran out.
@@ -34,8 +24,8 @@ const RESTORE_PP: int = 6
 ## Cleanse Tag, which is an overworld encounter-rate item and not a battle one.
 const CLEANSE_TAG: int = 8
 
-## The status berries, one effect per status plus Miracleberry for all of them
-## and Bitter Berry for confusion, which is not a status at all.
+## One effect per status, plus Miracleberry for all of them and Bitter Berry for
+## confusion, which is not a status.
 const HEAL_POISON: int = 10
 const HEAL_FREEZE: int = 11
 const HEAL_BURN: int = 12
@@ -47,9 +37,8 @@ const HEAL_CONFUSION: int = 16
 ## Metal Powder, which is only worth anything on a Ditto.
 const METAL_POWDER: int = 42
 
-## The seventeen type-boosting items, one per type, running from
-## `HELD_NORMAL_BOOST` in the type chart's own order. Each carries a parameter of
-## 10, which is the percentage it adds.
+## The seventeen type boosts, `HELD_NORMAL_BOOST` up in type-chart order, each
+## with a parameter of 10 percent.
 const NORMAL_BOOST: int = 50
 const STEEL_BOOST: int = 66
 
@@ -65,8 +54,7 @@ const QUICK_CLAW: int = 74
 ## King's Rock: a chance to make an ordinary attack flinch.
 const FLINCH: int = 75
 
-## Amulet Coin, which doubles prize money and so is not a battle-engine effect
-## here: no money changes hands inside [Gen2Battle].
+## Amulet Coin: prize money, which [Gen2Battle] does not pay.
 const AMULET_COIN: int = 76
 
 ## BrightPowder: its parameter comes straight off the attacker's accuracy.
@@ -75,11 +63,9 @@ const BRIGHTPOWDER: int = 77
 ## Focus Band: a chance to survive on one hit point.
 const FOCUS_BAND: int = 79
 
-## `TypeBoostItems` (data/types/type_boost_items.asm), which is the whole of the
-## `HELD_*_BOOST` run in the type chart's own order. Dragon Scale rather than
-## Dragon Fang boosts Dragon, which `docs/bugs_and_glitches.md` records as a bug
-## the games ship rather than a choice; nothing here has to do anything about
-## that, since the effect byte is on the item the cartridge put it on.
+## `TypeBoostItems` (data/types/type_boost_items.asm). Dragon Scale rather than
+## Dragon Fang boosts Dragon, a shipped bug (`docs/bugs_and_glitches.md`) that
+## costs nothing: the effect byte sits where the cartridge put it.
 const TYPE_BOOSTS: Dictionary = {
 	NORMAL_BOOST: RomLayout.TYPE_NORMAL,
 	51: RomLayout.TYPE_FIGHTING,
@@ -100,9 +86,8 @@ const TYPE_BOOSTS: Dictionary = {
 	STEEL_BOOST: RomLayout.TYPE_STEEL,
 }
 
-## The two items `SpeciesItemBoost` checks by number, with the species each one
-## answers for. Thick Club is reached on the physical branch and Light Ball on
-## the special one, so each doubles the stat its own branch had already chosen.
+## `SpeciesItemBoost`'s two by-number items: Thick Club on the physical branch,
+## Light Ball on the special one.
 const THICK_CLUB: int = 118
 const LIGHT_BALL: int = 163
 const CUBONE: int = 104
@@ -113,42 +98,34 @@ const PIKACHU: int = 25
 const METAL_POWDER_ITEM: int = 35
 const DITTO: int = 132
 
-## `MailItems` (data/items/mail_items.asm), which `ItemIsMail` walks. Pinned here
-## rather than imported: the table has no locator, the way `RadioChannels` in
-## `game/world/world_radio.gd` has none. `BattleCommand_Thief` is its only reader,
-## and no mail model exists.
+## `MailItems` (data/items/mail_items.asm), pinned rather than imported for want
+## of a locator. `BattleCommand_Thief` is the only reader.
 const MAIL_ITEMS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]
 
-## What Metal Powder does to the defence it is read against: half again, floored
-## the way the cartridge's `srl a; add c` floors it.
+## Metal Powder's half again, floored the way `srl a; add c` floors it.
 const METAL_POWDER_NUMERATOR: int = 3
 const METAL_POWDER_DENOMINATOR: int = 2
 
 ## What a type-boosting item multiplies by, as a percentage added to 100.
 const BOOST_DIVISOR: int = 100
 
-## One more critical level, the same shape [constant Gen2Damage.FOCUS_ENERGY_LEVELS]
-## already has.
+## One more critical level, as [constant Gen2Damage.FOCUS_ENERGY_LEVELS] is.
 const CRITICAL_LEVELS: int = 1
 
-## The range every held-item roll is out of: `BattleRandom` against the item's
-## own parameter byte, so a parameter of 30 is 30 in 256.
+## `BattleRandom` against the parameter byte: a parameter of 30 is 30 in 256.
 const CHANCE_RANGE: int = 256
 
-## What Leftovers gives back each turn, `GetSixteenthMaxHP`'s at-least-one
-## sixteenth. Its own parameter is not read.
+## `GetSixteenthMaxHP`'s at-least-one sixteenth.
 const LEFTOVERS_DIVISOR: int = 16
 
-## What Mysteryberry puts back into the first move that ran out, and the one move
-## it puts back less into. Sketch is by number, and the cartridge's own comment
-## calls it a lousy hack.
+## Mysteryberry's refill, and Sketch's smaller one, which the cartridge's own
+## comment calls a lousy hack.
 const RESTORED_PP: int = 5
 const SKETCH_RESTORED_PP: int = 1
 const SKETCH: int = 166
 
-## `HeldStatusHealingEffects` (data/battle/held_heal_status.asm): which status
-## each berry answers for. Miracleberry's row is every status at once, and Bitter
-## Berry is not here at all because confusion is not a status.
+## `HeldStatusHealingEffects` (data/battle/held_heal_status.asm): Miracleberry's
+## row is every status, and Bitter Berry is absent, confusion being none.
 const STATUS_HEALS: Dictionary = {
 	HEAL_POISON: Gen2Status.POISON,
 	HEAL_FREEZE: Gen2Status.FREEZE,
@@ -159,23 +136,19 @@ const STATUS_HEALS: Dictionary = {
 }
 
 
-## Whether an effect is a berry that answers for [param status].
-##
 ## `UseHeldStatusHealingItem` clears the whole status byte rather than the masked
 ## bit, which is the same thing while one status is all a Pokémon can carry.
 static func heals_status(effect: int, status: int) -> bool:
 	return (int(STATUS_HEALS.get(effect, 0)) & status) != 0
 
 
-## Whether an effect is one of the two berries that answer for confusion:
 ## `UseConfusionHealingItem` takes Bitter Berry and Miracleberry alike.
 static func heals_confusion(effect: int) -> bool:
 	return effect == HEAL_CONFUSION or effect == HEAL_STATUS
 
 
-## `HandleHPHealingItem`'s own condition, which is strictly under half rather
-## than at or under it: the cartridge doubles the current HP and returns unless
-## it comes in below the maximum.
+## `HandleHPHealingItem`'s condition: strictly under half, since the cartridge
+## doubles the current HP and returns unless it lands below the maximum.
 static func wants_hp_berry(hp: int, max_hp: int) -> bool:
 	return hp * 2 < max_hp
 
@@ -191,26 +164,21 @@ static func restored_pp(move_number: int) -> int:
 	return SKETCH_RESTORED_PP if move_number == SKETCH else RESTORED_PP
 
 
-## The held effect of [param item], or [constant NONE]. The item's own
-## [code]effect[/code] field is `ITEMATTR_EFFECT`.
+## `ITEMATTR_EFFECT`, or [constant NONE].
 static func effect_of(data: GameData, item: int) -> int:
 	if data == null or item <= 0:
 		return NONE
 	return int(data.item(item).get("effect", NONE))
 
 
-## The item's `ITEMATTR_PARAM`, which is what every held-item roll is against and
-## what the HP and percentage effects carry their number in. Absent parameters
-## are stored as -1 by the importer and answer zero here, since nothing that
-## reads one is reached by an item that has none.
+## `ITEMATTR_PARAM`; an absent one is -1 in the cache and zero here.
 static func parameter_of(data: GameData, item: int) -> int:
 	if data == null or item <= 0:
 		return 0
 	return maxi(int(data.item(item).get("parameter", 0)), 0)
 
 
-## Whether a held effect boosts [param move_type], which is `TypeBoostItems`'
-## own walk: the row has to match both the effect and the type.
+## `TypeBoostItems`' own walk: the row matches both the effect and the type.
 static func boosts_type(effect: int, move_type: int) -> bool:
 	return TYPE_BOOSTS.get(effect, -1) == move_type
 
@@ -221,17 +189,15 @@ static func apply_type_boost(damage: int, percent: int) -> int:
 	return damage * (BOOST_DIVISOR + percent) / BOOST_DIVISOR
 
 
-## Whether `ThickClubBoost` or `LightBallBoost` doubles the stat this hit is
-## worked out from: Thick Club on Cubone or Marowak for a physical move, Light
-## Ball on Pikachu for a special one.
+## `ThickClubBoost` on Cubone or Marowak for a physical move, `LightBallBoost`
+## on Pikachu for a special one.
 static func doubles_attack(species: int, item: int, physical: bool) -> bool:
 	if physical:
 		return item == THICK_CLUB and (species == CUBONE or species == MAROWAK)
 	return item == LIGHT_BALL and species == PIKACHU
 
 
-## Whether `DittoMetalPowder` applies: the Pokémon being hit is a Ditto and it is
-## holding Metal Powder.
+## `DittoMetalPowder`: a Ditto holding Metal Powder.
 static func boosts_defence(species: int, item: int) -> bool:
 	return species == DITTO and item == METAL_POWDER_ITEM
 
@@ -247,8 +213,7 @@ static func is_mail(item: int) -> bool:
 	return MAIL_ITEMS.has(item)
 
 
-## Whether a roll out of 256 came in under an item's own parameter, which is
-## every held-item chance in the game: `BattleRandom; cp c; jr nc` keeps the
-## effect only while the roll is below it.
+## Every held-item chance: `BattleRandom; cp c; jr nc` keeps the effect only
+## while the roll is under the parameter.
 static func rolls_under(rng: RandomNumberGenerator, parameter: int) -> bool:
 	return rng.randi_range(0, CHANCE_RANGE - 1) < parameter

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -1,29 +1,22 @@
 class_name Gen2Turn
 extends RefCounted
 
-## One move being used, while it is being used.
-##
-## The commands in [Gen2EffectCommands] hand each other their working: the damage
-## step writes down what it calculated and the applying step reads it back. This
-## is where that lives, for exactly as long as the move does.
-##
-## Not a copy of the battle: both Pokémon are read through the battle every time,
-## so a command that changes one is seen by the commands after it.
+## `wPlayerMoveStruct` and the working [Gen2EffectCommands] hand between its
+## commands, for exactly as long as one move lasts. Not a copy of the battle:
+## both Pokémon are read through it, so a command that changes one is seen by the
+## commands after it.
 
 var battle: Gen2Battle = null
 
-## Who is using the move, and who it is aimed at.
 var side: int = Gen2Battle.PLAYER
 var target: int = Gen2Battle.ENEMY
 
-## The move, its number, and the slot it came out of. The slot is what PP is
-## spent from and is -1 for a move that came from nowhere, like Struggle.
+## The slot PP is spent from, -1 for a move that came from nowhere (Struggle).
 var slot: int = -1
 var move_number: int = 0
 var move: Dictionary = {}
 
-## Where the story of the turn is written. The same Array the caller of
-## [method Gen2Battle.take_actions] is handed back.
+## The same Array [method Gen2Battle.take_actions] hands its caller back.
 var events: Array = []
 
 ## What the damage steps worked out, for the steps after them.
@@ -33,98 +26,71 @@ var effectiveness: int = RomLayout.MATCHUP_EFFECTIVE
 var immune: bool = false
 var missed: bool = false
 
-## The truncated pair `damagestats` leaves in `b` and `c` for `damagecalc` to
-## divide with. Two commands rather than one, so Present can set the power
-## between them.
+## The truncated pair `damagestats` leaves for `damagecalc`: two commands rather
+## than one, so Present can set the power between them.
 var attack_stat: int = 0
 var defense_stat: int = 0
 
-## What a command has written over the move's own power and type, or -1 for the
-## cartridge row's own.
-##
-## `wPlayerMoveStruct` is a per-turn copy the cartridge writes into freely, so
-## `happinesspower`, `getmagnitude`, `present` and `hiddenpower` all just store a
-## byte there. [member move] is not a copy: [method GameData.move] hands back the
-## cached row itself, so writing to it would edit the move table for the rest of
-## the process. These two are that per-turn copy, read through
-## [method effective_move].
+## The per-turn copy `happinesspower`, `getmagnitude`, `present` and
+## `hiddenpower` write a byte into, -1 for the row's own. [member move] is the
+## cache's row itself, so writing there would edit the move table.
 var power_override: int = -1
 var type_override: int = -1
 
-## The level `damagecalc` multiplies, or -1 for the attacker's own. The one field
-## here with no `wPlayerMoveStruct` counterpart: `BattleCommand_BeatUp` hands the
-## formula a party member's level in `e`, and the Pokémon on the field is only
-## one of the six it walks.
+## The level `damagecalc` multiplies, -1 for the attacker's own. No
+## `wPlayerMoveStruct` counterpart: `BattleCommand_BeatUp` hands the formula a
+## party member's level in `e`.
 var level_override: int = -1
 
-## The same per-turn copy one field along, with one writer: `DoSubstituteDamage`
-## stamps `EFFECT_NORMAL_HIT` over `wPlayerMoveStruct + MOVE_EFFECT` once a doll
-## has broken, so the steps behind the break read an ordinary attack.
+## `DoSubstituteDamage` stamps `EFFECT_NORMAL_HIT` over `wPlayerMoveStruct +
+## MOVE_EFFECT` once a doll has broken, so the steps behind it read a plain hit.
 var effect_override: int = -1
 
-## What was actually taken off, which is not the same as [member damage]: a
-## Pokémon with three hit points left takes three from a hit worth forty.
+## What was taken off, not [member damage]: three hit points left takes three.
 var dealt: int = 0
 
-## Set by a command that has decided the move is finished, whether because it
-## missed, because it did nothing, or because it reached its end.
+## A command has decided the move is finished, however it finished.
 var ended: bool = false
 
-## Whether this is the release turn of a two-turn move, set by [Gen2Battle]
-## before anything runs. The PP for a two-turn move is spent once, on the
-## charge turn, so [method Gen2EffectCommands._do_turn] reads this rather than
-## spending again on the turn the attack actually lands.
+## The release turn of a two-turn move, whose PP was spent on the charge turn:
+## what [method Gen2EffectCommands._do_turn] reads.
 var locked: bool = false
 
-## A move entered through Metronome, Mirror Move or Sleep Talk. `ResetTurn`
-## marks the cartridge's temporary charging byte before it re-enters `DoMove`:
-## the called sequence still announces and executes, but `doturn` spends no PP
-## and does not add a second turn. This flag is that temporary byte, separate
-## from [member locked], which is a real multi-turn continuation.
+## `ResetTurn`'s temporary charging byte: a move entered through Metronome,
+## Mirror Move or Sleep Talk spends no PP and adds no second turn. Not
+## [member locked], which is a real continuation.
 var called: bool = false
 
-## A called-move command asks the effect interpreter to replace this turn's
-## move and restart at that move's first command. Zero means no restart is
-## pending. [Gen2Battle] consumes it immediately after the command returns.
+## A called-move command's request to restart at another move's first command,
+## zero for none. [Gen2Battle] consumes it as soon as the command returns.
 var called_move_number: int = 0
 
-## StoreEnergy marks a Bide release so UsedMoveText is skipped, matching its
-## jump directly to `unleashenergy` in the command stream.
+## `StoreEnergy`'s Bide release, which skips `UsedMoveText`.
 var bide_release: bool = false
 
-## The accuracy byte this move is rolled against, or -1 for the move's own.
-## `wPlayerMoveStruct` is a per-turn copy the cartridge is free to write into;
-## [member move] is the cached row, so what would be a write there is this
-## instead. Only [method Gen2EffectCommands._thunder_accuracy] sets it.
+## The accuracy byte rolled against, -1 for the move's own. Only
+## [method Gen2EffectCommands._thunder_accuracy] sets it.
 var accuracy: int = -1
 
-## Set by [method Gen2EffectCommands._skip_sun_charge] so
-## [method Gen2EffectCommands._charge_move] locks nothing in: Solarbeam in sun is
-## a one-turn move.
+## Solarbeam in sun: [method Gen2EffectCommands._charge_move] locks nothing in.
 var skip_charge: bool = false
 
-## Set when a secondary effect's roll came up short. It is not the same as
-## [member ended]: the move has happened and its damage stands, and only what was
-## behind the roll is skipped.
+## A secondary effect's roll came up short. Not [member ended]: the damage
+## stands and only what was behind the roll is skipped.
 var failed_chance: bool = false
 
 ## What a stat-changing command worked out, for the message command behind it.
-## [member stat_target] is who it happened to, which is the user for a raise and
-## the defender for almost every drop.
+## [member stat_target] is the user for a raise and the defender for most drops.
 var stat_key: String = ""
 var stat_by: int = 0
 var stat_target: int = Gen2Battle.PLAYER
 var stat_moved: bool = false
 
-## `wSomeoneIsRampaging`, which `DoMove` clears before every move and only a
-## rampage or a Rollout being *started* sets. `BattleCommand_LowerSub` is the
-## one reader: a continuation turn drops the doll where a charging turn would
-## not have.
+## `wSomeoneIsRampaging`, read by `BattleCommand_LowerSub` alone.
 var someone_is_rampaging: bool = false
 
-## Set instead of moving a stat when a drop was blocked by the target's own
-## Mist, so the fail-text step behind it can tell that apart from the ordinary
-## "already at the bottom" failure and say the right thing.
+## A drop blocked by Mist, which the fail-text step says differently from an
+## "already at the bottom" one.
 var stat_mist_blocked: bool = false
 
 
@@ -165,11 +131,8 @@ func effect() -> int:
 	return int(move.get("effect", -1))
 
 
-## The move as the damage steps read it: the cartridge row with whatever
-## [member power_override] and [member type_override] have put over it.
-##
-## Never [member move] itself once either is set, and never a write into it: that
-## Dictionary is the cache's own row.
+## The row with [member power_override] and [member type_override] over it,
+## copied rather than written into: [member move] is the cache's own row.
 func effective_move() -> Dictionary:
 	if power_override < 0 and type_override < 0:
 		return move
@@ -181,14 +144,13 @@ func effective_move() -> Dictionary:
 	return out
 
 
-## Writes an event down. [param extra] is merged over the side, which every event
-## carries.
+## [param extra] merged over the side every event carries.
 func emit(type: StringName, extra: Dictionary = {}) -> void:
 	var event: Dictionary = {"type": type, "side": side}
 	event.merge(extra, true)
 	events.append(event)
 
 
-## Stops the move where it stands. The commands after this one are not run.
+## Stops the move: the commands after this one are not run.
 func end() -> void:
 	ended = true

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -759,8 +759,8 @@ func overworld_icon_indices(icon_number: int) -> PackedByteArray:
 ## `ReadMonMenuIcon`: the icon a species is drawn with in a party menu, or zero
 ## when the cache does not hold the table. Its `cp EGG` answer is not modelled
 ## because nothing here holds an egg; a mod species numbered past the
-## cartridge's own range has no row and answers zero for the same reason
-## `Gen2ContentOverlay.defined_numbers()` reaches no dex order.
+## cartridge's own range has no row in the imported table and answers zero,
+## which is `ICON_NULL`.
 func mon_menu_icon(species: int) -> int:
 	var table: PackedByteArray = mon_menu_icon_table()
 	if species < 1 or species > table.size():
@@ -910,6 +910,16 @@ func dex_entry(number: int) -> Dictionary:
 		"weight": int(dex.get("weight", 0)),
 		"pages": pages,
 	}
+
+
+## Every species number a mod defined, ascending, and empty when no mod did.
+## Both dex order tables are cartridge data of exactly [constant
+## RomLayout.SPECIES_COUNT] entries, so a mod row can only follow them; see
+## [method Gen2Pokedex.order_by_mode].
+func mod_species_numbers() -> Array[int]:
+	if _overlay == null:
+		return [] as Array[int]
+	return _overlay.defined_numbers(Gen2ContentOverlay.KIND_SPECIES)
 
 
 ## data/pokemon/dex_order_new.asm, the order DEXMODE_NEW lists species in.

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -132,8 +132,9 @@ var _state: Gen2WorldState = null
 ## `wPrevDexEntryBackup`, which `.show_search_results` fills so leaving the
 ## results screen puts the main listing back exactly where it was.
 var _listing_backup: Dictionary = {}
-## `wPokedexOrder`, always [constant RomLayout.SPECIES_COUNT] long. ABC mode
-## zero-fills its tail, and a zero is what `.PrintEntry` draws nothing for.
+## `wPokedexOrder`, [constant RomLayout.SPECIES_COUNT] long plus one slot per mod
+## species. ABC mode zero-fills its tail, and a zero is what `.PrintEntry` draws
+## nothing for.
 var _order: PackedInt32Array = PackedInt32Array()
 
 
@@ -156,27 +157,37 @@ static func open(
 
 ## `Pokedex_OrderMonsByMode`. NEW copies the new-dex table, OLD counts from 1,
 ## and ABC keeps only the species that have been seen and zero-fills the rest.
+##
+## Both tables are cartridge data of exactly [constant RomLayout.SPECIES_COUNT]
+## entries and OLD counts that far, so a mod's species can only follow the
+## cartridge's own run, ascending by number, the way `FIRST_MOD_POCKET` numbers a
+## mod pocket after the cartridge's.
 func order_by_mode() -> void:
+	var mod_species: Array[int] = _data.mod_species_numbers() if _data != null \
+		else [] as Array[int]
 	_order = PackedInt32Array()
-	_order.resize(RomLayout.SPECIES_COUNT)
+	_order.resize(RomLayout.SPECIES_COUNT + mod_species.size())
 	match mode:
 		RomLayout.DEXMODE_ABC:
-			_order_abc()
+			_order_abc(mod_species)
 		RomLayout.DEXMODE_OLD:
 			for index: int in RomLayout.SPECIES_COUNT:
 				_order[index] = index + 1
+			_append_mod_species(mod_species, RomLayout.SPECIES_COUNT)
 			_find_last_seen()
 		_:
 			var table: PackedInt32Array = _data.dex_order_new() if _data != null \
 				else PackedInt32Array()
 			for index: int in RomLayout.SPECIES_COUNT:
 				_order[index] = table[index] if index < table.size() else 0
+			_append_mod_species(mod_species, RomLayout.SPECIES_COUNT)
 			_find_last_seen()
 
 
 ## `Pokedex_ABCMode`: the alphabetical table filtered down to what has been
-## seen, and `wDexListingEnd` is that count rather than a position.
-func _order_abc() -> void:
+## seen, and `wDexListingEnd` is that count rather than a position. A mod's
+## species are filtered the same way and follow the table.
+func _order_abc(mod_species: Array[int]) -> void:
 	var table: PackedInt32Array = _data.dex_order_alpha() if _data != null \
 		else PackedInt32Array()
 	listing_end = 0
@@ -185,14 +196,24 @@ func _order_abc() -> void:
 			continue
 		_order[listing_end] = table[index]
 		listing_end += 1
+	for species: int in mod_species:
+		if not _has_seen(species):
+			continue
+		_order[listing_end] = species
+		listing_end += 1
+
+
+func _append_mod_species(mod_species: Array[int], at: int) -> void:
+	for index: int in mod_species.size():
+		_order[at + index] = mod_species[index]
 
 
 ## `.FindLastSeen`: walks the order backwards and stops at the first species that
 ## has been seen, answering that species' 1-based position. Nothing seen at all
 ## answers zero, which the loop reaches by counting all the way down.
 func _find_last_seen() -> void:
-	var end: int = RomLayout.SPECIES_COUNT
-	for index: int in range(RomLayout.SPECIES_COUNT - 1, -1, -1):
+	var end: int = _order.size()
+	for index: int in range(_order.size() - 1, -1, -1):
 		if _has_seen(_order[index]):
 			break
 		end -= 1
@@ -209,7 +230,11 @@ func _find_last_seen() -> void:
 func init_cursor_position() -> void:
 	scroll = 0
 	cursor = 0
-	if prev_entry <= 0 or prev_entry > RomLayout.SPECIES_COUNT:
+	if prev_entry <= 0:
+		return
+	# A mod species is numbered past the cartridge's range, so the bound is the
+	# order itself rather than the count.
+	if prev_entry > RomLayout.SPECIES_COUNT and not _order.has(prev_entry):
 		return
 	var index: int = 0
 	if listing_end >= listing_height + 1:

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -4,16 +4,13 @@ extends RefCounted
 ## Scene-free tables and gates for the overworld field moves
 ## (engine/events/overworld.asm).
 ##
-## All seven overworld field moves are resolved here. Cut, Surf and Whirlpool
-## follow the shape CutFunction defines: check the badge, then check the faced
-## tile, then stage a change the text acknowledge commits. Strength is the odd
-## one, see BADGE_PLAIN; Flash checks the map rather than a tile, see
-## [method Gen2WorldPalette.is_dark]; Headbutt checks a tile and no badge at
-## all, and its roll lives in [Gen2WorldTreemon].
+## Cut, Surf and Whirlpool follow CutFunction's shape: badge, faced tile, then a
+## change the text acknowledge commits. Strength is the odd one (BADGE_PLAIN),
+## Flash checks the map rather than a tile ([method Gen2WorldPalette.is_dark]),
+## and Headbutt checks a tile and no badge, its roll being [Gen2WorldTreemon]'s.
 
 ## constants/move_constants.asm, whose comment column is hex. The submenu, not
-## CutFunction, SurfFunction or WhirlpoolFunction, is what checks a party Pokemon
-## knows these.
+## the functions, is what checks a party Pokemon knows these.
 const MOVE_CUT: int = 0x0F
 const MOVE_SURF: int = 0x39
 const MOVE_STRENGTH: int = 0x46
@@ -22,69 +19,54 @@ const MOVE_WATERFALL: int = 0x7F
 const MOVE_FLASH: int = 0x94
 const MOVE_HEADBUTT: int = 0x1D
 const MOVE_ROCK_SMASH: int = 0xF9
-## The rows whose own routine is an escape rather than a tile: Fly picks a spawn
-## off the region map, Teleport takes the last Pokemon Center's and Dig the warp
-## the player came into the cave through.
+## The escape rows: Fly picks a spawn off the region map, Teleport takes the last
+## Pokemon Center's and Dig the warp the player came in through.
 const MOVE_FLY: int = 0x13
 const MOVE_DIG: int = 0x5B
 const MOVE_TELEPORT: int = 0x64
-## The row that is neither a tile nor an escape: SWEET SCENT calls a wild
-## encounter up out of the map the player is standing on.
+## Neither a tile nor an escape: a wild encounter out of the map underfoot.
 const MOVE_SWEET_SCENT: int = 0xE6
-## The two rows that move health between party members rather than touching the
-## map at all. `MonMenu_Softboiled_MilkDrink` is one routine for both.
+## `MonMenu_Softboiled_MilkDrink`, one routine for both: health between party
+## members, no map.
 const MOVE_SOFTBOILED: int = 0x87
 const MOVE_MILK_DRINK: int = 0xD0
 
-## CheckBadge's arguments in CutFunction's .CheckAble, SurfFunction's .TrySurf,
-## StrengthFunction's .TryStrength and WhirlpoolFunction's .TryWhirlpool, as
-## source badge-order indices rather than flag numbers, so
-## Gen2WorldState.badge_flag() resolves them on either profile:
-## ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold/Silver, ENGINE_PLAINBADGE
-## 29 and 28, ENGINE_FOGBADGE 30 and 29, ENGINE_GLACIERBADGE 33 and 32.
+## Each function's own CheckBadge argument, as badge-order indices rather than
+## flag numbers: ENGINE_HIVEBADGE is 28 in Crystal and 27 in Gold and Silver, and
+## every badge past it splits the same way, so Gen2WorldState.badge_flag()
+## resolves them.
 const BADGE_HIVE: int = 1
-## .TryStrength is the whole gate: CheckBadge ENGINE_PLAINBADGE and nothing
-## else. It checks no tile, no block table and no player state, unlike the other
-## three, and its .AlreadyUsingStrength branch is marked unreferenced in both
-## pins, so an already-active flag is not a refusal either.
+## .TryStrength is the whole gate: no tile, no block table, no player state, and
+## its .AlreadyUsingStrength branch is unreferenced in both pins.
 const BADGE_PLAIN: int = 2
 const BADGE_FOG: int = 3
 const BADGE_GLACIER: int = 6
 ## `.TryFly`'s own `CheckBadge ENGINE_STORMBADGE`, the sixth badge.
 const BADGE_STORM: int = 5
-## WaterfallFunction's .TryWaterfall, whose CheckBadge argument is
-## ENGINE_RISINGBADGE: 34 in Crystal and 33 in Gold/Silver.
+## WaterfallFunction's .TryWaterfall: ENGINE_RISINGBADGE.
 const BADGE_RISING: int = 7
-## FlashFunction's .CheckUseFlash, whose CheckBadge argument is
-## ENGINE_ZEPHYRBADGE: 27 in Crystal and 26 in Gold/Silver. It is the first
-## badge, so Flash is gated on the least of the eight.
+## FlashFunction's .CheckUseFlash: ENGINE_ZEPHYRBADGE, the least of the eight.
 const BADGE_ZEPHYR: int = 0
 
 ## GetSurfType's comparison, constants/pokemon_constants.asm.
 const SPECIES_PIKACHU: int = 0x19
 
-## constants/music_constants.asm. home/audio.asm's SpecialMapMusic returns this
-## ahead of the map header's own music whenever the player state is surfing, so
-## it belongs to Surf rather than to any one map. Surf has no sound effect:
-## UsedSurfScript never calls PlaySFX.
+## `SpecialMapMusic` returns this ahead of the map header's while the player is
+## surfing, so it belongs to Surf. `UsedSurfScript` calls no PlaySFX.
 const MUSIC_SURF: int = 0x21
-## `BikeFunction`'s own `ld de, MUSIC_BICYCLE`, which it writes to `wMapMusic` so
-## the track survives a map load the way `SpecialMapMusic` keeps MUSIC_SURF.
+## `BikeFunction` writes this to `wMapMusic`, so it survives a map load.
 const MUSIC_BICYCLE: int = 0x13
 
-## The data/mon_menu.asm MonMenuOptions field-move rows this project acts on.
-## Both pins ship the same rows, so this needs no profile split. IsFieldMove
-## decides submenu membership from this list alone, so a move stops appearing
-## the moment it leaves it.
+## data/mon_menu.asm's MonMenuOptions rows, identical between the pins and the
+## whole of IsFieldMove's submenu membership.
 const FIELD_MOVES: Array[int] = [
 	MOVE_CUT, MOVE_SURF, MOVE_STRENGTH, MOVE_WHIRLPOOL, MOVE_WATERFALL, MOVE_FLASH,
 	MOVE_HEADBUTT, MOVE_ROCK_SMASH, MOVE_DIG, MOVE_TELEPORT, MOVE_SWEET_SCENT,
 	MOVE_FLY, MOVE_SOFTBOILED, MOVE_MILK_DRINK,
 ]
 
-## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry. Two of
-## the six block ($12, $1a); the four grass codes are LAND_TILE and cuttable
-## anyway, which is why membership here is separate from the permission.
+## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry: the
+## four grass codes are LAND_TILE and cuttable, so this is not the permission.
 const CUTTABLE_COLLISIONS: Array[int] = [
 	0x12,  # COLL_CUT_TREE
 	0x1A,  # COLL_CUT_TREE_1A
@@ -94,16 +76,13 @@ const CUTTABLE_COLLISIONS: Array[int] = [
 	0x1C,  # COLL_LONG_GRASS_1C
 ]
 
-## OWCutAnimation's index in e: which of the two cut animations the replacement
-## plays. Recorded because CheckOverworldTileArrays returns it beside the
-## replacement block; this renderer draws neither.
+## OWCutAnimation's index in e, returned beside the replacement block by
+## CheckOverworldTileArrays. This renderer draws neither.
 const ANIMATION_TREE: int = 0
 const ANIMATION_GRASS: int = 1
 
-## constants/tileset_constants.asm. Numbers 1 to 3 agree between the pins, but
-## pokegold has no BATTLE_TOWER_OUTSIDE, POKECOM_CENTER or BATTLE_TOWER_INSIDE,
-## so everything above $03 is shifted. PARK and FOREST are the two tilesets in
-## the cut table that this reaches.
+## constants/tileset_constants.asm: 1 to 3 agree, and pokegold ships three fewer
+## tilesets after them, so PARK and FOREST shift.
 const TILESET_JOHTO: int = 0x01
 const TILESET_JOHTO_MODERN: int = 0x02
 const TILESET_KANTO: int = 0x03
@@ -113,9 +92,8 @@ const TILESET_FOREST_CRYSTAL: int = 0x1F
 const TILESET_FOREST_GOLD_SILVER: int = 0x1C
 
 ## data/collision/field_move_blocks.asm's CutTreeBlockPointers, byte identical
-## between the pins: facing block to [replacement block, animation]. Only the
-## tileset numbers keying it are profile split, so the lists are shared and
-## _cut_tables() picks the keys.
+## between the pins: facing block to [replacement block, animation]. Only its
+## tileset keys are profile split, which is what _cut_tables() picks.
 const CUT_BLOCKS_JOHTO: Dictionary = {
 	0x03: [0x02, ANIMATION_GRASS],
 	0x5B: [0x3C, ANIMATION_TREE],
@@ -147,25 +125,21 @@ static func is_field_move(move: int) -> bool:
 	return FIELD_MOVES.has(move)
 
 
-## GetSurfType resolved through ChrisStateSprites: the surfing player's sprite
-## for the party member carrying the move. The source keeps the Pikachu variant
-## as a separate wPlayerState value; only the sprite differs, so this collapses
-## the two lookups into the one number a renderer needs.
+## GetSurfType through ChrisStateSprites. The source keeps the Pikachu variant
+## as its own wPlayerState value and only the sprite differs, so the two lookups
+## collapse into the one number a renderer needs.
 static func surf_sprite(species: int) -> int:
 	return Gen2WorldSprite.SPRITE_SURFING_PIKACHU if species == SPECIES_PIKACHU \
 		else Gen2WorldSprite.SPRITE_SURF
 
 
-## CheckCutCollision: whether the faced cell's collision code is one Cut acts on
-## at all. A match still needs a block in the tileset's list.
 static func cuttable(collision_code: int) -> bool:
 	return CUTTABLE_COLLISIONS.has(collision_code)
 
 
-## home/map_objects.asm's CheckCutTreeTile, which is the two tree codes alone.
-## TryTileCollisionEvent's `.cut` branch reads this rather than
-## CheckCutCollision, so pressing A at tall grass offers nothing while the party
-## submenu's CUT still cuts it.
+## CheckCutTreeTile, the two tree codes alone. TryTileCollisionEvent's `.cut`
+## reads this rather than CheckCutCollision, so an A press at tall grass offers
+## nothing while the submenu's CUT still cuts it.
 const CUT_TREE_COLLISIONS: Array[int] = [0x12, 0x1A]
 
 
@@ -173,8 +147,7 @@ static func cut_tree_tile(collision_code: int) -> bool:
 	return CUT_TREE_COLLISIONS.has(collision_code)
 
 
-## The tileset-to-block-list mapping for one profile. Kept as a function rather
-## than two constants so the shared lists above stay single-sourced.
+## A function rather than two constants, so the lists above stay single-sourced.
 static func _cut_tables(is_crystal: bool) -> Dictionary:
 	return {
 		TILESET_JOHTO: CUT_BLOCKS_JOHTO,
@@ -185,10 +158,8 @@ static func _cut_tables(is_crystal: bool) -> Dictionary:
 	}
 
 
-## CheckOverworldTileArrays against CutTreeBlockPointers: the replacement for
-## [param block] in [param tileset], or a not-ok result when the tileset carries
-## no list or the block is not in it. Both misses are the source's same
-## "nothing to cut" answer.
+## CheckOverworldTileArrays against CutTreeBlockPointers; an absent tileset and
+## an absent block are the same "nothing to cut".
 static func cut_replacement(tileset: int, block: int, is_crystal: bool) -> Dictionary:
 	var blocks: Variant = _cut_tables(is_crystal).get(tileset)
 	if blocks == null:
@@ -199,32 +170,27 @@ static func cut_replacement(tileset: int, block: int, is_crystal: bool) -> Dicti
 	return {"ok": true, "block": int(row[0]), "animation": int(row[1])}
 
 
-## home/map_objects.asm's CheckWhirlpoolTile, which TryWhirlpoolMenu applies to
-## the faced tile. Both codes are WATER_TILE | TALK, so the cell is reachable by
-## surfing straight onto it; what makes it an obstacle is
+## home/map_objects.asm's CheckWhirlpoolTile. Both codes are WATER_TILE | TALK,
+## so the cell can be surfed onto: what makes it an obstacle is
 ## Gen2WorldCollision.forced_action(), not the permission.
 const WHIRLPOOL_COLLISIONS: Array[int] = [
 	Gen2WorldCollision.COLL_WHIRLPOOL,
 	Gen2WorldCollision.COLL_WHIRLPOOL_2C,
 ]
 
-## data/collision/field_move_blocks.asm's WhirlpoolBlockPointers, byte identical
-## between the pins like CutTreeBlockPointers. It names only TILESET_JOHTO, which
-## is $01 in both games, so unlike the cut table this needs no profile split.
+## WhirlpoolBlockPointers, which names only TILESET_JOHTO, $01 in both games, so
+## unlike the cut table it needs no profile split.
 const WHIRLPOOL_BLOCKS_JOHTO: Dictionary = {
 	0x07: [0x36, ANIMATION_TREE],
 }
 
 
-## CheckWhirlpoolTile: whether the faced cell's collision code is one Whirlpool
-## acts on. A match still needs a block in the tileset's list.
 static func whirlpool_tile(collision_code: int) -> bool:
 	return WHIRLPOOL_COLLISIONS.has(collision_code)
 
 
-## CheckOverworldTileArrays against WhirlpoolBlockPointers, the counterpart of
-## cut_replacement(). Both misses, absent tileset and absent block, are the
-## source's same "nothing to do" answer.
+## CheckOverworldTileArrays against WhirlpoolBlockPointers, cut_replacement()'s
+## counterpart down to both misses answering the same way.
 static func whirlpool_replacement(tileset: int, block: int) -> Dictionary:
 	if tileset != TILESET_JOHTO:
 		return {"ok": false}
@@ -234,34 +200,27 @@ static func whirlpool_replacement(tileset: int, block: int) -> Dictionary:
 	return {"ok": true, "block": int(row[0]), "animation": int(row[1])}
 
 
-## home/map_objects.asm's CheckWaterfallTile, which CheckMapCanWaterfall applies
-## to wTileUp. COLL_CURRENT_DOWN is in the table beside COLL_WATERFALL and is
-## marked unused in both pins; it is kept because the source compares both and a
-## list of interesting codes that quietly drops one is how a table rots.
+## home/map_objects.asm's CheckWaterfallTile, on wTileUp. COLL_CURRENT_DOWN is
+## unused in both pins and kept because the source compares both.
 const WATERFALL_COLLISIONS: Array[int] = [
 	Gen2WorldCollision.COLL_WATERFALL,
 	Gen2WorldCollision.COLL_CURRENT_DOWN,
 ]
 
 
-## CheckWaterfallTile: whether [param collision_code] is one Waterfall climbs.
-## Unlike Cut and Whirlpool this needs no block table, because Waterfall changes
-## no block. It moves the player and nothing else.
+## No block table: Waterfall moves the player and changes nothing.
 static func waterfall_tile(collision_code: int) -> bool:
 	return WATERFALL_COLLISIONS.has(collision_code)
 
 
-## home/map_objects.asm's CheckHeadbuttTreeTile, applied to the faced tile by
-## both TryHeadbuttFromMenu and the overworld A-press in
-## engine/overworld/events.asm.
+## home/map_objects.asm's CheckHeadbuttTreeTile, read by TryHeadbuttFromMenu and
+## by the overworld A press.
 const HEADBUTT_COLLISIONS: Array[int] = [
 	Gen2WorldCollision.COLL_HEADBUTT_TREE,
 	Gen2WorldCollision.COLL_HEADBUTT_TREE_1D,
 ]
 
 
-## CheckHeadbuttTreeTile: whether [param collision_code] is a headbutt tree.
-## Like Waterfall this needs no block table, because a headbutt changes no
-## block: ShakeHeadbuttTree is an animation and the tree is still there after.
+## No block table either: ShakeHeadbuttTree is an animation and the tree stands.
 static func headbutt_tile(collision_code: int) -> bool:
 	return HEADBUTT_COLLISIONS.has(collision_code)

--- a/game/world/world_treemon.gd
+++ b/game/world/world_treemon.gd
@@ -4,55 +4,46 @@ extends RefCounted
 ## The headbutt-tree and rock-smash encounter rolls
 ## (engine/events/treemons.asm), which share their tables.
 ##
-## TreeMonEncounter is four questions in order: does this map have a treemon
-## set, does that set exist under this profile's limit, does GetTreeMon's score
-## and roll produce an encounter, and which row does SelectTreeMon land on.
-## Only the last two are random; the first two are table lookups the caller
-## resolves through [GameData]. RockMonEncounter is the same two lookups over
-## RockMonMaps and then one flat roll, see [method rock_encounter].
-##
-## The generator is required rather than defaulted, so nothing here can roll on
-## an uninjected generator. The roaming scheduler follows the same rule.
+## TreeMonEncounter is four questions: has this map a set, is the set under this
+## profile's limit, does GetTreeMon's score and roll make an encounter, and which
+## row does SelectTreeMon land on. Only the last two are random; the caller
+## resolves the lookups through [GameData]. The generator is required rather than
+## defaulted, so nothing here can roll on an uninjected one.
 
 ## GetTreeScore's three answers (constants/pokemon_data_constants.asm).
 const SCORE_BAD: int = 0
 const SCORE_GOOD: int = 1
 const SCORE_RARE: int = 2
 
-## GetTreeMons' `cp NUM_TREEMON_SETS`. pokegold reads `cp NUM_TREEMON_SETS - 2`
-## instead, with its own assert that the last two sets are UNUSED and CITY, so
-## Gold and Silver refuse both: the five maps TreeMonMaps gives
-## TREEMON_SET_CITY yield no headbutt encounter at all despite having data.
+## GetTreeMons' `cp NUM_TREEMON_SETS`; pokegold reads `- 2` and asserts the last
+## two sets are UNUSED and CITY, so its five TREEMON_SET_CITY maps yield no
+## headbutt encounter despite having data.
 const SET_LIMIT_CRYSTAL: int = 8
 const SET_LIMIT_GOLD_SILVER: int = 4
 
 ## TREEMON_SET_NONE, which GetTreeMons refuses before the limit check.
 const SET_NONE: int = 0
 
-## GetTreeMon's three RandomRange(10) thresholds: an encounter needs a roll
-## under the threshold for the score it drew.
+## GetTreeMon's three RandomRange(10) thresholds.
 const ENCOUNTER_THRESHOLDS: Dictionary = {
 	SCORE_BAD: 1,
 	SCORE_GOOD: 5,
 	SCORE_RARE: 8,
 }
 
-## RockMonEncounter's own threshold, commented "40% chance of an encounter" in
-## both pins. It is a flat chance rather than one of three, because nothing
-## scores a rock.
+## RockMonEncounter's flat threshold, "40% chance of an encounter" in both pins:
+## nothing scores a rock.
 const ROCK_ENCOUNTER_THRESHOLD: int = 4
 
 ## CheckSleepingTreeMon's status turns for a tree encounter that starts asleep
 ## (constants/battle_constants.asm's TREEMON_SLEEP_TURNS).
 const SLEEP_TURNS: int = 7
 
-## The four-cell border every map is drawn inside, which is what separates a
-## walk cell from wPlayerMapX/wPlayerMapY.
+## What separates a walk cell from wPlayerMapX/wPlayerMapY.
 const MAP_BORDER: int = 4
 
 
-## The set limit for a profile, which is the only line
-## engine/events/treemons.asm differs on between the pins.
+## The only line engine/events/treemons.asm differs on between the pins.
 static func set_limit(is_crystal: bool) -> int:
 	return SET_LIMIT_CRYSTAL if is_crystal else SET_LIMIT_GOLD_SILVER
 
@@ -62,15 +53,10 @@ static func set_is_usable(set_number: int, is_crystal: bool) -> bool:
 	return set_number != SET_NONE and set_number < set_limit(is_crystal)
 
 
-## GetTreeScore's .CoordScore, over the coordinates GetFacingTileCoord returns.
-##
-## Those are wPlayerMapX/wPlayerMapY, which carry the source's four-cell border
-## offset: CheckCurrentMapCoordEvents subtracts 4 from each to compare against a
-## map's own coord events (home/map.asm). [param cell] is a walk cell, so the
-## offset is applied here and nowhere else.
-##
-## The arithmetic is `hl = y * (x + 1) + x`, then `/ 5`, then `% 10`, all
-## through the source's 16-bit Divide.
+## GetTreeScore's .CoordScore: `hl = y * (x + 1) + x`, then `/ 5`, then `% 10`,
+## through the source's 16-bit Divide. GetFacingTileCoord answers in
+## wPlayerMapX/wPlayerMapY, which carry the four-cell border, so [param cell]
+## being a walk cell is why the offset is added here and nowhere else.
 static func coord_score(cell: Vector2i) -> int:
 	var x: int = cell.x + MAP_BORDER
 	var y: int = cell.y + MAP_BORDER
@@ -84,10 +70,9 @@ static func otid_score(player_id: int) -> int:
 	return (player_id & 0xFFFF) % 10
 
 
-## GetTreeScore: the two scores compared. Equal is RARE; a difference under
-## five once wrapped into 0..9 is GOOD; anything else is BAD. The source
-## answers RARE on the difference itself before wrapping, so only a true equal
-## reaches it.
+## GetTreeScore: equal is RARE, a difference under five once wrapped into 0..9
+## GOOD, anything else BAD. The source tests before wrapping, so only a true
+## equal is RARE.
 static func score(cell: Vector2i, player_id: int) -> int:
 	var difference: int = coord_score(cell) - otid_score(player_id)
 	if difference == 0:
@@ -97,12 +82,9 @@ static func score(cell: Vector2i, player_id: int) -> int:
 	return SCORE_GOOD if difference < 5 else SCORE_BAD
 
 
-## GetTreeMon: the score, then RandomRange(10) against its threshold, then
-## SelectTreeMon over the table that score chose. Only RARE walks past the
-## common table's terminator to the rare one.
-##
-## Returns an empty Dictionary for every no-encounter answer, which is
-## TreeMonEncounter's own `wScriptVar = 0`.
+## GetTreeMon: the score, RandomRange(10) against its threshold, then
+## SelectTreeMon over the table that score chose, only RARE reaching the rare
+## one. Empty is TreeMonEncounter's own `wScriptVar = 0`.
 static func resolve(
 	set_record: Dictionary, cell: Vector2i, player_id: int,
 	random: RandomNumberGenerator
@@ -125,13 +107,11 @@ static func resolve(
 	return selected
 
 
-## RockMonEncounter, which is the same tables and a much shorter question:
-## GetTreeMonSet over RockMonMaps, GetTreeMons, then a flat 40 percent
-## `RandomRange(10)` under 4 and `SelectTreeMon` on the common table. It calls
-## SelectTreeMon directly rather than GetTreeMon, so there is no score, no
-## trainer ID and no rare table, which is why TreeMonSet_Rock can ship without
-## one. It also writes no wBattleType, so a smashed rock is an ordinary wild
-## battle and CheckSleepingTreeMon never looks at it.
+## RockMonEncounter: the same tables over RockMonMaps, a flat `RandomRange(10)`
+## under 4, and `SelectTreeMon` called directly rather than through GetTreeMon,
+## so there is no score, no trainer ID and no rare table, which is why
+## TreeMonSet_Rock ships without one. It writes no wBattleType either, so a
+## smashed rock is an ordinary wild battle.
 static func rock_encounter(
 	set_record: Dictionary, random: RandomNumberGenerator
 ) -> Dictionary:
@@ -150,21 +130,19 @@ static func rock_encounter(
 	return selected
 
 
-## RockMonEncounter's `cp 4` against its RandomRange(10), kept apart from the
-## roll the way the tree thresholds are.
+## RockMonEncounter's `cp 4`, kept apart from the roll as the tree ones are.
 static func rock_encounter_allowed(roll: int) -> bool:
 	return roll < ROCK_ENCOUNTER_THRESHOLD
 
 
-## GetTreeMon's per-tier comparison against its RandomRange(10) result, kept
-## apart from the roll so both sides of each threshold are assertable.
+## GetTreeMon's per-tier comparison, apart from the roll so both sides of each
+## threshold are assertable.
 static func encounter_allowed(tier: int, roll: int) -> bool:
 	return roll < int(ENCOUNTER_THRESHOLDS.get(tier, 0))
 
 
-## SelectTreeMon with its RandomRange(100) result already drawn: subtract each
-## row's percentage until the subtraction borrows. Running off the end of the
-## table is the source's `$ff` row, which is NoTreeMon.
+## SelectTreeMon with its RandomRange(100) drawn: subtract each row's percentage
+## until it borrows. Off the end is the `$ff` row, NoTreeMon.
 static func select_at(table: Array, roll: int) -> Dictionary:
 	var remainder: int = roll
 	for row: Variant in table:
@@ -189,8 +167,7 @@ static func asleep_list_key(time_of_day: int) -> String:
 	return "day" if time_of_day == Gen2WorldPalette.TIME_DAY else "nite"
 
 
-## CheckSleepingTreeMon: whether a tree encounter with this species starts
-## asleep. Gold and Silver import no lists, so this is false there, which is
-## what pokegold shipping neither the routine nor the data means.
+## CheckSleepingTreeMon. Gold and Silver import no lists, pokegold shipping
+## neither the routine nor the data, so this is false there.
 static func starts_asleep(species: int, asleep_species: Array) -> bool:
 	return asleep_species.has(species)

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -5,6 +5,8 @@ extends GutTest
 
 const Fixture := preload("res://tests/unit/pokedex_fixture.gd")
 
+const MOD_SPECIES: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
+
 var _data: GameData = null
 
 
@@ -476,3 +478,48 @@ func test_an_empty_unown_dex_has_no_form_and_no_word() -> void:
 	assert_eq(dex.selected_unown_form(), 0)
 	assert_eq(dex.unown_word(), "")
 	assert_false(dex.move_unown(Gen2Button.RIGHT))
+
+
+## Both order tables are cartridge data of exactly 251 entries and OLD counts
+## that far, so a mod's species follows the cartridge's own run in every mode
+## rather than being left out of the listing entirely.
+func test_a_mod_species_follows_the_cartridge_run_in_every_mode() -> void:
+	var overlay := Gen2ContentOverlay.new()
+	overlay.define(
+		Gen2ContentOverlay.KIND_SPECIES, &"testmod", MOD_SPECIES, {"name": "VOLTLING"}
+	)
+	_data.set_content_overlay(overlay)
+
+	for mode: int in [RomLayout.DEXMODE_NEW, RomLayout.DEXMODE_OLD]:
+		var dex: Gen2Pokedex = _dex([MOD_SPECIES], [MOD_SPECIES], mode)
+		assert_eq(dex.listing_end, RomLayout.SPECIES_COUNT + 1,
+			"the mod species is the last row of the order")
+		dex.scroll = dex.listing_end - dex.listing_height
+		dex.cursor = dex.listing_height - 1
+		assert_eq(dex.selected_species(), MOD_SPECIES)
+		assert_eq(String(dex.rows()[dex.cursor]["name"]), "VOLTLING")
+
+	# ABC filters the mod species by seen the way it filters the table.
+	var abc: Gen2Pokedex = _dex([4, MOD_SPECIES], [], RomLayout.DEXMODE_ABC)
+	assert_eq(abc.listing_end, 2)
+	assert_eq(int(abc.rows()[1]["species"]), MOD_SPECIES)
+
+
+## `wPrevDexEntry` is a species number, so a mod's is past the cartridge's count
+## and the order is what says whether it is a real entry.
+func test_the_dex_reopens_on_a_mod_species_it_was_left_on() -> void:
+	var overlay := Gen2ContentOverlay.new()
+	overlay.define(
+		Gen2ContentOverlay.KIND_SPECIES, &"testmod", MOD_SPECIES, {"name": "VOLTLING"}
+	)
+	_data.set_content_overlay(overlay)
+	var dex: Gen2Pokedex = _dex([MOD_SPECIES], [], RomLayout.DEXMODE_OLD, MOD_SPECIES)
+	assert_eq(dex.selected_species(), MOD_SPECIES)
+
+	# A number no mod defined is out of the order and seeks nowhere, which is
+	# where the cartridge's own bound left it.
+	var unknown: Gen2Pokedex = _dex(
+		[MOD_SPECIES], [], RomLayout.DEXMODE_OLD, Gen2ContentOverlay.FIRST_MOD_NUMBER + 9
+	)
+	assert_eq(unknown.scroll, 0)
+	assert_eq(unknown.cursor, 0)


### PR DESCRIPTION
Both dex order tables are cartridge data of exactly 251 entries and OLD mode counts that far, so a species a mod defined appeared in no dex listing. It now follows the cartridge's own run in every mode, ascending by number, the way a mod pocket is numbered after the cartridge's pockets; ABC filters it by seen the way it filters the table, and the reopen bound for `wPrevDexEntry` is the order rather than the species count.

The comment pass reaches the seven files that were still above 27 percent, leaving only the three big ones. No line of code moved in any of them:

| File | Before | After |
|---|---|---|
| `turn.gd` | 40% | 26% |
| `held_item.gd` | 37% | 27% |
| `exp_bar_animation.gd` | 38% | 26% |
| `battle_switch_menu.gd` | 37% | 27% |
| `world_field_move.gd` | 37% | 27% |
| `damage.gd` | 36% | 25% |
| `world_treemon.gd` | 35% | 27% |

GUT 2,950 over 148 scripts green (unit tier 2,604), `validate.gd -- all` exit 0 over 46 topics, `replay_world.gd` 27 routes 0 failures, and the story walk reaches Red on all three cartridges.