### PR TITLE
Mod resource packs, a cached index listing, and an update check

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -37,7 +37,8 @@ user://mods/<id>/
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
 | `api_version` | Must equal `Gen2ModManifest.API_VERSION` |
-| `entry` | A `.gd` path inside the mod directory |
+| `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
+| `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
 | `dependencies` | Optional object from required mod ids to SemVer ranges |
 | `games` | Optional list of cartridge ids the mod is for |
@@ -62,6 +63,23 @@ and a list of ids stays right when the launcher gains one.
 An entry that is absolute, contains `..` or is not GDScript is refused before
 anything runs. Manifests are read without executing mod code, so a launcher can
 list what is installed and say why something was rejected.
+
+A mod may ship its scripts and resources in a resource pack instead of loose
+files. `pack` names a `.pck` or `.zip` beside `mod.json`, exported from
+`res://mods/<id>/`, and `entry` is then a path inside that root:
+
+```
+user://mods/voxel/
+  mod.json      { "pack": "content.zip", "entry": "mod.gd", ... }
+  content.zip   mods/voxel/mod.gd, mods/voxel/renderer.gd, ...
+```
+
+`mod.json` itself stays a plain file, so the launcher lists a packed mod and can
+refuse it without mounting anything. The pack is mounted only when the mod
+actually loads, with `replace_files` false, so it can add paths and never land on
+one the game itself ships. A pack that names a path rather than a file beside the
+manifest, or that is neither `.pck` nor `.zip`, is refused when the manifest is
+read.
 
 ```gdscript
 extends RefCounted
@@ -150,6 +168,19 @@ GitHub slug.
 A listed mod installs through the same path an imported `.zip` does, and its
 manifest id must match the one the feed advertised, so a listing grants a mod
 nothing that picking the same file by hand would not.
+
+A row whose `version` is newer than the installed copy's says so and offers
+**Update** rather than **Reinstall**, and the status line counts how many the
+listing offers. Both sides have to be strict `major.minor.patch` numbers to be
+compared: a version a feed made up is reported as uncomparable rather than
+guessed at, and a listing older than the installed copy is neither an update nor
+an error.
+
+Each feed's last listing that parsed is kept under `user://mod_index_cache/`. It
+goes up while the request is in flight and stays up when the fetch fails, with
+the age of the copy said on the status line, so browsing what you follow does not
+depend on the server being reachable at that moment. Unfollowing an index drops
+its cached copy with it.
 
 ## Adding content
 

--- a/game/main/mod_index_dialog.gd
+++ b/game/main/mod_index_dialog.gd
@@ -26,6 +26,7 @@ var _status: Label = null
 var _entry_list: VBoxContainer = null
 var _http: HTTPRequest = null
 var _entries: Array[Dictionary] = []
+var _feed: String = ""
 var _pending_entry: Dictionary = {}
 var _busy: bool = false
 
@@ -147,7 +148,14 @@ func _on_open_pressed() -> void:
 	if _busy or _sources.selected < 0:
 		return
 	var feed: String = String(_sources.get_item_metadata(_sources.selected))
+	open_feed(feed)
 	_clear_entries()
+	# The last good copy goes up first, so a slow or unreachable server costs
+	# the freshness of the listing rather than the listing.
+	var cached: Dictionary = Gen2ModIndex.cached_feed(feed)
+	if bool(cached.get("ok", false)):
+		_entries.assign(cached["entries"])
+		_show_entries()
 	_set_status("Reading %s..." % feed, MUTED)
 	_request(feed, _on_feed_received)
 
@@ -157,31 +165,90 @@ func _on_feed_received(
 ) -> void:
 	_busy = false
 	if result != HTTPRequest.RESULT_SUCCESS or code != 200:
-		_set_status("That index could not be read (HTTP %d)." % code, ERROR)
+		apply_feed_response(false, "That index could not be read (HTTP %d)." % code)
 		return
-	var parsed: Dictionary = Gen2ModIndex.parse_feed(body.get_string_from_utf8())
+	apply_feed_response(true, "", body.get_string_from_utf8())
+
+
+## Shows whatever the request came back with. Separate from the handler, the way
+## [method install_entry_bytes] is, so both answers a server can give are
+## testable without one: a feed that parsed is listed and kept, and anything else
+## falls back to the copy already on disk.
+func apply_feed_response(ok: bool, problem: String, text: String = "") -> Dictionary:
+	if not ok:
+		_fall_back_to_cache(problem)
+		return {"ok": false, "reason": &"index_request_failed", "detail": problem}
+	var parsed: Dictionary = Gen2ModIndex.parse_feed(text)
 	if not bool(parsed.get("ok", false)):
-		_set_status(_reason_text(parsed), ERROR)
-		return
+		_fall_back_to_cache(_reason_text(parsed))
+		return parsed
+	Gen2ModIndex.cache_feed(_feed, text)
 	_entries.assign(parsed["entries"])
 	_show_entries()
-	var name: String = String(parsed.get("name", ""))
+	_set_status(_listing_text(parsed), MUTED)
+	return parsed
+
+
+## Which feed the listing is about. Set before a request goes out, so a failure
+## and a stored copy both know which index they are for.
+func open_feed(feed: String) -> void:
+	_feed = feed
+
+
+## What the player is told when the fetch failed. The cached listing goes up with
+## it, so the message says which copy they are looking at rather than only what
+## went wrong.
+func _fall_back_to_cache(problem: String) -> void:
+	var cached: Dictionary = Gen2ModIndex.cached_feed(_feed)
+	if not bool(cached.get("ok", false)):
+		_set_status(problem, ERROR)
+		return
+	_entries.assign(cached["entries"])
+	_show_entries()
 	_set_status(
-		"%s lists %d mod%s." % [
-			name if not name.is_empty() else "That index",
-			_entries.size(), "" if _entries.size() == 1 else "s",
-		],
-		MUTED,
+		"%s Showing the copy saved %s ago." % [problem, _age_text(int(cached.get("age", 0)))],
+		ACCENT,
 	)
+
+
+func _listing_text(parsed: Dictionary) -> String:
+	var name: String = String(parsed.get("name", ""))
+	var line: String = "%s lists %d mod%s." % [
+		name if not name.is_empty() else "That index",
+		_entries.size(), "" if _entries.size() == 1 else "s",
+	]
+	var updates: int = Gen2ModIndex.update_count(_entries, _installed_versions())
+	if updates > 0:
+		line += "  %d can be updated." % updates
+	return line
+
+
+## Rounded to the largest unit that still says something useful: a listing hours
+## old and one days old are different answers, and minutes below an hour are not.
+static func _age_text(seconds: int) -> String:
+	if seconds < 3600:
+		return "%d minute%s" % [maxi(seconds / 60, 1), "" if seconds < 120 else "s"]
+	if seconds < 86400:
+		@warning_ignore("integer_division")
+		var hours: int = seconds / 3600
+		return "%d hour%s" % [hours, "" if hours == 1 else "s"]
+	@warning_ignore("integer_division")
+	var days: int = seconds / 86400
+	return "%d day%s" % [days, "" if days == 1 else "s"]
 
 
 func _show_entries() -> void:
 	_clear_entries()
+	var installed: Dictionary = _installed_versions()
+	for entry: Dictionary in _entries:
+		_entry_list.add_child(_entry_row(entry, installed))
+
+
+func _installed_versions() -> Dictionary:
 	var installed: Dictionary = {}
 	for manifest: Gen2ModManifest in Gen2ModHost.instance().manifests():
 		installed[manifest.id] = manifest.version
-	for entry: Dictionary in _entries:
-		_entry_list.add_child(_entry_row(entry, installed))
+	return installed
 
 
 func _entry_row(entry: Dictionary, installed: Dictionary) -> Control:
@@ -206,12 +273,47 @@ func _entry_row(entry: Dictionary, installed: Dictionary) -> Control:
 		detail.add_theme_color_override("font_color", MUTED)
 		text.add_child(detail)
 
+	var state: StringName = Gen2ModIndex.update_state(
+		version, String(installed.get(StringName(entry["id"]), ""))
+	)
+	if state != Gen2ModIndex.NOT_INSTALLED:
+		var have := Label.new()
+		have.text = _installed_text(state, String(installed[StringName(entry["id"])]))
+		have.add_theme_color_override(
+			"font_color", ACCENT if state == Gen2ModIndex.UPDATE_AVAILABLE else MUTED
+		)
+		text.add_child(have)
+
 	var button := Button.new()
-	var have: bool = installed.has(entry["id"])
-	button.text = "Reinstall" if have else "Install"
-	button.pressed.connect(_on_install_pressed.bind(entry, have))
+	button.text = _button_text(state)
+	button.pressed.connect(
+		_on_install_pressed.bind(entry, state != Gen2ModIndex.NOT_INSTALLED)
+	)
 	row.add_child(button)
 	return row
+
+
+## What the row says about the copy on disk. An unorderable version on either
+## side is said as such rather than guessed at, since a feed is a stranger's file
+## and a version it made up is not a reason to offer an update.
+static func _installed_text(state: StringName, installed: String) -> String:
+	match state:
+		Gen2ModIndex.UPDATE_AVAILABLE:
+			return "Installed %s" % installed
+		Gen2ModIndex.INSTALLED_IS_NEWER:
+			return "Installed %s, newer than this listing" % installed
+		Gen2ModIndex.UNKNOWN:
+			return "Installed %s, versions cannot be compared" % installed
+	return "Installed %s, up to date" % installed
+
+
+static func _button_text(state: StringName) -> String:
+	match state:
+		Gen2ModIndex.NOT_INSTALLED:
+			return "Install"
+		Gen2ModIndex.UPDATE_AVAILABLE:
+			return "Update"
+	return "Reinstall"
 
 
 func _on_install_pressed(entry: Dictionary, replace: bool) -> void:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -133,6 +133,10 @@ signal option_changed(id: StringName, key: StringName, value: Variant)
 signal action_changed(id: StringName, key: StringName, pressed: bool)
 
 static var _instance: Gen2ModHost = null
+## Which mod packs this process has mounted. Static because a resource pack
+## cannot be unmounted, so a host rebuilt by [method reset] inherits whatever the
+## last one mounted whether it tracks it or not.
+static var _mounted_packs: Dictionary = {}
 
 var _manifests: Dictionary = {}
 ## Mod id to version for every entry script that ran. See [method loaded_mods].
@@ -976,6 +980,10 @@ func _dependency_refusal(
 ## is only reported by whatever the caller can name it with: without this the
 ## launcher and the startup warning both say "?".
 func load_mod(manifest: Gen2ModManifest) -> Dictionary:
+	if manifest.packed():
+		var mounted: Dictionary = _mount_pack(manifest)
+		if not bool(mounted.get("ok", false)):
+			return mounted
 	var path: String = manifest.entry_path()
 	if not FileAccess.file_exists(path):
 		return _refuse_load(manifest, &"missing_entry_script", path)
@@ -999,6 +1007,24 @@ func loaded_mods() -> Array:
 	for id: StringName in ids:
 		out.append({"id": String(id), "version": String(_loaded[id])})
 	return out
+
+
+## Mounts a mod's own resource pack, once per run.
+##
+## `replace_files` is false, so a pack can only add paths and can never land on
+## one the game itself ships: a mod that names `res://game/...` is ignored there
+## rather than obeyed. There is no unmount in the engine, which is why a reload
+## remounts nothing and why the set is kept on the host rather than the manifest.
+func _mount_pack(manifest: Gen2ModManifest) -> Dictionary:
+	if _mounted_packs.has(manifest.id):
+		return {"ok": true, "id": manifest.id}
+	var path: String = manifest.pack_path()
+	if not FileAccess.file_exists(path):
+		return _refuse_load(manifest, &"missing_mod_pack", path)
+	if not ProjectSettings.load_resource_pack(ProjectSettings.globalize_path(path), false):
+		return _refuse_load(manifest, &"mod_pack_unreadable", path)
+	_mounted_packs[manifest.id] = true
+	return {"ok": true, "id": manifest.id}
 
 
 func _refuse_load(manifest: Gen2ModManifest, reason: StringName, path: String) -> Dictionary:

--- a/game/mods/mod_index.gd
+++ b/game/mods/mod_index.gd
@@ -27,6 +27,22 @@ const MAX_ENTRIES: int = 500
 ## The indexes this player follows. Small enough to keep beside the mods rather
 ## than wait for a general settings model.
 const FOLLOWED_PATH: String = "user://mod_indexes.json"
+## Where a fetched feed is kept, one file per feed. A cached listing is what a
+## player sees while the request is in flight and what they still see when the
+## server is down or the device is offline, so browsing what they follow does not
+## depend on the network being up at that moment.
+const CACHE_DIRECTORY: String = "user://mod_index_cache"
+
+## What [method update_state] answers.
+const UPDATE_AVAILABLE: StringName = &"update_available"
+const UP_TO_DATE: StringName = &"up_to_date"
+## The installed copy is newer than the listing, which a feed lagging behind its
+## own releases produces. Not an update, and not an error either.
+const INSTALLED_IS_NEWER: StringName = &"installed_is_newer"
+## Either side is missing a version or carries one nothing can order.
+const UNKNOWN: StringName = &"unknown"
+## Not installed at all, so there is nothing to compare.
+const NOT_INSTALLED: StringName = &"not_installed"
 
 
 ## Turns whatever the player pasted into the feed URL to read.
@@ -108,6 +124,88 @@ static func parse_feed(text: String) -> Dictionary:
 ## feed cannot downgrade a download to a channel anyone can rewrite.
 static func is_downloadable(url: String) -> bool:
 	return url.begins_with("https://") and url.length() > len("https://")
+
+
+## What a listed entry is to the copy already installed: [constant NOT_INSTALLED],
+## [constant UNKNOWN] when either side has no orderable version, or one of the
+## three orderings. [Gen2UpdateCheck.compare_versions] is the same comparison the
+## launcher makes against the project's own releases, so a feed and a release are
+## ordered by one rule.
+static func update_state(listed: String, installed: String) -> StringName:
+	if installed.strip_edges().is_empty():
+		return NOT_INSTALLED
+	if not Gen2ModVersion.valid_version(listed) \
+		or not Gen2ModVersion.valid_version(installed):
+		return UNKNOWN
+	var order: int = Gen2UpdateCheck.compare_versions(installed, listed)
+	if order < 0:
+		return UPDATE_AVAILABLE
+	return UP_TO_DATE if order == 0 else INSTALLED_IS_NEWER
+
+
+## How many of [param entries] a newer version is listed for. [param installed]
+## is mod id to installed version, which [method Gen2ModHost.manifests] fills.
+static func update_count(entries: Array, installed: Dictionary) -> int:
+	var out: int = 0
+	for entry: Variant in entries:
+		if not entry is Dictionary:
+			continue
+		var row: Dictionary = entry as Dictionary
+		var have: String = String(installed.get(StringName(row.get("id", &"")), ""))
+		if update_state(String(row.get("version", "")), have) == UPDATE_AVAILABLE:
+			out += 1
+	return out
+
+
+## The file a feed's last good copy is kept in. Named by hash rather than by URL,
+## because a URL is not a filename and a feed may live at any path a publisher
+## likes.
+static func cache_path(feed: String, directory: String = CACHE_DIRECTORY) -> String:
+	return "%s/%s.json" % [directory, feed.sha256_text().substr(0, 32)]
+
+
+## Keeps [param text] as the last good copy of [param feed]. Only a feed that
+## parsed is worth keeping, so the caller stores after [method parse_feed] rather
+## than on arrival.
+static func cache_feed(feed: String, text: String, directory: String = CACHE_DIRECTORY) -> bool:
+	if text.length() > MAX_FEED_BYTES:
+		return false
+	DirAccess.make_dir_recursive_absolute(directory)
+	var file: FileAccess = FileAccess.open(cache_path(feed, directory), FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_string(JSON.stringify({
+		"feed": feed, "fetched_at": int(Time.get_unix_time_from_system()), "text": text,
+	}))
+	file.close()
+	return true
+
+
+## The cached copy of [param feed], parsed, as
+## { ok, name, entries, fetched_at, age }, or { ok: false, reason }. A cache file
+## that no longer parses is refused like any other feed, so a corrupted one costs
+## the listing and nothing else.
+static func cached_feed(feed: String, directory: String = CACHE_DIRECTORY) -> Dictionary:
+	var path: String = cache_path(feed, directory)
+	if not FileAccess.file_exists(path):
+		return {"ok": false, "reason": &"index_not_cached"}
+	var json := JSON.new()
+	if json.parse(FileAccess.get_file_as_string(path)) != OK or json.data is not Dictionary:
+		return {"ok": false, "reason": &"index_not_cached"}
+	var stored: Dictionary = json.data as Dictionary
+	var parsed: Dictionary = parse_feed(String(stored.get("text", "")))
+	if not bool(parsed.get("ok", false)):
+		return parsed
+	var fetched_at: int = int(stored.get("fetched_at", 0))
+	parsed["fetched_at"] = fetched_at
+	parsed["age"] = maxi(int(Time.get_unix_time_from_system()) - fetched_at, 0)
+	return parsed
+
+
+## Drops a feed's cached copy, which [method unfollow] does so an index the
+## player stopped following leaves nothing on disk.
+static func forget_cache(feed: String, directory: String = CACHE_DIRECTORY) -> void:
+	DirAccess.remove_absolute(cache_path(feed, directory))
 
 
 static func _entry_from(raw: Dictionary) -> Dictionary:
@@ -197,6 +295,7 @@ static func unfollow(feed: String, path: String = FOLLOWED_PATH) -> void:
 		if row["feed"] != feed:
 			kept.append(row)
 	_store(kept, path)
+	forget_cache(feed)
 
 
 static func _store(rows: Array[Dictionary], path: String) -> void:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -22,6 +22,10 @@ var name: String = ""
 var version: String = ""
 var api_version: int = 0
 var entry: String = ""
+## An optional resource pack beside the manifest, `.pck` or `.zip`, holding the
+## mod's own scripts and resources. Its files mount at [method mount_root], so
+## [member entry] is a path inside that root rather than inside the directory.
+var pack: String = ""
 var description: String = ""
 ## Required mod ids to accepted semantic-version ranges.
 var dependencies: Dictionary = {}
@@ -65,6 +69,7 @@ static func from_dictionary(source: Dictionary, directory: String) -> Dictionary
 	manifest.version = String(source.get("version", ""))
 	manifest.api_version = int(source.get("api_version", 0))
 	manifest.entry = String(source.get("entry", ""))
+	manifest.pack = String(source.get("pack", ""))
 	manifest.description = String(source.get("description", ""))
 	var raw_dependencies: Variant = source.get("dependencies", {})
 	if not raw_dependencies is Dictionary:
@@ -112,11 +117,37 @@ static func from_dictionary(source: Dictionary, directory: String) -> Dictionary
 		# iOS forbids JIT and loading native code at runtime, so a mod is
 		# interpreted GDScript or it is nothing.
 		return _refuse(&"entry_not_gdscript", manifest.entry)
+	if not manifest.pack.is_empty():
+		if manifest.pack.begins_with("/") or manifest.pack.contains("..") \
+			or manifest.pack.contains(":") or manifest.pack.contains("/"):
+			# A pack is a file beside the manifest, not a path: it is mounted
+			# rather than read, so there is nothing to gain by letting it point
+			# anywhere else.
+			return _refuse(&"pack_escapes_mod", manifest.pack)
+		if not (manifest.pack.ends_with(".pck") or manifest.pack.ends_with(".zip")):
+			return _refuse(&"pack_not_a_resource_pack", manifest.pack)
 	return {"ok": true, "manifest": manifest}
 
 
+## Whether this mod ships its files as a resource pack rather than loose.
+func packed() -> bool:
+	return not pack.is_empty()
+
+
+## Where a pack's files are expected to land. `ProjectSettings.load_resource_pack`
+## mounts each file at the `res://` path it was packed with, so a mod exports
+## from this root and the host resolves the entry against it. One root per id,
+## which is also what keeps two packs from landing on each other.
+func mount_root() -> String:
+	return "res://mods/%s" % id
+
+
+func pack_path() -> String:
+	return "%s/%s" % [directory, pack]
+
+
 func entry_path() -> String:
-	return "%s/%s" % [directory, entry]
+	return "%s/%s" % [mount_root() if packed() else directory, entry]
 
 
 ## Whether this mod declares [param game_id]. An empty declaration is every game,
@@ -145,6 +176,7 @@ func summary() -> Dictionary:
 		"version": version,
 		"description": description,
 		"directory": directory,
+		"pack": pack,
 		"dependencies": dependencies.duplicate(),
 		"games": games.duplicate(),
 	}

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -40,6 +40,8 @@ const WORDING: Dictionary = {
 	&"missing_entry": "The mod names no entry script.",
 	&"entry_not_gdscript": "A mod's entry script has to be GDScript (%s).",
 	&"entry_escapes_mod": "The entry script points outside the mod folder (%s).",
+	&"pack_escapes_mod": "The mod's resource pack has to be a file beside its mod.json (%s).",
+	&"pack_not_a_resource_pack": "A mod's pack has to be a .pck or .zip (%s).",
 
 	# Writing it into place.
 	&"could_not_create_mod_directory": "The mod folder could not be created.",
@@ -48,6 +50,8 @@ const WORDING: Dictionary = {
 	&"already_installed": "It is already installed.",
 
 	# Running it.
+	&"missing_mod_pack": "The mod's resource pack %s is missing.",
+	&"mod_pack_unreadable": "The mod's resource pack %s could not be opened.",
 	&"missing_entry_script": "The entry script %s is missing.",
 	&"entry_not_a_script": "The entry %s is not a script.",
 	&"entry_has_no_register": "The entry script %s has no register() function.",

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -202,6 +202,72 @@ func test_index_install_requires_the_download_to_be_the_listed_mod() -> void:
 	assert_string_contains(dialog.status_text(), "Installed")
 
 
+## A server that is down costs the freshness of a listing rather than the
+## listing: the last feed that parsed is kept and shown, with the player told
+## which copy they are looking at.
+func test_an_index_that_cannot_be_read_falls_back_to_the_copy_on_disk() -> void:
+	var feed: String = "https://mods.example.com/index.json"
+	var dialog := Gen2ModIndexDialog.new()
+	add_child_autofree(dialog)
+	await get_tree().process_frame
+	dialog.open_feed(feed)
+
+	var text: String = JSON.stringify({
+		"schema_version": Gen2ModIndex.SCHEMA_VERSION,
+		"name": "Example",
+		"mods": [{"id": "voxel", "name": "Voxel", "version": "1.2.0",
+			"download": "https://example.com/voxel.zip"}],
+	})
+	assert_true(bool(dialog.apply_feed_response(true, "", text).get("ok", false)))
+	assert_string_contains(dialog.status_text(), "lists 1 mod")
+
+	dialog.apply_feed_response(false, "That index could not be read (HTTP 503).")
+	assert_string_contains(dialog.status_text(), "Showing the copy saved")
+
+	# A fetch that arrives as something other than a feed is the same answer.
+	dialog.apply_feed_response(true, "", "not json")
+	assert_string_contains(dialog.status_text(), "Showing the copy saved")
+
+	Gen2ModIndex.forget_cache(feed)
+	dialog.apply_feed_response(false, "That index could not be read (HTTP 503).")
+	assert_string_contains(dialog.status_text(), "HTTP 503")
+	assert_false(dialog.status_text().contains("Showing the copy"))
+
+
+## A listing offering a newer version than the one installed says so, and the
+## count of them is on the status line.
+func test_an_index_names_the_mods_a_newer_version_is_listed_for() -> void:
+	_write_probe_mod_zip()
+	var installed: Dictionary = Gen2ModInstaller.install_zip(_mod_archive)
+	assert_true(bool(installed.get("ok", false)), JSON.stringify(installed))
+	Gen2ModHost.reset()
+	Gen2ModHost.instance().discover()
+
+	var feed: String = "https://mods.example.com/updates.json"
+	var dialog := Gen2ModIndexDialog.new()
+	add_child_autofree(dialog)
+	await get_tree().process_frame
+	dialog.open_feed(feed)
+	dialog.apply_feed_response(true, "", JSON.stringify({
+		"schema_version": Gen2ModIndex.SCHEMA_VERSION,
+		"name": "Example",
+		"mods": [{"id": String(PROBE_MOD_ID), "name": "Launcher Probe", "version": "9.9.9",
+			"download": "https://example.com/probe.zip"}],
+	}))
+	assert_string_contains(dialog.status_text(), "1 can be updated")
+
+	# The same listing at the installed version offers a reinstall and no update.
+	dialog.apply_feed_response(true, "", JSON.stringify({
+		"schema_version": Gen2ModIndex.SCHEMA_VERSION,
+		"name": "Example",
+		"mods": [{"id": String(PROBE_MOD_ID), "name": "Launcher Probe",
+			"version": String(installed["version"]),
+			"download": "https://example.com/probe.zip"}],
+	}))
+	assert_false(dialog.status_text().contains("can be updated"))
+	Gen2ModIndex.forget_cache(feed)
+
+
 ## A toast with nothing to say occupies nothing: not drawn, and not in the hit
 ## test either.
 func test_a_silent_toast_is_not_on_screen_at_all() -> void:

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -503,6 +503,69 @@ func test_a_broken_mod_is_reported_and_does_not_stop_the_others() -> void:
 	assert_true(String(failures[0]["directory"]).ends_with(_valid_manifest()["id"]))
 
 
+## A mod may ship its scripts inside a resource pack rather than loose, which is
+## how an exported mod arrives: `mod.json` stays readable so the launcher can
+## list it without mounting anything, and the pack is mounted only when the mod
+## actually loads.
+func test_a_packed_mod_mounts_its_pack_and_runs_the_entry_inside_it() -> void:
+	var source: Dictionary = _valid_manifest()
+	source["id"] = "packmod"
+	source["entry"] = "main.gd"
+	source["pack"] = "content.zip"
+	var directory: String = "%s/packmod" % ROOT
+	DirAccess.make_dir_recursive_absolute(directory)
+	_write("%s/mod.json" % directory, JSON.stringify(source))
+	# Packed at the root the host mounts it from, which is what a mod exports to.
+	_write_zip("%s/content.zip" % directory, {
+		"mods/packmod/main.gd":
+			"extends RefCounted\n\nfunc register(host, manifest) -> void:\n"
+			+ "\thost.register_menu_entry(&\"start_menu\", &\"packed\", {\"label\": manifest.name})\n",
+	})
+	_clear(_directory)
+
+	var read: Dictionary = Gen2ModManifest.read(directory)
+	assert_true(read["ok"], JSON.stringify(read))
+	var manifest: Gen2ModManifest = read["manifest"]
+	assert_true(manifest.packed())
+	assert_eq(manifest.entry_path(), "res://mods/packmod/main.gd")
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	assert_eq(host.load_discovered(), [&"packmod"], JSON.stringify(host.failures()))
+	var entries: Array = host.menu_entries(Gen2ModHost.MENU_START)
+	assert_eq(entries.size(), 1)
+	assert_eq(String(entries[0]["label"]), "Voxel World")
+
+
+## A mod naming a pack that is not there is refused by name rather than failing
+## at its entry, which would say the script is missing and not why.
+func test_a_declared_pack_that_is_absent_is_refused_by_name() -> void:
+	var source: Dictionary = _valid_manifest()
+	source["pack"] = "content.pck"
+	_write_manifest(source)
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	assert_eq(host.load_discovered(), [])
+	assert_eq(host.failures()[0]["reason"], &"missing_mod_pack")
+
+
+## A pack is a file beside the manifest. Anything that points elsewhere, or is
+## not a resource pack at all, is refused before a mount is attempted.
+func test_a_pack_that_points_outside_the_mod_is_refused() -> void:
+	for pack: String in ["../other.pck", "/tmp/other.pck", "nested/other.pck", "res://x.pck"]:
+		var source: Dictionary = _valid_manifest()
+		source["pack"] = pack
+		_write_manifest(source)
+		assert_eq(
+			Gen2ModManifest.read(_directory)["reason"], &"pack_escapes_mod",
+			"pack %s must be refused" % pack
+		)
+	var source: Dictionary = _valid_manifest()
+	source["pack"] = "content.tar"
+	_write_manifest(source)
+	assert_eq(Gen2ModManifest.read(_directory)["reason"], &"pack_not_a_resource_pack")
+
+
 ## Builds a zip at [param path] from { entry path: text } so an installer test
 ## can describe an archive's layout in one literal.
 func _write_zip(path: String, entries: Dictionary) -> void:
@@ -771,6 +834,57 @@ func test_following_an_index_persists_it_and_never_duplicates_a_feed() -> void:
 
 	Gen2ModIndex.unfollow(added["feed"], store)
 	assert_eq(Gen2ModIndex.followed(store).size(), 0)
+
+
+## A listing is kept so browsing what the player follows does not depend on the
+## server being up at that moment, and it goes with the index when they stop
+## following it.
+func test_a_fetched_feed_is_cached_and_dropped_with_the_index() -> void:
+	var store: String = "%s/indexes.json" % ROOT
+	DirAccess.make_dir_recursive_absolute(ROOT)
+	var cache: String = "%s/index_cache" % ROOT
+	var feed: String = Gen2ModIndex.follow("someone/mods", store)["feed"]
+	assert_false(Gen2ModIndex.cached_feed(feed, cache)["ok"], "nothing cached before a fetch")
+
+	assert_true(Gen2ModIndex.cache_feed(feed, _feed([
+		{"id": "voxel", "name": "Voxel", "version": "1.2.0",
+			"download": "https://example.com/voxel.zip"},
+	]), cache))
+	var cached: Dictionary = Gen2ModIndex.cached_feed(feed, cache)
+	assert_true(cached["ok"], JSON.stringify(cached))
+	assert_eq((cached["entries"] as Array).size(), 1)
+	assert_eq(cached["entries"][0]["id"], &"voxel")
+	assert_true(int(cached["age"]) >= 0)
+
+	Gen2ModIndex.forget_cache(feed, cache)
+	assert_eq(Gen2ModIndex.cached_feed(feed, cache)["reason"], &"index_not_cached")
+
+
+## A cache file that no longer parses costs the listing and nothing else.
+func test_an_unreadable_cache_is_refused_like_any_other_feed() -> void:
+	var cache: String = "%s/index_cache" % ROOT
+	var feed: String = "https://mods.example.com/index.json"
+	DirAccess.make_dir_recursive_absolute(cache)
+	_write(Gen2ModIndex.cache_path(feed, cache), "{not json")
+	assert_eq(Gen2ModIndex.cached_feed(feed, cache)["reason"], &"index_not_cached")
+
+
+## What a listed version is to the copy on disk. A version either side cannot
+## order is said to be unknown rather than guessed at: a feed is a stranger's
+## file, and a version it made up is no reason to offer an update.
+func test_a_listed_version_is_compared_against_the_installed_one() -> void:
+	assert_eq(Gen2ModIndex.update_state("1.2.0", ""), Gen2ModIndex.NOT_INSTALLED)
+	assert_eq(Gen2ModIndex.update_state("1.2.0", "1.1.9"), Gen2ModIndex.UPDATE_AVAILABLE)
+	assert_eq(Gen2ModIndex.update_state("1.2.0", "1.2.0"), Gen2ModIndex.UP_TO_DATE)
+	assert_eq(Gen2ModIndex.update_state("1.2.0", "1.3.0"), Gen2ModIndex.INSTALLED_IS_NEWER)
+	assert_eq(Gen2ModIndex.update_state("latest", "1.2.0"), Gen2ModIndex.UNKNOWN)
+	assert_eq(Gen2ModIndex.update_state("", "1.2.0"), Gen2ModIndex.UNKNOWN)
+
+	assert_eq(Gen2ModIndex.update_count([
+		{"id": &"voxel", "version": "1.2.0"},
+		{"id": &"other", "version": "0.1.0"},
+		{"id": &"absent", "version": "9.9.9"},
+	], {&"voxel": "1.1.0", &"other": "0.1.0"}), 1)
 
 
 func test_following_a_refused_url_stores_nothing() -> void:


### PR DESCRIPTION
Three of the mod loader's four named gaps.

**Resource packs.** `mod.json` may name a `pack`, a `.pck` or `.zip` beside it holding the mod's own files. The host mounts it at `res://mods/<id>` when the mod actually loads, with `replace_files` false, so a pack can add paths and can never land on one the game itself ships. The manifest stays a plain file, so a packed mod is listed and can be refused without mounting anything; a pack that names a path rather than a file beside the manifest, or that is neither `.pck` nor `.zip`, is refused when the manifest is read.

**A cached listing.** Each feed's last listing that parsed is kept under `user://mod_index_cache/`. It goes up while the request is in flight and stays up when the fetch fails, with the age of the copy on the status line, so browsing what you follow does not depend on the server being reachable. Unfollowing an index drops its copy.

**An update check.** A listed version is compared against the installed one with `Gen2UpdateCheck.compare_versions`, the same rule the launcher already uses for the project's own releases: a row offers **Update** rather than **Reinstall** and the status line counts how many. A version either side cannot order is reported as uncomparable rather than guessed at, and a listing older than the installed copy is neither an update nor an error.

`docs/MODS.md` documents all three.

| Check | Result |
|---|---|
| GUT full tier | 2,958 / 2,958 over 148 scripts, 118 s |
| GUT unit tier | 2,612 / 2,612, 30 s |
| Boot smoke test | clean, both installed mods load and both renderers instantiate |