### PR TITLE
The Pokegear's clock, phone and radio cards on the tile grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ The start menu wires every source entry: Pokedex, Pokemon, Pack, Pokegear,
 Player, Save, Options and Exit. Options is the cartridge's own seven-row OPTION
 screen over the same values the launcher's settings edit, so the two cannot
 disagree. Pokedex has the three source orderings, type search and the
-`<MON>'S NEST` area map. Pokegear has the clock, map, phone and radio cards, and
-a tuned station keeps playing after it closes, which is how the Poke Flute
-channel wakes Vermilion's Snorlax. Pack opens each item's own submenu: USE,
+`<MON>'S NEST` area map. Pokegear draws all four of its cards on the hardware
+tile grid, clock, map, phone and radio, each with its own dial, list and mode
+arrow, and a tuned station keeps playing after it closes, which is how the Poke
+Flute channel wakes Vermilion's Snorlax. Pack opens each item's own submenu: USE,
 GIVE, TOSS and SEL, which registers an item to the SELECT button and uses it
 from the map. The party submenu offers all eight field moves to a Pokemon that
 knows one, and ITEM gives or takes what it holds.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1507,6 +1507,29 @@ func town_map_region(region: String) -> PackedByteArray:
 	return out
 
 
+## `ClockTilemapRLE` and its two neighbours, decoded: the twelve rows a Pokegear
+## card draws above its text box. Empty for a name no card has.
+func pokegear_card(card: StringName) -> PackedByteArray:
+	var cards: Variant = _town_map.get("cards", {})
+	var out := PackedByteArray()
+	if not cards is Dictionary:
+		return out
+	var stored: Variant = (cards as Dictionary).get(String(card), [])
+	if not stored is Array:
+		return out
+	for cell: Variant in stored as Array:
+		out.append(int(cell))
+	return out
+
+
+## One of the Pokegear's own two texts, by the name `RomLayout` gives it.
+func pokegear_text(name: String) -> String:
+	var texts: Variant = _town_map.get("card_texts", {})
+	if not texts is Dictionary:
+		return ""
+	return String((texts as Dictionary).get(name, ""))
+
+
 ## `TownMapPals`: which of the six palettes a region-map tile is drawn through.
 ## Its table covers $00 to $5f; $60 and above take palette 0, and so does a cache
 ## that has no palette map.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 59
+const FORMAT_VERSION: int = 60
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -865,6 +865,34 @@ static func verify_town_map(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if not bool(nest_check["ok"]):
 		return nest_check
 
+	var cards: Dictionary = read_pokegear_cards(rom, layout)
+	if cards.size() != RomLayout.POKEGEAR_CARD_ORDER.size():
+		return {
+			"ok": false,
+			"message": "The Pokegear cards decoded to %d tilemaps, wanted %d." % [
+				cards.size(), RomLayout.POKEGEAR_CARD_ORDER.size(),
+			],
+		}
+	for name: String in cards:
+		for cell: int in cards[name] as PackedByteArray:
+			# Every card is drawn out of the same VRAM window the region map is,
+			# so a tile past the two sheets and the font is a wrong offset.
+			if cell >= RomLayout.POKEGEAR_FIRST_TILE + RomLayout.POKEGEAR_TILES \
+				and cell < Gen2Text.SPACE:
+				return {
+					"ok": false,
+					"message": "The %s card names tile $%02X, past its sheets." % [
+						name, cell,
+					],
+				}
+
+	var texts: Dictionary = read_pokegear_texts(rom, layout)
+	if texts.size() != RomLayout.POKEGEAR_TEXT_NAMES.size():
+		return {"ok": false, "message": "The Pokegear texts did not decode."}
+	for name: String in texts:
+		if String(texts[name]).is_empty():
+			return {"ok": false, "message": "Pokegear text %s is empty." % name}
+
 	var palette_map: int = int(entry["palette_map"])
 	if not rom.in_bounds(palette_map, RomLayout.TOWN_MAP_PALETTE_MAP_BYTES):
 		return {"ok": false, "message": "The region palette map is outside the cartridge."}
@@ -1647,6 +1675,50 @@ static func read_town_map_region(
 			return out
 		out.append(byte)
 	return PackedByteArray()
+
+
+## `Pokegear_LoadTilemapRLE` over the three cards in the run's own order, each
+## answered as its twelve rows of tile numbers. A card that does not decode to
+## exactly that many cells answers empty, which is what a wrong offset gives.
+static func read_pokegear_cards(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int((layout.get("town_map", {}) as Dictionary).get("cards", -1))
+	var out: Dictionary = {}
+	if at < 0 or not rom.in_bounds(at, RomLayout.POKEGEAR_CARD_TILEMAP_BYTES):
+		return out
+	var end: int = at + RomLayout.POKEGEAR_CARD_TILEMAP_BYTES
+	for name: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var cells: PackedByteArray = PackedByteArray()
+		while at < end and rom.u8(at) != RomLayout.POKEGEAR_CARD_TERMINATOR:
+			if at + 1 >= end:
+				return {}
+			var tile: int = rom.u8(at)
+			for _step: int in rom.u8(at + 1):
+				cells.append(tile)
+			at += 2
+		if cells.size() != RomLayout.POKEGEAR_CARD_CELLS:
+			return {}
+		out[name] = cells
+		at += 1
+	return out
+
+
+## `_PokegearAskWhoCallText` and its neighbour, read one after the other from the
+## first: each decode answers where it ended, which is where the next begins.
+static func read_pokegear_texts(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int((layout.get("town_map", {}) as Dictionary).get("card_texts", -1))
+	var out: Dictionary = {}
+	var window: int = RomLayout.POKEGEAR_TEXT_NAMES.size() * RomLayout.POKEGEAR_TEXT_MAX_BYTES
+	if at < 0 or not rom.in_bounds(at, window):
+		return out
+	var data: PackedByteArray = rom.slice(at, window)
+	var offset: int = 0
+	for name: String in RomLayout.POKEGEAR_TEXT_NAMES:
+		var decoded: Dictionary = Gen2TextStream.decode(data, offset)
+		if not bool(decoded.get("ok", false)):
+			return {}
+		out[name] = String(decoded["text"])
+		offset = int(decoded["bytes"])
+	return out
 
 
 ## `LoadTitleScreenTilemap`'s own loop: bytes until `-1`, which is not copied.
@@ -4323,7 +4395,8 @@ func _import_title(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## The region map's data half: both region tilemaps, `TownMapPals`' palette map,
-## the landmark table and the palettes the six tile classes are drawn through.
+## the landmark table, the palettes the six tile classes are drawn through, and
+## the other three Pokegear cards, which share the whole of that VRAM window.
 ##
 ## A landmark's name is kept as the codes it is rather than as text, because
 ## `TownMap_ConvertLineBreakCharacters` rewrites one of those codes before the
@@ -4351,6 +4424,12 @@ func _import_town_map(rom: RomFile, layout: Dictionary) -> Dictionary:
 			rom, int(entry["palette_female"]),
 			RomLayout.TOWN_MAP_PALETTES * RomLayout.TOWN_MAP_PALETTE_COLORS
 		)
+	var decoded: Dictionary = read_pokegear_cards(rom, layout)
+	var cards: Dictionary = {}
+	for name: String in decoded:
+		cards[name] = Array(decoded[name] as PackedByteArray)
+	out["cards"] = cards
+	out["card_texts"] = read_pokegear_texts(rom, layout)
 	return out
 
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -802,6 +802,28 @@ const TOWN_MAP_REGION_BYTES: int = TOWN_MAP_REGION_CELLS + 1
 ## `KantoMap`, so the region map locates it rather than a fourth offset.
 const DEX_NEST_ICON_TILES: int = 1
 
+## `RadioTilemapRLE`, `PhoneTilemapRLE` and `ClockTilemapRLE`: the other three
+## Pokegear cards, one contiguous run in that order directly behind
+## `PokegearSpritesGFX`, byte identical on all three cartridges.
+##
+## `Pokegear_LoadTilemapRLE` reads the *tile* first and its run length second,
+## the opposite way round from the comment above it, and writes from (0,0) until
+## `-1`. Each card is twelve rows; `Textbox` draws the four below them.
+const POKEGEAR_CARD_ORDER: Array[String] = ["radio", "phone", "clock"]
+const POKEGEAR_CARD_COLUMNS: int = 20
+const POKEGEAR_CARD_ROWS: int = 12
+const POKEGEAR_CARD_CELLS: int = POKEGEAR_CARD_ROWS * POKEGEAR_CARD_COLUMNS
+const POKEGEAR_CARD_TERMINATOR: int = 0xFF
+## The whole run, which is what bounds the walk over the three.
+const POKEGEAR_CARD_TILEMAP_BYTES: int = 305
+
+## `_PokegearAskWhoCallText` and its two neighbours, adjacent in
+## `data/text/common_3.asm` and decoded in that order from the one offset: the
+## phone card asks the first when it opens, the clock card says the second, and
+## the phone submenu's DELETE row asks the third.
+const POKEGEAR_TEXT_NAMES: Array[String] = ["ask_who", "press_button", "ask_delete"]
+const POKEGEAR_TEXT_MAX_BYTES: int = 64
+
 ## `TownMapPals`: a palette per tile id, condensed to nybbles, least significant
 ## first. It covers $00 to $5f; $60 and above take palette 0.
 const TOWN_MAP_PALETTE_MAP_BYTES: int = 48
@@ -1506,13 +1528,17 @@ const GOLD_SILVER: Dictionary = {
 	# three graphics by decompressing at every offset and keeping the run that
 	# reproduces the pinned PNG exactly. Every hit is unique per dump. The
 	# landmark table was located by its own x,y byte pairs at a stride of four,
-	# which no other run in the cartridge matches. Nested the way trainer_card
-	# is, so Gold and Silver's absent female palette stays out of the flat offset
-	# checks.
+	# which no other run in the cartridge matches. `cards` is the three card
+	# tilemaps as one run, matched from the pinned .rle files, and `card_texts`
+	# the two Pokegear texts, matched as encoded characters. Nested the way
+	# trainer_card is, so Gold and Silver's absent female palette stays out of
+	# the flat offset checks.
 	"town_map": {
 		"gfx": 0xF8C92,
 		"pokegear_gfx": 0x1C0E43,
 		"sprites": 0x9149C,
+		"cards": 0x914CC,
+		"card_texts": 0x198089,
 		"fast_ship": 0x90C7C,
 		"johto": 0x91F52,
 		"kanto": 0x920BB,
@@ -1882,6 +1908,8 @@ const CRYSTAL: Dictionary = {
 		"gfx": 0xF8BA0,
 		"pokegear_gfx": 0x1DE2E4,
 		"sprites": 0x914DD,
+		"cards": 0x9150D,
+		"card_texts": 0x1C5847,
 		"fast_ship": 0x90CB2,
 		"johto": 0x91FFF,
 		"kanto": 0x92168,

--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -296,9 +296,14 @@ static func _buffer_string(context: Dictionary, buffer: int) -> String:
 	return "<BUFFER_%d>" % buffer
 
 
-static func _weekday(context: Dictionary) -> String:
-	var day: int = int(context.get("weekday", 0))
+## `GetWeekday`'s own answer, which `TextCommand_DAY` and the Pokegear's clock
+## card both print.
+static func weekday_name(day: int) -> String:
 	return WEEKDAYS[posmod(day, WEEKDAYS.size())]
+
+
+static func _weekday(context: Dictionary) -> String:
+	return weekday_name(int(context.get("weekday", 0)))
 
 
 ## `TextCommand_FAR` banks in and runs the target as a whole text of its own.

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -1,8 +1,8 @@
 class_name Gen2TownMapPage
 extends RefCounted
 
-## The region map (`_TownMap` and `InitPokegearTilemap.Map`), on the tile grid
-## the hardware uses.
+## The region map (`_TownMap` and `InitPokegearTilemap.Map`) and the Pokegear's
+## other three cards, on the tile grid the hardware uses.
 ##
 ## Like the trainer card this is a tilemap screen: `FillTownMap` writes one tile
 ## number per cell of the whole screen out of `JohtoMap` or `KantoMap`, the frame
@@ -17,6 +17,10 @@ extends RefCounted
 ## | $00-$2f | `TownMapGFX`, which is every tile a region map names |
 ## | $30-$5d | `PokegearGFX`, the card frame and its icons |
 ## | $60+ | the font, so printed text addresses glyphs as usual |
+##
+## The other three cards are the same window with one of the RLE tilemaps over
+## it instead of a region map, so they are built here rather than in a page of
+## their own; `Pokegear_FinishTilemap`'s icon row runs on all four.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -63,6 +67,67 @@ const CARD_POKEGEAR_ICON_TILE: int = 0x46
 ## lower half of an icon sixteen tiles along rather than two.
 const CARD_ICON_ROW_STRIDE: int = 16
 
+## `InitPokegearTilemap`'s other three cards, which are the same VRAM window and
+## the same palettes: the screen is filled with the Pokegear sheet's own blank,
+## one of `ClockTilemapRLE`, `PhoneTilemapRLE` and `RadioTilemapRLE` covers the
+## top twelve rows, and `Textbox` draws the four below it.
+const CARD_TEXTBOX_AT: Vector2i = Vector2i(0, 12)
+const CARD_TEXTBOX_COLUMNS: int = 20
+const CARD_TEXTBOX_ROWS: int = 6
+## Where `PrintText` puts a line inside that box, which is one tile in and every
+## second row, the way every text box on the hardware is written.
+const CARD_TEXT_AT: Vector2i = Vector2i(1, 14)
+const CARD_TEXT_SPACING: int = 2
+
+## `.Clock`'s own string, and `Pokegear_UpdateClock`: a 14x5 box cleared at
+## (3,5), `_GearTodayText`'s weekday at (6,6) and `PrintHoursMins` at (6,8).
+const CLOCK_SWITCH_TEXT: String = " SWITCH▶"
+const CLOCK_SWITCH_AT: Vector2i = Vector2i(12, 1)
+const CLOCK_CLEAR_AT: Vector2i = Vector2i(3, 5)
+const CLOCK_CLEAR_COLUMNS: int = 14
+const CLOCK_CLEAR_ROWS: int = 5
+const CLOCK_DAY_AT: Vector2i = Vector2i(6, 6)
+const CLOCK_TIME_AT: Vector2i = Vector2i(6, 8)
+
+## `UpdateRadioStation.returnafterstation`, which places the tuned station's own
+## name and is the only thing the radio card prints. A dial between stations
+## reaches `NoRadioStation` instead, which prints nothing.
+const RADIO_STATION_AT: Vector2i = Vector2i(2, 9)
+
+## `.PlacePhoneBars`: three fixed tiles of the signal meter, and a fourth only
+## where `GetMapPhoneService` answers that there is service.
+const PHONE_BARS_AT: Vector2i = Vector2i(17, 1)
+const PHONE_BARS_TILE: int = 0x3C
+const PHONE_SERVICE_AT: Vector2i = Vector2i(18, 2)
+const PHONE_SERVICE_TILE: int = 0x3F
+
+## `PokegearPhone_UpdateDisplayList` and `PokegearPhone_UpdateCursor`: the list
+## is cleared from (1,3) and each of the four rows is two tall, the caller's own
+## name at column 2 and a trainer's class under it at column 5.
+const PHONE_DISPLAY_HEIGHT: int = 4
+const PHONE_CLEAR_AT: Vector2i = Vector2i(1, 3)
+const PHONE_CLEAR_COLUMNS: int = COLUMNS - 2
+const PHONE_FIRST_ROW: int = 4
+const PHONE_ROW_SPACING: int = 2
+const PHONE_NAME_COLUMN: int = 2
+const PHONE_CLASS_COLUMN: int = 5
+const PHONE_CURSOR_COLUMN: int = 1
+const PHONE_CURSOR_CODE: int = 0xED
+
+## `PokegearPhoneContactSubmenu`, which is hand-built rather than a
+## `menu_coords` menu: its box is eight tiles wide inside and as tall as the
+## options are rows, its cursor sits in the column the strings' own `dwcoord`
+## names, and `.UpdateCursor`'s caller places the text one tile right of it. The
+## last row is always at 10, so a two-option box opens two rows lower.
+const PHONE_SUBMENU_LAST_ROW: int = 10
+const PHONE_SUBMENU_COLUMNS: int = 8
+const PHONE_SUBMENU_CURSOR_COLUMN: int = 10
+
+## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into a
+## five-by-four border from that corner.
+const YES_NO_BOX: Array[int] = [14, 7, 19, 11]
+const YES_NO_OPTIONS: Array[String] = ["YES", "NO"]
+
 ## `PokegearMap_UpdateLandmarkName`: a 2x12 box cleared at (8,0), the name placed
 ## at (9,0) and the sheet's own marker left in the corner it opened.
 const NAME_BOX_AT: Vector2i = Vector2i(8, 0)
@@ -78,8 +143,13 @@ const NAME_BREAK_CODES: Array[int] = [0x1F, 0x25]
 const CITY_PALETTE: int = 3
 
 var font: Gen2Font = null
+## Which text-box border the player chose, for the box a card draws under itself.
+## The region map screens have no box and never read it.
+var frame_style: int = 0
 ## The VRAM window, as one indices strip per tile number.
 var _tiles: Dictionary = {}
+## The three card tilemaps, by the names the cache keys them with.
+var _cards: Dictionary = {}
 
 
 ## [param data] supplies the glyphs and both graphics sheets; a cache without
@@ -90,8 +160,13 @@ static func from_data(data: GameData) -> Gen2TownMapPage:
 		return null
 	var out := Gen2TownMapPage.new()
 	out.font = glyphs
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
 	out._load_sheet(data, "town_map", TOWN_MAP_FIRST_TILE, RomLayout.TOWN_MAP_TILES)
 	out._load_sheet(data, "pokegear", POKEGEAR_FIRST_TILE, RomLayout.POKEGEAR_TILES)
+	for card: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var cells: PackedByteArray = data.pokegear_card(StringName(card))
+		if cells.size() == RomLayout.POKEGEAR_CARD_CELLS:
+			out._cards[card] = cells
 	return out
 
 
@@ -143,6 +218,167 @@ func tilemap(
 			_draw_town_map_frame(map)
 			_draw_name(map, name_codes)
 	return map
+
+
+## Whether the three card tilemaps are in the cache this page was built from.
+func cards_ready() -> bool:
+	return _cards.size() == RomLayout.POKEGEAR_CARD_ORDER.size()
+
+
+## `.Clock`: the card, its own SWITCH label, the cleared face, the weekday and
+## `PrintHoursMins`' twelve-hour reading. [param minute] and [param hour] are the
+## world clock's; [param text] is `PokegearPressButtonText`.
+func clock_tilemap(
+	owned: Array, weekday: int, hour: int, minute: int, text: String
+) -> PackedInt32Array:
+	var map: PackedInt32Array = _card_base(&"clock", text)
+	_draw_string(map, CLOCK_SWITCH_AT, CLOCK_SWITCH_TEXT)
+	for row: int in CLOCK_CLEAR_ROWS:
+		for column: int in CLOCK_CLEAR_COLUMNS:
+			_put(map, CLOCK_CLEAR_AT + Vector2i(column, row), BLANK_TILE)
+	_draw_string(map, CLOCK_DAY_AT, Gen2TextStream.weekday_name(weekday) + "DAY")
+	_draw_string(map, CLOCK_TIME_AT, _clock_reading(hour, minute))
+	_draw_card_icons(map, owned)
+	return map
+
+
+## `PrintHoursMins`: the hour space-padded to two tiles, the minute with its
+## leading zero, and AM or PM one tile past it. Midnight and noon are both
+## printed as twelve, which is what its two branches do with a zero hour.
+static func _clock_reading(hour: int, minute: int) -> String:
+	var hour24: int = posmod(hour, 24)
+	var reading: int = hour24 % 12
+	if reading == 0:
+		reading = 12
+	return "%2d:%02d %s" % [reading, posmod(minute, 60), "AM" if hour24 < 12 else "PM"]
+
+
+## `.Radio`, whose card prints nothing but the tuned station's own name.
+func radio_tilemap(owned: Array, station: String) -> PackedInt32Array:
+	var map: PackedInt32Array = _card_base(&"radio", "")
+	if not station.is_empty():
+		_draw_string(map, RADIO_STATION_AT, station)
+	_draw_card_icons(map, owned)
+	return map
+
+
+## `.Phone` and `PokegearPhone_UpdateDisplayList`. [param rows] is the window of
+## contacts on screen, each `{ name, class }`, [param cursor] the row the arrow
+## is on and [param service] `GetMapPhoneService`'s answer.
+func phone_tilemap(
+	owned: Array, rows: Array, cursor: int, service: bool, text: String
+) -> PackedInt32Array:
+	var map: PackedInt32Array = _card_base(&"phone", text)
+	_put(map, PHONE_BARS_AT, PHONE_BARS_TILE)
+	_put(map, PHONE_BARS_AT + Vector2i(1, 0), PHONE_BARS_TILE + 1)
+	_put(map, PHONE_BARS_AT + Vector2i(0, 1), PHONE_BARS_TILE + 2)
+	if service:
+		_put(map, PHONE_SERVICE_AT, PHONE_SERVICE_TILE)
+	for row: int in PHONE_DISPLAY_HEIGHT * 2 + 1:
+		for column: int in PHONE_CLEAR_COLUMNS:
+			_put(map, PHONE_CLEAR_AT + Vector2i(column, row), BLANK_TILE)
+	for index: int in mini(rows.size(), PHONE_DISPLAY_HEIGHT):
+		var entry: Dictionary = rows[index]
+		var top: int = PHONE_FIRST_ROW + index * PHONE_ROW_SPACING
+		var caller: String = String(entry.get("name", ""))
+		var class_name_text: String = String(entry.get("class", ""))
+		# `GetCallerName`: a trainer's own name carries a colon and their class
+		# goes on the line below; every other caller is one line.
+		_draw_string(
+			map, Vector2i(PHONE_NAME_COLUMN, top),
+			caller + ":" if not class_name_text.is_empty() else caller
+		)
+		if not class_name_text.is_empty():
+			_draw_string(map, Vector2i(PHONE_CLASS_COLUMN, top + 1), class_name_text)
+	if cursor >= 0 and cursor < PHONE_DISPLAY_HEIGHT:
+		_put(
+			map,
+			Vector2i(PHONE_CURSOR_COLUMN, PHONE_FIRST_ROW + cursor * PHONE_ROW_SPACING),
+			PHONE_CURSOR_CODE
+		)
+	_draw_card_icons(map, owned)
+	return map
+
+
+## What every card opens with: `InitPokegearTilemap`'s screen-wide fill with the
+## Pokegear sheet's blank, the card's own twelve rows, and the text box each of
+## the three draws under them.
+func _card_base(card: StringName, text: String) -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	map.fill(CARD_BLANK_TILE)
+	var cells: PackedByteArray = _cards.get(String(card), PackedByteArray())
+	for cell: int in mini(cells.size(), map.size()):
+		map[cell] = cells[cell]
+	_draw_textbox(map, text)
+	return map
+
+
+## `Textbox`: the chosen frame's own six tiles around a cleared interior, with
+## the text printed a tile in and on every second row.
+func _draw_textbox(map: PackedInt32Array, text: String) -> void:
+	_draw_box(map, CARD_TEXTBOX_AT, Vector2i(CARD_TEXTBOX_COLUMNS, CARD_TEXTBOX_ROWS))
+	var line: int = 0
+	for row_text: String in text.split("\n", false):
+		_draw_string(map, CARD_TEXT_AT + Vector2i(0, line * CARD_TEXT_SPACING), row_text)
+		line += 1
+
+
+## `PokegearPhoneContactSubmenu`, over whichever card is up. [param options] is
+## the two- or three-row list `CheckCanDeletePhoneNumber` picks between.
+func draw_phone_submenu(
+	map: PackedInt32Array, options: Array, cursor: int
+) -> void:
+	var top: int = PHONE_SUBMENU_LAST_ROW - options.size() * 2
+	_draw_box(
+		map, Vector2i(PHONE_SUBMENU_CURSOR_COLUMN - 1, top),
+		Vector2i(PHONE_SUBMENU_COLUMNS + 2, options.size() * 2 + 2)
+	)
+	for index: int in options.size():
+		var at := Vector2i(PHONE_SUBMENU_CURSOR_COLUMN, top + 2 + index * 2)
+		_draw_string(map, at + Vector2i(1, 0), String(options[index]))
+		if index == cursor:
+			_put(map, at, PHONE_CURSOR_CODE)
+
+
+## `YesNoBox`, which the DELETE row opens over the card.
+func draw_yes_no(map: PackedInt32Array, cursor: int) -> void:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		YES_NO_BOX[0], YES_NO_BOX[1], YES_NO_BOX[2], YES_NO_BOX[3],
+		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+	)
+	_draw_box(map, box.border_position(), box.border_size())
+	for index: int in YES_NO_OPTIONS.size():
+		_draw_string(map, box.item_position(index), YES_NO_OPTIONS[index])
+		if index == cursor:
+			_put(map, box.cursor_position(index), PHONE_CURSOR_CODE)
+
+
+## `Textbox`'s border and its cleared interior, as the tile numbers
+## `TextBoxBorder` writes: [param size] counts the border in.
+func _draw_box(map: PackedInt32Array, at: Vector2i, size: Vector2i) -> void:
+	var first: int = RomLayout.FRAME_FIRST_CODE
+	var right: int = at.x + size.x - 1
+	var bottom: int = at.y + size.y - 1
+	for column: int in range(at.x + 1, right):
+		_put(map, Vector2i(column, at.y), first + RomLayout.FRAME_HORIZONTAL)
+		_put(map, Vector2i(column, bottom), first + RomLayout.FRAME_HORIZONTAL)
+	for row: int in range(at.y + 1, bottom):
+		_put(map, Vector2i(at.x, row), first + RomLayout.FRAME_VERTICAL)
+		_put(map, Vector2i(right, row), first + RomLayout.FRAME_VERTICAL)
+		for column: int in range(at.x + 1, right):
+			_put(map, Vector2i(column, row), BLANK_TILE)
+	_put(map, at, first + RomLayout.FRAME_TOP_LEFT)
+	_put(map, Vector2i(right, at.y), first + RomLayout.FRAME_TOP_RIGHT)
+	_put(map, Vector2i(at.x, bottom), first + RomLayout.FRAME_BOTTOM_LEFT)
+	_put(map, Vector2i(right, bottom), first + RomLayout.FRAME_BOTTOM_RIGHT)
+
+
+func _draw_string(map: PackedInt32Array, at: Vector2i, text: String) -> void:
+	var cell: Vector2i = at
+	for code: int in Gen2Text.encode(text):
+		_put(map, cell, code)
+		cell.x += 1
 
 
 func _draw_town_map_frame(map: PackedInt32Array) -> void:
@@ -253,7 +489,8 @@ func image(data: GameData, map: PackedInt32Array, female: bool = false) -> Image
 
 
 ## Resolves every tile number to pixels: the two graphics sheets out of the VRAM
-## window, everything else out of the font.
+## window, a card's text box out of the chosen frame, everything else out of the
+## font.
 func compose(map: PackedInt32Array) -> PackedByteArray:
 	var width: int = COLUMNS * TILE
 	var indices := PackedByteArray()
@@ -264,6 +501,9 @@ func compose(map: PackedInt32Array) -> PackedByteArray:
 			var at := Vector2i(column * TILE, row * TILE)
 			if _tiles.has(tile):
 				_blit(indices, width, _tiles[tile], at)
+			elif tile >= RomLayout.FRAME_FIRST_CODE \
+				and tile < RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TILES:
+				font.draw_frame_code(frame_style, tile, indices, width, at.x, at.y)
 			elif tile != BLANK_TILE:
 				font.draw_code(tile, indices, width, at.x, at.y, Gen2Text.FONT_MAIN)
 	return indices

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -1,0 +1,478 @@
+class_name Gen2PokegearScreen
+extends Control
+
+## The Pokegear's clock, phone and radio cards, embedded the way the MAP card is.
+##
+## [Gen2TownMapPage] draws all four; this composes one of the three over a
+## [Gen2Screen] and puts the two objects `InitPokegearTilemap` spawns on top: the
+## mode indicator arrow under the card icons, and the radio card's tuning knob.
+## The MAP card is [Gen2TownMapScreen], which owns the region map's own cursor,
+## player icon and landmark walk and is also the dex area and the fly map.
+##
+## Nothing here decides anything: the world owns the clock, the dial and the
+## contact list, so a press is reported and the host reopens the card with what
+## the world then says.
+
+signal closed()
+## Left or right, which is `Pokegear_SwitchPage` and is the host's to resolve:
+## the card offered depends on which cards the player owns.
+signal switched(direction: int)
+## A press on the radio card's dial, as the knob value `.TuningKnob` would leave.
+signal tuned(knob: int)
+## The phone submenu's CALL row: the contact under the cursor, as its own index.
+signal called(contact: int)
+## Its DELETE row, once the yes/no box has been answered.
+signal deleted(contact: int)
+
+const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
+
+const CARD_CLOCK: StringName = &"clock"
+const CARD_PHONE: StringName = &"phone"
+const CARD_RADIO: StringName = &"radio"
+
+## `InitPokegearModeIndicatorArrow`'s `depixel 4, 2, 4, 0`, less the hardware's
+## own OAM offsets and `.OAMData_RedWalk`'s `dbsprite -1, -1`, plus the card's
+## own entry in `AnimatePokegearModeIndicatorArrow.XCoords`. The clock's is zero,
+## which puts the arrow under the Pokegear's own icon rather than a card's.
+const ARROW_TILE: int = 0x00
+const ARROW_AT: Vector2i = Vector2i(0, 12)
+const ARROW_CARD_STRIDE: int = 0x10
+const ARROW_CARDS: Array[StringName] = [CARD_CLOCK, &"map", CARD_PHONE, CARD_RADIO]
+
+## `PokegearRadio_Init`'s `depixel 4, 10, 4, 4` with `SPRITEANIMSTRUCT_TILE_ID`
+## $08, read the same way: three tiles stacked, sliding right with
+## `wRadioTuningKnob`, so the middle one rides the dial's own scale row.
+const KNOB_TILE: int = 0x08
+const KNOB_AT: Vector2i = Vector2i(72, 8)
+const KNOB_TILES: int = 3
+
+## `wPhoneList`, which the display list scrolls a row at a time.
+const PHONE_LIST_SIZE: int = 10
+const PHONE_DISPLAY_HEIGHT: int = Gen2TownMapPage.PHONE_DISPLAY_HEIGHT
+
+## `PokegearPhoneContactSubmenu`'s two lists, and the contacts
+## `CheckCanDeletePhoneNumber` refuses to offer the second of: the two
+## non-trainers whose numbers the story needs.
+const SUBMENU_CALL: String = "CALL"
+const SUBMENU_DELETE: String = "DELETE"
+const SUBMENU_CANCEL: String = "CANCEL"
+const UNDELETABLE_CONTACTS: Array[int] = [1, 4]
+
+var _data: GameData = null
+var _page: Gen2TownMapPage = null
+var _card: StringName = CARD_CLOCK
+var _owned: Array = []
+var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
+var _open: bool = false
+
+## The clock card's reading, the radio card's dial and the box text, all as the
+## host last gave them.
+var _weekday: int = 0
+var _hour: int = 0
+var _minute: int = 0
+var _knob: int = 0
+var _station: String = ""
+var _text: String = ""
+## `PokegearAskDeleteText`, which replaces the card's question while the yes/no
+## box is up.
+var _delete_text: String = ""
+## The phone card's own list: every contact, the window's first row and the
+## cursor inside that window.
+var _contacts: Array = []
+var _scroll: int = 0
+var _cursor: int = 0
+var _service: bool = true
+## `PokegearPhoneContactSubmenu` while it is up, and the yes/no box DELETE opens
+## over it. Both are drawn on the card rather than on a layer of their own, the
+## way `Textbox` writes into the same tilemap.
+var _submenu: Array = []
+var _submenu_cursor: int = 0
+var _asking_delete: bool = false
+var _yes_no_cursor: int = 0
+
+var _field: Control = null
+var _background: TextureRect = null
+var _arrow: TextureRect = null
+var _knob_icon: TextureRect = null
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_build()
+	if _page != null:
+		_refresh()
+
+
+## Opens one of the three cards. [param owned] is `wPokegearFlags` as the card
+## names `Pokegear_FinishTilemap` tests, [param text] whichever of the Pokegear's
+## own texts the card prints: the question it opens with and, on the phone card,
+## `PokegearAskDeleteText`.
+##
+## Optional the way the region map is: a cache with no card tilemaps answers
+## false and the caller keeps its own screen open.
+func open(
+	data: GameData,
+	card: StringName,
+	owned: Array,
+	text: String = "",
+	delete_text: String = "",
+	time_of_day: int = Gen2WorldPalette.TIME_MORNING,
+) -> bool:
+	_data = data
+	_page = Gen2TownMapPage.from_data(_data) if _data != null else null
+	if _page == null or not _page.ready() or not _page.cards_ready():
+		visible = false
+		return false
+	_card = card
+	_owned = owned.duplicate()
+	_text = text
+	_delete_text = delete_text
+	_time_of_day = time_of_day
+	## `PokegearPhone_Init`'s three zeroes.
+	_scroll = 0
+	_cursor = 0
+	_close_submenu()
+	_open = true
+	visible = true
+	if is_inside_tree() and _background != null:
+		_refresh()
+	return true
+
+
+## `Pokegear_UpdateClock`'s three readings, which the card redraws every frame.
+func set_clock(weekday: int, hour: int, minute: int) -> void:
+	_weekday = weekday
+	_hour = hour
+	_minute = minute
+	_refresh()
+
+
+## `wRadioTuningKnob` and whatever `UpdateRadioStation` last placed for it.
+func set_radio(knob: int, station: String) -> void:
+	_knob = knob
+	_station = station
+	_refresh()
+
+
+## The whole contact list and `GetMapPhoneService`'s answer. Only the first ten
+## are kept, which is `wPhoneList`; the window and the cursor are left where they
+## are, since `PokegearPhone_Init` is the one place that zeroes them and a delete
+## redraws the list under the cursor it was chosen from.
+func set_contacts(contacts: Array, service: bool) -> void:
+	_contacts = contacts.slice(0, PHONE_LIST_SIZE)
+	_service = service
+	_refresh()
+
+
+func card() -> StringName:
+	return _card
+
+
+## Which contact the cursor is on, or -1 on an empty slot, which is what
+## `.a`'s own `and a / ret z` refuses.
+func selected_contact() -> int:
+	var index: int = _scroll + _cursor
+	if index < 0 or index >= _contacts.size():
+		return -1
+	return int((_contacts[index] as Dictionary).get("index", -1))
+
+
+## The three joypad handlers: B leaves every card, left and right are
+## `Pokegear_SwitchPage`, and up and down are the dial on the radio card and the
+## contact list on the phone card. The clock card reads neither.
+func handle_button(button: int) -> bool:
+	if not _open:
+		return false
+	if _asking_delete:
+		_press_yes_no(button)
+		return true
+	if not _submenu.is_empty():
+		_press_submenu(button)
+		return true
+	match button:
+		Gen2Button.B:
+			close()
+			return true
+		Gen2Button.LEFT, Gen2Button.RIGHT:
+			switched.emit(-1 if button == Gen2Button.LEFT else 1)
+			return true
+	if _card == CARD_RADIO and button in [Gen2Button.UP, Gen2Button.DOWN]:
+		var step: int = Gen2WorldRadio.KNOB_STEP * (1 if button == Gen2Button.UP else -1)
+		var next: int = clampi(_knob + step, Gen2WorldRadio.KNOB_MIN, Gen2WorldRadio.KNOB_MAX)
+		if next != _knob:
+			tuned.emit(next)
+		return true
+	if _card != CARD_PHONE:
+		# `PokegearClock_Joypad` quits on `PAD_BUTTONS`, so its up and down do
+		# nothing at all; A on the radio card is swallowed, the dial being that
+		# card's whole input.
+		if _card == CARD_CLOCK and not Gen2Button.is_direction(button):
+			close()
+		return true
+	match button:
+		Gen2Button.UP:
+			_move_phone(-1)
+		Gen2Button.DOWN:
+			_move_phone(1)
+		Gen2Button.A:
+			## `.a` refuses an empty slot before it opens the submenu.
+			if selected_contact() >= 0:
+				_open_submenu()
+	return true
+
+
+## `PokegearPhoneContactSubmenu`: CALL and CANCEL always, DELETE between them
+## for a contact `CheckCanDeletePhoneNumber` allows.
+func _open_submenu() -> void:
+	_submenu = [SUBMENU_CALL, SUBMENU_CANCEL] if not _can_delete_selected() \
+		else [SUBMENU_CALL, SUBMENU_DELETE, SUBMENU_CANCEL]
+	_submenu_cursor = 0
+	_refresh()
+
+
+## `CheckCanDeletePhoneNumber`: every trainer, and every other caller but the two
+## whose numbers it names.
+func _can_delete_selected() -> bool:
+	var index: int = _scroll + _cursor
+	if index < 0 or index >= _contacts.size():
+		return false
+	var contact: Dictionary = _contacts[index]
+	if int(contact.get("trainer_class", 0)) != 0:
+		return true
+	return not int(contact.get("non_trainer_id", -1)) in UNDELETABLE_CONTACTS
+
+
+## `.loop`'s own joypad read: the cursor stops at both ends rather than wrapping,
+## and B is CANCEL wherever it is.
+func _press_submenu(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			_submenu_cursor = maxi(_submenu_cursor - 1, 0)
+		Gen2Button.DOWN:
+			_submenu_cursor = mini(_submenu_cursor + 1, _submenu.size() - 1)
+		Gen2Button.B:
+			_close_submenu()
+			return
+		Gen2Button.A:
+			match String(_submenu[_submenu_cursor]):
+				SUBMENU_CALL:
+					var contact: int = selected_contact()
+					_close_submenu()
+					called.emit(contact)
+					return
+				SUBMENU_DELETE:
+					_asking_delete = true
+					## `YesNoMenuHeader`'s own `db 1`, which is YES.
+					_yes_no_cursor = 0
+				_:
+					_close_submenu()
+					return
+	_refresh()
+
+
+## `YesNoBox`, whose B is the same answer NO is.
+func _press_yes_no(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			_yes_no_cursor = 0
+		Gen2Button.DOWN:
+			_yes_no_cursor = 1
+		Gen2Button.B:
+			## `InterpretTwoOptionMenu` answers a B the way NO answers.
+			_close_submenu()
+			return
+		Gen2Button.A:
+			var contact: int = selected_contact()
+			var yes: bool = _yes_no_cursor == 0
+			_close_submenu()
+			if yes:
+				deleted.emit(contact)
+			return
+	_refresh()
+
+
+func _close_submenu() -> void:
+	_submenu = []
+	_asking_delete = false
+	_refresh()
+
+
+## `PokegearPhone_GetDPad`: the cursor walks the four rows on screen and the
+## window scrolls only once it is against an end, and neither wraps.
+func _move_phone(step: int) -> void:
+	if step < 0:
+		if _cursor > 0:
+			_cursor -= 1
+		elif _scroll > 0:
+			_scroll -= 1
+		else:
+			return
+	else:
+		if _cursor < PHONE_DISPLAY_HEIGHT - 1:
+			_cursor += 1
+		elif _scroll < PHONE_LIST_SIZE - PHONE_DISPLAY_HEIGHT:
+			_scroll += 1
+		else:
+			return
+	_refresh()
+
+
+func close() -> void:
+	if not _open:
+		return
+	_open = false
+	visible = false
+	closed.emit()
+
+
+## The whole card as one 160x144 image, objects included, for a preview or a test
+## that wants pixels rather than a viewport.
+func render() -> Image:
+	var out: Image = _background_image()
+	out.blend_rect(
+		_arrow_image(), Rect2i(Vector2i.ZERO, Vector2i(16, 16)), _arrow_position()
+	)
+	if _card == CARD_RADIO:
+		out.blend_rect(
+			_knob_image(),
+			Rect2i(Vector2i.ZERO, Vector2i(Gen2TownMapPage.TILE, KNOB_TILES * Gen2TownMapPage.TILE)),
+			_knob_position()
+		)
+	return out
+
+
+func _build() -> void:
+	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
+	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(screen)
+	_field = Control.new()
+	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	screen.display(_field)
+	_background = _sprite()
+	# The knob is spawned after the arrow and so takes the higher shadow-OAM
+	# index; the two never overlap, but the order is the source's.
+	_arrow = _sprite()
+	_knob_icon = _sprite()
+
+
+func _sprite() -> TextureRect:
+	var node := TextureRect.new()
+	node.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	node.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_field.add_child(node)
+	return node
+
+
+func _refresh() -> void:
+	if not _open or _background == null or _page == null:
+		return
+	_background.texture = ImageTexture.create_from_image(_background_image())
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_arrow.position = Vector2(_arrow_position())
+	_arrow.texture = ImageTexture.create_from_image(_arrow_image())
+	_knob_icon.visible = _card == CARD_RADIO
+	if _knob_icon.visible:
+		_knob_icon.position = Vector2(_knob_position())
+		_knob_icon.texture = ImageTexture.create_from_image(_knob_image())
+
+
+func _background_image() -> Image:
+	if _page == null or _data == null:
+		return Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
+	return _page.image(_data, _tilemap())
+
+
+func _tilemap() -> PackedInt32Array:
+	if _card == CARD_RADIO:
+		return _page.radio_tilemap(_owned, _station)
+	if _card != CARD_PHONE:
+		return _page.clock_tilemap(_owned, _weekday, _hour, _minute, _text)
+	var map: PackedInt32Array = _page.phone_tilemap(
+		_owned, _phone_rows(), _cursor, _service,
+		_delete_text if _asking_delete else _text
+	)
+	if not _submenu.is_empty():
+		# The yes/no box is a window over the submenu rather than a replacement,
+		# so the row it was chosen from keeps its arrow.
+		_page.draw_phone_submenu(map, _submenu, _submenu_cursor)
+	if _asking_delete:
+		_page.draw_yes_no(map, _yes_no_cursor)
+	return map
+
+
+## The four rows on screen, as `GetCallerClassAndName` writes them: a trainer's
+## own name over their class, and one line for everyone else. An empty slot is an
+## empty row, which is what `wPhoneList`'s zeroes print.
+func _phone_rows() -> Array:
+	var rows: Array = []
+	for row: int in PHONE_DISPLAY_HEIGHT:
+		var index: int = _scroll + row
+		if index >= _contacts.size():
+			rows.append({})
+			continue
+		var contact: Dictionary = _contacts[index]
+		var trainer_class: int = int(contact.get("trainer_class", 0))
+		if trainer_class <= 0:
+			rows.append({"name": String(contact.get("caller_label", ""))})
+			continue
+		rows.append({
+			"name": String(_data.trainer_party(
+				trainer_class, int(contact.get("trainer_number", 1)) - 1
+			).get("name", "")),
+			"class": _data.trainer_name(trainer_class),
+		})
+	return rows
+
+
+func _arrow_position() -> Vector2i:
+	return ARROW_AT + Vector2i(ARROW_CARD_STRIDE * maxi(ARROW_CARDS.find(_card), 0), 0)
+
+
+func _knob_position() -> Vector2i:
+	return KNOB_AT + Vector2i(_knob, 0)
+
+
+## `.OAMData_RedWalk` over `PokegearSpritesGFX`'s first four tiles, which is the
+## arrow rather than the region map's cursor.
+func _arrow_image() -> Image:
+	return _icon(ARROW_TILE, 2, 2)
+
+
+## `.OAMData_RadioTuningKnob`, which is the same tile three times over.
+func _knob_image() -> Image:
+	return _icon(KNOB_TILE, 1, KNOB_TILES, true)
+
+
+## A block of object tiles out of the Pokegear's own sprite sheet, coloured
+## through the overworld's first palette the way every icon on these screens is.
+## Colour zero is transparent, which is what lets one sit over the card.
+func _icon(first: int, columns: int, rows: int, repeat: bool = false) -> Image:
+	var size := Vector2i(columns, rows) * Gen2TownMapPage.TILE
+	var out := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
+	out.fill(Color(0, 0, 0, 0))
+	var tiles: PackedByteArray = _data.tile_indices("pokegear_sprites") if _data != null \
+		else PackedByteArray()
+	var palette: PackedColorArray = _data.overworld_sprite_palette(0, _time_of_day) \
+		if _data != null else PackedColorArray()
+	if tiles.is_empty() or palette.is_empty():
+		return out
+	var width: int = tiles.size() / Gen2TownMapPage.TILE
+	for row: int in rows:
+		for column: int in columns:
+			var tile: int = first if repeat else first + row * columns + column
+			for y: int in Gen2TownMapPage.TILE:
+				for x: int in Gen2TownMapPage.TILE:
+					var index: int = tiles[
+						y * width + tile * Gen2TownMapPage.TILE + x
+					]
+					if index == 0:
+						continue
+					out.set_pixel(
+						column * Gen2TownMapPage.TILE + x,
+						row * Gen2TownMapPage.TILE + y,
+						palette[clampi(index, 0, palette.size() - 1)]
+					)
+	return out

--- a/game/world/pokegear_screen.gd.uid
+++ b/game/world/pokegear_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://csi1hm6pdce4u

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -44,6 +44,12 @@ const OBJECT_PALETTE: int = 0
 ## takes `PAL_OW_RED` whoever the player is; only the dex area asks.
 const OBJECT_PALETTE_FEMALE: int = 1
 
+## `InitPokegearModeIndicatorArrow`, which the Pokegear spawns on every card
+## including this one. Its position is [Gen2PokegearScreen]'s, at the MAP card's
+## own entry in `AnimatePokegearModeIndicatorArrow.XCoords`.
+const ARROW_TILE: int = 0x00
+const ARROW_CARD: StringName = &"map"
+
 ## `PokedexNestIconGFX`, one 8x8 object tile whose OAM position is the landmark's
 ## own coordinates less four, which centres it on the point.
 const NEST_TILE: int = 0
@@ -74,6 +80,8 @@ var _open: bool = false
 var _field: Control = null
 var _background: TextureRect = null
 var _cursor_icon: TextureRect = null
+## The Pokegear's mode arrow, which is up on the card and on no other screen.
+var _arrow: TextureRect = null
 ## `.pressedA`'s own answer, which `_FlyMap` returns in `e`: the chosen spawn, or
 ## -1 for the `ld a, -1` a B press leaves.
 var _chosen_spawn: int = -1
@@ -302,6 +310,16 @@ func render() -> Image:
 		return out
 	if _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
 		return _render_dex_area(out)
+	if _map.screen == Gen2TownMap.SCREEN_POKEGEAR_CARD:
+		out.blend_rect(
+			_icon_from("pokegear_sprites", ARROW_TILE),
+			Rect2i(Vector2i.ZERO, Vector2i(ICON_SIZE, ICON_SIZE)),
+			Gen2PokegearScreen.ARROW_AT + Vector2i(
+				Gen2PokegearScreen.ARROW_CARD_STRIDE
+				* Gen2PokegearScreen.ARROW_CARDS.find(ARROW_CARD),
+				0
+			)
+		)
 	for object: Array in [
 		[_cursor_image(), cursor_landmark()], [_player_image(), _map.player_landmark],
 	]:
@@ -371,6 +389,7 @@ func _build() -> void:
 	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	screen.display(_field)
 	_background = _sprite()
+	_arrow = _sprite()
 	_cursor_icon = _sprite()
 	_player_icon = _sprite()
 
@@ -387,6 +406,7 @@ func _refresh() -> void:
 	if _background != null:
 		_background.texture = ImageTexture.create_from_image(_background_image())
 		_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_refresh_arrow()
 	if _map != null and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
 		_refresh_objects()
 		return
@@ -417,6 +437,24 @@ func _refresh_objects() -> void:
 			continue
 		node.position = Vector2(_nest_position(landmark))
 		node.texture = ImageTexture.create_from_image(icon)
+
+
+## Up only on the Pokegear's own card: `OverworldTownMap`, the fly map and the
+## dex area each open the region map without a Pokegear around it.
+func _refresh_arrow() -> void:
+	if _arrow == null:
+		return
+	_arrow.visible = _map != null and _map.screen == Gen2TownMap.SCREEN_POKEGEAR_CARD
+	if not _arrow.visible:
+		return
+	_arrow.position = Vector2(
+		Gen2PokegearScreen.ARROW_AT + Vector2i(
+			Gen2PokegearScreen.ARROW_CARD_STRIDE
+			* Gen2PokegearScreen.ARROW_CARDS.find(ARROW_CARD),
+			0
+		)
+	)
+	_arrow.texture = ImageTexture.create_from_image(_icon_from("pokegear_sprites", ARROW_TILE))
 
 
 func _background_image() -> Image:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -17,7 +17,7 @@ const SUCCESS: Color = Color("#7bd89a")
 const ERROR: Color = Color("#ef8a8a")
 
 enum MODE {
-	MENU, MART, PHONE, PHONE_LIST, AUDIO, POKEGEAR, RADIO, TOWN_MAP, CLOCK,
+	MENU, MART, PHONE, AUDIO, POKEGEAR, TOWN_MAP, CARD,
 	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT,
 }
 
@@ -53,9 +53,11 @@ var _mart_entries: Array = []
 var _mart_quantity: int = 1
 var _mart_purchased: bool = false
 var _apricorns: Gen2WorldApricorn = null
-var _phone_entries: Array = []
 var _pokegear_cards: Array = []
 var _town_map: Gen2TownMapScreen = null
+## The clock, phone or radio card while one is open, which is a hardware-
+## resolution screen over this panel the way the region map is.
+var _pokegear: Gen2PokegearScreen = null
 ## Whether the region map on screen is the fly map, which answers a spawn rather
 ## than closing back into the card list.
 var _fly_map: bool = false
@@ -145,23 +147,17 @@ func is_active() -> bool:
 	return _mode >= 0
 
 
-## Opens the Pokegear phone list. Contact order follows the cartridge table,
-## and only registered numbers are selectable.
+## Opens the Pokegear straight onto its PHONE card, which is what the overworld's
+## own phone shortcut reaches.
 func open_phone_list(
 	world: Gen2WorldAPI,
 	data: GameData,
 	save: Gen2SaveData = null,
 	persist: bool = false
 ) -> bool:
-	_world = world
-	_data = data
-	_save = save
-	_persist = persist
-	if _world == null or _data == null:
-		_show_error("Phone has no world or cartridge cache.")
+	if not _open_pokegear(world, data, save, persist, "Phone"):
 		return false
-	_phone_entries = _world.registered_phone_contacts()
-	_open_phone_list()
+	_open_card(Gen2PokegearScreen.CARD_PHONE)
 	return true
 
 
@@ -173,12 +169,22 @@ func open_pokegear(
 	save: Gen2SaveData = null,
 	persist: bool = false
 ) -> bool:
+	if not _open_pokegear(world, data, save, persist, "Pokegear"):
+		return false
+	_open_pokegear_cards()
+	return true
+
+
+## `wPokegearFlags`: which cards the player owns, in the jumptable's own order.
+func _open_pokegear(
+	world: Gen2WorldAPI, data: GameData, save: Gen2SaveData, persist: bool, label: String
+) -> bool:
 	_world = world
 	_data = data
 	_save = save
 	_persist = persist
 	if _world == null or _data == null:
-		_show_error("Pokegear has no world or cartridge cache.")
+		_show_error("%s has no world or cartridge cache." % label)
 		return false
 	_pokegear_cards = []
 	for card: Dictionary in POKEGEAR_CARDS:
@@ -187,7 +193,6 @@ func open_pokegear(
 		if not owned:
 			continue
 		_pokegear_cards.append(card)
-	_open_pokegear_cards()
 	return true
 
 
@@ -198,6 +203,8 @@ func handle_button(button: int) -> bool:
 	if _mode == MODE.APRICORN:
 		_press_apricorns(button)
 		return true
+	if _mode == MODE.CARD and _pokegear != null:
+		return _pokegear.handle_button(button)
 	if Gen2Button.is_direction(button):
 		_move_direction(Gen2Button.vector(button))
 		return true
@@ -626,16 +633,6 @@ func _open_phone(request: Dictionary, data: Dictionary) -> void:
 	_render_options(["Continue"])
 
 
-func _open_phone_list() -> void:
-	_mode = MODE.PHONE_LIST
-	_cursor = 0
-	_title.text = "PHONE"
-	_summary.text = "Registered numbers"
-	_status.text = "Choose a contact to call." if not _phone_entries.is_empty() else "No registered numbers."
-	_footer.text = "D-pad: move    A: call    B: close"
-	_render_options()
-
-
 func _open_pokegear_cards() -> void:
 	_mode = MODE.POKEGEAR
 	_cursor = 0
@@ -647,37 +644,118 @@ func _open_pokegear_cards() -> void:
 	_render_options()
 
 
-## The source clock card clears its inner box, prints the weekday and renders a
-## 12-hour clock with the AM/PM label. The host keeps the card list as its
-## navigation shell, then presents the card as its own read-only page.
-func _open_clock_card() -> void:
-	_mode = MODE.CLOCK
+## The clock, phone and radio cards, each on the hardware's own tile grid the way
+## the MAP card is. The card list stays this panel's, so a card is opened over it
+## and closing one comes back to the list.
+func _open_card(card: StringName) -> void:
+	_mode = MODE.CARD
 	_cursor = 0
-	_title.text = "CLOCK"
-	var clock: Dictionary = _world.world_clock()
-	var hour24: int = int(clock.get("hour", 0))
-	var hour12: int = hour24 % 12
-	if hour12 == 0:
-		hour12 = 12
-	var period: String = "AM" if hour24 < 12 else "PM"
-	var weekday: String = ["SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY"][
-		posmod(int(clock.get("day", 0)), 7)
-	]
-	_summary.text = "%s\n\n%02d:%02d %s" % [
-		weekday, hour12, int(clock.get("minute", 0)), period,
-	]
-	_status.text = "Time of day: %s" % _time_of_day_label(hour24)
-	_status.add_theme_color_override("font_color", TEXT)
-	_footer.text = "B: back to cards"
-	_render_options(["CLOCK CARD"])
+	_panel.visible = false
+	_pokegear = Gen2PokegearScreen.new()
+	_pokegear.z_index = 5
+	add_child(_pokegear)
+	_pokegear.closed.connect(_on_card_closed)
+	_pokegear.switched.connect(_on_card_switched)
+	_pokegear.tuned.connect(_on_card_tuned)
+	_pokegear.called.connect(_on_card_called)
+	_pokegear.deleted.connect(_on_card_deleted)
+	var owned: Array = []
+	for entry: Dictionary in _pokegear_cards:
+		owned.append(StringName(entry.get("card", &"")))
+	var text: String = ""
+	if card == Gen2PokegearScreen.CARD_CLOCK:
+		text = _data.pokegear_text("press_button")
+	elif card == Gen2PokegearScreen.CARD_PHONE:
+		text = _data.pokegear_text("ask_who")
+	if not _pokegear.open(
+		_data, card, owned, text, _data.pokegear_text("ask_delete"),
+		_world.map_time_of_day()
+	):
+		_on_card_closed()
+		return
+	_refresh_card()
 
 
-func _time_of_day_label(hour24: int) -> String:
-	if hour24 < Gen2WorldClock.MORN_START or hour24 >= Gen2WorldClock.NITE_START:
-		return "NIGHT"
-	if hour24 < Gen2WorldClock.DAY_START:
-		return "MORNING"
-	return "DAY"
+## What the open card reads off the world, which is all of its display state.
+func _refresh_card() -> void:
+	if _pokegear == null:
+		return
+	match _pokegear.card():
+		Gen2PokegearScreen.CARD_CLOCK:
+			var clock: Dictionary = _world.world_clock()
+			_pokegear.set_clock(
+				int(clock.get("day", 0)), int(clock.get("hour", 0)),
+				int(clock.get("minute", 0))
+			)
+		Gen2PokegearScreen.CARD_RADIO:
+			var tuned: Dictionary = _world.radio_station()
+			_pokegear.set_radio(
+				_world.state.radio_knob(),
+				String(tuned.get("name", "")) if bool(tuned.get("ok", false)) else ""
+			)
+		Gen2PokegearScreen.CARD_PHONE:
+			_pokegear.set_contacts(
+				_world.registered_phone_contacts(),
+				Gen2WorldPhoneHost.map_has_phone_service(_world.current_map)
+			)
+
+
+## `Pokegear_SwitchPage`: the next or previous card the player owns, with no wrap
+## at either end. The clock is always there and is where the Pokegear opens.
+func _on_card_switched(direction: int) -> void:
+	var order: Array = []
+	for entry: Dictionary in _pokegear_cards:
+		order.append(StringName(entry.get("card", &"")))
+	var at: int = order.find(_pokegear.card()) + direction
+	if at < 0 or at >= order.size():
+		return
+	var card: StringName = order[at]
+	if card == &"map":
+		# The MAP card is the region map's own screen, and closing it comes back
+		# to the card list rather than to the card this left.
+		_close_card()
+		_open_town_map(false)
+		return
+	_close_card()
+	_open_card(card)
+
+
+func _on_card_tuned(knob: int) -> void:
+	_world.tune_radio(knob)
+	_refresh_card()
+
+
+func _on_card_called(contact: int) -> void:
+	var results: Array = _world.request_outgoing_phone_call(contact)
+	_close_card()
+	_panel.visible = true
+	_mode = -1
+	completed.emit(results)
+
+
+## `PokegearPhone_DeletePhoneNumber`, which clears the slot and closes the gap
+## behind it. The list here is a set, so dropping the contact is the whole of it.
+func _on_card_deleted(contact: int) -> void:
+	var changed: Dictionary = _world.state.apply_changes({}, {}, {
+		"phone_contacts": {contact: false},
+	})
+	if bool(changed.get("ok", false)):
+		_refresh_card()
+
+
+func _on_card_closed() -> void:
+	if _pokegear != null and _pokegear.card() == Gen2PokegearScreen.CARD_RADIO:
+		_world.close_radio()
+	_close_card()
+	_panel.visible = true
+	_open_pokegear_cards()
+
+
+func _close_card() -> void:
+	if _pokegear == null:
+		return
+	_pokegear.queue_free()
+	_pokegear = null
 
 
 ## `_FlyMap` opened as an overlay of its own: the region map with the flypoint
@@ -770,43 +848,6 @@ func _on_town_map_closed() -> void:
 	completed.emit([])
 
 
-## The radio card. Left and right are the tuning knob, which is the whole of the
-## card's input: the source has no confirm on a station.
-func _open_radio() -> void:
-	_mode = MODE.RADIO
-	_cursor = 0
-	_title.text = "RADIO"
-	_refresh_radio()
-	_footer.text = "Left and right: tune    B: close"
-
-
-func _refresh_radio() -> void:
-	var tuned: Dictionary = _world.radio_station()
-	_summary.text = "%.1f MHz" % float(tuned.get("frequency", 0.0))
-	if bool(tuned.get("ok", false)):
-		_status.text = String(tuned.get("name", ""))
-		_status.add_theme_color_override("font_color", SUCCESS)
-	else:
-		# NoRadioName blanks the label rather than saying anything.
-		_status.text = ""
-		_status.add_theme_color_override("font_color", MUTED)
-	_render_options([_radio_dial()])
-
-
-## The dial as the knob positions it can stop on, so a player can see where the
-## stations sit without a drawn tuner.
-func _radio_dial() -> String:
-	var dial: String = ""
-	for knob: int in Gen2WorldRadio.knob_values():
-		dial += "|" if knob == _world.state.radio_knob() else "."
-	return dial
-
-
-func _tune_radio(step: int) -> void:
-	_world.tune_radio(_world.state.radio_knob() + step * Gen2WorldRadio.KNOB_STEP)
-	_refresh_radio()
-
-
 func _open_audio(request: Dictionary, record: Dictionary) -> void:
 	_mode = MODE.AUDIO
 	_cursor = 0
@@ -847,10 +888,6 @@ func _move_direction(direction: Vector2i) -> void:
 		return
 	if _mode == MODE.MART and direction.x != 0:
 		_change_mart_quantity(direction.x)
-		return
-	if _mode == MODE.RADIO:
-		if direction.x != 0:
-			_tune_radio(direction.x)
 		return
 	if _mode == MODE.PC_ITEM_LIST and direction.x != 0:
 		_change_pc_quantity(direction.x)
@@ -915,29 +952,11 @@ func _confirm() -> void:
 			_status.text = "%s is not implemented." % String(card.get("name", ""))
 			_status.add_theme_color_override("font_color", ERROR)
 			return
-		match StringName(card.get("card", &"")):
-			&"map":
-				_open_town_map(false)
-			&"radio":
-				_open_radio()
-			&"phone":
-				_phone_entries = _world.registered_phone_contacts()
-				_open_phone_list()
-			&"clock":
-				_open_clock_card()
-		return
-	if _mode == MODE.CLOCK:
-		return
-	if _mode == MODE.RADIO:
-		return
-	if _mode == MODE.PHONE_LIST:
-		if _phone_entries.is_empty():
-			_status.text = "No registered numbers."
-			return
-		var contact: Dictionary = _phone_entries[_cursor]
-		var results: Array = _world.request_outgoing_phone_call(int(contact.get("index", -1)))
-		_mode = -1
-		completed.emit(results)
+		var chosen: StringName = StringName(card.get("card", &""))
+		if chosen == &"map":
+			_open_town_map(false)
+		else:
+			_open_card(chosen)
 		return
 	if _mode in [MODE.PHONE, MODE.AUDIO]:
 		_finish_runtime({"ok": true, "script_value": 1})
@@ -961,20 +980,9 @@ func _cancel() -> void:
 		_finish_input_cancelled()
 	elif _mode == MODE.MART:
 		_finish_runtime({"ok": true, "script_value": 1 if _mart_purchased else 0, "cancelled": true})
-	elif _mode == MODE.RADIO:
-		_world.close_radio()
-		_open_pokegear_cards()
-	elif _mode == MODE.CLOCK:
-		_open_pokegear_cards()
 	elif _mode == MODE.POKEGEAR:
 		_mode = -1
 		completed.emit([])
-	elif _mode == MODE.PHONE_LIST:
-		if _pokegear_cards.is_empty():
-			_mode = -1
-			completed.emit([])
-		else:
-			_open_pokegear_cards()
 	elif _mode in [MODE.PHONE, MODE.AUDIO]:
 		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
 	elif _mode == MODE.TOWN_MAP and _town_map != null:
@@ -1021,7 +1029,6 @@ func _render_options(override: Array = []) -> void:
 		parent = grid
 	var values: Array = override if not override.is_empty() else (
 		_choices if _mode == MODE.MENU else _mart_entries if _mode == MODE.MART \
-		else _phone_entries if _mode == MODE.PHONE_LIST \
 		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS] \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else _pokegear_cards if _mode == MODE.POKEGEAR else ["Continue"]
@@ -1059,9 +1066,6 @@ func _render_options(override: Array = []) -> void:
 			var stack: int = int((value as Dictionary).get("quantity", 0))
 			name = "%s    x%d of %d" % [name, _pc_quantity, stack] if index == _cursor \
 				else "%s    x%d" % [name, stack]
-		if value is Dictionary and _mode == MODE.PHONE_LIST:
-			if int((value as Dictionary).get("trainer_class", 0)) > 0:
-				name = "%s %d" % [name, int((value as Dictionary).get("trainer_number", 0))]
 		label.text = ("> " if index == _cursor else "  ") + name
 		label.add_theme_color_override("font_color", ACCENT if index == _cursor else TEXT)
 		label.add_theme_font_size_override("font_size", 18)
@@ -1075,8 +1079,6 @@ func _option_count() -> int:
 		return _menu.options.size() if _menu != null else _choices.size()
 	if _mode == MODE.MART:
 		return _mart_entries.size()
-	if _mode == MODE.PHONE_LIST:
-		return _phone_entries.size()
 	if _mode == MODE.POKEGEAR:
 		return _pokegear_cards.size()
 	if _mode in [MODE.PC, MODE.PC_ITEMS]:

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -259,9 +259,13 @@ func test_phone_list_shows_registered_numbers_and_can_close() -> void:
 	await get_tree().process_frame
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_eq(host._title.text, "PHONE")
-	assert_eq(host._summary.text, "Registered numbers")
-	assert_eq(host.selected_index(), 0)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.CARD)
+	assert_eq(host._pokegear.card(), Gen2PokegearScreen.CARD_PHONE)
+	assert_eq(host._pokegear.selected_contact(), 0)
+	## B leaves the card for the Pokegear's own card list, and the second one
+	## closes the device.
+	assert_true(host.handle_button(Gen2Button.B))
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
 	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
@@ -279,6 +283,9 @@ func test_phone_list_starts_the_source_timed_outgoing_ring() -> void:
 	await get_tree().process_frame
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
+	## The first A opens `PokegearPhoneContactSubmenu`, whose own first row is
+	## CALL.
+	assert_true(host.handle_button(Gen2Button.A))
 	assert_true(host.handle_button(Gen2Button.A))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
@@ -290,6 +297,35 @@ func test_phone_list_starts_the_source_timed_outgoing_ring() -> void:
 	await get_tree().process_frame
 	assert_true(_world_screen._world.script_input_waiting())
 	assert_eq(_world_screen._world.pending_script_input()["text"], "PHONE SCRIPT")
+
+
+## `PokegearPhoneContactSubmenu`'s DELETE row and the yes/no box behind it:
+## MOM is one of the two `CheckCanDeletePhoneNumber` refuses, so the contact the
+## fixture registers is offered all three rows and answering YES drops it.
+func test_the_phone_submenu_deletes_the_chosen_contact() -> void:
+	_write_phone_request()
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world()
+	assert_true(_world_screen._world.state.apply_changes({}, {}, {
+		"phone_contacts": {0: true},
+	})["ok"])
+	_world_screen._open_phone_list()
+	await get_tree().process_frame
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._pokegear._submenu, ["CALL", "DELETE", "CANCEL"])
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_true(host._pokegear._asking_delete)
+	## The card's own box carries `PokegearAskDeleteText` while it is up.
+	assert_eq(
+		_row_text(host._pokegear._tilemap(), Gen2TownMapPage.CARD_TEXT_AT, 19),
+		_data.pokegear_text("ask_delete")
+	)
+	host.handle_button(Gen2Button.A)
+	assert_false(host._pokegear._asking_delete)
+	assert_false(_world_screen._world.state.has_phone_contact(0))
+	assert_eq(host._pokegear.selected_contact(), -1)
 
 
 func test_pokegear_clock_card_renders_source_time_and_returns_to_cards() -> void:
@@ -304,12 +340,24 @@ func test_pokegear_clock_card_renders_source_time_and_returns_to_cards() -> void
 	assert_not_null(host)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
 	assert_true(host.handle_button(Gen2Button.A))
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.CLOCK)
-	assert_true(host._summary.text.contains("WEDNESDAY"))
-	assert_true(host._summary.text.contains("12:07 AM"))
-	assert_true(host._status.text.contains("NIGHT"))
-	assert_true(host.handle_button(Gen2Button.B))
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.CARD)
+	assert_eq(host._pokegear.card(), Gen2PokegearScreen.CARD_CLOCK)
+	## `Pokegear_UpdateClock` writes the weekday and `PrintHoursMins`' reading
+	## into the card's own tilemap, which is what the screen draws from.
+	var map: PackedInt32Array = host._pokegear._tilemap()
+	assert_eq(_row_text(map, Gen2TownMapPage.CLOCK_DAY_AT, 9), "WEDNESDAY")
+	assert_eq(_row_text(map, Gen2TownMapPage.CLOCK_TIME_AT, 8), "12:07 AM")
+	## Any button quits the clock card, which lands back on the card list.
+	assert_true(host.handle_button(Gen2Button.A))
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
+
+
+## A run of a card's tilemap read back as text, which is what the page printed.
+func _row_text(map: PackedInt32Array, at: Vector2i, length: int) -> String:
+	var out: String = ""
+	for column: int in length:
+		out += Gen2Text.character(map[at.y * Gen2TownMapPage.COLUMNS + at.x + column])
+	return out
 
 
 func test_audio_request_decodes_and_starts_the_runtime_player() -> void:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -722,6 +722,14 @@ static func _town_map() -> Dictionary:
 		landmarks.append({"x": index, "y": index, "codes": _codes("SPECIAL")})
 	landmarks[1] = {"x": 140, "y": 100, "codes": _codes("NEW BARK<BSP>TOWN")}
 	landmarks[2] = {"x": 128, "y": 100, "codes": _codes("ROUTE 29")}
+	## The three card tilemaps, each a flat fill of the Pokegear sheet's own
+	## blank: a card test reads what the page draws over one, never the art.
+	var cards: Dictionary = {}
+	for card: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var cells: Array = []
+		for cell: int in RomLayout.POKEGEAR_CARD_CELLS:
+			cells.append(Gen2TownMapPage.CARD_BLANK_TILE)
+		cards[card] = cells
 	return {
 		"johto": johto,
 		"kanto": kanto,
@@ -729,6 +737,11 @@ static func _town_map() -> Dictionary:
 		"palettes": palettes,
 		"palettes_female": palettes_female,
 		"landmarks": landmarks,
+		"cards": cards,
+		"card_texts": {
+			"ask_who": "WHOM TO CALL?", "press_button": "PRESS A BUTTON",
+			"ask_delete": "DELETE THIS NUMBER?",
+		},
 	}
 
 

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -1221,3 +1221,69 @@ func test_a_word_with_a_byte_outside_the_alphabet_fails() -> void:
 	data[run] = RomLayout.FIRST_UNOWN_CHAR + RomLayout.UNOWN_FORMS
 	assert_false(RomImporter.verify_unown_words(_rom(data), _layout)["ok"])
 	assert_true(RomImporter.read_unown_words(_rom(data), _layout).is_empty())
+
+
+## `Pokegear_LoadTilemapRLE`, whose pairs are the tile first and its run length
+## second, the opposite way round from the comment above it. The three cards are
+## one run, so a reader that took them the other way round would decode the first
+## card into something the wrong length and take the other two with it.
+func test_the_pokegear_cards_decode_as_tile_then_length() -> void:
+	var data: PackedByteArray = _dump()
+	_write(data, int((_layout["town_map"] as Dictionary)["cards"]), _cards())
+	var cards: Dictionary = RomImporter.read_pokegear_cards(_rom(data), _layout)
+	assert_eq(cards.size(), RomLayout.POKEGEAR_CARD_ORDER.size())
+	for name: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var cells: PackedByteArray = cards[name]
+		assert_eq(cells.size(), RomLayout.POKEGEAR_CARD_CELLS)
+		assert_eq(cells[0], Gen2TownMapPage.CARD_BLANK_TILE)
+
+
+## A card whose runs do not add up to a screen is a wrong offset, and the whole
+## walk answers empty rather than three cards of the wrong length.
+func test_a_short_pokegear_card_refuses_the_whole_run() -> void:
+	var data: PackedByteArray = _dump()
+	var at: int = int((_layout["town_map"] as Dictionary)["cards"])
+	_write(data, at, _cards())
+	data[at + 1] -= 1
+	assert_true(RomImporter.read_pokegear_cards(_rom(data), _layout).is_empty())
+
+
+## The Pokegear's own two texts, read one after the other from a single offset:
+## each decode says where it ended, which is where the next begins.
+func test_the_pokegear_texts_are_read_in_sequence() -> void:
+	var data: PackedByteArray = _dump()
+	var at: int = int((_layout["town_map"] as Dictionary)["card_texts"])
+	var offset: int = at
+	for words: String in ["WHOM?", "PRESS", "DELETE?"]:
+		_write(data, offset, _text(words))
+		offset += _text(words).size()
+	var texts: Dictionary = RomImporter.read_pokegear_texts(_rom(data), _layout)
+	assert_eq(
+		texts,
+		{"ask_who": "WHOM?", "press_button": "PRESS", "ask_delete": "DELETE?"}
+	)
+	data[at] = 0xFF
+	assert_true(RomImporter.read_pokegear_texts(_rom(data), _layout).is_empty())
+
+
+## `text "..." / done`: the start command, the characters and `<DONE>`.
+func _text(words: String) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray([Gen2TextStream.TX_START])
+	out.append_array(Gen2Text.encode(words))
+	out.append(Gen2TextStream.CHAR_DONE)
+	return out
+
+
+## Three cards of one tile each, at the source's own encoding: the run length is
+## a byte, so a screen takes two pairs.
+func _cards() -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	for _card: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var left: int = RomLayout.POKEGEAR_CARD_CELLS
+		while left > 0:
+			var run: int = mini(left, 0xFF)
+			out.append(Gen2TownMapPage.CARD_BLANK_TILE)
+			out.append(run)
+			left -= run
+		out.append(RomLayout.POKEGEAR_CARD_TERMINATOR)
+	return out

--- a/tests/unit/test_town_map_page.gd
+++ b/tests/unit/test_town_map_page.gd
@@ -145,3 +145,128 @@ func test_the_dex_area_header_replaces_the_name_box() -> void:
 	assert_eq(_at(map, Vector2i(10, 1)), Gen2TownMapPage.TOWN_MAP_FRAME_TOP_TILE)
 	assert_eq(_at(map, Vector2i(19, 1)), Gen2TownMapPage.TOWN_MAP_FRAME_RIGHT_TILE)
 	assert_eq(_at(map, Vector2i(0, 2)), Fixture.TOWN_MAP_JOHTO_TILE)
+
+
+## `Textbox`'s own border codes, which every card draws under itself and which
+## `compose` resolves through the chosen frame rather than through the font.
+func test_every_card_draws_the_source_text_box() -> void:
+	assert_true(_page.cards_ready())
+	for map: PackedInt32Array in [
+		_page.clock_tilemap([], 0, 0, 0, ""),
+		_page.radio_tilemap([], ""),
+		_page.phone_tilemap([], [], 0, true, ""),
+	]:
+		assert_eq(
+			_at(map, Gen2TownMapPage.CARD_TEXTBOX_AT),
+			RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_LEFT
+		)
+		assert_eq(
+			_at(map, Vector2i(19, 17)),
+			RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_BOTTOM_RIGHT
+		)
+		assert_eq(_at(map, Vector2i(1, 13)), Gen2TownMapPage.BLANK_TILE)
+
+
+## `Pokegear_FinishTilemap` runs after every card's own jumptable entry, so the
+## icon row is on all four screens rather than on the MAP card alone.
+func test_a_card_carries_the_icon_row() -> void:
+	var map: PackedInt32Array = _page.clock_tilemap([&"map", &"radio"], 0, 0, 0, "")
+	assert_eq(
+		_at(map, Gen2TownMapPage.CARD_POKEGEAR_ICON_AT),
+		Gen2TownMapPage.CARD_POKEGEAR_ICON_TILE
+	)
+	assert_eq(_at(map, Vector2i(2, 0)), 0x40)
+	assert_eq(_at(map, Vector2i(6, 0)), 0x42)
+	## The PHONE card is not owned here, so its two cells keep the blank
+	## `Pokegear_FinishTilemap` filled them with.
+	assert_eq(_at(map, Vector2i(4, 0)), Gen2TownMapPage.CARD_BLANK_TILE)
+
+
+## `PrintHoursMins`: twelve-hour, the hour space-padded and the minute not, and
+## both midnight and noon printed as twelve.
+func test_the_clock_card_prints_the_source_reading() -> void:
+	assert_eq(Gen2TownMapPage._clock_reading(0, 7), "12:07 AM")
+	assert_eq(Gen2TownMapPage._clock_reading(12, 0), "12:00 PM")
+	assert_eq(Gen2TownMapPage._clock_reading(9, 30), " 9:30 AM")
+	assert_eq(Gen2TownMapPage._clock_reading(23, 59), "11:59 PM")
+	var map: PackedInt32Array = _page.clock_tilemap([], 3, 13, 5, "")
+	assert_eq(_text(map, Gen2TownMapPage.CLOCK_DAY_AT, 9), "WEDNESDAY")
+	assert_eq(_text(map, Gen2TownMapPage.CLOCK_TIME_AT, 8), " 1:05 PM")
+	assert_eq(_text(map, Gen2TownMapPage.CLOCK_SWITCH_AT, 8), " SWITCH▶")
+
+
+## `UpdateRadioStation` places a station's name and `NoRadioStation` places
+## nothing, which is a dial between two channels.
+func test_the_radio_card_prints_only_a_tuned_station() -> void:
+	assert_eq(
+		_text(_page.radio_tilemap([], "LUCKY CHANNEL"), Gen2TownMapPage.RADIO_STATION_AT, 13),
+		"LUCKY CHANNEL"
+	)
+	## The card's own art is left where a name would go, which in the fixture is
+	## its flat fill.
+	assert_eq(
+		_at(_page.radio_tilemap([], ""), Gen2TownMapPage.RADIO_STATION_AT),
+		Gen2TownMapPage.CARD_BLANK_TILE
+	)
+
+
+## `GetCallerName`: a trainer's own name with a colon and their class on the line
+## below, everyone else on one line, and `.PlacePhoneBars`' fourth tile only
+## where there is service.
+func test_the_phone_card_lists_callers_the_source_way() -> void:
+	var rows: Array = [
+		{"name": "MOM:"}, {"name": "JACK", "class": "SCHOOLBOY"},
+	]
+	var map: PackedInt32Array = _page.phone_tilemap([], rows, 1, true, "")
+	assert_eq(_text(map, Vector2i(Gen2TownMapPage.PHONE_NAME_COLUMN, 4), 4), "MOM:")
+	assert_eq(_text(map, Vector2i(Gen2TownMapPage.PHONE_NAME_COLUMN, 6), 5), "JACK:")
+	assert_eq(_text(map, Vector2i(Gen2TownMapPage.PHONE_CLASS_COLUMN, 7), 9), "SCHOOLBOY")
+	assert_eq(
+		_at(map, Vector2i(Gen2TownMapPage.PHONE_CURSOR_COLUMN, 6)),
+		Gen2TownMapPage.PHONE_CURSOR_CODE
+	)
+	assert_eq(_at(map, Gen2TownMapPage.PHONE_SERVICE_AT), Gen2TownMapPage.PHONE_SERVICE_TILE)
+	assert_eq(
+		_at(_page.phone_tilemap([], rows, 0, false, ""), Gen2TownMapPage.PHONE_SERVICE_AT),
+		Gen2TownMapPage.CARD_BLANK_TILE
+	)
+
+
+## `PokegearPhoneContactSubmenu`: the cursor in the strings' own column, the
+## text one tile right of it, and a two-option box opening two rows lower than a
+## three-option one so both end on the same row.
+func test_the_phone_submenu_sits_where_its_strings_do() -> void:
+	var map: PackedInt32Array = _page.phone_tilemap([], [], 0, true, "")
+	_page.draw_phone_submenu(map, ["CALL", "DELETE", "CANCEL"], 1)
+	assert_eq(_text(map, Vector2i(11, 6), 4), "CALL")
+	assert_eq(_text(map, Vector2i(11, 8), 6), "DELETE")
+	assert_eq(_text(map, Vector2i(11, 10), 6), "CANCEL")
+	assert_eq(
+		_at(map, Vector2i(Gen2TownMapPage.PHONE_SUBMENU_CURSOR_COLUMN, 8)),
+		Gen2TownMapPage.PHONE_CURSOR_CODE
+	)
+	var short_map: PackedInt32Array = _page.phone_tilemap([], [], 0, true, "")
+	_page.draw_phone_submenu(short_map, ["CALL", "CANCEL"], 0)
+	assert_eq(_text(short_map, Vector2i(11, 8), 4), "CALL")
+	assert_eq(_text(short_map, Vector2i(11, 10), 6), "CANCEL")
+
+
+## `YesNoBox`'s `lb bc, SCREEN_WIDTH - 6, 7`, which DELETE opens over the card.
+func test_the_yes_no_box_is_at_the_source_corner() -> void:
+	var map: PackedInt32Array = _page.phone_tilemap([], [], 0, true, "")
+	_page.draw_yes_no(map, 1)
+	assert_eq(
+		_at(map, Vector2i(Gen2TownMapPage.YES_NO_BOX[0], Gen2TownMapPage.YES_NO_BOX[1])),
+		RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_LEFT
+	)
+	assert_eq(_text(map, Vector2i(16, 8), 3), "YES")
+	assert_eq(_text(map, Vector2i(16, 10), 2), "NO")
+	assert_eq(_at(map, Vector2i(15, 10)), Gen2TownMapPage.PHONE_CURSOR_CODE)
+
+
+## A run of the tile map read back as text, which is what the page printed.
+func _text(map: PackedInt32Array, at: Vector2i, length: int) -> String:
+	var out: String = ""
+	for column: int in length:
+		out += Gen2Text.character(_at(map, at + Vector2i(column, 0)))
+	return out

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -10,6 +10,9 @@ var _r: RefCounted = null
 ## and engine/pokegear/pokegear.asm's `_TownMap`, `PokegearMap` and
 ## `TownMap_GetKantoLandmarkLimits`.
 ##
+## The Pokegear's other three cards are swept here too: they are the same VRAM
+## window, the same palettes and the same page.
+##
 ## The real-cartridge counterpart to tests/unit/test_town_map.gd and
 ## test_town_map_page.gd, which use a synthetic cache. What only a real cache can
 ## say is that the 96 landmarks and the two 360-cell maps decoded, that the
@@ -38,6 +41,23 @@ const UNBROKEN_NAME: int = 2
 const ICON_ORIGIN: int = Gen2TownMapScreen.ICON_ORIGIN
 const LANDMARK_SPECIAL: int = 0
 
+## One cell of each card tilemap that no other card has in that place: the clock
+## card's own name-box corner, the phone card's frame, and the radio dial's scale
+## row (gfx/pokegear/clock.tilemap.rle and its two neighbours).
+const CARD_PINS: Array[Array] = [
+	["clock", Vector2i(12, 0), 0x30],
+	["clock", Vector2i(19, 2), 0x33],
+	["phone", Vector2i(0, 2), 0x06],
+	["radio", Vector2i(9, 2), 0x3B],
+]
+
+## `_PokegearAskWhoCallText` and `_PokegearPressButtonText`, whose `line` is the
+## newline a decoded text carries.
+const CARD_TEXTS: Dictionary = {
+	"ask_who": "Whom do you want\nto call?",
+	"press_button": "Press any button\nto exit.",
+}
+
 ## `wShadowOAMEnd - wShadowOAM` in sprites, which is what `.nestloop` would run
 ## past if a species were found at more landmarks than the hardware has objects.
 const SHADOW_OAM_SPRITES: int = 40
@@ -58,6 +78,7 @@ func run(r: RefCounted) -> void:
 		_verify_page(game_id, data, crystal)
 		_verify_nests(game_id, data, crystal)
 		_verify_flypoints(game_id, data)
+		_verify_cards(game_id, data)
 
 
 ## `Flypoints` and `SpawnPoints` against the cache they were imported beside:
@@ -411,3 +432,68 @@ func _verify_nests(game_id: StringName, data: GameData, crystal: bool) -> void:
 			Gen2WorldEncounter.nests(data, species, "kanto", roaming).is_empty(),
 			"%s: roamer %d (species %d) nests in Kanto." % [game_id, index, species]
 		)
+
+
+## The clock, phone and radio cards on a real cache: each RLE tilemap decoded to
+## a whole screen out of the two sheets, both Pokegear texts as the source's own
+## words, and the page drawing all three. The tilemaps and the texts are byte
+## identical on the three cartridges, so the pins below are the same everywhere.
+func _verify_cards(game_id: StringName, data: GameData) -> void:
+	var page: Gen2TownMapPage = Gen2TownMapPage.from_data(data)
+	if not _r.check(
+		page != null and page.cards_ready(),
+		"%s: the cache holds no Pokegear card tilemaps." % game_id
+	):
+		return
+	for card: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var cells: PackedByteArray = data.pokegear_card(StringName(card))
+		if not _r.check(
+			cells.size() == RomLayout.POKEGEAR_CARD_CELLS,
+			"%s: the %s card is %d cells, wanted %d." % [
+				game_id, card, cells.size(), RomLayout.POKEGEAR_CARD_CELLS,
+			]
+		):
+			continue
+		for cell: int in cells:
+			if not _r.check(
+				cell < RomLayout.POKEGEAR_FIRST_TILE + RomLayout.POKEGEAR_TILES
+					or cell == Gen2TownMapPage.BLANK_TILE,
+				"%s: the %s card names tile $%02X, past its sheets." % [game_id, card, cell]
+			):
+				break
+	for pin: Array in CARD_PINS:
+		var cells: PackedByteArray = data.pokegear_card(StringName(pin[0]))
+		var at: Vector2i = pin[1]
+		var cell: int = int(cells[at.y * Gen2TownMapPage.COLUMNS + at.x])
+		_r.check(
+			cell == int(pin[2]),
+			"%s: the %s card has $%02X at (%d,%d), wanted $%02X." % [
+				game_id, pin[0], cell, at.x, at.y, int(pin[2]),
+			]
+		)
+	for name: String in CARD_TEXTS:
+		_r.check(
+			data.pokegear_text(name) == String(CARD_TEXTS[name]),
+			"%s: Pokegear text %s reads \"%s\"." % [
+				game_id, name, data.pokegear_text(name).replace("\n", "|"),
+			]
+		)
+	## `PrintHoursMins` and `_GearTodayText` on the card the cartridge draws
+	## them on, read back off the tile map the page built.
+	var map: PackedInt32Array = page.clock_tilemap([&"map"], 3, 13, 5, "")
+	_r.check(
+		_card_text(map, Gen2TownMapPage.CLOCK_TIME_AT, 8) == " 1:05 PM",
+		"%s: the clock card reads \"%s\"." % [
+			game_id, _card_text(map, Gen2TownMapPage.CLOCK_TIME_AT, 8),
+		]
+	)
+	print("%s: 3 Pokegear cards of %d cells, %d texts." % [
+		game_id, RomLayout.POKEGEAR_CARD_CELLS, CARD_TEXTS.size(),
+	])
+
+
+func _card_text(map: PackedInt32Array, at: Vector2i, length: int) -> String:
+	var out: String = ""
+	for column: int in length:
+		out += Gen2Text.character(map[at.y * Gen2TownMapPage.COLUMNS + at.x + column])
+	return out

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -3,13 +3,15 @@ extends SceneTree
 ## Captures the region map against a real imported cache.
 ##
 ##   Godot --headless --path . -s res://tools/preview_town_map.gd -- \
-##       crystal /tmp/map.png [landmark] [town_map|card|area:<species>|fly[:all]] [presses]
+##       crystal /tmp/map.png [landmark] [town_map|card|clock|phone|radio|area:<species>|fly[:all]] [presses]
 ##
 ## [landmark] is `TownMap_GetCurrentLandmark`'s answer, which picks the region and
 ## where the player icon stands; `card` draws the Pokegear's own MAP frame instead
 ## of `_TownMap`'s corner box, `area:19` draws `Pokedex_GetArea` for that
 ## species, and `fly` draws `_FlyMap` with its own cursor, `fly:all` with every
-## flypoint visited rather than none. [presses] is a `u,d,l,r,a,b` list driven into the screen before the
+## flypoint visited rather than none. `clock`, `phone` and `radio` are the
+## Pokegear's other three cards, each read off a real world the way the service
+## host reads it. [presses] is a `u,d,l,r,a,b` list driven into the screen before the
 ## shot, which is how a cursor walk is photographed. Three other tokens: `hof`
 ## opens with `STATUSFLAGS_HALL_OF_FAME_F` set, which widens the Kanto window past
 ## Victory Road and is what lets the dex area reach Kanto at all; `sel` and `rel`
@@ -18,6 +20,11 @@ extends SceneTree
 ##
 ## Headless: the screen composes into an [Image] rather than through a viewport,
 ## so no window and no settle are needed.
+
+## Where a card preview's world stands, which is what its clock, dial and contact
+## list are read from.
+const NEW_BARK_GROUP: int = 24
+const NEW_BARK_MAP: int = 7
 
 const BUTTONS: Dictionary = {
 	"u": Gen2Button.UP, "d": Gen2Button.DOWN,
@@ -31,7 +38,7 @@ func _initialize() -> void:
 	if args.size() < 2:
 		push_error(
 			"Usage: preview_town_map.gd -- <game> <output.png> [landmark] "
-			+ "[town_map|card|area:<species>|fly[:all]] [presses]"
+			+ "[town_map|card|clock|phone|radio|area:<species>|fly[:all]] [presses]"
 		)
 		quit(1)
 		return
@@ -57,6 +64,10 @@ func _initialize() -> void:
 			steps.append(["release", Gen2Button.SELECT])
 		elif BUTTONS.has(key):
 			steps.append(["press", int(BUTTONS[key])])
+
+	if mode in ["clock", "phone", "radio"]:
+		_capture_card(data, StringName(mode), args[1], steps)
+		return
 
 	var host := Gen2TownMapScreen.new()
 	root.add_child(host)
@@ -125,3 +136,71 @@ func _open(
 		Gen2TownMap.SCREEN_POKEGEAR_CARD if mode == "card" else Gen2TownMap.SCREEN_TOWN_MAP,
 		[&"map", &"phone", &"radio"] as Array,
 	)
+
+
+## The Pokegear's other three cards, driven the way the service host drives them:
+## a real world for the clock, the dial and the contact list, and the screen's own
+## presses on top.
+func _capture_card(
+	data: GameData, card: StringName, output: String, steps: Array
+) -> void:
+	# The phone card is a list, so the preview's world carries a full one: ten
+	# contacts from the first real one, `PHONECONTACT_NONE` being contact zero.
+	var registered: Dictionary = {}
+	for index: int in range(1, mini(
+		data.world_phone_contact_count(), Gen2WorldState.PHONE_CONTACT_CAPACITY + 1
+	)):
+		registered[index] = true
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, NEW_BARK_GROUP, NEW_BARK_MAP, Vector2i.ZERO,
+		Gen2WorldState.new({}, {}, {}, {}, 0, registered)
+	)
+	var host := Gen2PokegearScreen.new()
+	root.add_child(host)
+	if not host.open(
+		data, card, [&"map", &"phone", &"radio"] as Array, _card_text(data, card),
+		data.pokegear_text("ask_delete")
+	):
+		push_error("The cache holds no Pokegear cards.")
+		quit(1)
+		return
+	host.tuned.connect(func(knob: int) -> void:
+		world.tune_radio(knob)
+		host.set_radio(knob, _station_name(world))
+	)
+	var clock: Dictionary = world.world_clock()
+	host.set_clock(
+		int(clock["day"]), int(clock["hour"]), int(clock["minute"])
+	)
+	host.set_radio(world.state.radio_knob(), _station_name(world))
+	host.set_contacts(
+		world.registered_phone_contacts(),
+		Gen2WorldPhoneHost.map_has_phone_service(world.current_map)
+	)
+	for step: Array in steps:
+		if String(step[0]) == "press":
+			host.handle_button(int(step[1]))
+	var error: Error = host.render().save_png(output)
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [output, error])
+		quit(1)
+		return
+	print("Wrote %s: %s card, %02d:%02d, knob %d %s, %d contacts" % [
+		output, card, int(clock["hour"]), int(clock["minute"]),
+		world.state.radio_knob(), _station_name(world).replace(" ", "_"),
+		world.registered_phone_contacts().size(),
+	])
+	quit(0)
+
+
+static func _card_text(data: GameData, card: StringName) -> String:
+	if card == Gen2PokegearScreen.CARD_CLOCK:
+		return data.pokegear_text("press_button")
+	if card == Gen2PokegearScreen.CARD_PHONE:
+		return data.pokegear_text("ask_who")
+	return ""
+
+
+static func _station_name(world: Gen2WorldAPI) -> String:
+	var tuned: Dictionary = world.radio_station()
+	return String(tuned.get("name", "")) if bool(tuned.get("ok", false)) else ""

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -5,6 +5,7 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/mart.png
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/kurt.png apricorn
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/map.png town_map
+##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/clock.png pokegear a
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/card.png trainer_card
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/oak.png oak_pc
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc
@@ -66,8 +67,11 @@ func _initialize() -> void:
 		for item: int in [0x55, 0x59, 0x5C, 0x5D, 0x61]:
 			items[item] = 6
 	var state := Gen2WorldState.new({}, {}, items, {0: 500})
-	if _kind == &"town_map":
+	if _kind in [&"town_map", &"pokegear"]:
 		state.set_engine_flag(Gen2WorldState.ENGINE_MAP_CARD, true)
+	if _kind == &"pokegear":
+		state.set_engine_flag(Gen2WorldState.ENGINE_PHONE_CARD, true)
+		state.set_engine_flag(Gen2WorldState.ENGINE_RADIO_CARD, true)
 	if _kind == &"unown_dex":
 		state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
 		## What the Ruins of Alph research centre leaves behind: the upgraded
@@ -95,6 +99,10 @@ func _process(_delta: float) -> bool:
 			_screen._open_pokegear()
 			for button: int in [Gen2Button.DOWN, Gen2Button.A]:
 				_screen._service_host.handle_button(button)
+		elif _kind == &"pokegear":
+			# The card list alone: `presses` picks the card, which is the live
+			# path each of the other three is reached by.
+			_screen._open_pokegear()
 		elif _kind == &"trainer_card":
 			_screen._open_trainer_card()
 		elif _kind == &"oak_pc":


### PR DESCRIPTION
The Pokegear's other three cards are now the cartridge's own screens, beside the MAP card that already was.

## Import

`ClockTilemapRLE`, `PhoneTilemapRLE` and `RadioTilemapRLE` are one contiguous 305-byte run directly behind `PokegearSpritesGFX`, byte identical on Gold, Silver and Crystal, so one pinned offset walks all three. `Pokegear_LoadTilemapRLE` reads the tile first and its run length second, the opposite way round from the comment above it; each card decodes to exactly the twelve rows above its text box, which is what checks the offset. The Pokegear's own three texts are read in sequence from a second offset.

Cache format 59 to 60. Re-import all three dumps.

## Drawing

`Gen2TownMapPage` gains the three cards: same VRAM window, same `TownMapPals` palettes, same `Pokegear_FinishTilemap` icon row, plus the text box each card draws under itself in the player's chosen frame.

`Gen2PokegearScreen` hosts them over a `Gen2Screen`, with the two objects `InitPokegearTilemap` spawns: the mode indicator arrow, now drawn on the MAP card as well, and the radio card's tuning knob.

- **Clock**: `Pokegear_UpdateClock`'s cleared face, `_GearTodayText`'s weekday and `PrintHoursMins`' twelve-hour reading, with the `SWITCH` label and `Press any button to exit.`
- **Radio**: `UpdateRadioStation`'s station name, and the knob riding the dial on up and down, which is where `.TuningKnob` reads them.
- **Phone**: `PokegearPhone_UpdateDisplayList`'s four rows over ten slots, a trainer's name over their class, `.PlacePhoneBars`' signal meter, and `PokegearPhoneContactSubmenu`'s CALL/DELETE/CANCEL over `YesNoBox`. `CheckCanDeletePhoneNumber` picks between the two lists, so Mom and Prof. Elm are offered CALL and CANCEL alone.

Nothing in the models moved: the world still owns the clock, the dial and the contact list, and the screen reports a press for the host to answer.

## Checked

| Check | Result |
|---|---|
| `validate.gd -- all` | 46 topics PASS on all three cartridges, exit 0 |
| GUT, both tiers | 2,969 tests over 148 scripts, green |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | 294 steps on Crystal, 291 on Gold and Silver, 16 badges, 0 failures |
| Layout | `Layout verified.` on all three re-imports |

`tools/checks/town_map.gd` sweeps the three tilemaps, their tile range, four content pins and both texts on every cartridge; `tools/preview_town_map.gd` takes `clock`, `phone` and `radio` against a real cache.