### PR TITLE
Draw a chamber wall's Unown word in its own box

### DIFF
--- a/game/render/unown_wall_page.gd
+++ b/game/render/unown_wall_page.gd
@@ -1,0 +1,70 @@
+class_name Gen2UnownWallPage
+extends RefCounted
+
+## `DisplayUnownWords`' box on the hardware tile grid: `MenuBox`'s frame with
+## [Gen2UnownWall]'s 2x2 letter blocks placed in it.
+##
+## The letters come out of the chamber's own tileset strip rather than a font,
+## and wear `PAL_BG_BROWN` whatever the tileset's palette map says about those
+## tile numbers, which is what `_DisplayUnownWords_FillAttr` writes.
+##
+## Node-free: the image is the whole product, so the box can be read back
+## headless.
+
+const TILE: int = Gen2Font.TILE
+
+
+## The box for [param word] as an image of its own size, or null when the cache
+## cannot answer for the tileset or the word holds a character with no tile.
+static func render(
+	data: GameData, tileset: Gen2WorldTileset, map: Gen2WorldMap, word: String,
+	time_of_day: int = Gen2WorldPalette.TIME_MORNING
+) -> Image:
+	if data == null or tileset == null or map == null or word.is_empty():
+		return null
+	var blocks: Array = Gen2UnownWall.blocks(word)
+	if blocks.is_empty():
+		return null
+	var indices: PackedByteArray = data.world_tileset_indices(tileset.number)
+	if indices.size() < RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS:
+		return null
+	var menu: Gen2MenuPage = Gen2MenuPage.from_data(data)
+	if menu == null:
+		return null
+	var box: Gen2MenuBox = Gen2UnownWall.menu_box(word)
+	var image: Image = menu.render(box, [], -1)
+	var slots: Array = Gen2WorldPalette.palette_slots(map.environment, time_of_day)
+	var palette: PackedColorArray = data.world_palette(
+		int(slots[Gen2UnownWall.PALETTE_BROWN])
+	)
+	if palette.size() < 4:
+		return null
+	for index: int in blocks.size():
+		var block: Dictionary = blocks[index]
+		var at: Vector2i = (
+			Gen2UnownWall.block_position(box, index) - box.border_position()
+		) * TILE
+		var tiles: Array = block["tiles"]
+		var base: int = RomLayout.TILESET_BLOCK_STRIDE if bool(block["bank1"]) else 0
+		for corner: int in tiles.size():
+			_draw_tile(
+				image, indices, palette, base + int(tiles[corner]),
+				at + Vector2i((corner % 2) * TILE, (corner >> 1) * TILE)
+			)
+	return image
+
+
+## One tile of the strip, painted opaque: the box covers the map behind it.
+static func _draw_tile(
+	image: Image, indices: PackedByteArray, palette: PackedColorArray,
+	tile: int, at: Vector2i
+) -> void:
+	var stride: int = RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_WIDTH
+	var left: int = tile * Gen2Tiles.TILE_WIDTH
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in Gen2Tiles.TILE_WIDTH:
+			var to: Vector2i = at + Vector2i(x, y)
+			if to.x < 0 or to.y < 0 or to.x >= image.get_width() or to.y >= image.get_height():
+				continue
+			var color_index: int = int(indices[y * stride + left + x])
+			image.set_pixelv(to, palette[mini(color_index, palette.size() - 1)])

--- a/game/render/unown_wall_page.gd.uid
+++ b/game/render/unown_wall_page.gd.uid
@@ -1,0 +1,1 @@
+uid://dkoxwgn20tcgf

--- a/game/world/unown_wall.gd
+++ b/game/world/unown_wall.gd
@@ -1,0 +1,99 @@
+class_name Gen2UnownWall
+extends RefCounted
+
+## `DisplayUnownWords` (engine/events/unown_walls.asm): the word a Ruins of Alph
+## chamber wall spells, as the box it is drawn in and the tiles that draw it.
+##
+## The letters are not font glyphs and are not `UnownFont`, which is the
+## Pokedex's own sheet: `_DisplayUnownWords_CopyWord` computes a tile number
+## from the character itself and places a 2x2 block of the *tileset's* own tiles,
+## which is why the chambers ship a tileset holding an alphabet
+## (gfx/tilesets/ruins_of_alph.png). So this needs no import: the word comes from
+## `UnownWalls`, which [method GameData.unown_wall_word] already carries, and the
+## tiles come from the tileset the chamber is already drawn with.
+##
+## Scene-free arithmetic. [Gen2UnownWallPage] draws what this places.
+
+## `constants/charmap.asm`'s `unown` charmap, `$10 * (i / 8) + 2 * i` over
+## "ABCDEFGHIJKLMNOPQRSTUVWXYZ-": eight letters to a row of the sheet, each two
+## tiles wide and two rows tall, so a row of letters steps a whole $10.
+const ALPHABET: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+const LETTERS_PER_ROW: int = 8
+
+## `_DisplayUnownWords_FillAttr`'s split: everything below 'Y' is drawn out of
+## VRAM bank 1 with `OAM_BANK1`, and the last three letters out of bank 0.
+const BANK_SPLIT: int = 0x60
+
+## `constants/tileset_constants.asm`: the palette both halves of the word are
+## given, whatever the tileset's own palette map says about those tiles.
+const PALETTE_BROWN: int = 5
+
+## The three characters `.ConvertChar` branches away from the arithmetic for,
+## because their tiles do not sit in the alphabet block: top-left, top-right,
+## bottom-left, bottom-right.
+const SPECIAL_TILES: Dictionary = {
+	"Y": [0x5B, 0x5C, 0x4D, 0x5D],
+	"Z": [0x4E, 0x4F, 0x5E, 0x5F],
+	"-": [0x02, 0x03, 0x03, 0x02],
+}
+
+## `MenuHeaders_UnownWalls`' `menu_coords 9 - n, 4, 10 + n, 9`, where n is the
+## word's length: the box is built around the word rather than the word fitted
+## into a box.
+const BOX_TOP: int = 4
+const BOX_BOTTOM: int = 9
+const BOX_CENTRE: int = 9
+
+## `MenuBoxCoord2Tile`, `inc hl` and `add hl, 2 * SCREEN_WIDTH`: the word starts
+## one column in from the frame and two rows down from it.
+const WORD_OFFSET: Vector2i = Vector2i(1, 2)
+
+
+## The `unown` charmap value of [param letter], or -1 for anything else.
+static func char_code(letter: String) -> int:
+	var index: int = ALPHABET.find(letter)
+	if index < 0:
+		return -1
+	@warning_ignore("integer_division")
+	return 0x10 * (index / LETTERS_PER_ROW) + 2 * index
+
+
+## The box `MenuHeaders_UnownWalls` gives [param word]. Its flags byte is
+## `MENU_BACKUP_TILES`, which restores the map behind the box when it closes;
+## an overlay that is removed does that by existing, so no flag is carried.
+static func menu_box(word: String) -> Gen2MenuBox:
+	var length: int = word.length()
+	return Gen2MenuBox.from_coords(
+		BOX_CENTRE - length, BOX_TOP, BOX_CENTRE + 1 + length, BOX_BOTTOM, 0
+	)
+
+
+## One entry per letter of [param word], in order:
+## [code]{"tiles": [tl, tr, bl, br], "bank1": bool, "palette": int}[/code].
+##
+## `tiles` are tile numbers in the chamber's own tileset. `bank1` says which of
+## the two graphics blocks they are in, which is `OAM_BANK1` in the attribute
+## map and [constant RomLayout.TILESET_BLOCK_STRIDE] into the flat strip here.
+## Empty when the word holds a character the charmap has no tile for.
+static func blocks(word: String) -> Array:
+	var out: Array = []
+	for index: int in word.length():
+		var letter: String = word[index]
+		var code: int = char_code(letter)
+		if code < 0:
+			return []
+		var tiles: Array = SPECIAL_TILES.get(letter, []) as Array
+		if tiles.is_empty():
+			tiles = [code, code + 1, code + 0x10, code + 0x11]
+		out.append({
+			"tiles": tiles,
+			"bank1": code < BANK_SPLIT,
+			"palette": PALETTE_BROWN,
+		})
+	return out
+
+
+## Where the block for letter [param index] sits, in tiles, given the box
+## [method menu_box] built.
+static func block_position(box: Gen2MenuBox, index: int) -> Vector2i:
+	return box.border_position() + WORD_OFFSET + Vector2i(index * 2, 0)

--- a/game/world/unown_wall.gd.uid
+++ b/game/world/unown_wall.gd.uid
@@ -1,0 +1,1 @@
+uid://j2j0ldemp73h

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -87,6 +87,8 @@ var _field_move_text: bool = false
 ## for it to play once the last of them is up.
 var _oak_pc_pages: Array = []
 var _oak_pc_sfx: int = -1
+## `DisplayUnownWords`' box, up until the `JoyWaitAorB` behind it is answered.
+var _unown_wall_box: TextureRect = null
 ## Mirrors the source's wBattleMenuCursorPosition surviving a reopen.
 var _start_menu_cursor: int = 0
 ## `.MenuReturns`' first entry, `.Reopen`: Pokedex, Pokemon, Pokegear and the
@@ -644,6 +646,11 @@ func _handle_button(button: int) -> bool:
 		## `JoyWaitAorB`, which is what waits between each of the three texts.
 		if button in [Gen2Button.A, Gen2Button.B]:
 			_advance_prof_oaks_pc()
+		return true
+	if _unown_wall_box != null:
+		## `DisplayUnownWords`' own `JoyWaitAorB`, and the click it plays after.
+		if button in [Gen2Button.A, Gen2Button.B]:
+			_close_unown_wall()
 		return true
 	if _pokedex_host != null:
 		return _pokedex_host.handle_button(button)
@@ -2832,6 +2839,9 @@ func _show_script_results(results: Array) -> void:
 			waiting = true
 			var event: Dictionary = result.get("event", {})
 			var event_type: StringName = StringName(event.get("type", &""))
+			if event_type == &"text" and event.has("unown_wall") \
+				and _open_unown_wall(String(event.get("text", ""))):
+				break
 			if event_type == &"text" and _text_box != null and _text_box.font != null:
 				## Prof Oak's PC is the one special that draws on its own and
 				## whose script runs on past it, so its pages are shown first and
@@ -3086,6 +3096,42 @@ func _show_story_picture(species: int) -> void:
 	) / 2.0
 	_story_picture.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_screen.display(_story_picture)
+
+
+## `DisplayUnownWords`: the chamber wall's word in a box of its own, held by
+## `JoyWaitAorB`. The special stages the word as a text the runner is waiting on,
+## so answering the box is what answers that wait; a cache or a map that cannot
+## draw the letters falls back to the text box, which is what puts the word up
+## on any host without the chamber's own tileset.
+func _open_unown_wall(word: String) -> bool:
+	if _world == null or _data == null or _unown_wall_box != null:
+		return false
+	var image: Image = Gen2UnownWallPage.render(
+		_data, _world.current_tileset, _world.current_map, word, _render_time_of_day()
+	)
+	if image == null:
+		return false
+	var box: Gen2MenuBox = Gen2UnownWall.menu_box(word)
+	_unown_wall_box = TextureRect.new()
+	_unown_wall_box.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_unown_wall_box.texture = ImageTexture.create_from_image(image)
+	_unown_wall_box.size = image.get_size()
+	_unown_wall_box.position = Vector2(box.border_position() * Gen2Font.TILE)
+	_unown_wall_box.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_screen.display(_unown_wall_box)
+	_script_prompt = "A or B: close the wall"
+	return true
+
+
+func _close_unown_wall() -> void:
+	if _unown_wall_box == null:
+		return
+	_unown_wall_box.queue_free()
+	_unown_wall_box = null
+	_play_sfx(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+	## The wait behind the box is the staged text the special left, so the script
+	## resumes on the same press the source's `CloseWindow` returns on.
+	_show_script_results(_world.run_event_queue(true))
 
 
 func _hide_story_picture() -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -2307,10 +2307,10 @@ func _execute_special(special: int) -> Dictionary:
 				"defaults": true,
 			})
 		SPECIAL_DISPLAY_UNOWN_WORDS:
-			## The word the wall spells, in a menu box of its own that
-			## `JoyWaitAorB` holds until a button. Here it is the sign's own text
-			## box, acknowledged the same way, since `UnownFont`'s 2x2 letter
-			## blocks are not imported.
+			## The word the wall spells, staged as the text `JoyWaitAorB` holds
+			## until a button. A host that can reach the chamber's own tileset
+			## draws it as `_DisplayUnownWords_CopyWord`'s 2x2 letter blocks
+			## instead ([Gen2UnownWallPage]); the wait it answers is this one.
 			var wall_word: String = data.unown_wall_word(_script_value) if data != null \
 				else ""
 			if wall_word.is_empty():

--- a/tests/unit/test_menu_box.gd
+++ b/tests/unit/test_menu_box.gd
@@ -125,3 +125,45 @@ func test_the_move_info_box_is_the_source_rectangle() -> void:
 	assert_eq(box.interior(), Vector2i(9, 3))
 	assert_eq(box.border_position(), Vector2i(0, 8))
 	assert_eq(box.border_size(), Vector2i(11, 5))
+
+
+## `MenuHeaders_UnownWalls`' `menu_coords 9 - n, 4, 10 + n, 9`: the box is built
+## around the word, so "ESCAPE" and "HO-OH" are different sizes and both are
+## centred on the same two columns.
+func test_an_unown_wall_box_is_built_around_its_word() -> void:
+	var escape: Gen2MenuBox = Gen2UnownWall.menu_box("ESCAPE")
+	assert_eq(escape.border_position(), Vector2i(3, 4))
+	assert_eq(escape.border_size(), Vector2i(14, 6))
+	var ho_oh: Gen2MenuBox = Gen2UnownWall.menu_box("HO-OH")
+	assert_eq(ho_oh.border_position(), Vector2i(4, 4))
+	assert_eq(ho_oh.border_size(), Vector2i(12, 6))
+	## `MenuBoxCoord2Tile`, `inc hl` and two rows down, then two columns a letter.
+	assert_eq(Gen2UnownWall.block_position(escape, 0), Vector2i(4, 6))
+	assert_eq(Gen2UnownWall.block_position(escape, 5), Vector2i(14, 6))
+
+
+## The `unown` charmap's `$10 * (i / 8) + 2 * i`: eight letters to a row of the
+## sheet, each two tiles wide and two rows tall, so I opens a new row rather than
+## following H.
+func test_the_unown_charmap_steps_a_row_every_eighth_letter() -> void:
+	assert_eq(Gen2UnownWall.char_code("A"), 0x00)
+	assert_eq(Gen2UnownWall.char_code("H"), 0x0E)
+	assert_eq(Gen2UnownWall.char_code("I"), 0x20)
+	assert_eq(Gen2UnownWall.char_code("X"), 0x4E)
+	assert_eq(Gen2UnownWall.char_code(" "), -1)
+
+
+## `_DisplayUnownWords_CopyWord`: a letter is the computed tile, the one after
+## it, and the two a whole sheet row below. `.ConvertChar` branches away from
+## that arithmetic for the last three characters, whose tiles sit in the other
+## graphics block, which is what `_DisplayUnownWords_FillAttr`'s `cp 'Y'` splits.
+func test_a_letter_block_is_four_tiles_and_the_last_three_are_the_exception() -> void:
+	var word: Array = Gen2UnownWall.blocks("AYZ-")
+	assert_eq(word[0]["tiles"], [0x00, 0x01, 0x10, 0x11])
+	assert_true(bool(word[0]["bank1"]), "A is drawn out of the second block")
+	assert_eq(word[1]["tiles"], [0x5B, 0x5C, 0x4D, 0x5D], "Y")
+	assert_eq(word[2]["tiles"], [0x4E, 0x4F, 0x5E, 0x5F], "Z")
+	assert_eq(word[3]["tiles"], [0x02, 0x03, 0x03, 0x02], "the dash is one tile twice")
+	for index: int in [1, 2, 3]:
+		assert_false(bool(word[index]["bank1"]), "the last three are in the first block")
+	assert_eq(Gen2UnownWall.blocks("ESCAPE!"), [], "a character with no tile")

--- a/tools/checks/unown_dex.gd
+++ b/tools/checks/unown_dex.gd
@@ -171,6 +171,7 @@ func _check_walls() -> void:
 			))
 			if not word.is_empty():
 				said.append(word)
+				_check_wall_box(number, word)
 	if not _r.crystal:
 		_r.check(said.is_empty(), "a Gold or Silver chamber said %s." % [said])
 		return
@@ -188,6 +189,38 @@ func _check_walls() -> void:
 		"the four chambers said %d distinct words: %s." % [distinct.size(), said]
 	)
 	_r.note("unown walls: %s." % " ".join(said))
+
+
+## The box `DisplayUnownWords` draws that word in: `MenuHeaders_UnownWalls`'
+## size, and every letter block drawn out of the chamber's own tileset rather
+## than left as the frame's own blank. A letter whose tiles land outside the
+## graphics the tileset ships is what this catches, since the charmap computes
+## them rather than reading a table.
+func _check_wall_box(number: int, word: String) -> void:
+	var map: Gen2WorldMap = _r.data.world_map(CHAMBER_GROUP, number)
+	var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset) if map != null else null
+	var image: Image = Gen2UnownWallPage.render(_r.data, tileset, map, word)
+	if not _r.check(image != null, "map %d's \"%s\" box did not draw." % [number, word]):
+		return
+	var box: Gen2MenuBox = Gen2UnownWall.menu_box(word)
+	_r.check(
+		image.get_size() == box.border_size() * Gen2Font.TILE,
+		"map %d's \"%s\" box is %s, not %s." % [
+			number, word, image.get_size(), box.border_size() * Gen2Font.TILE,
+		]
+	)
+	for index: int in word.length():
+		var at: Vector2i = (
+			Gen2UnownWall.block_position(box, index) - box.border_position()
+		) * Gen2Font.TILE
+		var colours: Dictionary = {}
+		for y: int in Gen2Font.TILE * 2:
+			for x: int in Gen2Font.TILE * 2:
+				colours[image.get_pixelv(at + Vector2i(x, y))] = true
+		_r.check(
+			colours.size() > 1,
+			"map %d's \"%s\" letter %d is one flat colour." % [number, word, index]
+		)
 
 
 ## Faces the bg event at [param cell] and drains what it says, answering the

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -13,6 +13,9 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y]
 ##
 ## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
+## `unown_wall` (`DisplayUnownWords`' box, read off a Ruins of Alph chamber's
+## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
+## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
 ## `cut` (`OWCutAnimation`'s two halves and the jump shadow), or one of
 ## [constant FIELD_ITEMS]' own names, which is the pack's USE on that item: the
 ## Itemfinder closes the pack over the world's answer, the Coin Case prints
@@ -126,7 +129,17 @@ func _process(_delta: float) -> bool:
 		return false
 	_frames += 1
 	if _frames == 2:
-		if FIELD_ITEMS.has(_kind):
+		if _kind == &"unown_wall":
+			## The chamber's own `bg_event ..., BGEVENT_UP`: face the wall from
+			## the cell below it and read it, which is the only way in.
+			_screen.move_up()
+			_screen.interact()
+			## `writetext` is one page: the first press finishes the reveal the
+			## text speed is still spending, and the second ends the page, which
+			## is what runs `special DisplayUnownWords` and puts the box up.
+			_screen.press_button(Gen2Button.A)
+			_screen.press_button(Gen2Button.A)
+		elif FIELD_ITEMS.has(_kind):
 			if _kind in FACE_UP_FIRST:
 				_screen.move_up()
 			_screen.preview_field_item(int(FIELD_ITEMS[_kind]))


### PR DESCRIPTION
`DisplayUnownWords` puts the word a Ruins of Alph wall spells in `MenuHeaders_UnownWalls`' box and holds it on `JoyWaitAorB`. The word was said in the sign's text box instead, on the belief that its letters came from `UnownFont`.

They do not. `_DisplayUnownWords_CopyWord` computes a tile number from the character itself under `charmap.asm`'s `unown` map and places a 2x2 block of the chamber's own tileset; Y, Z and the dash branch to the first graphics block, which is the split `_DisplayUnownWords_FillAttr` writes as `OAM_BANK1`. `UnownFont` is the Pokedex's sheet. So the box needs no import: the words are already `UnownWalls` and the letters are already in the tileset the chamber is drawn with.

- `Gen2UnownWall`: the charmap, the box `menu_coords` builds around the word, and the four tiles per letter.
- `Gen2UnownWallPage`: those blocks over `MenuBox`'s frame in `PAL_BG_BROWN`.
- The world screen puts the box up on the staged text the special leaves, answers the same wait on A or B with `PlayClickSFX` after it, and falls back to the text box when the tileset cannot be reached.

Checked: `tools/checks/unown_dex.gd` renders all eight chamber walls (HO-OH, ESCAPE, WATER, LIGHT, twice each) and checks each box's size and that every letter drew; `validate.gd -- all` green on the three cartridges; GUT 2,972 over 148 scripts; `replay_world.gd` 27 routes, 0 failures; the three-profile story walk reaches Red at 294/291/291 steps.