### PR TITLE
Patchable wild encounters, number settings, animated tile frames

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -191,9 +191,10 @@ this section.
 A content number is per kind and starts at `Gen2ContentOverlay.FIRST_MOD_NUMBER`,
 which is 256. Every cartridge number fits in a byte, so a number that does not is
 unambiguously not the cartridge's, and a mod's own numbers mean the same thing on
-Gold, Silver and Crystal. Four kinds are reachable: `KIND_SPECIES`, `KIND_MOVE`,
-`KIND_ITEM` and `KIND_TRAINER`. Types are not, because the matchup lookup keys on
-the type count and a twenty-ninth type would renumber every pair in the chart.
+Gold, Silver and Crystal. Four kinds are numbered this way: `KIND_SPECIES`,
+`KIND_MOVE`, `KIND_ITEM` and `KIND_TRAINER`. Types are not reachable at all,
+because the matchup lookup keys on the type count and a twenty-ninth type would
+renumber every pair in the chart.
 
 ```gdscript
 host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
@@ -218,6 +219,30 @@ change, and a Dictionary field merges, so patching one stat leaves the other fiv
 alone. A patch of a number this cartridge lacks changes nothing rather than
 inventing a row, which is what keeps a mod that patches Crystal's MYSTICALMAN
 from conjuring one on Gold.
+
+`KIND_ENCOUNTER` and `KIND_FISHING` are the cartridge's wild tables. They are
+patched and never defined, since a mod can add neither a map nor a map header,
+and their numbers are table coordinates rather than content numbers. Patch them
+through the two helpers rather than counting the coordinate out yourself:
+
+```gdscript
+host.patch_encounter(manifest.id, &"grass", 3, 2, {
+	"rate": 20,
+	"slots": [[{"level": 50, "species": 1}], [], []],
+})
+host.patch_fishing_group(manifest.id, 1, {"rods": [...]})
+```
+
+An encounter row is what `GameData.world_encounter(method, group, number)`
+answers, and the patched row is what every reader gets, including the region
+walk `FindNest` uses. The method is one of `grass`, `surf`, `swarm_grass` and
+`swarm_water`. `slots` and `rates` are arrays and replace whole; patching a map
+this cartridge lacks changes nothing, exactly as a species patch does. The
+treemon sets, the Bug Contest list and the roaming mons are not patchable yet.
+
+Counts: `species_count()`, `move_count()` and `trainer_count()` are the
+cartridge's own runs. Mod numbers are not part of them and are enumerated with
+`Gen2ContentOverlay.defined_numbers(kind)`.
 
 Two mods claiming one number is refused and named, rather than decided by load
 order. `Gen2ContentOverlay.owner_of()` says which mod won a number.
@@ -356,7 +381,13 @@ tileset that ships only one block leaves 128 to 223 blank. Nothing needs to know
 which block a tile came from; the number is enough.
 
 `Gen2WorldAnimation` rewrites slots in this strip, so a renderer texturing from
-it follows water and flowers without knowing an animation ran.
+it follows water and flowers without knowing an animation ran. That is also why
+geometry cut from the strip is cut from one arbitrary frame:
+`tile_frames(tile)` answers every frame a tile is ever drawn as, in play order,
+each entry that tile's sixty-four palette indices row by row, with the tileset's
+own tile first and an empty array for a tile no command touches. It does not
+advance the live sequence, since the running game shares the object. Ask it once
+per animated tile when a map resolves, and let a mesh span the union.
 
 ### Asking what a cell is
 
@@ -613,7 +644,8 @@ silently winning.
 
 ## Adding a setting
 
-`register_option(id, option)` describes one setting as a ladder of values. The
+`register_option(id, option)` describes one setting: a ladder of values, a
+number in a range, or a button. The
 game and the launcher each build a surface from that one registration, so a mod
 writes no settings screen and the two can never disagree.
 
@@ -629,20 +661,33 @@ host.register_option(manifest.id, {
 |---|---|
 | `key` | Addresses the setting within the mod |
 | `label` | Shown to the player |
-| `kind` | Optional; `Gen2ModHost.OPTION_LADDER` (the default) or `OPTION_BUTTON` |
+| `kind` | Optional; `Gen2ModHost.OPTION_LADDER` (the default), `OPTION_NUMBER` or `OPTION_BUTTON` |
 | `values` | The rungs, at least one. A toggle is a two-rung ladder. Ladder only |
 | `labels` | Optional; what each rung is shown as, defaulting to the values |
-| `default` | Optional; the rung used until the player picks one, defaulting to the first |
+| `minimum`, `maximum` | The range, inclusive. Number only |
+| `step` | Optional; what one press moves the value by, defaulting to 1. Number only |
+| `default` | Optional; the rung or the number used until the player picks one, defaulting to the first rung or the minimum |
 | `press_label` | Optional; what a button setting's control reads, defaulting to `Go`. Button only |
+
+A **number** setting is one whole value in a range rather than a ladder with
+every rung written out: a randomizer's seed is one field with ten thousand
+values, and dialling it as four one-digit ladders spends four menu rows on one
+value. Set it with `set_option(id, key, value)`, clamped into the range as
+registered now, or step it with `adjust_option(id, key, delta)`, which is what
+both surfaces call and which steps a ladder just as well. The launcher draws it
+as a field that can be typed into; the start menu steps it left and right.
 
 A **button** setting is a press rather than a ladder, for something with no value
 to keep: "recentre the camera now" is an action, not a rung. It stores nothing,
 `press_option(id, key)` is what both surfaces call, and `option_changed` carries
 a null value to say the press is the whole setting.
 
-Read it back with `host.option(id, key)`, or `option_index(id, key)` for the rung.
+Read it back with `host.option(id, key)`, or `option_index(id, key)` for the
+rung, which is -1 for anything that is not a ladder.
 A mod that has to rebuild something on a change connects to `option_changed(id,
-key, value)` rather than polling: `mods/examples/voxel_preview/` registers a
+key, value)` rather than polling. The host keeps the entry object `register` was
+called on for as long as the mod is loaded, so connecting a signal to it is safe
+and a mod does not have to hold itself in a static variable: `mods/examples/voxel_preview/` registers a
 camera setting in `mod.gd` and its renderer reads it once and then listens.
 
 The two surfaces are a **MODS** entry in the start menu, beside the pack and the

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -27,7 +27,28 @@ const KIND_SPECIES: StringName = &"species"
 const KIND_MOVE: StringName = &"move"
 const KIND_ITEM: StringName = &"item"
 const KIND_TRAINER: StringName = &"trainer"
-const KINDS: Array[StringName] = [KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER]
+## One map's wild encounter record, the row [method GameData.world_encounter]
+## answers, numbered with [method encounter_number].
+const KIND_ENCOUNTER: StringName = &"encounter"
+## One fishing group, the row [method GameData.world_fishing_group] answers,
+## numbered with the group number a map header carries.
+const KIND_FISHING: StringName = &"fishing"
+const KINDS: Array[StringName] = [
+	KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER, KIND_ENCOUNTER, KIND_FISHING,
+]
+
+## The kinds that are a cartridge table rather than numbered content, and are
+## therefore [method patch]-only: a mod cannot add a map or a map header, so
+## there is no row for a [method define] to sit at. Their numbers are table
+## coordinates and do not obey [constant FIRST_MOD_NUMBER].
+const TABLE_KINDS: Array[StringName] = [KIND_ENCOUNTER, KIND_FISHING]
+
+## The methods [method encounter_number] can name, in the order it encodes them.
+## `surf` is the runtime's name for the cartridge's water table, which is what
+## [method GameData.world_encounter] takes.
+const ENCOUNTER_METHODS: Array[StringName] = [
+	&"grass", &"surf", &"swarm_grass", &"swarm_water",
+]
 
 ## The first number a mod may define. Every cartridge content number is one byte,
 ## in all three games, so a number that does not fit in one is unambiguously not
@@ -142,6 +163,8 @@ func is_empty() -> bool:
 func define(kind: StringName, id: StringName, number: int, row: Dictionary) -> Dictionary:
 	if not KINDS.has(kind):
 		return {"ok": false, "reason": &"unknown_content_kind", "detail": String(kind)}
+	if TABLE_KINDS.has(kind):
+		return {"ok": false, "reason": &"content_kind_is_patch_only", "detail": String(kind)}
 	if number < FIRST_MOD_NUMBER:
 		return {
 			"ok": false, "reason": &"reserved_content_number",
@@ -161,11 +184,19 @@ func define(kind: StringName, id: StringName, number: int, row: Dictionary) -> D
 ##
 ## Only the fields given change, and a Dictionary field merges rather than
 ## replacing, so patching [code]{"stats": {"speed": 120}}[/code] leaves the other
-## five stats alone. Refused for a number a mod would have to [method define].
+## five stats alone. An Array field replaces whole, which is what a randomizer
+## rewriting an encounter row's [code]slots[/code] wants. Refused for a number a
+## mod would have to [method define].
 func patch(kind: StringName, id: StringName, number: int, fields: Dictionary) -> Dictionary:
 	if not KINDS.has(kind):
 		return {"ok": false, "reason": &"unknown_content_kind", "detail": String(kind)}
-	if number < 1 or number >= FIRST_MOD_NUMBER:
+	if TABLE_KINDS.has(kind):
+		if number < 0:
+			return {
+				"ok": false, "reason": &"not_a_table_row",
+				"detail": "%s %d" % [kind, number],
+			}
+	elif number < 1 or number >= FIRST_MOD_NUMBER:
 		return {
 			"ok": false, "reason": &"not_a_cartridge_number",
 			"detail": "%s %d" % [kind, number],
@@ -209,6 +240,17 @@ func defined_numbers(kind: StringName) -> Array[int]:
 		out.append(number)
 	out.sort()
 	return out
+
+
+## The [constant KIND_ENCOUNTER] number for one map's table under one method, or
+## -1 for a method or a map coordinate that cannot exist. A map group and number
+## are each one byte, so the three parts pack without colliding and a mod's
+## patch means the same thing on all three cartridges.
+static func encounter_number(method: StringName, group: int, number: int) -> int:
+	var at: int = ENCOUNTER_METHODS.find(method)
+	if at < 0 or group < 0 or group > 0xFF or number < 0 or number > 0xFF:
+		return -1
+	return at * 0x10000 + group * 0x100 + number
 
 
 ## Which mod claimed [param number], or an empty name. For a launcher listing

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -455,7 +455,12 @@ func world_encounter(method: StringName, group: int, number: int) -> Dictionary:
 	if not table is Dictionary:
 		return {}
 	var value: Variant = (table as Dictionary).get("%d:%d" % [group, number], {})
-	return value.duplicate(true) if value is Dictionary else {}
+	var row: Dictionary = value.duplicate(true) if value is Dictionary else {}
+	return _overlaid(
+		Gen2ContentOverlay.KIND_ENCOUNTER,
+		Gen2ContentOverlay.encounter_number(method, group, number),
+		row
+	)
 
 
 ## One region's normal encounter table, in the cartridge's own row order, which
@@ -469,7 +474,14 @@ func world_encounter_region_rows(method: StringName, region: String) -> Array:
 	for map_key: String in table as Dictionary:
 		var row: Variant = (table as Dictionary)[map_key]
 		if row is Dictionary and String((row as Dictionary).get("region", "")) == region:
-			out.append((row as Dictionary).duplicate(true))
+			var pair: PackedStringArray = map_key.split(":")
+			out.append(_overlaid(
+				Gen2ContentOverlay.KIND_ENCOUNTER,
+				Gen2ContentOverlay.encounter_number(
+					method, int(pair[0]), int(pair[1]) if pair.size() > 1 else -1
+				),
+				(row as Dictionary).duplicate(true)
+			))
 	return out
 
 
@@ -485,7 +497,10 @@ func world_fishing_group(group: int) -> Dictionary:
 	if not groups is Array or group > (groups as Array).size():
 		return {}
 	var value: Variant = (groups as Array)[group - 1]
-	return value.duplicate(true) if value is Dictionary else {}
+	return _overlaid(
+		Gen2ContentOverlay.KIND_FISHING, group,
+		value.duplicate(true) if value is Dictionary else {}
+	)
 
 
 ## The twenty-two day/night fishing substitutions used by entries whose
@@ -978,6 +993,14 @@ func _rows(entry: Dictionary, key: String, fields: Array) -> Array:
 			coerced[field] = int(row.get(field, 0))
 		out.append(coerced)
 	return out
+
+
+## How many moves the cartridge carried, the counterpart of
+## [method species_count] and [method trainer_count]: mod moves are numbered
+## above the cartridge's range and enumerated through
+## [method Gen2ContentOverlay.defined_numbers].
+func move_count() -> int:
+	return _moves.size()
 
 
 func move(number: int) -> Dictionary:
@@ -2051,8 +2074,14 @@ func _entry(rows: Array, index: int) -> Dictionary:
 ##
 ## Numbering is one-based, the cartridge's own; see [Gen2ContentOverlay].
 func _content(kind: StringName, rows: Array, number: int) -> Dictionary:
-	var base: Dictionary = _entry(rows, number - 1)
-	if _overlay == null or _overlay.is_empty():
+	return _overlaid(kind, number, _entry(rows, number - 1))
+
+
+## The same for a row that is not one of the numbered content tables: an
+## encounter record or a fishing group, whose number is a table coordinate. A
+## number of -1 is a row no mod could have named and is answered untouched.
+func _overlaid(kind: StringName, number: int, base: Dictionary) -> Dictionary:
+	if _overlay == null or _overlay.is_empty() or number < 0:
 		return base
 	return _overlay.resolve(kind, number, base)
 

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -1,8 +1,9 @@
 class_name Gen2LauncherUI
 extends RefCounted
 
-## Small shared pieces every launcher page builds from: text, rows, and the two
-## composite controls (segmented choice and slider) that replace Godot's own.
+## Small shared pieces every launcher page builds from: text, rows, and the
+## composite controls (segmented choice, number and slider) that replace Godot's
+## own.
 
 const GAP_XS: int = 4
 const GAP_SM: int = 8
@@ -88,6 +89,28 @@ static func segmented(
 	if selected >= 0 and selected < buttons.size():
 		buttons[selected].set_active(true)
 	return track
+
+
+## One whole number, typed or stepped. A slider is the wrong shape for a value
+## whose range is wide and whose exact digits matter, which is what a mod's
+## number setting usually is.
+static func number(
+	theme: Gen2LauncherTheme, value: int, minimum: int, maximum: int, step: int,
+	handler: Callable,
+) -> Control:
+	var box := SpinBox.new()
+	box.min_value = minimum
+	box.max_value = maximum
+	box.step = maxi(step, 1)
+	box.value = value
+	box.select_all_on_focus = true
+	box.custom_minimum_size = Vector2(120, 0)
+	box.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	var field_edit: LineEdit = box.get_line_edit()
+	field_edit.add_theme_font_size_override("font_size", Gen2LauncherTheme.FONT_SMALL)
+	field_edit.add_theme_color_override("font_color", theme.text)
+	box.value_changed.connect(func(changed: float) -> void: handler.call(int(changed)))
+	return box
 
 
 static func slider(

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -140,6 +140,17 @@ func _option_field(id: StringName, option: Dictionary) -> Control:
 				_fail(Gen2ModRefusal.text(result))
 		)
 		return Gen2LauncherUI.field(_theme, String(option.get("label", "")), press)
+	if StringName(option.get("kind", Gen2ModHost.OPTION_LADDER)) == Gen2ModHost.OPTION_NUMBER:
+		# Typed rather than dialled: a seed is one field with ten thousand values
+		# and no player wants to hold an arrow through it.
+		return Gen2LauncherUI.field(_theme, String(option.get("label", "")), Gen2LauncherUI.number(
+			_theme, int(option.get("value", 0)), int(option.get("minimum", 0)),
+			int(option.get("maximum", 0)), int(option.get("step", 1)),
+			func(value: int) -> void:
+				var result: Dictionary = Gen2ModHost.instance().set_option(id, key, value)
+				if not bool(result.get("ok", false)):
+					_fail(Gen2ModRefusal.text(result))
+		))
 	return Gen2LauncherUI.field(_theme, String(option.get("label", "")), Gen2LauncherUI.segmented(
 		_theme, option.get("labels", []) as Array, int(option.get("index", 0)),
 		func(index: int) -> void:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -117,12 +117,18 @@ const CHANNELS: Array[StringName] = [CHANNEL_WORLD, CHANNEL_BATTLE]
 ## [constant Gen2ContentOverlay.FIRST_MOD_NUMBER] makes for content.
 const FIRST_MOD_POCKET: int = 5
 
-## The two shapes a registered setting can take: a ladder of values the player
-## steps along, and a button that does something the moment it is pressed. A
-## button stores nothing, because "recentre the camera now" has no value to keep.
+## The three shapes a registered setting can take: a ladder of values the player
+## steps along, a whole number in a range, and a button that does something the
+## moment it is pressed. A button stores nothing, because "recentre the camera
+## now" has no value to keep.
+##
+## A number is not a ladder with every rung written out: a randomizer's seed is
+## one value with ten thousand of them, and dialling it as four one-digit
+## ladders spends four rows of a menu on one field.
 const OPTION_LADDER: StringName = &"ladder"
+const OPTION_NUMBER: StringName = &"number"
 const OPTION_BUTTON: StringName = &"button"
-const OPTION_KINDS: Array[StringName] = [OPTION_LADDER, OPTION_BUTTON]
+const OPTION_KINDS: Array[StringName] = [OPTION_LADDER, OPTION_NUMBER, OPTION_BUTTON]
 
 ## Emitted when a registered option's value changes, whichever surface changed
 ## it. A mod that has to rebuild something on a change connects to this rather
@@ -141,6 +147,9 @@ static var _mounted_packs: Dictionary = {}
 var _manifests: Dictionary = {}
 ## Mod id to version for every entry script that ran. See [method loaded_mods].
 var _loaded: Dictionary = {}
+## Mod id to the entry object `register` was called on, held so it survives the
+## load. See [method load_mod].
+var _entries: Dictionary = {}
 ## The cartridge being played, which is what a mod's `games` declaration is
 ## checked against. Empty until one is chosen, and an empty target restricts
 ## nothing: the launcher runs before Play is pressed.
@@ -295,13 +304,16 @@ func menu_entries(menu: StringName) -> Array:
 	return entries.duplicate(true)
 
 
-## Adds one setting the player can change, as a ladder of values.
+## Adds one setting the player can change: a ladder of values, a number in a
+## range, or a button. [code]kind[/code] chooses, and defaults to
+## [constant OPTION_LADDER].
 ##
-## [param option] needs a [code]key[/code], a [code]label[/code] and a non-empty
+## A ladder needs a [code]key[/code], a [code]label[/code] and a non-empty
 ## [code]values[/code] array; [code]labels[/code] is what each rung is shown as
 ## and defaults to the values themselves, and [code]default[/code] is the rung
 ## used until the player picks one and defaults to the first. A toggle is a
-## two-rung ladder.
+## two-rung ladder. [constant OPTION_NUMBER] takes a range instead; see
+## [method _register_number_option].
 ##
 ## A mod describes a setting rather than drawing one: the start menu's MODS entry
 ## and the launcher's mods page are both built from these registrations, so a mod
@@ -318,6 +330,8 @@ func register_option(id: StringName, option: Dictionary) -> Dictionary:
 		return {"ok": false, "reason": &"unknown_option_kind", "detail": String(kind)}
 	if kind == OPTION_BUTTON:
 		return _register_button_option(id, key, label, option)
+	if kind == OPTION_NUMBER:
+		return _register_number_option(id, key, label, option)
 	var values: Array = option.get("values", []) as Array
 	if values.is_empty():
 		return {"ok": false, "reason": &"option_missing_values", "detail": _option_name(id, key)}
@@ -359,6 +373,32 @@ func _register_button_option(
 	return {"ok": true, "id": id, "key": key}
 
 
+## A setting that is one whole number rather than a list of them. [param option]
+## takes [code]minimum[/code], [code]maximum[/code], an optional
+## [code]step[/code] the two surfaces move by, and an optional
+## [code]default[/code], clamped into the range as registered.
+func _register_number_option(
+	id: StringName, key: StringName, label: String, option: Dictionary
+) -> Dictionary:
+	var minimum: int = int(option.get("minimum", 0))
+	var maximum: int = int(option.get("maximum", 0))
+	if maximum < minimum:
+		return {"ok": false, "reason": &"option_range_inverted", "detail": _option_name(id, key)}
+	var rows: Array = _options.get(id, [])
+	for existing: Dictionary in rows:
+		if StringName(existing.get("key", &"")) == key:
+			return {"ok": false, "reason": &"duplicate_option", "detail": _option_name(id, key)}
+	rows.append({
+		"key": key, "label": label, "kind": OPTION_NUMBER,
+		"minimum": minimum, "maximum": maximum,
+		"step": maxi(int(option.get("step", 1)), 1),
+		"default": clampi(int(option.get("default", minimum)), minimum, maximum),
+		"values": [], "labels": [],
+	})
+	_options[id] = rows
+	return {"ok": true, "id": id, "key": key}
+
+
 ## Presses a button-kind setting. Nothing is stored: what a press means is the
 ## mod's, and [signal option_changed] carries a null value to say so.
 func press_option(id: StringName, key: StringName) -> Dictionary:
@@ -394,6 +434,14 @@ func options(id: StringName) -> Array:
 				"values": [], "labels": [], "default": 0, "index": 0, "value": null,
 			})
 			continue
+		if StringName(row.get("kind", OPTION_LADDER)) == OPTION_NUMBER:
+			out.append({
+				"key": row["key"], "label": row["label"], "kind": OPTION_NUMBER,
+				"minimum": row["minimum"], "maximum": row["maximum"], "step": row["step"],
+				"values": [], "labels": [], "default": row["default"],
+				"index": 0, "value": _stored_number(id, row),
+			})
+			continue
 		var index: int = _stored_index(id, row)
 		out.append({
 			"key": row["key"], "label": row["label"], "kind": OPTION_LADDER,
@@ -410,13 +458,21 @@ func option(id: StringName, key: StringName) -> Variant:
 	var row: Dictionary = _option_row(id, key)
 	if row.is_empty():
 		return null
+	match StringName(row.get("kind", OPTION_LADDER)):
+		OPTION_NUMBER:
+			return _stored_number(id, row)
+		OPTION_BUTTON:
+			return null
 	return (row["values"] as Array)[_stored_index(id, row)]
 
 
-## Which rung of the ladder [param key] is on, and -1 when nothing registered it.
+## Which rung of the ladder [param key] is on, and -1 when nothing registered it
+## or when it is not a ladder.
 func option_index(id: StringName, key: StringName) -> int:
 	var row: Dictionary = _option_row(id, key)
-	return -1 if row.is_empty() else _stored_index(id, row)
+	if row.is_empty() or StringName(row.get("kind", OPTION_LADDER)) != OPTION_LADDER:
+		return -1
+	return _stored_index(id, row)
 
 
 ## Sets [param key] to [param value], which has to be one of the registered
@@ -426,6 +482,8 @@ func set_option(id: StringName, key: StringName, value: Variant) -> Dictionary:
 	var row: Dictionary = _option_row(id, key)
 	if row.is_empty():
 		return {"ok": false, "reason": &"unknown_option", "detail": _option_name(id, key)}
+	if StringName(row.get("kind", OPTION_LADDER)) == OPTION_NUMBER:
+		return _store_number(id, key, row, int(value))
 	var index: int = _value_index(row["values"] as Array, value)
 	if index < 0:
 		return {"ok": false, "reason": &"invalid_option_value", "detail": _option_name(id, key)}
@@ -433,11 +491,14 @@ func set_option(id: StringName, key: StringName, value: Variant) -> Dictionary:
 
 
 ## The same by rung rather than by value, which is what a menu stepping left and
-## right has in hand.
+## right has in hand. A number setting has no rungs; set it with
+## [method set_option] or [method adjust_option].
 func set_option_index(id: StringName, key: StringName, index: int) -> Dictionary:
 	var row: Dictionary = _option_row(id, key)
 	if row.is_empty():
 		return {"ok": false, "reason": &"unknown_option", "detail": _option_name(id, key)}
+	if StringName(row.get("kind", OPTION_LADDER)) != OPTION_LADDER:
+		return {"ok": false, "reason": &"option_is_not_a_ladder", "detail": _option_name(id, key)}
 	var values: Array = row["values"] as Array
 	if index < 0 or index >= values.size():
 		return {"ok": false, "reason": &"invalid_option_value", "detail": _option_name(id, key)}
@@ -445,6 +506,50 @@ func set_option_index(id: StringName, key: StringName, index: int) -> Dictionary
 		return {"ok": false, "reason": &"option_not_written", "detail": Gen2ModOptions.PATH}
 	option_changed.emit(id, key, values[index])
 	return {"ok": true, "id": id, "key": key, "index": index, "value": values[index]}
+
+
+## One step either way, whatever kind the setting is: a ladder wraps to the next
+## rung, a number moves by its own step and stops at either end. What a menu
+## pressing left and right has in hand, so neither surface has to branch on the
+## kind to move a value.
+func adjust_option(id: StringName, key: StringName, delta: int) -> Dictionary:
+	var row: Dictionary = _option_row(id, key)
+	if row.is_empty():
+		return {"ok": false, "reason": &"unknown_option", "detail": _option_name(id, key)}
+	match StringName(row.get("kind", OPTION_LADDER)):
+		OPTION_BUTTON:
+			return {"ok": false, "reason": &"option_is_a_button", "detail": _option_name(id, key)}
+		OPTION_NUMBER:
+			return _store_number(
+				id, key, row, _stored_number(id, row) + signi(delta) * int(row["step"])
+			)
+	var values: Array = row["values"] as Array
+	return set_option_index(
+		id, key, wrapi(_stored_index(id, row) + signi(delta), 0, maxi(values.size(), 1))
+	)
+
+
+## Writes a number setting, clamped into the range as registered now. Out of
+## range is clamped rather than refused: a stored 9999 under a maximum a later
+## version lowered is the same question [method _stored_index] answers for a
+## ladder, and a menu holding right must stop at the end rather than fail.
+func _store_number(
+	id: StringName, key: StringName, row: Dictionary, value: int
+) -> Dictionary:
+	var clamped: int = clampi(value, int(row["minimum"]), int(row["maximum"]))
+	if not Gen2ModOptions.store(id, key, clamped):
+		return {"ok": false, "reason": &"option_not_written", "detail": Gen2ModOptions.PATH}
+	option_changed.emit(id, key, clamped)
+	return {"ok": true, "id": id, "key": key, "index": 0, "value": clamped}
+
+
+## The stored number resolved against the range as registered now, which is what
+## [method _stored_index] does for a ladder.
+func _stored_number(id: StringName, row: Dictionary) -> int:
+	var stored: Variant = Gen2ModOptions.value(id, StringName(row["key"]))
+	if stored is not float and stored is not int:
+		return int(row["default"])
+	return clampi(int(stored), int(row["minimum"]), int(row["maximum"]))
 
 
 ## Declares a control of the mod's own, in the shape [method register_option]
@@ -629,6 +734,32 @@ func patch_content(
 	kind: StringName, id: StringName, number: int, fields: Dictionary
 ) -> Dictionary:
 	return Gen2ContentOverlay.shared().patch(kind, id, number, fields)
+
+
+## Changes one map's wild encounter record: the rates and the per-time-of-day
+## slots [method GameData.world_encounter] answers with, which is what a
+## randomizer rewrites. [param method] is one of
+## [constant Gen2ContentOverlay.ENCOUNTER_METHODS].
+##
+## `slots` and `rates` are arrays and replace whole. Patching a map this
+## cartridge does not carry changes nothing, exactly as a species patch does.
+func patch_encounter(
+	id: StringName, method: StringName, group: int, number: int, fields: Dictionary
+) -> Dictionary:
+	var at: int = Gen2ContentOverlay.encounter_number(method, group, number)
+	if at < 0:
+		return {
+			"ok": false, "reason": &"unknown_encounter_method",
+			"detail": "%s %d:%d" % [method, group, number],
+		}
+	return Gen2ContentOverlay.shared().patch(Gen2ContentOverlay.KIND_ENCOUNTER, id, at, fields)
+
+
+## The same for one fishing group, numbered as the map headers number them. The
+## treemon sets, the Bug Contest list and the roaming mons are not patchable
+## yet; they are read straight off the cache.
+func patch_fishing_group(id: StringName, group: int, fields: Dictionary) -> Dictionary:
+	return Gen2ContentOverlay.shared().patch(Gen2ContentOverlay.KIND_FISHING, id, group, fields)
 
 
 ## The overlay every opened [GameData] reads through, for a launcher listing what
@@ -994,8 +1125,21 @@ func load_mod(manifest: Gen2ModManifest) -> Dictionary:
 	if mod == null or not mod.has_method("register"):
 		return _refuse_load(manifest, &"entry_has_no_register", path)
 	mod.call("register", self, manifest)
+	# Kept for as long as the mod is loaded. A Callable does not keep a
+	# RefCounted alive, so an entry that connects to option_changed and is then
+	# dropped has connected a signal to an object about to be collected; holding
+	# it here is what makes `register` the whole contract. Dropped by reset(),
+	# which builds a new host, so a reload does not leave the last load
+	# listening.
+	_entries[manifest.id] = mod
 	_loaded[manifest.id] = manifest.version
 	return {"ok": true, "id": manifest.id}
+
+
+## The object whose `register` ran for [param id], or null. A mod does not need
+## this; a launcher or a test asking what is loaded does.
+func mod_entry(id: StringName) -> Object:
+	return _entries.get(id, null)
 
 
 ## Every mod whose entry script ran, as `id` and `version` pairs in id order.

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -557,10 +557,13 @@ func _mod_options() -> Array:
 
 func _render_mod_options() -> void:
 	_render_options(_mod_options(), _mod_option_cursor, func(row: Dictionary) -> String:
-		if StringName(row.get("kind", Gen2ModHost.OPTION_LADDER)) == Gen2ModHost.OPTION_BUTTON:
-			return "%s    %s" % [
-				String(row.get("label", "")), String(row.get("press_label", "Go"))
-			]
+		match StringName(row.get("kind", Gen2ModHost.OPTION_LADDER)):
+			Gen2ModHost.OPTION_BUTTON:
+				return "%s    %s" % [
+					String(row.get("label", "")), String(row.get("press_label", "Go"))
+				]
+			Gen2ModHost.OPTION_NUMBER:
+				return "%s    %d" % [String(row.get("label", "")), int(row.get("value", 0))]
 		return "%s    %s" % [
 			String(row.get("label", "")),
 			String((row.get("labels", []) as Array)[int(row.get("index", 0))]),
@@ -584,17 +587,16 @@ func _press_mod_option() -> void:
 		_status.add_theme_color_override("font_color", ERROR)
 
 
-## One rung either way, wrapping the way the cartridge's own value rows do.
-## Written through the host, so the file is committed on the press and whatever
-## registered the setting hears about it at once.
+## One step either way: a rung, wrapping the way the cartridge's own value rows
+## do, or one of a number's own steps. Written through the host, so the file is
+## committed on the press and whatever registered the setting hears about it at
+## once.
 func _adjust_mod_option(rows: Array, delta: int) -> void:
 	var row: Dictionary = rows[_mod_option_cursor]
 	if StringName(row.get("kind", Gen2ModHost.OPTION_LADDER)) == Gen2ModHost.OPTION_BUTTON:
 		return
-	var values: Array = row.get("values", []) as Array
-	var next: int = wrapi(int(row.get("index", 0)) + signi(delta), 0, maxi(values.size(), 1))
-	var result: Dictionary = Gen2ModHost.instance().set_option_index(
-		_mod_id, StringName(row.get("key", &"")), next
+	var result: Dictionary = Gen2ModHost.instance().adjust_option(
+		_mod_id, StringName(row.get("key", &"")), delta
 	)
 	if not bool(result.get("ok", false)):
 		_status.text = Gen2ModRefusal.text(result)

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -103,6 +103,76 @@ func current_indices() -> PackedByteArray:
 	return _indices
 
 
+## Every frame one animated tile is ever drawn as, in the order the sequence
+## plays them, each entry the tile's sixty-four palette indices row by row. An
+## empty array for a tile no command touches.
+##
+## Read-only and one map resolve's question: a mesh cut from the live strip is
+## cut from whichever frame the atlas happened to hold, so geometry has to span
+## the union of every frame. The live sequence is not advanced, because the
+## running game shares this object and stepping it would move what the player
+## sees; the walk runs on a copy from the start of the command list.
+func tile_frames(tile: int) -> Array[PackedByteArray]:
+	var out: Array[PackedByteArray] = []
+	if _commands.is_empty() or tileset == null or tile < 0 or tile >= tileset.tile_count:
+		return out
+	var walk: Gen2WorldAnimation = Gen2WorldAnimation.new()
+	walk.data = data
+	walk.map = map
+	walk.tileset = tileset
+	walk._time_of_day = _time_of_day
+	walk._commands = _commands
+	walk._indices = data.world_tileset_indices(tileset.number).duplicate()
+	walk._buffer.resize(TILE_BYTES)
+	var base: PackedByteArray = walk._tile_indices(tile)
+	# Every timer mask in the command table is &7 or narrower and a pass bumps
+	# the timer at most once, so eight passes of the list is a whole cycle of
+	# anything the cartridge animates.
+	for _step: int in _commands.size() * 8:
+		walk._changed_tiles = {}
+		walk.tick()
+		if walk._changed_tiles.has(tile):
+			out.append(walk._tile_indices(tile))
+	if out.is_empty():
+		return out
+	out = _cycle(out)
+	# The tileset's own tile is on screen from the map load until the first
+	# write, so it belongs to the union a mesh has to span unless a frame draws
+	# it again anyway.
+	if not out.has(base):
+		out.insert(0, base)
+	return out
+
+
+## The shortest prefix the frame list repeats, so a tile whose cycle is four
+## frames answers four rather than the same four eight times over. The walk
+## stops wherever eight passes leave it, so the last repeat may be partial.
+static func _cycle(frames: Array[PackedByteArray]) -> Array[PackedByteArray]:
+	for period: int in range(1, frames.size()):
+		var repeats: bool = true
+		for at: int in frames.size():
+			if frames[at] != frames[at % period]:
+				repeats = false
+				break
+		if repeats:
+			return frames.slice(0, period)
+	return frames
+
+
+## One tile's palette indices as sixty-four bytes, row by row, out of the strip
+## the atlas is built from.
+func _tile_indices(tile: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
+	var width: int = tileset.tile_count * Gen2Tiles.TILE_WIDTH
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in Gen2Tiles.TILE_WIDTH:
+			out[y * Gen2Tiles.TILE_WIDTH + x] = _indices[
+				y * width + tile * Gen2Tiles.TILE_WIDTH + x
+			]
+	return out
+
+
 func water_palette_color() -> int:
 	return _water_color
 

--- a/tests/unit/test_content_overlay.gd
+++ b/tests/unit/test_content_overlay.gd
@@ -46,6 +46,14 @@ func _write_cache() -> void:
 		{"number": 1, "name": "LEADER", "palette": [0x1234, 0x5678], "trainers": []},
 	])
 	RomCache.write_json(RomCache.world_trades_path(_directory), [])
+	RomCache.write_json(RomCache.world_encounters_path(_directory), {
+		"grass": {"3:2": {
+			"map": "3:2", "region": "johto", "rate": 4, "rates": [4, 4, 4],
+			"slots": [[{"level": 2, "species": 16}], [], []],
+		}},
+		"water": {},
+		"fishing": {"groups": [{"rods": []}], "time_groups": []},
+	})
 	RomCache.write_json(RomCache.tmhm_moves_path(_directory), [1])
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
@@ -179,3 +187,48 @@ func test_the_overlay_names_who_claimed_what() -> void:
 	var overlay: Gen2ContentOverlay = Gen2ModHost.instance().content_overlay()
 	assert_eq(overlay.defined_numbers(Gen2ContentOverlay.KIND_SPECIES), [NEW_SPECIES] as Array[int])
 	assert_eq(overlay.owner_of(Gen2ContentOverlay.KIND_SPECIES, NEW_SPECIES), MOD)
+
+
+func test_an_encounter_row_is_patched_where_the_cartridge_table_is_read() -> void:
+	# The single most wanted thing a randomizer does, and it has to arrive at
+	# GameData's own chokepoint so nothing downstream learns a mod exists.
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_encounter(MOD, &"grass", 3, 2, {
+		"rate": 20, "slots": [[{"level": 50, "species": 1}], [], []],
+	}).get("ok", false)))
+
+	var data: GameData = _data()
+	var row: Dictionary = data.world_encounter(&"grass", 3, 2)
+	assert_eq(int(row["rate"]), 20)
+	assert_eq(int(row["slots"][0][0]["species"]), 1, "an array field replaces whole")
+	assert_eq(row["rates"], [4.0, 4.0, 4.0], "an unnamed field is untouched")
+	# FindNest walks the region table rather than one map, and reads the same
+	# patched row.
+	var rows: Array = data.world_encounter_region_rows(&"grass", "johto")
+	assert_eq(int(rows[0]["rate"]), 20)
+	# A map this cartridge lacks, and a method that is not one, change nothing.
+	assert_true(data.world_encounter(&"grass", 9, 9).is_empty())
+	assert_eq(
+		StringName(host.patch_encounter(MOD, &"headbutt", 3, 2, {"rate": 1})["reason"]),
+		&"unknown_encounter_method"
+	)
+
+
+func test_a_fishing_group_is_patched_by_its_own_group_number() -> void:
+	assert_true(bool(Gen2ModHost.instance().patch_fishing_group(
+		MOD, 1, {"rods": [{"level": 10, "species": 129}]}
+	).get("ok", false)))
+	var groups: Array = _data().world_fishing_group(1)["rods"]
+	assert_eq(int(groups[0]["species"]), 129)
+	assert_true(_data().world_fishing_group(9).is_empty())
+
+
+func test_a_table_kind_is_patched_and_never_defined() -> void:
+	# There is no map or map header a mod can add, so there is no row for a
+	# definition to sit at.
+	assert_eq(
+		StringName(Gen2ModHost.instance().register_content(
+			Gen2ContentOverlay.KIND_ENCOUNTER, MOD, NEW_SPECIES, {}
+		)["reason"]),
+		&"content_kind_is_patch_only"
+	)

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -206,6 +206,9 @@ func test_a_complete_cache_opens() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	assert_not_null(data)
 	assert_eq(data.species_count(), 2)
+	# Moves are counted like species and trainer classes, so a mod walking every
+	# one does not have to scan 1 to 255 and keep what answers.
+	assert_eq(data.move_count(), 1)
 
 
 func test_an_incomplete_cache_does_not_open() -> void:

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1048,3 +1048,52 @@ func test_a_button_setting_stores_nothing_and_acts_on_the_press() -> void:
 		host.register_option(&"voxel", {"key": &"x", "label": "X", "kind": &"slider"})["reason"],
 		&"unknown_option_kind"
 	)
+
+
+func test_a_number_setting_is_one_field_rather_than_a_ladder_of_digits() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(host.register_option(&"voxel", {
+		"key": &"seed", "label": "Seed", "kind": Gen2ModHost.OPTION_NUMBER,
+		"minimum": 0, "maximum": 9999, "default": 1234,
+	})["ok"])
+	var row: Dictionary = host.options(&"voxel")[0]
+	assert_eq(StringName(row["kind"]), Gen2ModHost.OPTION_NUMBER)
+	assert_eq(int(row["value"]), 1234)
+	assert_eq(int(host.option(&"voxel", &"seed")), 1234)
+
+	var heard: Array = []
+	host.option_changed.connect(func(_id: StringName, _key: StringName, value: Variant) -> void:
+		heard.append(value)
+	)
+	assert_true(host.set_option(&"voxel", &"seed", 4321)["ok"])
+	assert_eq(heard, [4321])
+	assert_eq(Gen2ModOptions.value(&"voxel", &"seed"), 4321, "stored like any other value")
+	# Either surface steps a number the same way it steps a ladder, and a
+	# number stops at its own end rather than wrapping into the other one.
+	assert_eq(int(host.adjust_option(&"voxel", &"seed", 1)["value"]), 4322)
+	assert_true(host.set_option(&"voxel", &"seed", 99999)["ok"])
+	assert_eq(int(host.option(&"voxel", &"seed")), 9999, "clamped into the range")
+	assert_eq(host.option_index(&"voxel", &"seed"), -1, "a number is on no rung")
+	assert_eq(
+		host.set_option_index(&"voxel", &"seed", 0)["reason"], &"option_is_not_a_ladder"
+	)
+	assert_eq(
+		host.register_option(&"voxel", {
+			"key": &"bad", "label": "Bad", "kind": Gen2ModHost.OPTION_NUMBER,
+			"minimum": 10, "maximum": 1,
+		})["reason"],
+		&"option_range_inverted"
+	)
+
+
+func test_a_loaded_mod_survives_its_own_registration() -> void:
+	# A Callable does not keep a RefCounted alive, so a mod that connects to
+	# option_changed and is then dropped would be listening from the grave.
+	_write_dependency_mod("%s/listener" % ROOT, "listener", "1.0.0")
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	assert_eq(host.load_discovered(), [&"listener"])
+	assert_not_null(host.mod_entry(&"listener"))
+	assert_null(host.mod_entry(&"absent"))
+	Gen2ModHost.reset()
+	assert_null(Gen2ModHost.instance().mod_entry(&"listener"), "a reload drops the last load")

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -40,6 +40,21 @@ func _write_cache() -> void:
 			{"operation": "water", "tile": 0},
 			{"operation": "done"},
 		],
+	}, {
+		# The same tile animated properly: a timer bump per pass, so the water
+		# command walks all four frames of the asset instead of standing on the
+		# first. What tile_frames() has to recover.
+		"number": 1,
+		"block_count": 1,
+		"tile_count": RomLayout.TILESET_TILE_COUNT,
+		"meta": meta,
+		"collision": [],
+		"palette_map": [0],
+		"animation_commands": [
+			{"operation": "timer_8"},
+			{"operation": "water", "tile": 0},
+			{"operation": "done"},
+		],
 	}])
 	RomCache.write_json(RomCache.world_maps_path(_directory), [{
 		"group": 1,
@@ -52,10 +67,22 @@ func _write_cache() -> void:
 		"collision": [0, 0, 0, 0],
 		"collision_width": 2,
 		"collision_height": 2,
+	}, {
+		"group": 1,
+		"number": 2,
+		"tileset": 1,
+		"environment": 0,
+		"width_blocks": 1,
+		"height_blocks": 1,
+		"blocks": [0],
+		"collision": [0, 0, 0, 0],
+		"collision_width": 2,
+		"collision_height": 2,
 	}])
 	var pixels := PackedByteArray()
 	pixels.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
 	RomCache.write_indices(RomCache.world_tile_path(_directory, 0), pixels)
+	RomCache.write_indices(RomCache.world_tile_path(_directory, 1), pixels)
 
 	var palettes: Array = []
 	for _group: int in RomLayout.WORLD_PALETTE_GROUP_COUNT:
@@ -66,8 +93,13 @@ func _write_cache() -> void:
 	water.resize(64)
 	for index: int in water.size():
 		water[index] = 0
+	# Frame 0 is a solid low plane; the other three are one, two and three lit
+	# rows, so the four frames are told apart by their contents.
 	for y: int in 8:
 		water[y * 2] = 0xFF
+	for frame: int in range(1, 4):
+		for y: int in frame:
+			water[frame * 16 + y * 2] = 0xFF
 	RomCache.write_json(RomCache.world_animation_assets_path(_directory), {"water": water})
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
@@ -129,3 +161,28 @@ func test_changed_tiles_reports_exactly_the_tiles_a_frame_rewrote() -> void:
 					break
 		assert_eq(Array(animation.changed_tiles()), actually_changed)
 		assert_eq(redraw, not actually_changed.is_empty() or animation.palette_changed())
+
+
+func test_tile_frames_answers_every_frame_in_order_without_moving_the_sequence() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 2, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world)
+	for _frame: int in 5:
+		animation.advance_frame()
+	var before: PackedByteArray = animation.current_indices().duplicate()
+	var at: int = animation.command_index()
+
+	# The tileset's own tile, then the four the water command plays.
+	var frames: Array[PackedByteArray] = animation.tile_frames(0)
+	assert_eq(frames.size(), 5)
+	# The asset's four frames light 8, 1, 2 and 3 rows, in that play order.
+	var lit: Array[int] = []
+	for frame: PackedByteArray in frames:
+		lit.append(frame.count(1))
+	assert_eq(lit, [0, 64, 8, 16, 24] as Array[int])
+	# A mod shares this object with the running game, so asking must not step it.
+	assert_eq(animation.current_indices(), before)
+	assert_eq(animation.command_index(), at)
+	# A tile no command touches has no frames, rather than one of itself.
+	assert_eq(animation.tile_frames(1).size(), 0)


### PR DESCRIPTION
Four asks from the mod side, plus two small ones, all against `docs/MODS.md`'s contract.

- **Wild encounters are patchable.** `Gen2ContentOverlay` gains `KIND_ENCOUNTER` and `KIND_FISHING`, patch-only because a mod can add neither a map nor a map header. `host.patch_encounter(id, method, group, number, fields)` and `patch_fishing_group(id, group, fields)` are the calls; the patched row arrives at `GameData.world_encounter`, `world_encounter_region_rows` and `world_fishing_group`, so nothing downstream learns a mod exists. Patching a map this cartridge lacks changes nothing, as a species patch does. The treemon sets, the Bug Contest list and the roaming mons are still read straight off the cache.
- **A setting can be a number.** `OPTION_NUMBER` with `minimum`, `maximum`, `step` and `default`, stored in `user://mod_options.json` like a ladder's value and read back through `option(id, key)`. `adjust_option(id, key, delta)` steps either kind, which is what both surfaces now call; the launcher draws a typable field and the start menu steps it left and right.
- **A loaded mod outlives its own `register`.** The host keeps the entry object for as long as the mod is loaded and drops it with the host, so connecting to `option_changed` no longer needs a static variable.
- **`Gen2WorldAnimation.tile_frames(tile)`** answers every frame an animated tile is drawn as, in play order, as 8x8 palette indices, without advancing the live sequence.
- **`GameData.move_count()`**, beside `species_count()` and `trainer_count()`.

Measured: GUT 2,978 over 148 scripts green (2,631 unit), `validate.gd -- all` 46 topics pass on all three cartridges, `replay_world.gd` 27 routes 0 failures, the story walk reaches Red at 291/291/294 steps.