### PR TITLE
The stage owns the pointer, and a tool run loads no mods

### DIFF
--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -102,6 +102,13 @@ func load_mods(game_id: StringName = &"") -> Array:
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	host.set_target_game(game_id)
 	host.discover()
+	if not mods_are_allowed():
+		_loaded_mods = []
+		if not host.manifests().is_empty():
+			print("Mods: %d installed, none loaded. Pass --mods to run them." % [
+				host.manifests().size()
+			])
+		return _loaded_mods
 	_loaded_mods = host.load_discovered()
 	# A mod registers its own controls inside its entry script, which is after the
 	# options were applied, so the InputMap gets them now rather than never.
@@ -114,6 +121,24 @@ func load_mods(game_id: StringName = &"") -> Array:
 			failure.get("reason", "unknown"), failure.get("detail", ""),
 		])
 	return _loaded_mods
+
+
+## Whether this process runs the mods it finds.
+##
+## A headless run or one driving a `-s` tool script is a check, a test tier or a
+## screenshot, and a mod that swaps the renderer or shuffles a table changes what
+## those measure without saying so anywhere in their output. Such a run discovers
+## mods, so a list is still right, and loads none unless `--mods` is passed. A
+## player's own launch is neither, so what they switched on in the launcher is
+## what runs.
+static func mods_are_allowed() -> bool:
+	var args: PackedStringArray = OS.get_cmdline_args()
+	if args.has("--mods") or OS.get_cmdline_user_args().has("--mods"):
+		return true
+	return not (
+		DisplayServer.get_name() == "headless"
+		or args.has("-s") or args.has("--script")
+	)
 
 
 func loaded_mods() -> Array:

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -122,6 +122,15 @@ what is already installed untouched. Reimporting a mod that is present asks
 first, and replacing one removes files the new version dropped rather than
 leaving them behind.
 
+Mods do not load in a headless run or one driving a `-s` tool script: a check, a
+test tier or a screenshot would otherwise be measuring a renderer or a shuffled
+table without saying so. Such a run still discovers mods, so a listing is right,
+and `--mods` on the command line puts them back for a run that is about a mod:
+
+```bash
+godot --headless --path . --quit-after 30 --mods
+```
+
 Mods load the same way in an exported build as in the editor: the entry script
 is plain GDScript read at runtime, even though the game's own scripts ship as
 binary tokens. An installed mod loads immediately, without a restart, and so

--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -65,13 +65,13 @@ static func create(theme: Gen2LauncherTheme, id: StringName) -> Gen2Cartridge:
 
 
 func _build() -> void:
-	mouse_filter = Control.MOUSE_FILTER_STOP
-	mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
-	tooltip_text = RomRegistry.title_for(game_id)
-	mouse_entered.connect(_on_hover.bind(true))
-	mouse_exited.connect(_on_hover.bind(false))
-	# The stage owns every press on the row, because a press here is the start of
-	# a drag as often as it is a choice, and only the stage knows which it became.
+	# The stage owns the pointer for the whole row, so a card is invisible to it
+	# and calls [method set_hovered] when the stage says so. A press here is the
+	# start of a drag as often as it is a choice, and only the stage knows which
+	# it became; a card that took the press would also lose the release, because
+	# a drag long enough carries the card being held off the stage and Godot
+	# stops delivering to a control that is no longer drawn.
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
 	resized.connect(_place)
 
 	_bay = Control.new()
@@ -212,6 +212,14 @@ func _corner(centre: Vector2, radius: float, from: float, to: float) -> PackedVe
 		var angle: float = lerpf(from, to, float(step) / float(steps))
 		points.append(centre + Vector2(cos(angle), sin(angle)) * radius)
 	return points
+
+
+## Lit and lifted under the pointer. Called by the stage, which hit-tests the
+## row itself.
+func set_hovered(entered: bool) -> void:
+	if _hover == entered:
+		return
+	_on_hover(entered)
 
 
 func _on_hover(entered: bool) -> void:

--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -72,9 +72,11 @@ func _build() -> void:
 	size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	size_flags_vertical = Control.SIZE_EXPAND_FILL
 	custom_minimum_size = Vector2(0, MIN_HEIGHT)
+	mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	resized.connect(_place_all)
 	focus_entered.connect(_place_all)
 	focus_exited.connect(_place_all)
+	mouse_exited.connect(func() -> void: _hover(-1))
 	for index: int in _order.size():
 		var cartridge: Gen2Cartridge = Gen2Cartridge.create(_theme, _order[index])
 		add_child(cartridge)
@@ -152,9 +154,12 @@ func _gui_input(event: InputEvent) -> void:
 		return
 	if event is InputEventMouseButton:
 		_on_click(event)
-	elif event is InputEventMouseMotion and _grabbed:
-		accept_event()
-		_on_drag(event)
+	elif event is InputEventMouseMotion:
+		if _grabbed:
+			accept_event()
+			_on_drag(event)
+		else:
+			_hover(_at((event as InputEventMouseMotion).position))
 
 
 ## The row is dragged rather than paged: a press takes hold of it, the pointer
@@ -188,6 +193,7 @@ func _on_click(click: InputEventMouseButton) -> void:
 	if not _grabbed:
 		return
 	_grabbed = false
+	_hover(_at(click.position))
 	# A press that went nowhere is a click on whatever it landed on. Anything
 	# further than that was a drag, and a drag chooses by where it stopped.
 	if _travel <= TAP:
@@ -196,6 +202,14 @@ func _on_click(click: InputEventMouseButton) -> void:
 			_on_pressed(hit)
 			return
 	_settle()
+
+
+## Lights whichever card the pointer is over, and names it in the tooltip. The
+## cards take no pointer events of their own, so this is where hover lives.
+func _hover(index: int) -> void:
+	for at: int in _cartridges.size():
+		_cartridges[at].set_hovered(at == index)
+	tooltip_text = RomRegistry.title_for(_order[index]) if index >= 0 else ""
 
 
 func _on_drag(motion: InputEventMouseMotion) -> void:

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -236,6 +236,56 @@ func test_dragging_the_row_settles_on_whatever_it_was_left_nearest() -> void:
 	assert_eq(stage.selected, 0, "clicking the one beside it chooses it")
 
 
+## The pointer path itself, pushed through a viewport rather than handed to the
+## stage. Every other test here calls `_gui_input` directly and is blind to what
+## the mouse actually reaches: a card that stopped the pointer left the row
+## selectable only by the gaps between the cards, on a mouse and on a
+## touchscreen alike.
+func test_a_press_on_a_cartridge_reaches_the_row_behind_it() -> void:
+	var stage: Gen2CartridgeStage = await _pointed_stage()
+	var neighbour: Gen2Cartridge = stage.cartridge(RomRegistry.ORDER[1])
+	assert_eq(neighbour.mouse_filter, Control.MOUSE_FILTER_IGNORE, "the card is not a wall")
+	_point(stage, neighbour.get_global_rect().get_center())
+	await get_tree().process_frame
+	assert_eq(stage.selected, 1, "pressing a cartridge chooses it")
+
+	# And a drag begun on a card carries the row, which is the touch gesture.
+	# After the slide, so the card being grabbed is the size it has at rest.
+	await wait_seconds(0.4)
+	var card: Gen2Cartridge = stage.selected_cartridge()
+	var from: Vector2 = card.get_global_rect().get_center()
+	var by := Vector2(-card.size.x * 1.2, 0.0)
+	_pointer(stage, _button(from, true))
+	_pointer(stage, _motion(from + by, by))
+	_pointer(stage, _button(from + by, false))
+	await wait_seconds(0.5)
+	assert_eq(stage.selected, 2, "dragging from a cartridge moves the row")
+
+
+## A shelf in a viewport of its own, so pushed input is routed the way the
+## running launcher routes it. The test runner's own interface is over the
+## window and would take every press pushed at that one.
+func _pointed_stage() -> Gen2CartridgeStage:
+	var holder := SubViewport.new()
+	holder.size = Vector2i(1000, 640)
+	holder.handle_input_locally = true
+	add_child_autofree(holder)
+	var page: Gen2ShelfPage = Gen2ShelfPage.create(_light, false)
+	holder.add_child(page)
+	page.size = Vector2(1000, 640)
+	await get_tree().process_frame
+	return page.stage()
+
+
+func _point(stage: Gen2CartridgeStage, at: Vector2) -> void:
+	_pointer(stage, _button(at, true))
+	_pointer(stage, _button(at, false))
+
+
+func _pointer(stage: Gen2CartridgeStage, event: InputEvent) -> void:
+	(stage.get_viewport() as SubViewport).push_input(event, true)
+
+
 func test_a_scroll_pane_only_stops_a_pad_when_there_is_more_to_see() -> void:
 	var pane: Gen2LauncherScroll = Gen2LauncherScroll.create()
 	pane.size = Vector2(200, 120)

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1160,3 +1160,21 @@ func test_two_sources_listing_one_mod_leave_it_under_the_first() -> void:
 	})
 	assert_eq(groups.size(), 1)
 	assert_eq(String(groups[0]["label"]), "A")
+
+
+## A headless process or one driving a tool script is a check, a test tier or a
+## screenshot. A mod that swaps the renderer or shuffles a table would change
+## what those measure without appearing anywhere in their output, so they
+## discover mods and run none.
+func test_a_tool_run_lists_the_mods_it_finds_and_runs_none_of_them() -> void:
+	assert_false(GameRuntime.mods_are_allowed(), "this run is headless and script-driven")
+	_write_dependency_mod("%s/quiet" % Gen2ModHost.ROOT, "quiet", "1.0.0")
+	assert_eq(GameRuntime.load_mods(), [], "nothing was run")
+	assert_true(
+		Gen2ModHost.instance().manifests().any(
+			func(manifest: Gen2ModManifest) -> bool: return manifest.id == &"quiet"
+		),
+		"and the list is still right"
+	)
+	assert_true(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START).is_empty())
+	Gen2ModInstaller.uninstall(&"quiet")


### PR DESCRIPTION
Two launcher defects, reported together.

**The shelf could not be used with a pointer.** `Gen2Cartridge` set `MOUSE_FILTER_STOP`, so every press on a card was swallowed and the carousel behind it never saw one: clicking a side cartridge did nothing, and a drag only worked if it began in a gap between the cards. Touch goes through the same path, so it was out too. The cards are now invisible to the pointer and the stage hit-tests the row itself, which also fixes a second half of it: a drag long enough carries the grabbed card off the stage, and Godot stops delivering to a control that is no longer drawn, so a card holding the press would lose the release and leave the row stuck mid-drag. Hover and the tooltip move to the stage with it.

Every existing test called `stage._gui_input` directly and was blind to what the mouse actually reaches. The new one pushes real events through a `SubViewport` of its own, and it fails on the old filter.

**A tool run no longer loads mods.** A headless run, or one driving a `-s` script, discovers mods and runs none: a check, a test tier, a screenshot or the story walk was otherwise measuring whatever the player left switched on in the launcher, with nothing in the output to say so. It prints one line naming how many it skipped, and `--mods` puts them back for a run that is about a mod. A player's own launch is unaffected.

Measured: GUT 2,982 over 148 scripts green (2,635 unit), `validate.gd -- all` 46 topics pass, `replay_world.gd` 27 routes 0 failures, story walk 291 (Gold) and 294 (Crystal) steps to Red.