### PR TITLE
A pane outlives the button that rebuilt it, and every text_ram is answered

### DIFF
--- a/game/launcher/binding_sheet.gd
+++ b/game/launcher/binding_sheet.gd
@@ -102,9 +102,7 @@ func _registered_default() -> Array:
 
 
 func _refresh() -> void:
-	for child: Node in _list.get_children():
-		_list.remove_child(child)
-		child.queue_free()
+	Gen2LauncherUI.clear(_list)
 	var bindings: Array = _bindings()
 	for index: int in bindings.size():
 		var row: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -253,8 +253,7 @@ func flash(duration: float = 0.4) -> void:
 
 
 func _rebuild_dock() -> void:
-	for child: Node in _dock.get_children():
-		child.queue_free()
+	Gen2LauncherUI.clear(_dock)
 	_buttons.clear()
 	# A screen with one page has nowhere to navigate to, so it gets no dock.
 	_dock_host.visible = _entries.size() > 1

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -44,6 +44,20 @@ static func row(separation: int = GAP_MD) -> HBoxContainer:
 	return box
 
 
+## Empties a container that is about to be rebuilt.
+##
+## Every launcher pane is rebuilt from a button inside it, so the node emitting
+## `pressed` is one of the children being removed and `free()` there destroys an
+## object the signal is still walking. Detaching first takes the child out of the
+## rebuilt list at once and leaves the deletion to the end of the frame.
+static func clear(container: Node) -> void:
+	if container == null:
+		return
+	for child: Node in container.get_children():
+		container.remove_child(child)
+		child.queue_free()
+
+
 static func spacer() -> Control:
 	var gap := Control.new()
 	gap.size_flags_horizontal = Control.SIZE_EXPAND_FILL

--- a/game/launcher/mod_detail_page.gd
+++ b/game/launcher/mod_detail_page.gd
@@ -71,8 +71,7 @@ func set_row(row: Dictionary) -> void:
 	_row = row.duplicate(true)
 	_title.text = String(row["name"])
 	_subtitle.text = "%s  %s" % [row["id"], row["source_label"]]
-	for child: Node in _body.get_children():
-		child.queue_free()
+	Gen2LauncherUI.clear(_body)
 
 	_body.add_child(_summary(row))
 	var description: String = String(row["description"])

--- a/game/launcher/mod_sources_page.gd
+++ b/game/launcher/mod_sources_page.gd
@@ -75,8 +75,7 @@ func _build() -> void:
 
 
 func refresh() -> void:
-	for child: Node in _list.get_children():
-		child.queue_free()
+	Gen2LauncherUI.clear(_list)
 	var sources: Array[Dictionary] = Gen2ModIndex.followed()
 	if sources.is_empty():
 		var empty: Gen2LauncherCard = Gen2LauncherCard.well(

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -114,8 +114,7 @@ func refresh() -> void:
 
 
 func _relist() -> void:
-	for child: Node in _list.get_children():
-		child.queue_free()
+	Gen2LauncherUI.clear(_list)
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	var groups: Array = Gen2ModCatalogue.groups(
 		host.manifests(), Gen2ModIndex.followed(), _listings

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -249,16 +249,14 @@ func _build_ui() -> void:
 func _refresh() -> void:
 	if _box_grid == null:
 		return
-	for child: Node in _box_grid.get_children():
-		child.free()
+	Gen2LauncherUI.clear(_box_grid)
 	for slot: int in Gen2SaveBox.CAPACITY:
 		var button := _button(_slot_text(slot), TEXT)
 		button.custom_minimum_size = Vector2(170, 58)
 		button.pressed.connect(_select_box_slot.bind(slot))
 		_box_grid.add_child(button)
 	if _party_members != null:
-		for child: Node in _party_members.get_children():
-			child.free()
+		Gen2LauncherUI.clear(_party_members)
 		for index: int in Gen2SaveData.MAX_PARTY:
 			var member := _button(_party_text(index), TEXT)
 			member.custom_minimum_size = Vector2(280, 40)

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -354,8 +354,7 @@ func submenu_snapshot() -> Dictionary:
 func _render_submenu() -> void:
 	if _submenu == null:
 		return
-	for child: Node in _submenu.get_children():
-		child.queue_free()
+	Gen2LauncherUI.clear(_submenu)
 	_submenu.visible = _submenu_open
 	if not _submenu_open:
 		return
@@ -459,8 +458,7 @@ func _build_ui() -> void:
 func _refresh() -> void:
 	if _cards == null:
 		return
-	for child: Node in _cards.get_children():
-		child.free()
+	Gen2LauncherUI.clear(_cards)
 	if _player_label != null:
 		_player_label.text = "Player: %s" % (_save.player_name if _save != null else "Unavailable")
 	if _data == null or _save == null:

--- a/game/save/save_editor_screen.gd
+++ b/game/save/save_editor_screen.gd
@@ -403,8 +403,7 @@ func _refresh_party() -> void:
 func _refresh_party_form() -> void:
 	if _party_form == null:
 		return
-	for child: Node in _party_form.get_children():
-		child.queue_free()
+	Gen2LauncherUI.clear(_party_form)
 	if _selected_party < 0 or _selected_party >= _editor.save.party.size():
 		return
 	var mon: Gen2SaveMon = _editor.save.party[_selected_party]

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -293,12 +293,7 @@ func _refresh() -> void:
 
 
 func _refresh_slot_cards() -> void:
-	# Selecting a slot is reached from a slot card's own `pressed`, so the
-	# card being replaced is still emitting. `free()` there is a use after
-	# free; detaching first keeps it out of the rebuilt list.
-	for child: Node in _slots_container.get_children():
-		_slots_container.remove_child(child)
-		child.queue_free()
+	Gen2LauncherUI.clear(_slots_container)
 	_slots_section.visible = not _new_game_visible
 	_slots_container.visible = not _new_game_visible
 
@@ -351,8 +346,11 @@ func _refresh_details() -> void:
 		return
 	_slots_section.visible = not _new_game_visible
 	_slots_container.visible = not _new_game_visible
-	for child: Node in _details_box.get_children():
-		child.free()
+	Gen2LauncherUI.clear(_details_box)
+	# The pane's own controls go with it. A detached child is deleted at the end
+	# of the frame rather than here, so a reference kept past the rebuild would
+	# still answer `is_instance_valid` and report a form that is off screen.
+	_name_input = null
 	if _data == null or _selected_slot < 0:
 		return
 	# A slot targeted for a new game has no row yet, since slots_for answers only

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -315,3 +315,48 @@ func test_renaming_from_the_screen_reaches_the_slot() -> void:
 
 	var rows: Array = _screen.save_screen_snapshot()["slots"]
 	assert_eq(rows[0]["label"], "Run two")
+
+
+## The reported "the app exits after Create save": every details-pane button
+## rebuilds the pane it sits in, so the node emitting `pressed` was one of the
+## children `_refresh_details` freed outright, and the engine walked a destroyed
+## object on the way back out of the signal. The API-driven cases above cannot
+## see it, because nothing is emitting when they call.
+func test_a_details_pane_button_survives_the_rebuild_it_triggers() -> void:
+	assert_true(Gen2SaveStore.save(_save(), _data)["ok"])
+	await _open_save_screen()
+	assert_true(_screen.select_slot(1))
+	_press_and_outlive("Rename")
+	assert_eq(_screen.save_screen_snapshot()["status"], "Renamed slot 2.")
+
+	assert_true(_screen.open_new_game(1))
+	_press_and_outlive("Cancel")
+	assert_false(_screen.save_screen_snapshot()["new_game_form"], "the form closed")
+
+	assert_true(_screen.open_new_game(1))
+	_press_and_outlive("Start game")
+	assert_eq(int(GameRuntime.take_pending_new_game()["slot"]), 1, "the press did the work")
+
+
+## Presses the pane button [param label] and asserts it is still a live object
+## when its own `pressed` returns. Reading the pending new game after a frame
+## would not: the press hands the tree a deferred scene change.
+func _press_and_outlive(label: String) -> void:
+	var button: Button = _find_button(_screen, label)
+	assert_not_null(button, "%s is on the pane" % label)
+	button.pressed.emit()
+	assert_true(
+		is_instance_valid(button),
+		"%s is still alive when its own signal returns" % label,
+	)
+
+
+## First button under [param node] whose text is [param label], or null.
+func _find_button(node: Node, label: String) -> Button:
+	if node is Button and (node as Button).text == label:
+		return node as Button
+	for child: Node in node.get_children():
+		var found: Button = _find_button(child, label)
+		if found != null:
+			return found
+	return null

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -75,6 +75,8 @@ func _validate(game_id: StringName) -> bool:
 	var invalid_text: int = 0
 	var invalid_text_reasons: Dictionary = {}
 	var invalid_text_samples: Array = []
+	var ram_addresses: Dictionary = {}
+	var number_markers: int = 0
 	for raw_key: Variant in (text_value as Dictionary):
 		var raw_text: PackedByteArray = _pointer_bytes(data, String(raw_key), true)
 		var decoded: Dictionary = Gen2WorldScript.decode_text(raw_text)
@@ -84,6 +86,9 @@ func _validate(game_id: StringName) -> bool:
 			invalid_text_reasons[reason] = int(invalid_text_reasons.get(reason, 0)) + 1
 			if invalid_text_samples.size() < 3:
 				invalid_text_samples.append({"length": raw_text.size(), "head": _head(raw_text)})
+		var text: String = String(decoded.get("text", ""))
+		_tally_ram_markers(text, ram_addresses)
+		number_markers += text.count(Gen2TextStream.NUMBER_MARKER)
 	print("%s: scripts=%d commands=%d terminal=%d parse_failures=%d texts=%d invalid_text=%d" % [
 		game_id, script_count, command_count, terminal_count, parse_failures,
 		(text_value as Dictionary).size(), invalid_text,
@@ -95,6 +100,7 @@ func _validate(game_id: StringName) -> bool:
 	print("  invalid_text_reasons=%s" % invalid_text_reasons)
 	print("  invalid_text_samples=%s" % JSON.stringify(invalid_text_samples))
 	print("  commands=%s" % command_names)
+	_print_ram_markers(data, ram_addresses, number_markers)
 	_print_standard_table(game_id)
 	return true
 
@@ -107,6 +113,38 @@ func _pointer_bytes(data: GameData, key: String, text: bool) -> PackedByteArray:
 	var bank: int = int(parts[0])
 	var address: int = ("0x%s" % parts[1]).hex_to_int()
 	return data.world_text(bank, address) if text else data.world_script(bank, address)
+
+
+## Counts the `<RAM_xxxx>` markers one decoded text left behind.
+func _tally_ram_markers(text: String, tally: Dictionary) -> void:
+	var at: int = text.find(Gen2TextStream.RAM_MARKER)
+	while at >= 0:
+		var address: int = ("0x%s" % text.substr(
+			at + Gen2TextStream.RAM_MARKER.length(), 4
+		)).hex_to_int()
+		tally[address] = int(tally.get(address, 0)) + 1
+		at = text.find(Gen2TextStream.RAM_MARKER, at + 1)
+
+
+## Which `text_ram` targets the corpus names, split by whether the runner can
+## answer one. Everything it can is a StringBufferPointers entry, which is what
+## `Gen2WorldScriptRunner._text_buffer_ram` fills; an address outside that table
+## names storage nothing here writes and reaches the player as `<RAM_xxxx>`.
+##
+## Gold and Silver each carry one unwired entry, `0415`, and it is not a text:
+## the reference scanner reaches 94:4188 through bytes that are not commands,
+## the same speculation the parse failures above come from.
+func _print_ram_markers(data: GameData, tally: Dictionary, numbers: int) -> void:
+	var buffers: Array[int] = data.string_buffer_addresses()
+	var wired: int = 0
+	var unwired: Dictionary = {}
+	for address: Variant in tally:
+		var count: int = int(tally[address])
+		if buffers.has(int(address)):
+			wired += count
+		else:
+			unwired["%04X" % int(address)] = count
+	print("  ram_markers wired=%d unwired=%s number_markers=%d" % [wired, unwired, numbers])
 
 
 func _head(bytes: PackedByteArray) -> String:


### PR DESCRIPTION
The reported "the app exits after Create save" reproduces and is fixed.

`_refresh_details` freed the details pane's children with `free()`, and that
pane holds Rename, Start game, Cancel and Delete: pressing one destroyed the
node whose `pressed` was still on the stack, which is a hard exit with no line
number. `_refresh_slot_cards` had been detached before queueing for exactly this
reason; its sibling had not, and nor had the party, box, save editor, mod list,
mod detail, mod sources, binding sheet or dock rebuilds, each of which is also
reached from a control inside the container it empties.

All twelve now go through one `Gen2LauncherUI.clear`, which removes the child
before queueing it. A queued child still answers `is_instance_valid`, so
`_refresh_details` drops its own name field with the pane rather than reporting a
new-game form that is off screen.

`test_save_screen.gd` presses the real buttons rather than calling the API,
which is why nothing caught this: with the old `free()` the new case fails, with
the fix it passes.

`tools/checks/world_scripts.gd` additionally reports the `<RAM_xxxx>` and
`<NUM_xxxx>` markers each cached corpus leaves behind, split by whether the
runner can fill one.

| | Crystal | Gold | Silver |
|---|---|---|---|
| `text_ram` wired | 389/389 | 72/73 | 72/73 |
| `text_decimal` markers | 0 | 1 | 1 |

The single exception on Gold and Silver is not a text: the reference scanner
reaches 94:4188 through bytes that are not commands, and it decodes as a lone
`text_ram $0415`.

GUT 2,983 over 148 scripts green (both tiers, 120 s); `validate.gd -- all` exit
0 over 46 topics; save screen and both mod pages photographed.