### PR TITLE
The Pokedex is drawn on the hardware's grid

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -51,6 +51,7 @@ var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
+var _pokedex_palettes: Dictionary = {}
 var _gender_screen_palette: Array = []
 var _copyright_string: Array = []
 var _copyright_palette: Array = []
@@ -125,6 +126,7 @@ static func open_directory(path: String) -> GameData:
 	data._tiles = manifest.get("tiles", {})
 	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
+	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	var gender_palette: Variant = manifest.get("gender_screen_palette", [])
 	data._gender_screen_palette = gender_palette if gender_palette is Array else []
 	var copyright_string: Variant = manifest.get("copyright_string", [])
@@ -1626,6 +1628,37 @@ func card_badge_palette() -> PackedColorArray:
 	for packed: Variant in stored as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
+
+
+## One of `_CGB_Pokedex`'s three palettes by name: `interface` is
+## PREDEFPAL_POKEDEX, `question_mark` what an unseen species' picture wears, and
+## `cursor` the arrow's object palette. Empty when the cache does not carry it.
+func pokedex_palette(name: String) -> PackedColorArray:
+	var stored: Variant = _pokedex_palettes.get(name, [])
+	if not stored is Array or (stored as Array).size() < Gen2Palette.COLORS_PER_PIC:
+		return PackedColorArray()
+	var colors := PackedColorArray()
+	for packed: Variant in stored as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## The four tiles of a species' footprint, in the `footprints` strip's own
+## numbering: the two top halves where the species sits, and the two bottom
+## halves [constant RomLayout.FOOTPRINT_HALF_STRIDE] tiles further on, which is
+## the offset the source calls a forgotten tile-editor fix. Empty for a species
+## outside the run.
+func footprint_tiles(species: int) -> PackedInt32Array:
+	if species < 1 or species > RomLayout.FOOTPRINT_SPECIES:
+		return PackedInt32Array()
+	var index: int = species - 1
+	var first: int = (index / 8) * (8 * RomLayout.FOOTPRINT_TILES) \
+		+ (index % 8) * RomLayout.FOOTPRINT_HALF_TILES
+	return PackedInt32Array([
+		first, first + 1,
+		first + RomLayout.FOOTPRINT_HALF_STRIDE,
+		first + RomLayout.FOOTPRINT_HALF_STRIDE + 1,
+	])
 
 
 ## The three bar palettes in `GetHPPal`'s own order.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 60
+const FORMAT_VERSION: int = 61
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3520,6 +3520,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		},
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
+		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
 		"gender_screen_palette": _import_gender_screen_palette(rom, layout),
 		"menu_text": _import_menu_text(rom, layout),
 		"copyright_string": _import_copyright_string(rom, layout),
@@ -4052,6 +4053,27 @@ func _import_card_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"background": background, "badge": badge}
 
 
+## `_CGB_Pokedex`'s three palettes.
+##
+## `interface` is PREDEFPAL_POKEDEX, the four colours the whole screen is drawn
+## through; `question_mark` is what an unseen species' Slowpoke picture wears,
+## which `_CGB_Pokedex` fills the 7x7 pic box with; `cursor` is object palette 7,
+## the arrow's own. All three are four colours stored whole rather than as a
+## pair, the way `card_badge_palette` is.
+func _import_pokedex_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("pokedex", {})
+	var out: Dictionary = {}
+	for name: String in ["interface", "question_mark", "cursor"]:
+		var at: int = int(entry.get("%s_palette" % name, -1))
+		if at < 0:
+			continue
+		var colors: Array = []
+		for index: int in Gen2Palette.COLORS_PER_PIC:
+			colors.append(rom.u16le(at + index * Gen2Palette.COLOR_BYTES))
+		out[name] = colors
+	return out
+
+
 ## `Palette_TextBG7`, the four colours a text box is drawn through. Only index 0
 ## and index 3 are ever a pixel, since the font is 1bpp; the two between them are
 ## what a palette fade over a box passes through. Empty on Gold and Silver.
@@ -4525,6 +4547,33 @@ func _import_town_map_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
+## `Pokedex_LoadGFX`'s two LZ runs, each as one strip of tiles.
+##
+## Kept out of the fixed table [method _import_tiles] uses for the same reason
+## the region map's are: a compressed run has to be decompressed before its tile
+## count is even known.
+func _import_pokedex_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("pokedex", {})
+	if not entry.has("gfx"):
+		return {}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var out: Dictionary = {}
+	for run: Array in [
+		["pokedex", int(entry["gfx"]), RomLayout.POKEDEX_TILES],
+		["pokedex_slowpoke", int(entry["slowpoke"]), RomLayout.POKEDEX_SLOWPOKE_TILES],
+	]:
+		var name: String = String(run[0])
+		var tiles: int = int(run[2])
+		var raw: PackedByteArray = _lz.decompress(rom.bytes(), int(run[1]))
+		if _lz.failed or raw.size() < tiles * Gen2Tiles.TILE_BYTES:
+			return {}
+		var indices: PackedByteArray = Gen2Tiles.decode_2bpp_strip(raw, 0, tiles)
+		if not RomCache.write_indices(RomCache.tile_path(directory, name), indices):
+			return {}
+		out[name] = _strip_sheet_entry(tiles)
+	return out
+
+
 ## The title screen's graphics, each as one strip of tiles.
 ##
 ## Every one but the trail is an LZ run, so they cannot go through the fixed
@@ -4682,6 +4731,24 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"tiles": RomLayout.CARD_FRAME_TILES,
 			"first_code": 0,
 			"bits": 2,
+		},
+		## `Footprints`, one 1bpp strip of every species' four tiles.
+		## `Pokedex_GetAndPlaceFootprint` addresses a half at a time, so the
+		## strip is stored the cartridge's way and read through
+		## [method GameData.footprint_tiles] rather than reordered here.
+		## `UnownFont`, which `Pokedex_LoadUnownFont` inverts over the dex
+		## sheet's own tiles rather than loading beside it.
+		"unown_font": {
+			"offset": int(layout["pokedex"]["unown_font"]),
+			"tiles": RomLayout.UNOWN_FONT_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		"footprints": {
+			"offset": int(layout["pokedex"]["footprints"]),
+			"tiles": RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES,
+			"first_code": 0,
+			"bits": 1,
 		},
 		## LoadNamingScreenGFX's own four. The border and the cursor are 2bpp,
 		## the two entry markers 1bpp, and all four are located from the keyboard
@@ -4849,6 +4916,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_ditto_sheet(rom, layout), true)
 	written.merge(_import_title_sheets(rom, layout), true)
 	written.merge(_import_town_map_sheets(rom, layout), true)
+	written.merge(_import_pokedex_sheets(rom, layout), true)
 	written.merge(_import_intro_sheets(rom, layout), true)
 	written.merge(_import_gs_intro_sheets(rom, layout), true)
 	var done: int = 0

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -609,6 +609,42 @@ const CARD_PIC_COLUMNS: int = 5
 const CARD_PIC_ROWS: int = 7
 const CARD_PIC_TILES: int = CARD_PIC_COLUMNS * CARD_PIC_ROWS
 
+## The Pokedex's own graphics (engine/pokedex/pokedex.asm).
+##
+## `PokedexLZ` is the 58 tiles `Pokedex_LoadGFX` decompresses to `vTiles2 tile
+## $31`, and `PokedexSlowpokeLZ` the 55 that go to `vTiles0`, which is what an
+## unseen species is drawn as. Both were located by compressing the pinned
+## `gfx/pokedex` PNGs with pret's own `tools/lzcompress` flags and matching the
+## bytes: each hits once per dump, the second follows the first, and that is the
+## order the source stores them in.
+##
+## `Footprints` is 1bpp and uncompressed: 251 species of four tiles, stored as
+## eight top halves and then the eight matching bottom halves, which is why a
+## species' bottom half sits [constant FOOTPRINT_HALF_STRIDE] tiles past its top.
+## The 8 KiB run matches once per dump and is byte identical on all three.
+const POKEDEX_TILES: int = 58
+const POKEDEX_SLOWPOKE_TILES: int = 55
+## `Pokedex_GetAndPlaceFootprint` asks for two 1bpp tiles at a time, twice.
+const FOOTPRINT_TILES: int = 4
+const FOOTPRINT_HALF_TILES: int = 2
+## The gap the source calls "each bottom half is 8 tiles off": eight species of
+## two tiles sit between a footprint's halves.
+const FOOTPRINT_HALF_STRIDE: int = 8 * FOOTPRINT_HALF_TILES
+const FOOTPRINT_SPECIES: int = 251
+## The stored image is 16x64 tiles, which is 256 species of four and not 251:
+## the last eight species' bottom halves are only addressable because the run
+## carries the whole grid. All 1,024 tiles are imported for that reason.
+const FOOTPRINT_SLOTS: int = 256
+
+## `UnownFont`, the alphabet `Pokedex_LoadUnownFont` inverts into the dex sheet's
+## own `$40` onwards. The file is 27 tiles and `Request2bpp` sends
+## `NUM_UNOWN + 1`, which is the same 27; the `39 tiles` the copy before it asks
+## for runs past the sheet into whatever follows and is never drawn. Located by
+## matching the assembled `gfx/font/unown_font.png`, which hits once per dump.
+const UNOWN_FONT_TILES: int = 27
+## `FIRST_UNOWN_CHAR`, where the letters land.
+const UNOWN_FONT_FIRST_TILE: int = 0x40
+
 ## `DrawIntroPlayerPic`'s uncompressed 7x7 picture. Crystal stores Chris and
 ## Kris column-major; Gold and Silver use CAL's normal trainer picture instead.
 const INTRO_PLAYER_PIC_COLUMNS: int = 7
@@ -1676,6 +1712,16 @@ const GOLD_SILVER: Dictionary = {
 		"entry_banks": [0x68, 0x69, 0x6A, 0x6B],
 		"order_alpha": 0x40C65,
 		"order_new": 0x40D60,
+		# The screen's own graphics; see POKEDEX_TILES for how these were
+		# located. All five are byte identical across the three dumps, so only
+		# the addresses differ.
+		"gfx": 0x41511,
+		"slowpoke": 0x416B3,
+		"footprints": 0xF930E,
+		"interface_palette": 0xA34D,
+		"unown_font": 0xFB30E,
+		"question_mark_palette": 0x9559,
+		"cursor_palette": 0x9551,
 	},
 	# Battle animations. `BattleAnimations` was located by matching
 	# `BattleAnim_Pound` whole (d1 01 e0 01 31 d0 08 88 38 00 06 d0 01 88 38 00
@@ -2024,6 +2070,17 @@ const CRYSTAL: Dictionary = {
 		"entry_banks": [0x60, 0x6E, 0x73, 0x74],
 		"order_alpha": 0x40C65,
 		"order_new": 0x40D60,
+		# Crystal stores the two small palettes the other way round, which is
+		# why each is pinned rather than walked from its neighbour.
+		# `interface_palette` is PREDEFPAL_POKEDEX, pinned as its own offset the
+		# way `trainer_card.badge_palette` pins PREDEFPAL_CGB_BADGE.
+		"gfx": 0x4150E,
+		"slowpoke": 0x416B0,
+		"footprints": 0xF9434,
+		"interface_palette": 0x9EDE,
+		"unown_font": 0x1DC000,
+		"question_mark_palette": 0x8FBA,
+		"cursor_palette": 0x8FC2,
 	},
 	# Battle animations; see the Gold and Silver block above for how these were
 	# located. All five tables sit in the same two banks in every dump and only

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -1,0 +1,765 @@
+class_name Gen2PokedexPage
+extends RefCounted
+
+## The Pokedex's own tile screens (engine/pokedex/pokedex.asm).
+##
+## [Gen2Pokedex] owns the listing, the cursor and the mode; this is the picture,
+## the way [Gen2TownMapPage] is the region map's. Every layout here is one of the
+## source's `Pokedex_Draw*BG` routines read as tile writes, so a screen is a
+## 20x18 grid of tile numbers in the dex's own VRAM numbering and nothing else.
+##
+## Three sheets share that numbering, which is what `Pokedex_LoadGFX` leaves in
+## `vTiles2`:
+##
+## - `$00` to `$30` is the font, **inverted**. `Pokedex_LoadInvertedFont` XORs
+##   every byte, so a lit pixel becomes an unlit one and the whole screen is
+##   light text on dark rather than the overworld's dark on light.
+## - `$31` to `$6a` is `PokedexLZ`'s 58 tiles, which the decompress lands on top
+##   of whatever was there.
+## - `$6b` up is `LoadFontsExtra`, inverted by the same `Pokedex_InvertTiles`
+##   pass over `$60` to `$7f`. Only the run past the dex sheet survives it.
+##
+## The main screen is the one that is not a plain grid: its listing is in the
+## *window* layer at `hWX`, over a background scrolled by `POKEDEX_SCX`, so it
+## is composed in pixels by [method image_main] rather than written into one map.
+
+const COLUMNS: int = 20
+const ROWS: int = 18
+const TILE: int = 8
+const WIDTH: int = COLUMNS * TILE
+const HEIGHT: int = ROWS * TILE
+
+## Where `PokedexLZ` lands, which is what a sheet tile number is offset by.
+const SHEET_FIRST_TILE: int = 0x31
+
+## `Pokedex_FillBackgroundColor2`'s fill, and the tile every cleared cell is.
+const BACKGROUND_TILE: int = 0x32
+
+## `Pokedex_PlaceBorder`'s nine tiles, in the order it writes them: the top row,
+## then each middle row, then the bottom.
+const BORDER_TOP_LEFT: int = 0x33
+const BORDER_TOP: int = 0x34
+const BORDER_TOP_RIGHT: int = 0x35
+const BORDER_LEFT: int = 0x36
+const BORDER_RIGHT: int = 0x37
+const BORDER_BOTTOM_LEFT: int = 0x38
+const BORDER_BOTTOM: int = 0x39
+const BORDER_BOTTOM_RIGHT: int = 0x3A
+## The border's inside, which is a space rather than one of its own tiles.
+const BORDER_FILL: int = 0x7F
+
+## The sidebar's own column and its three joints (`Pokedex_DrawMainScreenBG`).
+const SIDEBAR_TOP: int = 0x59
+const SIDEBAR: int = 0x5A
+const SIDEBAR_BOTTOM: int = 0x5B
+const SIDEBAR_SPLIT_TOP: int = 0x53
+const SIDEBAR_SPLIT_BOTTOM: int = 0x54
+## The search results screen's own pair below the split, where the main screen
+## has the second box's top.
+const RESULTS_SPLIT_TOP: int = 0x69
+const RESULTS_SPLIT_BOTTOM: int = 0x6A
+
+## `DrawPokedexListWindow`: the listing's frame, its scroll bar and the two
+## tiles that replace the bar in DEXMODE_OLD.
+const WINDOW_LEFT_JOINT: int = 0x3F
+const WINDOW_LEFT_JOINT_BOTTOM: int = 0x40
+const SCROLL_TOP: int = 0x50
+const SCROLL: int = 0x51
+const SCROLL_BOTTOM: int = 0x52
+const NO_SCROLL_TOP: int = 0x66
+const NO_SCROLL: int = 0x67
+const NO_SCROLL_BOTTOM: int = 0x68
+
+## The entry screen's divider under the picture, and the page marker beside it.
+const ENTRY_DIVIDER: int = 0x61
+const PAGE_MARKER_TOP: int = 0x55
+const PAGE_MARKER: int = 0x56
+const PAGE_ONE: int = 0x57
+const PAGE_TWO: int = 0x58
+
+## `Pokedex_DrawFootprint`'s four cells, and where they go.
+const FOOTPRINT_TOP: int = 0x62
+const FOOTPRINT_BOTTOM: int = 0x64
+const FOOTPRINT_AT := Vector2i(18, 1)
+
+## `.Number`'s two tiles, and the two the height line's feet and inches use.
+const NUMBER_NO: int = 0x5C
+const NUMBER_DOT: int = 0x5D
+const HEIGHT_FEET: int = 0x5E
+const HEIGHT_INCHES: int = 0x5F
+
+## `Pokedex_PlaceCaughtSymbolIfCaught`'s own tile, which is a character.
+const CAUGHT_SYMBOL: int = 0x4F
+## `Pokedex_BlinkArrowCursor`'s two, which are characters as well.
+const CURSOR_CODE: int = 0xED
+const CURSOR_BLANK: int = 0x7F
+
+## `POKEDEX_SCX`, the five pixels the main screen's background is scrolled by.
+const MAIN_SCX: int = 5
+## `hWX` less the hardware's own seven, for the two dex modes: `$47` for a mode
+## with a scroll bar and `$4a` for DEXMODE_OLD, which has none. Neither is a tile
+## boundary once the background is scrolled, which is why the main screen is
+## composed in pixels.
+const MAIN_WINDOW_X: int = 0x47 - 7
+const MAIN_WINDOW_X_OLD: int = 0x4A - 7
+## `DrawPokedexListWindow` writes twelve columns and no more.
+const WINDOW_COLUMNS: int = 12
+
+## `String_SELECT_OPTION` and `String_START_SEARCH`, which are tile runs rather
+## than text: the two button pictures are drawn out of the dex sheet.
+const SELECT_OPTION: Array[int] = [0x3B, 0x48, 0x49, 0x4A, 0x44, 0x45, 0x46, 0x47]
+const START_SEARCH: Array[int] = [
+	0x3C, 0x3B, 0x41, 0x42, 0x43, 0x4B, 0x4C, 0x4D, 0x4E, 0x3C,
+]
+## `.TypeLeftRightArrows`' two ends, and the pair the Unown screen puts under its
+## own box.
+const ARROW_LEFT: int = 0x3D
+const ARROW_RIGHT: int = 0x3E
+
+var font: Gen2Font = null
+## The dex sheet, the Slowpoke picture and the footprint strip, each as the
+## cache's own index buffer.
+var _sheet: PackedByteArray = PackedByteArray()
+var _slowpoke: PackedByteArray = PackedByteArray()
+var _footprints: PackedByteArray = PackedByteArray()
+var _unown_font: PackedByteArray = PackedByteArray()
+var _palette: PackedColorArray = PackedColorArray()
+var _question_mark: PackedColorArray = PackedColorArray()
+
+
+## [param data] supplies the glyphs and all three sheets; a cache without them
+## answers null rather than drawing a screen of blanks.
+static func from_data(data: GameData) -> Gen2PokedexPage:
+	if data == null:
+		return null
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null:
+		return null
+	var out := Gen2PokedexPage.new()
+	out.font = glyphs
+	out._sheet = data.tile_indices("pokedex")
+	out._slowpoke = data.tile_indices("pokedex_slowpoke")
+	out._footprints = data.tile_indices("footprints")
+	out._unown_font = data.tile_indices("unown_font")
+	out._palette = data.pokedex_palette("interface")
+	out._question_mark = data.pokedex_palette("question_mark")
+	return out
+
+
+func ready() -> bool:
+	return font != null and not _sheet.is_empty() and not _footprints.is_empty() \
+		and _palette.size() == Gen2Palette.COLORS_PER_PIC
+
+
+## A screen filled the way `Pokedex_FillBackgroundColor2` fills one.
+static func blank_map() -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	map.fill(BACKGROUND_TILE)
+	return map
+
+
+## `Pokedex_DrawMainScreenBG`: the left sidebar, the two boxes and the bottom
+## bar. The listing is not in it; that is the window, and [method window_map]
+## draws it.
+##
+## [param seen] and [param caught] are the two counts `CountSetBits` prints.
+func main_background(seen: int, caught: int) -> PackedInt32Array:
+	_unown_letters = false
+	var map: PackedInt32Array = blank_map()
+	_place_border(map, 0, 0, 7, 7)
+	_place_border(map, 0, 9, 6, 7)
+	_text(map, 1, 11, "SEEN")
+	_number(map, 5, 12, seen, 3)
+	_text(map, 1, 14, "OWN")
+	_number(map, 5, 15, caught, 3)
+	# `String_SELECT_OPTION` falls through into `String_START_SEARCH`, so the one
+	# `Pokedex_PlaceString` at (1,17) writes both runs; the START one on its own
+	# is in the window, which is what covers the right-hand half of this row.
+	_tiles(map, 1, 17, SELECT_OPTION)
+	_tiles(map, 1 + SELECT_OPTION.size(), 17, START_SEARCH)
+	_column(map, 8, 1, 7, SIDEBAR)
+	_column(map, 8, 10, 6, SIDEBAR)
+	_put(map, 8, 0, SIDEBAR_TOP)
+	_put(map, 8, 8, SIDEBAR_SPLIT_TOP)
+	_put(map, 8, 9, SIDEBAR_SPLIT_BOTTOM)
+	_put(map, 8, 16, SIDEBAR_BOTTOM)
+	_place_pic_corner(map, 1, 1)
+	return map
+
+
+## `Pokedex_DrawSearchResultsScreenBG`, which is the main screen's sidebar with
+## one box instead of two and the result count under it.
+func search_results_background(count: int, type_line: String) -> PackedInt32Array:
+	_unown_letters = false
+	var map: PackedInt32Array = blank_map()
+	_place_border(map, 0, 0, 7, 7)
+	_place_border(map, 0, 11, 5, 18)
+	_text(map, 1, 12, "SEARCH RESULTS")
+	_text(map, 1, 13, "  TYPE")
+	# `.BottomWindowText`'s third line and `Pokedex_PlaceSearchResultsTypeStrings`
+	# are written into two different maps and overlap on screen; laid out as one
+	# row here, which is the one thing on this screen the oracle has not settled.
+	_text(map, 1, 14, type_line)
+	_text(map, 9, 14, "FOUND!")
+	_number(map, 1, 16, count, 3)
+	_put(map, 8, 0, SIDEBAR_TOP)
+	_column(map, 8, 1, 7, SIDEBAR)
+	_put(map, 8, 8, SIDEBAR_SPLIT_TOP)
+	_put(map, 8, 9, RESULTS_SPLIT_TOP)
+	_put(map, 8, 10, RESULTS_SPLIT_BOTTOM)
+	_place_pic_corner(map, 1, 1)
+	return map
+
+
+## `DrawPokedexListWindow` and `Pokedex_PrintListing`, as the twelve-column
+## window the main screen and the results screen both put their listing in.
+##
+## [param rows] is [method Gen2Pokedex.rows]' own shape: `number`, `name`,
+## `seen` and `caught` per visible entry. [param old_mode] swaps the scroll bar
+## for the two tiles that replace it and is what prints a dex number above each
+## name; [param cursor] is which row the arrow stands on, or -1 while it blinks
+## off.
+func window_map(rows: Array, old_mode: bool, cursor: int) -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(WINDOW_COLUMNS * ROWS)
+	map.fill(CURSOR_BLANK)
+	# `DrawPokedexListWindow` fills its own row 17, and `Pokedex_InitMainScreen`
+	# writes `String_START_SEARCH` over it: the bar under the listing is the
+	# window's, not the background's.
+	for column: int in WINDOW_COLUMNS:
+		map[17 * WINDOW_COLUMNS + column] = BACKGROUND_TILE
+	for index: int in START_SEARCH.size():
+		map[17 * WINDOW_COLUMNS + index] = START_SEARCH[index]
+	for column: int in 11:
+		map[column] = BORDER_TOP
+		map[16 * WINDOW_COLUMNS + column] = BORDER_BOTTOM
+	map[5] = WINDOW_LEFT_JOINT
+	map[16 * WINDOW_COLUMNS + 5] = WINDOW_LEFT_JOINT_BOTTOM
+	map[11] = NO_SCROLL_TOP if old_mode else SCROLL_TOP
+	for row: int in ROWS - 3:
+		map[(row + 1) * WINDOW_COLUMNS + 11] = NO_SCROLL if old_mode else SCROLL
+	map[(ROWS - 2) * WINDOW_COLUMNS + 11] = NO_SCROLL_BOTTOM if old_mode else SCROLL_BOTTOM
+
+	_window_rows(map, rows, old_mode, cursor)
+	return map
+
+
+## `Pokedex_PrintListing`, which both listing screens share: one entry every two
+## rows from row 2, the caught symbol one cell ahead of the name, and the arrow
+## in column 0.
+func _window_rows(
+	map: PackedInt32Array, rows: Array, old_mode: bool, cursor: int
+) -> void:
+	for index: int in rows.size():
+		var entry: Dictionary = rows[index]
+		var row: int = 2 + index * 2
+		if row >= ROWS:
+			break
+		if old_mode:
+			_window_number(map, 1, row - 1, int(entry.get("number", 0)))
+		if not bool(entry.get("seen", false)):
+			_window_text(map, 2, row, Gen2Pokedex.NOT_SEEN_NAME)
+			continue
+		if bool(entry.get("caught", false)):
+			map[row * WINDOW_COLUMNS + 1] = CAUGHT_SYMBOL
+		_window_text(map, 2, row, String(entry.get("name", "")))
+	if cursor >= 0 and cursor < rows.size():
+		map[(2 + cursor * 2) * WINDOW_COLUMNS] = CURSOR_CODE
+
+
+## How much of the results window reaches the screen; see [method
+## results_window_map].
+const RESULTS_WINDOW_ROWS: int = 11
+
+
+## `DrawPokedexSearchResultsWindow`: two stacked frames rather than the main
+## screen's one, with the four-row listing in the upper.
+func results_window_map(rows: Array, cursor: int) -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(WINDOW_COLUMNS * ROWS)
+	map.fill(CURSOR_BLANK)
+	# `DrawPokedexSearchResultsWindow` draws a second frame over rows 11 to 17,
+	# which at `hWX` $4a would cut `.BottomWindowText` in the background box in
+	# half. Only the listing's own frame is drawn until the oracle says what the
+	# hardware puts there; see HANDOFF.md.
+	for frame: Array in [[0, 10]]:
+		var top: int = int(frame[0])
+		var bottom: int = int(frame[1])
+		for column: int in 11:
+			map[top * WINDOW_COLUMNS + column] = BORDER_TOP
+			map[bottom * WINDOW_COLUMNS + column] = BORDER_BOTTOM
+		map[top * WINDOW_COLUMNS + 11] = NO_SCROLL_TOP
+		for row: int in range(top + 1, bottom):
+			map[row * WINDOW_COLUMNS + 11] = NO_SCROLL
+		map[bottom * WINDOW_COLUMNS + 11] = NO_SCROLL_BOTTOM
+	map[5] = WINDOW_LEFT_JOINT
+	map[10 * WINDOW_COLUMNS + 5] = WINDOW_LEFT_JOINT_BOTTOM
+	_window_rows(map, rows, false, cursor)
+	return map
+
+
+## `Pokedex_DrawDexEntryScreenBG` and `DisplayDexEntry`, as one grid.
+##
+## [param entry] is [method GameData.dex_entry]'s own record. A species that has
+## not been caught keeps the placeholder height and weight the background draws,
+## which is what the source's early `ret z` leaves on screen.
+func entry_map(
+	number: int, name: String, entry: Dictionary, caught: bool, page: int, cursor: int
+) -> PackedInt32Array:
+	_unown_letters = false
+	var map: PackedInt32Array = blank_map()
+	_place_border(map, 0, 0, 15, 18)
+	_put(map, 19, 0, BORDER_TOP)
+	_column(map, 19, 1, 15, CURSOR_BLANK)
+	_put(map, 19, 16, BORDER_BOTTOM)
+	_fill(map, 1, 10, 19, ENTRY_DIVIDER)
+	_fill(map, 1, 17, 18, CURSOR_BLANK)
+	_text(map, 9, 7, "HT  ?")
+	_put(map, 14, 7, HEIGHT_FEET)
+	_text(map, 15, 7, "??")
+	_put(map, 17, 7, HEIGHT_INCHES)
+	_text(map, 9, 9, "WT   ???lb")
+	_put(map, 0, 17, SELECT_OPTION[0])
+	_text(map, 1, 17, " PAGE AREA CRY PRNT")
+	_place_pic_corner(map, 1, 1)
+
+	_text(map, 9, 3, name)
+	_text(map, 9, 5, String(entry.get("category", "")))
+	_put(map, 2, 8, NUMBER_NO)
+	_put(map, 3, 8, NUMBER_DOT)
+	_number(map, 4, 8, number, 3, true)
+	if caught:
+		# `PrintNum` writes the height as four digits with two in front of the
+		# point, and the point is then overwritten with the feet symbol; the
+		# weight is five digits with four in front of it, which is tenths of a
+		# pound. Both are the numbers the cartridge stores, not a conversion.
+		var height: int = int(entry.get("height", 0))
+		@warning_ignore("integer_division")
+		_number(map, 12, 7, height / 100, 2)
+		_put(map, 14, 7, HEIGHT_FEET)
+		_number(map, 15, 7, height % 100, 2, true)
+		_number(map, 11, 9, int(entry.get("weight", 0)), 5, false, 1)
+	_put(map, 1, 9, PAGE_MARKER_TOP)
+	_put(map, 2, 9, PAGE_MARKER_TOP)
+	_put(map, 1, 10, PAGE_MARKER)
+	_put(map, 2, 10, PAGE_ONE if page == Gen2Pokedex.PAGE_1 else PAGE_TWO)
+	var pages: Array = entry.get("pages", []) as Array
+	var body: String = String(pages[page]) if page < pages.size() else ""
+	_paragraph(map, 2, 11, body)
+	_place_footprint_cells(map)
+	if cursor >= 0 and cursor < Gen2PokedexScreen.ENTRY_BUTTONS.size():
+		_put(map, ENTRY_CURSOR_COLUMNS[cursor], 17, CURSOR_CODE)
+	return map
+
+
+## `DexEntryScreen_ArrowCursorData`'s four `dwcoord`s, which are all on row 17.
+const ENTRY_CURSOR_COLUMNS: Array[int] = [1, 6, 11, 15]
+## `.ArrowCursorData` on the OPTION screen and on SEARCH, whose rows are the ones
+## the two `dwcoord` lists name.
+const OPTION_CURSOR_ROWS: Array[int] = [4, 6, 8, 10]
+const SEARCH_CURSOR_ROWS: Array[int] = [4, 6, 13, 15]
+
+
+## `Pokedex_DrawOptionScreenBG`, whose fourth row is drawn only once
+## `wUnlockedUnownMode` is set.
+func option_map(
+	unown_unlocked: bool, cursor: int, description: String = ""
+) -> PackedInt32Array:
+	_unown_letters = false
+	var map: PackedInt32Array = blank_map()
+	_place_border(map, 0, 2, 8, 18)
+	_title(map, 1, "OPTION")
+	for index: int in Gen2Pokedex.MODE_ROWS.size():
+		if index == 3 and not unown_unlocked:
+			break
+		_text(map, 3, OPTION_CURSOR_ROWS[index], String(
+			Gen2Pokedex.MODE_ROWS[index]["label"]
+		))
+	var rows: int = 4 if unown_unlocked else 3
+	if cursor >= 0 and cursor < rows:
+		_put(map, 2, OPTION_CURSOR_ROWS[cursor], CURSOR_CODE)
+	_bottom_box(map, description)
+	return map
+
+
+## `Pokedex_DisplayModeDescription`, `Pokedex_DisplayChangingModesMessage` and
+## `Pokedex_DisplayTypeNotFoundMessage` are the same box redrawn: four rows at
+## (0,12) with two lines of words from (1,14).
+func _bottom_box(map: PackedInt32Array, text: String) -> void:
+	_place_border(map, 0, 12, 4, 18)
+	var row: int = 0
+	for line: String in text.split("\n"):
+		if row >= 2:
+			break
+		_text(map, 1, 14 + row, line)
+		row += 1
+
+
+## `Pokedex_DrawSearchScreenBG`, with the two chosen type names in place.
+func search_map(
+	type_1: String, type_2: String, cursor: int, message: String = ""
+) -> PackedInt32Array:
+	_unown_letters = false
+	var map: PackedInt32Array = blank_map()
+	_place_border(map, 0, 2, 14, 18)
+	_title(map, 1, "SEARCH")
+	for row: int in [4, 6]:
+		_put(map, 8, row, ARROW_LEFT)
+		_put(map, 17, row, ARROW_RIGHT)
+	_text(map, 3, 4, "TYPE1")
+	_text(map, 3, 6, "TYPE2")
+	_text(map, 10, 4, type_1)
+	_text(map, 10, 6, type_2)
+	_text(map, 3, 13, "BEGIN SEARCH!!")
+	_text(map, 3, 15, "CANCEL")
+	if cursor >= 0 and cursor < SEARCH_CURSOR_ROWS.size():
+		_put(map, 2, SEARCH_CURSOR_ROWS[cursor], CURSOR_CODE)
+	if not message.is_empty():
+		_bottom_box(map, message)
+	return map
+
+
+## `Pokedex_DrawUnownModeBG` and its own letter walk.
+##
+## [param forms] is `wUnownDex`, the forms in catching order, and
+## [constant UNOWN_COORDS] the table it indexes: the letter's cell and the cell
+## the cursor stands in beside it, which are not always the same column.
+## [param word] is `PrintUnownWord`'s own, the chamber word for the form the
+## cursor is on.
+func unown_map(forms: Array, cursor: int, word: String = "") -> PackedInt32Array:
+	_unown_letters = true
+	var map: PackedInt32Array = blank_map()
+	_place_border(map, 2, 1, 10, 13)
+	_place_border(map, 2, 14, 1, 13)
+	_put(map, 2, 15, ARROW_LEFT)
+	_put(map, 16, 15, ARROW_RIGHT)
+	_place_pic_corner(map, 6, 5)
+	for index: int in mini(forms.size(), UNOWN_COORDS.size()):
+		var form: int = int(forms[index])
+		if form <= 0:
+			break
+		var at: Array = UNOWN_COORDS[index]
+		_put(map, int(at[0]), int(at[1]), UNOWN_FIRST_CHAR + form - 1)
+		if index == cursor:
+			_put(map, int(at[2]), int(at[3]), CURSOR_CODE)
+	# `PrintUnownWord` clears twelve cells at (4,15) and prints the cursor's own
+	# word into them.
+	_fill(map, 4, 15, 12, CURSOR_BLANK)
+	_text(map, 4, 15, word)
+	return map
+
+
+## `FIRST_UNOWN_CHAR`, which the letter walk adds the form to. The letters are
+## `UnownFont` inverted into the dex sheet's own numbering, so a form's cell is a
+## sheet tile rather than a character.
+const UNOWN_FIRST_CHAR: int = RomLayout.UNOWN_FONT_FIRST_TILE
+## `UnownModeLetterAndCursorCoords`, as (letter x, letter y, cursor x, cursor y)
+## per form in catching order.
+const UNOWN_COORDS: Array = [
+	[4, 11, 3, 11], [4, 10, 3, 10], [4, 9, 3, 9], [4, 8, 3, 8],
+	[4, 7, 3, 7], [4, 6, 3, 6], [4, 5, 3, 5], [4, 4, 3, 4],
+	[4, 3, 3, 2], [5, 3, 5, 2], [6, 3, 6, 2], [7, 3, 7, 2],
+	[8, 3, 8, 2], [9, 3, 9, 2], [10, 3, 10, 2], [11, 3, 11, 2],
+	[12, 3, 12, 2], [13, 3, 13, 2], [14, 3, 15, 2], [14, 4, 15, 4],
+	[14, 5, 15, 5], [14, 6, 15, 6], [14, 7, 15, 7], [14, 8, 15, 8],
+	[14, 9, 15, 9], [14, 10, 15, 10],
+]
+
+
+## One grid as pixels. [param pic] is the species picture drawn into the 7x7 box
+## the layout left blank, or null for a screen that shows none.
+func image(map: PackedInt32Array, pic: Image = null, pic_at: Vector2i = Vector2i(1, 1)) -> Image:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			_blit_tile(indices, WIDTH, map[row * COLUMNS + column], column * TILE, row * TILE)
+	var out: Image = Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, _palette)
+	if pic != null:
+		# `_PrepMonFrontpic` centres a pic in its seven-tile cell and sits it on
+		# the cell's floor, so a 5x5 species is not drawn in the corner.
+		var cell: int = 7 * TILE
+		out.blend_rect(pic, Rect2i(Vector2i.ZERO, pic.get_size()), Vector2i(
+			pic_at.x * TILE + (cell - pic.get_width()) / 2,
+			pic_at.y * TILE + cell - pic.get_height()
+		))
+	return out
+
+
+## The main screen, composed the way the hardware composes it: the background
+## scrolled left by [constant MAIN_SCX] and the listing window blitted over it at
+## its own `hWX`. Both layers wrap at the background map's 256 pixels, which is
+## why the background is drawn wide and sampled rather than blitted.
+func image_main(
+	background: PackedInt32Array, window: PackedInt32Array, old_mode: bool,
+	pic: Image = null, window_rows: int = ROWS
+) -> Image:
+	var out: Image = image(background, pic)
+	var scrolled: Image = Image.create(WIDTH, HEIGHT, false, out.get_format())
+	for x: int in WIDTH:
+		scrolled.blit_rect(
+			out, Rect2i((x + MAIN_SCX) % WIDTH, 0, 1, HEIGHT), Vector2i(x, 0)
+		)
+	var indices := PackedByteArray()
+	indices.resize(WINDOW_COLUMNS * TILE * HEIGHT)
+	for row: int in ROWS:
+		for column: int in WINDOW_COLUMNS:
+			_blit_tile(
+				indices, WINDOW_COLUMNS * TILE,
+				window[row * WINDOW_COLUMNS + column], column * TILE, row * TILE
+			)
+	var layer: Image = Gen2PicImage.from_indices(
+		indices, WINDOW_COLUMNS * TILE, HEIGHT, _palette
+	)
+	var at: int = MAIN_WINDOW_X_OLD if old_mode else MAIN_WINDOW_X
+	scrolled.blit_rect(
+		layer,
+		Rect2i(0, 0, mini(layer.get_width(), WIDTH - at), window_rows * TILE),
+		Vector2i(at, 0)
+	)
+	return scrolled
+
+
+## The Slowpoke picture, which is what `Pokedex_LoadSelectedMonTiles` puts in the
+## box for a species that has not been seen. Drawn through its own palette, the
+## one `_CGB_Pokedex` fills the 7x7 box with.
+func unseen_pic() -> Image:
+	if _slowpoke.is_empty():
+		return null
+	var colors: PackedColorArray = _question_mark if _question_mark.size() \
+		== Gen2Palette.COLORS_PER_PIC else _palette
+	var side: int = 7 * TILE
+	var indices := PackedByteArray()
+	indices.resize(side * side)
+	for tile: int in mini(RomLayout.POKEDEX_SLOWPOKE_TILES, 49):
+		@warning_ignore("integer_division")
+		Gen2Font.blit_slot(
+			_slowpoke, _slowpoke.size() / TILE, tile, indices, side,
+			(tile / 7) * TILE, (tile % 7) * TILE
+		)
+	return Gen2PicImage.from_indices(indices, side, side, colors)
+
+
+## `Pokedex_LoadCurrentFootprint`, as the four tiles the entry screen's grid
+## names. Answers false when the cache carries no footprint for the species, in
+## which case the four cells keep whatever the sheet has at those numbers.
+func load_footprint(data: GameData, species: int) -> bool:
+	_footprint = PackedInt32Array()
+	if data == null:
+		return false
+	var tiles: PackedInt32Array = data.footprint_tiles(species)
+	if tiles.is_empty():
+		return false
+	_footprint = tiles
+	return true
+
+
+var _footprint := PackedInt32Array()
+## Whether `Pokedex_LoadUnownFont` has run, which only the Unown screen does.
+var _unown_letters: bool = false
+
+
+## `Pokedex_DrawFootprint`'s four cells at (18,1) and (18,2).
+func _place_footprint_cells(map: PackedInt32Array) -> void:
+	for index: int in 4:
+		@warning_ignore("integer_division")
+		_put(
+			map, FOOTPRINT_AT.x + (index % 2), FOOTPRINT_AT.y + (index / 2),
+			FOOTPRINT_TOP + index if index < 2 else FOOTPRINT_BOTTOM + index - 2
+		)
+
+
+## `Pokedex_PlaceBorder`: a box [param height] rows of inside tall and
+## [param width] columns of inside wide, from its own top-left corner.
+func _place_border(
+	map: PackedInt32Array, x: int, y: int, height: int, width: int
+) -> void:
+	_put(map, x, y, BORDER_TOP_LEFT)
+	for column: int in width:
+		_put(map, x + 1 + column, y, BORDER_TOP)
+	_put(map, x + 1 + width, y, BORDER_TOP_RIGHT)
+	for row: int in height:
+		_put(map, x, y + 1 + row, BORDER_LEFT)
+		for column: int in width:
+			_put(map, x + 1 + column, y + 1 + row, BORDER_FILL)
+		_put(map, x + 1 + width, y + 1 + row, BORDER_RIGHT)
+	_put(map, x, y + 1 + height, BORDER_BOTTOM_LEFT)
+	for column: int in width:
+		_put(map, x + 1 + column, y + 1 + height, BORDER_BOTTOM)
+	_put(map, x + 1 + width, y + 1 + height, BORDER_BOTTOM_RIGHT)
+
+
+## `Pokedex_PlaceFrontpicAtHL`: the 7x7 run of tile numbers the picture is drawn
+## through, counted down each column, which is how a pic is stored.
+func _place_pic_corner(map: PackedInt32Array, x: int, y: int) -> void:
+	for row: int in 7:
+		for column: int in 7:
+			_put(map, x + column, y + row, row + column * 7)
+
+
+## `.Title`'s own three pieces: the SELECT picture, the name, and the START one.
+func _title(map: PackedInt32Array, y: int, label: String) -> void:
+	_put(map, 0, y, SELECT_OPTION[0])
+	_text(map, 1, y, " %s " % label)
+	_put(map, 2 + label.length(), y, START_SEARCH[0])
+
+
+func _column(map: PackedInt32Array, x: int, y: int, height: int, tile: int) -> void:
+	for row: int in height:
+		_put(map, x, y + row, tile)
+
+
+func _fill(map: PackedInt32Array, x: int, y: int, width: int, tile: int) -> void:
+	for column: int in width:
+		_put(map, x + column, y, tile)
+
+
+func _tiles(map: PackedInt32Array, x: int, y: int, run: Array[int]) -> void:
+	for index: int in run.size():
+		_put(map, x + index, y, run[index])
+
+
+## `PlaceString`, whose `CheckDict` expands the shorthand before a tile is drawn.
+##
+## `#` is `$54` and prints "POKé" as four characters; on this screen `$54` is a
+## dex sheet tile, so a byte placed as itself would draw part of the frame. The
+## expansion cannot go back through the encoder either, because "POKé" is the
+## shorthand's own text and encodes to `$54` again.
+const POKE_CODES: Array[int] = [0x8F, 0x8E, 0x8A, 0xEA]
+
+
+func _text(map: PackedInt32Array, x: int, y: int, text: String) -> void:
+	var at: int = x
+	var first: bool = true
+	for part: String in text.split("#"):
+		if not first:
+			for code: int in POKE_CODES:
+				_put(map, at, y, code)
+				at += 1
+		first = false
+		var codes: PackedByteArray = Gen2Text.encode(part)
+		for index: int in codes.size():
+			_put(map, at + index, y, codes[index])
+		at += codes.size()
+
+
+## `PrintNum`, as the digits it writes. [param leading_zeros] is its own flag;
+## [param decimals] splits the run the way the height and weight lines do.
+func _number(
+	map: PackedInt32Array, x: int, y: int, value: int, width: int,
+	leading_zeros: bool = false, decimals: int = 0
+) -> void:
+	var text: String = String.num_int64(maxi(value, 0))
+	if leading_zeros:
+		text = text.lpad(width, "0")
+	else:
+		text = text.lpad(width, " ")
+	if decimals > 0 and text.length() > decimals:
+		text = "%s.%s" % [
+			text.substr(0, text.length() - decimals),
+			text.substr(text.length() - decimals),
+		]
+	_text(map, x, y, text)
+
+
+## One dex entry's page, wrapped into the five rows `ClearBox` cleared for it.
+func _paragraph(map: PackedInt32Array, x: int, y: int, text: String) -> void:
+	var row: int = 0
+	for line: String in text.split("\n"):
+		if row >= 5:
+			break
+		_text(map, x, y + row, line)
+		row += 1
+
+
+func _put(map: PackedInt32Array, x: int, y: int, tile: int) -> void:
+	if x < 0 or x >= COLUMNS or y < 0 or y >= ROWS:
+		return
+	map[y * COLUMNS + x] = tile
+
+
+func _window_text(map: PackedInt32Array, x: int, y: int, text: String) -> void:
+	var codes: PackedByteArray = Gen2Text.encode(text)
+	for index: int in codes.size():
+		var column: int = x + index
+		if column >= WINDOW_COLUMNS or y >= ROWS:
+			break
+		map[y * WINDOW_COLUMNS + column] = codes[index]
+
+
+func _window_number(map: PackedInt32Array, x: int, y: int, value: int) -> void:
+	var text: String = String.num_int64(maxi(value, 0)).lpad(3, "0")
+	_window_text(map, x, y, text)
+
+
+## One tile of the dex's own VRAM into an index buffer. `$31` to `$6a` is the
+## dex sheet, the footprint cells are the four the strip was loaded with, and
+## everything else is the font, inverted the way `Pokedex_LoadInvertedFont`
+## leaves it.
+func _blit_tile(
+	into: PackedByteArray, into_width: int, tile: int, at_x: int, at_y: int
+) -> void:
+	# `Pokedex_LoadUnownFont` lands on top of the sheet, so this run is the
+	# alphabet on the Unown screen and the sheet's own tiles everywhere else.
+	if _unown_letters and tile >= UNOWN_FIRST_CHAR \
+		and tile < UNOWN_FIRST_CHAR + RomLayout.UNOWN_FONT_TILES:
+		@warning_ignore("integer_division")
+		Gen2Font.blit_slot(
+			_unown_font, _unown_font.size() / TILE, tile - UNOWN_FIRST_CHAR,
+			into, into_width, at_x, at_y
+		)
+		_invert(into, into_width, at_x, at_y)
+		return
+	var footprint: int = _footprint_slot(tile)
+	if footprint >= 0:
+		@warning_ignore("integer_division")
+		Gen2Font.blit_slot(
+			_footprints, _footprints.size() / TILE, footprint,
+			into, into_width, at_x, at_y
+		)
+		_invert(into, into_width, at_x, at_y)
+		return
+	if tile >= SHEET_FIRST_TILE and tile < SHEET_FIRST_TILE + RomLayout.POKEDEX_TILES:
+		@warning_ignore("integer_division")
+		Gen2Font.blit_slot(
+			_sheet, _sheet.size() / TILE, tile - SHEET_FIRST_TILE,
+			into, into_width, at_x, at_y
+		)
+		return
+	font.draw_code(tile, into, into_width, at_x, at_y)
+	_invert(into, into_width, at_x, at_y)
+
+
+## Which of the four loaded footprint tiles a cell names, or -1 for a cell that
+## is not one. The numbers are `Pokedex_DrawFootprint`'s own.
+func _footprint_slot(tile: int) -> int:
+	if _footprint.size() != 4:
+		return -1
+	if tile == FOOTPRINT_TOP:
+		return _footprint[0]
+	if tile == FOOTPRINT_TOP + 1:
+		return _footprint[1]
+	if tile == FOOTPRINT_BOTTOM:
+		return _footprint[2]
+	if tile == FOOTPRINT_BOTTOM + 1:
+		return _footprint[3]
+	return -1
+
+
+## `Pokedex_LoadInvertedFont`'s `xor $ff`, which on a 1bpp tile swaps the two
+## indices a pixel can be: 3 is lit and 0 is not (`Serve1bppRequest` writes each
+## byte into both planes).
+func _invert(into: PackedByteArray, into_width: int, at_x: int, at_y: int) -> void:
+	@warning_ignore("integer_division")
+	var height: int = into.size() / into_width
+	for y: int in TILE:
+		var row: int = at_y + y
+		if row < 0 or row >= height:
+			continue
+		for x: int in TILE:
+			var column: int = at_x + x
+			if column < 0 or column >= into_width:
+				continue
+			var at: int = row * into_width + column
+			into[at] = 0 if into[at] == 3 else 3

--- a/game/render/pokedex_page.gd.uid
+++ b/game/render/pokedex_page.gd.uid
@@ -1,0 +1,1 @@
+uid://bawk8bspjgyil

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -36,17 +36,17 @@ const MODE_ROWS: Array[Dictionary] = [
 	{
 		"mode": RomLayout.DEXMODE_NEW,
 		"label": "NEW #DEX MODE",
-		"description": "#MN are listed by\nevolution type.",
+		"description": "PKMN are listed by\nevolution type.",
 	},
 	{
 		"mode": RomLayout.DEXMODE_OLD,
 		"label": "OLD #DEX MODE",
-		"description": "#MN are listed by\nofficial type.",
+		"description": "PKMN are listed by\nofficial type.",
 	},
 	{
 		"mode": RomLayout.DEXMODE_ABC,
 		"label": "A to Z MODE",
-		"description": "#MN are listed\nalphabetically.",
+		"description": "PKMN are listed\nalphabetically.",
 	},
 	{
 		"mode": RomLayout.DEXMODE_UNOWN,

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -4,11 +4,9 @@ extends Control
 ## The Pokedex (engine/pokedex/pokedex.asm), embedded in the overworld the way
 ## the start menu and its own submenus are.
 ##
-## Presented as a window-resolution Control panel, consistent with the start
-## menu, mart, phone and PC storage overlays rather than the hardware's tiled
-## screen: no `gfx/pokedex` graphics are imported, so there is nothing to draw a
-## tile-accurate listing with. Every rule the screen obeys is [Gen2Pokedex]'s,
-## which is the source's own.
+## Drawn on the hardware's own tile grid: [Gen2Pokedex] owns the listing, the
+## cursor and the mode, and [Gen2PokedexPage] the picture, the way the region map
+## and the trainer card are split. Every rule the screen obeys is the source's.
 ##
 ## All six of the source's states are here: the listing, the entry screen, the
 ## OPTION screen, SEARCH, its results and the Unown dex. The OPTION screen draws
@@ -28,17 +26,14 @@ signal cry_requested(species: int)
 
 enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA, UNOWN }
 
-const PANEL: Color = Color("#14233a")
-const BORDER: Color = Color("#4f6f9e")
-const SCRIM: Color = Color(0.02, 0.04, 0.08, 0.78)
-const TEXT: Color = Color("#f4f7fb")
-const MUTED: Color = Color("#9eacc0")
-const ACCENT: Color = Color("#f3c969")
+## The dex is drawn in hardware pixels and the start menu it opens over is
+## ordinary UI at window resolution, so it carries a [Gen2Screen] of its own the
+## way [Gen2TownMapScreen] does.
+const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
-## `Pokedex_PlaceCaughtSymbolIfCaught` writes one tile ahead of the name, and a
-## row that is not caught keeps the blank the listing was cleared with.
-const CAUGHT_SYMBOL: String = "*"
-const UNCAUGHT_SYMBOL: String = " "
+## `Pokedex_BlinkArrowCursor` counts its own frames and shows the arrow on the
+## eight it is off `$8`, so the cursor is up for eight frames and down for eight.
+const CURSOR_BLINK_FRAMES: int = 8
 
 ## `DexEntryScreen_ArrowCursorData`'s four positions, in its own order. PRNT
 ## wants a printer, which is deliberately out, so it is drawn and refuses.
@@ -61,11 +56,18 @@ var _mode_rows: Array = []
 
 var _area: Gen2TownMapScreen = null
 
-var _title: Label = null
-var _summary: Label = null
-var _options: VBoxContainer = null
-var _status: Label = null
-var _footer: Label = null
+var _page: Gen2PokedexPage = null
+## The 160x144 field inside the hardware screen, and the one layer drawn into it.
+var _field: Control = null
+var _background: TextureRect = null
+## `Pokedex_DisplayChangingModesMessage` and `Pokedex_DisplayTypeNotFoundMessage`
+## both replace the bottom box's own words; empty means the box says what its
+## screen normally says.
+var _message: String = ""
+## `wDexArrowCursorBlinkCounter`, and the leftover of a hardware frame this
+## screen has not counted yet.
+var _blink: int = 0
+var _elapsed: float = 0.0
 
 
 ## Optional the way the trainer card is: without a world, its state or a cache
@@ -78,10 +80,13 @@ func open(data: GameData, world: Gen2WorldAPI, previous_entry: int = 0) -> bool:
 		return false
 	if _data.dex_order_new().is_empty() or _data.dex_order_alpha().is_empty():
 		return false
+	_page = Gen2PokedexPage.from_data(_data)
+	if _page == null or not _page.ready():
+		return false
 	_dex = Gen2Pokedex.open(
 		_data, _world.state, _world.state.last_dex_mode(), previous_entry
 	)
-	if is_inside_tree() and _options != null:
+	if is_inside_tree() and _background != null:
 		_open_list_mode()
 	return true
 
@@ -98,6 +103,13 @@ func _ready() -> void:
 ## cartridge's own byte survives the dex closing.
 func previous_entry() -> int:
 	return _dex.prev_entry if _dex != null else 0
+
+
+## Which species the listing's cursor is on, which every screen here draws the
+## picture of. A preview and a test read it rather than the model, since the
+## screen is what owns the mode.
+func selected_species() -> int:
+	return _dex.selected_species() if _dex != null else 0
 
 
 func current_mode() -> Mode:
@@ -150,7 +162,7 @@ func _handle_list(button: int) -> bool:
 			_open_search_mode()
 			return true
 	if _dex.move_listing(button):
-		_render_list()
+		_refresh()
 	return Gen2Button.is_direction(button)
 
 
@@ -173,14 +185,14 @@ func _handle_entry(button: int) -> bool:
 			## four positions, and stops at either end.
 			var next: int = _entry_cursor + (1 if button == Gen2Button.RIGHT else -1)
 			_entry_cursor = clampi(next, 0, ENTRY_BUTTONS.size() - 1)
-			_render_entry()
+			_refresh()
 			return true
 		Gen2Button.UP, Gen2Button.DOWN:
 			if _dex.step_entry(button):
 				## `Pokedex_ReinitDexEntryScreen` calls `Pokedex_InitArrowCursor`,
 				## so a new entry opens on PAGE whatever the last one ended on.
 				_entry_cursor = 0
-				_render_entry()
+				_refresh()
 			return true
 	return false
 
@@ -192,7 +204,7 @@ func _entry_action() -> void:
 	match _entry_cursor:
 		ENTRY_BUTTON_PAGE:
 			_dex.toggle_page()
-			_render_entry()
+			_refresh()
 		ENTRY_BUTTON_AREA:
 			_open_area()
 		ENTRY_BUTTON_CRY:
@@ -236,7 +248,7 @@ func _on_area_closed() -> void:
 		_area = null
 	## `.Area` redisplays the entry it left, cursor and page included.
 	_mode = Mode.ENTRY
-	_render_entry()
+	_refresh()
 
 
 ## `Pokedex_UpdateOptionScreen`: SELECT and B both return to the listing, and A
@@ -254,7 +266,7 @@ func _handle_option(button: int) -> bool:
 			## `Pokedex_MoveArrowCursor` stops at either end rather than wrapping.
 			var next: int = _option_cursor + (1 if button == Gen2Button.DOWN else -1)
 			_option_cursor = clampi(next, 0, _mode_rows.size() - 1)
-			_render_option()
+			_refresh()
 			return true
 	return false
 
@@ -270,13 +282,16 @@ func _choose_mode() -> void:
 	if int(row["mode"]) == RomLayout.DEXMODE_UNOWN:
 		_open_unown_mode()
 		return
-	var changed: bool = _dex.change_mode(int(row["mode"]))
-	if changed:
+	if _dex.change_mode(int(row["mode"])):
 		_world.state.set_last_dex_mode(_dex.mode)
+		# `Pokedex_DisplayChangingModesMessage` puts its two lines in the option
+		# screen's own description box and spends 128 frames there. The message
+		# is drawn; the wait is not, since nothing here rebuilds an order slowly
+		# enough to need one.
+		_message = Gen2Pokedex.CHANGING_MODES_TEXT
+		_refresh()
+		_message = ""
 	_open_list_mode()
-	if changed:
-		_status.text = Gen2Pokedex.CHANGING_MODES_TEXT
-		_status.add_theme_color_override("font_color", MUTED)
 
 
 ## `.exit` writes the mode back to `wLastDexMode` before it leaves.
@@ -288,35 +303,30 @@ func _exit() -> void:
 ## `Pokedex_InitMainScreen`, whose own `ld a, 7` is what puts the listing height
 ## back after the search results screen has set it to four.
 func _open_list_mode() -> void:
+	_message = ""
 	_mode = Mode.LIST
 	_dex.listing_height = Gen2Pokedex.LISTING_HEIGHT
-	_title.text = "#DEX"
-	_footer.text = "D-pad: move    A: entry    SELECT: option    B: close"
-	_status.text = ""
-	_render_list()
+	_refresh()
 
 
 func _open_entry_mode() -> void:
+	_message = ""
 	_mode = Mode.ENTRY
 	_entry_cursor = 0
-	_status.text = ""
-	_render_entry()
+	_refresh()
 
 
 func _open_option_mode() -> void:
+	_message = ""
 	_mode = Mode.OPTION
 	_mode_rows = Gen2Pokedex.mode_rows(_dex.unown_unlocked())
-	_title.text = "OPTION"
-	_summary.text = ""
-	_status.text = ""
-	_footer.text = "D-pad: move    A: choose    B: back"
 	## `Pokedex_InitOptionScreen` points the cursor at the current mode, which
 	## it can do directly because the modes are the row indices.
 	_option_cursor = 0
 	for index: int in _mode_rows.size():
 		if int(_mode_rows[index]["mode"]) == _dex.mode:
 			_option_cursor = index
-	_render_option()
+	_refresh()
 
 
 ## `Pokedex_UpdateUnownMode`: left and right walk the forms caught, and A or B
@@ -328,37 +338,17 @@ func _handle_unown(button: int) -> bool:
 			return true
 		Gen2Button.LEFT, Gen2Button.RIGHT:
 			if _dex.move_unown(button):
-				_render_unown()
+				_refresh()
 			return true
 	return false
 
 
 ## `Pokedex_InitUnownMode`, which opens on the first form caught.
 func _open_unown_mode() -> void:
+	_message = ""
 	_mode = Mode.UNOWN
 	_dex.open_unown_mode()
-	_title.text = "UNOWN MODE"
-	_status.text = ""
-	_footer.text = "Left/Right: form    A or B: back"
-	_render_unown()
-
-
-## `Pokedex_DrawUnownModeBG` and `PrintUnownWord`: the forms caught, in catching
-## order, with the cursor's own letter and its word underneath. The letters are
-## drawn with the alphabet rather than the Unown font, which is
-## `Pokedex_LoadUnownFont`'s inverted copy of the pic sheet and is not imported.
-func _render_unown() -> void:
-	var forms: Array[int] = _dex.unown_forms()
-	_summary.text = "CAUGHT %2d/%d" % [forms.size(), RomLayout.UNOWN_FORMS]
-	var letters: PackedStringArray = PackedStringArray()
-	for index: int in forms.size():
-		var letter: String = char("A".unicode_at(0) + forms[index] - 1)
-		letters.append(("[%s]" if index == _dex.unown_cursor else " %s ") % letter)
-	for child: Node in _options.get_children():
-		child.queue_free()
-	_add_line(" ".join(letters))
-	_add_line("")
-	_add_line(_dex.unown_word())
+	_refresh()
 
 
 ## `Pokedex_UpdateSearchScreen`: up and down move the four rows, left and right
@@ -375,11 +365,11 @@ func _handle_search(button: int) -> bool:
 		Gen2Button.UP, Gen2Button.DOWN:
 			var next: int = _dex.search_cursor + (1 if button == Gen2Button.DOWN else -1)
 			_dex.search_cursor = clampi(next, 0, Gen2Pokedex.SEARCH_ROWS.size() - 1)
-			_render_search()
+			_refresh()
 			return true
 		Gen2Button.LEFT, Gen2Button.RIGHT:
 			if _dex.move_search_type(button):
-				_render_search()
+				_refresh()
 			return true
 	return false
 
@@ -390,16 +380,15 @@ func _confirm_search_row() -> void:
 	match _dex.search_cursor:
 		Gen2Pokedex.SEARCH_ROW_TYPE_1, Gen2Pokedex.SEARCH_ROW_TYPE_2:
 			_dex.move_search_type(Gen2Button.RIGHT)
-			_render_search()
+			_refresh()
 		Gen2Pokedex.SEARCH_ROW_BEGIN:
 			if _dex.begin_search() > 0:
 				_open_search_results_mode()
 				return
 			## `.MenuAction_BeginSearch`'s no-result branch redraws the search
 			## screen under its own message rather than leaving it.
-			_render_search()
-			_status.text = Gen2Pokedex.TYPE_NOT_FOUND_TEXT
-			_status.add_theme_color_override("font_color", MUTED)
+			_message = Gen2Pokedex.TYPE_NOT_FOUND_TEXT
+			_refresh()
 		Gen2Pokedex.SEARCH_ROW_CANCEL:
 			_open_list_mode()
 
@@ -418,7 +407,7 @@ func _handle_search_results(button: int) -> bool:
 				_open_entry_mode()
 			return true
 	if _dex.move_listing(button):
-		_render_search_results()
+		_refresh()
 	return Gen2Button.is_direction(button)
 
 
@@ -428,174 +417,155 @@ func _handle_search_results(button: int) -> bool:
 ## jumps to DEXSTATE_SEARCH_SCR, and that jumptable entry is this Init rather
 ## than its Update, so the search is not remembered.
 func _open_search_mode() -> void:
+	_message = ""
 	_mode = Mode.SEARCH
 	_dex.open_search()
-	_title.text = "SEARCH"
-	_status.text = ""
-	_footer.text = "D-pad: move    Left/Right: type    A: choose    B: back"
-	_render_search()
+	_refresh()
 
 
 ## `Pokedex_InitSearchResultsScreen`, whose own `ld a, 4` is the shorter listing.
 func _open_search_results_mode() -> void:
+	_message = ""
 	_mode = Mode.SEARCH_RESULTS
 	_dex.listing_height = Gen2Pokedex.SEARCH_RESULTS_HEIGHT
-	_title.text = "SEARCH RESULTS"
-	_status.text = ""
-	_footer.text = "D-pad: move    A: entry    B: back"
-	_render_search_results()
+	_refresh()
 
 
-func _render_search() -> void:
-	_summary.text = ""
-	_render_rows(Gen2Pokedex.SEARCH_ROWS, func(row: String) -> String:
-		match row:
-			Gen2Pokedex.SEARCH_ROWS[Gen2Pokedex.SEARCH_ROW_TYPE_1]:
-				return "%s  %s" % [row, _dex.search_type_name(_dex.search_type_1)]
-			Gen2Pokedex.SEARCH_ROWS[Gen2Pokedex.SEARCH_ROW_TYPE_2]:
-				return "%s  %s" % [row, _dex.search_type_name(_dex.search_type_2)]
-		return row
-	, _dex.search_cursor)
-
-
-## `.BottomWindowText` and `Pokedex_PlaceSearchResultsTypeStrings`: the count and
-## the types it was found for sit under the listing.
-func _render_search_results() -> void:
-	var types: String = _dex.search_type_name(_dex.search_type_1)
-	if _dex.search_type_2 != Gen2Pokedex.SEARCH_TYPE_NONE:
-		types += "/%s" % _dex.search_type_name(_dex.search_type_2)
-	_summary.text = "%s    %3d FOUND!" % [types, _dex.search_result_count]
-	_render_rows(_dex.rows(), func(row: Dictionary) -> String:
-		if bool(row["empty"]):
-			return ""
-		var symbol: String = CAUGHT_SYMBOL if bool(row["caught"]) else UNCAUGHT_SYMBOL
-		var number: String = String(row["number"])
-		var prefix: String = "%s " % number if not number.is_empty() else ""
-		return "%s%s%s" % [prefix, symbol, String(row["name"])]
-	)
-
-
-## The listing, plus the SEEN and OWN totals `Pokedex_DrawMainScreenBG` prints
-## beside it.
-func _render_list() -> void:
-	_summary.text = "SEEN %3d    OWN %3d" % [_dex.seen_count(), _dex.caught_count()]
-	var rows: Array = _dex.rows()
-	_render_rows(rows, func(row: Dictionary) -> String:
-		if bool(row["empty"]):
-			return ""
-		var symbol: String = CAUGHT_SYMBOL if bool(row["caught"]) else UNCAUGHT_SYMBOL
-		var number: String = String(row["number"])
-		var prefix: String = "%s " % number if not number.is_empty() else ""
-		return "%s%s%s" % [prefix, symbol, String(row["name"])]
-	)
-
-
-func _render_entry() -> void:
-	var entry: Dictionary = _dex.entry()
-	_title.text = "No.%s  %s" % [String(entry["number"]), String(entry["name"])]
-	_summary.text = String(entry["category"])
-	for child: Node in _options.get_children():
-		child.queue_free()
-	## The height and weight rows come from the entry screen's own template
-	## ("HT" and "WT"), and stay blank for a species that has not been caught.
-	_add_line("HT  %s" % String(entry["height"]))
-	_add_line("WT  %slb" % String(entry["weight"]))
-	_add_line("")
-	for line: String in String(entry["text"]).split("\n"):
-		_add_line(line)
-	_status.text = "P.%d" % (int(entry["page"]) + 1) if bool(entry["caught"]) else ""
-	var buttons: PackedStringArray = PackedStringArray()
-	for index: int in ENTRY_BUTTONS.size():
-		buttons.append(
-			("[%s]" if index == _entry_cursor else " %s ") % ENTRY_BUTTONS[index]
-		)
-	_footer.text = "%s   Left/Right: button   A: choose   B: back" % " ".join(buttons)
-
-
-func _render_option() -> void:
-	_render_rows(_mode_rows, func(row: Dictionary) -> String:
-		return String(row["label"])
-	)
-	_summary.text = String(_mode_rows[_option_cursor]["description"])
-
-
-## [param row_cursor] is the highlighted row; the listing screens pass the
-## dex's own cursor and the two form screens pass theirs.
-func _render_rows(values: Array, label_for: Callable, row_cursor: int = -1) -> void:
-	if _options == null:
+## The whole screen, redrawn from the model. One layer: every state here is a
+## background the source writes as tiles, with the species picture blitted into
+## the box its layout left blank.
+func _refresh() -> void:
+	if _background == null or _page == null or _dex == null:
 		return
-	for child: Node in _options.get_children():
-		child.queue_free()
-	var cursor: int = row_cursor
-	if cursor < 0:
-		cursor = _option_cursor if _mode == Mode.OPTION else _dex.cursor
-	for index: int in values.size():
-		var label := Label.new()
-		var text: String = label_for.call(values[index])
-		label.text = ("> " if index == cursor and not text.is_empty() else "  ") + text
-		label.add_theme_color_override(
-			"font_color", ACCENT if index == cursor else TEXT
+	_background.texture = ImageTexture.create_from_image(render())
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## The screen as one 160x144 image, for a preview or a test that wants pixels.
+func render() -> Image:
+	if _page == null or _dex == null:
+		return Image.create_empty(
+			Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 		)
-		label.add_theme_font_size_override("font_size", 18)
-		_options.add_child(label)
+	var cursor: int = -1 if _blink >= CURSOR_BLINK_FRAMES else 0
+	match _mode:
+		Mode.OPTION:
+			return _page.image(_page.option_map(
+				_dex.unown_unlocked(), _option_cursor if cursor == 0 else -1,
+				_message if not _message.is_empty() else String(
+					_mode_rows[_option_cursor]["description"]
+				)
+			))
+		Mode.SEARCH:
+			return _page.image(_page.search_map(
+				_dex.search_type_name(_dex.search_type_1),
+				_dex.search_type_name(_dex.search_type_2),
+				_dex.search_cursor if cursor == 0 else -1, _message
+			))
+		Mode.UNOWN:
+			return _page.image(
+				_page.unown_map(
+					_dex.unown_forms(), _dex.unown_cursor, _dex.unown_word()
+				),
+				_selected_pic(), Vector2i(6, 5)
+			)
+		Mode.ENTRY:
+			return _render_entry_image(cursor)
+		Mode.SEARCH_RESULTS:
+			# `Pokedex_InitSearchResultsScreen` puts its listing in the same
+			# window the main screen uses, at DEXMODE_OLD's own `hWX`.
+			return _page.image_main(
+				_page.search_results_background(
+					_dex.search_result_count, _search_type_line()
+				),
+				_page.results_window_map(_dex.rows(), cursor), true, _selected_pic(),
+				Gen2PokedexPage.RESULTS_WINDOW_ROWS
+			)
+	return _page.image_main(
+		_page.main_background(_dex.seen_count(), _dex.caught_count()),
+		_page.window_map(_dex.rows(), _dex.mode == RomLayout.DEXMODE_OLD, cursor),
+		_dex.mode == RomLayout.DEXMODE_OLD, _selected_pic()
+	)
 
 
-func _add_line(text: String) -> void:
-	var label := Label.new()
-	label.text = text
-	label.add_theme_color_override("font_color", TEXT)
-	label.add_theme_font_size_override("font_size", 18)
-	_options.add_child(label)
+## `Pokedex_InitDexEntryScreen`, which loads the species' footprint before it
+## draws the grid that names its four tiles.
+func _render_entry_image(cursor: int) -> Image:
+	var entry: Dictionary = _dex.entry()
+	var species: int = _dex.selected_species()
+	_page.load_footprint(_data, species)
+	return _page.image(_page.entry_map(
+		species, String(entry["name"]), _data.dex_entry(species),
+		bool(entry["caught"]), int(entry["page"]),
+		_entry_cursor if cursor == 0 else -1
+	), _selected_pic())
+
+
+## `Pokedex_LoadSelectedMonTiles`: the species' front picture, or the Slowpoke
+## one for a species that has not been seen.
+func _selected_pic() -> Image:
+	var species: int = _dex.selected_species()
+	# `Pokedex_LoadUnownFrontpicTiles` draws the cursor's own form rather than
+	# the listing's species, which on this screen is UNOWN either way.
+	if _mode == Mode.UNOWN:
+		var forms: Array[int] = _dex.unown_forms()
+		if _dex.unown_cursor < 0 or _dex.unown_cursor >= forms.size():
+			return null
+		return _pic_image(_data.unown_pic(forms[_dex.unown_cursor] - 1), species)
+	# `Pokedex_CheckSeen`, which is what `can_open_entry` already answers for the
+	# selected row.
+	if species <= 0 or not _dex.can_open_entry():
+		return _page.unseen_pic()
+	return _pic_image(_data.species_pic(species), species)
+
+
+## One imported pic through `LoadPalette_White_Col1_Col2_Black`'s own four
+## colours, or the Slowpoke picture when the cache does not hold it.
+func _pic_image(pic: Dictionary, species: int) -> Image:
+	if pic.is_empty():
+		return _page.unseen_pic()
+	return Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.palette(species)
+	)
+
+
+## `Pokedex_PlaceSearchResultsTypeStrings`, which prints the second type only
+## when there is one and it is not the first.
+func _search_type_line() -> String:
+	var first: String = _dex.search_type_name(_dex.search_type_1)
+	if _dex.search_type_2 == Gen2Pokedex.SEARCH_TYPE_NONE \
+		or _dex.search_type_2 == _dex.search_type_1:
+		return first
+	return "%s/%s" % [first, _dex.search_type_name(_dex.search_type_2)]
+
+
+## `Pokedex_BlinkArrowCursor` is the only thing here that counts frames.
+func _process(delta: float) -> void:
+	if _dex == null:
+		return
+	_elapsed += delta
+	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_frame()
+
+
+func advance_frame() -> void:
+	_blink = (_blink + 1) % (CURSOR_BLINK_FRAMES * 2)
+	if _blink == 0 or _blink == CURSOR_BLINK_FRAMES:
+		_refresh()
 
 
 func _build_ui() -> void:
-	var scrim := ColorRect.new()
-	scrim.color = SCRIM
-	scrim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	scrim.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child(scrim)
-
-	var center := CenterContainer.new()
-	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(center)
-	var panel := PanelContainer.new()
-	panel.custom_minimum_size = Vector2(420, 320)
-	panel.add_theme_stylebox_override("panel", _panel_style())
-	center.add_child(panel)
-	var margin := MarginContainer.new()
-	margin.add_theme_constant_override("margin_left", 24)
-	margin.add_theme_constant_override("margin_top", 20)
-	margin.add_theme_constant_override("margin_right", 24)
-	margin.add_theme_constant_override("margin_bottom", 20)
-	panel.add_child(margin)
-	var content := VBoxContainer.new()
-	content.add_theme_constant_override("separation", 10)
-	margin.add_child(content)
-	_title = Label.new()
-	_title.add_theme_color_override("font_color", TEXT)
-	_title.add_theme_font_size_override("font_size", 24)
-	content.add_child(_title)
-	_summary = Label.new()
-	_summary.add_theme_color_override("font_color", MUTED)
-	_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	content.add_child(_summary)
-	_options = VBoxContainer.new()
-	_options.add_theme_constant_override("separation", 4)
-	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	content.add_child(_options)
-	_status = Label.new()
-	_status.add_theme_color_override("font_color", MUTED)
-	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	content.add_child(_status)
-	_footer = Label.new()
-	_footer.add_theme_color_override("font_color", ACCENT)
-	content.add_child(_footer)
-
-
-func _panel_style() -> StyleBoxFlat:
-	var style := StyleBoxFlat.new()
-	style.bg_color = PANEL
-	style.border_color = BORDER
-	style.set_border_width_all(2)
-	style.set_corner_radius_all(8)
-	return style
+	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
+	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(screen)
+	_field = Control.new()
+	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	screen.display(_field)
+	_background = TextureRect.new()
+	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_field.add_child(_background)

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -601,6 +601,14 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 		"pokegear": [RomLayout.POKEGEAR_TILES, 2],
 		"pokegear_sprites": [RomLayout.POKEGEAR_SPRITE_TILES, 3],
 		"dex_nest_icon": [RomLayout.DEX_NEST_ICON_TILES, 3],
+		## `Pokedex_LoadGFX`'s two runs, `UnownFont` and the footprint grid, at
+		## their real lengths so the dex page can address every tile a layout
+		## names. Flat fills like the rest: what a test checks is where each
+		## lands.
+		"pokedex": [RomLayout.POKEDEX_TILES, 1],
+		"pokedex_slowpoke": [RomLayout.POKEDEX_SLOWPOKE_TILES, 2],
+		"unown_font": [RomLayout.UNOWN_FONT_TILES, 3],
+		"footprints": [RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES, 1],
 	}
 	## The font and the frames are the two sheets addressed by character code
 	## rather than by slot, so both need their real first code. A frames sheet
@@ -631,6 +639,13 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 			[0x7FE0, 0x0000], [0x03FF, 0x0000], [0x7C1F, 0x0000], [0x4210, 0x0000],
 		],
 		"badge": [0x7FFF, 0x5ABA, 0x49EF, 0x0000],
+	}
+	## `_CGB_Pokedex`'s three: PREDEFPAL_POKEDEX and the two the screen loads
+	## beside it (gfx/pokedex/question_mark.pal and cursor.pal).
+	manifest["pokedex_palettes"] = {
+		"interface": [0x7FFF, 0x2A9F, 0x195A, 0x0000],
+		"question_mark": [0x2EB, 0x227, 0xCC6, 0x584],
+		"cursor": [0x0000, 0x2EB, 0x227, 0x0000],
 	}
 	## `gfx/new_game/gender_screen.pal`'s own four colours.
 	manifest["gender_screen_palette"] = [0x7FFF, 0x7FC9, 0x7D61, 0x0000]

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -73,6 +73,14 @@ static func build() -> GameData:
 		"sha1": SHA1,
 		"complete": true,
 		"unown_words": unown_words(),
+		"tiles": _tiles(path),
+		## `_CGB_Pokedex`'s three, at their real values so a page test reads the
+		## colours the screen actually draws through.
+		"pokedex_palettes": {
+			"interface": [0x7FFF, 0x2A9F, 0x195A, 0x0000],
+			"question_mark": [0x2EB, 0x227, 0xCC6, 0x584],
+			"cursor": [0x0000, 0x2EB, 0x227, 0x0000],
+		},
 	})
 	return GameData.open_directory(path)
 
@@ -94,3 +102,31 @@ static func _species() -> Array:
 			},
 		})
 	return out
+
+
+## `Pokedex_LoadGFX`'s sheets and the font the page draws characters with, each
+## at its real length and filled with its own index, so a test can say which
+## sheet a cell came from by reading one pixel.
+static func _tiles(path: String) -> Dictionary:
+	var sheets: Dictionary = {}
+	for entry: Array in [
+		["font", RomLayout.FONT_TILES, 3, RomLayout.FONT_FIRST_CODE],
+		["pokedex", RomLayout.POKEDEX_TILES, 1, 0],
+		["pokedex_slowpoke", RomLayout.POKEDEX_SLOWPOKE_TILES, 2, 0],
+		["unown_font", RomLayout.UNOWN_FONT_TILES, 3, 0],
+		["footprints", RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES, 1, 0],
+	]:
+		var name: String = String(entry[0])
+		var count: int = int(entry[1])
+		var indices := PackedByteArray()
+		indices.resize(count * Gen2Tiles.TILE_PIXELS)
+		indices.fill(int(entry[2]))
+		RomCache.write_indices(RomCache.tile_path(path, name), indices)
+		sheets[name] = {
+			"width": count * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": count,
+			"first_code": int(entry[3]),
+			"bits": 1,
+		}
+	return sheets

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -523,3 +523,135 @@ func test_the_dex_reopens_on_a_mod_species_it_was_left_on() -> void:
 	)
 	assert_eq(unknown.scroll, 0)
 	assert_eq(unknown.cursor, 0)
+
+
+## The page, which is the picture the model drives: engine/pokedex/pokedex.asm's
+## own `Pokedex_Draw*BG` routines as tile writes. Only the layout is checked
+## here; that the sheets behind it are the cartridge's is `tools/checks/pokedex.gd`.
+func _page() -> Gen2PokedexPage:
+	var page: Gen2PokedexPage = Gen2PokedexPage.from_data(_data)
+	assert_not_null(page, "the fixture carries the dex sheets")
+	assert_true(page.ready())
+	return page
+
+
+func _cell(map: PackedInt32Array, x: int, y: int) -> int:
+	return map[y * Gen2PokedexPage.COLUMNS + x]
+
+
+## `Pokedex_DrawMainScreenBG`: the sidebar column and its three joints, and the
+## two counts `CountSetBits` prints.
+func test_the_main_screen_draws_the_sidebar_and_both_counts() -> void:
+	var map: PackedInt32Array = _page().main_background(40, 20)
+	assert_eq(_cell(map, 8, 0), Gen2PokedexPage.SIDEBAR_TOP)
+	assert_eq(_cell(map, 8, 4), Gen2PokedexPage.SIDEBAR)
+	assert_eq(_cell(map, 8, 8), Gen2PokedexPage.SIDEBAR_SPLIT_TOP)
+	assert_eq(_cell(map, 8, 9), Gen2PokedexPage.SIDEBAR_SPLIT_BOTTOM)
+	assert_eq(_cell(map, 8, 16), Gen2PokedexPage.SIDEBAR_BOTTOM)
+	assert_eq(_cell(map, 6, 12), Gen2Text.encode("40")[0], "SEEN's own digits")
+	assert_eq(_cell(map, 6, 15), Gen2Text.encode("20")[0], "OWN's")
+
+
+## `Pokedex_PlaceFrontpicTopLeftCorner` counts down each column, because that is
+## how a pic is stored.
+func test_the_picture_box_names_its_tiles_down_each_column() -> void:
+	var map: PackedInt32Array = _page().main_background(0, 0)
+	assert_eq(_cell(map, 1, 1), 0)
+	assert_eq(_cell(map, 1, 2), 1, "one down is the next tile")
+	assert_eq(_cell(map, 2, 1), 7, "one across is seven on")
+
+
+## `DrawPokedexListWindow`'s scroll bar, which DEXMODE_OLD replaces with the two
+## tiles that are not one, and `Pokedex_PrintListing`'s own row spacing.
+func test_the_listing_window_swaps_its_scroll_bar_in_old_mode() -> void:
+	var page: Gen2PokedexPage = _page()
+	var rows: Array = _dex([1, 2], [2]).rows()
+	var new_mode: PackedInt32Array = page.window_map(rows, false, 0)
+	var old_mode: PackedInt32Array = page.window_map(rows, true, 0)
+	var columns: int = Gen2PokedexPage.WINDOW_COLUMNS
+	assert_eq(new_mode[11], Gen2PokedexPage.SCROLL_TOP)
+	assert_eq(old_mode[11], Gen2PokedexPage.NO_SCROLL_TOP)
+	assert_eq(new_mode[5 * columns + 11], Gen2PokedexPage.SCROLL)
+	assert_eq(old_mode[5 * columns + 11], Gen2PokedexPage.NO_SCROLL)
+
+
+## `Pokedex_PlaceCaughtSymbolIfCaught` writes one cell ahead of the name, and
+## `Pokedex_PlaceDefaultStringIfNotSeen` replaces the name entirely.
+func test_a_listing_row_marks_caught_and_hides_an_unseen_name() -> void:
+	var page: Gen2PokedexPage = _page()
+	var order: Array = Fixture.new_order()
+	var caught: int = int(order[0])
+	var map: PackedInt32Array = page.window_map(_dex([caught], [caught]).rows(), false, 0)
+	var columns: int = Gen2PokedexPage.WINDOW_COLUMNS
+	assert_eq(map[2 * columns], Gen2PokedexPage.CURSOR_CODE, "the arrow is in column 0")
+	assert_eq(map[2 * columns + 1], Gen2PokedexPage.CAUGHT_SYMBOL)
+	assert_eq(
+		map[4 * columns + 2], Gen2Text.encode(Gen2Pokedex.NOT_SEEN_NAME)[0],
+		"the second row has not been seen",
+	)
+
+
+## `Pokedex_DrawFootprint`'s four cells, and `Pokedex_LoadCurrentFootprint`'s own
+## stride: a species' bottom half sits eight species of two tiles past its top.
+func test_the_entry_screen_names_its_footprint_cells() -> void:
+	var page: Gen2PokedexPage = _page()
+	assert_true(page.load_footprint(_data, 1))
+	var tiles: PackedInt32Array = _data.footprint_tiles(1)
+	assert_eq(tiles[2], tiles[0] + RomLayout.FOOTPRINT_HALF_STRIDE)
+	var map: PackedInt32Array = page.entry_map(
+		1, "MON001", _data.dex_entry(1), true, Gen2Pokedex.PAGE_1, 0
+	)
+	var at: Vector2i = Gen2PokedexPage.FOOTPRINT_AT
+	assert_eq(_cell(map, at.x, at.y), Gen2PokedexPage.FOOTPRINT_TOP)
+	assert_eq(_cell(map, at.x + 1, at.y + 1), Gen2PokedexPage.FOOTPRINT_BOTTOM + 1)
+
+
+## `DisplayDexEntry` prints the height as two digits of feet and two of inches
+## and the weight in tenths, and leaves the template's own placeholders on a
+## species that has not been caught.
+func test_the_entry_screen_prints_its_measurements_only_once_caught() -> void:
+	var page: Gen2PokedexPage = _page()
+	var entry: Dictionary = _data.dex_entry(211)
+	var caught: PackedInt32Array = page.entry_map(
+		211, "MON211", entry, true, Gen2Pokedex.PAGE_1, 0
+	)
+	var uncaught: PackedInt32Array = page.entry_map(
+		211, "MON211", entry, false, Gen2Pokedex.PAGE_1, 0
+	)
+	assert_eq(_cell(caught, 14, 7), Gen2PokedexPage.HEIGHT_FEET)
+	assert_eq(_cell(caught, 16, 7), Gen2Text.encode("11")[0], "eleven inches")
+	assert_eq(_cell(uncaught, 15, 7), Gen2Text.encode("?")[0], "the template's own")
+	assert_eq(_cell(caught, 1, 10), Gen2PokedexPage.PAGE_MARKER)
+	assert_eq(_cell(caught, 2, 10), Gen2PokedexPage.PAGE_ONE)
+	assert_eq(
+		_cell(page.entry_map(211, "MON211", entry, true, Gen2Pokedex.PAGE_2, 0), 2, 10),
+		Gen2PokedexPage.PAGE_TWO,
+	)
+
+
+## `Pokedex_DrawOptionScreenBG` draws the fourth row only once
+## `wUnlockedUnownMode` is set, and the box under it carries whichever message
+## the screen last asked for.
+func test_the_option_screen_draws_the_unown_row_only_when_it_is_unlocked() -> void:
+	var page: Gen2PokedexPage = _page()
+	var locked: PackedInt32Array = page.option_map(false, 0, "a description")
+	var unlocked: PackedInt32Array = page.option_map(true, 3, "a description")
+	var unown: int = Gen2Text.encode("UNOWN MODE")[0]
+	assert_ne(_cell(locked, 3, 10), unown)
+	assert_eq(_cell(unlocked, 3, 10), unown)
+	assert_eq(_cell(unlocked, 2, 10), Gen2PokedexPage.CURSOR_CODE)
+	assert_eq(_cell(unlocked, 1, 14), Gen2Text.encode("a")[0], "the box says it")
+
+
+## `UnownModeLetterAndCursorCoords` is indexed by catching position rather than
+## by form, so the second form caught takes the second cell whichever letter it
+## is, and its cursor is not always in the column beside it.
+func test_the_unown_screen_places_its_letters_and_word() -> void:
+	var map: PackedInt32Array = _page().unown_map([1, 9], 1, "ESCAPE")
+	assert_eq(_cell(map, 4, 11), RomLayout.UNOWN_FONT_FIRST_TILE, "A caught first")
+	assert_eq(
+		_cell(map, 4, 10), RomLayout.UNOWN_FONT_FIRST_TILE + 8,
+		"I caught second, in the second cell",
+	)
+	assert_eq(_cell(map, 3, 10), Gen2PokedexPage.CURSOR_CODE)
+	assert_eq(_cell(map, 4, 15), Gen2Text.encode("ESCAPE")[0])

--- a/tools/checks/pokedex.gd
+++ b/tools/checks/pokedex.gd
@@ -1,0 +1,144 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the Pokedex's own graphics against freshly imported real caches, on
+## all three cartridges.
+##
+## The expected values come from the pinned sources: `Pokedex_LoadGFX`'s two LZ
+## runs, `gfx/footprints.asm`'s 16x64-tile grid, `Pokedex_LoadUnownFont` and
+## `_CGB_Pokedex`'s three palettes.
+##
+## The real-cartridge counterpart to tests/unit/test_pokedex.gd, which uses a
+## synthetic cache. What only a real cache can say is that the runs decompressed
+## to exactly the tiles the source asks for, that all three dumps carry the same
+## art, that every one of the 251 footprints is a real picture rather than the
+## blank the grid's tail is, and that every species draws an entry screen whose
+## own four footprint cells resolve.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- pokedex
+
+## `Pokedex_LoadGFX` decompresses `PokedexLZ` to `vTiles2 tile $31`, so the sheet
+## number a layout writes is offset by this and the last one it can name is
+## `$6a`.
+const SHEET_FIRST: int = Gen2PokedexPage.SHEET_FIRST_TILE
+
+## Every species has a footprint, so a slot with no lit pixel at all is a defect
+## rather than a species that has none.
+const SPECIES: int = RomLayout.FOOTPRINT_SPECIES
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	var digests: Dictionary = {}
+	for game_id: StringName in _r.GAME_IDS:
+		var digest: String = _validate(game_id)
+		if digest.is_empty():
+			_r.fail("%s: the Pokedex graphics did not check out." % game_id)
+			continue
+		digests[game_id] = digest
+	var unique: Dictionary = {}
+	for game_id: Variant in digests:
+		unique[digests[game_id]] = true
+	if digests.size() == _r.GAME_IDS.size() and unique.size() != 1:
+		_r.fail("The three dumps do not carry the same Pokedex art: %s" % digests)
+	else:
+		print("  art identical on all three: %s" % [unique.keys()])
+
+
+## Answers a digest of the three sheets, or "" when the cache failed a check.
+func _validate(game_id: StringName) -> String:
+	var data: GameData = GameData.open(game_id)
+	if data == null:
+		print("FAIL %s: cache is not usable" % game_id)
+		return ""
+
+	var ok: bool = true
+	for sheet: Array in [
+		["pokedex", RomLayout.POKEDEX_TILES],
+		["pokedex_slowpoke", RomLayout.POKEDEX_SLOWPOKE_TILES],
+		["unown_font", RomLayout.UNOWN_FONT_TILES],
+		["footprints", RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES],
+	]:
+		var name: String = String(sheet[0])
+		var wanted: int = int(sheet[1])
+		var entry: Dictionary = data.tile_sheet(name)
+		if int(entry.get("tiles", 0)) != wanted:
+			print("FAIL %s: %s is %d tiles, wanted %d" % [
+				game_id, name, int(entry.get("tiles", 0)), wanted,
+			])
+			ok = false
+	if not ok:
+		return ""
+
+	for name: String in ["interface", "question_mark", "cursor"]:
+		if data.pokedex_palette(name).size() != Gen2Palette.COLORS_PER_PIC:
+			print("FAIL %s: the %s palette is not four colours" % [game_id, name])
+			return ""
+
+	var page: Gen2PokedexPage = Gen2PokedexPage.from_data(data)
+	if page == null or not page.ready():
+		print("FAIL %s: the page would not build" % game_id)
+		return ""
+
+	# Every species' four footprint tiles, checked for being inside the strip and
+	# for carrying a picture: the grid's own tail is blank, and a species landing
+	# in it would be a stride error rather than an absent footprint.
+	var indices: PackedByteArray = data.tile_indices("footprints")
+	@warning_ignore("integer_division")
+	var width: int = indices.size() / Gen2Tiles.TILE_HEIGHT
+	var blank: Array[int] = []
+	for species: int in range(1, SPECIES + 1):
+		var tiles: PackedInt32Array = data.footprint_tiles(species)
+		if tiles.size() != RomLayout.FOOTPRINT_TILES:
+			print("FAIL %s: species %d has no footprint" % [game_id, species])
+			return ""
+		var lit: int = 0
+		for tile: int in tiles:
+			if (tile + 1) * Gen2Tiles.TILE_WIDTH > width:
+				print("FAIL %s: footprint tile %d of species %d is off the strip" % [
+					game_id, tile, species,
+				])
+				return ""
+			for y: int in Gen2Tiles.TILE_HEIGHT:
+				for x: int in Gen2Tiles.TILE_WIDTH:
+					if indices[y * width + tile * Gen2Tiles.TILE_WIDTH + x] != 0:
+						lit += 1
+		if lit == 0:
+			blank.append(species)
+	if not blank.is_empty():
+		print("FAIL %s: %d species have a blank footprint: %s" % [
+			game_id, blank.size(), blank.slice(0, 8),
+		])
+		return ""
+
+	# Every entry screen, so a species whose dex record is short or whose pic is
+	# missing is found here rather than on the screen.
+	var short_entries: Array[int] = []
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var entry: Dictionary = data.dex_entry(species)
+		if entry.is_empty() or String(entry.get("category", "")).is_empty():
+			short_entries.append(species)
+			continue
+		page.load_footprint(data, species)
+		var map: PackedInt32Array = page.entry_map(
+			species, String(data.species(species).get("name", "")), entry, true, Gen2Pokedex.PAGE_1, 0
+		)
+		if map.size() != Gen2PokedexPage.COLUMNS * Gen2PokedexPage.ROWS:
+			print("FAIL %s: species %d drew no entry screen" % [game_id, species])
+			return ""
+	if not short_entries.is_empty():
+		print("FAIL %s: %d species carry no dex entry: %s" % [
+			game_id, short_entries.size(), short_entries.slice(0, 8),
+		])
+		return ""
+
+	print("%s: sheet=%d slowpoke=%d unown_font=%d footprints=%d species=%d" % [
+		game_id, RomLayout.POKEDEX_TILES, RomLayout.POKEDEX_SLOWPOKE_TILES,
+		RomLayout.UNOWN_FONT_TILES, SPECIES, RomLayout.SPECIES_COUNT,
+	])
+	return "%s/%s/%s" % [
+		indices.slice(0, 4096).hex_encode().sha1_text().substr(0, 8),
+		data.tile_indices("pokedex").slice(0, 928).hex_encode().sha1_text().substr(0, 8),
+		data.tile_indices("unown_font").hex_encode().sha1_text().substr(0, 8),
+	]

--- a/tools/checks/pokedex.gd.uid
+++ b/tools/checks/pokedex.gd.uid
@@ -1,0 +1,1 @@
+uid://xliqb8au8nbw

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -1,0 +1,105 @@
+extends SceneTree
+
+## Captures the Pokedex against a real imported cache.
+##
+##   Godot --headless --path . -s res://tools/preview_pokedex.gd -- \
+##       crystal /tmp/dex.png [list|entry|option|search|results|unown] [presses]
+##
+## The world behind it is a new game with every species seen and every second one
+## caught, which is what puts a full listing, both row states and a real entry on
+## screen at once. [presses] is a
+## `u,d,l,r,a,b,sel,start` list driven in before the shot, and `f<n>` spends n
+## hardware frames, which is how the arrow is caught blinking either way.
+##
+## Headless: the screen composes into an [Image] rather than through a viewport,
+## so no window and no settle are needed.
+
+const NEW_BARK_GROUP: int = 24
+const NEW_BARK_MAP: int = 7
+## How far down the dex the preview's save has been filled.
+const SEEN: int = 251
+
+const BUTTONS: Dictionary = {
+	"u": Gen2Button.UP, "d": Gen2Button.DOWN,
+	"l": Gen2Button.LEFT, "r": Gen2Button.RIGHT,
+	"a": Gen2Button.A, "b": Gen2Button.B,
+	"sel": Gen2Button.SELECT, "start": Gen2Button.START,
+}
+
+## Which presses each named screen is reached by, so a caller naming one does not
+## have to know the walk.
+const ROUTES: Dictionary = {
+	"list": "",
+	"entry": "a",
+	"option": "sel",
+	"search": "start",
+	"results": "start,d,d,a",
+	"unown": "sel,d,d,d,a",
+}
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error(
+			"Usage: preview_pokedex.gd -- <game> <output.png> "
+			+ "[list|entry|option|search|results|unown] [presses]"
+		)
+		quit(1)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var screen: String = args[2] if args.size() > 2 else "list"
+	var tokens: String = String(ROUTES.get(screen, ""))
+	if args.size() > 3:
+		tokens = "%s,%s" % [tokens, args[3]] if not tokens.is_empty() else args[3]
+
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, NEW_BARK_GROUP, NEW_BARK_MAP, Vector2i.ZERO, _state()
+	)
+	var host := Gen2PokedexScreen.new()
+	root.add_child(host)
+	if not host.open(data, world):
+		push_error("The %s cache holds no Pokedex graphics." % args[0])
+		quit(1)
+		return
+	# The screen counts hardware frames off wall clock in `_process`; the preview
+	# spends them by hand so the arrow is where the presses left it.
+	host.set_process(false)
+	for token: String in tokens.split(",", false):
+		var key: String = token.strip_edges().to_lower()
+		if key.begins_with("f"):
+			for _frame: int in maxi(1, int(key.substr(1))):
+				host.advance_frame()
+		elif BUTTONS.has(key):
+			host.handle_button(int(BUTTONS[key]))
+
+	var error: Error = host.render().save_png(args[1])
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [args[1], error])
+		quit(1)
+		return
+	print("Wrote %s: %s, mode %d, cursor on %s" % [
+		args[1], screen, host.current_mode(),
+		data.species(host.selected_species()).get("name", "?"),
+	])
+	quit(0)
+
+
+## A world whose dex is filled far enough to draw every row state: seen up to
+## [constant SEEN], caught on every second one, and the Unown dex unlocked so the
+## OPTION screen offers its fourth row.
+static func _state() -> Gen2WorldState:
+	var state := Gen2WorldState.new({}, {}, {}, {})
+	for species: int in range(1, SEEN + 1):
+		state.set_species_seen(species)
+		if species % 2 == 0:
+			state.set_species_caught(species)
+	state.set_engine_flag(Gen2WorldState.ENGINE_UNOWN_DEX)
+	for form: int in range(1, 8):
+		state.update_unown_dex(form)
+	return state

--- a/tools/preview_pokedex.gd.uid
+++ b/tools/preview_pokedex.gd.uid
@@ -1,0 +1,1 @@
+uid://cfw4r4knbrnb4

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -37,7 +37,7 @@ const GROUPS: Dictionary = {
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
-		&"pack", &"unown_dex",
+		&"pack", &"unown_dex", &"pokedex",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
The dex was the last big window-resolution panel. It is the cartridge's own
screen now, on all three cartridges.

## Import

| Asset | Located by | Hits per dump |
|---|---|---|
| `PokedexLZ` (58 tiles) | compressing `gfx/pokedex/pokedex.png` with pret's own lzcompress flags | 1 |
| `PokedexSlowpokeLZ` (55) | the same, and it follows the first | 1 |
| `UnownFont` (27) | matching the assembled sheet | 1 |
| `Footprints` (1,024 1bpp tiles) | matching the 8 KiB grid | 1 |
| `_CGB_Pokedex`'s three palettes | PREDEFPAL_POKEDEX as its own offset, the two small ones by their colours | 1 each |

All four sheets are byte identical on Gold, Silver and Crystal. Cache format 61,
so all three need re-importing.

## The page

`render/pokedex_page.gd` is the source's `Pokedex_Draw*BG` routines read as tile
writes. Six states: the listing, the entry screen with both pages and the
species' footprint, OPTION with its description box, SEARCH, its results, and
the Unown dex with `UnownFont`'s own letters.

The main screen and the results screen are composed the way the hardware
composes them, a background scrolled by `POKEDEX_SCX` under the listing window
at its own `hWX`; at five pixels and `$47` neither lands on a tile boundary, so
neither can be one grid.

Three findings the grid made visible that a label panel could not:

- `#` is the POKé ligature and `$54` on this screen is a dex frame tile, so the
  shorthand has to be expanded to four characters that do not encode back to it.
- The option screen's descriptions are `<PK><MN>`, two glyphs, not `#MN`.
- `String_SELECT_OPTION` falls through into `String_START_SEARCH`, so one
  `PlaceString` writes both runs and the START one under the listing belongs to
  the window rather than the background.

Two things are left, both in the divergence table: `DrawPokedexSearchResultsWindow`'s
second frame would cut the background box's own words in half at `hWX` $4a, and
the results screen's type line and `FOUND!` are written into two maps that
overlap. Both need the oracle to settle; the screen reads whole either way.

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 2,991 over 148 scripts, green (was 2,983) |
| GUT, unit tier | 2,644 in 32 s |
| `validate.gd -- all` | exit 0, 47 topics |
| `checks/pokedex` | 4 sheets, 3 palettes, 251 footprints and 251 entry screens on each cartridge; art identical on all three |
| Screenshots | all six states on Crystal, three on Gold |