### PR TITLE
The pack is the cartridge's own screen, and it says the cartridge's words

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -358,9 +358,10 @@ paints the background itself and a hole would show the window behind the screen.
 change including the empty rectangle when it goes away. The standard box is
 twenty by six at row twelve, but a box can be any size and is not always up.
 
-The world's own menus are not this box: the start menu, pack, party and PC are
+The world's own menus are not this box: the start menu, party and PC are
 window-resolution panels with their own scrim, so a renderer neither sees nor
-styles them. `Gen2MenuPage` is the cartridge box path, used by the naming and
+styles them. The pack's listing inside that panel is the cartridge's own screen,
+drawn by `Gen2PackPage`, and is not this box either. `Gen2MenuPage` is the cartridge box path, used by the naming and
 gender screens, neither of which is ever over a renderer.
 
 A world renderer has a third:

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -52,6 +52,7 @@ var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
 var _pokedex_palettes: Dictionary = {}
+var _pack: Dictionary = {}
 var _gender_screen_palette: Array = []
 var _copyright_string: Array = []
 var _copyright_palette: Array = []
@@ -127,6 +128,7 @@ static func open_directory(path: String) -> GameData:
 	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
+	data._pack = manifest.get("pack", {})
 	var gender_palette: Variant = manifest.get("gender_screen_palette", [])
 	data._gender_screen_palette = gender_palette if gender_palette is Array else []
 	var copyright_string: Variant = manifest.get("copyright_string", [])
@@ -1281,8 +1283,10 @@ func copyright_palette() -> PackedColorArray:
 
 
 ## One of the pack's five texts (`oak_no_time`, `no_mon`, `toss_ask`,
-## `toss_ask_quantity`, `toss_threw`), still carrying [Gen2TextStream]'s markers
-## for the quantity and the item name. Empty on a cache imported before them,
+## `toss_ask_quantity`, `toss_threw`) or the six a field item says
+## (`escape_rope`, `itemfinder_nearby`, `itemfinder_nope`, `sacred_ash`,
+## `squirtbottle`, `coin_case`), still carrying [Gen2TextStream]'s markers
+## for the quantity, the player and the item name. Empty on a cache imported before them,
 ## which is the caller's cue to use its own wording.
 func menu_text(key: String) -> String:
 	return String(_menu_text.get(key, ""))
@@ -1640,6 +1644,37 @@ func pokedex_palette(name: String) -> PackedColorArray:
 	var colors := PackedColorArray()
 	for packed: Variant in stored as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## `DrawPocketName`'s own 5x3 piece for [param pocket], as the tile numbers it
+## copies. Empty for a cache without the screen, or for a pocket outside the
+## four the tilemap holds.
+func pack_pocket_name(pocket: int) -> PackedByteArray:
+	var stored: Variant = _pack.get("pocket_names", [])
+	var cells: int = RomLayout.PACK_NAME_COLUMNS * RomLayout.PACK_NAME_ROWS
+	if not stored is Array or pocket < 0 or pocket >= RomLayout.PACK_POCKETS \
+		or (stored as Array).size() < RomLayout.PACK_NAME_CELLS:
+		return PackedByteArray()
+	var out := PackedByteArray()
+	for cell: int in cells:
+		out.append(int((stored as Array)[pocket * cells + cell]))
+	return out
+
+
+## One of `_CGB_PackPals`' six palettes, Kris's set for [param female]. Empty
+## where the cache does not carry it, which is every Gold and Silver cache for
+## the female set.
+func pack_palette(index: int, female: bool = false) -> PackedColorArray:
+	var stored: Variant = _pack.get("female_palettes" if female else "palettes", [])
+	if not stored is Array or index < 0 or index >= RomLayout.PACK_PALETTES:
+		return PackedColorArray()
+	var first: int = index * RomLayout.PACK_PALETTE_COLORS
+	if (stored as Array).size() < first + RomLayout.PACK_PALETTE_COLORS:
+		return PackedColorArray()
+	var colors := PackedColorArray()
+	for offset: int in RomLayout.PACK_PALETTE_COLORS:
+		colors.append(Gen2Palette.from_packed(int((stored as Array)[first + offset])))
 	return colors
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 61
+const FORMAT_VERSION: int = 62
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -336,6 +336,14 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not menu_text["ok"]:
 		return menu_text
 
+	var pack: Dictionary = verify_pack(rom, layout)
+	if not pack["ok"]:
+		return pack
+
+	var descriptions: Dictionary = verify_descriptions(rom, layout)
+	if not descriptions["ok"]:
+		return descriptions
+
 	return {"ok": true, "message": "Layout verified."}
 
 
@@ -1852,12 +1860,23 @@ const INTRO_TEXT_OPENINGS: Dictionary = {
 
 ## What each pack text opens with once its `text` macro byte is past. Short
 ## anchors, the way the intro texts are anchored.
+## The pack's own five, and the six a field item says. Every one is
+## `data/text/common_*.asm`, which no other importer reads, so each is pinned by
+## its own opening rather than by a table.
 const PACK_TEXT_OPENINGS: Dictionary = {
 	"oak_no_time": "OAK:",
 	"no_mon": "You don't have a",
 	"toss_ask": "Throw away how",
 	"toss_ask_quantity": "Throw away ",
 	"toss_threw": "Threw away",
+	"escape_rope": "<PLAYER> used an",
+	"itemfinder_nearby": "Yes! ITEMFINDER",
+	"itemfinder_nope": "Nope! ITEMFINDER",
+	## `#` is the charmap's own ligature and decodes spelled out, the way
+	## MENU_DESCRIPTION_FIRST does.
+	"sacred_ash": "<PLAYER>'s POKéMON",
+	"squirtbottle": "<PLAYER> sprinkled",
+	"coin_case": "Coins:",
 }
 ## The first and last of `.PokedexDesc` through `.QuitDesc`, which is what says a
 ## nine-string run is that run and not another one in the same bank. As decoded
@@ -1899,7 +1918,11 @@ static func verify_menu_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 		}
 	for key: String in PACK_TEXT_OPENINGS:
 		var at: int = int(entry.get(key, -1))
-		if at < 0 or not rom.in_bounds(at, RomLayout.PACK_TEXT_MAX_BYTES):
+		## -1 is a text this cartridge has nothing usable at; only the Coin
+		## Case's is, and only on Gold and Silver.
+		if at < 0:
+			continue
+		if not rom.in_bounds(at, RomLayout.PACK_TEXT_MAX_BYTES):
 			return {"ok": false, "message": "Pack text %s is outside the cartridge." % key}
 		if rom.u8(at) != TEXT_MACRO_START:
 			return {
@@ -2143,6 +2166,78 @@ static func verify_gender_screen(rom: RomFile, layout: Dictionary) -> Dictionary
 				],
 			}
 	return {"ok": true, "message": "Gender screen graphics verified."}
+
+
+## `gfx/pack/pack.pal` and `pack_f.pal`, six palettes each, which pin both sets:
+## every dump ships them byte identical and Crystal stores Kris's immediately
+## after Chris's, inside `_CGB_PackPals` itself.
+const PACK_CHRIS_COLORS: Array[int] = [
+	0x7FFF, 0x7DEF, 0x7C00, 0x0000, 0x7FFF, 0x7DEF, 0x7C00, 0x0000,
+	0x7D7F, 0x7DEF, 0x7C00, 0x0000, 0x7FFF, 0x7DEF, 0x7C00, 0x001F,
+	0x7FFF, 0x7DEF, 0x001F, 0x0000, 0x7FFF, 0x1E67, 0x1E67, 0x0000,
+]
+const PACK_KRIS_COLORS: Array[int] = [
+	0x7FFF, 0x7DDF, 0x7CFF, 0x0000, 0x7FFF, 0x7DDF, 0x7CFF, 0x0000,
+	0x7DEF, 0x7DDF, 0x7CFF, 0x0000, 0x7FFF, 0x7DDF, 0x7CFF, 0x001F,
+	0x7FFF, 0x7DDF, 0x001F, 0x0000, 0x7FFF, 0x1E67, 0x1E67, 0x0000,
+]
+## What `DrawPocketName`'s tilemap sits before `PackMenuGFX` by in every dump.
+## The two were located independently, so the constant gap is what says both are
+## right rather than both being plausible.
+const PACK_NAME_TILEMAP_GAP: int = 0x135
+
+
+## The pack screen's four runs. Both palette sets are checked colour for colour,
+## the tilemap for being where it is relative to the sheet and for naming only
+## tiles the sheet carries, and every run for being inside the cartridge.
+static func verify_pack(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("pack", {})
+	if entry.is_empty():
+		return {"ok": true, "message": "No pack screen on this cartridge."}
+	var menu_gfx: int = int(entry["menu_gfx"])
+	var names: int = int(entry["pocket_names"])
+	if not rom.in_bounds(menu_gfx, RomLayout.PACK_MENU_TILES * RomLayout.TILE_BYTES_2BPP) \
+		or not rom.in_bounds(
+			RomLayout.pack_gfx_offset(layout),
+			RomLayout.PACK_TILES * RomLayout.TILE_BYTES_2BPP
+		) \
+		or not rom.in_bounds(names, RomLayout.PACK_NAME_CELLS):
+		return {"ok": false, "message": "Pack graphics are outside the cartridge."}
+	if menu_gfx - names != PACK_NAME_TILEMAP_GAP:
+		return {
+			"ok": false,
+			"message": "The pack tilemap sits $%X before its sheet, expected $%X." % [
+				menu_gfx - names, PACK_NAME_TILEMAP_GAP,
+			],
+		}
+	for cell: int in RomLayout.PACK_NAME_CELLS:
+		var tile: int = rom.u8(names + cell)
+		if tile >= RomLayout.PACK_FIRST_TILE:
+			return {
+				"ok": false,
+				"message": "Pack tilemap cell %d is tile $%02X, past the sheet." % [
+					cell, tile,
+				],
+			}
+
+	var sets: Array = [["palettes", PACK_CHRIS_COLORS], ["female_palettes", PACK_KRIS_COLORS]]
+	for set_row: Array in sets:
+		var at: int = int(entry.get(String(set_row[0]), -1))
+		if at < 0:
+			continue
+		var want: Array[int] = set_row[1]
+		if not rom.in_bounds(at, want.size() * Gen2Palette.COLOR_BYTES):
+			return {"ok": false, "message": "Pack palettes are outside the cartridge."}
+		for index: int in want.size():
+			var stored: int = rom.u16le(at + index * Gen2Palette.COLOR_BYTES)
+			if stored != want[index]:
+				return {
+					"ok": false,
+					"message": "Pack %s colour %d is $%04X, expected $%04X." % [
+						set_row[0], index, stored, want[index],
+					],
+				}
+	return {"ok": true, "message": "Pack graphics verified."}
 
 
 ## Walks the type matchup chart from its offset to the terminator.
@@ -3527,6 +3622,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"copyright_palette": _import_copyright_palette(rom, layout),
 		"presents_palettes": _import_presents_palettes(rom, layout),
 		"title": _import_title(rom, layout),
+		"pack": _import_pack(rom, layout),
 		"town_map": _import_town_map(rom, layout),
 		"intro_movie": _import_intro_movie(rom, layout),
 		"gs_intro": _import_gs_intro(rom, layout),
@@ -3697,6 +3793,11 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 		rom.bytes(), int(layout["move_names"]), RomLayout.MOVE_COUNT, RomLayout.MAX_NAME_LENGTH
 	)
 	var out: Array = []
+	## `PrintMoveDescription`'s own line, which the TM/HM pocket prints for the
+	## move a TM teaches.
+	var descriptions: Array[String] = read_descriptions(
+		rom, int(layout.get("move_descriptions", -1)), RomLayout.MOVE_DESCRIPTION_COUNT
+	)
 
 	for move: int in range(1, RomLayout.MOVE_COUNT + 1):
 		var entry: int = RomLayout.move_data_offset(layout, move)
@@ -3705,6 +3806,7 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 		out.append({
 			"number": move,
 			"name": names[move - 1],
+			"description": descriptions[move - 1] if move <= descriptions.size() else "",
 			"effect": rom.u8(entry + RomLayout.MOVE_EFFECT),
 			"power": rom.u8(entry + RomLayout.MOVE_POWER),
 			"type": rom.u8(entry + RomLayout.MOVE_TYPE),
@@ -3829,6 +3931,11 @@ func _import_items(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 	var out: Array = []
 	var status_masks: Dictionary = _read_item_status_masks(rom, layout)
 	var healing_amounts: Dictionary = _read_item_healing_amounts(rom, layout)
+	## `PrintItemDescription`'s own line, which the pack's text box prints under
+	## the pocket the row is in.
+	var descriptions: Array[String] = read_descriptions(
+		rom, int(layout.get("item_descriptions", -1)), RomLayout.ITEM_COUNT
+	)
 
 	for item: int in range(1, RomLayout.ITEM_COUNT + 1):
 		var at: int = int(layout["item_attributes"]) + (item - 1) * RomLayout.ITEM_ATTRIBUTE_SIZE
@@ -3847,6 +3954,8 @@ func _import_items(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 			"field_menu": packed_menu >> 4,
 			"battle_menu": packed_menu & 0x0F,
 		}
+		if item <= descriptions.size():
+			entry["description"] = descriptions[item - 1]
 		if status_masks.has(item):
 			entry["status_mask"] = int(status_masks[item])
 		if healing_amounts.has(item):
@@ -3856,6 +3965,45 @@ func _import_items(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 			on_progress.call("items", item, RomLayout.ITEM_COUNT)
 
 	return out
+
+
+## One `table_width 2` description table, as [param count] decoded texts in
+## entry order. Every pointer is an address inside the table's own bank, which is
+## what `PrintItemDescription` and `PrintMoveDescription` read them as; an entry
+## that leaves the bank or runs past [constant RomLayout.DESCRIPTION_MAX_BYTES]
+## without a terminator answers an empty Array, since a wrong table decodes as
+## words rather than failing.
+static func read_descriptions(rom: RomFile, at: int, count: int) -> Array[String]:
+	var out: Array[String] = []
+	if at < 0 or not rom.in_bounds(at, count * 2):
+		return out
+	var bank: int = at / RomFile.BANK_SIZE
+	var data: PackedByteArray = rom.bytes()
+	for index: int in count:
+		var address: int = rom.u16le(at + index * 2)
+		if address < 0x4000 or address >= 0x8000:
+			return [] as Array[String]
+		var offset: int = bank * RomFile.BANK_SIZE + (address - 0x4000)
+		var end: int = Gen2Text.terminated_end(
+			data, offset, RomLayout.DESCRIPTION_MAX_BYTES
+		)
+		if end <= offset or end - offset >= RomLayout.DESCRIPTION_MAX_BYTES:
+			return [] as Array[String]
+		out.append(Gen2Text.decode(data, offset, end - offset))
+	return out
+
+
+## Both description tables, checked by decoding every entry of each.
+static func verify_descriptions(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if read_descriptions(
+		rom, int(layout.get("item_descriptions", -1)), RomLayout.ITEM_COUNT
+	).size() != RomLayout.ITEM_COUNT:
+		return {"ok": false, "message": "The item descriptions do not decode."}
+	if read_descriptions(
+		rom, int(layout.get("move_descriptions", -1)), RomLayout.MOVE_DESCRIPTION_COUNT
+	).size() != RomLayout.MOVE_DESCRIPTION_COUNT:
+		return {"ok": false, "message": "The move descriptions do not decode."}
+	return {"ok": true, "message": "Descriptions verified."}
 
 
 static func verify_item_metadata(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -4115,8 +4263,11 @@ func _import_menu_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 		descriptions[String(RomLayout.MENU_DESCRIPTION_ORDER[index])] = read[index]
 	out["descriptions"] = descriptions
 	for key: String in PACK_TEXT_OPENINGS:
+		var at: int = int(entry.get(key, -1))
+		if at < 0:
+			continue
 		var decoded: Dictionary = Gen2WorldScript.decode_text(
-			rom.slice(int(entry[key]), RomLayout.PACK_TEXT_MAX_BYTES)
+			rom.slice(at, RomLayout.PACK_TEXT_MAX_BYTES)
 		)
 		if not bool(decoded.get("ok", false)):
 			return {}
@@ -4188,6 +4339,29 @@ func _packed_palette(rom: RomFile, at: int, colors: int) -> Array:
 	for index: int in colors:
 		out.append(rom.u16le(at + index * Gen2Palette.COLOR_BYTES))
 	return out
+
+
+## The pack screen's data half: `DrawPocketName`'s 5x12 tilemap and the palettes
+## `_CGB_PackPals` fills the attrmap with. The graphics go through the tile table
+## with the rest of the strips.
+##
+## Both palette sets are six palettes, not the eight the copy asks for; the two
+## past them are read out of whatever follows and no attribute names them.
+func _import_pack(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("pack", {})
+	if entry.is_empty():
+		return {}
+	var names: Array = []
+	for cell: int in RomLayout.PACK_NAME_CELLS:
+		names.append(rom.u8(int(entry["pocket_names"]) + cell))
+	var colors: int = RomLayout.PACK_PALETTES * RomLayout.PACK_PALETTE_COLORS
+	return {
+		"pocket_names": names,
+		"palettes": _packed_palette(rom, int(entry["palettes"]), colors),
+		"female_palettes": _packed_palette(
+			rom, int(entry.get("female_palettes", -1)), colors
+		),
+	}
 
 
 ## `CopyrightString`, as the tile codes it is. Kept as codes rather than as text
@@ -4902,6 +5076,31 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"first_code": 0,
 			"bits": 2,
 		}
+
+	## `Pack_InitGFX`'s own two runs. The pocket pictures are one strip of all
+	## four rather than the fifteen tiles `DrawPackGFX` requests, since a cache
+	## holds what the cartridge stores and the screen picks its pocket out of it.
+	var pack: Dictionary = layout.get("pack", {})
+	if not pack.is_empty():
+		sheets["pack_menu"] = {
+			"offset": int(pack["menu_gfx"]),
+			"tiles": RomLayout.PACK_MENU_TILES,
+			"first_code": 0,
+			"bits": 2,
+		}
+		sheets["pack_pockets"] = {
+			"offset": RomLayout.pack_gfx_offset(layout),
+			"tiles": RomLayout.PACK_TILES,
+			"first_code": 0,
+			"bits": 2,
+		}
+		if int(pack.get("female_gfx", -1)) >= 0:
+			sheets["pack_pockets_female"] = {
+				"offset": int(pack["female_gfx"]),
+				"tiles": RomLayout.PACK_TILES,
+				"first_code": 0,
+				"bits": 2,
+			}
 
 	var title: Dictionary = layout.get("title", {})
 	if int(title.get("trail", -1)) >= 0:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -645,6 +645,45 @@ const UNOWN_FONT_TILES: int = 27
 ## `FIRST_UNOWN_CHAR`, where the letters land.
 const UNOWN_FONT_FIRST_TILE: int = 0x40
 
+## `ItemDescriptions` and `MoveDescriptions`, the two lines a pack row prints
+## into its own text box (`PrintItemDescription`, `PrintMoveDescription`). Both
+## are `table_width 2` pointer tables in the bank their texts sit in, so an entry
+## is read as an in-bank address rather than as a far pointer.
+const DESCRIPTION_MAX_BYTES: int = 80
+const MOVE_DESCRIPTION_COUNT: int = 251
+
+## The pack screen's own graphics (engine/items/pack.asm).
+##
+## `PackMenuGFX` is 80 tiles and `Pack_InitGFX` copies `$60 tiles` of it, so the
+## sixteen that land on `vTiles2 tile $50` are `PackGFX`'s own first sixteen;
+## `DrawPackGFX` then puts the current pocket's fifteen there before the screen
+## is shown, and the sixteenth is never named by a tilemap. That overrun is what
+## says the two runs are adjacent, and they are, in every dump.
+##
+## `PackFGFX` is Crystal's alone: Gold and Silver have no player gender and no
+## `DrawKrisPackGFX`. All four runs are uncompressed and each matches the
+## assembled `gfx/pack` PNGs once per dump.
+const PACK_MENU_TILES: int = 80
+const PACK_POCKET_TILES: int = 15
+const PACK_POCKETS: int = 4
+const PACK_TILES: int = PACK_POCKET_TILES * PACK_POCKETS
+## `PlacePackGFX`'s own `ld a, $50`, which is where a pocket's picture is placed
+## and so what a pack tile number is offset by.
+const PACK_FIRST_TILE: int = 0x50
+## `PackGFXPointers`' order, as the pocket each of the four pictures belongs to:
+## the sheet is stored key items, items, TM/HM, balls.
+const PACK_POCKET_PICTURES: Array[int] = [1, 3, 0, 2]
+## `DrawPocketName`'s 5x12 tilemap, four 5x3 pieces in `*_POCKET` order.
+const PACK_NAME_COLUMNS: int = 5
+const PACK_NAME_ROWS: int = 3
+const PACK_NAME_CELLS: int = PACK_NAME_COLUMNS * PACK_NAME_ROWS * PACK_POCKETS
+## `.ChrisPackPals` and `.KrisPackPals`, which `gfx/pack/pack.pal` and
+## `pack_f.pal` define six palettes each of. `_CGB_PackPals` copies eight and its
+## own comment asks why; the attrmap it then fills names only 0 to 5, so the two
+## past the file are read and never drawn.
+const PACK_PALETTES: int = 6
+const PACK_PALETTE_COLORS: int = 4
+
 ## `DrawIntroPlayerPic`'s uncompressed 7x7 picture. Crystal stores Chris and
 ## Kris column-major; Gold and Silver use CAL's normal trainer picture instead.
 const INTRO_PLAYER_PIC_COLUMNS: int = 7
@@ -1490,6 +1529,13 @@ const GOLD_SILVER: Dictionary = {
 	"palettes": 0xAD3D,
 	"move_names": 0x1B1574,
 	"item_names": 0x1B0000,
+	# `ItemDescriptions` and `MoveDescriptions`, each a table of in-bank
+	# pointers its own texts follow. Located by encoding the pinned first entry
+	# of each (`MasterBallDesc`, `PoundDescription`), which hits once per dump,
+	# and taking the pointer to it in the same bank; every one of the 255 and 251
+	# entries then terminates within [constant DESCRIPTION_MAX_BYTES].
+	"item_descriptions": 0x1B8000,
+	"move_descriptions": 0x1B4000,
 	"item_attributes": 0x68A0,
 	"item_status_actions": 0xF0C7,
 	"item_healing_hp": 0xF405,
@@ -1520,6 +1566,17 @@ const GOLD_SILVER: Dictionary = {
 		"toss_ask": 0x194569,
 		"toss_ask_quantity": 0x19457F,
 		"toss_threw": 0x19459C,
+		# The six a field item says, in the same file and located the same way.
+		"escape_rope": 0x1940AE,
+		"itemfinder_nearby": 0x19443B,
+		"itemfinder_nope": 0x19446D,
+		"sacred_ash": 0x194529,
+		"squirtbottle": 0x1944FF,
+		# `_CoinCaseCountText` ends with `done` rather than `text_end` here, so
+		# `DoTextUntilTerminator` indexes `TextCommands` with $57 and runs off
+		# the table: the arbitrary code execution pokegold's own comment names.
+		# There is no text to be faithful to, so it is not imported.
+		"coin_case": -1,
 	},
 	"intro_text": {
 		"oak_1": 0x195624,
@@ -1723,6 +1780,19 @@ const GOLD_SILVER: Dictionary = {
 		"question_mark_palette": 0x9559,
 		"cursor_palette": 0x9551,
 	},
+	# The pack screen. `menu_gfx` and `pocket_names` were located by assembling
+	# the pinned `gfx/pack` files and matching the bytes, and `palettes` by
+	# encoding `pack.pal`; each hits once per dump. `PackGFX` is not pinned
+	# separately because it follows the menu sheet immediately, which is what
+	# `Pack_InitGFX`'s sixteen-tile overrun relies on. `female_gfx` is -1 here:
+	# these cartridges have no Kris.
+	"pack": {
+		"menu_gfx": 0x10F31,
+		"female_gfx": -1,
+		"pocket_names": 0x10DFC,
+		"palettes": 0x996F,
+		"female_palettes": -1,
+	},
 	# Battle animations. `BattleAnimations` was located by matching
 	# `BattleAnim_Pound` whole (d1 01 e0 01 31 d0 08 88 38 00 06 d0 01 88 38 00
 	# 10 ff), then finding the run of 278 in-bank pointers whose second entry is
@@ -1887,6 +1957,9 @@ const CRYSTAL: Dictionary = {
 	"palettes": 0xA8CE,
 	"move_names": 0x1C9F29,
 	"item_names": 0x1C8000,
+	# The two description tables; see the Gold and Silver block above.
+	"item_descriptions": 0x1C8987,
+	"move_descriptions": 0x2CB52,
 	"item_attributes": 0x67C1,
 	"item_status_actions": 0xF071,
 	"item_healing_hp": 0xF3AF,
@@ -1912,6 +1985,12 @@ const CRYSTAL: Dictionary = {
 		"toss_ask": 0x1C0BA5,
 		"toss_ask_quantity": 0x1C0BBB,
 		"toss_threw": 0x1C0BD8,
+		"escape_rope": 0x1C06ED,
+		"itemfinder_nearby": 0x1C0A77,
+		"itemfinder_nope": 0x1C0AA9,
+		"sacred_ash": 0x1C0B65,
+		"squirtbottle": 0x1C0B3B,
+		"coin_case": 0x1C5C7B,
 	},
 	"intro_text": {
 		"oak_1": 0x1C1D35,
@@ -2081,6 +2160,17 @@ const CRYSTAL: Dictionary = {
 		"unown_font": 0x1DC000,
 		"question_mark_palette": 0x8FBA,
 		"cursor_palette": 0x8FC2,
+	},
+	# The pack screen; see the Gold and Silver block above for how these were
+	# located. Crystal is the profile that has both packs: `.KrisPackPals`
+	# follows `.ChrisPackPals` in the same routine, which is the contiguity
+	# `verify_pack` checks, while `PackFGFX` sits in a bank of its own.
+	"pack": {
+		"menu_gfx": 0x10B16,
+		"female_gfx": 0x48E9B,
+		"pocket_names": 0x109E1,
+		"palettes": 0x9439,
+		"female_palettes": 0x9469,
 	},
 	# Battle animations; see the Gold and Silver block above for how these were
 	# located. All five tables sit in the same two banks in every dump and only
@@ -2305,6 +2395,13 @@ const NAMING_CURSOR_TILES: int = 2
 const NAMING_MARKER_TILES: int = 1
 const TILE_BYTES_2BPP: int = 16
 const TILE_BYTES_1BPP: int = 8
+
+
+## `PackGFX`, which the source stores immediately after `PackMenuGFX` and never
+## points at except through `PackGFXPointers`' own offsets into it.
+static func pack_gfx_offset(layout: Dictionary) -> int:
+	return int((layout["pack"] as Dictionary)["menu_gfx"]) \
+		+ PACK_MENU_TILES * TILE_BYTES_2BPP
 
 
 static func naming_border_offset(layout: Dictionary) -> int:

--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -1,0 +1,352 @@
+class_name Gen2PackPage
+extends RefCounted
+
+## The pack's own tile screen (`Pack_InitGFX`, engine/items/pack.asm).
+##
+## [Gen2WorldPack] owns the pockets and what a row may do; this is the picture,
+## the way [Gen2PokedexPage] is the dex's. The screen is a 20x18 grid of tile
+## numbers plus one palette per cell, since `_CGB_PackPals` fills the attrmap
+## with six palettes at once and a single-palette blit cannot say what it draws.
+##
+## `Pack_InitGFX`'s VRAM window:
+##
+## | Tiles | Contents |
+## |---|---|
+## | $00-$4f | `PackMenuGFX`, the background, the header row and the pocket names |
+## | $50-$5e | the current pocket's picture, which `DrawPackGFX` swaps per pocket |
+## | $80+ | the font, so printed text addresses glyphs as usual |
+##
+## The copy is `$60 tiles` of an 80-tile sheet, so the sixteen it lands on $50
+## are `PackGFX`'s own first sixteen; `DrawPackGFX` overwrites fifteen of them
+## before the screen is shown and no tilemap names the sixteenth.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+const SHEET_TILES: int = RomLayout.PACK_MENU_TILES
+const PACK_FIRST_TILE: int = RomLayout.PACK_FIRST_TILE
+const BLANK_TILE: int = 0x7F
+
+## `Pack_InitGFX`'s own three writes: the field `ByteFill`ed over rows 1 to 11,
+## the header row of twenty ascending tiles from $28, and the 5x3 corner the
+## pocket picture is placed in.
+const FIELD_TILE: int = 0x24
+const FIELD_AT: Vector2i = Vector2i(0, 1)
+const FIELD_ROWS: int = 11
+const HEADER_FIRST_TILE: int = 0x28
+const PACK_AT: Vector2i = Vector2i(0, 3)
+const PACK_COLUMNS: int = 5
+const PACK_ROWS: int = 3
+## `DrawPocketName`'s own corner, the same shape one row above the text box.
+const NAME_AT: Vector2i = Vector2i(0, 7)
+
+## `hlcoord 5, 1 / lb bc, 11, 15`, the listing's own cleared box.
+const LIST_AT: Vector2i = Vector2i(5, 1)
+const LIST_COLUMNS: int = 15
+const LIST_ROWS: int = 11
+
+## `hlcoord 0, SCREEN_HEIGHT - 4 - 2 / lb bc, 4, SCREEN_WIDTH - 2`, which is a
+## four-row interior and so a six-row frame across the screen.
+const TEXTBOX_AT: Vector2i = Vector2i(0, 12)
+const TEXTBOX_COLUMNS: int = 20
+const TEXTBOX_ROWS: int = 6
+## Where `PrintItemDescription` is handed, and the row spacing every text box on
+## the hardware is written with.
+const TEXT_AT: Vector2i = Vector2i(1, 14)
+const TEXT_SPACING: int = 2
+
+## `ItemsPocketMenuHeader`: `menu_coords 7, 1, 19, 11` with five rows of eight
+## columns. `ScrollingMenu_UpdateDisplay` starts one cell in from that corner and
+## steps two rows, `w2DMenuCursorInitX` is the border column itself, and
+## `PlaceMenuItemQuantity` writes `SCREEN_WIDTH + 1` past the name's own width.
+const LIST_HEIGHT: int = 5
+const CURSOR_COLUMN: int = 7
+const NAME_COLUMN: int = 8
+const FIRST_ROW: int = 2
+const ROW_SPACING: int = 2
+const QUANTITY_AT: Vector2i = Vector2i(17, 3)
+const QUANTITY_DIGITS: int = 2
+
+## `TMHM_DisplayPocketItems`, which is a listing of its own rather than a
+## scrolling menu: the TM number sits in the column the other pockets leave
+## empty and the move name three cells past it, on the same rows.
+const TMHM_NUMBER_COLUMN: int = 5
+
+## `Place2DMenuCursor`'s "▶" and the "×" `PlaceMenuItemQuantity` writes.
+const CURSOR_CODE: int = 0xED
+const TIMES_CODE: int = 0xF1
+
+## `ScrollingMenu_UpdateDisplay.CancelString` and `TMHM_CancelString`, which are
+## the same word in both listings.
+const CANCEL: String = "CANCEL"
+
+## A row of [method pocket_map]'s listing. `item` is every pocket but TM/HM,
+## `tm` carries the number the TM/HM pocket prints beside the move name, and
+## `cancel` is the row both listings end with.
+const ROW_ITEM: StringName = &"item"
+const ROW_TM: StringName = &"tm"
+const ROW_CANCEL: StringName = &"cancel"
+
+## `_CGB_PackPals`' five `FillBoxCGB` calls, as (x, y, width, height, palette)
+## over an attrmap `WipeAttrmap` left on palette 0.
+const ATTRIBUTES: Array = [
+	[0, 0, 10, 1, 1],
+	[10, 0, 10, 1, 2],
+	[7, 2, 1, 9, 3],
+	[0, 7, 5, 3, 4],
+	[0, 3, 5, 3, 5],
+]
+
+var font: Gen2Font = null
+## Which text-box border the player chose, for the box the description sits in.
+var frame_style: int = 0
+## The VRAM window, as one indices strip per tile number.
+var _tiles: Dictionary = {}
+## `PackGFX` and `PackFGFX`, each as the whole four-pocket strip.
+var _pockets: PackedByteArray = PackedByteArray()
+var _pockets_female: PackedByteArray = PackedByteArray()
+
+
+## [param data] supplies the glyphs and both sheets; a cache without them answers
+## null rather than drawing a screen of blanks.
+static func from_data(data: GameData) -> Gen2PackPage:
+	if data == null:
+		return null
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null:
+		return null
+	var out := Gen2PackPage.new()
+	out.font = glyphs
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	out._load_sheet(data.tile_indices("pack_menu"))
+	out._pockets = data.tile_indices("pack_pockets")
+	out._pockets_female = data.tile_indices("pack_pockets_female")
+	return out
+
+
+func ready() -> bool:
+	return font != null and _tiles.size() >= SHEET_TILES and not _pockets.is_empty()
+
+
+func _load_sheet(indices: PackedByteArray) -> void:
+	if indices.is_empty():
+		return
+	@warning_ignore("integer_division")
+	var width: int = indices.size() / TILE
+	for tile: int in SHEET_TILES:
+		if (tile + 1) * TILE > width:
+			break
+		var cell := PackedByteArray()
+		cell.resize(TILE * TILE)
+		for y: int in TILE:
+			for x: int in TILE:
+				cell[y * TILE + x] = indices[y * width + tile * TILE + x]
+		_tiles[tile] = cell
+
+
+## The whole screen as tile numbers, in the order `Pack_InitGFX` writes them.
+##
+## [param pocket] is `wCurPocket`, which picks both the picture and the name.
+## [param rows] is the visible listing, at most [constant LIST_HEIGHT] entries of
+## the three shapes [constant ROW_ITEM] names, and [param cursor] which of them
+## the arrow stands on, or -1 while `PlaceHollowCursor` has taken it away.
+func pocket_map(
+	pocket: int, rows: Array, cursor: int, description: String,
+	pocket_name: PackedByteArray = PackedByteArray()
+) -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	map.fill(BLANK_TILE)
+	for row: int in FIELD_ROWS:
+		for column: int in COLUMNS:
+			_put(map, Vector2i(column, FIELD_AT.y + row), FIELD_TILE)
+	for row: int in LIST_ROWS:
+		for column: int in LIST_COLUMNS:
+			_put(map, LIST_AT + Vector2i(column, row), BLANK_TILE)
+	for column: int in COLUMNS:
+		_put(map, Vector2i(column, 0), HEADER_FIRST_TILE + column)
+	for row: int in PACK_ROWS:
+		for column: int in PACK_COLUMNS:
+			_put(
+				map, PACK_AT + Vector2i(column, row),
+				PACK_FIRST_TILE + row * PACK_COLUMNS + column
+			)
+	for cell: int in pocket_name.size():
+		@warning_ignore("integer_division")
+		_put(
+			map,
+			NAME_AT + Vector2i(cell % RomLayout.PACK_NAME_COLUMNS, cell / RomLayout.PACK_NAME_COLUMNS),
+			pocket_name[cell]
+		)
+	_draw_textbox(map, description)
+	_draw_rows(map, rows, cursor)
+	return map
+
+
+## `ScrollingMenu_UpdateDisplay` and `TMHM_DisplayPocketItems`, which write the
+## same rows out of different fields.
+func _draw_rows(map: PackedInt32Array, rows: Array, cursor: int) -> void:
+	for index: int in mini(rows.size(), LIST_HEIGHT + 1):
+		var entry: Dictionary = rows[index]
+		var top: int = FIRST_ROW + index * ROW_SPACING
+		match StringName(entry.get("kind", ROW_ITEM)):
+			ROW_CANCEL:
+				_string(map, Vector2i(NAME_COLUMN, top), CANCEL)
+			ROW_TM:
+				_string(map, Vector2i(TMHM_NUMBER_COLUMN, top), _tm_label(entry))
+				_string(map, Vector2i(NAME_COLUMN, top), String(entry.get("name", "")))
+				_quantity(map, index, entry)
+			_:
+				_string(map, Vector2i(NAME_COLUMN, top), String(entry.get("name", "")))
+				_quantity(map, index, entry)
+	if cursor >= 0 and cursor < mini(rows.size(), LIST_HEIGHT + 1):
+		_put(
+			map, Vector2i(CURSOR_COLUMN, FIRST_ROW + cursor * ROW_SPACING), CURSOR_CODE
+		)
+
+
+## `PlaceMenuItemQuantity`, which prints nothing for a row `_CheckTossableItem`
+## refuses: a key item and an HM have no count on the cartridge either.
+func _quantity(map: PackedInt32Array, index: int, entry: Dictionary) -> void:
+	if not bool(entry.get("show_quantity", false)):
+		return
+	var at: Vector2i = QUANTITY_AT + Vector2i(0, index * ROW_SPACING)
+	_put(map, at, TIMES_CODE)
+	_string(
+		map, at + Vector2i(1, 0),
+		String.num_int64(maxi(int(entry.get("quantity", 0)), 0)).lpad(QUANTITY_DIGITS, " ")
+	)
+
+
+## The TM/HM pocket's own number column: a TM is two digits with its leading
+## zero, an HM an "H" and its number left aligned.
+func _tm_label(entry: Dictionary) -> String:
+	var number: int = maxi(int(entry.get("number", 0)), 0)
+	if bool(entry.get("hm", false)):
+		return "H%d" % number
+	return String.num_int64(number).lpad(2, "0")
+
+
+## `Textbox`: the chosen frame around a cleared interior, with the description
+## printed a tile in and on every second row.
+func _draw_textbox(map: PackedInt32Array, text: String) -> void:
+	var first: int = RomLayout.FRAME_FIRST_CODE
+	var right: int = TEXTBOX_AT.x + TEXTBOX_COLUMNS - 1
+	var bottom: int = TEXTBOX_AT.y + TEXTBOX_ROWS - 1
+	for column: int in range(TEXTBOX_AT.x + 1, right):
+		_put(map, Vector2i(column, TEXTBOX_AT.y), first + RomLayout.FRAME_HORIZONTAL)
+		_put(map, Vector2i(column, bottom), first + RomLayout.FRAME_HORIZONTAL)
+	for row: int in range(TEXTBOX_AT.y + 1, bottom):
+		_put(map, Vector2i(TEXTBOX_AT.x, row), first + RomLayout.FRAME_VERTICAL)
+		_put(map, Vector2i(right, row), first + RomLayout.FRAME_VERTICAL)
+		for column: int in range(TEXTBOX_AT.x + 1, right):
+			_put(map, Vector2i(column, row), BLANK_TILE)
+	_put(map, TEXTBOX_AT, first + RomLayout.FRAME_TOP_LEFT)
+	_put(map, Vector2i(right, TEXTBOX_AT.y), first + RomLayout.FRAME_TOP_RIGHT)
+	_put(map, Vector2i(TEXTBOX_AT.x, bottom), first + RomLayout.FRAME_BOTTOM_LEFT)
+	_put(map, Vector2i(right, bottom), first + RomLayout.FRAME_BOTTOM_RIGHT)
+	var line: int = 0
+	for row_text: String in text.split("\n", false):
+		_string(map, TEXT_AT + Vector2i(0, line * TEXT_SPACING), row_text)
+		line += 1
+
+
+## `_CGB_PackPals`' attrmap, as one palette index per cell.
+static func attributes() -> PackedInt32Array:
+	var out := PackedInt32Array()
+	out.resize(COLUMNS * ROWS)
+	for box: Array in ATTRIBUTES:
+		for row: int in int(box[3]):
+			for column: int in int(box[2]):
+				var x: int = int(box[0]) + column
+				var y: int = int(box[1]) + row
+				if x < COLUMNS and y < ROWS:
+					out[y * COLUMNS + x] = int(box[4])
+	return out
+
+
+## The whole screen as pixels. [param female] is Kris's pack and her own
+## palettes, which only Crystal carries.
+func image(
+	data: GameData, map: PackedInt32Array, pocket: int, female: bool = false
+) -> Image:
+	var indices: PackedByteArray = compose(map, pocket, female)
+	var slots: PackedInt32Array = attributes()
+	var palettes: Array = []
+	for slot: int in RomLayout.PACK_PALETTES:
+		var colors: PackedColorArray = data.pack_palette(slot, female)
+		palettes.append(colors if not colors.is_empty() else data.pack_palette(slot))
+	var out := Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var palette: PackedColorArray = palettes[
+				clampi(slots[row * COLUMNS + column], 0, palettes.size() - 1)
+			]
+			if palette.is_empty():
+				continue
+			for y: int in TILE:
+				for x: int in TILE:
+					var at_x: int = column * TILE + x
+					var at_y: int = row * TILE + y
+					out.set_pixel(at_x, at_y, palette[
+						clampi(indices[at_y * Gen2Screen.WIDTH + at_x], 0, palette.size() - 1)
+					])
+	return out
+
+
+## Resolves every tile number to pixels: the menu sheet, the pocket's own
+## fifteen tiles where `DrawPackGFX` put them, the text box out of the chosen
+## frame, and everything else out of the font.
+func compose(
+	map: PackedInt32Array, pocket: int, female: bool = false
+) -> PackedByteArray:
+	var width: int = COLUMNS * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * ROWS * TILE)
+	var strip: PackedByteArray = _pockets_female if female \
+		and not _pockets_female.is_empty() else _pockets
+	@warning_ignore("integer_division")
+	var strip_tiles: int = strip.size() / TILE
+	var picture: int = RomLayout.PACK_POCKET_PICTURES[
+		clampi(pocket, 0, RomLayout.PACK_POCKETS - 1)
+	] * RomLayout.PACK_POCKET_TILES
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var tile: int = map[row * COLUMNS + column]
+			var at := Vector2i(column * TILE, row * TILE)
+			if tile >= PACK_FIRST_TILE \
+				and tile < PACK_FIRST_TILE + RomLayout.PACK_POCKET_TILES:
+				Gen2Font.blit_slot(
+					strip, strip_tiles, picture + tile - PACK_FIRST_TILE,
+					indices, width, at.x, at.y
+				)
+			elif _tiles.has(tile):
+				_blit(indices, width, _tiles[tile], at)
+			elif tile >= RomLayout.FRAME_FIRST_CODE \
+				and tile < RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TILES:
+				font.draw_frame_code(frame_style, tile, indices, width, at.x, at.y)
+			elif tile != BLANK_TILE:
+				font.draw_code(tile, indices, width, at.x, at.y, Gen2Text.FONT_MAIN)
+	return indices
+
+
+func _string(map: PackedInt32Array, at: Vector2i, text: String) -> void:
+	var cell: Vector2i = at
+	for code: int in Gen2Text.encode(text):
+		_put(map, cell, code)
+		cell.x += 1
+
+
+func _put(map: PackedInt32Array, at: Vector2i, tile: int) -> void:
+	if at.x < 0 or at.y < 0 or at.x >= COLUMNS or at.y >= ROWS:
+		return
+	map[at.y * COLUMNS + at.x] = tile
+
+
+func _blit(
+	indices: PackedByteArray, width: int, cell: PackedByteArray, at: Vector2i
+) -> void:
+	for y: int in TILE:
+		for x: int in TILE:
+			indices[(at.y + y) * width + at.x + x] = cell[y * TILE + x]

--- a/game/render/pack_page.gd.uid
+++ b/game/render/pack_page.gd.uid
@@ -1,0 +1,1 @@
+uid://b0rrggvaoxl1l

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -58,6 +58,9 @@ const ACCENT: Color = Color("#f3c969")
 const SUCCESS: Color = Color("#7bd89a")
 const ERROR: Color = Color("#ef8a8a")
 
+## How many window pixels a hardware pixel is drawn as inside the panel.
+const PACK_VIEW_SCALE: int = 2
+
 var _world: Gen2WorldAPI = null
 var _data: GameData = null
 var _save_action: Callable = Callable()
@@ -73,6 +76,12 @@ var _item_actions: Array = []
 var _item_cursor: int = 0
 var _target_cursor: int = 0
 var _pack_result: String = ""
+## `wItemsPocketScrollPosition` and its three siblings: which entry the visible
+## five start at. Held per pocket, the way the source holds one variable each.
+var _pack_scroll: Array[int] = [0, 0, 0, 0]
+var _pack_cursors: Array[int] = [0, 0, 0, 0]
+var _pack_page: Gen2PackPage = null
+var _pack_view: TextureRect = null
 var _pack_result_ok: bool = false
 ## AskTeachTMHM's resolved prompt, held while its yes/no is on screen, and
 ## whether the party list that follows is ChooseMonToLearnTMHM's rather than
@@ -332,7 +341,10 @@ func _confirm() -> void:
 		Mode.LIST:
 			_confirm_list()
 		Mode.PACK:
-			if _current_pocket_items().is_empty():
+			## `ScrollingMenuJoyAction`'s `.a_button` answers `-1` on the CANCEL
+			## row and falls into `.b_button`, so choosing it leaves the pack.
+			if _pack_cursor_on_cancel():
+				_cancel()
 				return
 			## `DepositSellPack` acts on the item it is given rather than
 			## opening a submenu over it, which is the pack `.GiveItem` opens.
@@ -618,8 +630,12 @@ func _open_pack_mode(reset: bool = true) -> void:
 	if reset:
 		_pack_pocket_index = 0
 		_pack_cursor = 0
+		_pack_cursors.fill(0)
+		_pack_scroll.fill(0)
 	_pack_pocket_index = clampi(_pack_pocket_index, 0, maxi(_pack_pockets.size() - 1, 0))
-	_pack_cursor = clampi(_pack_cursor, 0, maxi(_current_pocket_items().size() - 1, 0))
+	## The CANCEL row is always there, so an emptied pocket puts the cursor on it
+	## rather than on an item that is gone.
+	_pack_cursor = clampi(_pack_cursor, 0, _current_pocket_items().size())
 	_status.text = ""
 	_footer.text = "Left and right: pocket    Up and down: move    A: %s    B: back" % (
 		"give" if _give_target >= 0 else "choose"
@@ -637,33 +653,124 @@ func _current_pocket_items() -> Array:
 	return _current_pocket().get("items", [])
 
 
+## `.ItemsPocketMenu` and its three siblings, each of which stores its own
+## `w*PocketCursor` and `w*PocketScrollPosition` on the way out and loads them
+## again on the way in, so a pocket is where the player left it.
 func _cycle_pocket(delta: int) -> void:
 	if _pack_pockets.is_empty():
 		return
+	_pack_cursors[_pack_pocket_index] = _pack_cursor
 	_pack_pocket_index = wrapi(_pack_pocket_index + signi(delta), 0, _pack_pockets.size())
-	_pack_cursor = 0
+	_pack_cursor = clampi(
+		_pack_cursors[_pack_pocket_index], 0, _current_pocket_items().size()
+	)
 	_render_pack()
 
 
+## `ScrollingMenuJoyAction`'s `.d_up` and `.d_down`, which move the cursor
+## inside the visible five and scroll only at their edges. The CANCEL row is one
+## past the last item, which is what makes the walk wrap over `size + 1`.
 func _move_pack_cursor(delta: int) -> void:
-	var items: Array = _current_pocket_items()
-	if items.is_empty():
-		return
-	_pack_cursor = wrapi(_pack_cursor + signi(delta), 0, items.size())
+	var rows: int = _current_pocket_items().size() + 1
+	_pack_cursor = wrapi(_pack_cursor + signi(delta), 0, rows)
+	_pack_scroll[_pack_pocket_index] = clampi(
+		clampi(
+			_pack_scroll[_pack_pocket_index],
+			_pack_cursor - (Gen2PackPage.LIST_HEIGHT - 1), _pack_cursor
+		),
+		0, maxi(rows - Gen2PackPage.LIST_HEIGHT, 0)
+	)
 	_render_pack()
+
+
+## Whether the cursor is on `ScrollingMenu_UpdateDisplay`'s CANCEL row, which is
+## what a pocket with nothing in it is entirely made of.
+func _pack_cursor_on_cancel() -> bool:
+	return _pack_cursor >= _current_pocket_items().size()
 
 
 func _render_pack() -> void:
 	var pocket: Dictionary = _current_pocket()
 	_title.text = "GIVE" if _give_target >= 0 else "PACK"
 	_summary.text = String(pocket.get("name", ""))
-	var items: Array = pocket.get("items", [])
-	if items.is_empty():
-		_status.text = "No items in this pocket."
-		_status.add_theme_color_override("font_color", MUTED)
-	_render_options(items, _pack_cursor, func(entry: Dictionary) -> String:
-		return "%s    x%d" % [entry.get("name", "UNKNOWN"), int(entry.get("quantity", 0))]
+	_status.text = ""
+	_render_options([], -1, func(_entry: Variant) -> String: return "")
+	if _pack_view != null:
+		_pack_view.visible = true
+		_pack_view.texture = ImageTexture.create_from_image(_pack_image())
+
+
+## The five rows `ScrollingMenu_UpdateDisplay` writes, out of the pocket's own
+## items and the CANCEL row after them. The TM/HM pocket is
+## `TMHM_DisplayPocketItems`, which prints the TM number and the move it teaches
+## rather than the item's name.
+func _pack_rows() -> Array:
+	var items: Array = _current_pocket_items()
+	var tmhm: bool = int(_current_pocket().get("pocket", 0)) == Gen2WorldPack.TYPE_TM_HM
+	var scroll: int = _pack_scroll[_pack_pocket_index]
+	var out: Array = []
+	for offset: int in Gen2PackPage.LIST_HEIGHT:
+		var index: int = scroll + offset
+		if index > items.size():
+			break
+		if index == items.size():
+			out.append({"kind": Gen2PackPage.ROW_CANCEL})
+			break
+		var entry: Dictionary = items[index]
+		var item: int = int(entry.get("item", 0))
+		## `PlaceMenuItemQuantity` asks `_CheckTossableItem`, so a key item and
+		## an HM carry no count on this screen.
+		var row: Dictionary = {
+			"kind": Gen2PackPage.ROW_ITEM,
+			"name": String(entry.get("name", "")),
+			"quantity": int(entry.get("quantity", 0)),
+			"show_quantity": Gen2WorldPack.can_toss(_data, item),
+		}
+		if tmhm:
+			var number: int = RomLayout.tmhm_number_for_item(
+				item, _data.tmhm_moves().size() if _data != null else 0
+			)
+			var hm: bool = Gen2WorldTMHM.is_hm(item)
+			row["kind"] = Gen2PackPage.ROW_TM
+			row["hm"] = hm
+			row["number"] = number - RomLayout.TMHM_TM_COUNT if hm else number
+			row["name"] = _data.move(
+				Gen2WorldTMHM.move_for_item(_data, item)
+			).get("name", "") if _data != null else ""
+		out.append(row)
+	return out
+
+
+## The pack as the cartridge draws it. `UpdateItemDescription` prints the item's
+## own description, and the TM/HM pocket the move's; a cursor on CANCEL leaves
+## the box empty, which is what `TMHM_CheckHoveringOverCancel` does.
+func _pack_image() -> Image:
+	if _pack_page == null:
+		_pack_page = Gen2PackPage.from_data(_data)
+	var pocket: int = _pack_pocket_index
+	var rows: Array = _pack_rows()
+	var cursor: int = _pack_cursor - _pack_scroll[_pack_pocket_index]
+	var map: PackedInt32Array = _pack_page.pocket_map(
+		pocket, rows, cursor, _pack_description(),
+		_data.pack_pocket_name(pocket) if _data != null else PackedByteArray()
 	)
+	return _pack_page.image(_data, map, pocket, _player_is_female())
+
+
+func _pack_description() -> String:
+	if _pack_cursor_on_cancel() or _data == null:
+		return ""
+	var item: int = int(_selected_item().get("item", 0))
+	if Gen2WorldTMHM.is_tm_hm(item):
+		return String(_data.move(
+			Gen2WorldTMHM.move_for_item(_data, item)
+		).get("description", ""))
+	return String(_data.item(item).get("description", ""))
+
+
+## `wPlayerGender`, which picks Kris's pack and her own palettes.
+func _player_is_female() -> bool:
+	return _world != null and _world.player_female()
 
 
 func _selected_item() -> Dictionary:
@@ -854,7 +961,7 @@ func _confirm_use() -> void:
 			## `_CoinCaseCountText` and nothing else: the count is shown where the
 			## pack already prints, and the pack stays open behind it.
 			if number == Gen2WorldPack.ITEM_COIN_CASE:
-				_show_pack_result("Coins:\n%4d" % _coins(), true)
+				_show_pack_result(_coin_case_text(), true)
 				return
 			_use_selected_item(-1)
 		Gen2WorldPack.ITEMMENU_CLOSE:
@@ -1311,6 +1418,20 @@ func _press_toss_quantity(button: int) -> bool:
 	return true
 
 
+## `_CoinCaseCountText`, whose `text_decimal wCoins, 2, 4` comes back as a
+## number marker the count fills. Gold and Silver carry no usable text: theirs
+## ends with `done` rather than `text_end`, so `DoTextUntilTerminator` runs off
+## `TextCommands` and the cartridge executes whatever follows, which is
+## `docs/bugs_and_glitches.md`'s own Coin Case entry. Those two keep the wording.
+func _coin_case_text() -> String:
+	var text: String = _data.menu_text("coin_case") if _data != null else ""
+	if text.is_empty():
+		return "Coins:\n%4d" % _coins()
+	return Gen2TextStream.fill_marker(
+		text, Gen2TextStream.NUMBER_MARKER, "%4d" % _coins()
+	)
+
+
 ## `wCoins`, which only the Coin Case reads here.
 func _coins() -> int:
 	return _world.state.coins() if _world != null and _world.state != null else 0
@@ -1421,6 +1542,16 @@ func _build_ui() -> void:
 	_options.add_theme_constant_override("separation", 4)
 	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	content.add_child(_options)
+	## The pack listing is the cartridge's own screen inside this panel, the way
+	## the Pokegear's card list holds the cartridge's four cards.
+	_pack_view = TextureRect.new()
+	_pack_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_pack_view.custom_minimum_size = Vector2(
+		Gen2Screen.WIDTH * PACK_VIEW_SCALE, Gen2Screen.HEIGHT * PACK_VIEW_SCALE
+	)
+	_pack_view.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	_pack_view.visible = false
+	content.add_child(_pack_view)
 	_status = Label.new()
 	_status.add_theme_color_override("font_color", MUTED)
 	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -1431,6 +1562,8 @@ func _build_ui() -> void:
 
 
 func _render_options(values: Array, cursor: int, label_for: Callable) -> void:
+	if _pack_view != null:
+		_pack_view.visible = false
 	if _options == null:
 		return
 	for child: Node in _options.get_children():

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2209,10 +2209,9 @@ func _on_start_menu_closed() -> void:
 
 
 ## `PACKSTATE_QUITRUNSCRIPT`: the pack closes and the script the effect queued
-## runs in the overworld. The texts are the source's own words, host-authored the
-## way the field moves' are, because none of them is a text this project imports.
-## Each drops its `<PLAYER>` for the reason `FOUND_ITEM_TEXT` does: nothing
-## writes `wPlayerName` yet.
+## runs in the overworld. The words are the cartridge's own, read out of the
+## cache by [method _field_item_text]; the host's wording behind it is only what
+## a cache imported before those texts were carries.
 func _on_field_item_used(request: Dictionary) -> void:
 	var host: Gen2StartMenuScreen = _start_menu_host
 	_start_menu_host = null
@@ -2240,7 +2239,7 @@ func _on_field_item_used(request: Dictionary) -> void:
 			if _renderer != null:
 				_renderer.refresh()
 		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
-			_show_field_move_text("Used an\nESCAPE ROPE.")
+			_show_field_move_text(_field_item_text("escape_rope", "Used an\nESCAPE ROPE."))
 			_refresh_after_escape()
 		Gen2WorldPack.FIELD_EFFECT_ROD:
 			var rods: Array[StringName] = _world.available_fishing_rods()
@@ -2248,12 +2247,18 @@ func _on_field_item_used(request: Dictionary) -> void:
 			start_fishing()
 		Gen2WorldPack.FIELD_EFFECT_ITEMFINDER:
 			_show_field_move_text(
-				"Yes! ITEMFINDER\nindicates there's\nan item nearby." \
-				if bool(request.get("found", false)) \
-				else "Nope! ITEMFINDER\nisn't responding."
+				_field_item_text(
+					"itemfinder_nearby",
+					"Yes! ITEMFINDER\nindicates there's\nan item nearby."
+				) if bool(request.get("found", false)) \
+				else _field_item_text(
+					"itemfinder_nope", "Nope! ITEMFINDER\nisn't responding."
+				)
 			)
 		Gen2WorldPack.FIELD_EFFECT_SACRED_ASH:
-			_show_field_move_text("#MON were all\nhealed!")
+			_show_field_move_text(
+				_field_item_text("sacred_ash", "#MON were all\nhealed!")
+			)
 		## `farsjump CardKeySlotScript` and `farsjump BasementDoorScript`, each
 		## `QueueScript`d by its own routine, so both run as any map script does.
 		Gen2WorldPack.FIELD_EFFECT_CARD_KEY, Gen2WorldPack.FIELD_EFFECT_BASEMENT_KEY:
@@ -2264,8 +2269,22 @@ func _on_field_item_used(request: Dictionary) -> void:
 			if StringName(request.get("kind", &"")) == &"squirtbottle_watered":
 				_show_script_results(_world.queue_item_script(request))
 			else:
-				_show_field_move_text("Sprinkled water.\nBut nothing\nhappened…")
+				_show_field_move_text(_field_item_text(
+					"squirtbottle", "Sprinkled water.\nBut nothing\nhappened…"
+				))
 	_refresh_labels()
+
+
+## One of `data/text/common_2.asm`'s field-item lines, with `<PLAYER>` filled
+## from the world the way every other text's marker is. [param fallback] is what
+## a cache imported before these texts were carries instead.
+func _field_item_text(key: String, fallback: String) -> String:
+	var text: String = _data.menu_text(key) if _data != null else ""
+	if text.is_empty():
+		return fallback
+	return text.replace(
+		Gen2WorldPC.PLAYER_MARKER, _world.player_name() if _world != null else ""
+	)
 
 
 ## The save the embedded party view shows: the injected or selected one, or a

--- a/tests/unit/test_pack_page.gd
+++ b/tests/unit/test_pack_page.gd
@@ -1,0 +1,236 @@
+extends GutTest
+
+## `Pack_InitGFX`'s screen and the two listings that share it
+## (`ScrollingMenu_UpdateDisplay`, `TMHM_DisplayPocketItems`), checked by where
+## each write lands rather than by eye.
+##
+## The fixture fills the menu sheet with one index and gives each of the four
+## pocket pictures a different one, so which pocket is on screen can be read off
+## the pixels. Everything else on the page is [Gen2Font]'s own drawing.
+
+const DIRECTORY_ID: StringName = &"packpagetest"
+const SHA: String = "0123456789abcdef"
+## The index the menu sheet is filled with, distinct from every pocket's.
+const SHEET_INDEX: int = 1
+## The tilemap piece each pocket's name is, one solid tile number per pocket so
+## the four are told apart without any art.
+const NAME_TILES: Array[int] = [0x10, 0x11, 0x12, 0x13]
+
+var _directory: String = ""
+
+
+func before_each() -> void:
+	_directory = RomCache.directory_for(DIRECTORY_ID, SHA)
+	RomCache.clear(_directory)
+	RomCache.prepare(_directory)
+	_write_cache()
+
+
+func after_each() -> void:
+	RomCache.clear(_directory)
+
+
+func test_attributes_are_the_five_filled_boxes() -> void:
+	var attributes: PackedInt32Array = Gen2PackPage.attributes()
+	assert_eq(attributes[0], 1, "the header's left half")
+	assert_eq(attributes[10], 2, "the header's right half")
+	assert_eq(attributes[2 * Gen2PackPage.COLUMNS + 7], 3, "the cursor column")
+	assert_eq(attributes[10 * Gen2PackPage.COLUMNS + 7], 3, "the cursor column's foot")
+	assert_eq(attributes[7 * Gen2PackPage.COLUMNS], 4, "the pocket name")
+	assert_eq(attributes[3 * Gen2PackPage.COLUMNS], 5, "the pack picture")
+	assert_eq(attributes[17 * Gen2PackPage.COLUMNS + 19], 0, "the text box")
+
+
+func test_the_screen_is_the_source_s_own_writes() -> void:
+	var map: PackedInt32Array = _page().pocket_map(0, [], -1, "", _name_piece(0))
+	for column: int in Gen2PackPage.COLUMNS:
+		assert_eq(
+			map[column], Gen2PackPage.HEADER_FIRST_TILE + column,
+			"the header row ascends from $28"
+		)
+	assert_eq(map[Gen2PackPage.COLUMNS], Gen2PackPage.FIELD_TILE, "the field")
+	assert_eq(
+		map[Gen2PackPage.COLUMNS + 5], Gen2PackPage.BLANK_TILE, "the listing is cleared"
+	)
+	assert_eq(
+		map[3 * Gen2PackPage.COLUMNS], Gen2PackPage.PACK_FIRST_TILE, "the pack picture"
+	)
+	assert_eq(
+		map[3 * Gen2PackPage.COLUMNS + 4], Gen2PackPage.PACK_FIRST_TILE + 4,
+		"the picture's own run"
+	)
+	assert_eq(map[7 * Gen2PackPage.COLUMNS], NAME_TILES[0], "the pocket name")
+	assert_eq(
+		map[12 * Gen2PackPage.COLUMNS], RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TOP_LEFT,
+		"the text box"
+	)
+
+
+func test_a_row_is_a_name_a_count_and_the_cursor() -> void:
+	var rows: Array = [
+		{"kind": Gen2PackPage.ROW_ITEM, "name": "AB", "quantity": 7, "show_quantity": true},
+		{"kind": Gen2PackPage.ROW_CANCEL},
+	]
+	var map: PackedInt32Array = _page().pocket_map(0, rows, 1, "", _name_piece(0))
+	var name_codes: PackedByteArray = Gen2Text.encode("AB")
+	assert_eq(
+		map[2 * Gen2PackPage.COLUMNS + Gen2PackPage.NAME_COLUMN], int(name_codes[0]),
+		"the name starts in column 8 of row 2"
+	)
+	assert_eq(
+		map[3 * Gen2PackPage.COLUMNS + 17], Gen2PackPage.TIMES_CODE,
+		"the count sits a row under the name"
+	)
+	assert_eq(
+		map[3 * Gen2PackPage.COLUMNS + 19], int(Gen2Text.encode("7")[0]),
+		"and is two digits wide"
+	)
+	assert_eq(
+		map[4 * Gen2PackPage.COLUMNS + Gen2PackPage.NAME_COLUMN],
+		int(Gen2Text.encode("CANCEL")[0]), "CANCEL follows the last item"
+	)
+	assert_eq(
+		map[4 * Gen2PackPage.COLUMNS + Gen2PackPage.CURSOR_COLUMN], Gen2PackPage.CURSOR_CODE,
+		"the cursor is one column left of the names"
+	)
+
+
+## `PlaceMenuItemQuantity` asks `_CheckTossableItem` first, so a key item is a
+## name and nothing else.
+func test_an_untossable_row_has_no_count() -> void:
+	var rows: Array = [
+		{"kind": Gen2PackPage.ROW_ITEM, "name": "AB", "quantity": 1, "show_quantity": false},
+	]
+	var map: PackedInt32Array = _page().pocket_map(2, rows, 0, "", _name_piece(2))
+	assert_eq(
+		map[3 * Gen2PackPage.COLUMNS + 17], Gen2PackPage.BLANK_TILE, "no × is written"
+	)
+
+
+## `TMHM_DisplayPocketItems` prints its number in the column the other pockets
+## leave empty: two digits with the leading zero for a TM, "H" and the number
+## for an HM.
+func test_the_tmhm_pocket_prints_its_number() -> void:
+	var rows: Array = [
+		{"kind": Gen2PackPage.ROW_TM, "name": "CUT", "number": 3, "hm": false,
+			"quantity": 1, "show_quantity": true},
+		{"kind": Gen2PackPage.ROW_TM, "name": "FLY", "number": 2, "hm": true,
+			"quantity": 1, "show_quantity": false},
+	]
+	var map: PackedInt32Array = _page().pocket_map(3, rows, -1, "", _name_piece(3))
+	var at: int = 2 * Gen2PackPage.COLUMNS + Gen2PackPage.TMHM_NUMBER_COLUMN
+	assert_eq(map[at], int(Gen2Text.encode("0")[0]), "a TM keeps its leading zero")
+	assert_eq(map[at + 1], int(Gen2Text.encode("3")[0]))
+	var hm_at: int = 4 * Gen2PackPage.COLUMNS + Gen2PackPage.TMHM_NUMBER_COLUMN
+	assert_eq(map[hm_at], int(Gen2Text.encode("H")[0]), "an HM is an H and its number")
+	assert_eq(map[hm_at + 1], int(Gen2Text.encode("2")[0]))
+
+
+## `PackGFXPointers` is not in pocket order: the sheet holds key items, items,
+## TM/HM and balls, and each pocket indexes its own picture out of it.
+func test_each_pocket_draws_its_own_picture() -> void:
+	var page: Gen2PackPage = _page()
+	var seen: Dictionary = {}
+	for pocket: int in RomLayout.PACK_POCKETS:
+		var map: PackedInt32Array = page.pocket_map(pocket, [], -1, "", _name_piece(pocket))
+		var indices: PackedByteArray = page.compose(map, pocket)
+		var pixel: int = indices[3 * Gen2PackPage.TILE * Gen2Screen.WIDTH]
+		assert_eq(
+			pixel, RomLayout.PACK_POCKET_PICTURES[pocket],
+			"pocket %d draws its own piece" % pocket
+		)
+		seen[pixel] = pocket
+	assert_eq(seen.size(), RomLayout.PACK_POCKETS, "four distinct pictures")
+
+
+## `_CGB_PackPals` picks Kris's six palettes over Chris's, and her pack over his.
+func test_the_female_pack_is_its_own_sheet_and_palettes() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var page: Gen2PackPage = Gen2PackPage.from_data(data)
+	var map: PackedInt32Array = page.pocket_map(0, [], -1, "", _name_piece(0))
+	assert_ne(
+		page.compose(map, 0, true)[3 * Gen2PackPage.TILE * Gen2Screen.WIDTH],
+		page.compose(map, 0, false)[3 * Gen2PackPage.TILE * Gen2Screen.WIDTH],
+		"the two sheets are different pictures"
+	)
+	assert_ne(
+		data.pack_palette(0, true)[1], data.pack_palette(0, false)[1],
+		"and are drawn through different palettes"
+	)
+
+
+func _page() -> Gen2PackPage:
+	return Gen2PackPage.from_data(GameData.open_directory(_directory))
+
+
+func _name_piece(pocket: int) -> PackedByteArray:
+	return GameData.open_directory(_directory).pack_pocket_name(pocket)
+
+
+func _write_cache() -> void:
+	var sheets: Dictionary = {}
+	for name: String in ["font", "frames"]:
+		var tiles: int = RomLayout.FONT_TILES if name == "font" \
+			else RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES
+		var indices := PackedByteArray()
+		indices.resize(tiles * Gen2Tiles.TILE_PIXELS)
+		indices.fill(3)
+		RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
+		sheets[name] = _sheet_entry(tiles, RomLayout.FONT_FIRST_CODE \
+			if name == "font" else RomLayout.FRAME_FIRST_CODE)
+
+	var menu := PackedByteArray()
+	menu.resize(RomLayout.PACK_MENU_TILES * Gen2Tiles.TILE_PIXELS)
+	menu.fill(SHEET_INDEX)
+	RomCache.write_indices(RomCache.tile_path(_directory, "pack_menu"), menu)
+	sheets["pack_menu"] = _sheet_entry(RomLayout.PACK_MENU_TILES, 0)
+
+	# Piece p is filled with index p, and the female sheet with the piece after
+	# it, so which sheet and which piece reached the screen are both readable.
+	for name: String in ["pack_pockets", "pack_pockets_female"]:
+		var strip := PackedByteArray()
+		var width: int = RomLayout.PACK_TILES * Gen2Tiles.TILE_WIDTH
+		strip.resize(width * Gen2Tiles.TILE_HEIGHT)
+		var shift: int = 1 if name.ends_with("female") else 0
+		for row: int in Gen2Tiles.TILE_HEIGHT:
+			for column: int in width:
+				@warning_ignore("integer_division")
+				var piece: int = column / (RomLayout.PACK_POCKET_TILES * Gen2Tiles.TILE_WIDTH)
+				strip[row * width + column] = (piece + shift) % RomLayout.PACK_POCKETS
+		RomCache.write_indices(RomCache.tile_path(_directory, name), strip)
+		sheets[name] = _sheet_entry(RomLayout.PACK_TILES, 0)
+
+	var names: Array = []
+	for pocket: int in RomLayout.PACK_POCKETS:
+		for _cell: int in RomLayout.PACK_NAME_COLUMNS * RomLayout.PACK_NAME_ROWS:
+			names.append(NAME_TILES[pocket])
+	var palettes: Array = []
+	var female_palettes: Array = []
+	for index: int in RomLayout.PACK_PALETTES * RomLayout.PACK_PALETTE_COLORS:
+		palettes.append(0x7FFF if index % RomLayout.PACK_PALETTE_COLORS == 0 else 0x001F)
+		female_palettes.append(
+			0x7FFF if index % RomLayout.PACK_PALETTE_COLORS == 0 else 0x7C00
+		)
+
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": String(DIRECTORY_ID),
+		"sha1": SHA,
+		"tiles": sheets,
+		"pack": {
+			"pocket_names": names,
+			"palettes": palettes,
+			"female_palettes": female_palettes,
+		},
+		"complete": true,
+	})
+
+
+func _sheet_entry(tiles: int, first_code: int) -> Dictionary:
+	return {
+		"width": tiles * Gen2Tiles.TILE_WIDTH,
+		"height": Gen2Tiles.TILE_HEIGHT,
+		"tiles": tiles,
+		"first_code": first_code,
+		"bits": 1,
+	}

--- a/tests/unit/test_pack_page.gd.uid
+++ b/tests/unit/test_pack_page.gd.uid
@@ -1,0 +1,1 @@
+uid://dn5e6rj5jekyf

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -69,6 +69,10 @@ const REGISTERABLE_KEY_ITEMS: Dictionary = {
 ## the item list never reaches.
 const ITEM_ROWS: int = 255
 
+## What fits between the text box's own borders: `Textbox`'s interior is 18
+## columns and `PrintItemDescription` is handed the cell one in from the left.
+const DESCRIPTION_COLUMNS: int = 18
+
 
 func run(r: RefCounted) -> void:
 	_r = r
@@ -81,6 +85,8 @@ func run(r: RefCounted) -> void:
 		_verify_submenus(game_id, data)
 		_verify_field_effects(game_id, data)
 		_verify_key_item_effects(game_id, data)
+		_verify_screen(game_id, data)
+		_verify_descriptions(game_id, data)
 
 
 ## `CheckSelectableItem` over the real rows. The eight named key items are the
@@ -333,3 +339,77 @@ func _verify_squirtbottle(game_id: StringName, data: GameData) -> void:
 			and StringName(nothing.get("kind", &"")) == &"squirtbottle_nothing",
 		"%s: the squirtbottle away from the tree answered %s." % [game_id, nothing]
 	)
+
+
+## The screen itself, drawn once per pocket out of the real cache: every cell of
+## every picture resolves to a tile the sheets carry, and the four pocket names
+## are four different pieces rather than one piece read four times.
+func _verify_screen(game_id: StringName, data: GameData) -> void:
+	var page: Gen2PackPage = Gen2PackPage.from_data(data)
+	if page == null or not page.ready():
+		_r.fail("%s: the cache carries no pack graphics." % game_id)
+		return
+	var names: Dictionary = {}
+	for pocket: int in RomLayout.PACK_POCKETS:
+		var name_cells: PackedByteArray = data.pack_pocket_name(pocket)
+		_r.check(
+			name_cells.size() == RomLayout.PACK_NAME_COLUMNS * RomLayout.PACK_NAME_ROWS,
+			"%s: pocket %d has no name piece." % [game_id, pocket]
+		)
+		names[name_cells] = pocket
+		var map: PackedInt32Array = page.pocket_map(
+			pocket,
+			[{"kind": Gen2PackPage.ROW_ITEM, "name": "POTION", "quantity": 9,
+				"show_quantity": true}, {"kind": Gen2PackPage.ROW_CANCEL}],
+			0, "Restores HP.", name_cells
+		)
+		var image: Image = page.image(data, map, pocket)
+		_r.check(
+			image != null and image.get_width() == Gen2Screen.WIDTH
+				and image.get_height() == Gen2Screen.HEIGHT,
+			"%s: pocket %d did not compose a screen." % [game_id, pocket]
+		)
+	_r.check(
+		names.size() == RomLayout.PACK_POCKETS,
+		"%s: the four pocket names are %d distinct pieces." % [game_id, names.size()]
+	)
+	## Kris's pack is Crystal's alone, so a Gold or Silver cache carrying one
+	## would mean the female offset was read off the wrong profile.
+	var female: bool = not data.tile_indices("pack_pockets_female").is_empty()
+	_r.check(
+		female == (game_id == &"crystal"),
+		"%s: a female pack is %spresent." % [game_id, "" if female else "not "]
+	)
+	print("%s: four pockets drawn, %d palettes, female pack %s." % [
+		game_id, RomLayout.PACK_PALETTES, "yes" if female else "no",
+	])
+
+
+## `PrintItemDescription` and `PrintMoveDescription`: every row the pack can
+## stand on has a line to print, and it fits the two rows the box holds.
+func _verify_descriptions(game_id: StringName, data: GameData) -> void:
+	var widest: int = 0
+	var rows: int = 0
+	for number: int in range(1, ITEM_ROWS + 1):
+		var entry: Dictionary = data.item(number)
+		if entry.is_empty():
+			continue
+		var text: String = String(entry.get("description", ""))
+		_r.check(not text.is_empty(), "%s: item $%02X has no description." % [game_id, number])
+		rows += 1
+		for line: String in text.split("\n", false):
+			widest = maxi(widest, line.length())
+	for number: int in range(1, RomLayout.MOVE_DESCRIPTION_COUNT + 1):
+		var text: String = String(data.move(number).get("description", ""))
+		_r.check(not text.is_empty(), "%s: move %d has no description." % [game_id, number])
+		for line: String in text.split("\n", false):
+			widest = maxi(widest, line.length())
+	_r.check(
+		widest <= DESCRIPTION_COLUMNS,
+		"%s: a description is %d characters, wider than the box's %d." % [
+			game_id, widest, DESCRIPTION_COLUMNS,
+		]
+	)
+	print("%s: %d item and %d move descriptions, widest line %d." % [
+		game_id, rows, RomLayout.MOVE_DESCRIPTION_COUNT, widest,
+	])

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -1,0 +1,111 @@
+extends SceneTree
+
+## Captures the pack against a real imported cache.
+##
+##   Godot --headless --path . -s res://tools/preview_pack.gd -- \
+##       crystal /tmp/pack.png [items|balls|key|tmhm] [presses] [female]
+##
+## The world behind it is a new game holding enough of each pocket to fill the
+## five visible rows and scroll past them. [presses] is a `u,d,l,r,a,b` list
+## driven into the real screen before the shot, so the picture is what the
+## cartridge's own listing would show after those buttons.
+##
+## Headless: the page composes into an [Image] rather than through a viewport,
+## so no window and no settle are needed.
+
+const NEW_BARK_GROUP: int = 24
+const NEW_BARK_MAP: int = 7
+
+const BUTTONS: Dictionary = {
+	"u": Gen2Button.UP, "d": Gen2Button.DOWN,
+	"l": Gen2Button.LEFT, "r": Gen2Button.RIGHT,
+	"a": Gen2Button.A, "b": Gen2Button.B,
+}
+
+## Which presses each pocket is reached by, since the pack opens on Items and
+## the cartridge cycles left and right through the four.
+const ROUTES: Dictionary = {
+	"items": "",
+	"balls": "r",
+	"key": "r,r",
+	"tmhm": "l",
+}
+
+## What the preview's world is carrying: enough items for the listing to scroll,
+## a ball, two key items and two TMs, by their own item numbers.
+const ITEMS: Dictionary = {
+	1: 1, 4: 12, 5: 30,
+	17: 3, 18: 2, 19: 1, 20: 5, 21: 9, 22: 4,
+	7: 1, 70: 1,
+	0xBF: 1, 0xF3: 1,
+}
+
+
+## The screen builds its panel in `_ready`, which does not run until the tree has
+## processed a frame, so the shot is taken from [method _process] rather than
+## from `_initialize`.
+func _process(_delta: float) -> bool:
+	_capture()
+	return true
+
+
+func _capture() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error(
+			"Usage: preview_pack.gd -- <game> <output.png> "
+			+ "[items|balls|key|tmhm] [presses] [female]"
+		)
+		quit(1)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var pocket: String = args[2] if args.size() > 2 else "items"
+	var tokens: String = String(ROUTES.get(pocket, ""))
+	if args.size() > 3 and not args[3].is_empty():
+		tokens = "%s,%s" % [tokens, args[3]] if not tokens.is_empty() else args[3]
+
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, NEW_BARK_GROUP, NEW_BARK_MAP, Vector2i.ZERO,
+		Gen2WorldState.new({}, {}, ITEMS, {})
+	)
+	if args.size() > 4 and args[4] == "female":
+		world.set_player_gender(true)
+
+	var host := Gen2StartMenuScreen.new()
+	root.add_child(host)
+	if not host.open(world, data, func() -> Dictionary: return {"ok": true}):
+		push_error("The %s cache holds no start menu." % args[0])
+		quit(1)
+		return
+	# The pack is opened by walking the start menu's own list to its PACK row and
+	# pressing A, rather than by naming the mode: a preview that sets its own
+	# state photographs a screen no player can reach.
+	var menu: Gen2WorldStartMenu = host.get("_menu")
+	var rows: Array = menu.items()
+	for index: int in rows.size():
+		if StringName((rows[index] as Dictionary).get("kind", &"")) \
+			== Gen2WorldStartMenu.ITEM_PACK:
+			for _step: int in index - menu.cursor:
+				host.handle_button(Gen2Button.DOWN)
+			break
+	host.handle_button(Gen2Button.A)
+	for token: String in tokens.split(",", false):
+		var key: String = token.strip_edges().to_lower()
+		if BUTTONS.has(key):
+			host.handle_button(int(BUTTONS[key]))
+
+	var error: Error = (host.call("_pack_image") as Image).save_png(args[1])
+	if error != OK:
+		push_error("Could not write %s (error %d)" % [args[1], error])
+		quit(1)
+		return
+	print("Wrote %s: %s pocket, cursor %d" % [
+		args[1], String(host.call("_current_pocket").get("name", "?")),
+		int(host.get("_pack_cursor")),
+	])
+	quit(0)

--- a/tools/preview_pack.gd.uid
+++ b/tools/preview_pack.gd.uid
@@ -1,0 +1,1 @@
+uid://bxtk1qn84g6c2


### PR DESCRIPTION
`Pack_InitGFX`'s writes read as tile numbers, in a page beside the model the way the Pokedex and the trainer card are: the header row, the field, the pocket picture `DrawPackGFX` swaps, `DrawPocketName`'s tilemap and the text box, coloured through the six palettes `_CGB_PackPals` fills the attrmap with. Both listings are drawn, `ScrollingMenu`'s and `TMHM_DisplayPocketItems`' with its own number column and `H`-prefixed HMs, and each pocket keeps its own cursor and scroll position the way the four `w*PocketCursor` variables do. CANCEL is a row the cursor can reach, which is what `.a_button`'s `-1` falls into.

`PackMenuGFX` pins `PackGFX` by its own overrun: the copy asks for `$60` tiles of an 80-tile sheet, so the sixteen landing on `vTiles2 tile $50` are the pocket sheet's first sixteen, and the two runs are adjacent in every dump. `PackFGFX` and `.KrisPackPals` are Crystal's alone.

`ItemDescriptions` and `MoveDescriptions` are imported and fill the box under the listing; the widest line of all 1,518 of them is 18 characters, which is exactly the box's interior. Five of the six field-item texts are now read out of the cartridge rather than authored here. The sixth is not a text: Gold and Silver's `_CoinCaseCountText` ends with `done` rather than `text_end`, so `DoTextUntilTerminator` indexes `TextCommands` with `$57` and runs off a table of 23 entries, which is pokegold's own arbitrary-code-execution comment.

Cache format 62; all three cartridges re-imported and `layout: Layout verified.` on each.

| Check | Result |
|---|---|
| GUT, both tiers | 2,998 tests over 149 scripts, green |
| `validate.gd -- all` | 47 topics, exit 0 |
| `tools/checks/pack.gd` | four pockets drawn per cartridge, 255 item and 251 move descriptions, widest line 18 |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | 294 steps on Crystal, 291 on Gold and Silver, no failures |