### PR TITLE
Bill's PC is the cartridge's own screen

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -53,6 +53,7 @@ var _bar_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
 var _pokedex_palettes: Dictionary = {}
 var _pack: Dictionary = {}
+var _pc_palette: Array = []
 var _gender_screen_palette: Array = []
 var _copyright_string: Array = []
 var _copyright_palette: Array = []
@@ -129,6 +130,8 @@ static func open_directory(path: String) -> GameData:
 	data._card_palettes = manifest.get("card_palettes", {})
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	data._pack = manifest.get("pack", {})
+	var pc_palette: Variant = manifest.get("pc_palette", [])
+	data._pc_palette = pc_palette if pc_palette is Array else []
 	var gender_palette: Variant = manifest.get("gender_screen_palette", [])
 	data._gender_screen_palette = gender_palette if gender_palette is Array else []
 	var copyright_string: Variant = manifest.get("copyright_string", [])
@@ -1643,6 +1646,17 @@ func pokedex_palette(name: String) -> PackedColorArray:
 		return PackedColorArray()
 	var colors := PackedColorArray()
 	for packed: Variant in stored as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## `BillsPCOrangePalette`, the mon-pic box's colours while the PC's cursor
+## stands on a row holding no Pokemon. Empty for a cache without the screen.
+func pc_palette() -> PackedColorArray:
+	if _pc_palette.size() < RomLayout.PC_PALETTE_COLORS:
+		return PackedColorArray()
+	var colors := PackedColorArray()
+	for packed: Variant in _pc_palette:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 62
+const FORMAT_VERSION: int = 63
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -340,6 +340,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not pack["ok"]:
 		return pack
 
+	var pc: Dictionary = verify_pc(rom, layout)
+	if not pc["ok"]:
+		return pc
+
 	var descriptions: Dictionary = verify_descriptions(rom, layout)
 	if not descriptions["ok"]:
 		return descriptions
@@ -2240,6 +2244,76 @@ static func verify_pack(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"ok": true, "message": "Pack graphics verified."}
 
 
+## `PCMailGFX`, the four tiles `BillsPC_InitGFX` copies to `vTiles2 tile $5c`:
+## the mail marker `PCMonInfo` prints for a held mail, the item marker beside it,
+## and the two halves of each. Byte identical in all three dumps.
+const PC_MAIL_BYTES: Array[int] = [
+	0xFF, 0xFF, 0xFF, 0x81, 0xFF, 0xC3, 0xFF, 0xA5,
+	0xFF, 0x99, 0xFF, 0x81, 0xFF, 0x81, 0xFF, 0xFF,
+	0xFF, 0xFF, 0x81, 0xFF, 0xFF, 0xFF, 0xBD, 0xE7,
+	0xBD, 0xFF, 0x81, 0xFF, 0x81, 0xFF, 0xFF, 0xFF,
+	0x00, 0x00, 0x38, 0x38, 0x3C, 0x3C, 0x3E, 0x3E,
+	0x3E, 0x3E, 0x3C, 0x3C, 0x38, 0x38, 0x00, 0x00,
+	0x00, 0x00, 0x1C, 0x1C, 0x3C, 0x3C, 0x7C, 0x7C,
+	0x7C, 0x7C, 0x3C, 0x3C, 0x1C, 0x1C, 0x00, 0x00,
+]
+## `BillsPCOrangePalette`, `gfx/pc/orange.pal` encoded.
+const PC_ORANGE_COLORS: Array[int] = [0x01FF, 0x0197, 0x00EF, 0x0000]
+## The most padding an aligned `PCSelectLZ` leaves before `PCMailGFX`: the run
+## is `--align 4` on Gold and Silver and `--align 1` on Crystal.
+const PC_SELECT_MAX_PADDING: int = 4
+
+
+## Bill's PC's own three runs. The mail sheet and the palette are checked byte
+## for byte, and the cursor sheet by decompressing: a run that yields exactly
+## eight tiles and ends where the mail sheet begins is the one the source names,
+## which is the same neighbour argument `verify_pack` makes.
+static func verify_pc(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("pc", {})
+	if entry.is_empty():
+		return {"ok": true, "message": "No PC screen on this cartridge."}
+	var select: int = int(entry["select_gfx"])
+	var mail: int = int(entry["mail_gfx"])
+	var orange: int = int(entry["orange_palette"])
+	if not rom.in_bounds(mail, PC_MAIL_BYTES.size()) \
+		or not rom.in_bounds(orange, PC_ORANGE_COLORS.size() * Gen2Palette.COLOR_BYTES) \
+		or select < 0 or select >= mail:
+		return {"ok": false, "message": "PC graphics are outside the cartridge."}
+	for index: int in PC_MAIL_BYTES.size():
+		if rom.u8(mail + index) != PC_MAIL_BYTES[index]:
+			return {
+				"ok": false,
+				"message": "PCMailGFX byte %d is $%02X, expected $%02X." % [
+					index, rom.u8(mail + index), PC_MAIL_BYTES[index],
+				],
+			}
+	for index: int in PC_ORANGE_COLORS.size():
+		var stored: int = rom.u16le(orange + index * Gen2Palette.COLOR_BYTES)
+		if stored != PC_ORANGE_COLORS[index]:
+			return {
+				"ok": false,
+				"message": "PC orange colour %d is $%04X, expected $%04X." % [
+					index, stored, PC_ORANGE_COLORS[index],
+				],
+			}
+	var lz := Gen2Lz.new()
+	var raw: PackedByteArray = lz.decompress(rom.bytes(), select)
+	if lz.failed or raw.size() != RomLayout.PC_SELECT_TILES * Gen2Tiles.TILE_BYTES:
+		return {
+			"ok": false,
+			"message": "PCSelectLZ decompresses to %d bytes, expected %d." % [
+				raw.size(), RomLayout.PC_SELECT_TILES * Gen2Tiles.TILE_BYTES,
+			],
+		}
+	var padding: int = mail - select - lz.consumed
+	if padding < 0 or padding > PC_SELECT_MAX_PADDING:
+		return {
+			"ok": false,
+			"message": "PCSelectLZ ends %d bytes before PCMailGFX." % padding,
+		}
+	return {"ok": true, "message": "PC graphics verified."}
+
+
 ## Walks the type matchup chart from its offset to the terminator.
 ##
 ## Returns an Array of { attacker, defender, multiplier, negated_by_foresight },
@@ -3616,6 +3690,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
 		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
+		"pc_palette": _import_pc_palette(rom, layout),
 		"gender_screen_palette": _import_gender_screen_palette(rom, layout),
 		"menu_text": _import_menu_text(rom, layout),
 		"copyright_string": _import_copyright_string(rom, layout),
@@ -4222,6 +4297,19 @@ func _import_pokedex_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
+## `BillsPCOrangePalette`, the four colours `_CGB_BillsPC` puts on the mon-pic
+## box while `wCurPartySpecies` is $ff, which is every row holding no Pokemon.
+func _import_pc_palette(rom: RomFile, layout: Dictionary) -> Array:
+	var entry: Dictionary = layout.get("pc", {})
+	if entry.is_empty():
+		return []
+	var at: int = int(entry["orange_palette"])
+	var out: Array = []
+	for index: int in RomLayout.PC_PALETTE_COLORS:
+		out.append(rom.u16le(at + index * Gen2Palette.COLOR_BYTES))
+	return out
+
+
 ## `Palette_TextBG7`, the four colours a text box is drawn through. Only index 0
 ## and index 3 are ever a pixel, since the font is 1bpp; the two between them are
 ## what a palette fade over a box passes through. Empty on Gold and Silver.
@@ -4721,6 +4809,32 @@ func _import_town_map_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
+## `BillsPC_InitGFX`'s two runs: the compressed cursor sheet and the mail and
+## item markers stored uncompressed behind it.
+func _import_pc_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("pc", {})
+	if entry.is_empty():
+		return {}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var raw: PackedByteArray = _lz.decompress(rom.bytes(), int(entry["select_gfx"]))
+	if _lz.failed or raw.size() < RomLayout.PC_SELECT_TILES * Gen2Tiles.TILE_BYTES:
+		return {}
+	var out: Dictionary = {}
+	for run: Array in [
+		["pc_select", Gen2Tiles.decode_2bpp_strip(raw, 0, RomLayout.PC_SELECT_TILES),
+			RomLayout.PC_SELECT_TILES],
+		["pc_mail", Gen2Tiles.decode_2bpp_strip(
+			rom.bytes(), int(entry["mail_gfx"]), RomLayout.PC_MAIL_TILES),
+			RomLayout.PC_MAIL_TILES],
+	]:
+		if not RomCache.write_indices(
+			RomCache.tile_path(directory, String(run[0])), run[1]
+		):
+			return {}
+		out[String(run[0])] = _strip_sheet_entry(int(run[2]))
+	return out
+
+
 ## `Pokedex_LoadGFX`'s two LZ runs, each as one strip of tiles.
 ##
 ## Kept out of the fixed table [method _import_tiles] uses for the same reason
@@ -5116,6 +5230,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_title_sheets(rom, layout), true)
 	written.merge(_import_town_map_sheets(rom, layout), true)
 	written.merge(_import_pokedex_sheets(rom, layout), true)
+	written.merge(_import_pc_sheets(rom, layout), true)
 	written.merge(_import_intro_sheets(rom, layout), true)
 	written.merge(_import_gs_intro_sheets(rom, layout), true)
 	var done: int = 0

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -684,6 +684,18 @@ const PACK_NAME_CELLS: int = PACK_NAME_COLUMNS * PACK_NAME_ROWS * PACK_POCKETS
 const PACK_PALETTES: int = 6
 const PACK_PALETTE_COLORS: int = 4
 
+## `BillsPC_InitGFX`'s two runs and `BillsPCOrangePalette`. `PCSelectLZ` is the
+## selection cursor's own eight sprite tiles and `PCMailGFX` the four the mail
+## and item markers are drawn from, stored immediately after it in every dump.
+## Crystal compresses the first with `--literal-only` and Gold and Silver do
+## not, so its run is 131 bytes there and 29 here; the decompressed sheet is
+## what the importer checks, not the run's length.
+const PC_SELECT_TILES: int = 8
+const PC_MAIL_TILES: int = 4
+## `gfx/pc/orange.pal`, which `_CGB_BillsPC` loads over the mon-pic palette
+## while the cursor stands on a row holding no Pokémon.
+const PC_PALETTE_COLORS: int = 4
+
 ## `DrawIntroPlayerPic`'s uncompressed 7x7 picture. Crystal stores Chris and
 ## Kris column-major; Gold and Silver use CAL's normal trainer picture instead.
 const INTRO_PLAYER_PIC_COLUMNS: int = 7
@@ -1793,6 +1805,15 @@ const GOLD_SILVER: Dictionary = {
 		"palettes": 0x996F,
 		"female_palettes": -1,
 	},
+	# Bill's PC. `mail_gfx` was located by assembling `gfx/pc/pc_mail.png`,
+	# `select_gfx` by decompressing backwards from it until the run reproduced
+	# `gfx/pc/pc.png` and ended where the mail sheet begins, and
+	# `orange_palette` by encoding `gfx/pc/orange.pal`. Each hits once per dump.
+	"pc": {
+		"select_gfx": 0xE3BF8,
+		"mail_gfx": 0xE3C18,
+		"orange_palette": 0x95CD,
+	},
 	# Battle animations. `BattleAnimations` was located by matching
 	# `BattleAnim_Pound` whole (d1 01 e0 01 31 d0 08 88 38 00 06 d0 01 88 38 00
 	# 10 ff), then finding the run of 278 in-bank pointers whose second entry is
@@ -2171,6 +2192,13 @@ const CRYSTAL: Dictionary = {
 		"pocket_names": 0x109E1,
 		"palettes": 0x9439,
 		"female_palettes": 0x9469,
+	},
+	# Bill's PC; see the Gold and Silver block above for how these were located.
+	# Crystal's cursor sheet is `--literal-only`, so its run is the longer one.
+	"pc": {
+		"select_gfx": 0xE3419,
+		"mail_gfx": 0xE349D,
+		"orange_palette": 0x9036,
 	},
 	# Battle animations; see the Gold and Silver block above for how these were
 	# located. All five tables sit in the same two banks in every dump and only

--- a/game/render/pc_box_page.gd
+++ b/game/render/pc_box_page.gd
@@ -1,0 +1,253 @@
+class_name Gen2PCBoxPage
+extends RefCounted
+
+## Bill's PC on the tile grid the hardware uses (`engine/pokemon/bills_pc.asm`).
+##
+## `Gen2BoxScreen` owns the party, the boxes and what a row may do; this is the
+## picture, the way [Gen2PackPage] is the pack's. Every position is the source's
+## own: `BillsPC_BoxName`'s header box, `BillsPC_RefreshTextboxes`' listing,
+## `PCMonInfo`'s left column and `BillsPC_PlaceString`'s bottom box.
+##
+## Node-free: it writes indices into a buffer, so a page can be drawn and read
+## back headless. The selected Pokemon's pic is not in that buffer and neither is
+## the cursor, since both are drawn through palettes of their own; the screen
+## composes them over the page from [method pic_position] and
+## [method cursor_sprites].
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## `hlcoord 8, 0 / lb bc, 1, 10`, so a one-row interior is a three-row frame,
+## and the name is printed two columns in.
+const NAME_BOX: Rect2i = Rect2i(8, 0, 12, 3)
+const NAME_AT: Vector2i = Vector2i(10, 1)
+
+## `hlcoord 8, 2 / lb bc, 10, 10`, whose top corners are then overwritten with
+## `└` and `┘` so the listing joins the header box above it rather than closing
+## against it.
+const LIST_BOX: Rect2i = Rect2i(8, 2, 12, 12)
+const LIST_AT: Vector2i = Vector2i(9, 4)
+## `ld a, $5 / ld [wBillsPC_NumMonsOnScreen], a`, and the two rows a nickname
+## steps by.
+const LIST_HEIGHT: int = 5
+const ROW_SPACING: int = 2
+## `.CancelString`, the row `CopyBoxmonSpecies` terminates every list with.
+const CANCEL: String = "CANCEL"
+
+## `BillsPC_PlaceString`: `hlcoord 0, 15 / lb bc, 1, 18` and its own line.
+const PROMPT_BOX: Rect2i = Rect2i(0, 15, 20, 3)
+const PROMPT_AT: Vector2i = Vector2i(1, 16)
+
+## `PCMonInfo`'s own column. The pic is seven tiles square at `hlcoord 1, 4`,
+## laid down column by column (`ld [hli], a / add 7`), which is the order
+## `GetMonFrontpic` decompresses into.
+const PIC_AT: Vector2i = Vector2i(1, 4)
+const PIC_TILES: int = 7
+const LEVEL_AT: Vector2i = Vector2i(1, 12)
+const GENDER_AT: Vector2i = Vector2i(5, 12)
+const ITEM_AT: Vector2i = Vector2i(7, 12)
+const SPECIES_AT: Vector2i = Vector2i(1, 14)
+
+## `PrintLevel`'s `<LV>`, and the two markers `BillsPC_InitGFX` copies
+## `PCMailGFX` over: `$5c` for a held mail and `$5d` for any other held item.
+## Everything on the page is printed with the battle-extra strip loaded, which
+## `BillsPC_InitGFX` does before it copies `PCMailGFX` over two of its tiles.
+const FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
+const CODE_LEVEL: int = 0x6E
+const MAIL_CODE: int = 0x5C
+const ITEM_CODE: int = 0x5D
+
+## `BillsPC_UpdateSelectionCursor`'s OAM, as (x, y, tile, x flip, y flip) in
+## screen pixels: `dbsprite` is x tile, y tile, x pixel, y pixel, and a shadow
+## OAM position carries the hardware's own 8 and 16 pixel bias, which is taken
+## off here. The whole set moves down sixteen pixels per cursor row
+## (`and $7 / swap a`), so only the row inside the listing is stored.
+##
+## The two profiles draw different rings out of different sheets, the way
+## `.Frameset_GSTitleTrail` does: Crystal's twenty-four objects are two tiles
+## flipped into four edges, and Gold and Silver's twenty are six tiles with no
+## flip in them at all. Reading either set out of the other's sheet draws the
+## side pieces along the top.
+const CURSOR_STEP: int = 16
+const CURSOR_SPRITES: Array = [
+	[72, 22, 0, false, false], [80, 22, 0, false, false],
+	[88, 22, 0, false, false], [96, 22, 0, false, false],
+	[104, 22, 0, false, false], [112, 22, 0, false, false],
+	[120, 22, 0, false, false], [128, 22, 0, false, false],
+	[136, 22, 0, false, false], [143, 22, 0, false, false],
+	[72, 46, 0, false, true], [80, 46, 0, false, true],
+	[88, 46, 0, false, true], [96, 46, 0, false, true],
+	[104, 46, 0, false, true], [112, 46, 0, false, true],
+	[120, 46, 0, false, true], [128, 46, 0, false, true],
+	[136, 46, 0, false, true], [143, 46, 0, false, true],
+	[70, 30, 1, false, false], [70, 33, 1, false, true],
+	[145, 30, 1, true, false], [145, 33, 1, true, true],
+]
+const CURSOR_SPRITES_GOLD: Array = [
+	[71, 25, 0, false, false], [79, 25, 1, false, false],
+	[87, 25, 1, false, false], [95, 25, 1, false, false],
+	[103, 25, 1, false, false], [111, 25, 1, false, false],
+	[119, 25, 1, false, false], [127, 25, 1, false, false],
+	[135, 25, 1, false, false], [143, 25, 2, false, false],
+	[71, 33, 3, false, false], [79, 33, 4, false, false],
+	[87, 33, 4, false, false], [95, 33, 4, false, false],
+	[103, 33, 4, false, false], [111, 33, 4, false, false],
+	[119, 33, 4, false, false], [127, 33, 4, false, false],
+	[135, 33, 4, false, false], [143, 33, 5, false, false],
+]
+
+## Whichever text box border the player chose, the way every other screen's
+## boxes are drawn.
+var frame_style: int = 0
+var font: Gen2Font = null
+## Which cartridge's cursor set the screen draws.
+var _profile: StringName = RomRegistry.CRYSTAL
+## `PCMailGFX`, the two markers a held item is printed as.
+var _mail: PackedByteArray = PackedByteArray()
+
+
+static func from_data(data: GameData) -> Gen2PCBoxPage:
+	if data == null:
+		return null
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null:
+		return null
+	var out := Gen2PCBoxPage.new()
+	out.font = glyphs
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	out._profile = data.id
+	out._mail = data.tile_indices("pc_mail")
+	return out
+
+
+## The whole 160x144 page as palette indices.
+##
+## [param state] is the screen's own: `box_name`, the visible `rows` of at most
+## [constant LIST_HEIGHT] nicknames with `cancel` on the last one, `prompt` for
+## the line the bottom box carries, and `mon` for whatever `PCMonInfo` prints
+## about the row the cursor stands on.
+func draw(state: Dictionary) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(COLUMNS * TILE * ROWS * TILE)
+	if font == null:
+		return indices
+	var width: int = COLUMNS * TILE
+	_box(indices, width, NAME_BOX)
+	_text(indices, width, String(state.get("box_name", "")), NAME_AT)
+	_box(indices, width, LIST_BOX)
+	## The two corners `BillsPC_RefreshTextboxes` writes over the frame it has
+	## just drawn, which is what joins the two boxes into one.
+	_frame_code(indices, width, RomLayout.FRAME_BOTTOM_LEFT, LIST_BOX.position)
+	_frame_code(
+		indices, width, RomLayout.FRAME_BOTTOM_RIGHT,
+		Vector2i(LIST_BOX.position.x + LIST_BOX.size.x - 1, LIST_BOX.position.y)
+	)
+	var rows: Array = state.get("rows", [])
+	for index: int in mini(rows.size(), LIST_HEIGHT):
+		var row: Dictionary = rows[index]
+		var at: Vector2i = LIST_AT + Vector2i(0, index * ROW_SPACING)
+		_text(
+			indices, width,
+			CANCEL if bool(row.get("cancel", false)) else String(row.get("name", "")),
+			at
+		)
+	_box(indices, width, PROMPT_BOX)
+	_text(indices, width, String(state.get("prompt", "")), PROMPT_AT)
+	_draw_mon(indices, width, state.get("mon", {}))
+	return indices
+
+
+## `PCMonInfo`'s fields. It returns before any of them for an empty row and
+## after the pic for an egg, which is why a state with no `mon` draws neither.
+func _draw_mon(indices: PackedByteArray, width: int, mon: Dictionary) -> void:
+	if mon.is_empty():
+		return
+	_code(indices, width, CODE_LEVEL, LEVEL_AT)
+	_text(indices, width, str(int(mon.get("level", 0))), LEVEL_AT + Vector2i(1, 0))
+	_text(indices, width, String(mon.get("gender", " ")), GENDER_AT)
+	_text(indices, width, String(mon.get("species_name", "")), SPECIES_AT)
+	var item: int = int(mon.get("item", 0))
+	if item > 0:
+		_marker(
+			indices, width,
+			MAIL_CODE if bool(mon.get("mail", false)) else ITEM_CODE, ITEM_AT
+		)
+
+
+## Where the pic goes and how big its cell is, in pixels, for the screen that
+## composes it.
+static func pic_position() -> Vector2i:
+	return PIC_AT * TILE
+
+
+static func pic_size() -> int:
+	return PIC_TILES * TILE
+
+
+## `BillsPC_UpdateSelectionCursor`'s sprites for [param cursor], as
+## { position, tile, flip_x, flip_y }. Empty for a list with nothing in it,
+## which is where the source calls `ClearSprites` instead.
+func cursor_sprites(cursor: int, rows: int) -> Array:
+	if rows <= 0 or cursor < 0:
+		return []
+	var out: Array = []
+	for sprite: Array in cursor_set():
+		out.append({
+			"position": Vector2i(
+				int(sprite[0]), int(sprite[1]) + (cursor & 0x7) * CURSOR_STEP
+			),
+			"tile": int(sprite[2]),
+			"flip_x": bool(sprite[3]),
+			"flip_y": bool(sprite[4]),
+		})
+	return out
+
+
+## How many objects a host has to keep around for either profile.
+static func max_cursor_sprites() -> int:
+	return maxi(CURSOR_SPRITES.size(), CURSOR_SPRITES_GOLD.size())
+
+
+## The profile's own OAM table.
+func cursor_set() -> Array:
+	return CURSOR_SPRITES if _profile == RomRegistry.CRYSTAL else CURSOR_SPRITES_GOLD
+
+
+func _box(indices: PackedByteArray, width: int, box: Rect2i) -> void:
+	font.draw_box(
+		frame_style, indices, width,
+		box.position.x * TILE, box.position.y * TILE, box.size.x, box.size.y
+	)
+
+
+func _frame_code(
+	indices: PackedByteArray, width: int, within: int, at: Vector2i
+) -> void:
+	font.draw_frame_code(
+		frame_style, RomLayout.FRAME_FIRST_CODE + within, indices, width,
+		at.x * TILE, at.y * TILE
+	)
+
+
+func _text(
+	indices: PackedByteArray, width: int, text: String, at: Vector2i
+) -> void:
+	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE, FONT)
+
+
+func _code(indices: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
+	font.draw_code(code, indices, width, at.x * TILE, at.y * TILE, FONT)
+
+
+## One of `PCMailGFX`'s two tiles, which sit where the battle-extra strip's own
+## $5c and $5d would be: the copy is made after `LoadFontsBattleExtra`.
+func _marker(
+	indices: PackedByteArray, width: int, code: int, at: Vector2i
+) -> void:
+	if _mail.is_empty():
+		return
+	Gen2Font.blit_slot(
+		_mail, RomLayout.PC_MAIL_TILES * TILE, code - MAIL_CODE,
+		indices, width, at.x * TILE, at.y * TILE
+	)

--- a/game/render/pc_box_page.gd.uid
+++ b/game/render/pc_box_page.gd.uid
@@ -1,0 +1,1 @@
+uid://d0orevubt4wcl

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -1,20 +1,37 @@
 class_name Gen2BoxScreen
 extends Control
 
-## First PC presentation: one numbered box, its twenty fixed slots, and the
-## explicit party/box transfer boundary. Box names and cartridge SRAM layout
-## remain outside this screen until their canonical source is verified.
+## Bill's PC, on the hardware's own grid.
+##
+## [Gen2PCBoxPage] is the picture and `engine/pokemon/bills_pc.asm` is the model:
+## `wBillsPC_LoadedBox` picks the party or one box, `CopyBoxmonSpecies` builds
+## the list it walks with a CANCEL row on the end, and
+## `BillsPC_PressUp`/`Down`/`Left`/`Right` are the cursor, the scroll and the box
+## the D-pad changes.
+##
+## What the source splits between DEPOSIT, WITHDRAW and MOVE WITHOUT MAIL is one
+## screen here: A on a party row deposits and A on a box row withdraws, through
+## [Gen2SaveStorage]'s atomic transfers. The submenus behind those rows (STATS,
+## RELEASE, MOVE) are not built; nothing calls them and the storage boundary is
+## what the PC exists for.
 
 signal closed(result: Dictionary)
 
-const BACKGROUND: Color = Color("#09111f")
-const PANEL: Color = Color("#14233a")
-const BORDER: Color = Color("#2d4566")
-const TEXT: Color = Color("#f4f7fb")
-const MUTED: Color = Color("#9eacc0")
-const ACCENT: Color = Color("#f3c969")
-const SUCCESS: Color = Color("#7bd89a")
-const ERROR: Color = Color("#ef8a8a")
+## The PC is drawn in hardware pixels and the panel it is opened from is ordinary
+## UI at window resolution, so the screen carries a [Gen2Screen] of its own, the
+## way [Gen2TownMapScreen] does.
+const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
+
+## `PCString_ChooseaPKMN` and `.PartyPKMN`. Both are engine strings inside
+## `bills_pc.asm` that no script points at, so nothing imports them and they are
+## the host's, like the contest judging lines. "PKMN" is the two tiles `<PK>` and
+## `<MN>`, which is what [method Gen2Text.encode] makes of it; "#" is the POKé
+## ligature and has no tile in either font.
+const PROMPT_CHOOSE: String = "Choose a PKMN."
+const PARTY_NAME: String = "PARTY PKMN"
+
+## `wBillsPC_LoadedBox`: zero is the party and the boxes follow it.
+const LOADED_PARTY: int = 0
 
 var _data: GameData = null
 var _data_override: GameData = null
@@ -25,17 +42,27 @@ var _embedded: bool = false
 var _box_index: int = 0
 var _selected_box_slot: int = -1
 var _selected_party_index: int = -1
-var _box_title: Label = null
-var _party_members: VBoxContainer = null
-var _box_grid: GridContainer = null
-var _selection: Label = null
-var _status: Label = null
+## `wBillsPC_LoadedBox`, `wBillsPC_CursorPosition` and `wBillsPC_ScrollPosition`.
+var _loaded: int = LOADED_PARTY
+var _cursor: int = 0
+var _scroll: int = 0
+## The line the bottom box carries, which is `PCString_ChooseaPKMN` until a
+## transfer answers.
+var _prompt: String = PROMPT_CHOOSE
+var _page: Gen2PCBoxPage = null
+var _field: Control = null
+var _backdrop: ColorRect = null
+var _background: TextureRect = null
+var _pic: TextureRect = null
+var _cursor_sprites: Array[TextureRect] = []
 
 
 func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
 	_data = _data_override if _data_override != null else _resolve_data()
 	_save = _save_override if _save_override != null else _resolve_save()
-	_build_ui()
+	_page = Gen2PCBoxPage.from_data(_data)
+	_build()
 	_refresh()
 	# Not while embedded in the overworld: the world screen routes buttons here
 	# itself, and a focus ring appearing over the map would be the map's.
@@ -54,7 +81,9 @@ func set_context(
 	_embedded = embedded
 	_data = data
 	_save = save
-	if is_inside_tree() and _box_grid != null:
+	if is_inside_tree():
+		if _page == null:
+			_page = Gen2PCBoxPage.from_data(_data)
 		_refresh()
 
 
@@ -72,6 +101,10 @@ func box_snapshot() -> Dictionary:
 		"box": _box_index,
 		"selected_box_slot": _selected_box_slot,
 		"selected_party_index": _selected_party_index,
+		"loaded": _loaded,
+		"cursor": _cursor,
+		"scroll": _scroll,
+		"prompt": _prompt,
 		"boxes": boxes,
 	}
 
@@ -81,8 +114,11 @@ func select_box(box_index: int) -> bool:
 		return false
 	_box_index = box_index
 	_selected_box_slot = -1
-	if _box_grid != null:
-		_refresh()
+	if _loaded != LOADED_PARTY:
+		_loaded = box_index + 1
+	_cursor = 0
+	_scroll = 0
+	_refresh()
 	return true
 
 
@@ -91,8 +127,7 @@ func select_box_slot(slot: int) -> bool:
 		return false
 	_selected_box_slot = slot
 	_selected_party_index = -1
-	if _box_grid != null:
-		_refresh_selection()
+	_refresh()
 	return true
 
 
@@ -101,41 +136,97 @@ func select_party_member(index: int) -> bool:
 		return false
 	_selected_party_index = index
 	_selected_box_slot = -1
-	if _party_members != null:
-		_refresh_selection()
+	_refresh()
 	return true
 
 
 func deposit_selected_party() -> bool:
 	if _save == null or _selected_party_index < 0:
-		_set_status("Select a party member first.", ERROR)
+		_prompt = "Choose a party PKMN."
+		_refresh()
 		return false
 	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(
 		_save, _data, _selected_party_index, _box_index, -1, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_set_status(String(result.get("message", result.get("reason", "Deposit refused."))), ERROR)
+		_prompt = String(result.get("message", result.get("reason", "Deposit refused.")))
+		_refresh()
 		return false
-	_set_status("Moved to Box %d slot %d." % [int(result["box"]) + 1, int(result["slot"]) + 1], SUCCESS)
+	_prompt = "Stored in BOX %d." % (int(result["box"]) + 1)
 	_selected_party_index = -1
+	_clamp_cursor()
 	_refresh()
 	return true
 
 
 func withdraw_selected_box() -> bool:
 	if _save == null or _selected_box_slot < 0:
-		_set_status("Select a stored Pokémon first.", ERROR)
+		_prompt = "Choose a stored PKMN."
+		_refresh()
 		return false
 	var result: Dictionary = Gen2SaveStorage.withdraw_box_to_party(
 		_save, _data, _box_index, _selected_box_slot, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_set_status(String(result.get("message", result.get("reason", "Withdrawal refused."))), ERROR)
+		_prompt = String(result.get("message", result.get("reason", "Withdrawal refused.")))
+		_refresh()
 		return false
-	_set_status("Moved to party slot %d." % (int(result["party_index"]) + 1), SUCCESS)
+	_prompt = "Taken out of BOX %d." % (_box_index + 1)
 	_selected_box_slot = -1
+	_clamp_cursor()
 	_refresh()
 	return true
+
+
+## `_StatsScreenDPad` and its siblings: up and down walk the list, left and right
+## change the loaded box, A takes the row the cursor stands on and B leaves.
+func handle_button(button: int) -> bool:
+	match button:
+		Gen2Button.UP:
+			_press_up()
+		Gen2Button.DOWN:
+			_press_down()
+		Gen2Button.LEFT:
+			_press_left()
+		Gen2Button.RIGHT:
+			_press_right()
+		Gen2Button.A:
+			_confirm()
+		Gen2Button.B:
+			_back()
+		_:
+			return false
+	return true
+
+
+## The list `CopyBoxmonSpecies` builds: every occupied slot of the loaded list,
+## then the CANCEL row its `ld a, -1` terminator becomes.
+func rows() -> Array:
+	var out: Array = []
+	for entry: Array in _entries():
+		var mon: Gen2SaveMon = entry[1]
+		out.append({
+			"name": _display_name(mon), "index": int(entry[0]), "cancel": false,
+		})
+	out.append({"name": Gen2PCBoxPage.CANCEL, "index": -1, "cancel": true})
+	return out
+
+
+func _entries() -> Array:
+	var out: Array = []
+	if _save == null:
+		return out
+	if _loaded == LOADED_PARTY:
+		for index: int in _save.party.size():
+			out.append([index, _save.party[index]])
+		return out
+	var box: Gen2SaveBox = _save.boxes[_box_index] if _box_index < _save.boxes.size() else null
+	if box == null:
+		return out
+	for slot: int in Gen2SaveBox.CAPACITY:
+		if slot < box.slots.size() and box.slots[slot] != null:
+			out.append([slot, box.slots[slot]])
+	return out
 
 
 func _resolve_data() -> GameData:
@@ -146,167 +237,199 @@ func _resolve_save() -> Gen2SaveData:
 	return Gen2GameRuntime.selected_save_or_null() if _data != null else null
 
 
-func _build_ui() -> void:
-	var background := ColorRect.new()
-	background.color = BACKGROUND
-	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	background.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(background)
-
-	var margin := MarginContainer.new()
-	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	margin.add_theme_constant_override("margin_left", 42)
-	margin.add_theme_constant_override("margin_top", 30)
-	margin.add_theme_constant_override("margin_right", 42)
-	margin.add_theme_constant_override("margin_bottom", 30)
-	add_child(margin)
-
-	var content := VBoxContainer.new()
-	content.add_theme_constant_override("separation", 12)
-	margin.add_child(content)
-
-	var header := HBoxContainer.new()
-	header.add_theme_constant_override("separation", 12)
-	content.add_child(header)
-	var heading := VBoxContainer.new()
-	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	heading.add_theme_constant_override("separation", 3)
-	header.add_child(heading)
-	var title := Label.new()
-	title.text = "PC STORAGE"
-	title.add_theme_color_override("font_color", TEXT)
-	title.add_theme_font_size_override("font_size", 30)
-	heading.add_child(title)
-	var subtitle := Label.new()
-	subtitle.text = "Party and fixed twenty-slot boxes"
-	subtitle.add_theme_color_override("font_color", MUTED)
-	heading.add_child(subtitle)
-	var previous := _button("Previous box", TEXT)
-	previous.pressed.connect(_previous_box)
-	header.add_child(previous)
-	var next := _button("Next box", TEXT)
-	next.pressed.connect(_next_box)
-	header.add_child(next)
-	var back := _button("Turn off PC" if _embedded else "Back to party", TEXT)
-	back.pressed.connect(_back)
-	header.add_child(back)
-
-	_box_title = Label.new()
-	_box_title.add_theme_color_override("font_color", ACCENT)
-	_box_title.add_theme_font_size_override("font_size", 18)
-	content.add_child(_box_title)
-
-	var main := HBoxContainer.new()
-	main.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	main.add_theme_constant_override("separation", 18)
-	content.add_child(main)
-
-	var box_panel := PanelContainer.new()
-	box_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	box_panel.add_theme_stylebox_override("panel", _panel_style(PANEL, BORDER, 8))
-	main.add_child(box_panel)
-	var box_margin := MarginContainer.new()
-	box_margin.add_theme_constant_override("margin_left", 14)
-	box_margin.add_theme_constant_override("margin_top", 14)
-	box_margin.add_theme_constant_override("margin_right", 14)
-	box_margin.add_theme_constant_override("margin_bottom", 14)
-	box_panel.add_child(box_margin)
-	_box_grid = GridContainer.new()
-	_box_grid.columns = 4
-	_box_grid.add_theme_constant_override("h_separation", 8)
-	_box_grid.add_theme_constant_override("v_separation", 8)
-	box_margin.add_child(_box_grid)
-
-	var side := VBoxContainer.new()
-	side.custom_minimum_size.x = 300
-	side.add_theme_constant_override("separation", 10)
-	main.add_child(side)
-	var party_heading := Label.new()
-	party_heading.text = "PARTY"
-	party_heading.add_theme_color_override("font_color", TEXT)
-	party_heading.add_theme_font_size_override("font_size", 18)
-	side.add_child(party_heading)
-	_party_members = VBoxContainer.new()
-	_party_members.add_theme_constant_override("separation", 6)
-	side.add_child(_party_members)
-	var deposit := _button("Deposit selected party member", ACCENT)
-	deposit.pressed.connect(deposit_selected_party)
-	side.add_child(deposit)
-	var withdraw := _button("Withdraw selected box slot", ACCENT)
-	withdraw.pressed.connect(withdraw_selected_box)
-	side.add_child(withdraw)
-	_selection = Label.new()
-	_selection.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_selection.custom_minimum_size.y = 56
-	_selection.add_theme_color_override("font_color", MUTED)
-	side.add_child(_selection)
-
-	_status = Label.new()
-	_status.add_theme_color_override("font_color", MUTED)
-	content.add_child(_status)
+func _build() -> void:
+	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
+	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(screen)
+	_field = Control.new()
+	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	screen.display(_field)
+	## The page is drawn with colour 0 transparent so the pic shows through the
+	## cell it is composed into, which leaves the backdrop to fill it.
+	_backdrop = ColorRect.new()
+	_backdrop.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_field.add_child(_backdrop)
+	## The pic sits under the page so the listing's border stays drawn over it,
+	## the way the hardware's own window does.
+	_pic = _sprite()
+	_background = _sprite()
+	for _index: int in Gen2PCBoxPage.max_cursor_sprites():
+		_cursor_sprites.append(_sprite())
 
 
+func _sprite() -> TextureRect:
+	var node := TextureRect.new()
+	node.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	node.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_field.add_child(node)
+	return node
+
+
+## The cursor's row is the selection whether or not there is anything to draw
+## it with: a cache carrying no font still stores and withdraws.
+## Drawing only. The selection is [method _sync_selection]'s, so a caller that
+## picked a slot by hand keeps it and a cache carrying no font still draws
+## nothing without losing one.
 func _refresh() -> void:
-	if _box_grid == null:
+	var mon: Gen2SaveMon = _selected_mon()
+	if _page == null or _background == null:
 		return
-	Gen2LauncherUI.clear(_box_grid)
-	for slot: int in Gen2SaveBox.CAPACITY:
-		var button := _button(_slot_text(slot), TEXT)
-		button.custom_minimum_size = Vector2(170, 58)
-		button.pressed.connect(_select_box_slot.bind(slot))
-		_box_grid.add_child(button)
-	if _party_members != null:
-		Gen2LauncherUI.clear(_party_members)
-		for index: int in Gen2SaveData.MAX_PARTY:
-			var member := _button(_party_text(index), TEXT)
-			member.custom_minimum_size = Vector2(280, 40)
-			if _save != null and index < _save.party.size():
-				member.pressed.connect(_select_party_member.bind(index))
-			else:
-				member.disabled = true
-			_party_members.add_child(member)
-	if _box_title != null:
-		_box_title.text = "Box %d of %d" % [_box_index + 1, Gen2SaveData.BOX_COUNT]
-	_refresh_selection()
+	var visible_rows: Array = []
+	var all_rows: Array = rows()
+	for index: int in Gen2PCBoxPage.LIST_HEIGHT:
+		var at: int = _scroll + index
+		if at < all_rows.size():
+			visible_rows.append(all_rows[at])
+	var indices: PackedByteArray = _page.draw({
+		"box_name": _box_name(),
+		"rows": visible_rows,
+		"prompt": _prompt,
+		"mon": _mon_state(mon),
+	})
+	var palette: PackedColorArray = _interface_palette()
+	if _backdrop != null:
+		_backdrop.color = palette[0]
+	_background.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
+	))
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_refresh_pic(mon)
+	_refresh_cursor(all_rows.size())
 
 
-func _refresh_selection() -> void:
-	if _selection == null:
+## `_CGB_BillsPC`'s background palette, PREDEFPAL_POKEDEX, which the Pokedex
+## already imports as its own interface palette.
+func _interface_palette() -> PackedColorArray:
+	var colors: PackedColorArray = _data.pokedex_palette("interface") if _data != null \
+		else PackedColorArray()
+	if colors.is_empty():
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return colors
+
+
+## Which slot the cursor stands on, kept in the two fields the transfers read so
+## that walking the list and picking a slot by hand are the same selection.
+func _sync_selection() -> void:
+	if _selected_mon() == null:
 		return
-	if _save == null:
-		_selection.text = "No validated save selected."
-		_set_status("No validated save selected.", ERROR)
+	var entries: Array = _entries()
+	var at: int = _cursor + _scroll
+	if at < 0 or at >= entries.size():
 		return
-	if _selected_party_index >= 0 and _selected_party_index < _save.party.size():
-		_selection.text = "Selected party: %s\nDeposit uses the first free slot in Box %d." % [
-			_display_name(_save.party[_selected_party_index]), _box_index + 1,
-		]
+	if _loaded == LOADED_PARTY:
+		_selected_party_index = int(entries[at][0])
+		_selected_box_slot = -1
 		return
-	if _selected_box_slot >= 0:
-		var box: Gen2SaveBox = _save.boxes[_box_index]
-		var mon: Gen2SaveMon = box.slots[_selected_box_slot] if box != null else null
-		_selection.text = "Selected Box %d slot %d: %s" % [
-			_box_index + 1, _selected_box_slot + 1,
-			_display_name(mon) if mon != null else "Empty",
-		]
+	_selected_box_slot = int(entries[at][0])
+	_selected_party_index = -1
+
+
+func _selected_mon() -> Gen2SaveMon:
+	var entries: Array = _entries()
+	var at: int = _cursor + _scroll
+	if at < 0 or at >= entries.size():
+		return null
+	return entries[at][1]
+
+
+## `PCMonInfo`'s own fields. An egg is drawn as its pic and nothing else, which
+## is where the source returns.
+func _mon_state(mon: Gen2SaveMon) -> Dictionary:
+	if mon == null or _data == null:
+		return {}
+	if mon.is_egg:
+		return {}
+	return {
+		"level": mon.level,
+		"gender": _gender_glyph(Gen2BattleMon.gender_for(_data, mon.species, mon.dvs)),
+		"species_name": String(_data.species(mon.species).get("name", "")),
+		"item": mon.item,
+		## `ItemIsMail` reads a list no importer reads, so no item is mail here
+		## and the mail marker is unreachable; see HANDOFF.md.
+		"mail": false,
+	}
+
+
+func _gender_glyph(gender: StringName) -> String:
+	if gender == Gen2BattleMon.GENDER_MALE:
+		return "♂"
+	if gender == Gen2BattleMon.GENDER_FEMALE:
+		return "♀"
+	return " "
+
+
+func _refresh_pic(mon: Gen2SaveMon) -> void:
+	if _pic == null:
 		return
-	_selection.text = "Select a party member or a stored Pokémon."
+	_pic.texture = null
+	if mon == null or _data == null:
+		return
+	var pic: Dictionary = _data.species_pic(mon.species)
+	if pic.is_empty():
+		return
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.palette(mon.species)
+	)
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = Vector2(image.get_size())
+	## `_PrepMonFrontpic` places a pic smaller than the seven-tile cell at its
+	## bottom, which is what keeps every species standing on the same line.
+	var cell: int = Gen2PCBoxPage.pic_size()
+	_pic.position = Vector2(Gen2PCBoxPage.pic_position()) + Vector2(
+		float(cell - image.get_width()) * 0.5, float(cell - image.get_height())
+	)
 
 
-func _slot_text(slot: int) -> String:
-	if _save == null or _box_index >= _save.boxes.size() or _save.boxes[_box_index] == null:
-		return "%02d\nEmpty" % (slot + 1)
-	var mon: Gen2SaveMon = _save.boxes[_box_index].slots[slot]
-	if mon == null:
-		return "%02d\nEmpty" % (slot + 1)
-	return "%02d  %s\nLv %d" % [slot + 1, _display_name(mon), mon.level]
+func _refresh_cursor(row_count: int) -> void:
+	var sprites: Array = _page.cursor_sprites(_cursor, row_count)
+	var sheet: PackedByteArray = _data.tile_indices("pc_select") if _data != null \
+		else PackedByteArray()
+	var palette: PackedColorArray = _data.party_menu_icon_palette(0) if _data != null \
+		else PackedColorArray()
+	for index: int in _cursor_sprites.size():
+		var node: TextureRect = _cursor_sprites[index]
+		node.visible = index < sprites.size() and not sheet.is_empty() \
+			and not palette.is_empty()
+		if not node.visible:
+			continue
+		var sprite: Dictionary = sprites[index]
+		node.position = Vector2(sprite["position"])
+		node.texture = ImageTexture.create_from_image(_cursor_image(
+			sheet, palette, int(sprite["tile"]),
+			bool(sprite["flip_x"]), bool(sprite["flip_y"])
+		))
 
 
-func _party_text(index: int) -> String:
-	if _save == null or index >= _save.party.size():
-		return "%d  Empty" % (index + 1)
-	var mon: Gen2SaveMon = _save.party[index]
-	return "%d  %s  Lv %d" % [index + 1, _display_name(mon), mon.level]
+## One tile of `PCSelectLZ`, flipped the way its OAM attribute asks. `B_OAM_XFLIP`
+## flips the tile where it stands rather than mirroring a square, which is why
+## each object is drawn on its own.
+func _cursor_image(
+	sheet: PackedByteArray, palette: PackedColorArray, tile: int,
+	flip_x: bool, flip_y: bool
+) -> Image:
+	var size: int = Gen2Font.TILE
+	var cell := PackedByteArray()
+	cell.resize(size * size)
+	Gen2Font.blit_slot(
+		sheet, RomLayout.PC_SELECT_TILES * size, tile, cell, size, 0, 0
+	)
+	var image: Image = Gen2PicImage.from_indices(cell, size, size, palette, true)
+	if flip_x:
+		image.flip_x()
+	if flip_y:
+		image.flip_y()
+	return image
+
+
+## `BillsPC_BoxName`, which names the party or the loaded box.
+func _box_name() -> String:
+	if _loaded == LOADED_PARTY:
+		return PARTY_NAME
+	return "BOX %d" % (_box_index + 1)
 
 
 func _mon_snapshot(box: int, slot: int, mon: Gen2SaveMon) -> Dictionary:
@@ -320,39 +443,86 @@ func _mon_snapshot(box: int, slot: int, mon: Gen2SaveMon) -> Dictionary:
 
 func _display_name(mon: Gen2SaveMon) -> String:
 	if mon == null:
-		return "Empty"
+		return ""
 	if not mon.nickname.is_empty():
 		return mon.nickname
-	return String(_data.species(mon.species).get("name", "UNKNOWN")) if _data != null else "UNKNOWN"
+	return String(_data.species(mon.species).get("name", "UNKNOWN")) if _data != null \
+		else "UNKNOWN"
 
 
-func _previous_box() -> void:
-	if _save != null:
-		_box_index = posmod(_box_index - 1, Gen2SaveData.BOX_COUNT)
-		_selected_box_slot = -1
-		_refresh()
-
-
-func _next_box() -> void:
-	if _save != null:
-		_box_index = posmod(_box_index + 1, Gen2SaveData.BOX_COUNT)
-		_selected_box_slot = -1
-		_refresh()
-
-
-func _select_box_slot(slot: int) -> void:
-	select_box_slot(slot)
-
-
-func _select_party_member(index: int) -> void:
-	select_party_member(index)
-
-
-func _set_status(message: String, colour: Color) -> void:
-	if _status == null:
+func _press_up() -> void:
+	if _cursor > 0:
+		_cursor -= 1
+	elif _scroll > 0:
+		_scroll -= 1
+	else:
 		return
-	_status.text = message
-	_status.add_theme_color_override("font_color", colour)
+	_sync_selection()
+	_refresh()
+
+
+## `BillsPC_PressDown`: the cursor stops one row short of the list's length and
+## the scroll takes over at the bottom of the five rows on screen.
+func _press_down() -> void:
+	var count: int = rows().size()
+	if _cursor + _scroll + 1 >= count:
+		return
+	if _cursor + 1 < Gen2PCBoxPage.LIST_HEIGHT:
+		_cursor += 1
+	else:
+		_scroll += 1
+	_sync_selection()
+	_refresh()
+
+
+## `BillsPC_PressLeft`/`Right`, which wrap the party and every box round.
+func _press_left() -> void:
+	_load(_loaded - 1 if _loaded > LOADED_PARTY else Gen2SaveData.BOX_COUNT)
+
+
+func _press_right() -> void:
+	_load(_loaded + 1 if _loaded < Gen2SaveData.BOX_COUNT else LOADED_PARTY)
+
+
+func _load(loaded: int) -> void:
+	_loaded = loaded
+	if _loaded != LOADED_PARTY:
+		_box_index = _loaded - 1
+	_cursor = 0
+	_scroll = 0
+	_selected_box_slot = -1
+	_selected_party_index = -1
+	_prompt = PROMPT_CHOOSE
+	_sync_selection()
+	_refresh()
+
+
+## A on the CANCEL row leaves, the way `.Cancel` does; on any other row it is the
+## transfer the loaded list implies.
+func _confirm() -> void:
+	var all_rows: Array = rows()
+	var at: int = _cursor + _scroll
+	if at < 0 or at >= all_rows.size() or bool((all_rows[at] as Dictionary)["cancel"]):
+		_back()
+		return
+	_sync_selection()
+	if _loaded == LOADED_PARTY:
+		deposit_selected_party()
+		return
+	withdraw_selected_box()
+
+
+## After a transfer the list is one row shorter, so the cursor comes back inside
+## it the way `CopyBoxmonSpecies` and the joypad bounds do together.
+func _clamp_cursor() -> void:
+	var count: int = rows().size()
+	while _cursor + _scroll >= count and (_cursor > 0 or _scroll > 0):
+		if _scroll > 0:
+			_scroll -= 1
+		else:
+			_cursor -= 1
+	_selected_box_slot = -1
+	_selected_party_index = -1
 
 
 func _back() -> void:
@@ -366,25 +536,3 @@ func close_embedded() -> void:
 	if not _embedded:
 		return
 	closed.emit({"ok": true, "script_value": 0, "changed": false})
-
-
-func _button(text: String, colour: Color) -> Button:
-	var button := Button.new()
-	button.text = text
-	button.add_theme_color_override("font_color", colour)
-	button.add_theme_color_override("font_hover_color", Color.WHITE)
-	button.add_theme_font_size_override("font_size", 14)
-	return button
-
-
-func _panel_style(fill: Color, line: Color, radius: int) -> StyleBoxFlat:
-	var style := StyleBoxFlat.new()
-	style.bg_color = fill
-	style.border_color = line
-	style.set_border_width_all(1)
-	style.set_corner_radius_all(radius)
-	style.content_margin_left = 18
-	style.content_margin_top = 14
-	style.content_margin_right = 18
-	style.content_margin_bottom = 14
-	return style

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -205,6 +205,10 @@ func handle_button(button: int) -> bool:
 		return true
 	if _mode == MODE.CARD and _pokegear != null:
 		return _pokegear.handle_button(button)
+	## The panel is behind the box screen while BILL'S PC is open, the way it is
+	## behind the region map, so the buttons are the box screen's.
+	if _boxes != null:
+		return _boxes.handle_button(button)
 	if Gen2Button.is_direction(button):
 		_move_direction(Gen2Button.vector(button))
 		return true

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -227,6 +227,41 @@ func test_pc_storage_moves_party_to_box_and_back_through_atomic_save() -> void:
 	assert_null(restored.boxes[0].slots[0])
 
 
+## `CopyBoxmonSpecies` ends every list with the row its `ld a, -1` terminator
+## becomes, and `BillsPC_PressDown` stops the cursor on it.
+func test_box_screen_lists_the_party_with_a_cancel_row() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	await _open_box_screen(save)
+	var rows: Array = _box_screen.rows()
+	assert_eq(rows.size(), 3)
+	assert_eq(String((rows[0] as Dictionary)["name"]), "SPARKY")
+	assert_true(bool((rows[2] as Dictionary)["cancel"]))
+	for _press: int in 5:
+		_box_screen.handle_button(Gen2Button.DOWN)
+	var snapshot: Dictionary = _box_screen.box_snapshot()
+	assert_eq(int(snapshot["cursor"]) + int(snapshot["scroll"]), rows.size() - 1)
+
+
+## `BillsPC_PressRight` walks the party and every box round, and the row the
+## cursor stands on is what a transfer takes.
+func test_box_screen_walks_boxes_and_deposits_the_row_under_the_cursor() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	await _open_box_screen(save)
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(save.party.size(), 1)
+	assert_not_null(save.boxes[0].slots[0])
+	_box_screen.handle_button(Gen2Button.RIGHT)
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), 1)
+	assert_eq(String(_box_screen.rows()[0]["name"]), "GEODUDE")
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(save.party.size(), 2)
+	assert_null(save.boxes[0].slots[0])
+	for _press: int in Gen2SaveData.BOX_COUNT:
+		_box_screen.handle_button(Gen2Button.RIGHT)
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
+
+
 func test_pc_storage_refuses_depositing_the_last_party_member() -> void:
 	var save: Gen2SaveData = _save()
 	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(save, _data, 0, 0)

--- a/tools/checks/pc.gd
+++ b/tools/checks/pc.gd
@@ -1,0 +1,146 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies Bill's PC's own graphics and its screen against freshly imported real
+## caches, over every species rather than a sampled one.
+##
+## Expected values come from `engine/pokemon/bills_pc.asm`: `BillsPC_InitGFX`'s
+## two runs, `_CGB_BillsPC`'s palettes, `BillsPC_RefreshTextboxes`' listing and
+## `PCMonInfo`'s left column. The sweep is over species because that column is
+## the one thing on the screen whose width is not fixed: a pic wider than its
+## seven-tile cell, or a name wider than the two boxes `ClearBox` leaves for it,
+## would overrun the listing, and no one-species screenshot says so.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- pc
+
+## `BillsPCOrangePalette`, `gfx/pc/orange.pal`, which is the same four colours in
+## all three dumps.
+const ORANGE: Array[int] = [0x01FF, 0x0197, 0x00EF, 0x0000]
+const SPECIES_COUNT: int = 251
+## What `PCMonInfo` clears for the pic, the name and the level: eight columns
+## (`hlcoord 0, 0 / lb bc, 15, 8`) plus the three past them on the name's own row
+## (`hlcoord 8, 14 / lb bc, 1, 3`). The second clear is there for exactly one
+## reason: the longest species name is ten tiles printed from column 1.
+const INFO_COLUMNS: int = 8
+const NAME_OVERHANG: Vector2i = Vector2i(8, 14)
+const NAME_OVERHANG_COLUMNS: int = 3
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_graphics(game_id, data)
+		_verify_cursor(game_id, Gen2PCBoxPage.from_data(data))
+		_verify_info_column(game_id, data)
+
+
+## `BillsPC_InitGFX`'s two sheets and the palette `_CGB_BillsPC` loads over the
+## pic box for a row with no Pokemon on it.
+func _verify_graphics(game_id: StringName, data: GameData) -> void:
+	for run_row: Array in [
+		["pc_select", RomLayout.PC_SELECT_TILES], ["pc_mail", RomLayout.PC_MAIL_TILES],
+	]:
+		var strip: PackedByteArray = data.tile_indices(String(run_row[0]))
+		var want: int = int(run_row[1]) * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT
+		_r.check(
+			strip.size() == want,
+			"%s: %s is %d pixels, not the %d its %d tiles need." % [
+				game_id, String(run_row[0]), strip.size(), want, int(run_row[1]),
+			]
+		)
+	var palette: PackedColorArray = data.pc_palette()
+	if not _r.check(
+		palette.size() == RomLayout.PC_PALETTE_COLORS,
+		"%s: the PC palette holds %d colours, not %d." % [
+			game_id, palette.size(), RomLayout.PC_PALETTE_COLORS,
+		]
+	):
+		return
+	for index: int in ORANGE.size():
+		_r.check(
+			palette[index].is_equal_approx(Gen2Palette.from_packed(ORANGE[index])),
+			"%s: PC colour %d is %s, not the pinned $%04X." % [
+				game_id, index, palette[index], ORANGE[index],
+			]
+		)
+
+
+## `BillsPC_UpdateSelectionCursor`'s OAM for each of the five rows it can stand
+## on: every object inside the listing box and stepping sixteen pixels a row,
+## which is what says the shadow-OAM bias was taken off once rather than twice.
+func _verify_cursor(game_id: StringName, page: Gen2PCBoxPage) -> void:
+	if not _r.check(page != null, "%s: the PC page needs a font." % game_id):
+		return
+	var box: Rect2i = Gen2PCBoxPage.LIST_BOX
+	var left: int = box.position.x * Gen2Font.TILE
+	var right: int = (box.position.x + box.size.x) * Gen2Font.TILE
+	var first: Array = page.cursor_sprites(0, 1)
+	for cursor: int in Gen2PCBoxPage.LIST_HEIGHT:
+		var sprites: Array = page.cursor_sprites(cursor, 1)
+		if not _r.check(
+			sprites.size() == page.cursor_set().size(),
+			"%s: cursor %d draws %d objects, not %d." % [
+				game_id, cursor, sprites.size(), page.cursor_set().size(),
+			]
+		):
+			return
+		for index: int in sprites.size():
+			var at: Vector2i = sprites[index]["position"]
+			var step: int = at.y - Vector2i(first[index]["position"]).y
+			_r.check(
+				step == cursor * Gen2PCBoxPage.CURSOR_STEP,
+				"%s: cursor %d object %d sits %d pixels down, not %d." % [
+					game_id, cursor, index, step,
+					cursor * Gen2PCBoxPage.CURSOR_STEP,
+				]
+			)
+			_r.check(
+				at.x >= left - Gen2Font.TILE and at.x < right \
+					and at.y >= 0 and at.y < Gen2Screen.HEIGHT,
+				"%s: cursor %d object %d is at %s, outside the listing." % [
+					game_id, cursor, index, at,
+				]
+			)
+	_r.check(
+		page.cursor_sprites(0, 0).is_empty(),
+		"%s: a list with nothing in it still draws a cursor." % game_id
+	)
+
+
+## `PCMonInfo`'s column over the whole species run: the pic fits the seven-tile
+## cell and the name fits the eleven columns its two clears cover.
+func _verify_info_column(game_id: StringName, data: GameData) -> void:
+	var cell: int = Gen2PCBoxPage.pic_size()
+	var widest: int = 0
+	var widest_name: String = ""
+	for species: int in range(1, SPECIES_COUNT + 1):
+		var pic: Dictionary = data.species_pic(species)
+		if not _r.check(not pic.is_empty(), "%s: species %d has no pic." % [game_id, species]):
+			continue
+		_r.check(
+			int(pic.get("width", 0)) <= cell and int(pic.get("height", 0)) <= cell,
+			"%s: species %d is %dx%d, past the %dx%d cell." % [
+				game_id, species, int(pic["width"]), int(pic["height"]), cell, cell,
+			]
+		)
+		var name: String = String(data.species(species).get("name", ""))
+		var columns: int = Gen2Text.encoded_length(name, Gen2Text.FONT_BATTLE_EXTRA)
+		if columns > widest:
+			widest = columns
+			widest_name = name
+	_r.check(
+		Gen2PCBoxPage.SPECIES_AT.x + widest <= INFO_COLUMNS + NAME_OVERHANG_COLUMNS,
+		"%s: %s is %d columns and runs past the %d PCMonInfo clears." % [
+			game_id, widest_name, widest, INFO_COLUMNS + NAME_OVERHANG_COLUMNS,
+		]
+	)
+	_r.check(
+		Gen2PCBoxPage.SPECIES_AT.y == NAME_OVERHANG.y \
+			and Gen2PCBoxPage.SPECIES_AT.x + widest <= NAME_OVERHANG.x + NAME_OVERHANG_COLUMNS,
+		"%s: the name row is not the one the second ClearBox covers." % game_id
+	)

--- a/tools/checks/pc.gd.uid
+++ b/tools/checks/pc.gd.uid
@@ -1,0 +1,1 @@
+uid://cao1nb54f3l1

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -37,7 +37,7 @@ const GROUPS: Dictionary = {
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
-		&"pack", &"unown_dex", &"pokedex",
+		&"pack", &"unown_dex", &"pokedex", &"pc",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
The last screen that was waiting on an import has one.

`PCSelectLZ`, `PCMailGFX` and `BillsPCOrangePalette` are imported and each located from its own neighbour: the mail sheet by its assembled bytes, the cursor sheet by decompressing backwards until the run reproduces `gfx/pc/pc.png` and ends where the mail sheet begins, the palette by encoding `orange.pal`. Each hits once per dump and `verify_pc` checks all three before anything decodes.

`game/render/pc_box_page.gd` is `BillsPC_BoxName`'s header box, `BillsPC_RefreshTextboxes`' listing with the two corners that join the two boxes, `PCMonInfo`'s left column and `BillsPC_PlaceString`'s bottom box, read as tile writes. `game/save/box_screen.gd` is the model behind it: `wBillsPC_LoadedBox`, its cursor and its scroll, with the D-pad walking the list and the boxes and A depositing a party row or withdrawing a box one through the same atomic transfers as before.

Two things the source hides in plain sight and this carries: the two profiles' cursors are different sheets *and* different OAM sets, and `PCMonInfo`'s second `ClearBox` exists for the single ten-tile species name. `tools/checks/pc.gd` sweeps all 251 species on all three cartridges for the second.

| Check | Result |
|---|---|
| GUT unit | 2,653 pass |
| GUT with scene tier | 3,000 pass |
| `validate.gd -- all` | every topic PASS, exit 0 |
| `replay_world.gd` | 27 routes, 0 failures |
| Story walk | Gold 291, Silver 291, Crystal 294, 16 badges each |
| Import | Layout verified on all three; cache format 63 |
