### PR TITLE
A mod may put one sprite in the world

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -600,6 +600,50 @@ the four source directions using the source tie-breaking, and pass both to the
 existing interaction path. Smooth movement then leaves an NPC in the
 neighbouring cell interacting exactly as it would on the cartridge.
 
+## Putting one sprite in the world
+
+A mod that wants a follower, a pet, a marker over an object or a ghost of a
+previous run does not need a renderer: it registers a world **actor** and the
+built-in view draws it with the map's own objects.
+
+```gdscript
+func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
+    host.register_world_actor(manifest.id, Follower.new())
+```
+
+The actor is a `RefCounted` and never a `Node`, because it is a pose and not a
+view. Three methods, refused by name at registration the way a renderer's are:
+
+| Method | Called when |
+|---|---|
+| `set_world(world: Gen2WorldAPI)` | The map changed, or the view was created |
+| `advance_frame()` | Once per world frame, after the player's step advanced |
+| `sprites() -> Array` | What to draw now. A read: it is asked once a frame however many times the screen redraws |
+
+Each entry of `sprites()` is a dictionary naming cartridge art and nothing else:
+
+| Key | Meaning |
+|---|---|
+| `icon` | An `IconPointers` row, as `GameData.mon_menu_icon(species)` answers it |
+| `sprite` | An `OverworldSprites` row instead, for an NPC or an object picture |
+| `facing` | `Gen2WorldSprite.FACING_*`. Right is the left picture mirrored, as on the cartridge |
+| `position_cells` | Where to draw it, in fractional walk cells, the unit `player_position_cells()` is in |
+
+The host resolves the strip, the palette, the time of day and the icon's own
+two-frame animation (`.Frameset_PartyMon`'s rate), so a mod never composes
+pixels. An entry naming art the cache does not carry is dropped rather than
+drawn as a placeholder.
+
+An actor's sprite is **presentation**: it occupies no cell, blocks nothing,
+nobody talks to it, no trainer sees it and it is in no snapshot. That is what
+lets it exist at all, since world state is the one thing a mod must not write.
+Actors are sorted into the object pass by the row they stand on, so a follower
+one cell below an NPC is drawn over it.
+
+A registered world renderer that wants to draw them takes them through the
+optional `set_actors(actors: Gen2WorldActors)`, which is handed the same
+resolved list the built-in view draws.
+
 ## Measured against the voxel mod
 
 [DramaticShapeVoxelMod](https://github.com/DramaticShape/DramaticShapeVoxelMod)

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -50,6 +50,11 @@ const RENDERER_RESIZE_METHOD: String = "set_native_size"
 ## map rather than as objects, all of them presentation with no world state
 ## behind them, so a renderer that draws its own effects can ignore it.
 const RENDERER_EFFECTS_METHOD: String = "set_effects"
+## Optional, world renderers only. Called with the screen's [Gen2WorldActors]
+## when the renderer is built. It holds the sprites registered mods put in the
+## world, already resolved to the same [Gen2WorldSprite] the map's own objects
+## are drawn from, so a renderer draws them with its objects or ignores them.
+const RENDERER_ACTORS_METHOD: String = "set_actors"
 ## Optional, battle renderers only. Called with a [Gen2BattleWorldContext] once
 ## per battle, before the first [code]set_view[/code], when the battle was
 ## entered from the world. It is where the fight is happening: a renderer staging
@@ -158,6 +163,10 @@ var _options: Dictionary = {}
 ## Mod id to its registered actions. See [method register_action].
 var _actions: Dictionary = {}
 var _world_renderers: Dictionary = {}
+## Mod id to the world actor it registered. Held for as long as the mod is
+## loaded, the way its entry object is: an actor carries the mod's own state
+## between frames. See [method register_world_actor].
+var _world_actors: Dictionary = {}
 var _selected_world_renderer: StringName = BUILT_IN_RENDERER
 var _battle_renderers: Dictionary = {}
 var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
@@ -224,6 +233,47 @@ func select_world_renderer(id: StringName) -> Dictionary:
 ## built-in one so a screen always has something to draw with.
 func create_world_renderer() -> Node:
 	return _create(_world_renderers, _selected_world_renderer, Gen2WorldRenderer)
+
+
+## Registers a world ACTOR under [param id]: one sprite in the overworld, drawn
+## with the map's own objects.
+##
+## [param actor] is an object and not a script, because an actor is a pose and
+## not a view: the host drives the one it is handed rather than building one per
+## world. It must be a [RefCounted] and never a [Node], and must answer the three
+## methods in [constant Gen2WorldActors.ACTOR_METHODS]; a registration missing
+## one is refused here, where the mod's name is still in hand.
+##
+## What an actor draws is presentation and takes part in nothing else. See
+## [Gen2WorldActors] for the contract and `docs/MODS.md` for the entry shape.
+func register_world_actor(id: StringName, actor: Object) -> Dictionary:
+	if String(id).is_empty() or actor == null:
+		return {"ok": false, "reason": &"invalid_actor"}
+	if actor is Node:
+		return {"ok": false, "reason": &"actor_is_a_node", "detail": String(id)}
+	var missing: Array[String] = []
+	for method: String in Gen2WorldActors.ACTOR_METHODS:
+		if not actor.has_method(method):
+			missing.append(method)
+	if not missing.is_empty():
+		return {
+			"ok": false, "reason": &"actor_missing_methods",
+			"detail": "%s: %s" % [id, ", ".join(missing)],
+		}
+	if _world_actors.has(id):
+		return {"ok": false, "reason": &"duplicate_actor", "detail": String(id)}
+	_world_actors[id] = actor
+	return {"ok": true, "id": id}
+
+
+func world_actor_ids() -> Array:
+	return _world_actors.keys()
+
+
+## Every registered actor, in registration order, which is the order two standing
+## on one row are drawn in.
+func world_actors() -> Array:
+	return _world_actors.values()
 
 
 ## Registers a battle renderer under [param id]. See

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -1,0 +1,164 @@
+class_name Gen2WorldActors
+extends RefCounted
+
+## The sprites a mod puts in the world, driven and resolved by the host.
+##
+## A mod that wants one thing in the overworld, a follower, a pet, a marker over
+## an object, registers a world ACTOR through
+## [method Gen2ModHost.register_world_actor] rather than a whole world renderer.
+## This class is what the screen drives it with: one `advance_frame` per world
+## frame, one `sprites()` read after it, and the answer resolved into the same
+## [Gen2WorldSprite] the map's own objects are drawn from.
+##
+## PRESENTATION and nothing else. An actor's sprite occupies no cell, blocks
+## nothing, is talked to by nobody, is seen by no trainer and appears in no
+## snapshot. That is the whole reason this is a layer of its own rather than a
+## map object: a mod must not be able to change what the cartridge says the
+## world is, and an object is world state.
+##
+## A mod names cartridge art and never composes pixels: an entry carries an
+## `IconPointers` row (`icon`), or an `OverworldSprites` row (`sprite`), and the
+## strip, the palette, the time of day and the icon's own animation rate are
+## resolved here exactly as they are for a mon-icon object standing on a map.
+
+## The methods an actor has to provide. Checked at registration, where the mod's
+## name is still in hand, the way a renderer's are.
+const ACTOR_METHODS: Array[String] = ["set_world", "advance_frame", "sprites"]
+
+## `.Frameset_PartyMon`, the icon's own two-frame animation: two OAM sets of
+## eight, which is nine passes each because `GetSpriteAnimFrame` returns the
+## entry on the pass that loads the duration too. An actor is not a party row,
+## so it takes the unmodified speed rather than
+## `SetPartyMonIconAnimSpeed`'s hurt-Pokemon slowdown.
+const ICON_FRAME_FRAMES: int = 9
+const ICON_FRAMES: int = 2
+
+var _actors: Array = []
+var _world: Gen2WorldAPI = null
+## What the last `advance_frame` collected. Held rather than re-read, so two
+## views drawing the same frame draw the same thing and a mod's `sprites()` is
+## asked once a frame however many times the screen redraws.
+var _sprites: Array = []
+var _frame: int = 0
+
+
+## [param actors] is [method Gen2ModHost.world_actors], in registration order,
+## which is the order they are drawn in within one row.
+func set_actors(actors: Array) -> void:
+	_actors = actors
+	_collect()
+
+
+func has_actors() -> bool:
+	return not _actors.is_empty()
+
+
+## The map changed, or the view was created.
+func set_world(world: Gen2WorldAPI) -> void:
+	_world = world
+	for actor: Object in _actors:
+		actor.call("set_world", world)
+	_collect()
+
+
+## One world frame, spent after the player's own step has advanced so an actor
+## reading `player_step_offset_cells()` sees this frame's position rather than
+## the last one's. Answers whether anything it draws moved.
+func advance_frame() -> bool:
+	if _actors.is_empty():
+		return false
+	_frame += 1
+	for actor: Object in _actors:
+		actor.call("advance_frame")
+	var before: Array = _sprites
+	_collect()
+	return _changed(before, _sprites)
+
+
+## What to draw now, as { sprite, facing, frame, position_cells }, sorted the way
+## the map's own objects are: by the row they stand on, then by the order they
+## were registered in.
+func sprites() -> Array:
+	return _sprites
+
+
+func _collect() -> void:
+	_sprites = []
+	if _world == null or _world.data == null:
+		return
+	for index: int in _actors.size():
+		for entry: Variant in _actors[index].call("sprites"):
+			var resolved: Dictionary = _resolve(entry, index)
+			if not resolved.is_empty():
+				_sprites.append(resolved)
+	_sprites.sort_custom(_sort)
+
+
+## One entry of a mod's answer. An entry naming art the cache does not carry is
+## dropped rather than drawn as a placeholder: a mod asking for a species icon
+## on a cartridge that has none should show nothing, not a magenta square.
+func _resolve(entry: Variant, order: int) -> Dictionary:
+	if not entry is Dictionary:
+		return {}
+	var row: Dictionary = entry as Dictionary
+	var sprite: Gen2WorldSprite = null
+	if row.has("icon"):
+		sprite = _world.data.overworld_icon(int(row["icon"]))
+		if sprite != null:
+			## A map object's icon never animates: `GetUsedSprite` copies its
+			## eight tiles into both VRAM halves, so the walking rows of
+			## `Facings` land on the same picture. An actor is not a map object
+			## and asks for the two frames the strip carries.
+			sprite.animate_icon_frames = true
+	elif row.has("sprite"):
+		sprite = _world.data.overworld_sprite(int(row["sprite"]))
+	if sprite == null:
+		return {}
+	var facing: int = clampi(
+		int(row.get("facing", Gen2WorldSprite.FACING_DOWN)),
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
+	)
+	return {
+		"sprite": sprite,
+		"facing": facing,
+		"frame": _frame_for(sprite),
+		"position_cells": Vector2(row.get("position_cells", Vector2.ZERO)),
+		"order": order,
+	}
+
+
+## Which of the sprite's frames is up this frame. A mon icon steps through its
+## own two at `.Frameset_PartyMon`'s rate; anything else is drawn standing,
+## since only the actor knows whether it is moving and `Facings`' walking rows
+## belong to a step this layer does not take.
+func _frame_for(sprite: Gen2WorldSprite) -> int:
+	if sprite.sprite_type != Gen2WorldSprite.TYPE_MON_ICON:
+		return 0
+	@warning_ignore("integer_division")
+	var step: int = (_frame / ICON_FRAME_FRAMES) % ICON_FRAMES
+	## Frame 1 is `Gen2WorldSprite.is_walking_frame`'s own, which is what reads
+	## the strip's second half.
+	return step
+
+
+func _sort(first: Dictionary, second: Dictionary) -> bool:
+	var first_y: float = (first["position_cells"] as Vector2).y
+	var second_y: float = (second["position_cells"] as Vector2).y
+	if is_equal_approx(first_y, second_y):
+		return int(first["order"]) < int(second["order"])
+	return first_y < second_y
+
+
+func _changed(before: Array, after: Array) -> bool:
+	if before.size() != after.size():
+		return true
+	for index: int in before.size():
+		var was: Dictionary = before[index]
+		var now: Dictionary = after[index]
+		if was["position_cells"] != now["position_cells"] \
+			or int(was["facing"]) != int(now["facing"]) \
+			or int(was["frame"]) != int(now["frame"]) \
+			or (was["sprite"] as Gen2WorldSprite).number \
+				!= (now["sprite"] as Gen2WorldSprite).number:
+			return true
+	return false

--- a/game/world/world_actors.gd.uid
+++ b/game/world/world_actors.gd.uid
@@ -1,0 +1,1 @@
+uid://oof8s8omijd7

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -11,6 +11,7 @@ const FALLBACK_BACKGROUND: Color = Color("#f5f1d8")
 var _world: Gen2WorldAPI = null
 var _animation: Gen2WorldAnimation = null
 var _effects: Gen2WorldEffects = null
+var _actors: Gen2WorldActors = null
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var _atlas: ImageTexture = null
 ## Kept beside the texture so an animation frame can repaint the one or two
@@ -38,6 +39,14 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 ## renderer may be handed null and draw none of them.
 func set_effects(effects: Gen2WorldEffects) -> void:
 	_effects = effects
+	queue_redraw()
+
+
+## Gen2ModHost.RENDERER_ACTORS_METHOD: the sprites registered mods put in the
+## world. Presentation only, drawn with the map's own objects and taking part in
+## nothing else, so a renderer may be handed null and draw none of them.
+func set_actors(actors: Gen2WorldActors) -> void:
+	_actors = actors
 	queue_redraw()
 
 
@@ -173,9 +182,24 @@ func _draw() -> void:
 				Rect2(Vector2(tile * Gen2Tiles.TILE_WIDTH, 0), Vector2(8, 8)),
 			)
 
-	var actors: Array = _world.visible_objects()
-	actors.sort_custom(_sort_objects)
-	for object: Gen2WorldObject in actors:
+	var objects: Array = _world.visible_objects()
+	objects.sort_custom(_sort_objects)
+	## A mod's actors are drawn in the same pass and sorted into the same rows:
+	## a follower one cell below an NPC has to be drawn over it, and one cell
+	## above it under it. They carry no emote, no effect sprite and no grass of
+	## their own beyond the tuft the map draws over anything standing in it.
+	var drawn: Array = []
+	for object: Gen2WorldObject in objects:
+		drawn.append({"object": object, "row": float(object.cell.y)})
+	if _actors != null:
+		for sprite: Dictionary in _actors.sprites():
+			drawn.append({"actor": sprite, "row": (sprite["position_cells"] as Vector2).y})
+	drawn.sort_custom(_sort_drawn)
+	for entry: Dictionary in drawn:
+		if entry.has("actor"):
+			_draw_actor(entry["actor"], camera_pixels, page, tile_origin, tile_offset, window_size)
+			continue
+		var object: Gen2WorldObject = entry["object"]
 		var pixel: Vector2 = Vector2(object.cell * Gen2WorldAPI.CELL_PIXELS) \
 			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS)) - camera_pixels
 		var texture: Texture2D = _actor_texture(
@@ -246,6 +270,35 @@ func _actor_texture(
 	var texture: Texture2D = ImageTexture.create_from_image(image)
 	_actor_textures[key] = texture
 	return texture
+
+
+## One mod actor, drawn from the [Gen2WorldSprite] the actor layer resolved for
+## it. Its position is in walk cells, the unit `player_position_cells()` is in,
+## so a follower halfway through a step is drawn halfway.
+func _draw_actor(
+	sprite: Dictionary, camera_pixels: Vector2, page: PackedInt32Array,
+	tile_origin: Vector2i, tile_offset: Vector2, window_size: Vector2i
+) -> void:
+	var position: Vector2 = sprite["position_cells"]
+	var pixel: Vector2 = position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels
+	var texture: Texture2D = _actor_texture(
+		sprite["sprite"], 0, int(sprite["facing"]), int(sprite["frame"])
+	)
+	if texture == null:
+		return
+	draw_texture(texture, pixel)
+	if _in_grass(Vector2i(roundi(position.x), roundi(position.y))):
+		_draw_grass_over(pixel, page, tile_origin, tile_offset, window_size)
+
+
+## The object pass's own order, with a mod's actors sorted into it: the row a
+## thing stands on, then the map's objects before any actor on that row.
+func _sort_drawn(first: Dictionary, second: Dictionary) -> bool:
+	if is_equal_approx(float(first["row"]), float(second["row"])):
+		if first.has("object") and second.has("object"):
+			return _sort_objects(first["object"], second["object"])
+		return first.has("object")
+	return float(first["row"]) < float(second["row"])
 
 
 func _sort_objects(first: Gen2WorldObject, second: Gen2WorldObject) -> bool:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -59,6 +59,9 @@ var _world: Gen2WorldAPI = null
 var _renderer: Node = null
 var _animation: Gen2WorldAnimation = null
 var _effects: Gen2WorldEffects = null
+## The sprites registered mods put in the world, driven a frame at a time here
+## and drawn by the renderer with the map's own objects.
+var _actors: Gen2WorldActors = null
 ## The headbutt result waiting for ShakeHeadbuttTree's 32 frames to be spent.
 var _pending_headbutt_finish: Dictionary = {}
 var _text_box: Gen2TextBox = null
@@ -227,6 +230,8 @@ func _build_world() -> void:
 	time_of_day = _clock.time_of_day()
 	_animation = Gen2WorldAnimation.new()
 	_effects = Gen2WorldEffects.new()
+	_actors = Gen2WorldActors.new()
+	_actors.set_actors(Gen2ModHost.instance().world_actors())
 	## The cut leaves ride BattleAnimSineWave, which is cartridge data rather
 	## than a table this could derive.
 	_effects.set_sine_table(Gen2BattleAnimData.from_game_data(_data))
@@ -282,9 +287,24 @@ func _build_renderer() -> void:
 		_on_native_size_changed(_screen.native_size())
 	if _renderer.has_method(Gen2ModHost.RENDERER_EFFECTS_METHOD):
 		_renderer.call(Gen2ModHost.RENDERER_EFFECTS_METHOD, _effects)
-	_renderer.set_world(_world, _animation)
+	if _renderer.has_method(Gen2ModHost.RENDERER_ACTORS_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_ACTORS_METHOD, _actors)
+	_set_renderer_world()
 	_renderer.set_time_of_day(_render_time_of_day())
 	_apply_renderer_interface_style()
+
+
+## The map under the player changed, or the view was created: the renderer and
+## the mod actors are both told, since an actor is handed the same
+## [Gen2WorldAPI] a renderer is and has to drop whatever it was following on the
+## map it has just left.
+func _set_renderer_world() -> void:
+	if _world == null:
+		return
+	if _renderer != null:
+		_renderer.set_world(_world, _animation)
+	if _actors != null:
+		_actors.set_world(_world)
 
 
 ## The text box is the screen's, not the renderer's, and over a native-layer view
@@ -392,6 +412,10 @@ func advance_frame() -> void:
 	if _world != null and _world.advance_player_step_frame() and _renderer != null:
 		_renderer.refresh()
 	if _world != null and _world.advance_emotes_frame() and _renderer != null:
+		_renderer.refresh()
+	## After the player's own step, so an actor reading
+	## `player_step_offset_cells()` sees this frame rather than the last one's.
+	if _actors != null and _actors.advance_frame() and _renderer != null:
 		_renderer.refresh()
 	_advance_forced_movement()
 	_advance_held_direction()
@@ -844,7 +868,7 @@ func _after_player_move(movement: Dictionary) -> bool:
 	if _renderer != null:
 		if bool(transition.get("ok", false)) and transition.get("kind", &"") != &"move":
 			_animation.configure(_world, time_of_day)
-			_renderer.set_world(_world, _animation)
+			_set_renderer_world()
 			_play_current_map_music()
 		else:
 			_renderer.refresh()
@@ -3008,7 +3032,7 @@ func _show_script_results(results: Array) -> void:
 		if map_changed:
 			_world.reload_current_map()
 			_animation.configure(_world, time_of_day)
-			_renderer.set_world(_world, _animation)
+			_set_renderer_world()
 			_renderer.set_time_of_day(_render_time_of_day())
 			_play_current_map_music()
 		else:
@@ -3024,8 +3048,8 @@ func _refresh_after_escape() -> void:
 	if _world == null:
 		return
 	_animation.configure(_world, time_of_day)
+	_set_renderer_world()
 	if _renderer != null:
-		_renderer.set_world(_world, _animation)
 		_renderer.set_time_of_day(_render_time_of_day())
 	_play_current_map_music()
 	_refresh_labels()

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -25,6 +25,11 @@ const FACING_RIGHT: int = 3
 ## `GetUsedSprite` copies that many twice; see [method frame_tile_offset].
 const WALKING_HALF_TILES: int = 12
 
+## Tiles in one frame of a mon icon. `LoadOverworldMonIcon` asks for eight, which
+## is the two `.Frameset_PartyMon` steps through; see [member
+## animate_icon_frames] for why only an actor gets the second.
+const MON_ICON_FRAME_TILES: int = 4
+
 ## data/sprites/player_sprites.asm's ChrisStateSprites and KrisStateSprites, the
 ## wPlayerState to sprite lookup GetPlayerSprite walks. ChrisStateSprites is
 ## identical in both pins and the numbers themselves
@@ -78,6 +83,13 @@ var tiles: int = 0
 var sprite_type: int = TYPE_STILL
 var default_palette: int = 0
 var icon_number: int = 0
+## Whether a mon icon's two 4-tile frames are both drawn. False for a map
+## object, because the cartridge does not animate one: `GetUsedSprite` copies an
+## icon's eight tiles into `vTiles0` and `vTiles1` both, so the walking rows of
+## `Facings` land on the same picture and the object shows its first frame
+## forever. A mod's world actor is not a map object and asks for the animation
+## the strip carries, which is the two frames `Gen2PartyMenuPage` steps through.
+var animate_icon_frames: bool = false
 
 
 static func from_cache(value: Dictionary) -> Gen2WorldSprite:
@@ -128,7 +140,10 @@ func is_walking() -> bool:
 ## does frame 3 of down and up: `FacingStepDown3` is `FacingStepDown1` with
 ## `OAM_XFLIP` on every tile and its two columns swapped.
 func frame_tile_offset(facing: int, frame: int) -> int:
-	if tiles <= 4 or sprite_type in [TYPE_STILL, TYPE_MON_ICON]:
+	if sprite_type == TYPE_MON_ICON:
+		return MON_ICON_FRAME_TILES if animate_icon_frames and is_walking_frame(frame) \
+			and tiles >= MON_ICON_FRAME_TILES * 2 else 0
+	if tiles <= 4 or sprite_type == TYPE_STILL:
 		return 0
 	var facing_index: int = clampi(facing, FACING_DOWN, FACING_RIGHT)
 	if facing_index == FACING_RIGHT:

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -1,8 +1,9 @@
 extends GutTest
 
 ## The interface seam a native-layer renderer gets: how opaque the screen draws
-## its own text box, and where that box is. Both screens are the production
-## paths; only the renderer is synthetic.
+## its own text box, and where that box is, plus the seam a mod's world actor
+## gets, which is the same shape one layer down. Both screens are the production
+## paths; only the renderer and the actor are synthetic.
 ##
 ## The contract is that the box stays the screen's. A renderer asks and is told;
 ## it never draws or moves the box, and the frame and the glyphs are opaque
@@ -176,3 +177,47 @@ func test_the_battle_screen_opens_the_same_seam() -> void:
 		(renderer.get("rects") as Array).back(),
 		Rect2i(0, Gen2TextBox.STANDARD_TOP * Gen2Font.TILE, 160, 48)
 	)
+
+
+## A mod's world actor, driven by the screen rather than by a view: the world it
+## is handed, one advance per world frame, and the resolved sprites reaching the
+## renderer that draws them.
+const ACTOR_SOURCE: String = """extends RefCounted
+
+var world = null
+var frames: int = 0
+
+func set_world(value) -> void:
+	world = value
+
+func advance_frame() -> void:
+	frames += 1
+
+func sprites() -> Array:
+	return [{"icon": 1, "position_cells": Vector2(3, 4)}]
+"""
+
+
+func test_a_registered_world_actor_is_driven_by_the_screen_and_drawn_by_the_view() -> void:
+	var actor: Object = _script(ACTOR_SOURCE).new()
+	assert_true(Gen2ModHost.instance().register_world_actor(&"follower", actor)["ok"])
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	## The screen owns the frames it spends, so take its processing away before
+	## counting them.
+	_world_screen.set_process(false)
+	assert_eq(actor.get("world"), _world_screen._world)
+	var before: int = int(actor.get("frames"))
+	_world_screen.advance_frames(3)
+	assert_eq(int(actor.get("frames")), before + 3)
+	var drawn: Array = _world_screen._actors.sprites()
+	assert_eq(drawn.size(), 1)
+	assert_eq((drawn[0]["sprite"] as Gen2WorldSprite).icon_number, 1)
+	assert_eq(drawn[0]["position_cells"], Vector2(3, 4))
+	assert_eq(_world_screen._renderer._actors, _world_screen._actors)

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -249,6 +249,77 @@ func test_the_built_in_battle_renderer_is_registered_before_any_mod_loads() -> v
 	renderer.free()
 
 
+## A world actor is one sprite in the world rather than a view of it, so it is
+## an object and not a script and the host holds the one it is handed.
+func test_a_discovered_mod_registers_a_world_actor_the_screen_then_drives() -> void:
+	var directory: String = "%s/follower" % ROOT
+	DirAccess.make_dir_recursive_absolute(directory)
+	var manifest: Dictionary = _valid_manifest()
+	manifest["id"] = "follower"
+	_write("%s/mod.json" % directory, JSON.stringify(manifest))
+	_write("%s/actor.gd" % directory, """extends RefCounted
+
+var _world = null
+
+func set_world(world) -> void:
+	_world = world
+
+func advance_frame() -> void:
+	pass
+
+func sprites() -> Array:
+	return [{"icon": 1, "position_cells": Vector2(2, 3)}]
+""")
+	_write("%s/mod.gd" % directory, """extends RefCounted
+
+func register(host, manifest) -> void:
+	host.register_world_actor(manifest.id, load("%s/actor.gd").new())
+""" % directory)
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(host.discover(ROOT).size(), 1)
+	assert_eq(host.load_discovered(), [&"follower"])
+	assert_eq(host.world_actor_ids(), [&"follower"])
+	var actors: Array = host.world_actors()
+	assert_eq(actors.size(), 1)
+	assert_eq((actors[0].call("sprites")[0] as Dictionary)["icon"], 1)
+	## The host keeps it for as long as the mod is loaded: an actor carries the
+	## mod's own state between frames.
+	assert_eq(host.world_actors()[0], actors[0])
+
+
+func test_a_world_actor_missing_a_contract_method_is_refused_at_registration() -> void:
+	var script := GDScript.new()
+	# Has set_world and sprites, but not advance_frame.
+	script.source_code = "extends RefCounted\nfunc set_world(_w) -> void:\n\tpass\nfunc sprites() -> Array:\n\treturn []\n"
+	script.reload()
+	var result: Dictionary = Gen2ModHost.instance().register_world_actor(&"broken", script.new())
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"actor_missing_methods")
+	assert_string_contains(String(result["detail"]), "advance_frame")
+
+
+## A follower is a pose, not a scene, so a node is refused rather than parented
+## somewhere it would outlive the map.
+func test_a_world_actor_that_is_a_node_is_refused() -> void:
+	var node := Node2D.new()
+	var result: Dictionary = Gen2ModHost.instance().register_world_actor(&"node", node)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"actor_is_a_node")
+	node.free()
+
+
+func test_two_mods_cannot_claim_one_world_actor_id() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var script := GDScript.new()
+	script.source_code = "extends RefCounted\nfunc set_world(_w) -> void:\n\tpass\nfunc advance_frame() -> void:\n\tpass\nfunc sprites() -> Array:\n\treturn []\n"
+	script.reload()
+	assert_true(bool(host.register_world_actor(&"first", script.new()).get("ok", false)))
+	var second: Dictionary = host.register_world_actor(&"first", script.new())
+	assert_false(second["ok"])
+	assert_eq(second["reason"], &"duplicate_actor")
+
+
 func test_a_battle_renderer_missing_a_contract_method_is_refused_at_registration() -> void:
 	var script := GDScript.new()
 	# Has set_battle_data and refresh, but not set_view.

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -157,3 +157,136 @@ func _sine_bytes() -> PackedByteArray:
 	for value: int in RomLayout.BATTLE_ANIM_SINE_WAVE:
 		out.append(value)
 	return out
+
+
+## The mod actor layer, which is the other half of this file's subject: sprites
+## the screen drives a frame at a time and the renderer draws, with no world
+## state behind them. Its own contract is Gen2WorldActors.
+const ActorFixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+
+class TestActor extends RefCounted:
+	var world: Gen2WorldAPI = null
+	var frames: int = 0
+	var reads: int = 0
+	var out: Array = []
+
+	func set_world(value: Gen2WorldAPI) -> void:
+		world = value
+
+	func advance_frame() -> void:
+		frames += 1
+
+	func sprites() -> Array:
+		reads += 1
+		return out
+
+
+func _actor_world() -> Gen2WorldAPI:
+	ActorFixture.build()
+	return Gen2WorldAPI.open(
+		GameData.open_directory(ActorFixture.directory()), 1, 1, Vector2i(4, 4)
+	)
+
+
+func test_an_actors_entry_is_resolved_to_the_sprite_the_map_objects_use() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{
+		"icon": 1, "facing": Gen2WorldSprite.FACING_LEFT,
+		"position_cells": Vector2(4, 5.5),
+	}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_eq(actor.world, world)
+	var drawn: Array = actors.sprites()
+	assert_eq(drawn.size(), 1)
+	var sprite: Gen2WorldSprite = drawn[0]["sprite"]
+	assert_eq(sprite.sprite_type, Gen2WorldSprite.TYPE_MON_ICON)
+	assert_eq(sprite.icon_number, 1)
+	assert_true(sprite.animate_icon_frames, "an actor's icon animates, a map object's does not")
+	assert_eq(drawn[0]["facing"], Gen2WorldSprite.FACING_LEFT)
+	assert_eq(drawn[0]["position_cells"], Vector2(4, 5.5))
+	RomCache.clear(ActorFixture.directory())
+
+
+## `.Frameset_PartyMon`: two sets of eight, nine passes each.
+func test_an_icon_actor_steps_the_strips_two_frames_at_the_framesets_rate() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{"icon": 1, "position_cells": Vector2.ZERO}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_eq(int(actors.sprites()[0]["frame"]), 0)
+	for _frame: int in Gen2WorldActors.ICON_FRAME_FRAMES:
+		actors.advance_frame()
+	assert_eq(int(actors.sprites()[0]["frame"]), 1)
+	var sprite: Gen2WorldSprite = actors.sprites()[0]["sprite"]
+	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_DOWN, 1), 4)
+	for _frame: int in Gen2WorldActors.ICON_FRAME_FRAMES:
+		actors.advance_frame()
+	assert_eq(int(actors.sprites()[0]["frame"]), 0)
+	assert_eq(actor.frames, Gen2WorldActors.ICON_FRAME_FRAMES * 2)
+	RomCache.clear(ActorFixture.directory())
+
+
+## A map object's icon is copied into both VRAM halves, so it shows one frame
+## forever; only an actor asks for the second.
+func test_a_map_objects_icon_never_reaches_the_strips_second_frame() -> void:
+	var sprite: Gen2WorldSprite = Gen2WorldSprite.from_mon_icon(1)
+	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_DOWN, 1), 0)
+	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_UP, 3), 0)
+
+
+func test_actor_sprites_are_sorted_by_row_and_read_once_a_frame() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [
+		{"icon": 1, "position_cells": Vector2(0, 6)},
+		{"icon": 2, "position_cells": Vector2(0, 2)},
+	]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	var reads: int = actor.reads
+	var drawn: Array = actors.sprites()
+	assert_eq((drawn[0]["sprite"] as Gen2WorldSprite).icon_number, 2)
+	assert_eq((drawn[1]["sprite"] as Gen2WorldSprite).icon_number, 1)
+	actors.sprites()
+	assert_eq(actor.reads, reads, "a second draw in one frame asks the mod nothing")
+	RomCache.clear(ActorFixture.directory())
+
+
+## Art the cache does not carry is dropped rather than drawn as a placeholder,
+## and an entry naming neither an icon nor a sprite is not an entry.
+func test_an_actor_naming_art_that_is_not_there_draws_nothing() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [
+		{"icon": 0, "position_cells": Vector2.ZERO},
+		{"icon": RomLayout.MON_ICON_COUNT + 1, "position_cells": Vector2.ZERO},
+		{"position_cells": Vector2.ZERO},
+		"not a sprite",
+	]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_eq(actors.sprites().size(), 0)
+	RomCache.clear(ActorFixture.directory())
+
+
+## Whether the screen has to redraw: a still actor costs nothing beyond the
+## icon's own animation.
+func test_an_actor_that_has_not_moved_reports_no_redraw() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{"icon": 1, "position_cells": Vector2(3, 3)}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_false(actors.advance_frame())
+	actor.out = [{"icon": 1, "position_cells": Vector2(3, 3.5)}]
+	assert_true(actors.advance_frame())
+	RomCache.clear(ActorFixture.directory())


### PR DESCRIPTION
R16. A mod could register a world renderer, a battle renderer, content, a menu entry, a setting, a control and an event subscriber, but not ONE sprite in the overworld the built-in view draws. That blocked a follower and every mod of that shape.

`Gen2ModHost.register_world_actor(id, actor)` takes a `RefCounted` answering `set_world`, `advance_frame` and `sprites`, refused by name at registration the way a renderer's methods are, and refused outright for a `Node`: an actor is a pose, not a view. The host keeps the object for as long as the mod is loaded.

`Gen2WorldActors` is what `Gen2WorldScreen` drives it with, one advance per world frame after the player's own step so an actor reading `player_step_offset_cells()` sees this frame. Each entry names cartridge art and no more:

| Key | Meaning |
|---|---|
| `icon` | An `IconPointers` row, as `GameData.mon_menu_icon()` answers it |
| `sprite` | An `OverworldSprites` row instead |
| `facing` | `Gen2WorldSprite.FACING_*` |
| `position_cells` | Fractional walk cells, the unit `player_position_cells()` is in |

The host resolves the strip, the palette, the time of day and the icon's own animation rate. The built-in renderer draws actors in the object pass sorted into the same rows; a registered renderer takes them through the optional `set_actors` and one without it draws none. Presentation only: no cell, no collision, no interaction, no sight, nothing saved.

Also in the ask: a mon icon's second frame was unreachable. It is unreachable *for a map object* on the cartridge too, because `GetUsedSprite` copies an icon's eight tiles into both VRAM halves, so `Gen2WorldSprite.animate_icon_frames` is what an actor sets to get the two frames the strip carries, at `.Frameset_PartyMon`'s rate. A map object never sets it and is unchanged.

| Check | Result |
|---|---|
| GUT unit | 2,663 pass |
| GUT with scene tier | 3,011 pass |
| `replay_world.gd` | 27 routes, 0 failures |
| Boot smoke, with mods | exit 0 |
| End to end | a real mod loaded from `user://mods`, registering through `register_world_actor`, drawn on Crystal beside the map's own objects |

`docs/MODS.md` carries the contract under "Putting one sprite in the world".
