### PR TITLE
The radio card reads its programmes

### DIFF
--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -253,9 +253,19 @@ static func _clock_reading(hour: int, minute: int) -> String:
 	return "%2d:%02d %s" % [reading, posmod(minute, 60), "AM" if hour24 < 12 else "PM"]
 
 
-## `.Radio`, whose card prints nothing but the tuned station's own name.
-func radio_tilemap(owned: Array, station: String) -> PackedInt32Array:
+## `.Radio`: the tuned station's own name under the dial, and whatever
+## [Gen2RadioShow] has printed into the two box rows.
+func radio_tilemap(
+	owned: Array, station: String, lines: PackedStringArray = PackedStringArray()
+) -> PackedInt32Array:
 	var map: PackedInt32Array = _card_base(&"radio", "")
+	# Drawn row by row rather than as one `\n` text: a show whose top row is
+	# still empty must leave the bottom one where it is, and `_draw_textbox`
+	# closes the gap instead.
+	for line: int in lines.size():
+		_draw_string(
+			map, CARD_TEXT_AT + Vector2i(0, line * CARD_TEXT_SPACING), lines[line]
+		)
 	if not station.is_empty():
 		_draw_string(map, RADIO_STATION_AT, station)
 	_draw_card_icons(map, owned)

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -72,6 +72,7 @@ var _hour: int = 0
 var _minute: int = 0
 var _knob: int = 0
 var _station: String = ""
+var _show_lines: PackedStringArray = PackedStringArray()
 var _text: String = ""
 ## `PokegearAskDeleteText`, which replaces the card's question while the yes/no
 ## box is up.
@@ -148,10 +149,14 @@ func set_clock(weekday: int, hour: int, minute: int) -> void:
 	_refresh()
 
 
-## `wRadioTuningKnob` and whatever `UpdateRadioStation` last placed for it.
-func set_radio(knob: int, station: String) -> void:
+## `wRadioTuningKnob`, whatever `UpdateRadioStation` last placed for it, and the
+## two rows [Gen2RadioShow] has printed into the card's text box.
+func set_radio(
+	knob: int, station: String, lines: PackedStringArray = PackedStringArray()
+) -> void:
 	_knob = knob
 	_station = station
+	_show_lines = lines
 	_refresh()
 
 
@@ -387,7 +392,7 @@ func _background_image() -> Image:
 
 func _tilemap() -> PackedInt32Array:
 	if _card == CARD_RADIO:
-		return _page.radio_tilemap(_owned, _station)
+		return _page.radio_tilemap(_owned, _station, _show_lines)
 	if _card != CARD_PHONE:
 		return _page.clock_tilemap(_owned, _weekday, _hour, _minute, _text)
 	var map: PackedInt32Array = _page.phone_tilemap(

--- a/game/world/radio_show.gd
+++ b/game/world/radio_show.gd
@@ -1,0 +1,907 @@
+class_name Gen2RadioShow
+extends RefCounted
+
+## `engine/pokegear/radio.asm`: the words a tuned station prints into the radio
+## card's text box, one line at a time.
+##
+## [Gen2WorldRadio] is the dial, its availability rules and the music a station
+## commits. This is the layer above it: `RadioJumptable`, dispatched once a
+## hardware frame the way `PlayRadioShow` is, with `PrintRadioLine`,
+## `NextRadioLine` and `RadioScroll` as the whole of its output.
+##
+## Scene-free and injected with its own generator, like the rest of the world:
+## a caller hands it the facts the source reads off WRAM and spends frames.
+##
+## Segments are named after the source's own labels rather than numbered,
+## because the numbers are profile split: Gold and Silver ship no Buena's
+## Password, so every segment past `$04` in their jumptable sits fifteen lower.
+
+## `wCurRadioLine`'s own RADIO_SCROLL entry, which every printing segment leaves
+## behind it.
+const SCROLL: StringName = &"RadioScroll"
+## `PrintRadioLine` and `PlaceRadioString` both wait 100 frames; only
+## `OaksPKMNTalk14`'s restart uses a different one.
+const LINE_FRAMES: int = 100
+const RESTART_FRAMES: int = 10
+
+## `RadioJumptable` in table order, which is the whole state space. The three
+## music-only stations answer no segment past their first.
+const SEGMENTS: Array[StringName] = [
+	&"OaksPKMNTalk1", &"PokedexShow1", &"BenMonMusic1", &"LuckyNumberShow1",
+	&"BuenasPassword1", &"PeoplePlaces1", &"FernMonMusic1", &"RocketRadio1",
+	&"PokeFluteRadio", &"UnownRadio", &"EvolutionRadio",
+	&"OaksPKMNTalk2", &"OaksPKMNTalk3", &"OaksPKMNTalk4", &"OaksPKMNTalk5",
+	&"OaksPKMNTalk6", &"OaksPKMNTalk7", &"OaksPKMNTalk8", &"OaksPKMNTalk9",
+	&"PokedexShow2", &"PokedexShow3", &"PokedexShow4", &"PokedexShow5",
+	&"BenMonMusic2", &"BenMonMusic3", &"BenFernMusic4", &"BenFernMusic5",
+	&"BenFernMusic6", &"BenFernMusic7", &"FernMonMusic2",
+	&"LuckyNumberShow2", &"LuckyNumberShow3", &"LuckyNumberShow4",
+	&"LuckyNumberShow5", &"LuckyNumberShow6", &"LuckyNumberShow7",
+	&"LuckyNumberShow8", &"LuckyNumberShow9", &"LuckyNumberShow10",
+	&"LuckyNumberShow11", &"LuckyNumberShow12", &"LuckyNumberShow13",
+	&"LuckyNumberShow14", &"LuckyNumberShow15",
+	&"PeoplePlaces2", &"PeoplePlaces3", &"PeoplePlaces4", &"PeoplePlaces5",
+	&"PeoplePlaces6", &"PeoplePlaces7",
+	&"RocketRadio2", &"RocketRadio3", &"RocketRadio4", &"RocketRadio5",
+	&"RocketRadio6", &"RocketRadio7", &"RocketRadio8", &"RocketRadio9",
+	&"RocketRadio10",
+	&"OaksPKMNTalk10", &"OaksPKMNTalk11", &"OaksPKMNTalk12", &"OaksPKMNTalk13",
+	&"OaksPKMNTalk14",
+	&"BuenasPassword2", &"BuenasPassword3", &"BuenasPassword4",
+	&"BuenasPassword5", &"BuenasPassword6", &"BuenasPassword7",
+	&"BuenasPassword8", &"BuenasPassword9", &"BuenasPassword10",
+	&"BuenasPassword11", &"BuenasPassword12", &"BuenasPassword13",
+	&"BuenasPassword14", &"BuenasPassword15", &"BuenasPassword16",
+	&"BuenasPassword17", &"BuenasPassword18", &"BuenasPassword19",
+	&"BuenasPassword20", &"BuenasPassword21",
+	SCROLL,
+	&"PokedexShow6", &"PokedexShow7", &"PokedexShow8",
+]
+
+## The segment each channel's `LoadStation_` jumps to, by canonical channel id.
+const CHANNEL_ENTRY: Dictionary = {
+	Gen2WorldRadio.OAKS_POKEMON_TALK: &"OaksPKMNTalk1",
+	Gen2WorldRadio.POKEDEX_SHOW: &"PokedexShow1",
+	Gen2WorldRadio.POKEMON_MUSIC: &"BenMonMusic1",
+	Gen2WorldRadio.LUCKY_CHANNEL: &"LuckyNumberShow1",
+	Gen2WorldRadio.BUENAS_PASSWORD: &"BuenasPassword1",
+	Gen2WorldRadio.PLACES_AND_PEOPLE: &"PeoplePlaces1",
+	Gen2WorldRadio.LETS_ALL_SING: &"FernMonMusic1",
+	Gen2WorldRadio.ROCKET_RADIO: &"RocketRadio1",
+	Gen2WorldRadio.POKE_FLUTE_RADIO: &"PokeFluteRadio",
+	Gen2WorldRadio.UNOWN_RADIO: &"UnownRadio",
+	Gen2WorldRadio.EVOLUTION_RADIO: &"EvolutionRadio",
+}
+
+## `data/text/common_1.asm`, which no importer reads: every radio text is one
+## `line` and nothing else, so a segment's output is exactly one box line.
+## Braced names are the `text_ram` buffers the segment fills first.
+const TEXTS: Dictionary = {
+	&"OPT_IntroText1": "MARY: PROF.OAK'S",
+	&"OPT_IntroText2": "#MON TALK!",
+	&"OPT_IntroText3": "With me, MARY!",
+	&"OPT_OakText1": "OAK: {mon}",
+	&"OPT_OakText2": "may be seen around",
+	&"OPT_OakText3": "{landmark}.",
+	&"OPT_MaryText1": "MARY: {mon}'s",
+	&"OPT_PokemonChannelText": "#MON",
+	&"PokedexShowText": "{mon}",
+	&"BenIntroText1": "BEN: #MON MUSIC",
+	&"BenIntroText2": "CHANNEL!",
+	&"BenIntroText3": "It's me, DJ BEN!",
+	&"FernIntroText1": "FERN: #MUSIC!",
+	&"FernIntroText2": "With DJ FERN!",
+	&"BenFernText1": "Today's {today},",
+	&"BenFernText2A": "so let us jam to",
+	&"BenFernText2B": "so chill out to",
+	&"BenFernText3A": "#MON March!",
+	&"BenFernText3B": "#MON Lullaby!",
+	&"LC_Text1": "REED: Yeehaw! How",
+	&"LC_Text2": "y'all doin' now?",
+	&"LC_Text3": "Whether you're up",
+	&"LC_Text4": "or way down low,",
+	&"LC_Text5": "don't you miss the",
+	&"LC_Text6": "LUCKY NUMBER SHOW!",
+	&"LC_Text7": "This week's Lucky",
+	&"LC_Text8": "Number is {number}!",
+	&"LC_Text9": "I'll repeat that!",
+	&"LC_Text10": "Match it and go to",
+	&"LC_Text11": "the RADIO TOWER!",
+	&"LC_DragText1": "…Repeating myself",
+	&"LC_DragText2": "gets to be a drag…",
+	&"PnP_Text1": "PLACES AND PEOPLE!",
+	&"PnP_Text2": "Brought to you by",
+	&"PnP_Text3": "me, DJ LILY!",
+	&"PnP_Text4": "{class} {trainer}",
+	&"PnP_Text5": "{landmark}",
+	&"RocketRadioText1": "… …Ahem, we are",
+	&"RocketRadioText2": "TEAM ROCKET!",
+	&"RocketRadioText3": "After three years",
+	&"RocketRadioText4": "of preparation, we",
+	&"RocketRadioText5": "have risen again",
+	&"RocketRadioText6": "from the ashes!",
+	&"RocketRadioText7": "GIOVANNI! Can you",
+	&"RocketRadioText8": "hear? We did it!",
+	&"RocketRadioText9": "Where is our boss?",
+	&"RocketRadioText10": "Is he listening?",
+	&"BuenaRadioText1": "BUENA: BUENA here!",
+	&"BuenaRadioText2": "Today's password!",
+	&"BuenaRadioText3": "Let me think… It's",
+	&"BuenaRadioText4": "{password}!",
+	&"BuenaRadioText5": "Don't forget it!",
+	&"BuenaRadioText6": "I'm in GOLDENROD's",
+	&"BuenaRadioText7": "RADIO TOWER!",
+	&"BuenaRadioMidnightText1": "BUENA: Oh my…",
+	&"BuenaRadioMidnightText2": "It's midnight! I",
+	&"BuenaRadioMidnightText3": "have to shut down!",
+	&"BuenaRadioMidnightText4": "Thanks for tuning",
+	&"BuenaRadioMidnightText5": "in to the end! But",
+	&"BuenaRadioMidnightText6": "don't stay up too",
+	&"BuenaRadioMidnightText7": "late! Presented to",
+	&"BuenaRadioMidnightText8": "you by DJ BUENA!",
+	&"BuenaRadioMidnightText9": "I'm outta here!",
+	&"BuenaRadioMidnightText10": "…",
+	&"BuenaOffTheAirText": "",
+}
+
+## `OaksPKMNTalk8`'s `.Adverbs` and `OaksPKMNTalk9`'s `.Adjectives`, sixteen
+## each so the mask needs no retry loop. Gold and Silver's eighth adjective is
+## `.OPT_NowText` where Crystal's is `.OPT_GroovyText`; nothing else differs.
+const OPT_ADVERBS: Array[String] = [
+	"sweet and adorably", "wiggly and slickly", "aptly named and",
+	"undeniably kind of", "so, so unbearably", "wow, impressively",
+	"almost poisonously", "ooh, so sensually", "so mischievously",
+	"so very topically", "sure addictively", "looks in water is",
+	"evolution must be", "provocatively", "so flipped out and",
+	"heart-meltingly",
+]
+const OPT_ADJECTIVES: Array[String] = [
+	"cute.", "weird.", "pleasant.", "bold, sort of.", "frightening.",
+	"suave & debonair!", "powerful.", "exciting.", "groovy!", "inspiring.",
+	"friendly.", "hot, hot, hot!", "stimulating.", "guarded.", "lovely.",
+	"speedy.",
+]
+const OPT_ADJECTIVE_GROOVY: int = 8
+const OPT_ADJECTIVE_NOW_GOLD_SILVER: String = "now!"
+
+## `PeoplePlaces5` and `PeoplePlaces7` share one `.Adjectives` table, listed
+## twice in the source and identical both times.
+const PNP_ADJECTIVES: Array[String] = [
+	"is cute.", "is sort of lazy.", "is always happy.", "is quite noisy.",
+	"is precocious.", "is somewhat bold.", "is too picky!", "is sort of OK.",
+	"is just so-so.", "is actually great.", "is just my type.",
+	"is so cool, no?", "is inspiring!", "is kind of weird.",
+	"is right for me?", "is definitely odd!",
+]
+
+## `data/radio/oaks_pkmn_talk_routes.asm` by landmark rather than by map id: a
+## map number shifts between the profiles and a Johto landmark does not.
+const OAKS_TALK_LANDMARKS: Array[int] = [
+	2,   # ROUTE_29
+	45,  # ROUTE_46
+	4,   # ROUTE_30
+	8,   # ROUTE_32
+	15,  # ROUTE_34
+	18,  # ROUTE_35
+	21,  # ROUTE_37
+	25,  # ROUTE_38
+	26,  # ROUTE_39
+	34,  # ROUTE_42
+	37,  # ROUTE_43
+	39,  # ROUTE_44
+	43,  # ROUTE_45
+	20,  # ROUTE_36
+	5,   # ROUTE_31
+]
+
+## `data/radio/pnp_places.asm`, likewise as landmarks. `PnP_Places` names four
+## maps whose own landmark is their city's, which is why Cerulean appears as
+## the police station and Cinnabar as a beta Pokecenter.
+const PNP_PLACE_LANDMARKS: Array[int] = [
+	47,  # PALLET_TOWN
+	87,  # ROUTE_22
+	51,  # PEWTER_CITY
+	55,  # CERULEAN_CITY
+	74,  # ROUTE_12
+	73,  # ROUTE_11
+	78,  # ROUTE_16
+	76,  # ROUTE_14
+	85,  # CINNABAR_ISLAND
+]
+
+## `data/radio/pnp_hidden_people.asm`, which is one list with two labels inside
+## it: `PeoplePlaces4` picks the label to start walking from, so progress makes
+## the list *shorter* rather than longer. The Elite Four are described once the
+## Hall of Fame is entered, the Kanto leaders once all eight Kanto badges are
+## in, and the last five never.
+const PNP_HIDDEN_ELITE_FOUR: Array[int] = [11, 13, 14, 15, 16]
+const PNP_HIDDEN_KANTO_LEADERS: Array[int] = [17, 18, 19, 21, 26, 35, 46, 64]
+const PNP_HIDDEN_ALWAYS: Array[int] = [9, 10, 12, 42, 63]
+
+## `maskbits NUM_TRAINER_CLASSES / inc a`: seven bits of a byte, so the roll is
+## 1 to 128 and everything past the class count is retried.
+const TRAINER_CLASS_ROLL: int = 128
+## `NUM_TRAINER_CLASSES`. Crystal's own `cp` excludes MYSTICALMAN, which Gold
+## and Silver's `+ 1` lets through.
+const NUM_TRAINER_CLASSES: int = 67
+
+## `data/radio/buenas_passwords.asm`. `kind` is the BUENA_* string function and
+## `values` its three operands: species, item or move numbers, or literals.
+const BUENA_MON: StringName = &"mon"
+const BUENA_ITEM: StringName = &"item"
+const BUENA_MOVE: StringName = &"move"
+const BUENA_STRING: StringName = &"string"
+const BUENA_PASSWORDS: Array[Dictionary] = [
+	{"kind": BUENA_MON, "values": [155, 158, 152]},
+	{"kind": BUENA_ITEM, "values": [20, 21, 22]},
+	{"kind": BUENA_ITEM, "values": [17, 12, 14]},
+	{"kind": BUENA_ITEM, "values": [5, 4, 3]},
+	{"kind": BUENA_MON, "values": [25, 19, 74]},
+	{"kind": BUENA_MON, "values": [163, 167, 96]},
+	{"kind": BUENA_STRING, "values": ["NEW BARK TOWN", "CHERRYGROVE CITY", "AZALEA TOWN"]},
+	{"kind": BUENA_STRING, "values": ["FLYING", "BUG", "GRASS"]},
+	{"kind": BUENA_MOVE, "values": [33, 45, 189]},
+	{"kind": BUENA_ITEM, "values": [64, 65, 66]},
+	{"kind": BUENA_STRING, "values": ["#MON Talk", "#MON Music", "Lucky Channel"]},
+]
+## `NITE_HOUR`. `BuenasPasswordCheckTime` is a bare `cp NITE_HOUR` on the hour,
+## so Buena is on the air from six in the evening until midnight and off it for
+## the other eighteen hours.
+const NITE_HOUR: int = 18
+const BUENAS_PASSWORD_CHANNEL_NAME: String = "BUENA'S PASSWORD"
+
+## `OaksPKMNTalk11` to `OaksPKMNTalk13` place strings at screen columns rather
+## than as box lines, so each is padded to the column its `hlcoord` names. The
+## box's own text starts at column 1.
+const RESTART_TOP_COLUMN: int = 9
+const BOX_TEXT_COLUMN: int = 1
+
+## `MUSIC_POKEMON_TALK`, `MUSIC_POKEMON_MARCH` and `MUSIC_POKEMON_LULLABY`
+## (`constants/music_constants.asm`), the three tracks a segment restarts.
+const MUSIC_POKEMON_TALK: int = 29
+const MUSIC_POKEMON_MARCH: int = 30
+const MUSIC_POKEMON_LULLABY: int = 31
+
+var _data: GameData = null
+var _random: RandomNumberGenerator = null
+var _context: Dictionary = {}
+var _crystal: bool = true
+
+## `wCurRadioLine`, `wNextRadioLine`, `wNumRadioLinesPrinted` and
+## `wRadioTextDelay`.
+var _line: StringName = &""
+var _next_line: StringName = &""
+var _lines_printed: int = 0
+var _delay: int = 0
+
+## The two rows `PrintRadioLine` writes: the first line printed lands on the
+## top one and every line after it on the bottom, which `RadioScroll` then
+## copies up.
+var _top: String = ""
+var _bottom: String = ""
+
+## `wOaksPKMNTalkSegmentCounter`: five topics before the station restarts.
+var _oaks_counter: int = 0
+var _mon_name: String = ""
+var _landmark_name: String = ""
+var _class_name: String = ""
+var _trainer_name: String = ""
+var _password: String = ""
+## The remaining lines of the dex entry `PokedexShow1` chose, which
+## `CopyDexEntry` walks one per segment.
+var _dex_lines: PackedStringArray = PackedStringArray()
+
+## `wBuenasPassword` and `DAILYFLAGS2_BUENAS_PASSWORD_F`, kept by the caller so
+## the password survives a retune within the day.
+var buenas_password: int = -1
+var buenas_password_today: bool = false
+
+## The jumptable entry that last executed, which is not always [method segment]:
+## four of Buena's segments `jp` straight at another entry rather than printing
+## and handing over.
+var ran_segment: StringName = &""
+
+## What `RadioMusicRestartDE` was last handed, drained by the host. -1 while no
+## segment has asked for a track.
+var pending_music: int = -1
+
+
+## Starts [param channel]'s own `LoadStation_` segment.
+##
+## [param context] carries what the show reads off WRAM beyond the dial's own
+## facts: `crystal`, `weekday`, `hour`, `caught` (the species numbers
+## `CheckCaughtMon` answers for), `hall_of_fame`, `kanto_badges` and
+## `lucky_number`.
+static func start(
+	data: GameData, channel: int, context: Dictionary = {},
+	random: RandomNumberGenerator = null
+) -> Gen2RadioShow:
+	var show := Gen2RadioShow.new()
+	show._data = data
+	show._context = context
+	show._crystal = bool(context.get("crystal", true))
+	show._random = random if random != null else RandomNumberGenerator.new()
+	if random == null:
+		show._random.randomize()
+	show._line = StringName(CHANNEL_ENTRY.get(channel, &""))
+	return show
+
+
+## `UpdateTime`, which `BuenasPasswordCheckTime` calls before every reading: the
+## hour is live, so midnight arriving mid-show is what puts Buena off the air.
+func set_hour(hour: int) -> void:
+	_context["hour"] = hour
+
+
+## The two box rows, oldest first.
+func lines() -> PackedStringArray:
+	return PackedStringArray([_top, _bottom])
+
+
+## `wCurRadioLine`, which is `SCROLL` while a line is being read.
+func segment() -> StringName:
+	return _line
+
+
+## True once the channel has no segment left to run, which only
+## `BenFernMusic7`'s bare `ret` and the three music-only stations reach.
+func finished() -> bool:
+	return _line.is_empty()
+
+
+## One `PlayRadioShow` dispatch. Answers whether the box changed.
+func advance_frame() -> bool:
+	if _line.is_empty():
+		return false
+	if _line == SCROLL:
+		return _scroll()
+	var before_top: String = _top
+	var before_bottom: String = _bottom
+	_run(_line)
+	return _top != before_top or _bottom != before_bottom
+
+
+## `RadioScroll`: spend the delay, then take `wNextRadioLine` and roll the box.
+## A station that has printed exactly one line has nothing to copy up yet.
+func _scroll() -> bool:
+	if _delay > 0:
+		_delay -= 1
+		return false
+	_line = _next_line
+	if _lines_printed == 1:
+		return false
+	_top = _bottom
+	_bottom = ""
+	return true
+
+
+## `PrintRadioLine`: the first line lands on the top row, every later one on the
+## bottom, and the segment hands over to `RadioScroll` for 100 frames.
+func _print(text: String, next: StringName) -> void:
+	_next_line = next
+	if _lines_printed < 2:
+		_lines_printed += 1
+	if _lines_printed == 1:
+		_top = text
+	else:
+		_bottom = text
+	_line = SCROLL
+	_delay = LINE_FRAMES
+
+
+## `NextRadioLine`, which is `CopyRadioTextToRAM` and then the above.
+func _say(text_id: StringName, next: StringName, fills: Dictionary = {}) -> void:
+	_print(_fill(String(TEXTS.get(text_id, "")), fills), next)
+
+
+## The `text_ram` buffers a line names, filled from what the segment resolved.
+func _fill(text: String, fills: Dictionary) -> String:
+	var out: String = text
+	out = out.replace("{mon}", _mon_name)
+	out = out.replace("{landmark}", _landmark_name)
+	out = out.replace("{class}", _class_name)
+	out = out.replace("{trainer}", _trainer_name)
+	out = out.replace("{password}", _password)
+	out = out.replace("{today}", Gen2TextStream.weekday_name(
+		int(_context.get("weekday", 0))
+	) + "DAY")
+	out = out.replace("{number}", "%05d" % int(_context.get("lucky_number", 0)))
+	for key: String in fills:
+		out = out.replace("{%s}" % key, String(fills[key]))
+	return out
+
+
+## `StartRadioStation`, which is skipped once a station is already talking: it
+## clears the box and commits the channel's own track.
+func _start_station(channel: int) -> void:
+	if _lines_printed != 0:
+		return
+	_top = ""
+	_bottom = ""
+	if channel >= 0 and channel < Gen2WorldRadio.CHANNEL_SONGS.size():
+		pending_music = Gen2WorldRadio.CHANNEL_SONGS[channel]
+
+
+func _roll(bound: int) -> int:
+	return _random.randi_range(0, maxi(1, bound) - 1)
+
+
+## `Random` compared against a percentage, which the source writes as a byte:
+## `cp 49 percent - 1` is `cp 124`.
+func _roll_percent(threshold: int) -> bool:
+	return _random.randi_range(0, 255) < threshold
+
+
+func _run(segment_id: StringName) -> void:
+	ran_segment = segment_id
+	match segment_id:
+		&"OaksPKMNTalk1":
+			_oaks_counter = 5
+			_start_station(Gen2WorldRadio.OAKS_POKEMON_TALK)
+			_say(&"OPT_IntroText1", &"OaksPKMNTalk2")
+		&"OaksPKMNTalk2":
+			_say(&"OPT_IntroText2", &"OaksPKMNTalk3")
+		&"OaksPKMNTalk3":
+			_say(&"OPT_IntroText3", &"OaksPKMNTalk4")
+		&"OaksPKMNTalk4":
+			_oaks_pick_wild()
+			_say(&"OPT_OakText1", &"OaksPKMNTalk5")
+		&"OaksPKMNTalk5":
+			_say(&"OPT_OakText2", &"OaksPKMNTalk6")
+		&"OaksPKMNTalk6":
+			_say(&"OPT_OakText3", &"OaksPKMNTalk7")
+		&"OaksPKMNTalk7":
+			_say(&"OPT_MaryText1", &"OaksPKMNTalk8")
+		&"OaksPKMNTalk8":
+			_print(OPT_ADVERBS[_roll(OPT_ADVERBS.size())], &"OaksPKMNTalk9")
+		&"OaksPKMNTalk9":
+			var adjective: String = _oaks_adjective(_roll(OPT_ADJECTIVES.size()))
+			_oaks_counter -= 1
+			var next: StringName = &"OaksPKMNTalk4"
+			if _oaks_counter == 0:
+				_oaks_counter = 5
+				next = &"OaksPKMNTalk10"
+			_print(adjective, next)
+		&"OaksPKMNTalk10":
+			# `RadioMusicRestartPokemonChannel` and two `PrintText`s rather than
+			# radio lines: the box is cleared and "#MON" placed straight into it.
+			pending_music = MUSIC_POKEMON_TALK
+			_top = ""
+			_bottom = String(TEXTS[&"OPT_PokemonChannelText"])
+			_line = &"OaksPKMNTalk11"
+			_delay = LINE_FRAMES
+		&"OaksPKMNTalk11":
+			_place(_pad(RESTART_TOP_COLUMN, "#MON"), true, &"OaksPKMNTalk12")
+		&"OaksPKMNTalk12":
+			_place("#MON Channel", false, &"OaksPKMNTalk13")
+		&"OaksPKMNTalk13":
+			_place(_bottom, false, &"OaksPKMNTalk14")
+		&"OaksPKMNTalk14":
+			if _delay > 0:
+				_delay -= 1
+				return
+			pending_music = MUSIC_POKEMON_TALK
+			_top = ""
+			_bottom = ""
+			_next_line = &"OaksPKMNTalk4"
+			_lines_printed = 0
+			_line = SCROLL
+			_delay = RESTART_FRAMES
+
+		&"PokedexShow1":
+			_start_station(Gen2WorldRadio.POKEDEX_SHOW)
+			if not _pokedex_pick_mon():
+				# `.loop` retries until it finds a caught species, so an empty
+				# dex would spin forever on the cartridge; here the station
+				# simply has nothing to read.
+				_line = &""
+				return
+			_say(&"PokedexShowText", &"PokedexShow2")
+		&"PokedexShow2":
+			_print(_dex_line(), &"PokedexShow3")
+		&"PokedexShow3":
+			_print(_dex_line(), &"PokedexShow4")
+		&"PokedexShow4":
+			_print(_dex_line(), &"PokedexShow5")
+		&"PokedexShow5":
+			_print(_dex_line(), &"PokedexShow6")
+		&"PokedexShow6":
+			_print(_dex_line(), &"PokedexShow7")
+		&"PokedexShow7":
+			_print(_dex_line(), &"PokedexShow8")
+		&"PokedexShow8":
+			_print(_dex_line(), &"PokedexShow1")
+
+		&"BenMonMusic1":
+			_start_pokemon_music()
+			_say(&"BenIntroText1", &"BenMonMusic2")
+		&"BenMonMusic2":
+			_say(&"BenIntroText2", &"BenMonMusic3")
+		&"BenMonMusic3":
+			_say(&"BenIntroText3", &"BenFernMusic4")
+		&"FernMonMusic1":
+			_start_pokemon_music()
+			_say(&"FernIntroText1", &"FernMonMusic2")
+		&"FernMonMusic2":
+			_say(&"FernIntroText2", &"BenFernMusic4")
+		&"BenFernMusic4":
+			_say(&"BenFernText1", &"BenFernMusic5")
+		&"BenFernMusic5":
+			_say(
+				&"BenFernText2A" if _march_day() else &"BenFernText2B",
+				&"BenFernMusic6"
+			)
+		&"BenFernMusic6":
+			_say(
+				&"BenFernText3A" if _march_day() else &"BenFernText3B",
+				&"BenFernMusic7"
+			)
+		&"BenFernMusic7":
+			# A bare `ret`: the music channel says its three lines once and then
+			# leaves the box alone until the dial moves.
+			_line = &""
+
+		&"LuckyNumberShow1":
+			_start_station(Gen2WorldRadio.LUCKY_CHANNEL)
+			_say(&"LC_Text1", &"LuckyNumberShow2")
+		&"LuckyNumberShow2":
+			_say(&"LC_Text2", &"LuckyNumberShow3")
+		&"LuckyNumberShow3":
+			_say(&"LC_Text3", &"LuckyNumberShow4")
+		&"LuckyNumberShow4":
+			_say(&"LC_Text4", &"LuckyNumberShow5")
+		&"LuckyNumberShow5":
+			_say(&"LC_Text5", &"LuckyNumberShow6")
+		&"LuckyNumberShow6":
+			_say(&"LC_Text6", &"LuckyNumberShow7")
+		&"LuckyNumberShow7":
+			_say(&"LC_Text7", &"LuckyNumberShow8")
+		&"LuckyNumberShow8":
+			_say(&"LC_Text8", &"LuckyNumberShow9")
+		&"LuckyNumberShow9":
+			_say(&"LC_Text9", &"LuckyNumberShow10")
+		&"LuckyNumberShow10":
+			_say(&"LC_Text7", &"LuckyNumberShow11")
+		&"LuckyNumberShow11":
+			_say(&"LC_Text8", &"LuckyNumberShow12")
+		&"LuckyNumberShow12":
+			_say(&"LC_Text10", &"LuckyNumberShow13")
+		&"LuckyNumberShow13":
+			# `call Random / and a`: 255 of 256 rolls restart the show, and the
+			# one zero gets REED's two extra lines.
+			_say(
+				&"LC_Text11",
+				&"LuckyNumberShow14" if _roll(256) == 0 else &"LuckyNumberShow1"
+			)
+		&"LuckyNumberShow14":
+			_say(&"LC_DragText1", &"LuckyNumberShow15")
+		&"LuckyNumberShow15":
+			_say(&"LC_DragText2", &"LuckyNumberShow1")
+
+		&"PeoplePlaces1":
+			_start_station(Gen2WorldRadio.PLACES_AND_PEOPLE)
+			_say(&"PnP_Text1", &"PeoplePlaces2")
+		&"PeoplePlaces2":
+			_say(&"PnP_Text2", &"PeoplePlaces3")
+		&"PeoplePlaces3":
+			_say(&"PnP_Text3", _pnp_topic())
+		&"PeoplePlaces4":
+			_pnp_pick_person()
+			_say(&"PnP_Text4", &"PeoplePlaces5")
+		&"PeoplePlaces5":
+			_print(PNP_ADJECTIVES[_roll(PNP_ADJECTIVES.size())], _pnp_next())
+		&"PeoplePlaces6":
+			_pnp_pick_place()
+			_say(&"PnP_Text5", &"PeoplePlaces7")
+		&"PeoplePlaces7":
+			_print(PNP_ADJECTIVES[_roll(PNP_ADJECTIVES.size())], _pnp_next())
+
+		&"RocketRadio1":
+			_start_station(Gen2WorldRadio.ROCKET_RADIO)
+			_say(&"RocketRadioText1", &"RocketRadio2")
+		&"RocketRadio2":
+			_say(&"RocketRadioText2", &"RocketRadio3")
+		&"RocketRadio3":
+			_say(&"RocketRadioText3", &"RocketRadio4")
+		&"RocketRadio4":
+			_say(&"RocketRadioText4", &"RocketRadio5")
+		&"RocketRadio5":
+			_say(&"RocketRadioText5", &"RocketRadio6")
+		&"RocketRadio6":
+			_say(&"RocketRadioText6", &"RocketRadio7")
+		&"RocketRadio7":
+			_say(&"RocketRadioText7", &"RocketRadio8")
+		&"RocketRadio8":
+			_say(&"RocketRadioText8", &"RocketRadio9")
+		&"RocketRadio9":
+			_say(&"RocketRadioText9", &"RocketRadio10")
+		&"RocketRadio10":
+			_say(&"RocketRadioText10", &"RocketRadio1")
+
+		&"PokeFluteRadio", &"UnownRadio", &"EvolutionRadio":
+			# All three are `StartRadioStation` and a line count of 1, which is
+			# what stops `RadioScroll` clearing a box they never write to.
+			_start_station(_music_only_channel(segment_id))
+			_lines_printed = 1
+			_line = &""
+
+		&"BuenasPassword1":
+			if _off_air():
+				_run(&"BuenasPassword20" if _lines_printed == 0 else &"BuenasPassword8")
+				return
+			_start_station(Gen2WorldRadio.BUENAS_PASSWORD)
+			_say(&"BuenaRadioText1", &"BuenasPassword2")
+		&"BuenasPassword2":
+			_say(&"BuenaRadioText2", &"BuenasPassword3")
+		&"BuenasPassword3":
+			_say(
+				&"BuenaRadioText3",
+				&"BuenasPassword8" if _off_air() else &"BuenasPassword4"
+			)
+			if _off_air():
+				buenas_password_today = false
+		&"BuenasPassword4":
+			if _off_air():
+				_run(&"BuenasPassword8")
+				return
+			_roll_password()
+			_say(&"BuenaRadioText4", &"BuenasPassword5")
+		&"BuenasPassword5":
+			_say(&"BuenaRadioText5", &"BuenasPassword6")
+		&"BuenasPassword6":
+			_say(&"BuenaRadioText6", &"BuenasPassword7")
+		&"BuenasPassword7":
+			var midnight: bool = _off_air()
+			if midnight:
+				buenas_password_today = false
+			_say(
+				&"BuenaRadioText7",
+				&"BuenasPassword8" if midnight else &"BuenasPassword1"
+			)
+		&"BuenasPassword8":
+			buenas_password_today = false
+			_say(&"BuenaRadioMidnightText10", &"BuenasPassword9")
+		&"BuenasPassword9":
+			_say(&"BuenaRadioMidnightText1", &"BuenasPassword10")
+		&"BuenasPassword10":
+			_say(&"BuenaRadioMidnightText2", &"BuenasPassword11")
+		&"BuenasPassword11":
+			_say(&"BuenaRadioMidnightText3", &"BuenasPassword12")
+		&"BuenasPassword12":
+			_say(&"BuenaRadioMidnightText4", &"BuenasPassword13")
+		&"BuenasPassword13":
+			_say(&"BuenaRadioMidnightText5", &"BuenasPassword14")
+		&"BuenasPassword14":
+			_say(&"BuenaRadioMidnightText6", &"BuenasPassword15")
+		&"BuenasPassword15":
+			_say(&"BuenaRadioMidnightText7", &"BuenasPassword16")
+		&"BuenasPassword16":
+			_say(&"BuenaRadioMidnightText8", &"BuenasPassword17")
+		&"BuenasPassword17":
+			_say(&"BuenaRadioMidnightText9", &"BuenasPassword18")
+		&"BuenasPassword18":
+			_say(&"BuenaRadioMidnightText10", &"BuenasPassword19")
+		&"BuenasPassword19":
+			_say(&"BuenaRadioMidnightText10", &"BuenasPassword20")
+		&"BuenasPassword20":
+			# `NoRadioMusic` and `NoRadioName`: the station goes quiet and its
+			# name comes off the dial before the off-air line.
+			pending_music = Gen2WorldState.MUSIC_NONE
+			buenas_password_today = false
+			_lines_printed = 0
+			_say(&"BuenaOffTheAirText", &"BuenasPassword21")
+		&"BuenasPassword21":
+			_lines_printed = 0
+			if not _off_air():
+				_run(&"BuenasPassword1")
+				return
+			_say(&"BuenaOffTheAirText", &"BuenasPassword21")
+
+
+## `PlaceRadioString`: a string written straight into the box at a column, with
+## its own 100-frame wait counted by the segment that follows.
+func _place(text: String, top: bool, next: StringName) -> void:
+	if _delay > 0:
+		_delay -= 1
+		return
+	if top:
+		_top = text
+	else:
+		_bottom = text
+	_line = next
+	_delay = LINE_FRAMES
+
+
+static func _pad(column: int, text: String) -> String:
+	return " ".repeat(maxi(0, column - BOX_TEXT_COLUMN)) + text
+
+
+## Crystal's ninth adjective is "groovy!" and Gold and Silver's is "now!".
+func _oaks_adjective(index: int) -> String:
+	if index == OPT_ADJECTIVE_GROOVY and not _crystal:
+		return OPT_ADJECTIVE_NOW_GOLD_SILVER
+	return OPT_ADJECTIVES[index]
+
+
+func _music_only_channel(segment_id: StringName) -> int:
+	match segment_id:
+		&"UnownRadio":
+			return Gen2WorldRadio.UNOWN_RADIO
+		&"EvolutionRadio":
+			return Gen2WorldRadio.EVOLUTION_RADIO
+	return Gen2WorldRadio.POKE_FLUTE_RADIO
+
+
+## `StartPokemonMusicChannel`: the box is cleared and the weekday picks between
+## the march and the lullaby. It is not `StartRadioStation`, so it runs whether
+## or not the station is already talking.
+func _start_pokemon_music() -> void:
+	_top = ""
+	_bottom = ""
+	pending_music = MUSIC_POKEMON_MARCH if _march_day() else MUSIC_POKEMON_LULLABY
+
+
+## `GetWeekday / and 1`: Sunday, Tuesday, Thursday and Saturday get the march.
+func _march_day() -> bool:
+	return int(_context.get("weekday", 0)) % 2 == 0
+
+
+## `BuenasPasswordCheckTime`'s carry: the hour is before six in the evening.
+func _off_air() -> bool:
+	return int(_context.get("hour", 12)) < NITE_HOUR
+
+
+## `OaksPKMNTalk4`: a random route, then a random time-of-day column, then one
+## of that column's middle three slots.
+func _oaks_pick_wild() -> void:
+	var landmark: int = Gen2WorldRadio.profile_landmark(
+		OAKS_TALK_LANDMARKS[_roll(OAKS_TALK_LANDMARKS.size())], _crystal
+	)
+	_landmark_name = _data.landmark_name(landmark) if _data != null else ""
+	var row: Dictionary = _grass_row(landmark)
+	if row.is_empty():
+		# `.overflow`, which the cartridge reaches when the chosen map is not in
+		# `JohtoGrassWildMons` and which restarts the station.
+		_mon_name = ""
+		return
+	var slots: Array = row.get("slots", []) as Array
+	var column: Array = slots[_roll(slots.size())] as Array
+	var slot: int = 2 + _roll(3)
+	var species: int = int((column[mini(slot, column.size() - 1)] as Dictionary).get("species", 0))
+	_mon_name = _species_name(species)
+
+
+## The Johto grass table row for a landmark, which is the one map carrying both
+## that landmark and grass encounters.
+func _grass_row(landmark: int) -> Dictionary:
+	if _data == null:
+		return {}
+	for row: Dictionary in _data.world_encounter_region_rows(&"grass", "johto"):
+		var pair: PackedStringArray = String(row.get("map", "")).split(":")
+		if pair.size() < 2:
+			continue
+		var map: Gen2WorldMap = _data.world_map(int(pair[0]), int(pair[1]))
+		if map != null and map.location == landmark:
+			return row
+	return {}
+
+
+## `PokedexShow1`: a caught species, and its entry split into the lines
+## `CopyDexEntry` walks one per segment.
+func _pokedex_pick_mon() -> bool:
+	var caught: Array = _context.get("caught", []) as Array
+	if caught.is_empty() or _data == null:
+		return false
+	var species: int = int(caught[_roll(caught.size())])
+	_mon_name = _species_name(species)
+	_dex_lines = PackedStringArray()
+	for page: String in _data.dex_entry(species).get("pages", []) as Array:
+		for line: String in page.split("\n"):
+			_dex_lines.append(line)
+	return true
+
+
+## `CopyDexEntry`. An entry runs out before `PokedexShow8` does, and the
+## cartridge reads on past its terminator into whatever follows; here the
+## remaining segments print nothing.
+func _dex_line() -> String:
+	if _dex_lines.is_empty():
+		return ""
+	var line: String = _dex_lines[0]
+	_dex_lines.remove_at(0)
+	return line
+
+
+## `PeoplePlaces3`: just under half the rolls take the People branch.
+func _pnp_topic() -> StringName:
+	return &"PeoplePlaces4" if _roll_percent(124) else &"PeoplePlaces6"
+
+
+## `PeoplePlaces5` and `PeoplePlaces7`'s shared tail: a 4 percent chance of
+## restarting the show, and otherwise another person or place.
+func _pnp_next() -> StringName:
+	if _roll_percent(10):
+		return &"PeoplePlaces1"
+	return &"PeoplePlaces4" if _roll_percent(124) else &"PeoplePlaces6"
+
+
+## `PeoplePlaces4`: a trainer class the hidden-people list allows, and the first
+## trainer of it.
+func _pnp_pick_person() -> void:
+	if _data == null:
+		return
+	var hidden: Array[int] = hidden_people(
+		bool(_context.get("hall_of_fame", false)),
+		int(_context.get("kanto_badges", 0))
+	)
+	var bound: int = NUM_TRAINER_CLASSES if _crystal else NUM_TRAINER_CLASSES + 1
+	while true:
+		var class_number: int = _roll(TRAINER_CLASS_ROLL) + 1
+		if class_number >= bound or class_number in hidden:
+			continue
+		var entry: Dictionary = _data.trainer(class_number)
+		if entry.is_empty():
+			continue
+		_class_name = String(entry.get("name", ""))
+		var trainers: Array = entry.get("trainers", []) as Array
+		_trainer_name = String((trainers[0] as Dictionary).get("name", "")) \
+			if not trainers.is_empty() else ""
+		return
+
+
+## The classes `PeoplePlaces4`'s own walk refuses, given the two progress facts
+## that shorten the list.
+static func hidden_people(hall_of_fame: bool, kanto_badges: int) -> Array[int]:
+	var hidden: Array[int] = PNP_HIDDEN_ALWAYS.duplicate()
+	if not hall_of_fame:
+		hidden.append_array(PNP_HIDDEN_ELITE_FOUR)
+	if not hall_of_fame or kanto_badges != 0xFF:
+		hidden.append_array(PNP_HIDDEN_KANTO_LEADERS)
+	return hidden
+
+
+## `PeoplePlaces6`: one of nine Kanto landmarks, named through `GetLandmarkName`.
+func _pnp_pick_place() -> void:
+	var landmark: int = Gen2WorldRadio.profile_landmark(
+		PNP_PLACE_LANDMARKS[_roll(PNP_PLACE_LANDMARKS.size())], _crystal
+	)
+	_landmark_name = _data.landmark_name(landmark) if _data != null else ""
+
+
+## `BuenasPassword4` and `GetBuenasPassword`: one category and one of its three
+## words, rolled once a day and kept in the high and low nybbles of one byte.
+func _roll_password() -> void:
+	if not buenas_password_today or buenas_password < 0:
+		var category: int = _roll(BUENA_PASSWORDS.size() + 5)
+		while category >= BUENA_PASSWORDS.size():
+			category = _roll(BUENA_PASSWORDS.size() + 5)
+		var word: int = _roll(4)
+		while word >= 3:
+			word = _roll(4)
+		buenas_password = (category << 4) | word
+		buenas_password_today = true
+	_password = password_words(_data, buenas_password)
+
+
+## The word a `wBuenasPassword` byte names, which Buena's own script reads as
+## well as the radio.
+static func password_words(data: GameData, password: int) -> String:
+	if password < 0:
+		return ""
+	var entry: Dictionary = BUENA_PASSWORDS[mini(password >> 4, BUENA_PASSWORDS.size() - 1)]
+	var values: Array = entry["values"] as Array
+	var value: Variant = values[mini(password & 0xF, values.size() - 1)]
+	if data == null:
+		return String(value) if entry["kind"] == BUENA_STRING else ""
+	match StringName(entry["kind"]):
+		BUENA_MON:
+			return String(data.species(int(value)).get("name", ""))
+		BUENA_ITEM:
+			return data.item_name(int(value))
+		BUENA_MOVE:
+			return String(data.move(int(value)).get("name", ""))
+	return String(value)
+
+
+func _species_name(species: int) -> String:
+	return String(_data.species(species).get("name", "")) if _data != null else ""

--- a/game/world/radio_show.gd.uid
+++ b/game/world/radio_show.gd.uid
@@ -1,0 +1,1 @@
+uid://bxwg0l8uwkp48

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -206,6 +206,19 @@ var script_random: RandomNumberGenerator = null
 ## other two so seeding NPC motion cannot shift an encounter, a phone roll or a
 ## script's RANDOM result.
 var object_random: RandomNumberGenerator = null
+## Supplies the radio shows' own rolls, apart from the three above for the same
+## reason they are apart from each other: reading the radio must not move a
+## wild encounter or an NPC.
+var radio_random: RandomNumberGenerator = null
+## The programme the open radio card is reading, built by tune_radio() and
+## dropped when the card closes or the dial finds dead air.
+var _radio_show: Gen2RadioShow = null
+## `wBuenasPassword` and `DAILYFLAGS2_BUENAS_PASSWORD_F`, and `wLuckyIDNumber`.
+## None of the three is in the save model, so each is rolled once per world and
+## kept here; see HANDOFF.md's divergence row.
+var _buenas_password: int = -1
+var _buenas_password_today: bool = false
+var _lucky_number: int = -1
 ## The seed the three generators above were built from, mirrored here so a
 ## snapshot records what a run can be reproduced with. Zero means nothing seeded
 ## them and the run is not reproducible.
@@ -401,16 +414,64 @@ func tune_radio(knob: int) -> Dictionary:
 		# NoRadioStation: no channel, and the map's own music comes back.
 		state.set_radio_channel(-1)
 		state.set_map_music(map_music_track())
+		_radio_show = null
 		return tuned
 	state.set_radio_channel(int(tuned["channel"]))
 	state.set_map_music(int(tuned["music"]))
+	_start_radio_show(int(tuned["channel"]))
 	return tuned
+
+
+## The programme the tuned station is reading, or null on dead air.
+func radio_show() -> Gen2RadioShow:
+	return _radio_show
+
+
+## `PlayRadioShow`, dispatched once a hardware frame while the radio card is
+## open. Answers whether the box changed, so the host redraws only then.
+func advance_radio_frame() -> bool:
+	if _radio_show == null:
+		return false
+	_radio_show.set_hour(int(world_clock().get("hour", 12)))
+	var changed_box: bool = _radio_show.advance_frame()
+	var track: int = _radio_show.pending_music
+	if track >= 0:
+		_radio_show.pending_music = -1
+		state.set_map_music(track)
+	_buenas_password = _radio_show.buenas_password
+	_buenas_password_today = _radio_show.buenas_password_today
+	return changed_box
+
+
+## `LoadStation_`'s own jump into `RadioJumptable`, with the WRAM facts the
+## shows read beyond the dial's.
+func _start_radio_show(channel: int) -> void:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	var clock: Dictionary = world_clock()
+	if radio_random == null:
+		radio_random = RandomNumberGenerator.new()
+		radio_random.randomize()
+	if _lucky_number < 0:
+		# `ResetLuckyNumberShowFlag`'s weekly roll, which has no saved home here.
+		_lucky_number = radio_random.randi_range(0, 99999)
+	_radio_show = Gen2RadioShow.start(data, channel, {
+		"crystal": crystal,
+		"weekday": world_day,
+		"hour": int(clock.get("hour", 12)),
+		"caught": state.caught_species().keys(),
+		"hall_of_fame": state.hall_of_fame(),
+		"kanto_badges": (state.badge_mask(crystal) >> 8) & 0xFF,
+		"lucky_number": _lucky_number,
+	}, radio_random)
+	_radio_show.buenas_password = _buenas_password
+	_radio_show.buenas_password_today = _buenas_password_today
 
 
 ## Closing the radio card. ExitPokegearRadio_HandleMusic restores the map's own
 ## music only for the two sentinels; a real station id falls through both, so
 ## whatever was tuned keeps playing.
 func close_radio() -> void:
+	_radio_show = null
 	if state.radio_channel() < 0:
 		state.set_map_music(map_music_track())
 

--- a/game/world/world_radio.gd
+++ b/game/world/world_radio.gd
@@ -9,11 +9,10 @@ extends RefCounted
 ## the tuned channel live on `Gen2WorldState`; the music a station commits lands
 ## in `Gen2WorldState.map_music`, which is what `SnorlaxAwake` reads.
 ##
-## The station *programmes* are out. `engine/pokegear/radio.asm`'s shows are
-## their own content layer. What is modelled here is `UpdateRadioStation`,
-## `RadioChannels`, each handler's availability check, `LoadStation_*`,
-## `PlayRadioShow`'s Rocket override and `StartRadioStation`'s music commit,
-## which is the whole of what the overworld can observe.
+## Modelled here: `UpdateRadioStation`, `RadioChannels`, each handler's
+## availability check, `LoadStation_*`, `PlayRadioShow`'s Rocket override and
+## `StartRadioStation`'s music commit, which is the whole of what the overworld
+## can observe. The words a station then prints are [Gen2RadioShow].
 ##
 ## Channel ids are Crystal-canonical, the way `Gen2WorldScript.special_index()`
 ## keeps specials Crystal-canonical: Gold and Silver ship no Buena's Password
@@ -65,21 +64,18 @@ const KNOB_MIN: int = 0
 const KNOB_MAX: int = 80
 const KNOB_STEP: int = 2
 
-## constants/landmark_constants.asm. Crystal's LANDMARK_BATTLE_TOWER sits inside
-## the Johto run, so every landmark from it onward is one higher than
-## Gold/Silver's.
+## constants/landmark_constants.asm, Crystal-canonical. The two tables differ by
+## exactly one insertion, LANDMARK_BATTLE_TOWER inside the Johto run, so every
+## landmark from it onward is one higher than Gold and Silver's and
+## `profile_landmark()` is the whole conversion.
+const LANDMARK_BATTLE_TOWER: int = 29
 const KANTO_LANDMARK: int = 47
-const KANTO_LANDMARK_GOLD_SILVER: int = 46
 const LANDMARK_FAST_SHIP: int = 95
-const LANDMARK_FAST_SHIP_GOLD_SILVER: int = 94
 const LANDMARK_SPECIAL: int = 0
 const LANDMARK_RUINS_OF_ALPH: int = 9
 const LANDMARK_MAHOGANY_TOWN: int = 36
-const LANDMARK_MAHOGANY_TOWN_GOLD_SILVER: int = 35
 const LANDMARK_ROUTE_43: int = 37
-const LANDMARK_ROUTE_43_GOLD_SILVER: int = 36
 const LANDMARK_LAKE_OF_RAGE: int = 38
-const LANDMARK_LAKE_OF_RAGE_GOLD_SILVER: int = 37
 
 ## `wTimeOfDay`: .PKMNTalkAndPokedexShow runs the Pokedex Show in the morning and
 ## Oak's Talk the rest of the day.
@@ -147,12 +143,19 @@ static func raw_channel(channel: int, crystal: bool = true) -> int:
 	return -1 if channel == BUENAS_PASSWORD else channel - 1
 
 
+## A Crystal landmark index on the active profile.
+static func profile_landmark(landmark: int, crystal: bool = true) -> int:
+	if crystal or landmark < LANDMARK_BATTLE_TOWER:
+		return landmark
+	return landmark - 1
+
+
 static func kanto_landmark(crystal: bool = true) -> int:
-	return KANTO_LANDMARK if crystal else KANTO_LANDMARK_GOLD_SILVER
+	return profile_landmark(KANTO_LANDMARK, crystal)
 
 
 static func fast_ship_landmark(crystal: bool = true) -> int:
-	return LANDMARK_FAST_SHIP if crystal else LANDMARK_FAST_SHIP_GOLD_SILVER
+	return profile_landmark(LANDMARK_FAST_SHIP, crystal)
 
 
 ## `IsInJohto` and the Pokegear's own `.InJohto`, which agree once the landmark
@@ -234,9 +237,9 @@ static func _channel_for_rule(entry: Dictionary, context: Dictionary) -> int:
 			if not bool(context.get("rocket_signal", false)):
 				return -1
 			var lake: Array[int] = [
-				LANDMARK_MAHOGANY_TOWN if crystal else LANDMARK_MAHOGANY_TOWN_GOLD_SILVER,
-				LANDMARK_ROUTE_43 if crystal else LANDMARK_ROUTE_43_GOLD_SILVER,
-				LANDMARK_LAKE_OF_RAGE if crystal else LANDMARK_LAKE_OF_RAGE_GOLD_SILVER,
+				profile_landmark(LANDMARK_MAHOGANY_TOWN, crystal),
+				profile_landmark(LANDMARK_ROUTE_43, crystal),
+				profile_landmark(LANDMARK_LAKE_OF_RAGE, crystal),
 			]
 			return int(entry["channel"]) if landmark in lake else -1
 	return -1

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -455,6 +455,10 @@ func advance_frame() -> void:
 		)
 		if bool(audio_result.get("ok", false)):
 			_show_script_results(audio_result.get("results", []))
+	# `PlayRadioShow` runs from the Pokegear's own loop, so an open radio card
+	# spends this frame too rather than counting one of its own.
+	if _service_host != null:
+		_service_host.advance_frame()
 	_spending_frame = false
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -693,9 +693,11 @@ func _refresh_card() -> void:
 			)
 		Gen2PokegearScreen.CARD_RADIO:
 			var tuned: Dictionary = _world.radio_station()
+			var show: Gen2RadioShow = _world.radio_show()
 			_pokegear.set_radio(
 				_world.state.radio_knob(),
-				String(tuned.get("name", "")) if bool(tuned.get("ok", false)) else ""
+				String(tuned.get("name", "")) if bool(tuned.get("ok", false)) else "",
+				show.lines() if show != null else PackedStringArray()
 			)
 		Gen2PokegearScreen.CARD_PHONE:
 			_pokegear.set_contacts(
@@ -722,6 +724,15 @@ func _on_card_switched(direction: int) -> void:
 		return
 	_close_card()
 	_open_card(card)
+
+
+## One hardware frame of whichever card is open. Only the radio card spends any:
+## `PlayRadioShow` is the one thing the Pokegear runs per frame.
+func advance_frame() -> void:
+	if _pokegear == null or _pokegear.card() != Gen2PokegearScreen.CARD_RADIO:
+		return
+	if _world.advance_radio_frame():
+		_refresh_card()
 
 
 func _on_card_tuned(knob: int) -> void:

--- a/tests/unit/test_world_radio.gd
+++ b/tests/unit/test_world_radio.gd
@@ -209,3 +209,141 @@ func test_play_map_music_reports_only_a_real_change() -> void:
 	assert_false(state.play_map_music(12), "the same track does not restart")
 	assert_true(state.play_map_music(13))
 	assert_eq(state.map_music(), 13)
+
+
+## The programme layer. The corpus sweep lives in `tools/checks/radio.gd`, which
+## drives every segment on a real cache; what is worth pinning here is the box's
+## own two-line behaviour and the four branches whose input is not a roll.
+
+func _show(channel: int, context: Dictionary = {}) -> Gen2RadioShow:
+	var random := RandomNumberGenerator.new()
+	random.seed = 1
+	var facts: Dictionary = {"crystal": true, "weekday": 0, "hour": 20}
+	facts.merge(context, true)
+	return Gen2RadioShow.start(null, channel, facts, random)
+
+
+## Runs frames until a segment actually prints, rather than until the box moves:
+## `RadioScroll` clears the bottom row a frame before the next line lands on it.
+func _next_line(show: Gen2RadioShow) -> PackedStringArray:
+	for _frame: int in Gen2RadioShow.LINE_FRAMES + 3:
+		var before: StringName = show.segment()
+		show.advance_frame()
+		if before != Gen2RadioShow.SCROLL:
+			return show.lines()
+	return show.lines()
+
+
+func test_the_first_line_lands_on_the_top_row_and_the_rest_scroll_up() -> void:
+	var show: Gen2RadioShow = _show(Gen2WorldRadio.ROCKET_RADIO)
+	assert_eq(
+		_next_line(show), PackedStringArray(["… …Ahem, we are", ""]),
+		"the first line printed is the top row and nothing has scrolled"
+	)
+	assert_eq(_next_line(show), PackedStringArray(["… …Ahem, we are", "TEAM ROCKET!"]))
+	assert_eq(_next_line(show), PackedStringArray(["TEAM ROCKET!", "After three years"]))
+
+
+func test_a_line_is_up_for_a_hundred_frames() -> void:
+	var show: Gen2RadioShow = _show(Gen2WorldRadio.ROCKET_RADIO)
+	show.advance_frame()
+	assert_eq(show.lines()[0], "… …Ahem, we are")
+	for _frame: int in Gen2RadioShow.LINE_FRAMES:
+		assert_false(show.advance_frame(), "the box moved before its delay ran out")
+	# Frame 101 is `RadioScroll` taking wNextRadioLine, which prints nothing;
+	# the segment it took runs on the frame after it.
+	assert_false(show.advance_frame())
+	assert_eq(show.segment(), StringName("RocketRadio2"))
+	assert_true(show.advance_frame(), "the next segment did not run on frame 102")
+
+
+func test_the_three_music_only_stations_print_nothing_and_stop() -> void:
+	for channel: int in [
+		Gen2WorldRadio.POKE_FLUTE_RADIO, Gen2WorldRadio.UNOWN_RADIO,
+		Gen2WorldRadio.EVOLUTION_RADIO,
+	]:
+		var show: Gen2RadioShow = _show(channel)
+		show.advance_frame()
+		assert_true(show.finished(), "channel %d kept talking" % channel)
+		assert_eq(show.lines(), PackedStringArray(["", ""]))
+		assert_eq(
+			show.pending_music, Gen2WorldRadio.CHANNEL_SONGS[channel],
+			"StartRadioStation did not commit channel %d's track" % channel
+		)
+
+
+func test_the_music_channel_picks_its_track_off_the_weekday() -> void:
+	for weekday: int in 7:
+		var show: Gen2RadioShow = _show(
+			Gen2WorldRadio.POKEMON_MUSIC, {"weekday": weekday}
+		)
+		show.advance_frame()
+		assert_eq(
+			show.pending_music,
+			Gen2RadioShow.MUSIC_POKEMON_MARCH if weekday % 2 == 0 \
+				else Gen2RadioShow.MUSIC_POKEMON_LULLABY,
+			"weekday %d took the wrong half of StartPokemonMusicChannel" % weekday
+		)
+
+
+func test_the_music_channel_says_its_three_lines_once_and_stops() -> void:
+	var show: Gen2RadioShow = _show(Gen2WorldRadio.POKEMON_MUSIC, {"weekday": 1})
+	var said: Array[String] = []
+	for _frame: int in Gen2RadioShow.LINE_FRAMES * 10:
+		if show.finished():
+			break
+		if show.advance_frame():
+			said.append(show.lines()[1] if not show.lines()[1].is_empty() else show.lines()[0])
+	assert_true(show.finished(), "BenFernMusic7's bare ret did not end the show")
+	assert_eq(said[said.size() - 1], "#MON Lullaby!")
+
+
+## `BuenasPasswordCheckTime` is a live reading, so the hour moving under a show
+## already talking is what reaches the ten shutdown lines.
+func test_midnight_takes_buena_off_the_air_mid_show() -> void:
+	var show: Gen2RadioShow = _show(Gen2WorldRadio.BUENAS_PASSWORD, {"hour": 20})
+	assert_eq(_next_line(show), PackedStringArray(["BUENA: BUENA here!", ""]))
+	show.set_hour(0)
+	var said: Array[String] = []
+	for _frame: int in Gen2RadioShow.LINE_FRAMES * 20:
+		if show.advance_frame():
+			said.append(show.lines()[1])
+	assert_true(
+		said.has("have to shut down!"),
+		"the midnight arm never ran: %s" % ", ".join(said.slice(0, 6))
+	)
+
+
+func test_buenas_password_is_rolled_once_a_day_and_kept() -> void:
+	var show: Gen2RadioShow = _show(Gen2WorldRadio.BUENAS_PASSWORD, {"hour": 20})
+	for _frame: int in Gen2RadioShow.LINE_FRAMES * 6:
+		show.advance_frame()
+	assert_true(show.buenas_password_today, "the daily flag was not set")
+	var first: int = show.buenas_password
+	assert_true(first >= 0 and (first & 0xF) < 3, "the low nybble is not a word index")
+	assert_true(
+		(first >> 4) < Gen2RadioShow.BUENA_PASSWORDS.size(),
+		"the high nybble is not a category"
+	)
+	for _frame: int in Gen2RadioShow.LINE_FRAMES * 20:
+		show.advance_frame()
+	assert_eq(show.buenas_password, first, "a second pass rolled a new password")
+
+
+func test_a_password_category_names_a_word_of_its_own_kind() -> void:
+	assert_eq(
+		Gen2RadioShow.password_words(null, (6 << 4) | 1), "CHERRYGROVE CITY",
+		"the literal categories are read straight out of the table"
+	)
+
+
+## `PeoplePlaces4`'s list is walked from a label, so progress shortens it.
+func test_the_hidden_people_list_shrinks_with_progress() -> void:
+	var early: Array[int] = Gen2RadioShow.hidden_people(false, 0)
+	var beaten: Array[int] = Gen2RadioShow.hidden_people(true, 0)
+	var all_badges: Array[int] = Gen2RadioShow.hidden_people(true, 0xFF)
+	assert_eq(early.size(), 18)
+	assert_eq(beaten.size(), 13)
+	assert_eq(all_badges.size(), 5)
+	for class_number: int in all_badges:
+		assert_true(class_number in early, "class %d stopped being hidden" % class_number)

--- a/tools/checks/radio.gd
+++ b/tools/checks/radio.gd
@@ -81,6 +81,11 @@ const SPECIES_SNORLAX: int = 143
 const SNORLAX_LEVEL: int = 50
 const BATTLETYPE_FORCEITEM: int = 10
 
+## Long enough for a hundred lines at `PrintRadioLine`'s own 100 frames, which
+## walks the longest station (Buena's twenty-one segments) several times over.
+const SHOW_FRAMES: int = 12000
+const SHOW_SEEDS: int = 20
+
 
 func run(r: RefCounted) -> void:
 	_r = r
@@ -92,6 +97,7 @@ func run(r: RefCounted) -> void:
 		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
 		_verify_stations(data, game_id, crystal)
 		_verify_music_records(data, game_id, crystal)
+		_verify_shows(data, game_id, crystal)
 		_verify_big_object_census(data, game_id)
 		_verify_snorlax(data, game_id, crystal)
 		_verify_route_2(data, game_id, crystal)
@@ -141,6 +147,76 @@ func _verify_stations(data: GameData, game_id: StringName, crystal: bool) -> voi
 	print("%s radio: %d channels, the Poke Flute channel on %.1f, music %d." % [
 		game_id, Gen2WorldRadio.channel_count(crystal),
 		Gen2WorldRadio.frequency_for(KNOB_POKE_FLUTE), Gen2WorldRadio.MUSIC_POKE_FLUTE_CHANNEL,
+	])
+
+
+## Every channel's programme, driven for long enough that each of its segments
+## runs many times over, on twenty seeds and both halves of the clock. What it
+## can catch that a unit test cannot: a line whose `text_ram` buffer the cache
+## does not fill, so it prints an empty name, and a segment that never leaves
+## the box it wrote.
+func _verify_shows(data: GameData, game_id: StringName, crystal: bool) -> void:
+	var caught: Array = []
+	for species: int in range(1, data.species_count() + 1):
+		caught.append(species)
+	var visited: Dictionary = {}
+	var lines_seen: int = 0
+	var blank: Array[String] = []
+	for channel: int in Gen2WorldRadio.CHANNEL_SONGS.size():
+		if channel == Gen2WorldRadio.BUENAS_PASSWORD and not crystal:
+			continue
+		for seed_index: int in SHOW_SEEDS:
+			var random := RandomNumberGenerator.new()
+			random.seed = seed_index
+			# Both sides of NITE_HOUR, so Buena's off-air arm is walked too.
+			var hour: int = 20 if seed_index % 2 == 0 else 9
+			var show: Gen2RadioShow = Gen2RadioShow.start(data, channel, {
+				"crystal": crystal, "weekday": seed_index % 7, "hour": hour,
+				"caught": caught, "hall_of_fame": seed_index % 3 == 0,
+				"kanto_badges": 0xFF if seed_index % 3 == 0 else 0,
+				"lucky_number": 12345,
+			}, random)
+			var last: String = ""
+			for frame: int in SHOW_FRAMES:
+				if show.finished():
+					break
+				# Midnight arrives halfway through, which is the only way
+				# Buena's ten shutdown lines are ever reached.
+				if frame == SHOW_FRAMES / 2:
+					show.set_hour(0 if hour >= Gen2RadioShow.NITE_HOUR else 20)
+				visited[show.segment()] = true
+				show.advance_frame()
+				if not show.ran_segment.is_empty():
+					visited[show.ran_segment] = true
+				var bottom: String = show.lines()[1]
+				if bottom == last:
+					continue
+				last = bottom
+				lines_seen += 1
+				if bottom.strip_edges().is_empty():
+					continue
+				if bottom.contains("{") \
+					or (bottom.contains("  ") and not bottom.begins_with(" ")):
+					blank.append("%s ch%d: \"%s\"" % [game_id, channel, bottom])
+	_r.check(
+		blank.is_empty(),
+		"%s: a radio line has an unfilled buffer in it: %s" % [
+			game_id, ", ".join(blank.slice(0, 3)),
+		]
+	)
+	var unreached: Array[String] = []
+	for segment_id: StringName in Gen2RadioShow.SEGMENTS:
+		if segment_id == Gen2RadioShow.SCROLL or visited.has(segment_id):
+			continue
+		if not crystal and String(segment_id).begins_with("BuenasPassword"):
+			continue
+		unreached.append(String(segment_id))
+	_r.check(
+		unreached.is_empty(),
+		"%s: radio segments never ran: %s" % [game_id, ", ".join(unreached)]
+	)
+	print("%s radio shows: %d of %d segments run, %d lines printed." % [
+		game_id, visited.size() - 1, Gen2RadioShow.SEGMENTS.size() - 1, lines_seen,
 	])
 
 

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -33,6 +33,10 @@ const BUTTONS: Dictionary = {
 }
 
 
+## Any fixed value; the point is that two runs photograph the same programme.
+const RADIO_SEED: int = 20260816
+
+
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 2:
@@ -164,15 +168,20 @@ func _capture_card(
 		push_error("The cache holds no Pokegear cards.")
 		quit(1)
 		return
+	# The show rolls its own species, places and adjectives, so the run is
+	# pinned the way preview_world.gd's is: the same seed photographs the same
+	# words every time.
+	world.radio_random = RandomNumberGenerator.new()
+	world.radio_random.seed = RADIO_SEED
 	host.tuned.connect(func(knob: int) -> void:
 		world.tune_radio(knob)
-		host.set_radio(knob, _station_name(world))
+		_refresh_radio(host, world)
 	)
 	var clock: Dictionary = world.world_clock()
 	host.set_clock(
 		int(clock["day"]), int(clock["hour"]), int(clock["minute"])
 	)
-	host.set_radio(world.state.radio_knob(), _station_name(world))
+	_refresh_radio(host, world)
 	host.set_contacts(
 		world.registered_phone_contacts(),
 		Gen2WorldPhoneHost.map_has_phone_service(world.current_map)
@@ -180,6 +189,12 @@ func _capture_card(
 	for step: Array in steps:
 		if String(step[0]) == "press":
 			host.handle_button(int(step[1]))
+		elif String(step[0]) == "frames":
+			# `PlayRadioShow`'s own dispatch, spent by hand: a line is up for
+			# 100 frames, so `f250` is the third one of the tuned programme.
+			for _frame: int in int(step[1]):
+				world.advance_radio_frame()
+			_refresh_radio(host, world)
 	var error: Error = host.render().save_png(output)
 	if error != OK:
 		push_error("Could not write %s (error %d)" % [output, error])
@@ -191,6 +206,14 @@ func _capture_card(
 		world.registered_phone_contacts().size(),
 	])
 	quit(0)
+
+
+static func _refresh_radio(host: Gen2PokegearScreen, world: Gen2WorldAPI) -> void:
+	var show: Gen2RadioShow = world.radio_show()
+	host.set_radio(
+		world.state.radio_knob(), _station_name(world),
+		show.lines() if show != null else PackedStringArray()
+	)
 
 
 static func _card_text(data: GameData, card: StringName) -> String:


### PR DESCRIPTION
`engine/pokegear/radio.asm`'s shows, which were the last thing the Pokegear card
was missing: the dial, its availability rules and the music each station commits
were already modelled, and the words a programme prints were not.

`Gen2RadioShow` is `RadioJumptable` dispatched once a hardware frame the way
`PlayRadioShow` is. All 87 segments across the eleven channels, each one's rolls
(Oak's route and slot walk, the Pokedex Show's caught-species pick, Places and
People's trainer classes and Kanto landmarks, Buena's daily password), the
100-frame line delay, and the two-row box `PrintRadioLine` and `RadioScroll`
share. The texts come out of `data/text/common_1.asm`, which no importer reads
and which this project authors beside its other engine text.

Two readings the source hides:

- `PrintRadioLine` overwrites the text's own `<LINE>` for the first two lines
  and no others, so line one lands on the top row, line two on the bottom, and
  everything after that on the bottom again once the old line has been copied
  up. The box is a rolling window of two, not a scrollback.
- `PnP_HiddenPeople`'s three labels are one list ending in a single `-1`, and
  `PeoplePlaces4` picks which label to start walking from. Progress therefore
  makes the list *shorter*. Read as three lists that accumulate, the whole rule
  inverts.

Gold and Silver split three ways: no Buena's Password channel, one different
adjective in Oak's Talk (`.OPT_NowText` for `.OPT_GroovyText`), and MYSTICALMAN
inside Places and People's class bound rather than outside it. Landmark ids stay
Crystal-canonical throughout; the two tables differ by exactly one insertion, so
`Gen2WorldRadio.profile_landmark()` is now the whole conversion and replaces six
paired constants.

## Proof

| Check | Result |
|---|---|
| `tools/validate.gd -- radio` | PASS; 87/87 segments on Crystal, 66/66 on Gold and Silver, 25,230 and 22,680 lines printed, no unfilled buffer |
| `tools/validate.gd -- all` | PASS |
| GUT, both tiers | 3,020 tests over 149 scripts, green |
| `tools/replay_world.gd` | 27 routes, 0 failures |
| Story walk, three profiles | Red on all three: 294 steps Crystal, 291 Gold and Silver |

The sweep drives every channel on twenty seeds and both halves of the clock, so
Buena's ten shutdown lines (only reachable when midnight arrives mid-show) are
walked too. `tools/preview_town_map.gd -- crystal out.png 0 radio "<presses>,fN"`
spends the show's frames by hand and pins its seed, so the photograph is
repeatable.