### PR TITLE
The SRAM adapter carries Crystal's player gender

### DIFF
--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -19,9 +19,22 @@ const MON_NAME_LENGTH: int = 11
 const PP_MASK: int = 0x3F
 const PP_UP_MASK: int = 0xC0
 
+## `wPlayerGender` is the first byte of `wCrystalData`, and bit 0 is the whole of
+## it: 0 male, 1 female. The other six bytes of the run are the mobile profile's
+## age, prefecture and postal code, which nothing here owns.
+const PLAYER_GENDER_MASK: int = 0x01
+
 ## `player_id` is wPlayerID, the two big-endian bytes wPlayerData opens with in
 ## both pins (ram/wram.asm), which is why it shares an address with
 ## `primary_data_start`.
+##
+## `player_gender` is Crystal's alone and sits nowhere near the rest: it is
+## `sCrystalData`, its own SRAM section past the Active Box, Link Battle and Hall
+## of Fame ones, so no checksum covers it and `_SaveData` is the only routine
+## that ever writes it. `01:be3d` in `pokecrystal11.sym`, which is bank 1 offset
+## `0x3E3D` in a 32 KiB image; that build is byte identical to the cartridge this
+## project verifies, so the address is the linker's rather than a guess. Gold and
+## Silver have no such section and no such byte: their player is always male.
 const LAYOUTS: Dictionary = {
 	"gold": {
 		"primary_check_1": 0x2008,
@@ -99,6 +112,7 @@ const LAYOUTS: Dictionary = {
 		"player_id": 0x2009,
 		"player_name": 0x200B,
 		"party": 0x2865,
+		"player_gender": 0x3E3D,
 		"game_time": {
 			"cap": 0x2051, "hours": 0x2052, "minutes": 0x2054,
 			"seconds": 0x2055, "frames": 0x2056,
@@ -295,6 +309,7 @@ static func _read_save(
 	save.player_name = Gen2Text.decode_fixed(raw, int(layout["player_name"]), NAME_LENGTH)
 	save.player_id = _read_u16_be(raw, int(layout["player_id"]))
 	save.game_time = _read_game_time(raw, layout["game_time"])
+	save.gender = _read_gender(raw, layout)
 
 	var species_start: int = party_start + 1
 	var terminator: int = int(raw[species_start + count])
@@ -378,6 +393,7 @@ static func _write_save(raw: PackedByteArray, save: Gen2SaveData, data: GameData
 	_write_fixed_text(raw, int(layout["player_name"]), NAME_LENGTH, save.player_name)
 	_write_u16_be(raw, int(layout["player_id"]), save.player_id)
 	_write_game_time(raw, layout["game_time"], save.game_time)
+	_write_gender(raw, layout, save.gender)
 	var party_start: int = int(layout["party"])
 	raw[party_start] = save.party.size()
 	var species_start: int = party_start + 1
@@ -396,6 +412,26 @@ static func _write_save(raw: PackedByteArray, save: Gen2SaveData, data: GameData
 		_write_mon(raw, mons_start + index * PARTYMON_SIZE, mon, data)
 		_write_fixed_text(raw, ot_start + index * NAME_LENGTH, NAME_LENGTH, mon.original_trainer)
 		_write_fixed_text(raw, nickname_start + index * MON_NAME_LENGTH, MON_NAME_LENGTH, mon.nickname)
+
+
+## A profile with no `sCrystalData` reads as male, which is what Gold and Silver
+## are: `wPlayerGender` exists in neither pin's WRAM.
+static func _read_gender(raw: PackedByteArray, layout: Dictionary) -> int:
+	if not layout.has("player_gender"):
+		return Gen2SaveData.GENDER_MALE
+	return Gen2SaveData.GENDER_FEMALE \
+		if raw[int(layout["player_gender"])] & PLAYER_GENDER_MASK \
+		else Gen2SaveData.GENDER_MALE
+
+
+## Only bit 0 is written: the six bytes after it and the seven bits beside it are
+## the mobile profile's, which this project does not own.
+static func _write_gender(raw: PackedByteArray, layout: Dictionary, gender: int) -> void:
+	if not layout.has("player_gender"):
+		return
+	var at: int = int(layout["player_gender"])
+	raw[at] = (int(raw[at]) & ~PLAYER_GENDER_MASK) \
+		| (PLAYER_GENDER_MASK if gender == Gen2SaveData.GENDER_FEMALE else 0)
 
 
 static func _write_mon(raw: PackedByteArray, start: int, mon: Gen2SaveMon, data: GameData) -> void:

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -640,6 +640,72 @@ func test_sram_game_time_round_trips_both_profile_layouts() -> void:
 		assert_eq(restored_time.to_dict(), save.game_time.to_dict(), String(game_id))
 
 
+## `sCrystalData` is its own SRAM section outside both save copies, so the byte
+## is neither checksummed nor mirrored into the backup: an import reads it where
+## it stands and an export writes it in place.
+func test_crystal_carries_the_players_gender_and_the_others_do_not() -> void:
+	var data: GameData = _adapter_data(RomRegistry.CRYSTAL)
+	var raw: PackedByteArray = _raw_cartridge(RomRegistry.CRYSTAL, data)
+	var at: int = int(Gen2SramAdapter.LAYOUTS["crystal"]["player_gender"])
+	# The six bytes after it are the mobile profile's, and so are the seven bits
+	# beside it; both have to come back untouched.
+	raw[at] = 0xF0
+	for byte: int in 6:
+		raw[at + 1 + byte] = 0xA0 + byte
+
+	var male: Dictionary = Gen2SramAdapter.import_bytes(
+		RomRegistry.CRYSTAL, data.sha1, 0, raw, data
+	)
+	assert_true(male["ok"], male["message"])
+	assert_eq((male["save"] as Gen2SaveData).gender, Gen2SaveData.GENDER_MALE)
+
+	raw[at] = 0xF1
+	var female: Dictionary = Gen2SramAdapter.import_bytes(
+		RomRegistry.CRYSTAL, data.sha1, 0, raw, data
+	)
+	assert_true(female["ok"], female["message"])
+	var save: Gen2SaveData = female["save"]
+	assert_eq(save.gender, Gen2SaveData.GENDER_FEMALE)
+
+	save.gender = Gen2SaveData.GENDER_MALE
+	var exported: Dictionary = Gen2SramAdapter.export_bytes(save, raw, data)
+	assert_true(exported["ok"], exported["message"])
+	var output: PackedByteArray = exported["raw"]
+	assert_eq(output[at], 0xF0, "only bit 0 of wPlayerGender is ours to write")
+	for byte: int in 6:
+		assert_eq(output[at + 1 + byte], 0xA0 + byte, "the mobile profile moved")
+	assert_eq(
+		(Gen2SramAdapter.import_bytes(
+			RomRegistry.CRYSTAL, data.sha1, 0, output, data
+		)["save"] as Gen2SaveData).gender,
+		Gen2SaveData.GENDER_MALE
+	)
+
+
+func test_gold_and_silver_have_no_gender_byte_to_read_or_write() -> void:
+	for game_id: StringName in [RomRegistry.GOLD, RomRegistry.SILVER]:
+		assert_false(
+			Gen2SramAdapter.LAYOUTS[String(game_id)].has("player_gender"),
+			"%s has no sCrystalData section" % game_id
+		)
+		var data: GameData = _adapter_data(game_id)
+		var raw: PackedByteArray = _raw_cartridge(game_id, data)
+		var imported: Dictionary = Gen2SramAdapter.import_bytes(
+			game_id, data.sha1, 0, raw, data
+		)
+		assert_true(imported["ok"], imported["message"])
+		var save: Gen2SaveData = imported["save"]
+		assert_eq(save.gender, Gen2SaveData.GENDER_MALE, String(game_id))
+		# An export of a female save must not invent a byte for her.
+		save.gender = Gen2SaveData.GENDER_FEMALE
+		var exported: Dictionary = Gen2SramAdapter.export_bytes(save, raw, data)
+		assert_true(exported["ok"], exported["message"])
+		assert_eq(
+			(exported["raw"] as PackedByteArray).slice(0x3E00, 0x3F00),
+			raw.slice(0x3E00, 0x3F00), String(game_id)
+		)
+
+
 func test_silver_uses_the_gold_save_layout() -> void:
 	var data: GameData = _adapter_data(RomRegistry.SILVER)
 	var raw: PackedByteArray = _raw_cartridge(RomRegistry.SILVER, data)


### PR DESCRIPTION
The last mapped field the cartridge boundary was missing, and the reason it was
open was that the address had nowhere to come from.

`wPlayerGender` is the first byte of `wCrystalData`, which sits *before*
`wPlayerData` in WRAM. So it is outside `sGameData`, outside both save copies and
outside either checksum: `sCrystalData` is its own SRAM section, `_SaveData`
writes it and nothing else does, which is how it survives a normal save without
being in one.

That section has no address in the source at all, only an order in
`layout.link`, which is why counting struct sizes was never going to settle it.
It is read off the linker instead. rgbds is on this machine, and
`make pokecrystal11.gbc` in a scratch copy of the pinned checkout comes out byte
identical to the cartridge this project verifies
(`f2f52230b536214ef7c9924f483392993e226cfb`), so `pokecrystal11.sym` beside it is
that cartridge's own symbol table: `sCrystalData` is `01:be3d`, offset `0x3E3D`
in a 32 KiB image.

Only bit 0 is written. The six bytes after it are the mobile profile's age,
prefecture and postal code, and the seven bits beside it are the profile's too;
the tests assert both come back untouched through an import, an edit and an
export. Gold and Silver ship neither the section nor the WRAM byte, so their
layouts carry no entry, they read as male, and exporting a female save does not
invent a byte for her.

## Proof

| Check | Result |
|---|---|
| GUT, both tiers | 3,022 tests over 149 scripts, green |
| `tools/validate.gd -- all` | 48 topics PASS, 0 FAIL |
| `tools/replay_world.gd` | 27 routes, 0 failures |
| Story walk, three profiles | Red on all three: 294 Crystal, 291 Gold and Silver |

The full tier came back red once on three of the mod tests that pick up a broken
mod outside this repository, and green on the two runs either side of it.