### PR TITLE
The replay corpus buys something

### DIFF
--- a/game/world/oak_speech.gd
+++ b/game/world/oak_speech.gd
@@ -1,96 +1,75 @@
 class_name Gen2OakSpeech
 extends RefCounted
 
-## `engine/menus/intro_menu.asm`'s OakSpeech as a list of beats.
-##
-## The routine is a straight run of pic-then-text pairs with one branch in it,
-## `NamePlayer`, so the model is the sequence and nothing else: no timing, no
-## palette rotation and no cry, which are the screen's or a boundary.
-##
-## Scene-free, so the order can be checked without drawing it.
+## `engine/menus/intro_menu.asm`'s OakSpeech as a list of beats: a run of
+## pic-then-text pairs with one branch, `NamePlayer`. Timing, palette rotation
+## and the cry belong to the screen, so this stays scene-free and checkable.
 
 ## What a beat shows above its text.
 enum Pic {
 	## `Intro_PrepTrainerPic` with wTrainerClass POKEMON_PROF.
 	OAK,
-	## `PrepMonFrontpic` with zeroed DVs, on whichever species the profile
-	## shows: see [method intro_species].
+	## `PrepMonFrontpic`, zeroed DVs, on [method intro_species].
 	MON,
-	## `DrawIntroPlayerPic`: CAL's trainer pic in Gold and Silver, and the
-	## uncompressed ChrisPic or KrisPic in Crystal.
+	## `DrawIntroPlayerPic`: CAL in Gold and Silver, ChrisPic or KrisPic here.
 	PLAYER,
 }
 
-## How a beat's picture arrives, which is the call between `GetSGBLayout` and
-## the `PrintText` over it.
+## How a beat's picture arrives, between `GetSGBLayout` and the `PrintText`.
 enum Enter {
 	## The beat keeps the picture the one before it drew.
 	NONE,
-	## `Intro_RotatePalettesLeftFrontpic`, the six-step fade the three trainer
-	## pics come in on.
+	## `Intro_RotatePalettesLeftFrontpic`, the trainer pics' six-step fade.
 	FRONTPIC,
 	## `Intro_WipeInFrontpic`, which the species beat uses instead.
 	WIPE,
 }
 
-## `constants/trainer_constants.asm`: POKEMON_PROF is class $0a, and its pic is
-## in the same table every other trainer class's is. CAL is $0c, the class Gold
-## and Silver draw the player with, since they ship no ChrisPic.
+## `constants/trainer_constants.asm`. CAL is the class Gold and Silver draw the
+## player with, since they ship no ChrisPic.
 const POKEMON_PROF: int = 0x0A
 const CAL: int = 0x0C
-## The one species the speech shows, and it is not the same on both pins:
-## `OakSpeech` is `ld a, MARILL` in pokegold and `ld a, WOOPER` in
-## pokecrystal (`engine/menus/intro_menu.asm`). Numbers from
-## `constants/pokemon_constants.asm`.
+## `OakSpeech` is `ld a, MARILL` in pokegold and `ld a, WOOPER` in pokecrystal.
 const MARILL: int = 183
 const WOOPER: int = 194
 
-## Where `NamePlayer` sits: after `_OakText6` and before `_OakText7`. The source
-## reaches `ShowPlayerNamingChoices` first and only its NEW NAME row reaches
+## Where `NamePlayer` sits. Only `ShowPlayerNamingChoices`' NEW NAME row reaches
 ## `NamingScreen`.
 const NAME_AFTER: String = "oak_6"
 
 ## `constants/music_constants.asm`: MUSIC_ROUTE_30.
 const MUSIC_ROUTE_30: int = 0x2B
 
-## `ShrinkPlayer`, which `InitializeWorld` calls the moment `OakSpeech` returns,
-## on the screen the speech left standing. `constants/sfx_constants.asm`:
-## SFX_ESCAPE_ROPE.
+## `ShrinkPlayer`, which `InitializeWorld` runs on the screen the speech left
+## standing. SFX_ESCAPE_ROPE, then `ld a, 32` into wMusicFade on MUSIC_NONE.
 const SHRINK_SFX: int = 0x10
-## `ld a, 32` into wMusicFade, on MUSIC_NONE.
 const SHRINK_FADE_FRAMES: int = 32
-## Its five `DelayFrames` operands, in order: before the first shrink picture,
-## between the two, before the box is cleared, before the sprite is placed, and
-## while the sprite stands there.
+## Its five `DelayFrames` operands: before the first shrink picture, between the
+## two, before the box is cleared, before the sprite is placed, and while it
+## stands there.
 const SHRINK_WAITS: Array[int] = [8, 8, 8, 3, 50]
-## `hlcoord 6, 5`, one row below the pictures `ShrinkFrame` places at (6,4), so
-## the box `ClearBox` empties leaves their top tile row behind. Both shrink
-## pictures are blank there, so nothing of it shows.
+## `hlcoord 6, 5`, a row below `ShrinkFrame`'s (6,4), so `ClearBox` leaves the
+## pictures' top tile row behind; both are blank there.
 const SHRINK_CLEAR_AT: Vector2i = Vector2i(6, 5)
-## `Intro_PlacePlayerSprite`'s four `dbsprite` entries are one 16x16 icon whose
-## first OAM slot is y `9 * 8 + 4`, x `9 * 8`. Hardware OAM counts from
-## (-8, -16), so the icon's top-left pixel is (72 - 8, 76 - 16).
+## `Intro_PlacePlayerSprite`'s four `dbsprite` entries are one 16x16 icon at
+## y `9 * 8 + 4`, x `9 * 8`; hardware OAM counts from (-8, -16).
 const SHRINK_SPRITE_AT: Vector2i = Vector2i(64, 60)
 
-## `.PlayerNameString`, which the naming screen prints above its entry.
+## `.PlayerNameString`, printed above the naming screen's entry.
 const NAME_PROMPT: String = "YOUR NAME?"
 
-## `home/string.asm`'s InitName: an empty or all-spaces entry is replaced by the
-## gendered default rather than kept, so a save never carries a blank trainer.
+## `home/string.asm`'s InitName replaces a blank entry with the gendered
+## default, so a save never carries a blank trainer.
 const DEFAULT_MALE: String = "CHRIS"
 const DEFAULT_FEMALE: String = "KRIS"
 
 
 ## The beats in source order, each `{ pic, text, key, enter, clears_after }`.
 ##
-## `_OakText2` and `_OakText4` are two `PrintText` calls with one pic between
-## them, so they are two beats on the same picture; `_OakText3` is a bare
-## promptbutton and carries no words, so it is not one.
-##
-## `clears_after` is the `RotateThreePalettesRight` and `ClearTilemap` that
-## follow a beat's text. The two beats without it are `_OakText4`'s neighbour,
-## which keeps its picture, and `_OakText6`, which runs straight into
-## `NamePlayer`.
+## `_OakText2` and `_OakText4` are two `PrintText` calls over one pic, so they
+## are two beats; `_OakText3` is a bare promptbutton and is not one.
+## `clears_after` is the `RotateThreePalettesRight` and `ClearTilemap` behind a
+## beat's text, which `_OakText4`'s neighbour and `_OakText6` do not have.
 static func beats(data: GameData) -> Array:
 	if data == null:
 		return []
@@ -119,7 +98,7 @@ static func beats(data: GameData) -> Array:
 
 
 ## `InitName`'s substitution, which is what makes the naming screen's END
-## reachable with nothing typed: a blank entry becomes CHRIS or KRIS.
+## reachable with nothing typed.
 static func resolve_name(entered: String, gender: int) -> String:
 	if entered.strip_edges() != "":
 		return entered
@@ -127,12 +106,11 @@ static func resolve_name(entered: String, gender: int) -> String:
 
 
 ## `_OakText7` opens on `<PLAYER>`, which the text codec leaves as a marker
-## because only the caller knows the name. This is that caller.
+## because only the caller knows the name.
 static func with_player_name(text: String, player_name: String) -> String:
 	return text.replace("<PLAYER>", player_name)
 
 
-## Which species `OakSpeech` puts on the two middle beats. Gold and Silver show
-## a Marill where Crystal shows a Wooper.
+## Which species `OakSpeech` puts on the two middle beats.
 static func intro_species(data: GameData) -> int:
 	return WOOPER if Gen2WorldState.is_crystal_profile(data) else MARILL

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -37,6 +37,15 @@ const DIRECTIONS: Array[int] = [
 const ROUTE_GROUP: int = Gen2WorldSpawn.NEW_BARK_GROUP
 const ROUTE_MAPS: int = 8
 
+## Cherrygrove's mart, which is map 1/8 with the clerk on (1,3) and its two door
+## cells on (2,7) and (3,7) in all three caches, so one errand route sweeps
+## every profile the way the walk routes do.
+const MART_MAP: Vector2i = Vector2i(1, 8)
+const MART_DOOR: Vector2i = Vector2i(3, 7)
+## The counter cell the clerk is talked to across, which is `preview_world_story`'s
+## own MART_CLERK_FACE: `CheckFacingObject` reaches two cells over a `$90`.
+const MART_COUNTER: Vector2i = Vector2i(3, 3)
+
 var _failures: int = 0
 var _routes: int = 0
 
@@ -73,11 +82,21 @@ func _sweep() -> void:
 
 
 ## Every map in the spawn group the cache ships, entered on a cell the cartridge
-## itself warps onto, plus the new game's own spawn. A route list rather than one
-## map, because a walk that never leaves an empty bedroom proves the pump on
-## nothing.
+## itself warps onto, plus the new game's own spawn and one scripted errand. A
+## route list rather than one map, because a walk that never leaves an empty
+## bedroom proves the pump on nothing.
 func _routes_for(data: GameData) -> Array:
-	var out: Array = [{"name": "new_game_spawn", "spawn": true}]
+	var out: Array = [
+		{"name": "new_game_spawn", "spawn": true},
+		{
+			"name": "mart_errand",
+			"spawn": true,
+			"errand": true,
+			"group": MART_MAP.x,
+			"number": MART_MAP.y,
+			"cell": MART_DOOR,
+		},
+	]
 	for number: int in range(1, ROUTE_MAPS + 1):
 		var map: Gen2WorldMap = data.world_map(ROUTE_GROUP, number)
 		if map == null:
@@ -99,7 +118,8 @@ func _check_route(data: GameData, route: Dictionary, frames: int) -> int:
 	_routes += 1
 	var failures: int = 0
 	var seed_value: int = _route_seed(data, route)
-	var program: Array = _program(seed_value, frames)
+	var errand: bool = bool(route.get("errand", false))
+	var program: Array = _program(seed_value, frames, errand)
 
 	var recorded: Dictionary = await _run(data, route, seed_value, frames, program, true)
 	if not bool(recorded.get("ok", false)):
@@ -112,6 +132,12 @@ func _check_route(data: GameData, route: Dictionary, frames: int) -> int:
 	## closes in the story walker.
 	if String(recorded["world"]) == String(recorded["initial"]):
 		_report(data, route, "record", "the run moved no world state, so it proves nothing")
+		return 1
+	## And an errand that never reached the till is a walk around a shop: the
+	## money is what says the clerk's script ran, the overlay opened and a
+	## purchase was committed, which is the whole reason this route is here.
+	if errand and int(recorded["money"]) >= int(recorded["initial_money"]):
+		_report(data, route, "record", "the mart took no money, so no purchase was replayed")
 		return 1
 
 	for label: String in ["replay", "30fps", "144fps"]:
@@ -160,6 +186,13 @@ func _run(
 	save.run_seed = seed_value
 	if bool(route.get("spawn", false)):
 		save.world = Gen2WorldSpawn.new_game_snapshot(data)
+		## An errand starts from the new game's own snapshot rather than a bare
+		## map, because the start money is what a mart spends and only the spawn
+		## carries it, and then stands on the errand's map.
+		if bool(route.get("errand", false)) and save.world != null:
+			save.world.map_id = Vector2i(int(route["group"]), int(route["number"]))
+			save.world.player_cell = route["cell"]
+			save.world.last_spawn_map = save.world.map_id
 	else:
 		screen.map_group = int(route["group"])
 		screen.map_number = int(route["number"])
@@ -180,6 +213,7 @@ func _run(
 	screen.set_process(false)
 
 	var initial: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
+	var initial_money: int = screen._world.state.money()
 	screen.replay_input(log)
 	if recording:
 		screen.record_input()
@@ -195,6 +229,7 @@ func _run(
 
 	var state: String = _state(screen, save)
 	var world: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
+	var money: int = screen._world.state.money()
 	var consumed: Array = screen.input_recording()
 	root.remove_child(screen)
 	screen.free()
@@ -202,6 +237,8 @@ func _run(
 		"ok": true,
 		"state": state,
 		"initial": initial,
+		"initial_money": initial_money,
+		"money": money,
 		"world": world,
 		"log": log if not recording else consumed,
 	}
@@ -220,7 +257,9 @@ func _state(screen: Gen2WorldScreen, save: Gen2SaveData) -> String:
 ## The input a run is driven by: a direction held for a while, an occasional A,
 ## and nothing else the cartridge's own controller does not have. Deterministic
 ## in the route's seed, so the generated program is itself reproducible.
-func _program(seed_value: int, frames: int) -> Array:
+func _program(seed_value: int, frames: int, errand: bool = false) -> Array:
+	if errand:
+		return _errand_program(frames)
 	var random := RandomNumberGenerator.new()
 	random.seed = seed_value
 	var log: Array = []
@@ -236,6 +275,36 @@ func _program(seed_value: int, frames: int) -> Array:
 				break
 			log.append({"frame": frame, "kind": "hold", "button": direction})
 			frame += 1
+	return log
+
+
+## The scripted errand: walk the door column up to the counter, turn into the
+## clerk, and then press A on a cadence for the rest of the run. That one button
+## carries the whole leg, because every step of it answers a press: the clerk's
+## `pokemart` dialog, the mart overlay's own A, and the boxes on either side.
+##
+## Held rather than counted out step by step: `move_player` refuses while a step
+## is in flight, so a direction held to the counter arrives on the cell whatever
+## the walk rate is, and the turn into the counter is a press the wall refuses to
+## move on.
+func _errand_program(frames: int) -> Array:
+	var log: Array = []
+	var walk: int = mini(frames, (MART_DOOR.y - MART_COUNTER.y) * Gen2WorldAPI.STEP_FRAMES_WALK)
+	for frame: int in range(1, walk + 1):
+		log.append({"frame": frame, "kind": "hold", "button": Gen2Button.UP})
+	## Clear of the walk rather than up against it: `move_player` refuses a press
+	## while the last step is still in flight, and a turn that is refused leaves
+	## the player facing the wall behind the counter instead of the clerk.
+	if walk + Gen2WorldAPI.STEP_FRAMES_WALK * 3 <= frames:
+		log.append({
+			"frame": walk + Gen2WorldAPI.STEP_FRAMES_WALK * 3,
+			"kind": "press",
+			"button": Gen2Button.LEFT,
+		})
+	var frame: int = walk + Gen2WorldAPI.STEP_FRAMES_WALK * 5
+	while frame <= frames:
+		log.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
+		frame += 8
 	return log
 
 


### PR DESCRIPTION
`tools/replay_world.gd` walked group 24 with a generated button program, which is a corpus of walks: nothing in it opened an overlay a script had asked for, so the one thing a replay most has to reproduce was never exercised.

Adds a scripted errand route on map 1/8, whose clerk stands on (1,3) and whose door cells are (2,7) and (3,7) in all three caches. It starts from the new game's own snapshot, because the start money is what a mart spends and only the spawn carries it, walks the door column to the counter, turns into the clerk and then presses A on a cadence until the money is gone. The run is refused unless the till took some, so a walk around a shop cannot pass for a purchase.

| Run | Routes | Failures |
|---|---|---|
| `replay_world.gd` on all three cartridges | 30 | 0 |
| GUT unit tier | 2,675 tests, 121 scripts | 0 |
| `validate.gd -- all` | exit 0 | 0 |
| story walk, Gold / Silver / Crystal | 292 / 292 / 295 steps to Red | 0 |

Also tightens `game/world/oak_speech.gd`'s comments to one line a symbol, 62 to 40, with the code byte for byte.