### PR TITLE
A received item has a name, and Mom stays in the room

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2273,7 +2273,12 @@ func set_object_time(hour: int, time_of_day: int) -> void:
 	object_hour = clampi(hour, 0, 23)
 	object_time_of_day = clampi(time_of_day, 0, 3)
 	for object: Gen2WorldObject in objects:
-		object.active = object.visible_with_state(object_hour, object_time_of_day, state)
+		## The flag half of the test is the one the object table was built with,
+		## not the live one: see [member Gen2WorldObject.flag_hidden]. The time
+		## half is live, because `CheckObjectTime` runs from the clock callback
+		## while the map is up.
+		object.active = object.visible_at(object_hour, object_time_of_day) \
+			and not object.flag_hidden
 		var key: String = _object_key(current_map.group, current_map.number, object.index)
 		if _object_visibility_overrides.has(key):
 			object.active = bool(_object_visibility_overrides[key])
@@ -5558,8 +5563,15 @@ func _load_objects(carry_presentation: bool = false) -> void:
 			object.cell = _object_position_overrides[key]
 		if _object_facing_overrides.has(key):
 			object.facing = int(_object_facing_overrides[key])
+		## A reload that carries presentation is a refresh under a running
+		## script, not a map load, so the flag answer is carried with it;
+		## `ReadObjectEvents` is the only thing that reads the flag, and it runs
+		## once per map load.
 		if index < previous.size():
 			object.carry_presentation_from(previous[index] as Gen2WorldObject)
+			object.flag_hidden = (previous[index] as Gen2WorldObject).flag_hidden
+		else:
+			object.flag_hidden = object.event_flag_active(state)
 		objects.append(object)
 	set_object_time(object_hour, object_time_of_day)
 

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -65,6 +65,12 @@ var object_type: int = 0
 var sight_range: int = 0
 var event_script: int = 0
 var event_flag: int = 0
+## Whether [member event_flag] was set when this object table was built.
+## `ReadObjectEvents` reads the flag at map load and `wMapObjects` carries the
+## answer until the next one, so a script that writes the flag while the map is
+## up moves nothing: only `appear` and `disappear`, which edit the live struct as
+## well, do. Kept across a mid-script object reload for that reason.
+var flag_hidden: bool = false
 var trainer_data: Dictionary = {}
 var facing: int = Gen2WorldSprite.FACING_DOWN
 ## The `Facings` frame this object is drawn on, 0 to 3: two standing and two
@@ -272,6 +278,12 @@ func visible_at(hour: int, time_of_day: int) -> bool:
 
 ## A zero or negative flag is the cache's no-flag/default value. The source
 ## uses $FFFF as the explicit always-visible sentinel, imported as -1.
+##
+## Read once, when the object table is built: `ReadObjectEvents` tests the flag
+## at map load and nothing re-tests it while the map is up, which is the whole
+## reason `appear` and `disappear` exist. A `setevent` on an object's own flag
+## therefore changes nothing on screen until the map is loaded again. See
+## [member flag_hidden].
 func visible_with_state(hour: int, time_of_day: int, state: Gen2WorldState) -> bool:
 	return visible_at(hour, time_of_day) and not event_flag_active(state)
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1197,14 +1197,18 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 			)
 			_emit_runtime_event(&"text_buffer_requested", command)
 		Gen2WorldScript.GETSTRING:
+			## `Script_getstring` is `CopyName1`, which copies a plain character
+			## run up to its `@`. It is not a text: the first byte of
+			## `PokegearName` is `#`, which the command layer reads as an unknown
+			## command and refuses, so decoding this the way `writetext` is
+			## decoded leaves every `getstring` buffer empty and prints
+			## "<PLAYER> received !" with a hole where the name belongs.
 			var string_text: String = ""
 			if data != null:
 				var string_data: PackedByteArray = data.world_text(
 					int(_request.get("bank", 0)), int(command["address"])
 				)
-				var string_decoded: Dictionary = _decode_text_with_buffers(string_data)
-				if bool(string_decoded.get("ok", false)):
-					string_text = String(string_decoded.get("text", ""))
+				string_text = Gen2Text.decode(string_data, 0, string_data.size())
 			_set_text_buffer(int(command["string_buffer"]), string_text, &"string", {
 				"bank": int(_request.get("bank", 0)), "address": int(command["address"]),
 			})

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -923,11 +923,11 @@ func test_a_flagged_rock_stays_smashed_across_a_reload() -> void:
 	assert_true(bool(world.smash_object(ROCK_OBJECT_INDEX).get("ok", false)))
 	assert_true(world.state.is_event_flag_active(ROCK_EVENT_FLAG))
 
-	# The cache's own record still carries -1, so the reloaded object needs the
-	# flag put back on it the way the cartridge's map data carries it.
+	# The cache's own record still carries -1, so the map data needs the flag put
+	# on it the way the cartridge's does, before the load that reads it:
+	# `ReadObjectEvents` is the only thing that tests an object's event flag.
+	world.current_map.events["objects"][ROCK_OBJECT_INDEX]["event_flag"] = ROCK_EVENT_FLAG
 	world.reload_current_map()
-	(world.objects[ROCK_OBJECT_INDEX] as Gen2WorldObject).event_flag = ROCK_EVENT_FLAG
-	world.set_object_time(world.object_hour, world.object_time_of_day)
 	assert_null(world.object_at(ROCK_CELL), "a set event flag keeps it hidden")
 
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -313,7 +313,10 @@ func test_production_world_entry_and_facing_object_story_persist_separate_flags(
 	_world_screen._advance_script_input()
 	assert_true(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_true(_world_screen._world.state.hall_of_fame())
-	assert_eq(_world_screen.world_snapshot()["visible_objects"], 0)
+	## Still on screen: `ReadObjectEvents` tested the flag when the map loaded
+	## and nothing re-tests it while the map is up, so the `setevent` this script
+	## just ran hides the object on the next load, which is `restored` below.
+	assert_eq(_world_screen.world_snapshot()["visible_objects"], 1)
 
 	var snapshot: Gen2WorldSnapshot = _world_screen.world_save_snapshot()
 	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(_data, snapshot)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2402,11 +2402,19 @@ func test_event_flags_hide_objects_from_rendering_occupancy_and_dispatch() -> vo
 	assert_eq(world.dispatch_events(Vector2i(5, 6)).size(), 1)
 	assert_false(world.can_walk_to(Vector2i(5, 6)))
 
+	## `ReadObjectEvents` tests the flag at map load and nothing re-tests it while
+	## the map is up, so writing it moves nothing until the map is loaded again.
+	## That is why `appear` and `disappear` exist and edit the struct themselves.
 	world.set_event_flag(7)
-	assert_eq(world.visible_objects().size(), 0)
-	assert_null(world.object_at(Vector2i(5, 6)))
-	assert_true(world.can_walk_to(Vector2i(5, 6)))
-	assert_eq(world.dispatch_events(Vector2i(5, 6)).size(), 0)
+	assert_eq(world.visible_objects().size(), 1)
+	assert_not_null(world.object_at(Vector2i(5, 6)))
+	assert_false(world.can_walk_to(Vector2i(5, 6)))
+
+	var reloaded: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(world.data, world.snapshot())
+	assert_eq(reloaded.visible_objects().size(), 0)
+	assert_null(reloaded.object_at(Vector2i(5, 6)))
+	assert_true(reloaded.can_walk_to(Vector2i(5, 6)))
+	assert_eq(reloaded.dispatch_events(Vector2i(5, 6)).size(), 0)
 
 	world.clear_event_flag(7)
 	assert_eq(world.visible_objects().size(), 1)
@@ -2649,7 +2657,9 @@ func test_facing_interaction_commits_map_and_engine_flags_after_text() -> void:
 	assert_eq(completed[0]["status"], &"complete")
 	assert_true(world.event_flag_active(7))
 	assert_true(world.state.hall_of_fame())
-	assert_eq(world.visible_objects().size(), 0)
+	## Still standing there: the flag hides it on the next map load, not on the
+	## `setevent` that wrote it, which is what `restored` below is.
+	assert_eq(world.visible_objects().size(), 1)
 
 	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(data, world.snapshot())
 	assert_not_null(restored)
@@ -5885,6 +5895,35 @@ func test_text_ram_resolves_through_the_cartridges_own_pointer_table() -> void:
 	var ram: Dictionary = runner.text_context()["ram"]
 	assert_true(ram.has(0xCF6B), "buffer 4 is wStringBuffer1, not wStringBuffer4")
 	assert_false(ram.has(0xCFA4))
+
+
+## `Script_getstring` is `CopyName1`: a plain character run ending in `@`, not a
+## text-command stream. `PokegearName` is `db "#GEAR@"`, and `#` is `$54`, which
+## the command layer refuses as an unknown command; decoding it that way filled
+## the buffer with nothing and printed "<PLAYER> received !" in Mom's own scene.
+func test_getstring_reads_a_name_and_not_a_text_stream() -> void:
+	var texts: Dictionary = RomCache.read_json(RomCache.world_text_path(_directory))
+	# "#GEAR@": the word code for POKé, four letters, and the name terminator.
+	texts["48:6500"] = [0x54, 0x86, 0x84, 0x80, 0x91, 0x50]
+	RomCache.write_json(RomCache.world_text_path(_directory), texts)
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6430"] = [
+		Gen2WorldScript.GETSTRING, 0x00, 0x65, RomLayout.STRING_BUFFER_4,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.from_dict({}), {
+		"kind": &"script", "bank": 48, "script": 0x6430,
+	})
+	runner.advance()
+
+	var context: Dictionary = runner.text_context()
+	assert_eq(String(context["buffers"][RomLayout.STRING_BUFFER_4]), "POKéGEAR")
+	assert_eq(
+		String((context["ram"] as Dictionary)[0xCFA4]), "POKéGEAR",
+		"_ReceivedItemText reads wStringBuffer4 by address, not by number"
+	)
 
 
 func test_an_unfilled_buffer_contributes_no_address() -> void:


### PR DESCRIPTION
Two defects in `PlayersHouse1F`'s own scene, both reproducible on Gold, Silver and Crystal.

**`getstring` read its operand with the text-command decoder.** `Script_getstring` is `CopyName1`: a plain character run ending in `@`, not a command stream. The first byte of `PokegearName` is `#`, which is `$54`, which the command layer refuses as an unknown command, so the buffer was filled with nothing and `_ReceivedItemText` printed `PLAYER received .` with a hole where POKéGEAR belongs. All 283 `getstring` uses read the same way.

**An object's visibility was re-derived from the live event flags.** `ReadObjectEvents` tests an object's flag while it builds `wMapObjects` and nothing re-tests it while the map is up, which is exactly why `appear` and `disappear` exist and edit the live struct themselves. `MeetMomScript` sets `EVENT_PLAYERS_HOUSE_MOM_1` and clears `MOM_2` twenty lines before Mom walks back to her spot, so re-reading the flags moved her into the kitchen in the middle of her own scene. The flag answer is now taken when the object table is built and carried across a mid-script reload; `appear`, `disappear` and `smash_object` are unaffected, since each already edits the object as well as the flag.

| Check | Result |
|---|---|
| GUT, both tiers | 3,024 tests over 149 scripts, green |
| `validate.gd -- all` | exit 0, 48 topics |
| `replay_world.gd` | 30 routes, 0 failures |
| story walk Gold / Silver / Crystal | 292 / 292 / 295 steps to Red |