### PR TITLE
Say each source finding once

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -10,9 +10,8 @@ extends RefCounted
 ## through [method must_replace] and stands still until [method replace_fallen],
 ## the only entry point besides [method take_actions] that moves a battle on.
 
-## The two sides, as plain numbers rather than an enum: they are dictionary keys
-## and event payloads throughout, and an enum buys nothing where everything that
-## reads one is comparing it against these two constants.
+## Plain numbers rather than an enum: they are dictionary keys and event payloads
+## throughout, and everything reading one compares it against these two.
 const PLAYER: int = 0
 const ENEMY: int = 1
 
@@ -29,9 +28,9 @@ const FAINTED: StringName = &"fainted"
 const HIT_TIMES: StringName = &"hit_times"
 ## A draining move healed the attacker off what it dealt.
 const DRAINED: StringName = &"drained"
-## A one-hit KO landed. Its own event rather than a flag on [constant HIT]:
-## the cartridge shows neither a critical hit nor an effectiveness line for
-## one, since the damage was never actually multiplied by either.
+## A one-hit KO landed. Its own event rather than a flag on [constant HIT]: the
+## cartridge shows neither a critical nor an effectiveness line, the damage
+## having been multiplied by neither.
 const OHKO: StringName = &"ohko"
 ## A status stopped a Pokémon moving, [code]reason[/code] being which:
 ## [code]&"sleep"[/code], [code]&"freeze"[/code], [code]&"paralysis"[/code],

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -1,75 +1,62 @@
 class_name Gen2BattleAnimPlayer
 extends RefCounted
 
-## One battle animation playing: `RunBattleAnimScript`'s own frame loop
-## (engine/battle_anims/anim_commands.asm).
+## One battle animation playing: `RunBattleAnimScript`'s frame loop
+## (engine/battle_anims/anim_commands.asm). [Gen2BattleAnimScript] is the
+## interpreter and knows only bytes, [Gen2BattleAnimObject] is one object and
+## knows only itself; this is what the cartridge does with both once a frame,
+## running the script until it yields, stepping every live object and collecting
+## what they would put in `wShadowOAM`.
 ##
-## [Gen2BattleAnimScript] is the interpreter and knows only bytes;
-## [Gen2BattleAnimObject] is one object and knows only itself. This is what the
-## cartridge does with both once a frame: run the script until it yields, step
-## every live object, and collect what they would put in `wShadowOAM`.
-##
-## Scene-free like the rest of the battle layer. Nothing here draws: a frame
-## answers with sprites, a tile window and the palette each sprite wants, and
-## whoever is drawing decides what that looks like.
-##
-## All five of `.playframe`'s steps are here. [method unimplemented] reports what
-## an animation asked for and did not get, which cartridge data no longer
-## produces and a hand-built region still can.
+## Scene-free: a frame answers with sprites, a tile window and the palette each
+## sprite wants. All five of `.playframe`'s steps are here, and
+## [method unimplemented] reports what an animation asked for and did not get,
+## which cartridge data no longer produces and a hand-built region still can.
 
-## `NUM_BATTLE_ANIM_STRUCTS`: ten slots, and an eleventh object is simply not
-## spawned.
+## `NUM_BATTLE_ANIM_STRUCTS`: an eleventh object is simply not spawned.
 const MAX_OBJECTS: int = 10
 
-## `BATTLEANIMSTRUCT_LENGTH`, which only matters because `BattleAnimCmd_ClearObjs`
-## counts in bytes rather than objects.
+## Matters only because `BattleAnimCmd_ClearObjs` counts bytes, not objects.
 const OBJECT_STRUCT_BYTES: int = 24
 
 ## `BattleAnimCmd_ClearObjs` clears `$a0` bytes where the ten structs are `$f0`,
-## so it reaches into the seventh object and stops. Zeroing a struct's first byte
-## is what frees it, so seven slots are freed and the last three survive a
-## command that reads as if it cleared everything.
-## This is the cartridge's own bug (docs/bugs_and_glitches.md) and is reproduced.
+## stopping inside the seventh. Zeroing a struct's first byte frees it, so seven
+## go and the last three survive a command that reads as clearing everything:
+## the cartridge's own bug (docs/bugs_and_glitches.md), reproduced.
 const CLEAR_OBJS_BYTES: int = 0xA0
 
-## `OAM_COUNT`: the hardware's forty sprites. An object whose sprites would run
-## past the end aborts the whole update, which is why a busy frame can lose the
-## objects queued after it rather than truncating one.
+## The hardware's forty sprites. An object whose sprites would overrun aborts the
+## whole update, so a busy frame loses the objects after it rather than one.
 const MAX_SPRITES: int = 40
 
-## `NUM_BATTLEANIMTILEDICT_ENTRIES`: the five graphics sheets one animation may
-## have loaded at once, as `anim_1gfx` through `anim_5gfx` fill them.
+## The five sheets `anim_1gfx` through `anim_5gfx` may have loaded at once.
 const TILE_DICT_ENTRIES: int = 5
 
-## The tile window an animation's graphics are loaded into, from
-## `BATTLEANIM_BASE_TILE` up to `vTiles1`. `BattleAnimCmd_*GFX` stops loading
-## once the running tile id reaches this, which is why a five-sheet animation
-## can silently load fewer than five.
+## The window graphics load into, `BATTLEANIM_BASE_TILE` up to `vTiles1`.
+## `BattleAnimCmd_*GFX` stops once the running tile id reaches it, so a
+## five-sheet animation can silently load fewer.
 const MAX_TILES: int = 128 - Gen2BattleAnimObject.BASE_TILE
 
 ## `wBattleAnimFlags` bits (constants/ram_constants.asm).
 const FLAG_KEEP_SPRITES: int = 1 << 3
 
-## The two `AnimObjGFX` rows that hold no sheet of their own: the battler
-## graphics commands fill them in from whichever picture is on the field.
+## The two `AnimObjGFX` rows with no sheet: the battler graphics commands fill
+## them from whichever picture is on the field.
 const GFX_PLAYERHEAD: int = 0x28
 const GFX_ENEMYFEET: int = 0x29
 
-## `vTiles0`, the object tile bank the animation window sits at the end of.
-## `BattleAnimCmd_BattlerGFX_*` counts its destinations back from the top of it.
+## `vTiles0`, whose top `BattleAnimCmd_BattlerGFX_*` counts back from.
 const OBJECT_TILES: int = 0x80
 
-## `NUM_BG_EFFECTS`: five background effects run at once, and a sixth is simply
-## not queued, the way an eleventh object is not spawned.
+## Five background effects at once; a sixth is not queued, as an eleventh object
+## is not spawned.
 const MAX_BG_EFFECTS: int = Gen2BattleAnimBgEffects.MAX_EFFECTS
 
-## `ROLLOUT`, the move `Rollout_FillLYOverridesBackup` and `.playframe`'s own
-## frame-delay branch both check `wFXAnimID` against.
+## What `Rollout_FillLYOverridesBackup` and `.playframe` check `wFXAnimID` for.
 const ROLLOUT: int = 0xCD
 
-## `BATTLE_AFTERANIMS` (constants/move_constants.asm) and the four offsets from
-## it a battle command writes into `wBattleAfterAnim`. The byte stored is the
-## offset; `BattleAnimRunScript` adds the base back to reach the animation.
+## `BATTLE_AFTERANIMS` and the four offsets from it written into
+## `wBattleAfterAnim`; `BattleAnimRunScript` adds the base back.
 const BATTLE_AFTERANIMS: int = 0x10E
 const AFTER_ANIM_NONE: int = 0
 const AFTER_ANIM_ENEMY_DAMAGE: int = 0x10F - BATTLE_AFTERANIMS
@@ -78,10 +65,9 @@ const AFTER_ANIM_PLAYER_DAMAGE: int = 0x112 - BATTLE_AFTERANIMS
 const AFTER_ANIM_WOBBLE: int = 0x113 - BATTLE_AFTERANIMS
 
 ## The status animations `PlayOpponentBattleAnim` plays on the target, past
-## `wFXAnimID`'s low byte and so reached by `BattleAnimRunScript`'s `.not_move`
-## branch. Only these five of the non-move block are named, because only these
-## five have a caller: `constants/move_constants.asm`'s `ANIM_SLP` and `ANIM_SAP`
-## sit among them and nothing in either pin ever asks for one.
+## `wFXAnimID`'s low byte and so reached by `BattleAnimRunScript`'s `.not_move`.
+## Only these five of the block are named, the rest having no caller: `ANIM_SLP`
+## and `ANIM_SAP` sit among them and nothing in either pin asks for one.
 const ANIM_CONFUSED: int = 0x103
 const ANIM_BRN: int = 0x105
 const ANIM_PSN: int = 0x106
@@ -97,15 +83,14 @@ var _objects: Array[Gen2BattleAnimObject] = []
 var _last_object_index: int = 0
 ## `wBattleAnimTileDict`: five (graphics id, tile offset) pairs.
 var _tile_dict: Array = []
-## Which sheet occupies each tile of the window, as
-## [code]{ gfx, tile }[/code] per loaded tile, so a renderer knows where an
-## OAM tile id's pixels come from.
+## [code]{ gfx, tile }[/code] per loaded tile, so a renderer knows where an OAM
+## tile id's pixels come from.
 var _tiles: Array = []
 var _keep_sprites: bool = false
 var _sprites: Array = []
 ## What the last frame's `RunBattleAnimCommand` ran, for the caller that owns
-## the things the interpreter does not: `anim_sound` and `anim_cry` have to
-## reach an audio player, and this layer has none.
+## what the interpreter does not: `anim_sound` and `anim_cry` need an audio
+## player, which this layer has none of.
 var _frame_commands: Array = []
 var _unimplemented: Dictionary = {}
 ## `wActiveBGEffects`: five `battle_bg_effect` slots.
@@ -113,22 +98,18 @@ var _bg_effects: Array[Gen2BattleAnimBgEffect] = []
 ## The video state the bg effects and `BattleAnimFunc_Surf` share.
 var _background: Gen2BattleAnimBackground = null
 
-## `wCurItem`, which `GetBallAnimPal` reads to colour a thrown ball. Nothing but
-## a ball animation asks, and an item that is not a ball falls out of
-## `BallColors` on its own terminator.
+## `wCurItem`, read by `GetBallAnimPal` to colour a thrown ball. Nothing else
+## asks, and a non-ball falls out of `BallColors` on its own terminator.
 var cur_item: int = 0
 
-## `wPlayerSubStatus3` and `wEnemySubStatus3`'s Fly and Dig bits, which three bg
-## effects check before they touch a battler that is not on the field.
+## The Fly and Dig bits three bg effects check before touching a battler.
 var player_off_field: bool = false
 var enemy_off_field: bool = false
 
 
-## Starts [param index] of `BattleAnimations`. Answers null when the cache has no
-## such animation, which is what an unimported layer looks like.
-##
-## [param param] is `wBattleAnimParam`, and [param enemy_turn] is `hBattleTurn`:
-## the two inputs the battle engine sets before `PlayBattleAnim`.
+## Starts [param index] of `BattleAnimations`, null when the cache has no such
+## animation. [param param] is `wBattleAnimParam` and [param enemy_turn] is
+## `hBattleTurn`, the two inputs set before `PlayBattleAnim`.
 static func create(
 	data: Gen2BattleAnimData, index: int, enemy_turn: bool = false, param: int = 0
 ) -> Gen2BattleAnimPlayer:
@@ -194,9 +175,8 @@ func bg_effects() -> Array:
 	return out
 
 
-## `BGEffect_CheckFlyDigStatus`: whether the battler on [param player_side] is
-## off the field mid-Fly or mid-Dig, which is what stops three effects touching
-## a picture that is not there.
+## `BGEffect_CheckFlyDigStatus`: whether the battler is off the field mid-Fly or
+## mid-Dig, which stops three effects touching a picture that is not there.
 func fly_dig_status(player_side: bool) -> bool:
 	return player_off_field if player_side else enemy_off_field
 
@@ -278,14 +258,11 @@ func unimplemented() -> Dictionary:
 	return out
 
 
-## One hardware frame of `.playframe`, in its own order: the script, the bg
-## effects, every object, the scanline table and the palettes. Answers whether
-## the animation is still running.
-##
-## `.playframe` skips its own `BattleAnimDelayFrame` while Rollout's bg effect is
-## live, because that effect waits a frame itself. Both paths spend exactly one
-## frame, so a player stepped once per frame runs its body once either way and
-## there is nothing here for the check to decide.
+## One hardware frame of `.playframe`, in its order: the script, the bg effects,
+## every object, the scanline table and the palettes. `.playframe` skips its own
+## `BattleAnimDelayFrame` while Rollout's bg effect is live, because that effect
+## waits a frame itself, but both paths spend exactly one frame, so a player
+## stepped once per frame has nothing for the check to decide.
 func advance_frame() -> bool:
 	if finished():
 		_finish()
@@ -391,22 +368,18 @@ func _load_graphics(operands: Array) -> void:
 
 
 ## `BattleAnimCmd_BattlerGFX_1Row` and `..._2Row`: one or two rows of each
-## battler's own picture copied into the top of the animation window, so an
-## effect can lift a battler's feet or head off the tilemap and move them as
-## objects. Three of the bg effects do exactly that, `BattleBGEffect_Tackle`
-## among them.
+## battler's picture copied into the top of the animation window, so an effect
+## can lift a battler's feet or head off the tilemap and move them as objects,
+## which three bg effects including `BattleBGEffect_Tackle` do.
 ##
-## The two dict entries are crosswise with what is copied: the entry named
-## `PLAYERHEAD` holds the enemy's rows and the one named `ENEMYFEET` the
-## player's. The object rows are crossed the same way, since
-## `BATTLE_ANIM_OBJ_ENEMYFEET_*` names `BATTLE_ANIM_GFX_PLAYERHEAD`, so the two
-## cancel and each object draws its own battler. Both crossings are the
-## cartridge's and neither is tidied, the same answer `$d9` and `$da` already
-## get.
+## The two dict entries are crosswise with what is copied, `PLAYERHEAD` holding
+## the enemy's rows and `ENEMYFEET` the player's, and the object rows are crossed
+## the same way, `BATTLE_ANIM_OBJ_ENEMYFEET_*` naming
+## `BATTLE_ANIM_GFX_PLAYERHEAD`, so the two cancel. Both crossings are the
+## cartridge's and neither is tidied.
 ##
-## The window tiles these fill do not name an imported sheet: they name a tile of
-## `vTiles2`, which is where the battle's own two pictures live, in the numbering
-## [Gen2BattleScreenMap] already writes into the tilemap.
+## The window tiles these fill name a tile of `vTiles2`, where the battle's own
+## pictures live, in the numbering [Gen2BattleScreenMap] writes.
 func _load_battler_graphics(rows: int) -> void:
 	var slot: int = _free_tile_dict_slot()
 	if slot < 0 or slot + 1 >= TILE_DICT_ENTRIES:

--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -1,40 +1,32 @@
 class_name Gen2BattleIntro
 extends RefCounted
 
-## `BattleIntroSlidingPics` (engine/battle/sliding_intro.asm), which is a
-## background scroll rather than a moving object: the routine rewrites `SCX` part
-## way down the frame so the top band comes in from one side and the middle from
-## the other, while the bottom never moves. A band edge falls inside the player's
-## status panel, which is why this is a per-scanline offset.
-##
-## `InitBattleDisplay.BlankBGMap` leaves everything past the drawn scene blank,
-## so an offset wraps at [constant MAP_WIDTH] and blank is what scrolls in.
+## `BattleIntroSlidingPics` (engine/battle/sliding_intro.asm) is a background
+## scroll, not a moving object: `SCX` is rewritten part way down the frame so the
+## top band comes in from one side and the middle from the other while the bottom
+## holds. A band edge falls inside the player's status panel, hence per scanline.
+## `InitBattleDisplay.BlankBGMap` leaves everything past the scene blank, so an
+## offset wraps at [constant MAP_WIDTH] and blank scrolls in.
 ##
 ## The one part of the battle presentation the two games do not share: Crystal
-## drives `wLYOverrides`, an HBlank table with a value per scanline, while
-## pokegold busy-waits on `rLY` and writes `rSCX` twice a frame. Band edges,
-## starting offsets and the walk all differ, so both are written out.
-##
+## drives `wLYOverrides` while pokegold busy-waits on `rLY` and writes `rSCX`
+## twice a frame, so band edges, starting offsets and the walk all differ.
 ## Neither band lands on zero (Crystal's middle ends at 2, Gold's top at 4);
-## `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles the screen, and
-## [method finished] is that write.
+## `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles it and [method
+## finished] is that write.
 ##
-## `.subfunction3` slides the overworld's own objects off before `HideSprites`
-## clears them. This screen has no OAM, so there is nothing to walk: a boundary,
-## not a gap.
+## `.subfunction3` slides the overworld's objects off before `HideSprites`; this
+## screen has no OAM, so there is nothing to walk.
 
-## 32 tiles of 8, what an offset wraps at. Everything past the screen's 160 is
-## blank.
+## 32 tiles of 8, what an offset wraps at; past the screen's 160 is blank.
 const MAP_WIDTH: int = 256
 
 const HEIGHT: int = Gen2Screen.HEIGHT
 
-## Both games step twice per frame, in opposite directions: `dec d` twice
-## against `inc e` twice.
+## Twice per frame in opposite directions: `dec d` twice against `inc e` twice.
 const STEP: int = 2
 
-## Crystal's `ld d, $90` and `ld e, $72`, over `.subfunction5`'s three runs of
-## 62, 34 and 48 scanlines, for `$48 + 1` frames.
+## Crystal's `ld d, $90` and `ld e, $72` over `.subfunction5`'s 62, 34 and 48.
 const CRYSTAL_FRAMES: int = 73
 const CRYSTAL_TOP_START: int = 0x90
 const CRYSTAL_MIDDLE_START: int = 0x72
@@ -50,8 +42,7 @@ const GOLD_TOP_ROWS: int = 64
 const GOLD_MIDDLE_ROWS: int = 32
 
 ## `ld a, c` / `ldh [hSCX], a` / `call DelayFrame` puts the whole screen at the
-## starting offset with no band written yet. Crystal delays nowhere, so it has
-## none.
+## starting offset with no band written yet. Crystal delays nowhere.
 const GOLD_LEAD_FRAMES: int = 1
 
 var _crystal: bool = true
@@ -77,8 +68,7 @@ func finished() -> bool:
 	return _frame >= frames()
 
 
-## One hardware frame. Redraws on every frame of the walk and on the one that
-## ends it, since the settle to zero is a change like any other.
+## One hardware frame. The settle to zero is a redraw like any other.
 func advance_frame() -> bool:
 	if finished():
 		return false
@@ -86,8 +76,7 @@ func advance_frame() -> bool:
 	return true
 
 
-## The background offset per scanline, hardware draw order. An offset looks
-## *right* into the map, so a larger one puts the scene further left.
+## Per scanline in hardware draw order; an offset looks *right* into the map.
 func offsets() -> PackedInt32Array:
 	var out: PackedInt32Array = PackedInt32Array()
 	out.resize(HEIGHT)
@@ -105,8 +94,8 @@ func offsets() -> PackedInt32Array:
 		elif row < top_rows + middle_rows:
 			out[row] = middle
 		else:
-			# Gold and Silver's lead frame is the whole screen at the starting
-			# offset: `rSCX` still holds it and nothing has written a band yet.
+			# The lead frame is the whole screen at the starting offset:
+			# `rSCX` holds it and no band has been written yet.
 			out[row] = GOLD_TOP_START if _is_gold_lead() else 0
 	return out
 
@@ -115,11 +104,9 @@ func _is_gold_lead() -> bool:
 	return not _crystal and _frame < GOLD_LEAD_FRAMES
 
 
-## Crystal steps every frame, `ld d, $90` down by two. Gold and Silver write to
-## `hSCX`, which VBlank copies to `rSCX` only after the frame it was written
-## during, so their top band trails the middle by one: both the lead frame and
-## the loop's first frame show the starting offset. Crystal's two bands come out
-## of one table and lag together, so only Gold's separate writes show it.
+## Crystal steps `ld d, $90` down by two every frame. Gold and Silver write
+## `hSCX`, which VBlank copies to `rSCX` a frame late, so their top band trails
+## the middle by one. Crystal's two bands share a table and lag together.
 func _top_offset() -> int:
 	if _crystal:
 		return posmod(CRYSTAL_TOP_START - STEP * _frame, MAP_WIDTH)

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -1,16 +1,13 @@
 class_name Gen2BattleMon
 extends RefCounted
 
-## One Pokémon as a battle sees it: its stats, what it knows, how much of it is
-## left, and how far its stats have been pushed around.
+## One Pokémon as a battle sees it: its stats, what it knows, how much is left
+## and how far its stats have been pushed around. Scene-free, reading cartridge
+## content through [GameData] and never a ROM.
 ##
-## [RefCounted] and scene-free, reading cartridge content through [GameData] and
-## never a ROM.
-##
-## Stats are worked out once, at build time, because that is when the cartridge
-## works them out; only a level up recalculates them. Stages are applied on the
-## way out, to the unmodified stat every time, which is why they are stored
-## separately rather than folded in.
+## Stats are worked out at build time, which is when the cartridge works them
+## out, and only a level up recalculates them. Stages are applied on the way out
+## to the unmodified stat every time, hence stored separately.
 
 ## What a Pokémon can carry into a battle, which is the same four slots
 ## [Gen2Learnset] fills.
@@ -316,13 +313,10 @@ func _stat(
 	)
 
 
-## A stat as the damage formula sees it, with its stage and then its status
-## applied.
-##
-## The cartridge's order: copy the stat, apply the stage, then halve a burned
-## Pokémon's Attack and quarter a paralysed one's Speed. Both land on the copy the
-## stages did, which is why a critical hit reading [method unmodified_stat] is
-## free of the burn as well as the stages.
+## A stat as the damage formula sees it, in the cartridge's order: copy, apply
+## the stage, then halve a burned Attack or quarter a paralysed Speed. Both land
+## on the copy the stages did, which is why a critical hit reading
+## [method unmodified_stat] is free of the burn as well as the stages.
 func stat(key: String) -> int:
 	var value: int = _badge_boosted(int(stats.get(key, 0)), key)
 	if not STAGED_STATS.has(key):
@@ -381,18 +375,16 @@ func reset_stages() -> void:
 		stages[key] = 0
 
 
-## What Baton Pass hands to whoever comes in behind it.
+## What Baton Pass hands to whoever comes in behind it. On the cartridge none of
+## this is the Pokémon's: `wPlayerSubStatus1` through `5` and their counters are
+## battle-position state, cleared on an ordinary entrance only because
+## `NewBattleMonStatus` says so, where `PassedBattleMonEntrance` and
+## `EnemySwitch_SetMode` do not. Here the same state is per-Pokémon and copied
+## across instead, with `ResetBatonPassStatus` naming what does not survive the
+## trip ([method Gen2Battle._reset_baton_pass_status]).
 ##
-## On the cartridge none of this is the Pokémon's: `wPlayerSubStatus1` through
-## `5` and every counter beside them are battle-position state, and an ordinary
-## entrance clears them only because `NewBattleMonStatus` says so.
-## `PassedBattleMonEntrance` and `EnemySwitch_SetMode` do not, which is the whole
-## of what Baton Pass is. Here the same state is per-Pokémon, so it is copied
-## across instead, and `ResetBatonPassStatus` then names the few things that do
-## not survive the trip: see [method Gen2Battle._reset_baton_pass_status].
-##
-## The list is exactly [method reset_volatile]'s, plus the stages, which is why
-## the two sit together: a field added to one belongs in the other.
+## The list is [method reset_volatile]'s plus the stages, which is why the two
+## sit together: a field added to one belongs in the other.
 const PASSED_FIELDS: Array[String] = [
 	"substatus", "confusion_turns", "charged_move", "rollout_count",
 	"rampage_turns", "rampage_move", "toxic_counter", "disabled_slot",
@@ -501,16 +493,11 @@ func persistent_dvs() -> int:
 	return int(transform_original.get("dvs", dvs))
 
 
-## The gender the cartridge's own `GetGender` would answer, from the species'
-## gender ratio and this Pokémon's own Attack and Speed DVs.
-##
-## Not a coin flip and not a stat total: the cartridge folds the Attack DV into
-## one byte's high nibble and the Speed DV into its low nibble, then compares
-## that against the species ratio. Ratio 0 is always male and 254 always female
-## with no comparison at all; 255 is genderless. Otherwise below the ratio is
-## male and at or above it female, so a higher ratio means likelier female.
-## [constant Gen2Species.GENDER_UNKNOWN] and the two extremes are named here
-## rather than repeated at every caller.
+## `GetGender`'s answer, from the species ratio and this Pokémon's Attack and
+## Speed DVs: the cartridge folds the Attack DV into a byte's high nibble and the
+## Speed DV into its low, then compares against the ratio. Ratio 0 is always male
+## and 254 always female with no comparison at all, 255 is genderless, and
+## otherwise below the ratio is male, so a higher ratio means likelier female.
 const GENDER_F0: int = 0
 const GENDER_F100: int = 254
 const GENDER_UNKNOWN: int = 255
@@ -651,12 +638,11 @@ func spend_pp(slot: int) -> void:
 		pp[slot] = maxi(int(pp[slot]) - 1, 0)
 
 
-## Whether there is anything left to do with a move slot.
-##
-## A disabled slot answers false whatever its PP, as the cartridge's menu never
-## offers it. [method Gen2Battle.effective_slot] and [method Gen2Battle.move_for]
-## reroute a caller that still asks; [constant Gen2EffectCommands.CHECK_STATUS]
-## catches the one path through neither.
+## Whether there is anything left to do with a move slot. A disabled one answers
+## false whatever its PP, the cartridge's menu never offering it;
+## [method Gen2Battle.effective_slot] and [method Gen2Battle.move_for] reroute a
+## caller that still asks, and [constant Gen2EffectCommands.CHECK_STATUS] catches
+## the one path through neither.
 func can_use(slot: int) -> bool:
 	return slot >= 0 and slot < moves.size() and pp_left(slot) > 0 and slot != disabled_slot
 

--- a/game/battle/experience.gd
+++ b/game/battle/experience.gd
@@ -1,17 +1,13 @@
 class_name Gen2Experience
 extends RefCounted
 
-## The six growth curves, what a defeated Pokémon is worth, and what it leaves
-## behind in stat experience.
-##
-## Static like [Gen2Stats] and [Gen2Damage]: integer arithmetic in the hardware's
-## order, every division truncating, so a tidier rearrangement gives a different
-## answer. The curves are `CalcExpAtLevel`'s formula, pinned against
-## `data/growth_rates.asm` and checked against all 251 species in all three
-## games; see `tools/dump_tables.gd`'s `growth` view.
+## The six growth curves, what a defeated Pokémon is worth, and the stat
+## experience it leaves. Static like [Gen2Stats] and [Gen2Damage]: hardware
+## order, every division truncating. The curves are `CalcExpAtLevel`'s formula
+## pinned against `data/growth_rates.asm` and swept over all 251 species on all
+## three games; see `tools/dump_tables.gd`'s `growth` view.
 
-## `wBaseGrowthRate` order (`GROWTH_*`). Only four are used by a real species;
-## the other two are named for completeness.
+## `wBaseGrowthRate` order. Only four are used by a real species.
 const GROWTH_MEDIUM_FAST: int = 0
 const GROWTH_SLIGHTLY_FAST: int = 1
 const GROWTH_SLIGHTLY_SLOW: int = 2
@@ -32,8 +28,7 @@ const CURVES: Dictionary = {
 
 const MAX_LEVEL: int = 100
 
-## Three bytes on the cartridge. No curve reaches it before level 100; it exists
-## to have an answer ready, like [constant Gen2Stats.MAX_STAT_EXP].
+## Three bytes on the cartridge, which no curve reaches before level 100.
 const MAX_EXP: int = 0xFFFFFF
 
 ## The cartridge copies base Sp. Attack into the fifth slot and never touches
@@ -48,17 +43,14 @@ const MIN_PARTICIPANTS_TO_SPLIT: int = 2
 ## `IsAnyMonHoldingExpShare` checks it. It carries no `ITEMATTR_EFFECT` at all.
 const EXP_SHARE_ITEM: int = 39
 
-## `BoostExp`'s own shape, `value + floor(value / 2)` rather than
-## multiply-by-3-divide-by-2: the two disagree exactly where the extra truncation
-## matters. The traded and Lucky Egg boosts are not implemented, since nothing
-## here has an original trainer ID or an item engine.
+## `BoostExp` is `value + floor(value / 2)`, not multiply-then-divide, and the
+## two disagree. The traded and Lucky Egg boosts have no OT ID to read.
 const TRAINER_BONUS_NUMERATOR: int = 3
 const TRAINER_BONUS_DENOMINATOR: int = 2
 
 
-## Level 1 is hard-coded to zero rather than run through the formula, which
-## underflows there on the medium slow curve. `docs/bugs_and_glitches.md` calls
-## that a bug, not a rule.
+## Level 1 is hard-coded to zero: the medium slow curve underflows there, which
+## `docs/bugs_and_glitches.md` calls a bug rather than a rule.
 static func total_exp_at(growth_rate: int, level: int) -> int:
 	var n: int = clampi(level, 1, MAX_LEVEL)
 	if n <= 1:
@@ -88,11 +80,9 @@ static func level_for_exp(growth_rate: int, experience_points: int) -> int:
 
 
 ## `floor(base_exp * level / 7)`, then a trainer battle's 1.5x.
-##
-## [param defeated_base_exp] is the base experience *after* [method shared_block]
-## has divided it: `wEnemyMonBaseExp` sits in the same seven-byte block as the
-## base stats and `.EvenlyDivideExpAmongParticipants` divides all of it in one
-## loop. Dividing the award instead would truncate in the wrong place.
+## [param defeated_base_exp] is *already* divided by [method shared_block], since
+## `wEnemyMonBaseExp` is in the block `.EvenlyDivideExpAmongParticipants` walks;
+## dividing the award instead truncates in the wrong place.
 static func award_for(defeated_level: int, defeated_base_exp: int, is_trainer_battle: bool) -> int:
 	@warning_ignore("integer_division")
 	var award: int = (defeated_base_exp * defeated_level) / 7
@@ -114,14 +104,11 @@ static func stat_exp_gain(defeated_stats: Dictionary, participants: int) -> Dict
 	return shared_block(defeated_stats, 0, false, participants)["stats"]
 
 
-## The seven-byte block `wEnemyMonBaseStats` to `wEnemyMonEnd`, shared out.
-##
-## The five base stats and the base experience are always divided together in one
-## loop, which is why this answers for both at once. The catch rate is the
-## seventh byte and is divided with them; nothing reads it after a faint.
-##
-## [param halved] is the Exp. Share pass of `UpdateFaintedPlayerMon`: every byte
-## is halved once before any division, however many holders there are.
+## The seven-byte block `wEnemyMonBaseStats` to `wEnemyMonEnd`, shared out. The
+## five base stats and the base experience go through one loop, which is why this
+## answers for both; the seventh byte is the catch rate, which nothing reads
+## after a faint. [param halved] is `UpdateFaintedPlayerMon`'s Exp. Share pass,
+## once before any division however many holders there are.
 static func shared_block(
 	defeated_stats: Dictionary, defeated_base_exp: int, halved: bool, recipients: int
 ) -> Dictionary:

--- a/game/battle/stats.gd
+++ b/game/battle/stats.gd
@@ -1,20 +1,14 @@
 class_name Gen2Stats
 extends RefCounted
 
-## The stat arithmetic: base stats, DVs and stat experience into the numbers a
-## battle is fought with.
+## Base stats, DVs and stat experience into the numbers a battle is fought with.
 ##
 ## Integer arithmetic in the hardware's order: every division truncates, and a
-## tidier rearrangement gives a different answer often enough to matter.
-##
-## Generation 2 has DVs and stat experience, not later games' effort values. A DV
-## is four bits per stat, and HP's is assembled from the low bit of the other
-## four rather than stored, which is why a shiny Pokémon has the stats it does:
-## shininess is a pattern in the same nibbles.
+## tidier rearrangement gives a different answer often enough to matter. A DV is
+## four bits per stat, and HP's is assembled from the other four rather than
+## stored, which is the same reading that decides shininess.
 
-## The two constants the formula ends on. A stat is never below its floor, so a
-## level 1 Pokémon with nothing going for it still has 5 of everything and 11 hit
-## points.
+## The floors the formula ends on: a level 1 Pokémon still has 5 and 11.
 const STAT_MIN_NORMAL: int = 5
 const STAT_MIN_HP: int = 10
 
@@ -27,21 +21,17 @@ const MAX_STAT_EXP: int = 65535
 ## `ld a, $ff / NUM_UNOWN + 1`, assembled rather than computed: 255 / 26 is 9.
 const UNOWN_LETTER_DIVISOR: int = 10
 
-## The cartridge finds a square root by walking a table of squares, so it stops
-## at the last entry rather than at the true root. Stat experience above 255
-## squared is therefore wasted, and the most a full stat exp bar is worth is 63.
+## The table of squares stops here rather than at the true root, so stat
+## experience above 255 squared is wasted and a full bar is worth 63.
 const MAX_SQUARE_ROOT: int = 255
 
-## Stat stages run from -6 to +6. The cartridge stores them 7-centred, from 1 to
-## 13, because it indexes the multiplier table with them directly; here they are
-## the numbers a player would recognise and the table is offset instead.
+## The cartridge stores stages 7-centred so it can index the table with them;
+## here they are signed and the table is offset instead.
 const MIN_STAGE: int = -6
 const MAX_STAGE: int = 6
 
-## What each stage multiplies a stat by, as the numerator and denominator pair the
-## cartridge stores. They are not a clean 2/(2+n) curve: the drops are rounded
-## percentages, so -1 is 66/100 and not 2/3, and the two disagree by a point on a
-## stat of 150.
+## The cartridge's own numerator/denominator pairs, not a 2/(2+n) curve: the
+## drops are rounded percentages, so -1 is 66/100 and differs on a stat of 150.
 const STAGE_MULTIPLIERS: Array = [
 	[25, 100], [28, 100], [33, 100], [40, 100], [50, 100], [66, 100],
 	[1, 1],
@@ -56,14 +46,9 @@ const DV_SPEED_SHIFT: int = 4
 const DV_SPECIAL_SHIFT: int = 0
 
 
-## The square root as the cartridge computes it: the smallest whole number whose
-## square is at least [param value], never below 1 and never above
-## [constant MAX_SQUARE_ROOT].
-##
-## A ceiling, not a floor: getting it wrong shows up as a stat being one out on
-## any trained Pokémon. The cartridge scans a table of squares for the first
-## entry not smaller than the stat experience, and that table starts at 1, so an
-## untrained Pokémon answers 1 rather than 0.
+## The cartridge's square root: the first entry of a table of squares not
+## smaller than [param value]. A ceiling, not a floor, and the table starts at 1,
+## so an untrained Pokémon answers 1 rather than 0.
 static func square_root(value: int) -> int:
 	for root: int in range(1, MAX_SQUARE_ROOT):
 		if root * root >= value:
@@ -71,11 +56,8 @@ static func square_root(value: int) -> int:
 	return MAX_SQUARE_ROOT
 
 
-## One stat, from its base value, its DV, its stat experience and a level.
-##
-## [param is_hp] picks the other ending: HP adds the level and ten where every
-## other stat adds five. Everything before that is shared, which is why they are
-## one function rather than two.
+## One stat, from base, DV, stat experience and level. [param is_hp] picks the
+## other ending alone: HP adds the level and ten where the rest add five.
 static func calculate(
 	base: int, dv: int, stat_exp: int, level: int, is_hp: bool = false
 ) -> int:
@@ -88,11 +70,8 @@ static func calculate(
 	return mini(out, MAX_STAT_VALUE)
 
 
-## HP's DV, which is not stored: it is the low bit of each of the other four,
-## in the order attack, defense, speed, special.
-##
-## The same four nibbles decide whether a Pokémon is shiny, so its colour and its
-## hit points are two readings of one number rather than two facts about it.
+## HP's DV is not stored: it is the low bit of each of the other four, in the
+## order attack, defense, speed, special, which is what shininess reads too.
 static func hp_dv(dvs: int) -> int:
 	return ((attack_dv(dvs) & 1) << 3) | ((defense_dv(dvs) & 1) << 2) \
 		| ((speed_dv(dvs) & 1) << 1) | (special_dv(dvs) & 1)
@@ -110,20 +89,15 @@ static func speed_dv(dvs: int) -> int:
 	return (dvs >> DV_SPEED_SHIFT) & 0xF
 
 
-## Special Attack and Special Defense share one DV in these games. The split
-## arrived in Generation 2 for base stats and stat experience but not for DVs.
+## Special Attack and Special Defense share one DV: the split arrived for base
+## stats and stat experience but not here.
 static func special_dv(dvs: int) -> int:
 	return (dvs >> DV_SPECIAL_SHIFT) & 0xF
 
 
-## Which of Unown's twenty-six letters a Pokémon with these DVs is, 1 being A.
-##
-## `GetUnownLetter` (engine/gfx/load_pics.asm) takes the middle two bits of each
-## DV in the order attack, defense, speed, special, packs them into one byte and
-## divides by `$ff / NUM_UNOWN + 1`, which is ten. So a letter is one more than a
-## byte that only ever holds those eight bits: the highest is $FF, which is Z.
-## Nothing stores the letter, here or on the cartridge; it is read off the DVs
-## every time the pic, the dex or a wild encounter needs it.
+## `GetUnownLetter` (engine/gfx/load_pics.asm), 1 being A: the middle two bits of
+## each DV packed into a byte and divided by [constant UNOWN_LETTER_DIVISOR], so
+## the highest, $FF, is Z. Nothing stores the letter on either side.
 static func unown_letter(dvs: int) -> int:
 	var packed: int = ((attack_dv(dvs) & 0x6) << 5) | ((defense_dv(dvs) & 0x6) << 3) \
 		| ((speed_dv(dvs) & 0x6) << 1) | ((special_dv(dvs) & 0x6) >> 1)
@@ -132,8 +106,7 @@ static func unown_letter(dvs: int) -> int:
 	return letter + 1
 
 
-## Packs four DVs into the word the cartridge stores, which is what a caller
-## building a Pokémon by hand wants.
+## Four DVs into the word the cartridge stores, for a caller building one by hand.
 static func pack_dvs(attack: int, defense: int, speed: int, special: int) -> int:
 	return (clampi(attack, 0, MAX_DV) << DV_ATTACK_SHIFT) \
 		| (clampi(defense, 0, MAX_DV) << DV_DEFENSE_SHIFT) \
@@ -142,11 +115,8 @@ static func pack_dvs(attack: int, defense: int, speed: int, special: int) -> int
 
 
 ## A stat with a stage applied, capped at [constant MAX_STAT_VALUE] and never
-## below 1.
-##
-## The stage is applied to the unmodified stat every time rather than to the last
-## answer, so six drops and six rises leave the stat where it started instead of
-## grinding it down through twelve truncations.
+## below 1. Applied to the unmodified stat every time rather than to the last
+## answer, so six drops and six rises leave it where it started.
 static func apply_stage(value: int, stage: int) -> int:
 	var ratio: Array = STAGE_MULTIPLIERS[clampi(stage, MIN_STAGE, MAX_STAGE) - MIN_STAGE]
 	@warning_ignore("integer_division")

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -1,17 +1,13 @@
 class_name Gen2Status
 extends RefCounted
 
-## The status byte, and the four things it does to a Pokémon.
+## One byte as the cartridge stores it: the low three bits are turns of sleep
+## left and the four above are one flag each. That is the rule as well as the
+## storage, since one status at a time falls out of checking the byte whole.
 ##
-## One byte, as the cartridge stores it: the low three bits are turns of sleep
-## left and the four above are one flag each. That is also the rule, not just
-## storage: one status at a time, a second refused rather than added, which falls
-## out of checking the byte as a whole.
-##
-## What the four do is spread across the turn. Sleep, freeze and paralysis are
-## checked before a move; burn and paralysis bend a stat where it is read; burn
-## and poison take a slice at the end of the turn. This class is the arithmetic
-## behind that and holds no state.
+## Sleep, freeze and paralysis are checked before a move; burn and paralysis bend
+## a stat where it is read; burn and poison take a slice at the end of the turn.
+## The arithmetic behind that, holding no state.
 
 ## The low three bits: turns of sleep left, from 1 to 7.
 const SLEEP_MASK: int = 0b111
@@ -24,23 +20,19 @@ const PARALYSIS: int = 1 << 6
 
 const NONE: int = 0
 
-## Everything the byte can say, which is what "does this Pokémon already have a
-## status" asks about.
+## Everything the byte can say, which is what [method is_afflicted] asks.
 const ANY: int = SLEEP_MASK | POISON | BURN | FREEZE | PARALYSIS
 
-## What sleep is rolled from. The cartridge rolls the low three bits until it
-## gets something that is neither 0 nor 7 and then adds one, so the counter
-## starts between 2 and 7 and the Pokémon loses between one and six turns.
+## The cartridge rolls the low three bits until it gets neither 0 nor 7 and adds
+## one, so the counter starts here and the Pokémon loses one to six turns.
 const MIN_SLEEP: int = 2
 const MAX_SLEEP: int = 7
 
-## Rest does not roll: it writes `REST_SLEEP_TURNS + 1`
-## (constants/battle_constants.asm) over the whole byte, so the sleeper loses
-## two turns and every other status goes with it.
+## Rest does not roll: it writes `REST_SLEEP_TURNS + 1` over the whole byte, so
+## the sleeper loses two turns and every other status goes with it.
 const REST_SLEEP_TURNS: int = 2
 
-## Burn halves the Attack and paralysis quarters the Speed, both to a minimum of
-## one, and both are shifts rather than divisions on the hardware.
+## Shifts rather than divisions on the hardware, both floored at one.
 const BURN_ATTACK_SHIFT: int = 1
 const PARALYSIS_SPEED_SHIFT: int = 2
 
@@ -56,9 +48,7 @@ const THAW_CHANCE: int = 25
 ## Burn and poison cost an eighth of the maximum, never less than one.
 const RESIDUAL_DIVISOR: int = 8
 
-## Toxic ramps rather than costing a flat eighth: a sixteenth of the maximum for
-## every turn it has been in effect, so the first turn costs the least of any
-## status and the Pokémon that stays in against it pays more each turn after.
+## Toxic ramps instead: a sixteenth of the maximum per turn it has been up.
 const TOXIC_RESIDUAL_DIVISOR: int = 16
 
 
@@ -74,15 +64,13 @@ static func sleep_turns(status: int) -> int:
 	return status & SLEEP_MASK
 
 
-## Whether there is anything at all on the byte. A Pokémon that has one status
-## cannot be given another, which is why this is asked as one question.
+## Anything at all on the byte: one status refuses a second.
 static func is_afflicted(status: int) -> bool:
 	return (status & ANY) != 0
 
 
-## One turn of sleep counted off. A counter that reaches zero has taken sleep off
-## the byte, and the Pokémon acts that same turn: the cartridge wakes it and
-## carries on into the rest of its checks rather than ending its turn.
+## One turn counted off. A counter reaching zero clears the byte and the Pokémon
+## acts that same turn: the cartridge carries on into its remaining checks.
 static func tick_sleep(status: int) -> int:
 	if not is_asleep(status):
 		return status
@@ -99,17 +87,14 @@ static func rolls_full_paralysis(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, CHANCE_RANGE - 1) < PARALYSIS_CHANCE
 
 
-## Whether a frozen Pokémon thaws on its own at the end of a turn, which is
-## `HandleDefrost`'s roll. Without it a freeze is permanent, the way Generation
-## 1's is; this is the whole of what makes Generation 2's temporary.
+## `HandleDefrost`'s roll, which is the whole of what makes a freeze temporary
+## here where Generation 1's is permanent.
 static func rolls_thaw(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, CHANCE_RANGE - 1) < THAW_CHANCE
 
 
-## The Attack a burned Pokémon attacks with, and the Speed a paralysed one moves
-## at. Both are applied where the stat is read rather than to the stat itself,
-## because a status is a lens on a stat exactly as a stage is, and a Pokémon
-## cured of a burn has its Attack back without anything being recalculated.
+## Applied where the stat is read rather than to the stat, the way a stage is, so
+## a cure needs no recalculation.
 static func apply_burn(attack: int) -> int:
 	return maxi(attack >> BURN_ATTACK_SHIFT, 1)
 
@@ -124,17 +109,15 @@ static func residual_damage(max_hp: int) -> int:
 	return maxi(max_hp / RESIDUAL_DIVISOR, 1)
 
 
-## What Toxic takes at the end of a turn, at [param counter] turns of it having
-## been in effect. [param counter] starts at 1 the turn it is inflicted, so the
-## first hit is a sixteenth and not nothing.
+## [param counter] starts at 1 the turn Toxic is inflicted, so the first hit is a
+## sixteenth and not nothing.
 static func toxic_damage(max_hp: int, counter: int) -> int:
 	@warning_ignore("integer_division")
 	return maxi(max_hp * counter / TOXIC_RESIDUAL_DIVISOR, 1)
 
 
-## What is on the byte, as a name a message can be built from, or an empty
-## StringName for a Pokémon with nothing on it. Sleep first, because a byte that
-## carries a sleep counter carries nothing else.
+## The byte as a name a message can be built from, empty for nothing. Sleep
+## first, because a byte carrying a counter carries nothing else.
 static func name_of(status: int) -> StringName:
 	if is_asleep(status):
 		return &"sleep"

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -1,22 +1,17 @@
 class_name Gen2Substatus
 extends RefCounted
 
-## The volatile flags, for everything the one-at-a-time [Gen2Status] byte cannot
-## hold. Pure arithmetic and no state, the same shape as [Gen2Status].
-##
-## The cartridge keeps these as `wPlayerSubStatus1` through `5`; they fold into
-## one int here, since nothing needs to address a byte on its own. Counters that
-## belong beside a flag (confusion turns, the charged move, the disabled slot)
-## live on [Gen2BattleMon]. Every flag clears on a switch, in
-## [method Gen2BattleMon.reset_volatile].
+## The volatile flags, for what the one-at-a-time [Gen2Status] byte cannot hold.
+## `wPlayerSubStatus1` through `5` folded into one int, since nothing addresses a
+## byte alone; counters that belong beside a flag live on [Gen2BattleMon], and
+## every flag clears in [method Gen2BattleMon.reset_volatile].
 
 const CONFUSED: int = 1 << 0
 const FLINCHED: int = 1 << 1
 const RECHARGING: int = 1 << 2
 const CHARGING: int = 1 << 3
-## Bit 4 was a DISABLED flag. The cartridge has none: `wDisabledMove` and
-## `wPlayerDisableCount` are the whole of it. Left unused rather than reassigned
-## so a bit number keeps meaning what it did.
+## Bit 4 was a DISABLED flag; the cartridge has none, `wDisabledMove` and
+## `wPlayerDisableCount` being the whole of it. Left unused, not reassigned.
 const ATTRACTED: int = 1 << 5
 const ENCORED: int = 1 << 6
 const MIST: int = 1 << 7
@@ -27,52 +22,45 @@ const CURLED: int = 1 << 11
 const ROLLOUT: int = 1 << 12
 const RAMPAGING: int = 1 << 13
 
-## `SUBSTATUS_CANT_RUN`. On the Pokémon that used Mean Look, not the one that
-## cannot leave: `BattleCommand_ArenaTrap` sets the user's own
-## `BATTLE_VARS_SUBSTATUS5`.
+## On the Pokémon that used Mean Look, not the one that cannot leave:
+## `BattleCommand_ArenaTrap` sets the user's own `BATTLE_VARS_SUBSTATUS5`.
 const CANT_RUN: int = 1 << 14
 
-## `SUBSTATUS_X_ACCURACY`. Every move its holder uses hits, checked in `CheckHit`
-## ahead of the modifiers. Only a trainer's AI sets it; the player's pack has no
-## X items yet.
+## Every move its holder uses hits, checked in `CheckHit` ahead of the modifiers.
+## Only a trainer's AI sets it; the player's pack has no X items yet.
 const X_ACCURACY: int = 1 << 15
 
-## `SUBSTATUS_PERISH`, with [member Gen2BattleMon.perish_count] beside it. A
-## send-out zeroes the flag and leaves the count, but every read of the count is
-## behind the flag, so clearing both is the same behaviour.
+## With [member Gen2BattleMon.perish_count] beside it. A send-out zeroes the flag
+## and leaves the count, but every read of the count is behind the flag.
 const PERISH: int = 1 << 16
 
-## `SUBSTATUS_SUBSTITUTE`. The doll's hit points are
-## [member Gen2BattleMon.substitute_hp].
+## The doll's hit points are [member Gen2BattleMon.substitute_hp].
 const SUBSTITUTE: int = 1 << 17
 
-## `SUBSTATUS_LEECH_SEED`. On the seeded Pokémon, which is why
-## `BattleCommand_ClearHazards` reads the user's own flag.
+## On the seeded Pokémon, which is why `BattleCommand_ClearHazards` reads the
+## user's own flag.
 const LEECH_SEED: int = 1 << 18
 
-## `SUBSTATUS_NIGHTMARE` and `SUBSTATUS_CURSE`. Both cost a quarter at the end of
-## the turn and both sit on the sufferer.
+## Both cost a quarter at the end of the turn and sit on the sufferer.
 const NIGHTMARE: int = 1 << 19
 const CURSE: int = 1 << 20
 
-## `SUBSTATUS_PROTECT` and `SUBSTATUS_ENDURE`. Neither is spent by the hit it
-## answers, so every hit of a multi-hit move is turned away or clamped;
-## `EndOpponentProtectEndureDestinyBond` is what ends them.
+## Neither is spent by the hit it answers, so every hit of a multi-hit move is
+## turned away; `EndOpponentProtectEndureDestinyBond` ends them.
 const PROTECT: int = 1 << 21
 const ENDURE: int = 1 << 22
 
-## `SUBSTATUS_DESTINY_BOND`. On its user, read only by the opponent's
-## `BattleCommand_CheckFaint`. `EndUserDestinyBond` clears it in front of its
-## user's next action, so it covers exactly the opponent's next move.
+## On its user, read only by the opponent's `BattleCommand_CheckFaint`.
+## `EndUserDestinyBond` clears it before its user's next action, so it covers
+## exactly the opponent's next move.
 const DESTINY_BOND: int = 1 << 23
 
-## `SUBSTATUS_IDENTIFIED`. Foresight sets it on the target, not the user:
-## `BattleCommand_Foresight` writes `BATTLE_VARS_SUBSTATUS1_OPP`.
+## Foresight sets it on the target: `BATTLE_VARS_SUBSTATUS1_OPP`.
 const IDENTIFIED: int = 1 << 24
 
-## `SUBSTATUS_LOCK_ON`. On the Pokémon aimed at, so `CheckHit`'s `.LockOn` reads
-## `BATTLE_VARS_SUBSTATUS5_OPP` and consumes it. The cartridge's other readers
-## are the 25% AI status-move failure, which this engine does not model.
+## On the Pokémon aimed at, so `CheckHit`'s `.LockOn` reads
+## `BATTLE_VARS_SUBSTATUS5_OPP` and consumes it. Its only other reader is the 25%
+## AI status-move failure, which this engine does not model.
 const LOCK_ON: int = 1 << 25
 
 ## Both cleared by switching or by choosing another action; their counters live
@@ -83,8 +71,7 @@ const TRANSFORMED: int = 1 << 28
 
 const NONE: int = 0
 
-## Rolled the shape [constant Gen2Status.MIN_SLEEP] is: the cartridge rolls the
-## low bits until it lands in range, inclusive of both ends.
+## Rolled the shape [constant Gen2Status.MIN_SLEEP] is, both ends inclusive.
 const MIN_CONFUSION: int = 2
 const MAX_CONFUSION: int = 5
 
@@ -96,9 +83,8 @@ const MAX_RAMPAGE_TURNS: int = 2
 const MIN_RAMPAGE_CONFUSION: int = 2
 const MAX_RAMPAGE_CONFUSION: int = 3
 
-## `BattleCommand_Disable`: three bits of a random byte, rerolled on zero, plus
-## one. The cartridge packs the count with the disabled slot; the two are
-## separate fields on [Gen2BattleMon] here.
+## `BattleCommand_Disable`: three bits rerolled on zero, plus one. The cartridge
+## packs the count with the slot; they are two fields on [Gen2BattleMon] here.
 const MIN_DISABLE: int = 2
 const MAX_DISABLE: int = 8
 
@@ -107,8 +93,7 @@ const MIN_ENCORE: int = 3
 const MAX_ENCORE: int = 6
 
 ## `BattleCommand_TrapTarget`: two bits incremented three times. The landing
-## turn's `HandleWrap` spends one without damage, which is why the source
-## comments the same roll as two to five.
+## turn's `HandleWrap` spends one without damage, hence the source's "two to five".
 const MIN_TRAP_TURNS: int = 3
 const MAX_TRAP_TURNS: int = 6
 
@@ -123,8 +108,7 @@ const HALF_DIVISOR: int = 2
 ## 2, 1 and 0 and the song's own line says three turns.
 const PERISH_TURNS: int = 4
 
-## Both out of 256, the cartridge's own coin flip, rolled fresh every turn the
-## Pokémon tries to move rather than decided when the flag landed.
+## Both out of 256, rolled fresh every turn rather than when the flag landed.
 const ATTRACT_IMMOBILE_CHANCE: int = 128
 const CONFUSION_HURTS_SELF_CHANCE: int = 128
 const CHANCE_RANGE: int = 256
@@ -191,8 +175,7 @@ static func half_damage(max_hp: int) -> int:
 	return maxi(max_hp / HALF_DIVISOR, 1)
 
 
-## Not [method quarter_damage]: `BattleCommand_Substitute` shifts the maximum
-## right twice by hand with no `GetQuarterMaxHP` and so no floor at one, which is
-## why a maximum under four makes a doll with no hit points at all.
+## Not [method quarter_damage]: `BattleCommand_Substitute` shifts right twice by
+## hand with no floor at one, so a maximum under four makes a doll with no HP.
 static func substitute_hp_for(max_hp: int) -> int:
 	return (max_hp >> 2) & 0xFF

--- a/game/battle/weather.gd
+++ b/game/battle/weather.gd
@@ -1,16 +1,11 @@
 class_name Gen2Weather
 extends RefCounted
 
-## What the sky is doing, and everything that reads it.
-##
-## `wBattleWeather` and `wWeatherCount` are one value each for the whole battle
-## rather than one per side, so the state lives on [Gen2Battle] and this class is
-## pure arithmetic, the same shape [Gen2Status] and [Gen2Substatus] have.
-##
-## Weather reaches five places: the damage formula
+## `wBattleWeather` and `wWeatherCount` are one value each for the whole battle,
+## so the state lives on [Gen2Battle] and this class is pure arithmetic, the
+## shape [Gen2Status] and [Gen2Substatus] have. Five readers: the damage formula
 ## ([method Gen2Damage.calculate_with]), Thunder's accuracy, Solarbeam's charge
-## turn, Freeze, and the between-turn countdown that ends it and that a Sandstorm
-## damages through ([method Gen2Battle._tick_weather]).
+## turn, Freeze, and [method Gen2Battle._tick_weather]'s countdown.
 
 const NONE: int = 0
 const RAIN: int = 1
@@ -22,16 +17,14 @@ const SANDSTORM: int = 3
 ## and a fifth that ends it, the setting turn counting as the first.
 const TURNS: int = 5
 
-## The two multipliers `DoWeatherModifiers` applies, in tenths:
-## `MORE_EFFECTIVE` and `NOT_VERY_EFFECTIVE` (constants/battle_constants.asm),
-## the same numbers the type chart uses.
+## `DoWeatherModifiers`' multipliers in tenths, which are the type chart's own
+## `MORE_EFFECTIVE` and `NOT_VERY_EFFECTIVE` (constants/battle_constants.asm).
 const BOOSTED: int = 15
 const WEAKENED: int = 5
 const UNCHANGED: int = 10
 
-## The divisor the multiplication is against, and the range the result is held
-## in: `DoWeatherModifiers` floors a result of zero at one and answers `$FFFF`
-## for anything that overflows two bytes.
+## `DoWeatherModifiers` floors a zero result at one and answers `$FFFF` on a
+## two-byte overflow.
 const MODIFIER_DIVISOR: int = 10
 const MAX_DAMAGE: int = 0xFFFF
 
@@ -50,25 +43,20 @@ const EFFECT_MODIFIERS: Dictionary = {
 ## What a Sandstorm takes each turn, `GetEighthMaxHP`'s at-least-one eighth.
 const SANDSTORM_DIVISOR: int = 8
 
-## The three types a Sandstorm cannot touch. Flying is not among them and
-## neither is a Pokémon in mid-Fly: `.SandstormDamage` checks
-## `SUBSTATUS_UNDERGROUND` and these three types, and nothing else.
+## `.SandstormDamage` checks these and `SUBSTATUS_UNDERGROUND` and nothing else,
+## so Flying and a Pokémon in mid-Fly are both hit.
 const SANDSTORM_EXEMPT_TYPES: Array[int] = [
 	RomLayout.TYPE_ROCK, RomLayout.TYPE_GROUND, RomLayout.TYPE_STEEL,
 ]
 
 
-## Whether [param weather] is weather at all, which is the check every reader
-## makes before anything else.
+## The check every reader makes before anything else.
 static func is_active(weather: int) -> bool:
 	return weather != NONE
 
 
-## What the weather multiplies a hit by, in tenths, or [constant UNCHANGED].
-##
-## `DoWeatherModifiers` walks the type table first and applies the first row it
-## matches, reaching the effect table only when no type row did. Solarbeam is
-## Grass and so never matches a type row, which is what lets its own row answer.
+## `DoWeatherModifiers` in tenths: the type table first, the effect table only
+## when no type row matched, which is how Solarbeam's own row is reached.
 static func damage_modifier(weather: int, move_type: int, move_effect: int) -> int:
 	var by_type: Dictionary = TYPE_MODIFIERS.get(weather, {})
 	if by_type.has(move_type):
@@ -78,8 +66,7 @@ static func damage_modifier(weather: int, move_type: int, move_effect: int) -> i
 	return int(by_effect.get(move_effect, UNCHANGED))
 
 
-## One hit put through [method damage_modifier]'s answer, in the range the
-## cartridge's own divide leaves behind.
+## One hit through [method damage_modifier]'s answer, in the cartridge's range.
 static func apply_damage_modifier(damage: int, tenths: int) -> int:
 	if tenths == UNCHANGED:
 		return damage
@@ -93,8 +80,7 @@ static func sandstorm_damage(max_hp: int) -> int:
 	return maxi(max_hp / SANDSTORM_DIVISOR, 1)
 
 
-## Whether a Sandstorm reaches this Pokémon: not while it is underground, and
-## not at all if either of its types is Rock, Ground or Steel.
+## Whether a Sandstorm reaches this Pokémon.
 static func hits_in_sandstorm(types: Array, substatus: int) -> bool:
 	if Gen2Substatus.has(substatus, Gen2Substatus.UNDERGROUND):
 		return false

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -4,67 +4,51 @@ extends RefCounted
 ## Content a mod adds or changes, consulted ahead of the cartridge's own tables.
 ##
 ## [GameData] funnels every species, move, item and trainer read through one
-## place, so this is the one place that has to answer to add a Pokémon or
-## rebalance a move. Nothing downstream knows a mod exists: a defined species has
-## a learnset, evolutions and TM flags because those live on the species row, and
-## the engine reads them the way it reads Pikachu's.
+## place, so this is the one place that has to answer. Nothing downstream knows a
+## mod exists: a defined species has a learnset, evolutions and TM flags because
+## those live on the species row.
 ##
-## Two operations, deliberately distinct:
-##
-## - [method define] adds content at a number the cartridge does not use.
-## - [method patch] changes fields of a row the cartridge does use.
-##
-## Definitions are normalized on the way in, against [constant DEFAULTS], because
-## readers index these rows directly: [method GameData.palette] reads
-## [code]palette.normal[/code] and [method GameData.species_pic] reads
-## [code]front_tiles[/code], and a definition that omitted either would crash the
-## reader rather than draw wrong. A mod supplies what it cares about.
+## [method define] adds content at a number the cartridge does not use;
+## [method patch] changes fields of a row it does. Definitions are normalized
+## against [constant DEFAULTS] on the way in, because readers index these rows
+## directly ([method GameData.palette] reads [code]palette.normal[/code],
+## [method GameData.species_pic] reads [code]front_tiles[/code]) and an omitted
+## field would crash the reader rather than draw wrong.
 
-## The content kinds a mod may reach. Types are not one of them: the matchup
-## lookup keys on [constant RomLayout.TYPE_COUNT], so a twenty-ninth type would
-## renumber every pair already in the chart.
+## The kinds a mod may reach. Types are not one: the matchup lookup keys on
+## [constant RomLayout.TYPE_COUNT], so a new type renumbers the whole chart.
 const KIND_SPECIES: StringName = &"species"
 const KIND_MOVE: StringName = &"move"
 const KIND_ITEM: StringName = &"item"
 const KIND_TRAINER: StringName = &"trainer"
-## One map's wild encounter record, the row [method GameData.world_encounter]
-## answers, numbered with [method encounter_number].
+## [method GameData.world_encounter]'s row, numbered by [method encounter_number].
 const KIND_ENCOUNTER: StringName = &"encounter"
-## One fishing group, the row [method GameData.world_fishing_group] answers,
-## numbered with the group number a map header carries.
+## [method GameData.world_fishing_group]'s row, numbered as a map header does.
 const KIND_FISHING: StringName = &"fishing"
 const KINDS: Array[StringName] = [
 	KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER, KIND_ENCOUNTER, KIND_FISHING,
 ]
 
-## The kinds that are a cartridge table rather than numbered content, and are
-## therefore [method patch]-only: a mod cannot add a map or a map header, so
-## there is no row for a [method define] to sit at. Their numbers are table
+## A cartridge table rather than numbered content, so [method patch]-only: a mod
+## cannot add a map for a definition to sit at. Their numbers are table
 ## coordinates and do not obey [constant FIRST_MOD_NUMBER].
 const TABLE_KINDS: Array[StringName] = [KIND_ENCOUNTER, KIND_FISHING]
 
-## The methods [method encounter_number] can name, in the order it encodes them.
-## `surf` is the runtime's name for the cartridge's water table, which is what
-## [method GameData.world_encounter] takes.
+## [method encounter_number]'s methods in the order it encodes them. `surf` is
+## the runtime's name for the water table, which is what the reader takes.
 const ENCOUNTER_METHODS: Array[StringName] = [
 	&"grass", &"surf", &"swarm_grass", &"swarm_water",
 ]
 
-## The first number a mod may define. Every cartridge content number is one byte,
-## in all three games, so a number that does not fit in one is unambiguously not
-## the cartridge's. That is what makes a mod's own numbers mean the same thing on
-## Gold, Silver and Crystal, which a boundary derived from a per-game count
-## (251 species, 66 or 67 trainer classes) would not.
-##
-## The cost is that a mod number does not fit the cartridge's byte-wide storage:
-## [Gen2SramAdapter] exports party species to a real `.sav` and cannot carry one.
-## The project save is JSON and carries them fine.
+## Every cartridge content number is one byte in all three games, so anything
+## past a byte is unambiguously not the cartridge's, and a mod's numbers mean the
+## same thing on each. A boundary taken from a per-game count (251 species, 66 or
+## 67 trainer classes) would not. The cost: [Gen2SramAdapter] exports party
+## species to a real `.sav` and cannot carry one. The project save is JSON.
 const FIRST_MOD_NUMBER: int = 256
 
-## What a definition that omits a field gets instead, per kind. The field lists
-## are the importer's own rows (`_import_species`, `_import_moves`,
-## `_import_items`, `_import_trainers`), so a definition is a cartridge row with
-## the parts a mod did not care about filled in.
+## What an omitted field gets, per kind. The field lists are the importer's own
+## rows (`_import_species`, `_import_moves`, `_import_items`, `_import_trainers`).
 const DEFAULTS: Dictionary = {
 	KIND_SPECIES: {
 		"name": "?",
@@ -133,33 +117,27 @@ var _patched: Dictionary = {}
 var _owners: Dictionary = {}
 
 
-## The overlay [GameData] consults. Shared rather than per-cache because mods
-## load before any cache is opened and their content applies to whichever game
-## the player then picks.
+## Shared rather than per-cache: mods load before any cache is opened and apply
+## to whichever game the player then picks.
 static func shared() -> Gen2ContentOverlay:
 	if _shared == null:
 		_shared = Gen2ContentOverlay.new()
 	return _shared
 
 
-## Discards every registration. [method Gen2ModHost.reset] calls this, so
-## reloading the mod list does not leave the last load's content behind.
+## [method Gen2ModHost.reset]'s, so a reload leaves no earlier content behind.
 static func reset() -> void:
 	_shared = null
 
 
-## Whether anything is registered at all. Every content read asks this first, so
-## a game with no mods pays one dictionary check per species lookup.
+## Asked first by every content read, so an unmodded game pays one check.
 func is_empty() -> bool:
 	return _defined.is_empty() and _patched.is_empty()
 
 
-## Adds content at a number the cartridge does not use.
-##
-## [param row] is a partial row: whatever it does not carry comes from
-## [constant DEFAULTS], so a species defined with a name, stats and a learnset is
-## a complete species. Refused if the number is a cartridge number, if the kind
-## is not one of [constant KINDS], or if another mod already claimed it.
+## Adds content at a number the cartridge does not use. [param row] is partial
+## and the rest comes from [constant DEFAULTS]. Refused for a cartridge number,
+## a kind outside [constant KINDS], or a number another mod claimed.
 func define(kind: StringName, id: StringName, number: int, row: Dictionary) -> Dictionary:
 	if not KINDS.has(kind):
 		return {"ok": false, "reason": &"unknown_content_kind", "detail": String(kind)}
@@ -179,14 +157,10 @@ func define(kind: StringName, id: StringName, number: int, row: Dictionary) -> D
 	return {"ok": true, "kind": kind, "number": number}
 
 
-## Replaces named fields of a cartridge row: a move's power, a species' types, an
-## item's price.
-##
-## Only the fields given change, and a Dictionary field merges rather than
-## replacing, so patching [code]{"stats": {"speed": 120}}[/code] leaves the other
-## five stats alone. An Array field replaces whole, which is what a randomizer
-## rewriting an encounter row's [code]slots[/code] wants. Refused for a number a
-## mod would have to [method define].
+## Replaces named fields of a cartridge row. A Dictionary field merges, so
+## [code]{"stats": {"speed": 120}}[/code] leaves the other five alone; an Array
+## replaces whole, which is what a randomizer rewriting an encounter row's
+## [code]slots[/code] wants. Refused for a number [method define] would take.
 func patch(kind: StringName, id: StringName, number: int, fields: Dictionary) -> Dictionary:
 	if not KINDS.has(kind):
 		return {"ok": false, "reason": &"unknown_content_kind", "detail": String(kind)}
@@ -212,13 +186,10 @@ func patch(kind: StringName, id: StringName, number: int, fields: Dictionary) ->
 	return {"ok": true, "kind": kind, "number": number}
 
 
-## The row a reader gets for [param number], given the cartridge's own
-## [param base]. A definition answers on its own; a patch is folded onto the
-## base; anything else is the base untouched.
-##
-## A patch of a number this cartridge does not carry answers empty rather than
-## conjuring a row out of the patch alone: Crystal's MYSTICALMAN is not a trainer
-## class Gold has, and a mod patching it must not invent one there.
+## The row a reader gets: a definition answers alone, a patch is folded onto
+## [param base], anything else is the base untouched. A patch of a number this
+## cartridge does not carry answers empty rather than conjuring a row, since
+## Crystal's MYSTICALMAN is not a trainer class Gold has.
 func resolve(kind: StringName, number: int, base: Dictionary) -> Dictionary:
 	var defined: Dictionary = _defined.get(kind, {})
 	if defined.has(number):
@@ -231,9 +202,8 @@ func resolve(kind: StringName, number: int, base: Dictionary) -> Dictionary:
 	return _merged(base, patched[number])
 
 
-## Every number defined for [param kind], in ascending order. What a menu or a
-## dex listing walks to show mod content beside the cartridge's, since
-## [method GameData.species_count] stays the cartridge's own count.
+## Ascending, for a menu or dex listing showing mod content beside the
+## cartridge's, since [method GameData.species_count] stays the cartridge's.
 func defined_numbers(kind: StringName) -> Array[int]:
 	var out: Array[int] = []
 	for number: int in (_defined.get(kind, {}) as Dictionary).keys():
@@ -242,10 +212,8 @@ func defined_numbers(kind: StringName) -> Array[int]:
 	return out
 
 
-## The [constant KIND_ENCOUNTER] number for one map's table under one method, or
-## -1 for a method or a map coordinate that cannot exist. A map group and number
-## are each one byte, so the three parts pack without colliding and a mod's
-## patch means the same thing on all three cartridges.
+## One map's table under one method, or -1 for a coordinate that cannot exist.
+## Group and number are a byte each, so the three parts pack without colliding.
 static func encounter_number(method: StringName, group: int, number: int) -> int:
 	var at: int = ENCOUNTER_METHODS.find(method)
 	if at < 0 or group < 0 or group > 0xFF or number < 0 or number > 0xFF:
@@ -253,14 +221,12 @@ static func encounter_number(method: StringName, group: int, number: int) -> int
 	return at * 0x10000 + group * 0x100 + number
 
 
-## Which mod claimed [param number], or an empty name. For a launcher listing
-## what changed the game it is about to start.
+## Which mod claimed [param number], for a launcher listing what it will change.
 func owner_of(kind: StringName, number: int) -> StringName:
 	return StringName((_owners.get(kind, {}) as Dictionary).get(number, &""))
 
 
-## One number, one mod. Two mods reaching for the same species is exactly the
-## conflict a player wants named rather than resolved by load order.
+## One number, one mod: a collision is named rather than settled by load order.
 func _claim(kind: StringName, id: StringName, number: int) -> Dictionary:
 	var owners: Dictionary = _owners.get(kind, {})
 	var owner: StringName = StringName(owners.get(number, &""))
@@ -283,10 +249,9 @@ func _normalized(kind: StringName, number: int, row: Dictionary) -> Dictionary:
 
 
 ## [param over] laid on [param base], recursing into Dictionary values so a
-## partial [code]stats[/code] keeps the stats it did not name. Arrays replace
-## whole: a two-element [code]types[/code] merged element-wise would make
-## [code][15][/code] mean "Ice and whatever was there", which is not what writing
-## it says.
+## partial [code]stats[/code] keeps what it did not name. Arrays replace whole: a
+## merged [code]types[/code] would read [code][15][/code] as "Ice and whatever
+## was there".
 func _merged(base: Dictionary, over: Dictionary) -> Dictionary:
 	var out: Dictionary = base.duplicate(true)
 	for key: Variant in over:

--- a/game/data/move_forget.gd
+++ b/game/data/move_forget.gd
@@ -1,36 +1,21 @@
 class_name Gen2MoveForget
 extends RefCounted
 
-## Giving up one of four moves to make room for a fifth
-## (engine/pokemon/learn.asm's LearnMove and ForgetMove).
+## engine/pokemon/learn.asm's `LearnMove` and `ForgetMove`. Shared here because
+## `LearnMove` is reached from both `TeachTMHM` and a level-up in battle, so
+## neither [Gen2WorldPartyHost] nor [Gen2Battle] owns it. Identical in both pins.
 ##
-## `LearnMove` reaches `ForgetMove` from both of its callers: `TeachTMHM` for a
-## TM or HM out of the pack, and a level-up in battle. So the tables and the
-## wording live here rather than beside either one, and neither
-## [Gen2WorldPartyHost] nor [Gen2Battle] owns the other's copy.
-##
-## Everything here is byte identical between the pins. learn.asm differs by one
-## line, `bit B_PAD_B` against `bit B_BUTTON_F`, which is the same bit under two
-## names; home/hm_moves.asm and the seven move numbers are identical.
-##
-## The order the source asks in, which both screens follow:
-##
-## 1. `AskForgetMoveText` and its yes/no. No returns carry, which is
-##    `LearnMove.cancel`.
-## 2. `MoveAskForgetText` and the move list. B is also `LearnMove.cancel`; an HM
-##    row prints `MoveCantForgetHMText` and redisplays the list (`jr .loop`),
-##    which is not a cancel.
-## 3. `LearnMove.cancel` is `StopLearningMoveText` and its yes/no. Yes ends with
-##    `DidNotLearnMoveText`; no returns to step 1.
+## The order the source asks in: `AskForgetMoveText`'s yes/no, then
+## `MoveAskForgetText` and the move list, where an HM row prints
+## `MoveCantForgetHMText` and loops rather than cancelling. B or a no reaches
+## `LearnMove.cancel`, ending in `DidNotLearnMoveText` or asking again.
 
 ## How many moves a Pokémon can know at once, NUM_MOVES.
 const MOVE_SLOTS: int = 4
 
-## home/hm_moves.asm's `IsHMMove.HMMoves`, in source order, from
-## constants/move_constants.asm's hex comment column. Seven moves, which is a
-## longer list than the four [constant Gen2WorldFieldMove.FIELD_MOVES] this
-## project acts on in the overworld: forgetting is gated on every HM the
-## cartridge has, not on the ones with a field effect here.
+## home/hm_moves.asm's `IsHMMove.HMMoves`, in source order. Seven, against the
+## four [constant Gen2WorldFieldMove.FIELD_MOVES] the overworld acts on:
+## forgetting is gated on every HM, not on the ones with a field effect here.
 const HM_MOVES: Array[int] = [
 	0x0F,  # CUT
 	0x13,  # FLY
@@ -42,18 +27,14 @@ const HM_MOVES: Array[int] = [
 ]
 
 
-## `IsHMMove`: whether [param move] is one an HM teaches, and so one
-## `ForgetMove` refuses to give up.
+## `IsHMMove`: an HM's move, which `ForgetMove` refuses to give up.
 static func is_hm_move(move: int) -> bool:
 	return HM_MOVES.has(move)
 
 
-## The rows `ListMoves` draws, one per move the Pokémon actually knows.
-##
-## `ListMoves` stops at the first zero, so a padded slot is not listed; in
-## practice `ForgetMove` is only reached with all four taken. `forgettable` is
-## the `IsHMMove` test the menu makes on confirm, resolved up front so a screen
-## can mark the row rather than only refuse it.
+## `ListMoves`' rows: it stops at the first zero, so a padded slot is not listed.
+## `forgettable` is the `IsHMMove` test the menu makes on confirm, resolved up
+## front so a screen can mark the row rather than only refuse it.
 static func options(data: GameData, moves: Array) -> Array:
 	var out: Array = []
 	if data == null:
@@ -93,10 +74,8 @@ static func did_not_learn_text(mon_name: String, move_name: String) -> String:
 	return "%s did not learn %s." % [mon_name, move_name]
 
 
-## `Text_1_2_and_Poof` then `_MoveForgotText`, as the one line this project
-## shows where the source shows two boxes and a pause. The SFX_SWITCH_POKEMON
-## between them is a boundary: neither screen that reaches this has an SFX
-## route.
+## `Text_1_2_and_Poof` then `_MoveForgotText`, as one line where the source
+## shows two: the SFX_SWITCH_POKEMON between them has no route on either screen.
 static func forgot_text(mon_name: String, old_move_name: String) -> String:
 	return "1, 2 and… Poof! %s forgot %s. And…" % [mon_name, old_move_name]
 
@@ -106,7 +85,6 @@ static func learned_text(mon_name: String, move_name: String) -> String:
 	return "%s learned %s!" % [mon_name, move_name]
 
 
-## `MoveCantForgetHMText`. The list stays open behind it, since the source's
-## `.hmmove` branch is `jr .loop`.
+## `MoveCantForgetHMText`. The list stays open, since `.hmmove` is `jr .loop`.
 static func cant_forget_hm_text() -> String:
 	return "HM moves can't be forgotten now."

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1,21 +1,17 @@
 class_name RomLayout
 extends RefCounted
 
-## Where the data lives inside each supported cartridge.
-##
-## Offsets are absolute positions in the 2 MiB dump, not bank:address pairs, so
-## a decoder never has to think about banking. Gold and Silver share the bank
-## map, while a few data sections use per-game offsets; Crystal moved almost
-## everything and is its own table.
+## Where the data lives inside each supported cartridge. Offsets are absolute
+## positions in the 2 MiB dump rather than bank:address pairs, so a decoder never
+## thinks about banking; Gold and Silver share the bank map with a few per-game
+## sections, and Crystal moved almost everything and is its own table.
 ##
 ## Every offset was located in the cartridges themselves, by searching for
-## independently known bytes (the encoded string "BULBASAUR", Bulbasaur's
-## published base stats), then cross-checked against the pret disassemblies for
-## structure. An offset table is a claim about a specific dump, which is why an
-## uncharacterised ROM is refused rather than guessed at.
-##
-## An offset is only trustworthy alongside its check: see
-## [method RomImporter.verify_layout], run before anything is decoded.
+## independently known bytes (the encoded "BULBASAUR", Bulbasaur's published base
+## stats), then cross-checked against pret for structure. A table is a claim
+## about a specific dump, which is why an uncharacterised ROM is refused rather
+## than guessed at, and an offset is only trustworthy alongside its check in
+## [method RomImporter.verify_layout].
 
 const SPECIES_COUNT: int = 251
 const NAME_LENGTH: int = 10
@@ -96,21 +92,18 @@ const ASLEEP_TREEMON_MAX_ROWS: int = 16
 ## values are the source's integer `$FF / 100 * percent` expressions.
 const WILD_SURF_LEVEL_THRESHOLDS: Array[int] = [89, 165, 216, 242]
 
-## The graphics stream supplies two blocks of 96 tiles: `LoadTilesetGFX`
-## (home/map.asm) copies the first to vTiles2 in VRAM bank 0 and the second to
-## vTiles5 in bank 1, at the same tile numbers. A metatile byte with the high bit
-## set names the second block, because `_LoadOverworldAttrmapPals`
-## (engine/tilesets/map_palettes.asm) reads the palette map at the full byte,
-## takes bit 3 of the nibble as the VRAM bank, then clears bit 7 of the tile
-## number. So the addressable span is 224: block 0 at 0..95, the 32 font tiles
-## `_LoadFontsExtra1` owns at 96..127, and block 1 at 128..223. The strip carries
-## all 224 with the font gap blank, so a metatile byte indexes it directly.
+## Two blocks of 96 tiles: `LoadTilesetGFX` (home/map.asm) copies the first to
+## vTiles2 in VRAM bank 0 and the second to vTiles5 in bank 1 at the same tile
+## numbers, and a metatile byte with bit 7 set names the second, since
+## `_LoadOverworldAttrmapPals` reads the palette map at the full byte, takes bit
+## 3 of the nibble as the bank, then clears bit 7. So the span is 224: block 0 at
+## 0..95, `_LoadFontsExtra1`'s 32 font tiles at 96..127, block 1 at 128..223. The
+## strip carries all 224 with the font gap blank, indexed directly.
 ##
-## Eight tilesets compress only one block; the cartridge copies whatever follows
-## into bank 1 and no block of theirs ever names it, so the import blanks it.
-## Metatile and collision tables are shorter for tilesets that never use all 128
-## blocks; unused metatile entries may still contain $FF placeholders, which is
-## why a tile number past the span resolves to 0 rather than to a read.
+## Eight tilesets compress one block only; the cartridge copies whatever follows
+## into bank 1 and no block of theirs names it, so the import blanks it. Metatile
+## and collision tables are shorter for tilesets under 128 blocks and unused
+## entries may hold $FF, which is why a tile past the span resolves to 0.
 const TILESET_RECORD_SIZE: int = 15
 const TILESET_TILE_COUNT: int = 224
 const TILESET_BLOCK_TILES: int = 96
@@ -344,13 +337,10 @@ const TYPE_DARK: int = 0x1B
 ## the runaway guard for a terminator walk, not a field width.
 const MAX_NAME_LENGTH: int = 16
 
-## The type matchup chart: three bytes an entry, attacker then defender then the
-## multiplier, and only the exceptions are listed. A pair that is not in the
-## table is [constant MATCHUP_EFFECTIVE], which is why the whole of Generation 2
-## fits in 332 bytes.
-##
-## Multipliers are in tenths as the cartridge stores them, applied by multiplying
-## then dividing by ten. Tenths rather than a float because the games truncate
+## The type matchup chart: attacker, defender, multiplier, exceptions only, so a
+## pair not in the table is [constant MATCHUP_EFFECTIVE] and the whole of
+## Generation 2 fits in 332 bytes. Multipliers are in tenths as the cartridge
+## stores them, applied by multiplying then dividing, because the games truncate
 ## after each of a defender's two types.
 const MATCHUP_ENTRY_SIZE: int = 3
 const MATCHUP_ATTACKER: int = 0
@@ -391,17 +381,12 @@ const MAX_MATCHUPS: int = 256
 const PHYSICAL_TYPES_END: int = 0x09
 const SPECIAL_TYPES_START: int = 0x14
 
-## One Pokedex entry (data/pokemon/dex_entries.asm): a terminated category
-## string, then height and weight as little-endian words, then two terminated
-## description pages.
-##
-## The page break is the terminator itself, not a code of its own: `MACRO page`
-## in macros/scripts/text.asm is `db "@", \#`, so an entry ends after the second
-## terminated run rather than at the first.
-##
-## Height is decimal digits of feet and inches (204 is 2'04") and weight is
-## tenths of a pound (150 is 15.0 lb), which is why both are stored raw and
-## formatted at draw time rather than converted here.
+## One Pokedex entry (data/pokemon/dex_entries.asm): a terminated category, then
+## height and weight as little-endian words, then two terminated pages. The page
+## break is the terminator itself, `MACRO page` being `db "@", \#`, so an entry
+## ends after the second run rather than the first. Height is decimal digits of
+## feet and inches (204 is 2'04") and weight tenths of a pound, both stored raw
+## and formatted at draw time.
 const DEX_ENTRY_PAGES: int = 2
 const DEX_ENTRY_MEASUREMENT_BYTES: int = 2
 ## Runaway guard for a page walk, well past the longest entry in any of the
@@ -440,9 +425,8 @@ const EVOS_ATTACKS_END: int = 0
 
 ## How a species evolves. The byte after the method is a level for
 ## [constant EVOLVE_LEVEL] and [constant EVOLVE_STAT], an item for
-## [constant EVOLVE_ITEM], the item that has to be held for
-## [constant EVOLVE_TRADE] ($FF when the trade needs none), and a time of day for
-## [constant EVOLVE_HAPPINESS].
+## [constant EVOLVE_ITEM], a held item for [constant EVOLVE_TRADE] ($FF for
+## none), and a time of day for [constant EVOLVE_HAPPINESS].
 const EVOLVE_LEVEL: int = 1
 const EVOLVE_ITEM: int = 2
 const EVOLVE_TRADE: int = 3
@@ -548,19 +532,16 @@ const FONT_FIRST_CODE: int = 0x80
 ## arithmetically rather than listing.
 const FONT_INK_RUNS: Array = [[0x80, 0x99], [0xA0, 0xB9], [0xF6, 0xFF]]
 
-## Codes with no character in [Gen2Text], whose tiles are therefore blank. These
-## sit between the runs above, which is what makes the pair a layout check: an
-## offset out by a single tile drags a blank onto "z" and a glyph onto a code
-## that has none, and both halves fail at once.
-##
-## Not every unmapped code is here. Crystal draws an arrow at $EB where Gold and
-## Silver leave a hole, so only the runs all three agree on are checked.
+## Codes with no character in [Gen2Text], whose tiles are blank. They sit between
+## the runs above, which is what makes the pair a layout check: an offset out by
+## one tile drags a blank onto "z" and a glyph onto a code that has none. Crystal
+## draws an arrow at $EB where Gold and Silver leave a hole, so only the runs all
+## three agree on are checked.
 const FONT_BLANK_RUNS: Array = [[0xBA, 0xBF], [0xC6, 0xCF], [0xD7, 0xDE]]
 
-## Text box borders: eight to choose from, six tiles each, in the order
-## ┌ ─ ┐ │ └ ┘. They are loaded at code $79, which is where the box-drawing
-## codes start in [Gen2Text], so those codes address the border directly and a
-## box is drawn by printing characters like anything else.
+## Text box borders: eight frames of six tiles, in the order ┌ ─ ┐ │ └ ┘, loaded
+## at code $79 where [Gen2Text]'s box-drawing codes start, so a box is drawn by
+## printing characters like anything else.
 const FRAME_COUNT: int = 8
 const FRAME_TILES: int = 6
 const FRAME_FIRST_CODE: int = 0x79
@@ -575,31 +556,27 @@ const FRAME_BOTTOM_RIGHT: int = 5
 ## The battle HUD's own graphics, which sit in the same section as the font and
 ## the text box borders and are the rest of what a battle screen draws.
 ##
-## [code]battle_font[/code] is 2bpp and carries "HP:", the nine fill levels of
-## the HP bar and the battle screen's odds and ends. The two HUD borders are 1bpp
-## and are the boxes a name and a level sit in, one shape for the enemy's and one
-## for the player's. The exp bar is 2bpp and is seven fill levels and two ends.
+## [code]battle_font[/code] is 2bpp and carries "HP:", the HP bar's nine fill
+## levels and the screen's odds and ends. The two HUD borders are 1bpp, the boxes
+## a name and level sit in. The exp bar is 2bpp, seven fills and two ends.
 const BATTLE_FONT_TILES: int = 32
-## Where `_LoadFontsBattleExtra` puts its first tile: `ld hl, vTiles2 tile $60`.
-## Its twenty-five tiles cover $60 to $78, so a code in that run addresses this
-## strip rather than the main font while it is loaded, which is what
-## [constant Gen2Text.FONT_BATTLE_EXTRA] names.
+## `_LoadFontsBattleExtra`'s `ld hl, vTiles2 tile $60`. Its twenty-five tiles
+## cover $60 to $78, so a code in that run addresses this strip rather than the
+## main font while loaded, which [constant Gen2Text.FONT_BATTLE_EXTRA] names.
 const BATTLE_FONT_FIRST_CODE: int = 0x60
 const ENEMY_HUD_TILES: int = 4
 const PLAYER_HUD_TILES: int = 6
 const EXP_BAR_TILES: int = 9
 
-## The trainer card's own graphics (engine/menus/trainer_card.asm).
+## The trainer card's graphics (engine/menus/trainer_card.asm). `CardStatusGFX`
+## is six tiles but `_Option`'s page 1 asks for 86, running on into `LeaderGFX`,
+## so page 1's strip is those 86 from the card_status offset; pages 2 and 3 load
+## 86 from the leaders offset, which overlaps it, and both are imported because
+## that is what each page draws.
 ##
-## `CardStatusGFX` is six tiles but `_Option`'s page 1 asks for 86, running
-## straight on into `LeaderGFX`, so the strip page 1 loads is those 86 tiles from
-## the card_status offset. Pages 2 and 3 load 86 from the leaders offset, which
-## overlaps it; both are imported, because that is what each page draws.
-##
-## The pic is a 5x7 picture. Crystal stores it column-major (`--columns` plus
-## `PlaceGraphic`, which fills down each column) and Gold and Silver row-major
-## (their own inline `.row`/`.col` loop), so the importer reorders Crystal's into
-## the picture and both profiles reach the screen the same way.
+## The pic is 5x7. Crystal stores it column-major (`--columns` plus
+## `PlaceGraphic`) and Gold and Silver row-major (their inline `.row`/`.col`
+## loop), so the importer reorders Crystal's and both reach the screen alike.
 const CARD_STATUS_TILES: int = 86
 const CARD_LEADER_TILES: int = 86
 const CARD_BADGE_TILES: int = 44
@@ -609,19 +586,17 @@ const CARD_PIC_COLUMNS: int = 5
 const CARD_PIC_ROWS: int = 7
 const CARD_PIC_TILES: int = CARD_PIC_COLUMNS * CARD_PIC_ROWS
 
-## The Pokedex's own graphics (engine/pokedex/pokedex.asm).
+## The Pokedex's graphics (engine/pokedex/pokedex.asm). `PokedexLZ` is the 58
+## tiles `Pokedex_LoadGFX` decompresses to `vTiles2 tile $31` and
+## `PokedexSlowpokeLZ` the 55 at `vTiles0` that an unseen species is drawn as.
+## Both were located by compressing the pinned `gfx/pokedex` PNGs with pret's
+## `tools/lzcompress` flags: each hits once per dump and the second follows the
+## first, which is the source's own order.
 ##
-## `PokedexLZ` is the 58 tiles `Pokedex_LoadGFX` decompresses to `vTiles2 tile
-## $31`, and `PokedexSlowpokeLZ` the 55 that go to `vTiles0`, which is what an
-## unseen species is drawn as. Both were located by compressing the pinned
-## `gfx/pokedex` PNGs with pret's own `tools/lzcompress` flags and matching the
-## bytes: each hits once per dump, the second follows the first, and that is the
-## order the source stores them in.
-##
-## `Footprints` is 1bpp and uncompressed: 251 species of four tiles, stored as
-## eight top halves and then the eight matching bottom halves, which is why a
-## species' bottom half sits [constant FOOTPRINT_HALF_STRIDE] tiles past its top.
-## The 8 KiB run matches once per dump and is byte identical on all three.
+## `Footprints` is 1bpp and uncompressed, 251 species of four tiles stored as
+## eight top halves then the eight matching bottoms, which is why a bottom half
+## sits [constant FOOTPRINT_HALF_STRIDE] tiles past its top. The 8 KiB run
+## matches once per dump and is byte identical on all three.
 const POKEDEX_TILES: int = 58
 const POKEDEX_SLOWPOKE_TILES: int = 55
 ## `Pokedex_GetAndPlaceFootprint` asks for two 1bpp tiles at a time, twice.
@@ -652,16 +627,13 @@ const UNOWN_FONT_FIRST_TILE: int = 0x40
 const DESCRIPTION_MAX_BYTES: int = 80
 const MOVE_DESCRIPTION_COUNT: int = 251
 
-## The pack screen's own graphics (engine/items/pack.asm).
-##
-## `PackMenuGFX` is 80 tiles and `Pack_InitGFX` copies `$60 tiles` of it, so the
-## sixteen that land on `vTiles2 tile $50` are `PackGFX`'s own first sixteen;
-## `DrawPackGFX` then puts the current pocket's fifteen there before the screen
-## is shown, and the sixteenth is never named by a tilemap. That overrun is what
-## says the two runs are adjacent, and they are, in every dump.
-##
-## `PackFGFX` is Crystal's alone: Gold and Silver have no player gender and no
-## `DrawKrisPackGFX`. All four runs are uncompressed and each matches the
+## The pack screen's graphics (engine/items/pack.asm). `PackMenuGFX` is 80 tiles
+## and `Pack_InitGFX` copies `$60 tiles`, so the sixteen landing on `vTiles2 tile
+## $50` are `PackGFX`'s own first sixteen; `DrawPackGFX` puts the pocket's
+## fifteen there before the screen is shown and no tilemap names the sixteenth.
+## That overrun is what says the two runs are adjacent, and they are in every
+## dump. `PackFGFX` is Crystal's alone, Gold and Silver having no player gender
+## and no `DrawKrisPackGFX`. All four are uncompressed and each matches the
 ## assembled `gfx/pack` PNGs once per dump.
 const PACK_MENU_TILES: int = 80
 const PACK_POCKET_TILES: int = 15
@@ -772,14 +744,10 @@ const PRESENTS_DITTO_FADE_COLORS: int = 16
 const PRESENTS_OBJECT_PALETTE_COLORS: int = 4
 
 ## The title screen (`_TitleScreen` on Crystal, `TitleScreen` on Gold and Silver,
-## `engine/movie/title.asm`). Two different screens sharing a phase: Crystal
-## decompresses three graphics and holds sixteen palettes of its own, while Gold
-## and Silver decompress two halves of a logo over one `$FF`-terminated tilemap
-## and animate a bird sprite behind a raw trail.
-##
-## Every offset was located the way the splash's were: the pinned PNG encoded as
-## cartridge 2bpp and matched, or, for an LZ run, every offset in the bank
-## decompressed and the one reproducing the PNG exactly kept. Each hits once.
+## `engine/movie/title.asm`): two screens sharing a phase, Crystal decompressing
+## three graphics with sixteen palettes of its own and Gold and Silver two halves
+## of a logo over one `$FF`-terminated tilemap with a bird behind a raw trail.
+## Every offset was located the way the splash's were, and each hits once.
 const TITLE_SUICUNE_TILES: int = 256
 ## `--trim-end 4`: `DrawTitleGraphic` places 7 rows of 20 from `vTiles1`, and the
 ## four tiles past them are whitespace the build drops.
@@ -1046,15 +1014,12 @@ const INTRO_GRASS_FIRST_TILE: int = 0x09
 ## The blank the two Suicune scenes park in the sprite tile the dict points at.
 const INTRO_GRASS_BLANK: String = "grass_4"
 
-## `GoldSilverIntro` (pokegold/engine/movie/intro.asm), the movie Gold and Silver
-## run where Crystal runs `CrystalIntro`: seventeen scenes over water, grass and
-## fire rather than twenty-eight over Unown and Suicune.
-##
-## Its art section is the same shape as Crystal's, contiguous and
-## [constant INTRO_ENTRY_ALIGN]-aligned, so the one pinned address walks all
-## eleven entries. The names are pret's own file names, which are also the INCBIN
-## order the walk depends on: `1` is the sheet a scene puts at `vTiles2` and `2`
-## the one it puts at `vTiles0`, and `fire2` is the third at `vTiles1`.
+## `GoldSilverIntro` (pokegold/engine/movie/intro.asm), where Crystal runs
+## `CrystalIntro`: seventeen scenes over water, grass and fire rather than
+## twenty-eight over Unown and Suicune. Its art section is Crystal's shape,
+## contiguous and [constant INTRO_ENTRY_ALIGN]-aligned, so one pinned address
+## walks all eleven. The names are pret's, which is also the INCBIN order the
+## walk depends on: `1` goes to `vTiles2`, `2` to `vTiles0`, `fire2` to `vTiles1`.
 const GS_INTRO_SCENES: int = 17
 const GS_INTRO_SECTION: Array[Array] = [
 	["water1", "lz", 128],
@@ -1184,18 +1149,15 @@ const LANDMARK_OAM_Y: int = 16
 const LANDMARK_NAME_BYTES: int = 18
 
 ## The battle animation data layer: the per-move scripts and the four tables the
-## objects they spawn are built from.
-##
-## Every one of the five is stored as a contiguous region rather than entry by
-## entry, because each is a pointer table immediately followed by the data it
-## points at, and every pointer inside it is bank-local. Keeping the region whole
-## means a cached address resolves by subtraction and the bytes are the
-## cartridge's own; see [Gen2BattleAnimImporter].
+## objects they spawn are built from. All five are stored as contiguous regions
+## rather than entry by entry, each being a pointer table followed by the
+## bank-local data it points at, so a cached address resolves by subtraction and
+## the bytes stay the cartridge's ([Gen2BattleAnimImporter]).
 ##
 ## `BattleAnimations` (data/moves/animations.asm) is indexed by move number, so
-## entry 0 is `BattleAnim_Dummy` and 1 is `BattleAnim_Pound`. Entries past
+## entry 0 is `BattleAnim_Dummy` and 1 `BattleAnim_Pound`. Entries past
 ## [constant MOVE_COUNT] are the four the table pads to $100 with and then the
-## non-move animations, which `wFXAnimID`'s high byte reaches.
+## non-move animations `wFXAnimID`'s high byte reaches.
 const BATTLE_ANIM_SCRIPT_COUNT: int = 278
 const BATTLE_ANIM_OBJECT_COUNT: int = 188
 const BATTLE_ANIM_OBJECT_SIZE: int = 6
@@ -1567,10 +1529,9 @@ const GOLD_SILVER: Dictionary = {
 	## not ship stays out of the flat offset checks. `_OakText3` is a bare
 	## `text_promptbutton` and carries no words, so it has no offset here.
 	# `engine/menus/start_menu.asm`'s description run and `data/text/common_2.asm`'s
-	# five pack texts, all located by encoding what the source says they read and
-	# matching the bytes. Each hits once per dump except the two refusals, which
-	# the cartridge also keeps a copy of elsewhere; the common_2 copy is the one
-	# beside the toss texts, which is what the offsets below are.
+	# five pack texts, encoded from the source and matched. Each hits once per
+	# dump except the two refusals, which the cartridge copies elsewhere too; the
+	# offsets below are the common_2 copy beside the toss texts.
 	"menu_text": {
 		"descriptions": 0x12B15,
 		"oak_no_time": 0x1945B2,
@@ -1628,15 +1589,13 @@ const GOLD_SILVER: Dictionary = {
 		"right_corner": -1,
 		"badge_palette": 0xA385,
 	},
-	# The region map. `johto`, `kanto`, `palette_map` and `palette` were located
-	# by assembling the pinned gfx/pokegear files and matching the bytes; the
-	# three graphics by decompressing at every offset and keeping the run that
-	# reproduces the pinned PNG exactly. Every hit is unique per dump. The
-	# landmark table was located by its own x,y byte pairs at a stride of four,
-	# which no other run in the cartridge matches. `cards` is the three card
-	# tilemaps as one run, matched from the pinned .rle files, and `card_texts`
-	# the two Pokegear texts, matched as encoded characters. Nested the way
-	# trainer_card is, so Gold and Silver's absent female palette stays out of
+	# The region map. `johto`, `kanto`, `palette_map` and `palette` were matched
+	# from the assembled gfx/pokegear files, the three graphics by decompressing
+	# at every offset and keeping the run reproducing the PNG, and the landmark
+	# table by its x,y pairs at a stride of four, which nothing else matches.
+	# Every hit is unique per dump. `cards` is the three card tilemaps as one run
+	# from the pinned .rle files and `card_texts` the two Pokegear texts. Nested
+	# like trainer_card, so Gold and Silver's absent female palette stays out of
 	# the flat offset checks.
 	"town_map": {
 		"gfx": 0xF8C92,
@@ -1816,13 +1775,11 @@ const GOLD_SILVER: Dictionary = {
 	},
 	# Battle animations. `BattleAnimations` was located by matching
 	# `BattleAnim_Pound` whole (d1 01 e0 01 31 d0 08 88 38 00 06 d0 01 88 38 00
-	# 10 ff), then finding the run of 278 in-bank pointers whose second entry is
-	# its address; the other four tables were located by assembling the pinned
-	# data/battle_anims files and matching the bytes. Each hit is unique in the
-	# dump. `sine` is the one that is not: the same 64 bytes appear four or five
-	# times per dump, so it was located from `calc_sine_wave`'s own operand, the
-	# `ld hl` at the end of the copy sharing this bank with the four tables, and
-	# only that hit lies in the bank. Nested for the same reason trainer_card is.
+	# 10 ff), then the run of 278 in-bank pointers whose second entry is its
+	# address; the other four came from the assembled data/battle_anims files.
+	# Each hit is unique except `sine`, whose 64 bytes appear four or five times
+	# per dump: it was located from `calc_sine_wave`'s own `ld hl` operand, and
+	# only that hit lies in the bank. Nested like trainer_card.
 	"battle_anims": {
 		"scripts": 0xC900A,
 		"objects": 0xCCAA5,

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -1,43 +1,35 @@
 class_name Gen2Text
 extends RefCounted
 
-## The Generation 2 character encoding, for the international ROMs.
+## The Generation 2 character encoding, for the international ROMs. One byte per
+## character terminated by $50, the alphabet in runs: $80 is "A", $A0 is "a", $F6
+## is "0". Some codes expand to whole words ($5D is "TRAINER") or name the player
+## at print time ($52); those stay bracketed markers so nothing is silently lost.
+## The Japanese cartridges reuse most of this range for kana, are not in
+## [RomRegistry], and would decode into nonsense here.
 ##
-## One byte per character, terminated by $50, the alphabet in runs: $80 is "A",
-## $A0 is "a", $F6 is "0". Some codes expand to whole words ($5D is "TRAINER") or
-## name the player at print time ($52); those stay bracketed markers so a caller
-## can substitute them and nothing is silently lost.
-##
-## The Japanese cartridges reuse most of this range for kana. They are not in
-## [RomRegistry], and this table would decode them into nonsense.
-##
-## A byte does not name a character on its own. `constants/charmap.asm` maps the
-## $60 to $7F run twice over, once from `gfx/font/font.png` and again from
-## `gfx/font/font_battle_extra.png` under its own "Actual characters" heading,
-## and $6e three times; the byte means whichever strip the hardware last loaded
-## into video memory. Every entry point here takes the strip, defaulting to the
-## main font, which is what all but the battle and Hall of Fame screens have up.
+## A byte does not name a character on its own: `constants/charmap.asm` maps the
+## $60 to $7F run twice, from `gfx/font/font.png` and from
+## `gfx/font/font_battle_extra.png`, and $6e three times, so a byte means
+## whichever strip the hardware last loaded. Every entry point takes the strip,
+## defaulting to the main font that all but the battle and Hall of Fame have up.
 
 const TERMINATOR: int = 0x50
 const SPACE: int = 0x7F
 
-## Which strip is loaded. [constant FONT_MAIN] is `_LoadStandardFont`'s;
-## [constant FONT_BATTLE_EXTRA] is what `_LoadFontsBattleExtra` leaves behind,
-## which `engine/events/halloffame.asm` calls before it prints a panel.
+## `_LoadStandardFont`'s strip, and `_LoadFontsBattleExtra`'s, which
+## `engine/events/halloffame.asm` calls before it prints a panel.
 const FONT_MAIN: StringName = &"main"
 const FONT_BATTLE_EXTRA: StringName = &"battle_extra"
 
-## The run `_LoadFontsBattleExtra` overwrites: twenty-five tiles from $60, which
-## is `ld hl, vTiles2 tile $60` and `lb bc, BANK(FontBattleExtra), 25`. Outside
-## it the main font is still up, so letters, digits and the box-drawing codes
-## mean what they always did.
+## The run `_LoadFontsBattleExtra` overwrites: `ld hl, vTiles2 tile $60` and
+## `lb bc, BANK(FontBattleExtra), 25`. Outside it the main font is still up.
 const BATTLE_EXTRA_FIRST_CODE: int = 0x60
 const BATTLE_EXTRA_LAST_CODE: int = 0x78
 
-## What that run says. The rest of it is the HP bar's fill levels and the two HUD
-## borders, which are graphics rather than characters, so a code in the run and
-## not in here has no character at all: falling back to the main font's would
-## decode $75 as an ellipsis when the tile in memory is a piece of a bar.
+## What that run says. The rest is the HP bar's fill levels and the HUD borders,
+## graphics rather than characters, so a code in the run and not here has none:
+## falling back would decode $75 as an ellipsis when the tile is part of a bar.
 const BATTLE_EXTRA_CHARACTERS: Dictionary = {
 	0x6E: "<LV>",
 	0x70: "<DO>",
@@ -47,22 +39,19 @@ const BATTLE_EXTRA_CHARACTERS: Dictionary = {
 	0x74: "№",
 }
 
-## The lowest code the font has a tile for. Everything below it is a space, a
-## border, a control code or a name substituted at print time, so it is also the
-## line between what [method encode] will produce and what only [method decode]
-## understands.
+## The lowest code with a tile. Below it is a space, border, control code or a
+## print-time name, so it is also the line between [method encode]'s range and
+## what only [method decode] understands.
 const FIRST_PRINTABLE: int = 0x80
 
 ## What an unencodable character becomes: "?", because a question mark on screen
 ## is a bug someone will report and a dropped character is not.
 const UNKNOWN: int = 0xE6
 
-## The longest character sequence one tile can stand for: the apostrophe
-## ligatures ('s, 't) and PK/MN are two characters in a single glyph, because
-## the font has no room for a free-standing apostrophe followed by a letter.
-## The longer word codes $54 ("POKé") and $4a ("PKMN") are not reachable through
-## this: they sit below FIRST_PRINTABLE and so are decode-only by design. Write
-## "#" for $54 the way the source charmap does.
+## The longest sequence one tile stands for: the apostrophe ligatures and PK/MN
+## are two characters in one glyph. The word codes $54 ("POKé") and $4a ("PKMN")
+## sit below FIRST_PRINTABLE and are decode-only; write "#" for $54 as the source
+## charmap does.
 const MAX_LIGATURE: int = 2
 
 static var _table: Dictionary = {}
@@ -70,8 +59,7 @@ static var _codes: Dictionary = {}
 static var _battle_extra_codes: Dictionary = {}
 
 
-## Decodes bytes from [param offset] up to a terminator or [param max_length]
-## characters, whichever comes first.
+## Up to a terminator or [param max_length] characters, whichever comes first.
 static func decode(
 	data: PackedByteArray, offset: int, max_length: int, font: StringName = FONT_MAIN
 ) -> String:
@@ -87,23 +75,18 @@ static func decode(
 	return out
 
 
-## A fixed-width field: the game pads names with $50 and reads a known number of
-## bytes, so trailing padding is stripped rather than treated as a terminator
-## mid-string.
+## A fixed-width field: the game pads names with $50 and reads a known count, so
+## trailing padding is stripped rather than read as a mid-string terminator.
 static func decode_fixed(data: PackedByteArray, offset: int, length: int) -> String:
 	return decode(data, offset, length)
 
 
-## Walks [param count] consecutive terminated strings starting at [param offset].
-##
-## Species names are fixed-width, but move and item names are not: each entry
-## ends at its terminator and the next begins on the very next byte. Nothing
-## announces a length, so one wrong byte slides every name after it, which is why
-## the importer checks such a table's last entry as well as its first.
-##
-## [param max_length] is a runaway guard, not a field width: without it a table
-## read past its end would scan the remaining megabyte for a terminator that is
-## not coming.
+## [param count] consecutive terminated strings from [param offset]. Species
+## names are fixed-width; move and item names are not, each ending at its
+## terminator with the next on the following byte. Nothing announces a length, so
+## one wrong byte slides every name after it, which is why the importer checks
+## such a table's last entry as well as its first. [param max_length] is a
+## runaway guard, not a field width.
 static func decode_sequence(
 	data: PackedByteArray, offset: int, count: int, max_length: int
 ) -> PackedStringArray:
@@ -117,13 +100,10 @@ static func decode_sequence(
 	return out
 
 
-## The offset just past the terminator of the string at [param offset].
-##
-## What a caller needs to read the field that follows a variable-length string:
-## a Pokedex entry's height sits directly after its category, and its second
-## description page directly after its first. [param max_length] is the same
-## runaway guard [method decode_sequence] uses, and a walk that hits it, or the
-## end of the data, still answers one past where it stopped rather than looping.
+## Just past the terminator, for a caller reading the field that follows a
+## variable-length string: a Pokedex entry's height sits directly after its
+## category. [param max_length] is [method decode_sequence]'s runaway guard, and
+## a walk that hits it still answers one past where it stopped.
 static func terminated_end(data: PackedByteArray, offset: int, max_length: int) -> int:
 	var end: int = offset
 	while end < data.size() and data[end] != TERMINATOR and end - offset < max_length:
@@ -131,19 +111,13 @@ static func terminated_end(data: PackedByteArray, offset: int, max_length: int) 
 	return end + 1
 
 
-## Turns a string into the codes that draw it, one code per tile.
-##
-## The inverse of [method decode] over the printable range only: a name read back
-## out of the cache is a Godot [String] and has to become tiles again. Control
-## codes and print-time name codes are decode-only, since they are not glyphs and
-## the layout layer handles line breaks itself.
-##
-## Anything the font cannot draw becomes [constant UNKNOWN] rather than being
-## dropped, like an unrecognised byte on the way in.
-## [param font] adds the strip's own single characters. Its bracketed markers
-## (`<LV>`, `<ID>`, `<DO>`) stay decode-only, the way `<PLAYER>` and the word
-## codes already are: a marker is not a character someone types, and the callers
-## that place one place the code itself.
+## A string to the codes that draw it, one per tile: [method decode]'s inverse
+## over the printable range alone, since a name read back out of the cache is a
+## Godot [String]. Control and print-time name codes are decode-only, not being
+## glyphs, and anything the font cannot draw becomes [constant UNKNOWN] rather
+## than being dropped. [param font] adds the strip's own single characters; its
+## bracketed markers (`<LV>`, `<ID>`, `<DO>`) stay decode-only like `<PLAYER>`,
+## since the callers that place one place the code itself.
 static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArray:
 	var codes: Dictionary = _encodings() if font == FONT_MAIN else _battle_extra_encodings()
 	var out: PackedByteArray = PackedByteArray()
@@ -151,8 +125,7 @@ static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArra
 
 	while at < text.length():
 		var taken: int = 0
-		# Longest first, so "'s" wins over "'" followed by an "s" that has no
-		# code of its own.
+		# Longest first, so "'s" wins over a "'" with no "s" code after it.
 		for length: int in range(mini(MAX_LIGATURE, text.length() - at), 0, -1):
 			var candidate: String = text.substr(at, length)
 			if codes.has(candidate):
@@ -167,8 +140,7 @@ static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArra
 	return out
 
 
-## How many tiles a string occupies, which is not its length: a ligature is two
-## characters in one tile, so anything laying text out has to ask.
+## Tiles, not length: a ligature is two characters in one, so layout has to ask.
 static func encoded_length(text: String, font: StringName = FONT_MAIN) -> int:
 	return encode(text, font).size()
 
@@ -176,14 +148,12 @@ static func encoded_length(text: String, font: StringName = FONT_MAIN) -> int:
 static func character(byte: int, font: StringName = FONT_MAIN) -> String:
 	if font == FONT_BATTLE_EXTRA \
 		and byte >= BATTLE_EXTRA_FIRST_CODE and byte <= BATTLE_EXTRA_LAST_CODE:
-		# The run this strip owns answers only from its own table, never from the
-		# main font's meaning for the same byte.
+		# The run this strip owns answers from its own table alone.
 		return BATTLE_EXTRA_CHARACTERS.get(byte, "<%02X>" % byte)
 	var table: Dictionary = _characters()
 	if table.has(byte):
 		return table[byte]
-	# Never silently drop a byte we do not understand: an unrecognised code in a
-	# name means the offset table is wrong, and that should be visible.
+	# Never drop an unknown byte: it means the offset table is wrong.
 	return "<%02X>" % byte
 
 
@@ -241,8 +211,7 @@ static func _characters() -> Dictionary:
 	table[0x7D] = "└"
 	table[0x7E] = "┘"
 
-	# Apostrophe ligatures: one tile each, because the font has no room for a
-	# free-standing apostrophe followed by a letter.
+	# Apostrophe ligatures, one tile each: the font has no free-standing one.
 	table[0xD0] = "'d"
 	table[0xD1] = "'l"
 	table[0xD2] = "'m"
@@ -262,9 +231,9 @@ static func _characters() -> Dictionary:
 	table[0xE1] = "PK"
 	table[0xE2] = "MN"
 
-	# Substituted from RAM when the game prints them. $14 is not among them:
-	# `charmap.asm` gives it no character and `CheckDict` no entry, because it
-	# is TX_STRINGBUFFER one layer up. See [Gen2TextStream].
+	# Substituted from RAM at print time. $14 is not among them: `charmap.asm`
+	# gives it no character and `CheckDict` no entry, it being TX_STRINGBUFFER
+	# one layer up. See [Gen2TextStream].
 	table[0x38] = "<RED>"
 	table[0x39] = "<GREEN>"
 	table[0x3F] = "<ENEMY>"
@@ -274,15 +243,14 @@ static func _characters() -> Dictionary:
 	table[0x59] = "<TARGET>"
 	table[0x5A] = "<USER>"
 
-	# `CheckDict`'s two break opportunities, which draw nothing of their own:
-	# `<BSP>` is replaced with a space and `<WBR>` skipped. Both are `<LF>`
-	# instead on the region map, which is `TownMap_ConvertLineBreakCharacters`
-	# rewriting the byte before the string is placed.
+	# `CheckDict`'s two break opportunities, drawing nothing: `<BSP>` becomes a
+	# space and `<WBR>` is skipped. `TownMap_ConvertLineBreakCharacters` rewrites
+	# both to `<LF>` before a region map string is placed.
 	table[0x1F] = " "
 	table[0x25] = ""
 
-	# Line and box control. $16 is left out for the reason $14 is: to the
-	# command loop it is TX_FAR, and `CheckDict` has no `<CR>` entry.
+	# Line and box control. $16 is left out for $14's reason: to the command
+	# loop it is TX_FAR, and `CheckDict` has no `<CR>` entry.
 	table[0x22] = "\n"
 	table[0x4B] = "\n"
 	table[0x4C] = "\n"
@@ -298,10 +266,9 @@ static func _characters() -> Dictionary:
 	return _table
 
 
-## The printable table inverted. Built in ascending code order and never
-## overwritten, so where two codes draw the same character the lower one wins:
-## the only such pair is the full stop at $E8 and the narrower decimal point at
-## $F2, and $E8 is the one sentences end with.
+## The printable table inverted, built ascending and never overwritten, so the
+## lower of two codes drawing one character wins. The only such pair is the full
+## stop at $E8 and the narrower decimal point at $F2.
 static func _encodings() -> Dictionary:
 	if not _codes.is_empty():
 		return _codes
@@ -317,29 +284,24 @@ static func _encodings() -> Dictionary:
 		if not out.has(text):
 			out[text] = code
 
-	# constants/charmap.asm maps "#" to $54, the POKé ligature, which is how every
-	# source text writes it. Encode only: decoding $54 stays "POKé", so a round
-	# trip through the cartridge's own shorthand is not silently rewritten.
-	# Without this a synthesized literal such as "a #MON!" encodes "#" as UNKNOWN
-	# and draws a question mark.
+	# constants/charmap.asm maps "#" to $54, the POKé ligature every source text
+	# writes. Encode only, so decoding $54 stays "POKé" and a round trip is not
+	# rewritten. Without it "a #MON!" draws a question mark.
 	out["#"] = 0x54
 
-	# charmap.asm maps "…" to $75, which is likewise below FIRST_PRINTABLE and so
-	# decode-only. Source text writes the character itself (Text_MoveForgetCount's
-	# "1, 2 and…"), so a synthesized line quoting that wording needs it to encode
-	# rather than draw a question mark. $56 is "……" and stays decode-only: two
-	# $75s draw the same thing, and nothing has to choose between them.
+	# charmap.asm maps "…" to $75, likewise below FIRST_PRINTABLE. Source text
+	# writes the character itself (Text_MoveForgetCount's "1, 2 and…"), so a line
+	# quoting that wording has to encode it. $56 is "……" and stays decode-only,
+	# two $75s drawing the same thing.
 	out["…"] = 0x75
 
 	_codes = out
 	return _codes
 
 
-## The main font's encodings with the battle-extra run replaced.
-##
-## The main table's entries for $60 to $78 are dropped rather than kept
-## alongside: with that strip loaded there is no tile drawing an ellipsis, so
-## encoding one would place a byte that draws part of an HP bar.
+## The main font's encodings with the battle-extra run replaced. $60 to $78 are
+## dropped rather than kept alongside: with that strip loaded no tile draws an
+## ellipsis, so encoding one would place a byte that draws part of an HP bar.
 static func _battle_extra_encodings() -> Dictionary:
 	if not _battle_extra_codes.is_empty():
 		return _battle_extra_codes

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -76,12 +76,9 @@ static func decode_1bpp_strip(data: PackedByteArray, offset: int, count: int) ->
 	return out
 
 
-## The same, for tiles stored 2bpp: the battle HUD's graphics, which are four
-## colours where the font is two.
-##
-## Kept as a strip for the same reason the font is. These sheets are addressed by
-## tile number, so one row turns that number into a horizontal offset and nothing
-## else, and a sheet that decoded short leaves a visible hole rather than failing.
+## The same for 2bpp tiles: the battle HUD's graphics, four colours where the
+## font is two. A strip for the same reason, these sheets being addressed by tile
+## number, and a short decode leaves a visible hole rather than failing.
 static func decode_2bpp_strip(data: PackedByteArray, offset: int, count: int) -> PackedByteArray:
 	var width: int = count * TILE_WIDTH
 	var out: PackedByteArray = PackedByteArray()

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -4,17 +4,14 @@ extends RefCounted
 ## What a mod is allowed to change, and the only way it gets to change it.
 ##
 ## A mod never touches scene nodes or engine internals: it is handed this host,
-## registers what it provides, and is done. All it can reach is cartridge content
-## through [GameData] and live world state through [Gen2WorldAPI], both
-## scene-free.
+## registers what it provides, and is done. All it reaches is cartridge content
+## through [GameData] and live world state through [Gen2WorldAPI].
 ##
-## Two things are replaceable this way: the world renderer and the battle
-## renderer. Nothing about either requires the drawing to be 2D, so a renderer
-## building geometry from the same block and collision data, or drawing a battle
-## from the same display values, is a registration, not a fork.
+## The world renderer and the battle renderer are replaceable this way. Neither
+## requires 2D, so a renderer building geometry from the same block and collision
+## data is a registration rather than a fork, and
 ## [method select_world_renderer] and [method select_battle_renderer] swap
-## between registered renderers, which is why the contract is a factory rather
-## than a one-time construction.
+## between them, which is why the contract is a factory.
 ##
 ## Mods are interpreted GDScript: iOS forbids JIT and runtime native loading, so
 ## a compiled extension is not an option for a distributed mod.
@@ -56,24 +53,19 @@ const RENDERER_EFFECTS_METHOD: String = "set_effects"
 ## are drawn from, so a renderer draws them with its objects or ignores them.
 const RENDERER_ACTORS_METHOD: String = "set_actors"
 ## Optional, battle renderers only. Called with a [Gen2BattleWorldContext] once
-## per battle, before the first [code]set_view[/code], when the battle was
-## entered from the world. It is where the fight is happening: a renderer staging
-## it on the map needs that, and one drawing the cartridge's white field ignores
-## it. A development battle started outside the world passes null.
+## per battle, before the first [code]set_view[/code], saying where the fight is
+## happening: a renderer staging it on the map needs that and one drawing the
+## white field ignores it. A battle started outside the world passes null.
 const RENDERER_WORLD_CONTEXT_METHOD: String = "set_world_context"
-## Optional, world renderers only. Offered every input event the world screen
-## chose not to use, so a renderer can own camera pitch, first person or
-## free-roam. Answering true consumes the event.
+## Optional, world renderers only. Offered every input event the world screen did
+## not use, so a renderer can own camera pitch or first person; answering true
+## consumes the event. The screen decides first, so a renderer can never take a
+## movement or interaction key: it reads world state and must not write it, and
+## free-roam movement is the separate pose layer docs/MODS.md describes.
 ##
-## The screen decides first and offers what is left, so a renderer can never take
-## a movement or interaction key: a renderer reads world state and must not write
-## it, and moving the player is writing it. A renderer wanting free-roam movement
-## is the separate pose layer docs/MODS.md describes, not this.
-##
-## Implement this rather than Godot's own [method Node._input] or
-## [method Node._unhandled_input]: a node in the tree is offered events before
-## the screen decides what it needs, so reading them directly races the gameplay
-## keys instead of taking what is left.
+## Implement this rather than [method Node._input] or
+## [method Node._unhandled_input], which are offered events before the screen
+## decides and so race the gameplay keys instead of taking what is left.
 const RENDERER_INPUT_METHOD: String = "handle_world_input"
 ## Optional, battle renderers only. The same seam on the battle side: every event
 ## [Gen2BattleScreen] did not claim, so a renderer composing its own shot can let
@@ -127,9 +119,8 @@ const FIRST_MOD_POCKET: int = 5
 ## moment it is pressed. A button stores nothing, because "recentre the camera
 ## now" has no value to keep.
 ##
-## A number is not a ladder with every rung written out: a randomizer's seed is
-## one value with ten thousand of them, and dialling it as four one-digit
-## ladders spends four rows of a menu on one field.
+## A number is not a ladder with every rung written out: a randomizer's seed has
+## ten thousand, and four one-digit ladders spend four menu rows on one field.
 const OPTION_LADDER: StringName = &"ladder"
 const OPTION_NUMBER: StringName = &"number"
 const OPTION_BUTTON: StringName = &"button"
@@ -354,20 +345,18 @@ func menu_entries(menu: StringName) -> Array:
 	return entries.duplicate(true)
 
 
-## Adds one setting the player can change: a ladder of values, a number in a
-## range, or a button. [code]kind[/code] chooses, and defaults to
-## [constant OPTION_LADDER].
-##
-## A ladder needs a [code]key[/code], a [code]label[/code] and a non-empty
-## [code]values[/code] array; [code]labels[/code] is what each rung is shown as
-## and defaults to the values themselves, and [code]default[/code] is the rung
-## used until the player picks one and defaults to the first. A toggle is a
-## two-rung ladder. [constant OPTION_NUMBER] takes a range instead; see
-## [method _register_number_option].
+## One setting the player can change: a ladder of values, a number in a range or
+## a button, chosen by [code]kind[/code] and defaulting to
+## [constant OPTION_LADDER]. A ladder needs a [code]key[/code], a
+## [code]label[/code] and a non-empty [code]values[/code] array;
+## [code]labels[/code] names each rung and defaults to the values themselves, and
+## [code]default[/code] is the rung used until the player picks, defaulting to
+## the first. A toggle is a two-rung ladder, and [constant OPTION_NUMBER] takes a
+## range instead ([method _register_number_option]).
 ##
 ## A mod describes a setting rather than drawing one: the start menu's MODS entry
-## and the launcher's mods page are both built from these registrations, so a mod
-## never writes a settings screen and the two surfaces cannot disagree.
+## and the launcher's mods page are both built from these, so the two surfaces
+## cannot disagree.
 func register_option(id: StringName, option: Dictionary) -> Dictionary:
 	var key: StringName = StringName(option.get("key", &""))
 	if String(id).is_empty() or String(key).is_empty():
@@ -613,11 +602,10 @@ func _stored_number(id: StringName, row: Dictionary) -> int:
 ## })
 ## [/codeblock]
 ##
-## `default` is [Gen2InputActions]' own binding shape, so a mod's action is bound
-## by key, pad button or stick and is rebound by the controls card that rebinds
-## the eight. A default already on one of the cartridge's buttons is dropped and
-## reported: the screen claims those before a renderer is offered anything, so
-## such a binding would never once fire.
+## `default` is [Gen2InputActions]' binding shape, so a mod's action binds by key,
+## pad button or stick and is rebound by the same controls card. A default on one
+## of the cartridge's buttons is dropped and reported, since the screen claims
+## those first and such a binding would never fire.
 func register_action(id: StringName, action: Dictionary) -> Dictionary:
 	var key: StringName = StringName(action.get("key", &""))
 	if String(id).is_empty() or String(key).is_empty():
@@ -821,10 +809,9 @@ func content_overlay() -> Gen2ContentOverlay:
 ## Watches one of [constant CHANNELS]. [param handler] is called with each event
 ## dictionary as it reaches the screen showing it.
 ##
-## Reading only. A subscriber is handed a copy, so writing to it changes nothing,
-## and there is no return value the engine reads: observation cannot make two
-## mods fight over the same state, which is what makes this safe to hand out
-## before any mutation hook exists.
+## Reading only. A subscriber is handed a copy and there is no return value the
+## engine reads, so observation cannot make two mods fight over the same state,
+## which is what makes this safe before any mutation hook exists.
 func subscribe(channel: StringName, id: StringName, handler: Callable) -> Dictionary:
 	if not CHANNELS.has(channel):
 		return {"ok": false, "reason": &"unknown_channel", "detail": String(channel)}
@@ -1179,8 +1166,7 @@ func load_mod(manifest: Gen2ModManifest) -> Dictionary:
 	# RefCounted alive, so an entry that connects to option_changed and is then
 	# dropped has connected a signal to an object about to be collected; holding
 	# it here is what makes `register` the whole contract. Dropped by reset(),
-	# which builds a new host, so a reload does not leave the last load
-	# listening.
+	# so a reload does not leave the last load listening.
 	_entries[manifest.id] = mod
 	_loaded[manifest.id] = manifest.version
 	return {"ok": true, "id": manifest.id}
@@ -1205,10 +1191,9 @@ func loaded_mods() -> Array:
 
 ## Mounts a mod's own resource pack, once per run.
 ##
-## `replace_files` is false, so a pack can only add paths and can never land on
-## one the game itself ships: a mod that names `res://game/...` is ignored there
-## rather than obeyed. There is no unmount in the engine, which is why a reload
-## remounts nothing and why the set is kept on the host rather than the manifest.
+## `replace_files` is false, so a pack only adds paths and never lands on one the
+## game ships. The engine has no unmount, which is why a reload remounts nothing
+## and the set is kept on the host rather than the manifest.
 func _mount_pack(manifest: Gen2ModManifest) -> Dictionary:
 	if _mounted_packs.has(manifest.id):
 		return {"ok": true, "id": manifest.id}

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -3,30 +3,21 @@ extends Control
 
 ## A Game Boy Color screen: 160x144 pixels, scaled by a whole number to fit.
 ##
-## The game must not run at the window's resolution: a GBC pixel has to stay
-## square and sharp, so everything the game draws goes into a hardware-sized
-## [SubViewport] blown up by an integer factor. Any other scale resamples an 8x8
-## tile into something that crawls when it moves.
-##
-## Surrounding chrome is ordinary Godot UI at window resolution. Keeping the two
-## apart is why this is a [Control] rather than a project-wide stretch setting.
-##
-## Add what the game draws with [method display]; it goes inside the viewport.
+## What the game draws goes into a hardware-sized [SubViewport] blown up by an
+## integer factor, since any other scale resamples an 8x8 tile into something
+## that crawls when it moves. Surrounding chrome is ordinary Godot UI at window
+## resolution, which is why this is a [Control] and not a stretch setting.
 ##
 ## [method display_native] is a second layer behind it, covering the same
-## rectangle at window resolution, for a view not made of hardware pixels: a 3D
-## or HD renderer cannot be drawn into a 160x144 buffer and magnified, but still
-## has to line up with the text boxes and menus above it, which stay hardware
-## pixels.
+## rectangle at window resolution, for a view that cannot be drawn into a 160x144
+## buffer and magnified but still has to line up with the boxes above it.
 
 const WIDTH: int = 160
 const HEIGHT: int = 144
 
-## Emitted after a resize changes the whole-number factor the screen is drawn
-## at. Nothing in the game should care, but a debug overlay might.
+## After a resize changes the factor. Nothing in the game should care.
 signal scale_changed(factor: int)
-## Emitted after the native layer's rectangle changes, in window pixels. A view
-## drawn there sizes itself to this rather than to the window.
+## After the native layer's rectangle changes; a view drawn there sizes to this.
 signal native_size_changed(size: Vector2i)
 
 var scale_factor: int = 1
@@ -37,33 +28,29 @@ var scale_factor: int = 1
 
 
 func _ready() -> void:
-	# The viewport's size is not set here: a stretching SubViewportContainer
-	# owns it, and it falls out of the container's size divided by the shrink
-	# factor. Writing it directly is refused at runtime.
+	# The viewport's size is the container's divided by the shrink factor, and
+	# writing it directly is refused at runtime.
 	resized.connect(_fit)
 	_fit()
 
 
-## Puts a node inside the screen. Anything added this way is drawn in hardware
-## pixels, so position it in the 160x144 space and nothing else.
+## Inside the screen, in hardware pixels: position it in the 160x144 space.
 func display(node: Node) -> void:
 	_viewport.add_child(node)
 
 
-## Puts a node on the layer behind the hardware screen, covering the same
-## rectangle at the window's own resolution. Position it in [method native_size]
-## pixels; what is drawn in the hardware viewport is composited over it.
+## On the layer behind, in [method native_size] window pixels; the hardware
+## viewport is composited over it.
 func display_native(node: Node) -> void:
 	_native.add_child(node)
 
 
-## The native layer's rectangle in window pixels, which is the hardware screen's
-## size times the whole-number factor it is drawn at.
+## The native layer's rectangle in window pixels.
 func native_size() -> Vector2i:
 	return Vector2i(WIDTH * scale_factor, HEIGHT * scale_factor)
 
 
-## Removes and frees everything currently on screen, on both layers.
+## Frees everything on screen, on both layers.
 func clear() -> void:
 	for parent: Node in [_viewport, _native]:
 		for child: Node in parent.get_children():
@@ -76,10 +63,8 @@ func viewport() -> SubViewport:
 	return _viewport
 
 
-## The largest whole number of window pixels per hardware pixel that fits in an
-## area. Public because [Gen2GameFrame] has to know how tall the screen will be
-## before it can decide what is left for the on-screen controller, and two
-## copies of this arithmetic would eventually disagree.
+## The largest whole number of window pixels per hardware pixel that fits.
+## Public because [Gen2GameFrame] sizes the on-screen controller off it.
 static func fit_factor(area: Vector2) -> int:
 	return maxi(1, mini(int(area.x) / WIDTH, int(area.y) / HEIGHT))
 
@@ -90,8 +75,7 @@ func _fit() -> void:
 
 	_container.stretch_shrink = factor
 	_container.size = drawn
-	# Centred rather than anchored: a screen that does not divide evenly into
-	# the window leaves a margin, and an uneven one is visible.
+	# Centred rather than anchored: an uneven margin is visible.
 	_container.position = ((size - drawn) * 0.5).floor()
 	_native.size = drawn
 	_native.position = _container.position

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -1,22 +1,18 @@
 class_name Gen2MenuPage
 extends RefCounted
 
-## One cartridge menu box on the hardware tile grid: `MenuBox`'s frame,
+## One menu box on the hardware tile grid: `MenuBox`'s frame,
 ## `PlaceVerticalMenuItems`' options, `PlaceMenuStrings`' title and
-## `Place2DMenuCursor`'s arrow.
-##
-## The geometry is [Gen2MenuBox]'s and the selection [Gen2WorldMenu]'s; this is
-## presentation only. Node-free, so a menu can be drawn into any buffer a screen
-## already owns and read back headless: the naming screen and the gender screen
-## both draw one over a page they built first.
+## `Place2DMenuCursor`'s arrow. Geometry is [Gen2MenuBox]'s and selection
+## [Gen2WorldMenu]'s; this is presentation, and node-free so a menu can be drawn
+## into any buffer a screen already owns and read back headless.
 
 const TILE: int = Gen2Font.TILE
 
 ## `charmap.asm`: `"▶"` is $ed, which is what `Place2DMenuCursor` writes.
 const CURSOR_CODE: int = 0xED
 
-## `Textbox` draws with wTextboxFrame, so a menu is drawn in whichever frame the
-## player chose, the way the Hall of Fame panel and the world's own boxes are.
+## `Textbox` draws with wTextboxFrame, so a menu wears the player's chosen frame.
 var frame_style: int = 0
 
 var font: Gen2Font = null
@@ -36,13 +32,10 @@ static func from_data(data: GameData) -> Gen2MenuPage:
 ## [param width] pixels across, with the arrow on [param cursor]. A negative
 ## cursor draws no arrow, which is what a menu without STATICMENU_CURSOR is.
 ##
-## The box's interior is not cleared: `MenuBox` calls `Textbox`, which fills its
-## own interior with blanks, and every caller here draws onto a buffer it has
-## already filled.
-## [param extras] are `PlaceString` calls the box's own caller makes at absolute
-## tile coordinates, as [code]{"text": String, "at": Vector2i}[/code]: the
-## battle's `MoveInfoBox` writes its type and PP into a plain `Textbox` that way
-## rather than as menu items.
+## [param extras] are `PlaceString` calls the caller makes at absolute tile
+## coordinates, as [code]{"text": String, "at": Vector2i}[/code]: the battle's
+## `MoveInfoBox` writes its type and PP into a plain `Textbox` that way rather
+## than as menu items.
 func draw(
 	box: Gen2MenuBox, options: Array, cursor: int,
 	indices: PackedByteArray, width: int, title: String = "", title_indent: int = 0,
@@ -75,13 +68,10 @@ func draw(
 		font.draw_code(CURSOR_CODE, indices, width, arrow.x * TILE, arrow.y * TILE)
 
 
-## The same menu as an image of its own frame alone, for a screen that composes
-## layers rather than one page: the box is drawn into a screen-sized buffer at
-## its own coordinates and then cropped back to it, so [method draw]'s absolute
-## placement stays the one piece of arithmetic.
-##
-## Opaque, because `MenuBox` fills its interior: a menu over the battle field
-## covers what is behind it.
+## The same menu as an image of its frame alone, for a screen that composes
+## layers: drawn into a screen-sized buffer at its own coordinates and cropped
+## back, so [method draw]'s placement stays the one piece of arithmetic. Opaque,
+## because `MenuBox` fills its interior.
 func render(
 	box: Gen2MenuBox, options: Array, cursor: int,
 	title: String = "", title_indent: int = 0, extras: Array = []
@@ -96,9 +86,8 @@ func render(
 	).get_region(Rect2i(box.border_position() * TILE, box.border_size() * TILE))
 
 
-## `Textbox`'s own `ClearBox` over the interior, so a menu drawn over a filled
-## page does not show that page through its options. The blank the source fills
-## with is $7f, which sits below the font and draws as index 0.
+## `Textbox`'s own `ClearBox`, so a menu over a filled page does not show it
+## through. The source's blank is $7f, below the font, which draws as index 0.
 func _fill_interior(box: Gen2MenuBox, indices: PackedByteArray, width: int) -> void:
 	var interior: Vector2i = box.interior()
 	var left: int = (box.left + 1) * TILE

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -1,26 +1,22 @@
 class_name Gen2PicImage
 extends RefCounted
 
-## Colour indices plus a palette to an [Image].
+## Colour indices plus a palette to an [Image]. The cache stores what the
+## cartridge stores, two bits per pixel and no colour, so the palette is chosen
+## here at draw time and a shiny sprite costs one [PackedColorArray] rather than
+## a second copy of the pixels.
 ##
-## The cache stores what the cartridge stores: two bits per pixel, no colour. The
-## palette is chosen here, at draw time, so a shiny sprite costs one different
-## [PackedColorArray] rather than a second copy of the pixels.
-##
-## The image is built as one buffer for [method Image.create_from_data]:
-## per-pixel [method Image.set_pixel] on a 56x56 sprite is 3136 binding calls for
-## a table lookup, and a battle can want several sprites a frame.
-##
-## Node-free: an [Image] is data, not a scene, so this can be checked headless.
+## Built as one buffer for [method Image.create_from_data]: per-pixel
+## [method Image.set_pixel] on a 56x56 sprite is 3136 binding calls for a table
+## lookup, and a battle can want several sprites a frame. Node-free, so headless.
 
 const CHANNELS: int = 4
 
 
-## An image [param width] x [param height] pixels from a row-major index buffer.
-##
-## [param transparent_background] makes index 0 transparent. The hardware has no
-## alpha and draws that index as white, which is right for a battle sprite in
-## its window; it is wrong for a sprite over anything else.
+## An image [param width] x [param height] from a row-major index buffer.
+## [param transparent_background] makes index 0 transparent: the hardware has no
+## alpha and draws it white, which is right for a battle sprite in its window and
+## wrong for one over anything else.
 static func from_indices(
 	indices: PackedByteArray,
 	width: int,
@@ -47,11 +43,9 @@ static func from_indices(
 
 
 ## One cell out of a pic atlas, cropped to the pic's real size.
-##
-## [param pic] is what [method GameData.species_pic] returns: which atlas, which
-## slot, and how much of the cell the sprite actually fills. Cropping matters
-## because a cell is the size of the largest pic of its kind, so a 5x5 sprite
-## carries two rows and columns of blank tiles it should not be positioned by.
+## [param pic] is [method GameData.species_pic]'s answer: which atlas, which slot
+## and how much of the cell is filled. A cell is the size of the largest pic of
+## its kind, so a 5x5 sprite carries blank tiles it must not be positioned by.
 static func from_atlas(
 	indices: PackedByteArray,
 	atlas: Dictionary,
@@ -68,10 +62,9 @@ static func from_atlas(
 	)
 
 
-## The same cell as indices, before a palette is chosen: { indices, width,
-## height }, or empty for a slot the atlas does not hold. Split out because a
-## screen that recolours one pic every few frames should swap the palette rather
-## than crop the atlas again, which is what a palette fade over a frontpic does.
+## The same cell before a palette is chosen: { indices, width, height }, or empty
+## for a slot the atlas does not hold. Split out so a palette fade over a
+## frontpic swaps colours rather than cropping the atlas again.
 static func atlas_cell(
 	indices: PackedByteArray, atlas: Dictionary, pic: Dictionary
 ) -> Dictionary:
@@ -102,8 +95,7 @@ static func atlas_cell(
 	return {"indices": cropped, "width": width, "height": height}
 
 
-## The palette flattened to bytes, four per index, so the inner loop is a copy
-## rather than a colour conversion.
+## Four bytes per index, so the inner loop copies rather than converting colours.
 static func _lookup(palette: PackedColorArray, transparent_background: bool) -> PackedByteArray:
 	var out: PackedByteArray = PackedByteArray()
 	out.resize(Gen2Palette.COLORS_PER_PIC * CHANNELS)
@@ -114,31 +106,26 @@ static func _lookup(palette: PackedColorArray, transparent_background: bool) -> 
 		out[at] = int(roundf(color.r * 255.0))
 		out[at + 1] = int(roundf(color.g * 255.0))
 		out[at + 2] = int(roundf(color.b * 255.0))
-		# The palette's own alpha, so a caller that wants one colour translucent
-		# says so in the colour rather than needing a second flag. Every
-		# cartridge palette is opaque, since Gen2Palette.decode_color builds an
-		# opaque Color.
+		# The palette's own alpha, so a translucent colour needs no second
+		# flag. Every cartridge palette is opaque, Gen2Palette.decode_color
+		# building an opaque Color.
 		out[at + 3] = 0 if transparent_background and i == 0 \
 			else int(roundf(clampf(color.a, 0.0, 1.0) * 255.0))
 
 	return out
 
 
-## What `wBoxAlignment` produces, which is a plain horizontal mirror.
-##
-## The flag is read twice, and only both halves together make sense of it.
-## `LoadOrientedFrontpic`'s `.x_flip` (`engine/gfx/load_pics.asm:401`) bit-
-## reverses every byte of pic data as it loads, mirroring each tile's own
-## pixels; `PlaceGraphic`'s `.right` (`engine/gfx/place_graphic.asm:30`) then
-## walks the tile columns with `dec hl` instead of `inc hl`, so the pic's first
-## tile column lands in the box's last. Reversing the columns without flipping
-## the tiles scrambles the sprite, which is what a column-strip reversal alone
-## did here.
+## What `wBoxAlignment` produces, a plain horizontal mirror. The flag is read
+## twice and only both halves make sense of it: `LoadOrientedFrontpic`'s
+## `.x_flip` bit-reverses every byte as it loads, mirroring each tile's pixels,
+## and `PlaceGraphic`'s `.right` then walks the tile columns with `dec hl`, so
+## the first column lands in the box's last. Reversing the columns alone
+## scrambles the sprite, which is what a column-strip reversal did here.
 ##
 ## The two compose exactly into [method Image.flip_x]: a pixel at
 ## `x = 8 * column + px` lands at `8 * (columns - 1 - column) + (7 - px)`, which
-## is `width - 1 - x`. `PrepMonFrontpic` (`home/pokemon.asm:61`) is the one
-## caller that sets the flag and the Oak speech the one screen that reaches it.
+## is `width - 1 - x`. `PrepMonFrontpic` is the one caller that sets the flag and
+## the Oak speech the one screen that reaches it.
 static func x_flipped(image: Image) -> Image:
 	if image == null:
 		return image
@@ -147,8 +134,7 @@ static func x_flipped(image: Image) -> Image:
 	return out
 
 
-## The same mirror on an index buffer, for a caller keeping the indices so it
-## can recolour them.
+## The same mirror on an index buffer, for a caller that will recolour it.
 static func x_flipped_indices(indices: PackedByteArray, width: int) -> PackedByteArray:
 	if width <= 0:
 		return indices

--- a/game/world/intro_presentation.gd
+++ b/game/world/intro_presentation.gd
@@ -5,14 +5,11 @@ extends RefCounted
 ## `Intro_RotatePalettesLeftFrontpic`, `Intro_WipeInFrontpic` and
 ## `MovePlayerPic`, queued as steps a screen advances one VBlank at a time.
 ##
-## Two things about this are the source's rather than an approximation of it.
-##
-## A palette step is a DMG palette byte, not a rotation: `CopyPals` reads the
-## byte two bits at a time and writes the loaded colour each pair names, so a
-## fade is an index remap of the palette already loaded. See [method apply_bgp].
-##
-## Every count is a `DelayFrames` operand, so a screen that steps this at
-## [constant FRAME_RATE] spends the frames the cartridge spends.
+## A palette step is a DMG palette byte, not a rotation: `CopyPals` reads it two
+## bits at a time and writes the loaded colour each pair names, so a fade is an
+## index remap of the palette already loaded ([method apply_bgp]). Every count is
+## a `DelayFrames` operand, so a screen stepping this at [constant FRAME_RATE]
+## spends the frames the cartridge spends.
 
 const FRAME_RATE: float = 59.7275
 
@@ -22,10 +19,9 @@ const KEEP: int = -1
 ## `%11100100`: the identity remap, which is what an unfaded screen shows.
 const BGP_NORMAL: int = 0xE4
 
-## `home/fade.asm`'s IncGradGBPalTable_00 to _07, the half `RotatePalettesRight`
-## and `RotatePalettesLeft` take when hCGB is set. A row is bgp, obp0 and obp1,
-## and all three are equal in this half, so one byte stands for the row and one
-## fade covers the sprites `Intro_PlacePlayerSprite` leaves on screen.
+## `home/fade.asm`'s IncGradGBPalTable_00 to _07, the half the rotate routines
+## take when hCGB is set. A row is bgp, obp0 and obp1, all three equal here, so
+## one byte stands for the row and one fade covers the sprites too.
 const INC_GRAD: Array[int] = [0xFF, 0xFE, 0xF9, 0xE4, 0xE4, 0x90, 0x40, 0x00]
 ## Both rotate routines' own `ld c, 8`.
 const FADE_STEP_FRAMES: int = 8
@@ -39,10 +35,9 @@ const WAIT_BG_MAP_FRAMES: int = 4
 const FRONTPIC_FADE: Array[int] = [0x54, 0xA8, 0xFC, 0xF8, 0xF4, 0xE4]
 const FRONTPIC_FADE_STEP_FRAMES: int = 10
 
-## `Intro_WipeInFrontpic` walks hWX from $77 down in eights, stopping when the
-## subtraction would pass zero. hWY sits at $90 for the whole of `OakSpeech`
-## (`home/init.asm`, `StartTitleScreen`), so the window it moves is off the
-## bottom of the screen: the walk is a delay, and the pic appears when the
+## `Intro_WipeInFrontpic` walks hWX from $77 down in eights until it would pass
+## zero. hWY sits at $90 for the whole of `OakSpeech` (`StartTitleScreen`), so
+## the window is off the bottom and the walk is a delay; the pic appears when the
 ## routine writes the identity palette on its second frame.
 const WIPE_START: int = 0x77
 const WIPE_STEP: int = 8
@@ -64,9 +59,9 @@ var _bgp: int = BGP_NORMAL
 var _column: int = PIC_LEFT_COLUMN
 
 
-## Empties the queue. The palette byte and the pic column are hardware state and
-## survive it: a routine that returns leaves the screen as it drew it, which is
-## how `MovePlayerPicRight` hands the naming menu a pic already at column 13.
+## Empties the queue. The palette byte and pic column are hardware state and
+## survive it, which is how `MovePlayerPicRight` hands the naming menu a pic
+## already at column 13.
 func clear() -> void:
 	_steps.clear()
 	_step = 0

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -1,17 +1,13 @@
 class_name Gen2MenuBox
 extends RefCounted
 
-## The geometry every cartridge menu is laid out with: `menu_coords`' four
-## corners, `GetMenuBoxDims`, `GetMenuTextStartCoord` and the cursor position
-## `_InitVerticalMenuCursor` derives from them.
-##
-## Scene-free arithmetic on the hardware tile grid, so a layout can be checked
-## without drawing it. [Gen2MenuPage] draws what this places, and
-## [Gen2WorldMenu] owns the selection rules; nothing here reads input or holds a
-## cursor of its own.
+## Every cartridge menu's geometry: `menu_coords`' four corners,
+## `GetMenuBoxDims`, `GetMenuTextStartCoord` and the cursor position
+## `_InitVerticalMenuCursor` derives from them. Scene-free arithmetic on the tile
+## grid, so a layout can be checked without drawing it. [Gen2MenuPage] draws what
+## this places and [Gen2WorldMenu] owns the selection rules.
 
-## constants/menu_constants.asm. Owned here because this is the layer that reads
-## all of them; [Gen2WorldMenu] takes the two that decide selection from here.
+## constants/menu_constants.asm, owned here because this layer reads all of them.
 const STATICMENU_DISABLE_B: int = 1 << 0
 const STATICMENU_ENABLE_SELECT: int = 1 << 1
 const STATICMENU_ENABLE_LEFT_RIGHT: int = 1 << 2
@@ -21,9 +17,8 @@ const STATICMENU_WRAP: int = 1 << 5
 const STATICMENU_NO_TOP_SPACING: int = 1 << 6
 const STATICMENU_CURSOR: int = 1 << 7
 
-## `_InitVerticalMenuCursor`'s `ln a, 2, 0`: the cursor steps two rows per item
-## and no columns, which is why `PlaceVerticalMenuItems` advances by
-## `2 * SCREEN_WIDTH`.
+## `_InitVerticalMenuCursor`'s `ln a, 2, 0`: two rows per item and no columns,
+## which is why `PlaceVerticalMenuItems` advances by `2 * SCREEN_WIDTH`.
 const ROW_STEP: int = 2
 
 ## `menu_coords x1, y1, x2, y2`, which stores `db y1, x1` then `db y2, x2`.
@@ -32,9 +27,8 @@ var top: int = 0
 var right: int = 0
 var bottom: int = 0
 var flags: int = 0
-## `dn rows, columns` and the `db spacing` beside it in a menu's own data
-## (`Place2DMenuItemStrings`, `Get2DMenuNumberOfColumns`). One column and no
-## spacing is `PlaceVerticalMenuItems`, which is every list menu here.
+## `dn rows, columns` and its `db spacing` (`Place2DMenuItemStrings`). One column
+## and no spacing is `PlaceVerticalMenuItems`, which is every list menu here.
 var columns: int = 1
 var column_spacing: int = 0
 ## `w2DMenuCursorOffsets`' high nybble, which is `ROW_STEP` for every menu built
@@ -56,9 +50,8 @@ func has_flag(flag: int) -> bool:
 	return (flags & flag) != 0
 
 
-## `GetMenuBoxDims`, which answers the span between the corners. `MenuBox`
-## then decrements both before calling `Textbox`, so this is the interior plus
-## one in each direction.
+## `GetMenuBoxDims`, the span between the corners. `MenuBox` decrements both
+## before `Textbox`, so this is the interior plus one on each axis.
 func dims() -> Vector2i:
 	return Vector2i(right - left, bottom - top)
 
@@ -68,8 +61,7 @@ func interior() -> Vector2i:
 	return dims() - Vector2i.ONE
 
 
-## The whole drawn frame, border included, which is the interior plus the two
-## edge tiles on each axis.
+## The drawn frame: the interior plus the two edge tiles on each axis.
 func border_size() -> Vector2i:
 	return interior() + Vector2i(2, 2)
 
@@ -90,16 +82,14 @@ func text_start() -> Vector2i:
 	return at
 
 
-## `_InitVerticalMenuCursor`'s init coords, which share the text's row and sit
-## one column left of it. The source writes `wMenuBorderLeftCoord + 1` outright
-## rather than subtracting from the text column, so a menu without
-## STATICMENU_CURSOR still has a position here; it just never draws one.
+## `_InitVerticalMenuCursor`'s init coords, one column left of the text. The
+## source writes `wMenuBorderLeftCoord + 1` outright rather than subtracting, so
+## a menu without STATICMENU_CURSOR has a position here and never draws one.
 func cursor_start() -> Vector2i:
 	return Vector2i(left + 1, text_start().y)
 
 
-## Where item [param index] prints, zero-based. `Place2DMenuItemStrings` walks
-## the columns of a row before moving on, so an index counts along the row.
+## Zero-based. `Place2DMenuItemStrings` walks a row's columns before moving on.
 func item_position(index: int) -> Vector2i:
 	return text_start() + _item_offset(index)
 
@@ -116,7 +106,6 @@ func _item_offset(index: int) -> Vector2i:
 	)
 
 
-## `PlaceMenuStrings`' title, which prints on the box's own top row indented by
-## the byte that follows the item list.
+## `PlaceMenuStrings`' title: the top row, indented by the byte after the items.
 func title_position(indent: int) -> Vector2i:
 	return Vector2i(left + indent, top)

--- a/game/world/oak_speech.gd
+++ b/game/world/oak_speech.gd
@@ -1,9 +1,8 @@
 class_name Gen2OakSpeech
 extends RefCounted
 
-## `engine/menus/intro_menu.asm`'s OakSpeech as a list of beats: a run of
-## pic-then-text pairs with one branch, `NamePlayer`. Timing, palette rotation
-## and the cry belong to the screen, so this stays scene-free and checkable.
+## `engine/menus/intro_menu.asm`'s OakSpeech as beats: pic-then-text pairs with
+## one branch, `NamePlayer`. Timing, palettes and the cry are the screen's.
 
 ## What a beat shows above its text.
 enum Pic {
@@ -25,51 +24,42 @@ enum Enter {
 	WIPE,
 }
 
-## `constants/trainer_constants.asm`. CAL is the class Gold and Silver draw the
-## player with, since they ship no ChrisPic.
+## `constants/trainer_constants.asm`. Gold and Silver ship no ChrisPic, so CAL.
 const POKEMON_PROF: int = 0x0A
 const CAL: int = 0x0C
 ## `OakSpeech` is `ld a, MARILL` in pokegold and `ld a, WOOPER` in pokecrystal.
 const MARILL: int = 183
 const WOOPER: int = 194
 
-## Where `NamePlayer` sits. Only `ShowPlayerNamingChoices`' NEW NAME row reaches
-## `NamingScreen`.
+## Where `NamePlayer` sits; only its NEW NAME row reaches `NamingScreen`.
 const NAME_AFTER: String = "oak_6"
 
 ## `constants/music_constants.asm`: MUSIC_ROUTE_30.
 const MUSIC_ROUTE_30: int = 0x2B
 
-## `ShrinkPlayer`, which `InitializeWorld` runs on the screen the speech left
-## standing. SFX_ESCAPE_ROPE, then `ld a, 32` into wMusicFade on MUSIC_NONE.
+## `ShrinkPlayer`: SFX_ESCAPE_ROPE, then `ld a, 32` into wMusicFade on MUSIC_NONE.
 const SHRINK_SFX: int = 0x10
 const SHRINK_FADE_FRAMES: int = 32
-## Its five `DelayFrames` operands: before the first shrink picture, between the
-## two, before the box is cleared, before the sprite is placed, and while it
-## stands there.
+## Its five `DelayFrames`: the two pictures, the box clear, the sprite, the hold.
 const SHRINK_WAITS: Array[int] = [8, 8, 8, 3, 50]
-## `hlcoord 6, 5`, a row below `ShrinkFrame`'s (6,4), so `ClearBox` leaves the
-## pictures' top tile row behind; both are blank there.
+## `hlcoord 6, 5`, below `ShrinkFrame`'s (6,4), so `ClearBox` leaves its top row.
 const SHRINK_CLEAR_AT: Vector2i = Vector2i(6, 5)
-## `Intro_PlacePlayerSprite`'s four `dbsprite` entries are one 16x16 icon at
-## y `9 * 8 + 4`, x `9 * 8`; hardware OAM counts from (-8, -16).
+## `Intro_PlacePlayerSprite`'s four `dbsprite` are one 16x16 icon at y `9 * 8 +
+## 4`, x `9 * 8`; hardware OAM counts from (-8, -16).
 const SHRINK_SPRITE_AT: Vector2i = Vector2i(64, 60)
 
 ## `.PlayerNameString`, printed above the naming screen's entry.
 const NAME_PROMPT: String = "YOUR NAME?"
 
-## `home/string.asm`'s InitName replaces a blank entry with the gendered
-## default, so a save never carries a blank trainer.
+## `home/string.asm`'s InitName substitutes these for a blank entry.
 const DEFAULT_MALE: String = "CHRIS"
 const DEFAULT_FEMALE: String = "KRIS"
 
 
-## The beats in source order, each `{ pic, text, key, enter, clears_after }`.
-##
-## `_OakText2` and `_OakText4` are two `PrintText` calls over one pic, so they
-## are two beats; `_OakText3` is a bare promptbutton and is not one.
-## `clears_after` is the `RotateThreePalettesRight` and `ClearTilemap` behind a
-## beat's text, which `_OakText4`'s neighbour and `_OakText6` do not have.
+## Source order, each `{ pic, text, key, enter, clears_after }`. `_OakText2` and
+## `_OakText4` are two `PrintText` calls over one pic and so two beats, while
+## `_OakText3` is a bare promptbutton and is none. `clears_after` is the
+## `RotateThreePalettesRight` and `ClearTilemap` behind the text.
 static func beats(data: GameData) -> Array:
 	if data == null:
 		return []
@@ -97,16 +87,14 @@ static func beats(data: GameData) -> Array:
 	return out
 
 
-## `InitName`'s substitution, which is what makes the naming screen's END
-## reachable with nothing typed.
+## `InitName`, which makes the naming screen's END reachable with nothing typed.
 static func resolve_name(entered: String, gender: int) -> String:
 	if entered.strip_edges() != "":
 		return entered
 	return DEFAULT_FEMALE if gender == Gen2SaveData.GENDER_FEMALE else DEFAULT_MALE
 
 
-## `_OakText7` opens on `<PLAYER>`, which the text codec leaves as a marker
-## because only the caller knows the name.
+## `_OakText7` opens on `<PLAYER>`, which the codec leaves as a marker.
 static func with_player_name(text: String, player_name: String) -> String:
 	return text.replace("<PLAYER>", player_name)
 

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -1,22 +1,17 @@
 class_name Gen2Pokedex
 extends RefCounted
 
-## Scene-free model of the Pokedex (engine/pokedex/pokedex.asm).
+## Scene-free model of the Pokedex (engine/pokedex/pokedex.asm), holding what
+## `wPokedexDataStart`..`wPokedexDataEnd` does: the mode, the species order that
+## mode built, how far the listing runs, and the cursor and scroll into it. A
+## screen draws [method rows] and feeds buttons back in.
 ##
-## Holds what `wPokedexDataStart`..`wPokedexDataEnd` holds: the current mode, the
-## species order that mode built, how far down the listing runs, and the cursor
-## and scroll offset into it. A screen draws [method rows] and feeds buttons back
-## in; nothing here knows what a Control is.
-##
-## The two orderings come from the cache ([method GameData.dex_order_new] and
-## [method GameData.dex_order_alpha]); DEXMODE_OLD has no table because
-## `.OldMode` counts from 1. Seen and caught come from [Gen2WorldState], which
-## already keeps both arrays.
+## The orderings come from the cache ([method GameData.dex_order_new] and
+## [method GameData.dex_order_alpha]); DEXMODE_OLD has no table, `.OldMode`
+## counting from 1. Seen and caught come from [Gen2WorldState].
 
-## What each screen writes to `wDexListingHeight`: the main screen `ld a, 7` and
-## the search results screen `ld a, 4`. It is WRAM the source rewrites per
-## screen, so [member listing_height] carries it and these are only the two
-## values written to it.
+## What each screen writes to `wDexListingHeight`: `ld a, 7` on the main screen
+## and `ld a, 4` on the search results. [member listing_height] carries it.
 const LISTING_HEIGHT: int = 7
 const SEARCH_RESULTS_HEIGHT: int = 4
 
@@ -59,14 +54,11 @@ const MODE_ROWS: Array[Dictionary] = [
 ## rebuilds the order.
 const CHANGING_MODES_TEXT: String = "Changing modes.\nPlease wait."
 
-## `PokedexTypeSearchConversionTable` (data/types/search_types.asm), which is
-## what turns a search row's 1-based position into a real type number. Its order
-## is the cartridge's own and is not the type numbering: FIRE follows NORMAL
-## because the search screen lists the special types first.
-##
-## Kept as named constants rather than imported, the way the matchup multipliers
-## are: all seventeen entries are types [RomLayout] already names, and the table
-## is identical in both pins.
+## `PokedexTypeSearchConversionTable` (data/types/search_types.asm), turning a
+## search row's 1-based position into a type number. Its order is not the type
+## numbering: FIRE follows NORMAL, the search screen listing specials first.
+## Named rather than imported, like the matchup multipliers: all seventeen are
+## types [RomLayout] already names and the table is identical in both pins.
 const SEARCH_TYPES: Array[int] = [
 	RomLayout.TYPE_NORMAL, RomLayout.TYPE_FIRE, RomLayout.TYPE_WATER,
 	RomLayout.TYPE_GRASS, RomLayout.TYPE_ELECTRIC, RomLayout.TYPE_ICE,
@@ -156,12 +148,9 @@ static func open(
 
 
 ## `Pokedex_OrderMonsByMode`. NEW copies the new-dex table, OLD counts from 1,
-## and ABC keeps only the species that have been seen and zero-fills the rest.
-##
-## Both tables are cartridge data of exactly [constant RomLayout.SPECIES_COUNT]
-## entries and OLD counts that far, so a mod's species can only follow the
-## cartridge's own run, ascending by number, the way `FIRST_MOD_POCKET` numbers a
-## mod pocket after the cartridge's.
+## ABC keeps the seen species and zero-fills the rest. Both tables are exactly
+## [constant RomLayout.SPECIES_COUNT] entries and OLD counts that far, so a mod's
+## species can only follow the cartridge's run, ascending by number.
 func order_by_mode() -> void:
 	var mod_species: Array[int] = _data.mod_species_numbers() if _data != null \
 		else [] as Array[int]
@@ -220,13 +209,11 @@ func _find_last_seen() -> void:
 	listing_end = end
 
 
-## `Pokedex_InitCursorPosition`: seeks the cursor to `wPrevDexEntry`, scrolling
-## first while there is more than one page and then moving the cursor within it.
-##
-## A zero or out-of-range previous entry leaves both at zero. An entry that is
-## not in the order at all is not special-cased on the cartridge either: the
-## second walk runs its full seven steps and leaves the cursor past the last row,
-## which ABC mode can reach when the last entry viewed has not been seen.
+## `Pokedex_InitCursorPosition`: seeks to `wPrevDexEntry`, scrolling while there
+## is more than one page and then moving the cursor within it. A zero or
+## out-of-range entry leaves both at zero. An entry not in the order is not
+## special-cased on the cartridge either: the second walk runs its full seven
+## steps and leaves the cursor past the last row, which ABC mode can reach.
 func init_cursor_position() -> void:
 	scroll = 0
 	cursor = 0
@@ -258,14 +245,11 @@ func selected_species() -> int:
 	return _order[index]
 
 
-## The listing as [constant LISTING_HEIGHT] rows, in `Pokedex_PrintListing`'s
-## own order, each as `.PrintEntry` would draw it:
-## { species, empty, number, seen, caught, name, selected }.
-##
-## [code]empty[/code] is the species-zero row `.PrintEntry` returns from
-## immediately, which is what the tail of an ABC listing is made of.
-## [code]number[/code] is the three-digit zero-padded dex number, and only OLD
-## mode prints one.
+## `Pokedex_PrintListing`'s rows, each as `.PrintEntry` would draw it:
+## { species, empty, number, seen, caught, name, selected }. [code]empty[/code]
+## is the species-zero row `.PrintEntry` returns from at once, which the tail of
+## an ABC listing is made of; [code]number[/code] is three digits zero-padded and
+## only OLD mode prints one.
 func rows() -> Array:
 	var out: Array = []
 	for index: int in listing_height:
@@ -350,12 +334,9 @@ func move_unown(button: int) -> bool:
 	return false
 
 
-## `Pokedex_ListingHandleDPadInput`. Answers whether the position changed, which
-## is the carry flag the source returns.
-##
-## Left and right page the listing and are refused outright while it fits on one
-## screen: the source checks `wDexListingHeight` against `wDexListingEnd` before
-## it looks at either button.
+## `Pokedex_ListingHandleDPadInput`, answering the carry flag the source returns.
+## Left and right page the listing and are refused while it fits on one screen,
+## the source checking `wDexListingHeight` against `wDexListingEnd` first.
 func move_listing(button: int) -> bool:
 	match button:
 		Gen2Button.UP:
@@ -443,9 +424,8 @@ func toggle_page() -> void:
 	prev_entry = selected_species()
 
 
-## `Pokedex_NextOrPreviousDexEntry`: moves in the pressed direction until it
-## lands on a species that has been seen, and puts the cursor and scroll back
-## where they were if it runs out of listing first.
+## `Pokedex_NextOrPreviousDexEntry`: moves until it lands on a seen species, and
+## puts the cursor and scroll back if it runs out of listing first.
 ##
 ## Answers whether it moved. A move re-enters the entry screen at page 1, which
 ## is `Pokedex_ReinitDexEntryScreen`.
@@ -494,18 +474,15 @@ func entry() -> Dictionary:
 	}
 
 
-## `_PrintNum` (engine/math/print_num.asm) for the two calls this screen makes:
-## [param digits] digits with [param before_point] of them in front of a decimal
-## point, and neither the money nor the leading-zero flag set.
+## `_PrintNum` (engine/math/print_num.asm) for this screen's two calls:
+## [param digits] digits with [param before_point] before a decimal point, and
+## neither the money nor the leading-zero flag set. A leading zero is neither
+## printed nor replaced, `.PrintLeadingZero` writing nothing while the flag is
+## clear and `.AdvancePointer` stepping over the cell anyway, which is why this
+## answers a fixed-width field of spaces rather than a trimmed number.
 ##
-## A leading zero is not printed and not replaced: `.PrintLeadingZero` writes
-## nothing while the flag is clear and `.AdvancePointer` steps over the cell
-## regardless, leaving the background template's own space. That is why this
-## returns a fixed-width field with spaces rather than a trimmed number.
-##
-## The digit immediately in front of the point is always printed, even when it
-## is a zero: `.PrintDigit` latches "a digit has been printed" as `e` runs out,
-## which is what makes a height of 8 read 0'08" rather than blank.
+## The digit in front of the point always prints, zero or not: `.PrintDigit`
+## latches as `e` runs out, which makes a height of 8 read 0'08" not blank.
 static func print_num(value: int, digits: int, before_point: int) -> String:
 	var text: String = ""
 	var padded: String = String.num_int64(maxi(value, 0)).lpad(digits, "0").right(digits)
@@ -617,17 +594,12 @@ func _step_search_type(delta: int) -> void:
 		search_type_2 = value
 
 
-## `Pokedex_SearchForMons` plus `.MenuAction_BeginSearch`'s answer to it.
-##
-## Each chosen type filters the listing in place and the second row is applied
-## first, so choosing two types finds the species carrying both rather than
-## either. A species has to have been *caught*, not merely seen: `.Search`
-## checks `Pokedex_CheckCaught`.
-##
-## Answers the number of results. Zero leaves the listing rebuilt by mode, which
-## is what `.MenuAction_BeginSearch` does before showing its own not-found text;
-## anything else moves the listing onto the results and backs up what it
-## replaced.
+## `Pokedex_SearchForMons` plus `.MenuAction_BeginSearch`'s answer to it. Each
+## chosen type filters the listing in place with the second row applied first, so
+## two types find the species carrying both; a species has to have been *caught*,
+## `.Search` checking `Pokedex_CheckCaught`. Answers the result count: zero
+## leaves the listing rebuilt by mode, before the not-found text, and anything
+## else moves it onto the results and backs up what it replaced.
 func begin_search() -> int:
 	search_result_count = 0
 	if search_type_2 != SEARCH_TYPE_NONE:

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -1,18 +1,15 @@
 class_name Gen2TitleScene
 extends RefCounted
 
-## The title screen's own scene machine (`TitleScreenScene`,
-## `engine/menus/intro_menu.asm`), one source frame at a time.
+## `TitleScreenScene` (`engine/menus/intro_menu.asm`), one source frame at a
+## time. Two screens under one name: Crystal opens on `TitleScreenEntrance`,
+## walking `hSCX` in from 112 while the crystal falls and the interlaced
+## `wLYOverrides` pull the logo together, and Gold and Silver go straight to the
+## timer with a bird on its own sine.
 ##
-## Two screens under one name. Crystal opens on `TitleScreenEntrance`, which
-## walks `hSCX` in from 112 while the crystal falls into place and the interlaced
-## `wLYOverrides` pull the logo together; Gold and Silver have no entrance at all
-## and go straight to the timer with a bird flying on its own sine.
-##
-## Scene-free: this owns the frames, the scroll, the sprites and the option the
-## screen answers with. [Gen2TitlePage] owns the pixels and a host owns the
-## device. What it never owns is the decision behind the answer: the caller reads
-## [method selected_option] once [method finished] holds.
+## Scene-free: the frames, the scroll, the sprites and the answer. The pixels are
+## [Gen2TitlePage]'s and the caller reads [method selected_option] once
+## [method finished] holds.
 
 ## `.scenes`. Crystal's table opens on the entrance and Gold and Silver's does
 ## not, so the phase is named rather than numbered here.
@@ -36,10 +33,9 @@ const OPTION_RESET_CLOCK: int = 4
 const TIMER_GOLD: int = 84 * 60 + 16
 const TIMER_DEFAULT: int = 73 * 60 + 36
 
-## `TitleScreenEntrance`: `hSCX` starts at +112 and comes off four a frame, and
-## `AnimateTitleCrystal` moves thirty sprites down two a frame until the first
-## one's y reaches 6 + two tiles. Both take the same twenty-eight frames, which
-## is why neither has to wait for the other.
+## `TitleScreenEntrance`: `hSCX` from +112 off four a frame, and
+## `AnimateTitleCrystal` thirty sprites down two a frame until the first's y
+## reaches 6 + two tiles. Both take the same twenty-eight frames.
 const ENTRANCE_SCX: int = 112
 const ENTRANCE_SCX_STEP: int = 4
 ## The interlaced band is the logo's height, and only its odd lines take the
@@ -65,41 +61,36 @@ const SUICUNE_FRAMES: Array[int] = [0x80, 0x88, 0x00, 0x08]
 ## before the iterator has re-pointed it once.
 const SUICUNE_FIRST_BASE: int = 0x00
 ## `LoadSuicuneFrame` draws six rows of eight from whichever base it is handed.
-## Its `d` rises by one across each of the eight columns and then by eight more
-## at the end of the row, so a row starts sixteen tiles past the one above it:
-## the sheet is sixteen wide and only its left half is on screen.
+## Its `d` rises by one per column and eight more at the row's end, so a row
+## starts sixteen past the one above: the sheet is 16 wide, half of it on screen.
 const SUICUNE_COLUMNS: int = 8
 const SUICUNE_ROW_STRIDE: int = 16
 const SUICUNE_ROWS: int = 6
 const SUICUNE_AT := Vector2i(6, 12)
-## `Decompress` puts the sheet at `vTiles4`, which is tile $80 of the bank the
-## Suicune strip is read through, and a tile number is a byte: `.Frames`' last
-## two bases are written as `vTiles5` $00 and $08 because $180 and $188 have
-## wrapped. Subtracting the sheet's own start as a byte undoes both.
+## `Decompress` puts the sheet at `vTiles4`, tile $80 of its bank, and a tile
+## number is a byte: `.Frames`' last two bases read `vTiles5` $00 and $08 because
+## $180 and $188 wrapped. Subtracting the sheet's start as a byte undoes both.
 const SUICUNE_VRAM_FIRST_TILE: int = 0x80
 
-## `InitializeBackground`: thirty 8x16 objects as five rows of six. Its
-## `.InitColumn` keeps `d` for the whole run and walks `b` by eight, so what it
-## calls a column is a row of sprites across; `d` rises by $10, one object's
-## height, between them. The tile number steps by two throughout.
+## `InitializeBackground`: thirty 8x16 objects as five rows of six. `.InitColumn`
+## keeps `d` and walks `b` by eight, so its "column" is a row across; `d` rises
+## by $10, one object's height, between them, and the tile number steps by two.
 const CRYSTAL_ROWS: int = 5
 const CRYSTAL_COLUMNS: int = 6
 const CRYSTAL_ROW_STEP: int = 0x10
 const CRYSTAL_FIRST_X: int = 0x40
 const CRYSTAL_X_STEP: int = 8
 
-## `depixel 12, 11`, the bird's own struct coordinate. `_InitSpriteAnimStruct`
-## takes x in e and y in d, and `ldpixel` loads the first operand into the high
-## byte, so the pair reads (y, x) however the macro's own comment names them.
+## `depixel 12, 11`, the bird's struct coordinate. `_InitSpriteAnimStruct` takes
+## x in e and y in d and `ldpixel` loads the first operand high, so it is (y, x).
 const BIRD_AT := Vector2i(11 * Gen2Tiles.TILE_WIDTH, 12 * Gen2Tiles.TILE_HEIGHT)
 ## `AnimSeq_GSIntroHoOhLugia`: Gold counts its sine input up and scales by two,
 ## Silver counts down and scales by eight, and the answer is the y offset.
 const BIRD_SINE_GOLD: int = 2
 const BIRD_SINE_SILVER: int = 8
 
-## `.Frameset_GSIntroHoOhLugia`, as [code](oam set, frames)[/code] pairs in each
-## profile's own order. `oamframe X, n` lasts n + 1 frames and `oamrestart`
-## takes the sequence back to the top, so both loop rather than settling.
+## `.Frameset_GSIntroHoOhLugia` as [code](oam set, frames)[/code] pairs per
+## profile. `oamframe X, n` lasts n + 1 and `oamrestart` loops rather than ending.
 const BIRD_FRAMESET_GOLD: Array[Vector2i] = [
 	Vector2i(0, 11), Vector2i(1, 10), Vector2i(2, 11),
 	Vector2i(3, 11), Vector2i(2, 10), Vector2i(4, 11),
@@ -110,10 +101,9 @@ const BIRD_FRAMESET_SILVER: Array[Vector2i] = [
 	Vector2i(1, 4),
 ]
 
-## `UpdateTitleTrailSprite`, which spawns a trail behind the bird on every
-## fourth frame of the timer. Gold picks the spawn from `.TitleTrailCoords` by
-## the bird's own frame and the timer's bit 2, and a row of zeroes means that
-## frame drops no trail; Silver spawns from one fixed place.
+## `UpdateTitleTrailSprite`, a trail every fourth frame of the timer. Gold picks
+## from `.TitleTrailCoords` by the bird's frame and the timer's bit 2, a row of
+## zeroes dropping none; Silver spawns from one fixed place.
 const TRAIL_SPAWN_MASK: int = 0b11
 const TRAIL_SPAWN_ALTERNATE: int = 0b100
 ## `dbpixel x, y, 4, 0` per entry, as (x, y) pixel pairs and (-1, -1) for the
@@ -128,43 +118,38 @@ const TRAIL_COORDS_GOLD: Array[Array] = [
 ]
 ## `depixel 15, 11, 4, 0`.
 const TRAIL_AT_SILVER := Vector2i(88, 124)
-## `AnimSeq_GSTitleTrail`: four pixels right a frame, gone once its x reaches
-## $a4. The rest of it is two routines under one name. Only Gold's `.one` has the
-## `inc [hl]` that walks the y coordinate down, and only Gold's `.zero` seeds
-## VAR1 from the struct's own index and then reaches
-## `AnimSeqs_IncAnonJumptableIndex`, so its sine is set up once and stepped by
-## three a frame from there.
+## `AnimSeq_GSTitleTrail`: four pixels right a frame, gone at x $a4. Two routines
+## under one name past that. Only Gold's `.one` has the `inc [hl]` walking y
+## down, and only Gold's `.zero` seeds VAR1 from the struct's index and reaches
+## `AnimSeqs_IncAnonJumptableIndex`, so its sine is set up once then stepped by
+## three.
 const TRAIL_X_STEP: int = 4
 const TRAIL_Y_STEP: int = 1
 const TRAIL_X_END: int = 0xA4
 const TRAIL_SINE_STEP: int = 3
 const TRAIL_SINE_AMPLITUDE: int = 2
-## Silver's `.zero` runs every frame, and both numbers it wants come from
+## Silver's `.zero` runs every frame and takes both numbers from
 ## `wIntroSceneTimer`, which the union at `wJumptableIndex + 2` gives to
-## `LOW(wTitleScreenTimer)`: the byte the screen itself is counting down. Masked
-## and swapped it is 0 to 3, which is an amplitude of 3 to 6 and a step of 7 to
-## 10.
+## `LOW(wTitleScreenTimer)`, the byte the screen counts down. Masked and swapped
+## it is 0 to 3: an amplitude of 3 to 6 and a step of 7 to 10.
 const TRAIL_SILVER_TIMER_MASK: int = 0x30
 const TRAIL_SILVER_TIMER_SHIFT: int = 4
-## `.Frameset_GSTitleTrail`, as (OAM set, duration) pairs. Gold alternates the
-## two `spriteanimoam` vtiles and `oamrestart`s, so each picture is up for two
-## frames; Silver holds the first and `oamend`s, which repeats it forever. A
-## frame lasts its duration plus one, the way `GetSpriteAnimFrame` counts.
+## `.Frameset_GSTitleTrail` as (OAM set, duration) pairs. Gold alternates two
+## `spriteanimoam` vtiles and `oamrestart`s; Silver holds the first and `oamend`s,
+## repeating it forever. A frame lasts its duration plus one.
 const TRAIL_FRAMESET_GOLD: Array[Vector2i] = [Vector2i(0, 1), Vector2i(1, 1)]
 const TRAIL_FRAMESET_SILVER: Array[Vector2i] = [Vector2i(0, 32)]
 const TRAIL_SILVER_AMPLITUDE_BASE: int = 3
 const TRAIL_SILVER_STEP_BASE: int = 7
 
-## `ScrollTitleScreenClouds`: forty scanlines from line $5f take one shared
-## offset that falls by one, on every eighth frame on Gold and on every frame on
-## Silver.
+## `ScrollTitleScreenClouds`: forty scanlines from $5f share one falling offset,
+## stepped every eighth frame on Gold and every frame on Silver.
 const CLOUD_FIRST_LINE: int = 0x5F
 const CLOUD_LINES: int = 0x28
 const CLOUD_GOLD_MASK: int = 0b111
 
-## `NUM_SPRITE_ANIM_STRUCTS`: `_InitSpriteAnimStruct` walks ten slots and returns
-## carry rather than making an eleventh, so a burst of trails simply stops. The
-## bird holds one of the ten for the whole screen's life, which leaves nine.
+## `_InitSpriteAnimStruct` walks ten slots and returns carry rather than making
+## an eleventh. The bird holds one for the screen's life, leaving nine.
 const MAX_SPRITE_STRUCTS: int = 10
 const MAX_TRAILS: int = MAX_SPRITE_STRUCTS - 1
 
@@ -180,23 +165,20 @@ var _timer: int = 0
 var _scx: int = 0
 var _crystal_y: int = 0
 var _suicune_counter: int = 0
-## `LoadSuicuneFrame`'s live base, which the iterator re-points rather than the
-## page deriving it: the counter is read before it is raised, so the write lands
-## a frame later than a derivation from the raised counter would put it.
+## `LoadSuicuneFrame`'s live base, re-pointed by the iterator rather than derived
+## by the page: the counter is read before it is raised, so the write lands late.
 var _suicune_base: int = SUICUNE_FIRST_BASE
 var _bird_var: int = 0
 var _bird_frame: int = 0
 var _selected: int = -1
 var _sine: Gen2BattleAnimData = null
-## The live trail particles, each `{ at, var1, yoffset, fresh }`, capped the way
-## `_InitSpriteAnimStruct` caps them. `fresh` is a struct that has not had a
+## Live particles as `{ at, var1, yoffset, fresh }`, capped the way
+## `_InitSpriteAnimStruct` caps them. `fresh` is a struct with no
 ## `PlaySpriteAnimations` pass yet: `UpdateTitleTrailSprite` spawns behind that
-## call, so a new trail neither runs its `.zero` nor reaches shadow OAM until the
-## next frame.
+## call, so a new trail neither runs `.zero` nor reaches OAM until next frame.
 var _trails: Array[Dictionary] = []
-## `wSpriteAnimCount`, which `_InitSpriteAnimStruct` raises on every spawn and
-## which every struct keeps as its own `SPRITEANIMSTRUCT_INDEX`. `TitleScreen`
-## spawns the bird before any trail, so the count opens at one.
+## `wSpriteAnimCount`, raised on every spawn and kept as each struct's
+## `SPRITEANIMSTRUCT_INDEX`. The bird is spawned first, so it opens at one.
 var _anim_count: int = 1
 var _cloud_scroll: int = 0
 
@@ -247,27 +229,22 @@ func window_y() -> int:
 	return WINDOW_Y
 
 
-## `wLYOverrides`, one signed scroll per scanline, empty when nothing is
-## overriding `hSCX`.
-##
-## Crystal's is `TitleScreenEntrance`: the logo's eighty lines take the scroll
-## with the odd ones negated, which is the interlaced pull-together, and `.done`
-## clears the pointer so nothing overrides after it. Gold and Silver's is
-## `ScrollTitleScreenClouds`, forty lines of cloud walking left for the whole
-## screen's life.
+## `wLYOverrides`, one signed scroll per scanline, empty when nothing overrides
+## `hSCX`. Crystal's is `TitleScreenEntrance`: the logo's eighty lines take the
+## scroll with the odd ones negated, the interlaced pull-together, and `.done`
+## clears the pointer. Gold and Silver's is `ScrollTitleScreenClouds`, forty
+## lines walking left for the screen's whole life.
 func line_offsets() -> PackedInt32Array:
 	var out := PackedInt32Array()
 	if _profile == RomRegistry.CRYSTAL:
 		if _scene != SCENE_ENTRANCE or _scx == 0:
 			return out
-		# `wLYOverrides` is read by the LCD interrupt where it stands rather than
-		# copied at VBlank, so the screen this state's sprites reach carries the
-		# *next* pass's fill: `TitleScreenEntrance` writes it before the frame it
-		# opened is drawn. Everything else here is a frame behind it.
+		# `wLYOverrides` is read live rather than copied at VBlank, so the screen
+		# this state's sprites reach carries the *next* pass's fill:
+		# `TitleScreenEntrance` writes it before the frame it opened is drawn.
 		var scx: int = _scx - ENTRANCE_SCX_STEP
-		# Only the logo's own eighty lines are written; `_TitleScreen` zeroed
-		# the rest of the buffer and nothing rewrites them, so the strip below
-		# the logo stands still while the logo comes in.
+		# Only the logo's eighty lines are written; `_TitleScreen` zeroed the
+		# rest, so the strip below it stands still while the logo comes in.
 		out.resize(Gen2Screen.HEIGHT)
 		out.fill(0)
 		for line: int in ENTRANCE_LINES:
@@ -280,9 +257,8 @@ func line_offsets() -> PackedInt32Array:
 	return out
 
 
-## Whether the screen has answered. The caller reads [method selected_option]
-## and moves on: a timer that ran out answers nothing and is the intro movie's
-## cue instead.
+## Whether the screen has answered. A timer that ran out answers nothing and is
+## the intro movie's cue instead.
 func finished() -> bool:
 	return _scene == SCENE_END
 
@@ -292,16 +268,14 @@ func selected_option() -> int:
 	return _selected
 
 
-## One source frame. [param held] is the buttons down this frame, as
-## [Gen2Button] values, since `GetJoypad`'s `hJoyDown` is what every branch here
-## reads rather than a press.
+## One source frame. [param held] is the buttons down, since every branch here
+## reads `GetJoypad`'s `hJoyDown` rather than a press.
 func advance_frame(held: Array = []) -> void:
 	if _scene == SCENE_END:
 		return
 	_frame += 1
-	# `RunTitleScreen`'s own order: the clouds, then the scene, which is what
-	# counts the timer down, then the sprites and the spawn behind them, both of
-	# which read that timer after the count.
+	# `RunTitleScreen`'s order: clouds, then the scene that counts the timer
+	# down, then the sprites and the spawn, both of which read it after.
 	_advance_clouds()
 	match _scene:
 		SCENE_ENTRANCE:
@@ -342,8 +316,7 @@ func _advance_clouds() -> void:
 
 
 ## `AnimSeq_GSTitleTrail` over every live particle, then
-## `UpdateTitleTrailSprite`'s own spawn. The move runs first because
-## `PlaySpriteAnimations` does, and the spawn is the call behind it.
+## `UpdateTitleTrailSprite`'s spawn, which is the call behind it.
 func _advance_trails() -> void:
 	var alive: Array[Dictionary] = []
 	for trail: Dictionary in _trails:
@@ -395,9 +368,8 @@ func _advance_trails() -> void:
 
 
 ## `GetSpriteAnimFrame` for one trail. The counter starts at -1 and the duration
-## is loaded on the pass that reads an entry, so an `oamframe X, n` is drawn
-## n + 1 times; Gold `oamrestart`s to the first entry and Silver `oamend`s, which
-## repeats the last for as long as the sprite is up.
+## loads on the pass that reads an entry, so `oamframe X, n` is drawn n + 1
+## times; Gold `oamrestart`s and Silver `oamend`s, repeating the last.
 func _advance_trail_frameset(trail: Dictionary) -> void:
 	var frames: Array[Vector2i] = TRAIL_FRAMESET_GOLD if _profile == RomRegistry.GOLD \
 		else TRAIL_FRAMESET_SILVER
@@ -431,9 +403,8 @@ func _advance_entrance() -> void:
 		_crystal_y = (_crystal_y + CRYSTAL_STEP) & 0xFF
 
 
-## `TitleScreenMain`: the timer down a frame, then the three chords. The button
-## checks run before the timer is looked at again, so the last frame of the
-## count can still be answered.
+## `TitleScreenMain`: the timer down a frame, then the three chords. The buttons
+## are checked before the timer is looked at again, so its last frame answers.
 func _advance_main(held: Array) -> void:
 	if _timer <= 0:
 		# `.end` into `TitleScreenEnd`, which fades the music out and then answers
@@ -487,9 +458,8 @@ func suicune_tiles() -> Array[Vector3i]:
 	return out
 
 
-## The screen's objects for this frame, as
-## [code]{ kind, at, tile, palette }[/code] in shadow-OAM coordinates. Crystal's
-## thirty crystal parts, or Gold and Silver's bird and the trail behind it.
+## [code]{ kind, at, tile, palette }[/code] in shadow-OAM coordinates: Crystal's
+## thirty crystal parts, or the bird and its trail.
 func sprites() -> Array[Dictionary]:
 	if _profile == RomRegistry.CRYSTAL:
 		return _crystal_sprites()
@@ -516,15 +486,13 @@ func _crystal_sprites() -> Array[Dictionary]:
 	return out
 
 
-## The bird's own frameset and the trail sprite under it. The y offset is
-## `AnimSeqs_Sine` over `BattleAnimSineWave`, which is the same table every
-## battle animation reads.
+## The bird's frameset and the trail under it. The y offset is `AnimSeqs_Sine`
+## over `BattleAnimSineWave`, the table every battle animation reads.
 func _bird_sprites() -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
-	# `TitleScreen` spawns the bird into the first free slot and then copies the
-	# struct into `wSpriteAnim10` and clears the first, so the bird holds the last
-	# slot however late a trail is spawned: the trails are drawn first and the
-	# bird over them.
+	# `TitleScreen` spawns the bird into the first free slot, copies the struct
+	# into `wSpriteAnim10` and clears the first, so the bird holds the last slot
+	# however late a trail is spawned and is drawn over them.
 	for trail: Dictionary in _trails:
 		if bool(trail["fresh"]):
 			continue
@@ -554,9 +522,8 @@ func bird_frame() -> int:
 	return int(_bird_frameset()[_bird_entry()].x)
 
 
-## `SPRITEANIMSTRUCT_FRAME`, which is the entry of the frameset rather than the
-## OAM set it names: Gold's list reaches set 2 twice, and `.TitleTrailCoords` is
-## indexed by the entry, not by the picture.
+## `SPRITEANIMSTRUCT_FRAME` is the frameset entry, not the OAM set it names:
+## Gold's list reaches set 2 twice and `.TitleTrailCoords` indexes the entry.
 func _bird_entry() -> int:
 	var frameset: Array[Vector2i] = _bird_frameset()
 	var total: int = 0

--- a/game/world/town_map.gd
+++ b/game/world/town_map.gd
@@ -1,21 +1,16 @@
 class_name Gen2TownMap
 extends RefCounted
 
-## `_TownMap` and the Pokegear's MAP card (engine/pokegear/pokegear.asm), as
-## state rather than pixels: which region is drawn, where the cursor is and which
-## landmarks it may reach.
-##
-## Both screens share `PokegearMap_UpdateLandmarkName` and the cursor walk; they
-## differ in the frame drawn over the region map, which is [Gen2TownMapPage]'s
-## business, and in what the Fast Ship counts as. Landmark numbering itself lives
-## in [Gen2WorldRadio], whose station rules read the same table.
+## `_TownMap` and the Pokegear's MAP card (engine/pokegear/pokegear.asm) as state
+## rather than pixels. The two share `PokegearMap_UpdateLandmarkName` and the
+## cursor walk and differ only in the frame, which is [Gen2TownMapPage]'s, and in
+## what the Fast Ship counts as. Landmark numbering is [Gen2WorldRadio]'s.
 
 ## `PokegearMap_JohtoMap`'s own `ld e, JOHTO_LANDMARK`.
 const JOHTO_LANDMARK: int = 1
 
-## `TownMap_GetKantoLandmarkLimits`' pre-Hall of Fame window, which is Victory
-## Road to Route 28 rather than the whole region. Crystal's numbers; Gold and
-## Silver's are one lower, the way every landmark past `BATTLE TOWER` is.
+## `TownMap_GetKantoLandmarkLimits`' pre-Hall of Fame window. Crystal's numbers;
+## see [method _shift].
 const LANDMARK_VICTORY_ROAD: int = 0x58
 const LANDMARK_ROUTE_28: int = 0x5E
 
@@ -24,20 +19,16 @@ const REGION_KANTO: int = 1
 ## What the cache calls each region map, which is the pinned file name.
 const REGION_NAMES: Array[String] = ["johto", "kanto"]
 
-## Which screen is being drawn. `_TownMap` is the town map poster and the
-## `OverworldTownMap` special; the card is the Pokegear's second page; the dex
-## area is `Pokedex_GetArea`, which draws both maps and switches between them.
+## `_TownMap` is the poster and the `OverworldTownMap` special; the card is the
+## Pokegear's second page; the dex area is `Pokedex_GetArea`, which draws both.
 const SCREEN_TOWN_MAP: StringName = &"town_map"
 const SCREEN_POKEGEAR_CARD: StringName = &"pokegear_card"
 const SCREEN_DEX_AREA: StringName = &"dex_area"
-## `_FlyMap`, which is the same two maps with the cursor walking flypoints
-## instead of landmarks: `wTownMapPlayerIconLandmark` holds a `FLY_*` index there
-## rather than a landmark, and the up and down presses skip every flypoint the
-## player has not visited.
+## `_FlyMap`: the same maps with the cursor walking `FLY_*` indexes instead of
+## landmarks, skipping every flypoint the player has not visited.
 const SCREEN_FLY: StringName = &"fly"
 
-## `FLY_INDIGO`, the last flypoint and Kanto's own default. It is also the one
-## `FlyMap` tests before it will draw Kanto at all.
+## Kanto's default flypoint, and the one `FlyMap` tests before drawing Kanto.
 const FLY_INDIGO: int = RomLayout.FLYPOINT_COUNT - 1
 
 var crystal: bool = true
@@ -51,24 +42,17 @@ var cursor: int = JOHTO_LANDMARK
 ## `STATUSFLAGS_HALL_OF_FAME_F`, which the dex area reads on every right press
 ## rather than once.
 var hall_of_fame: bool = false
-## Which `FLY_*` indexes the player has visited, for the fly map's own walk.
-## Empty on every other screen, which reads none of it.
+## For the fly map's walk alone; empty on every other screen.
 var visited_flypoints: Array[int] = []
 var _first: int = JOHTO_LANDMARK
 var _last: int = JOHTO_LANDMARK
 
 
-## `FlyMap`: the fly map opened on whichever region the player is in, with the
-## cursor on that region's default flypoint.
-##
-## [param visited] is which `FLY_*` indexes `CheckIfVisitedFlypoint` answers for,
-## which is the `wVisitedSpawns` bit of each one's own spawn. Kanto is only drawn
-## once Indigo Plateau is among them: `.NoKanto` falls back to Johto's map
-## instead, which is what stops the source's own crash on a region with no
-## flypoint enabled.
-##
-## The default flypoint is on the map whether or not it has been visited, which
-## is the source's own quirk and is why New Bark can always be flown to.
+## `FlyMap`, opened on the region the player is in with the cursor on its default
+## flypoint. [param visited] is what `CheckIfVisitedFlypoint` answers for, the
+## `wVisitedSpawns` bit of each spawn; `.NoKanto` falls back to Johto's map
+## unless Indigo Plateau is among them. The default is reachable whether or not
+## it was visited, which is the source's quirk and why New Bark always flies.
 static func fly(
 	landmark: int, in_kanto: bool, visited: Array[int], is_crystal: bool
 ) -> Gen2TownMap:
@@ -76,9 +60,8 @@ static func fly(
 	out.crystal = is_crystal
 	out.screen = SCREEN_FLY
 	out.visited_flypoints = visited.duplicate()
-	# `.MapHud` hands `TownMapPlayerIcon` the landmark it popped, so the player
-	# icon still says where the player is standing while the cursor walks
-	# flypoints.
+	# `.MapHud` hands `TownMapPlayerIcon` the landmark it popped, so the icon
+	# still says where the player stands while the cursor walks flypoints.
 	out.player_landmark = landmark
 	if in_kanto and visited.has(FLY_INDIGO):
 		out._first = RomLayout.KANTO_FLYPOINT
@@ -91,9 +74,8 @@ static func fly(
 	return out
 
 
-## `TownMap_GetCurrentLandmark` has already run: [param landmark] is the resolved
-## one, never `LANDMARK_SPECIAL`. [param hall_of_fame] is `STATUSFLAGS_HALL_OF_FAME_F`,
-## which is what opens the whole Kanto map rather than the Victory Road window.
+## `TownMap_GetCurrentLandmark` has already run, so [param landmark] is resolved
+## and never `LANDMARK_SPECIAL`. [param hall_of_fame] opens the whole Kanto map.
 static func create(
 	landmark: int, is_crystal: bool, hall_of_fame: bool = false,
 	on_screen: StringName = SCREEN_TOWN_MAP
@@ -104,44 +86,38 @@ static func create(
 	out.hall_of_fame = hall_of_fame
 	out.player_landmark = landmark
 	if on_screen == SCREEN_DEX_AREA:
-		# `.Area` sets hWY to 144 before calling, so the window is off and BG map
-		# 0, the Johto one, is what `Pokedex_GetArea` opens on whatever landmark
-		# the player is standing at.
+		# `.Area` sets hWY to 144, so the window is off and BG map 0, Johto's, is
+		# what `Pokedex_GetArea` opens on whatever landmark the player is at.
 		out.cursor = REGION_JOHTO
 		return out
 	if out.region() == REGION_KANTO:
-		# `TownMap_GetKantoLandmarkLimits`. Its two branches end on the same
-		# landmark, `LANDMARK_ROUTE_28` being `KANTO_LANDMARK_LAST`; only the
-		# first moves, from Victory Road to the top of the region.
+		# `TownMap_GetKantoLandmarkLimits`' two branches end on the same
+		# `KANTO_LANDMARK_LAST`; only the first landmark moves.
 		out._first = Gen2WorldRadio.kanto_landmark(is_crystal) if hall_of_fame \
 			else out._shift(LANDMARK_VICTORY_ROAD)
 		out._last = out._shift(LANDMARK_ROUTE_28)
 	else:
 		out._first = JOHTO_LANDMARK
 		out._last = Gen2WorldRadio.kanto_landmark(is_crystal) - 1
-	# `_TownMap` writes the cursor from the same landmark the player icon takes
-	# and never clamps it into the window, so a Kanto map opened before the Hall
-	# of Fame starts below Victory Road and the first press walks in.
+	# `_TownMap` never clamps the cursor into the window, so a Kanto map opened
+	# before the Hall of Fame starts below Victory Road and one press walks in.
 	out.cursor = landmark
 	return out
 
 
-## A Crystal landmark number on the active profile. Gold and Silver ship no
-## `BATTLE TOWER`, so everything past it is one lower.
+## Gold and Silver ship no `BATTLE TOWER`, so every landmark past it is one lower.
 func _shift(landmark: int) -> int:
 	if crystal:
 		return landmark
 	return landmark - 1
 
 
-## Which map is drawn. `_TownMap` picks by number alone, so the Fast Ship shows
-## Kanto there; `InitPokegearTilemap.Map` tests it first and shows Johto; the dex
-## area is told which one to show and keeps it in the cursor byte.
+## `_TownMap` picks by number alone, so the Fast Ship shows Kanto there;
+## `InitPokegearTilemap.Map` tests it first and shows Johto.
 func region() -> int:
 	if screen == SCREEN_DEX_AREA:
 		return cursor
-	# `FlyMap` fills one region's map and walks that region's flypoints, and
-	# `.NoKanto` is what puts a player standing in Kanto on Johto's.
+	# `.NoKanto` is what puts a player standing in Kanto on Johto's map.
 	if screen == SCREEN_FLY:
 		return REGION_KANTO if _first == RomLayout.KANTO_FLYPOINT else REGION_JOHTO
 	if screen == SCREEN_POKEGEAR_CARD \
@@ -155,9 +131,7 @@ static func region_name(region: int) -> String:
 	return REGION_NAMES[clampi(region, REGION_JOHTO, REGION_KANTO)]
 
 
-## `.CheckPlayerLocation`, which is what decides whether the dex area draws the
-## player icon at all: the Fast Ship counts as Johto, and a player in the region
-## that is not on screen is not drawn.
+## `.CheckPlayerLocation`: whether the dex area draws the player icon at all.
 func player_in_region() -> bool:
 	var player: int = REGION_KANTO if Gen2WorldRadio.is_kanto_landmark(
 		player_landmark, crystal
@@ -173,13 +147,10 @@ func last_landmark() -> int:
 	return _last
 
 
-## `.pressed_up` and `.pressed_down`, which wrap round the window's ends rather
-## than stopping at them: a cursor already at the last landmark is rewound to one
-## before the first and then stepped on.
-##
-## The dex area walks regions instead: `.left` shows Johto and `.right` Kanto,
-## the second only once the Hall of Fame flag is set, and each returns without
-## redrawing when that region is already up.
+## `.pressed_up` and `.pressed_down` wrap round the window's ends rather than
+## stopping at them. The dex area walks regions instead: `.left` shows Johto and
+## `.right` Kanto, the second only past the Hall of Fame, and each returns
+## without redrawing when that region is already up.
 func press(button: int) -> bool:
 	if screen == SCREEN_DEX_AREA:
 		match button:
@@ -206,10 +177,8 @@ func press(button: int) -> bool:
 	return false
 
 
-## `.ScrollNext` and `.ScrollPrev`'s own loop: a press keeps stepping while the
-## flypoint it lands on has not been visited, wrapping the way one press does.
-## The window is at most twelve wide and the default is always on it, so the walk
-## cannot run forever.
+## `.ScrollNext` and `.ScrollPrev`'s loop, wrapping the way one press does. The
+## window is at most twelve wide and always holds the default, so it terminates.
 func _skip_unvisited(step: int) -> void:
 	if screen != SCREEN_FLY:
 		return
@@ -222,7 +191,6 @@ func _skip_unvisited(step: int) -> void:
 			cursor = _last if cursor == _first else cursor - 1
 
 
-## Which flypoint the map opened on, and so the one the source leaves reachable
-## whether or not it has been visited.
+## The flypoint the map opened on, which the source leaves reachable regardless.
 func _default_flypoint() -> int:
 	return FLY_INDIGO if _first == RomLayout.KANTO_FLYPOINT else 0

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -1,43 +1,36 @@
 class_name Gen2WorldActors
 extends RefCounted
 
-## The sprites a mod puts in the world, driven and resolved by the host.
+## The sprites a mod puts in the world, driven and resolved by the host. A mod
+## wanting one thing in the overworld, a follower or a marker, registers an actor
+## through [method Gen2ModHost.register_world_actor] rather than a whole
+## renderer. The screen drives it with one `advance_frame` per world frame and
+## one `sprites()` read after it, resolved into the same [Gen2WorldSprite] the
+## map's own objects are drawn from.
 ##
-## A mod that wants one thing in the overworld, a follower, a pet, a marker over
-## an object, registers a world ACTOR through
-## [method Gen2ModHost.register_world_actor] rather than a whole world renderer.
-## This class is what the screen drives it with: one `advance_frame` per world
-## frame, one `sprites()` read after it, and the answer resolved into the same
-## [Gen2WorldSprite] the map's own objects are drawn from.
-##
-## PRESENTATION and nothing else. An actor's sprite occupies no cell, blocks
-## nothing, is talked to by nobody, is seen by no trainer and appears in no
-## snapshot. That is the whole reason this is a layer of its own rather than a
-## map object: a mod must not be able to change what the cartridge says the
-## world is, and an object is world state.
+## PRESENTATION and nothing else: an actor's sprite occupies no cell, blocks
+## nothing, is talked to by nobody, is seen by no trainer and is in no snapshot.
+## That is why it is a layer of its own rather than a map object, which is world
+## state a mod must not be able to change.
 ##
 ## A mod names cartridge art and never composes pixels: an entry carries an
-## `IconPointers` row (`icon`), or an `OverworldSprites` row (`sprite`), and the
-## strip, the palette, the time of day and the icon's own animation rate are
-## resolved here exactly as they are for a mon-icon object standing on a map.
+## `IconPointers` row (`icon`) or an `OverworldSprites` row (`sprite`), and the
+## strip, palette, time of day and animation rate are resolved here the way they
+## are for a mon-icon object standing on a map.
 
-## The methods an actor has to provide. Checked at registration, where the mod's
-## name is still in hand, the way a renderer's are.
+## Checked at registration, where the mod's name is still in hand.
 const ACTOR_METHODS: Array[String] = ["set_world", "advance_frame", "sprites"]
 
-## `.Frameset_PartyMon`, the icon's own two-frame animation: two OAM sets of
-## eight, which is nine passes each because `GetSpriteAnimFrame` returns the
-## entry on the pass that loads the duration too. An actor is not a party row,
-## so it takes the unmodified speed rather than
-## `SetPartyMonIconAnimSpeed`'s hurt-Pokemon slowdown.
+## `.Frameset_PartyMon`: two OAM sets of eight, nine passes each because
+## `GetSpriteAnimFrame` returns the entry on the pass that loads the duration
+## too. An actor is not a party row, so no `SetPartyMonIconAnimSpeed` slowdown.
 const ICON_FRAME_FRAMES: int = 9
 const ICON_FRAMES: int = 2
 
 var _actors: Array = []
 var _world: Gen2WorldAPI = null
-## What the last `advance_frame` collected. Held rather than re-read, so two
-## views drawing the same frame draw the same thing and a mod's `sprites()` is
-## asked once a frame however many times the screen redraws.
+## Held rather than re-read, so a mod's `sprites()` is asked once a frame however
+## many times the screen redraws and two views agree.
 var _sprites: Array = []
 var _frame: int = 0
 
@@ -61,9 +54,8 @@ func set_world(world: Gen2WorldAPI) -> void:
 	_collect()
 
 
-## One world frame, spent after the player's own step has advanced so an actor
-## reading `player_step_offset_cells()` sees this frame's position rather than
-## the last one's. Answers whether anything it draws moved.
+## One world frame, spent after the player's step so an actor reading
+## `player_step_offset_cells()` sees this frame. Answers whether anything moved.
 func advance_frame() -> bool:
 	if _actors.is_empty():
 		return false
@@ -75,9 +67,8 @@ func advance_frame() -> bool:
 	return _changed(before, _sprites)
 
 
-## What to draw now, as { sprite, facing, frame, position_cells }, sorted the way
-## the map's own objects are: by the row they stand on, then by the order they
-## were registered in.
+## { sprite, facing, frame, position_cells }, sorted by the row stood on and then
+## by registration order, the way the map's own objects are.
 func sprites() -> Array:
 	return _sprites
 
@@ -94,9 +85,8 @@ func _collect() -> void:
 	_sprites.sort_custom(_sort)
 
 
-## One entry of a mod's answer. An entry naming art the cache does not carry is
-## dropped rather than drawn as a placeholder: a mod asking for a species icon
-## on a cartridge that has none should show nothing, not a magenta square.
+## One entry of a mod's answer. Art the cache does not carry is dropped rather
+## than drawn as a placeholder.
 func _resolve(entry: Variant, order: int) -> Dictionary:
 	if not entry is Dictionary:
 		return {}
@@ -105,10 +95,9 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 	if row.has("icon"):
 		sprite = _world.data.overworld_icon(int(row["icon"]))
 		if sprite != null:
-			## A map object's icon never animates: `GetUsedSprite` copies its
-			## eight tiles into both VRAM halves, so the walking rows of
-			## `Facings` land on the same picture. An actor is not a map object
-			## and asks for the two frames the strip carries.
+			# A map object's icon never animates: `GetUsedSprite` copies its
+			# eight tiles into both VRAM halves, so `Facings`' walking rows
+			# land on the same picture. An actor asks for both frames.
 			sprite.animate_icon_frames = true
 	elif row.has("sprite"):
 		sprite = _world.data.overworld_sprite(int(row["sprite"]))
@@ -127,17 +116,15 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 	}
 
 
-## Which of the sprite's frames is up this frame. A mon icon steps through its
-## own two at `.Frameset_PartyMon`'s rate; anything else is drawn standing,
-## since only the actor knows whether it is moving and `Facings`' walking rows
-## belong to a step this layer does not take.
+## A mon icon steps through its two at `.Frameset_PartyMon`'s rate; anything else
+## stands, since `Facings`' walking rows belong to a step this layer never takes.
 func _frame_for(sprite: Gen2WorldSprite) -> int:
 	if sprite.sprite_type != Gen2WorldSprite.TYPE_MON_ICON:
 		return 0
 	@warning_ignore("integer_division")
+	# Frame 1 is `Gen2WorldSprite.is_walking_frame`'s, which reads the strip's
+	# second half.
 	var step: int = (_frame / ICON_FRAME_FRAMES) % ICON_FRAMES
-	## Frame 1 is `Gen2WorldSprite.is_walking_frame`'s own, which is what reads
-	## the strip's second half.
 	return step
 
 

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -1,26 +1,23 @@
 class_name Gen2WorldCollision
 extends RefCounted
 
-## Generation 2 collision-code permissions.
+## Collision-code permissions. A map's grid stores the raw code from the
+## tileset's four-cell table and the game looks it up in a second table before
+## letting ordinary walking in; keeping that lookup here leaves the code itself
+## available for water, ledges and warps.
 ##
-## A map's collision grid stores the raw code from the tileset's four-cell table,
-## which the game looks up in a second table before deciding whether ordinary
-## walking can enter. Keeping that lookup here leaves the imported code available
-## for water, ledges and warps.
-##
-## The table below is the source [code]CollisionPermissionTable[/code] entry for
-## entry; all three games ship the same 256 bytes. Carried whole rather than as a
-## list of interesting codes, because a code left off such a list silently
-## becomes ordinary ground: that is how the waterfall, current and buoy families,
-## and one of the two headbutt trees, were walkable here.
+## [constant PERMISSIONS] is [code]CollisionPermissionTable[/code] entry for
+## entry, the same 256 bytes in all three games. Carried whole rather than as a
+## list of interesting codes: a code left off such a list silently becomes
+## ordinary ground, which is how the waterfall, current and buoy families and one
+## of the two headbutt trees were once walkable here.
 
 const LAND_TILE: int = 0x00
 const WATER_TILE: int = 0x01
 const WALL_TILE: int = 0x0F
-## The bit the source sets on a tile that answers to a button as well as
-## blocking or floating: cut and headbutt trees, whirlpools and buoys. It rides
-## on top of the permission rather than replacing it, so it is masked off before
-## the permission is compared.
+## Set on a tile that answers to a button as well as blocking or floating: cut
+## and headbutt trees, whirlpools and buoys. It rides on top of the permission,
+## so it is masked off before the permission is compared.
 const TALK: int = 0x10
 
 ## One permission per collision code, sixteen to a row.
@@ -44,41 +41,33 @@ const PERMISSIONS: Array[int] = [
 ]
 
 
-## The permission the original engine uses for [param collision_code], with the
-## TALK bit masked off. Out-of-range values answer wall, which is the safe answer
-## for a corrupt map rather than silently opening it; every value a cartridge can
-## store is in the table.
+## The engine's permission for [param collision_code], TALK masked off. Out of
+## range answers wall rather than silently opening a corrupt map; every value a
+## cartridge can store is in the table.
 static func permission_for(collision_code: int) -> int:
 	if collision_code < 0 or collision_code >= PERMISSIONS.size():
 		return WALL_TILE
 	return PERMISSIONS[collision_code] & ~TALK
 
 
-## Whether the source lets the player face [param collision_code] and press A:
-## a cut or headbutt tree, a whirlpool or a buoy. The permission still blocks or
-## floats; this is the other half of the same byte.
+## Whether the player may face [param collision_code] and press A. The permission
+## still blocks or floats; this is the other half of the same byte.
 static func talks(collision_code: int) -> bool:
 	if collision_code < 0 or collision_code >= PERMISSIONS.size():
 		return false
 	return (PERMISSIONS[collision_code] & TALK) != 0
 
 
-## Normal walking only accepts cells whose permission is LAND. Water and
-## special collision codes need stateful movement rules that are not part of
-## this first runtime slice.
+## Normal walking accepts LAND alone; water and the special codes are stateful.
 static func is_walkable(collision_code: int) -> bool:
 	return permission_for(collision_code) == LAND_TILE
 
 
-## Grass: home/map_objects.asm's SetTallGrassFlags, which is what sets an
-## object's IN_GRASS_F and so what puts it in the tufts.
-##
-## Two kinds, and the source keeps them apart: CheckSuperTallGrassTile names the
-## long grass on its own (the Bug Contest doubles its encounter rate,
-## engine/overworld/events.asm's TryWildEncounter_BugContest), and CheckGrassTile
-## answers the rest by nybble. It is not the encounter gate: CheckGrassCollision
-## is, and that one includes water, which is how one routine gates a surf roll
-## too.
+## home/map_objects.asm's SetTallGrassFlags, which sets an object's IN_GRASS_F.
+## Two kinds kept apart: CheckSuperTallGrassTile names the long grass alone (the
+## Bug Contest doubles its encounter rate, `TryWildEncounter_BugContest`) and
+## CheckGrassTile answers the rest by nybble. Neither is the encounter gate;
+## [method gates_encounter] is.
 const HI_NYBBLE_TALL_GRASS: int = 0x10
 const HI_NYBBLE_WATER: int = 0x20
 const LO_NYBBLE_GRASS: int = 0x07
@@ -90,8 +79,7 @@ const GRASS_TALL: int = 1
 const GRASS_LONG: int = 2
 
 
-## Which kind of grass a cell is, or [constant GRASS_NONE]. One call rather than
-## two for a renderer that draws the two heights differently.
+## Which grass a cell is, one call for a renderer drawing the two heights apart.
 static func grass_kind(collision_code: int) -> int:
 	if is_long_grass(collision_code):
 		return GRASS_LONG
@@ -100,8 +88,7 @@ static func grass_kind(collision_code: int) -> int:
 	return GRASS_NONE
 
 
-## Whether standing on [param collision_code] puts an object in grass at all,
-## which is SetTallGrassFlags' own condition.
+## SetTallGrassFlags' own condition.
 static func is_grass(collision_code: int) -> bool:
 	return grass_kind(collision_code) != GRASS_NONE
 
@@ -111,11 +98,10 @@ static func is_long_grass(collision_code: int) -> bool:
 	return collision_code == COLL_LONG_GRASS or collision_code == COLL_LONG_GRASS_1C
 
 
-## engine/overworld/tile_events.asm's CheckGrassCollision: the ten codes it
-## searches, in its own order. This is the encounter gate, which is why it is a
-## list rather than the nybble test grass_kind() uses: COLL_WATER is on it, so
-## one routine gates a surf roll too, and COLL_TALL_GRASS_10 is not, so the
-## unused tall-grass code carries tufts without carrying encounters.
+## engine/overworld/tile_events.asm's CheckGrassCollision, in its own order: a
+## list rather than grass_kind()'s nybble test because COLL_WATER is on it, so
+## one routine gates a surf roll, and COLL_TALL_GRASS_10 is not, so that code
+## carries tufts without encounters.
 const COLL_WATER: int = 0x29
 const ENCOUNTER_TILE_CODES: Array[int] = [
 	0x08,             # COLL_CUT_08
@@ -131,8 +117,7 @@ const COLL_ICE: int = 0x23
 const COLL_ICE_2B: int = 0x2B
 
 
-## CheckGrassCollision: whether standing on [param collision_code] is a tile a
-## wild encounter can be rolled on at all.
+## CheckGrassCollision: whether a wild encounter can be rolled here at all.
 static func gates_encounter(collision_code: int) -> bool:
 	return ENCOUNTER_TILE_CODES.has(collision_code)
 
@@ -154,12 +139,10 @@ static func _check_grass_tile(collision_code: int) -> bool:
 	return (collision_code & LO_NYBBLE_GRASS) == 0
 
 
-## Ledges: engine/overworld/player_movement.asm's .TryJump. Attempted only after
-## an ordinary step into the faced cell is blocked, reading the collision code of
-## the cell the player already stands on (wPlayerTileCollision). All eight hop
-## codes are LAND_TILE in PERMISSIONS, so the player walks onto one normally; the
-## hop bypasses collision on both the intervening and landing cells, as the
-## source never checks either.
+## Ledges: engine/overworld/player_movement.asm's .TryJump, attempted only after
+## an ordinary step is blocked and read off the cell the player already stands on
+## (wPlayerTileCollision). All eight hop codes are LAND_TILE, so the player walks
+## onto one normally, and the hop itself checks neither cell it crosses.
 const HI_NYBBLE_LEDGES: int = 0xA0
 const COLL_HOP_RIGHT: int = 0xA0
 const COLL_HOP_LEFT: int = 0xA1
@@ -178,12 +161,10 @@ const FACE_LEFT: int = 2
 const FACE_UP: int = 4
 const FACE_DOWN: int = 8
 
-## .ledge_table, entry for entry, indexed by a hop code's low three bits.
-## .TryJump computes this index as [code] & 7 after only checking the high
-## nybble is HI_NYBBLE_LEDGES, so codes $A8-$AF alias into this same table
-## rather than being rejected; that quirk is preserved by allows_hop() below
-## rather than papered over, since those codes are unused in every pinned
-## tileset and the source itself does not special-case them.
+## .ledge_table, indexed by a hop code's low three bits. .TryJump checks the high
+## nybble alone before masking with 7, so $A8-$AF alias into this table rather
+## than being rejected; allows_hop() preserves that, since no pinned tileset uses
+## those codes and the source does not special-case them.
 const LEDGE_FACE_MASK: Array[int] = [
 	FACE_RIGHT,               # COLL_HOP_RIGHT
 	FACE_LEFT,                # COLL_HOP_LEFT
@@ -210,10 +191,8 @@ static func face_mask_for_direction(direction: Vector2i) -> int:
 	return 0
 
 
-## Whether standing on [param collision_code] lets the player hop toward
-## [param direction], matching .TryJump bit for bit: the high nybble must be
-## HI_NYBBLE_LEDGES and the low three bits must index a .ledge_table entry
-## whose mask includes the pressed direction.
+## .TryJump bit for bit: the high nybble must be HI_NYBBLE_LEDGES and the low
+## three must index a .ledge_table entry whose mask includes the press.
 static func allows_hop(collision_code: int, direction: Vector2i) -> bool:
 	if collision_code < 0 or collision_code > 0xFF:
 		return false
@@ -226,11 +205,10 @@ static func allows_hop(collision_code: int, direction: Vector2i) -> bool:
 	return (LEDGE_FACE_MASK[index] & face) != 0
 
 
-## Side walls and side buoys: home/map.asm's GetMovementPermissions and
+## Side walls and buoys: home/map.asm's GetMovementPermissions and
 ## engine/overworld/npc_movement.asm's CanObjectLeaveTile/WillObjectBumpIntoTile.
-## Unlike the ledge codes above, these stay their plain permission ($b0-$b7
-## LAND_TILE, $c0-$c7 WATER_TILE in PERMISSIONS) and additionally wall off one
-## or two of the standing tile's own edges by direction.
+## These keep their plain permission ($b0-$b7 LAND, $c0-$c7 WATER) and wall off
+## one or two of the standing tile's own edges as well.
 const HI_NYBBLE_SIDE_WALLS: int = 0xB0
 const HI_NYBBLE_SIDE_BUOYS: int = 0xC0
 const COLL_RIGHT_WALL: int = 0xB0
@@ -242,11 +220,9 @@ const COLL_DOWN_LEFT_WALL: int = 0xB5
 const COLL_UP_RIGHT_WALL: int = 0xB6
 const COLL_UP_LEFT_WALL: int = 0xB7
 
-## .MovementPermissionsData, entry for entry, indexed by a wall/buoy code's low
-## three bits: which of the standing tile's own edges it walls off, in FACE_*
-## terms. Numerically identical to LEDGE_FACE_MASK above; kept as its own
-## table because a ledge direction and a walled edge are different things, and
-## the source keeps them as two separate tables too.
+## .MovementPermissionsData, indexed by a wall or buoy code's low three bits:
+## which of the standing tile's edges it walls off, in FACE_* terms. Numerically
+## identical to LEDGE_FACE_MASK, and two tables in the source as well.
 const SIDE_WALL_FACE_MASK: Array[int] = [
 	FACE_RIGHT,               # COLL_RIGHT_WALL/BUOY
 	FACE_LEFT,                # COLL_LEFT_WALL/BUOY
@@ -259,11 +235,9 @@ const SIDE_WALL_FACE_MASK: Array[int] = [
 ]
 
 
-## The FACE_* mask of edges [param collision_code] walls off, or 0 when it is
-## not a side-wall or side-buoy code. .CheckHiNybble ANDs against $f0 before
-## comparing, so $b8-$bf and $c8-$cf alias onto the same eight entries as
-## $b0-$b7/$c0-$c7 rather than being rejected, the same way allows_hop()
-## preserves the $a8-$af ledge alias above.
+## The FACE_* mask of edges [param collision_code] walls off, or 0. .CheckHiNybble
+## ANDs against $f0 first, so $b8-$bf and $c8-$cf alias onto the same eight
+## entries, the way allows_hop() keeps the $a8-$af ledge alias.
 static func side_wall_face_mask(collision_code: int) -> int:
 	if collision_code < 0 or collision_code > 0xFF:
 		return 0
@@ -273,15 +247,12 @@ static func side_wall_face_mask(collision_code: int) -> int:
 	return SIDE_WALL_FACE_MASK[collision_code & 0x07]
 
 
-## engine/overworld/npc_movement.asm's CanObjectLeaveTile (leave rule, on
-## [param from_code]) and WillObjectBumpIntoTile (enter rule, on [param
-## to_code] at the destination). Both routines index a differently bit-packed
-## table than SIDE_WALL_FACE_MASK (GetSideWallDirectionMask's DOWN_MASK/
-## UP_MASK/LEFT_MASK/RIGHT_MASK, keyed by wWalkingDirection rather than
-## wFacingDirection), but produce the identical per-code, per-direction result;
-## this reuses the FACE_* table rather than re-encoding the same rule twice.
-## Both games ship byte-identical npc_movement.asm, so unlike tile_permissions()
-## below this never takes a profile argument.
+## engine/overworld/npc_movement.asm's CanObjectLeaveTile (on [param from_code])
+## and WillObjectBumpIntoTile (on [param to_code]). Both index a differently
+## bit-packed table, GetSideWallDirectionMask's, keyed by wWalkingDirection
+## rather than wFacingDirection, and produce the identical per-code result, so
+## the FACE_* table is reused instead of encoding the rule twice. Both games ship
+## npc_movement.asm byte identical, hence no profile argument here.
 static func side_wall_step_blocked(from_code: int, to_code: int, direction: Vector2i) -> bool:
 	var forward_face: int = face_mask_for_direction(direction)
 	if forward_face == 0:
@@ -291,20 +262,16 @@ static func side_wall_step_blocked(from_code: int, to_code: int, direction: Vect
 	return (side_wall_face_mask(to_code) & face_mask_for_direction(-direction)) != 0
 
 
-## home/map.asm's GetMovementPermissions: the wTilePermissions byte for a
-## player standing on [param standing_code] with the four cardinal neighbours
-## already read. The leave rule (side_wall_face_mask of the standing code) is
-## byte-identical between both games; the enter rule (whether a neighbour's own
-## wall faces back at the player) is not. pokegold/pokecrystal diverge only in
-## .ok_down/.ok_up/.ok_right/.ok_left: crystal ORs the matching FACE_* constant
-## on a match, gold always sets bit RIGHT, numerically FACE_DOWN, since
-## wFacingDirection and wWalkingDirection use transposed bit layouts and
-## .ok_down/.ok_up/.ok_right/.ok_left were written with the latter's RIGHT by
-## mistake. Every enter-rule match therefore blocks only DOWN on Gold/Silver.
-## No shipped Gold/Silver map carries a side-wall code whose low three bits
-## differ from 2 (COLL_UP_WALL, whose own FACE_UP mask cannot match any
-## opposite-face test below), so this split changes no pinned map's
-## reachability; it stays because a mod-authored map could reach it.
+## home/map.asm's GetMovementPermissions: the wTilePermissions byte for a player
+## standing on [param standing_code] with its four neighbours already read. The
+## leave rule is byte identical between the games; the enter rule is not. The
+## pins diverge only in .ok_down/.ok_up/.ok_right/.ok_left, where Crystal ORs the
+## matching FACE_* and Gold always sets bit RIGHT, numerically FACE_DOWN, because
+## those four were written with wWalkingDirection's transposed bit layout. So
+## every enter-rule match blocks DOWN alone on Gold and Silver. No shipped map of
+## theirs carries a side-wall code whose low three bits differ from 2
+## (COLL_UP_WALL, which no opposite-face test below can match), so the split
+## changes no pinned map; it stays because a mod-authored map could reach it.
 static func tile_permissions(
 	standing_code: int, up_code: int, down_code: int, left_code: int, right_code: int,
 	is_crystal: bool = true,
@@ -323,28 +290,24 @@ static func tile_permissions(
 	return permissions
 
 
-## Forced tiles: engine/overworld/player_movement.asm's DoPlayerMovement.CheckTile,
-## which runs in all three movement modes after .GetAction and before .CheckTurning,
-## .TryStep/.TrySurf and .CheckWarp. It reads the code of the cell the player
-## already stands on and overwrites wWalkingDirection, so the pressed direction is
-## discarded. A match reaches .continue_walk, whose .DoStep never consults
-## permissions, so a forced step ignores collision entirely.
+## Forced tiles: DoPlayerMovement.CheckTile, which runs in all three movement
+## modes after .GetAction and before .CheckTurning, .TryStep/.TrySurf and
+## .CheckWarp. It reads the cell the player already stands on and overwrites
+## wWalkingDirection, discarding the press; a match reaches .continue_walk, whose
+## .DoStep never consults permissions, so a forced step ignores collision.
 const HI_NYBBLE_CURRENT: int = 0x30
 const HI_NYBBLE_WALK: int = 0x40
 const HI_NYBBLE_WALK_ALT: int = 0x50
 const HI_NYBBLE_WARPS: int = 0x70
 const COLL_WHIRLPOOL: int = 0x24
 const COLL_WHIRLPOOL_2C: int = 0x2C
-## The two codes home/map_objects.asm's CheckWaterfallTile compares. The second
-## is marked unused in both pins and kept for the same reason the whole
-## permission table is: the source compares it.
+## home/map_objects.asm's CheckWaterfallTile. The second is marked unused in both
+## pins and kept because the source still compares it.
 const COLL_WATERFALL: int = 0x33
 const COLL_CURRENT_DOWN: int = 0x3B
-## home/map_objects.asm's CheckHeadbuttTreeTile, the same shape: the second code
-## is marked unused in both pins and kept because the source compares it. Both
-## are WALL_TILE | TALK in data/collision/collision_permissions.asm, exactly
-## like the two cut-tree codes, so the tree blocks and is faced rather than
-## stood on.
+## CheckHeadbuttTreeTile, the same shape and the same unused second code. Both
+## are WALL_TILE | TALK like the two cut-tree codes, so a tree blocks and is
+## faced rather than stood on.
 const COLL_HEADBUTT_TREE: int = 0x15
 const COLL_HEADBUTT_TREE_1D: int = 0x1D
 const COLL_DOOR: int = 0x71
@@ -355,19 +318,17 @@ const COLL_PIT: int = 0x60
 const COLL_PIT_68: int = 0x68
 
 
-## engine/overworld/tile_events.asm's CheckWarpCollision: a warp fires on the
-## two pit codes or on the whole $70 nybble, and nowhere else. A warp_event on
-## an ordinary floor tile is inert, which is what lets a player walk over
-## Burned Tower B1F's (10,8) instead of being sent back upstairs.
+## CheckWarpCollision: the two pit codes or the whole $70 nybble, and nowhere
+## else. A warp_event on ordinary floor is inert, which is what lets a player
+## walk over Burned Tower B1F's (10,8) instead of being sent upstairs.
 static func is_warp_tile(collision_code: int) -> bool:
 	if is_pit_tile(collision_code):
 		return true
 	return (collision_code & 0xF0) == HI_NYBBLE_WARPS
 
 
-## home/map_objects.asm's CheckPitTile, the two codes on their own. Read by
-## is_warp_tile() above and by MovementFunction_Strength, which stops a boulder
-## standing on one for good.
+## CheckPitTile, read by is_warp_tile() and by MovementFunction_Strength, which
+## stops a boulder standing on one for good.
 static func is_pit_tile(collision_code: int) -> bool:
 	return collision_code == COLL_PIT or collision_code == COLL_PIT_68
 
@@ -405,9 +366,8 @@ const WALK_ALT_DIRECTION: Array[Vector2i] = [
 
 ## The .warps branch accepts four codes and refuses every other $7x.
 const WARP_STEP_CODES: Array[int] = [COLL_DOOR, COLL_DOOR_79, COLL_STAIRCASE, COLL_CAVE]
-## CheckWarpFacingDown's complete list. It is broader than WARP_STEP_CODES:
-## RefreshPlayerSprite uses it only to choose the initial drawing direction,
-## while .CheckTile forces a downward step for four codes above.
+## CheckWarpFacingDown, broader than WARP_STEP_CODES because RefreshPlayerSprite
+## only chooses a drawing direction with it.
 const SPAWN_FACING_DOWN_CODES: Array[int] = [
 	COLL_DOOR, COLL_DOOR_79, COLL_STAIRCASE, 0x73, COLL_CAVE, 0x74, 0x7C, 0x75, 0x7D,
 ]
@@ -417,10 +377,9 @@ static func faces_down_on_spawn(collision_code: int) -> bool:
 	return SPAWN_FACING_DOWN_CODES.has(collision_code)
 
 
-## What .CheckTile does to a player standing on [param collision_code]:
-## [code]none[/code], [code]force_turn[/code] (CheckWhirlpoolTile matched, so
-## PLAYERMOVEMENT_FORCE_TURN queues Script_ForcedMovement) or [code]walk[/code]
-## with the direction the tile imposes. Branch order is the source's.
+## .CheckTile's answer: [code]none[/code], [code]force_turn[/code]
+## (CheckWhirlpoolTile matched, so PLAYERMOVEMENT_FORCE_TURN queues
+## Script_ForcedMovement) or [code]walk[/code]. Branch order is the source's.
 static func forced_action(collision_code: int) -> Dictionary:
 	if collision_code < 0 or collision_code > 0xFF:
 		return {"kind": &"none"}
@@ -441,13 +400,6 @@ static func forced_action(collision_code: int) -> Dictionary:
 	return {"kind": &"walk", "direction": direction}
 
 
-## Tile-collision std scripts: engine/events/std_collision.asm's
-## CheckFacingTileForStdScript, dispatched on A once object and background events
-## both find nothing. data/collision/collision_stdscripts.asm is byte identical
-## between the two repositories, but the std-script index each entry resolves to
-## is not: PCScript is 49 in Crystal and 43 in Gold/Silver, because Crystal's
-## table carries six extra phone entries earlier. Every other entry was recounted
-## in both and lands on the same index.
 ## CheckCounterTile (`home/map_objects.asm`). $98 ships in the table but no map
 ## uses it.
 const COLL_COUNTER: int = 0x90
@@ -462,6 +414,12 @@ const COLL_TV: int = 0x97
 const COLL_WINDOW: int = 0x9D
 const COLL_INCENSE_BURNER: int = 0x9F
 
+## engine/events/std_collision.asm's CheckFacingTileForStdScript, dispatched on A
+## once object and background events both find nothing.
+## data/collision/collision_stdscripts.asm is byte identical between the pins but
+## the index each entry resolves to is not: PCScript is 49 in Crystal and 43 in
+## Gold and Silver, Crystal's table carrying six extra phone entries earlier.
+## Every other entry was recounted in both and lands on the same index.
 const TILE_COLLISION_STD_INDEX_CRYSTAL: Dictionary = {
 	COLL_BOOKSHELF: 3,        # MagazineBookshelfScript
 	COLL_PC: 49,              # PCScript
@@ -485,14 +443,12 @@ const TILE_COLLISION_STD_INDEX_GOLD_SILVER: Dictionary = {
 }
 
 
-## CheckCounterTile. A counter is what CheckFacingObject doubles the facing
-## distance over, so an NPC behind one is talked to across it.
+## CheckCounterTile: what CheckFacingObject doubles the facing distance over.
 static func is_counter(collision_code: int) -> bool:
 	return collision_code in [COLL_COUNTER, COLL_COUNTER_98]
 
 
-## The std-script index [param collision_code] dispatches to on A, or -1 when
-## the code has no entry in TileCollisionStdScripts.
+## The std-script index dispatched on A, or -1 outside TileCollisionStdScripts.
 static func tile_collision_std_index(collision_code: int, is_crystal: bool) -> int:
 	var table: Dictionary = TILE_COLLISION_STD_INDEX_CRYSTAL if is_crystal \
 		else TILE_COLLISION_STD_INDEX_GOLD_SILVER

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -20,18 +20,16 @@ const MOVEMENT_PLAYER: int = 11
 const MOVEMENT_FOLLOW: int = 19
 const MOVEMENT_SCRIPTED: int = 20
 ## SPRITEMOVEDATA_STRENGTH_BOULDER. The constants file's comment column is hex,
-## which is why this is $19 and not 19: 19 is SPRITEMOVEDATA_FOLLOWING ($13)
-## above. A boulder decides nothing on its own, so it is deliberately in neither
-## movement_supported() nor movement_advances(); it only reacts to a push.
+## hence $19 and not 19, which is SPRITEMOVEDATA_FOLLOWING ($13). A boulder
+## decides nothing, so it is in neither movement_supported() nor
+## movement_advances() and only reacts to a push.
 const MOVEMENT_STRENGTH_BOULDER: int = 0x19
-## SPRITEMOVEDATA_SMASHABLE_ROCK, the row directly below the boulder and in
-## neither template set for the same reason: a rock decides nothing and only
-## reacts to being smashed. Its flags1 are the boulder's, minus the palette bit
-## and plus USE_OBP1, so nothing but the movement byte tells the two apart.
+## SPRITEMOVEDATA_SMASHABLE_ROCK, below the boulder and in neither set for the
+## same reason. Its flags1 are the boulder's minus the palette bit and plus
+## USE_OBP1, so only the movement byte tells the two apart.
 const MOVEMENT_SMASHABLE_ROCK: int = 0x18
-## SPRITEMOVEDATA_SUDOWOODO, the row above the rock and in neither template set
-## for the same reason. Route 36's weird tree is the only object in either game
-## on it, and `.CheckCanUseSquirtbottle` is the only reader.
+## SPRITEMOVEDATA_SUDOWOODO, in neither set for the same reason. Route 36's weird
+## tree is the only object on it and `.CheckCanUseSquirtbottle` the only reader.
 const MOVEMENT_SUDOWOODO: int = 0x17
 const MOVEMENT_SWIM_WANDER: int = 0x24
 ## The three rows data/sprites/map_objects.asm gives BIG_OBJECT in their palette
@@ -65,11 +63,10 @@ var object_type: int = 0
 var sight_range: int = 0
 var event_script: int = 0
 var event_flag: int = 0
-## Whether [member event_flag] was set when this object table was built.
-## `ReadObjectEvents` reads the flag at map load and `wMapObjects` carries the
-## answer until the next one, so a script that writes the flag while the map is
-## up moves nothing: only `appear` and `disappear`, which edit the live struct as
-## well, do. Kept across a mid-script object reload for that reason.
+## Whether [member event_flag] was set when the table was built.
+## `ReadObjectEvents` reads it at map load and `wMapObjects` carries the answer
+## until the next, so only `appear` and `disappear`, which edit the live struct
+## too, move anything mid-map. Kept across a mid-script object reload.
 var flag_hidden: bool = false
 var trainer_data: Dictionary = {}
 var facing: int = Gen2WorldSprite.FACING_DOWN
@@ -85,9 +82,8 @@ var deleted: bool = false
 var emote_id: int = -1
 var emote_visible: bool = false
 var emote_remaining: int = 0
-## Transient sub-cell presentation offset toward a cell this object already
-## committed to. The logical cell changes at the start of a step, not here;
-## a renderer reads this only to draw the approach to it.
+## Sub-cell presentation offset toward a cell already committed to: the logical
+## cell changes at the start of a step, and this only draws the approach.
 var step_direction: Vector2i = Vector2i.ZERO
 var step_frames_total: int = 0
 var step_frames_remaining: int = 0
@@ -141,15 +137,12 @@ static func from_event(
 	return out
 
 
-## Carries the live presentation of the object this one replaces at the same
-## index on the same map: the emote it is showing, the trail it is still being
-## drawn walking, and whether a movement stream deleted it.
-##
-## The cartridge never rebuilds an object struct for any of the reasons this
-## project rebuilds a record: `ApplyObjectFacing`, `CopyDECoordsToMapObject` and
-## the variable-sprite table all write into the struct that is already there.
-## Without this, a `turnobject` between a `showemote` and its `applymovement`
-## takes the emote down and empties the trail the script is waiting on.
+## Carries the live presentation of the object this replaces at the same index:
+## its emote, the trail it is still being drawn walking, and whether a movement
+## stream deleted it. The cartridge never rebuilds a struct for the reasons this
+## project rebuilds a record, `ApplyObjectFacing` and the rest writing into the
+## one already there, so without this a `turnobject` between a `showemote` and
+## its `applymovement` empties the trail the script is waiting on.
 func carry_presentation_from(previous: Gen2WorldObject) -> void:
 	if previous == null:
 		return
@@ -186,10 +179,9 @@ func is_strength_boulder() -> bool:
 	return movement == MOVEMENT_STRENGTH_BOULDER
 
 
-## TryRockSmashFromMenu's own test: GetFacingObject hands MAPOBJECT_MOVEMENT
-## back in `d` and the whole check is `cp SPRITEMOVEDATA_SMASHABLE_ROCK`. Unlike
-## the three below it that is the source asking the movement byte directly
-## rather than a palette flag the row happens to carry.
+## TryRockSmashFromMenu: `GetFacingObject` hands MAPOBJECT_MOVEMENT back in `d`
+## and the check is `cp SPRITEMOVEDATA_SMASHABLE_ROCK`. Unlike the three below,
+## that is the movement byte directly rather than a palette flag.
 func is_smashable_rock() -> bool:
 	return movement == MOVEMENT_SMASHABLE_ROCK
 
@@ -202,9 +194,8 @@ func is_sudowoodo() -> bool:
 
 ## OBJECT_PALETTE bit SWIMMING, which CanObjectMoveInDirection reads to pick
 ## WillObjectBumpIntoLand over WillObjectBumpIntoWater. Same shape as
-## is_strength_boulder(): data/sprites/map_objects.asm sets the bit on exactly the
-## SPRITEMOVEDATA_SWIM_WANDER row, so the movement template answers it. Only
-## Union Cave B2F's Lapras uses that row, in either game.
+## is_strength_boulder(): the bit sits on the SPRITEMOVEDATA_SWIM_WANDER row
+## alone, which only Union Cave B2F's Lapras uses.
 func is_swimming() -> bool:
 	return movement == MOVEMENT_SWIM_WANDER
 
@@ -250,10 +241,8 @@ func movement_supported() -> bool:
 	]
 
 
-## The supported templates that actually decide something on their own: the
-## three random-walk rows and the two random-spin rows. The standing and
-## fixed-facing rows resolve once in the source and never ask again, so a
-## per-frame driver skips them rather than re-deciding nothing every frame.
+## The templates that decide something: the three random-walk and two
+## random-spin rows. Standing and fixed-facing resolve once and never ask again.
 func movement_advances() -> bool:
 	return movement in [
 		MOVEMENT_WANDER, MOVEMENT_WALK_UP_DOWN, MOVEMENT_WALK_LEFT_RIGHT,
@@ -276,13 +265,10 @@ func visible_at(hour: int, time_of_day: int) -> bool:
 	return hour >= hour_1 or hour <= hour_2
 
 
-## A zero or negative flag is the cache's no-flag/default value. The source
-## uses $FFFF as the explicit always-visible sentinel, imported as -1.
-##
-## Read once, when the object table is built: `ReadObjectEvents` tests the flag
-## at map load and nothing re-tests it while the map is up, which is the whole
-## reason `appear` and `disappear` exist. A `setevent` on an object's own flag
-## therefore changes nothing on screen until the map is loaded again. See
+## A zero or negative flag is the cache's default; the source's always-visible
+## $FFFF is imported as -1. Read once, when the object table is built, which is
+## why `appear` and `disappear` exist and why a bare `setevent` on an object's
+## own flag changes nothing until the map is loaded again. See
 ## [member flag_hidden].
 func visible_with_state(hour: int, time_of_day: int, state: Gen2WorldState) -> bool:
 	return visible_at(hour, time_of_day) and not event_flag_active(state)
@@ -343,10 +329,9 @@ func tick_emote() -> bool:
 	return false
 
 
-## Starts the presentation offset for a step whose destination cell is
-## already committed. [param frames] is the caller's own step duration, kept
-## caller-side so a slow trainer approach and an ordinary walk can share this
-## helper without this class knowing which one is running.
+## Starts the presentation offset for a step whose cell is already committed.
+## [param frames] is the caller's duration, so a slow trainer approach and an
+## ordinary walk share this helper.
 func start_step(direction: Vector2i, frames: int) -> void:
 	queued_steps.clear()
 	scripted_steps = false
@@ -364,12 +349,10 @@ func queue_step(direction: Vector2i, frames: int) -> void:
 	_begin_step(direction, frames)
 
 
-## `Movement_tree_shake`: 24 frames of STEP_TYPE_SLEEP with OBJECT_ACTION_WEIRD_TREE.
-##
-## Nothing moves and nothing shakes but this object's own drawing:
-## `SetFacingWeirdTree` steps the frame counter every frame and takes its two
-## high bits, which is `walk_frame()` again, so Sudowoodo wobbles between its
-## standing drawing and its two walking ones where it stands.
+## `Movement_tree_shake`: 24 frames of STEP_TYPE_SLEEP with
+## OBJECT_ACTION_WEIRD_TREE. Nothing moves but the drawing: `SetFacingWeirdTree`
+## steps the frame counter and takes its two high bits, `walk_frame()` again, so
+## Sudowoodo wobbles between its standing and walking pictures where it stands.
 func queue_tree_shake(frames: int) -> void:
 	weird_tree = true
 	queue_wait(frames)
@@ -392,15 +375,14 @@ func _begin_step(direction: Vector2i, frames: int) -> void:
 	step_direction = direction
 	step_frames_total = maxi(0, frames)
 	step_frames_remaining = step_frames_total
-	## `NormalStep` calls `ShakeGrass` where it starts the step, and a queued
-	## stream starts its later steps here rather than at a call site, so the flag
-	## is raised here and read once by Gen2WorldAPI.take_grass_rustles().
+	# `NormalStep` calls `ShakeGrass` where it starts the step, and a queued
+	# stream starts its later steps here, so the flag is raised here and read
+	# once by Gen2WorldAPI.take_grass_rustles().
 	step_began = direction != Vector2i.ZERO
 
 
-## Consumes one frame of an in-flight step. Returns true when a frame was
-## consumed, false once the step has already finished, so a caller pacing by
-## call count rather than delta time can tell "still stepping" from "done".
+## One frame of an in-flight step; false once it has finished, so a caller pacing
+## by call count can tell "still stepping" from "done".
 func tick_step() -> bool:
 	if step_frames_remaining <= 0:
 		return false
@@ -409,8 +391,8 @@ func tick_step() -> bool:
 	step_frames_remaining -= 1
 	if step_frames_remaining <= 0:
 		if weird_tree:
-			## The 24 frames are not a multiple of the four-frame cycle, so
-			## unlike a step this one has to be stood back up by hand.
+			# The 24 frames are not a multiple of the four-frame cycle, so
+			# unlike a step this one has to be stood back up by hand.
 			weird_tree = false
 			step_frame = 0
 			frame = 0
@@ -427,9 +409,8 @@ func is_stepping() -> bool:
 
 
 ## One hardware frame of `SetFacingStepAction`. The counter is never cleared
-## here: `EndSpriteMovement` is what zeroes it on the cartridge, and every step
-## duration is a multiple of four, so a stopped object is already standing on
-## frame 0 or 2 without one. Frames 1 and 3 are the two walking drawings.
+## here, `EndSpriteMovement` doing it on the cartridge, and every step duration
+## is a multiple of four, so a stopped object already stands on frame 0 or 2.
 func advance_walk_frame() -> void:
 	step_frame = (step_frame + 1) & 0x0F
 	frame = walk_frame()
@@ -466,14 +447,10 @@ func step_offset(cell_pixels: int) -> Vector2i:
 	return Vector2i(int(round(offset.x)), int(round(offset.y)))
 
 
-## The same offset in fractional walk cells, from where the sprite is drawn back
-## to the committed cell. A renderer that does not think in hardware pixels reads
-## this instead of step_offset(), exactly as a renderer reads the player's
-## Gen2WorldAPI.player_step_offset_cells().
-##
-## One in-flight step is at most a cell behind. A scripted stream commits its
-## whole path at once, so its trail is as many cells behind as it has left to
-## draw.
+## The same offset in fractional walk cells, for a renderer that does not think
+## in hardware pixels, matching Gen2WorldAPI.player_step_offset_cells(). One
+## in-flight step is at most a cell behind; a scripted stream commits its whole
+## path at once, so its trail is as many cells behind as it has left to draw.
 func step_offset_cells() -> Vector2:
 	var behind := Vector2.ZERO
 	for entry: Dictionary in queued_steps:


### PR DESCRIPTION
A wording pass over the twenty-seven files in `game/` that were above 27 percent comment density. Source symbol plus a one-line reason, no essay, and the code byte for byte identical in every one:

```
diff <(git show HEAD:<f> | grep -vE '^\s*(#|$)') <(grep -vE '^\s*(#|$)' <f>)
```

is empty for all twenty-seven.

| | before | after |
|---|---|---|
| Files over 100 lines at 27 percent or more | 27 | 1 |
| `game/` comment lines | 19,021 / 100,814 (18.9%) | 18,477 / 100,270 (18.4%) |
| `game/import/rom_layout.gd` | 1,083 / 2,827 (38.3%) | 1,040 / 2,784 (37.4%) |

Three things fixed on the way rather than noted:

- `world_collision.gd`'s tile-collision std-script paragraph was attached to `COLL_COUNTER`, five constants above the two index tables it actually describes. It now sits on them.
- `world_actors.gd` and `world_object.gd` carried `##` doc comments inside function bodies, where only `#` means anything.

`rom_layout.gd` had its largest prose blocks tightened and is not going under 27 percent by wording: that would need 644 comment lines, two per block over its 315 blocks, and most of them are how an offset was located.

Unit tier green (2,676 tests, 121 scripts, 30 s), `tools/validate.gd -- all` exits 0 on all three cartridges, editor scan clean.