### PR TITLE
The player has a name and the bedroom is empty

### DIFF
--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -231,9 +231,9 @@ static func _characters() -> Dictionary:
 	table[0xE1] = "PK"
 	table[0xE2] = "MN"
 
-	# Substituted from RAM at print time. $14 is not among them: `charmap.asm`
-	# gives it no character and `CheckDict` no entry, it being TX_STRINGBUFFER
-	# one layer up. See [Gen2TextStream].
+	# Substituted from RAM at print time. $14 belongs here too and is
+	# [constant Gen2TextStream.CHAR_PLAY_G]'s, left to the command layer because
+	# it is TX_STRINGBUFFER to that one and only a character inside a literal.
 	table[0x38] = "<RED>"
 	table[0x39] = "<GREEN>"
 	table[0x3F] = "<ENEMY>"
@@ -249,8 +249,8 @@ static func _characters() -> Dictionary:
 	table[0x1F] = " "
 	table[0x25] = ""
 
-	# Line and box control. $16 is left out for $14's reason: to the command
-	# loop it is TX_FAR, and `CheckDict` has no `<CR>` entry.
+	# Line and box control. $16 is left out because the command loop reads it as
+	# TX_FAR and `CheckDict` has no `<CR>` entry.
 	table[0x22] = "\n"
 	table[0x4B] = "\n"
 	table[0x4C] = "\n"

--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -39,6 +39,12 @@ const TX_DAY: int = 0x15
 const TX_FAR: int = 0x16
 const TX_END: int = 0x50
 
+## `<PLAY_G>`, which is `TX_STRINGBUFFER`'s byte read as a character rather than
+## as a command. `constants/charmap.asm` maps it and `CheckDict` sends it to
+## `PlaceGenderedPlayerName`, so it is the player's name; 243 Crystal texts use
+## it and no Gold or Silver text does, their `CheckDict` having no entry for it.
+const CHAR_PLAY_G: int = 0x14
+
 ## What an unfilled slot in a decoded text opens with. A caller that knows the
 ## value puts it in through [method fill_marker]; one that does not can at least
 ## see that something belongs there.
@@ -238,7 +244,9 @@ static func _place(data: PackedByteArray, offset: int, context: Dictionary) -> D
 ## The `print_name` half of `CheckDict`. Everything else is a glyph.
 static func _dict(byte: int, context: Dictionary) -> String:
 	match byte:
-		0x52:
+		CHAR_PLAY_G, 0x52:
+			# `PlaceGenderedPlayerName` places `wPlayerName`, the same string
+			# `PrintPlayerName` does; the honorific is the Japanese build's.
 			return _name(context, "player", "<PLAYER>")
 		0x53:
 			return _name(context, "rival", "<RIVAL>")

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2817,7 +2817,30 @@ func dispatch_map_entry() -> Array:
 		_queue_map_callbacks(-1)
 		if not _map_entry_scene_ran:
 			_map_entry_scene_pending = true
-	return run_event_queue(false)
+	var events: Array = run_event_queue(false)
+	load_object_masks()
+	return events
+
+
+## `LoadObjectMasks` (engine/overworld/map_objects_2.asm), which is what actually
+## masks an object rather than `ReadObjectEvents`: that one copies every event
+## into `wMapObjects` without looking at a flag.
+##
+## The distinction is the whole reason this is a step of its own.
+## `MapSetupScript_Warp` runs `LoadMapAttributes`, then `HandleNewMap`, whose
+## `MAPCALLBACK_NEWMAP` is where `ToggleDecorationsVisibility` sets the four
+## `EVENT_PLAYERS_HOUSE_2F_*` flags for a decoration the player does not own, and
+## only then `LoadMapObjects`, which runs `MAPCALLBACK_OBJECTS` and calls this.
+## So a flag a map-entry callback writes is read *after* it is written. Reading
+## it while the record is built puts the console, both dolls and the big doll in
+## the player's bedroom on a new game, each drawn as the `SPRITE_CHRIS` its
+## unassigned variable sprite falls back to.
+func load_object_masks() -> void:
+	for object: Gen2WorldObject in objects:
+		object.flag_hidden = object.event_flag_active(state)
+	## `LoadObjectMasks` writes one mask byte an object out of `GetObjectTimeMask`
+	## and `CheckObjectFlag` together, which is what this already is.
+	set_object_time(object_hour, object_time_of_day)
 
 
 ## Starts the first active scripted object in the cell the player is facing.
@@ -5539,14 +5562,15 @@ func _load_objects(carry_presentation: bool = false) -> void:
 		var sprite_number: int = int(_variable_sprites.get(
 			source_sprite_number, source_sprite_number
 		))
-		## GetMonSprite's `.Variable` branch reads wVariableSprites and falls
-		## through to `.NoBreedmon` when the slot is still zero, which answers
-		## SPRITE_CHRIS (1) rather than nothing
+		## `GetMonSprite`'s `.Variable` branch reads wVariableSprites and falls
+		## through to `.NoBreedmon` on a zero slot, whose `ld a, WALKING_SPRITE`
+		## is 1 and so `SPRITE_CHRIS` by coincidence of two constant lists
 		## (engine/overworld/overworld.asm). So an object whose variable sprite
 		## no script has assigned yet is drawn, occupies its cell and is
 		## talkable. Copycat's House 2F is where it matters: SPRITE_COPYCAT is
 		## $fb and only the Copycat's own script assigns it, so without this she
-		## could not be reached to run it.
+		## could not be reached to run it. An object that should not be there at
+		## all is masked by [method load_object_masks], not by this fallback.
 		if sprite_number >= Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE:
 			sprite_number = SPRITE_CHRIS
 		var sprite: Gen2WorldSprite = null
@@ -5564,9 +5588,8 @@ func _load_objects(carry_presentation: bool = false) -> void:
 		if _object_facing_overrides.has(key):
 			object.facing = int(_object_facing_overrides[key])
 		## A reload that carries presentation is a refresh under a running
-		## script, not a map load, so the flag answer is carried with it;
-		## `ReadObjectEvents` is the only thing that reads the flag, and it runs
-		## once per map load.
+		## script, not a map load, so the flag answer is carried with it rather
+		## than re-read: [method load_object_masks] is a map-setup step.
 		if index < previous.size():
 			object.carry_presentation_from(previous[index] as Gen2WorldObject)
 			object.flag_hidden = (previous[index] as Gen2WorldObject).flag_hidden

--- a/tests/unit/test_text_stream.gd
+++ b/tests/unit/test_text_stream.gd
@@ -70,6 +70,19 @@ func test_a_name_with_nobody_to_ask_stays_a_marker() -> void:
 	assert_eq(decoded["text"], "<PLAYER>")
 
 
+func test_the_same_byte_is_a_buffer_command_and_the_player_inside_a_literal() -> void:
+	# Elm's "#MON's first partner, <PLAY_G>!": $14 after TX_START is a character
+	# `CheckDict` sends to `PlaceGenderedPlayerName`, not a second command.
+	var literal: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x00, 0x14, 0xE7, 0x50]), 0, {"player": "GOLD"}
+	)
+	assert_eq(literal["text"], "GOLD!")
+	var command: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x14, 0x03, 0x50]), 0, {"player": "GOLD", "buffers": {3: "TM24"}}
+	)
+	assert_eq(command["text"], "TM24")
+
+
 func test_a_string_buffer_is_read_by_number() -> void:
 	var decoded: Dictionary = Gen2TextStream.decode(
 		PackedByteArray([0x14, 0x03, 0x50]), 0, {"buffers": {3: "TM24"}}

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2402,9 +2402,9 @@ func test_event_flags_hide_objects_from_rendering_occupancy_and_dispatch() -> vo
 	assert_eq(world.dispatch_events(Vector2i(5, 6)).size(), 1)
 	assert_false(world.can_walk_to(Vector2i(5, 6)))
 
-	## `ReadObjectEvents` tests the flag at map load and nothing re-tests it while
-	## the map is up, so writing it moves nothing until the map is loaded again.
-	## That is why `appear` and `disappear` exist and edit the struct themselves.
+	## `LoadObjectMasks` reads the flag once a map load and nothing re-tests it
+	## while the map is up, so writing it moves nothing on its own. That is why
+	## `appear` and `disappear` exist and edit the struct themselves.
 	world.set_event_flag(7)
 	assert_eq(world.visible_objects().size(), 1)
 	assert_not_null(world.object_at(Vector2i(5, 6)))
@@ -2419,6 +2419,26 @@ func test_event_flags_hide_objects_from_rendering_occupancy_and_dispatch() -> vo
 	world.clear_event_flag(7)
 	assert_eq(world.visible_objects().size(), 1)
 	assert_eq(world.dispatch_events(Vector2i(5, 6)).size(), 1)
+
+
+func test_a_map_entry_masks_on_the_flags_its_own_callbacks_wrote() -> void:
+	## `MapSetupScript_Warp` runs `HandleNewMap`'s `MAPCALLBACK_NEWMAP` before
+	## `LoadMapObjects` calls `LoadObjectMasks`, so a flag the entry callback set
+	## hides its object on that entry rather than on the next map load. Reading
+	## the flag while the record is built instead is what put the bedroom's four
+	## decorations on screen for a new game.
+	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
+	assert_eq(world.visible_objects().size(), 1)
+
+	world.set_event_flag(7)
+	var _entry: Array = world.dispatch_map_entry()
+	assert_eq(world.visible_objects().size(), 0)
+	assert_true(world.can_walk_to(Vector2i(5, 6)))
+	assert_eq(world.dispatch_events(Vector2i(5, 6)).size(), 0)
+
+	world.clear_event_flag(7)
+	var _reentry: Array = world.dispatch_map_entry()
+	assert_eq(world.visible_objects().size(), 1)
 
 
 func test_event_dispatch_reports_decoded_records_without_running_scripts() -> void:

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -1,5 +1,12 @@
 extends RefCounted
 
+## The one cached "text" that is not one. `96:4081` is bank 96, `0x180081` in a
+## Gold or Silver dump, and the bytes there are a pointer table: `00 09 3a 42 03
+## 94 40 31 2d ...`, the same `00 09 xx 42 31 xx` row repeating. The reference
+## scanner reached it through bytes that are not commands, which is where the
+## parse failures and the unwired `0415` marker below come from too.
+const NOT_A_TEXT: Array[String] = ["96:4081"]
+
 var _r: RefCounted = null
 
 ## Reports how far the cached overworld script and text resources can be read.
@@ -77,6 +84,7 @@ func _validate(game_id: StringName) -> bool:
 	var invalid_text_samples: Array = []
 	var ram_addresses: Dictionary = {}
 	var number_markers: int = 0
+	var raw_bytes: Dictionary = {}
 	for raw_key: Variant in (text_value as Dictionary):
 		var raw_text: PackedByteArray = _pointer_bytes(data, String(raw_key), true)
 		var decoded: Dictionary = Gen2WorldScript.decode_text(raw_text)
@@ -89,6 +97,8 @@ func _validate(game_id: StringName) -> bool:
 		var text: String = String(decoded.get("text", ""))
 		_tally_ram_markers(text, ram_addresses)
 		number_markers += text.count(Gen2TextStream.NUMBER_MARKER)
+		_tally_raw_bytes(text, String(raw_key), raw_bytes)
+
 	print("%s: scripts=%d commands=%d terminal=%d parse_failures=%d texts=%d invalid_text=%d" % [
 		game_id, script_count, command_count, terminal_count, parse_failures,
 		(text_value as Dictionary).size(), invalid_text,
@@ -101,8 +111,9 @@ func _validate(game_id: StringName) -> bool:
 	print("  invalid_text_samples=%s" % JSON.stringify(invalid_text_samples))
 	print("  commands=%s" % command_names)
 	_print_ram_markers(data, ram_addresses, number_markers)
+	print("  raw_byte_markers=%s" % raw_bytes)
 	_print_standard_table(game_id)
-	return true
+	return raw_bytes.is_empty()
 
 
 ## Resolves one "bank:address" cache key through the runtime accessor.
@@ -113,6 +124,23 @@ func _pointer_bytes(data: GameData, key: String, text: bool) -> PackedByteArray:
 	var bank: int = int(parts[0])
 	var address: int = ("0x%s" % parts[1]).hex_to_int()
 	return data.world_text(bank, address) if text else data.world_script(bank, address)
+
+
+## The `<xx>` [method Gen2Text.character] leaves for a byte it has no character
+## for, which is a decoder gap rather than anything the cartridge draws: every
+## byte `PlaceString` reaches is either a glyph or a `CheckDict` entry. `$14`
+## reached the player as `?14?` mid-sentence in 243 Crystal texts before
+## `<PLAY_G>` was wired, so this is a failure and not a census.
+func _tally_raw_bytes(text: String, key: String, tally: Dictionary) -> void:
+	var found: Array[RegExMatch] = RegEx.create_from_string("<([0-9A-F]{2})>").search_all(text)
+	if found.is_empty():
+		return
+	if NOT_A_TEXT.has(key):
+		return
+	var bytes: PackedStringArray = PackedStringArray()
+	for match_result: RegExMatch in found:
+		bytes.append(match_result.get_string(1))
+	tally[key] = bytes
 
 
 ## Counts the `<RAM_xxxx>` markers one decoded text left behind.


### PR DESCRIPTION
Two reports from a Crystal new game.

### `?14?` where the player's name goes

`$14` is a text command **and** a character. `DoTextUntilTerminator` reads it as `TX_STRINGBUFFER`; `CheckDict` reads it as `<PLAY_G>`, whose `PlaceGenderedPlayerName` places `wPlayerName` — `<PLAYER>` under a second byte, the honorific being the Japanese build's. `Gen2TextStream._dict` had the `$52` half and not this one, so a byte inside a literal fell through to the character table, which has no entry, and `Gen2Text.character` returned its `<14>` marker. The font draws `<` and `>` as `?`.

pokegold ships neither the charmap entry nor the dict row, so no Gold or Silver text carries it. 243 Crystal texts do, Elm's `#MON's first partner, <PLAY_G>!` among them.

### The four decorations in the bedroom

An object's event flag is read by `LoadObjectMasks`, **not** by `ReadObjectEvents` — that one copies every event into `wMapObjects` without looking at a flag. `MapSetupScript_Warp` reaches the mask three steps after `LoadMapAttributes`:

```
LoadMapAttributes   ; ReadObjectEvents, no flag test
HandleNewMap        ; MAPCALLBACK_NEWMAP -> ToggleDecorationsVisibility sets the flags
LoadMapObjects      ; MAPCALLBACK_OBJECTS, then LoadObjectMasks reads them
```

So a flag a map-entry callback writes is read *after* it is written. We read it while building the record, before any callback ran, so `EVENT_PLAYERS_HOUSE_2F_CONSOLE` and its three siblings never hid anything. Their sprites are `SPRITE_VARS` slots no script had assigned, and `GetMonSprite`'s `.NoBreedmon` answers `WALKING_SPRITE`, which is 1 and so `SPRITE_CHRIS` — hence a heap of the player.

`Gen2WorldAPI.load_object_masks()` is that step, run at the end of `dispatch_map_entry()`.

### Proving it

`tools/checks/world_scripts.gd` grew `raw_byte_markers`: any byte `PlaceString` reaches that the decoder has no character for is a gap, since every such byte is a glyph or a `CheckDict` entry on the cartridge. It is a failure, not a census.

| | before | after |
|---|---|---|
| Crystal texts carrying a raw marker | 230 | 0 |
| Gold / Silver | 0 | 0 |

One named exemption, `96:4081`: bank 96, `0x180081` in a Gold or Silver dump, where the bytes are a pointer table the reference scanner speculated into the text list — the same source as the unwired `0415` marker and the parse failures.

Full tier green (3,026 tests over 149 scripts), `tools/validate.gd -- all` 48 topics PASS and exit 0, story walk clean on all three cartridges.

Two wrong source findings that caused these are corrected in `.claude/traps.md` and `HANDOFF.md`.