### PR TITLE
rom_layout.gd's comments are evidence, not commentary

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -157,7 +157,9 @@ subject. Before creating any file, name the existing one it cannot go in.
 - **Comments.** A source symbol plus a one-line reason. Comment non-obvious
   constraints and quirks; never restate the line below. No section banners, no
   doc comment on a self-evident function. Net new comment lines should stay a
-  small fraction of net new code lines.
+  small fraction of net new code lines. `rom_layout.gd` is the one exemption and
+  says why in its own header: a comment recording how an offset was located is
+  the evidence for that number, not an explanation of the code.
 
 When something changes, replace the old text. Never append a correction, and
 never let a file grow just because work happened.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -12,6 +12,11 @@ extends RefCounted
 ## about a specific dump, which is why an uncharacterised ROM is refused rather
 ## than guessed at, and an offset is only trustworthy alongside its check in
 ## [method RomImporter.verify_layout].
+##
+## So the comments here are dense on purpose and this file is the one exemption
+## from the density rule in `docs/CONTRIBUTING.md`: most of them record how an
+## offset was found, which is the evidence for a number rather than a restatement
+## of the code beside it. Tighten the wording, never delete the derivation.
 
 const SPECIES_COUNT: int = 251
 const NAME_LENGTH: int = 10


### PR DESCRIPTION
Closes the comment-density pass. Twenty-six of the twenty-seven files that were above the threshold came under it in #256; `rom_layout.gd` is the one left, and the owner's call is that it stays where it is.

It cannot reach the threshold by wording: that needs 644 comment lines, two per block across its 315 blocks, and most of those blocks record how an offset was located. Deleting them would leave 2,784 lines of numbers with nothing saying why any of them is right.

So the rule in `docs/CONTRIBUTING.md` now names its one exemption, and the file says why in its own header. Wording tightens; the derivation stays.

No code changed:

```
diff <(git show HEAD:game/import/rom_layout.gd | grep -vE '^\s*(#|$)') \
     <(grep -vE '^\s*(#|$)' game/import/rom_layout.gd)
```

is empty. Unit tier green, 2,678 tests over 121 scripts.