### PR TITLE
A pokepic is a menu box, and its picture is grey

### DIFF
--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -72,17 +72,23 @@ func draw(
 ## layers: drawn into a screen-sized buffer at its own coordinates and cropped
 ## back, so [method draw]'s placement stays the one piece of arithmetic. Opaque,
 ## because `MenuBox` fills its interior.
+##
+## [param palette] is the four colours the box is drawn with, and defaults to
+## `PAL_BG_TEXT`'s black on white. A box a CGB layout fills with a palette of the
+## map's own passes that one instead, which is what `_CGB_Pokepic` does.
 func render(
 	box: Gen2MenuBox, options: Array, cursor: int,
-	title: String = "", title_indent: int = 0, extras: Array = []
+	title: String = "", title_indent: int = 0, extras: Array = [],
+	palette: PackedColorArray = PackedColorArray()
 ) -> Image:
 	var width: int = Gen2Screen.WIDTH
 	var indices: PackedByteArray = PackedByteArray()
 	indices.resize(width * Gen2Screen.HEIGHT)
 	draw(box, options, cursor, indices, width, title, title_indent, extras)
+	var colors: PackedColorArray = palette if palette.size() >= 4 \
+		else Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 	return Gen2PicImage.from_indices(
-		indices, width, Gen2Screen.HEIGHT,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		indices, width, Gen2Screen.HEIGHT, colors
 	).get_region(Rect2i(box.border_position() * TILE, box.border_size() * TILE))
 
 

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -12,6 +12,10 @@ extends RefCounted
 
 const CHANNELS: int = 4
 
+## `PadFrontpic`'s box: every front pic is placed as 7x7 tiles whatever its own
+## size is.
+const FRONTPIC_TILES: int = 7
+
 
 ## An image [param width] x [param height] from a row-major index buffer.
 ## [param transparent_background] makes index 0 transparent: the hardware has no
@@ -132,6 +136,20 @@ static func x_flipped(image: Image) -> Image:
 	var out: Image = image.duplicate()
 	out.flip_x()
 	return out
+
+
+## `PadFrontpic` (engine/gfx/load_pics.asm) fills the 7x7 block a front pic is
+## placed in, and does not centre a smaller pic: it lays one blank tile column
+## before it and blank rows above it, so the pic is bottom-aligned one column in.
+## This is that left pad, in tiles, for a [param width]-tile-wide pic.
+##
+## [param mirrored] is `wBoxAlignment`, which `LoadOrientedFrontpic` reads:
+## reversing the columns leaves the trailing blank on the left instead, which for
+## a 5x5 is one column further in than a 6x6.
+static func frontpic_pad_columns(width: int, mirrored: bool = false) -> int:
+	if width >= FRONTPIC_TILES or width <= 0:
+		return 0
+	return FRONTPIC_TILES - 1 - width if mirrored else 1
 
 
 ## The same mirror on an index buffer, for a caller that will recolour it.

--- a/game/render/pokepic_page.gd
+++ b/game/render/pokepic_page.gd
@@ -1,0 +1,85 @@
+class_name Gen2PokepicPage
+extends RefCounted
+
+## `Pokepic` (engine/events/pokepic.asm): the box a script's `pokepic` command
+## shows a species in, on the hardware tile grid. `MenuBox` at
+## `menu_coords 6, 4, 14, 13`, then `PlaceGraphic` writing a 7x7 block of the
+## front pic one tile in from the box's top-left corner.
+##
+## `_CGB_Pokepic` fills the whole box with `PAL_BG_GRAY`, so the pic wears the
+## map's first background palette rather than the species' own colours: the
+## picture a script shows is grey.
+##
+## Node-free: the image is the whole product, so the box can be read back
+## headless.
+
+const TILE: int = Gen2Font.TILE
+
+## `PokepicMenuHeader`'s `menu_coords 6, 4, 14, 13`. Its flags byte is
+## MENU_BACKUP_TILES, which restores the map behind the box when `ClosePokepic`
+## runs; an overlay that is removed does that by existing, so no flag is carried.
+const BOX_LEFT: int = 6
+const BOX_TOP: int = 4
+const BOX_RIGHT: int = 14
+const BOX_BOTTOM: int = 13
+
+## `Coord2Tile` on `wMenuBorderTopCoord + 1` and `wMenuBorderLeftCoord + 1`:
+## the pic starts one tile inside the frame, which leaves the bottom interior
+## row of this box empty.
+const PIC_OFFSET: Vector2i = Vector2i(1, 1)
+
+## `_CGB_Pokepic`'s `ld a, PAL_BG_GRAY`, which is index 0 of
+## `constants/palette_constants.asm`'s background list and so slot 0 of whatever
+## eight the map is drawn with.
+const PALETTE_GRAY: int = 0
+
+
+static func menu_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(BOX_LEFT, BOX_TOP, BOX_RIGHT, BOX_BOTTOM, 0)
+
+
+## The box holding [param species] as an image of its own size, or null when the
+## cache cannot answer for the pic, the font or the palette.
+static func render(
+	data: GameData, species: int, map: Gen2WorldMap,
+	time_of_day: int = Gen2WorldPalette.TIME_MORNING
+) -> Image:
+	if data == null or map == null:
+		return null
+	var pic: Dictionary = data.species_pic(species)
+	if pic.is_empty():
+		return null
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		data.atlas_indices(pic["atlas"]), data.atlas(pic["atlas"]), pic
+	)
+	if cell.is_empty():
+		return null
+	var menu: Gen2MenuPage = Gen2MenuPage.from_data(data)
+	if menu == null:
+		return null
+	var slots: Array = Gen2WorldPalette.palette_slots(map.environment, time_of_day)
+	var palette: PackedColorArray = data.world_palette(int(slots[PALETTE_GRAY]))
+	if palette.size() < 4:
+		return null
+	var box: Gen2MenuBox = menu_box()
+	var image: Image = menu.render(box, [], -1, "", 0, [], palette)
+	image.blend_rect(
+		Gen2PicImage.from_indices(
+			cell["indices"], int(cell["width"]), int(cell["height"]), palette
+		),
+		Rect2i(Vector2i.ZERO, Vector2i(int(cell["width"]), int(cell["height"]))),
+		pic_position(int(cell["width"]) / TILE, int(cell["height"]) / TILE)
+	)
+	return image
+
+
+## Where a [param width] x [param height] pic lands inside the rendered box, in
+## pixels from its top-left corner: `PlaceGraphic`'s 7x7 block plus
+## [method Gen2PicImage.frontpic_pad_columns]' padding inside it.
+static func pic_position(width: int, height: int) -> Vector2i:
+	return (
+		PIC_OFFSET + Vector2i(
+			Gen2PicImage.frontpic_pad_columns(width),
+			Gen2PicImage.FRONTPIC_TILES - height
+		)
+	) * TILE

--- a/game/render/pokepic_page.gd.uid
+++ b/game/render/pokepic_page.gd.uid
@@ -1,0 +1,1 @@
+uid://d243qkoi8yens

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -491,7 +491,7 @@ func _show_pic(kind: int) -> void:
 		return
 	_pic_cell = cell
 	_pic_palette = palette
-	_pic_pad_columns = _pad_columns(int(cell["width"]) / TILE, mirrored)
+	_pic_pad_columns = Gen2PicImage.frontpic_pad_columns(int(cell["width"]) / TILE, mirrored)
 	_pic.size = Vector2(float(cell["width"]), float(cell["height"]))
 	_pic.position = Vector2(
 		float((PIC_AT.x + _pic_pad_columns) * TILE),
@@ -508,17 +508,6 @@ func _redraw_pic(colors: PackedColorArray) -> void:
 	_pic.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
 		_pic_cell["indices"], int(_pic_cell["width"]), int(_pic_cell["height"]), colors
 	))
-
-
-## Blank tile columns `PadFrontpic` leaves to the left of a pic in the 7x7 box.
-##
-## A full-width pic is padded on neither side. A narrower one takes one blank
-## column at the left, so `.right`'s column reversal leaves `PIC_TILES - 1 -
-## width` of the trailing blank on that side instead.
-static func _pad_columns(width: int, mirrored: bool) -> int:
-	if width >= PIC_TILES or width <= 0:
-		return 0
-	return PIC_TILES - 1 - width if mirrored else 1
 
 
 func _trainer_cell(trainer_class: int) -> Dictionary:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -69,7 +69,6 @@ var _clock: Gen2WorldClock = null
 var _audio_player: Gen2AudioPlayer = null
 var _audio_waiting: bool = false
 var _script_prompt: String = ""
-var _story_picture_backdrop: ColorRect = null
 var _story_picture: TextureRect = null
 var _battle_host: Gen2BattleScreen = null
 var _trainer_card_host: Gen2TrainerCardScreen = null
@@ -1123,6 +1122,14 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 		nearest.set_emote(0, true)
 		_script_prompt = "Debug effect sprite preview"
 	_renderer.refresh()
+	_refresh_labels()
+
+
+## Public screenshot driver for `Script_pokepic`'s box. The scripts that run one
+## are Elm's three balls and their neighbours, which no map reaches from a bare
+## warp, so the species is named here; everything else is the branch's own call.
+func preview_pokepic(species: int) -> void:
+	_show_story_picture(species)
 	_refresh_labels()
 
 
@@ -3118,29 +3125,25 @@ func _prompted_field_move_name(slot: int) -> String:
 	return _mon_display_name(member as Gen2SaveMon) if member is Gen2SaveMon else "#MON"
 
 
+## `Script_pokepic`'s box over the map, which is what a starter's ball and every
+## other `pokepic` shows. The map stays up behind it: `MENU_BACKUP_TILES` is what
+## `ClosePokepic` restores, and an overlay that is removed does that by existing.
 func _show_story_picture(species: int) -> void:
-	if _data == null:
+	if _data == null or _world == null:
 		return
-	var pic: Dictionary = _data.species_pic(species)
-	if pic.is_empty():
-		return
-	var image: Image = Gen2PicImage.from_atlas(
-		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(species)
+	var image: Image = Gen2PokepicPage.render(
+		_data, species, _world.current_map, _render_time_of_day()
 	)
+	if image == null:
+		return
 	_hide_story_picture()
-	_story_picture_backdrop = ColorRect.new()
-	_story_picture_backdrop.color = Color.WHITE
-	_story_picture_backdrop.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
-	_story_picture_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	_screen.display(_story_picture_backdrop)
 	_story_picture = TextureRect.new()
 	_story_picture.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_story_picture.texture = ImageTexture.create_from_image(image)
 	_story_picture.size = image.get_size()
-	_story_picture.position = (
-		Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) - Vector2(image.get_size())
-	) / 2.0
+	_story_picture.position = Vector2(
+		Gen2PokepicPage.menu_box().border_position() * Gen2Font.TILE
+	)
 	_story_picture.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_screen.display(_story_picture)
 
@@ -3185,9 +3188,6 @@ func _hide_story_picture() -> void:
 	if _story_picture != null:
 		_story_picture.queue_free()
 		_story_picture = null
-	if _story_picture_backdrop != null:
-		_story_picture_backdrop.queue_free()
-		_story_picture_backdrop = null
 
 
 func _sync_host_clock() -> void:

--- a/tests/unit/test_menu_page.gd
+++ b/tests/unit/test_menu_page.gd
@@ -7,6 +7,7 @@ extends GutTest
 ## border, the options and the cursor be told apart without a real cartridge.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
 
 const TILE: int = Gen2Font.TILE
 const WIDTH: int = Gen2Screen.WIDTH
@@ -127,3 +128,48 @@ func test_a_title_prints_only_when_the_flag_is_set() -> void:
 	var with_title: PackedByteArray = _blank()
 	_page.draw(titled, OPTIONS, 0, with_title, WIDTH, "LONGTITLEHERE", 2)
 	assert_true(_ink_in_tile(with_title, Vector2i(14, 4)), "the title ran past the corner")
+
+
+## `Pokepic`'s box is a `MenuBox` and a `PlaceGraphic`, so it is checked where
+## the box it is made of is. `PokepicMenuHeader`'s `menu_coords 6, 4, 14, 13` is
+## nine tiles by ten drawn, with a seven-wide interior the 7x7 pic fills and one
+## interior row left under it.
+func test_the_pokepic_box_is_the_headers_own_size() -> void:
+	var box: Gen2MenuBox = Gen2PokepicPage.menu_box()
+	assert_eq(box.border_position(), Vector2i(6, 4))
+	assert_eq(box.border_size(), Vector2i(9, 10))
+	assert_eq(box.interior(), Vector2i(7, 8))
+
+
+## `PadFrontpic` bottom-aligns a smaller pic one column in rather than centring
+## it, on top of `PlaceGraphic`'s own one-tile inset.
+func test_a_pokepic_smaller_than_the_block_is_padded_not_centred() -> void:
+	assert_eq(Gen2PokepicPage.pic_position(7, 7), Vector2i(TILE, TILE))
+	assert_eq(Gen2PokepicPage.pic_position(6, 6), Vector2i(2 * TILE, 2 * TILE))
+	assert_eq(Gen2PokepicPage.pic_position(5, 5), Vector2i(2 * TILE, 3 * TILE))
+
+
+func test_the_pokepic_box_draws_the_pic_inside_its_frame() -> void:
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	var image: Image = Gen2PokepicPage.render(data, BattleFixture.CHARMANDER, Gen2WorldMap.new())
+	assert_not_null(image)
+	assert_eq(image.get_size(), Vector2i(9, 10) * TILE)
+	## The atlas is filled with index 1, so a pic pixel is the map's own second
+	## background colour and the interior around it is the box's blank.
+	## Through [method Gen2PicImage.from_indices] rather than off the palette, so
+	## the comparison is against the same eight bits a channel the image holds.
+	var pic: Color = Gen2PicImage.from_indices(
+		PackedByteArray([1]), 1, 1,
+		data.world_palette(int(Gen2WorldPalette.palette_slots(
+			Gen2WorldMap.new().environment, Gen2WorldPalette.TIME_MORNING
+		)[Gen2PokepicPage.PALETTE_GRAY]))
+	).get_pixel(0, 0)
+	assert_eq(image.get_pixelv(Gen2PokepicPage.pic_position(7, 7)), pic, "the pic's corner")
+	## `lb bc, 7, 7` in an eight-row interior leaves the bottom row of it blank.
+	assert_ne(image.get_pixel(TILE, 8 * TILE + 1), pic, "the row under the pic")
+
+
+func test_the_pokepic_box_refuses_a_species_the_cache_does_not_hold() -> void:
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	assert_null(Gen2PokepicPage.render(data, BattleFixture.MAX_SPECIES + 1, Gen2WorldMap.new()))
+	assert_null(Gen2PokepicPage.render(data, BattleFixture.CHARMANDER, null))

--- a/tests/unit/test_pic_image.gd
+++ b/tests/unit/test_pic_image.gd
@@ -151,3 +151,15 @@ func test_x_flipped_leaves_the_source_alone() -> void:
 
 func test_x_flipped_tolerates_a_null_image() -> void:
 	assert_null(Gen2PicImage.x_flipped(null))
+
+
+## `PadFrontpic`'s three branches. A full-width pic is padded on neither side; a
+## narrower one takes one blank column at the left, and `LoadOrientedFrontpic`'s
+## column reversal moves the trailing blank there instead.
+func test_frontpic_pad_columns_is_padfrontpics_own_alignment() -> void:
+	assert_eq(Gen2PicImage.frontpic_pad_columns(7), 0)
+	assert_eq(Gen2PicImage.frontpic_pad_columns(6), 1)
+	assert_eq(Gen2PicImage.frontpic_pad_columns(5), 1)
+	assert_eq(Gen2PicImage.frontpic_pad_columns(6, true), 0)
+	assert_eq(Gen2PicImage.frontpic_pad_columns(5, true), 1)
+	assert_eq(Gen2PicImage.frontpic_pad_columns(0), 0, "a pic the cache has no size for")

--- a/tools/checks/pokepic.gd
+++ b/tools/checks/pokepic.gd
@@ -1,0 +1,88 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies `Script_pokepic`'s box against freshly imported real caches: the
+## whole species corpus on all three cartridges, drawn through the same
+## [Gen2PokepicPage] the world screen displays.
+##
+## What a sampled case cannot say: `PadFrontpic` gives a 5x5, a 6x6 and a 7x7
+## three different corners inside `PlaceGraphic`'s block, so a page that centres
+## a pic instead is right about roughly half the corpus. Every species is drawn
+## and its ink is required to sit inside the frame and above the interior's last
+## row, which is the row `lb bc, 7, 7` leaves empty in an eight-row interior.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- pokepic
+
+## `data/pokemon/base_stats/`'s own range.
+const FIRST_SPECIES: int = 1
+const LAST_SPECIES: int = 251
+
+## New Bark Town, whose group is untouched by the Gold and Silver map-id shifts
+## (`HANDOFF.md`, "What a Gold/Silver leg costs"). Any map would do: what the
+## box reads off one is its eight background palettes.
+const MAP_GROUP: int = 24
+const MAP_NUMBER: int = 4
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var map: Gen2WorldMap = _r.data.world_map(MAP_GROUP, MAP_NUMBER)
+	if not _r.check(map != null, "map %d/%d is missing." % [MAP_GROUP, MAP_NUMBER]):
+		return
+	var box: Gen2MenuBox = Gen2PokepicPage.menu_box()
+	var size: Vector2i = box.border_size() * Gen2Font.TILE
+	var sizes: Dictionary = {}
+	var drawn: int = 0
+	for species: int in range(FIRST_SPECIES, LAST_SPECIES + 1):
+		var image: Image = Gen2PokepicPage.render(_r.data, species, map)
+		if not _r.check(image != null, "species %d draws no box." % species):
+			continue
+		if not _r.check(
+			image.get_size() == size,
+			"species %d draws %s, not the header's %s." % [species, image.get_size(), size]
+		):
+			continue
+		drawn += 1
+		var pic: Dictionary = _r.data.species_pic(species)
+		var tiles := Vector2i(
+			int(pic["width"]) / Gen2Font.TILE, int(pic["height"]) / Gen2Font.TILE
+		)
+		sizes[tiles] = int(sizes.get(tiles, 0)) + 1
+		_check_placement(image, species, tiles)
+	_r.note("pokepic %d of %d species, sizes %s" % [
+		drawn, LAST_SPECIES - FIRST_SPECIES + 1, sizes
+	])
+
+
+## Where `PadFrontpic` says the pic is, and where it says it is not: the ink runs
+## to the block's own bottom-right corner, and the interior row below it is the
+## blank the box was filled with.
+func _check_placement(image: Image, species: int, tiles: Vector2i) -> void:
+	var at: Vector2i = Gen2PokepicPage.pic_position(tiles.x, tiles.y)
+	var blank: Color = image.get_pixel(1, 1 + Gen2Font.TILE)
+	var interior_rows: int = Gen2PokepicPage.menu_box().interior().y
+	_r.check(
+		_ink(image, Rect2i(at, Vector2i(tiles.x, tiles.y) * Gen2Font.TILE), blank),
+		"species %d draws nothing where PadFrontpic puts its pic." % species
+	)
+	_r.check(
+		not _ink(image, Rect2i(
+			Vector2i(Gen2Font.TILE, interior_rows * Gen2Font.TILE),
+			Vector2i(Gen2PicImage.FRONTPIC_TILES, 1) * Gen2Font.TILE
+		), blank),
+		"species %d draws on the interior row `lb bc, 7, 7` leaves empty." % species
+	)
+
+
+## Whether [param area] holds a pixel that is not the box's own blank.
+func _ink(image: Image, area: Rect2i, blank: Color) -> bool:
+	for y: int in area.size.y:
+		for x: int in area.size.x:
+			if image.get_pixel(area.position.x + x, area.position.y + y) != blank:
+				return true
+	return false

--- a/tools/checks/pokepic.gd.uid
+++ b/tools/checks/pokepic.gd.uid
@@ -1,0 +1,1 @@
+uid://ctmesyflne2lc

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -16,7 +16,8 @@ extends SceneTree
 ## `unown_wall` (`DisplayUnownWords`' box, read off a Ruins of Alph chamber's
 ## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
 ## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
-## `cut` (`OWCutAnimation`'s two halves and the jump shadow), or one of
+## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `pokepic`
+## (`Script_pokepic`'s box over the map, holding Chikorita), or one of
 ## [constant FIELD_ITEMS]' own names, which is the pack's USE on that item: the
 ## Itemfinder closes the pack over the world's answer, the Coin Case prints
 ## inside the pack, and the three in [constant FACE_UP_FIRST] each need their own
@@ -47,6 +48,9 @@ const FIELD_ITEMS: Dictionary = {
 const FACE_UP_FIRST: Array[StringName] = [
 	&"squirtbottle", &"card_key", &"basement_key",
 ]
+
+## `ElmsLabScript`'s left ball, which is the first `pokepic` a new game shows.
+const POKEPIC_SPECIES: int = 152
 
 const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_CUT: int = 12
@@ -139,6 +143,8 @@ func _process(_delta: float) -> bool:
 			## is what runs `special DisplayUnownWords` and puts the box up.
 			_screen.press_button(Gen2Button.A)
 			_screen.press_button(Gen2Button.A)
+		elif _kind == &"pokepic":
+			_screen.preview_pokepic(POKEPIC_SPECIES)
 		elif FIELD_ITEMS.has(_kind):
 			if _kind in FACE_UP_FIRST:
 				_screen.move_up()

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -33,7 +33,7 @@ const GROUPS: Dictionary = {
 	],
 	&"art": [
 		&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims",
-		&"overworld_effects", &"party_icons",
+		&"overworld_effects", &"party_icons", &"pokepic",
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",


### PR DESCRIPTION
`Script_pokepic` drew a full-screen white rectangle with the pic centred on it, which covered the map and gave a starter's ball no frame.

- `Gen2PokepicPage` is `Pokepic`'s own box: `MenuBox` at `menu_coords 6, 4, 14, 13`, `PlaceGraphic`'s 7x7 block one tile inside it, and `PadFrontpic`'s alignment within that block. The world screen displays it over the map the way it displays the Unown wall, so the map stays up behind it as `MENU_BACKUP_TILES` says.
- `_CGB_Pokepic` fills the whole box with `PAL_BG_GRAY`, slot 0 of the map's own eight, so the picture is grey and the frame wears the map's tint. `Gen2MenuPage.render` now takes the palette a CGB layout gives its box.
- `PadFrontpic`'s alignment had one owner and needed two: it moves to `Gen2PicImage.frontpic_pad_columns` and the Oak speech reads it from there.
- `tools/checks/pokepic.gd` draws all 251 species on all three cartridges: 251 of 251 each, covering all three pic shapes.

GUT 3,031 over 149 scripts green, `validate.gd -- all` exit 0 over 49 topics, `replay_world.gd` 30 routes 0 failures, and the story walk still reaches Red at 295 steps on Crystal and 292 on Gold and Silver.