### PR TITLE
The overworld's party menu is PartyMenu

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -779,11 +779,13 @@ func overworld_icon_indices(icon_number: int) -> PackedByteArray:
 
 
 ## `ReadMonMenuIcon`: the icon a species is drawn with in a party menu, or zero
-## when the cache does not hold the table. Its `cp EGG` answer is not modelled
-## because nothing here holds an egg; a mod species numbered past the
-## cartridge's own range has no row in the imported table and answers zero,
-## which is `ICON_NULL`.
-func mon_menu_icon(species: int) -> int:
+## when the cache does not hold the table. Its `cp EGG` is [param egg], which
+## this save model carries beside a real species rather than as species $fd. A
+## mod species numbered past the cartridge's own range has no row in the imported
+## table and answers zero, which is `ICON_NULL`.
+func mon_menu_icon(species: int, egg: bool = false) -> int:
+	if egg:
+		return RomLayout.ICON_EGG
 	var table: PackedByteArray = mon_menu_icon_table()
 	if species < 1 or species > table.size():
 		return 0

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -151,6 +151,11 @@ const MON_ICON_BYTES: int = MON_ICON_TILES * Gen2Tiles.TILE_BYTES
 const ICON_POINTER_COUNT: int = MON_ICON_COUNT + 1
 const ICON_POINTER_SIZE: int = 2
 
+## `constants/icon_constants.asm`'s `ICON_EGG`, which `ReadMonMenuIcon` answers
+## for species EGG rather than reading `MonMenuIcons`. It is the one icon no
+## species row names.
+const ICON_EGG: int = 28
+
 ## `HeldItemIcons` is `gfx/stats/mail.2bpp` and `gfx/stats/item.2bpp`, the two
 ## tiles `GetIconGFX` loads behind every icon's eight. The mail one is drawn by
 ## no party menu here: nothing imports `data/items/mail_items.asm`, so

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -48,6 +48,12 @@ const FIRST_PRINTABLE: int = 0x80
 ## is a bug someone will report and a dropped character is not.
 const UNKNOWN: int = 0xE6
 
+## `constants/charmap.asm`'s "#" is $54, which `CheckDict` prints as this word.
+## [method encode] writes the word rather than the code, since only the word has
+## glyphs; decoding $54 still answers "POKé", so a round trip is unchanged.
+const POKE_SHORTHAND: String = "#"
+const POKE_WORD: String = "POK\u00e9"
+
 ## The longest sequence one tile stands for: the apostrophe ligatures and PK/MN
 ## are two characters in one glyph. The word codes $54 ("POKé") and $4a ("PKMN")
 ## sit below FIRST_PRINTABLE and are decode-only; write "#" for $54 as the source
@@ -122,12 +128,16 @@ static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArra
 	var codes: Dictionary = _encodings() if font == FONT_MAIN else _battle_extra_encodings()
 	var out: PackedByteArray = PackedByteArray()
 	var at: int = 0
+	# `PlaceNextChar` hands $54 to `CheckDict`, whose `PlacePOKe` prints four
+	# characters, so the source's own "#" is four tiles and not one. Expanding
+	# here is what puts POKé on screen: $54 is no glyph and would draw a blank.
+	var expanded: String = text.replace(POKE_SHORTHAND, POKE_WORD)
 
-	while at < text.length():
+	while at < expanded.length():
 		var taken: int = 0
 		# Longest first, so "'s" wins over a "'" with no "s" code after it.
-		for length: int in range(mini(MAX_LIGATURE, text.length() - at), 0, -1):
-			var candidate: String = text.substr(at, length)
+		for length: int in range(mini(MAX_LIGATURE, expanded.length() - at), 0, -1):
+			var candidate: String = expanded.substr(at, length)
 			if codes.has(candidate):
 				out.append(codes[candidate])
 				taken = length
@@ -283,11 +293,6 @@ static func _encodings() -> Dictionary:
 		var text: String = table[code]
 		if not out.has(text):
 			out[text] = code
-
-	# constants/charmap.asm maps "#" to $54, the POKé ligature every source text
-	# writes. Encode only, so decoding $54 stays "POKé" and a round trip is not
-	# rewritten. Without it "a #MON!" draws a question mark.
-	out["#"] = 0x54
 
 	# charmap.asm maps "…" to $75, likewise below FIRST_PRINTABLE. Source text
 	# writes the character itself (Text_MoveForgetCount's "1, 2 and…"), so a line

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -16,8 +16,9 @@ extends RefCounted
 ## behind them are per-frame state and nothing else here holds it: [method
 ## advance] is one pass of `PlaySpriteAnimations` over them.
 ##
-## Not drawn: the eggs `PartyMenuCheckEgg` skips every quality for, which a
-## battle party cannot contain.
+## A row carrying `egg` is `PartyMenuCheckEgg`'s: its nickname and its icon are
+## drawn and every other quality is stepped past. Only the overworld menu can
+## show one; a battle party cannot hold an egg.
 
 const TILE: int = Gen2Font.TILE
 
@@ -172,8 +173,15 @@ func reset(rows: Array) -> void:
 			int(member.get("hp", 0)), int(member.get("max_hp", 0)),
 			Gen2BattleHud.HP_BAR_TILES * TILE
 		))
+		## `PlacePartyMenuHPBar` never runs for an egg, so the speed byte behind
+		## its icon is whatever the last party left in `wHPPals`. Zero here, the
+		## green one, rather than a stale byte no save can reproduce.
+		if bool(member.get("egg", false)):
+			speed = 0
 		_icons.append({
-			"icon": data.mon_menu_icon(int(member.get("species", 0))) if data != null else 0,
+			"icon": data.mon_menu_icon(
+				int(member.get("species", 0)), bool(member.get("egg", false))
+			) if data != null else 0,
 			"item": int(member.get("item", 0)) != 0,
 			"speed": speed,
 			"frame": -1,
@@ -288,6 +296,12 @@ func _draw_member(page: PackedByteArray, width: int, index: int, row: Dictionary
 		String(row.get("name", "")), page, width,
 		NICKNAME.x * TILE, (NICKNAME.y + step) * TILE
 	)
+	## Every quality below `PlacePartyNicknames` opens its loop with
+	## `PartyMenuCheckEgg` and steps past the row, so an egg is a nickname and
+	## an icon and nothing else. Reachable from the overworld menu only: a battle
+	## party cannot hold one.
+	if bool(row.get("egg", false)):
+		return
 	font.draw_text(
 		"%s/%s" % [
 			str(hp).lpad(HP_NUMBER_DIGITS), str(max_hp).lpad(HP_NUMBER_DIGITS),
@@ -307,6 +321,8 @@ func _draw_member(page: PackedByteArray, width: int, index: int, row: Dictionary
 ## gives every tile its own palette, and one index buffer carries one.
 func _blend_bar(image: Image, index: int, row: Dictionary) -> void:
 	var width: int = Gen2Screen.WIDTH
+	if bool(row.get("egg", false)):
+		return
 	var buffer: PackedByteArray = PackedByteArray()
 	buffer.resize(width * Gen2Screen.HEIGHT)
 	var hp: int = int(row.get("hp", 0))

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -621,27 +621,13 @@ func _tiles(map: PackedInt32Array, x: int, y: int, run: Array[int]) -> void:
 
 
 ## `PlaceString`, whose `CheckDict` expands the shorthand before a tile is drawn.
-##
-## `#` is `$54` and prints "POKé" as four characters; on this screen `$54` is a
-## dex sheet tile, so a byte placed as itself would draw part of the frame. The
-## expansion cannot go back through the encoder either, because "POKé" is the
-## shorthand's own text and encodes to `$54` again.
-const POKE_CODES: Array[int] = [0x8F, 0x8E, 0x8A, 0xEA]
-
-
+## That expansion is [method Gen2Text.encode]'s, which matters here more than
+## elsewhere: `$54` is a dex sheet tile on this screen, so a byte placed as
+## itself would draw part of the frame.
 func _text(map: PackedInt32Array, x: int, y: int, text: String) -> void:
-	var at: int = x
-	var first: bool = true
-	for part: String in text.split("#"):
-		if not first:
-			for code: int in POKE_CODES:
-				_put(map, at, y, code)
-				at += 1
-		first = false
-		var codes: PackedByteArray = Gen2Text.encode(part)
-		for index: int in codes.size():
-			_put(map, at + index, y, codes[index])
-		at += codes.size()
+	var codes: PackedByteArray = Gen2Text.encode(text)
+	for index: int in codes.size():
+		_put(map, x + index, y, codes[index])
 
 
 ## `PrintNum`, as the digits it writes. [param leading_zeros] is its own flag;

--- a/game/render/trainer_card_page.gd
+++ b/game/render/trainer_card_page.gd
@@ -388,11 +388,11 @@ func _tilemap(map: PackedInt32Array, tiles: Array[int], at: Vector2i) -> void:
 ## Printed text is character codes, which are tile numbers in the font's own
 ## window, so it goes into the same map as everything else.
 ##
-## `#` ($54) is not a tile: `PlacePOKe` prints `PlacePOKeText`, four characters,
-## so the label the source writes as "#DEX" occupies seven columns and reads
-## POKéDEX. Expanding it here is what that dict entry does.
+## `#` ($54) is not a tile: [method Gen2Text.encode] prints `PlacePOKe`'s four
+## characters for it, so the label the source writes as "#DEX" occupies seven
+## columns and reads POKéDEX.
 func _text(map: PackedInt32Array, text: String, at: Vector2i) -> void:
-	var codes: PackedByteArray = Gen2Text.encode(text.replace("#", "POKé"))
+	var codes: PackedByteArray = Gen2Text.encode(text)
 	for index: int in codes.size():
 		_put(map, at + Vector2i(index, 0), codes[index])
 

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -1,7 +1,18 @@
 class_name Gen2PartyScreen
 extends Control
 
-## Player party summary for a validated project save.
+## The party menu, in the two places it is opened from.
+##
+## Embedded in the overworld it is `PartyMenu` itself: `StartMenu_Pokemon` runs
+## `InitPartyMenuWithCancel`, `WritePartyMenuTilemap` and `PlacePartyMenuText`,
+## and `PokemonActionSubmenu` opens `MonSubmenu`'s box over the bottom of it. So
+## the embedded view is [Gen2PartyMenuPage] and [Gen2MenuPage] at hardware
+## resolution, in a [Gen2Screen] of its own, and the model below is what
+## `PartyMenuSelect` and `MonMenuLoop` answer.
+##
+## The launcher's own party view, which is not a cartridge screen, keeps the
+## window-resolution panel: it is opened from the save slots with a mouse and
+## carries the PC storage and development battle buttons that no cartridge has.
 
 ## Emitted only when embedded, mirroring Gen2BoxScreen.closed: the overworld
 ## start menu resumes on this rather than the screen navigating away with
@@ -11,6 +22,8 @@ signal closed(result: Dictionary)
 ## Gen2StartMenuScreen.action_chosen. Field moves need the live world, which
 ## belongs to the world screen, so the choice is reported rather than run here.
 signal action_chosen(action: Dictionary)
+
+const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
 const BACKGROUND: Color = Color("#09111f")
 const PANEL: Color = Color("#14233a")
@@ -40,6 +53,32 @@ const OPTION_TAKE: StringName = &"take"
 ## drops CANCEL rather than growing.
 const MAX_SUBMENU_ITEMS: int = 8
 
+## `PartyMenuStrings`' two rows this screen reaches: `ChooseAMonString` for
+## `PARTYMENUACTION_CHOOSE_POKEMON`, which `StartMenu_Pokemon` writes, and
+## `UseOnWhichPKMNString` for the `PARTYMENUACTION_HEALING_ITEM` that
+## `.SelectMilkDrinkRecipient` sets. Engine text no importer reads, like the rest
+## of `data/text/common_*.asm`.
+const PROMPT_CHOOSE: String = "Choose a #MON."
+const PROMPT_USE_ON_WHICH: String = "Use on which PKMN?"
+
+## `_PokemonNotEnoughHPText` and `_ItemCantUseOnMonText`, the two refusals the
+## heal transfer prints. Both are a `MenuTextbox` over the menu on the cartridge
+## and stand in the menu's own bottom box here, which is the divergence
+## `HANDOFF.md` records; the A or B they wait for is the same.
+const MESSAGE_NOT_ENOUGH_HP: String = "Not enough HP…"
+const MESSAGE_NO_EFFECT: String = "It won't have any effect."
+
+## `MonSubmenu.MenuHeader`'s `menu_coords 6, 0, SCREEN_WIDTH - 1,
+## SCREEN_HEIGHT - 1` with `.GetTopCoord`'s own top:
+## `1 + bottom - 2 * (count + 1)`, so the box grows upward from the bottom row.
+const SUBMENU_LEFT: int = 6
+const SUBMENU_RIGHT: int = 19
+const SUBMENU_BOTTOM: int = 17
+
+## `GiveTakeItemMenuData`'s `menu_coords 12, 12, SCREEN_WIDTH - 1,
+## SCREEN_HEIGHT - 1`, which is a fixed box rather than a grown one.
+const ITEM_MENU_BOX: Rect2i = Rect2i(12, 12, 7, 5)
+
 var _data: GameData = null
 var _data_override: GameData = null
 var _save: Gen2SaveData = null
@@ -66,12 +105,24 @@ var _item_menu_open: bool = false
 var _heal_user: int = -1
 var _heal_move: int = 0
 
+## The embedded view's own hardware screen and the two pages drawn into it.
+var _hardware: Gen2Screen = null
+var _view: TextureRect = null
+var _page: Gen2PartyMenuPage = null
+var _menu_page: Gen2MenuPage = null
+## A refusal standing in the menu's own bottom box, which the next A or B
+## clears. See [constant MESSAGE_NOT_ENOUGH_HP].
+var _message: String = ""
+var _elapsed: float = 0.0
+
 
 func _ready() -> void:
 	_data = _data_override if _data_override != null else _resolve_data()
 	_save = _save_override if _save_override != null else _resolve_save()
 	_build_ui()
 	_refresh()
+	## Only the hardware view has anything to spend a frame on.
+	set_process(_embedded)
 	# Not while embedded in the overworld: the world screen routes buttons here
 	# itself, and a focus ring appearing over the map would be the map's.
 	if not _embedded:
@@ -176,6 +227,14 @@ func _party_size() -> int:
 ## Button driver for the embedded overworld view, mirroring
 ## Gen2StartMenuScreen.handle_button. Returns whether the button was used.
 func handle_button(button: int) -> bool:
+	## `JoyWaitAorB` behind a refusal: the press that clears the box does nothing
+	## else, and a direction is not one of the two it waits for.
+	if not _message.is_empty():
+		if button == Gen2Button.A or button == Gen2Button.B:
+			_message = ""
+			_refresh()
+			return true
+		return false
 	if _party_size() == 0:
 		if button == Gen2Button.B:
 			close_embedded()
@@ -203,11 +262,31 @@ func _move_cursor(delta: int) -> void:
 			return
 		_submenu_cursor = wrapi(_submenu_cursor + delta, 0, _submenu_items.size())
 	else:
-		_member_cursor = wrapi(_member_cursor + delta, 0, _party_size())
+		_member_cursor = wrapi(_member_cursor + delta, 0, _row_count())
 	_refresh()
 
 
+## `InitPartyMenuWithCancel`, which every way into this menu goes through: the
+## party plus the CANCEL row `PlacePartyNicknames.end` prints after it.
+func _row_count() -> int:
+	return _party_size() + 1
+
+
+## Where the arrow is, which [Gen2PartyMenuPage] counts the same way.
+func _cursor_row() -> int:
+	return _member_cursor
+
+
+func _on_cancel_row() -> bool:
+	return _member_cursor >= _party_size()
+
+
 func _confirm() -> void:
+	## `PartyMenuSelect` answers CANCEL with the same carry a B press sets, so
+	## the row and the button are one path.
+	if _on_cancel_row() and not _submenu_open:
+		_cancel()
+		return
 	if _heal_user >= 0:
 		_choose_heal_target()
 		return
@@ -221,8 +300,7 @@ func _confirm() -> void:
 		_close_submenu()
 		return
 	if not bool(entry.get("available", false)):
-		_status.text = "%s is not available yet." % String(entry.get("label", ""))
-		_status.add_theme_color_override("font_color", MUTED)
+		_say("%s is not available yet." % String(entry.get("label", "")))
 		return
 	match StringName(entry.get("kind", &"")):
 		&"field_move":
@@ -275,9 +353,10 @@ func _open_heal_target(move: int) -> void:
 	var user: Gen2SaveMon = _save.party[_member_cursor]
 	var fifth: int = Gen2WorldPartyHost.one_fifth_max_hp(_data, user)
 	if fifth <= 0 or user.hp <= fifth:
-		## `_PokemonNotEnoughHPText`.
-		_status.text = "Not enough HP…"
-		_status.add_theme_color_override("font_color", MUTED)
+		## `.NotEnoughHP` prints and then returns 3, which is `.menu`: the
+		## submenu does not survive the refusal.
+		_say(MESSAGE_NOT_ENOUGH_HP)
+		_close_submenu()
 		return
 	_heal_user = _member_cursor
 	_heal_move = move
@@ -292,15 +371,13 @@ func _open_heal_target(move: int) -> void:
 ## the health it moves belongs to a save the world owns.
 func _choose_heal_target() -> void:
 	if _member_cursor == _heal_user:
-		_status.text = "It won't have any effect."
-		_status.add_theme_color_override("font_color", MUTED)
+		_say(MESSAGE_NO_EFFECT)
 		return
 	var target: Gen2SaveMon = _save.party[_member_cursor]
 	var target_max: int = Gen2SaveBattleAdapter.to_battle_mon(_data, target).max_hp() \
 		if not target.is_egg else 0
 	if target.is_egg or target.hp <= 0 or target.hp >= target_max:
-		_status.text = "It won't have any effect."
-		_status.add_theme_color_override("font_color", MUTED)
+		_say(MESSAGE_NO_EFFECT)
 		return
 	var action: Dictionary = {
 		"kind": &"heal_transfer",
@@ -347,6 +424,8 @@ func submenu_snapshot() -> Dictionary:
 		"item_menu": _item_menu_open,
 		"cursor": _submenu_cursor,
 		"member": _member_cursor,
+		"on_cancel": _on_cancel_row(),
+		"message": _message,
 		"items": _submenu_items.duplicate(true),
 	}
 
@@ -379,7 +458,125 @@ func _resolve_save() -> Gen2SaveData:
 	return Gen2GameRuntime.selected_save_or_null() if _data != null else null
 
 
+## `StartMenu_Pokemon`'s screen: the party menu owns all 160x144 of it, so the
+## view goes in a [Gen2Screen] of its own rather than into whatever window-
+## resolution parent added this one.
+func _build_hardware_ui() -> void:
+	_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
+	_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_hardware)
+	_view = TextureRect.new()
+	_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_hardware.display(_view)
+
+
+## One hardware frame of `PlaySpriteAnimations` over the icons. `FreezeMonIcons`
+## is what `MonSubmenu` calls before it draws its box, so a menu that is up
+## stops them where they stand.
+func _process(delta: float) -> void:
+	if _view == null or _page == null:
+		return
+	_elapsed += delta
+	var frames: int = 0
+	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		frames += 1
+	if frames == 0 or _submenu_open or _item_menu_open:
+		return
+	var rows: Array = _rows()
+	for _frame: int in frames:
+		_page.advance(rows, _cursor_row())
+	_render_hardware()
+
+
+## `WritePartyMenuTilemap`'s rows, in [Gen2BattleSwitchMenu]'s own shape plus the
+## `egg` [Gen2PartyMenuPage] needs, which a battle party never carries.
+func _rows() -> Array:
+	var out: Array = []
+	if _save == null:
+		return out
+	for index: int in _save.party.size():
+		var mon: Gen2SaveMon = _save.party[index]
+		if mon == null:
+			continue
+		out.append({
+			"index": index,
+			"species": mon.species,
+			"item": mon.item,
+			"name": _display_name(mon),
+			"level": mon.level,
+			"hp": mon.hp,
+			"max_hp": 0 if mon.is_egg else _max_hp(mon),
+			"status": mon.status,
+			"fainted": not mon.is_egg and mon.hp <= 0,
+			"egg": mon.is_egg,
+		})
+	return out
+
+
+## `PlacePartyMenuText`'s string: a refusal that is still standing, then the
+## recipient list's own action text, then `StartMenu_Pokemon`'s.
+func _prompt() -> String:
+	if not _message.is_empty():
+		return _message
+	return PROMPT_USE_ON_WHICH if _heal_user >= 0 else PROMPT_CHOOSE
+
+
+func _render_hardware() -> void:
+	if _view == null or _data == null:
+		return
+	if _page == null:
+		_page = Gen2PartyMenuPage.from_data(_data)
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _page == null:
+		return
+	var rows: Array = _rows()
+	var image: Image = _page.render(rows, _cursor_row(), _prompt())
+	if image == null:
+		return
+	if _menu_page != null and (_submenu_open or _item_menu_open):
+		var box: Gen2MenuBox = _submenu_box()
+		var menu: Image = _menu_page.render(box, _submenu_labels(), _submenu_cursor)
+		image.blend_rect(
+			menu, Rect2i(Vector2i.ZERO, menu.get_size()),
+			box.border_position() * Gen2Font.TILE
+		)
+	_view.texture = ImageTexture.create_from_image(image)
+
+
+## `.GetTopCoord` for the mon's own submenu, and `GiveTakeItemMenuData`'s fixed
+## box for the GIVE/TAKE it opens.
+func _submenu_box() -> Gen2MenuBox:
+	if _item_menu_open:
+		return Gen2MenuBox.from_coords(
+			ITEM_MENU_BOX.position.x, ITEM_MENU_BOX.position.y,
+			ITEM_MENU_BOX.end.x, ITEM_MENU_BOX.end.y, Gen2MenuBox.STATICMENU_CURSOR
+		)
+	return Gen2MenuBox.from_coords(
+		SUBMENU_LEFT, SUBMENU_BOTTOM + 1 - 2 * (_submenu_items.size() + 1),
+		SUBMENU_RIGHT, SUBMENU_BOTTOM, Gen2MenuBox.STATICMENU_CURSOR
+	)
+
+
+## `PopulateMonMenu` places the option strings themselves. The "(unavailable)"
+## the panel appends is the launcher's affordance and has no room in a box the
+## cartridge sized for a name, so an option this project does not act on says so
+## when it is chosen instead.
+func _submenu_labels() -> Array:
+	var out: Array = []
+	for entry: Variant in _submenu_items:
+		out.append(String((entry as Dictionary).get("label", "")))
+	return out
+
+
 func _build_ui() -> void:
+	if _embedded:
+		_build_hardware_ui()
+		return
 	var background := ColorRect.new()
 	background.color = BACKGROUND
 	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -455,7 +652,23 @@ func _build_ui() -> void:
 	footer.add_child(_status)
 
 
+## A refusal, in whichever box this view has: the menu's own bottom one when it
+## is the cartridge's screen, and the panel's status line when it is not.
+func _say(message: String) -> void:
+	if _embedded:
+		_message = message
+		_render_hardware()
+		return
+	if _status == null:
+		return
+	_status.text = message
+	_status.add_theme_color_override("font_color", MUTED)
+
+
 func _refresh() -> void:
+	if _embedded:
+		_render_hardware()
+		return
 	if _cards == null:
 		return
 	Gen2LauncherUI.clear(_cards)

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1098,3 +1098,36 @@ func _open_waterfall_world(badge: bool = true) -> void:
 	)
 	_world_screen._world.player_facing = Gen2WorldSprite.FACING_UP
 	_world_screen._world.movement_mode = Gen2WorldAPI.MOVEMENT_SURF
+
+
+## `InitPartyMenuWithCancel`: the row after the last member answers A with the
+## same carry a B press sets, so the menu closes from either.
+func test_the_cancel_row_closes_the_menu_the_way_b_does() -> void:
+	await _open_world()
+	var party: Gen2PartyScreen = await _open_party()
+	var members: int = _world_screen._embedded_party_save().party.size()
+	for _step: int in members:
+		party.handle_button(Gen2Button.DOWN)
+	assert_true(bool(party.submenu_snapshot()["on_cancel"]), "the cursor is past the party")
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_null(_world_screen._party_host)
+
+
+## A refusal stands in the menu's own bottom box and `JoyWaitAorB` holds there:
+## a direction does not answer it and the next A or B does nothing but clear it.
+func test_a_refusal_holds_the_menu_until_a_or_b() -> void:
+	await _open_world()
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	## STATS, the first row this project does not act on.
+	party.handle_button(Gen2Button.DOWN)
+	party.handle_button(Gen2Button.A)
+	var refused: Dictionary = party.submenu_snapshot()
+	assert_ne(String(refused["message"]), "", "the refusal is in the box")
+
+	assert_false(party.handle_button(Gen2Button.DOWN), "a direction is not one of the two")
+	assert_eq(int(party.submenu_snapshot()["cursor"]), int(refused["cursor"]))
+	assert_true(party.handle_button(Gen2Button.B))
+	assert_eq(String(party.submenu_snapshot()["message"]), "")
+	assert_true(bool(party.submenu_snapshot()["open"]), "and the submenu is still up")

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -323,3 +323,24 @@ func test_the_prompt_box_covers_the_bottom_four_rows() -> void:
 	)
 	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.PROMPT.x, Gen2PartyMenuPage.PROMPT.y), 0)
 	assert_eq(_ink_in_tile(image, 0, Gen2PartyMenuPage.TEXTBOX.y - 1), 0, "nothing above it")
+
+
+## `PartyMenuCheckEgg` opens every quality's loop below the nicknames, so an egg
+## is a name and nothing else. Reachable from the overworld menu alone.
+func test_an_egg_row_draws_its_nickname_and_no_other_quality() -> void:
+	var rows: Array = _rows(1)
+	rows[0]["egg"] = true
+	rows[0]["name"] = "EGG"
+	var image: Image = _render(rows)
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.NICKNAME.x, 1), 0, "the nickname")
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.HP_DIGITS.x + 1, 1), 0, "no HP numbers")
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.LEVEL.x, 2), 0, "no level")
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.HP_BAR.x, 2), 0, "no bar")
+	assert_eq(_ink_in_tile(image, Gen2PartyMenuPage.STATUS.x, 2), 0, "no status")
+
+
+## `ReadMonMenuIcon`'s `cp EGG`: the icon is the one no species row names.
+func test_an_egg_takes_the_egg_icon_rather_than_its_species_own() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.mon_menu_icon(FIXTURE_SPECIES), FIXTURE_ICON)
+	assert_eq(data.mon_menu_icon(FIXTURE_SPECIES, true), RomLayout.ICON_EGG)

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -51,16 +51,17 @@ func test_word_codes_expand() -> void:
 	assert_eq(Gen2Text.decode(PackedByteArray([0xE1, 0xE2]), 0, 4), "PKMN")
 
 
-## constants/charmap.asm maps "#" to $54, so a synthesized literal writes the
-## POKé ligature the way every source text does. Spelling it out instead is legal
-## but costs three extra tiles, because $54 is below FIRST_PRINTABLE and so
-## decode-only.
-func test_hash_encodes_the_poke_ligature_the_source_charmap_names() -> void:
-	assert_eq(Gen2Text.encode("#"), PackedByteArray([0x54]))
-	assert_eq(Gen2Text.encoded_length("a #MON!"), 7)
+## constants/charmap.asm maps "#" to $54, which `CheckDict` prints as four
+## characters, so a synthesized literal may write the shorthand the way every
+## source text does and still occupy the four tiles POKé takes. $54 itself is no
+## glyph, which is why the code is not what is written.
+func test_hash_encodes_the_word_the_source_dictionary_prints() -> void:
+	assert_eq(Gen2Text.encode("#"), Gen2Text.encode("POKé"))
+	assert_eq(Gen2Text.encoded_length("a #MON!"), 10)
 	assert_eq(Gen2Text.decode(Gen2Text.encode("#MON"), 0, 16), "POKéMON")
-	# Without the alias this drew UNKNOWN, the question-mark glyph.
-	assert_ne(Gen2Text.encode("#")[0], Gen2Text.UNKNOWN)
+	# Every code it writes is a glyph, which $54 is not.
+	for code: int in Gen2Text.encode("#"):
+		assert_true(code >= Gen2Text.FIRST_PRINTABLE, "code %02X is drawable" % code)
 	assert_eq(Gen2Text.encoded_length("POKéMON"), 7)
 
 

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -17,7 +17,11 @@ extends SceneTree
 ## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
 ## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
 ## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `pokepic`
-## (`Script_pokepic`'s box over the map, holding Chikorita), or one of
+## (`Script_pokepic`'s box over the map, holding Chikorita), the name of any
+## `preview_*` driver on the world screen without that prefix (`field_move` is
+## `PartyMenu` with a taught CUT on it, `start_menu`, `capture`, `move_forget`
+## and the rest; a `*_use` name is driven twice, since each call is one step of
+## its own sequence), or one of
 ## [constant FIELD_ITEMS]' own names, which is the pack's USE on that item: the
 ## Itemfinder closes the pack over the world's answer, the Coin Case prints
 ## inside the pack, and the three in [constant FACE_UP_FIRST] each need their own
@@ -51,6 +55,10 @@ const FACE_UP_FIRST: Array[StringName] = [
 
 ## `ElmsLabScript`'s left ball, which is the first `pokepic` a new game shows.
 const POKEPIC_SPECIES: int = 152
+
+## How a `kind` names one of [Gen2WorldScreen]'s own screenshot drivers, so
+## every `preview_*` on it is reachable from here rather than from nothing.
+const SCREEN_DRIVER: String = "preview_%s"
 
 const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_CUT: int = 12
@@ -149,6 +157,13 @@ func _process(_delta: float) -> bool:
 			if _kind in FACE_UP_FIRST:
 				_screen.move_up()
 			_screen.preview_field_item(int(FIELD_ITEMS[_kind]))
+		elif _screen.has_method(SCREEN_DRIVER % _kind):
+			## The screen's own `preview_*` drivers, by their name without the
+			## prefix. A `*_use` driver is one step per call, so it is called
+			## twice: the first opens the menu and the second answers it.
+			_screen.call(SCREEN_DRIVER % _kind)
+			if String(_kind).ends_with("_use"):
+				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
 		for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):


### PR DESCRIPTION
The start menu's POKéMON row opened a window-resolution panel of `Label` cards. It is now the cartridge's screen.

- Embedded in the overworld, `Gen2PartyScreen` draws `Gen2PartyMenuPage` in a `Gen2Screen` of its own, with `PokemonActionSubmenu` as a `Gen2MenuPage` box at `MonSubmenu.GetTopCoord`'s top (`1 + bottom - 2 * (count + 1)`) and `GiveTakeItemMenuData`'s fixed box for GIVE/TAKE. The launcher's party view keeps its panel: it is not a cartridge screen.
- Three model gaps the picture made visible: CANCEL is a row (every way in is `InitPartyMenuWithCancel`, and A there answers the carry B does); the two heal refusals are `JoyWaitAorB` in the menu's own bottom box, and `.NotEnoughHP` returns 3, so the submenu does not survive one; an egg is `PartyMenuCheckEgg`'s row, a nickname and `ICON_EGG` with every other quality stepped past.
- `#` is $54, which `CheckDict` prints as four characters and which is no glyph: "Choose a #MON." drew a blank tile where POKé belongs. `Gen2Text.encode` writes the word, and the trainer card and the dex drop their own copies of that expansion.
- `preview_world.gd` reaches every `preview_*` driver on the world screen by name: sixteen of them were callable from nothing.

GUT 3,035 over 149 scripts green (unit tier 2,685), `validate.gd -- all` exit 0 over 49 topics, `replay_world.gd` 30 routes 0 failures, story walk 295 steps on Crystal and 292 on Gold and Silver, 16 badges each.