### PR TITLE
A mart is BuyMenu, in the cartridge's own words

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -69,6 +69,7 @@ var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _gs_intro: Dictionary = {}
 var _menu_text: Dictionary = {}
+var _mart_text: Dictionary = {}
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 var _world_maps: Array = []
@@ -167,6 +168,8 @@ static func open_directory(path: String) -> GameData:
 	data._gs_intro = gs_intro if gs_intro is Dictionary else {}
 	var menu_text: Variant = manifest.get("menu_text", {})
 	data._menu_text = menu_text if menu_text is Dictionary else {}
+	var mart_text: Variant = manifest.get("mart_text", {})
+	data._mart_text = mart_text if mart_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
@@ -1295,6 +1298,14 @@ func copyright_palette() -> PackedColorArray:
 ## which is the caller's cue to use its own wording.
 func menu_text(key: String) -> String:
 	return String(_menu_text.get(key, ""))
+
+
+## One of `engine/items/mart.asm`'s own boxes, by the name
+## `RomLayout.MART_TEXT_AT` gives its stub, still carrying [Gen2TextStream]'s
+## markers for the quantity, the item name and the price. Empty on a cache
+## imported before them.
+func mart_text(name: String) -> String:
+	return String(_mart_text.get(name, ""))
 
 
 ## `.MenuDesc`'s line for one start-menu item, by the item's own kind. Empty for

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 63
+const FORMAT_VERSION: int = 64
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -336,6 +336,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not menu_text["ok"]:
 		return menu_text
 
+	var mart_text: Dictionary = verify_mart_text(rom, layout)
+	if not mart_text["ok"]:
+		return mart_text
+
 	var pack: Dictionary = verify_pack(rom, layout)
 	if not pack["ok"]:
 		return pack
@@ -1078,6 +1082,24 @@ static func verify_pokecenter_pc(rom: RomFile, layout: Dictionary) -> Dictionary
 				"message": "The Pokemon Center PC's %s text did not decode." % name,
 			}
 	return {"ok": true, "message": "The Pokemon Center PC verified."}
+
+
+## `engine/items/mart.asm`'s own `text_far` stubs, identified by content: all
+## twenty-nine have to decode and the standard welcome has to be the word the
+## shop opens with, which is what says the one pinned address is right.
+static func verify_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	for name: String in RomLayout.MART_TEXT_AT:
+		if read_oak_text(rom, layout, RomLayout.mart_text_offset(layout, name)).is_empty():
+			return {"ok": false, "message": "The mart's %s text did not decode." % name}
+	var welcome: String = read_oak_text(
+		rom, layout, RomLayout.mart_text_offset(layout, "welcome")
+	)
+	if not welcome.begins_with("Welcome!"):
+		return {
+			"ok": false,
+			"message": "The mart's welcome text is \"%s\", not the shop's own." % welcome,
+		}
+	return {"ok": true, "message": "The mart's texts verified."}
 
 
 ## `UnownWords`, twenty-six words in form order, A first. Empty on any failure,
@@ -3693,6 +3715,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"pc_palette": _import_pc_palette(rom, layout),
 		"gender_screen_palette": _import_gender_screen_palette(rom, layout),
 		"menu_text": _import_menu_text(rom, layout),
+		"mart_text": _import_mart_text(rom, layout),
 		"copyright_string": _import_copyright_string(rom, layout),
 		"copyright_palette": _import_copyright_palette(rom, layout),
 		"presents_palettes": _import_presents_palettes(rom, layout),
@@ -4363,6 +4386,14 @@ func _import_menu_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
+## The mart's own boxes, by the name `RomLayout.MART_TEXT_AT` gives each stub.
+func _import_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in RomLayout.MART_TEXT_AT:
+		out[name] = read_oak_text(rom, layout, RomLayout.mart_text_offset(layout, name))
+	return out
+
+
 ## The splash's object palettes: PREDEFPAL_GAMEFREAK_LOGO_OB on every profile,
 ## and on Crystal `gfx/splash/ditto.pal` with the sixteen-step fade
 ## `GameFreakLogo_Transform` walks through its third colour.
@@ -4977,6 +5008,15 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"tiles": RomLayout.BATTLE_FONT_TILES,
 			"first_code": 0,
 			"bits": 2,
+		},
+		# `'▲'`, the one tile a scrolling menu needs that no font strip carries:
+		# Crystal loads it out of a 2bpp sheet of its own and Gold and Silver
+		# out of the second tile of a 1bpp pair.
+		"up_arrow": {
+			"offset": int((layout.get("up_arrow", {}) as Dictionary).get("offset", -1)),
+			"tiles": 1,
+			"first_code": Gen2Text.UP_ARROW_CODE,
+			"bits": int((layout.get("up_arrow", {}) as Dictionary).get("bits", 2)),
 		},
 		"enemy_hud": {
 			"offset": int(layout["enemy_hud"]),

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1146,6 +1146,44 @@ const POKECENTER_PC_TEXT_AT: Dictionary = {
 	"closed": 0x446,
 }
 
+## Every `text_far` stub `engine/items/mart.asm` prints through, as its distance
+## from `MartHowManyText`. `GetMartDialogGroup.MartTextFunctionPointers` is what
+## groups them: the rooftop sale reads the standard group, the bargain shop asks
+## no quantity, and every other group's sold-out slot is `BuyMenuLoop` rather
+## than a text. The deltas are the same on all three cartridges, which ship the
+## whole routine byte identical.
+const MART_TEXT_AT: Dictionary = {
+	"how_many": 0x000,
+	"final_price": 0x005,
+	"bitter_intro": 0x03C,
+	"bitter_how_many": 0x041,
+	"bitter_final_price": 0x046,
+	"bitter_thanks": 0x04B,
+	"bitter_pack_full": 0x050,
+	"bitter_no_money": 0x055,
+	"bitter_come_again": 0x05A,
+	"bargain_intro": 0x05F,
+	"bargain_final_price": 0x064,
+	"bargain_thanks": 0x069,
+	"bargain_pack_full": 0x06E,
+	"bargain_sold_out": 0x073,
+	"bargain_no_money": 0x078,
+	"bargain_come_again": 0x07D,
+	"pharmacy_intro": 0x082,
+	"pharmacy_how_many": 0x087,
+	"pharmacy_final_price": 0x08C,
+	"pharmacy_thanks": 0x091,
+	"pharmacy_pack_full": 0x096,
+	"pharmacy_no_money": 0x09B,
+	"pharmacy_come_again": 0x0A0,
+	"welcome": 0x175,
+	"thanks": 0x192,
+	"no_money": 0x197,
+	"pack_full": 0x19C,
+	"come_again": 0x1A6,
+	"ask_more": 0x1AB,
+}
+
 ## `Landmarks` (data/maps/landmarks.asm): `db x + 8, y + 16` then a name pointer,
 ## so the stored bytes are already shadow-OAM coordinates and the raw x,y are
 ## screen pixels. Gold and Silver ship no `BATTLE TOWER`, so every landmark from
@@ -1578,6 +1616,9 @@ const GOLD_SILVER: Dictionary = {
 	"frames": 0xF88F2,
 	"bar_palettes": 0xAD2D,
 	"battle_font": 0xF86F2,
+	# `FontsExtra_SolidBlackAndUpArrowGFX`' second tile, which is 1bpp here and
+	# a 2bpp sheet of its own on Crystal. Both are unique in their dump.
+	"up_arrow": {"offset": 0xF9306, "bits": 1},
 	"enemy_hud": 0xF8BB2,
 	"player_hud": 0xF8BD2,
 	"exp_bar": 0xF8C02,
@@ -1836,6 +1877,7 @@ const GOLD_SILVER: Dictionary = {
 	"mart_table": 0x162FE,
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
+	"mart_text": 0x16063,
 	"fruit_trees": 0x44091,
 	## `SpawnPoints` and `Flypoints`, each located by the byte column that is the
 	## same on all three dumps: the spawn coordinates at a stride of four, and
@@ -1996,6 +2038,8 @@ const CRYSTAL: Dictionary = {
 	"frames": 0xF8800,
 	"bar_palettes": 0xA8BE,
 	"battle_font": 0xF8600,
+	# `FontsExtra2_UpArrowGFX`, its own 2bpp tile here.
+	"up_arrow": {"offset": 0xF9424, "bits": 2},
 	"enemy_hud": 0xF8AC0,
 	"player_hud": 0xF8AE0,
 	"exp_bar": 0xF8B10,
@@ -2215,6 +2259,7 @@ const CRYSTAL: Dictionary = {
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,
+	"mart_text": 0x15E0E,
 	"fruit_trees": 0x44097,
 	"spawn_points": 0x152AB,
 	"flypoints": 0x91C5E,
@@ -2711,6 +2756,14 @@ static func pokecenter_pc_text_offset(layout: Dictionary, name: String) -> int:
 	if at < 0 or not POKECENTER_PC_TEXT_AT.has(name):
 		return -1
 	return at + int(POKECENTER_PC_TEXT_AT[name])
+
+
+## Where the mart's `text_far` stub [param name] names sits.
+static func mart_text_offset(layout: Dictionary, name: String) -> int:
+	var at: int = int(layout.get("mart_text", -1))
+	if at < 0 or not MART_TEXT_AT.has(name):
+		return -1
+	return at + int(MART_TEXT_AT[name])
 
 
 ## `Credits_LoadBorderGFX.Frames`, as 16-tile block indices into the mon run.

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -39,6 +39,11 @@ const BATTLE_EXTRA_CHARACTERS: Dictionary = {
 	0x74: "№",
 }
 
+## `'▲'`, which `_LoadFontsExtra2` parks in the middle of that run: a scrolling
+## menu draws it and nothing else does, so it is the one code in $60 to $78 that
+## is a character under the main font as well.
+const UP_ARROW_CODE: int = 0x61
+
 ## The lowest code with a tile. Below it is a space, border, control code or a
 ## print-time name, so it is also the line between [method encode]'s range and
 ## what only [method decode] understands.
@@ -199,6 +204,7 @@ static func _characters() -> Dictionary:
 	table[0xE9] = "&"
 	table[0xEA] = "é"
 	table[0xEB] = "→"
+	table[UP_ARROW_CODE] = "▲"
 	table[0xEC] = "▷"
 	table[0xED] = "▶"
 	table[0xEE] = "▼"

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -1,0 +1,205 @@
+class_name Gen2MartPage
+extends RefCounted
+
+## `BuyMenu`'s screen (`engine/items/mart.asm`): `BlankScreen`, the money box
+## `PlaceMoneyTopRight` puts in the corner, `MenuHeader_Buy`'s scrolling list of
+## names and BCD prices, and the speech box `UpdateItemDescription` writes into.
+##
+## [Gen2WorldMartHost] owns the list, the money and the transaction; this is the
+## picture, and node-free so it can be read back headless. The quantity box is
+## `BuyItem_MenuHeader`, which stands over the speech box rather than replacing
+## it, and the yes/no over it is the host's own [Gen2MenuPage].
+##
+## Three things the source does that a redraw here has to keep:
+##
+## - `ScrollingMenu` draws no frame around the list. Only `ClearWholeMenuBox`
+##   runs, so the names sit on the blank screen and the arrows stand where a
+##   border would have been.
+## - The fourth row's price lands on the box's own bottom coordinate, row 11,
+##   because `.PrintBCDPrices` prints one row below a name that is already on
+##   the last row the height allows.
+## - `▼` is drawn whenever the list has arrows at all, while `▲` waits for
+##   `wMenuScrollPosition` to leave zero.
+
+const TILE: int = Gen2Font.TILE
+
+## `MoneyTopRightMenuHeader`: `menu_coords 11, 0, SCREEN_WIDTH - 1, 2`, with
+## `PlaceMoneyTextbox` printing `SCREEN_WIDTH + 1` past the border coordinate.
+const MONEY_AT: Vector2i = Vector2i(11, 0)
+const MONEY_SIZE: Vector2i = Vector2i(9, 3)
+const MONEY_TEXT_AT: Vector2i = Vector2i(12, 1)
+
+## `MenuHeader_Buy`: `menu_coords 1, 3, SCREEN_WIDTH - 1, TEXTBOX_Y - 1`, four
+## rows of eight columns. `ScrollingMenu_InitFlags` puts the cursor on the left
+## border coordinate itself and steps `$20`, which is two rows.
+const LIST_AT: Vector2i = Vector2i(1, 3)
+const LIST_RIGHT: int = 19
+const LIST_BOTTOM: int = 11
+const LIST_HEIGHT: int = 4
+const NAME_AT: Vector2i = Vector2i(2, 4)
+const ROW_STEP: int = 2
+## `ScrollingMenu_CallFunctions1and2` steps `wMenuData_ScrollingMenuWidth` from
+## the name before it calls function 2.
+const PRICE_COLUMN: int = NAME_AT.x + 8
+
+## `UpdateItemDescription`: `hlcoord 0, 12` with `lb bc, 4, SCREEN_WIDTH - 2`,
+## so a six-row frame across the screen, and the description at `decoord 1, 14`.
+const TEXTBOX_AT: Vector2i = Vector2i(0, 12)
+const TEXTBOX_SIZE: Vector2i = Vector2i(20, 6)
+const TEXT_AT: Vector2i = Vector2i(1, 14)
+const TEXT_SPACING: int = 2
+
+## `BuyItem_MenuHeader`: `menu_coords 7, 15, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1`.
+## `BuySellToss_UpdateQuantityDisplay` prints `×` and two digits one row in, and
+## `BuySell_DisplaySubtotal` the running total one cell past them.
+const QUANTITY_AT: Vector2i = Vector2i(7, 15)
+const QUANTITY_SIZE: Vector2i = Vector2i(13, 3)
+const QUANTITY_TEXT_AT: Vector2i = Vector2i(8, 16)
+const QUANTITY_DIGITS: int = 2
+const SUBTOTAL_AT: Vector2i = Vector2i(12, 16)
+
+## `ScrollingMenu_UpdateDisplay.CancelString`, the row a list of any length ends
+## with.
+const CANCEL: String = "CANCEL"
+
+## `Place2DMenuCursor`'s "▶" and the two arrows `SCROLLINGMENU_DISPLAY_ARROWS`
+## draws. The up arrow is the one code no font strip carries.
+const CURSOR_CODE: int = 0xED
+const DOWN_ARROW_CODE: int = 0xEE
+
+## `PRINTNUM_MONEY` with six digits: the `¥` is printed in front of the first
+## significant digit rather than at the field's left edge, so the whole thing is
+## seven cells right aligned.
+const MONEY_CELLS: int = 7
+
+var font: Gen2Font = null
+## Which text-box border the player chose, for the three boxes this draws.
+var frame_style: int = 0
+## `FontsExtra2_UpArrowGFX`, the single tile `'▲'` is drawn from.
+var _up_arrow: PackedByteArray = PackedByteArray()
+
+
+static func from_data(data: GameData) -> Gen2MartPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null:
+		return null
+	var out := Gen2MartPage.new()
+	out.font = glyphs
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	out._up_arrow = data.tile_indices("up_arrow")
+	return out
+
+
+## The whole screen. [param state] is what the host holds:
+##
+## [codeblock]
+## {
+##   "money": int,
+##   "rows": Array,      # {"name": String, "price": int} or {"cancel": true}
+##   "cursor": int,      # which visible row the arrow stands on
+##   "scrolled": bool,   # wMenuScrollPosition is past zero
+##   "text": String,     # the speech box's lines
+##   "quantity": int,    # -1 while no quantity box is up
+##   "subtotal": int,
+## }
+## [/codeblock]
+func render(state: Dictionary) -> Image:
+	if font == null:
+		return null
+	var width: int = Gen2Screen.WIDTH
+	var indices := PackedByteArray()
+	indices.resize(width * Gen2Screen.HEIGHT)
+	_draw_money(indices, width, int(state.get("money", 0)))
+	_draw_list(indices, width, state)
+	_draw_textbox(indices, width, String(state.get("text", "")))
+	if int(state.get("quantity", -1)) >= 0:
+		_draw_quantity(
+			indices, width, int(state["quantity"]), int(state.get("subtotal", 0))
+		)
+	return Gen2PicImage.from_indices(
+		indices, width, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+
+
+## `PRINTNUM_MONEY`'s own shape: `¥` against the number, the pair right aligned
+## in seven cells. `PrintBCDNumber` lays the prices down the same way.
+static func money_string(amount: int) -> String:
+	return ("¥%d" % maxi(amount, 0)).lpad(MONEY_CELLS)
+
+
+func _draw_money(indices: PackedByteArray, width: int, money: int) -> void:
+	font.draw_box(
+		frame_style, indices, width, MONEY_AT.x * TILE, MONEY_AT.y * TILE,
+		MONEY_SIZE.x, MONEY_SIZE.y
+	)
+	_text(indices, width, money_string(money), MONEY_TEXT_AT)
+
+
+func _draw_list(indices: PackedByteArray, width: int, state: Dictionary) -> void:
+	var rows: Array = state.get("rows", [])
+	var cursor: int = int(state.get("cursor", 0))
+	for index: int in mini(rows.size(), LIST_HEIGHT + 1):
+		var row: Dictionary = rows[index]
+		var at: Vector2i = NAME_AT + Vector2i(0, index * ROW_STEP)
+		if bool(row.get("cancel", false)):
+			_text(indices, width, CANCEL, at)
+			continue
+		_text(indices, width, String(row.get("name", "")), at)
+		_text(
+			indices, width, money_string(int(row.get("price", 0))),
+			Vector2i(PRICE_COLUMN, at.y + 1)
+		)
+	if cursor >= 0 and cursor < mini(rows.size(), LIST_HEIGHT + 1):
+		_code(
+			indices, width, CURSOR_CODE,
+			Vector2i(LIST_AT.x, NAME_AT.y + cursor * ROW_STEP)
+		)
+	if bool(state.get("scrolled", false)):
+		_up(indices, width, Vector2i(LIST_RIGHT, LIST_AT.y))
+	_code(indices, width, DOWN_ARROW_CODE, Vector2i(LIST_RIGHT, LIST_BOTTOM))
+
+
+func _draw_textbox(indices: PackedByteArray, width: int, text: String) -> void:
+	font.draw_box(
+		frame_style, indices, width, TEXTBOX_AT.x * TILE, TEXTBOX_AT.y * TILE,
+		TEXTBOX_SIZE.x, TEXTBOX_SIZE.y
+	)
+	var line: int = 0
+	for row: String in text.split("\n", false):
+		_text(indices, width, row, TEXT_AT + Vector2i(0, line * TEXT_SPACING))
+		line += 1
+
+
+func _draw_quantity(
+	indices: PackedByteArray, width: int, quantity: int, subtotal: int
+) -> void:
+	font.draw_box(
+		frame_style, indices, width, QUANTITY_AT.x * TILE, QUANTITY_AT.y * TILE,
+		QUANTITY_SIZE.x, QUANTITY_SIZE.y
+	)
+	## `PRINTNUM_LEADINGZEROS | 1` over two digits, which is what makes a single
+	## item read `×01`.
+	_text(
+		indices, width,
+		"×%s" % String.num_int64(maxi(quantity, 0)).lpad(QUANTITY_DIGITS, "0"),
+		QUANTITY_TEXT_AT
+	)
+	_text(indices, width, money_string(subtotal), SUBTOTAL_AT)
+
+
+func _text(indices: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
+	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE)
+
+
+func _code(indices: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
+	font.draw_code(code, indices, width, at.x * TILE, at.y * TILE)
+
+
+## `'▲'` comes off its own imported tile: it sits inside the run the battle font
+## owns, so neither strip [Gen2Font] draws from can answer for it. A cache
+## imported without it leaves the corner empty rather than drawing a wrong tile.
+func _up(indices: PackedByteArray, width: int, at: Vector2i) -> void:
+	if _up_arrow.size() < TILE * TILE:
+		return
+	Gen2Font.blit_slot(_up_arrow, TILE, 0, indices, width, at.x * TILE, at.y * TILE)

--- a/game/render/mart_page.gd.uid
+++ b/game/render/mart_page.gd.uid
@@ -1,0 +1,1 @@
+uid://1h0ae5kb2sgp

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -26,6 +26,9 @@ enum MODE {
 ## region map, so the top menu is still there when the box screen closes.
 const BOX_SCENE := preload("res://game/save/box_screen.tscn")
 
+## `BuyMenu`'s own 160x144, which a window-resolution panel cannot host.
+const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
+
 ## engine/pokegear/pokegear.asm's card order. Each is behind its own
 ## wPokegearFlags bit, named here by the engine flag that carries it, since that
 ## is what the state holds. The clock card needs no flag.
@@ -37,6 +40,30 @@ const POKEGEAR_CARDS: Array[Dictionary] = [
 ]
 
 const WorldMenu := preload("res://game/world/world_menu.gd")
+
+## `BuyMenuLoop`'s four states: the list `ScrollingMenu` runs, the quantity
+## `SelectQuantityToBuy` asks for, `MartConfirmPurchase`'s yes/no, and a box
+## waiting on `JoyWaitAorB`.
+const MART_LIST: StringName = &"list"
+const MART_QUANTITY: StringName = &"quantity"
+const MART_CONFIRM: StringName = &"confirm"
+const MART_MESSAGE: StringName = &"message"
+## Which of `GetMartDialogGroup.MartTextFunctionPointers`' groups a variant
+## reads. The rooftop sale takes the standard group, which is why it has no
+## prefix of its own; the bargain shop's `MARTTEXT_HOW_MANY` slot is
+## `BuyMenuLoop` rather than a text, so it asks no quantity.
+const MART_TEXT_PREFIX: Dictionary = {
+	&"standard": "", &"bitter": "bitter_", &"bargain": "bargain_",
+	&"pharmacy": "pharmacy_", &"rooftop_mart_1": "", &"rooftop_mart_2": "",
+}
+## `PlayTransactionSound`, once the money has been taken.
+const SFX_TRANSACTION: int = 0x22
+## `Textbox`'s interior, which is what a mart box's words are wrapped to.
+const MART_TEXT_COLUMNS: int = 18
+const MART_TEXT_ROWS: int = 2
+## `hMoneyTemp` is HRAM and `wItemQuantityChange` is not, which is how a
+## `text_decimal` marker says which of the two numbers it wants.
+const HRAM_FIRST: int = 0xFF00
 
 var _world: Gen2WorldAPI = null
 var _data: GameData = null
@@ -52,6 +79,18 @@ var _cursor: int = 0
 var _mart_entries: Array = []
 var _mart_quantity: int = 1
 var _mart_purchased: bool = false
+## `BuyMenu`'s screen, which owns all 160x144 the way the region map does: the
+## scrolling list's own scroll and cursor, which of `BuyMenuLoop`'s four states
+## it is in, and the boxes waiting on a press.
+var _mart_hardware: Gen2Screen = null
+var _mart_view: TextureRect = null
+var _mart_page: Gen2MartPage = null
+var _mart_menu_page: Gen2MenuPage = null
+var _mart_stage: StringName = MART_LIST
+var _mart_scroll: int = 0
+var _mart_pages: Array = []
+var _mart_after: StringName = MART_LIST
+var _mart_confirm: int = 0
 var _apricorns: Gen2WorldApricorn = null
 var _pokegear_cards: Array = []
 var _town_map: Gen2TownMapScreen = null
@@ -203,6 +242,9 @@ func handle_button(button: int) -> bool:
 	if _mode == MODE.APRICORN:
 		_press_apricorns(button)
 		return true
+	if _mode == MODE.MART:
+		_press_mart(button)
+		return true
 	if _mode == MODE.CARD and _pokegear != null:
 		return _pokegear.handle_button(button)
 	## The panel is behind the box screen while BILL'S PC is open, the way it is
@@ -283,18 +325,325 @@ func _open_menu(input: Dictionary) -> void:
 	_render_options()
 
 
-func _open_mart(mart: Dictionary) -> void:
+## `BuyMenu`, which is a screen of its own rather than a box over the map: the
+## panel steps aside for it the way it does for the region map, and the shop's
+## own intro box is the first thing it prints.
+func _open_mart(_mart: Dictionary) -> void:
 	_mode = MODE.MART
 	_refresh_mart_entries()
 	_mart_quantity = 1
 	_mart_purchased = false
+	_mart_scroll = 0
 	_cursor = 0
-	_title.text = String(mart.get("label", "MART"))
-	_summary.text = "Money: %d" % _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT)
-	_status.text = "One of each item per visit." if StringName(mart.get("variant", &"")) == &"bargain" \
-		else "Select an item. Left and right change the quantity."
-	_footer.text = "D-pad: move and quantity    A: buy    B: leave"
-	_render_options()
+	_panel.visible = false
+	if _mart_hardware == null:
+		_mart_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
+		_mart_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		_mart_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_mart_hardware.z_index = 5
+		add_child(_mart_hardware)
+		_mart_view = TextureRect.new()
+		_mart_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		_mart_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+		_mart_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_mart_hardware.display(_mart_view)
+	_show_mart_text(_mart_text("intro"), MART_LIST)
+
+
+## One of the shop's own boxes, by the slot name its group gives it.
+func _mart_text(slot: String, filled: Dictionary = {}) -> String:
+	var prefix: String = String(MART_TEXT_PREFIX.get(
+		StringName(_mart_source().get("variant", &"standard")), ""
+	))
+	var name: String = prefix + slot
+	if slot == "intro" and prefix.is_empty():
+		name = "welcome"
+	var text: String = _data.mart_text(name)
+	if text.is_empty():
+		return ""
+	return _fill_mart_markers(text, filled)
+
+
+## `PartyMonItemName` and the two `text_decimal`s a mart box carries. The number
+## markers are told apart by their address rather than by their order, since the
+## bargain shop names the item first and the price second.
+func _fill_mart_markers(text: String, filled: Dictionary) -> String:
+	var out: String = Gen2TextStream.fill_marker(
+		text, Gen2TextStream.RAM_MARKER, String(filled.get("name", ""))
+	)
+	while true:
+		var at: int = out.find(Gen2TextStream.NUMBER_MARKER)
+		if at < 0:
+			break
+		var end: int = out.find(">", at)
+		if end < 0:
+			break
+		var address: int = out.substr(
+			at + Gen2TextStream.NUMBER_MARKER.length(),
+			end - at - Gen2TextStream.NUMBER_MARKER.length()
+		).hex_to_int()
+		out = out.substr(0, at) + String.num_int64(int(filled.get(
+			"total" if address >= HRAM_FIRST else "quantity", 0
+		))) + out.substr(end + 1)
+	return out
+
+
+## A box the shop is holding on, laid out into the pages `JoyWaitAorB` steps
+## through. An empty text goes straight on, which is what a cache imported
+## before the mart's own words leaves.
+func _show_mart_text(text: String, after: StringName) -> void:
+	_mart_after = after
+	_mart_pages = [] if text.strip_edges().is_empty() \
+		else Gen2TextLayout.lay_out(text, MART_TEXT_COLUMNS, MART_TEXT_ROWS)
+	if _mart_pages.is_empty():
+		_advance_mart_text()
+		return
+	_mart_stage = MART_MESSAGE
+	_render_mart()
+
+
+func _advance_mart_text() -> void:
+	if not _mart_pages.is_empty():
+		_mart_pages.remove_at(0)
+	if not _mart_pages.is_empty():
+		_render_mart()
+		return
+	if _mart_after == MART_LIST:
+		_mart_stage = MART_LIST
+		_render_mart()
+		return
+	_close_mart()
+	_finish_runtime({"ok": true, "script_value": 1 if _mart_purchased else 0})
+
+
+## `w2DMenuNumRows`: the CANCEL row is only on offer when the whole list fits,
+## because `ScrollingMenu_InitFlags` adds it to the row count and `.d_down`
+## stops scrolling at `size - height`.
+func _mart_row_count() -> int:
+	return _mart_entries.size() + 1 if _mart_entries.size() < Gen2MartPage.LIST_HEIGHT \
+		else Gen2MartPage.LIST_HEIGHT
+
+
+func _mart_rows() -> Array:
+	var out: Array = []
+	for row: int in _mart_row_count():
+		var index: int = _mart_scroll + row
+		out.append(
+			{"cancel": true} if index >= _mart_entries.size() else _mart_entries[index]
+		)
+	return out
+
+
+func _mart_selection() -> Dictionary:
+	var index: int = _mart_scroll + _cursor
+	return {} if index >= _mart_entries.size() else _mart_entries[index]
+
+
+func _press_mart(button: int) -> void:
+	match _mart_stage:
+		MART_MESSAGE:
+			if button in [Gen2Button.A, Gen2Button.B]:
+				_advance_mart_text()
+		MART_LIST:
+			_press_mart_list(button)
+		MART_QUANTITY:
+			_press_mart_quantity(button)
+		MART_CONFIRM:
+			_press_mart_confirm(button)
+
+
+func _press_mart_list(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			_move_mart_cursor(-1)
+		Gen2Button.DOWN:
+			_move_mart_cursor(1)
+		Gen2Button.B:
+			_leave_mart()
+		Gen2Button.A:
+			var entry: Dictionary = _mart_selection()
+			if entry.is_empty():
+				_leave_mart()
+				return
+			if bool(entry.get("sold_out", false)):
+				## `BargainShopAskPurchaseQuantity.SoldOut`, the one refusal that
+				## comes before a price is ever named.
+				_show_mart_text(_mart_text("sold_out", {"name": entry.get("name", "")}), MART_LIST)
+				return
+			_mart_quantity = 1
+			if StringName(_mart_source().get("variant", &"")) == &"bargain":
+				_ask_mart_confirm()
+				return
+			## `MARTTEXT_HOW_MANY` is printed before `SelectQuantityToBuy`, and
+			## the box stays up under the dial rather than waiting on a press.
+			_mart_pages = Gen2TextLayout.lay_out(
+				_mart_text("how_many"), MART_TEXT_COLUMNS, MART_TEXT_ROWS
+			)
+			_mart_stage = MART_QUANTITY
+			_render_mart()
+
+
+func _move_mart_cursor(delta: int) -> void:
+	var rows: int = _mart_row_count()
+	var next: int = _cursor + delta
+	if next < 0:
+		if _mart_scroll > 0:
+			_mart_scroll -= 1
+	elif next >= rows:
+		if _mart_entries.size() >= _mart_scroll + Gen2MartPage.LIST_HEIGHT:
+			_mart_scroll += 1
+	else:
+		_cursor = next
+	_render_mart()
+
+
+## `BuySellToss_InterpretJoypad`: one on up and down, ten on left and right,
+## against `wItemQuantity`, which `StandardMartAskPurchaseQuantity` sets to the
+## whole stack rather than to what the money or the pack allows.
+func _press_mart_quantity(button: int) -> void:
+	var maximum: int = Gen2WorldMartHost.MAX_ITEM_STACK
+	match button:
+		Gen2Button.UP:
+			_mart_quantity = 1 if _mart_quantity >= maximum else _mart_quantity + 1
+		Gen2Button.DOWN:
+			_mart_quantity = maximum if _mart_quantity <= 1 else _mart_quantity - 1
+		Gen2Button.RIGHT:
+			_mart_quantity = mini(_mart_quantity + 10, maximum)
+		Gen2Button.LEFT:
+			_mart_quantity = maxi(_mart_quantity - 10, 1)
+		Gen2Button.B:
+			_mart_stage = MART_LIST
+		Gen2Button.A:
+			_ask_mart_confirm()
+			return
+	_render_mart()
+
+
+## `MartConfirmPurchase`: the price box and the yes/no over it.
+func _ask_mart_confirm() -> void:
+	var entry: Dictionary = _mart_selection()
+	_mart_confirm = 0
+	_mart_stage = MART_CONFIRM
+	_mart_pages = Gen2TextLayout.lay_out(
+		_mart_text("final_price", {
+			"name": entry.get("name", ""),
+			"quantity": _mart_quantity,
+			"total": int(entry.get("price", 0)) * _mart_quantity,
+		}),
+		MART_TEXT_COLUMNS, MART_TEXT_ROWS
+	)
+	_render_mart()
+
+
+func _press_mart_confirm(button: int) -> void:
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN:
+			_mart_confirm = 1 - _mart_confirm
+		Gen2Button.B:
+			_mart_stage = MART_LIST
+		Gen2Button.A:
+			if _mart_confirm == 0:
+				_buy_mart_selection()
+				return
+			_mart_stage = MART_LIST
+	_render_mart()
+
+
+## The transaction itself, and whichever of `BuyMenuLoop`'s three answers it
+## earns: too little money, no room in the pack, or the shop's own thanks.
+func _buy_mart_selection() -> void:
+	var entry: Dictionary = _mart_selection()
+	var purchase: Dictionary = Gen2WorldMartHost.purchase(
+		_world, _save, _mart_source(), int(entry.get("item", 0)), _mart_quantity, _persist
+	)
+	if not bool(purchase.get("ok", false)):
+		var reason: StringName = StringName(purchase.get("reason", &""))
+		var slot: String = {
+			&"insufficient_money": "no_money", &"item_stack_full": "pack_full",
+			&"bargain_item_sold_out": "sold_out",
+		}.get(reason, "")
+		if slot.is_empty():
+			_status.text = "Purchase failed: %s" % String(reason)
+			_status.add_theme_color_override("font_color", ERROR)
+			_mart_stage = MART_LIST
+			_render_mart()
+			return
+		_show_mart_text(_mart_text(slot, {"name": entry.get("name", "")}), MART_LIST)
+		return
+	_mart_purchased = true
+	Gen2WorldAudioHost.play(_data.world_audio(&"sfx", SFX_TRANSACTION), &"sound")
+	_refresh_mart_entries()
+	_show_mart_text(_mart_text("thanks", {
+		"name": purchase.get("name", ""), "quantity": _mart_quantity,
+		"total": int(purchase.get("total", 0)),
+	}), MART_LIST)
+
+
+func _leave_mart() -> void:
+	_show_mart_text(_mart_text("come_again"), &"exit")
+
+
+func _close_mart() -> void:
+	if _mart_hardware != null:
+		_mart_hardware.queue_free()
+		_mart_hardware = null
+		_mart_view = null
+	_panel.visible = true
+
+
+func _render_mart() -> void:
+	if _mart_view == null or _data == null:
+		return
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _mart_page == null:
+		return
+	var page: PackedStringArray = _mart_pages[0] if not _mart_pages.is_empty() \
+		else PackedStringArray()
+	var image: Image = _mart_page.render({
+		"money": _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
+		"rows": _mart_rows(),
+		"cursor": _cursor if _mart_stage == MART_LIST else -1,
+		"scrolled": _mart_scroll > 0,
+		"text": "\n".join(page) if _mart_stage != MART_LIST else _mart_description(),
+		## `StandardMartAskPurchaseQuantity` closes the dial with `ExitMenu`
+		## before `MartConfirmPurchase` prints, so the box is the quantity
+		## stage's alone.
+		"quantity": _mart_quantity if _mart_stage == MART_QUANTITY else -1,
+		"subtotal": int(_mart_selection().get("price", 0)) * _mart_quantity,
+	})
+	if image == null:
+		return
+	if _mart_stage == MART_CONFIRM:
+		if _mart_menu_page == null:
+			_mart_menu_page = Gen2MenuPage.from_data(_data)
+		if _mart_menu_page != null:
+			var box: Gen2MenuBox = _mart_yes_no_box()
+			var menu: Image = _mart_menu_page.render(
+				box, ["YES", "NO"], _mart_confirm
+			)
+			image.blend_rect(
+				menu, Rect2i(Vector2i.ZERO, menu.get_size()),
+				box.border_position() * Gen2Font.TILE
+			)
+	_mart_view.texture = ImageTexture.create_from_image(image)
+
+
+## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
+## the five-wide, four-tall box at (14,7).
+func _mart_yes_no_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		14, 7, 19, 11,
+		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+	)
+
+
+## `UpdateItemDescription`, which prints nothing for the CANCEL row.
+func _mart_description() -> String:
+	var entry: Dictionary = _mart_selection()
+	if entry.is_empty():
+		return ""
+	return String(_data.item(int(entry.get("item", 0))).get("description", ""))
 
 
 ## `SelectApricornForKurt`'s two boxes. The model owns both cursors and the loop
@@ -885,8 +1234,6 @@ func _move_cursor(delta: int) -> void:
 	if count <= 0:
 		return
 	_cursor = wrapi(_cursor + delta, 0, count)
-	if _mode == MODE.MART:
-		_mart_quantity = 1
 	if _mode == MODE.PC_ITEM_LIST:
 		_pc_quantity = 1
 	_render_options()
@@ -900,9 +1247,6 @@ func _move_direction(direction: Vector2i) -> void:
 		if _menu.move(direction):
 			_cursor = _menu.selected_index()
 			_render_options()
-		return
-	if _mode == MODE.MART and direction.x != 0:
-		_change_mart_quantity(direction.x)
 		return
 	if _mode == MODE.PC_ITEM_LIST and direction.x != 0:
 		_change_pc_quantity(direction.x)
@@ -929,35 +1273,6 @@ func _confirm() -> void:
 			_status.add_theme_color_override("font_color", ERROR)
 			return
 		_finish_input(_cursor)
-		return
-	if _mode == MODE.MART:
-		if _cursor >= _mart_entries.size():
-			_cancel()
-			return
-		var entry: Dictionary = _mart_entries[_cursor]
-		if bool(entry.get("leave", false)):
-			_finish_runtime({"ok": true, "script_value": 1 if _mart_purchased else 0})
-			return
-		if bool(entry.get("sold_out", false)):
-			_status.text = "This item is sold out for this visit."
-			_status.add_theme_color_override("font_color", ERROR)
-			return
-		var purchase: Dictionary = Gen2WorldMartHost.purchase(
-			_world, _save, _mart_source(), int(entry.get("item", 0)), _mart_quantity, _persist
-		)
-		if not bool(purchase.get("ok", false)):
-			_status.text = "Purchase failed: %s" % String(purchase.get("reason", "unknown"))
-			_status.add_theme_color_override("font_color", ERROR)
-			return
-		_mart_purchased = true
-		_summary.text = "Money: %d" % _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT)
-		_status.text = "Bought %s. Owned: %d" % [
-			String(purchase.get("name", "UNKNOWN")), int(purchase.get("owned", 0)),
-		]
-		_status.add_theme_color_override("font_color", SUCCESS)
-		_mart_quantity = 1
-		_refresh_mart_entries()
-		_render_options()
 		return
 	if _mode == MODE.POKEGEAR:
 		if _cursor >= _pokegear_cards.size():
@@ -993,8 +1308,6 @@ func _cancel() -> void:
 		_advance_pc_text()
 	elif _mode == MODE.MENU:
 		_finish_input_cancelled()
-	elif _mode == MODE.MART:
-		_finish_runtime({"ok": true, "script_value": 1 if _mart_purchased else 0, "cancelled": true})
 	elif _mode == MODE.POKEGEAR:
 		_mode = -1
 		completed.emit([])
@@ -1027,6 +1340,7 @@ func _finish_runtime(result: Dictionary) -> void:
 
 func _finish(results: Array) -> void:
 	_mode = -1
+	_close_mart()
 	completed.emit(results)
 
 
@@ -1043,7 +1357,7 @@ func _render_options(override: Array = []) -> void:
 		_options.add_child(grid)
 		parent = grid
 	var values: Array = override if not override.is_empty() else (
-		_choices if _mode == MODE.MENU else _mart_entries if _mode == MODE.MART \
+		_choices if _mode == MODE.MENU \
 		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS] \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else _pokegear_cards if _mode == MODE.POKEGEAR else ["Continue"]
@@ -1061,22 +1375,6 @@ func _render_options(override: Array = []) -> void:
 				name = str(dictionary.get("trainer_name", "UNKNOWN"))
 			if name.is_empty() and dictionary.has("index"):
 				name = "CONTACT %d" % int(dictionary.get("index", -1))
-		if value is Dictionary and _mode == MODE.MART \
-			and not bool((value as Dictionary).get("leave", false)):
-			if bool((value as Dictionary).get("sold_out", false)):
-				name = "%s    SOLD OUT" % name
-				label.text = ("> " if index == _cursor else "  ") + name
-				label.add_theme_color_override("font_color", ERROR if index == _cursor else MUTED)
-				label.add_theme_font_size_override("font_size", 18)
-				parent.add_child(label)
-				continue
-			var price: int = int((value as Dictionary).get("price", 0))
-			if index == _cursor:
-				name = "%s    %d x %d = %d" % [
-					name, price, _mart_quantity, price * _mart_quantity,
-				]
-			else:
-				name = "%s    %d" % [name, price]
 		if value is Dictionary and _mode == MODE.PC_ITEM_LIST:
 			var stack: int = int((value as Dictionary).get("quantity", 0))
 			name = "%s    x%d of %d" % [name, _pc_quantity, stack] if index == _cursor \
@@ -1085,15 +1383,11 @@ func _render_options(override: Array = []) -> void:
 		label.add_theme_color_override("font_color", ACCENT if index == _cursor else TEXT)
 		label.add_theme_font_size_override("font_size", 18)
 		parent.add_child(label)
-	if _mode == MODE.MART:
-		_update_mart_status()
 
 
 func _option_count() -> int:
 	if _mode == MODE.MENU:
 		return _menu.options.size() if _menu != null else _choices.size()
-	if _mode == MODE.MART:
-		return _mart_entries.size()
 	if _mode == MODE.POKEGEAR:
 		return _pokegear_cards.size()
 	if _mode in [MODE.PC, MODE.PC_ITEMS]:
@@ -1107,47 +1401,10 @@ func _mart_source() -> Dictionary:
 	return _resolved.get("data", {}).get("mart", {})
 
 
+## `FarReadMart`'s own list. CANCEL is not one of its rows: `ScrollingMenu`
+## draws it past the terminator, which is what [method _mart_rows] does.
 func _refresh_mart_entries() -> void:
 	_mart_entries = Gen2WorldMartHost.entries(_data, _mart_source())
-	_mart_entries.append({"leave": true, "name": "LEAVE"})
-
-
-func _change_mart_quantity(delta: int) -> void:
-	if _cursor < 0 or _cursor >= _mart_entries.size():
-		return
-	var entry: Dictionary = _mart_entries[_cursor]
-	if bool(entry.get("leave", false)) or bool(entry.get("sold_out", false)):
-		return
-	if StringName(_mart_source().get("variant", &"")) == &"bargain":
-		return
-	var owned: int = _world.state.item_quantity(int(entry.get("item", 0)))
-	var maximum: int = Gen2WorldMartHost.MAX_ITEM_STACK - owned
-	if maximum <= 0:
-		_mart_quantity = 0
-	else:
-		_mart_quantity = clampi(_mart_quantity + delta, 1, maximum)
-	_render_options()
-
-
-func _update_mart_status() -> void:
-	if _mode != MODE.MART or _cursor < 0 or _cursor >= _mart_entries.size():
-		return
-	var entry: Dictionary = _mart_entries[_cursor]
-	if bool(entry.get("leave", false)):
-		_status.text = "Leave this shop."
-		return
-	if bool(entry.get("sold_out", false)):
-		_status.text = "Sold out for this visit."
-		return
-	var item: int = int(entry.get("item", 0))
-	var owned: int = _world.state.item_quantity(item)
-	var maximum: int = Gen2WorldMartHost.MAX_ITEM_STACK - owned
-	if maximum <= 0:
-		_status.text = "This item stack is full."
-		return
-	_status.text = "Owned: %d    Quantity: %d    Total: %d" % [
-		owned, _mart_quantity, int(entry.get("price", 0)) * _mart_quantity,
-	]
 
 
 func _phone_text(summary: Dictionary) -> String:

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -145,15 +145,25 @@ func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_eq(host._title.text, "MART")
-	assert_eq(host.selected_index(), 0)
+	## `BuyMenu` owns the whole screen, so the panel steps aside for it.
+	assert_false(host._panel.visible)
+	assert_not_null(host._mart_hardware)
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
+	## One item and CANCEL, which is the row `ScrollingMenu` draws past the
+	## list's own terminator.
+	assert_eq(host._mart_rows().size(), 2)
+	assert_true(bool(host._mart_rows()[1].get("cancel", false)))
+
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_QUANTITY)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_CONFIRM)
 	assert_true(host.handle_button(Gen2Button.A))
 	assert_eq(_world_screen._world.state.money(), 380)
 	assert_eq(_world_screen._world.state.item_quantity(7), 2)
 	assert_true(host.is_active())
 
-	assert_true(host.handle_button(Gen2Button.DOWN))
-	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_false(_world_screen._world.script_input_waiting())
@@ -165,17 +175,64 @@ func test_mart_overlay_purchases_the_selected_quantity() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
+	assert_true(host.handle_button(Gen2Button.A))
+	## `BuySellToss_InterpretJoypad`: ten on right, one on down, and down off one
+	## wraps to `wItemQuantity` rather than stopping.
 	assert_true(host.handle_button(Gen2Button.RIGHT))
+	assert_eq(host._mart_quantity, 11)
+	assert_true(host.handle_button(Gen2Button.LEFT))
+	assert_eq(host._mart_quantity, 1)
+	assert_true(host.handle_button(Gen2Button.DOWN))
+	assert_eq(host._mart_quantity, Gen2WorldMartHost.MAX_ITEM_STACK)
+	assert_true(host.handle_button(Gen2Button.UP))
+	assert_eq(host._mart_quantity, 1)
+	assert_true(host.handle_button(Gen2Button.UP))
+
+	assert_true(host.handle_button(Gen2Button.A))
 	assert_true(host.handle_button(Gen2Button.A))
 	assert_eq(_world_screen._world.state.money(), 260)
 	assert_eq(_world_screen._world.state.item_quantity(7), 3)
 	assert_true(host.is_active())
 
-	assert_true(host.handle_button(Gen2Button.DOWN))
-	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_false(_world_screen._world.script_input_waiting())
+
+
+## `MartConfirmPurchase`'s NO, and B off the quantity box: both come back to the
+## list with the money untouched.
+func test_mart_overlay_refuses_without_taking_money() -> void:
+	await _open_world()
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.B))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
+
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.DOWN))
+	assert_eq(host._mart_confirm, 1)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
+	assert_eq(_world_screen._world.state.money(), 500)
+	assert_eq(_world_screen._world.state.item_quantity(7), 1)
+
+
+## The CANCEL row leaves the same way B does.
+func test_mart_overlay_cancel_row_leaves_the_shop() -> void:
+	await _open_world()
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_true(host.handle_button(Gen2Button.DOWN))
+	assert_eq(host.selected_index(), 1)
+	assert_true(host._mart_selection().is_empty())
+	assert_true(host.handle_button(Gen2Button.A))
+	await get_tree().process_frame
+	assert_null(_world_screen._service_host)
 
 
 func test_menu_overlay_cancel_resumes_with_false_script_value() -> void:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -601,6 +601,8 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 		"pokegear": [RomLayout.POKEGEAR_TILES, 2],
 		"pokegear_sprites": [RomLayout.POKEGEAR_SPRITE_TILES, 3],
 		"dex_nest_icon": [RomLayout.DEX_NEST_ICON_TILES, 3],
+		## `'▲'`, the single tile a scrolling menu draws its own arrow from.
+		"up_arrow": [1, 2],
 		## `Pokedex_LoadGFX`'s two runs, `UnownFont` and the footprint grid, at
 		## their real lengths so the dex page can address every tile a layout
 		## names. Flat fills like the rest: what a test checks is where each
@@ -618,6 +620,7 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 		"font": RomLayout.FONT_FIRST_CODE,
 		"frames": RomLayout.FRAME_FIRST_CODE,
 		"copyright": RomLayout.COPYRIGHT_FIRST_CODE,
+		"up_arrow": Gen2Text.UP_ARROW_CODE,
 	}
 	for name: String in sheet_tiles:
 		var tile_count: int = int(sheet_tiles[name][0])

--- a/tests/unit/test_mart_page.gd
+++ b/tests/unit/test_mart_page.gd
@@ -1,0 +1,117 @@
+extends GutTest
+
+## `BuyMenu`'s screen on the tile grid, against a synthetic cache.
+##
+## The fixture fills each sheet with an index of its own, so a drawn pixel says
+## which strip it came from and an untouched one reads 0: that is what tells the
+## arrow's own tile from a glyph without a real cartridge.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const TILE: int = Gen2Font.TILE
+
+var _page: Gen2MartPage = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_page = Gen2MartPage.from_data(GameData.open_directory(Fixture.directory()))
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+func _state(overrides: Dictionary = {}) -> Dictionary:
+	var state: Dictionary = {
+		"money": 3000,
+		"rows": [
+			{"name": "POTION", "price": 300},
+			{"name": "ANTIDOTE", "price": 100},
+			{"cancel": true},
+		],
+		"cursor": 0,
+		"scrolled": false,
+		"text": "A spray-type\nmedicine.",
+		"quantity": -1,
+		"subtotal": 0,
+	}
+	state.merge(overrides, true)
+	return state
+
+
+func _ink(image: Image, tile: Vector2i) -> bool:
+	for row: int in TILE:
+		for column: int in TILE:
+			if image.get_pixel(tile.x * TILE + column, tile.y * TILE + row) != Color.WHITE:
+				return true
+	return false
+
+
+func test_the_money_box_stands_in_the_top_right_corner() -> void:
+	var image: Image = _page.render(_state())
+	assert_eq(image.get_size(), Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT))
+	assert_true(_ink(image, Gen2MartPage.MONEY_AT), "the box's own corner is drawn")
+	## `PlaceMoneyTextbox` prints seven cells from (12,1), and the two rows above
+	## the list are otherwise empty.
+	assert_true(_ink(image, Gen2MartPage.MONEY_TEXT_AT + Vector2i(6, 0)))
+	assert_false(_ink(image, Vector2i(0, 1)), "nothing is drawn left of the box")
+
+
+func test_a_row_prints_its_price_on_the_row_below_its_name() -> void:
+	var image: Image = _page.render(_state())
+	assert_true(_ink(image, Gen2MartPage.NAME_AT), "the first name is drawn")
+	## The price is seven cells right aligned from its own column, so what says
+	## it landed is its last digit rather than the column it starts in.
+	var price_at := Vector2i(
+		Gen2MartPage.PRICE_COLUMN + Gen2MartPage.MONEY_CELLS - 1, Gen2MartPage.NAME_AT.y + 1
+	)
+	assert_true(_ink(image, price_at), "its price is one row below it")
+	assert_false(
+		_ink(image, price_at - Vector2i(0, 1)), "and not beside it"
+	)
+	## `Place2DMenuCursor` writes on the list's own left border coordinate.
+	assert_true(_ink(image, Vector2i(Gen2MartPage.LIST_AT.x, Gen2MartPage.NAME_AT.y)))
+	assert_false(
+		_ink(image, Vector2i(Gen2MartPage.LIST_AT.x, Gen2MartPage.NAME_AT.y + 2)),
+		"the arrow is on one row only"
+	)
+
+
+func test_the_down_arrow_is_always_drawn_and_the_up_one_waits_for_a_scroll() -> void:
+	var image: Image = _page.render(_state())
+	assert_true(
+		_ink(image, Vector2i(Gen2MartPage.LIST_RIGHT, Gen2MartPage.LIST_BOTTOM)),
+		"SCROLLINGMENU_DISPLAY_ARROWS draws the down arrow whatever the scroll is"
+	)
+	assert_false(_ink(image, Vector2i(Gen2MartPage.LIST_RIGHT, Gen2MartPage.LIST_AT.y)))
+	var scrolled: Image = _page.render(_state({"scrolled": true}))
+	assert_true(_ink(scrolled, Vector2i(Gen2MartPage.LIST_RIGHT, Gen2MartPage.LIST_AT.y)))
+
+
+func test_the_quantity_box_stands_over_the_speech_box() -> void:
+	var plain: Image = _page.render(_state())
+	assert_false(_ink(plain, Gen2MartPage.QUANTITY_AT), "no frame until one is asked for")
+	var asked: Image = _page.render(_state({"quantity": 2, "subtotal": 600}))
+	assert_true(_ink(asked, Gen2MartPage.QUANTITY_TEXT_AT), "×02 is drawn")
+	assert_true(
+		_ink(asked, Gen2MartPage.SUBTOTAL_AT + Vector2i(Gen2MartPage.MONEY_CELLS - 1, 0)),
+		"and the subtotal beside it"
+	)
+	assert_true(_ink(asked, Gen2MartPage.QUANTITY_AT), "inside its own frame")
+
+
+func test_money_is_right_aligned_against_its_own_yen_sign() -> void:
+	assert_eq(Gen2MartPage.money_string(200), "   ¥200")
+	assert_eq(Gen2MartPage.money_string(999999), "¥999999")
+	assert_eq(Gen2MartPage.money_string(0), "     ¥0")
+
+
+func test_the_speech_box_prints_its_lines_two_rows_apart() -> void:
+	var image: Image = _page.render(_state())
+	assert_true(_ink(image, Gen2MartPage.TEXT_AT))
+	assert_true(_ink(image, Gen2MartPage.TEXT_AT + Vector2i(0, Gen2MartPage.TEXT_SPACING)))
+	assert_false(
+		_ink(image, Gen2MartPage.TEXT_AT + Vector2i(0, 1)),
+		"the row between them is the box's own spacing"
+	)

--- a/tests/unit/test_mart_page.gd.uid
+++ b/tests/unit/test_mart_page.gd.uid
@@ -1,0 +1,1 @@
+uid://dtynvhjtvdgrf

--- a/tools/checks/mart.gd
+++ b/tools/checks/mart.gd
@@ -1,0 +1,167 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the mart's own boxes and its buy screen against freshly imported
+## real caches, over every mart the cartridge ships rather than a sampled one.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `engine/items/mart.asm`'s `GetMartDialogGroup.MartTextFunctionPointers`, the
+## twenty-nine `text_far` stubs behind it, and `MenuHeader_Buy`'s own geometry.
+##
+## One pinned address per cartridge finds every text, so what says the address
+## is right is the content: each stub has to decode, each group's opening has to
+## be that shop's own words, and every marker a box carries has to be one of the
+## three values `MartConfirmPurchase` fills. The screen itself is swept by
+## drawing all thirty-four marts: a name or a price that ran past the list's own
+## columns is what a wrong geometry looks like.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- mart
+
+## Enough of each group's boxes to say which stub decoded, without pinning a
+## whole one. `bargain_sold_out` is the only refusal that is not shared.
+const EXPECTED_TEXT_OPENINGS: Dictionary = {
+	"welcome": "Welcome! How may I",
+	"come_again": "Please come again!",
+	"ask_more": "Can I do anything",
+	"how_many": "How many?",
+	"thanks": "Here you are.",
+	"no_money": "You don't have",
+	"pack_full": "You can't carry",
+	"bitter_intro": "Hello, dear.",
+	"bitter_come_again": "Come again, dear.",
+	"bargain_intro": "Hiya! Care to see",
+	"bargain_sold_out": "You bought that",
+	"bargain_thanks": "Thanks.",
+	"pharmacy_intro": "What's up? Need",
+	"pharmacy_come_again": "All right.",
+}
+
+## The three values a mart box leaves a marker for. `hMoneyTemp` is HRAM and
+## `wItemQuantityChange` is not, which is how the two numbers are told apart.
+const HRAM_FIRST: int = 0xFF00
+
+## Which boxes carry which markers, as the count of each. Read off the source's
+## own `text_ram` and `text_decimal` lines.
+const EXPECTED_MARKERS: Dictionary = {
+	"final_price": {"name": 1, "quantity": 1, "total": 1},
+	"bitter_final_price": {"name": 1, "quantity": 1, "total": 1},
+	"pharmacy_final_price": {"name": 1, "quantity": 1, "total": 1},
+	"bargain_final_price": {"name": 1, "quantity": 0, "total": 1},
+}
+
+## The screen's own width. A name prints from column 2 and its price from
+## column 10 of the row below, so the two never collide however long the name
+## is: what a wrong geometry looks like is a row running off the right edge.
+const SCREEN_COLUMNS: int = 20
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		_verify_texts(data)
+		_verify_markers(data)
+		_verify_lists(data)
+	_r.game_id = &""
+
+
+func _verify_texts(data: GameData) -> void:
+	var decoded: int = 0
+	for name: String in RomLayout.MART_TEXT_AT:
+		if not data.mart_text(name).is_empty():
+			decoded += 1
+	_r.check(
+		decoded == RomLayout.MART_TEXT_AT.size(),
+		"%d of %d mart texts decoded" % [decoded, RomLayout.MART_TEXT_AT.size()]
+	)
+	for name: String in EXPECTED_TEXT_OPENINGS:
+		var text: String = data.mart_text(name)
+		_r.check(
+			text.begins_with(String(EXPECTED_TEXT_OPENINGS[name])),
+			"text %s opens \"%s\", not \"%s\"" % [
+				name, text.substr(0, 24), EXPECTED_TEXT_OPENINGS[name],
+			]
+		)
+
+
+## Every marker in every box, counted by kind. A box carrying one the screen
+## cannot fill would print `<NUM_C2DE>` at the player.
+func _verify_markers(data: GameData) -> void:
+	for name: String in RomLayout.MART_TEXT_AT:
+		var counts: Dictionary = _markers(data.mart_text(name))
+		var expected: Dictionary = EXPECTED_MARKERS.get(
+			name, {"name": 0, "quantity": 0, "total": 0}
+		)
+		_r.check(
+			counts == expected,
+			"text %s carries %s, not %s" % [
+				name, JSON.stringify(counts), JSON.stringify(expected),
+			]
+		)
+
+
+func _markers(text: String) -> Dictionary:
+	var out: Dictionary = {"name": 0, "quantity": 0, "total": 0}
+	var at: int = 0
+	while true:
+		at = text.find(Gen2TextStream.NUMBER_MARKER, at)
+		if at < 0:
+			break
+		var end: int = text.find(">", at)
+		var address: int = text.substr(
+			at + Gen2TextStream.NUMBER_MARKER.length(),
+			end - at - Gen2TextStream.NUMBER_MARKER.length()
+		).hex_to_int()
+		out["total" if address >= HRAM_FIRST else "quantity"] += 1
+		at = end + 1
+	at = 0
+	while true:
+		at = text.find(Gen2TextStream.RAM_MARKER, at)
+		if at < 0:
+			break
+		out["name"] += 1
+		at += 1
+	return out
+
+
+## Every mart the cartridge ships, drawn through the buy screen's own columns.
+func _verify_lists(data: GameData) -> void:
+	var marts: Array = _marts(data)
+	var rows: int = 0
+	for mart: Dictionary in marts:
+		for entry: Dictionary in Gen2WorldMartHost.entries(data, mart):
+			rows += 1
+			var name: String = String(entry.get("name", ""))
+			_r.check(
+				Gen2MartPage.NAME_AT.x + Gen2Text.encoded_length(name) <= SCREEN_COLUMNS,
+				"%s is %d tiles, which runs past the screen" % [
+					name, Gen2Text.encoded_length(name),
+				]
+			)
+			var price: String = Gen2MartPage.money_string(int(entry.get("price", 0)))
+			_r.check(
+				Gen2MartPage.PRICE_COLUMN + price.length() <= SCREEN_COLUMNS,
+				"%s costs %s, which runs past the screen" % [name, price.strip_edges()]
+			)
+	_r.check(rows > 0, "no mart in this cache carries a row")
+	_r.note("%d marts, %d rows" % [marts.size(), rows])
+
+
+## The indexed marts plus whichever specials this profile ships, which is what
+## `OpenMartDialog` can reach.
+func _marts(data: GameData) -> Array:
+	var out: Array = []
+	for index: int in data.world_mart_count():
+		var mart: Dictionary = data.world_mart(index)
+		if not mart.is_empty():
+			out.append(mart)
+	for special: StringName in [&"bargain", &"rooftop_mart_1", &"rooftop_mart_2"]:
+		var mart: Dictionary = data.world_mart_special(special)
+		if not mart.is_empty():
+			out.append(mart)
+	return out

--- a/tools/checks/mart.gd.uid
+++ b/tools/checks/mart.gd.uid
@@ -1,0 +1,1 @@
+uid://bakoccoh65vrb

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -16,7 +16,9 @@ extends SceneTree
 ## `unown_wall` (`DisplayUnownWords`' box, read off a Ruins of Alph chamber's
 ## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
 ## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
-## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `pokepic`
+## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `mart`
+## (`BuyMenu`, talked open from the cell in front of a shop's counter, as
+## `crystal 1 8 ... mart 3 3`), `pokepic`
 ## (`Script_pokepic`'s box over the map, holding Chikorita), the name of any
 ## `preview_*` driver on the world screen without that prefix (`field_move` is
 ## `PartyMenu` with a taught CUT on it, `start_menu`, `capture`, `move_forget`
@@ -59,6 +61,11 @@ const POKEPIC_SPECIES: int = 152
 ## How a `kind` names one of [Gen2WorldScreen]'s own screenshot drivers, so
 ## every `preview_*` on it is reachable from here rather than from nothing.
 const SCREEN_DRIVER: String = "preview_%s"
+
+## The clerk's own text box, which is the one press between `pokemart` and the
+## welcome the buy screen opens on. One more reaches the list, two the quantity
+## dial and three the yes/no.
+const MART_PRESSES: int = 1
 
 const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_CUT: int = 12
@@ -151,6 +158,15 @@ func _process(_delta: float) -> bool:
 			## is what runs `special DisplayUnownWords` and puts the box up.
 			_screen.press_button(Gen2Button.A)
 			_screen.press_button(Gen2Button.A)
+		elif _kind == &"mart":
+			## The clerk behind the counter, talked to from the cell in front of
+			## him: his `pokemart` is what opens `BuyMenu`, so the shop is
+			## reached the way a player reaches it. The presses are the dialog's
+			## own, the welcome box first and then the list.
+			_screen.press_button(Gen2Button.LEFT)
+			_screen.interact()
+			for _press: int in MART_PRESSES:
+				_screen.press_button(Gen2Button.A)
 		elif _kind == &"pokepic":
 			_screen.preview_pokepic(POKEPIC_SPECIES)
 		elif FIELD_ITEMS.has(_kind):

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -37,7 +37,7 @@ const GROUPS: Dictionary = {
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
-		&"pack", &"unown_dex", &"pokedex", &"pc",
+		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
The mart overlay was a `PanelContainer` of `Label` rows with host wording. It is now `BuyMenu`'s own screen at hardware resolution:

- `PlaceMoneyTopRight`'s box, `MenuHeader_Buy`'s scrolling list with each BCD price a row under its name, `UpdateItemDescription`'s speech box, `BuyItem_MenuHeader`'s quantity dial and `YesNoBox` over the price.
- The words are the cartridge's: `engine/items/mart.asm` lays `MartHowManyText` down first and every other `text_far` stub at a fixed delta from it, identical on all three dumps, so one pinned address per cartridge imports all twenty-nine. Which group a shop reads is `GetMartDialogGroup.MartTextFunctionPointers`'.
- The up arrow is the one tile a scrolling menu needs that no font strip carries: its own 2bpp sheet on Crystal, the second tile of a 1bpp pair on Gold and Silver.

Cache format 64; re-import the three cartridges.

| Proof | Result |
|---|---|
| GUT, both tiers | 3,043 tests over 150 scripts, green |
| `validate.gd -- all` | 50 topics pass, `mart` among them: 37 marts, 242 rows on Crystal and 232 on Gold and Silver |
| `import_rom.gd` | `layout: Layout verified.` on all three |
| `replay_world.gd` | 30 routes, 0 failures, the Cherrygrove errand still taking money through the new screen |
| Story walk | Gold, Silver and Crystal reach Red, Violet Mart's balls bought on each |