### PR TITLE
Engine requests R17 to R20

### DIFF
--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -174,7 +174,12 @@ func _retarget_mods(game_id: StringName) -> void:
 ## applies where it was thrown instead of at the next launch.
 func reload_mods(game_id: StringName = selected_game_id) -> Array:
 	Gen2ModHost.reset()
-	return load_mods(game_id)
+	var loaded: Array = load_mods(game_id)
+	## The reset dropped the old host's providers and its overlay with them, so
+	## the freshly loaded ones are told which save is open rather than finding
+	## out at the next slot change.
+	_activate_mod_save()
+	return loaded
 
 
 func has_selected_game() -> bool:
@@ -195,6 +200,7 @@ func select_save_slot(game_id: StringName, slot: int) -> bool:
 	if selected_save_slot != slot:
 		reload_selected_save()
 	selected_save_slot = slot
+	_activate_mod_save()
 	return true
 
 
@@ -229,3 +235,18 @@ func selected_save() -> Gen2SaveData:
 func reload_selected_save() -> void:
 	_save = null
 	_save_key = ""
+
+
+## Tells the mods that hold a run which save it is, before any screen reads
+## `GameData`. Every slot change goes through here, including the one to no slot
+## at all: a development run is null rather than an invented save, and a mod that
+## patched for the last run has its contributions dropped either way.
+func _activate_mod_save() -> void:
+	Gen2ModHost.instance().activate_save(selected_save_or_null())
+
+
+## A save that has just been made. The mods are told before it is written, so
+## whatever a run is built from is in the file the player will load next time.
+func announce_new_save(save: Gen2SaveData) -> void:
+	Gen2ModHost.instance().created_save(save)
+	Gen2ModHost.instance().activate_save(save)

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -254,8 +254,25 @@ An encounter row is what `GameData.world_encounter(method, group, number)`
 answers, and the patched row is what every reader gets, including the region
 walk `FindNest` uses. The method is one of `grass`, `surf`, `swarm_grass` and
 `swarm_water`. `slots` and `rates` are arrays and replace whole; patching a map
-this cartridge lacks changes nothing, exactly as a species patch does. The
-treemon sets, the Bug Contest list and the roaming mons are not patchable yet.
+this cartridge lacks changes nothing, exactly as a species patch does.
+
+The four wild sources beside the map tables are patched the same way, each by its
+own index in the cartridge's own table:
+
+| Helper | Row | Index |
+|---|---|---|
+| `patch_treemon_set(id, set, fields)` | `GameData.treemon_set(set)`, which Headbutt and Rock Smash share | The set number `treemon_set_for_map` answers |
+| `patch_bug_contest_mon(id, index, fields)` | One `ContestMons` row | Its position in the list |
+| `patch_roaming_mon(id, index, fields)` | One roaming Pokemon | Its position in the list |
+| `patch_fishing_time_group(id, index, fields)` | One day/night fishing substitution | Its position in the list |
+
+Name only what changes. A contest row's `percent` is both the choice roll's
+weight and part of what the judging reads, a rod entry's `threshold` is the bite,
+and a roaming mon's `map_group`/`map_number` are where it currently is, which the
+roamer's own movement writes; a patch naming `species` and `level` leaves all
+three exactly as the cartridge has them. Every runtime reader goes through
+`GameData`, so a patched row reaches the encounter roll, the treemon draw, the
+Pokedex nest search and a visible encounter's context alike.
 
 Counts: `species_count()`, `move_count()` and `trainer_count()` are the
 cartridge's own runs. Mod numbers are not part of them and are enumerated with
@@ -773,6 +790,65 @@ above `Gen2ModHost.FIRST_MOD_POCKET`: 1 to 4 are the cartridge's ITEM, KEY_ITEM,
 BALL and TM_HM, and an item joins the pocket its own definition names. Two mods
 claiming the same entry id is refused with `duplicate_menu_entry` rather than one
 silently winning.
+
+## Adding a row to a party member's menu
+
+`register_party_member_menu(id, entry)` appends to the box a party slot opens.
+Both halves are Callables taking the ONE-based slot, because a row here is about
+a member rather than about the menu:
+
+```gdscript
+host.register_party_member_menu(manifest.id, {
+	"label": func(slot: int) -> String:
+		return "FOLLOWING" if slot == following_slot else "FOLLOW",
+	"handler": func(slot: int) -> void:
+		host.set_option(manifest.id, &"slot", slot),
+})
+```
+
+Rows land after every cartridge action and before CANCEL, which is the way out
+of the box; a mod cannot displace or reorder a cartridge row, and the list still
+stops at the source's own `NUM_MONMENU_ITEMS`. A label answering an empty string
+drops its own row, which is how a row is shown conditionally. Choosing one calls
+the handler and closes the menu, the way a field move does.
+
+Not offered for an egg, and not offered inside a battle: a battle's party list is
+a switch, and a row running a mod's action in the middle of a turn would be world
+state changing while the turn owns it.
+
+## Holding a run rather than an installation
+
+A mod whose settings decide what a whole playthrough looks like has a problem
+`read_save_data` alone does not solve: an installation option changed mid-run
+would silently rewrite the save being played, and opening another save could not
+restore the settings that made it. `register_save_lifecycle(manifest, provider)`
+is the seam for that.
+
+The `manifest` is the object `register()` was handed, and it IS the capability:
+the host keeps it beside the provider, so a callback reaches
+`read_save_data`/`write_save_data` for its own namespace and no other mod's. A
+manifest this host never discovered registers nothing.
+
+| Method | Called when |
+|---|---|
+| `save_created(save)` | A save has just been made, before it is written. Snapshot whatever the run is built from into your namespace here |
+| `save_activated(save)` | That save is about to be played. `save` is `null` for a DEVELOPMENT run, one started with no selected slot |
+| `save_deactivated()` | The save was closed |
+
+Ordering, which is the part that matters:
+
+1. The host drops every lifecycle mod's overlay contributions, in one pass.
+2. `save_activated` runs, in registration order.
+
+So a provider always starts from the cartridge, two slots cannot leak patches
+into one another, and a provider that fails leaves nothing installed rather than
+the previous run's shuffle. `save_deactivated` clears afterwards, so nothing
+stays patched by a run nobody is playing.
+
+Save the compact INPUTS plus an algorithm version, not the generated plan: a plan
+can exceed the 64 KiB namespace and duplicates cartridge rows anyway. A save
+carrying no snapshot has no run and should stay vanilla rather than adopt today's
+options.
 
 ## Adding a setting
 

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -36,7 +36,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Must equal `Gen2ModManifest.API_VERSION` |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -643,6 +643,76 @@ one cell below an NPC is drawn over it.
 A registered world renderer that wants to draw them takes them through the
 optional `set_actors(actors: Gen2WorldActors)`, which is handed the same
 resolved list the built-in view draws.
+
+## Visible wild encounters
+
+A mod that wants wild Pokemon standing on the map instead of a roll on every
+step registers a **provider** (`api_version` 2). It owns the population and
+nothing else; every rule a cartridge owns stays in `Gen2WorldAPI`.
+
+```gdscript
+func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
+    host.register_visible_encounters(manifest.id, Roamers.new())
+```
+
+A `RefCounted` and never a `Node`, with four methods refused by name at
+registration:
+
+| Method | Called when |
+|---|---|
+| `set_context(context: Dictionary)` | The map changed, and again whenever the player's pose moves |
+| `advance_frame()` | Once per hardware frame |
+| `encounters() -> Array` | The population now. A read, asked once a frame |
+| `battle_finished(id: StringName, result: Dictionary)` | A battle this provider's entry started ended |
+
+The context is a snapshot, never a live handle:
+
+| Key | Meaning |
+|---|---|
+| `map` | `Vector2i(group, number)` |
+| `eligible` | `{grass, surf}` to `PackedVector2Array` of cells a wild may stand on. `CanEncounterWildMon` per cell: the grass test, the cave and dungeon branch that skips it, and the ice refusal |
+| `tables` | `{grass, surf}` to `{source, slots}`, the table a roll would read right now, with the swarm's and the Bug Contest's substitutions already made and the time of day already picked. A slot is `{species, min_level, max_level}` |
+| `player` | `{cell, facing}` |
+| `run_seed` | The run's own seed, so a population is reproducible |
+| `generation` | Bumped on every map change: a context with an older one is stale |
+
+Each entry of `encounters()`:
+
+| Key | Meaning |
+|---|---|
+| `id` | Stable across frames. It is what a battle result is reported back under |
+| `cell` | Must be in `eligible`; which method it is in decides which table it is checked against |
+| `facing` | `Gen2WorldSprite.FACING_*` |
+| `species`, `level` | Must be offered by that table |
+| `dvs` | The packed DV word, carried into the battle unchanged |
+| `pulse` | Optional. Ask for the shiny sparkle over this entry |
+
+Anything else is dropped rather than drawn, including an entry that names
+`shiny`: shininess is `CheckShininess` over the DVs and is the host's answer.
+At most `Gen2WorldEncounters.MAX_ENTRIES` entries are drawn in a frame.
+
+What the host does with a valid population:
+
+- Draws it through the actor layer, with the SPECIES' own four colours, shiny or
+  not, so a renderer reading `set_actors` gets it for free.
+- Turns the ordinary post-step roll off while any provider is registered.
+  Scripted, fishing, Headbutt, Rock Smash, Sweet Scent and Bug Contest
+  encounters keep their own paths.
+- Starts the normal wild battle when the player steps onto an entry, with that
+  entry's exact species, level and DVs, then calls `battle_finished`. Whether
+  the entry survives that is the provider's one rule to document.
+- Discards the population, its sprites and any running pulse on a map change,
+  before the new map is drawn.
+- Plays `ANIM_SEND_OUT_MON` with the shiny param over a pulsing shiny entry,
+  anchored to it and with no battle field behind it, sound included. The host
+  deduplicates: a request inside `Gen2WorldEncounters.PULSE_FRAMES` of the last
+  one is dropped, so a provider may ask on spawn and every ten seconds without
+  touching a node or the audio service. A pulse on an ordinary Pokemon draws
+  nothing.
+
+A world renderer that wants to draw the sparkle itself takes the optional
+`set_encounters(encounters: Gen2WorldEncounters)`; the population itself already
+arrives through `set_actors`.
 
 ## Measured against the voxel mod
 

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -274,6 +274,53 @@ three exactly as the cartridge has them. Every runtime reader goes through
 `GameData`, so a patched row reaches the encounter roll, the treemon draw, the
 Pokedex nest search and a visible encounter's context alike.
 
+## The gameplay catalog
+
+Everything else a cartridge hands out is a SITE in a script or a map event, not a
+table: a starter, a gift, a static battle, a trade, a Game Corner prize, an item
+on the ground, a badge and a shop. `GameData.catalog()` decodes them once and
+gives each a stable id, so a mod places rewards without holding a single script
+address of its own.
+
+```gdscript
+var catalog := data.catalog()
+for row in catalog.rows(Gen2WorldCatalog.KIND_STATIC):
+	host.patch_check(manifest.id, row["id"], {"species": 25, "level": 5})
+```
+
+| Kind | A row carries | Decoded from |
+|---|---|---|
+| `KIND_STARTER` | `species`, `level`, `item` | A `givepoke` whose script also shows the same species with `pokepic`, which only Elm's three balls do |
+| `KIND_GIFT` | `species`, `level`, `item` | Any other `givepoke` or `giveegg` |
+| `KIND_PRIZE` | `species`, `level`, `price` | A give site in a script that spends `takecoins`, priced by the branch's own take |
+| `KIND_STATIC` | `species`, `level` | A `loadwildmon` with the `startbattle` that makes it one |
+| `KIND_TRADE` | `trade`, `species`, `requested_species` | A `trade` command and the record it names |
+| `KIND_ITEM` | `item`, `quantity`, `hidden` | `giveitem`, `verbosegiveitem`, an `itemball` object and a `hiddenitem` bg event |
+| `KIND_BADGE` | `badge`, `engine_flag` | A `setflag` of a badge's engine flag |
+| `KIND_SHOP` | `mart`, `dialog` | A `pokemart` command |
+
+Every row also carries `id`, `kind`, its `bank` and `address` (or its `map` and
+`event_index`), and `requires`: the events, engine flags and items the script
+tested before reaching the site. `requires` is a decoded fact about what the
+cartridge looked at, not a claim that the site is unreachable without them.
+
+For proving a placement finishes: `catalog.possible_starters()` is the three
+species Elm offers, `catalog.field_hm_items()` is the HM items whose move is a
+field move on THIS cartridge, and `catalog.is_progression(row)` is true for a
+badge or a field HM. A check the catalog did not record stays vanilla; nothing
+is guessed.
+
+`patch_check(id, fields)` changes a field of a row. It cannot replace the script:
+the site still sets its own completion flag, prints its own dialogue, takes its
+own money and runs its own battle, and only the number it hands over is the
+mod's. Two mods patching one id is refused by the overlay's own ownership rule,
+not by load order.
+
+The catalog is DERIVED, not imported, so it needs no cache-format bump and no
+re-import. It is also a decode of a corpus: `tools/checks/catalog.gd` pins both
+the census and the semantics on all three cartridges, because a decode that
+drifts into something still plausible is what a count alone cannot see.
+
 Counts: `species_count()`, `move_count()` and `trainer_count()` are the
 cartridge's own runs. Mod numbers are not part of them and are enumerated with
 `Gen2ContentOverlay.defined_numbers(kind)`.

--- a/game/battle/stats.gd
+++ b/game/battle/stats.gd
@@ -45,6 +45,11 @@ const DV_DEFENSE_SHIFT: int = 8
 const DV_SPEED_SHIFT: int = 4
 const DV_SPECIAL_SHIFT: int = 0
 
+## `SHINY_ATK_MASK`, `SHINY_DEF_DV`, `SHINY_SPD_DV` and `SHINY_SPC_DV`. See
+## [method is_shiny].
+const SHINY_ATK_MASK: int = 0b0010
+const SHINY_DV: int = 10
+
 
 ## The cartridge's square root: the first entry of a table of squares not
 ## smaller than [param value]. A ceiling, not a floor, and the table starts at 1,
@@ -93,6 +98,16 @@ static func speed_dv(dvs: int) -> int:
 ## stats and stat experience but not here.
 static func special_dv(dvs: int) -> int:
 	return (dvs >> DV_SPECIAL_SHIFT) & 0xF
+
+
+## `CheckShininess` (engine/gfx/color.asm): three DVs at exactly ten and the
+## Attack DV carrying `SHINY_ATK_MASK`, which is the whole of what being shiny
+## is. Everything that draws a shiny picture asks this and nothing stores a flag.
+static func is_shiny(dvs: int) -> bool:
+	return (attack_dv(dvs) & SHINY_ATK_MASK) != 0 \
+		and defense_dv(dvs) == SHINY_DV \
+		and speed_dv(dvs) == SHINY_DV \
+		and special_dv(dvs) == SHINY_DV
 
 
 ## `GetUnownLetter` (engine/gfx/load_pics.asm), 1 being A: the middle two bits of

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -36,9 +36,14 @@ const KIND_TREEMON: StringName = &"treemon"
 const KIND_BUG_CONTEST: StringName = &"bug_contest"
 const KIND_ROAMING: StringName = &"roaming"
 const KIND_FISHING_TIME: StringName = &"fishing_time"
+## One [Gen2WorldCatalog] site, numbered by its own stable id: a starter, a gift,
+## a static battle, a trade, a prize, an item, a badge or a shop. Patch-only for
+## the same reason the tables are, and a patch changes a FIELD of the site rather
+## than the script that runs it.
+const KIND_CHECK: StringName = &"check"
 const KINDS: Array[StringName] = [
 	KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER, KIND_ENCOUNTER, KIND_FISHING,
-	KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING, KIND_FISHING_TIME,
+	KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING, KIND_FISHING_TIME, KIND_CHECK,
 ]
 
 ## A cartridge table rather than numbered content, so [method patch]-only: a mod
@@ -46,7 +51,7 @@ const KINDS: Array[StringName] = [
 ## coordinates and do not obey [constant FIRST_MOD_NUMBER].
 const TABLE_KINDS: Array[StringName] = [
 	KIND_ENCOUNTER, KIND_FISHING, KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING,
-	KIND_FISHING_TIME,
+	KIND_FISHING_TIME, KIND_CHECK,
 ]
 
 ## [method encounter_number]'s methods in the order it encodes them. `surf` is

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -25,14 +25,29 @@ const KIND_TRAINER: StringName = &"trainer"
 const KIND_ENCOUNTER: StringName = &"encounter"
 ## [method GameData.world_fishing_group]'s row, numbered as a map header does.
 const KIND_FISHING: StringName = &"fishing"
+## The four wild sources beside the map tables, each numbered by its own index
+## in the cartridge's table: [method GameData.treemon_set]'s set, one
+## `ContestMons` row, one roaming mon, and one day/night fishing substitution.
+##
+## A row is PATCHED, never replaced: `percent` is the contest's own roll and its
+## scoring weight, a rod entry's `threshold` is the bite, and a roaming mon's map
+## is live state. Naming only `species` and `level` leaves every one of them.
+const KIND_TREEMON: StringName = &"treemon"
+const KIND_BUG_CONTEST: StringName = &"bug_contest"
+const KIND_ROAMING: StringName = &"roaming"
+const KIND_FISHING_TIME: StringName = &"fishing_time"
 const KINDS: Array[StringName] = [
 	KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER, KIND_ENCOUNTER, KIND_FISHING,
+	KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING, KIND_FISHING_TIME,
 ]
 
 ## A cartridge table rather than numbered content, so [method patch]-only: a mod
 ## cannot add a map for a definition to sit at. Their numbers are table
 ## coordinates and do not obey [constant FIRST_MOD_NUMBER].
-const TABLE_KINDS: Array[StringName] = [KIND_ENCOUNTER, KIND_FISHING]
+const TABLE_KINDS: Array[StringName] = [
+	KIND_ENCOUNTER, KIND_FISHING, KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING,
+	KIND_FISHING_TIME,
+]
 
 ## [method encounter_number]'s methods in the order it encodes them. `surf` is
 ## the runtime's name for the water table, which is what the reader takes.
@@ -224,6 +239,23 @@ static func encounter_number(method: StringName, group: int, number: int) -> int
 ## Which mod claimed [param number], for a launcher listing what it will change.
 func owner_of(kind: StringName, number: int) -> StringName:
 	return StringName((_owners.get(kind, {}) as Dictionary).get(number, &""))
+
+
+## Drops everything [param id] claimed, definitions and patches both, and
+## releases the numbers so it or another mod may claim them again.
+##
+## What a save switch needs: a run's patches belong to the save that created
+## them, and the next save has to start from the cartridge rather than from the
+## last one's shuffle. See [method Gen2ModHost.activate_save].
+func clear_owner(id: StringName) -> void:
+	for kind: Variant in _owners:
+		var owners: Dictionary = _owners[kind]
+		for number: Variant in owners.keys():
+			if StringName(owners[number]) != id:
+				continue
+			owners.erase(number)
+			(_defined.get(kind, {}) as Dictionary).erase(number)
+			(_patched.get(kind, {}) as Dictionary).erase(number)
 
 
 ## One number, one mod: a collision is named rather than settled by load order.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -94,6 +94,9 @@ var _overworld_sprite_palettes: Array = []
 var _party_menu_icon_palette_rows: Array = []
 var _world_menus: Dictionary = {}
 var _world_marts: Dictionary = {}
+## Built on first ask and kept, since the walk behind it is the whole script
+## corpus. See [method catalog].
+var _catalog: Gen2WorldCatalog = null
 var _world_phone: Dictionary = {}
 var _world_fruit_trees: Array = []
 var _world_spawns: Dictionary = {}
@@ -222,6 +225,14 @@ func world_map(group: int, number: int) -> Gen2WorldMap:
 
 func world_maps() -> Array:
 	return _maps().duplicate()
+
+
+## Every imported script's `bank:address` key, sorted, for a caller that has to
+## walk the whole corpus rather than follow one pointer. See [Gen2WorldCatalog].
+func world_script_keys() -> Array:
+	var out: Array = _scripts().keys()
+	out.sort()
+	return out
 
 
 ## Raw bounded script bytes indexed by the cartridge's bank and CPU address.
@@ -2215,6 +2226,28 @@ func _overlaid(kind: StringName, number: int, base: Dictionary) -> Dictionary:
 	if _overlay == null or _overlay.is_empty() or number < 0:
 		return base
 	return _overlay.resolve(kind, number, base)
+
+
+## The catalog of gameplay sites this cartridge holds, built once and kept: the
+## walk is the whole script corpus and nothing about it changes while a cache is
+## open. See [Gen2WorldCatalog].
+func catalog() -> Gen2WorldCatalog:
+	if _catalog == null:
+		_catalog = Gen2WorldCatalog.build(self)
+	return _catalog
+
+
+## One catalog row with any patch folded in. Called by the catalog itself, which
+## holds the rows; nothing else should need it.
+func overlaid_check(id: int, base: Dictionary) -> Dictionary:
+	return _overlaid(Gen2ContentOverlay.KIND_CHECK, id, base)
+
+
+## Whether any mod content reaches this cache at all, which is the one check a
+## hot path pays before asking the overlay anything. Not the SHARED overlay: a
+## tool or a test may hand this cache one of its own.
+func has_content_overlay() -> bool:
+	return _overlay != null and not _overlay.is_empty()
 
 
 ## Replaces the mod content this cache answers with. For a tool or a test that

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -520,7 +520,9 @@ func world_fishing_time_groups() -> Array:
 	if not fishing is Dictionary:
 		return []
 	var groups: Variant = (fishing as Dictionary).get("time_groups", [])
-	return groups.duplicate(true) if groups is Array else []
+	if not groups is Array:
+		return []
+	return _overlaid_rows(Gen2ContentOverlay.KIND_FISHING_TIME, groups as Array)
 
 
 func world_roaming_maps() -> Array:
@@ -536,7 +538,9 @@ func world_roaming_mons() -> Array:
 	if not roaming is Dictionary:
 		return []
 	var mons: Variant = (roaming as Dictionary).get("mons", [])
-	return mons.duplicate(true) if mons is Array else []
+	if not mons is Array:
+		return []
+	return _overlaid_rows(Gen2ContentOverlay.KIND_ROAMING, mons as Array)
 
 
 ## GetTreeMonSet against TreeMonMaps or RockMonMaps: the treemon set number for
@@ -558,6 +562,16 @@ func treemon_set_for_map(group: int, number: int, rock: bool = false) -> int:
 	return 0
 
 
+## How many treemon sets this cartridge imported, which is what a caller walking
+## them needs: Gold and Silver ship six and Crystal nine.
+func treemon_set_count() -> int:
+	var treemons: Variant = _encounters().get("treemons", {})
+	if not treemons is Dictionary:
+		return 0
+	var sets: Variant = (treemons as Dictionary).get("sets", [])
+	return (sets as Array).size() if sets is Array else 0
+
+
 ## GetTreeMons: one set's common and rare tables by set number. The caller
 ## applies the profile's own set limit first; this answers the raw table.
 func treemon_set(index: int) -> Dictionary:
@@ -568,7 +582,10 @@ func treemon_set(index: int) -> Dictionary:
 	if not sets is Array or index < 0 or index >= (sets as Array).size():
 		return {}
 	var value: Variant = (sets as Array)[index]
-	return value.duplicate(true) if value is Dictionary else {}
+	return _overlaid(
+		Gen2ContentOverlay.KIND_TREEMON, index,
+		value.duplicate(true) if value is Dictionary else {}
+	)
 
 
 ## `ContestMons`, the eleven `%, species, min, max` rows
@@ -589,7 +606,26 @@ func _bug_contest_table(key: String) -> Array:
 	if not contest is Dictionary:
 		return []
 	var value: Variant = (contest as Dictionary).get(key, [])
-	return (value as Array).duplicate(true) if value is Array else []
+	if not value is Array:
+		return []
+	## Only the mon rows are patchable. A contestant is a trainer and its three
+	## placings are the judging's own scores, which a wild shuffle has no say in.
+	if key != "mons":
+		return (value as Array).duplicate(true)
+	return _overlaid_rows(Gen2ContentOverlay.KIND_BUG_CONTEST, value as Array)
+
+
+## A table stored as an ARRAY of rows, each row overlaid under its own index.
+## The map tables are dictionaries keyed by a coordinate and go through
+## [method _overlaid]; these four are lists and the index IS the number.
+func _overlaid_rows(kind: StringName, rows: Array) -> Array:
+	var out: Array = []
+	for index: int in rows.size():
+		var row: Variant = rows[index]
+		out.append(_overlaid(
+			kind, index, row.duplicate(true) if row is Dictionary else {}
+		))
+	return out
 
 
 ## CheckSleepingTreeMon's list for one time of day. Empty on Gold and Silver,

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -1,0 +1,462 @@
+class_name Gen2WorldCatalog
+extends RefCounted
+
+## Every stable gameplay SITE the cartridge hands something out at, decoded once
+## and addressed by an id that does not move: a starter, a gift, a static battle,
+## a trade, a Game Corner prize, an item on the ground, a badge and a shop.
+##
+## Why this exists rather than a mod holding a list of script addresses: a
+## randomizer that shuffled starters by patching `ElmsLab` at $58F3 would be a
+## private copy of cartridge semantics, wrong on Gold the moment an address
+## shifts, and silently broken by any change here. The host owns the decoding;
+## the mod owns the placement.
+##
+## Nothing is imported for this. Every row is derived from data the cache already
+## holds: the decoded scripts, the map events, the mart lists and the trade
+## records. That is why there is no cache-format bump behind it and why a fresh
+## cartridge needs no re-import.
+##
+## A patch changes a FIELD of a row. It never replaces a script, a completion
+## flag, a dialogue, an inventory transaction or a battle flow: the site still
+## runs the cartridge's own code, and only the number it hands over is the mod's.
+## See [method Gen2ModHost.patch_check].
+
+const KIND_STARTER: StringName = &"starter"
+const KIND_GIFT: StringName = &"gift"
+const KIND_STATIC: StringName = &"static"
+const KIND_TRADE: StringName = &"trade"
+const KIND_PRIZE: StringName = &"prize"
+const KIND_ITEM: StringName = &"item"
+const KIND_BADGE: StringName = &"badge"
+const KIND_SHOP: StringName = &"shop"
+## Also the id's own kind nibble, so the order is part of the id and adding a
+## kind at the end cannot renumber the ones before it.
+const KINDS: Array[StringName] = [
+	KIND_STARTER, KIND_GIFT, KIND_STATIC, KIND_TRADE, KIND_PRIZE, KIND_ITEM,
+	KIND_BADGE, KIND_SHOP,
+]
+
+## `id = kind << 40 | bank << 24 | absolute address`. The address is ABSOLUTE, the
+## script's own base plus the command's offset inside it, and that is what makes
+## the id stable: the cache stores one blob per entry point and two entry points
+## into one routine overlap, so a site addressed by (blob, offset) would be
+## counted once per blob that reaches it. Addressed by the byte it lives at, it
+## is one site however many ways in there are, and a runtime reader computes the
+## same number from its own frame.
+##
+## A site that is a map EVENT rather than a script has no address: it uses the
+## map's group as the bank and [constant ID_EVENT_BIT] over the map number and
+## the event index, so the two spaces cannot collide.
+const ID_KIND_SHIFT: int = 40
+const ID_BANK_SHIFT: int = 24
+const ID_ADDRESS_MASK: int = 0xFFFFFF
+const ID_EVENT_BIT: int = 0x800000
+
+## `ObjectEventTypeArray.itemball`, and `BGEVENT_ITEM` for one under a tile.
+const OBJECT_TYPE_ITEMBALL: int = Gen2WorldObject.OBJECTTYPE_ITEMBALL
+const BGEVENT_ITEM: int = Gen2WorldAPI.BGEVENT_ITEM
+
+## How far back a site looks for the conditions guarding it. The whole script, in
+## practice; this is the guard against a decode that runs away.
+const MAX_SCRIPT_COMMANDS: int = 4096
+
+var _data: GameData = null
+## id to row.
+var _rows: Dictionary = {}
+## kind to the ids under it, in decode order.
+var _by_kind: Dictionary = {}
+
+
+## Builds the catalog for [param data]. Walks every imported script once and
+## every map's events once, which is why a caller holds the result rather than
+## asking twice; [method GameData.catalog] does that holding.
+static func build(data: GameData) -> Gen2WorldCatalog:
+	var out := Gen2WorldCatalog.new()
+	out._data = data
+	if data == null:
+		return out
+	out._scan_scripts()
+	out._scan_map_events()
+	return out
+
+
+## [param address] is the command's absolute address: the script's base plus the
+## command's own offset inside it.
+static func pack_id(kind: StringName, bank: int, address: int) -> int:
+	var index: int = KINDS.find(kind)
+	if index < 0:
+		return -1
+	return index << ID_KIND_SHIFT | (bank & 0xFF) << ID_BANK_SHIFT \
+		| (address & ID_ADDRESS_MASK)
+
+
+## The id of a map EVENT site: an item ball or an item under a tile.
+static func pack_event_id(kind: StringName, group: int, number: int, index: int) -> int:
+	return pack_id(kind, group, ID_EVENT_BIT | (number & 0xFF) << 8 | (index & 0xFF))
+
+
+## The row at [param id] with any mod patch already folded in, or empty for an id
+## this cartridge has no site for. This is what a runtime reader asks.
+func check(id: int) -> Dictionary:
+	var row: Variant = _rows.get(id, null)
+	if not row is Dictionary:
+		return {}
+	if _data == null:
+		return (row as Dictionary).duplicate(true)
+	return _data.overlaid_check(id, (row as Dictionary).duplicate(true))
+
+
+## Every id of [param kind], in the order the corpus was walked, which is stable
+## for one cache. Pass nothing for every id of every kind.
+func ids(kind: StringName = &"") -> Array:
+	if String(kind).is_empty():
+		var all: Array = []
+		for name: StringName in KINDS:
+			all.append_array(_by_kind.get(name, []))
+		return all
+	return (_by_kind.get(kind, []) as Array).duplicate()
+
+
+func size() -> int:
+	return _rows.size()
+
+
+## Every row, patched, for a mod planning a placement in one pass.
+func rows(kind: StringName = &"") -> Array:
+	var out: Array = []
+	for id: int in ids(kind):
+		out.append(check(id))
+	return out
+
+
+## The three species Elm's own balls offer, which is what a mod proving a seed
+## traversable starts from. Empty on a cache whose scripts did not decode.
+func possible_starters() -> Array[int]:
+	var out: Array[int] = []
+	for row: Dictionary in rows(KIND_STARTER):
+		var species: int = int(row.get("species", 0))
+		if species > 0 and not out.has(species):
+			out.append(species)
+	return out
+
+
+## The HM items whose move is a field move, which are the rewards a placement
+## must keep reachable. Read off the cartridge's own TM/HM move table rather
+## than written down, so Gold and Crystal each answer for themselves.
+func field_hm_items() -> Array[int]:
+	var out: Array[int] = []
+	if _data == null:
+		return out
+	var count: int = _data.tmhm_moves().size()
+	for number: int in count:
+		var item: int = RomLayout.item_for_tmhm_number(number + 1, count)
+		if not Gen2WorldTMHM.is_hm(item):
+			continue
+		if Gen2WorldFieldMove.is_field_move(_data.tmhm_move(number + 1)):
+			out.append(item)
+	return out
+
+
+## Whether a row's reward is one a later check may be gated behind: a badge, or a
+## field HM. A placement that moves one of these has to prove the seed still
+## finishes; a placement that moves a Potion does not.
+func is_progression(row: Dictionary) -> bool:
+	if StringName(row.get("kind", &"")) == KIND_BADGE:
+		return true
+	return field_hm_items().has(int(row.get("item", 0)))
+
+
+## Walks every imported script, decoding linearly from its first byte. A command
+## the decoder does not know ends that script's walk rather than guessing an
+## operand width, which is the same rule `scan_references` follows: a site found
+## past an unknown command would be at an invented offset.
+func _scan_scripts() -> void:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
+	for key: Variant in _data.world_script_keys():
+		var parts: PackedStringArray = String(key).split(":")
+		if parts.size() != 2:
+			continue
+		## `Gen2WorldScript.pointer_key` is a DECIMAL bank and a hex address.
+		var bank: int = String(parts[0]).to_int()
+		var address: int = String(parts[1]).hex_to_int()
+		_scan_one_script(bank, address, _data.world_script(bank, address), crystal)
+
+
+func _scan_one_script(
+	bank: int, address: int, body: PackedByteArray, crystal: bool
+) -> void:
+	if body.is_empty():
+		return
+	var commands: Array = []
+	var offset: int = 0
+	## The walk does NOT stop at the first `end` or `sjump`. A bounded blob holds
+	## a routine and the branch bodies behind it, and the Game Corner's three
+	## prizes are exactly that: one `.loop` and three labels after its jump.
+	##
+	## It DOES stop at the first byte no command owns. Everything decoded before
+	## that came from a real entry point at a real offset; everything after would
+	## be text or a data table read as code. Two more guards sit behind this one:
+	## a site's numbers have to be ones the cartridge can hold ([method
+	## _plausible]), and a static has to be followed by the `startbattle` that
+	## makes it one.
+	for _step: int in MAX_SCRIPT_COMMANDS:
+		if offset >= body.size():
+			break
+		var command: Dictionary = Gen2WorldScript.command_at(body, offset, crystal)
+		if not bool(command.get("ok", false)):
+			break
+		commands.append(command)
+		offset += int(command["width"])
+	## Two facts about the WHOLE script decide what its give sites mean: a
+	## `takecoins` makes them purchases, and a `pokepic` of the species a
+	## `givepoke` later hands over is the only shape Elm's three balls take and
+	## the only shape anything else in either game does not.
+	## The price is per SITE, not per script: a prize vendor's three branches sit
+	## in one script and each spends its own `takecoins`.
+	var pictured: Dictionary = {}
+	for command: Dictionary in commands:
+		if StringName(command["name"]) == &"pokepic":
+			pictured[int(command.get("pokemon", 0))] = true
+	for command: Dictionary in commands:
+		_record_script_site(
+			bank, address, command, commands, _coin_price(commands, int(command["offset"])),
+			pictured, crystal
+		)
+
+
+## `takecoins`' own operand, which is the purchase price and is what makes a
+## `givepoke` beside it a PRIZE rather than a gift. The source order is give then
+## take, so the answer is the nearest one AFTER [param at]; a script that takes
+## before it gives falls back to the nearest before. Zero when the script spends
+## no coins at all.
+func _coin_price(commands: Array, at: int) -> int:
+	var before: int = 0
+	for command: Dictionary in commands:
+		if StringName(command["name"]) != &"takecoins":
+			continue
+		if int(command["offset"]) > at:
+			return int(command.get("value", 0))
+		before = int(command.get("value", 0))
+	return before
+
+
+func _record_script_site(
+	bank: int, address: int, command: Dictionary, commands: Array, coins: int,
+	pictured: Dictionary, crystal: bool
+) -> void:
+	var offset: int = int(command["offset"])
+	## Each command's own decoded keys, not a positional operand list:
+	## `Gen2WorldScript.command_at` names what it read.
+	match StringName(command["name"]):
+		&"givepoke", &"giveegg":
+			var species: int = int(command.get("pokemon", command.get("value", 0)))
+			var level: int = int(command.get("level", command.get("value_2", 0)))
+			if species <= 0:
+				return
+			var kind: StringName = KIND_GIFT
+			if coins > 0:
+				kind = KIND_PRIZE
+			elif pictured.has(species):
+				kind = KIND_STARTER
+			_add(kind, bank, address, offset, {
+				"species": species, "level": level,
+				"item": int(command.get("item", 0)), "price": coins,
+			}, commands, offset, crystal)
+		&"loadwildmon":
+			## `loadwildmon` then `startbattle` is what a static encounter IS;
+			## two bytes that merely decode as one are not.
+			if not _followed_by(commands, offset, &"startbattle"):
+				return
+			_add(KIND_STATIC, bank, address, offset, {
+				"species": int(command.get("pokemon", 0)),
+				"level": int(command.get("level", 0)),
+			}, commands, offset, crystal)
+		&"trade":
+			var index: int = int(command.get("value", 0))
+			var record: Dictionary = _data.world_trade(index)
+			_add(KIND_TRADE, bank, address, offset, {
+				"trade": index,
+				"species": int(record.get("offered_species", 0)),
+				"requested_species": int(record.get("requested_species", 0)),
+			}, commands, offset, crystal)
+		&"pokemart":
+			## `db dialog_id / dw mart_id`, so the dialog is the byte and the
+			## mart index the word behind it.
+			_add(KIND_SHOP, bank, address, offset, {
+				"mart": int(command.get("address", 0)),
+				"dialog": int(command.get("value", 0)),
+			}, commands, offset, crystal)
+		&"giveitem", &"verbosegiveitem":
+			var item: int = int(command.get("item", command.get("value", 0)))
+			if item <= 0:
+				return
+			_add(KIND_ITEM, bank, address, offset, {
+				"item": item,
+				"quantity": maxi(1, int(command.get("quantity", command.get("value_2", 1)))),
+				"price": coins, "hidden": false,
+			}, commands, offset, crystal)
+		&"setflag":
+			var badge: int = _badge_for_flag(int(command.get("flag", -1)))
+			if badge < 0:
+				return
+			_add(KIND_BADGE, bank, address, offset, {
+				"badge": badge, "engine_flag": int(command.get("flag", 0)),
+			}, commands, offset, crystal)
+
+
+## Whether [param name] is the next few commands after [param at]. The cartridge
+## puts `startbattle` immediately behind its `loadwildmon`, with at most a text
+## or a flag between them.
+static func _followed_by(commands: Array, at: int, name: StringName, within: int = 6) -> bool:
+	var seen: int = 0
+	for command: Dictionary in commands:
+		if int(command["offset"]) <= at:
+			continue
+		if StringName(command["name"]) == name:
+			return true
+		seen += 1
+		if seen >= within:
+			return false
+	return false
+
+
+## Which badge an engine flag grants, or -1. The two profiles number the badge
+## block one apart, so the answer is the cartridge's own list rather than a
+## constant.
+func _badge_for_flag(flag: int) -> int:
+	var flags: Array[int] = Gen2WorldState.BADGE_ENGINE_FLAGS \
+		if Gen2WorldState.is_crystal_profile(_data) \
+		else Gen2WorldState.BADGE_ENGINE_FLAGS_GOLD_SILVER
+	return flags.find(flag)
+
+
+## The item balls and the items under a tile, which are map EVENTS and carry no
+## script of their own: `itemball`'s two bytes are the object's script pointer
+## read as data, and `hiddenitem` is a `bg_event` of type
+## [constant BGEVENT_ITEM].
+func _scan_map_events() -> void:
+	for map: Gen2WorldMap in _data.world_maps():
+		var bank: int = int(map.events.get("bank", 0))
+		var objects: Array = map.events.get("objects", [])
+		for index: int in objects.size():
+			var object: Variant = objects[index]
+			if not object is Dictionary:
+				continue
+			if int((object as Dictionary).get("object_type", 0)) != OBJECT_TYPE_ITEMBALL:
+				continue
+			## `db item, quantity` behind the object's script pointer, read as
+			## data. `Gen2WorldAPI._item_ball_request_for_event` decodes the same
+			## two bytes at runtime and asks this catalog for them.
+			var raw: PackedByteArray = _data.world_script(
+				bank, int((object as Dictionary).get("script", 0))
+			)
+			if raw.size() < 2 or int(raw[0]) <= 0:
+				continue
+			_add_event(KIND_ITEM, map, index, {
+				"item": int(raw[0]), "quantity": maxi(1, int(raw[1])), "hidden": false,
+			})
+		var bg_events: Array = map.events.get("bg_events", [])
+		for index: int in bg_events.size():
+			var event: Variant = bg_events[index]
+			if not event is Dictionary:
+				continue
+			if int((event as Dictionary).get("type", 0)) != BGEVENT_ITEM:
+				continue
+			## `dwb event, item`: the flag first as a word, the item last.
+			var raw: PackedByteArray = _data.world_script(
+				bank, int((event as Dictionary).get("script", 0))
+			)
+			if raw.size() < 3 or int(raw[2]) <= 0:
+				continue
+			_add_event(KIND_ITEM, map, objects.size() + index, {
+				"item": int(raw[2]), "quantity": 1, "hidden": true,
+				"event_flag": int(raw[0]) | (int(raw[1]) << 8),
+			})
+
+
+func _add(
+	kind: StringName, bank: int, address: int, offset: int, fields: Dictionary,
+	commands: Array, at: int, crystal: bool
+) -> void:
+	var row: Dictionary = fields.duplicate()
+	row["id"] = pack_id(kind, bank, address + offset)
+	row["kind"] = kind
+	row["bank"] = bank
+	row["address"] = address + offset
+	row["requires"] = _requirements(commands, at, crystal)
+	_store(row)
+
+
+func _add_event(
+	kind: StringName, map: Gen2WorldMap, index: int, fields: Dictionary
+) -> void:
+	var row: Dictionary = fields.duplicate()
+	row["id"] = pack_event_id(kind, map.group, map.number, index)
+	row["kind"] = kind
+	row["map"] = Vector2i(map.group, map.number)
+	row["event_index"] = index
+	row["requires"] = []
+	_store(row)
+
+
+## A linear walk over bounded blobs finds real sites and, occasionally, three
+## bytes of text that read as a command. A row whose numbers are outside what the
+## cartridge can hold is one of those, and is dropped rather than offered to a
+## mod as somewhere to put a Pokemon.
+func _plausible(row: Dictionary) -> bool:
+	var species: int = int(row.get("species", 0))
+	if row.has("species") and (species < 1 or species > RomLayout.SPECIES_COUNT):
+		return false
+	var level: int = int(row.get("level", 0))
+	if row.has("level") and (level < 1 or level > RomLayout.MAX_LEVEL):
+		return false
+	var item: int = int(row.get("item", 0))
+	if row.has("item") and item != 0 and _data != null and _data.item(item).is_empty():
+		return false
+	if row.has("trade") and _data != null and _data.world_trade(int(row["trade"])).is_empty():
+		return false
+	return true
+
+
+func _store(row: Dictionary) -> void:
+	var id: int = int(row["id"])
+	if id < 0 or _rows.has(id) or not _plausible(row):
+		return
+	_rows[id] = row
+	var kind: StringName = StringName(row["kind"])
+	var list: Array = _by_kind.get(kind, [])
+	list.append(id)
+	_by_kind[kind] = list
+
+
+## What the script tested BEFORE reaching this site: the event and engine flags
+## it checked and the items it asked for. The decoded graph fact a placement
+## needs, and no more than a fact: it does not say the site is unreachable
+## without them, only that the cartridge looked.
+##
+## Read in source order up to the site rather than over the whole script, since a
+## `checkevent` after a `givepoke` guards something else.
+func _requirements(commands: Array, at: int, _crystal: bool) -> Array:
+	var out: Array = []
+	var seen: Dictionary = {}
+	for command: Dictionary in commands:
+		if int(command["offset"]) >= at:
+			break
+		match StringName(command["name"]):
+			&"checkevent":
+				_append_once(out, seen, {"event": int(command.get("flag", 0))})
+			&"checkflag":
+				_append_once(out, seen, {"engine_flag": int(command.get("flag", 0))})
+			&"checkitem":
+				_append_once(out, seen, {"item": int(command.get("value", 0))})
+	return out
+
+
+## One entry per distinct condition. Two entry points into one routine overlap in
+## the cache, so the same `checkevent` is walked once per blob that reaches it.
+static func _append_once(out: Array, seen: Dictionary, entry: Dictionary) -> void:
+	var key: String = str(entry)
+	if seen.has(key):
+		return
+	seen[key] = true
+	out.append(entry)

--- a/game/data/world_catalog.gd.uid
+++ b/game/data/world_catalog.gd.uid
@@ -1,0 +1,1 @@
+uid://clvxntnj0d6w7

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -52,6 +52,11 @@ const RENDERER_EFFECTS_METHOD: String = "set_effects"
 ## world, already resolved to the same [Gen2WorldSprite] the map's own objects
 ## are drawn from, so a renderer draws them with its objects or ignores them.
 const RENDERER_ACTORS_METHOD: String = "set_actors"
+## Optional, world renderers only. Called with the screen's [Gen2WorldEncounters]
+## when the renderer is built. The population itself is drawn through
+## [constant RENDERER_ACTORS_METHOD]; what is only here is the shiny pulse, which
+## is battle-animation OAM over the map and which a renderer may ignore.
+const RENDERER_ENCOUNTERS_METHOD: String = "set_encounters"
 ## Optional, battle renderers only. Called with a [Gen2BattleWorldContext] once
 ## per battle, before the first [code]set_view[/code], saying where the fight is
 ## happening: a renderer staging it on the map needs that and one drawing the
@@ -158,6 +163,9 @@ var _world_renderers: Dictionary = {}
 ## loaded, the way its entry object is: an actor carries the mod's own state
 ## between frames. See [method register_world_actor].
 var _world_actors: Dictionary = {}
+## Mod id to the visible-encounter provider it registered, held the way an actor
+## is. See [method register_visible_encounters].
+var _visible_encounters: Dictionary = {}
 var _selected_world_renderer: StringName = BUILT_IN_RENDERER
 var _battle_renderers: Dictionary = {}
 var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
@@ -265,6 +273,48 @@ func world_actor_ids() -> Array:
 ## on one row are drawn in.
 func world_actors() -> Array:
 	return _world_actors.values()
+
+
+## Registers a VISIBLE ENCOUNTER provider under [param id]: a bounded population
+## of wild Pokemon standing on the map, met by walking into one, instead of the
+## roll a step takes.
+##
+## [param provider] is an object and not a script, for the reason an actor is:
+## the host drives the one it is handed. It must be a [RefCounted] and never a
+## [Node], and must answer the four methods in
+## [constant Gen2WorldEncounters.PROVIDER_METHODS].
+##
+## The provider owns its population and nothing else. Which cells are eligible,
+## which table is active, whether an entry is inside both, what a shiny is and
+## what meeting one starts are all the host's, and while at least one provider is
+## registered the ordinary post-step roll is off. See [Gen2WorldEncounters].
+func register_visible_encounters(id: StringName, provider: Object) -> Dictionary:
+	if String(id).is_empty() or provider == null:
+		return {"ok": false, "reason": &"invalid_provider"}
+	if provider is Node:
+		return {"ok": false, "reason": &"provider_is_a_node", "detail": String(id)}
+	var missing: Array[String] = []
+	for method: String in Gen2WorldEncounters.PROVIDER_METHODS:
+		if not provider.has_method(method):
+			missing.append(method)
+	if not missing.is_empty():
+		return {
+			"ok": false, "reason": &"provider_missing_methods",
+			"detail": "%s: %s" % [id, ", ".join(missing)],
+		}
+	if _visible_encounters.has(id):
+		return {"ok": false, "reason": &"duplicate_provider", "detail": String(id)}
+	_visible_encounters[id] = provider
+	return {"ok": true, "id": id}
+
+
+func visible_encounter_ids() -> Array:
+	return _visible_encounters.keys()
+
+
+## Every registered provider, in registration order.
+func visible_encounter_providers() -> Array:
+	return _visible_encounters.values()
 
 
 ## Registers a battle renderer under [param id]. See

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -935,6 +935,27 @@ func patch_fishing_time_group(id: StringName, index: int, fields: Dictionary) ->
 	)
 
 
+## One [Gen2WorldCatalog] site, by the stable id the catalog gave it. This is how
+## a mod reaches a starter, a gift, a static battle, a trade, a Game Corner
+## prize, an item on the ground, a badge or a shop.
+##
+## Name only the field that moves: `species` and `level` for anything that hands
+## over a Pokemon, `item` and `quantity` for anything that hands over an item,
+## `price` for a prize, `mart` for a shop, `badge` for a badge. The site still
+## runs the cartridge's own script, so its completion flag, its dialogue, its
+## inventory transaction and its battle flow are untouched.
+##
+## An id no cartridge site carries changes nothing, exactly as a species patch of
+## a number this cartridge lacks does. Read the ids from
+## `GameData.catalog().rows(kind)` rather than computing one.
+func patch_check(id: StringName, check_id: int, fields: Dictionary) -> Dictionary:
+	if check_id < 0:
+		return {"ok": false, "reason": &"not_a_check_id", "detail": str(check_id)}
+	return Gen2ContentOverlay.shared().patch(
+		Gen2ContentOverlay.KIND_CHECK, id, check_id, fields
+	)
+
+
 ## The overlay every opened [GameData] reads through, for a launcher listing what
 ## a mod changed before the player starts.
 func content_overlay() -> Gen2ContentOverlay:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -170,6 +170,12 @@ var _selected_world_renderer: StringName = BUILT_IN_RENDERER
 var _battle_renderers: Dictionary = {}
 var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
 var _menu_entries: Dictionary = {}
+## The rows mods add to a party member's own submenu, in registration order. See
+## [method register_party_member_menu].
+var _party_member_entries: Array = []
+## `{manifest, provider}` per mod told which save is being played, in
+## registration order. See [method register_save_lifecycle].
+var _save_providers: Array = []
 var _subscribers: Dictionary = {}
 var _failures: Array = []
 
@@ -386,6 +392,50 @@ func register_menu_entry(menu: StringName, id: StringName, entry: Dictionary) ->
 	entries.append(registered)
 	_menu_entries[menu] = entries
 	return {"ok": true, "id": id}
+
+
+## Adds one row to the PARTY MEMBER submenu, the box a party slot opens.
+##
+## Unlike [method register_menu_entry] a row here is about a SLOT rather than
+## about the menu, so both halves are Callables taking the one-based slot: the
+## label so a mod can say something different on the slot it already owns, and
+## the handler so it knows which one was chosen. Both are validated here, where
+## the mod's name is still in hand.
+##
+## Outside battle only. A battle's party list is a switch, and a row that ran a
+## mod's field action in the middle of a turn would be world state changing while
+## the turn owns it.
+func register_party_member_menu(id: StringName, entry: Dictionary) -> Dictionary:
+	if String(id).is_empty():
+		return {"ok": false, "reason": &"invalid_party_menu_entry"}
+	var label: Variant = entry.get("label", null)
+	var handler: Variant = entry.get("handler", null)
+	for pair: Array in [["label", label], ["handler", handler]]:
+		if not pair[1] is Callable or not (pair[1] as Callable).is_valid():
+			return {
+				"ok": false, "reason": &"party_menu_entry_missing_callable",
+				"detail": "%s: %s" % [id, pair[0]],
+			}
+	for existing: Dictionary in _party_member_entries:
+		if StringName(existing["kind"]) == id:
+			return {"ok": false, "reason": &"duplicate_party_menu_entry", "detail": String(id)}
+	_party_member_entries.append({"kind": id, "label": label, "handler": handler})
+	return {"ok": true, "id": id}
+
+
+## The mod rows for [param slot], one-based, each `{kind, label, handler}` with
+## the label already resolved. Empty inside a battle. A label callable answering
+## an empty string drops its own row, which is how a mod shows one conditionally.
+func party_member_entries(slot: int, in_battle: bool = false) -> Array:
+	var out: Array = []
+	if in_battle or slot < 1:
+		return out
+	for entry: Dictionary in _party_member_entries:
+		var label: String = String((entry["label"] as Callable).call(slot))
+		if label.is_empty():
+			continue
+		out.append({"kind": entry["kind"], "label": label, "handler": entry["handler"]})
+	return out
 
 
 ## Every entry registered for [param menu], in registration order. The callers
@@ -843,11 +893,46 @@ func patch_encounter(
 	return Gen2ContentOverlay.shared().patch(Gen2ContentOverlay.KIND_ENCOUNTER, id, at, fields)
 
 
-## The same for one fishing group, numbered as the map headers number them. The
-## treemon sets, the Bug Contest list and the roaming mons are not patchable
-## yet; they are read straight off the cache.
+## The same for one fishing group, numbered as the map headers number them.
 func patch_fishing_group(id: StringName, group: int, fields: Dictionary) -> Dictionary:
 	return Gen2ContentOverlay.shared().patch(Gen2ContentOverlay.KIND_FISHING, id, group, fields)
+
+
+## One treemon SET, by the set number [method GameData.treemon_set_for_map]
+## answers: Headbutt and Rock Smash draw from the same table and differ only in
+## which map list names the set. `common` and `rare` are arrays and replace
+## whole; each row is `{species, level, percent}` and the percent is the roll.
+func patch_treemon_set(id: StringName, set_index: int, fields: Dictionary) -> Dictionary:
+	return Gen2ContentOverlay.shared().patch(
+		Gen2ContentOverlay.KIND_TREEMON, id, set_index, fields
+	)
+
+
+## One `ContestMons` row by index. Name `species`, `min_level` or `max_level`;
+## `percent` is both the choice roll's weight and part of what the judging reads,
+## so leaving it out leaves the contest scoring exactly as the cartridge has it.
+func patch_bug_contest_mon(id: StringName, index: int, fields: Dictionary) -> Dictionary:
+	return Gen2ContentOverlay.shared().patch(
+		Gen2ContentOverlay.KIND_BUG_CONTEST, id, index, fields
+	)
+
+
+## One roaming mon by index. Name `species` or `level`; `map_group` and
+## `map_number` are where it currently is, which is live state the roamer's own
+## movement writes and a patch must not pin.
+func patch_roaming_mon(id: StringName, index: int, fields: Dictionary) -> Dictionary:
+	return Gen2ContentOverlay.shared().patch(
+		Gen2ContentOverlay.KIND_ROAMING, id, index, fields
+	)
+
+
+## One of the day/night fishing substitutions, by index. A rod entry whose
+## species byte is zero defers to these, and its own `threshold` is the bite and
+## stays with the entry rather than moving here.
+func patch_fishing_time_group(id: StringName, index: int, fields: Dictionary) -> Dictionary:
+	return Gen2ContentOverlay.shared().patch(
+		Gen2ContentOverlay.KIND_FISHING_TIME, id, index, fields
+	)
 
 
 ## The overlay every opened [GameData] reads through, for a launcher listing what
@@ -1085,6 +1170,88 @@ func write_save_data(
 	if save == null:
 		return {"ok": false, "reason": &"missing_mod_save"}
 	return save.set_mod_data(manifest.id, value)
+
+
+## Checked at registration. See [method register_save_lifecycle].
+const SAVE_LIFECYCLE_METHODS: Array[String] = [
+	"save_created", "save_activated", "save_deactivated",
+]
+
+
+## Registers a provider told which save is being played, so a mod can hold a run
+## rather than an installation.
+##
+## [param manifest] is the object `register()` was handed, and it is the
+## capability: the host keeps it beside the provider, so a callback can reach
+## [method read_save_data] and [method write_save_data] for its OWN namespace and
+## no other mod's. A manifest this host did not discover registers nothing.
+##
+## [param provider] is a [RefCounted] answering
+## [constant SAVE_LIFECYCLE_METHODS]. Ordering is in `docs/MODS.md`; the part
+## that matters here is that the host drops every lifecycle mod's overlay
+## contributions before a `save_activated` runs, so two slots cannot leak
+## patches into one another and a provider that fails leaves nothing installed.
+func register_save_lifecycle(manifest: Gen2ModManifest, provider: Object) -> Dictionary:
+	if not _owns_manifest(manifest):
+		return {"ok": false, "reason": &"unknown_mod_save_owner"}
+	if provider == null or provider is Node:
+		return {"ok": false, "reason": &"invalid_save_provider", "detail": String(manifest.id)}
+	var missing: Array[String] = []
+	for method: String in SAVE_LIFECYCLE_METHODS:
+		if not provider.has_method(method):
+			missing.append(method)
+	if not missing.is_empty():
+		return {
+			"ok": false, "reason": &"save_provider_missing_methods",
+			"detail": "%s: %s" % [manifest.id, ", ".join(missing)],
+		}
+	for entry: Dictionary in _save_providers:
+		if (entry["manifest"] as Gen2ModManifest).id == manifest.id:
+			return {"ok": false, "reason": &"duplicate_save_provider", "detail": String(manifest.id)}
+	_save_providers.append({"manifest": manifest, "provider": provider})
+	return {"ok": true, "id": manifest.id}
+
+
+func save_lifecycle_ids() -> Array:
+	var out: Array = []
+	for entry: Dictionary in _save_providers:
+		out.append((entry["manifest"] as Gen2ModManifest).id)
+	return out
+
+
+## A save that has just been made, before it is written or played. A provider
+## snapshots whatever its run is built from into its own namespace here; there is
+## nothing to clear, since the save carries no run yet.
+func created_save(save: Gen2SaveData) -> void:
+	for entry: Dictionary in _save_providers:
+		entry["provider"].call("save_created", save)
+
+
+## The save about to be played, or null for a DEVELOPMENT run: one started
+## without a selected slot, which has no namespace to read and must not be handed
+## an invented save to write into.
+##
+## Every lifecycle mod's overlay contributions are dropped first, in one pass, so
+## the callbacks that follow all start from the cartridge whatever order they run
+## in. A mod that patches at load time and registers no provider is untouched.
+func activate_save(save: Gen2SaveData) -> void:
+	_clear_save_overlays()
+	for entry: Dictionary in _save_providers:
+		entry["provider"].call("save_activated", save)
+
+
+## The save was closed. The overlay is cleared after, not before, so nothing is
+## left patched by a run nobody is playing.
+func deactivate_save() -> void:
+	for entry: Dictionary in _save_providers:
+		entry["provider"].call("save_deactivated")
+	_clear_save_overlays()
+
+
+func _clear_save_overlays() -> void:
+	var overlay: Gen2ContentOverlay = Gen2ContentOverlay.shared()
+	for entry: Dictionary in _save_providers:
+		overlay.clear_owner((entry["manifest"] as Gen2ModManifest).id)
 
 
 func _owns_manifest(manifest: Gen2ModManifest) -> bool:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -7,12 +7,16 @@ extends RefCounted
 ## and say why something was refused without running a line of mod code.
 ##
 ## [code]api_version[/code] is [Gen2ModHost]'s contract, not the mod's own
-## version. A mod built against an older host is refused rather than allowed to
-## fail somewhere less obvious.
+## version. A mod built against a NEWER host is refused rather than allowed to
+## fail somewhere less obvious; one built against an older one still runs, since
+## every version so far has only added to the contract.
 
 const FILENAME: String = "mod.json"
 ## Bumped when the host contract changes in a way an existing mod would notice.
-const API_VERSION: int = 1
+## 2 added [method Gen2ModHost.register_visible_encounters].
+const API_VERSION: int = 2
+## The oldest contract this host still answers. See [constant API_VERSION].
+const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase
 ## alphabet. A mod cannot name itself something that escapes its own folder.
 const ID_PATTERN: String = "^[a-z0-9][a-z0-9_-]*$"
@@ -92,7 +96,7 @@ static func from_dictionary(source: Dictionary, directory: String) -> Dictionary
 			manifest.games.append(StringName(game))
 	if regex.search(String(manifest.id)) == null:
 		return _refuse(&"invalid_id", String(manifest.id))
-	if manifest.api_version != API_VERSION:
+	if manifest.api_version < MIN_API_VERSION or manifest.api_version > API_VERSION:
 		return _refuse(
 			&"unsupported_api_version",
 			"mod declares %d, host provides %d" % [manifest.api_version, API_VERSION]

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -175,12 +175,19 @@ func party_snapshot() -> Dictionary:
 ## The MAIL branch is not reproduced: ItemIsMail tests the held item against
 ## data/items/mail_items.asm, and this project has no mail, so ITEM is always
 ## the entry in that position.
-static func submenu_items_for(data: GameData, mon: Gen2SaveMon) -> Array:
+## [param slot] is one-based and [param in_battle] is whether the list belongs to
+## a turn: both only decide which mod rows are offered, and neither changes a
+## cartridge row.
+static func submenu_items_for(
+	data: GameData, mon: Gen2SaveMon, slot: int = 0, in_battle: bool = false
+) -> Array:
 	var items: Array = []
 	if mon == null:
 		return items
 	# The source compares wCurPartySpecies against EGG ($fd); this save model
 	# carries the same fact as Gen2SaveMon.is_egg beside a real species.
+	## An egg is three rows and no moves, and a mod gets none of them: there is
+	## nothing to follow, teach or send out, and the source itself offers less.
 	if mon.is_egg:
 		items.append(_option_entry(OPTION_STATS, "STATS"))
 		items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
@@ -199,6 +206,16 @@ static func submenu_items_for(data: GameData, mon: Gen2SaveMon) -> Array:
 	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
 	items.append(_option_entry(OPTION_MOVE, "MOVE"))
 	items.append(_option_entry(OPTION_ITEM, "ITEM", true))
+	## After every cartridge action and before CANCEL, which is the source's own
+	## last row and the way out of the box. A mod cannot displace one: the list
+	## still stops at `NUM_MONMENU_ITEMS`, so rows past it are simply not offered.
+	for entry: Dictionary in Gen2ModHost.instance().party_member_entries(slot, in_battle):
+		if items.size() >= MAX_SUBMENU_ITEMS:
+			break
+		items.append({
+			"kind": &"mod_party_action", "mod": entry["kind"],
+			"label": entry["label"], "handler": entry["handler"], "available": true,
+		})
 	if items.size() < MAX_SUBMENU_ITEMS:
 		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
 	return items
@@ -321,6 +338,17 @@ func _confirm() -> void:
 				"slot": _member_cursor,
 				"name": _display_name(_save.party[_member_cursor]),
 			})
+		&"mod_party_action":
+			## The handler is the mod's, and the slot is the only thing it is
+			## told: the menu closes behind it the way a field move's does.
+			(entry["handler"] as Callable).call(_member_cursor + 1)
+			_close_submenu()
+			action_chosen.emit({
+				"kind": &"mod_party_action",
+				"mod": StringName(entry.get("mod", &"")),
+				"slot": _member_cursor,
+				"name": _display_name(_save.party[_member_cursor]),
+			})
 		&"option":
 			if StringName(entry.get("option", &"")) == OPTION_ITEM:
 				_open_item_menu()
@@ -402,7 +430,7 @@ func _open_item_menu() -> void:
 func _open_submenu() -> void:
 	if _member_cursor < 0 or _member_cursor >= _party_size():
 		return
-	_submenu_items = submenu_items_for(_data, _save.party[_member_cursor])
+	_submenu_items = submenu_items_for(_data, _save.party[_member_cursor], _member_cursor + 1)
 	_submenu_cursor = 0
 	_submenu_open = not _submenu_items.is_empty()
 	_item_menu_open = false

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -185,6 +185,9 @@ func _on_speech_finished(player_name: String) -> void:
 		return
 	created.gender = _gender
 	created.label = _label
+	## Before the write: a mod holding a run snapshots what built it into the
+	## save's own namespace, and that has to be in the bytes on disk.
+	GameRuntime.announce_new_save(created)
 	var result: Dictionary = Gen2SaveStore.save(created, _data)
 	if not bool(result["ok"]):
 		_fail(String(result["message"]))

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -28,6 +28,9 @@ const ICON_FRAME_FRAMES: int = 9
 const ICON_FRAMES: int = 2
 
 var _actors: Array = []
+## The visible-encounter population, drawn in the same pass. See
+## [method set_encounters].
+var _encounters: Gen2WorldEncounters = null
 var _world: Gen2WorldAPI = null
 ## Held rather than re-read, so a mod's `sprites()` is asked once a frame however
 ## many times the screen redraws and two views agree.
@@ -42,8 +45,17 @@ func set_actors(actors: Array) -> void:
 	_collect()
 
 
+## The host's own visible-encounter layer, whose population is drawn through this
+## one so a wild standing on the map sorts into the same rows and reaches both
+## views. What it IS is not presentation and lives in [Gen2WorldEncounters]; what
+## it looks like is one more sprite here.
+func set_encounters(encounters: Gen2WorldEncounters) -> void:
+	_encounters = encounters
+	_collect()
+
+
 func has_actors() -> bool:
-	return not _actors.is_empty()
+	return not _actors.is_empty() or (_encounters != null and _encounters.active())
 
 
 ## The map changed, or the view was created.
@@ -57,7 +69,7 @@ func set_world(world: Gen2WorldAPI) -> void:
 ## One world frame, spent after the player's step so an actor reading
 ## `player_step_offset_cells()` sees this frame. Answers whether anything moved.
 func advance_frame() -> bool:
-	if _actors.is_empty():
+	if not has_actors():
 		return false
 	_frame += 1
 	for actor: Object in _actors:
@@ -67,8 +79,9 @@ func advance_frame() -> bool:
 	return _changed(before, _sprites)
 
 
-## { sprite, facing, frame, position_cells }, sorted by the row stood on and then
-## by registration order, the way the map's own objects are.
+## { sprite, facing, frame, position_cells, colors }, sorted by the row stood on
+## and then by registration order, the way the map's own objects are. `colors` is
+## empty for everything but a visible encounter.
 func sprites() -> Array:
 	return _sprites
 
@@ -80,6 +93,11 @@ func _collect() -> void:
 	for index: int in _actors.size():
 		for entry: Variant in _actors[index].call("sprites"):
 			var resolved: Dictionary = _resolve(entry, index)
+			if not resolved.is_empty():
+				_sprites.append(resolved)
+	if _encounters != null:
+		for entry: Variant in _encounters.actor_entries():
+			var resolved: Dictionary = _resolve(entry, _actors.size())
 			if not resolved.is_empty():
 				_sprites.append(resolved)
 	_sprites.sort_custom(_sort)
@@ -113,6 +131,11 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 		"frame": _frame_for(sprite),
 		"position_cells": Vector2(row.get("position_cells", Vector2.ZERO)),
 		"order": order,
+		# An overworld sprite wears one of the map's own sprite palettes. A
+		# visible encounter wears the SPECIES' four colours instead, which is the
+		# only way a shiny one is a shiny one before the battle starts. A view
+		# that does not read this draws the ordinary palette and is not wrong.
+		"colors": row.get("colors", PackedColorArray()),
 	}
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -687,7 +687,8 @@ func set_movement_mode(mode: StringName) -> Dictionary:
 ## byte it stashes, and `storage_full` for `CheckPartyFullAfterContest`.
 func set_party_summary(
 	count: int, has_pokerus: bool, species: Array[int] = [] as Array[int],
-	moves: Array = [], names: Array = [], eggs: Array = [], extra: Dictionary = {}
+	moves: Array = [], names: Array = [], eggs: Array = [], extra: Dictionary = {},
+	fainted: Array = []
 ) -> Dictionary:
 	if count < 0:
 		return {"ok": false, "reason": &"invalid_party_summary", "count": count}
@@ -695,6 +696,10 @@ func set_party_summary(
 		"count": count, "pokerus": has_pokerus, "species": species.duplicate(),
 		"moves": moves.duplicate(true), "names": names.duplicate(),
 		"eggs": eggs.duplicate(),
+		## Per slot, beside the three per-slot arrays above. `lead_fainted` in
+		## `extra` is the same fact about slot 0 and stays: the Bug Contest's own
+		## scripts ask it by that name.
+		"fainted": fainted.duplicate(),
 	}
 	for key: Variant in extra:
 		_party_summary[key] = extra[key]

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2799,6 +2799,9 @@ func events_at(cell: Vector2i = player_cell) -> Array:
 				continue
 			var event: Dictionary = raw.duplicate(true)
 			event["kind"] = StringName(source)
+			## Its place in its own list, which is the only stable name a bg
+			## event has: [Gen2WorldCatalog] addresses an item under a tile by it.
+			event["event_index"] = index
 			if source == "objects":
 				event["object_index"] = index
 			out.append(event)
@@ -3259,6 +3262,10 @@ func _item_ball_request_for_event(event: Dictionary) -> Dictionary:
 	var raw: PackedByteArray = data.world_script(bank, pointer)
 	if raw.size() < 2 or int(raw[0]) <= 0:
 		return {}
+	## The catalog addresses a ball by its map and its object index, so a mod
+	## that moved what is in it is read here rather than in the runner: these two
+	## bytes are data, not a command anything executes.
+	var patched: Dictionary = _catalogued_item(object_index, int(raw[0]), maxi(1, int(raw[1])))
 	return {
 		"kind": &"item_ball",
 		"map_group": current_map.group,
@@ -3268,9 +3275,23 @@ func _item_ball_request_for_event(event: Dictionary) -> Dictionary:
 		"script": pointer,
 		"object_index": object.index,
 		"event": event.duplicate(true),
-		"item": int(raw[0]),
-		"quantity": maxi(1, int(raw[1])),
+		"item": int(patched["item"]),
+		"quantity": int(patched["quantity"]),
 	}
+
+
+## One item site's row from [Gen2WorldCatalog], by the map event it is. Answers
+## the cartridge's own numbers when no mod has moved it.
+func _catalogued_item(event_index: int, item: int, quantity: int) -> Dictionary:
+	var fallback: Dictionary = {"item": item, "quantity": quantity}
+	if data == null or current_map == null or not data.has_content_overlay():
+		return fallback
+	var row: Dictionary = data.catalog().check(Gen2WorldCatalog.pack_event_id(
+		Gen2WorldCatalog.KIND_ITEM, current_map.group, current_map.number, event_index
+	))
+	if row.is_empty():
+		return fallback
+	return {"item": int(row["item"]), "quantity": maxi(1, int(row["quantity"]))}
 
 
 ## `.itemifset`'s own record (engine/overworld/events.asm): a BGEVENT_ITEM
@@ -3290,10 +3311,15 @@ func _hidden_item_record(event: Dictionary) -> Dictionary:
 	)
 	if raw.size() < 3 or int(raw[2]) <= 0:
 		return {"ok": false, "reason": &"invalid_hidden_item", "pointer": pointer}
+	## A hidden item is indexed after the map's objects, which is the order the
+	## catalog walked them in. Its own event flag is the site's completion and is
+	## never a patch.
+	var index: int = (current_map.events.get("objects", []) as Array).size() \
+		+ maxi(0, int(event.get("event_index", 0)))
 	return {
 		"ok": true,
 		"flag": int(raw[0]) | (int(raw[1]) << 8),
-		"item": int(raw[2]),
+		"item": int(_catalogued_item(index, int(raw[2]), 1)["item"]),
 	}
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1667,14 +1667,92 @@ func judge_bug_contest(random: RandomNumberGenerator) -> Dictionary:
 ## which is both an encounter outside the grass and, over a walk, several times
 ## the rate the cartridge has.
 func can_encounter_wild_mon() -> bool:
+	return can_encounter_wild_mon_at(player_cell)
+
+
+## `CanEncounterWildMon` asked of a cell the player is not standing on, which is
+## what a visible encounter needs before it may put one there. The engine flag is
+## the map's, the rest is the cell's.
+func can_encounter_wild_mon_at(cell: Vector2i) -> bool:
 	if state.wild_encounters_off():
 		return false
-	var code: int = collision_code_at(player_cell)
+	var code: int = collision_code_at(cell)
 	var environment: int = current_map.environment if current_map != null else 0
 	if environment != ENVIRONMENT_CAVE and environment != ENVIRONMENT_DUNGEON \
 		and not Gen2WorldCollision.gates_encounter(code):
 		return false
 	return not Gen2WorldCollision.is_ice(code)
+
+
+## Every cell of the current map a wild could be met on, grouped by the method
+## the terrain resolves to, as [method encounter_request] resolves it: WATER_TILE
+## is `surf` and LAND_TILE is `grass`, and a cave or dungeon floor is grass
+## whether or not it is drawn as grass.
+##
+## One narrowing on [method can_encounter_wild_mon]: a cell nothing can stand on
+## is not offered. A cave's walls pass the gate, since the cave branch skips the
+## grass test, and a Pokemon cannot be put inside one.
+##
+## The map's own collision grid and nothing past it: a connection's cells belong
+## to the connected map's own tables.
+func visible_encounter_cells() -> Dictionary:
+	var out: Dictionary = {
+		Gen2WorldEncounter.METHOD_GRASS: PackedVector2Array(),
+		Gen2WorldEncounter.METHOD_SURF: PackedVector2Array(),
+	}
+	if current_map == null or state.wild_encounters_off():
+		return out
+	var size: Vector2i = map_size_cells()
+	for y: int in size.y:
+		for x: int in size.x:
+			var cell := Vector2i(x, y)
+			if not can_encounter_wild_mon_at(cell):
+				continue
+			var permission: int = collision_permission_at(cell)
+			if permission == Gen2WorldCollision.WATER_TILE:
+				out[Gen2WorldEncounter.METHOD_SURF].append(Vector2(cell))
+			elif permission == Gen2WorldCollision.LAND_TILE:
+				out[Gen2WorldEncounter.METHOD_GRASS].append(Vector2(cell))
+	return out
+
+
+## The wild table each method would resolve against right now, with the Bug
+## Contest's and the swarm's substitutions already made and the time of day
+## already picked. `slots` is the flat list of `{species, min_level, max_level}`
+## a roll would choose from, which is what a caller populating a map with visible
+## Pokemon needs and what it must not derive for itself. The two bounds are equal
+## for every table but the Bug Contest's, which rolls a level of its own.
+func active_encounter_tables() -> Dictionary:
+	var out: Dictionary = {}
+	if current_map == null or data == null:
+		return out
+	for method: StringName in [Gen2WorldEncounter.METHOD_GRASS, Gen2WorldEncounter.METHOD_SURF]:
+		var source: StringName = Gen2WorldEncounter.SOURCE_NORMAL
+		var record: Dictionary = data.world_encounter(
+			method, current_map.group, current_map.number
+		)
+		if bug_contest_active() and method == Gen2WorldEncounter.METHOD_GRASS:
+			out[method] = {
+				"source": Gen2WorldBugContest.SOURCE_CONTEST,
+				"slots": Gen2WorldBugContest.active_slots(data.bug_contest_mons()),
+			}
+			continue
+		if state.swarm_active_on(current_map.group, current_map.number):
+			var swarm_method: StringName = &"swarm_grass" \
+				if method == Gen2WorldEncounter.METHOD_GRASS else &"swarm_water"
+			var swarm_record: Dictionary = data.world_encounter(
+				swarm_method, current_map.group, current_map.number
+			)
+			if not swarm_record.is_empty():
+				record = swarm_record
+				source = Gen2WorldEncounter.SOURCE_SWARM
+		if record.is_empty():
+			continue
+		out[method] = {
+			"source": source,
+			"slots": Gen2WorldEncounter.active_slots(record, method, object_time_of_day),
+		}
+	return out
 
 
 ## Rolls an encounter from the current map. Auto mode preserves the existing

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -39,8 +39,12 @@ static func prepare(
 				return _failure(&"invalid_wild_species", {"species": species})
 			if level < 1 or level > Gen2Experience.MAX_LEVEL:
 				return _failure(&"invalid_wild_level", {"level": level})
+			# `LoadEnemyMon` rolls `wEnemyMonDVs` unless the caller already has
+			# them; a visible encounter chose its own before the player met it,
+			# and shininess is a fact about those four numbers alone.
 			var wild_mon: Gen2BattleMon = Gen2BattleMon.create(
-				data, species, level, data.moves_at_level(species, level)
+				data, species, level, data.moves_at_level(species, level),
+				int(values.get("dvs", Gen2BattleMon.PERFECT_DVS))
 			)
 			# LoadEnemyMon's .TreeMon branch: a headbutt encounter whose species
 			# is in CheckSleepingTreeMon's list for the current time of day

--- a/game/world/world_bug_contest.gd
+++ b/game/world/world_bug_contest.gd
@@ -107,6 +107,23 @@ const BATTLE_TYPE: int = Gen2Battle.BATTLETYPE_CONTEST
 
 
 ## `.RandomLevel`: a level between the row's own two, taken as
+## `ContestMons` in the shape [method Gen2WorldEncounter.active_slots] answers
+## in, which is how a caller reads the table the contest replaces the map's with.
+## The percentages are the roll's and are not part of what a slot offers.
+static func active_slots(mons: Array) -> Array:
+	var out: Array = []
+	for row: Variant in mons:
+		if not row is Dictionary:
+			continue
+		var low: int = int((row as Dictionary).get("min_level", 1))
+		out.append({
+			"species": int((row as Dictionary).get("species", 0)),
+			"min_level": low,
+			"max_level": maxi(low, int((row as Dictionary).get("max_level", low))),
+		})
+	return out
+
+
 ## `Random % (max - min + 1) + min`, which `SimpleDivide`'s remainder is. Equal
 ## bounds skip the roll entirely, so a Venomoth costs no draw.
 static func _level(row: Dictionary, random: RandomNumberGenerator) -> int:

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -302,6 +302,24 @@ static func _slots(record: Dictionary, method: StringName, time_of_day: int) -> 
 	return (value as Array)[index] if index < (value as Array).size() and (value as Array)[index] is Array else []
 
 
+## The slots [method resolve] would draw from, as
+## `{species, min_level, max_level}`. A cartridge table names one level per slot,
+## so the two bounds are equal; the shape is the Bug Contest's as well, whose
+## rows are a range. See [method Gen2WorldAPI.active_encounter_tables].
+static func active_slots(record: Dictionary, method: StringName, time_of_day: int) -> Array:
+	var out: Array = []
+	for slot: Variant in _slots(record, method, time_of_day):
+		if not slot is Dictionary:
+			continue
+		var level: int = int((slot as Dictionary).get("level", 0))
+		out.append({
+			"species": int((slot as Dictionary).get("species", 0)),
+			"min_level": level,
+			"max_level": level,
+		})
+	return out
+
+
 static func _choose_slot(random: RandomNumberGenerator, method: StringName) -> int:
 	var probabilities: Array[int] = (
 		RomLayout.WILD_WATER_PROBABILITIES if method == METHOD_SURF

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -1,0 +1,382 @@
+class_name Gen2WorldEncounters
+extends RefCounted
+
+## Wild Pokemon a mod puts on the map instead of a step roll, driven and
+## validated by the host. A mod registers a PROVIDER through
+## [method Gen2ModHost.register_visible_encounters]; the screen gives it a
+## snapshot of where a wild may stand and which table each method resolves to,
+## spends one frame of it per hardware frame, and takes back a bounded list of
+## entries.
+##
+## The division is the point. The PROVIDER owns the population: how many there
+## are, where each one goes, how it moves and what it does after a battle. The
+## HOST owns every rule a mod must not re-derive: which cells are eligible, which
+## table is active, whether an entry is inside both, what a shiny is, and what
+## meeting one starts. Nothing here reads a node.
+##
+## [Gen2WorldActors] is the layer next to this one and the two are different
+## contracts: an actor is presentation and takes part in nothing, a visible
+## encounter is met and fought.
+
+## Checked at registration, where the mod's name is still in hand.
+const PROVIDER_METHODS: Array[String] = [
+	"set_context", "advance_frame", "encounters", "battle_finished",
+]
+
+## How many entries one frame may carry, over every provider. A population is
+## the mod's to cap; this is the host refusing to draw a thousand of them.
+const MAX_ENTRIES: int = 32
+
+## `ANIM_SEND_OUT_MON` with `wBattleAnimParam` at 1, which is the whole of the
+## cartridge's shiny sparkle: `BattleCheckEnemyShininess` plays the same
+## animation a second time with the param set (engine/battle/core.asm).
+const SHINY_ANIM: int = 0x101
+const SHINY_ANIM_PARAM: int = 1
+
+## A pulse for an id that pulsed fewer frames ago than this is dropped, so a
+## provider may ask on every frame and get the cadence it asked for once.
+const PULSE_FRAMES: int = 600
+
+## The four `Gen2WorldSprite` facings.
+const MAX_FACING: int = Gen2WorldSprite.FACING_RIGHT
+
+var _providers: Array = []
+var _world: Gen2WorldAPI = null
+var _anim_data: Gen2BattleAnimData = null
+## Bumped on every map change, and carried in the context so a provider can tell
+## a stale snapshot from a fresh one.
+var _generation: int = 0
+var _context: Dictionary = {}
+## Validated entries this frame, each with the provider that produced it.
+var _entries: Array = []
+## Entry id to the provider that owns it, so a battle result reaches the right
+## one after the entry itself is gone.
+var _owners: Dictionary = {}
+var _frame: int = 0
+## Entry id to the frame its last pulse started on.
+var _pulsed: Dictionary = {}
+var _pulse: Gen2BattleAnimPlayer = null
+var _pulse_id: StringName = &""
+## What the running pulse's commands asked for this frame: the screen owns the
+## audio device, as the battle screen does.
+var _frame_commands: Array = []
+
+
+## [param providers] is [method Gen2ModHost.visible_encounter_providers], in
+## registration order.
+func set_providers(providers: Array) -> void:
+	_providers = providers
+	_reset()
+
+
+func active() -> bool:
+	return not _providers.is_empty()
+
+
+## The map changed, or the view was created. Every entry, every sprite and any
+## running pulse is discarded before the new map is drawn, and each provider is
+## handed the new context.
+func set_world(world: Gen2WorldAPI, anim_data: Gen2BattleAnimData = null) -> void:
+	if anim_data != null:
+		_anim_data = anim_data
+	## Called again whenever a view is rebuilt, which a keybind swapping
+	## renderers does mid-walk. Only a different MAP discards a population.
+	var same: bool = world == _world and not _context.is_empty() \
+		and world != null and world.map_id() == _context.get("map", Vector2i(-1, -1))
+	_world = world
+	if same:
+		return
+	_generation += 1
+	_reset()
+
+
+## One hardware frame: every provider steps, and what they answer becomes this
+## frame's population. Answers whether anything a view draws changed.
+func advance_frame() -> bool:
+	if _providers.is_empty():
+		return false
+	_frame += 1
+	_frame_commands = []
+	_push_player_pose()
+	for provider: Object in _providers:
+		provider.call("advance_frame")
+	var before: Array = _entries
+	_collect()
+	var moved: bool = _changed(before, _entries)
+	return _advance_pulse() or moved
+
+
+## The validated population, each entry `{id, cell, facing, species, level, dvs,
+## shiny}`. `shiny` is the host's own answer from the DVs; a provider that sends
+## one is refused.
+func entries() -> Array:
+	return _entries
+
+
+## The population in the shape [Gen2WorldActors] resolves, so a visible encounter
+## is drawn by the same pass a mod's actors are and reaches both views.
+func actor_entries() -> Array:
+	var out: Array = []
+	if _world == null or _world.data == null:
+		return out
+	for entry: Dictionary in _entries:
+		var icon: int = _world.data.mon_menu_icon(int(entry["species"]))
+		if icon <= 0:
+			continue
+		out.append({
+			"icon": icon,
+			"facing": int(entry["facing"]),
+			"position_cells": Vector2(entry["cell"]),
+			# `GetMonNormalOrShinyPalettePointer`: the species' own four colours,
+			# which is what makes a shiny one visible before the battle starts.
+			"colors": _world.data.palette(int(entry["species"]), bool(entry["shiny"])),
+		})
+	return out
+
+
+## `wShadowOAM` as the running pulse left it, empty when none is running. See
+## [method Gen2BattleAnimPlayer.sprites].
+func pulse_sprites() -> Array:
+	return _pulse.sprites() if _pulse != null else []
+
+
+## The tile window those sprites index. See [method Gen2BattleAnimPlayer.tiles].
+func pulse_tiles() -> Array:
+	return _pulse.tiles() if _pulse != null else []
+
+
+## Where the pulse is anchored, in map pixels, or null when none is running. The
+## animation is written in screen coordinates around a battler; over the world it
+## follows the sprite it belongs to instead.
+func pulse_anchor() -> Variant:
+	if _pulse == null:
+		return null
+	for entry: Dictionary in _entries:
+		if StringName(entry["id"]) == _pulse_id:
+			return Vector2(entry["cell"]) * float(Gen2WorldAPI.CELL_PIXELS)
+	return null
+
+
+## The cartridge's own packed pair for the pulsing Pokemon, which is what battle
+## object palette slot 0 is filled with on the field. Empty when no pulse runs.
+func pulse_battler_pair() -> Array:
+	if _pulse == null or _world == null or _world.data == null:
+		return []
+	for entry: Dictionary in _entries:
+		if StringName(entry["id"]) != _pulse_id:
+			continue
+		var species: Dictionary = _world.data.species(int(entry["species"]))
+		if species.is_empty():
+			return []
+		return (species["palette"] as Dictionary)["shiny" if bool(entry["shiny"]) else "normal"]
+	return []
+
+
+## `anim_sound` and `anim_cry` from the pulse's last frame, for the caller that
+## owns the audio device.
+func frame_commands() -> Array:
+	return _frame_commands
+
+
+## The battle to start when the player meets [param cell], or an empty dictionary
+## when nothing stands there. The species, level and DVs are the entry's own and
+## are not rolled again.
+func battle_request_at(cell: Vector2i) -> Dictionary:
+	for entry: Dictionary in _entries:
+		if entry["cell"] != cell:
+			continue
+		return {
+			"kind": &"battle_requested",
+			"visible_encounter": StringName(entry["id"]),
+			"values": {
+				"kind": &"wild",
+				"pokemon": int(entry["species"]),
+				"level": int(entry["level"]),
+				"dvs": int(entry["dvs"]),
+			},
+		}
+	return {}
+
+
+## Tells whichever provider owns [param id] how the battle ended. What it does
+## with the entry, remove it or keep it, is the provider's one documented rule
+## and not the host's.
+func battle_finished(id: StringName, result: Variant) -> void:
+	var provider: Object = _owners.get(id, null)
+	if provider == null:
+		return
+	provider.call("battle_finished", id, result)
+
+
+func _reset() -> void:
+	_entries = []
+	_owners = {}
+	_pulsed = {}
+	_pulse = null
+	_pulse_id = &""
+	_frame_commands = []
+	_context = _build_context()
+	for provider: Object in _providers:
+		provider.call("set_context", _context.duplicate(true))
+
+
+## The snapshot a provider plans against: where a wild may stand, what each
+## method resolves to right now, and enough of the run to be deterministic. Every
+## question in it is answered by [Gen2WorldAPI], never by the mod.
+func _build_context() -> Dictionary:
+	if _world == null:
+		return {}
+	return {
+		"map": _world.map_id(),
+		"eligible": _world.visible_encounter_cells(),
+		"tables": _world.active_encounter_tables(),
+		"player": {"cell": _world.player_cell, "facing": _world.player_facing},
+		"run_seed": _world.random_seed,
+		"generation": _generation,
+	}
+
+
+## The pose moves and the map does not, so the sweep and the tables are not taken
+## again: a provider is handed the same context with `player` refreshed, and only
+## when the player has actually moved.
+func _push_player_pose() -> void:
+	if _world == null or _context.is_empty():
+		return
+	var pose: Dictionary = {"cell": _world.player_cell, "facing": _world.player_facing}
+	if _context.get("player", {}) == pose:
+		return
+	_context["player"] = pose
+	for provider: Object in _providers:
+		provider.call("set_context", _context.duplicate(true))
+
+
+func _collect() -> void:
+	_entries = []
+	if _world == null or _world.data == null:
+		return
+	var seen: Dictionary = {}
+	for provider: Object in _providers:
+		var answer: Variant = provider.call("encounters")
+		if not answer is Array:
+			continue
+		for raw: Variant in answer as Array:
+			if _entries.size() >= MAX_ENTRIES:
+				return
+			var entry: Dictionary = _validate(raw)
+			if entry.is_empty() or seen.has(entry["id"]):
+				continue
+			seen[entry["id"]] = true
+			_owners[entry["id"]] = provider
+			_entries.append(entry)
+			if bool(entry["pulse"]):
+				_start_pulse(entry)
+
+
+## One entry against the context it was given. An id, a cell inside the eligible
+## set, and a species and level the active table for that cell's own method
+## offers: anything else is dropped rather than drawn, because a population the
+## host cannot vouch for is a wild encounter a mod invented.
+func _validate(raw: Variant) -> Dictionary:
+	if not raw is Dictionary:
+		return {}
+	var row: Dictionary = raw as Dictionary
+	if row.has("shiny"):
+		return {}
+	var id: StringName = StringName(row.get("id", &""))
+	if String(id).is_empty():
+		return {}
+	var cell := Vector2i(row.get("cell", Vector2i(-1, -1)))
+	var method: StringName = _eligible_method(cell)
+	if method.is_empty():
+		return {}
+	var species: int = int(row.get("species", 0))
+	var level: int = int(row.get("level", 0))
+	if not _table_offers(method, species, level):
+		return {}
+	var dvs: int = int(row.get("dvs", 0))
+	if dvs < 0 or dvs > 0xFFFF:
+		return {}
+	return {
+		"id": id,
+		"cell": cell,
+		"facing": clampi(int(row.get("facing", Gen2WorldSprite.FACING_DOWN)), 0, MAX_FACING),
+		"species": species,
+		"level": level,
+		"dvs": dvs,
+		"shiny": Gen2Stats.is_shiny(dvs),
+		"pulse": bool(row.get("pulse", false)),
+	}
+
+
+## Which method's eligible list [param cell] is in, empty when neither.
+func _eligible_method(cell: Vector2i) -> StringName:
+	var eligible: Dictionary = _context.get("eligible", {})
+	for method: Variant in eligible:
+		if (eligible[method] as PackedVector2Array).has(Vector2(cell)):
+			return StringName(method)
+	return &""
+
+
+func _table_offers(method: StringName, species: int, level: int) -> bool:
+	var table: Variant = (_context.get("tables", {}) as Dictionary).get(method, null)
+	if not table is Dictionary:
+		return false
+	for slot: Variant in (table as Dictionary).get("slots", []):
+		if not slot is Dictionary:
+			continue
+		if int((slot as Dictionary)["species"]) != species:
+			continue
+		if level >= int((slot as Dictionary)["min_level"]) \
+			and level <= int((slot as Dictionary)["max_level"]):
+			return true
+	return false
+
+
+## The cartridge's own sparkle over the map. Only a shiny gets one: the request
+## is a presentation ask and shininess is the host's answer, so a pulse on an
+## ordinary Pokemon is dropped rather than drawn as something the cartridge has
+## no animation for.
+func _start_pulse(entry: Dictionary) -> void:
+	if not bool(entry["shiny"]) or _anim_data == null:
+		return
+	var id: StringName = StringName(entry["id"])
+	if _pulse != null and _pulse_id == id:
+		return
+	if _pulsed.has(id) and _frame - int(_pulsed[id]) < PULSE_FRAMES:
+		return
+	var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create(
+		_anim_data, SHINY_ANIM, true, SHINY_ANIM_PARAM
+	)
+	if player == null:
+		return
+	_pulsed[id] = _frame
+	_pulse = player
+	_pulse_id = id
+
+
+## One frame of the running pulse. The field and background layer is not run at
+## all: the map is the background out here, and `BattleAnimCmd_*BGEffect` edits a
+## battle tilemap this view does not have.
+func _advance_pulse() -> bool:
+	if _pulse == null:
+		return false
+	if _pulse.finished() or pulse_anchor() == null:
+		_pulse = null
+		_pulse_id = &""
+		return true
+	_pulse.advance_frame()
+	_frame_commands = _pulse.frame_commands()
+	return true
+
+
+func _changed(before: Array, after: Array) -> bool:
+	if before.size() != after.size():
+		return true
+	for index: int in before.size():
+		var was: Dictionary = before[index]
+		var now: Dictionary = after[index]
+		if was["cell"] != now["cell"] or int(was["facing"]) != int(now["facing"]) \
+			or int(was["species"]) != int(now["species"]) \
+			or bool(was["shiny"]) != bool(now["shiny"]):
+			return true
+	return false

--- a/game/world/world_encounters.gd.uid
+++ b/game/world/world_encounters.gd.uid
@@ -1,0 +1,1 @@
+uid://bamjiokrsdg

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -12,6 +12,8 @@ var _world: Gen2WorldAPI = null
 var _animation: Gen2WorldAnimation = null
 var _effects: Gen2WorldEffects = null
 var _actors: Gen2WorldActors = null
+var _encounters: Gen2WorldEncounters = null
+var _anim_textures: Dictionary = {}
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var _atlas: ImageTexture = null
 ## Kept beside the texture so an animation frame can repaint the one or two
@@ -47,6 +49,15 @@ func set_effects(effects: Gen2WorldEffects) -> void:
 ## nothing else, so a renderer may be handed null and draw none of them.
 func set_actors(actors: Gen2WorldActors) -> void:
 	_actors = actors
+	queue_redraw()
+
+
+## Gen2ModHost.RENDERER_ENCOUNTERS_METHOD: the host's visible-encounter layer.
+## Its population is drawn through [method set_actors] with everything else; what
+## is read here is the shiny pulse alone, which is the cartridge's own battle
+## animation objects over the map and has no other layer to ride.
+func set_encounters(encounters: Gen2WorldEncounters) -> void:
+	_encounters = encounters
 	queue_redraw()
 
 
@@ -243,6 +254,7 @@ func _draw() -> void:
 			sprite,
 			Vector2((sprite["cell"] as Vector2i) * Gen2WorldAPI.CELL_PIXELS) - camera_pixels,
 		)
+	_draw_encounter_pulse(camera_pixels)
 
 
 func _actor_texture(
@@ -251,19 +263,24 @@ func _actor_texture(
 	facing: int,
 	frame: int,
 	big_shape: int = Gen2WorldSprite.BIG_SHAPE_NONE,
+	color_override: PackedColorArray = PackedColorArray(),
 ) -> Texture2D:
 	if sprite == null or _world == null or _world.data == null:
 		return null
 	var palette: int = palette_override if palette_override != 0 else sprite.default_palette
-	var key: String = "%d:%d:%d:%d:%d:%d:%d" % [
+	var key: String = "%d:%d:%d:%d:%d:%d:%d:%d" % [
 		sprite.sprite_type, sprite.number, palette, facing, frame, big_shape, _time_of_day,
+		hash(color_override),
 	]
 	if _actor_textures.has(key):
 		return _actor_textures[key]
 	var indices: PackedByteArray = _world.data.overworld_icon_indices(sprite.icon_number) \
 		if sprite.sprite_type == Gen2WorldSprite.TYPE_MON_ICON \
 		else _world.data.overworld_sprite_indices(sprite.number)
-	var colors: PackedColorArray = _world.data.overworld_sprite_palette(palette, _time_of_day)
+	## A visible encounter names the species' own four colours; everything else
+	## wears one of the map's sprite palettes.
+	var colors: PackedColorArray = color_override if not color_override.is_empty() \
+		else _world.data.overworld_sprite_palette(palette, _time_of_day)
 	var image: Image = Gen2WorldSprite.big_image_for(sprite, indices, colors, big_shape) \
 		if big_shape != Gen2WorldSprite.BIG_SHAPE_NONE \
 		else Gen2WorldSprite.image_for(sprite, indices, colors, facing, frame)
@@ -282,7 +299,8 @@ func _draw_actor(
 	var position: Vector2 = sprite["position_cells"]
 	var pixel: Vector2 = position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels
 	var texture: Texture2D = _actor_texture(
-		sprite["sprite"], 0, int(sprite["facing"]), int(sprite["frame"])
+		sprite["sprite"], 0, int(sprite["facing"]), int(sprite["frame"]),
+		Gen2WorldSprite.BIG_SHAPE_NONE, sprite.get("colors", PackedColorArray())
 	)
 	if texture == null:
 		return
@@ -402,6 +420,91 @@ func _draw_fishing_rod(pixel: Vector2) -> void:
 		sheet, int(tile["tile"]), Gen2WorldEffects.PAL_OW_EMOTE, bool(tile["flip_x"]),
 		pixel + Vector2(tile["offset"] as Vector2i),
 	)
+
+
+## The enemy battler's own box on the battle screen, in pixels: `wShadowOAM` from
+## an animation aimed at it is written around this, so translating its centre
+## onto a walk cell's is what puts the sparkle over the Pokemon out here.
+const BATTLER_CENTRE := Vector2(
+	(Gen2BattleScreenMap.ENEMY_AT.x + 0.5 * Gen2BattleScreenMap.ENEMY_SIDE) * Gen2Tiles.TILE_WIDTH,
+	(Gen2BattleScreenMap.ENEMY_AT.y + 0.5 * Gen2BattleScreenMap.ENEMY_SIDE) * Gen2Tiles.TILE_HEIGHT
+)
+
+
+## The shiny pulse: the cartridge's own `ANIM_SEND_OUT_MON` objects, drawn where
+## the Pokemon stands instead of where a battler would. The field and background
+## layer the animation shares the screen with in a battle is simply not run, so
+## what lands here is the sparkle and nothing behind it.
+func _draw_encounter_pulse(camera_pixels: Vector2) -> void:
+	if _encounters == null or _world == null or _world.data == null:
+		return
+	var anchor: Variant = _encounters.pulse_anchor()
+	if not anchor is Vector2:
+		return
+	var origin: Vector2 = (anchor as Vector2) - camera_pixels \
+		+ Vector2(Gen2WorldAPI.CELL_PIXELS, Gen2WorldAPI.CELL_PIXELS) * 0.5 - BATTLER_CENTRE
+	var window: Array = _encounters.pulse_tiles()
+	var pair: Array = _encounters.pulse_battler_pair()
+	for entry: Variant in _encounters.pulse_sprites():
+		if entry is Dictionary:
+			_draw_pulse_sprite(entry as Dictionary, window, pair, origin)
+
+
+func _draw_pulse_sprite(
+	sprite: Dictionary, window: Array, pair: Array, origin: Vector2
+) -> void:
+	var at: int = int(sprite.get("tile", 0)) - Gen2BattleAnimObject.BASE_TILE
+	if at < 0 or at >= window.size() or not window[at] is Dictionary:
+		return
+	var slot: Dictionary = window[at]
+	# `anim_battlergfx_*` moves a battler as objects and has no picture out here.
+	if not slot.has("gfx"):
+		return
+	var attributes: int = int(sprite.get("attributes", 0))
+	var texture: Texture2D = _pulse_texture(
+		int(slot["gfx"]), int(slot["tile"]), attributes, pair
+	)
+	if texture == null:
+		return
+	draw_texture(texture, origin + Vector2(
+		float(int(sprite.get("x", 0)) - 8), float(int(sprite.get("y", 0)) - 16)
+	))
+
+
+func _pulse_texture(
+	gfx: int, tile: int, attributes: int, pair: Array
+) -> Texture2D:
+	var key: String = "%d:%d:%d:%s" % [
+		gfx, tile, attributes & (Gen2BattleAnimObject.OAM_SHARED_FLAGS
+			| Gen2BattleAnimObject.OAM_PALETTE), str(pair),
+	]
+	if _anim_textures.has(key):
+		return _anim_textures[key]
+	var strip: PackedByteArray = _world.data.battle_anim_gfx_indices(gfx)
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / Gen2Tiles.TILE_HEIGHT
+	if width <= 0 or (tile + 1) * Gen2Tiles.TILE_WIDTH > width:
+		return null
+	var pixels := PackedByteArray()
+	pixels.resize(Gen2Tiles.TILE_PIXELS)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		var from: int = row * width + tile * Gen2Tiles.TILE_WIDTH
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			pixels[row * Gen2Tiles.TILE_WIDTH + column] = strip[from + column]
+	var image: Image = Gen2PicImage.from_indices(
+		pixels, Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT,
+		_world.data.battle_object_palette(
+			attributes & Gen2BattleAnimObject.OAM_PALETTE, pair
+		),
+		true
+	)
+	if (attributes & Gen2BattleAnimObject.OAM_XFLIP) != 0:
+		image.flip_x()
+	if (attributes & Gen2BattleAnimObject.OAM_YFLIP) != 0:
+		image.flip_y()
+	var texture: Texture2D = ImageTexture.create_from_image(image)
+	_anim_textures[key] = texture
+	return texture
 
 
 func _effect_sprites() -> Array:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -62,6 +62,10 @@ var _effects: Gen2WorldEffects = null
 ## The sprites registered mods put in the world, driven a frame at a time here
 ## and drawn by the renderer with the map's own objects.
 var _actors: Gen2WorldActors = null
+var _encounters: Gen2WorldEncounters = null
+## The id of the visible encounter the running battle belongs to, so its provider
+## is told how the fight ended and nothing else is.
+var _battle_encounter_id: StringName = &""
 ## The headbutt result waiting for ShakeHeadbuttTree's 32 frames to be spent.
 var _pending_headbutt_finish: Dictionary = {}
 var _text_box: Gen2TextBox = null
@@ -233,9 +237,16 @@ func _build_world() -> void:
 	_actors.set_actors(Gen2ModHost.instance().world_actors())
 	## The cut leaves ride BattleAnimSineWave, which is cartridge data rather
 	## than a table this could derive.
-	_effects.set_sine_table(Gen2BattleAnimData.from_game_data(_data))
+	var anim_data: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(_data)
+	_effects.set_sine_table(anim_data)
 	_world.set_world_clock(initial_day, initial_hour, initial_minute)
 	_world.set_object_time(initial_hour, time_of_day)
+	## After the clock, since the tables a provider is handed are the ones this
+	## time of day resolves to.
+	_encounters = Gen2WorldEncounters.new()
+	_encounters.set_providers(Gen2ModHost.instance().visible_encounter_providers())
+	_encounters.set_world(_world, anim_data)
+	_actors.set_encounters(_encounters)
 	var rods: Array[StringName] = _world.available_fishing_rods()
 	if not rods.is_empty() and not rods.has(_selected_rod):
 		_selected_rod = rods[0]
@@ -288,6 +299,8 @@ func _build_renderer() -> void:
 		_renderer.call(Gen2ModHost.RENDERER_EFFECTS_METHOD, _effects)
 	if _renderer.has_method(Gen2ModHost.RENDERER_ACTORS_METHOD):
 		_renderer.call(Gen2ModHost.RENDERER_ACTORS_METHOD, _actors)
+	if _renderer.has_method(Gen2ModHost.RENDERER_ENCOUNTERS_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_ENCOUNTERS_METHOD, _encounters)
 	_set_renderer_world()
 	_renderer.set_time_of_day(_render_time_of_day())
 	_apply_renderer_interface_style()
@@ -304,6 +317,8 @@ func _set_renderer_world() -> void:
 		_renderer.set_world(_world, _animation)
 	if _actors != null:
 		_actors.set_world(_world)
+	if _encounters != null:
+		_encounters.set_world(_world)
 
 
 ## The text box is the screen's, not the renderer's, and over a native-layer view
@@ -414,6 +429,12 @@ func advance_frame() -> void:
 		_renderer.refresh()
 	## After the player's own step, so an actor reading
 	## `player_step_offset_cells()` sees this frame rather than the last one's.
+	## Before the actors, which draw its population: a wild that moved this frame
+	## has to be in the sprite list the actor layer collects after it.
+	if _encounters != null and _encounters.advance_frame():
+		_play_encounter_sounds()
+		if _renderer != null:
+			_renderer.refresh()
 	if _actors != null and _actors.advance_frame() and _renderer != null:
 		_renderer.refresh()
 	_advance_forced_movement()
@@ -900,6 +921,15 @@ func _after_player_move(movement: Dictionary) -> bool:
 		_show_script_results(contest_over)
 		return true
 	_show_script_results([])
+	## While a provider is active the step takes no roll of its own: a wild is
+	## met by walking into one. Everything else that reaches a wild, a script, a
+	## rod, Headbutt, Rock Smash, Sweet Scent and the contest, keeps its own path.
+	if _encounters != null and _encounters.active():
+		var visible: Dictionary = _encounters.battle_request_at(_world.player_cell)
+		if not visible.is_empty():
+			_battle_encounter_id = StringName(visible["visible_encounter"])
+			_start_battle_request(visible)
+		return true
 	var encounter: Dictionary = _world.encounter_request(
 		_encounter_random, false, &"auto", _repel_lead_level(), _party_holds_cleanse_tag()
 	)
@@ -1123,6 +1153,61 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 		_script_prompt = "Debug effect sprite preview"
 	_renderer.refresh()
 	_refresh_labels()
+
+
+## Public screenshot driver for the visible-encounter seam, which otherwise needs
+## a mod: a shiny Pokemon of the map's own table, on the eligible cell nearest
+## the player, asking for its pulse. The provider is the synthetic one below;
+## everything else is the host's own path.
+func preview_visible_encounter() -> void:
+	if _world == null or _encounters == null or _renderer == null:
+		return
+	_encounters.set_providers([PreviewEncounters.new(_world)])
+	advance_frames(2)
+	_script_prompt = "Debug visible encounter preview"
+	_renderer.refresh()
+	_refresh_labels()
+
+
+## What a mod's provider is, in the fewest lines that exercise the contract.
+class PreviewEncounters extends RefCounted:
+	## `CheckShininess`: the attack mask and three tens.
+	const SHINY_DVS: int = (2 << 12) | (10 << 8) | (10 << 4) | 10
+
+	var _entries: Array = []
+
+	func _init(world: Gen2WorldAPI) -> void:
+		var cells: Dictionary = world.visible_encounter_cells()
+		var tables: Dictionary = world.active_encounter_tables()
+		for method: Variant in cells:
+			var slots: Array = (tables.get(method, {}) as Dictionary).get("slots", [])
+			var nearest := Vector2(-1, -1)
+			for cell: Vector2 in cells[method] as PackedVector2Array:
+				if nearest.x < 0 or cell.distance_squared_to(Vector2(world.player_cell)) \
+					< nearest.distance_squared_to(Vector2(world.player_cell)):
+					nearest = cell
+			if nearest.x < 0 or slots.is_empty():
+				continue
+			_entries.append({
+				"id": StringName("preview_%s" % method),
+				"cell": Vector2i(nearest),
+				"species": int(slots[0]["species"]),
+				"level": int(slots[0]["min_level"]),
+				"dvs": SHINY_DVS,
+				"pulse": true,
+			})
+
+	func set_context(_context: Dictionary) -> void:
+		pass
+
+	func advance_frame() -> void:
+		pass
+
+	func encounters() -> Array:
+		return _entries
+
+	func battle_finished(_id: StringName, _result: Variant) -> void:
+		pass
 
 
 ## Public screenshot driver for `Script_pokepic`'s box. The scripts that run one
@@ -1700,6 +1785,11 @@ func _on_battle_finished(result: Dictionary) -> void:
 	_battle_host = null
 	if host != null:
 		host.queue_free()
+	if not String(_battle_encounter_id).is_empty():
+		var fought: StringName = _battle_encounter_id
+		_battle_encounter_id = &""
+		if _encounters != null:
+			_encounters.battle_finished(fought, result.duplicate(true))
 	if _world == null:
 		return
 	var pay_day_money: int = int(result.get("pay_day_money", 0))
@@ -3280,6 +3370,15 @@ func _play_current_map_music() -> void:
 
 func _play_ledge_hop_sfx() -> void:
 	_play_sfx(SFX_JUMP_OVER_LEDGE)
+
+
+## `BattleAnimCmd_Sound` from a shiny pulse. The interpreter has no audio device,
+## as it has none in a battle either, so the screen spends what its commands
+## asked for. A cry is not one of them: the sparkle's script has no `anim_cry`.
+func _play_encounter_sounds() -> void:
+	for command: Dictionary in _encounters.frame_commands():
+		if StringName(command["name"]) == Gen2BattleAnimScript.SOUND:
+			_play_sfx(int((command["operands"] as Array)[1]))
 
 
 func _play_sfx(index: int) -> void:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3424,6 +3424,7 @@ func _refresh_party_summary() -> void:
 	var moves: Array = []
 	var names: Array = []
 	var eggs: Array = []
+	var fainted: Array = []
 	for member: Variant in save.party:
 		if member is Gen2SaveMon:
 			var mon: Gen2SaveMon = member as Gen2SaveMon
@@ -3439,6 +3440,7 @@ func _refresh_party_summary() -> void:
 			moves.append(mon_moves)
 			names.append(_mon_display_name(mon))
 			eggs.append(mon.is_egg)
+			fainted.append(mon.hp <= 0)
 	## The three party facts the Bug Contest's own scripts ask about, which are
 	## not per-slot: whether the lead can be entered at all, the byte
 	## `ContestDropOffMons` stashes, and whether what is caught can be taken home.
@@ -3451,7 +3453,8 @@ func _refresh_party_summary() -> void:
 			"second_species": int(second.species) if second != null else 0,
 			"storage_full": save.party.size() >= Gen2SaveData.MAX_PARTY \
 				and not bool(save.first_empty_box_slot().get("ok", false)),
-		}
+		},
+		fainted
 	)
 
 

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -444,6 +444,13 @@ static func _later_command_width(opcode: int) -> int:
 static func _later_command_name(opcode: int, crystal_commands: bool) -> StringName:
 	if opcode < 0x55:
 		return &""
+	## $55 is the seam between the two tables: pokegold's `pokepic` and Crystal's
+	## own `promptbutton`, which is one byte and has no species. The base table
+	## already splits them, and answering `pokepic` here shadowed it, so every one
+	## of Crystal's promptbuttons decoded under the wrong name and
+	## `command_at` read the next command's first byte as a species.
+	if crystal_commands and opcode == PROMPTBUTTON:
+		return &""
 	if crystal_commands:
 		match opcode:
 			0x9F: return &"verbosegiveitemvar"
@@ -744,7 +751,10 @@ static func command_at(
 		var source: int = Gen2WorldScript.source_opcode(opcode, crystal_commands)
 		match source:
 			0x55:
-				command["pokemon"] = int(data[offset + 1])
+				## Crystal's own $55 is `promptbutton`, one byte and no species;
+				## only pokegold's $55 is `pokepic`. See `_later_command_name`.
+				if command["name"] == &"pokepic":
+					command["pokemon"] = int(data[offset + 1])
 			0x5C:
 				command["pokemon"] = int(data[offset + 1])
 				command["level"] = int(data[offset + 2])

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -941,6 +941,7 @@ func is_finished() -> bool:
 func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 	var opcode: int = int(command["opcode"])
 	var bank: int = int(frame["bank"])
+	command = _catalogued(command, frame)
 	if opcode == Gen2WorldScript.FARJUMPTEXT:
 		if _crystal_commands():
 			return _show_text(int(command["bank"]), int(command["address"]), true)
@@ -1317,6 +1318,83 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		"reason": &"unsupported_runtime_command",
 		"command": command,
 	}
+
+
+## A command whose numbers a mod may have moved, substituted before it runs.
+##
+## The site is addressed by the byte it sits at, `frame.address + offset`, which
+## is exactly the id [Gen2WorldCatalog] gave it. Only the OPERANDS change: the
+## command still runs, its script still sets its own completion flag, prints its
+## own dialogue and takes its own money, and nothing here can replace any of
+## that. A cartridge with no mod patch pays one dictionary read.
+func _catalogued(command: Dictionary, frame: Dictionary) -> Dictionary:
+	if data == null or not data.has_content_overlay():
+		return command
+	var candidates: Array = CATALOG_KINDS.get(StringName(command["name"]), [])
+	if candidates.is_empty():
+		return command
+	var at: int = int(frame["address"]) + int(command["offset"])
+	var row: Dictionary = {}
+	var kind: StringName = &""
+	for candidate: StringName in candidates:
+		row = data.catalog().check(
+			Gen2WorldCatalog.pack_id(candidate, int(frame["bank"]), at)
+		)
+		if not row.is_empty():
+			kind = candidate
+			break
+	if row.is_empty():
+		return command
+	var out: Dictionary = command.duplicate(true)
+	match kind:
+		Gen2WorldCatalog.KIND_STATIC:
+			out["pokemon"] = int(row["species"])
+			out["level"] = int(row["level"])
+		Gen2WorldCatalog.KIND_TRADE:
+			out["value"] = int(row["trade"])
+		Gen2WorldCatalog.KIND_SHOP:
+			out["address"] = int(row["mart"])
+		Gen2WorldCatalog.KIND_BADGE:
+			## The badge a flag grants IS the flag, so moving one moves which
+			## bit the site sets. An index outside the list leaves it alone.
+			var flags: Array[int] = Gen2WorldState.BADGE_ENGINE_FLAGS \
+				if Gen2WorldState.is_crystal_profile(data) \
+				else Gen2WorldState.BADGE_ENGINE_FLAGS_GOLD_SILVER
+			var badge: int = int(row["badge"])
+			if badge >= 0 and badge < flags.size():
+				out["flag"] = flags[badge]
+		Gen2WorldCatalog.KIND_ITEM:
+			out["item"] = int(row["item"])
+			out["value"] = int(row["item"])
+			out["quantity"] = maxi(1, int(row["quantity"]))
+			out["value_2"] = maxi(1, int(row["quantity"]))
+		_:
+			## Every giving kind: a starter, a gift and a prize are one command.
+			out["pokemon"] = int(row["species"])
+			out["value"] = int(row["species"])
+			out["level"] = int(row["level"])
+			out["value_2"] = int(row["level"])
+			out["item"] = int(row.get("item", command.get("item", 0)))
+	return out
+
+
+## Which catalog kinds a command name can be a site for. `givepoke` is three at
+## once, and which one it is was decided when the catalog walked the script, so
+## the id is tried under each until one answers. A site the catalog never
+## recorded answers empty under all of them and the command runs untouched.
+const CATALOG_KINDS: Dictionary = {
+	&"loadwildmon": [Gen2WorldCatalog.KIND_STATIC],
+	&"trade": [Gen2WorldCatalog.KIND_TRADE],
+	&"pokemart": [Gen2WorldCatalog.KIND_SHOP],
+	&"setflag": [Gen2WorldCatalog.KIND_BADGE],
+	&"giveitem": [Gen2WorldCatalog.KIND_ITEM],
+	&"verbosegiveitem": [Gen2WorldCatalog.KIND_ITEM],
+	&"givepoke": [
+		Gen2WorldCatalog.KIND_GIFT, Gen2WorldCatalog.KIND_STARTER,
+		Gen2WorldCatalog.KIND_PRIZE,
+	],
+	&"giveegg": [Gen2WorldCatalog.KIND_GIFT],
+}
 
 
 func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) -> Dictionary:

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -221,3 +221,122 @@ func test_a_registered_world_actor_is_driven_by_the_screen_and_drawn_by_the_view
 	assert_eq((drawn[0]["sprite"] as Gen2WorldSprite).icon_number, 1)
 	assert_eq(drawn[0]["position_cells"], Vector2(3, 4))
 	assert_eq(_world_screen._renderer._actors, _world_screen._actors)
+
+
+## A mod's visible-encounter provider: the context it is handed, one advance per
+## world frame, the entries it answers, and the result of a battle it caused.
+const PROVIDER_SOURCE: String = """extends RefCounted
+
+var context: Dictionary = {}
+var frames: int = 0
+var results: Array = []
+var entry: Dictionary = {}
+
+func set_context(value: Dictionary) -> void:
+	context = value
+
+func advance_frame() -> void:
+	frames += 1
+
+func encounters() -> Array:
+	return [] if entry.is_empty() else [entry]
+
+func battle_finished(id, result) -> void:
+	results.append([id, result])
+"""
+
+
+## The whole seam in one walk: the provider is contexted from the map's own
+## tables, its entry is validated against them, drawn with the SPECIES' colours,
+## and met by stepping onto it instead of by a roll.
+func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() -> void:
+	var provider: Object = _script(PROVIDER_SOURCE).new()
+	assert_true(
+		Gen2ModHost.instance().register_visible_encounters(&"wilds", provider)["ok"]
+	)
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen.set_process(false)
+	## The fixture map is plain land, which is not grass. A cave floor is
+	## eligible everywhere, which is the branch that makes the sweep answerable
+	## here at all.
+	_world_screen._world.current_map.environment = Gen2WorldAPI.ENVIRONMENT_CAVE
+	_world_screen._encounters.set_providers([provider])
+
+	var context: Dictionary = provider.get("context")
+	assert_eq(context["map"], Vector2i(Fixture.MAP_GROUP, Fixture.MAP_NUMBER))
+	assert_eq(int(context["generation"]), 1)
+	var slots: Array = context["tables"][Gen2WorldEncounter.METHOD_GRASS]["slots"]
+	assert_eq(int(slots[0]["species"]), Fixture.TRAINER_SPECIES)
+	var cell := Vector2i(7, 7)
+	assert_true(
+		(context["eligible"][Gen2WorldEncounter.METHOD_GRASS] as PackedVector2Array).has(
+			Vector2(cell)
+		)
+	)
+
+	## Off the table, so nothing is drawn: the host will not stand a Pokemon the
+	## map cannot produce.
+	provider.set("entry", {
+		"id": &"a", "cell": cell, "species": Fixture.TRAINER_SPECIES, "level": 99, "dvs": 0,
+	})
+	_world_screen.advance_frames(1)
+	assert_eq(_world_screen._encounters.entries().size(), 0, "level off the table")
+
+	## Shiny DVs: `CheckShininess`'s three tens and the attack mask.
+	var shiny: int = Gen2Stats.pack_dvs(2, 10, 10, 10)
+	provider.set("entry", {
+		"id": &"a", "cell": cell, "species": Fixture.TRAINER_SPECIES, "level": 5,
+		"dvs": shiny, "facing": Gen2WorldSprite.FACING_UP,
+	})
+	var stepped: int = int(provider.get("frames"))
+	_world_screen.advance_frames(1)
+	assert_eq(int(provider.get("frames")), stepped + 1)
+	var entries: Array = _world_screen._encounters.entries()
+	assert_eq(entries.size(), 1)
+	assert_true(bool(entries[0]["shiny"]), "the host answers shininess, not the mod")
+	var drawn: Array = _world_screen._actors.sprites()
+	assert_eq(drawn.size(), 1)
+	assert_eq(drawn[0]["position_cells"], Vector2(cell))
+	assert_eq(
+		drawn[0]["colors"], _data.palette(Fixture.TRAINER_SPECIES, true),
+		"the shiny palette"
+	)
+
+	## A step onto an empty cell starts nothing, though the map's own grass rate
+	## is 255: while a provider is active the post-step roll is off.
+	_world_screen._world.player_cell = Vector2i(6, 7)
+	_world_screen._after_player_move({"kind": &"step"})
+	assert_null(_world_screen._battle_host, "no roll while a provider is active")
+
+	## Walking onto it starts the battle with those exact DVs.
+	_world_screen._world.player_cell = cell
+	_world_screen._after_player_move({"kind": &"step"})
+	var request: Dictionary = _world_screen._battle_host.get_meta(
+		"world_battle_request"
+	)["request"]
+	assert_eq(int(request["values"]["dvs"]), shiny)
+	assert_eq(int(request["values"]["level"]), 5)
+	assert_eq(StringName(request["visible_encounter"]), &"a")
+
+	_world_screen._on_battle_finished({"outcome": Gen2WorldBattleAdapter.OUTCOME_RAN})
+	var reported: Array = provider.get("results")
+	assert_eq(reported.size(), 1)
+	assert_eq(StringName(reported[0][0]), &"a")
+	assert_eq(StringName(reported[0][1]["outcome"]), Gen2WorldBattleAdapter.OUTCOME_RAN)
+
+	## A map change discards the population and every sprite resolved from it
+	## before the next map is drawn, and says so with a fresh generation.
+	var generation: int = int((provider.get("context") as Dictionary)["generation"])
+	_world_screen._world.current_map.number = Fixture.MAP_NUMBER + 1
+	_world_screen._encounters.set_world(_world_screen._world)
+	assert_eq(_world_screen._encounters.entries().size(), 0)
+	assert_eq(
+		int((provider.get("context") as Dictionary)["generation"]), generation + 1
+	)

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -73,6 +73,7 @@ func after_each() -> void:
 	if is_instance_valid(_world_screen):
 		_world_screen.free()
 		_world_screen = null
+	Gen2ModHost.reset()
 	RomCache.clear(Fixture.directory())
 
 
@@ -1131,3 +1132,78 @@ func test_a_refusal_holds_the_menu_until_a_or_b() -> void:
 	assert_true(party.handle_button(Gen2Button.B))
 	assert_eq(String(party.submenu_snapshot()["message"]), "")
 	assert_true(bool(party.submenu_snapshot()["open"]), "and the submenu is still up")
+
+
+## A mod's party-member rows land after every cartridge action and before CANCEL,
+## which is the way out of the box. The label is asked per slot, so a mod can say
+## something different about the one it already owns.
+func test_a_mod_party_row_lands_after_the_cartridge_actions() -> void:
+	await _open_world()
+	var chosen: Array = []
+	assert_true(bool(Gen2ModHost.instance().register_party_member_menu(&"follower", {
+		"label": func(slot: int) -> String: return "FOLLOWING" if slot == 2 else "FOLLOW",
+		"handler": func(slot: int) -> void: chosen.append(slot),
+	}).get("ok", false)))
+	## A second mod appends behind the first rather than replacing it.
+	assert_true(bool(Gen2ModHost.instance().register_party_member_menu(&"pet", {
+		"label": func(_slot: int) -> String: return "PET",
+		"handler": func(_slot: int) -> void: pass,
+	}).get("ok", false)))
+
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	assert_eq(
+		_labels(party.submenu_snapshot()["items"]),
+		["CUT", "STATS", "SWITCH", "MOVE", "ITEM", "FOLLOW", "PET", "CANCEL"]
+	)
+
+	## Choosing it calls the mod's handler with the ONE-based slot and closes the
+	## menu, the way a field move does.
+	for _step: int in 5:
+		party.handle_button(Gen2Button.DOWN)
+	party.handle_button(Gen2Button.A)
+	assert_eq(chosen, [1])
+	await get_tree().process_frame
+	assert_null(_world_screen._party_host)
+
+
+## An egg has nothing to follow, and a battle's party list is a switch: neither
+## is offered a mod row.
+func test_an_egg_and_a_battle_list_are_offered_no_mod_row() -> void:
+	await _open_world()
+	assert_true(bool(Gen2ModHost.instance().register_party_member_menu(&"follower", {
+		"label": func(_slot: int) -> String: return "FOLLOW",
+		"handler": func(_slot: int) -> void: pass,
+	}).get("ok", false)))
+	var egg := Gen2SaveMon.new()
+	egg.is_egg = true
+	assert_eq(
+		_labels(Gen2PartyScreen.submenu_items_for(_data, egg, 1)),
+		["STATS", "SWITCH", "CANCEL"]
+	)
+	var mon: Gen2SaveMon = Gen2SaveStore.create_development_save(_data, 0).party[0]
+	assert_false(
+		_labels(Gen2PartyScreen.submenu_items_for(_data, mon, 1, true)).has("FOLLOW"),
+		"a battle party list"
+	)
+	assert_true(_labels(Gen2PartyScreen.submenu_items_for(_data, mon, 1)).has("FOLLOW"))
+
+
+## A row is registered by name with two Callables, and both are checked here
+## rather than at the press.
+func test_a_party_row_needs_both_callables_and_a_free_name() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var label: Callable = func(_slot: int) -> String: return "X"
+	assert_eq(
+		host.register_party_member_menu(&"a", {"label": label})["reason"],
+		&"party_menu_entry_missing_callable"
+	)
+	assert_true(bool(host.register_party_member_menu(
+		&"a", {"label": label, "handler": func(_slot: int) -> void: pass}
+	).get("ok", false)))
+	assert_eq(
+		host.register_party_member_menu(
+			&"a", {"label": label, "handler": func(_slot: int) -> void: pass}
+		)["reason"],
+		&"duplicate_party_menu_entry"
+	)

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -349,6 +349,17 @@ static func _write_overworld_graphics(directory: String) -> void:
 	sprite.fill(1)
 	RomCache.write_indices(RomCache.overworld_sprite_path(directory, TRAINER_SPRITE), sprite)
 
+	## `MonMenuIcons`, one row per species: every one of them icon 1, which is
+	## all anything drawing a party icon or a visible encounter needs here.
+	var menu_icons: PackedByteArray = PackedByteArray()
+	menu_icons.resize(RomLayout.SPECIES_COUNT)
+	menu_icons.fill(1)
+	RomCache.write_indices(RomCache.mon_menu_icons_path(directory), menu_icons)
+	var icon: PackedByteArray = PackedByteArray()
+	icon.resize(8 * Gen2Tiles.TILE_PIXELS)
+	icon.fill(1)
+	RomCache.write_indices(RomCache.overworld_icon_path(directory, 1), icon)
+
 
 ## The start menu's nine descriptions and the pack's five texts, as the cartridge
 ## words them. The two toss texts keep [Gen2TextStream]'s markers, since what

--- a/tests/unit/test_content_overlay.gd
+++ b/tests/unit/test_content_overlay.gd
@@ -52,7 +52,32 @@ func _write_cache() -> void:
 			"slots": [[{"level": 2, "species": 16}], [], []],
 		}},
 		"water": {},
-		"fishing": {"groups": [{"rods": []}], "time_groups": []},
+		"fishing": {
+			"groups": [{"rods": []}],
+			"time_groups": [{
+				"day": {"species": 0xDE, "level": 20},
+				"night": {"species": 0x78, "level": 20},
+			}],
+		},
+		"treemons": {
+			"tree_maps": [{"map_group": 3, "map_number": 2, "set": 1}],
+			"rock_maps": [],
+			"sets": [
+				{"common": [], "rare": []},
+				{
+					"common": [{"percent": 50, "species": 10, "level": 10}],
+					"rare": [{"percent": 50, "species": 11, "level": 12}],
+				},
+			],
+		},
+		"bug_contest": {
+			"mons": [{"percent": 20, "species": 10, "min_level": 7, "max_level": 18}],
+			"contestants": [],
+		},
+		"roaming": {
+			"maps": [],
+			"mons": [{"species": 243, "level": 40, "map_group": 3, "map_number": 2}],
+		},
 	})
 	RomCache.write_json(RomCache.tmhm_moves_path(_directory), [1])
 	RomCache.write_json(RomCache.manifest_path(_directory), {
@@ -232,3 +257,60 @@ func test_a_table_kind_is_patched_and_never_defined() -> void:
 		)["reason"]),
 		&"content_kind_is_patch_only"
 	)
+
+
+## The four wild sources beside the map tables. Each is patched by its own index
+## and each keeps the field a patch did not name, which is the whole point: a
+## contest row's percent is its scoring weight and a roamer's map is live state.
+func test_the_four_other_wild_sources_are_patched_by_index() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_treemon_set(MOD, 1, {
+		"common": [{"percent": 50, "species": 1, "level": 3}],
+	}).get("ok", false)))
+	assert_true(bool(host.patch_bug_contest_mon(MOD, 0, {"species": 2}).get("ok", false)))
+	assert_true(bool(host.patch_roaming_mon(MOD, 0, {"species": 3}).get("ok", false)))
+	assert_true(bool(host.patch_fishing_time_group(MOD, 0, {
+		"night": {"species": 4, "level": 20},
+	}).get("ok", false)))
+
+	var data: GameData = _data()
+	var set_one: Dictionary = data.treemon_set(1)
+	assert_eq(int(set_one["common"][0]["species"]), 1)
+	assert_eq(int(set_one["rare"][0]["species"]), 11, "the rare table is untouched")
+
+	var contest: Array = data.bug_contest_mons()
+	assert_eq(int(contest[0]["species"]), 2)
+	assert_eq(int(contest[0]["percent"]), 20, "the contest's own weight survives")
+	assert_eq(int(contest[0]["max_level"]), 18)
+
+	var roaming: Array = data.world_roaming_mons()
+	assert_eq(int(roaming[0]["species"]), 3)
+	assert_eq(int(roaming[0]["map_group"]), 3, "where it is now is not a patch")
+	assert_eq(int(roaming[0]["level"]), 40)
+
+	var times: Array = data.world_fishing_time_groups()
+	assert_eq(int(times[0]["night"]["species"]), 4)
+	assert_eq(int(times[0]["day"]["species"]), 0xDE, "the day half is untouched")
+
+	## Every one is a table row, so none of them can be DEFINED.
+	for kind: StringName in [
+		Gen2ContentOverlay.KIND_TREEMON, Gen2ContentOverlay.KIND_BUG_CONTEST,
+		Gen2ContentOverlay.KIND_ROAMING, Gen2ContentOverlay.KIND_FISHING_TIME,
+	]:
+		assert_eq(
+			StringName(host.register_content(kind, MOD, NEW_SPECIES, {})["reason"]),
+			&"content_kind_is_patch_only", String(kind)
+		)
+
+
+## `clear_owner` is what a save switch spends: everything one mod claimed goes,
+## and the numbers are free for the next run to claim again.
+func test_clearing_one_owner_leaves_the_cartridge_row_and_frees_the_number() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_bug_contest_mon(MOD, 0, {"species": 2}).get("ok", false)))
+	assert_eq(int(_data().bug_contest_mons()[0]["species"]), 2)
+	Gen2ContentOverlay.shared().clear_owner(MOD)
+	assert_eq(int(_data().bug_contest_mons()[0]["species"]), 10)
+	assert_eq(Gen2ContentOverlay.shared().owner_of(Gen2ContentOverlay.KIND_BUG_CONTEST, 0), &"")
+	assert_true(bool(host.patch_bug_contest_mon(&"other", 0, {"species": 5}).get("ok", false)))
+	assert_eq(int(_data().bug_contest_mons()[0]["species"]), 5)

--- a/tests/unit/test_content_overlay.gd
+++ b/tests/unit/test_content_overlay.gd
@@ -314,3 +314,51 @@ func test_clearing_one_owner_leaves_the_cartridge_row_and_frees_the_number() -> 
 	assert_eq(Gen2ContentOverlay.shared().owner_of(Gen2ContentOverlay.KIND_BUG_CONTEST, 0), &"")
 	assert_true(bool(host.patch_bug_contest_mon(&"other", 0, {"species": 5}).get("ok", false)))
 	assert_eq(int(_data().bug_contest_mons()[0]["species"]), 5)
+
+
+## A catalog site is patched by the stable id the catalog gave it, and only the
+## fields named move. The decode itself is checked on real cartridges by
+## `tools/checks/catalog.gd`; what is here is the patch surface.
+func test_a_catalog_site_is_patched_by_its_own_id() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var id: int = Gen2WorldCatalog.pack_id(Gen2WorldCatalog.KIND_STATIC, 48, 0x6E00)
+	assert_true(bool(host.patch_check(MOD, id, {"species": 25}).get("ok", false)))
+	assert_eq(
+		Gen2ContentOverlay.shared().resolve(
+			Gen2ContentOverlay.KIND_CHECK, id, {"species": 109, "level": 21}
+		),
+		{"species": 25, "level": 21},
+		"the level a patch did not name is the cartridge's"
+	)
+	assert_eq(host.patch_check(MOD, -1, {"species": 1})["reason"], &"not_a_check_id")
+	assert_eq(
+		StringName(host.register_content(
+			Gen2ContentOverlay.KIND_CHECK, MOD, NEW_SPECIES, {}
+		)["reason"]),
+		&"content_kind_is_patch_only"
+	)
+
+
+## Two mods cannot both move one site, and the refusal names both.
+func test_two_mods_cannot_claim_one_catalog_site() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var id: int = Gen2WorldCatalog.pack_id(Gen2WorldCatalog.KIND_GIFT, 30, 0x4C62)
+	assert_true(bool(host.patch_check(MOD, id, {"species": 1}).get("ok", false)))
+	var second: Dictionary = host.patch_check(&"other", id, {"species": 2})
+	assert_false(second["ok"])
+	assert_eq(second["reason"], &"duplicate_content")
+	assert_string_contains(String(second["detail"]), String(MOD))
+
+
+## An id is the byte a site lives at, so the two spaces cannot collide and an
+## event site is not a script site.
+func test_a_catalog_id_names_a_kind_a_bank_and_an_address() -> void:
+	var script_id: int = Gen2WorldCatalog.pack_id(Gen2WorldCatalog.KIND_ITEM, 48, 0x6E04)
+	var event_id: int = Gen2WorldCatalog.pack_event_id(Gen2WorldCatalog.KIND_ITEM, 48, 0x6E, 4)
+	assert_ne(script_id, event_id)
+	assert_ne(
+		script_id,
+		Gen2WorldCatalog.pack_id(Gen2WorldCatalog.KIND_BADGE, 48, 0x6E04),
+		"the kind is part of the id"
+	)
+	assert_eq(Gen2WorldCatalog.pack_id(&"not_a_kind", 1, 1), -1)

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -85,6 +85,15 @@ func test_a_manifest_built_for_another_host_is_refused() -> void:
 	_write_manifest(source)
 	assert_eq(Gen2ModManifest.read(_directory)["reason"], &"unsupported_api_version")
 
+	## An OLDER contract still runs: every bump so far has only added to it, and
+	## refusing one would break every mod already installed.
+	source["api_version"] = Gen2ModManifest.MIN_API_VERSION
+	_write_manifest(source)
+	assert_true(bool(Gen2ModManifest.read(_directory).get("ok", false)))
+	source["api_version"] = Gen2ModManifest.MIN_API_VERSION - 1
+	_write_manifest(source)
+	assert_eq(Gen2ModManifest.read(_directory)["reason"], &"unsupported_api_version")
+
 
 func test_manifest_versions_and_dependency_ranges_are_validated_before_code_runs() -> void:
 	var source: Dictionary = _valid_manifest()
@@ -318,6 +327,37 @@ func test_two_mods_cannot_claim_one_world_actor_id() -> void:
 	var second: Dictionary = host.register_world_actor(&"first", script.new())
 	assert_false(second["ok"])
 	assert_eq(second["reason"], &"duplicate_actor")
+
+
+## The visible-encounter seam is registered on the same rules an actor is, and
+## for the same reason: a provider is state the host drives, not a scene.
+func test_a_visible_encounter_provider_is_refused_on_the_same_three_rules() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var partial := GDScript.new()
+	# Every method but battle_finished.
+	partial.source_code = "extends RefCounted\nfunc set_context(_c) -> void:\n\tpass\nfunc advance_frame() -> void:\n\tpass\nfunc encounters() -> Array:\n\treturn []\n"
+	partial.reload()
+	var missing: Dictionary = host.register_visible_encounters(&"broken", partial.new())
+	assert_false(missing["ok"])
+	assert_eq(missing["reason"], &"provider_missing_methods")
+	assert_string_contains(String(missing["detail"]), "battle_finished")
+
+	var node := Node2D.new()
+	assert_eq(
+		host.register_visible_encounters(&"node", node)["reason"], &"provider_is_a_node"
+	)
+	node.free()
+
+	var whole := GDScript.new()
+	whole.source_code = partial.source_code + "func battle_finished(_id, _r) -> void:\n\tpass\n"
+	whole.reload()
+	assert_true(bool(host.register_visible_encounters(&"wilds", whole.new())["ok"]))
+	assert_eq(host.visible_encounter_ids(), [&"wilds"])
+	assert_eq(host.visible_encounter_providers().size(), 1)
+	assert_eq(
+		host.register_visible_encounters(&"wilds", whole.new())["reason"],
+		&"duplicate_provider"
+	)
 
 
 func test_a_battle_renderer_missing_a_contract_method_is_refused_at_registration() -> void:

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -69,6 +69,27 @@ func _valid_manifest() -> Dictionary:
 	}
 
 
+## A manifest this host has actually discovered, which is what a capability
+## check needs: the object, not an id that matches one.
+## Its own directory and entry filename: Godot caches a loaded script by path,
+## so two tests writing different code to one path would run the first one's.
+func _loaded_manifest() -> Gen2ModManifest:
+	var directory: String = "%s/lifecycle" % ROOT
+	DirAccess.make_dir_recursive_absolute(directory)
+	var source: Dictionary = _valid_manifest()
+	source["id"] = "lifecycle"
+	source["entry"] = "lifecycle_entry.gd"
+	_write("%s/mod.json" % directory, JSON.stringify(source))
+	_write(
+		"%s/lifecycle_entry.gd" % directory,
+		"extends RefCounted\n\nfunc register(_host, _manifest) -> void:\n\tpass\n"
+	)
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	host.load_discovered()
+	return host.manifests()[0]
+
+
 func test_a_valid_manifest_is_read_without_running_the_mod() -> void:
 	_write_manifest(_valid_manifest())
 	var result: Dictionary = Gen2ModManifest.read(_directory)
@@ -358,6 +379,106 @@ func test_a_visible_encounter_provider_is_refused_on_the_same_three_rules() -> v
 		host.register_visible_encounters(&"wilds", whole.new())["reason"],
 		&"duplicate_provider"
 	)
+
+
+## A mod that holds a RUN rather than an installation. The manifest is the
+## capability, and the ordering is the point: the overlay is cleared before any
+## `save_activated`, so two slots cannot leak patches into one another.
+func test_a_save_lifecycle_provider_is_driven_and_its_overlay_cleared_per_save() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var script := GDScript.new()
+	script.source_code = """extends RefCounted
+
+var calls: Array = []
+
+func save_created(save) -> void:
+	calls.append([&"created", save])
+
+func save_activated(save) -> void:
+	calls.append([&"activated", save])
+	Gen2ModHost.instance().patch_content(&"species", &"lifecycle", 1, {"name": "PATCHED"})
+
+func save_deactivated() -> void:
+	calls.append([&"deactivated", null])
+"""
+	script.reload()
+	var provider: Object = script.new()
+	assert_true(bool(host.register_save_lifecycle(manifest, provider).get("ok", false)))
+	assert_eq(host.save_lifecycle_ids(), [manifest.id])
+
+	## A manifest this host never discovered is not the capability.
+	var stranger := Gen2ModManifest.new()
+	stranger.id = manifest.id
+	assert_eq(
+		host.register_save_lifecycle(stranger, script.new())["reason"],
+		&"unknown_mod_save_owner"
+	)
+	assert_eq(
+		host.register_save_lifecycle(manifest, script.new())["reason"],
+		&"duplicate_save_provider"
+	)
+
+	var overlay: Gen2ContentOverlay = Gen2ContentOverlay.shared()
+	host.activate_save(null)
+	assert_eq(overlay.owner_of(&"species", 1), manifest.id, "a development run patches too")
+	## Switching saves drops the last run's contributions BEFORE the callback, so
+	## what is installed after is only what this activation put there.
+	host.activate_save(null)
+	assert_eq(overlay.owner_of(&"species", 1), manifest.id)
+	host.deactivate_save()
+	assert_eq(overlay.owner_of(&"species", 1), &"", "nothing stays patched with no save open")
+	assert_eq(
+		[provider.get("calls")[0][0], provider.get("calls")[1][0], provider.get("calls")[2][0]],
+		[&"activated", &"activated", &"deactivated"]
+	)
+	## A development run is told so explicitly rather than handed an invented save.
+	assert_null(provider.get("calls")[0][1])
+
+
+## A provider that fails leaves the previous save's patches gone rather than
+## installed, because the clear happens first.
+func test_a_failing_save_provider_leaves_no_earlier_patches_installed() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var script := GDScript.new()
+	script.source_code = """extends RefCounted
+
+var fail: bool = false
+
+func save_created(_save) -> void:
+	pass
+
+func save_activated(_save) -> void:
+	if fail:
+		return
+	Gen2ModHost.instance().patch_content(&"species", &"lifecycle", 1, {"name": "RUN ONE"})
+
+func save_deactivated() -> void:
+	pass
+"""
+	script.reload()
+	var provider: Object = script.new()
+	assert_true(bool(host.register_save_lifecycle(manifest, provider).get("ok", false)))
+	host.activate_save(null)
+	assert_eq(Gen2ContentOverlay.shared().owner_of(&"species", 1), manifest.id)
+	provider.set("fail", true)
+	host.activate_save(null)
+	assert_eq(Gen2ContentOverlay.shared().owner_of(&"species", 1), &"")
+
+
+func test_a_save_lifecycle_provider_is_refused_by_shape() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var node := Node2D.new()
+	assert_eq(host.register_save_lifecycle(manifest, node)["reason"], &"invalid_save_provider")
+	node.free()
+	var partial := GDScript.new()
+	partial.source_code = "extends RefCounted\nfunc save_created(_s) -> void:\n\tpass\n"
+	partial.reload()
+	var result: Dictionary = host.register_save_lifecycle(manifest, partial.new())
+	assert_eq(result["reason"], &"save_provider_missing_methods")
+	assert_string_contains(String(result["detail"]), "save_activated")
 
 
 func test_a_battle_renderer_missing_a_contract_method_is_refused_at_registration() -> void:

--- a/tests/unit/test_stats.gd
+++ b/tests/unit/test_stats.gd
@@ -122,3 +122,14 @@ func test_a_stage_never_takes_a_stat_below_one_or_above_the_cap() -> void:
 func test_a_stage_past_the_ends_is_clamped_rather_than_read_off_the_table() -> void:
 	assert_eq(Gen2Stats.apply_stage(100, 99), Gen2Stats.apply_stage(100, Gen2Stats.MAX_STAGE))
 	assert_eq(Gen2Stats.apply_stage(100, -99), Gen2Stats.apply_stage(100, Gen2Stats.MIN_STAGE))
+
+
+## `CheckShininess`: the Attack DV's own bit and three tens, and nothing else.
+func test_shininess_is_the_attack_mask_and_three_tens() -> void:
+	assert_true(Gen2Stats.is_shiny(Gen2Stats.pack_dvs(2, 10, 10, 10)))
+	assert_true(Gen2Stats.is_shiny(Gen2Stats.pack_dvs(15, 10, 10, 10)), "the mask, not the value")
+	assert_false(Gen2Stats.is_shiny(Gen2Stats.pack_dvs(1, 10, 10, 10)), "attack mask clear")
+	assert_false(Gen2Stats.is_shiny(Gen2Stats.pack_dvs(2, 11, 10, 10)))
+	assert_false(Gen2Stats.is_shiny(Gen2Stats.pack_dvs(2, 10, 9, 10)))
+	assert_false(Gen2Stats.is_shiny(Gen2Stats.pack_dvs(2, 10, 10, 0)))
+	assert_false(Gen2Stats.is_shiny(0))

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6479,3 +6479,87 @@ func _shiny_anim_data() -> Gen2BattleAnimData:
 				0xF8, 0xF8, 0x00, 0x00]),
 		},
 	}, [{"tiles": 0, "sheet": false}, {"tiles": 4, "sheet": true}])
+
+
+## The catalog over a hand-built cache: what each shape decodes to, and that a
+## patch reaches the request the SCRIPT makes rather than only the row.
+func test_a_catalogued_site_hands_over_what_a_mod_patched() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	## `loadwildmon KOFFING, 21` then `startbattle`, which is what a static IS,
+	## and a `verbosegiveitem` behind it.
+	scripts["48:6E00"] = [
+		0x5D, 109, 21,
+		0x5F,
+		0x9E, 0x2A, 1,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open_directory(_directory)
+	data.set_content_overlay(overlay)
+	var catalog: Gen2WorldCatalog = data.catalog()
+
+	var statics: Array = catalog.rows(Gen2WorldCatalog.KIND_STATIC)
+	assert_eq(statics.size(), 1, JSON.stringify(statics))
+	assert_eq(int(statics[0]["species"]), 109)
+	assert_eq(int(statics[0]["level"]), 21)
+	## The id is the byte the command sits at, not its offset in a blob: the
+	## `loadwildmon` is the first command of the script at $6E00.
+	assert_eq(
+		int(statics[0]["id"]),
+		Gen2WorldCatalog.pack_id(Gen2WorldCatalog.KIND_STATIC, 48, 0x6E00)
+	)
+	var items: Array = catalog.rows(Gen2WorldCatalog.KIND_ITEM)
+	var given: Array = items.filter(func(row: Dictionary) -> bool:
+		return row.has("address") and int(row["address"]) == 0x6E04
+	)
+	assert_eq(given.size(), 1, "the verbosegiveitem behind the battle")
+	assert_eq(int(given[0]["item"]), 0x2A)
+
+	overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"mod", int(statics[0]["id"]), {
+		"species": 25, "level": 3,
+	})
+	overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"mod", int(given[0]["id"]), {
+		"item": 1, "quantity": 4,
+	})
+
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(8, 6),
+		Gen2WorldState.new({}, {}, {Gen2WorldInventory.ITEM_OLD_ROD: 1})
+	)
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 8, "y": 6, "script": 0x6E00,
+	}]
+	var waiting: Array = world.dispatch_script_events(Vector2i(8, 6))
+	assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+	var request: Dictionary = waiting[0]["event"]["request"]
+	assert_eq(int(request["values"]["pokemon"]), 25, "the script asked for the patch")
+	assert_eq(int(request["values"]["level"]), 3)
+
+	## The battle is answered and the give runs behind it, into its own
+	## acknowledge text, which is where the script is left waiting.
+	var after: Array = world.complete_runtime_request({
+		"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_WON,
+	})
+	var changed: Dictionary = {}
+	for event: Dictionary in after[0]["events"]:
+		if StringName(event.get("type", &"")) == &"item_changed":
+			changed = event
+	assert_eq(int(changed.get("item", 0)), 1, "the patched item")
+	assert_eq(int(changed.get("quantity", 0)), 4, "in the patched quantity")
+
+
+## The site still runs the cartridge's own script: only the number it hands over
+## is the mod's. An unpatched cache is the control.
+func test_an_unpatched_catalogue_hands_over_the_cartridges_own_numbers() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6E00"] = [0x5D, 109, 21, 0x5F, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 8, "y": 6, "script": 0x6E00,
+	}]
+	var waiting: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var request: Dictionary = waiting[0]["event"]["request"]
+	assert_eq(int(request["values"]["pokemon"]), 109)
+	assert_eq(int(request["values"]["level"]), 21)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6280,3 +6280,198 @@ func test_contest_state_round_trips_through_the_state_dictionary() -> void:
 	assert_eq(int(restored.contest_mon()["species"]), 13)
 	assert_eq(restored.contest_second_party_species(), 155)
 	assert_eq(restored.bug_contest_started(), world.state.bug_contest_started())
+
+
+## What a visible-encounter provider is handed instead of deriving it: the cells
+## a wild may stand on, grouped by the method the terrain resolves to.
+func test_visible_encounter_cells_group_by_terrain_and_refuse_ice() -> void:
+	var world := _world()
+	var cells: Dictionary = world.visible_encounter_cells()
+	var grass: PackedVector2Array = cells[Gen2WorldEncounter.METHOD_GRASS]
+	var surf: PackedVector2Array = cells[Gen2WorldEncounter.METHOD_SURF]
+	assert_true(grass.has(Vector2(5, 10)), "the tall grass cell")
+	assert_false(grass.has(Vector2(5, 9)), "plain land is not grass")
+	assert_false(grass.has(Vector2(6, 10)), "ice")
+	assert_true(surf.has(Vector2(11, 11)), "the pond")
+	assert_true(surf.has(Vector2(12, 11)), "and its second cell")
+	assert_false(surf.has(Vector2(5, 10)), "grass is not surfable")
+
+	## The cave branch skips the grass test, so every walkable floor is eligible.
+	world.current_map.environment = Gen2WorldAPI.ENVIRONMENT_CAVE
+	var cave: PackedVector2Array = world.visible_encounter_cells()[
+		Gen2WorldEncounter.METHOD_GRASS
+	]
+	assert_true(cave.has(Vector2(5, 9)), "plain land in a cave")
+	assert_false(cave.has(Vector2(6, 10)), "ice in a cave")
+
+
+## `wildoff` empties the sweep, so a mod cannot stand a Pokemon on a map a script
+## has switched encounters off for.
+func test_visible_encounter_cells_are_empty_while_wild_encounters_are_off() -> void:
+	var world := _world()
+	world.state.set_wild_encounters_off(true)
+	var cells: Dictionary = world.visible_encounter_cells()
+	assert_eq((cells[Gen2WorldEncounter.METHOD_GRASS] as PackedVector2Array).size(), 0)
+	assert_eq((cells[Gen2WorldEncounter.METHOD_SURF] as PackedVector2Array).size(), 0)
+
+
+## The active table is the one a roll would read: the day's slots, and the swarm's
+## in place of them while one is on.
+func test_active_encounter_tables_follow_the_clock_and_the_swarm() -> void:
+	var world := _world()
+	world.set_object_time(12, Gen2WorldPalette.TIME_DAY)
+	var tables: Dictionary = world.active_encounter_tables()
+	var grass: Dictionary = tables[Gen2WorldEncounter.METHOD_GRASS]
+	assert_eq(StringName(grass["source"]), Gen2WorldEncounter.SOURCE_NORMAL)
+	assert_eq(int((grass["slots"] as Array)[0]["species"]), 16)
+	assert_eq(int((grass["slots"] as Array)[0]["min_level"]), 5)
+	assert_eq(int((grass["slots"] as Array)[0]["max_level"]), 5)
+	assert_eq(
+		int((tables[Gen2WorldEncounter.METHOD_SURF]["slots"] as Array)[0]["species"]), 16
+	)
+
+	world.set_swarm_map(Vector2i(1, 1))
+	var swarmed: Dictionary = world.active_encounter_tables()[
+		Gen2WorldEncounter.METHOD_GRASS
+	]
+	assert_eq(StringName(swarmed["source"]), Gen2WorldEncounter.SOURCE_SWARM)
+	assert_eq(int((swarmed["slots"] as Array)[0]["species"]), 19)
+
+
+## The contest replaces the map's own grass table wholesale, and its rows are a
+## level RANGE where a cartridge table's slot is one level.
+func test_active_encounter_tables_take_the_contest_table_while_it_runs() -> void:
+	var world := _contest_world()
+	world.start_bug_contest()
+	var grass: Dictionary = world.active_encounter_tables()[
+		Gen2WorldEncounter.METHOD_GRASS
+	]
+	assert_eq(StringName(grass["source"]), Gen2WorldBugContest.SOURCE_CONTEST)
+	assert_eq(int((grass["slots"] as Array)[0]["species"]), 10)
+	assert_eq(int((grass["slots"] as Array)[0]["min_level"]), 7)
+	assert_eq(int((grass["slots"] as Array)[0]["max_level"]), 18)
+
+
+## `ANIM_SEND_OUT_MON` with the shiny param, anchored to the Pokemon rather than
+## to a battler and with no field behind it: the host's whole pulse. A provider
+## may ask on every frame; only the first of a window is played.
+func test_a_shiny_pulse_runs_the_cartridge_animation_and_is_deduplicated() -> void:
+	var world := _world()
+	var driver := Gen2WorldEncounters.new()
+	var provider: Object = _pulse_provider()
+	driver.set_providers([provider])
+	driver.set_world(world, _shiny_anim_data())
+	driver.advance_frame()
+	assert_eq(driver.entries().size(), 1)
+	assert_true(bool(driver.entries()[0]["shiny"]))
+	assert_eq(driver.pulse_anchor(), Vector2(5, 10) * float(Gen2WorldAPI.CELL_PIXELS))
+	assert_false(driver.pulse_sprites().is_empty(), "the animation put objects in OAM")
+
+	## The provider asks for a pulse on every frame of the window and gets one
+	## sparkle: the host owns the cadence.
+	for _frame: int in 8:
+		driver.advance_frame()
+	assert_null(driver.pulse_anchor(), "no second sparkle inside the window")
+
+	## An ordinary Pokemon asking for one gets nothing, since the cartridge's
+	## sparkle is the only animation this seam plays.
+	provider.set("dvs", 0)
+	var plain := Gen2WorldEncounters.new()
+	plain.set_providers([provider])
+	plain.set_world(world, _shiny_anim_data())
+	plain.advance_frame()
+	assert_false(bool(plain.entries()[0]["shiny"]))
+	assert_true(plain.pulse_sprites().is_empty())
+	assert_null(plain.pulse_anchor())
+
+
+## An entry the map cannot produce is dropped rather than drawn, and so is one
+## that asserts a shininess of its own.
+func test_a_visible_encounter_entry_is_validated_against_the_snapshot() -> void:
+	var world := _world()
+	var driver := Gen2WorldEncounters.new()
+	var provider: Object = _pulse_provider()
+	driver.set_providers([provider])
+	driver.set_world(world)
+	for bad: Dictionary in [
+		{"cell": Vector2i(5, 9)},          # not an eligible cell
+		{"species": 200},                  # not in the active table
+		{"level": 40},                     # off the slot's own level
+		{"id": &""},                       # no stable id
+		{"shiny": true},                   # the host's answer, not the mod's
+	]:
+		provider.set("overrides", bad)
+		driver.advance_frame()
+		assert_eq(driver.entries().size(), 0, str(bad))
+	provider.set("overrides", {})
+	driver.advance_frame()
+	assert_eq(driver.entries().size(), 1)
+
+
+func _pulse_provider() -> Object:
+	var script := GDScript.new()
+	script.source_code = """extends RefCounted
+
+var dvs: int = 0
+var overrides: Dictionary = {}
+
+func set_context(_context) -> void:
+	pass
+
+func advance_frame() -> void:
+	pass
+
+func encounters() -> Array:
+	var entry: Dictionary = {
+		"id": &"one", "cell": Vector2i(5, 10), "species": 16, "level": 5,
+		"dvs": dvs, "pulse": true,
+	}
+	entry.merge(overrides, true)
+	return [entry]
+
+func battle_finished(_id, _result) -> void:
+	pass
+"""
+	script.reload()
+	var out: Object = script.new()
+	## `CheckShininess`: the attack mask and three tens.
+	out.set("dvs", Gen2Stats.pack_dvs(2, 10, 10, 10))
+	return out
+
+
+## A hand-built animation region whose only script sits at the shiny index, so
+## the pulse has something real to run without a cartridge in hand. One object
+## spawned and held, which is all the pulse is asked to prove here.
+func _shiny_anim_data() -> Gen2BattleAnimData:
+	var base: int = 0x4000
+	var table: int = (Gen2WorldEncounters.SHINY_ANIM + 1) * 2
+	var body: int = base + table
+	var bytes := PackedByteArray()
+	bytes.resize(table)
+	bytes[Gen2WorldEncounters.SHINY_ANIM * 2] = body & 0xFF
+	bytes[Gen2WorldEncounters.SHINY_ANIM * 2 + 1] = body >> 8
+	# `anim_obj` row 0 at (80, 64), a yield, and `anim_ret`.
+	for value: int in [0xD0, 0x00, 0x50, 0x40, 0x00, 0x01, 0xFF]:
+		bytes.append(value)
+	var frameset: int = base + 2
+	var oam: int = base + RomLayout.BATTLE_ANIM_OAM_SET_SIZE
+	return Gen2BattleAnimData.create({
+		&"scripts": {
+			"bank": 0x32, "address": base,
+			"count": Gen2WorldEncounters.SHINY_ANIM + 1, "data": bytes,
+		},
+		&"objects": {
+			"bank": 0x33, "address": base, "count": 1,
+			"data": PackedByteArray([0x00, 0x90, 0x00, 0x00, 0x02, 0x01]),
+		},
+		&"framesets": {
+			"bank": 0x33, "address": base, "count": 1,
+			"data": PackedByteArray([frameset & 0xFF, frameset >> 8,
+				0x00, 0x0F, Gen2BattleAnimObject.OAM_END]),
+		},
+		&"oam_sets": {
+			"bank": 0x33, "address": base, "count": 1,
+			"data": PackedByteArray([0x00, 0x01, oam & 0xFF, oam >> 8,
+				0xF8, 0xF8, 0x00, 0x00]),
+		},
+	}, [{"tiles": 0, "sheet": false}, {"tiles": 4, "sheet": true}])

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3170,11 +3170,15 @@ func test_party_summary_round_trips_and_reaches_queued_script_requests() -> void
 	var world: Gen2WorldAPI = _world()
 	assert_true(world.party_summary().is_empty())
 	assert_true(world.set_party_summary(
-		3, true, [25, 1] as Array[int], [[0x46], []], ["PIKA", "BULBASAUR"], [false, true]
+		3, true, [25, 1] as Array[int], [[0x46], []], ["PIKA", "BULBASAUR"], [false, true],
+		{}, [false, true]
 	)["ok"])
 	var expected: Dictionary = {
 		"count": 3, "pokerus": true, "species": [25, 1],
 		"moves": [[0x46], []], "names": ["PIKA", "BULBASAUR"], "eggs": [false, true],
+		## Per slot beside the rest: a fainted Pokemon in slot 2 is a fact the
+		## lead's own flag cannot carry.
+		"fainted": [false, true],
 	}
 	assert_eq(world.party_summary(), expected)
 	assert_false(world.set_party_summary(-1, false)["ok"])

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -163,3 +163,25 @@ func test_invalid_battle_identifiers_are_structured_failures() -> void:
 	)
 	assert_false(invalid_trainer["ok"])
 	assert_eq(invalid_trainer["reason"], &"invalid_trainer")
+
+
+## A visible encounter chose its DVs before the player met it, so the battle is
+## built with those four numbers rather than a fresh roll. Nothing else names
+## `dvs`, and what does not gets the perfect word it always got.
+func test_a_wild_request_carries_its_own_dvs_into_the_battle() -> void:
+	var shiny: int = Gen2Stats.pack_dvs(2, 10, 10, 10)
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5, "dvs": shiny}},
+		_player_party()
+	)
+	assert_true(bool(prepared["ok"]), String(prepared.get("reason", "")))
+	assert_eq((prepared["battle"] as Gen2Battle).enemy.dvs, shiny)
+	assert_true(Gen2Stats.is_shiny((prepared["battle"] as Gen2Battle).enemy.dvs))
+
+	var rolled: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5}},
+		_player_party()
+	)
+	assert_eq(
+		(rolled["battle"] as Gen2Battle).enemy.dvs, Gen2BattleMon.PERFECT_DVS
+	)

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -1,0 +1,219 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies [Gen2WorldCatalog] against freshly imported real caches, on all three
+## cartridges.
+##
+## The catalog is derived, not imported: it walks the decoded scripts and the map
+## events and calls certain shapes starters, gifts, statics, trades, prizes,
+## items, badges and shops. A derivation like that is exactly the thing that
+## quietly stops being true, so what is pinned here is not a count alone but the
+## SEMANTICS: the three starters are Chikorita, Cyndaquil and Totodile, the
+## badges are sixteen distinct ones, the legendaries are among the statics at
+## their own levels, and the Game Corner's prices are the cartridge's.
+##
+## A census pin catches a decode that drifts. A semantic pin catches a decode
+## that drifts into something still plausible, which is the failure a census
+## cannot see.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- catalog
+
+## constants/pokemon_constants.asm.
+const CHIKORITA: int = 152
+const CYNDAQUIL: int = 155
+const TOTODILE: int = 158
+const LUGIA: int = 249
+const HO_OH: int = 250
+const CELEBI: int = 251
+const SUICUNE: int = 245
+const SUDOWOODO: int = 185
+const SNORLAX: int = 143
+const RED_GYARADOS: int = 130
+
+## Per game: total rows, and the count under each kind in
+## [constant Gen2WorldCatalog.KINDS]' own order.
+const EXPECTED_CENSUS: Dictionary = {
+	&"gold": [482, 3, 9, 15, 9, 9, 360, 18, 59],
+	&"silver": [482, 3, 9, 15, 9, 9, 360, 18, 59],
+	&"crystal": [547, 3, 11, 15, 13, 6, 427, 16, 56],
+}
+
+## The legendaries and set pieces every profile has to place, and at what level.
+## `maps/*.asm`'s own `loadwildmon` operands.
+const EXPECTED_STATICS: Dictionary = {
+	&"gold": {LUGIA: [70, 40], HO_OH: [40, 70], SNORLAX: [50], SUDOWOODO: [20]},
+	&"silver": {LUGIA: [70, 40], HO_OH: [40, 70], SNORLAX: [50], SUDOWOODO: [20]},
+	&"crystal": {
+		LUGIA: [60], HO_OH: [60], CELEBI: [30], SUICUNE: [40],
+		## Crystal reaches its Sudowoodo from two `loadwildmon` sites, one per
+		## branch of the Squirtbottle script; Gold and Silver from one.
+		SNORLAX: [50], SUDOWOODO: [20, 20], RED_GYARADOS: [30],
+	},
+}
+
+## `maps/GoldenrodGameCorner.asm` and `maps/CeladonGameCorner.asm`'s own
+## `EQU` prices, in the order the corpus walk reaches them.
+const EXPECTED_PRIZE_PRICES: Dictionary = {
+	&"gold": [200, 700, 2100, 200, 700, 2100, 3333, 6666, 9999],
+	&"silver": [200, 700, 2100, 200, 700, 2100, 3333, 6666, 9999],
+	&"crystal": [100, 800, 1500, 2222, 5555, 8888],
+}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		var catalog: Gen2WorldCatalog = _r.data.catalog()
+		_verify_census(catalog)
+		_verify_starters(catalog)
+		_verify_statics(catalog)
+		_verify_prizes(catalog)
+		_verify_badges(catalog)
+		_verify_ids(catalog)
+		_verify_patching(catalog)
+	)
+
+
+func _verify_census(catalog: Gen2WorldCatalog) -> void:
+	var found: Array = [catalog.size()]
+	for kind: StringName in Gen2WorldCatalog.KINDS:
+		found.append(catalog.ids(kind).size())
+	var expected: Array = EXPECTED_CENSUS[_r.game_id]
+	_r.note("catalog %d rows: %s." % [catalog.size(), str(found.slice(1))])
+	_r.check(
+		found == expected,
+		"census is %s, not the pinned %s." % [str(found), str(expected)]
+	)
+
+
+## The one shape only Elm's three balls take: a `pokepic` of the species a
+## `givepoke` in the same script hands over. If that stops being unique, this is
+## where it shows.
+func _verify_starters(catalog: Gen2WorldCatalog) -> void:
+	var found: Array[int] = catalog.possible_starters()
+	found.sort()
+	var wanted: Array[int] = [CHIKORITA, CYNDAQUIL, TOTODILE]
+	_r.check(
+		found == wanted, "starters are %s, not the three Elm offers." % str(found)
+	)
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_STARTER):
+		_r.check(
+			int(row["level"]) == 5,
+			"a starter is offered at level %d rather than 5." % int(row["level"])
+		)
+
+
+func _verify_statics(catalog: Gen2WorldCatalog) -> void:
+	var levels: Dictionary = {}
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_STATIC):
+		var species: int = int(row["species"])
+		var list: Array = levels.get(species, [])
+		list.append(int(row["level"]))
+		levels[species] = list
+	for species: int in EXPECTED_STATICS[_r.game_id]:
+		var wanted: Array = EXPECTED_STATICS[_r.game_id][species]
+		var found: Array = levels.get(species, [])
+		found.sort()
+		var sorted_wanted: Array = wanted.duplicate()
+		sorted_wanted.sort()
+		_r.check(
+			found == sorted_wanted,
+			"species %d stands at %s, not the pinned %s." % [
+				species, str(found), str(sorted_wanted),
+			]
+		)
+
+
+## A prize is a give site with a `takecoins` behind it, and the price has to be
+## the one for THAT branch rather than the first one in the vendor's script.
+func _verify_prizes(catalog: Gen2WorldCatalog) -> void:
+	var prices: Array = []
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_PRIZE):
+		prices.append(int(row["price"]))
+	_r.check(
+		prices == EXPECTED_PRIZE_PRICES[_r.game_id],
+		"prize prices are %s, not the pinned %s." % [
+			str(prices), str(EXPECTED_PRIZE_PRICES[_r.game_id]),
+		]
+	)
+
+
+## Sixteen badges exist and each is granted somewhere. Gold and Silver set two of
+## them from a second script as well, which is why the row count is not the badge
+## count and why the test is over the SET rather than the list.
+func _verify_badges(catalog: Gen2WorldCatalog) -> void:
+	var seen: Dictionary = {}
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_BADGE):
+		seen[int(row["badge"])] = true
+		_r.check(
+			catalog.is_progression(row), "badge %d is not progression." % int(row["badge"])
+		)
+	var badges: Array = seen.keys()
+	badges.sort()
+	_r.check(
+		badges.size() == Gen2WorldState.BADGE_ENGINE_FLAGS.size(),
+		"%d distinct badges are granted, not %d." % [
+			badges.size(), Gen2WorldState.BADGE_ENGINE_FLAGS.size(),
+		]
+	)
+
+
+## An id has to name one site and be recomputable from the site's own address,
+## since that is what a runtime reader does. Both directions, over every row.
+func _verify_ids(catalog: Gen2WorldCatalog) -> void:
+	var seen: Dictionary = {}
+	for row: Dictionary in catalog.rows():
+		var id: int = int(row["id"])
+		if seen.has(id):
+			_r.check(false, "id %d names two sites." % id)
+			return
+		seen[id] = true
+		if not row.has("address"):
+			continue
+		var recomputed: int = Gen2WorldCatalog.pack_id(
+			StringName(row["kind"]), int(row["bank"]), int(row["address"])
+		)
+		if recomputed != id:
+			_r.check(false, "id %d does not recompute from its own address." % id)
+			return
+	_r.note("%d ids, each naming one site." % seen.size())
+
+
+## The whole point of the catalog: a patch has to reach the row a runtime reader
+## gets. Done on an overlay of this check's own, so the shared one is untouched.
+func _verify_patching(catalog: Gen2WorldCatalog) -> void:
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open(_r.game_id)
+	if data == null:
+		return
+	data.set_content_overlay(overlay)
+	var patched: Gen2WorldCatalog = data.catalog()
+	var moved: int = 0
+	for kind: StringName in [
+		Gen2WorldCatalog.KIND_STARTER, Gen2WorldCatalog.KIND_GIFT,
+		Gen2WorldCatalog.KIND_STATIC, Gen2WorldCatalog.KIND_PRIZE,
+	]:
+		for row: Dictionary in patched.rows(kind):
+			overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"check", int(row["id"]), {
+				"species": CELEBI, "level": 7,
+			})
+			var after: Dictionary = patched.check(int(row["id"]))
+			if int(after["species"]) != CELEBI or int(after["level"]) != 7:
+				_r.check(false, "row %d did not read its patch back." % int(row["id"]))
+				return
+			moved += 1
+	for row: Dictionary in patched.rows(Gen2WorldCatalog.KIND_ITEM):
+		overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"check", int(row["id"]), {
+			"item": 1, "quantity": 3,
+		})
+		var after: Dictionary = patched.check(int(row["id"]))
+		if int(after["item"]) != 1 or int(after["quantity"]) != 3:
+			_r.check(false, "item row %d did not read its patch back." % int(row["id"]))
+			return
+		moved += 1
+	_r.note("%d rows patched and read back." % moved)
+	_r.check(
+		Gen2ContentOverlay.shared().is_empty(),
+		"the check leaked into the shared overlay."
+	)

--- a/tools/checks/catalog.gd.uid
+++ b/tools/checks/catalog.gd.uid
@@ -1,0 +1,1 @@
+uid://dyunblo23wq1u

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -50,6 +50,7 @@ func run(r: RefCounted) -> void:
 		_verify_bug_contest()
 		_verify_gate_errand()
 		_census()
+		_verify_wild_patch_indices()
 	)
 
 
@@ -360,6 +361,66 @@ func _verify_union_cave() -> void:
 
 
 ## Every map in the cache, so a rule change is one number rather than one map.
+## Every index of the four wild sources beside the map tables is patchable and
+## reads back through `GameData`, on a real cache. An off-by-one in either
+## direction, or a source a reader takes from somewhere else, shows here and
+## nowhere in a hand-built fixture.
+func _verify_wild_patch_indices() -> void:
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open(_r.game_id)
+	if data == null:
+		return
+	data.set_content_overlay(overlay)
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var sets: int = 0
+	for index: int in data.treemon_set_count():
+		if data.treemon_set(index).is_empty():
+			continue
+		sets += 1
+		overlay.patch(Gen2ContentOverlay.KIND_TREEMON, &"check", index, {
+			"common": [{"percent": 100, "species": index + 1, "level": 5}],
+		})
+		var patched: Dictionary = data.treemon_set(index)
+		_r.check(
+			int((patched["common"] as Array)[0]["species"]) == index + 1
+				and (patched["rare"] as Array).size() == (data.treemon_set(index)["rare"] as Array).size(),
+			"treemon set %d did not read its patch back." % index
+		)
+	var rows: int = 0
+	for pair: Array in [
+		[Gen2ContentOverlay.KIND_BUG_CONTEST, data.bug_contest_mons()],
+		[Gen2ContentOverlay.KIND_ROAMING, data.world_roaming_mons()],
+	]:
+		for index: int in (pair[1] as Array).size():
+			rows += 1
+			overlay.patch(pair[0], &"check", index, {"species": index + 1})
+	for index: int in data.world_fishing_time_groups().size():
+		rows += 1
+		overlay.patch(Gen2ContentOverlay.KIND_FISHING_TIME, &"check", index, {
+			"night": {"species": index + 1, "level": 5},
+		})
+	for index: int in data.bug_contest_mons().size():
+		_r.check(
+			int(data.bug_contest_mons()[index]["species"]) == index + 1,
+			"contest row %d did not read its patch back." % index
+		)
+	for index: int in data.world_roaming_mons().size():
+		_r.check(
+			int(data.world_roaming_mons()[index]["species"]) == index + 1,
+			"roaming mon %d did not read its patch back." % index
+		)
+	for index: int in data.world_fishing_time_groups().size():
+		_r.check(
+			int(data.world_fishing_time_groups()[index]["night"]["species"]) == index + 1,
+			"fishing time group %d did not read its patch back." % index
+		)
+	_r.note("wild patch indices: %d treemon sets and %d list rows read back." % [
+		sets, rows,
+	])
+	## The shared overlay is untouched, since a check is not a mod.
+	_r.check(host.content_overlay().is_empty(), "the check leaked into the shared overlay.")
+
+
 func _census() -> void:
 	var cells: int = 0
 	var maps: Dictionary = {}

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -11,6 +11,10 @@ var _r: RefCounted = null
 ## home/map_objects.asm's CheckIceTile. The real-cartridge counterpart to the
 ## gate cases in tests/unit/test_world_api.gd, which use a hand-built map.
 ##
+## The visible-encounter sweep is checked against the same rule on the same
+## corpus: `visible_encounter_cells` has to name exactly the cells the step roll
+## accepts, grouped by the method the terrain resolves to.
+##
 ## The census is the point: an encounter cell is a small minority of a map's
 ## walkable cells, and the defect this topic exists to catch was every land cell
 ## rolling. A route whose grass moves, or a collision code that stops being read
@@ -369,6 +373,12 @@ func _census() -> void:
 		)
 		world.state.set_wild_encounter_cooldown(0)
 		var counts: Dictionary = _map_counts(world)
+		var visible: Dictionary = _visible_cells_match(world)
+		if not bool(visible["ok"]):
+			_r.check(false, "map %d/%d cell %s: %s." % [
+				map.group, map.number, str(visible["cell"]), visible["reason"],
+			])
+			return
 		cells += int(counts["encounter"])
 		iced += int(counts["ice"])
 		if int(counts["encounter"]) > 0:
@@ -405,3 +415,36 @@ func _map_counts(world: Gen2WorldAPI) -> Dictionary:
 			elif Gen2WorldCollision.is_ice(world.collision_code_at(cell)):
 				ice += 1
 	return {"walkable": walkable, "encounter": encounter, "ice": ice}
+
+
+## The sweep a visible-encounter provider is handed has to be exactly the set of
+## cells the step roll accepts, cell for cell, or a mod stands a Pokemon where
+## the cartridge would never have produced one. Answered per map and grouped by
+## the method the terrain resolves to, so the two counts also have to add up.
+func _visible_cells_match(world: Gen2WorldAPI) -> Dictionary:
+	var sweep: Dictionary = world.visible_encounter_cells()
+	var listed: Dictionary = {}
+	for method: Variant in sweep:
+		for cell: Vector2 in sweep[method] as PackedVector2Array:
+			var at := Vector2i(cell)
+			var permission: int = world.collision_permission_at(at)
+			var wanted: StringName = Gen2WorldEncounter.METHOD_SURF \
+				if permission == Gen2WorldCollision.WATER_TILE \
+				else Gen2WorldEncounter.METHOD_GRASS
+			if StringName(method) != wanted or listed.has(at):
+				return {"ok": false, "cell": at, "reason": "wrong method or listed twice"}
+			listed[at] = true
+	var map: Gen2WorldMap = world.current_map
+	for y: int in map.collision_height:
+		for x: int in map.collision_width:
+			var cell := Vector2i(x, y)
+			world.player_cell = cell
+			## The sweep's one narrowing on the roll: a cell nothing can stand
+			## on. A cave's walls pass `CanEncounterWildMon`, since that branch
+			## skips the grass test, and a Pokemon cannot be put in one.
+			var permission: int = world.collision_permission_at(cell)
+			var standable: bool = permission == Gen2WorldCollision.LAND_TILE \
+				or permission == Gen2WorldCollision.WATER_TILE
+			if (world.can_encounter_wild_mon() and standable) != listed.has(cell):
+				return {"ok": false, "cell": cell, "reason": "the roll and the sweep disagree"}
+	return {"ok": true, "cells": listed.size()}

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -19,7 +19,10 @@ extends SceneTree
 ## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `mart`
 ## (`BuyMenu`, talked open from the cell in front of a shop's counter, as
 ## `crystal 1 8 ... mart 3 3`), `pokepic`
-## (`Script_pokepic`'s box over the map, holding Chikorita), the name of any
+## (`Script_pokepic`'s box over the map, holding Chikorita),
+## `visible_encounter` (a shiny of the map's own table standing on the eligible
+## cell nearest the player, with the cartridge's sparkle over it: try
+## `crystal 24 3 ... visible_encounter 4 9`), the name of any
 ## `preview_*` driver on the world screen without that prefix (`field_move` is
 ## `PartyMenu` with a taught CUT on it, `start_menu`, `capture`, `move_forget`
 ## and the rest; a `*_use` name is driven twice, since each call is one step of


### PR DESCRIPTION
Every open engine request, complete. Four host seams a mod cannot build for itself, each keeping the cartridge's own rules on this side of the boundary.

## R17: visible wild encounters

`register_visible_encounters(id, provider)`. A provider is handed the cells a wild may stand on and the table each method resolves to, and answers a bounded population; the host validates every entry against both and owns everything else.

- `Gen2WorldAPI.visible_encounter_cells()` is `CanEncounterWildMon` per cell, grouped by the method the terrain resolves to, narrowed only by whether anything can stand there.
- `active_encounter_tables()` is the table a roll would read, with swarm and Bug Contest substitutions made and the time of day picked.
- The ordinary post-step roll is off while a provider is registered. Scripted, fishing, Headbutt, Rock Smash, Sweet Scent and contest encounters keep their own paths.
- Meeting one starts the normal wild battle with the entry's exact species, level and DVs; the result goes back by id.
- `Gen2Stats.is_shiny` is `CheckShininess`. A shiny wears the species' own colours and pulses `ANIM_SEND_OUT_MON` with the shiny param, anchored to it with no battle field behind it.

`api_version` is 2, and the manifest check is a range now, so mods declaring 1 keep running.

## R18: the follower's party boundary

`party_summary()` carries a per-slot `fainted` array; only the lead had a flag. `register_party_member_menu(id, {label, handler})` appends a row to a party member's submenu, both halves Callables taking the one-based slot, after every cartridge action and before CANCEL, never for an egg and never in a battle.

## R19: a run bound to its save

`register_save_lifecycle(manifest, provider)`. The manifest is the capability. Every lifecycle mod's overlay contributions are dropped in one pass **before** the `save_activated` callbacks, so two slots cannot leak patches into one another and a provider that fails leaves nothing installed. A development run is null, not an invented save.

## R20: the rest of the content boundary

**The wild sources**: `patch_treemon_set`, `patch_bug_contest_mon`, `patch_roaming_mon`, `patch_fishing_time_group`, each by its own table index, each preserving what a patch does not name.

**The gameplay catalog**: `Gen2WorldCatalog` decodes eight kinds of site — starters, gifts, statics, trades, Game Corner prizes, items on the ground, badges, shops — and gives each a stable id, with `possible_starters`, `field_hm_items`, `is_progression` and per-site `requires` for proving a placement finishes. `patch_check` moves a field; the script still sets its own flag, prints its own dialogue, takes its own money and runs its own battle.

None of it needed a cache-format bump, because **none of these categories is a table in the ROM**. A prize is `checkcoins`/`givepoke`/`takecoins` in a map script; a starter is the only `givepoke` whose script also draws the same species with `pokepic`. The catalog is derived from data the cache already holds, and an id is the byte the site lives at, so two entry points into one routine name one site and the runner recomputes the id from its own frame.

## A bug found on the way

Crystal's `promptbutton` decoded under pokegold's `pokepic` name: `_later_command_name` shadowed the base table at $55. All 4,368 of Crystal's promptbuttons carried a species read off the next command's first byte, and one at the end of a blob read past the buffer. Nothing dispatched on the name, so no behaviour moved; `validate.gd -- world_scripts` reported 4,394 pokepics on Crystal and now reports 26.

## Proof

| Check | Result |
|---|---|
| GUT, unit + integration | 3,066 passing over 151 scripts |
| `validate.gd -- all` | no failures |
| `catalog` topic (new) | census and semantics pinned on all three cartridges: three starters, sixteen distinct badges, Lugia/Ho-Oh/Celebi/Suicune at their own levels, the Game Corner's own prices, every id naming one site, 396–462 rows patched and read back |
| `wild_encounters` topic | the visible-encounter sweep agrees with the roll on every map of all three cartridges; every index of the four wild sources reads its patch back |
| `replay_world.gd` | 30 routes, 0 failures |
| Three-profile story walk | byte-identical to `main` before and after |
| Boot smoke | clean |

Photographed on Route 29 through the new `preview_world.gd` `visible_encounter` mode: a shiny of the map's own table, in its shiny palette, with the cartridge's sparkle over it.