### PR TITLE
Engine request R21: catalog transactions and the placement proof

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -300,21 +300,60 @@ for row in catalog.rows(Gen2WorldCatalog.KIND_STATIC):
 | `KIND_SHOP` | `mart`, `dialog` | A `pokemart` command |
 
 Every row also carries `id`, `kind`, its `bank` and `address` (or its `map` and
-`event_index`), and `requires`: the events, engine flags and items the script
-tested before reaching the site. `requires` is a decoded fact about what the
-cartridge looked at, not a claim that the site is unreachable without them.
-
-For proving a placement finishes: `catalog.possible_starters()` is the three
-species Elm offers, `catalog.field_hm_items()` is the HM items whose move is a
-field move on THIS cartridge, and `catalog.is_progression(row)` is true for a
-badge or a field HM. A check the catalog did not record stays vanilla; nothing
-is guessed.
+`event_index`), the `map` it stands on where the host could attribute one, and
+`requires`: the events, engine flags and items the script tested before reaching
+the site, read from the site's own branch rather than the whole blob.
 
 `patch_check(id, fields)` changes a field of a row. It cannot replace the script:
 the site still sets its own completion flag, prints its own dialogue, takes its
 own money and runs its own battle, and only the number it hands over is the
 mod's. Two mods patching one id is refused by the overlay's own ownership rule,
 not by load order.
+
+A field is effective at its whole TRANSACTION, not at one command of it. The
+host links the commands a site's numbers also reach:
+
+| Patch | Also drives |
+|---|---|
+| a starter's `species` | the `pokepic` its ball shows, so the picture and the Pokemon cannot disagree |
+| a prize's `price` | its `checkcoins` affordability branch and its `takecoins` deduction, as one transaction |
+| a trade's `species` / `requested_species` | both halves of the trade, carried beside the cartridge record rather than written into it, so a second site naming that record is unaffected |
+| a shop's `items` | the shelf the counter sells, as `{item, price}` rows |
+
+## Proving a placement finishes
+
+A shuffle of badges and key items can write a seed nobody can beat.
+`host.validate_placement(data, patches)` answers before anything is installed:
+
+```gdscript
+var result := host.validate_placement(data, {check_id: {"item": hm_surf}, ...})
+if not result["ok"]:
+	print(result["missing"])   # {check, kind, requirement}
+```
+
+`patches` is the same `{check_id: fields}` shape `patch_check` takes one row at a
+time. The answer is `{ok, reached, critical, missing}`, deterministic, and it
+installs nothing: a failed seed leaves the game exactly as it was, so a generator
+retries against `missing` rather than guessing.
+
+`missing.requirement` is one of `{map}`, `{item}` or `{badge}`, which is the
+first thing that never became satisfiable. Behind it:
+
+- `Gen2WorldReachability` floods each map's own collision grid from the cells a
+  player arrives on, so an exit only Surf reaches is a Surf exit, and asks the
+  same tile questions the overworld does.
+- An HM is only a way past anything once its badge is in hand; the badge each
+  field move needs is `Gen2WorldFieldMove.badge_for_move`.
+- `catalog.possible_starters()`, `catalog.field_hm_items()` and
+  `catalog.is_progression(row)` are the same facts for a mod doing its own
+  planning.
+
+What it does NOT model, stated so a mod does not read more into a pass than is
+there: it is MAP-granular rather than cell-exact, and story `checkevent` guards
+are treated as satisfiable because a placement does not move the scripts that
+set them. Both are deliberate and both err toward passing a seed rather than
+rejecting a good one. A site the catalog could not attribute to a map is taken
+as standing where the player already is.
 
 The catalog is DERIVED, not imported, so it needs no cache-format bump and no
 re-import. It is also a decode of a corpus: `tools/checks/catalog.gd` pins both

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -60,11 +60,29 @@ const BGEVENT_ITEM: int = Gen2WorldAPI.BGEVENT_ITEM
 ## practice; this is the guard against a decode that runs away.
 const MAX_SCRIPT_COMMANDS: int = 4096
 
+## The cache stores every script as a fixed 512-byte window rather than as its
+## own length, so a walk that ran the whole window would spend most of it
+## decoding whatever the ROM put after the script. A blob holds one routine and
+## the branch labels behind it: the Game Corner's vendor, the busiest shape
+## either game has, is a loop and three prizes, which is five. Sixteen is well
+## past anything real and is what keeps this a second rather than eight.
+const MAX_ROUTINES: int = 16
+
 var _data: GameData = null
 ## id to row.
 var _rows: Dictionary = {}
 ## kind to the ids under it, in decode order.
 var _by_kind: Dictionary = {}
+## The commands a site's fields also have to reach, keyed by the byte they sit
+## at: `bank << 24 | address` to `{id, role}`. A starter's species is its ball's
+## PICTURE as well as its `givepoke`, and a prize's price is both the
+## `checkcoins` that decides affordability and the `takecoins` that charges. See
+## [method link_at].
+var _links: Dictionary = {}
+## Built on first ask. See [method item_sources].
+var _item_sources: Dictionary = {}
+## Built on first ask. See [method field_hm_items].
+var _field_hms: Array[int] = []
 
 
 ## Builds the catalog for [param data]. Walks every imported script once and
@@ -77,6 +95,7 @@ static func build(data: GameData) -> Gen2WorldCatalog:
 		return out
 	out._scan_scripts()
 	out._scan_map_events()
+	out._attribute_maps()
 	return out
 
 
@@ -121,6 +140,19 @@ func size() -> int:
 	return _rows.size()
 
 
+## The site a command at [param bank]:[param address] belongs to but is not
+## itself, as `{id, role}`, or empty. `role` is `picture` for a starter's
+## `pokepic` and `price` for a prize's `checkcoins` or `takecoins`.
+##
+## This is what makes a patched field effective at the whole TRANSACTION rather
+## than at one command of it: the ball that shows a Bellsprout hands over a
+## Bellsprout, and a prize the mod priced at 500 is refused at 499 coins and
+## charges 500.
+func link_at(bank: int, address: int) -> Dictionary:
+	var value: Variant = _links.get((bank & 0xFF) << ID_BANK_SHIFT | (address & ID_ADDRESS_MASK), null)
+	return value if value is Dictionary else {}
+
+
 ## Every row, patched, for a mod planning a placement in one pass.
 func rows(kind: StringName = &"") -> Array:
 	var out: Array = []
@@ -144,6 +176,8 @@ func possible_starters() -> Array[int]:
 ## must keep reachable. Read off the cartridge's own TM/HM move table rather
 ## than written down, so Gold and Crystal each answer for themselves.
 func field_hm_items() -> Array[int]:
+	if not _field_hms.is_empty():
+		return _field_hms
 	var out: Array[int] = []
 	if _data == null:
 		return out
@@ -154,7 +188,44 @@ func field_hm_items() -> Array[int]:
 			continue
 		if Gen2WorldFieldMove.is_field_move(_data.tmhm_move(number + 1)):
 			out.append(item)
+	_field_hms = out
 	return out
+
+
+## Which badge an engine flag grants, or -1. Public because a requirement names
+## the FLAG and a placement reasons about the badge.
+func badge_for_engine_flag(flag: int) -> int:
+	return _badge_for_flag(flag)
+
+
+## The badge [param item]'s own move needs before the overworld will run it, or
+## -1 for an item that is not a field HM. `GetTMHMItemMove` and the field
+## functions' own `CheckBadge` arguments, neither of them written down here.
+func badge_for_hm_item(item: int) -> int:
+	return Gen2WorldFieldMove.badge_for_move(move_for_hm_item(item))
+
+
+## The field move [param item] teaches, or 0 for anything that is not a field HM.
+func move_for_hm_item(item: int) -> int:
+	if _data == null or not Gen2WorldTMHM.is_hm(item):
+		return 0
+	var move: int = Gen2WorldTMHM.move_for_item(_data, item)
+	return move if Gen2WorldFieldMove.is_field_move(move) else 0
+
+
+## Every item some check in this catalog hands over, as a set. An item outside it
+## is bought, found in a mart or given by a story script, so asking for it gates
+## no placement.
+func item_sources() -> Dictionary:
+	if not _item_sources.is_empty():
+		return _item_sources
+	for row: Dictionary in rows(KIND_ITEM):
+		_item_sources[int(row["item"])] = true
+	for kind: StringName in [KIND_STARTER, KIND_GIFT, KIND_PRIZE]:
+		for row: Dictionary in rows(kind):
+			if int(row.get("item", 0)) > 0:
+				_item_sources[int(row["item"])] = true
+	return _item_sources
 
 
 ## Whether a row's reward is one a later check may be gated behind: a badge, or a
@@ -187,6 +258,7 @@ func _scan_one_script(
 ) -> void:
 	if body.is_empty():
 		return
+
 	var commands: Array = []
 	var offset: int = 0
 	## The walk does NOT stop at the first `end` or `sjump`. A bounded blob holds
@@ -199,6 +271,7 @@ func _scan_one_script(
 	## a site's numbers have to be ones the cartridge can hold ([method
 	## _plausible]), and a static has to be followed by the `startbattle` that
 	## makes it one.
+	var terminators: int = 0
 	for _step: int in MAX_SCRIPT_COMMANDS:
 		if offset >= body.size():
 			break
@@ -207,6 +280,10 @@ func _scan_one_script(
 			break
 		commands.append(command)
 		offset += int(command["width"])
+		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal):
+			terminators += 1
+			if terminators >= MAX_ROUTINES:
+				break
 	## Two facts about the WHOLE script decide what its give sites mean: a
 	## `takecoins` makes them purchases, and a `pokepic` of the species a
 	## `givepoke` later hands over is the only shape Elm's three balls take and
@@ -219,25 +296,23 @@ func _scan_one_script(
 			pictured[int(command.get("pokemon", 0))] = true
 	for command: Dictionary in commands:
 		_record_script_site(
-			bank, address, command, commands, _coin_price(commands, int(command["offset"])),
-			pictured, crystal
+			bank, address, command, commands,
+			_coin_price(commands, int(command["offset"]), crystal), pictured, crystal
 		)
 
 
 ## `takecoins`' own operand, which is the purchase price and is what makes a
-## `givepoke` beside it a PRIZE rather than a gift. The source order is give then
-## take, so the answer is the nearest one AFTER [param at]; a script that takes
-## before it gives falls back to the nearest before. Zero when the script spends
-## no coins at all.
-func _coin_price(commands: Array, at: int) -> int:
-	var before: int = 0
+## `givepoke` beside it a PRIZE rather than a gift. Read from the give's own
+## branch, so a vendor's three prizes get three prices. Zero when the branch
+## spends no coins at all, which is what makes a give a gift.
+func _coin_price(commands: Array, at: int, crystal: bool) -> int:
+	var take: int = _nearest_coin_command(commands, at, &"takecoins", crystal)
+	if take < 0:
+		return 0
 	for command: Dictionary in commands:
-		if StringName(command["name"]) != &"takecoins":
-			continue
-		if int(command["offset"]) > at:
+		if int(command["offset"]) == take:
 			return int(command.get("value", 0))
-		before = int(command.get("value", 0))
-	return before
+	return 0
 
 
 func _record_script_site(
@@ -258,10 +333,25 @@ func _record_script_site(
 				kind = KIND_PRIZE
 			elif pictured.has(species):
 				kind = KIND_STARTER
-			_add(kind, bank, address, offset, {
+			var row: Dictionary = {
 				"species": species, "level": level,
 				"item": int(command.get("item", 0)), "price": coins,
-			}, commands, offset, crystal)
+			}
+			## The ball's own picture, and the two coin commands of the branch
+			## this give sits in. Absolute addresses, so the runner finds them
+			## from its own frame.
+			if kind == KIND_STARTER:
+				var picture: int = _address_of(commands, &"pokepic", species)
+				if picture >= 0:
+					row["picture_address"] = address + picture
+			if kind == KIND_PRIZE:
+				var check: int = _nearest_coin_command(commands, offset, &"checkcoins", crystal)
+				var take: int = _nearest_coin_command(commands, offset, &"takecoins", crystal)
+				if check >= 0:
+					row["check_address"] = address + check
+				if take >= 0:
+					row["take_address"] = address + take
+			_add(kind, bank, address, offset, row, commands, offset, crystal)
 		&"loadwildmon":
 			## `loadwildmon` then `startbattle` is what a static encounter IS;
 			## two bytes that merely decode as one are not.
@@ -282,9 +372,14 @@ func _record_script_site(
 		&"pokemart":
 			## `db dialog_id / dw mart_id`, so the dialog is the byte and the
 			## mart index the word behind it.
+			var mart: int = int(command.get("address", 0))
 			_add(KIND_SHOP, bank, address, offset, {
-				"mart": int(command.get("address", 0)),
+				"mart": mart,
 				"dialog": int(command.get("value", 0)),
+				## The inventory this site sells, resolved to `{item, price}` so
+				## a mod can move one row of one shop without inventing a mart.
+				## Prices are the items' own until a patch names another.
+				"items": _mart_items(mart),
 			}, commands, offset, crystal)
 		&"giveitem", &"verbosegiveitem":
 			var item: int = int(command.get("item", command.get("value", 0)))
@@ -302,6 +397,129 @@ func _record_script_site(
 			_add(KIND_BADGE, bank, address, offset, {
 				"badge": badge, "engine_flag": int(command.get("flag", 0)),
 			}, commands, offset, crystal)
+
+
+## Where a command naming [param species] sits inside the blob, or -1. Used for
+## the `pokepic` a starter's `givepoke` answers.
+static func _address_of(commands: Array, name: StringName, species: int) -> int:
+	for command: Dictionary in commands:
+		if StringName(command["name"]) == name and int(command.get("pokemon", -1)) == species:
+			return int(command["offset"])
+	return -1
+
+
+## The coin command of the BRANCH [param at] sits in, or -1. A branch is what
+## lies between two terminators, which is how the Game Corner's vendor keeps
+## three prices in one script: one `.loop` and a label per prize. Bounded that
+## way, one coin command belongs to one give site and no two sites claim it.
+static func _nearest_coin_command(
+	commands: Array, at: int, name: StringName, crystal: bool
+) -> int:
+	var bounds: Array = _branch_bounds(commands, at, crystal)
+	for command: Dictionary in commands:
+		if StringName(command["name"]) != name:
+			continue
+		var offset: int = int(command["offset"])
+		if offset >= int(bounds[0]) and offset < int(bounds[1]):
+			return offset
+	return -1
+
+
+## The offsets bounding the branch [param at] sits in: just past the terminator
+## before it, up to and including the terminator after it.
+static func _branch_bounds(commands: Array, at: int, crystal: bool) -> Array:
+	var start: int = 0
+	var end: int = 0x10000
+	for command: Dictionary in commands:
+		var offset: int = int(command["offset"])
+		if not Gen2WorldScript.is_terminal(int(command["opcode"]), crystal) \
+			and StringName(command["name"]) not in [&"sjump", &"farsjump", &"jumpstd"]:
+			continue
+		if offset < at:
+			start = offset + int(command["width"])
+		else:
+			end = offset + int(command["width"])
+			break
+	return [start, end]
+
+
+## The mart list at [param index] as `{item, price}` rows, which is the shape
+## [method Gen2WorldMartHost.entries] already reads.
+func _mart_items(index: int) -> Array:
+	var out: Array = []
+	if _data == null:
+		return out
+	var mart: Dictionary = _data.world_mart(index)
+	for raw: Variant in mart.get("items", []):
+		var item: int = int(raw) if not raw is Dictionary else int((raw as Dictionary).get("item", 0))
+		if item <= 0:
+			continue
+		out.append({"item": item, "price": int(_data.item(item).get("price", 0))})
+	return out
+
+
+## Stamps every script site with the MAP whose events reach it, which is the one
+## thing a script address does not carry and a placement cannot do without: a
+## badge is only completable if its gym can be walked to.
+##
+## Each map's own event scripts are followed through `scall`, `sjump`, `farscall`
+## and the branch commands, which is the same closure the importer walks. A
+## script two maps both reach is stamped with the first in map order, so the
+## answer is stable; a script no map reaches keeps no map at all rather than a
+## guessed one.
+func _attribute_maps() -> void:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
+	var owner: Dictionary = {}
+	## One scan per script for the whole corpus, not one per map that reaches it:
+	## the busiest scripts are reached from dozens of maps.
+	var references: Dictionary = {}
+	for map: Gen2WorldMap in _data.world_maps():
+		var bank: int = int(map.events.get("bank", 0))
+		var pending: Array = []
+		for source: String in ["objects", "bg_events", "coord_events"]:
+			for raw: Variant in map.events.get(source, []):
+				if raw is Dictionary and int((raw as Dictionary).get("script", 0)) > 0:
+					pending.append([bank, int((raw as Dictionary)["script"])])
+		var scripts: Dictionary = map.scripts
+		if int(scripts.get("address", 0)) > 0:
+			pending.append([int(scripts.get("bank", bank)), int(scripts["address"])])
+		for raw: Variant in scripts.get("callbacks", []):
+			if raw is Dictionary and int((raw as Dictionary).get("script", 0)) > 0:
+				pending.append([int(scripts.get("bank", bank)), int((raw as Dictionary)["script"])])
+		var seen: Dictionary = {}
+		for _step: int in MAX_SCRIPT_COMMANDS:
+			if pending.is_empty():
+				break
+			var entry: Array = pending.pop_back()
+			var key: int = (int(entry[0]) & 0xFF) << ID_BANK_SHIFT \
+				| (int(entry[1]) & ID_ADDRESS_MASK)
+			if seen.has(key):
+				continue
+			seen[key] = true
+			if not owner.has(key):
+				owner[key] = Vector2i(map.group, map.number)
+			if not references.has(key):
+				var body: PackedByteArray = _data.world_script(int(entry[0]), int(entry[1]))
+				references[key] = Gen2WorldScript.scan_references(
+					body, int(entry[0]), int(entry[1]), crystal
+				).get("scripts", []) if not body.is_empty() else []
+			for reference: Variant in references[key]:
+				if reference is Dictionary:
+					pending.append([
+						int((reference as Dictionary)["bank"]),
+						int((reference as Dictionary)["address"]),
+					])
+	for id: Variant in _rows:
+		var row: Dictionary = _rows[id]
+		if row.has("map") or not row.has("address"):
+			continue
+		## The site's own byte first, then the entry point its blob starts at:
+		## a site inside a routine is reached through the routine, not at it.
+		for address: int in [int(row["address"]), int(row.get("script_base", row["address"]))]:
+			var key: int = (int(row["bank"]) & 0xFF) << ID_BANK_SHIFT | (address & ID_ADDRESS_MASK)
+			if owner.has(key):
+				row["map"] = owner[key]
+				break
 
 
 ## Whether [param name] is the next few commands after [param at]. The cartridge
@@ -383,6 +601,9 @@ func _add(
 	row["kind"] = kind
 	row["bank"] = bank
 	row["address"] = address + offset
+	## The blob this site was decoded from, which is the address a map's own
+	## event points at. See [method _attribute_maps].
+	row["script_base"] = address
 	row["requires"] = _requirements(commands, at, crystal)
 	_store(row)
 
@@ -423,6 +644,12 @@ func _store(row: Dictionary) -> void:
 	if id < 0 or _rows.has(id) or not _plausible(row):
 		return
 	_rows[id] = row
+	for key: String in ["picture_address", "check_address", "take_address"]:
+		if not row.has(key):
+			continue
+		_links[(int(row["bank"]) & 0xFF) << ID_BANK_SHIFT | (int(row[key]) & ID_ADDRESS_MASK)] = {
+			"id": id, "role": &"picture" if key == "picture_address" else &"price",
+		}
 	var kind: StringName = StringName(row["kind"])
 	var list: Array = _by_kind.get(kind, [])
 	list.append(id)
@@ -436,12 +663,21 @@ func _store(row: Dictionary) -> void:
 ##
 ## Read in source order up to the site rather than over the whole script, since a
 ## `checkevent` after a `givepoke` guards something else.
-func _requirements(commands: Array, at: int, _crystal: bool) -> Array:
+func _requirements(commands: Array, at: int, crystal: bool) -> Array:
 	var out: Array = []
 	var seen: Dictionary = {}
 	for command: Dictionary in commands:
 		if int(command["offset"]) >= at:
 			break
+		## A blob holds several routines back to back, and a condition before the
+		## last `end` or `sjump` guards one of the earlier ones. Reading the whole
+		## blob put thirteen conditions on a starter, two of them badges the
+		## cartridge plainly does not ask a starter for.
+		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal) \
+			or StringName(command["name"]) in [&"sjump", &"farsjump", &"jumpstd"]:
+			out.clear()
+			seen.clear()
+			continue
 		match StringName(command["name"]):
 			&"checkevent":
 				_append_once(out, seen, {"event": int(command.get("flag", 0))})

--- a/game/data/world_progression.gd
+++ b/game/data/world_progression.gd
@@ -1,0 +1,229 @@
+class_name Gen2WorldProgression
+extends RefCounted
+
+## Whether a proposed placement can still be finished, answered by the host.
+##
+## A mod shuffling badges and key items can write a seed nobody can beat, and it
+## cannot tell on its own: the gates are the cartridge's. This walks the
+## [Gen2WorldCatalog] as a dependency graph and answers deterministically, with
+## the FIRST requirement that was never satisfiable so generation can retry
+## against a reason rather than a guess.
+##
+## What it proves is one thing, exactly: that nothing critical is locked behind
+## itself. Start with nothing in hand, take every check whose requirements are
+## met, take what those checks hand over, and repeat until no new check opens.
+## A placement passes when every critical check is inside that closure.
+##
+## What it does NOT model, and why:
+##
+## - Story EVENTS. `checkevent` guards are set by story scripts a placement does
+##   not move, so an event requirement is treated as satisfiable. A shuffle that
+##   only moves rewards cannot make one unreachable.
+##
+## - A site the catalog could not attribute to a MAP. It is taken as standing
+##   wherever the player already is, which can pass a seed a walk would not; the
+##   opposite would reject good ones.
+##
+## The gates it DOES model are the ones a placement can break: an item or badge a
+## check asks for, the badge an HM needs before its move works at all, and
+## whether the map a check stands on can be WALKED to with the field moves in
+## hand, which [Gen2WorldReachability] answers off the cartridge's own collision.
+
+## What a validation answers with when it fails: which check could not be
+## reached, and the one requirement of it that never became satisfiable.
+const REASON_UNREACHABLE: StringName = &"unreachable_check"
+const REASON_NO_CATALOG: StringName = &"missing_catalog"
+
+## How many rounds the closure may take before it is called stuck. One round per
+## check is the theoretical worst case, so this is a runaway guard rather than a
+## limit anything real reaches.
+const MAX_ROUNDS: int = 64
+
+## `Gen2WorldSpawn`'s own new-game map, which is where every walk starts.
+const START_MAP := Vector2i(Gen2WorldSpawn.NEW_BARK_GROUP, Gen2WorldSpawn.PLAYERS_HOUSE_2F)
+
+## Cache directory to the scratch cache, overlay, catalog and map graph a
+## validation runs against. See [method validate].
+static var _scratch: Dictionary = {}
+
+
+## Drops the scratch caches. For a test that rewrote a cache under the same path.
+static func reset() -> void:
+	_scratch.clear()
+
+
+## Validates [param patches], a map of catalog check id to the fields a mod
+## proposes for it, WITHOUT installing any of them: the rows are resolved through
+## an overlay of this call's own, so the shared one and the live game are
+## untouched and two validations of two seeds cannot see each other.
+##
+## Answers
+## [code]{ok, reached, critical, missing: {check, requirement, kind}}[/code].
+## Deterministic: every walk is over ids in sorted order, so one placement always
+## answers the same way.
+static func validate(data: GameData, patches: Dictionary = {}) -> Dictionary:
+	if data == null:
+		return {"ok": false, "reason": REASON_NO_CATALOG, "reached": 0, "critical": 0}
+	## The scratch cache, its catalog and its map graph are built once per
+	## cartridge and reused: a generator validates one seed after another, and
+	## decoding the whole script corpus each time is seconds an hour of retries
+	## cannot afford. Only the OVERLAY changes between calls, and rows are
+	## resolved through it at read time rather than baked in.
+	if not _scratch.has(data.directory):
+		var opened: GameData = GameData.open_directory(data.directory)
+		if opened == null:
+			return {"ok": false, "reason": REASON_NO_CATALOG, "reached": 0, "critical": 0}
+		var fresh := Gen2ContentOverlay.new()
+		opened.set_content_overlay(fresh)
+		_scratch[data.directory] = {
+			"data": opened, "overlay": fresh,
+			"catalog": opened.catalog(), "walk": Gen2WorldReachability.build(opened),
+		}
+	var held: Dictionary = _scratch[data.directory]
+	var overlay: Gen2ContentOverlay = held["overlay"]
+	overlay.clear_owner(&"progression")
+	var ids: Array = patches.keys()
+	ids.sort()
+	for id: Variant in ids:
+		overlay.patch(
+			Gen2ContentOverlay.KIND_CHECK, &"progression", int(id), patches[id]
+		)
+	return _walk(held["catalog"], held["walk"])
+
+
+## The closure itself. Split from [method validate] so a caller holding a catalog
+## it built for another reason can ask directly.
+static func _walk(catalog: Gen2WorldCatalog, walk: Gen2WorldReachability) -> Dictionary:
+	## Resolved once: the overlay does not move during a walk, and re-resolving
+	## every row every round is what made this seconds rather than milliseconds.
+	var rows: Array = catalog.rows()
+	rows.sort_custom(func(first: Dictionary, second: Dictionary) -> bool:
+		return int(first["id"]) < int(second["id"])
+	)
+	var critical: Array = []
+	for row: Dictionary in rows:
+		if catalog.is_progression(row):
+			critical.append(row)
+
+	var items: Dictionary = {}
+	var badges: Dictionary = {}
+	var reached: Dictionary = {}
+	var maps: Dictionary = {}
+	## The flood only has to be taken again when the move set actually grows.
+	var last_moves: Dictionary = {}
+	for _round: int in MAX_ROUNDS:
+		var opened: bool = false
+		var usable: Dictionary = _usable_moves(catalog, items, badges)
+		if usable != last_moves or maps.is_empty():
+			last_moves = usable
+			maps = walk.reachable(START_MAP, usable)
+		for row: Dictionary in rows:
+			var id: int = int(row["id"])
+			if reached.has(id):
+				continue
+			if not _blocker(catalog, row, items, badges, maps).is_empty():
+				continue
+			reached[id] = true
+			opened = true
+			## What the check hands over is in hand from now on.
+			if row.has("item") and int(row["item"]) > 0:
+				items[int(row["item"])] = true
+			if StringName(row["kind"]) == Gen2WorldCatalog.KIND_BADGE:
+				badges[int(row["badge"])] = true
+		if not opened:
+			break
+
+	for row: Dictionary in critical:
+		if reached.has(int(row["id"])):
+			continue
+		var blocker: Dictionary = _blocker(catalog, row, items, badges, maps)
+		return {
+			"ok": false,
+			"reason": REASON_UNREACHABLE,
+			"reached": reached.size(),
+			"critical": critical.size(),
+			"missing": {
+				"check": int(row["id"]),
+				"kind": StringName(row["kind"]),
+				"requirement": blocker,
+			},
+		}
+	return {
+		"ok": true, "reached": reached.size(), "critical": critical.size(),
+		"missing": {},
+	}
+
+
+## The field moves the player can actually USE: an HM in the bag whose badge is
+## also in hand. A move with no badge gate needs the HM alone.
+static func _usable_moves(
+	catalog: Gen2WorldCatalog, items: Dictionary, badges: Dictionary
+) -> Dictionary:
+	var out: Dictionary = {}
+	for item: Variant in items:
+		var move: int = catalog.move_for_hm_item(int(item))
+		if move <= 0:
+			continue
+		var badge: int = Gen2WorldFieldMove.badge_for_move(move)
+		if badge < 0 or badges.has(badge):
+			out[move] = true
+	return out
+
+
+## The first thing standing between the player and [param row], or empty when
+## nothing is. Walking there is asked first, since it is the gate a placement
+## breaks most often.
+static func _blocker(
+	catalog: Gen2WorldCatalog, row: Dictionary, items: Dictionary, badges: Dictionary,
+	maps: Dictionary
+) -> Dictionary:
+	if row.has("map"):
+		var key: int = Gen2WorldReachability.map_key(
+			int((row["map"] as Vector2i).x), int((row["map"] as Vector2i).y)
+		)
+		if not maps.has(key):
+			return {"map": row["map"]}
+	return _satisfied(catalog, row, items, badges)
+
+
+## The first requirement of [param row] that is not met, or empty when all are.
+##
+## An `event` requirement is not one of them: see the class comment. An `item`
+## requirement that is an HM brings its badge with it, which is the gate that
+## makes a placement circular rather than merely late.
+static func _satisfied(
+	catalog: Gen2WorldCatalog, row: Dictionary, items: Dictionary, badges: Dictionary
+) -> Dictionary:
+	for requirement: Variant in row.get("requires", []):
+		if not requirement is Dictionary:
+			continue
+		var entry: Dictionary = requirement as Dictionary
+		if entry.has("item"):
+			var item: int = int(entry["item"])
+			if not items.has(item) and _is_placed(catalog, item):
+				return {"item": item}
+			var badge: int = _badge_for_item(catalog, item)
+			if badge >= 0 and not badges.has(badge):
+				return {"badge": badge, "for_item": item}
+		elif entry.has("engine_flag"):
+			## A gym script opens with `checkflag` of the badge it is about to
+			## grant, which is its own "have I been done already" test rather
+			## than a gate. Reading it as one makes every badge require itself.
+			if int(entry["engine_flag"]) == int(row.get("engine_flag", -1)):
+				continue
+			var flag_badge: int = catalog.badge_for_engine_flag(int(entry["engine_flag"]))
+			if flag_badge >= 0 and not badges.has(flag_badge):
+				return {"badge": flag_badge}
+	return {}
+
+
+## Whether [param item] is something a check hands over at all. An item no check
+## carries is bought, found in a mart or given by a story script a placement did
+## not move, so asking for it gates nothing.
+static func _is_placed(catalog: Gen2WorldCatalog, item: int) -> bool:
+	return catalog.item_sources().has(item)
+
+
+## The badge an HM's own move needs, or -1 for anything else.
+static func _badge_for_item(catalog: Gen2WorldCatalog, item: int) -> int:
+	return catalog.badge_for_hm_item(item)

--- a/game/data/world_progression.gd.uid
+++ b/game/data/world_progression.gd.uid
@@ -1,0 +1,1 @@
+uid://de7346f7oflxp

--- a/game/data/world_reachability.gd
+++ b/game/data/world_reachability.gd
@@ -1,0 +1,237 @@
+class_name Gen2WorldReachability
+extends RefCounted
+
+## Which maps a player can stand on with a given set of field moves, derived from
+## the cartridge's own collision, warps and connections.
+##
+## The half of a progression proof that is not about rewards. A shuffled badge is
+## only completable if the gym holding it can be WALKED to, and walking is gated
+## by Surf, Cut, Strength, Whirlpool and Waterfall, each of which is gated by a
+## badge. Nothing here is written down: the flood asks
+## [Gen2WorldCollision] and [Gen2WorldFieldMove] the same questions
+## `DoPlayerMovement` asks.
+##
+## The unit is the MAP, not the cell. A cell-exact frontier would be the truer
+## model and is not the one to build: it would need the block-level surf rules,
+## the ledge one-way tests and the forced-tile paths as a second copy of
+## `Gen2WorldAPI`'s, and the two would drift. A map is reachable here when some
+## walkable cell of it is, which is the granularity a placement is decided at
+## anyway, since a check sits on a map.
+##
+## Deliberately CONSERVATIVE in one direction only: an edge is offered when the
+## cartridge's own collision says a step across it is possible, so this can call
+## a map reachable that a cell-exact walk would not. It never calls a reachable
+## map unreachable, which is the direction that would reject a good seed.
+
+## The moves an edge can ask for, in the order a report lists them.
+const GATE_MOVES: Array[int] = [
+	Gen2WorldFieldMove.MOVE_SURF,
+	Gen2WorldFieldMove.MOVE_CUT,
+	Gen2WorldFieldMove.MOVE_WHIRLPOOL,
+	Gen2WorldFieldMove.MOVE_WATERFALL,
+]
+
+## Guard on the flood, not a limit anything real reaches: Crystal has 388 maps.
+const MAX_MAPS: int = 1024
+
+var _data: GameData = null
+## Move-set key to the exit graph that move set opens: map key to the map keys
+## its usable exits lead to. See [method _edges_for].
+var _edges: Dictionary = {}
+
+
+static func build(data: GameData) -> Gen2WorldReachability:
+	var out := Gen2WorldReachability.new()
+	out._data = data
+	return out
+
+
+static func map_key(group: int, number: int) -> int:
+	return (group & 0xFF) << 8 | (number & 0xFF)
+
+
+## Every map reachable from [param start] with [param moves] in hand, as a set of
+## [method map_key]s. The moves are the field moves the player can actually USE,
+## which is the caller's job to work out: an HM without its badge is not one.
+func reachable(start: Vector2i, moves: Dictionary) -> Dictionary:
+	if _data == null:
+		return {}
+	var edges: Dictionary = _edges_for(moves)
+	var out: Dictionary = {}
+	var frontier: Array = [map_key(start.x, start.y)]
+	out[frontier[0]] = true
+	for _step: int in MAX_MAPS:
+		if frontier.is_empty():
+			break
+		var next: Array = []
+		for key: int in frontier:
+			for target: int in edges.get(key, []):
+				if out.has(target):
+					continue
+				out[target] = true
+				next.append(target)
+		frontier = next
+	return out
+
+
+## The fewest moves that make [param to_key] reachable from the start, or an
+## empty array when it already is. What a report names when a placement puts
+## something behind a move the seed cannot reach.
+func gates_for(start: Vector2i, to_key: int) -> Array:
+	if reachable(start, {}).has(to_key):
+		return []
+	for count: int in GATE_MOVES.size():
+		for mask: int in 1 << GATE_MOVES.size():
+			var moves: Dictionary = {}
+			for index: int in GATE_MOVES.size():
+				if (mask & (1 << index)) != 0:
+					moves[GATE_MOVES[index]] = true
+			if moves.size() != count + 1:
+				continue
+			if reachable(start, moves).has(to_key):
+				return moves.keys()
+	return GATE_MOVES.duplicate()
+
+
+func map_count() -> int:
+	return _data.world_maps().size() if _data != null else 0
+
+
+## One pass over every map: which of its exits are usable with which moves,
+## worked out by FLOODING the map's own collision grid from the cells a player
+## arrives on. An exit the flood cannot touch without Surf is a Surf exit.
+##
+## Taken once per move set rather than once, because the flood is what the moves
+## change: with Cut in hand a tree stops being a wall and a whole wing of a map
+## opens. [method reachable] asks for the set it needs and the answer is kept.
+func _edges_for(moves: Dictionary) -> Dictionary:
+	var key: int = _moves_key(moves)
+	if _edges.has(key):
+		return _edges[key]
+	var out: Dictionary = {}
+	for map: Gen2WorldMap in _data.world_maps():
+		var tileset: Gen2WorldTileset = _data.world_tileset(map.tileset)
+		if tileset == null:
+			continue
+		var world := Gen2WorldAPI.new(
+			_data, map, tileset, Vector2i.ZERO, Gen2WorldState.new()
+		)
+		out[map_key(map.group, map.number)] = _exits(world, map, moves)
+	_edges[key] = out
+	return out
+
+
+## The maps one map's usable exits lead to. An exit is usable when it stands in
+## the same flooded region as some cell a player can arrive on.
+func _exits(world: Gen2WorldAPI, map: Gen2WorldMap, moves: Dictionary) -> Array:
+	var region: Dictionary = _flood(world, map, moves)
+	var out: Array = []
+	var seen: Dictionary = {}
+	for raw: Variant in map.events.get("warps", []):
+		if not raw is Dictionary:
+			continue
+		var warp: Dictionary = raw as Dictionary
+		if not region.has(_cell_key(int(warp.get("x", 0)), int(warp.get("y", 0)))):
+			continue
+		var target: int = map_key(
+			int(warp.get("map_group", 0)), int(warp.get("map_number", 0))
+		)
+		if not seen.has(target):
+			seen[target] = true
+			out.append(target)
+	for raw: Variant in map.connections:
+		if not raw is Dictionary:
+			continue
+		var connection: Dictionary = raw as Dictionary
+		if not _edge_reached(region, map, String(connection.get("direction", ""))):
+			continue
+		var target: int = map_key(
+			int(connection.get("map_group", 0)), int(connection.get("map_number", 0))
+		)
+		if not seen.has(target):
+			seen[target] = true
+			out.append(target)
+	return out
+
+
+## Every cell a player standing anywhere on the map could get to, as a set. The
+## seeds are every warp cell and every edge cell, since a player arrives through
+## one of those; a region no seed touches is not part of the map for this.
+func _flood(world: Gen2WorldAPI, map: Gen2WorldMap, moves: Dictionary) -> Dictionary:
+	var region: Dictionary = {}
+	var frontier: Array = []
+	for raw: Variant in map.events.get("warps", []):
+		if raw is Dictionary:
+			_seed(world, map, moves, region, frontier,
+				Vector2i(int((raw as Dictionary).get("x", 0)), int((raw as Dictionary).get("y", 0))))
+	for x: int in map.collision_width:
+		_seed(world, map, moves, region, frontier, Vector2i(x, 0))
+		_seed(world, map, moves, region, frontier, Vector2i(x, map.collision_height - 1))
+	for y: int in map.collision_height:
+		_seed(world, map, moves, region, frontier, Vector2i(0, y))
+		_seed(world, map, moves, region, frontier, Vector2i(map.collision_width - 1, y))
+	while not frontier.is_empty():
+		var cell: Vector2i = frontier.pop_back()
+		for step: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+			_seed(world, map, moves, region, frontier, cell + step)
+	return region
+
+
+func _seed(
+	world: Gen2WorldAPI, map: Gen2WorldMap, moves: Dictionary, region: Dictionary,
+	frontier: Array, cell: Vector2i
+) -> void:
+	if cell.x < 0 or cell.y < 0 or cell.x >= map.collision_width \
+		or cell.y >= map.collision_height:
+		return
+	var key: int = _cell_key(cell.x, cell.y)
+	if region.has(key) or not _standable(world.collision_code_at(cell), moves):
+		return
+	region[key] = true
+	frontier.append(cell)
+
+
+## Whether a player with [param moves] can be on a cell of this code. The four
+## water gates are the cartridge's own tile tests; everything else is the
+## permission byte, which is what makes a wall a wall.
+static func _standable(code: int, moves: Dictionary) -> bool:
+	match Gen2WorldCollision.permission_for(code):
+		Gen2WorldCollision.LAND_TILE:
+			return true
+		Gen2WorldCollision.WATER_TILE:
+			if Gen2WorldFieldMove.waterfall_tile(code):
+				return moves.has(Gen2WorldFieldMove.MOVE_WATERFALL)
+			if Gen2WorldFieldMove.whirlpool_tile(code):
+				return moves.has(Gen2WorldFieldMove.MOVE_WHIRLPOOL)
+			return moves.has(Gen2WorldFieldMove.MOVE_SURF)
+	## A cut tree is not walkable until it is cut, and then it is ordinary ground.
+	return Gen2WorldFieldMove.cuttable(code) and moves.has(Gen2WorldFieldMove.MOVE_CUT)
+
+
+## Whether the flood touched the side a connection leaves by.
+static func _edge_reached(region: Dictionary, map: Gen2WorldMap, direction: String) -> bool:
+	match direction:
+		"north", "south":
+			var y: int = 0 if direction == "north" else map.collision_height - 1
+			for x: int in map.collision_width:
+				if region.has(_cell_key(x, y)):
+					return true
+		"west", "east":
+			var x: int = 0 if direction == "west" else map.collision_width - 1
+			for y: int in map.collision_height:
+				if region.has(_cell_key(x, y)):
+					return true
+	return false
+
+
+static func _cell_key(x: int, y: int) -> int:
+	return (x & 0xFF) << 8 | (y & 0xFF)
+
+
+## A move set as one number, so a flood taken for it can be found again.
+static func _moves_key(moves: Dictionary) -> int:
+	var key: int = 0
+	for index: int in GATE_MOVES.size():
+		if moves.has(GATE_MOVES[index]):
+			key |= 1 << index
+	return key

--- a/game/data/world_reachability.gd.uid
+++ b/game/data/world_reachability.gd.uid
@@ -1,0 +1,1 @@
+uid://cr1iakgfabwhv

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -956,6 +956,19 @@ func patch_check(id: StringName, check_id: int, fields: Dictionary) -> Dictionar
 	)
 
 
+## Whether [param patches] leaves the game finishable, WITHOUT installing any of
+## them. [param patches] is catalog check id to the fields a mod proposes, which
+## is the same shape [method patch_check] takes one row at a time.
+##
+## Answers `{ok, reached, critical, missing}`, and on a failure `missing` names
+## the check that could not be reached and the one requirement of it that never
+## became satisfiable, so a generator retries against a reason. Deterministic:
+## one placement always answers the same way. See [Gen2WorldProgression] for what
+## the proof does and does not cover.
+func validate_placement(data: GameData, patches: Dictionary) -> Dictionary:
+	return Gen2WorldProgression.validate(data, patches)
+
+
 ## The overlay every opened [GameData] reads through, for a launcher listing what
 ## a mod changed before the player starts.
 func content_overlay() -> Gen2ContentOverlay:

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -57,6 +57,27 @@ const MUSIC_SURF: int = 0x21
 ## `BikeFunction` writes this to `wMapMusic`, so it survives a map load.
 const MUSIC_BICYCLE: int = 0x13
 
+## Which badge each gated field move asks `CheckBadge` for, as the badge-order
+## index the constants above are. A move that is not here has no badge gate:
+## Headbutt, Rock Smash, Dig, Teleport, Sweet Scent and the two heals.
+const MOVE_BADGES: Dictionary = {
+	MOVE_CUT: BADGE_HIVE,
+	MOVE_SURF: BADGE_FOG,
+	MOVE_STRENGTH: BADGE_PLAIN,
+	MOVE_WHIRLPOOL: BADGE_GLACIER,
+	MOVE_WATERFALL: BADGE_RISING,
+	MOVE_FLASH: BADGE_ZEPHYR,
+	MOVE_FLY: BADGE_STORM,
+}
+
+
+## The badge [param move] needs before the overworld will run it, or -1. The one
+## fact a placement has to respect: an HM in the bag is not a way past anything
+## until its badge is in hand.
+static func badge_for_move(move: int) -> int:
+	return int(MOVE_BADGES.get(move, -1))
+
+
 ## data/mon_menu.asm's MonMenuOptions rows, identical between the pins and the
 ## whole of IsFieldMove's submenu membership.
 const FIELD_MOVES: Array[int] = [

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -158,12 +158,17 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 					"ok": false,
 					"reason": StringName(mart_result.get("reason", &"mart_data_unavailable")),
 				}
+			var mart: Dictionary = mart_result["mart"]
+			## A catalog site may sell its own shelf. `{item, price}` is the shape
+			## `Gen2WorldMartHost.entries` already reads, so a patched price is
+			## the price the counter charges and nothing else changes.
+			if values.has("items") and values["items"] is Array \
+				and not (values["items"] as Array).is_empty():
+				mart = mart.duplicate(true)
+				mart["items"] = (values["items"] as Array).duplicate(true)
 			return {
 				"ok": true,
-				"data": {
-					"mart": mart_result["mart"], "mart_id": mart_id,
-					"dialog": dialog_id,
-				},
+				"data": {"mart": mart, "mart_id": mart_id, "dialog": dialog_id},
 			}
 		&"apricorn_selection_requested":
 			## `FindApricornsInBag` is the whole of the request's data: an empty

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -553,6 +553,16 @@ static func _apply_party_request(
 		var trade: Dictionary = world.data.world_trade(trade_id)
 		if trade.is_empty():
 			return {"ok": false, "reason": &"unknown_trade", "trade_id": trade_id}
+		## A visible-catalog site may name its own two halves. Applied to this
+		## call's COPY of the record: one cartridge trade row is named by more
+		## than one site, and writing the row would move the other one too. The
+		## nickname, OT, item and DVs stay the record's, since they belong to the
+		## Pokemon the cartridge wrote rather than to the species.
+		for half: Array in [
+			["offered_species", "offered_species"], ["requested_species", "requested_species"],
+		]:
+			if values.has(half[0]) and int(values[half[0]]) > 0:
+				trade[half[1]] = int(values[half[0]])
 		var requested_index: int = int(result.get("party_index", -1))
 		if requested_index < 0 or requested_index >= candidate.party.size():
 			requested_index = _find_trade_candidate(world.data, candidate, trade)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1306,6 +1306,11 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE,
 		Gen2WorldScript.CLOSEWINDOW,
 		Gen2WorldScript.LOADMENU,
+		## Both comparisons answer through `_script_value` and stage nothing, so
+		## they never returned from their own branch and fell through to the
+		## refusal below. Every `checkcoins` in either game is a Game Corner or a
+		## Buena prize counter, and every one of them stopped its script here.
+		Gen2WorldScript.CHECKMONEY, Gen2WorldScript.CHECKCOINS,
 		Gen2WorldScript.GETMONEY, Gen2WorldScript.GETCOINS, Gen2WorldScript.GETNUM,
 		Gen2WorldScript.GETMONNAME, Gen2WorldScript.GETITEMNAME,
 		Gen2WorldScript.GETCURLANDMARKNAME, Gen2WorldScript.GETTRAINERNAME,
@@ -1330,6 +1335,11 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 func _catalogued(command: Dictionary, frame: Dictionary) -> Dictionary:
 	if data == null or not data.has_content_overlay():
 		return command
+	var linked: Dictionary = data.catalog().link_at(
+		int(frame["bank"]), int(frame["address"]) + int(command["offset"])
+	)
+	if not linked.is_empty():
+		return _linked_command(command, linked)
 	var candidates: Array = CATALOG_KINDS.get(StringName(command["name"]), [])
 	if candidates.is_empty():
 		return command
@@ -1350,10 +1360,17 @@ func _catalogued(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldCatalog.KIND_STATIC:
 			out["pokemon"] = int(row["species"])
 			out["level"] = int(row["level"])
-		Gen2WorldCatalog.KIND_TRADE:
-			out["value"] = int(row["trade"])
 		Gen2WorldCatalog.KIND_SHOP:
 			out["address"] = int(row["mart"])
+			## The inventory this site sells, carried to the mart host so a
+			## patched shelf reaches the shop rather than a different mart id.
+			out["mart_items"] = row.get("items", [])
+		Gen2WorldCatalog.KIND_TRADE:
+			out["value"] = int(row["trade"])
+			## Both halves, carried beside the record rather than written into
+			## it: one cartridge trade row can be named by two sites.
+			out["offered_species"] = int(row["species"])
+			out["requested_species"] = int(row["requested_species"])
 		Gen2WorldCatalog.KIND_BADGE:
 			## The badge a flag grants IS the flag, so moving one moves which
 			## bit the site sets. An index outside the list leaves it alone.
@@ -1375,6 +1392,23 @@ func _catalogued(command: Dictionary, frame: Dictionary) -> Dictionary:
 			out["level"] = int(row["level"])
 			out["value_2"] = int(row["level"])
 			out["item"] = int(row.get("item", command.get("item", 0)))
+	return out
+
+
+## A command that is not the site itself but carries one of its numbers: the
+## `pokepic` a starter's ball shows, and the `checkcoins`/`takecoins` a prize
+## charges with. Substituting only the `givepoke` would show one Pokemon and hand
+## over another, and price a prize the player could not afford.
+func _linked_command(command: Dictionary, linked: Dictionary) -> Dictionary:
+	var row: Dictionary = data.catalog().check(int(linked["id"]))
+	if row.is_empty():
+		return command
+	var out: Dictionary = command.duplicate(true)
+	match StringName(linked["role"]):
+		&"picture":
+			out["pokemon"] = int(row["species"])
+		&"price":
+			out["value"] = int(row["price"])
 	return out
 
 
@@ -1649,18 +1683,25 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 			## player and then relies on this to drop them through it.
 			_emit_runtime_event(&"warp_check_requested", {})
 		0x93:
-			return _stage_runtime_request(&"mart_requested", {
+			var mart: Dictionary = {
 				"dialog": int(command.get("value", 0)),
 				"address": int(command.get("address", 0)),
-			})
+			}
+			if command.has("mart_items"):
+				mart["items"] = command["mart_items"]
+			return _stage_runtime_request(&"mart_requested", mart)
 		0x94:
 			return _stage_runtime_request(&"elevator_requested", {
 				"address": int(command.get("address", 0)),
 			})
 		0x95:
-			return _stage_runtime_request(&"trade_requested", {
-				"trade_id": int(command.get("value", 0)),
-			})
+			var trade: Dictionary = {"trade_id": int(command.get("value", 0))}
+			## A patched site names both halves; an unpatched one names neither
+			## and the record answers for both, as it always has.
+			for key: String in ["offered_species", "requested_species"]:
+				if command.has(key):
+					trade[key] = int(command[key])
+			return _stage_runtime_request(&"trade_requested", trade)
 		0x96:
 			return _stage_phone_choice(int(command.get("value", 0)))
 		0x97:

--- a/tests/unit/test_content_overlay.gd
+++ b/tests/unit/test_content_overlay.gd
@@ -362,3 +362,17 @@ func test_a_catalog_id_names_a_kind_a_bank_and_an_address() -> void:
 		"the kind is part of the id"
 	)
 	assert_eq(Gen2WorldCatalog.pack_id(&"not_a_kind", 1, 1), -1)
+
+
+## The validator is what a mod asks before it installs a placement, and it must
+## install nothing itself: two calls in a row see the same world.
+func test_validating_a_placement_installs_nothing() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var id: int = Gen2WorldCatalog.pack_id(Gen2WorldCatalog.KIND_STATIC, 48, 0x6E00)
+	var first: Dictionary = host.validate_placement(_data(), {id: {"species": 25}})
+	assert_true(first.has("ok"))
+	assert_true(Gen2ContentOverlay.shared().is_empty(), "nothing was installed")
+	assert_eq(
+		host.validate_placement(_data(), {id: {"species": 25}}), first,
+		"and one placement always answers the same way"
+	)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6563,3 +6563,182 @@ func test_an_unpatched_catalogue_hands_over_the_cartridges_own_numbers() -> void
 	var request: Dictionary = waiting[0]["event"]["request"]
 	assert_eq(int(request["values"]["pokemon"]), 109)
 	assert_eq(int(request["values"]["level"]), 21)
+
+
+## A starter's species drives the BALL as well as the gift: patching the
+## `givepoke` alone would show one Pokemon and hand over another.
+func test_a_patched_starter_shows_and_gives_the_same_pokemon() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	## `pokepic CYNDAQUIL` then `givepoke CYNDAQUIL, 5, BERRY`, which is the one
+	## shape Elm's three balls take.
+	scripts["48:6F00"] = [
+		0x56, 155,
+		Gen2WorldScript.GIVEPOKE, 155, 5, 0, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open_directory(_directory)
+	data.set_content_overlay(overlay)
+	var catalog: Gen2WorldCatalog = data.catalog()
+	var starters: Array = catalog.rows(Gen2WorldCatalog.KIND_STARTER)
+	assert_eq(starters.size(), 1, JSON.stringify(starters))
+	assert_eq(int(starters[0]["picture_address"]), 0x6F00, "the ball's own pokepic")
+
+	overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"mod", int(starters[0]["id"]), {
+		"species": 25, "level": 9,
+	})
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(8, 6),
+		Gen2WorldState.new({}, {}, {Gen2WorldInventory.ITEM_OLD_ROD: 1})
+	)
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 8, "y": 6, "script": 0x6F00,
+	}]
+	var results: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var pictured: int = -1
+	for event: Dictionary in results[0]["events"]:
+		if StringName(event.get("type", &"")) == &"pokemon_picture_requested":
+			pictured = int(event["pokemon"])
+	assert_eq(pictured, 25, "the ball shows the patch")
+	var request: Dictionary = results[0]["event"]["request"]
+	assert_eq(int(request["values"]["pokemon"]), 25, "and hands the same one over")
+	assert_eq(int(request["values"]["level"]), 9)
+	## What the ball carries is the cartridge's and is not a species patch.
+	assert_eq(int(request["values"]["item"]), 0)
+
+
+## A prize's price is its affordability branch and its deduction, one linked
+## transaction. Patching the Pokemon alone would sell a Mewtwo for 100 coins.
+func test_a_patched_prize_checks_and_charges_the_patched_price() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	## The Game Corner vendor's own shape: `checkcoins`, a branch on HAVE_LESS,
+	## then the give and the charge.
+	scripts["48:6F40"] = [
+		Gen2WorldScript.CHECKCOINS, 100, 0,
+		Gen2WorldScript.IFEQUAL, 0, 0x60, 0x6F,
+		Gen2WorldScript.GIVEPOKE, 63, 5, 0, 0,
+		Gen2WorldScript.TAKECOINS, 100, 0,
+		Gen2WorldScript.END,
+	]
+	## `.NotEnoughCoins`: sets a flag and stops, so the refusal is observable.
+	scripts["48:6F60"] = [Gen2WorldScript.SETEVENT, 12, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open_directory(_directory)
+	data.set_content_overlay(overlay)
+	var catalog: Gen2WorldCatalog = data.catalog()
+	var prizes: Array = catalog.rows(Gen2WorldCatalog.KIND_PRIZE)
+	assert_eq(prizes.size(), 1, JSON.stringify(prizes))
+	assert_eq(int(prizes[0]["price"]), 100)
+	assert_eq(int(prizes[0]["check_address"]), 0x6F40, "the affordability branch")
+	assert_eq(int(prizes[0]["take_address"]), 0x6F4C, "and the deduction")
+
+	overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"mod", int(prizes[0]["id"]), {
+		"species": 150, "price": 9000,
+	})
+
+	## One coin short of the PATCHED price takes the refusal branch, though the
+	## cartridge's own 100 is long since covered.
+	var short: Gen2WorldAPI = _coin_world(data, 8999)
+	var short_results: Array = _run_script(short, short.dispatch_script_events(Vector2i(8, 6)))
+	assert_eq(_final_status(short_results), &"complete", JSON.stringify(short_results))
+	assert_true(short.state.is_event_flag_active(12), "refused below the patched price")
+	assert_eq(short.state.coins(), 8999, "and nothing was charged")
+
+	var rich: Gen2WorldAPI = _coin_world(data, 9000)
+	var paid: Array = rich.dispatch_script_events(Vector2i(8, 6))
+	var request: Dictionary = paid[0]["event"]["request"]
+	assert_eq(int(request["values"]["pokemon"]), 150, "the patched prize")
+	var after: Array = rich.complete_runtime_request({"ok": true, "accepted": true})
+	assert_eq(_final_status(after), &"complete", JSON.stringify(after))
+	assert_false(rich.state.is_event_flag_active(12))
+	assert_eq(rich.state.coins(), 0, "and the patched price was charged")
+
+
+func _coin_world(data: GameData, coins: int) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new(
+		{}, {}, {Gen2WorldInventory.ITEM_OLD_ROD: 1}, {}, coins
+	)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6), state)
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 8, "y": 6, "script": 0x6F40,
+	}]
+	return world
+
+
+## A shop sells the shelf its own site names, at that site's prices. Two shops on
+## one mart list can differ without either inventing a mart.
+func test_a_patched_shop_sells_its_own_shelf_at_its_own_prices() -> void:
+	_write_service_cache()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	## `pokemart MARTTYPE_STANDARD, 0`.
+	scripts["48:6F80"] = [0x94, 0, 0, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open_directory(_directory)
+	data.set_content_overlay(overlay)
+	var shops: Array = data.catalog().rows(Gen2WorldCatalog.KIND_SHOP)
+	assert_eq(shops.size(), 1, JSON.stringify(shops))
+	assert_eq(shops[0]["items"], [{"item": 7, "price": 0}], "the mart's own shelf")
+
+	overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"mod", int(shops[0]["id"]), {
+		"items": [{"item": 3, "price": 4242}],
+	})
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(8, 6),
+		Gen2WorldState.new({}, {}, {Gen2WorldInventory.ITEM_OLD_ROD: 1})
+	)
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 8, "y": 6, "script": 0x6F80,
+	}]
+	var waiting: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var request: Dictionary = waiting[0]["event"]["request"]
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(world, request)
+	assert_true(bool(resolved.get("ok", false)), JSON.stringify(resolved))
+	var entries: Array = Gen2WorldMartHost.entries(
+		data, resolved["data"]["mart"]
+	)
+	assert_eq(entries.size(), 1)
+	assert_eq(int(entries[0]["item"]), 3, "the patched shelf")
+	assert_eq(int(entries[0]["price"]), 4242, "at the patched price")
+
+
+## Both halves of a trade take the patch, and the cartridge record they came from
+## is left alone for whatever other site names it.
+func test_a_patched_trade_uses_both_halves_without_moving_the_record() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	## `trade 0`.
+	scripts["48:6FA0"] = [0x96, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	RomCache.write_json(RomCache.world_trades_path(_directory), [{
+		"trade_id": 0, "dialog": 0, "requested_species": 16, "offered_species": 19,
+		"nickname": "SWAPPY", "ot_name": "MIKE", "ot_id": 1234, "dvs": 0,
+		"item": 0, "gender": RomLayout.TRADE_GENDER_EITHER,
+	}])
+	var overlay := Gen2ContentOverlay.new()
+	var data: GameData = GameData.open_directory(_directory)
+	data.set_content_overlay(overlay)
+	var trades: Array = data.catalog().rows(Gen2WorldCatalog.KIND_TRADE)
+	assert_eq(trades.size(), 1, JSON.stringify(trades))
+	assert_eq(int(trades[0]["species"]), 19)
+	assert_eq(int(trades[0]["requested_species"]), 16)
+
+	overlay.patch(Gen2ContentOverlay.KIND_CHECK, &"mod", int(trades[0]["id"]), {
+		"species": 25, "requested_species": 1,
+	})
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(8, 6),
+		Gen2WorldState.new({}, {}, {Gen2WorldInventory.ITEM_OLD_ROD: 1})
+	)
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 8, "y": 6, "script": 0x6FA0,
+	}]
+	var waiting: Array = world.dispatch_script_events(Vector2i(8, 6))
+	var values: Dictionary = waiting[0]["event"]["request"]["values"]
+	assert_eq(int(values["offered_species"]), 25, "what the trade hands over")
+	assert_eq(int(values["requested_species"]), 1, "and what it asks for")
+	assert_eq(int(values["trade_id"]), 0, "still the cartridge's own record")
+	## The record itself is untouched, so a second site naming it is unaffected.
+	assert_eq(int(data.world_trade(0)["offered_species"]), 19)
+	assert_eq(int(data.world_trade(0)["requested_species"]), 16)

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -72,6 +72,8 @@ func run(r: RefCounted) -> void:
 		_verify_badges(catalog)
 		_verify_ids(catalog)
 		_verify_patching(catalog)
+		_verify_links(catalog)
+		_verify_progression(catalog)
 	)
 
 
@@ -178,6 +180,101 @@ func _verify_ids(catalog: Gen2WorldCatalog) -> void:
 			_r.check(false, "id %d does not recompute from its own address." % id)
 			return
 	_r.note("%d ids, each naming one site." % seen.size())
+
+
+## The four fields whose effect is not at the command the site is: a starter's
+## picture, and a prize's two coin commands. A patch that reached the `givepoke`
+## alone would show one Pokemon and hand over another.
+func _verify_links(catalog: Gen2WorldCatalog) -> void:
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_STARTER):
+		_r.check(
+			row.has("picture_address"),
+			"a starter has no linked pokepic, so its ball would show the old one."
+		)
+		if not row.has("picture_address"):
+			return
+		var linked: Dictionary = catalog.link_at(
+			int(row["bank"]), int(row["picture_address"])
+		)
+		_r.check(
+			int(linked.get("id", -1)) == int(row["id"])
+				and StringName(linked.get("role", &"")) == &"picture",
+			"a starter's pokepic does not link back to it."
+		)
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_PRIZE):
+		for key: String in ["check_address", "take_address"]:
+			_r.check(row.has(key), "a prize has no linked %s." % key)
+			if not row.has(key):
+				return
+			var linked: Dictionary = catalog.link_at(int(row["bank"]), int(row[key]))
+			_r.check(
+				int(linked.get("id", -1)) == int(row["id"])
+					and StringName(linked.get("role", &"")) == &"price",
+				"a prize's %s does not link back to it." % key
+			)
+	var shops: Array = catalog.rows(Gen2WorldCatalog.KIND_SHOP)
+	var stocked: int = 0
+	for row: Dictionary in shops:
+		if not (row.get("items", []) as Array).is_empty():
+			stocked += 1
+	_r.check(stocked > 0, "no shop site carries an inventory.")
+	_r.note("%d of %d shop sites carry their own shelf." % [stocked, shops.size()])
+
+
+## The cartridge's own placement finishes, and one that hides Surf behind Surf
+## does not. The second is the whole reason the validator exists.
+func _verify_progression(catalog: Gen2WorldCatalog) -> void:
+	var data: GameData = GameData.open(_r.game_id)
+	if data == null:
+		return
+	var vanilla: Dictionary = Gen2WorldProgression.validate(data, {})
+	_r.check(
+		bool(vanilla["ok"]),
+		"the cartridge's own placement does not validate: %s." % str(vanilla.get("missing", {}))
+	)
+	_r.note("progression: %d checks reached, %d of them critical." % [
+		int(vanilla["reached"]), int(vanilla["critical"]),
+	])
+
+	var surf_item: int = 0
+	for item: int in catalog.field_hm_items():
+		if catalog.move_for_hm_item(item) == Gen2WorldFieldMove.MOVE_SURF:
+			surf_item = item
+	var walk: Gen2WorldReachability = Gen2WorldReachability.build(data)
+	var dry: Dictionary = walk.reachable(Gen2WorldProgression.START_MAP, {})
+	var behind: int = -1
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_ITEM):
+		if not row.has("map"):
+			continue
+		var key: int = Gen2WorldReachability.map_key(
+			int((row["map"] as Vector2i).x), int((row["map"] as Vector2i).y)
+		)
+		if not dry.has(key):
+			behind = int(row["id"])
+			break
+	if behind < 0 or surf_item <= 0:
+		_r.check(false, "no site behind Surf to build a self-locking placement from.")
+		return
+	## Surf on a shore only Surf reaches, and nowhere else.
+	var patches: Dictionary = {behind: {"item": surf_item}}
+	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_ITEM):
+		if int(row["item"]) == surf_item and int(row["id"]) != behind:
+			patches[int(row["id"])] = {"item": RomLayout.ITEM_TM01}
+	var locked: Dictionary = Gen2WorldProgression.validate(data, patches)
+	_r.check(not bool(locked["ok"]), "a placement hiding Surf behind Surf validated.")
+	_r.check(
+		not (locked.get("missing", {}) as Dictionary).is_empty(),
+		"a rejected placement named no unreachable requirement."
+	)
+	## And it is the same answer twice, which is what lets a generator retry.
+	_r.check(
+		Gen2WorldProgression.validate(data, patches) == locked,
+		"two validations of one placement disagreed."
+	)
+	_r.check(
+		bool(Gen2WorldProgression.validate(data, {})["ok"]),
+		"a rejected placement was left installed."
+	)
 
 
 ## The whole point of the catalog: a patch has to reach the row a runtime reader


### PR DESCRIPTION
R20 left four catalog fields reaching one command of their transaction instead of all of it, and gave a mod no way to know a shuffle was beatable. Both are closed.

## Fields effective at their transaction

The host links the commands a site's numbers also drive, keyed by the byte a command sits at — the same address space the site ids already use, so the runner finds them from its own frame.

| Patch | Also drives |
|---|---|
| a starter's `species` | the `pokepic` its ball shows, so the picture and the Pokemon cannot disagree |
| a prize's `price` | its `checkcoins` affordability branch **and** its `takecoins` deduction, as one transaction |
| a trade's `species` / `requested_species` | both halves, carried beside the cartridge record rather than written into it, so a second site naming that record is unaffected |
| a shop's `items` | the shelf the counter sells, as `{item, price}` rows |

The script is still the cartridge's: its completion flag, dialogue, money and battle flow are untouched.

## The placement proof

`host.validate_placement(data, patches)` takes the same `{check_id: fields}` shape `patch_check` takes one row at a time, and answers `{ok, reached, critical, missing}` — deterministic, and installing nothing, so a rejected seed leaves the game exactly as it was and a generator retries against a reason.

`missing.requirement` is `{map}`, `{item}` or `{badge}`. Behind it:

- **`Gen2WorldReachability`** floods each map's own collision grid from the cells a player arrives on, so an exit only Surf reaches is a Surf exit. It asks the same tile questions the overworld does rather than holding a second world model.
- An HM is only a way past anything once its badge is in hand (`Gen2WorldFieldMove.badge_for_move`).
- The scratch cache, its catalog and its map graph are held per cartridge: the first validation pays the corpus decode, every one after it is ~3 ms.

Stated in `docs/MODS.md` so a mod does not read more into a pass than is there: the model is map-granular rather than cell-exact, and story `checkevent` guards are treated as satisfiable because a placement does not move the scripts that set them. Both err toward passing a seed rather than rejecting a good one.

## Three bugs found on the way

- **`checkcoins` and `checkmoney` were missing from the runner's handled list.** Each answered through `_script_value` and then fell through to `unsupported_runtime_command`, so every Game Corner and Buena prize counter in either game stopped its script there. No test had ever run one.
- **`requires` was read over a whole 512-byte blob** rather than the site's own branch, which put thirteen conditions on a starter, two of them badges the cartridge plainly does not ask a starter for. This is why vanilla did not validate at first.
- **A prize's price could be claimed by a neighbouring branch's `takecoins`**, so two of a vendor's three prizes shared one price.

## Proof

| Check | Result |
|---|---|
| GUT, unit + integration | 3,071 passing over 151 scripts |
| `validate.gd -- all` | no failures |
| `catalog` topic | links resolve both ways on all three cartridges; vanilla validates (478/478/543 checks reached, 25/25/23 critical); a placement hiding Surf behind Surf is refused with the map it could not reach; two validations of one placement agree; a rejected placement leaves nothing installed |
| Runtime tests | patched starter shows and gives the same Pokemon; a prize refuses one coin below its patched price and charges exactly it; a shop sells its patched shelf at its patched prices; a trade uses both patched halves and leaves the record alone |
| `replay_world.gd` | 30 routes, 0 failures |
| Three-profile story walk | byte-identical to `main` |
| Boot smoke | clean |