### PR TITLE
The opening's music, and the map's after a service

### DIFF
--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -13,6 +13,11 @@ const FRAME_RATE: float = 59.7275
 const COPYRIGHT_PRELUDE_FRAMES: int = 10
 const COPYRIGHT_HOLD_FRAMES: int = 100
 
+## `constants/music_constants.asm`'s first two entries, which is every song the
+## boot itself names; the movies name their own.
+const MUSIC_NONE: int = 0
+const MUSIC_TITLE: int = 1
+
 const PHASE_COPYRIGHT: StringName = &"copyright"
 const PHASE_PRESENTS: StringName = &"presents"
 const PHASE_INTRO_MOVIE: StringName = &"intro_movie"
@@ -82,7 +87,7 @@ func start(
 	_phase_frame = 0
 	_waiting_sound = &""
 	_events.clear()
-	_emit(&"play_music", {"music": &"none", "restart": true})
+	_emit(&"play_music", {"music": MUSIC_NONE, "restart": true})
 	_emit(&"hide_image", {"id": &"boot"})
 
 
@@ -160,7 +165,12 @@ func _advance_title(held: Array) -> void:
 	if _title == null:
 		_enter_after(PHASE_TITLE)
 		return
+	var entrance: bool = _title.scene() == Gen2TitleScene.SCENE_ENTRANCE
 	_title.advance_frame(held)
+	if entrance and _title.scene() != Gen2TitleScene.SCENE_ENTRANCE:
+		# `TitleScreenEntrance.done`: the logo has come in, the LY override is
+		# dropped and the music starts there rather than with the screen.
+		_emit(&"play_music", {"music": MUSIC_TITLE, "restart": true})
 	if not _title.finished():
 		return
 	var option: int = _title.selected_option()
@@ -330,12 +340,14 @@ func _enter_after(phase: StringName) -> void:
 				_emit(&"show_image", {"id": &"intro_movie", "scene": 0})
 			PHASE_TITLE:
 				# `_TitleScreen` draws the whole screen and plays
-				# `SFX_TITLE_SCREEN_ENTRANCE` before the loop's first frame;
-				# Crystal's music waits for its entrance to finish, so the
-				# request is the same either way and the host owns the delay.
+				# `SFX_TITLE_SCREEN_ENTRANCE` before the loop's first frame. Gold
+				# and Silver's `_TitleScreen` ends on `PlayMusic MUSIC_TITLE`;
+				# Crystal's sits in `TitleScreenEntrance.done` instead, which
+				# [method _advance_title] is where this coordinator reaches.
 				_title = Gen2TitleScene.create(_profile, _sine)
 				_emit(&"open_title", {"profile": _profile})
-				_emit(&"play_music", {"music": &"title", "restart": false})
+				if _profile != RomRegistry.CRYSTAL:
+					_emit(&"play_music", {"music": MUSIC_TITLE, "restart": true})
 		return
 	_phase = PHASE_FINISHED
 	_phase_frame = 0

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -41,6 +41,9 @@ var _image: Image = null
 var _visible_id: StringName = &""
 var _accumulator: float = 0.0
 var _closed: bool = false
+## The last `PlayMusic` handed to the driver, which is the only place the
+## opening's own music can be observed from outside.
+var _last_music: Dictionary = {}
 
 
 ## Answers false on a cache with no imported splash art at all, which is the
@@ -80,8 +83,7 @@ func _ready() -> void:
 	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	add_child(_background)
-	_audio = Gen2AudioPlayer.new()
-	add_child(_audio)
+	_ensure_audio()
 	if _cinema != null:
 		_refresh()
 
@@ -157,6 +159,18 @@ func frames_left() -> int:
 		+ Gen2BootCinema.COPYRIGHT_HOLD_FRAMES - _cinema.phase_frame()
 
 
+## The last `PlayMusic` this host handed the driver, and whether the driver took
+## it: `{ music, restart, played }`, empty before the first one. The events
+## themselves are the coordinator's; only this says one arrived.
+func last_music_request() -> Dictionary:
+	return _last_music.duplicate()
+
+
+## Whether a song is running in the driver right now.
+func music_playing() -> bool:
+	return _audio != null and bool(_audio.audio_status().get("music_active", false))
+
+
 ## Which image the coordinator has up, empty while the screen is blank.
 func visible_image() -> StringName:
 	return _visible_id
@@ -195,6 +209,10 @@ func _apply(events: Array[Dictionary]) -> void:
 				return
 			&"play_sfx":
 				_play_sfx(int(event.get("sfx", 0)))
+			&"play_music":
+				_play_music(
+					int(event.get("music", 0)), bool(event.get("restart", true))
+				)
 			&"finish_intro":
 				_refresh()
 				_finish()
@@ -234,16 +252,52 @@ func _frame_image() -> Image:
 	return _blank()
 
 
-## `PlaySFX`, which the GameFreak animation calls five times on Crystal and once
-## on Gold and Silver. A screen built outside the tree has no player, which is
-## what a frame-count test is, so the frames are spent either way.
-func _play_sfx(sfx: int) -> void:
-	if _audio == null or _data == null or sfx <= 0:
+## The driver, built on the first frame that needs it rather than in `_ready`: a
+## tool or a check that adds this screen and spends its frames by hand runs
+## before the tree calls one, and the copyright's own `PlayMusic MUSIC_NONE` is
+## on the first of those frames.
+func _ensure_audio() -> void:
+	if _audio != null:
 		return
-	_audio.play_record(_data.world_audio(&"sfx", sfx), &"sfx", {
+	_audio = Gen2AudioPlayer.new()
+	add_child(_audio)
+
+
+## `PlaySFX`, which the GameFreak animation calls five times on Crystal and once
+## on Gold and Silver. A cache with no record for one spends its frames anyway,
+## which is what a frame-count test is.
+func _play_sfx(sfx: int) -> void:
+	_ensure_audio()
+	if _data == null or sfx <= 0:
+		return
+	_audio.play_record(_data.world_audio(&"sfx", sfx), &"sfx", _audio_assets())
+
+
+## `PlayMusic`, which the copyright's own start, both movies and the title
+## screen each ask for. `MUSIC_NONE` is a stop rather than a stream, and the
+## player answers it as `_InitSound` does.
+func _play_music(music: int, restart: bool) -> void:
+	_ensure_audio()
+	if _data == null or music < 0:
+		return
+	var answer: Dictionary = _audio.play_record(
+		_data.world_audio(&"music", music), &"music", _audio_assets(), restart
+	)
+	_last_music = {
+		"music": music,
+		"restart": restart,
+		"played": bool(answer.get("ok", false)),
+		"frame": _cinema.frame() if _cinema != null else 0,
+	}
+
+
+## The two blobs `Gen2SoundEngine` reads outside a record: `WaveSamples` and the
+## drumkits, which every request here shares.
+func _audio_assets() -> Dictionary:
+	return {
 		"wave_samples": _data.world_audio_asset(&"wave_samples"),
 		"drumkits": _data.world_audio_asset(&"drumkits"),
-	})
+	}
 
 
 ## `ClearTilemap` leaves the blank tile everywhere, which through this palette

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2955,9 +2955,12 @@ func _on_service_completed(results: Array) -> void:
 		host.queue_free()
 	if _apply_fly_choice(results):
 		return
-	# The radio card writes wMapMusic, so what plays after the Pokegear closes is
-	# whichever station was left tuned, or the map's own track when none was.
-	_play_current_map_music()
+	# `ExitPokegearRadio_HandleMusic`: only the radio card takes the music off the
+	# map, and the restart behind it is what plays whichever station was left
+	# tuned, or the map's own track when none was. Every other service leaves the
+	# music where it stands, which is what `_TownMap` does with the map poster.
+	if host != null and host.radio_music_playing() != Gen2WorldServiceScreen.RADIO_MUSIC_SILENT:
+		_play_current_map_music()
 	_show_script_results(results)
 	_reopen_start_menu_if_due()
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -39,6 +39,13 @@ const POKEGEAR_CARDS: Array[Dictionary] = [
 	{"card": &"radio", "name": "RADIO", "flag": Gen2WorldState.ENGINE_RADIO_CARD},
 ]
 
+## `wPokegearRadioMusicPlaying`, which is what `ExitPokegearRadio_HandleMusic`
+## branches on: zero while nothing in this overlay has touched the music, and
+## one of the source's own two values once the radio card has.
+const RADIO_MUSIC_SILENT: int = 0
+const RADIO_MUSIC_RESTART_MAP: int = 0xFE
+const RADIO_MUSIC_ENTER_MAP: int = 0xFF
+
 const WorldMenu := preload("res://game/world/world_menu.gd")
 
 ## `BuyMenuLoop`'s four states: the list `ScrollingMenu` runs, the quantity
@@ -97,6 +104,9 @@ var _town_map: Gen2TownMapScreen = null
 ## The clock, phone or radio card while one is open, which is a hardware-
 ## resolution screen over this panel the way the region map is.
 var _pokegear: Gen2PokegearScreen = null
+## `wPokegearRadioMusicPlaying`. Only the radio card writes it, so an overlay
+## that never opened one leaves the map's own music where it stands.
+var _radio_music: int = RADIO_MUSIC_SILENT
 ## Whether the region map on screen is the fly map, which answers a spawn rather
 ## than closing back into the card list.
 var _fly_map: bool = false
@@ -1042,6 +1052,11 @@ func _refresh_card() -> void:
 			)
 		Gen2PokegearScreen.CARD_RADIO:
 			var tuned: Dictionary = _world.radio_station()
+			# `RadioMusicRestartDE` on a station and `NoRadioMusic` on dead air:
+			# either way the card has taken the music off the map, which is what
+			# makes the exit restart it.
+			_radio_music = RADIO_MUSIC_RESTART_MAP if bool(tuned.get("ok", false)) \
+				else RADIO_MUSIC_ENTER_MAP
 			var show: Gen2RadioShow = _world.radio_show()
 			_pokegear.set_radio(
 				_world.state.radio_knob(),
@@ -1073,6 +1088,15 @@ func _on_card_switched(direction: int) -> void:
 		return
 	_close_card()
 	_open_card(card)
+
+
+## `wPokegearRadioMusicPlaying`, for the host that owns the driver:
+## `ExitPokegearRadio_HandleMusic` restarts the map's music only when the radio
+## card has played something over it, and every other service leaves it alone.
+## The restart lands when this overlay closes rather than when the card does,
+## since the card list is this panel rather than the Pokegear's own screen.
+func radio_music_playing() -> int:
+	return _radio_music
 
 
 ## One hardware frame of whichever card is open. Only the radio card spends any:

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -409,6 +409,22 @@ func test_pokegear_clock_card_renders_source_time_and_returns_to_cards() -> void
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
 
 
+## The other half of the same rule: the radio card is what writes
+## `wPokegearRadioMusicPlaying`, so a Pokegear that opened one owes the map its
+## music back. Dead air is `NoRadioMusic`, which owes it just as a station does.
+func test_the_radio_card_is_what_owes_the_map_its_music_back() -> void:
+	await _open_world()
+	_world_screen._open_pokegear()
+	await get_tree().process_frame
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_eq(host.radio_music_playing(), Gen2WorldServiceScreen.RADIO_MUSIC_SILENT)
+	host._open_card(Gen2PokegearScreen.CARD_RADIO)
+	await get_tree().process_frame
+	assert_eq(host._pokegear.card(), Gen2PokegearScreen.CARD_RADIO)
+	assert_ne(host.radio_music_playing(), Gen2WorldServiceScreen.RADIO_MUSIC_SILENT)
+
+
 ## A run of a card's tilemap read back as text, which is what the page printed.
 func _row_text(map: PackedInt32Array, at: Vector2i, length: int) -> String:
 	var out: String = ""
@@ -451,6 +467,12 @@ func test_town_map_decoration_opens_fullscreen_and_closes_the_script_request() -
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.TOWN_MAP)
 	assert_not_null(host._town_map)
 	assert_true(host._town_map.visible)
+	## `_TownMap` touches no music, so nothing is owed on the way out: only the
+	## radio card sets `wPokegearRadioMusicPlaying`, and only that restarts the
+	## map's own track over the poster.
+	assert_eq(
+		host.radio_music_playing(), Gen2WorldServiceScreen.RADIO_MUSIC_SILENT
+	)
 	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)

--- a/tests/unit/test_boot_cinema.gd
+++ b/tests/unit/test_boot_cinema.gd
@@ -152,6 +152,39 @@ func test_a_skipped_copyright_starts_on_the_next_phase_the_host_names() -> void:
 	))
 
 
+## `PlayMusic MUSIC_TITLE` sits in `_TitleScreen` on Gold and Silver and in
+## `TitleScreenEntrance.done` on Crystal, so the request lands with the screen on
+## one profile and once the logo has come in on the other.
+func test_the_title_music_lands_where_each_profile_plays_it() -> void:
+	var gs := Boot.new()
+	gs.start(&"gold", null, [Boot.PHASE_TITLE])
+	var opening: Array[Dictionary] = gs.drain_events().filter(
+		func(event: Dictionary) -> bool: return event["type"] == &"play_music"
+	)
+	assert_eq(opening.size(), 1, "`_TitleScreen` ends on it")
+	assert_eq(int(opening[0]["music"]), Boot.MUSIC_TITLE)
+
+	var crystal := Boot.new()
+	crystal.start(&"crystal", null, [Boot.PHASE_TITLE])
+	assert_true(crystal.drain_events().all(
+		func(event: Dictionary) -> bool: return event["type"] != &"play_music"
+	), "Crystal's entrance is still coming in")
+	var music: Array[Dictionary] = []
+	var frames: int = 0
+	while music.is_empty() and frames < 200:
+		music.append_array(crystal.advance_frame().filter(
+			func(event: Dictionary) -> bool: return event["type"] == &"play_music"
+		))
+		frames += 1
+		assert_eq(
+			crystal.title().scene() == Gen2TitleScene.SCENE_ENTRANCE,
+			music.is_empty(),
+			"the entrance and the silence in front of it end together"
+		)
+	assert_eq(music.size(), 1, "`.done` is what starts it")
+	assert_eq(int(music[0]["music"]), Boot.MUSIC_TITLE)
+
+
 ## `RunTitleScreen` runs the screen rather than holding the phase: a held START
 ## answers it, and the answer is what reaches the host.
 func test_the_title_phase_runs_its_own_screen_and_answers_the_host() -> void:

--- a/tools/checks/opening_lane.gd
+++ b/tools/checks/opening_lane.gd
@@ -8,6 +8,10 @@ var _r: RefCounted = null
 ##
 ##   Godot --headless --path . -s res://tools/validate.gd -- opening_lane
 
+## Longer than the whole boot: Crystal's movie is 2,340 frames and Gold and
+## Silver's 2,355, and the title screen's music lands just behind either.
+const OPENING_FRAME_CAP: int = 6000
+
 const REQUIRED_SECTIONS: Dictionary = {
 	"maps": RomCache.WORLD_MAPS,
 	"tilesets": RomCache.WORLD_TILESETS,
@@ -88,6 +92,8 @@ func _validate(game_id: StringName) -> bool:
 			elif record.get("bytes", PackedByteArray()).is_empty():
 				failures.append("missing_audio_record_payload:%s:%d" % [kind, index])
 
+	failures.append_array(_audit_opening_music(data))
+
 	var script_audit: Dictionary = _audit_scripts(data, game_id == &"crystal")
 	for reason: String in script_audit["failures"]:
 		failures.append(reason)
@@ -143,3 +149,57 @@ func _audit_scripts(data: GameData, crystal: bool) -> Dictionary:
 		"unknown_commands": unknown_commands,
 		"malformed_pointers": malformed_pointers,
 	}
+
+
+## The opening's own `PlayMusic` calls, driven through the live screen rather
+## than counted off the coordinator: every one of them has to reach the driver,
+## which is the half `tests/unit/test_boot_cinema.gd` cannot see. The whole boot
+## is run to the title screen's own `PlayMusic MUSIC_TITLE`, so the movie's
+## request is spent on the way.
+func _audit_opening_music(data: GameData) -> Array[String]:
+	var tree: SceneTree = Engine.get_main_loop() as SceneTree
+	if tree == null:
+		return ["no_scene_tree_for_opening_music"]
+	var splash := Gen2SplashScreen.new()
+	tree.root.add_child(splash)
+	# The screen counts its own frames off the clock in `_process`; this check
+	# spends them by hand, the way `tools/preview_*.gd` do.
+	splash.set_process(false)
+	var out: Array[String] = []
+	if not splash.open(data):
+		out.append("splash_did_not_open")
+		tree.root.remove_child(splash)
+		splash.free()
+		return out
+	var movie_music: int = -1
+	var movie_frame: int = 0
+	var title_music: int = -1
+	var frames: int = 0
+	var seen: int = -1
+	while frames < OPENING_FRAME_CAP and title_music < 0:
+		splash.advance_frames(1)
+		frames += 1
+		var request: Dictionary = splash.last_music_request()
+		if int(request.get("frame", -1)) == seen or int(request.get("music", 0)) <= 0:
+			continue
+		seen = int(request.get("frame", -1))
+		if not bool(request.get("played", false)):
+			out.append("opening_music_refused:%d" % int(request.get("music", 0)))
+			break
+		if splash.visible_image() == &"title":
+			title_music = int(request["music"])
+		elif movie_music < 0:
+			movie_music = int(request["music"])
+			movie_frame = seen
+	if movie_music < 0:
+		out.append("the movie asked the driver for no music")
+	if title_music != Gen2BootCinema.MUSIC_TITLE:
+		out.append("the title screen asked the driver for music %d" % title_music)
+	elif not splash.music_playing():
+		out.append("the title screen's music did not reach the driver")
+	print("  opening_music: movie=%d at frame %d, title=%d" % [
+		movie_music, movie_frame, title_music,
+	])
+	tree.root.remove_child(splash)
+	splash.free()
+	return out


### PR DESCRIPTION
Two reported defects, both audio and both live-path rather than model.

**The opening was silent on all three cartridges.** `splash_screen.gd` answered
`play_sfx` and had no `play_music` case, so every request the boot emits was
dropped: Crystal's `MUSIC_CRYSTAL_OPENING`, Gold and Silver's two, and the title
theme. The host answers them now, and builds its driver on the first frame that
asks rather than in `_ready`, since a tool or a check that spends frames by hand
runs before the tree calls one.

The event payload is one shape now, a music index, and the title screen's
request lands where each profile plays it: `_TitleScreen` ends on
`PlayMusic MUSIC_TITLE` on Gold and Silver, while Crystal's sits in
`TitleScreenEntrance.done`, behind the logo coming in.

**Closing the bedroom's wall map restarted the map's music.**
`_on_service_completed` restarted it after every service overlay. On the
cartridge only `ExitPokegearRadio_HandleMusic` does, gated on
`wPokegearRadioMusicPlaying`, which only the radio card writes; `_TownMap`
touches no music at all.

Proof:

| Run | Result |
|---|---|
| `validate.gd -- opening_lane` | PASS on all three. Music reaches the driver: movie 82 at frame 457 on Gold and Silver, 37 at 1,675 on Crystal, `MUSIC_TITLE` behind each |
| `validate.gd -- art radio` | PASS |
| GUT, both tiers | 3,073 tests over 150 scripts, green |
| `--quit-after 30` boot | clean |