### PR TITLE
A warp spends the setup script's own frames

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -747,6 +747,17 @@ A registered world renderer that wants to draw them takes them through the
 optional `set_actors(actors: Gen2WorldActors)`, which is handed the same
 resolved list the built-in view draws.
 
+### The map fades
+
+A warp spends `MapSetupScript_Door`'s two fades, sixteen frames in which no
+input is read. A renderer is offered each step of them through the optional
+`set_fade(order: int, white_fill: bool)`: `order` is the palette order
+`DmgToCgbTimePals` applies to every palette on screen, and `white_fill` is
+`FillWhiteBGColor`, which the way out runs and the way in does not. The identity
+order (`Gen2WorldPalette.FADE_IDENTITY`) is every other frame of the game. A
+renderer that does not define it cuts to the new map on the frame the cartridge
+is at its whitest; the host spends the frames either way.
+
 ## Visible wild encounters
 
 A mod that wants wild Pokemon standing on the map instead of a roll on every

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -123,6 +123,26 @@ func fade_out(frames: int = 0) -> bool:
 	return true
 
 
+## `FadeToMapMusic`: the same `wMusicFade`, with `wMusicFadeID` behind it, so the
+## new track starts when the fade reaches zero rather than over the old one.
+## Answers false when there is nothing playing to fade, which is the source's own
+## `cp e / jr z, .done` and the driver starting the piece at once.
+func fade_to(record: Dictionary, frames: int, assets: Dictionary = {}) -> bool:
+	if record.is_empty():
+		return false
+	_engine.set_assets(assets)
+	_engine.stereo = stereo
+	var key: String = "%d:%d" % [int(record.get("bank", -1)), int(record.get("address", -1))]
+	if key == _music_key:
+		return false
+	if not _engine.any_channel_active():
+		return bool(play_record(record, &"map_music", assets).get("played", false))
+	_start_stream()
+	_engine.start_fade(frames, record)
+	_music_key = key
+	return true
+
+
 func stop_all() -> void:
 	_engine.init_sound()
 	_music_key = ""

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -57,6 +57,12 @@ const RENDERER_ACTORS_METHOD: String = "set_actors"
 ## [constant RENDERER_ACTORS_METHOD]; what is only here is the shiny pulse, which
 ## is battle-animation OAM over the map and which a renderer may ignore.
 const RENDERER_ENCOUNTERS_METHOD: String = "set_encounters"
+## Optional, world renderers only. Called with one step of a map fade: the
+## palette order `DmgToCgbTimePals` applies to every palette on screen, and
+## `FillWhiteBGColor` beside it on the way out. The host spends the fade's own
+## frames either way, so a renderer that ignores this cuts to the new map on the
+## frame the cartridge is at its whitest rather than desynchronising.
+const RENDERER_FADE_METHOD: String = "set_fade"
 ## Optional, battle renderers only. Called with a [Gen2BattleWorldContext] once
 ## per battle, before the first [code]set_view[/code], saying where the fight is
 ## happening: a renderer staging it on the map needs that and one drawing the

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4073,6 +4073,15 @@ func _apply_script_warp(request: Dictionary) -> Dictionary:
 ## field selects a one-based warp in the destination map, as in the original
 ## map macro. An invalid target leaves this API unchanged and returns an error
 ## record instead of silently placing the player on another map.
+## `CheckWarpCollision`'s own answer, without walking through the warp: whether
+## the step that just landed on [param cell] has a warp to take. A host that
+## spends `MapSetupScript_Door`'s fade before the map swaps asks this first, and
+## [method try_warp] is the swap itself.
+func warp_pending(cell: Vector2i = player_cell) -> bool:
+	return not warp_at(cell).is_empty() \
+		and Gen2WorldCollision.is_warp_tile(collision_code_at(cell))
+
+
 func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	var source_warp: Dictionary = warp_at(cell)
 	if source_warp.is_empty():

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -106,6 +106,36 @@ const PALETTE_ROWS: Array = [
 ]
 
 
+## `.cgbfade`, the seven rows `GetTimePalFade` answers with on a CGB, each
+## packed the way `dc` packs one: colour j of the result is colour
+## `(order >> 2j) & 3` of the palette it is applied to, which is what
+## `DmgToCgbTimePals` does with it. Row 3 is the identity, row 6 is every colour
+## flattened onto colour 0.
+const FADE_ORDERS: Array[int] = [0xFF, 0xFE, 0xF9, 0xE4, 0x90, 0x40, 0x00]
+## `RotatePalettesRight`'s and the two map fades' own starting rows.
+const FADE_IDENTITY: int = 0xE4
+
+## `FadeOutToWhite`: `ld c, $9` is row 3, and `ConvertTimePalsIncHL` walks four
+## rows forward, two frames each. `FadeInFromWhite` is `ld c, $12`, row 6, and
+## `ConvertTimePalsDecHL` walks the same four back.
+const FADE_OUT_ORDERS: Array[int] = [0xE4, 0x90, 0x40, 0x00]
+const FADE_IN_ORDERS: Array[int] = [0x00, 0x40, 0x90, 0xE4]
+## `DelayFrames`' own `ld c, 2` inside either loop.
+const FADE_STEP_FRAMES: int = 2
+
+
+## One step of a palette fade: `CopyPals`' rule, which every `DmgToCgb*Pals`
+## caller shares. The identity order answers the palette it was handed.
+static func fade_palette(palette: PackedColorArray, order: int) -> PackedColorArray:
+	if order == FADE_IDENTITY or palette.size() < 4:
+		return palette
+	var out := PackedColorArray()
+	out.resize(palette.size())
+	for index: int in palette.size():
+		out[index] = palette[(order >> (2 * mini(index, 3))) & 3] if index < 4 			else palette[index]
+	return out
+
+
 static func palette_slots(environment: int, time_of_day: int) -> Array:
 	var environment_index: int = clampi(environment, 0, PALETTE_ROWS.size() - 1)
 	var time_index: int = clampi(time_of_day, 0, 3)
@@ -125,6 +155,8 @@ static func tile_palettes(
 	time_of_day: int = TIME_MORNING,
 	water_color: int = -1,
 	cave_color: int = -1,
+	fade_order: int = FADE_IDENTITY,
+	white_fill: bool = false,
 ) -> Array:
 	var slots: Array = palette_slots(map.environment, time_of_day)
 	var resolved: Array = []
@@ -137,7 +169,19 @@ static func tile_palettes(
 		elif slot == 4 and cave_color >= 0 and base.size() >= 2:
 			palette[0] = base[clampi(cave_color, 0, 1)]
 		resolved.append(palette)
-	var fallback: PackedColorArray = data.world_palette(0)
+	# `FillWhiteBGColor`, which only the fade out of the map runs: every
+	# background palette takes palette 0's own colour 0, so the order that
+	# flattens a palette onto it flattens the screen onto one white.
+	if white_fill and not resolved.is_empty():
+		var white: Color = (resolved[0] as PackedColorArray)[0]
+		for slot: int in range(1, resolved.size()):
+			var palette: PackedColorArray = resolved[slot]
+			palette[0] = white
+			resolved[slot] = palette
+	if fade_order != FADE_IDENTITY:
+		for slot: int in resolved.size():
+			resolved[slot] = fade_palette(resolved[slot], fade_order)
+	var fallback: PackedColorArray = fade_palette(data.world_palette(0), fade_order)
 	var out: Array = []
 	out.resize(tileset.tile_count)
 	for tile: int in tileset.tile_count:

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -25,6 +25,10 @@ var _priority_atlas: ImageTexture = null
 var _priority_indices: PackedByteArray = PackedByteArray()
 var _effect_sheets: Dictionary = {}
 var _effect_textures: Dictionary = {}
+## The palette order the map fades are one step of, and `FillWhiteBGColor`
+## beside it. The identity order is every other frame of the game.
+var _fade_order: int = Gen2WorldPalette.FADE_IDENTITY
+var _fade_white_fill: bool = false
 
 
 func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> void:
@@ -68,6 +72,23 @@ func set_time_of_day(time_of_day: int) -> void:
 	_time_of_day = clampi(time_of_day, 0, 3)
 	_actor_textures.clear()
 	_effect_textures.clear()
+	_rebuild_atlas()
+	queue_redraw()
+
+
+## Gen2ModHost.RENDERER_FADE_METHOD: one step of `FadeOutToWhite` or
+## `FadeInFromWhite`, which is a palette order applied to every palette on
+## screen and, on the way out, `FillWhiteBGColor` under it. The identity order
+## is a screen that is not fading. Presentation only: the host spends the frames
+## whether or not the view it is drawing with takes this.
+func set_fade(order: int, white_fill: bool = false) -> void:
+	if order == _fade_order and white_fill == _fade_white_fill:
+		return
+	_fade_order = order
+	_fade_white_fill = white_fill
+	_actor_textures.clear()
+	_effect_textures.clear()
+	_anim_textures.clear()
 	_rebuild_atlas()
 	queue_redraw()
 
@@ -132,6 +153,8 @@ func _tile_palettes() -> Array:
 		_time_of_day,
 		_animation.water_palette_color() if _animation != null else -1,
 		_animation.cave_palette_color() if _animation != null else -1,
+		_fade_order,
+		_fade_white_fill,
 	)
 
 
@@ -279,8 +302,13 @@ func _actor_texture(
 		else _world.data.overworld_sprite_indices(sprite.number)
 	## A visible encounter names the species' own four colours; everything else
 	## wears one of the map's sprite palettes.
-	var colors: PackedColorArray = color_override if not color_override.is_empty() \
-		else _world.data.overworld_sprite_palette(palette, _time_of_day)
+	## `DmgToCgbObjPals` takes the fade's own order too, and `FillWhiteBGColor`
+	## is background only, so a sprite flattens onto its own colour 0.
+	var colors: PackedColorArray = Gen2WorldPalette.fade_palette(
+		color_override if not color_override.is_empty() \
+			else _world.data.overworld_sprite_palette(palette, _time_of_day),
+		_fade_order,
+	)
 	var image: Image = Gen2WorldSprite.big_image_for(sprite, indices, colors, big_shape) \
 		if big_shape != Gen2WorldSprite.BIG_SHAPE_NONE \
 		else Gen2WorldSprite.image_for(sprite, indices, colors, facing, frame)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -41,6 +41,18 @@ const SFX_HEADBUTT_TREE: int = 0x6D
 ## induction.
 const MUSIC_HALL_OF_FAME: int = 20
 
+## `GetWarpSFX`: the door, the warp panel, and everything else, which is a step
+## out of a building. Read off the tile the step landed on, the way
+## `wPlayerTileCollision` is.
+const SFX_ENTER_DOOR: int = 0x1F
+const SFX_WARP_TO: int = 0x13
+const SFX_EXIT_BUILDING: int = 0x23
+const COLL_DOOR: int = 0x71
+const COLL_WARP_PANEL: int = 0x7C
+## `FadeToMapMusic`'s own `ld a, 8` into `wMusicFade`, which is what the new
+## map's track arrives behind.
+const WARP_MUSIC_FADE_FRAMES: int = 8
+
 @export var map_group: int = 24
 @export var map_number: int = 3
 @export var start_cell: Vector2i = Vector2i(4, 4)
@@ -68,6 +80,10 @@ var _encounters: Gen2WorldEncounters = null
 var _battle_encounter_id: StringName = &""
 ## The headbutt result waiting for ShakeHeadbuttTree's 32 frames to be spent.
 var _pending_headbutt_finish: Dictionary = {}
+## `MapSetupScript_Door` while it is running: `{ stage, step, frames, cell }`,
+## empty on every other frame. The map swaps between the two stages, which is
+## where the setup script's own list sits.
+var _map_fade: Dictionary = {}
 var _text_box: Gen2TextBox = null
 var _clock: Gen2WorldClock = null
 var _audio_player: Gen2AudioPlayer = null
@@ -417,6 +433,9 @@ func advance_frame() -> void:
 		if _replaying_input:
 			_apply_replayed_input(_world.frame_number)
 	_advance_game_time_frame()
+	## Before everything the map draws: the fade owns the frame the map swaps on,
+	## and nothing else runs while `RunMapSetupScript` is spending its own.
+	_advance_map_fade()
 	if _effects != null:
 		if _effects.advance_frame() and _renderer != null:
 			_renderer.refresh()
@@ -590,7 +609,10 @@ func _advance_held_direction() -> void:
 ## they all need this one, and adding an overlay to five of six lists by hand is
 ## what the Cut and Hall of Fame work each paid for once.
 func _overlay_open() -> bool:
-	return _battle_host != null or _service_host != null \
+	## A map fade is not an overlay, but nothing may move or be pressed inside
+	## one either: `RunMapSetupScript` runs with the joypad unread.
+	return not _map_fade.is_empty() \
+		or _battle_host != null or _service_host != null \
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
 		or _pokedex_host != null or _credits_host != null
@@ -672,7 +694,8 @@ func press_button(button: int) -> bool:
 ## refusing the ones it has no use for, which is what keeps a stray press from
 ## reaching the map behind it.
 func _handle_button(button: int) -> bool:
-	if not _trainer_approach.is_empty() or _world.phone_ring_active():
+	if not _map_fade.is_empty() or not _trainer_approach.is_empty() \
+		or _world.phone_ring_active():
 		return true
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -882,20 +905,36 @@ func _after_player_move(movement: Dictionary) -> bool:
 	if movement.get("kind", &"") == &"exit_water":
 		_play_current_map_music()
 
-	var transition: Dictionary = movement
 	## CheckTileEvent gates warps on nothing, so surfing onto a warp tile and the
 	## step back onto land both reach one.
 	if movement.get("kind", &"") in [
 		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
-	]:
-		transition = _world.try_warp()
+	] and _world.warp_pending():
+		## `WarpToNewMapScript`: the sound, and then `newloadmap MAPSETUP_DOOR`,
+		## whose `FadeOutToWhite` runs before the map is loaded at all. The map
+		## swaps when that fade lands, and everything a step still owes waits
+		## for `FadeInFromWhite` behind it.
+		_start_map_fade()
+		return true
 	if _renderer != null:
-		if bool(transition.get("ok", false)) and transition.get("kind", &"") != &"move":
+		if bool(movement.get("ok", false)) and movement.get("kind", &"") != &"move":
+			## `MapSetupScript_Connection`, which is the step itself rather than
+			## a warp: the neighbour's blocks are loaded under a camera that
+			## never stops, and its `FadeToMapMusic` is why crossing a route
+			## boundary into the same track is one continuous piece.
 			_animation.configure(_world, time_of_day)
 			_set_renderer_world()
-			_play_current_map_music()
+			_fade_to_map_music()
 		else:
 			_renderer.refresh()
+	return _after_map_settled()
+
+
+## `EnterMap`'s own tail, which a warp reaches once its setup script has run and
+## an ordinary step reaches on the frame it finished: the sight lines, the map's
+## scripts, the two phone paths, the contest timer, and the wild roll behind all
+## of them.
+func _after_map_settled() -> bool:
 	_refresh_labels()
 	var sight_results: Array = _world.dispatch_sight_events()
 	if sight_results.is_empty():
@@ -940,6 +979,92 @@ func _after_player_move(movement: Dictionary) -> bool:
 			"encounter": encounter.duplicate(true),
 		})
 	return true
+
+
+## `MapSetupScript_Door` while it is running, for a test or a preview tool that
+## has to land on one of its frames: `{ stage, step, frames }`, empty on every
+## other frame of the game.
+func map_fade() -> Dictionary:
+	return _map_fade.duplicate()
+
+
+## `WarpToNewMapScript`. `GetWarpSFX` reads the tile the step landed on, and
+## `MapSetupScript_Door`'s `FadeOutToWhite` is the first thing the setup script
+## spends: four palette orders, two frames each, before anything is loaded.
+func _start_map_fade() -> void:
+	_play_sfx(_warp_sfx())
+	_map_fade = {"stage": &"out", "step": 0, "frames": Gen2WorldPalette.FADE_STEP_FRAMES}
+	_apply_map_fade_step()
+
+
+## `GetWarpSFX`, off `wPlayerTileCollision`.
+func _warp_sfx() -> int:
+	match _world.collision_code_at(_world.player_cell):
+		COLL_DOOR:
+			return SFX_ENTER_DOOR
+		COLL_WARP_PANEL:
+			return SFX_WARP_TO
+	return SFX_EXIT_BUILDING
+
+
+## One frame of the fade the warp is inside, spent from [method advance_frame]
+## like every other countdown here. The two stages are `FadeOutToWhite` and
+## `FadeInFromWhite`; the map is loaded between them, which is where the rest of
+## `MapSetupScript_Door`'s list sits.
+func _advance_map_fade() -> void:
+	if _map_fade.is_empty():
+		return
+	_map_fade["frames"] = int(_map_fade["frames"]) - 1
+	if int(_map_fade["frames"]) > 0:
+		return
+	var step: int = int(_map_fade["step"]) + 1
+	var out: bool = StringName(_map_fade["stage"]) == &"out"
+	if step < Gen2WorldPalette.FADE_OUT_ORDERS.size():
+		_map_fade["step"] = step
+		_map_fade["frames"] = Gen2WorldPalette.FADE_STEP_FRAMES
+		_apply_map_fade_step()
+		return
+	if out:
+		_swap_warped_map()
+		_map_fade = {"stage": &"in", "step": 0, "frames": Gen2WorldPalette.FADE_STEP_FRAMES}
+		_apply_map_fade_step()
+		return
+	_map_fade = {}
+	_apply_map_fade_step()
+	## `EnterMap` runs the map's own scripts once the setup script has finished,
+	## which is the frame the fade lands on.
+	_after_map_settled()
+
+
+## The palette order this step of the fade draws with. `FillWhiteBGColor` is the
+## fade out's alone, so the way back in flattens onto whatever the new map's own
+## palette 0 holds.
+func _apply_map_fade_step() -> void:
+	if _renderer == null or not _renderer.has_method(Gen2ModHost.RENDERER_FADE_METHOD):
+		return
+	if _map_fade.is_empty():
+		_renderer.call(
+			Gen2ModHost.RENDERER_FADE_METHOD, Gen2WorldPalette.FADE_IDENTITY, false
+		)
+		return
+	var out: bool = StringName(_map_fade["stage"]) == &"out"
+	var orders: Array[int] = Gen2WorldPalette.FADE_OUT_ORDERS if out \
+		else Gen2WorldPalette.FADE_IN_ORDERS
+	_renderer.call(
+		Gen2ModHost.RENDERER_FADE_METHOD, orders[int(_map_fade["step"])], out
+	)
+
+
+## The middle of `MapSetupScript_Door`: the map the warp names is loaded with the
+## screen at its whitest, and `FadeToMapMusic` is the eight-step fade the new
+## map's track arrives behind rather than a restart.
+func _swap_warped_map() -> void:
+	var transition: Dictionary = _world.try_warp()
+	if not bool(transition.get("ok", false)):
+		return
+	_animation.configure(_world, time_of_day)
+	_set_renderer_world()
+	_fade_to_map_music()
 
 
 ## The three placings as one line. `_BugContestJudging` prints them as three
@@ -3354,6 +3479,20 @@ func _audio_assets() -> Dictionary:
 		"wave_samples": _data.world_audio_asset(&"wave_samples") if _data != null else {},
 		"drumkits": _data.world_audio_asset(&"drumkits") if _data != null else {},
 	}
+
+
+## `FadeToMapMusic`, which is what a map entered through a warp arrives behind:
+## `wMusicFade` is eight and `wMusicFadeID` the map's own track, so the piece
+## that was playing fades out and the new one starts where it lands. A map whose
+## track is already playing keeps it, which is the routine's own `cp e`.
+func _fade_to_map_music() -> void:
+	if _audio_player == null or _data == null or _world == null \
+		or _world.current_map == null:
+		return
+	_audio_player.fade_to(
+		_data.world_audio(&"music", _world.state.map_music()),
+		WARP_MUSIC_FADE_FRAMES, _audio_assets(),
+	)
 
 
 ## Plays whatever `wMapMusic` currently holds. `Gen2WorldAPI` owns the write,

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -14,18 +14,27 @@ extends GutTest
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
+## Longer than the turn, the step and the fade behind them: the helper below
+## drives to a state rather than spending a count.
+const WALK_FRAME_CAP: int = 40
+
 var _world: Gen2WorldAPI = null
+var _data: GameData = null
+var _screen: Gen2WorldScreen = null
 
 
 func before_each() -> void:
-	var data: GameData = Fixture.build()
-	data = GameData.open_directory(Fixture.directory())
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
 	_world = Gen2WorldAPI.open(
-		data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(2, 2)
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(2, 2)
 	)
 
 
 func after_each() -> void:
+	if is_instance_valid(_screen):
+		_screen.free()
+		_screen = null
 	RomCache.clear(Fixture.directory())
 
 
@@ -80,3 +89,79 @@ func test_the_offset_covers_one_cell() -> void:
 	)
 	_world.advance_player_step_frame()
 	assert_eq(_world.player_step_offset_cells(), Vector2.ZERO, "and lands on it")
+
+
+## The production screen on the fixture's map, walked up onto the door and
+## stopped on the frame `WarpToNewMapScript` starts, which is the frame the step
+## onto the warp tile landed on and no fade frame has been spent yet. Its own clock is taken away, so every frame after
+## that is spent by hand.
+func _walk_onto_the_door() -> Gen2WorldScreen:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	screen.map_group = Fixture.MAP_GROUP
+	screen.map_number = Fixture.MAP_NUMBER
+	screen.start_cell = Fixture.WARP_CELL + Vector2i.DOWN
+	screen.encounter_seed = 1
+	screen.set_data(_data)
+	add_child(screen)
+	await get_tree().process_frame
+	screen.set_process(false)
+	screen._frame_elapsed = 0.0
+	for _frame: int in WALK_FRAME_CAP:
+		## One press turns and the next steps, and a press inside the fade is
+		## swallowed, so the same call drives all three.
+		screen.move_up()
+		screen.advance_frame()
+		if not screen.map_fade().is_empty():
+			break
+	return screen
+
+
+## `WarpToNewMapScript` is `warpsound` and `newloadmap MAPSETUP_DOOR`, and that
+## setup script spends frames before the map is loaded and after: four palette
+## orders of `FadeOutToWhite`, two frames each, then the load, then the four of
+## `FadeInFromWhite`. A warp that swapped the map on the frame the step landed
+## on is what puts the same input on a different frame from the cartridge's.
+func test_a_warp_spends_the_setup_script_own_fade() -> void:
+	_screen = await _walk_onto_the_door()
+	assert_eq(_screen._world.player_cell, Fixture.WARP_CELL, "the step landed on it")
+	assert_eq(
+		_screen._world.map_id(), Vector2i(Fixture.MAP_GROUP, Fixture.MAP_NUMBER),
+		"and the map has not swapped: `FadeOutToWhite` runs first"
+	)
+	assert_eq(StringName(_screen.map_fade().get("stage", &"")), &"out")
+	var fade_frames: int = Gen2WorldPalette.FADE_OUT_ORDERS.size() \
+		* Gen2WorldPalette.FADE_STEP_FRAMES
+	## One of the fade out's own frames is the frame the step landed on, which is
+	## the one the fade was started in.
+	var out_frames: int = 1
+	while StringName(_screen.map_fade().get("stage", &"")) == &"out" \
+		and out_frames < WALK_FRAME_CAP:
+		_screen.advance_frame()
+		out_frames += 1
+	assert_eq(out_frames, fade_frames, "`FadeOutToWhite` is four orders of two frames")
+	assert_eq(
+		_screen._world.map_id(),
+		Vector2i(Gen2WorldSpawn.NEW_BARK_GROUP, Gen2WorldSpawn.PLAYERS_HOUSE_2F),
+		"the map is loaded when the fade out lands"
+	)
+	assert_eq(
+		StringName(_screen.map_fade().get("stage", &"")), &"in",
+		"and `FadeInFromWhite` is what the new map arrives behind"
+	)
+	var in_frames: int = 0
+	while not _screen.map_fade().is_empty() and in_frames < WALK_FRAME_CAP:
+		_screen.advance_frame()
+		in_frames += 1
+	assert_eq(in_frames, fade_frames, "and the way back in is the same four")
+
+
+## `RunMapSetupScript` runs with the joypad unread, so nothing the player does
+## inside those sixteen frames moves anything.
+func test_no_input_is_taken_while_the_warp_fade_runs() -> void:
+	_screen = await _walk_onto_the_door()
+	assert_false(_screen.map_fade().is_empty(), "the fade is up")
+	var cell: Vector2i = _screen._world.player_cell
+	assert_false(_screen.move_player(Vector2i.DOWN), "no step is taken")
+	assert_true(_screen.press_button(Gen2Button.A), "and A is swallowed rather than used")
+	assert_eq(_screen._world.player_cell, cell)

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -11,6 +11,12 @@ const SHA1: String = "0123456789abcdef"
 const BANK: int = 48
 const MAP_GROUP: int = 1
 const MAP_NUMBER: int = 1
+## The door either map warps through, each the other's destination 1. Both sit
+## away from everything else the fixture stages, since a warp tile is also a
+## forced step.
+const WARP_CELL := Vector2i(10, 8)
+const HOME_WARP_CELL := Vector2i(6, 4)
+
 const MAP_WIDTH_BLOCKS: int = 6
 const MAP_HEIGHT_BLOCKS: int = 5
 ## The fixture's copyright strip, shorter than either cartridge's so a page test
@@ -176,6 +182,10 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 	collision.resize(MAP_WIDTH_CELLS * MAP_HEIGHT_CELLS)
 	collision.fill(0)
 	collision[7 * MAP_WIDTH_CELLS + 8] = 0x29
+	## A door on the far corner, and its pair on the home map: a warp is the one
+	## thing a step can owe that the screen spends frames on, and
+	## `CheckWarpCollision` needs a warp tile under the `warp_event` for it.
+	collision[WARP_CELL.y * MAP_WIDTH_CELLS + WARP_CELL.x] = Gen2WorldCollision.COLL_DOOR
 
 	var objects: Array = [{
 		"sprite": TRAINER_SPRITE,
@@ -220,6 +230,11 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 			"bank": BANK,
 			"coord_events": [{"scene": 0, "x": 4, "y": 5, "script": TUTORIAL_SCRIPT}],
 			"objects": objects,
+			"warps": [{
+				"x": WARP_CELL.x, "y": WARP_CELL.y, "destination": 1,
+				"map_group": Gen2WorldSpawn.NEW_BARK_GROUP,
+				"map_number": Gen2WorldSpawn.PLAYERS_HOUSE_2F,
+			}],
 		},
 	}
 	var home_map: Dictionary = map.duplicate(true)
@@ -239,7 +254,11 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 	home_map["collision"] = home_collision
 	home_map["collision_width"] = 8
 	home_map["collision_height"] = 6
-	home_map["events"] = {"bank": BANK, "objects": []}
+	home_collision[HOME_WARP_CELL.y * 8 + HOME_WARP_CELL.x] = Gen2WorldCollision.COLL_DOOR
+	home_map["events"] = {"bank": BANK, "objects": [], "warps": [{
+		"x": HOME_WARP_CELL.x, "y": HOME_WARP_CELL.y, "destination": 1,
+		"map_group": MAP_GROUP, "map_number": MAP_NUMBER,
+	}]}
 	RomCache.write_json(RomCache.world_maps_path(directory), [map, home_map])
 	var grass_slots: Array = []
 	for _slot: int in RomLayout.WILD_GRASS_SLOT_COUNT:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -20,6 +20,10 @@ extends SceneTree
 ## (`BuyMenu`, talked open from the cell in front of a shop's counter, as
 ## `crystal 1 8 ... mart 3 3`), `pokepic`
 ## (`Script_pokepic`'s box over the map, holding Chikorita),
+## `warp` (`MapSetupScript_Door` at its whitest: the player is walked up onto the
+## warp tile named by the two numbers below it, and the picture is
+## `FadeOutToWhite`'s last order, which is the frame the new map is loaded on:
+## `crystal 24 7 ... warp 7 1` is the bedroom staircase),
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
@@ -35,6 +39,9 @@ extends SceneTree
 ## is photographed.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
+## Longer than a step onto a warp tile and the fade behind it, for the `warp`
+## kind, which drives to a frame rather than spending a count.
+const WARP_FRAME_CAP: int = 120
 ## Hardware frames spent after the sprites are staged. Two puts the grass rustle
 ## on its first facing and the boulder dust on its second, so every one of them
 ## is up and none is on the frame it was spawned. Cut needs more: its tree stands
@@ -150,6 +157,11 @@ func _process(_delta: float) -> bool:
 	if _screen == null:
 		return false
 	_frames += 1
+	## Again, and after the screen is in the tree: a node whose script defines
+	## `_process` has its processing turned back on when it is made ready, so the
+	## call in [method _build_live] alone leaves the screen spending frames of
+	## its own beside the ones staged below.
+	_screen.set_process(false)
 	if _frames == 2:
 		if _kind == &"unown_wall":
 			## The chamber's own `bg_event ..., BGEVENT_UP`: face the wall from
@@ -170,6 +182,19 @@ func _process(_delta: float) -> bool:
 			_screen.interact()
 			for _press: int in MART_PRESSES:
 				_screen.press_button(Gen2Button.A)
+		elif _kind == &"warp":
+			## `MapSetupScript_Door` at its whitest: the step onto the warp tile
+			## and then `FadeOutToWhite`'s last order, which is the frame the map
+			## is loaded on.
+			for _frame: int in WARP_FRAME_CAP:
+				## The first press turns, the second steps: the player is facing
+				## the room rather than the stairs when the map opens.
+				_screen.move_up()
+				_screen.advance_frame()
+				var fade: Dictionary = _screen.map_fade()
+				if StringName(fade.get("stage", &"")) == &"out" \
+					and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
+					break
 		elif _kind == &"pokepic":
 			_screen.preview_pokepic(POKEPIC_SPECIES)
 		elif FIELD_ITEMS.has(_kind):
@@ -185,8 +210,11 @@ func _process(_delta: float) -> bool:
 				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
-		for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
-			_screen.advance_frame()
+		if _kind != &"warp":
+			## The `warp` kind drove itself to the frame it wants; every other
+			## kind stages a sprite and then spends the frames it needs.
+			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
+				_screen.advance_frame()
 	if _frames < 18:
 		return false
 	var image: Image = root.get_texture().get_image()


### PR DESCRIPTION
The top reported defect: a warp swapped the map on the frame the step landed on,
so the same input reached a different frame from the cartridge's at the first
staircase and the two drifted from there.

`WarpToNewMapScript` is `warpsound` and `newloadmap MAPSETUP_DOOR`, and that
setup script spends sixteen frames with the joypad unread: `FadeOutToWhite`'s
four palette orders at two frames each, the map load, then the four of
`FadeInFromWhite`. `world_screen.gd` asks the new `Gen2WorldAPI.warp_pending()`
on the step that landed and runs that fade around `try_warp()`, which is
unchanged and still the swap itself, so every API-level caller (the story walk,
the checks) keeps the instant warp it drives.

The fade is the source's own mechanism rather than an alpha ramp: `.cgbfade`'s
four orders applied the way `DmgToCgbTimePals` applies them, with
`FillWhiteBGColor` under the way out. A renderer takes each step through the
optional `set_fade`; one that does not define it cuts on the frame the cartridge
is at its whitest and spends the same frames.

The music is `FadeToMapMusic` rather than a restart, through the fade-in record
`Gen2SoundEngine.start_fade` already modelled. A connection crossing takes the
same call, which closes the music half of the second reported defect; what is
left of that one is `InitMapNameSign` and `SaveScreen`.

Found on the way and fixed in the same commit: `tools/preview_world.gd`'s live
mode photographed a screen still spending frames of its own, because a node
whose script defines `_process` has processing turned back on when it is made
ready and the tool only asked before that.

| Run | Result |
|---|---|
| GUT, both tiers | 3,075 tests over 150 scripts, green |
| `validate.gd -- all` | 51 topics, exit 0 |
| `replay_world.gd` | exit 0 |
| Story walk, three profiles | 292 / 292 / 295 steps, 16 badges, Red reached |
| `preview_world.gd ... warp 7 1` | the bedroom staircase at its whitest, attached in the conversation |