### PR TITLE
A map entry raises its name sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ Facing something and pressing A is the other way to every field move: a cut
 tree, a whirlpool, a waterfall, a headbutt tree and open water each offer their
 move in the cartridge's own order and words. Fruit trees bear once a day, Poke
 Balls and hidden items are picked up by facing them, and the imported Players
-House PC opens box storage.
+House PC opens box storage. Walking into a new area raises Crystal's own map name
+sign for sixty frames, which Gold and Silver never had.
 
 Icons come from [Lucide](https://lucide.dev). See
 [docs/THIRD_PARTY.md](docs/THIRD_PARTY.md).
@@ -201,7 +202,7 @@ or `all`; with no argument it lists them.
 | `terrain` | Ledge hops, side walls, every map's drawn blocks, the story's map ids |
 | `johto` | Radio Tower, the Rising Badge, command queues, item balls, Route 27, the Magnet Train |
 | `kanto` | Each city, its gym and the way in, from Vermilion to Mt. Silver |
-| `art` | Both intro movies, the credits, the region map, all 278 battle animations |
+| `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 64
+const FORMAT_VERSION: int = 65
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -340,6 +340,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not mart_text["ok"]:
 		return mart_text
 
+	var map_entry_sign: Dictionary = verify_map_entry_sign(rom, layout)
+	if not map_entry_sign["ok"]:
+		return map_entry_sign
+
 	var pack: Dictionary = verify_pack(rom, layout)
 	if not pack["ok"]:
 		return pack
@@ -2211,6 +2215,27 @@ const PACK_KRIS_COLORS: Array[int] = [
 ## The two were located independently, so the constant gap is what says both are
 ## right rather than both being plausible.
 const PACK_NAME_TILEMAP_GAP: int = 0x135
+
+
+## `MapEntryFrameGFX`, which `gfx/font.asm` lays down immediately before
+## `FontsExtra2_UpArrowGFX`. The two were pinned independently, so the sheet
+## ending exactly where the arrow starts is what says both are right.
+static func verify_map_entry_sign(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("map_entry_sign", -1))
+	if at < 0:
+		return {"ok": true, "message": "No map name sign on this cartridge."}
+	var bytes: int = RomLayout.MAP_ENTRY_SIGN_TILES * RomLayout.TILE_BYTES_2BPP
+	if not rom.in_bounds(at, bytes):
+		return {"ok": false, "message": "The map name sign is outside the cartridge."}
+	var arrow: int = int((layout.get("up_arrow", {}) as Dictionary).get("offset", -1))
+	if at + bytes != arrow:
+		return {
+			"ok": false,
+			"message": "The map name sign ends at $%X, expected the up arrow's $%X." % [
+				at + bytes, arrow,
+			],
+		}
+	return {"ok": true, "message": "Map name sign verified."}
 
 
 ## The pack screen's four runs. Both palette sets are checked colour for colour,
@@ -5197,6 +5222,17 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 		sheets["game_freak_stars"] = {
 			"offset": int(presents["stars"]),
 			"tiles": RomLayout.PRESENTS_STARS_TILES,
+			"first_code": 0,
+			"bits": 2,
+		}
+
+	## `MapEntryFrameGFX`, the map name sign's frame. Crystal only: Gold and
+	## Silver ship neither the sheet nor `InitMapNameSign`, and say so with the
+	## -1 every absent record uses.
+	if int(layout.get("map_entry_sign", -1)) >= 0:
+		sheets["map_entry_sign"] = {
+			"offset": int(layout["map_entry_sign"]),
+			"tiles": RomLayout.MAP_ENTRY_SIGN_TILES,
 			"first_code": 0,
 			"bits": 2,
 		}

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -563,6 +563,11 @@ const FRAME_VERTICAL: int = 3
 const FRAME_BOTTOM_LEFT: int = 4
 const FRAME_BOTTOM_RIGHT: int = 5
 
+## `MapEntryFrameGFX`, the fourteen tiles `LoadMapNameSignGFX` requests into
+## `vTiles2 tile MAP_NAME_SIGN_START`. `PlaceMapNameFrame` addresses them by
+## offset from that base, so the strip is stored in the cartridge's own order.
+const MAP_ENTRY_SIGN_TILES: int = 14
+
 ## The battle HUD's own graphics, which sit in the same section as the font and
 ## the text box borders and are the rest of what a battle screen draws.
 ##
@@ -1619,6 +1624,9 @@ const GOLD_SILVER: Dictionary = {
 	# `FontsExtra_SolidBlackAndUpArrowGFX`' second tile, which is 1bpp here and
 	# a 2bpp sheet of its own on Crystal. Both are unique in their dump.
 	"up_arrow": {"offset": 0xF9306, "bits": 1},
+	# No `MapEntryFrameGFX` and no `InitMapNameSign` on these two: the map name
+	# sign is Crystal's own screen.
+	"map_entry_sign": -1,
 	"enemy_hud": 0xF8BB2,
 	"player_hud": 0xF8BD2,
 	"exp_bar": 0xF8C02,
@@ -2040,6 +2048,11 @@ const CRYSTAL: Dictionary = {
 	"battle_font": 0xF8600,
 	# `FontsExtra2_UpArrowGFX`, its own 2bpp tile here.
 	"up_arrow": {"offset": 0xF9424, "bits": 2},
+	# `MapEntryFrameGFX`, the map name sign's own fourteen tiles. It is the entry
+	# before `FontsExtra2_UpArrowGFX` in `gfx/font.asm` and ends exactly where
+	# that one starts, which is what checks the address. Gold and Silver ship
+	# neither the sheet nor `InitMapNameSign`, and say so with a -1.
+	"map_entry_sign": 0xF9344,
 	"enemy_hud": 0xF8AC0,
 	"player_hud": 0xF8AE0,
 	"exp_bar": 0xF8B10,

--- a/game/render/map_name_sign_page.gd
+++ b/game/render/map_name_sign_page.gd
@@ -1,0 +1,106 @@
+class_name Gen2MapNameSignPage
+extends RefCounted
+
+## `PlaceMapNameFrame` and `PlaceMapNameCenterAlign`
+## (engine/events/map_name_sign.asm): the sign a map entry raises, drawn out of
+## `MapEntryFrameGFX`'s own fourteen tiles with the landmark's name centred on
+## its lower interior row.
+##
+## Four rows of the window, which the hardware can only start at a scanline and
+## run to the bottom of the screen from: `rWY` $70 is what puts the sign in the
+## bottom four rows rather than the top.
+##
+## Crystal's own screen. Gold and Silver ship neither `InitMapNameSign` nor the
+## sheet, so a cache without it renders nothing at all.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 4
+
+## `PlaceMapNameSign`'s `ld a, $70 / ldh [rWY]`, in pixels down the screen.
+const TOP: int = 0x70
+
+## Offsets from `MAP_NAME_SIGN_START`, which is where `LoadMapNameSignGFX`
+## requests the sheet: the strip is stored in the cartridge's order, so each is
+## its index in it. Tile 0 is named by nothing.
+const TILE_TOP_LEFT: int = 1
+const TILE_TOP: int = 2
+const TILE_TOP_RIGHT: int = 4
+const TILE_LEFT_UPPER: int = 5
+const TILE_LEFT_LOWER: int = 6
+const TILE_BOTTOM_LEFT: int = 7
+const TILE_BOTTOM: int = 8
+const TILE_BOTTOM_RIGHT: int = 10
+const TILE_RIGHT_UPPER: int = 11
+const TILE_RIGHT_LOWER: int = 12
+const TILE_INTERIOR: int = 13
+
+## `PlaceMapNameCenterAlign`'s `hlcoord 0, 2`: the name sits on the second
+## interior row, not the first.
+const NAME_ROW: int = 2
+
+
+## The sign holding [param name], or null when the cache carries no sheet, no
+## font or no text palette, which is every Gold and Silver cache.
+static func render(data: GameData, name: String) -> Image:
+	if data == null:
+		return null
+	var sheet: PackedByteArray = data.tile_indices("map_entry_sign")
+	if sheet.size() < RomLayout.MAP_ENTRY_SIGN_TILES * TILE * TILE:
+		return null
+	var font: Gen2Font = Gen2Font.from_data(data)
+	if font == null:
+		return null
+	var palette: PackedColorArray = data.text_bg_palette()
+	if palette.size() < 4:
+		palette = Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	var width: int = COLUMNS * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * ROWS * TILE)
+	var strip_width: int = RomLayout.MAP_ENTRY_SIGN_TILES * TILE
+	for row: int in ROWS:
+		var tiles: Array[int] = _row_tiles(row)
+		for column: int in COLUMNS:
+			Gen2Font.blit_slot(
+				sheet, strip_width, tiles[column], indices, width,
+				column * TILE, row * TILE
+			)
+	font.draw_text(name, indices, width, name_column(name) * TILE, NAME_ROW * TILE)
+	return Gen2PicImage.from_indices(indices, width, ROWS * TILE, palette)
+
+
+## `PlaceMapNameCenterAlign`: `(SCREEN_WIDTH - length) >> 1`, where the length is
+## `.GetNameLength`'s, one per character placed.
+static func name_column(name: String) -> int:
+	return maxi(0, (COLUMNS - Gen2Text.encoded_length(name)) >> 1)
+
+
+## One row of the frame. The top and bottom rows are `.FillTopBottom`, whose loop
+## writes its first pair from the incremented tile and every pair after that in
+## twos: two of `tile + 1`, then four repeats of `tile, tile, tile + 1,
+## tile + 1`.
+static func _row_tiles(row: int) -> Array[int]:
+	match row:
+		0:
+			return _edge_row(TILE_TOP_LEFT, TILE_TOP, TILE_TOP_RIGHT)
+		ROWS - 1:
+			return _edge_row(TILE_BOTTOM_LEFT, TILE_BOTTOM, TILE_BOTTOM_RIGHT)
+		1:
+			return _interior_row(TILE_LEFT_UPPER, TILE_RIGHT_UPPER)
+	return _interior_row(TILE_LEFT_LOWER, TILE_RIGHT_LOWER)
+
+
+static func _edge_row(left: int, fill: int, right: int) -> Array[int]:
+	var out: Array[int] = [left, fill + 1, fill + 1]
+	while out.size() < COLUMNS - 1:
+		out.append_array([fill, fill, fill + 1, fill + 1])
+	out.append(right)
+	return out
+
+
+static func _interior_row(left: int, right: int) -> Array[int]:
+	var out: Array[int] = [left]
+	for _column: int in COLUMNS - 2:
+		out.append(TILE_INTERIOR)
+	out.append(right)
+	return out

--- a/game/render/map_name_sign_page.gd.uid
+++ b/game/render/map_name_sign_page.gd.uid
@@ -1,0 +1,1 @@
+uid://c47qs0s0mrpjq

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -61,6 +61,19 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 	_commands = tileset.animation_commands.duplicate(true)
 
 
+## `MapSetupScript_Connection`'s own tileset load: `LoadMapTileset` between
+## `SuspendMapAnims` and `ActivateMapAnims`, with no `LoadMapGraphics` and so no
+## `hTileAnimFrame` reset. The strip and the command list are the new map's; the
+## place in the sequence is where the crossing left it, which is what keeps the
+## water moving across a route boundary rather than restarting it.
+func reload_tileset(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MORNING) -> void:
+	var command_index: int = _command_index
+	var timer: int = _timer
+	configure(world, time_of_day)
+	_command_index = command_index
+	_timer = timer
+
+
 ## Runs one hardware frame's command and reports whether the tile strip or a
 ## palette row actually changed.
 ##

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -101,6 +101,25 @@ const BGEVENT_IFNOTSET: int = 6
 const BGEVENT_ITEM: int = 7
 const BGEVENT_COPY: int = 8
 
+## `InitMapNameSign`. `wCurLandmark` is -1 on a map that has no name to show,
+## and the five landmarks `.CheckSpecialMap` names get no sign either, alongside
+## `LANDMARK_SPECIAL` itself. Crystal indices, since the sign is Crystal's own
+## screen. The two National Park gates are `GROUP_ROUTE_35_NATIONAL_PARK_GATE`'s
+## maps 15 and 17, which `.CheckNationalParkGate` names because their
+## environment is not `GATE`.
+const MAP_NAME_SIGN_NO_LANDMARK: int = -1
+const MAP_NAME_SIGN_FRAMES: int = 60
+const NATIONAL_PARK_GATE_GROUP: int = 10
+const NATIONAL_PARK_GATE_MAPS: Array[int] = [15, 17]
+const MAP_NAME_SIGN_SILENT_LANDMARKS: Array[int] = [
+	Gen2WorldRadio.LANDMARK_SPECIAL,
+	0x11,  # LANDMARK_RADIO_TOWER
+	0x46,  # LANDMARK_LAV_RADIO_TOWER
+	0x3B,  # LANDMARK_UNDERGROUND_PATH
+	0x5A,  # LANDMARK_INDIGO_PLATEAU
+	0x44,  # LANDMARK_POWER_PLANT
+]
+
 var data: GameData = null
 var state: Gen2WorldState = null
 var inventory: Gen2WorldInventory = null
@@ -129,6 +148,12 @@ var last_spawn_map: Vector2i = Vector2i(-1, -1)
 ## the player last came into a cave through, which is where Dig and an Escape
 ## Rope put them back. Empty until one is walked.
 var dig_warp: Dictionary = {}
+## `wPrevLandmark`, which is not saved on the cartridge either: `NewGame` writes
+## New Bark Town into it and `FinishContinueFunction` sets SHOWN_MAP_NAME_SIGN so
+## the map a loaded game opens on raises no sign. Opening a world is both of
+## those, so the map it opens on is what the field starts as.
+var _prev_landmark: int = MAP_NAME_SIGN_NO_LANDMARK
+var _map_name_sign: int = MAP_NAME_SIGN_NO_LANDMARK
 var _script_queue: Array = []
 var _active_script: Gen2WorldScriptRunner = null
 var _map_entry_scene_pending: bool = false
@@ -343,6 +368,7 @@ func _init(
 	# Opening a world is `StartMap`, which falls into `EnterMap`: the five-step
 	# cooldown is set here for the same reason _apply_map() sets it on a warp.
 	state.set_wild_encounter_cooldown(Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS)
+	_prev_landmark = map_name_sign_landmark()
 	_load_objects()
 	_apply_map_music()
 
@@ -357,6 +383,53 @@ func map_id() -> Vector2i:
 ## no caller and is deliberately not modelled.
 func landmark() -> int:
 	return current_map.location if current_map != null else Gen2WorldRadio.LANDMARK_SPECIAL
+
+
+## `InitMapNameSign`'s own `wCurLandmark`: a gate borrows nobody's name, so its
+## landmark is -1 and no sign is ever raised on it. `.CheckNationalParkGate`
+## names the two gates whose environment is not `GATE` and folds them in.
+func map_name_sign_landmark() -> int:
+	if current_map == null:
+		return MAP_NAME_SIGN_NO_LANDMARK
+	if current_map.environment == ENVIRONMENT_GATE \
+		or (current_map.group == NATIONAL_PARK_GATE_GROUP
+			and NATIONAL_PARK_GATE_MAPS.has(current_map.number)):
+		return MAP_NAME_SIGN_NO_LANDMARK
+	return landmark()
+
+
+## The landmark a sign is waiting to be raised for, or -1 for no sign. Read once
+## by the host, which owns the sixty frames it is up for; `InitMapNameSign`
+## itself only decides and loads.
+func map_name_sign_pending() -> int:
+	return _map_name_sign
+
+
+func clear_map_name_sign() -> void:
+	_map_name_sign = MAP_NAME_SIGN_NO_LANDMARK
+
+
+## `InitMapNameSign`, which every map setup script but the submenu's reaches.
+##
+## The sign is Crystal's own screen: pokegold ships neither `MapEntryFrameGFX`
+## nor the routine, so the whole decision is skipped there. `wPrevLandmark` is
+## written on both branches, which is what makes a walk through a gate silent on
+## the way out as well as the way in.
+func _init_map_name_sign() -> void:
+	var current: int = map_name_sign_landmark()
+	var previous: int = _prev_landmark
+	_prev_landmark = current
+	_map_name_sign = MAP_NAME_SIGN_NO_LANDMARK
+	if not Gen2WorldState.is_crystal_profile(data):
+		return
+	## `.CheckMovingWithinLandmark`: the same landmark, or arriving from a map
+	## that had none.
+	if current == previous or previous == Gen2WorldRadio.LANDMARK_SPECIAL:
+		return
+	if current == MAP_NAME_SIGN_NO_LANDMARK \
+		or MAP_NAME_SIGN_SILENT_LANDMARKS.has(current):
+		return
+	_map_name_sign = current
 
 
 ## GetMapMusic_MaybeSpecial: SpecialMapMusic answers first, so a surfing player
@@ -5087,6 +5160,7 @@ func _apply_map(
 	# station: its own track is not this map's, so the comparison fails and the
 	# map's music wins.
 	_apply_map_music()
+	_init_map_name_sign()
 	_queue_map_callbacks(-1)
 	_map_entry_scene_pending = true
 	_map_entry_scene_ran = false

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -84,6 +84,11 @@ var _pending_headbutt_finish: Dictionary = {}
 ## empty on every other frame. The map swaps between the two stages, which is
 ## where the setup script's own list sits.
 var _map_fade: Dictionary = {}
+## `wLandmarkSignTimer` and the window the sign is drawn in. The map load decides
+## whether there is a sign (`Gen2WorldAPI.map_name_sign_pending`); the sixty
+## frames it stands for are spent here, like every other overworld countdown.
+var _map_name_sign: TextureRect = null
+var _map_name_sign_frames: int = 0
 var _text_box: Gen2TextBox = null
 var _clock: Gen2WorldClock = null
 var _audio_player: Gen2AudioPlayer = null
@@ -436,6 +441,11 @@ func advance_frame() -> void:
 	## Before everything the map draws: the fade owns the frame the map swaps on,
 	## and nothing else runs while `RunMapSetupScript` is spending its own.
 	_advance_map_fade()
+	## `RefreshMapSprites` runs inside the setup script and `PlaceMapNameSign`
+	## with the rest of the map's background, so a sign raised by the load this
+	## frame carried is spent from the next one.
+	_advance_map_name_sign()
+	_raise_map_name_sign()
 	if _effects != null:
 		if _effects.advance_frame() and _renderer != null:
 			_renderer.refresh()
@@ -921,8 +931,10 @@ func _after_player_move(movement: Dictionary) -> bool:
 			## `MapSetupScript_Connection`, which is the step itself rather than
 			## a warp: the neighbour's blocks are loaded under a camera that
 			## never stops, and its `FadeToMapMusic` is why crossing a route
-			## boundary into the same track is one continuous piece.
-			_animation.configure(_world, time_of_day)
+			## boundary into the same track is one continuous piece. It carries
+			## no `LoadMapGraphics` either, so the tile animation is re-pointed
+			## at the new tileset where it stands rather than restarted.
+			_animation.reload_tileset(_world, time_of_day)
 			_set_renderer_world()
 			_fade_to_map_music()
 		else:
@@ -3364,6 +3376,72 @@ func _show_story_picture(species: int) -> void:
 	)
 	_story_picture.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_screen.display(_story_picture)
+
+
+## How many of `wLandmarkSignTimer`'s sixty frames the sign has left, and zero
+## when there is none up. What a test or a screenshot tool waits on.
+func map_name_sign_frames() -> int:
+	return _map_name_sign_frames
+
+
+## `InitMapNameSign`'s own decision, raised where the map load leaves it: the
+## sign is a window over the bottom four rows and the map keeps moving behind it,
+## which is why a connection crossing shows one without stopping the camera.
+##
+## Gold and Silver ship neither the routine nor `MapEntryFrameGFX`, so the world
+## asks for no sign there and the page would answer none either.
+func _raise_map_name_sign() -> void:
+	if _world == null or _data == null:
+		return
+	var landmark: int = _world.map_name_sign_pending()
+	_world.clear_map_name_sign()
+	if landmark < 0:
+		return
+	_hide_map_name_sign()
+	## The timer is the setup script's, not the sheet's: a cache with no
+	## `MapEntryFrameGFX` spends the same sixty frames with nothing drawn in
+	## them rather than skipping them.
+	_map_name_sign_frames = Gen2WorldAPI.MAP_NAME_SIGN_FRAMES
+	var image: Image = Gen2MapNameSignPage.render(_data, _data.landmark_name(landmark))
+	if image == null:
+		return
+	_map_name_sign = TextureRect.new()
+	_map_name_sign.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_map_name_sign.texture = ImageTexture.create_from_image(image)
+	_map_name_sign.size = image.get_size()
+	_map_name_sign.position = Vector2(0, Gen2MapNameSignPage.TOP)
+	_map_name_sign.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	## `PlaceMapNameSign` returns on the frame the timer still reads 60, so the
+	## window is only brought down on the frame after the one that raised it.
+	_map_name_sign.visible = false
+	_screen.display(_map_name_sign)
+
+
+## `PlaceMapNameSign`, which counts `wLandmarkSignTimer` down a frame at a time
+## and takes the window away on the frame it runs out.
+func _advance_map_name_sign() -> void:
+	if _map_name_sign_frames <= 0:
+		return
+	## `PlayerEvents` zeroes the timer behind every player event but a connection
+	## crossing and a change of facing, neither of which runs a script: a text
+	## box, a trainer or a warp takes the sign down where it stands.
+	if _world != null and _world.script_busy():
+		_hide_map_name_sign()
+		return
+	_map_name_sign_frames -= 1
+	if _map_name_sign_frames <= 0:
+		_hide_map_name_sign()
+		return
+	if _map_name_sign != null:
+		_map_name_sign.visible = true
+
+
+func _hide_map_name_sign() -> void:
+	_map_name_sign_frames = 0
+	if _map_name_sign == null:
+		return
+	_map_name_sign.queue_free()
+	_map_name_sign = null
 
 
 ## `DisplayUnownWords`: the chamber wall's word in a box of its own, held by

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -165,3 +165,43 @@ func test_no_input_is_taken_while_the_warp_fade_runs() -> void:
 	assert_false(_screen.move_player(Vector2i.DOWN), "no step is taken")
 	assert_true(_screen.press_button(Gen2Button.A), "and A is swallowed rather than used")
 	assert_eq(_screen._world.player_cell, cell)
+
+
+## `InitMapNameSign` sits inside the same setup script: the warp crosses from the
+## map's own landmark into the house's, so a sign is raised, and
+## `PlaceMapNameSign` counts `wLandmarkSignTimer`'s sixty frames down behind it.
+func test_a_warp_into_another_landmark_raises_the_map_name_sign() -> void:
+	_screen = await _walk_onto_the_door()
+	assert_eq(_screen.map_name_sign_frames(), 0, "nothing is up while the fade runs")
+	for _frame: int in WALK_FRAME_CAP:
+		_screen.advance_frame()
+		if _screen.map_name_sign_frames() > 0:
+			break
+	assert_eq(
+		_screen.map_name_sign_frames(), Gen2WorldAPI.MAP_NAME_SIGN_FRAMES,
+		"the sign is raised once the map is loaded, with all sixty frames to spend"
+	)
+	for _frame: int in Gen2WorldAPI.MAP_NAME_SIGN_FRAMES - 1:
+		_screen.advance_frame()
+	assert_eq(_screen.map_name_sign_frames(), 1, "still up on its last frame")
+	_screen.advance_frame()
+	assert_eq(_screen.map_name_sign_frames(), 0, "and gone on the sixtieth")
+
+
+## `.CheckMovingWithinLandmark`: the map the world opens on is `wPrevLandmark`,
+## so walking back into the landmark just left raises nothing.
+func test_a_warp_back_into_the_same_landmark_raises_no_sign() -> void:
+	assert_eq(_world.map_name_sign_pending(), -1, "opening a world raises none")
+	var home: Gen2WorldMap = _data.world_map(
+		Gen2WorldSpawn.NEW_BARK_GROUP, Gen2WorldSpawn.PLAYERS_HOUSE_2F
+	)
+	_world._apply_map(
+		_data.world_map(Fixture.MAP_GROUP, Fixture.MAP_NUMBER),
+		_world.current_tileset, Vector2i(2, 2)
+	)
+	assert_eq(_world.map_name_sign_pending(), -1, "the same landmark, so no sign")
+	_world._apply_map(home, _data.world_tileset(home.tileset), Vector2i(1, 1))
+	assert_eq(
+		_world.map_name_sign_pending(), Fixture.HOME_MAP_LANDMARK,
+		"and the house's own landmark is what the sign names"
+	)

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -186,3 +186,25 @@ func test_tile_frames_answers_every_frame_in_order_without_moving_the_sequence()
 	assert_eq(animation.command_index(), at)
 	# A tile no command touches has no frames, rather than one of itself.
 	assert_eq(animation.tile_frames(1).size(), 0)
+
+
+func test_reload_tileset_keeps_the_place_a_connection_crossing_left() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world)
+	for _frame: int in 3:
+		animation.advance_frame()
+	var at: int = animation.command_index()
+	assert_ne(at, 0)
+
+	# `MapSetupScript_Connection` carries `LoadMapTileset` and no
+	# `LoadMapGraphics`, so nothing resets `hTileAnimFrame`: the neighbour's own
+	# command list is loaded where the sequence stands.
+	var neighbour := Gen2WorldAPI.open(data, 1, 2, Vector2i.ZERO)
+	animation.reload_tileset(neighbour)
+	assert_eq(animation.command_index(), at)
+	assert_eq(animation.tileset.number, 1)
+	# A warp is the other setup script and does reset it.
+	animation.configure(neighbour)
+	assert_eq(animation.command_index(), 0)

--- a/tools/checks/map_name_sign.gd
+++ b/tools/checks/map_name_sign.gd
@@ -1,0 +1,132 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies `InitMapNameSign` and its sign against freshly imported real caches:
+## every map on all three cartridges is asked what landmark it would raise, and
+## every name that answers is drawn through the same [Gen2MapNameSignPage] the
+## overworld displays.
+##
+## What a sampled map cannot say: the rule is three tests over the whole corpus
+## (`GATE`, the two National Park gates, and `.CheckSpecialMap`'s six landmarks),
+## and the sign is Crystal's own screen, so Gold and Silver must raise none at
+## all rather than draw one out of a sheet they do not ship.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- map_name_sign
+
+const TILE: int = Gen2Font.TILE
+const SIZE: Vector2i = Vector2i(
+	Gen2MapNameSignPage.COLUMNS * TILE, Gen2MapNameSignPage.ROWS * TILE
+)
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var maps: Array = _r.data.world_maps()
+	var silent: int = 0
+	var raising: Dictionary = {}
+	for map: Gen2WorldMap in maps:
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(
+			_r.data, map.group, map.number, Vector2i.ZERO
+		)
+		if world == null:
+			continue
+		var landmark: int = world.map_name_sign_landmark()
+		_check_landmark(map, landmark)
+		if not _raises(landmark):
+			silent += 1
+			continue
+		raising[landmark] = int(raising.get(landmark, 0)) + 1
+	if not _r.crystal:
+		_r.check(
+			_r.data.tile_indices("map_entry_sign").is_empty(),
+			"Gold and Silver ship no MapEntryFrameGFX, but the cache holds one."
+		)
+		_r.check(
+			Gen2MapNameSignPage.render(_r.data, "ROUTE 29") == null,
+			"a sign was drawn on a cartridge with no map name sign."
+		)
+	_check_signs(raising.keys())
+	_r.note("map name sign: %d of %d maps raise one, %d landmarks, %d silent" % [
+		maps.size() - silent, maps.size(), raising.size(), silent
+	])
+
+
+## `.CheckNationalParkGate` and the `GetMapEnvironment` test behind it, which are
+## the only two things that take a map's own landmark away.
+func _check_landmark(map: Gen2WorldMap, landmark: int) -> void:
+	var gate: bool = map.environment == Gen2WorldAPI.ENVIRONMENT_GATE \
+		or (map.group == Gen2WorldAPI.NATIONAL_PARK_GATE_GROUP
+			and Gen2WorldAPI.NATIONAL_PARK_GATE_MAPS.has(map.number))
+	if gate:
+		_r.check(
+			landmark == Gen2WorldAPI.MAP_NAME_SIGN_NO_LANDMARK,
+			"map %d/%d is a gate and still names landmark %d." % [
+				map.group, map.number, landmark
+			]
+		)
+		return
+	_r.check(
+		landmark == map.location,
+		"map %d/%d names landmark %d, not its own %d." % [
+			map.group, map.number, landmark, map.location
+		]
+	)
+
+
+## Whether a map arrived at from a different landmark would raise a sign, which
+## is `.CheckSpecialMap` once `.CheckMovingWithinLandmark` has been passed.
+func _raises(landmark: int) -> bool:
+	if not _r.crystal:
+		return false
+	return landmark != Gen2WorldAPI.MAP_NAME_SIGN_NO_LANDMARK \
+		and not Gen2WorldAPI.MAP_NAME_SIGN_SILENT_LANDMARKS.has(landmark)
+
+
+## Every landmark a map raises a sign for, drawn: the frame is the sheet's own
+## fourteen tiles and the name is centred on `hlcoord 0, 2`, so the row above it
+## must be blank interior and the name must sit inside the frame.
+func _check_signs(landmarks: Array) -> void:
+	for landmark: int in landmarks:
+		var name: String = _r.data.landmark_name(landmark)
+		if not _r.check(not name.is_empty(), "landmark %d has no name." % landmark):
+			continue
+		var image: Image = Gen2MapNameSignPage.render(_r.data, name)
+		if not _r.check(image != null, "landmark %d draws no sign." % landmark):
+			continue
+		if not _r.check(
+			image.get_size() == SIZE,
+			"landmark %d draws %s, not %s." % [landmark, image.get_size(), SIZE]
+		):
+			continue
+		var column: int = Gen2MapNameSignPage.name_column(name)
+		var blank: Color = image.get_pixel(TILE + 1, TILE + 1)
+		_r.check(
+			_ink(image, Rect2i(
+				Vector2i(column, Gen2MapNameSignPage.NAME_ROW) * TILE,
+				Vector2i(Gen2Text.encoded_length(name), 1) * TILE
+			), blank),
+			"landmark %d draws no name where PlaceMapNameCenterAlign puts it." % landmark
+		)
+		_r.check(
+			not _ink(image, Rect2i(
+				Vector2i(TILE, TILE), Vector2i((Gen2MapNameSignPage.COLUMNS - 2) * TILE, TILE)
+			), blank),
+			"landmark %d draws on the sign's upper interior row." % landmark
+		)
+		_r.check(
+			column + Gen2Text.encoded_length(name) <= Gen2MapNameSignPage.COLUMNS - 1,
+			"landmark %d's name runs into the frame's right edge." % landmark
+		)
+
+
+static func _ink(image: Image, area: Rect2i, blank: Color) -> bool:
+	for y: int in area.size.y:
+		for x: int in area.size.x:
+			if image.get_pixel(area.position.x + x, area.position.y + y) != blank:
+				return true
+	return false

--- a/tools/checks/map_name_sign.gd.uid
+++ b/tools/checks/map_name_sign.gd.uid
@@ -1,0 +1,1 @@
+uid://buex285h3pe4j

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -24,6 +24,9 @@ extends SceneTree
 ## warp tile named by the two numbers below it, and the picture is
 ## `FadeOutToWhite`'s last order, which is the frame the new map is loaded on:
 ## `crystal 24 7 ... warp 7 1` is the bedroom staircase),
+## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
+## map's edge onto its neighbour: `crystal 24 4 ... map_name_sign 1 8` crosses
+## New Bark Town into Route 29),
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
@@ -195,6 +198,18 @@ func _process(_delta: float) -> bool:
 				if StringName(fade.get("stage", &"")) == &"out" \
 					and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
 					break
+		elif _kind == &"map_name_sign":
+			## `MapSetupScript_Connection`'s `InitMapNameSign`: walked west off
+			## New Bark Town's edge onto Route 29, photographed while the sign
+			## the crossing raised is still up (`crystal 24 4 ... map_name_sign
+			## 0 6`). The camera and the tile animation both keep running behind
+			## it, which is the whole point of the row.
+			for _frame: int in WARP_FRAME_CAP:
+				_screen.move_left()
+				_screen.advance_frame()
+				if _screen.map_name_sign_frames() > 0 \
+					and _screen.map_name_sign_frames() < Gen2WorldAPI.MAP_NAME_SIGN_FRAMES:
+					break
 		elif _kind == &"pokepic":
 			_screen.preview_pokepic(POKEPIC_SPECIES)
 		elif FIELD_ITEMS.has(_kind):
@@ -210,9 +225,9 @@ func _process(_delta: float) -> bool:
 				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
-		if _kind != &"warp":
-			## The `warp` kind drove itself to the frame it wants; every other
-			## kind stages a sprite and then spends the frames it needs.
+		if _kind not in [&"warp", &"map_name_sign"]:
+			## Those two kinds drove themselves to the frame they want; every
+			## other kind stages a sprite and then spends the frames it needs.
 			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
 				_screen.advance_frame()
 	if _frames < 18:

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -33,7 +33,7 @@ const GROUPS: Dictionary = {
 	],
 	&"art": [
 		&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims",
-		&"overworld_effects", &"party_icons", &"pokepic",
+		&"overworld_effects", &"party_icons", &"pokepic", &"map_name_sign",
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",


### PR DESCRIPTION
InitMapNameSign is Crystal's own screen: pokegold ships neither the routine nor `MapEntryFrameGFX`, so the sheet is pinned and imported there alone (cache format 65) and nothing is raised on the other two profiles.

- `Gen2WorldAPI` carries `wPrevLandmark` and decides at every map load: a gate and the two National Park gates have no landmark, `.CheckSpecialMap`'s six are silent, and the map a world opens on is what the field starts as.
- `Gen2MapNameSignPage` is `PlaceMapNameFrame`'s four rows out of the sheet's fourteen tiles with `PlaceMapNameCenterAlign`'s centring; the host spends `wLandmarkSignTimer`'s sixty frames.
- `MapSetupScript_Connection` carries `LoadMapTileset` and no `LoadMapGraphics`, so `Gen2WorldAnimation.reload_tileset` re-points the strip and the command list without restarting the tile animation across a route boundary.

Checked: `validate.gd -- all` green over 52 topics, including the new `map_name_sign` sweep (341 of Crystal's 388 maps raise a sign over 90 landmarks; Gold and Silver none). GUT 3,078 tests green, `replay_world.gd` 30 routes 0 failures, the story walk 292/292/295 steps and sixteen badges on all three.