### PR TITLE
Crystal's intro movie is measured frame by frame

### DIFF
--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -240,13 +240,15 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	var image := Image.create(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
 	if movie == null:
 		return image
-	var behind: PackedByteArray = _draw_background(image, movie)
+	var background: Array = _draw_background(image, movie)
+	var behind: PackedByteArray = background[0]
+	var forced: PackedByteArray = background[1]
 	# The lower OAM index wins a pixel, so a slot only paints where no earlier
 	# one did.
 	var taken := PackedByteArray()
 	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):
-		_draw_sprite(image, movie, entry, behind, taken)
+		_draw_sprite(image, movie, entry, behind, forced, taken)
 	return image
 
 
@@ -298,13 +300,19 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 ## The BG map, sampled through `hSCY` and the scanline's own `hSCX`. Both are
 ## bytes and the map is 256 pixels square, so the sampling wraps rather than
 ## clipping.
-func _draw_background(image: Image, movie: Gen2IntroMovie) -> PackedByteArray:
+func _draw_background(image: Image, movie: Gen2IntroMovie) -> Array:
 	var behind := PackedByteArray()
+	# The same indices where the tile's own attribute carries the priority bit,
+	# which wins over every sprite rather than only over the ones marked
+	# `OAM_PRIO`. The panorama's grass row carries it, which is what puts the
+	# blades over Pichu's ears.
+	var forced := PackedByteArray()
 	var map: PackedByteArray = movie.bg_map()
 	var attr: PackedByteArray = movie.bg_attr()
 	if map.size() < RomLayout.INTRO_MAP_BYTES:
-		return behind
+		return [behind, forced]
 	behind.resize(WIDTH * HEIGHT)
+	forced.resize(WIDTH * HEIGHT)
 	var screen: PackedByteArray = movie.screen_tilemap()
 	var palettes: Array[PackedColorArray] = []
 	for slot: int in Gen2IntroMovie.BG_PALETTES:
@@ -355,15 +363,17 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> PackedByteArray:
 				bool(byte & ATTR_XFLIP), bool(byte & ATTR_YFLIP)
 			)
 			behind[y * WIDTH + x] = pixel
+			if byte & ATTR_PRIORITY != 0:
+				forced[y * WIDTH + x] = pixel
 			image.set_pixel(x, y, palette[pixel])
-	return behind
+	return [behind, forced]
 
 
 ## One shadow-OAM entry, off the sheet its struct was loaded into. The position
 ## is already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
 func _draw_sprite(
 	image: Image, movie: Gen2IntroMovie, entry: Dictionary,
-	behind: PackedByteArray, taken: PackedByteArray
+	behind: PackedByteArray, forced: PackedByteArray, taken: PackedByteArray
 ) -> void:
 	var tile: int = int(entry["tile"])
 	var strip: PackedByteArray = _sheet(
@@ -389,14 +399,15 @@ func _draw_sprite(
 		image, strip, palette, tile,
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
 		bool(entry["flip_x"]), bool(entry["flip_y"]), taken,
-		behind if bool(entry.get("priority", false)) else PackedByteArray()
+		behind if bool(entry.get("priority", false)) else forced
 	)
 
 
 ## [param taken] marks the pixels an earlier slot has already claimed, and
-## [param behind] is the background's own colour indices when the entry carries
-## `OAM_PRIO` and empty otherwise. The claim comes first: a sprite that loses the
-## pixel to the background still wins it against the sprites behind it.
+## [param behind] is the background's own colour indices: every one of them when
+## the entry carries `OAM_PRIO`, and only the tiles whose attribute carries the
+## priority bit otherwise. The claim comes first: a sprite that loses the pixel
+## to the background still wins it against the sprites behind it.
 func _blit_sprite_tile(
 	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
 	at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -318,6 +318,12 @@ func counter() -> int:
 	return _counter1
 
 
+## Whether this frame is one a setup scene's own `DelayFrames` debt is paid on;
+## see [method Gen2IntroMovie.waiting].
+func waiting() -> bool:
+	return _delay > 0
+
+
 ## `wIntroSpriteStateFlag`, which is what Jigglypuff waits on and the note stops
 ## on.
 func sprite_flag() -> bool:

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -258,6 +258,14 @@ var _scy: int = 0
 ## when [member _ly_active] is false, which is `hLCDCPointer` zero.
 var _ly: PackedByteArray = PackedByteArray()
 var _ly_active: bool = false
+## The same buffer as the *next* pass will have written it. `wLYOverrides` is
+## read live by `LCD` rather than DMA'd, so the screen this pass's sprites reach
+## carries the fill the pass after it makes; drawing the picture from `_ly`
+## leaves the perspective band two pixels behind everything else on it.
+## `Gen2TitleScene.line_offsets` is the same correction on the entrance.
+var _ly_shown: PackedByteArray = PackedByteArray()
+## The palette run a setup scene copies in once its decompressions are served.
+var _pending_palette: String = ""
 
 ## `wBGPals2`, eight palettes of four packed colours.
 var _palettes: PackedInt32Array = PackedInt32Array()
@@ -298,6 +306,7 @@ static func create(data: GameData, sine: Gen2BattleAnimData = null) -> Gen2Intro
 	out._data = data
 	out._sine = sine
 	out._ly.resize(SCREEN_HEIGHT_PX)
+	out._ly_shown.resize(SCREEN_HEIGHT_PX)
 	out._palettes.resize(PALETTES * PALETTE_COLORS)
 	return out
 
@@ -324,6 +333,15 @@ func counter() -> int:
 	return _counter
 
 
+## Whether this frame is one a setup scene's own `DelayFrames` debt is paid on.
+## The source spends them inside the setup scene's jumptable index and
+## `_setup_scene` has already stepped past it, so a trace lining these frames up
+## against a cartridge's own `wJumptableIndex` has to say which index each
+## belongs to (`tools/trace_opening_oam.gd`).
+func waiting() -> bool:
+	return _delay > 0
+
+
 ## `wIntroSceneTimer`, which `AnimSeq_GSTitleTrail` reads on Gold and Silver and
 ## `CrystalIntro_UnownFade` writes here.
 func timer() -> int:
@@ -340,9 +358,9 @@ func scroll() -> Vector2i:
 ## `VBlank_Cutscene` writes entry zero, which is why the first two lines share
 ## it.
 func scroll_x_at(line: int) -> int:
-	if not _ly_active or line < 0 or line >= _ly.size():
+	if not _ly_active or line < 0 or line >= _ly_shown.size():
 		return _scx
-	return _ly[maxi(line - 1, 0)]
+	return _ly_shown[maxi(line - 1, 0)]
 
 
 ## One background palette, as colours a page can draw with.
@@ -439,6 +457,9 @@ func advance_frame() -> Array[Dictionary]:
 	_frame += 1
 	if _delay > 0:
 		_delay -= 1
+		if _delay == 0 and not _pending_palette.is_empty():
+			_load_palettes(_pending_palette)
+			_pending_palette = ""
 		return drain_events()
 	_run_scene()
 	_run_sprites()
@@ -566,9 +587,15 @@ func _setup_scene() -> void:
 	_overlay = SCENE_OVERLAY.get(_scene, []) as Array
 	_scx = 0
 	_scy = 0
-	var name: String = String(SCENE_PALETTE.get(_scene, ""))
-	if not name.is_empty() and _data != null:
-		_load_palettes(name)
+	# The routine clears the palettes first and copies its own run in last, past
+	# every decompression, so the screen is that clear for the whole wait: black
+	# under `Intro_ClearBGPals` and white under `IntroScene26`'s
+	# `ClearBGPalettes`. Loading the run here instead shows the next scene forty
+	# to ninety frames before the cartridge does.
+	var cleared: int = WHITE if _scene == SCENE_CRYSTAL_UNOWNS else 0
+	for index: int in _palettes.size():
+		_palettes[index] = cleared
+	_pending_palette = String(SCENE_PALETTE.get(_scene, ""))
 	# `Intro_ClearBGPals` spends two `DelayFrame`s. `IntroScene26` is the one
 	# setup scene that calls `ClearBGPalettes` instead, whose `WaitBGMap` tail
 	# spends four. `ClearTilemap` then spends four of its own, and every sheet
@@ -649,7 +676,7 @@ func _scene_unown_hi() -> void:
 
 ## `IntroScene4`: `Intro_PerspectiveScrollBG` for $80 frames.
 func _scene_perspective_scroll() -> void:
-	_perspective_scroll()
+	_perspective_scroll(_counter != 0x80)
 	if _counter == 0x80:
 		_next_scene()
 		return
@@ -662,7 +689,7 @@ func _scene_suicune_runs_in() -> void:
 	var value: int = _counter
 	_counter = (_counter + 1) & 0xFF
 	if value < 0x40:
-		_perspective_scroll()
+		_perspective_scroll(value + 1 < 0x40)
 		return
 	if value == 0x40:
 		_emit(&"play_sfx", {"sfx": SFX_INTRO_SUICUNE_3})
@@ -871,7 +898,9 @@ func _scene_end() -> void:
 
 ## `Intro_PerspectiveScrollBG`: the trees scroll one pixel every other frame and
 ## the grass two every frame, which is what makes the ground look nearer.
-func _perspective_scroll() -> void:
+## [param again] is whether the pass after this one scrolls too, which is what
+## says how far ahead the screen this pass reaches already is.
+func _perspective_scroll(again: bool) -> void:
 	if _counter & 0x01 != 0:
 		var trees: int = (_ly[0] + 1) & 0xFF
 		for line: int in 0x5F:
@@ -880,11 +909,20 @@ func _perspective_scroll() -> void:
 	for offset: int in 0x31:
 		_ly[0x5F + offset] = grass
 	_scx = _ly[0]
+	var next_trees: int = (
+		(_ly[0] + 1) & 0xFF if again and (_counter + 1) & 0x01 != 0 else _ly[0]
+	)
+	var next_grass: int = (_ly[0x5F] + 2) & 0xFF if again else _ly[0x5F]
+	for line: int in 0x5F:
+		_ly_shown[line] = next_trees
+	for offset: int in 0x31:
+		_ly_shown[0x5F + offset] = next_grass
 
 
 func _reset_ly_overrides() -> void:
 	for line: int in _ly.size():
 		_ly[line] = 0
+		_ly_shown[line] = 0
 	_ly_active = true
 
 

--- a/tests/unit/test_intro_movie.gd
+++ b/tests/unit/test_intro_movie.gd
@@ -131,3 +131,55 @@ func test_a_button_ends_the_movie_and_the_music() -> void:
 func test_a_cache_without_the_art_does_not_offer_the_movie() -> void:
 	assert_false(Gen2IntroMovie.available(null))
 	assert_null(Gen2IntroMoviePage.from_data(null))
+
+
+## `Intro_PerspectiveScrollBG` writes `wLYOverrides`, which `LCD` reads live
+## rather than at VBlank, so the screen a pass's sprites reach already carries
+## the fill the pass after it makes. Reporting the live buffer instead leaves
+## the grass band two pixels behind everything drawn on it.
+func test_the_perspective_band_is_reported_a_pass_ahead() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	while movie.scene() != 3 and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+	while movie.waiting():
+		movie.advance_frame()
+	var band: Array[int] = []
+	for _pass: int in 4:
+		band.append(movie.scroll_x_at(96))
+		movie.advance_frame()
+	# The scene's own first pass has not run on the frame its delay ends; every
+	# pass after it is two pixels past the buffer it wrote.
+	assert_eq(band, [0, 4, 6, 8] as Array[int])
+	# The last pass has none after it, so the screen it reaches is the buffer as
+	# it stands: $81 passes of two pixels, wrapped.
+	var last: int = 0
+	while movie.scene() == 3 and movie.frame() < FRAME_CAP:
+		last = movie.scroll_x_at(96)
+		movie.advance_frame()
+	assert_eq(last, (0x81 * 2) & 0xFF)
+
+
+## A setup scene clears the palettes first and copies its own run in last, past
+## every decompression, so the whole wait is that clear rather than the scene it
+## is loading.
+func test_a_setup_scene_is_cleared_until_its_decompressions_are_served() -> void:
+	var movie: Gen2IntroMovie = _movie()
+	while not movie.waiting() and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+	assert_eq(movie.scene(), 1)
+	var waits: int = 0
+	while movie.waiting():
+		waits += 1
+		for slot: int in Gen2IntroMovie.BG_PALETTES:
+			for colour: Color in movie.palette(slot):
+				assert_eq(colour, Color.BLACK)
+		movie.advance_frame()
+	# `Intro_ClearBGPals` and `ClearTilemap` plus a frame per eight tiles of the
+	# scene's four sheets.
+	assert_eq(waits, 58)
+	# `IntroScene26` calls `ClearBGPalettes` instead, whose fill is white.
+	while movie.scene() != Gen2IntroMovie.SCENE_CRYSTAL_UNOWNS + 1 \
+			and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+	assert_true(movie.waiting())
+	assert_eq(movie.palette(0)[0], Color.WHITE)

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -16,8 +16,19 @@ extends SceneTree
 ## A line is `frame slot y x tile`, with `y` and `x` the OAM bytes: a cartridge's
 ## own buffer is read at the frame boundary, where hDMATransfer copies it.
 ##
+## Either movie also writes `<out>.state`, one `frame scene counter` line per
+## frame. That is the pair a cartridge's own `wJumptableIndex` and
+## `wIntroSceneFrameCounter` hold, and it is what aligns a pixel diff: a setup
+## scene's decompression overruns VBlank by three to twelve frames there and by
+## none here, so a per-scene offset is still several frames out inside the scene
+## and every frame of a fade compares against the wrong step of it. A frame
+## spending the setup's own delay is written under the setup scene's index,
+## which is where the source spends it.
+##
 ## A fourth argument writes the page's own picture for those frames, named after
 ## each, so the frame a diff points at can be looked at beside the emulator's.
+## It is a comma list, and an entry may be a `lo-hi` range, which is what a
+## per-frame pixel diff over a whole scene wants rather than a hand-listed set.
 ## The page draws into an `Image`, so this stays headless;
 ## `tools/preview_intro.gd` photographs the same screen through the boot
 ## cinema, whose frames count from the copyright rather than from this phase.
@@ -33,6 +44,8 @@ const MOVIE_FRAME_CAP: int = 4000
 ## Frames to write a PNG for, beside the trace's own output path.
 var _shots: Dictionary = {}
 var _shot_prefix: String = "res://presents"
+## `frame scene counter` per frame, for whichever phase keeps those.
+var _state := PackedStringArray()
 
 
 func _initialize() -> void:
@@ -52,7 +65,14 @@ func _initialize() -> void:
 		_shot_prefix = args[2].get_basename()
 	if args.size() > 3:
 		for value: String in args[3].split(","):
-			_shots[int(value)] = true
+			var dash: int = value.find("-", 1)
+			if dash < 0:
+				_shots[int(value)] = true
+				continue
+			for frame: int in range(
+				int(value.left(dash)), int(value.substr(dash + 1)) + 1
+			):
+				_shots[frame] = true
 	var lines: PackedStringArray
 	match args[1]:
 		"presents":
@@ -71,6 +91,10 @@ func _initialize() -> void:
 			return
 		file.store_string("\n".join(lines) + "\n")
 		print("%d lines to %s" % [lines.size(), args[2]])
+		if not _state.is_empty():
+			var states := FileAccess.open(args[2] + ".state", FileAccess.WRITE)
+			if states != null:
+				states.store_string("\n".join(_state) + "\n")
 	else:
 		print("\n".join(lines))
 	quit(0)
@@ -122,6 +146,7 @@ func _trace_intro(data: GameData) -> PackedStringArray:
 	var scene: int = -1
 	while not movie.finished() and frame < MOVIE_FRAME_CAP:
 		_append_frame(out, frame, page.shadow_oam(movie))
+		_append_state(frame, movie.scene(), movie.counter(), movie.waiting())
 		if _shots.has(frame):
 			page.draw(movie).save_png("%s_f%d.png" % [_shot_prefix, frame])
 		if movie.scene() != scene:
@@ -147,6 +172,7 @@ func _trace_gs_intro(data: GameData) -> PackedStringArray:
 	var scene: int = -1
 	while not movie.finished() and frame < MOVIE_FRAME_CAP:
 		_append_frame(out, frame, page.shadow_oam(movie))
+		_append_state(frame, movie.scene(), movie.counter(), movie.waiting())
 		if _shots.has(frame):
 			page.draw(movie).save_png("%s_f%d.png" % [_shot_prefix, frame])
 		if movie.scene() != scene:
@@ -185,6 +211,19 @@ func _trace_title(data: GameData) -> PackedStringArray:
 		frame += 1
 	print("frame %d: finished" % frame)
 	return out
+
+
+## A frame paying a setup scene's delay is written under the setup scene's own
+## index, which is the one the cartridge is still in while it spends it.
+func _append_state(frame: int, scene: int, counter: int, waiting: bool) -> void:
+	# A setup scene's counter is the previous scene's last value until the
+	# routine's own tail zeroes it, and the routine is spread over every
+	# `DelayFrame` its decompressions spend, so a waiting frame carries no
+	# counter to line up on and is written as -1.
+	_state.append(
+		"%d %d %d" % [frame, scene - 1, -1] if waiting
+		else "%d %d %d" % [frame, scene, counter]
+	)
 
 
 func _append_frame(out: PackedStringArray, frame: int, entries: Array[Dictionary]) -> void:


### PR DESCRIPTION
Every frame of both intro movies is now compared against the cartridge, aligned on the movie's own jumptable index and scene frame counter rather than on a per-scene offset. A setup scene overruns VBlank by three to twelve frames on hardware and by none here, so the scene body starts several frames apart and every frame of a fade was being compared against the wrong step of it.

Three defects came out of that, all visible on screen:

- **`wLYOverrides` is read live.** `LCD` reads the buffer where it stands during the frame the CPU wrote it in, so the screen a pass's sprites reach carries the fill the pass after it makes. `Intro_PerspectiveScrollBG`'s grass band was drawn from the buffer as it stood, two pixels behind everything else on the picture.
- **A setup scene showed the scene it was loading.** The routine clears the palettes first and copies its own run in last, past every decompression, so the whole wait is that clear: black under `Intro_ClearBGPals`, white under `IntroScene26`'s `ClearBGPalettes`. The next scene was appearing forty to ninety frames early at each of the ten transitions.
- **A BG tile attribute's priority bit was ignored**, so a sprite drew over the tiles that carry it rather than losing the pixel to them.

Crystal goes from 1,495 of 2,339 frames pixel exact to 2,127, with 16 of the rest accounted for by `UpdateBGMap`'s staged copy (every differing scanline is one this port drew a pass or two earlier). Gold and Silver measure 1,732 of 2,281, identically on both.

`tools/trace_opening_oam.gd` gains the scene and counter pair per frame beside the OAM trace, and takes a frame range rather than a hand-listed set.

GUT 3,080 over 150 scripts green, the real-cache check suite green on all three cartridges, boot smoke clean.