### PR TITLE
The start menu is the cartridge's own box over the map

### DIFF
--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -1,0 +1,153 @@
+class_name Gen2StartMenuPage
+extends RefCounted
+
+## `StartMenu`'s own box over the map, and the `_Option` screen behind it.
+##
+## Node-free presentation, like the other pages: geometry is [Gen2MenuBox]'s and
+## the models are [Gen2WorldStartMenu] and [Gen2WorldOptionsMenu]. The list is a
+## box in the top-right of the map with the map still showing around it, so it
+## is drawn as a transparent overlay; OPTION owns the whole screen.
+
+const TILE: int = Gen2Font.TILE
+## The hardware tile grid, which every page in here counts in.
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## `.MenuHeader`'s `menu_coords 10, 0, SCREEN_WIDTH - 1, SCREEN_HEIGHT - 1`, and
+## `.ContestMenuHeader`, which is the same box two rows down.
+const LIST_LEFT: int = 10
+const LIST_RIGHT: int = COLUMNS - 1
+const LIST_TOP: int = 0
+const LIST_CONTEST_TOP: int = 2
+## `.MenuData`'s own flags.
+const LIST_FLAGS: int = (
+	Gen2MenuBox.STATICMENU_CURSOR
+	| Gen2MenuBox.STATICMENU_WRAP
+	| Gen2MenuBox.STATICMENU_ENABLE_START
+)
+
+## `._DrawMenuAccount`'s `ClearBox` at `hlcoord 0, 13`, five rows of ten, and
+## `.PrintMenuAccount`'s `decoord 0, 14` for the description itself. There is no
+## frame around it: the routine clears the block and sets its palette, and the
+## words stand on the cleared tiles.
+const ACCOUNT_AT: Vector2i = Vector2i(0, 13)
+const ACCOUNT_SIZE: Vector2i = Vector2i(10, 5)
+const ACCOUNT_TEXT_ROW: int = 14
+
+## `_Option`'s `Textbox` at `hlcoord 0, 0` with `b = SCREEN_HEIGHT - 2` and
+## `c = SCREEN_WIDTH - 2`, which is a border around the whole screen.
+const OPTIONS_FIRST_ROW: int = 2
+const OPTIONS_LABEL_COLUMN: int = 2
+## `StringOptions`' own `"        :"` row under each label.
+const OPTIONS_COLON_COLUMN: int = 10
+## Every `hlcoord 11, n` in the file, and `UpdateFrame`'s digit lands on 16
+## because the value it draws opens with `TYPE `.
+const OPTIONS_VALUE_COLUMN: int = 11
+## `Options_UpdateCursorPosition` walks column 1 by two rows per option.
+const OPTIONS_CURSOR_COLUMN: int = 1
+
+var frame_style: int = 0
+var font: Gen2Font = null
+var menu: Gen2MenuPage = null
+
+
+static func from_data(data: GameData) -> Gen2StartMenuPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	var box: Gen2MenuPage = Gen2MenuPage.from_data(data)
+	if glyphs == null or box == null:
+		return null
+	var out := Gen2StartMenuPage.new()
+	out.font = glyphs
+	out.menu = box
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	return out
+
+
+## `AutomaticGetMenuBottomCoord`: the box grows downward by two rows an entry
+## plus its own border, so the header's bottom coordinate is never read.
+static func list_box(count: int, contest: bool = false) -> Gen2MenuBox:
+	var top: int = LIST_CONTEST_TOP if contest else LIST_TOP
+	return Gen2MenuBox.from_coords(
+		LIST_LEFT, top, LIST_RIGHT, top + 2 * maxi(count, 0) + 1, LIST_FLAGS
+	)
+
+
+## The menu over the map: the whole screen, transparent everywhere the map is
+## still showing. [param description] is `.MenuDesc`'s two lines and is drawn
+## only when MENU ACCOUNT is on, which is what `.IsMenuAccountOn` decides.
+func render_list(
+	labels: Array, cursor: int, description: String = "", contest: bool = false
+) -> Image:
+	if menu == null or font == null:
+		return null
+	var image: Image = Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	var box: Gen2MenuBox = list_box(labels.size(), contest)
+	var drawn: Image = menu.render(box, labels, cursor)
+	if drawn != null:
+		image.blit_rect(
+			drawn, Rect2i(Vector2i.ZERO, drawn.get_size()),
+			box.border_position() * TILE
+		)
+	if not description.is_empty():
+		var account: Image = _render_account(description)
+		if account != null:
+			image.blit_rect(
+				account, Rect2i(Vector2i.ZERO, account.get_size()), ACCOUNT_AT * TILE
+			)
+	return image
+
+
+## `_Option`'s whole screen: the border, `StringOptions` and each row's own
+## setting, with `Options_UpdateCursorPosition`'s arrow beside the chosen one.
+func render_options(rows: Array, cursor: int) -> Image:
+	if font == null:
+		return null
+	var indices := PackedByteArray()
+	indices.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	font.draw_box(
+		frame_style, indices, Gen2Screen.WIDTH, 0, 0,
+		COLUMNS, ROWS
+	)
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		var label_row: int = OPTIONS_FIRST_ROW + 2 * index
+		_text(indices, String(row.get("label", "")), OPTIONS_LABEL_COLUMN, label_row)
+		var value: String = String(row.get("value", ""))
+		if value.is_empty():
+			continue
+		_text(indices, ":", OPTIONS_COLON_COLUMN, label_row + 1)
+		_text(indices, value, OPTIONS_VALUE_COLUMN, label_row + 1)
+	if cursor >= 0 and cursor < rows.size():
+		font.draw_code(
+			Gen2MenuPage.CURSOR_CODE, indices, Gen2Screen.WIDTH,
+			OPTIONS_CURSOR_COLUMN * TILE, (OPTIONS_FIRST_ROW + 2 * cursor) * TILE
+		)
+	return Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _palette()
+	)
+
+
+## The account block, which is cleared tiles and two rows of words rather than a
+## box: `ClearBox` writes the source's own blank, which draws as index 0.
+func _render_account(description: String) -> Image:
+	var width: int = ACCOUNT_SIZE.x * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * ACCOUNT_SIZE.y * TILE)
+	var row: int = ACCOUNT_TEXT_ROW - ACCOUNT_AT.y
+	for line: String in description.split("\n"):
+		font.draw_text(line, indices, width, 0, row * TILE)
+		row += 1
+	return Gen2PicImage.from_indices(
+		indices, width, ACCOUNT_SIZE.y * TILE, _palette()
+	)
+
+
+func _text(indices: PackedByteArray, text: String, column: int, row: int) -> void:
+	font.draw_text(text, indices, Gen2Screen.WIDTH, column * TILE, row * TILE)
+
+
+## `PAL_BG_TEXT`, which is what every one of these boxes is drawn with.
+func _palette() -> PackedColorArray:
+	return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))

--- a/game/render/start_menu_page.gd.uid
+++ b/game/render/start_menu_page.gd.uid
@@ -1,0 +1,1 @@
+uid://byt5selculjy5

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -129,6 +129,18 @@ var _mod_cursor: int = 0
 var _mod_id: StringName = &""
 var _mod_option_cursor: int = 0
 
+## The cartridge's own screens, drawn into whichever [Gen2Screen] the host
+## handed over. `StartMenu`'s box sits over the map, so it goes into the world's
+## own screen rather than one of this node's; without one, the panel below
+## stands in, which is what a test or the launcher gets. The pack and its
+## modes are still the panel, and are the next row of `HANDOFF.md`'s table.
+var _screen: Gen2Screen = null
+var _view: TextureRect = null
+var _page: Gen2StartMenuPage = null
+## The panel's own two roots, hidden whenever a cartridge screen is up.
+var _scrim: ColorRect = null
+var _center: CenterContainer = null
+
 var _title: Label = null
 var _summary: Label = null
 var _options: VBoxContainer = null
@@ -245,16 +257,21 @@ func handle_button(button: int) -> bool:
 	## carry, so the dial takes the whole button rather than a direction and an
 	## A/B split, the way [Gen2WorldApricorn] feeds it.
 	if _mode == Mode.PACK_TOSS_QUANTITY:
-		return _press_toss_quantity(button)
+		var pressed: bool = _press_toss_quantity(button)
+		_render_hardware()
+		return pressed
 	if Gen2Button.is_direction(button):
 		_move(Gen2Button.vector(button))
+		_render_hardware()
 		return true
 	match button:
 		Gen2Button.A:
 			_confirm()
+			_render_hardware()
 			return true
 		Gen2Button.B:
 			_cancel()
+			_render_hardware()
 			return true
 	return false
 
@@ -1513,10 +1530,12 @@ func _build_ui() -> void:
 	scrim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	scrim.mouse_filter = Control.MOUSE_FILTER_STOP
 	add_child(scrim)
+	_scrim = scrim
 
 	var center := CenterContainer.new()
 	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	add_child(center)
+	_center = center
 	var panel := PanelContainer.new()
 	panel.custom_minimum_size = Vector2(420, 320)
 	panel.add_theme_stylebox_override("panel", _panel_style())
@@ -1561,7 +1580,82 @@ func _build_ui() -> void:
 	content.add_child(_footer)
 
 
+## The screen `StartMenu`'s own box is drawn into. The world hands over the one
+## the map is already in, so the box stands over it the way the map name sign
+## does; a caller that hands over none keeps the panel.
+func set_screen(screen: Gen2Screen) -> void:
+	_screen = screen
+	if _screen == null or _view != null:
+		return
+	_view = TextureRect.new()
+	_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_screen.display(_view)
+	_render_hardware()
+
+
+## Frees the overlay, since it lives in a screen this node does not own.
+func _exit_tree() -> void:
+	if _view != null:
+		_view.queue_free()
+		_view = null
+
+
+## Whichever of the cartridge's screens this mode is, or nothing for a mode that
+## is still the panel.
+func _render_hardware() -> void:
+	if _view == null:
+		return
+	var image: Image = _hardware_image()
+	_view.visible = image != null
+	if _scrim != null:
+		_scrim.visible = image == null
+	if _center != null:
+		_center.visible = image == null
+	if image == null:
+		return
+	_view.texture = ImageTexture.create_from_image(image)
+
+
+func _hardware_image() -> Image:
+	if _data == null:
+		return null
+	if _page == null:
+		_page = Gen2StartMenuPage.from_data(_data)
+	if _page == null:
+		return null
+	match _mode:
+		Mode.LIST:
+			if _menu == null:
+				return null
+			var labels: Array = []
+			for entry: Variant in _menu.items():
+				labels.append(String((entry as Dictionary).get("label", "")))
+			## `.PrintMenuAccount` reads the option on every cursor move, so
+			## turning MENU ACCOUNT off takes the block away at once.
+			var description: String = _menu.selected_description() \
+				if Gen2OptionsStore.current().menu_account else ""
+			return _page.render_list(
+				labels, _menu.cursor, description,
+				_world != null and _world.bug_contest_active()
+			)
+		Mode.OPTIONS:
+			if _options_menu == null:
+				return null
+			return _page.render_options(_options_menu.rows(), _options_menu.cursor)
+		Mode.MODS:
+			## Not a cartridge screen: this project's own list, in `_Option`'s
+			## own shape so the two do not look like different games.
+			var rows: Array = []
+			for id: StringName in _mod_ids:
+				rows.append({"label": _mod_name(id), "value": ""})
+			return _page.render_options(rows, _mod_cursor)
+	return null
+
+
 func _render_options(values: Array, cursor: int, label_for: Callable) -> void:
+	_render_hardware()
 	if _pack_view != null:
 		_pack_view.visible = false
 	if _options == null:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1530,6 +1530,22 @@ func preview_start_menu() -> void:
 	_start_menu_host.handle_button(Gen2Button.DOWN)
 
 
+## Public screenshot driver for `_Option`, which is what the start menu's own
+## OPTION row opens. One call, since the picture wanted is the settings screen
+## and not the row that reaches it.
+func preview_options() -> void:
+	if _world == null or _data == null:
+		return
+	if _start_menu_host == null:
+		_injected_save = _embedded_party_save()
+		_open_start_menu()
+	if _start_menu_host == null:
+		return
+	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_OPTION:
+		_start_menu_host.handle_button(Gen2Button.DOWN)
+	_start_menu_host.handle_button(Gen2Button.A)
+
+
 ## Public screenshot driver for `TossMenu`. Grants a stack on an injected save
 ## so nothing persists, then advances one menu step per call: Pack, the item,
 ## TOSS, the quantity dial, the yes/no and the result.
@@ -2268,6 +2284,9 @@ func _open_start_menu_host(entry: Callable) -> void:
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 20
 	add_child(host)
+	## `StartMenu`'s box stands over the map, so it is drawn into the screen the
+	## map is already in rather than into one of the host's own.
+	host.set_screen(_screen)
 	host.action_chosen.connect(_on_start_menu_action)
 	host.closed.connect(_on_start_menu_closed)
 	host.field_item_used.connect(_on_field_item_used)

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -49,15 +49,19 @@ const GATE_POKEGEAR: StringName = &"pokegear"
 ## host's registered entries can be spliced in without the order becoming a
 ## question. EXIT stays last: it is what closes the menu, and the source never
 ## puts anything after it.
+## The labels are `.PokedexString` and its siblings verbatim, which is what the
+## box over the map prints. `#` is the charmap's own $54 and expands to "POKe";
+## `<PLAYER>`, which the source's own `.StatusString` is, is filled in by
+## [method build] because `PlaceString` reads `wPlayerName` for it.
 const SOURCE_ENTRIES: Array[Dictionary] = [
-	{"kind": ITEM_POKEDEX, "label": "Pokedex", "available": true, "gate": GATE_POKEDEX},
-	{"kind": ITEM_POKEMON, "label": "Pokemon", "available": true, "gate": GATE_PARTY},
-	{"kind": ITEM_PACK, "label": "Pack", "available": true, "gate": &""},
-	{"kind": ITEM_POKEGEAR, "label": "Pokegear", "available": true, "gate": GATE_POKEGEAR},
-	{"kind": ITEM_PLAYER, "label": "Player", "available": true, "gate": &""},
-	{"kind": ITEM_SAVE, "label": "Save", "available": true, "gate": &""},
-	{"kind": ITEM_OPTION, "label": "Options", "available": true, "gate": &""},
-	{"kind": ITEM_EXIT, "label": "Exit", "available": true, "gate": &""},
+	{"kind": ITEM_POKEDEX, "label": "#DEX", "available": true, "gate": GATE_POKEDEX},
+	{"kind": ITEM_POKEMON, "label": "#MON", "available": true, "gate": GATE_PARTY},
+	{"kind": ITEM_PACK, "label": "PACK", "available": true, "gate": &""},
+	{"kind": ITEM_POKEGEAR, "label": "<POKE>GEAR", "available": true, "gate": GATE_POKEGEAR},
+	{"kind": ITEM_PLAYER, "label": "<PLAYER>", "available": true, "gate": &""},
+	{"kind": ITEM_SAVE, "label": "SAVE", "available": true, "gate": &""},
+	{"kind": ITEM_OPTION, "label": "OPTION", "available": true, "gate": &""},
+	{"kind": ITEM_EXIT, "label": "EXIT", "available": true, "gate": &""},
 ]
 
 ## `.Items`' third column, the one MENU ACCOUNT draws under the list
@@ -80,6 +84,7 @@ static func build(
 	pokedex_obtained: bool,
 	pokegear_obtained: bool,
 	previous_cursor: int = 0,
+	player_name: String = "",
 ) -> Gen2WorldStartMenu:
 	var menu := Gen2WorldStartMenu.new()
 	var passes: Dictionary = {
@@ -96,8 +101,16 @@ static func build(
 			if not Gen2ModHost.instance().option_mod_ids().is_empty():
 				items.append(_entry(ITEM_MODS, "Mods", true))
 			items.append_array(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START))
+		var label: String = String(entry["label"])
+		## `PlaceString` reads `wPlayerName` for `<PLAYER>`, so the STATUS row
+		## says the player's own name and never those eight characters.
+		## A world with no save selected has no name to read, which is a
+		## screenshot tool or a test rather than a game: the row says PLAYER
+		## rather than printing the marker's own characters.
+		if entry["kind"] == ITEM_PLAYER:
+			label = player_name if not player_name.is_empty() else "PLAYER"
 		items.append(_entry(
-			StringName(entry["kind"]), String(entry["label"]), bool(entry["available"])
+			StringName(entry["kind"]), label, bool(entry["available"])
 		))
 	menu._items = items
 	menu.cursor = clampi(previous_cursor, 0, maxi(items.size() - 1, 0))
@@ -116,6 +129,7 @@ static func from_world(world: Gen2WorldAPI, previous_cursor: int = 0) -> Gen2Wor
 		world.state.is_engine_flag_active(ENGINE_POKEDEX),
 		world.state.is_engine_flag_active(ENGINE_POKEGEAR),
 		previous_cursor,
+		world.player_name(),
 	)
 	menu.load_descriptions(world.data)
 	return menu
@@ -132,7 +146,9 @@ func load_descriptions(data: GameData) -> void:
 		var kind: StringName = StringName(entry.get("kind", &""))
 		var text: String = data.menu_description(kind)
 		if not text.is_empty():
-			_descriptions[kind] = text.replace("\n", " ")
+			## Kept as the two rows `.MenuDesc`'s own `next` places, since the
+			## account block is ten tiles wide and no line of it fits on one.
+			_descriptions[kind] = text
 
 
 static func _entry(kind: StringName, label: String, available: bool) -> Dictionary:

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -193,3 +193,28 @@ func test_mods_appears_only_for_a_mod_that_registered_a_setting() -> void:
 	])
 	assert_true(bool(menu.items()[4].get("available", false)))
 	Gen2ModHost.reset()
+
+
+## `.PokedexString` and its siblings, which are what the box over the map
+## prints, and the name `PlaceString` reads for `<PLAYER>`.
+func test_the_labels_are_the_source_strings_with_the_player_name_filled_in() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true, 0, "GOLD")
+	var labels: Array = []
+	for entry: Variant in menu.items():
+		labels.append(String((entry as Dictionary).get("label", "")))
+	assert_eq(labels, [
+		"#DEX", "#MON", "PACK", "<POKE>GEAR", "GOLD", "SAVE", "OPTION", "EXIT",
+	])
+	## A world with no save selected has no name to read.
+	assert_eq(String(Gen2WorldStartMenu.build(0, false, false).items()[1]["label"]), "PLAYER")
+
+
+## `AutomaticGetMenuBottomCoord` grows the box downward by two rows an entry and
+## its own border, so `.MenuHeader`'s bottom coordinate is never read;
+## `.ContestMenuHeader` is the same box two rows down.
+func test_the_box_grows_downward_by_two_rows_an_entry() -> void:
+	var five: Gen2MenuBox = Gen2StartMenuPage.list_box(5)
+	assert_eq(five.border_position(), Vector2i(10, 0))
+	assert_eq(five.border_size(), Vector2i(10, 12))
+	assert_eq(Gen2StartMenuPage.list_box(8).border_size(), Vector2i(10, 18))
+	assert_eq(Gen2StartMenuPage.list_box(5, true).border_position(), Vector2i(10, 2))


### PR DESCRIPTION
Third row of `HANDOFF.md`'s "in-game screens that are still Godot panels" table, after `pokepic` and the mart. The model was already the source's and already tested, so this is a `render/*_page.gd` and a host pointed at it.

`Gen2StartMenuPage` draws:

- **The list** where `StartMenu` puts it: column 10 to the right edge, sized by `AutomaticGetMenuBottomCoord` (two rows an entry plus its border) rather than by the header's bottom coordinate, with `.ContestMenuHeader`'s two-row drop.
- **`._DrawMenuAccount`'s block** under it, which is ten tiles of *cleared* tiles and two rows of words rather than a framed box, drawn only while MENU ACCOUNT is on.
- **OPTION**, which is `_Option`'s whole screen: the border, `StringOptions` at column 2 with its own colon row under each label, every setting at column 11, and `Options_UpdateCursorPosition`'s arrow walking column 1 by two rows. MODS is not a cartridge screen and borrows that shape.

The rows are the cartridge's strings now (`#DEX` through `EXIT`), and the STATUS row is the player's own name, which is what `PlaceString` reads `wPlayerName` for. `.MenuDesc`'s two lines are kept as two: no line of a description fits in ten tiles on one, and the panel was flattening them.

The overlay goes into the world's own `Gen2Screen`, the way the map name sign does, so the map is still drawn around it. A caller that hands over no screen keeps the panel, which is what the pack's own modes are still drawn with; SAVE is the one mode of this screen left, and stays in that table.

`preview_world.gd`'s `start_menu` kind and a new `options` kind photograph both.

GUT 3,082 over 150 scripts green, `validate.gd -- all` clean on all three cartridges, boot smoke clean.