### PR TITLE
The start menu's SAVE row is SaveMenu's own screen

### DIFF
--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 65
+const FORMAT_VERSION: int = 66
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -2890,7 +2890,46 @@ static func verify_font(rom: RomFile, layout: Dictionary) -> Dictionary:
 		if rom.u8(offset + i) == 0xFF:
 			return {"ok": false, "message": "Font: solid row at byte %d; not font data." % i}
 
+	return verify_font_extra(rom, layout)
+
+
+## `FontExtra` has no address of its own: it is the entry before `Font` in
+## `gfx/font.asm`, so it is checked by what it draws. Every code
+## `_LoadFontsExtra1` puts on screen is a glyph, and the ellipsis is one row of
+## three dots on the seventh, which no neighbouring sheet read a tile early or
+## late reproduces.
+static func verify_font_extra(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var offset: int = RomLayout.font_extra_offset(layout)
+	if not rom.in_bounds(offset, RomLayout.FONT_EXTRA_TILES * Gen2Tiles.TILE_BYTES):
+		return {"ok": false, "message": "FontExtra runs past the end of the dump."}
+
+	for code: int in range(
+		RomLayout.FONT_EXTRA_LOADED_FIRST, RomLayout.FONT_EXTRA_LOADED_LAST + 1
+	):
+		if _extra_glyph_rows(rom, offset, code).count(0) == Gen2Tiles.TILE_1BPP_BYTES:
+			return {
+				"ok": false,
+				"message": "FontExtra: code $%02X has no glyph." % code,
+			}
+
+	var ellipsis: Array[int] = _extra_glyph_rows(rom, offset, Gen2Text.ELLIPSIS_CODE)
+	if ellipsis[6] == 0 or ellipsis.count(0) != Gen2Tiles.TILE_1BPP_BYTES - 1:
+		return {
+			"ok": false,
+			"message": "FontExtra: $%02X is not the ellipsis." % Gen2Text.ELLIPSIS_CODE,
+		}
+
 	return {"ok": true, "message": ""}
+
+
+## One 2bpp tile of `FontExtra` as eight row masks, a set bit per lit pixel.
+static func _extra_glyph_rows(rom: RomFile, offset: int, code: int) -> Array[int]:
+	var at: int = offset \
+		+ (code - RomLayout.FONT_EXTRA_FIRST_CODE) * Gen2Tiles.TILE_BYTES
+	var rows: Array[int] = []
+	for row: int in Gen2Tiles.TILE_1BPP_BYTES:
+		rows.append(rom.u8(at + 2 * row) | rom.u8(at + 2 * row + 1))
+	return rows
 
 
 ## Ink in the tile for one character code, in pixels.
@@ -5021,6 +5060,12 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"tiles": RomLayout.FONT_TILES,
 			"first_code": RomLayout.FONT_FIRST_CODE,
 			"bits": 1,
+		},
+		"font_extra": {
+			"offset": RomLayout.font_extra_offset(layout),
+			"tiles": RomLayout.FONT_EXTRA_TILES,
+			"first_code": RomLayout.FONT_EXTRA_FIRST_CODE,
+			"bits": 2,
 		},
 		"frames": {
 			"offset": RomLayout.frame_offset(layout, 0),

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -549,6 +549,20 @@ const FONT_INK_RUNS: Array = [[0x80, 0x99], [0xA0, 0xB9], [0xF6, 0xFF]]
 ## three agree on are checked.
 const FONT_BLANK_RUNS: Array = [[0xBA, 0xBF], [0xC6, 0xCF], [0xD7, 0xDE]]
 
+## `FontExtra`, the 2bpp sheet `_LoadFontsExtra1` parks under the main font.
+## Thirty-two tiles stored, of which it copies `FontExtra + 3 tiles` to
+## `vTiles2 tile '<BOLD_D>'` for 22, so a tile is addressed by its code minus
+## $60 and the run that reaches the screen is $63 to $78. That run carries the
+## ellipsis, the two quotes, the middle dot and `<COLON>`, which is every
+## character [Gen2Text] decodes below the main font's own $80 and the reason a
+## text saying "…" drew nothing without it. Codes $60 to $62 are overwritten by
+## `FontsExtra_SolidBlackGFX`, `FontsExtra2_UpArrowGFX` and
+## `PokegearPhoneIconGFX` and are stored but never drawn from here.
+const FONT_EXTRA_TILES: int = 32
+const FONT_EXTRA_FIRST_CODE: int = 0x60
+const FONT_EXTRA_LOADED_FIRST: int = 0x63
+const FONT_EXTRA_LOADED_LAST: int = 0x78
+
 ## Text box borders: eight frames of six tiles, in the order ┌ ─ ┐ │ └ ┘, loaded
 ## at code $79 where [Gen2Text]'s box-drawing codes start, so a box is drawn by
 ## printing characters like anything else.
@@ -2846,6 +2860,13 @@ static func landmark_name_offset(rom: RomFile, layout: Dictionary, index: int) -
 
 static func font_offset(layout: Dictionary) -> int:
 	return int(layout["font"])
+
+
+## `FontExtra` is the entry immediately before `Font` in `gfx/font.asm` on all
+## three dumps, so the pinned font offset walks it too and it needs no address
+## of its own. Its own content is what checks that (`verify_layout`).
+static func font_extra_offset(layout: Dictionary) -> int:
+	return font_offset(layout) - FONT_EXTRA_TILES * Gen2Tiles.TILE_BYTES
 
 
 ## Frames are stored back to back in selection order, six tiles of 1bpp each.

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -44,6 +44,11 @@ const BATTLE_EXTRA_CHARACTERS: Dictionary = {
 ## is a character under the main font as well.
 const UP_ARROW_CODE: int = 0x61
 
+## `charmap.asm`'s "…", the one code in that run source text writes as itself.
+## `_LoadFontsExtra1` is what puts a tile under it, which is why the importer
+## checks this one glyph by shape (`RomImporter.verify_font_extra`).
+const ELLIPSIS_CODE: int = 0x75
+
 ## The lowest code with a tile. Below it is a space, border, control code or a
 ## print-time name, so it is also the line between [method encode]'s range and
 ## what only [method decode] understands.
@@ -219,7 +224,7 @@ static func _characters() -> Dictionary:
 	table[0x72] = "“"
 	table[0x73] = "”"
 	table[0x74] = "·"
-	table[0x75] = "…"
+	table[ELLIPSIS_CODE] = "…"
 	table[0x79] = "┌"
 	table[0x7A] = "─"
 	table[0x7B] = "┐"
@@ -304,7 +309,7 @@ static func _encodings() -> Dictionary:
 	# writes the character itself (Text_MoveForgetCount's "1, 2 and…"), so a line
 	# quoting that wording has to encode it. $56 is "……" and stays decode-only,
 	# two $75s drawing the same thing.
-	out["…"] = 0x75
+	out["…"] = ELLIPSIS_CODE
 
 	_codes = out
 	return _codes

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -38,6 +38,13 @@ var _battle_extra: PackedByteArray = PackedByteArray()
 var _battle_extra_width: int = 0
 var _battle_extra_tiles: int = 0
 
+## `FontExtra`, which `_LoadFontsExtra1` parks under the main font's own $80
+## floor: the ellipsis, the two quotes, the middle dot and `<COLON>` all draw
+## from here, and nothing else in this project can draw them.
+var _extra: PackedByteArray = PackedByteArray()
+var _extra_width: int = 0
+var _extra_tiles: int = 0
+
 
 ## Reads both sheets out of a cache, or null if that cache has no font in it.
 static func from_data(data: GameData) -> Gen2Font:
@@ -66,6 +73,12 @@ static func from_data(data: GameData) -> Gen2Font:
 	out._battle_extra = data.tile_indices("battle_font")
 	out._battle_extra_width = int(battle_extra.get("width", 0))
 	out._battle_extra_tiles = int(battle_extra.get("tiles", 0))
+
+	# Optional for the same reason.
+	var extra: Dictionary = data.tile_sheet("font_extra")
+	out._extra = data.tile_indices("font_extra")
+	out._extra_width = int(extra.get("width", 0))
+	out._extra_tiles = int(extra.get("tiles", 0))
 
 	return out if out.is_usable() else null
 
@@ -104,6 +117,14 @@ func draw_code(
 		if within < 0 or within >= _battle_extra_tiles:
 			return
 		blit_slot(_battle_extra, _battle_extra_width, within, into, into_width, at_x, at_y)
+		return
+	# `_LoadFontsExtra1`'s own run, which is under the main font everywhere the
+	# battle's strip is not: a code below the font's $80 draws from FontExtra.
+	if code >= RomLayout.FONT_EXTRA_LOADED_FIRST \
+		and code <= RomLayout.FONT_EXTRA_LOADED_LAST:
+		var extra_slot: int = code - RomLayout.FONT_EXTRA_FIRST_CODE
+		if extra_slot < _extra_tiles:
+			blit_slot(_extra, _extra_width, extra_slot, into, into_width, at_x, at_y)
 		return
 	var slot: int = code - _first_code
 	if slot < 0 or slot >= _glyph_tiles:

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -1,7 +1,8 @@
 class_name Gen2StartMenuPage
 extends RefCounted
 
-## `StartMenu`'s own box over the map, and the `_Option` screen behind it.
+## `StartMenu`'s own box over the map, the `_Option` screen behind it, and
+## `SaveMenu`'s three boxes over the map as well.
 ##
 ## Node-free presentation, like the other pages: geometry is [Gen2MenuBox]'s and
 ## the models are [Gen2WorldStartMenu] and [Gen2WorldOptionsMenu]. The list is a
@@ -46,6 +47,48 @@ const OPTIONS_VALUE_COLUMN: int = 11
 ## `Options_UpdateCursorPosition` walks column 1 by two rows per option.
 const OPTIONS_CURSOR_COLUMN: int = 1
 
+## `DisplaySaveInfoOnSave`'s `lb de, 4, 0` through `_OffsetMenuHeader`, which
+## keeps `menu_coords 0, 0, 15, 9`'s span and moves its left edge to column 4.
+const SAVE_INFO_LEFT: int = 4
+const SAVE_INFO_TOP: int = 0
+const SAVE_INFO_RIGHT: int = 19
+const SAVE_INFO_BOTTOM: int = 9
+## `.MenuData_Dex`'s own `db 0`: no cursor, no title and the ordinary top
+## spacing, so the four rows start at (5, 2) and step two.
+const SAVE_INFO_FLAGS: int = 0
+## `Continue_DisplayBadgesDexPlayerName`'s three `decoord`s and
+## `Continue_PrintGameTime`'s, each an offset from `MenuBoxCoord2Tile`'s corner
+## and so four columns right of what the source writes.
+const SAVE_NAME_AT: Vector2i = Vector2i(SAVE_INFO_LEFT + 8, 2)
+const SAVE_BADGES_AT: Vector2i = Vector2i(SAVE_INFO_LEFT + 13, 4)
+const SAVE_DEX_AT: Vector2i = Vector2i(SAVE_INFO_LEFT + 12, 6)
+const SAVE_TIME_AT: Vector2i = Vector2i(SAVE_INFO_LEFT + 9, 8)
+## Each value's `PrintNum` width: `lb bc, 1, 2` for the badges, `1, 3` for the
+## dex count and `2, 3` then `PRINTNUM_LEADINGZEROS | 1, 2` for the timer.
+const SAVE_BADGE_CELLS: int = 2
+const SAVE_DEX_CELLS: int = 3
+const SAVE_HOUR_CELLS: int = 3
+
+## `SpeechTextbox`: `hlcoord 0, 12` with `TEXTBOX_INNERH`/`TEXTBOX_INNERW`, and
+## `PrintText`'s own two rows inside it.
+const SAVE_TEXTBOX_AT: Vector2i = Vector2i(0, 12)
+const SAVE_TEXTBOX_SIZE: Vector2i = Vector2i(20, 6)
+const SAVE_TEXT_AT: Vector2i = Vector2i(1, 14)
+const SAVE_TEXT_SPACING: int = 2
+## How many of a text's lines the box shows at once, which is what makes
+## `_ContText` a scroll rather than a third row.
+const SAVE_TEXT_ROWS: int = 2
+
+## `SaveTheGame_yesorno`'s `lb bc, 0, 7` into `_YesNoBox`, which stores the left
+## coordinate, adds 5 for the right, the top, and adds 4 for the bottom.
+## `YesNoMenuHeader.MenuData` is where the flags and the two strings come from.
+const SAVE_YES_NO_AT: Vector2i = Vector2i(0, 7)
+const SAVE_YES_NO_SPAN: Vector2i = Vector2i(5, 4)
+const SAVE_YES_NO_FLAGS: int = (
+	Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+)
+const SAVE_YES_NO_OPTIONS: Array[String] = ["YES", "NO"]
+
 var frame_style: int = 0
 var font: Gen2Font = null
 var menu: Gen2MenuPage = null
@@ -84,19 +127,113 @@ func render_list(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
 	var box: Gen2MenuBox = list_box(labels.size(), contest)
-	var drawn: Image = menu.render(box, labels, cursor)
-	if drawn != null:
-		image.blit_rect(
-			drawn, Rect2i(Vector2i.ZERO, drawn.get_size()),
-			box.border_position() * TILE
-		)
+	_blit(image, menu.render(box, labels, cursor), box.border_position())
 	if not description.is_empty():
-		var account: Image = _render_account(description)
-		if account != null:
-			image.blit_rect(
-				account, Rect2i(Vector2i.ZERO, account.get_size()), ACCOUNT_AT * TILE
-			)
+		_blit(image, _render_account(description), ACCOUNT_AT)
 	return image
+
+
+## `SaveMenu`'s screen: `DisplaySaveInfoOnSave`'s box in the top-right,
+## `SpeechTextbox` at the foot, and `PlaceYesNoBox`'s own box on the left when a
+## question is up. Transparent everywhere else, since the map stays behind it.
+##
+## [param state] is what [Gen2StartMenuScreen] holds:
+##
+## [codeblock]
+## {
+##   "player_name": String,
+##   "badges": int,
+##   "pokedex": bool,     # STATUSFLAGS_POKEDEX_F, which blanks the #DEX row
+##   "caught": int,
+##   "hours": int, "minutes": int,
+##   "lines": Array,      # the text's own lines, whole
+##   "line": int,         # which of them is on the box's top row
+##   "cursor": int,       # -1 while no yes/no box is up
+## }
+## [/codeblock]
+func render_save(state: Dictionary) -> Image:
+	if menu == null or font == null:
+		return null
+	var image: Image = Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	_blit(image, _render_save_info(state), Vector2i(SAVE_INFO_LEFT, SAVE_INFO_TOP))
+	_blit(image, _render_save_textbox(state), SAVE_TEXTBOX_AT)
+	var cursor: int = int(state.get("cursor", -1))
+	if cursor >= 0:
+		var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+			SAVE_YES_NO_AT.x, SAVE_YES_NO_AT.y,
+			SAVE_YES_NO_AT.x + SAVE_YES_NO_SPAN.x,
+			SAVE_YES_NO_AT.y + SAVE_YES_NO_SPAN.y, SAVE_YES_NO_FLAGS
+		)
+		_blit(image, menu.render(box, SAVE_YES_NO_OPTIONS, cursor), SAVE_YES_NO_AT)
+	return image
+
+
+## `Continue_LoadMenuHeader`'s four rows and the three values
+## `Continue_DisplayBadgesDexPlayerName` prints over them. `.MenuData_NoDex`
+## blanks the third row's label, and `Continue_DisplayPokedexNumCaught` returns
+## before its own `PrintNum`, so a player without the Pokedex is shown neither.
+func _render_save_info(state: Dictionary) -> Image:
+	var dex: bool = bool(state.get("pokedex", false))
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		SAVE_INFO_LEFT, SAVE_INFO_TOP, SAVE_INFO_RIGHT, SAVE_INFO_BOTTOM,
+		SAVE_INFO_FLAGS
+	)
+	var extras: Array = [
+		{"text": String(state.get("player_name", "")), "at": SAVE_NAME_AT},
+		{
+			"text": ("%d" % int(state.get("badges", 0))).lpad(SAVE_BADGE_CELLS),
+			"at": SAVE_BADGES_AT,
+		},
+		{
+			"text": "%s:%02d" % [
+				("%d" % int(state.get("hours", 0))).lpad(SAVE_HOUR_CELLS),
+				int(state.get("minutes", 0)),
+			],
+			"at": SAVE_TIME_AT,
+		},
+	]
+	if dex:
+		extras.append({
+			"text": ("%d" % int(state.get("caught", 0))).lpad(SAVE_DEX_CELLS),
+			"at": SAVE_DEX_AT,
+		})
+	return menu.render(
+		box, ["PLAYER", "BADGES", "#DEX" if dex else " ", "TIME"], -1, "", 0, extras
+	)
+
+
+## The speech box and the two lines of the text standing in it. A text longer
+## than the box is scrolled by [code]state["line"][/code], which is what
+## `_ContText` does to `AlreadyASaveFileText`'s third line.
+func _render_save_textbox(state: Dictionary) -> Image:
+	var width: int = SAVE_TEXTBOX_SIZE.x * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * SAVE_TEXTBOX_SIZE.y * TILE)
+	font.draw_box(
+		frame_style, indices, width, 0, 0, SAVE_TEXTBOX_SIZE.x, SAVE_TEXTBOX_SIZE.y
+	)
+	var lines: Array = state.get("lines", [])
+	var first: int = maxi(int(state.get("line", 0)), 0)
+	var at: Vector2i = SAVE_TEXT_AT - SAVE_TEXTBOX_AT
+	for row: int in SAVE_TEXT_ROWS:
+		var index: int = first + row
+		if index < 0 or index >= lines.size():
+			continue
+		font.draw_text(
+			String(lines[index]), indices, width,
+			at.x * TILE, (at.y + row * SAVE_TEXT_SPACING) * TILE
+		)
+	return Gen2PicImage.from_indices(
+		indices, width, SAVE_TEXTBOX_SIZE.y * TILE, _palette()
+	)
+
+
+func _blit(into: Image, part: Image, at: Vector2i) -> void:
+	if part == null:
+		return
+	into.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), at * TILE)
 
 
 ## `_Option`'s whole screen: the border, `StringOptions` and each row's own

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1,9 +1,10 @@
 class_name Gen2StartMenuScreen
 extends Control
 
-## The overworld pause menu (engine/menus/start_menu.asm), presented as a
-## window-resolution Control panel consistent with the mart, phone and PC
-## storage overlays rather than the hardware `menu_coords` box.
+## The overworld pause menu (engine/menus/start_menu.asm). The list, `_Option`
+## and `SaveMenu` are the cartridge's own screens through [Gen2StartMenuPage],
+## drawn into whichever [Gen2Screen] the host hands over; the pack's modes are
+## still a window-resolution Control panel, which is `HANDOFF.md`'s open row.
 ##
 ## Pokedex, Pokemon and Pokegear are screens the world already owns
 ## (Gen2PokedexScreen, Gen2PartyScreen, the phone list on
@@ -21,13 +22,47 @@ signal closed
 ## The payload is the resolved effect, because the screen hosting the world is
 ## the one that can cast a rod or draw a warp.
 signal field_item_used(request: Dictionary)
+## `PlaySFX`, which this screen has no driver of its own for: the world that
+## hosts it owns the player. `SFX_SAVE` is the only one it asks for.
+signal sfx_requested(sfx: int)
 
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
 	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING,
 	PACK_TOSS_QUANTITY, PACK_TOSS_CONFIRM, PACK_GIVE_SWAP,
-	PACK_RESULT, SAVE_CONFIRM, OPTIONS, MODS, MOD_OPTIONS,
+	PACK_RESULT, SAVE_ASK, SAVE_OVERWRITE, SAVE_SAVING, SAVE_SAVED,
+	SAVE_FAILED, OPTIONS, MODS, MOD_OPTIONS,
 }
+
+## `SaveMenu`'s four texts, out of `data/text/common_3.asm` on Crystal and
+## `common_2.asm` on Gold and Silver, which no importer reads and which this
+## project authors beside its other engine text. Verbatim, one entry a line, so
+## the box scrolls where `_ContText` scrolls.
+const SAVE_ASK_LINES: Array[String] = [
+	"Would you like to", "save the game?",
+]
+## `AlreadyASaveFileText`. `AnotherSaveFileText` is its sibling for a save file
+## belonging to another player, and `CompareLoadedAndSavedPlayerID` cannot
+## reach it here: a world is always played from the slot it was started in.
+const SAVE_OVERWRITE_LINES: Array[String] = [
+	"There is already a", "save file. Is it", "OK to overwrite?",
+]
+const SAVE_SAVING_LINES: Array[String] = [
+	"SAVING… DON'T TURN", "OFF THE POWER.",
+]
+## `_SavedTheGameText`, whose `<PLAYER>` is filled from the save.
+const SAVE_SAVED_LINES: Array[String] = [
+	"%s saved", "the game.",
+]
+
+## `SavingDontTurnOffThePower`'s own `ld c, 16`, then `SavedTheGame`'s 32 before
+## the words and 30 after them.
+const SAVE_SAVING_FRAMES: int = 16
+const SAVE_WRITE_FRAMES: int = 32
+const SAVE_DONE_FRAMES: int = 30
+## `ld de, SFX_SAVE` (constants/sfx_constants.asm; the comment column there is
+## hex).
+const SFX_SAVE: int = 0x25
 
 ## The pack's five imported texts, by the key `GameData.menu_text` holds each
 ## under. `UseItem`'s two refusals and `TossMenu`'s three; "(S)" is three literal
@@ -116,8 +151,15 @@ var _forget_cursor: int = 0
 var _forget_party_index: int = -1
 var _forget_confirm_cursor: int = 0
 
-var _save_cursor: int = 0
-var _save_result_shown: bool = false
+## `SaveMenu`'s own state: the text standing in the speech box, which of its
+## lines is on the top row, `wMenuCursorY` for the yes/no, and the frames the
+## two timed modes have spent.
+var _save_lines: Array = []
+var _save_line: int = 0
+var _save_cursor: int = -1
+var _save_frames: int = 0
+var _save_elapsed: float = 0.0
+var _save_result: Dictionary = {}
 
 var _options_menu: Gen2WorldOptionsMenu = null
 
@@ -325,10 +367,12 @@ func _move(direction: Vector2i) -> void:
 					_target_cursor + signi(direction.y), 0, _party_targets().size()
 				)
 				_render_targets()
-		Mode.SAVE_CONFIRM:
-			if not _save_result_shown and (direction.x != 0 or direction.y != 0):
+		## `VerticalMenu` over `YesNoMenuHeader`, which is only up while a
+		## question is; the two timed modes read no joypad at all.
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE:
+			if _save_cursor >= 0 and (direction.x != 0 or direction.y != 0):
 				_save_cursor = 1 - _save_cursor
-				_render_save_confirm()
+				_render_save()
 		Mode.OPTIONS:
 			if direction.y != 0:
 				_options_menu.move(direction.y)
@@ -397,7 +441,8 @@ func _confirm() -> void:
 				closed.emit()
 			else:
 				_open_pack_mode(false)
-		Mode.SAVE_CONFIRM:
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
+		Mode.SAVE_FAILED:
 			_confirm_save()
 		## Options_Cancel is the only handler that reads A.
 		Mode.OPTIONS:
@@ -443,8 +488,9 @@ func _cancel() -> void:
 		## the pocket list rather than on the item's own menu.
 		Mode.PACK_TOSS_CONFIRM, Mode.PACK_GIVE_SWAP:
 			_open_pack_mode(false)
-		Mode.SAVE_CONFIRM:
-			_open_list_mode()
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
+		Mode.SAVE_FAILED:
+			_cancel_save()
 		## `_Option.joypad_loop` exits on PAD_START | PAD_B from any row.
 		Mode.OPTIONS, Mode.MODS:
 			_open_list_mode()
@@ -1491,37 +1537,152 @@ func _render_pack_result() -> void:
 	_render_options(["Continue"], 0, func(entry: Variant) -> String: return str(entry))
 
 
+## `SaveMenu`'s first question. `LoadStandardMenuHeader` and
+## `DisplaySaveInfoOnSave` put the info box up before it, and both stay up for
+## every mode below.
 func _open_save_confirm_mode() -> void:
-	_mode = Mode.SAVE_CONFIRM
-	_save_cursor = 0
-	_save_result_shown = false
+	_enter_save_mode(Mode.SAVE_ASK, SAVE_ASK_LINES, 0)
+
+
+## The yes/no's own cursor, `YesNoMenuHeader`'s `db 1` default, and the words
+## the box holds. [param cursor] below zero is a mode with no box at all.
+func _enter_save_mode(mode: Mode, lines: Array, cursor: int) -> void:
+	_mode = mode
+	_save_lines = lines.duplicate()
+	_save_line = 0
+	_save_cursor = cursor
+	_save_frames = 0
 	_title.text = "SAVE"
-	_summary.text = "Save your progress?"
+	_summary.text = " ".join(_save_lines)
 	_status.text = ""
-	_footer.text = "D-pad: choose    A: confirm    B: cancel"
-	_render_save_confirm()
+	_footer.text = "D-pad: choose    A: confirm    B: cancel" if cursor >= 0 \
+		else "A: continue"
+	_render_save()
 
 
 func _confirm_save() -> void:
-	if _save_result_shown:
-		_open_list_mode()
-		return
-	if _save_cursor == 1:
-		_open_list_mode()
-		return
-	var result: Dictionary = _save_action.call() if _save_action.is_valid() else {"ok": false, "reason": &"no_save_action"}
-	_save_result_shown = true
-	if bool(result.get("ok", false)):
-		_status.text = "World saved."
-		_status.add_theme_color_override("font_color", SUCCESS)
-	else:
-		_status.text = "Save failed: %s" % String(result.get("reason", "unknown"))
-		_status.add_theme_color_override("font_color", ERROR)
-	_render_options(["Continue"], 0, func(entry: Variant) -> String: return str(entry))
+	match _mode:
+		## `.refused` on NO, which is the carry `StartMenu_Save` answers with 0:
+		## back to the list rather than out of the menu.
+		Mode.SAVE_ASK:
+			if _save_cursor == 1:
+				_open_list_mode()
+			else:
+				_enter_save_mode(Mode.SAVE_OVERWRITE, SAVE_OVERWRITE_LINES, -1)
+		Mode.SAVE_OVERWRITE:
+			## `_ContText`'s own `PromptButton` before the third line, which
+			## `AlreadyASaveFileText` is the only one of these texts to carry.
+			if _save_cursor < 0:
+				_save_line = 1
+				_save_cursor = 0
+				_render_save()
+			elif _save_cursor == 1:
+				_open_list_mode()
+			else:
+				_enter_save_mode(Mode.SAVE_SAVING, SAVE_SAVING_LINES, -1)
+		## The two timed modes read no button, since `SavingDontTurnOffThePower`
+		## zeroes the joypad bytes before it prints.
+		Mode.SAVE_SAVING, Mode.SAVE_SAVED:
+			pass
+		Mode.SAVE_FAILED:
+			_open_list_mode()
 
 
-func _render_save_confirm() -> void:
-	_render_options(["Yes", "No"], _save_cursor, func(entry: Variant) -> String: return str(entry))
+## B is `YesNoBox`'s no wherever a question is up, and `PromptButton`'s other
+## button while the text still has a line to come. The two timed modes read no
+## joypad at all.
+func _cancel_save() -> void:
+	if _save_cursor < 0 and _mode == Mode.SAVE_OVERWRITE:
+		_confirm_save()
+	elif _save_cursor >= 0:
+		_open_list_mode()
+
+
+## One hardware frame of the two timed modes. Public so a test or a preview owns
+## its own frames rather than sampling a screen mid-flight.
+func advance_save_frame() -> void:
+	if _mode != Mode.SAVE_SAVING and _mode != Mode.SAVE_SAVED:
+		return
+	_save_frames += 1
+	match _mode:
+		Mode.SAVE_SAVING:
+			if _save_frames == SAVE_SAVING_FRAMES:
+				_write_save()
+			elif _save_frames == SAVE_SAVING_FRAMES + SAVE_WRITE_FRAMES:
+				_show_save_result()
+		## Exactly, not past: the host is freed a frame later and this would
+		## otherwise emit again on every frame in between.
+		Mode.SAVE_SAVED:
+			if _save_frames == SAVE_DONE_FRAMES:
+				## `StartMenu_Save`'s `ld a, 1`, which is `StartMenu`'s exit
+				## rather than its `.Reopen`.
+				closed.emit()
+
+
+func advance_save_frames(count: int) -> void:
+	for _step: int in count:
+		advance_save_frame()
+
+
+func _process(delta: float) -> void:
+	if _mode != Mode.SAVE_SAVING and _mode != Mode.SAVE_SAVED:
+		return
+	_save_elapsed += delta
+	while _save_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+		_save_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		advance_save_frame()
+
+
+func _write_save() -> void:
+	_save_result = _save_action.call() if _save_action.is_valid() \
+		else {"ok": false, "reason": &"no_save_action"}
+
+
+## `SavedTheGame`'s words and `SFX_SAVE` behind them. A refused write is this
+## project's own line: the cartridge has no failure path, because its write is
+## to SRAM it has already checked.
+func _show_save_result() -> void:
+	if not bool(_save_result.get("ok", false)):
+		_enter_save_mode(Mode.SAVE_FAILED, [
+			"Save failed:", String(_save_result.get("reason", "unknown")),
+		], 0)
+		return
+	var name: String = _pack_save.player_name if _pack_save != null else ""
+	_enter_save_mode(Mode.SAVE_SAVED, [
+		SAVE_SAVED_LINES[0] % name, SAVE_SAVED_LINES[1],
+	], -1)
+	## `WaitSFX` after it is not spent, for the reason the intro cry's is not.
+	sfx_requested.emit(SFX_SAVE)
+
+
+## `DisplaySaveInfoOnSave`'s four rows: the same fields [Gen2TrainerCard]'s
+## first page reads, with `Continue_DisplayBadgeCount`'s popcount over both
+## badge bytes beside them.
+func _save_state() -> Dictionary:
+	var state: Gen2WorldState = _world.state if _world != null else null
+	var time: Gen2GameTime = _pack_save.game_time \
+		if _pack_save != null and _pack_save.game_time != null else Gen2GameTime.new()
+	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
+	return {
+		"player_name": _pack_save.player_name if _pack_save != null else "",
+		"badges": state.badge_count(crystal) if state != null else 0,
+		"pokedex": state != null and state.is_engine_flag_active(
+			Gen2WorldStartMenu.ENGINE_POKEDEX
+		),
+		"caught": state.caught_count() if state != null else 0,
+		"hours": time.hours,
+		"minutes": time.minutes,
+		"lines": _save_lines,
+		"line": _save_line,
+		"cursor": _save_cursor,
+	}
+
+
+func _render_save() -> void:
+	_render_options(
+		["Yes", "No"] if _save_cursor >= 0 else [], _save_cursor,
+		func(entry: Variant) -> String: return str(entry)
+	)
 
 
 func _build_ui() -> void:
@@ -1640,6 +1801,9 @@ func _hardware_image() -> Image:
 				labels, _menu.cursor, description,
 				_world != null and _world.bug_contest_active()
 			)
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
+		Mode.SAVE_FAILED:
+			return _page.render_save(_save_state())
 		Mode.OPTIONS:
 			if _options_menu == null:
 				return null

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1546,6 +1546,37 @@ func preview_options() -> void:
 	_start_menu_host.handle_button(Gen2Button.A)
 
 
+## Public screenshot drivers for `SaveMenu`, one per box it puts up:
+## `WouldYouLikeToSaveTheGameText` with its yes/no, `AlreadyASaveFileText` past
+## `_ContText`'s own wait, and `SavingDontTurnOffThePowerText` with no question
+## behind it. An injected save keeps the write in memory, the way
+## [method preview_pack_toss] keeps its stack.
+func preview_save_menu() -> void:
+	_preview_save_menu(0)
+
+
+func preview_save_overwrite() -> void:
+	_preview_save_menu(2)
+
+
+func preview_save_writing() -> void:
+	_preview_save_menu(3)
+
+
+## [param answers] is how many A presses to spend past the first question.
+func _preview_save_menu(answers: int) -> void:
+	if _world == null or _data == null or _start_menu_host != null:
+		return
+	_injected_save = _embedded_party_save()
+	_open_start_menu()
+	if _start_menu_host == null:
+		return
+	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_SAVE:
+		_start_menu_host.handle_button(Gen2Button.DOWN)
+	for _press: int in answers + 1:
+		_start_menu_host.handle_button(Gen2Button.A)
+
+
 ## Public screenshot driver for `TossMenu`. Grants a stack on an injected save
 ## so nothing persists, then advances one menu step per call: Pack, the item,
 ## TOSS, the quantity dial, the yes/no and the result.
@@ -2290,6 +2321,7 @@ func _open_start_menu_host(entry: Callable) -> void:
 	host.action_chosen.connect(_on_start_menu_action)
 	host.closed.connect(_on_start_menu_closed)
 	host.field_item_used.connect(_on_field_item_used)
+	host.sfx_requested.connect(_play_sfx)
 	_start_menu_host = host
 	_script_prompt = "Start menu open"
 	if entry.is_valid():

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -688,17 +688,33 @@ func test_save_writes_a_snapshot_to_the_injected_save_without_touching_disk() ->
 	_select(host, Gen2WorldStartMenu.ITEM_SAVE)
 	host.handle_button(Gen2Button.A)
 	await get_tree().process_frame
-	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_CONFIRM)
-	## Yes is the confirm menu's default cursor position.
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_ASK)
+	## Yes is YesNoMenuHeader's own default cursor position. The second question
+	## is AskOverwriteSaveFile's, which every save here reaches: the slot the
+	## world is played from always exists and always carries this player's ID.
 	host.handle_button(Gen2Button.A)
-	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_OVERWRITE)
+	## `_ContText`'s wait before the text's third line, then its yes.
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_SAVING)
+	## SavingDontTurnOffThePower's sixteen frames and SavedTheGame's thirty-two
+	## are both spent before the words that follow them.
+	host.advance_save_frames(
+		Gen2StartMenuScreen.SAVE_SAVING_FRAMES
+		+ Gen2StartMenuScreen.SAVE_WRITE_FRAMES - 1
+	)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_SAVING)
+	host.advance_save_frames(1)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.SAVE_SAVED)
 	assert_eq(save.world.map_id, expected.map_id)
 	assert_eq(save.world.player_cell, expected.player_cell)
 	assert_true(save.world.world_state.is_event_flag_active(MARKER_FLAG))
-	## Continue returns to the list without reopening a fresh menu instance.
-	host.handle_button(Gen2Button.A)
-	await get_tree().process_frame
-	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+	## `StartMenu_Save`'s `ld a, 1`: a save that succeeded leaves the menu.
+	var closed: Array = []
+	host.closed.connect(func() -> void: closed.append(true))
+	host.advance_save_frames(Gen2StartMenuScreen.SAVE_DONE_FRAMES)
+	assert_eq(closed.size(), 1)
 
 
 ## Covers three of _open_start_menu()'s busy-state guards directly; the fourth

--- a/tests/unit/test_font.gd
+++ b/tests/unit/test_font.gd
@@ -10,8 +10,10 @@ const SHEET_TILES: int = 3
 const WIDTH: int = SHEET_TILES * Gen2Font.TILE
 
 const BATTLE_EXTRA_WIDTH: int = RomLayout.BATTLE_FONT_TILES * Gen2Font.TILE
+const FONT_EXTRA_WIDTH: int = RomLayout.FONT_EXTRA_TILES * Gen2Font.TILE
 ## Not [constant Gen2Tiles.INK], so a pixel says which strip it came from.
 const BATTLE_EXTRA_INK: int = 2
+const FONT_EXTRA_INK: int = 1
 
 var _directory: String = ""
 var _font: Gen2Font = null
@@ -48,6 +50,12 @@ func _write_cache() -> void:
 	battle_extra.fill(BATTLE_EXTRA_INK)
 	RomCache.write_indices(RomCache.tile_path(_directory, "battle_font"), battle_extra)
 
+	# FontExtra, which is under that same run whenever the battle strip is not.
+	var extra: PackedByteArray = PackedByteArray()
+	extra.resize(FONT_EXTRA_WIDTH * Gen2Font.TILE)
+	extra.fill(FONT_EXTRA_INK)
+	RomCache.write_indices(RomCache.tile_path(_directory, "font_extra"), extra)
+
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "fontgame",
@@ -65,6 +73,11 @@ func _write_cache() -> void:
 			"battle_font": {
 				"width": BATTLE_EXTRA_WIDTH, "height": Gen2Font.TILE,
 				"tiles": RomLayout.BATTLE_FONT_TILES, "first_code": 0,
+			},
+			"font_extra": {
+				"width": FONT_EXTRA_WIDTH, "height": Gen2Font.TILE,
+				"tiles": RomLayout.FONT_EXTRA_TILES,
+				"first_code": RomLayout.FONT_EXTRA_FIRST_CODE,
 			},
 		},
 	})
@@ -169,10 +182,32 @@ func test_a_battle_extra_code_is_drawn_from_that_strip() -> void:
 	assert_eq(into[0], BATTLE_EXTRA_INK)
 
 
-func test_the_same_code_draws_nothing_with_the_main_font_loaded() -> void:
-	# The main font sheet starts at $80, so $74 is below it and has no tile.
+func test_the_same_code_is_font_extras_with_the_main_font_loaded() -> void:
+	# `_LoadFontsExtra1` is what stands in that run outside a battle, so $74 is
+	# № under one strip and the middle dot under the other.
 	var into: PackedByteArray = _canvas(1)
 	_font.draw_code(0x74, into, Gen2Font.TILE, 0, 0)
+	assert_eq(into[0], FONT_EXTRA_INK)
+
+
+## The three codes below `_LoadFontsExtra1`'s own `vTiles2 tile '<BOLD_D>'` are
+## overwritten by black, the up arrow and the phone icon, so FontExtra's first
+## three tiles never reach the screen through this path.
+func test_the_run_below_bold_d_is_not_drawn_from_font_extra() -> void:
+	var into: PackedByteArray = _canvas(1)
+	_font.draw_code(RomLayout.FONT_EXTRA_LOADED_FIRST - 1, into, Gen2Font.TILE, 0, 0)
+	assert_eq(into[0], 0)
+
+
+func test_a_cache_without_font_extra_draws_that_run_blank() -> void:
+	var manifest: Dictionary = RomCache.read_manifest(_directory)
+	(manifest["tiles"] as Dictionary).erase("font_extra")
+	RomCache.write_json(RomCache.manifest_path(_directory), manifest)
+
+	var font: Gen2Font = Gen2Font.from_data(GameData.open_directory(_directory))
+	assert_not_null(font)
+	var into: PackedByteArray = _canvas(1)
+	font.draw_code(Gen2Text.ELLIPSIS_CODE, into, Gen2Font.TILE, 0, 0)
 	assert_eq(into[0], 0)
 
 

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -21,6 +21,7 @@ func _dump() -> PackedByteArray:
 	var data: PackedByteArray = PackedByteArray()
 	data.resize(RomRegistry.EXPECTED_SIZE)
 	_write(data, RomLayout.font_offset(_layout), _font())
+	_write(data, RomLayout.font_extra_offset(_layout), _font_extra())
 	for frame: int in RomLayout.FRAME_COUNT:
 		_write(data, RomLayout.frame_offset(_layout, frame), _frame(frame))
 	return data
@@ -41,6 +42,23 @@ func _font() -> PackedByteArray:
 			continue
 		for row: int in Gen2Tiles.TILE_1BPP_BYTES:
 			out[tile * Gen2Tiles.TILE_1BPP_BYTES + row] = 0x7E
+	return out
+
+
+## Ink on every tile `_LoadFontsExtra1` loads, and the ellipsis's own single row
+## of dots on the seventh, which is the shape the check pins.
+func _font_extra() -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(RomLayout.FONT_EXTRA_TILES * Gen2Tiles.TILE_BYTES)
+	for code: int in range(
+		RomLayout.FONT_EXTRA_LOADED_FIRST, RomLayout.FONT_EXTRA_LOADED_LAST + 1
+	):
+		var tile: int = code - RomLayout.FONT_EXTRA_FIRST_CODE
+		var rows: Array = [6] if code == Gen2Text.ELLIPSIS_CODE else range(
+			Gen2Tiles.TILE_1BPP_BYTES
+		)
+		for row: int in rows:
+			out[tile * Gen2Tiles.TILE_BYTES + 2 * row] = 0x92
 	return out
 
 
@@ -83,6 +101,26 @@ func test_a_plausible_font_and_borders_verify() -> void:
 	var data: PackedByteArray = _dump()
 	assert_true(RomImporter.verify_font(_rom(data), _layout)["ok"])
 	assert_true(RomImporter.verify_frames(_rom(data), _layout)["ok"])
+
+
+## FontExtra has no pinned address: it is read off the font's, so the check that
+## it is the right sheet is the only thing standing between "…" and a blank.
+func test_a_font_extra_one_tile_out_fails() -> void:
+	var data: PackedByteArray = _dump()
+	_write(
+		data, RomLayout.font_extra_offset(_layout) + Gen2Tiles.TILE_BYTES,
+		_font_extra()
+	)
+	assert_false(RomImporter.verify_font(_rom(data), _layout)["ok"])
+
+
+func test_a_font_extra_with_no_ellipsis_fails() -> void:
+	var data: PackedByteArray = _dump()
+	var at: int = RomLayout.font_extra_offset(_layout) \
+		+ (Gen2Text.ELLIPSIS_CODE - RomLayout.FONT_EXTRA_FIRST_CODE) * Gen2Tiles.TILE_BYTES
+	for row: int in Gen2Tiles.TILE_1BPP_BYTES:
+		data[at + 2 * row] = 0xFF
+	assert_false(RomImporter.verify_font_extra(_rom(data), _layout)["ok"])
 
 
 func test_a_font_one_tile_out_fails() -> void:

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -218,3 +218,73 @@ func test_the_box_grows_downward_by_two_rows_an_entry() -> void:
 	assert_eq(five.border_size(), Vector2i(10, 12))
 	assert_eq(Gen2StartMenuPage.list_box(8).border_size(), Vector2i(10, 18))
 	assert_eq(Gen2StartMenuPage.list_box(5, true).border_position(), Vector2i(10, 2))
+
+
+func _save_state(pokedex: bool, cursor: int) -> Dictionary:
+	return {
+		"player_name": "GOLD", "badges": 3, "pokedex": pokedex, "caught": 42,
+		"hours": 12, "minutes": 7,
+		"lines": Gen2StartMenuScreen.SAVE_ASK_LINES, "line": 0, "cursor": cursor,
+	}
+
+
+func _opaque(image: Image, tile: Vector2i) -> bool:
+	return image.get_pixel(
+		tile.x * Gen2Font.TILE + 4, tile.y * Gen2Font.TILE + 4
+	).a > 0.0
+
+
+## `SaveMenu` draws `DisplaySaveInfoOnSave`'s box in the right-hand sixteen
+## columns, `SpeechTextbox` at the foot and `PlaceYesNoBox`'s own on the left,
+## and nothing else: the map is still showing everywhere between them.
+func test_the_save_screen_draws_three_boxes_over_the_map() -> void:
+	Fixture.build()
+	var page: Gen2StartMenuPage = Gen2StartMenuPage.from_data(
+		GameData.open_directory(Fixture.directory())
+	)
+	var asked: Image = page.render_save(_save_state(true, 0))
+	assert_true(_opaque(asked, Vector2i(4, 0)), "the info box's own corner")
+	assert_true(_opaque(asked, Vector2i(19, 9)), "and its far one")
+	assert_true(_opaque(asked, Vector2i(0, 12)), "the speech box")
+	assert_true(_opaque(asked, Vector2i(0, 7)), "the yes/no box")
+	assert_true(_opaque(asked, Vector2i(5, 11)), "and its far corner")
+	assert_false(_opaque(asked, Vector2i(3, 0)), "the map left of the info box")
+	assert_false(_opaque(asked, Vector2i(0, 6)), "the map above the yes/no box")
+	assert_false(_opaque(asked, Vector2i(19, 11)), "the map between the boxes")
+
+	## `SavingDontTurnOffThePower` prints with no question behind it, so the
+	## yes/no box is not up at all.
+	var saving: Image = page.render_save(_save_state(true, -1))
+	assert_false(_opaque(saving, Vector2i(0, 7)))
+	RomCache.clear(Fixture.directory())
+
+
+## `.MenuData_NoDex` blanks the third row's label and
+## `Continue_DisplayPokedexNumCaught` returns before its own `PrintNum`, so a
+## player without the Pokedex is shown neither the word nor the count.
+func test_the_dex_row_is_blank_without_the_pokedex_flag() -> void:
+	Fixture.build()
+	var page: Gen2StartMenuPage = Gen2StartMenuPage.from_data(
+		GameData.open_directory(Fixture.directory())
+	)
+	var without: Image = page.render_save(_save_state(false, 0))
+	var with_dex: Image = page.render_save(_save_state(true, 0))
+	assert_ne(without.get_data(), with_dex.get_data())
+	## An interior tile the box never writes, which is what a blank row reads as.
+	var blank: Color = without.get_pixel(6 * Gen2Font.TILE, 3 * Gen2Font.TILE)
+	var row: int = Gen2StartMenuPage.SAVE_DEX_AT.y
+	for column: int in range(5, Gen2StartMenuPage.SAVE_INFO_RIGHT):
+		assert_true(
+			_tile_is(without, Vector2i(column, row), blank),
+			"column %d of the dex row is blank" % column
+		)
+	assert_false(_tile_is(with_dex, Vector2i(5, row), blank), "#DEX is printed")
+	RomCache.clear(Fixture.directory())
+
+
+func _tile_is(image: Image, tile: Vector2i, color: Color) -> bool:
+	for y: int in Gen2Font.TILE:
+		for x: int in Gen2Font.TILE:
+			if image.get_pixel(tile.x * Gen2Font.TILE + x, tile.y * Gen2Font.TILE + y) != color:
+				return false
+	return true


### PR DESCRIPTION
`StartMenu_Save` reached a `PanelContainer` with Yes/No `Label`s. It now
reaches the cartridge's screen: `DisplaySaveInfoOnSave`'s box offset to
column 4 by `_OffsetMenuHeader`, `SpeechTextbox` at the foot, and
`PlaceYesNoBox`'s own box at `lb bc, 0, 7`, all over the map the way the
start menu list already is.

The sequence is the source's too. Both questions are asked, since
`AskOverwriteSaveFile` reaches `.yoursavefile` on every save here: a world
is always played from a slot that exists and carries its own player ID.
`_ContText`'s wait inside `AlreadyASaveFileText` is spent, so is
`SavingDontTurnOffThePower`'s sixteen frames and `SavedTheGame`'s
thirty-two before the words and thirty after them, `SFX_SAVE` plays behind
them, and a save that succeeded leaves the menu rather than reopening the
list (`ld a, 1`).

Found on the way and fixed in the same commit: `FontExtra` was never
imported. `_LoadFontsExtra1` puts codes $63 to $78 under the main font
everywhere the battle strip is not, and that run carries `…`, both quotes,
the middle dot and `<COLON>` - five characters the decoder already knew and
nothing could draw, so every imported text saying "…" printed a blank. It
needs no pinned address, being the entry before `Font` in `gfx/font.asm` on
all three dumps; what checks it is the ellipsis's own shape.

Cache format 66. All three cartridges re-import with `layout: Layout
verified.`, `validate.gd -- all` exits 0, `replay_world.gd` is 30 routes and
0 failures, and the three-profile story walk still reaches Red with 16
badges at 295 steps on Crystal and 292 on Gold and Silver. GUT 3,088 over
150 scripts, green.