### PR TITLE
Run a step's events on the frame it lands

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -693,6 +693,11 @@ func _queue_player_step(direction: Vector2i, frames: int) -> void:
 
 
 func _begin_player_step(direction: Vector2i, frames: int) -> void:
+	## `StepFunction_PlayerJump` is the only step type that runs
+	## `UpdateJumpPosition`, and every other step type replaces it, so the arc
+	## belongs to the hop that set it and to nothing begun after it.
+	## `_try_ledge_hop` raises the flag again once this has cleared it.
+	_player_jumping = false
 	_player_step_direction = direction
 	_player_step_frames_total = maxi(0, frames)
 	_player_step_frames_remaining = _player_step_frames_total
@@ -4146,13 +4151,34 @@ func _apply_script_warp(request: Dictionary) -> Dictionary:
 ## field selects a one-based warp in the destination map, as in the original
 ## map macro. An invalid target leaves this API unchanged and returns an error
 ## record instead of silently placing the player on another map.
-## `CheckWarpCollision`'s own answer, without walking through the warp: whether
+## `CheckWarpTile`'s own answer, without walking through the warp: whether
 ## the step that just landed on [param cell] has a warp to take. A host that
 ## spends `MapSetupScript_Door`'s fade before the map swaps asks this first, and
 ## [method try_warp] is the swap itself.
+##
+## `CheckWarpTile` is `GetDestinationWarpNumber` and then `CheckDirectionalWarp`,
+## which clears carry on the four warp carpets: landing on one of those warps
+## nothing, and only [method edge_warp_ready] takes it.
 func warp_pending(cell: Vector2i = player_cell) -> bool:
+	var code: int = collision_code_at(cell)
 	return not warp_at(cell).is_empty() \
-		and Gen2WorldCollision.is_warp_tile(collision_code_at(cell))
+		and Gen2WorldCollision.is_warp_tile(code) \
+		and not Gen2WorldCollision.is_directional_warp(code)
+
+
+## `DoPlayerMovement.CheckWarp`: the player is standing on the warp carpet that
+## names [param direction], is already facing that way, and the cell carries a
+## warp. The press takes the warp instead of bumping, which is why an interior
+## door is stood on first and walked into afterwards.
+func edge_warp_ready(direction: Vector2i) -> bool:
+	var code: int = collision_code_at(player_cell)
+	if Gen2WorldCollision.directional_warp_direction(code) != direction:
+		return false
+	## `ld a, [wPlayerDirection] / rrca / rrca` against wWalkingDirection: the
+	## facing has to agree with the press, which a turn from the same cell buys.
+	if _facing_for_direction(direction) != player_facing:
+		return false
+	return not warp_at(player_cell).is_empty()
 
 
 func try_warp(cell: Vector2i = player_cell) -> Dictionary:
@@ -4748,7 +4774,23 @@ func player_input_move(direction: Vector2i) -> Dictionary:
 			return {
 				"ok": true, "kind": &"turn", "facing": player_facing, "cell": player_cell,
 			}
-	return move_result(direction)
+	var stepped: Dictionary = move_result(direction)
+	if bool(stepped.get("ok", false)):
+		return stepped
+	## `.CheckWarp` sits after `.TryStep` and `.TryJump` and before `.NotMoving`,
+	## so a carpet is only reached once the step into it has been refused, which
+	## it always is: the cell past a door carpet is the map's own wall or edge.
+	## `.StandInPlace` spends no step, so the warp is taken on the press.
+	if forced == &"none" and edge_warp_ready(direction):
+		return {
+			"ok": true,
+			"kind": &"edge_warp",
+			"from_map": map_id(),
+			"from_cell": player_cell,
+			"to_map": map_id(),
+			"to_cell": player_cell,
+		}
+	return stepped
 
 
 func move_result(direction: Vector2i) -> Dictionary:

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -316,6 +316,31 @@ const COLL_STAIRCASE: int = 0x7A
 const COLL_CAVE: int = 0x7B
 const COLL_PIT: int = 0x60
 const COLL_PIT_68: int = 0x68
+## CheckDirectionalWarp's four carpets, keyed by the direction the player has to
+## walk in to take them. `DoPlayerMovement.CheckWarp` indexes `.EdgeWarps` with
+## wWalkingDirection, whose order is down, up, left, right.
+const DIRECTIONAL_WARPS: Dictionary = {
+	Vector2i.DOWN: 0x70,   # COLL_WARP_CARPET_DOWN
+	Vector2i.UP: 0x78,     # COLL_WARP_CARPET_UP
+	Vector2i.LEFT: 0x76,   # COLL_WARP_CARPET_LEFT
+	Vector2i.RIGHT: 0x7E,  # COLL_WARP_CARPET_RIGHT
+}
+
+
+## CheckDirectionalWarp: a carpet clears carry, so `CheckWarpTile` refuses it and
+## the step that lands on one takes no warp. Only `DoPlayerMovement.CheckWarp`
+## takes these, and only for the one direction the carpet names.
+static func is_directional_warp(collision_code: int) -> bool:
+	return DIRECTIONAL_WARPS.values().has(collision_code)
+
+
+## Which direction [param collision_code] has to be walked in to warp, or
+## Vector2i.ZERO when it is not a carpet.
+static func directional_warp_direction(collision_code: int) -> Vector2i:
+	for direction: Vector2i in DIRECTIONAL_WARPS:
+		if int(DIRECTIONAL_WARPS[direction]) == collision_code:
+			return direction
+	return Vector2i.ZERO
 
 
 ## CheckWarpCollision: the two pit codes or the whole $70 nybble, and nowhere

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -80,6 +80,10 @@ var _encounters: Gen2WorldEncounters = null
 var _battle_encounter_id: StringName = &""
 ## The headbutt result waiting for ShakeHeadbuttTree's 32 frames to be spent.
 var _pending_headbutt_finish: Dictionary = {}
+## The step in flight whose `PlayerEvents` are still owed, empty while none is.
+## `CheckPlayerState` reads `PLAYERSTEP_STOP_F`, so the warp, the coord events
+## and the wild roll all belong to the frame the step lands on.
+var _pending_step_events: Dictionary = {}
 ## `MapSetupScript_Door` while it is running: `{ stage, step, frames, cell }`,
 ## empty on every other frame. The map swaps between the two stages, which is
 ## where the setup script's own list sits.
@@ -454,6 +458,13 @@ func advance_frame() -> void:
 		_renderer.refresh_animation()
 	if _world != null and _world.advance_player_step_frame() and _renderer != null:
 		_renderer.refresh()
+	## `_HandlePlayerStep` runs before `PlayerEvents` in `HandleMap`, so the step
+	## that finishes on this frame is the one whose events this frame runs.
+	if not _pending_step_events.is_empty() and _world != null \
+		and not _world.player_step_in_progress():
+		var landed: Dictionary = _pending_step_events
+		_pending_step_events = {}
+		_complete_player_step(landed)
 	if _world != null and _world.advance_emotes_frame() and _renderer != null:
 		_renderer.refresh()
 	## After the player's own step, so an actor reading
@@ -896,10 +907,10 @@ func move_player(direction: Vector2i) -> bool:
 	return _after_player_move(movement)
 
 
-## Everything a completed step owes the rest of the screen: contextual audio, the
-## warp it may have landed on, the redraw, then sight, phone and encounter checks
-## in that order. Shared with the forced-tile path, which reaches it without a
-## key press.
+## What a step owes the rest of the screen on the frame it starts: the sounds
+## that belong to the step itself and the redraw. Everything else waits for the
+## step to land; see [method _complete_player_step]. Shared with the forced-tile
+## path, which reaches it without a key press.
 func _after_player_move(movement: Dictionary) -> bool:
 	if movement.get("kind", &"") == &"ledge_hop":
 		_play_ledge_hop_sfx()
@@ -914,20 +925,8 @@ func _after_player_move(movement: Dictionary) -> bool:
 	## surfing track once the player is walking again.
 	if movement.get("kind", &"") == &"exit_water":
 		_play_current_map_music()
-
-	## CheckTileEvent gates warps on nothing, so surfing onto a warp tile and the
-	## step back onto land both reach one.
-	if movement.get("kind", &"") in [
-		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
-	] and _world.warp_pending():
-		## `WarpToNewMapScript`: the sound, and then `newloadmap MAPSETUP_DOOR`,
-		## whose `FadeOutToWhite` runs before the map is loaded at all. The map
-		## swaps when that fade lands, and everything a step still owes waits
-		## for `FadeInFromWhite` behind it.
-		_start_map_fade()
-		return true
 	if _renderer != null:
-		if bool(movement.get("ok", false)) and movement.get("kind", &"") != &"move":
+		if movement.get("kind", &"") == &"connection":
 			## `MapSetupScript_Connection`, which is the step itself rather than
 			## a warp: the neighbour's blocks are loaded under a camera that
 			## never stops, and its `FadeToMapMusic` is why crossing a route
@@ -939,6 +938,33 @@ func _after_player_move(movement: Dictionary) -> bool:
 			_fade_to_map_music()
 		else:
 			_renderer.refresh()
+	## `CheckPlayerState` only turns `wMapEventStatus` on where the step function
+	## set `PLAYERSTEP_STOP_F`, so `PlayerEvents` and everything under it run on
+	## the frame the step lands rather than on the frame it was asked for. The
+	## step's own frames are spent by `advance_frame`, which drains this.
+	if _world != null and _world.player_step_in_progress():
+		_pending_step_events = movement.duplicate(true)
+		return true
+	return _complete_player_step(movement)
+
+
+## `PlayerEvents` for the step that has just landed: the warp it stands on, and
+## then the map's own tail.
+func _complete_player_step(movement: Dictionary) -> bool:
+	## `CheckTileEvent` gates warps on nothing, so surfing onto a warp tile and
+	## the step back onto land both reach one. `edge_warp` is
+	## `DoPlayerMovement.CheckWarp`'s own answer, which has already made the
+	## check `CheckWarpTile` refuses for a carpet.
+	var kind: StringName = StringName(movement.get("kind", &""))
+	if kind == &"edge_warp" or (kind in [
+		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
+	] and _world.warp_pending()):
+		## `WarpToNewMapScript`: the sound, and then `newloadmap MAPSETUP_DOOR`,
+		## whose `FadeOutToWhite` runs before the map is loaded at all. The map
+		## swaps when that fade lands, and everything a step still owes waits
+		## for `FadeInFromWhite` behind it.
+		_start_map_fade()
+		return true
 	return _after_map_settled()
 
 

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -96,6 +96,18 @@ func test_the_offset_covers_one_cell() -> void:
 ## onto the warp tile landed on and no fade frame has been spent yet. Its own clock is taken away, so every frame after
 ## that is spent by hand.
 func _walk_onto_the_door() -> Gen2WorldScreen:
+	var screen: Gen2WorldScreen = await _screen_below_the_door()
+	for _frame: int in WALK_FRAME_CAP:
+		## One press turns and the next steps, and a press inside the fade is
+		## swallowed, so the same call drives all three.
+		screen.move_up()
+		screen.advance_frame()
+		if not screen.map_fade().is_empty():
+			break
+	return screen
+
+
+func _screen_below_the_door() -> Gen2WorldScreen:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
 	screen.map_group = Fixture.MAP_GROUP
@@ -107,14 +119,30 @@ func _walk_onto_the_door() -> Gen2WorldScreen:
 	await get_tree().process_frame
 	screen.set_process(false)
 	screen._frame_elapsed = 0.0
-	for _frame: int in WALK_FRAME_CAP:
-		## One press turns and the next steps, and a press inside the fade is
-		## swallowed, so the same call drives all three.
-		screen.move_up()
-		screen.advance_frame()
-		if not screen.map_fade().is_empty():
-			break
 	return screen
+
+
+## `CheckPlayerState` turns `wMapEventStatus` on where the step function set
+## `PLAYERSTEP_STOP_F`, so `PlayerEvents` and everything under it, the warp, the
+## coord events and the wild roll, run on the frame the step lands rather than on
+## the frame the button was read.
+func test_a_warp_waits_for_the_step_onto_its_tile_to_land() -> void:
+	_screen = await _screen_below_the_door()
+	_screen.move_up()   # `.CheckTurning`: the first press only turns.
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_TURN:
+		_screen.advance_frame()
+	_screen.move_up()
+	assert_true(_screen._world.player_step_in_progress(), "the step onto the door started")
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK - 1:
+		_screen.advance_frame()
+		assert_true(
+			_screen.map_fade().is_empty(),
+			"no warp while the player is still between the two cells",
+		)
+	assert_true(_screen._world.player_step_in_progress(), "the last frame of the step")
+	_screen.advance_frame()
+	assert_false(_screen._world.player_step_in_progress(), "which lands it")
+	assert_false(_screen.map_fade().is_empty(), "and the warp is taken on that frame")
 
 
 ## `WarpToNewMapScript` is `warpsound` and `newloadmap MAPSETUP_DOOR`, and that
@@ -132,9 +160,9 @@ func test_a_warp_spends_the_setup_script_own_fade() -> void:
 	assert_eq(StringName(_screen.map_fade().get("stage", &"")), &"out")
 	var fade_frames: int = Gen2WorldPalette.FADE_OUT_ORDERS.size() \
 		* Gen2WorldPalette.FADE_STEP_FRAMES
-	## One of the fade out's own frames is the frame the step landed on, which is
-	## the one the fade was started in.
-	var out_frames: int = 1
+	## `PlayerEvents` runs after the frame's own map background, so the frame the
+	## step landed on starts the script and spends none of its fade.
+	var out_frames: int = 0
 	while StringName(_screen.map_fade().get("stage", &"")) == &"out" \
 		and out_frames < WALK_FRAME_CAP:
 		_screen.advance_frame()

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -107,6 +107,12 @@ func _write_cache(game_id: String = "testworld") -> void:
 	collision[6 * 16 + 12] = 0x07  # wall below the door
 	collision[5 * 16 + 15] = 0x41  # COLL_WALK_RIGHT
 
+	# CheckDirectionalWarp's carpet, for DoPlayerMovement.CheckWarp: a warp cell
+	# that is stood on rather than warped onto, with the wall an interior door
+	# always has behind it.
+	collision[4 * 16 + 13] = 0x78  # COLL_WARP_CARPET_UP
+	collision[3 * 16 + 13] = 0x07  # wall above the carpet
+
 	# A lone COLL_UP_WALL at (2,10), matching real Route 42 cliff cells: it
 	# blocks stepping off the edge (entering from above, moving DOWN) but not
 	# climbing it (moving UP from below), since the enter rule only tests the
@@ -134,9 +140,10 @@ func _write_cache(game_id: String = "testworld") -> void:
 
 	var source_events: Dictionary = {
 		"bank": 48,
-		"warps": [{
-			"x": 6, "y": 6, "destination": 1, "map_group": 1, "map_number": 2,
-		}],
+		"warps": [
+			{"x": 6, "y": 6, "destination": 1, "map_group": 1, "map_number": 2},
+			{"x": 13, "y": 4, "destination": 1, "map_group": 1, "map_number": 2},
+		],
 		"coord_events": [{"scene": 0, "x": 7, "y": 6, "script": 0x6000}],
 		"bg_events": [{"x": 8, "y": 6, "type": 0, "script": 0x6015}],
 		"objects": [{"sprite": 1, "x": 5, "y": 6, "script": 0x6030, "event_flag": 7}],
@@ -887,6 +894,14 @@ func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
 	assert_true(bool(walker.move_result(Vector2i.UP).get("ok", false)))
 	assert_eq(walker.player_jump_offset(), 0)
 
+	## StepFunction_PlayerJump is the only step type that runs
+	## UpdateJumpPosition, so the step after the hop is on the ground for the
+	## whole of it however the hop left the flag.
+	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)), "a walk off the ledge")
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		assert_eq(world.player_jump_offset(), 0, "the walk after a hop has no arc")
+		world.advance_player_step_frame()
+
 
 func test_ledge_hop_refuses_a_direction_the_code_does_not_allow() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(3, 2))
@@ -1588,6 +1603,43 @@ func test_a_warp_event_on_ordinary_floor_never_fires() -> void:
 	assert_true(
 		floor_world.try_warp(Vector2i(6, 6)).is_empty(),
 		"a warp record on floor answers nothing",
+	)
+
+
+## CheckDirectionalWarp clears carry on the four warp carpets, so CheckWarpTile
+## refuses them and the step that lands on one takes nothing. Only
+## DoPlayerMovement.CheckWarp takes a carpet, and only for the direction it names
+## and only once the facing agrees: an interior door is stood on first and walked
+## into afterwards.
+func test_a_warp_carpet_is_walked_into_rather_than_landed_on() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(13, 5))
+	assert_eq(world.collision_code_at(Vector2i(13, 4)), 0x78, "COLL_WARP_CARPET_UP")
+
+	assert_true(bool(world.move_result(Vector2i.UP).get("ok", false)), "the carpet is walkable")
+	assert_eq(world.player_cell, Vector2i(13, 4))
+	assert_false(world.warp_pending(), "and landing on it warps nothing")
+
+	_finish_player_step(world)
+	assert_false(world.edge_warp_ready(Vector2i.LEFT), "only the direction the carpet names")
+	assert_true(world.edge_warp_ready(Vector2i.UP), "which the step up is already facing")
+
+	var taken: Dictionary = world.player_input_move(Vector2i.UP)
+	assert_eq(StringName(taken.get("kind", &"")), &"edge_warp")
+	assert_false(world.player_step_in_progress(), ".StandInPlace spends no step")
+	assert_eq(world.player_cell, Vector2i(13, 4), "the warp itself is the host's")
+
+
+## `ld a, [wPlayerDirection] / rrca / rrca` against wWalkingDirection: the press
+## that arrives with the wrong facing turns, and the one after it warps.
+func test_a_warp_carpet_facing_the_wrong_way_turns_first() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(13, 4))
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_false(world.edge_warp_ready(Vector2i.UP), "facing down, so no warp yet")
+	assert_eq(StringName(world.player_input_move(Vector2i.UP).get("kind", &"")), &"turn")
+	_finish_player_step(world)
+	assert_eq(
+		StringName(world.player_input_move(Vector2i.UP).get("kind", &"")), &"edge_warp",
+		"and the second press takes it",
 	)
 
 

--- a/tools/checks/ledge_hops.gd
+++ b/tools/checks/ledge_hops.gd
@@ -2,10 +2,11 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies ledge hopping against freshly imported real caches, for both
-## command profiles. The expected codes come from the pinned pokecrystal and
-## pokegold sources: engine/overworld/player_movement.asm's .TryJump, its
-## .ledge_table, and data/collision/collision_permissions.asm.
+## Verifies the two `DoPlayerMovement` branches a step is refused into against
+## freshly imported real caches, for both command profiles: `.TryJump` and the
+## `.CheckWarp` behind it. The expected codes come from the pinned pokecrystal
+## and pokegold sources: engine/overworld/player_movement.asm's .TryJump, its
+## .ledge_table, .EdgeWarps, and data/collision/collision_permissions.asm.
 ##
 ## The real-cartridge counterpart to tests/unit/test_world_collision.gd and the
 ## ledge cases in tests/unit/test_world_api.gd, which use synthetic caches. It
@@ -33,13 +34,14 @@ const ROUTE30_BATTLE_EVENT_FLAG: int = 1812
 
 func run(r: RefCounted) -> void:
 	_r = r
-	for game_id: StringName in [&"crystal", &"gold"]:
+	for game_id: StringName in [&"crystal", &"gold", &"silver"]:
 		var data: GameData = GameData.open(game_id)
 		if data == null:
 			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
 			continue
 		_verify_permissions(game_id)
 		_verify_route30(game_id, data)
+		_verify_warp_carpets(game_id, data)
 
 
 ## The eight hop codes stay LAND_TILE, which is what makes .TryStep walk onto
@@ -189,6 +191,68 @@ func _reachable(world: Gen2WorldAPI) -> Dictionary:
 			seen[next] = true
 			frontier.append(next)
 	return seen
+
+
+## `.CheckWarp` over the whole corpus. Every warp event standing on one of
+## `CheckDirectionalWarp`'s four carpets takes nothing on the step that lands on
+## it, because `CheckWarpTile` clears carry there. What the press does next is
+## decided by the cell the carpet names, since `.CheckWarp` sits after
+## `.TryStep`: a wall there leaves the warp as the only answer, which is every
+## door, and a walkable cell there means the press steps off instead. The two
+## ports are the whole of that second set on all three cartridges, and their
+## warps are taken by `OlivinePortSailorAtGangwayScript` rather than by walking.
+func _verify_warp_carpets(game_id: StringName, data: GameData) -> void:
+	var carpets: int = 0
+	var stepped_off: int = 0
+	var by_code: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		for warp: Dictionary in map.events.get("warps", []) as Array:
+			var cell := Vector2i(int(warp.get("x", -1)), int(warp.get("y", -1)))
+			if cell.x < 0 or cell.y < 0 \
+				or cell.x >= map.collision_width or cell.y >= map.collision_height:
+				continue
+			var code: int = int(map.collision[cell.y * map.collision_width + cell.x])
+			if not Gen2WorldCollision.is_directional_warp(code):
+				continue
+			carpets += 1
+			by_code[code] = int(by_code.get(code, 0)) + 1
+			var direction: Vector2i = Gen2WorldCollision.directional_warp_direction(code)
+			var world: Gen2WorldAPI = Gen2WorldAPI.open(
+				data, map.group, map.number, cell, Gen2WorldState.new()
+			)
+			if not _r.check(
+				world != null, "%s: map %d/%d did not open." % [game_id, map.group, map.number]
+			):
+				continue
+			world.player_facing = world._facing_for_direction(direction)
+			_r.check(
+				not world.warp_pending(cell),
+				"%s: map %d/%d %s warps on the step that lands on it." % [
+					game_id, map.group, map.number, cell
+				]
+			)
+			var walkable: bool = world.can_walk_to(cell + direction, direction)
+			var pressed: StringName = StringName(
+				world.player_input_move(direction).get("kind", &"")
+			)
+			if walkable:
+				stepped_off += 1
+				_r.check(
+					pressed == &"move",
+					"%s: map %d/%d %s warped instead of stepping off." % [
+						game_id, map.group, map.number, cell
+					]
+				)
+				continue
+			_r.check(
+				pressed == &"edge_warp",
+				"%s: map %d/%d %s did not warp when walked into." % [
+					game_id, map.group, map.number, cell
+				]
+			)
+	_r.note("%s: %d warp carpets, %d walked into and %d stepped off, by code %s" % [
+		game_id, carpets, carpets - stepped_off, stepped_off, by_code
+	])
 
 
 func _reaches_north_edge(world: Gen2WorldAPI, seen: Dictionary) -> bool:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -24,6 +24,9 @@ extends SceneTree
 ## warp tile named by the two numbers below it, and the picture is
 ## `FadeOutToWhite`'s last order, which is the frame the new map is loaded on:
 ## `crystal 24 7 ... warp 7 1` is the bedroom staircase),
+## `door` (`.CheckWarp`'s carpet: the player is walked down onto an interior
+## door's mat and photographed standing on it, which the step itself no longer
+## warps: `crystal 24 6 ... door 6 5` is the front door of the player's house),
 ## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
 ## map's edge onto its neighbour: `crystal 24 4 ... map_name_sign 1 8` crosses
 ## New Bark Town into Route 29),
@@ -198,6 +201,20 @@ func _process(_delta: float) -> bool:
 				if StringName(fade.get("stage", &"")) == &"out" \
 					and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
 					break
+		elif _kind == &"door":
+			## `CheckDirectionalWarp`'s carpet: the step onto an interior door's
+			## mat lands and takes no warp, which is what this photographs. The
+			## press after it is `.CheckWarp`, and that is the one that warps.
+			for _frame: int in WARP_FRAME_CAP:
+				_screen.move_down()
+				_screen.advance_frame()
+				if Gen2WorldCollision.is_directional_warp(
+					int(_screen.world_snapshot().get("collision", -1))
+				):
+					## player_cell commits when the step starts, so the frames
+					## the player is still walking are spent before the picture.
+					_screen.advance_frames(Gen2WorldAPI.STEP_FRAMES_WALK)
+					break
 		elif _kind == &"map_name_sign":
 			## `MapSetupScript_Connection`'s `InitMapNameSign`: walked west off
 			## New Bark Town's edge onto Route 29, photographed while the sign
@@ -225,7 +242,7 @@ func _process(_delta: float) -> bool:
 				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
-		if _kind not in [&"warp", &"map_name_sign"]:
+		if _kind not in [&"warp", &"door", &"map_name_sign"]:
 			## Those two kinds drove themselves to the frame they want; every
 			## other kind stages a sprite and then spends the frames it needs.
 			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):


### PR DESCRIPTION
Three reported overworld defects, all in `DoPlayerMovement` and the step that follows it.

**A step's events waited for nothing.** `CheckPlayerState` only turns `wMapEventStatus` on where the step function set `PLAYERSTEP_STOP_F`, so `PlayerEvents`, and with it the warp, the coord events, the sight lines and the wild roll, belongs to the frame the player arrives on. The encounter used to start on the first pixel of movement into the grass. `world_screen.gd` now holds the landed step in `_pending_step_events` and drains it from `advance_frame`, right after `_HandlePlayerStep`'s own place in `HandleMap`.

**An interior door warped on the step onto its mat.** `CheckDirectionalWarp` clears carry on the four `COLL_WARP_CARPET_*` codes, so `CheckWarpTile` refuses them; only `DoPlayerMovement.CheckWarp` takes one, and only on a press of the direction the carpet names with the facing already agreeing.

**A ledge hop's arc outlived its own step.** `StepFunction_PlayerJump` is the only step type that runs `UpdateJumpPosition`, and every other step type replaces it.

Two more met on the way and fixed in the same commit: a ledge hop, a surf step and an exit from water each re-pointed the tile animation and re-faded the map music as though they were a map connection.

| Check | Result |
|---|---|
| GUT, both tiers | 3,099 tests over 150 scripts, green |
| `validate.gd -- all` | 52 topics, exit 0 |
| `replay_world.gd` | 30 routes, 0 failures |
| Story walk, three profiles | 292 / 292 / 295 steps, 16 badges, Red reached |
| Warp carpets swept, all three cartridges | Crystal 579, Gold and Silver 555; 577 / 553 walked into, the two ports stepped off |

`tools/checks/ledge_hops.gd` grew the carpet sweep (it already owns `player_movement.asm`'s refused-step branches) and now runs Silver as well as Gold and Crystal. `preview_world.gd` grew a `door` kind that photographs the player standing on the mat.