### PR TITLE
Keep the interface above a renderer and give a hop its arc

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -850,6 +850,17 @@ speed. `Gen2WorldObject.frame` is the cartridge's `Facings` index, 0 to 3,
 changing every four frames the way `SetFacingStepAction` does.
 `mods/examples/voxel_preview/` reads all of it.
 
+A hop is the one step with a second axis.
+`Gen2WorldAPI.player_height_offset_pixels()` and
+`Gen2WorldObject.height_offset_pixels()` return how far above the ground the
+sprite is drawn, in world pixels and positive upward, which is
+`UpdateJumpPosition`'s own `.y_offsets` table over the step's frames. It is zero
+at rest, zero on every ordinary step, and zero again on the frame the hop
+completes; only a ledge hop and the three `jump_step` movement commands raise it,
+and each of those covers two cells over twice its command's frames. Presentation
+only, like the horizontal offset beside it: the cell, the collision, the triggers
+and the snapshot are at the landing cell for the whole arc.
+
 Not covered: the teleport, skyfall and dig step types. `teleport_from`,
 `teleport_to`, `skyfall` and `step_dig` reach the caller as a
 `movement_command_requested` event and change nothing. None moves a cell on the

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3544,7 +3544,7 @@ func _build_renderer() -> void:
 		_renderer.queue_free()
 	_renderer = Gen2ModHost.instance().create_battle_renderer()
 	if Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
-		_screen.display(_renderer)
+		_screen.display_content(_renderer)
 	else:
 		_screen.display_native(_renderer)
 		_screen.native_size_changed.connect(_on_native_size_changed)

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -35,8 +35,19 @@ func _ready() -> void:
 
 
 ## Inside the screen, in hardware pixels: position it in the 160x144 space.
+##
+## Everything placed this way is interface, and sits above whatever
+## [method display_content] put there, in the order it was placed.
 func display(node: Node) -> void:
 	_viewport.add_child(node)
+
+
+## Renderer content, in hardware pixels, kept below every node [method display]
+## placed. A renderer rebuilt mid-screen would otherwise be appended after a live
+## text box and paint over it.
+func display_content(node: Node) -> void:
+	_viewport.add_child(node)
+	_viewport.move_child(node, 0)
 
 
 ## On the layer behind, in [method native_size] window pixels; the hardware

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -56,11 +56,16 @@ const STEP_FRAMES_TURN: int = 4
 ## How long each scripted step command takes, from the `STEP_*` speed it passes
 ## to `InitStep` (engine/overworld/movement.asm) and that row of `StepVectors`.
 ##
-## Every command here moves one cell, because every one of them reaches
-## `InitStep`: `NormalStep`, `SlideStep`, `JumpStep` and `TurningStep` all call
-## it and differ only in the `OBJECT_ACTION` they set over the top, a spin for
-## the three turning rows and a jump arc for the three jumping ones. The turning
-## rows keep the direction the command names; `turn_away` does not reverse it.
+## Every command here reaches `InitStep`: `NormalStep`, `SlideStep`, `JumpStep`
+## and `TurningStep` all call it and differ in the step type they set over the
+## top, a spin for the three turning rows and a jump for the three jumping ones.
+## The turning rows keep the direction the command names; `turn_away` does not
+## reverse it.
+##
+## The frames here are one cell's. The three jumping rows cover two: `JumpStep`
+## sets `STEP_TYPE_NPC_JUMP` or `STEP_TYPE_PLAYER_JUMP`, whose jumptables are
+## `.Jump` then `.Land` with a `GetNextTile` between them, so each spends this
+## many frames and the command lands two cells on (JUMP_STEP_KINDS below).
 ##
 ## `turn_step` is the one command that is not here: `TurnStep` sets
 ## STEP_TYPE_TURN, never calls `InitStep`, and `StepFunction_Turn` is two frames
@@ -79,6 +84,11 @@ const SCRIPTED_STEP_FRAMES: Dictionary = {
 	&"turn_in": STEP_FRAMES_WALK,
 	&"turn_waterfall": STEP_FRAMES_FAST,
 }
+## The three rows of SCRIPTED_STEP_FRAMES that are a hop: two cells, twice the
+## frames, and the arc `UpdateJumpPosition` draws over them.
+const JUMP_STEP_KINDS: Array[StringName] = [
+	&"slow_jump_step", &"jump_step", &"fast_jump_step",
+]
 ## The commands that only change a facing. `TurnHead` writes the direction and
 ## stands; `TurnStep` writes it two frames in and stands for two more.
 const SCRIPTED_TURN_KINDS: Array[StringName] = [&"turn_head", &"turn_step"]
@@ -645,7 +655,29 @@ func player_jump_offset() -> int:
 	if not _player_jumping or _player_step_frames_total <= 0:
 		return 0
 	var spent: int = _player_step_frames_total - _player_step_frames_remaining
-	return JUMP_OFFSETS[clampi(spent, 0, JUMP_OFFSETS.size() - 1)]
+	return jump_offset_at(spent, _player_step_frames_total)
+
+
+## The table entry a jump of [param total] frames is on after [param spent] of
+## them. `UpdateJumpPosition` indexes it with an accumulator stepped by the step
+## vector and halved, so a hop covering two cells in 16 frames advances one entry
+## a frame and every other duration covers the same table at its own rate: the
+## proportion is the accumulator.
+static func jump_offset_at(spent: int, total: int) -> int:
+	if total <= 0:
+		return 0
+	var index: int = spent * JUMP_OFFSETS.size() / total
+	return JUMP_OFFSETS[clampi(index, 0, JUMP_OFFSETS.size() - 1)]
+
+
+## How far above the ground the player is drawn this frame, in world pixels and
+## positive upward: the mod-facing spelling of player_jump_offset(), which is the
+## same arc in the renderer's own downward-positive draw space. Zero at rest, on
+## an ordinary step, and on the frame a hop completes. Presentation only: the
+## cell, the collision, the triggers and the snapshot are already at the landing
+## cell while this is above zero.
+func player_height_offset_pixels() -> float:
+	return float(-player_jump_offset())
 
 
 ## The in-flight walk step's presentation offset in fractional walk cells,
@@ -676,28 +708,34 @@ func player_walk_frame() -> int:
 	return (_player_step_frame >> 2) & 3
 
 
-func _start_player_step(direction: Vector2i, frames: int) -> void:
+func _start_player_step(
+	direction: Vector2i, frames: int, jumping: bool = false
+) -> void:
 	_player_queued_steps.clear()
 	_player_scripted_steps = false
-	_begin_player_step(direction, frames)
+	_begin_player_step(direction, frames, jumping)
 
 
 ## One step of a scripted stream, behind whatever the player is already walking.
 ## See Gen2WorldObject.queue_step().
-func _queue_player_step(direction: Vector2i, frames: int) -> void:
+func _queue_player_step(direction: Vector2i, frames: int, jumping: bool = false) -> void:
 	_player_scripted_steps = true
 	if _player_step_frames_remaining > 0:
-		_player_queued_steps.append({"direction": direction, "frames": maxi(0, frames)})
+		_player_queued_steps.append({
+			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
+		})
 		return
-	_begin_player_step(direction, frames)
+	_begin_player_step(direction, frames, jumping)
 
 
-func _begin_player_step(direction: Vector2i, frames: int) -> void:
-	## `StepFunction_PlayerJump` is the only step type that runs
-	## `UpdateJumpPosition`, and every other step type replaces it, so the arc
-	## belongs to the hop that set it and to nothing begun after it.
-	## `_try_ledge_hop` raises the flag again once this has cleared it.
-	_player_jumping = false
+func _begin_player_step(
+	direction: Vector2i, frames: int, jumping: bool = false
+) -> void:
+	## `StepFunction_PlayerJump` and `StepFunction_NPCJump` are the only step
+	## types that run `UpdateJumpPosition`, and every other step type replaces
+	## them, so the arc belongs to the hop that set it and to nothing begun after
+	## it. `_try_ledge_hop` and a `jump_step` raise the flag again.
+	_player_jumping = jumping
 	_player_step_direction = direction
 	_player_step_frames_total = maxi(0, frames)
 	_player_step_frames_remaining = _player_step_frames_total
@@ -730,7 +768,9 @@ func advance_player_step_frame() -> bool:
 			_player_scripted_steps = false
 		else:
 			var next: Dictionary = _player_queued_steps.pop_front()
-			_begin_player_step(next["direction"], int(next["frames"]))
+			_begin_player_step(
+				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
+			)
 	return true
 
 
@@ -3883,14 +3923,18 @@ func _apply_object_movement(event: Dictionary) -> Array:
 		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			object.apply_direction(direction)
-			var destination: Vector2i = object.cell + direction
+			var jumping: bool = kind in JUMP_STEP_KINDS
+			var cells: int = 2 if jumping else 1
+			var destination: Vector2i = object.cell + direction * cells
 			if _cell_in_bounds(destination):
 				object.cell = destination
 				# The cell commits here, as it does for every other step in this
 				# runtime; only the drawing trails. A stream applies in one call,
 				# so the whole path is queued and drawn a step at a time by
 				# advance_scripted_steps_frame().
-				object.queue_step(direction, int(SCRIPTED_STEP_FRAMES[kind]))
+				object.queue_step(
+					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping
+				)
 			else:
 				generated.append({
 					"type": &"movement_blocked", "object_index": object_index,
@@ -3996,10 +4040,14 @@ func _apply_player_movement(event: Dictionary) -> Array:
 		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			player_facing = _facing_for_direction(direction)
-			var destination: Vector2i = player_cell + direction
+			var jumping: bool = kind in JUMP_STEP_KINDS
+			var cells: int = 2 if jumping else 1
+			var destination: Vector2i = player_cell + direction * cells
 			if _cell_in_bounds(destination):
 				player_cell = destination
-				_queue_player_step(direction, int(SCRIPTED_STEP_FRAMES[kind]))
+				_queue_player_step(
+					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping
+				)
 			else:
 				generated.append({
 					"type": &"movement_blocked", "player": true, "cell": destination,
@@ -5031,8 +5079,7 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
 	_advance_followers(from_cell, previous_cells)
-	_start_player_step(direction * 2, STEP_FRAMES_HOP)
-	_player_jumping = true
+	_start_player_step(direction * 2, STEP_FRAMES_HOP, true)
 	return {
 		"ok": true,
 		"kind": &"ledge_hop",

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -87,6 +87,9 @@ var emote_remaining: int = 0
 var step_direction: Vector2i = Vector2i.ZERO
 var step_frames_total: int = 0
 var step_frames_remaining: int = 0
+## Whether the in-flight step is a `jump_step`, which is the only kind drawn
+## above its own cell. See height_offset_pixels().
+var step_jumping: bool = false
 ## Set on the frame a step starts and cleared by whoever reads it, which is the
 ## grass rustle `NormalStep` spawns there.
 var step_began: bool = false
@@ -152,6 +155,7 @@ func carry_presentation_from(previous: Gen2WorldObject) -> void:
 	step_direction = previous.step_direction
 	step_frames_total = previous.step_frames_total
 	step_frames_remaining = previous.step_frames_remaining
+	step_jumping = previous.step_jumping
 	queued_steps = previous.queued_steps.duplicate(true)
 	scripted_steps = previous.scripted_steps
 	step_frame = previous.step_frame
@@ -341,12 +345,14 @@ func start_step(direction: Vector2i, frames: int) -> void:
 ## Adds one step of a scripted stream to the trail. The first one starts at
 ## once and the rest wait their turn, so a five-step applymovement is drawn as
 ## five steps rather than as one arrival.
-func queue_step(direction: Vector2i, frames: int) -> void:
+func queue_step(direction: Vector2i, frames: int, jumping: bool = false) -> void:
 	scripted_steps = true
 	if step_frames_remaining > 0:
-		queued_steps.append({"direction": direction, "frames": maxi(0, frames)})
+		queued_steps.append({
+			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
+		})
 		return
-	_begin_step(direction, frames)
+	_begin_step(direction, frames, jumping)
 
 
 ## `Movement_tree_shake`: 24 frames of STEP_TYPE_SLEEP with
@@ -371,7 +377,10 @@ static func sleep_frames(length: int) -> int:
 	return length if length > 0 else 0x100
 
 
-func _begin_step(direction: Vector2i, frames: int) -> void:
+func _begin_step(direction: Vector2i, frames: int, jumping: bool = false) -> void:
+	# `StepFunction_NPCJump` is the only step type running `UpdateJumpPosition`,
+	# and every step begun after it replaces the type, so the arc ends here.
+	step_jumping = jumping
 	step_direction = direction
 	step_frames_total = maxi(0, frames)
 	step_frames_remaining = step_frames_total
@@ -400,7 +409,9 @@ func tick_step() -> bool:
 			scripted_steps = false
 		else:
 			var next: Dictionary = queued_steps.pop_front()
-			_begin_step(next["direction"], int(next["frames"]))
+			_begin_step(
+				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
+			)
 	return true
 
 
@@ -445,6 +456,18 @@ func is_idle() -> bool:
 func step_offset(cell_pixels: int) -> Vector2i:
 	var offset: Vector2 = step_offset_cells() * float(cell_pixels)
 	return Vector2i(int(round(offset.x)), int(round(offset.y)))
+
+
+## How far above the ground this object is drawn, in world pixels and positive
+## upward, matching Gen2WorldAPI.player_height_offset_pixels(). Zero unless a
+## `jump_step` is in flight; presentation only, the cell having committed to the
+## landing cell when the jump started.
+func height_offset_pixels() -> float:
+	if not step_jumping or step_frames_total <= 0:
+		return 0.0
+	return float(-Gen2WorldAPI.jump_offset_at(
+		step_frames_total - step_frames_remaining, step_frames_total
+	))
 
 
 ## The same offset in fractional walk cells, for a renderer that does not think

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -239,8 +239,11 @@ func _draw() -> void:
 		var texture: Texture2D = _actor_texture(
 			object.sprite, object.palette, object.facing, object.frame, object.big_object_shape()
 		)
+		# The same sprite offset the player's hop takes, so a `jump_step` in a
+		# movement stream arcs rather than sliding.
+		var object_jump := Vector2(0, -object.height_offset_pixels())
 		if texture != null:
-			draw_texture(texture, pixel)
+			draw_texture(texture, pixel + object_jump)
 		if _in_grass(object.cell):
 			_draw_grass_over(pixel, page, tile_origin, tile_offset, window_size)
 		if object.emote_visible:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -94,6 +94,9 @@ var _map_fade: Dictionary = {}
 var _map_name_sign: TextureRect = null
 var _map_name_sign_frames: int = 0
 var _text_box: Gen2TextBox = null
+var _text_box_rect: Rect2i = Rect2i()
+var _text_box_rect_pushed: bool = false
+var _text_box_rect_held: int = 0
 var _clock: Gen2WorldClock = null
 var _audio_player: Gen2AudioPlayer = null
 var _audio_waiting: bool = false
@@ -315,7 +318,7 @@ func _build_renderer() -> void:
 		_renderer.queue_free()
 	_renderer = Gen2ModHost.instance().create_world_renderer()
 	if Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
-		_screen.display(_renderer)
+		_screen.display_content(_renderer)
 	else:
 		_screen.display_native(_renderer)
 		_screen.native_size_changed.connect(_on_native_size_changed)
@@ -355,13 +358,25 @@ func _apply_renderer_interface_style() -> void:
 	if _text_box == null:
 		return
 	_text_box.field_opacity = Gen2ModHost.renderer_interface_opacity(_renderer)
+	# A renderer swapped in mid-scene has no rectangle, so this one is not deduped.
+	_text_box_rect_pushed = false
 	_push_text_box_rect()
 
 
+## Pushed only when the rectangle actually changes, and never while a page turn
+## is between the box it just closed and the box the next event opens: a renderer
+## composing around the box would otherwise pan away and back inside one
+## conversation. A conversation that really ends pushes the empty rectangle once,
+## because the empty one differs from the occupied one it replaces.
 func _push_text_box_rect() -> void:
-	if _text_box == null:
+	if _text_box == null or _text_box_rect_held > 0:
 		return
-	Gen2ModHost.renderer_set_text_box_rect(_renderer, _text_box.occupied_rect())
+	var rect: Rect2i = _text_box.occupied_rect()
+	if _text_box_rect_pushed and rect == _text_box_rect:
+		return
+	_text_box_rect = rect
+	_text_box_rect_pushed = true
+	Gen2ModHost.renderer_set_text_box_rect(_renderer, rect)
 
 
 ## What the renderer actually draws with, which is not always the clock: a dark
@@ -1177,6 +1192,12 @@ func move_up() -> void:
 
 func move_down() -> void:
 	move_player(Vector2i.DOWN)
+
+
+## The hop's own arc, for `preview_world.gd`'s `ledge` kind, which drives to the
+## top of it rather than spending a count.
+func player_height_offset_pixels() -> float:
+	return _world.player_height_offset_pixels() if _world != null else 0.0
 
 
 func world_snapshot() -> Dictionary:
@@ -2050,9 +2071,12 @@ func _advance_script_input() -> void:
 		return
 	if _text_box.advance():
 		return
+	_text_box_rect_held += 1
 	_text_box.visible = false
 	_script_prompt = ""
 	_show_script_results(_world.run_event_queue(true))
+	_text_box_rect_held -= 1
+	_push_text_box_rect()
 	_refresh_labels()
 
 

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -204,7 +204,8 @@ func refresh() -> void:
 	if _world == null or _camera == null:
 		return
 	var here: Vector3 = _player_position()
-	_player.position = here + Vector3(0.0, 0.6, 0.0)
+	# The hop is the card's alone: arcing the camera with it shakes the view.
+	_player.position = here + Vector3(0.0, 0.6 + _player_height(), 0.0)
 	_camera.position = here + _camera_offset()
 	_camera.look_at(here, Vector3.UP)
 	_rebuild_objects()
@@ -224,6 +225,13 @@ func _cell_center(cell: Vector2i) -> Vector3:
 func _player_position() -> Vector3:
 	var position: Vector2 = _world.player_position_cells()
 	return Vector3(position.x * CELL_SIZE, 0.0, position.y * CELL_SIZE)
+
+
+## The ledge hop's own arc, in cells: the host gives it in world pixels, and a
+## walk cell is Gen2WorldAPI.CELL_PIXELS of them.
+func _player_height() -> float:
+	return _world.player_height_offset_pixels() \
+		/ float(Gen2WorldAPI.CELL_PIXELS) * CELL_SIZE
 
 
 ## One solid per walk cell, extruded by what the cell's collision permission

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -169,6 +169,93 @@ func test_the_world_renderer_is_told_where_the_box_is_and_when_it_is_gone() -> v
 	assert_eq((renderer.get("rects") as Array).back(), Rect2i())
 
 
+## The screen owns everything above the renderer, so a renderer built after the
+## text box, which is what cycling back to the built-in one does, still goes
+## below it. Before this the fresh view was appended after the live box and
+## painted over the words being read.
+func test_a_renderer_rebuilt_mid_scene_stays_below_the_live_text_box() -> void:
+	await _open_world(HARDWARE_SOURCE)
+	var box: Gen2TextBox = _world_screen._text_box
+	box.show_text("HI")
+	box.finish()
+	box.visible = true
+	var texture: Texture2D = box.texture
+
+	assert_true(Gen2ModHost.instance().select_world_renderer(&"gen2")["ok"])
+	_world_screen._build_renderer()
+	var viewport: SubViewport = _world_screen._screen.viewport()
+	assert_eq(_world_screen._renderer.get_parent(), viewport, "still in the viewport")
+	assert_true(
+		viewport.get_children().find(_world_screen._renderer)
+			< viewport.get_children().find(box),
+		"and below the box rather than over it"
+	)
+	assert_eq(_world_screen._text_box, box, "the same live box node")
+	assert_eq(box.texture, texture, "with the glyphs it was already showing")
+	assert_true(box.visible)
+
+
+## The same rule in the battle screen, whose box is never hidden at all.
+func test_a_battle_renderer_rebuilt_mid_scene_stays_below_the_interface() -> void:
+	await _open_battle()
+	assert_true(Gen2ModHost.instance().select_battle_renderer(&"gen2")["ok"])
+	_battle_screen._build_renderer()
+	var viewport: SubViewport = _battle_screen._screen.viewport()
+	var children: Array = viewport.get_children()
+	assert_eq(children.find(_battle_screen._renderer), 0, "the renderer is the floor")
+	assert_true(children.find(_battle_screen._box) > 0)
+
+
+## A page turn hides the box and the next event shows it again inside one call,
+## so the rectangle a renderer composes around must not go empty between them: a
+## 3D view told the box had closed pans back to the player and away again.
+func test_one_conversation_never_publishes_an_empty_text_box_rect_between_pages() -> void:
+	var raw: Callable = func(source_opcode: int) -> int:
+		return Gen2WorldScript.raw_opcode(source_opcode, true)
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), {
+		Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TRAINER_SCRIPT): [
+			raw.call(0x90),
+		],
+		Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT): [
+			Gen2WorldScript.OPENTEXT,
+			Gen2WorldScript.WRITETEXT,
+			Fixture.SEEN_TEXT & 0xFF, Fixture.SEEN_TEXT >> 8,
+			Gen2WorldScript.WAITBUTTON,
+			Gen2WorldScript.WRITETEXT,
+			Fixture.WIN_TEXT & 0xFF, Fixture.WIN_TEXT >> 8,
+			Gen2WorldScript.WAITBUTTON,
+			Gen2WorldScript.CLOSETEXT,
+			raw.call(0x90),
+		],
+	})
+	_data = GameData.open_directory(Fixture.directory())
+	var renderer: Node = await _open_world(NATIVE_SOURCE)
+	var box: Gen2TextBox = _world_screen._text_box
+
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(Vector2i(4, 5))
+	)
+	box.finish()
+	assert_true(box.visible, "the first page is up")
+	var occupied: Rect2i = (renderer.get("rects") as Array).back() as Rect2i
+	assert_ne(occupied, Rect2i())
+
+	## Every page and button of it, driven the way a press does. The box closes
+	## and reopens inside those calls; the renderer must not hear about it.
+	var pushed: int = (renderer.get("rects") as Array).size()
+	for _press: int in 8:
+		if not box.visible:
+			break
+		box.finish()
+		_world_screen._advance_script_input()
+	assert_false(box.visible, "the conversation is over")
+	assert_eq(
+		(renderer.get("rects") as Array).size(), pushed + 1,
+		"one publication for the whole conversation, at the end of it"
+	)
+	assert_eq((renderer.get("rects") as Array).back(), Rect2i())
+
+
 func test_the_battle_screen_opens_the_same_seam() -> void:
 	var renderer: Node = await _open_battle()
 	assert_almost_eq(_battle_screen._box.field_opacity, 0.75, 0.001)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -890,6 +890,19 @@ func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
 	assert_eq(arc, Gen2WorldAPI.JUMP_OFFSETS)
 	assert_eq(world.player_jump_offset(), 0, "and the arc ends with the step")
 
+	## The mod-facing spelling of the same arc: world pixels, positive upward.
+	var lifted: Gen2WorldAPI = _world(Vector2i(3, 2))
+	assert_eq(lifted.player_height_offset_pixels(), 0.0, "at rest")
+	assert_eq(lifted.move_result(Vector2i.DOWN)["kind"], &"ledge_hop")
+	var cell: Vector2i = lifted.player_cell
+	var highest: float = 0.0
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_HOP:
+		highest = maxf(highest, lifted.player_height_offset_pixels())
+		assert_eq(lifted.player_cell, cell, "the cell is the landing cell throughout")
+		lifted.advance_player_step_frame()
+	assert_eq(highest, 12.0, "the top of .y_offsets, above the ground")
+	assert_eq(lifted.player_height_offset_pixels(), 0.0, "and back down on landing")
+
 	var walker: Gen2WorldAPI = _world(Vector2i(5, 11))
 	assert_true(bool(walker.move_result(Vector2i.UP).get("ok", false)))
 	assert_eq(walker.player_jump_offset(), 0)
@@ -3739,6 +3752,33 @@ func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> v
 		world.advance_player_step_frame()
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(_final_status(_run_script(world, dispatched)), &"complete")
+
+
+## `JumpStep` sets STEP_TYPE_NPC_JUMP, whose jumptable is `.Jump` then `.Land`
+## with a `GetNextTile` between them, so one `jump_step` covers two cells over
+## twice the duration and wears `UpdateJumpPosition`'s arc for the whole of it.
+func test_a_scripted_jump_step_covers_two_cells_and_arcs_over_them() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x33, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var object: Gen2WorldObject = world.objects[0]
+	var start: Vector2i = object.cell
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+	assert_eq(object.cell, start + Vector2i(2, 0), "two cells, committed at once")
+
+	var highest: float = 0.0
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK * 2:
+		assert_true(world.advance_scripted_steps_frame())
+		highest = maxf(highest, object.height_offset_pixels())
+	assert_eq(highest, 12.0, "the top of .y_offsets")
+	assert_eq(object.step_offset_cells(), Vector2.ZERO, "and the whole hop is drawn")
+	assert_eq(object.height_offset_pixels(), 0.0, "back on the ground where it lands")
 
 
 func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -> void:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -27,6 +27,8 @@ extends SceneTree
 ## `door` (`.CheckWarp`'s carpet: the player is walked down onto an interior
 ## door's mat and photographed standing on it, which the step itself no longer
 ## warps: `crystal 24 6 ... door 6 5` is the front door of the player's house),
+## `ledge` (the ledge hop at the top of its arc, walking south from the cell the
+## two numbers name until one allows the hop: `crystal 24 4 ... ledge 5 4`),
 ## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
 ## map's edge onto its neighbour: `crystal 24 4 ... map_name_sign 1 8` crosses
 ## New Bark Town into Route 29),
@@ -48,6 +50,9 @@ const WINDOW_SIZE := Vector2i(1152, 648)
 ## Longer than a step onto a warp tile and the fade behind it, for the `warp`
 ## kind, which drives to a frame rather than spending a count.
 const WARP_FRAME_CAP: int = 120
+## `UpdateJumpPosition`'s highest `.y_offsets` entry, which is where the `ledge`
+## kind photographs the hop.
+const LEDGE_ARC_TOP: float = 12.0
 ## Hardware frames spent after the sprites are staged. Two puts the grass rustle
 ## on its first facing and the boulder dust on its second, so every one of them
 ## is up and none is on the frame it was spawned. Cut needs more: its tree stands
@@ -215,6 +220,16 @@ func _process(_delta: float) -> bool:
 					## the player is still walking are spent before the picture.
 					_screen.advance_frames(Gen2WorldAPI.STEP_FRAMES_WALK)
 					break
+		elif _kind == &"ledge":
+			## `StepFunction_PlayerJump` at the top of its arc: the player is
+			## walked south until a cell allows the hop below it, and the picture
+			## is the frame `UpdateJumpPosition` draws highest
+			## (`crystal 24 4 ... ledge 5 4`).
+			for _frame: int in WARP_FRAME_CAP:
+				_screen.move_down()
+				_screen.advance_frame()
+				if _screen.player_height_offset_pixels() >= LEDGE_ARC_TOP:
+					break
 		elif _kind == &"map_name_sign":
 			## `MapSetupScript_Connection`'s `InitMapNameSign`: walked west off
 			## New Bark Town's edge onto Route 29, photographed while the sign
@@ -242,7 +257,7 @@ func _process(_delta: float) -> bool:
 				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
-		if _kind not in [&"warp", &"door", &"map_name_sign"]:
+		if _kind not in [&"warp", &"door", &"map_name_sign", &"ledge"]:
 			## Those two kinds drove themselves to the frame they want; every
 			## other kind stages a sprite and then spends the frames it needs.
 			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):


### PR DESCRIPTION
Two engine requests from the mod work, answered together.

**Renderer switching no longer paints over live interface.** `Gen2Screen.display_content` is a floor below everything `display` puts on the hardware viewport, so a renderer built after the text box, which is what cycling back to the built-in one does, stays under it. Both the world and the battle screen build through it.

**A conversation publishes one text-box rectangle, at the end of it.** The world screen pushes the rectangle only when it changes and never inside a page turn, so the hide-and-reshow between two events of one conversation is invisible to a renderer composing around the box. A conversation that really closes still pushes the empty rectangle, once.

**A hop has a second axis.** `Gen2WorldAPI.player_height_offset_pixels()` and `Gen2WorldObject.height_offset_pixels()` are `UpdateJumpPosition`'s `.y_offsets` in world pixels, positive upward, documented in `docs/MODS.md` and applied by the voxel preview to its player card.

One bug found on the way and fixed in the same commit: `JumpStep` sets a step type whose jumptable is `.Jump` then `.Land` with a `GetNextTile` between them, so `slow_jump_step`, `jump_step` and `fast_jump_step` each cover **two** cells over twice the command's frames. Each was walking one cell with no arc.

| Check | Result |
|---|---|
| GUT, both tiers | 3,103 tests over 150 scripts, green |
| `tools/validate.gd -- all` | exit 0 |
| `replay_world.gd` | 30 routes, 0 failures |
| Story walk, three profiles | ok, 295 / 292 / 292 steps |
| `preview_world.gd ... ledge` | new kind, photographed at the top of the arc |