### PR TITLE
Charge a text box what the cartridge charges, and follow the right leader

### DIFF
--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -81,6 +81,10 @@ const CHAR_DEXEND: int = 0x5F
 ## [method Gen2Text.character] can produce either of these.
 const PAGE_BREAK: String = "\ue000"
 const SCROLL_BREAK: String = "\ue001"
+## `_ContTextNoPause`, which `<SCROLL>` and `TextCommand_SCROLL` reach directly:
+## the same two `TextScroll`s with no `PromptButton` in front of them, so the box
+## rolls on without a press.
+const SCROLL_NOWAIT_BREAK: String = "\ue002"
 
 ## `GetWeekday`'s `.Days`, which `TextCommand_DAY` follows with "DAY".
 const WEEKDAYS: Array[String] = [
@@ -165,7 +169,7 @@ static func _run(
 			TX_LOW:
 				out += "\n"
 			TX_SCROLL:
-				out += SCROLL_BREAK
+				out += SCROLL_NOWAIT_BREAK
 			TX_PROMPT_BUTTON, TX_WAIT_BUTTON:
 				# Both wait for a press; only the first shows the arrow, which is
 				# the box's business rather than the string's.
@@ -226,8 +230,10 @@ static func _place(data: PackedByteArray, offset: int, context: Dictionary) -> D
 				out += "\n"
 			CHAR_PARA:
 				out += PAGE_BREAK
-			CHAR_CONT, CHAR_CONT_RAW, CHAR_SCROLL:
+			CHAR_CONT, CHAR_CONT_RAW:
 				out += SCROLL_BREAK
+			CHAR_SCROLL:
+				out += SCROLL_NOWAIT_BREAK
 			CHAR_WBR:
 				pass
 			CHAR_BSP:

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -46,6 +46,13 @@ const CURSOR_COLUMN: int = 18
 const CURSOR_BLINK_FRAMES: int = 16
 const FRAME_SECONDS: float = 1.0 / 60.0
 
+## `TextScroll` shifts the whole interior up one tile row, blanks the row it
+## leaves at the bottom and spends five frames. `_ContText` and
+## `_ContTextNoPause` both call it twice, which is one text line, since a box's
+## lines sit two rows apart.
+const SCROLL_STEPS: int = 2
+const SCROLL_STEP_FRAMES: int = 5
+
 const TILE: int = Gen2Font.TILE
 
 ## Tiles per second while a page is revealing. The games run this off the frame
@@ -92,6 +99,13 @@ var _lines: Array = []
 var _tiles_on_page: int = 0
 var _shown: float = 0.0
 var _blink: float = 0.0
+## The rows on their way off the top of the box while `TextScroll` runs, how far
+## up they have moved, and the page to start once they are gone. `_scroll_page`
+## is -1 whenever nothing is scrolling.
+var _scroll_lines: Array = []
+var _scroll_rows: int = 0
+var _scroll_elapsed: float = 0.0
+var _scroll_page: int = -1
 
 
 func _ready() -> void:
@@ -101,12 +115,20 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
+	if _scroll_page >= 0:
+		_advance_scroll(delta)
+		return
 	if _shown < float(_tiles_on_page):
 		_shown = minf(_shown + delta * reveal_speed, float(_tiles_on_page))
 		_redraw()
 		return
 	if _pages.is_empty():
 		set_process(false)
+		return
+	if _enter_of(_page + 1) == &"scroll_nowait":
+		# `_ContTextNoPause` has no `PromptButton` in front of it: the printer
+		# reaches the code, scrolls and carries on.
+		_begin_scroll(_page + 1)
 		return
 	# Waiting: only the arrow changes, and only when it crosses a half period.
 	var was_up: bool = _cursor_up()
@@ -123,14 +145,26 @@ func place_at_bottom() -> void:
 
 ## Lays [param text] out and starts revealing its first page.
 func show_text(text: String) -> void:
-	_pages = Gen2TextLayout.lay_out(text, text_columns(), text_rows())
+	_pages = Gen2TextLayout.lay_out_pages(text, text_columns(), text_rows())
 	_page = 0
+	_scroll_page = -1
+	_scroll_lines = []
 	_start_page()
 
 
-## True while a page still has tiles left to reveal.
+## True while a page still has tiles left to reveal, or while the box is in the
+## middle of a scroll: neither has reached its `PromptButton` yet.
 func is_revealing() -> bool:
-	return _shown < float(_tiles_on_page)
+	return _scroll_page >= 0 or _shown < float(_tiles_on_page)
+
+
+## Every line the box is holding, its pages in order. What is on screen is read
+## through this rather than through the pagination behind it.
+func text_lines() -> PackedStringArray:
+	var out: PackedStringArray = PackedStringArray()
+	for page: Dictionary in _pages:
+		out.append_array(page["lines"])
+	return out
 
 
 ## Whether a page after this one is still waiting, which is what the blinking
@@ -143,6 +177,8 @@ func has_pages_left() -> bool:
 
 ## Reveals the rest of the current page at once.
 func finish() -> void:
+	if _scroll_page >= 0:
+		_end_scroll()
 	_shown = float(_tiles_on_page)
 	set_process(false)
 	_redraw()
@@ -156,6 +192,10 @@ func advance() -> bool:
 		return false
 	if is_revealing():
 		finish()
+		return true
+
+	if _enter_of(_page + 1) == &"scroll":
+		_begin_scroll(_page + 1)
 		return true
 
 	_page += 1
@@ -199,11 +239,78 @@ func text_rows() -> int:
 	return maxi((rows - 1 - TEXT_TOP) / LINE_SPACING + 1, 0)
 
 
+## How the page at [param index] is reached, and `&""` when there is no such
+## page.
+func _enter_of(index: int) -> StringName:
+	if index < 0 or index >= _pages.size():
+		return &""
+	return StringName(_pages[index].get("enter", &"page"))
+
+
+## Starts `TextScroll`'s two steps, with the lines that are on screen moving up
+## through the interior and off the top of it.
+func _begin_scroll(next_page: int) -> void:
+	_scroll_lines = _lines.duplicate()
+	_scroll_rows = 1
+	_scroll_elapsed = 0.0
+	_scroll_page = next_page
+	_lines = []
+	_tiles_on_page = 0
+	_shown = 0.0
+	set_process(true)
+	_redraw()
+
+
+func _advance_scroll(delta: float) -> void:
+	advance_scroll_frames(delta / FRAME_SECONDS)
+
+
+## [param frames] hardware frames of `TextScroll`. Counted in frames rather than
+## seconds so a tool spending them one at a time lands on the same step the
+## clock does; see [method is_scrolling].
+func advance_scroll_frames(frames: float) -> void:
+	if _scroll_page < 0:
+		return
+	_scroll_elapsed += frames
+	while _scroll_elapsed >= float(SCROLL_STEP_FRAMES):
+		_scroll_elapsed -= float(SCROLL_STEP_FRAMES)
+		if _scroll_rows >= SCROLL_STEPS:
+			_end_scroll()
+			return
+		_scroll_rows += 1
+		_redraw()
+
+
+## Whether `TextScroll`'s two steps are running, which is the one wait that is
+## neither a page turn nor a reveal.
+func is_scrolling() -> bool:
+	return _scroll_page >= 0
+
+
+## Puts the page the scroll was heading for up. Its first line is the one that
+## was underneath, which is where `_ContText` leaves it.
+func _end_scroll() -> void:
+	var next_page: int = _scroll_page
+	_scroll_page = -1
+	_scroll_lines = []
+	_scroll_rows = 0
+	if next_page < 0:
+		return
+	_page = next_page
+	if _page >= _pages.size():
+		_pages = []
+		_lines = []
+		_tiles_on_page = 0
+		finished.emit()
+		return
+	_start_page()
+
+
 func _start_page() -> void:
 	_lines = []
 	_tiles_on_page = 0
 	if _page < _pages.size():
-		for line: String in _pages[_page]:
+		for line: String in _pages[_page]["lines"]:
 			var codes: PackedByteArray = Gen2Text.encode(line)
 			_lines.append(codes)
 			_tiles_on_page += codes.size()
@@ -268,6 +375,8 @@ func _draw_border(indices: PackedByteArray, width: int) -> void:
 func _draw_cursor(indices: PackedByteArray, width: int) -> void:
 	if _pages.is_empty() or is_revealing() or not _cursor_up():
 		return
+	if _enter_of(_page + 1) == &"scroll_nowait":
+		return
 	if CURSOR_COLUMN >= columns or rows <= 0:
 		return
 	font.draw_code(
@@ -276,6 +385,9 @@ func _draw_cursor(indices: PackedByteArray, width: int) -> void:
 
 
 func _draw_lines(indices: PackedByteArray, width: int) -> void:
+	if _scroll_page >= 0:
+		_draw_scrolling_lines(indices, width)
+		return
 	var left: int = 0
 	for i: int in _lines.size():
 		var codes: PackedByteArray = _lines[i]
@@ -287,3 +399,18 @@ func _draw_lines(indices: PackedByteArray, width: int) -> void:
 				codes[tile], indices, width, (TEXT_LEFT + tile) * TILE, top
 			)
 		left += codes.size()
+
+
+## The interior mid-`TextScroll`: every line one tile row higher per step, and
+## the row that reaches the border gone, which is what the second copy does to
+## the first line on the cartridge.
+func _draw_scrolling_lines(indices: PackedByteArray, width: int) -> void:
+	for i: int in _scroll_lines.size():
+		var codes: PackedByteArray = _scroll_lines[i]
+		var row: int = TEXT_TOP + i * LINE_SPACING - _scroll_rows
+		if row < 1:
+			continue
+		for tile: int in codes.size():
+			font.draw_code(
+				codes[tile], indices, width, (TEXT_LEFT + tile) * TILE, row * TILE
+			)

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -79,35 +79,56 @@ static func paginate(lines: PackedStringArray, rows: int) -> Array:
 ## paragraph that runs past two.
 static func lay_out(text: String, columns: int, rows: int) -> Array:
 	var out: Array = []
+	for page: Dictionary in lay_out_pages(text, columns, rows):
+		out.append(page["lines"])
+	return out
+
+
+## The same pages with what each of them costs to reach, which is what a box
+## animating a scroll needs and a caller only counting lines does not.
+##
+## `enter` is `&"page"` for a `Paragraph`, whose box is cleared and which waits
+## for a press first; `&"scroll"` for `_ContText`, which waits and then runs
+## `TextScroll` twice; and `&"scroll_nowait"` for `_ContTextNoPause`, which is
+## the same two scrolls with nothing waited for. The first page is `&"start"`.
+static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
+	var out: Array = []
 	if rows <= 0 or columns <= 0:
 		return out
 	var page: PackedStringArray = PackedStringArray()
+	var enter: StringName = &"start"
 	var at: int = 0
 	while at <= text.length():
 		var page_at: int = text.find(Gen2TextStream.PAGE_BREAK, at)
 		var scroll_at: int = text.find(Gen2TextStream.SCROLL_BREAK, at)
+		var nowait_at: int = text.find(Gen2TextStream.SCROLL_NOWAIT_BREAK, at)
 		var stop: int = page_at
-		if stop < 0 or (scroll_at >= 0 and scroll_at < stop):
-			stop = scroll_at
+		for candidate: int in [scroll_at, nowait_at]:
+			if candidate >= 0 and (stop < 0 or candidate < stop):
+				stop = candidate
 		var segment: String = text.substr(at, -1) if stop < 0 else text.substr(at, stop - at)
 		for line: String in wrap_lines(segment, columns):
 			page.append(line)
 			if page.size() == rows:
-				out.append(page)
+				out.append({"lines": page, "enter": enter})
 				page = PackedStringArray()
+				enter = &"page"
 		if stop < 0:
 			break
-		var scrolled: bool = stop == scroll_at
+		var scrolled: bool = stop == scroll_at or stop == nowait_at
 		if not page.is_empty():
-			out.append(page)
-		page = PackedStringArray()
-		if scrolled and not out.is_empty():
-			var previous: PackedStringArray = out[out.size() - 1]
-			if not previous.is_empty():
-				page.append(previous[previous.size() - 1])
+			out.append({"lines": page, "enter": enter})
+			page = PackedStringArray()
+		enter = &"page"
+		if scrolled:
+			enter = &"scroll" if stop == scroll_at else &"scroll_nowait"
+			if not out.is_empty():
+				var previous: PackedStringArray = out[out.size() - 1]["lines"]
+				if not previous.is_empty():
+					page.append(previous[previous.size() - 1])
 		at = stop + 1
 	if not page.is_empty():
-		out.append(page)
+		out.append({"lines": page, "enter": enter})
 	return out
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3799,6 +3799,11 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 				int(event.get("map_group", -1)), int(event.get("map_number", -1)),
 				int(event.get("object_index", -1))
 			)
+			## `wObjectFollow_Leader` and `wObjectFollow_Follower` are one byte
+			## each, and `SetFollowerIfVisible` runs `ResetFollower` before it
+			## writes: a second `follow` replaces the pair rather than adding to
+			## it.
+			_object_followers.clear()
 			_object_followers[follow_key] = {
 				"target_index": int(event.get("target_index", -1)),
 				"exact": bool(event.get("exact", true)),
@@ -3927,6 +3932,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 			var cells: int = 2 if jumping else 1
 			var destination: Vector2i = object.cell + direction * cells
 			if _cell_in_bounds(destination):
+				var vacated: Vector2i = object.cell
 				object.cell = destination
 				# The cell commits here, as it does for every other step in this
 				# runtime; only the drawing trails. A stream applies in one call,
@@ -3935,6 +3941,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				object.queue_step(
 					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping
 				)
+				_advance_followers(object_index, vacated)
 			else:
 				generated.append({
 					"type": &"movement_blocked", "object_index": object_index,
@@ -4044,10 +4051,12 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			var cells: int = 2 if jumping else 1
 			var destination: Vector2i = player_cell + direction * cells
 			if _cell_in_bounds(destination):
+				var vacated: Vector2i = player_cell
 				player_cell = destination
 				_queue_player_step(
 					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping
 				)
+				_advance_followers(-1, vacated)
 			else:
 				generated.append({
 					"type": &"movement_blocked", "player": true, "cell": destination,
@@ -4728,66 +4737,86 @@ func _remember_object_position(object: Gen2WorldObject) -> void:
 	_object_facing_overrides[key] = object.facing
 
 
+## Every follower of [param leader_index] steps into the cell that leader has
+## just left. `follow` names the leader first and the follower second, and the
+## follower may be the player, so this is driven by an object's scripted step as
+## well as by a player one; [param leader_index] is -1 for the player.
+##
 ## Follower steps commit on the map bounds alone, for the same reason a scripted
 ## step and a trainer approach do: MovementFunction_Follow is HandleMovementData
 ## over the queued leader commands (engine/overworld/map_objects.asm), so every
 ## one of them lands in NormalStep and never reaches CanObjectMoveInDirection.
-func _advance_followers(previous_player_cell: Vector2i, previous_cells: Dictionary) -> void:
+func _advance_followers(leader_index: int, leader_from_cell: Vector2i) -> void:
+	if current_map == null:
+		return
 	var relations: Array = []
 	for key: String in _object_followers:
 		var separator: PackedStringArray = key.split(":")
 		if separator.size() != 3 or int(separator[0]) != current_map.group \
 			or int(separator[1]) != current_map.number:
 			continue
-		relations.append({
-			"key": key,
-			"index": int(separator[2]),
-			"relation": (_object_followers[key] as Dictionary).duplicate(true),
-		})
+		var relation: Dictionary = _object_followers[key]
+		if int(relation.get("target_index", -1)) != leader_index:
+			continue
+		relations.append({"index": int(separator[2]), "relation": relation.duplicate(true)})
 	relations.sort_custom(func(first: Dictionary, second: Dictionary) -> bool:
 		return int(first["index"]) < int(second["index"])
 	)
 	for entry: Dictionary in relations:
-		var follower_index: int = int(entry["index"])
-		if follower_index < 0 or follower_index >= objects.size():
-			continue
-		var follower: Gen2WorldObject = objects[follower_index]
+		_step_follower(
+			int(entry["index"]), leader_from_cell,
+			bool((entry["relation"] as Dictionary).get("exact", true))
+		)
+
+
+## One follower's step toward [param target_cell], which is the cell its leader
+## has just left. An index below zero is the player, who is the object the
+## source counts as zero and who is the follower in every `follow <NPC>, PLAYER`.
+func _step_follower(follower_index: int, target_cell: Vector2i, exact: bool) -> void:
+	var follower_cell: Vector2i = player_cell
+	var follower: Gen2WorldObject = null
+	if follower_index >= 0:
+		if follower_index >= objects.size():
+			return
+		follower = objects[follower_index]
 		if not follower.active or follower.deleted:
-			continue
-		var relation: Dictionary = entry["relation"]
-		var target_index: int = int(relation.get("target_index", -1))
-		var exact: bool = bool(relation.get("exact", true))
-		var target_cell: Vector2i = previous_player_cell
-		if target_index >= 0 and previous_cells.has(target_index):
-			target_cell = previous_cells[target_index]
-		elif target_index >= 0 and target_index < objects.size():
-			target_cell = (objects[target_index] as Gen2WorldObject).cell
-		var delta: Vector2i = target_cell - follower.cell
-		if abs(delta.x) + abs(delta.y) <= 1:
-			continue
-		var direction: Vector2i
-		if exact and abs(delta.x) != 0 and abs(delta.y) != 0:
-			# Exact followers preserve the leader's cardinal path instead of
-			# cutting a diagonal corner.
-			direction = Vector2i(signi(delta.x), 0) if abs(delta.x) >= abs(delta.y) \
-				else Vector2i(0, signi(delta.y))
-		elif abs(delta.x) >= abs(delta.y):
-			direction = Vector2i(signi(delta.x), 0)
-		else:
-			direction = Vector2i(0, signi(delta.y))
-		var destination: Vector2i = follower.cell + direction
-		if _cell_in_bounds(destination):
-			follower.cell = destination
-			follower.apply_direction(direction)
-			# The player's own walk duration, not the slower wandering one:
-			# QueueFollowerFirstStep queues `movement_step` and the queue after
-			# it holds the leader's own command bytes.
-			follower.start_step(direction, STEP_FRAMES_WALK)
-			var override_key: String = _object_key(
-				current_map.group, current_map.number, follower_index
-			)
-			_object_position_overrides[override_key] = follower.cell
-			_object_facing_overrides[override_key] = follower.facing
+			return
+		follower_cell = follower.cell
+	## The queue holds the leader's own command bytes one step behind it, so a
+	## follower steps into the cell just vacated however close it already is;
+	## only a follower standing in that cell has nothing to walk to.
+	var delta: Vector2i = target_cell - follower_cell
+	if delta == Vector2i.ZERO:
+		return
+	var direction: Vector2i
+	if exact and abs(delta.x) != 0 and abs(delta.y) != 0:
+		# Exact followers preserve the leader's cardinal path instead of
+		# cutting a diagonal corner.
+		direction = Vector2i(signi(delta.x), 0) if abs(delta.x) >= abs(delta.y) \
+			else Vector2i(0, signi(delta.y))
+	elif abs(delta.x) >= abs(delta.y):
+		direction = Vector2i(signi(delta.x), 0)
+	else:
+		direction = Vector2i(0, signi(delta.y))
+	var destination: Vector2i = follower_cell + direction
+	if not _cell_in_bounds(destination):
+		return
+	# The player's own walk duration, not the slower wandering one:
+	# QueueFollowerFirstStep queues `movement_step` and the queue after it holds
+	# the leader's own command bytes.
+	if follower == null:
+		player_cell = destination
+		player_facing = _facing_for_direction(direction)
+		_queue_player_step(direction, STEP_FRAMES_WALK)
+		return
+	follower.cell = destination
+	follower.apply_direction(direction)
+	follower.queue_step(direction, STEP_FRAMES_WALK)
+	var override_key: String = _object_key(
+		current_map.group, current_map.number, follower_index
+	)
+	_object_position_overrides[override_key] = follower.cell
+	_object_facing_overrides[override_key] = follower.facing
 
 
 ## Moves one cell or enters a neighboring map when the step leaves a connected
@@ -4886,9 +4915,6 @@ func move_result(direction: Vector2i) -> Dictionary:
 		return {"ok": false, "kind": &"move", "reason": &"blocked"}
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
-	var previous_cells: Dictionary = {}
-	for index: int in objects.size():
-		previous_cells[index] = (objects[index] as Gen2WorldObject).cell
 	## .TrySurf's .ExitWater: .GetOutOfWater restores PLAYER_NORMAL and the walking
 	## sprite before .DoStep runs, so the state is already back to walking while
 	## the step onto land is still being taken.
@@ -4904,7 +4930,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 	player_cell = destination
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
-	_advance_followers(from_cell, previous_cells)
+	_advance_followers(-1, from_cell)
 	_start_player_step(direction, _step_frames_for_movement())
 	return {
 		"ok": true,
@@ -4961,13 +4987,10 @@ func _forced_turn() -> Dictionary:
 func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
-	var previous_cells: Dictionary = {}
-	for index: int in objects.size():
-		previous_cells[index] = (objects[index] as Gen2WorldObject).cell
 	player_cell = destination
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
-	_advance_followers(from_cell, previous_cells)
+	_advance_followers(-1, from_cell)
 	_start_player_step(direction, STEP_FRAMES_WALK)
 	return {
 		"ok": true,
@@ -5072,13 +5095,10 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 		return {}
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
-	var previous_cells: Dictionary = {}
-	for index: int in objects.size():
-		previous_cells[index] = (objects[index] as Gen2WorldObject).cell
 	player_cell = landing
 	player_facing = _facing_for_direction(direction)
 	state.consume_repel_step()
-	_advance_followers(from_cell, previous_cells)
+	_advance_followers(-1, from_cell)
 	_start_player_step(direction * 2, STEP_FRAMES_HOP, true)
 	return {
 		"ok": true,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -117,6 +117,12 @@ var _credits_host: Gen2CreditsScreen = null
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
+## Whether the text on screen owes a press of its own. A `writetext` whose last
+## page ends in `<DONE>` does not: `MapTextbox` prints and returns, and the
+## press is the `waitbutton` behind the command.
+var _text_awaits_press: bool = true
+## How many presses [method preview_text_scroll] will spend looking for one.
+const PREVIEW_TEXT_PRESSES: int = 8
 ## `ProfOaksPCBoot`'s three texts, one page at a time, and the sfx `Rate` leaves
 ## for it to play once the last of them is up.
 var _oak_pc_pages: Array = []
@@ -1402,6 +1408,28 @@ func preview_pokepic(species: int) -> void:
 	_refresh_labels()
 
 
+## Public screenshot driver for `_ContText`'s scroll: the object in front of the
+## player is talked to and its text walked to the `<CONT>` that scrolls, and the
+## box's own frames are then spent by hand so the picture is the same every run
+## rather than whatever the wall clock reached.
+func preview_text_scroll() -> void:
+	if _text_box == null:
+		return
+	## A `BGEVENT_READ` is read from the cell below it, so the sign is faced
+	## first; its own tile is a wall, so this turns rather than steps.
+	move_up()
+	interact()
+	for _press: int in PREVIEW_TEXT_PRESSES:
+		if _text_box.is_scrolling():
+			break
+		_advance_script_pause()
+	_text_box.set_process(false)
+	## One frame into the first of `TextScroll`'s two steps, where the two lines
+	## sit on rows no finished page can put them on.
+	_text_box.advance_scroll_frames(1.0)
+	_refresh_labels()
+
+
 ## Public screenshot driver. It executes the first active scripted event in
 ## source order, which keeps the debug image tied to imported map data.
 func preview_script_event() -> void:
@@ -2070,11 +2098,31 @@ func _advance_script_input() -> void:
 		_text_box.finish()
 		return
 	if _text_box.advance():
+		## The press that reaches a `<DONE>` last page is that page's `<PARA>`,
+		## not an acknowledgement of the text: the script runs on behind it.
+		if not _text_awaits_press and not _text_box.has_pages_left():
+			_continue_after_text()
 		return
 	_text_box_rect_held += 1
 	_text_box.visible = false
 	_script_prompt = ""
 	_show_script_results(_world.run_event_queue(true))
+	_text_box_rect_held -= 1
+	_push_text_box_rect()
+	_refresh_labels()
+
+
+## Runs a script on past a text that owes no press, leaving the box up: the
+## cartridge closes it at `closetext`, not at the end of a `writetext`. So the
+## box is taken down only where nothing is left to print into it.
+func _continue_after_text() -> void:
+	_text_awaits_press = true
+	_text_box_rect_held += 1
+	_script_prompt = ""
+	_show_script_results(_world.run_event_queue(true))
+	if _text_box != null and StringName(_world.pending_script_input().get("type", &"")) \
+		not in [&"text", &"button"] and _world.pending_script_wait().is_empty():
+		_text_box.visible = false
 	_text_box_rect_held -= 1
 	_push_text_box_rect()
 	_refresh_labels()
@@ -3204,6 +3252,7 @@ func _on_service_completed(results: Array) -> void:
 
 
 func _show_script_results(results: Array) -> void:
+	var continue_after_text: bool = false
 	var waiting: bool = false
 	var failed: bool = false
 	var map_changed: bool = false
@@ -3236,6 +3285,9 @@ func _show_script_results(results: Array) -> void:
 					_text_box.show_text(String(event.get("text", "")))
 					_text_box.visible = true
 				_script_prompt = "A: advance text"
+				_text_awaits_press = bool(event.get("prompt", true))
+				continue_after_text = not _text_awaits_press \
+					and not _text_box.has_pages_left()
 			elif event_type == &"button":
 				if _text_box != null:
 					_text_box.visible = true
@@ -3379,6 +3431,11 @@ func _show_script_results(results: Array) -> void:
 			_play_current_map_music()
 		else:
 			_renderer.refresh()
+	## Decided in the loop and spent here, because a special drawing its own
+	## pages is an event on the same result as the text waiting behind them.
+	if continue_after_text and _oak_pc_pages.is_empty():
+		_continue_after_text()
+		return
 	_refresh_labels()
 
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1845,9 +1845,16 @@ func _execute_object_command(source_opcode: int, command: Dictionary) -> Diction
 			})
 			_stage_object_event_flag(int(command.get("object_id", 0)), false)
 		0x6F, 0x76:
+			## `StartFollow` takes the FIRST operand through `SetLeaderIfVisible`
+			## and the second through `SetFollowerIfVisible`, which is the object
+			## that takes SPRITEMOVEDATA_FOLLOWING. So the first leads and the
+			## second follows; the macro's own operand comments say the reverse.
+			## Reading them the other way round leaves the player standing where
+			## `NewBarkTown_TeacherBringsYouBackMovement` should have walked them
+			## and steps the rival out of the cell he pushed the player from.
 			_emit_object_event(&"object_follow", {
-				"object_index": _object_index_from_id(int(command.get("object_id", 0))),
-				"target_index": _object_index_from_id(int(command.get("object_id_2", 0))),
+				"object_index": _object_index_from_id(int(command.get("object_id_2", 0))),
+				"target_index": _object_index_from_id(int(command.get("object_id", 0))),
 				"exact": source_opcode == 0x6F,
 			})
 		0x70:
@@ -3250,6 +3257,13 @@ func _show_text(bank: int, address: int, finish_after: bool) -> Dictionary:
 		"text": String(decoded.get("text", "")),
 		"bank": bank,
 		"address": address,
+		## `Script_writetext` is `MapTextbox` and returns: only `<PROMPT>`,
+		## `text_promptbutton` and `text_waitbutton` spend a press inside the
+		## text. A text ending in `<DONE>` therefore owes none of its own, and
+		## the press belongs to the `waitbutton` behind the command.
+		## `JumpTextScript` carries that `waitbutton` itself, which is what
+		## [param finish_after] names.
+		"prompt": finish_after or bool(decoded.get("prompt", false)),
 		"source": _request.duplicate(true),
 	}
 	_finish_after_pending = finish_after

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -260,10 +260,7 @@ func _open_party() -> Gen2PartyScreen:
 ## The text box holds its message as wrapped lines, so the assertions below
 ## rejoin them rather than depending on where the wrap lands.
 func _shown_text() -> String:
-	var lines: PackedStringArray = PackedStringArray()
-	for page: PackedStringArray in _world_screen._text_box.get("_pages"):
-		lines.append_array(page)
-	return " ".join(lines)
+	return " ".join(_world_screen._text_box.text_lines())
 
 
 func _labels(items: Array) -> Array:

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -295,7 +295,12 @@ func test_pending_special_call_dispatches_the_imported_script() -> void:
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_true(_world_screen._world.script_input_waiting())
-	assert_eq(_world_screen._world.pending_script_input()["text"], "PHONE SCRIPT")
+	## `writetext` prints and returns: the `waitbutton` behind it is what the
+	## script is holding on, and the words are on the box either way.
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"button"
+	)
+	assert_eq(" ".join(_world_screen._text_box.text_lines()), "PHONE SCRIPT")
 	## The first press completes the revealing page, as holding A does in
 	## `PrintLetterDelay`; the second acknowledges it.
 	_world_screen._advance_script_input()
@@ -353,7 +358,12 @@ func test_phone_list_starts_the_source_timed_outgoing_ring() -> void:
 	_world_screen.advance_frames(4 * Gen2WorldPhoneRing.TOTAL_FRAMES)
 	await get_tree().process_frame
 	assert_true(_world_screen._world.script_input_waiting())
-	assert_eq(_world_screen._world.pending_script_input()["text"], "PHONE SCRIPT")
+	## `writetext` prints and returns: the `waitbutton` behind it is what the
+	## script is holding on, and the words are on the box either way.
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"button"
+	)
+	assert_eq(" ".join(_world_screen._text_box.text_lines()), "PHONE SCRIPT")
 
 
 ## `PokegearPhoneContactSubmenu`'s DELETE row and the yes/no box behind it:
@@ -522,10 +532,12 @@ func _write_phone_request() -> void:
 	_write_request_script([0x9C, 0x01, 0x00, 0x91], 0x6320)
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6400)] = [
-		0x4B, Fixture.BANK, 0x00, 0x70, 0x9C, 0x00, 0x00, 0x91,
+		0x4B, Fixture.BANK, 0x00, 0x70, Gen2WorldScript.WAITBUTTON,
+		0x9C, 0x00, 0x00, 0x91,
 	]
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6500)] = [
-		0x4B, Fixture.BANK, 0x00, 0x70, 0x9C, 0x00, 0x00, 0x91,
+		0x4B, Fixture.BANK, 0x00, 0x70, Gen2WorldScript.WAITBUTTON,
+		0x9C, 0x00, 0x00, 0x91,
 	]
 	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
 	var phone_text: Array = [Gen2WorldScript.TEXT_START]

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -302,7 +302,11 @@ func test_production_world_entry_and_facing_object_story_persist_separate_flags(
 	_world_screen._world.player_cell = Vector2i(4, 3)
 	_world_screen._world.player_facing = Gen2WorldSprite.FACING_RIGHT
 	assert_true(_world_screen.interact())
-	assert_eq(_world_screen._world.pending_script_input()["type"], &"text")
+	## The `waitbutton` behind the `writetext`, which is what a text ending in
+	## `<DONE>` leaves the script holding on.
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"button"
+	)
 	assert_false(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_false(_world_screen._world.state.hall_of_fame())
 
@@ -676,6 +680,9 @@ func _install_story_slice() -> void:
 	]
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, STORY_OBJECT)] = [
 		Gen2WorldScript.WRITETEXT, STORY_TEXT & 0xFF, STORY_TEXT >> 8,
+		## The `waitbutton` every talked-to script carries behind its text:
+		## `writetext` itself prints and returns.
+		Gen2WorldScript.WAITBUTTON,
 		Gen2WorldScript.SETEVENT, STORY_EVENT_FLAG, 0,
 		Gen2WorldScript.SETFLAG, Gen2WorldState.ENGINE_HALL_OF_FAME, 0,
 		Gen2WorldScript.END,

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -1,7 +1,9 @@
 extends GutTest
 
-## Wrapping and pagination. No font, no screen: the whole of what a text box
-## decides about a string can be settled here.
+## Wrapping, pagination, and the box walking the pages they make. No font and no
+## screen are needed for any of it: [method Gen2TextBox._redraw] draws nothing
+## without a font, so the paging and the scroll can be driven frame by frame
+## here rather than photographed.
 
 const COLUMNS: int = 18
 const ROWS: int = 2
@@ -79,3 +81,63 @@ func test_nothing_is_lost_between_the_string_and_the_pages() -> void:
 		for line: String in page:
 			words.append_array(line.split(" ", false))
 	assert_eq(" ".join(words), text)
+
+
+## `Paragraph`, `_ContText` and `_ContTextNoPause` are three different ways into
+## the next page, and only the box can tell them apart from the lines.
+func test_a_page_says_how_it_was_reached() -> void:
+	var text: String = "a" + Gen2TextStream.PAGE_BREAK + "b" \
+		+ Gen2TextStream.SCROLL_BREAK + "c" + Gen2TextStream.SCROLL_NOWAIT_BREAK + "d"
+	var pages: Array = Gen2TextLayout.lay_out_pages(text, COLUMNS, ROWS)
+	assert_eq(pages.size(), 4)
+	assert_eq(StringName(pages[0]["enter"]), &"start")
+	assert_eq(StringName(pages[1]["enter"]), &"page")
+	assert_eq(StringName(pages[2]["enter"]), &"scroll")
+	assert_eq(StringName(pages[3]["enter"]), &"scroll_nowait")
+	## Both scrolls keep the line that was underneath, which a cleared page does
+	## not.
+	assert_eq(pages[1]["lines"], PackedStringArray(["b"]))
+	assert_eq(pages[2]["lines"], PackedStringArray(["b", "c"]))
+
+
+const FRAME: float = 1.0 / 60.0
+
+
+func _box() -> Gen2TextBox:
+	var box: Gen2TextBox = autofree(Gen2TextBox.new())
+	box.columns = Gen2TextBox.STANDARD_COLUMNS
+	box.rows = Gen2TextBox.STANDARD_ROWS
+	# Nothing to reveal a tile at a time: this is about the waits between pages.
+	box.reveal_speed = 0.0
+	return box
+
+
+## `_ContText` is `PromptButton` and then `TextScroll` twice, five frames each,
+## so a continuation costs one press and ten frames rather than a page turn.
+func test_a_continuation_scrolls_for_ten_frames_after_its_press() -> void:
+	var box: Gen2TextBox = _box()
+	box.show_text("a" + Gen2TextStream.SCROLL_BREAK + "b")
+	assert_true(box.has_pages_left())
+	assert_false(box.is_revealing(), "the first page is up and waiting")
+
+	assert_true(box.advance(), "the press starts the scroll rather than the page")
+	assert_true(box.is_revealing(), "and nothing is waited for while it runs")
+	for _frame: int in Gen2TextBox.SCROLL_STEP_FRAMES * Gen2TextBox.SCROLL_STEPS - 1:
+		box._process(FRAME)
+		assert_true(box.is_revealing(), "still scrolling")
+	box._process(FRAME)
+	assert_false(box.is_revealing())
+	assert_false(box.has_pages_left(), "the second page is up")
+
+
+## `_ContTextNoPause` has no `PromptButton` in front of those two scrolls, so
+## `<SCROLL>` rolls the box on with no press at all.
+func test_a_no_pause_scroll_runs_itself() -> void:
+	var box: Gen2TextBox = _box()
+	box.show_text("a" + Gen2TextStream.SCROLL_NOWAIT_BREAK + "b")
+	assert_true(box.has_pages_left())
+
+	for _frame: int in Gen2TextBox.SCROLL_STEP_FRAMES * Gen2TextBox.SCROLL_STEPS + 1:
+		box._process(FRAME)
+	assert_false(box.has_pages_left(), "the second page arrived without a press")
+	assert_false(box.is_revealing())

--- a/tests/unit/test_text_stream.gd
+++ b/tests/unit/test_text_stream.gd
@@ -131,3 +131,22 @@ func test_the_layout_carries_a_line_over_a_scroll_but_not_a_paragraph() -> void:
 	var paged: Array = Gen2TextLayout.lay_out("one\ntwo" + PARA + "three", 20, 2)
 	assert_eq(paged.size(), 2)
 	assert_eq(Array(paged[1]), ["three"])
+
+
+## `<SCROLL>` and `TextCommand_SCROLL` both reach `_ContTextNoPause`, which is
+## the two `TextScroll`s with no `PromptButton` in front of them. Reading either
+## as a `<CONT>` puts a press in the middle of a sentence.
+func test_the_two_scrolls_that_wait_for_nothing_are_their_own_break() -> void:
+	var character: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x00, 0x80, 0x4C, 0x81, 0x57])
+	)
+	assert_true(character["ok"])
+	assert_eq(character["text"], "A" + Gen2TextStream.SCROLL_NOWAIT_BREAK + "B")
+	assert_false(bool(character["prompt"]))
+
+	var command: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x00, 0x80, 0x50, 0x07, 0x00, 0x81, 0x57])
+	)
+	assert_true(command["ok"])
+	assert_eq(command["text"], "A" + Gen2TextStream.SCROLL_NOWAIT_BREAK + "B")
+	assert_false(bool(command["prompt"]))

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2434,7 +2434,7 @@ func test_advance_objects_still_makes_one_decision_per_call() -> void:
 
 func test_follower_carries_the_player_walk_step_offset() -> void:
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
-		"48:6080": [0x70, 2, 0, 0x91],
+		"48:6080": [0x70, 0, 2, 0x91],
 	})
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6080
@@ -4038,7 +4038,7 @@ func test_script_movement_still_refuses_a_step_off_the_map() -> void:
 
 func test_follow_command_moves_the_follower_after_a_player_step() -> void:
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
-		"48:6080": [0x70, 2, 0, 0x91],
+		"48:6080": [0x70, 0, 2, 0x91],
 	})
 	var data: GameData = GameData.open_directory(_directory)
 	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6080
@@ -4048,6 +4048,53 @@ func test_follow_command_moves_the_follower_after_a_player_step() -> void:
 	assert_eq(results[0]["status"], &"complete")
 	assert_true(world.move(Vector2i.LEFT))
 	assert_eq((world.objects[0] as Gen2WorldObject).cell, Vector2i(6, 6))
+
+
+## `follow NEWBARKTOWN_TEACHER, PLAYER`, which is what walks the player back out
+## of the route and what a swapped pair of operands leaves standing still.
+func test_follow_names_the_leader_first_so_the_player_can_be_the_follower() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6080": [0x70, 2, 0, 0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6080
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(4, 6))
+	var leader: Gen2WorldObject = world.objects[0]
+	var from: Vector2i = leader.cell
+	assert_eq(_final_status(_run_script(world, world.dispatch_script_events(Vector2i(7, 6)))),
+		&"complete")
+	assert_eq(leader.cell, from + Vector2i(2, 0), "the leader walked its own two steps")
+	assert_eq(world.player_cell, from + Vector2i(1, 0), "the player followed into its trail")
+
+
+## `Script_writetext` is `MapTextbox` and returns. A text ending in `<DONE>`
+## owes no press of its own, so the `waitbutton` behind the command is what the
+## script holds on; one ending in `<PROMPT>` owes its own.
+func test_a_writetext_says_whether_its_text_owes_a_press() -> void:
+	RomCache.write_json(RomCache.world_text_path(_directory), {
+		"48:7000": [0x00, 0x80, 0x57],
+		"48:7010": [0x00, 0x80, 0x58],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6060": [
+			Gen2WorldScript.WRITETEXT, 0x00, 0x70, Gen2WorldScript.WAITBUTTON, 0x91,
+		],
+		"48:6070": [Gen2WorldScript.WRITETEXT, 0x10, 0x70, 0x91],
+	})
+	for expected: Dictionary in [
+		{"script": 0x6060, "prompt": false}, {"script": 0x6070, "prompt": true},
+	]:
+		var data: GameData = GameData.open_directory(_directory)
+		data.world_map(1, 1).events["coord_events"][0]["script"] = int(expected["script"])
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
+		assert_eq(world.dispatch_script_events(Vector2i(7, 6))[0]["status"], &"waiting")
+		var pending: Dictionary = world.pending_script_input()
+		assert_eq(StringName(pending.get("type", &"")), &"text")
+		assert_eq(bool(pending.get("prompt", true)), bool(expected["prompt"]),
+			"script %04X" % int(expected["script"]))
 
 
 func test_script_items_money_and_coins_commit_as_one_runtime_transaction() -> void:


### PR DESCRIPTION
Four reported defects, three root causes.

**A `writetext` was charging a press of its own.** `Script_writetext` is
`MapTextbox` and returns; only `<PROMPT>`, `text_promptbutton` and
`text_waitbutton` wait inside a text. A text ending in `<DONE>` therefore owes
nothing, and the `waitbutton` behind the command is the press. The pending now
carries the decoder's `prompt`, and the screen continues the script as soon as
the last page is on screen, leaving the box up until `closetext`.

**`<CONT>` had no scroll.** `_ContText` waits and then runs `TextScroll` twice,
five frames each; the box now moves its interior up one tile row per step and
drops the row that reaches the border, which is what the second copy does to the
first line. `<SCROLL>` and `TextCommand_SCROLL` reach `_ContTextNoPause`, the
same two scrolls with no `PromptButton`, so they are a break of their own and
the box rolls itself on instead of asking for a press mid-sentence.

**`follow` had its operands the wrong way round.** `StartFollow` takes the first
through `SetLeaderIfVisible` and the second through `SetFollowerIfVisible`; the
macro's own operand comments say the reverse. `follow NEWBARKTOWN_TEACHER,
PLAYER` left the player standing where `TeacherBringsYouBackMovement` should
have walked them out of the route, and `follow PLAYER, NEWBARKTOWN_RIVAL` left
the rival in the cell he shoves from, so his step back to the shadows landed in
the laboratory wall. A follower is now driven by its leader's own step, an
object's scripted one as well as a player one, steps into the cell just vacated
rather than only when it falls two behind, and may be the player.

| Check | Result |
|---|---|
| GUT, both tiers | 3,109 tests over 150 scripts, green |
| `validate.gd -- all` | 52 topics pass, exit 0 |
| `replay_world.gd` | 30 routes, 0 failures |
| Story walk, three profiles | reaches Red, 16 badges on each |