### PR TITLE
Fix in-game menu presentation and intro sprite banking

### DIFF
--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -383,7 +383,9 @@ func _draw_sprite(
 	# the window, which the last two Suicune scenes load a sheet of their own
 	# into. A bare `Request2bpp` on top of either half wins over both.
 	var overlay: Array = movie.tile_overlay()
-	if overlay.size() == 3 and tile >= int(overlay[0]) \
+	## `Intro_RustleGrass` writes vTiles2 in VRAM bank 0. Pichu and Wooper read
+	## the same tile numbers from bank 1, where their own sheet remains intact.
+	if not bool(entry["bank1"]) and overlay.size() == 3 and tile >= int(overlay[0]) \
 			and tile < int(overlay[0]) + int(overlay[1]):
 		strip = _sheet(movie, String(overlay[2]))
 		tile -= int(overlay[0])

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -2,7 +2,8 @@ class_name Gen2StartMenuPage
 extends RefCounted
 
 ## `StartMenu`'s own box over the map, the `_Option` screen behind it, and
-## `SaveMenu`'s three boxes over the map as well.
+## `SaveMenu`'s three boxes over the map as well. In-game mod rows borrow the
+## OPTION layout because they have no cartridge screen of their own.
 ##
 ## Node-free presentation, like the other pages: geometry is [Gen2MenuBox]'s and
 ## the models are [Gen2WorldStartMenu] and [Gen2WorldOptionsMenu]. The list is a

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -318,6 +318,10 @@ func counter() -> int:
 	return _counter1
 
 
+func secondary_counter() -> int:
+	return _counter2
+
+
 ## Whether this frame is one a setup scene's own `DelayFrames` debt is paid on;
 ## see [method Gen2IntroMovie.waiting].
 func waiting() -> bool:

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -759,7 +759,7 @@ func _render_pack() -> void:
 	_status.text = ""
 	_render_options([], -1, func(_entry: Variant) -> String: return "")
 	if _pack_view != null:
-		_pack_view.visible = true
+		_pack_view.visible = _view == null or not _view.visible
 		_pack_view.texture = ImageTexture.create_from_image(_pack_image())
 
 
@@ -1722,8 +1722,7 @@ func _build_ui() -> void:
 	_options.add_theme_constant_override("separation", 4)
 	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	content.add_child(_options)
-	## The pack listing is the cartridge's own screen inside this panel, the way
-	## the Pokegear's card list holds the cartridge's four cards.
+	## Fallback for a caller that did not hand this host the world's Gen2Screen.
 	_pack_view = TextureRect.new()
 	_pack_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_pack_view.custom_minimum_size = Vector2(
@@ -1808,13 +1807,29 @@ func _hardware_image() -> Image:
 			if _options_menu == null:
 				return null
 			return _page.render_options(_options_menu.rows(), _options_menu.cursor)
+		Mode.PACK:
+			return _pack_image()
 		Mode.MODS:
-			## Not a cartridge screen: this project's own list, in `_Option`'s
-			## own shape so the two do not look like different games.
 			var rows: Array = []
 			for id: StringName in _mod_ids:
 				rows.append({"label": _mod_name(id), "value": ""})
 			return _page.render_options(rows, _mod_cursor)
+		Mode.MOD_OPTIONS:
+			var rows: Array = []
+			for raw: Dictionary in _mod_options():
+				var value: String = ""
+				match StringName(raw.get("kind", Gen2ModHost.OPTION_LADDER)):
+					Gen2ModHost.OPTION_BUTTON:
+						value = String(raw.get("press_label", "Go"))
+					Gen2ModHost.OPTION_NUMBER:
+						value = str(int(raw.get("value", 0)))
+					_:
+						var labels: Array = raw.get("labels", []) as Array
+						var index: int = int(raw.get("index", 0))
+						if index >= 0 and index < labels.size():
+							value = String(labels[index])
+				rows.append({"label": String(raw.get("label", "")), "value": value})
+			return _page.render_options(rows, _mod_option_cursor)
 	return null
 
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -127,6 +127,29 @@ func test_cancel_closes_the_menu_the_same_as_exit() -> void:
 	assert_true(_world_screen._objects_may_move())
 
 
+func test_mod_settings_use_the_hardware_option_screen() -> void:
+	var host_api: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host_api.register_option(&"display", {
+		"key": &"distance", "label": "Distance", "values": [1, 2],
+		"labels": ["Near", "Far"],
+	})["ok"]))
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_MODS)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.MODS)
+	assert_true((host.get("_view") as TextureRect).visible)
+	assert_false((host.get("_center") as Control).visible)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.MOD_OPTIONS)
+	assert_true((host.get("_view") as TextureRect).visible)
+	assert_false((host.get("_center") as Control).visible)
+
+	Gen2ModHost.reset()
+
+
 func test_pokemon_opens_the_embedded_party_screen_and_reopens_the_menu() -> void:
 	await _open_world()
 	_world_screen._world.set_party_summary(1, false)
@@ -161,6 +184,9 @@ func test_pack_lists_a_granted_item() -> void:
 	host.handle_button(Gen2Button.A)
 	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
+	assert_true((host.get("_view") as TextureRect).visible)
+	assert_false((host.get("_center") as Control).visible)
+	assert_false((host.get("_pack_view") as TextureRect).visible)
 	var items_pocket: Dictionary = host.get("_pack_pockets")[0]
 	assert_eq(items_pocket["pocket"], Gen2WorldPack.TYPE_ITEM)
 	var items: Array = items_pocket["items"]

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -17,8 +17,9 @@ extends SceneTree
 ## own buffer is read at the frame boundary, where hDMATransfer copies it.
 ##
 ## Either movie also writes `<out>.state`, one `frame scene counter` line per
-## frame. That is the pair a cartridge's own `wJumptableIndex` and
-## `wIntroSceneFrameCounter` hold, and it is what aligns a pixel diff: a setup
+## frame. Gold and Silver append their second scene counter, since their scroll
+## scenes advance that one while the first stays fixed. These are the cartridge
+## state that aligns a pixel diff: a setup
 ## scene's decompression overruns VBlank by three to twelve frames there and by
 ## none here, so a per-scene offset is still several frames out inside the scene
 ## and every frame of a fade compares against the wrong step of it. A frame
@@ -172,7 +173,10 @@ func _trace_gs_intro(data: GameData) -> PackedStringArray:
 	var scene: int = -1
 	while not movie.finished() and frame < MOVIE_FRAME_CAP:
 		_append_frame(out, frame, page.shadow_oam(movie))
-		_append_state(frame, movie.scene(), movie.counter(), movie.waiting())
+		_append_state(
+			frame, movie.scene(), movie.counter(), movie.waiting(),
+			movie.secondary_counter()
+		)
 		if _shots.has(frame):
 			page.draw(movie).save_png("%s_f%d.png" % [_shot_prefix, frame])
 		if movie.scene() != scene:
@@ -215,15 +219,21 @@ func _trace_title(data: GameData) -> PackedStringArray:
 
 ## A frame paying a setup scene's delay is written under the setup scene's own
 ## index, which is the one the cartridge is still in while it spends it.
-func _append_state(frame: int, scene: int, counter: int, waiting: bool) -> void:
+func _append_state(
+	frame: int, scene: int, counter: int, waiting: bool, secondary: int = -1
+) -> void:
 	# A setup scene's counter is the previous scene's last value until the
 	# routine's own tail zeroes it, and the routine is spread over every
 	# `DelayFrame` its decompressions spend, so a waiting frame carries no
 	# counter to line up on and is written as -1.
-	_state.append(
-		"%d %d %d" % [frame, scene - 1, -1] if waiting
-		else "%d %d %d" % [frame, scene, counter]
-	)
+	var values: Array = [frame, scene - 1, -1] if waiting \
+		else [frame, scene, counter]
+	if secondary >= 0:
+		values.append(secondary)
+	var words := PackedStringArray()
+	for value: int in values:
+		words.append(str(value))
+	_state.append(" ".join(words))
 
 
 func _append_frame(out: PackedStringArray, frame: int, entries: Array[Dictionary]) -> void:


### PR DESCRIPTION
## Summary

- render the pack, mod list, and individual mod settings as full hardware screens
- preserve VRAM bank selection when applying Crystal intro tile overlays
- include Gold and Silver secondary scene counters in opening trace state
- add integration coverage for pack and mod hardware presentation

## Verification

- `Godot --headless --path . -s res://tools/validate.gd -- all`
- unit GUT: 2,740 tests, 24,817 assertions
- combined unit and integration GUT: 3,110 tests, 32,057 assertions
- world replay: 30 routes, 0 failures
- Gold, Silver, and Crystal story walks through Red and credits
- Crystal focused cartridge comparison: 96/96 corrected frames pixel-exact
- normal headless boot smoke test
- pack screenshot inspected at 160x144