### PR TITLE
Scroll long mod menus within the hardware screen

### DIFF
--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -47,6 +47,10 @@ const OPTIONS_COLON_COLUMN: int = 10
 const OPTIONS_VALUE_COLUMN: int = 11
 ## `Options_UpdateCursorPosition` walks column 1 by two rows per option.
 const OPTIONS_CURSOR_COLUMN: int = 1
+## Eight labels fit between the borders. Only seven entries may carry a value
+## on the following row; the eighth label is OPTION's value-less CANCEL row.
+const OPTIONS_VISIBLE_ROWS: int = 8
+const OPTIONS_VISIBLE_VALUE_ROWS: int = 7
 
 ## `DisplaySaveInfoOnSave`'s `lb de, 4, 0` through `_OffsetMenuHeader`, which
 ## keeps `menu_coords 0, 0, 15, 9`'s span and moves its left edge to column 4.

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1813,7 +1813,8 @@ func _hardware_image() -> Image:
 			var rows: Array = []
 			for id: StringName in _mod_ids:
 				rows.append({"label": _mod_name(id), "value": ""})
-			return _page.render_options(rows, _mod_cursor)
+			var window: Dictionary = _option_window(rows, _mod_cursor)
+			return _page.render_options(window["rows"], window["cursor"])
 		Mode.MOD_OPTIONS:
 			var rows: Array = []
 			for raw: Dictionary in _mod_options():
@@ -1829,8 +1830,28 @@ func _hardware_image() -> Image:
 						if index >= 0 and index < labels.size():
 							value = String(labels[index])
 				rows.append({"label": String(raw.get("label", "")), "value": value})
-			return _page.render_options(rows, _mod_option_cursor)
+			var window: Dictionary = _option_window(
+				rows, _mod_option_cursor, Gen2StartMenuPage.OPTIONS_VISIBLE_VALUE_ROWS
+			)
+			return _page.render_options(window["rows"], window["cursor"])
 	return null
+
+
+## Keeps the active global row on the hardware page. Input and mutations retain
+## the global cursor; only the rows handed to the page move.
+func _option_window(
+	rows: Array, cursor: int,
+	visible_rows: int = Gen2StartMenuPage.OPTIONS_VISIBLE_ROWS
+) -> Dictionary:
+	var first: int = clampi(
+		cursor - visible_rows + 1,
+		0, maxi(rows.size() - visible_rows, 0)
+	)
+	var last: int = mini(first + visible_rows, rows.size())
+	return {
+		"rows": rows.slice(first, last),
+		"cursor": cursor - first if cursor >= 0 else -1,
+	}
 
 
 func _render_options(values: Array, cursor: int, label_for: Callable) -> void:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -150,6 +150,66 @@ func test_mod_settings_use_the_hardware_option_screen() -> void:
 	Gen2ModHost.reset()
 
 
+func test_long_mod_list_scrolls_the_hardware_option_screen() -> void:
+	var host_api: Gen2ModHost = Gen2ModHost.instance()
+	for index: int in 10:
+		assert_true(bool(host_api.register_option(StringName("mod_%02d" % index), {
+			"key": &"enabled", "label": "ENABLED", "values": [0, 1],
+		})["ok"]))
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_MODS)
+	host.handle_button(Gen2Button.A)
+	for _step: int in 8:
+		host.handle_button(Gen2Button.DOWN)
+	assert_eq(host.get("_mod_cursor"), 8)
+	var rows: Array = []
+	for id: StringName in host.get("_mod_ids") as Array[StringName]:
+		rows.append({"label": String(id), "value": ""})
+	var window: Dictionary = host.call("_option_window", rows, 8)
+	assert_eq((window["rows"] as Array).size(), Gen2StartMenuPage.OPTIONS_VISIBLE_ROWS)
+	assert_eq((window["rows"] as Array)[7]["label"], "mod_08")
+	assert_eq(window["cursor"], 7)
+	assert_true((host.get("_view") as TextureRect).visible)
+
+	Gen2ModHost.reset()
+
+
+func test_long_mod_settings_scroll_and_adjust_the_global_row() -> void:
+	var host_api: Gen2ModHost = Gen2ModHost.instance()
+	for index: int in 14:
+		assert_true(bool(host_api.register_option(&"randomizer", {
+			"key": StringName("setting_%02d" % index),
+			"label": "SETTING %02d" % index,
+			"values": [0, 1], "labels": ["OFF", "ON"],
+		})["ok"]))
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_MODS)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	for _step: int in 8:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.RIGHT)
+	assert_eq(host.get("_mod_option_cursor"), 8)
+	assert_eq(host_api.option(&"randomizer", &"setting_08"), 1)
+	assert_eq(host_api.option(&"randomizer", &"setting_07"), 0)
+	var window: Dictionary = host.call(
+		"_option_window", host.call("_mod_options"), 8,
+		Gen2StartMenuPage.OPTIONS_VISIBLE_VALUE_ROWS
+	)
+	assert_eq((window["rows"] as Array).size(), Gen2StartMenuPage.OPTIONS_VISIBLE_VALUE_ROWS)
+	assert_eq((window["rows"] as Array)[6]["key"], &"setting_08")
+	assert_eq(window["cursor"], 6)
+	assert_true((host.get("_view") as TextureRect).visible)
+
+	Gen2ModHost.reset()
+
+
 func test_pokemon_opens_the_embedded_party_screen_and_reopens_the_menu() -> void:
 	await _open_world()
 	_world_screen._world.set_party_summary(1, false)


### PR DESCRIPTION
## Summary

- keep long mod indexes inside an eight-row hardware window
- keep long setting lists inside a seven-row window so values do not overwrite the bottom border
- retain global cursors so scrolling still adjusts or presses the intended registered setting
- cover ten installed mods and the randomizer-shaped fourteen-setting list

## Verification

- focused start-menu integration: 48 tests, 300 assertions
- complete unit and integration suite: 3,112 tests, 32,095 assertions
- full validator
- inspected a Crystal hardware screenshot at the ninth randomizer setting