### PR TITLE
Restore Crystal intro sprite coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ real cartridge, so they run anywhere.
 godot --headless -s res://addons/gut/gut_cmdln.gd -gexit
 ```
 
-That is the unit tier, and the default: roughly 2,500 tests in well under a
+That is the unit tier, and the default: more than 2,700 tests in well under a
 minute. The scene integration tier drives real screens and is slower, so it is
 asked for explicitly, which is how CI runs both:
 

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -390,8 +390,10 @@ func _draw_sprite(
 		strip = _sheet(movie, String(overlay[2]))
 		tile -= int(overlay[0])
 	elif tile >= HIGH_TILE:
-		strip = _sheet(movie, movie.sheet("obj_high"))
-		tile -= HIGH_TILE
+		var high: String = movie.sheet("obj_high")
+		if not high.is_empty():
+			strip = _sheet(movie, high)
+			tile -= HIGH_TILE
 	if strip.is_empty():
 		return
 	var palette: PackedColorArray = movie.object_palette(int(entry["palette"]))


### PR DESCRIPTION
## Summary
- keep Crystal intro sprite tiles on the base object sheet when no high-half replacement is loaded
- restore Suicune's lower-half pixels across the affected movie run
- refresh the documented unit-test count

## Verification
- 2,287/2,339 Crystal intro frames pixel-exact against the cartridge oracle, up from 2,223
- 3,112/3,112 full GUT tests
- all real-cache validation topics
- 30/30 replay routes
- Gold, Silver, and Crystal story walks through Red