### PR TITLE
Finish cartridge service and clock screens

### DIFF
--- a/game/render/clock_set_page.gd
+++ b/game/render/clock_set_page.gd
@@ -1,0 +1,52 @@
+class_name Gen2ClockSetPage
+extends RefCounted
+
+## `InitClock` and `SetDayOfWeek` on the hardware tile grid. The two one-tile
+## arrows stand where the source loads its temporary arrow graphics.
+
+const TILE: int = Gen2Font.TILE
+var font: Gen2Font = null
+var menu: Gen2MenuPage = null
+
+
+static func from_data(data: GameData) -> Gen2ClockSetPage:
+	var out := Gen2ClockSetPage.new()
+	out.font = Gen2Font.from_data(data)
+	out.menu = Gen2MenuPage.from_data(data)
+	return out if out.font != null and out.menu != null else null
+
+
+func render(value: String, prompt: String, confirm_cursor: int, day: bool) -> Image:
+	var indices := PackedByteArray()
+	indices.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	var dial := Gen2MenuBox.from_coords(9 if day else 3, 3 if day else 7, 19, 7 if day else 11,
+		Gen2MenuBox.STATICMENU_NO_TOP_SPACING)
+	menu.draw(dial, [], -1, indices, Gen2Screen.WIDTH)
+	var value_at := Vector2i(10, 5) if day else Vector2i(4, 9)
+	font.draw_text(value, indices, Gen2Screen.WIDTH, value_at.x * TILE, value_at.y * TILE)
+	var arrow_x: int = 14 if day else (15 if value.contains("min.") else 11)
+	var arrow_top: int = 4 if day else 8
+	_draw_arrow(indices, arrow_x * TILE, arrow_top * TILE, false)
+	_draw_arrow(indices, arrow_x * TILE, (arrow_top + 3) * TILE, true)
+	var speech := Gen2MenuBox.from_coords(0, 12, 19, 17, 0)
+	menu.draw(speech, [], -1, indices, Gen2Screen.WIDTH)
+	var pages: Array = Gen2TextLayout.lay_out(prompt, 18, 2)
+	var lines: PackedStringArray = pages[0] if not pages.is_empty() else PackedStringArray()
+	for row: int in mini(2, lines.size()):
+		font.draw_text(String(lines[row]), indices, Gen2Screen.WIDTH,
+			TILE, (14 + row * 2) * TILE)
+	if confirm_cursor >= 0:
+		var yes_no := Gen2MenuBox.from_coords(14, 7, 19, 11,
+			Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING)
+		menu.draw(yes_no, ["YES", "NO"], confirm_cursor, indices, Gen2Screen.WIDTH)
+	return Gen2PicImage.from_indices(indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])))
+
+
+func _draw_arrow(indices: PackedByteArray, x: int, y: int, down: bool) -> void:
+	for row: int in 5:
+		var span: int = (row + 1) if not down else (5 - row)
+		for pixel: int in span:
+			var px: int = x + 3 - int((span - 1) / 2) + pixel
+			var py: int = y + row
+			indices[py * Gen2Screen.WIDTH + px] = 3

--- a/game/render/clock_set_page.gd.uid
+++ b/game/render/clock_set_page.gd.uid
@@ -1,0 +1,1 @@
+uid://dg8r2j6cnhaoc

--- a/game/render/world_service_page.gd
+++ b/game/render/world_service_page.gd
@@ -1,0 +1,57 @@
+class_name Gen2WorldServicePage
+extends RefCounted
+
+## The cartridge-sized menus hosted by the overworld service dispatcher. The
+## caller supplies the imported rows; this page owns only MenuTextbox geometry.
+
+const TILE: int = Gen2Font.TILE
+
+var font: Gen2Font = null
+var menu: Gen2MenuPage = null
+
+
+static func from_data(data: GameData) -> Gen2WorldServicePage:
+	var out := Gen2WorldServicePage.new()
+	out.font = Gen2Font.from_data(data)
+	out.menu = Gen2MenuPage.from_data(data)
+	return out if out.font != null and out.menu != null else null
+
+
+## `MenuTextbox` over the map. PC owns the screen, while script menus leave the
+## map visible around their box.
+func render(title: String, prompt: String, rows: Array, cursor: int,
+		message: String = "", full_screen: bool = false) -> Image:
+	var image := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	if full_screen:
+		image.fill(Color.WHITE)
+	var count: int = maxi(rows.size(), 1)
+	var bottom: int = mini(17, 1 + count * 2)
+	var box := Gen2MenuBox.from_coords(
+		0 if full_screen else 9, 0, 19, bottom,
+		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
+	)
+	var labels: Array = rows if not rows.is_empty() else [""]
+	_blit(image, menu.render(box, labels, cursor), box.border_position())
+	var words: String = message if not message.is_empty() else prompt
+	if words.is_empty():
+		words = title
+	if not words.is_empty():
+		var pages: Array = Gen2TextLayout.lay_out(words, 18, 2)
+		var lines: PackedStringArray = pages[0] if not pages.is_empty() else PackedStringArray()
+		var indices := PackedByteArray()
+		indices.resize(Gen2Screen.WIDTH * 6 * TILE)
+		font.draw_box(Gen2OptionsStore.current().textbox_frame, indices,
+			Gen2Screen.WIDTH, 0, 0, 20, 6)
+		for row: int in mini(2, lines.size()):
+			font.draw_text(lines[row], indices, Gen2Screen.WIDTH, TILE, (2 + row * 2) * TILE)
+		var part: Image = Gen2PicImage.from_indices(indices, Gen2Screen.WIDTH, 6 * TILE,
+			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])))
+		image.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), Vector2i(0, 12 * TILE))
+	return image
+
+
+func _blit(into: Image, part: Image, at: Vector2i) -> void:
+	if part != null:
+		into.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), at * TILE)

--- a/game/render/world_service_page.gd.uid
+++ b/game/render/world_service_page.gd.uid
@@ -1,0 +1,1 @@
+uid://bte2id61r0dr4

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -1,0 +1,114 @@
+class_name Gen2ClockSetScreen
+extends Control
+
+## `InitClock` followed by `SetDayOfWeek`, before Oak's first speech beat.
+
+signal finished(day: int, hour: int, minute: int)
+
+enum Phase { HOUR, HOUR_CONFIRM, MINUTE, MINUTE_CONFIRM, DAY, DAY_CONFIRM, DONE }
+
+const DAYS: Array[String] = [
+	" SUNDAY", " MONDAY", " TUESDAY", "WEDNESDAY", "THURSDAY", " FRIDAY", "SATURDAY",
+]
+
+var _page: Gen2ClockSetPage = null
+var _view: TextureRect = null
+var _phase: int = Phase.HOUR
+var _hour: int = 10
+var _minute: int = 0
+var _day: int = 0
+var _confirm_cursor: int = 0
+
+
+func open(data: GameData) -> bool:
+	_page = Gen2ClockSetPage.from_data(data)
+	return _page != null
+
+
+func _ready() -> void:
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	_view = TextureRect.new()
+	_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_view.size = size
+	add_child(_view)
+	_render()
+
+
+func handle_button(button: int) -> bool:
+	if _phase == Phase.DONE:
+		return true
+	if button in [Gen2Button.UP, Gen2Button.DOWN]:
+		if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM]:
+			_confirm_cursor = 1 - _confirm_cursor
+			_render()
+			return true
+		var step: int = 1 if button == Gen2Button.UP else -1
+		match _phase:
+			Phase.HOUR: _hour = wrapi(_hour + step, 0, 24)
+			Phase.MINUTE: _minute = wrapi(_minute + step, 0, 60)
+			Phase.DAY: _day = wrapi(_day + step, 0, 7)
+		_render()
+		return true
+	if button == Gen2Button.B and _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM]:
+		_phase -= 1
+		_confirm_cursor = 0
+		_render()
+		return true
+	if button != Gen2Button.A:
+		return false
+	if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM] \
+			and _confirm_cursor == 1:
+		_phase -= 1
+		_confirm_cursor = 0
+		_render()
+		return true
+	match _phase:
+		Phase.HOUR:
+			_phase = Phase.HOUR_CONFIRM
+			_confirm_cursor = 0
+		Phase.HOUR_CONFIRM: _phase = Phase.MINUTE
+		Phase.MINUTE:
+			_phase = Phase.MINUTE_CONFIRM
+			_confirm_cursor = 0
+		Phase.MINUTE_CONFIRM: _phase = Phase.DAY
+		Phase.DAY:
+			_phase = Phase.DAY_CONFIRM
+			_confirm_cursor = 0
+		Phase.DAY_CONFIRM:
+			_phase = Phase.DONE
+			finished.emit(_day, _hour, _minute)
+	_render()
+	return true
+
+
+func value() -> Dictionary:
+	return {"day": _day, "hour": _hour, "minute": _minute}
+
+
+func _render() -> void:
+	if _view == null or _page == null or _phase == Phase.DONE:
+		return
+	var day: bool = _phase in [Phase.DAY, Phase.DAY_CONFIRM]
+	var confirm: bool = _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM]
+	var value_text: String
+	var prompt: String
+	if day:
+		value_text = DAYS[_day]
+		prompt = "%s, is it?" % DAYS[_day].strip_edges() if confirm else "What day is it?"
+	elif _phase in [Phase.MINUTE, Phase.MINUTE_CONFIRM]:
+		value_text = "%d min." % _minute
+		prompt = "Whoa! %d min.?" % _minute if confirm else "How many minutes?"
+	else:
+		value_text = "%s o'clock" % _hour_text()
+		prompt = "What? %s?" % value_text if confirm else "What time is it?"
+	_view.texture = ImageTexture.create_from_image(_page.render(
+		value_text, prompt, _confirm_cursor if confirm else -1, day
+	))
+
+
+func _hour_text() -> String:
+	var shown: int = _hour % 12
+	if shown == 0:
+		shown = 12
+	return "%d %s" % [shown, "AM" if _hour < 12 else "PM"]

--- a/game/world/clock_set_screen.gd.uid
+++ b/game/world/clock_set_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dw428aqesnay0

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -31,7 +31,9 @@ var _standalone: bool = true
 
 var _splash: Gen2SplashScreen = null
 var _gender_screen: Gen2GenderScreen = null
+var _clock_screen: Gen2ClockSetScreen = null
 var _speech: Gen2OakSpeechScreen = null
+var _clock: Dictionary = {"day": 0, "hour": 10, "minute": 0}
 ## Null when a driver builds this class directly rather than instancing the
 ## scene; the sub-screens are then plain children and draw at their own size.
 var _viewport: Gen2Screen = null
@@ -103,6 +105,8 @@ func current() -> Control:
 		return _splash
 	if _gender_screen != null:
 		return _gender_screen
+	if _clock_screen != null:
+		return _clock_screen
 	return _speech
 
 
@@ -152,7 +156,7 @@ func _start_profile_setup() -> void:
 		# Never parented, so it is freed outright rather than queued.
 		_gender_screen.free()
 		_gender_screen = null
-		_start_speech()
+		_start_clock()
 		return
 	_gender_screen.closed.connect(_on_gender_chosen)
 	_show_sub_screen(_gender_screen)
@@ -162,6 +166,26 @@ func _on_gender_chosen(chosen: int) -> void:
 	_gender = chosen
 	_gender_screen.queue_free()
 	_gender_screen = null
+	_start_clock()
+
+
+## `OakSpeech` farcalls `InitClock` before its first `PrintText`, then
+## `SetDayOfWeek` after the hour and minute have been accepted.
+func _start_clock() -> void:
+	_clock_screen = Gen2ClockSetScreen.new()
+	if not _clock_screen.open(_data):
+		_clock_screen.free()
+		_clock_screen = null
+		_fail("This cartridge cache carries no clock font.")
+		return
+	_clock_screen.finished.connect(_on_clock_set)
+	_show_sub_screen(_clock_screen)
+
+
+func _on_clock_set(day: int, hour: int, minute: int) -> void:
+	_clock = {"day": day, "hour": hour, "minute": minute}
+	_clock_screen.queue_free()
+	_clock_screen = null
 	_start_speech()
 
 
@@ -185,6 +209,10 @@ func _on_speech_finished(player_name: String) -> void:
 		return
 	created.gender = _gender
 	created.label = _label
+	if created.world != null:
+		created.world.world_day = int(_clock["day"])
+		created.world.world_hour = int(_clock["hour"])
+		created.world.world_minute = int(_clock["minute"])
 	## Before the write: a mod holding a run snapshots what built it into the
 	## save's own namespace, and that has to be in the bytes on disk.
 	GameRuntime.announce_new_save(created)

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -9,7 +9,6 @@ signal completed(results: Array)
 
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#4f6f9e")
-const SCRIM: Color = Color(0.02, 0.04, 0.08, 0.78)
 const TEXT: Color = Color("#f4f7fb")
 const MUTED: Color = Color("#9eacc0")
 const ACCENT: Color = Color("#f3c969")
@@ -125,6 +124,10 @@ var _pc_sfx: int = -1
 var _pc_after: StringName = &"top"
 var _pc_label: String = ""
 var _boxes: Gen2BoxScreen = null
+
+var _service_hardware: Gen2Screen = null
+var _service_view: TextureRect = null
+var _service_page: Gen2WorldServicePage = null
 
 var _panel: PanelContainer = null
 var _title: Label = null
@@ -279,12 +282,6 @@ func selected_index() -> int:
 
 
 func _build_ui() -> void:
-	var scrim := ColorRect.new()
-	scrim.color = SCRIM
-	scrim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	scrim.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child(scrim)
-
 	var center := CenterContainer.new()
 	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	add_child(center)
@@ -320,6 +317,19 @@ func _build_ui() -> void:
 	_footer = Label.new()
 	_footer.add_theme_color_override("font_color", ACCENT)
 	content.add_child(_footer)
+
+	_service_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
+	_service_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_service_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_service_hardware.z_index = 4
+	add_child(_service_hardware)
+	_service_view = TextureRect.new()
+	_service_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_service_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_service_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_service_hardware.display(_service_view)
+	_panel.visible = false
+	_service_hardware.visible = false
 
 
 func _open_menu(input: Dictionary) -> void:
@@ -599,6 +609,7 @@ func _close_mart() -> void:
 		_mart_hardware = null
 		_mart_view = null
 	_panel.visible = true
+	_service_hardware.visible = true
 
 
 func _render_mart() -> void:
@@ -953,6 +964,7 @@ func _open_boxes() -> void:
 		return
 	_boxes = host
 	_panel.visible = false
+	_service_hardware.visible = false
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 5
 	add_child(host)
@@ -967,6 +979,7 @@ func _on_boxes_closed(_result: Dictionary) -> void:
 		_boxes.queue_free()
 		_boxes = null
 	_panel.visible = true
+	_service_hardware.visible = true
 	_open_pc(&"pokemon_center")
 
 
@@ -1014,6 +1027,7 @@ func _open_card(card: StringName) -> void:
 	_mode = MODE.CARD
 	_cursor = 0
 	_panel.visible = false
+	_service_hardware.visible = false
 	_pokegear = Gen2PokegearScreen.new()
 	_pokegear.z_index = 5
 	add_child(_pokegear)
@@ -1117,6 +1131,7 @@ func _on_card_called(contact: int) -> void:
 	var results: Array = _world.request_outgoing_phone_call(contact)
 	_close_card()
 	_panel.visible = true
+	_service_hardware.visible = true
 	_mode = -1
 	completed.emit(results)
 
@@ -1136,6 +1151,7 @@ func _on_card_closed() -> void:
 		_world.close_radio()
 	_close_card()
 	_panel.visible = true
+	_service_hardware.visible = true
 	_open_pokegear_cards()
 
 
@@ -1166,6 +1182,7 @@ func open_fly_map(
 	_town_map_from_request = false
 	_fly_map = true
 	_panel.visible = false
+	_service_hardware.visible = false
 	_town_map = Gen2TownMapScreen.new()
 	_town_map.z_index = 5
 	add_child(_town_map)
@@ -1193,6 +1210,7 @@ func _open_town_map(from_request: bool) -> void:
 	# The region map is the whole screen, so the card list's own panel goes with
 	# its labels; the scrim behind it stays as the overlay's backdrop.
 	_panel.visible = false
+	_service_hardware.visible = false
 	_town_map = Gen2TownMapScreen.new()
 	_town_map.z_index = 5
 	add_child(_town_map)
@@ -1223,6 +1241,7 @@ func _on_town_map_closed() -> void:
 		_town_map.queue_free()
 		_town_map = null
 	_panel.visible = true
+	_service_hardware.visible = true
 	if _fly_map:
 		_fly_map = false
 		_mode = -1
@@ -1407,6 +1426,33 @@ func _render_options(override: Array = []) -> void:
 		label.add_theme_color_override("font_color", ACCENT if index == _cursor else TEXT)
 		label.add_theme_font_size_override("font_size", 18)
 		parent.add_child(label)
+	_render_service_page(values)
+
+
+func _render_service_page(values: Array) -> void:
+	if _service_view == null or _data == null:
+		return
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _service_page == null:
+		return
+	var labels: Array = []
+	for value: Variant in values:
+		if value is Dictionary:
+			var row: Dictionary = value
+			var label: String = String(row.get("name", row.get("caller_label", "")))
+			if _mode == MODE.PC_ITEM_LIST:
+				label += " x%d" % int(row.get("quantity", 0))
+			labels.append(label)
+		else:
+			labels.append(String(value))
+	var full_screen: bool = _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_ITEM_LIST, MODE.PC_TEXT]
+	var image: Image = _service_page.render(
+		_title.text, _summary.text, labels, _cursor, _status.text, full_screen
+	)
+	if image != null:
+		_service_view.texture = ImageTexture.create_from_image(image)
+		_service_hardware.visible = true
 
 
 func _option_count() -> int:

--- a/tests/integration/test_intro_screen.gd
+++ b/tests/integration/test_intro_screen.gd
@@ -1,6 +1,6 @@
 extends GutTest
 
-## `NewGame`: the gender question, then Oak's speech with the naming screen in
+## `NewGame`: the gender question, clock set, then Oak's speech with the naming screen in
 ## it, then one write. Nothing reaches disk until the run is over, which is what
 ## lets [Gen2SaveValidator]'s rule that a save has a trainer stand unchanged.
 
@@ -70,6 +70,12 @@ func _settle(limit: int = 40) -> void:
 		speech.advance_frames(speech.animation_frames_left())
 
 
+func _accept_clock() -> void:
+	assert_true(_screen.current() is Gen2ClockSetScreen)
+	for _step: int in 6:
+		_screen.handle_button(Gen2Button.A)
+
+
 ## Presses A until [param stop] answers, so a test never has to know how many
 ## pages a text wrapped to.
 func _press_a_until(stop: Callable, limit: int = 200) -> void:
@@ -95,6 +101,7 @@ func _run_intro(female: bool = false) -> String:
 	if female:
 		_screen.handle_button(Gen2Button.DOWN)
 	_screen.handle_button(Gen2Button.A)
+	_accept_clock()
 	_press_a_until(_at_naming)
 	_screen.handle_button(Gen2Button.A)
 	_screen.handle_button(Gen2Button.START)
@@ -128,7 +135,27 @@ func test_the_gender_question_comes_first() -> void:
 	_begin()
 	assert_true(_screen.current() is Gen2GenderScreen)
 	_screen.handle_button(Gen2Button.A)
+	assert_true(_screen.current() is Gen2ClockSetScreen, "then InitClock")
+	_accept_clock()
 	assert_true(_screen.current() is Gen2OakSpeechScreen, "then the speech")
+
+
+func test_clock_set_wraps_each_source_dial_and_reaches_the_speech() -> void:
+	_begin()
+	_screen.handle_button(Gen2Button.A)
+	var clock: Gen2ClockSetScreen = _screen.current() as Gen2ClockSetScreen
+	assert_not_null(clock)
+	clock.handle_button(Gen2Button.DOWN)
+	clock.handle_button(Gen2Button.A)
+	clock.handle_button(Gen2Button.A)
+	clock.handle_button(Gen2Button.DOWN)
+	clock.handle_button(Gen2Button.A)
+	clock.handle_button(Gen2Button.A)
+	clock.handle_button(Gen2Button.DOWN)
+	assert_eq(clock.value(), {"day": 6, "hour": 9, "minute": 59})
+	clock.handle_button(Gen2Button.A)
+	clock.handle_button(Gen2Button.A)
+	assert_true(_screen.current() is Gen2OakSpeechScreen)
 
 
 ## `NewGame` reaches `InitializeWorld` only after both have returned, so nothing
@@ -137,6 +164,7 @@ func test_nothing_is_written_while_the_intro_runs() -> void:
 	_begin()
 	assert_false(Gen2SaveStore.exists(_data.id, _data.sha1, SLOT))
 	_screen.handle_button(Gen2Button.A)
+	_accept_clock()
 	_press_a_until(_at_naming)
 	assert_false(
 		Gen2SaveStore.exists(_data.id, _data.sha1, SLOT),
@@ -149,6 +177,7 @@ func test_nothing_is_written_while_the_intro_runs() -> void:
 func test_abandoning_the_intro_leaves_no_slot() -> void:
 	_begin()
 	_screen.handle_button(Gen2Button.A)
+	_accept_clock()
 	_press_a_until(_at_naming)
 	_screen.free()
 	_screen = null
@@ -199,6 +228,7 @@ func test_the_written_save_carries_the_new_game_spawn() -> void:
 	assert_not_null(save.world, "the new-game snapshot came with it")
 	assert_eq(save.slot, SLOT)
 	assert_eq(save.game_id, _data.id)
+	assert_eq(save.world.world_clock(), {"day": 0, "hour": 10, "minute": 0})
 
 
 ## A cartridge with no gender screen starts on the speech instead, and its save
@@ -210,6 +240,8 @@ func test_a_cartridge_without_a_gender_screen_starts_on_the_speech() -> void:
 	_data = GameData.open_directory(Fixture.directory())
 
 	_begin()
+	assert_true(_screen.current() is Gen2ClockSetScreen)
+	_accept_clock()
 	assert_true(_screen.current() is Gen2OakSpeechScreen)
 	assert_eq(_screen.gender(), Gen2SaveData.GENDER_MALE)
 
@@ -220,5 +252,6 @@ func test_a_cache_without_intro_text_fails_without_writing() -> void:
 	RomCache.write_json(RomCache.intro_text_path(Fixture.directory()), {})
 	_data = GameData.open_directory(Fixture.directory())
 	_begin()
+	_accept_clock()
 	assert_eq(_failed.size(), 1)
 	assert_false(Gen2SaveStore.exists(_data.id, _data.sha1, SLOT))

--- a/tools/preview_intro.gd
+++ b/tools/preview_intro.gd
@@ -4,7 +4,7 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_intro.gd -- <game> <out.png> [what] [steps]
 ##
-## `what` is `copyright`, `presents`, `gender`, `speech` or `shrink`; `steps` is how many source frames or
+## `what` is `copyright`, `presents`, `gender`, `clock`, `speech` or `shrink`; `steps` is how many source frames or
 ## advances to run first, so any beat of `OakSpeech` can be photographed. Several
 ## comma-separated steps write one file each, suffixed with the step, which is
 ## how a whole fade is looked at without paying for a process per frame. The
@@ -37,7 +37,7 @@ func _initialize() -> void:
 	if args.size() < 2:
 		push_error(
 			"Usage: preview_intro.gd -- <game> <out.png> "
-			+ "[copyright|presents|gender|speech|shrink] [step]"
+			+ "[copyright|presents|gender|clock|speech|shrink] [step]"
 		)
 		quit(1)
 		return
@@ -96,6 +96,13 @@ func _build(data: GameData) -> Control:
 			gender.free()
 			return null
 		return gender
+	if _what == "clock":
+		var clock := Gen2ClockSetScreen.new()
+		if not clock.open(data):
+			push_error("This cache carries no clock font.")
+			clock.free()
+			return null
+		return clock
 	var speech := Gen2OakSpeechScreen.new()
 	if not speech.open(data, Gen2SaveData.GENDER_MALE):
 		push_error("This cache carries no intro text.")
@@ -124,6 +131,11 @@ func _drive(step: Vector2i) -> void:
 		for _press: int in step.x - _presses_run:
 			_screen.handle_button(Gen2Button.DOWN)
 		_presses_run = step.x
+		return
+	if _what == "clock":
+		while _presses_run < step.x:
+			_screen.handle_button(Gen2Button.A)
+			_presses_run += 1
 		return
 	var speech: Gen2OakSpeechScreen = _screen as Gen2OakSpeechScreen
 	if _what == "speech":


### PR DESCRIPTION
## Summary
- draw the remaining overworld service menus and PC flows at hardware resolution
- run the hour, minute, and weekday setup before Oak's speech and persist the accepted clock
- extend intro coverage and visual preview support

## Verification
- full GUT suite: 3,113 tests, 32,119 assertions
- full real-cache validation suite
- replay suite: 30 routes, 0 failures
- Gold, Silver, and Crystal full story walks through Red
- standard and mod-enabled boot smoke tests