### PR TITLE
Fix save screen game title layout

### DIFF
--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -202,6 +202,8 @@ func _build_ui() -> void:
 		_palette, _data.title() if _data != null else "No cartridge selected"
 	)
 	game_title.name = "SaveScreenGameTitle"
+	# The expanding spacer otherwise squeezes a wrapping label to one character per line.
+	game_title.autowrap_mode = TextServer.AUTOWRAP_OFF
 	game_title.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	game_title.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	head.add_child(game_title)

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -108,6 +108,9 @@ func test_save_screen_shows_no_slots_before_any_save_exists() -> void:
 	assert_same(save_title.get_parent(), game_title.get_parent(),
 		"game name shares the Save data heading row")
 	assert_eq(game_title.horizontal_alignment, HORIZONTAL_ALIGNMENT_RIGHT)
+	assert_eq(game_title.autowrap_mode, TextServer.AUTOWRAP_OFF)
+	assert_eq(game_title.get_line_count(), 1,
+		"the game name stays on one line beside the expanding spacer")
 
 
 func test_save_screen_distinguishes_an_occupied_slot() -> void:


### PR DESCRIPTION
## Summary
- keep the selected game title on one line beside the save-screen header spacer
- add a regression assertion for the title layout

## Verification
- focused save-screen tests: 20/20 passed
- full unit tier: 2740/2740 passed
- launcher boot smoke test passed
- dark save-screen preview inspected at 1280x800