### PR TITLE
Close the last three open seams: content, rules, replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ live under their own root and are not touched.
 |---|---|
 | Species | Names, base stats, types, held items, egg groups, TM/HM flags |
 | Learnsets, evolutions | All 251 species' level-up moves in cartridge order; every evolution and its method |
+| Egg moves | Every species' inherited moves: 478 across 106 species on Gold and Silver, 480 across 105 on Crystal |
 | Moves, TM/HM | Power, type, accuracy, PP, effect and chance; the 57 or 60 TM, HM and tutor rows; the happiness table teaching one moves |
 | Items, types | 255 items with prices, effects, pockets and healing metadata; 28 type names |
 | Type chart | Every matchup and the two Foresight-cancelled entries |
@@ -210,7 +211,7 @@ The rest are previews and dumps, each driving a real screen or table:
 
 | Tool | Does |
 |---|---|
-| `dump_tables.gd <game> <table>` | Prints a decoded table: `species`, `moves`, `items`, `types`, `matchups`, `trainers`, `learnsets`, `evolutions`, `growth` or `all` |
+| `dump_tables.gd <game> <table>` | Prints a decoded table: `species`, `moves`, `items`, `types`, `matchups`, `trainers`, `learnsets`, `egg_moves`, `evolutions`, `growth` or `all` |
 | `preview_pics.gd <game> <png> [kind]` | Contact sheet of `front`, `trainers`, `font` or `frames` |
 | `preview_*.gd` | One per screen: the intro, title, credits, Hall of Fame, region map, party, marts, fishing, battle switch and animations, overworld sprites and collision |
 | `preview_world_story.gd` | Map entry callbacks, event-flag visibility, facing interactions and the whole story route |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The rest are previews and dumps, each driving a real screen or table:
 | `preview_pics.gd <game> <png> [kind]` | Contact sheet of `front`, `trainers`, `font` or `frames` |
 | `preview_*.gd` | One per screen: the intro, title, credits, Hall of Fame, region map, party, marts, fishing, battle switch and animations, overworld sprites and collision |
 | `preview_world_story.gd` | Map entry callbacks, event-flag visibility, facing interactions and the whole story route |
-| `replay_world.gd [game ...] [frames]` | Records `(frame, button)` from a real run and replays it into a fresh world; the same seed and log must reach the same snapshot byte for byte, at 30 fps and at 144 |
+| `replay_world.gd [game ...] [frames]` | Records `(frame, button)` from a real run and replays it into a fresh world; the same seed and log must reach the same snapshot, party and battle outcome byte for byte, at 30 fps and at 144. One route fights: a wild battle is spent from the world's own pump and steered through its own funnel |
 | `render_audio.gd <game> <kind> <id> <frames> <prefix>` | One record or a whole table through the driver and APU: a WAV plus a per-frame register trace to diff |
 | `screenshot.gd <scene> <png> [frames] [method]` | Any scene to PNG. Opens a window, so it is not headless |
 

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -246,10 +246,28 @@ func reload_selected_save() -> void:
 ## patched for the last run has its contributions dropped either way.
 func _activate_mod_save() -> void:
 	Gen2ModHost.instance().activate_save(selected_save_or_null())
+	_activate_rules(selected_save_or_null())
+
+
+## Plays under the slot's own rules, not the installation's. A slot written before
+## the block existed has none and adopts the installation once, here, which is the
+## only place the two can honestly be reconciled; a run with no slot plays the
+## settings screen's own set.
+func _activate_rules(save: Gen2SaveData) -> void:
+	var installed: Gen2Rules = Gen2OptionsStore.current().rules
+	if save != null:
+		if save.run_rules == null:
+			save.run_rules = installed.duplicate_rules()
+		installed = save.run_rules
+	Gen2Rules.install(installed)
 
 
 ## A save that has just been made. The mods are told before it is written, so
-## whatever a run is built from is in the file the player will load next time.
+## whatever a run is built from is in the file the player will load next time,
+## and the rules it records are the ones it will always be played under.
 func announce_new_save(save: Gen2SaveData) -> void:
+	if save != null and save.run_rules == null:
+		save.run_rules = Gen2OptionsStore.current().rules.duplicate_rules()
 	Gen2ModHost.instance().created_save(save)
 	Gen2ModHost.instance().activate_save(save)
+	_activate_rules(save)

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -36,7 +36,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -1020,6 +1020,30 @@ the slot is played, and puts a change made mid-run into the save rather than int
 the installation. So `host.option()` answers with what THIS run is played with,
 the launcher edits the installation with no slot open, and a slot written before
 the snapshot existed adopts the installation once, when it is first activated.
+
+## Reading the run's rules
+
+`world.rules` is a `Gen2Rules`: which of the cartridge's own bugs this run
+reproduces, and its trainer-AI difficulty. Read it, do not write it. A rule that
+changed mid-run would make the save it produced unreproducible, which is the
+whole reason the rules belong to the run rather than to the installation.
+
+```gdscript
+if world.rules.reproduces(&"metal_powder_overflow"):
+	...
+if world.rules.difficulty == Gen2Rules.DIFFICULTY_HARD:
+	...
+```
+
+`Gen2Rules.FLAGS` is every flag this build names, mapped to what it does by
+default. Each is named for the HARDWARE's behaviour, so a flag that is on means
+the cartridge's bug is reproduced and off means this project's corrected answer is
+used. An unknown flag answers false rather than failing, so a mod written against
+a later build still runs.
+
+The same object is on a battle (`battle.rules`), and exactly one set is installed
+at a time (`Gen2Rules.active()`) because the damage formula and the experience
+curves are statics with no engine object to read it off.
 
 ## Adding a setting
 

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -36,7 +36,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -208,10 +208,15 @@ this section.
 A content number is per kind and starts at `Gen2ContentOverlay.FIRST_MOD_NUMBER`,
 which is 256. Every cartridge number fits in a byte, so a number that does not is
 unambiguously not the cartridge's, and a mod's own numbers mean the same thing on
-Gold, Silver and Crystal. Four kinds are numbered this way: `KIND_SPECIES`,
-`KIND_MOVE`, `KIND_ITEM` and `KIND_TRAINER`. Types are not reachable at all,
-because the matchup lookup keys on the type count and a twenty-ninth type would
-renumber every pair in the chart.
+Gold, Silver and Crystal. Five kinds are numbered this way: `KIND_SPECIES`,
+`KIND_MOVE`, `KIND_ITEM`, `KIND_TRAINER` and `KIND_TYPE`.
+
+A type is the one kind numbered from zero, the cartridge's own chart being
+zero-based, so `patch_content(KIND_TYPE, id, 0, ...)` renames NORMAL and a defined
+type sits past 256 like the rest. It carries a `name` and `physical`, which is
+which stat pair it uses: Generation II splits by type number rather than per move,
+and a number past the chart has nothing to compare against, so a defined type has
+to say. Special is the default.
 
 ```gdscript
 host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
@@ -227,9 +232,32 @@ which exist because readers index these rows directly: `palette.normal` and
 that omitted either would crash the reader rather than draw wrong.
 
 Everything a species carries is a field on the one row, so a learnset, an
-evolution and TM compatibility are part of the definition rather than three more
-registrations. The engine then reads them the way it reads Pikachu's, because
+evolution, its egg moves and TM compatibility are part of the definition rather
+than four more registrations. The engine then reads them the way it reads Pikachu's, because
 every content read in the game goes through one place, `GameData._content()`.
+
+### Art
+
+The pic atlases hold exactly the cartridge's own slots, so a defined species or
+trainer class has no cell to point at and supplies decoded indices instead: two
+bits a pixel, row-major, in the same 0-3 index space the cache stores, and exactly
+`tiles * tiles * 64` of them.
+
+```gdscript
+host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
+	"name": "VOLTLING",
+	"pics": {"front": {"tiles": 7, "indices": front}, "back": {"tiles": 6, "indices": back}},
+	"icon": {"indices": strip},          # or a cartridge icon number, 1 to 38
+	"palette": {"normal": [0x7FFF, 0x0000], "shiny": [0x7FFF, 0x0000]},
+})
+```
+
+A trainer class names one `pic` rather than two. An `icon` is the party menu's
+own strip, the eight tiles of its two 2x2 frames, or one of the cartridge's icon
+numbers to borrow a picture that already exists. Art left out is not an error: a
+species with no `pics` draws whatever its atlas slot holds, which for a number
+past 251 is nothing, and `GameData.species_pic()` answers both kinds in one shape
+so no screen has to know which it got.
 
 `patch_content()` changes a row the cartridge does have. Only the fields named
 change, and a Dictionary field merges, so patching one stat leaves the other five
@@ -248,6 +276,18 @@ host.patch_encounter(manifest.id, &"grass", 3, 2, {
 	"slots": [[{"level": 50, "species": 1}], [], []],
 })
 host.patch_fishing_group(manifest.id, 1, {"rods": [...]})
+```
+
+A type matchup is patched by its pair rather than by a number, and is patch-only:
+the cartridge chart is a sparse table of exceptions, so an absent pair is already
+neutral and there is no row to define. `multiplier` is in tenths, the way the
+damage formula divides, and `negated_by_foresight` is the Ghost immunities' own
+rule.
+
+```gdscript
+host.patch_type_matchup(manifest.id, 256, RomLayout.TYPE_NORMAL, {
+	"multiplier": RomLayout.MATCHUP_SUPER_EFFECTIVE,
+})
 ```
 
 An encounter row is what `GameData.world_encounter(method, group, number)`
@@ -411,10 +451,20 @@ answering for a list it is no longer in.
 `CHANNEL_BATTLE` calls `handler` with each event dictionary as the screen showing
 it reads it, so a subscriber sees what the player sees, in that order.
 
-Reading only. The handler is given a copy and nothing reads its return value:
-observation cannot make two mods fight over the same state, which is what makes
-this safe to hand out before any mutation hook exists. Events are published from
-the screens, so a headless tool or a test driving the engine directly fires none.
+A subscriber reads only: the handler is given a copy and nothing reads its return
+value, so watching cannot make two mods fight over the same state. Events are
+published from the screens, so a headless tool or a test driving the engine
+directly fires none.
+
+`register_event_mutator(channel, id, handler)` is the other half. The turn or the
+script has already committed its state by the time these events reach the screen,
+so the handler may rewrite what is SHOWN - text, animation, display values - and
+is handed the whole event to return a changed copy of. Two things it cannot do:
+change the routing key (`type` on the battle channel, `status` on the world one),
+which would turn one screen operation into another, and share the channel. One
+mutator per channel, because composing two rewrites in load order would make the
+picture depend on which mod loaded first. A handler that returns anything else
+leaves the event alone, and subscribers see the mutated event, not the original.
 
 ## Replacing the world renderer
 
@@ -964,6 +1014,13 @@ can exceed the 64 KiB namespace and duplicates cartridge rows anyway. A save
 carrying no snapshot has no run and should stay vanilla rather than adopt today's
 options.
 
+Registered settings need none of that. The host snapshots them onto the save
+itself (`Gen2SaveData.run_options`) when it is created, binds that snapshot while
+the slot is played, and puts a change made mid-run into the save rather than into
+the installation. So `host.option()` answers with what THIS run is played with,
+the launcher edits the installation with no slot open, and a slot written before
+the snapshot existed adopts the installation once, when it is first activated.
+
 ## Adding a setting
 
 `register_option(id, option)` describes one setting: a ladder of values, a
@@ -1018,11 +1075,15 @@ only when at least one loaded mod registered a setting, so a player with no mods
 sees the cartridge's menu exactly.
 
 A change is committed the moment it is made, the way the cartridge's own OPTION
-menu writes each press to `wOptions`. Values live in `user://mod_options.json`,
-keyed by mod id, because a draw distance is a property of this installation and
-must not change when a save slot is loaded. Only values are stored, never what a setting means, so a
-mod that drops a rung in a later version finds its stored value refused and its
-default used instead, and uninstalling a mod drops what it stored.
+menu writes each press to `wOptions`. With no slot open it lands in
+`user://mod_options.json`, keyed by mod id: that file is the installation's own
+values and the template a new run is created from. While a slot is played the
+change belongs to the slot instead (`run_options`, see "Holding a run rather than
+an installation"), because a draw distance that moved under a loaded save would
+make that save's own recorded walk unreproducible. Only values are stored, never
+what a setting means, so a mod that drops a rung in a later version finds its
+stored value refused and its default used instead, and uninstalling a mod drops
+what it stored.
 
 Per-slot state belongs in the save instead. A discovered manifest can use
 `host.read_save_data(manifest, save)` and
@@ -1098,10 +1159,12 @@ takes the press first.
 
 ## Not built yet
 
-Art for mod content and mutation hooks on the event channels. A mod
-species does not appear in the Pokedex either: both dex order tables are
-cartridge data of exactly 251 entries, and nothing splices `defined_numbers()`
-into them, though a mod species that replaces a cartridge one does carry its own
-dex entry. Evaluate
+A mod species does not appear in the Pokedex: both dex order tables are cartridge
+data of exactly 251 entries, and nothing splices `defined_numbers()` into them,
+though a mod species that replaces a cartridge one does carry its own dex entry.
+Mod content cannot leave the project's own save either: every species, item and
+move on the hardware is one byte, so `Gen2SramAdapter` refuses to export a save
+carrying any of it rather than truncating a number into a different Pokemon.
+Evaluate
 [godot-mod-loader](https://github.com/GodotModding/godot-mod-loader) before
 expanding the loader itself.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -27,7 +27,8 @@ Save format version 6 stores:
   the state: the world's seed, the mods that were loaded when it was last
   written, and the registered mod settings the run is played with
   (`run_options`), so a slot cannot silently change draw distance when it is
-  reopened;
+  reopened, and the gameplay rules it is played under (`run_rules`: which of the
+  cartridge's own bugs are reproduced, and the trainer-AI difficulty);
 - `is_egg` for received eggs. An egg keeps its party slot and is skipped when
   the battle party is built, matching the cartridge refusing it as a combatant
   rather than removing it; the writeback puts it back in the same slot. Hatch
@@ -59,8 +60,9 @@ an empty mod namespace. Migration preserves a missing world snapshot as missing;
 it does not invent a map, player position or event state, and it does not roll an
 ID, since that would change an existing save's headbutt encounters. The `run`
 block joined version 6 after it shipped and is not a version of its own: it
-defaults to no seed, mod list or settings snapshot, which is the truth about a
-slot written before it existed. The next successful save writes version 6.
+defaults to no seed, mod list, settings snapshot or rules, which is the truth
+about a slot written before it existed; such a slot adopts the installation's
+rules once, when it is first activated. The next successful save writes version 6.
 
 ## Player flow
 

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -5,7 +5,7 @@ battle engine. Slots live in Godot's `user://`, never in the repository.
 
 ## Canonical project model
 
-Save format version 2 stores:
+Save format version 6 stores:
 
 - game ID and ROM SHA-1, preventing use with another cache;
 - player name, party order and each Pokémon's species, held item, level,
@@ -21,6 +21,13 @@ Save format version 2 stores:
   day/hour/minute clock and the daylight-saving flag;
 - imported-save and party-transaction identity fields: OT ID, nickname, OT,
   happiness, Pokerus and caught data;
+- the trainer card's own fields: `player_id`, the player's `gender` and the play
+  timer;
+- a per-slot, per-mod JSON namespace, and the `run` block naming what produced
+  the state: the world's seed, the mods that were loaded when it was last
+  written, and the registered mod settings the run is played with
+  (`run_options`), so a slot cannot silently change draw distance when it is
+  reopened;
 - `is_egg` for received eggs. An egg keeps its party slot and is skipped when
   the battle party is built, matching the cartridge refusing it as a combatant
   rather than removing it; the writeback puts it back in the same slot. Hatch
@@ -39,18 +46,21 @@ own `label`, the player's name for the slot, so an exported file names itself;
 an empty label means fall back to the player name. Box names, current-box UI
 state and cartridge SRAM box placement are intentionally outside this model.
 
-Each save also carries `player_id`, the cartridge's own `wPlayerID`. It is
-rolled once when a game starts, read from SRAM on import and written back on
-export, and `GetTreeScore` is what reads it: half of a headbutt tree's
-encounter tier comes from the trainer ID. The rest of the trainer card, gender
-and play time, is not modelled.
+`player_id` is the cartridge's own `wPlayerID`, rolled once when a game starts,
+read from SRAM on import and written back on export. `GetTreeScore` is what reads
+it: half of a headbutt tree's encounter tier comes from the trainer ID. `gender`
+is Crystal's `wPlayerGender` and is always male on Gold and Silver, which ship
+neither the byte nor Kris.
 
 Older project saves migrate in memory one version step at a time: version 1
 gains fourteen empty boxes, version 2 gains an empty label, version 3 gains a
-zero `player_id`. Migration preserves a missing world snapshot as missing; it
-does not invent a map, player position or event state, and it does not roll an
-ID, since that would change an existing save's headbutt encounters. The next
-successful save writes version 4.
+zero `player_id`, version 4 gains a male gender and a 0:00 timer, version 5 gains
+an empty mod namespace. Migration preserves a missing world snapshot as missing;
+it does not invent a map, player position or event state, and it does not roll an
+ID, since that would change an existing save's headbutt encounters. The `run`
+block joined version 6 after it shipped and is not a version of its own: it
+defaults to no seed, mod list or settings snapshot, which is the truth about a
+slot written before it existed. The next successful save writes version 6.
 
 ## Player flow
 
@@ -155,7 +165,12 @@ It maps player name and six-party fields: species, item, moves, OT ID,
 experience, stat experience, DVs, PP, happiness, Pokerus, caught data, level,
 status, current HP, nickname and OT. Derived stats are rebuilt from selected
 `GameData`; other bytes remain untouched. Export requires an existing valid SRAM
-image and does not invent unsupported map or event state.
+image and does not invent unsupported map or event state. It also refuses a save
+carrying mod content: every species, item and move on the hardware is one byte,
+and `Gen2ContentOverlay.FIRST_MOD_NUMBER` sits past that, so truncating one would
+write a different Pokemon into a real cartridge. Crystal's player gender rides
+along in `sCrystalData`, its own section outside both save copies, of which only
+bit 0 is written.
 
 | Profile | Primary data | Checksum | Party | Backup |
 |---|---|---|---|---|

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -27,6 +27,9 @@ var stereo: bool = false:
 var _player: AudioStreamPlayer = null
 var _generator: AudioStreamGenerator = null
 var _playback: AudioStreamGeneratorPlayback = null
+## Driver frames rendered, which is what says the timeline is moving at all. See
+## [method timeline_updates].
+var _timeline_updates: int = 0
 var _engine: Gen2SoundEngine = null
 var _apu: Gen2Apu = null
 var _music_key: String = ""
@@ -171,6 +174,20 @@ func effect_playing() -> bool:
 	return _engine.sfx_active()
 
 
+## How many driver frames this player has actually rendered.
+##
+## The engine only advances inside [method _service_timeline], which needs an
+## output stream with room in it: a headless run, a check or a replay leaves the
+## channels exactly as the last request set them, so [method effect_playing] would
+## answer true for the rest of the run. Anything WAITING on a sound compares this
+## count across two frames instead of trusting that answer, and stops waiting when
+## it has not moved. `AudioStreamPlayer.playing` is not that test: the dummy audio
+## driver reports true and consumes nothing. See `Gen2BattleScreen`'s
+## `ANIM_WAIT_SFX` and `HANDOFF.md`'s `WaitSFX` row.
+func timeline_updates() -> int:
+	return _timeline_updates
+
+
 func audio_status() -> Dictionary:
 	var active: Array[int] = []
 	for index: int in Gen2SoundEngine.NUM_CHANNELS:
@@ -238,6 +255,7 @@ func _service_timeline() -> void:
 		if _playback == null:
 			return
 	while _playback.get_frames_available() >= Gen2Apu.SAMPLES_PER_FRAME:
+		_timeline_updates += 1
 		_engine.update_sound()
 		_apu.render_frame(_buffer)
 		_playback.push_buffer(_buffer)

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -1397,9 +1397,9 @@ static func _estimate_damage(
 ## once it is no longer the attacker's first turn.
 ##
 ## Diverges from a documented source bug (`docs/bugs_and_glitches.md`,
-## "'Cautious' AI may fail to discourage residual moves"): a missed roll there
-## abandons the remaining slots instead of moving on. This implements pret's own
-## fix, the same call [code]Gen2EffectCommands._belly_drum[/code] makes.
+## "'Cautious' AI may fail to discourage residual moves") unless
+## `cautious_ai_abandons_remaining_moves` is on: `ret nc` abandons the remaining
+## slots on a missed roll, where pret's own fix moves on to the next one.
 static func _apply_cautious(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int, weather: int,
@@ -1413,8 +1413,12 @@ static func _apply_cautious(
 		if not attacker.can_use(slot):
 			continue
 		var move: Dictionary = _move_at(attacker, data, slot)
-		if RESIDUAL_MOVE_NUMBERS.has(int(move.get("number", 0))) and _roll(rng, 90):
+		if not RESIDUAL_MOVE_NUMBERS.has(int(move.get("number", 0))):
+			continue
+		if _roll(rng, 90):
 			_discourage(scores, slot, 1)
+		elif Gen2Rules.hardware(&"cautious_ai_abandons_remaining_moves"):
+			return
 
 
 ## [constant RomLayout.AI_STATUS]: dismiss a status move the defender's typing

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -430,6 +430,9 @@ const VITAL_THROW: int = 0xE9
 
 var data: GameData = null
 var rng: RandomNumberGenerator = null
+## The run's own divergences and difficulty. Set by [method create_parties], which
+## also installs it, so the statics in the formula read the same set.
+var rules: Gen2Rules = null
 
 ## Whether beating this opponent is worth [Gen2Experience]'s trainer 1.5x. A wild
 ## encounter, which is the default, never sets it.
@@ -574,7 +577,8 @@ static func create_parties(
 	enemy_party: Gen2Party,
 	generator: RandomNumberGenerator,
 	trainer_battle: bool = false,
-	player_badges: int = 0
+	player_badges: int = 0,
+	battle_rules: Gen2Rules = null
 ) -> Gen2Battle:
 	if game_data == null or player_party == null or enemy_party == null:
 		return null
@@ -586,6 +590,10 @@ static func create_parties(
 	out.parties = {PLAYER: player_party, ENEMY: enemy_party}
 	out.rng = generator if generator != null else RandomNumberGenerator.new()
 	out.is_trainer_battle = trainer_battle
+	# The rules the fight is fought under, installed for its duration: the damage
+	# formula and the experience curves are statics with no battle in hand.
+	out.rules = battle_rules if battle_rules != null else Gen2Rules.active()
+	Gen2Rules.install(out.rules)
 	out.player_badge_mask = player_badges & 0xFFFF
 	out._participants = {PLAYER: {player_party.active: true}, ENEMY: {enemy_party.active: true}}
 	out._apply_player_badges()
@@ -597,12 +605,14 @@ static func create(
 	game_data: GameData,
 	player_mon: Gen2BattleMon,
 	enemy_mon: Gen2BattleMon,
-	generator: RandomNumberGenerator
+	generator: RandomNumberGenerator,
+	battle_rules: Gen2Rules = null
 ) -> Gen2Battle:
 	if player_mon == null or enemy_mon == null:
 		return null
 	return create_parties(
-		game_data, Gen2Party.of(player_mon), Gen2Party.of(enemy_mon), generator
+		game_data, Gen2Party.of(player_mon), Gen2Party.of(enemy_mon), generator,
+		false, 0, battle_rules
 	)
 
 

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -306,26 +306,20 @@ func _padded_pic(pic: Dictionary, side: int) -> PackedByteArray:
 	if pic.is_empty():
 		return out
 
-	var atlas: Dictionary = _data.atlas(String(pic["atlas"]))
-	var indices: PackedByteArray = _data.atlas_indices(String(pic["atlas"]))
-	var cell: int = int(atlas.get("cell", 0))
-	var columns: int = int(atlas.get("columns", 0))
-	var atlas_width: int = int(atlas.get("width", 0))
-	var slot: int = int(pic.get("slot", -1))
-	if cell <= 0 or columns <= 0 or atlas_width <= 0 or slot < 0:
+	var name: String = String(pic.get("atlas", ""))
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		_data.atlas_indices(name), _data.atlas(name), pic
+	)
+	if cell.is_empty():
 		return out
 
-	var width: int = mini(int(pic.get("width", cell)), mini(cell, box))
-	var height: int = mini(int(pic.get("height", cell)), mini(cell, box))
-	var left: int = (slot % columns) * cell
-	@warning_ignore("integer_division")
-	var top: int = (slot / columns) * cell
+	var indices: PackedByteArray = cell["indices"]
+	var width: int = mini(int(cell["width"]), box)
+	var height: int = mini(int(cell["height"]), box)
+	var stride: int = int(cell["width"])
 	for y: int in height:
-		var from: int = (top + y) * atlas_width + left
-		if from + width > indices.size():
-			break
 		for x: int in width:
-			out[y * box + x] = indices[from + x]
+			out[y * box + x] = indices[y * stride + x]
 	return out
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -152,6 +152,11 @@ var _renderer_ready: bool = false
 var _battle: Gen2Battle = null
 var _pending: Array = []
 var _rng := RandomNumberGenerator.new()
+## Whether something else owns the funnel every button arrives through. Set while
+## this screen is an overlay inside the overworld, so a press is recorded once, by
+## the world, and a replayed log reaches the fight: see
+## [method Gen2WorldScreen.press_button] and `tools/replay_world.gd`.
+var _external_input: bool = false
 var _save_slot: int = -1
 var _save_written: bool = false
 var _source_save: Gen2SaveData = null
@@ -444,16 +449,15 @@ func _ready() -> void:
 	_screen.display(_info_layer)
 	_apply_renderer_interface_style()
 
-	var world_meta: Variant = get_meta("world_battle_request", {})
-	if world_meta is Dictionary and not (world_meta as Dictionary).is_empty():
-		call_deferred("_start_world_battle_from_meta", world_meta)
+	## Whatever this screen was opened on its own for. A battle inside the
+	## overworld is started by [method start_world_battle], from the frame the
+	## encounter fired on, rather than from anything read here.
+	var saved: Gen2SaveData = _selected_runtime_save()
+	if saved != null and show_saved_party(saved):
+		show_message("Save slot %d loaded. Wild %s appeared!" % [_save_slot + 1, _name_of(_enemy)])
 	else:
-		var saved: Gen2SaveData = _selected_runtime_save()
-		if saved != null and show_saved_party(saved):
-			show_message("Save slot %d loaded. Wild %s appeared!" % [_save_slot + 1, _name_of(_enemy)])
-		else:
-			show_matchup(DEFAULT_ENEMY, DEFAULT_PLAYER, DEFAULT_LEVEL, DEFAULT_LEVEL)
-			_announce()
+		show_matchup(DEFAULT_ENEMY, DEFAULT_PLAYER, DEFAULT_LEVEL, DEFAULT_LEVEL)
+		_announce()
 
 
 ## Supplies a cache-backed data source before the scene enters the tree. The
@@ -467,6 +471,58 @@ func set_data(data: GameData) -> void:
 ## under the same ones rather than under whatever was installed last.
 func set_rules(battle_rules: Gen2Rules) -> void:
 	_injected_rules = battle_rules
+
+
+## Seeds everything this screen decides for itself: the enemy's move choice, its
+## item and switch decisions, and the capture rolls.
+##
+## A battle inside a walk is drawn from the world's own generator, so the seed is
+## part of the run's own chain and a replay reproduces the fight without recording
+## anything about it. A battle with no world seeds itself randomly, which is what
+## a development one should do.
+func set_random_seed(value: int) -> void:
+	_rng.seed = value
+
+
+## Hands the input funnel to whoever opened this screen. The world does while a
+## battle is an overlay on it: one funnel is what makes a recorded log complete,
+## and two would record every press twice or none.
+func set_external_input(external: bool) -> void:
+	_external_input = external
+
+
+## The request this fight was started from, as the adapter prepared it: the
+## species, the level, the DVs and which visible encounter it was, for a test or a
+## mod asking what is being fought rather than what is drawn.
+func world_battle_request() -> Dictionary:
+	return _world_battle_request.duplicate(true)
+
+
+## One button, from the funnel rather than from an [InputEvent]. Public so the
+## world can forward what it consumed and a tool can drive a fight by hand.
+func press_button(button: int) -> bool:
+	if not is_ready() or button == Gen2Button.NONE:
+		return false
+	return _handle_button(button)
+
+
+## One hardware frame of everything this screen counts, including the party icons
+## the switch menu animates, which [method _process] otherwise paces off real
+## time. What lets the world spend a battle's frames from its own pump, so a
+## replayed run reaches the same place at the same frame.
+func advance_hardware_frame() -> bool:
+	var moved: bool = false
+	## `PrintLetterDelay` is a frame count, and with nothing servicing the box's
+	## own `_process` a message would never finish revealing, so a press would
+	## complete the page forever and never acknowledge it.
+	if _box != null:
+		_box.advance_frame()
+	if _switch_stage in [&"pick", &"refused"]:
+		moved = advance_party_icons()
+		_refresh_menu_layer()
+	if not frames_running():
+		return moved
+	return advance_frame() or moved
 
 
 ## Null rather than the first imported cache: a battle opened without a runtime
@@ -718,18 +774,6 @@ func _preview_world_battle_loss() -> void:
 	finish()
 	advance()
 	finish()
-
-
-func _start_world_battle_from_meta(meta: Variant) -> void:
-	if not meta is Dictionary:
-		_emit_world_battle_failure(&"invalid_battle_metadata")
-		return
-	var values: Dictionary = meta as Dictionary
-	var save_value: Variant = values.get("save", null)
-	var save: Gen2SaveData = save_value if save_value is Gen2SaveData else null
-	start_world_battle(
-		values.get("request", {}), save, int(values.get("player_badges", -1))
-	)
 
 
 func _emit_world_battle_failure(reason: StringName, details: Dictionary = {}) -> void:
@@ -1069,10 +1113,19 @@ func _run_next_anim_step() -> void:
 				_push_view()
 				return
 			ANIM_WAIT_SFX:
+				## `WaitSFX` is a real wait while the driver is being serviced and
+				## no wait at all when it is not: a run with no audio device leaves
+				## the channels as the sound left them, so `effect_playing()` would
+				## answer true for the rest of the run and this plan would never
+				## finish. The rendered-frame count is what tells the two apart,
+				## and it costs one frame either way.
 				if _audio_player != null and _audio_player.effect_playing():
-					_anim_plan.push_front(step)
-					_anim_delay = 1
-					return
+					var rendered: int = _audio_player.timeline_updates()
+					if int(step.get("rendered", -1)) != rendered:
+						step["rendered"] = rendered
+						_anim_plan.push_front(step)
+						_anim_delay = 1
+						return
 			ANIM_HIT_SOUND:
 				_play_hit_sound()
 			ANIM_SCRIPT:
@@ -3408,7 +3461,7 @@ func _read_hp() -> void:
 ## The cartridge's own controls first, then the development drivers that stand
 ## in for a battle menu this screen does not have yet.
 func _unhandled_input(event: InputEvent) -> void:
-	if not is_ready():
+	if not is_ready() or _external_input:
 		return
 	var button: int = Gen2Button.pressed_in(event)
 	if button != Gen2Button.NONE:

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -158,6 +158,9 @@ var _source_save: Gen2SaveData = null
 var _world_battle_active: bool = false
 var _world_battle_tutorial: bool = false
 var _world_battle_request: Dictionary = {}
+## The run's rules, handed over by whoever opened this screen. A development
+## battle has none and plays the installed set.
+var _injected_rules: Gen2Rules = null
 var _world_battle_completion_sent: bool = false
 var _world_battle_terminal_text_shown: bool = false
 var _world_battle_recovery_shown: bool = false
@@ -460,6 +463,12 @@ func set_data(data: GameData) -> void:
 	_injected_data = data
 
 
+## The rules the world is being played under, so the fight inside it is fought
+## under the same ones rather than under whatever was installed last.
+func set_rules(battle_rules: Gen2Rules) -> void:
+	_injected_rules = battle_rules
+
+
 ## Null rather than the first imported cache: a battle opened without a runtime
 ## is a development one, and the caller has already injected what it draws with.
 func _selected_runtime_data() -> GameData:
@@ -620,7 +629,7 @@ func start_world_battle(
 	if badge_mask < 0:
 		badge_mask = 0
 	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
-		_data, request, player_party, _rng, badge_mask
+		_data, request, player_party, _rng, badge_mask, _injected_rules
 	)
 	if not bool(prepared.get("ok", false)):
 		_emit_world_battle_failure(
@@ -1744,7 +1753,11 @@ func _random_slot(side: int) -> int:
 func _enemy_slot() -> int:
 	if _enemy_trainer_class == 0:
 		return _random_slot(Gen2Battle.ENEMY)
-	var weights: int = int(_data.trainer_attributes(_enemy_trainer_class).get("ai_move_weights", 0))
+	# The class's own imported mask under the normal difficulty; the other two
+	# rewrite which layers score rather than inventing a level or a stat.
+	var weights: int = _rules().ai_move_weights(
+		int(_data.trainer_attributes(_enemy_trainer_class).get("ai_move_weights", 0))
+	)
 	return Gen2BattleAI.choose_slot(
 		_battle.mon(Gen2Battle.ENEMY), _battle.mon(Gen2Battle.PLAYER), _data, weights, _rng,
 		_battle.mon(Gen2Battle.ENEMY).turns_taken, _battle.mon(Gen2Battle.PLAYER).turns_taken,
@@ -1765,6 +1778,14 @@ func _enemy_action() -> Dictionary:
 		_data.trainer_attributes(_enemy_trainer_class).get("ai_item_switch", 0)
 	)
 	return Gen2BattleAI.choose_action(_battle, flags, slot, _rng)
+
+
+## The run's rules, which the battle carries once it exists and the installed set
+## answers for before that: a screen builds its menus before its battle.
+func _rules() -> Gen2Rules:
+	if _battle != null and _battle.rules != null:
+		return _battle.rules
+	return _injected_rules if _injected_rules != null else Gen2Rules.active()
 
 
 ## Tries to run, which is `BattleMenu_Run` and settles before the turn does.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2851,7 +2851,7 @@ func _replace_the_fallen() -> bool:
 func _show_next_event() -> void:
 	while not _pending.is_empty():
 		var event: Dictionary = _pending.pop_front()
-		Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
+		event = Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
 		if StringName(event["type"]) == Gen2Battle.ANIMATION:
 			## The engine has already resolved; this event is the frames the
 			## screen owes for it, and nothing behind it is shown until they are

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -451,7 +451,13 @@ static func psywave_damage(level: int, rng: RandomNumberGenerator) -> int:
 
 ## The split is by type, not by move: below Fire is physical and Fire up
 ## special, which is why Hyper Beam is special and Bite physical.
+##
+## A type past the cartridge's chart is a mod's own and carries the choice on its
+## row instead, since there is no number to compare it against. Only such a
+## number reaches the overlay, so a cartridge battle pays one comparison.
 static func is_physical(move_type: int) -> bool:
+	if move_type >= RomLayout.TYPE_COUNT:
+		return Gen2ContentOverlay.shared().type_is_physical(move_type)
 	return move_type < RomLayout.SPECIAL_TYPES_START
 
 

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -497,10 +497,12 @@ static func _defense_stat(
 ## `DittoMetalPowder`, called at `.done` after `TruncateHL_BC`, so the half again
 ## lands on the byte rather than on the stat it was truncated from.
 ##
-## Its overflow is reproduced, not corrected: `srl a / add c` carries for a byte
-## over 170 and the recovery halves the *attack* and shifts the carry back into
-## the defence, which is `docs/bugs_and_glitches.md`'s "Metal Powder can increase
-## damage taken with boosted (Special) Defense".
+## Its overflow is reproduced by default: `srl a / add c` carries for a byte over
+## 170 and the recovery halves the *attack* and shifts the carry back into the
+## defence, which is `docs/bugs_and_glitches.md`'s "Metal Powder can increase
+## damage taken with boosted (Special) Defense". Turning
+## `metal_powder_overflow` off keeps the boosted defence at the byte it would
+## have overflowed past, which is what the boost was for.
 static func metal_powder_pair(defender: Gen2BattleMon, pair: Array) -> Array:
 	if defender == null or not Gen2HeldItem.boosts_defence(defender.species, defender.item):
 		return pair
@@ -508,6 +510,8 @@ static func metal_powder_pair(defender: Gen2BattleMon, pair: Array) -> Array:
 	var boosted: int = Gen2HeldItem.metal_powder_defence(int(pair[1]))
 	if boosted <= STAT_BYTE_MAX:
 		return [attack, boosted]
+	if not Gen2Rules.hardware(&"metal_powder_overflow"):
+		return [attack, STAT_BYTE_MAX]
 	# `srl b`, floored at one the way the routine's own `inc b` floors it.
 	attack = maxi(attack >> 1, 1)
 	# `scf / rr c`: the carry comes back as the high bit of what is left.

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -258,6 +258,9 @@ const HAZE: StringName = &"haze"
 ## Half the user's maximum HP for an Attack straight to the top of its range.
 ## Fails free if it has no more than half, or if Attack is already there.
 const BELLY_DRUM: StringName = &"bellydrum"
+## What one `BattleCommand_AttackUp2` is worth, which is what Belly Drum spends
+## before it checks whether it can pay. See [method _belly_drum].
+const ATTACK_UP_2_STAGES: int = 2
 
 ## Copies the target's stages onto the user, all seven at once. Fails if the
 ## target has nothing raised or lowered to copy.
@@ -2384,6 +2387,15 @@ static func _belly_drum(turn: Gen2Turn) -> void:
 	var has_enough_hp: bool = mon.hp * 2 > mon.max_hp()
 	var stage: int = mon.stage("attack")
 	if not has_enough_hp or stage >= Gen2Stats.MAX_STAGE:
+		## `BattleCommand_BellyDrum` calls `BattleCommand_AttackUp2` before the
+		## HP check and only branches to `.failed` after it, so on hardware a
+		## Belly Drum that cannot pay has already been paid: Attack is up two
+		## stages and no HP was taken.
+		if not has_enough_hp and stage < Gen2Stats.MAX_STAGE \
+			and Gen2Rules.hardware(&"belly_drum_boosts_below_half_hp"):
+			var by: int = mini(ATTACK_UP_2_STAGES, Gen2Stats.MAX_STAGE - stage)
+			mon.change_stage("attack", by)
+			turn.emit(Gen2Battle.STAT_CHANGED, {"target": turn.side, "stat": "attack", "by": by})
 		turn.emit(Gen2Battle.STAT_CHANGE_FAILED, {"target": turn.side, "stat": "attack", "by": 6})
 		return
 

--- a/game/battle/experience.gd
+++ b/game/battle/experience.gd
@@ -49,11 +49,13 @@ const TRAINER_BONUS_NUMERATOR: int = 3
 const TRAINER_BONUS_DENOMINATOR: int = 2
 
 
-## Level 1 is hard-coded to zero: the medium slow curve underflows there, which
-## `docs/bugs_and_glitches.md` calls a bug rather than a rule.
+## Level 1 is hard-coded to zero, which is pret's own fix: the medium slow curve
+## underflows there, and `docs/bugs_and_glitches.md` calls it a bug rather than a
+## rule. Under `medium_slow_level_one_underflow` the formula runs at level 1 the
+## way `CalcExpAtLevel` does, and its three bytes wrap.
 static func total_exp_at(growth_rate: int, level: int) -> int:
 	var n: int = clampi(level, 1, MAX_LEVEL)
-	if n <= 1:
+	if n <= 1 and not Gen2Rules.hardware(&"medium_slow_level_one_underflow"):
 		return 0
 
 	var curve: Array = CURVES.get(growth_rate, CURVES[GROWTH_MEDIUM_FAST])
@@ -67,7 +69,12 @@ static func total_exp_at(growth_rate: int, level: int) -> int:
 	var cubic: int = (a * n * n * n) / b
 	var quadratic: int = c * n * n
 	var linear: int = d * n
-	return clampi(cubic + quadratic + linear - e, 0, MAX_EXP)
+	var total: int = cubic + quadratic + linear - e
+	if total < 0:
+		# `sub`/`sbc` over the three bytes of hProduct, which is the underflow
+		# itself rather than a floor at zero.
+		return total & MAX_EXP
+	return clampi(total, 0, MAX_EXP)
 
 
 ## Walked upward the way `CalcLevel` walks it: the forward formula truncates, so

--- a/game/battle/hp_bar_animation.gd
+++ b/game/battle/hp_bar_animation.gd
@@ -25,6 +25,7 @@ const LENGTH_PX: int = Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
 const FRAMES_PER_STEP: int = 2
 
 var _max_hp: int = 0
+var _from_hp: int = 0
 var _to_hp: int = 0
 var _pixels: int = 0
 var _target_pixels: int = 0
@@ -36,6 +37,7 @@ var _frames: int = 0
 static func create(from_hp: int, to_hp: int, max_hp: int) -> Gen2HpBarAnimation:
 	var animation := Gen2HpBarAnimation.new()
 	animation._max_hp = max_hp
+	animation._from_hp = from_hp
 	animation._to_hp = to_hp
 	animation._pixels = Gen2BattleHud.bar_pixels(from_hp, max_hp, LENGTH_PX)
 	animation._target_pixels = Gen2BattleHud.bar_pixels(to_hp, max_hp, LENGTH_PX)
@@ -67,10 +69,10 @@ func advance_frame() -> bool:
 ## arrived.
 ##
 ## Mid-animation this is the inverse of `ComputeHPBarPixels`, which is what the
-## long branch prints as it steps real HP toward the target. The short branch
-## back-computes with `ShortHPBar_CalcPixelFrame` instead, whose documented
-## off-by-one for low HP is not reproduced; see the divergence note in
-## `HANDOFF.md`. Only the number differs, never the bar.
+## long branch prints as it steps real HP toward the target. The short branch is
+## `ShortHPBar_CalcPixelFrame`'s own answer instead, whose off-by-one for low HP
+## is switched by `short_hp_bar_number_off_by_one`. Only the number differs,
+## never the bar.
 func hp() -> int:
 	if finished():
 		return _to_hp
@@ -80,6 +82,37 @@ func hp() -> int:
 		return 0
 	if _pixels >= LENGTH_PX:
 		return _max_hp
+	if _max_hp < LENGTH_PX:
+		return _short_bar_hp()
 	@warning_ignore("integer_division")
 	var value: int = _pixels * _max_hp / LENGTH_PX
 	return clampi(maxi(value, 1), 0, _max_hp)
+
+
+## `ShortHPBar_CalcPixelFrame`, which is how a maximum under the bar's own width
+## recovers an HP number from a pixel count: multiply, subtract the width until it
+## borrows, then round with its `add hl, $80` and one more subtraction.
+##
+## Its loop subtracts before it tests, so an exact multiple of the width is
+## counted and then rounded up again: one HP too many, which is
+## `docs/bugs_and_glitches.md`'s "HP bar animation off-by-one error for low HP".
+## pret's fix stops the loop on the zero, and the rounding then lands on the
+## quotient itself. Everything else about the routine is the same either way.
+##
+## The answer is clamped to the two ends of this animation, which is the routine's
+## own `wCurHPAnimLowHP`/`wCurHPAnimHighHP` comparison and is why the extra HP is
+## invisible until the drain passes through an exact multiple.
+func _short_bar_hp() -> int:
+	var total: int = _max_hp * _pixels
+	var counted: int = 0
+	var rest: int = total
+	while true:
+		rest -= LENGTH_PX
+		if rest < 0:
+			break
+		if rest == 0 and not Gen2Rules.hardware(&"short_hp_bar_number_off_by_one"):
+			break
+		counted += 1
+	if rest + 0x80 - LENGTH_PX >= 0:
+		counted += 1
+	return clampi(counted, mini(_from_hp, _to_hp), maxi(_from_hp, _to_hp))

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -15,12 +15,18 @@ extends RefCounted
 ## [method GameData.species_pic] reads [code]front_tiles[/code]) and an omitted
 ## field would crash the reader rather than draw wrong.
 
-## The kinds a mod may reach. Types are not one: the matchup lookup keys on
-## [constant RomLayout.TYPE_COUNT], so a new type renumbers the whole chart.
+## The kinds a mod may reach. Types are zero-based while the other numbered
+## content is one-based; [method define] and [method patch] keep that distinction
+## at this boundary so every reader can use the same overlay.
 const KIND_SPECIES: StringName = &"species"
 const KIND_MOVE: StringName = &"move"
 const KIND_ITEM: StringName = &"item"
 const KIND_TRAINER: StringName = &"trainer"
+const KIND_TYPE: StringName = &"type"
+## One attacking/defending type pair, packed by [method matchup_number]. The
+## cartridge chart is a sparse table of exceptions, so this is patch-only: an
+## absent pair already means neutral and there is no separate row to define.
+const KIND_MATCHUP: StringName = &"matchup"
 ## [method GameData.world_encounter]'s row, numbered by [method encounter_number].
 const KIND_ENCOUNTER: StringName = &"encounter"
 ## [method GameData.world_fishing_group]'s row, numbered as a map header does.
@@ -42,7 +48,8 @@ const KIND_FISHING_TIME: StringName = &"fishing_time"
 ## than the script that runs it.
 const KIND_CHECK: StringName = &"check"
 const KINDS: Array[StringName] = [
-	KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER, KIND_ENCOUNTER, KIND_FISHING,
+	KIND_SPECIES, KIND_MOVE, KIND_ITEM, KIND_TRAINER, KIND_TYPE, KIND_MATCHUP,
+	KIND_ENCOUNTER, KIND_FISHING,
 	KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING, KIND_FISHING_TIME, KIND_CHECK,
 ]
 
@@ -50,7 +57,7 @@ const KINDS: Array[StringName] = [
 ## cannot add a map for a definition to sit at. Their numbers are table
 ## coordinates and do not obey [constant FIRST_MOD_NUMBER].
 const TABLE_KINDS: Array[StringName] = [
-	KIND_ENCOUNTER, KIND_FISHING, KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING,
+	KIND_MATCHUP, KIND_ENCOUNTER, KIND_FISHING, KIND_TREEMON, KIND_BUG_CONTEST, KIND_ROAMING,
 	KIND_FISHING_TIME, KIND_CHECK,
 ]
 
@@ -88,8 +95,14 @@ const DEFAULTS: Dictionary = {
 		"egg_groups": [15, 15],
 		"tmhm": [0, 0, 0, 0, 0, 0, 0, 0],
 		"evolutions": [],
+		"egg_moves": [],
 		"learnset": [],
 		"front_tiles": [7, 7],
+		# Optional decoded, indexed art. A custom pic is
+		# `{tiles, indices}` and an icon is either a cartridge icon number or
+		# `{indices}`. Empty means the mod intentionally supplied no art.
+		"pics": {"front": {}, "back": {}},
+		"icon": 0,
 		# White and black, which draws something legible and obviously not
 		# coloured, the same answer bar_palette() gives an unknown name.
 		"palette": {"normal": [0x7FFF, 0x0000], "shiny": [0x7FFF, 0x0000]},
@@ -118,12 +131,19 @@ const DEFAULTS: Dictionary = {
 	KIND_TRAINER: {
 		"name": "?",
 		"palette": [0x7FFF, 0x0000],
+		"pic": {},
 		"trainers": [],
 		"attributes": {
 			"item1": 0, "item2": 0, "base_reward": 0,
 			"ai_move_weights": 0, "ai_item_switch": 0,
 		},
 		"dvs": Gen2BattleMon.PERFECT_DVS,
+	},
+	KIND_TYPE: {
+		"name": "?",
+		# Generation II has no per-move category. A newly defined type has to
+		# choose which stat pair it uses, and special is the safer default.
+		"physical": false,
 	},
 }
 
@@ -168,6 +188,9 @@ func define(kind: StringName, id: StringName, number: int, row: Dictionary) -> D
 			"ok": false, "reason": &"reserved_content_number",
 			"detail": "%s %d" % [kind, number],
 		}
+	var validation: Dictionary = _validate_fields(kind, row)
+	if not bool(validation.get("ok", false)):
+		return validation
 	var conflict: Dictionary = _claim(kind, id, number)
 	if not bool(conflict.get("ok", false)):
 		return conflict
@@ -190,13 +213,21 @@ func patch(kind: StringName, id: StringName, number: int, fields: Dictionary) ->
 				"ok": false, "reason": &"not_a_table_row",
 				"detail": "%s %d" % [kind, number],
 			}
-	elif number < 1 or number >= FIRST_MOD_NUMBER:
+	elif kind == KIND_TYPE and (number < 0 or number >= FIRST_MOD_NUMBER):
+		return {
+			"ok": false, "reason": &"not_a_cartridge_number",
+			"detail": "%s %d" % [kind, number],
+		}
+	elif kind != KIND_TYPE and (number < 1 or number >= FIRST_MOD_NUMBER):
 		return {
 			"ok": false, "reason": &"not_a_cartridge_number",
 			"detail": "%s %d" % [kind, number],
 		}
 	if fields.is_empty():
 		return {"ok": false, "reason": &"empty_content_patch", "detail": String(kind)}
+	var validation: Dictionary = _validate_fields(kind, fields)
+	if not bool(validation.get("ok", false)):
+		return validation
 	var conflict: Dictionary = _claim(kind, id, number)
 	if not bool(conflict.get("ok", false)):
 		return conflict
@@ -241,6 +272,29 @@ static func encounter_number(method: StringName, group: int, number: int) -> int
 	return at * 0x10000 + group * 0x100 + number
 
 
+## One collision-free key for a type matchup. Both ids remain whole rather than
+## being multiplied by the cartridge's type count, so a mod type cannot alias a
+## cartridge pair. Negative or wider-than-31-bit ids cannot be content numbers.
+static func matchup_number(attacking: int, defending: int) -> int:
+	if attacking < 0 or attacking > 0x7FFFFFFF \
+		or defending < 0 or defending > 0x7FFFFFFF:
+		return -1
+	return (attacking << 32) | defending
+
+
+## Which stat pair a type uses. Only a mod type reaches this: the cartridge's own
+## split is a number comparison ([method Gen2Damage.is_physical]) and needs no
+## lookup, so an unmodded battle pays nothing for the question.
+func type_is_physical(number: int) -> bool:
+	var defined: Dictionary = _defined.get(KIND_TYPE, {})
+	if defined.has(number):
+		return bool((defined[number] as Dictionary).get("physical", false))
+	var patched: Dictionary = _patched.get(KIND_TYPE, {})
+	if patched.has(number):
+		return bool((patched[number] as Dictionary).get("physical", false))
+	return number < RomLayout.SPECIAL_TYPES_START
+
+
 ## Which mod claimed [param number], for a launcher listing what it will change.
 func owner_of(kind: StringName, number: int) -> StringName:
 	return StringName((_owners.get(kind, {}) as Dictionary).get(number, &""))
@@ -283,6 +337,81 @@ func _normalized(kind: StringName, number: int, row: Dictionary) -> Dictionary:
 	var out: Dictionary = _merged(DEFAULTS[kind], row)
 	out["number"] = number
 	return out
+
+
+## Validates the fields readers index directly before a mod claims their number.
+## Rows otherwise stay open-ended so future readers can add optional fields
+## without making an older host erase them.
+func _validate_fields(kind: StringName, fields: Dictionary) -> Dictionary:
+	if kind == KIND_SPECIES:
+		if fields.has("pics"):
+			var pics: Variant = fields["pics"]
+			if not pics is Dictionary:
+				return _invalid(&"invalid_content_pic", "species pics")
+			for facing: String in ["front", "back"]:
+				if (pics as Dictionary).has(facing):
+					var valid_pic: Dictionary = _validate_pic((pics as Dictionary)[facing], 7)
+					if not bool(valid_pic.get("ok", false)):
+						return valid_pic
+		if fields.has("icon"):
+			var icon: Variant = fields["icon"]
+			if icon is int or icon is float:
+				if int(icon) < 0 or int(icon) > RomLayout.MON_ICON_COUNT:
+					return _invalid(&"invalid_content_icon", "icon %d" % int(icon))
+			elif icon is Dictionary:
+				if not _valid_indices((icon as Dictionary).get("indices", null), 8 * Gen2Tiles.TILE_PIXELS):
+					return _invalid(&"invalid_content_icon", "custom icon")
+			else:
+				return _invalid(&"invalid_content_icon", "species icon")
+	elif kind == KIND_TRAINER and fields.has("pic"):
+		var valid_trainer_pic: Dictionary = _validate_pic(fields["pic"], 7)
+		if not bool(valid_trainer_pic.get("ok", false)):
+			return valid_trainer_pic
+	elif kind == KIND_TYPE:
+		if fields.has("name") and String(fields["name"]).is_empty():
+			return _invalid(&"invalid_content_type", "type name")
+		if fields.has("physical") and not fields["physical"] is bool:
+			return _invalid(&"invalid_content_type", "physical must be true or false")
+	elif kind == KIND_MATCHUP:
+		if not fields.has("multiplier"):
+			return _invalid(&"invalid_type_matchup", "multiplier is missing")
+		var multiplier: int = int(fields["multiplier"])
+		if multiplier < 0 or multiplier > 0xFF:
+			return _invalid(&"invalid_type_matchup", "multiplier %d" % multiplier)
+		if fields.has("negated_by_foresight") and not fields["negated_by_foresight"] is bool:
+			return _invalid(&"invalid_type_matchup", "negated_by_foresight")
+	return {"ok": true}
+
+
+func _validate_pic(value: Variant, maximum_tiles: int) -> Dictionary:
+	if value is Dictionary and (value as Dictionary).is_empty():
+		return {"ok": true}
+	if not value is Dictionary:
+		return _invalid(&"invalid_content_pic", "pic is not a dictionary")
+	var tiles: int = int((value as Dictionary).get("tiles", 0))
+	if tiles < 1 or tiles > maximum_tiles:
+		return _invalid(&"invalid_content_pic", "pic tiles %d" % tiles)
+	if not _valid_indices(
+		(value as Dictionary).get("indices", null), tiles * tiles * Gen2Tiles.TILE_PIXELS
+	):
+		return _invalid(&"invalid_content_pic", "pic indices")
+	return {"ok": true}
+
+
+func _valid_indices(value: Variant, expected: int) -> bool:
+	if not value is PackedByteArray and not value is Array:
+		return false
+	if value.size() != expected:
+		return false
+	for pixel: Variant in value:
+		var index: int = int(pixel)
+		if index < 0 or index > 3:
+			return false
+	return true
+
+
+func _invalid(reason: StringName, detail: String) -> Dictionary:
+	return {"ok": false, "reason": reason, "detail": detail}
 
 
 ## [param over] laid on [param base], recursing into Dictionary values so a

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -832,14 +832,33 @@ func overworld_icon_indices(icon_number: int) -> PackedByteArray:
 ## when the cache does not hold the table. Its `cp EGG` is [param egg], which
 ## this save model carries beside a real species rather than as species $fd. A
 ## mod species numbered past the cartridge's own range has no row in the imported
-## table and answers zero, which is `ICON_NULL`.
-func mon_menu_icon(species: int, egg: bool = false) -> int:
+## table, so its own row names one of the cartridge's icons instead; a mod that
+## supplied indices of its own answers zero here and is drawn through
+## [method species_icon_indices].
+func mon_menu_icon(species_number: int, egg: bool = false) -> int:
 	if egg:
 		return RomLayout.ICON_EGG
+	var icon: Variant = species(species_number).get("icon", null)
+	if icon is int or icon is float:
+		if int(icon) > 0 and int(icon) <= RomLayout.MON_ICON_COUNT:
+			return int(icon)
 	var table: PackedByteArray = mon_menu_icon_table()
-	if species < 1 or species > table.size():
+	if species_number < 1 or species_number > table.size():
 		return 0
-	return table[species - 1]
+	return table[species_number - 1]
+
+
+## The two-frame strip a species is drawn with in a party menu: the cartridge
+## icon [method mon_menu_icon] names, or a mod's own indices where it supplied
+## them. Empty when neither exists, which is what a menu draws no icon for.
+func species_icon_indices(species_number: int, egg: bool = false) -> PackedByteArray:
+	if not egg:
+		var icon: Variant = species(species_number).get("icon", null)
+		if icon is Dictionary:
+			var indices: Variant = (icon as Dictionary).get("indices", null)
+			if indices is PackedByteArray:
+				return indices
+	return overworld_icon_indices(mon_menu_icon(species_number, egg))
 
 
 func mon_menu_icon_table() -> PackedByteArray:
@@ -961,6 +980,21 @@ func learnset(number: int) -> Array:
 ## [constant RomLayout.EVOLVE_STAT].
 func evolutions(number: int) -> Array:
 	return _rows(species(number), "evolutions", ["method", "parameter", "condition", "target"])
+
+
+## The moves a species can inherit from its father, in `EggMovePointers`' own
+## order. Empty for the 145 or 146 species that inherit none, and for a mod
+## species that named none.
+##
+## Move numbers alone: an egg move has no level, unlike a [method learnset] row.
+## Which of them a hatched Pokémon actually knows is the breeding rule, not this
+## table, and no breeding exists here yet; the data is what a mod, a dex screen or
+## a randomizer asks for.
+func egg_moves(number: int) -> Array[int]:
+	var out: Array[int] = []
+	for move: Variant in species(number).get("egg_moves", []):
+		out.append(int(move))
+	return out
 
 
 ## A species' Pokedex entry as { category, height, weight, pages }, or an empty
@@ -1159,9 +1193,27 @@ func world_trade_count() -> int:
 	return _world_trades.size()
 
 
-## Type names are indexed from zero, unlike everything else here.
+## Type names are indexed from zero, unlike everything else here, which is why
+## this passes the number to the overlay untouched rather than through
+## [method _content]'s one-based subtraction.
 func type_name(number: int) -> String:
-	return String(_entry(_types, number).get("name", ""))
+	return String(_overlaid(Gen2ContentOverlay.KIND_TYPE, number, _entry(_types, number))
+		.get("name", ""))
+
+
+## Which stat pair a type attacks and defends with. The cartridge's answer is
+## [method Gen2Damage.is_physical]'s number comparison; a mod type carries the
+## choice on its own row, since Generation II has no per-move category.
+func type_is_physical(number: int) -> bool:
+	return Gen2Damage.is_physical(number)
+
+
+## Every type number a mod defined, ascending. The cartridge's own run is
+## [constant RomLayout.TYPE_COUNT] wide and includes the padding these follow.
+func mod_type_numbers() -> Array[int]:
+	if _overlay == null:
+		return [] as Array[int]
+	return _overlay.defined_numbers(Gen2ContentOverlay.KIND_TYPE)
 
 
 ## How effective [param attacking] is against [param defending], in tenths: 0 for
@@ -1176,11 +1228,34 @@ func type_name(number: int) -> String:
 ##
 ## [param foresight] is whether the defender has been identified, which cancels
 ## the Ghost immunities and nothing else.
+##
+## The key keeps both ids whole ([method Gen2ContentOverlay.matchup_number]) so a
+## mod type cannot alias a cartridge pair. An unmodded game answers off the
+## folded lookup alone; the overlay is asked only when a mod loaded, this being
+## the damage formula's own path.
 func type_matchup(attacking: int, defending: int, foresight: bool = false) -> int:
-	var key: int = attacking * RomLayout.TYPE_COUNT + defending
+	var key: int = Gen2ContentOverlay.matchup_number(attacking, defending)
+	if _overlay != null and not _overlay.is_empty():
+		var row: Dictionary = _overlay.resolve(
+			Gen2ContentOverlay.KIND_MATCHUP, key, _matchup_row(key)
+		)
+		if foresight and bool(row.get("negated_by_foresight", false)):
+			return RomLayout.MATCHUP_EFFECTIVE
+		return int(row.get("multiplier", RomLayout.MATCHUP_EFFECTIVE))
 	if foresight and _foresight_matchups.has(key):
 		return RomLayout.MATCHUP_EFFECTIVE
 	return int(_matchups.get(key, RomLayout.MATCHUP_EFFECTIVE))
+
+
+## The cartridge's own row for a pair, in the shape a patch merges onto. Never
+## empty, because an absent pair is a real answer here (neutral) rather than a
+## row the cartridge does not carry: [method Gen2ContentOverlay.resolve] leaves an
+## empty base untouched.
+func _matchup_row(key: int) -> Dictionary:
+	return {
+		"multiplier": int(_matchups.get(key, RomLayout.MATCHUP_EFFECTIVE)),
+		"negated_by_foresight": _foresight_matchups.has(key),
+	}
 
 
 ## How effective [param attacking] is against a defender of one or two types,
@@ -1213,7 +1288,9 @@ func _build_matchups(rows: Array) -> void:
 	_matchups = {}
 	_foresight_matchups = {}
 	for row: Dictionary in rows:
-		var key: int = int(row["attacker"]) * RomLayout.TYPE_COUNT + int(row["defender"])
+		var key: int = Gen2ContentOverlay.matchup_number(
+			int(row["attacker"]), int(row["defender"])
+		)
 		_matchups[key] = int(row["multiplier"])
 		if bool(row.get("negated_by_foresight", false)):
 			_foresight_matchups[key] = true
@@ -1892,8 +1969,13 @@ func trainer_dvs(number: int) -> int:
 ## Where a trainer class sits in the trainer atlas. Every trainer is drawn at the
 ## same size, so unlike a species pic this one always fills its cell.
 func trainer_pic(number: int) -> Dictionary:
-	if trainer(number).is_empty():
+	var entry: Dictionary = trainer(number)
+	if entry.is_empty():
 		return {}
+
+	var supplied: Dictionary = _supplied_pic(entry.get("pic", {}))
+	if not supplied.is_empty():
+		return supplied
 
 	var cell: int = int(atlas("trainers").get("cell", 0))
 	if cell <= 0:
@@ -1951,11 +2033,18 @@ func tile_indices(name: String) -> PackedByteArray:
 ## Cells are the size of the largest pic of their kind so a slot can be found by
 ## arithmetic; a smaller pic sits in the top-left of its cell and the rest is
 ## blank. Returns { atlas, slot, width, height } in pixels, or an empty
-## Dictionary for a species that is not in the cache.
+## Dictionary for a species that is not in the cache. A mod species carries its
+## own pixels instead of a cell; see [method _supplied_pic].
 func species_pic(number: int, back: bool = false) -> Dictionary:
 	var entry: Dictionary = species(number)
 	if entry.is_empty():
 		return {}
+
+	var supplied: Dictionary = _supplied_pic(
+		(entry.get("pics", {}) as Dictionary).get("back" if back else "front", {})
+	)
+	if not supplied.is_empty():
+		return supplied
 
 	# Unown's main-table slot holds form A. Its other 25 forms are in an atlas
 	# of their own and are asked for by form, not by species.
@@ -1970,6 +2059,29 @@ func species_pic(number: int, back: bool = false) -> Dictionary:
 		"slot": number - 1,
 		"width": int(tiles[0]) * Gen2Tiles.TILE_WIDTH,
 		"height": int(tiles[1]) * Gen2Tiles.TILE_HEIGHT,
+	}
+
+
+## A mod's own picture for a numbered row, in [method species_pic]'s shape but
+## carrying the pixels instead of an atlas cell to crop.
+##
+## The atlases hold exactly the cartridge's slots, so a defined species or
+## trainer class has no cell to point at and supplies decoded indices on its own
+## row instead. [method Gen2PicImage.atlas_cell] takes either, which is what lets
+## every screen draw both without knowing which it has.
+func _supplied_pic(art: Variant) -> Dictionary:
+	if not art is Dictionary or (art as Dictionary).is_empty():
+		return {}
+	var tiles: int = int((art as Dictionary).get("tiles", 0))
+	var indices: Variant = (art as Dictionary).get("indices", null)
+	if tiles <= 0 or not indices is PackedByteArray:
+		return {}
+	return {
+		"atlas": "",
+		"slot": -1,
+		"indices": indices,
+		"width": tiles * Gen2Tiles.TILE_WIDTH,
+		"height": tiles * Gen2Tiles.TILE_HEIGHT,
 	}
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 66
+const FORMAT_VERSION: int = 67
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -30,6 +30,16 @@ const TRAINER_MIDDLE_CLASS_NAME: String = "YOUNGSTER"
 const FIRST_EVOLUTION_LEVEL: int = 16
 const FIRST_LEARNSET_MOVE: int = 33
 
+## Two independently pinned EggMovePointers rows, one at each side of the
+## breeding divide between the profiles. Staryu loses its three inherited moves
+## in Crystal; Bulbasaur loses Charm there and keeps the other five.
+const EGG_MOVE_BULBASAUR_SPECIES: int = 1
+const EGG_MOVE_STARYU_SPECIES: int = 120
+const EGG_MOVES_BULBASAUR_GOLD_SILVER: Array[int] = [113, 130, 219, 204, 13, 80]
+const EGG_MOVES_BULBASAUR_CRYSTAL: Array[int] = [113, 130, 219, 13, 80]
+const EGG_MOVES_STARYU_GOLD_SILVER: Array[int] = [62, 112, 48]
+const EGG_MOVES_STARYU_CRYSTAL: Array[int] = []
+
 ## Tyrogue, the only species that evolves on a stat comparison, and the number of
 ## ways it can go. It is worth checking on its own: [constant RomLayout.EVOLVE_STAT]
 ## is the one entry that is four bytes rather than three, so a decoder that has
@@ -215,6 +225,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	var evos_attacks: Dictionary = verify_evos_attacks(rom, layout)
 	if not evos_attacks["ok"]:
 		return evos_attacks
+
+	var egg_moves: Dictionary = verify_egg_moves(rom, layout)
+	if not egg_moves["ok"]:
+		return egg_moves
 
 	var pokedex: Dictionary = verify_pokedex(rom, layout)
 	if not pokedex["ok"]:
@@ -2535,6 +2549,104 @@ static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) ->
 	return {"evolutions": evolutions, "learnset": learnset}
 
 
+## One species' inherited move list from EggMovePointers. Returns { moves } on
+## success, including an empty list, and an empty Dictionary for a malformed
+## pointer, move id or unterminated list.
+##
+## The address has no bank byte, so it must name the switchable window and is
+## resolved against the pointer table's bank. The walk stops at that bank's end,
+## not merely the dump's end: continuing into the next bank would turn a missing
+## terminator into plausible data from an unrelated section.
+static func read_egg_moves(rom: RomFile, layout: Dictionary, species: int) -> Dictionary:
+	if species < 1 or species > RomLayout.SPECIES_COUNT \
+		or not layout.has("egg_move_pointers"):
+		return {}
+	var table: int = RomLayout.egg_move_pointer_offset(layout, species)
+	if not rom.in_bounds(table, RomLayout.EGG_MOVE_POINTER_SIZE):
+		return {}
+
+	var address: int = rom.u16le(table)
+	if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
+		return {}
+	var bank: int = RomLayout.bank_of(table)
+	var at: int = RomFile.linear(bank, address)
+	var bank_end: int = mini((bank + 1) * RomFile.BANK_SIZE, rom.size())
+	var moves: Array[int] = []
+	while at < bank_end:
+		var move: int = rom.u8(at)
+		at += 1
+		if move == RomLayout.EGG_MOVE_END:
+			return {"moves": moves}
+		if move < 1 or move > RomLayout.MOVE_COUNT:
+			return {}
+		moves.append(move)
+	return {}
+
+
+## Checks all 251 inherited-move lists before they can enter the cache. The
+## census pins the complete table while Bulbasaur and Staryu distinguish the
+## Gold/Silver data from Crystal's revision.
+static func verify_egg_moves(rom: RomFile, layout: Dictionary) -> Dictionary:
+	for key: String in ["egg_move_pointers", "egg_move_count", "egg_move_species_count"]:
+		if not layout.has(key):
+			return {"ok": false, "message": "No egg-move layout field %s." % key}
+
+	var entries: Array = []
+	var total: int = 0
+	var nonempty: int = 0
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var entry: Dictionary = read_egg_moves(rom, layout, species)
+		if entry.is_empty():
+			return {
+				"ok": false,
+				"message": "Species %d has no readable egg-move list." % species,
+			}
+		var moves: Array = entry["moves"]
+		entries.append(moves)
+		total += moves.size()
+		if not moves.is_empty():
+			nonempty += 1
+
+	var expected_total: int = int(layout["egg_move_count"])
+	if total != expected_total:
+		return {
+			"ok": false,
+			"message": "Read %d egg moves, expected %d." % [total, expected_total],
+		}
+	var expected_nonempty: int = int(layout["egg_move_species_count"])
+	if nonempty != expected_nonempty:
+		return {
+			"ok": false,
+			"message": "%d species have egg moves, expected %d." % [
+				nonempty, expected_nonempty,
+			],
+		}
+
+	var bulbasaur: Array[int] = EGG_MOVES_BULBASAUR_GOLD_SILVER
+	var staryu: Array[int] = EGG_MOVES_STARYU_GOLD_SILVER
+	if rom.id == RomRegistry.CRYSTAL:
+		bulbasaur = EGG_MOVES_BULBASAUR_CRYSTAL
+		staryu = EGG_MOVES_STARYU_CRYSTAL
+	elif rom.id != RomRegistry.GOLD and rom.id != RomRegistry.SILVER:
+		return {"ok": false, "message": "No egg-move profile for %s." % rom.id}
+
+	if entries[EGG_MOVE_BULBASAUR_SPECIES - 1] != bulbasaur:
+		return {
+			"ok": false,
+			"message": "Bulbasaur egg moves are %s, expected %s." % [
+				entries[EGG_MOVE_BULBASAUR_SPECIES - 1], bulbasaur,
+			],
+		}
+	if entries[EGG_MOVE_STARYU_SPECIES - 1] != staryu:
+		return {
+			"ok": false,
+			"message": "Staryu egg moves are %s, expected %s." % [
+				entries[EGG_MOVE_STARYU_SPECIES - 1], staryu,
+			],
+		}
+	return {"ok": true, "message": ""}
+
+
 ## Walks one species' Pokedex entry (data/pokemon/dex_entries.asm).
 ##
 ## Returns { category, height, weight, pages }, empty if the pointer or the walk
@@ -3591,6 +3703,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"trainer_party_count": 0,
 		"evolutions": 0,
 		"learnset_moves": 0,
+		"egg_moves": 0,
 		"maps": 0,
 		"tilesets": 0,
 		"overworld_sprites": 0,
@@ -3727,6 +3840,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 
 	var evolutions: int = _count_in(species, "evolutions")
 	var learnset_moves: int = _count_in(species, "learnset")
+	var egg_moves: int = _count_in(species, "egg_moves")
 	var trainer_party_count: int = _count_in(trainers, "trainers")
 
 	var manifest: Dictionary = {
@@ -3736,6 +3850,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"species_count": species.size(),
 		"evolution_count": evolutions,
 		"learnset_move_count": learnset_moves,
+		"egg_move_count": egg_moves,
 		"move_count": moves.size(),
 		"item_count": items.size(),
 		"world_trade_count": trades.size(),
@@ -3836,6 +3951,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	result["battle_anim_gfx_tiles"] = int(battle_anims["gfx_tiles"])
 	result["evolutions"] = evolutions
 	result["learnset_moves"] = learnset_moves
+	result["egg_moves"] = egg_moves
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
 	result["message"] = ("Imported %d species, %d moves, %d items, %d type matchups, "
 		+ "%d trainer classes carrying %d trainers, %d maps, %d tilesets, %d grass encounter maps, "
@@ -3845,7 +3961,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		+ "%d menus, %d marts, %d phone contacts, %d phone script resources, "
 		+ "%d music tracks and %d sound effects, "
 		+ "%d battle animations over %d graphics tiles, "
-		+ "%d evolutions and %d level-up moves in %d ms.") % [
+		+ "%d evolutions, %d level-up moves and %d egg moves in %d ms.") % [
 		species.size(), moves.size(), items.size(), matchups.size(), trainers.size(),
 		trainer_party_count, int(world["maps"]), int(world["tilesets"]),
 		int(encounters["grass"]), int(encounters["water"]),
@@ -3857,7 +3973,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		int(services["phone_scripts"]),
 		int(services["music"]), int(services["sfx"]),
 		int(battle_anims["scripts"]), int(battle_anims["gfx_tiles"]),
-		evolutions, learnset_moves, result["elapsed_ms"],
+		evolutions, learnset_moves, egg_moves, result["elapsed_ms"],
 	]
 	return result
 
@@ -3880,6 +3996,7 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 		var egg_groups: int = rom.u8(stats + RomLayout.OFFSET_EGG_GROUPS)
 		var palette: int = RomLayout.palette_offset(layout, species)
 		var evos_attacks: Dictionary = read_evos_attacks(rom, layout, species)
+		var inherited: Dictionary = read_egg_moves(rom, layout, species)
 		var dex: Dictionary = read_dex_entry(rom, layout, species)
 
 		out.append({
@@ -3914,6 +4031,7 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 			# stored on the species rather than in tables of their own.
 			"evolutions": evos_attacks.get("evolutions", []),
 			"learnset": evos_attacks.get("learnset", []),
+			"egg_moves": inherited.get("moves", []),
 			"front_tiles": [dimensions & 0x0F, dimensions >> 4],
 			# The Pokedex entry. On the species rather than in a table of its
 			# own because it is asked for by species number and nothing else,

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -433,6 +433,13 @@ const DEXMODE_UNOWN: int = 3
 const EVOS_ATTACKS_POINTER_SIZE: int = 2
 const EVOS_ATTACKS_END: int = 0
 
+## EggMovePointers is one little-endian pointer per species. Like the evolution
+## table, each pointer names a list in the table's own bank. Unlike a level-up
+## list, an egg-move list carries move numbers alone and ends at $FF; an empty
+## list is therefore one $FF byte.
+const EGG_MOVE_POINTER_SIZE: int = 2
+const EGG_MOVE_END: int = 0xFF
+
 ## How a species evolves. The byte after the method is a level for
 ## [constant EVOLVE_LEVEL] and [constant EVOLVE_STAT], an item for
 ## [constant EVOLVE_ITEM], a held item for [constant EVOLVE_TRADE] ($FF for
@@ -1629,6 +1636,11 @@ const GOLD_SILVER: Dictionary = {
 		"gender": -1,
 	},
 	"evos_attacks": 0x427BD,
+	# `EggMovePointers` followed through its 251 same-bank pointers. The lists
+	# contain 478 move ids across 106 nonempty species in both Gold and Silver.
+	"egg_move_pointers": 0x239FE,
+	"egg_move_count": 478,
+	"egg_move_species_count": 106,
 	"type_names": 0x509AE,
 	"type_matchups": 0x34D01,
 	"font": 0xF82F2,
@@ -2054,6 +2066,11 @@ const CRYSTAL: Dictionary = {
 		"gender": 0x1C0CA3,
 	},
 	"evos_attacks": 0x425B1,
+	# Crystal's own `EggMovePointers`; its revised breeding data contains 480
+	# move ids across 105 nonempty species.
+	"egg_move_pointers": 0x23B11,
+	"egg_move_count": 480,
+	"egg_move_species_count": 105,
 	"type_names": 0x5097B,
 	"type_matchups": 0x34BB1,
 	"font": 0xF8200,
@@ -2701,6 +2718,12 @@ static func move_data_offset(layout: Dictionary, move: int) -> int:
 ## bank, so [method bank_of] on the table itself resolves it.
 static func evos_attacks_pointer_offset(layout: Dictionary, species: int) -> int:
 	return int(layout["evos_attacks"]) + (species - 1) * EVOS_ATTACKS_POINTER_SIZE
+
+
+## One species' pointer in EggMovePointers. The address has no bank byte; the
+## table's bank is the list's bank too.
+static func egg_move_pointer_offset(layout: Dictionary, species: int) -> int:
+	return int(layout["egg_move_pointers"]) + (species - 1) * EGG_MOVE_POINTER_SIZE
 
 
 ## How many bytes one evolution entry occupies. [constant EVOLVE_STAT] carries a

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -12,6 +12,9 @@ signal appearance_changed
 ## Label, then the values in the order the source cycles them.
 const TEXT_SPEEDS: Array[String] = ["Fast", "Mid", "Slow"]
 const PRINTER_LABELS: Array[String] = ["Lightest", "Lighter", "Normal", "Darker", "Darkest"]
+## [constant Gen2Rules.MODES], in its order. Written out rather than capitalized
+## from the names, which would say "Qol".
+const RULE_MODES: Array[String] = ["Current", "Vanilla", "QoL"]
 
 var _theme: Gen2LauncherTheme = null
 var _options: Gen2Options = null
@@ -100,6 +103,27 @@ func _build() -> void:
 	)
 	section.arrange_requested.connect(_open_touch_layout)
 	controls.add_child(section)
+
+	var rules: VBoxContainer = _card(column, "Gameplay")
+	rules.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"What the engine does where this port and the cartridge disagree. A run "
+		+ "keeps the rules it was created with, so changing these affects the next "
+		+ "new game rather than a save already in progress."
+	))
+	rules.add_child(Gen2LauncherUI.field(_theme, "Bugs", Gen2LauncherUI.segmented(
+		_theme, RULE_MODES, maxi(Gen2Rules.MODES.find(_options.rules.mode), 0),
+		func(index: int) -> void:
+			_options.rules.set_mode(Gen2Rules.MODES[index])
+			_persist()
+	)))
+	rules.add_child(Gen2LauncherUI.field(_theme, "Trainer AI", Gen2LauncherUI.segmented(
+		_theme, _titles(Gen2Rules.DIFFICULTIES),
+		maxi(Gen2Rules.DIFFICULTIES.find(_options.rules.difficulty), 0),
+		func(index: int) -> void:
+			_options.rules.difficulty = Gen2Rules.DIFFICULTIES[index]
+			_persist()
+	)))
 
 	var game: VBoxContainer = _card(column, "In game")
 	game.add_child(Gen2LauncherUI.muted(

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -184,6 +184,10 @@ var _party_member_entries: Array = []
 ## registration order. See [method register_save_lifecycle].
 var _save_providers: Array = []
 var _subscribers: Dictionary = {}
+## One presentation-event mutator per channel. Mutation is exclusive because
+## composing two rewrites in load order would make the result depend on which
+## mod happened to load first.
+var _event_mutators: Dictionary = {}
 var _failures: Array = []
 
 
@@ -939,6 +943,23 @@ func patch_content(
 	return Gen2ContentOverlay.shared().patch(kind, id, number, fields)
 
 
+## Changes one attacking/defending type pair. A matchup is an exception row,
+## not separately numbered content, so its collision-free key is packed here
+## and the caller keeps speaking in type ids.
+func patch_type_matchup(
+	id: StringName, attacking: int, defending: int, fields: Dictionary
+) -> Dictionary:
+	var number: int = Gen2ContentOverlay.matchup_number(attacking, defending)
+	if number < 0:
+		return {
+			"ok": false, "reason": &"invalid_type_matchup",
+			"detail": "%d against %d" % [attacking, defending],
+		}
+	return Gen2ContentOverlay.shared().patch(
+		Gen2ContentOverlay.KIND_MATCHUP, id, number, fields
+	)
+
+
 ## Changes one map's wild encounter record: the rates and the per-time-of-day
 ## slots [method GameData.world_encounter] answers with, which is what a
 ## randomizer rewrites. [param method] is one of
@@ -1043,9 +1064,8 @@ func content_overlay() -> Gen2ContentOverlay:
 ## Watches one of [constant CHANNELS]. [param handler] is called with each event
 ## dictionary as it reaches the screen showing it.
 ##
-## Reading only. A subscriber is handed a copy and there is no return value the
-## engine reads, so observation cannot make two mods fight over the same state,
-## which is what makes this safe before any mutation hook exists.
+## Reading only. A subscriber is handed a copy of the event after the channel's
+## optional presentation mutator has run.
 func subscribe(channel: StringName, id: StringName, handler: Callable) -> Dictionary:
 	if not CHANNELS.has(channel):
 		return {"ok": false, "reason": &"unknown_channel", "detail": String(channel)}
@@ -1065,21 +1085,67 @@ func unsubscribe(channel: StringName, id: StringName) -> void:
 	(_subscribers.get(channel, {}) as Dictionary).erase(id)
 
 
-## Hands [param event] to whoever is watching [param channel].
+## Exclusively claims a channel's presentation-event rewrite. The battle turn or
+## world script has already committed its state when these events reach the
+## screen, so this may change text, animation and other presentation fields but
+## not gameplay outcomes. The event's routing key (`type` or `status`) cannot be
+## changed, which keeps a rewrite from turning one screen operation into another.
+func register_event_mutator(
+	channel: StringName, id: StringName, handler: Callable
+) -> Dictionary:
+	if not CHANNELS.has(channel):
+		return {"ok": false, "reason": &"unknown_channel", "detail": String(channel)}
+	if String(id).is_empty():
+		return {"ok": false, "reason": &"invalid_event_mutator", "detail": String(channel)}
+	if not handler.is_valid():
+		return {"ok": false, "reason": &"invalid_event_mutator_handler", "detail": String(id)}
+	if _event_mutators.has(channel):
+		var owner: StringName = StringName((_event_mutators[channel] as Dictionary).get("id", &""))
+		return {
+			"ok": false, "reason": &"duplicate_event_mutator",
+			"detail": "%s: %s and %s" % [channel, owner, id],
+		}
+	_event_mutators[channel] = {"id": id, "handler": handler}
+	return {"ok": true, "id": id}
+
+
+func unregister_event_mutator(channel: StringName, id: StringName) -> void:
+	var registered: Dictionary = _event_mutators.get(channel, {})
+	if StringName(registered.get("id", &"")) == id:
+		_event_mutators.erase(channel)
+
+
+## Hands [param event] through the optional presentation rewrite and then to
+## every watcher. Returns the effective event for the screen to consume.
 ##
 ## Static and null-safe on the instance, because this sits on the path every
 ## battle event and every world result takes: a game with no mods must not build
 ## a host, or copy an event, to publish to nobody.
-static func publish(channel: StringName, event: Dictionary) -> void:
+static func publish(channel: StringName, event: Dictionary) -> Dictionary:
 	if _instance == null:
-		return
+		return event
+	var effective: Dictionary = event
+	var registration: Dictionary = _instance._event_mutators.get(channel, {})
+	var mutator: Variant = registration.get("handler", null)
+	if mutator is Callable and (mutator as Callable).is_valid():
+		var candidate: Variant = (mutator as Callable).call(event.duplicate(true))
+		if candidate is Dictionary and _same_event_kind(channel, event, candidate as Dictionary):
+			effective = (candidate as Dictionary).duplicate(true)
 	var handlers: Dictionary = _instance._subscribers.get(channel, {})
-	if handlers.is_empty():
-		return
 	for id: StringName in handlers.keys():
 		var handler: Callable = handlers[id]
 		if handler.is_valid():
-			handler.call(event.duplicate(true))
+			handler.call(effective.duplicate(true))
+	return effective
+
+
+static func _same_event_kind(
+	channel: StringName, original: Dictionary, candidate: Dictionary
+) -> bool:
+	var key: String = "type" if channel == CHANNEL_BATTLE else "status"
+	if not original.has(key):
+		return not candidate.has(key)
+	return candidate.has(key) and candidate[key] == original[key]
 
 
 ## Adds a move effect, as the list of commands a move carrying [param effect]
@@ -1336,7 +1402,13 @@ func save_lifecycle_ids() -> Array:
 ## A save that has just been made, before it is written or played. A provider
 ## snapshots whatever its run is built from into its own namespace here; there is
 ## nothing to clear, since the save carries no run yet.
+##
+## The installation's mod settings are copied onto the save first, so the run
+## records what it was created with and a later change to the installation cannot
+## reach back into it. See [method Gen2ModOptions.bind_run].
 func created_save(save: Gen2SaveData) -> void:
+	if save != null:
+		save.run_options = Gen2ModOptions.snapshot(_options.keys())
 	for entry: Dictionary in _save_providers:
 		entry["provider"].call("save_created", save)
 
@@ -1348,8 +1420,19 @@ func created_save(save: Gen2SaveData) -> void:
 ## Every lifecycle mod's overlay contributions are dropped first, in one pass, so
 ## the callbacks that follow all start from the cartridge whatever order they run
 ## in. A mod that patches at load time and registers no provider is untouched.
+##
+## The save's own mod settings are bound before any callback runs, so a provider
+## reads the values this run was played with rather than the installation's. A
+## slot written before that snapshot existed adopts the installation once, here,
+## which is the one place the two can honestly be reconciled.
 func activate_save(save: Gen2SaveData) -> void:
 	_clear_save_overlays()
+	if save == null:
+		Gen2ModOptions.unbind_run()
+	else:
+		if save.run_options.is_empty():
+			save.run_options = Gen2ModOptions.snapshot(_options.keys())
+		Gen2ModOptions.bind_run(save.run_options)
 	for entry: Dictionary in _save_providers:
 		entry["provider"].call("save_activated", save)
 
@@ -1360,6 +1443,7 @@ func deactivate_save() -> void:
 	for entry: Dictionary in _save_providers:
 		entry["provider"].call("save_deactivated")
 	_clear_save_overlays()
+	Gen2ModOptions.unbind_run()
 
 
 func _clear_save_overlays() -> void:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -17,7 +17,8 @@ const FILENAME: String = "mod.json"
 ## 3 added mart rows and named action axes.
 ## 4 added types, type matchups and mod-supplied art as content, and
 ## [method Gen2ModHost.register_event_mutator].
-const API_VERSION: int = 4
+## 5 added [member Gen2WorldAPI.rules], the run's own divergence flags.
+const API_VERSION: int = 5
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -15,7 +15,9 @@ const FILENAME: String = "mod.json"
 ## Bumped when the host contract changes in a way an existing mod would notice.
 ## 2 added [method Gen2ModHost.register_visible_encounters].
 ## 3 added mart rows and named action axes.
-const API_VERSION: int = 3
+## 4 added types, type matchups and mod-supplied art as content, and
+## [method Gen2ModHost.register_event_mutator].
+const API_VERSION: int = 4
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/mods/mod_options.gd
+++ b/game/mods/mod_options.gd
@@ -3,10 +3,16 @@ extends RefCounted
 
 ## What the player chose for each mod's registered settings.
 ##
-## Stored per mod id in one file under user://, beside [Gen2ModState]'s disabled
-## list and for the same reason: a draw distance is a property of this
-## installation, not of a save file, so it must not change when a slot is
-## loaded. Per-mod *save* data is a separate thing and is not this.
+## The file under user:// is the installation's own values, beside
+## [Gen2ModState]'s disabled list: it is what a NEW run is created from and what
+## the launcher edits with no slot open. Per-mod *save* data is a separate thing
+## and is not this.
+##
+## A run bound with [method bind_run] takes over while it is played, because a
+## draw distance that changed under a loaded slot would make that slot's own
+## recorded walk unreproducible ([member Gen2SaveData.run_options]). The bound
+## Dictionary is the save's, so a setting changed mid-run is kept by the save that
+## was played rather than by the installation alone.
 ##
 ## Only values are kept. What a setting is, what it may be and what it falls back
 ## to is the mod's own registration on [Gen2ModHost], so an uninstalled mod's
@@ -17,26 +23,76 @@ const PATH: String = "user://mod_options.json"
 
 static var _values: Dictionary = {}
 static var _loaded: bool = false
+## The run's own values, or null when no slot is being played. See
+## [method bind_run].
+static var _run: Variant = null
 
 
 ## The stored value for [param key], or null when the player never chose one.
 static func value(id: StringName, key: StringName) -> Variant:
 	_ensure_loaded()
+	if _run != null and (_run as Dictionary).has(id):
+		return ((_run as Dictionary)[id] as Dictionary).get(key, null)
 	return (_values.get(id, {}) as Dictionary).get(key, null)
 
 
 ## Every stored value for one mod, as `{key: value}`.
 static func values_for(id: StringName) -> Dictionary:
 	_ensure_loaded()
+	if _run != null and (_run as Dictionary).has(id):
+		return ((_run as Dictionary)[id] as Dictionary).duplicate()
 	return (_values.get(id, {}) as Dictionary).duplicate()
+
+
+## Plays a run out of [param values], which is the save's own Dictionary rather
+## than a copy of it: a write during the run lands in the save that is being
+## played and is kept with it.
+##
+## A mod with no row in it falls back to the installation's value, which is what a
+## slot written before a mod was installed has to do.
+static func bind_run(values: Dictionary) -> void:
+	_ensure_loaded()
+	_run = values
+
+
+## Ends the run, so the launcher edits the installation again.
+static func unbind_run() -> void:
+	_run = null
+
+
+static func run_bound() -> bool:
+	return _run != null
+
+
+## Every registered value of every mod, for a new save to record what it was
+## created with. Only the ids named are read, since a mod that registered no
+## option has nothing to snapshot.
+static func snapshot(ids: Array) -> Dictionary:
+	_ensure_loaded()
+	var out: Dictionary = {}
+	for raw_id: Variant in ids:
+		var id: StringName = StringName(raw_id)
+		var stored: Dictionary = values_for(id)
+		if not stored.is_empty():
+			out[id] = stored
+	return out
 
 
 ## Returns false only when the change could not be written, in which case the
 ## in-memory value is rolled back so it never disagrees with the file.
+##
+## A bound run takes the write instead of the file: the value belongs to the slot
+## being played, and writing it installation-wide would change every other slot
+## with it. It reaches the disk when that save is written.
 static func store(id: StringName, key: StringName, value_to_store: Variant) -> bool:
 	_ensure_loaded()
 	if String(id).is_empty() or String(key).is_empty():
 		return false
+	if _run != null:
+		var run_mod: Dictionary = (_run as Dictionary).get(id, {})
+		run_mod[key] = value_to_store
+		(_run as Dictionary)[id] = run_mod
+		return true
 	var mod: Dictionary = _values.get(id, {})
 	var had: bool = mod.has(key)
 	var previous: Variant = mod.get(key, null)
@@ -57,6 +113,8 @@ static func store(id: StringName, key: StringName, value_to_store: Variant) -> b
 ## would be read again if the same id were reinstalled later.
 static func forget(id: StringName) -> bool:
 	_ensure_loaded()
+	if _run != null:
+		(_run as Dictionary).erase(id)
 	if not _values.has(id):
 		return true
 	var previous: Variant = _values[id]
@@ -67,9 +125,11 @@ static func forget(id: StringName) -> bool:
 	return false
 
 
+## Rereads the file and ends any bound run, which is what starting over means.
 static func reload() -> void:
 	_loaded = false
 	_values = {}
+	_run = null
 	_ensure_loaded()
 
 

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -82,6 +82,11 @@ var ui_theme: StringName = &"light"
 ## Button bindings, in the shape [Gen2InputActions] stores. Held as data rather
 ## than as an [InputMap] state so the file is the whole scheme and nothing has
 ## to read the engine back to know what the player chose.
+## What the engine does where this project and the cartridge disagree, and the
+## difficulty. Its own object because it belongs to a run rather than to this
+## installation: see [Gen2Rules] and [member Gen2SaveData.run_rules].
+var rules: Gen2Rules = Gen2Rules.new()
+
 var controls: Dictionary = Gen2InputActions.defaults()
 ## What the player bound a mod's own actions to, keyed by the [InputMap] action
 ## name rather than by a button. Separate from [member controls] because a mod's
@@ -180,6 +185,7 @@ func to_dict() -> Dictionary:
 		"max_fps": max_fps,
 		"game_speed": String(game_speed),
 		"ui_theme": String(ui_theme),
+		"rules": rules.to_dict(),
 		"controls": Gen2InputActions.to_dict(controls),
 		"mod_controls": mod_controls.duplicate(true),
 		"touch_mode": String(touch_mode),
@@ -213,6 +219,7 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.ui_theme = _one_of(row.get("ui_theme", ""), UI_THEMES)
 	var fps: int = int(row.get("max_fps", 60))
 	options.max_fps = fps if FPS_CHOICES.has(fps) else 60
+	options.rules = Gen2Rules.parse(row.get("rules"))
 	options.controls = Gen2InputActions.sanitize(row.get("controls"))
 	options.mod_controls = Gen2InputActions.sanitize_mod_controls(row.get("mod_controls"))
 	options.touch_mode = _one_of(row.get("touch_mode", ""), TOUCH_MODES)

--- a/game/options/rules.gd
+++ b/game/options/rules.gd
@@ -1,0 +1,227 @@
+class_name Gen2Rules
+extends RefCounted
+
+## Which behaviour a run is played under, where this project and the cartridge
+## disagree on purpose.
+##
+## Separate from [Gen2Options], which is the installation's own settings: a rule
+## changes what the engine DOES, so it belongs to the run that produced a save
+## rather than to whichever machine is playing it. `HANDOFF.md`'s divergence table
+## is what becomes named flags here, one at a time, each with a live branch on
+## both sides and a test on each.
+##
+## Every flag is named for the cartridge's behaviour and answers "reproduce the
+## hardware", so a flag that is off is this project's own corrected answer. That
+## way a flag added later cannot silently change what an existing run did: the
+## default for a new flag is whatever [constant MODE_CURRENT] says, which is the
+## behaviour that shipped before the flag existed.
+
+## Every named flag, mapped to what [constant MODE_CURRENT] does today. The
+## descriptions belong beside the branch, not here; each key names the
+## `docs/bugs_and_glitches.md` entry it switches.
+const FLAGS: Dictionary = {
+	## `BattleCommand_BellyDrum` calls `BattleCommand_AttackUp2` BEFORE the HP
+	## check, so a failed Belly Drum has already raised Attack by two stages.
+	&"belly_drum_boosts_below_half_hp": false,
+	## `CalcExpAtLevel` runs its formula at level 1, where the medium slow curve's
+	## `- 140` underflows three bytes.
+	&"medium_slow_level_one_underflow": false,
+	## `AI_Cautious`'s `ret nc` abandons the remaining move slots on a failed
+	## roll rather than moving on to the next one.
+	&"cautious_ai_abandons_remaining_moves": false,
+	## `ShortHPBar_CalcPixelFrame`'s off-by-one, which changes the HP NUMBER
+	## printed mid-drain under a 48-pixel maximum and never the bar.
+	&"short_hp_bar_number_off_by_one": false,
+	## `DittoMetalPowder` runs past `TruncateHL_BC`, so a defence byte over 170
+	## carries, halves the attack and folds back below where it started.
+	&"metal_powder_overflow": true,
+}
+
+## `HANDOFF.md`'s mutual recoil faint row is deliberately NOT here: the award pass
+## already refuses a fainted recipient, so clearing the participant as
+## `UpdateFaintedPlayerMon` does changes no outcome that can be observed. It
+## becomes a flag when turn-event ordering makes the difference visible, and a
+## flag with both sides identical would be scaffolding.
+
+## What each mode answers for a flag. `current` is what shipped and is the
+## default; `vanilla` reproduces every listed bug; `qol` corrects every one.
+const MODE_CURRENT: StringName = &"current"
+const MODE_VANILLA: StringName = &"vanilla"
+const MODE_QOL: StringName = &"qol"
+## Not a mode a player picks: what [method mode_of] answers once a flag has been
+## moved away from every preset.
+const MODE_CUSTOM: StringName = &"custom"
+const MODES: Array[StringName] = [MODE_CURRENT, MODE_VANILLA, MODE_QOL]
+
+## Which AI layers a trainer scores with. `normal` is the trainer class's own
+## imported mask, which is the cartridge's; the other two rewrite it rather than
+## inventing numbers, since a level or a stat this project made up would not be
+## this cartridge's game any more.
+const DIFFICULTY_EASY: StringName = &"easy"
+const DIFFICULTY_NORMAL: StringName = &"normal"
+const DIFFICULTY_HARD: StringName = &"hard"
+const DIFFICULTIES: Array[StringName] = [DIFFICULTY_EASY, DIFFICULTY_NORMAL, DIFFICULTY_HARD]
+
+## `easy` keeps `AI_BASIC` alone, which is what the cartridge's own least
+## thoughtful classes carry, and `hard` adds every layer a class does not already
+## have. Neither can produce a mask the scorer does not understand, both being
+## subsets of the imported one's own bits.
+const DIFFICULTY_EASY_WEIGHTS: int = RomLayout.AI_BASIC
+const DIFFICULTY_HARD_WEIGHTS: int = RomLayout.AI_MOVE_WEIGHTS_MASK
+
+## The rules the engine is playing under right now.
+##
+## Statics reach the run through here: [Gen2Experience], [Gen2Damage] and
+## [Gen2BattleAI] take no engine object, and threading a rules argument through
+## every one of them would put the same value in two places to disagree. So there
+## is exactly one installed set at a time, and the two objects that own a run
+## ([Gen2WorldAPI] and [Gen2Battle]) install what they were built with.
+static var _active: Gen2Rules = null
+
+var mode: StringName = MODE_CURRENT
+var difficulty: StringName = DIFFICULTY_NORMAL
+## Only the flags moved away from [member mode], so a mode change carries every
+## flag the player never touched.
+var overrides: Dictionary = {}
+
+
+## The installed rules, which are [constant MODE_CURRENT]'s until something
+## installs otherwise. Never null, so a caller never branches on having a run.
+static func active() -> Gen2Rules:
+	if _active == null:
+		_active = Gen2Rules.new()
+	return _active
+
+
+## Plays under [param rules]. A null one restores the shipped behaviour, which is
+## what a tool, a check or a test with no run of its own wants.
+static func install(rules: Gen2Rules) -> void:
+	_active = rules
+
+
+## Whether the cartridge's behaviour is reproduced for [param flag]. An unknown
+## flag answers false rather than crashing: a mod or a save may name one this
+## build does not have.
+func reproduces(flag: StringName) -> bool:
+	if not FLAGS.has(flag):
+		return false
+	if overrides.has(flag):
+		return bool(overrides[flag])
+	return _mode_value(mode, flag)
+
+
+## Reads the installed rules, for a static that has no run object in hand.
+static func hardware(flag: StringName) -> bool:
+	return active().reproduces(flag)
+
+
+## Moves one flag off its mode. Refuses a flag this build does not name, so a
+## typo in a mod is a refusal rather than a setting that silently does nothing.
+func set_flag(flag: StringName, reproduce_hardware: bool) -> bool:
+	if not FLAGS.has(flag):
+		return false
+	if _mode_value(mode, flag) == reproduce_hardware:
+		overrides.erase(flag)
+	else:
+		overrides[flag] = reproduce_hardware
+	return true
+
+
+## The mode the flags actually describe, which is [constant MODE_CUSTOM] once one
+## of them is not any preset's answer. What a settings row shows.
+func mode_of() -> StringName:
+	for candidate: StringName in MODES:
+		var matches: bool = true
+		for flag: StringName in FLAGS:
+			if reproduces(flag) != _mode_value(candidate, flag):
+				matches = false
+				break
+		if matches:
+			return candidate
+	return MODE_CUSTOM
+
+
+## Switches every flag the player has not moved. The overrides are kept, which is
+## what makes a mode a starting point rather than a reset; [method clear_flags]
+## is the reset.
+func set_mode(new_mode: StringName) -> void:
+	mode = new_mode if MODES.has(new_mode) else MODE_CURRENT
+	for flag: StringName in overrides.keys():
+		if _mode_value(mode, flag) == bool(overrides[flag]):
+			overrides.erase(flag)
+
+
+func clear_flags() -> void:
+	overrides = {}
+
+
+## The AI layers a trainer class scores with, its imported mask under
+## [constant DIFFICULTY_NORMAL]. Masked to the layers the scorer knows either
+## way, so a patched trainer cannot ask for a bit nothing reads.
+func ai_move_weights(imported: int) -> int:
+	match difficulty:
+		DIFFICULTY_EASY:
+			return DIFFICULTY_EASY_WEIGHTS
+		DIFFICULTY_HARD:
+			return DIFFICULTY_HARD_WEIGHTS
+	return imported & RomLayout.AI_MOVE_WEIGHTS_MASK
+
+
+func duplicate_rules() -> Gen2Rules:
+	var out := Gen2Rules.new()
+	out.mode = mode
+	out.difficulty = difficulty
+	out.overrides = overrides.duplicate()
+	return out
+
+
+func matches(other: Gen2Rules) -> bool:
+	if other == null:
+		return false
+	if difficulty != other.difficulty:
+		return false
+	for flag: StringName in FLAGS:
+		if reproduces(flag) != other.reproduces(flag):
+			return false
+	return true
+
+
+## Only what differs from the mode, so a saved run stays readable and a flag
+## added later is not written into a file that never chose it.
+func to_dict() -> Dictionary:
+	var flags: Dictionary = {}
+	for flag: StringName in overrides:
+		flags[String(flag)] = bool(overrides[flag])
+	return {
+		"mode": String(mode),
+		"difficulty": String(difficulty),
+		"flags": flags,
+	}
+
+
+## Clamped rather than refused, the way [method Gen2Options.parse] is: one
+## unreadable value must not cost the player the rest of the block.
+static func parse(raw: Variant) -> Gen2Rules:
+	var out := Gen2Rules.new()
+	if raw is not Dictionary:
+		return out
+	var row: Dictionary = raw
+	var raw_mode := StringName(String(row.get("mode", "")))
+	out.mode = raw_mode if MODES.has(raw_mode) else MODE_CURRENT
+	var raw_difficulty := StringName(String(row.get("difficulty", "")))
+	out.difficulty = raw_difficulty if DIFFICULTIES.has(raw_difficulty) else DIFFICULTY_NORMAL
+	var flags: Variant = row.get("flags", {})
+	if flags is Dictionary:
+		for key: Variant in flags as Dictionary:
+			out.set_flag(StringName(String(key)), bool((flags as Dictionary)[key]))
+	return out
+
+
+## `current` is the table itself; `vanilla` and `qol` are its two ends.
+static func _mode_value(for_mode: StringName, flag: StringName) -> bool:
+	match for_mode:
+		MODE_VANILLA:
+			return true
+		MODE_QOL:
+			return false
+	return bool(FLAGS.get(flag, false))

--- a/game/options/rules.gd.uid
+++ b/game/options/rules.gd.uid
@@ -1,0 +1,1 @@
+uid://c4wqtb7615l4r

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -179,9 +179,11 @@ func reset(rows: Array) -> void:
 		if bool(member.get("egg", false)):
 			speed = 0
 		_icons.append({
-			"icon": data.mon_menu_icon(
+			## The strip is asked for by species rather than by icon number, so a
+			## mod species drawing indices of its own animates with the rest.
+			"strip": data.species_icon_indices(
 				int(member.get("species", 0)), bool(member.get("egg", false))
-			) if data != null else 0,
+			) if data != null else PackedByteArray(),
 			"item": int(member.get("item", 0)) != 0,
 			"speed": speed,
 			"frame": -1,
@@ -243,7 +245,7 @@ func _blend_icons(image: Image, count: int) -> void:
 		## reached yet, which is why FRAME opens at -1 rather than at zero.
 		if int(icon["frame"]) < 0:
 			continue
-		var strip: PackedByteArray = data.overworld_icon_indices(int(icon["icon"]))
+		var strip: PackedByteArray = icon["strip"]
 		if strip.is_empty():
 			continue
 		var at := Vector2i(

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -69,9 +69,22 @@ static func from_atlas(
 ## The same cell before a palette is chosen: { indices, width, height }, or empty
 ## for a slot the atlas does not hold. Split out so a palette fade over a
 ## frontpic swaps colours rather than cropping the atlas again.
+##
+## A [param pic] carrying its own [code]indices[/code] is a mod's picture and has
+## no cell to crop: the atlases hold exactly the cartridge's slots. Answering it
+## here is what lets every screen draw one without knowing which it has.
 static func atlas_cell(
 	indices: PackedByteArray, atlas: Dictionary, pic: Dictionary
 ) -> Dictionary:
+	if pic.has("indices"):
+		var supplied: Variant = pic["indices"]
+		var pic_width: int = int(pic.get("width", 0))
+		var pic_height: int = int(pic.get("height", 0))
+		if not supplied is PackedByteArray or pic_width <= 0 or pic_height <= 0 \
+			or (supplied as PackedByteArray).size() < pic_width * pic_height:
+			return {}
+		return {"indices": supplied, "width": pic_width, "height": pic_height}
+
 	var cell: int = int(atlas.get("cell", 0))
 	var columns: int = int(atlas.get("columns", 0))
 	var atlas_width: int = int(atlas.get("width", 0))

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -114,6 +114,14 @@ func _ready() -> void:
 	set_process(false)
 
 
+## One hardware frame of the reveal, for a caller spending frames by hand rather
+## than by real time: the overworld's own pump while an overlay is up, a check, a
+## screenshot driver, a replay. `PrintLetterDelay` is a frame count on the
+## cartridge, so this is the same clock [method _process] converts real time into.
+func advance_frame() -> void:
+	_process(FRAME_SECONDS)
+
+
 func _process(delta: float) -> void:
 	if _scroll_page >= 0:
 		_advance_scroll(delta)

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -57,10 +57,10 @@ static func to_battle_mon(data: GameData, saved: Gen2SaveMon) -> Gen2BattleMon:
 ## rest in order; the write fails rather than dropping an egg or shifting a
 ## slot when the two no longer line up.
 ##
-## The fields restored off [param source_save] are the ones the battle model does
-## not carry at all. Happiness is not among them any more: Return and Frustration
-## read it, so [Gen2BattleMon] holds it and it round-trips rather than being put
-## back from before the fight.
+## The candidate starts as a complete clone of [param source_save], so fields
+## the battle model does not carry cannot disappear as the save schema grows.
+## Happiness is not restored from that clone: Return and Frustration read it,
+## so [Gen2BattleMon] holds it and it round-trips with the fought party.
 static func from_battle_party(
 	game_id: StringName, rom_sha1: String, slot: int, party: Gen2Party, player_name: String = "",
 	source_save: Gen2SaveData = null
@@ -76,26 +76,17 @@ static func from_battle_party(
 			return null
 		if source_save.party.size() > Gen2Party.MAX_SIZE:
 			return null
-	var out := Gen2SaveData.new()
+	var out: Gen2SaveData = (
+		Gen2SaveData.from_dict(source_save.to_dict())
+		if source_save != null else Gen2SaveData.new()
+	)
+	if out == null:
+		return null
 	out.game_id = game_id
 	out.rom_sha1 = rom_sha1
 	out.slot = slot
 	out.player_name = source_save.player_name if source_save != null else player_name
-	if source_save != null:
-		out.boxes.clear()
-		for raw_box: Variant in source_save.boxes:
-			var box: Gen2SaveBox = raw_box if raw_box is Gen2SaveBox else null
-			if box == null:
-				out.boxes.append(Gen2SaveBox.new())
-				continue
-			var copied_box: Gen2SaveBox = Gen2SaveBox.from_dict(box.to_dict())
-			copied_box.shape_valid = box.shape_valid
-			out.boxes.append(copied_box)
-		while out.boxes.size() < Gen2SaveData.BOX_COUNT:
-			out.boxes.append(Gen2SaveBox.new())
-		if source_save.world != null:
-			out.world = Gen2WorldSnapshot.from_dict(source_save.world.to_dict())
-		out.mods = source_save.mods.duplicate(true)
+	out.party.clear()
 	var fought: int = 0
 	var slot_count: int = source_save.party.size() if egg_count > 0 else party.mons.size()
 	for index: int in slot_count:

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -42,8 +42,7 @@ var label: String = ""
 var party: Array = []
 var boxes: Array = []
 var world: Gen2WorldSnapshot = null
-## Per-slot, per-mod JSON objects. Installation-wide options stay in their own
-## user file; this namespace travels with the save.
+## Per-slot, per-mod JSON objects. This namespace travels with the save.
 var mods: Dictionary = {}
 ## What names the run beside the state it produced: the seed the world's
 ## generators are built from and the mods that were loaded when the slot was
@@ -51,6 +50,11 @@ var mods: Dictionary = {}
 ## recorded", which is what every slot written before this existed says.
 var run_seed: int = 0
 var run_mods: Array = []
+## The registered mod settings this run was created with, keyed by mod id and
+## option key. The installation-wide options file is only the template for a
+## new run; once a slot exists its effective settings live here so reopening it
+## cannot silently change the state that produced the save.
+var run_options: Dictionary = {}
 var boxes_shape_valid: bool = true
 
 
@@ -81,7 +85,11 @@ func to_dict() -> Dictionary:
 		"boxes": saved_boxes,
 		"world": world.to_dict() if world != null else {},
 		"mods": mods.duplicate(true),
-		"run": {"seed": run_seed, "mods": run_mods.duplicate(true)},
+		"run": {
+			"seed": run_seed,
+			"mods": run_mods.duplicate(true),
+			"mod_options": run_options.duplicate(true),
+		},
 	}
 
 
@@ -144,6 +152,13 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 						"id": String((entry as Dictionary).get("id", "")),
 						"version": String((entry as Dictionary).get("version", "")),
 					})
+		var raw_run_options: Variant = (raw_run as Dictionary).get("mod_options", {})
+		if raw_run_options is Dictionary:
+			for raw_id: Variant in raw_run_options:
+				var id: String = String(raw_id)
+				var options: Variant = (raw_run_options as Dictionary)[raw_id]
+				if _valid_mod_id(id) and options is Dictionary:
+					out.run_options[StringName(id)] = (options as Dictionary).duplicate(true)
 	return out
 
 
@@ -160,8 +175,9 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 ## Version 5 had no per-mod namespace.
 ##
 ## The `run` block joined version 6 after it shipped and is not a version of its
-## own: it defaults to no seed and no mod list, which is the truth about a slot
-## written before it existed rather than a value worth inventing.
+## own: it defaults to no seed, mod list or mod-option snapshot, which is the
+## truth about a slot written before it existed rather than a value worth
+## inventing.
 static func migrate_dict(raw: Variant) -> Dictionary:
 	if not raw is Dictionary:
 		return {"ok": false, "message": "save data is not an object"}
@@ -254,6 +270,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	mods = copied.mods.duplicate(true)
 	run_seed = copied.run_seed
 	run_mods = copied.run_mods.duplicate(true)
+	run_options = copied.run_options.duplicate(true)
 	boxes_shape_valid = copied.boxes_shape_valid
 	return true
 

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -55,6 +55,12 @@ var run_mods: Array = []
 ## new run; once a slot exists its effective settings live here so reopening it
 ## cannot silently change the state that produced the save.
 var run_options: Dictionary = {}
+## The divergence flags and difficulty this run is played under. Its own field
+## rather than a mod's, because it changes what the engine does: a run recorded
+## under one set of rules did not produce the state a different set would.
+## Null reads as "not recorded", which every slot written before it says, and
+## adopts the installation's once.
+var run_rules: Gen2Rules = null
 var boxes_shape_valid: bool = true
 
 
@@ -89,6 +95,7 @@ func to_dict() -> Dictionary:
 			"seed": run_seed,
 			"mods": run_mods.duplicate(true),
 			"mod_options": run_options.duplicate(true),
+			"rules": run_rules.to_dict() if run_rules != null else {},
 		},
 	}
 
@@ -152,6 +159,9 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 						"id": String((entry as Dictionary).get("id", "")),
 						"version": String((entry as Dictionary).get("version", "")),
 					})
+		var raw_rules: Variant = (raw_run as Dictionary).get("rules", {})
+		if raw_rules is Dictionary and not (raw_rules as Dictionary).is_empty():
+			out.run_rules = Gen2Rules.parse(raw_rules)
 		var raw_run_options: Variant = (raw_run as Dictionary).get("mod_options", {})
 		if raw_run_options is Dictionary:
 			for raw_id: Variant in raw_run_options:
@@ -175,8 +185,8 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 ## Version 5 had no per-mod namespace.
 ##
 ## The `run` block joined version 6 after it shipped and is not a version of its
-## own: it defaults to no seed, mod list or mod-option snapshot, which is the
-## truth about a slot written before it existed rather than a value worth
+## own: it defaults to no seed, mod list, mod-option snapshot or rules, which is
+## the truth about a slot written before it existed rather than a value worth
 ## inventing.
 static func migrate_dict(raw: Variant) -> Dictionary:
 	if not raw is Dictionary:
@@ -271,6 +281,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	run_seed = copied.run_seed
 	run_mods = copied.run_mods.duplicate(true)
 	run_options = copied.run_options.duplicate(true)
+	run_rules = copied.run_rules.duplicate_rules() if copied.run_rules != null else null
 	boxes_shape_valid = copied.boxes_shape_valid
 	return true
 

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -5,6 +5,23 @@ extends RefCounted
 ## cartridge-derived data and has a different lifecycle.
 
 const ROOT: String = "user://save_slots"
+
+## Where slots are actually read and written, which is [constant ROOT] unless a
+## tool moved it. The seam exists because a tool that drives a real battle to its
+## end writes the slot it was played from, and a check must never be able to
+## overwrite the owner's own save; see [method use_root] and
+## `tools/replay_world.gd`.
+static var _root: String = ROOT
+
+
+static func root() -> String:
+	return _root
+
+
+## Points every slot path at [param path]. An empty one restores
+## [constant ROOT], which is what a tool does when it is finished.
+static func use_root(path: String) -> void:
+	_root = ROOT if path.is_empty() else path
 ## Slots are created on demand rather than preallocated, so this is only a
 ## ceiling: it keeps a slot number a bounded, validatable thing and stops a
 ## runaway caller filling the directory. Slot files are still `slot_N.json`,
@@ -26,7 +43,7 @@ const DEVELOPMENT_PLAYER_ID: int = 0x1A2B
 
 
 static func directory_for(game_id: StringName, rom_sha1: String) -> String:
-	return "%s/%s_%s" % [ROOT, String(game_id), rom_sha1.substr(0, 8)]
+	return "%s/%s_%s" % [root(), String(game_id), rom_sha1.substr(0, 8)]
 
 
 static func path_for(game_id: StringName, rom_sha1: String, slot: int) -> String:

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -190,6 +190,9 @@ static func export_bytes(
 	var validation: Dictionary = Gen2SaveValidator.validate(save, data)
 	if not validation["ok"]:
 		return _failure("save cannot be exported: %s" % validation["message"])
+	var mod_content: Dictionary = _mod_content_refusal(save)
+	if not mod_content["ok"]:
+		return mod_content
 
 	var selected: String = ""
 	if _primary_is_valid(raw, layout):
@@ -211,6 +214,34 @@ static func export_bytes(
 		"raw": output,
 		"copy": selected,
 	}
+
+
+## Refuses a save holding content a cartridge byte cannot name.
+##
+## Every species, item and move on the hardware is one byte, and
+## [constant Gen2ContentOverlay.FIRST_MOD_NUMBER] sits past that on purpose. So a
+## mod's own content has no representation here: truncating it would write a
+## different Pokémon into a real cartridge, which is worse than refusing. The
+## project's own JSON save carries it either way.
+static func _mod_content_refusal(save: Gen2SaveData) -> Dictionary:
+	var mons: Array = save.party.duplicate()
+	for raw_box: Variant in save.boxes:
+		if raw_box is Gen2SaveBox:
+			mons.append_array((raw_box as Gen2SaveBox).slots)
+	for raw_mon: Variant in mons:
+		if not raw_mon is Gen2SaveMon:
+			continue
+		var mon: Gen2SaveMon = raw_mon
+		var numbers: Array[int] = [mon.species, mon.item]
+		for move: Variant in mon.moves:
+			numbers.append(int(move))
+		for number: int in numbers:
+			if number >= Gen2ContentOverlay.FIRST_MOD_NUMBER:
+				return _failure(
+					"%s carries mod content (%d) no cartridge byte can name"
+					% [mon.nickname if not mon.nickname.is_empty() else "a Pokemon", number]
+				)
+	return {"ok": true, "message": ""}
 
 
 static func _layout_for(game_id: StringName) -> Dictionary:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -130,6 +130,10 @@ const MAP_NAME_SIGN_SILENT_LANDMARKS: Array[int] = [
 ]
 
 var data: GameData = null
+## What this run diverges from the cartridge on, and its difficulty. Read-only to
+## a mod: a rule that changed mid-run would make the save it produced
+## unreproducible, which is the whole reason it belongs to the run.
+var rules: Gen2Rules = null
 var state: Gen2WorldState = null
 var inventory: Gen2WorldInventory = null
 var current_map: Gen2WorldMap = null
@@ -306,6 +310,7 @@ static func open(
 	number: int,
 	start_cell: Vector2i,
 	world_state: Gen2WorldState = null,
+	world_rules: Gen2Rules = null,
 ) -> Gen2WorldAPI:
 	if game_data == null:
 		return null
@@ -315,11 +320,13 @@ static func open(
 	var tileset: Gen2WorldTileset = game_data.world_tileset(map.tileset)
 	if tileset == null:
 		return null
-	return Gen2WorldAPI.new(game_data, map, tileset, start_cell, world_state)
+	return Gen2WorldAPI.new(game_data, map, tileset, start_cell, world_state, world_rules)
 
 
 ## Opens a validated map/player snapshot without silently clamping its cell.
-static func open_snapshot(game_data: GameData, world_snapshot: Gen2WorldSnapshot) -> Gen2WorldAPI:
+static func open_snapshot(
+	game_data: GameData, world_snapshot: Gen2WorldSnapshot, world_rules: Gen2Rules = null
+) -> Gen2WorldAPI:
 	if game_data == null or world_snapshot == null:
 		return null
 	var map: Gen2WorldMap = game_data.world_map(world_snapshot.map_id.x, world_snapshot.map_id.y)
@@ -343,7 +350,8 @@ static func open_snapshot(game_data: GameData, world_snapshot: Gen2WorldSnapshot
 	if tileset == null:
 		return null
 	var out := Gen2WorldAPI.new(
-		game_data, map, tileset, world_snapshot.player_cell, world_snapshot.world_state
+		game_data, map, tileset, world_snapshot.player_cell, world_snapshot.world_state,
+		world_rules
 	)
 	out.player_facing = world_snapshot.player_facing
 	out.movement_mode = world_snapshot.movement_mode
@@ -365,8 +373,15 @@ func _init(
 	tileset: Gen2WorldTileset,
 	start_cell: Vector2i = Vector2i.ZERO,
 	world_state: Gen2WorldState = null,
+	world_rules: Gen2Rules = null,
 ) -> void:
 	data = game_data
+	# Opening a world is the run starting, so its rules become the installed ones:
+	# the statics that read them ([Gen2Experience], [Gen2Damage], [Gen2BattleAI])
+	# take no world object, and one installed set is what keeps them from
+	# disagreeing with this one. A null set leaves the shipped behaviour alone.
+	rules = world_rules if world_rules != null else Gen2Rules.active()
+	Gen2Rules.install(rules)
 	state = world_state if world_state != null else Gen2WorldState.new()
 	state.changed.connect(_on_world_state_changed)
 	inventory = Gen2WorldInventory.new(data, state)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -33,9 +33,8 @@ const STEP_FRAMES_WALK: int = 8
 ## A ledge hop is two chained STEP_WALK-duration cells back to back
 ## (engine/overworld/map_objects.asm's StepFunction_PlayerJump: .initjump/
 ## .stepjump then .initland/.stepland, each timed by the same InitStep call
-## the ordinary walk uses). The source also overlays a visual jump arc via
-## OBJECT_JUMP_HEIGHT/UpdateJumpPosition, which this project does not render;
-## no vertical bob exists anywhere else in this renderer either.
+## the ordinary walk uses). OBJECT_JUMP_HEIGHT/UpdateJumpPosition supplies the
+## vertical arc exposed by player_jump_offset() and drawn by the world renderer.
 const STEP_FRAMES_HOP: int = STEP_FRAMES_WALK * 2
 ## StepVectors' slow row: 1 pixel per frame for 16 frames. _RandomWalkContinue
 ## calls InitStep with a direction of 0 to 3, which indexes that first row, so

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -18,6 +18,7 @@ static func prepare(
 	player_party: Gen2Party,
 	random: RandomNumberGenerator = null,
 	player_badges: int = 0,
+	battle_rules: Gen2Rules = null,
 ) -> Dictionary:
 	if data == null or player_party == null or player_party.is_wiped():
 		return _failure(&"missing_player_party")
@@ -69,7 +70,8 @@ static func prepare(
 		return _failure(&"missing_enemy_party")
 	var generator := random if random != null else RandomNumberGenerator.new()
 	var battle: Gen2Battle = Gen2Battle.create_parties(
-		data, player_party, enemy_party, generator, kind == &"trainer", player_badges
+		data, player_party, enemy_party, generator, kind == &"trainer", player_badges,
+		battle_rules
 	)
 	if battle == null:
 		return _failure(&"battle_setup_failed")

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -138,6 +138,17 @@ var _start_menu_cursor: int = 0
 var _reopen_start_menu: bool = false
 var _trainer_approach: Dictionary = {}
 var _active_battle_save: Gen2SaveData = null
+## How many battles this run has started, which is what a replay compares beside
+## the party: a route that fought and one that walked past the grass reach
+## different states for the same reason.
+var _battles_fought: int = 0
+## What the last one resolved to (`Gen2WorldBattleAdapter.OUTCOME_*`), which is
+## the fight's own result rather than the party's: a lost battle heals the party
+## on the way out, so the outcome is what says the turn resolved at all.
+var _last_battle_outcome: StringName = &""
+## The audio driver's rendered-frame count as of the last frame, for the one
+## script wait that reads it. See [method Gen2AudioPlayer.timeline_updates].
+var _audio_rendered_seen: int = 0
 var _active_battle_persist: bool = false
 var _encounter_random := RandomNumberGenerator.new()
 ## NPC movement rolls from its own generator, so a seeded route keeps the same
@@ -529,7 +540,14 @@ func advance_frame() -> void:
 		_refresh_labels()
 	# The condition is the audio device's, not a counter's, but the request it
 	# completes is a script's, so it lands on a frame like every other resume.
-	if _audio_waiting and _audio_player != null and not _audio_player.effect_playing():
+	## The same rule the battle's `ANIM_WAIT_SFX` follows: a driver nobody is
+	## servicing leaves `effect_playing()` true for the rest of the run, so the
+	## rendered-frame count is what decides whether this is a wait at all.
+	var audio_rendered: int = _audio_player.timeline_updates() if _audio_player != null else 0
+	var audio_moved: bool = audio_rendered != _audio_rendered_seen
+	_audio_rendered_seen = audio_rendered
+	if _audio_waiting and _audio_player != null \
+		and (not _audio_player.effect_playing() or not audio_moved):
 		_audio_waiting = false
 		var audio_result: Dictionary = Gen2WorldHost.complete_runtime_request(
 			_world, {"ok": true, "sound_finished": true}
@@ -540,7 +558,36 @@ func advance_frame() -> void:
 	# spends this frame too rather than counting one of its own.
 	if _service_host != null:
 		_service_host.advance_frame()
+	## A battle is `BattleIntro` onward running inside the map's own loop, so its
+	## bars, its animations and its faints are spent from this pump rather than
+	## from real time. That is what makes a fight inside a replay reach the same
+	## place on the same frame.
+	if _battle_host != null:
+		_battle_host.advance_hardware_frame()
 	_spending_frame = false
+
+
+## Whether a battle owns the screen right now. Public beside
+## [method battles_fought] so a tool driving a run knows which of the two funnels
+## its presses are going through, and so a replay can compare the count.
+func battle_active() -> bool:
+	return _battle_host != null
+
+
+func battles_fought() -> int:
+	return _battles_fought
+
+
+func last_battle_outcome() -> StringName:
+	return _last_battle_outcome
+
+
+## The save this run is playing, which is what a fight writes its party back into.
+## The injected one for a test or a tool, the runtime's selected slot otherwise.
+func active_save() -> Gen2SaveData:
+	if _active_battle_save != null:
+		return _active_battle_save
+	return _injected_save if _injected_save != null else _selected_runtime_save()
 
 
 ## Starts recording every button the world consumes, discarding any earlier log.
@@ -676,7 +723,7 @@ func _objects_may_move() -> bool:
 ## device produced it. What is left over is a development shortcut or something
 ## only a renderer could want.
 func _unhandled_input(event: InputEvent) -> void:
-	if _world == null or _battle_host != null:
+	if _world == null:
 		return
 	var button: int = Gen2Button.pressed_in(event)
 	if button != Gen2Button.NONE:
@@ -736,6 +783,13 @@ func press_button(button: int) -> bool:
 ## refusing the ones it has no use for, which is what keeps a stray press from
 ## reaching the map behind it.
 func _handle_button(button: int) -> bool:
+	## First, because a battle hides the map entirely and owns every button while
+	## it does. The fight takes it through this funnel rather than reading events
+	## of its own, so a press inside a battle is recorded once, by the world, and
+	## a replayed log reaches the fight (`tools/replay_world.gd`).
+	if _battle_host != null:
+		_battle_host.press_button(button)
+		return true
 	if not _map_fade.is_empty() or not _trainer_approach.is_empty() \
 		or _world.phone_ring_active():
 		return true
@@ -1951,14 +2005,40 @@ func _start_battle_request(request: Dictionary) -> void:
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	_active_battle_save = save
 	_active_battle_persist = save != null and _injected_save == null
+	_battles_fought += 1
 	var host: Gen2BattleScreen = BATTLE_SCENE.instantiate() as Gen2BattleScreen
 	host.set_data(_data)
 	host.set_rules(_world.rules if _world != null else null)
+	## Drawn from the world's own generator, so the fight's own decisions are part
+	## of the run's seeded chain and a replay reproduces them without recording
+	## anything about the battle. Its frames and its buttons both come through this
+	## screen from here on.
+	host.set_random_seed(_encounter_random.randi())
+	host.set_external_input(true)
 	host.set_time_of_day(time_of_day)
 	# The clock's row is what the battle's own heals read; the drawn row is what
 	# a renderer staging the fight on this map has to match, so the context
 	# carries that one.
 	host.set_world_context(Gen2BattleWorldContext.capture(_world, _render_time_of_day()))
+	var badges: int = _world.state.badge_mask(Gen2WorldState.is_crystal_profile(_data)) \
+		if _world != null and _world.state != null else 0
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 10
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(host)
+	host.battle_finished.connect(_on_battle_finished)
+	host.enemy_seen.connect(_on_enemy_seen)
+	if not tutorial:
+		host.capture_requested.connect(_on_capture_requested)
+		host.item_used.connect(_on_battle_item_used)
+	_battle_host = host
+	## Started after the connections and here rather than left to the host's own
+	## deferred call: `startbattle` is a script command, so the fight belongs to
+	## the frame the encounter fired on, and a run driven frame by frame (a check,
+	## a replay) never reaches a deferred call at all.
+	host.start_world_battle(request.duplicate(true), save, badges)
+	## After the fight exists, because starting one clears whatever capture action
+	## was staged: the bag belongs to this battle rather than to the last one.
 	if _world != null and not tutorial:
 		## `BattleMenu_Pack`'s contest branch loads PARK_BALL and nothing else,
 		## and the count is `wParkBallsRemaining` rather than the bag.
@@ -1974,22 +2054,9 @@ func _start_battle_request(request: Dictionary) -> void:
 			host.set_battle_pack(
 				Gen2WorldPack.battle_items(_data, _world.state), _world.state.items()
 			)
-	host.set_meta("world_battle_request", {
-		"request": request.duplicate(true),
-		"save": save,
-		"player_badges": _world.state.badge_mask(Gen2WorldState.is_crystal_profile(_data)) \
-			if _world != null and _world.state != null else 0,
-	})
-	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	host.z_index = 10
-	host.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child(host)
-	host.battle_finished.connect(_on_battle_finished)
-	host.enemy_seen.connect(_on_enemy_seen)
-	if not tutorial:
-		host.capture_requested.connect(_on_capture_requested)
-		host.item_used.connect(_on_battle_item_used)
-	_battle_host = host
+	## Its frames come from this screen's own pump from here on, so it must not
+	## also spend real-time ones of its own.
+	host.set_process(false)
 	_script_prompt = "Battle in progress"
 	_refresh_labels()
 
@@ -2052,6 +2119,7 @@ func _on_battle_finished(result: Dictionary) -> void:
 			_encounters.battle_finished(fought, result.duplicate(true))
 	if _world == null:
 		return
+	_last_battle_outcome = StringName(result.get("outcome", &""))
 	var pay_day_money: int = int(result.get("pay_day_money", 0))
 	if pay_day_money > 0 and StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON:
 		_world.state.apply_changes({}, {}, {"money": {

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1953,6 +1953,7 @@ func _start_battle_request(request: Dictionary) -> void:
 	_active_battle_persist = save != null and _injected_save == null
 	var host: Gen2BattleScreen = BATTLE_SCENE.instantiate() as Gen2BattleScreen
 	host.set_data(_data)
+	host.set_rules(_world.rules if _world != null else null)
 	host.set_time_of_day(time_of_day)
 	# The clock's row is what the battle's own heals read; the drawn row is what
 	# a renderer staging the fight on this map has to match, so the context

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3259,8 +3259,8 @@ func _show_script_results(results: Array) -> void:
 	var clock_changed: bool = false
 	var recovered: bool = false
 	var recovery_prompt: String = ""
-	for result: Dictionary in results:
-		Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, result)
+	for source_result: Dictionary in results:
+		var result: Dictionary = Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, source_result)
 		if result.has("clock"):
 			clock_changed = true
 		var status: StringName = StringName(result.get("status", &""))

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -405,12 +405,13 @@ func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() ->
 	## Walking onto it starts the battle with those exact DVs.
 	_world_screen._world.player_cell = cell
 	_world_screen._after_player_move({"kind": &"step"})
-	var request: Dictionary = _world_screen._battle_host.get_meta(
-		"world_battle_request"
-	)["request"]
-	assert_eq(int(request["values"]["dvs"]), shiny)
-	assert_eq(int(request["values"]["level"]), 5)
-	assert_eq(StringName(request["visible_encounter"]), &"a")
+	## The adapter's own prepared request, which is the `values` block itself.
+	var request: Dictionary = _world_screen._battle_host.world_battle_request()
+	assert_eq(int(request["dvs"]), shiny)
+	assert_eq(int(request["level"]), 5)
+	## Which entry it was is the world's own bookkeeping, since that is what gets
+	## reported back to the provider when the fight ends.
+	assert_eq(_world_screen._battle_encounter_id, &"a")
 
 	_world_screen._on_battle_finished({"outcome": Gen2WorldBattleAdapter.OUTCOME_RAN})
 	var reported: Array = provider.get("results")

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -30,12 +30,13 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory(&"gold"))
 
 
-func _open_world(with_save: bool = false) -> void:
+func _open_world(with_save: bool = false, seed_value: int = 0) -> void:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
 	_world_screen.map_number = Fixture.MAP_NUMBER
 	_world_screen.start_cell = Vector2i(4, 5)
+	_world_screen.encounter_seed = seed_value
 	_world_screen.set_data(_data)
 	if with_save:
 		var player: Gen2BattleMon = Gen2BattleMon.create(
@@ -281,6 +282,62 @@ func test_defeat_displays_imported_loss_text_and_uses_save_recovery() -> void:
 	assert_eq(world["player_cell"], Vector2i(5, 5))
 	assert_eq(world["visible_objects"], 1)
 	assert_false(world["just_battled"])
+
+
+## The seam `tools/replay_world.gd` closes: a fight inside a walk belongs to the
+## world's own clock and the world's own funnel, so it is spent and steered by the
+## same two calls the map is, and its own decisions come out of the run's seed.
+func test_a_battle_is_spent_and_steered_by_the_world_that_opened_it() -> void:
+	await _open_world(true)
+	await _trigger_trainer()
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_true(_world_screen.battle_active())
+	assert_eq(_world_screen.battles_fought(), 1)
+	assert_false(host.is_processing(), "the fight does not spend frames of its own")
+
+	## The intro slides on hardware frames, and the only ones it gets are the
+	## world's: nothing here waits on real time.
+	var slid: bool = false
+	for _frame: int in 200:
+		_world_screen.advance_frame()
+		if host.battle_snapshot()["message"] != "":
+			slid = true
+			break
+	assert_true(slid, "the world's own pump reached the battle's first message")
+
+	## And one press, through the world, reaches the fight rather than the map:
+	## the funnel is what makes a recorded log complete.
+	_world_screen.record_input()
+	assert_true(_world_screen.press_button(Gen2Button.A))
+	var log: Array = _world_screen.input_recording()
+	assert_eq(log.size(), 1, "the world recorded the battle's own press")
+	assert_eq(int(log[0]["button"]), Gen2Button.A)
+
+
+## Two runs of the same fight from the same seed decide the same things, which is
+## what makes a battle inside a replay reproducible without recording any of it.
+func test_two_battles_from_one_seed_choose_the_same_enemy_moves() -> void:
+	var choices: Array = []
+	for _run: int in 2:
+		await _open_world(true, 0x5EED)
+		await _trigger_trainer()
+		var host: Gen2BattleScreen = _battle_host()
+		assert_not_null(host)
+		var seen: Array = []
+		for _frame: int in 900:
+			_world_screen.advance_frame()
+			if not _world_screen.battle_active():
+				break
+			var message: String = String(host.battle_snapshot()["message"])
+			if message.begins_with("Enemy ") and (seen.is_empty() or seen[-1] != message):
+				seen.append(message)
+			_world_screen.press_button(Gen2Button.A)
+		choices.append(seen)
+		_world_screen.queue_free()
+		await get_tree().process_frame
+	assert_false((choices[0] as Array).is_empty(), "the enemy took at least one turn")
+	assert_eq(choices[0], choices[1])
 
 
 func test_effect_sprite_preview_reaches_the_production_world_renderer() -> void:

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -1218,3 +1218,65 @@ func _score_spread(
 		_rng.seed = seed_value
 		seen[int(_scores(attacker, defender, flags, attacker_turns, defender_turns)[slot])] = true
 	return seen
+
+
+## `AI_Cautious`'s `ret nc` abandons the remaining slots on a missed roll, so a
+## Pokemon carrying several residual moves has the ones after the miss left alone.
+## pret's fix moves on to the next slot instead, which is the default here.
+##
+## Read off the scores rather than the choice: the layer is a 90% roll per slot,
+## so what differs between the two is which slots were reached, and the argmin
+## would hide that.
+func test_the_cautious_bug_abandons_the_slots_after_a_missed_roll() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [
+		Fixture.LEECH_SEED, Fixture.THUNDER_WAVE, Fixture.POISON_POWDER, Fixture.SPIKES,
+	])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var rules := Gen2Rules.new()
+	var discouraged: Callable = func(scores: Array) -> int:
+		var count: int = 0
+		for score: int in scores:
+			if score > Gen2BattleAI.DEFAULT_SCORE:
+				count += 1
+		return count
+
+	# Every one of the four is residual, so the fix discourages all four whenever
+	# no roll misses and never leaves a gap; with the bug a miss stops the walk.
+	var abandoned: bool = false
+	for seed: int in 60:
+		Gen2Rules.install(null)
+		_rng.seed = seed
+		var fixed: Array = Gen2BattleAI.score_slots(
+			pikachu, geodude, _data, RomLayout.AI_CAUTIOUS, _rng, 1
+		)
+		rules.set_flag(&"cautious_ai_abandons_remaining_moves", true)
+		Gen2Rules.install(rules)
+		_rng.seed = seed
+		var hardware: Array = Gen2BattleAI.score_slots(
+			pikachu, geodude, _data, RomLayout.AI_CAUTIOUS, _rng, 1
+		)
+		assert_true(
+			int(discouraged.call(hardware)) <= int(discouraged.call(fixed)),
+			"the bug can only ever discourage fewer moves, never more"
+		)
+		if int(discouraged.call(hardware)) < int(discouraged.call(fixed)):
+			abandoned = true
+	Gen2Rules.install(null)
+	assert_true(abandoned, "a missed roll has to be reachable in sixty seeds")
+
+
+## The first turn is exempt either way: `AI_Cautious` returns before the loop.
+func test_cautious_leaves_the_first_turn_alone_under_both_rules() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.LEECH_SEED, Fixture.TACKLE])
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var rules := Gen2Rules.new()
+	rules.set_flag(&"cautious_ai_abandons_remaining_moves", true)
+	for hardware: bool in [false, true]:
+		Gen2Rules.install(rules if hardware else null)
+		_rng.seed = 7
+		assert_eq(
+			Gen2BattleAI.score_slots(pikachu, geodude, _data, RomLayout.AI_CAUTIOUS, _rng, 0),
+			[Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE,
+				Gen2BattleAI.UNUSABLE_SCORE, Gen2BattleAI.UNUSABLE_SCORE]
+		)
+	Gen2Rules.install(null)

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1308,6 +1308,27 @@ func test_experience_and_stat_experience_both_divide_among_participants() -> voi
 		assert_eq(stat_gain["gains"]["speed"], 10, "20 / 2")
 
 
+## The rules a battle was built with are the ones it keeps and the ones the
+## formula's statics read, so a test or a tool cannot resolve half a fight under
+## one set and half under another.
+func test_a_battle_installs_the_rules_it_was_created_with() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_flag(&"metal_powder_overflow", false)
+	var battle: Gen2Battle = Gen2Battle.create(
+		_data, _mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE]), _rng, rules
+	)
+	assert_same(battle.rules, rules)
+	assert_false(Gen2Rules.hardware(&"metal_powder_overflow"))
+
+	Gen2Rules.install(null)
+	var plain: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	assert_not_null(plain.rules, "a battle with no rules of its own plays the installed set")
+	assert_true(Gen2Rules.hardware(&"metal_powder_overflow"))
+
+
 func test_participants_narrow_to_whoever_is_active_once_an_enemy_faints() -> void:
 	# Three enemies, one at a time. The lead player Pokémon is credited for the
 	# first kill by default; switching in the second one adds it without

--- a/tests/unit/test_content_overlay.gd
+++ b/tests/unit/test_content_overlay.gd
@@ -8,6 +8,7 @@ extends GutTest
 const MOD: StringName = &"testmod"
 const NEW_SPECIES: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
 const NEW_MOVE: int = Gen2ContentOverlay.FIRST_MOD_NUMBER + 1
+const NEW_TYPE: int = Gen2ContentOverlay.FIRST_MOD_NUMBER + 2
 
 var _directory: String = ""
 
@@ -376,3 +377,203 @@ func test_validating_a_placement_installs_nothing() -> void:
 		host.validate_placement(_data(), {id: {"species": 25}}), first,
 		"and one placement always answers the same way"
 	)
+
+
+## A type is the one kind numbered from zero, so the cartridge's own NORMAL is
+## patchable at 0 and a mod's own type sits past FIRST_MOD_NUMBER like the rest.
+func test_a_type_is_patched_at_zero_and_defined_past_the_cartridge() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_content(
+		Gen2ContentOverlay.KIND_TYPE, MOD, 0, {"name": "PLAIN"}
+	).get("ok", false)))
+	assert_true(bool(host.register_content(
+		Gen2ContentOverlay.KIND_TYPE, MOD, NEW_TYPE, {"name": "SOUND", "physical": true}
+	).get("ok", false)))
+
+	var data: GameData = _data()
+	assert_eq(data.type_name(0), "PLAIN")
+	assert_eq(data.type_name(NEW_TYPE), "SOUND")
+	assert_eq(data.mod_type_numbers(), [NEW_TYPE] as Array[int])
+	# The stat pair a mod type uses is its own row's, since Generation II splits
+	# by type number and a number past the chart compares against nothing.
+	assert_true(data.type_is_physical(NEW_TYPE))
+	assert_false(data.type_is_physical(RomLayout.SPECIAL_TYPES_START))
+	assert_true(Gen2Damage.is_physical(NEW_TYPE), "and the damage formula agrees")
+
+
+func test_a_defined_type_defaults_to_the_special_side() -> void:
+	assert_true(bool(Gen2ModHost.instance().register_content(
+		Gen2ContentOverlay.KIND_TYPE, MOD, NEW_TYPE, {"name": "SOUND"}
+	).get("ok", false)))
+	assert_false(_data().type_is_physical(NEW_TYPE))
+	assert_false(Gen2Damage.is_physical(NEW_TYPE))
+
+
+## A matchup is an exception row rather than numbered content: an absent pair is
+## already neutral, so there is nothing to define and both halves of the key stay
+## whole so a mod type cannot alias a cartridge pair.
+func test_a_type_matchup_is_patched_by_its_pair() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_type_matchup(
+		MOD, NEW_TYPE, RomLayout.TYPE_NORMAL,
+		{"multiplier": RomLayout.MATCHUP_SUPER_EFFECTIVE}
+	).get("ok", false)))
+	assert_true(bool(host.patch_type_matchup(
+		MOD, RomLayout.TYPE_NORMAL, NEW_TYPE, {"multiplier": RomLayout.MATCHUP_NO_EFFECT}
+	).get("ok", false)))
+
+	var data: GameData = _data()
+	assert_eq(
+		data.type_matchup(NEW_TYPE, RomLayout.TYPE_NORMAL),
+		RomLayout.MATCHUP_SUPER_EFFECTIVE
+	)
+	assert_eq(
+		data.type_matchup(RomLayout.TYPE_NORMAL, NEW_TYPE), RomLayout.MATCHUP_NO_EFFECT,
+		"the pair is ordered: attacking against defending is not its own reverse"
+	)
+	assert_eq(
+		data.type_matchup(RomLayout.TYPE_NORMAL, RomLayout.TYPE_NORMAL),
+		RomLayout.MATCHUP_EFFECTIVE,
+		"and a pair nobody named is still neutral"
+	)
+	assert_eq(
+		StringName(host.patch_type_matchup(MOD, -1, 0, {"multiplier": 10})["reason"]),
+		&"invalid_type_matchup"
+	)
+
+
+func test_a_patched_matchup_carries_its_own_foresight_rule() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.patch_type_matchup(
+		MOD, RomLayout.TYPE_NORMAL, NEW_TYPE, {
+			"multiplier": RomLayout.MATCHUP_NO_EFFECT, "negated_by_foresight": true,
+		}
+	).get("ok", false)))
+	var data: GameData = _data()
+	assert_eq(data.type_matchup(RomLayout.TYPE_NORMAL, NEW_TYPE), RomLayout.MATCHUP_NO_EFFECT)
+	assert_eq(
+		data.type_matchup(RomLayout.TYPE_NORMAL, NEW_TYPE, true), RomLayout.MATCHUP_EFFECTIVE,
+		"identified, the immunity is cancelled the way the Ghost ones are"
+	)
+	assert_eq(
+		StringName(host.patch_type_matchup(MOD, 0, 1, {"name": "X"})["reason"]),
+		&"invalid_type_matchup", "a matchup with no multiplier is not a matchup"
+	)
+
+
+## The atlases hold exactly the cartridge's 251 slots, so a defined species has
+## no cell to point at and carries decoded indices instead. Every screen reads
+## them through the same crop.
+func test_a_defined_species_draws_its_own_pixels() -> void:
+	var pixels: PackedByteArray = _indices(2, 3)
+	assert_true(bool(Gen2ModHost.instance().register_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES, {
+			"name": "VOLTLING",
+			"pics": {"front": {"tiles": 2, "indices": pixels}},
+		}
+	).get("ok", false)))
+
+	var data: GameData = _data()
+	var pic: Dictionary = data.species_pic(NEW_SPECIES)
+	assert_eq(int(pic["width"]), 2 * Gen2Tiles.TILE_WIDTH)
+	assert_eq(int(pic["slot"]), -1, "there is no atlas cell behind it")
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		data.atlas_indices("front"), data.atlas("front"), pic
+	)
+	assert_eq(cell["indices"], pixels)
+	assert_eq(int(cell["width"]), 2 * Gen2Tiles.TILE_WIDTH)
+	# The back pic was not supplied, so it is the cartridge's own answer: an
+	# atlas slot no cell holds, which draws nothing rather than the wrong species.
+	assert_eq(int(data.species_pic(NEW_SPECIES, true)["slot"]), NEW_SPECIES - 1)
+
+
+func test_a_pic_that_does_not_fill_its_own_size_is_refused() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(
+		StringName(host.register_content(
+			Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES,
+			{"pics": {"front": {"tiles": 3, "indices": _indices(2, 0)}}}
+		)["reason"]),
+		&"invalid_content_pic"
+	)
+	assert_eq(
+		StringName(host.register_content(
+			Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES,
+			{"pics": {"front": {"tiles": 2, "indices": _indices(2, 9)}}}
+		)["reason"]),
+		&"invalid_content_pic", "a pixel is two bits, so index 9 is not one"
+	)
+	assert_true(
+		_data().species(NEW_SPECIES).is_empty(), "and nothing was claimed by either"
+	)
+
+
+## A trainer class is drawn from the same atlas and gets the same answer.
+func test_a_defined_trainer_class_draws_its_own_pixels() -> void:
+	var pixels: PackedByteArray = _indices(7, 1)
+	assert_true(bool(Gen2ModHost.instance().register_content(
+		Gen2ContentOverlay.KIND_TRAINER, MOD, Gen2ContentOverlay.FIRST_MOD_NUMBER, {
+			"name": "RANGER", "pic": {"tiles": 7, "indices": pixels},
+		}
+	).get("ok", false)))
+	var pic: Dictionary = _data().trainer_pic(Gen2ContentOverlay.FIRST_MOD_NUMBER)
+	assert_eq(pic["indices"], pixels)
+	assert_eq(int(pic["height"]), 7 * Gen2Tiles.TILE_HEIGHT)
+
+
+## Its party icon is either one of the cartridge's 38 strips or the mod's own two
+## frames. `ReadMonMenuIcon`'s table has no row for a mod species either way.
+func test_a_defined_species_names_or_supplies_its_party_icon() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.register_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES,
+		{"name": "VOLTLING", "icon": RomLayout.ICON_EGG}
+	).get("ok", false)))
+	assert_eq(_data().mon_menu_icon(NEW_SPECIES), RomLayout.ICON_EGG)
+
+	var strip: PackedByteArray = _icon_strip()
+	assert_true(bool(host.register_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES,
+		{"name": "VOLTLING", "icon": {"indices": strip}}
+	).get("ok", false)))
+	var data: GameData = _data()
+	assert_eq(data.mon_menu_icon(NEW_SPECIES), 0, "no cartridge icon is named")
+	assert_eq(data.species_icon_indices(NEW_SPECIES), strip)
+	assert_eq(
+		StringName(host.register_content(
+			Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES,
+			{"icon": RomLayout.MON_ICON_COUNT + 1}
+		)["reason"]),
+		&"invalid_content_icon"
+	)
+
+
+## Inherited moves ride the species row like the learnset does, so a defined
+## species answers with its own list and a cartridge one with the cache's.
+func test_egg_moves_read_off_the_species_row() -> void:
+	assert_true(bool(Gen2ModHost.instance().register_content(
+		Gen2ContentOverlay.KIND_SPECIES, MOD, NEW_SPECIES,
+		{"name": "VOLTLING", "egg_moves": [1, 1]}
+	).get("ok", false)))
+	var data: GameData = _data()
+	assert_eq(data.egg_moves(NEW_SPECIES), [1, 1] as Array[int])
+	assert_eq(data.egg_moves(1), [] as Array[int], "the cartridge row named none")
+	assert_eq(data.egg_moves(NEW_SPECIES + 99), [] as Array[int], "and neither does nothing")
+
+
+## An icon is two 2x2-tile frames, which is the eight tiles the strip a party
+## menu steps through carries.
+func _icon_strip() -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(8 * Gen2Tiles.TILE_PIXELS)
+	out.fill(2)
+	return out
+
+
+## Two bits a pixel, so a filled buffer is what a real decode produces and the
+## validator has something to reject when it is not.
+func _indices(tiles: int, value: int) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(tiles * tiles * Gen2Tiles.TILE_PIXELS)
+	out.fill(value)
+	return out

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -398,6 +398,16 @@ func test_the_metal_powder_carry_halves_the_attack_and_folds_the_defence_back() 
 		"only a Ditto holding it"
 	)
 
+	# With `metal_powder_overflow` off the boost stops at the byte instead of
+	# carrying, so the boost cannot end up raising the damage taken.
+	var rules := Gen2Rules.new()
+	rules.set_flag(&"metal_powder_overflow", false)
+	Gen2Rules.install(rules)
+	assert_eq(apply.call(200, 171), [200, Gen2Damage.STAT_BYTE_MAX])
+	assert_eq(apply.call(200, 100), [200, 150], "and nothing below the byte moves")
+	Gen2Rules.install(null)
+	assert_eq(apply.call(200, 171), [100, 128], "the default is still the hardware's")
+
 
 ## The Scope Lens is one more critical level, added after the move's own two and
 ## Focus Energy's one, in `BattleCommand_Critical`'s own order.

--- a/tests/unit/test_experience.gd
+++ b/tests/unit/test_experience.gd
@@ -54,6 +54,28 @@ func test_level_one_is_zero_on_every_curve_not_the_formulas_underflow() -> void:
 	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLOW, 1), 0)
 
 
+## The same level under `medium_slow_level_one_underflow`, which is the cartridge
+## itself: `CalcExpAtLevel` has no level 1 branch, so the formula runs and its
+## three bytes wrap. The other curves are positive there and are unaffected, which
+## is why the bug is Medium Slow's alone.
+func test_the_medium_slow_underflow_is_switchable_and_wraps_three_bytes() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_flag(&"medium_slow_level_one_underflow", true)
+	Gen2Rules.install(rules)
+
+	assert_eq(
+		Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 1),
+		Gen2Experience.MAX_EXP - 54 + 1,
+		"-54 stored unsigned in hProduct's three bytes"
+	)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 1), 1)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_FAST, 1), 0, "4/5 truncates")
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_SLOW, 1), 1)
+
+	Gen2Rules.install(null)
+	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_SLOW, 1), 0)
+
+
 func test_level_never_goes_below_one_or_past_the_cap() -> void:
 	assert_eq(Gen2Experience.total_exp_at(Gen2Experience.GROWTH_MEDIUM_FAST, 0), 0)
 	assert_eq(

--- a/tests/unit/test_hp_bar_animation.gd
+++ b/tests/unit/test_hp_bar_animation.gd
@@ -85,3 +85,49 @@ func test_a_small_maximum_still_walks_pixel_by_pixel() -> void:
 		_settle(animation),
 		Gen2HpBarAnimation.LENGTH_PX * Gen2HpBarAnimation.FRAMES_PER_STEP
 	)
+
+
+## `ShortHPBar_CalcPixelFrame` is what prints the number under a 48-pixel
+## maximum, and it rounds up: 20 HP over 48 pixels has no exact HP per pixel, so
+## every pixel but the ends is a fraction the routine rounds rather than floors.
+func test_a_small_maximum_prints_the_short_branchs_own_number() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(20, 0, 20)
+	var seen: Array = []
+	while not animation.finished():
+		animation.advance_frame()
+		seen.append(animation.hp())
+	assert_eq(int(seen[0]), 20, "the first step is still the HP it started from")
+	assert_eq(int(seen[-1]), 0)
+	for index: int in range(1, seen.size()):
+		assert_true(int(seen[index]) <= int(seen[index - 1]), "the number never goes back up")
+
+
+## The routine's loop subtracts before it tests, so a product that lands exactly
+## on a multiple of the bar's width is counted and then rounded up again: one HP
+## too many, which pret's fix removes by stopping on the zero. 24 of 48 pixels of
+## a 12 HP maximum is such a product (12 * 24 = 288 = 6 * 48).
+func test_the_short_bar_off_by_one_is_switchable_at_an_exact_multiple() -> void:
+	var corrected: Gen2HpBarAnimation = Gen2HpBarAnimation.create(12, 0, 12)
+	var buggy: Gen2HpBarAnimation = Gen2HpBarAnimation.create(12, 0, 12)
+	var rules := Gen2Rules.new()
+
+	while corrected.pixels() > Gen2HpBarAnimation.LENGTH_PX / 2:
+		corrected.advance_frame()
+		buggy.advance_frame()
+	assert_eq(corrected.pixels(), Gen2HpBarAnimation.LENGTH_PX / 2)
+
+	Gen2Rules.install(null)
+	assert_eq(corrected.hp(), 6, "the quotient itself")
+	rules.set_flag(&"short_hp_bar_number_off_by_one", true)
+	Gen2Rules.install(rules)
+	assert_eq(buggy.hp(), 7, "and one HP more on hardware")
+	Gen2Rules.install(null)
+
+
+## `wCurHPAnimLowHP`/`wCurHPAnimHighHP`: the routine clamps its answer to the two
+## ends of the animation, which is why the extra HP is invisible on most drains.
+func test_the_short_bar_number_stays_inside_the_two_ends() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(10, 8, 20)
+	while not animation.finished():
+		animation.advance_frame()
+		assert_true(animation.hp() >= 8 and animation.hp() <= 10, str(animation.hp()))

--- a/tests/unit/test_mod_options.gd
+++ b/tests/unit/test_mod_options.gd
@@ -193,3 +193,73 @@ func test_the_shipped_example_registers_the_setting_its_renderer_reads() -> void
 	# The renderer heard the change rather than polling for it.
 	assert_eq(renderer.camera_pitch(), host.option(renderer.MOD_ID, renderer.OPTION_PITCH))
 	renderer.free()
+
+
+## A slot's own settings, which is what makes its recorded walk reproducible: the
+## file is the template a new run is created from, and the run holds the values it
+## was played with from then on.
+func test_a_new_save_records_the_settings_it_was_created_with() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(_distance(host).get("ok", false)))
+	assert_true(bool(host.set_option(MOD, &"draw_distance", 24).get("ok", false)))
+
+	var save := Gen2SaveData.new()
+	host.created_save(save)
+	assert_eq(save.run_options, {MOD: {&"draw_distance": 24}})
+
+	host.activate_save(save)
+	# The installation moves on; the run does not, and the value the run is played
+	# with is the one it recorded.
+	Gen2ModOptions.unbind_run()
+	assert_true(bool(host.set_option(MOD, &"draw_distance", 8).get("ok", false)))
+	host.activate_save(save)
+	assert_eq(host.option(MOD, &"draw_distance"), 24)
+
+	host.deactivate_save()
+	assert_false(Gen2ModOptions.run_bound())
+	assert_eq(host.option(MOD, &"draw_distance"), 8, "and the launcher edits the installation")
+
+
+## A slot written before the snapshot existed adopts the installation once, which
+## is the only honest reconciliation: nothing recorded what it was played with.
+func test_a_save_with_no_recorded_settings_adopts_the_installation_once() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(_distance(host).get("ok", false)))
+	assert_true(bool(host.set_option(MOD, &"draw_distance", 16).get("ok", false)))
+
+	var save := Gen2SaveData.new()
+	host.activate_save(save)
+	assert_eq(save.run_options, {MOD: {&"draw_distance": 16}})
+	assert_eq(host.option(MOD, &"draw_distance"), 16)
+
+
+## A change made while a slot is played belongs to that slot: the installation is
+## left alone, so the other slots keep the walk they recorded.
+func test_a_change_during_a_run_is_kept_by_the_run() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(_distance(host).get("ok", false)))
+	assert_true(bool(host.set_option(MOD, &"draw_distance", 8).get("ok", false)))
+
+	var save := Gen2SaveData.new()
+	host.created_save(save)
+	host.activate_save(save)
+	assert_true(bool(host.set_option(MOD, &"draw_distance", 24).get("ok", false)))
+	assert_eq(save.run_options, {MOD: {&"draw_distance": 24}}, "the save carries it")
+	assert_eq(
+		Gen2SaveData.from_dict(save.to_dict()).run_options, {MOD: {&"draw_distance": 24}},
+		"and it survives the round trip through the file"
+	)
+
+	host.deactivate_save()
+	assert_eq(host.option(MOD, &"draw_distance"), 8, "the installation was left alone")
+
+
+## A development run has no slot, so there is nothing to bind and nothing to
+## invent: the installation is what it plays with.
+func test_a_run_with_no_slot_plays_the_installations_settings() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(_distance(host).get("ok", false)))
+	assert_true(bool(host.set_option(MOD, &"draw_distance", 16).get("ok", false)))
+	host.activate_save(null)
+	assert_false(Gen2ModOptions.run_bound())
+	assert_eq(host.option(MOD, &"draw_distance"), 16)

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -137,6 +137,92 @@ func test_a_subscriber_sees_published_events_and_cannot_write_through_them() -> 
 	assert_eq(_seen.size(), 1)
 
 
+## Mutation is the other half of the event channel: the turn or the script has
+## already committed, so what reaches the screen is presentation and may be
+## rewritten, while the key the screen dispatches on may not.
+func test_an_event_mutator_rewrites_presentation_and_not_the_routing_key() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.register_event_mutator(
+		Gen2ModHost.CHANNEL_BATTLE, MOD,
+		func(event: Dictionary) -> Dictionary:
+			event["damage"] = 1
+			return event
+	).get("ok", false)))
+	assert_true(bool(host.subscribe(Gen2ModHost.CHANNEL_BATTLE, MOD, _watch).get("ok", false)))
+
+	var effective: Dictionary = Gen2ModHost.publish(
+		Gen2ModHost.CHANNEL_BATTLE, {"type": Gen2Battle.HIT, "damage": 12}
+	)
+	assert_eq(int(effective["damage"]), 1, "the screen shows what the mutator returned")
+	assert_eq(int(_seen[0]["damage"]), 1, "and a watcher sees the same event")
+
+	host.unregister_event_mutator(Gen2ModHost.CHANNEL_BATTLE, MOD)
+	assert_eq(
+		int(Gen2ModHost.publish(
+			Gen2ModHost.CHANNEL_BATTLE, {"type": Gen2Battle.HIT, "damage": 12}
+		)["damage"]),
+		12
+	)
+
+
+func test_a_mutator_that_changes_the_key_or_answers_with_nothing_is_ignored() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_event_mutator(
+		Gen2ModHost.CHANNEL_BATTLE, MOD,
+		func(event: Dictionary) -> Dictionary:
+			event["type"] = Gen2Battle.ANIMATION
+			return event
+	)
+	var event: Dictionary = {"type": Gen2Battle.HIT, "damage": 12}
+	assert_eq(
+		StringName(Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)["type"]),
+		StringName(Gen2Battle.HIT),
+		"a rewrite cannot turn one screen operation into another"
+	)
+
+	host.unregister_event_mutator(Gen2ModHost.CHANNEL_BATTLE, MOD)
+	host.register_event_mutator(
+		Gen2ModHost.CHANNEL_WORLD, MOD, func(_event: Dictionary) -> Variant: return null
+	)
+	assert_eq(
+		Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, {"status": &"waiting"}),
+		{"status": &"waiting"},
+		"and a mutator answering with nothing leaves the event alone"
+	)
+
+
+## Exclusive, because composing two rewrites in load order would make the picture
+## depend on which mod happened to load first.
+func test_only_one_mod_may_mutate_a_channel() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	assert_true(bool(host.register_event_mutator(
+		Gen2ModHost.CHANNEL_WORLD, MOD, _watch
+	).get("ok", false)))
+	var second: Dictionary = host.register_event_mutator(
+		Gen2ModHost.CHANNEL_WORLD, &"othermod", _watch
+	)
+	assert_eq(StringName(second["reason"]), &"duplicate_event_mutator")
+	assert_string_contains(String(second["detail"]), "othermod")
+	assert_eq(
+		StringName(host.register_event_mutator(&"nowhere", MOD, _watch)["reason"]),
+		&"unknown_channel"
+	)
+	assert_eq(
+		StringName(host.register_event_mutator(
+			Gen2ModHost.CHANNEL_BATTLE, MOD, Callable()
+		)["reason"]),
+		&"invalid_event_mutator_handler"
+	)
+	# Another mod's id cannot release it either.
+	host.unregister_event_mutator(Gen2ModHost.CHANNEL_WORLD, &"othermod")
+	assert_eq(
+		StringName(host.register_event_mutator(
+			Gen2ModHost.CHANNEL_WORLD, &"othermod", _watch
+		)["reason"]),
+		&"duplicate_event_mutator"
+	)
+
+
 func test_unsubscribing_and_unknown_channels() -> void:
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	assert_eq(

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -838,6 +838,40 @@ func test_belly_drum_fails_without_cost_under_half_health() -> void:
 	assert_eq(_first(turn.events, Gen2Battle.STAT_CHANGE_FAILED)["by"], 6)
 
 
+## `BattleCommand_BellyDrum` calls `BattleCommand_AttackUp2` BEFORE the HP check
+## and only branches to `.failed` after it, so on hardware the two stages have
+## already been paid when the failure is printed.
+func test_the_belly_drum_bug_pays_two_stages_before_it_fails() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_flag(&"belly_drum_boosts_below_half_hp", true)
+	Gen2Rules.install(rules)
+
+	var turn: Gen2Turn = _turn(_battle())
+	var mon: Gen2BattleMon = turn.attacker()
+	mon.hp = 1
+	Gen2EffectCommands.run(Gen2EffectCommands.BELLY_DRUM, turn)
+
+	assert_eq(mon.stage("attack"), Gen2EffectCommands.ATTACK_UP_2_STAGES)
+	assert_eq(mon.hp, 1, "and still no HP spent, the subtraction being past the branch")
+	assert_eq(_first(turn.events, Gen2Battle.STAT_CHANGED)["by"], 2)
+	assert_eq(_first(turn.events, Gen2Battle.STAT_CHANGE_FAILED)["by"], 6)
+
+	# The raise is capped by the room left, so it cannot walk past the top, and a
+	# Pokemon already there is the ordinary failure with nothing paid.
+	var full: Gen2Turn = _turn(_battle())
+	var maxed: Gen2BattleMon = full.attacker()
+	maxed.hp = 1
+	maxed.change_stage("attack", Gen2Stats.MAX_STAGE - 1)
+	Gen2EffectCommands.run(Gen2EffectCommands.BELLY_DRUM, full)
+	assert_eq(maxed.stage("attack"), Gen2Stats.MAX_STAGE)
+
+	Gen2Rules.install(null)
+	var corrected: Gen2Turn = _turn(_battle())
+	corrected.attacker().hp = 1
+	Gen2EffectCommands.run(Gen2EffectCommands.BELLY_DRUM, corrected)
+	assert_eq(corrected.attacker().stage("attack"), 0, "the default pays nothing")
+
+
 func test_belly_drum_fails_once_attack_is_already_at_the_top() -> void:
 	var turn: Gen2Turn = _turn(_battle())
 	var mon: Gen2BattleMon = turn.attacker()

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -146,6 +146,24 @@ func test_out_of_range_values_are_clamped_rather_than_refused() -> void:
 	assert_eq(options.max_fps, 60, "an unlisted frame cap falls back to 60")
 
 
+## The gameplay rules live in the options file but are their own block: the
+## settings screen edits them there, and a new run takes a copy.
+func test_the_rules_block_travels_with_the_options_file() -> void:
+	var options := Gen2Options.new()
+	assert_eq(options.rules.mode, Gen2Rules.MODE_CURRENT)
+	options.rules.set_mode(Gen2Rules.MODE_VANILLA)
+	options.rules.difficulty = Gen2Rules.DIFFICULTY_EASY
+
+	var restored: Gen2Options = Gen2Options.parse(options.to_dict())
+	assert_true(restored.rules.matches(options.rules))
+	assert_eq(restored.rules.mode, Gen2Rules.MODE_VANILLA)
+	assert_eq(restored.rules.difficulty, Gen2Rules.DIFFICULTY_EASY)
+	assert_eq(
+		Gen2Options.parse({}).rules.mode, Gen2Rules.MODE_CURRENT,
+		"a file written before the block existed plays what shipped"
+	)
+
+
 func test_a_non_dictionary_parses_as_defaults() -> void:
 	var options: Gen2Options = Gen2Options.parse("not options")
 	assert_eq(options.to_source_bytes(), Gen2Options.new().to_source_bytes())

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -1118,6 +1118,129 @@ func test_a_learnset_with_no_terminator_fails_rather_than_running_away() -> void
 	assert_false(RomImporter.verify_evos_attacks(_rom(data), _layout)["ok"])
 
 
+## `EggMovePointers`, built to the census the layout pins so the check has
+## something it should accept as well as things it should not. The two pinned
+## species carry the Gold/Silver lists, this dump being a Gold one.
+func _egg_move_entries() -> Array:
+	var out: Array = []
+	for _species: int in RomLayout.SPECIES_COUNT:
+		out.append([] as Array[int])
+	out[RomImporter.EGG_MOVE_BULBASAUR_SPECIES - 1] = \
+		RomImporter.EGG_MOVES_BULBASAUR_GOLD_SILVER.duplicate()
+	out[RomImporter.EGG_MOVE_STARYU_SPECIES - 1] = \
+		RomImporter.EGG_MOVES_STARYU_GOLD_SILVER.duplicate()
+
+	# Filler enough to reach the pinned totals, clear of the two named species.
+	var moves: int = int(_layout["egg_move_count"]) \
+		- RomImporter.EGG_MOVES_BULBASAUR_GOLD_SILVER.size() \
+		- RomImporter.EGG_MOVES_STARYU_GOLD_SILVER.size()
+	var species: int = int(_layout["egg_move_species_count"]) - 2
+	for index: int in species:
+		var list: Array[int] = [1]
+		if index == 0:
+			list.resize(moves - species + 1)
+			list.fill(1)
+		out[10 + index] = list
+	return out
+
+
+func _write_egg_moves(data: PackedByteArray, entries: Array) -> void:
+	var table: int = int(_layout["egg_move_pointers"])
+	var at: int = table + RomLayout.SPECIES_COUNT * RomLayout.EGG_MOVE_POINTER_SIZE
+	for species: int in RomLayout.SPECIES_COUNT:
+		var address: int = RomFile.BANK_SIZE + (at % RomFile.BANK_SIZE)
+		var pointer: int = table + species * RomLayout.EGG_MOVE_POINTER_SIZE
+		data[pointer] = address & 0xFF
+		data[pointer + 1] = address >> 8
+		for move: int in entries[species] as Array:
+			data[at] = move
+			at += 1
+		data[at] = RomLayout.EGG_MOVE_END
+		at += 1
+
+
+func _egg_move_dump() -> PackedByteArray:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_egg_moves(data, _egg_move_entries())
+	return data
+
+
+func test_a_plausible_egg_move_table_verifies_and_reads_back() -> void:
+	var rom: RomFile = _rom(_egg_move_dump())
+	var result: Dictionary = RomImporter.verify_egg_moves(rom, _layout)
+	assert_true(result["ok"], result["message"])
+	assert_eq(
+		RomImporter.read_egg_moves(rom, _layout, RomImporter.EGG_MOVE_BULBASAUR_SPECIES)["moves"],
+		RomImporter.EGG_MOVES_BULBASAUR_GOLD_SILVER
+	)
+	assert_eq(
+		RomImporter.read_egg_moves(rom, _layout, RomImporter.EGG_MOVE_STARYU_SPECIES)["moves"],
+		RomImporter.EGG_MOVES_STARYU_GOLD_SILVER
+	)
+	assert_eq(
+		RomImporter.read_egg_moves(rom, _layout, 2)["moves"], [] as Array[int],
+		"a species that inherits nothing is one terminator, not a missing list"
+	)
+
+
+## The empty list is what makes this table easy to read one byte out of step: a
+## slid pointer still lands on a plausible move id, and the census is the only
+## thing that notices.
+func test_an_egg_move_pointer_table_one_byte_out_fails() -> void:
+	var data: PackedByteArray = _egg_move_dump()
+	var table: int = int(_layout["egg_move_pointers"])
+	for species: int in RomLayout.SPECIES_COUNT:
+		var at: int = table + species * RomLayout.EGG_MOVE_POINTER_SIZE
+		data[at] = (data[at] + 1) & 0xFF
+	assert_false(RomImporter.verify_egg_moves(_rom(data), _layout)["ok"])
+
+
+func test_an_egg_move_pointer_outside_the_banked_window_fails() -> void:
+	var data: PackedByteArray = _egg_move_dump()
+	data[int(_layout["egg_move_pointers"]) + 1] = 0x20
+	assert_false(RomImporter.verify_egg_moves(_rom(data), _layout)["ok"])
+
+
+func test_an_egg_move_that_is_not_a_move_fails() -> void:
+	var entries: Array = _egg_move_entries()
+	entries[9] = [RomLayout.MOVE_COUNT + 1] as Array[int]
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_egg_moves(data, entries)
+	assert_false(RomImporter.verify_egg_moves(_rom(data), _layout)["ok"])
+
+
+## The walk stops at the bank's end rather than the dump's, so an unterminated
+## list fails instead of collecting whatever the next section holds.
+func test_an_egg_move_list_with_no_terminator_fails() -> void:
+	var data: PackedByteArray = _egg_move_dump()
+	var at: int = int(_layout["egg_move_pointers"]) \
+		+ RomLayout.SPECIES_COUNT * RomLayout.EGG_MOVE_POINTER_SIZE
+	var bank_end: int = (RomLayout.bank_of(at) + 1) * RomFile.BANK_SIZE
+	for i: int in bank_end - at:
+		data[at + i] = 1
+	assert_false(RomImporter.verify_egg_moves(_rom(data), _layout)["ok"])
+
+
+func test_an_egg_move_census_that_disagrees_with_the_layout_fails() -> void:
+	var entries: Array = _egg_move_entries()
+	(entries[RomImporter.EGG_MOVE_BULBASAUR_SPECIES - 1] as Array).append(1)
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomRegistry.EXPECTED_SIZE)
+	_write_egg_moves(data, entries)
+	var result: Dictionary = RomImporter.verify_egg_moves(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(result["message"], "egg moves")
+
+
+## Crystal's revision differs from Gold's in these two lists and in nothing else
+## this check can see, so reading a Crystal dump with the Gold pins has to fail.
+func test_the_gold_lists_are_refused_for_crystal() -> void:
+	var crystal: RomFile = RomFile.from_bytes(_egg_move_dump(), RomRegistry.CRYSTAL)
+	assert_false(RomImporter.verify_egg_moves(crystal, _layout)["ok"])
+
+
 ## `Copyright`'s two halves check each other: every code the string carries has
 ## to be a tile of the strip the same routine loads, and the run has to end at
 ## "@" after the source's three rows. A wrong offset for either fails one of

--- a/tests/unit/test_rules.gd
+++ b/tests/unit/test_rules.gd
@@ -1,0 +1,144 @@
+extends GutTest
+
+## The rules object itself: what a mode answers, what an override does to it, and
+## what survives the options file. Each flag's own BEHAVIOUR is tested where the
+## branch is, at the layer that owns it, not here.
+
+const FIRST_FLAG: StringName = &"belly_drum_boosts_below_half_hp"
+const REPRODUCED_TODAY: StringName = &"metal_powder_overflow"
+
+
+func after_each() -> void:
+	Gen2Rules.install(null)
+
+
+## The default is what shipped, which is a mix: some cartridge bugs are
+## reproduced and some are corrected, and a mode is what makes that uniform.
+func test_the_default_is_todays_behaviour_and_the_two_modes_are_its_ends() -> void:
+	var rules := Gen2Rules.new()
+	assert_eq(rules.mode, Gen2Rules.MODE_CURRENT)
+	assert_eq(rules.mode_of(), Gen2Rules.MODE_CURRENT)
+	assert_false(rules.reproduces(FIRST_FLAG))
+	assert_true(rules.reproduces(REPRODUCED_TODAY), "reproduced before any flag existed")
+
+	rules.set_mode(Gen2Rules.MODE_VANILLA)
+	for flag: StringName in Gen2Rules.FLAGS:
+		assert_true(rules.reproduces(flag), String(flag))
+	rules.set_mode(Gen2Rules.MODE_QOL)
+	for flag: StringName in Gen2Rules.FLAGS:
+		assert_false(rules.reproduces(flag), String(flag))
+
+
+func test_an_override_moves_one_flag_and_names_the_set_custom() -> void:
+	var rules := Gen2Rules.new()
+	assert_true(rules.set_flag(FIRST_FLAG, true))
+	assert_true(rules.reproduces(FIRST_FLAG))
+	assert_eq(rules.mode_of(), Gen2Rules.MODE_CUSTOM)
+	# Set back to what the mode already says and the override is gone rather than
+	# kept as a value that agrees with it.
+	assert_true(rules.set_flag(FIRST_FLAG, false))
+	assert_true(rules.overrides.is_empty())
+	assert_eq(rules.mode_of(), Gen2Rules.MODE_CURRENT)
+
+	assert_false(rules.set_flag(&"no_such_bug", true), "a flag this build lacks is refused")
+	assert_true(rules.overrides.is_empty())
+
+
+## A mode is a starting point, not a reset: what the player moved by hand stays
+## moved. `clear_flags` is the reset.
+func test_a_mode_change_keeps_a_hand_moved_flag() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_flag(FIRST_FLAG, true)
+	rules.set_mode(Gen2Rules.MODE_QOL)
+	assert_true(rules.reproduces(FIRST_FLAG))
+	assert_false(rules.reproduces(REPRODUCED_TODAY))
+	assert_eq(rules.mode_of(), Gen2Rules.MODE_CUSTOM)
+
+	# Under vanilla that same override agrees with the mode, so it stops being one.
+	rules.set_mode(Gen2Rules.MODE_VANILLA)
+	assert_true(rules.overrides.is_empty())
+	assert_eq(rules.mode_of(), Gen2Rules.MODE_VANILLA)
+
+	rules.set_flag(REPRODUCED_TODAY, false)
+	rules.clear_flags()
+	assert_eq(rules.mode_of(), Gen2Rules.MODE_VANILLA)
+
+
+## Only the overrides are written, so a flag added by a later build is not
+## recorded in a file that never chose it and keeps its own default.
+func test_only_what_differs_is_written_and_read_back() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_mode(Gen2Rules.MODE_VANILLA)
+	rules.difficulty = Gen2Rules.DIFFICULTY_HARD
+	rules.set_flag(REPRODUCED_TODAY, false)
+
+	var written: Dictionary = rules.to_dict()
+	assert_eq(written["mode"], String(Gen2Rules.MODE_VANILLA))
+	assert_eq(written["flags"], {String(REPRODUCED_TODAY): false})
+
+	var restored: Gen2Rules = Gen2Rules.parse(written)
+	assert_true(restored.matches(rules))
+	assert_eq(restored.difficulty, Gen2Rules.DIFFICULTY_HARD)
+	assert_false(restored.reproduces(REPRODUCED_TODAY))
+	assert_true(restored.reproduces(FIRST_FLAG))
+
+
+func test_an_unreadable_block_falls_back_rather_than_refusing_the_rest() -> void:
+	var rules: Gen2Rules = Gen2Rules.parse({
+		"mode": "sideways", "difficulty": "impossible", "flags": {"no_such_bug": true},
+	})
+	assert_eq(rules.mode, Gen2Rules.MODE_CURRENT)
+	assert_eq(rules.difficulty, Gen2Rules.DIFFICULTY_NORMAL)
+	assert_true(rules.overrides.is_empty())
+	assert_true(Gen2Rules.parse("not a block").matches(Gen2Rules.new()))
+
+
+## The difficulty rewrites which AI layers score rather than inventing a level or
+## a stat, so it can only ever ask for bits the scorer already reads.
+func test_the_difficulty_rewrites_a_trainer_classes_own_ai_layers() -> void:
+	var rules := Gen2Rules.new()
+	var imported: int = RomLayout.AI_BASIC | RomLayout.AI_SMART
+	assert_eq(rules.ai_move_weights(imported), imported, "normal is the cartridge's own")
+
+	rules.difficulty = Gen2Rules.DIFFICULTY_EASY
+	assert_eq(rules.ai_move_weights(imported), RomLayout.AI_BASIC)
+
+	rules.difficulty = Gen2Rules.DIFFICULTY_HARD
+	assert_eq(rules.ai_move_weights(imported), RomLayout.AI_MOVE_WEIGHTS_MASK)
+	assert_eq(
+		rules.ai_move_weights(0) & ~RomLayout.AI_MOVE_WEIGHTS_MASK, 0,
+		"and never a bit the scorer does not read"
+	)
+
+	rules.difficulty = Gen2Rules.DIFFICULTY_NORMAL
+	assert_eq(
+		rules.ai_move_weights(RomLayout.AI_BASIC | (1 << 15)), RomLayout.AI_BASIC,
+		"a patched trainer cannot smuggle one in either"
+	)
+
+
+## One installed set at a time, because the statics that read the rules
+## ([Gen2Damage], [Gen2Experience], [Gen2BattleAI]) take no engine object and two
+## sources would let them disagree with the battle they are resolving.
+func test_the_installed_set_is_what_a_static_reads() -> void:
+	assert_false(Gen2Rules.hardware(FIRST_FLAG))
+	var rules := Gen2Rules.new()
+	rules.set_flag(FIRST_FLAG, true)
+	Gen2Rules.install(rules)
+	assert_true(Gen2Rules.hardware(FIRST_FLAG))
+	assert_same(Gen2Rules.active(), rules)
+
+	Gen2Rules.install(null)
+	assert_false(Gen2Rules.hardware(FIRST_FLAG), "and nothing is left installed")
+	assert_false(Gen2Rules.hardware(&"no_such_bug"), "an unknown flag is not hardware")
+
+
+func test_a_copy_is_independent_of_what_it_was_copied_from() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_flag(FIRST_FLAG, true)
+	var copy: Gen2Rules = rules.duplicate_rules()
+	assert_true(copy.matches(rules))
+	copy.set_flag(FIRST_FLAG, false)
+	assert_true(rules.reproduces(FIRST_FLAG))
+	assert_false(copy.matches(rules))
+	assert_false(rules.matches(null))

--- a/tests/unit/test_rules.gd.uid
+++ b/tests/unit/test_rules.gd.uid
@@ -1,0 +1,1 @@
+uid://cpetduapujpgh

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -95,6 +95,15 @@ func test_a_saved_pokemon_restores_stats_hp_status_exp_and_pp() -> void:
 
 func test_battle_save_writeback_preserves_player_and_pokemon_identity() -> void:
 	var source: Gen2SaveData = _save()
+	source.label = "ROUTE TEST"
+	source.player_id = 0xBEEF
+	source.gender = Gen2SaveData.GENDER_FEMALE
+	source.game_time.hours = 17
+	source.game_time.minutes = 42
+	source.run_seed = 0x12345678
+	source.run_mods = [{"id": "weather_plus", "version": "1.2.0"}]
+	source.run_options = {&"weather_plus": {&"storms": true}}
+	source.mods = {&"weather_plus": {"fronts": [1, 3, 5]}}
 	(source.party[0] as Gen2SaveMon).nickname = "SPARKY"
 	(source.party[0] as Gen2SaveMon).original_trainer = "RED"
 	var boxed: Gen2SaveMon = Gen2SaveMon.from_dict(source.party[1].to_dict())
@@ -106,6 +115,15 @@ func test_battle_save_writeback_preserves_player_and_pokemon_identity() -> void:
 		_data.id, _data.sha1, source.slot, party, "", source
 	)
 	assert_eq(written.player_name, "RED")
+	assert_eq(written.label, "ROUTE TEST")
+	assert_eq(written.player_id, 0xBEEF)
+	assert_eq(written.gender, Gen2SaveData.GENDER_FEMALE)
+	assert_eq(written.game_time.hours, 17)
+	assert_eq(written.game_time.minutes, 42)
+	assert_eq(written.run_seed, 0x12345678)
+	assert_eq(written.run_mods, [{"id": "weather_plus", "version": "1.2.0"}])
+	assert_eq(written.run_options, {&"weather_plus": {&"storms": true}})
+	assert_eq(written.mods, {&"weather_plus": {"fronts": [1, 3, 5]}})
 	assert_eq((written.party[0] as Gen2SaveMon).nickname, "SPARKY")
 	assert_eq((written.party[0] as Gen2SaveMon).original_trainer, "RED")
 	assert_eq(written.boxes[2].slots[4].species, boxed.species)
@@ -241,9 +259,16 @@ func test_the_run_block_round_trips_and_refuses_an_invented_mod_id() -> void:
 		{"id": "weather_plus", "version": "1.2.0"},
 		{"id": "Bad Id", "version": "9"},
 	]
+	save.run_options = {
+		&"weather_plus": {&"draw_distance": 24, &"storms": true},
+		&"Bad Id": {&"ignored": true},
+	}
 	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
 	assert_eq(restored.run_seed, 0x0BADF00D)
 	assert_eq(restored.run_mods, [{"id": "weather_plus", "version": "1.2.0"}])
+	assert_eq(restored.run_options, {
+		&"weather_plus": {&"draw_distance": 24, &"storms": true},
+	})
 
 
 ## A slot written before the block existed says so rather than claiming frame
@@ -255,6 +280,7 @@ func test_a_save_without_a_run_block_records_no_seed() -> void:
 	assert_not_null(restored)
 	assert_eq(restored.run_seed, 0)
 	assert_eq(restored.run_mods, [])
+	assert_eq(restored.run_options, {})
 
 
 func test_format_five_migrates_to_an_empty_mod_namespace() -> void:
@@ -680,6 +706,55 @@ func test_crystal_carries_the_players_gender_and_the_others_do_not() -> void:
 		)["save"] as Gen2SaveData).gender,
 		Gen2SaveData.GENDER_MALE
 	)
+
+
+## Every species, item and move on the hardware is one byte, and mod content is
+## numbered past that on purpose, so an export refuses rather than truncating a
+## number into a different Pokemon in a real cartridge.
+func test_mod_content_cannot_be_exported_to_a_cartridge() -> void:
+	var data: GameData = _adapter_data(RomRegistry.CRYSTAL)
+	var raw: PackedByteArray = _raw_cartridge(RomRegistry.CRYSTAL, data)
+	var save: Gen2SaveData = Gen2SramAdapter.import_bytes(
+		RomRegistry.CRYSTAL, data.sha1, 0, raw, data
+	)["save"]
+	assert_true(Gen2SramAdapter.export_bytes(save, raw, data)["ok"], "the cartridge save exports")
+
+	# Registered, so the save validator accepts the numbers and the refusal below
+	# is this boundary's own rather than an unknown-content one.
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_content(
+		Gen2ContentOverlay.KIND_SPECIES, &"testmod", Gen2ContentOverlay.FIRST_MOD_NUMBER,
+		{"name": "VOLTLING"}
+	)
+	host.register_content(
+		Gen2ContentOverlay.KIND_MOVE, &"testmod", Gen2ContentOverlay.FIRST_MOD_NUMBER + 4,
+		{"name": "HOWL"}
+	)
+	host.register_content(
+		Gen2ContentOverlay.KIND_ITEM, &"testmod", Gen2ContentOverlay.FIRST_MOD_NUMBER + 9,
+		{"name": "CHARM"}
+	)
+
+	var mon: Gen2SaveMon = save.party[0]
+	var species: int = mon.species
+	mon.species = Gen2ContentOverlay.FIRST_MOD_NUMBER
+	var refused: Dictionary = Gen2SramAdapter.export_bytes(save, raw, data)
+	assert_false(refused["ok"])
+	assert_string_contains(String(refused["message"]), "mod content")
+
+	mon.species = species
+	mon.moves[1] = Gen2ContentOverlay.FIRST_MOD_NUMBER + 4
+	assert_false(
+		Gen2SramAdapter.export_bytes(save, raw, data)["ok"], "a mod move is a byte too wide too"
+	)
+	mon.moves[1] = 1
+	var boxed: Gen2SaveMon = Gen2SaveMon.from_dict(mon.to_dict())
+	boxed.item = Gen2ContentOverlay.FIRST_MOD_NUMBER + 9
+	(save.boxes[3] as Gen2SaveBox).slots[2] = boxed
+	assert_false(
+		Gen2SramAdapter.export_bytes(save, raw, data)["ok"], "and a boxed one is not exempt"
+	)
+	Gen2ModHost.reset()
 
 
 func test_gold_and_silver_have_no_gender_byte_to_read_or_write() -> void:

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -271,6 +271,31 @@ func test_the_run_block_round_trips_and_refuses_an_invented_mod_id() -> void:
 	})
 
 
+## The rules travel with the slot, not with the installation: a run recorded under
+## one set did not produce the state a different set would.
+func test_the_runs_rules_round_trip_and_are_absent_when_never_recorded() -> void:
+	var save: Gen2SaveData = _save()
+	assert_null(save.run_rules, "a save invents none")
+
+	var rules := Gen2Rules.new()
+	rules.set_mode(Gen2Rules.MODE_VANILLA)
+	rules.difficulty = Gen2Rules.DIFFICULTY_HARD
+	rules.set_flag(&"metal_powder_overflow", false)
+	save.run_rules = rules
+
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	assert_not_null(restored.run_rules)
+	assert_true(restored.run_rules.matches(rules))
+	assert_eq(restored.run_rules.difficulty, Gen2Rules.DIFFICULTY_HARD)
+
+	# A copy is its own object, so editing one slot's rules cannot reach another's.
+	var copy := Gen2SaveData.new()
+	assert_true(copy.copy_from(save))
+	assert_true(copy.run_rules.matches(rules))
+	copy.run_rules.difficulty = Gen2Rules.DIFFICULTY_EASY
+	assert_eq(save.run_rules.difficulty, Gen2Rules.DIFFICULTY_HARD)
+
+
 ## A slot written before the block existed says so rather than claiming frame
 ## zero of a seeded run.
 func test_a_save_without_a_run_block_records_no_seed() -> void:
@@ -281,6 +306,7 @@ func test_a_save_without_a_run_block_records_no_seed() -> void:
 	assert_eq(restored.run_seed, 0)
 	assert_eq(restored.run_mods, [])
 	assert_eq(restored.run_options, {})
+	assert_null(restored.run_rules)
 
 
 func test_format_five_migrates_to_an_empty_mod_namespace() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6881,3 +6881,29 @@ func test_a_patched_trade_uses_both_halves_without_moving_the_record() -> void:
 	## The record itself is untouched, so a second site naming it is unaffected.
 	assert_eq(int(data.world_trade(0)["offered_species"]), 19)
 	assert_eq(int(data.world_trade(0)["requested_species"]), 16)
+
+
+## A world is a run, so opening one installs the rules it was opened with: the
+## statics that read them ([Gen2Experience], [Gen2Damage], [Gen2BattleAI]) take no
+## world object, and the battles inside the walk have to be fought under the same
+## set the walk is.
+func test_opening_a_world_carries_and_installs_its_rules() -> void:
+	var rules := Gen2Rules.new()
+	rules.set_flag(&"belly_drum_boosts_below_half_hp", true)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(8, 6), Gen2WorldState.new(), rules
+	)
+	assert_same(world.rules, rules)
+	assert_true(Gen2Rules.hardware(&"belly_drum_boosts_below_half_hp"))
+
+	# A snapshot restore is the same run continuing, so it takes the rules the
+	# same way rather than adopting whatever is installed.
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(data, world.snapshot(), rules)
+	assert_same(restored.rules, rules)
+
+	Gen2Rules.install(null)
+	var plain: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6), Gen2WorldState.new())
+	assert_not_null(plain.rules, "a world opened without rules plays the installed set")
+	assert_false(Gen2Rules.hardware(&"belly_drum_boosts_below_half_hp"))
+	Gen2Rules.install(null)

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -7,11 +7,11 @@ extends SceneTree
 ## The written counterpart of the contact sheet: a bad offset in a name table
 ## produces plausible words rather than an error, so the check is reading the
 ## output. <game> is a registry id; [table] is species, moves, items, types,
-## matchups, trainers, learnsets, evolutions or all.
+## matchups, trainers, learnsets, egg_moves, evolutions or all.
 
 const TABLES: PackedStringArray = [
 	"species", "moves", "items", "types", "matchups", "trainers", "learnsets",
-	"evolutions", "growth",
+	"egg_moves", "evolutions", "growth",
 ]
 
 ## Which file a table is read out of, where it is not a file of its own.
@@ -20,6 +20,7 @@ const TABLES: PackedStringArray = [
 ## of their own.
 const SOURCES: Dictionary = {
 	"learnsets": RomCache.SPECIES,
+	"egg_moves": RomCache.SPECIES,
 	"evolutions": RomCache.SPECIES,
 	"growth": RomCache.SPECIES,
 }
@@ -142,6 +143,8 @@ func _dump(directory: String, table: String) -> void:
 			_dump_trainers(directory, rows)
 		"learnsets":
 			_dump_learnsets(directory, rows)
+		"egg_moves":
+			_dump_egg_moves(directory, rows)
 		"evolutions":
 			_dump_evolutions(directory, rows)
 		"growth":
@@ -171,6 +174,30 @@ func _dump_learnsets(directory: String, rows: Array) -> void:
 			parts.append("%d %s" % [int(entry["level"]), _name_at(moves, int(entry["move"]))])
 		print("  %3d  %-11s %s" % [int(row["number"]), String(row["name"]), ", ".join(parts)])
 	print("  %d level-up moves" % total)
+
+
+## Only the species that inherit something, which is a little over 40 percent of
+## them. An egg-move list has no self-checking shape at all: every byte in it is a
+## plausible move number, and one pointer read a byte out of step still decodes.
+## What settles it is reading names against the published lists, which is why the
+## two the importer pins are worth finding here: Bulbasaur and Staryu.
+func _dump_egg_moves(directory: String, rows: Array) -> void:
+	var moves: Array = _names_in(RomCache.moves_path(directory))
+	var total: int = 0
+	var species: int = 0
+
+	print("\negg moves")
+	for row: Dictionary in rows:
+		var inherited: Array = row.get("egg_moves", [])
+		if inherited.is_empty():
+			continue
+		total += inherited.size()
+		species += 1
+		var parts: PackedStringArray = []
+		for move: Variant in inherited:
+			parts.append(_name_at(moves, int(move)))
+		print("  %3d  %-11s %s" % [int(row["number"]), String(row["name"]), ", ".join(parts)])
+	print("  %d egg moves across %d species" % [total, species])
 
 
 ## Every species' growth rate and base experience yield, the two fields

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -4,9 +4,11 @@ extends SceneTree
 ## chosen set of cartridges present.
 ##
 ##   Godot --path . -s res://tools/preview_launcher.gd -- \
-##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id]
+##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] [scroll]
 ##
 ## `view` is the mods page's own: `list`, `sources`, or `mod` with an id.
+## `scroll` is how far down the page's own scroll to photograph, in pixels, for a
+## card that does not fit the window.
 ##
 ## The state argument uses the preview seams on the launcher, so an empty shelf
 ## can be photographed on a machine that has every cache imported. Like
@@ -26,6 +28,7 @@ var _page: String = "shelf"
 var _state: String = "full"
 var _view: String = ""
 var _mod: String = ""
+var _scroll: int = 0
 
 
 func _initialize() -> void:
@@ -42,6 +45,7 @@ func _initialize() -> void:
 	var state: String = args[5] if args.size() > 5 else "full"
 	_view = args[6] if args.size() > 6 else ""
 	_mod = args[7] if args.size() > 7 else ""
+	_scroll = int(args[8]) if args.size() > 8 else 0
 
 	# Both, because the window already exists by the time a tool script runs and
 	# only the display server moves it.
@@ -70,6 +74,12 @@ func _process(_delta: float) -> bool:
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():
 			_launcher.preview_mods_view(StringName(_view), StringName(_mod))
+	# After the seams, so the page being photographed is the one that scrolls, and
+	# every frame, since a rebuilt page starts at the top again.
+	if _scroll > 0:
+		var scroll: ScrollContainer = _first_scroll(_launcher)
+		if scroll != null:
+			scroll.scroll_vertical = _scroll
 	if _frames < 26:
 		return false
 	var image: Image = root.get_texture().get_image()
@@ -80,3 +90,13 @@ func _process(_delta: float) -> bool:
 	print("Wrote %s (%dx%d)" % [_output, image.get_width(), image.get_height()])
 	quit()
 	return true
+
+
+func _first_scroll(node: Node) -> ScrollContainer:
+	if node is ScrollContainer and node.is_visible_in_tree():
+		return node
+	for child: Node in node.get_children():
+		var found: ScrollContainer = _first_scroll(child)
+		if found != null:
+			return found
+	return null

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -19,6 +19,12 @@ extends SceneTree
 ## | 30 fps | `_process(1/30)`, the recorded log | the pump, not the host, spends frames |
 ## | 144 fps | `_process(1/144)` , the recorded log | the same, from the other side |
 ##
+## The corpus is twenty-seven generated walks over the spawn group, one scripted
+## errand and one wild battle. The battle route is the seam this tool exists to
+## close: a fight is spent from the world's own pump and its buttons arrive
+## through the world's own funnel, so the encounter, the enemy's own choices and
+## the party that comes out are all functions of the run's seed and its log.
+##
 ## The two `_process` runs top up the last frame or two with `advance_frame()`,
 ## because a host slower than the hardware cannot land on every frame; the run is
 ## otherwise entirely theirs. They also feed `Gen2WorldClock` real seconds, which
@@ -29,6 +35,10 @@ const GAMES: Array[StringName] = [&"gold", &"silver", &"crystal"]
 ## Twenty seconds of hardware frames: long enough for several walks, a script
 ## and a wild roll, short enough that no run crosses a clock minute.
 const DEFAULT_FRAMES: int = 1200
+## What the battle route asks for instead. A fight costs its intro, an animation
+## per hit and the boxes on either side of each, and it has to be walked into
+## first; forty seconds is still inside the same clock minute.
+const BATTLE_FRAMES: int = 2400
 const DIRECTIONS: Array[int] = [
 	Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT
 ]
@@ -45,6 +55,13 @@ const MART_DOOR: Vector2i = Vector2i(3, 7)
 ## The counter cell the clerk is talked to across, which is `preview_world_story`'s
 ## own MART_CLERK_FACE: `CheckFacingObject` reaches two cells over a `$90`.
 const MART_COUNTER: Vector2i = Vector2i(3, 3)
+## How often the driver presses A inside a battle: the errand's own cadence, which
+## is slow enough that a box waiting for a press is not pressed twice.
+const BATTLE_PRESS_FRAMES: int = 8
+
+## A won battle writes the slot it was played from, so every run below is pointed
+## at a scratch root and the owner's own saves cannot be reached.
+const SAVE_ROOT: String = "user://replay_world_slots"
 
 var _failures: int = 0
 var _routes: int = 0
@@ -52,6 +69,19 @@ var _routes: int = 0
 
 func _initialize() -> void:
 	_sweep.call_deferred()
+
+
+func _clear_save_root() -> void:
+	if DirAccess.dir_exists_absolute(SAVE_ROOT):
+		var directory: DirAccess = DirAccess.open(SAVE_ROOT)
+		if directory != null:
+			for name: String in directory.get_directories():
+				var inner: DirAccess = DirAccess.open("%s/%s" % [SAVE_ROOT, name])
+				if inner != null:
+					for file: String in inner.get_files():
+						DirAccess.remove_absolute("%s/%s/%s" % [SAVE_ROOT, name, file])
+				DirAccess.remove_absolute("%s/%s" % [SAVE_ROOT, name])
+	DirAccess.make_dir_recursive_absolute(SAVE_ROOT)
 
 
 ## The screen's own nodes do not resolve until the tree has run a frame, so every
@@ -69,6 +99,9 @@ func _sweep() -> void:
 	if games.is_empty():
 		games = GAMES
 
+	Gen2SaveStore.use_root(SAVE_ROOT)
+	_clear_save_root()
+
 	for game: StringName in games:
 		var data: GameData = GameData.open(game)
 		if data == null:
@@ -77,6 +110,8 @@ func _sweep() -> void:
 		for route: Dictionary in _routes_for(data):
 			_failures += await _check_route(data, route, frames)
 
+	_clear_save_root()
+	Gen2SaveStore.use_root("")
 	print("%d routes, %d failures" % [_routes, _failures])
 	quit(1 if _failures > 0 else 0)
 
@@ -86,7 +121,11 @@ func _sweep() -> void:
 ## route list rather than one map, because a walk that never leaves an empty
 ## bedroom proves the pump on nothing.
 func _routes_for(data: GameData) -> Array:
-	var out: Array = [
+	var out: Array = []
+	var battle: Dictionary = _battle_route(data)
+	if not battle.is_empty():
+		out.append(battle)
+	out.append_array([
 		{"name": "new_game_spawn", "spawn": true},
 		{
 			"name": "mart_errand",
@@ -96,7 +135,7 @@ func _routes_for(data: GameData) -> Array:
 			"number": MART_MAP.y,
 			"cell": MART_DOOR,
 		},
-	]
+	])
 	for number: int in range(1, ROUTE_MAPS + 1):
 		var map: Gen2WorldMap = data.world_map(ROUTE_GROUP, number)
 		if map == null:
@@ -114,14 +153,58 @@ func _routes_for(data: GameData) -> Array:
 	return out
 
 
-func _check_route(data: GameData, route: Dictionary, frames: int) -> int:
+## The first map this cache holds with two adjacent cells a wild roll can fire
+## on, walked between. Found rather than named, because a map id is not the same
+## number on the three profiles and a grass cell is a `.blk` fact: the story
+## walker paid for both lessons already. Iterated in id order, so one cache always
+## answers with the same map.
+func _battle_route(data: GameData) -> Dictionary:
+	for map: Gen2WorldMap in data.world_maps():
+		if (data.world_encounter(
+			Gen2WorldEncounter.METHOD_GRASS, map.group, map.number
+		) as Dictionary).is_empty():
+			continue
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(data, map.group, map.number, Vector2i.ZERO)
+		if world == null:
+			continue
+		var cells: PackedVector2Array = world.visible_encounter_cells().get(
+			Gen2WorldEncounter.METHOD_GRASS, PackedVector2Array()
+		)
+		var grass: Dictionary = {}
+		for raw: Vector2 in cells:
+			grass[Vector2i(raw)] = true
+		for raw: Vector2 in cells:
+			var cell := Vector2i(raw)
+			# Up and down rather than any neighbour: the two directions a walk
+			# alternates below, so both of its steps land on grass.
+			if grass.has(cell + Vector2i(0, 1)):
+				return {
+					"name": "wild_battle",
+					"battle": true,
+					"frames": BATTLE_FRAMES,
+					"group": map.group,
+					"number": map.number,
+					"cell": cell,
+				}
+	return {}
+
+
+func _check_route(data: GameData, route: Dictionary, requested_frames: int) -> int:
 	_routes += 1
 	var failures: int = 0
+	## A route may ask for more than the sweep's own count, and the battle one
+	## does: a fight does not fit in a walk's twenty seconds.
+	var frames: int = maxi(requested_frames, int(route.get("frames", 0)))
 	var seed_value: int = _route_seed(data, route)
 	var errand: bool = bool(route.get("errand", false))
-	var program: Array = _program(seed_value, frames, errand)
+	var battle: bool = bool(route.get("battle", false))
+	## A battle route records what a driver decides frame by frame rather than
+	## replaying a precomputed program: how long the walk takes to roll an
+	## encounter is the seed's business, and a fixed program would either press A
+	## at the map or hold a direction inside the move menu.
+	var program: Array = [] if battle else _program(seed_value, frames, errand)
 
-	var recorded: Dictionary = await _run(data, route, seed_value, frames, program, true)
+	var recorded: Dictionary = await _run(data, route, seed_value, frames, program, true, 0.0, battle)
 	if not bool(recorded.get("ok", false)):
 		_report(data, route, "open", String(recorded.get("reason", "unavailable")))
 		return 1
@@ -138,6 +221,19 @@ func _check_route(data: GameData, route: Dictionary, frames: int) -> int:
 	## purchase was committed, which is the whole reason this route is here.
 	if errand and int(recorded["money"]) >= int(recorded["initial_money"]):
 		_report(data, route, "record", "the mart took no money, so no purchase was replayed")
+		return 1
+	## And a battle route that never met anything is a walk in the grass: the
+	## fought counter is what says the encounter fired, the fight was spent from
+	## the world's own pump and the party came back out of it.
+	if battle and int(recorded["battles"]) == 0:
+		_report(data, route, "record", "no wild battle started, so none was replayed")
+		return 1
+	## A fight that started and resolved nothing is an encounter box on screen, so
+	## it has to have reached an outcome. The party is deliberately not the test:
+	## a lost battle blacks out and heals it on the way, which can land back on the
+	## numbers it started with. Same reason the errand checks the till.
+	if battle and String(recorded["outcome"]).is_empty():
+		_report(data, route, "record", "the battle reached no outcome, so it proves nothing")
 		return 1
 
 	for label: String in ["replay", "30fps", "144fps"]:
@@ -159,8 +255,9 @@ func _check_route(data: GameData, route: Dictionary, frames: int) -> int:
 			_report(data, route, label, "the replay consumed a different log")
 			failures += 1
 			continue
-		print("%-8s %-16s %-7s %d frames, %d input entries" % [
-			data.id, route["name"], label, frames, log.size()
+		print("%-8s %-16s %-7s %d frames, %d input entries%s" % [
+			data.id, route["name"], label, frames, log.size(),
+			", %d battles" % int(run["battles"]) if int(run["battles"]) > 0 else "",
 		])
 	return failures
 
@@ -176,6 +273,7 @@ func _run(
 	log: Array,
 	recording: bool,
 	host_fps: float = 0.0,
+	adaptive: bool = false,
 ) -> Dictionary:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
@@ -214,10 +312,16 @@ func _run(
 
 	var initial: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
 	var initial_money: int = screen._world.state.money()
+
 	screen.replay_input(log)
 	if recording:
 		screen.record_input()
-	if host_fps <= 0.0:
+	var battles: int = 0
+	if adaptive:
+		battles = _drive(screen, frames)
+	elif host_fps <= 0.0:
+		screen.advance_frames(frames)
+	elif host_fps <= 0.0:
 		screen.advance_frames(frames)
 	else:
 		var delta: float = 1.0 / host_fps
@@ -226,18 +330,23 @@ func _run(
 			screen._process(delta)
 			guard -= 1
 		screen.advance_frames(frames - screen._world.frame_number)
+	if not adaptive:
+		battles = screen.battles_fought()
 
 	var state: String = _state(screen, save)
 	var world: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
 	var money: int = screen._world.state.money()
+	var outcome: String = String(screen.last_battle_outcome())
 	var consumed: Array = screen.input_recording()
 	root.remove_child(screen)
 	screen.free()
 	return {
 		"ok": true,
+		"battles": battles,
 		"state": state,
 		"initial": initial,
 		"initial_money": initial_money,
+		"outcome": outcome,
 		"money": money,
 		"world": world,
 		"log": log if not recording else consumed,
@@ -245,13 +354,82 @@ func _run(
 
 
 ## The compared artefact: the world snapshot the save would carry, the play timer
-## beside it and the frame both are read at.
+## beside it, the frame both are read at, and the party.
+##
+## The party is what a battle changes, the snapshot carrying none of it: HP, level,
+## experience, moves and PP are the whole outcome of a fight, so a route that
+## fights is only proved replayable by comparing them.
 func _state(screen: Gen2WorldScreen, save: Gen2SaveData) -> String:
 	return JSON.stringify({
 		"frame": screen._world.frame_number,
+		"battles": screen.battles_fought(),
+		"outcome": String(screen.last_battle_outcome()),
 		"game_time": save.game_time.to_dict(),
+		"party": _party(screen.active_save()),
 		"world": screen._world.snapshot().to_dict(),
 	}, "\t")
+
+
+## Every field of the party a fight can move, and nothing that would differ
+## between two runs for another reason.
+func _party(save: Gen2SaveData) -> Array:
+	var out: Array = []
+	if save == null:
+		return out
+	for raw: Variant in save.party:
+		if not raw is Gen2SaveMon:
+			continue
+		var mon: Gen2SaveMon = raw
+		out.append({
+			"species": mon.species, "level": mon.level, "hp": mon.hp, "exp": mon.exp,
+			"status": mon.status, "item": mon.item,
+			"moves": mon.moves.duplicate(), "pp": mon.pp.duplicate(),
+			"stat_exp": mon.stat_exp.duplicate(),
+		})
+	return out
+
+
+## Drives the run itself instead of replaying a program: hold a direction in the
+## grass until something appears, then press A on the mart errand's own cadence,
+## which is every button a wild battle asks for (FIGHT, the first move, and the
+## boxes on either side of it). Every press goes through the world's own
+## `press_button`, so the recording is what a replay is then fed.
+func _drive(screen: Gen2WorldScreen, frames: int) -> int:
+	var battles: int = 0
+	var in_battle: bool = false
+	var since_press: int = 0
+	var cursor_moved: int = 0
+	while screen._world.frame_number < frames:
+		if screen.battle_active():
+			if not in_battle:
+				in_battle = true
+				battles += 1
+				since_press = 0
+			since_press += 1
+			if since_press >= BATTLE_PRESS_FRAMES:
+				since_press = 0
+				## A is every button a wild battle asks for, except the one place
+				## it is refused: the list that asks which Pokemon replaces a
+				## fainted one opens on the fainted one itself, so the cursor has
+				## to move before the choice is taken.
+				var picking: bool = screen._battle_host._switch_stage == &"pick"
+				screen.press_button(
+					Gen2Button.DOWN if picking and cursor_moved % 2 == 0 else Gen2Button.A
+				)
+				if picking:
+					cursor_moved += 1
+		else:
+			in_battle = false
+			## Two cells, alternating, so every step lands on grass and the roll
+			## keeps being offered. A step is STEP_FRAMES_WALK long, and a
+			## direction held across it is one step.
+			@warning_ignore("integer_division")
+			var step: int = screen._world.frame_number / Gen2WorldAPI.STEP_FRAMES_WALK
+			screen.press_button(
+				Gen2Button.DOWN if step % 2 == 0 else Gen2Button.UP
+			)
+		screen.advance_frame()
+	return battles
 
 
 ## The input a run is driven by: a direction held for a while, an occasional A,


### PR DESCRIPTION
Four commits on one branch. `HANDOFF.md`'s "Seams still open" section is now empty.

## 1. Egg moves ([7083634](https://github.com/Decryptu/pokerecomp/commit/7083634))

`EggMovePointers` is 251 same-bank pointers. Each list is walked only to its own bank's end, so a missing terminator fails instead of collecting plausible data from the next section, and every byte in such a list is a valid move number, which makes the census the only thing that notices a pointer read one byte out of step.

| Profile | Pointer table | Moves | Species | Bulbasaur | Staryu |
|---|---|---|---|---|---|
| Gold, Silver | `0x239FE` | 478 | 106 | Light Screen, Skull Bash, Safeguard, Charm, Razor Wind, Petal Dance | Aurora Beam, Barrier, Supersonic |
| Crystal | `0x23B11` | 480 | 105 | the same without Charm | none |

`GameData.egg_moves()` reads them off the species row the way the learnset is read. `dump_tables.gd <game> egg_moves` reads the names against the published lists, which is the only check a table with no self-checking shape can have. Cache format 67.

## 2. Mod content ([7083634](https://github.com/Decryptu/pokerecomp/commit/7083634))

Types are content, numbered from zero the way the cartridge's chart is, each carrying `physical`. Matchups are patched by their pair, both halves of the key staying whole so a mod type cannot alias a cartridge pair. A defined species or trainer class supplies decoded indices rather than an atlas cell it has no slot in, answered in `species_pic`'s own shape and cropped by `Gen2PicImage.atlas_cell`. `export_bytes` refuses a save carrying mod content rather than truncating a species into a different Pokemon in a real cartridge. `register_event_mutator` is the event channel's other half, exclusive per channel and unable to change the key a screen dispatches on. Registered mod settings became per-run. api_version 4.

## 3. A run's own rules ([cb48e01](https://github.com/Decryptu/pokerecomp/commit/cb48e01))

`Gen2Rules` is what the divergence table becomes. Each flag is named for the HARDWARE's behaviour, so off is this project's corrected answer; three modes sit over them (`current` = what shipped, `vanilla`, `qol`) with per-flag overrides.

| Flag | Source | Default |
|---|---|---|
| `belly_drum_boosts_below_half_hp` | `BattleCommand_AttackUp2` runs before the HP check | off |
| `medium_slow_level_one_underflow` | `CalcExpAtLevel` has no level 1 branch | off |
| `cautious_ai_abandons_remaining_moves` | `AI_Cautious`'s `ret nc` | off |
| `short_hp_bar_number_off_by_one` | `ShortHPBar_CalcPixelFrame`'s loop | off |
| `metal_powder_overflow` | `DittoMetalPowder` past `TruncateHL_BC` | **on**, always reproduced here |

Difficulty rewrites which of a trainer class's own AI layers score rather than inventing a level or a stat. The rules belong to the run (`run_rules`), the settings screen edits the installation's, and a slot written before the block adopts it once. api_version 5.

## 4. A battle inside a replay ([00fce42](https://github.com/Decryptu/pokerecomp/commit/00fce42))

A fight is part of the walk rather than a screen beside it: its frames come from the world's pump, its buttons through the world's funnel, its generator from the world's own, and it starts on the frame the encounter fired rather than the deferred call after it. `replay_world.gd` gains a route that fights, on a map found rather than named (the first with two adjacent cells a wild roll can fire on). **Three battles per cartridge, fought to their outcomes, byte identical at 30 and 144 fps as well as frame by frame.**

Two deadlocks fixed on the way, both invisible in normal play:

- `ANIM_WAIT_SFX` waited on `effect_playing()`, which only changes while the audio driver is serviced — headless, every battle animation carrying a `wait_sfx` hung for the rest of the run. `Gen2AudioPlayer.timeline_updates()` is the rendered-frame count that tells the two apart; `AudioStreamPlayer.playing` is not, the dummy driver reporting true and consuming nothing.
- `Gen2TextBox` revealed on real time alone, so a driven message never finished printing and a press completed the page forever instead of acknowledging it.

`Gen2SaveStore.use_root()` exists because a won battle writes the slot it was played from, so a check driving one must not be able to reach the owner's saves.

## Proof

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3,161 tests over 151 scripts, green (was 3,116) |
| `validate.gd -- all` | 53 topics, all three real caches, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures, 3 battles per cartridge |
| Story walk, three profiles | Red reached: 292, 292, 295 steps, 16 badges |
| Boot smoke, with and without mods | clean |