### PR TITLE
Give the service overlay its own menu_coords boxes

### DIFF
--- a/game/render/world_service_page.gd
+++ b/game/render/world_service_page.gd
@@ -17,23 +17,17 @@ static func from_data(data: GameData) -> Gen2WorldServicePage:
 	return out if out.font != null and out.menu != null else null
 
 
-## `MenuTextbox` over the map. PC owns the screen, while script menus leave the
-## map visible around their box.
+## `MenuTextbox` over the map: every box here carries `MENU_BACKUP_TILES`, so
+## the map stays visible around it and nothing here fills the screen white.
+## The caller supplies its own `menu_coords` box; an empty [param rows] draws
+## no box at all, which is what a plain `MenuTextbox` print is.
 func render(title: String, prompt: String, rows: Array, cursor: int,
-		message: String = "", full_screen: bool = false) -> Image:
+		message: String = "", box: Gen2MenuBox = null) -> Image:
 	var image := Image.create_empty(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
-	if full_screen:
-		image.fill(Color.WHITE)
-	var count: int = maxi(rows.size(), 1)
-	var bottom: int = mini(17, 1 + count * 2)
-	var box := Gen2MenuBox.from_coords(
-		0 if full_screen else 9, 0, 19, bottom,
-		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
-	)
-	var labels: Array = rows if not rows.is_empty() else [""]
-	_blit(image, menu.render(box, labels, cursor), box.border_position())
+	if not rows.is_empty() and box != null:
+		_blit(image, menu.render(box, rows, cursor), box.border_position())
 	var words: String = message if not message.is_empty() else prompt
 	if words.is_empty():
 		words = title

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -107,8 +107,16 @@ func _render() -> void:
 	))
 
 
+## `PrintHour` prints `GetTimeOfDayString`'s own MORN/DAY/NITE ahead of the
+## hour, not AM/PM: `constants/misc_constants.asm`'s `MORN_HOUR`/`DAY_HOUR`/
+## `NITE_HOUR` are 4, 10 and 18, so midnight through 3 is still NITE.
 func _hour_text() -> String:
 	var shown: int = _hour % 12
 	if shown == 0:
 		shown = 12
-	return "%d %s" % [shown, "AM" if _hour < 12 else "PM"]
+	var word: String = "NITE"
+	if _hour >= 4 and _hour < 10:
+		word = "MORN"
+	elif _hour >= 10 and _hour < 18:
+		word = "DAY"
+	return "%s %d" % [word, shown]

--- a/game/world/world_menu.gd
+++ b/game/world/world_menu.gd
@@ -10,12 +10,30 @@ extends RefCounted
 const STATICMENU_ENABLE_LEFT_RIGHT: int = Gen2MenuBox.STATICMENU_ENABLE_LEFT_RIGHT
 const STATICMENU_WRAP: int = Gen2MenuBox.STATICMENU_WRAP
 
+## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
+## the five-wide, four-tall box at (14,7). A `choice` pending value carries no
+## `loadmenu` header, since `Script_yesorno` never loads one, so this is the
+## box every such prompt falls back to.
+const YES_NO_LEFT: int = 14
+const YES_NO_TOP: int = 7
+const YES_NO_RIGHT: int = 19
+const YES_NO_BOTTOM: int = 11
+
 var kind: StringName = &"vertical"
 var options: Array = []
 var flags: int = 0
 var rows: int = 0
 var columns: int = 1
 var cursor: int = 0
+## `menu_coords x1, y1, x2, y2`, imported off the `LoadMenuHeader` a scripted
+## `verticalmenu`/`2dmenu` reads. [const YES_NO_LEFT] and its three siblings
+## when there is no such header.
+var box_left: int = YES_NO_LEFT
+var box_top: int = YES_NO_TOP
+var box_right: int = YES_NO_RIGHT
+var box_bottom: int = YES_NO_BOTTOM
+## `Place2DMenuItemStrings`' own column spacing, a `2d` menu's `db spacing`.
+var _spacing: int = 0
 
 
 static func from_input(input: Dictionary) -> Gen2WorldMenu:
@@ -31,9 +49,26 @@ static func from_input(input: Dictionary) -> Gen2WorldMenu:
 	if menu.kind == &"2d":
 		menu.rows = maxi(1, int(header.get("rows", menu.rows)))
 		menu.columns = maxi(1, int(header.get("columns", menu.columns)))
+		menu._spacing = int(header.get("spacing", 0))
 	var default_position: int = int(header.get("default", 1)) - 1
 	menu.cursor = menu._clamp_position(default_position)
+	menu.box_left = int(header.get("left", YES_NO_LEFT))
+	menu.box_top = int(header.get("top", YES_NO_TOP))
+	menu.box_right = int(header.get("right", YES_NO_RIGHT))
+	menu.box_bottom = int(header.get("bottom", YES_NO_BOTTOM))
 	return menu
+
+
+## The box the source's own `menu_coords` puts this menu in, for a renderer
+## that draws it over the map the way `MenuBox` does. `Place2DMenuItemStrings`'
+## own column count and spacing carry over for a `2d` menu; every list menu
+## here is one column with no spacing.
+func box() -> Gen2MenuBox:
+	var out := Gen2MenuBox.from_coords(box_left, box_top, box_right, box_bottom, flags)
+	if kind == &"2d":
+		out.columns = maxi(1, columns)
+		out.column_spacing = _spacing
+	return out
 
 
 func move(direction: Vector2i) -> bool:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -1433,6 +1433,8 @@ func _render_options(override: Array = []) -> void:
 	_render_service_page(values)
 
 
+## `PhoneCall`'s ringing box and `PC_DisplayText`'s plain `MenuTextbox` print
+## neither one, so those two draw no rows at all here.
 func _render_service_page(values: Array) -> void:
 	if _service_view == null or _data == null:
 		return
@@ -1440,8 +1442,9 @@ func _render_service_page(values: Array) -> void:
 		_service_page = Gen2WorldServicePage.from_data(_data)
 	if _service_page == null:
 		return
+	var page_rows: Array = [] if _mode in [MODE.PHONE, MODE.PC_TEXT, MODE.AUDIO] else values
 	var labels: Array = []
-	for value: Variant in values:
+	for value: Variant in page_rows:
 		if value is Dictionary:
 			var row: Dictionary = value
 			var label: String = String(row.get("name", row.get("caller_label", "")))
@@ -1450,13 +1453,65 @@ func _render_service_page(values: Array) -> void:
 			labels.append(label)
 		else:
 			labels.append(String(value))
-	var full_screen: bool = _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_ITEM_LIST, MODE.PC_TEXT]
 	var image: Image = _service_page.render(
-		_title.text, _summary.text, labels, _cursor, _status.text, full_screen
+		_title.text, _summary.text, labels, _cursor, _status.text, _service_box()
 	)
 	if image != null:
 		_service_view.texture = ImageTexture.create_from_image(image)
 		_service_hardware.visible = true
+
+
+## The `menu_coords` box this mode's own list sits in. `null` draws no box,
+## which is what MODE.MENU falls back to before a menu is loaded.
+func _service_box() -> Gen2MenuBox:
+	match _mode:
+		MODE.MENU:
+			return _menu.box() if _menu != null else null
+		MODE.PC, MODE.PC_ITEMS:
+			return _pc_top_box()
+		MODE.PC_ITEM_LIST:
+			return _pc_item_list_box()
+		MODE.APRICORN:
+			return _apricorn_quantity_box() if _apricorns != null \
+				and _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY \
+				else _apricorn_select_box()
+		MODE.POKEGEAR, MODE.AUDIO:
+			return _dynamic_box(_option_count())
+	return null
+
+
+## `PokemonCenterPC.TopMenu` and `PlayersPCMenuData` share this `menu_coords`.
+func _pc_top_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		0, 0, 15, 12, Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
+	)
+
+
+## `PCItemsMenuData`'s `menu_coords 4, 1, 18, 10`.
+func _pc_item_list_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(4, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
+
+
+## `Kurt_SelectApricorn.MenuHeader`'s `menu_coords 1, 1, 13, 10`.
+func _apricorn_select_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(1, 1, 13, 10, Gen2MenuBox.STATICMENU_CURSOR)
+
+
+## `Kurt_SelectQuantity.MenuHeader`'s `menu_coords 6, 9, SCREEN_WIDTH - 1, 12`.
+## `PlaceApricornQuantity` writes the name and quantity by hand rather than
+## through a `STATICMENU_CURSOR` list, so this box draws no cursor.
+func _apricorn_quantity_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(6, 9, 19, 12, 0)
+
+
+## The list box every mode above still leaves to the panel: POKEGEAR's card
+## list, which `HANDOFF.md` already records as staying a panel, and AUDIO,
+## which is a debug host with no cartridge screen of its own.
+func _dynamic_box(count: int) -> Gen2MenuBox:
+	var bottom: int = mini(17, 1 + maxi(count, 1) * 2)
+	return Gen2MenuBox.from_coords(
+		9, 0, 19, bottom, Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
+	)
 
 
 func _option_count() -> int:

--- a/tests/unit/test_world_menu.gd
+++ b/tests/unit/test_world_menu.gd
@@ -56,3 +56,45 @@ func test_two_dimensional_menu_does_not_select_a_missing_cell() -> void:
 	assert_eq(menu.selected_index(), 2)
 	assert_false(menu.move(Vector2i.RIGHT))
 	assert_eq(menu.selected_index(), 2)
+
+
+## `Script_yesorno` loads no `LoadMenuHeader`, so a `choice` header is empty and
+## the box falls back to `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`.
+func test_choice_with_no_header_falls_back_to_the_yes_no_box() -> void:
+	var menu: Gen2WorldMenu = Gen2WorldMenu.from_input({
+		"menu_kind": &"vertical", "header": {}, "choices": [&"yes", &"no"],
+	})
+	var box: Gen2MenuBox = menu.box()
+	assert_eq(box.left, 14)
+	assert_eq(box.top, 7)
+	assert_eq(box.right, 19)
+	assert_eq(box.bottom, 11)
+
+
+## `LoadMenuHeader`'s own `menu_coords`, carried through the importer's
+## top/left/bottom/right and into the box a scripted `verticalmenu` draws.
+func test_vertical_menu_carries_its_own_menu_coords() -> void:
+	var menu: Gen2WorldMenu = Gen2WorldMenu.from_input({
+		"menu_kind": &"vertical",
+		"header": {"data_flags": 1 << 7, "left": 1, "top": 1, "right": 13, "bottom": 10},
+		"options": ["A", "B"],
+	})
+	var box: Gen2MenuBox = menu.box()
+	assert_eq(box.left, 1)
+	assert_eq(box.top, 1)
+	assert_eq(box.right, 13)
+	assert_eq(box.bottom, 10)
+	assert_eq(box.flags, 1 << 7)
+
+
+## `Place2DMenuItemStrings`' column count and spacing carry into the box so a
+## `2d` menu's items land where the grid puts them, not one under another.
+func test_two_dimensional_menu_carries_columns_and_spacing_into_its_box() -> void:
+	var menu: Gen2WorldMenu = Gen2WorldMenu.from_input({
+		"menu_kind": &"2d",
+		"header": {"rows": 2, "columns": 3, "spacing": 5, "default": 1},
+		"options": ["A", "B", "C", "D", "E", "F"],
+	})
+	var box: Gen2MenuBox = menu.box()
+	assert_eq(box.columns, 3)
+	assert_eq(box.column_spacing, 5)

--- a/tests/unit/test_world_service_page.gd
+++ b/tests/unit/test_world_service_page.gd
@@ -1,0 +1,56 @@
+extends GutTest
+
+## `MenuTextbox` over the map: the caller's own `menu_coords` box and its
+## `MenuTextbox`-shaped message strip, against a synthetic cache.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const TILE: int = Gen2Font.TILE
+
+var _page: Gen2WorldServicePage = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_page = Gen2WorldServicePage.from_data(GameData.open_directory(Fixture.directory()))
+
+
+func after_each() -> void:
+	RomCache.clear(Fixture.directory())
+
+
+## The page draws onto a transparent buffer and only `blit_rect`s the boxes it
+## actually places, so a tile with nothing on it stays fully transparent.
+func _ink(image: Image, tile: Vector2i) -> bool:
+	for row: int in TILE:
+		for column: int in TILE:
+			if image.get_pixel(tile.x * TILE + column, tile.y * TILE + row).a > 0.0:
+				return true
+	return false
+
+
+## `MENU_BACKUP_TILES` keeps the map behind the box; nothing here fills the
+## screen white the way the old `full_screen` flag did.
+func test_no_box_leaves_the_map_area_untouched() -> void:
+	var image: Image = _page.render("PC", "", [], -1, "")
+	assert_eq(image.get_size(), Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT))
+	assert_false(_ink(image, Vector2i(0, 0)), "no rows and no message draws nothing")
+
+
+## `PokemonCenterPC.TopMenu`'s own `menu_coords 0, 0, 15, 12`: the frame's
+## corner is drawn there and nothing spills into the four columns the source
+## leaves for the map.
+func test_a_row_box_draws_at_the_coords_it_is_given() -> void:
+	var box := Gen2MenuBox.from_coords(0, 0, 15, 12, Gen2MenuBox.STATICMENU_CURSOR)
+	var image: Image = _page.render("", "", ["BILL's PC"], 0, "", box)
+	assert_true(_ink(image, Vector2i(0, 0)), "the box's own corner is drawn")
+	assert_false(_ink(image, Vector2i(16, 0)), "nothing right of the source's own box")
+	assert_false(_ink(image, Vector2i(0, 13)), "nothing below the source's own box")
+
+
+## A `message` (or a `prompt` behind it) always draws `MenuTextbox`'s own
+## bottom strip at rows 12 to 17, whether or not a row box is also up.
+func test_the_message_draws_menu_textboxs_own_bottom_strip() -> void:
+	var image: Image = _page.render("PC", "", [], -1, "Welcome.")
+	assert_true(_ink(image, Vector2i(1, 13)), "the bottom strip prints inside its frame")
+	assert_false(_ink(image, Vector2i(1, 11)), "and nothing above row 12")

--- a/tests/unit/test_world_service_page.gd.uid
+++ b/tests/unit/test_world_service_page.gd.uid
@@ -1,0 +1,1 @@
+uid://da1hqn4tn2uqb


### PR DESCRIPTION
## Summary
- `Gen2WorldServicePage` drew one dynamic box for every mode; it now draws each mode's real `menu_coords` box, sourced from what the importer already decodes (a scripted menu's own header) or from the fixed boxes pret uses for the PC and the apricorn selector.
- `MENU_BACKUP_TILES` keeps the map visible behind the PC screens; the invented full white fill is gone, and the PHONE/PC-text option row that had no cartridge counterpart no longer draws.
- Fixed `Gen2ClockSetScreen`'s hour text: the source prints MORN/DAY/NITE ahead of the hour, not AM/PM.

## Test plan
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd -gexit` (unit tier)
- [x] `godot --headless -s res://addons/gut/gut_cmdln.gd -gdir=res://tests -ginclude_subdirs -gexit` (full tier, 3167/3167)
- [x] `godot --headless --path . -s res://tools/validate.gd -- all` (53/53 topics)
- [x] `godot --headless --path . -s res://tools/replay_world.gd -- crystal` (11 routes, 0 failures)
- [x] `godot --headless --path . -s res://tools/preview_world_story.gd -- crystal 24 7 2 2 1 none home story` (reaches Red)
- [x] Visual check via `tools/preview_world_services.gd` (`pc`, `apricorn`, `oak_pc` kinds) against the real box positions