### PR TITLE
Update README status and drop dead godot-mod-loader note

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > Silver: every Johto badge with the errand behind it, then Kanto, all sixteen
 > badges, the Hall of Fame with Prof Oak's rating, and the credits.
 >
-> Missing: full story state, the Unown dex, and the remaining special-call
-> branches and story-driven contacts.
+> Missing: link play, item mail and Mystery Gift, the Battle Tower, and a
+> handful of pixel-level divergences still being chased in the opening movies
+> and title screen against a real cartridge.
 
 ## Getting started
 

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1189,6 +1189,3 @@ though a mod species that replaces a cartridge one does carry its own dex entry.
 Mod content cannot leave the project's own save either: every species, item and
 move on the hardware is one byte, so `Gen2SramAdapter` refuses to export a save
 carrying any of it rather than truncating a number into a different Pokemon.
-Evaluate
-[godot-mod-loader](https://github.com/GodotModding/godot-mod-loader) before
-expanding the loader itself.


### PR DESCRIPTION
## Summary
- The README's "Missing" line was describing a state from before the Unown dex and the full story walk to Red/credits landed; replaced with what's actually still absent (link play, item mail, Mystery Gift, the Battle Tower, and the opening's known pixel-level divergences).
- Dropped the `godot-mod-loader` evaluation note from `docs/MODS.md`: the library has had no update this year and the project's own mod loader already works standalone.

## Test plan
Docs only, no code changed.