### PR TITLE
Copy a battle's save write back over the live save

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2127,6 +2127,10 @@ func _save_battle_result() -> bool:
 				"message": result.get("message", ""),
 			})
 		return false
+	# from_battle_party() returns a clone; without this, the fought party's HP,
+	# experience and PP reach disk but never the live save the world screen and
+	# the next battle read, so both keep showing the pre-battle party.
+	Gen2WorldTransaction.copy_into(_source_save, save)
 	_save_written = true
 	return true
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2099,13 +2099,36 @@ func advance() -> void:
 	_open_battle_menu()
 
 
+## The fought party over the live save, with nothing written to disk.
+##
+## A ball is thrown mid-battle and the catch is its own transaction, which
+## builds its candidate from the live save; without this the party that reaches
+## the candidate is the pre-battle one, so the HP and PP spent weakening the
+## wild are given back the moment it is caught.
+func sync_live_party() -> bool:
+	if _source_save == null or _battle == null or _data == null:
+		return false
+	var fought: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
+		_data.id, _data.sha1, _source_save.slot, _battle.party(Gen2Battle.PLAYER),
+		"", _source_save
+	)
+	if fought == null:
+		return false
+	_source_save.party = fought.party
+	return true
+
+
 ## Writes back only after every event from a finished battle has been shown.
 ## Saving during a resolved turn would capture battle state the player has not
 ## seen yet, while the persistent save model intentionally has no such state.
 func _save_battle_result() -> bool:
 	if _save_slot < 0 or _save_written or _battle == null:
 		return true
-	if _battle.winner() != Gen2Battle.PLAYER:
+	## `wPartyMon` holds the fighting copy on the cartridge, so damage taken and
+	## PP spent belong to the party whatever ended the battle: a run keeps them
+	## the same way a win does. A loss is the one exception, since the blackout
+	## puts the pre-battle party back rather than keeping the fought one.
+	if _battle.winner() != Gen2Battle.PLAYER and not _battle.has_fled():
 		return true
 	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
 		_data.id, _data.sha1, _save_slot, _battle.party(Gen2Battle.PLAYER), "", _source_save

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2078,6 +2078,10 @@ func _on_capture_requested(ball: int) -> void:
 			save.world = _world.snapshot()
 		_active_battle_save = save
 		_active_battle_persist = false
+	## The ball is thrown from a party that has already fought: the catch's own
+	## candidate is built from this save, so the fought HP and PP have to be on
+	## it before the transaction opens.
+	_battle_host.sync_live_party()
 	var target: Gen2BattleMon = _battle_host.capture_target()
 	## A contest throw is its own transaction: the ball is the contest's, the
 	## catch goes to wContestMon and no save is touched.

--- a/game/world/world_transaction.gd
+++ b/game/world/world_transaction.gd
@@ -90,9 +90,21 @@ static func copy_into(target: Gen2SaveData, source: Gen2SaveData) -> void:
 	target.rom_sha1 = source.rom_sha1
 	target.slot = source.slot
 	target.player_name = source.player_name
+	target.player_id = source.player_id
+	target.gender = source.gender
+	target.label = source.label
 	target.party = source.party.duplicate(true)
 	target.boxes = source.boxes
 	target.world = source.world
+	target.mods = source.mods.duplicate(true)
+	target.run_seed = source.run_seed
+	target.run_mods = source.run_mods.duplicate(true)
+	target.run_options = source.run_options.duplicate(true)
+	target.run_rules = source.run_rules.duplicate_rules() if source.run_rules != null else null
+	target.boxes_shape_valid = source.boxes_shape_valid
+	## `game_time` is the one field the live save owns rather than the candidate:
+	## `Gen2WorldScreen._advance_game_time_frame` has been counting frames into it
+	## since the candidate was cloned, and copying the clone back loses them.
 
 
 static func failure(reason: StringName, details: Dictionary) -> Dictionary:

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -699,6 +699,64 @@ func test_a_trainer_battle_fights_and_writes_back_with_an_egg_in_the_party() -> 
 	assert_eq((written.party[1] as Gen2SaveMon).nickname, "EGG")
 
 
+## Regression: `Gen2SaveBattleAdapter.from_battle_party` returns a clone, and
+## `_save_battle_result` used to write that clone to disk without copying it
+## back over `_source_save`, the live save the world screen and the next
+## battle both read. A won battle's HP, experience and PP reverted the moment
+## a second battle started.
+func test_hp_experience_and_pp_survive_into_the_next_wild_battle() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var starting_pp: int = (save.party[0] as Gen2SaveMon).pp[0]
+
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_eq(host.battle_snapshot()["message"], "Wild %s appeared!" % _wild_name())
+	host.finish()
+	host.advance()
+
+	var player_mon: Gen2BattleMon = host._battle.party(Gen2Battle.PLAYER).mons[0]
+	var max_hp: int = player_mon.max_hp()
+	player_mon.take_damage(1)
+	player_mon.pp[0] -= 1
+
+	for _hit: int in 20:
+		host.hurt_enemy()
+	## A wild victory carries no win text on the cartridge, unlike a trainer's
+	## (`_show_world_battle_terminal_text` finds no `win_text` pointer in the
+	## wild request and returns false), so the overlay closes silently rather
+	## than pausing on a "YOU WON." message the way the trainer tests wait for.
+	var guard: int = 10
+	while _battle_child() != null and guard > 0:
+		host.finish()
+		host.advance()
+		guard -= 1
+	await get_tree().process_frame
+	assert_null(_battle_child())
+
+	var after_first: Gen2SaveMon = save.party[0] as Gen2SaveMon
+	assert_true(after_first.exp > 0, "a win must award experience into the live save")
+	assert_true(after_first.hp < max_hp, "the live save must carry the damage taken")
+	assert_eq(after_first.pp[0], starting_pp - 1, "the live save must carry the PP spent")
+
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var second_host: Gen2BattleScreen = _battle_host()
+	assert_not_null(second_host)
+	var second_player: Gen2BattleMon = second_host._battle.party(Gen2Battle.PLAYER).mons[0]
+	assert_eq(second_player.hp, after_first.hp, "the next battle must start from the carried HP")
+	assert_eq(
+		second_player.exp, after_first.exp, "the next battle must start from the carried experience"
+	)
+	assert_eq(
+		second_player.pp[0], after_first.pp[0], "the next battle must start from the carried PP"
+	)
+
+
 func _event_value(events: Array, event_type: StringName, key: String) -> Variant:
 	for event: Dictionary in events:
 		if event.get("type", &"") == event_type:

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -757,6 +757,85 @@ func test_hp_experience_and_pp_survive_into_the_next_wild_battle() -> void:
 	)
 
 
+## `wPartyMon` is the fighting copy, so a run keeps the damage taken and the PP
+## spent exactly as a win does; only a blackout puts the pre-battle party back.
+## `_save_battle_result` used to refuse every battle the player did not win, so
+## a wild encounter walked away from cost nothing.
+func test_running_away_keeps_the_damage_taken_and_the_pp_spent() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var starting_pp: int = (save.party[0] as Gen2SaveMon).pp[0]
+	var starting_hp: int = (save.party[0] as Gen2SaveMon).hp
+
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	host.finish()
+	host.advance()
+
+	var player_mon: Gen2BattleMon = host._battle.party(Gen2Battle.PLAYER).mons[0]
+	player_mon.take_damage(3)
+	player_mon.pp[0] -= 1
+
+	host.run_from_battle()
+	assert_true(host._battle.has_fled())
+	var guard: int = 10
+	while _battle_child() != null and guard > 0:
+		host.finish()
+		host.advance()
+		guard -= 1
+	await get_tree().process_frame
+	assert_null(_battle_child())
+
+	var after: Gen2SaveMon = save.party[0] as Gen2SaveMon
+	assert_eq(after.hp, starting_hp - 3, "the live save must carry the damage taken")
+	assert_eq(after.pp[0], starting_pp - 1, "the live save must carry the PP spent")
+
+
+## The catch is its own transaction and builds its candidate from the live save,
+## so the party that fought the wild down has to reach that save before the ball
+## is thrown; otherwise catching gives the HP and PP back.
+func test_a_capture_keeps_the_damage_taken_and_the_pp_spent() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var starting_pp: int = (save.party[0] as Gen2SaveMon).pp[0]
+	var starting_hp: int = (save.party[0] as Gen2SaveMon).hp
+	var added: Dictionary = _world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	)
+	assert_true(added["ok"])
+
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	host.finish()
+	host.advance()
+
+	var player_mon: Gen2BattleMon = host._battle.party(Gen2Battle.PLAYER).mons[0]
+	player_mon.take_damage(3)
+	player_mon.pp[0] -= 1
+
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.select_capture_ball(1)["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	var guard: int = 12
+	while _battle_child() != null and guard > 0:
+		host.finish()
+		host.advance()
+		guard -= 1
+	await get_tree().process_frame
+	assert_null(_battle_child())
+	assert_eq(_world_screen.world_snapshot()["script_prompt"], "Caught %s" % _wild_name())
+
+	var after: Gen2SaveMon = save.party[0] as Gen2SaveMon
+	assert_eq(after.hp, starting_hp - 3, "the caught save must carry the damage taken")
+	assert_eq(after.pp[0], starting_pp - 1, "the caught save must carry the PP spent")
+
+
 func _event_value(events: Array, event_type: StringName, key: String) -> Variant:
 	for event: Dictionary in events:
 		if event.get("type", &"") == event_type:

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -296,6 +296,41 @@ func test_the_runs_rules_round_trip_and_are_absent_when_never_recorded() -> void
 	assert_eq(save.run_rules.difficulty, Gen2Rules.DIFFICULTY_HARD)
 
 
+## `Gen2WorldTransaction.copy_into` is the write-back every world-owned commit
+## and the battle save both end on, and it names its fields one by one: a field
+## added to the save and forgotten here reaches disk and never the live save,
+## which is what made a won battle revert. Compared through `to_dict`, so a new
+## field fails this rather than nothing.
+func test_the_transaction_write_back_carries_every_field_but_the_live_clock() -> void:
+	var live: Gen2SaveData = _save()
+	var candidate: Gen2SaveData = _save()
+	candidate.player_name = "AFTER"
+	candidate.player_id = 0x4321
+	candidate.gender = 1
+	candidate.label = "committed"
+	candidate.slot = live.slot + 1
+	candidate.mods = {"probe": {"kept": true}}
+	candidate.run_seed = 99
+	candidate.run_mods = ["probe"]
+	candidate.run_options = {"probe": {"level": 2}}
+	var rules := Gen2Rules.new()
+	rules.difficulty = Gen2Rules.DIFFICULTY_HARD
+	candidate.run_rules = rules
+	live.game_time.frames = 12
+
+	Gen2WorldTransaction.copy_into(live, candidate)
+
+	var written: Dictionary = live.to_dict()
+	var expected: Dictionary = candidate.to_dict()
+	written.erase("game_time")
+	expected.erase("game_time")
+	assert_eq(written, expected)
+	assert_eq(live.game_time.frames, 12, "the frames counted since the clone are the live save's")
+	# Its own objects, so the discarded candidate cannot be edited through it.
+	live.run_rules.difficulty = Gen2Rules.DIFFICULTY_EASY
+	assert_eq(candidate.run_rules.difficulty, Gen2Rules.DIFFICULTY_HARD)
+
+
 ## A slot written before the block existed says so rather than claiming frame
 ## zero of a seeded run.
 func test_a_save_without_a_run_block_records_no_seed() -> void:


### PR DESCRIPTION
## Summary
- A won battle's HP/experience/PP reached disk but not the live save the world screen and the next battle read, so both showed the pre-battle party until a relaunch reloaded the file from disk.
- `Gen2BattleScreen._save_battle_result` now copies its write back over `_source_save` with `Gen2WorldTransaction.copy_into`, the same call every other world-owned write already makes.

## Test plan
- [x] `test_hp_experience_and_pp_survive_into_the_next_wild_battle` (new): fights a wild battle to a win, asserts the live save carries HP/exp/PP, then starts a second battle and asserts it reads the carried values.
- [x] Full suite green: 3,168/3,168.
- [x] Not yet confirmed on an actual playthrough, flagged for a second look before trusting it.