### PR TITLE
Stop internal keys and unmapped glyphs reaching the screen

### DIFF
--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -64,6 +64,14 @@ const UNKNOWN: int = 0xE6
 const POKE_SHORTHAND: String = "#"
 const POKE_WORD: String = "POK\u00e9"
 
+## The same two codes spelled the other way pret spells them. A caller writing
+## `<POKE>` or `<PKMN>` means the charmap entry, not six literal characters, and
+## without this each angle bracket encodes as UNKNOWN and prints "?".
+const WORD_SPELLINGS: Dictionary = {
+	"<POKE>": POKE_WORD,
+	"<PKMN>": "PKMN",
+}
+
 ## The longest sequence one tile stands for: the apostrophe ligatures and PK/MN
 ## are two characters in one glyph. The word codes $54 ("POKé") and $4a ("PKMN")
 ## sit below FIRST_PRINTABLE and are decode-only; write "#" for $54 as the source
@@ -142,6 +150,8 @@ static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArra
 	# characters, so the source's own "#" is four tiles and not one. Expanding
 	# here is what puts POKé on screen: $54 is no glyph and would draw a blank.
 	var expanded: String = text.replace(POKE_SHORTHAND, POKE_WORD)
+	for spelling: String in WORD_SPELLINGS:
+		expanded = expanded.replace(spelling, WORD_SPELLINGS[spelling])
 
 	while at < expanded.length():
 		var taken: int = 0

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -236,6 +236,18 @@ func first_empty_box_slot() -> Dictionary:
 	return {"ok": false, "reason": &"storage_full"}
 
 
+## `_GetVarAction`'s `.BoxFreeSpace`, which is `MONS_PER_BOX - [sBoxCount]`. The
+## save model keeps no current-box pointer, so the box a deposit would land in is
+## the one [method first_empty_box_slot] picks; a full storage answers 0, which is
+## the same refusal the source's zero gives every script that reads the var.
+func box_free_space() -> int:
+	var destination: Dictionary = first_empty_box_slot()
+	if not bool(destination.get("ok", false)):
+		return 0
+	var box: Gen2SaveBox = boxes[int(destination["box"])]
+	return Gen2SaveBox.CAPACITY - box.occupied_count()
+
+
 func add_party_or_box(mon: Gen2SaveMon) -> Dictionary:
 	if mon == null:
 		return {"ok": false, "reason": &"missing_pokemon"}

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -1,12 +1,18 @@
 class_name Gen2ClockSetScreen
 extends Control
 
-## `InitClock` followed by `SetDayOfWeek`, before Oak's first speech beat.
+## `InitClock`, before Oak's first speech beat. Hour and minutes only: the
+## routine ends on `OakText_ResponseToSetTime` after `.MinutesAreSet` and never
+## calls `SetDayOfWeek`, which is Mom's own errand in `PlayersHouse1F.asm`. The
+## weekday the save starts on is whatever the RTC holds, SUNDAY on a fresh one.
 
 signal finished(day: int, hour: int, minute: int)
 
-enum Phase { HOUR, HOUR_CONFIRM, MINUTE, MINUTE_CONFIRM, DAY, DAY_CONFIRM, DONE }
+enum Phase { HOUR, HOUR_CONFIRM, MINUTE, MINUTE_CONFIRM, DONE }
 
+## `SetDayOfWeek`'s own `.WeekdayStrings`, padded the way the source pads them so
+## the name is centred in its nine-wide box. Drawn by Mom's errand rather than
+## here; this is where the strings live because the dial page is shared.
 const DAYS: Array[String] = [
 	" SUNDAY", " MONDAY", " TUESDAY", "WEDNESDAY", "THURSDAY", " FRIDAY", "SATURDAY",
 ]
@@ -16,6 +22,8 @@ var _view: TextureRect = null
 var _phase: int = Phase.HOUR
 var _hour: int = 10
 var _minute: int = 0
+## `InitTimeOfDay` leaves the RTC's own weekday alone, so a new save starts on
+## SUNDAY and Mom's `SetDayOfWeek` is what changes it.
 var _day: int = 0
 var _confirm_cursor: int = 0
 
@@ -39,7 +47,7 @@ func handle_button(button: int) -> bool:
 	if _phase == Phase.DONE:
 		return true
 	if button in [Gen2Button.UP, Gen2Button.DOWN]:
-		if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM]:
+		if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM]:
 			_confirm_cursor = 1 - _confirm_cursor
 			_render()
 			return true
@@ -47,17 +55,16 @@ func handle_button(button: int) -> bool:
 		match _phase:
 			Phase.HOUR: _hour = wrapi(_hour + step, 0, 24)
 			Phase.MINUTE: _minute = wrapi(_minute + step, 0, 60)
-			Phase.DAY: _day = wrapi(_day + step, 0, 7)
 		_render()
 		return true
-	if button == Gen2Button.B and _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM]:
+	if button == Gen2Button.B and _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM]:
 		_phase -= 1
 		_confirm_cursor = 0
 		_render()
 		return true
 	if button != Gen2Button.A:
 		return false
-	if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM] \
+	if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM] \
 			and _confirm_cursor == 1:
 		_phase -= 1
 		_confirm_cursor = 0
@@ -71,11 +78,7 @@ func handle_button(button: int) -> bool:
 		Phase.MINUTE:
 			_phase = Phase.MINUTE_CONFIRM
 			_confirm_cursor = 0
-		Phase.MINUTE_CONFIRM: _phase = Phase.DAY
-		Phase.DAY:
-			_phase = Phase.DAY_CONFIRM
-			_confirm_cursor = 0
-		Phase.DAY_CONFIRM:
+		Phase.MINUTE_CONFIRM:
 			_phase = Phase.DONE
 			finished.emit(_day, _hour, _minute)
 	_render()
@@ -89,21 +92,17 @@ func value() -> Dictionary:
 func _render() -> void:
 	if _view == null or _page == null or _phase == Phase.DONE:
 		return
-	var day: bool = _phase in [Phase.DAY, Phase.DAY_CONFIRM]
-	var confirm: bool = _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM, Phase.DAY_CONFIRM]
+	var confirm: bool = _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM]
 	var value_text: String
 	var prompt: String
-	if day:
-		value_text = DAYS[_day]
-		prompt = "%s, is it?" % DAYS[_day].strip_edges() if confirm else "What day is it?"
-	elif _phase in [Phase.MINUTE, Phase.MINUTE_CONFIRM]:
+	if _phase in [Phase.MINUTE, Phase.MINUTE_CONFIRM]:
 		value_text = "%d min." % _minute
 		prompt = "Whoa! %d min.?" % _minute if confirm else "How many minutes?"
 	else:
 		value_text = "%s o'clock" % _hour_text()
 		prompt = "What? %s?" % value_text if confirm else "What time is it?"
 	_view.texture = ImageTexture.create_from_image(_page.render(
-		value_text, prompt, _confirm_cursor if confirm else -1, day
+		value_text, prompt, _confirm_cursor if confirm else -1, false
 	))
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3904,6 +3904,9 @@ func _refresh_party_summary() -> void:
 			"second_species": int(second.species) if second != null else 0,
 			"storage_full": save.party.size() >= Gen2SaveData.MAX_PARTY \
 				and not bool(save.first_empty_box_slot().get("ok", false)),
+			## `VAR_BOXSPACE`, which Route 29's catching tutorial reads before it
+			## offers to hand a POKé BALL over.
+			"box_free_space": save.box_free_space(),
 		},
 		fainted
 	)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -38,6 +38,12 @@ var _reset_phone_receive_timer: bool = false
 var _events: Array = []
 var _pending: Dictionary = {}
 var _last_text: Dictionary = {}
+
+## The text the still-open box is showing. `Script_yesorno`'s `YesNoBox` and
+## `Script_verticalmenu`'s `_2DMenu` draw over that box rather than replacing it,
+## so the question a choice answers is the last text the script wrote; without it
+## a host has nothing but the command's own name to print.
+var _standing_text: String = ""
 var _last_talked_object_index: int = -1
 var _last_item: int = 0
 var _staged_warp: Dictionary = {}
@@ -241,8 +247,9 @@ const WAIT_FRAMES: StringName = &"frames"
 ## delays six.
 const PAUSE_FRAMES_PER_UNIT: int = 2
 const WAIT_FRAMES_PER_UNIT: int = 6
+## `_SetDayOfWeek`'s own `.Days`, which are uppercase like every cartridge string.
 const WEEKDAY_NAMES: Array[StringName] = [
-	&"Sunday", &"Monday", &"Tuesday", &"Wednesday", &"Thursday", &"Friday", &"Saturday",
+	&"SUNDAY", &"MONDAY", &"TUESDAY", &"WEDNESDAY", &"THURSDAY", &"FRIDAY", &"SATURDAY",
 ]
 
 ## Crystal event flags used by the player's room decoration callbacks. The
@@ -361,6 +368,8 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		_phone_started = true
 		_emit_runtime_event(&"phone_call_started", _phone_context)
 	if _pending:
+		if _pending.has("text"):
+			_standing_text = String(_pending["text"])
 		var pending_request: Dictionary = _pending.get("request", {})
 		if _pending.get("type", &"") == &"runtime_request" \
 			and StringName(pending_request.get("kind", &"")) == &"battle_requested":
@@ -406,6 +415,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"type": &"choice",
 				"command": &"yesorno",
 				"choices": [&"yes", &"no"],
+				"text": _standing_text,
 				"special": &"strength_ask",
 				"slot": int(_pending.get("slot", -1)),
 				"source": _request.duplicate(true),
@@ -477,6 +487,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"type": &"choice",
 				"command": &"yesorno",
 				"choices": [&"yes", &"no"],
+				"text": _standing_text,
 				"special": &"field_move_ask",
 				"move": int(_pending.get("move", 0)),
 				"slot": int(_pending.get("slot", -1)),
@@ -504,6 +515,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"type": &"choice",
 				"command": &"yesorno",
 				"choices": [&"yes", &"no"],
+				"text": _standing_text,
 				"special": &"rock_smash_ask",
 				"slot": int(_pending.get("slot", -1)),
 				"source": _request.duplicate(true),
@@ -1237,7 +1249,11 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.WARP:
 			return _stage_warp(command)
 		Gen2WorldScript.OPENTEXT, Gen2WorldScript.REANCHORMAP, Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE, Gen2WorldScript.CLOSEWINDOW:
-			pass
+			## `Script_closetext` takes the box down, so nothing stands behind a
+			## later choice; leaving the last question there would print it under
+			## an unrelated menu.
+			if opcode == Gen2WorldScript.CLOSETEXT:
+				_standing_text = ""
 		Gen2WorldScript.ITEMNOTIFY:
 			## `CurItemName` reads wCurItem, which whichever `giveitem` came
 			## before this wrote.
@@ -1967,6 +1983,7 @@ func _stage_menu(two_dimensional: bool, command: Dictionary) -> Dictionary:
 		"menu_kind": &"2d" if two_dimensional else &"vertical",
 		"header": _loaded_menu.duplicate(true),
 		"options": _loaded_menu.get("options", []).duplicate(true),
+		"text": _standing_text,
 		"source": _request.duplicate(true),
 	}
 	return {"ok": true}
@@ -2129,6 +2146,12 @@ func _stage_trainer_approach() -> void:
 	})
 
 
+## `wXCoord`/`wYCoord`, mirrored onto the request the way the party count is.
+func _player_cell() -> Vector2i:
+	var standing: Variant = _request.get("player_cell", Vector2i(-1, -1))
+	return standing if standing is Vector2i else Vector2i(-1, -1)
+
+
 func _read_runtime_variable(variable: int) -> Dictionary:
 	var clock: Dictionary = _request.get("clock", {})
 	var hour: int = int(clock.get("hour", _clock_hour()))
@@ -2162,6 +2185,24 @@ func _read_runtime_variable(variable: int) -> Dictionary:
 			_script_value = state.unown_caught_count() if state != null else 0
 		0x0F: # VAR_ENVIRONMENT
 			_script_value = int(_request.get("environment", -1))
+		0x05: # VAR_DEXCAUGHT
+			_script_value = state.caught_count() if state != null else 0
+		0x06: # VAR_DEXSEEN
+			_script_value = state.seen_count() if state != null else 0
+		0x10: # VAR_BOXSPACE
+			## `.BoxFreeSpace` opens SRAM for the count; the party mirror carries
+			## it here for the same reason it carries VAR_PARTYCOUNT, and an
+			## absent mirror fails rather than inventing an empty box.
+			var storage: Dictionary = _request.get("party", {})
+			if not storage.has("box_free_space"):
+				return {
+					"ok": false, "reason": &"missing_party_summary", "variable": variable,
+				}
+			_script_value = int(storage.get("box_free_space", 0))
+		0x12: # VAR_XCOORD
+			_script_value = _player_cell().x
+		0x13: # VAR_YCOORD
+			_script_value = _player_cell().y
 		0x14: # VAR_SPECIALPHONECALL
 			_script_value = _current_special_phone_call()
 		0x16: # VAR_KURT_APRICORNS
@@ -2331,8 +2372,7 @@ func _execute_special(special: int) -> Dictionary:
 			## player stands on. The Poke Flute channel reaches wMapMusic through
 			## StartRadioStation and stays there because closing the Pokegear
 			## restores the map's music only for its two sentinel ids.
-			var standing: Variant = _request.get("player_cell", Vector2i(-1, -1))
-			var cell: Vector2i = standing if standing is Vector2i else Vector2i(-1, -1)
+			var cell: Vector2i = _player_cell()
 			_script_value = 1 if state != null \
 				and state.map_music() == Gen2WorldRadio.MUSIC_POKE_FLUTE_CHANNEL \
 				and cell in SNORLAX_PROXIMITY_CELLS else 0
@@ -2529,10 +2569,15 @@ func _decoration_block(category: StringName, decoration: int) -> int:
 func _stage_day_of_week_menu() -> void:
 	_pending = {
 		"type": &"menu",
-		"menu_kind": &"vertical",
+		## `SetDayOfWeek` is a dial, not a list: one weekday in a nine-wide box at
+		## `hlcoord 9, 3` between two arrows, with `.GetJoypadAction` stepping
+		## `wTempDayOfWeek` and A accepting. The selection rules are a wrapping
+		## vertical menu's, so only the drawing differs from one.
+		"menu_kind": &"spinner",
 		"command": &"set_day_of_week",
 		"options": WEEKDAY_NAMES.duplicate(),
 		"header": {"default": 1, "data_flags": 1 << 5},
+		"text": _standing_text,
 		"special": &"set_day_of_week",
 		"source": _request.duplicate(true),
 	}
@@ -2543,6 +2588,7 @@ func _stage_day_of_week_confirmation(day: int) -> void:
 		"type": &"choice",
 		"command": &"set_day_of_week_confirmation",
 		"choices": [&"yes", &"no"],
+		"text": _standing_text,
 		"special": &"set_day_of_week_confirmation",
 		"day": posmod(day, WEEKDAY_NAMES.size()),
 		"source": _request.duplicate(true),
@@ -3236,6 +3282,7 @@ func _stage_choice(command: Dictionary, choices: Array) -> Dictionary:
 		"type": &"choice",
 		"command": command.get("name", &"choice"),
 		"choices": choices.duplicate(true),
+		"text": _standing_text,
 		"source": _request.duplicate(true),
 	}
 	return {"ok": true}

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -129,6 +129,8 @@ var _boxes: Gen2BoxScreen = null
 var _service_hardware: Gen2Screen = null
 var _service_view: TextureRect = null
 var _service_page: Gen2WorldServicePage = null
+## `SetDayOfWeek`'s own dial, shared with the new game's `InitClock` screen.
+var _clock_page: Gen2ClockSetPage = null
 
 var _panel: PanelContainer = null
 var _title: Label = null
@@ -340,7 +342,10 @@ func _open_menu(input: Dictionary) -> void:
 	_choices = _menu.options.duplicate(true)
 	_cursor = _menu.selected_index()
 	_title.text = "MENU"
-	_summary.text = String(input.get("command", input.get("menu_kind", "Choose an option")))
+	## The question the box behind this menu is still showing. A command name is
+	## an internal key, never something the cartridge prints, so it is not a
+	## fallback: an unattached menu says nothing rather than saying "yesorno".
+	_summary.text = String(input.get("text", ""))
 	_status.text = ""
 	_footer.text = "D-pad: move    A: choose    B: cancel"
 	_render_options()
@@ -1403,6 +1408,10 @@ func _render_options(override: Array = []) -> void:
 		grid.add_theme_constant_override("h_separation", 18)
 		_options.add_child(grid)
 		parent = grid
+	if _is_dial() and override.is_empty():
+		## One value at a time, the way the dial itself shows it.
+		override = [_choices[clampi(_cursor, 0, _choices.size() - 1)]] if not _choices.is_empty() \
+			else []
 	var values: Array = override if not override.is_empty() else (
 		_choices if _mode == MODE.MENU \
 		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS] \
@@ -1453,7 +1462,7 @@ func _render_service_page(values: Array) -> void:
 			labels.append(label)
 		else:
 			labels.append(String(value))
-	var image: Image = _service_page.render(
+	var image: Image = _dial_image() if _is_dial() else _service_page.render(
 		_title.text, _summary.text, labels, _cursor, _status.text, _service_box()
 	)
 	if image != null:
@@ -1461,12 +1470,31 @@ func _render_service_page(values: Array) -> void:
 		_service_hardware.visible = true
 
 
+func _is_dial() -> bool:
+	return _mode == MODE.MENU and _menu != null and _menu.kind == &"spinner"
+
+
+## `SetDayOfWeek`'s `.loop`: the box, the two arrows, the one weekday string at
+## `hlcoord 10, 5` and `.OakTimeWhatDayIsItText` in the speech box below it.
+func _dial_image() -> Image:
+	if _clock_page == null:
+		_clock_page = Gen2ClockSetPage.from_data(_data)
+	if _clock_page == null:
+		return null
+	var day: int = clampi(_cursor, 0, Gen2ClockSetScreen.DAYS.size() - 1)
+	var prompt: String = _summary.text if not _summary.text.is_empty() \
+		else "What day is it?"
+	return _clock_page.render(Gen2ClockSetScreen.DAYS[day], prompt, -1, true)
+
+
 ## The `menu_coords` box this mode's own list sits in. `null` draws no box,
 ## which is what MODE.MENU falls back to before a menu is loaded.
 func _service_box() -> Gen2MenuBox:
 	match _mode:
 		MODE.MENU:
-			return _menu.box() if _menu != null else null
+			if _menu == null or _menu.kind == &"spinner":
+				return null
+			return _menu.box()
 		MODE.PC, MODE.PC_ITEMS:
 			return _pc_top_box()
 		MODE.PC_ITEM_LIST:

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -99,7 +99,7 @@ static func build(
 			continue
 		if entry["kind"] == ITEM_EXIT:
 			if not Gen2ModHost.instance().option_mod_ids().is_empty():
-				items.append(_entry(ITEM_MODS, "Mods", true))
+				items.append(_entry(ITEM_MODS, "MODS", true))
 			items.append_array(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START))
 		var label: String = String(entry["label"])
 		## `PlaceString` reads `wPlayerName` for `<PLAYER>`, so the STATUS row

--- a/tests/integration/test_intro_screen.gd
+++ b/tests/integration/test_intro_screen.gd
@@ -140,6 +140,9 @@ func test_the_gender_question_comes_first() -> void:
 	assert_true(_screen.current() is Gen2OakSpeechScreen, "then the speech")
 
 
+## `InitClock` is hour and minutes: it ends on `OakText_ResponseToSetTime` after
+## `.MinutesAreSet`. The weekday is `SetDayOfWeek`, which only Mom's errand in
+## `PlayersHouse1F.asm` calls, so a new game leaves the RTC's own SUNDAY alone.
 func test_clock_set_wraps_each_source_dial_and_reaches_the_speech() -> void:
 	_begin()
 	_screen.handle_button(Gen2Button.A)
@@ -149,10 +152,7 @@ func test_clock_set_wraps_each_source_dial_and_reaches_the_speech() -> void:
 	clock.handle_button(Gen2Button.A)
 	clock.handle_button(Gen2Button.A)
 	clock.handle_button(Gen2Button.DOWN)
-	clock.handle_button(Gen2Button.A)
-	clock.handle_button(Gen2Button.A)
-	clock.handle_button(Gen2Button.DOWN)
-	assert_eq(clock.value(), {"day": 6, "hour": 9, "minute": 59})
+	assert_eq(clock.value(), {"day": 0, "hour": 9, "minute": 59})
 	clock.handle_button(Gen2Button.A)
 	clock.handle_button(Gen2Button.A)
 	assert_true(_screen.current() is Gen2OakSpeechScreen)

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -65,6 +65,18 @@ func test_hash_encodes_the_word_the_source_dictionary_prints() -> void:
 	assert_eq(Gen2Text.encoded_length("POKéMON"), 7)
 
 
+## `constants/charmap.asm` spells the same two codes `<POKE>` and `<PKMN>`, and a
+## caller copying a source string writes them; an unexpanded bracket is UNKNOWN,
+## which is the "?" the start menu's POKéGEAR row was printing.
+func test_angle_bracket_word_spellings_encode_like_their_codes() -> void:
+	assert_eq(Gen2Text.encode("<POKE>"), Gen2Text.encode("POKé"))
+	assert_eq(Gen2Text.encode("<POKE>GEAR"), Gen2Text.encode("POKéGEAR"))
+	assert_eq(Gen2Text.encoded_length("<POKE>GEAR"), 8)
+	assert_eq(Gen2Text.encode("<PKMN>"), Gen2Text.encode("PKMN"))
+	for code: int in Gen2Text.encode("<POKE>GEAR"):
+		assert_ne(code, Gen2Text.UNKNOWN)
+
+
 ## $75 is decode-only for the same reason $54 is, and source text writes the
 ## character itself, so a synthesized line quoting it has to encode.
 func test_ellipsis_encodes_the_source_charmap_code() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3273,13 +3273,16 @@ func test_set_day_of_week_follows_the_source_selection_and_confirmation_flow() -
 	var menu: Dictionary = runner.advance()
 	assert_eq(menu["status"], &"waiting")
 	assert_eq(menu["event"]["type"], &"menu")
+	## `SetDayOfWeek` shows one weekday between two arrows, not a seven-row list:
+	## seven rows at `_InitVerticalMenuCursor`'s two-row step do not fit a screen.
+	assert_eq(menu["event"]["menu_kind"], &"spinner")
 	assert_eq(menu["event"]["options"], [
-		&"Sunday", &"Monday", &"Tuesday", &"Wednesday", &"Thursday", &"Friday", &"Saturday",
+		&"SUNDAY", &"MONDAY", &"TUESDAY", &"WEDNESDAY", &"THURSDAY", &"FRIDAY", &"SATURDAY",
 	])
 
 	var confirmation_text: Dictionary = runner.advance(true, 3)
 	assert_eq(confirmation_text["event"]["type"], &"text")
-	assert_eq(confirmation_text["event"]["text"], "Wednesday,\nis it?")
+	assert_eq(confirmation_text["event"]["text"], "WEDNESDAY,\nis it?")
 	var confirmation: Dictionary = runner.advance(true)
 	assert_eq(confirmation["event"]["type"], &"choice")
 	assert_eq(confirmation["event"]["choices"], [&"yes", &"no"])
@@ -3290,6 +3293,85 @@ func test_set_day_of_week_follows_the_source_selection_and_confirmation_flow() -
 	var complete: Dictionary = runner.advance(true)
 	assert_eq(complete["status"], &"complete")
 	assert_eq(complete["clock"], {"day": 3, "hour": 8, "minute": 15})
+
+
+## `Script_yesorno` is `YesNoBox` drawn over the box `writetext` left open, and
+## `Script_verticalmenu` is `_2DMenu` over the same box, so the question a choice
+## answers is the last text the script wrote. Without it a host has nothing but
+## the command's own name, which is how "yesorno" reached the screen.
+func test_a_choice_carries_the_text_the_open_box_is_still_showing() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6640"] = [
+		Gen2WorldScript.WRITETEXT, 0x00, 0x70,
+		Gen2WorldScript.YESORNO,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6650"] = [
+		Gen2WorldScript.WRITETEXT, 0x00, 0x70,
+		Gen2WorldScript.CLOSETEXT,
+		Gen2WorldScript.YESORNO,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6640,
+	})
+	assert_eq(runner.advance()["event"]["text"], "AB")
+	var choice: Dictionary = runner.advance(true)
+	assert_eq(choice["event"]["type"], &"choice")
+	assert_eq(choice["event"]["text"], "AB", JSON.stringify(choice))
+
+	var closed := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6650,
+	})
+	assert_eq(closed.advance()["event"]["text"], "AB")
+	assert_eq(closed.advance(true)["event"]["text"], "")
+
+
+## `_GetVarAction.BoxFreeSpace` is `MONS_PER_BOX - [sBoxCount]`. Route 29's
+## catching tutorial reads it before it hands a POKé BALL over, so an
+## unsupported variable stops that NPC talking at all.
+func test_readvar_boxspace_reads_the_party_summary_mirror() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6660"] = [
+		Gen2WorldScript.READVAR, 0x10,
+		Gen2WorldScript.IFEQUAL, 14, 0x70, 0x66,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6670"] = [Gen2WorldScript.SETEVENT, 41, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+
+	var state := Gen2WorldState.new()
+	var runner := Gen2WorldScriptRunner.begin(data, state, {
+		"kind": &"test", "bank": 48, "script": 0x6660,
+		"party": {"count": 1, "box_free_space": 14},
+	})
+	assert_eq(runner.advance()["status"], &"complete")
+	assert_true(state.is_event_flag_active(41))
+
+	var unmirrored := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6660,
+	})
+	var refused: Dictionary = unmirrored.advance()
+	assert_eq(refused["status"], &"failed", JSON.stringify(refused))
+	assert_eq(refused["reason"], &"missing_party_summary")
+
+
+## An empty box is the whole box; a storage with no free slot anywhere answers 0,
+## which is the refusal every reader of the var already branches on.
+func test_box_free_space_answers_the_box_a_deposit_would_land_in() -> void:
+	var save: Gen2SaveData = Gen2SaveData.new()
+	assert_eq(save.box_free_space(), Gen2SaveBox.CAPACITY)
+	for slot: int in Gen2SaveBox.CAPACITY:
+		(save.boxes[0] as Gen2SaveBox).put(Gen2SaveMon.new())
+	assert_eq(save.box_free_space(), Gen2SaveBox.CAPACITY)
+	for box: Gen2SaveBox in save.boxes:
+		for slot: int in Gen2SaveBox.CAPACITY:
+			box.put(Gen2SaveMon.new())
+	assert_eq(save.box_free_space(), 0)
 
 
 func test_initial_dst_specials_publish_source_confirmation_text_and_commit_state() -> void:


### PR DESCRIPTION
The service screen printed a pending's `command` when a script asked a question, so `Script_yesorno` said "yesorno" and Mom's clock ask said `set?day?of?week`: every character the charmap has no code for encodes as `Gen2Text.UNKNOWN`, which draws "?". `YesNoBox` and `_2DMenu` draw over the box `writetext` left open, so the runner carries that standing text onto every choice and menu now, and drops it on `closetext`.

The other half of the "?" is the encoder: `<POKE>` and `<PKMN>` are how `constants/charmap.asm` spells two codes, and the start menu's row is a literal `<POKE>GEAR`, so both spellings expand the way `#` already did.

`SetDayOfWeek` is a dial, not a list. Seven weekdays at `_InitVerticalMenuCursor`'s two-row step do not fit a screen, which is why the names came out truncated in a yes/no-sized box; the ask draws `Gen2ClockSetPage`'s nine-wide box and two arrows now, and the names are the source's own uppercase. `InitClock` no longer asks for a weekday at all: it ends on `OakText_ResponseToSetTime` after `.MinutesAreSet`, and `PlayersHouse1F.asm`'s errand is the only caller of `SetDayOfWeek`. The cartridge asks about the clock twice, for two different reasons.

`_GetVarAction`'s table gains `VAR_DEXCAUGHT`, `VAR_DEXSEEN`, `VAR_BOXSPACE`, `VAR_XCOORD` and `VAR_YCOORD`. Route 29's catching tutorial reads `VAR_BOXSPACE` before it hands a POKe BALL over, so an unsupported variable stopped that NPC talking; the party mirror carries `box_free_space` the way it carries the count.

The start menu's `Mods` row is uppercase like every sibling.

| Check | Result |
|---|---|
| GUT, both tiers | 3,175 / 3,175 over 152 scripts |
| `validate.gd -- all` | exit 0 |
| Story walk, three profiles | no failure, no refused script |
| Boot smoke, 30 frames | no error |