### PR TITLE
Charge a text the presses the source charges, and stop prompting for requests nothing draws

### DIFF
--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -7,6 +7,16 @@ extends RefCounted
 ## pending with a specific reason rather than being guessed or acknowledged as
 ## if the subsystem had run.
 
+## The requests the host settles out of the save alone. `special HealParty`,
+## `givepoke` and `giveegg` each run to completion inside the command that asked
+## for them and the script runs straight on, so a screen completes one where it
+## is staged rather than waiting for a press: the cartridge spends none, and a
+## request nothing draws for has nothing to acknowledge.
+const UNATTENDED_REQUESTS: Array[StringName] = [
+	&"party_heal_requested", &"pokemon_requested", &"trade_requested",
+]
+
+
 static func complete_runtime_request(
 	world: Gen2WorldAPI,
 	result: Dictionary,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -172,6 +172,12 @@ var _replay_held_direction: int = Gen2Button.NONE
 ## Whether a frame is being spent right now, which is what tells a press
 ## delivered from inside the pump from one that arrived between two frames.
 var _spending_frame: bool = false
+## `HealMachineAnim`'s own sounds and the frame of its wait each is due on, taken
+## from the event the special emits and spent by [method advance_frame]. The
+## machine's two tiles are not drawn with them: `gfx/overworld/heal_machine.2bpp`
+## is imported by nothing.
+var _heal_machine_sounds: Array = []
+var _heal_machine_frame: int = 0
 var _screen_base_position: Vector2 = Vector2.ZERO
 
 @onready var _screen: Gen2Screen = %Screen
@@ -531,6 +537,10 @@ func advance_frame() -> void:
 		var wait_results: Array = _world.advance_script_wait_frame()
 		if not wait_results.is_empty():
 			_show_script_results(wait_results)
+	_advance_heal_machine_sounds()
+	## `_ContText`'s scroll ends on a frame rather than on a press, and the page
+	## it lands on may be the text's last, which is where the script runs on.
+	_continue_if_text_settled()
 	if not _trainer_approach.is_empty():
 		_advance_trainer_approach()
 	if _world != null and _world.phone_ring_active():
@@ -884,16 +894,33 @@ func _advance_script_pause() -> void:
 		if not audio_results.is_empty():
 			_show_script_results(audio_results)
 		return
-	var pending_save: Gen2SaveData = _injected_save if _injected_save != null \
-		else _selected_runtime_save()
-	var host_result: Dictionary = Gen2WorldHost.complete_runtime_request(
-		_world, {"ok": true}, pending_save, _injected_save == null, _encounter_random
-	)
+	var host_result: Dictionary = _complete_pending_request()
 	if bool(host_result.get("ok", false)):
 		_show_script_results(host_result.get("results", []))
 		return
 	_script_prompt = "Host unavailable: %s" % String(host_result.get("reason", "unknown"))
 	_refresh_labels()
+
+
+## One pending runtime request answered by the host with the selected save,
+## which is the same call whether a press asked for it or nothing did.
+func _complete_pending_request(result: Dictionary = {"ok": true}) -> Dictionary:
+	var pending_save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	return Gen2WorldHost.complete_runtime_request(
+		_world, result, pending_save, _injected_save == null, _encounter_random
+	)
+
+
+## A request that spends no press on the cartridge, settled where it is staged.
+## Empty when the host refused it, which leaves the caller its own prompt: a
+## save with no party heals nothing, and that is a reason, not a press.
+func _complete_unattended_request() -> Array:
+	var settled: Dictionary = _complete_pending_request()
+	if not bool(settled.get("ok", false)):
+		_script_prompt = "Host unavailable: %s" % String(settled.get("reason", "unknown"))
+		return []
+	return settled.get("results", [])
 
 
 ## Scaffolding that reaches parts of the world no cartridge control does: the
@@ -2169,12 +2196,10 @@ func _on_battle_finished(result: Dictionary) -> void:
 func _advance_script_input() -> void:
 	if _text_box.is_revealing():
 		_text_box.finish()
+		_continue_if_text_settled()
 		return
 	if _text_box.advance():
-		## The press that reaches a `<DONE>` last page is that page's `<PARA>`,
-		## not an acknowledgement of the text: the script runs on behind it.
-		if not _text_awaits_press and not _text_box.has_pages_left():
-			_continue_after_text()
+		_continue_if_text_settled()
 		return
 	_text_box_rect_held += 1
 	_text_box.visible = false
@@ -2183,6 +2208,28 @@ func _advance_script_input() -> void:
 	_text_box_rect_held -= 1
 	_push_text_box_rect()
 	_refresh_labels()
+
+
+## `Script_writetext` is `MapTextbox` and returns as soon as the string is
+## placed, so a text ending in `<DONE>` owes no press of its own and the script
+## runs on the moment its last page is up. The box reaches that page three ways:
+## shown whole, turned to by the press that clears a `<PARA>`, or scrolled into
+## by `_ContText`, and only the first two are a press. The scroll ends on a
+## frame, which is why [method advance_frame] asks this as well; without it the
+## last page sat there with the script still suspended and the press that closed
+## the box paid for the `waitbutton` behind it, so every `<CONT>`-terminated
+## text cost one press more than the cartridge spends.
+func _continue_if_text_settled() -> bool:
+	if _text_box == null or not _text_box.visible or _world == null:
+		return false
+	if _text_awaits_press or not _oak_pc_pages.is_empty():
+		return false
+	if _text_box.is_scrolling() or _text_box.has_pages_left():
+		return false
+	if StringName(_world.pending_script_input().get("type", &"")) != &"text":
+		return false
+	_continue_after_text()
+	return true
 
 
 ## Runs a script on past a text that owes no press, leaving the box up: the
@@ -3325,6 +3372,8 @@ func _on_service_completed(results: Array) -> void:
 
 
 func _show_script_results(results: Array) -> void:
+	## Whether this result staged a text at all; whether it owes a press is
+	## [method _continue_if_text_settled]'s question, asked once the loop is done.
 	var continue_after_text: bool = false
 	var waiting: bool = false
 	var failed: bool = false
@@ -3359,8 +3408,7 @@ func _show_script_results(results: Array) -> void:
 					_text_box.visible = true
 				_script_prompt = "A: advance text"
 				_text_awaits_press = bool(event.get("prompt", true))
-				continue_after_text = not _text_awaits_press \
-					and not _text_box.has_pages_left()
+				continue_after_text = true
 			elif event_type == &"button":
 				if _text_box != null:
 					_text_box.visible = true
@@ -3404,10 +3452,12 @@ func _show_script_results(results: Array) -> void:
 					})
 					_show_script_results(swarm_results)
 					return
-				if StringName(request.get("kind", &"")) in [
-					&"pokemon_requested", &"trade_requested",
-				]:
-					_script_prompt = "Party transaction: press A to confirm"
+				if StringName(request.get("kind", &"")) in \
+					Gen2WorldHost.UNATTENDED_REQUESTS:
+					var settled: Array = _complete_unattended_request()
+					if not settled.is_empty():
+						_show_script_results(settled)
+						return
 					continue
 				if StringName(request.get("kind", &"")) in [
 					&"mart_requested", &"phone_call_requested",
@@ -3433,6 +3483,9 @@ func _show_script_results(results: Array) -> void:
 			if result_event.get("type", &"") == &"presentation_special_applied" \
 				and StringName(result_event.get("kind", &"")) == &"prof_oaks_pc_boot":
 				open_prof_oaks_pc()
+			elif result_event.get("type", &"") == &"presentation_special_applied" \
+				and StringName(result_event.get("kind", &"")) == &"heal_machine_anim":
+				_start_heal_machine_sounds(result_event)
 			elif result_event.get("type", &"") == &"hall_of_fame_requested":
 				## An event, not a runtime request: `halloffame` commits its flag
 				## and runs on, and the source's own `end` is the next command,
@@ -3506,8 +3559,7 @@ func _show_script_results(results: Array) -> void:
 			_renderer.refresh()
 	## Decided in the loop and spent here, because a special drawing its own
 	## pages is an event on the same result as the text waiting behind them.
-	if continue_after_text and _oak_pc_pages.is_empty():
-		_continue_after_text()
+	if continue_after_text and _continue_if_text_settled():
 		return
 	_refresh_labels()
 
@@ -3830,6 +3882,39 @@ func _play_encounter_sounds() -> void:
 	for command: Dictionary in _encounters.frame_commands():
 		if StringName(command["name"]) == Gen2BattleAnimScript.SOUND:
 			_play_sfx(int((command["operands"] as Array)[1]))
+
+
+## The machine's sounds, started where the special asked for them. A schedule
+## already running is replaced rather than mixed: two heal machines cannot be
+## going at once, since the script that started the first is waiting for it.
+func _start_heal_machine_sounds(event: Dictionary) -> void:
+	_heal_machine_sounds = (event.get("sounds", []) as Array).duplicate(true)
+	_heal_machine_frame = 0
+	_advance_heal_machine_sounds()
+
+
+## One frame of that schedule, spent from the same pump the script's own wait is.
+func _advance_heal_machine_sounds() -> void:
+	if _heal_machine_sounds.is_empty():
+		return
+	while not _heal_machine_sounds.is_empty() \
+		and int(_heal_machine_sounds[0].get("frame", 0)) <= _heal_machine_frame:
+		var due: Dictionary = _heal_machine_sounds.pop_front()
+		var index: int = int(due.get("index", 0))
+		if StringName(due.get("kind", &"sound")) == &"music":
+			_play_music(index)
+		else:
+			_play_sfx(index)
+	_heal_machine_frame += 1
+
+
+func _play_music(index: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	var record: Dictionary = _data.world_audio(&"music", index)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
 
 
 func _play_sfx(index: int) -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -110,6 +110,22 @@ const SPECIAL_SET_DAY_OF_WEEK: int = 37
 const SPECIAL_PLAY_MAP_MUSIC: int = 60
 const SPECIAL_RESTART_MAP_MUSIC: int = 61
 const SPECIAL_HEAL_MACHINE_ANIM: int = 62
+## `HealMachineAnim.Pointers`' three sequences. Only the Hall of Fame's differs:
+## it loads its balls from a second OAM table and plays two effects where the
+## other two play `MUSIC_HEAL`.
+const HEAL_MACHINE_HALL_OF_FAME: int = 2
+## `.LoadBallsOntoMachine`'s `ld c, 30 / call DelayFrames`, once a party member.
+const HEAL_MACHINE_BALL_FRAMES: int = 30
+## `.FlashPalettes8Times`: eight passes of `ld c, 10 / call DelayFrames`.
+const HEAL_MACHINE_FLASH_FRAMES: int = 80
+## constants/sfx_constants.asm. The first is played once a ball by
+## `.LoadBallsOntoMachine`; the other two are `.HOF_PlaySFX`'s pair.
+const SFX_SECOND_PART_OF_ITEMFINDER: int = 0x12
+const SFX_GAME_FREAK_LOGO_GS: int = 0xAA
+const SFX_BOOT_PC: int = 0x0D
+## constants/music_constants.asm's MUSIC_HEAL, which `.PlayHealMusic` starts
+## under the flashes rather than after them.
+const MUSIC_HEAL: int = 0x0D
 const SPECIAL_CHECK_POKERUS: int = 78
 ## MagnetTrain, the ride's cutscene. wScriptVar picks the direction, which a
 ## preceding SETVAL loads: TRUE for Saffron to Goldenrod, FALSE for the return
@@ -2282,6 +2298,36 @@ func _clock_minute() -> int:
 	return clampi(int(clock.get("minute", 0)), 0, 59)
 
 
+## `HealMachineAnim`'s sounds and the frame of its own wait each is played on.
+## `.LoadBallsOntoMachine` plays one effect a ball and then delays thirty frames,
+## so ball zero sounds on the frame the routine starts. `.PlayHealMusic` starts
+## `MUSIC_HEAL` under `.FlashPalettes8Times` rather than after it; the Hall of
+## Fame's sequence plays one effect there instead and a second once the flashes
+## are done. Its `WaitSFX` between the two is not spent, like the other two the
+## world leaves unspent.
+static func heal_machine_sounds(machine_type: int, balls: int) -> Array:
+	if balls <= 0:
+		return []
+	var schedule: Array = []
+	for ball: int in balls:
+		schedule.append({
+			"frame": ball * HEAL_MACHINE_BALL_FRAMES,
+			"kind": &"sound", "index": SFX_SECOND_PART_OF_ITEMFINDER,
+		})
+	var flashes_at: int = balls * HEAL_MACHINE_BALL_FRAMES
+	if machine_type == HEAL_MACHINE_HALL_OF_FAME:
+		schedule.append({
+			"frame": flashes_at, "kind": &"sound", "index": SFX_GAME_FREAK_LOGO_GS,
+		})
+		schedule.append({
+			"frame": flashes_at + HEAL_MACHINE_FLASH_FRAMES,
+			"kind": &"sound", "index": SFX_BOOT_PC,
+		})
+	else:
+		schedule.append({"frame": flashes_at, "kind": &"music", "index": MUSIC_HEAL})
+	return schedule
+
+
 ## [param special] is the Crystal-canonical index from
 ## Gen2WorldScript.special_index(), not the raw stream byte, so the payloads
 ## below report that index on both profiles.
@@ -2338,12 +2384,26 @@ func _execute_special(special: int) -> Dictionary:
 			return _stage_runtime_request(&"party_heal_requested", {"special": special})
 		SPECIAL_HEAL_MACHINE_ANIM:
 			## wScriptVar selects the machine's screen position: 0 Pokemon Center,
-			## 1 Elm's Lab, 2 Hall of Fame. A preceding SETVAL loads it, so it is
-			## carried through as presentation only; nothing here changes state.
+			## 1 Elm's Lab, 2 Hall of Fame. A preceding SETVAL loads it. Nothing
+			## here changes state, but the routine is not free: it spends thirty
+			## frames a ball and `.FlashPalettes8Times`' eighty, with a sound on
+			## each ball, so the script waits for it the way the cartridge does.
+			var machine_type: int = clampi(_script_value, 0, HEAL_MACHINE_HALL_OF_FAME)
+			var balls: int = int((_request.get("party", {}) as Dictionary).get("count", 0))
+			var sounds: Array = heal_machine_sounds(machine_type, balls)
 			_emit_runtime_event(&"presentation_special_applied", {
 				"special": special, "kind": &"heal_machine_anim",
-				"machine_type": _script_value,
+				"machine_type": machine_type,
+				"balls": balls,
+				"sounds": sounds.duplicate(true),
 			})
+			## `ld a, [wPartyCount] / and a / ret z`: an empty party leaves the
+			## machine alone and spends nothing.
+			if balls > 0:
+				return _stage_frame_wait(
+					balls * HEAL_MACHINE_BALL_FRAMES + HEAL_MACHINE_FLASH_FRAMES,
+					{"special": special, "kind": &"heal_machine_anim"}
+				)
 		SPECIAL_MAGNET_TRAIN:
 			## engine/events/magnet_train.asm's MagnetTrain is scroll positions,
 			## graphics, music and a VBlank cutscene handler. It reads

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -27,6 +27,13 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory())
 
 
+## `_ContText`'s two `TextScroll` steps, which the box spends on its own frames.
+const TEXT_SCROLL_FRAMES: int = 16
+## The fixture's coord event, which every script case below is written onto.
+const SCRIPT_CELL: Vector2i = Vector2i(4, 5)
+const SCROLL_TEXT: int = 0x6400
+
+
 func _open_world(seed_value: int = 4242) -> Gen2WorldScreen:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
@@ -153,3 +160,94 @@ func test_the_day_cycle_stays_on_real_seconds() -> void:
 		int(_world_screen._world.world_clock()["day"]),
 		(day + 1) % Gen2WorldClock.DAYS_PER_WEEK
 	)
+
+
+## A `writetext` whose text breaks at `<CONT>` and ends at `<DONE>`, with the
+## `waitbutton` the source puts behind every such command.
+func _write_scroll_script() -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		Gen2WorldScript.WRITETEXT, SCROLL_TEXT & 0xFF, SCROLL_TEXT >> 8,
+		Gen2WorldScript.WAITBUTTON,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+	var text: Dictionary = RomCache.read_json(RomCache.world_text_path(directory))
+	var encoded: Array = [Gen2WorldScript.TEXT_START]
+	for byte: int in Gen2Text.encode("AB"):
+		encoded.append(byte)
+	encoded.append(Gen2TextStream.CHAR_CONT)
+	for byte: int in Gen2Text.encode("CD"):
+		encoded.append(byte)
+	encoded.append(Gen2TextStream.CHAR_DONE)
+	text[Gen2WorldScript.pointer_key(Fixture.BANK, SCROLL_TEXT)] = encoded
+	RomCache.write_json(RomCache.world_text_path(directory), text)
+	_data = GameData.open_directory(directory)
+
+
+## Frames until the box is neither revealing a page nor scrolling into one, so
+## the press that follows is the one the cartridge charges rather than the one
+## that skips a reveal.
+func _settle_text_box(screen: Gen2WorldScreen) -> void:
+	for _frame: int in 240:
+		if not screen._text_box.is_revealing() and not screen._text_box.is_scrolling():
+			return
+		screen.advance_frame()
+		screen._text_box.advance_frame()
+		screen._text_box.advance_scroll_frames(1.0)
+
+
+## `_ContText` waits for a press and scrolls; the `<DONE>` behind it owes none,
+## so the script runs on where the scroll lands and the `waitbutton` is paid for
+## once. The scroll ends on a frame rather than on a press, which is why the pump
+## asks: while it did not, the press that closed the box paid for the scroll and
+## the `waitbutton` needed one more.
+func test_a_scroll_landing_on_the_last_page_runs_the_script_on_without_a_press() -> void:
+	_write_scroll_script()
+	_world_screen = await _open_world()
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(SCRIPT_CELL)
+	)
+	_settle_text_box(_world_screen)
+	assert_true(_world_screen._text_box.visible)
+
+	# The `<CONT>`.
+	_world_screen.press_button(Gen2Button.A)
+	assert_true(_world_screen._text_box.is_scrolling(), "TextScroll is running")
+	_settle_text_box(_world_screen)
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")),
+		&"button",
+		"the script ran on to its waitbutton where the scroll landed",
+	)
+	assert_true(_world_screen._text_box.visible, "closetext takes the box down, not this")
+
+	# The `waitbutton`.
+	_world_screen.press_button(Gen2Button.A)
+	assert_true(_world_screen._world.pending_script_input().is_empty())
+	assert_false(_world_screen._text_box.visible)
+
+
+## `special HealParty` is a save transaction with nothing drawn in front of it,
+## so the cartridge spends no press on it and neither does the screen.
+func test_a_party_heal_request_is_settled_where_it_is_staged() -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		Gen2WorldScript.SPECIAL, 27, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+	_data = GameData.open_directory(directory)
+	_world_screen = await _open_world()
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	(save.party[0] as Gen2SaveMon).hp = 1
+	_world_screen.set_save(save)
+	await get_tree().process_frame
+
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(SCRIPT_CELL)
+	)
+	assert_true(_world_screen._world.pending_runtime_request().is_empty())
+	assert_true((save.party[0] as Gen2SaveMon).hp > 1, "the party healed with no press")

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -599,14 +599,36 @@ func test_nurse_script_heals_the_party_after_accepting_and_shows_the_heal_machin
 	)
 	assert_true(complete["ok"], JSON.stringify(complete))
 	var results: Array = complete.get("results", [])
-	assert_eq(results[results.size() - 1]["status"], &"complete", JSON.stringify(results))
+	var last: Dictionary = results[results.size() - 1]
 	assert_eq(
-		_event_value(results[results.size() - 1].get("events", []), &"presentation_special_applied", "kind"),
+		_event_value(last.get("events", []), &"presentation_special_applied", "kind"),
 		&"heal_machine_anim",
 		JSON.stringify(results),
 	)
 	var healed_mon: Gen2SaveMon = save.party[0]
 	assert_eq(healed_mon.hp, battle_mon.max_hp())
+
+	## `HealMachineAnim` is thirty frames a ball and `.FlashPalettes8Times`'
+	## eighty, so the script is still standing in the special rather than past it.
+	assert_eq(StringName(last["status"]), &"waiting", JSON.stringify(results))
+	assert_eq(
+		int(last["event"]["frames"]),
+		Gen2WorldScriptRunner.HEAL_MACHINE_BALL_FRAMES
+			+ Gen2WorldScriptRunner.HEAL_MACHINE_FLASH_FRAMES,
+	)
+	assert_eq(
+		_event_value(last.get("events", []), &"presentation_special_applied", "sounds"),
+		[
+			{
+				"frame": 0, "kind": &"sound",
+				"index": Gen2WorldScriptRunner.SFX_SECOND_PART_OF_ITEMFINDER,
+			},
+			{
+				"frame": Gen2WorldScriptRunner.HEAL_MACHINE_BALL_FRAMES,
+				"kind": &"music", "index": Gen2WorldScriptRunner.MUSIC_HEAL,
+			},
+		],
+	)
 
 
 func test_nurse_script_leaves_the_party_unhealed_on_refusal() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3187,6 +3187,39 @@ func test_heal_machine_anim_special_emits_presentation_event_without_state_chang
 		JSON.stringify(result),
 	)
 	assert_false(world.event_flag_active(0))
+	## `ld a, [wPartyCount] / and a / ret z`: with no party the routine returns
+	## before it has loaded a tile, so it spends no frame and no sound.
+	assert_eq(
+		_event_value(result[0]["events"], &"presentation_special_applied", "sounds"), []
+	)
+
+
+## `.HallOfFame`'s sequence is the only one that differs: two effects around
+## `.FlashPalettes8Times` where the other two start `MUSIC_HEAL` under it.
+func test_heal_machine_sounds_follow_the_sequence_the_machine_type_selects() -> void:
+	var centre: Array = Gen2WorldScriptRunner.heal_machine_sounds(0, 3)
+	assert_eq(centre.size(), 4)
+	for ball: int in 3:
+		assert_eq(int(centre[ball]["frame"]), ball * 30)
+		assert_eq(
+			int(centre[ball]["index"]),
+			Gen2WorldScriptRunner.SFX_SECOND_PART_OF_ITEMFINDER,
+		)
+	assert_eq(StringName(centre[3]["kind"]), &"music")
+	assert_eq(int(centre[3]["frame"]), 90)
+
+	var hall: Array = Gen2WorldScriptRunner.heal_machine_sounds(
+		Gen2WorldScriptRunner.HEAL_MACHINE_HALL_OF_FAME, 1
+	)
+	assert_eq(
+		[int(hall[1]["frame"]), int(hall[1]["index"])],
+		[30, Gen2WorldScriptRunner.SFX_GAME_FREAK_LOGO_GS],
+	)
+	## `WaitSFX` between the two is not spent, like the world's other two.
+	assert_eq(
+		[int(hall[2]["frame"]), int(hall[2]["index"])],
+		[110, Gen2WorldScriptRunner.SFX_BOOT_PC],
+	)
 
 
 func test_check_pokerus_special_reads_the_low_nibble_across_the_party_summary() -> void:


### PR DESCRIPTION
Three fixes on one shared path: what a script's text and its host requests cost the player.

## A `<DONE>` text costs one press too many

`Script_writetext` is `MapTextbox` and returns as soon as the string is placed, so a text ending in `<DONE>` owes no press of its own and the press behind it belongs to the `waitbutton` the command carries. `Gen2WorldScreen` only asked that on the press that turns a page.

`_ContText`'s scroll ends on a frame, and `Gen2TextBox.advance()` leaves `_page` on the page it came from until `_end_scroll` runs, so `has_pages_left()` was still true on the press that started the scroll. A text broken at `<CONT>` therefore settled on its last page with the script still suspended: the press that closed the box paid for the scroll, and the `waitbutton` needed one more. The `is_revealing()` branch returned early for the same reason.

The three conditions are one `_continue_if_text_settled()` now, asked from the page turn, from the reveal finishing and from the frame pump, so no way of reaching the last page can miss it.

## A request nothing draws for asked for an acknowledgement

`Gen2WorldHost.UNATTENDED_REQUESTS` names the three requests the host answers out of the save alone: `special HealParty`, `givepoke` and `giveegg` each run to completion inside the command that asked for them and the cartridge spends no press on any of them. Each used to stand on a debug prompt naming its own internal event until a press acknowledged it. They are settled where they are staged now. The refusal path is unchanged: a host that cannot answer still leaves its reason in the prompt.

## `HealMachineAnim` was free

It spends thirty frames a ball (`.LoadBallsOntoMachine`) and `.FlashPalettes8Times`' eighty, with `SFX_SECOND_PART_OF_ITEMFINDER` on each ball and `MUSIC_HEAL` started under the flashes, or `.HOF_PlaySFX`'s two effects around them. An empty party returns at once, which is the routine's own `ret z`. `Gen2WorldScriptRunner.heal_machine_sounds` is that schedule and `Gen2WorldScreen` spends it from the same pump the script's wait counts on. The machine's own two tiles are read by no importer and are not drawn.

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 3,178 tests over 152 scripts, green, no orphans (was 3,175) |
| `tools/validate.gd -- all` | PASS, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed result on crystal, gold or silver |
| Boot smoke test | clean |

The new scroll case fails on the pre-change screen with `[text] expected to equal [button]`, which is the suspended script the bug left behind.