### PR TITLE
Remove orientation comment from project.godot

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -29,8 +29,6 @@ file_logging/enable_file_logging=true
 
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
-; Both orientations: `Gen2GameFrame.split()` sends the hardware screen to the
-; top of a portrait window and gives the controller the room under it.
 window/handheld/orientation=6
 
 [editor_plugins]


### PR DESCRIPTION
Delete two obsolete comment lines referencing `Gen2GameFrame.split()` and portrait window layout from project.godot. This is a no-op change that cleans up stale comments and does not alter runtime behavior.