### PR TITLE
A press cannot finish a printing page, and one file picker for all of them

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -96,7 +96,7 @@ Two example mods are in `mods/examples/`, to copy into `user://mods/`:
 | Mod | Shows |
 |---|---|
 | `voxel_preview/` | A world renderer. Press `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it, on the native layer with a translucent text box and one registered setting |
-| `new_content/` | A species, a move, a move effect, two rebalancing patches and both event channels |
+| `new_content/` | Every non-renderer surface in one file: a type and two matchups, a species with its own art, a move, a move effect, an item with its pocket and mart shelf, a named control axis, a visible-encounter population that reads the run's rules, two rebalancing patches, both event channels and the world channel's presentation mutator |
 
 The repository examples are development material and are excluded from every
 export preset. A distributed build contains the loader but no preinstalled mod;
@@ -201,9 +201,13 @@ belongs to the first one followed, so it is on screen once.
 
 ## Adding content
 
-`mods/examples/new_content/` registers a species, a move, a move effect and two
-rebalancing patches, and watches both event channels. Copy it and read it beside
-this section.
+`mods/examples/new_content/` is every non-renderer surface of the contract in one
+file, `api_version` 5: it registers a type and two chart exceptions, a species
+with its own decoded art, a move and its effect, an item with a pack pocket and a
+mart shelf, a named control axis and a visible-encounter population that reads
+the run's rules, patches two cartridge rows, watches both event channels and
+rewrites the world channel's presentation. Copy it and read it beside this
+section.
 
 A content number is per kind and starts at `Gen2ContentOverlay.FIRST_MOD_NUMBER`,
 which is 256. Every cartridge number fits in a byte, so a number that does not is

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -325,12 +325,21 @@ var _audio_player: Gen2AudioPlayer = null
 ## step `HPBarAnim_BGMapUpdate` waits and `BattleIntroSlidingPics`' own
 ## `DelayFrame` are both hardware frame counts.
 func _process(delta: float) -> void:
+	if _box != null:
+		_box.accelerated = Gen2Button.text_accelerating()
 	## The yes/no box appears when the question above it has finished printing,
 	## and the box prints on its own clock rather than on a press.
 	if _switch_stage != &"":
 		_advance_party_icons(delta)
 		_refresh_menu_layer()
-	if not frames_running():
+	## The box is on the same hardware clock as everything else the screen draws,
+	## and it keeps counting while nothing else does: a text prints, scrolls and
+	## blinks its arrow whether or not a bar or an animation is running.
+	## [method frames_running] deliberately does not answer for it, since a box
+	## waiting at a page is waiting on a press and a caller draining frames on
+	## that answer would never stop.
+	var running: bool = frames_running()
+	if not running and (_box == null or not _box.visible):
 		_frame_elapsed = 0.0
 		return
 	## Capped the way [method Gen2WorldScreen._process] caps it: a stall should
@@ -339,9 +348,14 @@ func _process(delta: float) -> void:
 		_frame_elapsed + delta,
 		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
 	)
-	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS and frames_running():
+	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
 		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
-		advance_frame()
+		if frames_running():
+			advance_frame()
+		elif _box != null:
+			_box.advance_frame()
+		else:
+			break
 
 
 ## Whether anything is counting hardware frames right now. Public with
@@ -362,6 +376,8 @@ func frames_running() -> bool:
 ## [method advance_bars] and [method advance_intro] so a test or a screenshot
 ## driver can settle either without waiting on real time.
 func advance_frame() -> bool:
+	if _box != null:
+		_box.advance_frame()
 	var moved: bool = advance_intro()
 	moved = advance_bars() or moved
 	moved = advance_faint() or moved
@@ -425,6 +441,7 @@ func _ready() -> void:
 	_screen.display(_menu_layer)
 
 	_box = Gen2TextBox.new()
+	_box.driven = true
 	_box.font = Gen2Font.from_data(_data)
 	## wTextboxFrame and the TEXT SPEED delay: a battle's own boxes are the
 	## player's boxes, drawn through `PrintLetterDelay` like every other one.

--- a/game/input/button.gd
+++ b/game/input/button.gd
@@ -103,3 +103,11 @@ static func released_in(event: InputEvent) -> int:
 
 static func held(button: int) -> bool:
 	return Input.is_action_pressed(ACTIONS.get(button, &""))
+
+
+## Whether a printing text should run at one letter a frame. `PrintLetterDelay`
+## reads `hJoyDown` and answers a HELD A or B with a single `DelayFrame`
+## (`home/print_text.asm`), so this is the whole of what a button does to text
+## that is still appearing, and it is a hold rather than a press.
+static func text_accelerating() -> bool:
+	return held(A) or held(B)

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -261,6 +261,31 @@ static func slider(
 	return line
 
 
+## The one file picker every launcher dialog is built from.
+##
+## `use_native_dialog` is asked for unconditionally rather than gated on
+## `FEATURE_NATIVE_DIALOG_FILE`: [FileDialog] already makes that exact test
+## before it goes native and falls back to its own window when the platform says
+## no, so a second gate here can only refuse a picker the platform would have
+## given us. That is what left iOS on the built-in browser, which lists paths
+## `FileAccess.open()` then refuses on every sandboxed platform. Any new
+## file-picking UI goes through here rather than building its own [FileDialog].
+static func file_picker(
+	theme: Gen2LauncherTheme,
+	title_text: String,
+	mode: FileDialog.FileMode,
+	filters: PackedStringArray
+) -> FileDialog:
+	var dialog := FileDialog.new()
+	dialog.file_mode = mode
+	dialog.access = FileDialog.ACCESS_FILESYSTEM
+	dialog.filters = filters
+	dialog.title = title_text
+	dialog.use_native_dialog = true
+	dialog.theme = theme.control_theme()
+	return dialog
+
+
 static func _label(text: String, size: int, colour: Color) -> Label:
 	var label := Label.new()
 	label.text = text

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -101,18 +101,9 @@ func _build_dialogs() -> void:
 
 
 func _picker(title: String, filters: PackedStringArray) -> FileDialog:
-	var dialog := FileDialog.new()
-	dialog.file_mode = FileDialog.FILE_MODE_OPEN_FILE
-	dialog.access = FileDialog.ACCESS_FILESYSTEM
-	dialog.filters = filters
-	dialog.title = title
-	# Android's own picker is the only one that returns a readable file: the app
-	# declares no storage permission, so a path the built-in browser lists still
-	# fails to open. The system picker grants access to the one file chosen.
-	dialog.use_native_dialog = DisplayServer.has_feature(
-		DisplayServer.FEATURE_NATIVE_DIALOG_FILE
+	var dialog: FileDialog = Gen2LauncherUI.file_picker(
+		_palette, title, FileDialog.FILE_MODE_OPEN_FILE, filters
 	)
-	dialog.theme = _palette.control_theme()
 	add_child(dialog)
 	return dialog
 

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -58,6 +58,27 @@ const TILE: int = Gen2Font.TILE
 ## Tiles per second while a page is revealing. The games run this off the frame
 ## counter; a rate is the same thing said in a way that does not assume 60 Hz.
 @export var reveal_speed: float = 30.0
+## Whether A or B is being HELD, which is the whole of what a button does to a
+## printing text. `PrintLetterDelay` reads `hJoyDown` and answers a held A or B
+## with a single `DelayFrame`, whatever the speed setting says
+## (`home/print_text.asm`): one letter a frame, and never the rest of the page.
+## A host sets this per frame; nothing here polls, so a replay and a check drive
+## the same acceleration a player does.
+@export var accelerated: bool = false
+## Whether a host spends this box's hardware frames itself with
+## [method advance_frame]. The reveal is a frame count on the cartridge, so a
+## screen that already owns the frame drives the box on the same clock as
+## everything else it draws, and the box never runs a second one of its own.
+## Off leaves the box on real time, which is what a dev viewer with no frame
+## pump wants.
+var driven: bool = false:
+	set(value):
+		driven = value
+		if value:
+			set_process(false)
+## `TEXT_DELAY_FAST` is one frame a letter, which is what a held A or B costs and
+## also the fastest the speed setting goes.
+const ACCELERATED_SPEED: float = 60.0
 ## Per-scanline background offsets for the box's own rows, empty when the
 ## background is sitting still. A box is drawn into the background plane like
 ## everything else, so a routine that scrolls the plane scrolls the box with it;
@@ -127,7 +148,8 @@ func _process(delta: float) -> void:
 		_advance_scroll(delta)
 		return
 	if _shown < float(_tiles_on_page):
-		_shown = minf(_shown + delta * reveal_speed, float(_tiles_on_page))
+		var rate: float = maxf(reveal_speed, ACCELERATED_SPEED) if accelerated else reveal_speed
+		_shown = minf(_shown + delta * rate, float(_tiles_on_page))
 		_redraw()
 		return
 	if _pages.is_empty():
@@ -158,6 +180,29 @@ func show_text(text: String) -> void:
 	_scroll_page = -1
 	_scroll_lines = []
 	_start_page()
+
+
+## How many hardware frames the box still owes before it reaches its
+## `PromptButton`: the rest of the page, or the rest of a `TextScroll`. Zero
+## while it is waiting on a press, which is what it is waiting on there.
+##
+## Public so a caller settling a screen by frames settles the text with it. A
+## screen that owns the frame has no other way to know a printing text is not
+## finished, and a press cannot shorten it.
+func frames_left() -> int:
+	if _scroll_page >= 0:
+		var steps: int = SCROLL_STEPS - _scroll_rows
+		return int(ceil(float(steps) * float(SCROLL_STEP_FRAMES) - _scroll_elapsed))
+	var rate: float = maxf(reveal_speed, ACCELERATED_SPEED) if accelerated else reveal_speed
+	if rate <= 0.0 or _shown >= float(_tiles_on_page):
+		return 0
+	var frames: float = (float(_tiles_on_page) - _shown) / (rate * FRAME_SECONDS)
+	var whole: int = int(ceil(frames))
+	# The reveal is a float summed a frame at a time, so a run that divides
+	# exactly lands a hair short of its own total and owes one more frame. A
+	# count that is one low leaves the caller waiting on a press that will not
+	# come, which is worse than a spare frame.
+	return whole + 1 if is_equal_approx(float(whole), frames) else whole
 
 
 ## True while a page still has tiles left to reveal, or while the box is in the
@@ -192,14 +237,19 @@ func finish() -> void:
 	_redraw()
 
 
-## What a button press does: completes the page if it is still revealing,
-## otherwise moves to the next one. Returns false once there is nothing left,
-## having emitted [signal finished].
+## What a button press does: moves to the next page. Returns false once there is
+## nothing left, having emitted [signal finished].
+##
+## A press while the page is still printing is SPENT and does nothing else. The
+## cartridge has no path from a press to the end of a page: `PrintLetterDelay`
+## is the only thing a button reaches while text is running and the most it does
+## is [member accelerated]. Completing the page on the press instead let a
+## repeated one tear through a whole text a page per press, which is what
+## holding the advance key looked like.
 func advance() -> bool:
 	if _pages.is_empty():
 		return false
 	if is_revealing():
-		finish()
 		return true
 
 	if _enter_of(_page + 1) == &"scroll":
@@ -265,7 +315,7 @@ func _begin_scroll(next_page: int) -> void:
 	_lines = []
 	_tiles_on_page = 0
 	_shown = 0.0
-	set_process(true)
+	set_process(not driven)
 	_redraw()
 
 
@@ -325,7 +375,7 @@ func _start_page() -> void:
 
 	_shown = 0.0
 	_blink = 0.0
-	set_process(_tiles_on_page > 0)
+	set_process(_tiles_on_page > 0 and not driven)
 	if reveal_speed <= 0.0:
 		_shown = float(_tiles_on_page)
 	_redraw()

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -242,15 +242,7 @@ func _build_ui() -> void:
 	_slot_import_dialog.file_selected.connect(_import_slot_file)
 
 func _picker(title: String, mode: FileDialog.FileMode, filters: PackedStringArray) -> FileDialog:
-	var dialog := FileDialog.new()
-	dialog.file_mode = mode
-	dialog.access = FileDialog.ACCESS_FILESYSTEM
-	dialog.filters = filters
-	dialog.title = title
-	dialog.use_native_dialog = DisplayServer.has_feature(
-		DisplayServer.FEATURE_NATIVE_DIALOG_FILE
-	)
-	dialog.theme = _palette.control_theme()
+	var dialog: FileDialog = Gen2LauncherUI.file_picker(_palette, title, mode, filters)
 	add_child(dialog)
 	return dialog
 

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -107,6 +107,7 @@ func _ready() -> void:
 	add_child(_pic)
 
 	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
 	_text_box.font = Gen2Font.from_data(_data)
 	_text_box.frame_style = Gen2OptionsStore.current().textbox_frame
 	_text_box.position = Vector2(0, Gen2TextBox.STANDARD_TOP * TILE)
@@ -120,6 +121,8 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
+	if _text_box != null:
+		_text_box.accelerated = Gen2Button.text_accelerating()
 	_accumulator += delta * Gen2IntroPresentation.FRAME_RATE
 	var frames: int = int(_accumulator)
 	_accumulator -= float(frames)
@@ -131,6 +134,8 @@ func _process(delta: float) -> void:
 ## `DelayFrames` without a clock; [method _process] is the only other caller.
 func advance_frames(count: int) -> void:
 	for _frame: int in count:
+		if _text_box != null:
+			_text_box.advance_frame()
 		if _phase != Phase.ANIMATING:
 			# The cry sits inside `OakText2`'s own `text_asm`, so it fires when
 			# the words have finished appearing rather than when A is pressed.
@@ -167,9 +172,13 @@ func name_choice_image() -> Image:
 	return _name_menu.image() if _name_menu != null else null
 
 
-## How many source frames the queued animation still owes, zero at a `PrintText`.
+## How many source frames the screen still owes before it is waiting on a press:
+## the queued animation, or the rest of a text that is still printing. A press
+## cannot shorten either, so a caller settling the screen spends these.
 func animation_frames_left() -> int:
-	return _presentation.remaining_frames() if _phase == Phase.ANIMATING else 0
+	if _phase == Phase.ANIMATING:
+		return _presentation.remaining_frames()
+	return _text_box.frames_left() if _text_box != null else 0
 
 
 ## The name the intro has settled on so far, empty until the naming screen

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -309,6 +309,10 @@ func _build_world() -> void:
 	add_child(_audio_player)
 	_play_current_map_music()
 	_text_box = Gen2TextBox.new()
+	# The overworld owns the frame, so the reveal is spent in [method
+	# advance_frame] with everything else the frame draws rather than on a second
+	# clock only real time turns.
+	_text_box.driven = true
 	_text_box.font = Gen2Font.from_data(_data)
 	_apply_text_box_options()
 	_text_box.place_at_bottom()
@@ -475,6 +479,9 @@ func advance_frames(count: int) -> void:
 ## [member Gen2WorldAPI.frame_number] and not of banked real time.
 func advance_frame() -> void:
 	_spending_frame = true
+	if _text_box != null:
+		_text_box.accelerated = Gen2Button.text_accelerating()
+		_text_box.advance_frame()
 	if _world != null:
 		_world.advance_frame_counter()
 		if _replaying_input:
@@ -2194,10 +2201,6 @@ func _on_battle_finished(result: Dictionary) -> void:
 
 
 func _advance_script_input() -> void:
-	if _text_box.is_revealing():
-		_text_box.finish()
-		_continue_if_text_settled()
-		return
 	if _text_box.advance():
 		_continue_if_text_settled()
 		return
@@ -2663,9 +2666,6 @@ func _show_prof_oaks_pc_page() -> void:
 func _advance_prof_oaks_pc() -> void:
 	if _text_box == null:
 		_close_prof_oaks_pc()
-		return
-	if _text_box.is_revealing():
-		_text_box.finish()
 		return
 	if _text_box.advance():
 		return

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -18,29 +18,55 @@ const STATIC_FIELD: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
 ## An effect byte no cartridge move carries.
 const RECOIL_AND_PARALYSE: int = 0xF0
 
-## Electric. RomLayout names only the types the engine itself names; the rest are
-## reached by number, since a move's type byte is already one.
-const ELECTRIC: int = 0x17
+const ELECTRIC: int = RomLayout.TYPE_ELECTRIC
+## A type of the mod's own. Types are the one kind numbered from zero, the
+## cartridge chart being zero-based, so a DEFINED one still sits past 256.
+const PLASMA: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
+## An item of the mod's own, and the pack pocket it lands in. A mod pocket is at
+## or above Gen2ModHost.FIRST_MOD_POCKET; 1 to 4 are the cartridge's.
+const CELL_BATTERY: int = Gen2ContentOverlay.FIRST_MOD_NUMBER
+const CURIOS_POCKET: int = Gen2ModHost.FIRST_MOD_POCKET
 ## Cartridge numbers, for the two rows this mod changes rather than adds.
 const PIKACHU: int = 25
 const THUNDERBOLT: int = 85
 
-
 func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
+	_add_a_type(host, manifest.id)
 	_add_a_species(host, manifest.id)
 	_add_a_move(host, manifest.id)
+	_add_an_item_and_its_shelf(host, manifest.id)
+	_add_a_control(host, manifest.id)
+	_populate_the_map(host, manifest.id)
 	_rebalance(host, manifest.id)
 	_watch(host, manifest.id)
+
+
+## A type, and the two chart exceptions that make it mean something
+## (`api_version` 4).
+##
+## The chart is a sparse table of exceptions, so a pair nobody names is already
+## neutral: there is no row to define and matchups are patched even for a type
+## this mod invented. `physical` is which stat pair the type uses, which
+## Generation II decides by type number rather than per move, so a number past
+## the cartridge chart has to say.
+func _add_a_type(host: Gen2ModHost, id: StringName) -> void:
+	host.register_content(Gen2ContentOverlay.KIND_TYPE, id, PLASMA, {
+		"name": "PLASMA",
+		"physical": false,
+	})
+	# Multipliers are in tenths, the way the damage formula divides.
+	host.patch_type_matchup(id, PLASMA, RomLayout.TYPE_STEEL, {
+		"multiplier": RomLayout.MATCHUP_SUPER_EFFECTIVE,
+	})
+	host.patch_type_matchup(id, RomLayout.TYPE_GROUND, PLASMA, {
+		"multiplier": RomLayout.MATCHUP_NOT_VERY_EFFECTIVE,
+	})
 
 
 ## A whole Pokémon. Everything a species carries is a field on one row, so the
 ## learnset, the evolution and the TM flags are part of the definition rather
 ## than four separate registrations; anything left out gets the kind's default,
 ## which is why this does not have to name a hatch cycle or a gender ratio.
-##
-## It has no pic: the atlas is decoded from the cartridge and holds 251 slots. A
-## mod wanting art for its own species needs a renderer, which is the other half
-## of docs/MODS.md.
 func _add_a_species(host: Gen2ModHost, id: StringName) -> void:
 	host.register_content(Gen2ContentOverlay.KIND_SPECIES, id, VOLTLING, {
 		"name": "VOLTLING",
@@ -48,8 +74,7 @@ func _add_a_species(host: Gen2ModHost, id: StringName) -> void:
 			"hp": 70, "attack": 65, "defense": 60,
 			"speed": 115, "sp_attack": 110, "sp_defense": 70,
 		},
-		# The second slot repeated is how the cartridge writes a single type.
-		"types": [ELECTRIC, ELECTRIC],
+		"types": [ELECTRIC, PLASMA],
 		"catch_rate": 45,
 		"base_exp": 180,
 		"growth_rate": Gen2Experience.GROWTH_MEDIUM_FAST,
@@ -60,7 +85,29 @@ func _add_a_species(host: Gen2ModHost, id: StringName) -> void:
 			{"level": 36, "move": THUNDERBOLT},
 		],
 		"evolutions": [],
+		# The pic atlases hold the cartridge's own slots and nothing else, so a
+		# defined species supplies decoded indices instead: two bits a pixel,
+		# row-major, exactly tiles * tiles * 64 of them (`api_version` 4).
+		"pics": {
+			"front": {"tiles": 7, "indices": _plaid(7)},
+			"back": {"tiles": 6, "indices": _plaid(6)},
+		},
+		# Eight tiles, the two 2x2 frames of the party menu's own strip. A
+		# cartridge icon number, 1 to 38, borrows a picture that already exists.
+		"icon": {"indices": _plaid(0, 8)},
+		"palette": {"normal": [0x3F1F, 0x1084], "shiny": [0x7FE0, 0x1084]},
 	})
+
+
+## Two bits a pixel is four shades, and a readable placeholder is worth more here
+## than a picture: the point of the example is the SHAPE the host takes.
+func _plaid(tiles: int, count: int = 0) -> PackedByteArray:
+	var pixels: int = count * 64 if count > 0 else tiles * tiles * 64
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(pixels)
+	for at: int in pixels:
+		out[at] = ((at >> 3) + at) & 3
+	return out
 
 
 ## A move, and the effect that decides what it does.
@@ -96,6 +143,160 @@ func _add_a_move(host: Gen2ModHost, id: StringName) -> void:
 	})
 
 
+## An item, the pocket it lands in, and the mart shelf it is sold from
+## (`api_version` 3).
+##
+## The shelf row is a MENU entry rather than content: the item exists whatever a
+## mart sells, and `available` decides which marts carry it. A filter is handed
+## the resolved mart, `mart_id` included, and a row is dropped when it answers
+## false or when the cartridge shelf already sells that item.
+func _add_an_item_and_its_shelf(host: Gen2ModHost, id: StringName) -> void:
+	host.register_content(Gen2ContentOverlay.KIND_ITEM, id, CELL_BATTERY, {
+		"name": "CELLBATTERY",
+		"price": 800,
+		"pocket": CURIOS_POCKET,
+	})
+	host.register_menu_entry(Gen2ModHost.MENU_PACK_POCKET, id, {
+		"label": "CURIOS",
+		"pocket": CURIOS_POCKET,
+	})
+	host.register_menu_entry(Gen2ModHost.MENU_MART, id, {
+		"label": "CELLBATTERY",
+		"item": CELL_BATTERY,
+		# Half what the pack values it at, so the shelf price is visibly the
+		# shelf's rather than the item's.
+		"price": 400,
+		"available": func(mart: Dictionary) -> bool:
+			return int(mart.get("variant", 0)) == 0,
+	})
+
+
+## A control of the mod's own, as the two halves of one named axis
+## (`api_version` 3).
+##
+## A mod cannot see the cartridge's eight and the screen claims every one of them
+## first, so a raw keycode read out of `handle_world_input` would produce a
+## control that cannot be rebound and does not exist on a touchscreen. A default
+## already bound to one of the eight is dropped and reported rather than
+## silently never firing, which is why neither of these is `A` or `D`.
+func _add_a_control(host: Gen2ModHost, id: StringName) -> void:
+	host.register_action(id, {
+		"key": "survey_left", "label": "Survey left",
+		"default": [{"kind": "key", "code": KEY_Q}],
+	})
+	host.register_action(id, {
+		"key": "survey_right", "label": "Survey right",
+		"default": [{"kind": "key", "code": KEY_E}],
+	})
+
+
+## Wild Pokemon standing on the map instead of a roll on every step
+## (`api_version` 2), and the run's own rules deciding how they behave
+## (`api_version` 5).
+##
+## The provider owns its population and nothing else: which cells a wild may
+## stand on, which table each is checked against and what a battle costs all stay
+## the host's. It is a RefCounted and never a Node, and its four methods are
+## refused by name at registration.
+func _populate_the_map(host: Gen2ModHost, id: StringName) -> void:
+	host.register_visible_encounters(id, Population.new())
+
+
+## Rewriting how an event is PRESENTED, without changing what happened
+## (`api_version` 4).
+##
+## One mutator per channel, ahead of every watcher, and the host refuses a return
+## that changed the event's own kind: a mutator may dress a result and may not
+## turn one result into another. This is why the pair is registered rather than
+## the subscriber doing both jobs.
+func _rewrite_presentation(host: Gen2ModHost, id: StringName) -> void:
+	host.register_event_mutator(Gen2ModHost.CHANNEL_WORLD, id, _dress_world_event)
+
+
+## `status` is the world channel's routing key and is left exactly as it came:
+## the text a waiting result is showing is presentation, and which screen
+## operation the result is is not.
+func _dress_world_event(result: Dictionary) -> Dictionary:
+	var event: Dictionary = result.get("event", {})
+	if StringName(event.get("type", &"")) == &"text":
+		event["text"] = String(event.get("text", "")).replace("PIKACHU", "VOLTLING")
+		result["event"] = event
+	return result
+
+
+## The population itself. A separate object because a provider is a RefCounted
+## the host holds by name, and because everything it is told is a SNAPSHOT: the
+## context is a copy taken when the map or the player's pose changed, never a
+## live handle on the world.
+class Population:
+	extends RefCounted
+
+	## How many wanderers stand on a map, out of the cells the host says a wild
+	## is allowed on at all.
+	const POPULATION: int = 3
+
+	var _context: Dictionary = {}
+	var _entries: Array = []
+	var _generation: int = -1
+
+	func set_context(context: Dictionary) -> void:
+		_context = context
+		# `generation` is bumped on every map change, so this is the one test
+		# that says "a new map" rather than "the player moved".
+		if int(context.get("generation", -1)) == _generation:
+			return
+		_generation = int(context.get("generation", -1))
+		_repopulate()
+
+	func advance_frame() -> void:
+		pass
+
+	func encounters() -> Array:
+		return _entries
+
+	## This provider's rule, which every provider owes its reader: an entry the
+	## player fought is gone whatever the battle did.
+	func battle_finished(id: StringName, _result: Dictionary) -> void:
+		for at: int in _entries.size():
+			if StringName((_entries[at] as Dictionary)["id"]) == id:
+				_entries.remove_at(at)
+				return
+
+	func _repopulate() -> void:
+		_entries = []
+		var cells: PackedVector2Array = (
+			_context.get("eligible", {}).get("grass", PackedVector2Array())
+		)
+		var table: Array = _context.get("tables", {}).get("grass", {}).get("slots", [])
+		if cells.is_empty() or table.is_empty():
+			return
+		# The run's seed rather than a fresh generator, so the same save walking
+		# back onto the same map meets the same population.
+		var rolls := RandomNumberGenerator.new()
+		rolls.seed = int(_context.get("run_seed", 0)) ^ _generation
+		# `Gen2Rules` is the run's own divergence flags. A run reproducing the
+		# cartridge's bugs is the one that wants the cartridge's density; read
+		# it, never write it, since a rule that changed mid-run would make the
+		# save it produced unreproducible.
+		var count: int = POPULATION
+		if Gen2Rules.active().difficulty == Gen2Rules.DIFFICULTY_HARD:
+			count += 1
+		for at: int in mini(count, cells.size()):
+			var slot: Dictionary = table[rolls.randi_range(0, table.size() - 1)]
+			_entries.append({
+				"id": StringName("voltling_%d_%d" % [_generation, at]),
+				"cell": Vector2i(cells[rolls.randi_range(0, cells.size() - 1)]),
+				"facing": Gen2WorldSprite.FACING_DOWN,
+				"species": int(slot.get("species", 0)),
+				"level": int(slot.get("min_level", 2)),
+				"dvs": Gen2BattleMon.PERFECT_DVS,
+				# Asked for on spawn; the host drops a repeat inside
+				# Gen2WorldEncounters.PULSE_FRAMES and draws nothing over a
+				# Pokemon that is not shiny.
+				"pulse": true,
+			})
+
+
 ## Changing what the cartridge shipped, rather than adding to it. A patch names
 ## only the fields it changes, and a Dictionary field merges, so this moves one
 ## stat and one number and leaves everything else on both rows alone.
@@ -113,6 +314,7 @@ func _rebalance(host: Gen2ModHost, id: StringName) -> void:
 func _watch(host: Gen2ModHost, id: StringName) -> void:
 	host.subscribe(Gen2ModHost.CHANNEL_BATTLE, id, _on_battle_event)
 	host.subscribe(Gen2ModHost.CHANNEL_WORLD, id, _on_world_event)
+	_rewrite_presentation(host, id)
 
 
 func _on_battle_event(event: Dictionary) -> void:

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 1,
+	"api_version": 5,
 	"entry": "mod.gd",
-	"description": "Adds a species, a move and a move effect, rebalances a cartridge one, and watches the world and battle event channels. The reference for everything a mod can register that is not a renderer."
+	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 1,
+	"api_version": 5,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_battle_move_forget.gd
+++ b/tests/integration/test_battle_move_forget.gd
@@ -93,8 +93,16 @@ func _stage() -> String:
 ## test_a_confirm_pages_the_prompt_before_answering_it.
 func _drain_box() -> void:
 	var box: Gen2TextBox = _screen.get("_box")
-	while box != null and box.advance():
-		pass
+	if box == null:
+		return
+	# A press cannot finish a printing page any more than it can on the
+	# cartridge, so reading to the end is frames first and then the page turn.
+	while true:
+		if box.is_revealing():
+			box.advance_frame()
+			continue
+		if not box.advance():
+			return
 
 
 func _press(button: int) -> void:

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -409,6 +409,9 @@ func test_experience_says_its_line_first_and_the_level_line_after_the_bar() -> v
 		"the level line waited for the bar to reach the end"
 	)
 
+	# The level line has to finish printing before a press can turn its page: a
+	# press reaches nothing but `PrintLetterDelay` while a text is running.
+	_battle_screen._box.finish()
 	_battle_screen._box.advance()
 	_battle_screen.advance()
 	assert_false(_battle_screen._exp_bar.paused(), "the press let the next fill start")

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -109,6 +109,9 @@ func _read_question() -> void:
 
 func _press(button: int) -> void:
 	_settle_bars()
+	# A press cannot finish a printing page, so the page is read first, which is
+	# what a player waits through.
+	_screen.finish()
 	_screen._handle_button(button)
 	await get_tree().process_frame
 
@@ -204,10 +207,8 @@ func test_the_one_already_out_is_refused_and_the_list_comes_back() -> void:
 	)
 	assert_eq(battle.awaiting_switch_offer(), 1, "and nothing was answered")
 
-	## The first press finishes the line the box is still revealing, as it does
-	## anywhere else; the second is the one `StdBattleTextbox` was waiting for.
-	await _press(Gen2Button.A)
-	assert_eq(_stage(), "refused")
+	## One press, which is the one `StdBattleTextbox` was waiting for: the line is
+	## read first and a press cannot shorten the reading.
 	await _press(Gen2Button.A)
 	assert_eq(_stage(), "pick", "the list is redrawn")
 	assert_true(_layer().visible)
@@ -397,7 +398,6 @@ func test_the_fainted_row_is_refused_and_the_list_comes_back() -> void:
 	)
 	assert_true(battle.must_replace(Gen2Battle.PLAYER), "and nothing was answered")
 
-	await _press(Gen2Button.A)
 	await _press(Gen2Button.A)
 	assert_eq(_stage(), "pick", "the list is redrawn")
 	assert_true(bool(_screen.battle_snapshot()["switch_forced"]), "still with no way out")

--- a/tests/integration/test_oak_speech.gd
+++ b/tests/integration/test_oak_speech.gd
@@ -269,6 +269,9 @@ func test_the_speech_ends_on_the_shrink_rather_than_on_the_last_text() -> void:
 	for _step: int in 40:
 		if _screen.beat_index() >= _screen.beat_count():
 			break
+		# The page has to print before a press can turn it; only the shrink the
+		# last page starts is deliberately left unspent.
+		_screen.advance_frames(_screen.animation_frames_left())
 		_screen.handle_button(Gen2Button.A)
 	assert_eq(_finished.size(), 0, "the speech has not handed a name over yet")
 	assert_eq(_screen.animation_frames_left(), 8, "ShrinkPlayer's first DelayFrames")

--- a/tests/integration/test_world_prof_oaks_pc.gd
+++ b/tests/integration/test_world_prof_oaks_pc.gd
@@ -12,8 +12,10 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 const PLAYER_CELL: Vector2i = Vector2i(2, 2)
 const TUTORIAL_CELL: Vector2i = Vector2i(4, 5)
 const GOODBYE_TEXT: int = 0x6400
-## Each page takes two presses: one completes the reveal, the next advances.
-const PRESSES_PER_PAGE: int = 2
+## A page costs one press, once it has finished printing. A press cannot shorten
+## the printing: `PrintLetterDelay` is the only thing a button reaches while text
+## is running, so a page is spent in frames and then turned.
+const PRESSES_PER_PAGE: int = 1
 
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
@@ -23,6 +25,12 @@ func before_each() -> void:
 	Fixture.build()
 	_write_oak_script()
 	_data = GameData.open_directory(Fixture.directory())
+	## The box reveals at the OPTION menu's TEXT SPEED and a press cannot
+	## shorten it, so a page count depends on the setting: run on the test
+	## path's defaults rather than on whatever an earlier script, or this
+	## machine's own installed options, left behind.
+	Gen2OptionsStore.use_test_path()
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
 
 
 func after_each() -> void:
@@ -63,6 +71,10 @@ func _open_world() -> void:
 	_world_screen.set_save(save)
 	add_child(_world_screen)
 	await get_tree().process_frame
+	# The box reveals on hardware frames now, and this test counts pages against
+	# exact presses: take the host's processing away so the frames it spends are
+	# the ones it asked for.
+	_world_screen.set_process(false)
 
 
 func _run_script() -> void:
@@ -87,10 +99,12 @@ func test_a_or_b_walks_the_pages_and_hands_the_box_back_to_the_script() -> void:
 	await _open_world()
 	_run_script()
 	for _press: int in PRESSES_PER_PAGE * 2:
+		_settle_text()
 		_world_screen.press_button(Gen2Button.B)
 	assert_eq(_world_screen._oak_pc_pages.size(), 1, "the rating is up")
 
 	for _press: int in PRESSES_PER_PAGE:
+		_settle_text()
 		_world_screen.press_button(Gen2Button.A)
 	assert_eq(_world_screen._oak_pc_pages.size(), 0)
 	assert_true(_world_screen._text_box.visible, "the script's own text now")
@@ -104,3 +118,12 @@ func test_the_pages_hold_the_world() -> void:
 	_run_script()
 	assert_false(_world_screen.move_player(Vector2i.RIGHT))
 	assert_false(_world_screen.interact())
+
+
+## Spends the frames the box still owes, which is what a player waits through.
+func _settle_text() -> void:
+	var box: Gen2TextBox = _world_screen._text_box
+	var guard: int = 600
+	while box != null and box.is_revealing() and guard > 0:
+		_world_screen.advance_frame()
+		guard -= 1

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -20,6 +20,12 @@ func before_each() -> void:
 	_data = Fixture.build()
 	_add_capture_metadata()
 	_data = GameData.open_directory(Fixture.directory())
+	## The box reveals at the OPTION menu's TEXT SPEED and a press cannot
+	## shorten it, so a page count depends on the setting: run on the test
+	## path's defaults rather than on whatever an earlier script, or this
+	## machine's own installed options, left behind.
+	Gen2OptionsStore.use_test_path()
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
 
 
 func after_each() -> void:
@@ -367,10 +373,11 @@ func test_production_world_entry_and_facing_object_story_persist_separate_flags(
 	assert_false(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_false(_world_screen._world.state.hall_of_fame())
 
-	## Two presses, not one: the box reveals at the OPTION menu's TEXT SPEED now,
-	## and the first press completes the page the way holding A does in
-	## `PrintLetterDelay`. The second is the one that acknowledges it.
-	_world_screen._advance_script_input()
+	## The box reveals at the OPTION menu's TEXT SPEED, and a press cannot shorten
+	## it: `PrintLetterDelay` is all a button reaches while a text is running, and
+	## the most it does there is one letter a frame. So the page is spent in
+	## frames and then one press acknowledges it.
+	_world_screen.advance_frames(_world_screen._text_box.frames_left())
 	_world_screen._advance_script_input()
 	assert_true(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_true(_world_screen._world.state.hall_of_fame())

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -97,6 +97,41 @@ func test_every_named_icon_rasterises_rather_than_drawing_nothing() -> void:
 	assert_eq(Gen2LauncherIcon.source_path(&"nonesuch"), "")
 
 
+## The built-in browser lists paths `FileAccess.open()` then refuses on every
+## sandboxed platform, so a dialog that does not ask for the system picker is a
+## picker the player cannot import with. `FileDialog` makes the feature test
+## itself, so asking is always right and gating is what breaks iOS.
+func test_every_file_picker_asks_for_the_systems_own() -> void:
+	var dialog: FileDialog = Gen2LauncherUI.file_picker(
+		_light, "Choose", FileDialog.FILE_MODE_OPEN_FILE, PackedStringArray(["*.gbc; Dump"])
+	)
+	autofree(dialog)
+	assert_true(dialog.use_native_dialog)
+	assert_eq(dialog.access, FileDialog.ACCESS_FILESYSTEM)
+	assert_eq(dialog.file_mode, FileDialog.FILE_MODE_OPEN_FILE)
+	assert_eq(dialog.title, "Choose")
+	# One helper, so a screen added later cannot reintroduce its own gate.
+	for path: String in _scripts_under("res://game"):
+		var source: String = FileAccess.get_file_as_string(path)
+		if path.ends_with("launcher/launcher_ui.gd"):
+			continue
+		assert_false(source.contains("FileDialog.new()"), path)
+		assert_false(source.contains("FEATURE_NATIVE_DIALOG_FILE"), path)
+
+
+func _scripts_under(root: String) -> Array[String]:
+	var found: Array[String] = []
+	var queue: Array[String] = [root]
+	while not queue.is_empty():
+		var directory: String = queue.pop_front()
+		for name: String in DirAccess.get_directories_at(directory):
+			queue.append("%s/%s" % [directory, name])
+		for name: String in DirAccess.get_files_at(directory):
+			if name.ends_with(".gd"):
+				found.append("%s/%s" % [directory, name])
+	return found
+
+
 ## A launcher page scrolls vertically only, so nothing inside one may measure
 ## wider than the window it is given: a portrait phone is the ordinary case.
 func test_a_settings_row_stacks_rather_than_running_off_a_narrow_page() -> void:

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -301,6 +301,58 @@ func test_the_shipped_example_mod_registers_everything_it_documents() -> void:
 	assert_eq(int(pikachu["stats"]["hp"]), 35)
 	assert_eq(String(pikachu["name"]), "PIKACHU")
 
+	# The example is the documentation for the whole contract, so it declares the
+	# current one and demonstrates each surface a version added. A host bump with
+	# the example left behind fails here rather than in a mod author's reading.
+	for id: String in ["new_content", "voxel_preview"]:
+		var declared: Dictionary = Gen2ModManifest.read("res://mods/examples/%s" % id)
+		assert_true(bool(declared.get("ok", false)), id)
+		assert_eq(
+			(declared["manifest"] as Gen2ModManifest).api_version,
+			Gen2ModManifest.API_VERSION,
+			id
+		)
+	# 4: a type of its own, and a chart exception naming it.
+	assert_eq(
+		overlay.defined_numbers(Gen2ContentOverlay.KIND_TYPE),
+		[Gen2ContentOverlay.FIRST_MOD_NUMBER] as Array[int]
+	)
+	assert_eq(int(overlay.resolve(
+		Gen2ContentOverlay.KIND_MATCHUP,
+		Gen2ContentOverlay.matchup_number(
+			Gen2ContentOverlay.FIRST_MOD_NUMBER, RomLayout.TYPE_STEEL
+		),
+		{"multiplier": RomLayout.MATCHUP_EFFECTIVE}
+	).get("multiplier", 0)), RomLayout.MATCHUP_SUPER_EFFECTIVE)
+	# 4: decoded art, which is exactly tiles * tiles * 64 indices or it is dropped.
+	var voltling: Dictionary = overlay.resolve(
+		Gen2ContentOverlay.KIND_SPECIES, Gen2ContentOverlay.FIRST_MOD_NUMBER, {}
+	)
+	var front: Dictionary = (voltling["pics"] as Dictionary)["front"]
+	assert_eq((front["indices"] as PackedByteArray).size(), 7 * 7 * 64)
+	# 3: an item in a mod pocket, and the mart shelf it is sold from.
+	assert_eq(
+		int(overlay.resolve(
+			Gen2ContentOverlay.KIND_ITEM, Gen2ContentOverlay.FIRST_MOD_NUMBER, {}
+		)["pocket"]),
+		Gen2ModHost.FIRST_MOD_POCKET
+	)
+	var shelf: Array = host.mart_entries({"mart_id": 0, "variant": 0, "items": []})
+	assert_eq(shelf.size(), 1)
+	assert_eq(int((shelf[0] as Dictionary)["item"]), Gen2ContentOverlay.FIRST_MOD_NUMBER)
+	assert_eq(int((shelf[0] as Dictionary)["price"]), 400)
+	# 3: a named axis, whose two halves both registered rather than colliding
+	# with the cartridge's eight.
+	assert_eq(host.actions().size(), 2)
+	# 2: a visible-encounter population.
+	assert_eq(host.visible_encounter_ids().size(), 1)
+	# 4: one presentation mutator, which may not change the routing key.
+	var dressed: Dictionary = Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, {
+		"status": &"waiting", "event": {"type": &"text", "text": "PIKACHU!"},
+	})
+	assert_eq(StringName(dressed["status"]), &"waiting")
+	assert_eq(String((dressed["event"] as Dictionary)["text"]), "VOLTLING!")
+
 
 func test_every_refusal_reason_the_mod_layer_produces_has_player_wording() -> void:
 	# The launcher and the index dialog share one table now; a reason worded in

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -112,6 +112,52 @@ func _box() -> Gen2TextBox:
 	return box
 
 
+## `PrintLetterDelay` is the only thing a button reaches while a text is still
+## printing, and the most it does there is one letter a frame. There is no path
+## from a press to the end of a page, so a repeated press cannot tear through a
+## text: it is spent and the page keeps printing at its own rate.
+func test_a_press_cannot_finish_a_printing_page() -> void:
+	var box: Gen2TextBox = _box()
+	box.reveal_speed = 30.0
+	box.show_text("hello there" + Gen2TextStream.PAGE_BREAK + "second")
+	assert_true(box.is_revealing())
+
+	for _press: int in 20:
+		assert_true(box.advance(), "the press is spent on the box")
+	assert_true(box.is_revealing(), "and the page is still printing")
+	assert_true(box.has_pages_left(), "so no page was turned")
+
+	# It finishes on frames, and only then does a press turn the page.
+	var owed: int = box.frames_left()
+	assert_gt(owed, 0)
+	for _frame: int in owed:
+		box.advance_frame()
+	assert_false(box.is_revealing(), "frames_left() is enough to finish the page")
+	assert_true(box.advance())
+	assert_false(box.has_pages_left())
+
+
+## `PrintLetterDelay` answers a HELD A or B with a single `DelayFrame`, whatever
+## TEXT SPEED says, so holding one prints at the fastest the setting reaches and
+## never faster.
+func test_holding_a_button_prints_one_letter_a_frame() -> void:
+	var slow: Gen2TextBox = _box()
+	slow.reveal_speed = 12.0
+	slow.show_text("hello there")
+	var patient: int = slow.frames_left()
+
+	var held: Gen2TextBox = _box()
+	held.reveal_speed = 12.0
+	held.show_text("hello there")
+	held.accelerated = true
+	assert_lt(held.frames_left(), patient, "a held button is faster than TEXT SPEED slow")
+
+	for _frame: int in held.frames_left():
+		held.advance_frame()
+	assert_false(held.is_revealing())
+	assert_eq(held.frames_left(), 0)
+
+
 ## `_ContText` is `PromptButton` and then `TextScroll` twice, five frames each,
 ## so a continuation costs one press and ten frames rather than a page turn.
 func test_a_continuation_scrolls_for_ten_frames_after_its_press() -> void:


### PR DESCRIPTION
## What

Three defects, each fixed at the layer that owns it rather than at the screen that showed it.

**A press cannot finish a printing page.** `PrintLetterDelay` (`home/print_text.asm`) is the only thing a button reaches while a text is running, and the most it does there is answer a *held* A or B with a single `DelayFrame`: one letter a frame, whatever TEXT SPEED says. `Gen2TextBox.advance()` completed the page instead, so a repeated press tore through a whole text a page per press. The press is spent now and the page prints on; the hold is `accelerated`, set per frame by each host from `Gen2Button.text_accelerating()`.

Because the reveal is a frame count on the cartridge, the box is `driven` by its host's own hardware frame pump rather than by a second clock only real time turns, and `frames_left()` is what a caller settling a screen spends. `Gen2OakSpeechScreen.animation_frames_left()` answers with it at a `PrintText`. A run that divides exactly owes one more frame than the arithmetic says, since the reveal is a float summed a frame at a time.

**One file picker.** Both `_picker()` helpers gated `use_native_dialog` on `FEATURE_NATIVE_DIALOG_FILE`, which `FileDialog` already tests itself before going native, so the second gate could only refuse a system picker the platform would have given us; on a sandboxed platform the built-in browser lists paths `FileAccess.open()` then refuses. Every picker is `Gen2LauncherUI.file_picker()` now, and a test sweeps `game/` for a `FileDialog.new()` or a feature gate outside it.

**The example mods.** Both declare `api_version` 5, and `new_content` demonstrates every surface between 1 and 5: a type and two chart exceptions, a species with its own decoded art, an item with a pocket and a mart shelf, a named control axis, a visible-encounter population that reads the run's rules, and the world channel's presentation mutator.

Met on the way and fixed here: two integration tests read this machine's own installed options through the shared store, so their page counts moved with whatever ran before them. Both run on the test path's defaults now.

## Proving it

| Check | Result |
|---|---|
| GUT unit tier | 2,800 / 2,800 |
| GUT scene integration tier | 381 / 381 |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no refusal on any |
| Boot smoke | exit 0 |