### PR TITLE
Draw a pokepic, walk facing each leg, and stop asking for presses

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -188,6 +188,11 @@ var _intro_message: String = ""
 ## prints it after the bar arrives, since `applydamage` runs before
 ## `criticaltext` and `supereffectivetext`.
 var _held_message: String = ""
+## Whether the box is holding a line nobody has pressed past yet. Only a box
+## waits for a button in `DoMove`'s loop, so this is what tells the frame pump
+## that the run of frames it just finished owes a press rather than the next
+## command; see [method _resume_after_frames].
+var _message_awaits_press: bool = false
 ## Leftover of a hardware frame the bars and the intro have not counted yet.
 var _frame_elapsed: float = 0.0
 ## The same, for the party page's icons. Kept apart because they animate while
@@ -378,10 +383,31 @@ func frames_running() -> bool:
 func advance_frame() -> bool:
 	if _box != null:
 		_box.advance_frame()
+	var was_running: bool = frames_running()
 	var moved: bool = advance_intro()
 	moved = advance_bars() or moved
 	moved = advance_faint() or moved
-	return advance_animation() or moved
+	moved = advance_animation() or moved
+	_resume_after_frames(was_running)
+	return moved
+
+
+## What the source does when the frames a command spends run out: it runs on to
+## the next command. Nothing in `DoMove`'s loop reads a button between an
+## animation, `AnimateHPBar` and `MonFaintedAnimation` and whatever follows them,
+## so the pump continues here rather than standing still until a press.
+##
+## The waits that are real are all a box: a message on screen is left alone, and
+## so is a bar that is holding one (`_held_message`, released by
+## [method advance_bars]) or the exp bar stopped at a level boundary.
+func _resume_after_frames(was_running: bool) -> void:
+	if not was_running or frames_running() or _pending.is_empty():
+		return
+	if not _held_message.is_empty() or not _intro_message.is_empty():
+		return
+	if _message_awaits_press:
+		return
+	_show_next_event()
 
 
 ## Whether a picture is still sinking off its square.
@@ -1360,6 +1386,7 @@ func show_message(text: String) -> void:
 		_intro_message = text
 		return
 	_last_message = text
+	_message_awaits_press = true
 	if _box != null:
 		_box.show_text(text)
 
@@ -2060,6 +2087,7 @@ func advance() -> void:
 		return
 	if _box.advance():
 		return
+	_message_awaits_press = false
 	## The battle menu is answered with A, which is what this call is: the source
 	## reads one joypad for the box and for the menu over it.
 	if _menu_stage != &"":

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -732,14 +732,46 @@ func _start_player_step(
 
 ## One step of a scripted stream, behind whatever the player is already walking.
 ## See Gen2WorldObject.queue_step().
-func _queue_player_step(direction: Vector2i, frames: int, jumping: bool = false) -> void:
-	_player_scripted_steps = true
-	if _player_step_frames_remaining > 0:
+## [param facing] is the direction the player is drawn looking while this step
+## runs, the way [method Gen2WorldObject.queue_step] takes one: `NormalStep`
+## writes OBJECT_FACING as the step starts, so a stream applied in one call still
+## turns a step at a time.
+func _queue_player_step(
+	direction: Vector2i, frames: int, jumping: bool = false,
+	facing: Vector2i = Vector2i.ZERO
+) -> void:
+	if _player_step_frames_remaining > 0 or not _player_queued_steps.is_empty():
+		_player_scripted_steps = true
 		_player_queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
+			"facing": facing,
 		})
 		return
+	_face_player_toward(facing)
+	## See [method Gen2WorldObject.queue_step]: a turn with nothing to spend
+	## leaves the stream's wait nothing to end on.
+	if frames <= 0 and direction == Vector2i.ZERO:
+		return
+	_player_scripted_steps = true
 	_begin_player_step(direction, frames, jumping)
+
+
+func _face_player_toward(direction: Vector2i) -> void:
+	if direction != Vector2i.ZERO:
+		player_facing = _facing_for_direction(direction)
+
+
+## The player's half of [method Gen2WorldObject._start_next_queued_step].
+func _start_next_player_step() -> void:
+	while not _player_queued_steps.is_empty():
+		var next: Dictionary = _player_queued_steps.pop_front()
+		_face_player_toward(next.get("facing", Vector2i.ZERO))
+		if int(next["frames"]) > 0 or next["direction"] != Vector2i.ZERO:
+			_begin_player_step(
+				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
+			)
+			return
+	_player_scripted_steps = false
 
 
 func _begin_player_step(
@@ -778,13 +810,7 @@ func advance_player_step_frame() -> bool:
 	_player_step_frame = (_player_step_frame + 1) & 0x0F
 	_player_step_frames_remaining -= 1
 	if _player_step_frames_remaining <= 0:
-		if _player_queued_steps.is_empty():
-			_player_scripted_steps = false
-		else:
-			var next: Dictionary = _player_queued_steps.pop_front()
-			_begin_player_step(
-				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
-			)
+		_start_next_player_step()
 	return true
 
 
@@ -3934,17 +3960,25 @@ func _apply_object_movement(event: Dictionary) -> Array:
 		})
 		return generated
 	var object: Gen2WorldObject = objects[object_index]
+	## Where the stream leaves the object looking. The drawn facing trails the
+	## walk one step at a time, so the record the next map load restores is this
+	## rather than whichever step is on screen when the stream is applied.
+	var final_facing: int = object.facing
 	for command: Dictionary in decoded.get("commands", []):
 		var kind: StringName = StringName(command.get("kind", &""))
 		if kind in SCRIPTED_TURN_KINDS:
-			object.apply_direction(_movement_direction(int(command.get("direction", 0))))
+			## Queued rather than applied, so a turn behind a walk turns where
+			## the walk ends. `queue_step` drains an entry of no frames itself.
+			var turn: Vector2i = _movement_direction(int(command.get("direction", 0)))
+			object.queue_step(Vector2i.ZERO, 0, false, turn)
+			final_facing = _facing_for_direction(turn)
 			continue
 		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
-			object.apply_direction(direction)
 			var jumping: bool = kind in JUMP_STEP_KINDS
 			var cells: int = 2 if jumping else 1
 			var destination: Vector2i = object.cell + direction * cells
+			final_facing = _facing_for_direction(direction)
 			if _cell_in_bounds(destination):
 				var vacated: Vector2i = object.cell
 				object.cell = destination
@@ -3953,10 +3987,14 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				# so the whole path is queued and drawn a step at a time by
 				# advance_scripted_steps_frame().
 				object.queue_step(
-					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping
+					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping,
+					direction,
 				)
 				_advance_followers(object_index, vacated)
 			else:
+				## `NormalStep` writes the facing before `GetNextTile` refuses,
+				## so a step off the map turns the object where it stands.
+				object.queue_step(Vector2i.ZERO, 0, false, direction)
 				generated.append({
 					"type": &"movement_blocked", "object_index": object_index,
 					"cell": destination,
@@ -4018,7 +4056,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				})
 	var key: String = _object_key(map_group, map_number, object_index)
 	_object_position_overrides[key] = object.cell
-	_object_facing_overrides[key] = object.facing
+	_object_facing_overrides[key] = final_facing
 	return generated
 
 
@@ -4054,13 +4092,15 @@ func _apply_player_movement(event: Dictionary) -> Array:
 	for command: Dictionary in decoded.get("commands", []):
 		var kind: StringName = StringName(command.get("kind", &""))
 		if kind in SCRIPTED_TURN_KINDS:
-			player_facing = _facing_for_direction(
-				_movement_direction(int(command.get("direction", 0)))
+			## Queued behind whatever is still walking, so the turn lands where
+			## the walk ends rather than on the frame the stream was applied.
+			_queue_player_step(
+				Vector2i.ZERO, 0, false,
+				_movement_direction(int(command.get("direction", 0))),
 			)
 			continue
 		if SCRIPTED_STEP_FRAMES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
-			player_facing = _facing_for_direction(direction)
 			var jumping: bool = kind in JUMP_STEP_KINDS
 			var cells: int = 2 if jumping else 1
 			var destination: Vector2i = player_cell + direction * cells
@@ -4068,10 +4108,14 @@ func _apply_player_movement(event: Dictionary) -> Array:
 				var vacated: Vector2i = player_cell
 				player_cell = destination
 				_queue_player_step(
-					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping
+					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping,
+					direction,
 				)
 				_advance_followers(-1, vacated)
 			else:
+				## `NormalStep` writes the facing before the refusal, so a step
+				## off the map turns the player where they stand.
+				_queue_player_step(Vector2i.ZERO, 0, false, direction)
 				generated.append({
 					"type": &"movement_blocked", "player": true, "cell": destination,
 				})

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -345,13 +345,28 @@ func start_step(direction: Vector2i, frames: int) -> void:
 ## Adds one step of a scripted stream to the trail. The first one starts at
 ## once and the rest wait their turn, so a five-step applymovement is drawn as
 ## five steps rather than as one arrival.
-func queue_step(direction: Vector2i, frames: int, jumping: bool = false) -> void:
-	scripted_steps = true
-	if step_frames_remaining > 0:
+## [param facing] is the direction the object is drawn looking while this step
+## runs, which is not the step's own vector for a `jump_step` and is the whole of
+## a queued `turn_head`. `NormalStep` writes OBJECT_FACING as it starts the step,
+## so a stream applied in one call still turns one step at a time rather than
+## walking its whole path already facing the last command's way.
+func queue_step(
+	direction: Vector2i, frames: int, jumping: bool = false,
+	facing: Vector2i = Vector2i.ZERO
+) -> void:
+	if step_frames_remaining > 0 or not queued_steps.is_empty():
+		scripted_steps = true
 		queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
+			"facing": facing,
 		})
 		return
+	apply_direction(facing)
+	## A turn spends no frames, so an entry with none to spend leaves nothing
+	## for the stream's wait to end on: it is the turn and nothing else.
+	if frames <= 0 and direction == Vector2i.ZERO:
+		return
+	scripted_steps = true
 	_begin_step(direction, frames, jumping)
 
 
@@ -405,14 +420,23 @@ func tick_step() -> bool:
 			weird_tree = false
 			step_frame = 0
 			frame = 0
-		if queued_steps.is_empty():
-			scripted_steps = false
-		else:
-			var next: Dictionary = queued_steps.pop_front()
+		_start_next_queued_step()
+	return true
+
+
+## Pops the trail's next entry, turning where it says to. A `turn_head` queued
+## behind a step is an entry of no frames and no vector, so the drain runs on
+## past it rather than stalling the rest of the stream on it.
+func _start_next_queued_step() -> void:
+	while not queued_steps.is_empty():
+		var next: Dictionary = queued_steps.pop_front()
+		apply_direction(next.get("facing", Vector2i.ZERO))
+		if int(next["frames"]) > 0 or next["direction"] != Vector2i.ZERO:
 			_begin_step(
 				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
 			)
-	return true
+			return
+	scripted_steps = false
 
 
 func is_stepping() -> bool:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1675,8 +1675,8 @@ func preview_pack_use() -> void:
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
-	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
-		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PACK):
+		return
 	_start_menu_host.handle_button(Gen2Button.A)
 
 
@@ -1704,9 +1704,29 @@ func preview_options() -> void:
 		_open_start_menu()
 	if _start_menu_host == null:
 		return
-	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_OPTION:
-		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_OPTION):
+		return
 	_start_menu_host.handle_button(Gen2Button.A)
+
+
+## Walks the open start menu's cursor onto [param kind] and answers whether it
+## got there. Bounded by the row count on purpose: a row the menu is not
+## offering, because its gate is shut on this save, is a cursor that never
+## reaches it, and an unbounded walk there spins a core without ever rendering a
+## frame. Every `preview_*` driver below goes through this.
+func _walk_start_menu_to(kind: StringName) -> bool:
+	if _start_menu_host == null:
+		return false
+	var menu: Variant = _start_menu_host.get("_menu")
+	for _row: int in Gen2WorldStartMenu.SOURCE_ENTRIES.size():
+		if menu.selected_kind() == kind:
+			return true
+		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if menu.selected_kind() == kind:
+		return true
+	_script_prompt = "The start menu is not offering %s" % kind
+	_refresh_labels()
+	return false
 
 
 ## Public screenshot driver for the Pokegear, reached the way a player reaches
@@ -1724,11 +1744,8 @@ func preview_pokegear() -> void:
 		})
 		_open_start_menu()
 	if _start_menu_host != null:
-		for _row: int in Gen2WorldStartMenu.SOURCE_ENTRIES.size():
-			if _start_menu_host.get("_menu").selected_kind() \
-				== Gen2WorldStartMenu.ITEM_POKEGEAR:
-				break
-			_start_menu_host.handle_button(Gen2Button.DOWN)
+		if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_POKEGEAR):
+			return
 		## The row opens the overlay through the same signal a press does, so
 		## the card list is up by the time this returns.
 		_start_menu_host.handle_button(Gen2Button.A)
@@ -1761,8 +1778,8 @@ func _preview_save_menu(answers: int) -> void:
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
-	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_SAVE:
-		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_SAVE):
+		return
 	for _press: int in answers + 1:
 		_start_menu_host.handle_button(Gen2Button.A)
 
@@ -1795,8 +1812,8 @@ func preview_pack_toss() -> void:
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
-	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
-		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PACK):
+		return
 	_start_menu_host.handle_button(Gen2Button.A)
 
 
@@ -1834,8 +1851,8 @@ func preview_move_forget() -> void:
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
-	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
-		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PACK):
+		return
 	_start_menu_host.handle_button(Gen2Button.A)
 	# The pack opens on the ITEM pocket, and the granted item is in the TM/HM
 	# one. The guard bounds the walk in case no such pocket is built.
@@ -1944,8 +1961,8 @@ func preview_field_item(item: int = Gen2WorldPack.ITEM_ITEMFINDER) -> void:
 	_open_start_menu()
 	if _start_menu_host == null:
 		return
-	while _start_menu_host.get("_menu").selected_kind() != Gen2WorldStartMenu.ITEM_PACK:
-		_start_menu_host.handle_button(Gen2Button.DOWN)
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PACK):
+		return
 	_start_menu_host.handle_button(Gen2Button.A)
 	# The row itself, rather than whichever one the pocket opens on: the save may
 	# already own other key items, and a capture has to photograph the named one.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1709,6 +1709,33 @@ func preview_options() -> void:
 	_start_menu_host.handle_button(Gen2Button.A)
 
 
+## Public screenshot driver for the Pokegear, reached the way a player reaches
+## it: START, the POKEGEAR row, and then A on the card list. What it is for is
+## the panel-over-panel stack, so the picture has to be the card over the list.
+func preview_pokegear() -> void:
+	if _world == null or _data == null:
+		return
+	if _service_host == null and _start_menu_host == null:
+		_injected_save = _embedded_party_save()
+		## The row is gated on ENGINE_POKEGEAR, which a world opened straight
+		## onto a map has not been given yet.
+		_world.state.apply_changes({}, {}, {
+			"engine_flags": {Gen2WorldStartMenu.ENGINE_POKEGEAR: true},
+		})
+		_open_start_menu()
+	if _start_menu_host != null:
+		for _row: int in Gen2WorldStartMenu.SOURCE_ENTRIES.size():
+			if _start_menu_host.get("_menu").selected_kind() \
+				== Gen2WorldStartMenu.ITEM_POKEGEAR:
+				break
+			_start_menu_host.handle_button(Gen2Button.DOWN)
+		## The row opens the overlay through the same signal a press does, so
+		## the card list is up by the time this returns.
+		_start_menu_host.handle_button(Gen2Button.A)
+	if _service_host != null:
+		_service_host.handle_button(Gen2Button.A)
+
+
 ## Public screenshot drivers for `SaveMenu`, one per box it puts up:
 ## `WouldYouLikeToSaveTheGameText` with its yes/no, `AlreadyASaveFileText` past
 ## `_ContText`'s own wait, and `SavingDontTurnOffThePowerText` with no question
@@ -3383,6 +3410,74 @@ func _show_script_results(results: Array) -> void:
 	var recovery_prompt: String = ""
 	for source_result: Dictionary in results:
 		var result: Dictionary = Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, source_result)
+		## Applied before the status below, and before any branch of it that leaves
+		## the loop: a command's presentation effect happened before the wait the
+		## same result ends on, and a `break` that skipped this dropped it. That is
+		## what left a `pokepic` undrawn, since `Script_pokepic` is followed by the
+		## `cry` whose runtime request breaks out of the loop.
+		for result_event: Dictionary in result.get("events", []):
+			if result_event.get("type", &"") == &"presentation_special_applied" \
+				and StringName(result_event.get("kind", &"")) == &"prof_oaks_pc_boot":
+				open_prof_oaks_pc()
+			elif result_event.get("type", &"") == &"presentation_special_applied" \
+				and StringName(result_event.get("kind", &"")) == &"heal_machine_anim":
+				_start_heal_machine_sounds(result_event)
+			elif result_event.get("type", &"") == &"hall_of_fame_requested":
+				## An event, not a runtime request: `halloffame` commits its flag
+				## and runs on, and the source's own `end` is the next command,
+				## so nothing is waiting to be resumed when this opens.
+				open_hall_of_fame()
+			elif result_event.get("type", &"") == &"credits_requested":
+				open_credits()
+			elif result_event.get("type", &"") == &"field_move_confirmed":
+				## `iftrue Script_Cut` and its four counterparts. The move is the
+				## host's, and it is the same staged request and acknowledge the
+				## party submenu reaches, so the two ways in stay one path.
+				_use_prompted_field_move(int(result_event.get("move", 0)),
+					int(result_event.get("slot", -1)))
+			elif result_event.get("type", &"") == &"pokemon_picture_requested":
+				_show_story_picture(int(result_event.get("pokemon", 0)))
+			elif result_event.get("type", &"") == &"pokemon_picture_closed":
+				_hide_story_picture()
+			elif result_event.get("type", &"") == &"screen_shake_requested":
+				if _effects != null:
+					_effects.start_screen_shake(
+						int(result_event.get("strength", 0)),
+						&"screen_shake",
+						result_event,
+					)
+				_apply_world_effect_offset()
+			elif result_event.get("type", &"") == &"tree_shake_requested":
+				## The object animates itself for the frames the stream sleeps;
+				## there is nothing for a host to start.
+				pass
+			elif result_event.get("type", &"") in [
+				&"rock_smash_effect_requested",
+				&"movement_command_requested",
+			]:
+				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
+			elif result_event.get("type", &"") == &"warp":
+				map_changed = true
+			elif result_event.get("type", &"") == &"world_clock_changed":
+				clock_changed = true
+			elif result_event.get("type", &"") == &"battle_map_reload_requested":
+				map_changed = true
+			elif result_event.get("type", &"") == &"blackout":
+				recovered = true
+				var recovery: Variant = result_event.get("recovery", {})
+				var source: StringName = StringName(
+					recovery.get("source", &"save") if recovery is Dictionary else &"save"
+				)
+				recovery_prompt = (
+					"Blackout recovered from the development party"
+					if source == &"development"
+					else "Blackout recovered from the last saved party"
+				)
+			elif result_event.get("type", &"") in [
+				&"item_changed", &"money_changed", &"coins_changed", &"movement_blocked",
+				&"movement_failed",
+			]:
+				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
 		if result.has("clock"):
 			clock_changed = true
 		var status: StringName = StringName(result.get("status", &""))
@@ -3479,69 +3574,6 @@ func _show_script_results(results: Array) -> void:
 		elif not bool(result.get("ok", false)):
 			failed = true
 			_script_prompt = "Script stopped: %s" % String(result.get("reason", "unknown"))
-		for result_event: Dictionary in result.get("events", []):
-			if result_event.get("type", &"") == &"presentation_special_applied" \
-				and StringName(result_event.get("kind", &"")) == &"prof_oaks_pc_boot":
-				open_prof_oaks_pc()
-			elif result_event.get("type", &"") == &"presentation_special_applied" \
-				and StringName(result_event.get("kind", &"")) == &"heal_machine_anim":
-				_start_heal_machine_sounds(result_event)
-			elif result_event.get("type", &"") == &"hall_of_fame_requested":
-				## An event, not a runtime request: `halloffame` commits its flag
-				## and runs on, and the source's own `end` is the next command,
-				## so nothing is waiting to be resumed when this opens.
-				open_hall_of_fame()
-			elif result_event.get("type", &"") == &"credits_requested":
-				open_credits()
-			elif result_event.get("type", &"") == &"field_move_confirmed":
-				## `iftrue Script_Cut` and its four counterparts. The move is the
-				## host's, and it is the same staged request and acknowledge the
-				## party submenu reaches, so the two ways in stay one path.
-				_use_prompted_field_move(int(result_event.get("move", 0)),
-					int(result_event.get("slot", -1)))
-			elif result_event.get("type", &"") == &"pokemon_picture_requested":
-				_show_story_picture(int(result_event.get("pokemon", 0)))
-			elif result_event.get("type", &"") == &"pokemon_picture_closed":
-				_hide_story_picture()
-			elif result_event.get("type", &"") == &"screen_shake_requested":
-				if _effects != null:
-					_effects.start_screen_shake(
-						int(result_event.get("strength", 0)),
-						&"screen_shake",
-						result_event,
-					)
-				_apply_world_effect_offset()
-			elif result_event.get("type", &"") == &"tree_shake_requested":
-				## The object animates itself for the frames the stream sleeps;
-				## there is nothing for a host to start.
-				pass
-			elif result_event.get("type", &"") in [
-				&"rock_smash_effect_requested",
-				&"movement_command_requested",
-			]:
-				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
-			elif result_event.get("type", &"") == &"warp":
-				map_changed = true
-			elif result_event.get("type", &"") == &"world_clock_changed":
-				clock_changed = true
-			elif result_event.get("type", &"") == &"battle_map_reload_requested":
-				map_changed = true
-			elif result_event.get("type", &"") == &"blackout":
-				recovered = true
-				var recovery: Variant = result_event.get("recovery", {})
-				var source: StringName = StringName(
-					recovery.get("source", &"save") if recovery is Dictionary else &"save"
-				)
-				recovery_prompt = (
-					"Blackout recovered from the development party"
-					if source == &"development"
-					else "Blackout recovered from the last saved party"
-				)
-			elif result_event.get("type", &"") in [
-				&"item_changed", &"money_changed", &"coins_changed", &"movement_blocked",
-				&"movement_failed",
-			]:
-				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
 	if recovered and not recovery_prompt.is_empty():
 		_script_prompt = recovery_prompt
 	elif not waiting and not failed:

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -12,20 +12,21 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
 var _data: GameData = null
 var _screen: Gen2BattleScreen = null
-var _battle_scene: bool = true
 
 
 func before_each() -> void:
 	Gen2ModHost.reset()
 	Fixture.build()
 	_data = GameData.open_directory(Fixture.directory())
-	_battle_scene = Gen2OptionsStore.current().battle_scene
+	## The battle-scene row and the reveal speed are both read off the options
+	## store, and a case here writes one: redirect the store first, so a test run
+	## reads and writes the test path rather than the settings on this machine.
+	Gen2OptionsStore.use_test_path()
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
 
 
 func after_each() -> void:
-	var options: Gen2Options = Gen2OptionsStore.current()
-	options.battle_scene = _battle_scene
-	Gen2OptionsStore.save(options)
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
 	if is_instance_valid(_screen):
 		_screen.free()
 		_screen = null
@@ -285,5 +286,19 @@ func test_a_line_on_screen_still_owes_its_press() -> void:
 	_screen._begin_animation(_animation_event())
 	_settle_animation()
 	assert_eq(_screen._pending.size(), 1, "the line was not pressed past")
+	## The reveal is a frame count at the OPTION menu's text speed, and a press
+	## cannot shorten one, so the line is spent before the press that dismisses
+	## it: how many frames the animation happened to cover is not the subject.
+	_settle_message()
+	assert_false(_screen._box.is_revealing(), "the line has finished printing")
 	_screen.advance()
 	assert_eq(_screen._pending.size(), 0)
+
+
+## Spends the frames the box still owes, the way a player waits through them.
+func _settle_message() -> void:
+	var box: Gen2TextBox = _screen._box
+	var guard: int = 4000
+	while box != null and box.is_revealing() and guard > 0:
+		_screen.advance_frame()
+		guard -= 1

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -257,3 +257,33 @@ func test_a_send_out_draws_a_picture_rather_than_the_doll_the_last_one_had() -> 
 		"level": 5, "hp": 20, "max_hp": 20,
 	})
 	assert_false(bool(_view()["player_substitute"]))
+
+
+func test_the_frames_an_animation_spends_do_not_owe_a_press() -> void:
+	# `DoMove` reads no joypad between `PlayFXAnimID` and the command after it,
+	# so the line behind an animation is said when its frames run out rather
+	# than when the player presses A.
+	await _open_battle()
+	_screen._pending = [{
+		"type": Gen2Battle.MISSED, "side": Gen2Battle.PLAYER, "move": 33,
+	}]
+	_screen._begin_animation(_animation_event())
+	_settle_animation()
+	assert_false(_screen.animation_running())
+	assert_eq(_screen._pending.size(), 0, "the pump ran on without a press")
+	assert_ne(String(_screen.battle_snapshot()["message"]), "",
+		"the held line was said")
+
+
+func test_a_line_on_screen_still_owes_its_press() -> void:
+	# The same pump must not walk past a box: only a button dismisses one.
+	await _open_battle()
+	_screen.show_message("ATTACK MISSED!")
+	_screen._pending = [{
+		"type": Gen2Battle.MISSED, "side": Gen2Battle.PLAYER, "move": 33,
+	}]
+	_screen._begin_animation(_animation_event())
+	_settle_animation()
+	assert_eq(_screen._pending.size(), 1, "the line was not pressed past")
+	_screen.advance()
+	assert_eq(_screen._pending.size(), 0)

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -251,3 +251,25 @@ func test_a_party_heal_request_is_settled_where_it_is_staged() -> void:
 	)
 	assert_true(_world_screen._world.pending_runtime_request().is_empty())
 	assert_true((save.party[0] as Gen2SaveMon).hp > 1, "the party healed with no press")
+
+
+## `Script_pokepic` puts its box up and `Script_cry` is the next command, so the
+## picture and the runtime request the cry stages land on the same result. The
+## request takes the pump out of the result loop, and the events beside it are
+## the box: they are applied before the status, not skipped with it.
+func test_a_picture_beside_a_runtime_request_is_still_drawn() -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		0x56, 155,
+		0x84, 155, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+	_data = GameData.open_directory(directory)
+	_world_screen = await _open_world()
+
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(SCRIPT_CELL)
+	)
+	assert_not_null(_world_screen._story_picture, "the pokepic box is on screen")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3925,6 +3925,37 @@ func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -
 	assert_false(world.advance_scripted_steps_frame())
 
 
+## `NormalStep` writes OBJECT_FACING where it starts each step, so a stream whose
+## legs turn is drawn turning with them. The whole path commits in one call here,
+## which is why the facing has to travel with the trail rather than with the
+## commit: applied with the cells it would walk the first two legs already facing
+## the way the last one ends.
+func test_a_turning_stream_is_drawn_facing_each_leg_in_turn() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		# step down, step down, step right.
+		"48:6100": [0x0C, 0x0C, 0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var object: Gen2WorldObject = world.objects[0]
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+
+	assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN, "the first leg")
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_scripted_steps_frame()
+	assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN, "still the second")
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_scripted_steps_frame()
+	assert_eq(object.facing, Gen2WorldSprite.FACING_RIGHT, "and the last one turns")
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_scripted_steps_frame()
+	assert_eq(object.step_offset_cells(), Vector2.ZERO)
+
+
 ## `Script_applymovement` sets SCRIPT_WAIT_MOVEMENT and StopScript, and
 ## `WaitScriptMovement` holds the script until the stream clears
 ## SCRIPTED_MOVEMENT_STATE_F, which `Movement_step_end` is what does. So the


### PR DESCRIPTION
Three reports from the New Bark playtest, each fixed at the shared path rather than at the site it was seen.

**A starter's ball drew no picture.** `Gen2WorldScreen._show_script_results` applied a result's `events` after its status, and half the status branches leave the result loop, so every presentation event on a result that ended on a runtime request, a service host or an unattended request was dropped. `Script_pokepic` is followed by the `cry` whose request does exactly that. The events are applied first now, where the commands that produced them ran; this covers every `pokepic`, `halloffame`, `credits`, warp and blackout event that shared a result with one of those requests, not just the ball.

**Battle asked for presses the source does not.** The screen stood still whenever an animation, an HP bar or `MonFaintedAnimation` ran out of frames with nothing held to say, so a press paid for each. `DoMove` reads no joypad between them: `_resume_after_frames` runs the pump on when the frames do, and `_message_awaits_press` still stops it at a box.

**Facing was wrong during scripted movements.** A stream applies in one call, and `player_facing` and `Gen2WorldObject.facing` were written with the whole of it, so a turning walk was drawn already facing its last leg. The facing travels with the trail now, one step at a time, the way `NormalStep` writes OBJECT_FACING as each step starts. The record a map reload restores is still the stream's last facing. A turn is queued with the steps and spends no frames, so it must not raise the scripted-step flag with nothing to spend, or the stream's own wait never ends.

| Check | Result |
|---|---|
| GUT, both tiers | 3,187 / 3,187 over 152 scripts |
| `validate.gd -- all` | 53 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step on any |
| Boot smoke | exit 0 |

Four new cases, each confirmed to fail without its fix.