### PR TITLE
Two launcher fixes: the side fade stops darkening, and the focus ring stands clear

### DIFF
--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -21,16 +21,12 @@ const SIDE_FADE_SHADER: String = """
 shader_type canvas_item;
 
 uniform float side = 0.0;
-uniform sampler2D cartridge_texture : source_color;
-uniform bool use_cartridge_texture = false;
 
+// COLOR arrives already equal to texture(TEXTURE, UV) * MODULATE, so the sample
+// is never read again: multiplying by it would square the artwork and darken it.
 void fragment() {
-	vec4 sampled = use_cartridge_texture ? texture(cartridge_texture, UV) : texture(TEXTURE, UV);
-	vec4 colour = sampled * COLOR;
 	float inward = side < 0.0 ? UV.x : 1.0 - UV.x;
-	float gradient_alpha = mix(0.25, 1.0, inward);
-	colour.a *= mix(1.0, gradient_alpha, clamp(abs(side), 0.0, 1.0));
-	COLOR = colour;
+	COLOR.a *= mix(1.0, mix(0.25, 1.0, inward), clamp(abs(side), 0.0, 1.0));
 }
 """
 
@@ -88,7 +84,6 @@ func _build() -> void:
 	fade_shader.code = SIDE_FADE_SHADER
 	_side_fade = ShaderMaterial.new()
 	_side_fade.shader = fade_shader
-	_side_fade.set_shader_parameter("use_cartridge_texture", true)
 	_bay_side_fade = ShaderMaterial.new()
 	_bay_side_fade.shader = fade_shader
 
@@ -126,7 +121,6 @@ func _build() -> void:
 	_art.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_art.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	_art.material = _side_fade
-	_side_fade.set_shader_parameter("cartridge_texture", _art.texture)
 	add_child(_art)
 
 	set_imported(false)
@@ -154,10 +148,8 @@ func set_side_fade(slot: float) -> void:
 	if _side_fade == null:
 		return
 	var side: float = clampf(slot, -1.0, 1.0)
-	# Keep the selected artwork on TextureRect's native colour path so its colour
-	# is identical to the source image.
-	_art.material = null if is_zero_approx(side) else _side_fade
-	_bay.material = null if is_zero_approx(side) else _bay_side_fade
+	# The material stays attached at every slot: at side 0 it is a pass through,
+	# so detaching it could only reintroduce a seam mid-slide.
 	_side_fade.set_shader_parameter("side", side)
 	_bay_side_fade.set_shader_parameter("side", side)
 

--- a/game/launcher/launcher_button.gd
+++ b/game/launcher/launcher_button.gd
@@ -165,10 +165,13 @@ func repaint() -> void:
 	_style("pressed", _pressed_fill(fill), _hovered(border), radius, pad_x, pad_y)
 	_style("disabled", _theme.with_alpha(fill, 0.4), _theme.with_alpha(border, 0.4),
 		radius, pad_x, pad_y)
-	# Focus is not hover or the active value. A distinct, heavy accent ring is
-	# always present so keyboard and controller users can locate the cursor even
-	# on a filled primary button or the already-selected dock page.
-	_style("focus", Color(0, 0, 0, 0), _theme.accent, radius, pad_x, pad_y, 3)
+	# Focus is not hover or the active value. A heavy accent ring standing clear
+	# of the button is always present, so keyboard and controller users can locate
+	# the cursor even on a filled primary button or the already-selected dock page,
+	# where a flush ring would only read as a slightly larger button.
+	add_theme_stylebox_override(
+		"focus", _theme.padded(_theme.focus_ring(radius, 3), pad_x, pad_y)
+	)
 
 	for state: String in ["font_color", "font_hover_color", "font_pressed_color",
 			"font_focus_color"]:

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -25,6 +25,11 @@ const RADIUS_MD: float = 14.0
 const RADIUS_SM: float = 10.0
 const RADIUS_PILL: float = 999.0
 
+## The clear space between a control's own edge and the focus ring around it. A
+## ring drawn flush on an accent button only makes the button look bigger; a
+## ring standing off it reads as a ring in every palette.
+const FOCUS_GAP: int = 3
+
 const FONT_HERO: int = 40
 const FONT_DISPLAY: int = 28
 const FONT_TITLE: int = 19
@@ -163,6 +168,18 @@ func box(
 	return style
 
 
+## The ring that says a keyboard or a pad is on a control, drawn clear of it by
+## [constant FOCUS_GAP]. Expand margins draw outside the control's rect without
+## touching its layout, so nothing moves when focus arrives.
+func focus_ring(radius: float = RADIUS_SM, width: int = 2) -> StyleBoxFlat:
+	# A border is drawn inside its box, so the box has to clear the control by the
+	# gap and the stroke together for the gap to survive.
+	var reach: float = float(FOCUS_GAP + width)
+	var style: StyleBoxFlat = box(Color(0, 0, 0, 0), radius + reach, accent, width)
+	style.set_expand_margin_all(reach)
+	return style
+
+
 ## A card that reads as sitting on the page rather than printed on it. Reserved
 ## for the few things that really float, because a shadow is drawn outside the
 ## control and any clipping ancestor would cut it.
@@ -190,7 +207,7 @@ func control_theme() -> Theme:
 
 	var field: StyleBoxFlat = padded(box(surface_alt, RADIUS_SM, line), 12, 9)
 	theme.set_stylebox("normal", "LineEdit", field)
-	theme.set_stylebox("focus", "LineEdit", padded(box(surface_alt, RADIUS_SM, accent, 2), 12, 9))
+	theme.set_stylebox("focus", "LineEdit", padded(focus_ring(RADIUS_SM), 12, 9))
 	theme.set_stylebox("read_only", "LineEdit", field)
 	theme.set_color("font_color", "LineEdit", text)
 	theme.set_color("font_placeholder_color", "LineEdit", faint)
@@ -203,9 +220,7 @@ func control_theme() -> Theme:
 			"hover", type, padded(box(panel.lerp(accent, 0.07), RADIUS_SM, accent_wash(0.4)), 14, 9)
 		)
 		theme.set_stylebox("pressed", type, padded(box(surface_alt, RADIUS_SM, line), 14, 9))
-		theme.set_stylebox(
-			"focus", type, padded(box(Color(0, 0, 0, 0), RADIUS_SM, accent, 2), 14, 9)
-		)
+		theme.set_stylebox("focus", type, padded(focus_ring(RADIUS_SM), 14, 9))
 		theme.set_stylebox("disabled", type, padded(box(surface_alt, RADIUS_SM, line), 14, 9))
 		theme.set_color("font_color", type, text)
 		theme.set_color("font_hover_color", type, text)
@@ -238,7 +253,7 @@ func control_theme() -> Theme:
 		theme.set_stylebox("slider", type, padded(box(surface_alt, 3.0, line), 0, 3))
 		theme.set_stylebox("grabber_area", type, padded(box(accent, 3.0), 0, 3))
 		theme.set_stylebox("grabber_area_highlight", type, padded(box(accent, 3.0), 0, 3))
-		theme.set_stylebox("focus", type, padded(box(Color(0, 0, 0, 0), RADIUS_SM, accent, 2), 4, 4))
+		theme.set_stylebox("focus", type, padded(focus_ring(RADIUS_SM), 4, 4))
 		theme.set_icon("grabber", type, _knob(accent))
 		theme.set_icon("grabber_highlight", type, _knob(accent.lightened(0.15)))
 		theme.set_icon("grabber_disabled", type, _knob(faint))

--- a/game/launcher/launcher_toggle.gd
+++ b/game/launcher/launcher_toggle.gd
@@ -44,10 +44,7 @@ func _draw() -> void:
 	draw_circle(centre, KNOB * 0.5, _theme.on_accent)
 	draw_circle(centre, KNOB * 0.5, _theme.with_alpha(_theme.line, 0.9), false, 1.0, true)
 	if has_focus():
-		draw_style_box(
-			_theme.box(Color(0, 0, 0, 0), TRACK.y * 0.5 + 3.0, _theme.accent, 2),
-			Rect2(Vector2(-3, -3), TRACK + Vector2(6, 6)),
-		)
+		draw_style_box(_theme.focus_ring(TRACK.y * 0.5), Rect2(Vector2.ZERO, TRACK))
 
 
 func _on_toggled(on: bool) -> void:

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -4,11 +4,14 @@ extends SceneTree
 ## chosen set of cartridges present.
 ##
 ##   Godot --path . -s res://tools/preview_launcher.gd -- \
-##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] [scroll]
+##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] \
+##       [scroll] [focus index]
 ##
 ## `view` is the mods page's own: `list`, `sources`, or `mod` with an id.
 ## `scroll` is how far down the page's own scroll to photograph, in pixels, for a
-## card that does not fit the window.
+## card that does not fit the window. `focus` puts the keyboard on the nth
+## focusable control in tree order, which is the only way to photograph a focus
+## ring: nothing takes focus until the player presses something.
 ##
 ## The state argument uses the preview seams on the launcher, so an empty shelf
 ## can be photographed on a machine that has every cache imported. Like
@@ -29,6 +32,7 @@ var _state: String = "full"
 var _view: String = ""
 var _mod: String = ""
 var _scroll: int = 0
+var _focus: int = -1
 
 
 func _initialize() -> void:
@@ -46,6 +50,7 @@ func _initialize() -> void:
 	_view = args[6] if args.size() > 6 else ""
 	_mod = args[7] if args.size() > 7 else ""
 	_scroll = int(args[8]) if args.size() > 8 else 0
+	_focus = int(args[9]) if args.size() > 9 else -1
 
 	# Both, because the window already exists by the time a tool script runs and
 	# only the display server moves it.
@@ -80,6 +85,15 @@ func _process(_delta: float) -> bool:
 		var scroll: ScrollContainer = _first_scroll(_launcher)
 		if scroll != null:
 			scroll.scroll_vertical = _scroll
+	# Late enough that the page it lands on is the one being photographed, and the
+	# guard has finished moving focus about after the page change.
+	if _frames == 20 and _focus >= 0:
+		var reachable: Array[Control] = []
+		_focusable(_launcher, reachable)
+		if _focus < reachable.size():
+			reachable[_focus].grab_focus()
+		else:
+			push_error("Only %d focusable controls" % reachable.size())
 	if _frames < 26:
 		return false
 	var image: Image = root.get_texture().get_image()
@@ -90,6 +104,15 @@ func _process(_delta: float) -> bool:
 	print("Wrote %s (%dx%d)" % [_output, image.get_width(), image.get_height()])
 	quit()
 	return true
+
+
+func _focusable(node: Node, into: Array[Control]) -> void:
+	var control := node as Control
+	if control != null and control.is_visible_in_tree() \
+			and control.focus_mode == Control.FOCUS_ALL:
+		into.append(control)
+	for child: Node in node.get_children():
+		_focusable(child, into)
 
 
 func _first_scroll(node: Node) -> ScrollContainer:


### PR DESCRIPTION
### A side cartridge fades without the artwork being multiplied by itself

The launcher's side-fade shader multiplied its own texture sample by `COLOR`. In a `canvas_item` fragment shader `COLOR` already arrives as `texture(TEXTURE, UV) * MODULATE`, so the artwork was squared and every faded cartridge drew dark, at any gradient value. The material was being detached at the middle slot to keep the selected cartridge correct, which is what made a cartridge flash from dark back to normal as it settled in the centre.

The shader now scales only the alpha it was written for and samples nothing, so the extra `cartridge_texture` uniform goes with it and the material can stay attached at every slot.

Measured on `preview_launcher dark 1280x800 shelf full`, mean luma over the cartridge rows:

| band | before | after | |
|---|---|---|---|
| left | 76.20 | 93.90 | x1.23 |
| centre | 158.76 | 158.76 | x1.00 |
| right | 73.45 | 92.27 | x1.26 |

The centre is byte identical, which is the proof that the shader is now an exact pass through at slot 0 and that the settle no longer steps.

### A focus ring stands clear of the control it marks

The ring was drawn flush on the control's own edge, so an accent ring on an accent button, on the current dock page or on the chosen segment only made the control look slightly larger. `Gen2LauncherTheme.focus_ring` pushes it outside by `FOCUS_GAP` plus its own stroke, since a border is drawn inside its box and would otherwise eat the gap. Expand margins draw outside the control's rect without touching layout, so nothing moves when focus arrives. The stock control theme, every `Gen2LauncherButton` variant and the toggle, which drew its own offset ring by hand, now share it.

`preview_launcher` takes a focus index, because nothing in the launcher holds focus until the player presses something and a ring could not be photographed otherwise.

### Proof

GUT 2803 passing, 25854 asserts. `validate.gd -- all` rc=0. Boot smoke clean.