### PR TITLE
A launch fades where it used to be announced, and a battle opens on its own music

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -392,6 +392,8 @@ const BATTLETYPE_NORMAL: int = 0
 const BATTLETYPE_DEBUG: int = 2
 const BATTLETYPE_CONTEST: int = 6
 const BATTLETYPE_FORCESHINY: int = 7
+## Named by `PlayBattleMusic` alone: nothing else here branches on it.
+const BATTLETYPE_ROAMING: int = 5
 ## What TreeMonEncounter writes before a headbutt battle. CheckSleepingTreeMon
 ## is the only thing that reads it.
 const BATTLETYPE_TREE: int = 8
@@ -2409,3 +2411,111 @@ func _run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
 		called_turn.called = true
 		_run_move_effect(called_turn, depth + 1)
 		return
+
+
+## `PlayBattleMusic` (engine/battle/start_battle.asm) and the two routines it
+## calls, `RegionCheck` and `IsGymLeader`. Kept here rather than on the screen
+## because every input is battle state: `wBattleType`, `wOtherTrainerClass`,
+## `wOtherTrainerID`, `wTimeOfDay` and the map's landmark.
+##
+## `MUSIC_SUICUNE_BATTLE` exists on Crystal alone; the two `BATTLETYPE_` rows in
+## front of the trainer check are the only place either game reaches it, and
+## Gold and Silver never write those types.
+const MUSIC_NONE: int = 0x00
+const MUSIC_KANTO_GYM_LEADER_BATTLE: int = 0x06
+const MUSIC_KANTO_TRAINER_BATTLE: int = 0x07
+const MUSIC_KANTO_WILD_BATTLE: int = 0x08
+const MUSIC_JOHTO_WILD_BATTLE: int = 0x29
+const MUSIC_JOHTO_TRAINER_BATTLE: int = 0x2A
+const MUSIC_JOHTO_GYM_LEADER_BATTLE: int = 0x2E
+const MUSIC_CHAMPION_BATTLE: int = 0x2F
+const MUSIC_RIVAL_BATTLE: int = 0x30
+const MUSIC_ROCKET_BATTLE: int = 0x31
+const MUSIC_JOHTO_WILD_BATTLE_NIGHT: int = 0x4A
+const MUSIC_SUICUNE_BATTLE: int = 0x64
+
+## constants/trainer_constants.asm. The `trainerclass` indexes agree byte for
+## byte between the two pins, so there is no profile conversion here.
+const TRAINER_CLASS_RIVAL1: int = 0x09
+const TRAINER_CLASS_CHAMPION: int = 0x10
+const TRAINER_CLASS_GRUNTM: int = 0x1F
+const TRAINER_CLASS_RIVAL2: int = 0x2A
+const TRAINER_CLASS_RED: int = 0x3F
+const TRAINER_CLASS_GRUNTF: int = 0x42
+## `RIVAL2_2_CHIKORITA`. `trainerclass` restarts the id count at 1, so the
+## Indigo Plateau rematch is the fourth id of the class and `jr c, .done` keeps
+## the three below it on `MUSIC_RIVAL_BATTLE`.
+const TRAINER_ID_RIVAL2_2_CHIKORITA: int = 4
+
+## `data/trainers/leaders.asm`. `GymLeaders` falls through into
+## `KantoGymLeaders`, so `IsGymLeader` matches both rows and `IsKantoGymLeader`
+## only the second. CHAMPION and RED sit in the first list and are unreachable
+## from the music check, which the file's own comment says.
+const KANTO_GYM_LEADERS: Array[int] = [
+	0x11, 0x12, 0x13, 0x15, 0x1A, 0x23, 0x2E, 0x40,
+]
+const JOHTO_GYM_LEADERS: Array[int] = [
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x0B, 0x0D, 0x0E, 0x0F, TRAINER_CLASS_CHAMPION, TRAINER_CLASS_RED,
+]
+
+## constants/landmark_constants.asm, Crystal-canonical like
+## [constant Gen2WorldRadio.KANTO_LANDMARK], which is where the Gold and Silver
+## conversion lives.
+const LANDMARK_VICTORY_ROAD: int = 0x58
+
+
+## `RegionCheck`, which is not `IsInJohto`: the Fast Ship counts as Johto, so
+## does everything below `KANTO_LANDMARK`, and so does Victory Road and every
+## landmark above it, because `cp LANDMARK_VICTORY_ROAD / jr c, .kanto` only
+## takes the Kanto branch below that row.
+##
+## The `LANDMARK_SPECIAL` backup lookup in front of it is the six Cable Club
+## rooms and is deliberately not modelled; see [method Gen2WorldAPI.landmark].
+static func region_is_kanto(landmark: int, crystal: bool = true) -> bool:
+	if landmark == Gen2WorldRadio.fast_ship_landmark(crystal):
+		return false
+	if landmark < Gen2WorldRadio.kanto_landmark(crystal):
+		return false
+	return landmark < Gen2WorldRadio.profile_landmark(LANDMARK_VICTORY_ROAD, crystal)
+
+
+## `PlayBattleMusic`'s answer: the track a battle opens on.
+##
+## [param landmark] is `GetWorldMapLocation`'s, [param trainer_class] and
+## [param trainer_id] are `wOtherTrainerClass` and `wOtherTrainerID` (class 0
+## being a wild fight), and [param time_of_day] is `wTimeOfDay`.
+static func battle_music(
+	battle_type: int,
+	trainer_class: int,
+	trainer_id: int,
+	landmark: int,
+	time_of_day: int,
+	crystal: bool = true,
+) -> int:
+	# `ld de, MUSIC_SUICUNE_BATTLE` sits in front of both compares, so the
+	# roaming branch reaches `.done` with the same track still in `de`.
+	if battle_type == BATTLETYPE_SUICUNE or battle_type == BATTLETYPE_ROAMING:
+		return MUSIC_SUICUNE_BATTLE
+	var kanto: bool = region_is_kanto(landmark, crystal)
+	if trainer_class <= 0:
+		if kanto:
+			return MUSIC_KANTO_WILD_BATTLE
+		return MUSIC_JOHTO_WILD_BATTLE_NIGHT \
+			if time_of_day == Gen2WorldPalette.TIME_NIGHT else MUSIC_JOHTO_WILD_BATTLE
+	if trainer_class == TRAINER_CLASS_CHAMPION or trainer_class == TRAINER_CLASS_RED:
+		return MUSIC_CHAMPION_BATTLE
+	# `docs/bugs_and_glitches.md`: only the two grunt classes reach the Rocket
+	# track, so an Executive or a Scientist falls through to the trainer rows.
+	if trainer_class == TRAINER_CLASS_GRUNTM or trainer_class == TRAINER_CLASS_GRUNTF:
+		return MUSIC_ROCKET_BATTLE
+	if KANTO_GYM_LEADERS.has(trainer_class):
+		return MUSIC_KANTO_GYM_LEADER_BATTLE
+	if JOHTO_GYM_LEADERS.has(trainer_class):
+		return MUSIC_JOHTO_GYM_LEADER_BATTLE
+	if trainer_class == TRAINER_CLASS_RIVAL1:
+		return MUSIC_RIVAL_BATTLE
+	if trainer_class == TRAINER_CLASS_RIVAL2:
+		return MUSIC_CHAMPION_BATTLE \
+			if trainer_id >= TRAINER_ID_RIVAL2_2_CHIKORITA else MUSIC_RIVAL_BATTLE
+	return MUSIC_KANTO_TRAINER_BATTLE if kanto else MUSIC_JOHTO_TRAINER_BATTLE

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -321,6 +321,8 @@ var _anim_delay: int = 0
 var _anim_event: Dictionary = {}
 var _anim_hud_hidden: bool = false
 var _audio_player: Gen2AudioPlayer = null
+## `PlayBattleMusic`'s answer for this fight; see [method battle_music].
+var _battle_music: int = Gen2Battle.MUSIC_NONE
 
 @onready var _screen: Gen2Screen = %Screen
 
@@ -760,6 +762,7 @@ func start_world_battle(
 	_enemy = enemy_party_ready.active_mon().species
 	_enemy_level = enemy_party_ready.active_mon().level
 	_init_battle_display()
+	_play_battle_music()
 
 	if _world_battle_tutorial:
 		show_message("Gotcha! %s was caught!" % _name_of(_enemy))
@@ -1235,6 +1238,32 @@ func _end_script() -> void:
 		_bg_map = _anim.background().bg_map.duplicate()
 	_anim = null
 	_run_next_anim_step()
+
+
+## `PlayBattleMusic`, which `FindFirstAliveMonAndStartBattle` runs in front of
+## `DoBattleTransition`: the piece playing is stopped, the volume goes back to
+## maximum, and the battle's own track starts. The world's map music is stopped
+## by the screen that opened this one, so the two players never overlap.
+func _play_battle_music() -> void:
+	_battle_music = Gen2Battle.MUSIC_NONE
+	if _audio_player == null or _data == null or _battle == null:
+		return
+	var landmark: int = _world_context.landmark if _world_context != null \
+		else Gen2WorldRadio.LANDMARK_SPECIAL
+	_battle_music = Gen2Battle.battle_music(
+		_battle.battle_type, _enemy_trainer_class, _enemy_trainer_index,
+		landmark, _time_of_day, Gen2WorldState.is_crystal_profile(_data),
+	)
+	var record: Dictionary = _data.world_audio(&"music", _battle_music)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
+## Which track [method _play_battle_music] chose, for a check or a test that
+## cannot hear one. `MUSIC_NONE` until a world battle has started.
+func battle_music() -> int:
+	return _battle_music
 
 
 ## `BattleAnimCmd_Sound`'s second operand, which is the SFX id `PlayStereoSFX`

--- a/game/battle/battle_world_context.gd
+++ b/game/battle/battle_world_context.gd
@@ -25,6 +25,9 @@ var player_facing: int = Gen2WorldSprite.FACING_DOWN
 ## The row the world was drawn with rather than the hour: a dark cave is night
 ## until Flash is used. See [method Gen2WorldPalette.map_time_of_day].
 var time_of_day: int = Gen2WorldPalette.TIME_DAY
+## `GetWorldMapLocation`'s answer for this map, which is what `RegionCheck`
+## reads and so what `PlayBattleMusic` picks a wild track off.
+var landmark: int = Gen2WorldRadio.LANDMARK_SPECIAL
 
 
 ## The world's own values, read once. [param drawn_time_of_day] is the caller's,
@@ -40,6 +43,7 @@ static func capture(
 	out.tileset = world.current_map.tileset
 	out.player_cell = world.player_cell
 	out.player_facing = world.player_facing
+	out.landmark = world.landmark()
 	out.time_of_day = clampi(
 		drawn_time_of_day if drawn_time_of_day >= 0 else world.map_time_of_day(), 0, 3
 	)
@@ -61,4 +65,5 @@ func to_dictionary() -> Dictionary:
 		"player_cell": player_cell,
 		"player_facing": player_facing,
 		"time_of_day": time_of_day,
+		"landmark": landmark,
 	}

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -44,6 +44,11 @@ var _page_nodes: Dictionary = {}
 var _current: StringName = &""
 var _focus: Gen2FocusGuard = null
 
+## Set by [method flash] and consumed by the next shell built, which is what
+## carries one transition across a scene change. Static because the shell that
+## faded out is gone by the time the next one exists.
+static var _transition_pending: bool = false
+
 
 static func create(palette: Gen2LauncherTheme) -> Gen2LauncherShell:
 	var shell := Gen2LauncherShell.new()
@@ -131,6 +136,12 @@ func _build() -> void:
 	_flash.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_flash.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	add_child(_flash)
+	# The screen this one replaced left through `flash()`, so this one arrives
+	# under the same sheet and walks it back rather than cutting in under it.
+	if _transition_pending:
+		_transition_pending = false
+		_flash.color = Color(_flash_color(), 1.0)
+		ready.connect(fade_in, CONNECT_ONE_SHOT)
 
 	resized.connect(_apply_layout)
 	_apply_layout()
@@ -268,14 +279,62 @@ func _art_layer() -> TextureRect:
 	return layer
 
 
-## A wipe over everything, used when a game is about to open.
-func flash(duration: float = 0.4) -> void:
+## The screen-to-screen transition, in the family of the cartridge's own:
+## `FadeOutToWhite` walks `Gen2WorldPalette.FADE_OUT_ORDERS` one row at a time,
+## holding each for `FADE_STEP_FRAMES`, so the screen leaves in four discrete
+## steps rather than on a continuous ramp. The launcher is not a cartridge
+## screen, so the colour it flattens onto is the palette's own rather than a
+## map's white, and the steps are alpha rather than palette rows.
+##
+## The next shell built after one of these fades in from the same colour, so a
+## launch is one transition across the scene change instead of a wipe and a cut.
+## [param hand_over] is false when the screen after this one is not a shell
+## screen: the world arrives on its own map fade, which is the cartridge's, so
+## it must not be walked back out of the launcher's sheet as well.
+func flash(hand_over: bool = true) -> void:
 	if not is_inside_tree():
 		return
-	_flash.color = Color(0, 0, 0, 0) if theme_palette.is_dark() else Color(1, 1, 1, 0)
-	var tween: Tween = create_tween()
-	tween.tween_property(_flash, "color:a", 1.0, duration).set_ease(Tween.EASE_IN)
-	await tween.finished
+	_transition_pending = hand_over
+	await _step_flash(_flash_color(), 0.0, 1.0)
+
+
+## `FadeInFromWhite`: the same four rows walked back. Run by `_build` when the
+## screen before this one left through [method flash], and by nothing else, so
+## a cold boot opens on the launcher rather than on a wipe.
+func fade_in() -> void:
+	if not is_inside_tree():
+		return
+	await _step_flash(_flash_color(), 1.0, 0.0)
+	_flash.color = _flash_color()
+
+
+## Preview seam for `tools/preview_launcher.gd`: the sheet as [method flash]
+## leaves it after [param step] of its four, which a moving fade cannot be
+## photographed at.
+func preview_fade_step(step: int) -> void:
+	if _flash == null:
+		return
+	var steps: int = Gen2WorldPalette.FADE_OUT_ORDERS.size()
+	var color: Color = _flash_color()
+	color.a = float(clampi(step, 0, steps)) / float(steps)
+	_flash.color = color
+
+
+func _flash_color() -> Color:
+	return Color(0, 0, 0, 0) if theme_palette.is_dark() else Color(1, 1, 1, 0)
+
+
+func _step_flash(color: Color, from: float, to: float) -> void:
+	var steps: int = Gen2WorldPalette.FADE_OUT_ORDERS.size()
+	color.a = from
+	_flash.color = color
+	for step: int in steps:
+		for _frame: int in Gen2WorldPalette.FADE_STEP_FRAMES:
+			await get_tree().process_frame
+			if not is_inside_tree():
+				return
+		color.a = lerpf(from, to, float(step + 1) / float(steps))
+		_flash.color = color
 
 
 func _rebuild_dock() -> void:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -389,6 +389,13 @@ func select_page(id: StringName) -> void:
 		_shell.select(id)
 
 
+## Preview seam: holds the transition sheet at one of `FadeOutToWhite`'s four
+## rows so a still can show that the fade is stepped. Photography only; the
+## launcher itself only ever runs the whole walk.
+func preview_fade_step(step: int) -> void:
+	_shell.preview_fade_step(step)
+
+
 ## Preview seam: shows the shelf as if these cartridges were imported, so the
 ## empty and full states can be photographed on one machine. Changes nothing on
 ## disk and is never called by the launcher itself.
@@ -459,7 +466,8 @@ func _launch_game(game_id: StringName) -> void:
 		)
 		return
 	_selected_game_id = game_id
-	_set_status(&"success", "Starting %s." % RomRegistry.title_for(game_id), "")
+	# The launch says itself with the transition; a toast announcing it would be
+	# a second, slower answer to the same press.
 	_shelf.set_busy(true)
 	var seated: Gen2Cartridge = _shelf.cartridge(game_id)
 	if seated != null:

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -598,7 +598,7 @@ func _continue_selected() -> void:
 		)
 		return
 	Gen2LauncherAudio.play(&"power")
-	await _shell.flash(0.35)
+	await _shell.flash(false)
 	get_tree().change_scene_to_file.call_deferred("res://game/world/world_screen.tscn")
 
 
@@ -615,7 +615,10 @@ func _open_party() -> void:
 	get_tree().change_scene_to_file.call_deferred("res://game/save/party_screen.tscn")
 
 
+## The same transition the launcher opened this screen with, walked the other
+## way: both ends carry a shell, so the sheet is handed over the scene change.
 func _back_to_launcher() -> void:
+	await _shell.flash()
 	get_tree().change_scene_to_file.call_deferred("res://game/main/main.tscn")
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2114,6 +2114,11 @@ func _start_battle_request(request: Dictionary) -> void:
 	## deferred call: `startbattle` is a script command, so the fight belongs to
 	## the frame the encounter fired on, and a run driven frame by frame (a check,
 	## a replay) never reaches a deferred call at all.
+	## `PlayBattleMusic` opens with `PlayMusic MUSIC_NONE`, which is one driver
+	## silencing itself. The battle runs its own [Gen2AudioPlayer], so the map's
+	## has to be the thing that stops, or both pieces play at once.
+	if _audio_player != null:
+		_audio_player.stop_all()
 	host.start_world_battle(request.duplicate(true), save, badges)
 	## After the fight exists, because starting one clears whatever capture action
 	## was staged: the bag belongs to this battle rather than to the last one.
@@ -2241,6 +2246,10 @@ func _on_battle_finished(result: Dictionary) -> void:
 		_show_script_results(resumed)
 	_active_battle_save = null
 	_active_battle_persist = false
+	## `MapSetupScript_ReloadMap`'s `ForceMapMusic`, which is `TryRestartMapMusic`:
+	## a battle leaves through a map reload, and that reload is what puts the
+	## map's own track back over the one `PlayBattleMusic` started.
+	_play_current_map_music()
 	_refresh_labels()
 
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -980,3 +980,18 @@ func test_a_trainer_battle_refuses_the_run_and_the_overlay_stays_open() -> void:
 	assert_eq(host._battle.mon(Gen2Battle.ENEMY).hp, enemy_before)
 	assert_eq(host._battle.mon(Gen2Battle.PLAYER).hp, player_before, "the turn was spent")
 	assert_not_null(_battle_host())
+
+
+## `PlayBattleMusic` runs inside `FindFirstAliveMonAndStartBattle`, so the track
+## is chosen where the fight starts rather than by whatever opened it. The
+## fixture's trainer is class 1, FALKNER, on a Johto landmark.
+func test_a_trainer_battle_opens_on_the_track_its_class_names() -> void:
+	await _open_world()
+	await _trigger_trainer()
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_eq(host.battle_music(), Gen2Battle.MUSIC_JOHTO_GYM_LEADER_BATTLE)
+	assert_false(
+		Gen2Battle.region_is_kanto(_world_screen._world.landmark()),
+		"the fixture map is in Johto"
+	)

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -4076,3 +4076,123 @@ func test_a_wild_force_switch_skips_the_end_of_turn_tail() -> void:
 		"`ResidualDamage` sits behind the `ret nz`")
 	assert_eq(battle.weather_turns, Gen2Weather.TURNS, "and so does the weather count")
 	assert_eq(_of_type(events, Gen2Battle.OVER).size(), 1)
+
+
+## `PlayBattleMusic` (engine/battle/start_battle.asm), whose whole answer is the
+## battle type, the trainer class and id, the landmark and `wTimeOfDay`.
+const JOHTO_LANDMARK: int = Gen2WorldRadio.LANDMARK_RUINS_OF_ALPH
+const KANTO_LANDMARK: int = Gen2WorldRadio.KANTO_LANDMARK
+
+
+func _music(
+	trainer_class: int = 0,
+	landmark: int = JOHTO_LANDMARK,
+	time_of_day: int = Gen2WorldPalette.TIME_DAY,
+	trainer_id: int = 1,
+	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL,
+) -> int:
+	return Gen2Battle.battle_music(
+		battle_type, trainer_class, trainer_id, landmark, time_of_day
+	)
+
+
+func test_a_wild_battle_takes_the_region_and_the_hour() -> void:
+	assert_eq(_music(), Gen2Battle.MUSIC_JOHTO_WILD_BATTLE)
+	assert_eq(
+		_music(0, JOHTO_LANDMARK, Gen2WorldPalette.TIME_NIGHT),
+		Gen2Battle.MUSIC_JOHTO_WILD_BATTLE_NIGHT
+	)
+	## Kanto has one wild track, so the hour does not reach it.
+	assert_eq(_music(0, KANTO_LANDMARK), Gen2Battle.MUSIC_KANTO_WILD_BATTLE)
+	assert_eq(
+		_music(0, KANTO_LANDMARK, Gen2WorldPalette.TIME_NIGHT),
+		Gen2Battle.MUSIC_KANTO_WILD_BATTLE
+	)
+
+
+## `cp BATTLETYPE_SUICUNE` and `cp BATTLETYPE_ROAMING` both `jp z, .done` with
+## `MUSIC_SUICUNE_BATTLE` already in `de`, and both sit in front of the trainer
+## check, so a trainer class cannot take either of them off.
+func test_the_two_battle_types_in_front_answer_before_anything_else() -> void:
+	for battle_type: int in [Gen2Battle.BATTLETYPE_SUICUNE, Gen2Battle.BATTLETYPE_ROAMING]:
+		assert_eq(
+			_music(0, JOHTO_LANDMARK, Gen2WorldPalette.TIME_DAY, 1, battle_type),
+			Gen2Battle.MUSIC_SUICUNE_BATTLE
+		)
+		assert_eq(
+			_music(
+				Gen2Battle.TRAINER_CLASS_CHAMPION, KANTO_LANDMARK,
+				Gen2WorldPalette.TIME_DAY, 1, battle_type
+			),
+			Gen2Battle.MUSIC_SUICUNE_BATTLE
+		)
+
+
+func test_the_champion_and_red_answer_before_the_leader_lists() -> void:
+	assert_eq(_music(Gen2Battle.TRAINER_CLASS_CHAMPION), Gen2Battle.MUSIC_CHAMPION_BATTLE)
+	assert_eq(_music(Gen2Battle.TRAINER_CLASS_RED), Gen2Battle.MUSIC_CHAMPION_BATTLE)
+
+
+## `docs/bugs_and_glitches.md`: only the two grunt classes reach the Rocket
+## track. EXECUTIVEM and EXECUTIVEF fall through to the ordinary trainer rows.
+func test_only_the_two_grunt_classes_reach_the_rocket_track() -> void:
+	assert_eq(_music(Gen2Battle.TRAINER_CLASS_GRUNTM), Gen2Battle.MUSIC_ROCKET_BATTLE)
+	assert_eq(_music(Gen2Battle.TRAINER_CLASS_GRUNTF), Gen2Battle.MUSIC_ROCKET_BATTLE)
+	assert_eq(_music(0x33), Gen2Battle.MUSIC_JOHTO_TRAINER_BATTLE, "EXECUTIVEM")
+	assert_eq(_music(0x37), Gen2Battle.MUSIC_JOHTO_TRAINER_BATTLE, "EXECUTIVEF")
+	assert_eq(_music(0x14), Gen2Battle.MUSIC_JOHTO_TRAINER_BATTLE, "SCIENTIST")
+
+
+func test_the_kanto_list_is_checked_before_the_johto_one() -> void:
+	for leader: int in Gen2Battle.KANTO_GYM_LEADERS:
+		assert_eq(
+			_music(leader), Gen2Battle.MUSIC_KANTO_GYM_LEADER_BATTLE,
+			"class %d" % leader
+		)
+	for leader: int in Gen2Battle.JOHTO_GYM_LEADERS:
+		if leader in [Gen2Battle.TRAINER_CLASS_CHAMPION, Gen2Battle.TRAINER_CLASS_RED]:
+			continue
+		assert_eq(
+			_music(leader), Gen2Battle.MUSIC_JOHTO_GYM_LEADER_BATTLE,
+			"class %d" % leader
+		)
+
+
+## `cp RIVAL2_2_CHIKORITA / jr c, .done` keeps the three ids below the Indigo
+## Plateau rematch on the rival's own track and gives it the champion's.
+func test_the_second_rival_class_splits_on_its_trainer_id() -> void:
+	assert_eq(_music(Gen2Battle.TRAINER_CLASS_RIVAL1), Gen2Battle.MUSIC_RIVAL_BATTLE)
+	for id: int in [1, 2, 3]:
+		assert_eq(
+			_music(Gen2Battle.TRAINER_CLASS_RIVAL2, JOHTO_LANDMARK,
+				Gen2WorldPalette.TIME_DAY, id),
+			Gen2Battle.MUSIC_RIVAL_BATTLE, "id %d" % id
+		)
+	for id: int in [4, 5, 6]:
+		assert_eq(
+			_music(Gen2Battle.TRAINER_CLASS_RIVAL2, JOHTO_LANDMARK,
+				Gen2WorldPalette.TIME_DAY, id),
+			Gen2Battle.MUSIC_CHAMPION_BATTLE, "id %d" % id
+		)
+
+
+func test_an_ordinary_trainer_takes_the_region() -> void:
+	assert_eq(_music(0x16), Gen2Battle.MUSIC_JOHTO_TRAINER_BATTLE, "YOUNGSTER in Johto")
+	assert_eq(
+		_music(0x16, KANTO_LANDMARK), Gen2Battle.MUSIC_KANTO_TRAINER_BATTLE,
+		"YOUNGSTER in Kanto"
+	)
+
+
+## `RegionCheck` is not `IsInJohto`: the Fast Ship is Johto on both, and so is
+## Victory Road and everything above it, which `IsInJohto` calls Kanto.
+func test_region_check_keeps_the_fast_ship_and_victory_road_in_johto() -> void:
+	assert_false(Gen2Battle.region_is_kanto(Gen2WorldRadio.LANDMARK_FAST_SHIP))
+	assert_false(Gen2Battle.region_is_kanto(Gen2Battle.LANDMARK_VICTORY_ROAD))
+	assert_false(Gen2Battle.region_is_kanto(Gen2Battle.LANDMARK_VICTORY_ROAD + 1))
+	assert_true(Gen2Battle.region_is_kanto(Gen2Battle.LANDMARK_VICTORY_ROAD - 1))
+	assert_true(Gen2Battle.region_is_kanto(Gen2WorldRadio.KANTO_LANDMARK))
+	assert_false(Gen2Battle.region_is_kanto(Gen2WorldRadio.KANTO_LANDMARK - 1))
+	## Gold and Silver's table is one shorter from LANDMARK_BATTLE_TOWER on.
+	assert_true(Gen2Battle.region_is_kanto(Gen2WorldRadio.KANTO_LANDMARK - 1, false))
+	assert_false(Gen2Battle.region_is_kanto(Gen2WorldRadio.LANDMARK_FAST_SHIP - 1, false))

--- a/tests/unit/test_battle_world_context.gd
+++ b/tests/unit/test_battle_world_context.gd
@@ -59,3 +59,12 @@ func test_an_unnamed_time_of_day_falls_back_to_the_maps_own_row() -> void:
 
 func test_a_world_without_a_map_answers_nothing() -> void:
 	assert_null(Gen2BattleWorldContext.capture(null))
+
+
+## `RegionCheck` reads `GetWorldMapLocation`, which is what `PlayBattleMusic`
+## picks a wild track off, so the snapshot has to carry it.
+func test_capture_copies_the_maps_landmark() -> void:
+	var world: Gen2WorldAPI = _world()
+	var context: Gen2BattleWorldContext = Gen2BattleWorldContext.capture(world)
+	assert_eq(context.landmark, world.landmark())
+	assert_eq(int(context.to_dictionary()["landmark"]), world.landmark())

--- a/tools/checks/battle_music.gd
+++ b/tools/checks/battle_music.gd
@@ -1,0 +1,145 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies `PlayBattleMusic` (engine/battle/start_battle.asm) against freshly
+## imported real caches, on all three cartridges.
+##
+## The routine is a walk down a list of compares, so the failure it can have is
+## not an arithmetic one: it is a row that stops being reachable, or a track it
+## names that the audio importer does not hold. Both are swept here over the
+## whole corpus rather than sampled, which is two sweeps:
+##
+## - every map in the cache, through `RegionCheck`, so the wild rows are asked
+##   at every landmark the cartridge has rather than at one;
+## - every trainer class the cartridge ships and every individual trainer inside
+##   it, so the RIVAL2 id split and both leader lists are reached by real data.
+##
+## Every track either sweep names is then looked up in the imported audio index,
+## which is what says the piece can actually be played. Gold and Silver have no
+## `MUSIC_SUICUNE_BATTLE` and never write the two battle types that reach it, so
+## that row is asked of Crystal alone.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- battle_music
+
+## The two hours the wild rows split on. Only Johto has a night track.
+const HOURS: Array[int] = [Gen2WorldPalette.TIME_DAY, Gen2WorldPalette.TIME_NIGHT]
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		_verify_wild_over_every_map()
+		_verify_every_trainer_class()
+		_verify_the_crystal_only_row()
+	)
+
+
+## `RegionCheck` over the whole map list, which is the only input a wild battle's
+## track has beyond the hour.
+func _verify_wild_over_every_map() -> void:
+	var tracks: Dictionary = {}
+	var kanto_maps: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		if Gen2Battle.region_is_kanto(map.location, _r.crystal):
+			kanto_maps += 1
+		for hour: int in HOURS:
+			var track: int = Gen2Battle.battle_music(
+				Gen2Battle.BATTLETYPE_NORMAL, 0, 0, map.location, hour, _r.crystal
+			)
+			tracks[track] = int(tracks.get(track, 0)) + 1
+			_verify_track_exists(track, "map %d/%d at hour %d" % [
+				map.group, map.number, hour,
+			])
+	var wanted: Array = [
+		Gen2Battle.MUSIC_JOHTO_WILD_BATTLE,
+		Gen2Battle.MUSIC_JOHTO_WILD_BATTLE_NIGHT,
+		Gen2Battle.MUSIC_KANTO_WILD_BATTLE,
+	]
+	var found: Array = tracks.keys()
+	found.sort()
+	wanted.sort()
+	_r.note("wild: %d maps, %d in Kanto, tracks %s." % [
+		_r.data.world_maps().size(), kanto_maps, str(found),
+	])
+	_r.check(
+		found == wanted,
+		"the corpus reaches wild tracks %s, not all three of %s." % [
+			str(found), str(wanted),
+		]
+	)
+	## A cartridge with no Kanto map would pass the row above by accident.
+	_r.check(kanto_maps > 0, "no map in the corpus is in Kanto.")
+
+
+## Every class the cartridge ships, and every individual trainer inside it, so
+## the RIVAL2 id split is asked with the ids that exist rather than invented.
+func _verify_every_trainer_class() -> void:
+	var tracks: Dictionary = {}
+	var classes: int = 0
+	for trainer_class: int in range(1, _r.data.trainer_count() + 1):
+		var count: int = _r.data.trainer_party_count(trainer_class)
+		if count == 0:
+			continue
+		classes += 1
+		for index: int in count:
+			## `wOtherTrainerID` is one-based, which is what `trainerclass`
+			## restarts its own count at.
+			var track: int = Gen2Battle.battle_music(
+				Gen2Battle.BATTLETYPE_NORMAL, trainer_class, index + 1,
+				Gen2WorldRadio.LANDMARK_SPECIAL, Gen2WorldPalette.TIME_DAY, _r.crystal
+			)
+			tracks[track] = int(tracks.get(track, 0)) + 1
+			_verify_track_exists(track, "trainer class %d id %d" % [
+				trainer_class, index + 1,
+			])
+	var found: Array = tracks.keys()
+	found.sort()
+	_r.note("trainers: %d classes, tracks %s." % [classes, str(found)])
+	## Every row of `.trainermusic` but the Kanto ones, which need a Kanto
+	## landmark rather than a class and are swept above.
+	for track: int in [
+		Gen2Battle.MUSIC_CHAMPION_BATTLE, Gen2Battle.MUSIC_ROCKET_BATTLE,
+		Gen2Battle.MUSIC_KANTO_GYM_LEADER_BATTLE,
+		Gen2Battle.MUSIC_JOHTO_GYM_LEADER_BATTLE, Gen2Battle.MUSIC_RIVAL_BATTLE,
+		Gen2Battle.MUSIC_JOHTO_TRAINER_BATTLE,
+	]:
+		_r.check(
+			tracks.has(track),
+			"no trainer class in the corpus reaches track %d." % track
+		)
+	## The same classes on a Kanto landmark, which is the only way the ordinary
+	## trainer row changes its answer.
+	var kanto: int = Gen2Battle.battle_music(
+		Gen2Battle.BATTLETYPE_NORMAL, 0x16, 1,
+		Gen2WorldRadio.kanto_landmark(_r.crystal), Gen2WorldPalette.TIME_DAY, _r.crystal
+	)
+	_r.check(
+		kanto == Gen2Battle.MUSIC_KANTO_TRAINER_BATTLE,
+		"a Kanto trainer takes track %d rather than the Kanto trainer battle." % kanto
+	)
+	_verify_track_exists(Gen2Battle.MUSIC_KANTO_TRAINER_BATTLE, "a Kanto trainer")
+
+
+## `MUSIC_SUICUNE_BATTLE` is Crystal's own constant; the two battle types that
+## reach it are written by no Gold or Silver script.
+func _verify_the_crystal_only_row() -> void:
+	for battle_type: int in [Gen2Battle.BATTLETYPE_SUICUNE, Gen2Battle.BATTLETYPE_ROAMING]:
+		var track: int = Gen2Battle.battle_music(
+			battle_type, Gen2Battle.TRAINER_CLASS_CHAMPION, 1,
+			Gen2WorldRadio.kanto_landmark(_r.crystal),
+			Gen2WorldPalette.TIME_NIGHT, _r.crystal
+		)
+		_r.check(
+			track == Gen2Battle.MUSIC_SUICUNE_BATTLE,
+			"battle type %d takes track %d rather than Suicune's." % [battle_type, track]
+		)
+	if _r.crystal:
+		_verify_track_exists(Gen2Battle.MUSIC_SUICUNE_BATTLE, "a Suicune battle")
+
+
+func _verify_track_exists(track: int, where: String) -> void:
+	if _r.data.world_audio(&"music", track).is_empty():
+		_r.fail("%s asks for track %d, which the audio index does not hold." % [
+			where, track,
+		])

--- a/tools/checks/battle_music.gd.uid
+++ b/tools/checks/battle_music.gd.uid
@@ -1,0 +1,1 @@
+uid://luybo6lekj7u

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -5,9 +5,14 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_launcher.gd -- \
 ##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] \
-##       [scroll] [focus index]
+##       [scroll] [focus index] [fade step]
 ##
 ## `view` is the mods page's own: `list`, `sources`, or `mod` with an id.
+## `fade` is which step of the screen transition to photograph, 0 for none and 1
+## to 4 for one of `FadeOutToWhite`'s own rows: the launcher's leave-the-screen
+## sheet is stepped rather than tweened, so a still is the only way to see that
+## it is discrete. See [method Gen2LauncherShell.flash].
+##
 ## `scroll` is how far down the page's own scroll to photograph, in pixels, for a
 ## card that does not fit the window. `focus` puts the keyboard on the nth
 ## focusable control in tree order, which is the only way to photograph a focus
@@ -33,6 +38,7 @@ var _view: String = ""
 var _mod: String = ""
 var _scroll: int = 0
 var _focus: int = -1
+var _fade: int = 0
 
 
 func _initialize() -> void:
@@ -51,6 +57,7 @@ func _initialize() -> void:
 	_mod = args[7] if args.size() > 7 else ""
 	_scroll = int(args[8]) if args.size() > 8 else 0
 	_focus = int(args[9]) if args.size() > 9 else -1
+	_fade = int(args[10]) if args.size() > 10 else 0
 
 	# Both, because the window already exists by the time a tool script runs and
 	# only the display server moves it.
@@ -94,6 +101,10 @@ func _process(_delta: float) -> bool:
 			reachable[_focus].grab_focus()
 		else:
 			push_error("Only %d focusable controls" % reachable.size())
+	# After the page and the focus, so the sheet lies over the screen the fade is
+	# actually leaving.
+	if _frames == 24 and _fade > 0:
+		_launcher.preview_fade_step(_fade)
 	if _frames < 26:
 		return false
 	var image: Image = root.get_texture().get_image()


### PR DESCRIPTION
Two of the reported defects.

**The launch toast is now a screen transition.** `Gen2LauncherShell.flash()` walks `FadeOutToWhite`'s four palette rows, two frames each, instead of tweening an alpha, and the next shell built walks them back the way `FadeInFromWhite` does. The sheet is handed across the scene change, so a launch reads as one transition rather than a wipe and a cut; going back to the launcher takes the same walk. The colour flattened onto is the launcher palette's own, since these screens have no map white behind them. `tools/preview_launcher.gd` takes a fade step so a still can show the ramp is discrete.

**`PlayBattleMusic` is built.** `Gen2Battle.battle_music` is the routine whole, with the two it calls:

- `RegionCheck`, which is not `IsInJohto`: the Fast Ship is Johto, and so is Victory Road and every landmark above it.
- `IsGymLeader` and `IsKantoGymLeader`, whose lists fall through into one another, so the Kanto row is checked first.
- the `RIVAL2` id split at the Indigo Plateau rematch, and the documented bug that keeps Executives and Scientists off the Rocket track.

The screen plays it where `FindFirstAliveMonAndStartBattle` runs it. The world stops its own driver first, because a battle here runs a second one and both pieces would otherwise play at once, and `MapSetupScript_ReloadMap`'s `ForceMapMusic` puts the map's track back on the way out.

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 3,197 tests over 152 scripts, green |
| `validate.gd -- all` | 54 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 6 legs each, 0 failures |
| `validate.gd -- battle_music` | every map and every trainer class on all three, every track in the audio index |

The new topic sweeps the corpus rather than a sample: 368 maps on Gold and Silver and 388 on Crystal through `RegionCheck`, 65 and 66 trainer classes with every id inside them, and each chosen track looked up in the imported audio index.