### PR TITLE
A map crossing costs a step, and a sign wears its own map's colours

### DIFF
--- a/game/render/map_name_sign_page.gd
+++ b/game/render/map_name_sign_page.gd
@@ -40,9 +40,27 @@ const TILE_INTERIOR: int = 13
 const NAME_ROW: int = 2
 
 
+## `PAL_BG_TEXT`, the slot `InitMapSignAttrmap` writes over every tile of the
+## sign. On a map that is the map's OWN palette 7, which `LoadMapPalettes` fills
+## out of `bg_tiles.pal`'s per-environment, per-time-of-day "text" row: cream,
+## cream, brown, black, which is what makes the sign read as wood. The blue
+## `Palette_TextBG7` this used to draw with is `LoadOW_BGPal7`'s, and nothing in
+## `MapSetupScript_Connection` or `RefreshMapSprites` runs that before the sign
+## is placed.
+const PAL_BG_TEXT: int = 7
+
+
 ## The sign holding [param name], or null when the cache carries no sheet, no
-## font or no text palette, which is every Gold and Silver cache.
-static func render(data: GameData, name: String) -> Image:
+## font or no palette, which is every Gold and Silver cache.
+##
+## [param environment] and [param time_of_day] are the map's, since the slot the
+## sign is drawn through is one of the eight the map loaded.
+static func render(
+	data: GameData,
+	name: String,
+	environment: int = Gen2WorldAPI.ENVIRONMENT_TOWN,
+	time_of_day: int = Gen2WorldPalette.TIME_MORNING,
+) -> Image:
 	if data == null:
 		return null
 	var sheet: PackedByteArray = data.tile_indices("map_entry_sign")
@@ -51,7 +69,8 @@ static func render(data: GameData, name: String) -> Image:
 	var font: Gen2Font = Gen2Font.from_data(data)
 	if font == null:
 		return null
-	var palette: PackedColorArray = data.text_bg_palette()
+	var slots: Array = Gen2WorldPalette.palette_slots(environment, time_of_day)
+	var palette: PackedColorArray = data.world_palette(int(slots[PAL_BG_TEXT]))
 	if palette.size() < 4:
 		palette = Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 	var width: int = COLUMNS * TILE

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4468,6 +4468,15 @@ func try_connection(direction: Vector2i) -> Dictionary:
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
 	_apply_map(target_map, target_tileset, target_cell)
+	## `CheckMovingOffEdgeOfMap` answers a step that has ALREADY landed: the
+	## player walks the whole step onto the cell the connection strip's blocks
+	## are drawn in, and only then does `EdgeWarpScript`'s `MAPSETUP_CONNECTION`
+	## re-anchor the map around it. So a crossing costs exactly the frames any
+	## other step does. `_apply_map` clears the step it inherits, so the step is
+	## begun after it; the cell it is drawn walking out of is the new map's own
+	## connection strip, which is the same picture the old map's edge was.
+	player_facing = _facing_for_direction(direction)
+	_start_player_step(direction, _step_frames_for_movement())
 	return {
 		"ok": true,
 		"kind": &"connection",
@@ -4951,9 +4960,9 @@ func move_result(direction: Vector2i) -> Dictionary:
 		or destination.y >= current_map.collision_height:
 		var transition: Dictionary = try_connection(direction)
 		if not transition.is_empty():
-			if bool(transition.get("ok", false)):
-				player_facing = _facing_for_direction(direction)
-				state.consume_repel_step()
+			## `CheckTileEvent` branches to `.map_connection` before it reaches
+			## `CountStep`, so the step that leaves a map costs no repel step;
+			## try_connection() owns the facing and the step's own frames.
 			return transition
 		return {"ok": false, "kind": &"move", "reason": &"map_edge"}
 	if forced_walk:

--- a/game/world/world_menu.gd
+++ b/game/world/world_menu.gd
@@ -18,6 +18,19 @@ const YES_NO_LEFT: int = 14
 const YES_NO_TOP: int = 7
 const YES_NO_RIGHT: int = 19
 const YES_NO_BOTTOM: int = 11
+## `YesNoMenuHeader.MenuData`'s own `db STATICMENU_CURSOR |
+## STATICMENU_NO_TOP_SPACING`. A `choice` with no `loadmenu` header behind it is
+## a `Script_yesorno`, so it inherits these rather than no flags at all: without
+## STATICMENU_CURSOR [Gen2MenuPage] draws no arrow, and the box said YES and NO
+## with nothing marking which one A would answer.
+## `YesNoMenuHeader.MenuData`'s own `db "YES@"` / `db "NO@"`. The runner names
+## the two answers with internal keys, which every branch reading a choice
+## compares against; those keys are not what the cartridge prints.
+const YES_NO_KEYS: Array = [&"yes", &"no"]
+const YES_NO_OPTIONS: Array = ["YES", "NO"]
+const YES_NO_FLAGS: int = (
+	Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+)
 
 var kind: StringName = &"vertical"
 var options: Array = []
@@ -43,7 +56,9 @@ static func from_input(input: Dictionary) -> Gen2WorldMenu:
 	menu.options = input.get(
 		"options", input.get("choices", header.get("options", []))
 	).duplicate(true)
-	menu.flags = int(header.get("data_flags", 0))
+	if menu.options == YES_NO_KEYS:
+		menu.options = YES_NO_OPTIONS.duplicate()
+	menu.flags = int(header.get("data_flags", YES_NO_FLAGS))
 	menu.rows = maxi(1, int(header.get("rows", menu.options.size())))
 	menu.columns = maxi(1, int(header.get("columns", 1)))
 	if menu.kind == &"2d":

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1072,6 +1072,7 @@ func _complete_player_step(movement: Dictionary) -> bool:
 		## whose `FadeOutToWhite` runs before the map is loaded at all. The map
 		## swaps when that fade lands, and everything a step still owes waits
 		## for `FadeInFromWhite` behind it.
+		_zero_map_name_sign_timer()
 		_start_map_fade()
 		return true
 	return _after_map_settled()
@@ -1087,16 +1088,19 @@ func _after_map_settled() -> bool:
 	if sight_results.is_empty():
 		sight_results = _world.dispatch_script_events()
 	if not sight_results.is_empty():
+		_zero_map_name_sign_timer()
 		_show_script_results(sight_results)
 		return true
 	var special_attempt: Dictionary = _world.try_special_phone_call()
 	var special_results: Array = special_attempt.get("results", [])
 	if bool(special_attempt.get("attempted", false)) and not special_results.is_empty():
+		_zero_map_name_sign_timer()
 		_show_script_results(special_results)
 		return true
 	var phone_attempt: Dictionary = _world.try_receive_phone_call(_encounter_random)
 	var phone_results: Array = phone_attempt.get("results", [])
 	if bool(phone_attempt.get("attempted", false)) and not phone_results.is_empty():
+		_zero_map_name_sign_timer()
 		_show_script_results(phone_results)
 		return true
 	## `CheckTimeEvents`' contest branch, which is read a step at a time and
@@ -1104,6 +1108,7 @@ func _after_map_settled() -> bool:
 	## the contest ends.
 	var contest_over: Array = _world.check_bug_contest_timer()
 	if not contest_over.is_empty():
+		_zero_map_name_sign_timer()
 		_show_script_results(contest_over)
 		return true
 	_show_script_results([])
@@ -1114,12 +1119,16 @@ func _after_map_settled() -> bool:
 		var visible: Dictionary = _encounters.battle_request_at(_world.player_cell)
 		if not visible.is_empty():
 			_battle_encounter_id = StringName(visible["visible_encounter"])
+			_zero_map_name_sign_timer()
 			_start_battle_request(visible)
 		return true
 	var encounter: Dictionary = _world.encounter_request(
 		_encounter_random, false, &"auto", _repel_lead_level(), _party_holds_cleanse_tag()
 	)
 	if not encounter.is_empty():
+		## `RandomEncounter` answers `CheckTileEvent` with carry, so a wild met
+		## on a step is a player event like any other.
+		_zero_map_name_sign_timer()
 		_start_battle_request({
 			"kind": &"battle_requested",
 			"values": encounter["values"],
@@ -1268,6 +1277,9 @@ func interact() -> bool:
 	var results: Array = _world.interact()
 	if results.is_empty():
 		return false
+	## `OWPlayerInput`, the last branch `PlayerEvents` tries, and a player event
+	## like the rest of them.
+	_zero_map_name_sign_timer()
 	_show_script_results(results)
 	return true
 
@@ -3743,7 +3755,13 @@ func _raise_map_name_sign() -> void:
 	## `MapEntryFrameGFX` spends the same sixty frames with nothing drawn in
 	## them rather than skipping them.
 	_map_name_sign_frames = Gen2WorldAPI.MAP_NAME_SIGN_FRAMES
-	var image: Image = Gen2MapNameSignPage.render(_data, _data.landmark_name(landmark))
+	var image: Image = Gen2MapNameSignPage.render(
+		_data,
+		_data.landmark_name(landmark),
+		_world.current_map.environment if _world.current_map != null \
+			else Gen2WorldAPI.ENVIRONMENT_TOWN,
+		_render_time_of_day(),
+	)
 	if image == null:
 		return
 	_map_name_sign = TextureRect.new()
@@ -3763,18 +3781,22 @@ func _raise_map_name_sign() -> void:
 func _advance_map_name_sign() -> void:
 	if _map_name_sign_frames <= 0:
 		return
-	## `PlayerEvents` zeroes the timer behind every player event but a connection
-	## crossing and a change of facing, neither of which runs a script: a text
-	## box, a trainer or a warp takes the sign down where it stands.
-	if _world != null and _world.script_busy():
-		_hide_map_name_sign()
-		return
 	_map_name_sign_frames -= 1
 	if _map_name_sign_frames <= 0:
 		_hide_map_name_sign()
 		return
 	if _map_name_sign != null:
 		_map_name_sign.visible = true
+
+
+## `PlayerEvents`' own `xor a / ld [wLandmarkSignTimer], a`, which sits behind
+## `DoPlayerEvent` and is skipped for PLAYEREVENT_CONNECTION and
+## PLAYEREVENT_JOYCHANGEFACING alone. Called where this screen dispatches one of
+## the others, rather than keyed on a script being busy: the map's own callbacks
+## are `RunMapCallback`'s work inside map setup and reach `PlayerEvents` never,
+## so a queued one used to take down the very sign the map load had raised.
+func _zero_map_name_sign_timer() -> void:
+	_hide_map_name_sign()
 
 
 func _hide_map_name_sign() -> void:

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -216,6 +216,30 @@ func test_a_warp_into_another_landmark_raises_the_map_name_sign() -> void:
 	assert_eq(_screen.map_name_sign_frames(), 0, "and gone on the sixtieth")
 
 
+## `PlayerEvents` zeroes `wLandmarkSignTimer` behind `DoPlayerEvent`, so only a
+## dispatched player event takes the sign down. A map's own callbacks are
+## `RunMapCallback`'s work inside map setup and reach `PlayerEvents` never: one
+## sitting on the queue used to take down the sign that same map load raised,
+## which is every connection crossing into a map that has one.
+func test_a_queued_map_callback_does_not_take_the_sign_down() -> void:
+	_screen = await _walk_onto_the_door()
+	for _frame: int in WALK_FRAME_CAP:
+		_screen.advance_frame()
+		if _screen.map_name_sign_frames() > 0:
+			break
+	assert_eq(_screen.map_name_sign_frames(), Gen2WorldAPI.MAP_NAME_SIGN_FRAMES)
+	## The fixture's house has no callback of its own, so one stands on the
+	## queue directly: what is under test is that a waiting script is not what
+	## takes the sign down, whatever put it there.
+	_screen._world._script_queue.append({})
+	assert_true(_screen._world.script_busy(), "a callback is waiting to run")
+	_screen.advance_frame()
+	assert_eq(
+		_screen.map_name_sign_frames(), Gen2WorldAPI.MAP_NAME_SIGN_FRAMES - 1,
+		"and the sign spent that frame rather than being taken down"
+	)
+
+
 ## `.CheckMovingWithinLandmark`: the map the world opens on is `wPrevLandmark`,
 ## so walking back into the landmark just left raises nothing.
 func test_a_warp_back_into_the_same_landmark_raises_no_sign() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2077,7 +2077,11 @@ func test_player_step_does_not_affect_cell_collision_or_events() -> void:
 	assert_eq(world.player_cell, Vector2i(7, 6))
 
 
-func test_player_step_clears_on_connection_transition() -> void:
+## CheckMovingOffEdgeOfMap only answers a step that has landed, so the crossing
+## costs the frames any other step does: the map is swapped under a step that is
+## still running, and the cell it is drawn walking out of is the connection
+## strip the neighbour's edge was drawn in.
+func test_connection_transition_spends_a_step() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(14, 6))
 	assert_true(world.move(Vector2i.RIGHT))
 	assert_eq(world.player_cell, Vector2i(15, 6))
@@ -2087,6 +2091,10 @@ func test_player_step_clears_on_connection_transition() -> void:
 	assert_true(result["ok"])
 	assert_eq(result["kind"], &"connection")
 	assert_eq(world.map_id(), Vector2i(1, 2))
+	assert_true(world.player_step_in_progress())
+	assert_eq(world.player_step_offset_cells(), Vector2(-1, 0))
+	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+		world.advance_player_step_frame()
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 

--- a/tests/unit/test_world_menu.gd
+++ b/tests/unit/test_world_menu.gd
@@ -98,3 +98,30 @@ func test_two_dimensional_menu_carries_columns_and_spacing_into_its_box() -> voi
 	var box: Gen2MenuBox = menu.box()
 	assert_eq(box.columns, 3)
 	assert_eq(box.column_spacing, 5)
+
+
+## `Script_yesorno` loads no menu header, so a `choice` arrives with none. The
+## fallback is `YesNoMenuHeader`'s whole record and not just its coordinates:
+## without STATICMENU_CURSOR nothing draws the arrow, so the box offered two
+## answers with no mark on the one A would take.
+func test_a_headerless_choice_wears_the_yes_no_menu_header() -> void:
+	var menu: Gen2WorldMenu = Gen2WorldMenu.from_input({
+		"type": &"choice", "command": &"yesorno", "choices": [&"yes", &"no"],
+	})
+	assert_eq(menu.options, ["YES", "NO"], "the strings are MenuData's own")
+	assert_true(
+		menu.box().has_flag(Gen2MenuBox.STATICMENU_CURSOR), "and the cursor is drawn"
+	)
+	assert_true(menu.box().has_flag(Gen2MenuBox.STATICMENU_NO_TOP_SPACING))
+	assert_eq(menu.selected_index(), 0, "`db 1` is YES")
+	assert_eq(menu.box().border_position(), Vector2i(14, 7), "_YesNoBox's own box")
+
+
+## A header that names its flags still wins, zero included.
+func test_a_loaded_header_keeps_its_own_flags() -> void:
+	var menu: Gen2WorldMenu = Gen2WorldMenu.from_input({
+		"menu_kind": &"vertical", "header": {"data_flags": 0, "default": 1},
+		"options": ["A", "B"],
+	})
+	assert_eq(menu.flags, 0)
+	assert_false(menu.box().has_flag(Gen2MenuBox.STATICMENU_CURSOR))

--- a/tools/checks/map_name_sign.gd
+++ b/tools/checks/map_name_sign.gd
@@ -105,6 +105,7 @@ func _check_signs(landmarks: Array) -> void:
 			continue
 		var column: int = Gen2MapNameSignPage.name_column(name)
 		var blank: Color = image.get_pixel(TILE + 1, TILE + 1)
+		_check_palette(landmark, blank)
 		_r.check(
 			_ink(image, Rect2i(
 				Vector2i(column, Gen2MapNameSignPage.NAME_ROW) * TILE,
@@ -122,6 +123,29 @@ func _check_signs(landmarks: Array) -> void:
 			column + Gen2Text.encoded_length(name) <= Gen2MapNameSignPage.COLUMNS - 1,
 			"landmark %d's name runs into the frame's right edge." % landmark
 		)
+
+
+## `InitMapSignAttrmap` writes PAL_BG_TEXT over the whole sign, and on a map
+## that slot holds `bg_tiles.pal`'s own "text" row rather than `LoadOW_BGPal7`'s
+## blue `Palette_TextBG7`. Colour 0 of the two differs, so the interior says
+## which one the sign was drawn through.
+func _check_palette(landmark: int, blank: Color) -> void:
+	var slots: Array = Gen2WorldPalette.palette_slots(
+		Gen2WorldAPI.ENVIRONMENT_TOWN, Gen2WorldPalette.TIME_MORNING
+	)
+	var wanted: PackedColorArray = _r.data.world_palette(
+		int(slots[Gen2MapNameSignPage.PAL_BG_TEXT])
+	)
+	if not _r.check(wanted.size() >= 4, "the cache holds no PAL_BG_TEXT palette."):
+		return
+	## The rendered sign is an 8-bit image, so the comparison is made there
+	## rather than on the palette's own 5-bit-derived floats.
+	_r.check(
+		blank.to_rgba32() == wanted[0].to_rgba32(),
+		"landmark %d's sign interior is %s, not PAL_BG_TEXT's own %s." % [
+			landmark, blank, wanted[0]
+		]
+	)
 
 
 static func _ink(image: Image, area: Rect2i, blank: Color) -> bool:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -38,6 +38,8 @@ extends SceneTree
 ## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
 ## map's edge onto its neighbour: `crystal 24 4 ... map_name_sign 1 8` crosses
 ## New Bark Town into Route 29),
+## `yes_no` (`Script_yesorno`'s box, over the map's first script run to the
+## choice it ends on: `crystal 26 3 ... yes_no 31 6` is Cherrygrove's guide),
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
@@ -201,6 +203,20 @@ func _process(_delta: float) -> bool:
 			## is what runs `special DisplayUnownWords` and puts the box up.
 			_screen.press_button(Gen2Button.A)
 			_screen.press_button(Gen2Button.A)
+		elif _kind == &"yes_no":
+			## `Script_yesorno`'s own box: the NPC beside the player is talked
+			## to and each page answered until the choice the script ends on is
+			## up, which is what photographs `YesNoMenuHeader.MenuData`'s
+			## cursor. `crystal 26 3 ... yes_no 31 6` is Cherrygrove's guide.
+			_screen.press_button(Gen2Button.RIGHT)
+			_screen.interact()
+			for _press: int in WARP_FRAME_CAP:
+				if StringName(_screen._world.pending_script_input().get(
+					"command", &"")) == &"yesorno":
+					break
+				_screen.press_button(Gen2Button.A)
+				for _frame: int in 20:
+					_screen.advance_frame()
 		elif _kind == &"mart":
 			## The clerk behind the counter, talked to from the cell in front of
 			## him: his `pokemart` is what opens `BuyMenu`, so the shop is


### PR DESCRIPTION
Four findings from one playtest, each read back to the source before it was fixed.

**A connection crossing spent no frames.** `CheckMovingOffEdgeOfMap` only ever answers a step that has *already* landed: the player walks the whole step onto the cell the connection strip's blocks are drawn in, and `EdgeWarpScript`'s `MAPSETUP_CONNECTION` re-anchors the map around it afterwards. `try_connection` swapped the map and put the player down on the far edge with no step at all, so every crossing in the game read as a two-cell jump. It now spends the same frames any other step does, and the cell it is drawn walking out of is the new map's own strip, which is the picture the old map's edge already was. `CheckTileEvent` branches to `.map_connection` before `CountStep`, so the crossing also costs no repel step.

**The map name sign was drawn through the wrong palette.** `InitMapSignAttrmap` writes `PAL_BG_TEXT` over every tile of the sign, and on a map that slot holds the map's own palette 7 out of `gfx/tilesets/bg_tiles.pal`: cream, cream, brown, black, per environment and per time of day. It was drawn through `Palette_TextBG7`'s white and blue, which is `LoadOW_BGPal7`'s and which nothing in `MapSetupScript_Connection` or `RefreshMapSprites` loads before the sign is placed. `tools/checks/map_name_sign.gd` reads the interior colour on all ninety landmarks now.

**A queued map callback took the sign down.** `PlayerEvents` zeroes `wLandmarkSignTimer` behind `DoPlayerEvent`, skipping `PLAYEREVENT_CONNECTION` and `PLAYEREVENT_JOYCHANGEFACING` alone, so only a dispatched player event takes the sign down. The countdown keyed on any script being busy instead; a map's own callbacks are `RunMapCallback`'s work inside map setup and reach `PlayerEvents` never, so one sitting on the queue took down the very sign that map load had raised. The seven sites that really do dispatch a player event zero the timer now.

**The yes/no box drew no cursor.** `Script_yesorno` loads no menu header, so a choice arrives with none and the flags defaulted to zero; `VerticalMenu` reads `STATICMENU_CURSOR` to decide whether to draw an arrow at all, so the box offered two answers with nothing marking which one A would take. A headerless choice inherits `YesNoMenuHeader.MenuData` whole now, its `STATICMENU_NO_TOP_SPACING` and its own `"YES"`/`"NO"` strings included; the runner's `&"yes"`/`&"no"` are internal keys every branch compares against and are not what the cartridge prints.

The gender screen's blue background is the cartridge's own (`LoadGenderScreenPal` and `LoadGenderScreenLightBlueTile`), so nothing changed there.

GUT 3,200 over 152 scripts green, `tools/validate.gd -- all` silent on all three cartridges, `replay_world.gd` 33 routes 0 failures, the three-profile story walk reaches Red with sixteen badges, boot smoke clean.