### PR TITLE
A dictionary entry draws its own tiles, and a bar is written the way its routine walks

### DIFF
--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -64,18 +64,30 @@ const UNKNOWN: int = 0xE6
 const POKE_SHORTHAND: String = "#"
 const POKE_WORD: String = "POK\u00e9"
 
-## The same two codes spelled the other way pret spells them. A caller writing
-## `<POKE>` or `<PKMN>` means the charmap entry, not six literal characters, and
-## without this each angle bracket encodes as UNKNOWN and prints "?".
-const WORD_SPELLINGS: Dictionary = {
+## The same two codes spelled the other way pret spells them, and the tiles each
+## one actually draws. `CheckDict` hands $24 to `PlacePOKE`, whose text is
+## `db "<PO><KE>@"`, and $4a to `PlacePKMN`, whose text is `db "<PK><MN>@"`: two
+## dedicated narrow tiles each, never the four letters `PlacePOKe` prints for
+## `#`. Without this each angle bracket encodes as UNKNOWN and prints "?".
+const WORD_TILES: Dictionary = {
+	"<POKE>": [0x70, 0x71],
+	"<PKMN>": [0xE1, 0xE2],
+}
+
+## The letters to fall back to when the loaded strip has no such tile: only the
+## battle-extra one, where $70 and $71 are `<DO>` and `◀`. Same policy as
+## [method _battle_extra_encodings]' dropped run, and no battle text writes
+## `<POKE>` anyway; `<PKMN>`'s $e1 and $e2 sit outside that run and are exact.
+const WORD_FALLBACKS: Dictionary = {
 	"<POKE>": POKE_WORD,
 	"<PKMN>": "PKMN",
 }
 
 ## The longest sequence one tile stands for: the apostrophe ligatures and PK/MN
-## are two characters in one glyph. The word codes $54 ("POKé") and $4a ("PKMN")
-## sit below FIRST_PRINTABLE and are decode-only; write "#" for $54 as the source
-## charmap does.
+## are two characters in one glyph. [constant WORD_TILES]' spellings are longer
+## and are matched ahead of this run rather than through it. The three word codes
+## themselves sit below FIRST_PRINTABLE and are decode-only; write "#" for $54 as
+## the source charmap does.
 const MAX_LIGATURE: int = 2
 
 static var _table: Dictionary = {}
@@ -149,12 +161,25 @@ static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArra
 	# `PlaceNextChar` hands $54 to `CheckDict`, whose `PlacePOKe` prints four
 	# characters, so the source's own "#" is four tiles and not one. Expanding
 	# here is what puts POKé on screen: $54 is no glyph and would draw a blank.
+	# `<POKE>` and `<PKMN>` are the other two dict entries and are not spellings:
+	# each places its own pair of tiles below, or its letters where the strip
+	# has none.
 	var expanded: String = text.replace(POKE_SHORTHAND, POKE_WORD)
-	for spelling: String in WORD_SPELLINGS:
-		expanded = expanded.replace(spelling, WORD_SPELLINGS[spelling])
+	for spelling: String in WORD_TILES:
+		if not _strip_draws(WORD_TILES[spelling], font):
+			expanded = expanded.replace(spelling, WORD_FALLBACKS[spelling])
 
 	while at < expanded.length():
 		var taken: int = 0
+		for spelling: String in WORD_TILES:
+			if expanded.substr(at, spelling.length()) == spelling:
+				for code: int in WORD_TILES[spelling] as Array:
+					out.append(code)
+				taken = spelling.length()
+				break
+		if taken > 0:
+			at += taken
+			continue
 		# Longest first, so "'s" wins over a "'" with no "s" code after it.
 		for length: int in range(mini(MAX_LIGATURE, expanded.length() - at), 0, -1):
 			var candidate: String = expanded.substr(at, length)
@@ -168,6 +193,18 @@ static func encode(text: String, font: StringName = FONT_MAIN) -> PackedByteArra
 		at += taken
 
 	return out
+
+
+## Whether every tile of a [constant WORD_TILES] pair is drawn by the loaded
+## strip. `_LoadFontsBattleExtra` overwrites $60 to $78, so $70 and $71 are the
+## HP bar's neighbours there and only the letters can stand in.
+static func _strip_draws(tiles: Array, font: StringName) -> bool:
+	if font == FONT_MAIN:
+		return true
+	for code: int in tiles:
+		if code >= BATTLE_EXTRA_FIRST_CODE and code <= BATTLE_EXTRA_LAST_CODE:
+			return false
+	return true
 
 
 ## Tiles, not length: a ligature is two characters in one, so layout has to ask.
@@ -231,6 +268,10 @@ static func _characters() -> Dictionary:
 	table[0xF4] = ","
 	table[0xF5] = "♀"
 	table[0x6D] = ":"
+	# `PlacePOKEText`'s two tiles, out of `FontExtra`'s $63 to $78 run. Spelled
+	# as charmap spells them so nothing collapses them onto letters.
+	table[0x70] = "<PO>"
+	table[0x71] = "<KE>"
 	table[0x72] = "“"
 	table[0x73] = "”"
 	table[0x74] = "·"
@@ -252,8 +293,11 @@ static func _characters() -> Dictionary:
 	table[0xD6] = "'v"
 
 	# Codes that stand for whole words at print time.
-	table[0x24] = "POKé"
-	table[0x4A] = "PKMN"
+	# $24 and $4a are two tiles each and $54 is four, so the first two decode to
+	# the spelling [constant WORD_TILES] re-encodes exactly and only $54 to the
+	# word. Reading all three as "POKé"/"PKMN" is what drew `<POKE>` as letters.
+	table[0x24] = "<POKE>"
+	table[0x4A] = "<PKMN>"
 	table[0x54] = "POKé"
 	table[0x5B] = "PC"
 	table[0x5C] = "TM"

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -153,19 +153,26 @@ func draw_hp_bar(
 ## [param pixels] is `PlaceExpBar`'s own `b`: the bar is a pixel count, never a
 ## ratio, because `CalcExpBar` has already done the division and rounded it the
 ## cartridge's way.
+##
+## `PlaceExpBar` starts at `hlcoord 17, 11` and writes with `ld [hld], a`, so
+## the full tiles land at the right-hand end and the run walks left; unlike
+## `DrawBattleHPBar` it lays no empty template first and instead writes $62 for
+## every tile the fill did not reach. Filling the other way put the bar's lit
+## end on the wrong side, and skipping the empties left the trough unpainted.
 func draw_exp_bar(into: PackedByteArray, width: int, pixels: int) -> void:
-	var length: int = EXP_BAR_TILES * TILE
-	var lit: int = clampi(pixels, 0, length)
-	var left: int = PLAYER_EXP.x * TILE
+	var remaining: int = clampi(pixels, 0, EXP_BAR_TILES * TILE)
+	var right: int = PLAYER_EXP.x + EXP_BAR_TILES - 1
 	var top: int = PLAYER_EXP.y * TILE
 
 	for tile: int in EXP_BAR_TILES:
-		var within: int = clampi(lit - tile * TILE, 0, TILE)
-		if within <= 0:
-			continue
-		var number: int = Gen2BattleTiles.HP_BAR_FULL if within >= TILE \
-			else Gen2BattleTiles.EXP_BAR_FIRST_PARTIAL + within - 1
-		tiles.draw(number, into, width, left + tile * TILE, top)
+		var number: int = Gen2BattleTiles.HP_BAR_EMPTY
+		if remaining >= TILE:
+			number = Gen2BattleTiles.HP_BAR_FULL
+			remaining -= TILE
+		elif remaining > 0:
+			number = Gen2BattleTiles.EXP_BAR_FIRST_PARTIAL + remaining - 1
+			remaining = 0
+		tiles.draw(number, into, width, (right - tile) * TILE, top)
 
 
 ## The level symbol and the number, left-aligned after it, which is how a level

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -135,14 +135,21 @@ func draw_code(
 ## Draws a string left to right from [param at_x], advancing eight pixels per
 ## tile. Returns how many tiles were drawn, which is not the string's length
 ## when it contains a ligature.
+##
+## [param max_tiles] stops the run short. `PlaceString` has no such bound and
+## needs none: every cartridge string is written to fit the box it is placed in.
+## A label a mod supplies is not, so a caller drawing into a fixed width passes
+## the room it has and the rest of the string is dropped rather than written
+## over whatever is beside the box. Negative means no bound.
 func draw_text(
 	text: String, into: PackedByteArray, into_width: int, at_x: int, at_y: int,
-	font: StringName = Gen2Text.FONT_MAIN
+	font: StringName = Gen2Text.FONT_MAIN, max_tiles: int = -1
 ) -> int:
 	var codes: PackedByteArray = Gen2Text.encode(text, font)
-	for i: int in codes.size():
+	var drawn: int = codes.size() if max_tiles < 0 else mini(codes.size(), max_tiles)
+	for i: int in drawn:
 		draw_code(codes[i], into, into_width, at_x + i * TILE, at_y, font)
-	return codes.size()
+	return drawn
 
 
 ## Draws one tile of one text box border. [param code] is a box-drawing code

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -52,9 +52,16 @@ func draw(
 		var title_at: Vector2i = box.title_position(title_indent)
 		font.draw_text(title, indices, width, title_at.x * TILE, title_at.y * TILE)
 
+	# Every cartridge label is written to fit its box, so `PlaceVerticalMenuItems`
+	# needs no bound; a label a mod registers can be any length, and unbounded it
+	# is drawn straight through the right-hand border and over the map beside it.
+	var last_column: int = box.left + box.interior().x
 	for index: int in options.size():
 		var item: Vector2i = box.item_position(index)
-		font.draw_text(String(options[index]), indices, width, item.x * TILE, item.y * TILE)
+		font.draw_text(
+			String(options[index]), indices, width, item.x * TILE, item.y * TILE,
+			Gen2Text.FONT_MAIN, maxi(0, last_column - item.x + 1)
+		)
 
 	for extra: Dictionary in extras:
 		var extra_at: Vector2i = extra.get("at", Vector2i.ZERO)

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -181,38 +181,61 @@ func test_the_hp_bar_fill_is_drawn_apart_from_the_panel() -> void:
 	assert_eq(_ink_in_row(empty, Gen2BattleHud.ENEMY_BAR.y), 0, "a fainted bar draws nothing")
 
 
-## `PlaceExpBar` takes a pixel count in `b`, walks eight tiles filling whole
-## ones and draws the remainder as a partial. It is never a ratio: `CalcExpBar`
-## has already divided.
+## `PlaceExpBar` takes a pixel count in `b`, and it is never a ratio:
+## `CalcExpBar` has already divided. It starts at `hlcoord 17, 11` and writes
+## with `ld [hld], a`, so the full tiles land at the right-hand end and the run
+## walks left, and unlike `DrawBattleHPBar` it lays no empty template first:
+## every tile the fill did not reach is written $62 by `.loop2`.
+##
+## The fixture fills each sheet with one index, so a column says which sheet
+## drew it: the seven partial fills are the exp bar's own (2) and the empty and
+## full tiles are the battle font's (1). A column of 0 is a hole.
 func test_the_exp_bar_is_drawn_from_a_pixel_count() -> void:
 	_write_cache()
 	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
-	var length: int = Gen2BattleHud.EXP_BAR_TILES * Gen2BattleHud.TILE
+	var tile: int = Gen2BattleHud.TILE
+	var length: int = Gen2BattleHud.EXP_BAR_TILES * tile
 
-	var empty: PackedByteArray = PackedByteArray()
-	empty.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
-	hud.draw_exp_bar(empty, Gen2Screen.WIDTH, 0)
-	assert_eq(_ink_in_row(empty, Gen2BattleHud.PLAYER_EXP.y), 0, "no exp draws nothing")
+	for pixels: int in [0, 4, tile, tile + 4, length, length * 2]:
+		var screen: PackedByteArray = _exp_row(hud, pixels)
+		for column: int in Gen2BattleHud.EXP_BAR_TILES:
+			assert_ne(
+				_exp_column(screen, column), 0,
+				"tile %d is drawn at %d pixels" % [column, pixels]
+			)
 
-	var part: PackedByteArray = PackedByteArray()
-	part.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
-	hud.draw_exp_bar(part, Gen2Screen.WIDTH, length / 2)
+	# Under one tile: only the rightmost column is a partial, and it is the
+	# right-hand one because the run is written leftward from column 17.
+	var part: PackedByteArray = _exp_row(hud, 4)
+	assert_eq(_exp_column(part, Gen2BattleHud.EXP_BAR_TILES - 1), 2, "the lit end is the right")
+	for column: int in Gen2BattleHud.EXP_BAR_TILES - 1:
+		assert_eq(_exp_column(part, column), 1, "tile %d is still empty" % column)
 
-	var full: PackedByteArray = PackedByteArray()
-	full.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
-	hud.draw_exp_bar(full, Gen2Screen.WIDTH, length)
+	# One tile and a remainder: the rightmost is full and the partial has moved
+	# one column left, which a bar filling the other way would invert.
+	var more: PackedByteArray = _exp_row(hud, tile + 4)
+	assert_eq(_exp_column(more, Gen2BattleHud.EXP_BAR_TILES - 1), 1, "a whole tile")
+	assert_eq(_exp_column(more, Gen2BattleHud.EXP_BAR_TILES - 2), 2, "then the remainder")
 
-	var part_ink: int = _ink_in_row(part, Gen2BattleHud.PLAYER_EXP.y)
-	var full_ink: int = _ink_in_row(full, Gen2BattleHud.PLAYER_EXP.y)
-	assert_ne(part_ink, 0)
-	assert_gt(full_ink, part_ink, "a fuller bar is more ink")
+	# Exactly full and past full draw the same eight whole tiles and no partial.
+	for pixels: int in [length, length * 2]:
+		var screen: PackedByteArray = _exp_row(hud, pixels)
+		for column: int in Gen2BattleHud.EXP_BAR_TILES:
+			assert_eq(_exp_column(screen, column), 1, "tile %d is whole" % column)
 
-	var over: PackedByteArray = PackedByteArray()
-	over.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
-	hud.draw_exp_bar(over, Gen2Screen.WIDTH, length * 2)
-	assert_eq(
-		_ink_in_row(over, Gen2BattleHud.PLAYER_EXP.y), full_ink, "the bar stops at its own end"
-	)
+
+func _exp_row(hud: Gen2BattleHud, pixels: int) -> PackedByteArray:
+	var screen: PackedByteArray = PackedByteArray()
+	screen.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_exp_bar(screen, Gen2Screen.WIDTH, pixels)
+	return screen
+
+
+## The index one pixel inside tile [param column] of the exp bar's own row.
+func _exp_column(screen: PackedByteArray, column: int) -> int:
+	var x: int = (Gen2BattleHud.PLAYER_EXP.x + column) * Gen2Font.TILE
+	var y: int = Gen2BattleHud.PLAYER_EXP.y * Gen2Font.TILE
+	return screen[y * Gen2Screen.WIDTH + x]
 
 
 ## Lit pixels in one row of tiles.

--- a/tests/unit/test_menu_page.gd
+++ b/tests/unit/test_menu_page.gd
@@ -173,3 +173,22 @@ func test_the_pokepic_box_refuses_a_species_the_cache_does_not_hold() -> void:
 	var data: GameData = GameData.open_directory(Fixture.directory())
 	assert_null(Gen2PokepicPage.render(data, BattleFixture.MAX_SPECIES + 1, Gen2WorldMap.new()))
 	assert_null(Gen2PokepicPage.render(data, BattleFixture.CHARMANDER, null))
+
+
+## `PlaceVerticalMenuItems` has no bound and needs none: every cartridge label is
+## written to fit the box it is placed in. A label a mod registers is not, and
+## unbounded it was drawn straight through the right-hand border and over
+## whatever the box sits on, which is what the in-game MODS row could do.
+func test_a_row_too_wide_for_its_box_is_cut_at_the_border() -> void:
+	var box: Gen2MenuBox = _box()
+	var indices: PackedByteArray = _blank()
+	_page.draw(box, ["A VERY LONG MOD NAME INDEED"], 0, indices, WIDTH)
+
+	# The last interior column, one short of the right-hand border at box.right.
+	var last: int = box.left + box.interior().x
+	assert_true(_ink_in_tile(indices, Vector2i(last, box.item_position(0).y)), "fills the row")
+	for column: int in range(box.right + 1, Gen2Screen.WIDTH / TILE):
+		assert_false(
+			_ink_in_tile(indices, Vector2i(column, box.item_position(0).y)),
+			"nothing past the border at column %d" % column
+		)

--- a/tests/unit/test_text_codec.gd
+++ b/tests/unit/test_text_codec.gd
@@ -67,14 +67,30 @@ func test_hash_encodes_the_word_the_source_dictionary_prints() -> void:
 
 ## `constants/charmap.asm` spells the same two codes `<POKE>` and `<PKMN>`, and a
 ## caller copying a source string writes them; an unexpanded bracket is UNKNOWN,
-## which is the "?" the start menu's POKéGEAR row was printing.
+## which is the "?" the start menu's POKéGEAR row was printing. Neither is the
+## four letters `#` prints: `PlacePOKE`'s text is `db "<PO><KE>@"` and
+## `PlacePKMN`'s is `db "<PK><MN>@"`, two dedicated tiles each.
 func test_angle_bracket_word_spellings_encode_like_their_codes() -> void:
-	assert_eq(Gen2Text.encode("<POKE>"), Gen2Text.encode("POKé"))
-	assert_eq(Gen2Text.encode("<POKE>GEAR"), Gen2Text.encode("POKéGEAR"))
-	assert_eq(Gen2Text.encoded_length("<POKE>GEAR"), 8)
-	assert_eq(Gen2Text.encode("<PKMN>"), Gen2Text.encode("PKMN"))
+	assert_eq(Gen2Text.encode("<POKE>"), PackedByteArray([0x70, 0x71]))
+	assert_eq(Gen2Text.encode("<PKMN>"), PackedByteArray([0xE1, 0xE2]))
+	assert_eq(Gen2Text.encoded_length("<POKE>GEAR"), 6, "four tiles narrower than POKéGEAR")
+	assert_ne(Gen2Text.encode("<POKE>"), Gen2Text.encode("POKé"), "$24 is not $54")
 	for code: int in Gen2Text.encode("<POKE>GEAR"):
 		assert_ne(code, Gen2Text.UNKNOWN)
+	# The two codes decode to the spelling that re-encodes to those same tiles;
+	# only $54 is the word, so a round trip never widens a name.
+	assert_eq(Gen2Text.character(0x24), "<POKE>")
+	assert_eq(Gen2Text.character(0x4A), "<PKMN>")
+	assert_eq(Gen2Text.encode(Gen2Text.character(0x24)), PackedByteArray([0x70, 0x71]))
+	assert_eq(Gen2Text.encode(Gen2Text.character(0x4A)), PackedByteArray([0xE1, 0xE2]))
+	# `_LoadFontsBattleExtra` overwrites $70 and $71, so only there do the
+	# letters stand in, the way the ellipsis is dropped from that strip.
+	assert_eq(
+		Gen2Text.encode("<POKE>", Gen2Text.FONT_BATTLE_EXTRA), Gen2Text.encode("POKé")
+	)
+	assert_eq(
+		Gen2Text.encode("<PKMN>", Gen2Text.FONT_BATTLE_EXTRA), PackedByteArray([0xE1, 0xE2])
+	)
 
 
 ## $75 is decode-only for the same reason $54 is, and source text writes the


### PR DESCRIPTION
Three reported defects, read down to the routine each one comes from.

**`<POKE>` and `<PKMN>` are two tiles each, not four letters.** `CheckDict` has three word entries: `#` ($54) reaches `PlacePOKe`, whose text is `db "POKé@"`, four letters; `<POKE>` ($24) reaches `PlacePOKE`, `db "<PO><KE>@"`; `<PKMN>` ($4a) reaches `PlacePKMN`, `db "<PK><MN>@"`. The encoder collapsed all three onto letters. `<PKMN>` came out right anyway, because $e1 and $e2 are the PK and MN ligatures it already had; `<POKE>` did not, because $70 and $71 sit in `FontExtra`'s $63 to $78 run and nothing named them. Both are tile pairs now, and both codes decode to the spelling that re-encodes to them, so the start menu's row is six tiles rather than eight and an imported name round trips. `_LoadFontsBattleExtra` overwrites $70 and $71, so only under that strip do the letters stand in.

**The exp bar filled the wrong way and had holes.** `PlaceExpBar` starts at `hlcoord 17, 11` and writes with `ld [hld], a`, so the full tiles land at the right-hand end and the run walks left; and unlike `DrawBattleHPBar` it lays no empty template, writing $62 for every tile the fill did not reach. Ours filled from the left and skipped the empties: one routine for the direction, one for the holes. The HP bar is `hli` with a template and was already right.

**A menu row could be drawn through its own border.** `PlaceVerticalMenuItems` needs no bound because every cartridge label is written to fit its box; a label a mod registers is not. `Gen2Font.draw_text` takes a tile bound now and `Gen2MenuPage` passes the room the box has, so every menu row in the game is cut at its border rather than only the one that was reported.

| Check | Result |
|---|---|
| GUT unit | 2,815/2,815 |
| GUT unit + scene | 3,201/3,201, 152 scripts |
| `validate.gd -- all` | exit 0, 54 topics, 0 failures |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | exit 0 on crystal, gold, silver |