### PR TITLE
A turn runs on to its own menu, and a party member is moved where the source moves it

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -399,17 +399,12 @@ func advance_frame() -> bool:
 ## animation, `AnimateHPBar` and `MonFaintedAnimation` and whatever follows them,
 ## so the pump continues here rather than standing still until a press.
 ##
-## The waits that are real are all a box: a message on screen is left alone, and
-## so is a bar that is holding one (`_held_message`, released by
-## [method advance_bars]) or the exp bar stopped at a level boundary.
+## The waits that are real are all a box, and [method _continue_after_messages]
+## owns that test: a message on screen is left alone, and so is a bar holding one.
 func _resume_after_frames(was_running: bool) -> void:
-	if not was_running or frames_running() or _pending.is_empty():
+	if not was_running or frames_running():
 		return
-	if not _held_message.is_empty() or not _intro_message.is_empty():
-		return
-	if _message_awaits_press:
-		return
-	_show_next_event()
+	_continue_after_messages()
 
 
 ## Whether a picture is still sinking off its square.
@@ -988,11 +983,7 @@ func advance_bars() -> bool:
 	if moved:
 		_push_view()
 
-	if not _held_message.is_empty() and _bars.is_empty() and not fainting():
-		var text: String = _held_message
-		_held_message = ""
-		show_message(text)
-	elif boundary and _exp_bar != null:
+	if boundary and _exp_bar != null:
 		# The bar has reached the end of the level it was filling and stopped
 		# there. `.LoopLevels` prints its grew-to-level line at exactly this
 		# point, so the pump runs on to the event that carries it.
@@ -1415,7 +1406,9 @@ func show_message(text: String) -> void:
 		_intro_message = text
 		return
 	_last_message = text
-	_message_awaits_press = true
+	## `StdBattleTextbox` blocks on a press for a line it printed; an empty box
+	## is the one a menu is drawn over and owes nothing.
+	_message_awaits_press = not text.is_empty()
 	if _box != null:
 		_box.show_text(text)
 
@@ -2122,7 +2115,39 @@ func advance() -> void:
 	if _menu_stage != &"":
 		_answer_menu(Gen2Button.A)
 		return
+	_continue_after_messages()
+
+
+## What the source runs on to once nothing is left to say. `DoTurn` falls
+## straight out of the last command into `HandleBetweenTurnEffects` and then
+## into `BattleMenu`, and nothing between them reads a button, so this is
+## reached both by the press that dismissed the last box and by
+## [method _show_next_event] finding no line left to print.
+func _continue_after_messages() -> void:
+	if _box == null:
+		return
+	## The same waits [method _resume_after_frames] respects: a box still up, a
+	## line held behind a bar, or frames nobody has spent yet.
+	if _intro != null or bars_animating() or fainting() or animation_running():
+		return
+	## `applydamage` animates the bar and sinks the picture before `criticaltext`
+	## prints, so a line produced while either was running was held rather than
+	## raced. Released here, where every wait it can be held behind ends: a faint
+	## with no bar beside it is one, and the bar pump never sees that frame.
+	if not _held_message.is_empty():
+		var held: String = _held_message
+		_held_message = ""
+		show_message(held)
+		return
+	if _message_awaits_press or not _intro_message.is_empty():
+		return
 	if _capture_selecting or _capture_waiting:
+		return
+	## A list already up owns the joypad: the battle menu, the pack and its two
+	## sub-lists, and the forget offer are each answered by a press rather than
+	## run past by the pump.
+	if _menu_stage != &"" or _pack_selecting or _pack_move_selecting \
+		or _forget_stage != &"":
 		return
 	if _world_battle_tutorial:
 		return
@@ -3046,6 +3071,10 @@ func _show_next_event() -> void:
 			else:
 				show_message(text)
 			return
+	## The queue ran dry with nothing to print. `DoTurn` does not read a button
+	## between its last command and `BattleMenu`, so the screen runs on rather
+	## than leaving a stale box up until a press nobody owes.
+	_continue_after_messages()
 
 
 ## The events that mean a bar moved rather than a bar was placed: each is a

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -38,6 +38,10 @@ const CANCEL_COLUMN: int = NICKNAME.x - 2
 ## `Place2DMenuCursor`'s column, `PartyMenu2DMenuData`'s `db 1, 0`.
 const CURSOR_COLUMN: int = 0
 
+## `charmap.asm`: `"▷"` is $ec, which `SwitchPartyMons` writes at
+## `hlcoord 0, 1` over the row of the member being moved.
+const HELD_CODE: int = 0xEC
+
 ## Rows per member, `dn 2, 0`.
 const ROW_STEP: int = 2
 
@@ -123,7 +127,12 @@ static func from_data(source: GameData) -> Gen2PartyMenuPage:
 
 ## The whole screen, with the arrow on [param cursor] counting CANCEL as the row
 ## after the last member. [param rows] is [member Gen2BattleSwitchMenu.rows].
-func render(rows: Array, cursor: int, prompt: String) -> Image:
+## `SwitchPartyMons` opens through `InitPartyMenuNoCancel`, so [param cancel] is
+## false while a member is being moved, and [param held] is that member's row,
+## which wears `▷` instead of nothing.
+func render(
+	rows: Array, cursor: int, prompt: String, cancel: bool = true, held: int = -1
+) -> Image:
 	var width: int = Gen2Screen.WIDTH
 	var height: int = Gen2Screen.HEIGHT
 	var page: PackedByteArray = PackedByteArray()
@@ -131,10 +140,16 @@ func render(rows: Array, cursor: int, prompt: String) -> Image:
 
 	for index: int in rows.size():
 		_draw_member(page, width, index, rows[index])
-	font.draw_text(
-		Gen2BattleSwitchMenu.cancel_label(), page, width,
-		CANCEL_COLUMN * TILE, (NICKNAME.y + rows.size() * ROW_STEP) * TILE
-	)
+	if cancel:
+		font.draw_text(
+			Gen2BattleSwitchMenu.cancel_label(), page, width,
+			CANCEL_COLUMN * TILE, (NICKNAME.y + rows.size() * ROW_STEP) * TILE
+		)
+	if held >= 0 and held < rows.size():
+		font.draw_code(
+			HELD_CODE, page, width,
+			CURSOR_COLUMN * TILE, (NICKNAME.y + held * ROW_STEP) * TILE
+		)
 	_draw_cursor(page, width, cursor)
 	_draw_prompt(page, width, prompt)
 

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -22,6 +22,9 @@ signal closed(result: Dictionary)
 ## Gen2StartMenuScreen.action_chosen. Field moves need the live world, which
 ## belongs to the world screen, so the choice is reported rather than run here.
 signal action_chosen(action: Dictionary)
+## A sound this screen owes, by `constants/sfx_constants.asm` index. Emitted
+## rather than played: the audio player belongs to whoever embedded this.
+signal sfx_requested(index: int)
 
 const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
@@ -60,6 +63,13 @@ const MAX_SUBMENU_ITEMS: int = 8
 ## of `data/text/common_*.asm`.
 const PROMPT_CHOOSE: String = "Choose a #MON."
 const PROMPT_USE_ON_WHICH: String = "Use on which PKMN?"
+
+## `SwitchPartyMons`' own `PARTYMENUACTION_MOVE` string, `MoveToWhereString`.
+const PROMPT_MOVE_TO_WHERE: String = "Move to where?"
+
+## `constants/sfx_constants.asm`'s SFX_SWITCH_POKEMON, which
+## `_SwitchPartyMons.ClearSprite` plays once the two rows have traded places.
+const SFX_SWITCH_POKEMON: int = 0x20
 
 ## `_PokemonNotEnoughHPText` and `_ItemCantUseOnMonText`, the two refusals the
 ## heal transfer prints. Both are a `MenuTextbox` over the menu on the cartridge
@@ -104,6 +114,9 @@ var _item_menu_open: bool = false
 ## which of the two moves asked. -1 and 0 when no recipient list is open.
 var _heal_user: int = -1
 var _heal_move: int = 0
+## `wSwitchMon` less one: which member SWITCH is holding, or -1 when the list is
+## not `InitPartyMenuNoCancel`'s.
+var _switch_from: int = -1
 
 ## The embedded view's own hardware screen and the two pages drawn into it.
 var _hardware: Gen2Screen = null
@@ -144,6 +157,7 @@ func set_context(data: GameData, save: Gen2SaveData, embedded: bool = false) -> 
 	_item_menu_open = false
 	_submenu_items = []
 	_submenu_cursor = 0
+	_switch_from = -1
 	if is_inside_tree() and _cards != null:
 		_refresh()
 
@@ -190,7 +204,7 @@ static func submenu_items_for(
 	## nothing to follow, teach or send out, and the source itself offers less.
 	if mon.is_egg:
 		items.append(_option_entry(OPTION_STATS, "STATS"))
-		items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
+		items.append(_option_entry(OPTION_SWITCH, "SWITCH", true))
 		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
 		return items
 	for move: int in mon.moves:
@@ -203,7 +217,9 @@ static func submenu_items_for(
 			"available": true,
 		})
 	items.append(_option_entry(OPTION_STATS, "STATS"))
-	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
+	## `SwitchPartyMons` makes its own `cp 2` refusal rather than being greyed
+	## out, so the row is offered whatever the party holds.
+	items.append(_option_entry(OPTION_SWITCH, "SWITCH", true))
 	items.append(_option_entry(OPTION_MOVE, "MOVE"))
 	items.append(_option_entry(OPTION_ITEM, "ITEM", true))
 	## After every cartridge action and before CANCEL, which is the source's own
@@ -286,7 +302,9 @@ func _move_cursor(delta: int) -> void:
 ## `InitPartyMenuWithCancel`, which every way into this menu goes through: the
 ## party plus the CANCEL row `PlacePartyNicknames.end` prints after it.
 func _row_count() -> int:
-	return _party_size() + 1
+	## `SwitchPartyMons` reopens through `InitPartyMenuNoCancel`, so the row
+	## after the last member is not there to land on.
+	return _party_size() if _switch_from >= 0 else _party_size() + 1
 
 
 ## Where the arrow is, which [Gen2PartyMenuPage] counts the same way.
@@ -295,7 +313,7 @@ func _cursor_row() -> int:
 
 
 func _on_cancel_row() -> bool:
-	return _member_cursor >= _party_size()
+	return _switch_from < 0 and _member_cursor >= _party_size()
 
 
 func _confirm() -> void:
@@ -303,6 +321,9 @@ func _confirm() -> void:
 	## the row and the button are one path.
 	if _on_cancel_row() and not _submenu_open:
 		_cancel()
+		return
+	if _switch_from >= 0:
+		_finish_switch()
 		return
 	if _heal_user >= 0:
 		_choose_heal_target()
@@ -350,11 +371,20 @@ func _confirm() -> void:
 				"name": _display_name(_save.party[_member_cursor]),
 			})
 		&"option":
-			if StringName(entry.get("option", &"")) == OPTION_ITEM:
-				_open_item_menu()
+			match StringName(entry.get("option", &"")):
+				OPTION_ITEM:
+					_open_item_menu()
+				OPTION_SWITCH:
+					_begin_switch()
 
 
 func _cancel() -> void:
+	## `SwitchPartyMons`' `bit B_PAD_B` reaches `.DontSwitch`, which is
+	## `CancelPokemonAction`: the move is given up and the plain list comes back.
+	if _switch_from >= 0:
+		_switch_from = -1
+		_close_submenu()
+		return
 	## `.SelectMilkDrinkRecipient`'s own `.set_carry`: a B press over the
 	## recipient list gives up on the move and leaves the party menu standing.
 	if _heal_user >= 0:
@@ -420,6 +450,39 @@ func _choose_heal_target() -> void:
 	action_chosen.emit(action)
 
 
+## `SwitchPartyMons`: a party of one has nothing to trade with and falls straight
+## into `.DontSwitch`, and anything else holds this member and reopens the list
+## without its CANCEL row.
+func _begin_switch() -> void:
+	if _party_size() < 2:
+		_close_submenu()
+		return
+	_switch_from = _member_cursor
+	_submenu_open = false
+	_item_menu_open = false
+	_submenu_items = []
+	_refresh()
+
+
+## `_SwitchPartyMons`: the two members trade places whole, and the same row twice
+## is its own `jr z, .skip`. The list comes back with CANCEL either way.
+func _finish_switch() -> void:
+	var from: int = _switch_from
+	_switch_from = -1
+	if from != _member_cursor and from >= 0 and from < _party_size() \
+		and _member_cursor < _party_size():
+		var held: Gen2SaveMon = _save.party[from]
+		_save.party[from] = _save.party[_member_cursor]
+		_save.party[_member_cursor] = held
+		sfx_requested.emit(SFX_SWITCH_POKEMON)
+	_member_cursor = clampi(_member_cursor, 0, _row_count() - 1)
+	## The icons are respawned rather than stepped: `LoadPartyMenuGFX` and
+	## `InitPartyMenuGFX` run again behind the reopened list.
+	if _page != null:
+		_page.reset(_rows())
+	_refresh()
+
+
 func _open_item_menu() -> void:
 	_submenu_items = item_menu_items()
 	_submenu_cursor = 0
@@ -453,6 +516,7 @@ func submenu_snapshot() -> Dictionary:
 		"cursor": _submenu_cursor,
 		"member": _member_cursor,
 		"on_cancel": _on_cancel_row(),
+		"switch_from": _switch_from,
 		"message": _message,
 		"items": _submenu_items.duplicate(true),
 	}
@@ -550,6 +614,8 @@ func _rows() -> Array:
 func _prompt() -> String:
 	if not _message.is_empty():
 		return _message
+	if _switch_from >= 0:
+		return PROMPT_MOVE_TO_WHERE
 	return PROMPT_USE_ON_WHICH if _heal_user >= 0 else PROMPT_CHOOSE
 
 
@@ -563,7 +629,9 @@ func _render_hardware() -> void:
 	if _page == null:
 		return
 	var rows: Array = _rows()
-	var image: Image = _page.render(rows, _cursor_row(), _prompt())
+	var image: Image = _page.render(
+		rows, _cursor_row(), _prompt(), _switch_from < 0, _switch_from
+	)
 	if image == null:
 		return
 	if _menu_page != null and (_submenu_open or _item_menu_open):

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2912,6 +2912,7 @@ func _open_embedded_party() -> void:
 	add_child(host)
 	host.closed.connect(_on_party_closed)
 	host.action_chosen.connect(_on_party_action)
+	host.sfx_requested.connect(_play_sfx)
 	_party_host = host
 	_script_prompt = "Party open"
 	_refresh_labels()

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -45,6 +45,9 @@ func _open_battle() -> void:
 	while _screen.intro_running() and guard > 0:
 		_screen.advance_frame()
 		guard -= 1
+	## The intro runs on into `BattleMenu`, and a menu owns the joypad. These
+	## tests drive the pump mid-turn instead, so it is closed behind them.
+	_screen._close_battle_menu()
 
 
 func _animation_event(extra: Dictionary = {}) -> Dictionary:

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -328,7 +328,7 @@ func test_a_hit_drains_the_bar_before_it_says_what_the_hit_was() -> void:
 
 	var guard: int = 4000
 	while _battle_screen.bars_animating() and guard > 0:
-		_battle_screen.advance_bars()
+		_battle_screen.advance_frame()
 		guard -= 1
 	assert_eq(_battle_screen.battle_snapshot()["message"], "It's super effective!")
 
@@ -397,7 +397,7 @@ func test_experience_says_its_line_first_and_the_level_line_after_the_bar() -> v
 	# printed and the walk stops for the button that dismisses it.
 	var guard: int = 4000
 	while not _battle_screen._exp_bar.paused() and guard > 0:
-		_battle_screen.advance_bars()
+		_battle_screen.advance_frame()
 		guard -= 1
 	assert_gt(guard, 0, "the bar reached the end of the level")
 	assert_eq(
@@ -418,7 +418,7 @@ func test_experience_says_its_line_first_and_the_level_line_after_the_bar() -> v
 
 	guard = 4000
 	while _battle_screen.bars_animating() and guard > 0:
-		_battle_screen.advance_bars()
+		_battle_screen.advance_frame()
 		guard -= 1
 	assert_gt(guard, 0, "the walk ended")
 	assert_eq(

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -87,9 +87,12 @@ func _layer() -> TextureRect:
 
 func _advance_to(stage: String, limit: int = 40) -> void:
 	for _press: int in limit:
+		## Settled first: the frames a turn owes can reach the state by
+		## themselves, and a press spent after it has arrived is a press into
+		## whatever the state opened.
+		_settle_bars()
 		if _stage() == stage:
 			return
-		_settle_bars()
 		_screen.finish()
 		_screen.advance()
 		await get_tree().process_frame
@@ -435,9 +438,9 @@ func _menu_layer() -> TextureRect:
 
 func _advance_to_menu(limit: int = 40) -> void:
 	for _press: int in limit:
+		_settle_bars()
 		if _menu_stage() != "":
 			return
-		_settle_bars()
 		_screen.finish()
 		_screen.advance()
 		await get_tree().process_frame

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1307,6 +1307,72 @@ func test_the_party_submenu_takes_a_held_item_back() -> void:
 	assert_eq(_world_screen._world.state.item_quantity(7), 2)
 
 
+## `SwitchPartyMons`: the row is held, the list comes back with `▷` on it and no
+## CANCEL, and `_SwitchPartyMons` trades the two members whole.
+func test_the_party_submenu_switch_row_moves_a_member() -> void:
+	await _open_world()
+	var save: Gen2SaveData = _world_screen._injected_save
+	var first: Gen2SaveMon = save.party[0]
+	var second: Gen2SaveMon = save.party[1]
+	var played: Array[int] = []
+	_world_screen._open_embedded_party()
+	await get_tree().process_frame
+	var party: Gen2PartyScreen = _world_screen._party_host
+	party.sfx_requested.connect(func(index: int) -> void: played.append(index))
+	_choose_submenu(party, Gen2PartyScreen.OPTION_SWITCH)
+
+	var snapshot: Dictionary = party.submenu_snapshot()
+	assert_eq(int(snapshot["switch_from"]), 0, "the first row is being moved")
+	assert_false(bool(snapshot["open"]), "and the submenu is gone")
+	assert_eq(party._prompt(), Gen2PartyScreen.PROMPT_MOVE_TO_WHERE)
+	assert_eq(party._row_count(), 2, "InitPartyMenuNoCancel has no CANCEL row")
+
+	party.handle_button(Gen2Button.DOWN)
+	party.handle_button(Gen2Button.A)
+	assert_same(save.party[0], second, "the two traded places")
+	assert_same(save.party[1], first)
+	assert_eq(played, [Gen2PartyScreen.SFX_SWITCH_POKEMON])
+	assert_eq(int(party.submenu_snapshot()["switch_from"]), -1)
+	assert_eq(party._row_count(), 3, "and CANCEL is back")
+
+
+## `.DontSwitch`, both ways into it: a party of one never leaves the submenu, and
+## B over the list is `CancelPokemonAction`.
+func test_switch_refuses_a_party_of_one_and_b_gives_the_move_up() -> void:
+	await _open_world()
+	var save: Gen2SaveData = _world_screen._injected_save
+	var first: Gen2SaveMon = save.party[0]
+	var second: Gen2SaveMon = save.party[1]
+	_world_screen._open_embedded_party()
+	await get_tree().process_frame
+	var party: Gen2PartyScreen = _world_screen._party_host
+
+	_choose_submenu(party, Gen2PartyScreen.OPTION_SWITCH)
+	party.handle_button(Gen2Button.DOWN)
+	party.handle_button(Gen2Button.B)
+	assert_eq(int(party.submenu_snapshot()["switch_from"]), -1)
+	assert_false(bool(party.submenu_snapshot()["open"]), "CancelPokemonAction")
+	assert_same(save.party[0], first, "and nothing moved")
+	assert_same(save.party[1], second)
+
+	save.party.remove_at(1)
+	party.set_context(_data, save, true)
+	_choose_submenu(party, Gen2PartyScreen.OPTION_SWITCH)
+	assert_eq(int(party.submenu_snapshot()["switch_from"]), -1, "cp 2 refused it")
+	assert_false(bool(party.submenu_snapshot()["open"]))
+
+
+## Opens the mon's submenu and puts the cursor on one of its option rows.
+func _choose_submenu(party: Gen2PartyScreen, option: StringName) -> void:
+	party.handle_button(Gen2Button.A)
+	var items: Array = (party.submenu_snapshot()["items"] as Array)
+	for index: int in items.size():
+		if StringName((items[index] as Dictionary).get("option", &"")) == option:
+			party.set("_submenu_cursor", index)
+			break
+	party.handle_button(Gen2Button.A)
+
+
 ## `SelectMenu`: `CheckRegisteredItem` answers first, and `MayRegisterItemText`
 ## is the whole of what an unregistered SELECT does.
 func test_select_says_an_item_may_be_registered_when_none_is() -> void:

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -256,6 +256,30 @@ func test_cancel_prints_below_the_last_member() -> void:
 		)
 
 
+## `SwitchPartyMons` reopens through `InitPartyMenuNoCancel` and writes `▷` over
+## `hlcoord 0, 1` plus two rows per held member.
+func test_a_held_row_wears_its_marker_and_the_switch_list_has_no_cancel() -> void:
+	var rows: Array = _rows(2)
+	var image: Image = _page().render(
+		rows, 1, Gen2BattleSwitchMenu.prompt_text(), false, 0
+	)
+	assert_eq(
+		_ink_in_tile(image, Gen2PartyMenuPage.CANCEL_COLUMN, 5), 0,
+		"InitPartyMenuNoCancel prints no CANCEL"
+	)
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.CURSOR_COLUMN, 1), 0, "the marker")
+	assert_ne(_ink_in_tile(image, Gen2PartyMenuPage.CURSOR_COLUMN, 3), 0, "the cursor")
+	## Without a member held, column 0 of that row is the blank it always was:
+	## the fixture's glyphs are solid tiles, so which glyph landed cannot be read
+	## off the picture, only that one did.
+	assert_eq(
+		_ink_in_tile(
+			_page().render(rows, 1, Gen2BattleSwitchMenu.prompt_text(), false, -1),
+			Gen2PartyMenuPage.CURSOR_COLUMN, 1
+		), 0, "and nothing is written there otherwise"
+	)
+
+
 ## The four qualities `.Default` asks for, each in its own column on the row
 ## under the nickname, except the HP numbers which share the nickname's.
 func test_every_quality_lands_in_its_own_column() -> void:


### PR DESCRIPTION
Two reported defects, plus the unreported one the first of them was hiding.

## The turn's tail

`DoTurn` reads no button between its last command and `BattleMenu`. This screen
only ever ran on when a press dismissed a box, and three sites shared that
mistake, so `_continue_after_messages` is now the one of them: reached by the
press, by `_show_next_event` finding its queue dry with nothing left to print,
and by `_resume_after_frames` when the frames a command spends run out.

- The wasted press after the enemy's move is the reported half.
- The unreported half is worse. `_held_message` was released inside
  `advance_bars`, which returns before that line on any frame with no bar on it,
  so a line held behind a faint with no bar beside it was never printed. The
  experience award's own line went missing that way every time an enemy fainted.
- `show_message("")` no longer owes a press: an empty box is the one a menu is
  drawn over. A list already up (the battle menu, the pack and its two
  sub-lists, the forget offer) now stops the pump rather than being run past.

Driving eight turns through the menu, the presses a turn costs are now one per
line printed and no more; the run that used to spend one on nothing now prints
`CHARMANDER gained 274 EXP. Points!` where it used to skip it.

## SWITCH

`SwitchPartyMons` is built. The row is offered whatever the party holds, because
the source makes its own `cp 2` refusal rather than greying it out. Choosing it
holds the member and reopens through `InitPartyMenuNoCancel`, so there is no
CANCEL row to land on, with `MoveToWhereString` in the box and the held row
wearing `▷`; A runs `_SwitchPartyMons`, which trades the two members whole and
plays `SFX_SWITCH_POKEMON`; B is `.DontSwitch`, which is `CancelPokemonAction`.

The party screen reports the sound through a `sfx_requested` signal rather than
carrying an audio player: the world that embedded it already owns one.

| Check | Result |
|---|---|
| GUT, both tiers | 3,204 tests over 152 scripts, green |
| `tools/validate.gd -- all` | 54 topics, no FAIL |
| Story walk, three profiles | no errors |