### PR TITLE
STATS and MOVE are screens, and the sheet they both load is imported

### DIFF
--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 67
+const FORMAT_VERSION: int = 68
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3175,6 +3175,28 @@ static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictiona
 	if not levels["ok"]:
 		return levels
 
+	## `StatsScreenPageTilesGFX` carries no progression to sweep, so it is
+	## checked on the two tiles the source names by shape: tile 0 is the
+	## vertical divider, two lit columns on every row, and tile 14 is the `'⁂'`
+	## `constants/charmap.asm` points at. Both pin the address, which is walked
+	## back from the enemy HUD rather than stored.
+	var stats_tiles: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		data, RomLayout.stats_tiles_offset(layout), RomLayout.STATS_TILES
+	)
+	var divider: PackedByteArray = _strip_tile(
+		stats_tiles, RomLayout.STATS_TILES, 0
+	)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			var lit: bool = divider[row * Gen2Tiles.TILE_WIDTH + column] != 0
+			if lit != (column < 2):
+				return {
+					"ok": false,
+					"message": "Stats tiles: the vertical divider is not two columns wide.",
+				}
+	if _ink(_strip_tile(stats_tiles, RomLayout.STATS_TILES, RomLayout.STATS_SHINY_TILE)) == 0:
+		return {"ok": false, "message": "Stats tiles: the shiny icon is blank."}
+
 	for name: String in ["enemy_hud", "player_hud"]:
 		var tiles: int = RomLayout.ENEMY_HUD_TILES if name == "enemy_hud" \
 			else RomLayout.PLAYER_HUD_TILES
@@ -5221,6 +5243,14 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 		"exp_bar": {
 			"offset": int(layout["exp_bar"]),
 			"tiles": RomLayout.EXP_BAR_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		## `StatsScreenPageTilesGFX`, which the stats screen and the move
+		## screen both load at `vTiles2 tile $31`.
+		"stats_tiles": {
+			"offset": RomLayout.stats_tiles_offset(layout),
+			"tiles": RomLayout.STATS_TILES,
 			"first_code": 0,
 			"bits": 2,
 		},

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -604,6 +604,17 @@ const ENEMY_HUD_TILES: int = 4
 const PLAYER_HUD_TILES: int = 6
 const EXP_BAR_TILES: int = 9
 
+## `StatsScreenPageTilesGFX`, the seventeen tiles `LoadStatsScreenPageTilesGFX`
+## puts at `vTiles2 tile $31`: the vertical divider, the page indicator squares,
+## the exp bar's two end caps and `'⁂'`, which `constants/charmap.asm` names as
+## this sheet's tile 14. The stats screen and the move screen are the two that
+## load it.
+const STATS_TILES: int = 17
+const STATS_FIRST_TILE: int = 0x31
+## `PrintPartyMonPage1` and `StatsScreen_PlaceShinyIcon` both draw `'⁂'`,
+## which is this sheet's tile 14.
+const STATS_SHINY_TILE: int = 14
+
 ## The trainer card's graphics (engine/menus/trainer_card.asm). `CardStatusGFX`
 ## is six tiles but `_Option`'s page 1 asks for 86, running on into `LeaderGFX`,
 ## so page 1's strip is those 86 from the card_status offset; pages 2 and 3 load
@@ -2890,6 +2901,14 @@ static func font_offset(layout: Dictionary) -> int:
 ## of its own. Its own content is what checks that (`verify_layout`).
 static func font_extra_offset(layout: Dictionary) -> int:
 	return font_offset(layout) - FONT_EXTRA_TILES * Gen2Tiles.TILE_BYTES
+
+
+## `StatsScreenPageTilesGFX` is the entry immediately before
+## `EnemyHPBarBorderGFX` in `gfx/font.asm` on all three dumps, so the pinned
+## enemy HUD offset walks back to it and it needs no address of its own. Its own
+## content is what checks that (`verify_layout`).
+static func stats_tiles_offset(layout: Dictionary) -> int:
+	return int(layout["enemy_hud"]) - STATS_TILES * Gen2Tiles.TILE_BYTES
 
 
 ## Frames are stored back to back in selection order, six tiles of 1bpp each.

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -159,10 +159,14 @@ func draw_hp_bar(
 ## `DrawBattleHPBar` it lays no empty template first and instead writes $62 for
 ## every tile the fill did not reach. Filling the other way put the bar's lit
 ## end on the wrong side, and skipping the empties left the trough unpainted.
-func draw_exp_bar(into: PackedByteArray, width: int, pixels: int) -> void:
+## [param at] is the bar's left-hand tile, which is the HUD's own everywhere but
+## the stats screen, where `LoadPinkPage` fills the same bar in at (11,16).
+func draw_exp_bar(
+	into: PackedByteArray, width: int, pixels: int, at: Vector2i = PLAYER_EXP
+) -> void:
 	var remaining: int = clampi(pixels, 0, EXP_BAR_TILES * TILE)
-	var right: int = PLAYER_EXP.x + EXP_BAR_TILES - 1
-	var top: int = PLAYER_EXP.y * TILE
+	var right: int = at.x + EXP_BAR_TILES - 1
+	var top: int = at.y * TILE
 
 	for tile: int in EXP_BAR_TILES:
 		var number: int = Gen2BattleTiles.HP_BAR_EMPTY

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -14,9 +14,28 @@ extends RefCounted
 
 const TILE: int = Gen2Font.TILE
 
-## The first and last tile numbers the page covers.
+## The first and last tile numbers a battle's page covers.
 const FIRST_TILE: int = 0x55
 const LAST_TILE: int = 0x78
+
+## `StatsScreen_LoadFont` reaches further down: `LoadStatsScreenPageTilesGFX`
+## parks seventeen tiles at $31, so the stats screen and the move screen assemble
+## the same strip starting there.
+const STATS_FIRST_TILE: int = RomLayout.STATS_FIRST_TILE
+const STATS_TILES_AT: int = RomLayout.STATS_FIRST_TILE
+
+## The page indicator squares `StatsScreen_LoadPageIndicators` writes as 2x2
+## blocks: the small one for a page that is not open and the large one for the
+## one that is.
+const PAGE_SQUARE_SMALL: int = 0x36
+const PAGE_SQUARE_LARGE: int = 0x3A
+## `'⁂'`, the shiny marker, at this sheet's own charmap code.
+const SHINY: int = 0x3F
+## The vertical divider both `StatsScreen_PlaceVerticalDivider` and each page
+## draw, and the two exp bar end caps the pink page closes its bar with.
+const STATS_DIVIDER: int = 0x31
+const EXP_BAR_LEFT_CAP: int = 0x40
+const EXP_BAR_RIGHT_CAP: int = 0x41
 
 ## Where each sheet is copied to, in the order the battle loads them.
 const EXP_BAR_AT: int = 0x55
@@ -51,6 +70,10 @@ const HUD_BOTTOM: int = 0x76
 
 var _tiles: PackedByteArray = PackedByteArray()
 var _width: int = 0
+## The tile number the strip starts and ends at, which is the one thing a
+## battle's page and the stats screen's disagree on.
+var _first: int = FIRST_TILE
+var _last: int = LAST_TILE
 
 
 ## Builds the page out of a cache, or null if the battle graphics are not in it.
@@ -59,8 +82,9 @@ static func from_data(data: GameData) -> Gen2BattleTiles:
 		return null
 
 	var out := Gen2BattleTiles.new()
-	var count: int = LAST_TILE - FIRST_TILE + 1
-	out._width = count * TILE
+	out._first = FIRST_TILE
+	out._last = LAST_TILE
+	out._width = (LAST_TILE - FIRST_TILE + 1) * TILE
 	out._tiles.resize(out._width * TILE)
 
 	# In load order, so that where two sheets claim a tile the later one wins,
@@ -81,11 +105,49 @@ static func from_data(data: GameData) -> Gen2BattleTiles:
 	return out if loaded == sheets.size() else null
 
 
+## `StatsScreen_LoadFont`'s own page, which the stats screen and the move screen
+## share. It differs from a battle's in three ways: the stats sheet is loaded at
+## $31, the exp bar contributes eight tiles rather than nine, and the player HUD
+## border is scattered rather than copied whole (`HPExpBarBorderGFX` tile 0 to
+## $78 and its tiles 3 and 4 to $76), which leaves $73 to $75 as the battle-extra
+## font's own `<ID>`, `№` and `…`.
+static func stats_page(data: GameData) -> Gen2BattleTiles:
+	if data == null:
+		return null
+
+	var out := Gen2BattleTiles.new()
+	out._first = STATS_FIRST_TILE
+	out._last = LAST_TILE
+	out._width = (LAST_TILE - STATS_FIRST_TILE + 1) * TILE
+	out._tiles.resize(out._width * TILE)
+
+	var sheets: Array = [
+		["stats_tiles", STATS_TILES_AT, 0, RomLayout.STATS_TILES],
+		["exp_bar", EXP_BAR_AT, 0, 8],
+		["battle_font", BATTLE_FONT_AT, 0, -1],
+		["enemy_hud", ENEMY_HUD_AT, 0, -1],
+		["player_hud", 0x78, 0, 1],
+		["player_hud", 0x76, 3, 2],
+	]
+	var loaded: int = 0
+	for sheet: Array in sheets:
+		var name: String = sheet[0]
+		var meta: Dictionary = data.tile_sheet(name)
+		if meta.is_empty():
+			continue
+		if out._copy(
+			data.tile_indices(name), int(meta.get("width", 0)), int(sheet[1]),
+			int(sheet[2]), int(sheet[3])
+		):
+			loaded += 1
+	return out if loaded == sheets.size() else null
+
+
 ## One tile of the page, drawn at a pixel position in [param into].
 func draw(tile: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int) -> void:
-	if tile < FIRST_TILE or tile > LAST_TILE:
+	if tile < _first or tile > _last:
 		return
-	Gen2Font.blit_slot(_tiles, _width, tile - FIRST_TILE, into, into_width, at_x, at_y)
+	Gen2Font.blit_slot(_tiles, _width, tile - _first, into, into_width, at_x, at_y)
 
 
 ## Draws the same tile across a run of columns, which is what a HUD's bottom
@@ -97,17 +159,35 @@ func draw_run(
 		draw(tile, into, into_width, at_x + i * TILE, at_y)
 
 
-func _copy(strip: PackedByteArray, strip_width: int, at_tile: int) -> bool:
+## The same tile down a run of rows, which is what every vertical divider on the
+## stats screen is.
+func draw_run_down(
+	tile: int, count: int, into: PackedByteArray, into_width: int, at_x: int, at_y: int
+) -> void:
+	for i: int in count:
+		draw(tile, into, into_width, at_x, at_y + i * TILE)
+
+
+## [param from] and [param count] copy a run out of the middle of a sheet, which
+## only `StatsScreen_LoadFont`'s scattered HUD border needs; -1 takes the rest.
+func _copy(
+	strip: PackedByteArray, strip_width: int, at_tile: int,
+	from: int = 0, count: int = -1
+) -> bool:
 	if strip_width <= 0 or strip.size() < strip_width * TILE:
 		return false
 
-	var tiles: int = strip_width / TILE
+	@warning_ignore("integer_division")
+	var available: int = strip_width / TILE - from
+	var tiles: int = available if count < 0 else mini(count, available)
+	if tiles <= 0:
+		return false
 	for tile: int in tiles:
-		var to: int = (at_tile - FIRST_TILE + tile) * TILE
+		var to: int = (at_tile - _first + tile) * TILE
 		if to < 0 or to + TILE > _width:
 			continue
 		for y: int in TILE:
-			var from: int = y * strip_width + tile * TILE
+			var at: int = y * strip_width + (from + tile) * TILE
 			for x: int in TILE:
-				_tiles[y * _width + to + x] = strip[from + x]
+				_tiles[y * _width + to + x] = strip[at + x]
 	return true

--- a/game/render/move_screen_page.gd
+++ b/game/render/move_screen_page.gd
@@ -1,0 +1,253 @@
+class_name Gen2MoveScreenPage
+extends RefCounted
+
+## The move screen (`MoveScreenLoop` in `engine/pokemon/mon_menu.asm`), on the
+## tile grid the hardware uses.
+##
+## `SetUpMoveScreenBG` draws the two boxes, the nickname and the two arrows once;
+## `SetUpMoveList` fills the list; `PlaceMoveData` fills the bottom box with
+## whichever row the cursor is on. Swapping replaces that box with `Where?`
+## instead, which is `.moving_move`.
+##
+## It loads `LoadStatsScreenPageTilesGFX` and nothing else the stats screen does
+## not, so the two share [method Gen2BattleTiles.stats_page] and the move-list
+## rows are drawn by [Gen2StatsScreenPage], whose green page lists the same four.
+##
+## Node-free: it writes indices into a buffer. The mon icon is not in that
+## buffer; it is an object with a palette of its own, composed over the page by
+## the screen.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## `SetUpMoveScreenBG`'s two `Textbox` calls, which take an interior: `b, c` of
+## 9 by 18 at (0,1) and 5 by 18 at (0,11).
+const TOP_BOX: Rect2i = Rect2i(0, 1, 20, 11)
+const BOTTOM_BOX: Rect2i = Rect2i(0, 11, 20, 7)
+
+## `GetNickname` at (5,1), and `PrintLevel` one column past whatever it printed,
+## which is where `PlaceString` leaves `bc`.
+const NICKNAME: Vector2i = Vector2i(5, 1)
+
+## `PlaceMoveScreenLeftArrow` and `PlaceMoveScreenRightArrow`, each drawn only
+## when there is another Pokémon that way that is neither an egg nor a hole.
+const LEFT_ARROW: Vector2i = Vector2i(16, 0)
+const RIGHT_ARROW: Vector2i = Vector2i(18, 0)
+
+## `MoveList_InitAnimatedMonIcon`'s `depixel 3, 4, 2, 4`, less shadow OAM's own
+## origin and the tile the four-tile icon hangs above and left of.
+const ICON_AT: Vector2i = Vector2i(20, 2)
+
+## `SetUpMoveList`: `ListMoves` at (2,3) and `ListMovePP` at (10,4), both with
+## `wListMovesLineSpacing` of two rows.
+const MOVES_AT: Vector2i = Vector2i(2, 3)
+const MOVE_PP_AT: Vector2i = Vector2i(10, 4)
+
+## `MoveScreen2DMenuData`'s `db 3, 1` start and `dn 2, 0` offset.
+const CURSOR_COLUMN: int = 1
+const CURSOR_FIRST_ROW: int = 3
+const CURSOR_ROW_STEP: int = 2
+
+## `PlaceMoveData`'s own strings and columns.
+const TYPE_BOX_TOP: Vector2i = Vector2i(0, 10)
+const TYPE_BOX_BOTTOM: Vector2i = Vector2i(0, 11)
+## `String_MoveType_Top` and `String_MoveType_Bottom` are printed as characters,
+## so the corners come off whichever textbox frame is chosen rather than off the
+## font: seven columns of `┌ ───── ┐` over `│ TYPE/ └`.
+const TYPE_BOX_WIDTH: int = 7
+const TYPE_LABEL_STRING: String = "TYPE/"
+## `constants/charmap.asm`'s box-drawing codes, which print from whichever frame
+## is loaded at $79.
+const CODE_BOX_TOP_LEFT: int = 0x79
+const CODE_BOX_HORIZONTAL: int = 0x7A
+const CODE_BOX_TOP_RIGHT: int = 0x7B
+const CODE_BOX_VERTICAL: int = 0x7C
+const CODE_BOX_BOTTOM_LEFT: int = 0x7D
+const TYPE_AT: Vector2i = Vector2i(2, 12)
+const ATTACK_LABEL: Vector2i = Vector2i(12, 12)
+const ATTACK_LABEL_STRING: String = "ATK/"
+const POWER_AT: Vector2i = Vector2i(16, 12)
+const POWER_DIGITS: int = 3
+const NO_POWER_STRING: String = "---"
+## `cp 2`: a power of 0 or 1 is a move with none, and 1 is what every status move
+## in `data/moves/moves.asm` carries.
+const MIN_PRINTED_POWER: int = 2
+const DESCRIPTION_AT: Vector2i = Vector2i(1, 14)
+const DESCRIPTION_LINE_STEP: int = 2
+
+## `.moving_move`'s `String_MoveWhere`, which replaces the move's data.
+const WHERE_AT: Vector2i = Vector2i(1, 12)
+const WHERE_STRING: String = "Where?"
+
+## `PlaceHollowCursor`, the outlined arrow a held row wears.
+const HOLLOW_CURSOR_CODE: int = 0xEC
+
+## `SPRITE_ANIM_OBJ_PARTY_MON`'s frameset, which still steps here even though
+## `MoveList_InitAnimatedMonIcon` nulls the sequence: two sets of four tiles,
+## eight passes each, and no speed byte added because no HP bar chose one.
+const ICON_FRAMES: int = Gen2PartyMenuPage.ICON_FRAMES
+const ICON_FRAME_TILES: int = Gen2PartyMenuPage.ICON_FRAME_TILES
+const ICON_FRAME_DURATION: int = Gen2PartyMenuPage.ICON_FRAME_DURATION
+
+var font: Gen2Font = null
+var tiles: Gen2BattleTiles = null
+var stats: Gen2StatsScreenPage = null
+## `Textbox` draws with wTextboxFrame, so both boxes wear whichever frame the
+## player chose.
+var frame_style: int = 0
+
+## `GetSpriteAnimFrame`'s own two: FRAME opens at -1 and DURATION at zero, so
+## the first pass shows the first entry and shadow OAM holds nothing before it.
+var _frame: int = -1
+var _duration: int = 0
+
+
+static func from_data(data: GameData) -> Gen2MoveScreenPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	var page_tiles: Gen2BattleTiles = Gen2BattleTiles.stats_page(data)
+	var rows: Gen2StatsScreenPage = Gen2StatsScreenPage.from_data(data)
+	if glyphs == null or page_tiles == null or rows == null:
+		return null
+	var out := Gen2MoveScreenPage.new()
+	out.font = glyphs
+	out.tiles = page_tiles
+	out.stats = rows
+	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	return out
+
+
+## Where the screen puts the mon icon, in pixels.
+static func icon_position() -> Vector2i:
+	return ICON_AT
+
+
+## One pass of `PlaySpriteAnimations` over the one struct this screen spawns.
+func advance() -> void:
+	if _duration > 0:
+		_duration -= 1
+		return
+	_frame = (_frame + 1) % ICON_FRAMES
+	_duration = ICON_FRAME_DURATION
+
+
+## The page as pixels with the icon composed on top: it is an object, so colour
+## 0 is transparent and it is blended rather than written into the buffer.
+func render(page: Dictionary, data: GameData) -> Image:
+	var image: Image = Gen2PicImage.from_indices(
+		draw(page), COLUMNS * TILE, ROWS * TILE,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	if data == null or _frame < 0:
+		return image
+	var colors: PackedColorArray = data.party_menu_icon_palette()
+	var strip: PackedByteArray = data.species_icon_indices(int(page.get("species", 0)))
+	if strip.is_empty() or colors.size() != Gen2Palette.COLORS_PER_PIC:
+		return image
+	var first: int = _frame * ICON_FRAME_TILES
+	for quadrant: int in ICON_FRAME_TILES:
+		Gen2PartyMenuPage.blend_tile(
+			image, strip, first + quadrant, colors,
+			ICON_AT + Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
+		)
+	return image
+
+
+## The whole 160x144 screen as palette indices. [param page] is
+## [method Gen2MoveScreen.snapshot].
+func draw(page: Dictionary) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(COLUMNS * TILE * ROWS * TILE)
+	if font == null:
+		return indices
+	var width: int = COLUMNS * TILE
+	_box(indices, width, TOP_BOX)
+	_box(indices, width, BOTTOM_BOX)
+
+	var name: String = String(page.get("nickname", ""))
+	_text(indices, width, name, NICKNAME)
+	stats.draw_level(
+		indices, width, NICKNAME + Vector2i(name.length() + 1, 0),
+		int(page.get("level", 0))
+	)
+	if bool(page.get("previous", false)):
+		_code(indices, width, Gen2StatsScreenPage.CODE_LEFT_ARROW, LEFT_ARROW)
+	if bool(page.get("next", false)):
+		_code(indices, width, Gen2StatsScreenPage.CODE_RIGHT_ARROW, RIGHT_ARROW)
+
+	stats.draw_move_list(indices, width, page.get("moves", []), MOVES_AT, MOVE_PP_AT)
+	var cursor: int = int(page.get("cursor", 0))
+	_code(
+		indices, width, Gen2MenuPage.CURSOR_CODE,
+		Vector2i(CURSOR_COLUMN, CURSOR_FIRST_ROW + cursor * CURSOR_ROW_STEP)
+	)
+	var held: int = int(page.get("held", -1))
+	if held >= 0:
+		_code(
+			indices, width, HOLLOW_CURSOR_CODE,
+			Vector2i(CURSOR_COLUMN, CURSOR_FIRST_ROW + held * CURSOR_ROW_STEP)
+		)
+		_text(indices, width, WHERE_STRING, WHERE_AT)
+		return indices
+	_draw_move_data(page, indices, width)
+	return indices
+
+
+## `PlaceMoveData`: the type box, the attack power and the description, all for
+## the row the cursor is on. A list with no moves on it has none of this.
+func _draw_move_data(page: Dictionary, into: PackedByteArray, width: int) -> void:
+	var moves: Array = page.get("moves", [])
+	var cursor: int = int(page.get("cursor", 0))
+	if cursor < 0 or cursor >= moves.size():
+		return
+	var move: Dictionary = moves[cursor]
+	_type_box(into, width)
+	_text(into, width, String(move.get("type_name", "")), TYPE_AT)
+	_text(into, width, ATTACK_LABEL_STRING, ATTACK_LABEL)
+	var power: int = int(move.get("power", 0))
+	_text(
+		into, width,
+		str(power).lpad(POWER_DIGITS) if power >= MIN_PRINTED_POWER else NO_POWER_STRING,
+		POWER_AT
+	)
+	var lines: PackedStringArray = String(move.get("description", "")).split("\n")
+	for index: int in lines.size():
+		_text(
+			into, width, lines[index],
+			DESCRIPTION_AT + Vector2i(0, index * DESCRIPTION_LINE_STEP)
+		)
+
+
+## The half-open box `String_MoveType_Top` and its sibling draw around TYPE/: a
+## closed top row and a bottom row that is open to the right, which is what the
+## `└` at the end of the second string is.
+func _type_box(into: PackedByteArray, width: int) -> void:
+	_frame_tile(into, width, CODE_BOX_TOP_LEFT, TYPE_BOX_TOP)
+	for column: int in range(1, TYPE_BOX_WIDTH - 1):
+		_frame_tile(into, width, CODE_BOX_HORIZONTAL, TYPE_BOX_TOP + Vector2i(column, 0))
+	_frame_tile(into, width, CODE_BOX_TOP_RIGHT, TYPE_BOX_TOP + Vector2i(TYPE_BOX_WIDTH - 1, 0))
+	_frame_tile(into, width, CODE_BOX_VERTICAL, TYPE_BOX_BOTTOM)
+	_text(into, width, TYPE_LABEL_STRING, TYPE_BOX_BOTTOM + Vector2i(1, 0))
+	_frame_tile(
+		into, width, CODE_BOX_BOTTOM_LEFT,
+		TYPE_BOX_BOTTOM + Vector2i(TYPE_BOX_WIDTH - 1, 0)
+	)
+
+
+func _frame_tile(into: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
+	font.draw_frame_code(frame_style, code, into, width, at.x * TILE, at.y * TILE)
+
+
+func _box(into: PackedByteArray, width: int, box: Rect2i) -> void:
+	font.draw_box(
+		frame_style, into, width,
+		box.position.x * TILE, box.position.y * TILE, box.size.x, box.size.y
+	)
+
+
+func _text(into: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
+	font.draw_text(text, into, width, at.x * TILE, at.y * TILE, Gen2StatsScreenPage.FONT)
+
+
+func _code(into: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
+	font.draw_code(code, into, width, at.x * TILE, at.y * TILE, Gen2StatsScreenPage.FONT)

--- a/game/render/move_screen_page.gd.uid
+++ b/game/render/move_screen_page.gd.uid
@@ -1,0 +1,1 @@
+uid://2uc7mra8atr

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -275,14 +275,15 @@ func _blend_icons(image: Image, count: int) -> void:
 			if quadrant == ICON_ITEM_QUADRANT and bool(icon["item"]) and not held.is_empty():
 				source = held
 				tile = ICON_ITEM_TILE
-			_blend_tile(
+			blend_tile(
 				image, source, tile, colors,
 				at + Vector2i((quadrant & 1) * ICON_TILE, (quadrant >> 1) * ICON_TILE)
 			)
 
 
-## One 8x8 tile of an index strip, clipped to the screen.
-func _blend_tile(
+## One 8x8 tile of an index strip, clipped to the screen. Static and public
+## because the move screen composes the same icon over its own page.
+static func blend_tile(
 	image: Image, strip: PackedByteArray, tile: int, colors: PackedColorArray, at: Vector2i
 ) -> void:
 	@warning_ignore("integer_division")

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -1,0 +1,496 @@
+class_name Gen2StatsScreenPage
+extends RefCounted
+
+## The stats screen (`engine/pokemon/stats_screen.asm`), on the tile grid the
+## hardware uses.
+##
+## `StatsScreen_InitUpperHalf` draws the top seven rows once and each of
+## `LoadPinkPage`, `LoadGreenPage` and `LoadBluePage` fills the ten rows under
+## the divider, so the page number picks the lower half and nothing else. An egg
+## replaces the whole screen with `EggStatsScreen` instead.
+##
+## `StatsScreen_LoadFont` is `_LoadFontsBattleExtra` plus the bar borders and
+## `LoadStatsScreenPageTilesGFX`, so every glyph here is the battle-extra strip's
+## (`<LV>`, `<ID>`, `№`, `◀`) and the dividers, the page indicators, the exp
+## bar's end caps and `⁂` are tiles off [method Gen2BattleTiles.stats_page].
+##
+## Node-free: it writes indices into a buffer, so a page can be drawn and read
+## back headless. The Pokémon's own pic is not in that buffer; it has its own
+## palette and is composed over the page by the screen.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## `stats_screen.asm`'s own page constants.
+const PINK_PAGE: int = 1
+const GREEN_PAGE: int = 2
+const BLUE_PAGE: int = 3
+const NUM_PAGES: int = 3
+
+## Everything on this screen prints with the battle-extra strip loaded.
+const FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
+
+## Codes the source places as bytes rather than printing as a string.
+const CODE_NUMERO: int = 0x74
+const CODE_ID: int = 0x73
+const CODE_LEVEL: int = 0x6E
+const CODE_DOT: int = 0xF2
+const CODE_SLASH: int = 0xF3
+const CODE_LEFT_ARROW: int = 0x71
+const CODE_RIGHT_ARROW: int = 0xED
+const CODE_MALE: int = 0xEF
+const CODE_FEMALE: int = 0xF5
+
+## `StatsScreen_InitUpperHalf`, every position its own `hlcoord`.
+const DEX_LABEL: Vector2i = Vector2i(8, 0)
+const DEX_NUMBER: Vector2i = Vector2i(10, 0)
+const DEX_DIGITS: int = 3
+const HEADER_LEVEL: Vector2i = Vector2i(14, 0)
+const GENDER: Vector2i = Vector2i(18, 0)
+const SHINY: Vector2i = Vector2i(19, 0)
+const NICKNAME: Vector2i = Vector2i(8, 2)
+const SPECIES_SLASH: Vector2i = Vector2i(9, 4)
+const DIVIDER_ROW: int = 7
+const PAGE_LEFT_ARROW: Vector2i = Vector2i(12, 6)
+const PAGE_RIGHT_ARROW: Vector2i = Vector2i(19, 6)
+
+## `StatsScreen_LoadPageIndicators`: three 2x2 blocks, one per page.
+const PAGE_INDICATORS: Array[Vector2i] = [
+	Vector2i(13, 5), Vector2i(15, 5), Vector2i(17, 5),
+]
+
+## `hlcoord 0, 0`, and `PrepMonFrontpic` centres a seven-tile cell there.
+const PIC_AT: Vector2i = Vector2i(0, 0)
+const PIC_TILES: int = 7
+
+## `LoadPinkPage`. `DrawPlayerHP` lays "HP:", six bar tiles and a cap at (0,9)
+## and the numbers a row under it; the page then writes $41 over the cap.
+const HP_BAR: Vector2i = Vector2i(0, 9)
+const HP_NUMBERS: Vector2i = Vector2i(1, 10)
+const HP_DIGITS: int = 3
+const POKERUS_DOT: Vector2i = Vector2i(8, 8)
+const STATUS_LABEL: Vector2i = Vector2i(0, 12)
+const TYPE_LABEL: Vector2i = Vector2i(0, 14)
+const STATUS_AT: Vector2i = Vector2i(6, 13)
+const POKERUS_AT: Vector2i = Vector2i(1, 13)
+const TYPES_AT: Vector2i = Vector2i(1, 15)
+const PINK_DIVIDER_COLUMN: int = 9
+const LOWER_FIRST_ROW: int = 8
+const LOWER_ROWS: int = 10
+const EXP_POINTS_LABEL: Vector2i = Vector2i(10, 9)
+const EXP_POINTS_AT: Vector2i = Vector2i(13, 10)
+const EXP_DIGITS: int = 7
+const LEVEL_UP_LABEL: Vector2i = Vector2i(10, 12)
+const EXP_TO_NEXT_AT: Vector2i = Vector2i(13, 13)
+const TO_LABEL: Vector2i = Vector2i(14, 14)
+const NEXT_LEVEL_AT: Vector2i = Vector2i(17, 14)
+const EXP_BAR_AT: Vector2i = Vector2i(11, 16)
+const EXP_BAR_LEFT_CAP: Vector2i = Vector2i(10, 16)
+const EXP_BAR_RIGHT_CAP: Vector2i = Vector2i(19, 16)
+
+const STATUS_TYPE_TOP: String = "STATUS/"
+const STATUS_TYPE_BOTTOM: String = "TYPE/"
+const OK_STRING: String = "OK "
+const EXP_POINT_STRING: String = "EXP POINTS"
+const LEVEL_UP_STRING: String = "LEVEL UP"
+const TO_STRING: String = "TO"
+const POKERUS_STRING: String = "#RUS"
+
+## `PlaceNonFaintStatus`' own strings and the FNT `PlaceStatusString` reaches
+## before it ever reads the byte, which is [Gen2PartyMenuPage]'s set as well.
+const STATUS_STRINGS: Dictionary = Gen2PartyMenuPage.STATUS_STRINGS
+const FAINTED_STRING: String = Gen2PartyMenuPage.FAINTED_STRING
+
+## `LoadGreenPage`.
+const ITEM_LABEL: Vector2i = Vector2i(0, 8)
+const ITEM_AT: Vector2i = Vector2i(8, 8)
+const MOVE_LABEL: Vector2i = Vector2i(0, 10)
+const MOVES_AT: Vector2i = Vector2i(8, 10)
+const MOVE_PP_AT: Vector2i = Vector2i(12, 11)
+const ITEM_STRING: String = "ITEM"
+const MOVE_STRING: String = "MOVE"
+const THREE_DASHES: String = "---"
+
+## `wListMovesLineSpacing` is `SCREEN_WIDTH * 2` on both screens that list moves,
+## so a row is two tiles below the one above it.
+const MOVE_ROW_STEP: int = 2
+const MAX_MOVES: int = 4
+## `ListMovePP`: two digits either side of the slash, and "PP" is two copies of
+## the stats sheet's own P.
+const PP_DIGITS: int = 2
+const PP_LABEL_TILE: int = 0x3E
+
+## `LoadBluePage`.
+const ID_LABEL: Vector2i = Vector2i(0, 9)
+const OT_LABEL: Vector2i = Vector2i(0, 12)
+const ID_NUMBER_AT: Vector2i = Vector2i(2, 10)
+const ID_DIGITS: int = 5
+const OT_NAME_AT: Vector2i = Vector2i(2, 13)
+const CAUGHT_GENDER_AT: Vector2i = Vector2i(9, 13)
+## `constants/pokemon_data_constants.asm`' CAUGHT_GENDER_MASK, read off the whole
+## caught-data byte the way `.PlaceOTInfo` reads it.
+const CAUGHT_GENDER_MASK: int = 0x80
+const BLUE_DIVIDER_COLUMN: int = 10
+const STAT_NAMES_AT: Vector2i = Vector2i(11, 8)
+const OT_STRING: String = "OT/"
+
+## `PrintTempMonStats`' own five names and the spacing the two callers pass:
+## the stats screen 6 and the battle's level-up box 4, which is the column the
+## numbers land in relative to the names.
+const STAT_NAMES: Array[String] = [
+	"ATTACK", "DEFENSE", "SPCL.ATK", "SPCL.DEF", "SPEED",
+]
+const STAT_KEYS: Array[String] = [
+	"attack", "defense", "sp_attack", "sp_defense", "speed",
+]
+const STAT_ROW_STEP: int = 2
+const STAT_DIGITS: int = 3
+const STATS_SPACING: int = 6
+
+## `EggStatsScreen`.
+const EGG_LABEL: Vector2i = Vector2i(8, 1)
+const EGG_ID_LABEL: Vector2i = Vector2i(8, 3)
+const EGG_OT_LABEL: Vector2i = Vector2i(8, 5)
+const EGG_ID_MARKS: Vector2i = Vector2i(11, 3)
+const EGG_OT_MARKS: Vector2i = Vector2i(11, 5)
+const EGG_TEXT_AT: Vector2i = Vector2i(1, 9)
+const EGG_STRING: String = "EGG"
+const FIVE_QUESTION_MARKS: String = "?????"
+
+## The four hatch hints and the `wTempMonHappiness` each is chosen under, which
+## is the egg's remaining step counter rather than a happiness value.
+const EGG_SOON_STEPS: int = 6
+const EGG_CLOSE_STEPS: int = 11
+const EGG_MORE_TIME_STEPS: int = 41
+const EGG_MESSAGES: Array[String] = [
+	"It's making sounds\ninside. It's going\nto hatch soon!",
+	"It moves around\ninside sometimes.\nIt must be close\nto hatching.",
+	"Wonder what's\ninside? It needs\nmore time, though.",
+	"This EGG needs a\nlot more time to\nhatch.",
+]
+
+var font: Gen2Font = null
+var tiles: Gen2BattleTiles = null
+var hud: Gen2BattleHud = null
+
+
+static func from_data(data: GameData) -> Gen2StatsScreenPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	var page_tiles: Gen2BattleTiles = Gen2BattleTiles.stats_page(data)
+	var panels: Gen2BattleHud = Gen2BattleHud.from_data(data)
+	if glyphs == null or page_tiles == null or panels == null:
+		return null
+	var out := Gen2StatsScreenPage.new()
+	out.font = glyphs
+	out.tiles = page_tiles
+	out.hud = panels
+	return out
+
+
+## Where the screen puts the front pic, in pixels, and how wide the cell is.
+static func pic_position() -> Vector2i:
+	return PIC_AT * TILE
+
+
+static func pic_size() -> int:
+	return PIC_TILES * TILE
+
+
+## The hatch hint `EggStatsScreen` picks for a step counter.
+static func egg_message(steps: int) -> String:
+	if steps < EGG_SOON_STEPS:
+		return EGG_MESSAGES[0]
+	if steps < EGG_CLOSE_STEPS:
+		return EGG_MESSAGES[1]
+	if steps < EGG_MORE_TIME_STEPS:
+		return EGG_MESSAGES[2]
+	return EGG_MESSAGES[3]
+
+
+## The whole 160x144 screen as palette indices. [param page] is
+## [method Gen2StatsScreen.snapshot].
+func draw(page: Dictionary) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(COLUMNS * TILE * ROWS * TILE)
+	if font == null:
+		return indices
+	if bool(page.get("egg", false)):
+		_draw_egg(page, indices)
+		return indices
+	_draw_upper(page, indices)
+	match int(page.get("page", PINK_PAGE)):
+		GREEN_PAGE:
+			_draw_green(page, indices)
+		BLUE_PAGE:
+			_draw_blue(page, indices)
+		_:
+			_draw_pink(page, indices)
+	return indices
+
+
+## The page as pixels, with the HP bar blended over it in its own colour: the
+## hardware gives every tile a palette and one index buffer carries one, which
+## is how [Gen2PartyMenuPage] draws the same bar.
+func render(page: Dictionary, data: GameData) -> Image:
+	var image: Image = Gen2PicImage.from_indices(
+		draw(page), COLUMNS * TILE, ROWS * TILE,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	if data == null or bool(page.get("egg", false)) \
+		or int(page.get("page", PINK_PAGE)) != PINK_PAGE:
+		return image
+	var width: int = COLUMNS * TILE
+	var buffer := PackedByteArray()
+	buffer.resize(width * ROWS * TILE)
+	var hp: int = int(page.get("hp", 0))
+	var max_hp: int = int(page.get("max_hp", 0))
+	hud.draw_hp_bar(buffer, width, HP_BAR, hp, max_hp)
+	var lit: int = Gen2BattleHud.bar_pixels(hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE)
+	var fill: Image = Gen2PicImage.from_indices(
+		buffer, width, ROWS * TILE,
+		data.bar_palette(GameData.hp_bar_palette_name(lit)), true
+	)
+	var at := Vector2i((HP_BAR.x + 2) * TILE, HP_BAR.y * TILE)
+	image.blend_rect(
+		fill, Rect2i(at, Vector2i(Gen2BattleHud.HP_BAR_TILES * TILE, TILE)), at
+	)
+	return image
+
+
+## `PrintTempMonStats`: the five names down one column and the five numbers down
+## another, both stepping two rows. Shared with the battle's own level-up box,
+## which passes a spacing of four instead of six.
+func draw_stats(
+	into: PackedByteArray, width: int, at: Vector2i, stats: Dictionary,
+	spacing: int = STATS_SPACING
+) -> void:
+	for index: int in STAT_NAMES.size():
+		_text(into, width, STAT_NAMES[index], at + Vector2i(0, index * STAT_ROW_STEP))
+	var numbers: Vector2i = at + Vector2i(spacing, 1)
+	for index: int in STAT_KEYS.size():
+		_text(
+			into, width, str(int(stats.get(STAT_KEYS[index], 0))).lpad(STAT_DIGITS),
+			numbers + Vector2i(0, index * STAT_ROW_STEP)
+		)
+
+
+## `StatsScreen_InitUpperHalf` plus `StatsScreen_LoadPageIndicators`, which
+## `.ClearBox` runs for whichever page is being loaded.
+func _draw_upper(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_code(into, width, CODE_NUMERO, DEX_LABEL)
+	_code(into, width, CODE_DOT, DEX_LABEL + Vector2i(1, 0))
+	## PRINTNUM_LEADINGZEROS, so a two-digit dex number keeps its column.
+	_text(into, width, "%0*d" % [DEX_DIGITS, int(page.get("dex_number", 0))], DEX_NUMBER)
+	draw_level(into, width, HEADER_LEVEL, int(page.get("level", 0)))
+	_text(into, width, String(page.get("nickname", "")), NICKNAME)
+	_gender(into, width, GENDER, StringName(page.get("gender", &"")))
+	if bool(page.get("shiny", false)):
+		tiles.draw(Gen2BattleTiles.SHINY, into, width, SHINY.x * TILE, SHINY.y * TILE)
+	_code(into, width, CODE_SLASH, SPECIES_SLASH)
+	_text(into, width, String(page.get("species_name", "")), SPECIES_SLASH + Vector2i(1, 0))
+
+	## `StatsScreen_PlaceHorizontalDivider` writes the empty bar tile across the
+	## whole width, which is why the divider is the same tile as an empty bar.
+	tiles.draw_run(
+		Gen2BattleTiles.HP_BAR_EMPTY, COLUMNS, into, width, 0, DIVIDER_ROW * TILE
+	)
+	_code(into, width, CODE_LEFT_ARROW, PAGE_LEFT_ARROW)
+	_code(into, width, CODE_RIGHT_ARROW, PAGE_RIGHT_ARROW)
+	_page_indicators(into, width, int(page.get("page", PINK_PAGE)))
+
+
+## Three 2x2 blocks, the open page's drawn from the large square instead of the
+## small one. The source writes the four tiles in the order top-left, top-right,
+## bottom-left, bottom-right off one incrementing tile number.
+func _page_indicators(into: PackedByteArray, width: int, open_page: int) -> void:
+	for index: int in PAGE_INDICATORS.size():
+		var first: int = Gen2BattleTiles.PAGE_SQUARE_LARGE \
+			if index + PINK_PAGE == open_page else Gen2BattleTiles.PAGE_SQUARE_SMALL
+		var at: Vector2i = PAGE_INDICATORS[index]
+		for quadrant: int in 4:
+			@warning_ignore("integer_division")
+			var offset := Vector2i(quadrant % 2, quadrant / 2)
+			tiles.draw(
+				first + quadrant, into, width,
+				(at.x + offset.x) * TILE, (at.y + offset.y) * TILE
+			)
+
+
+func _draw_pink(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	var hp: int = int(page.get("hp", 0))
+	var max_hp: int = int(page.get("max_hp", 0))
+	hud.draw_bar_frame(into, width, HP_BAR, Gen2BattleTiles.HP_BAR_END)
+	hud.draw_hp_bar(into, width, HP_BAR, hp, max_hp)
+	## The page writes its own cap over `DrawBattleHPBar`'s, which is the one
+	## piece of the bar that comes off the stats sheet rather than the HUD's.
+	tiles.draw(
+		Gen2BattleTiles.EXP_BAR_RIGHT_CAP, into, width,
+		(HP_BAR.x + 8) * TILE, HP_BAR.y * TILE
+	)
+	_text(
+		into, width, "%s/%s" % [str(hp).lpad(HP_DIGITS), str(max_hp).lpad(HP_DIGITS)],
+		HP_NUMBERS
+	)
+
+	_text(into, width, STATUS_TYPE_TOP, STATUS_LABEL)
+	_text(into, width, STATUS_TYPE_BOTTOM, TYPE_LABEL)
+	## `wTempMonPokerusStatus`: the low nibble is the days left and the high one
+	## the strain, so a mon that has had it and recovered is a dot and one that
+	## still has it prints `#RUS` where the status would go.
+	var pokerus: int = int(page.get("pokerus", 0))
+	if pokerus & 0x0F != 0:
+		_text(into, width, POKERUS_STRING, POKERUS_AT)
+	else:
+		if pokerus & 0xF0 != 0:
+			_code(into, width, CODE_DOT, POKERUS_DOT)
+		_text(into, width, _status_string(page), STATUS_AT)
+
+	var types: Array = page.get("types", [])
+	for index: int in types.size():
+		_text(into, width, String(types[index]), TYPES_AT + Vector2i(0, index))
+
+	tiles.draw_run_down(
+		Gen2BattleTiles.STATS_DIVIDER, LOWER_ROWS, into, width,
+		PINK_DIVIDER_COLUMN * TILE, LOWER_FIRST_ROW * TILE
+	)
+	_text(into, width, EXP_POINT_STRING, EXP_POINTS_LABEL)
+	_text(into, width, LEVEL_UP_STRING, LEVEL_UP_LABEL)
+	_text(into, width, TO_STRING, TO_LABEL)
+	draw_level(into, width, NEXT_LEVEL_AT, int(page.get("next_level", 0)))
+	_text(into, width, str(int(page.get("exp", 0))).lpad(EXP_DIGITS), EXP_POINTS_AT)
+	_text(
+		into, width, str(int(page.get("exp_to_next", 0))).lpad(EXP_DIGITS), EXP_TO_NEXT_AT
+	)
+	hud.draw_exp_bar(into, width, int(page.get("exp_pixels", 0)), EXP_BAR_AT)
+	tiles.draw(
+		Gen2BattleTiles.EXP_BAR_LEFT_CAP, into, width,
+		EXP_BAR_LEFT_CAP.x * TILE, EXP_BAR_LEFT_CAP.y * TILE
+	)
+	tiles.draw(
+		Gen2BattleTiles.EXP_BAR_RIGHT_CAP, into, width,
+		EXP_BAR_RIGHT_CAP.x * TILE, EXP_BAR_RIGHT_CAP.y * TILE
+	)
+
+
+func _draw_green(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_text(into, width, ITEM_STRING, ITEM_LABEL)
+	_text(into, width, String(page.get("item_name", THREE_DASHES)), ITEM_AT)
+	_text(into, width, MOVE_STRING, MOVE_LABEL)
+	draw_move_list(into, width, page.get("moves", []), MOVES_AT, MOVE_PP_AT)
+
+
+## `ListMoves` and `ListMovePP` together: four rows two tiles apart, a name in
+## each and either its PP or the dashes an empty slot draws. The move screen
+## lists the same four from its own two columns.
+func draw_move_list(
+	into: PackedByteArray, width: int, moves: Array, names_at: Vector2i, pp_at: Vector2i
+) -> void:
+	for slot: int in MAX_MOVES:
+		var row: int = slot * MOVE_ROW_STEP
+		if slot >= moves.size():
+			## `.nonmove_loop` prints one `-` for the name and `.load_loop`
+			## writes two for the PP label.
+			_text(into, width, "-", names_at + Vector2i(0, row))
+			_text(into, width, "--", pp_at + Vector2i(0, row))
+			continue
+		var move: Dictionary = moves[slot]
+		_text(into, width, String(move.get("name", "")), names_at + Vector2i(0, row))
+		for column: int in 2:
+			tiles.draw(
+				PP_LABEL_TILE, into, width,
+				(pp_at.x + column) * TILE, (pp_at.y + row) * TILE
+			)
+		_text(
+			into, width, str(int(move.get("pp", 0))).lpad(PP_DIGITS),
+			pp_at + Vector2i(3, row)
+		)
+		_code(into, width, CODE_SLASH, pp_at + Vector2i(5, row))
+		_text(
+			into, width, str(int(move.get("max_pp", 0))).lpad(PP_DIGITS),
+			pp_at + Vector2i(6, row)
+		)
+
+
+func _draw_blue(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_id_label(into, width, ID_LABEL)
+	_text(into, width, OT_STRING, OT_LABEL)
+	_text(into, width, "%0*d" % [ID_DIGITS, int(page.get("ot_id", 0))], ID_NUMBER_AT)
+	_text(into, width, String(page.get("ot_name", "")), OT_NAME_AT)
+	## `wTempMonCaughtGender`: zero is a mon this save has no caught data for and
+	## $7f is a traded one, and neither prints a symbol.
+	var caught: int = int(page.get("caught_gender", 0))
+	if caught != 0 and caught != 0x7F:
+		_code(
+			into, width,
+			CODE_FEMALE if caught & CAUGHT_GENDER_MASK != 0 else CODE_MALE,
+			CAUGHT_GENDER_AT
+		)
+	tiles.draw_run_down(
+		Gen2BattleTiles.STATS_DIVIDER, LOWER_ROWS, into, width,
+		BLUE_DIVIDER_COLUMN * TILE, LOWER_FIRST_ROW * TILE
+	)
+	draw_stats(into, width, STAT_NAMES_AT, page.get("stats", {}))
+
+
+## `EggStatsScreen`, which replaces the whole screen rather than a page of it:
+## the divider, four labels beside the pic and the hatch hint under it.
+func _draw_egg(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	tiles.draw_run(
+		Gen2BattleTiles.HP_BAR_EMPTY, COLUMNS, into, width, 0, DIVIDER_ROW * TILE
+	)
+	_text(into, width, EGG_STRING, EGG_LABEL)
+	_id_label(into, width, EGG_ID_LABEL)
+	_text(into, width, OT_STRING, EGG_OT_LABEL)
+	_text(into, width, FIVE_QUESTION_MARKS, EGG_ID_MARKS)
+	_text(into, width, FIVE_QUESTION_MARKS, EGG_OT_MARKS)
+	var lines: PackedStringArray = String(page.get("egg_message", "")).split("\n")
+	for index: int in lines.size():
+		_text(into, width, lines[index], EGG_TEXT_AT + Vector2i(0, index * MOVE_ROW_STEP))
+
+
+## `IDNoString`, which is `<ID>`, `№` and a decimal point.
+func _id_label(into: PackedByteArray, width: int, at: Vector2i) -> void:
+	_code(into, width, CODE_ID, at)
+	_code(into, width, CODE_NUMERO, at + Vector2i(1, 0))
+	_code(into, width, CODE_DOT, at + Vector2i(2, 0))
+
+
+## `PlaceStatusString`: the health is tested before the byte, so a fainted mon
+## reads FNT whatever else it carries, and anything with no status at all is the
+## page's own `OK `.
+func _status_string(page: Dictionary) -> String:
+	if bool(page.get("fainted", false)):
+		return FAINTED_STRING
+	var name: StringName = Gen2Status.name_of(int(page.get("status", 0)))
+	return String(STATUS_STRINGS.get(name, OK_STRING))
+
+
+## `PrintLevel`: the `<LV>` tile and then the number left-aligned beside it.
+func draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> void:
+	_code(into, width, CODE_LEVEL, at)
+	_text(into, width, str(level), at + Vector2i(1, 0))
+
+
+## `.PlaceGenderChar`, which prints nothing at all for a genderless species
+## rather than a space.
+func _gender(
+	into: PackedByteArray, width: int, at: Vector2i, gender: StringName
+) -> void:
+	if gender == Gen2BattleMon.GENDER_MALE:
+		_code(into, width, CODE_MALE, at)
+	elif gender == Gen2BattleMon.GENDER_FEMALE:
+		_code(into, width, CODE_FEMALE, at)
+
+
+func _text(into: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
+	font.draw_text(text, into, width, at.x * TILE, at.y * TILE, FONT)
+
+
+func _code(into: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
+	font.draw_code(code, into, width, at.x * TILE, at.y * TILE, FONT)

--- a/game/render/stats_screen_page.gd.uid
+++ b/game/render/stats_screen_page.gd.uid
@@ -1,0 +1,1 @@
+uid://bi54mfjl070q0

--- a/game/save/mon_stats_screen.gd
+++ b/game/save/mon_stats_screen.gd
@@ -1,0 +1,213 @@
+class_name Gen2MonStatsScreen
+extends RefCounted
+
+## The stats screen's model (`engine/pokemon/stats_screen.asm`): which member of
+## a list is shown, which of the three pages is open, and what each page has to
+## say about it. [Gen2StatsScreenPage] draws the answer.
+##
+## `StatsScreenInit` is opened over whatever screen asked for it and hands
+## control back on the way out, so this owns no nodes: whoever embedded it draws
+## [method snapshot] and feeds it [method handle_button].
+##
+## The list is the party in the two places STATS is reached from today, the
+## overworld's `MonMenu_Stats` and a battle's own party menu. `wMonType` picks a
+## different list on the cartridge (`sBoxMons`, the enemy's party, `wBufferMon`);
+## the shape here is the same for any of them, which is why the mons are passed
+## in rather than read out of a save.
+
+## `StatsScreen_Exit`: B, or A on the last page.
+signal closed
+## `PlayMonCry2`, which `StatsScreen_PlaceFrontpic` plays when a mon is loaded
+## and not when a page is turned. Emitted rather than played: the audio player
+## belongs to whoever embedded this.
+signal cry_requested(species: int)
+
+const PINK_PAGE: int = Gen2StatsScreenPage.PINK_PAGE
+const BLUE_PAGE: int = Gen2StatsScreenPage.BLUE_PAGE
+
+var _data: GameData = null
+var _mons: Array = []
+var _cursor: int = 0
+## `wStatsScreenFlags`' page bits, `StatsScreenMain` opening on `PINK_PAGE`.
+var _page: int = PINK_PAGE
+
+
+static func create(data: GameData, mons: Array, cursor: int = 0) -> Gen2MonStatsScreen:
+	var out := Gen2MonStatsScreen.new()
+	out._data = data
+	out._mons = mons
+	out._cursor = clampi(cursor, 0, maxi(mons.size() - 1, 0))
+	return out
+
+
+## `MonStatsInit` reaches `StatsScreen_PlaceFrontpic`, which plays the cry unless
+## the Pokémon is an egg or `CheckFaintedFrzSlp` answers yes. Called by the host
+## once the screen is up, and again by [method handle_button] on every UP or DOWN.
+func announce() -> void:
+	var mon: Gen2SaveMon = current()
+	if mon == null or mon.is_egg:
+		return
+	if mon.hp <= 0 or Gen2Status.has(mon.status, Gen2Status.FREEZE) \
+		or Gen2Status.is_asleep(mon.status):
+		return
+	cry_requested.emit(mon.species)
+
+
+func current() -> Gen2SaveMon:
+	if _cursor < 0 or _cursor >= _mons.size():
+		return null
+	return _mons[_cursor] as Gen2SaveMon
+
+
+func cursor() -> int:
+	return _cursor
+
+
+## `StatsScreen_JoypadAction`. Returns whether the button was used.
+func handle_button(button: int) -> bool:
+	## `EggStatsJoypad` masks the joypad down to `PAD_DOWN | PAD_UP | PAD_A |
+	## PAD_B` before it reaches the same action, and answers A with the exit
+	## rather than with a page: an egg has no pages to turn.
+	var egg: bool = current() != null and current().is_egg
+	match button:
+		Gen2Button.B:
+			closed.emit()
+			return true
+		Gen2Button.A:
+			if egg or _page == BLUE_PAGE:
+				closed.emit()
+				return true
+			_turn_page(1)
+			return true
+		Gen2Button.RIGHT:
+			if egg:
+				return false
+			_turn_page(1)
+			return true
+		Gen2Button.LEFT:
+			if egg:
+				return false
+			_turn_page(-1)
+			return true
+		Gen2Button.UP:
+			return _move_cursor(-1)
+		Gen2Button.DOWN:
+			return _move_cursor(1)
+	return false
+
+
+## `.d_right` and `.d_left`: the pages wrap in both directions, and a page change
+## reloads the lower half without reloading the Pokémon.
+func _turn_page(delta: int) -> void:
+	_page = wrapi(_page - PINK_PAGE + delta, 0, Gen2StatsScreenPage.NUM_PAGES) + PINK_PAGE
+
+
+## `.d_up` and `.d_down`: neither wraps, and the row the party menu is left on
+## follows the one this screen lands on (`wPartyMenuCursor`).
+func _move_cursor(delta: int) -> bool:
+	var next: int = _cursor + delta
+	if next < 0 or next >= _mons.size():
+		return false
+	_cursor = next
+	announce()
+	return true
+
+
+## Everything [Gen2StatsScreenPage] draws, for the member the cursor is on.
+func snapshot() -> Dictionary:
+	var mon: Gen2SaveMon = current()
+	if mon == null or _data == null:
+		return {"egg": true, "page": _page, "egg_message": ""}
+	if mon.is_egg:
+		## `wTempMonHappiness` holds an egg's remaining step count rather than a
+		## happiness value, which is what `EggStatsScreen` reads it as.
+		return {
+			"egg": true,
+			"page": _page,
+			"species": mon.species,
+			"egg_message": Gen2StatsScreenPage.egg_message(mon.happiness),
+		}
+
+	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
+	var species: Dictionary = _data.species(mon.species)
+	var out: Dictionary = {
+		"egg": false,
+		"page": _page,
+		"species": mon.species,
+		"dex_number": mon.species,
+		"species_name": String(species.get("name", "")),
+		"nickname": mon.nickname if not mon.nickname.is_empty() \
+			else String(species.get("name", "")),
+		"level": mon.level,
+		"gender": Gen2BattleMon.gender_for(_data, mon.species, mon.dvs),
+		"shiny": Gen2Stats.is_shiny(mon.dvs),
+		"hp": mon.hp,
+		"max_hp": battle_mon.max_hp() if battle_mon != null else 0,
+		"status": mon.status,
+		"fainted": mon.hp <= 0,
+		"pokerus": mon.pokerus,
+		"types": _types(species),
+		"item_name": _data.item_name(mon.item) if mon.item != 0 \
+			else Gen2StatsScreenPage.THREE_DASHES,
+		"moves": _moves(mon),
+		"ot_id": mon.ot_id,
+		"ot_name": mon.original_trainer,
+		## `.PlaceOTInfo` reads the whole caught-data byte, which this save model
+		## splits into a gender bit and a location.
+		"caught_gender": (mon.caught_gender << 7) | mon.caught_location,
+		"stats": battle_mon.stats if battle_mon != null else {},
+	}
+	out.merge(_experience(mon))
+	return out
+
+
+## `PrintMonTypes`: a single-typed species really carries the same type twice and
+## the second line is erased rather than printed.
+func _types(species: Dictionary) -> Array:
+	var pair: Array = species.get("types", [0, 0])
+	var first: int = int(pair[0])
+	var second: int = int(pair[1]) if pair.size() > 1 else first
+	var out: Array = [_data.type_name(first)]
+	if second != first:
+		out.append(_data.type_name(second))
+	return out
+
+
+## `ListMoves` and `ListMovePP` over `wTempMonMoves`: an empty slot ends the list
+## and the page draws dashes for the rest.
+func _moves(mon: Gen2SaveMon) -> Array:
+	var out: Array = []
+	for slot: int in mon.moves.size():
+		var number: int = int(mon.moves[slot])
+		if number <= 0:
+			break
+		var record: Dictionary = _data.move(number)
+		out.append({
+			"name": String(record.get("name", "")),
+			"pp": int(mon.pp[slot]) if slot < mon.pp.size() else 0,
+			## `GetMaxPPOfMove` adds the PP Up bits, which this save model masks
+			## off when it reads a party struct, so the base is the maximum.
+			"max_pp": int(record.get("pp", 0)),
+		})
+	return out
+
+
+## `.PrintNextLevel` and `.CalcExpToNextLevel`, which both leave a level 100
+## Pokémon where it is: the next level is 100 again and the debt is zero.
+func _experience(mon: Gen2SaveMon) -> Dictionary:
+	var rate: int = int(
+		_data.species(mon.species).get("growth_rate", Gen2Experience.GROWTH_MEDIUM_FAST)
+	)
+	if mon.level >= Gen2Experience.MAX_LEVEL:
+		return {
+			"exp": mon.exp,
+			"next_level": Gen2Experience.MAX_LEVEL,
+			"exp_to_next": 0,
+			"exp_pixels": Gen2ExpBarAnimation.LENGTH_PX,
+		}
+	return {
+		"exp": mon.exp,
+		"next_level": mon.level + 1,
+		"exp_to_next": maxi(Gen2Experience.total_exp_at(rate, mon.level + 1) - mon.exp, 0),
+		"exp_pixels": Gen2ExpBarAnimation.pixels_for(rate, mon.level, mon.exp),
+	}

--- a/game/save/mon_stats_screen.gd.uid
+++ b/game/save/mon_stats_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cssibxuk53vqj

--- a/game/save/move_screen.gd
+++ b/game/save/move_screen.gd
@@ -1,0 +1,183 @@
+class_name Gen2MoveScreen
+extends RefCounted
+
+## The move screen's model (`MoveScreenLoop` in `engine/pokemon/mon_menu.asm`):
+## which member of the party is shown, which of its moves the cursor is on, and
+## which one is being moved. [Gen2MoveScreenPage] draws the answer.
+##
+## `ManagePokemonMoves` is opened over the party menu and hands control back on
+## the way out, so this owns no nodes, exactly like [Gen2MonStatsScreen]. The two
+## moves that trade places trade their PP with them, which is `.place_move`
+## copying `wPartyMon1Moves` and `wPartyMon1PP` in the same shape.
+
+## `.exit`, which is B with nothing held.
+signal closed
+## `PlayClickSFX` on every press this screen answers, and `SFX_SWITCH_POKEMON`
+## twice once two moves have traded places.
+signal sfx_requested(index: int)
+
+## `constants/sfx_constants.asm`.
+const SFX_READ_TEXT_2: int = 0x02
+const SFX_SWITCH_POKEMON: int = Gen2PartyScreen.SFX_SWITCH_POKEMON
+
+var _data: GameData = null
+var _party: Array = []
+var _cursor: int = 0
+## `wMenuCursorY` less one: the row the arrow is on.
+var _row: int = 0
+## `wSwappingMove` less one: the row being moved, or -1 when nothing is held.
+var _held: int = -1
+
+
+static func create(data: GameData, party: Array, cursor: int = 0) -> Gen2MoveScreen:
+	var out := Gen2MoveScreen.new()
+	out._data = data
+	out._party = party
+	out._cursor = clampi(cursor, 0, maxi(party.size() - 1, 0))
+	return out
+
+
+func current() -> Gen2SaveMon:
+	if _cursor < 0 or _cursor >= _party.size():
+		return null
+	return _party[_cursor] as Gen2SaveMon
+
+
+func cursor() -> int:
+	return _cursor
+
+
+## `MoveScreenLoop`'s joypad block, which `ScrollingMenuJoypad` has already
+## narrowed to the control pad, A and B. Returns whether the button was used.
+func handle_button(button: int) -> bool:
+	match button:
+		Gen2Button.B:
+			sfx_requested.emit(SFX_READ_TEXT_2)
+			## `.b_button`: a held move is put back where it came from and the
+			## screen stays up; nothing held is the way out.
+			if _held >= 0:
+				_row = _held
+				_held = -1
+				return true
+			closed.emit()
+			return true
+		Gen2Button.A:
+			sfx_requested.emit(SFX_READ_TEXT_2)
+			if _held < 0:
+				_held = _row
+				return true
+			_swap(_held, _row)
+			_held = -1
+			return true
+		Gen2Button.UP:
+			return _move_row(-1)
+		Gen2Button.DOWN:
+			return _move_row(1)
+		Gen2Button.LEFT:
+			return _cycle(-1)
+		Gen2Button.RIGHT:
+			return _cycle(1)
+	return false
+
+
+## `Load2DMenuData`'s own wrap: the list is a single column of `wNumMoves + 1`
+## rows and the cursor runs round it.
+func _move_row(delta: int) -> bool:
+	var rows: int = _move_count()
+	if rows <= 0:
+		return false
+	_row = wrapi(_row + delta, 0, rows)
+	return true
+
+
+## `.cycle_right` and `.cycle_left`: a step past either end and a step onto an
+## egg both turn round, so the screen never lands on a member it cannot list.
+## `.d_left` and `.d_right` refuse outright while a move is held.
+func _cycle(delta: int) -> bool:
+	if _held >= 0:
+		return false
+	var found: int = _next_listable(delta)
+	if found < 0 or found == _cursor:
+		return false
+	_cursor = found
+	_row = 0
+	return true
+
+
+## Whether there is a member that way worth an arrow, which is what
+## `PlaceMoveScreenLeftArrow` and its sibling walk the party for.
+func has_neighbour(delta: int) -> bool:
+	var found: int = _next_listable(delta)
+	return found >= 0 and found != _cursor
+
+
+func _next_listable(delta: int) -> int:
+	var at: int = _cursor + delta
+	while at >= 0 and at < _party.size():
+		var mon: Gen2SaveMon = _party[at] as Gen2SaveMon
+		if mon != null and not mon.is_egg:
+			return at
+		at += delta
+	return -1
+
+
+func _move_count() -> int:
+	var mon: Gen2SaveMon = current()
+	if mon == null:
+		return 0
+	var count: int = 0
+	for move: Variant in mon.moves:
+		if int(move) <= 0:
+			break
+		count += 1
+	return count
+
+
+## `.place_move`: the two rows trade their move and their PP together, and the
+## same row twice is a swap with itself, which the source performs and which
+## changes nothing.
+func _swap(from: int, to: int) -> void:
+	var mon: Gen2SaveMon = current()
+	if mon == null or from == to:
+		return
+	var move: int = int(mon.moves[from])
+	mon.moves[from] = mon.moves[to]
+	mon.moves[to] = move
+	var pp: int = int(mon.pp[from])
+	mon.pp[from] = mon.pp[to]
+	mon.pp[to] = pp
+	## `.swap_moves` plays the same effect twice, waiting for each.
+	sfx_requested.emit(SFX_SWITCH_POKEMON)
+	sfx_requested.emit(SFX_SWITCH_POKEMON)
+
+
+## Everything [Gen2MoveScreenPage] draws.
+func snapshot() -> Dictionary:
+	var mon: Gen2SaveMon = current()
+	if mon == null or _data == null:
+		return {"moves": [], "cursor": 0, "held": -1}
+	var moves: Array = []
+	for slot: int in mon.moves.size():
+		var number: int = int(mon.moves[slot])
+		if number <= 0:
+			break
+		var record: Dictionary = _data.move(number)
+		moves.append({
+			"name": String(record.get("name", "")),
+			"pp": int(mon.pp[slot]) if slot < mon.pp.size() else 0,
+			"max_pp": int(record.get("pp", 0)),
+			"power": int(record.get("power", 0)),
+			"type_name": _data.type_name(int(record.get("type", 0))),
+			"description": String(record.get("description", "")),
+		})
+	return {
+		"species": mon.species,
+		"nickname": mon.nickname if not mon.nickname.is_empty() \
+			else String(_data.species(mon.species).get("name", "")),
+		"level": mon.level,
+		"moves": moves,
+		"cursor": clampi(_row, 0, maxi(moves.size() - 1, 0)),
+		"held": _held,
+		"previous": has_neighbour(-1),
+		"next": has_neighbour(1),
+	}

--- a/game/save/move_screen.gd.uid
+++ b/game/save/move_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://qt3r8b7x8t7b

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -25,6 +25,9 @@ signal action_chosen(action: Dictionary)
 ## A sound this screen owes, by `constants/sfx_constants.asm` index. Emitted
 ## rather than played: the audio player belongs to whoever embedded this.
 signal sfx_requested(index: int)
+## `PlayMonCry2`, which the stats screen this menu opens plays on every mon it
+## loads. Emitted for the same reason [signal sfx_requested] is.
+signal cry_requested(species: int)
 
 const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
@@ -127,6 +130,13 @@ var _menu_page: Gen2MenuPage = null
 ## clears. See [constant MESSAGE_NOT_ENOUGH_HP].
 var _message: String = ""
 var _elapsed: float = 0.0
+## `OpenPartyStats`' own screen, standing over the whole party menu while it is
+## up, and the page that draws it.
+var _stats: Gen2MonStatsScreen = null
+var _stats_page: Gen2StatsScreenPage = null
+## `ManagePokemonMoves`' own screen, opened the same way over the same menu.
+var _moves: Gen2MoveScreen = null
+var _moves_page: Gen2MoveScreenPage = null
 
 
 func _ready() -> void:
@@ -158,6 +168,8 @@ func set_context(data: GameData, save: Gen2SaveData, embedded: bool = false) -> 
 	_submenu_items = []
 	_submenu_cursor = 0
 	_switch_from = -1
+	_stats = null
+	_moves = null
 	if is_inside_tree() and _cards != null:
 		_refresh()
 
@@ -181,10 +193,9 @@ func party_snapshot() -> Dictionary:
 ##
 ## An egg gets three entries and no moves. Otherwise the four move slots are
 ## walked in the mon's own slot order, appending every move that appears in
-## MonMenuOptions' field-move rows, then the fixed options follow. Only entries
-## this project acts on are marked available; the rest keep their source
-## position rather than being omitted, the same way Gen2WorldStartMenu carries
-## its unimplemented entries.
+## MonMenuOptions' field-move rows, then the fixed options follow. Every row is
+## acted on: the screens STATS and MOVE open are built, so a row that cannot be
+## chosen no longer exists here.
 ##
 ## The MAIL branch is not reproduced: ItemIsMail tests the held item against
 ## data/items/mail_items.asm, and this project has no mail, so ITEM is always
@@ -204,7 +215,7 @@ static func submenu_items_for(
 	## nothing to follow, teach or send out, and the source itself offers less.
 	if mon.is_egg:
 		items.append(_option_entry(OPTION_STATS, "STATS"))
-		items.append(_option_entry(OPTION_SWITCH, "SWITCH", true))
+		items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
 		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
 		return items
 	for move: int in mon.moves:
@@ -214,14 +225,13 @@ static func submenu_items_for(
 			"kind": &"field_move",
 			"move": move,
 			"label": String(data.move(move).get("name", "MOVE")) if data != null else "MOVE",
-			"available": true,
 		})
 	items.append(_option_entry(OPTION_STATS, "STATS"))
 	## `SwitchPartyMons` makes its own `cp 2` refusal rather than being greyed
 	## out, so the row is offered whatever the party holds.
-	items.append(_option_entry(OPTION_SWITCH, "SWITCH", true))
+	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
 	items.append(_option_entry(OPTION_MOVE, "MOVE"))
-	items.append(_option_entry(OPTION_ITEM, "ITEM", true))
+	items.append(_option_entry(OPTION_ITEM, "ITEM"))
 	## After every cartridge action and before CANCEL, which is the source's own
 	## last row and the way out of the box. A mod cannot displace one: the list
 	## still stops at `NUM_MONMENU_ITEMS`, so rows past it are simply not offered.
@@ -230,17 +240,15 @@ static func submenu_items_for(
 			break
 		items.append({
 			"kind": &"mod_party_action", "mod": entry["kind"],
-			"label": entry["label"], "handler": entry["handler"], "available": true,
+			"label": entry["label"], "handler": entry["handler"],
 		})
 	if items.size() < MAX_SUBMENU_ITEMS:
 		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
 	return items
 
 
-static func _option_entry(
-	option: StringName, label: String, available: bool = false
-) -> Dictionary:
-	return {"kind": &"option", "option": option, "label": label, "available": available}
+static func _option_entry(option: StringName, label: String) -> Dictionary:
+	return {"kind": &"option", "option": option, "label": label}
 
 
 ## `GiveTakeItemMenuData`, the two-row box ITEM opens. Both answers need the live
@@ -248,8 +256,8 @@ static func _option_entry(
 ## field move is.
 static func item_menu_items() -> Array:
 	return [
-		{"kind": &"mon_item", "option": OPTION_GIVE, "label": "GIVE", "available": true},
-		{"kind": &"mon_item", "option": OPTION_TAKE, "label": "TAKE", "available": true},
+		{"kind": &"mon_item", "option": OPTION_GIVE, "label": "GIVE"},
+		{"kind": &"mon_item", "option": OPTION_TAKE, "label": "TAKE"},
 	]
 
 
@@ -260,6 +268,18 @@ func _party_size() -> int:
 ## Button driver for the embedded overworld view, mirroring
 ## Gen2StartMenuScreen.handle_button. Returns whether the button was used.
 func handle_button(button: int) -> bool:
+	## `StatsScreenInit` runs its own joypad loop over the whole screen, so
+	## nothing below it is reachable while it is up.
+	if _stats != null:
+		var used: bool = _stats.handle_button(button)
+		if _stats != null:
+			_refresh()
+		return used
+	if _moves != null:
+		var used_move: bool = _moves.handle_button(button)
+		if _moves != null:
+			_refresh()
+		return used_move
 	## `JoyWaitAorB` behind a refusal: the press that clears the box does nothing
 	## else, and a direction is not one of the two it waits for.
 	if not _message.is_empty():
@@ -337,9 +357,6 @@ func _confirm() -> void:
 	if StringName(entry.get("option", &"")) == OPTION_CANCEL:
 		_close_submenu()
 		return
-	if not bool(entry.get("available", false)):
-		_say("%s is not available yet." % String(entry.get("label", "")))
-		return
 	match StringName(entry.get("kind", &"")):
 		&"field_move":
 			var move: int = int(entry.get("move", 0))
@@ -376,6 +393,62 @@ func _confirm() -> void:
 					_open_item_menu()
 				OPTION_SWITCH:
 					_begin_switch()
+				OPTION_STATS:
+					_open_stats()
+				OPTION_MOVE:
+					_open_moves()
+
+
+## `MonMenu_Stats` reaches `OpenPartyStats`, which is `StatsScreenInit` over the
+## whole party menu. It answers 0, which is `.choosemenu`: the list comes back
+## with the submenu shut and the prompt reset, on whichever row the stats screen
+## was left on.
+func _open_stats() -> void:
+	if _data == null or _save == null or _member_cursor >= _party_size():
+		return
+	_stats = Gen2MonStatsScreen.create(_data, _save.party, _member_cursor)
+	_stats.closed.connect(_close_stats)
+	_stats.cry_requested.connect(cry_requested.emit)
+	## `StatsScreenInit` clears the tilemap before it draws, so the submenu is
+	## gone rather than standing behind the screen.
+	_submenu_open = false
+	_item_menu_open = false
+	_stats.announce()
+	_refresh()
+
+
+## `MonMenu_Move` reaches `ManagePokemonMoves`, which answers 0 for the same
+## `.choosemenu` STATS answers with, and refuses an egg outright.
+func _open_moves() -> void:
+	if _data == null or _save == null or _member_cursor >= _party_size():
+		return
+	var mon: Gen2SaveMon = _save.party[_member_cursor]
+	if mon == null or mon.is_egg:
+		_close_submenu()
+		return
+	_moves = Gen2MoveScreen.create(_data, _save.party, _member_cursor)
+	_moves.closed.connect(_close_moves)
+	_moves.sfx_requested.connect(sfx_requested.emit)
+	## `SetUpMoveScreenBG`'s own `ClearTilemap`, as above.
+	_submenu_open = false
+	_item_menu_open = false
+	_refresh()
+
+
+func _close_moves() -> void:
+	if _moves == null:
+		return
+	_member_cursor = clampi(_moves.cursor(), 0, _row_count() - 1)
+	_moves = null
+	_close_submenu()
+
+
+func _close_stats() -> void:
+	if _stats == null:
+		return
+	_member_cursor = clampi(_stats.cursor(), 0, _row_count() - 1)
+	_stats = null
+	_close_submenu()
 
 
 func _cancel() -> void:
@@ -532,11 +605,8 @@ func _render_submenu() -> void:
 	for index: int in _submenu_items.size():
 		var entry: Dictionary = _submenu_items[index]
 		var label := Label.new()
-		var text: String = String(entry.get("label", ""))
-		if not bool(entry.get("available", false)) \
-			and StringName(entry.get("option", &"")) != OPTION_CANCEL:
-			text = "%s (unavailable)" % text
-		label.text = ("> " if index == _submenu_cursor else "  ") + text
+		label.text = ("> " if index == _submenu_cursor else "  ") \
+			+ String(entry.get("label", ""))
 		label.add_theme_color_override("font_color", ACCENT if index == _submenu_cursor else TEXT)
 		label.add_theme_font_size_override("font_size", 18)
 		_submenu.add_child(label)
@@ -576,12 +646,22 @@ func _process(delta: float) -> void:
 	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
 		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
 		frames += 1
-	if frames == 0 or _submenu_open or _item_menu_open:
+	if frames == 0 or _submenu_open or _item_menu_open or _stats != null:
+		return
+	if _moves != null:
+		for _icon_frame: int in frames:
+			_moves_page_advance()
+		_render_hardware()
 		return
 	var rows: Array = _rows()
 	for _frame: int in frames:
 		_page.advance(rows, _cursor_row())
 	_render_hardware()
+
+
+func _moves_page_advance() -> void:
+	if _moves_page != null:
+		_moves_page.advance()
 
 
 ## `WritePartyMenuTilemap`'s rows, in [Gen2BattleSwitchMenu]'s own shape plus the
@@ -622,6 +702,12 @@ func _prompt() -> String:
 func _render_hardware() -> void:
 	if _view == null or _data == null:
 		return
+	if _stats != null:
+		_render_stats()
+		return
+	if _moves != null:
+		_render_moves()
+		return
 	if _page == null:
 		_page = Gen2PartyMenuPage.from_data(_data)
 	if _menu_page == null:
@@ -644,6 +730,57 @@ func _render_hardware() -> void:
 	_view.texture = ImageTexture.create_from_image(image)
 
 
+## `StatsScreenInit`'s own screen, over the party menu rather than beside it. The
+## front pic has a palette of its own, so it is composed on top the way a party
+## icon is rather than written into the page's index buffer.
+func _render_stats() -> void:
+	if _stats_page == null:
+		_stats_page = Gen2StatsScreenPage.from_data(_data)
+	if _stats_page == null:
+		return
+	var snapshot: Dictionary = _stats.snapshot()
+	var image: Image = _stats_page.render(snapshot, _data)
+	_blend_stats_pic(image, snapshot)
+	_view.texture = ImageTexture.create_from_image(image)
+
+
+## `MoveScreenLoop`'s own screen, which steps its one mon icon per frame the way
+## the party list steps six.
+func _render_moves() -> void:
+	if _moves_page == null:
+		_moves_page = Gen2MoveScreenPage.from_data(_data)
+	if _moves_page == null:
+		return
+	_view.texture = ImageTexture.create_from_image(
+		_moves_page.render(_moves.snapshot(), _data)
+	)
+
+
+## `PrepMonFrontpic` centres a seven-tile cell on `hlcoord 0, 0` and sits a
+## smaller pic on its bottom, which is what the Pokedex and the Hall of Fame do
+## with the same cell.
+func _blend_stats_pic(image: Image, snapshot: Dictionary) -> void:
+	var species: int = int(snapshot.get("species", 0))
+	if species <= 0:
+		return
+	var pic: Dictionary = _data.species_pic(species)
+	if pic.is_empty():
+		return
+	var art: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.palette(species, bool(snapshot.get("shiny", false)))
+	)
+	if art == null:
+		return
+	var cell: int = Gen2StatsScreenPage.pic_size()
+	var at: Vector2i = Gen2StatsScreenPage.pic_position()
+	@warning_ignore("integer_division")
+	var origin := Vector2i(
+		at.x + (cell - art.get_width()) / 2, at.y + cell - art.get_height()
+	)
+	image.blit_rect(art, Rect2i(Vector2i.ZERO, art.get_size()), origin)
+
+
 ## `.GetTopCoord` for the mon's own submenu, and `GiveTakeItemMenuData`'s fixed
 ## box for the GIVE/TAKE it opens.
 func _submenu_box() -> Gen2MenuBox:
@@ -658,10 +795,7 @@ func _submenu_box() -> Gen2MenuBox:
 	)
 
 
-## `PopulateMonMenu` places the option strings themselves. The "(unavailable)"
-## the panel appends is the launcher's affordance and has no room in a box the
-## cartridge sized for a name, so an option this project does not act on says so
-## when it is chosen instead.
+## `PopulateMonMenu` places the option strings themselves.
 func _submenu_labels() -> Array:
 	var out: Array = []
 	for entry: Variant in _submenu_items:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2913,6 +2913,9 @@ func _open_embedded_party() -> void:
 	host.closed.connect(_on_party_closed)
 	host.action_chosen.connect(_on_party_action)
 	host.sfx_requested.connect(_play_sfx)
+	## `OpenPartyStats`' `PlayMonCry2` reaches the same player the Pokedex's own
+	## CRY button does.
+	host.cry_requested.connect(_on_pokedex_cry_requested)
 	_party_host = host
 	_script_prompt = "Party open"
 	_refresh_labels()

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1114,21 +1114,24 @@ func test_the_cancel_row_closes_the_menu_the_way_b_does() -> void:
 
 ## A refusal stands in the menu's own bottom box and `JoyWaitAorB` holds there:
 ## a direction does not answer it and the next A or B does nothing but clear it.
+## `.SelectMilkDrinkRecipient`'s `.cant_use` is the one that loops back to the
+## recipient list rather than closing anything, so the list is still up after it.
 func test_a_refusal_holds_the_menu_until_a_or_b() -> void:
-	await _open_world()
+	await _open_world(true, Gen2WorldFieldMove.MOVE_SOFTBOILED)
 	var party: Gen2PartyScreen = await _open_party()
+	## SOFTBOILED is the first row, being the only move the member knows.
 	party.handle_button(Gen2Button.A)
-	## STATS, the first row this project does not act on.
-	party.handle_button(Gen2Button.DOWN)
+	party.handle_button(Gen2Button.A)
+	assert_false(bool(party.submenu_snapshot()["open"]), "the recipient list is open")
+	## `.cant_use`: a member cannot give its own health to itself.
 	party.handle_button(Gen2Button.A)
 	var refused: Dictionary = party.submenu_snapshot()
-	assert_ne(String(refused["message"]), "", "the refusal is in the box")
-
+	assert_eq(String(refused["message"]), Gen2PartyScreen.MESSAGE_NO_EFFECT)
 	assert_false(party.handle_button(Gen2Button.DOWN), "a direction is not one of the two")
-	assert_eq(int(party.submenu_snapshot()["cursor"]), int(refused["cursor"]))
+	assert_eq(int(party.submenu_snapshot()["member"]), int(refused["member"]))
 	assert_true(party.handle_button(Gen2Button.B))
 	assert_eq(String(party.submenu_snapshot()["message"]), "")
-	assert_true(bool(party.submenu_snapshot()["open"]), "and the submenu is still up")
+	assert_not_null(_world_screen._party_host, "and the party menu is still up")
 
 
 ## A mod's party-member rows land after every cartridge action and before CANCEL,

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -47,6 +47,9 @@ func _write_cache() -> void:
 		"player_hud": RomLayout.PLAYER_HUD_TILES,
 		"font": RomLayout.FONT_TILES,
 		"frames": RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES,
+		## Only the stats and move screens read this one, and both are drawn from
+		## the same cache the party menu is.
+		"stats_tiles": RomLayout.STATS_TILES,
 	}
 	var first_codes: Dictionary = {
 		"font": RomLayout.FONT_FIRST_CODE, "frames": RomLayout.FRAME_FIRST_CODE,
@@ -368,3 +371,182 @@ func test_an_egg_takes_the_egg_icon_rather_than_its_species_own() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	assert_eq(data.mon_menu_icon(FIXTURE_SPECIES), FIXTURE_ICON)
 	assert_eq(data.mon_menu_icon(FIXTURE_SPECIES, true), RomLayout.ICON_EGG)
+
+
+## `StatsScreen_LoadFont`'s page, which the stats and move screens share: the
+## same tiles as a battle's plus `LoadStatsScreenPageTilesGFX`' seventeen at $31,
+## and the player HUD's border scattered rather than copied whole, which leaves
+## $73 to $75 as the battle-extra font's own.
+func test_the_stats_page_reaches_further_down_than_a_battles() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var tiles: Gen2BattleTiles = Gen2BattleTiles.stats_page(data)
+	assert_not_null(tiles)
+	var buffer: PackedByteArray = PackedByteArray()
+	buffer.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	for tile: int in [
+		Gen2BattleTiles.STATS_DIVIDER, Gen2BattleTiles.SHINY,
+		Gen2BattleTiles.EXP_BAR_LEFT_CAP, Gen2BattleTiles.HP_BAR_EMPTY,
+	]:
+		buffer.fill(0)
+		tiles.draw(tile, buffer, Gen2Screen.WIDTH, 0, 0)
+		assert_ne(buffer[0], 0, "tile $%02X is on the page" % tile)
+	## A battle's own page starts at $55, so the stats sheet is out of its reach.
+	buffer.fill(0)
+	Gen2BattleTiles.from_data(data).draw(
+		Gen2BattleTiles.STATS_DIVIDER, buffer, Gen2Screen.WIDTH, 0, 0
+	)
+	assert_eq(buffer[0], 0, "and off a battle's")
+
+
+func _stats_page() -> Gen2StatsScreenPage:
+	return Gen2StatsScreenPage.from_data(GameData.open_directory(_directory))
+
+
+func _stats_image(page: Dictionary) -> Image:
+	return Gen2PicImage.from_indices(
+		_stats_page().draw(page), Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+
+
+func _stats_snapshot(page: int) -> Dictionary:
+	return {
+		"egg": false, "page": page, "species": FIXTURE_SPECIES, "dex_number": 25,
+		"species_name": "PIKACHU", "nickname": "SPARKY", "level": 20,
+		"gender": Gen2BattleMon.GENDER_MALE, "shiny": false,
+		"hp": 18, "max_hp": 20, "status": 0, "fainted": false, "pokerus": 0,
+		"types": ["ELECTRIC"], "item_name": "---",
+		"moves": [{"name": "TACKLE", "pp": 35, "max_pp": 35}],
+		"ot_id": 1234, "ot_name": "RED", "caught_gender": 0,
+		"stats": {"attack": 30, "defense": 20, "sp_attack": 25, "sp_defense": 25, "speed": 40},
+		"exp": 8000, "next_level": 21, "exp_to_next": 200, "exp_pixels": 32,
+	}
+
+
+## `StatsScreen_InitUpperHalf` draws the same seven rows whichever page is open,
+## and `StatsScreen_PlaceHorizontalDivider` closes them with a full-width run.
+func test_the_stats_upper_half_is_the_same_on_every_page() -> void:
+	for page: int in [
+		Gen2StatsScreenPage.PINK_PAGE, Gen2StatsScreenPage.GREEN_PAGE,
+		Gen2StatsScreenPage.BLUE_PAGE,
+	]:
+		var image: Image = _stats_image(_stats_snapshot(page))
+		assert_ne(
+			_ink_in_tile(image, Gen2StatsScreenPage.NICKNAME.x, Gen2StatsScreenPage.NICKNAME.y),
+			0, "the nickname on page %d" % page
+		)
+		for column: int in [0, 19]:
+			assert_ne(
+				_ink_in_tile(image, column, Gen2StatsScreenPage.DIVIDER_ROW), 0,
+				"the divider spans column %d" % column
+			)
+
+
+## `StatsScreen_LoadPageIndicators`: three 2x2 blocks at (13,5), (15,5) and
+## (17,5), whichever page is open. Which of the two squares each block is drawn
+## from is a tile number rather than a shape, and every sheet in this fixture is
+## filled with one index, so only where they land is readable here.
+func test_every_page_indicator_is_a_two_by_two_block() -> void:
+	var image: Image = _stats_image(_stats_snapshot(Gen2StatsScreenPage.PINK_PAGE))
+	for at: Vector2i in Gen2StatsScreenPage.PAGE_INDICATORS:
+		for quadrant: int in 4:
+			@warning_ignore("integer_division")
+			assert_ne(
+				_ink_in_tile(image, at.x + quadrant % 2, at.y + quadrant / 2), 0,
+				"the block at %s" % at
+			)
+	assert_eq(
+		_ink_in_tile(image, Gen2StatsScreenPage.PAGE_INDICATORS[0].x - 1, 5), 0,
+		"and nothing beside the first of them"
+	)
+
+
+## Each page fills the ten rows under the divider and nothing above it, which is
+## `.ClearBox`'s `hlcoord 0, 8` with `lb bc, 10, 20`.
+func test_each_page_writes_its_own_lower_half() -> void:
+	var pink: Image = _stats_image(_stats_snapshot(Gen2StatsScreenPage.PINK_PAGE))
+	assert_ne(
+		_ink_in_tile(pink, Gen2StatsScreenPage.HP_BAR.x, Gen2StatsScreenPage.HP_BAR.y), 0,
+		"the pink page's HP bar"
+	)
+	assert_ne(
+		_ink_in_tile(pink, Gen2StatsScreenPage.PINK_DIVIDER_COLUMN, 17), 0,
+		"and its divider reaches the last row"
+	)
+	assert_ne(
+		_ink_in_tile(pink, Gen2StatsScreenPage.TYPE_LABEL.x, Gen2StatsScreenPage.TYPE_LABEL.y),
+		0, "and its TYPE/ label"
+	)
+	var blue: Image = _stats_image(_stats_snapshot(Gen2StatsScreenPage.BLUE_PAGE))
+	assert_eq(
+		_ink_in_tile(blue, Gen2StatsScreenPage.TYPE_LABEL.x, Gen2StatsScreenPage.TYPE_LABEL.y),
+		0, "which the blue page does not draw"
+	)
+	## `PrintTempMonStats` at (11,8) with a spacing of six: five names down one
+	## column and five numbers three columns from the right-hand edge.
+	assert_ne(
+		_ink_in_tile(blue, Gen2StatsScreenPage.STAT_NAMES_AT.x, 16), 0, "SPEED"
+	)
+	## `PrintNum`'s three digits are space padded and a space draws nothing, so a
+	## two-digit stat leaves the first of the three columns blank.
+	assert_eq(_ink_in_tile(blue, 17, 17), 0, "the number's own padding")
+	assert_ne(_ink_in_tile(blue, 18, 17), 0, "and the number beside it")
+
+
+## `ListMoves` and `.nonmove_loop`: a slot with no move draws one dash for the
+## name and `.load_loop` writes two where its PP would go.
+func test_an_empty_move_slot_draws_dashes_on_the_green_page() -> void:
+	var image: Image = _stats_image(_stats_snapshot(Gen2StatsScreenPage.GREEN_PAGE))
+	var names: Vector2i = Gen2StatsScreenPage.MOVES_AT
+	var pp: Vector2i = Gen2StatsScreenPage.MOVE_PP_AT
+	assert_ne(_ink_in_tile(image, names.x, names.y), 0, "the one move it knows")
+	assert_ne(_ink_in_tile(image, pp.x, pp.y), 0, "and its PP label")
+	assert_ne(_ink_in_tile(image, names.x, names.y + 2), 0, "the dash under it")
+	assert_eq(_ink_in_tile(image, names.x + 1, names.y + 2), 0, "which is one tile wide")
+
+
+## `MoveScreen2DMenuData`'s `db 3, 1` and `dn 2, 0`, and `.moving_move`, which
+## replaces the move's own data with `Where?` and hollows the held row's arrow.
+func test_the_move_screen_marks_the_row_it_is_holding() -> void:
+	var page: Gen2MoveScreenPage = Gen2MoveScreenPage.from_data(
+		GameData.open_directory(_directory)
+	)
+	assert_not_null(page)
+	var snapshot: Dictionary = {
+		"species": FIXTURE_SPECIES, "nickname": "SPARKY", "level": 20,
+		"moves": [
+			{"name": "TACKLE", "pp": 35, "max_pp": 35, "power": 35,
+			"type_name": "NORMAL", "description": "A charge."},
+			{"name": "GROWL", "pp": 40, "max_pp": 40, "power": 0,
+			"type_name": "NORMAL", "description": "A growl."},
+		],
+		"cursor": 1, "held": -1, "previous": false, "next": true,
+	}
+	var listed: Image = Gen2PicImage.from_indices(
+		page.draw(snapshot), Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	var second_row: int = Gen2MoveScreenPage.CURSOR_FIRST_ROW \
+		+ Gen2MoveScreenPage.CURSOR_ROW_STEP
+	assert_ne(
+		_ink_in_tile(listed, Gen2MoveScreenPage.CURSOR_COLUMN, second_row), 0,
+		"the cursor sits on the row it is over"
+	)
+	assert_ne(
+		_ink_in_tile(listed, Gen2MoveScreenPage.ATTACK_LABEL.x, Gen2MoveScreenPage.ATTACK_LABEL.y),
+		0, "and ATK/ is printed for it"
+	)
+	snapshot["held"] = 1
+	var holding: Image = Gen2PicImage.from_indices(
+		page.draw(snapshot), Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	assert_eq(
+		_ink_in_tile(
+			holding, Gen2MoveScreenPage.ATTACK_LABEL.x, Gen2MoveScreenPage.ATTACK_LABEL.y
+		), 0, "which `Where?` replaces while a move is held"
+	)
+	assert_ne(
+		_ink_in_tile(holding, Gen2MoveScreenPage.WHERE_AT.x, Gen2MoveScreenPage.WHERE_AT.y),
+		0, "with the prompt in its place"
+	)

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -700,7 +700,24 @@ func _battle_dump() -> PackedByteArray:
 	_write_hud(data, int(_layout["player_hud"]), RomLayout.PLAYER_HUD_TILES)
 	_write_bar_palettes(data)
 	_write_battle_object_palettes(data)
+	_write_stats_tiles(data)
 	return data
+
+
+## `StatsScreenPageTilesGFX`, which sits immediately before the enemy HUD: the
+## two shapes `verify_battle_graphics` reads, its two-column divider and the
+## `⁂` fourteen tiles on.
+func _write_stats_tiles(data: PackedByteArray) -> void:
+	var at: int = RomLayout.stats_tiles_offset(_layout)
+	var divider: PackedByteArray = PackedByteArray()
+	divider.resize(Gen2Tiles.TILE_BYTES)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		divider[row * 2] = 0xC0
+	_write(data, at, divider)
+	_write(
+		data, at + RomLayout.STATS_SHINY_TILE * Gen2Tiles.TILE_BYTES,
+		_lit_tile(Gen2Tiles.TILE_WIDTH)
+	)
 
 
 ## The four bar palettes, whose values are the check on where they are.
@@ -784,6 +801,25 @@ func test_a_bar_whose_levels_do_not_climb_fails() -> void:
 		int(_layout["battle_font"]) + (RomLayout.HP_BAR_FIRST_TILE + 4) * Gen2Tiles.TILE_BYTES,
 		_lit_tile(Gen2Tiles.TILE_WIDTH)
 	)
+	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
+
+
+## The stats sheet has no address of its own: it is walked back from the enemy
+## HUD, so its own two shapes are what pin it.
+func test_stats_tiles_that_are_not_where_the_enemy_hud_says_fail() -> void:
+	var data: PackedByteArray = _battle_dump()
+	data[RomLayout.stats_tiles_offset(_layout)] = 0xFF
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(String(result["message"]), "vertical divider")
+
+
+func test_stats_tiles_missing_their_shiny_icon_fail() -> void:
+	var data: PackedByteArray = _battle_dump()
+	var at: int = RomLayout.stats_tiles_offset(_layout) \
+		+ RomLayout.STATS_SHINY_TILE * Gen2Tiles.TILE_BYTES
+	for i: int in Gen2Tiles.TILE_BYTES:
+		data[at + i] = 0
 	assert_false(RomImporter.verify_battle_graphics(_rom(data), _layout)["ok"])
 
 

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -409,3 +409,137 @@ func _find_button(node: Node, label: String) -> Button:
 		if found != null:
 			return found
 	return null
+
+
+## `MonMenu_Stats` and `MonMenu_Move`, the two whole screens the party submenu
+## opens over itself. Both are models with no nodes, so they are driven here
+## rather than through the screen that embeds them.
+func test_the_stats_screen_turns_its_three_pages_and_wraps_both_ways() -> void:
+	var screen: Gen2MonStatsScreen = Gen2MonStatsScreen.create(_data, _save().party)
+	assert_eq(int(screen.snapshot()["page"]), Gen2StatsScreenPage.PINK_PAGE)
+	screen.handle_button(Gen2Button.RIGHT)
+	assert_eq(int(screen.snapshot()["page"]), Gen2StatsScreenPage.GREEN_PAGE)
+	screen.handle_button(Gen2Button.RIGHT)
+	screen.handle_button(Gen2Button.RIGHT)
+	assert_eq(int(screen.snapshot()["page"]), Gen2StatsScreenPage.PINK_PAGE)
+	screen.handle_button(Gen2Button.LEFT)
+	assert_eq(int(screen.snapshot()["page"]), Gen2StatsScreenPage.BLUE_PAGE)
+
+
+func test_the_stats_screen_leaves_on_b_and_on_a_over_its_last_page() -> void:
+	var screen: Gen2MonStatsScreen = Gen2MonStatsScreen.create(_data, _save().party)
+	watch_signals(screen)
+	screen.handle_button(Gen2Button.A)
+	screen.handle_button(Gen2Button.A)
+	assert_signal_not_emitted(screen, "closed")
+	assert_eq(int(screen.snapshot()["page"]), Gen2StatsScreenPage.BLUE_PAGE)
+	screen.handle_button(Gen2Button.A)
+	assert_signal_emitted(screen, "closed")
+
+
+## `.d_up` and `.d_down` neither wrap nor reach past the party, and each reload
+## is a `PlayMonCry2`. The first member is poisoned rather than asleep or frozen,
+## so `CheckFaintedFrzSlp` lets both cries through.
+func test_the_stats_screen_walks_the_party_without_wrapping_and_cries() -> void:
+	var screen: Gen2MonStatsScreen = Gen2MonStatsScreen.create(_data, _save_with_two().party)
+	watch_signals(screen)
+	assert_false(screen.handle_button(Gen2Button.UP))
+	assert_true(screen.handle_button(Gen2Button.DOWN))
+	assert_eq(screen.cursor(), 1)
+	assert_false(screen.handle_button(Gen2Button.DOWN))
+	assert_eq(get_signal_emit_count(screen, "cry_requested"), 1)
+
+
+## `.PrintNextLevel` and `.CalcExpToNextLevel` on the pink page: the debt is the
+## curve's own next step less what the Pokémon has.
+func test_the_pink_page_owes_the_experience_its_next_level_costs() -> void:
+	var save: Gen2SaveData = _save()
+	var mon: Gen2SaveMon = save.party[0]
+	var screen: Gen2MonStatsScreen = Gen2MonStatsScreen.create(_data, save.party)
+	var page: Dictionary = screen.snapshot()
+	var rate: int = int(_data.species(mon.species).get("growth_rate", 0))
+	assert_eq(int(page["next_level"]), mon.level + 1)
+	assert_eq(
+		int(page["exp_to_next"]),
+		Gen2Experience.total_exp_at(rate, mon.level + 1) - mon.exp
+	)
+
+
+## `EggStatsScreen`'s four hints, chosen off the step counter the egg keeps in
+## its happiness byte.
+func test_the_egg_page_picks_its_hint_off_the_step_counter() -> void:
+	assert_eq(Gen2StatsScreenPage.egg_message(0), Gen2StatsScreenPage.EGG_MESSAGES[0])
+	assert_eq(Gen2StatsScreenPage.egg_message(6), Gen2StatsScreenPage.EGG_MESSAGES[1])
+	assert_eq(Gen2StatsScreenPage.egg_message(11), Gen2StatsScreenPage.EGG_MESSAGES[2])
+	assert_eq(Gen2StatsScreenPage.egg_message(41), Gen2StatsScreenPage.EGG_MESSAGES[3])
+
+
+## `.place_move`: the two rows trade their move and their PP together, which is
+## the second `.copy_move` over `wPartyMon1PP`.
+func test_the_move_screen_trades_a_moves_pp_with_the_move() -> void:
+	var save: Gen2SaveData = _save()
+	var mon: Gen2SaveMon = save.party[0]
+	mon.pp[1] = 3
+	var before: Array = [mon.moves[0], mon.moves[1], mon.pp[0], mon.pp[1]]
+	var screen: Gen2MoveScreen = Gen2MoveScreen.create(_data, save.party)
+	screen.handle_button(Gen2Button.A)
+	screen.handle_button(Gen2Button.DOWN)
+	screen.handle_button(Gen2Button.A)
+	assert_eq(mon.moves[0], before[1])
+	assert_eq(mon.moves[1], before[0])
+	assert_eq(mon.pp[0], before[3])
+	assert_eq(mon.pp[1], before[2])
+	assert_eq(int(screen.snapshot()["held"]), -1)
+
+
+## `.b_button` with something held is `.loop` again: the cursor goes back to the
+## row that was picked up and the screen stays open.
+func test_b_puts_a_held_move_back_rather_than_leaving() -> void:
+	var save: Gen2SaveData = _save()
+	var screen: Gen2MoveScreen = Gen2MoveScreen.create(_data, save.party)
+	watch_signals(screen)
+	screen.handle_button(Gen2Button.DOWN)
+	screen.handle_button(Gen2Button.A)
+	screen.handle_button(Gen2Button.B)
+	assert_signal_not_emitted(screen, "closed")
+	assert_eq(int(screen.snapshot()["held"]), -1)
+	assert_eq(int(screen.snapshot()["cursor"]), 1)
+	screen.handle_button(Gen2Button.B)
+	assert_signal_emitted(screen, "closed")
+	assert_eq(save.party[0].moves[0], Fixture.TACKLE)
+
+
+## `.d_left` and `.d_right` return to `.joy_loop` untouched while a move is held,
+## and the arrows are only drawn for a neighbour there is one.
+func test_the_move_screen_refuses_to_change_pokemon_while_a_move_is_held() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	var screen: Gen2MoveScreen = Gen2MoveScreen.create(_data, save.party)
+	assert_false(screen.has_neighbour(-1))
+	assert_true(screen.has_neighbour(1))
+	screen.handle_button(Gen2Button.A)
+	assert_false(screen.handle_button(Gen2Button.RIGHT))
+	assert_eq(screen.cursor(), 0)
+	screen.handle_button(Gen2Button.B)
+	assert_true(screen.handle_button(Gen2Button.RIGHT))
+	assert_eq(screen.cursor(), 1)
+
+
+## `ManagePokemonMoves`' own `cp EGG`, and `MonMenuOptions`' egg row set, which
+## offers STATS and SWITCH and nothing else.
+func test_an_egg_is_offered_stats_and_switch_and_no_move_row() -> void:
+	var egg := Gen2SaveMon.new()
+	egg.is_egg = true
+	egg.species = Fixture.PIKACHU
+	var rows: Array = Gen2PartyScreen.submenu_items_for(_data, egg)
+	var options: Array = []
+	for row: Dictionary in rows:
+		options.append(StringName(row.get("option", &"")))
+	assert_eq(options, [
+		Gen2PartyScreen.OPTION_STATS, Gen2PartyScreen.OPTION_SWITCH,
+		Gen2PartyScreen.OPTION_CANCEL,
+	])
+	var screen: Gen2MonStatsScreen = Gen2MonStatsScreen.create(_data, [egg])
+	watch_signals(screen)
+	## `EggStatsJoypad` answers A with `.quit` rather than with a page.
+	screen.handle_button(Gen2Button.A)
+	assert_signal_emitted(screen, "closed")


### PR DESCRIPTION
The party submenu offered STATS and MOVE and answered both with a refusal. Neither is a branch in that box: `OpenPartyStats` is `StatsScreenInit`, its three pages and `EggStatsScreen`, and `MonMenu_Move` is `MoveScreenLoop`. Both open over the whole party menu and answer 0, which is `.choosemenu`, so the list comes back with the submenu shut on whichever row the screen was left on.

## The screens

`Gen2MonStatsScreen` and `Gen2MoveScreen` own the cursor, the pages and the held row, and no nodes: `Gen2PartyScreen` draws their snapshots and feeds them buttons, the way it already hosts its own submenu. `Gen2StatsScreenPage` and `Gen2MoveScreenPage` own the geometry, every column being the disassembly's own `hlcoord`.

- Pages wrap both ways on LEFT and RIGHT, A turns one and exits on the last, UP and DOWN walk the party without wrapping, and each reload is a `PlayMonCry2` unless `CheckFaintedFrzSlp` says otherwise.
- The move screen swaps a move and its PP together, which is `.place_move`'s second `.copy_move` over `wPartyMon1PP`; B with something held puts it back rather than leaving; LEFT and RIGHT skip eggs and refuse outright while a move is held.
- `Gen2StatsScreenPage.draw_stats` is `PrintTempMonStats`, and `draw_move_list` is `ListMoves` and `ListMovePP`, which the green page and the move screen both list from.

## The sheet

Both load `LoadStatsScreenPageTilesGFX`, whose seventeen tiles at $31 no importer read, so the cache format is bumped. `StatsScreenPageTilesGFX` is the entry immediately before `EnemyHPBarBorderGFX` in `gfx/font.asm` on all three dumps, so it is walked back from the pinned enemy HUD offset rather than stored, and its own two shapes check the address: the two-column vertical divider and the shiny mark fourteen tiles on, which `constants/charmap.asm` names as this sheet's tile 14.

`Gen2BattleTiles` grew `stats_page()` beside `from_data()`: the same strip reaching down to $31, the exp bar contributing eight tiles rather than nine, and `HPExpBarBorderGFX` scattered to $78 and $76 rather than copied whole, which is the one thing `StatsScreen_LoadFont` and a battle's own load disagree on.

## What went with it

Every submenu row is acted on now, so the "not available yet" refusal is unreachable and goes, along with the `available` flag that only ever guarded it and the launcher panel's "(unavailable)" decoration. The test that drove that refusal through STATS drives `.SelectMilkDrinkRecipient`'s own `.cant_use` instead, which is the same `JoyWaitAorB` hold on a path that still has one.

## Proving it

GUT 3,221 over 152 scripts, green. `tools/validate.gd -- all` passes, `replay_world.gd` is 11 routes and 0 failures on each of the three cartridges, all three re-import with `layout: Layout verified.`, and the boot smoke test exits 0. New cases cover the tile page reaching $31 and a battle's not, the upper half being the same on every page, the page indicators, each page's own lower half, the empty-slot dashes, the held row's hollow arrow and `Where?`, both screens' navigation, the PP swap and the egg's three-row submenu.

Palettes are the one thing not built: `LoadStatsScreenPals` tints the background per page and `SCGB_STATS_SCREEN_HP_PALS` colours the pic and bars through an attribute map, and neither is imported, so the pages are black on white with the HP bar in its own colour, which is how every other page here is composed.