### PR TITLE
Level up draws its stats box; the pack's target list is the party menu

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -470,6 +470,11 @@ var safeguard_turns: Dictionary = {PLAYER: 0, ENEMY: 0}
 ## unmapped. A battle nobody told stands at midday.
 var time_of_day: int = Gen2WorldPalette.TIME_DAY
 
+## `GetWorldMapLocation`'s answer for the map this is being fought on, which
+## `LevelUpHappinessMod` compares a Pokémon's caught location against. A battle
+## nobody told is nowhere, and no Pokémon was caught there.
+var landmark: int = LANDMARK_NONE
+
 ## `wEnemyTrainerItem1` and `wEnemyTrainerItem2`, one copy for the whole battle
 ## and each removed as it is spent (`xor a; ld [de], a`). Empty for a wild battle
 ## and for a class carrying `NO_ITEM` twice.
@@ -2165,6 +2170,7 @@ func _give_experience_to(
 	})
 
 	var target_level: int = learner.level_for_exp()
+	var grew: bool = learner.level < target_level
 	while learner.level < target_level:
 		var old_level: int = learner.level
 		var old_stats: Dictionary = learner.stats.duplicate()
@@ -2192,6 +2198,23 @@ func _give_experience_to(
 		# `LearnLevelMoves` runs after the species has been replaced, so an
 		# evolved species gets its own move at the level that triggered it.
 		_offer_moves_learned_at(learner, index, learner.level, events)
+
+	## `LevelUpHappinessMod` sits after `.level_loop`, outside it: an award that
+	## crossed four levels raises happiness once, not four times.
+	if grew:
+		_gain_level_happiness(learner)
+
+
+## `LevelUpHappinessMod`: HAPPINESS_GAINLEVELATHOME when the Pokémon is standing
+## on the landmark it was caught on and HAPPINESS_GAINLEVEL anywhere else. The
+## compare is Crystal's alone; Gold and Silver inline HAPPINESS_GAINLEVEL with no
+## row to reach for, which is also why their table is one row shorter.
+func _gain_level_happiness(learner: Gen2BattleMon) -> void:
+	var kind: int = HAPPINESS_GAINLEVEL
+	if Gen2WorldState.is_crystal_profile(data) and landmark != LANDMARK_NONE \
+			and learner.caught_location == landmark:
+		kind = HAPPINESS_GAINLEVELATHOME
+	learner.happiness = Gen2WorldPartyHost.change_happiness(data, learner.happiness, kind)
 
 
 ## What [param learner] is taught at exactly [param level]: into an empty slot
@@ -2458,6 +2481,16 @@ const JOHTO_GYM_LEADERS: Array[int] = [
 	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 	0x0B, 0x0D, 0x0E, 0x0F, TRAINER_CLASS_CHAMPION, TRAINER_CLASS_RED,
 ]
+
+## A landmark no map has, so an untold battle matches nobody's caught location.
+const LANDMARK_NONE: int = -1
+
+## `constants/pokemon_data_constants.asm`, one-based the way `ChangeHappiness`
+## takes it. Gold and Silver ship neither the second row nor the compare in
+## front of it: their `.skip_active_mon_update` passes HAPPINESS_GAINLEVEL flat.
+const HAPPINESS_GAINLEVEL: int = 0x01
+const HAPPINESS_GAINLEVELATHOME: int = 0x13
+
 
 ## constants/landmark_constants.asm, Crystal-canonical like
 ## [constant Gen2WorldRadio.KANTO_LANDMARK], which is where the Gold and Silver

--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -62,6 +62,17 @@ const INFO_TYPE_LABEL: String = "TYPE/"
 const INFO_DISABLED_AT := Vector2i(1, 10)
 const INFO_DISABLED: String = "Disabled!"
 
+## The level-up stats box `.skip_exp_bar_animation` draws over the upper screen:
+## `hlcoord 9, 0` with `ld b, 10` and `ld c, 9`, then `PrintTempMonStats` at
+## `hlcoord 11, 1` with a spacing of four. No options and no cursor; the ten
+## strings are [method Gen2StatsScreenPage.stats_placements].
+const LEVEL_UP_LEFT: int = 9
+const LEVEL_UP_TOP: int = 0
+const LEVEL_UP_RIGHT: int = 19
+const LEVEL_UP_BOTTOM: int = 11
+const LEVEL_UP_STATS_AT := Vector2i(11, 1)
+const LEVEL_UP_STATS_SPACING: int = 4
+
 ## `BattleText_TheresNoPPLeftForThisMove` and `BattleText_TheMoveIsDisabled`,
 ## which `.use_move` prints over the list and then reopens it behind.
 const NO_PP_TEXT: String = "There's no PP left for this move!"
@@ -103,6 +114,12 @@ static func move_box() -> Gen2MenuBox:
 static func info_box() -> Gen2MenuBox:
 	return Gen2MenuBox.from_coords(
 		INFO_LEFT, INFO_TOP, INFO_RIGHT, INFO_BOTTOM, 0
+	)
+
+
+static func level_up_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		LEVEL_UP_LEFT, LEVEL_UP_TOP, LEVEL_UP_RIGHT, LEVEL_UP_BOTTOM, 0
 	)
 
 

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -197,6 +197,15 @@ var minimized: bool = false
 ## that is the default rather than zero.
 var happiness: int = BASE_HAPPINESS
 
+## constants/pokemon_data_constants.asm's CAUGHT_LOCATION_MASK, the low seven
+## bits of the caught-data byte the caught gender shares.
+const CAUGHT_LOCATION_MASK: int = 0x7F
+
+## `MON_CAUGHT_LOCATION` masked with CAUGHT_LOCATION_MASK: the landmark the
+## Pokémon was caught on. `LevelUpHappinessMod` is the only thing in a battle to
+## read it, and a mon nobody told (a wild one, a trainer's) has none.
+var caught_location: int = 0
+
 
 ## Builds a Pokémon at a level, at full health, knowing [param moves].
 ##

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -269,6 +269,11 @@ var _move_cursor: int = 0
 ## `MoveInfoBox`, which is its own `Textbox` beside the list rather than part of
 ## it, so it is drawn into a layer of its own.
 var _info_layer: TextureRect = null
+## `.skip_exp_bar_animation`'s stats box, over the upper screen while the
+## grew-to-level line it accompanies is up.
+var _level_up_layer: TextureRect = null
+## The stats that box is showing, empty while there is no box.
+var _level_up_stats: Dictionary = {}
 ## The menu itself, which unlike [member _menu_layer] sits over the text box.
 var _battle_menu_layer: TextureRect = null
 
@@ -487,6 +492,10 @@ func _ready() -> void:
 	_info_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_info_layer.visible = false
 	_screen.display(_info_layer)
+	_level_up_layer = TextureRect.new()
+	_level_up_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_level_up_layer.visible = false
+	_screen.display(_level_up_layer)
 	_apply_renderer_interface_style()
 
 	## Whatever this screen was opened on its own for. A battle inside the
@@ -749,6 +758,10 @@ func start_world_battle(
 	_enemy_trainer_index = int(prepared.get("trainer_index", 0))
 	_battle = prepared["battle"]
 	_battle.time_of_day = _time_of_day
+	## `GetWorldMapLocation`, the same reading [method _play_battle_music] uses:
+	## `LevelUpHappinessMod` compares it against the winner's caught location.
+	_battle.landmark = _world_context.landmark if _world_context != null \
+		else Gen2Battle.LANDMARK_NONE
 	_battle.load_trainer_items(_enemy_trainer_class)
 	var player_party_ready: Gen2Party = prepared["player_party"]
 	var enemy_party_ready: Gen2Party = prepared["enemy_party"]
@@ -924,6 +937,7 @@ func _init_battle_display() -> void:
 	_enemy_unown_form = Gen2Battle.unown_form_of(_battle.enemy)
 	_player_unown_form = Gen2Battle.unown_form_of(_battle.player)
 	_close_switch()
+	_clear_level_up_box()
 	_reseed_bg_map()
 	set_hp(
 		_battle.enemy.hp, _battle.enemy.max_hp(),
@@ -1029,6 +1043,12 @@ const CRY_TRACKS_PLAYER: int = 0xF0
 
 const SFX_DAMAGE: int = 0xAC
 const SFX_SUPER_EFFECTIVE: int = 0xAD
+
+## `AnimateExpBar`'s two: `.PlayExpBarSound`'s at the head of every segment, and
+## the one `.LoopLevels` and `.skip_exp_bar_animation` both play before their
+## grew-to-level line.
+const SFX_EXP_BAR: int = 0x8C
+const SFX_HIT_END_OF_EXP_BAR: int = 0xB6
 
 
 ## Whether an animation, or any of the delays `PlayBattleAnim` wraps it in, is
@@ -1395,7 +1415,54 @@ func _start_exp_bar(event: Dictionary, from_pixels: int) -> void:
 		targets.append(Gen2ExpBarAnimation.LENGTH_PX)
 	targets.append(Gen2ExpBarAnimation.pixels_for(rate, mon.level, mon.exp))
 	_exp_bar = Gen2ExpBarAnimation.create(from_pixels, targets)
+	## `.PlayExpBarSound` runs before the first `.LoopBarAnimation`, so the sound
+	## leads the fill by its own ten frames.
+	if not _exp_bar.finished():
+		_play_anim_sound(SFX_EXP_BAR)
 	_push_view()
+
+
+## Whether [param index] has another [constant Gen2Battle.GREW_LEVEL] still
+## queued before the next award. `.level_loop` raises every level first and the
+## box is drawn once after it, so only the last one carries a box.
+func _more_levels_queued(index: int) -> bool:
+	for queued: Dictionary in _pending:
+		var kind: StringName = StringName(queued["type"])
+		if kind == Gen2Battle.EXP_GAINED:
+			return false
+		if kind == Gen2Battle.GREW_LEVEL and int(queued["index"]) == index:
+			return true
+	return false
+
+
+## `.skip_exp_bar_animation`'s `Textbox` and `PrintTempMonStats`, or nothing
+## while [member _level_up_stats] is empty. `SafeLoadTempTilemapToTilemap` puts
+## the screen back afterwards, which is what clearing it is.
+func _refresh_level_up_box() -> void:
+	if _level_up_layer == null:
+		return
+	if _level_up_stats.is_empty() or _menu_page == null:
+		_level_up_layer.visible = false
+		return
+	var box: Gen2MenuBox = Gen2BattleMenu.level_up_box()
+	_show_layer_image(
+		_level_up_layer,
+		_menu_page.render(
+			box, [], -1, "", 0,
+			Gen2StatsScreenPage.stats_placements(
+				Gen2BattleMenu.LEVEL_UP_STATS_AT, _level_up_stats,
+				Gen2BattleMenu.LEVEL_UP_STATS_SPACING
+			)
+		),
+		box.border_position() * Gen2Font.TILE
+	)
+
+
+func _clear_level_up_box() -> void:
+	if _level_up_stats.is_empty():
+		return
+	_level_up_stats = {}
+	_refresh_level_up_box()
 
 
 func show_message(text: String) -> void:
@@ -1457,6 +1524,7 @@ func battle_snapshot() -> Dictionary:
 		"capture_ball": _selected_capture_ball(),
 		"capture_balls": _capture_balls.duplicate(),
 		"capture_quantities": _capture_quantities.duplicate(),
+		"level_up_stats": _level_up_stats.duplicate(),
 	}
 
 
@@ -2097,6 +2165,9 @@ func advance() -> void:
 		if _box.advance():
 			return
 		_exp_bar.resume()
+		## The loop reaches `.PlayExpBarSound` again for the segment this press
+		## releases, the same as the first one.
+		_play_anim_sound(SFX_EXP_BAR)
 		return
 	## A bar the source is still animating has not printed its message yet, so
 	## there is nothing for a press to advance past. Without this the press
@@ -2141,6 +2212,9 @@ func _continue_after_messages() -> void:
 		return
 	if _message_awaits_press or not _intro_message.is_empty():
 		return
+	## Nothing is left to print, so the line the box stood beside is gone even
+	## though no event was popped to take it away.
+	_clear_level_up_box()
 	if _capture_selecting or _capture_waiting:
 		return
 	## A list already up owns the joypad: the battle menu, the pack and its two
@@ -3051,6 +3125,9 @@ func _replace_the_fallen() -> bool:
 func _show_next_event() -> void:
 	while not _pending.is_empty():
 		var event: Dictionary = _pending.pop_front()
+		## The box lasts exactly as long as the line it was drawn beside, and
+		## this is the press that took that line away.
+		_clear_level_up_box()
 		event = Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
 		if StringName(event["type"]) == Gen2Battle.ANIMATION:
 			## The engine has already resolved; this event is the frames the
@@ -3166,6 +3243,16 @@ func _apply_event_state(event: Dictionary) -> void:
 				_push_view()
 			if _exp_bar == null:
 				_refresh_exp_bar()
+			## `SFX_HIT_END_OF_EXP_BAR`, then `WaitSFX`, then the line. Both
+			## paths play it: `.LoopLevels` for whoever is out and
+			## `.skip_exp_bar_animation` for a benched participant.
+			_play_anim_sound(SFX_HIT_END_OF_EXP_BAR)
+			## `.skip_exp_bar_animation` draws the box once per award, after the
+			## last level it crossed, so a walk of several levels shows the
+			## stats it finished on rather than one box a level.
+			if not _more_levels_queued(int(event["index"])):
+				_level_up_stats = (event["new_stats"] as Dictionary).duplicate()
+			_refresh_level_up_box()
 
 
 ## An event as a sentence, or an empty string for one there is nothing to say

--- a/game/battle/exp_bar_animation.gd
+++ b/game/battle/exp_bar_animation.gd
@@ -19,8 +19,8 @@ extends RefCounted
 ## tiles.
 const LENGTH_PX: int = Gen2BattleHud.EXP_BAR_TILES * Gen2BattleHud.TILE
 
-## `.PlayExpBarSound`'s `ld c, 10`, spent before each segment moves. Its
-## `SFX_EXP_BAR` is the Poof's boundary: no battle screen has an SFX route.
+## `.PlayExpBarSound`'s `ld c, 10`, spent before each segment moves. Its own
+## `SFX_EXP_BAR` is played by the screen, which owns the audio player.
 const LEAD_FRAMES: int = 10
 
 ## `.LoopBarAnimation`'s `ld d, 3` and its floor: 3, 3, 2, 2, 1, 1 and on at a

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -265,14 +265,28 @@ func draw_stats(
 	into: PackedByteArray, width: int, at: Vector2i, stats: Dictionary,
 	spacing: int = STATS_SPACING
 ) -> void:
+	for placement: Dictionary in stats_placements(at, stats, spacing):
+		_text(into, width, String(placement["text"]), placement["at"])
+
+
+## The same ten strings as `PlaceString` calls, for a caller that draws them
+## through [method Gen2MenuPage.draw]'s extras rather than into a page: the
+## battle's level-up box is a plain `Textbox`, not a stats screen.
+static func stats_placements(
+	at: Vector2i, stats: Dictionary, spacing: int = STATS_SPACING
+) -> Array:
+	var out: Array = []
 	for index: int in STAT_NAMES.size():
-		_text(into, width, STAT_NAMES[index], at + Vector2i(0, index * STAT_ROW_STEP))
+		out.append({
+			"text": STAT_NAMES[index], "at": at + Vector2i(0, index * STAT_ROW_STEP),
+		})
 	var numbers: Vector2i = at + Vector2i(spacing, 1)
 	for index: int in STAT_KEYS.size():
-		_text(
-			into, width, str(int(stats.get(STAT_KEYS[index], 0))).lpad(STAT_DIGITS),
-			numbers + Vector2i(0, index * STAT_ROW_STEP)
-		)
+		out.append({
+			"text": str(int(stats.get(STAT_KEYS[index], 0))).lpad(STAT_DIGITS),
+			"at": numbers + Vector2i(0, index * STAT_ROW_STEP),
+		})
+	return out
 
 
 ## `StatsScreen_InitUpperHalf` plus `StatsScreen_LoadPageIndicators`, which

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -67,6 +67,14 @@ const MAX_SUBMENU_ITEMS: int = 8
 const PROMPT_CHOOSE: String = "Choose a #MON."
 const PROMPT_USE_ON_WHICH: String = "Use on which PKMN?"
 
+## The two more of `PartyMenuStrings` the pack's own lists reach:
+## `ToWhichPKMNString` for `PARTYMENUACTION_GIVE_ITEM`, which `GiveItem` writes,
+## and `TeachWhichPKMNString` for the `PARTYMENUACTION_TEACH_TMHM` that
+## `TeachTMHM` writes. Kept beside the two above rather than in the screen that
+## reads them, so all four strings are in one place.
+const PROMPT_TO_WHICH: String = "To which PKMN?"
+const PROMPT_TEACH_WHICH: String = "Teach which PKMN?"
+
 ## `SwitchPartyMons`' own `PARTYMENUACTION_MOVE` string, `MoveToWhereString`.
 const PROMPT_MOVE_TO_WHERE: String = "Move to where?"
 

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -20,6 +20,7 @@ static func from_battle_mon(mon: Gen2BattleMon) -> Gen2SaveMon:
 	out.hp = mon.hp
 	out.status = mon.status
 	out.happiness = mon.happiness
+	out.caught_location = mon.caught_location
 	for slot: int in Gen2SaveMon.MAX_MOVES:
 		# Mimic and Transform edit only the battle move struct. Sketch edits the
 		# party move too, so it needs no exception here.
@@ -47,6 +48,7 @@ static func to_battle_mon(data: GameData, saved: Gen2SaveMon) -> Gen2BattleMon:
 	out.exp = saved.exp
 	out.status = saved.status
 	out.happiness = saved.happiness
+	out.caught_location = saved.caught_location & Gen2BattleMon.CAUGHT_LOCATION_MASK
 	out.pp = saved_pp
 	out.hp = clampi(saved.hp, 0, out.max_hp())
 	return out

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -179,6 +179,11 @@ var _mod_option_cursor: int = 0
 var _screen: Gen2Screen = null
 var _view: TextureRect = null
 var _page: Gen2StartMenuPage = null
+## `LoadPartyMenuGFX`: the target list is the party menu, so it is drawn by the
+## page that draws the party menu everywhere else.
+var _target_page: Gen2PartyMenuPage = null
+## Leftover of a hardware frame the target list's icons have not counted yet.
+var _target_elapsed: float = 0.0
 ## The panel's own two roots, hidden whenever a cartridge screen is up.
 var _scrim: ColorRect = null
 var _center: CenterContainer = null
@@ -362,9 +367,12 @@ func _move(direction: Vector2i) -> void:
 				_swap_cursor = 1 - _swap_cursor
 				_render_give_swap()
 		Mode.PACK_TARGET:
+			## `InitPartyMenuWithCancel`: CANCEL is the row after the last member
+			## and the cursor wraps around it, which is `w2DMenuNumRows` being the
+			## party count plus one.
 			if direction.y != 0 and not _party_targets().is_empty():
 				_target_cursor = wrapi(
-					_target_cursor + signi(direction.y), 0, _party_targets().size()
+					_target_cursor + signi(direction.y), 0, _party_targets().size() + 1
 				)
 				_render_targets()
 		## `VerticalMenu` over `YesNoMenuHeader`, which is only up while a
@@ -428,7 +436,11 @@ func _confirm() -> void:
 		Mode.PACK_GIVE_SWAP:
 			_confirm_give_swap()
 		Mode.PACK_TARGET:
-			if _teaching:
+			## `PartyMenuSelect` returns carry on CANCEL, which the caller answers
+			## the same way it answers B.
+			if _target_cursor >= _party_targets().size():
+				_open_item_mode()
+			elif _teaching:
 				_teach_selected_item(_target_cursor)
 			elif _giving:
 				_give_selected_item(_target_cursor)
@@ -1105,7 +1117,9 @@ func _resolve_field_item(item: int) -> Dictionary:
 
 
 ## `.Party`'s party list. Reads the same save the USE will be applied to, so a
-## screen without one offers no targets and answers `.NoPokemon`.
+## screen without one offers no targets and answers `.NoPokemon`. The rows are
+## `WritePartyMenuTilemap`'s, in the shape [Gen2PartyMenuPage] draws and
+## [Gen2PartyScreen] builds, since the list this opens is that same menu.
 func _party_targets() -> Array:
 	if _pack_save == null:
 		return []
@@ -1117,13 +1131,48 @@ func _party_targets() -> Array:
 		# Max HP is derived, not stored, the same way Gen2PartyScreen derives it.
 		var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
 		targets.append({
+			"index": targets.size(),
+			"species": mon.species,
+			"item": mon.item,
 			"name": mon.nickname if not mon.nickname.is_empty() \
 				else String(_data.species(mon.species).get("name", "UNKNOWN")),
+			"level": mon.level,
 			"hp": mon.hp,
-			"max_hp": battle_mon.max_hp() if battle_mon != null else 0,
+			"max_hp": 0 if mon.is_egg else (battle_mon.max_hp() if battle_mon != null else 0),
+			"status": mon.status,
+			"fainted": not mon.is_egg and mon.hp <= 0,
 			"egg": mon.is_egg,
 		})
 	return targets
+
+
+## `PartyMenuStrings`, picked by the `wPartyMenuActionText` each of the three
+## entrances writes: `TeachTMHM`'s PARTYMENUACTION_TEACH_TMHM, `GiveItem`'s
+## PARTYMENUACTION_GIVE_ITEM, and the PARTYMENUACTION_HEALING_ITEM every
+## `.Party` item effect writes.
+func _target_prompt() -> String:
+	if _teaching:
+		return Gen2PartyScreen.PROMPT_TEACH_WHICH
+	return Gen2PartyScreen.PROMPT_TO_WHICH if _giving \
+		else Gen2PartyScreen.PROMPT_USE_ON_WHICH
+
+
+## `LoadPartyMenuGFX`, built the first time the list is opened and kept, the way
+## [member _page] is.
+func _party_menu_page() -> Gen2PartyMenuPage:
+	if _target_page == null and _data != null:
+		_target_page = Gen2PartyMenuPage.from_data(_data)
+	return _target_page
+
+
+## One pass of the target list's icons, which animate on the hardware clock the
+## rest of the party menu's do. Public the way [method advance_save_frame] is, so
+## a test or a screenshot driver can step them without waiting on real time.
+func advance_target_icons() -> void:
+	if _target_page == null or _mode != Mode.PACK_TARGET:
+		return
+	_target_page.advance(_party_targets(), _target_cursor)
+	_render_hardware()
 
 
 ## AskTeachTMHM: the booted-up text and its yes/no. A TM/HM the cartridge does
@@ -1321,17 +1370,32 @@ func _teach_refusal(reason: StringName, party_index: int) -> String:
 
 func _open_target_mode() -> void:
 	_mode = Mode.PACK_TARGET
-	_target_cursor = clampi(_target_cursor, 0, maxi(_party_targets().size() - 1, 0))
+	_target_cursor = clampi(_target_cursor, 0, _party_targets().size())
+	## `InitPartyMenuGFX` respawns one icon struct per member every time the list
+	## is opened, which is what puts the icons on the page at all.
+	if _party_menu_page() != null:
+		_target_page.reset(_party_targets())
 	_status.text = ""
 	_footer.text = "Up and down: move    A: %s    B: back" % ("give" if _giving else "use")
+	_target_elapsed = 0.0
 	_render_targets()
+	## `InitPartyMenuGFX` opens every struct on frame -1, so the icons are blank
+	## until `DoNextFrameForAllSprites` has run once; the list is drawn after
+	## that first pass rather than before it.
+	advance_target_icons()
 
 
 func _render_targets() -> void:
 	_title.text = "GIVE TO" if _giving else "USE ON"
 	_summary.text = String(_selected_item().get("name", ""))
-	_render_options(_party_targets(), 0 if _party_targets().is_empty() else _target_cursor,
+	## The panel fallback carries the same CANCEL row the hardware page draws, so
+	## the cursor means one thing whichever of the two is up.
+	var rows: Array = _party_targets()
+	rows.append({"cancel": true})
+	_render_options(rows, _target_cursor,
 		func(entry: Dictionary) -> String:
+			if bool(entry.get("cancel", false)):
+				return Gen2BattleSwitchMenu.cancel_label()
 			if bool(entry.get("egg", false)):
 				return "%s    EGG" % String(entry.get("name", ""))
 			return "%s    %d/%d HP" % [
@@ -1625,6 +1689,18 @@ func advance_save_frames(count: int) -> void:
 
 
 func _process(delta: float) -> void:
+	if _mode == Mode.PACK_TARGET:
+		## Capped the way every other hardware-frame pump here caps it: a stall
+		## drops icon passes rather than running a second of them at once.
+		_target_elapsed = minf(
+			_target_elapsed + delta,
+			Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
+		)
+		while _target_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
+			_target_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+			advance_target_icons()
+		return
+	_target_elapsed = 0.0
 	if _mode != Mode.SAVE_SAVING and _mode != Mode.SAVE_SAVED:
 		return
 	_save_elapsed += delta
@@ -1809,6 +1885,12 @@ func _hardware_image() -> Image:
 			return _page.render_options(_options_menu.rows(), _options_menu.cursor)
 		Mode.PACK:
 			return _pack_image()
+		Mode.PACK_TARGET:
+			if _party_menu_page() == null:
+				return null
+			return _target_page.render(
+				_party_targets(), _target_cursor, _target_prompt()
+			)
 		Mode.MODS:
 			var rows: Array = []
 			for id: StringName in _mod_ids:

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -443,6 +443,61 @@ func test_a_benched_gainer_animates_no_bar() -> void:
 	assert_false(_battle_screen.bars_animating())
 
 
+## `.skip_exp_bar_animation` draws its stats box once per award, after
+## `.level_loop` has raised every level: two levels crossed is one box, showing
+## what the walk finished on, and it lasts exactly as long as the line beside it.
+func test_the_level_up_stats_box_stands_beside_the_last_level_line() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+
+	var mon: Gen2BattleMon = _battle_screen._battle.player
+	var benched: int = _battle_screen._battle.party(Gen2Battle.PLAYER).active + 1
+	var middle: Dictionary = {"attack": 11, "defense": 12, "sp_attack": 13, "sp_defense": 14, "speed": 15}
+	var settled: Dictionary = {"attack": 21, "defense": 22, "sp_attack": 23, "sp_defense": 24, "speed": 25}
+	_battle_screen._pending = [
+		{
+			"type": Gen2Battle.GREW_LEVEL, "side": Gen2Battle.PLAYER, "index": benched,
+			"species": mon.species, "old_level": 9, "new_level": 10,
+			"old_stats": {}, "new_stats": middle,
+		},
+		{
+			"type": Gen2Battle.GREW_LEVEL, "side": Gen2Battle.PLAYER, "index": benched,
+			"species": mon.species, "old_level": 10, "new_level": 11,
+			"old_stats": middle, "new_stats": settled,
+		},
+	]
+
+	## The events are fed by hand, so the menu `_settle_intro` left open has to
+	## come down the way a real turn takes it down before a press means "next
+	## line" rather than "FIGHT".
+	_battle_screen._close_battle_menu()
+
+	_battle_screen._show_next_event()
+	assert_eq(
+		_battle_screen.battle_snapshot()["level_up_stats"], {},
+		"the level in the middle of the walk draws no box"
+	)
+
+	_battle_screen._box.finish()
+	_battle_screen._box.advance()
+	_battle_screen.advance()
+	assert_eq(
+		_battle_screen.battle_snapshot()["level_up_stats"], settled,
+		"the box goes up beside the last level's line, with the stats it settled on"
+	)
+	assert_true(_battle_screen._level_up_layer.visible, "and it is on screen")
+
+	_battle_screen._box.finish()
+	_battle_screen._box.advance()
+	_battle_screen.advance()
+	assert_eq(
+		_battle_screen.battle_snapshot()["level_up_stats"], {},
+		"and `SafeLoadTempTilemapToTilemap` takes it away with that line"
+	)
+	assert_false(_battle_screen._level_up_layer.visible)
+
+
 ## `InitBattleDisplay` runs `BattleIntroSlidingPics` and only then does
 ## `BattleStartMessage` say anything, so a battle opens on an empty box with the
 ## background sliding, and the player's back pic is not on the map at all until

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -915,6 +915,54 @@ func test_use_on_a_party_item_asks_which_mon_then_heals_and_spends_it() -> void:
 	assert_eq(((host.get("_pack_pockets")[0] as Dictionary)["items"] as Array).size(), 0)
 
 
+## `.Party` opens the party menu itself, not a panel: `GiveItem` and every
+## healing item write their own `wPartyMenuActionText` first, and
+## `InitPartyMenuWithCancel` puts CANCEL after the last member.
+func test_the_target_list_is_the_party_menu_with_its_own_prompt_and_cancel() -> void:
+	var host: Gen2StartMenuScreen = await _open_pack_with_a_hurt_party()
+	var save: Gen2SaveData = _world_screen.get("_injected_save")
+	var before: int = (save.party[0] as Gen2SaveMon).hp
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+	assert_eq(String(host.call("_target_prompt")), Gen2PartyScreen.PROMPT_USE_ON_WHICH)
+	assert_not_null(host.call("_hardware_image"), "the list has a cartridge page")
+
+	## `WritePartyMenuTilemap` draws a level and a status beside every nickname,
+	## so the rows carry what that page reads rather than a name and an HP pair.
+	var rows: Array = host.call("_party_targets")
+	assert_gt(rows.size(), 0)
+	for key: String in ["index", "species", "name", "level", "hp", "max_hp", "status", "egg"]:
+		assert_true((rows[0] as Dictionary).has(key), key)
+
+	## The row after the last member is CANCEL, and the cursor wraps around it.
+	var members: int = rows.size()
+	for _step: int in members + 1:
+		host.handle_button(Gen2Button.DOWN)
+	assert_eq(int(host.get("_target_cursor")), 0, "the cursor wrapped past CANCEL")
+	for _step: int in members:
+		host.handle_button(Gen2Button.DOWN)
+	assert_eq(int(host.get("_target_cursor")), members, "CANCEL is the last row")
+
+	## `PartyMenuSelect` returns carry there, which the caller answers the way it
+	## answers B: back to the item's own submenu, with nothing used.
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
+	assert_eq((save.party[0] as Gen2SaveMon).hp, before)
+	assert_eq(_world_screen._world.state.item_quantity(7), 1)
+
+
+## `GiveItem` writes PARTYMENUACTION_GIVE_ITEM, which is a different
+## `PartyMenuStrings` row from the healing items' above.
+func test_give_opens_the_same_list_under_its_own_prompt() -> void:
+	var host: Gen2StartMenuScreen = await _open_pack_with_a_hurt_party()
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+	assert_eq(String(host.call("_target_prompt")), Gen2PartyScreen.PROMPT_TO_WHICH)
+
+
 func test_using_an_item_with_nothing_to_do_reports_it_and_spends_nothing() -> void:
 	await _open_world()
 	_world_screen._open_start_menu()

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1399,6 +1399,61 @@ func test_levelling_up_learns_a_move_into_an_empty_slot_without_asking() -> void
 	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
 
 
+## `LevelUpHappinessMod`: once per award that levelled, not once per level, and
+## HAPPINESS_GAINLEVELATHOME only where the Pokemon was caught. The table's own
+## rows are signed, so the numbers come out of the cache rather than out of here.
+func test_levelling_up_raises_happiness_once_and_more_at_home() -> void:
+	var away: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	away.player.hp = away.player.max_hp() * 10
+	away.player.caught_location = 4
+	away.landmark = 9
+	away.enemy.hp = 1
+	var before: int = away.player.happiness
+	var events: Array = away.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.GREW_LEVEL).size(), 3, "three levels, one rise")
+	assert_eq(
+		away.player.happiness,
+		Gen2WorldPartyHost.change_happiness(_data, before, Gen2Battle.HAPPINESS_GAINLEVEL),
+		"HAPPINESS_GAINLEVEL, applied once for the whole walk"
+	)
+
+	var home: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	home.player.hp = home.player.max_hp() * 10
+	home.player.caught_location = 9
+	home.landmark = 9
+	home.enemy.hp = 1
+	home.take_turn(0, 0)
+	assert_eq(
+		home.player.happiness,
+		Gen2WorldPartyHost.change_happiness(_data, before, Gen2Battle.HAPPINESS_GAINLEVELATHOME),
+		"the same landmark reaches HAPPINESS_GAINLEVELATHOME"
+	)
+	## +5 against +10 at a base happiness of 70, so the two branches are visibly
+	## different rows rather than one row read twice.
+	assert_gt(home.player.happiness, away.player.happiness)
+
+
+## An award too small to cross a level runs `.next_mon` before
+## `.skip_active_mon_update`, so nothing touches happiness.
+func test_experience_without_a_level_leaves_happiness_alone() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 2, [Fixture.TACKLE])
+	)
+	battle.player.hp = battle.player.max_hp() * 10
+	battle.enemy.hp = 1
+	var before: int = battle.player.happiness
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.GREW_LEVEL).size(), 0, "no level was crossed")
+	assert_eq(battle.player.happiness, before)
+
+
 func test_a_full_moveset_is_offered_a_new_move_rather_than_taught_it() -> void:
 	# Geodude's own curve also reads 135 at level 5. A level 33 Magcargo (base
 	# exp 154) is worth floor(154*33/7) = 726 exactly, landing at 861, which is

--- a/tests/unit/test_menu_box.gd
+++ b/tests/unit/test_menu_box.gd
@@ -127,6 +127,25 @@ func test_the_move_info_box_is_the_source_rectangle() -> void:
 	assert_eq(box.border_size(), Vector2i(11, 5))
 
 
+## `.skip_exp_bar_animation`'s `hlcoord 9, 0` with `b, 10` and `c, 9`, and the
+## `PrintTempMonStats` at `hlcoord 11, 1` whose spacing of four puts the numbers
+## two columns further left than the stats screen's six does.
+func test_the_level_up_stats_box_is_the_source_rectangle() -> void:
+	var box: Gen2MenuBox = Gen2BattleMenu.level_up_box()
+	assert_eq(box.interior(), Vector2i(9, 10))
+	assert_eq(box.border_position(), Vector2i(9, 0))
+	assert_eq(box.border_size(), Vector2i(11, 12))
+	var placements: Array = Gen2StatsScreenPage.stats_placements(
+		Gen2BattleMenu.LEVEL_UP_STATS_AT, {"attack": 12, "speed": 7},
+		Gen2BattleMenu.LEVEL_UP_STATS_SPACING
+	)
+	assert_eq(placements.size(), 10)
+	assert_eq(placements[0], {"text": "ATTACK", "at": Vector2i(11, 1)})
+	assert_eq(placements[4], {"text": "SPEED", "at": Vector2i(11, 9)})
+	assert_eq(placements[5], {"text": " 12", "at": Vector2i(15, 2)})
+	assert_eq(placements[9], {"text": "  7", "at": Vector2i(15, 10)})
+
+
 ## `MenuHeaders_UnownWalls`' `menu_coords 9 - n, 4, 10 + n, 9`: the box is built
 ## around the word, so "ESCAPE" and "HO-OH" are different sizes and both are
 ## centred on the same two columns.

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -8,7 +8,8 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses] [passes]
 ##
 ## [stage] is one of `offer` (the default), `menu`, `move`, `contest`, `pack`,
-## `pick`, `use_next` and `replace`;
+## `pick`, `use_next`, `replace` and `level_up`, which is the stats box
+## `.skip_exp_bar_animation` draws beside its grew-to-level line;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
 ## cursor row or a refusal can be photographed; [passes] is how many sprite
 ## passes the party page's icons are given, which is what moves the chosen row's
@@ -141,6 +142,17 @@ func _open() -> void:
 		_screen.set("_pending", [
 			{"type": Gen2Battle.FAINTED, "side": Gen2Battle.PLAYER},
 		])
+	elif _stage == "level_up":
+		## A real knockout, not a staged event: the lead is parked one point
+		## under its next threshold so the award is certain to cross it, and the
+		## turn it takes is the one that runs `GiveExperiencePoints`.
+		battle.player.exp = Gen2Experience.total_exp_at(
+			battle.player.growth_rate(), battle.player.level + 1
+		) - 1
+		battle.enemy.hp = 1
+		_screen.set("_pending", battle.take_actions(
+			Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+		))
 	elif _stage not in ["menu", "move", "contest", "pack"]:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
@@ -155,6 +167,13 @@ func _open() -> void:
 			[Gen2WorldPartyHost.ITEM_PARK_BALL],
 			{Gen2WorldPartyHost.ITEM_PARK_BALL: Gen2WorldBugContest.BALLS}
 		)
+
+	if _stage == "level_up":
+		_drain_to_level_up()
+		_read_question()
+		_screen.finish()
+		_settle_icons()
+		return
 
 	## Both menu stages are what the intro leads into with nothing else staged,
 	## which is `BattleMenu`'s own first opening.
@@ -196,6 +215,19 @@ func _settle_icons() -> void:
 	for _pass: int in _icon_passes:
 		_screen.advance_party_icons()
 	_screen._refresh_menu_layer()
+
+
+## The same drain, stopping on the frame the level-up stats box is up.
+func _drain_to_level_up() -> void:
+	for _press: int in 60:
+		## The box is popped by the bar pump inside `_settle`, not by the press
+		## after it, so the check goes between the two: pressing on would scroll
+		## the line being photographed away.
+		_settle()
+		if not Dictionary(_screen.battle_snapshot()["level_up_stats"]).is_empty():
+			return
+		_screen.finish()
+		_screen.advance()
 
 
 ## The same drain, stopping at `BattleMenu` rather than at a switch question.

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -3,10 +3,13 @@ extends SceneTree
 ## Captures the pack against a real imported cache.
 ##
 ##   Godot --headless --path . -s res://tools/preview_pack.gd -- \
-##       crystal /tmp/pack.png [items|balls|key|tmhm] [presses] [female]
+##       crystal /tmp/pack.png [items|balls|key|tmhm|use|give] [presses] [female]
 ##
 ## The world behind it is a new game holding enough of each pocket to fill the
-## five visible rows and scroll past them. [presses] is a `u,d,l,r,a,b` list
+## five visible rows and scroll past them, with a development party behind it so
+## `use` and `give` reach `.Party`'s own list. Those two are the party menu
+## `GiveItem` and every `.Party` item effect open, so what they photograph is
+## [Gen2PartyMenuPage] with the prompt that entrance writes. [presses] is a `u,d,l,r,a,b` list
 ## driven into the real screen before the shot, so the picture is what the
 ## cartridge's own listing would show after those buttons.
 ##
@@ -29,6 +32,10 @@ const ROUTES: Dictionary = {
 	"balls": "r",
 	"key": "r,r",
 	"tmhm": "l",
+	## The first Items row is a healing item, so its submenu is USE / GIVE / TOSS
+	## and both rows reach `.Party`'s own list.
+	"use": "a,a",
+	"give": "a,d,a",
 }
 
 ## What the preview's world is carrying: enough items for the listing to scroll,
@@ -78,6 +85,11 @@ func _capture() -> void:
 
 	var host := Gen2StartMenuScreen.new()
 	root.add_child(host)
+	## No slot on disk, so nothing this photographs is written anywhere.
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if save != null:
+		save.world = world.snapshot()
+		host.set_party_context(save, false)
 	if not host.open(world, data, func() -> Dictionary: return {"ok": true}):
 		push_error("The %s cache holds no start menu." % args[0])
 		quit(1)
@@ -99,13 +111,20 @@ func _capture() -> void:
 		if BUTTONS.has(key):
 			host.handle_button(int(BUTTONS[key]))
 
-	var error: Error = (host.call("_pack_image") as Image).save_png(args[1])
+	## Whichever cartridge screen the presses landed on, so a route that opens
+	## `.Party`'s list photographs that rather than the pocket behind it.
+	var image: Image = host.call("_hardware_image") as Image
+	if image == null:
+		push_error("Mode %d has no cartridge screen to photograph." % int(host.get("_mode")))
+		quit(1)
+		return
+	var error: Error = image.save_png(args[1])
 	if error != OK:
 		push_error("Could not write %s (error %d)" % [args[1], error])
 		quit(1)
 		return
-	print("Wrote %s: %s pocket, cursor %d" % [
+	print("Wrote %s: %s pocket, cursor %d, mode %d" % [
 		args[1], String(host.call("_current_pocket").get("name", "?")),
-		int(host.get("_pack_cursor")),
+		int(host.get("_pack_cursor")), int(host.get("_mode")),
 	])
 	quit(0)


### PR DESCRIPTION
Two reported defects, one commit each.

## Level up draws its stats box, plays its two sounds and raises happiness

`.skip_exp_bar_animation` in `engine/battle/core.asm` draws a `Textbox` at
`hlcoord 9, 0` with `lb bc, 10, 9` and `PrintTempMonStats` at `hlcoord 11, 1`
with a spacing of four. That is a `Gen2MenuBox` with no options and the ten
strings as extras, and the strings are the stats screen's own: `draw_stats` now
consumes `stats_placements`, so both spacings are one routine.

The box is drawn once per award, after `.level_loop` has raised every level,
rather than once per level, and it stands exactly as long as the grew-to-level
line it accompanies.

Both exp-bar sounds were silent. `SFX_EXP_BAR` leads every segment and
`SFX_HIT_END_OF_EXP_BAR` plays in front of every grew-to-level line, on the
bench path as well as the field one.

`LevelUpHappinessMod` was not run at all. Crystal compares `GetWorldMapLocation`
against the caught location and reaches HAPPINESS_GAINLEVELATHOME on a match;
Gold and Silver pass HAPPINESS_GAINLEVEL flat and ship no such row.
`Gen2BattleMon` carries the caught location through `Gen2SaveBattleAdapter` and
`Gen2Battle` carries the landmark beside the time of day.

## The pack's target list is the party menu, not a panel

`.Party`'s list, which `GiveItem`, `TeachTMHM` and every healing item open,
renders through `Gen2PartyMenuPage` now, under the `PartyMenuStrings` row each
entrance's `wPartyMenuActionText` picks. `InitPartyMenuWithCancel` was missing:
CANCEL is the row after the last member, the cursor wraps around it, and A there
answers the way `PartyMenuSelect`'s carry does. The icons respawn on every open
and step from `_process` on the hardware clock.

## Proof

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3,227 tests over 152 scripts, green |
| `tools/validate.gd -- all` | exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | complete on each |
| Screenshots | `preview_battle_switch.gd level_up`, `preview_pack.gd use` and `give` |