### PR TITLE
The pack's boxes are the cartridge's, and only a player event takes the sign down

### DIFF
--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -52,9 +52,19 @@ const TEXTBOX_AT: Vector2i = Vector2i(0, 12)
 const TEXTBOX_COLUMNS: int = 20
 const TEXTBOX_ROWS: int = 6
 ## Where `PrintItemDescription` is handed, and the row spacing every text box on
-## the hardware is written with.
+## the hardware is written with. `TEXTBOX_INNERH` is two lines, so a longer text
+## is paged rather than drawn through the frame.
 const TEXT_AT: Vector2i = Vector2i(1, 14)
 const TEXT_SPACING: int = 2
+const TEXTBOX_ROWS_OF_TEXT: int = 2
+
+## `ForgetMove`'s `hlcoord 5, 2 / ld b, NUM_MOVES * 2 / ld c, MOVE_NAME_LENGTH`,
+## whose border runs from that corner to (19, 11).
+const FORGET_AT: Vector2i = Vector2i(5, 2)
+const FORGET_SIZE: Vector2i = Vector2i(15, 10)
+const FORGET_NAME_COLUMN: int = 7
+const FORGET_CURSOR_COLUMN: int = 6
+const FORGET_FIRST_ROW: int = 4
 
 ## `ItemsPocketMenuHeader`: `menu_coords 7, 1, 19, 11` with five rows of eight
 ## columns. `ScrollingMenu_UpdateDisplay` starts one cell in from that corner and
@@ -231,25 +241,78 @@ func _tm_label(entry: Dictionary) -> String:
 ## `Textbox`: the chosen frame around a cleared interior, with the description
 ## printed a tile in and on every second row.
 func _draw_textbox(map: PackedInt32Array, text: String) -> void:
-	var first: int = RomLayout.FRAME_FIRST_CODE
-	var right: int = TEXTBOX_AT.x + TEXTBOX_COLUMNS - 1
-	var bottom: int = TEXTBOX_AT.y + TEXTBOX_ROWS - 1
-	for column: int in range(TEXTBOX_AT.x + 1, right):
-		_put(map, Vector2i(column, TEXTBOX_AT.y), first + RomLayout.FRAME_HORIZONTAL)
-		_put(map, Vector2i(column, bottom), first + RomLayout.FRAME_HORIZONTAL)
-	for row: int in range(TEXTBOX_AT.y + 1, bottom):
-		_put(map, Vector2i(TEXTBOX_AT.x, row), first + RomLayout.FRAME_VERTICAL)
-		_put(map, Vector2i(right, row), first + RomLayout.FRAME_VERTICAL)
-		for column: int in range(TEXTBOX_AT.x + 1, right):
-			_put(map, Vector2i(column, row), BLANK_TILE)
-	_put(map, TEXTBOX_AT, first + RomLayout.FRAME_TOP_LEFT)
-	_put(map, Vector2i(right, TEXTBOX_AT.y), first + RomLayout.FRAME_TOP_RIGHT)
-	_put(map, Vector2i(TEXTBOX_AT.x, bottom), first + RomLayout.FRAME_BOTTOM_LEFT)
-	_put(map, Vector2i(right, bottom), first + RomLayout.FRAME_BOTTOM_RIGHT)
+	draw_frame(map, TEXTBOX_AT, Vector2i(TEXTBOX_COLUMNS, TEXTBOX_ROWS))
 	var line: int = 0
 	for row_text: String in text.split("\n", false):
+		if line >= TEXTBOX_ROWS_OF_TEXT:
+			break
 		_string(map, TEXT_AT + Vector2i(0, line * TEXT_SPACING), row_text)
 		line += 1
+
+
+## `TextboxBorder` and the `ClearBox` behind it, at any corner and any size in
+## tiles including the frame. Every box the pack opens over its own screen is one
+## of these, so the arithmetic lives here once.
+func draw_frame(map: PackedInt32Array, at: Vector2i, size: Vector2i) -> void:
+	var first: int = RomLayout.FRAME_FIRST_CODE
+	var right: int = at.x + size.x - 1
+	var bottom: int = at.y + size.y - 1
+	for column: int in range(at.x + 1, right):
+		_put(map, Vector2i(column, at.y), first + RomLayout.FRAME_HORIZONTAL)
+		_put(map, Vector2i(column, bottom), first + RomLayout.FRAME_HORIZONTAL)
+	for row: int in range(at.y + 1, bottom):
+		_put(map, Vector2i(at.x, row), first + RomLayout.FRAME_VERTICAL)
+		_put(map, Vector2i(right, row), first + RomLayout.FRAME_VERTICAL)
+		for column: int in range(at.x + 1, right):
+			_put(map, Vector2i(column, row), BLANK_TILE)
+	_put(map, at, first + RomLayout.FRAME_TOP_LEFT)
+	_put(map, Vector2i(right, at.y), first + RomLayout.FRAME_TOP_RIGHT)
+	_put(map, Vector2i(at.x, bottom), first + RomLayout.FRAME_BOTTOM_LEFT)
+	_put(map, Vector2i(right, bottom), first + RomLayout.FRAME_BOTTOM_RIGHT)
+
+
+## `MenuBox` and `PlaceVerticalMenuItems`: one of the pack's `MENU_BACKUP_TILES`
+## submenus, drawn over the screen already in [param map] so it wears the
+## attrmap's own palette rather than a layer of its own.
+func draw_menu(
+	map: PackedInt32Array, box: Gen2MenuBox, options: Array, cursor: int
+) -> void:
+	draw_frame(map, box.border_position(), box.border_size())
+	var last_column: int = box.left + box.interior().x
+	for index: int in options.size():
+		var at: Vector2i = box.item_position(index)
+		_string(map, at, String(options[index]), maxi(0, last_column - at.x + 1))
+	if cursor >= 0 and cursor < options.size() \
+		and box.has_flag(Gen2MenuBox.STATICMENU_CURSOR):
+		_put(map, box.cursor_position(cursor), CURSOR_CODE)
+
+
+## `BuySellToss_UpdateQuantityDisplay`: the frame, then `'×'` and
+## `PRINTNUM_LEADINGZEROS | 1, 2` one cell in from its own corner.
+func draw_quantity(map: PackedInt32Array, box: Gen2MenuBox, quantity: int) -> void:
+	draw_frame(map, box.border_position(), box.border_size())
+	var at: Vector2i = box.border_position() + Vector2i.ONE
+	_put(map, at, TIMES_CODE)
+	_string(
+		map, at + Vector2i(1, 0),
+		String.num_int64(maxi(quantity, 0)).lpad(QUANTITY_DIGITS, "0")
+	)
+
+
+## `ForgetMove`'s own list: a `Textbox` at `hlcoord 5, 2` holding `NUM_MOVES * 2`
+## rows of `MOVE_NAME_LENGTH`, `ListMoves` two cells in from that corner with
+## `wListMovesLineSpacing` of two rows, and `w2DMenuCursorInitX` one cell left.
+func draw_move_list(map: PackedInt32Array, names: Array, cursor: int) -> void:
+	draw_frame(map, FORGET_AT, FORGET_SIZE)
+	for index: int in names.size():
+		var row: int = FORGET_FIRST_ROW + index * ROW_SPACING
+		_string(map, Vector2i(FORGET_NAME_COLUMN, row), String(names[index]))
+	if cursor >= 0 and cursor < names.size():
+		_put(
+			map,
+			Vector2i(FORGET_CURSOR_COLUMN, FORGET_FIRST_ROW + cursor * ROW_SPACING),
+			CURSOR_CODE
+		)
 
 
 ## `_CGB_PackPals`' attrmap, as one palette index per cell.
@@ -331,11 +394,20 @@ func compose(
 	return indices
 
 
-func _string(map: PackedInt32Array, at: Vector2i, text: String) -> void:
+## [param max_tiles] below zero is unbounded; a menu passes the room its box has,
+## since a label a mod registers is not written to fit the way every cartridge
+## one is.
+func _string(
+	map: PackedInt32Array, at: Vector2i, text: String, max_tiles: int = -1
+) -> void:
 	var cell: Vector2i = at
+	var drawn: int = 0
 	for code: int in Gen2Text.encode(text):
+		if max_tiles >= 0 and drawn >= max_tiles:
+			return
 		_put(map, cell, code)
 		cell.x += 1
+		drawn += 1
 
 
 func _put(map: PackedInt32Array, at: Vector2i, tile: int) -> void:

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1,10 +1,11 @@
 class_name Gen2StartMenuScreen
 extends Control
 
-## The overworld pause menu (engine/menus/start_menu.asm). The list, `_Option`
-## and `SaveMenu` are the cartridge's own screens through [Gen2StartMenuPage],
-## drawn into whichever [Gen2Screen] the host hands over; the pack's modes are
-## still a window-resolution Control panel, which is `HANDOFF.md`'s open row.
+## The overworld pause menu (engine/menus/start_menu.asm). The list, `_Option`,
+## `SaveMenu` and every box the pack opens are the cartridge's own screens
+## through [Gen2StartMenuPage] and [Gen2PackPage], drawn into whichever
+## [Gen2Screen] the host hands over. A caller that hands over none keeps the
+## window-resolution panel below, which is what a launcher preview gets.
 ##
 ## Pokedex, Pokemon and Pokegear are screens the world already owns
 ## (Gen2PokedexScreen, Gen2PartyScreen, the phone list on
@@ -96,6 +97,28 @@ const ERROR: Color = Color("#ef8a8a")
 ## How many window pixels a hardware pixel is drawn as inside the panel.
 const PACK_VIEW_SCALE: int = 2
 
+## The pack's submenus, all `MENU_BACKUP_TILES` boxes over the pack's own screen.
+##
+## `MenuHeader_UsableKeyItem` and its five siblings differ only in where the box
+## starts: `menu_coords 13, y, SCREEN_WIDTH - 1, TEXTBOX_Y - 1` with y chosen so
+## the rows end on the text box, which is `TEXTBOX_Y - 1 - 2 * items`.
+const ITEM_MENU_LEFT: int = 13
+const ITEM_MENU_RIGHT: int = 19
+const ITEM_MENU_BOTTOM: int = 11
+## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
+## left 14, right 19, top 7, bottom 11.
+const YES_NO_AT: Vector2i = Vector2i(14, 7)
+const YES_NO_SPAN: Vector2i = Vector2i(5, 4)
+## `TossItem_MenuHeader`: `menu_coords 15, 9, SCREEN_WIDTH - 1, TEXTBOX_Y - 1`.
+const TOSS_QUANTITY_AT: Vector2i = Vector2i(15, 9)
+const TOSS_QUANTITY_TO: Vector2i = Vector2i(19, 11)
+## `STATICMENU_CURSOR | STATICMENU_NO_TOP_SPACING`, which every one of them sets.
+const SUBMENU_FLAGS: int = (
+	Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+)
+## `YesNoMenuHeader.MenuData`'s own two strings.
+const YES_NO_OPTIONS: Array[String] = ["YES", "NO"]
+
 var _world: Gen2WorldAPI = null
 var _data: GameData = null
 var _save_action: Callable = Callable()
@@ -118,6 +141,10 @@ var _pack_cursors: Array[int] = [0, 0, 0, 0]
 var _pack_page: Gen2PackPage = null
 var _pack_view: TextureRect = null
 var _pack_result_ok: bool = false
+## `PrintText` waits per page, so a result longer than the box's two rows is
+## pressed through rather than cut off at the frame.
+var _pack_result_pages: Array = []
+var _pack_result_page: int = 0
 ## AskTeachTMHM's resolved prompt, held while its yes/no is on screen, and
 ## whether the party list that follows is ChooseMonToLearnTMHM's rather than
 ## `.Party`'s.
@@ -134,9 +161,11 @@ var _toss_confirm_cursor: int = 0
 ## which acts on the item rather than opening a submenu over it.
 var _giving: bool = false
 var _give_target: int = -1
-## `PokemonAskSwapItemText`'s yes/no and who it is about.
+## `PokemonAskSwapItemText`'s yes/no, who it is about and the question itself,
+## which stands in the pack's own text box while the box is up.
 var _swap_cursor: int = 0
 var _swap_target: int = -1
+var _swap_question: String = ""
 ## Whether the USE running is `UseRegisteredItem`'s rather than the pack's own,
 ## which is the one thing the two jumptables disagree about: their refusals.
 var _using_registered: bool = false
@@ -174,8 +203,7 @@ var _mod_option_cursor: int = 0
 ## The cartridge's own screens, drawn into whichever [Gen2Screen] the host
 ## handed over. `StartMenu`'s box sits over the map, so it goes into the world's
 ## own screen rather than one of this node's; without one, the panel below
-## stands in, which is what a test or the launcher gets. The pack and its
-## modes are still the panel, and are the next row of `HANDOFF.md`'s table.
+## stands in, which is what a test or the launcher gets.
 var _screen: Gen2Screen = null
 var _view: TextureRect = null
 var _page: Gen2StartMenuPage = null
@@ -449,6 +477,8 @@ func _confirm() -> void:
 		## A pack opened over one Pokemon has no menu behind it to go back to:
 		## the party screen closed when it asked for this one.
 		Mode.PACK_RESULT:
+			if _pack_result_advanced():
+				return
 			if _give_target >= 0:
 				closed.emit()
 			else:
@@ -482,6 +512,8 @@ func _cancel() -> void:
 		Mode.PACK_ITEM, Mode.PACK_TEACH:
 			_open_pack_mode(false)
 		Mode.PACK_RESULT:
+			if _pack_result_advanced():
+				return
 			if _give_target >= 0:
 				closed.emit()
 			else:
@@ -822,14 +854,84 @@ func _pack_rows() -> Array:
 func _pack_image() -> Image:
 	if _pack_page == null:
 		_pack_page = Gen2PackPage.from_data(_data)
+	if _pack_page == null:
+		return null
+	return _pack_page.image(
+		_data, _pack_map(_pack_description()), _pack_pocket_index, _player_is_female()
+	)
+
+
+## The pocket listing's own tilemap with [param text] in its description box,
+## which is where every one of the pack's prints lands: `Pack_PrintTextNoScroll`
+## and `MenuTextbox` both write the same six rows at the foot of the screen.
+func _pack_map(text: String) -> PackedInt32Array:
 	var pocket: int = _pack_pocket_index
-	var rows: Array = _pack_rows()
-	var cursor: int = _pack_cursor - _pack_scroll[_pack_pocket_index]
-	var map: PackedInt32Array = _pack_page.pocket_map(
-		pocket, rows, cursor, _pack_description(),
+	return _pack_page.pocket_map(
+		pocket, _pack_rows(), _pack_cursor - _pack_scroll[pocket], text,
 		_data.pack_pocket_name(pocket) if _data != null else PackedByteArray()
 	)
-	return _pack_page.image(_data, map, pocket, _player_is_female())
+
+
+## The pack's screen with one of its `MENU_BACKUP_TILES` boxes over it.
+## [param draw] writes tiles into the map the pack just built, so the box wears
+## the attrmap `_CGB_PackPals` left rather than being a layer of its own.
+func _pack_overlay(text: String, draw: Callable) -> Image:
+	if _pack_page == null:
+		_pack_page = Gen2PackPage.from_data(_data)
+	if _pack_page == null:
+		return null
+	var map: PackedInt32Array = _pack_map(text)
+	if draw.is_valid():
+		draw.call(map)
+	return _pack_page.image(_data, map, _pack_pocket_index, _player_is_female())
+
+
+## `YesNoBox` over one of the pack's printed questions, which is what every one
+## of its confirmations is.
+func _pack_yes_no(text: String, cursor: int) -> Image:
+	return _pack_overlay(_last_page(text), func(map: PackedInt32Array) -> void:
+		_pack_page.draw_menu(
+			map,
+			Gen2MenuBox.from_coords(
+				YES_NO_AT.x, YES_NO_AT.y,
+				YES_NO_AT.x + YES_NO_SPAN.x, YES_NO_AT.y + YES_NO_SPAN.y,
+				SUBMENU_FLAGS
+			),
+			YES_NO_OPTIONS, cursor
+		)
+	)
+
+
+## `MenuHeader_UsableKeyItem` and its five siblings, which are one box whose top
+## is chosen so [param count] rows end on the text box.
+func _item_menu_box(count: int) -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		ITEM_MENU_LEFT, ITEM_MENU_BOTTOM - 2 * maxi(count, 0),
+		ITEM_MENU_RIGHT, ITEM_MENU_BOTTOM, SUBMENU_FLAGS
+	)
+
+
+## What a box is left holding after the prints in front of a question: `YesNoBox`
+## opens over the last page of the last `PrintText`, so a question preceded by
+## more words than two rows hold shows its tail rather than its head.
+## `AskTeachTMHM`'s pair of texts is the one that reaches past a page.
+func _last_page(text: String) -> String:
+	var pages: Array = Gen2TextLayout.lay_out(
+		text, Gen2PackPage.TEXTBOX_COLUMNS - 2, Gen2PackPage.TEXTBOX_ROWS_OF_TEXT
+	)
+	if pages.is_empty():
+		return ""
+	return "\n".join(pages[pages.size() - 1] as PackedStringArray)
+
+
+## Which page of the result text the box is holding.
+func _pack_result_text() -> String:
+	if _pack_result_pages.is_empty():
+		return ""
+	var page: PackedStringArray = _pack_result_pages[
+		clampi(_pack_result_page, 0, _pack_result_pages.size() - 1)
+	]
+	return "\n".join(page)
 
 
 func _pack_description() -> String:
@@ -987,15 +1089,15 @@ func _open_give_swap(party_index: int, held_name: String) -> void:
 	_mode = Mode.PACK_GIVE_SWAP
 	_swap_cursor = 0
 	_swap_target = party_index
+	_swap_question = Gen2WorldPack.ask_swap_text(_target_name(party_index), held_name)
 	_status.text = ""
 	_footer.text = "Up and down: move    A: choose    B: back"
-	_render_give_swap(held_name)
+	_render_give_swap()
 
 
-func _render_give_swap(held_name: String = "") -> void:
+func _render_give_swap() -> void:
 	_title.text = "GIVE"
-	if not held_name.is_empty():
-		_summary.text = Gen2WorldPack.ask_swap_text(_target_name(_swap_target), held_name)
+	_summary.text = _swap_question
 	_render_options([{"label": "YES"}, {"label": "NO"}], _swap_cursor,
 		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
 	)
@@ -1564,14 +1666,14 @@ func _coins() -> int:
 	return _world.state.coins() if _world != null and _world.state != null else 0
 
 
-## One of the pack's own texts, imported when the cache carries it. The lines
-## are joined with a space: these boxes are window-resolution panels rather than
-## the hardware's own, and the source's breaks are where its box ended.
+## One of the pack's own texts, imported when the cache carries it. The source's
+## own line breaks are kept: these boxes are the hardware's now, and a break is
+## where the cartridge ended the row.
 func _pack_text(key: String) -> String:
 	var text: String = _data.menu_text(key) if _data != null else ""
 	if text.is_empty():
 		text = String(TEXT_FALLBACKS.get(key, ""))
-	return text.replace("\n", " ")
+	return text
 
 
 ## `Pack_GetItemName` fills wStringBuffer2 and the dial owns wItemQuantityChange,
@@ -1590,8 +1692,22 @@ func _show_pack_result(message: String, ok: bool) -> void:
 	_mode = Mode.PACK_RESULT
 	_pack_result = message
 	_pack_result_ok = ok
+	_pack_result_pages = Gen2TextLayout.lay_out(
+		message, Gen2PackPage.TEXTBOX_COLUMNS - 2, Gen2PackPage.TEXTBOX_ROWS_OF_TEXT
+	)
+	_pack_result_page = 0
 	_footer.text = "A: continue"
 	_render_pack_result()
+
+
+## `PrintText`'s own wait: a result that runs past the box's two rows is pressed
+## through page by page before the pack comes back.
+func _pack_result_advanced() -> bool:
+	if _pack_result_page + 1 >= _pack_result_pages.size():
+		return false
+	_pack_result_page += 1
+	_render_pack_result()
+	return true
 
 
 func _render_pack_result() -> void:
@@ -1885,6 +2001,53 @@ func _hardware_image() -> Image:
 			return _page.render_options(_options_menu.rows(), _options_menu.cursor)
 		Mode.PACK:
 			return _pack_image()
+		Mode.PACK_ITEM:
+			var labels: Array = []
+			for entry: Dictionary in _item_actions:
+				labels.append(String(entry.get("label", "")))
+			return _pack_overlay(_pack_description(), func(map: PackedInt32Array) -> void:
+				_pack_page.draw_menu(map, _item_menu_box(labels.size()), labels, _item_cursor)
+			)
+		Mode.PACK_TEACH:
+			return _pack_yes_no(String(_teach_prompt.get("text", "")), _teach_cursor)
+		Mode.PACK_FORGET_ASK:
+			return _pack_yes_no(Gen2MoveForget.ask_text(
+				_target_name(_forget_party_index),
+				String(_teach_prompt.get("move_name", ""))
+			), _forget_confirm_cursor)
+		Mode.PACK_STOP_LEARNING:
+			return _pack_yes_no(Gen2MoveForget.stop_text(
+				String(_teach_prompt.get("move_name", ""))
+			), _forget_confirm_cursor)
+		Mode.PACK_TOSS_CONFIRM:
+			return _pack_yes_no(_fill_item_text(
+				_pack_text(TEXT_TOSS_ASK_QUANTITY),
+				String(_selected_item().get("name", "")),
+				_toss_prompt.value if _toss_prompt != null else 1
+			), _toss_confirm_cursor)
+		Mode.PACK_GIVE_SWAP:
+			return _pack_yes_no(_swap_question, _swap_cursor)
+		Mode.PACK_TOSS_QUANTITY:
+			return _pack_overlay(_pack_text(TEXT_TOSS_ASK), func(map: PackedInt32Array) -> void:
+				_pack_page.draw_quantity(
+					map,
+					Gen2MenuBox.from_coords(
+						TOSS_QUANTITY_AT.x, TOSS_QUANTITY_AT.y,
+						TOSS_QUANTITY_TO.x, TOSS_QUANTITY_TO.y, 0
+					),
+					_toss_prompt.value if _toss_prompt != null else 1
+				)
+			)
+		Mode.PACK_FORGET:
+			var moves: Array = []
+			for entry: Dictionary in _forget_moves:
+				moves.append(String(entry.get("name", "")))
+			return _pack_overlay(
+				Gen2MoveForget.which_text(), func(map: PackedInt32Array) -> void:
+					_pack_page.draw_move_list(map, moves, _forget_cursor)
+			)
+		Mode.PACK_RESULT:
+			return _pack_overlay(_pack_result_text(), Callable())
 		Mode.PACK_TARGET:
 			if _party_menu_page() == null:
 				return null

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1088,7 +1088,7 @@ func _after_map_settled() -> bool:
 	if sight_results.is_empty():
 		sight_results = _world.dispatch_script_events()
 	if not sight_results.is_empty():
-		_zero_map_name_sign_timer()
+		_zero_map_name_sign_for(sight_results)
 		_show_script_results(sight_results)
 		return true
 	var special_attempt: Dictionary = _world.try_special_phone_call()
@@ -3801,6 +3801,23 @@ func _advance_map_name_sign() -> void:
 ## so a queued one used to take down the very sign the map load had raised.
 func _zero_map_name_sign_timer() -> void:
 	_hide_map_name_sign()
+
+
+## The same, for a batch of script results, since only some of them are a player
+## event. `RunMapCallback`'s work is map setup and reaches `PlayerEvents` never;
+## `RunSceneScript` runs its scene script and then answers carry only when that
+## script set RUN_DEFERRED_SCRIPT, so a scene of bare `end`s (Route 29's two, and
+## most of the map scenes in either pin) raises no event and takes no sign down.
+func _zero_map_name_sign_for(results: Array) -> void:
+	for result: Dictionary in results:
+		match StringName((result.get("source", {}) as Dictionary).get("kind", &"")):
+			&"callback":
+				continue
+			&"scene":
+				if not bool(result.get("deferred", false)):
+					continue
+		_zero_map_name_sign_timer()
+		return
 
 
 func _hide_map_name_sign() -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -49,6 +49,11 @@ var _last_item: int = 0
 var _staged_warp: Dictionary = {}
 var _script_value: int = 0
 var _command_count: int = 0
+## `Script_sdefer`'s own `RUN_DEFERRED_SCRIPT`, which is the only thing that
+## makes `RunSceneScript` answer `PlayerEvents` with carry: a scene script that
+## does not set it has run and raised no player event
+## (engine/overworld/events.asm).
+var _ran_deferred: bool = false
 var _active: bool = false
 var _completed: bool = false
 var _failure: Dictionary = {}
@@ -1691,6 +1696,7 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 			})
 			return _stage_frame_wait(delay_frames)
 		0x8C:
+			_ran_deferred = true
 			if not _push_frame(bank, int(command.get("address", 0))):
 				return {
 					"ok": false, "reason": &"missing_deferred_script",
@@ -3648,6 +3654,7 @@ func _complete_result() -> Dictionary:
 		"source": _request.duplicate(true),
 		"warp": _staged_warp.duplicate(true),
 		"commands": _command_count,
+		"deferred": _ran_deferred,
 	}
 	if _staged_day_of_week >= 0:
 		result["clock"] = {
@@ -3760,6 +3767,7 @@ func _waiting_result() -> Dictionary:
 		"events": _drain_events(),
 		"source": _request.duplicate(true),
 		"commands": _command_count,
+		"deferred": _ran_deferred,
 	}
 
 

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -240,6 +240,30 @@ func test_a_queued_map_callback_does_not_take_the_sign_down() -> void:
 	)
 
 
+## And a callback that has actually run does not take it down either, which is
+## the other half: `RunMapCallback` is map setup, and `RunSceneScript` answers
+## `PlayerEvents` with carry only when its scene script set RUN_DEFERRED_SCRIPT.
+## Route 29's two scene scripts are bare `end`s, so crossing New Bark's west edge
+## used to lose the sign seven frames in.
+func test_only_a_player_event_result_takes_the_sign_down() -> void:
+	_screen = await _walk_onto_the_door()
+	for _frame: int in WALK_FRAME_CAP:
+		_screen.advance_frame()
+		if _screen.map_name_sign_frames() > 0:
+			break
+	var raised: int = _screen.map_name_sign_frames()
+	assert_eq(raised, Gen2WorldAPI.MAP_NAME_SIGN_FRAMES)
+
+	_screen._zero_map_name_sign_for([{"source": {"kind": &"callback"}}])
+	assert_eq(_screen.map_name_sign_frames(), raised, "a map callback raises no event")
+
+	_screen._zero_map_name_sign_for([{"source": {"kind": &"scene"}, "deferred": false}])
+	assert_eq(_screen.map_name_sign_frames(), raised, "and nor does a scene of bare ends")
+
+	_screen._zero_map_name_sign_for([{"source": {"kind": &"scene"}, "deferred": true}])
+	assert_eq(_screen.map_name_sign_frames(), 0, "an `sdefer` is the carry that does")
+
+
 ## `.CheckMovingWithinLandmark`: the map the world opens on is `wPrevLandmark`,
 ## so walking back into the landmark just left raises nothing.
 func test_a_warp_back_into_the_same_landmark_raises_no_sign() -> void:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -282,21 +282,23 @@ func test_menu_account_draws_the_entry_description_and_off_takes_it_away() -> vo
 
 
 ## The pack's wording is the cartridge's, read out of the cache rather than
-## written here. `Pack_GetItemName` fills the name slot and the dial owns the
-## number, so both markers are gone by the time a box is drawn.
+## written here, and its own line breaks are kept: the box is the hardware's now,
+## and a break is where the cartridge ended the row. `Pack_GetItemName` fills the
+## name slot and the dial owns the number, so both markers are gone by the time a
+## box is drawn.
 func test_the_toss_boxes_read_the_cartridges_own_words() -> void:
 	await _open_world()
 	_world_screen._world.state.apply_changes({}, {}, {"items": {7: 5}})
 	var host: Gen2StartMenuScreen = await _open_pack()
 	_choose_action(host, Gen2WorldPack.ACTION_TOSS)
-	assert_eq(host.get("_status").text, "Throw away how many?")
+	assert_eq(host.get("_status").text, "Throw away how\nmany?")
 
 	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
-	assert_eq(host.get("_summary").text, "Throw away 5 POTION(S)?")
+	assert_eq(host.get("_summary").text, "Throw away 5\nPOTION(S)?")
 
 	host.handle_button(Gen2Button.A)
-	assert_eq(String(host.get("_pack_result")), "Threw away POTION(S).")
+	assert_eq(String(host.get("_pack_result")), "Threw away\nPOTION(S).")
 	for marker: String in [Gen2TextStream.RAM_MARKER, Gen2TextStream.NUMBER_MARKER]:
 		assert_eq(String(host.get("_pack_result")).find(marker), -1, marker)
 
@@ -913,6 +915,65 @@ func test_use_on_a_party_item_asks_which_mon_then_heals_and_spends_it() -> void:
 	host.handle_button(Gen2Button.A)
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
 	assert_eq(((host.get("_pack_pockets")[0] as Dictionary)["items"] as Array).size(), 0)
+
+
+## Every box the pack opens is one of the cartridge's own `MENU_BACKUP_TILES`
+## menus over the pack screen rather than a window-resolution panel, so each mode
+## answers `_hardware_image()`. The two walks below reach all nine between them.
+func test_every_box_the_pack_opens_is_a_cartridge_page() -> void:
+	var host: Gen2StartMenuScreen = await _open_pack_with_a_hurt_party()
+	assert_not_null(host.call("_hardware_image"), "the pocket listing")
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
+	assert_not_null(host.call("_hardware_image"), "USE/GIVE/TOSS/QUIT")
+
+	## TOSS is the third row of a usable, holdable, tossable item.
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TOSS_QUANTITY)
+	assert_not_null(host.call("_hardware_image"), "the quantity dial")
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TOSS_CONFIRM)
+	assert_not_null(host.call("_hardware_image"), "the throw-away yes/no")
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_not_null(host.call("_hardware_image"), "the result box")
+
+
+func test_every_box_the_tm_path_opens_is_a_cartridge_page() -> void:
+	_write_tmhm_item()
+	await _open_world()
+	_fill_moveset()
+	var host: Gen2StartMenuScreen = await _open_tmhm_pack()
+
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TEACH)
+	assert_not_null(host.call("_hardware_image"), "AskTeachTMHM's yes/no")
+
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
+	assert_not_null(host.call("_hardware_image"), "ForgetMove's ask")
+
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET)
+	assert_not_null(host.call("_hardware_image"), "ListMoves' own box")
+
+	host.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_STOP_LEARNING)
+	assert_not_null(host.call("_hardware_image"), "LearnMove.cancel's yes/no")
 
 
 ## `.Party` opens the party menu itself, not a panel: `GiveItem` and every


### PR DESCRIPTION
Two reported defects.

**Every box the pack opens is a cartridge screen.** `Gen2StartMenuScreen`'s nine
remaining panels are `Gen2PackPage` overlays, so `_hardware_image()` answers
every mode. Each is a `MENU_BACKUP_TILES` box drawn as tiles into the pocket map
the pack had already built rather than a layer of its own, so it wears the
palette `_CGB_PackPals`' attrmap left over that region.

| Box | Source |
|---|---|
| USE/GIVE/TOSS/QUIT and its five siblings | `menu_coords 13, TEXTBOX_Y - 1 - 2 * items, SCREEN_WIDTH - 1, TEXTBOX_Y - 1` |
| The five yes/no confirmations | `YesNoBox`'s `lb bc, SCREEN_WIDTH - 6, 7` |
| The toss dial | `TossItem_MenuHeader`, with `'×'` and two leading-zero digits one cell in |
| `ForgetMove`'s list | its own `Textbox` at `hlcoord 5, 2`, `ListMoves` two cells in, the cursor one left |

`Pack_PrintTextNoScroll` and `LoadMenuTextbox`'s header are the same six rows, so
those prints keep the source's own line breaks now rather than joining them with
a space, a question that follows more words than two rows hold shows the last
page the way `YesNoBox` opens over it, and a result is pressed through page by
page the way `PrintText` waits.

**Only a player event takes the map name sign down.** `PlayerEvents` zeroes
`wLandmarkSignTimer` behind `DoPlayerEvent`, and a dispatched script result is
one of its carry branches only when it really is: `RunMapCallback` is map setup
and reaches `PlayerEvents` never, and `RunSceneScript` runs its scene script and
then answers carry only when that script set `RUN_DEFERRED_SCRIPT`, which is
`sdefer` alone. Route 29's two scene scripts are bare `end`s, so crossing New
Bark's west edge lost its sign seven frames into the sixty. It stands its full
sixty now, on that crossing and on every map whose callbacks or scene scripts run
under one.

GUT 3,230 over 152 scripts, green; `validate.gd` `world_scripts` and
`map_name_sign` PASS; `replay_world.gd` 11 routes, 0 failures; the story walk
green on all three profiles.