### PR TITLE
The healing machine draws its balls

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -792,16 +792,22 @@ func overworld_sprite_indices(number: int) -> PackedByteArray:
 
 ## One of the sprites the engine draws over an object rather than as one, by the
 ## name `data/sprites/emotes.asm` gives it plus ShakeHeadbuttTree's own sheet:
-## { tiles, vtile, indices }, empty when the cache does not hold it.
+## { tiles, vtile, indices, colors }, empty when the cache does not hold it.
+## `colors` is only on the heal machine, which is the one sheet that brings its
+## own palette instead of wearing an overworld one.
 func overworld_effect(name: String) -> Dictionary:
 	for row: Variant in _overworld_effect_records():
 		if not row is Dictionary or String((row as Dictionary).get("name", "")) != name:
 			continue
 		var record: Dictionary = row as Dictionary
+		var colors: PackedColorArray = PackedColorArray()
+		for packed: Variant in (record.get("colors", []) as Array):
+			colors.append(Gen2Palette.from_packed(int(packed)))
 		return {
 			"name": name,
 			"tiles": int(record.get("tiles", 0)),
 			"vtile": int(record.get("vtile", 0)),
+			"colors": colors,
 			"indices": _payload_bytes(
 				record if record.has(RomCache.PAYLOAD_KEY) else record.get("bytes", []),
 				_blob("overworld_effects"),

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 68
+const FORMAT_VERSION: int = 69
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1919,6 +1919,11 @@ const GOLD_SILVER: Dictionary = {
 	"headbutt_tree_gfx": 0x8CB0B,
 	"cut_tree_gfx": 0x8CC04,
 	"cut_grass_gfx": 0x8CC44,
+	## `HealMachineAnim.HealMachineGFX` and the palette `.LoadPalettes` copies
+	## into wOBPals2's PAL_OW_TREE slot. Neither has a table either: both are
+	## located by their own bytes, which occur once per dump.
+	"heal_machine_gfx": 0x127D5,
+	"heal_machine_palette": 0x12828,
 	"mart_table": 0x162FE,
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
@@ -2311,6 +2316,8 @@ const CRYSTAL: Dictionary = {
 	"headbutt_tree_gfx": 0x8C893,
 	"cut_tree_gfx": 0x8C98C,
 	"cut_grass_gfx": 0x8C9CC,
+	"heal_machine_gfx": 0x123FC,
+	"heal_machine_palette": 0x12451,
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -620,12 +620,12 @@ const EMOTE_TILE_LAYOUT: Array = [
 	[1, 0xFC], [2, 0xFC], [2, 0xFE], [1, 0xFE],
 ]
 
-## The three sheets `engine/events/field_moves.asm` loads by name rather than
-## through a table: name, layout key, tiles, the tile they are loaded to, and the
-## first tile row each one starts with. None has a table to pin it, and a wrong
-## offset in this bank decodes the routine beside it as legal-looking art, so the
-## signature is the check. CutTreeGFX and CutGrassGFX are adjacent, which is what
-## makes one wrong offset show up on two sheets.
+## The sheets an engine routine loads by name rather than through a table: name,
+## layout key, tiles, the tile they are loaded to, and the bytes each one starts
+## with. None has a table to pin it, and a wrong offset in these banks decodes
+## the routine beside it as legal-looking art, so the signature is the check.
+## CutTreeGFX and CutGrassGFX are adjacent, which is what makes one wrong offset
+## show up on two sheets.
 const FIELD_MOVE_SHEETS: Array = [
 	## FIELDMOVE_TREE, which ShakeHeadbuttTree and Cut_SpawnAnimateTree write
 	## into the struct's own tile field rather than reading from a table.
@@ -636,7 +636,20 @@ const FIELD_MOVE_SHEETS: Array = [
 	## FIELDMOVE_GRASS, the leaves' own tile.
 	["cut_grass", "cut_grass_gfx", 4, 0x80,
 		[0x00, 0x00, 0x3C, 0x3C, 0x7E, 0x42, 0xE3, 0x9D]],
+	## `HealMachineAnim.LoadGFX`'s two tiles at `vTiles0 tile $7c`: the machine's
+	## own bar and one ball. Both tiles are the signature, since a two-tile sheet
+	## whose first row is blank pins nothing on its own.
+	["heal_machine", "heal_machine_gfx", 2, 0x7C,
+		[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7E, 0x00,
+		0x7E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C, 0x12, 0x1E,
+		0x21, 0x3F, 0x33, 0x2D, 0x1E, 0x12, 0x0C, 0x0C]],
 ]
+
+## `HealMachineAnim.LoadPalettes` copies one four-colour palette over
+## `wOBPals2 palette PAL_OW_TREE`, so the machine and its balls do not wear the
+## time of day the rest of the overworld's objects do.
+const HEAL_MACHINE_PALETTE_COLORS: int = 4
 
 static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var table: int = int(layout.get("emotes", -1))
@@ -685,13 +698,39 @@ static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Diction
 		)
 		if sheet_pixels.size() != sheet_tiles * Gen2Tiles.TILE_PIXELS:
 			return _error("%s graphics did not decode." % name)
-		effects.append({
+		var record: Dictionary = {
 			"name": name,
 			"tiles": sheet_tiles,
 			"vtile": int(sheet[3]),
 			"bytes": Array(sheet_pixels),
-		})
+		}
+		if name == "heal_machine":
+			var machine_palette: Dictionary = _read_heal_machine_palette(rom, layout)
+			if not bool(machine_palette.get("ok", false)):
+				return machine_palette
+			record["colors"] = machine_palette["colors"]
+		effects.append(record)
 	return {"ok": true, "effects": effects}
+
+
+## `HealMachineAnim.palettes`, `gfx/overworld/heal_machine.pal`: white, two reds
+## and black. It is byte-identical on all three cartridges, and `.FlashPalettes`
+## rotates these four rather than loading a second set, so this is the whole of
+## the animation's colour.
+static func _read_heal_machine_palette(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var offset: int = int(layout.get("heal_machine_palette", -1))
+	var bytes: int = HEAL_MACHINE_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
+	if offset < 0 or not rom.in_bounds(offset, bytes):
+		return _error("The heal machine palette is outside the cartridge.")
+	var colors: Array = []
+	for slot: int in HEAL_MACHINE_PALETTE_COLORS:
+		var color: int = rom.u16le(offset + slot * Gen2Palette.COLOR_BYTES)
+		if color & 0x8000:
+			return _error("Heal machine palette colour %d is not colour data." % slot)
+		colors.append(color)
+	if colors[0] != 0x7FFF or colors[HEAL_MACHINE_PALETTE_COLORS - 1] != 0:
+		return _error("The heal machine palette does not run white to black.")
+	return {"ok": true, "colors": colors}
 
 
 static func _read_tileset(rom: RomFile, layout: Dictionary, number: int) -> Dictionary:

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -25,6 +25,45 @@ const SPRITE_HEADBUTT_TREE: StringName = &"headbutt_tree"
 const SPRITE_CUT_TREE: StringName = &"cut_tree"
 const SPRITE_CUT_LEAF: StringName = &"cut_grass"
 const SPRITE_SHADOW: StringName = &"shadow"
+const SPRITE_HEAL_MACHINE: StringName = &"heal_machine"
+
+## `HealMachineAnim`'s two OAM tables, as (screen pixel, tile, flip). An OAM byte
+## pair is (y + 16, x + 8), so each `dbsprite` is read back to the pixel the
+## renderer draws at. `.PC_ElmsLab_OAM` starts with the two `$7c` halves of the
+## machine itself, which `.PC_LoadBallsOntoMachine` places before the party loop
+## and `.HOF_LoadBallsOntoMachine` does not; the six behind them are the balls,
+## one a party member.
+const HEAL_MACHINE_BAR: Array = [
+	[Vector2i(26, 16), 0, false],
+	[Vector2i(30, 16), 0, false],
+]
+const HEAL_MACHINE_BALLS: Array = [
+	[Vector2i(24, 22), 1, false],
+	[Vector2i(32, 22), 1, true],
+	[Vector2i(24, 27), 1, false],
+	[Vector2i(32, 27), 1, true],
+	[Vector2i(24, 32), 1, false],
+	[Vector2i(32, 32), 1, true],
+]
+## `.HOF_OAM`, whose six balls are a ring rather than two columns.
+const HEAL_MACHINE_HOF_BALLS: Array = [
+	[Vector2i(73, 44), 1, false],
+	[Vector2i(78, 44), 1, false],
+	[Vector2i(69, 43), 1, false],
+	[Vector2i(82, 43), 1, false],
+	[Vector2i(65, 41), 1, false],
+	[Vector2i(85, 41), 1, false],
+]
+## `.PlaceHealingMachineTile`'s `bcpixel 2, 4`, added to every entry of the table
+## on Elm's Lab alone; the other two machine types add nothing.
+const HEAL_MACHINE_ELMS_LAB_OFFSET := Vector2i(16, 32)
+const HEAL_MACHINE_ELMS_LAB: int = 1
+const HEAL_MACHINE_HALL_OF_FAME: int = 2
+## `.LoadBallsOntoMachine`'s `ld c, 30 / call DelayFrames` and
+## `.FlashPalettes8Times`' eight rounds of ten, which is what the script waits.
+const HEAL_MACHINE_BALL_FRAMES: int = 30
+const HEAL_MACHINE_FLASH_INTERVAL: int = 10
+const HEAL_MACHINE_FLASHES: int = 8
 
 ## constants/sprite_data_constants.asm. Every emote-object spawn names its
 ## palette: PAL_OW_EMOTE for the dust and the emote bubbles, PAL_OW_TREE for the
@@ -203,6 +242,30 @@ func start_boulder_dust(object_index: int, cell: Vector2i, direction: Vector2i, 
 	})
 
 
+## `HealMachineAnim`, which is neither a map object nor an object-tracking
+## sprite: its OAM is written at fixed screen pixels while the script waits, and
+## it wears `gfx/overworld/heal_machine.pal` over `wOBPals2`' PAL_OW_TREE slot
+## rather than an overworld palette, which is what `palette: -1` says here.
+##
+## [param balls] is `wPartyCount`; the source returns before writing anything
+## when it is zero.
+func start_heal_machine(machine_type: int, balls: int) -> void:
+	if balls <= 0:
+		return
+	_sprites.append({
+		"kind": SPRITE_HEAL_MACHINE,
+		"cell": Vector2i.ZERO,
+		"object_index": -1,
+		"screen": true,
+		"palette": -1,
+		"frame": 0,
+		"duration": balls * HEAL_MACHINE_BALL_FRAMES
+			+ HEAL_MACHINE_FLASHES * HEAL_MACHINE_FLASH_INTERVAL,
+		"machine_type": clampi(machine_type, 0, HEAL_MACHINE_HALL_OF_FAME),
+		"balls": mini(balls, HEAL_MACHINE_BALLS.size()),
+	})
+
+
 func advance_frame() -> bool:
 	var moved: bool = false
 	var running: Array = []
@@ -255,7 +318,9 @@ func sprites() -> Array:
 			"kind": sprite["kind"],
 			"cell": sprite["cell"],
 			"object_index": int(sprite["object_index"]),
+			"screen": bool(sprite.get("screen", false)),
 			"palette": int(sprite["palette"]),
+			"rotation": _palette_rotation(sprite),
 			"frame": int(sprite["frame"]),
 			"tiles": _tiles_for(sprite),
 		})
@@ -358,6 +423,33 @@ func _tiles_for(sprite: Dictionary) -> Array:
 				{"offset": at, "tile": 0, "flip_x": false},
 				{"offset": at + Vector2i(8, 0), "tile": 0, "flip_x": true},
 			]
+		SPRITE_HEAL_MACHINE:
+			## One ball a party member, thirty frames apart, and the machine's
+			## own two tiles under them for every type but the Hall of Fame.
+			## Nothing is taken away again: the flashes run over the finished
+			## picture.
+			var machine_type: int = int(sprite["machine_type"])
+			var shown: int = clampi(
+				int(float(frame) / float(HEAL_MACHINE_BALL_FRAMES)) + 1,
+				0, int(sprite["balls"])
+			)
+			var entries: Array = []
+			if machine_type != HEAL_MACHINE_HALL_OF_FAME:
+				entries.append_array(HEAL_MACHINE_BAR)
+				entries.append_array(HEAL_MACHINE_BALLS.slice(0, shown))
+			else:
+				entries.append_array(HEAL_MACHINE_HOF_BALLS.slice(0, shown))
+			var shift := Vector2i.ZERO
+			if machine_type == HEAL_MACHINE_ELMS_LAB:
+				shift = HEAL_MACHINE_ELMS_LAB_OFFSET
+			var machine: Array = []
+			for entry: Array in entries:
+				machine.append({
+					"offset": (entry[0] as Vector2i) + shift,
+					"tile": int(entry[1]),
+					"flip_x": bool(entry[2]),
+				})
+			return machine
 		SPRITE_BOULDER_DUST:
 			## `SetFacingBoulderDust` swaps FACING_BOULDER_DUST_1 and _2 on bit 1
 			## of the step frame, and each draws its one tile four times in a
@@ -373,6 +465,20 @@ func _tiles_for(sprite: Dictionary) -> Array:
 				})
 			return dust
 	return []
+
+
+## `.FlashPalettes` rotates the four colours of the palette left by one and
+## `.FlashPalettes8Times` calls it once every ten frames, so a sprite wearing its
+## own palette reports which rotation is up. Eight rotations of four leave the
+## palette where it started, which is why the animation needs no restore.
+func _palette_rotation(sprite: Dictionary) -> int:
+	if StringName(sprite["kind"]) != SPRITE_HEAL_MACHINE:
+		return 0
+	var flashes_at: int = int(sprite["balls"]) * HEAL_MACHINE_BALL_FRAMES
+	var frame: int = int(sprite["frame"])
+	if frame < flashes_at:
+		return 0
+	return (int(float(frame - flashes_at) / float(HEAL_MACHINE_FLASH_INTERVAL)) + 1) & 3
 
 
 ## `BattleAnim_Sine` and `..._Cosine` over `BattleAnimSineWave`, which is what

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -280,6 +280,11 @@ func _draw() -> void:
 			sprite,
 			Vector2((sprite["cell"] as Vector2i) * Gen2WorldAPI.CELL_PIXELS) - camera_pixels,
 		)
+	## `HealMachineAnim` writes OAM at fixed screen pixels rather than over an
+	## object or a cell, so the camera does not move it.
+	for sprite: Dictionary in _effect_sprites():
+		if bool(sprite.get("screen", false)):
+			_draw_effect_sprite(sprite, Vector2.ZERO)
 	_draw_encounter_pulse(camera_pixels)
 
 
@@ -561,6 +566,8 @@ func _hidden_tree_tiles() -> Dictionary:
 ## spawned them, so their anchor is where that object is drawn. -1 is the player.
 func _draw_effect_sprites(object_index: int, pixel: Vector2) -> void:
 	for sprite: Dictionary in _effect_sprites():
+		if bool(sprite.get("screen", false)):
+			continue
 		if int(sprite["object_index"]) == object_index:
 			_draw_effect_sprite(sprite, pixel)
 
@@ -576,7 +583,22 @@ func _draw_effect_sprite(sprite: Dictionary, anchor: Vector2) -> void:
 			int(sprite["palette"]),
 			bool(tile["flip_x"]),
 			anchor + Vector2(tile["offset"] as Vector2i),
+			int(sprite.get("rotation", 0)),
 		)
+
+
+## A sheet with a `colors` of its own is the heal machine, whose palette
+## `.LoadPalettes` writes over PAL_OW_TREE and `.FlashPalettes` then rotates
+## left. Everything else wears the overworld palette its spawn named, at the
+## time of day the map is on.
+func _effect_palette(sheet: Dictionary, palette_index: int, rotation: int) -> PackedColorArray:
+	var own: PackedColorArray = sheet.get("colors", PackedColorArray())
+	if own.is_empty():
+		return _world.data.overworld_sprite_palette(palette_index, _time_of_day)
+	var rotated := PackedColorArray()
+	for slot: int in own.size():
+		rotated.append(own[(slot + rotation) % own.size()])
+	return rotated
 
 
 func _effect_sheet(name: String) -> Dictionary:
@@ -591,11 +613,14 @@ func _effect_sheet(name: String) -> Dictionary:
 
 ## One 8x8 tile of an effect sheet. Index 0 is the transparent colour here, as it
 ## is for every object: these are sprites, not background.
+## [param rotation] is `.FlashPalettes`' rotate-left count, which only a sheet
+## carrying its own palette can be asked for.
 func _draw_effect_tile(
-	sheet: Dictionary, tile: int, palette_index: int, flip_x: bool, at: Vector2
+	sheet: Dictionary, tile: int, palette_index: int, flip_x: bool, at: Vector2,
+	rotation: int = 0
 ) -> void:
-	var key: String = "%s:%d:%d:%d:%d" % [
-		sheet["name"], tile, palette_index, int(flip_x), _time_of_day,
+	var key: String = "%s:%d:%d:%d:%d:%d" % [
+		sheet["name"], tile, palette_index, int(flip_x), _time_of_day, rotation,
 	]
 	var texture: Texture2D = _effect_textures.get(key, null)
 	if texture == null:
@@ -603,9 +628,7 @@ func _draw_effect_tile(
 		var tiles: int = int(sheet["tiles"])
 		if tile < 0 or tile >= tiles or indices.size() < tiles * Gen2Tiles.TILE_PIXELS:
 			return
-		var palette: PackedColorArray = _world.data.overworld_sprite_palette(
-			palette_index, _time_of_day
-		)
+		var palette: PackedColorArray = _effect_palette(sheet, palette_index, rotation)
 		var image := Image.create(
 			Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT, false, Image.FORMAT_RGBA8
 		)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -174,8 +174,7 @@ var _replay_held_direction: int = Gen2Button.NONE
 var _spending_frame: bool = false
 ## `HealMachineAnim`'s own sounds and the frame of its wait each is due on, taken
 ## from the event the special emits and spent by [method advance_frame]. The
-## machine's two tiles are not drawn with them: `gfx/overworld/heal_machine.2bpp`
-## is imported by nothing.
+## machine's two tiles are drawn alongside them by Gen2WorldEffects.
 var _heal_machine_sounds: Array = []
 var _heal_machine_frame: int = 0
 var _screen_base_position: Vector2 = Vector2.ZERO
@@ -1418,6 +1417,20 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 				Gen2WorldAPI.STEP_FRAMES_HOP,
 			)
 		_script_prompt = "Debug cut animation preview"
+		_renderer.refresh()
+		_refresh_labels()
+		return
+	if kind == &"heal_machine":
+		## `HealMachineAnim` over Elm's Lab, driven to the last frame before
+		## `.FlashPalettes8Times` starts: a full party is on the machine and the
+		## palette is still the one `.LoadPalettes` wrote, which is the picture
+		## the colours can be read off.
+		if _effects != null:
+			var balls: int = Gen2WorldEffects.HEAL_MACHINE_BALLS.size()
+			_effects.start_heal_machine(Gen2WorldEffects.HEAL_MACHINE_ELMS_LAB, balls)
+			for _frame: int in balls * Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES - 1:
+				_effects.advance_frame()
+		_script_prompt = "Debug heal machine preview"
 		_renderer.refresh()
 		_refresh_labels()
 		return
@@ -3991,6 +4004,10 @@ func _play_encounter_sounds() -> void:
 func _start_heal_machine_sounds(event: Dictionary) -> void:
 	_heal_machine_sounds = (event.get("sounds", []) as Array).duplicate(true)
 	_heal_machine_frame = 0
+	if _effects != null:
+		_effects.start_heal_machine(
+			int(event.get("machine_type", 0)), int(event.get("balls", 0))
+		)
 	_advance_heal_machine_sounds()
 
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -117,12 +117,12 @@ const SPECIAL_RESTART_MAP_MUSIC: int = 61
 const SPECIAL_HEAL_MACHINE_ANIM: int = 62
 ## `HealMachineAnim.Pointers`' three sequences. Only the Hall of Fame's differs:
 ## it loads its balls from a second OAM table and plays two effects where the
-## other two play `MUSIC_HEAL`.
-const HEAL_MACHINE_HALL_OF_FAME: int = 2
-## `.LoadBallsOntoMachine`'s `ld c, 30 / call DelayFrames`, once a party member.
-const HEAL_MACHINE_BALL_FRAMES: int = 30
-## `.FlashPalettes8Times`: eight passes of `ld c, 10 / call DelayFrames`.
-const HEAL_MACHINE_FLASH_FRAMES: int = 80
+## other two play `MUSIC_HEAL`. The routine's own frame costs belong to the
+## animation, so they are read from the class that draws it.
+const HEAL_MACHINE_HALL_OF_FAME: int = Gen2WorldEffects.HEAL_MACHINE_HALL_OF_FAME
+const HEAL_MACHINE_BALL_FRAMES: int = Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES
+const HEAL_MACHINE_FLASH_FRAMES: int = Gen2WorldEffects.HEAL_MACHINE_FLASHES \
+	* Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL
 ## constants/sfx_constants.asm. The first is played once a ball by
 ## `.LoadBallsOntoMachine`; the other two are `.HOF_PlaySFX`'s pair.
 const SFX_SECOND_PART_OF_ITEMFINDER: int = 0x12

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -290,3 +290,68 @@ func test_an_actor_that_has_not_moved_reports_no_redraw() -> void:
 	actor.out = [{"icon": 1, "position_cells": Vector2(3, 3.5)}]
 	assert_true(actors.advance_frame())
 	RomCache.clear(ActorFixture.directory())
+
+
+## `HealMachineAnim`: one ball every thirty frames over the machine's own two
+## tiles, Elm's Lab shifted by `bcpixel 2, 4`, and the Hall of Fame's ring drawn
+## from its own table with no machine under it.
+func test_the_heal_machine_places_one_ball_every_thirty_frames() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_heal_machine(0, 3)
+	var first: Dictionary = effects.sprites()[0]
+	assert_true(bool(first["screen"]), "The machine is drawn at screen pixels.")
+	assert_eq(int(first["palette"]), -1, "The machine wears its own palette.")
+	assert_eq((first["tiles"] as Array).size(), 3, "Two machine tiles and one ball.")
+	assert_eq(
+		(first["tiles"] as Array)[2]["offset"], Gen2WorldEffects.HEAL_MACHINE_BALLS[0][0]
+	)
+	for _frame: int in Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES:
+		effects.advance_frame()
+	assert_eq((effects.sprites()[0]["tiles"] as Array).size(), 4, "The second ball.")
+	for _frame: int in Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES * 2:
+		effects.advance_frame()
+	assert_eq(
+		(effects.sprites()[0]["tiles"] as Array).size(), 5,
+		"A party of three places three balls and no more."
+	)
+
+
+func test_the_heal_machine_shifts_for_elms_lab_and_rings_for_the_hall_of_fame() -> void:
+	var lab := Gen2WorldEffects.new()
+	lab.start_heal_machine(Gen2WorldEffects.HEAL_MACHINE_ELMS_LAB, 1)
+	assert_eq(
+		(lab.sprites()[0]["tiles"] as Array)[0]["offset"],
+		Gen2WorldEffects.HEAL_MACHINE_BAR[0][0] + Gen2WorldEffects.HEAL_MACHINE_ELMS_LAB_OFFSET
+	)
+	var hall := Gen2WorldEffects.new()
+	hall.start_heal_machine(Gen2WorldEffects.HEAL_MACHINE_HALL_OF_FAME, 1)
+	var tiles: Array = hall.sprites()[0]["tiles"]
+	assert_eq(tiles.size(), 1, "The Hall of Fame places no machine tiles.")
+	assert_eq(tiles[0]["offset"], Gen2WorldEffects.HEAL_MACHINE_HOF_BALLS[0][0])
+
+
+## `.FlashPalettes8Times` rotates the four colours left once every ten frames,
+## and eight rotations of four leave the palette where it started.
+func test_the_heal_machine_rotates_its_palette_once_the_balls_are_placed() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_heal_machine(0, 1)
+	assert_eq(int(effects.sprites()[0]["rotation"]), 0, "Nothing rotates under the balls.")
+	for _frame: int in Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES:
+		effects.advance_frame()
+	assert_eq(int(effects.sprites()[0]["rotation"]), 1)
+	for _frame: int in Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL * 3:
+		effects.advance_frame()
+	assert_eq(int(effects.sprites()[0]["rotation"]), 0, "Four rotations is the identity.")
+	for _frame: int in Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL * 5:
+		effects.advance_frame()
+	assert_false(
+		effects.sprites_active(),
+		"The animation lasts the balls' frames plus the eight flashes' eighty."
+	)
+
+
+## `ld a, [wPartyCount] / and a / ret z`: an empty party draws nothing at all.
+func test_the_heal_machine_draws_nothing_for_an_empty_party() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_heal_machine(0, 0)
+	assert_false(effects.sprites_active())

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -23,8 +23,14 @@ const EXPECTED: Array = [
 	["heart", 4, 0xF8], ["bolt", 4, 0xF8], ["sleep", 4, 0xF8], ["fish", 4, 0xF8],
 	["shadow", 1, 0xFC], ["rod", 2, 0xFC], ["boulder_dust", 2, 0xFE],
 	["grass_rustle", 1, 0xFE], ["headbutt_tree", 8, 0x84], ["cut_tree", 4, 0x84],
-	["cut_grass", 4, 0x80],
+	["cut_grass", 4, 0x80], ["heal_machine", 2, 0x7C],
 ]
+
+## `gfx/overworld/heal_machine.pal`, the one sheet that carries a palette of its
+## own instead of wearing an overworld one: `RGB 31, 31, 31`, `RGB 31, 19, 10`,
+## `RGB 31, 07, 01` and black, packed the way the cartridge stores them and
+## identical on all three.
+const HEAL_MACHINE_COLORS: Array[int] = [0x7FFF, 0x2A7F, 0x04FF, 0x0000]
 
 var _first: Dictionary = {}
 
@@ -74,4 +80,20 @@ func _check_game() -> void:
 			)
 		else:
 			_first[name] = indices
+		var colors: PackedColorArray = sheet.get("colors", PackedColorArray())
+		if name == "heal_machine":
+			if _r.check(
+				colors.size() == HEAL_MACHINE_COLORS.size(),
+				"the heal machine carries %d colours, not four." % colors.size()
+			):
+				for slot: int in colors.size():
+					var want: Color = Gen2Palette.from_packed(HEAL_MACHINE_COLORS[slot])
+					_r.check(
+						colors[slot].is_equal_approx(want),
+						"heal machine colour %d is %s, not the source's %s." % [
+							slot, colors[slot], want,
+						]
+					)
+		else:
+			_r.check(colors.is_empty(), "%s carries a palette it has no source for." % name)
 	_r.note("overworld effects: %d sheets, %d drawn pixels." % [EXPECTED.size(), lit])

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -290,9 +290,9 @@ func _process(_delta: float) -> bool:
 				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
-		if _kind not in [&"warp", &"door", &"map_name_sign", &"ledge"]:
-			## Those two kinds drove themselves to the frame they want; every
-			## other kind stages a sprite and then spends the frames it needs.
+		if _kind not in [&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine"]:
+			## Those kinds drove themselves to the frame they want; every other
+			## kind stages a sprite and then spends the frames it needs.
 			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
 				_screen.advance_frame()
 	if _frames < 18:


### PR DESCRIPTION
`HealMachineAnim` loaded two tiles and a palette that no importer read, so the routine's sounds and its frame cost were the whole of it on this side.

- `gfx/overworld/heal_machine.2bpp` and `heal_machine.pal` are located by their own bytes, which occur once per dump, and imported as one more sheet of the overworld effects section. Cache format 69; all three cartridges re-imported and `layout: Layout verified.` on each.
- The sheet is the only one carrying a palette of its own: `.LoadPalettes` writes it over `wOBPals2`' PAL_OW_TREE slot, so it does not wear a time of day.
- `Gen2WorldEffects` places one ball a party member thirty frames apart over the machine's two tiles, shifted by `.PlaceHealingMachineTile`'s `bcpixel 2, 4` on Elm's Lab and drawn from `.HOF_OAM`'s ring with no machine under it in the Hall of Fame, then rotates the four colours left once every ten frames for `.FlashPalettes8Times`' eight rounds.
- First effect sprite anchored to the screen rather than to an object or a cell, since the routine writes fixed OAM while the script waits.

| Proof | Result |
|---|---|
| GUT, both tiers | 3,234 tests over 152 scripts, green |
| `tools/validate.gd -- all` | 54 topics PASS, exit 0 |
| `replay_world.gd` crystal | 11 routes, 0 failures |
| story walk, three profiles | no failures |
| `preview_world.gd ... live heal_machine` | six balls on the bar, black outline, red fill, orange highlight |