### PR TITLE
Choosing a view is one choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Development shortcuts are debug-build only, along with the map and cell readout:
 | `game/render/pic_viewer.tscn` | left/right species, `S` shiny, `B` front/back, `T` trainer classes |
 | `game/render/text_viewer.tscn` | Space advances, `F` cycles borders, `C` shows every glyph |
 | `game/battle/battle_screen.tscn` | `T` turn, A advances, `Y` switch, `R` run, `[`/`]` matchup, `G`/`H` damage; in wild battles B opens the ball selector |
-| `game/world/world_screen.tscn` | `F` fishes with an owned rod, `1`/`2`/`3` pick a rod, `P` opens the phone, `V` cycles renderers, F5 writes a snapshot |
+| `game/world/world_screen.tscn` | `F` fishes with an owned rod, `1`/`2`/`3` pick a rod, `P` opens the phone, `V` cycles views, F5 writes a snapshot |
 
 A release export offers the eight buttons and nothing else. The method behind
 each shortcut stays public, which is how `tools/preview_*.gd` drives them.

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -95,7 +95,7 @@ Two example mods are in `mods/examples/`, to copy into `user://mods/`:
 
 | Mod | Shows |
 |---|---|
-| `voxel_preview/` | A world renderer. Press `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it, on the native layer with a translucent text box and one registered setting |
+| `voxel_preview/` | A world renderer. Switch it on from its page in the launcher, or press `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it, on the native layer with a translucent text box and one registered setting |
 | `new_content/` | Every non-renderer surface in one file: a type and two matchups, a species with its own art, a move, a move effect, an item with its pocket and mart shelf, a named control axis, a visible-encounter population that reads the run's rules, two rebalancing patches, both event channels and the world channel's presentation mutator |
 
 The repository examples are development material and are excluded from every
@@ -622,11 +622,36 @@ agree whenever no step is in flight. A renderer that frames its own view, which
 is what a free camera is, can ignore all three and read
 `player_position_cells()` and `map_size_cells()` directly.
 
-The host constructs a renderer per world, so `select_world_renderer()` can
-switch between the built-in `gen2` renderer and a mod's while the game runs.
-`Gen2WorldScreen.cycle_world_renderer()` is that switch, bound to `V`: the map,
-the player and any running script are untouched, because a renderer reads world
-state and must not write it. Two views of one world have to agree.
+The host constructs a renderer per world, so the view can change while the game
+runs. `Gen2WorldScreen.select_view()` is that switch, and `cycle_view()` is what
+`V` is bound to: the map, the player and any running script are untouched,
+because a renderer reads world state and must not write it. Two views of one
+world have to agree.
+
+## Choosing the view
+
+**Choosing a view is one choice.** `Gen2ModHost.select_view(id)` takes a mod id,
+not a surface, and applies to whichever of the two renderer kinds that id
+registered. Registering a world renderer and a battle renderer under one id is
+how a mod says the two are one view of one world; a mod registering only one
+keeps the built-in renderer on the other, and `gen2` selects both.
+
+| Method | Value |
+|---|---|
+| `view_ids() -> Array[StringName]` | Every id that registered a renderer of either kind, `gen2` first and the rest in load order |
+| `view_label(id) -> String` | The label the registration gave |
+| `view_surfaces(id) -> Dictionary` | `{world, battle}`, which of the two that id draws |
+| `selected_view() -> StringName` | The chosen id, whether or not its mod is loaded |
+| `select_view(id) -> Dictionary` | Chooses it, and persists the choice |
+
+The choice is stored per installation in `user://mods_disabled.json` beside the
+disabled list, so it survives a restart the way a mod's own options do, and it is
+resolved every time a surface builds a renderer rather than once at load: a
+stored id whose mod is uninstalled or switched off draws with the built-in
+renderer and is not refused, and starts drawing again the moment the mod
+registers. Players reach it from the mod's own page in the launcher, which is
+where they already change what a mod does; `V` stays as the live switch where
+[Gen2DebugKeys] is enabled.
 
 ## Replacing the battle renderer
 
@@ -703,8 +728,9 @@ final number should wait for the animation to end rather than reading the view,
 since mid-animation it is deliberately not the real value.
 
 Registration uses the same refusal rules as a world renderer, and shares both
-optional methods (`uses_hardware_viewport()`, `set_native_size()`) and the `V`
-cycle, bound in `Gen2BattleScreen` the way `Gen2WorldScreen` binds it.
+optional methods (`uses_hardware_viewport()`, `set_native_size()`), the one view
+selection above, and the `V` cycle, bound in `Gen2BattleScreen` the way
+`Gen2WorldScreen` binds it.
 
 A battle renderer has two optional methods of its own:
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3813,7 +3813,7 @@ func _handle_debug_key(event: InputEvent) -> bool:
 		KEY_R:
 			run_from_battle()
 		KEY_V:
-			cycle_battle_renderer()
+			cycle_view()
 		_:
 			return false
 	return true
@@ -3879,27 +3879,27 @@ func _on_native_size_changed(size_pixels: Vector2i) -> void:
 		_renderer.call(Gen2ModHost.RENDERER_RESIZE_METHOD, size_pixels)
 
 
-## Switches the live view to another registered renderer without disturbing the
-## battle behind it.
-func select_battle_renderer(id: StringName) -> Dictionary:
-	var result: Dictionary = Gen2ModHost.instance().select_battle_renderer(id)
+## Switches the live view without disturbing the battle behind it. The same one
+## choice the overworld makes: see [method Gen2WorldScreen.select_view].
+func select_view(id: StringName) -> Dictionary:
+	var result: Dictionary = Gen2ModHost.instance().select_view(id)
 	if not bool(result.get("ok", false)):
 		show_message("Renderer unavailable: %s" % String(result.get("reason", "unknown")))
 		return result
 	_build_renderer()
-	show_message("Renderer: %s" % Gen2ModHost.instance().battle_renderer_label(id))
+	show_message("Renderer: %s" % Gen2ModHost.instance().view_label(id))
 	return result
 
 
-## Selects the registered renderer after the current one, wrapping.
-func cycle_battle_renderer() -> Dictionary:
+## Selects the view after the current one, wrapping.
+func cycle_view() -> Dictionary:
 	var host: Gen2ModHost = Gen2ModHost.instance()
-	var ids: Array = host.battle_renderer_ids()
+	var ids: Array[StringName] = host.view_ids()
 	if ids.size() < 2:
 		show_message("No other renderer is registered")
 		return {"ok": false, "reason": &"single_renderer"}
-	var at: int = ids.find(host.selected_battle_renderer())
-	return select_battle_renderer(ids[posmod(at + 1, ids.size())])
+	var at: int = ids.find(host.selected_view())
+	return select_view(ids[posmod(at + 1, ids.size())])
 
 
 ## `wild` or `trainer`, decided the way the battle itself decides it: a trainer

--- a/game/launcher/mod_detail_page.gd
+++ b/game/launcher/mod_detail_page.gd
@@ -20,6 +20,9 @@ var _body: VBoxContainer = null
 var _status: Label = null
 var _row: Dictionary = {}
 
+## The view switch's node name. See [method _view_field].
+const VIEW_SWITCH_NAME: StringName = &"ViewSwitch"
+
 
 static func create(palette: Gen2LauncherTheme) -> Gen2ModDetailPage:
 	var page := Gen2ModDetailPage.new()
@@ -78,6 +81,16 @@ func set_row(row: Dictionary) -> void:
 	if not description.is_empty():
 		var detail: Label = Gen2LauncherUI.muted(_theme, description)
 		_body.add_child(detail)
+
+	if bool(row["installed"]):
+		var view: Control = _view_field(mod_id())
+		if view != null:
+			_body.add_child(Gen2LauncherUI.caption(_theme, "View"))
+			var view_panel: Gen2LauncherCard = Gen2LauncherCard.create(
+				_theme, Gen2LauncherTheme.RADIUS_MD, 18
+			)
+			view_panel.add_child(view)
+			_body.add_child(view_panel)
 
 	var options: Array = Gen2ModHost.instance().options(mod_id())
 	if bool(row["installed"]) and not options.is_empty():
@@ -159,6 +172,40 @@ static func _download_label(row: Dictionary) -> String:
 		&"update":
 			return "Update to %s" % row["listed_version"]
 	return "Reinstall"
+
+
+## The switch that turns a mod's renderers on, or null for a mod that registered
+## none. One choice covers both surfaces, so this is a switch and not a pair:
+## see [method Gen2ModHost.select_view]. Turning it off returns to the built-in
+## view, and turning one mod's on takes it off whichever mod had it.
+##
+## A mod is only listed here once it has registered, which is at load: an
+## installed mod switched off, or one the running cartridge is not for, has no
+## renderers to offer and no row.
+func _view_field(id: StringName) -> Control:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var surfaces: Dictionary = host.view_surfaces(id)
+	var world: bool = bool(surfaces["world"])
+	var battle: bool = bool(surfaces["battle"])
+	if not world and not battle:
+		return null
+	var covers: String = "Overworld and battle"
+	if not battle:
+		covers = "Overworld only"
+	elif not world:
+		covers = "Battle only"
+	var switch: Gen2LauncherToggle = Gen2LauncherToggle.create(
+		_theme, host.selected_view() == id
+	)
+	## Named so it can be found in the tree: the enable switch above it is the
+	## other toggle on this page and the two are not interchangeable.
+	switch.name = VIEW_SWITCH_NAME
+	switch.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	switch.toggled.connect(func(on: bool) -> void:
+		_report(host.select_view(id if on else Gen2ModHost.BUILT_IN_RENDERER))
+		set_row(_row)
+	)
+	return Gen2LauncherUI.field(_theme, covers, switch)
 
 
 func _option_field(id: StringName, option: Dictionary) -> Control:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -9,9 +9,10 @@ extends RefCounted
 ##
 ## The world renderer and the battle renderer are replaceable this way. Neither
 ## requires 2D, so a renderer building geometry from the same block and collision
-## data is a registration rather than a fork, and
-## [method select_world_renderer] and [method select_battle_renderer] swap
-## between them, which is why the contract is a factory.
+## data is a registration rather than a fork, and [method select_view] swaps
+## between them, which is why the contract is a factory. A mod registering both
+## under its own id is saying they are one view of one world, and choosing that
+## view is one choice: see [method select_view].
 ##
 ## Mods are interpreted GDScript: iOS forbids JIT and runtime native loading, so
 ## a compiled extension is not an option for a distributed mod.
@@ -173,9 +174,13 @@ var _world_actors: Dictionary = {}
 ## Mod id to the visible-encounter provider it registered, held the way an actor
 ## is. See [method register_visible_encounters].
 var _visible_encounters: Dictionary = {}
-var _selected_world_renderer: StringName = BUILT_IN_RENDERER
 var _battle_renderers: Dictionary = {}
-var _selected_battle_renderer: StringName = BUILT_IN_RENDERER
+## The one id the player's view is chosen by, read from [Gen2ModState] when the
+## host is built and written back whenever it changes. It is a bare id and may
+## name a mod that is not installed, not enabled, or that registered only one of
+## the two renderer kinds; that is answered where a renderer is asked for rather
+## than by refusing it here, so an uninstalled mod costs the player nothing.
+var _selected_view: StringName = BUILT_IN_RENDERER
 var _menu_entries: Dictionary = {}
 ## The rows mods add to a party member's own submenu, in registration order. See
 ## [method register_party_member_menu].
@@ -202,6 +207,11 @@ static func instance() -> Gen2ModHost:
 		_instance.register_battle_renderer(
 			BUILT_IN_RENDERER, Gen2BattleRenderer, "Game Boy Color 2D"
 		)
+		## Read before any mod has registered anything, which is the only order
+		## available: the id is resolved every time a renderer is asked for, so a
+		## view whose mod loads later is picked up and one whose mod is gone
+		## falls back without a refusal.
+		_instance._selected_view = Gen2ModState.selected_view()
 	return _instance
 
 
@@ -231,24 +241,17 @@ func world_renderer_label(id: StringName) -> String:
 	return _renderer_label(_world_renderers, id)
 
 
+## Which world renderer the selected view resolves to. A view that registered no
+## world renderer leaves the overworld on the built-in one, which is what a mod
+## replacing only the battle screen wants.
 func selected_world_renderer() -> StringName:
-	return _selected_world_renderer
-
-
-## Chooses which registered renderer new worlds are drawn with. The caller
-## rebuilds its view; this only decides what [method create_world_renderer]
-## hands back, so a keybind can flip between 2D and a mod's renderer.
-func select_world_renderer(id: StringName) -> Dictionary:
-	var result: Dictionary = _select(_world_renderers, id)
-	if bool(result.get("ok", false)):
-		_selected_world_renderer = id
-	return result
+	return _selected_view if _world_renderers.has(_selected_view) else BUILT_IN_RENDERER
 
 
 ## A fresh renderer node for the selected world renderer, falling back to the
 ## built-in one so a screen always has something to draw with.
 func create_world_renderer() -> Node:
-	return _create(_world_renderers, _selected_world_renderer, Gen2WorldRenderer)
+	return _create(_world_renderers, selected_world_renderer(), Gen2WorldRenderer)
 
 
 ## Registers a world ACTOR under [param id]: one sprite in the overworld, drawn
@@ -350,23 +353,66 @@ func battle_renderer_label(id: StringName) -> String:
 	return _renderer_label(_battle_renderers, id)
 
 
+## The battle half of the same choice. See [method selected_world_renderer].
 func selected_battle_renderer() -> StringName:
-	return _selected_battle_renderer
-
-
-## Chooses which registered renderer new battles are drawn with. See
-## [method select_world_renderer].
-func select_battle_renderer(id: StringName) -> Dictionary:
-	var result: Dictionary = _select(_battle_renderers, id)
-	if bool(result.get("ok", false)):
-		_selected_battle_renderer = id
-	return result
+	return _selected_view if _battle_renderers.has(_selected_view) else BUILT_IN_RENDERER
 
 
 ## A fresh renderer node for the selected battle renderer, falling back to the
 ## built-in one so a screen always has something to draw with.
 func create_battle_renderer() -> Node:
-	return _create(_battle_renderers, _selected_battle_renderer, Gen2BattleRenderer)
+	return _create(_battle_renderers, selected_battle_renderer(), Gen2BattleRenderer)
+
+
+## Every id that registered a renderer of either kind, built-in first and the
+## rest in registration order. This is the list a player chooses a view from:
+## one entry per view, not one per surface.
+func view_ids() -> Array[StringName]:
+	var out: Array[StringName] = [BUILT_IN_RENDERER]
+	for id: StringName in _world_renderers:
+		if id != BUILT_IN_RENDERER:
+			out.append(id)
+	for id: StringName in _battle_renderers:
+		if id != BUILT_IN_RENDERER and not out.has(id):
+			out.append(id)
+	return out
+
+
+## What [param id] draws, as `{world, battle}`. Both false is an id that
+## registered nothing, which is every id the player has no view for.
+func view_surfaces(id: StringName) -> Dictionary:
+	return {"world": _world_renderers.has(id), "battle": _battle_renderers.has(id)}
+
+
+func view_label(id: StringName) -> String:
+	var label: String = _renderer_label(_world_renderers, id)
+	return label if not label.is_empty() else _renderer_label(_battle_renderers, id)
+
+
+## The id the player's view is chosen by, whether or not its mod is loaded.
+## [method selected_world_renderer] and [method selected_battle_renderer] are
+## what a surface actually draws with.
+func selected_view() -> StringName:
+	return _selected_view
+
+
+## Chooses the view, by mod id, for both surfaces at once: whichever of the two
+## renderer kinds [param id] registered is used, and the built-in one keeps the
+## other. Registering a world renderer and a battle renderer under one id is how
+## a mod says the two are one view of one world, and this is the only thing that
+## ever selects either.
+##
+## Persisted per installation, so the choice survives a restart the way a mod's
+## own options do. The caller rebuilds whatever it is showing; nothing here
+## touches a live screen.
+func select_view(id: StringName) -> Dictionary:
+	if id != BUILT_IN_RENDERER and not _world_renderers.has(id) \
+		and not _battle_renderers.has(id):
+		return {"ok": false, "reason": &"unknown_renderer", "detail": String(id)}
+	_selected_view = id
+	if not Gen2ModState.set_selected_view(id):
+		return {"ok": false, "reason": &"view_not_written", "detail": String(id)}
+	return {"ok": true, "id": id}
 
 
 ## Adds one entry to [param menu]. [param entry] needs a [code]label[/code]; the
@@ -1201,12 +1247,6 @@ func _register(
 
 func _renderer_label(registry: Dictionary, id: StringName) -> String:
 	return String((registry.get(id, {}) as Dictionary).get("label", ""))
-
-
-func _select(registry: Dictionary, id: StringName) -> Dictionary:
-	if not registry.has(id):
-		return {"ok": false, "reason": &"unknown_renderer", "detail": String(id)}
-	return {"ok": true, "id": id}
 
 
 func _create(registry: Dictionary, selected: StringName, fallback_script: Script) -> Node:

--- a/game/mods/mod_state.gd
+++ b/game/mods/mod_state.gd
@@ -1,7 +1,8 @@
 class_name Gen2ModState
 extends RefCounted
 
-## Which installed mods the player has switched off.
+## The installation's own choices about installed mods: which are switched off,
+## and which one's view the game is drawn with.
 ##
 ## Disabled ids are stored rather than enabled ones, so a mod that was just
 ## installed runs without needing an entry written for it, and a file lost or
@@ -11,10 +12,36 @@ extends RefCounted
 ## Gen2ModHost.load_discovered] skips it, so the launcher can show it, say it
 ## is off, and switch it back on without reinstalling.
 
+## Named for the list it was written for; it now also carries the selected view.
 const PATH: String = "user://mods_disabled.json"
 
 static var _disabled: Dictionary = {}
+## The id whose renderers the game is drawn with, or the built-in one. Stored as
+## a bare id and never validated here: whether the mod behind it is installed,
+## enabled and registered is [Gen2ModHost]'s question, and it is asked every time
+## a surface builds a renderer rather than once at load.
+static var _view: StringName = Gen2ModHost.BUILT_IN_RENDERER
 static var _loaded: bool = false
+
+
+## The selected view's id. See [method Gen2ModHost.select_view].
+static func selected_view() -> StringName:
+	_ensure_loaded()
+	return _view
+
+
+## Returns false only when the change could not be written, in which case the
+## in-memory value is rolled back so it never disagrees with the file.
+static func set_selected_view(id: StringName) -> bool:
+	_ensure_loaded()
+	if String(id).is_empty():
+		return false
+	var previous: StringName = _view
+	_view = id
+	if _write():
+		return true
+	_view = previous
+	return false
 
 
 static func is_enabled(id: StringName) -> bool:
@@ -78,6 +105,7 @@ static func forget(id: StringName) -> bool:
 static func reload() -> void:
 	_loaded = false
 	_disabled = {}
+	_view = Gen2ModHost.BUILT_IN_RENDERER
 	_ensure_loaded()
 
 
@@ -86,6 +114,7 @@ static func _ensure_loaded() -> void:
 		return
 	_loaded = true
 	_disabled = {}
+	_view = Gen2ModHost.BUILT_IN_RENDERER
 	if not FileAccess.file_exists(PATH):
 		return
 	var file: FileAccess = FileAccess.open(PATH, FileAccess.READ)
@@ -98,6 +127,9 @@ static func _ensure_loaded() -> void:
 		return
 	if json.data is not Dictionary:
 		return
+	var stored_view: Variant = (json.data as Dictionary).get("view", "")
+	if stored_view is String and not (stored_view as String).is_empty():
+		_view = StringName(stored_view as String)
 	var raw: Variant = (json.data as Dictionary).get("disabled", [])
 	if raw is not Array:
 		return
@@ -115,6 +147,6 @@ static func _write() -> bool:
 	var file: FileAccess = FileAccess.open(PATH, FileAccess.WRITE)
 	if file == null:
 		return false
-	file.store_string(JSON.stringify({"disabled": ids}, "\t"))
+	file.store_string(JSON.stringify({"disabled": ids, "view": String(_view)}, "\t"))
 	file.close()
 	return true

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -421,33 +421,33 @@ func _on_native_size_changed(size_pixels: Vector2i) -> void:
 		_renderer.call(Gen2ModHost.RENDERER_RESIZE_METHOD, size_pixels)
 
 
-## Switches the live view to another registered renderer without disturbing the
-## world behind it. This is the boundary a keybind uses to flip between the 2D
-## view and a mod's: nothing about the map, the player or the running script
-## changes, because a renderer only ever reads them.
-func select_world_renderer(id: StringName) -> Dictionary:
-	var result: Dictionary = Gen2ModHost.instance().select_world_renderer(id)
+## Switches the live view without disturbing the world behind it. The choice is
+## the whole view rather than the overworld's half of it, so a fight started
+## after this is drawn by the same mod: nothing about the map, the player or the
+## running script changes, because a renderer only ever reads them.
+func select_view(id: StringName) -> Dictionary:
+	var result: Dictionary = Gen2ModHost.instance().select_view(id)
 	if not bool(result.get("ok", false)):
 		_script_prompt = "Renderer unavailable: %s" % String(result.get("reason", "unknown"))
 		_refresh_labels()
 		return result
 	_build_renderer()
-	_script_prompt = "Renderer: %s" % Gen2ModHost.instance().world_renderer_label(id)
+	_script_prompt = "Renderer: %s" % Gen2ModHost.instance().view_label(id)
 	_refresh_labels()
 	return result
 
 
-## Selects the registered renderer after the current one, wrapping. One key can
-## then cycle every installed view, which is how a mod's 3D world is reached.
-func cycle_world_renderer() -> Dictionary:
+## Selects the view after the current one, wrapping. One key can then cycle every
+## installed view, which is how a mod's 3D world is reached with no launcher.
+func cycle_view() -> Dictionary:
 	var host: Gen2ModHost = Gen2ModHost.instance()
-	var ids: Array = host.world_renderer_ids()
+	var ids: Array[StringName] = host.view_ids()
 	if ids.size() < 2:
 		_script_prompt = "No other renderer is registered"
 		_refresh_labels()
 		return {"ok": false, "reason": &"single_renderer"}
-	var at: int = ids.find(host.selected_world_renderer())
-	return select_world_renderer(ids[posmod(at + 1, ids.size())])
+	var at: int = ids.find(host.selected_view())
+	return select_view(ids[posmod(at + 1, ids.size())])
 
 
 ## Real time becomes hardware frames here and nowhere else in the overworld.
@@ -953,7 +953,7 @@ func _handle_debug_key(event: InputEvent) -> bool:
 		KEY_P:
 			_open_phone_list()
 		KEY_V:
-			cycle_world_renderer()
+			cycle_view()
 		KEY_F5:
 			var saved: Dictionary = persist_world_snapshot()
 			_script_prompt = "World saved" if bool(saved.get("ok", false)) else "Save failed"

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -11,6 +11,7 @@ var _battle_screen: Gen2BattleScreen = null
 
 
 func before_each() -> void:
+	_forget_view()
 	Gen2ModHost.reset()
 	_data = Fixture.build()
 	_data = GameData.open_directory(Fixture.directory())
@@ -22,6 +23,14 @@ func after_each() -> void:
 		_battle_screen = null
 	RomCache.clear(Fixture.directory())
 	Gen2ModHost.reset()
+	_forget_view()
+
+
+## Choosing a view writes the installation's own file, so a test that chooses one
+## puts it back rather than leaving the player on a renderer a test registered.
+func _forget_view() -> void:
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
 
 
 func _open_battle() -> void:
@@ -74,7 +83,7 @@ func refresh() -> void:
 	pass
 """)
 	assert_true(Gen2ModHost.instance().register_battle_renderer(&"stub", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"stub")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"stub")["ok"])
 
 	await _open_battle()
 	assert_true(_battle_screen.is_ready())
@@ -113,7 +122,7 @@ func refresh() -> void:
 	pass
 """)
 	assert_true(Gen2ModHost.instance().register_battle_renderer(&"staged", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"staged")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"staged")["ok"])
 
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(_data, 1, 1, Vector2i(4, 4))
 	world.player_facing = Gen2WorldSprite.FACING_LEFT
@@ -174,7 +183,7 @@ func handle_battle_input(event) -> bool:
 	return consume
 """)
 	assert_true(Gen2ModHost.instance().register_battle_renderer(&"steered", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"steered")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"steered")["ok"])
 	await _open_battle()
 	assert_true(_battle_screen.is_ready())
 	var renderer: Node = _battle_screen._renderer
@@ -231,7 +240,7 @@ func refresh() -> void:
 	pass
 """)
 	assert_true(Gen2ModHost.instance().register_battle_renderer(&"named", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"named")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"named")["ok"])
 	await _open_battle()
 	var renderer: Node = _battle_screen._renderer
 
@@ -265,7 +274,7 @@ func refresh() -> void:
 	pass
 """)
 	assert_true(Gen2ModHost.instance().register_battle_renderer(&"broken_data", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"broken_data")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"broken_data")["ok"])
 
 	await _open_battle()
 	assert_false(_battle_screen.is_ready())
@@ -289,7 +298,7 @@ func uses_hardware_viewport() -> bool:
 	return false
 """)
 	assert_true(Gen2ModHost.instance().register_battle_renderer(&"native", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"native")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"native")["ok"])
 
 	await _open_battle()
 	assert_true(_battle_screen.is_ready())

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -70,6 +70,7 @@ var _battle_screen: Gen2BattleScreen = null
 
 
 func before_each() -> void:
+	_forget_view()
 	Fixture.build()
 	_data = GameData.open_directory(Fixture.directory())
 	Gen2ModHost.reset()
@@ -83,7 +84,15 @@ func after_each() -> void:
 		_battle_screen.free()
 		_battle_screen = null
 	Gen2ModHost.reset()
+	_forget_view()
 	RomCache.clear(Fixture.directory())
+
+
+## Choosing a view writes the installation's own file, so a test that chooses one
+## puts it back rather than leaving the player on a renderer a test registered.
+func _forget_view() -> void:
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
 
 
 func _script(source: String) -> GDScript:
@@ -95,7 +104,7 @@ func _script(source: String) -> GDScript:
 
 func _open_world(source: String) -> Node:
 	assert_true(Gen2ModHost.instance().register_world_renderer(&"native", _script(source))["ok"])
-	assert_true(Gen2ModHost.instance().select_world_renderer(&"native")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"native")["ok"])
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
@@ -111,7 +120,7 @@ func _open_battle() -> Node:
 	assert_true(
 		Gen2ModHost.instance().register_battle_renderer(&"native", _script(NATIVE_SOURCE))["ok"]
 	)
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"native")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"native")["ok"])
 	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
 	_battle_screen = packed.instantiate() as Gen2BattleScreen
 	_battle_screen.set_data(_data)
@@ -181,7 +190,7 @@ func test_a_renderer_rebuilt_mid_scene_stays_below_the_live_text_box() -> void:
 	box.visible = true
 	var texture: Texture2D = box.texture
 
-	assert_true(Gen2ModHost.instance().select_world_renderer(&"gen2")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"gen2")["ok"])
 	_world_screen._build_renderer()
 	var viewport: SubViewport = _world_screen._screen.viewport()
 	assert_eq(_world_screen._renderer.get_parent(), viewport, "still in the viewport")
@@ -198,7 +207,7 @@ func test_a_renderer_rebuilt_mid_scene_stays_below_the_live_text_box() -> void:
 ## The same rule in the battle screen, whose box is never hidden at all.
 func test_a_battle_renderer_rebuilt_mid_scene_stays_below_the_interface() -> void:
 	await _open_battle()
-	assert_true(Gen2ModHost.instance().select_battle_renderer(&"gen2")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"gen2")["ok"])
 	_battle_screen._build_renderer()
 	var viewport: SubViewport = _battle_screen._screen.viewport()
 	var children: Array = viewport.get_children()

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -35,6 +35,7 @@ var _world_screen: Gen2WorldScreen = null
 
 
 func before_each() -> void:
+	_forget_view()
 	_data = Fixture.build()
 	_data = GameData.open_directory(Fixture.directory())
 	Gen2ModHost.reset()
@@ -45,7 +46,15 @@ func after_each() -> void:
 		_world_screen.free()
 		_world_screen = null
 	Gen2ModHost.reset()
+	_forget_view()
 	RomCache.clear(Fixture.directory())
+
+
+## Choosing a view writes the installation's own file, so a test that chooses one
+## puts it back rather than leaving the player on a renderer a test registered.
+func _forget_view() -> void:
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
 
 
 func _open_world_with_renderer() -> Node:
@@ -53,7 +62,7 @@ func _open_world_with_renderer() -> Node:
 	script.source_code = RENDERER_SOURCE
 	script.reload()
 	assert_true(Gen2ModHost.instance().register_world_renderer(&"camera", script)["ok"])
-	assert_true(Gen2ModHost.instance().select_world_renderer(&"camera")["ok"])
+	assert_true(Gen2ModHost.instance().select_view(&"camera")["ok"])
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -6,10 +6,15 @@ extends GutTest
 var _launcher: Control = null
 var _scratch_path: String = "user://launcher-test-small.gbc"
 var _mod_archive: String = "user://launcher-test-mod.zip"
+var _view_archive: String = "user://launcher-test-view-mod.zip"
 
 ## The launcher installs into the real user://mods, so a mod test cleans up
 ## after itself whether or not it got that far.
 const PROBE_MOD_ID: StringName = &"launcher_probe"
+## The renderer-registering probe has an id of its own because Godot caches a
+## loaded script by path: two mods sharing a directory would have the first
+## one's entry script run for the second.
+const VIEW_MOD_ID: StringName = &"launcher_view_probe"
 
 
 func after_each() -> void:
@@ -22,7 +27,9 @@ func after_each() -> void:
 	await get_tree().process_frame
 	DirAccess.remove_absolute(_scratch_path)
 	DirAccess.remove_absolute(_mod_archive)
+	DirAccess.remove_absolute(_view_archive)
 	Gen2ModInstaller.uninstall(PROBE_MOD_ID)
+	Gen2ModInstaller.uninstall(VIEW_MOD_ID)
 
 
 ## The mods page on its own, which is what every mod workflow but the file
@@ -329,3 +336,112 @@ func test_every_cache_state_says_something_different() -> void:
 			main.cache_state_text(state).contains("Import the cartridge again"),
 			"%s asks for the dump" % state
 		)
+
+
+## A mod archive whose entry registers a renderer of each kind, for the view
+## switch below: the same id on both is what says the two are one view.
+func _write_view_mod_zip() -> void:
+	var packer := ZIPPacker.new()
+	assert_eq(packer.open(_view_archive), OK)
+	var files: Dictionary = {
+		"%s/mod.json" % VIEW_MOD_ID: JSON.stringify({
+			"id": String(VIEW_MOD_ID), "name": "Launcher View Probe", "version": "1.0.0",
+			"api_version": Gen2ModManifest.API_VERSION, "entry": "mod.gd",
+		}),
+		"%s/world.gd" % VIEW_MOD_ID: """extends Node2D
+func set_world(_world, _animation = null) -> void:
+	pass
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+func refresh() -> void:
+	pass
+func refresh_animation() -> void:
+	pass
+""",
+		"%s/battle.gd" % VIEW_MOD_ID: """extends Node2D
+func set_battle_data(_data) -> bool:
+	return true
+func set_view(_view: Dictionary) -> void:
+	pass
+func refresh() -> void:
+	pass
+""",
+		"%s/mod.gd" % VIEW_MOD_ID: """extends RefCounted
+
+func register(host, manifest) -> void:
+	host.register_world_renderer(
+		manifest.id, load("%s/world.gd" % manifest.directory), "Probe"
+	)
+	host.register_battle_renderer(
+		manifest.id, load("%s/battle.gd" % manifest.directory), "Probe"
+	)
+""",
+	}
+	for entry: String in files:
+		packer.start_file(entry)
+		packer.write_file(String(files[entry]).to_utf8_buffer())
+		packer.close_file()
+	packer.close()
+
+
+## The view is chosen from the mod's own page, which is the whole point of the
+## row: a release build has no debug keys, so `V` cannot be the only way in.
+## One switch covers both surfaces and turning it off returns to the built-in
+## view.
+func test_a_mod_registering_renderers_is_switched_on_from_its_own_page() -> void:
+	_write_view_mod_zip()
+	assert_true(bool(Gen2ModInstaller.install_zip(_view_archive).get("ok", false)))
+	Gen2ModHost.reset()
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover()
+	assert_true(host.load_discovered().has(VIEW_MOD_ID))
+
+	var page: Gen2ModsPage = _mods_page()
+	var row: Dictionary = page._row_for(VIEW_MOD_ID)
+	assert_false(row.is_empty(), "the installed mod is in the catalogue")
+	var detail: Gen2ModDetailPage = Gen2ModDetailPage.create(Gen2LauncherTheme.active())
+	add_child_autofree(detail)
+	detail.set_row(row)
+
+	var switch: Gen2LauncherToggle = detail.find_child(
+		String(Gen2ModDetailPage.VIEW_SWITCH_NAME), true, false
+	)
+	assert_not_null(switch, "a mod that registered a renderer gets a view switch")
+	assert_false(switch.button_pressed, "and starts on the built-in view")
+
+	switch.button_pressed = true
+	assert_eq(host.selected_view(), VIEW_MOD_ID)
+	assert_eq(host.selected_world_renderer(), VIEW_MOD_ID)
+	assert_eq(host.selected_battle_renderer(), VIEW_MOD_ID)
+	assert_eq(
+		Gen2ModState.selected_view(), VIEW_MOD_ID, "and the choice is on disk"
+	)
+
+	## set_row rebuilt the card, so the switch that is up now is a new node.
+	var again: Gen2LauncherToggle = detail.find_child(
+		String(Gen2ModDetailPage.VIEW_SWITCH_NAME), true, false
+	)
+	assert_true(again.button_pressed, "the rebuilt row shows the view as on")
+	again.button_pressed = false
+	assert_eq(host.selected_view(), Gen2ModHost.BUILT_IN_RENDERER)
+
+	Gen2ModHost.reset()
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
+
+
+## A mod that replaces nothing about how the game is drawn gets no row at all,
+## rather than a switch that would do nothing.
+func test_a_mod_with_no_renderer_has_no_view_switch() -> void:
+	_write_probe_mod_zip()
+	assert_true(bool(Gen2ModInstaller.install_zip(_mod_archive).get("ok", false)))
+	Gen2ModHost.reset()
+	Gen2ModHost.instance().discover()
+	Gen2ModHost.instance().load_discovered()
+
+	var page: Gen2ModsPage = _mods_page()
+	var detail: Gen2ModDetailPage = Gen2ModDetailPage.create(Gen2LauncherTheme.active())
+	add_child_autofree(detail)
+	detail.set_row(page._row_for(PROBE_MOD_ID))
+	assert_null(detail.find_child(String(Gen2ModDetailPage.VIEW_SWITCH_NAME), true, false))
+	Gen2ModHost.reset()

--- a/tests/unit/test_mod_options.gd
+++ b/tests/unit/test_mod_options.gd
@@ -14,6 +14,7 @@ var _heard: Array = []
 
 
 func before_each() -> void:
+	_forget_view()
 	Gen2ModHost.reset()
 	DirAccess.remove_absolute(Gen2ModOptions.PATH)
 	Gen2ModOptions.reload()
@@ -21,9 +22,17 @@ func before_each() -> void:
 
 
 func after_each() -> void:
+	_forget_view()
 	Gen2ModHost.reset()
 	DirAccess.remove_absolute(Gen2ModOptions.PATH)
 	Gen2ModOptions.reload()
+
+
+## Choosing a view writes the installation's own file, so a test that chooses one
+## puts it back rather than leaving the player on a renderer a test registered.
+func _forget_view() -> void:
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
 
 
 func _distance(host: Gen2ModHost) -> Dictionary:
@@ -183,7 +192,7 @@ func test_the_shipped_example_registers_the_setting_its_renderer_reads() -> void
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	assert_true(bool(host.load_mod(manifest["manifest"]).get("ok", false)))
 
-	assert_true(bool(host.select_world_renderer(manifest["manifest"].id).get("ok", false)))
+	assert_true(bool(host.select_view(manifest["manifest"].id).get("ok", false)))
 	var renderer: Node = host.create_world_renderer()
 	assert_eq(renderer.get_script().resource_path, "res://mods/examples/voxel_preview/renderer.gd")
 	assert_eq(host.option(renderer.MOD_ID, renderer.OPTION_PITCH), renderer.camera_pitch())

--- a/tests/unit/test_mod_state.gd
+++ b/tests/unit/test_mod_state.gd
@@ -117,3 +117,23 @@ func test_uninstalling_forgets_the_off_switch() -> void:
 		Gen2ModState.is_enabled(MOD_ID),
 		"a reinstall must not find itself silently disabled",
 	)
+
+
+## The view is the installation's own choice and lives in the same file as the
+## disabled list, so switching a mod off does not forget which view is on.
+func test_the_selected_view_is_stored_beside_the_disabled_list() -> void:
+	assert_eq(
+		Gen2ModState.selected_view(), Gen2ModHost.BUILT_IN_RENDERER,
+		"a fresh installation is on the built-in view"
+	)
+	assert_true(Gen2ModState.set_selected_view(&"voxel3d"))
+	assert_true(Gen2ModState.set_enabled(MOD_ID, false))
+	Gen2ModState.reload()
+	assert_eq(Gen2ModState.selected_view(), &"voxel3d")
+	assert_false(Gen2ModState.is_enabled(MOD_ID))
+
+
+func test_an_empty_view_id_is_refused_rather_than_stored() -> void:
+	assert_true(Gen2ModState.set_selected_view(&"voxel3d"))
+	assert_false(Gen2ModState.set_selected_view(&""))
+	assert_eq(Gen2ModState.selected_view(), &"voxel3d")

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -19,6 +19,10 @@ func before_each() -> void:
 func after_each() -> void:
 	_clear()
 	Gen2ModHost.reset()
+	## Choosing a view writes the installation's own file, so a test that chooses
+	## one puts it back rather than leaving the player on a test's renderer.
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
 
 
 ## Recursive, because an installed mod can carry nested directories and a
@@ -556,12 +560,12 @@ func register(host, manifest) -> void:
 	assert_eq(host.load_discovered(), [&"voxel_battle"])
 	assert_true(host.battle_renderer_ids().has(&"voxel_battle"))
 
-	assert_true(host.select_battle_renderer(&"voxel_battle")["ok"])
+	assert_true(host.select_view(&"voxel_battle")["ok"])
 	var renderer: Node = host.create_battle_renderer()
 	assert_true(renderer.has_method("is_voxel_battle_renderer"))
 	renderer.free()
 
-	assert_true(host.select_battle_renderer(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+	assert_true(host.select_view(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
 	var built_in: Node = host.create_battle_renderer()
 	assert_true(built_in is Gen2BattleRenderer)
 	built_in.free()
@@ -640,12 +644,12 @@ func register(host, manifest) -> void:
 
 	# Selecting is what a keybind does, and it must change what a new world is
 	# handed without the screen knowing which renderer it asked for.
-	assert_true(host.select_world_renderer(&"voxel")["ok"])
+	assert_true(host.select_view(&"voxel")["ok"])
 	var renderer: Node = host.create_world_renderer()
 	assert_true(renderer.has_method("is_voxel_renderer"))
 	renderer.free()
 
-	assert_true(host.select_world_renderer(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+	assert_true(host.select_view(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
 	var built_in: Node = host.create_world_renderer()
 	assert_true(built_in is Gen2WorldRenderer)
 	built_in.free()
@@ -1478,3 +1482,122 @@ func test_a_tool_run_lists_the_mods_it_finds_and_runs_none_of_them() -> void:
 	)
 	assert_true(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START).is_empty())
 	Gen2ModInstaller.uninstall(&"quiet")
+
+
+## A world renderer and a battle renderer meeting their contracts and nothing
+## more, for the tests below that care about which id was chosen rather than
+## about what is drawn.
+func _world_renderer_script() -> GDScript:
+	var script := GDScript.new()
+	script.source_code = """extends Node2D
+func set_world(_world, _animation = null) -> void:
+	pass
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+func refresh() -> void:
+	pass
+func refresh_animation() -> void:
+	pass
+"""
+	script.reload()
+	return script
+
+
+func _battle_renderer_script() -> GDScript:
+	var script := GDScript.new()
+	script.source_code = """extends Node2D
+func set_battle_data(_data) -> bool:
+	return true
+func set_view(_view: Dictionary) -> void:
+	pass
+func refresh() -> void:
+	pass
+"""
+	script.reload()
+	return script
+
+
+## The whole point of one selection: a mod registering both halves under its own
+## id is one view of one world, and choosing it must reach the fight as well as
+## the map. Two selections is what left every battle in 2D.
+func test_choosing_a_view_by_id_selects_both_surfaces_that_id_registered() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_world_renderer(&"voxel3d", _world_renderer_script(), "Voxel")
+	host.register_battle_renderer(&"voxel3d", _battle_renderer_script(), "Voxel")
+
+	assert_true(host.select_view(&"voxel3d")["ok"])
+	assert_eq(host.selected_view(), &"voxel3d")
+	assert_eq(host.selected_world_renderer(), &"voxel3d")
+	assert_eq(host.selected_battle_renderer(), &"voxel3d")
+
+	assert_true(host.select_view(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+	assert_eq(host.selected_world_renderer(), Gen2ModHost.BUILT_IN_RENDERER)
+	assert_eq(host.selected_battle_renderer(), Gen2ModHost.BUILT_IN_RENDERER)
+
+
+## A mod that replaces only one surface keeps the cartridge's own view on the
+## other, rather than being refused or blanking it.
+func test_a_view_registering_one_surface_leaves_the_other_built_in() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_battle_renderer(&"arena", _battle_renderer_script(), "Arena")
+
+	assert_true(host.select_view(&"arena")["ok"])
+	assert_eq(host.selected_battle_renderer(), &"arena")
+	assert_eq(
+		host.selected_world_renderer(), Gen2ModHost.BUILT_IN_RENDERER,
+		"the overworld keeps the built-in renderer"
+	)
+	var built_in: Node = host.create_world_renderer()
+	assert_true(built_in is Gen2WorldRenderer)
+	built_in.free()
+
+
+func test_a_view_no_mod_registered_is_refused_and_leaves_the_choice_alone() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var result: Dictionary = host.select_view(&"nothing_registered_this")
+	assert_false(bool(result["ok"]))
+	assert_eq(result["reason"], &"unknown_renderer")
+	assert_eq(host.selected_view(), Gen2ModHost.BUILT_IN_RENDERER)
+
+
+## One entry per view rather than one per surface, built-in first so a player
+## cycling from it reaches the mods in the order they loaded.
+func test_the_view_list_names_each_id_once_with_the_built_in_first() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_world_renderer(&"voxel3d", _world_renderer_script(), "Voxel")
+	host.register_battle_renderer(&"voxel3d", _battle_renderer_script(), "Voxel")
+	host.register_battle_renderer(&"arena", _battle_renderer_script(), "Arena")
+
+	assert_eq(
+		host.view_ids(), [Gen2ModHost.BUILT_IN_RENDERER, &"voxel3d", &"arena"] as Array[StringName]
+	)
+	assert_eq(host.view_label(&"voxel3d"), "Voxel")
+	assert_eq(host.view_surfaces(&"voxel3d"), {"world": true, "battle": true})
+	assert_eq(host.view_surfaces(&"arena"), {"world": false, "battle": true})
+
+
+## The choice is the installation's, so it outlives the host a mod list change
+## throws away. A stored id whose mod is no longer registered draws with the
+## built-in renderer and is not refused: the mod may be reinstalled.
+func test_a_chosen_view_survives_a_reload_and_falls_back_when_its_mod_is_gone() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_world_renderer(&"voxel3d", _world_renderer_script(), "Voxel")
+	assert_true(host.select_view(&"voxel3d")["ok"])
+
+	Gen2ModHost.reset()
+	Gen2ModState.reload()
+	var reloaded: Gen2ModHost = Gen2ModHost.instance()
+	assert_eq(reloaded.selected_view(), &"voxel3d", "the choice is remembered")
+	assert_eq(
+		reloaded.selected_world_renderer(), Gen2ModHost.BUILT_IN_RENDERER,
+		"and falls back while nothing has registered it"
+	)
+	var fallback: Node = reloaded.create_world_renderer()
+	assert_true(fallback is Gen2WorldRenderer)
+	fallback.free()
+
+	reloaded.register_world_renderer(&"voxel3d", _world_renderer_script(), "Voxel")
+	assert_eq(
+		reloaded.selected_world_renderer(), &"voxel3d",
+		"and is picked up again when the mod loads"
+	)


### PR DESCRIPTION
Answers the mod repository's R24. A player who switched the overworld to a mod's renderer still got the built-in `gen2` renderer in every fight: `Gen2ModHost` held `_selected_world_renderer` and `_selected_battle_renderer` as two independent fields, and the only thing that wrote either was a debug key, so on a release build a mod's battle renderer could not be reached at all.

**One selection, by id.** The host holds one `_selected_view`. `select_view(id)` applies to whichever of the two renderer kinds that id registered; a mod registering both under its own id is saying they are one view of one world, a mod registering either keeps the built-in renderer on the other, and `gen2` keeps selecting both. `select_world_renderer` and `select_battle_renderer` are gone from the host, and `selected_world_renderer()` / `selected_battle_renderer()` are derived from the one id, resolved every time a surface builds a renderer rather than once at load. An id whose mod is uninstalled or switched off falls back to the built-in renderer without a refusal, and starts drawing again the moment the mod registers.

**Persisted per installation.** In `user://mods_disabled.json` beside the disabled list, restored when the host is built, so the view survives a restart the way a mod's own options do. The file's name no longer covers what it holds and now says so; the format is additive, so an existing installation keeps its disabled list.

**Reachable without a debug key.** The mod's own page in the launcher carries a View switch naming what the id draws (`Overworld and battle`, `Overworld only`, `Battle only`); a mod that registered no renderer gets no row. `V` stays as the live switch where `Gen2DebugKeys` is enabled, now `cycle_view()` on both screens rather than a cycle per surface.

Nothing a mod registers changed, so `api_version` stays at 5. `docs/MODS.md` gains a "Choosing the view" section and is the contract.

| Proof | Result |
|---|---|
| GUT, both tiers | 3,239 tests over 152 scripts, green (was 3,230) |
| `tools/validate.gd -- all` | 54 topics PASS, exit 0 |
| `replay_world.gd` crystal | 11 routes, 0 failures |
| story walk, three profiles | no failures |
| `preview_launcher.gd ... mods full mod voxel3d` | the View switch on the real mod, above its settings |

New coverage: one id selecting both surfaces, one surface leaving the other built-in, an unregistered id refused, the view list naming each id once with the built-in first, a chosen view surviving a host reload and falling back while its mod is gone, the choice stored beside the disabled list, and the launcher switch driving all of it from the page rather than from a key.