### PR TITLE
Empty the editor's error panel

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -99,6 +99,17 @@ An optional `<method> <times> [int arg]` drives a scene before capture. Keep
 state changes as callable methods, not only input branches, so screens stay
 inspectable without a key press.
 
+The GDScript analyzer runs only inside the editor: no CLI mode prints its
+warnings, `--check-only` suppresses them, and file logging records the running
+game rather than the editor. Read them with `tools/dump_editor_errors.gd` from
+Editor > File > Run, which writes `user://editor_errors.txt` and tallies the
+warning codes; the panel holds what the session has analysed, so reload the
+project first for a full sweep. The tree stays at zero entries.
+
+`integer_division` is the one warning turned off in `project.godot`: this is
+8-bit hardware arithmetic throughout, where `a / b` on two integers is the
+intended operation, and a float result is written with an explicit `float()`.
+
 Before rewriting or finishing a subsystem, read the verification method: port
 the state machine rather than approximating its output, find a second executable
 implementation to diff against, pick an artefact that compares exactly, sweep

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -466,8 +466,8 @@ static func _apply_basic(
 ## encouraged only on the attacker's first turn and lowering only on the
 ## defender's; past that both are heavily discouraged.
 static func _apply_setup(
-	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, weather: int,
+	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
+	rng: RandomNumberGenerator, atk_turns: int, def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -504,7 +504,7 @@ static func _in_run(effect: int, base: int) -> bool:
 ## unless it is the only type of damage on offer.
 static func _apply_types(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -548,7 +548,7 @@ static func _apply_types(
 ## for a class whose whole strategy is to attack.
 static func _apply_offensive(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -1319,7 +1319,7 @@ static func _smart_psych_up(
 ## once its own HP is low, more insistently the lower it is.
 static func _apply_opportunist(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -1348,7 +1348,7 @@ static func _apply_opportunist(
 ## hard they rank, not which move is strongest.
 static func _apply_aggressive(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -1402,7 +1402,7 @@ static func _estimate_damage(
 ## slots on a missed roll, where pret's own fix moves on to the next one.
 static func _apply_cautious(
 	scores: Array, attacker: Gen2BattleMon, _defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int, weather: int,
+	rng: RandomNumberGenerator, atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -1427,7 +1427,7 @@ static func _apply_cautious(
 ## [constant RomLayout.MATCHUP_NO_EFFECT] out of the real chart.
 static func _apply_status(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	_rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE
@@ -1451,7 +1451,7 @@ static func _apply_status(
 ## back on unless the attacker is already hurt.
 static func _apply_risky(
 	scores: Array, attacker: Gen2BattleMon, defender: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, weather: int,
+	rng: RandomNumberGenerator, _atk_turns: int, _def_turns: int, _weather: int,
 	_attacker_screens: int = Gen2Screens.NONE, _defender_screens: int = Gen2Screens.NONE,
 	_has_bench: bool = false,
 	_matchup_score: int = Gen2AISwitch.BASE_SCORE

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2344,9 +2344,13 @@ func _quick_claw() -> Variant:
 		return null
 
 	if player_claw and not enemy_claw:
-		return true if _claw_fires(mon(PLAYER)) else null
+		if _claw_fires(mon(PLAYER)):
+			return true
+		return null
 	if enemy_claw and not player_claw:
-		return false if _claw_fires(mon(ENEMY)) else null
+		if _claw_fires(mon(ENEMY)):
+			return false
+		return null
 
 	# `.both_have_quick_claw`: two rolls, the enemy's read first, and the player
 	# only wins on its own roll after the enemy's has already come up short.
@@ -2505,37 +2509,37 @@ const LANDMARK_VICTORY_ROAD: int = 0x58
 ##
 ## The `LANDMARK_SPECIAL` backup lookup in front of it is the six Cable Club
 ## rooms and is deliberately not modelled; see [method Gen2WorldAPI.landmark].
-static func region_is_kanto(landmark: int, crystal: bool = true) -> bool:
-	if landmark == Gen2WorldRadio.fast_ship_landmark(crystal):
+static func region_is_kanto(landmark_id: int, crystal: bool = true) -> bool:
+	if landmark_id == Gen2WorldRadio.fast_ship_landmark(crystal):
 		return false
-	if landmark < Gen2WorldRadio.kanto_landmark(crystal):
+	if landmark_id < Gen2WorldRadio.kanto_landmark(crystal):
 		return false
-	return landmark < Gen2WorldRadio.profile_landmark(LANDMARK_VICTORY_ROAD, crystal)
+	return landmark_id < Gen2WorldRadio.profile_landmark(LANDMARK_VICTORY_ROAD, crystal)
 
 
 ## `PlayBattleMusic`'s answer: the track a battle opens on.
 ##
-## [param landmark] is `GetWorldMapLocation`'s, [param trainer_class] and
+## [param landmark_id] is `GetWorldMapLocation`'s, [param trainer_class] and
 ## [param trainer_id] are `wOtherTrainerClass` and `wOtherTrainerID` (class 0
 ## being a wild fight), and [param time_of_day] is `wTimeOfDay`.
 static func battle_music(
-	battle_type: int,
+	battle_kind: int,
 	trainer_class: int,
 	trainer_id: int,
-	landmark: int,
-	time_of_day: int,
+	landmark_id: int,
+	day_period: int,
 	crystal: bool = true,
 ) -> int:
 	# `ld de, MUSIC_SUICUNE_BATTLE` sits in front of both compares, so the
 	# roaming branch reaches `.done` with the same track still in `de`.
-	if battle_type == BATTLETYPE_SUICUNE or battle_type == BATTLETYPE_ROAMING:
+	if battle_kind == BATTLETYPE_SUICUNE or battle_kind == BATTLETYPE_ROAMING:
 		return MUSIC_SUICUNE_BATTLE
-	var kanto: bool = region_is_kanto(landmark, crystal)
+	var kanto: bool = region_is_kanto(landmark_id, crystal)
 	if trainer_class <= 0:
 		if kanto:
 			return MUSIC_KANTO_WILD_BATTLE
 		return MUSIC_JOHTO_WILD_BATTLE_NIGHT \
-			if time_of_day == Gen2WorldPalette.TIME_NIGHT else MUSIC_JOHTO_WILD_BATTLE
+			if day_period == Gen2WorldPalette.TIME_NIGHT else MUSIC_JOHTO_WILD_BATTLE
 	if trainer_class == TRAINER_CLASS_CHAMPION or trainer_class == TRAINER_CLASS_RED:
 		return MUSIC_CHAMPION_BATTLE
 	# `docs/bugs_and_glitches.md`: only the two grunt classes reach the Rocket

--- a/game/battle/battle_anim_bg_effect.gd
+++ b/game/battle/battle_anim_bg_effect.gd
@@ -18,17 +18,17 @@ var battle_turn: int = 0
 var param: int = 0
 
 
-static func create(id: int, jumptable_index: int, battle_turn: int, param: int
+static func create(effect_id: int, jumptable: int, turn: int, parameter: int
 ) -> Gen2BattleAnimBgEffect:
 	var out := Gen2BattleAnimBgEffect.new()
-	out.id = id & 0xFF
-	out.jumptable_index = jumptable_index & 0xFF
-	out.battle_turn = battle_turn & 0xFF
-	out.param = param & 0xFF
+	out.id = effect_id & 0xFF
+	out.jumptable_index = jumptable & 0xFF
+	out.battle_turn = turn & 0xFF
+	out.param = parameter & 0xFF
 	return out
 
 
-## `EndBattleBGEffect`: zeroing the id is what frees the slot.
+## `EndBattleBGEffect`: zeroing the effect_id is what frees the slot.
 func end() -> void:
 	id = 0
 

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -1361,7 +1361,7 @@ static func _wobble_screen(
 ## The jumptable index counts the frames left and the parameter's low nybble the
 ## frames between reversals, reloaded from its own high nybble.
 static func _shake_amount(
-	background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect
+	_background: Gen2BattleAnimBackground, effect: Gen2BattleAnimBgEffect
 ) -> int:
 	if effect.jumptable_index == 0:
 		effect.end()

--- a/game/battle/battle_anim_data.gd
+++ b/game/battle/battle_anim_data.gd
@@ -30,31 +30,31 @@ static func from_game_data(data: GameData) -> Gen2BattleAnimData:
 		return null
 	var regions: Dictionary = {}
 	for name: StringName in [&"scripts", &"objects", &"framesets", &"oam_sets"]:
-		var region: Dictionary = data.battle_anim_region(name)
-		if region.is_empty():
+		var region_data: Dictionary = data.battle_anim_region(name)
+		if region_data.is_empty():
 			return null
-		regions[name] = region
-	var gfx: Array = []
+		regions[name] = region_data
+	var sheets: Array = []
 	for index: int in data.battle_anim_gfx_count():
-		gfx.append(data.battle_anim_gfx(index))
-	return create(regions, gfx, data.battle_anim_sine(), data.id)
+		sheets.append(data.battle_anim_gfx(index))
+	return create(regions, sheets, data.battle_anim_sine(), data.id)
 
 
 static func create(
-	regions: Dictionary, gfx: Array, sine: PackedByteArray = PackedByteArray(),
-	profile: StringName = &"crystal"
+	regions: Dictionary, sheets: Array, sine: PackedByteArray = PackedByteArray(),
+	profile_name: StringName = &"crystal"
 ) -> Gen2BattleAnimData:
 	var out := Gen2BattleAnimData.new()
 	out._regions = regions
-	out._gfx = gfx
+	out._gfx = sheets
 	out._sine = sine
-	out._profile = profile
+	out._profile = profile_name
 	return out
 
 
 ## Which cartridge this came from. Only the bg effect table reads it, and only
 ## because pokegold's is one entry shorter than Crystal's; nothing else in the
-## layer is profile split.
+## layer is profile_name split.
 func profile() -> StringName:
 	return _profile
 

--- a/game/battle/battle_anim_object.gd
+++ b/game/battle/battle_anim_object.gd
@@ -86,8 +86,8 @@ var _frame_flags: int = 0
 ## `InitBattleAnimation`. [param row] is a `BattleAnimObjects` row and
 ## [param tile_id] is what `GetBattleAnimTileOffset` answered for its graphics.
 static func create(
-	object_index: int, row: Dictionary, tile_id: int,
-	x: int, y: int, param: int
+	object_index: int, row: Dictionary, tile: int,
+	at_x: int, at_y: int, parameter: int
 ) -> Gen2BattleAnimObject:
 	var out := Gen2BattleAnimObject.new()
 	out.index = object_index & 0xFF
@@ -96,10 +96,10 @@ static func create(
 	out.frameset = int(row.get(&"frameset", 0))
 	out.function = int(row.get(&"function", 0))
 	out.palette = int(row.get(&"palette", 0))
-	out.tile_id = tile_id & 0xFF
-	out.x = x & 0xFF
-	out.y = y & 0xFF
-	out.param = param & 0xFF
+	out.tile_id = tile & 0xFF
+	out.x = at_x & 0xFF
+	out.y = at_y & 0xFF
+	out.param = parameter & 0xFF
 	out.frame = 0xFF
 	return out
 
@@ -136,14 +136,14 @@ func oam_update(
 	# replacing the other, so a frameset can flip a sprite the row did not.
 	var flags: int = (_frame_flags ^ int(buffer["flags"])) & OAM_SHARED_FLAGS
 
-	var set: Dictionary = data.oam_set(command)
-	if set.is_empty():
+	var oam: Dictionary = data.oam_set(command)
+	if oam.is_empty():
 		return {"deleted": false, "sprites": []}
-	var tile: int = (int(buffer["tile_id"]) + int(set["vtile"])) & 0xFF
+	var tile: int = (int(buffer["tile_id"]) + int(oam["vtile"])) & 0xFF
 
 	var sprites: Array = []
-	for slot: int in int(set["length"]):
-		var sprite: Dictionary = data.oam_sprite(int(set["address"]), slot)
+	for slot: int in int(oam["length"]):
+		var sprite: Dictionary = data.oam_sprite(int(oam["address"]), slot)
 		sprites.append({
 			"y": _place(
 				int(sprite["y"]), int(buffer["y"]), int(buffer["y_offset"]),

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -111,19 +111,19 @@ var enemy_off_field: bool = false
 ## animation. [param param] is `wBattleAnimParam` and [param enemy_turn] is
 ## `hBattleTurn`, the two inputs set before `PlayBattleAnim`.
 static func create(
-	data: Gen2BattleAnimData, index: int, enemy_turn: bool = false, param: int = 0
+	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool = false, param: int = 0
 ) -> Gen2BattleAnimPlayer:
-	if data == null:
+	if anim_data == null:
 		return null
-	var region: Dictionary = data.region(&"scripts")
-	var address: int = data.pointer(&"scripts", index)
+	var region: Dictionary = anim_data.region(&"scripts")
+	var address: int = anim_data.pointer(&"scripts", index)
 	if region.is_empty() or address < 0:
 		return null
 
 	var player := Gen2BattleAnimPlayer.new()
-	player._data = data
+	player._data = anim_data
 	player._anim_index = index
-	player._enemy_turn = enemy_turn
+	player._enemy_turn = on_enemy_turn
 	# `ClearBattleAnims` zeroes the whole animation block before the script's
 	# pointer is loaded, so every object slot, the tile dict and the flags start
 	# empty on each animation rather than carrying over from the last one.
@@ -496,16 +496,16 @@ func _update_oam() -> void:
 		if not object.active():
 			continue
 		var update: Dictionary = object.oam_update(_data, _enemy_turn, _anim_index)
-		var sprites: Array = update["sprites"]
-		if _sprites.size() + sprites.size() > MAX_SPRITES:
+		var new_sprites: Array = update["sprites"]
+		if _sprites.size() + new_sprites.size() > MAX_SPRITES:
 			# `BattleAnimOAMUpdate` returns carry once the pointer reaches the end
 			# of the shadow buffer, and the caller stops there.
-			for sprite: Variant in sprites:
+			for sprite: Variant in new_sprites:
 				if _sprites.size() >= MAX_SPRITES:
 					break
 				_sprites.append(sprite)
 			return
-		_sprites.append_array(sprites)
+		_sprites.append_array(new_sprites)
 
 
 ## `DoBattleAnimFrame`: the object's own motion callback, in

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -148,29 +148,29 @@ var _failed: bool = false
 ## [param param] is `wBattleAnimParam`, which the caller sets before playing;
 ## `wBattleAnimVar` starts at zero because `ClearBattleAnims` clears it.
 static func create(
-	region: PackedByteArray, base_address: int, address: int, param: int = 0
+	region: PackedByteArray, base_address: int, start_address: int, param: int = 0
 ) -> Gen2BattleAnimScript:
 	var script := Gen2BattleAnimScript.new()
 	script._region = region
 	script._base_address = base_address
-	script._address = address
+	script._address = start_address
 	script._param = param & 0xFF
-	script._stopped = not script._holds(address)
+	script._stopped = not script._holds(start_address)
 	script._failed = script._stopped
 	return script
 
 
-## Decodes one command at [param address]. Returns
+## Decodes one command at [param start_address]. Returns
 ## [code]{ ok, name, byte, operands, size, target }[/code]; `target` is the
-## address a branch would take, or -1. A delay byte answers [constant WAIT] with
+## start_address a branch would take, or -1. A delay byte answers [constant WAIT] with
 ## its own value as its single operand.
 ##
 ## Shared with [Gen2BattleAnimImporter], which walks every body with it, so the
 ## vocabulary is stated once.
 static func decode_command(
-	region: PackedByteArray, base_address: int, address: int
+	region: PackedByteArray, base_address: int, at_address: int
 ) -> Dictionary:
-	var at: int = address - base_address
+	var at: int = at_address - base_address
 	if at < 0 or at >= region.size():
 		return {"ok": false}
 	var byte: int = region[at]
@@ -316,8 +316,8 @@ func _run_loop(count: int, target: int) -> void:
 	_in_loop = false
 
 
-func _holds(address: int) -> bool:
-	var at: int = address - _base_address
+func _holds(at_address: int) -> bool:
+	var at: int = at_address - _base_address
 	return at >= 0 and at < _region.size()
 
 

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -289,7 +289,7 @@ func set_badge_boosts(mask: int) -> void:
 			badge_stat_boosts["sp_defense"] = true
 
 	badge_type_boost_mask = 0
-	var types: Array[int] = [
+	var boosted_types: Array[int] = [
 		RomLayout.TYPE_FLYING, RomLayout.TYPE_BUG, RomLayout.TYPE_NORMAL,
 		RomLayout.TYPE_GHOST, RomLayout.TYPE_STEEL, RomLayout.TYPE_FIGHTING,
 		RomLayout.TYPE_ICE, RomLayout.TYPE_DRAGON, RomLayout.TYPE_ROCK,
@@ -297,9 +297,9 @@ func set_badge_boosts(mask: int) -> void:
 		RomLayout.TYPE_POISON, RomLayout.TYPE_PSYCHIC, RomLayout.TYPE_FIRE,
 		RomLayout.TYPE_GROUND,
 	]
-	for badge: int in types.size():
+	for badge: int in boosted_types.size():
 		if mask & (1 << badge):
-			badge_type_boost_mask |= 1 << types[badge]
+			badge_type_boost_mask |= 1 << boosted_types[badge]
 
 
 func clear_badge_boosts() -> void:

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -306,9 +306,9 @@ func _padded_pic(pic: Dictionary, side: int) -> PackedByteArray:
 	if pic.is_empty():
 		return out
 
-	var name: String = String(pic.get("atlas", ""))
+	var atlas_name: String = String(pic.get("atlas", ""))
 	var cell: Dictionary = Gen2PicImage.atlas_cell(
-		_data.atlas_indices(name), _data.atlas(name), pic
+		_data.atlas_indices(atlas_name), _data.atlas(atlas_name), pic
 	)
 	if cell.is_empty():
 		return out

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1819,8 +1819,8 @@ func _capture_quantity(ball: int) -> int:
 func _item_name(item: int) -> String:
 	if _data == null:
 		return "BALL"
-	var name: String = _data.item_name(item)
-	return name if not name.is_empty() else "BALL %d" % item
+	var item_name: String = _data.item_name(item)
+	return item_name if not item_name.is_empty() else "BALL %d" % item
 
 
 func _is_wild_battle() -> bool:
@@ -2061,8 +2061,8 @@ func _show_forget_list() -> void:
 	var names: PackedStringArray = []
 	for index: int in _forget_moves.size():
 		var entry: Dictionary = _forget_moves[index]
-		var name: String = String(entry.get("name", ""))
-		names.append("[%s]" % name if index == _forget_cursor else name)
+		var move_name: String = String(entry.get("name", ""))
+		names.append("[%s]" % move_name if index == _forget_cursor else move_name)
 	show_message("%s %s Up and down: move, A: forget, B: back" % [
 		Gen2MoveForget.which_text(), " ".join(names),
 	])

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -134,25 +134,25 @@ static func open_directory(path: String) -> GameData:
 	data._card_palettes = manifest.get("card_palettes", {})
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	data._pack = manifest.get("pack", {})
-	var pc_palette: Variant = manifest.get("pc_palette", [])
-	data._pc_palette = pc_palette if pc_palette is Array else []
+	var raw_pc_palette: Variant = manifest.get("pc_palette", [])
+	data._pc_palette = raw_pc_palette if raw_pc_palette is Array else []
 	var gender_palette: Variant = manifest.get("gender_screen_palette", [])
 	data._gender_screen_palette = gender_palette if gender_palette is Array else []
-	var copyright_string: Variant = manifest.get("copyright_string", [])
-	data._copyright_string = copyright_string if copyright_string is Array else []
-	var copyright_palette: Variant = manifest.get("copyright_palette", [])
-	data._copyright_palette = copyright_palette if copyright_palette is Array else []
+	var raw_copyright_string: Variant = manifest.get("copyright_string", [])
+	data._copyright_string = raw_copyright_string if raw_copyright_string is Array else []
+	var raw_copyright_palette: Variant = manifest.get("copyright_palette", [])
+	data._copyright_palette = raw_copyright_palette if raw_copyright_palette is Array else []
 	var text_palette: Variant = manifest.get("text_bg_palette", [])
 	data._text_bg_palette = text_palette if text_palette is Array else []
 	data._battle_object_palettes = manifest.get("battle_object_palettes", {})
 	var presents_palettes: Variant = manifest.get("presents_palettes", {})
 	data._presents_palettes = presents_palettes if presents_palettes is Dictionary else {}
-	var title: Variant = manifest.get("title", {})
-	data._title = title if title is Dictionary else {}
+	var raw_title: Variant = manifest.get("title", {})
+	data._title = raw_title if raw_title is Dictionary else {}
 	var town_map: Variant = manifest.get("town_map", {})
 	data._town_map = town_map if town_map is Dictionary else {}
-	var oak_ratings: Variant = manifest.get("oak_ratings", {})
-	data._oak_ratings = oak_ratings if oak_ratings is Dictionary else {}
+	var raw_oak_ratings: Variant = manifest.get("oak_ratings", {})
+	data._oak_ratings = raw_oak_ratings if raw_oak_ratings is Dictionary else {}
 	var pokecenter_pc: Variant = manifest.get("pokecenter_pc", {})
 	data._pokecenter_pc = pokecenter_pc if pokecenter_pc is Dictionary else {}
 	var unown_words: Variant = manifest.get("unown_words", [])
@@ -169,10 +169,10 @@ static func open_directory(path: String) -> GameData:
 	data._intro_movie = intro_movie if intro_movie is Dictionary else {}
 	var gs_intro: Variant = manifest.get("gs_intro", {})
 	data._gs_intro = gs_intro if gs_intro is Dictionary else {}
-	var menu_text: Variant = manifest.get("menu_text", {})
-	data._menu_text = menu_text if menu_text is Dictionary else {}
-	var mart_text: Variant = manifest.get("mart_text", {})
-	data._mart_text = mart_text if mart_text is Dictionary else {}
+	var raw_menu_text: Variant = manifest.get("menu_text", {})
+	data._menu_text = raw_menu_text if raw_menu_text is Dictionary else {}
+	var raw_mart_text: Variant = manifest.get("mart_text", {})
+	data._mart_text = raw_mart_text if raw_mart_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
@@ -372,11 +372,11 @@ func world_audio_pointer(kind: StringName, bank: int, address: int) -> Dictionar
 ## `PokemonCries`' row for one species: which cry stream it plays and the
 ## `wCryPitch`/`wCryLength` it plays it at. An empty answer is a species outside
 ## the table, which is what a mod's own number is.
-func mon_cry(species: int) -> Dictionary:
+func mon_cry(number: int) -> Dictionary:
 	var rows: Variant = _audio().get("mon_cries", [])
-	if not rows is Array or species < 1 or species > (rows as Array).size():
+	if not rows is Array or number < 1 or number > (rows as Array).size():
 		return {}
-	var row: Variant = (rows as Array)[species - 1]
+	var row: Variant = (rows as Array)[number - 1]
 	if not row is Dictionary:
 		return {}
 	return {
@@ -386,11 +386,11 @@ func mon_cry(species: int) -> Dictionary:
 	}
 
 
-## The cry one species plays, which is `PlayCry`'s own two steps: the
+## The cry one number plays, which is `PlayCry`'s own two steps: the
 ## `PokemonCries` row, then the stream it names, with the row's pitch and length
 ## carried on the record so `_PlayCry`'s modulation reaches the decoder.
-func species_cry(species: int) -> Dictionary:
-	var row: Dictionary = mon_cry(species)
+func species_cry(number: int) -> Dictionary:
+	var row: Dictionary = mon_cry(number)
 	if row.is_empty():
 		return {}
 	var record: Dictionary = world_audio(&"cries", int(row["index"]))
@@ -654,10 +654,10 @@ func asleep_treemons(time_of_day: int) -> Array:
 		return []
 	# Restored to integers because JSON reads them back as floats, and this is
 	# the one treemon list a caller searches by value rather than by index.
-	var species: Array[int] = []
+	var numbers: Array[int] = []
 	for entry: Variant in value as Array:
-		species.append(int(entry))
-	return species
+		numbers.append(int(entry))
+	return numbers
 
 
 func world_encounter_count(method: StringName) -> int:
@@ -998,8 +998,8 @@ func evolutions(number: int) -> Array:
 ## a randomizer asks for.
 func egg_moves(number: int) -> Array[int]:
 	var out: Array[int] = []
-	for move: Variant in species(number).get("egg_moves", []):
-		out.append(int(move))
+	for move_id: Variant in species(number).get("egg_moves", []):
+		out.append(int(move_id))
 	return out
 
 
@@ -1840,10 +1840,10 @@ func pack_palette(index: int, female: bool = false) -> PackedColorArray:
 ## halves [constant RomLayout.FOOTPRINT_HALF_STRIDE] tiles further on, which is
 ## the offset the source calls a forgotten tile-editor fix. Empty for a species
 ## outside the run.
-func footprint_tiles(species: int) -> PackedInt32Array:
-	if species < 1 or species > RomLayout.FOOTPRINT_SPECIES:
+func footprint_tiles(number: int) -> PackedInt32Array:
+	if number < 1 or number > RomLayout.FOOTPRINT_SPECIES:
 		return PackedInt32Array()
-	var index: int = species - 1
+	var index: int = number - 1
 	var first: int = (index / 8) * (8 * RomLayout.FOOTPRINT_TILES) \
 		+ (index % 8) * RomLayout.FOOTPRINT_HALF_TILES
 	return PackedInt32Array([
@@ -2357,8 +2357,8 @@ func catalog() -> Gen2WorldCatalog:
 
 ## One catalog row with any patch folded in. Called by the catalog itself, which
 ## holds the rows; nothing else should need it.
-func overlaid_check(id: int, base: Dictionary) -> Dictionary:
-	return _overlaid(Gen2ContentOverlay.KIND_CHECK, id, base)
+func overlaid_check(check_id: int, base: Dictionary) -> Dictionary:
+	return _overlaid(Gen2ContentOverlay.KIND_CHECK, check_id, base)
 
 
 ## Whether any mod content reaches this cache at all, which is the one check a

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -345,10 +345,10 @@ func _record_script_site(
 				if picture >= 0:
 					row["picture_address"] = address + picture
 			if kind == KIND_PRIZE:
-				var check: int = _nearest_coin_command(commands, offset, &"checkcoins", crystal)
+				var check_at: int = _nearest_coin_command(commands, offset, &"checkcoins", crystal)
 				var take: int = _nearest_coin_command(commands, offset, &"takecoins", crystal)
-				if check >= 0:
-					row["check_address"] = address + check
+				if check_at >= 0:
+					row["check_address"] = address + check_at
 				if take >= 0:
 					row["take_address"] = address + take
 			_add(kind, bank, address, offset, row, commands, offset, crystal)
@@ -503,11 +503,11 @@ func _attribute_maps() -> void:
 				references[key] = Gen2WorldScript.scan_references(
 					body, int(entry[0]), int(entry[1]), crystal
 				).get("scripts", []) if not body.is_empty() else []
-			for reference: Variant in references[key]:
-				if reference is Dictionary:
+			for referenced: Variant in references[key]:
+				if referenced is Dictionary:
 					pending.append([
-						int((reference as Dictionary)["bank"]),
-						int((reference as Dictionary)["address"]),
+						int((referenced as Dictionary)["bank"]),
+						int((referenced as Dictionary)["address"]),
 					])
 	for id: Variant in _rows:
 		var row: Dictionary = _rows[id]

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -1277,7 +1277,7 @@ static func read_pokecenter_pc_lists(
 
 ## One `text_far` stub, followed and decoded. Empty when the stub is not one,
 ## which is what a table that is not `OakRatings` produces.
-static func read_oak_text(rom: RomFile, layout: Dictionary, stub: int) -> String:
+static func read_oak_text(rom: RomFile, _layout: Dictionary, stub: int) -> String:
 	if not rom.in_bounds(stub, RomLayout.OAK_TEXT_STUB_SIZE) \
 		or rom.u8(stub) != Gen2TextStream.TX_FAR:
 		return ""
@@ -5551,7 +5551,6 @@ static func _rows_from_columns(
 		return strip
 	var out := PackedByteArray()
 	out.resize(strip.size())
-	var width: int = columns * Gen2Tiles.TILE_WIDTH
 	for column: int in columns:
 		for row: int in rows:
 			var source_tile: int = column * rows + row

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -267,9 +267,9 @@ static func _read_command_queues(
 		var references: Dictionary = Gen2WorldScript.scan_references(
 			bytes, int(parts[0]), 0, rom.id == &"crystal"
 		)
-		for reference: Dictionary in references.get("command_queues", []):
+		for referenced: Dictionary in references.get("command_queues", []):
 			_read_command_queue(
-				rom, int(reference["bank"]), int(reference["address"]),
+				rom, int(referenced["bank"]), int(referenced["address"]),
 				queues, script_data, text_data, movement_data
 			)
 	return {"ok": true, "queues": queues}

--- a/game/input/input_actions.gd
+++ b/game/input/input_actions.gd
@@ -165,16 +165,16 @@ static func to_event(binding: Dictionary) -> InputEvent:
 			var key := InputEventKey.new()
 			# Physical only. A binding that also carried a keycode would match
 			# twice on a US layout and disagree with itself on any other.
-			key.physical_keycode = code
+			key.physical_keycode = code as Key
 			return key
 		KIND_PAD_BUTTON:
 			var pad := InputEventJoypadButton.new()
-			pad.button_index = code
+			pad.button_index = code as JoyButton
 			pad.device = ALL_DEVICES
 			return pad
 		KIND_PAD_AXIS:
 			var axis := InputEventJoypadMotion.new()
-			axis.axis = code
+			axis.axis = code as JoyAxis
 			axis.axis_value = signf(float(binding.get("sign", 1)))
 			axis.device = ALL_DEVICES
 			return axis

--- a/game/input/touch_pad.gd
+++ b/game/input/touch_pad.gd
@@ -68,8 +68,8 @@ func _exit_tree() -> void:
 	Gen2InputRuntime.instance().release_touch_pad(self)
 
 
-func set_layout(layout: Gen2TouchLayout) -> void:
-	_layout = layout if layout != null else Gen2TouchLayout.new()
+func set_layout(new_layout: Gen2TouchLayout) -> void:
+	_layout = new_layout if new_layout != null else Gen2TouchLayout.new()
 	_layout_given = true
 	queue_redraw()
 

--- a/game/launcher/about_page.gd
+++ b/game/launcher/about_page.gd
@@ -58,9 +58,9 @@ func _build() -> void:
 		var row: Dictionary = RomRegistry.lookup(sha1)
 		var line: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
 		accepted.add_child(line)
-		var name: Label = Gen2LauncherUI.body(_theme, RomRegistry.title_for(game_id))
-		name.custom_minimum_size = Vector2(96, 0)
-		line.add_child(name)
+		var title: Label = Gen2LauncherUI.body(_theme, RomRegistry.title_for(game_id))
+		title.custom_minimum_size = Vector2(96, 0)
+		line.add_child(title)
 		var revision: Label = Gen2LauncherUI.muted(
 			_theme, String(row.get("revision", "Supported"))
 		)
@@ -79,10 +79,10 @@ func set_update_result(message: String, colour: Color) -> void:
 	_result.add_theme_color_override("font_color", colour)
 
 
-func _card(host: VBoxContainer, name: String) -> VBoxContainer:
+func _card(host: VBoxContainer, title: String) -> VBoxContainer:
 	var panel: Gen2LauncherCard = Gen2LauncherCard.create(_theme, Gen2LauncherTheme.RADIUS_MD, 22)
 	host.add_child(panel)
 	var column: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
 	panel.add_child(column)
-	column.add_child(Gen2LauncherUI.caption(_theme, name))
+	column.add_child(Gen2LauncherUI.caption(_theme, title))
 	return column

--- a/game/launcher/binding_sheet.gd
+++ b/game/launcher/binding_sheet.gd
@@ -77,12 +77,12 @@ func _build_rows() -> void:
 ## place, so a button with no entry yet is given one first.
 func _bindings() -> Array:
 	if _action != &"":
-		var name: String = String(_action)
-		if not _options.mod_controls.has(name):
+		var action_name: String = String(_action)
+		if not _options.mod_controls.has(action_name):
 			# Seeded from what the mod declared, so editing starts from what is
 			# bound rather than from nothing.
-			_options.mod_controls[name] = _registered_default()
-		return _options.mod_controls[name]
+			_options.mod_controls[action_name] = _registered_default()
+		return _options.mod_controls[action_name]
 	if not _options.controls.has(_button):
 		_options.controls[_button] = []
 	return _options.controls[_button]
@@ -106,9 +106,9 @@ func _refresh() -> void:
 	var bindings: Array = _bindings()
 	for index: int in bindings.size():
 		var row: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
-		var name: Label = Gen2LauncherUI.body(_theme, Gen2InputActions.describe(bindings[index]))
-		name.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		row.add_child(name)
+		var description: Label = Gen2LauncherUI.body(_theme, Gen2InputActions.describe(bindings[index]))
+		description.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.add_child(description)
 		var remove: Gen2LauncherButton = Gen2LauncherButton.icon_only(
 			_theme, &"trash", Gen2LauncherButton.Variant.DANGER, 36.0
 		)

--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -63,9 +63,9 @@ var _squash: Vector2 = Vector2.ONE:
 		_place()
 
 
-static func create(theme: Gen2LauncherTheme, id: StringName) -> Gen2Cartridge:
+static func create(palette: Gen2LauncherTheme, id: StringName) -> Gen2Cartridge:
 	var cartridge := Gen2Cartridge.new()
-	cartridge._theme = theme
+	cartridge._theme = palette
 	cartridge.game_id = id
 	cartridge._build()
 	return cartridge

--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -62,9 +62,9 @@ var _scroll: float = 0.0:
 		_place_all()
 
 
-static func create(theme: Gen2LauncherTheme, order: Array[StringName]) -> Gen2CartridgeStage:
+static func create(palette: Gen2LauncherTheme, order: Array[StringName]) -> Gen2CartridgeStage:
 	var stage := Gen2CartridgeStage.new()
-	stage._theme = theme
+	stage._theme = palette
 	stage._order = order
 	stage._build()
 	return stage
@@ -82,9 +82,9 @@ func _build() -> void:
 	focus_exited.connect(_place_all)
 	mouse_exited.connect(func() -> void: _hover(-1))
 	for index: int in _order.size():
-		var cartridge: Gen2Cartridge = Gen2Cartridge.create(_theme, _order[index])
-		add_child(cartridge)
-		_cartridges.append(cartridge)
+		var cartridge_node: Gen2Cartridge = Gen2Cartridge.create(_theme, _order[index])
+		add_child(cartridge_node)
+		_cartridges.append(cartridge_node)
 
 
 func cartridge(game_id: StringName) -> Gen2Cartridge:

--- a/game/launcher/controls_section.gd
+++ b/game/launcher/controls_section.gd
@@ -97,7 +97,7 @@ func _build_mod_actions() -> void:
 
 
 func _mod_row(action: Dictionary) -> HBoxContainer:
-	var name: StringName = action["name"]
+	var action_name: StringName = action["name"]
 	var value: Label = _bindings_label()
 	var edit: Gen2LauncherButton = Gen2LauncherButton.create(
 		_theme, "Change", Gen2LauncherButton.Variant.QUIET
@@ -111,38 +111,38 @@ func _mod_row(action: Dictionary) -> HBoxContainer:
 	row.add_child(label)
 	row.add_child(value)
 	row.add_child(edit)
-	_rows[name] = value
-	_refresh_mod_row(name)
+	_rows[action_name] = value
+	_refresh_mod_row(action_name)
 	return row
 
 
-func _refresh_mod_row(name: StringName) -> void:
-	var label: Label = _rows.get(name)
+func _refresh_mod_row(action_name: StringName) -> void:
+	var label: Label = _rows.get(action_name)
 	if label == null:
 		return
 	# What is actually bound, which is the mod's own default until the player
 	# overrides it. Reading only the override would say "Unbound" for every mod
 	# control nobody has touched.
-	label.text = describe(_mod_bindings(name))
+	label.text = describe(_mod_bindings(action_name))
 	label.add_theme_color_override("font_color", _theme.muted)
 
 
-func _mod_bindings(name: StringName) -> Array:
-	if _options.mod_controls.has(String(name)):
-		return _options.mod_controls[String(name)]
+func _mod_bindings(action_name: StringName) -> Array:
+	if _options.mod_controls.has(String(action_name)):
+		return _options.mod_controls[String(action_name)]
 	for action: Dictionary in Gen2ModHost.instance().actions():
-		if StringName(action["name"]) == name:
+		if StringName(action["name"]) == action_name:
 			return action["default"]
 	return []
 
 
 func _open_mod_editor(action: Dictionary) -> void:
-	var name: StringName = action["name"]
+	var action_name: StringName = action["name"]
 	var sheet: Gen2BindingSheet = Gen2BindingSheet.for_mod_action(
-		_theme, _options, name, String(action["label"])
+		_theme, _options, action_name, String(action["label"])
 	)
 	sheet.bindings_changed.connect(func() -> void:
-		_refresh_mod_row(name)
+		_refresh_mod_row(action_name)
 		changed.emit()
 	)
 	sheet.open(_host)

--- a/game/launcher/launcher_audio.gd
+++ b/game/launcher/launcher_audio.gd
@@ -36,10 +36,10 @@ static func play(clip: StringName) -> void:
 
 ## Public so a screen can silence itself while it rebuilds, and so tests can
 ## drive the launcher without waking the audio server.
-static func set_muted(muted: bool) -> void:
+static func set_muted(on: bool) -> void:
 	var audio: Gen2LauncherAudio = _shared()
 	if audio != null:
-		audio.muted = muted
+		audio.muted = on
 
 
 static func _shared() -> Gen2LauncherAudio:

--- a/game/launcher/launcher_battery.gd
+++ b/game/launcher/launcher_battery.gd
@@ -22,9 +22,9 @@ var _cell: Control = null
 var _readout: Label = null
 
 
-static func create(theme: Gen2LauncherTheme) -> Gen2LauncherBattery:
+static func create(palette: Gen2LauncherTheme) -> Gen2LauncherBattery:
 	var battery := Gen2LauncherBattery.new()
-	battery._theme = theme
+	battery._theme = palette
 	battery._build()
 	return battery
 

--- a/game/launcher/launcher_button.gd
+++ b/game/launcher/launcher_button.gd
@@ -47,13 +47,13 @@ var _side: float = DOCK_SIDE
 
 
 static func create(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	label: String,
 	kind: Variant = Variant.NEUTRAL,
 	glyph: StringName = &"",
 ) -> Gen2LauncherButton:
 	var button := Gen2LauncherButton.new()
-	button._theme = theme
+	button._theme = palette
 	button.variant = kind
 	button.text = label
 	button._glyph = glyph
@@ -64,12 +64,12 @@ static func create(
 
 ## A square button carrying only an icon.
 static func icon_only(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	glyph: StringName,
 	kind: Variant = Variant.QUIET,
 	side: float = 42.0,
 ) -> Gen2LauncherButton:
-	var button: Gen2LauncherButton = create(theme, "", kind, glyph)
+	var button: Gen2LauncherButton = create(palette, "", kind, glyph)
 	button.set_side(side)
 	return button
 
@@ -86,8 +86,8 @@ func set_side(side: float) -> void:
 
 
 ## A round dock button with its name written underneath by the caller.
-static func dock(theme: Gen2LauncherTheme, glyph: StringName) -> Gen2LauncherButton:
-	return icon_only(theme, glyph, Variant.DOCK, DOCK_SIDE)
+static func dock(palette: Gen2LauncherTheme, glyph: StringName) -> Gen2LauncherButton:
+	return icon_only(palette, glyph, Variant.DOCK, DOCK_SIDE)
 
 
 func _init() -> void:

--- a/game/launcher/launcher_card.gd
+++ b/game/launcher/launcher_card.gd
@@ -13,34 +13,34 @@ var palette: Gen2LauncherTheme = null
 ## A card printed on the page: filled, with a hairline, and no shadow to be cut
 ## off by whatever scrolls it.
 static func create(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 20,
 	padding_y: int = -1,
 ) -> Gen2LauncherCard:
-	return _made(theme, theme.padded(theme.box(theme.panel, radius, theme.line), padding, padding_y))
+	return _made(palette, palette.padded(palette.box(palette.panel, radius, palette.line), padding, padding_y))
 
 
 ## A step back from the page: the track a segmented control sits in, or a strip
 ## of read-only detail.
 static func well(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 16,
 	padding_y: int = -1,
 ) -> Gen2LauncherCard:
-	return _made(theme, theme.padded(theme.box(theme.surface_alt, radius), padding, padding_y))
+	return _made(palette, palette.padded(palette.box(palette.surface_alt, radius), padding, padding_y))
 
 
 ## The current choice in a list of cards: an accent hairline and a wash of it,
 ## rather than a fill that would fight the text inside.
 static func selected(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 20,
 ) -> Gen2LauncherCard:
-	var style: StyleBoxFlat = theme.box(theme.accent_wash(0.10), radius, theme.accent, 2)
-	return _made(theme, theme.padded(style, padding))
+	var style: StyleBoxFlat = palette.box(palette.accent_wash(0.10), radius, palette.accent, 2)
+	return _made(palette, palette.padded(style, padding))
 
 
 ## A surface that genuinely floats: sheets, toasts and the bottom dock. Never put
@@ -49,25 +49,25 @@ static func selected(
 ## which is the opposite side of the page from everything under it. Whatever goes
 ## inside is written in [member Gen2LauncherTheme.on_surface].
 static func chip(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 16,
 	spread: int = 20,
 ) -> Gen2LauncherCard:
-	return _made(theme, theme.padded(theme.floating(theme.surface, radius, spread), padding))
+	return _made(palette, palette.padded(palette.floating(palette.surface, radius, spread), padding))
 
 
 static func floating(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_LG,
 	padding: int = 20,
 	spread: int = 26,
 ) -> Gen2LauncherCard:
-	return _made(theme, theme.padded(theme.floating(theme.panel, radius, spread), padding))
+	return _made(palette, palette.padded(palette.floating(palette.panel, radius, spread), padding))
 
 
-static func _made(theme: Gen2LauncherTheme, style: StyleBoxFlat) -> Gen2LauncherCard:
+static func _made(palette: Gen2LauncherTheme, style: StyleBoxFlat) -> Gen2LauncherCard:
 	var card := Gen2LauncherCard.new()
-	card.palette = theme
+	card.palette = palette
 	card.add_theme_stylebox_override("panel", style)
 	return card

--- a/game/launcher/launcher_card.gd
+++ b/game/launcher/launcher_card.gd
@@ -13,34 +13,34 @@ var palette: Gen2LauncherTheme = null
 ## A card printed on the page: filled, with a hairline, and no shadow to be cut
 ## off by whatever scrolls it.
 static func create(
-	palette: Gen2LauncherTheme,
+	skin: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 20,
 	padding_y: int = -1,
 ) -> Gen2LauncherCard:
-	return _made(palette, palette.padded(palette.box(palette.panel, radius, palette.line), padding, padding_y))
+	return _made(skin, skin.padded(skin.box(skin.panel, radius, skin.line), padding, padding_y))
 
 
 ## A step back from the page: the track a segmented control sits in, or a strip
 ## of read-only detail.
 static func well(
-	palette: Gen2LauncherTheme,
+	skin: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 16,
 	padding_y: int = -1,
 ) -> Gen2LauncherCard:
-	return _made(palette, palette.padded(palette.box(palette.surface_alt, radius), padding, padding_y))
+	return _made(skin, skin.padded(skin.box(skin.surface_alt, radius), padding, padding_y))
 
 
 ## The current choice in a list of cards: an accent hairline and a wash of it,
 ## rather than a fill that would fight the text inside.
 static func selected(
-	palette: Gen2LauncherTheme,
+	skin: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 20,
 ) -> Gen2LauncherCard:
-	var style: StyleBoxFlat = palette.box(palette.accent_wash(0.10), radius, palette.accent, 2)
-	return _made(palette, palette.padded(style, padding))
+	var style: StyleBoxFlat = skin.box(skin.accent_wash(0.10), radius, skin.accent, 2)
+	return _made(skin, skin.padded(style, padding))
 
 
 ## A surface that genuinely floats: sheets, toasts and the bottom dock. Never put
@@ -49,25 +49,25 @@ static func selected(
 ## which is the opposite side of the page from everything under it. Whatever goes
 ## inside is written in [member Gen2LauncherTheme.on_surface].
 static func chip(
-	palette: Gen2LauncherTheme,
+	skin: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_MD,
 	padding: int = 16,
 	spread: int = 20,
 ) -> Gen2LauncherCard:
-	return _made(palette, palette.padded(palette.floating(palette.surface, radius, spread), padding))
+	return _made(skin, skin.padded(skin.floating(skin.surface, radius, spread), padding))
 
 
 static func floating(
-	palette: Gen2LauncherTheme,
+	skin: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_LG,
 	padding: int = 20,
 	spread: int = 26,
 ) -> Gen2LauncherCard:
-	return _made(palette, palette.padded(palette.floating(palette.panel, radius, spread), padding))
+	return _made(skin, skin.padded(skin.floating(skin.panel, radius, spread), padding))
 
 
-static func _made(palette: Gen2LauncherTheme, style: StyleBoxFlat) -> Gen2LauncherCard:
+static func _made(skin: Gen2LauncherTheme, style: StyleBoxFlat) -> Gen2LauncherCard:
 	var card := Gen2LauncherCard.new()
-	card.palette = palette
+	card.palette = skin
 	card.add_theme_stylebox_override("panel", style)
 	return card

--- a/game/launcher/launcher_icon.gd
+++ b/game/launcher/launcher_icon.gd
@@ -39,52 +39,52 @@ const PATHS: Dictionary = {
 static var _cache: Dictionary = {}
 
 
-static func create(glyph: StringName, side: float, colour: Color) -> Gen2LauncherIcon:
+static func create(glyph_name: StringName, drawn_side: float, colour: Color) -> Gen2LauncherIcon:
 	var icon := Gen2LauncherIcon.new()
-	icon.custom_minimum_size = Vector2(side, side)
+	icon.custom_minimum_size = Vector2(drawn_side, drawn_side)
 	icon.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	# The raster is drawn at twice its size, which would otherwise be the
 	# minimum this node reports.
 	icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	icon.set_glyph(glyph, side, colour)
+	icon.set_glyph(glyph_name, drawn_side, colour)
 	return icon
 
 
 ## The same drawing as a plain texture, for the places Godot wants an icon
 ## rather than a node: window titles, tree cells and stock buttons.
-static func raster(glyph: StringName, side: float, colour: Color) -> Texture2D:
-	var key: String = "%s|%d|%s" % [glyph, int(side), colour.to_html()]
+static func raster(glyph_name: StringName, drawn_side: float, colour: Color) -> Texture2D:
+	var key: String = "%s|%d|%s" % [glyph_name, int(drawn_side), colour.to_html()]
 	if _cache.has(key):
 		return _cache[key]
 	var image: Image = Image.new()
 	# Rendered at twice the drawn size: the launcher scales with the window, and
 	# a stroke resampled up from its exact size frays.
-	var source: String = _svg(glyph, colour)
+	var source: String = _svg(glyph_name, colour)
 	var error: int = OK if source.is_empty() else image.load_svg_from_string(
-		source, side * 2.0 / float(GRID)
+		source, drawn_side * 2.0 / float(GRID)
 	)
 	if source.is_empty() or error != OK or image.is_empty():
 		# A TextureRect with no texture looks exactly like one that was never
-		# asked for, so say which glyph failed rather than draw a hole.
-		push_warning("Launcher icon '%s' did not rasterise (error %d)." % [glyph, error])
+		# asked for, so say which glyph_name failed rather than draw a hole.
+		push_warning("Launcher icon '%s' did not rasterise (error %d)." % [glyph_name, error])
 		return null
 	var made: ImageTexture = ImageTexture.create_from_image(image)
 	_cache[key] = made
 	return made
 
 
-## The file the glyph is drawn from, so a check can reach it without repeating
+## The file the glyph_name is drawn from, so a check can reach it without repeating
 ## the layout of `PATHS`.
-static func source_path(glyph: StringName) -> String:
-	var filename: String = PATHS.get(glyph, "")
+static func source_path(glyph_name: StringName) -> String:
+	var filename: String = PATHS.get(glyph_name, "")
 	return "" if filename.is_empty() else "%s/%s" % [ICON_DIRECTORY, filename]
 
 
-static func _svg(glyph: StringName, colour: Color) -> String:
-	if source_path(glyph).is_empty():
+static func _svg(glyph_name: StringName, colour: Color) -> String:
+	if source_path(glyph_name).is_empty():
 		return ""
-	var source: String = FileAccess.get_file_as_string(source_path(glyph))
+	var source: String = FileAccess.get_file_as_string(source_path(glyph_name))
 	return source.replace("currentColor", "#%s" % colour.to_html(false))
 
 
@@ -93,16 +93,16 @@ var tint: Color = Color.WHITE
 var side: float = 24.0
 
 
-func set_glyph(name: StringName, drawn_side: float, colour: Color) -> void:
-	glyph = name
+func set_glyph(glyph_name: StringName, drawn_side: float, colour: Color) -> void:
+	glyph = glyph_name
 	tint = colour
 	side = drawn_side
 	custom_minimum_size = Vector2(drawn_side, drawn_side)
-	texture = Gen2LauncherIcon.raster(name, drawn_side, colour)
+	texture = Gen2LauncherIcon.raster(glyph_name, drawn_side, colour)
 
 
 
-## Whether a name is one the set actually draws, so a typo fails a test rather
+## Whether a glyph_name is one the set actually draws, so a typo fails a test rather
 ## than silently drawing nothing.
-static func has_glyph(name: StringName) -> bool:
-	return PATHS.has(name)
+static func has_glyph(glyph_name: StringName) -> bool:
+	return PATHS.has(glyph_name)

--- a/game/launcher/launcher_toggle.gd
+++ b/game/launcher/launcher_toggle.gd
@@ -18,9 +18,9 @@ var _slide: float = 0.0:
 		queue_redraw()
 
 
-static func create(theme: Gen2LauncherTheme, on: bool) -> Gen2LauncherToggle:
+static func create(palette: Gen2LauncherTheme, on: bool) -> Gen2LauncherToggle:
 	var toggle := Gen2LauncherToggle.new()
-	toggle._theme = theme
+	toggle._theme = palette
 	toggle.toggle_mode = true
 	toggle.custom_minimum_size = TRACK
 	toggle.set_pressed_no_signal(on)

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -421,9 +421,9 @@ func receive_feed_response(
 
 func _listing_text(received: Dictionary) -> String:
 	var entries: Array = received["entries"]
-	var name: String = String(received.get("name", ""))
+	var source_name: String = String(received.get("name", ""))
 	var line: String = "%s lists %d mod%s." % [
-		name if not name.is_empty() else "That source",
+		source_name if not source_name.is_empty() else "That source",
 		entries.size(), "" if entries.size() == 1 else "s",
 	]
 	var updates: int = Gen2ModIndex.update_count(entries, _installed_versions())

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -178,12 +178,12 @@ func _open_touch_layout() -> void:
 	sheet.open(_host if _host != null else self)
 
 
-func _card(host: VBoxContainer, name: String) -> VBoxContainer:
+func _card(host: VBoxContainer, title: String) -> VBoxContainer:
 	var panel: Gen2LauncherCard = Gen2LauncherCard.create(_theme, Gen2LauncherTheme.RADIUS_MD, 22)
 	host.add_child(panel)
 	var column: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
 	panel.add_child(column)
-	column.add_child(Gen2LauncherUI.caption(_theme, name))
+	column.add_child(Gen2LauncherUI.caption(_theme, title))
 	return column
 
 

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -194,10 +194,10 @@ func import_mod_path(path: String, replace: bool = false) -> Dictionary:
 	return result
 
 
-func _confirm_mod_replace(path: String, name: String) -> void:
+func _confirm_mod_replace(path: String, mod_name: String) -> void:
 	var sheet: Gen2LauncherSheet = Gen2LauncherSheet.create(_palette, "Replace mod")
 	sheet.body().add_child(Gen2LauncherUI.muted(
-		_palette, "%s is already installed. Replace it with this archive?" % name
+		_palette, "%s is already installed. Replace it with this archive?" % mod_name
 	))
 	var replace: Gen2LauncherButton = Gen2LauncherButton.create(
 		_palette, "Replace", Gen2LauncherButton.Variant.PRIMARY

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -553,24 +553,24 @@ func mart_entries(mart: Dictionary) -> Array:
 ## A mod describes a setting rather than drawing one: the start menu's MODS entry
 ## and the launcher's mods page are both built from these, so the two surfaces
 ## cannot disagree.
-func register_option(id: StringName, option: Dictionary) -> Dictionary:
-	var key: StringName = StringName(option.get("key", &""))
+func register_option(id: StringName, spec: Dictionary) -> Dictionary:
+	var key: StringName = StringName(spec.get("key", &""))
 	if String(id).is_empty() or String(key).is_empty():
 		return {"ok": false, "reason": &"invalid_option", "detail": String(id)}
-	var label: String = String(option.get("label", ""))
+	var label: String = String(spec.get("label", ""))
 	if label.is_empty():
 		return {"ok": false, "reason": &"option_missing_label", "detail": _option_name(id, key)}
-	var kind: StringName = StringName(option.get("kind", OPTION_LADDER))
+	var kind: StringName = StringName(spec.get("kind", OPTION_LADDER))
 	if not OPTION_KINDS.has(kind):
 		return {"ok": false, "reason": &"unknown_option_kind", "detail": String(kind)}
 	if kind == OPTION_BUTTON:
-		return _register_button_option(id, key, label, option)
+		return _register_button_option(id, key, label, spec)
 	if kind == OPTION_NUMBER:
-		return _register_number_option(id, key, label, option)
-	var values: Array = option.get("values", []) as Array
+		return _register_number_option(id, key, label, spec)
+	var values: Array = spec.get("values", []) as Array
 	if values.is_empty():
 		return {"ok": false, "reason": &"option_missing_values", "detail": _option_name(id, key)}
-	var labels: Array = option.get("labels", []) as Array
+	var labels: Array = spec.get("labels", []) as Array
 	if labels.is_empty():
 		labels = []
 		for value: Variant in values:
@@ -581,7 +581,7 @@ func register_option(id: StringName, option: Dictionary) -> Dictionary:
 	for existing: Dictionary in rows:
 		if StringName(existing.get("key", &"")) == key:
 			return {"ok": false, "reason": &"duplicate_option", "detail": _option_name(id, key)}
-	var fallback: int = maxi(_value_index(values, option.get("default", values[0])), 0)
+	var fallback: int = maxi(_value_index(values, spec.get("default", values[0])), 0)
 	rows.append({
 		"key": key, "label": label, "kind": OPTION_LADDER, "values": values.duplicate(),
 		"labels": _strings(labels), "default": fallback,
@@ -593,7 +593,7 @@ func register_option(id: StringName, option: Dictionary) -> Dictionary:
 ## A setting that is a press rather than a ladder: "recentre the camera now" has
 ## no values and nothing to persist, so it stores nothing and only emits.
 func _register_button_option(
-	id: StringName, key: StringName, label: String, option: Dictionary
+	id: StringName, key: StringName, label: String, spec: Dictionary
 ) -> Dictionary:
 	var rows: Array = _options.get(id, [])
 	for existing: Dictionary in rows:
@@ -601,22 +601,22 @@ func _register_button_option(
 			return {"ok": false, "reason": &"duplicate_option", "detail": _option_name(id, key)}
 	rows.append({
 		"key": key, "label": label, "kind": OPTION_BUTTON,
-		"press_label": String(option.get("press_label", "Go")),
+		"press_label": String(spec.get("press_label", "Go")),
 		"values": [], "labels": [], "default": 0,
 	})
 	_options[id] = rows
 	return {"ok": true, "id": id, "key": key}
 
 
-## A setting that is one whole number rather than a list of them. [param option]
+## A setting that is one whole number rather than a list of them. [param spec]
 ## takes [code]minimum[/code], [code]maximum[/code], an optional
 ## [code]step[/code] the two surfaces move by, and an optional
 ## [code]default[/code], clamped into the range as registered.
 func _register_number_option(
-	id: StringName, key: StringName, label: String, option: Dictionary
+	id: StringName, key: StringName, label: String, spec: Dictionary
 ) -> Dictionary:
-	var minimum: int = int(option.get("minimum", 0))
-	var maximum: int = int(option.get("maximum", 0))
+	var minimum: int = int(spec.get("minimum", 0))
+	var maximum: int = int(spec.get("maximum", 0))
 	if maximum < minimum:
 		return {"ok": false, "reason": &"option_range_inverted", "detail": _option_name(id, key)}
 	var rows: Array = _options.get(id, [])
@@ -626,8 +626,8 @@ func _register_number_option(
 	rows.append({
 		"key": key, "label": label, "kind": OPTION_NUMBER,
 		"minimum": minimum, "maximum": maximum,
-		"step": maxi(int(option.get("step", 1)), 1),
-		"default": clampi(int(option.get("default", minimum)), minimum, maximum),
+		"step": maxi(int(spec.get("step", 1)), 1),
+		"default": clampi(int(spec.get("default", minimum)), minimum, maximum),
 		"values": [], "labels": [],
 	})
 	_options[id] = rows

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -52,8 +52,8 @@ var directory: String = ""
 
 ## Reads and validates the manifest in [param directory].
 ## Returns { ok, manifest } or { ok: false, reason, detail }.
-static func read(directory: String) -> Dictionary:
-	var path: String = "%s/%s" % [directory, FILENAME]
+static func read(folder: String) -> Dictionary:
+	var path: String = "%s/%s" % [folder, FILENAME]
 	if not FileAccess.file_exists(path):
 		return _refuse(&"missing_manifest", path)
 	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
@@ -64,14 +64,14 @@ static func read(directory: String) -> Dictionary:
 	var parsed: Variant = JSON.parse_string(text)
 	if not parsed is Dictionary:
 		return _refuse(&"invalid_manifest", path)
-	return from_dictionary(parsed as Dictionary, directory)
+	return from_dictionary(parsed as Dictionary, folder)
 
 
 ## Validates an already-parsed manifest. Split out so a test, and a future pack
 ## reader, do not need a file on disk.
-static func from_dictionary(source: Dictionary, directory: String) -> Dictionary:
+static func from_dictionary(source: Dictionary, folder: String) -> Dictionary:
 	var manifest := Gen2ModManifest.new()
-	manifest.directory = directory
+	manifest.directory = folder
 	manifest.id = StringName(String(source.get("id", "")))
 	manifest.name = String(source.get("name", String(manifest.id)))
 	manifest.version = String(source.get("version", ""))
@@ -116,7 +116,7 @@ static func from_dictionary(source: Dictionary, directory: String) -> Dictionary
 			return _refuse(&"invalid_dependency_range", "%s %s" % [dependency_id, wanted])
 	if manifest.entry.is_empty():
 		return _refuse(&"missing_entry", String(manifest.id))
-	# An entry is a path inside the mod's own directory. Anything that climbs
+	# An entry is a path inside the mod's own folder. Anything that climbs
 	# out of it, or reaches for an absolute location, is refused.
 	if manifest.entry.begins_with("/") or manifest.entry.contains("..") \
 		or manifest.entry.contains(":"):

--- a/game/mods/mod_version.gd
+++ b/game/mods/mod_version.gd
@@ -68,8 +68,8 @@ static func _valid_token(token: String) -> bool:
 
 static func _matches_token(version: String, token: String) -> bool:
 	if token.begins_with("^"):
-		var floor: String = token.substr(1)
-		var values: Array[int] = _parts(floor)
+		var lower: String = token.substr(1)
+		var values: Array[int] = _parts(lower)
 		var ceiling: Array[int] = values.duplicate()
 		if values[0] > 0:
 			ceiling = [values[0] + 1, 0, 0]
@@ -77,19 +77,19 @@ static func _matches_token(version: String, token: String) -> bool:
 			ceiling = [0, values[1] + 1, 0]
 		else:
 			ceiling = [0, 0, values[2] + 1]
-		return _compare(version, floor) >= 0 and _compare(version, _join(ceiling)) < 0
+		return _compare(version, lower) >= 0 and _compare(version, _join(ceiling)) < 0
 	if token.begins_with("~"):
-		var floor: String = token.substr(1)
-		var values: Array[int] = _parts(floor)
-		return _compare(version, floor) >= 0 \
+		var lower: String = token.substr(1)
+		var values: Array[int] = _parts(lower)
+		return _compare(version, lower) >= 0 \
 			and _compare(version, "%d.%d.0" % [values[0], values[1] + 1]) < 0
 	if token.contains("x") or token.contains("X") or token.contains("*"):
-		var wanted: PackedStringArray = token.split(".", false)
+		var mask_parts: PackedStringArray = token.split(".", false)
 		var actual: Array[int] = _parts(version)
-		for index: int in wanted.size():
-			if wanted[index] in ["x", "X", "*"]:
+		for index: int in mask_parts.size():
+			if mask_parts[index] in ["x", "X", "*"]:
 				return true
-			if int(wanted[index]) != actual[index]:
+			if int(mask_parts[index]) != actual[index]:
 				return false
 		return true
 	var operator: String = "="

--- a/game/options/rules.gd
+++ b/game/options/rules.gd
@@ -131,12 +131,12 @@ func set_flag(flag: StringName, reproduce_hardware: bool) -> bool:
 ## of them is not any preset's answer. What a settings row shows.
 func mode_of() -> StringName:
 	for candidate: StringName in MODES:
-		var matches: bool = true
+		var all_match: bool = true
 		for flag: StringName in FLAGS:
 			if reproduces(flag) != _mode_value(candidate, flag):
-				matches = false
+				all_match = false
 				break
-		if matches:
+		if all_match:
 			return candidate
 	return MODE_CUSTOM
 

--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -162,7 +162,7 @@ func _load_sheet(indices: PackedByteArray) -> void:
 ## the three shapes [constant ROW_ITEM] names, and [param cursor] which of them
 ## the arrow stands on, or -1 while `PlaceHollowCursor` has taken it away.
 func pocket_map(
-	pocket: int, rows: Array, cursor: int, description: String,
+	_pocket: int, rows: Array, cursor: int, description: String,
 	pocket_name: PackedByteArray = PackedByteArray()
 ) -> PackedInt32Array:
 	var map := PackedInt32Array()

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -411,13 +411,13 @@ func _cursor_image(
 	sheet: PackedByteArray, palette: PackedColorArray, tile: int,
 	flip_x: bool, flip_y: bool
 ) -> Image:
-	var size: int = Gen2Font.TILE
+	var side: int = Gen2Font.TILE
 	var cell := PackedByteArray()
-	cell.resize(size * size)
+	cell.resize(side * side)
 	Gen2Font.blit_slot(
-		sheet, RomLayout.PC_SELECT_TILES * size, tile, cell, size, 0, 0
+		sheet, RomLayout.PC_SELECT_TILES * side, tile, cell, side, 0, 0
 	)
-	var image: Image = Gen2PicImage.from_indices(cell, size, size, palette, true)
+	var image: Image = Gen2PicImage.from_indices(cell, side, side, palette, true)
 	if flip_x:
 		image.flip_x()
 	if flip_y:

--- a/game/save/mon_stats_screen.gd
+++ b/game/save/mon_stats_screen.gd
@@ -32,11 +32,11 @@ var _cursor: int = 0
 var _page: int = PINK_PAGE
 
 
-static func create(data: GameData, mons: Array, cursor: int = 0) -> Gen2MonStatsScreen:
+static func create(data: GameData, mons: Array, start_cursor: int = 0) -> Gen2MonStatsScreen:
 	var out := Gen2MonStatsScreen.new()
 	out._data = data
 	out._mons = mons
-	out._cursor = clampi(cursor, 0, maxi(mons.size() - 1, 0))
+	out._cursor = clampi(start_cursor, 0, maxi(mons.size() - 1, 0))
 	return out
 
 

--- a/game/save/move_screen.gd
+++ b/game/save/move_screen.gd
@@ -29,11 +29,11 @@ var _row: int = 0
 var _held: int = -1
 
 
-static func create(data: GameData, party: Array, cursor: int = 0) -> Gen2MoveScreen:
+static func create(data: GameData, party: Array, start_cursor: int = 0) -> Gen2MoveScreen:
 	var out := Gen2MoveScreen.new()
 	out._data = data
 	out._party = party
-	out._cursor = clampi(cursor, 0, maxi(party.size() - 1, 0))
+	out._cursor = clampi(start_cursor, 0, maxi(party.size() - 1, 0))
 	return out
 
 

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -949,11 +949,11 @@ func _member_card(index: int) -> PanelContainer:
 	summary.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	summary.add_theme_constant_override("separation", 3)
 	content.add_child(summary)
-	var name := Label.new()
-	name.text = _display_name(mon)
-	name.add_theme_color_override("font_color", TEXT)
-	name.add_theme_font_size_override("font_size", 20)
-	summary.add_child(name)
+	var name_label := Label.new()
+	name_label.text = _display_name(mon)
+	name_label.add_theme_color_override("font_color", TEXT)
+	name_label.add_theme_font_size_override("font_size", 20)
+	summary.add_child(name_label)
 	var details := Label.new()
 	details.text = "%s    Level %d    HP %d/%d" % [
 		_species_name(mon.species), mon.level, mon.hp, _max_hp(mon)
@@ -994,8 +994,8 @@ func _species_name(species: int) -> String:
 
 
 func _status_name(status: int) -> String:
-	var name: StringName = Gen2Status.name_of(status)
-	return "OK" if name.is_empty() else String(name).to_upper()
+	var status_name: StringName = Gen2Status.name_of(status)
+	return "OK" if status_name.is_empty() else String(status_name).to_upper()
 
 
 func _status_color(status: int) -> Color:

--- a/game/save/save_box.gd
+++ b/game/save/save_box.gd
@@ -41,7 +41,10 @@ func to_dict() -> Array:
 	var out: Array = []
 	for index: int in CAPACITY:
 		var mon: Gen2SaveMon = slots[index] if index < slots.size() else null
-		out.append(mon.to_dict() if mon != null else null)
+		if mon == null:
+			out.append(null)
+			continue
+		out.append(mon.to_dict())
 	return out
 
 

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -230,9 +230,9 @@ func first_empty_box_slot() -> Dictionary:
 		var box: Gen2SaveBox = boxes[box_index]
 		if box == null:
 			continue
-		var slot: int = box.first_empty_slot()
-		if slot >= 0:
-			return {"ok": true, "box": box_index, "slot": slot}
+		var empty_slot: int = box.first_empty_slot()
+		if empty_slot >= 0:
+			return {"ok": true, "box": box_index, "slot": empty_slot}
 	return {"ok": false, "reason": &"storage_full"}
 
 

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -352,12 +352,12 @@ func _refresh_details() -> void:
 	var save: Gen2SaveData = _load_selected_save()
 	if save != null:
 		body.add_child(Gen2LauncherUI.muted(_palette, "Player: %s" % save.player_name))
-		var actions: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
-		body.add_child(actions)
-		actions.add_child(_action("Continue", Gen2LauncherButton.Variant.PRIMARY, &"play", _continue_selected))
-		actions.add_child(_action("Party", Gen2LauncherButton.Variant.NEUTRAL, &"", _open_party))
-		actions.add_child(_action("Import .sav", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_import))
-		actions.add_child(_action("Replace", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_new_game))
+		var save_actions: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+		body.add_child(save_actions)
+		save_actions.add_child(_action("Continue", Gen2LauncherButton.Variant.PRIMARY, &"play", _continue_selected))
+		save_actions.add_child(_action("Party", Gen2LauncherButton.Variant.NEUTRAL, &"", _open_party))
+		save_actions.add_child(_action("Import .sav", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_import))
+		save_actions.add_child(_action("Replace", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_new_game))
 		_add_party_summary(body, save)
 		_add_slot_management(body)
 		return
@@ -678,8 +678,8 @@ func _species_name(species: int) -> String:
 
 
 func _status_name(status: int) -> String:
-	var name: StringName = Gen2Status.name_of(status)
-	return "OK" if name.is_empty() else String(name).to_upper()
+	var status_name: StringName = Gen2Status.name_of(status)
+	return "OK" if status_name.is_empty() else String(status_name).to_upper()
 
 
 func _set_status(kind: StringName, title: String, detail: String) -> void:

--- a/game/world/credits.gd
+++ b/game/world/credits.gd
@@ -138,7 +138,7 @@ var _skippable: bool = false
 ## [param skippable] is `STATUSFLAGS_HALL_OF_FAME_F`, which is set by the time
 ## the induction it follows has been through once. Null when the cache carries no
 ## credits script.
-static func create(data: GameData, skippable: bool = false) -> Gen2Credits:
+static func create(data: GameData, can_skip: bool = false) -> Gen2Credits:
 	if data == null:
 		return null
 	var script: PackedByteArray = data.credits_script()
@@ -149,7 +149,7 @@ static func create(data: GameData, skippable: bool = false) -> Gen2Credits:
 	out._script = script
 	out._copyright_index = data.credits_index("copyright")
 	out._crystal = Gen2WorldState.is_crystal_profile(data)
-	out._skippable = skippable
+	out._skippable = can_skip
 	out._construct()
 	return out
 
@@ -239,18 +239,18 @@ func advance_frame(held: Array = []) -> Array:
 	var events: Array = []
 	if Gen2Button.B in held:
 		_skip()
-	var step: int = _step
-	_step = STEP_PARSE if step >= CYCLE_FRAMES - 1 else step + 1
-	if step == STEP_PARSE:
+	var at_step: int = _step
+	_step = STEP_PARSE if at_step >= CYCLE_FRAMES - 1 else at_step + 1
+	if at_step == STEP_PARSE:
 		events = _parse()
-	elif step in _gfx_steps():
+	elif at_step in _gfx_steps():
 		_load_banner()
 		## `Credits_UpdateGFXRequestPath` and `Credits_RequestGFX` both clear
 		## `hBGMapMode`, which is what stops the copy after its three thirds.
 		_copying = false
-	elif step == _ly_step():
+	elif at_step == _ly_step():
 		_scroll = (_scroll + _ly_delta()) & 0xFF
-	elif step == _prep_step():
+	elif at_step == _prep_step():
 		_copying = false
 	_copy_third()
 	return events

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -516,10 +516,10 @@ static func weight_text(weight: int) -> String:
 
 ## The OPTION screen's rows. UNOWN is dropped while `wUnlockedUnownMode` is
 ## clear, which is `.NoUnownModeArrowCursorData`'s shorter table.
-static func mode_rows(unown_unlocked: bool = false) -> Array:
+static func mode_rows(with_unown: bool = false) -> Array:
 	var out: Array = []
 	for row: Dictionary in MODE_ROWS:
-		if int(row["mode"]) == RomLayout.DEXMODE_UNOWN and not unown_unlocked:
+		if int(row["mode"]) == RomLayout.DEXMODE_UNOWN and not with_unown:
 			continue
 		out.append(row.duplicate(true))
 	return out

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -73,7 +73,7 @@ var _elapsed: float = 0.0
 ## Optional the way the trainer card is: without a world, its state or a cache
 ## carrying the dex order tables there is no listing, so this answers false and
 ## the caller keeps the start menu open.
-func open(data: GameData, world: Gen2WorldAPI, previous_entry: int = 0) -> bool:
+func open(data: GameData, world: Gen2WorldAPI, start_entry: int = 0) -> bool:
 	_data = data
 	_world = world
 	if _data == null or _world == null or _world.state == null:
@@ -84,7 +84,7 @@ func open(data: GameData, world: Gen2WorldAPI, previous_entry: int = 0) -> bool:
 	if _page == null or not _page.ready():
 		return false
 	_dex = Gen2Pokedex.open(
-		_data, _world.state, _world.state.last_dex_mode(), previous_entry
+		_data, _world.state, _world.state.last_dex_mode(), start_entry
 	)
 	if is_inside_tree() and _background != null:
 		_open_list_mode()

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -114,7 +114,7 @@ func _ready() -> void:
 ## false and the caller keeps its own screen open.
 func open(
 	data: GameData,
-	card: StringName,
+	card_id: StringName,
 	owned: Array,
 	text: String = "",
 	delete_text: String = "",
@@ -125,7 +125,7 @@ func open(
 	if _page == null or not _page.ready() or not _page.cards_ready():
 		visible = false
 		return false
-	_card = card
+	_card = card_id
 	_owned = owned.duplicate()
 	_text = text
 	_delete_text = delete_text
@@ -141,7 +141,7 @@ func open(
 	return true
 
 
-## `Pokegear_UpdateClock`'s three readings, which the card redraws every frame.
+## `Pokegear_UpdateClock`'s three readings, which the card_id redraws every frame.
 func set_clock(weekday: int, hour: int, minute: int) -> void:
 	_weekday = weekday
 	_hour = hour
@@ -455,8 +455,8 @@ func _knob_image() -> Image:
 ## through the overworld's first palette the way every icon on these screens is.
 ## Colour zero is transparent, which is what lets one sit over the card.
 func _icon(first: int, columns: int, rows: int, repeat: bool = false) -> Image:
-	var size := Vector2i(columns, rows) * Gen2TownMapPage.TILE
-	var out := Image.create(size.x, size.y, false, Image.FORMAT_RGBA8)
+	var pixels := Vector2i(columns, rows) * Gen2TownMapPage.TILE
+	var out := Image.create(pixels.x, pixels.y, false, Image.FORMAT_RGBA8)
 	out.fill(Color(0, 0, 0, 0))
 	var tiles: PackedByteArray = _data.tile_indices("pokegear_sprites") if _data != null \
 		else PackedByteArray()

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -875,20 +875,20 @@ func _pack_map(text: String) -> PackedInt32Array:
 ## The pack's screen with one of its `MENU_BACKUP_TILES` boxes over it.
 ## [param draw] writes tiles into the map the pack just built, so the box wears
 ## the attrmap `_CGB_PackPals` left rather than being a layer of its own.
-func _pack_overlay(text: String, draw: Callable) -> Image:
+func _pack_overlay(text: String, draw_page: Callable) -> Image:
 	if _pack_page == null:
 		_pack_page = Gen2PackPage.from_data(_data)
 	if _pack_page == null:
 		return null
 	var map: PackedInt32Array = _pack_map(text)
-	if draw.is_valid():
-		draw.call(map)
+	if draw_page.is_valid():
+		draw_page.call(map)
 	return _pack_page.image(_data, map, _pack_pocket_index, _player_is_female())
 
 
 ## `YesNoBox` over one of the pack's printed questions, which is what every one
 ## of its confirmations is.
-func _pack_yes_no(text: String, cursor: int) -> Image:
+func _pack_yes_no(text: String, cursor_index: int) -> Image:
 	return _pack_overlay(_last_page(text), func(map: PackedInt32Array) -> void:
 		_pack_page.draw_menu(
 			map,
@@ -897,7 +897,7 @@ func _pack_yes_no(text: String, cursor: int) -> Image:
 				YES_NO_AT.x + YES_NO_SPAN.x, YES_NO_AT.y + YES_NO_SPAN.y,
 				SUBMENU_FLAGS
 			),
-			YES_NO_OPTIONS, cursor
+			YES_NO_OPTIONS, cursor_index
 		)
 	)
 
@@ -1054,12 +1054,12 @@ func _give_selected_item(party_index: int, swap: bool = false) -> void:
 		_world, _pack_save, number, party_index, swap, _pack_persist
 	)
 	if bool(result.get("ok", false)):
-		var name: String = _target_name(party_index)
+		var target_name: String = _target_name(party_index)
 		var held_name: String = String(result.get("held_name", ""))
 		_show_pack_result(
-			Gen2WorldPack.swap_text(name, held_name, String(result.get("name", ""))) \
+			Gen2WorldPack.swap_text(target_name, held_name, String(result.get("name", ""))) \
 				if int(result.get("held", 0)) > 0 \
-				else Gen2WorldPack.hold_text(name, String(result.get("name", ""))),
+				else Gen2WorldPack.hold_text(target_name, String(result.get("name", ""))),
 			true
 		)
 		return
@@ -1405,10 +1405,10 @@ func _confirm_forget() -> void:
 			_teach_refusal(StringName(result.get("reason", &"")), _forget_party_index), false
 		)
 		return
-	var name: String = _target_name(_forget_party_index)
+	var target_name: String = _target_name(_forget_party_index)
 	_show_pack_result("%s %s" % [
-		Gen2MoveForget.forgot_text(name, String(entry.get("name", ""))),
-		Gen2MoveForget.learned_text(name, String(_teach_prompt.get("move_name", ""))),
+		Gen2MoveForget.forgot_text(target_name, String(entry.get("name", ""))),
+		Gen2MoveForget.learned_text(target_name, String(_teach_prompt.get("move_name", ""))),
 	], true)
 
 
@@ -1453,18 +1453,18 @@ func _target_name(party_index: int) -> String:
 ## revalidation failing between the two teach_tm_hm() calls.
 func _teach_refusal(reason: StringName, party_index: int) -> String:
 	var move_name: String = String(_teach_prompt.get("move_name", "that move"))
-	var name: String = _target_name(party_index)
+	var target_name: String = _target_name(party_index)
 	match reason:
 		&"not_compatible":
 			return "%s is not compatible with %s. It can't learn %s." % [
-				move_name, name, move_name,
+				move_name, target_name, move_name,
 			]
 		&"already_knows_move":
-			return "%s knows %s." % [name, move_name]
+			return "%s knows %s." % [target_name, move_name]
 		&"cannot_forget_hm":
 			return Gen2MoveForget.cant_forget_hm_text()
 		&"invalid_forget_slot":
-			return "%s can't forget that move." % name
+			return "%s can't forget that move." % target_name
 		&"cannot_teach_egg":
 			return "An EGG can't learn anything."
 	return "Can't teach that: %s" % String(reason)
@@ -1527,17 +1527,17 @@ func _use_selected_item(party_index: int) -> void:
 ## The source has no single "it worked" line: the effect routine prints its own.
 ## These name what changed, from the values Gen2WorldPartyHost already returns.
 func _use_summary(item: Dictionary, result: Dictionary) -> String:
-	var name: String = String(item.get("name", "ITEM"))
+	var item_name: String = String(item.get("name", "ITEM"))
 	if int(result.get("repel_steps", -1)) >= 0:
 		return "%s will repel weak Pokemon for %d steps." % [
-			name, int(result.get("repel_steps", 0)),
+			item_name, int(result.get("repel_steps", 0)),
 		]
 	var healed: int = int(result.get("healed", 0))
 	if healed > 0:
-		return "%s restored %d HP." % [name, healed]
+		return "%s restored %d HP." % [item_name, healed]
 	if int(result.get("status_cleared", 0)) != 0:
-		return "%s cured the status." % name
-	return "%s was used." % name
+		return "%s cured the status." % item_name
+	return "%s was used." % item_name
 
 
 ## `UseItem` and `UseRegisteredItem` refuse the same item in two words: the
@@ -1726,16 +1726,16 @@ func _open_save_confirm_mode() -> void:
 
 ## The yes/no's own cursor, `YesNoMenuHeader`'s `db 1` default, and the words
 ## the box holds. [param cursor] below zero is a mode with no box at all.
-func _enter_save_mode(mode: Mode, lines: Array, cursor: int) -> void:
+func _enter_save_mode(mode: Mode, lines: Array, cursor_index: int) -> void:
 	_mode = mode
 	_save_lines = lines.duplicate()
 	_save_line = 0
-	_save_cursor = cursor
+	_save_cursor = cursor_index
 	_save_frames = 0
 	_title.text = "SAVE"
 	_summary.text = " ".join(_save_lines)
 	_status.text = ""
-	_footer.text = "D-pad: choose    A: confirm    B: cancel" if cursor >= 0 \
+	_footer.text = "D-pad: choose    A: confirm    B: cancel" if cursor_index >= 0 \
 		else "A: continue"
 	_render_save()
 
@@ -1839,9 +1839,9 @@ func _show_save_result() -> void:
 			"Save failed:", String(_save_result.get("reason", "unknown")),
 		], 0)
 		return
-	var name: String = _pack_save.player_name if _pack_save != null else ""
+	var player_name: String = _pack_save.player_name if _pack_save != null else ""
 	_enter_save_mode(Mode.SAVE_SAVED, [
-		SAVE_SAVED_LINES[0] % name, SAVE_SAVED_LINES[1],
+		SAVE_SAVED_LINES[0] % player_name, SAVE_SAVED_LINES[1],
 	], -1)
 	## `WaitSFX` after it is not spent, for the reason the intro cry's is not.
 	sfx_requested.emit(SFX_SAVE)
@@ -2085,21 +2085,21 @@ func _hardware_image() -> Image:
 ## Keeps the active global row on the hardware page. Input and mutations retain
 ## the global cursor; only the rows handed to the page move.
 func _option_window(
-	rows: Array, cursor: int,
+	rows: Array, cursor_index: int,
 	visible_rows: int = Gen2StartMenuPage.OPTIONS_VISIBLE_ROWS
 ) -> Dictionary:
 	var first: int = clampi(
-		cursor - visible_rows + 1,
+		cursor_index - visible_rows + 1,
 		0, maxi(rows.size() - visible_rows, 0)
 	)
 	var last: int = mini(first + visible_rows, rows.size())
 	return {
 		"rows": rows.slice(first, last),
-		"cursor": cursor - first if cursor >= 0 else -1,
+		"cursor": cursor_index - first if cursor_index >= 0 else -1,
 	}
 
 
-func _render_options(values: Array, cursor: int, label_for: Callable) -> void:
+func _render_options(values: Array, cursor_index: int, label_for: Callable) -> void:
 	_render_hardware()
 	if _pack_view != null:
 		_pack_view.visible = false
@@ -2109,9 +2109,9 @@ func _render_options(values: Array, cursor: int, label_for: Callable) -> void:
 		child.queue_free()
 	for index: int in values.size():
 		var label := Label.new()
-		var name: String = label_for.call(values[index])
-		label.text = ("> " if index == cursor else "  ") + name
-		label.add_theme_color_override("font_color", ACCENT if index == cursor else TEXT)
+		var option_text: String = label_for.call(values[index])
+		label.text = ("> " if index == cursor_index else "  ") + option_text
+		label.add_theme_color_override("font_color", ACCENT if index == cursor_index else TEXT)
 		label.add_theme_font_size_override("font_size", 18)
 		_options.add_child(label)
 

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -185,12 +185,12 @@ var _cloud_scroll: int = 0
 
 ## [param sine] is `BattleAnimSineWave`, which the bird's own callback scales.
 ## Gold and Silver hold still without one rather than inventing a curve.
-static func create(profile: StringName, sine: Gen2BattleAnimData = null) -> Gen2TitleScene:
+static func create(profile_name: StringName, sine: Gen2BattleAnimData = null) -> Gen2TitleScene:
 	var out := Gen2TitleScene.new()
-	out._profile = profile
+	out._profile = profile_name
 	out._sine = sine
-	out._scene = SCENE_ENTRANCE if profile == RomRegistry.CRYSTAL else SCENE_TIMER
-	out._scx = ENTRANCE_SCX if profile == RomRegistry.CRYSTAL else 0
+	out._scene = SCENE_ENTRANCE if profile_name == RomRegistry.CRYSTAL else SCENE_TIMER
+	out._scx = ENTRANCE_SCX if profile_name == RomRegistry.CRYSTAL else 0
 	out._crystal_y = CRYSTAL_START_Y & 0xFF
 	return out
 

--- a/game/world/town_map.gd
+++ b/game/world/town_map.gd
@@ -77,13 +77,13 @@ static func fly(
 ## `TownMap_GetCurrentLandmark` has already run, so [param landmark] is resolved
 ## and never `LANDMARK_SPECIAL`. [param hall_of_fame] opens the whole Kanto map.
 static func create(
-	landmark: int, is_crystal: bool, hall_of_fame: bool = false,
+	landmark: int, is_crystal: bool, after_hall_of_fame: bool = false,
 	on_screen: StringName = SCREEN_TOWN_MAP
 ) -> Gen2TownMap:
 	var out := Gen2TownMap.new()
 	out.crystal = is_crystal
 	out.screen = on_screen
-	out.hall_of_fame = hall_of_fame
+	out.hall_of_fame = after_hall_of_fame
 	out.player_landmark = landmark
 	if on_screen == SCREEN_DEX_AREA:
 		# `.Area` sets hWY to 144, so the window is off and BG map 0, Johto's, is
@@ -93,7 +93,7 @@ static func create(
 	if out.region() == REGION_KANTO:
 		# `TownMap_GetKantoLandmarkLimits`' two branches end on the same
 		# `KANTO_LANDMARK_LAST`; only the first landmark moves.
-		out._first = Gen2WorldRadio.kanto_landmark(is_crystal) if hall_of_fame \
+		out._first = Gen2WorldRadio.kanto_landmark(is_crystal) if after_hall_of_fame \
 			else out._shift(LANDMARK_VICTORY_ROAD)
 		out._last = out._shift(LANDMARK_ROUTE_28)
 	else:
@@ -127,8 +127,8 @@ func region() -> int:
 		else REGION_JOHTO
 
 
-static func region_name(region: int) -> String:
-	return REGION_NAMES[clampi(region, REGION_JOHTO, REGION_KANTO)]
+static func region_name(region_id: int) -> String:
+	return REGION_NAMES[clampi(region_id, REGION_JOHTO, REGION_KANTO)]
 
 
 ## `.CheckPlayerLocation`: whether the dex area draws the player icon at all.

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -472,8 +472,8 @@ func _background_image() -> Image:
 func _header_codes() -> PackedByteArray:
 	if _map.screen != Gen2TownMap.SCREEN_DEX_AREA:
 		return _data.landmark(cursor_landmark()).get("codes", PackedByteArray())
-	var name: String = String(_data.species(_species).get("name", ""))
-	var out: PackedByteArray = Gen2Text.encode(name)
+	var species_name: String = String(_data.species(_species).get("name", ""))
+	var out: PackedByteArray = Gen2Text.encode(species_name)
 	out.append_array(Gen2Text.encode(NEST_HEADER_SUFFIX))
 	return out
 

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -48,7 +48,6 @@ const BADGE_OAM: Array[Dictionary] = [
 ]
 
 var _data: GameData = null
-var _card: Gen2TrainerCard = null
 var _page_renderer: Gen2TrainerCardPage = null
 var _save: Gen2SaveData = null
 var _world: Gen2WorldAPI = null
@@ -214,8 +213,8 @@ func _refresh_badges() -> void:
 func _badge_image(frame_tile: int) -> Image:
 	var tiles: PackedByteArray = _data.tile_indices("card_badges")
 	var palette: PackedColorArray = _data.card_badge_palette()
-	var size: int = BADGE_TILE_SIZE * 2
-	var image := Image.create(size, size, false, Image.FORMAT_RGBA8)
+	var side: int = BADGE_TILE_SIZE * 2
+	var image := Image.create(side, side, false, Image.FORMAT_RGBA8)
 	if tiles.is_empty():
 		return image
 	var strip_width: int = tiles.size() / BADGE_TILE_SIZE
@@ -235,7 +234,7 @@ func _badge_image(frame_tile: int) -> Image:
 				## rules, which is what lets a badge sit over the card.
 				if index == 0:
 					continue
-				var at_x: int = size - 1 - (to_x + x) if flip else to_x + x
+				var at_x: int = side - 1 - (to_x + x) if flip else to_x + x
 				image.set_pixel(
 					at_x, to_y + y, palette[clampi(index, 0, palette.size() - 1)]
 				)

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -67,10 +67,10 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 ## place in the sequence is where the crossing left it, which is what keeps the
 ## water moving across a route boundary rather than restarting it.
 func reload_tileset(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MORNING) -> void:
-	var command_index: int = _command_index
+	var at_command: int = _command_index
 	var timer: int = _timer
 	configure(world, time_of_day)
-	_command_index = command_index
+	_command_index = at_command
 	_timer = timer
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -874,13 +874,13 @@ func set_party_summary(
 ## (`TryCutOW`, `TrySurfOW`, `TryWhirlpoolOW`, `TryWaterfallOW`, `TryStrengthOW`)
 ## each call `CheckPartyMove` themselves, so there is no path in either game that
 ## uses a field move the party does not know.
-func party_slot_with_move(move: int) -> int:
+func party_slot_with_move(move_id: int) -> int:
 	var moves: Array = _party_summary.get("moves", [])
 	var eggs: Array = _party_summary.get("eggs", [])
 	for slot: int in moves.size():
 		if slot < eggs.size() and bool(eggs[slot]):
 			continue
-		if moves[slot] is Array and (moves[slot] as Array).has(move):
+		if moves[slot] is Array and (moves[slot] as Array).has(move_id):
 			return slot
 	return -1
 
@@ -1573,10 +1573,10 @@ static func _rock_smash_failure(reason: StringName) -> Dictionary:
 ## Mirrors the selected save's wPlayerID, the way set_party_summary() mirrors
 ## its party. Gen2WorldAPI owns no save, so this stays optional and unset
 ## refuses rather than scoring against zero.
-func set_player_id(player_id: int) -> Dictionary:
-	if player_id < 0 or player_id > 0xFFFF:
-		return {"ok": false, "reason": &"invalid_player_id", "player_id": player_id}
-	_player_id = player_id
+func set_player_id(new_player_id: int) -> Dictionary:
+	if new_player_id < 0 or new_player_id > 0xFFFF:
+		return {"ok": false, "reason": &"invalid_player_id", "player_id": new_player_id}
+	_player_id = new_player_id
 	return {"ok": true}
 
 
@@ -3140,25 +3140,25 @@ func _field_move_prompt_request(cell: Vector2i) -> Dictionary:
 	if current_map == null or current_tileset == null or data == null:
 		return {}
 	var collision: int = collision_code_at(cell)
-	var move: int = 0
+	var move_id: int = 0
 	var tile_ok: bool = true
 	if Gen2WorldFieldMove.cut_tree_tile(collision):
-		move = Gen2WorldFieldMove.MOVE_CUT
+		move_id = Gen2WorldFieldMove.MOVE_CUT
 	elif Gen2WorldFieldMove.whirlpool_tile(collision):
-		move = Gen2WorldFieldMove.MOVE_WHIRLPOOL
+		move_id = Gen2WorldFieldMove.MOVE_WHIRLPOOL
 		tile_ok = bool(Gen2WorldFieldMove.whirlpool_replacement(
 			current_map.tileset, block_at(_script_block_cell(cell).x, _script_block_cell(cell).y)
 		).get("ok", false))
 	elif Gen2WorldFieldMove.waterfall_tile(collision):
-		move = Gen2WorldFieldMove.MOVE_WATERFALL
+		move_id = Gen2WorldFieldMove.MOVE_WATERFALL
 		## CheckMapCanWaterfall is the facing and the tile above, which is this
 		## cell only when the player faces up.
 		tile_ok = player_facing == Gen2WorldSprite.FACING_UP
 	elif Gen2WorldFieldMove.headbutt_tile(collision):
-		move = Gen2WorldFieldMove.MOVE_HEADBUTT
+		move_id = Gen2WorldFieldMove.MOVE_HEADBUTT
 	elif _surf_prompt_applies(cell):
-		move = Gen2WorldFieldMove.MOVE_SURF
-	if move == 0:
+		move_id = Gen2WorldFieldMove.MOVE_SURF
+	if move_id == 0:
 		return {}
 	return {
 		"kind": &"field_move_prompt",
@@ -3167,7 +3167,7 @@ func _field_move_prompt_request(cell: Vector2i) -> Dictionary:
 		"cell": cell,
 		"bank": 0,
 		"script": 0,
-		"move": move,
+		"move": move_id,
 		"tile_ok": tile_ok,
 	}
 

--- a/game/world/world_menu.gd
+++ b/game/world/world_menu.gd
@@ -134,13 +134,13 @@ func _move_vertical(delta: int) -> bool:
 func _move_2d(direction: Vector2i) -> bool:
 	var next_row: int = row() + signi(direction.y)
 	var next_column: int = column() + signi(direction.x)
-	var wrap: bool = (flags & STATICMENU_WRAP) != 0
+	var wraps: bool = (flags & STATICMENU_WRAP) != 0
 	if next_row < 0 or next_row >= rows:
-		if not wrap:
+		if not wraps:
 			return false
 		next_row = rows - 1 if next_row < 0 else 0
 	if next_column < 0 or next_column >= columns:
-		if not wrap:
+		if not wraps:
 			return false
 		next_column = columns - 1 if next_column < 0 else 0
 	var next: int = next_row * columns + next_column

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -352,16 +352,16 @@ func start_step(direction: Vector2i, frames: int) -> void:
 ## walking its whole path already facing the last command's way.
 func queue_step(
 	direction: Vector2i, frames: int, jumping: bool = false,
-	facing: Vector2i = Vector2i.ZERO
+	new_facing: Vector2i = Vector2i.ZERO
 ) -> void:
 	if step_frames_remaining > 0 or not queued_steps.is_empty():
 		scripted_steps = true
 		queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
-			"facing": facing,
+			"facing": new_facing,
 		})
 		return
-	apply_direction(facing)
+	apply_direction(new_facing)
 	## A turn spends no frames, so an entry with none to spend leaves nothing
 	## for the stream's wait to end on: it is the turn and nothing else.
 	if frames <= 0 and direction == Vector2i.ZERO:

--- a/game/world/world_options_menu.gd
+++ b/game/world/world_options_menu.gd
@@ -42,9 +42,9 @@ var cursor: int = 0
 var _options: Gen2Options = null
 
 
-static func build(options: Gen2Options) -> Gen2WorldOptionsMenu:
+static func build(source_options: Gen2Options) -> Gen2WorldOptionsMenu:
 	var menu := Gen2WorldOptionsMenu.new()
-	menu._options = options if options != null else Gen2Options.new()
+	menu._options = source_options if source_options != null else Gen2Options.new()
 	return menu
 
 

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -199,11 +199,11 @@ func _draw() -> void:
 	)
 	var window_size: Vector2i = Gen2WorldAPI.VIEW_TILES + Vector2i.ONE
 	var page: PackedInt32Array = _world.tile_indices_in_window(tile_origin, window_size)
-	var hidden: Dictionary = _hidden_tree_tiles()
+	var hidden_tiles: Dictionary = _hidden_tree_tiles()
 	for y: int in window_size.y:
 		for x: int in window_size.x:
 			var tile: int = page[y * window_size.x + x]
-			if hidden.has(tile_origin + Vector2i(x, y)):
+			if hidden_tiles.has(tile_origin + Vector2i(x, y)):
 				tile = Gen2WorldEffects.HEADBUTT_TREE_HIDDEN_TILE
 			if _atlas == null or tile < 0 or tile >= _world.current_tileset.tile_count:
 				continue
@@ -332,8 +332,8 @@ func _draw_actor(
 	sprite: Dictionary, camera_pixels: Vector2, page: PackedInt32Array,
 	tile_origin: Vector2i, tile_offset: Vector2, window_size: Vector2i
 ) -> void:
-	var position: Vector2 = sprite["position_cells"]
-	var pixel: Vector2 = position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels
+	var cell_position: Vector2 = sprite["position_cells"]
+	var pixel: Vector2 = cell_position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels
 	var texture: Texture2D = _actor_texture(
 		sprite["sprite"], 0, int(sprite["facing"]), int(sprite["frame"]),
 		Gen2WorldSprite.BIG_SHAPE_NONE, sprite.get("colors", PackedColorArray())
@@ -341,7 +341,7 @@ func _draw_actor(
 	if texture == null:
 		return
 	draw_texture(texture, pixel)
-	if _in_grass(Vector2i(roundi(position.x), roundi(position.y))):
+	if _in_grass(Vector2i(roundi(cell_position.x), roundi(cell_position.y))):
 		_draw_grass_over(pixel, page, tile_origin, tile_offset, window_size)
 
 
@@ -393,7 +393,7 @@ func _in_grass(cell: Vector2i) -> bool:
 func _draw_grass_over(
 	pixel: Vector2,
 	page: PackedInt32Array,
-	tile_origin: Vector2i,
+	_tile_origin: Vector2i,
 	tile_offset: Vector2,
 	window_size: Vector2i,
 ) -> void:
@@ -591,23 +591,23 @@ func _draw_effect_sprite(sprite: Dictionary, anchor: Vector2) -> void:
 ## `.LoadPalettes` writes over PAL_OW_TREE and `.FlashPalettes` then rotates
 ## left. Everything else wears the overworld palette its spawn named, at the
 ## time of day the map is on.
-func _effect_palette(sheet: Dictionary, palette_index: int, rotation: int) -> PackedColorArray:
+func _effect_palette(sheet: Dictionary, palette_index: int, rotation_step: int) -> PackedColorArray:
 	var own: PackedColorArray = sheet.get("colors", PackedColorArray())
 	if own.is_empty():
 		return _world.data.overworld_sprite_palette(palette_index, _time_of_day)
 	var rotated := PackedColorArray()
 	for slot: int in own.size():
-		rotated.append(own[(slot + rotation) % own.size()])
+		rotated.append(own[(slot + rotation_step) % own.size()])
 	return rotated
 
 
-func _effect_sheet(name: String) -> Dictionary:
+func _effect_sheet(sheet_name: String) -> Dictionary:
 	if _world == null or _world.data == null:
 		return {}
-	if _effect_sheets.has(name):
-		return _effect_sheets[name]
-	var sheet: Dictionary = _world.data.overworld_effect(name)
-	_effect_sheets[name] = sheet
+	if _effect_sheets.has(sheet_name):
+		return _effect_sheets[sheet_name]
+	var sheet: Dictionary = _world.data.overworld_effect(sheet_name)
+	_effect_sheets[sheet_name] = sheet
 	return sheet
 
 
@@ -617,10 +617,10 @@ func _effect_sheet(name: String) -> Dictionary:
 ## carrying its own palette can be asked for.
 func _draw_effect_tile(
 	sheet: Dictionary, tile: int, palette_index: int, flip_x: bool, at: Vector2,
-	rotation: int = 0
+	rotation_step: int = 0
 ) -> void:
 	var key: String = "%s:%d:%d:%d:%d:%d" % [
-		sheet["name"], tile, palette_index, int(flip_x), _time_of_day, rotation,
+		sheet["name"], tile, palette_index, int(flip_x), _time_of_day, rotation_step,
 	]
 	var texture: Texture2D = _effect_textures.get(key, null)
 	if texture == null:
@@ -628,7 +628,7 @@ func _draw_effect_tile(
 		var tiles: int = int(sheet["tiles"])
 		if tile < 0 or tile >= tiles or indices.size() < tiles * Gen2Tiles.TILE_PIXELS:
 			return
-		var palette: PackedColorArray = _effect_palette(sheet, palette_index, rotation)
+		var palette: PackedColorArray = _effect_palette(sheet, palette_index, rotation_step)
 		var image := Image.create(
 			Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT, false, Image.FORMAT_RGBA8
 		)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -621,9 +621,9 @@ func input_recording() -> Array:
 
 ## Plays a recorded log back into this world instead of reading the input
 ## runtime. Every entry is applied on the frame it names, from inside the pump.
-func replay_input(log: Array) -> void:
+func replay_input(entries: Array) -> void:
 	_input_replay = {}
-	for raw: Variant in log:
+	for raw: Variant in entries:
 		if not raw is Dictionary:
 			continue
 		var entry: Dictionary = raw
@@ -1115,11 +1115,11 @@ func _after_map_settled() -> bool:
 	## met by walking into one. Everything else that reaches a wild, a script, a
 	## rod, Headbutt, Rock Smash, Sweet Scent and the contest, keeps its own path.
 	if _encounters != null and _encounters.active():
-		var visible: Dictionary = _encounters.battle_request_at(_world.player_cell)
-		if not visible.is_empty():
-			_battle_encounter_id = StringName(visible["visible_encounter"])
+		var request: Dictionary = _encounters.battle_request_at(_world.player_cell)
+		if not request.is_empty():
+			_battle_encounter_id = StringName(request["visible_encounter"])
 			_zero_map_name_sign_timer()
-			_start_battle_request(visible)
+			_start_battle_request(request)
 		return true
 	var encounter: Dictionary = _world.encounter_request(
 		_encounter_random, false, &"auto", _repel_lead_level(), _party_holds_cleanse_tag()
@@ -2027,10 +2027,10 @@ func preview_fishing_battle() -> void:
 func _position_for_fishing_preview() -> void:
 	if _world.current_map == null or _world.current_map.fish_group <= 0:
 		return
-	var size: Vector2i = _world.map_size_cells()
+	var map_size: Vector2i = _world.map_size_cells()
 	var directions: Array[Vector2i] = [Vector2i.DOWN, Vector2i.UP, Vector2i.LEFT, Vector2i.RIGHT]
-	for y: int in size.y:
-		for x: int in size.x:
+	for y: int in map_size.y:
+		for x: int in map_size.x:
 			var cell := Vector2i(x, y)
 			if _world.collision_permission_at(cell) != Gen2WorldCollision.LAND_TILE:
 				continue
@@ -3173,19 +3173,19 @@ func _run_mon_item_action(action: Dictionary) -> void:
 	var result: Dictionary = Gen2WorldBagHost.take_from_party(
 		_world, save, slot, _injected_save == null
 	)
-	var name: String = String(action.get("name", ""))
+	var action_name: String = String(action.get("name", ""))
 	if bool(result.get("ok", false)):
-		_show_field_move_text(Gen2WorldPack.took_text(name, String(result.get("name", ""))))
+		_show_field_move_text(Gen2WorldPack.took_text(action_name, String(result.get("name", ""))))
 		return
 	match StringName(result.get("reason", &"")):
 		&"not_holding":
-			_show_field_move_text(Gen2WorldPack.not_holding_text(name))
+			_show_field_move_text(Gen2WorldPack.not_holding_text(action_name))
 		&"bag_full":
 			_show_field_move_text(Gen2WorldPack.storage_full_text())
 		_:
 			_show_field_move_text(
 				"%s could not hand that over (%s)." % [
-					name, String(result.get("reason", "")),
+					action_name, String(result.get("reason", "")),
 				]
 			)
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -648,8 +648,8 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 			return _fail(
 				StringName(result.get("reason", &"catch_tutorial_failed")), result
 			)
-		var outcome: StringName = StringName(result.get("outcome", &""))
-		if outcome != Gen2WorldBattleAdapter.OUTCOME_CAUGHT:
+		var catch_outcome: StringName = StringName(result.get("outcome", &""))
+		if catch_outcome != Gen2WorldBattleAdapter.OUTCOME_CAUGHT:
 			return _fail(&"invalid_catch_tutorial_outcome", result)
 		_script_value = 1
 		_events.append({
@@ -2753,9 +2753,9 @@ func _phone_trainer_mon_name() -> String:
 	var party: Array = data.trainer_party(trainer_group, trainer_id).get("party", []) if data != null else []
 	var candidates: Array[int] = []
 	for mon: Dictionary in party:
-		var species: int = int(mon.get("species", 0))
-		if species > 0 and data.species(species).size() > 0:
-			candidates.append(species)
+		var party_species: int = int(mon.get("species", 0))
+		if party_species > 0 and data.species(party_species).size() > 0:
+			candidates.append(party_species)
 	if candidates.is_empty():
 		return ""
 	var species: int = candidates[_random.randi_range(0, candidates.size() - 1)]

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -384,10 +384,10 @@ func _mart_text(slot: String, filled: Dictionary = {}) -> String:
 	var prefix: String = String(MART_TEXT_PREFIX.get(
 		StringName(_mart_source().get("variant", &"standard")), ""
 	))
-	var name: String = prefix + slot
+	var slot_name: String = prefix + slot
 	if slot == "intro" and prefix.is_empty():
-		name = "welcome"
-	var text: String = _data.mart_text(name)
+		slot_name = "welcome"
+	var text: String = _data.mart_text(slot_name)
 	if text.is_empty():
 		return ""
 	return _fill_mart_markers(text, filled)
@@ -1080,11 +1080,11 @@ func _refresh_card() -> void:
 			# makes the exit restart it.
 			_radio_music = RADIO_MUSIC_RESTART_MAP if bool(tuned.get("ok", false)) \
 				else RADIO_MUSIC_ENTER_MAP
-			var show: Gen2RadioShow = _world.radio_show()
+			var radio_show: Gen2RadioShow = _world.radio_show()
 			_pokegear.set_radio(
 				_world.state.radio_knob(),
 				String(tuned.get("name", "")) if bool(tuned.get("ok", false)) else "",
-				show.lines() if show != null else PackedStringArray()
+				radio_show.lines() if radio_show != null else PackedStringArray()
 			)
 		Gen2PokegearScreen.CARD_PHONE:
 			_pokegear.set_contacts(
@@ -1421,21 +1421,21 @@ func _render_options(override: Array = []) -> void:
 	for index: int in values.size():
 		var value: Variant = values[index]
 		var label := Label.new()
-		var name: String = str(value)
+		var text: String = str(value)
 		if value is Dictionary:
 			var dictionary: Dictionary = value as Dictionary
-			name = str(dictionary.get("name", ""))
-			if name.is_empty():
-				name = str(dictionary.get("caller_label", ""))
-			if name.is_empty():
-				name = str(dictionary.get("trainer_name", "UNKNOWN"))
-			if name.is_empty() and dictionary.has("index"):
-				name = "CONTACT %d" % int(dictionary.get("index", -1))
+			text = str(dictionary.get("name", ""))
+			if text.is_empty():
+				text = str(dictionary.get("caller_label", ""))
+			if text.is_empty():
+				text = str(dictionary.get("trainer_name", "UNKNOWN"))
+			if text.is_empty() and dictionary.has("index"):
+				text = "CONTACT %d" % int(dictionary.get("index", -1))
 		if value is Dictionary and _mode == MODE.PC_ITEM_LIST:
 			var stack: int = int((value as Dictionary).get("quantity", 0))
-			name = "%s    x%d of %d" % [name, _pc_quantity, stack] if index == _cursor \
-				else "%s    x%d" % [name, stack]
-		label.text = ("> " if index == _cursor else "  ") + name
+			text = "%s    x%d of %d" % [text, _pc_quantity, stack] if index == _cursor \
+				else "%s    x%d" % [text, stack]
+		label.text = ("> " if index == _cursor else "  ") + text
 		label.add_theme_color_override("font_color", ACCENT if index == _cursor else TEXT)
 		label.add_theme_font_size_override("font_size", 18)
 		parent.add_child(label)

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -92,15 +92,15 @@ static func build(
 		GATE_PARTY: party_count > 0,
 		GATE_POKEGEAR: pokegear_obtained,
 	}
-	var items: Array = []
+	var rows: Array = []
 	for entry: Dictionary in SOURCE_ENTRIES:
 		var gate: StringName = StringName(entry.get("gate", &""))
 		if not String(gate).is_empty() and not bool(passes.get(gate, false)):
 			continue
 		if entry["kind"] == ITEM_EXIT:
 			if not Gen2ModHost.instance().option_mod_ids().is_empty():
-				items.append(_entry(ITEM_MODS, "MODS", true))
-			items.append_array(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START))
+				rows.append(_entry(ITEM_MODS, "MODS", true))
+			rows.append_array(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START))
 		var label: String = String(entry["label"])
 		## `PlaceString` reads `wPlayerName` for `<PLAYER>`, so the STATUS row
 		## says the player's own name and never those eight characters.
@@ -109,11 +109,11 @@ static func build(
 		## rather than printing the marker's own characters.
 		if entry["kind"] == ITEM_PLAYER:
 			label = player_name if not player_name.is_empty() else "PLAYER"
-		items.append(_entry(
+		rows.append(_entry(
 			StringName(entry["kind"]), label, bool(entry["available"])
 		))
-	menu._items = items
-	menu.cursor = clampi(previous_cursor, 0, maxi(items.size() - 1, 0))
+	menu._items = rows
+	menu.cursor = clampi(previous_cursor, 0, maxi(rows.size() - 1, 0))
 	return menu
 
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -1358,11 +1358,11 @@ func apply_changes(
 			next_flags.erase(flag)
 	var next_engine_flags: Dictionary = _engine_flags.duplicate()
 	for raw_flag: Variant in engine_flag_changes:
-		var engine_flag: int = int(raw_flag)
+		var flag_id: int = int(raw_flag)
 		if bool(engine_flag_changes[raw_flag]):
-			next_engine_flags[engine_flag] = true
+			next_engine_flags[flag_id] = true
 		else:
-			next_engine_flags.erase(engine_flag)
+			next_engine_flags.erase(flag_id)
 	var next_scenes: Dictionary = _map_scenes.duplicate()
 	for raw_map: Variant in scene_changes:
 		next_scenes[String(raw_map)] = int(scene_changes[raw_map])

--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,7 @@ InputRuntime="*res://autoload/input_runtime.gd"
 [debug]
 
 file_logging/enable_file_logging=true
+gdscript/warnings/integer_division=0
 
 [display]
 

--- a/tools/dump_editor_errors.gd
+++ b/tools/dump_editor_errors.gd
@@ -1,0 +1,75 @@
+@tool
+extends EditorScript
+
+## Editor > File > Run: writes the Debugger's error list to
+## user://editor_errors.txt and prints a tally per warning code.
+##
+## The GDScript analyzer runs only inside the editor and reports to that panel
+## alone: no CLI mode prints its warnings, `--check-only` suppresses them and
+## file logging records the running game rather than the editor. Scraping the
+## panel is the only way to read them outside it.
+##
+## The panel holds what this editor session has analysed, so a full sweep is
+## Project > Reload Current Project first, then this.
+
+const OUTPUT_PATH: String = "user://editor_errors.txt"
+
+
+func _run() -> void:
+	var lines := PackedStringArray()
+	for tree: Node in _trees(EditorInterface.get_base_control()):
+		var root: TreeItem = (tree as Tree).get_root()
+		if root == null:
+			continue
+		var entries := PackedStringArray()
+		_walk(root.get_first_child(), 0, entries)
+		if not _is_error_list(entries):
+			continue
+		lines.append_array(entries)
+
+	var file: FileAccess = FileAccess.open(OUTPUT_PATH, FileAccess.WRITE)
+	file.store_string("\n".join(lines))
+	file.close()
+
+	var codes: Dictionary = {}
+	for line: String in lines:
+		if not line.contains("<GDScript Error>"):
+			continue
+		var code: String = line.split("<GDScript Error>")[1].strip_edges()
+		codes[code] = int(codes.get(code, 0)) + 1
+	var total: int = 0
+	for code: String in codes:
+		total += int(codes[code])
+		print("%5d  %s" % [codes[code], code])
+	print("%d entries, %d of them GDScript, in %s"
+		% [lines.size(), total, ProjectSettings.globalize_path(OUTPUT_PATH)])
+
+
+## An error list is the one tree whose rows carry the debugger's own fields.
+func _is_error_list(entries: PackedStringArray) -> bool:
+	for line: String in entries:
+		if line.contains("<GDScript Source>") or line.contains("<C++ Source>"):
+			return true
+	return false
+
+
+func _walk(item: TreeItem, depth: int, lines: PackedStringArray) -> void:
+	while item != null:
+		var columns := PackedStringArray()
+		for column: int in item.get_tree().columns:
+			var text: String = item.get_text(column)
+			if not text.is_empty():
+				columns.append(text)
+		lines.append("\t".repeat(depth) + " ".join(columns))
+		if item.get_first_child() != null:
+			_walk(item.get_first_child(), depth + 1, lines)
+		item = item.get_next()
+
+
+func _trees(node: Node) -> Array[Node]:
+	var out: Array[Node] = []
+	if node.is_class("Tree"):
+		out.append(node)
+	for child: Node in node.get_children(true):
+		out.append_array(_trees(child))
+	return out

--- a/tools/dump_editor_errors.gd.uid
+++ b/tools/dump_editor_errors.gd.uid
@@ -1,0 +1,1 @@
+uid://bworp4s2juiob


### PR DESCRIPTION
The GDScript analyzer reports only inside the editor: no CLI mode prints its warnings, `--check-only` suppresses them and file logging records the running game. 223 had accumulated there unseen.

| Warning | Count | Fix |
|---|---|---|
| `SHADOWED_VARIABLE` | 75 | renamed |
| `SHADOWED_VARIABLE_BASE_CLASS` | 57 | renamed |
| `INTEGER_DIVISION` | 62 | turned off in `project.godot` |
| `UNUSED_PARAMETER` | 13 | underscored |
| `SHADOWED_GLOBAL_IDENTIFIER` | 4 | renamed |
| `CONFUSABLE_LOCAL_DECLARATION` | 4 | separated |
| `INT_AS_ENUM_WITHOUT_CAST` | 3 | cast |
| `INCOMPATIBLE_TERNARY` | 3 | written as branches |
| `UNUSED_VARIABLE`, `UNUSED_PRIVATE_CLASS_VARIABLE` | 2 | deleted |

Shadowing is the part that can bite: locals named `position`, `size`, `visible`, `name`, `theme` and `show` hid the `Control` properties underneath them, and factory parameters hid the class's own methods.

`integer_division` is a project setting rather than 62 annotations because this is 8-bit hardware arithmetic throughout, from the APU's fixed-point accumulators to bank numbers and cursor rows: `a / b` on two integers is the intended operation and a float result is written with an explicit `float()`.

`tools/dump_editor_errors.gd` (Editor > File > Run) writes the panel to `user://editor_errors.txt` and tallies the warning codes, so the count is checkable rather than scrolled. `docs/CONTRIBUTING.md` states both facts.

Green: GUT 3,243 tests over 152 scripts (unit and scene tiers), `validate.gd -- all` 54 topics 0 failures, `replay_world.gd` 33 routes 0 failures, the story walk on all three profiles with no failed step.