### PR TITLE
Let a sound finish before the next one takes its channels

### DIFF
--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -93,7 +93,18 @@ func play_record(
 			_engine.cry_tracks = cry_tracks
 			_engine.stereo_panning_mask = 1 if cry_tracks != 0 else 0
 			started = _engine.play_cry(record)
-		&"sound", &"sfx":
+		&"sound", &"sfx", &"waited_sfx":
+			# `WaitPlaySFX` holds until the channels are free, so its sound is
+			# never the one the gate refuses. The wait is not spent here.
+			started = _engine.play_sfx_gated(record, request_kind == &"waited_sfx")
+			if not started:
+				# `PlaySFX` refusing a lower-priority request is the driver
+				# working, not a failure: the effect on the channels keeps them.
+				return {"ok": true, "played": false, "refused": true}
+		&"stereo_sfx":
+			# `PlayStereoSFX`, which the battle animations reach directly: no
+			# `wCurSFX` gate in front of it, so an animation's own sound lands
+			# whatever is still ringing.
 			started = _engine.play_sfx(record)
 		_:
 			started = _engine.play_music(record)
@@ -110,6 +121,12 @@ func play_record(
 		"bank": int(record.get("bank", -1)),
 		"address": int(record.get("address", -1)),
 	}
+
+
+## `SFXChannelsOff`, which the Unown sounds spend in front of their own
+## `PlaySFX` so the one still ringing is cut rather than left to refuse the next.
+func stop_effects() -> void:
+	_engine.sfx_channels_off()
 
 
 ## `FadeMusic`: a frame count per volume step. Zero stops at once, which is what

--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -173,6 +173,9 @@ var cry_pitch: int = 0
 var cry_length: int = 0
 var cry_tracks: int = 0
 var stereo_panning_mask: int = 0
+## `wCurSFX`: which effect the four sfx channels are carrying, which is what
+## [method play_sfx_gated] compares a new request against.
+var cur_sfx: int = 0
 
 var _cur_channel: int = 0
 var _cur_track_duty: int = 0
@@ -261,6 +264,7 @@ func init_sound() -> void:
 	cry_length = 0
 	cry_tracks = 0
 	stereo_panning_mask = 0
+	cur_sfx = 0
 	_cur_track_duty = 0
 	_cur_track_volume_envelope = 0
 	_cur_track_frequency = 0
@@ -301,6 +305,43 @@ func play_music(record: Dictionary) -> bool:
 	_music_noise_sample_set = 0
 	music_on()
 	return true
+
+
+## `SFXChannelsOff`: the four effect channels' `CHANNEL_FLAGS1` zeroed and the
+## pitch sweep with them. It is what the Unown sounds and the other places that
+## cut an effect short reach in front of `PlaySFX`, which is also why their next
+## request is never the one [method play_sfx_gated] refuses.
+func sfx_channels_off() -> void:
+	for index: int in range(NUM_MUSIC_CHANNELS, NUM_CHANNELS):
+		var channel: Channel = channels[index]
+		channel.channel_on = false
+		channel.subroutine = false
+		channel.looping = false
+		channel.sfx = false
+		channel.noise = false
+		channel.cry = false
+	pitch_sweep_value = 0
+
+
+## `PlaySFX`: the wrapper every `playsound`, `specialsound` and menu beep goes
+## through, and the reason two of them do not pile onto each other. The table is
+## ordered highest priority first, so a request is refused while a *lower*-
+## numbered effect is still on the four channels; the same id restarts, since
+## the comparison is `cp e / jr c`.
+##
+## Only `PlayStereoSFX` and the battle animations behind it reach [method
+## play_sfx] without this gate. Without it every request restarted the channels
+## mid-effect, which is a fanfare cut in half by whatever the next box beeped.
+##
+## [param after_wait] is `WaitPlaySFX`, and the handful of sites that spend a
+## `WaitSFX` of their own first: the cartridge holds there until the channels
+## are free, so the gate can never be the thing that refuses those.
+func play_sfx_gated(record: Dictionary, after_wait: bool = false) -> bool:
+	var index: int = int(record.get("index", 0))
+	if not after_wait and sfx_active() and cur_sfx < index:
+		return false
+	cur_sfx = index
+	return play_sfx(record)
 
 
 ## `_PlaySFX`, including the hardware clear each active sfx channel gets first.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1286,7 +1286,7 @@ func _play_anim_sound(sfx: int) -> void:
 	var record: Dictionary = _data.world_audio(&"sfx", sfx)
 	if record.is_empty():
 		return
-	_audio_player.play_record(record, &"sound", _audio_assets())
+	_audio_player.play_record(record, &"stereo_sfx", _audio_assets())
 
 
 ## `BattleAnimCmd_Cry`: whichever battler `hBattleTurn` names, at its own

--- a/game/launcher/launcher_card.gd
+++ b/game/launcher/launcher_card.gd
@@ -43,8 +43,6 @@ static func selected(
 	return _made(skin, skin.padded(style, padding))
 
 
-## A surface that genuinely floats: sheets, toasts and the bottom dock. Never put
-## one inside a container that clips, because the shadow is drawn outside it.
 ## A solid object laid on the page: filled in [member Gen2LauncherTheme.surface],
 ## which is the opposite side of the page from everything under it. Whatever goes
 ## inside is written in [member Gen2LauncherTheme.on_surface].
@@ -57,6 +55,8 @@ static func chip(
 	return _made(skin, skin.padded(skin.floating(skin.surface, radius, spread), padding))
 
 
+## A surface that genuinely floats: sheets, toasts and the bottom dock. Never put
+## one inside a container that clips, because the shadow is drawn outside it.
 static func floating(
 	skin: Gen2LauncherTheme,
 	radius: float = Gen2LauncherTheme.RADIUS_LG,

--- a/game/save/move_screen.gd
+++ b/game/save/move_screen.gd
@@ -14,7 +14,7 @@ extends RefCounted
 signal closed
 ## `PlayClickSFX` on every press this screen answers, and `SFX_SWITCH_POKEMON`
 ## twice once two moves have traded places.
-signal sfx_requested(index: int)
+signal sfx_requested(index: int, waited: bool)
 
 ## `constants/sfx_constants.asm`.
 const SFX_READ_TEXT_2: int = 0x02
@@ -52,7 +52,7 @@ func cursor() -> int:
 func handle_button(button: int) -> bool:
 	match button:
 		Gen2Button.B:
-			sfx_requested.emit(SFX_READ_TEXT_2)
+			sfx_requested.emit(SFX_READ_TEXT_2, false)
 			## `.b_button`: a held move is put back where it came from and the
 			## screen stays up; nothing held is the way out.
 			if _held >= 0:
@@ -62,7 +62,7 @@ func handle_button(button: int) -> bool:
 			closed.emit()
 			return true
 		Gen2Button.A:
-			sfx_requested.emit(SFX_READ_TEXT_2)
+			sfx_requested.emit(SFX_READ_TEXT_2, false)
 			if _held < 0:
 				_held = _row
 				return true
@@ -147,8 +147,9 @@ func _swap(from: int, to: int) -> void:
 	mon.pp[from] = mon.pp[to]
 	mon.pp[to] = pp
 	## `.swap_moves` plays the same effect twice, waiting for each.
-	sfx_requested.emit(SFX_SWITCH_POKEMON)
-	sfx_requested.emit(SFX_SWITCH_POKEMON)
+	## `SwitchPartyMons` is `WaitPlaySFX`, twice over.
+	sfx_requested.emit(SFX_SWITCH_POKEMON, true)
+	sfx_requested.emit(SFX_SWITCH_POKEMON, true)
 
 
 ## Everything [Gen2MoveScreenPage] draws.

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -24,7 +24,7 @@ signal closed(result: Dictionary)
 signal action_chosen(action: Dictionary)
 ## A sound this screen owes, by `constants/sfx_constants.asm` index. Emitted
 ## rather than played: the audio player belongs to whoever embedded this.
-signal sfx_requested(index: int)
+signal sfx_requested(index: int, waited: bool)
 ## `PlayMonCry2`, which the stats screen this menu opens plays on every mon it
 ## loads. Emitted for the same reason [signal sfx_requested] is.
 signal cry_requested(species: int)
@@ -555,7 +555,8 @@ func _finish_switch() -> void:
 		var held: Gen2SaveMon = _save.party[from]
 		_save.party[from] = _save.party[_member_cursor]
 		_save.party[_member_cursor] = held
-		sfx_requested.emit(SFX_SWITCH_POKEMON)
+		## `SwitchPartyMons` is `WaitPlaySFX`.
+		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
 	_member_cursor = clampi(_member_cursor, 0, _row_count() - 1)
 	## The icons are respawned rather than stepped: `LoadPartyMenuGFX` and
 	## `InitPartyMenuGFX` run again behind the reopened list.

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -208,7 +208,9 @@ func _apply(events: Array[Dictionary]) -> void:
 				_finish()
 				return
 			&"play_sfx":
-				_play_sfx(int(event.get("sfx", 0)))
+				_play_sfx(
+					int(event.get("sfx", 0)), bool(event.get("channels_off", false))
+				)
 			&"play_music":
 				_play_music(
 					int(event.get("music", 0)), bool(event.get("restart", true))
@@ -265,11 +267,14 @@ func _ensure_audio() -> void:
 
 ## `PlaySFX`, which the GameFreak animation calls five times on Crystal and once
 ## on Gold and Silver. A cache with no record for one spends its frames anyway,
-## which is what a frame-count test is.
-func _play_sfx(sfx: int) -> void:
+## which is what a frame-count test is. `.PlayUnownSound` is the one caller that
+## spends `SFXChannelsOff` in front of it, which is what `channels_off` carries.
+func _play_sfx(sfx: int, channels_off: bool = false) -> void:
 	_ensure_audio()
 	if _data == null or sfx <= 0:
 		return
+	if channels_off:
+		_audio.stop_effects()
 	_audio.play_record(_data.world_audio(&"sfx", sfx), &"sfx", _audio_assets())
 
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -25,7 +25,7 @@ signal closed
 signal field_item_used(request: Dictionary)
 ## `PlaySFX`, which this screen has no driver of its own for: the world that
 ## hosts it owns the player. `SFX_SAVE` is the only one it asks for.
-signal sfx_requested(sfx: int)
+signal sfx_requested(sfx: int, waited: bool)
 
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
@@ -1844,7 +1844,8 @@ func _show_save_result() -> void:
 		SAVE_SAVED_LINES[0] % player_name, SAVE_SAVED_LINES[1],
 	], -1)
 	## `WaitSFX` after it is not spent, for the reason the intro cry's is not.
-	sfx_requested.emit(SFX_SAVE)
+	## `SavedTheGame` reaches SFX_SAVE through `WaitPlaySFX`.
+	sfx_requested.emit(SFX_SAVE, true)
 
 
 ## `DisplaySaveInfoOnSave`'s four rows: the same fields [Gen2TrainerCard]'s

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2445,6 +2445,7 @@ func _open_service_host() -> void:
 		_refresh_labels()
 		return
 	host.completed.connect(_on_service_completed)
+	host.sfx_requested.connect(_play_sfx)
 	_service_host = host
 	_script_prompt = "Service host open"
 	_refresh_labels()
@@ -3387,6 +3388,7 @@ func _open_service_overlay(kind: StringName) -> void:
 		_refresh_labels()
 		return
 	host.completed.connect(_on_service_completed)
+	host.sfx_requested.connect(_play_sfx)
 	_service_host = host
 	_script_prompt = "%s open" % label
 	_refresh_labels()
@@ -3414,6 +3416,7 @@ func _open_fly_map(request: Dictionary) -> void:
 		_refresh_labels()
 		return
 	host.completed.connect(_on_service_completed)
+	host.sfx_requested.connect(_play_sfx)
 	_service_host = host
 	_script_prompt = "Fly: choose a town"
 	_refresh_labels()
@@ -4035,13 +4038,17 @@ func _play_music(index: int) -> void:
 	_audio_player.play_record(record, &"map_music", _audio_assets())
 
 
-func _play_sfx(index: int) -> void:
+## `PlaySFX`. [param waited] is the `WaitSFX` the source spends in front of a
+## few of them; see [signal Gen2WorldServiceScreen.sfx_requested].
+func _play_sfx(index: int, waited: bool = false) -> void:
 	if _audio_player == null or _data == null:
 		return
 	var record: Dictionary = _data.world_audio(&"sfx", index)
 	if record.is_empty():
 		return
-	_audio_player.play_record(record, &"sound", _audio_assets())
+	_audio_player.play_record(
+		record, &"waited_sfx" if waited else &"sound", _audio_assets()
+	)
 
 
 ## The save whose party a queued script's VAR_PARTYCOUNT read and CheckPokerus

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -6,6 +6,20 @@ extends Control
 ## hosts and API.
 
 signal completed(results: Array)
+## The sound this screen asks for, played by whoever owns the driver.
+##
+## Nothing here reaches [Gen2AudioPlayer]: the world screen owns the one player
+## a map's music and its effects share, so a second surface asking for a sound
+## goes through it the way the start menu, the party screen and the move screen
+## already do. [Gen2WorldAudioHost] is an inspection probe that renders no
+## samples and must never stand in for it.
+##
+## [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent in front of the sound
+## by hand: the cartridge holds there until the four effect channels are free,
+## so the request can never be the one `PlaySFX`'s own priority gate refuses.
+## The wait itself is not spent (see `HANDOFF.md`'s `WaitSFX` row); what it
+## carries is that the sound is heard.
+signal sfx_requested(index: int, waited: bool)
 
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#4f6f9e")
@@ -16,7 +30,7 @@ const SUCCESS: Color = Color("#7bd89a")
 const ERROR: Color = Color("#ef8a8a")
 
 enum MODE {
-	MENU, MART, PHONE, AUDIO, POKEGEAR, TOWN_MAP, CARD,
+	MENU, MART, PHONE, POKEGEAR, TOWN_MAP, CARD,
 	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT,
 }
 
@@ -184,9 +198,6 @@ func open_pending(
 			return true
 		&"phone_call_requested", &"special_phone_call_requested":
 			_open_phone(request, resolved.get("data", {}))
-			return true
-		&"audio_requested":
-			_open_audio(request, resolved.get("data", {}).get("audio", {}))
 			return true
 		&"apricorn_selection_requested":
 			_open_apricorns()
@@ -600,7 +611,8 @@ func _buy_mart_selection() -> void:
 		_show_mart_text(_mart_text(slot, {"name": entry.get("name", "")}), MART_LIST)
 		return
 	_mart_purchased = true
-	Gen2WorldAudioHost.play(_data.world_audio(&"sfx", SFX_TRANSACTION), &"sound")
+	## `PlayTransactionSound` is a `WaitSFX` and then the sound.
+	sfx_requested.emit(SFX_TRANSACTION, true)
 	_refresh_mart_entries()
 	_show_mart_text(_mart_text("thanks", {
 		"name": purchase.get("name", ""), "quantity": _mart_quantity,
@@ -955,7 +967,8 @@ func _advance_pc_text() -> void:
 		_show_pc_page()
 		return
 	if _pc_sfx >= 0:
-		Gen2WorldAudioHost.play(_data.world_audio(&"sfx", _pc_sfx), &"sound")
+		## `ProfOaksPCBoot` waits *behind* its sound, not in front of it.
+		sfx_requested.emit(_pc_sfx, false)
 	_pc_sfx = -1
 	if _pc_after == &"close":
 		_finish_runtime({"ok": true, "script_value": 0})
@@ -1264,23 +1277,6 @@ func _on_town_map_closed() -> void:
 	completed.emit([])
 
 
-func _open_audio(request: Dictionary, record: Dictionary) -> void:
-	_mode = MODE.AUDIO
-	_cursor = 0
-	_title.text = "AUDIO HOST"
-	var kind: StringName = StringName(request.get("values", {}).get("kind", &"audio"))
-	var playback: Dictionary = Gen2WorldAudioHost.play(record, kind)
-	_summary.text = "Resolved %s %s:%04X (%d bytes)." % [
-		String(kind), int(record.get("bank", -1)), int(record.get("address", -1)),
-		int(record.get("byte_count", 0)),
-	]
-	_status.text = "Audio resolved for shared runtime: %s" % String(
-		playback.get("backend", "unavailable")
-	)
-	_footer.text = "A: continue    B: stop"
-	_render_options(["Continue"])
-
-
 func _move_cursor(delta: int) -> void:
 	var count: int = _option_count()
 	if count <= 0:
@@ -1340,7 +1336,7 @@ func _confirm() -> void:
 		else:
 			_open_card(chosen)
 		return
-	if _mode in [MODE.PHONE, MODE.AUDIO]:
+	if _mode == MODE.PHONE:
 		_finish_runtime({"ok": true, "script_value": 1})
 
 
@@ -1363,7 +1359,7 @@ func _cancel() -> void:
 	elif _mode == MODE.POKEGEAR:
 		_mode = -1
 		completed.emit([])
-	elif _mode in [MODE.PHONE, MODE.AUDIO]:
+	elif _mode == MODE.PHONE:
 		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
 	elif _mode == MODE.TOWN_MAP and _town_map != null:
 		_town_map.close()
@@ -1451,7 +1447,7 @@ func _render_service_page(values: Array) -> void:
 		_service_page = Gen2WorldServicePage.from_data(_data)
 	if _service_page == null:
 		return
-	var page_rows: Array = [] if _mode in [MODE.PHONE, MODE.PC_TEXT, MODE.AUDIO] else values
+	var page_rows: Array = [] if _mode in [MODE.PHONE, MODE.PC_TEXT] else values
 	var labels: Array = []
 	for value: Variant in page_rows:
 		if value is Dictionary:
@@ -1503,7 +1499,7 @@ func _service_box() -> Gen2MenuBox:
 			return _apricorn_quantity_box() if _apricorns != null \
 				and _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY \
 				else _apricorn_select_box()
-		MODE.POKEGEAR, MODE.AUDIO:
+		MODE.POKEGEAR:
 			return _dynamic_box(_option_count())
 	return null
 
@@ -1532,9 +1528,8 @@ func _apricorn_quantity_box() -> Gen2MenuBox:
 	return Gen2MenuBox.from_coords(6, 9, 19, 12, 0)
 
 
-## The list box every mode above still leaves to the panel: POKEGEAR's card
-## list, which `HANDOFF.md` already records as staying a panel, and AUDIO,
-## which is a debug host with no cartridge screen of its own.
+## The one list box still left to the panel: POKEGEAR's card list, which
+## `HANDOFF.md` already records as staying a panel.
 func _dynamic_box(count: int) -> Gen2MenuBox:
 	var bottom: int = mini(17, 1 + maxi(count, 1) * 2)
 	return Gen2MenuBox.from_coords(

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -221,6 +221,29 @@ func test_mart_overlay_purchases_the_selected_quantity() -> void:
 	assert_false(_world_screen._world.script_input_waiting())
 
 
+## `PlayTransactionSound` is the world screen's own driver, not the inspection
+## probe: an overlay is a second surface on one [Gen2AudioPlayer], the way the
+## start menu and the party screen already are.
+func test_a_purchase_plays_its_sound_through_the_world_driver() -> void:
+	await _open_world()
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	var played: Array[int] = []
+	host.sfx_requested.connect(
+		func(index: int, _waited: bool) -> void: played.append(index)
+	)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(played, [Gen2WorldServiceScreen.SFX_TRANSACTION] as Array[int])
+	## The world screen is on the other end of it, which is what stops the
+	## overlay reaching for a driver of its own. The synthetic cache carries no
+	## effect records, so the engine has nothing to start.
+	assert_true(host.sfx_requested.is_connected(_world_screen._play_sfx))
+
+
 ## `MartConfirmPurchase`'s NO, and B off the quantity box: both come back to the
 ## list with the money untouched.
 func test_mart_overlay_refuses_without_taking_money() -> void:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1427,7 +1427,9 @@ func test_the_party_submenu_switch_row_moves_a_member() -> void:
 	_world_screen._open_embedded_party()
 	await get_tree().process_frame
 	var party: Gen2PartyScreen = _world_screen._party_host
-	party.sfx_requested.connect(func(index: int) -> void: played.append(index))
+	party.sfx_requested.connect(
+		func(index: int, _waited: bool) -> void: played.append(index)
+	)
 	_choose_submenu(party, Gen2PartyScreen.OPTION_SWITCH)
 
 	var snapshot: Dictionary = party.submenu_snapshot()

--- a/tests/unit/test_sound_engine.gd
+++ b/tests/unit/test_sound_engine.gd
@@ -243,6 +243,36 @@ func test_an_effect_takes_the_music_channel_and_gives_it_back() -> void:
 	assert_true(engine.music_channels_active(), "the music never stopped")
 
 
+## `PlaySFX`'s own gate. The table is ordered highest priority first, so the id
+## still on the channels has to be less than or equal to the new one for it to
+## be taken; the same id restarts, which is `cp e / jr c`.
+func test_a_lower_priority_effect_is_refused_while_one_is_still_playing() -> void:
+	var engine: Gen2SoundEngine = _engine()
+	var first: Dictionary = _record([[4, [
+		0xDF, 0xD8, 0x20, 0xB1, 0xD4, 0x10, 0xFF,
+	]]], 0x3C)
+	first["index"] = 0x01
+	assert_true(engine.play_sfx_gated(first))
+	engine.update_sound()
+	assert_eq(engine.cur_sfx, 0x01)
+
+	var lower: Dictionary = first.duplicate(true)
+	lower["index"] = 0x22
+	assert_false(engine.play_sfx_gated(lower), "a higher id waits its turn")
+	assert_eq(engine.cur_sfx, 0x01, "and does not claim the channels")
+
+	var higher: Dictionary = first.duplicate(true)
+	higher["index"] = 0x00
+	assert_true(engine.play_sfx_gated(higher), "a lower id takes them")
+	assert_eq(engine.cur_sfx, 0x00)
+
+	# Nothing playing, so the gate is not consulted at all.
+	var _drain: Array = _writes(engine, 40)
+	assert_false(engine.sfx_active())
+	assert_true(engine.play_sfx_gated(lower))
+	assert_eq(engine.cur_sfx, 0x22)
+
+
 func test_sfx_priority_rests_the_music_channels_while_an_effect_runs() -> void:
 	var engine: Gen2SoundEngine = _engine()
 	assert_true(engine.play_music(_record([[1, [


### PR DESCRIPTION
`home/audio.asm`'s `PlaySFX` is a priority gate: `CheckSFX`, then `cp e / jr c` against `wCurSFX`. The effect table is ordered highest priority first, so a request is refused while a lower-numbered effect still holds the four channels, and only the same id restarts. Only `_PlaySFX` was ported here, so every request reset the channel registers mid-effect and any fanfare was cut in half by whatever the next box beeped.

Three things come with the gate, each of them what keeps the cartridge's own from refusing:

- `SFXChannelsOff`, which `.PlayUnownSound` spends in front of its `PlaySFX`. The intro movie already emitted `channels_off` and nothing read it.
- `WaitPlaySFX`, and the sites that spend a `WaitSFX` by hand: SFX_SAVE, SFX_SWITCH_POKEMON and `PlayTransactionSound`. The cartridge holds there until the channels are free, so those are never the ones refused.
- The two overlay sounds that reached no driver at all. The mart's transaction sound and Prof. Oak's PC rating were going through the inspection probe, which renders no samples, so both were silent in play.

`PlayStereoSFX` has no gate in front of it, so the battle animations keep the raw `_PlaySFX`. The service overlay's AUDIO mode goes with this: no caller has reached it since the world screen started answering `audio_requested` itself.

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3,245 over 152 scripts, green |
| `tools/validate.gd -- all` | 54 topics PASS, exit 0 |
| Boot smoke, three cartridges | clean |