### PR TITLE
Build the battle entrance and the transition in front of it

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -69,6 +69,16 @@ const STAT_CHANGE_FAILED: StringName = &"stat_change_failed"
 ## nobody to call back, and the screen has one sentence to say rather than two.
 const WITHDREW: StringName = &"withdrew"
 const SENT_OUT: StringName = &"sent_out"
+## `SendOutMonText`'s four lines, chosen off the opponent's remaining HP: the
+## `line` field of a player [constant SENT_OUT].
+const SEND_OUT_GO: int = 0
+const SEND_OUT_DO_IT: int = 1
+const SEND_OUT_GO_FOR_IT: int = 2
+const SEND_OUT_FOES_WEAK: int = 3
+## `PlayStereoCry` behind an entrance: the cry `CheckFaintedFrzSlp` allows, on
+## the entering side's own tracks. Silent on its own, so nothing is printed for
+## it.
+const CRY: StringName = &"cry"
 ## The player got away, `how` naming the branch: [code]&"battle_type"[/code] for
 ## the two that always escape, [code]&"item"[/code] for the Smoke Ball,
 ## [code]&"speed"[/code], [code]&"odds"[/code] and [code]&"roll"[/code].
@@ -340,6 +350,13 @@ const EVADED: StringName = &"evaded"
 ## "It's protected by mist!" rather than the "won't go any lower" a drop at its
 ## floor gets.
 const MIST_PROTECTED: StringName = &"mist_protected"
+
+## `ANIM_SEND_OUT_MON` (constants/move_constants.asm) and the two
+## `wBattleAnimParam` values every entrance plays it with: `BattleAnim_SendOutMon`
+## branches on the parameter, `$0` being the ball and `$1` the shiny sparkle.
+const ANIM_SEND_OUT_MON: int = 101
+const SEND_OUT_ANIM_NORMAL: int = 0
+const SEND_OUT_ANIM_SHINY: int = 1
 
 ## `PlayFXAnimID`: one animation to spend frames on, at its own index in the
 ## returned list so the ordering stays the cartridge's, as [Gen2HpBarAnimation]
@@ -1205,12 +1222,91 @@ func send_out(
 		"species": current.active_mon().species, "level": current.active_mon().level,
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
 		"unown_form": unown_form_of(current.active_mon()),
+		"line": send_out_line(side),
 	})
 	(_participants[side] as Dictionary)[index] = true
+	# `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation` both run their
+	# animation after the line that announced them, and `ForceEnemySwitch` runs
+	# it before `DraggedOutText`.
+	events.append_array(entrance_events(side))
 	if dragged_by >= 0:
 		events.append({"type": DRAGGED_OUT, "side": dragged_by, "target": side})
 	_spikes_damage(side, events)
 	return events
+
+
+## `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation`, which every
+## entrance in the source runs and which are the same three steps on both sides:
+## `ANIM_SEND_OUT_MON`, a second pass of it for a shiny, and the cry
+## `CheckFaintedFrzSlp` allows. Public because a battle's opening entrance is not
+## a [method send_out]: both sides are already standing there when the pics
+## finish sliding, and the screen plays the same list for them.
+##
+## [param ball] is false for `BattleStartMessage`'s wild branch, which is the one
+## entrance with no ball in it: the Pokemon is already standing there when the
+## pics stop sliding, so only the shiny pass and the cry are left of the list.
+func entrance_events(side: int, ball: bool = true) -> Array:
+	var entering: Gen2BattleMon = mon(side)
+	if entering == null:
+		return []
+	var enemy_turn: bool = side == ENEMY
+	var out: Array = []
+	if ball:
+		out.append(_send_out_animation(enemy_turn, SEND_OUT_ANIM_NORMAL))
+	# `BattleCheckPlayerShininess`/`BattleCheckEnemyShininess`, which read the
+	# live DVs: a Transform has already copied the target's over them.
+	if Gen2Stats.is_shiny(entering.dvs):
+		out.append(_send_out_animation(enemy_turn, SEND_OUT_ANIM_SHINY))
+	# `CheckFaintedFrzSlp`: no cry from a fainted, frozen or sleeping Pokemon.
+	if entering.is_fainted() \
+		or (entering.status & (Gen2Status.FREEZE | Gen2Status.SLEEP_MASK)) != 0:
+		return out
+	out.append({"type": CRY, "side": side, "species": entering.species})
+	return out
+
+
+## `Call_PlayBattleAnim` rather than `PlayFXAnimID`: `WaitBGMap` in place of the
+## three-frame delay, which is what `called` says.
+func _send_out_animation(enemy_turn: bool, param: int) -> Dictionary:
+	return {
+		"type": ANIMATION,
+		"index": ANIM_SEND_OUT_MON,
+		"param": param,
+		"after_anim": 0,
+		"enemy_turn": enemy_turn,
+		# `SendOutPlayerMon` clears `wTypeModifier` on its way past; nothing in a
+		# send-out reads it, since only a damage after-anim has a hit sound.
+		"effectiveness": 0,
+		"restore_user_pic": false,
+		"called": true,
+	}
+
+
+## `SendOutMonText`, which picks one of four lines off how much of the opponent
+## is left. Only the player is ever announced this way; the enemy has one line.
+##
+## The arithmetic is the source's own: the remaining HP times 25 over the top
+## quarter of the maximum, both read as the cartridge reads them, so the answer
+## is a percentage that has been through an eight-bit divisor. A maximum below
+## four leaves that divisor zero, which is `docs/bugs_and_glitches.md`'s freeze;
+## nothing here can freeze, so it answers the first line.
+func send_out_line(side: int) -> int:
+	if side != PLAYER:
+		return SEND_OUT_GO
+	var foe: Gen2BattleMon = mon(opponent_of(side))
+	if foe == null or foe.hp <= 0:
+		return SEND_OUT_GO
+	var divisor: int = (foe.max_hp() >> 2) & 0xFF
+	if divisor == 0:
+		return SEND_OUT_GO
+	var percent: int = ((foe.hp * 25) / divisor) & 0xFF
+	if percent >= 70:
+		return SEND_OUT_GO
+	if percent >= 40:
+		return SEND_OUT_DO_IT
+	if percent >= 10:
+		return SEND_OUT_GO_FOR_IT
+	return SEND_OUT_FOES_WEAK
 
 
 ## `SpikesDamage`, behind each entrance's own `SetPlayerTurn`/`SetEnemyTurn`, so

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1243,8 +1243,8 @@ func send_out(
 
 ## `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation`, which every
 ## entrance in the source runs and which are the same three steps on both sides:
-## `ANIM_SEND_OUT_MON`, a second pass of it for a shiny, and the cry
-## `CheckFaintedFrzSlp` allows. Public because a battle's opening entrance is not
+## `ANIM_SEND_OUT_MON`, a second pass of it for a shiny, and the cry Crystal's
+## own `CheckFaintedFrzSlp` allows. Public because a battle's opening entrance is not
 ## a [method send_out]: both sides are already standing there when the pics
 ## finish sliding, and the screen plays the same list for them.
 ##
@@ -1264,8 +1264,11 @@ func entrance_events(side: int, ball: bool = true) -> Array:
 	if Gen2Stats.is_shiny(entering.dvs):
 		out.append(_send_out_animation(enemy_turn, SEND_OUT_ANIM_SHINY))
 	# `CheckFaintedFrzSlp`: no cry from a fainted, frozen or sleeping Pokemon.
-	if entering.is_fainted() \
-		or (entering.status & (Gen2Status.FREEZE | Gen2Status.SLEEP_MASK)) != 0:
+	# Crystal's alone: pokegold's `SendOutPlayerMon` and
+	# `ShowSetEnemyMonAndSendOutAnimation` both reach `PlayStereoCry` with no
+	# test in front of it, the same place their own pic animation is missing.
+	if Gen2WorldState.is_crystal_profile(data) and (entering.is_fainted() \
+			or (entering.status & (Gen2Status.FREEZE | Gen2Status.SLEEP_MASK)) != 0):
 		return out
 	out.append({"type": CRY, "side": side, "species": entering.species})
 	return out

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -354,7 +354,13 @@ const MIST_PROTECTED: StringName = &"mist_protected"
 ## `ANIM_SEND_OUT_MON` (constants/move_constants.asm) and the two
 ## `wBattleAnimParam` values every entrance plays it with: `BattleAnim_SendOutMon`
 ## branches on the parameter, `$0` being the ball and `$1` the shiny sparkle.
-const ANIM_SEND_OUT_MON: int = 101
+##
+## The constant is `$101`, not 101: the comments in that file are hexadecimal,
+## and the animations past the moves start at `const_next $ff`. Read as a
+## decimal it is NIGHT SHADE, which decodes, runs and draws, so nothing falls
+## over: the ball is a night shade with the wrong palette and four times the
+## frames. `tools/checks/battle_anims.gd` pins the body each parameter reaches.
+const ANIM_SEND_OUT_MON: int = 0x101
 const SEND_OUT_ANIM_NORMAL: int = 0
 const SEND_OUT_ANIM_SHINY: int = 1
 

--- a/game/battle/battle_anim_background.gd
+++ b/game/battle/battle_anim_background.gd
@@ -49,6 +49,8 @@ const PAL_BG_ENEMY: int = 1
 const PAL_OB_ENEMY: int = 0
 const PAL_OB_PLAYER: int = 1
 const PAL_OB_GRAY: int = 2
+## `LoadTrainerHudOAM` draws the party balls on this one.
+const PAL_OB_YELLOW: int = 3
 
 ## `wSurfWaveBGEffect`, the 64-entry wave `BattleBGEffect_Surf` rotates.
 const SURF_WAVE_LENGTH: int = 0x40

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -1478,6 +1478,11 @@ static func _beta_send_out_lines(
 
 ## `BattleBGEffect_BetaSendOutMon2`, unused: a deformation that shrinks to
 ## nothing over $40 frames.
+## Its scanline window and the square `enter_mon` resizes beside it are opposite
+## bands, so a send-out visibly wobbles the *other* battler. That is the source:
+## `.zero` reads the side once for `SetLCDStatCustoms1` and then writes `$40`
+## over the same struct byte as a counter, and this is a beta effect whose own
+## operand does not agree with `enter_mon`'s. Do not "fix" the polarity.
 static func _beta_send_out_mon2(
 	player: Gen2BattleAnimPlayer, effect: Gen2BattleAnimBgEffect
 ) -> void:

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -56,6 +56,9 @@ var _panels: TextureRect = null
 var _enemy_bar: TextureRect = null
 var _player_bar: TextureRect = null
 var _exp_bar: TextureRect = null
+## `BattleStart_TrainerHuds`' party balls, which are OAM rather than background
+## and so take no scroll.
+var _hud_balls: TextureRect = null
 var _sprites: TextureRect = null
 
 ## `SPRITE_MONSTER` (constants/sprite_constants.asm), the same number in both
@@ -126,6 +129,7 @@ func set_battle_data(data: GameData) -> bool:
 	_enemy_bar = _new_layer()
 	_player_bar = _new_layer()
 	_exp_bar = _new_layer()
+	_hud_balls = _new_layer()
 	_sprites = _new_layer()
 	return true
 
@@ -153,12 +157,26 @@ func _draw_pics() -> void:
 	var map: PackedByteArray = _bg_map()
 	_ensure_pixels()
 	var raster: Array = _raster_key()
+	# A packed array is passed by reference, so a key holding the screen's own
+	# map is a key that changes with it: every animation that edits nothing but
+	# the tilemap, which is most of them, would compare equal to what is on
+	# screen and never be redrawn.
+	var map_key: PackedByteArray = map.duplicate()
 
 	var enemy: int = int(_view.get("enemy_species", 0))
 	var enemy_palette: PackedColorArray = _battler_palette(
 		enemy, Gen2BattleAnimBackground.PAL_BG_ENEMY
 	)
-	var enemy_key: Array = [map, enemy, _enemy_pixels_key, enemy_palette, raster]
+	# `GetFrontpicPalettePointer` reads `wTrainerClass` rather than a species
+	# when the square is holding a trainer, which it is until that trainer has
+	# sent something out.
+	var enemy_trainer: int = int(_view.get("enemy_trainer_pic", 0))
+	if enemy_trainer > 0:
+		enemy_palette = _remap(
+			_data.trainer_palette(enemy_trainer),
+			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_ENEMY)
+		)
+	var enemy_key: Array = [map_key, enemy, _enemy_pixels_key, enemy_palette, raster]
 	if enemy_key != _enemy_pic_key:
 		_enemy_pic_key = enemy_key
 		_show_layer(
@@ -174,7 +192,15 @@ func _draw_pics() -> void:
 		var player_palette: PackedColorArray = _battler_palette(
 			player, Gen2BattleAnimBackground.PAL_BG_PLAYER
 		)
-		var player_key: Array = [map, player, _player_pixels_key, player_palette, raster]
+		# `GetPlayerOrMonPalettePointer`'s `and a / jp nz`: a zero species is the
+		# player standing there, and the palette is the player's own.
+		var backpic: String = String(_view.get("player_backpic", ""))
+		if not backpic.is_empty():
+			player_palette = _remap(
+				_data.player_palette(String(_view.get("player_backpic_palette", "chris"))),
+				_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_PLAYER)
+			)
+		var player_key: Array = [map_key, player, _player_pixels_key, player_palette, raster]
 		if player_key != _player_pic_key:
 			_player_pic_key = player_key
 			_show_layer(
@@ -231,22 +257,35 @@ func _pic_layer(
 func _ensure_pixels() -> void:
 	var enemy_key: Array = [
 		int(_view.get("enemy_species", 0)), bool(_view.get("enemy_substitute", false)),
-		int(_view.get("enemy_unown_form", 0)),
+		int(_view.get("enemy_unown_form", 0)), int(_view.get("enemy_trainer_pic", 0)),
 	]
 	if enemy_key != _enemy_pixels_key:
-		_enemy_pixels = _substitute_pic(false) if bool(enemy_key[1]) \
-			else _padded_pic(
+		if int(enemy_key[3]) > 0:
+			_enemy_pixels = _padded_pic(
+				_data.trainer_pic(int(enemy_key[3])), Gen2BattleScreenMap.ENEMY_SIDE
+			)
+		elif bool(enemy_key[1]):
+			_enemy_pixels = _substitute_pic(false)
+		else:
+			_enemy_pixels = _padded_pic(
 				_battler_pic(int(enemy_key[0]), int(enemy_key[2]), false),
 				Gen2BattleScreenMap.ENEMY_SIDE
 			)
 		_enemy_pixels_key = enemy_key
 	var player_key: Array = [
 		int(_view.get("player_species", 0)), bool(_view.get("player_substitute", false)),
-		int(_view.get("player_unown_form", 0)),
+		int(_view.get("player_unown_form", 0)), String(_view.get("player_backpic", "")),
 	]
 	if player_key != _player_pixels_key:
-		_player_pixels = _substitute_pic(true) if bool(player_key[1]) \
-			else _padded_pic(
+		if not String(player_key[3]).is_empty():
+			_player_pixels = _padded_pic(
+				_data.player_backpic(String(player_key[3])),
+				Gen2BattleScreenMap.PLAYER_SIDE
+			)
+		elif bool(player_key[1]):
+			_player_pixels = _substitute_pic(true)
+		else:
+			_player_pixels = _padded_pic(
 				_battler_pic(int(player_key[0]), int(player_key[2]), true),
 				Gen2BattleScreenMap.PLAYER_SIDE
 			)
@@ -354,18 +393,11 @@ func _palette_map(key: String, slot: int) -> int:
 ## sits in a panel of black text without either being separate. Here that is one
 ## buffer per palette, which is why the bars are drawn apart from the panels.
 ##
-## `BattleAnimClearHud` takes all four off the map for the length of a move
-## animation and `BattleAnimRestoreHuds` puts them back, which is what
-## `hud_visible` is.
+## `BattleAnimClearHud` takes one side off the map for the length of a move
+## animation and `BattleAnimRestoreHuds` puts it back; a battle opening has
+## neither of them up for several seconds. Both are the two per-side keys, and
+## the view's own `hud_visible` is the summary of them.
 func _draw_panels() -> void:
-	if not bool(_view.get("hud_visible", true)):
-		_panels.texture = null
-		_enemy_bar.texture = null
-		_player_bar.texture = null
-		_exp_bar.texture = null
-		_layer_keys.clear()
-		return
-
 	var raster: Array = _raster_key()
 	var enemy_hp: int = int(_view.get("enemy_hp", 0))
 	var enemy_max_hp: int = int(_view.get("enemy_max_hp", 0))
@@ -376,38 +408,113 @@ func _draw_panels() -> void:
 	var player_name: String = String(_view.get("player_name", ""))
 	var player_level: int = int(_view.get("player_level", 0))
 	var exp_pixels: int = int(_view.get("exp_pixels", 0))
+	# Each panel goes up when its own side has something on the field.
+	# `InitBattleDisplay` clears the player's box, and its caller only reaches
+	# `UpdateEnemyHUD` for a wild battle, so an opening battle spends several
+	# seconds with neither of them drawn.
+	var enemy_hud: bool = bool(_view.get("enemy_hud_visible", true))
+	var player_hud: bool = bool(_view.get("player_hud_visible", true))
+	var border: Array = _view.get("trainer_hud_border", []) as Array
 
 	# The player's panel prints its own HP numbers, so it moves with the bar; the
 	# enemy's does not, which is why both sit in one layer keyed on all of it.
 	if _layer_changed(&"panels", [
-		enemy_name, enemy_level, player_name, player_level, player_hp, player_max_hp, raster,
+		enemy_name, enemy_level, player_name, player_level, player_hp, player_max_hp,
+		enemy_hud, player_hud, border, raster,
 	]):
 		var panels: PackedByteArray = _new_buffer()
-		_hud.draw_enemy(panels, Gen2Screen.WIDTH, enemy_name, enemy_level)
-		_hud.draw_player(
-			panels, Gen2Screen.WIDTH, player_name, player_level, player_hp, player_max_hp
-		)
+		if enemy_hud:
+			_hud.draw_enemy(panels, Gen2Screen.WIDTH, enemy_name, enemy_level)
+		if player_hud:
+			_hud.draw_player(
+				panels, Gen2Screen.WIDTH, player_name, player_level, player_hp, player_max_hp
+			)
+		_draw_trainer_hud_border(panels, border)
 		_show_layer(
 			_panels, panels,
 			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 		)
 
-	if _layer_changed(&"enemy_bar", [enemy_hp, enemy_max_hp, raster]):
+	if _layer_changed(&"enemy_bar", [enemy_hp, enemy_max_hp, enemy_hud, raster]):
 		var enemy: PackedByteArray = _new_buffer()
-		_hud.draw_hp_bar(enemy, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, enemy_hp, enemy_max_hp)
+		if enemy_hud:
+			_hud.draw_hp_bar(
+				enemy, Gen2Screen.WIDTH, Gen2BattleHud.ENEMY_BAR, enemy_hp, enemy_max_hp
+			)
 		_show_layer(_enemy_bar, enemy, _hp_palette(enemy_hp, enemy_max_hp))
 
-	if _layer_changed(&"player_bar", [player_hp, player_max_hp, raster]):
+	if _layer_changed(&"player_bar", [player_hp, player_max_hp, player_hud, raster]):
 		var player: PackedByteArray = _new_buffer()
-		_hud.draw_hp_bar(
-			player, Gen2Screen.WIDTH, Gen2BattleHud.PLAYER_BAR, player_hp, player_max_hp
-		)
+		if player_hud:
+			_hud.draw_hp_bar(
+				player, Gen2Screen.WIDTH, Gen2BattleHud.PLAYER_BAR, player_hp, player_max_hp
+			)
 		_show_layer(_player_bar, player, _hp_palette(player_hp, player_max_hp))
 
-	if _layer_changed(&"exp_bar", [exp_pixels, raster]):
+	if _layer_changed(&"exp_bar", [exp_pixels, player_hud, raster]):
 		var gained: PackedByteArray = _new_buffer()
-		_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, exp_pixels)
+		if player_hud:
+			_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, exp_pixels)
 		_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
+
+	_draw_hud_balls()
+
+
+## `DrawPlayerPartyIconHUDBorder` and `DrawEnemyHUDBorder`: the frame the party
+## balls hang in, a side, two corners and eight of a bottom edge out of the
+## battle's own tile page. Cells rather than pixels, the way the source writes
+## them into `wTilemap`.
+func _draw_trainer_hud_border(into: PackedByteArray, border: Array) -> void:
+	for entry: Variant in border:
+		if not entry is Dictionary:
+			continue
+		var cell: Dictionary = entry as Dictionary
+		_hud.tiles.draw(
+			int(cell.get("tile", 0)), into, Gen2Screen.WIDTH,
+			int(cell.get("x", 0)) * TILE, int(cell.get("y", 0)) * TILE
+		)
+
+
+## `LoadTrainerHudOAM`: six sprites a side, one of `LoadBallIconGFX`'s four tiles
+## each, all on `PAL_BATTLE_OB_YELLOW`. Objects, so they take no scroll, and they
+## are what `ClearSprites` takes away when the opening line is pressed past.
+func _draw_hud_balls() -> void:
+	var balls: Array = _view.get("trainer_hud_balls", []) as Array
+	if balls.is_empty():
+		_hud_balls.texture = null
+		_layer_keys.erase(&"hud_balls")
+		return
+	if not _layer_changed(&"hud_balls", [balls]):
+		return
+	var sheet: PackedByteArray = _data.tile_indices("ball_icons")
+	var width: int = int(_data.tile_sheet("ball_icons").get("width", 0))
+	var buffer: PackedByteArray = _new_buffer()
+	for entry: Variant in balls:
+		if not entry is Dictionary or width <= 0:
+			continue
+		var ball: Dictionary = entry as Dictionary
+		var tile: int = int(ball.get("tile", 0))
+		var left: int = int(ball.get("x", 0))
+		var top: int = int(ball.get("y", 0))
+		for row: int in TILE:
+			if top + row < 0 or top + row >= Gen2Screen.HEIGHT:
+				continue
+			var from: int = row * width + tile * TILE
+			var to: int = (top + row) * Gen2Screen.WIDTH + left
+			for column: int in TILE:
+				var x: int = left + column
+				if x < 0 or x >= Gen2Screen.WIDTH or from + column >= sheet.size():
+					continue
+				buffer[to + column] = sheet[from + column]
+	# Not through `_show_image`: an object is not part of the background plane
+	# and does not take the scroll the background layers do.
+	var image: Image = Gen2PicImage.from_indices(
+		buffer, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		_object_palette(Gen2BattleAnimBackground.PAL_OB_YELLOW), true
+	)
+	_hud_balls.texture = ImageTexture.create_from_image(image)
+	_hud_balls.size = image.get_size()
+	_hud_balls.position = Vector2.ZERO
 
 
 ## `wShadowOAM` as the animation left it: up to forty sprites, each eight by

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -187,6 +187,24 @@ var _intro_message: String = ""
 ## `BattleStartMessage` and `DoBattle`'s own opening, one step per entry, spent
 ## once the pics have finished sliding. See [method _build_entrance].
 var _entrance_stages: Array[Dictionary] = []
+## Which panel is on the map. `InitBattleDisplay` clears the player's box and its
+## caller only reaches `UpdateEnemyHUD` for a wild battle, so a battle opens with
+## neither: the enemy's arrives when the opening line is pressed past (wild) or
+## when the trainer has sent something out, and the player's inside
+## `SendOutPlayerMon`.
+var _enemy_hud_visible: bool = true
+var _player_hud_visible: bool = true
+## `GetTrainerBackpic`: which of the player's own pictures is standing on the
+## player's square, empty once a Pokemon has taken it.
+var _player_backpic: String = ""
+## `InitEnemyTrainer`'s `PlaceGraphic`: the trainer class whose picture is on the
+## enemy's square, zero once that trainer has sent something out.
+var _enemy_trainer_pic: int = 0
+## `LoadTrainerHudOAM`'s six sprites a side and the border they hang in.
+var _hud_balls: Array = []
+var _hud_border: Array = []
+## `SlideBattlePicOut`, one entry per square still sliding off.
+var _slides: Array[Dictionary] = []
 ## The text the event pump produced while a bar was still draining. The source
 ## prints it after the bar arrives, since `applydamage` runs before
 ## `criticaltext` and `supereffectivetext`.
@@ -327,7 +345,10 @@ var _anim: Gen2BattleAnimPlayer = null
 var _anim_plan: Array = []
 var _anim_delay: int = 0
 var _anim_event: Dictionary = {}
-var _anim_hud_hidden: bool = false
+## `ClearActorHud` clears the panel of whoever's turn it is and leaves the other
+## one alone, so this is the side an animation has taken off the map rather than
+## a flag for both.
+var _anim_hud_hidden: int = -1
 var _audio_player: Gen2AudioPlayer = null
 ## `PlayBattleMusic`'s answer for this fight; see [method battle_music].
 var _battle_music: int = Gen2Battle.MUSIC_NONE
@@ -384,7 +405,7 @@ func _process(delta: float) -> void:
 ## because that answers whether a bar is on screen.
 func frames_running() -> bool:
 	var bars: bool = not _bars.is_empty() or (_exp_bar != null and not _exp_bar.paused())
-	return bars or _intro != null or animation_running() or fainting()
+	return bars or _intro != null or animation_running() or fainting() or sliding()
 
 
 ## One hardware frame of everything that counts them. Public through
@@ -397,6 +418,7 @@ func advance_frame() -> bool:
 	var moved: bool = advance_intro()
 	moved = advance_bars() or moved
 	moved = advance_faint() or moved
+	moved = advance_slide() or moved
 	moved = advance_animation() or moved
 	_resume_after_frames(was_running)
 	return moved
@@ -434,6 +456,30 @@ func advance_faint() -> bool:
 	Gen2BattleScreenMap.faint_step(_bg_map, bool(faint["player_side"]))
 	if int(faint["step"]) >= Gen2BattleScreenMap.FAINT_STEPS:
 		_faints.remove_at(0)
+	_push_view()
+	return true
+
+
+## Whether a picture is still sliding off its square.
+func sliding() -> bool:
+	return not _slides.is_empty()
+
+
+## One hardware frame of `SlideBattlePicOut`, whose outer loop spends
+## [constant Gen2BattleScreenMap.SLIDE_STEP_FRAMES] on each column it shifts.
+func advance_slide() -> bool:
+	if _slides.is_empty():
+		return false
+	var slide: Dictionary = _slides[0]
+	slide["delay"] = int(slide["delay"]) - 1
+	if int(slide["delay"]) > 0:
+		return true
+	slide["delay"] = Gen2BattleScreenMap.SLIDE_STEP_FRAMES
+	slide["step"] = int(slide["step"]) + 1
+	var player_side: bool = bool(slide["player_side"])
+	Gen2BattleScreenMap.slide_step(_bg_map, player_side)
+	if int(slide["step"]) >= int(Gen2BattleScreenMap.SLIDE_STEPS[player_side]):
+		_slides.remove_at(0)
 	_push_view()
 	return true
 
@@ -624,6 +670,7 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 		return
 
 	_init_battle_display()
+	_announce()
 
 
 ## Puts the player against one of a trainer class's own trainers, built from the
@@ -667,10 +714,7 @@ func show_trainer(
 
 	_init_battle_display()
 
-	var trainer: Dictionary = _data.trainer_party(trainer_class, index)
-	show_message("%s %s wants to fight!" % [
-		_data.trainer_name(trainer_class), String(trainer.get("name", "")),
-	])
+	show_message("%s\nwants to battle!" % _enemy_battler_label())
 
 
 ## Starts the development battle with the player party from a validated save
@@ -779,13 +823,7 @@ func start_world_battle(
 		show_message("Gotcha! %s was caught!" % _name_of(_enemy))
 		call_deferred("_finish_world_catch_tutorial")
 	elif bool(prepared.get("trainer_battle", false)):
-		var trainer: Dictionary = _data.trainer_party(
-			int(prepared.get("trainer_class", 0)), int(prepared.get("trainer_index", 0))
-		)
-		show_message("%s %s wants to fight!" % [
-			_data.trainer_name(int(prepared.get("trainer_class", 0))),
-			String(trainer.get("name", "")),
-		])
+		show_message("%s\nwants to battle!" % _enemy_battler_label())
 	else:
 		_announce()
 	return true
@@ -958,7 +996,37 @@ func _init_battle_display() -> void:
 	_intro = Gen2BattleIntro.for_data(_data)
 	_intro_message = ""
 	_entrance_stages = []
+	_slides = []
+	_hud_balls = []
+	_hud_border = []
+	## `InitBattleDisplay` clears both panels off the map, and the two pictures
+	## the pics slide in with are the opponent and the player themselves:
+	## `InitEnemyTrainer` places a trainer class on the enemy's square and
+	## `GetTrainerBackpic` the player's own on the player's. A wild opponent is
+	## the one battler already standing there as itself.
+	_enemy_hud_visible = false
+	_player_hud_visible = false
+	_enemy_trainer_pic = _enemy_trainer_class
+	_player_backpic = player_backpic_kind()
 	_push_view()
+
+
+## `GetTrainerBackpic`'s choice: the Dude for the catching tutorial, and the
+## player's own picture otherwise.
+func player_backpic_kind() -> String:
+	if _world_battle_tutorial:
+		return "dude"
+	return "kris" if player_is_female() else "chris"
+
+
+## `wPlayerGender`'s `PLAYERGENDER_FEMALE_F`. Gold and Silver have one player
+## character and no gender screen, so the answer there is always the male one.
+func player_is_female() -> bool:
+	if _source_save == null or _data == null:
+		return false
+	if not Gen2WorldState.is_crystal_profile(_data):
+		return false
+	return _source_save.gender == Gen2SaveData.GENDER_FEMALE
 
 
 ## One hardware frame of the intro. Public so a test or a screenshot driver can
@@ -983,14 +1051,19 @@ func advance_intro() -> bool:
 ## `BattleStartMessage` and the opening of `DoBattle`, which the sliding pics run
 ## straight into and which is the whole of a battle's entrance.
 ##
-## One stage per step, spent in order by [method _advance_entrance]:
+## One stage per step, spent in order by [method _advance_entrance]. Measured
+## against a real cartridge frame by frame, which is where the frame counts and
+## the two presses come from:
 ##
-## | Stage | Trainer | Wild |
+## | | Wild | Trainer |
 ## |---|---|---|
-## | 1 | `SFX_SHINE`, `WaitSFX`, twenty frames | the shiny pass and the cry |
-## | 2 | the start line | the start line |
-## | 3 | `ShowBattleTextEnemySentOut` and the enemy's own entrance | - |
-## | 4 | `DoBattle`'s forty frames, `SendOutMonText` and the ball | the same |
+## | 1 | the shiny pass and the enemy's cry | `SFX_SHINE`, `WaitSFX`, twenty frames |
+## | 2 | the party balls, then the start line, which waits on a press | the same |
+## | 3 | the balls go and the enemy's panel arrives | the balls go and the trainer slides off |
+## | 4 | - | `ShowBattleTextEnemySentOut`, a press, the enemy's ball, cry and panel |
+## | 5 | `DoBattle`'s forty frames | the same |
+## | 6 | the player slides off, `SendOutMonText` prints without waiting | the same |
+## | 7 | the ball, the cry and the player's panel | the same |
 ##
 ## The one part of `BattleStartMessage` not here is `AnimateFrontpic`: the
 ## cartridge wobbles the enemy's picture and plays the cry inside that animation,
@@ -1013,21 +1086,48 @@ func _build_entrance() -> void:
 	else:
 		# `BattleCheckEnemyShininess` and the cry, both in front of the line.
 		_entrance_stages.append({"events": _battle.entrance_events(Gen2Battle.ENEMY, false)})
-	_entrance_stages.append({"message": text})
+	# `BattleStart_TrainerHuds` is pushed in front of the line it is called with.
+	_entrance_stages.append({"apply": ENTRANCE_START_HUDS, "message": text})
+	# `EmptyBattleTextbox` and `ClearSprites` take the balls away the moment that
+	# line is pressed past; the wild branch draws the enemy's panel there too.
+	_entrance_stages.append({
+		"apply": ENTRANCE_ENEMY_HUD if not trainer else ENTRANCE_CLEAR_HUDS,
+	})
 	if trainer:
+		# `ResetEnemyBattleVars`, then `ShowBattleTextEnemySentOut` and
+		# `ShowSetEnemyMonAndSendOutAnimation` inside `EnemySwitch`.
+		_entrance_stages.append({"slide": Gen2Battle.ENEMY})
 		_entrance_stages.append({
 			"message": "%s\nsent out\n%s!" % [_enemy_battler_label(), _name_of(_enemy)],
-			"prompt": false,
+		})
+		_entrance_stages.append({
+			"apply": ENTRANCE_ENEMY_PIC,
 			"events": _battle.entrance_events(Gen2Battle.ENEMY),
 		})
+		_entrance_stages.append({"apply": ENTRANCE_ENEMY_HUD})
+	# `DoBattle`'s own `ld c, 40`, then `SlideBattlePicOut` and `SendOutMonText`.
+	_entrance_stages.append({"delay": PLAYER_ENTRANCE_FRAMES})
+	_entrance_stages.append({"slide": Gen2Battle.PLAYER})
 	_entrance_stages.append({
-		"delay": PLAYER_ENTRANCE_FRAMES,
 		"message": SEND_OUT_LINES[
 			clampi(_battle.send_out_line(Gen2Battle.PLAYER), 0, SEND_OUT_LINES.size() - 1)
 		] % _name_of(_player),
 		"prompt": false,
+	})
+	_entrance_stages.append({
+		"apply": ENTRANCE_PLAYER_PIC,
 		"events": _battle.entrance_events(Gen2Battle.PLAYER),
 	})
+	_entrance_stages.append({"apply": ENTRANCE_PLAYER_HUD})
+
+
+## What an entrance stage's `apply` names, each one routine of the source's.
+const ENTRANCE_START_HUDS: StringName = &"start_huds"
+const ENTRANCE_CLEAR_HUDS: StringName = &"clear_huds"
+const ENTRANCE_ENEMY_HUD: StringName = &"enemy_hud"
+const ENTRANCE_PLAYER_HUD: StringName = &"player_hud"
+const ENTRANCE_ENEMY_PIC: StringName = &"enemy_pic"
+const ENTRANCE_PLAYER_PIC: StringName = &"player_pic"
 
 
 ## One step of the entrance, in the order the fields are read here. Answers
@@ -1039,6 +1139,10 @@ func _advance_entrance() -> bool:
 		return false
 	while not _entrance_stages.is_empty():
 		var stage: Dictionary = _entrance_stages[0]
+		var apply: StringName = StringName(stage.get("apply", &""))
+		if apply != &"":
+			stage["apply"] = &""
+			_apply_entrance_step(apply)
 		var sfx: int = int(stage.get("sfx", 0))
 		var delay: int = int(stage.get("delay", 0))
 		var wait_sfx: bool = bool(stage.get("wait_sfx", false))
@@ -1055,13 +1159,19 @@ func _advance_entrance() -> bool:
 				_step(ANIM_DELAY, {"frames": delay})
 			_run_next_anim_step()
 			return true
+		if stage.has("slide"):
+			var side: int = int(stage["slide"])
+			stage.erase("slide")
+			_begin_slide(side)
+			return true
 		var message: String = String(stage.get("message", ""))
 		if not message.is_empty():
+			## `SendOutMonText`'s line ends in `done` and prints with the ball
+			## already in the air; every other line here ends in `prompt` or
+			## carries a `cont`, and both of those wait on a press.
 			var prompt: bool = bool(stage.get("prompt", true))
 			stage["message"] = ""
 			show_message(message, prompt)
-			## A `prompt` line owes a press. The two send-out lines end in `done`
-			## instead, and their animation is played underneath them.
 			if prompt:
 				return true
 		var events: Array = stage.get("events", []) as Array
@@ -1073,6 +1183,32 @@ func _advance_entrance() -> bool:
 	return false
 
 
+## The state each named routine of the entrance leaves behind.
+func _apply_entrance_step(what: StringName) -> void:
+	match what:
+		ENTRANCE_START_HUDS:
+			_build_trainer_huds()
+		ENTRANCE_CLEAR_HUDS:
+			# `EmptyBattleTextbox`, `ClearBox` over both panels and
+			# `ClearSprites`, which is what takes the party balls away.
+			_hud_balls = []
+			_hud_border = []
+		ENTRANCE_ENEMY_HUD:
+			_hud_balls = []
+			_hud_border = []
+			_enemy_hud_visible = true
+		ENTRANCE_PLAYER_HUD:
+			_player_hud_visible = true
+		ENTRANCE_ENEMY_PIC:
+			# `GetEnemyMonFrontpic`: the trainer's picture is replaced in VRAM
+			# before the ball is thrown, and the square itself is empty until
+			# `BATTLE_BG_EFFECT_ENTER_MON` stamps the map back.
+			_enemy_trainer_pic = 0
+		ENTRANCE_PLAYER_PIC:
+			_player_backpic = ""
+	_push_view()
+
+
 ## `Battle_GetTrainerName`, which is the class and the trainer's own name. A wild
 ## battle has neither, and the one line that names an opponent without a trainer
 ## behind it is a link battle's, which this project does not open.
@@ -1082,6 +1218,93 @@ func _enemy_battler_label() -> String:
 	return "%s %s" % [
 		_data.trainer_name(_enemy_trainer_class), _enemy_trainer_name(),
 	]
+
+
+## What the opening is showing right now, for a frame by frame diff against a
+## real cartridge: which squares hold what, which panels are up, whether a
+## picture is sliding and what the box is saying.
+func entrance_snapshot() -> Dictionary:
+	return {
+		"stages": _entrance_stages.size(),
+		"message": _last_message,
+		"awaits_press": _message_awaits_press,
+		"enemy_hud": _enemy_hud_visible and _anim_hud_hidden != Gen2Battle.ENEMY,
+		"player_hud": _player_hud_visible and _anim_hud_hidden != Gen2Battle.PLAYER,
+		"enemy_trainer_pic": _enemy_trainer_pic,
+		"player_backpic": _player_backpic,
+		"balls": _hud_balls.size(),
+		"sliding": sliding(),
+		"animating": animation_running(),
+		"anim": int(_anim_event.get("index", 0)) if _anim != null else 0,
+	}
+
+
+## Whether both panels are on the map: neither side taken off by an animation,
+## and both of them drawn by the entrance in the first place.
+func _hud_visible() -> bool:
+	return _enemy_hud_visible and _player_hud_visible and _anim_hud_hidden < 0
+
+
+## `SlideBattlePicOut` over one square.
+func _begin_slide(side: int) -> void:
+	_slides.append({
+		"player_side": side == Gen2Battle.PLAYER,
+		"step": 0,
+		"delay": Gen2BattleScreenMap.SLIDE_STEP_FRAMES,
+	})
+
+
+## `BattleStart_TrainerHuds`: the player's party balls always, the opponent's as
+## well when there is a trainer behind them, each six sprites hanging under a
+## border of four tile kinds.
+func _build_trainer_huds() -> void:
+	_hud_balls = []
+	_hud_border = []
+	_add_trainer_hud(Gen2Battle.PLAYER)
+	if _enemy_trainer_class > 0:
+		_add_trainer_hud(Gen2Battle.ENEMY)
+
+
+## One side of it. `LoadTrainerHudOAM` walks six slots from
+## [constant HUD_BALL_AT] in [constant HUD_BALL_STEP]'s direction, taking the
+## tile `StageBallTilesData` staged for each, and `PlaceHUDBorderTiles` draws the
+## frame from a corner outwards in the same direction.
+func _add_trainer_hud(side: int) -> void:
+	var player_side: bool = side == Gen2Battle.PLAYER
+	var at: Vector2i = HUD_BALL_AT[player_side]
+	var step: int = int(HUD_BALL_STEP[player_side])
+	var party: Gen2Party = _battle.party(side) if _battle != null else null
+	for slot: int in Gen2Party.MAX_SIZE:
+		_hud_balls.append({
+			"x": at.x + slot * step, "y": at.y, "tile": _hud_ball_tile(party, slot),
+		})
+	var border: Vector2i = HUD_BORDER_AT[player_side]
+	var tiles: Array = HUD_BORDER_TILES[player_side]
+	var direction: int = 1 if player_side else -1
+	_hud_border.append({"x": border.x, "y": border.y, "tile": int(tiles[0])})
+	_hud_border.append({"x": border.x, "y": border.y + 1, "tile": int(tiles[1])})
+	for index: int in HUD_BORDER_EDGE:
+		_hud_border.append({
+			"x": border.x - (index + 1) * direction, "y": border.y + 1,
+			"tile": int(tiles[3]),
+		})
+	_hud_border.append({
+		"x": border.x - (HUD_BORDER_EDGE + 1) * direction, "y": border.y + 1,
+		"tile": int(tiles[2]),
+	})
+
+
+## `StageBallTilesData`: an empty slot, then a ball per party member, coloured by
+## whether that member is fainted, statused or well.
+func _hud_ball_tile(party: Gen2Party, slot: int) -> int:
+	if party == null or slot >= party.size():
+		return HUD_BALL_EMPTY
+	var mon: Gen2BattleMon = party.at(slot)
+	if mon == null:
+		return HUD_BALL_EMPTY
+	if mon.is_fainted():
+		return HUD_BALL_FAINTED
+	return HUD_BALL_STATUSED if mon.status != 0 else HUD_BALL_NORMAL
 
 
 ## One hardware frame of every running bar. Public so a test or a screenshot
@@ -1176,6 +1399,29 @@ const SFX_SHINE: int = 0x5E
 ## `DoBattle` spends before the player's Pokemon is sent out.
 const TRAINER_START_FRAMES: int = 20
 const PLAYER_ENTRANCE_FRAMES: int = 40
+
+## `ShowPlayerMonsRemaining` and `ShowOTTrainerMonsRemaining`: where the first
+## party ball sits and which way the other five are laid out. OAM coordinates
+## subtract sixteen from the y and eight from the x, which is done here.
+const HUD_BALL_AT: Dictionary = {
+	false: Vector2i(9 * 8 - 8, 4 * 8 - 16), true: Vector2i(12 * 8 - 8, 12 * 8 - 16),
+}
+const HUD_BALL_STEP: Dictionary = {false: -8, true: 8}
+## `StageBallTilesData`'s four tiles, as offsets into `LoadBallIconGFX`'s sheet.
+const HUD_BALL_NORMAL: int = 0
+const HUD_BALL_STATUSED: int = 1
+const HUD_BALL_FAINTED: int = 2
+const HUD_BALL_EMPTY: int = 3
+## `DrawEnemyHUDBorder`'s `hlcoord 1, 2` and
+## `DrawPlayerPartyIconHUDBorder`'s `hlcoord 18, 10`, and the four tiles each
+## walks out from there: a side, the corner under it, the far corner and the
+## bottom edge between them.
+const HUD_BORDER_AT: Dictionary = {false: Vector2i(1, 2), true: Vector2i(18, 10)}
+const HUD_BORDER_TILES: Dictionary = {
+	false: [0x6D, 0x74, 0x78, 0x76], true: [0x73, 0x5C, 0x6F, 0x76],
+}
+## `ld b, 8`, the run of bottom edge between the two corners.
+const HUD_BORDER_EDGE: int = 8
 
 const SFX_EXP_BAR: int = 0x8C
 const SFX_HIT_END_OF_EXP_BAR: int = 0xB6
@@ -1291,13 +1537,16 @@ func _run_next_anim_step() -> void:
 				return
 			ANIM_CLEAR_HUD:
 				# `BattleAnimClearHud`: a delay, the hud off the map, then three
-				# more while the map reaches VRAM.
-				_anim_hud_hidden = true
+				# more while the map reaches VRAM. `ClearActorHud` reads
+				# `hBattleTurn` and clears that side's panel only, which is why
+				# the target's bar is still there to watch while it drains.
+				_anim_hud_hidden = Gen2Battle.ENEMY \
+					if bool(_anim_event.get("enemy_turn", false)) else Gen2Battle.PLAYER
 				_anim_delay = 4
 				_push_view()
 				return
 			ANIM_RESTORE_HUD:
-				_anim_hud_hidden = false
+				_anim_hud_hidden = -1
 				_anim_delay = 4
 				_push_view()
 				return
@@ -1643,7 +1892,7 @@ func animation_snapshot() -> Dictionary:
 		"enemy_turn": bool(_anim_event.get("enemy_turn", false)),
 		"after_anim": int(_anim_event.get("after_anim", 0)),
 		"sprites": (_anim.sprites() as Array).size() if _anim != null else 0,
-		"hud_visible": not _anim_hud_hidden,
+		"hud_visible": _hud_visible(),
 	}
 
 
@@ -1660,6 +1909,8 @@ func battle_snapshot() -> Dictionary:
 		"message": _last_message,
 		"completion_sent": _world_battle_completion_sent,
 		"entrance_running": entrance_running(),
+		## Whether the line on screen is one `<PROMPT>` or `<CONT>` blocks on.
+		"awaits_press": _message_awaits_press,
 		"switch_stage": _switch_stage,
 		"switch_cursor": (
 			_switch_offer.selected_index() if _switch_offer != null
@@ -2016,12 +2267,10 @@ func finish() -> void:
 
 func next_enemy() -> void:
 	show_matchup(_enemy + 1, _player, _enemy_level, _player_level)
-	_announce()
 
 
 func next_player() -> void:
 	show_matchup(_enemy, _player + 1, _enemy_level, _player_level)
-	_announce()
 
 
 ## Takes a quarter of the enemy's health off, which is the fastest way to see
@@ -3285,6 +3534,18 @@ func _show_next_event() -> void:
 		## this is the press that took that line away.
 		_clear_level_up_box()
 		event = Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
+		if StringName(event["type"]) == Gen2Battle.CRY:
+			## `PlayStereoCry` is `_PlayMonCry` and then `WaitSFX`, so an
+			## entrance stands still for as long as the cry lasts. Its silent
+			## sibling `PlayStereoCry2` is what a pic animation uses and is not
+			## this.
+			_apply_event(event)
+			_anim_plan = []
+			_step(ANIM_WAIT_SFX, {})
+			_run_next_anim_step()
+			if animation_running():
+				return
+			continue
 		if StringName(event["type"]) == Gen2Battle.ANIMATION:
 			## The engine has already resolved; this event is the frames the
 			## screen owes for it, and nothing behind it is shown until they are
@@ -4116,13 +4377,28 @@ func _push_view() -> void:
 		"raster_scx": _raster_offsets(),
 		"raster_scy": _raster_rows(),
 		"player_pic_visible": _intro == null,
+		## Which picture each square is holding and which panel is on the map.
+		## Both change several times while a battle is opening: see
+		## [method _build_entrance].
+		"enemy_trainer_pic": _enemy_trainer_pic,
+		"player_backpic": _player_backpic,
+		"player_backpic_palette": "kris" if player_is_female() else "chris",
+		"enemy_hud_visible": _enemy_hud_visible \
+			and _anim_hud_hidden != Gen2Battle.ENEMY,
+		"player_hud_visible": _player_hud_visible \
+			and _anim_hud_hidden != Gen2Battle.PLAYER,
+		## `BattleStart_TrainerHuds`' party balls and the frame they hang in.
+		"trainer_hud_balls": _hud_balls,
+		"trainer_hud_border": _hud_border,
 		## `wTilemap` and the video state an animation writes over it.
 		"bg_map": _bg_map,
 		"bg_palette_maps": _background_maps(&"bg"),
 		"ob_palette_maps": _background_maps(&"ob"),
 		"anim_sprites": _anim.sprites() if _anim != null else [],
 		"anim_tiles": _anim.tiles() if _anim != null else [],
-		"hud_visible": not _anim_hud_hidden,
+		## Whether both panels are on the map, which is the summary of the two
+		## keys above rather than a third state.
+		"hud_visible": _hud_visible(),
 	})
 	if _box != null:
 		_box.raster_scx = _box_raster_offsets()
@@ -4191,4 +4467,4 @@ func _name_of(species: int) -> String:
 
 
 func _announce() -> void:
-	show_message("Wild %s appeared!" % _name_of(_enemy))
+	show_message("Wild %s\nappeared!" % _name_of(_enemy))

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -184,6 +184,9 @@ var _intro: Gen2BattleIntro = null
 ## `InitBattleDisplay` returns before it is called and the box drawn before the
 ## slide is an empty one.
 var _intro_message: String = ""
+## `BattleStartMessage` and `DoBattle`'s own opening, one step per entry, spent
+## once the pics have finished sliding. See [method _build_entrance].
+var _entrance_stages: Array[Dictionary] = []
 ## The text the event pump produced while a bar was still draining. The source
 ## prints it after the bar arrives, since `applydamage` runs before
 ## `criticaltext` and `supereffectivetext`.
@@ -924,6 +927,14 @@ func intro_running() -> bool:
 	return _intro != null
 
 
+## Whether `BattleStartMessage` and `DoBattle`'s opening still owe something: a
+## line to press past, frames to spend, or a ball to throw. A driver settling a
+## battle to its first menu waits on this as well as on [method frames_running],
+## because two of the steps are a box rather than a run of frames.
+func entrance_running() -> bool:
+	return not _entrance_stages.is_empty()
+
+
 ## `InitBattleDisplay`: the display a battle opens with, and the slide that puts
 ## it there. Every caller that has just built a battle reaches this, which is the
 ## same order the source uses, `InitBattleDisplay` before `BattleStartMessage`.
@@ -946,6 +957,7 @@ func _init_battle_display() -> void:
 	_refresh_exp_bar()
 	_intro = Gen2BattleIntro.for_data(_data)
 	_intro_message = ""
+	_entrance_stages = []
 	_push_view()
 
 
@@ -961,13 +973,115 @@ func advance_intro() -> bool:
 		# then `BattleStartMessage`.
 		_intro = null
 		_push_view()
-		if not _intro_message.is_empty():
-			var text: String = _intro_message
-			_intro_message = ""
-			show_message(text)
+		_build_entrance()
+		_advance_entrance()
 		return true
 	_push_view()
 	return true
+
+
+## `BattleStartMessage` and the opening of `DoBattle`, which the sliding pics run
+## straight into and which is the whole of a battle's entrance.
+##
+## One stage per step, spent in order by [method _advance_entrance]:
+##
+## | Stage | Trainer | Wild |
+## |---|---|---|
+## | 1 | `SFX_SHINE`, `WaitSFX`, twenty frames | the shiny pass and the cry |
+## | 2 | the start line | the start line |
+## | 3 | `ShowBattleTextEnemySentOut` and the enemy's own entrance | - |
+## | 4 | `DoBattle`'s forty frames, `SendOutMonText` and the ball | the same |
+##
+## The one part of `BattleStartMessage` not here is `AnimateFrontpic`: the
+## cartridge wobbles the enemy's picture and plays the cry inside that animation,
+## and this project imports neither the pic animations nor their pointers, so the
+## cry is played on its own the way `.cry_no_anim` plays it.
+func _build_entrance() -> void:
+	_entrance_stages = []
+	var text: String = _intro_message
+	_intro_message = ""
+	if _battle == null or _world_battle_tutorial:
+		if not text.is_empty():
+			show_message(text)
+		return
+
+	var trainer: bool = _enemy_trainer_class > 0
+	if trainer:
+		_entrance_stages.append({
+			"sfx": SFX_SHINE, "wait_sfx": true, "delay": TRAINER_START_FRAMES,
+		})
+	else:
+		# `BattleCheckEnemyShininess` and the cry, both in front of the line.
+		_entrance_stages.append({"events": _battle.entrance_events(Gen2Battle.ENEMY, false)})
+	_entrance_stages.append({"message": text})
+	if trainer:
+		_entrance_stages.append({
+			"message": "%s\nsent out\n%s!" % [_enemy_battler_label(), _name_of(_enemy)],
+			"prompt": false,
+			"events": _battle.entrance_events(Gen2Battle.ENEMY),
+		})
+	_entrance_stages.append({
+		"delay": PLAYER_ENTRANCE_FRAMES,
+		"message": SEND_OUT_LINES[
+			clampi(_battle.send_out_line(Gen2Battle.PLAYER), 0, SEND_OUT_LINES.size() - 1)
+		] % _name_of(_player),
+		"prompt": false,
+		"events": _battle.entrance_events(Gen2Battle.PLAYER),
+	})
+
+
+## One step of the entrance, in the order the fields are read here. Answers
+## whether it took the turn, so the caller can run on when the list is empty.
+func _advance_entrance() -> bool:
+	## A stage's own events are still being shown one line at a time; the next
+	## stage waits for the last of them.
+	if not _pending.is_empty():
+		return false
+	while not _entrance_stages.is_empty():
+		var stage: Dictionary = _entrance_stages[0]
+		var sfx: int = int(stage.get("sfx", 0))
+		var delay: int = int(stage.get("delay", 0))
+		var wait_sfx: bool = bool(stage.get("wait_sfx", false))
+		if sfx > 0 or delay > 0 or wait_sfx:
+			stage["sfx"] = 0
+			stage["delay"] = 0
+			stage["wait_sfx"] = false
+			_anim_plan = []
+			if sfx > 0:
+				_step(ANIM_SFX, {"sfx": sfx})
+			if wait_sfx:
+				_step(ANIM_WAIT_SFX, {})
+			if delay > 0:
+				_step(ANIM_DELAY, {"frames": delay})
+			_run_next_anim_step()
+			return true
+		var message: String = String(stage.get("message", ""))
+		if not message.is_empty():
+			var prompt: bool = bool(stage.get("prompt", true))
+			stage["message"] = ""
+			show_message(message, prompt)
+			## A `prompt` line owes a press. The two send-out lines end in `done`
+			## instead, and their animation is played underneath them.
+			if prompt:
+				return true
+		var events: Array = stage.get("events", []) as Array
+		_entrance_stages.pop_front()
+		if not events.is_empty():
+			_pending = events
+			_show_next_event()
+			return true
+	return false
+
+
+## `Battle_GetTrainerName`, which is the class and the trainer's own name. A wild
+## battle has neither, and the one line that names an opponent without a trainer
+## behind it is a link battle's, which this project does not open.
+func _enemy_battler_label() -> String:
+	if _enemy_trainer_class <= 0 or _data == null:
+		return "Enemy"
+	return "%s %s" % [
+		_data.trainer_name(_enemy_trainer_class), _enemy_trainer_name(),
+	]
 
 
 ## One hardware frame of every running bar. Public so a test or a screenshot
@@ -1017,6 +1131,9 @@ const ANIM_RESTORE_HUD: StringName = &"restore_hud"
 const ANIM_WAIT_SFX: StringName = &"wait_sfx"
 const ANIM_HIT_SOUND: StringName = &"hit_sound"
 const ANIM_APPEAR_USER: StringName = &"appear_user"
+## `PlaySFX` on its own, which only the entrance uses: an animation's own sounds
+## come out of its script.
+const ANIM_SFX: StringName = &"sfx"
 
 ## Whose square is showing the substitute's doll rather than the mon itself,
 ## keyed by [constant Gen2Battle.PLAYER] and [constant Gen2Battle.ENEMY].
@@ -1033,6 +1150,11 @@ var _substitute_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: f
 ## battle-scene, hud and after-anim half of `BattleAnimRunScript`.
 const ANIM_MOVE_LIMIT: int = 0x100
 
+## `SendOutMonText`'s four texts, in [constant Gen2Battle.SEND_OUT_GO]'s order.
+const SEND_OUT_LINES: Array[String] = [
+	"Go! %s!", "Do it! %s!", "Go for it,\n%s!", "Your foe's weak!\nGet'm, %s!",
+]
+
 ## `PlayHitSound`'s three effects, by their `constants/sfx_constants.asm`
 ## numbers, which are the same in both pins.
 const SFX_NOT_VERY_EFFECTIVE: int = 0xAB
@@ -1047,6 +1169,14 @@ const SFX_SUPER_EFFECTIVE: int = 0xAD
 ## `AnimateExpBar`'s two: `.PlayExpBarSound`'s at the head of every segment, and
 ## the one `.LoopLevels` and `.skip_exp_bar_animation` both play before their
 ## grew-to-level line.
+## `BattleStartMessage`'s own, in front of a trainer's line.
+const SFX_SHINE: int = 0x5E
+
+## The twenty frames `BattleStartMessage` spends after `SFX_SHINE`, and the forty
+## `DoBattle` spends before the player's Pokemon is sent out.
+const TRAINER_START_FRAMES: int = 20
+const PLAYER_ENTRANCE_FRAMES: int = 40
+
 const SFX_EXP_BAR: int = 0x8C
 const SFX_HIT_END_OF_EXP_BAR: int = 0xB6
 
@@ -1089,8 +1219,10 @@ func _begin_animation(event: Dictionary) -> void:
 	# `PlayFXAnimID`'s own `ld c, 3 / call DelayFrames`, then `_PlayBattleAnim`'s
 	# six, `BattleAnimAssignPals`/`..._RequestPals` and one more. The two pal
 	# calls write nothing here: the palettes an animation remaps are the battle's
-	# own and are read back off the background every frame.
-	_step(ANIM_DELAY, {"frames": 3 + 6 + 1})
+	# own and are read back off the background every frame. An entrance comes
+	# through `Call_PlayBattleAnim` instead, whose `WaitBGMap` is one frame.
+	var lead: int = 1 if bool(event.get("called", false)) else 3
+	_step(ANIM_DELAY, {"frames": lead + 6 + 1})
 
 	if is_move:
 		if Gen2OptionsStore.current().battle_scene:
@@ -1183,6 +1315,8 @@ func _run_next_anim_step() -> void:
 						_anim_plan.push_front(step)
 						_anim_delay = 1
 						return
+			ANIM_SFX:
+				_play_anim_sound(int(step["sfx"]))
 			ANIM_HIT_SOUND:
 				_play_hit_sound()
 			ANIM_SCRIPT:
@@ -1300,6 +1434,20 @@ func _play_anim_cry() -> void:
 		return
 	_audio_player.play_record(
 		record, &"cry", _audio_assets(), false, cry_tracks(enemy_turn)
+	)
+
+
+## `PlayStereoCry` behind an entrance, which names its own species rather than
+## reading whoever is on the field: the event is spent where the source plays it,
+## which is before the panel it came with has been drawn.
+func _play_entrance_cry(side: int, species: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	var record: Dictionary = _data.species_cry(species)
+	if record.is_empty():
+		return
+	_audio_player.play_record(
+		record, &"cry", _audio_assets(), false, cry_tracks(side == Gen2Battle.ENEMY)
 	)
 
 
@@ -1465,7 +1613,10 @@ func _clear_level_up_box() -> void:
 	_refresh_level_up_box()
 
 
-func show_message(text: String) -> void:
+## [param prompt] is the text's own terminator: `prompt` waits for a press and
+## `done` does not, which is the difference between the line a battle opens with
+## and the two send-out lines an animation is played underneath.
+func show_message(text: String, prompt: bool = true) -> void:
 	# `BattleStartMessage` is called after `InitBattleDisplay` returns, so
 	# nothing is said while the pics are still sliding: the box drawn before the
 	# slide is an empty one.
@@ -1475,7 +1626,7 @@ func show_message(text: String) -> void:
 	_last_message = text
 	## `StdBattleTextbox` blocks on a press for a line it printed; an empty box
 	## is the one a menu is drawn over and owes nothing.
-	_message_awaits_press = not text.is_empty()
+	_message_awaits_press = prompt and not text.is_empty()
 	if _box != null:
 		_box.show_text(text)
 
@@ -1508,6 +1659,7 @@ func battle_snapshot() -> Dictionary:
 		"player": _player,
 		"message": _last_message,
 		"completion_sent": _world_battle_completion_sent,
+		"entrance_running": entrance_running(),
 		"switch_stage": _switch_stage,
 		"switch_cursor": (
 			_switch_offer.selected_index() if _switch_offer != null
@@ -2210,7 +2362,11 @@ func _continue_after_messages() -> void:
 		_held_message = ""
 		show_message(held)
 		return
-	if _message_awaits_press or not _intro_message.is_empty():
+	if _message_awaits_press:
+		return
+	## `BattleStartMessage` and `DoBattle`'s opening: each step is either frames
+	## or a line, so the pump and the press both arrive back here for the next.
+	if _advance_entrance():
 		return
 	## Nothing is left to print, so the line the box stood beside is gone even
 	## though no event was popped to take it away.
@@ -3201,6 +3357,8 @@ func _apply_event_state(event: Dictionary) -> void:
 			_begin_faint(int(event["side"]))
 		Gen2Battle.SUBSTITUTE_PIC:
 			_set_substitute_pic(int(event["side"]), bool(event["raised"]))
+		Gen2Battle.CRY:
+			_play_entrance_cry(int(event["side"]), int(event["species"]))
 		Gen2Battle.SENT_OUT:
 			# The pic and the panel both change, and both come out of the event
 			# rather than out of the party, for the same reason every other number
@@ -3333,7 +3491,12 @@ func _describe(event: Dictionary) -> String:
 		Gen2Battle.SENT_OUT:
 			if side == Gen2Battle.ENEMY:
 				return "Enemy sent out %s!" % _name_of(int(event["species"]))
-			return "Go! %s!" % _name_of(int(event["species"]))
+			return SEND_OUT_LINES[
+				clampi(int(event.get("line", Gen2Battle.SEND_OUT_GO)), 0, SEND_OUT_LINES.size() - 1)
+			] % _name_of(int(event["species"]))
+		Gen2Battle.CRY:
+			# `PlayStereoCry` prints nothing.
+			return ""
 		Gen2Battle.EXP_GAINED:
 			return "%s gained %d EXP. Points!" % [_name_of(int(event["species"])), int(event["amount"])]
 		Gen2Battle.STAT_EXP_GAINED:

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -80,6 +80,42 @@ static func faint_step(map: PackedByteArray, player_side: bool) -> void:
 		map[at.y * COLUMNS + x] = BLANK_TILE
 
 
+## `SlideBattlePicOut`, which is not the picture's box either: seven rows from
+## one above the player's, and the whole of the enemy's, shifted a column at a
+## time until the picture is off the screen.
+##
+## `DoBattle`'s `hlcoord 1, 5 / ld a, 9` walks the player's left and
+## `ResetEnemyBattleVars`' `hlcoord 18, 0 / ld a, 8` walks the enemy's right, and
+## the count is both how many columns are touched and how many steps it takes.
+const SLIDE_AT: Dictionary = {false: Vector2i(18, 0), true: Vector2i(1, 5)}
+const SLIDE_ROWS: int = 7
+const SLIDE_STEPS: Dictionary = {false: 8, true: 9}
+const SLIDE_STEP_FRAMES: int = 2
+
+
+## One outer step of `SlideBattlePicOut`: every touched cell takes its
+## neighbour's on the side the picture is leaving towards, which is `.back`'s
+## `ld a, [hld] / ld [hli], a` for the player and `.forward`'s
+## `ld a, [hli] / ld [hld], a` for the enemy.
+static func slide_step(map: PackedByteArray, player_side: bool) -> void:
+	if map.size() != COLUMNS * ROWS:
+		return
+	var at: Vector2i = SLIDE_AT[player_side]
+	var count: int = int(SLIDE_STEPS[player_side])
+	for row_index: int in SLIDE_ROWS:
+		var y: int = at.y + row_index
+		if y < 0 or y >= ROWS:
+			continue
+		for index: int in count:
+			# The player's walk reads to the right of what it writes; the
+			# enemy's reads to the left of it.
+			var to: int = at.x + index - 1 if player_side else at.x - index + 1
+			var from: int = at.x + index if player_side else at.x - index
+			if to < 0 or to >= COLUMNS or from < 0 or from >= COLUMNS:
+				continue
+			map[y * COLUMNS + to] = map[y * COLUMNS + from]
+
+
 ## `PlaceGraphic` over one battler's box: a tile is
 ## [code]base + column * side + row[/code], the column-major order `.BGSquares`
 ## indexes and `AppearUser` restores.

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -1,0 +1,425 @@
+class_name Gen2BattleTransition
+extends RefCounted
+
+## `DoBattleTransition` (engine/battle/battle_transition.asm): what the overworld
+## does between the encounter and the battle screen.
+##
+## Four animations, picked by the lead's level against the opponent's and by the
+## environment, each of them a Poke Ball drawn over the map for a trainer, three
+## passes of a palette flash, and then one of four ways of going black. The
+## jumptable is walked one entry per frame, which is what `DoBattleTransition`'s
+## own `.loop` does with its `DelayFrame`.
+##
+## Node-free: it answers with a screen of cells, a DMG palette order and a
+## per-scanline offset, and the world screen draws those over whatever it was
+## already drawing. Nothing here reaches a renderer, so a whole transition can be
+## stepped and read headless.
+
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## What a cell of [method cells] holds. `BATTLETRANSITION_SQUARE` and
+## `..._BLACK` are the two tiles `LoadBattleTransitionGFX` loads, and a cell the
+## transition has not written is the map showing through.
+const CELL_NONE: int = 0
+const CELL_SQUARE: int = 1
+const CELL_BLACK: int = 2
+
+## `%11100100`, the order that draws every colour as itself.
+const IDENTITY: int = 0xE4
+
+## `ld a, [wBattleMonLevel] / add 3`: the lead has to be more than this far under
+## the opponent for the stronger pair of animations.
+const STRONGER_MARGIN: int = 3
+
+## `StartTrainerBattle_Flash.pals`, the thirteen `dc` bytes it walks two frames
+## at a time. The last is not a palette: `cp %00000001` is what ends the pass.
+const FLASH_PALETTES: Array[int] = [
+	0xF9, 0xFE, 0xFF, 0xFE, 0xF9, 0xE4, 0x90, 0x40, 0x00, 0x40, 0x90, 0xE4, 0x01,
+]
+const FLASH_TERMINATOR: int = 0x01
+
+## `PokeBallTransition`, the 16x16 overlay, one big-endian word per row.
+const POKE_BALL: Array[int] = [
+	0b0000001111000000, 0b0000111111110000, 0b0011110000111100, 0b0011000000001100,
+	0b0110000000000110, 0b0110001111000110, 0b1100011000110011, 0b1111110000111111,
+	0b1111110000111111, 0b1100011000110011, 0b0110001111000110, 0b0110000000000110,
+	0b0011000000001100, 0b0011110000111100, 0b0000111111110000, 0b0000001111000000,
+]
+## `hlcoord 2, 1` and the sixteen rows `ld b, SCREEN_WIDTH - 4` walks.
+const BALL_AT := Vector2i(2, 1)
+const BALL_SIDE: int = 16
+
+## The four animations, as the jumptable's own runs of scenes. `TRANS_STRONGER_F`
+## is set when the lead is more than three levels under the opponent and
+## `TRANS_NO_CAVE_F` when the environment is not a cave, and the pair indexes
+## `StartTrainerBattle_DetermineWhichAnimation.StartingPoints`.
+const SCENES: Array = [
+	## BATTLETRANSITION_CAVE. `init` is `.InitGFX` in front of the jumptable
+	## rather than an entry in it.
+	[&"init", &"ball", &"bgmap", &"flash", &"flash", &"flash", &"next", &"wavy_setup", &"sine"],
+	## BATTLETRANSITION_CAVE_STRONGER, which has no setup of its own
+	[&"init", &"ball", &"bgmap", &"flash", &"flash", &"flash", &"next", &"zoom"],
+	## BATTLETRANSITION_NO_CAVE
+	[&"init", &"ball", &"bgmap", &"flash", &"flash", &"flash", &"next", &"spin_setup", &"spin"],
+	## BATTLETRANSITION_NO_CAVE_STRONGER
+	[&"init", &"ball", &"bgmap", &"flash", &"flash", &"flash", &"next", &"scatter_setup", &"scatter"],
+]
+
+## `StartTrainerBattle_SpinToBlack.spin_quadrants`: which corner a wedge is
+## drawn from, which wedge, and where it starts. Bit 0 is
+## `RIGHT_QUADRANT_F` and bit 1 `LOWER_QUADRANT_F`.
+const UPPER_LEFT: int = 0
+const UPPER_RIGHT: int = 1
+const LOWER_LEFT: int = 2
+const LOWER_RIGHT: int = 3
+const SPIN_QUADRANTS: Array = [
+	[UPPER_LEFT, 1, 1, 6], [UPPER_LEFT, 2, 0, 3], [UPPER_LEFT, 3, 1, 0],
+	[UPPER_LEFT, 4, 5, 0], [UPPER_LEFT, 5, 9, 0],
+	[UPPER_RIGHT, 5, 10, 0], [UPPER_RIGHT, 4, 14, 0], [UPPER_RIGHT, 3, 18, 0],
+	[UPPER_RIGHT, 2, 19, 3], [UPPER_RIGHT, 1, 18, 6],
+	[LOWER_RIGHT, 1, 18, 11], [LOWER_RIGHT, 2, 19, 14], [LOWER_RIGHT, 3, 18, 17],
+	[LOWER_RIGHT, 4, 14, 17], [LOWER_RIGHT, 5, 10, 17],
+	[LOWER_LEFT, 5, 9, 17], [LOWER_LEFT, 4, 5, 17], [LOWER_LEFT, 3, 1, 17],
+	[LOWER_LEFT, 2, 0, 14], [LOWER_LEFT, 1, 1, 11],
+]
+## `.wedge1` to `.wedge5`, read as pairs: how many cells to black out along the
+## row, then how many to step back before the next one. `-1` ends the wedge.
+const WEDGES: Dictionary = {
+	1: [2, 3, 5, 4, 9, -1],
+	2: [1, 1, 2, 2, 4, 2, 4, 2, 3, -1],
+	3: [2, 1, 3, 1, 4, 1, 4, 1, 4, 1, 3, 1, 2, 1, 1, 1, 1, -1],
+	4: [4, 1, 4, 0, 3, 1, 3, 0, 2, 1, 2, 0, 1, -1],
+	5: [4, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, -1],
+}
+## `ld c, 2 / DelayFrames` between wedges, and the three frames the walk spends
+## after the last one.
+const SPIN_STEP_FRAMES: int = 2
+const SPIN_END_FRAMES: int = 3
+
+## `StartTrainerBattle_ZoomToBlack.boxes`: width, height and the top-left corner
+## of each, one `WaitBGMap` apart.
+const ZOOM_BOXES: Array = [
+	[4, 2, 8, 8], [6, 4, 7, 7], [8, 6, 6, 6], [10, 8, 5, 5], [12, 10, 4, 4],
+	[14, 12, 3, 3], [16, 14, 2, 2], [18, 16, 1, 1], [20, 18, 0, 0],
+]
+
+## `StartTrainerBattle_SetUpForRandomScatterOutro`'s `ld a, $10`, and the twelve
+## tiles a frame of `..._SpeckleToBlack` blacks out.
+const SCATTER_FRAMES: int = 0x10
+const SCATTER_PER_FRAME: int = 12
+
+## `StartTrainerBattle_SineWave`'s own `cp $60`, and the two-scanline step its
+## loop walks the screen with.
+const SINE_FRAMES: int = 0x60
+const SINE_STEP: int = 2
+const SCREEN_LINES: int = 144
+
+## The two frames `LoadPokeBallGraphics` spends before the next scene.
+const BALL_FRAMES: int = 2
+
+## `DoBattleTransition.InitGFX` before the jumptable, and `.done` after it.
+##
+## Both are runs of VRAM copies this port does at once: `ReanchorBGMap`,
+## `Request2bpp` twice for the two tiles and again for the forty the BG map is
+## filled with, `BattleStart_CopyTilemapAtOnce`, and then the palette wipe at the
+## end. The counts are measured against a real cartridge rather than derived,
+## because a `WaitBGMap` is worth whatever the copy in front of it left.
+const LEAD_FRAMES: int = 19
+const TAIL_FRAMES: int = 3
+
+var _scene: Array = []
+var _step: int = 0
+var _counter: int = 0
+var _sine_offset: int = 0
+var _delay: int = 0
+## Whether the scene that set [member _delay] had already handed on: a scene's
+## own frames belong to it rather than to the one it hands to.
+var _pending_next: bool = false
+var _finished: bool = false
+var _trainer: bool = false
+var _darkness: bool = false
+var _order: int = IDENTITY
+var _ball_drawn: bool = false
+var _cells: PackedByteArray = PackedByteArray()
+var _sine: PackedByteArray = PackedByteArray()
+var _rng: RandomNumberGenerator = null
+
+
+## [param stronger] is `TRANS_STRONGER_F`, [param cave] the environment test,
+## [param trainer] `wOtherTrainerClass`, [param darkness]
+## `wTimeOfDayPalset`'s `DARKNESS_PALSET`, which is the one thing that skips the
+## flash. [param sine] is `sine_table 32` as the cartridge stores it, which the
+## wavy outro reads; the battle animations' own copy is the same table.
+static func create(
+	stronger: bool, cave: bool, trainer: bool, darkness: bool,
+	rng: RandomNumberGenerator = null, sine: PackedByteArray = PackedByteArray()
+) -> Gen2BattleTransition:
+	var out := Gen2BattleTransition.new()
+	out._scene = SCENES[(1 if stronger else 0) | (0 if cave else 2)]
+	out._trainer = trainer
+	out._darkness = darkness
+	out._sine = sine
+	out._rng = rng if rng != null else RandomNumberGenerator.new()
+	out._cells = PackedByteArray()
+	out._cells.resize(COLUMNS * ROWS)
+	return out
+
+
+## Which scene of the jumptable is running, for a test or a trace: `ball`,
+## `bgmap`, `flash`, `next`, one of the four setups or one of the four outros.
+func scene() -> StringName:
+	if _finished or _step >= _scene.size():
+		return &""
+	return StringName(_scene[_step])
+
+
+## `wJumptableIndex`'s exit bit.
+func finished() -> bool:
+	return _finished
+
+
+## What the screen is holding: one entry per cell, [constant CELL_NONE] where the
+## map is still showing.
+func cells() -> PackedByteArray:
+	return _cells
+
+
+## The DMG order every background palette is drawn through, which is `wBGP` and
+## `DmgToCgbBGPals`.
+func palette_order() -> int:
+	return _order
+
+
+## Whether the Poke Ball is up, which is also when `.pal_loop` has put every
+## background tile on `PAL_BG_TEXT` and `.copypals` has filled it.
+func ball_drawn() -> bool:
+	return _ball_drawn
+
+
+## `wLYOverrides`, the per-scanline `rSCX` the wavy outro writes. Empty for the
+## three that write none.
+func raster_offsets() -> PackedInt32Array:
+	var out := PackedInt32Array()
+	if StringName(_scene[mini(_step, _scene.size() - 1)]) != &"sine" or _sine.is_empty():
+		return out
+	out.resize(SCREEN_LINES)
+	var amplitude: int = _counter
+	for line: int in SCREEN_LINES:
+		out[line] = _sine_wave(_sine_offset + line * SINE_STEP, amplitude)
+	return out
+
+
+## One frame of `DoBattleTransition.loop`: one jumptable entry, then its
+## `DelayFrame`. A scene that spends frames of its own answers for them here
+## rather than running ahead.
+func advance_frame() -> bool:
+	if _delay > 0:
+		_delay -= 1
+		if _delay == 0 and _pending_next:
+			_pending_next = false
+			_step += 1
+		return true
+	if _finished:
+		return false
+	_run()
+	return true
+
+
+func _run() -> void:
+	if _step >= _scene.size():
+		_finished = true
+		return
+	match StringName(_scene[_step]):
+		&"init":
+			_delay = LEAD_FRAMES
+			_next()
+		&"ball":
+			_load_poke_ball_graphics()
+		&"bgmap":
+			_counter = 0
+			_next()
+		&"flash":
+			_flash()
+		&"next":
+			_next()
+		&"wavy_setup":
+			_counter = 0
+			_sine_offset = 0
+			_next()
+		&"sine":
+			_sine_wave_step()
+		&"spin_setup":
+			_counter = 0
+			_next()
+		&"spin":
+			_spin_step()
+		&"scatter_setup":
+			_counter = SCATTER_FRAMES
+			_next()
+		&"scatter":
+			_scatter_step()
+		&"zoom":
+			_zoom_step()
+
+
+func _next() -> void:
+	if _delay > 0:
+		_pending_next = true
+		return
+	_step += 1
+
+
+## `StartTrainerBattle_LoadPokeBallGraphics`, which returns at once for a wild
+## battle: the ball is what says a person is on the other side.
+func _load_poke_ball_graphics() -> void:
+	if not _trainer:
+		_next()
+		return
+	for row: int in BALL_SIDE:
+		var bits: int = int(POKE_BALL[row])
+		for column: int in BALL_SIDE:
+			# `sla a` walks from bit 7 down and `and a / jr z` stops on a byte
+			# whose remaining bits are all clear, so a zero never writes a cell.
+			if (bits & (1 << (BALL_SIDE - 1 - column))) == 0:
+				continue
+			_write(BALL_AT.x + column, BALL_AT.y + row, CELL_SQUARE)
+	_ball_drawn = true
+	_delay = BALL_FRAMES
+	_next()
+
+
+## `StartTrainerBattle_Flash.DoFlashAnimation`, two frames a palette. Darkness is
+## the one palset it does nothing for, and the pass ends on the entry that is not
+## a palette at all.
+func _flash() -> void:
+	if _darkness:
+		_counter = 0
+		_next()
+		return
+	@warning_ignore("integer_division")
+	var index: int = _counter / 2
+	_counter += 1
+	var value: int = int(FLASH_PALETTES[mini(index, FLASH_PALETTES.size() - 1)])
+	if value == FLASH_TERMINATOR:
+		_counter = 0
+		_order = IDENTITY
+		_next()
+		return
+	_order = value
+
+
+## `StartTrainerBattle_SineWave`, whose counter is the amplitude and whose
+## offset walks the phase.
+func _sine_wave_step() -> void:
+	if _counter >= SINE_FRAMES:
+		_finish()
+		return
+	_sine_offset = (_sine_offset + 1) & 0xFF
+	_counter = (_counter + _sine_offset) & 0xFF
+
+
+## `calc_sine_wave`: `d * sin(a * pi/32)` out of the cartridge's own table, as a
+## signed byte.
+func _sine_wave(phase: int, amplitude: int) -> int:
+	var index: int = phase & 0x3F
+	var negative: bool = index >= 0x20
+	if negative:
+		index &= 0x1F
+	var word: int = 0
+	if index * 2 + 1 < _sine.size():
+		word = int(_sine[index * 2]) | (int(_sine[index * 2 + 1]) << 8)
+	var value: int = ((word * amplitude) >> 8) & 0xFF
+	if negative:
+		value = (-value) & 0xFF
+	return value - 256 if value >= 128 else value
+
+
+## `StartTrainerBattle_SpinToBlack`, one wedge a step.
+func _spin_step() -> void:
+	if _counter >= SPIN_QUADRANTS.size():
+		_delay = SPIN_END_FRAMES
+		_finish()
+		return
+	var entry: Array = SPIN_QUADRANTS[_counter]
+	_draw_wedge(int(entry[0]), int(entry[1]), Vector2i(int(entry[2]), int(entry[3])))
+	_counter += 1
+	_delay = SPIN_STEP_FRAMES
+
+
+## `.load`: a run of cells blacked out along a row, then a step back and down
+## (or up), until the wedge's own `-1`. Which way each of those goes is the
+## quadrant's two bits.
+func _draw_wedge(quadrant: int, wedge: int, at: Vector2i) -> void:
+	var data: Array = WEDGES[wedge]
+	var right: bool = (quadrant & 1) != 0
+	var lower: bool = (quadrant & 2) != 0
+	var cursor: Vector2i = at
+	var index: int = 0
+	while index < data.size():
+		var run: int = int(data[index])
+		index += 1
+		var head: Vector2i = cursor
+		for _cell: int in run:
+			_write(cursor.x, cursor.y, CELL_BLACK)
+			cursor.x += 1 if right else -1
+		cursor = head
+		# `ld bc, SCREEN_WIDTH / jr z, .upper / ld bc, -SCREEN_WIDTH`: an upper
+		# quadrant's wedge grows down the screen and a lower one grows up it.
+		cursor.y += -1 if lower else 1
+		if index >= data.size():
+			return
+		var back: int = int(data[index])
+		index += 1
+		if back < 0:
+			return
+		cursor.x += (-back if right else back)
+
+
+## `StartTrainerBattle_SpeckleToBlack`: twelve tiles a frame, resampling a tile
+## that is already black rather than counting it.
+func _scatter_step() -> void:
+	if _counter <= 0:
+		_delay = SPIN_END_FRAMES
+		_finish()
+		return
+	_counter -= 1
+	for _tile: int in SCATTER_PER_FRAME:
+		var guard: int = 256
+		while guard > 0:
+			guard -= 1
+			var y: int = _rng.randi_range(0, ROWS - 1)
+			var x: int = _rng.randi_range(0, COLUMNS - 1)
+			if _cells[y * COLUMNS + x] == CELL_BLACK:
+				continue
+			_cells[y * COLUMNS + x] = CELL_BLACK
+			break
+
+
+## `StartTrainerBattle_ZoomToBlack`, one box a frame: its own loop spends a
+## `WaitBGMap` between them.
+func _zoom_step() -> void:
+	if _counter >= ZOOM_BOXES.size():
+		_finish()
+		return
+	var box: Array = ZOOM_BOXES[_counter]
+	for row: int in int(box[1]):
+		for column: int in int(box[0]):
+			_write(int(box[3]) + column, int(box[2]) + row, CELL_BLACK)
+	_counter += 1
+
+
+## `StartTrainerBattle_Finish`, and `DoBattleTransition.done` behind it: every
+## background palette is filled with zero, which is what takes whatever the
+## outro left to black.
+func _finish() -> void:
+	_delay = TAIL_FRAMES
+	_finished = true
+	_order = IDENTITY
+	_cells.fill(CELL_BLACK)
+
+
+func _write(x: int, y: int, value: int) -> void:
+	if x < 0 or x >= COLUMNS or y < 0 or y >= ROWS:
+		return
+	_cells[y * COLUMNS + x] = value

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -28,6 +28,15 @@ const CELL_BLACK: int = 2
 ## `%11100100`, the order that draws every colour as itself.
 const IDENTITY: int = 0xE4
 
+## Which map objects are still in OAM, which is the one thing the transition does
+## to the sprites over it. Nothing in the loop writes shadow OAM, so the sprites
+## `.InitGFX`'s `UpdateSprites` left stand over the wedges until each outro's own
+## setup runs `RespawnPlayerAndOpponent`, which hides every object but the player
+## and `hLastTalked`, and `StartTrainerBattle_Finish` runs `ClearSprites`.
+const SPRITES_ALL: int = 0
+const SPRITES_BATTLERS: int = 1
+const SPRITES_NONE: int = 2
+
 ## `ld a, [wBattleMonLevel] / add 3`: the lead has to be more than this far under
 ## the opponent for the stronger pair of animations.
 const STRONGER_MARGIN: int = 3
@@ -92,17 +101,23 @@ const WEDGES: Dictionary = {
 	4: [4, 1, 4, 0, 3, 1, 3, 0, 2, 1, 2, 0, 1, -1],
 	5: [4, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, -1],
 }
-## `ld c, 2 / DelayFrames` between wedges, and the three frames the walk spends
-## after the last one.
+## `ld c, 2 / DelayFrames` between wedges, and the three `DelayFrame`s
+## `.end` spends before it hands to `BATTLETRANSITION_FINISH`.
+## `StartTrainerBattle_SpeckleToBlack.done` spends the same three; the zoom and
+## the wavy outros hand on with none.
 const SPIN_STEP_FRAMES: int = 2
 const SPIN_END_FRAMES: int = 3
 
 ## `StartTrainerBattle_ZoomToBlack.boxes`: width, height and the top-left corner
-## of each, one `WaitBGMap` apart.
+## of each. The nine are one call rather than nine, with a `WaitBGMap` between
+## them: measured with `wEnvironment` forced to CAVE and the opponent above the
+## lead, the whole outro is the frames 96 to 132 of that trace and each box is
+## four of them.
 const ZOOM_BOXES: Array = [
 	[4, 2, 8, 8], [6, 4, 7, 7], [8, 6, 6, 6], [10, 8, 5, 5], [12, 10, 4, 4],
 	[14, 12, 3, 3], [16, 14, 2, 2], [18, 16, 1, 1], [20, 18, 0, 0],
 ]
+const ZOOM_BOX_FRAMES: int = 4
 
 ## `StartTrainerBattle_SetUpForRandomScatterOutro`'s `ld a, $10`, and the twelve
 ## tiles a frame of `..._SpeckleToBlack` blacks out.
@@ -110,13 +125,23 @@ const SCATTER_FRAMES: int = 0x10
 const SCATTER_PER_FRAME: int = 12
 
 ## `StartTrainerBattle_SineWave`'s own `cp $60`, and the two-scanline step its
-## loop walks the screen with.
+## `ld e, 0 / add 2` loop walks the screen with.
 const SINE_FRAMES: int = 0x60
 const SINE_STEP: int = 2
 const SCREEN_LINES: int = 144
 
-## The two frames `LoadPokeBallGraphics` spends before the next scene.
-const BALL_FRAMES: int = 2
+## What a `.DoSineWave` call costs. It writes all 144 `wLYOverrides` through
+## `calc_sine_wave`, whose multiply loop is longer the larger the amplitude, so
+## a call late in the outro spends more frames than an early one. Measured on the
+## same forced-CAVE trace: the fifteen working calls land on frames 97, 99, 101,
+## 103, 105, 107, 110, 113, 116, 119, 122, 125, 128, 131 and 135, the `cp $60`
+## that ends it on 138 and `..._Finish` on 139.
+const SINE_STEP_FRAMES: Array[int] = [2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3]
+
+## The three frames `LoadPokeBallGraphics` spends before the next scene: its own
+## `DelayFrame` and the two `BattleStart_CopyTilemapAtOnce` behind it costs. On
+## the Route 30 trace it runs on frame 813 and `..._SetUpBGMap` on 817.
+const BALL_FRAMES: int = 3
 
 ## `DoBattleTransition.InitGFX` before the jumptable, and `.done` after it.
 ##
@@ -125,13 +150,20 @@ const BALL_FRAMES: int = 2
 ## filled with, `BattleStart_CopyTilemapAtOnce`, and then the palette wipe at the
 ## end. The counts are measured against a real cartridge rather than derived,
 ## because a `WaitBGMap` is worth whatever the copy in front of it left.
+## `.InitGFX` is 19 frames on that trace, 793 to 811, and
+## `..._DetermineWhichAnimation` is the twentieth. The tail is
+## `StartTrainerBattle_Finish` on 959, the loop's own `DelayFrame` behind it and
+## `.done`'s two, which is the screen fully black on 962.
 const LEAD_FRAMES: int = 19
-const TAIL_FRAMES: int = 3
+const TAIL_FRAMES: int = 4
 
 var _scene: Array = []
 var _step: int = 0
 var _counter: int = 0
 var _sine_offset: int = 0
+## `ld d, [hl]`: the amplitude a frame's wave is drawn at is the counter as it
+## stood before that frame's own step.
+var _sine_amplitude: int = 0
 var _delay: int = 0
 ## Whether the scene that set [member _delay] had already handed on: a scene's
 ## own frames belong to it rather than to the one it hands to.
@@ -141,6 +173,7 @@ var _trainer: bool = false
 var _darkness: bool = false
 var _order: int = IDENTITY
 var _ball_drawn: bool = false
+var _sprites: int = SPRITES_ALL
 var _cells: PackedByteArray = PackedByteArray()
 var _sine: PackedByteArray = PackedByteArray()
 var _rng: RandomNumberGenerator = null
@@ -197,6 +230,12 @@ func ball_drawn() -> bool:
 	return _ball_drawn
 
 
+## Which map objects the sprites are still drawn from: one of [constant
+## SPRITES_ALL], [constant SPRITES_BATTLERS] and [constant SPRITES_NONE].
+func sprites() -> int:
+	return _sprites
+
+
 ## `wLYOverrides`, the per-scanline `rSCX` the wavy outro writes. Empty for the
 ## three that write none.
 func raster_offsets() -> PackedInt32Array:
@@ -204,9 +243,10 @@ func raster_offsets() -> PackedInt32Array:
 	if StringName(_scene[mini(_step, _scene.size() - 1)]) != &"sine" or _sine.is_empty():
 		return out
 	out.resize(SCREEN_LINES)
-	var amplitude: int = _counter
+	## `ld e, 0` before the loop: the phase is the scanline alone. The wave does
+	## not travel down the screen; only its amplitude grows.
 	for line: int in SCREEN_LINES:
-		out[line] = _sine_wave(_sine_offset + line * SINE_STEP, amplitude)
+		out[line] = _sine_wave(line * SINE_STEP, _sine_amplitude)
 	return out
 
 
@@ -244,23 +284,33 @@ func _run() -> void:
 		&"next":
 			_next()
 		&"wavy_setup":
+			_respawn()
 			_counter = 0
 			_sine_offset = 0
 			_next()
 		&"sine":
 			_sine_wave_step()
 		&"spin_setup":
+			_respawn()
 			_counter = 0
 			_next()
 		&"spin":
 			_spin_step()
 		&"scatter_setup":
+			_respawn()
 			_counter = SCATTER_FRAMES
 			_next()
 		&"scatter":
 			_scatter_step()
 		&"zoom":
+			_respawn()
 			_zoom_step()
+
+
+## `RespawnPlayerAndOpponent`, which every one of the four outros opens with:
+## `HideAllObjects`, then the player and, in a scripted battle, `hLastTalked`.
+func _respawn() -> void:
+	_sprites = SPRITES_BATTLERS
 
 
 func _next() -> void:
@@ -310,13 +360,18 @@ func _flash() -> void:
 
 
 ## `StartTrainerBattle_SineWave`, whose counter is the amplitude and whose
-## offset walks the phase.
+## offset is what steps it.
 func _sine_wave_step() -> void:
 	if _counter >= SINE_FRAMES:
 		_finish()
 		return
-	_sine_offset = (_sine_offset + 1) & 0xFF
+	## `ld a, [hl] / inc [hl]` reads the offset before incrementing it, so the
+	## counter is stepped by the old one: 0, 1, 3, 6, 10 and on up the triangular
+	## numbers, which is the run a real cartridge walks.
+	_sine_amplitude = _counter
 	_counter = (_counter + _sine_offset) & 0xFF
+	_sine_offset = (_sine_offset + 1) & 0xFF
+	_delay = SINE_STEP_FRAMES[mini(_sine_offset - 1, SINE_STEP_FRAMES.size() - 1)] - 1
 
 
 ## `calc_sine_wave`: `d * sin(a * pi/32)` out of the cartridge's own table, as a
@@ -407,14 +462,20 @@ func _zoom_step() -> void:
 		for column: int in int(box[0]):
 			_write(int(box[3]) + column, int(box[2]) + row, CELL_BLACK)
 	_counter += 1
+	_delay = ZOOM_BOX_FRAMES - 1
 
 
-## `StartTrainerBattle_Finish`, and `DoBattleTransition.done` behind it: every
-## background palette is filled with zero, which is what takes whatever the
-## outro left to black.
+## `StartTrainerBattle_Finish`, and `DoBattleTransition.done` behind it:
+## `ClearSprites` empties shadow OAM, and every background palette is filled with
+## zero, which is what takes whatever the outro left to black.
 func _finish() -> void:
-	_delay = TAIL_FRAMES
+	## Added rather than assigned: `..._SpinToBlack.end` and
+	## `..._SpeckleToBlack.done` each spend three `DelayFrame`s of their own
+	## before writing `BATTLETRANSITION_FINISH`, and those are the outro's frames
+	## rather than the tail's.
+	_delay += TAIL_FRAMES
 	_finished = true
+	_sprites = SPRITES_NONE
 	_order = IDENTITY
 	_cells.fill(CELL_BLACK)
 

--- a/game/battle/battle_transition.gd.uid
+++ b/game/battle/battle_transition.gd.uid
@@ -1,0 +1,1 @@
+uid://dllrl6krp1s0q

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -51,6 +51,7 @@ var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
 var _player_palettes: Dictionary = {}
+var _transition_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
 var _pokedex_palettes: Dictionary = {}
 var _pack: Dictionary = {}
@@ -133,6 +134,7 @@ static func open_directory(path: String) -> GameData:
 	data._tiles = manifest.get("tiles", {})
 	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._player_palettes = manifest.get("player_palettes", {})
+	data._transition_palettes = manifest.get("transition_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	data._pack = manifest.get("pack", {})
@@ -1991,6 +1993,19 @@ func player_palette(kind: String) -> PackedColorArray:
 		Gen2Palette.from_packed(int((stored as Array)[0])),
 		Gen2Palette.from_packed(int((stored as Array)[1])),
 	]))
+
+
+## `StartTrainerBattle_LoadPokeBallGraphics`' own palette, which every
+## background tile is drawn in while a trainer transition runs. The dark one is
+## `wTimeOfDayPal`'s `DARKNESS_F`.
+func battle_transition_palette(dark: bool = false) -> PackedColorArray:
+	var stored: Variant = _transition_palettes.get("dark" if dark else "day", null)
+	if not stored is Array or (stored as Array).size() < RomLayout.TRANSITION_PALETTE_COLORS:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	var out := PackedColorArray()
+	for packed: Variant in stored as Array:
+		out.append(Gen2Palette.from_packed(int(packed)))
+	return out
 
 
 func player_backpic(kind: String) -> Dictionary:

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -50,6 +50,7 @@ var _foresight_matchups: Dictionary = {}
 var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
+var _player_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
 var _pokedex_palettes: Dictionary = {}
 var _pack: Dictionary = {}
@@ -131,6 +132,7 @@ static func open_directory(path: String) -> GameData:
 	data._atlases = manifest.get("atlases", {})
 	data._tiles = manifest.get("tiles", {})
 	data._bar_palettes = manifest.get("bar_palettes", {})
+	data._player_palettes = manifest.get("player_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	data._pack = manifest.get("pack", {})
@@ -1974,6 +1976,33 @@ func trainer_dvs(number: int) -> int:
 
 ## Where a trainer class sits in the trainer atlas. Every trainer is drawn at the
 ## same size, so unlike a species pic this one always fills its cell.
+## `GetTrainerBackpic`: the player's own 6x6 picture, which is what stands on
+## the player's square until a Pokemon is sent out. [param kind] is one of
+## [constant RomLayout.PLAYER_BACKPICS]; Gold and Silver ship no Kris, and the
+## empty Dictionary is what says so.
+## `GetPlayerOrMonPalettePointer`: the player's own colours, which is what the
+## back pic on the field is drawn in until a Pokemon replaces it. The Dude wears
+## the player's, so [param kind] is a gender rather than a picture.
+func player_palette(kind: String) -> PackedColorArray:
+	var stored: Variant = _player_palettes.get(kind, null)
+	if not stored is Array or (stored as Array).size() < 2:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int((stored as Array)[0])),
+		Gen2Palette.from_packed(int((stored as Array)[1])),
+	]))
+
+
+func player_backpic(kind: String) -> Dictionary:
+	var slot: int = RomLayout.PLAYER_BACKPICS.find(kind)
+	if slot < 0:
+		return {}
+	var cell: int = int(atlas("player_back").get("cell", 0))
+	if cell <= 0:
+		return {}
+	return {"atlas": "player_back", "slot": slot, "width": cell, "height": cell}
+
+
 func trainer_pic(number: int) -> Dictionary:
 	var entry: Dictionary = trainer(number)
 	if entry.is_empty():

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -75,7 +75,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 69
+const FORMAT_VERSION: int = 70
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3912,6 +3912,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		},
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"player_palettes": _import_player_palettes(rom, layout),
+		"transition_palettes": _import_transition_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
 		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
 		"pc_palette": _import_pc_palette(rom, layout),
@@ -4467,6 +4468,23 @@ func _import_player_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 		out[RomLayout.PLAYER_PALETTE_NAMES[index]] = [
 			rom.u16le(entry), rom.u16le(entry + Gen2Palette.COLOR_BYTES),
 		]
+	return out
+
+
+## `StartTrainerBattle_LoadPokeBallGraphics.pals` and its `.darkpals`, four
+## colours each: the whole background is put on `PAL_BG_TEXT` and filled with
+## one of them, which is why a trainer transition turns the map red.
+func _import_transition_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("battle_transition", {}) as Dictionary
+	var out: Dictionary = {}
+	for index: int in RomLayout.TRANSITION_PALETTE_NAMES.size():
+		var at: int = int(entry.get("palette" if index == 0 else "dark_palette", -1))
+		if at < 0:
+			continue
+		var colors: Array = []
+		for color: int in RomLayout.TRANSITION_PALETTE_COLORS:
+			colors.append(rom.u16le(at + color * Gen2Palette.COLOR_BYTES))
+		out[RomLayout.TRANSITION_PALETTE_NAMES[index]] = colors
 	return out
 
 
@@ -5274,7 +5292,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 		},
 		## `BattleTransitionTiles`, the two `DoBattleTransition` wipes with.
 		"battle_transition": {
-			"offset": int(layout["battle_transition"]),
+			"offset": int((layout["battle_transition"] as Dictionary)["tiles"]),
 			"tiles": RomLayout.BATTLE_TRANSITION_TILES,
 			"first_code": 0,
 			"bits": 2,

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3911,6 +3911,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 			"tiles": int(battle_anims["gfx_tiles"]),
 		},
 		"bar_palettes": _import_bar_palettes(rom, layout),
+		"player_palettes": _import_player_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
 		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
 		"pc_palette": _import_pc_palette(rom, layout),
@@ -4452,6 +4453,23 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 
 ## The four colours a battle draws its bars in. Small enough to live in the
 ## manifest beside the atlas metadata rather than in a file of its own.
+## `GetPlayerOrMonPalettePointer`'s two: the colours the player's own back pic is
+## drawn in while it is standing on the field, before a Pokemon is sent out.
+##
+## They are the first two rows of `TrainerPalettes`, which the cartridge shares
+## with two trainer classes on purpose ("Chris uses the same colors as Cal",
+## "Kris shares Falkner's palette"), so they are read at the table rather than
+## through a class number.
+func _import_player_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for index: int in RomLayout.PLAYER_PALETTE_NAMES.size():
+		var entry: int = RomLayout.trainer_palette_offset(layout, index)
+		out[RomLayout.PLAYER_PALETTE_NAMES[index]] = [
+			rom.u16le(entry), rom.u16le(entry + Gen2Palette.COLOR_BYTES),
+		]
+	return out
+
+
 func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var out: Dictionary = {}
 	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
@@ -5246,6 +5264,21 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"first_code": 0,
 			"bits": 2,
 		},
+		## `LoadBallIconGFX`, the party balls `BattleStart_TrainerHuds` puts
+		## over both huds while a battle is opening.
+		"ball_icons": {
+			"offset": int(layout["ball_icons"]),
+			"tiles": RomLayout.BALL_ICON_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		## `BattleTransitionTiles`, the two `DoBattleTransition` wipes with.
+		"battle_transition": {
+			"offset": int(layout["battle_transition"]),
+			"tiles": RomLayout.BATTLE_TRANSITION_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
 		## `StatsScreenPageTilesGFX`, which the stats screen and the move
 		## screen both load at `vTiles2 tile $31`.
 		"stats_tiles": {
@@ -5574,6 +5607,28 @@ func _import_pics(
 	var unown_back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.UNOWN_FORMS)
 	var trainer_classes: int = RomLayout.trainer_class_count(layout)
 	var trainers: Dictionary = _new_atlas(RomLayout.TRAINER_PIC_TILES, trainer_classes)
+	# `GetTrainerBackpic`'s three, which are the player standing on the field
+	# before a Pokemon is sent out rather than anybody's front pic.
+	var player_back: Dictionary = _new_atlas(
+		RomLayout.PLAYER_BACKPIC_TILES, RomLayout.PLAYER_BACKPICS.size()
+	)
+	var backpics: Dictionary = layout.get("player_backpic", {}) as Dictionary
+	var side: int = RomLayout.PLAYER_BACKPIC_TILES
+	for slot: int in RomLayout.PLAYER_BACKPICS.size():
+		var kind: String = RomLayout.PLAYER_BACKPICS[slot]
+		var at: int = int(backpics.get(kind, -1))
+		if at < 0:
+			continue
+		# "Kris's backpic is uncompressed" (`GetKrisBackpic`): it is a plain
+		# 2bpp run where the other two are LZ behind `GetTrainerBackpic`'s own
+		# `.Decompress`. All three are stored column major, the way every pic is.
+		if kind == "kris":
+			_blit_pic(
+				rom.bytes().slice(at, at + side * side * Gen2Tiles.TILE_BYTES),
+				side, side, player_back, slot
+			)
+			continue
+		_decode_lz_into(rom, at, side, side, player_back, slot)
 
 	for entry: Dictionary in species:
 		var number: int = entry["number"]
@@ -5629,7 +5684,7 @@ func _import_pics(
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var atlases: Dictionary = {
 		"front": front, "back": back, "unown_front": unown_front, "unown_back": unown_back,
-		"trainers": trainers,
+		"trainers": trainers, "player_back": player_back,
 	}
 	var written: Dictionary = {}
 	for name: String in atlases:
@@ -5658,6 +5713,21 @@ func _new_atlas(cell_tiles: int, cells: int) -> Dictionary:
 	}
 
 
+## The same as [method _decode_into] for a pic the cartridge stores at an
+## address rather than behind a pointer, which is what `GetTrainerBackpic`'s
+## three `ld hl, ChrisBackpic` are.
+func _decode_lz_into(
+	rom: RomFile, start: int, columns: int, rows: int, atlas: Dictionary, slot: int
+) -> bool:
+	if columns <= 0 or rows <= 0 or not rom.in_bounds(start):
+		return false
+	var raw: PackedByteArray = _lz.decompress(rom.bytes(), start)
+	if _lz.failed or raw.size() < columns * rows * Gen2Tiles.TILE_BYTES:
+		return false
+	_blit_pic(raw, columns, rows, atlas, slot)
+	return true
+
+
 func _decode_into(
 	rom: RomFile,
 	layout: Dictionary,
@@ -5680,6 +5750,14 @@ func _decode_into(
 	if _lz.failed or raw.size() < columns * rows * Gen2Tiles.TILE_BYTES:
 		return false
 
+	_blit_pic(raw, columns, rows, atlas, slot)
+	return true
+
+
+## One decompressed pic into its cell of an atlas.
+func _blit_pic(
+	raw: PackedByteArray, columns: int, rows: int, atlas: Dictionary, slot: int
+) -> void:
 	var pixels: PackedByteArray = Gen2Tiles.decode_pic(raw, columns, rows)
 	var cell: int = atlas["cell"]
 	Gen2Tiles.blit(
@@ -5688,4 +5766,3 @@ func _decode_into(
 		(slot % ATLAS_COLUMNS) * cell, floori(float(slot) / float(ATLAS_COLUMNS)) * cell
 	)
 	atlas["decoded"] = int(atlas["decoded"]) + 1
-	return true

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -604,6 +604,21 @@ const ENEMY_HUD_TILES: int = 4
 const PLAYER_HUD_TILES: int = 6
 const EXP_BAR_TILES: int = 9
 
+## `LoadBallIconGFX`'s own `.gfx`, four sprite tiles at `vTiles0 tile $31`:
+## a live Pokemon, a statused one, a fainted one and an empty party slot, which
+## `StageBallTilesData` picks between with `$31` to `$34`.
+const BALL_ICON_TILES: int = 4
+const BALL_ICON_FIRST_TILE: int = 0x31
+## `BattleTransitionTiles`, the two `DoBattleTransition` fills the screen with.
+const BATTLE_TRANSITION_TILES: int = 2
+## `GetTrainerBackpic`: the player's own 6x6 picture, the one standing on the
+## field before a Pokemon is sent out. Three of them, and the order here is the
+## order [constant PLAYER_BACKPICS] names.
+const PLAYER_BACKPIC_TILES: int = 6
+const PLAYER_BACKPICS: Array[String] = ["chris", "kris", "dude"]
+## The two palettes those three are drawn in: the Dude wears the player's own.
+const PLAYER_PALETTE_NAMES: Array[String] = ["chris", "kris"]
+
 ## `StatsScreenPageTilesGFX`, the seventeen tiles `LoadStatsScreenPageTilesGFX`
 ## puts at `vTiles2 tile $31`: the vertical divider, the page indicator squares,
 ## the exp bar's two end caps and `'⁂'`, which `constants/charmap.asm` names as
@@ -1667,6 +1682,13 @@ const GOLD_SILVER: Dictionary = {
 	"enemy_hud": 0xF8BB2,
 	"player_hud": 0xF8BD2,
 	"exp_bar": 0xF8C02,
+	# `LoadBallIconGFX`'s four ball icons and `BattleTransitionTiles`' two, both
+	# uncompressed 2bpp runs read straight off the address.
+	"ball_icons": 0x2C1A4,
+	"battle_transition": 0x8C5B3,
+	# `GetTrainerBackpic`'s pics, LZ at the address rather than behind a
+	# pointer. Gold and Silver have one player character, so there is no Kris.
+	"player_backpic": {"chris": 0x3F9CB, "kris": -1, "dude": 0x3FB5B},
 	# Trainer card. Located by converting the pinned gfx/trainer_card PNGs and
 	# matching the bytes in the cartridge; the run is contiguous and
 	# self-consistent, status running straight into the two leader copies and
@@ -2103,6 +2125,10 @@ const CRYSTAL: Dictionary = {
 	"enemy_hud": 0xF8AC0,
 	"player_hud": 0xF8AE0,
 	"exp_bar": 0xF8B10,
+	# See the Gold and Silver block above.
+	"ball_icons": 0x2C172,
+	"battle_transition": 0x8C2F4,
+	"player_backpic": {"chris": 0x2BA1A, "kris": 0x88ED6, "dude": 0x2BBAA},
 	# Trainer card; see the Gold and Silver block above for how these were
 	# located. Crystal splits the card pic in two by gender and stores both
 	# column-major, and adds the one-tile right corner Gold and Silver lack.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -609,8 +609,11 @@ const EXP_BAR_TILES: int = 9
 ## `StageBallTilesData` picks between with `$31` to `$34`.
 const BALL_ICON_TILES: int = 4
 const BALL_ICON_FIRST_TILE: int = 0x31
-## `BattleTransitionTiles`, the two `DoBattleTransition` fills the screen with.
+## `BattleTransitionTiles`, the two `DoBattleTransition` fills the screen with,
+## and the two four-colour palettes it draws them and the whole map in.
 const BATTLE_TRANSITION_TILES: int = 2
+const TRANSITION_PALETTE_NAMES: Array[String] = ["day", "dark"]
+const TRANSITION_PALETTE_COLORS: int = 4
 ## `GetTrainerBackpic`: the player's own 6x6 picture, the one standing on the
 ## field before a Pokemon is sent out. Three of them, and the order here is the
 ## order [constant PLAYER_BACKPICS] names.
@@ -1685,7 +1688,11 @@ const GOLD_SILVER: Dictionary = {
 	# `LoadBallIconGFX`'s four ball icons and `BattleTransitionTiles`' two, both
 	# uncompressed 2bpp runs read straight off the address.
 	"ball_icons": 0x2C1A4,
-	"battle_transition": 0x8C5B3,
+	# `BattleTransitionTiles` and the two palettes `LoadPokeBallGraphics` floods
+	# every background tile with, the second of which is the darkness palset's.
+	"battle_transition": {
+		"tiles": 0x8C5B3, "palette": 0x8C960, "dark_palette": 0x8C968,
+	},
 	# `GetTrainerBackpic`'s pics, LZ at the address rather than behind a
 	# pointer. Gold and Silver have one player character, so there is no Kris.
 	"player_backpic": {"chris": 0x3F9CB, "kris": -1, "dude": 0x3FB5B},
@@ -2127,7 +2134,9 @@ const CRYSTAL: Dictionary = {
 	"exp_bar": 0xF8B10,
 	# See the Gold and Silver block above.
 	"ball_icons": 0x2C172,
-	"battle_transition": 0x8C2F4,
+	"battle_transition": {
+		"tiles": 0x8C2F4, "palette": 0x8C6A1, "dark_palette": 0x8C6A9,
+	},
 	"player_backpic": {"chris": 0x2BA1A, "kris": 0x88ED6, "dude": 0x2BBAA},
 	# Trainer card; see the Gold and Silver block above for how these were
 	# located. Crystal splits the card pic in two by gender and stores both

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1704,8 +1704,14 @@ const ENVIRONMENT_TOWN: int = 1
 const ENVIRONMENT_ROUTE: int = 2
 const ENVIRONMENT_INDOOR: int = 3
 const ENVIRONMENT_CAVE: int = 4
+const ENVIRONMENT_5: int = 5
 const ENVIRONMENT_GATE: int = 6
 const ENVIRONMENT_DUNGEON: int = 7
+## The three `StartTrainerBattle_DetermineWhichAnimation` calls a cave, which is
+## what puts a battle on the flash-and-wave transition rather than the spin.
+const CAVE_ENVIRONMENTS: Array[int] = [
+	ENVIRONMENT_CAVE, ENVIRONMENT_5, ENVIRONMENT_DUNGEON,
+]
 
 ## `TILESET_POKECENTER` and `TILESET_POKECOM_CENTER`, the two `.SetSpawn`
 ## respawns in. The second is Crystal's alone and its number is past the split,

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -70,6 +70,7 @@ const HEAL_MACHINE_FLASHES: int = 8
 ## grass and for `.OAMData_Tree`.
 const PAL_OW_EMOTE: int = 5
 const PAL_OW_TREE: int = 6
+const PAL_OW_ROCK: int = 7
 
 ## ShakeHeadbuttTree's `ld a, 32 / ld [wFrameCounter], a`, and OWCutAnimation's
 ## own, which both branches of its jumptable write.

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -8,6 +8,17 @@ extends Node2D
 const PLAYER_COLOR: Color = Color("#d34a5a")
 const FALLBACK_BACKGROUND: Color = Color("#f5f1d8")
 
+## `.InitSprite` (engine/overworld/map_objects.asm) writes an object's OAM y as
+## `add OAM_Y_OFS - 4` against a plain `add OAM_X_OFS` on the other axis, so a
+## 16x16 overworld sprite stands four pixels above its own cell and nothing
+## shifts it sideways. Every map object shares the one write: the emote, the
+## shadow, the boulder dust and the shaking grass are tracking objects that copy
+## the tracked object's `OBJECT_SPRITE_Y` and go through it too, and the jump
+## arc, the tracking bob and the fishing rod are offsets added in front of it.
+## The tuft of grass over a sprite's legs is background rather than OAM and takes
+## no lift; it moves with the sprite because OAM_PRIO is what draws it.
+const SPRITE_LIFT := Vector2(0, -4)
+
 var _world: Gen2WorldAPI = null
 var _animation: Gen2WorldAnimation = null
 var _effects: Gen2WorldEffects = null
@@ -434,7 +445,8 @@ func _draw() -> void:
 			continue
 		var object: Gen2WorldObject = entry["object"]
 		var pixel: Vector2 = Vector2(object.cell * Gen2WorldAPI.CELL_PIXELS) \
-			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS)) - camera_pixels
+			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS)) - camera_pixels \
+			+ SPRITE_LIFT
 		var texture: Texture2D = _actor_texture(
 			object.sprite, object.palette, object.facing, object.frame, object.big_object_shape()
 		)
@@ -450,7 +462,7 @@ func _draw() -> void:
 		if not battlers_only:
 			_draw_effect_sprites(object.index, pixel)
 
-	var player: Vector2 = Vector2(_world.player_pixel_position())
+	var player: Vector2 = Vector2(_world.player_pixel_position()) + SPRITE_LIFT
 	## The jump arc is a sprite offset, not a position: the shadow and the grass
 	## the hop leaves behind stay on the ground.
 	var jump: Vector2 = Vector2(0, _world.player_jump_offset())
@@ -474,7 +486,8 @@ func _draw() -> void:
 	_draw_effect_sprites(-1, player)
 	## The tree sprite stands over its own cell rather than over an object, and
 	## the source draws every one of these from `wShadowOAMSprite36` up, which is
-	## past every map object.
+	## past every map object. `Cut_Headbutt_GetPixelFacing` is a sprite anim
+	## rather than a map object, so it takes no lift.
 	for sprite: Dictionary in _effect_sprites():
 		if int(sprite["object_index"]) != -2:
 			continue
@@ -546,7 +559,8 @@ func _draw_actor(
 	tile_origin: Vector2i, tile_offset: Vector2, window_size: Vector2i
 ) -> void:
 	var cell_position: Vector2 = sprite["position_cells"]
-	var pixel: Vector2 = cell_position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels
+	var pixel: Vector2 = cell_position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels \
+		+ SPRITE_LIFT
 	var texture: Texture2D = _actor_texture(
 		sprite["sprite"], 0, int(sprite["facing"]), int(sprite["frame"]),
 		Gen2WorldSprite.BIG_SHAPE_NONE, sprite.get("colors", PackedColorArray())

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -40,17 +40,30 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 	queue_redraw()
 
 
-## Gen2ModHost.RENDERER_EFFECTS_METHOD: the emote bubbles, boulder dust, grass
-## rustle and headbutt tree this view draws over the map. Presentation only, so a
-## renderer may be handed null and draw none of them.
 ## `DoBattleTransition`'s own screen: the cells it has written, the two tiles it
 ## draws them with and the palette it floods the map with, or an empty one when
 ## it floods nothing.
 var _transition_cells: PackedByteArray = PackedByteArray()
 var _transition_tiles: PackedByteArray = PackedByteArray()
 var _transition_palette: PackedColorArray = PackedColorArray()
+## Which map objects the transition has left in OAM, and which of them is the
+## opponent `RespawnPlayerAndOpponent` keeps beside the player.
+var _transition_sprites: int = Gen2BattleTransition.SPRITES_ALL
+var _transition_opponent: int = -1
+## `StartTrainerBattle_Flash` writes `wBGP` and calls `DmgToCgbBGPals` alone, so
+## the three flash passes are a background order and the sprites over them keep
+## their own colours. The map fade is the other shape and goes through
+## [method set_fade], which is both.
+var _transition_order: int = Gen2BattleTransition.IDENTITY
+## The one patterned tile of the pair, cached rather than drawn pixel by pixel:
+## the transition is redrawn once for the screen and again over the lower half of
+## every sprite standing in grass.
+var _transition_textures: Dictionary = {}
 
 
+## Gen2ModHost.RENDERER_EFFECTS_METHOD: the emote bubbles, boulder dust, grass
+## rustle and headbutt tree this view draws over the map. Presentation only, so a
+## renderer may be handed null and draw none of them.
 func set_effects(effects: Gen2WorldEffects) -> void:
 	_effects = effects
 	queue_redraw()
@@ -153,16 +166,28 @@ func _rebuild_atlas() -> void:
 	_priority_atlas = null
 
 
+## The one palette `.pal_loop` puts every background tile on, through whatever
+## order the flash is on. Empty when the transition floods nothing, which is
+## every wild battle: those wedges take the palette their own cell was drawn in.
+func flood_palette() -> PackedColorArray:
+	if _transition_palette.is_empty():
+		return PackedColorArray()
+	return Gen2WorldPalette.fade_palette(
+		Gen2WorldPalette.fade_palette(_transition_palette, _fade_order), _transition_order
+	)
+
+
 func _tile_palettes() -> Array:
 	## `StartTrainerBattle_LoadPokeBallGraphics.pal_loop` puts every background
 	## tile on `PAL_BG_TEXT` and fills that one palette, which is why a trainer
 	## transition draws the whole map in four colours.
 	if not _transition_palette.is_empty():
 		var flooded: Array = []
+		var flood: PackedColorArray = flood_palette()
 		for _tile: int in _world.current_tileset.tile_count:
-			flooded.append(Gen2WorldPalette.fade_palette(_transition_palette, _fade_order))
+			flooded.append(flood)
 		return flooded
-	return Gen2WorldPalette.tile_palettes(
+	var rows: Array = Gen2WorldPalette.tile_palettes(
 		_world.data,
 		_world.current_map,
 		_world.current_tileset,
@@ -172,6 +197,12 @@ func _tile_palettes() -> Array:
 		_fade_order,
 		_fade_white_fill,
 	)
+	if _transition_order == Gen2BattleTransition.IDENTITY:
+		return rows
+	var faded: Array = []
+	for row: PackedColorArray in rows:
+		faded.append(Gen2WorldPalette.fade_palette(row, _transition_order))
+	return faded
 
 
 ## One tile of the strip, coloured. Index 0 is a colour here rather than a hole:
@@ -197,16 +228,28 @@ func _paint_tile(image: Image, indices: PackedByteArray, palettes: Array, tile: 
 ## tiles `LoadBattleTransitionGFX` loads as index buffers, and [param palette]
 ## the four colours the whole map is flooded with while a trainer's ball is up.
 ## An empty palette is the wild branch, which floods nothing: its black tile is
-## colour 3 of whatever palette the cell under it was already drawn in, and that
-## is why the wedges are dark green over grass rather than black.
+## colour 3 of whatever palette the cell under it was already drawn in. Every
+## overworld palette's colour 3 is `gfx/overworld/trainer_battle.pal`'s own
+## (7,7,7), so both kinds of wedge come out the same dark grey.
+##
+## [param sprites] is [method Gen2BattleTransition.sprites] and [param opponent]
+## the map object `hLastTalked` names; [param order] is the flash's `wBGP`, which
+## `DmgToCgbBGPals` applies to the background alone.
 func set_transition(
-	cells: PackedByteArray, tiles: PackedByteArray, palette: PackedColorArray
+	cells: PackedByteArray, tiles: PackedByteArray, palette: PackedColorArray,
+	sprites: int = Gen2BattleTransition.SPRITES_ALL, opponent: int = -1,
+	order: int = Gen2BattleTransition.IDENTITY
 ) -> void:
 	var was: PackedColorArray = _transition_palette
+	var was_order: int = _transition_order
 	_transition_cells = cells
 	_transition_tiles = tiles
 	_transition_palette = palette
-	if palette != was:
+	_transition_sprites = sprites
+	_transition_opponent = opponent
+	_transition_order = order
+	if palette != was or order != was_order:
+		_transition_textures.clear()
 		_actor_textures.clear()
 		_effect_textures.clear()
 		_anim_textures.clear()
@@ -221,6 +264,12 @@ func clear_transition() -> void:
 	_transition_cells = PackedByteArray()
 	_transition_tiles = PackedByteArray()
 	_transition_palette = PackedColorArray()
+	_transition_sprites = Gen2BattleTransition.SPRITES_ALL
+	_transition_opponent = -1
+	_transition_textures.clear()
+	if _transition_order != Gen2BattleTransition.IDENTITY:
+		_transition_order = Gen2BattleTransition.IDENTITY
+		was_flooding = true
 	if was_flooding:
 		_actor_textures.clear()
 		_effect_textures.clear()
@@ -229,40 +278,84 @@ func clear_transition() -> void:
 	queue_redraw()
 
 
-## The transition's own cells, over the map and over everything standing on it.
-## `wTilemap` is one plane, so a wedge covers an NPC the way it covers a tree.
-func _draw_transition(page: PackedInt32Array, palettes: Array, window: Vector2i) -> void:
+## The transition's own cells. `wTilemap` is the background, and OAM draws over
+## the background, so these go under every sprite: the player and the NPCs stay
+## on top of the wedges until `StartTrainerBattle_Finish` takes them away.
+##
+## [param clip] is the rectangle to draw inside, and [param priority] the
+## OAM_PRIO pass a sprite standing in grass wants: colour 0 loses that test, so
+## it is left transparent there and drawn like any other colour here.
+func _draw_transition(
+	page: PackedInt32Array, palettes: Array, window: Vector2i,
+	clip: Rect2 = Rect2(), priority: bool = false
+) -> void:
 	var black: int = Gen2BattleTransition.CELL_BLACK
-	for y: int in Gen2BattleTransition.ROWS:
-		for x: int in Gen2BattleTransition.COLUMNS:
+	var flood: PackedColorArray = flood_palette()
+	## The whole screen, or the few cells a sprite's own lower half falls in.
+	var first := Vector2i.ZERO
+	var last := Vector2i(Gen2BattleTransition.COLUMNS - 1, Gen2BattleTransition.ROWS - 1)
+	if priority:
+		first = Vector2i(
+			floori(clip.position.x / Gen2Tiles.TILE_WIDTH),
+			floori(clip.position.y / Gen2Tiles.TILE_HEIGHT),
+		)
+		last = Vector2i(
+			mini(ceili(clip.end.x / Gen2Tiles.TILE_WIDTH), last.x),
+			mini(ceili(clip.end.y / Gen2Tiles.TILE_HEIGHT), last.y),
+		)
+	for y: int in range(maxi(first.y, 0), last.y + 1):
+		for x: int in range(maxi(first.x, 0), last.x + 1):
 			var cell: int = int(_transition_cells[y * Gen2BattleTransition.COLUMNS + x])
 			if cell == Gen2BattleTransition.CELL_NONE:
 				continue
-			var palette: PackedColorArray = _transition_palette
-			if palette.is_empty():
-				var tile: int = page[y * window.x + x] if y * window.x + x < page.size() else 0
-				palette = palettes[tile] if tile >= 0 and tile < palettes.size() \
-					else PackedColorArray()
 			var at := Rect2(
 				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT),
 				Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT)
 			)
-			if cell == black or _transition_tiles.is_empty():
-				draw_rect(at, palette[3] if palette.size() > 3 else Color.BLACK, true)
+			var covered: Rect2 = at if not priority else at.intersection(clip)
+			if covered.size.x <= 0.0 or covered.size.y <= 0.0:
 				continue
-			_draw_transition_square(at, palette)
+			var palette: PackedColorArray = flood
+			if palette.is_empty():
+				var tile: int = page[y * window.x + x] if y * window.x + x < page.size() else 0
+				palette = palettes[tile] if tile >= 0 and tile < palettes.size() \
+					else PackedColorArray()
+			if cell == black or _transition_tiles.is_empty():
+				draw_rect(covered, palette[3] if palette.size() > 3 else Color.BLACK, true)
+				continue
+			var texture: Texture2D = _transition_texture(palette, priority)
+			if texture == null:
+				continue
+			draw_texture_rect_region(
+				texture, covered, Rect2(covered.position - at.position, covered.size)
+			)
 
 
 ## `BATTLETRANSITION_SQUARE`, the one tile of the pair that has a pattern in it.
-func _draw_transition_square(at: Rect2, palette: PackedColorArray) -> void:
+## [param transparent_zero] is the OAM_PRIO pass, where the tile's colour 0
+## pixels lose to the sprite under them.
+func _transition_texture(
+	palette: PackedColorArray, transparent_zero: bool
+) -> Texture2D:
+	if _transition_tiles.size() < Gen2Tiles.TILE_PIXELS:
+		return null
+	var key: String = "%d:%d" % [hash(palette), int(transparent_zero)]
+	var texture: Texture2D = _transition_textures.get(key, null)
+	if texture != null:
+		return texture
+	var image := Image.create(
+		Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT, false, Image.FORMAT_RGBA8
+	)
 	for y: int in Gen2Tiles.TILE_HEIGHT:
 		for x: int in Gen2Tiles.TILE_WIDTH:
 			var index: int = int(_transition_tiles[y * Gen2Tiles.TILE_WIDTH + x])
-			draw_rect(
-				Rect2(at.position + Vector2(x, y), Vector2.ONE),
-				palette[index] if index < palette.size() else Color.BLACK,
-				true
-			)
+			var color: Color = palette[index] if index < palette.size() else Color.BLACK
+			if index == 0 and transparent_zero:
+				color.a = 0.0
+			image.set_pixel(x, y, color)
+	texture = ImageTexture.create_from_image(image)
+	_transition_textures[key] = texture
+	return texture
 
 
 func refresh() -> void:
@@ -306,22 +399,38 @@ func _draw() -> void:
 				Rect2(Vector2(tile * Gen2Tiles.TILE_WIDTH, 0), Vector2(8, 8)),
 			)
 
+	var palettes: Array = _tile_palettes()
+	if not _transition_cells.is_empty():
+		_draw_transition(page, palettes, window_size)
+	if _transition_sprites == Gen2BattleTransition.SPRITES_NONE:
+		return
+
 	var objects: Array = _world.visible_objects()
 	objects.sort_custom(_sort_objects)
+	## `RespawnPlayerAndOpponent` at each outro's setup: from there the only map
+	## objects left in OAM are the player and, in a scripted battle, whoever
+	## `hLastTalked` names.
+	var battlers_only: bool = _transition_sprites == Gen2BattleTransition.SPRITES_BATTLERS
 	## A mod's actors are drawn in the same pass and sorted into the same rows:
 	## a follower one cell below an NPC has to be drawn over it, and one cell
 	## above it under it. They carry no emote, no effect sprite and no grass of
-	## their own beyond the tuft the map draws over anything standing in it.
+	## their own beyond the tuft the map draws over anything standing in it, and
+	## they are map objects here, so the respawn takes them with the rest.
 	var drawn: Array = []
 	for object: Gen2WorldObject in objects:
+		if battlers_only and object.index != _transition_opponent:
+			continue
 		drawn.append({"object": object, "row": float(object.cell.y)})
-	if _actors != null:
+	if _actors != null and not battlers_only:
 		for sprite: Dictionary in _actors.sprites():
 			drawn.append({"actor": sprite, "row": (sprite["position_cells"] as Vector2).y})
 	drawn.sort_custom(_sort_drawn)
 	for entry: Dictionary in drawn:
 		if entry.has("actor"):
-			_draw_actor(entry["actor"], camera_pixels, page, tile_origin, tile_offset, window_size)
+			_draw_actor(
+				entry["actor"], camera_pixels, page, palettes, tile_origin, tile_offset,
+				window_size
+			)
 			continue
 		var object: Gen2WorldObject = entry["object"]
 		var pixel: Vector2 = Vector2(object.cell * Gen2WorldAPI.CELL_PIXELS) \
@@ -335,10 +444,11 @@ func _draw() -> void:
 		if texture != null:
 			draw_texture(texture, pixel + object_jump)
 		if _in_grass(object.cell):
-			_draw_grass_over(pixel, page, tile_origin, tile_offset, window_size)
+			_draw_grass_over(pixel, page, palettes, tile_origin, tile_offset, window_size)
 		if object.emote_visible:
 			_draw_emote(object.emote_id, pixel)
-		_draw_effect_sprites(object.index, pixel)
+		if not battlers_only:
+			_draw_effect_sprites(object.index, pixel)
 
 	var player: Vector2 = Vector2(_world.player_pixel_position())
 	## The jump arc is a sprite offset, not a position: the shadow and the grass
@@ -351,7 +461,7 @@ func _draw() -> void:
 	if player_texture != null:
 		draw_texture(player_texture, player + jump)
 		if _in_grass(_world.player_cell):
-			_draw_grass_over(player + jump, page, tile_origin, tile_offset, window_size)
+			_draw_grass_over(player + jump, page, palettes, tile_origin, tile_offset, window_size)
 		if _world.fishing_busy():
 			_draw_fishing_rod(player + jump)
 	else:
@@ -359,6 +469,8 @@ func _draw() -> void:
 		draw_rect(marker, PLAYER_COLOR, false, 1.0)
 		draw_line(marker.position, marker.end, PLAYER_COLOR, 1.0)
 		draw_line(Vector2(marker.end.x, marker.position.y), Vector2(marker.position.x, marker.end.y), PLAYER_COLOR, 1.0)
+	if battlers_only:
+		return
 	_draw_effect_sprites(-1, player)
 	## The tree sprite stands over its own cell rather than over an object, and
 	## the source draws every one of these from `wShadowOAMSprite36` up, which is
@@ -376,10 +488,17 @@ func _draw() -> void:
 		if bool(sprite.get("screen", false)):
 			_draw_effect_sprite(sprite, Vector2.ZERO)
 	_draw_encounter_pulse(camera_pixels)
-	## Last, over the map and over everything standing on it: `wTilemap` is one
-	## plane and a wedge covers an NPC the way it covers a tree.
-	if not _transition_cells.is_empty():
-		_draw_transition(page, _tile_palettes(), window_size)
+
+
+## `StartTrainerBattle_LoadPokeBallGraphics.copypals` writes the trainer palette
+## over `wOBPals1/2 palette PAL_OW_TREE` and `PAL_OW_ROCK` as well as
+## `PAL_BG_TEXT`, so a boulder or a fruit tree standing on the map turns with the
+## background it is standing on.
+func _sprite_palette(palette: int) -> PackedColorArray:
+	if not _transition_palette.is_empty() \
+		and palette in [Gen2WorldEffects.PAL_OW_TREE, Gen2WorldEffects.PAL_OW_ROCK]:
+		return _transition_palette
+	return _world.data.overworld_sprite_palette(palette, _time_of_day)
 
 
 func _actor_texture(
@@ -408,7 +527,7 @@ func _actor_texture(
 	## is background only, so a sprite flattens onto its own colour 0.
 	var colors: PackedColorArray = Gen2WorldPalette.fade_palette(
 		color_override if not color_override.is_empty() \
-			else _world.data.overworld_sprite_palette(palette, _time_of_day),
+			else _sprite_palette(palette),
 		_fade_order,
 	)
 	var image: Image = Gen2WorldSprite.big_image_for(sprite, indices, colors, big_shape) \
@@ -423,7 +542,7 @@ func _actor_texture(
 ## it. Its position is in walk cells, the unit `player_position_cells()` is in,
 ## so a follower halfway through a step is drawn halfway.
 func _draw_actor(
-	sprite: Dictionary, camera_pixels: Vector2, page: PackedInt32Array,
+	sprite: Dictionary, camera_pixels: Vector2, page: PackedInt32Array, palettes: Array,
 	tile_origin: Vector2i, tile_offset: Vector2, window_size: Vector2i
 ) -> void:
 	var cell_position: Vector2 = sprite["position_cells"]
@@ -436,7 +555,7 @@ func _draw_actor(
 		return
 	draw_texture(texture, pixel)
 	if _in_grass(Vector2i(roundi(cell_position.x), roundi(cell_position.y))):
-		_draw_grass_over(pixel, page, tile_origin, tile_offset, window_size)
+		_draw_grass_over(pixel, page, palettes, tile_origin, tile_offset, window_size)
 
 
 ## The object pass's own order, with a mod's actors sorted into it: the row a
@@ -487,6 +606,7 @@ func _in_grass(cell: Vector2i) -> bool:
 func _draw_grass_over(
 	pixel: Vector2,
 	page: PackedInt32Array,
+	palettes: Array,
 	_tile_origin: Vector2i,
 	tile_offset: Vector2,
 	window_size: Vector2i,
@@ -511,14 +631,53 @@ func _draw_grass_over(
 			var tile: int = page[y * window_size.x + x]
 			if tile < 0 or tile >= _world.current_tileset.tile_count:
 				continue
-			draw_texture_rect_region(
-				_priority_atlas,
-				covered,
-				Rect2(
-					Vector2(tile * Gen2Tiles.TILE_WIDTH, 0) + (covered.position - at.position),
-					covered.size,
-				),
-			)
+			for piece: Rect2 in _priority_pieces(covered):
+				draw_texture_rect_region(
+					_priority_atlas,
+					piece,
+					Rect2(
+						Vector2(tile * Gen2Tiles.TILE_WIDTH, 0) + (piece.position - at.position),
+						piece.size,
+					),
+				)
+	## The transition has already overwritten the map under the sprite, so what
+	## wins the priority test where it wrote is its own tile rather than the
+	## grass. The pieces above left those cells to it.
+	if not _transition_cells.is_empty():
+		_draw_transition(page, palettes, window_size, over, true)
+
+
+## The parts of [param rect] the map still owns, split on the screen's own
+## 8-pixel grid so a cell `DoBattleTransition` has written is left to it.
+func _priority_pieces(rect: Rect2) -> Array[Rect2]:
+	if _transition_cells.is_empty():
+		return [rect] as Array[Rect2]
+	var out: Array[Rect2] = []
+	var top: float = rect.position.y
+	while top < rect.end.y:
+		var bottom: float = minf(floorf(top / Gen2Tiles.TILE_HEIGHT) * Gen2Tiles.TILE_HEIGHT \
+			+ Gen2Tiles.TILE_HEIGHT, rect.end.y)
+		var left: float = rect.position.x
+		while left < rect.end.x:
+			var right: float = minf(floorf(left / Gen2Tiles.TILE_WIDTH) * Gen2Tiles.TILE_WIDTH \
+				+ Gen2Tiles.TILE_WIDTH, rect.end.x)
+			if not _transition_wrote(Vector2(left, top)):
+				out.append(Rect2(Vector2(left, top), Vector2(right - left, bottom - top)))
+			left = right
+		top = bottom
+	return out
+
+
+## Whether the transition has taken the screen cell [param at] falls in.
+func _transition_wrote(at: Vector2) -> bool:
+	var x: int = floori(at.x / Gen2Tiles.TILE_WIDTH)
+	var y: int = floori(at.y / Gen2Tiles.TILE_HEIGHT)
+	if x < 0 or x >= Gen2BattleTransition.COLUMNS \
+		or y < 0 or y >= Gen2BattleTransition.ROWS:
+		return false
+	var index: int = y * Gen2BattleTransition.COLUMNS + x
+	return index < _transition_cells.size() \
+		and int(_transition_cells[index]) != Gen2BattleTransition.CELL_NONE
 
 
 ## The same strip as the atlas with the cartridge's transparent index left out,

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -43,6 +43,14 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 ## Gen2ModHost.RENDERER_EFFECTS_METHOD: the emote bubbles, boulder dust, grass
 ## rustle and headbutt tree this view draws over the map. Presentation only, so a
 ## renderer may be handed null and draw none of them.
+## `DoBattleTransition`'s own screen: the cells it has written, the two tiles it
+## draws them with and the palette it floods the map with, or an empty one when
+## it floods nothing.
+var _transition_cells: PackedByteArray = PackedByteArray()
+var _transition_tiles: PackedByteArray = PackedByteArray()
+var _transition_palette: PackedColorArray = PackedColorArray()
+
+
 func set_effects(effects: Gen2WorldEffects) -> void:
 	_effects = effects
 	queue_redraw()
@@ -146,6 +154,14 @@ func _rebuild_atlas() -> void:
 
 
 func _tile_palettes() -> Array:
+	## `StartTrainerBattle_LoadPokeBallGraphics.pal_loop` puts every background
+	## tile on `PAL_BG_TEXT` and fills that one palette, which is why a trainer
+	## transition draws the whole map in four colours.
+	if not _transition_palette.is_empty():
+		var flooded: Array = []
+		for _tile: int in _world.current_tileset.tile_count:
+			flooded.append(Gen2WorldPalette.fade_palette(_transition_palette, _fade_order))
+		return flooded
 	return Gen2WorldPalette.tile_palettes(
 		_world.data,
 		_world.current_map,
@@ -172,6 +188,80 @@ func _paint_tile(image: Image, indices: PackedByteArray, palettes: Array, tile: 
 			image.set_pixel(
 				left + x, y,
 				palette[color_index] if color_index < palette.size() else _background_color
+			)
+
+
+## `DoBattleTransition`, drawn over whatever the map was already showing.
+##
+## [param cells] is [method Gen2BattleTransition.cells], [param tiles] the two
+## tiles `LoadBattleTransitionGFX` loads as index buffers, and [param palette]
+## the four colours the whole map is flooded with while a trainer's ball is up.
+## An empty palette is the wild branch, which floods nothing: its black tile is
+## colour 3 of whatever palette the cell under it was already drawn in, and that
+## is why the wedges are dark green over grass rather than black.
+func set_transition(
+	cells: PackedByteArray, tiles: PackedByteArray, palette: PackedColorArray
+) -> void:
+	var was: PackedColorArray = _transition_palette
+	_transition_cells = cells
+	_transition_tiles = tiles
+	_transition_palette = palette
+	if palette != was:
+		_actor_textures.clear()
+		_effect_textures.clear()
+		_anim_textures.clear()
+		_rebuild_atlas()
+	queue_redraw()
+
+
+func clear_transition() -> void:
+	if _transition_cells.is_empty() and _transition_palette.is_empty():
+		return
+	var was_flooding: bool = not _transition_palette.is_empty()
+	_transition_cells = PackedByteArray()
+	_transition_tiles = PackedByteArray()
+	_transition_palette = PackedColorArray()
+	if was_flooding:
+		_actor_textures.clear()
+		_effect_textures.clear()
+		_anim_textures.clear()
+		_rebuild_atlas()
+	queue_redraw()
+
+
+## The transition's own cells, over the map and over everything standing on it.
+## `wTilemap` is one plane, so a wedge covers an NPC the way it covers a tree.
+func _draw_transition(page: PackedInt32Array, palettes: Array, window: Vector2i) -> void:
+	var black: int = Gen2BattleTransition.CELL_BLACK
+	for y: int in Gen2BattleTransition.ROWS:
+		for x: int in Gen2BattleTransition.COLUMNS:
+			var cell: int = int(_transition_cells[y * Gen2BattleTransition.COLUMNS + x])
+			if cell == Gen2BattleTransition.CELL_NONE:
+				continue
+			var palette: PackedColorArray = _transition_palette
+			if palette.is_empty():
+				var tile: int = page[y * window.x + x] if y * window.x + x < page.size() else 0
+				palette = palettes[tile] if tile >= 0 and tile < palettes.size() \
+					else PackedColorArray()
+			var at := Rect2(
+				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT),
+				Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT)
+			)
+			if cell == black or _transition_tiles.is_empty():
+				draw_rect(at, palette[3] if palette.size() > 3 else Color.BLACK, true)
+				continue
+			_draw_transition_square(at, palette)
+
+
+## `BATTLETRANSITION_SQUARE`, the one tile of the pair that has a pattern in it.
+func _draw_transition_square(at: Rect2, palette: PackedColorArray) -> void:
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in Gen2Tiles.TILE_WIDTH:
+			var index: int = int(_transition_tiles[y * Gen2Tiles.TILE_WIDTH + x])
+			draw_rect(
+				Rect2(at.position + Vector2(x, y), Vector2.ONE),
+				palette[index] if index < palette.size() else Color.BLACK,
+				true
 			)
 
 
@@ -286,6 +376,10 @@ func _draw() -> void:
 		if bool(sprite.get("screen", false)):
 			_draw_effect_sprite(sprite, Vector2.ZERO)
 	_draw_encounter_pulse(camera_pixels)
+	## Last, over the map and over everything standing on it: `wTilemap` is one
+	## plane and a wedge covers an NPC the way it covers a tree.
+	if not _transition_cells.is_empty():
+		_draw_transition(page, _tile_palettes(), window_size)
 
 
 func _actor_texture(

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -88,6 +88,11 @@ var _pending_step_events: Dictionary = {}
 ## empty on every other frame. The map swaps between the two stages, which is
 ## where the setup script's own list sits.
 var _map_fade: Dictionary = {}
+## `DoBattleTransition` and the battle it is in front of: the encounter is
+## resolved when the transition starts, and the battle screen is not built until
+## it has finished.
+var _battle_transition: Gen2BattleTransition = null
+var _battle_transition_request: Dictionary = {}
 ## `wLandmarkSignTimer` and the window the sign is drawn in. The map load decides
 ## whether there is a sign (`Gen2WorldAPI.map_name_sign_pending`); the sixty
 ## frames it stands for are spent here, like every other overworld countdown.
@@ -489,6 +494,9 @@ func advance_frame() -> void:
 	## Before everything the map draws: the fade owns the frame the map swaps on,
 	## and nothing else runs while `RunMapSetupScript` is spending its own.
 	_advance_map_fade()
+	## `DoBattleTransition`'s own `.loop`, which owns every frame between the
+	## encounter and the battle screen.
+	_advance_battle_transition()
 	## `RefreshMapSprites` runs inside the setup script and `PlaceMapNameSign`
 	## with the rest of the map's background, so a sign raised by the load this
 	## frame carried is spent from the next one.
@@ -716,7 +724,7 @@ func _advance_held_direction() -> void:
 func _overlay_open() -> bool:
 	## A map fade is not an overlay, but nothing may move or be pressed inside
 	## one either: `RunMapSetupScript` runs with the joypad unread.
-	return not _map_fade.is_empty() \
+	return not _map_fade.is_empty() or _battle_transition != null \
 		or _battle_host != null or _service_host != null \
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
@@ -2100,7 +2108,131 @@ func _handle_fishing_result(result: Dictionary) -> void:
 	_refresh_labels()
 
 
+## `StartBattle`: the transition first, and the battle screen only once it has
+## finished. `PlayBattleMusic` opens with `PlayMusic MUSIC_NONE`, so the map's
+## own track stops here rather than when the fight is built.
 func _start_battle_request(request: Dictionary) -> void:
+	if _battle_host != null or _battle_transition != null or _data == null:
+		return
+	if _audio_player != null:
+		_audio_player.stop_all()
+	_battle_transition_request = request.duplicate(true)
+	_battle_transition = _build_battle_transition(request)
+	if _battle_transition == null:
+		_open_battle_host(_battle_transition_request)
+		return
+	_apply_battle_transition()
+	_script_prompt = "Battle starting"
+	_refresh_labels()
+
+
+## `StartTrainerBattle_DetermineWhichAnimation`'s two bits, and the ball only a
+## trainer's own transition draws.
+func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
+	if _world == null or _data == null:
+		return null
+	var values: Dictionary = request.get("values", {})
+	if bool(values.get("tutorial", false)):
+		return null
+	var environment: int = _world.current_map.environment if _world.current_map != null else 0
+	## `cp CAVE / cp ENVIRONMENT_5 / cp DUNGEON`, the three the flash and the
+	## wavy outro belong to.
+	var cave: bool = environment in Gen2WorldAPI.CAVE_ENVIRONMENTS
+	var lead: int = _battle_lead_level()
+	var opponent: int = int(values.get("level", lead))
+	return Gen2BattleTransition.create(
+		lead + Gen2BattleTransition.STRONGER_MARGIN < opponent,
+		cave,
+		int(values.get("trainer_class", 0)) > 0,
+		_render_time_of_day() == Gen2WorldPalette.TIME_DARK,
+		_encounter_random,
+		_data.battle_anim_sine()
+	)
+
+
+## `wBattleMonLevel`, which is the party's own lead rather than the battle's:
+## the transition is picked before `InitBattleMon` has run.
+func _battle_lead_level() -> int:
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	if save == null or save.party.is_empty():
+		return 1
+	return int((save.party[0] as Gen2SaveMon).level)
+
+
+## `DoBattleTransition` alone, driven to [param frames] frames in, for a
+## screenshot: the transition over the map it actually runs on, without the
+## battle behind it. [param trainer] is the branch that draws the Poke Ball and
+## floods every background tile with `PAL_BG_TEXT`.
+func preview_battle_transition(frames: int, trainer: bool = false) -> void:
+	_battle_transition = Gen2BattleTransition.create(
+		false, false, trainer, false, _encounter_random,
+		_data.battle_anim_sine() if _data != null else PackedByteArray()
+	)
+	_apply_battle_transition()
+	for _frame: int in maxi(frames, 0):
+		if _battle_transition == null:
+			break
+		_battle_transition.advance_frame()
+		_apply_battle_transition()
+
+
+## Spends `DoBattleTransition` where the caller wants the battle rather than the
+## animation in front of it, which is every driver that opens one without a
+## person watching.
+func settle_battle_transition(limit: int = 600) -> void:
+	var guard: int = limit
+	while _battle_transition != null and guard > 0:
+		advance_frame()
+		guard -= 1
+
+
+## Whether `DoBattleTransition` is still running, which is the several seconds
+## between an encounter resolving and the battle screen existing.
+func battle_transition_running() -> bool:
+	return _battle_transition != null
+
+
+## One frame of it, and the battle behind it when the last one has been spent.
+func _advance_battle_transition() -> void:
+	if _battle_transition == null:
+		return
+	_battle_transition.advance_frame()
+	_apply_battle_transition()
+	if not _battle_transition.finished():
+		return
+	var request: Dictionary = _battle_transition_request
+	_battle_transition = null
+	_battle_transition_request = {}
+	if _renderer != null and _renderer.has_method("clear_transition"):
+		_renderer.clear_transition()
+	if _renderer != null and _renderer.has_method(Gen2ModHost.RENDERER_FADE_METHOD):
+		_renderer.call(Gen2ModHost.RENDERER_FADE_METHOD, Gen2WorldPalette.FADE_IDENTITY, false)
+	_open_battle_host(request)
+
+
+## What the transition is showing right now, handed to whatever is drawing the
+## map. A renderer of a mod's own that does not take it draws the map as it was,
+## which is the same contract the map fade has.
+func _apply_battle_transition() -> void:
+	if _renderer == null or _battle_transition == null:
+		return
+	if _renderer.has_method(Gen2ModHost.RENDERER_FADE_METHOD):
+		_renderer.call(
+			Gen2ModHost.RENDERER_FADE_METHOD, _battle_transition.palette_order(), false
+		)
+	if not _renderer.has_method("set_transition"):
+		return
+	_renderer.set_transition(
+		_battle_transition.cells(),
+		_data.tile_indices("battle_transition") if _data != null else PackedByteArray(),
+		_data.battle_transition_palette(
+			_render_time_of_day() == Gen2WorldPalette.TIME_DARK
+		) if _battle_transition.ball_drawn() and _data != null else PackedColorArray()
+	)
+
+
+func _open_battle_host(request: Dictionary) -> void:
 	if _battle_host != null or _data == null:
 		return
 	var values: Dictionary = request.get("values", {})

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2206,8 +2206,6 @@ func _advance_battle_transition() -> void:
 	_battle_transition_request = {}
 	if _renderer != null and _renderer.has_method("clear_transition"):
 		_renderer.clear_transition()
-	if _renderer != null and _renderer.has_method(Gen2ModHost.RENDERER_FADE_METHOD):
-		_renderer.call(Gen2ModHost.RENDERER_FADE_METHOD, Gen2WorldPalette.FADE_IDENTITY, false)
 	_open_battle_host(request)
 
 
@@ -2217,10 +2215,6 @@ func _advance_battle_transition() -> void:
 func _apply_battle_transition() -> void:
 	if _renderer == null or _battle_transition == null:
 		return
-	if _renderer.has_method(Gen2ModHost.RENDERER_FADE_METHOD):
-		_renderer.call(
-			Gen2ModHost.RENDERER_FADE_METHOD, _battle_transition.palette_order(), false
-		)
 	if not _renderer.has_method("set_transition"):
 		return
 	_renderer.set_transition(
@@ -2228,7 +2222,15 @@ func _apply_battle_transition() -> void:
 		_data.tile_indices("battle_transition") if _data != null else PackedByteArray(),
 		_data.battle_transition_palette(
 			_render_time_of_day() == Gen2WorldPalette.TIME_DARK
-		) if _battle_transition.ball_drawn() and _data != null else PackedColorArray()
+		) if _battle_transition.ball_drawn() and _data != null else PackedColorArray(),
+		_battle_transition.sprites(),
+		## `hLastTalked`, which `RespawnPlayerAndOpponent` keeps beside the
+		## player. A wild encounter has none and leaves the player alone.
+		int(_battle_transition_request.get("values", {}).get("object_index", -1)),
+		## `StartTrainerBattle_Flash` writes `wBGP` and calls `DmgToCgbBGPals`
+		## alone, so this is the background's order and not the map fade's:
+		## the sprites standing over the wedges keep their own colours.
+		_battle_transition.palette_order(),
 	)
 
 

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -34,13 +34,19 @@ func after_each() -> void:
 	Gen2ModHost.reset()
 
 
-func _open_battle() -> void:
+## The battle as `InitBattleDisplay` leaves it, before `BattleStartMessage` and
+## `DoBattle`'s opening have spent a frame.
+func _seed_battle() -> void:
 	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
 	_screen = packed.instantiate() as Gen2BattleScreen
 	_screen.set_data(_data)
 	add_child(_screen)
 	await get_tree().process_frame
 	_screen.show_matchup(16, 155, 5, 5)
+
+
+func _open_battle() -> void:
+	await _seed_battle()
 	var guard: int = 8000
 	## The slide, then `BattleStartMessage` and `DoBattle`'s opening: the ball
 	## thrown there is an animation of its own, so it is spent before a test
@@ -144,7 +150,11 @@ func test_a_status_animation_leaves_the_hud_up() -> void:
 
 
 func test_the_tilemap_is_the_battle_it_is_seeded_from() -> void:
-	await _open_battle()
+	## Read where `InitBattleDisplay` leaves it rather than after the opening:
+	## the entrance slides the player's own picture off that square and the ball
+	## draws the Pokemon back, and on this cache no animation script resolves,
+	## so nothing would put it there.
+	await _seed_battle()
 	var map: PackedByteArray = _screen._bg_map
 	assert_eq(map.size(), Gen2BattleScreenMap.COLUMNS * Gen2BattleScreenMap.ROWS)
 	# `GetEnemyFrontpicCoords` and `AppearUser`'s own `xor a` / `ld a, $31`.
@@ -312,3 +322,80 @@ func _settle_message() -> void:
 	while box != null and box.is_revealing() and guard > 0:
 		_screen.advance_frame()
 		guard -= 1
+
+
+## `BattleStartMessage` and `DoBattle`'s opening, as the two shapes the source
+## has: the pictures each square opens with, the panels neither of them has yet,
+## and the party balls `BattleStart_TrainerHuds` hangs over both.
+func test_a_wild_battle_opens_with_the_player_standing_on_the_field() -> void:
+	await _seed_battle()
+	while _screen.intro_running():
+		_screen.advance_frame()
+	var entrance: Dictionary = _screen.entrance_snapshot()
+	# `GetTrainerBackpic` puts the player there; a wild opponent is already
+	# itself, so there is no trainer picture on the other square.
+	assert_eq(String(entrance["player_backpic"]), "chris")
+	assert_eq(int(entrance["enemy_trainer_pic"]), 0)
+	# `InitBattleDisplay` clears both panels and only `BattleStartMessage`'s
+	# caller draws the enemy's, after the opening line has been pressed past.
+	assert_false(bool(entrance["enemy_hud"]))
+	assert_false(bool(entrance["player_hud"]))
+	# `ShowPlayerMonsRemaining` alone: a wild battle has no opposing trainer.
+	assert_eq(int(entrance["balls"]), Gen2Party.MAX_SIZE)
+	assert_true(bool(entrance["awaits_press"]), "WildPokemonAppearedText ends in prompt")
+
+
+func test_a_trainer_battle_opens_with_both_trainers_on_the_field() -> void:
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_screen = packed.instantiate() as Gen2BattleScreen
+	_screen.set_data(_data)
+	add_child(_screen)
+	await get_tree().process_frame
+	_screen.show_trainer(Fixture.TRAINER_CLASS, 0)
+	while _screen.intro_running():
+		_screen.advance_frame()
+	# `SFX_SHINE` and its twenty frames come before the line, so the balls and
+	# the text are not up yet.
+	var guard: int = 400
+	while _screen.frames_running() and guard > 0:
+		_screen.advance_frame()
+		guard -= 1
+	var entrance: Dictionary = _screen.entrance_snapshot()
+	assert_eq(int(entrance["enemy_trainer_pic"]), Fixture.TRAINER_CLASS)
+	assert_eq(String(entrance["player_backpic"]), "chris")
+	# `ShowOTTrainerMonsRemaining` as well, so both sides' parties are up.
+	assert_eq(int(entrance["balls"]), Gen2Party.MAX_SIZE * 2)
+	assert_true(bool(entrance["awaits_press"]), "WantsToBattleText ends in prompt")
+
+
+## The order the two sides arrive in, which is `EnemySwitch` inside `DoBattle`
+## and then the player's own send-out forty frames later.
+func test_the_trainer_sends_out_first_and_the_player_second() -> void:
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_screen = packed.instantiate() as Gen2BattleScreen
+	_screen.set_data(_data)
+	add_child(_screen)
+	await get_tree().process_frame
+	_screen.show_trainer(Fixture.TRAINER_CLASS, 0)
+	var seen: Array[String] = []
+	var guard: int = 8000
+	while (_screen.frames_running() or _screen.entrance_running()) and guard > 0:
+		guard -= 1
+		var now: Dictionary = _screen.entrance_snapshot()
+		if int(now["enemy_trainer_pic"]) == 0 and not seen.has("enemy"):
+			seen.append("enemy")
+		if String(now["player_backpic"]).is_empty() and not seen.has("player"):
+			seen.append("player")
+		if bool(now["enemy_hud"]) and not seen.has("enemy_hud"):
+			seen.append("enemy_hud")
+		if bool(now["player_hud"]) and not seen.has("player_hud"):
+			seen.append("player_hud")
+		_screen.advance_frame()
+		if _screen.frames_running() or not _screen.entrance_running():
+			continue
+		_screen.finish()
+		_screen.advance()
+	if bool(_screen.entrance_snapshot()["player_hud"]) and not seen.has("player_hud"):
+		seen.append("player_hud")
+	assert_eq(seen, ["enemy", "enemy_hud", "player", "player_hud"])
+	_screen._close_battle_menu()

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -41,11 +41,18 @@ func _open_battle() -> void:
 	add_child(_screen)
 	await get_tree().process_frame
 	_screen.show_matchup(16, 155, 5, 5)
-	var guard: int = 4000
-	while _screen.intro_running() and guard > 0:
-		_screen.advance_frame()
+	var guard: int = 8000
+	## The slide, then `BattleStartMessage` and `DoBattle`'s opening: the ball
+	## thrown there is an animation of its own, so it is spent before a test
+	## drives one of its own.
+	while (_screen.frames_running() or _screen.entrance_running()) and guard > 0:
 		guard -= 1
-	## The intro runs on into `BattleMenu`, and a menu owns the joypad. These
+		_screen.advance_frame()
+		if _screen.frames_running() or not _screen.entrance_running():
+			continue
+		_screen.finish()
+		_screen.advance()
+	## The entrance runs on into `BattleMenu`, and a menu owns the joypad. These
 	## tests drive the pump mid-turn instead, so it is closed behind them.
 	_screen._close_battle_menu()
 

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -44,11 +44,25 @@ func _open_battle() -> void:
 ## `BattleIntroSlidingPics` runs before `BattleStartMessage`, so a battle says
 ## and does nothing until the pics are in place. In play the screen's own frames
 ## spend that; a test driving events without it would drive them into the slide.
-func _settle_intro() -> void:
+func _settle_slide() -> void:
 	var guard: int = 4000
 	while _battle_screen.intro_running() and guard > 0:
 		_battle_screen.advance_frame()
 		guard -= 1
+
+
+## The slide and the entrance behind it, which together are what `DoBattle`
+## spends before its first menu: a test feeding its own events starts there.
+func _settle_intro() -> void:
+	var guard: int = 8000
+	while (_battle_screen.frames_running() or _battle_screen.entrance_running()) \
+		and guard > 0:
+		guard -= 1
+		_battle_screen.advance_frame()
+		if _battle_screen.frames_running() or not _battle_screen.entrance_running():
+			continue
+		_battle_screen.finish()
+		_battle_screen.advance()
 
 
 func _stub_script(body: String) -> GDScript:
@@ -530,7 +544,7 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 	_battle_screen.advance()
 	assert_true(_battle_screen.intro_running())
 
-	_settle_intro()
+	_settle_slide()
 	assert_eq(
 		String(_battle_screen.battle_snapshot()["message"]), "Wild PIDGEY appeared!",
 		"the start message waited for the slide"

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -202,6 +202,9 @@ func test_a_renderer_rebuilt_mid_scene_stays_below_the_live_text_box() -> void:
 	assert_eq(_world_screen._text_box, box, "the same live box node")
 	assert_eq(box.texture, texture, "with the glyphs it was already showing")
 	assert_true(box.visible)
+	## `_build_renderer` drops the old view with `queue_free`, which the game
+	## serves at the end of its frame and a test has to spend one to see.
+	await get_tree().process_frame
 
 
 ## The same rule in the battle screen, whose box is never hidden at all.
@@ -213,6 +216,7 @@ func test_a_battle_renderer_rebuilt_mid_scene_stays_below_the_interface() -> voi
 	var children: Array = viewport.get_children()
 	assert_eq(children.find(_battle_screen._renderer), 0, "the renderer is the floor")
 	assert_true(children.find(_battle_screen._box) > 0)
+	await get_tree().process_frame
 
 
 ## A page turn hides the box and the next event shows it again inside one call,
@@ -438,3 +442,87 @@ func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() ->
 	assert_eq(
 		int((provider.get("context") as Dictionary)["generation"]), generation + 1
 	)
+
+
+## `StartTrainerBattle_Flash` writes `wBGP` and calls `DmgToCgbBGPals` alone,
+## so its three passes are a background order: the map, the Poke Ball's own tile
+## and the wedges take it, and the sprites standing over them do not. Measured
+## on a real Route 30 trainer, where the player's own 74 black, 35 red and 31
+## skin pixels are the same on every frame of the flash while the background
+## behind them walks the whole list.
+func test_the_transition_flash_is_the_background_s_order_and_not_the_sprites() -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen.set_process(false)
+	var renderer: Gen2WorldRenderer = _world_screen._renderer
+
+	var identity: PackedByteArray = _player_sprite_bytes(renderer)
+	var orders: Dictionary = {}
+	var floods: Dictionary = {}
+	## Every frame of the first flash pass, which is where the whole list is
+	## walked; `preview_battle_transition` drives the animation and nothing else.
+	for frame: int in range(24, 49):
+		_world_screen.preview_battle_transition(frame, true)
+		var order: int = _world_screen._battle_transition.palette_order()
+		orders[order] = true
+		floods[order] = renderer.flood_palette()
+		assert_eq(
+			_player_sprite_bytes(renderer), identity,
+			"the player keeps its own colours through order $%02X" % order
+		)
+	assert_gt(orders.size(), 4, "the flash walks more than one order")
+	var flood: PackedColorArray = floods[Gen2BattleTransition.IDENTITY]
+	assert_eq(flood.size(), 4, "`.copypals` fills one palette")
+	for order: int in floods:
+		if order == Gen2BattleTransition.IDENTITY:
+			continue
+		assert_ne(
+			floods[order], flood,
+			"$%02X reorders the background's own four colours" % order
+		)
+
+
+func _player_sprite_bytes(renderer: Gen2WorldRenderer) -> PackedByteArray:
+	var texture: Texture2D = renderer._actor_texture(
+		_world_screen._world.player_sprite(), _world_screen._world.player_palette(),
+		_world_screen._world.player_facing, 0
+	)
+	return PackedByteArray() if texture == null else texture.get_image().get_data()
+
+
+## A cell `DoBattleTransition` has written is the background under a sprite
+## standing in grass, so the map's own priority tile is not drawn there:
+## `.InitSprite`'s OAM_PRIO is a test against whatever the tilemap holds now.
+func test_the_grass_over_a_sprite_leaves_the_transition_s_own_cells_to_it() -> void:
+	var renderer := Gen2WorldRenderer.new()
+	var whole := Rect2(Vector2(64, 68), Vector2(8, 8))
+	assert_eq(
+		renderer._priority_pieces(whole), [whole] as Array[Rect2],
+		"with no transition up the map owns the lot"
+	)
+	var cells := PackedByteArray()
+	cells.resize(Gen2BattleTransition.COLUMNS * Gen2BattleTransition.ROWS)
+	## Screen cell (8, 8) alone, which is the left half of a rectangle spanning
+	## cells 8 and 9 of row 8.
+	cells[8 * Gen2BattleTransition.COLUMNS + 8] = Gen2BattleTransition.CELL_BLACK
+	renderer.set_transition(cells, PackedByteArray(), PackedColorArray())
+	assert_eq(
+		renderer._priority_pieces(Rect2(Vector2(64, 64), Vector2(8, 8))), [] as Array[Rect2],
+		"the cell it took is its own"
+	)
+	assert_eq(
+		renderer._priority_pieces(Rect2(Vector2(64, 64), Vector2(16, 8))),
+		[Rect2(Vector2(72, 64), Vector2(8, 8))] as Array[Rect2],
+		"the cell beside it is still the map's"
+	)
+	assert_eq(
+		renderer._priority_pieces(whole), [Rect2(Vector2(64, 72), Vector2(8, 4))] as Array[Rect2],
+		"a rectangle straddling the grid is split on it, not dropped whole"
+	)
+	renderer.free()

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -415,6 +415,7 @@ func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() ->
 	_world_screen._world.player_cell = cell
 	_world_screen._after_player_move({"kind": &"step"})
 	## The adapter's own prepared request, which is the `values` block itself.
+	_world_screen.settle_battle_transition()
 	var request: Dictionary = _world_screen._battle_host.world_battle_request()
 	assert_eq(int(request["dvs"]), shiny)
 	assert_eq(int(request["level"]), 5)

--- a/tests/integration/test_save_editor_screen.gd
+++ b/tests/integration/test_save_editor_screen.gd
@@ -90,6 +90,10 @@ func test_saving_writes_the_slot_and_leaves_it_clean() -> void:
 	var loaded: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
 	assert_true(loaded["ok"], loaded["message"])
 	assert_eq((loaded["save"] as Gen2SaveData).player_name, "ASH")
+	## A second editor rebuilds every row, and the rows it replaces are dropped
+	## with `queue_free`: the game serves those at the end of its frame and a
+	## test has to spend one to see it.
+	await get_tree().process_frame
 
 
 func test_reloading_drops_uncommitted_edits() -> void:

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -658,6 +658,7 @@ func test_a_rare_score_that_passes_its_roll_opens_the_tree_battle() -> void:
 	assert_eq(Gen2WorldTreemon.coord_score(HEADBUTT_CELL), 7)
 	await _headbutt_with(7, 1)
 
+	_world_screen.settle_battle_transition()
 	assert_not_null(_world_screen._battle_host, "a passed RARE roll reaches startbattle")
 	var battle: Gen2Battle = _world_screen._battle_host._battle
 	var enemy: Gen2BattleMon = battle.party(Gen2Battle.ENEMY).active_mon()
@@ -776,6 +777,7 @@ func test_rock_smash_needs_no_badge_and_refuses_when_facing_no_rock() -> void:
 func test_a_passed_rock_roll_opens_a_battle_and_a_failed_one_does_not() -> void:
 	await _open_rock_smash_world()
 	await _rock_smash_with(2)
+	_world_screen.settle_battle_transition()
 	assert_not_null(_world_screen._battle_host, "a roll under 4 reaches startbattle")
 	var battle: Gen2Battle = _world_screen._battle_host._battle
 	assert_eq(battle.party(Gen2Battle.ENEMY).active_mon().species, TREEMON_SPECIES)

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -168,7 +168,7 @@ func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	assert_true(host.is_ready())
 	var snapshot: Dictionary = host.battle_snapshot()
 	assert_eq(snapshot["enemy"], Fixture.TRAINER_SPECIES)
-	assert_eq(snapshot["message"], "LEADER RIVAL wants to fight!")
+	assert_eq(snapshot["message"], "LEADER RIVAL\nwants to battle!")
 	assert_eq(snapshot["world_battle_active"], true)
 
 
@@ -181,7 +181,7 @@ func test_a_trainer_battle_opens_with_the_source_entrance() -> void:
 	var host: Gen2BattleScreen = _battle_opening()
 	assert_not_null(host)
 	assert_true(host.entrance_running())
-	assert_eq(host.battle_snapshot()["message"], "LEADER RIVAL wants to fight!")
+	assert_eq(host.battle_snapshot()["message"], "LEADER RIVAL\nwants to battle!")
 
 	var lines: Array = []
 	## Whose ball is being thrown, in order. The fixture carries no animation
@@ -208,7 +208,7 @@ func test_a_trainer_battle_opens_with_the_source_entrance() -> void:
 		host.advance()
 
 	assert_eq(lines, [
-		"LEADER RIVAL wants to fight!",
+		"LEADER RIVAL\nwants to battle!",
 		"LEADER RIVAL\nsent out\n%s!" % _wild_name(),
 		"Go! %s!" % _wild_name(),
 	])
@@ -309,7 +309,7 @@ func test_gold_profile_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	assert_true(host.is_ready())
 	var snapshot: Dictionary = host.battle_snapshot()
 	assert_eq(snapshot["enemy"], Fixture.TRAINER_SPECIES)
-	assert_eq(snapshot["message"], "LEADER RIVAL wants to fight!")
+	assert_eq(snapshot["message"], "LEADER RIVAL\nwants to battle!")
 	assert_eq(snapshot["world_battle_active"], true)
 
 
@@ -477,7 +477,7 @@ func test_resolved_wild_encounter_reaches_the_real_battle_overlay() -> void:
 	assert_not_null(host)
 	assert_true(host.is_ready())
 	assert_eq(host.battle_snapshot()["enemy"], Fixture.TRAINER_SPECIES)
-	assert_eq(host.battle_snapshot()["message"], "Wild %s appeared!" % _wild_name())
+	assert_eq(host.battle_snapshot()["message"], "Wild %s\nappeared!" % _wild_name())
 
 
 func test_catch_tutorial_uses_the_real_battle_overlay_without_persistent_capture() -> void:
@@ -817,7 +817,7 @@ func test_hp_experience_and_pp_survive_into_the_next_wild_battle() -> void:
 	await get_tree().process_frame
 	var host: Gen2BattleScreen = _battle_opening()
 	assert_not_null(host)
-	assert_eq(host.battle_snapshot()["message"], "Wild %s appeared!" % _wild_name())
+	assert_eq(host.battle_snapshot()["message"], "Wild %s\nappeared!" % _wild_name())
 	host = _battle_host()
 
 	var player_mon: Gen2BattleMon = host._battle.party(Gen2Battle.PLAYER).mons[0]

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -95,10 +95,22 @@ func _trigger_trainer() -> void:
 	assert_not_null(_battle_child())
 
 
+## The battle overlay, once `DoBattleTransition` has been spent.
+##
+## The encounter is resolved on the frame it fires, and the transition owns
+## every frame between that and the battle screen being built, so a test that
+## looked for the child on the same frame would find nothing.
 func _battle_child() -> Gen2BattleScreen:
-	for child: Node in _world_screen.get_children():
-		if child is Gen2BattleScreen:
-			return child as Gen2BattleScreen
+	var guard: int = 600
+	while guard > 0:
+		for child: Node in _world_screen.get_children():
+			if child is Gen2BattleScreen:
+				return child as Gen2BattleScreen
+		if _world_screen.battle_transition_running():
+			_world_screen.advance_frame()
+			guard -= 1
+			continue
+		return null
 	return null
 
 
@@ -1068,3 +1080,35 @@ func test_a_trainer_battle_opens_on_the_track_its_class_names() -> void:
 		Gen2Battle.region_is_kanto(_world_screen._world.landmark()),
 		"the fixture map is in Johto"
 	)
+
+
+## `StartBattle`: `DoBattleTransition` owns every frame between the encounter
+## resolving and the battle screen existing, and the map is what it draws over.
+func test_a_battle_runs_its_transition_before_the_overlay_exists() -> void:
+	await _open_world()
+	await _walk_one(Vector2i.RIGHT)
+	for _frame: int in 400:
+		_world_screen.advance_frame()
+		if _world_screen.battle_transition_running():
+			break
+		var pending: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+			_world_screen._advance_script_input()
+	assert_true(
+		_world_screen.battle_transition_running(),
+		"the encounter is resolved and the transition is what is on screen"
+	)
+	var seen: bool = false
+	var frames: int = 0
+	while _world_screen.battle_transition_running() and frames < 600:
+		frames += 1
+		seen = seen or _world_screen._battle_transition.cells().count(
+			Gen2BattleTransition.CELL_BLACK
+		) > 0
+		## Nothing is built until the last of its frames is spent.
+		for child: Node in _world_screen.get_children():
+			assert_false(child is Gen2BattleScreen, "no overlay while the transition runs")
+		_world_screen.advance_frame()
+	assert_true(seen, "the outro blacks the map out on the way")
+	assert_gt(frames, Gen2BattleTransition.LEAD_FRAMES, "the flash and an outro")
+	assert_not_null(_battle_child(), "and the battle behind it once it lands")

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -90,7 +90,9 @@ func _trigger_trainer() -> void:
 		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
 	await get_tree().process_frame
-	assert_not_null(_battle_host())
+	## Only that the overlay opened: the entrance is left where each test wants
+	## it, since driving it here would spend the line one of them reads.
+	assert_not_null(_battle_child())
 
 
 func _battle_child() -> Gen2BattleScreen:
@@ -105,7 +107,30 @@ func _battle_child() -> Gen2BattleScreen:
 ## `BattleIntroSlidingPics` runs before `BattleStartMessage`, so a battle says
 ## nothing until the pics are in place. In play the screen's own frames spend
 ## that; a test that read the box without it would read an empty one.
+##
+## The entrance behind the slide is half frames and half boxes, so both are
+## driven: `DoBattle` reaches its first menu only once the ball has been thrown.
 func _battle_host() -> Gen2BattleScreen:
+	var host: Gen2BattleScreen = _battle_opening()
+	if host == null:
+		return null
+	var guard: int = 4000
+	while (host.frames_running() or host.entrance_running()) and guard > 0:
+		guard -= 1
+		host.advance_frame()
+		if host.frames_running() or not host.entrance_running():
+			continue
+		## The box owes a press rather than frames: the reveal is skipped and the
+		## press given, which is what a player does to a `prompt` line. The test
+		## is left on the first battle menu, never a press past it.
+		host.finish()
+		host.advance()
+	return host
+
+
+## The same overlay with the slide spent and nothing else, which is where the
+## line `BattleStartMessage` prints is still on screen.
+func _battle_opening() -> Gen2BattleScreen:
 	var host: Gen2BattleScreen = _battle_child()
 	if host == null:
 		return null
@@ -129,7 +154,7 @@ func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	var before: Dictionary = _world_screen.world_snapshot()
 	await _trigger_trainer()
 
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_opening()
 	assert_not_null(host)
 	assert_eq(before["map"], Vector2i(Fixture.MAP_GROUP, Fixture.MAP_NUMBER))
 	assert_eq(before["player_cell"], Vector2i(4, 5))
@@ -145,6 +170,52 @@ func test_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	assert_eq(snapshot["enemy"], Fixture.TRAINER_SPECIES)
 	assert_eq(snapshot["message"], "LEADER RIVAL wants to fight!")
 	assert_eq(snapshot["world_battle_active"], true)
+
+
+## `BattleStartMessage` and `DoBattle`'s opening, in the order they run: the
+## shine, the line the trainer wants to fight on, the enemy's own send-out and
+## the player's, each ball being `ANIM_SEND_OUT_MON`.
+func test_a_trainer_battle_opens_with_the_source_entrance() -> void:
+	await _open_world()
+	await _trigger_trainer()
+	var host: Gen2BattleScreen = _battle_opening()
+	assert_not_null(host)
+	assert_true(host.entrance_running())
+	assert_eq(host.battle_snapshot()["message"], "LEADER RIVAL wants to fight!")
+
+	var lines: Array = []
+	## Whose ball is being thrown, in order. The fixture carries no animation
+	## tables, so the script itself never runs and the event is what says the
+	## cartridge would have played one.
+	var balls: Array = []
+	var guard: int = 4000
+	while (host.frames_running() or host.entrance_running()) and guard > 0:
+		guard -= 1
+		host.advance_frame()
+		var snapshot: Dictionary = host.battle_snapshot()
+		if not lines.has(snapshot["message"]) and snapshot["message"] != "":
+			lines.append(snapshot["message"])
+		var animation: Dictionary = host.animation_snapshot()
+		if bool(animation["running"]) \
+			and int(animation["index"]) == Gen2Battle.ANIM_SEND_OUT_MON:
+			var side: int = Gen2Battle.ENEMY if bool(animation["enemy_turn"]) \
+				else Gen2Battle.PLAYER
+			if balls.is_empty() or balls[-1] != side:
+				balls.append(side)
+		if host.frames_running() or not host.entrance_running():
+			continue
+		host.finish()
+		host.advance()
+
+	assert_eq(lines, [
+		"LEADER RIVAL wants to fight!",
+		"LEADER RIVAL\nsent out\n%s!" % _wild_name(),
+		"Go! %s!" % _wild_name(),
+	])
+	assert_eq(balls, [Gen2Battle.ENEMY, Gen2Battle.PLAYER],
+		"the trainer throws first, and the player after `DoBattle`'s forty frames")
+	## `EmptyBattleTextbox` before the menu `DoBattle` reaches.
+	assert_eq(host.battle_snapshot()["message"], "")
 
 
 ## While the trainer object is mid-step, its presentation offset eases toward
@@ -195,13 +266,14 @@ func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 func test_victory_displays_imported_text_reloads_objects_and_keeps_player_cell() -> void:
 	await _open_world()
 	await _trigger_trainer()
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_child()
 	assert_not_null(host)
 
+	## Beaten before the entrance is spent, so `DoBattle` reaches its result
+	## rather than its first menu: nothing reads a button between them.
 	for _hit: int in 12:
 		host.hurt_enemy()
-	host.finish()
-	host.advance()
+	host = _battle_host()
 	var result_text: Dictionary = host.battle_snapshot()
 	assert_eq(result_text["message"], "YOU WON.")
 
@@ -224,7 +296,7 @@ func test_gold_profile_trainer_sight_reaches_the_real_battle_overlay() -> void:
 	var before: Dictionary = _world_screen.world_snapshot()
 	await _trigger_trainer()
 
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_opening()
 	assert_not_null(host)
 	assert_eq(before["player_cell"], Vector2i(4, 5))
 	assert_eq(_world_screen.world_snapshot()["player_cell"], Vector2i(5, 5))
@@ -245,13 +317,14 @@ func test_gold_profile_victory_commits_beaten_flag_and_reloads_objects() -> void
 	_data = Fixture.build(&"gold")
 	await _open_world()
 	await _trigger_trainer()
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_child()
 	assert_not_null(host)
 
+	## Beaten before the entrance is spent, so `DoBattle` reaches its result
+	## rather than its first menu: nothing reads a button between them.
 	for _hit: int in 12:
 		host.hurt_enemy()
-	host.finish()
-	host.advance()
+	host = _battle_host()
 	assert_eq(host.battle_snapshot()["message"], "YOU WON.")
 
 	host.finish()
@@ -266,15 +339,14 @@ func test_gold_profile_victory_commits_beaten_flag_and_reloads_objects() -> void
 func test_defeat_displays_imported_loss_text_and_uses_save_recovery() -> void:
 	await _open_world(true)
 	await _trigger_trainer()
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_child()
 	assert_not_null(host)
 
 	for _hit: int in 12:
 		host.hurt_player()
 	for member: Gen2BattleMon in host._battle.party(Gen2Battle.PLAYER).mons:
 		member.hp = 0
-	host.finish()
-	host.advance()
+	host = _battle_host()
 	assert_eq(host.battle_snapshot()["message"], "YOU LOST.")
 
 	host.finish()
@@ -296,7 +368,7 @@ func test_defeat_displays_imported_loss_text_and_uses_save_recovery() -> void:
 func test_a_battle_is_spent_and_steered_by_the_world_that_opened_it() -> void:
 	await _open_world(true)
 	await _trigger_trainer()
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_child()
 	assert_not_null(host)
 	assert_true(_world_screen.battle_active())
 	assert_eq(_world_screen.battles_fought(), 1)
@@ -401,7 +473,7 @@ func test_resolved_wild_encounter_reaches_the_real_battle_overlay() -> void:
 	await get_tree().process_frame
 	await get_tree().process_frame
 
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_opening()
 	assert_not_null(host)
 	assert_true(host.is_ready())
 	assert_eq(host.battle_snapshot()["enemy"], Fixture.TRAINER_SPECIES)
@@ -472,11 +544,14 @@ func test_master_ball_capture_runs_through_the_real_battle_overlay() -> void:
 		"You threw a %s!" % _data.item_name(Gen2WorldPartyHost.ITEM_MASTER_BALL)
 	)
 
-	for _message: int in 4:
+	var caught: String = "Gotcha! %s was caught!" % _wild_name()
+	for _message: int in 8:
+		if host.battle_snapshot()["message"] == caught:
+			break
 		host.finish()
 		host.advance()
 
-	assert_eq(host.battle_snapshot()["message"], "Gotcha! %s was caught!" % _wild_name())
+	assert_eq(host.battle_snapshot()["message"], caught)
 	host.finish()
 	host.advance()
 	await get_tree().process_frame
@@ -703,14 +778,13 @@ func test_a_trainer_battle_fights_and_writes_back_with_an_egg_in_the_party() -> 
 	save.party.append(egg)
 
 	await _trigger_trainer()
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_child()
 	assert_not_null(host, "an egg in the party must not refuse the battle")
 	assert_eq(host.battle_snapshot()["world_battle_active"], true)
 
 	for _hit: int in 12:
 		host.hurt_enemy()
-	host.finish()
-	host.advance()
+	host = _battle_host()
 	assert_eq(host.battle_snapshot()["message"], "YOU WON.")
 	host.finish()
 	host.advance()
@@ -741,11 +815,10 @@ func test_hp_experience_and_pp_survive_into_the_next_wild_battle() -> void:
 	_world_screen.preview_wild_encounter()
 	await get_tree().process_frame
 	await get_tree().process_frame
-	var host: Gen2BattleScreen = _battle_host()
+	var host: Gen2BattleScreen = _battle_opening()
 	assert_not_null(host)
 	assert_eq(host.battle_snapshot()["message"], "Wild %s appeared!" % _wild_name())
-	host.finish()
-	host.advance()
+	host = _battle_host()
 
 	var player_mon: Gen2BattleMon = host._battle.party(Gen2Battle.PLAYER).mons[0]
 	var max_hp: int = player_mon.max_hp()

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -403,8 +403,10 @@ const MATCHUPS: Array = [
 const FORESIGHT_MATCHUPS: Array = [[NORMAL, GHOST, 0], [FIGHTING, GHOST, 0]]
 
 
-## Writes a cache at [param directory] and opens it.
-static func build(directory: String) -> GameData:
+## Writes a cache at [param directory] and opens it. [param id] is the cartridge
+## the cache claims to be, which the two profiles are told apart by: everything
+## but `gold` and `silver` is Crystal's own branch.
+static func build(directory: String, id: String = "testgame") -> GameData:
 	RomCache.clear(directory)
 	RomCache.prepare(directory)
 
@@ -418,7 +420,7 @@ static func build(directory: String) -> GameData:
 	RomCache.write_json(RomCache.happiness_changes_path(directory), HAPPINESS_CHANGES)
 	RomCache.write_json(RomCache.manifest_path(directory), {
 		"format_version": RomCache.FORMAT_VERSION,
-		"game_id": "testgame",
+		"game_id": id,
 		"sha1": "0123456789abcdef",
 		"complete": true,
 	})

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -563,6 +563,33 @@ func test_an_entrance_plays_the_ball_the_shiny_pass_and_the_cry() -> void:
 	)
 
 
+## The one thing the two profiles part company on here: pokegold's
+## `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation` both reach
+## `PlayStereoCry` with nothing in front of it, so a Pokemon that is asleep,
+## frozen or fainted still cries there. `CheckFaintedFrzSlp` is Crystal's, and
+## so is the pic animation it was added beside.
+func test_gold_and_silver_cry_where_crystal_checks_first() -> void:
+	var directory: String = RomCache.directory_for(&"battletestgold", "0123456789abcdef")
+	var gold: GameData = Fixture.build(directory, "gold")
+	var battle: Gen2Battle = Gen2Battle.create(
+		gold,
+		Gen2BattleMon.create(gold, Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		Gen2BattleMon.create(gold, Fixture.CHARMANDER, 20, [Fixture.TACKLE]),
+		_rng
+	)
+	battle.player.status = Gen2Status.FREEZE
+	assert_eq(
+		_of_type(battle.entrance_events(Gen2Battle.PLAYER), Gen2Battle.CRY).size(), 1
+	)
+	battle.player.status = Gen2Status.NONE
+	battle.player.hp = 0
+	assert_eq(
+		_of_type(battle.entrance_events(Gen2Battle.PLAYER), Gen2Battle.CRY).size(), 1,
+		"and a fainted one, which is the third silence Crystal added"
+	)
+	RomCache.clear(directory)
+
+
 ## `SendOutMonText`'s four lines, at the three boundaries its compares name.
 func test_the_send_out_line_follows_the_opponents_remaining_hp() -> void:
 	var battle: Gen2Battle = _battle(

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -513,10 +513,80 @@ func test_a_switch_between_turns_calls_one_back_and_sends_one_out() -> void:
 		[_mon(Fixture.CHARMANDER, 20, [Fixture.TACKLE])]
 	)
 	var events: Array = battle.send_out(Gen2Battle.PLAYER, 1)
-	assert_eq(events.size(), 2)
+	# The two lines, then `SendOutPlayerMon`'s own ball animation and cry.
+	assert_eq(events.size(), 4)
 	assert_eq(events[0]["type"], Gen2Battle.WITHDREW)
 	assert_eq(int(events[0]["index"]), 0)
 	assert_eq(events[1]["type"], Gen2Battle.SENT_OUT)
+	assert_eq(events[2]["type"], Gen2Battle.ANIMATION)
+	assert_eq(int(events[2]["index"]), Gen2Battle.ANIM_SEND_OUT_MON)
+	assert_eq(int(events[2]["param"]), Gen2Battle.SEND_OUT_ANIM_NORMAL)
+	assert_eq(events[3]["type"], Gen2Battle.CRY)
+
+
+## `SendOutPlayerMon`, `ShowSetEnemyMonAndSendOutAnimation` and the cry gate
+## between them, which every entrance in the source shares.
+func test_an_entrance_plays_the_ball_the_shiny_pass_and_the_cry() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		_mon(Fixture.CHARMANDER, 20, [Fixture.TACKLE])
+	)
+
+	## `SHINY_ATK_MASK` set and the other three DVs at ten, which is the whole of
+	## what `BattleCheckPlayerShininess` asks.
+	battle.player.dvs = Gen2Stats.pack_dvs(
+		Gen2Stats.MAX_DV, Gen2Stats.SHINY_DV, Gen2Stats.SHINY_DV, Gen2Stats.SHINY_DV
+	)
+	var shiny: Array = battle.entrance_events(Gen2Battle.PLAYER)
+	assert_eq(shiny.size(), 3)
+	assert_eq(int(shiny[0]["param"]), Gen2Battle.SEND_OUT_ANIM_NORMAL)
+	assert_false(bool(shiny[0]["enemy_turn"]))
+	assert_eq(int(shiny[1]["param"]), Gen2Battle.SEND_OUT_ANIM_SHINY)
+	assert_eq(shiny[2]["type"], Gen2Battle.CRY)
+
+	## `BattleStartMessage`'s wild branch has no ball in it, and the enemy's own
+	## entrance is played on the other side of the field.
+	var wild: Array = battle.entrance_events(Gen2Battle.ENEMY, false)
+	assert_eq(wild.size(), 1, "an ordinary enemy is neither shiny nor thrown")
+	assert_eq(wild[0]["type"], Gen2Battle.CRY)
+
+	## `CheckFaintedFrzSlp`: asleep, frozen and fainted are the three silences.
+	for state: int in [Gen2Status.FREEZE, Gen2Status.MIN_SLEEP]:
+		battle.player.status = state
+		assert_eq(
+			_of_type(battle.entrance_events(Gen2Battle.PLAYER), Gen2Battle.CRY).size(), 0
+		)
+	battle.player.status = Gen2Status.NONE
+	battle.player.hp = 0
+	assert_eq(
+		_of_type(battle.entrance_events(Gen2Battle.PLAYER), Gen2Battle.CRY).size(), 0
+	)
+
+
+## `SendOutMonText`'s four lines, at the three boundaries its compares name.
+func test_the_send_out_line_follows_the_opponents_remaining_hp() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
+	)
+	var max_hp: int = battle.enemy.max_hp()
+	for row: Array in [
+		[100, Gen2Battle.SEND_OUT_GO], [80, Gen2Battle.SEND_OUT_GO],
+		[60, Gen2Battle.SEND_OUT_DO_IT], [45, Gen2Battle.SEND_OUT_DO_IT],
+		[30, Gen2Battle.SEND_OUT_GO_FOR_IT], [20, Gen2Battle.SEND_OUT_GO_FOR_IT],
+		[5, Gen2Battle.SEND_OUT_FOES_WEAK],
+	]:
+		@warning_ignore("integer_division")
+		battle.enemy.hp = maxi(max_hp * int(row[0]) / 100, 1)
+		assert_eq(
+			battle.send_out_line(Gen2Battle.PLAYER), int(row[1]),
+			"%d%% of the enemy left" % int(row[0])
+		)
+	## `ld hl, GoMonText / jr z` in front of the arithmetic, and the enemy is
+	## never the one announced this way.
+	battle.enemy.hp = 0
+	assert_eq(battle.send_out_line(Gen2Battle.PLAYER), Gen2Battle.SEND_OUT_GO)
+	assert_eq(battle.send_out_line(Gen2Battle.ENEMY), Gen2Battle.SEND_OUT_GO)
 
 
 func test_a_battle_is_over_when_a_whole_party_is_down() -> void:

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -130,3 +130,49 @@ func test_the_middle_band_cuts_through_the_player_panel() -> void:
 			offsets[top], offsets[bottom - 1],
 			"so one panel is drawn in two places at once, which is why this is per scanline"
 		)
+
+
+## `SlideBattlePicOut`, the other half of what the opening display does with the
+## two squares: the pics slide in, and each of them slides out again when its
+## own side sends something out.
+func test_a_pic_slides_off_its_own_side_of_the_screen() -> void:
+	for player_side: bool in [true, false]:
+		var map: PackedByteArray = Gen2BattleScreenMap.seeded()
+		var at: Vector2i = Gen2BattleScreenMap.PLAYER_AT if player_side \
+			else Gen2BattleScreenMap.ENEMY_AT
+		var head: int = at.y * Gen2BattleScreenMap.COLUMNS + at.x
+		var base: int = Gen2BattleScreenMap.PLAYER_BASE_TILE if player_side \
+			else Gen2BattleScreenMap.ENEMY_BASE_TILE
+		assert_eq(int(map[head]), base, "the square starts with its own picture")
+
+		# One step moves the picture one column towards the edge it leaves by,
+		# which is left for the player and right for the enemy.
+		Gen2BattleScreenMap.slide_step(map, player_side)
+		var moved: int = head - 1 if player_side else head + 1
+		assert_eq(int(map[moved]), base, "one column over after one step")
+
+		for _step: int in int(Gen2BattleScreenMap.SLIDE_STEPS[player_side]):
+			Gen2BattleScreenMap.slide_step(map, player_side)
+		var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+			else Gen2BattleScreenMap.ENEMY_SIDE
+		for row: int in side:
+			for column: int in side:
+				var cell: int = (at.y + row) * Gen2BattleScreenMap.COLUMNS + at.x + column
+				assert_eq(
+					int(map[cell]), Gen2BattleScreenMap.BLANK_TILE,
+					"the whole square is empty once the walk has run"
+				)
+
+
+## The other square is not touched: `hlcoord 1, 5` and `hlcoord 18, 0` are seven
+## rows each and neither reaches the other picture.
+func test_a_slide_leaves_the_other_square_alone() -> void:
+	var map: PackedByteArray = Gen2BattleScreenMap.seeded()
+	for _step: int in int(Gen2BattleScreenMap.SLIDE_STEPS[true]):
+		Gen2BattleScreenMap.slide_step(map, true)
+	var enemy: PackedByteArray = Gen2BattleScreenMap.seeded()
+	for row: int in Gen2BattleScreenMap.ENEMY_SIDE:
+		for column: int in Gen2BattleScreenMap.ENEMY_SIDE:
+			var cell: int = (Gen2BattleScreenMap.ENEMY_AT.y + row) * Gen2BattleScreenMap.COLUMNS \
+				+ Gen2BattleScreenMap.ENEMY_AT.x + column
+			assert_eq(int(map[cell]), int(enemy[cell]))

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -287,6 +287,12 @@ func test_the_flash_and_the_spin_take_the_cartridge_count() -> void:
 			break
 		frames += 1
 		spent[scene] = int(spent.get(scene, 0)) + 1
+	## The whole animation, against a real Route 30 trainer, where every one of
+	## these is a frame the oracle timed a routine on: `DoBattleTransition` 793,
+	## `..._DetermineWhichAnimation` 812, `..._LoadPokeBallGraphics` 813,
+	## `..._SetUpBGMap` 817, the first `..._Flash` 818, `..._SetUpForSpinOutro`
+	## 894, `..._Finish` 959, and the screen fully black on 962.
+	assert_eq(frames, 170, "`DoBattleTransition` on 793 and the screen black on 962")
 	assert_eq(int(spent.get(&"flash", 0)), 75, "three passes of 25")
 	assert_eq(
 		int(spent.get(&"spin", 0)),
@@ -299,5 +305,100 @@ func test_the_flash_and_the_spin_take_the_cartridge_count() -> void:
 	)
 	assert_eq(
 		int(spent.get(&"ball", 0)), Gen2BattleTransition.BALL_FRAMES + 1,
-		"LoadPokeBallGraphics and the two frames behind it"
+		"LoadPokeBallGraphics and the three frames behind it"
 	)
+
+
+## The two outros a cave battle takes, which the same oracle measured with
+## `wEnvironment` forced to CAVE: the wavy one runs `..._SineWave` sixteen times
+## over frames 97 to 138 and the zoom is one `..._ZoomToBlack` call over 96 to
+## 132, nine boxes four frames apart.
+func test_the_cave_outros_take_the_cartridge_count() -> void:
+	var wavy: Dictionary = _scene_frames(false, true)
+	assert_eq(int(wavy["sine"]), 42, "97 to 138 inclusive")
+	assert_eq(int(wavy["calls"].get(&"sine", 0)), 16, "fifteen waves and the `cp $60`")
+	var zoom: Dictionary = _scene_frames(true, true)
+	assert_eq(
+		int(zoom["zoom"]),
+		Gen2BattleTransition.ZOOM_BOXES.size() * Gen2BattleTransition.ZOOM_BOX_FRAMES + 1,
+		"96 to 132 inclusive"
+	)
+
+
+## `.DoSineWave` reads the offset before incrementing it, so the counter walks
+## the triangular numbers. A real cartridge holds 0, 1, 3, 6, 10, 15, 21, 28, 36,
+## 45, 55, 66, 78, 91 and 105, and 105 is what ends the outro.
+func test_the_wavy_outro_walks_the_triangular_numbers() -> void:
+	var transition: Gen2BattleTransition = Gen2BattleTransition.create(
+		false, true, false, false, null, _sine_table()
+	)
+	var seen: Array[int] = []
+	while transition.advance_frame():
+		if transition.scene() == &"sine" and not seen.has(transition._sine_amplitude):
+			seen.append(transition._sine_amplitude)
+	assert_eq(seen, [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91])
+
+
+## Frames and calls per scene, read before each step so a frame is counted
+## against the scene that ran on it.
+func _scene_frames(stronger: bool, cave: bool) -> Dictionary:
+	var transition: Gen2BattleTransition = Gen2BattleTransition.create(
+		stronger, cave, false, false, null, _sine_table()
+	)
+	var spent: Dictionary = {}
+	var calls: Dictionary = {}
+	var was_delayed: bool = false
+	var frames: int = 0
+	while frames < 4000:
+		var scene: StringName = transition.scene()
+		was_delayed = transition._delay > 0
+		if not transition.advance_frame():
+			break
+		frames += 1
+		spent[scene] = int(spent.get(scene, 0)) + 1
+		if not was_delayed:
+			calls[scene] = int(calls.get(scene, 0)) + 1
+	spent["calls"] = calls
+	return spent
+
+
+## Nothing in `DoBattleTransition.loop` writes shadow OAM, so the sprites
+## `.InitGFX`'s `UpdateSprites` left stand over the wedges. Each outro's own
+## setup runs `RespawnPlayerAndOpponent`, which hides every map object but the
+## player and `hLastTalked`, and `StartTrainerBattle_Finish` runs `ClearSprites`.
+## Measured on a real Route 30 trainer: 14 OAM slots through the whole flash, 8
+## from the frame `..._SetUpForSpinOutro` runs, and none from `..._Finish`.
+func test_the_sprites_stand_over_the_wedges_until_the_outro_hides_them() -> void:
+	for stronger: bool in [false, true]:
+		for cave: bool in [false, true]:
+			var rng := RandomNumberGenerator.new()
+			rng.seed = 7
+			var transition: Gen2BattleTransition = Gen2BattleTransition.create(
+				stronger, cave, true, false, rng, _sine_table()
+			)
+			var seen: Array[int] = []
+			var flash_sprites: Array[int] = []
+			var frames: int = 0
+			while frames < 4000:
+				var scene: StringName = transition.scene()
+				if not transition.advance_frame():
+					break
+				frames += 1
+				if not seen.has(transition.sprites()):
+					seen.append(transition.sprites())
+				if scene in [&"init", &"ball", &"bgmap", &"flash"]:
+					flash_sprites.append(transition.sprites())
+			assert_eq(
+				seen,
+				[
+					Gen2BattleTransition.SPRITES_ALL,
+					Gen2BattleTransition.SPRITES_BATTLERS,
+					Gen2BattleTransition.SPRITES_NONE,
+				],
+				"every object, then the two battlers, then none, in that order"
+			)
+			for sprites: int in flash_sprites:
+				assert_eq(
+					sprites, Gen2BattleTransition.SPRITES_ALL,
+					"the flash hides nothing: `RespawnPlayerAndOpponent` is the outro's"
+				)

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -176,3 +176,128 @@ func test_a_slide_leaves_the_other_square_alone() -> void:
 			var cell: int = (Gen2BattleScreenMap.ENEMY_AT.y + row) * Gen2BattleScreenMap.COLUMNS \
 				+ Gen2BattleScreenMap.ENEMY_AT.x + column
 			assert_eq(int(map[cell]), int(enemy[cell]))
+
+
+## `DoBattleTransition`, which is the other half of how a battle opens: the
+## overworld's own last two hundred frames, before the pics slide in at all.
+func _run_transition(
+	stronger: bool, cave: bool, trainer: bool, darkness: bool = false
+) -> Dictionary:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 7
+	var transition: Gen2BattleTransition = Gen2BattleTransition.create(
+		stronger, cave, trainer, darkness, rng, _sine_table()
+	)
+	var frames: int = 0
+	var orders: Array[int] = []
+	var squares: int = 0
+	while transition.advance_frame() and frames < 4000:
+		frames += 1
+		if not orders.has(transition.palette_order()):
+			orders.append(transition.palette_order())
+		squares = maxi(squares, _count(transition.cells(), Gen2BattleTransition.CELL_SQUARE))
+	return {
+		"frames": frames, "orders": orders, "squares": squares,
+		"black": _count(transition.cells(), Gen2BattleTransition.CELL_BLACK),
+	}
+
+
+## `sine_table 32` as the cartridge stores it, which is what the wavy outro
+## reads out of the cache. Built here rather than imported: this file has no
+## cartridge, and the table is the assembler's own arithmetic.
+func _sine_table() -> PackedByteArray:
+	var out := PackedByteArray()
+	for index: int in 32:
+		var value: int = int(round(sin(index * PI / 32.0) * 256.0))
+		out.append(value & 0xFF)
+		out.append((value >> 8) & 0xFF)
+	return out
+
+
+func _count(cells: PackedByteArray, value: int) -> int:
+	var out: int = 0
+	for cell: int in cells:
+		out += 1 if cell == value else 0
+	return out
+
+
+func test_every_transition_ends_with_the_screen_black() -> void:
+	for stronger: bool in [false, true]:
+		for cave: bool in [false, true]:
+			var ran: Dictionary = _run_transition(stronger, cave, false)
+			assert_eq(
+				int(ran["black"]),
+				Gen2BattleTransition.COLUMNS * Gen2BattleTransition.ROWS,
+				"DoBattleTransition.done fills every palette with zero"
+			)
+			assert_gt(int(ran["frames"]), 100, "the lead, three flashes and an outro")
+
+
+## `.DoFlashAnimation` walks its thirteen `dc` bytes two frames at a time, and
+## the thirteenth is the `cp %00000001` that ends the pass rather than a palette.
+func test_the_flash_walks_its_own_palette_list_three_times() -> void:
+	var ran: Dictionary = _run_transition(false, false, false)
+	for order: int in Gen2BattleTransition.FLASH_PALETTES:
+		if order == Gen2BattleTransition.FLASH_TERMINATOR:
+			continue
+		assert_true(
+			(ran["orders"] as Array).has(order),
+			"$%02X is one of the orders the flash draws with" % order
+		)
+
+
+## `wTimeOfDayPalset`'s `DARKNESS_PALSET` is the one thing that skips it, and it
+## skips the whole pass rather than one palette.
+func test_darkness_spends_no_frames_on_the_flash() -> void:
+	var lit: Dictionary = _run_transition(false, false, false)
+	var dark: Dictionary = _run_transition(false, false, false, true)
+	assert_eq(Array(dark["orders"]), [Gen2BattleTransition.IDENTITY])
+	assert_lt(int(dark["frames"]), int(lit["frames"]))
+
+
+## `StartTrainerBattle_LoadPokeBallGraphics` returns at once for a wild battle:
+## the ball is what says a person is on the other side of it.
+func test_only_a_trainer_transition_draws_the_poke_ball() -> void:
+	assert_eq(int(_run_transition(false, false, false)["squares"]), 0)
+	var trainer: Dictionary = _run_transition(false, false, true)
+	var lit: int = 0
+	for row: int in Gen2BattleTransition.POKE_BALL:
+		for bit: int in Gen2BattleTransition.BALL_SIDE:
+			lit += 1 if (row & (1 << bit)) != 0 else 0
+	assert_eq(int(trainer["squares"]), lit, "one cell per set bit of the overlay")
+
+
+## The two counts a real cartridge was measured at, which are what the flash and
+## the outros are paced by: `StartTrainerBattle_Flash` is called 25 times before
+## it hands on, three times over, and `..._SpinToBlack` spends three frames a
+## wedge over twenty of them.
+func test_the_flash_and_the_spin_take_the_cartridge_count() -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 1
+	var transition: Gen2BattleTransition = Gen2BattleTransition.create(
+		false, false, true, false, rng, _sine_table()
+	)
+	var spent: Dictionary = {}
+	var frames: int = 0
+	while frames < 4000:
+		## Read before the step, so a frame is counted against the scene that
+		## ran on it rather than against whatever it handed on to.
+		var scene: StringName = transition.scene()
+		if not transition.advance_frame():
+			break
+		frames += 1
+		spent[scene] = int(spent.get(scene, 0)) + 1
+	assert_eq(int(spent.get(&"flash", 0)), 75, "three passes of 25")
+	assert_eq(
+		int(spent.get(&"spin", 0)),
+		Gen2BattleTransition.SPIN_QUADRANTS.size() * 3 + 1,
+		"three frames a wedge, and the call that finds the list out"
+	)
+	assert_eq(
+		int(spent.get(&"init", 0)), Gen2BattleTransition.LEAD_FRAMES + 1,
+		"`.InitGFX` in front of the jumptable"
+	)
+	assert_eq(
+		int(spent.get(&"ball", 0)), Gen2BattleTransition.BALL_FRAMES + 1,
+		"LoadPokeBallGraphics and the two frames behind it"
+	)

--- a/tests/unit/test_trainer_party.gd
+++ b/tests/unit/test_trainer_party.gd
@@ -162,6 +162,8 @@ func test_falkners_pidgeotto_replaces_his_pidgey_after_it_faints() -> void:
 	assert_eq(battle.enemy.level, 9)
 	assert_false(battle.must_replace(Gen2Battle.ENEMY))
 
-	var sent_out: Dictionary = events[events.size() - 1]
+	## The entrance's own animation and cry follow the line, so the line is not
+	## the last event any more.
+	var sent_out: Dictionary = events[0]
 	assert_eq(sent_out["type"], Gen2Battle.SENT_OUT)
 	assert_eq(int(sent_out["level"]), 9, "the level battle_screen.gd reads out of the event")

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -116,6 +116,51 @@ func run(r: RefCounted) -> void:
 		_verify_substitute_pic(game_id, data)
 		_run_every_animation(game_id, data)
 		_play_every_animation(game_id, data)
+		_verify_the_entrance(game_id, data)
+
+
+## `ANIM_SEND_OUT_MON`, which every entrance plays and which nothing else in the
+## corpus reaches with a parameter: `BattleAnim_SendOutMon` is an
+## `anim_if_param_equal` fan, so the sweep above walks its `$0` body alone and
+## the shiny branch is never decoded. Both are run here, on both sides, and the
+## `SFX_SHINE` `BattleStartMessage` plays in front of a trainer's line is looked
+## up in the audio index the way a track is.
+func _verify_the_entrance(game_id: StringName, data: GameData) -> void:
+	var anims: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(data)
+	if not _r.check(anims != null, "%s: no battle animation data in the cache." % game_id):
+		return
+	for param: int in [Gen2Battle.SEND_OUT_ANIM_NORMAL, Gen2Battle.SEND_OUT_ANIM_SHINY]:
+		for enemy_turn: bool in [false, true]:
+			var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create(
+				anims, Gen2Battle.ANIM_SEND_OUT_MON, enemy_turn, param
+			)
+			if not _r.check(
+				player != null,
+				"%s: the send-out animation would not start at param %d." % [game_id, param]
+			):
+				continue
+			var frames: int = 0
+			var sprites: int = 0
+			while player.advance_frame() and frames < MAX_FRAMES:
+				frames += 1
+				sprites = maxi(sprites, player.sprites().size())
+			_r.check(
+				not player.failed(),
+				"%s: the send-out animation ran off its region at param %d." % [
+					game_id, param,
+				]
+			)
+			_r.check(
+				sprites > 0,
+				"%s: the send-out animation drew nothing at param %d on the %s side." % [
+					game_id, param, "enemy" if enemy_turn else "player",
+				]
+			)
+	_r.check(
+		not data.world_audio(&"sfx", Gen2BattleScreen.SFX_SHINE).is_empty(),
+		"%s: SFX_SHINE is not in the audio index, so a trainer battle opens silently." % game_id
+	)
+	print("%s: the entrance runs both send-out branches on both sides." % game_id)
 
 
 ## `GetSubstitutePic`, on both sides and all three cartridges: the doll is four

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -117,6 +117,7 @@ func run(r: RefCounted) -> void:
 		_run_every_animation(game_id, data)
 		_play_every_animation(game_id, data)
 		_verify_the_entrance(game_id, data)
+		_verify_the_transition(game_id, data)
 
 
 ## The two bodies `BattleAnim_SendOutMon`'s parameter picks between, by the bg
@@ -192,6 +193,74 @@ func _verify_the_entrance(game_id: StringName, data: GameData) -> void:
 		"%s: SFX_SHINE is not in the audio index, so a trainer battle opens silently." % game_id
 	)
 	print("%s: the entrance runs both send-out branches on both sides." % game_id)
+
+
+## `DoBattleTransition` on a real cache: the two tiles it wipes with, the palette
+## it floods the map with, and all four animations run to the end.
+##
+## The tiles are content whose value is known independently, which is what checks
+## the address: one of them is solid colour 3 and the other is the chequered
+## square, and no other pair of tiles in the dump is that.
+func _verify_the_transition(game_id: StringName, data: GameData) -> void:
+	var sheet: Dictionary = data.tile_sheet("battle_transition")
+	var indices: PackedByteArray = data.tile_indices("battle_transition")
+	if not _r.check(
+		int(sheet.get("tiles", 0)) == RomLayout.BATTLE_TRANSITION_TILES
+			and indices.size() == RomLayout.BATTLE_TRANSITION_TILES * Gen2Tiles.TILE_PIXELS,
+		"%s: the transition sheet is %d tiles, %d pixels." % [
+			game_id, int(sheet.get("tiles", 0)), indices.size(),
+		]
+	):
+		return
+	var width: int = int(sheet["width"])
+	var square: Array[int] = []
+	var black: Array[int] = []
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in Gen2Tiles.TILE_WIDTH:
+			square.append(int(indices[y * width + x]))
+			black.append(int(indices[y * width + Gen2Tiles.TILE_WIDTH + x]))
+	_r.check(
+		black.count(3) == black.size(),
+		"%s: BATTLETRANSITION_BLACK is not solid colour 3." % game_id
+	)
+	_r.check(
+		square.count(3) < square.size() and square.count(3) > 0,
+		"%s: BATTLETRANSITION_SQUARE has no pattern in it." % game_id
+	)
+	for dark: bool in [false, true]:
+		var palette: PackedColorArray = data.battle_transition_palette(dark)
+		_r.check(
+			palette.size() == RomLayout.TRANSITION_PALETTE_COLORS,
+			"%s: the %s transition palette has %d colours." % [
+				game_id, "dark" if dark else "day", palette.size(),
+			]
+		)
+	## Every animation, to the frame the screen is black on. Nothing here says
+	## what one looks like; what it pins is that all four reach their own end
+	## rather than running off a table, and how long each takes.
+	var lengths: Array[int] = []
+	for stronger: bool in [false, true]:
+		for cave: bool in [false, true]:
+			var rng := RandomNumberGenerator.new()
+			rng.seed = 5
+			var transition: Gen2BattleTransition = Gen2BattleTransition.create(
+				stronger, cave, true, false, rng, data.battle_anim_sine()
+			)
+			var frames: int = 0
+			while transition.advance_frame() and frames < MAX_FRAMES:
+				frames += 1
+			lengths.append(frames)
+			var cells: PackedByteArray = transition.cells()
+			var black_cells: int = 0
+			for cell: int in cells:
+				black_cells += 1 if cell == Gen2BattleTransition.CELL_BLACK else 0
+			_r.check(
+				transition.finished() and black_cells == cells.size(),
+				"%s: the %s transition left %d of %d cells unwiped." % [
+					game_id, "cave" if cave else "route", black_cells, cells.size(),
+				]
+			)
+	print("%s: the four transitions run %s frames." % [game_id, lengths])
 
 
 ## `GetSubstitutePic`, on both sides and all three cartridges: the doll is four

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -119,6 +119,17 @@ func run(r: RefCounted) -> void:
 		_verify_the_entrance(game_id, data)
 
 
+## The two bodies `BattleAnim_SendOutMon`'s parameter picks between, by the bg
+## effects each runs: `.Normal` is `BATTLE_BG_EFFECT_ENTER_MON` alone and
+## `.Shiny` is the inverted flash and the palette cycle. The beta body the fan
+## falls through to runs `BATTLE_BG_EFFECT_BETA_SEND_OUT_MON2` ($2b), which is
+## how a parameter that never reached the interpreter shows up here.
+const SEND_OUT_EFFECTS: Dictionary = {0: [0x0B], 1: [0x01, 0x06]}
+## And how long each takes: the two `anim_wait`s of `.Normal` and the ten of
+## `.Shiny`, plus the frame each batch of commands between them spends.
+const SEND_OUT_FRAMES: Dictionary = {0: 39, 1: 69}
+
+
 ## `ANIM_SEND_OUT_MON`, which every entrance plays and which nothing else in the
 ## corpus reaches with a parameter: `BattleAnim_SendOutMon` is an
 ## `anim_if_param_equal` fan, so the sweep above walks its `$0` body alone and
@@ -141,13 +152,33 @@ func _verify_the_entrance(game_id: StringName, data: GameData) -> void:
 				continue
 			var frames: int = 0
 			var sprites: int = 0
+			var effects: Array = []
 			while player.advance_frame() and frames < MAX_FRAMES:
 				frames += 1
 				sprites = maxi(sprites, player.sprites().size())
+				for effect: Gen2BattleAnimBgEffect in player.bg_effects():
+					if not effects.has(effect.id):
+						effects.append(effect.id)
 			_r.check(
 				not player.failed(),
 				"%s: the send-out animation ran off its region at param %d." % [
 					game_id, param,
+				]
+			)
+			## Which body ran, not just that one did. `BattleAnim_SendOutMon` is
+			## a fan of `anim_if_param_equal`, and a parameter that does not
+			## reach the interpreter falls through to the beta branch, which is
+			## four times as long and deforms the other battler.
+			_r.check(
+				effects == SEND_OUT_EFFECTS[param],
+				"%s: param %d ran bg effects %s, not the pinned %s." % [
+					game_id, param, effects, SEND_OUT_EFFECTS[param],
+				]
+			)
+			_r.check(
+				frames == SEND_OUT_FRAMES[param],
+				"%s: param %d ran %d frames, not the pinned %d." % [
+					game_id, param, frames, SEND_OUT_FRAMES[param],
 				]
 			)
 			_r.check(

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -11,6 +11,10 @@ extends SceneTree
 ## `<move>` is a move number, given to both Pokemon so either side's animation
 ## can be photographed; `<side>` is 0 for the player's own and 1 for the
 ## enemy's; `<frames>` is how many frames into the animation to stop.
+##
+## `<move> 0` photographs the entrance instead, which is `BattleStartMessage` and
+## the opening of `DoBattle` rather than a turn: a wild one, or a trainer's with
+## `<side>` at 1, and `<frames>` counted from the frame the pics stop sliding.
 ## `scene_off` clears the OPTION menu's battle-scene row first, which is what
 ## `CheckBattleScene` reads, and the capture should then show the field
 ## untouched.
@@ -96,12 +100,49 @@ func _process(_delta: float) -> bool:
 	return true
 
 
+## The entrance, stopped [member _frames_in] frames after the slide. `<side>` 1
+## opens a real trainer's fight instead of a wild one, which is the branch with
+## `SFX_SHINE`, a line of its own and two balls thrown rather than one.
+func _drive_entrance() -> bool:
+	if _side_is_enemy:
+		_screen.show_trainer(1, 0)
+	else:
+		_screen.show_matchup(16, 155, 20, 20)
+	while _screen.intro_running():
+		_screen.advance_frame()
+	for _frame: int in _frames_in:
+		if not _screen.frames_running() and _screen.entrance_running():
+			_screen.finish()
+			_screen.advance()
+			continue
+		_screen.advance_frame()
+	return true
+
+
+## Everything `DoBattle` spends before its first menu, so a turn driven after
+## this is a turn rather than the ball still being thrown.
+func _settle_entrance() -> void:
+	for _step: int in MAX_STEPS:
+		if not _screen.frames_running() and not _screen.entrance_running():
+			return
+		if _screen._audio_player != null:
+			_screen._audio_player.stop_all()
+		if _screen.frames_running():
+			_screen.advance_frame()
+			continue
+		_screen.finish()
+		_screen.advance()
+
+
 ## Settles the intro, teaches both Pokemon the move, takes the turn and walks the
 ## event queue to the first animation on the requested side.
 func _drive() -> bool:
+	if _move == 0:
+		return _drive_entrance()
 	_screen.show_matchup(16, 155, 20, 20)
 	while _screen.intro_running():
 		_screen.advance_frame()
+	_settle_entrance()
 
 	var battle: Gen2Battle = _screen._battle
 	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -15,6 +15,11 @@ extends SceneTree
 ## `<move> 0` photographs the entrance instead, which is `BattleStartMessage` and
 ## the opening of `DoBattle` rather than a turn: a wild one, or a trainer's with
 ## `<side>` at 1, and `<frames>` counted from the frame the pics stop sliding.
+## `<frames>` may be a range, `lo-hi`, which writes one `<output>_f<N>.png` per
+## frame in it instead of a single file: that is what a frame by frame diff
+## against a real cartridge reads. A line the entrance waits on is pressed
+## [constant PRESS_AFTER] frames after it has finished printing, since the
+## cartridge waits on a person there and nothing here can.
 ## `scene_off` clears the OPTION menu's battle-scene row first, which is what
 ## `CheckBattleScene` reads, and the capture should then show the field
 ## untouched.
@@ -27,12 +32,22 @@ const DRAW_FRAMES: int = 3
 ## A runaway guard on the event pump: no turn produces anywhere near this many
 ## steps, and a driver that never reaches its animation should say so.
 const MAX_STEPS: int = 4096
+## How long a line that owes a press is left on screen before this driver presses
+## it. A person is what the cartridge waits for; a fixed count is what makes two
+## runs of this tool the same run.
+const PRESS_AFTER: int = 40
 
 var _screen: Gen2BattleScreen = null
 var _output_path: String = ""
 var _move: int = 1
 var _side_is_enemy: bool = false
 var _frames_in: int = 0
+var _range_lo: int = -1
+var _range_hi: int = -1
+var _cursor: int = 0
+var _settle: int = 0
+var _held: int = 0
+var _last_trace: String = ""
 var _scene_off: bool = false
 var _frames: int = 0
 
@@ -48,7 +63,13 @@ func _initialize() -> void:
 	_output_path = args[1]
 	_move = int(args[2])
 	_side_is_enemy = int(args[3]) != 0
-	_frames_in = int(args[4])
+	if args[4].contains("-"):
+		var span: PackedStringArray = args[4].split("-", false)
+		_range_lo = int(span[0])
+		_range_hi = int(span[1]) if span.size() > 1 else int(span[0])
+		_frames_in = _range_hi
+	else:
+		_frames_in = int(args[4])
 	_scene_off = args.size() > 5 and args[5] == "scene_off"
 
 	var data: GameData = GameData.open(StringName(args[0]))
@@ -83,6 +104,8 @@ func _process(_delta: float) -> bool:
 			quit(1)
 			return true
 		return false
+	if _range_lo >= 0:
+		return _shoot_range()
 	if _frames < SETTLE_FRAMES + DRAW_FRAMES:
 		return false
 
@@ -100,6 +123,79 @@ func _process(_delta: float) -> bool:
 	return true
 
 
+## One frame of the entrance per captured picture, the viewport given
+## [constant DRAW_FRAMES] to catch up with each. The frame numbers are counted
+## from the one the pics stop sliding on, which is what the cartridge trace is
+## aligned to as well.
+func _shoot_range() -> bool:
+	## Godot turns processing back on for a node whose script has a `_process`,
+	## and the screen counts hardware frames in its own. Taken away again here
+	## rather than once in `_initialize`, or three of its frames are spent
+	## between every two of this driver's.
+	_screen.set_process(false)
+	if _settle > 0:
+		_settle -= 1
+		return false
+	if _cursor > _range_hi:
+		print("Wrote %d frames to %s_f*.png" % [_range_hi - _range_lo + 1, _prefix()])
+		quit(0)
+		return true
+	if _cursor >= _range_lo:
+		var image: Image = root.get_texture().get_image()
+		var error: Error = image.save_png("%s_f%d.png" % [_prefix(), _cursor])
+		if error != OK:
+			push_error("Could not write frame %d (error %d)" % [_cursor, error])
+			quit(1)
+			return true
+	_trace()
+	_cursor += 1
+	_entrance_frame()
+	_settle = DRAW_FRAMES
+	return false
+
+
+## The frame the opening changed on, and what it changed to. The cartridge's own
+## trace is a list of the frames its routines ran on, so this is the artefact the
+## two are diffed as.
+func _trace() -> void:
+	var now: Dictionary = _screen.entrance_snapshot()
+	var line: String = JSON.stringify(now)
+	if line == _last_trace:
+		return
+	_last_trace = line
+	print("%d %s" % [_cursor, line])
+
+
+func _prefix() -> String:
+	return _output_path.trim_suffix(".png")
+
+
+## One hardware frame of the opening, with the press a person would make.
+##
+## `WildPokemonAppearedText`, `WantsToBattleText` and the `cont` inside
+## `BattleText_EnemySentOut` all wait on a button; this counts
+## [constant PRESS_AFTER] frames of the line standing finished and then presses,
+## so a run of this tool is reproducible where a person is not.
+func _entrance_frame() -> void:
+	_screen.advance_frame()
+	if _screen.frames_running():
+		_held = 0
+		return
+	var box: Gen2TextBox = _screen.get("_box")
+	if box != null and box.is_revealing():
+		_held = 0
+		return
+	if not _screen.entrance_running() and not bool(_screen.battle_snapshot()["awaits_press"]):
+		_held = 0
+		return
+	_held += 1
+	if _held < PRESS_AFTER:
+		return
+	_held = 0
+	_screen.finish()
+	_screen.advance()
+
+
 ## The entrance, stopped [member _frames_in] frames after the slide. `<side>` 1
 ## opens a real trainer's fight instead of a wild one, which is the branch with
 ## `SFX_SHINE`, a line of its own and two balls thrown rather than one.
@@ -110,6 +206,8 @@ func _drive_entrance() -> bool:
 		_screen.show_matchup(16, 155, 20, 20)
 	while _screen.intro_running():
 		_screen.advance_frame()
+	if _range_lo >= 0:
+		return true
 	for _frame: int in _frames_in:
 		if not _screen.frames_running() and _screen.entrance_running():
 			_screen.finish()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -12,6 +12,9 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y] [WxH] [touch]
 ##
+## `kind` may carry the player's own cell as `<kind>@x,y`, which is what a kind
+## reading the two numbers as something else needs: `battle_transition@5,7`.
+##
 ## `WxH` is the window to photograph in, for the two shapes a phone has, and
 ## `touch` draws the on-screen controller with it, which is the only way to see
 ## how [Gen2GameFrame] splits a portrait screen:
@@ -108,6 +111,11 @@ var _kind: StringName = &"effects"
 ## The two numbers after the kind. Most kinds read them as the cell the player
 ## stands on; a few read them as their own arguments.
 var _cell := Vector2i(-1, -1)
+## `<kind>@x,y`: the cell for a kind whose own two numbers are not one, which is
+## `battle_transition`. `battle_transition@5,7` photographs the animation with
+## the player standing on that cell, which is how the grass over a sprite's legs
+## is photographed with the transition already written over it.
+var _kind_cell := Vector2i(-1, -1)
 
 
 func _initialize() -> void:
@@ -124,7 +132,14 @@ func _initialize() -> void:
 			quit(1)
 			return
 		_output_path = args[3]
-		_kind = StringName(args[5]) if args.size() >= 6 else &"effects"
+		var kind_arg: String = args[5] if args.size() >= 6 else "effects"
+		if kind_arg.contains("@"):
+			var halves: PackedStringArray = kind_arg.split("@")
+			kind_arg = halves[0]
+			var at: PackedStringArray = halves[1].split(",")
+			if at.size() == 2:
+				_kind_cell = Vector2i(int(at[0]), int(at[1]))
+		_kind = StringName(kind_arg)
 		if args.size() >= 9:
 			var shape: PackedStringArray = args[8].split("x")
 			if shape.size() == 2:
@@ -174,7 +189,9 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	_cell = cell
 	## The transition reads them as a frame count and a branch rather than as a
 	## cell, so the player is left where the map puts them.
-	if cell.x >= 0 and _kind != &"battle_transition":
+	if _kind_cell.x >= 0:
+		_screen.start_cell = _kind_cell
+	elif cell.x >= 0 and _kind != &"battle_transition":
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
 	## screen resolves is what a wandering NPC's own generator is built from.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -105,6 +105,9 @@ var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
 var _frames: int = 0
 var _kind: StringName = &"effects"
+## The two numbers after the kind. Most kinds read them as the cell the player
+## stands on; a few read them as their own arguments.
+var _cell := Vector2i(-1, -1)
 
 
 func _initialize() -> void:
@@ -168,7 +171,10 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	_screen = packed.instantiate() as Gen2WorldScreen
 	_screen.map_group = group
 	_screen.map_number = number
-	if cell.x >= 0:
+	_cell = cell
+	## The transition reads them as a frame count and a branch rather than as a
+	## cell, so the player is left where the map puts them.
+	if cell.x >= 0 and _kind != &"battle_transition":
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
 	## screen resolves is what a wandering NPC's own generator is built from.
@@ -203,6 +209,13 @@ func _process(_delta: float) -> bool:
 			## is what runs `special DisplayUnownWords` and puts the box up.
 			_screen.press_button(Gen2Button.A)
 			_screen.press_button(Gen2Button.A)
+		elif _kind == &"battle_transition":
+			## `DoBattleTransition` over the map it runs on. The first of the two
+			## numbers is how many frames into it to photograph rather than a
+			## cell, since a transition is two hundred of them and every one is
+			## a different picture; the second is 1 for a trainer's, which is the
+			## branch that draws the Poke Ball and floods the map.
+			_screen.preview_battle_transition(_cell.x, _cell.y != 0)
 		elif _kind == &"yes_no":
 			## `Script_yesorno`'s own box: the NPC beside the player is talked
 			## to and each page answered until the choice the script ends on is
@@ -290,7 +303,10 @@ func _process(_delta: float) -> bool:
 				_screen.call(SCREEN_DRIVER % _kind)
 		else:
 			_screen.preview_effect_sprites(_kind)
-		if _kind not in [&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine"]:
+		if _kind not in [
+			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
+			&"battle_transition",
+		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.
 			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -35,10 +35,11 @@ const GAMES: Array[StringName] = [&"gold", &"silver", &"crystal"]
 ## Twenty seconds of hardware frames: long enough for several walks, a script
 ## and a wild roll, short enough that no run crosses a clock minute.
 const DEFAULT_FRAMES: int = 1200
-## What the battle route asks for instead. A fight costs its intro, an animation
-## per hit and the boxes on either side of each, and it has to be walked into
-## first; forty seconds is still inside the same clock minute.
-const BATTLE_FRAMES: int = 2400
+## What the battle route asks for instead. A fight costs `DoBattleTransition`'s
+## own two hundred frames, then its intro, an animation per hit and the boxes on
+## either side of each, and it has to be walked into first; fifty seconds is
+## still inside the same clock minute.
+const BATTLE_FRAMES: int = 3000
 const DIRECTIONS: Array[int] = [
 	Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT
 ]


### PR DESCRIPTION
A battle went straight from the sliding pics to its first line: no shine, no cry, no ball, and no animation over the map in front of any of it. The whole entrance is built now, and every step of it is measured against a real cartridge frame by frame rather than read off the disassembly.

## The entrance

- `Gen2Battle.entrance_events` is `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation`: `ANIM_SEND_OUT_MON`, a second pass of it for a shiny, and the cry `CheckFaintedFrzSlp` allows. `send_out` appends it, so every switch, replacement and drag gets the same list.
- `Gen2BattleScreen._build_entrance` is the rest, one stage per step: a trainer's `SFX_SHINE`, `WaitSFX` and twenty frames, the start line, `ShowBattleTextEnemySentOut` with the enemy's own entrance, then `DoBattle`'s forty frames and the player's.
- `ANIM_SEND_OUT_MON` is `$101`, not 101. The comments in `constants/move_constants.asm` are hexadecimal and the animations past the moves open with `const_next $ff`; 101 is NIGHT SHADE, which decodes, runs and draws, so every ball thrown in the game was a night shade over the wrong battler for 145 frames instead of 39.
- The pic layer's cache key held the tilemap itself, and a packed array is passed by reference: the key changed with the map it was keyed on, so every animation that edits nothing but the tilemap was invisible. That is most of them, and it is why a trainer never left the field.
- `GetTrainerBackpic` stands the player on their own square and `InitEnemyTrainer` the opponent on theirs, `SlideBattlePicOut` walks each off it, and `BattleStart_TrainerHuds` hangs both parties' balls over them. `ClearActorHud` reads `hBattleTurn` and clears one panel, not two, and `InitBattleDisplay` clears both to begin with.
- The three opening lines wait on a button, `PlayStereoCry` holds for as long as the cry lasts, and Gold and Silver reach it with nothing in front of it: pokegold has no `AnimateFrontpic`, so `CheckFaintedFrzSlp` is Crystal's alone and applies on that profile only.

## `DoBattleTransition`

All four variants, the jumptable one entry a frame, owned by the world screen: an encounter resolves and then spends the animation before the battle screen is built at all.

| Scene | Cartridge | This branch |
|---|---|---|
| `.InitGFX` + `DetermineWhichAnimation` | 793 to 812 | 20 |
| `LoadPokeBallGraphics` | 813 to 816 | 4 |
| `SetUpBGMap`, `Flash`, `NextScene`, `SetUpForSpinOutro` | 817, 818 to 892, 893, 894 | 1, 75, 1, 1 |
| `SpinToBlack` | 895 to 958 | 64 |
| `Finish` and `.done` | 959 to 962 | 4 |
| **the whole animation** | **170** | **170** |
| `SineWave`, the wavy outro | 97 to 138, sixteen calls | 42, sixteen |
| `ZoomToBlack` | 96 to 132, **one** call | 37 |

Both cave outros were reached by forcing `wEnvironment` and the opponent's level on a wild encounter, since nothing walks into a cave battle from a new game. Three arithmetic errors fell out of that: the spin's and the scatter's own three `.end` frames were overwritten by the tail rather than added to it, the zoom draws its nine boxes inside one jumptable entry four frames apart rather than one entry a box, and the wavy outro stepped its counter by the offset after incrementing it where `ld a, [hl] / inc [hl]` reads it before.

## What is drawn over what

- **The transition is background and goes under the sprites.** Nothing in its loop writes shadow OAM, so every map object `UpdateSprites` left stands on top of the wedges: a real cartridge holds 14 OAM slots through the whole flash, 8 from the frame each outro's `RespawnPlayerAndOpponent` runs, and none from `StartTrainerBattle_Finish`, which is `ClearSprites`.
- **The flash is the background's order alone.** It writes `wBGP` and calls `DmgToCgbBGPals`, where a map fade writes `wOBP0`/`wOBP1` and calls `DmgToCgbObjPals` as well; the player's own 74 black, 35 red and 31 skin pixels are identical on every frame of it.
- **A sprite standing in grass loses its legs to the wedge, not to the grass**, since OAM_PRIO tests whatever the tilemap holds now. The sixteen rows of the player's box hold 6, 8, 10, 10, 12, 12, 14, 14 and then eight zeroes of visible pixels, which is the cartridge's own frame exactly.
- **Every overworld sprite was drawn four pixels too low.** `.InitSprite` writes an object's OAM y as `add OAM_Y_OFS - 4` against a plain `add OAM_X_OFS`, and one write covers the lot: the emote, the jump shadow, the boulder dust and the shaking grass are tracking objects that copy the tracked object's own `OBJECT_SPRITE_Y`, and the jump arc, the tracking bob and the fishing rod are offsets added in front of it. `UpdateAnimFrame` adds no `OAM_Y_OFS` at all, so the cut tree, the headbutt tree, the leaves and the heal machine were already right.

## Cache and tools

Cache format 70 carries what the entrance needs: `GetTrainerBackpic`'s three pictures with Kris's read uncompressed the way `GetKrisBackpic` reads it, the two palettes `GetPlayerOrMonPalettePointer` picks between, `LoadBallIconGFX`'s four tiles, `BattleTransitionTiles`' two and the two palettes `LoadPokeBallGraphics` floods with.

`tools/checks/battle_anims.gd` runs both parameter branches of the send-out animation on both sides of all three cartridges. `tools/preview_battle_anim.gd` takes a frame range and writes one PNG per frame beside a trace of what the opening changed on each, in the same shape a cartridge routine trace has. `tools/preview_world.gd ... live battle_transition[@x,y] <frame> <trainer>` photographs any frame of the animation, optionally with the player stood on a named cell.

| Check | Result |
|---|---|
| GUT, both tiers | 3,265 over 152 scripts, green, no orphans |
| `validate.gd -- all` | 54 topics, 0 failures |
| `replay_world.gd` | 11 routes on each of three profiles, 0 failures |
| Story walk, three profiles | exit 0 on each |
| Boot smoke, with and without mods | clean |

Two things are deliberately not the cartridge's yet and are recorded rather than hidden: `AnimateFrontpic`, the enemy picture's wobble, which is Crystal's alone and needs the pic model to grow, and the transition's silence, since `PlayBattleMusic` runs two frames in front of it on hardware and the two screens own an audio player each.
