### PR TITLE
Play the battle's own track under its transition, on one driver

### DIFF
--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -217,6 +217,9 @@ func audio_status() -> Dictionary:
 		"volume": _engine.volume,
 		"sound_output": _engine.sound_output,
 		"registered_banks": _engine.registered_bank_count(),
+		# The bank and address of the piece the driver is on, which is the same
+		# key a second request for it is continued by. Empty when nothing is.
+		"music_key": _music_key,
 	}
 
 

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -261,15 +261,15 @@ func _ensure_pixels() -> void:
 	]
 	if enemy_key != _enemy_pixels_key:
 		if int(enemy_key[3]) > 0:
-			_enemy_pixels = _padded_pic(
+			_enemy_pixels = padded_pic(_data,
 				_data.trainer_pic(int(enemy_key[3])), Gen2BattleScreenMap.ENEMY_SIDE
 			)
 		elif bool(enemy_key[1]):
 			_enemy_pixels = _substitute_pic(false)
 		else:
-			_enemy_pixels = _padded_pic(
+			_enemy_pixels = padded_pic(_data,
 				_battler_pic(int(enemy_key[0]), int(enemy_key[2]), false),
-				Gen2BattleScreenMap.ENEMY_SIDE
+				Gen2BattleScreenMap.ENEMY_SIDE, true
 			)
 		_enemy_pixels_key = enemy_key
 	var player_key: Array = [
@@ -278,14 +278,14 @@ func _ensure_pixels() -> void:
 	]
 	if player_key != _player_pixels_key:
 		if not String(player_key[3]).is_empty():
-			_player_pixels = _padded_pic(
+			_player_pixels = padded_pic(_data,
 				_data.player_backpic(String(player_key[3])),
 				Gen2BattleScreenMap.PLAYER_SIDE
 			)
 		elif bool(player_key[1]):
 			_player_pixels = _substitute_pic(true)
 		else:
-			_player_pixels = _padded_pic(
+			_player_pixels = padded_pic(_data,
 				_battler_pic(int(player_key[0]), int(player_key[2]), true),
 				Gen2BattleScreenMap.PLAYER_SIDE
 			)
@@ -338,7 +338,13 @@ static func substitute_pixels(strip: PackedByteArray, player_side: bool) -> Pack
 	return out
 
 
-func _padded_pic(pic: Dictionary, side: int) -> PackedByteArray:
+## [param front] is whether `PadFrontpic` runs over this one: a back pic fills
+## its own box and a trainer's is already the whole 7x7, so neither is padded.
+## Static because the placement is the whole of the picture and takes no screen:
+## a check sweeping three caches builds the box the way the renderer does.
+static func padded_pic(
+	data: GameData, pic: Dictionary, side: int, front: bool = false
+) -> PackedByteArray:
 	var box: int = side * TILE
 	var out: PackedByteArray = PackedByteArray()
 	out.resize(box * box)
@@ -347,7 +353,7 @@ func _padded_pic(pic: Dictionary, side: int) -> PackedByteArray:
 
 	var atlas_name: String = String(pic.get("atlas", ""))
 	var cell: Dictionary = Gen2PicImage.atlas_cell(
-		_data.atlas_indices(atlas_name), _data.atlas(atlas_name), pic
+		data.atlas_indices(atlas_name), data.atlas(atlas_name), pic
 	)
 	if cell.is_empty():
 		return out
@@ -356,9 +362,21 @@ func _padded_pic(pic: Dictionary, side: int) -> PackedByteArray:
 	var width: int = mini(int(cell["width"]), box)
 	var height: int = mini(int(cell["height"]), box)
 	var stride: int = int(cell["width"])
-	for y: int in height:
-		for x: int in width:
-			out[y * box + x] = indices[y * stride + x]
+	## `PadFrontpic` does not centre a pic smaller than the 7x7 block: it lays one
+	## blank tile column in front of it and blank tiles above each column, so the
+	## pic is bottom-aligned one column in. The tile numbers `PlaceGraphic` writes
+	## count over the padded block, so a pic left at the corner here is drawn a
+	## column left and a row or two high of where the cartridge draws it.
+	var pad_x: int = 0
+	var pad_y: int = 0
+	if front:
+		@warning_ignore("integer_division")
+		pad_x = Gen2PicImage.frontpic_pad_columns(width / TILE) * TILE
+		@warning_ignore("integer_division")
+		pad_y = Gen2PicImage.frontpic_pad_rows(height / TILE) * TILE
+	for y: int in mini(height, box - pad_y):
+		for x: int in mini(width, box - pad_x):
+			out[(y + pad_y) * box + x + pad_x] = indices[y * stride + x]
 	return out
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -350,6 +350,9 @@ var _anim_event: Dictionary = {}
 ## a flag for both.
 var _anim_hud_hidden: int = -1
 var _audio_player: Gen2AudioPlayer = null
+## False while the driver belongs to the screen that opened this one, which is
+## what says this screen may not stop or free it.
+var _owns_audio_player: bool = false
 ## `PlayBattleMusic`'s answer for this fight; see [method battle_music].
 var _battle_music: int = Gen2Battle.MUSIC_NONE
 
@@ -502,9 +505,15 @@ func _ready() -> void:
 	if not _renderer_ready:
 		return
 
-	_audio_player = AUDIO_PLAYER_SCRIPT.new()
-	_audio_player.name = "AudioPlayer"
-	add_child(_audio_player)
+	## The cartridge has one APU. A screen that opened this one hands its own
+	## driver over so a cry here takes the channels the map music is holding
+	## rather than sounding over a second copy of them; only a battle standing on
+	## its own builds a player, and only that one owns it.
+	if _audio_player == null:
+		_audio_player = AUDIO_PLAYER_SCRIPT.new()
+		_audio_player.name = "AudioPlayer"
+		_owns_audio_player = true
+		add_child(_audio_player)
 	_anim_data = Gen2BattleAnimData.from_game_data(_data)
 
 	## Under the text box, because the refusals a switch list is answered with are
@@ -563,6 +572,23 @@ func _ready() -> void:
 ## imported cache.
 func set_data(data: GameData) -> void:
 	_injected_data = data
+
+
+## `CleanUpBattleRAM` zeroes `wLowHealthAlarm`. A driver this screen does not own
+## outlives it, so the byte is cleared where the screen goes rather than where a
+## fight ends: every way out of a battle, including a wipe and a failed setup, is
+## a way out of the tree.
+func _exit_tree() -> void:
+	if _audio_player != null and not _owns_audio_player:
+		_audio_player.set_low_health_alarm(false)
+
+
+## Hands this screen the driver the opening screen is already running, before it
+## enters the tree. Without one the screen builds its own, which is what a
+## battle launched on its own does.
+func set_audio_player(player: Gen2AudioPlayer) -> void:
+	_audio_player = player
+	_owns_audio_player = false
 
 
 ## The rules the world is being played under, so the fight inside it is fought
@@ -1636,17 +1662,19 @@ func _end_script() -> void:
 
 ## `PlayBattleMusic`, which `FindFirstAliveMonAndStartBattle` runs in front of
 ## `DoBattleTransition`: the piece playing is stopped, the volume goes back to
-## maximum, and the battle's own track starts. The world's map music is stopped
-## by the screen that opened this one, so the two players never overlap.
+## maximum, and the battle's own track starts. A world battle has already had it
+## started by the screen that ran the transition, on the same driver and from the
+## same request, so this asks for a track already playing and the driver
+## continues it. A battle standing on its own is where it actually starts.
 func _play_battle_music() -> void:
 	_battle_music = Gen2Battle.MUSIC_NONE
 	if _audio_player == null or _data == null or _battle == null:
 		return
 	var landmark: int = _world_context.landmark if _world_context != null \
 		else Gen2WorldRadio.LANDMARK_SPECIAL
-	_battle_music = Gen2Battle.battle_music(
-		_battle.battle_type, _enemy_trainer_class, _enemy_trainer_index,
-		landmark, _time_of_day, Gen2WorldState.is_crystal_profile(_data),
+	_battle_music = Gen2WorldBattleAdapter.music_for(
+		_world_battle_request, landmark, _time_of_day,
+		Gen2WorldState.is_crystal_profile(_data),
 	)
 	var record: Dictionary = _data.world_audio(&"music", _battle_music)
 	if record.is_empty():
@@ -4256,7 +4284,7 @@ func _build_renderer() -> void:
 		if _screen.native_size_changed.is_connected(_on_native_size_changed):
 			_screen.native_size_changed.disconnect(_on_native_size_changed)
 		_renderer.get_parent().remove_child(_renderer)
-		_renderer.queue_free()
+		Gen2Screen.drop(_renderer)
 	_renderer = Gen2ModHost.instance().create_battle_renderer()
 	if Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
 		_screen.display_content(_renderer)

--- a/game/launcher/launcher_sheet.gd
+++ b/game/launcher/launcher_sheet.gd
@@ -104,7 +104,7 @@ func close() -> void:
 	if _restore_focus != null and is_instance_valid(_restore_focus):
 		_restore_focus.grab_focus()
 	closed.emit()
-	queue_free()
+	Gen2Screen.drop(self)
 
 
 ## Unhandled rather than [method Control._gui_input], which only ever reaches the

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -65,9 +65,7 @@ static func row(separation: int = GAP_MD) -> HBoxContainer:
 static func clear(container: Node) -> void:
 	if container == null:
 		return
-	for child: Node in container.get_children():
-		container.remove_child(child)
-		child.queue_free()
+	Gen2Screen.drop_children(container)
 
 
 static func spacer() -> Control:

--- a/game/launcher/touch_layout_sheet.gd
+++ b/game/launcher/touch_layout_sheet.gd
@@ -125,7 +125,7 @@ func close() -> void:
 	_pad.set_edit_mode(false)
 	Gen2InputRuntime.instance().apply_options(_options)
 	closed.emit()
-	queue_free()
+	Gen2Screen.drop(self)
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -39,9 +39,7 @@ func _ready() -> void:
 ## drawn entirely in code can switch palette without every widget growing a
 ## repaint path of its own.
 func _build() -> void:
-	for child: Node in get_children():
-		remove_child(child)
-		child.queue_free()
+	Gen2Screen.drop_children(self)
 	theme = _palette.control_theme()
 
 	_shell = Gen2LauncherShell.create(_palette)

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -65,8 +65,34 @@ func native_size() -> Vector2i:
 func clear() -> void:
 	for parent: Node in [_viewport, _native]:
 		for child: Node in parent.get_children():
-			parent.remove_child(child)
-			child.queue_free()
+			drop(child)
+
+
+## Takes a node off the screen now and frees it at the end of the frame.
+##
+## `queue_free` on its own only does the second half: the node stays in the tree,
+## and drawn, until the frame it was dropped on is served. A replacement added on
+## the same frame is then composited over its predecessor rather than instead of
+## it, which is a stale panel showing under the live one for exactly the frame a
+## screenshot catches; inside a [Container] the two are laid out side by side.
+##
+## Static, and the one way a screen drops a child it is replacing.
+static func drop(node: Node) -> void:
+	if node == null or not is_instance_valid(node):
+		return
+	var parent: Node = node.get_parent()
+	if parent != null:
+		parent.remove_child(node)
+	node.queue_free()
+
+
+## The same for every child of [param parent], which is what a row list being
+## rebuilt in place wants.
+static func drop_children(parent: Node) -> void:
+	if parent == null:
+		return
+	for child: Node in parent.get_children():
+		drop(child)
 
 
 ## The viewport itself, for a caller that needs to read the drawn frame.

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -165,6 +165,15 @@ static func frontpic_pad_columns(width: int, mirrored: bool = false) -> int:
 	return FRONTPIC_TILES - 1 - width if mirrored else 1
 
 
+## The same pad above the pic, in tiles. `PadFrontpic` writes its blank tiles in
+## front of each column, so a shorter pic is bottom-aligned in the box whichever
+## way `wBoxAlignment` runs its columns.
+static func frontpic_pad_rows(height: int) -> int:
+	if height >= FRONTPIC_TILES or height <= 0:
+		return 0
+	return FRONTPIC_TILES - height
+
+
 ## The same mirror on an index buffer, for a caller that will recolour it.
 static func x_flipped_indices(indices: PackedByteArray, width: int) -> PackedByteArray:
 	if width <= 0:

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -143,7 +143,7 @@ func _start() -> void:
 
 
 func _on_splash_finished() -> void:
-	_splash.queue_free()
+	Gen2Screen.drop(_splash)
 	_splash = null
 	_start_profile_setup()
 
@@ -164,7 +164,7 @@ func _start_profile_setup() -> void:
 
 func _on_gender_chosen(chosen: int) -> void:
 	_gender = chosen
-	_gender_screen.queue_free()
+	Gen2Screen.drop(_gender_screen)
 	_gender_screen = null
 	_start_clock()
 
@@ -184,7 +184,7 @@ func _start_clock() -> void:
 
 func _on_clock_set(day: int, hour: int, minute: int) -> void:
 	_clock = {"day": day, "hour": hour, "minute": minute}
-	_clock_screen.queue_free()
+	Gen2Screen.drop(_clock_screen)
 	_clock_screen = null
 	_start_speech()
 

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -403,7 +403,7 @@ func _show_name_choices() -> void:
 
 
 func _on_name_choice(chosen: String) -> void:
-	_name_menu.queue_free()
+	Gen2Screen.drop(_name_menu)
 	_name_menu = null
 	if chosen == "":
 		_open_naming()
@@ -439,7 +439,7 @@ func _on_named(entered: String) -> void:
 
 
 func _after_naming_fade() -> void:
-	_naming.queue_free()
+	Gen2Screen.drop(_naming)
 	_naming = null
 	_hide_speech(false)
 	if _text_box != null:

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -235,7 +235,7 @@ func _open_area() -> void:
 		_data, species, nests, _world.landmark(), _world.state.hall_of_fame(),
 		_world.player_female(), _world.map_time_of_day()
 	):
-		host.queue_free()
+		Gen2Screen.drop(host)
 		return
 	host.closed.connect(_on_area_closed)
 	_area = host
@@ -244,7 +244,7 @@ func _open_area() -> void:
 
 func _on_area_closed() -> void:
 	if _area != null:
-		_area.queue_free()
+		Gen2Screen.drop(_area)
 		_area = null
 	## `.Area` redisplays the entry it left, cursor and page included.
 	_mode = Mode.ENTRY

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1951,7 +1951,7 @@ func set_screen(screen: Gen2Screen) -> void:
 ## Frees the overlay, since it lives in a screen this node does not own.
 func _exit_tree() -> void:
 	if _view != null:
-		_view.queue_free()
+		Gen2Screen.drop(_view)
 		_view = null
 
 
@@ -2106,8 +2106,7 @@ func _render_options(values: Array, cursor_index: int, label_for: Callable) -> v
 		_pack_view.visible = false
 	if _options == null:
 		return
-	for child: Node in _options.get_children():
-		child.queue_free()
+	Gen2Screen.drop_children(_options)
 	for index: int in values.size():
 		var label := Label.new()
 		var option_text: String = label_for.call(values[index])

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -179,7 +179,7 @@ func _image_from(indices: PackedByteArray, attributes: PackedInt32Array) -> Imag
 ## shared counter is on.
 func _refresh_badges() -> void:
 	for node: Node in _badges:
-		node.queue_free()
+		Gen2Screen.drop(node)
 	_badges = []
 	if _page == Gen2TrainerCard.PAGE_1 or _data == null:
 		return

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -92,6 +92,29 @@ static func prepare(
 	}
 
 
+## `PlayBattleMusic`'s track, off the request alone.
+##
+## `FindFirstAliveMonAndStartBattle` runs `PlayBattleMusic` in front of
+## `DoBattleTransition`, so the piece starts before the fight is built: the
+## world screen asks here when the transition opens and the battle screen asks
+## again for the same track, which the driver continues rather than restarts.
+## Both read the one request, so neither can pick a different piece.
+static func music_for(
+	request: Dictionary, landmark_id: int, day_period: int, crystal: bool = true
+) -> int:
+	var raw: Variant = request.get("values", request)
+	if not raw is Dictionary:
+		return Gen2Battle.MUSIC_NONE
+	var values: Dictionary = raw as Dictionary
+	var trainer: bool = StringName(values.get("kind", &"")) == &"trainer"
+	return Gen2Battle.battle_music(
+		int(values.get("battle_type", Gen2Battle.BATTLETYPE_NORMAL)),
+		int(values.get("trainer_group", 0)) if trainer else 0,
+		int(values.get("trainer_id", 0)) if trainer else 0,
+		landmark_id, day_period, crystal,
+	)
+
+
 static func fallback_party(
 	data: GameData, first_species: int = 155, level: int = 5, size: int = 2
 ) -> Gen2Party:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -346,7 +346,7 @@ func _build_renderer() -> void:
 		if _screen.native_size_changed.is_connected(_on_native_size_changed):
 			_screen.native_size_changed.disconnect(_on_native_size_changed)
 		_renderer.get_parent().remove_child(_renderer)
-		_renderer.queue_free()
+		Gen2Screen.drop(_renderer)
 	_renderer = Gen2ModHost.instance().create_world_renderer()
 	if Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
 		_screen.display_content(_renderer)
@@ -2109,13 +2109,13 @@ func _handle_fishing_result(result: Dictionary) -> void:
 
 
 ## `StartBattle`: the transition first, and the battle screen only once it has
-## finished. `PlayBattleMusic` opens with `PlayMusic MUSIC_NONE`, so the map's
-## own track stops here rather than when the fight is built.
+## finished. `PlayBattleMusic` runs in front of `DoBattleTransition`, so the
+## map's track stops and the battle's own starts here, 170 frames before the
+## fight is built, and the animation is played under it rather than in silence.
 func _start_battle_request(request: Dictionary) -> void:
 	if _battle_host != null or _battle_transition != null or _data == null:
 		return
-	if _audio_player != null:
-		_audio_player.stop_all()
+	_play_battle_music(request)
 	_battle_transition_request = request.duplicate(true)
 	_battle_transition = _build_battle_transition(request)
 	if _battle_transition == null:
@@ -2234,6 +2234,25 @@ func _apply_battle_transition() -> void:
 	)
 
 
+## `PlayBattleMusic`, resolved from the request rather than from a fight that
+## does not exist yet. Asking twice for the same track is what the driver
+## continues, so the transition and the battle screen behind it never restart the
+## piece between them.
+func _play_battle_music(request: Dictionary) -> void:
+	if _audio_player == null or _data == null:
+		return
+	var landmark: int = _world.landmark() if _world != null \
+		else Gen2WorldRadio.LANDMARK_SPECIAL
+	var track: int = Gen2WorldBattleAdapter.music_for(
+		request, landmark, time_of_day, Gen2WorldState.is_crystal_profile(_data)
+	)
+	var record: Dictionary = _data.world_audio(&"music", track)
+	if record.is_empty():
+		_audio_player.stop_all()
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
 func _open_battle_host(request: Dictionary) -> void:
 	if _battle_host != null or _data == null:
 		return
@@ -2245,6 +2264,7 @@ func _open_battle_host(request: Dictionary) -> void:
 	_battles_fought += 1
 	var host: Gen2BattleScreen = BATTLE_SCENE.instantiate() as Gen2BattleScreen
 	host.set_data(_data)
+	host.set_audio_player(_audio_player)
 	host.set_rules(_world.rules if _world != null else null)
 	## Drawn from the world's own generator, so the fight's own decisions are part
 	## of the run's seeded chain and a replay reproduces them without recording
@@ -2273,11 +2293,10 @@ func _open_battle_host(request: Dictionary) -> void:
 	## deferred call: `startbattle` is a script command, so the fight belongs to
 	## the frame the encounter fired on, and a run driven frame by frame (a check,
 	## a replay) never reaches a deferred call at all.
-	## `PlayBattleMusic` opens with `PlayMusic MUSIC_NONE`, which is one driver
-	## silencing itself. The battle runs its own [Gen2AudioPlayer], so the map's
-	## has to be the thing that stops, or both pieces play at once.
-	if _audio_player != null:
-		_audio_player.stop_all()
+	## `PlayBattleMusic` has already run, either in front of the transition or
+	## here for a request that had none, and the fight is handed this screen's own
+	## driver, so its first cry takes the channels the track is holding.
+	_play_battle_music(request)
 	host.start_world_battle(request.duplicate(true), save, badges)
 	## After the fight exists, because starting one clears whatever capture action
 	## was staged: the bag belongs to this battle rather than to the last one.
@@ -2357,7 +2376,7 @@ func _on_battle_finished(result: Dictionary) -> void:
 	var host: Gen2BattleScreen = _battle_host
 	_battle_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	if not String(_battle_encounter_id).is_empty():
 		var fought: StringName = _battle_encounter_id
 		_battle_encounter_id = &""
@@ -2574,7 +2593,7 @@ func _open_service_host() -> void:
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	var persist: bool = save != null and _injected_save == null
 	if not host.open_pending(_world, _data, save, persist):
-		host.queue_free()
+		Gen2Screen.drop(host)
 		_script_prompt = "Service request unavailable"
 		_refresh_labels()
 		return
@@ -2625,7 +2644,7 @@ func _on_hall_of_fame_closed() -> void:
 	var host: Gen2HallOfFameScreen = _hall_of_fame_host
 	_hall_of_fame_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	var written: Dictionary = persist_world_snapshot()
 	_script_prompt = "Hall of Fame recorded" if bool(written.get("ok", false)) \
 		else "Hall of Fame not saved: %s" % String(written.get("reason", "unknown"))
@@ -2676,7 +2695,7 @@ func _on_credits_closed() -> void:
 	var host: Gen2CreditsScreen = _credits_host
 	_credits_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	_play_current_map_music()
 	if _renderer != null:
 		_renderer.refresh()
@@ -2742,7 +2761,7 @@ func _open_start_menu_host(entry: Callable) -> void:
 	if not host.open(
 		_world, _data, Callable(self, "persist_world_snapshot"), _start_menu_cursor
 	):
-		host.queue_free()
+		Gen2Screen.drop(host)
 		_script_prompt = "Start menu unavailable"
 		_refresh_labels()
 		return
@@ -2776,7 +2795,7 @@ func _on_start_menu_action(kind: StringName) -> void:
 	_start_menu_host = null
 	if host != null:
 		_start_menu_cursor = host.cursor()
-		host.queue_free()
+		Gen2Screen.drop(host)
 	_reopen_start_menu = kind in [
 		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_POKEGEAR,
 		Gen2WorldStartMenu.ITEM_PLAYER, Gen2WorldStartMenu.ITEM_POKEDEX,
@@ -2838,7 +2857,7 @@ func _on_pokedex_closed() -> void:
 	_pokedex_host = null
 	if host != null:
 		_pokedex_prev_entry = host.previous_entry()
-		host.queue_free()
+		Gen2Screen.drop(host)
 	_script_prompt = "Pokedex closed"
 	_reopen_start_menu_if_due()
 	_refresh_labels()
@@ -2936,7 +2955,7 @@ func _on_trainer_card_closed() -> void:
 	var host: Gen2TrainerCardScreen = _trainer_card_host
 	_trainer_card_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	_script_prompt = "Trainer card closed"
 	_reopen_start_menu_if_due()
 	_refresh_labels()
@@ -2947,7 +2966,7 @@ func _on_start_menu_closed() -> void:
 	_start_menu_host = null
 	if host != null:
 		_start_menu_cursor = host.cursor()
-		host.queue_free()
+		Gen2Screen.drop(host)
 	_script_prompt = "Start menu closed"
 	_refresh_labels()
 
@@ -2961,7 +2980,7 @@ func _on_field_item_used(request: Dictionary) -> void:
 	_start_menu_host = null
 	if host != null:
 		_start_menu_cursor = host.cursor()
-		host.queue_free()
+		Gen2Screen.drop(host)
 	## `.Field` reaches `ExitAllMenus`, so nothing reopens behind the effect.
 	_reopen_start_menu = false
 	if _world == null:
@@ -3049,7 +3068,7 @@ func _open_embedded_party() -> void:
 		return
 	var save: Gen2SaveData = _embedded_party_save()
 	if save == null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 		_script_prompt = "Party requires a validated save"
 		_refresh_labels()
 		return
@@ -3073,7 +3092,7 @@ func _on_party_closed(_result: Dictionary) -> void:
 	var host: Gen2PartyScreen = _party_host
 	_party_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	_script_prompt = "Party closed"
 	_reopen_start_menu_if_due()
 	_refresh_labels()
@@ -3089,7 +3108,7 @@ func _on_party_action(action: Dictionary) -> void:
 	var host: Gen2PartyScreen = _party_host
 	_party_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	# `PokemonActionSubmenu`'s `.quit` reaches `ExitAllMenus`, so a field move
 	# leaves the overworld rather than reopening the menu behind it.
 	_reopen_start_menu = false
@@ -3517,7 +3536,7 @@ func _open_service_overlay(kind: StringName) -> void:
 	var opened: bool = host.open_pokegear(_world, _data, save, persist) if kind == &"pokegear" \
 		else host.open_phone_list(_world, _data, save, persist)
 	if not opened:
-		host.queue_free()
+		Gen2Screen.drop(host)
 		_script_prompt = "%s unavailable" % label
 		_refresh_labels()
 		return
@@ -3545,7 +3564,7 @@ func _open_fly_map(request: Dictionary) -> void:
 	var save: Gen2SaveData = _injected_save if _injected_save != null \
 		else _selected_runtime_save()
 	if not host.open_fly_map(_world, _data, save, request):
-		host.queue_free()
+		Gen2Screen.drop(host)
 		_script_prompt = "Region map unavailable"
 		_refresh_labels()
 		return
@@ -3577,7 +3596,7 @@ func _on_service_completed(results: Array) -> void:
 	var host: Gen2WorldServiceScreen = _service_host
 	_service_host = null
 	if host != null:
-		host.queue_free()
+		Gen2Screen.drop(host)
 	if _apply_fly_choice(results):
 		return
 	# `ExitPokegearRadio_HandleMusic`: only the radio card takes the music off the
@@ -3974,7 +3993,7 @@ func _hide_map_name_sign() -> void:
 	_map_name_sign_frames = 0
 	if _map_name_sign == null:
 		return
-	_map_name_sign.queue_free()
+	Gen2Screen.drop(_map_name_sign)
 	_map_name_sign = null
 
 
@@ -4006,7 +4025,7 @@ func _open_unown_wall(word: String) -> bool:
 func _close_unown_wall() -> void:
 	if _unown_wall_box == null:
 		return
-	_unown_wall_box.queue_free()
+	Gen2Screen.drop(_unown_wall_box)
 	_unown_wall_box = null
 	_play_sfx(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
 	## The wait behind the box is the staged text the special left, so the script
@@ -4016,7 +4035,7 @@ func _close_unown_wall() -> void:
 
 func _hide_story_picture() -> void:
 	if _story_picture != null:
-		_story_picture.queue_free()
+		Gen2Screen.drop(_story_picture)
 		_story_picture = null
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -626,7 +626,7 @@ func _leave_mart() -> void:
 
 func _close_mart() -> void:
 	if _mart_hardware != null:
-		_mart_hardware.queue_free()
+		Gen2Screen.drop(_mart_hardware)
 		_mart_hardware = null
 		_mart_view = null
 	_panel.visible = true
@@ -998,7 +998,7 @@ func _open_boxes() -> void:
 ## script with; nothing is waiting here, because the PC's request is still open.
 func _on_boxes_closed(_result: Dictionary) -> void:
 	if _boxes != null:
-		_boxes.queue_free()
+		Gen2Screen.drop(_boxes)
 		_boxes = null
 	_panel.visible = true
 	_service_hardware.visible = true
@@ -1180,7 +1180,7 @@ func _on_card_closed() -> void:
 func _close_card() -> void:
 	if _pokegear == null:
 		return
-	_pokegear.queue_free()
+	Gen2Screen.drop(_pokegear)
 	_pokegear = null
 
 
@@ -1260,7 +1260,7 @@ func _open_town_map(from_request: bool) -> void:
 func _on_town_map_closed() -> void:
 	var chosen: int = _town_map.chosen_spawn() if _town_map != null else -1
 	if _town_map != null:
-		_town_map.queue_free()
+		Gen2Screen.drop(_town_map)
 		_town_map = null
 	_panel.visible = true
 	_service_hardware.visible = true
@@ -1395,8 +1395,7 @@ func _finish(results: Array) -> void:
 func _render_options(override: Array = []) -> void:
 	if _options == null:
 		return
-	for child: Node in _options.get_children():
-		child.queue_free()
+	Gen2Screen.drop_children(_options)
 	var parent: Container = _options
 	if _mode == MODE.MENU and _menu != null and _menu.kind == &"2d":
 		var grid := GridContainer.new()

--- a/tests/integration/test_battle_low_health_alarm.gd
+++ b/tests/integration/test_battle_low_health_alarm.gd
@@ -62,3 +62,26 @@ func test_a_fainted_player_silences_the_alarm() -> void:
 	assert_true(_alarm())
 	_screen.set_hp(40, 40, 0, 40)
 	assert_false(_alarm())
+
+
+## `CleanUpBattleRAM` zeroes the byte whole. When the driver belongs to the
+## screen that opened this one it outlives the fight, so a battle left with the
+## alarm armed would beep over the map music it hands back; the clear is where
+## the screen leaves the tree, which is every way out of a battle.
+func test_a_shared_driver_is_left_with_the_alarm_off() -> void:
+	var driver := Gen2AudioPlayer.new()
+	add_child(driver)
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	var borrower := packed.instantiate() as Gen2BattleScreen
+	borrower.set_data(_data)
+	borrower.set_audio_player(driver)
+	add_child(borrower)
+	borrower.set_hp(40, 40, 2, 40)
+	assert_true(driver.low_health_alarm())
+
+	remove_child(borrower)
+	borrower.free()
+	assert_false(driver.low_health_alarm())
+	assert_true(is_instance_valid(driver), "and the driver is not the fight's to free")
+	remove_child(driver)
+	driver.free()

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -202,9 +202,10 @@ func test_a_renderer_rebuilt_mid_scene_stays_below_the_live_text_box() -> void:
 	assert_eq(_world_screen._text_box, box, "the same live box node")
 	assert_eq(box.texture, texture, "with the glyphs it was already showing")
 	assert_true(box.visible)
-	## `_build_renderer` drops the old view with `queue_free`, which the game
-	## serves at the end of its frame and a test has to spend one to see.
-	await get_tree().process_frame
+	## And the view it replaced is off the screen on the frame it was replaced,
+	## not at the end of it: `queue_free` alone would leave the old one drawn
+	## under the new for one frame, which is a stale layer a screenshot catches.
+	assert_eq(_dropped_on(viewport), 0, "the old view is off the screen, not under the new")
 
 
 ## The same rule in the battle screen, whose box is never hidden at all.
@@ -216,7 +217,17 @@ func test_a_battle_renderer_rebuilt_mid_scene_stays_below_the_interface() -> voi
 	var children: Array = viewport.get_children()
 	assert_eq(children.find(_battle_screen._renderer), 0, "the renderer is the floor")
 	assert_true(children.find(_battle_screen._box) > 0)
-	await get_tree().process_frame
+	assert_eq(_dropped_on(viewport), 0, "the old view is off the screen, not under the new")
+
+
+## How many of the viewport's children are already dead: `queue_free` alone
+## leaves a replaced node in the tree, and drawn, until the frame ends.
+func _dropped_on(viewport: SubViewport) -> int:
+	var count: int = 0
+	for child: Node in viewport.get_children():
+		if child.is_queued_for_deletion():
+			count += 1
+	return count
 
 
 ## A page turn hides the box and the next event shows it again inside one call,

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1082,6 +1082,48 @@ func test_a_trainer_battle_opens_on_the_track_its_class_names() -> void:
 	)
 
 
+## `PlayBattleMusic` runs on frame 791 of the cartridge trace and
+## `DoBattleTransition` on 793, so the fight's own track is chosen and started
+## before the animation rather than 170 frames after it. The two screens share
+## one driver, the way the cartridge has one APU, and both read the one request,
+## so the battle screen asks for a piece already playing and the driver continues
+## it instead of restarting it.
+func test_the_battle_track_is_chosen_before_the_transition_on_one_driver() -> void:
+	await _open_world()
+	await _walk_one(Vector2i.RIGHT)
+	for _frame: int in 400:
+		_world_screen.advance_frame()
+		if _world_screen.battle_transition_running():
+			break
+		var pending: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+			_world_screen._advance_script_input()
+	assert_true(_world_screen.battle_transition_running())
+	var chosen: int = Gen2WorldBattleAdapter.music_for(
+		_world_screen._battle_transition_request,
+		_world_screen._world.landmark(),
+		_world_screen.time_of_day,
+		Gen2WorldState.is_crystal_profile(_world_screen._data)
+	)
+	assert_eq(chosen, Gen2Battle.MUSIC_JOHTO_GYM_LEADER_BATTLE)
+	var driver: Gen2AudioPlayer = _world_screen._audio_player
+	assert_not_null(driver)
+
+	## The transition is already running, so the overlay is what the rest of its
+	## frames build rather than another encounter.
+	for _frame: int in 600:
+		if _battle_child() != null:
+			break
+		_world_screen.advance_frame()
+	await get_tree().process_frame
+	var host: Gen2BattleScreen = _battle_child()
+	assert_not_null(host)
+	assert_same(host._audio_player, driver, "one driver, the way there is one APU")
+	assert_eq(host.battle_music(), chosen, "and the same piece either side")
+	## The driver is the world's child, so the fight leaving cannot take it.
+	assert_eq(driver.get_parent(), _world_screen)
+
+
 ## `StartBattle`: `DoBattleTransition` owns every frame between the encounter
 ## resolving and the battle screen existing, and the map is what it draws over.
 func test_a_battle_runs_its_transition_before_the_overlay_exists() -> void:

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -185,3 +185,50 @@ func test_a_wild_request_carries_its_own_dvs_into_the_battle() -> void:
 	assert_eq(
 		(rolled["battle"] as Gen2Battle).enemy.dvs, Gen2BattleMon.PERFECT_DVS
 	)
+
+
+## `PlayBattleMusic` runs in front of `DoBattleTransition`, so the track has to
+## be answerable from the request alone, before a battle exists to read. It is
+## the same answer `Gen2Battle.battle_music` gives the prepared fight, which is
+## what lets the driver continue the piece rather than restart it behind the
+## transition.
+func test_the_battle_track_is_answerable_from_the_request_alone() -> void:
+	var wild: Dictionary = {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5}}
+	assert_eq(
+		Gen2WorldBattleAdapter.music_for(wild, Gen2Battle.LANDMARK_NONE, Gen2WorldPalette.TIME_DAY),
+		Gen2Battle.battle_music(
+			Gen2Battle.BATTLETYPE_NORMAL, 0, 0,
+			Gen2Battle.LANDMARK_NONE, Gen2WorldPalette.TIME_DAY
+		)
+	)
+	## A trainer's own two numbers are the request's, and a wild request holding
+	## neither must not be read as trainer class 0's row by accident.
+	var leader: Dictionary = {"values": {
+		"kind": &"trainer",
+		"trainer_group": Gen2Battle.TRAINER_CLASS_CHAMPION,
+		"trainer_id": 1,
+	}}
+	assert_eq(
+		Gen2WorldBattleAdapter.music_for(
+			leader, Gen2Battle.LANDMARK_NONE, Gen2WorldPalette.TIME_DAY
+		),
+		Gen2Battle.MUSIC_CHAMPION_BATTLE
+	)
+	## `BATTLETYPE_SUICUNE` sits in front of both compares, so it wins over the
+	## class the request also carries.
+	var roaming: Dictionary = {"values": {
+		"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5,
+		"battle_type": Gen2Battle.BATTLETYPE_ROAMING,
+	}}
+	assert_eq(
+		Gen2WorldBattleAdapter.music_for(
+			roaming, Gen2Battle.LANDMARK_NONE, Gen2WorldPalette.TIME_NIGHT
+		),
+		Gen2Battle.MUSIC_SUICUNE_BATTLE
+	)
+	assert_eq(
+		Gen2WorldBattleAdapter.music_for(
+			{"values": 5}, Gen2Battle.LANDMARK_NONE, Gen2WorldPalette.TIME_DAY
+		),
+		Gen2Battle.MUSIC_NONE
+	)

--- a/tools/checks/pokepic.gd
+++ b/tools/checks/pokepic.gd
@@ -2,9 +2,10 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies `Script_pokepic`'s box against freshly imported real caches: the
-## whole species corpus on all three cartridges, drawn through the same
-## [Gen2PokepicPage] the world screen displays.
+## Verifies `PadFrontpic`'s placement against freshly imported real caches: the
+## whole species corpus on all three cartridges, through both boxes a front pic
+## is drawn in, `Script_pokepic`'s [Gen2PokepicPage] and the battle screen's own
+## 7x7 block.
 ##
 ## What a sampled case cannot say: `PadFrontpic` gives a 5x5, a 6x6 and a 7x7
 ## three different corners inside `PlaceGraphic`'s block, so a page that centres
@@ -54,6 +55,7 @@ func _check_game() -> void:
 		)
 		sizes[tiles] = int(sizes.get(tiles, 0)) + 1
 		_check_placement(image, species, tiles)
+		_check_battle_block(pic, species, tiles)
 	_r.note("pokepic %d of %d species, sizes %s" % [
 		drawn, LAST_SPECIES - FIRST_SPECIES + 1, sizes
 	])
@@ -84,5 +86,47 @@ func _ink(image: Image, area: Rect2i, blank: Color) -> bool:
 	for y: int in area.size.y:
 		for x: int in area.size.x:
 			if image.get_pixel(area.position.x + x, area.position.y + y) != blank:
+				return true
+	return false
+
+
+## The same pad in the battle screen's block. `PlaceGraphic` numbers the enemy's
+## 7x7 box column-major from its own first tile, so the tile numbers a fight and
+## an animation write only land on the pic if the pixels sit where `PadFrontpic`
+## put them: bottom-aligned, one column in. A pic left at the block's corner is
+## drawn a column left and a row or two high, which is what this catches.
+func _check_battle_block(pic: Dictionary, species: int, tiles: Vector2i) -> void:
+	var side: int = Gen2BattleScreenMap.ENEMY_SIDE
+	var box: int = side * Gen2Font.TILE
+	var block: PackedByteArray = Gen2BattleRenderer.padded_pic(_r.data, pic, side, true)
+	if not _r.check(block.size() == box * box, "species %d has no battle block." % species):
+		return
+	var at := Vector2i(
+		Gen2PicImage.frontpic_pad_columns(tiles.x), Gen2PicImage.frontpic_pad_rows(tiles.y)
+	) * Gen2Font.TILE
+	var area := Rect2i(at, tiles * Gen2Font.TILE)
+	_r.check(
+		_block_ink(block, box, area),
+		"species %d draws nothing where PadFrontpic puts it in the battle block." % species
+	)
+	## And nowhere else: every pixel outside the pic's own rectangle is the pad,
+	## which the hardware leaves as the blank tile the block was filled with.
+	var outside: bool = false
+	for y: int in box:
+		for x: int in box:
+			if area.has_point(Vector2i(x, y)):
+				continue
+			outside = outside or block[y * box + x] != 0
+	_r.check(
+		not outside,
+		"species %d draws outside its own pic in the battle block." % species
+	)
+
+
+## Whether [param area] of a battle block holds a pixel that is not colour 0.
+func _block_ink(block: PackedByteArray, box: int, area: Rect2i) -> bool:
+	for y: int in area.size.y:
+		for x: int in area.size.x:
+			if block[(area.position.y + y) * box + area.position.x + x] != 0:
 				return true
 	return false


### PR DESCRIPTION
`PlayBattleMusic` runs in front of `DoBattleTransition` (frames 791 and 793 of the Route 30 cartridge trace), so the fight's track plays under the whole 170-frame animation. The world screen resolves and starts it where the transition opens, and the battle screen is handed the world's own `Gen2AudioPlayer` rather than building a second one: the cartridge has one APU, and a cry in the fight has to take the channels the track is holding. Both sides read the track off the one request through `Gen2WorldBattleAdapter.music_for`, so the battle asks for a piece already playing and the driver continues it rather than restarting it. `CleanUpBattleRAM`'s `wLowHealthAlarm` is cleared where the screen leaves the tree, since a driver it does not own outlives the fight.

`PadFrontpic` does not centre a pic smaller than `PlaceGraphic`'s 7x7 block: one blank tile column in front of it and blank tiles above each column, so the pic is bottom-aligned one column in. The battle renderer left it at the block's corner, drawing 161 of Crystal's 251 species eight pixels left and eight or sixteen up. The `pokepic` check sweeps both boxes a front pic is drawn in, over the whole corpus on all three dumps.

`queue_free` does not take a node off the screen, it only frees it at the end of the frame: a screen that dropped a panel and added its replacement in the same call left both drawn, the old under the new, and inside a `Container` laid them out side by side. `Gen2Screen.drop` and `.drop_children` remove first and free after, which is what `Gen2Screen.clear` and the launcher's container rebuild already did; every site that drops a node on screen goes through them.

| Check | Result |
|---|---|
| GUT, unit tier | 2,864 over 124 scripts, green |
| GUT, full tier | 3,268 over 152 scripts, green, no orphans |
| `validate.gd -- all` | 54 topics PASS, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | exit 0 each |
| Boot smoke, with and without mods | no ERROR, WARNING or SCRIPT ERROR |
