### PR TITLE
Real cartridge UI everywhere in game, and occupancy for encounter providers

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -36,7 +36,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -202,10 +202,10 @@ belongs to the first one followed, so it is on screen once.
 ## Adding content
 
 `mods/examples/new_content/` is every non-renderer surface of the contract in one
-file, `api_version` 5: it registers a type and two chart exceptions, a species
+file, `api_version` 6: it registers a type and two chart exceptions, a species
 with its own decoded art, a move and its effect, an item with a pack pocket and a
 mart shelf, a named control axis and a visible-encounter population that reads
-the run's rules, patches two cartridge rows, watches both event channels and
+the run's rules and refuses a cell something is standing on, patches two cartridge rows, watches both event channels and
 rewrites the world channel's presentation. Copy it and read it beside this
 section.
 
@@ -865,6 +865,7 @@ The context is a snapshot, never a live handle:
 |---|---|
 | `map` | `Vector2i(group, number)` |
 | `eligible` | `{grass, surf}` to `PackedVector2Array` of cells a wild may stand on. `CanEncounterWildMon` per cell: the grass test, the cave and dungeon branch that skips it, and the ice refusal |
+| `occupied` | `PackedVector2Array` of the walk cells the map's own objects hold this frame: NPCs, item balls and every other map object, all four cells of a big one, and both cells an object mid-step is drawn across. Refreshed with `player`, not with `map`. Deliberately apart from `eligible`, which is a cartridge rule and never moves: an entry outside `eligible` is dropped, so folding the two together would delete a wild an NPC walks over. Refusing an occupied cell is the provider's own choice. The player's cell is not in it; `player` is where that is |
 | `tables` | `{grass, surf}` to `{source, slots}`, the table a roll would read right now, with the swarm's and the Bug Contest's substitutions already made and the time of day already picked. A slot is `{species, min_level, max_level}` |
 | `player` | `{cell, facing}` |
 | `run_seed` | The run's own seed, so a population is reproducible |

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -18,7 +18,9 @@ const FILENAME: String = "mod.json"
 ## 4 added types, type matchups and mod-supplied art as content, and
 ## [method Gen2ModHost.register_event_mutator].
 ## 5 added [member Gen2WorldAPI.rules], the run's own divergence flags.
-const API_VERSION: int = 5
+## 6 added `occupied` to the visible-encounter context, which is the only way a
+## provider can tell that a cell has an NPC or an item ball standing on it.
+const API_VERSION: int = 6
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -85,17 +85,6 @@ const TEXT_FALLBACKS: Dictionary = {
 	TEXT_TOSS_THREW: "Threw away\n<RAM_>(S).",
 }
 
-const PANEL: Color = Color("#14233a")
-const BORDER: Color = Color("#4f6f9e")
-const SCRIM: Color = Color(0.02, 0.04, 0.08, 0.78)
-const TEXT: Color = Color("#f4f7fb")
-const MUTED: Color = Color("#9eacc0")
-const ACCENT: Color = Color("#f3c969")
-const SUCCESS: Color = Color("#7bd89a")
-const ERROR: Color = Color("#ef8a8a")
-
-## How many window pixels a hardware pixel is drawn as inside the panel.
-const PACK_VIEW_SCALE: int = 2
 
 ## The pack's submenus, all `MENU_BACKUP_TILES` boxes over the pack's own screen.
 ##
@@ -139,7 +128,6 @@ var _pack_result: String = ""
 var _pack_scroll: Array[int] = [0, 0, 0, 0]
 var _pack_cursors: Array[int] = [0, 0, 0, 0]
 var _pack_page: Gen2PackPage = null
-var _pack_view: TextureRect = null
 var _pack_result_ok: bool = false
 ## `PrintText` waits per page, so a result longer than the box's two rows is
 ## pressed through rather than cut off at the frame.
@@ -176,6 +164,8 @@ var _pending_entry: Callable = Callable()
 ## because the second teach_tm_hm() call has to name the same Pokémon the first
 ## one refused.
 var _forget_moves: Array = []
+## `MoveCantForgetHMText` while the list it was refused on is still open.
+var _forget_refusal: String = ""
 var _forget_cursor: int = 0
 var _forget_party_index: int = -1
 var _forget_confirm_cursor: int = 0
@@ -213,20 +203,12 @@ var _target_page: Gen2PartyMenuPage = null
 ## Leftover of a hardware frame the target list's icons have not counted yet.
 var _target_elapsed: float = 0.0
 ## The panel's own two roots, hidden whenever a cartridge screen is up.
-var _scrim: ColorRect = null
-var _center: CenterContainer = null
 
-var _title: Label = null
-var _summary: Label = null
-var _options: VBoxContainer = null
-var _status: Label = null
-var _footer: Label = null
 
 
 func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	_build_ui()
 	if _menu != null:
 		_open_list_mode()
 	if _pending_entry.is_valid():
@@ -241,8 +223,8 @@ func _ready() -> void:
 ## to know how a snapshot is written or where saves live.
 ##
 ## Mirrors Gen2BoxScreen.set_context(): open() may be called before or after this
-## node enters the tree, so building the option list defers to _ready() until
-## _title/_options exist, and runs immediately here otherwise.
+## node enters the tree, so opening the list defers to _ready() until it is in
+## one, and runs immediately here otherwise.
 func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_cursor: int = 0) -> bool:
 	_world = world
 	_data = data
@@ -250,7 +232,7 @@ func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_c
 	if _world == null or _data == null:
 		return false
 	_menu = Gen2WorldStartMenu.from_world(_world, previous_cursor)
-	if is_inside_tree() and _options != null:
+	if is_inside_tree():
 		_open_list_mode()
 	return true
 
@@ -302,11 +284,11 @@ func open_registered_item() -> void:
 	_confirm_use()
 
 
-## Holds an entry point until the panel exists, the way [method open] holds the
-## list. A caller that opens this screen before adding it to the tree is a
-## preview or a test; the overworld adds it first.
+## Holds an entry point until this screen is in the tree, the way [method open]
+## holds the list. A caller that opens this screen before adding it to the tree
+## is a preview or a test; the overworld adds it first.
 func _defer_entry(entry: Callable) -> bool:
-	if is_inside_tree() and _options != null:
+	if is_inside_tree():
 		return false
 	_pending_entry = entry
 	return true
@@ -381,6 +363,7 @@ func _move(direction: Vector2i) -> void:
 				_forget_cursor = wrapi(
 					_forget_cursor + signi(direction.y), 0, _forget_moves.size()
 				)
+				_forget_refusal = ""
 				_render_forget_list()
 		Mode.PACK_STOP_LEARNING:
 			if direction.y != 0 or direction.x != 0:
@@ -546,8 +529,6 @@ func _confirm_list() -> void:
 	if _menu == null or _menu.size() == 0:
 		return
 	if not _menu.selected_available():
-		_status.text = "%s is not available yet." % String(_menu.selected_item().get("label", ""))
-		_status.add_theme_color_override("font_color", MUTED)
 		return
 	match _menu.selected_kind():
 		Gen2WorldStartMenu.ITEM_PACK:
@@ -573,28 +554,13 @@ func _confirm_list() -> void:
 
 func _open_list_mode() -> void:
 	_mode = Mode.LIST
-	_title.text = "MENU"
-	_summary.text = ""
-	_status.text = ""
-	_footer.text = "D-pad: move    A: choose    B: close"
 	_render_list()
 
 
 func _render_list() -> void:
 	if _menu == null:
 		return
-	## `.PrintMenuAccount`: the highlighted entry's own line, under the list,
-	## only while MENU ACCOUNT is on. `.IsMenuAccountOn` is read on every cursor
-	## move, so turning it off in OPTION takes the box away at once.
-	if Gen2OptionsStore.current().menu_account:
-		_status.text = _menu.selected_description()
-		_status.add_theme_color_override("font_color", MUTED)
-	else:
-		_status.text = ""
-	_render_options(_menu.items(), _menu.cursor, func(entry: Dictionary) -> String:
-		var label: String = String(entry.get("label", ""))
-		return label if bool(entry.get("available", false)) else "%s (unavailable)" % label
-	)
+	_render_hardware()
 
 
 ## `StartMenu_Option`'s `farcall Option`. The model edits the shared
@@ -604,10 +570,6 @@ func _render_list() -> void:
 func _open_options_mode() -> void:
 	_mode = Mode.OPTIONS
 	_options_menu = Gen2WorldOptionsMenu.build(Gen2OptionsStore.current())
-	_title.text = "OPTION"
-	_summary.text = ""
-	_status.text = ""
-	_footer.text = "Up and down: move    Left and right: change    B: back"
 	_render_options_menu()
 
 
@@ -616,16 +578,10 @@ func _open_options_mode() -> void:
 func _persist_options() -> void:
 	if Gen2OptionsStore.save(_options_menu.options()):
 		return
-	_status.text = "The options file could not be written."
-	_status.add_theme_color_override("font_color", ERROR)
 
 
 func _render_options_menu() -> void:
-	_render_options(_options_menu.rows(), _options_menu.cursor, func(row: Dictionary) -> String:
-		var value: String = String(row.get("value", ""))
-		var label: String = String(row.get("label", ""))
-		return label if value.is_empty() else "%s    %s" % [label, value]
-	)
+	_render_hardware()
 
 
 ## The MODS entry: the mods that registered a setting, one row each. Only
@@ -635,17 +591,11 @@ func _open_mods_mode() -> void:
 	_mode = Mode.MODS
 	_mod_ids = Gen2ModHost.instance().option_mod_ids()
 	_mod_cursor = clampi(_mod_cursor, 0, maxi(_mod_ids.size() - 1, 0))
-	_title.text = "MODS"
-	_summary.text = ""
-	_status.text = ""
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_mods()
 
 
 func _render_mods() -> void:
-	_render_options(_mod_ids, _mod_cursor, func(id: StringName) -> String:
-		return _mod_name(id)
-	)
+	_render_hardware()
 
 
 ## The name the player installed, falling back to the id for a mod registered
@@ -661,10 +611,6 @@ func _open_mod_options_mode(id: StringName) -> void:
 	_mode = Mode.MOD_OPTIONS
 	_mod_id = id
 	_mod_option_cursor = 0
-	_title.text = _mod_name(id).to_upper()
-	_summary.text = ""
-	_status.text = ""
-	_footer.text = "Up and down: move    Left and right: change    B: back"
 	_render_mod_options()
 
 
@@ -675,19 +621,7 @@ func _mod_options() -> Array:
 
 
 func _render_mod_options() -> void:
-	_render_options(_mod_options(), _mod_option_cursor, func(row: Dictionary) -> String:
-		match StringName(row.get("kind", Gen2ModHost.OPTION_LADDER)):
-			Gen2ModHost.OPTION_BUTTON:
-				return "%s    %s" % [
-					String(row.get("label", "")), String(row.get("press_label", "Go"))
-				]
-			Gen2ModHost.OPTION_NUMBER:
-				return "%s    %d" % [String(row.get("label", "")), int(row.get("value", 0))]
-		return "%s    %s" % [
-			String(row.get("label", "")),
-			String((row.get("labels", []) as Array)[int(row.get("index", 0))]),
-		]
-	)
+	_render_hardware()
 
 
 ## A button row acts on the press and stores nothing. A ladder row ignores A.
@@ -698,12 +632,9 @@ func _press_mod_option() -> void:
 	var row: Dictionary = rows[_mod_option_cursor]
 	if StringName(row.get("kind", Gen2ModHost.OPTION_LADDER)) != Gen2ModHost.OPTION_BUTTON:
 		return
-	var result: Dictionary = Gen2ModHost.instance().press_option(
-		_mod_id, StringName(row.get("key", &""))
-	)
-	if not bool(result.get("ok", false)):
-		_status.text = Gen2ModRefusal.text(result)
-		_status.add_theme_color_override("font_color", ERROR)
+	## Both of `press_option`'s refusals are ruled out by the two checks above,
+	## and this screen has no cartridge box to print one in either way.
+	Gen2ModHost.instance().press_option(_mod_id, StringName(row.get("key", &"")))
 
 
 ## One step either way: a rung, wrapping the way the cartridge's own value rows
@@ -718,10 +649,7 @@ func _adjust_mod_option(rows: Array, delta: int) -> void:
 		_mod_id, StringName(row.get("key", &"")), delta
 	)
 	if not bool(result.get("ok", false)):
-		_status.text = Gen2ModRefusal.text(result)
-		_status.add_theme_color_override("font_color", ERROR)
 		return
-	_status.text = ""
 	_render_mod_options()
 
 
@@ -743,10 +671,6 @@ func _open_pack_mode(reset: bool = true) -> void:
 	## The CANCEL row is always there, so an emptied pocket puts the cursor on it
 	## rather than on an item that is gone.
 	_pack_cursor = clampi(_pack_cursor, 0, _current_pocket_items().size())
-	_status.text = ""
-	_footer.text = "Left and right: pocket    Up and down: move    A: %s    B: back" % (
-		"give" if _give_target >= 0 else "choose"
-	)
 	_render_pack()
 
 
@@ -798,13 +722,7 @@ func _pack_cursor_on_cancel() -> bool:
 
 func _render_pack() -> void:
 	var pocket: Dictionary = _current_pocket()
-	_title.text = "GIVE" if _give_target >= 0 else "PACK"
-	_summary.text = String(pocket.get("name", ""))
-	_status.text = ""
-	_render_options([], -1, func(_entry: Variant) -> String: return "")
-	if _pack_view != null:
-		_pack_view.visible = _view == null or not _view.visible
-		_pack_view.texture = ImageTexture.create_from_image(_pack_image())
+	_render_hardware()
 
 
 ## The five rows `ScrollingMenu_UpdateDisplay` writes, out of the pocket's own
@@ -971,17 +889,11 @@ func _open_item_mode() -> void:
 	_giving = false
 	_item_actions = Gen2WorldPack.item_submenu(_data, int(item.get("item", 0)))
 	_item_cursor = 0
-	_status.text = ""
-	_summary.text = String(item.get("name", ""))
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_item_menu()
 
 
 func _render_item_menu() -> void:
-	_title.text = "PACK"
-	_render_options(_item_actions, _item_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
-	)
+	_render_hardware()
 
 
 func _confirm_item_action() -> void:
@@ -1090,17 +1002,11 @@ func _open_give_swap(party_index: int, held_name: String) -> void:
 	_swap_cursor = 0
 	_swap_target = party_index
 	_swap_question = Gen2WorldPack.ask_swap_text(_target_name(party_index), held_name)
-	_status.text = ""
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_give_swap()
 
 
 func _render_give_swap() -> void:
-	_title.text = "GIVE"
-	_summary.text = _swap_question
-	_render_options([{"label": "YES"}, {"label": "NO"}], _swap_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
-	)
+	_render_hardware()
 
 
 ## The answer to `PokemonAskSwapItemText`. Its no is `.abort`, which leaves both
@@ -1288,17 +1194,11 @@ func _open_teach_mode(item: int) -> void:
 	_teaching = false
 	_teach_cursor = 0
 	_mode = Mode.PACK_TEACH
-	_status.text = ""
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_teach()
 
 
 func _render_teach() -> void:
-	_title.text = "TEACH"
-	_summary.text = String(_teach_prompt.get("text", ""))
-	_render_options([{"label": "YES"}, {"label": "NO"}], _teach_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
-	)
+	_render_hardware()
 
 
 ## The yes/no answer. Yes reaches ChooseMonToLearnTMHM, which is the same party
@@ -1345,19 +1245,11 @@ func _teach_selected_item(party_index: int) -> void:
 func _open_forget_ask() -> void:
 	_mode = Mode.PACK_FORGET_ASK
 	_forget_confirm_cursor = 0
-	_status.text = ""
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_forget_ask()
 
 
 func _render_forget_ask() -> void:
-	_title.text = "TEACH"
-	_summary.text = Gen2MoveForget.ask_text(
-		_target_name(_forget_party_index), String(_teach_prompt.get("move_name", ""))
-	)
-	_render_options([{"label": "YES"}, {"label": "NO"}], _forget_confirm_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
-	)
+	_render_hardware()
 
 
 func _confirm_forget_ask() -> void:
@@ -1372,18 +1264,16 @@ func _confirm_forget_ask() -> void:
 ## on confirm, the way .hmmove does.
 func _open_forget_list() -> void:
 	_mode = Mode.PACK_FORGET
+	_forget_refusal = ""
 	_forget_cursor = 0
-	_status.text = ""
-	_footer.text = "Up and down: move    A: forget    B: back"
 	_render_forget_list()
 
 
+## The list's own box carries `MoveCantForgetHMText` while it stands, since
+## `.hmmove` prints it and is `jr .loop` rather than a cancel. Any move of the
+## cursor puts `ListMoves`' own question back.
 func _render_forget_list() -> void:
-	_title.text = "FORGET"
-	_summary.text = Gen2MoveForget.which_text()
-	_render_options(_forget_moves, _forget_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("name", ""))
-	)
+	_render_hardware()
 
 
 ## The answer TeachTMHM is called a second time with. An HM keeps the list open
@@ -1393,8 +1283,8 @@ func _confirm_forget() -> void:
 		return
 	var entry: Dictionary = _forget_moves[_forget_cursor]
 	if not bool(entry.get("forgettable", false)):
-		_status.text = Gen2MoveForget.cant_forget_hm_text()
-		_status.add_theme_color_override("font_color", ERROR)
+		_forget_refusal = Gen2MoveForget.cant_forget_hm_text()
+		_render_forget_list()
 		return
 	var result: Dictionary = Gen2WorldPartyHost.teach_tm_hm(
 		_world, _pack_save, int(_teach_prompt.get("item", 0)), _forget_party_index,
@@ -1416,17 +1306,11 @@ func _confirm_forget() -> void:
 func _open_stop_learning() -> void:
 	_mode = Mode.PACK_STOP_LEARNING
 	_forget_confirm_cursor = 0
-	_status.text = ""
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_stop_learning()
 
 
 func _render_stop_learning() -> void:
-	_title.text = "TEACH"
-	_summary.text = Gen2MoveForget.stop_text(String(_teach_prompt.get("move_name", "")))
-	_render_options([{"label": "YES"}, {"label": "NO"}], _forget_confirm_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
-	)
+	_render_hardware()
 
 
 ## Yes ends the offer with DidNotLearnMoveText; no is `jp .loop`, which reaches
@@ -1477,8 +1361,6 @@ func _open_target_mode() -> void:
 	## is opened, which is what puts the icons on the page at all.
 	if _party_menu_page() != null:
 		_target_page.reset(_party_targets())
-	_status.text = ""
-	_footer.text = "Up and down: move    A: %s    B: back" % ("give" if _giving else "use")
 	_target_elapsed = 0.0
 	_render_targets()
 	## `InitPartyMenuGFX` opens every struct on frame -1, so the icons are blank
@@ -1488,23 +1370,11 @@ func _open_target_mode() -> void:
 
 
 func _render_targets() -> void:
-	_title.text = "GIVE TO" if _giving else "USE ON"
-	_summary.text = String(_selected_item().get("name", ""))
 	## The panel fallback carries the same CANCEL row the hardware page draws, so
 	## the cursor means one thing whichever of the two is up.
 	var rows: Array = _party_targets()
 	rows.append({"cancel": true})
-	_render_options(rows, _target_cursor,
-		func(entry: Dictionary) -> String:
-			if bool(entry.get("cancel", false)):
-				return Gen2BattleSwitchMenu.cancel_label()
-			if bool(entry.get("egg", false)):
-				return "%s    EGG" % String(entry.get("name", ""))
-			return "%s    %d/%d HP" % [
-				String(entry.get("name", "")), int(entry.get("hp", 0)),
-				int(entry.get("max_hp", 0)),
-			]
-	)
+	_render_hardware()
 
 
 func _use_selected_item(party_index: int) -> void:
@@ -1566,19 +1436,11 @@ func _open_toss_quantity() -> void:
 		return
 	_mode = Mode.PACK_TOSS_QUANTITY
 	_toss_prompt = Gen2WorldQuantityPrompt.open(int(item.get("quantity", 1)))
-	_footer.text = "Up and down: one    Left and right: ten    A: choose    B: back"
 	_render_toss_quantity()
 
 
 func _render_toss_quantity() -> void:
-	_title.text = "TOSS"
-	_summary.text = String(_selected_item().get("name", ""))
-	_status.text = _pack_text(TEXT_TOSS_ASK)
-	_status.add_theme_color_override("font_color", TEXT)
-	_render_options(
-		[_toss_prompt.value if _toss_prompt != null else 1], 0,
-		func(value: Variant) -> String: return "x%d" % int(value)
-	)
+	_render_hardware()
 
 
 ## `AskQuantityThrowAwayText` and the `YesNoBox` behind it.
@@ -1587,21 +1449,11 @@ func _open_toss_confirm() -> void:
 		return
 	_mode = Mode.PACK_TOSS_CONFIRM
 	_toss_confirm_cursor = 0
-	_footer.text = "Up and down: move    A: choose    B: back"
 	_render_toss_confirm()
 
 
 func _render_toss_confirm() -> void:
-	_title.text = "TOSS"
-	_summary.text = _fill_item_text(
-		_pack_text(TEXT_TOSS_ASK_QUANTITY),
-		String(_selected_item().get("name", "")),
-		_toss_prompt.value if _toss_prompt != null else 1
-	)
-	_status.text = ""
-	_render_options([{"label": "YES"}, {"label": "NO"}], _toss_confirm_cursor,
-		func(entry: Dictionary) -> String: return String(entry.get("label", ""))
-	)
+	_render_hardware()
 
 
 ## `TossItem` and `ThrewAwayText`. The bag host owns the transaction; a refusal
@@ -1624,7 +1476,6 @@ func _confirm_toss() -> void:
 		return
 	## The result box keeps whatever summary the mode before it left, and the
 	## question is not it: `ThrewAwayText` is printed under the item's own name.
-	_summary.text = String(result.get("name", ""))
 	_show_pack_result(
 		_fill_item_text(_pack_text(TEXT_TOSS_THREW), String(result.get("name", ""))), true
 	)
@@ -1696,7 +1547,6 @@ func _show_pack_result(message: String, ok: bool) -> void:
 		message, Gen2PackPage.TEXTBOX_COLUMNS - 2, Gen2PackPage.TEXTBOX_ROWS_OF_TEXT
 	)
 	_pack_result_page = 0
-	_footer.text = "A: continue"
 	_render_pack_result()
 
 
@@ -1711,10 +1561,7 @@ func _pack_result_advanced() -> bool:
 
 
 func _render_pack_result() -> void:
-	_title.text = "PACK"
-	_status.text = _pack_result
-	_status.add_theme_color_override("font_color", SUCCESS if _pack_result_ok else MUTED)
-	_render_options(["Continue"], 0, func(entry: Variant) -> String: return str(entry))
+	_render_hardware()
 
 
 ## `SaveMenu`'s first question. `LoadStandardMenuHeader` and
@@ -1732,11 +1579,6 @@ func _enter_save_mode(mode: Mode, lines: Array, cursor_index: int) -> void:
 	_save_line = 0
 	_save_cursor = cursor_index
 	_save_frames = 0
-	_title.text = "SAVE"
-	_summary.text = " ".join(_save_lines)
-	_status.text = ""
-	_footer.text = "D-pad: choose    A: confirm    B: cancel" if cursor_index >= 0 \
-		else "A: continue"
 	_render_save()
 
 
@@ -1872,70 +1714,12 @@ func _save_state() -> Dictionary:
 
 
 func _render_save() -> void:
-	_render_options(
-		["Yes", "No"] if _save_cursor >= 0 else [], _save_cursor,
-		func(entry: Variant) -> String: return str(entry)
-	)
-
-
-func _build_ui() -> void:
-	var scrim := ColorRect.new()
-	scrim.color = SCRIM
-	scrim.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	scrim.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child(scrim)
-	_scrim = scrim
-
-	var center := CenterContainer.new()
-	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(center)
-	_center = center
-	var panel := PanelContainer.new()
-	panel.custom_minimum_size = Vector2(420, 320)
-	panel.add_theme_stylebox_override("panel", _panel_style())
-	center.add_child(panel)
-	var margin := MarginContainer.new()
-	margin.add_theme_constant_override("margin_left", 24)
-	margin.add_theme_constant_override("margin_top", 20)
-	margin.add_theme_constant_override("margin_right", 24)
-	margin.add_theme_constant_override("margin_bottom", 20)
-	panel.add_child(margin)
-	var content := VBoxContainer.new()
-	content.add_theme_constant_override("separation", 10)
-	margin.add_child(content)
-	_title = Label.new()
-	_title.add_theme_color_override("font_color", TEXT)
-	_title.add_theme_font_size_override("font_size", 24)
-	content.add_child(_title)
-	_summary = Label.new()
-	_summary.add_theme_color_override("font_color", MUTED)
-	_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	content.add_child(_summary)
-	_options = VBoxContainer.new()
-	_options.add_theme_constant_override("separation", 4)
-	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	content.add_child(_options)
-	## Fallback for a caller that did not hand this host the world's Gen2Screen.
-	_pack_view = TextureRect.new()
-	_pack_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_pack_view.custom_minimum_size = Vector2(
-		Gen2Screen.WIDTH * PACK_VIEW_SCALE, Gen2Screen.HEIGHT * PACK_VIEW_SCALE
-	)
-	_pack_view.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	_pack_view.visible = false
-	content.add_child(_pack_view)
-	_status = Label.new()
-	_status.add_theme_color_override("font_color", MUTED)
-	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	content.add_child(_status)
-	_footer = Label.new()
-	_footer.add_theme_color_override("font_color", ACCENT)
-	content.add_child(_footer)
+	_render_hardware()
 
 
 ## The screen `StartMenu`'s own box is drawn into. The world hands over the one
 ## the map is already in, so the box stands over it the way the map name sign
-## does; a caller that hands over none keeps the panel.
+## does.
 func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 	if _screen == null or _view != null:
@@ -1955,20 +1739,49 @@ func _exit_tree() -> void:
 		_view = null
 
 
-## Whichever of the cartridge's screens this mode is, or nothing for a mode that
-## is still the panel.
+## Whichever of the cartridge's screens this mode is. `_hardware_image()` answers
+## every one of them, so there is no window-resolution fallback behind it.
 func _render_hardware() -> void:
 	if _view == null:
 		return
 	var image: Image = _hardware_image()
 	_view.visible = image != null
-	if _scrim != null:
-		_scrim.visible = image == null
-	if _center != null:
-		_center.visible = image == null
 	if image == null:
 		return
 	_view.texture = ImageTexture.create_from_image(image)
+
+
+## The words this mode's own box prints, which is what [method _hardware_image]
+## hands the page. One reading, so a caller can have the box without the pixels.
+func box_text() -> String:
+	match _mode:
+		Mode.PACK_ITEM:
+			return _pack_description()
+		Mode.PACK_TEACH:
+			return String(_teach_prompt.get("text", ""))
+		Mode.PACK_FORGET_ASK:
+			return Gen2MoveForget.ask_text(
+				_target_name(_forget_party_index),
+				String(_teach_prompt.get("move_name", ""))
+			)
+		Mode.PACK_STOP_LEARNING:
+			return Gen2MoveForget.stop_text(String(_teach_prompt.get("move_name", "")))
+		Mode.PACK_TOSS_CONFIRM:
+			return _fill_item_text(
+				_pack_text(TEXT_TOSS_ASK_QUANTITY),
+				String(_selected_item().get("name", "")),
+				_toss_prompt.value if _toss_prompt != null else 1
+			)
+		Mode.PACK_GIVE_SWAP:
+			return _swap_question
+		Mode.PACK_TOSS_QUANTITY:
+			return _pack_text(TEXT_TOSS_ASK)
+		Mode.PACK_FORGET:
+			return _forget_refusal if not _forget_refusal.is_empty() \
+				else Gen2MoveForget.which_text()
+		Mode.PACK_RESULT:
+			return _pack_result_text()
+	return ""
 
 
 func _hardware_image() -> Image:
@@ -2006,30 +1819,21 @@ func _hardware_image() -> Image:
 			var labels: Array = []
 			for entry: Dictionary in _item_actions:
 				labels.append(String(entry.get("label", "")))
-			return _pack_overlay(_pack_description(), func(map: PackedInt32Array) -> void:
+			return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
 				_pack_page.draw_menu(map, _item_menu_box(labels.size()), labels, _item_cursor)
 			)
 		Mode.PACK_TEACH:
-			return _pack_yes_no(String(_teach_prompt.get("text", "")), _teach_cursor)
+			return _pack_yes_no(box_text(), _teach_cursor)
 		Mode.PACK_FORGET_ASK:
-			return _pack_yes_no(Gen2MoveForget.ask_text(
-				_target_name(_forget_party_index),
-				String(_teach_prompt.get("move_name", ""))
-			), _forget_confirm_cursor)
+			return _pack_yes_no(box_text(), _forget_confirm_cursor)
 		Mode.PACK_STOP_LEARNING:
-			return _pack_yes_no(Gen2MoveForget.stop_text(
-				String(_teach_prompt.get("move_name", ""))
-			), _forget_confirm_cursor)
+			return _pack_yes_no(box_text(), _forget_confirm_cursor)
 		Mode.PACK_TOSS_CONFIRM:
-			return _pack_yes_no(_fill_item_text(
-				_pack_text(TEXT_TOSS_ASK_QUANTITY),
-				String(_selected_item().get("name", "")),
-				_toss_prompt.value if _toss_prompt != null else 1
-			), _toss_confirm_cursor)
+			return _pack_yes_no(box_text(), _toss_confirm_cursor)
 		Mode.PACK_GIVE_SWAP:
-			return _pack_yes_no(_swap_question, _swap_cursor)
+			return _pack_yes_no(box_text(), _swap_cursor)
 		Mode.PACK_TOSS_QUANTITY:
-			return _pack_overlay(_pack_text(TEXT_TOSS_ASK), func(map: PackedInt32Array) -> void:
+			return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
 				_pack_page.draw_quantity(
 					map,
 					Gen2MenuBox.from_coords(
@@ -2044,11 +1848,11 @@ func _hardware_image() -> Image:
 			for entry: Dictionary in _forget_moves:
 				moves.append(String(entry.get("name", "")))
 			return _pack_overlay(
-				Gen2MoveForget.which_text(), func(map: PackedInt32Array) -> void:
+				box_text(), func(map: PackedInt32Array) -> void:
 					_pack_page.draw_move_list(map, moves, _forget_cursor)
 			)
 		Mode.PACK_RESULT:
-			return _pack_overlay(_pack_result_text(), Callable())
+			return _pack_overlay(box_text(), Callable())
 		Mode.PACK_TARGET:
 			if _party_menu_page() == null:
 				return null
@@ -2098,28 +1902,3 @@ func _option_window(
 		"rows": rows.slice(first, last),
 		"cursor": cursor_index - first if cursor_index >= 0 else -1,
 	}
-
-
-func _render_options(values: Array, cursor_index: int, label_for: Callable) -> void:
-	_render_hardware()
-	if _pack_view != null:
-		_pack_view.visible = false
-	if _options == null:
-		return
-	Gen2Screen.drop_children(_options)
-	for index: int in values.size():
-		var label := Label.new()
-		var option_text: String = label_for.call(values[index])
-		label.text = ("> " if index == cursor_index else "  ") + option_text
-		label.add_theme_color_override("font_color", ACCENT if index == cursor_index else TEXT)
-		label.add_theme_font_size_override("font_size", 18)
-		_options.add_child(label)
-
-
-func _panel_style() -> StyleBoxFlat:
-	var style := StyleBoxFlat.new()
-	style.bg_color = PANEL
-	style.border_color = BORDER
-	style.set_border_width_all(2)
-	style.set_corner_radius_all(8)
-	return style

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -229,6 +229,7 @@ func _build_context() -> Dictionary:
 	return {
 		"map": _world.map_id(),
 		"eligible": _world.visible_encounter_cells(),
+		"occupied": _occupied_cells(),
 		"tables": _world.active_encounter_tables(),
 		"player": {"cell": _world.player_cell, "facing": _world.player_facing},
 		"run_seed": _world.random_seed,
@@ -236,16 +237,52 @@ func _build_context() -> Dictionary:
 	}
 
 
+## The walk cells the map's own objects hold this frame, which is live state and
+## deliberately NOT folded into `eligible`: which cells a wild MAY stand on is
+## `CanEncounterWildMon`'s rule and does not change while the map is up, and
+## [method _validate] drops an entry standing outside `eligible`, so folding the
+## two together would delete a wild an NPC walks over.
+##
+## An object mid-step is DRAWN between two cells, so both are held: its committed
+## `cell` and the cell its drawing laps into, which is what `step_offset_cells()`
+## measures. A big object holds all four of the cells `occupies` answers for.
+## The player is not in it; `player` is where that cell is.
+func _occupied_cells() -> PackedVector2Array:
+	var out := PackedVector2Array()
+	if _world == null:
+		return out
+	var seen: Dictionary = {}
+	for object: Gen2WorldObject in _world.visible_objects():
+		var drawn: Vector2 = Vector2(object.cell) + object.step_offset_cells()
+		for corner: Vector2i in [
+			object.cell, Vector2i(drawn.floor()), Vector2i(drawn.ceil()),
+		]:
+			var span: int = Gen2WorldObject.BIG_OBJECT_SIZE if object.is_big_object() else 1
+			for x: int in span:
+				for y: int in span:
+					var cell := Vector2(corner + Vector2i(x, y))
+					if seen.has(cell):
+						continue
+					seen[cell] = true
+					out.append(cell)
+	return out
+
+
 ## The pose moves and the map does not, so the sweep and the tables are not taken
-## again: a provider is handed the same context with `player` refreshed, and only
-## when the player has actually moved.
+## again: a provider is handed the same context with `player` and `occupied`
+## refreshed, and only when one of the two has actually changed. An object walks
+## while the player stands still, so the occupancy is on this pass rather than on
+## the map change.
 func _push_player_pose() -> void:
 	if _world == null or _context.is_empty():
 		return
 	var pose: Dictionary = {"cell": _world.player_cell, "facing": _world.player_facing}
-	if _context.get("player", {}) == pose:
+	var occupied: PackedVector2Array = _occupied_cells()
+	if _context.get("player", {}) == pose \
+	and _context.get("occupied", PackedVector2Array()) == occupied:
 		return
 	_context["player"] = pose
+	_context["occupied"] = occupied
 	for provider: Object in _providers:
 		provider.call("set_context", _context.duplicate(true))
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1763,8 +1763,9 @@ func _walk_start_menu_to(kind: StringName) -> bool:
 
 
 ## Public screenshot driver for the Pokegear, reached the way a player reaches
-## it: START, the POKEGEAR row, and then A on the card list. What it is for is
-## the panel-over-panel stack, so the picture has to be the card over the list.
+## it: START and the POKEGEAR row. The picture is `Pokegear_LoadGFX`'s own card
+## list, which is the layer a debug panel used to stand behind; a card opened
+## from it is a full screen of its own and has its own cases.
 func preview_pokegear() -> void:
 	if _world == null or _data == null:
 		return
@@ -1782,8 +1783,6 @@ func preview_pokegear() -> void:
 		## The row opens the overlay through the same signal a press does, so
 		## the card list is up by the time this returns.
 		_start_menu_host.handle_button(Gen2Button.A)
-	if _service_host != null:
-		_service_host.handle_button(Gen2Button.A)
 
 
 ## Public screenshot drivers for `SaveMenu`, one per box it puts up:
@@ -3513,8 +3512,9 @@ func _open_phone_list() -> void:
 	_open_service_overlay(&"phone_list")
 
 
-## The Pokegear's own card list, which is what the start menu's POKEGEAR entry
-## reaches. The phone list is one card behind it, not the whole device.
+## `PokeGear` itself, which is what the start menu's POKEGEAR entry reaches: the
+## clock card, with the rest a `Pokegear_SwitchPage` away. The phone list opens
+## on one card instead of the whole device.
 func _open_pokegear() -> void:
 	_open_service_overlay(&"pokegear")
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -21,16 +21,8 @@ signal completed(results: Array)
 ## carries is that the sound is heard.
 signal sfx_requested(index: int, waited: bool)
 
-const PANEL: Color = Color("#14233a")
-const BORDER: Color = Color("#4f6f9e")
-const TEXT: Color = Color("#f4f7fb")
-const MUTED: Color = Color("#9eacc0")
-const ACCENT: Color = Color("#f3c969")
-const SUCCESS: Color = Color("#7bd89a")
-const ERROR: Color = Color("#ef8a8a")
-
 enum MODE {
-	MENU, MART, PHONE, POKEGEAR, TOWN_MAP, CARD,
+	MENU, MART, PHONE, TOWN_MAP, CARD,
 	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT,
 }
 
@@ -122,7 +114,7 @@ var _pokegear: Gen2PokegearScreen = null
 ## that never opened one leaves the map's own music where it stands.
 var _radio_music: int = RADIO_MUSIC_SILENT
 ## Whether the region map on screen is the fly map, which answers a spawn rather
-## than closing back into the card list.
+## than closing the overlay.
 var _fly_map: bool = false
 var _town_map_from_request: bool = false
 ## `PokemonCenterPC` and the item PC behind it: which rows are on offer, which
@@ -141,17 +133,19 @@ var _pc_label: String = ""
 var _boxes: Gen2BoxScreen = null
 
 var _service_hardware: Gen2Screen = null
+## Whether the hardware layer holds an image for the mode this host is in, and
+## whether a screen of its own is standing over both layers. [method
+## _apply_layer_visibility] is what these two decide.
+var _service_drawn: bool = false
+var _overlay_open: bool = false
 var _service_view: TextureRect = null
 var _service_page: Gen2WorldServicePage = null
 ## `SetDayOfWeek`'s own dial, shared with the new game's `InitClock` screen.
 var _clock_page: Gen2ClockSetPage = null
 
-var _panel: PanelContainer = null
-var _title: Label = null
-var _summary: Label = null
-var _options: VBoxContainer = null
-var _status: Label = null
-var _footer: Label = null
+var _title: String = ""
+var _summary: String = ""
+var _status: String = ""
 
 
 func _ready() -> void:
@@ -227,8 +221,9 @@ func open_phone_list(
 	return true
 
 
-## Opens the Pokegear on its card list. Only cards the player owns are
-## selectable, in the source's own clock/map/phone/radio order.
+## `PokeGear`'s own entrance. `.InitTilemap` writes POKEGEARCARD_CLOCK and
+## opens on it: there is no card list on the cartridge, and B on any card is
+## that card's own `.quit`, which leaves the Pokegear rather than a list.
 func open_pokegear(
 	world: Gen2WorldAPI,
 	data: GameData,
@@ -237,7 +232,7 @@ func open_pokegear(
 ) -> bool:
 	if not _open_pokegear(world, data, save, persist, "Pokegear"):
 		return false
-	_open_pokegear_cards()
+	_open_card(Gen2PokegearScreen.CARD_CLOCK)
 	return true
 
 
@@ -274,8 +269,8 @@ func handle_button(button: int) -> bool:
 		return true
 	if _mode == MODE.CARD and _pokegear != null:
 		return _pokegear.handle_button(button)
-	## The panel is behind the box screen while BILL'S PC is open, the way it is
-	## behind the region map, so the buttons are the box screen's.
+	## The box screen owns all 160x144 while BILL'S PC is open, the way the
+	## region map does, so the buttons are its own.
 	if _boxes != null:
 		return _boxes.handle_button(button)
 	if Gen2Button.is_direction(button):
@@ -296,42 +291,6 @@ func selected_index() -> int:
 
 
 func _build_ui() -> void:
-	var center := CenterContainer.new()
-	center.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(center)
-	_panel = PanelContainer.new()
-	_panel.custom_minimum_size = Vector2(500, 300)
-	_panel.add_theme_stylebox_override("panel", _panel_style())
-	center.add_child(_panel)
-	var margin := MarginContainer.new()
-	margin.add_theme_constant_override("margin_left", 24)
-	margin.add_theme_constant_override("margin_top", 20)
-	margin.add_theme_constant_override("margin_right", 24)
-	margin.add_theme_constant_override("margin_bottom", 20)
-	_panel.add_child(margin)
-	var content := VBoxContainer.new()
-	content.add_theme_constant_override("separation", 10)
-	margin.add_child(content)
-	_title = Label.new()
-	_title.add_theme_color_override("font_color", TEXT)
-	_title.add_theme_font_size_override("font_size", 24)
-	content.add_child(_title)
-	_summary = Label.new()
-	_summary.add_theme_color_override("font_color", MUTED)
-	_summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	content.add_child(_summary)
-	_options = VBoxContainer.new()
-	_options.add_theme_constant_override("separation", 4)
-	_options.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	content.add_child(_options)
-	_status = Label.new()
-	_status.add_theme_color_override("font_color", MUTED)
-	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	content.add_child(_status)
-	_footer = Label.new()
-	_footer.add_theme_color_override("font_color", ACCENT)
-	content.add_child(_footer)
-
 	_service_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
 	_service_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	_service_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -342,8 +301,7 @@ func _build_ui() -> void:
 	_service_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_service_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_service_hardware.display(_service_view)
-	_panel.visible = false
-	_service_hardware.visible = false
+	_apply_layer_visibility()
 
 
 func _open_menu(input: Dictionary) -> void:
@@ -352,14 +310,13 @@ func _open_menu(input: Dictionary) -> void:
 	_menu = WorldMenu.from_input(_menu_input)
 	_choices = _menu.options.duplicate(true)
 	_cursor = _menu.selected_index()
-	_title.text = "MENU"
+	_title = "MENU"
 	## The question the box behind this menu is still showing. A command name is
 	## an internal key, never something the cartridge prints, so it is not a
 	## fallback: an unattached menu says nothing rather than saying "yesorno".
-	_summary.text = String(input.get("text", ""))
-	_status.text = ""
-	_footer.text = "D-pad: move    A: choose    B: cancel"
-	_render_options()
+	_summary = String(input.get("text", ""))
+	_status = ""
+	_render_rows()
 
 
 ## `BuyMenu`, which is a screen of its own rather than a box over the map: the
@@ -375,7 +332,7 @@ func _open_mart(mart: Dictionary) -> void:
 	_mart_purchased = false
 	_mart_scroll = 0
 	_cursor = 0
-	_panel.visible = false
+	_set_overlay_open(true)
 	if _mart_hardware == null:
 		_mart_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
 		_mart_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
@@ -603,8 +560,7 @@ func _buy_mart_selection() -> void:
 			&"bargain_item_sold_out": "sold_out",
 		}.get(reason, "")
 		if slot.is_empty():
-			_status.text = "Purchase failed: %s" % String(reason)
-			_status.add_theme_color_override("font_color", ERROR)
+			_status = "Purchase failed: %s" % String(reason)
 			_mart_stage = MART_LIST
 			_render_mart()
 			return
@@ -629,8 +585,7 @@ func _close_mart() -> void:
 		Gen2Screen.drop(_mart_hardware)
 		_mart_hardware = null
 		_mart_view = null
-	_panel.visible = true
-	_service_hardware.visible = true
+	_set_overlay_open(false)
 
 
 func _render_mart() -> void:
@@ -693,7 +648,7 @@ func _mart_description() -> String:
 func _open_apricorns() -> void:
 	_mode = MODE.APRICORN
 	_apricorns = Gen2WorldApricorn.open(_world.data, _world.state)
-	_title.text = "APRICORNS"
+	_title = "APRICORNS"
 	if _apricorns.is_done():
 		## FindApricornsInBag's own refusal. Kurt only asks with one in the bag,
 		## so this is the guard rather than a branch a player reaches.
@@ -706,20 +661,17 @@ func _render_apricorns() -> void:
 	if _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY:
 		_cursor = 0
 		var chosen: Dictionary = _apricorns.selected_entry()
-		_summary.text = "How many should I make?"
+		_summary = "How many should I make?"
 		## `PlaceApricornQuantity` draws the name and `×NN` under it; the
 		## ceiling is this host's own, since nothing here draws a bag page.
-		_status.text = "x%d    of %d" % [
+		_status = "x%d    of %d" % [
 			_apricorns.prompt.value, _apricorns.prompt.maximum,
 		]
-		_status.add_theme_color_override("font_color", TEXT)
-		_footer.text = "Up/down: one    Left/right: ten    A: give    B: back"
-		_render_options([String(chosen.get("name", ""))])
+		_render_rows([String(chosen.get("name", ""))])
 		return
-	_summary.text = "Which APRICORN should I use?"
-	_status.text = ""
-	_footer.text = "D-pad: move    A: choose    B: leave"
-	_render_options(_apricorn_rows())
+	_summary = "Which APRICORN should I use?"
+	_status = ""
+	_render_rows(_apricorn_rows())
 
 
 ## The four-row window the scrolling menu shows, CANCEL included when the list
@@ -768,12 +720,10 @@ func _open_pc(mode: StringName) -> void:
 	_pc_rows = Gen2WorldPC.top_menu(
 		_data, _world.state, _save.player_name if _save != null else ""
 	)
-	_title.text = "PC"
-	_summary.text = _data.pokecenter_pc_text("whose")
-	_status.text = ""
-	_status.add_theme_color_override("font_color", MUTED)
-	_footer.text = "D-pad: move    A: choose    B: turn off"
-	_render_options()
+	_title = "PC"
+	_summary = _data.pokecenter_pc_text("whose")
+	_status = ""
+	_render_rows()
 
 
 ## The item PC's own menu. The Pokemon Center's list ends in LOG OFF because the
@@ -783,15 +733,14 @@ func _open_pc_items() -> void:
 	_cursor = 0
 	_pc_action = -1
 	_pc_rows = Gen2WorldPC.players_pc_menu(_data, _pc_house)
-	_title.text = _data.pokecenter_pc_row("players_pc").replace(
+	_title = _data.pokecenter_pc_row("players_pc").replace(
 		Gen2WorldPC.PLAYER_MARKER,
 		_save.player_name if _save != null and not _save.player_name.is_empty()
 		else "PLAYER"
 	)
-	_summary.text = _data.pokecenter_pc_text("ask_what_do")
+	_summary = _data.pokecenter_pc_text("ask_what_do")
 	_refresh_pc_counts()
-	_footer.text = "D-pad: move    A: choose    B: back"
-	_render_options()
+	_render_rows()
 
 
 ## Whichever of the bag and the PC the chosen action reads.
@@ -805,21 +754,19 @@ func _open_pc_item_list(action: int) -> void:
 		## for a deposit. The other two open an empty scrolling menu there, which
 		## can only be cancelled, so they are refused with the same box rather
 		## than drawn empty.
-		_status.text = _data.pokecenter_pc_text("no_items")
-		_status.add_theme_color_override("font_color", ERROR)
-		_render_options()
+		_status = _data.pokecenter_pc_text("no_items")
+		_render_rows()
 		return
 	_mode = MODE.PC_ITEM_LIST
 	## `SelectQuantityToToss` is asked before the move, so the box that names it
 	## is the list's own prompt here.
-	_summary.text = {
+	_summary = {
 		Gen2WorldPC.PLAYERSPCITEM_WITHDRAW_ITEM: "how_many_withdraw",
 		Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM: "how_many_deposit",
 	}.get(action, "")
-	_summary.text = _data.pokecenter_pc_text(_summary.text) if not _summary.text.is_empty() \
+	_summary = _data.pokecenter_pc_text(_summary) if not _summary.is_empty() \
 		else _data.menu_text("toss_ask")
-	_footer.text = "D-pad: move and quantity    A: choose    B: back"
-	_render_options()
+	_render_rows()
 
 
 func _refresh_pc_entries() -> void:
@@ -831,10 +778,9 @@ func _refresh_pc_entries() -> void:
 
 
 func _refresh_pc_counts() -> void:
-	_status.text = "PC %d/%d stacks" % [
+	_status = "PC %d/%d stacks" % [
 		_world.state.pc_items().size(), Gen2WorldPack.MAX_PC_ITEMS,
 	]
-	_status.add_theme_color_override("font_color", MUTED)
 
 
 func _confirm_pc_row() -> void:
@@ -884,19 +830,18 @@ func _confirm_pc_item() -> void:
 		## `.PackFull` and `.NoRoomInPC` are the two the source has a box for;
 		## everything else is a refusal it never reaches.
 		var reason: StringName = StringName(applied.get("reason", &""))
-		_status.text = {
+		_status = {
 			&"pc_full": "no_room_deposit", &"pack_full": "no_room_withdraw",
 			&"item_stack_full": "no_room_withdraw",
 		}.get(reason, "")
-		_status.text = _data.pokecenter_pc_text(_status.text) if not _status.text.is_empty() \
+		_status = _data.pokecenter_pc_text(_status) if not _status.is_empty() \
 			else "Refused: %s" % String(reason)
-		_status.add_theme_color_override("font_color", ERROR)
 		return
 	_pc_quantity = 1
 	_refresh_pc_entries()
 	## `.PlayersPCWithdrewItemsText` and `.PlayersPCDepositItemsText`, whose two
 	## markers `PartyMonItemName` and the quantity fill.
-	_status.text = _filled(
+	_status = _filled(
 		_data.pokecenter_pc_text(
 			"withdrew" if _pc_action == Gen2WorldPC.PLAYERSPCITEM_WITHDRAW_ITEM
 			else "deposited"
@@ -905,8 +850,7 @@ func _confirm_pc_item() -> void:
 	) if _pc_action != Gen2WorldPC.PLAYERSPCITEM_TOSS_ITEM else _filled(
 		_data.menu_text("toss_threw"), applied
 	)
-	_status.add_theme_color_override("font_color", SUCCESS)
-	_render_options()
+	_render_rows()
 
 
 ## The item name and the quantity into whichever markers the box left for them.
@@ -924,7 +868,7 @@ func _change_pc_quantity(step: int) -> void:
 		return
 	var owned: int = int(_pc_entries[_cursor].get("quantity", 1))
 	_pc_quantity = clampi(_pc_quantity + step, 1, maxi(1, owned))
-	_render_options()
+	_render_rows()
 
 
 ## `OaksPC`, which prints `ProfOaksPC`'s rating into the PC's own box and
@@ -933,8 +877,7 @@ func _change_pc_quantity(step: int) -> void:
 func _open_pc_oak() -> void:
 	var boot: Dictionary = Gen2ProfOaksPC.boot(_data, _world.state)
 	if boot.is_empty():
-		_status.text = "PROF.OAK'S PC needs a cache that carries its ratings."
-		_status.add_theme_color_override("font_color", ERROR)
+		_status = "PROF.OAK'S PC needs a cache that carries its ratings."
 		return
 	_pc_sfx = int(boot["sfx"])
 	_open_pc_text(boot["pages"], &"top", "PROF.OAK'S PC")
@@ -951,11 +894,9 @@ func _open_pc_text(pages: Array, after: StringName, label: String) -> void:
 
 
 func _show_pc_page() -> void:
-	_summary.text = String(_pc_pages[0]) if not _pc_pages.is_empty() else ""
-	_status.text = ""
-	_status.add_theme_color_override("font_color", MUTED)
-	_footer.text = "A: continue"
-	_render_options([_pc_label])
+	_summary = String(_pc_pages[0]) if not _pc_pages.is_empty() else ""
+	_status = ""
+	_render_rows([_pc_label])
 
 
 ## `ProfOaksPCBoot` plays the sound `Rate` chose once the rating is printed, so
@@ -981,12 +922,10 @@ func _advance_pc_text() -> void:
 func _open_boxes() -> void:
 	var host: Gen2BoxScreen = BOX_SCENE.instantiate() as Gen2BoxScreen
 	if host == null or _save == null:
-		_status.text = "Box storage needs a validated save."
-		_status.add_theme_color_override("font_color", ERROR)
+		_status = "Box storage needs a validated save."
 		return
 	_boxes = host
-	_panel.visible = false
-	_service_hardware.visible = false
+	_set_overlay_open(true)
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 5
 	add_child(host)
@@ -1000,56 +939,41 @@ func _on_boxes_closed(_result: Dictionary) -> void:
 	if _boxes != null:
 		Gen2Screen.drop(_boxes)
 		_boxes = null
-	_panel.visible = true
-	_service_hardware.visible = true
+	_set_overlay_open(false)
 	_open_pc(&"pokemon_center")
 
 
 func _open_phone(request: Dictionary, data: Dictionary) -> void:
 	_mode = MODE.PHONE
 	_cursor = 0
-	_title.text = "PHONE"
+	_title = "PHONE"
 	var summary: Dictionary = {}
 	if StringName(request.get("kind", &"")) == &"phone_call_requested":
 		summary = Gen2WorldPhoneHost.contact_summary(
 			_data, data.get("contact", {})
 		)
-		_summary.text = _phone_text(summary)
+		_summary = _phone_text(summary)
 	else:
 		summary = Gen2WorldPhoneHost.special_call_summary(
 			_data, data.get("special_call", {})
 		)
-		_summary.text = "Special call %d for contact %d." % [
+		_summary = "Special call %d for contact %d." % [
 			int(summary.get("index", -1)), int(summary.get("contact", -1)),
 		]
-	_status.text = "The imported call record is ready."
+	_status = "The imported call record is ready."
 	if bool(data.get("out_of_area", false)):
-		_status.text = "This call will use the cartridge out-of-area script."
+		_status = "This call will use the cartridge out-of-area script."
 	elif bool(data.get("phone", {}).get("same_map", false)):
-		_status.text = "This call will use the cartridge same-map script."
-	_footer.text = "A: continue    B: hang up"
-	_render_options(["Continue"])
+		_status = "This call will use the cartridge same-map script."
+	_render_rows(["Continue"])
 
 
-func _open_pokegear_cards() -> void:
-	_mode = MODE.POKEGEAR
-	_cursor = 0
-	_title.text = "POKEGEAR"
-	var clock: Dictionary = _world.world_clock()
-	_summary.text = "%02d:%02d" % [int(clock.get("hour", 0)), int(clock.get("minute", 0))]
-	_status.text = "Choose a card."
-	_footer.text = "D-pad: move    A: open    B: close"
-	_render_options()
-
-
-## The clock, phone and radio cards, each on the hardware's own tile grid the way
-## the MAP card is. The card list stays this panel's, so a card is opened over it
-## and closing one comes back to the list.
+## One of `PokegearJumptable`'s cards, each on the hardware's own tile grid the
+## way the MAP card is. It owns all 160x144 while it is up.
 func _open_card(card: StringName) -> void:
 	_mode = MODE.CARD
 	_cursor = 0
-	_panel.visible = false
-	_service_hardware.visible = false
+	_set_overlay_open(true)
 	_pokegear = Gen2PokegearScreen.new()
 	_pokegear.z_index = 5
 	add_child(_pokegear)
@@ -1117,8 +1041,8 @@ func _on_card_switched(direction: int) -> void:
 		return
 	var card: StringName = order[at]
 	if card == &"map":
-		# The MAP card is the region map's own screen, and closing it comes back
-		# to the card list rather than to the card this left.
+		# The MAP card is the region map's own screen, and B on it is the same
+		# `.cancel` every other card has: it leaves the Pokegear.
 		_close_card()
 		_open_town_map(false)
 		return
@@ -1130,7 +1054,7 @@ func _on_card_switched(direction: int) -> void:
 ## `ExitPokegearRadio_HandleMusic` restarts the map's music only when the radio
 ## card has played something over it, and every other service leaves it alone.
 ## The restart lands when this overlay closes rather than when the card does,
-## since the card list is this panel rather than the Pokegear's own screen.
+## since the overlay is what the world is waiting on rather than the card.
 func radio_music_playing() -> int:
 	return _radio_music
 
@@ -1152,9 +1076,8 @@ func _on_card_tuned(knob: int) -> void:
 func _on_card_called(contact: int) -> void:
 	var results: Array = _world.request_outgoing_phone_call(contact)
 	_close_card()
-	_panel.visible = true
-	_service_hardware.visible = true
 	_mode = -1
+	_set_overlay_open(false)
 	completed.emit(results)
 
 
@@ -1172,9 +1095,9 @@ func _on_card_closed() -> void:
 	if _pokegear != null and _pokegear.card() == Gen2PokegearScreen.CARD_RADIO:
 		_world.close_radio()
 	_close_card()
-	_panel.visible = true
-	_service_hardware.visible = true
-	_open_pokegear_cards()
+	_mode = -1
+	_set_overlay_open(false)
+	completed.emit([])
 
 
 func _close_card() -> void:
@@ -1203,8 +1126,7 @@ func open_fly_map(
 	_mode = MODE.TOWN_MAP
 	_town_map_from_request = false
 	_fly_map = true
-	_panel.visible = false
-	_service_hardware.visible = false
+	_set_overlay_open(true)
 	_town_map = Gen2TownMapScreen.new()
 	_town_map.z_index = 5
 	add_child(_town_map)
@@ -1229,10 +1151,9 @@ func open_fly_map(
 func _open_town_map(from_request: bool) -> void:
 	_mode = MODE.TOWN_MAP
 	_town_map_from_request = from_request
-	# The region map is the whole screen, so the card list's own panel goes with
-	# its labels; the scrim behind it stays as the overlay's backdrop.
-	_panel.visible = false
-	_service_hardware.visible = false
+	# The region map is the whole screen, so neither of this host's own layers
+	# is drawn under it.
+	_set_overlay_open(true)
 	_town_map = Gen2TownMapScreen.new()
 	_town_map.z_index = 5
 	add_child(_town_map)
@@ -1262,8 +1183,7 @@ func _on_town_map_closed() -> void:
 	if _town_map != null:
 		Gen2Screen.drop(_town_map)
 		_town_map = null
-	_panel.visible = true
-	_service_hardware.visible = true
+	_set_overlay_open(false)
 	if _fly_map:
 		_fly_map = false
 		_mode = -1
@@ -1284,7 +1204,7 @@ func _move_cursor(delta: int) -> void:
 	_cursor = wrapi(_cursor + delta, 0, count)
 	if _mode == MODE.PC_ITEM_LIST:
 		_pc_quantity = 1
-	_render_options()
+	_render_rows()
 
 
 func _move_direction(direction: Vector2i) -> void:
@@ -1294,7 +1214,7 @@ func _move_direction(direction: Vector2i) -> void:
 	if _mode == MODE.MENU and _menu != null:
 		if _menu.move(direction):
 			_cursor = _menu.selected_index()
-			_render_options()
+			_render_rows()
 		return
 	if _mode == MODE.PC_ITEM_LIST and direction.x != 0:
 		_change_pc_quantity(direction.x)
@@ -1317,24 +1237,9 @@ func _confirm() -> void:
 		return
 	if _mode == MODE.MENU:
 		if _choices.is_empty():
-			_status.text = "The imported menu has no selectable options."
-			_status.add_theme_color_override("font_color", ERROR)
+			_status = "The imported menu has no selectable options."
 			return
 		_finish_input(_cursor)
-		return
-	if _mode == MODE.POKEGEAR:
-		if _cursor >= _pokegear_cards.size():
-			return
-		var card: Dictionary = _pokegear_cards[_cursor]
-		if bool(card.get("unavailable", false)):
-			_status.text = "%s is not implemented." % String(card.get("name", ""))
-			_status.add_theme_color_override("font_color", ERROR)
-			return
-		var chosen: StringName = StringName(card.get("card", &""))
-		if chosen == &"map":
-			_open_town_map(false)
-		else:
-			_open_card(chosen)
 		return
 	if _mode == MODE.PHONE:
 		_finish_runtime({"ok": true, "script_value": 1})
@@ -1356,9 +1261,6 @@ func _cancel() -> void:
 		_advance_pc_text()
 	elif _mode == MODE.MENU:
 		_finish_input_cancelled()
-	elif _mode == MODE.POKEGEAR:
-		_mode = -1
-		completed.emit([])
 	elif _mode == MODE.PHONE:
 		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
 	elif _mode == MODE.TOWN_MAP and _town_map != null:
@@ -1380,8 +1282,8 @@ func _finish_runtime(result: Dictionary) -> void:
 		_world, result, _save, _persist
 	)
 	if not bool(host_result.get("ok", false)):
-		_status.text = "Request failed: %s" % String(host_result.get("reason", "unknown"))
-		_status.add_theme_color_override("font_color", ERROR)
+		_status = "Request failed: %s" % String(host_result.get("reason", "unknown"))
+		_render_rows()
 		return
 	_finish(host_result.get("results", []))
 
@@ -1392,17 +1294,9 @@ func _finish(results: Array) -> void:
 	completed.emit(results)
 
 
-func _render_options(override: Array = []) -> void:
-	if _options == null:
-		return
-	Gen2Screen.drop_children(_options)
-	var parent: Container = _options
-	if _mode == MODE.MENU and _menu != null and _menu.kind == &"2d":
-		var grid := GridContainer.new()
-		grid.columns = maxi(1, _menu.columns)
-		grid.add_theme_constant_override("h_separation", 18)
-		_options.add_child(grid)
-		parent = grid
+## The rows this mode is offering, which is all [method _render_service_page]
+## needs: there is no second list to keep in step with it any more.
+func _render_rows(override: Array = []) -> void:
 	if _is_dial() and override.is_empty():
 		## One value at a time, the way the dial itself shows it.
 		override = [_choices[clampi(_cursor, 0, _choices.size() - 1)]] if not _choices.is_empty() \
@@ -1411,29 +1305,8 @@ func _render_options(override: Array = []) -> void:
 		_choices if _mode == MODE.MENU \
 		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS] \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
-		else _pokegear_cards if _mode == MODE.POKEGEAR else ["Continue"]
+		else ["Continue"]
 	)
-	for index: int in values.size():
-		var value: Variant = values[index]
-		var label := Label.new()
-		var text: String = str(value)
-		if value is Dictionary:
-			var dictionary: Dictionary = value as Dictionary
-			text = str(dictionary.get("name", ""))
-			if text.is_empty():
-				text = str(dictionary.get("caller_label", ""))
-			if text.is_empty():
-				text = str(dictionary.get("trainer_name", "UNKNOWN"))
-			if text.is_empty() and dictionary.has("index"):
-				text = "CONTACT %d" % int(dictionary.get("index", -1))
-		if value is Dictionary and _mode == MODE.PC_ITEM_LIST:
-			var stack: int = int((value as Dictionary).get("quantity", 0))
-			text = "%s    x%d of %d" % [text, _pc_quantity, stack] if index == _cursor \
-				else "%s    x%d" % [text, stack]
-		label.text = ("> " if index == _cursor else "  ") + text
-		label.add_theme_color_override("font_color", ACCENT if index == _cursor else TEXT)
-		label.add_theme_font_size_override("font_size", 18)
-		parent.add_child(label)
 	_render_service_page(values)
 
 
@@ -1441,10 +1314,14 @@ func _render_options(override: Array = []) -> void:
 ## neither one, so those two draw no rows at all here.
 func _render_service_page(values: Array) -> void:
 	if _service_view == null or _data == null:
+		_service_drawn = false
+		_apply_layer_visibility()
 		return
 	if _service_page == null:
 		_service_page = Gen2WorldServicePage.from_data(_data)
 	if _service_page == null:
+		_service_drawn = false
+		_apply_layer_visibility()
 		return
 	var page_rows: Array = [] if _mode in [MODE.PHONE, MODE.PC_TEXT] else values
 	var labels: Array = []
@@ -1458,11 +1335,29 @@ func _render_service_page(values: Array) -> void:
 		else:
 			labels.append(String(value))
 	var image: Image = _dial_image() if _is_dial() else _service_page.render(
-		_title.text, _summary.text, labels, _cursor, _status.text, _service_box()
+		_title, _summary, labels, _cursor, _status, _service_box()
 	)
 	if image != null:
 		_service_view.texture = ImageTexture.create_from_image(image)
-		_service_hardware.visible = true
+	_service_drawn = image != null
+	_apply_layer_visibility()
+
+
+## An overlay owns all 160x144 while it is up: the mart, box storage, a Pokegear
+## card and the region map are each a screen rather than a box over this one.
+func _set_overlay_open(open: bool) -> void:
+	_overlay_open = open
+	_apply_layer_visibility()
+
+
+## The one place either layer is shown. The debug panel is a fallback for a host
+## handed no cartridge cache, never a layer *under* the hardware one: exactly one
+## of the two can be on screen, and neither is while an overlay is up or before a
+## service has opened. Setting the two by hand at each entrance is what left the
+## panel standing behind whatever the mode drew.
+func _apply_layer_visibility() -> void:
+	if _service_hardware != null:
+		_service_hardware.visible = _mode >= 0 and not _overlay_open and _service_drawn
 
 
 func _is_dial() -> bool:
@@ -1477,7 +1372,7 @@ func _dial_image() -> Image:
 	if _clock_page == null:
 		return null
 	var day: int = clampi(_cursor, 0, Gen2ClockSetScreen.DAYS.size() - 1)
-	var prompt: String = _summary.text if not _summary.text.is_empty() \
+	var prompt: String = _summary if not _summary.is_empty() \
 		else "What day is it?"
 	return _clock_page.render(Gen2ClockSetScreen.DAYS[day], prompt, -1, true)
 
@@ -1498,8 +1393,6 @@ func _service_box() -> Gen2MenuBox:
 			return _apricorn_quantity_box() if _apricorns != null \
 				and _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY \
 				else _apricorn_select_box()
-		MODE.POKEGEAR:
-			return _dynamic_box(_option_count())
 	return null
 
 
@@ -1527,20 +1420,9 @@ func _apricorn_quantity_box() -> Gen2MenuBox:
 	return Gen2MenuBox.from_coords(6, 9, 19, 12, 0)
 
 
-## The one list box still left to the panel: POKEGEAR's card list, which
-## `HANDOFF.md` already records as staying a panel.
-func _dynamic_box(count: int) -> Gen2MenuBox:
-	var bottom: int = mini(17, 1 + maxi(count, 1) * 2)
-	return Gen2MenuBox.from_coords(
-		9, 0, 19, bottom, Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
-	)
-
-
 func _option_count() -> int:
 	if _mode == MODE.MENU:
 		return _menu.options.size() if _menu != null else _choices.size()
-	if _mode == MODE.POKEGEAR:
-		return _pokegear_cards.size()
 	if _mode in [MODE.PC, MODE.PC_ITEMS]:
 		return _pc_rows.size()
 	if _mode == MODE.PC_ITEM_LIST:
@@ -1567,21 +1449,12 @@ func _phone_text(summary: Dictionary) -> String:
 	]
 
 
+## Nothing is drawn for it: a host with no world or cartridge cache never opens,
+## and the caller's own `false` is what says so.
 func _show_error(message: String) -> void:
 	_mode = -1
 	_menu = null
-	if _title != null:
-		_title.text = "SERVICE ERROR"
-		_summary.text = message
-		_status.text = ""
-		_footer.text = ""
-		_status.add_theme_color_override("font_color", ERROR)
-
-
-func _panel_style() -> StyleBoxFlat:
-	var style := StyleBoxFlat.new()
-	style.bg_color = PANEL
-	style.border_color = BORDER
-	style.set_border_width_all(2)
-	style.set_corner_radius_all(8)
-	return style
+	_title = "SERVICE ERROR"
+	_summary = message
+	_status = ""
+	_apply_layer_visibility()

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -270,6 +270,13 @@ class Population:
 		var table: Array = _context.get("tables", {}).get("grass", {}).get("slots", [])
 		if cells.is_empty() or table.is_empty():
 			return
+		# `occupied` is who is standing where this frame: NPCs, item balls and
+		# every other map object. It is beside `eligible` rather than inside it,
+		# because the host would delete an entry an NPC walked over; refusing a
+		# taken cell on spawn is this provider's own rule.
+		var taken: Dictionary = {}
+		for cell: Vector2 in _context.get("occupied", PackedVector2Array()):
+			taken[Vector2i(cell)] = true
 		# The run's seed rather than a fresh generator, so the same save walking
 		# back onto the same map meets the same population.
 		var rolls := RandomNumberGenerator.new()
@@ -283,9 +290,12 @@ class Population:
 			count += 1
 		for at: int in mini(count, cells.size()):
 			var slot: Dictionary = table[rolls.randi_range(0, table.size() - 1)]
+			var cell: Vector2i = Vector2i(cells[rolls.randi_range(0, cells.size() - 1)])
+			if taken.has(cell):
+				continue
 			_entries.append({
 				"id": StringName("voltling_%d_%d" % [_generation, at]),
-				"cell": Vector2i(cells[rolls.randi_range(0, cells.size() - 1)]),
+				"cell": cell,
 				"facing": Gen2WorldSprite.FACING_DOWN,
 				"species": int(slot.get("species", 0)),
 				"level": int(slot.get("min_level", 2)),

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 5,
+	"api_version": 6,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 5,
+	"api_version": 6,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -392,6 +392,45 @@ func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() ->
 		)
 	)
 
+	## `occupied` is who is standing where, and it is deliberately NOT folded
+	## into `eligible`: the trainer's cell is in both, because which cells a wild
+	## MAY stand on is a cartridge rule and `_validate` drops an entry outside it.
+	var trainer: Gen2WorldObject = _world_screen._world.visible_objects()[0]
+	assert_true(
+		(context["occupied"] as PackedVector2Array).has(Vector2(trainer.cell)),
+		"the map's own object holds its cell"
+	)
+	assert_true(
+		(context["eligible"][Gen2WorldEncounter.METHOD_GRASS] as PackedVector2Array).has(
+			Vector2(trainer.cell)
+		),
+		"and eligible still answers the cartridge's own rule for it"
+	)
+	assert_false(
+		(context["occupied"] as PackedVector2Array).has(
+			Vector2(_world_screen._world.player_cell)
+		),
+		"the player is in `player`, not in `occupied`"
+	)
+
+	## An object moves without the player moving, so the occupancy is refreshed
+	## with the pose rather than only on a map change.
+	trainer.cell = Vector2i(6, 3)
+	_world_screen._encounters.advance_frame()
+	var moved: PackedVector2Array = provider.get("context")["occupied"]
+	assert_true(moved.has(Vector2(6, 3)), "the cell it walked onto")
+	assert_false(moved.has(Vector2(5, 3)), "and not the one it left")
+
+	## Mid-step it is DRAWN across two cells, and a wild standing in either of
+	## them stands inside it, so `step_offset_cells()` puts both in the list.
+	trainer.step_direction = Vector2i(1, 0)
+	trainer.step_frames_total = 8
+	trainer.step_frames_remaining = 4
+	_world_screen._encounters.advance_frame()
+	var walking: PackedVector2Array = provider.get("context")["occupied"]
+	assert_true(walking.has(Vector2(6, 3)), "the cell it is committed to")
+	assert_true(walking.has(Vector2(5, 3)), "and the one it is still drawn over")
+
 	## Off the table, so nothing is drawn: the host will not stand a Pokemon the
 	## map cannot produce.
 	provider.set("entry", {

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -147,8 +147,8 @@ func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	## `BuyMenu` owns the whole screen, so the panel steps aside for it.
-	assert_false(host._panel.visible)
+	## `BuyMenu` owns the whole screen, so this host's own layer steps aside.
+	assert_false(host._service_hardware.visible)
 	assert_not_null(host._mart_hardware)
 	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
 	## One item and CANCEL, which is the row `ScrollingMenu` draws past the
@@ -287,7 +287,7 @@ func test_menu_overlay_cancel_resumes_with_false_script_value() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_eq(host._title.text, "MENU")
+	assert_eq(host._title, "MENU")
 	assert_eq(host.selected_index(), 0)
 	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
@@ -303,13 +303,10 @@ func test_two_dimensional_menu_uses_cached_grid_and_default_cursor() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_eq(host._title.text, "MENU")
+	assert_eq(host._title, "MENU")
 	assert_eq(host.selected_index(), 1)
-	assert_eq(host._options.get_child_count(), 1)
-	var grid: GridContainer = host._options.get_child(0) as GridContainer
-	assert_not_null(grid)
-	assert_eq(grid.columns, 2)
-	assert_eq(grid.get_child_count(), 4)
+	assert_eq(host._menu.columns, 2)
+	assert_eq(host._menu.options.size(), 4)
 
 	assert_true(host.handle_button(Gen2Button.LEFT))
 	assert_eq(host.selected_index(), 0)
@@ -368,10 +365,7 @@ func test_phone_list_shows_registered_numbers_and_can_close() -> void:
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.CARD)
 	assert_eq(host._pokegear.card(), Gen2PokegearScreen.CARD_PHONE)
 	assert_eq(host._pokegear.selected_contact(), 0)
-	## B leaves the card for the Pokegear's own card list, and the second one
-	## closes the device.
-	assert_true(host.handle_button(Gen2Button.B))
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
+	## B on a card is that card's own `.quit`, which leaves the Pokegear.
 	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
@@ -449,8 +443,6 @@ func test_pokegear_clock_card_renders_source_time_and_returns_to_cards() -> void
 	await get_tree().process_frame
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
-	assert_true(host.handle_button(Gen2Button.A))
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.CARD)
 	assert_eq(host._pokegear.card(), Gen2PokegearScreen.CARD_CLOCK)
 	## `Pokegear_UpdateClock` writes the weekday and `PrintHoursMins`' reading
@@ -458,9 +450,34 @@ func test_pokegear_clock_card_renders_source_time_and_returns_to_cards() -> void
 	var map: PackedInt32Array = host._pokegear._tilemap()
 	assert_eq(_row_text(map, Gen2TownMapPage.CLOCK_DAY_AT, 9), "WEDNESDAY")
 	assert_eq(_row_text(map, Gen2TownMapPage.CLOCK_TIME_AT, 8), "12:07 AM")
-	## Any button quits the clock card, which lands back on the card list.
+	## Any button quits the clock card, and `.quit` leaves the Pokegear.
 	assert_true(host.handle_button(Gen2Button.A))
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.POKEGEAR)
+	await get_tree().process_frame
+	assert_null(_world_screen._service_host)
+
+
+## The window-resolution panel this host used to keep beside its hardware layer
+## is gone, and the layer that is left is shown from one rule rather than set by
+## hand at each entrance, which is what left the old one standing behind the
+## mode's own boxes. An overlay owns all 160x144, so nothing is drawn under it.
+func test_only_one_service_layer_is_ever_on_screen() -> void:
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	await _queue_service()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_true(host._service_hardware.visible, "the hardware layer draws the mode")
+	## DEPOSIT ITEM's own list is still the one layer.
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_ITEM_LIST)
+	assert_true(host._service_hardware.visible)
+	## A screen of its own owns all 160x144, so nothing is drawn under it.
+	host._open_town_map(false)
+	assert_false(host._service_hardware.visible)
+	host._town_map.close()
+	await get_tree().process_frame
 
 
 ## The other half of the same rule: the radio card is what writes
@@ -627,7 +644,7 @@ func test_apricorn_overlay_gives_kurt_the_chosen_quantity_and_resumes() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_eq(host._title.text, "APRICORNS")
+	assert_eq(host._title, "APRICORNS")
 	assert_true(host.handle_button(Gen2Button.DOWN))
 	assert_true(host.handle_button(Gen2Button.A))
 	assert_true(host.handle_button(Gen2Button.UP))

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -26,6 +26,11 @@ func before_each() -> void:
 	## shared instance both start clean.
 	Gen2OptionsStore.use_test_path()
 	DirAccess.remove_absolute(Gen2OptionsStore.path())
+	## A mod option is written to user://mod_options.json on the press, so a run
+	## that moved a row would otherwise start the next one from its own answer
+	## and step away from it instead of onto it.
+	DirAccess.remove_absolute(Gen2ModOptions.PATH)
+	Gen2ModOptions.reload()
 
 
 func after_each() -> void:
@@ -141,11 +146,9 @@ func test_mod_settings_use_the_hardware_option_screen() -> void:
 	host.handle_button(Gen2Button.A)
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.MODS)
 	assert_true((host.get("_view") as TextureRect).visible)
-	assert_false((host.get("_center") as Control).visible)
 	host.handle_button(Gen2Button.A)
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.MOD_OPTIONS)
 	assert_true((host.get("_view") as TextureRect).visible)
-	assert_false((host.get("_center") as Control).visible)
 
 	Gen2ModHost.reset()
 
@@ -245,8 +248,6 @@ func test_pack_lists_a_granted_item() -> void:
 	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK)
 	assert_true((host.get("_view") as TextureRect).visible)
-	assert_false((host.get("_center") as Control).visible)
-	assert_false((host.get("_pack_view") as TextureRect).visible)
 	var items_pocket: Dictionary = host.get("_pack_pockets")[0]
 	assert_eq(items_pocket["pocket"], Gen2WorldPack.TYPE_ITEM)
 	var items: Array = items_pocket["items"]
@@ -270,15 +271,16 @@ func test_menu_account_draws_the_entry_description_and_off_takes_it_away() -> vo
 	await get_tree().process_frame
 	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
 	var menu: Gen2WorldStartMenu = host.get("_menu")
-	assert_eq(host.get("_status").text, menu.selected_description())
-	assert_ne(host.get("_status").text, "")
+	assert_ne(menu.selected_description(), "")
+	var with_box: Image = host.call("_hardware_image")
+	assert_not_null(with_box)
 
-	host.handle_button(Gen2Button.DOWN)
-	assert_eq(host.get("_status").text, menu.selected_description())
-
+	## The same row with MENU ACCOUNT off is the list without `.MenuDesc`' box,
+	## which is a different picture on the same cursor.
 	options.menu_account = false
-	host.handle_button(Gen2Button.DOWN)
-	assert_eq(host.get("_status").text, "", "the box is gone")
+	var without_box: Image = host.call("_hardware_image")
+	assert_not_null(without_box)
+	assert_ne(with_box.get_data(), without_box.get_data(), "the box is gone")
 
 
 ## The pack's wording is the cartridge's, read out of the cache rather than
@@ -291,11 +293,11 @@ func test_the_toss_boxes_read_the_cartridges_own_words() -> void:
 	_world_screen._world.state.apply_changes({}, {}, {"items": {7: 5}})
 	var host: Gen2StartMenuScreen = await _open_pack()
 	_choose_action(host, Gen2WorldPack.ACTION_TOSS)
-	assert_eq(host.get("_status").text, "Throw away how\nmany?")
+	assert_eq(host.call("box_text"), "Throw away how\nmany?")
 
 	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
-	assert_eq(host.get("_summary").text, "Throw away 5\nPOTION(S)?")
+	assert_eq(host.call("box_text"), "Throw away 5\nPOTION(S)?")
 
 	host.handle_button(Gen2Button.A)
 	assert_eq(String(host.get("_pack_result")), "Threw away\nPOTION(S).")
@@ -638,8 +640,8 @@ func test_a_full_moveset_opens_forget_move_and_a_choice_replaces_that_slot() -> 
 
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
 	assert_true(
-		String(host.get("_summary").text).contains("can't learn more than four moves"),
-		String(host.get("_summary").text)
+		String(host.call("box_text")).contains("can't learn more than four moves"),
+		String(host.call("box_text"))
 	)
 
 	## Yes is YesNoBox's default, which opens the list.
@@ -674,7 +676,10 @@ func test_choosing_an_hm_row_refuses_and_keeps_the_list_open() -> void:
 	await get_tree().process_frame
 
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET, "the list stays open")
-	assert_eq(String(host.get("_status").text), "HM moves can't be forgotten now.")
+	assert_eq(String(host.call("box_text")), "HM moves can't be forgotten now.")
+	## And moving the cursor puts `ListMoves`' own question back.
+	host.handle_button(Gen2Button.DOWN)
+	assert_eq(String(host.call("box_text")), Gen2MoveForget.which_text())
 	assert_eq(_world_screen._injected_save.party[0].moves, [1, 0x39, 3, 4])
 
 
@@ -691,8 +696,8 @@ func test_refusing_to_forget_reaches_stop_learning_and_teaches_nothing() -> void
 	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_STOP_LEARNING)
 	assert_true(
-		String(host.get("_summary").text).begins_with("Stop learning"),
-		String(host.get("_summary").text)
+		String(host.call("box_text")).begins_with("Stop learning"),
+		String(host.call("box_text"))
 	)
 
 	host.handle_button(Gen2Button.A)
@@ -1347,7 +1352,8 @@ func test_give_hands_the_item_to_the_chosen_party_member() -> void:
 	var host: Gen2StartMenuScreen = await _open_pack()
 	_choose_action(host, Gen2WorldPack.ACTION_GIVE)
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
-	assert_eq(host.get("_title").text, "GIVE TO")
+	## `PartyMenuStrings`' own row for `GiveItem`, which is what the page prints.
+	assert_eq(String(host.call("_target_prompt")), Gen2PartyScreen.PROMPT_TO_WHICH)
 
 	host.handle_button(Gen2Button.A)
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
@@ -1372,7 +1378,7 @@ func test_a_full_hand_asks_before_the_swap_and_no_takes_nothing() -> void:
 	host.handle_button(Gen2Button.A)
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_GIVE_SWAP)
 	assert_eq(
-		host.get("_summary").text,
+		String(host.call("box_text")),
 		Gen2WorldPack.ask_swap_text(_first_member_name(save), "REPEL")
 	)
 

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -14,6 +14,8 @@ func before_each() -> void:
 	_clear()
 	DirAccess.make_dir_recursive_absolute(_directory)
 	Gen2ModHost.reset()
+	DirAccess.remove_absolute(Gen2ModOptions.PATH)
+	Gen2ModOptions.reload()
 
 
 func after_each() -> void:

--- a/tests/unit/test_town_map_screen.gd
+++ b/tests/unit/test_town_map_screen.gd
@@ -43,7 +43,7 @@ func test_the_d_pad_walks_the_window_and_everything_else_is_swallowed() -> void:
 
 
 ## A cache with no region map answers false rather than drawing a screen of
-## blanks, which is what keeps the Pokegear's card list open over it.
+## blanks, which is what leaves the Pokegear's own card standing.
 func test_a_cache_without_the_region_map_refuses_to_open() -> void:
 	assert_false(_screen.open(null, 1))
 	assert_false(_screen.visible)

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -94,14 +94,13 @@ func _process(_delta: float) -> bool:
 	_frames += 1
 	if _frames == 3:
 		if _kind == &"town_map":
-			# The Pokegear's card list, then MAP, which is the live path the
-			# region map is reached by.
+			# The Pokegear on its clock card, then one `Pokegear_SwitchPage`
+			# right onto MAP, which is the live path the region map is reached by.
 			_screen._open_pokegear()
-			for button: int in [Gen2Button.DOWN, Gen2Button.A]:
-				_screen._service_host.handle_button(button)
+			_screen._service_host.handle_button(Gen2Button.RIGHT)
 		elif _kind == &"pokegear":
-			# The card list alone: `presses` picks the card, which is the live
-			# path each of the other three is reached by.
+			# The clock card `.InitTilemap` opens on: `presses` walks
+			# `Pokegear_SwitchPage` to whichever of the others is wanted.
 			_screen._open_pokegear()
 		elif _kind == &"trainer_card":
 			_screen._open_trainer_card()


### PR DESCRIPTION
Two commits.

## The stale panel, fixed at the class rather than at the screen

A window-resolution debug panel stood behind the Pokegear's boxes. Its two layers were set visible by hand at each of eleven entrances and one pair set both, so a hidden panel was one missed line away everywhere.

- Neither layer is set by hand now, and there is no second layer left to set. The service overlay's panel and the start menu's are **deleted** rather than hidden: no `Label`, `PanelContainer` or `StyleBoxFlat` is built anywhere under `game/world/`, `game/battle/` or `game/render/`, the strings the hardware pages read are strings rather than label text, and `_apply_layer_visibility` is the one rule the hardware layer is placed by.
- `PokeGear.InitTilemap` writes `POKEGEARCARD_CLOCK` and opens on it, and each card's own `.quit` sets `JUMPTABLE_EXIT_F`, so B anywhere leaves the Pokegear. The card list this project invented in front of that, its mode, its box and its row walk are gone; `Pokegear_SwitchPage` was already built and is the only way between cards.
- `MoveCantForgetHMText` was one of the lines only the panel printed. It is `ListMoves`' own box now and the next cursor move puts the question back, which is what `.hmmove`'s `jr .loop` does.
- A mod option is written to `user://mod_options.json` on the press, so `test_long_mod_settings_scroll_and_adjust_the_global_row` stepped off its own last answer and alternated pass/fail per run. The two files that write one and did not clear that store in `before_each` do now.

## Occupancy for a visible-encounter provider

A provider owns the population and could not see that a cell is taken: `eligible` is `CanEncounterWildMon` plus the collision permission, so it lists cells NPCs and item balls are standing on, and a provider has the snapshot rather than a `Gen2WorldAPI`. A roaming wild spawned on an NPC and walked through one.

- `occupied` is beside `eligible` in the context now: the walk cells the map's own objects hold this frame, all four of a big object's, and both cells one mid-step is drawn across, off `visible_objects()` and `step_offset_cells()`. The player is not in it, since `player` is where that cell is.
- Refreshed by `_push_player_pose`, now the pass that pushes the pose and the occupancy together and still only when one of the two has changed. Neither the eligibility sweep nor the tables are taken again.
- Deliberately **not** folded into `eligible`: `_validate` drops an entry outside it, so the two together would delete a wild an NPC walks over. Which cells a wild MAY be on is the cartridge's rule; who is standing where this frame is live state.
- `api_version` 6, and both shipped examples declare it. `mods/examples/new_content` reads the key and refuses a taken cell.

## Checks

| Check | Result |
|---|---|
| GUT, whole tier, run three times | 3,269/3,269 each time |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` x 3 cartridges | 11 routes, 0 failures each |
| Three-profile story walk | no failures, no errors |
| Boot smoke, with and without mods | clean |
| Net on the UI commit | 322 lines deleted |