### PR TITLE
Wobble the enemy's picture the way AnimateFrontpic wobbles it

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -256,6 +256,11 @@ host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
 })
 ```
 
+A species drawing its own `pics` stands still when it is sent out: the wobble is
+`AnimateFrontpic`, whose frames are the tiles the cartridge packs behind the
+picture, and a supplied one has none. The cry still plays, which is the source's
+own `.cry_no_anim` branch.
+
 A trainer class names one `pic` rather than two. An `icon` is the party menu's
 own strip, the eight tiles of its two 2x2 frames, or one of the cartridge's icon
 numbers to borrow a picture that already exists. Art left out is not an error: a

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -177,12 +177,17 @@ func _draw_pics() -> void:
 			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_ENEMY)
 		)
 	var vbank1: PackedByteArray = _vbank1()
-	var enemy_key: Array = [map_key, enemy, _enemy_pixels_key, enemy_palette, raster]
+	var enemy_key: Array = [
+		map_key, enemy, _enemy_pixels_key, enemy_palette, raster, vbank1.duplicate(),
+	]
 	if enemy_key != _enemy_pic_key:
 		_enemy_pic_key = enemy_key
 		_show_layer(
 			_enemy_pic,
-			_pic_layer(map, Gen2BattleScreenMap.ENEMY_BASE_TILE, Gen2BattleScreenMap.ENEMY_SIDE, _enemy_pixels),
+			_pic_layer(
+				map, Gen2BattleScreenMap.ENEMY_BASE_TILE,
+				Gen2BattleScreenMap.ENEMY_SIDE, _enemy_pixels, vbank1, true
+			),
 			enemy_palette
 		)
 	# `InitBattleDisplay` places the player's back pic with `PlaceGraphic` only
@@ -244,14 +249,21 @@ func _bg_map() -> PackedByteArray:
 ## falls inside this pic's own run, drawn from the pic's padded box. A tile is
 ## `base + column * side + row`, which is the column-major order `PlaceGraphic`
 ## walks and `.BGSquares` indexes.
-## [param foreign] is the cells this layer's sheet does not own, which is
-## `wAttrmap` bit 3: `PokeAnim_SetVBank1` puts the enemy's box in VRAM bank 1
-## while `AnimateFrontpic` runs, and bank 1 holds that pic and its frames alone.
-## Without it the animation's own tiles, which start at the block's 49, would be
-## read as the player's pic, whose first tile `AppearUser` names as `$31`.
+## [param vbank1] is `wAttrmap` bit 3, which is the VRAM bank each cell's tile
+## number is read from, and [param animated] is whether this layer owns bank 1.
+##
+## `PokeAnim_SetVBank1` is the whole reason both are needed. Bank 0 holds the
+## enemy's padded picture at tiles 0 to 48 and the player's back pic from `$31`,
+## which is 49; bank 1 holds the enemy's picture *and* `AnimateFrontpic`'s frames,
+## which run from that same 49. So the two sheets overlap in tile number and are
+## told apart by the bank alone: on a bank 0 cell this layer sees its own square
+## and nothing behind it, on a bank 1 cell only the layer that owns bank 1 draws
+## at all, and it may reach the frames. Reading one flat sheet instead puts the
+## animation's tiles over the player and the player's over the enemy, which is
+## the same defect from either side.
 func _pic_layer(
 	map: PackedByteArray, base: int, side: int, pixels: PackedByteArray,
-	foreign: PackedByteArray = PackedByteArray()
+	vbank1: PackedByteArray = PackedByteArray(), animated: bool = false
 ) -> PackedByteArray:
 	var out: PackedByteArray = _new_buffer()
 	var box: int = side * TILE
@@ -263,15 +275,15 @@ func _pic_layer(
 	@warning_ignore("integer_division")
 	var strip: int = pixels.size() / box
 	@warning_ignore("integer_division")
-	var tiles: int = (strip / TILE) * side
-	var owned: bool = foreign.size() == map.size()
+	var banked: int = (strip / TILE) * side
+	var square: int = side * side
+	var banks: bool = vbank1.size() == map.size()
 	for row: int in ROWS:
 		for column: int in COLUMNS:
 			var at: int = row * COLUMNS + column
-			if owned and foreign[at] != 0:
-				continue
+			var bank1: bool = banks and vbank1[at] != 0
 			var tile: int = int(map[at]) - base
-			if tile < 0 or tile >= tiles:
+			if not claims_tile(tile, bank1, animated, square, banked):
 				continue
 			@warning_ignore("integer_division")
 			var source_x: int = (tile / side) * TILE
@@ -282,6 +294,19 @@ func _pic_layer(
 				for x: int in TILE:
 					out[to + x] = pixels[from + x]
 	return out
+
+
+## Whether the layer whose first tile is [param tile]'s own base draws this
+## cell. Split out because it is the whole of `PokeAnim_SetVBank1`'s rule and
+## getting it wrong is invisible until two pictures share a tile number: bank 1
+## belongs to the animated layer alone and reaches its frames, [param banked],
+## while bank 0 gives every layer its own [param square] and nothing behind it.
+static func claims_tile(
+	tile: int, bank1: bool, animated: bool, square: int, banked: int
+) -> bool:
+	if bank1 and not animated:
+		return false
+	return tile >= 0 and tile < (banked if bank1 else square)
 
 
 ## The two pics as index buffers padded out to their own boxes, so a tile id

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -176,6 +176,7 @@ func _draw_pics() -> void:
 			_data.trainer_palette(enemy_trainer),
 			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_ENEMY)
 		)
+	var vbank1: PackedByteArray = _vbank1()
 	var enemy_key: Array = [map_key, enemy, _enemy_pixels_key, enemy_palette, raster]
 	if enemy_key != _enemy_pic_key:
 		_enemy_pic_key = enemy_key
@@ -200,17 +201,33 @@ func _draw_pics() -> void:
 				_data.player_palette(String(_view.get("player_backpic_palette", "chris"))),
 				_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_PLAYER)
 			)
-		var player_key: Array = [map_key, player, _player_pixels_key, player_palette, raster]
+		var player_key: Array = [
+			map_key, player, _player_pixels_key, player_palette, raster, vbank1.duplicate(),
+		]
 		if player_key != _player_pic_key:
 			_player_pic_key = player_key
 			_show_layer(
 				_player_pic,
-				_pic_layer(map, Gen2BattleScreenMap.PLAYER_BASE_TILE, Gen2BattleScreenMap.PLAYER_SIDE, _player_pixels),
+				_pic_layer(
+					map, Gen2BattleScreenMap.PLAYER_BASE_TILE,
+					Gen2BattleScreenMap.PLAYER_SIDE, _player_pixels, vbank1
+				),
 				player_palette
 			)
 	else:
 		_player_pic.texture = null
 		_player_pic_key = []
+
+
+## `wAttrmap` bit 3 over the screen, which is the VRAM bank each cell's tile
+## number is read from. Only `PokeAnim_SetVBank1` ever sets it here, so it is
+## empty unless the enemy's picture is being animated.
+func _vbank1() -> PackedByteArray:
+	var supplied: Variant = _view.get("bg_vbank1", null)
+	if supplied is PackedByteArray \
+			and (supplied as PackedByteArray).size() == COLUMNS * ROWS:
+		return supplied
+	return PackedByteArray()
 
 
 ## The tilemap the animation edits, or the plain one both pics sit in when the
@@ -227,23 +244,40 @@ func _bg_map() -> PackedByteArray:
 ## falls inside this pic's own run, drawn from the pic's padded box. A tile is
 ## `base + column * side + row`, which is the column-major order `PlaceGraphic`
 ## walks and `.BGSquares` indexes.
+## [param foreign] is the cells this layer's sheet does not own, which is
+## `wAttrmap` bit 3: `PokeAnim_SetVBank1` puts the enemy's box in VRAM bank 1
+## while `AnimateFrontpic` runs, and bank 1 holds that pic and its frames alone.
+## Without it the animation's own tiles, which start at the block's 49, would be
+## read as the player's pic, whose first tile `AppearUser` names as `$31`.
 func _pic_layer(
-	map: PackedByteArray, base: int, side: int, pixels: PackedByteArray
+	map: PackedByteArray, base: int, side: int, pixels: PackedByteArray,
+	foreign: PackedByteArray = PackedByteArray()
 ) -> PackedByteArray:
 	var out: PackedByteArray = _new_buffer()
 	var box: int = side * TILE
 	if pixels.size() < box * box:
 		return out
+	# The strip is `side` tiles tall and as wide as it has tiles, so a pic
+	# carrying `AnimateFrontpic`'s frames behind its own box is the same buffer
+	# with more columns and the same `column * side + row` addressing.
+	@warning_ignore("integer_division")
+	var strip: int = pixels.size() / box
+	@warning_ignore("integer_division")
+	var tiles: int = (strip / TILE) * side
+	var owned: bool = foreign.size() == map.size()
 	for row: int in ROWS:
 		for column: int in COLUMNS:
-			var tile: int = int(map[row * COLUMNS + column]) - base
-			if tile < 0 or tile >= side * side:
+			var at: int = row * COLUMNS + column
+			if owned and foreign[at] != 0:
+				continue
+			var tile: int = int(map[at]) - base
+			if tile < 0 or tile >= tiles:
 				continue
 			@warning_ignore("integer_division")
 			var source_x: int = (tile / side) * TILE
 			var source_y: int = (tile % side) * TILE
 			for line: int in TILE:
-				var from: int = (source_y + line) * box + source_x
+				var from: int = (source_y + line) * strip + source_x
 				var to: int = (row * TILE + line) * Gen2Screen.WIDTH + column * TILE
 				for x: int in TILE:
 					out[to + x] = pixels[from + x]
@@ -267,9 +301,12 @@ func _ensure_pixels() -> void:
 		elif bool(enemy_key[1]):
 			_enemy_pixels = _substitute_pic(false)
 		else:
+			# `GetAnimatedFrontpic` is what the enemy's square is loaded with,
+			# so its frames stand behind the picture in the same run.
 			_enemy_pixels = padded_pic(_data,
 				_battler_pic(int(enemy_key[0]), int(enemy_key[2]), false),
-				Gen2BattleScreenMap.ENEMY_SIDE, true
+				Gen2BattleScreenMap.ENEMY_SIDE, true,
+				_data.species_pic_animation(int(enemy_key[0]), int(enemy_key[2]))
 			)
 		_enemy_pixels_key = enemy_key
 	var player_key: Array = [
@@ -342,12 +379,17 @@ static func substitute_pixels(strip: PackedByteArray, player_side: bool) -> Pack
 ## its own box and a trainer's is already the whole 7x7, so neither is padded.
 ## Static because the placement is the whole of the picture and takes no screen:
 ## a check sweeping three caches builds the box the way the renderer does.
+## [param animation] is the same species' `front_anim` cell, which becomes the
+## tile columns behind the box: `GetAnimatedEnemyFrontpic` loads them at
+## `7 * 7 tiles` past the picture and `.GetTilemap` addresses them from there.
 static func padded_pic(
-	data: GameData, pic: Dictionary, side: int, front: bool = false
+	data: GameData, pic: Dictionary, side: int, front: bool = false,
+	animation: Dictionary = {}
 ) -> PackedByteArray:
 	var box: int = side * TILE
+	var extra: int = _animation_columns(animation, side) * TILE
 	var out: PackedByteArray = PackedByteArray()
-	out.resize(box * box)
+	out.resize(box * (box + extra))
 	if pic.is_empty():
 		return out
 
@@ -374,10 +416,60 @@ static func padded_pic(
 		pad_x = Gen2PicImage.frontpic_pad_columns(width / TILE) * TILE
 		@warning_ignore("integer_division")
 		pad_y = Gen2PicImage.frontpic_pad_rows(height / TILE) * TILE
+	var strip: int = box + extra
 	for y: int in mini(height, box - pad_y):
 		for x: int in mini(width, box - pad_x):
-			out[(y + pad_y) * box + x + pad_x] = indices[y * stride + x]
+			out[(y + pad_y) * strip + x + pad_x] = indices[y * stride + x]
+	if extra > 0:
+		_append_animation(data, animation, out, strip, side)
 	return out
+
+
+## How many tile columns of `side` an animation's own `w * h` tiles need. Zero
+## when the cartridge has no animation for this pic, which is every pic on Gold
+## and Silver and every trainer and back pic on Crystal.
+static func _animation_columns(animation: Dictionary, side: int) -> int:
+	if animation.is_empty() or side <= 0:
+		return 0
+	@warning_ignore("integer_division")
+	var tiles: int = (int(animation.get("width", 0)) / TILE) \
+		* (int(animation.get("height", 0)) / TILE)
+	return ceili(float(tiles) / float(side))
+
+
+## The animation's tiles laid into the strip past the box, in the run's own
+## order: tile `side * side + i` is at column `side + i / side`, row `i % side`.
+static func _append_animation(
+	data: GameData, animation: Dictionary, out: PackedByteArray, strip: int, side: int
+) -> void:
+	var name: String = String(animation.get("atlas", ""))
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		data.atlas_indices(name), data.atlas(name), animation
+	)
+	if cell.is_empty():
+		return
+	var indices: PackedByteArray = cell["indices"]
+	var source_stride: int = int(cell["width"])
+	@warning_ignore("integer_division")
+	var rows: int = int(cell["height"]) / TILE
+	@warning_ignore("integer_division")
+	var count: int = (source_stride / TILE) * rows
+	for index: int in count:
+		# The atlas cell holds the tiles column major, the way every pic is
+		# stored, and the strip wants them in the run's own order.
+		@warning_ignore("integer_division")
+		var source_x: int = (index / rows) * TILE
+		var source_y: int = (index % rows) * TILE
+		@warning_ignore("integer_division")
+		var target_x: int = (side + index / side) * TILE
+		var target_y: int = (index % side) * TILE
+		for line: int in TILE:
+			var from: int = (source_y + line) * source_stride + source_x
+			var to: int = (target_y + line) * strip + target_x
+			if from + TILE > indices.size() or to + TILE > out.size():
+				continue
+			for x: int in TILE:
+				out[to + x] = indices[from + x]
 
 
 ## A battler pic's own palette, permuted by whatever DMG byte the animation's

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -205,6 +205,13 @@ var _hud_balls: Array = []
 var _hud_border: Array = []
 ## `SlideBattlePicOut`, one entry per square still sliding off.
 var _slides: Array[Dictionary] = []
+## `AnimateFrontpic` over the enemy's square, or null when none is running.
+var _frontpic: Gen2PicAnimation = null
+## `wAttrmap` bit 3, which `PokeAnim_SetVBank1` sets over that square while the
+## animation runs and `PokeAnim_SetVBank0` clears in `PokeAnim_DeinitFrames`. It
+## is the whole reason the animation's tile numbers may sit on top of the
+## player's: bank 1 holds the enemy's picture and its frames and nothing else.
+var _bg_vbank1: PackedByteArray = PackedByteArray()
 ## The text the event pump produced while a bar was still draining. The source
 ## prints it after the bar arrives, since `applydamage` runs before
 ## `criticaltext` and `supereffectivetext`.
@@ -408,7 +415,8 @@ func _process(delta: float) -> void:
 ## because that answers whether a bar is on screen.
 func frames_running() -> bool:
 	var bars: bool = not _bars.is_empty() or (_exp_bar != null and not _exp_bar.paused())
-	return bars or _intro != null or animation_running() or fainting() or sliding()
+	return bars or _intro != null or animation_running() or fainting() or sliding() \
+		or animating_frontpic()
 
 
 ## One hardware frame of everything that counts them. Public through
@@ -422,6 +430,7 @@ func advance_frame() -> bool:
 	moved = advance_bars() or moved
 	moved = advance_faint() or moved
 	moved = advance_slide() or moved
+	moved = advance_frontpic() or moved
 	moved = advance_animation() or moved
 	_resume_after_frames(was_running)
 	return moved
@@ -485,6 +494,58 @@ func advance_slide() -> bool:
 		_slides.remove_at(0)
 	_push_view()
 	return true
+
+
+## Whether the enemy's picture is still wobbling through `AnimateFrontpic`.
+func animating_frontpic() -> bool:
+	return _frontpic != null
+
+
+## One turn of `AnimateFrontpic`'s own `.loop`, which is one `SetUpPokeAnim` and
+## so one hardware frame. The animation edits the tilemap and nothing else, the
+## way `PokeAnim_PlaceGraphic` does, so what it leaves is stamped into the
+## screen's own map over the enemy's square.
+func advance_frontpic() -> bool:
+	if _frontpic == null:
+		return false
+	var cry: StringName = _frontpic.advance()
+	if cry != &"":
+		# `PokeAnim_StereoCry` is `PlayStereoCry2`, the sibling that does not
+		# `WaitSFX`: the picture keeps moving over it, which is the whole reason
+		# the cry is inside the animation rather than in front of it.
+		_play_entrance_cry(Gen2Battle.ENEMY, _enemy)
+	_stamp_frontpic()
+	if _frontpic.finished():
+		# `PokeAnim_DeinitFrames` ends with `PokeAnim_SetVBank0`, which puts the
+		# square back on the sheet everything else is read from.
+		_frontpic = null
+		_bg_vbank1 = PackedByteArray()
+	_push_view()
+	return true
+
+
+## The animation's 7x7 box into the enemy's square. Its cells are numbered the
+## way `PokeAnim_PlaceGraphic` numbers them, which is the column-major order
+## [method Gen2BattleScreenMap.stamp] already writes for that square.
+func _stamp_frontpic() -> void:
+	if _frontpic == null or _frontpic.box.size() != Gen2PicAnimation.BOX * Gen2PicAnimation.BOX:
+		return
+	if _bg_vbank1.size() != _bg_map.size():
+		_bg_vbank1.resize(_bg_map.size())
+		_bg_vbank1.fill(0)
+	var at: Vector2i = Gen2BattleScreenMap.ENEMY_AT
+	for column: int in Gen2PicAnimation.BOX:
+		for row: int in Gen2PicAnimation.BOX:
+			var x: int = at.x + column
+			var y: int = at.y + row
+			if x < 0 or x >= Gen2BattleScreenMap.COLUMNS \
+					or y < 0 or y >= Gen2BattleScreenMap.ROWS:
+				continue
+			_bg_map[y * Gen2BattleScreenMap.COLUMNS + x] = (
+				Gen2BattleScreenMap.ENEMY_BASE_TILE
+				+ int(_frontpic.box[column * Gen2PicAnimation.BOX + row])
+			) & 0xFF
+			_bg_vbank1[y * Gen2BattleScreenMap.COLUMNS + x] = 1
 
 
 ## `PlayerMonFaintedAnimation` or `EnemyMonFaintedAnimation`, which
@@ -1023,6 +1084,8 @@ func _init_battle_display() -> void:
 	_intro_message = ""
 	_entrance_stages = []
 	_slides = []
+	_frontpic = null
+	_bg_vbank1 = PackedByteArray()
 	_hud_balls = []
 	_hud_border = []
 	## `InitBattleDisplay` clears both panels off the map, and the two pictures
@@ -1091,10 +1154,14 @@ func advance_intro() -> bool:
 ## | 6 | the player slides off, `SendOutMonText` prints without waiting | the same |
 ## | 7 | the ball, the cry and the player's panel | the same |
 ##
-## The one part of `BattleStartMessage` not here is `AnimateFrontpic`: the
-## cartridge wobbles the enemy's picture and plays the cry inside that animation,
-## and this project imports neither the pic animations nor their pointers, so the
-## cry is played on its own the way `.cry_no_anim` plays it.
+## `AnimateFrontpic` is the enemy's alone and is where its cry comes from:
+## `BattleStartMessage`'s wild branch runs `ANIM_MON_NORMAL` and
+## `ShowSetEnemyMonAndSendOutAnimation` runs `ANIM_MON_SLOW`, both at
+## `hlcoord 12, 0`, and both `jr .skip_cry` past `PlayStereoCry` because the
+## animation plays it. Crystal's alone: pokegold has no `pic_animation.asm` and
+## both of its send-outs reach `PlayStereoCry` directly, which is the
+## `.cry_no_anim` branch and what this project falls back on. The player's own
+## send-out has no animation on either cartridge.
 func _build_entrance() -> void:
 	_entrance_stages = []
 	var text: String = _intro_message
@@ -1111,7 +1178,12 @@ func _build_entrance() -> void:
 		})
 	else:
 		# `BattleCheckEnemyShininess` and the cry, both in front of the line.
-		_entrance_stages.append({"events": _battle.entrance_events(Gen2Battle.ENEMY, false)})
+		_entrance_stages.append(
+			_with_frontpic(
+				{"events": _battle.entrance_events(Gen2Battle.ENEMY, false)},
+				Gen2PicAnimation.ANIM_MON_NORMAL
+			)
+		)
 	# `BattleStart_TrainerHuds` is pushed in front of the line it is called with.
 	_entrance_stages.append({"apply": ENTRANCE_START_HUDS, "message": text})
 	# `EmptyBattleTextbox` and `ClearSprites` take the balls away the moment that
@@ -1126,10 +1198,15 @@ func _build_entrance() -> void:
 		_entrance_stages.append({
 			"message": "%s\nsent out\n%s!" % [_enemy_battler_label(), _name_of(_enemy)],
 		})
-		_entrance_stages.append({
-			"apply": ENTRANCE_ENEMY_PIC,
-			"events": _battle.entrance_events(Gen2Battle.ENEMY),
-		})
+		_entrance_stages.append(
+			_with_frontpic(
+				{
+					"apply": ENTRANCE_ENEMY_PIC,
+					"events": _battle.entrance_events(Gen2Battle.ENEMY),
+				},
+				Gen2PicAnimation.ANIM_MON_SLOW
+			)
+		)
 		_entrance_stages.append({"apply": ENTRANCE_ENEMY_HUD})
 	# `DoBattle`'s own `ld c, 40`, then `SlideBattlePicOut` and `SendOutMonText`.
 	_entrance_stages.append({"delay": PLAYER_ENTRANCE_FRAMES})
@@ -1145,6 +1222,39 @@ func _build_entrance() -> void:
 		"events": _battle.entrance_events(Gen2Battle.PLAYER),
 	})
 	_entrance_stages.append({"apply": ENTRANCE_PLAYER_HUD})
+
+
+## Moves the enemy's cry out of [param stage]'s events and into
+## `AnimateFrontpic`, where the cartridge plays it. A cache with no animation for
+## this species, and a battle scene switched off, both leave the stage as it was,
+## which is the source's own `.cry_no_anim`.
+func _with_frontpic(stage: Dictionary, kind: int) -> Dictionary:
+	if _data == null or _battle == null:
+		return stage
+	# `farcall CheckBattleScene / jr c, .cry_no_anim`: with the OPTION menu's
+	# battle-scene row off, the picture is left alone and `PlayStereoCry` is
+	# played where it stands.
+	if not Gen2OptionsStore.current().battle_scene:
+		return stage
+	var record: Dictionary = _data.pic_animation(_enemy, _enemy_unown_form)
+	if record.is_empty():
+		return stage
+	var events: Array = stage.get("events", []) as Array
+	var kept: Array = []
+	var animate: bool = false
+	for event: Variant in events:
+		# `CheckFaintedFrzSlp` and `CheckSleepingTreeMon` gate the cry, and both
+		# gate the animation with it: the source's `jr c, .skip_cry` jumps past
+		# the pair. So an entrance with no cry event has no animation either.
+		if event is Dictionary and StringName((event as Dictionary)["type"]) == Gen2Battle.CRY:
+			animate = true
+			continue
+		kept.append(event)
+	if not animate:
+		return stage
+	stage["events"] = kept
+	stage["frontpic"] = kind
+	return stage
 
 
 ## What an entrance stage's `apply` names, each one routine of the source's.
@@ -1199,6 +1309,12 @@ func _advance_entrance() -> bool:
 			stage["message"] = ""
 			show_message(message, prompt)
 			if prompt:
+				return true
+		if stage.has("frontpic"):
+			var kind: int = int(stage["frontpic"])
+			stage.erase("frontpic")
+			_begin_frontpic(kind)
+			if animating_frontpic():
 				return true
 		var events: Array = stage.get("events", []) as Array
 		_entrance_stages.pop_front()
@@ -1260,6 +1376,7 @@ func entrance_snapshot() -> Dictionary:
 		"player_backpic": _player_backpic,
 		"balls": _hud_balls.size(),
 		"sliding": sliding(),
+		"frontpic": animating_frontpic(),
 		"animating": animation_running(),
 		"anim": int(_anim_event.get("index", 0)) if _anim != null else 0,
 	}
@@ -1269,6 +1386,22 @@ func entrance_snapshot() -> Dictionary:
 ## and both of them drawn by the entrance in the first place.
 func _hud_visible() -> bool:
 	return _enemy_hud_visible and _player_hud_visible and _anim_hud_hidden < 0
+
+
+## `predef AnimateFrontpic` on the enemy's square, which `LoadMonAnimation` and
+## `PokeAnim_InitPicAttributes` set up before the first frame is spent.
+func _begin_frontpic(kind: int) -> void:
+	if _data == null:
+		return
+	var record: Dictionary = _data.pic_animation(_enemy, _enemy_unown_form)
+	if record.is_empty():
+		return
+	var animation := Gen2PicAnimation.new(record, kind)
+	if animation.finished():
+		return
+	_frontpic = animation
+	_stamp_frontpic()
+	_push_view()
 
 
 ## `SlideBattlePicOut` over one square.
@@ -4420,6 +4553,7 @@ func _push_view() -> void:
 		"trainer_hud_border": _hud_border,
 		## `wTilemap` and the video state an animation writes over it.
 		"bg_map": _bg_map,
+		"bg_vbank1": _bg_vbank1,
 		"bg_palette_maps": _background_maps(&"bg"),
 		"ob_palette_maps": _background_maps(&"ob"),
 		"anim_sprites": _anim.sprites() if _anim != null else [],

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -104,6 +104,7 @@ var _world_fruit_trees: Array = []
 var _world_spawns: Dictionary = {}
 var _world_audio: Dictionary = {}
 var _battle_anims_section: Dictionary = {}
+var _pic_anims_section: Dictionary = {}
 ## Which of the sections above have been read. A section that is genuinely empty
 ## is indistinguishable from one that has not been read yet, so the answer is
 ## recorded rather than inferred from the value.
@@ -2135,6 +2136,66 @@ func _supplied_pic(art: Variant) -> Dictionary:
 	}
 
 
+## Where a species' animation tiles sit, in [method species_pic]'s shape. The
+## cell is the same square as the front pic's and holds the `w * h` tiles
+## `GetAnimatedEnemyFrontpic` copies out of the run behind the picture. Empty
+## for a cartridge with no pic animation and for a mod's own supplied picture,
+## neither of which has frames to draw.
+func species_pic_animation(number: int, unown_form: int = 0) -> Dictionary:
+	if pic_animation(number, unown_form).is_empty():
+		return {}
+	var pic: Dictionary = species_pic(number, false)
+	if pic.is_empty() or pic.has("indices"):
+		return {}
+	if number == RomLayout.UNOWN_SPECIES and unown_form > 0:
+		pic["atlas"] = "unown_front_anim"
+		pic["slot"] = unown_form - 1
+		return pic
+	pic["atlas"] = "front_anim"
+	return pic
+
+
+## `AnimateFrontpic`'s record for a species, or for one of Unown's letters when
+## [param unown_form] is a letter rather than zero: { height, script, idle,
+## frames }, the scripts and each frame as a [PackedByteArray].
+##
+## Empty for Gold and Silver, which have no pic animation at all, and for an egg:
+## `AnimateMon_CheckIfPokemon` refuses `EGG` before anything is read, so the
+## cartridge's own egg tables are never reached through here.
+func pic_animation(number: int, unown_form: int = 0) -> Dictionary:
+	var section: Dictionary = _pic_anims()
+	if section.is_empty():
+		return {}
+
+	var value: Variant = null
+	if number == RomLayout.UNOWN_SPECIES and unown_form > 0:
+		var letters: Variant = section.get("unown", [])
+		if letters is Array and unown_form - 1 < (letters as Array).size():
+			value = (letters as Array)[unown_form - 1]
+	else:
+		value = (section.get("species", {}) as Dictionary).get(str(number), null)
+	if not value is Dictionary:
+		return {}
+
+	var record: Dictionary = value as Dictionary
+	var blob: PackedByteArray = _blob("pic_anims")
+	var frames: Array = []
+	for frame: Variant in (record.get("frames", []) as Array):
+		frames.append(_payload_bytes(frame, blob))
+	return {
+		"height": int(record.get("height", 0)),
+		"script": _payload_bytes(record.get("script", []), blob),
+		"idle": _payload_bytes(record.get("idle", []), blob),
+		"frames": frames,
+	}
+
+
+func _pic_anims() -> Dictionary:
+	if _claim_section("pic_anims"):
+		_pic_anims_section = _read_section(RomCache.pic_anims_path(directory), false)
+	return _pic_anims_section
+
+
 ## One of Unown's 26 letter forms, which live outside the species tables.
 func unown_pic(form: int, back: bool = false) -> Dictionary:
 	if form < 0 or form >= RomLayout.UNOWN_FORMS:
@@ -2198,6 +2259,8 @@ func _section_json_path(section: String) -> String:
 			return RomCache.world_audio_path(directory)
 		"battle_anims":
 			return RomCache.battle_anims_path(directory)
+		"pic_anims":
+			return RomCache.pic_anims_path(directory)
 		"overworld_effects":
 			return RomCache.overworld_effects_path(directory)
 	return ""

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -59,6 +59,7 @@ const WORLD_FRUIT_TREES: String = "world_fruit_trees.json"
 ## two escape moves and a blackout all read both.
 const WORLD_SPAWNS: String = "world_spawns.json"
 const BATTLE_ANIMS: String = "battle_anims.json"
+const PIC_ANIMS: String = "pic_anims.json"
 const BATTLE_ANIM_GFX_DIR: String = "battle_anim_gfx"
 
 ## The key a payload span is stored under, and how many numbers it holds. A
@@ -75,7 +76,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 70
+const FORMAT_VERSION: int = 71
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a
@@ -250,6 +251,13 @@ static func battle_anims_path(directory: String) -> String:
 ## JSON for the reason every other tile strip is: it is pixels, not records.
 static func battle_anim_gfx_path(directory: String, number: int) -> String:
 	return "%s/%s/%02d.idx" % [directory, BATTLE_ANIM_GFX_DIR, number]
+
+
+## `AnimateFrontpic`'s scripts, bitmasks and frames, one record per species and
+## per Unown letter; see [Gen2PicAnimation]. Absent for Gold and Silver, which
+## have no pic animation at all.
+static func pic_anims_path(directory: String) -> String:
+	return "%s/%s" % [directory, PIC_ANIMS]
 
 
 static func pic_path(directory: String, name: String) -> String:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3765,6 +3765,13 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		result["message"] = "Could not decode pics."
 		return result
 
+	# Crystal's alone; Gold and Silver have no pic animation, so an empty answer
+	# is the honest one rather than a failure.
+	var pic_anims: Dictionary = _import_pic_anims(rom, layout, species)
+	if pic_anims.is_empty() and not RomLayout.pic_anim(layout).is_empty():
+		result["message"] = "Could not decode pic animations."
+		return result
+
 	var tiles: Dictionary = _import_tiles(rom, layout, on_progress)
 	if tiles.is_empty():
 		result["message"] = "Could not write the font."
@@ -3820,6 +3827,12 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 
 	if not RomCache.write_json(RomCache.species_path(directory), species):
 		result["message"] = "Could not write species data."
+		return result
+	if not pic_anims.is_empty() and not RomCache.write_section(
+		RomCache.pic_anims_path(directory),
+		RomCache.blob_path(RomCache.pic_anims_path(directory)), pic_anims
+	):
+		result["message"] = "Could not write pic animation data."
 		return result
 	if not RomCache.write_json(RomCache.moves_path(directory), moves):
 		result["message"] = "Could not write move data."
@@ -5622,6 +5635,15 @@ func _import_pics(
 	var front: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, RomLayout.SPECIES_COUNT)
 	var back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.SPECIES_COUNT)
 	var unown_front: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, RomLayout.UNOWN_FORMS)
+	# `GetAnimatedEnemyFrontpic` loads the tiles past the pic's own `w * h` out
+	# of the same decompressed run, into VRAM behind the padded 7x7 block. They
+	# are frames, not a picture, so they get an atlas rather than a slot in the
+	# one beside them.
+	var animated: bool = not RomLayout.pic_anim(layout).is_empty()
+	var front_anim: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, RomLayout.SPECIES_COUNT)
+	var unown_front_anim: Dictionary = _new_atlas(
+		RomLayout.FRONTPIC_MAX_TILES, RomLayout.UNOWN_FORMS
+	)
 	var unown_back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.UNOWN_FORMS)
 	var trainer_classes: int = RomLayout.trainer_class_count(layout)
 	var trainers: Dictionary = _new_atlas(RomLayout.TRAINER_PIC_TILES, trainer_classes)
@@ -5663,6 +5685,11 @@ func _import_pics(
 					rom, layout, RomLayout.unown_pic_pointer_offset(layout, form, false),
 					tiles[0], tiles[1], unown_front, form
 				)
+				if animated:
+					_decode_into(
+						rom, layout, RomLayout.unown_pic_pointer_offset(layout, form, false),
+						tiles[0], tiles[1], unown_front_anim, form, tiles[0] * tiles[1]
+					)
 				_decode_into(
 					rom, layout, RomLayout.unown_pic_pointer_offset(layout, form, true),
 					RomLayout.BACKPIC_TILES, RomLayout.BACKPIC_TILES, unown_back, form
@@ -5680,6 +5707,11 @@ func _import_pics(
 				rom, layout, RomLayout.pic_pointer_offset(layout, source, false),
 				tiles[0], tiles[1], front, slot
 			)
+			if animated:
+				_decode_into(
+					rom, layout, RomLayout.pic_pointer_offset(layout, source, false),
+					tiles[0], tiles[1], front_anim, slot, tiles[0] * tiles[1]
+				)
 			_decode_into(
 				rom, layout, RomLayout.pic_pointer_offset(layout, source, true),
 				RomLayout.BACKPIC_TILES, RomLayout.BACKPIC_TILES, back, slot
@@ -5704,6 +5736,11 @@ func _import_pics(
 		"front": front, "back": back, "unown_front": unown_front, "unown_back": unown_back,
 		"trainers": trainers, "player_back": player_back,
 	}
+	# `AnimateFrontpic` is Crystal's alone, so the two atlases behind the front
+	# pics are written only where something reads them.
+	if animated:
+		atlases["front_anim"] = front_anim
+		atlases["unown_front_anim"] = unown_front_anim
 	var written: Dictionary = {}
 	for name: String in atlases:
 		var atlas: Dictionary = atlases[name]
@@ -5746,6 +5783,9 @@ func _decode_lz_into(
 	return true
 
 
+## [param skip_tiles] takes the run past the picture instead of the picture:
+## `GetAnimatedEnemyFrontpic` reads `wDecompressEnemyFrontpic + w * h tiles` for
+## the animation's own frames, which are the same LZ run's tail.
 func _decode_into(
 	rom: RomFile,
 	layout: Dictionary,
@@ -5753,7 +5793,8 @@ func _decode_into(
 	columns: int,
 	rows: int,
 	atlas: Dictionary,
-	slot: int
+	slot: int,
+	skip_tiles: int = 0
 ) -> bool:
 	if columns <= 0 or rows <= 0:
 		return false
@@ -5765,18 +5806,27 @@ func _decode_into(
 		return false
 
 	var raw: PackedByteArray = _lz.decompress(rom.bytes(), start)
-	if _lz.failed or raw.size() < columns * rows * Gen2Tiles.TILE_BYTES:
-		return false
+	if _lz.failed or raw.size() < (skip_tiles + columns * rows) * Gen2Tiles.TILE_BYTES:
+		# The animation's tail is as long as the picture only when every frame
+		# tile is distinct: `front.animated.2bpp` deduplicates them, and
+		# `GetAnimatedEnemyFrontpic` copies `w * h` whatever is there, so the
+		# short ones end in tiles no frame names. Pad rather than refuse.
+		if skip_tiles <= 0 or raw.size() <= skip_tiles * Gen2Tiles.TILE_BYTES:
+			return false
+		raw.resize((skip_tiles + columns * rows) * Gen2Tiles.TILE_BYTES)
 
-	_blit_pic(raw, columns, rows, atlas, slot)
+	_blit_pic(raw, columns, rows, atlas, slot, skip_tiles)
 	return true
 
 
 ## One decompressed pic into its cell of an atlas.
 func _blit_pic(
-	raw: PackedByteArray, columns: int, rows: int, atlas: Dictionary, slot: int
+	raw: PackedByteArray, columns: int, rows: int, atlas: Dictionary, slot: int,
+	skip_tiles: int = 0
 ) -> void:
-	var pixels: PackedByteArray = Gen2Tiles.decode_pic(raw, columns, rows)
+	var pixels: PackedByteArray = Gen2Tiles.decode_pic(
+		raw.slice(skip_tiles * Gen2Tiles.TILE_BYTES) if skip_tiles > 0 else raw, columns, rows
+	)
 	var cell: int = atlas["cell"]
 	Gen2Tiles.blit(
 		pixels, columns * Gen2Tiles.TILE_WIDTH,
@@ -5784,3 +5834,137 @@ func _blit_pic(
 		(slot % ATLAS_COLUMNS) * cell, floori(float(slot) / float(ATLAS_COLUMNS)) * cell
 	)
 	atlas["decoded"] = int(atlas["decoded"]) + 1
+
+
+## `AnimateFrontpic`'s tables: one record per species and one per Unown letter,
+## each carrying the two scripts and the frames they name. Empty for a cartridge
+## with no `pic_anim` pins, which is Gold and Silver: neither ships
+## `pic_animation.asm` and both send-outs reach `PlayStereoCry` directly.
+##
+## A frame is stored as its bitmask followed by its tile numbers, which is what
+## `PokeAnim_GetFrame` reads in that order, so one byte run holds a frame and
+## the bitmask table's own deduplication is resolved here rather than at every
+## draw.
+func _import_pic_anims(rom: RomFile, layout: Dictionary, species: Array) -> Dictionary:
+	var pins: Dictionary = RomLayout.pic_anim(layout)
+	if pins.is_empty():
+		return {}
+
+	var heights: Dictionary = {}
+	for entry: Dictionary in species:
+		heights[int(entry["number"])] = int((entry["front_tiles"] as Array)[1])
+
+	var out: Dictionary = {"species": {}, "unown": []}
+	for number: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var record: Dictionary = _read_pic_anim(
+			rom, int(heights.get(number, 0)), int(pins["script_bank"]),
+			int(pins["scripts"]) + (number - 1) * 2,
+			int(pins["idle_scripts"]) + (number - 1) * 2,
+			int(pins["bitmask_pointers"]) + (number - 1) * 2, int(pins["bitmask_bank"]),
+			int(pins["frame_pointers"]) + (number - 1) * 2,
+			int(pins["kanto_frame_bank"]) if number < RomLayout.JOHTO_SPECIES \
+				else int(pins["johto_frame_bank"])
+		)
+		if record.is_empty():
+			return {}
+		out["species"][str(number)] = record
+
+	# Unown is one placeholder in the species tables and 26 letters here, the
+	# split `PokeAnim_GetSpeciesOrUnown` makes.
+	var unown_height: int = int(heights.get(RomLayout.UNOWN_SPECIES, 0))
+	for form: int in RomLayout.UNOWN_FORMS:
+		var record: Dictionary = _read_pic_anim(
+			rom, unown_height, int(pins["script_bank"]),
+			int(pins["unown_scripts"]) + form * 2,
+			int(pins["unown_idle_scripts"]) + form * 2,
+			int(pins["unown_bitmask_pointers"]) + form * 2, int(pins["bitmask_bank"]),
+			int(pins["unown_frame_pointers"]) + form * 2, int(pins["unown_frame_bank"])
+		)
+		if record.is_empty():
+			return {}
+		(out["unown"] as Array).append(record)
+	return out
+
+
+## One species' or letter's record. Every pointer here is a plain in-bank word:
+## a script and a bitmask are read in their table's own bank, and a frame in the
+## bank its data lives in rather than its pointer table's.
+func _read_pic_anim(
+	rom: RomFile,
+	height: int,
+	script_bank: int,
+	script_pointer: int,
+	idle_pointer: int,
+	bitmask_pointer: int,
+	bitmask_bank: int,
+	frame_pointer: int,
+	frame_bank: int
+) -> Dictionary:
+	var mask_bytes: int = RomLayout.pic_anim_bitmask_bytes(height)
+	if mask_bytes <= 0:
+		return {}
+	var script: PackedByteArray = _read_pic_anim_script(rom, script_bank, script_pointer)
+	var idle: PackedByteArray = _read_pic_anim_script(rom, script_bank, idle_pointer)
+	if script.is_empty() or idle.is_empty():
+		return {}
+
+	# How many frames the two scripts between them name. Nothing bounds the
+	# table on the cartridge: `PokeAnim_GetBitmaskIndex` indexes it with
+	# `command - 1` and the highest command used is the last entry there is.
+	var count: int = 0
+	for run: PackedByteArray in [script, idle]:
+		for at: int in range(0, run.size(), 2):
+			if run[at] < PIC_ANIM_DOREPEAT:
+				count = maxi(count, int(run[at]))
+	var table: int = RomFile.linear(frame_bank, rom.u16le(frame_pointer))
+	var masks: int = RomFile.linear(bitmask_bank, rom.u16le(bitmask_pointer))
+	if not rom.in_bounds(table, count * 2):
+		return {}
+
+	var frames: Array = []
+	for index: int in count:
+		var frame: int = RomFile.linear(frame_bank, rom.u16le(table + index * 2))
+		if not rom.in_bounds(frame):
+			return {}
+		var mask_at: int = masks + rom.u8(frame) * mask_bytes
+		if not rom.in_bounds(mask_at, mask_bytes):
+			return {}
+		var mask: PackedByteArray = rom.slice(mask_at, mask_bytes)
+		var tiles: int = 0
+		for byte: int in mask:
+			for bit: int in 8:
+				tiles += (byte >> bit) & 1
+		if not rom.in_bounds(frame + 1, tiles):
+			return {}
+		frames.append({"bytes": Array(mask + rom.slice(frame + 1, tiles))})
+
+	return {
+		"height": height,
+		"script": {"bytes": Array(script)},
+		"idle": {"bytes": Array(idle)},
+		"frames": frames,
+	}
+
+
+## `frame`, `setrepeat` and `dorepeat` are all two bytes wide and `endanim` is
+## one, but `PokeAnim_GetPointer` reads a word at every step, so the run is a
+## table of pairs whose terminator's second byte is never looked at.
+const PIC_ANIM_ENDANIM: int = 0xFF
+const PIC_ANIM_SETREPEAT: int = 0xFE
+const PIC_ANIM_DOREPEAT: int = 0xFD
+## `wPokeAnimFrame` is a byte, so a script cannot honestly be longer than this.
+const PIC_ANIM_MAX_COMMANDS: int = 256
+
+
+func _read_pic_anim_script(rom: RomFile, bank: int, pointer: int) -> PackedByteArray:
+	if not rom.in_bounds(pointer, 2):
+		return PackedByteArray()
+	var at: int = RomFile.linear(bank, rom.u16le(pointer))
+	for index: int in PIC_ANIM_MAX_COMMANDS:
+		if not rom.in_bounds(at + index * 2, 2):
+			return PackedByteArray()
+		if rom.u8(at + index * 2) == PIC_ANIM_ENDANIM:
+			# The terminator is kept: an interpreter that walks the run needs an
+			# end to reach, and its second byte is the cartridge's own.
+			return rom.slice(at, (index + 1) * 2)
+	return PackedByteArray()

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -19,6 +19,9 @@ extends RefCounted
 ## of the code beside it. Tighten the wording, never delete the derivation.
 
 const SPECIES_COUNT: int = 251
+## `GetMonFramesPointer`'s `cp JOHTO_POKEMON`: the frame data below this species
+## is in `KantoFrames`' bank and from it in `JohtoFrames`'.
+const JOHTO_SPECIES: int = 152
 const NAME_LENGTH: int = 10
 const BASE_STATS_SIZE: int = 32
 const PIC_POINTER_SIZE: int = 3
@@ -1603,6 +1606,10 @@ const GOLD_SILVER: Dictionary = {
 	"base_stats": 0x51B0B,
 	"pic_pointers": 0x48000,
 	"unown_pic_pointers": 0x7C000,
+	# pokegold has no `pic_animation.asm`, no `anim.asm`, no bitmasks and no
+	# frames: both of its send-outs reach `PlayStereoCry` directly, which is
+	# Crystal's own `.cry_no_anim` branch. See [constant CRYSTAL].
+	"pic_anim": {},
 	"palettes": 0xAD3D,
 	"move_names": 0x1B1574,
 	"item_names": 0x1B0000,
@@ -2063,6 +2070,31 @@ const CRYSTAL: Dictionary = {
 	"base_stats": 0x51424,
 	"pic_pointers": 0x120000,
 	"unown_pic_pointers": 0x124000,
+	# `AnimateFrontpic`'s five tables, Crystal's alone: pokegold ships no
+	# `pic_animation.asm`, no `anim.asm`, no bitmasks and no frames, and both of
+	# its send-outs reach `PlayStereoCry` directly. Every address here is
+	# rgblink's own, from a `pokecrystal11.gbc` byte identical to the dump.
+	#
+	# A script pointer and a bitmask pointer are read in the table's own bank; a
+	# frames pointer is read in the bank its *data* lives in, which is
+	# `KantoFrames` below species [constant JOHTO_SPECIES] and `JohtoFrames`
+	# from it (`GetMonFramesPointer`).
+	"pic_anim": {
+		"scripts": 0xD0695,
+		"idle_scripts": 0xD16A3,
+		"bitmask_pointers": 0xD24EF,
+		"frame_pointers": 0xD4000,
+		"script_bank": 0x34,
+		"bitmask_bank": 0x34,
+		"frame_pointer_bank": 0x35,
+		"kanto_frame_bank": 0x35,
+		"johto_frame_bank": 0x36,
+		"unown_scripts": 0xD2229,
+		"unown_idle_scripts": 0xD23D1,
+		"unown_bitmask_pointers": 0xD3AD3,
+		"unown_frame_pointers": 0xD99A9,
+		"unown_frame_bank": 0x36,
+	},
 	"palettes": 0xA8CE,
 	"move_names": 0x1C9F29,
 	"item_names": 0x1C8000,
@@ -2630,6 +2662,44 @@ static func palette_offset(layout: Dictionary, species: int) -> int:
 
 
 ## Pointers come in pairs, front then back.
+## `AnimateFrontpic`'s tables, or empty for a game that has no pic animation at
+## all. Only Crystal does; see the `pic_anim` block in [constant CRYSTAL].
+static func pic_anim(layout: Dictionary) -> Dictionary:
+	var value: Variant = layout.get("pic_anim", {})
+	return value if value is Dictionary else {}
+
+
+## `PokeAnim_CopyBitmaskToBuffer.GetSize`: how many bytes one bitmask is, for a
+## pic [param height] tiles tall. `.Sizes: db 4, 5, 7`, indexed by `height - 5`.
+static func pic_anim_bitmask_bytes(height: int) -> int:
+	match height:
+		5:
+			return 4
+		6:
+			return 5
+		7:
+			return 7
+	return 0
+
+
+## `.GetTilemap`: an animation frame names a tile in the pic's own `w * h` run,
+## and `PokeAnim_PlaceGraphic` fills a 7x7 box. A tile inside the pic is
+## remapped through `poke_anim_box`, which is `PadFrontpic`'s own alignment
+## again, and one past it takes the box's own 49 tiles as its offset.
+static func pic_anim_box_tile(tile: int, height: int) -> int:
+	if height >= FRONTPIC_MAX_TILES or height <= 0:
+		return tile
+	var square: int = height * height
+	if tile >= square:
+		return tile + FRONTPIC_MAX_TILES * FRONTPIC_MAX_TILES - square
+	# `poke_anim_box`'s row is the pic's column and its column the pic's row,
+	# which is `PlaceGraphic`'s column-major box read the other way up.
+	@warning_ignore("integer_division")
+	var column: int = tile / height
+	var row: int = tile % height
+	return (column + 1) * FRONTPIC_MAX_TILES + row + FRONTPIC_MAX_TILES - height
+
+
 static func pic_pointer_offset(layout: Dictionary, species: int, back: bool) -> int:
 	var pair: int = (species - 1) * 2 + (1 if back else 0)
 	return int(layout["pic_pointers"]) + pair * PIC_POINTER_SIZE

--- a/game/render/pic_animation.gd
+++ b/game/render/pic_animation.gd
@@ -1,0 +1,340 @@
+class_name Gen2PicAnimation
+extends RefCounted
+
+## `AnimateFrontpic` (engine/gfx/pic_animation.asm), the wobble a front pic does
+## when it is sent out, looked at in a menu, traded, evolved or hatched.
+##
+## The cartridge's shape is a per-frame interpreter over two nested state
+## machines, and so is this one: `SetUpPokeAnim` spends one scene command a
+## frame, and `PokeAnim_DoAnimScript` spends one script command over as many
+## frames as its own duration. Neither is flattened into a list of frames
+## computed once, because a `dorepeat` counter and a `SetWait` are read while
+## the animation runs.
+##
+## What it produces is a 7x7 box of tile numbers, which is exactly what
+## `PokeAnim_PlaceGraphic` writes into `wTilemap` and what
+## [method Gen2BattleScreenMap.stamp] already writes for the enemy's square. The
+## caller stamps that box into its own map; nothing here draws.
+##
+## Crystal only. pokegold ships no `pic_animation.asm`, no `anim.asm`, no
+## bitmasks and no frames, and both of its send-outs reach `PlayStereoCry`
+## directly, so a record this has none of animates nothing and the caller plays
+## the cry on its own.
+
+## The `ANIM_MON_*` constants, in `PokeAnims`' own order.
+enum {
+	ANIM_MON_SLOW,
+	ANIM_MON_NORMAL,
+	ANIM_MON_MENU,
+	ANIM_MON_TRADE,
+	ANIM_MON_EVOLVE,
+	ANIM_MON_HATCH,
+	ANIM_MON_HOF,
+}
+
+## `PokeAnim_SetupCommands`, indexed by the `pokeanim` macro's own byte.
+enum {
+	SETUP_FINISH,
+	SETUP_BASE_PIC,
+	SETUP_SET_WAIT,
+	SETUP_WAIT,
+	SETUP_SETUP,
+	SETUP_SETUP2,
+	SETUP_IDLE,
+	SETUP_PLAY,
+	SETUP_PLAY2,
+	SETUP_CRY,
+	SETUP_CRY_NO_WAIT,
+	SETUP_STEREO_CRY,
+}
+
+## The `pokeanim` lists in `PokeAnims`, each ending in `PokeAnim_Finish`.
+const SCENES: Dictionary = {
+	ANIM_MON_SLOW: [SETUP_STEREO_CRY, SETUP_SETUP2, SETUP_PLAY, SETUP_FINISH],
+	ANIM_MON_NORMAL: [SETUP_STEREO_CRY, SETUP_SETUP, SETUP_PLAY, SETUP_FINISH],
+	ANIM_MON_MENU: [
+		SETUP_CRY_NO_WAIT, SETUP_SETUP, SETUP_PLAY, SETUP_SET_WAIT, SETUP_WAIT,
+		SETUP_IDLE, SETUP_PLAY, SETUP_FINISH,
+	],
+	ANIM_MON_TRADE: [
+		SETUP_IDLE, SETUP_PLAY2, SETUP_IDLE, SETUP_PLAY, SETUP_SET_WAIT, SETUP_WAIT,
+		SETUP_CRY, SETUP_SETUP, SETUP_PLAY, SETUP_FINISH,
+	],
+	ANIM_MON_EVOLVE: [
+		SETUP_IDLE, SETUP_PLAY, SETUP_SET_WAIT, SETUP_WAIT, SETUP_CRY_NO_WAIT,
+		SETUP_SETUP, SETUP_PLAY, SETUP_FINISH,
+	],
+	ANIM_MON_HATCH: [
+		SETUP_IDLE, SETUP_PLAY, SETUP_CRY_NO_WAIT, SETUP_SETUP, SETUP_PLAY,
+		SETUP_SET_WAIT, SETUP_WAIT, SETUP_IDLE, SETUP_PLAY, SETUP_FINISH,
+	],
+	ANIM_MON_HOF: [
+		SETUP_CRY_NO_WAIT, SETUP_SETUP, SETUP_PLAY, SETUP_SET_WAIT, SETUP_WAIT,
+		SETUP_IDLE, SETUP_PLAY, SETUP_FINISH,
+	],
+}
+
+## `PokeAnim_Setup2`'s `ld b, 4`, which `PokeAnim_GetDuration` divides by 16.
+const SLOW_SPEED: int = 4
+## `PokeAnim_SetWait`'s own `ld a, 18`.
+const WAIT_FRAMES: int = 18
+
+## `AnimateFrontpic`'s loop has no `DelayFrame` of its own: the frame comes from
+## `HDMATransferTilemapToWRAMBank3`, whose `WaitDMATransfer` is a `DelayFrame`
+## loop. So a scene command that transfers again costs that again.
+## `PokeAnim_SetVBank1` ends `Setup`, `Setup2` and `Idle` with one attrmap
+## transfer; `PokeAnim_DeinitFrames` is a tilemap and an attrmap transfer, which
+## is what `BasePic` and `Finish` are made of.
+const EXTRA_TRANSFERS: Dictionary = {
+	SETUP_SETUP: 1, SETUP_SETUP2: 1, SETUP_IDLE: 1,
+	SETUP_BASE_PIC: 2, SETUP_FINISH: 2,
+}
+
+const ENDANIM: int = 0xFF
+const SETREPEAT: int = 0xFE
+const DOREPEAT: int = 0xFD
+
+## `PokeAnim_PlaceGraphic`'s box, which is `PadFrontpic`'s.
+const BOX: int = Gen2PicImage.FRONTPIC_TILES
+
+## Which cry the scene command just reached asks for, or an empty StringName.
+## `PokeAnim_StereoCry` is `PlayStereoCry2`, the one that does not wait;
+## `PokeAnim_Cry` is `_PlayMonCry` and `PokeAnim_CryNoWait` is `PlayMonCry2`.
+const CRY_STEREO: StringName = &"stereo"
+const CRY_WAIT: StringName = &"wait"
+const CRY_NO_WAIT: StringName = &"no_wait"
+
+var _record: Dictionary = {}
+var _height: int = 0
+var _scene: Array = []
+var _scene_index: int = 0
+var _finished: bool = true
+
+var _script: PackedByteArray = PackedByteArray()
+var _speed: int = 0
+var _frame: int = 0
+var _repeat: int = 0
+var _wait: int = 0
+var _waiting: bool = false
+var _script_done: bool = true
+var _wait_counter: int = 0
+var _extra: int = 0
+var _finish_pending: bool = false
+
+## The 7x7 box as `PokeAnim_PlaceGraphic` and `.ApplyFrame` last left it, as
+## tile numbers counted from the pic's own first.
+var box: PackedByteArray = PackedByteArray()
+
+## `wBoxAlignment`, which `.GetCoord` walks its columns backwards for.
+var mirrored: bool = false
+
+
+## [param record] is [method GameData.pic_animation]'s answer. A record without
+## a script animates nothing and [member finished] is true from the start, which
+## is the answer a caller with no cache or a Gold and Silver cartridge gets.
+func _init(record: Dictionary, kind: int = ANIM_MON_NORMAL, box_mirrored: bool = false) -> void:
+	mirrored = box_mirrored
+	_record = record
+	_height = int(record.get("height", 0))
+	if _height <= 0 or not SCENES.has(kind) \
+			or (record.get("script", PackedByteArray()) as PackedByteArray).is_empty():
+		return
+	_scene = SCENES[kind]
+	_scene_index = 0
+	_finished = false
+	_place_graphic()
+
+
+## True once `PokeAnim_Finish` has run, which is what `AnimateFrontpic`'s
+## `jr nc, .loop` stops on.
+func finished() -> bool:
+	return _finished
+
+
+## One turn of `AnimateFrontpic`'s loop, which is one `SetUpPokeAnim` and so one
+## hardware frame. Answers which cry this frame asked for, if any: the cry is
+## the scene's own command rather than something around the animation.
+func advance() -> StringName:
+	if _finished:
+		return &""
+	# A command still paying for its own transfers has not moved on yet.
+	if _extra > 0:
+		_extra -= 1
+		if _extra == 0 and _finish_pending:
+			_finished = true
+		return &""
+	var command: int = int(_scene[mini(_scene_index, _scene.size() - 1)])
+	_extra = int(EXTRA_TRANSFERS.get(command, 0))
+	match command:
+		SETUP_FINISH:
+			_place_graphic()
+			if _extra > 0:
+				_finish_pending = true
+			else:
+				_finished = true
+		SETUP_BASE_PIC:
+			_place_graphic()
+			_scene_index += 1
+		SETUP_SET_WAIT:
+			_wait_counter = WAIT_FRAMES
+			_scene_index += 1
+			# `PokeAnim_SetWait` falls through into `PokeAnim_Wait`, so the
+			# frame it is reached on already spends one of the eighteen.
+			_tick_wait()
+		SETUP_WAIT:
+			_tick_wait()
+		SETUP_SETUP:
+			_init_anim(false, 0)
+		SETUP_SETUP2:
+			_init_anim(false, SLOW_SPEED)
+		SETUP_IDLE:
+			_init_anim(true, 0)
+		SETUP_PLAY:
+			_do_anim_script()
+			if _script_done:
+				_place_graphic()
+				_scene_index += 1
+		SETUP_PLAY2:
+			# The one difference from `PokeAnim_Play`: no `PlaceGraphic` at the
+			# end, so the last frame of the script stays on the screen.
+			_do_anim_script()
+			if _script_done:
+				_scene_index += 1
+		SETUP_CRY:
+			_scene_index += 1
+			return CRY_WAIT
+		SETUP_CRY_NO_WAIT:
+			_scene_index += 1
+			return CRY_NO_WAIT
+		SETUP_STEREO_CRY:
+			_scene_index += 1
+			return CRY_STEREO
+	return &""
+
+
+func _tick_wait() -> void:
+	_wait_counter -= 1
+	if _wait_counter <= 0:
+		_scene_index += 1
+
+
+## `PokeAnim_InitAnim`: the script, its speed and whether it is the idle one.
+func _init_anim(idle: bool, speed: int) -> void:
+	_script = _record.get("idle" if idle else "script", PackedByteArray())
+	_speed = speed
+	_frame = 0
+	_repeat = 0
+	_waiting = false
+	_script_done = _script.is_empty()
+	_scene_index += 1
+
+
+## `PokeAnim_DoAnimScript`, which is one command or one frame of a command's own
+## duration. `.RunAnim` loops through `setrepeat` and `dorepeat` without
+## spending a frame on either, which is what the `jr .loop` does.
+func _do_anim_script() -> void:
+	if _script_done:
+		return
+	if _waiting:
+		_wait -= 1
+		if _wait <= 0:
+			_waiting = false
+		return
+	for _step: int in _script.size():
+		var at: int = _frame * 2
+		if at + 1 >= _script.size():
+			_script_done = true
+			return
+		var command: int = int(_script[at])
+		var parameter: int = int(_script[at + 1])
+		_frame += 1
+		match command:
+			ENDANIM:
+				_script_done = true
+				return
+			SETREPEAT:
+				_repeat = parameter
+				continue
+			DOREPEAT:
+				# `.DoRepeat` returns on a counter that is already zero and on
+				# the one it takes to zero, so a `setrepeat n` runs the body n
+				# times rather than n + 1.
+				if _repeat == 0:
+					return
+				_repeat -= 1
+				if _repeat == 0:
+					return
+				_frame = parameter
+				continue
+			_:
+				_apply_frame(command)
+				_wait = _duration(parameter)
+				_waiting = true
+				# `PokeAnim_StartWaitAnim` moves to `.WaitAnim`, which spends
+				# this same frame decrementing the counter it was just given.
+				_wait -= 1
+				if _wait <= 0:
+					_waiting = false
+				return
+	_script_done = true
+
+
+## `PokeAnim_GetDuration`: `a * (1 + [wPokeAnimSpeed] / 16)`, built as an 8.8
+## fixed-point multiply, so the fraction is truncated rather than rounded.
+func _duration(base: int) -> int:
+	@warning_ignore("integer_division")
+	return base + (base * _speed) / 16
+
+
+## `PokeAnim_GetFrame`: the base pic first, then this frame's own tiles over it.
+## Command zero is the base pic on its own, which is what `and a / ret z` is.
+func _apply_frame(command: int) -> void:
+	_place_graphic()
+	if command == 0:
+		return
+	var frames: Array = _record.get("frames", []) as Array
+	if command - 1 >= frames.size():
+		return
+	var frame: PackedByteArray = frames[command - 1]
+	var mask_bytes: int = RomLayout.pic_anim_bitmask_bytes(_height)
+	if frame.size() < mask_bytes:
+		return
+
+	# `PokeAnim_ConvertAndApplyBitmask` walks the pic's own square column by
+	# column, one bit of the bitmask per cell, and takes the next tile number
+	# from the frame for every set bit.
+	#
+	# `.GetStartCoord` is `PadFrontpic`'s alignment a third time: a pic shorter
+	# than the box starts one column in and its own difference down.
+	var pad_column: int = 0 if _height >= BOX else 1
+	var pad_row: int = BOX - _height
+	var next: int = mask_bytes
+	for column: int in _height:
+		for row: int in _height:
+			var bit: int = column * _height + row
+			@warning_ignore("integer_division")
+			var byte: int = int(frame[bit / 8])
+			if (byte >> (bit % 8)) & 1 == 0:
+				continue
+			if next >= frame.size():
+				return
+			var tile: int = int(frame[next])
+			next += 1
+			# `.subtract`: the mirrored walk starts at the box's other end and
+			# runs its columns back, which is `PlaceGraphic`'s own `.flipped`.
+			var x: int = BOX - 1 - pad_column - column if mirrored \
+				else pad_column + column
+			box[x * BOX + pad_row + row] = \
+				RomLayout.pic_anim_box_tile(tile, _height) & 0xFF
+
+
+## `PokeAnim_PlaceGraphic`: the whole 7x7 box filled column by column, which is
+## the base pic as `PadFrontpic` laid it out. `.flipped` runs the columns the
+## other way, and the box is indexed here rather than the tilemap, so the caller
+## stamps it wherever the picture stands.
+func _place_graphic() -> void:
+	box.resize(BOX * BOX)
+	for column: int in BOX:
+		for row: int in BOX:
+			var x: int = BOX - 1 - column if mirrored else column
+			box[x * BOX + row] = column * BOX + row

--- a/game/render/pic_animation.gd.uid
+++ b/game/render/pic_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://cs5hbgeq4wmjw

--- a/tests/unit/test_pic_image.gd
+++ b/tests/unit/test_pic_image.gd
@@ -163,3 +163,116 @@ func test_frontpic_pad_columns_is_padfrontpics_own_alignment() -> void:
 	assert_eq(Gen2PicImage.frontpic_pad_columns(6, true), 0)
 	assert_eq(Gen2PicImage.frontpic_pad_columns(5, true), 1)
 	assert_eq(Gen2PicImage.frontpic_pad_columns(0), 0, "a pic the cache has no size for")
+
+
+## `AnimateFrontpic`, which draws through the same box these pads describe. The
+## records here are hand-built rather than read from a cache: what a real
+## cartridge holds is swept over the whole corpus by `tools/checks/pic_anim.gd`,
+## and what is asserted here is the interpreter's own arithmetic.
+const ANIM_HEIGHT: int = 5
+const ANIM_MASK_BYTES: int = 4
+
+
+## A record whose [param script] is the pairs given, terminated, and which holds
+## one frame per entry of [param frames]: a bitmask and its tile numbers.
+func _anim_record(script: Array, frames: Array = []) -> Dictionary:
+	var run := PackedByteArray()
+	for pair: Array in script:
+		run.append(int(pair[0]) & 0xFF)
+		run.append(int(pair[1]) & 0xFF)
+	run.append(0xFF)
+	run.append(0x00)
+	var built: Array = []
+	for frame: Array in frames:
+		built.append(PackedByteArray(frame))
+	return {"height": ANIM_HEIGHT, "script": run, "idle": run, "frames": built}
+
+
+## `PokeAnim_PlaceGraphic` fills the 7x7 block column by column, which is the
+## same `column * 7 + row` the enemy's square is stamped with.
+func test_pic_animation_places_the_base_pic_column_major() -> void:
+	var animation := Gen2PicAnimation.new(_anim_record([]))
+	assert_eq(animation.box.size(), 49)
+	assert_eq(int(animation.box[0]), 0)
+	assert_eq(int(animation.box[1]), 1, "the second cell down the first column")
+	assert_eq(int(animation.box[7]), 7, "the top of the second column")
+	assert_eq(int(animation.box[48]), 48)
+
+
+## `.flipped`: `PlaceGraphic` runs its columns back from the block's other end,
+## so the first column's tiles land in the last.
+func test_pic_animation_mirrors_the_whole_block() -> void:
+	var animation := Gen2PicAnimation.new(_anim_record([]), Gen2PicAnimation.ANIM_MON_NORMAL, true)
+	assert_eq(int(animation.box[42]), 0, "the first column at the block's right")
+	assert_eq(int(animation.box[0]), 42)
+
+
+## The frame counts are the source's own arithmetic, not a measurement: a
+## `frame n, d` spends d, `setrepeat`/`dorepeat` spend none of their own except
+## the pass that ends the repeat, `endanim` spends one, and `Setup` and `Finish`
+## each pay for the transfers they add to the loop's.
+func test_pic_animation_spends_the_scripts_own_frames() -> void:
+	# `ANIM_MON_NORMAL` is StereoCry, Setup, Play, Finish.
+	var script: Array = [[0, 2], [0, 3], [0xFE, 2], [0, 4], [0xFD, 3]]
+	var animation := Gen2PicAnimation.new(_anim_record(script))
+	var spent: int = 0
+	var cries: int = 0
+	while not animation.finished() and spent < 200:
+		if animation.advance() != &"":
+			cries += 1
+		spent += 1
+	assert_true(animation.finished(), "the script ended")
+	assert_eq(cries, 1, "`PokeAnim_StereoCry`, once and inside the animation")
+	# 1 cry + 2 setup + (2 + 3 + 4 + 4 + 1 dorepeat + 1 endanim) + 3 finish.
+	assert_eq(spent, 21)
+
+
+## `PokeAnim_GetDuration` is `a * (1 + speed / 16)` through an 8.8 multiply, so
+## `ANIM_MON_SLOW`'s speed of 4 is a quarter longer with the fraction dropped.
+func test_pic_animation_slow_stretches_every_duration() -> void:
+	var script: Array = [[0, 7]]
+	var normal: int = _frames_of(script, Gen2PicAnimation.ANIM_MON_NORMAL)
+	var slow: int = _frames_of(script, Gen2PicAnimation.ANIM_MON_SLOW)
+	assert_eq(slow - normal, 1, "7 becomes 8, not 8.75")
+
+
+func _frames_of(script: Array, kind: int) -> int:
+	var animation := Gen2PicAnimation.new(_anim_record(script), kind)
+	var spent: int = 0
+	while not animation.finished() and spent < 200:
+		animation.advance()
+		spent += 1
+	return spent
+
+
+## `PokeAnim_ConvertAndApplyBitmask` walks the pic's own square column by column,
+## one bit per cell, and `.GetCoord` offsets it by `PadFrontpic`'s own pads.
+func test_pic_animation_applies_a_frames_bitmask_over_the_pad() -> void:
+	# Bit 0 alone: the pic's own cell (0, 0), which is box column 1, row 2.
+	var frame: Array = [1, 0, 0, 0, 30]
+	var animation := Gen2PicAnimation.new(_anim_record([[1, 1]], [frame]))
+	while not animation.finished() and int(animation.box[1 * 7 + 2]) == 1 * 7 + 2:
+		animation.advance()
+	# Tile 30 is past a 5x5's own 25, so `.GetTilemap` takes the block's 49 as
+	# its offset rather than the `poke_anim_box` table.
+	assert_eq(int(animation.box[1 * 7 + 2]), 30 + 49 - 25)
+
+
+## A record the cache has none of animates nothing, which is Gold and Silver's
+## every row and the `.cry_no_anim` branch here.
+func test_pic_animation_without_a_record_is_finished_at_once() -> void:
+	assert_true(Gen2PicAnimation.new({}).finished())
+	assert_eq(Gen2PicAnimation.new({}).advance(), &"")
+
+
+## Why `PokeAnim_SetVBank1` is not decoration. The animation's tiles start at the
+## 7x7 block's own 49, and `$31` is 49: that is `AppearUser`'s first tile for the
+## player's back pic. The two only ever coexist because the enemy's box is put in
+## VRAM bank 1 for as long as the animation runs, so a renderer reading one flat
+## sheet draws the player's picture inside the enemy's square.
+func test_a_pic_animations_tiles_collide_with_the_players_own_run() -> void:
+	assert_eq(
+		Gen2PicImage.FRONTPIC_TILES * Gen2PicImage.FRONTPIC_TILES,
+		Gen2BattleScreenMap.PLAYER_BASE_TILE
+	)
+	assert_eq(RomLayout.pic_anim_box_tile(25, 5), Gen2BattleScreenMap.PLAYER_BASE_TILE)

--- a/tests/unit/test_pic_image.gd
+++ b/tests/unit/test_pic_image.gd
@@ -276,3 +276,26 @@ func test_a_pic_animations_tiles_collide_with_the_players_own_run() -> void:
 		Gen2BattleScreenMap.PLAYER_BASE_TILE
 	)
 	assert_eq(RomLayout.pic_anim_box_tile(25, 5), Gen2BattleScreenMap.PLAYER_BASE_TILE)
+
+
+## `PokeAnim_SetVBank1`'s rule, which is what stops the enemy's animation tiles
+## being drawn over the player and the player's back pic over the enemy. The
+## enemy's box is 7x7 and its frames run behind it; the player's is 6x6 from
+## `$31`, which is the enemy block's own 49.
+func test_a_pic_layer_claims_only_its_own_sheets_cells() -> void:
+	var square: int = Gen2PicImage.FRONTPIC_TILES * Gen2PicImage.FRONTPIC_TILES
+	var banked: int = square + 28
+	# Bank 0 is the sheet both pictures share, so neither reaches past its box.
+	assert_true(Gen2BattleRenderer.claims_tile(48, false, true, square, banked))
+	assert_false(
+		Gen2BattleRenderer.claims_tile(49, false, true, square, banked),
+		"the player's first tile is not the enemy's fiftieth"
+	)
+	# Bank 1 is the animated layer's alone, and there its frames are in reach.
+	assert_true(Gen2BattleRenderer.claims_tile(49, true, true, square, banked))
+	assert_false(
+		Gen2BattleRenderer.claims_tile(0, true, false, square, banked),
+		"a layer that owns no bank 1 sheet draws none of its cells"
+	)
+	assert_false(Gen2BattleRenderer.claims_tile(banked, true, true, square, banked))
+	assert_false(Gen2BattleRenderer.claims_tile(-1, false, false, square, banked))

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -517,3 +517,38 @@ func test_the_cry_table_carries_every_cry_constant() -> void:
 		var last: int = int(layout["cry_pointers"]) \
 			+ (RomLayout.AUDIO_CRY_COUNT - 1) * RomLayout.AUDIO_POINTER_SIZE
 		assert_lt(last + RomLayout.AUDIO_POINTER_SIZE, RomRegistry.EXPECTED_SIZE, "%s" % id)
+
+
+## `PokeAnim_ConvertAndApplyBitmask.GetTilemap`, which is `poke_anim_box`'s two
+## tables and the two `add`s past them. A 7x7's numbering is the block's own, so
+## the whole remap is the identity there.
+func test_pic_anim_box_tile_is_get_tilemaps_own_remap() -> void:
+	for tile: int in 98:
+		assert_eq(RomLayout.pic_anim_box_tile(tile, 7), tile, "7x7 is the identity")
+	# `._5by5` is `poke_anim_box 5`: rows 1 to 5 of the block, columns 2 to 6.
+	assert_eq(RomLayout.pic_anim_box_tile(0, 5), 1 * 7 + 2)
+	assert_eq(RomLayout.pic_anim_box_tile(4, 5), 1 * 7 + 6, "down the pic's first column")
+	assert_eq(RomLayout.pic_anim_box_tile(5, 5), 2 * 7 + 2, "the pic's second column")
+	assert_eq(RomLayout.pic_anim_box_tile(24, 5), 5 * 7 + 6)
+	assert_eq(RomLayout.pic_anim_box_tile(25, 5), 49, "`.add_24`, the first frame tile")
+	# `._6by6` is the same table one column and one row further out.
+	assert_eq(RomLayout.pic_anim_box_tile(0, 6), 1 * 7 + 1)
+	assert_eq(RomLayout.pic_anim_box_tile(35, 6), 6 * 7 + 6)
+	assert_eq(RomLayout.pic_anim_box_tile(36, 6), 49, "`.add_13`")
+
+
+## `.Sizes: db 4, 5, 7`, indexed by `height - 5`. Nothing else has a bitmask, so
+## a height the cache does not hold answers zero rather than reading the table.
+func test_pic_anim_bitmask_bytes_is_get_sizes() -> void:
+	assert_eq(RomLayout.pic_anim_bitmask_bytes(5), 4)
+	assert_eq(RomLayout.pic_anim_bitmask_bytes(6), 5)
+	assert_eq(RomLayout.pic_anim_bitmask_bytes(7), 7)
+	assert_eq(RomLayout.pic_anim_bitmask_bytes(0), 0)
+	assert_eq(RomLayout.pic_anim_bitmask_bytes(8), 0)
+
+
+## `AnimateFrontpic` is Crystal's alone; pokegold ships no `pic_animation.asm`.
+func test_only_crystal_carries_pic_animation_pins() -> void:
+	assert_false(RomLayout.pic_anim(RomLayout.for_id(RomRegistry.CRYSTAL)).is_empty())
+	assert_true(RomLayout.pic_anim(RomLayout.for_id(RomRegistry.GOLD)).is_empty())
+	assert_true(RomLayout.pic_anim(RomLayout.for_id(RomRegistry.SILVER)).is_empty())

--- a/tools/checks/pic_anim.gd
+++ b/tools/checks/pic_anim.gd
@@ -1,0 +1,142 @@
+extends RefCounted
+
+var _r: RefCounted = null
+var _collisions: int = 0
+
+## Sweeps `AnimateFrontpic` over the whole corpus on all three cartridges: every
+## species and every Unown letter, both scripts, every frame each names, run to
+## completion through [Gen2PicAnimation].
+##
+## What a sampled case cannot say: a frame's tile numbers are remapped by the
+## pic's own height (`.GetTilemap` adds 24 to a 5x5's, 13 to a 6x6's and nothing
+## to a 7x7's), a bitmask is 4, 5 or 7 bytes for the same reason, and the three
+## sizes are 84, 84 and 83 of Crystal's 251. One size proves a third of it.
+##
+## The invariants, all of them the cartridge's own arithmetic rather than a
+## transcribed expectation:
+##
+## - every frame names exactly as many tiles as its bitmask has set bits;
+## - every tile a frame names is inside the run `GetAnimatedEnemyFrontpic`
+##   loads, which is the padded 7x7 box plus the pic's own `w * h` behind it;
+## - every script terminates, and running it leaves no cell of the box outside
+##   that run either;
+## - Gold and Silver have no records at all, which is `pic_animation.asm` being
+##   Crystal's alone rather than an import that failed.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- pic_anim
+
+const FIRST_SPECIES: int = 1
+const LAST_SPECIES: int = RomLayout.SPECIES_COUNT
+
+## `PokeAnim_PlaceGraphic`'s box and the tiles behind it.
+const BOX_TILES: int = Gen2PicImage.FRONTPIC_TILES * Gen2PicImage.FRONTPIC_TILES
+
+## Long enough for any script here to have ended: the longest is well under a
+## hundred frames and the sweep needs a bound rather than a measurement.
+const FRAME_CAP: int = 600
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var records: int = 0
+	var frames: int = 0
+	var sizes: Dictionary = {}
+	_collisions = 0
+	for species: int in range(FIRST_SPECIES, LAST_SPECIES + 1):
+		var forms: Array = [0]
+		if species == RomLayout.UNOWN_SPECIES:
+			forms = range(1, RomLayout.UNOWN_FORMS + 1)
+		for form: int in forms:
+			var record: Dictionary = _r.data.pic_animation(species, form)
+			if record.is_empty():
+				continue
+			records += 1
+			var height: int = int(record["height"])
+			sizes[height] = int(sizes.get(height, 0)) + 1
+			frames += _check_record(record, species, form)
+
+	if not _r.crystal:
+		# `AnimateFrontpic` does not exist in pokegold: no `anim.asm`, no
+		# bitmasks and no frames, and both send-outs reach `PlayStereoCry`.
+		_r.check(records == 0, "%d pic animations on a cartridge that has none." % records)
+		_r.note("pic_anim none, as pokegold ships none")
+		return
+
+	_r.check(
+		records == LAST_SPECIES + RomLayout.UNOWN_FORMS - 1,
+		"pic_anim has %d records, not the 251 species and 26 Unown letters." % records
+	)
+	_r.note("pic_anim %d records over %d frames, heights %s, %d frames reach the player's own run" % [
+		records, frames, sizes, _collisions
+	])
+
+
+## One record's frames and both of its scripts. Answers how many frames it holds.
+func _check_record(record: Dictionary, species: int, form: int) -> int:
+	var where: String = "species %d" % species if form == 0 else "Unown %d" % form
+	var height: int = int(record["height"])
+	var mask_bytes: int = RomLayout.pic_anim_bitmask_bytes(height)
+	if not _r.check(mask_bytes > 0, "%s has height %d, which has no bitmask size." % [
+		where, height
+	]):
+		return 0
+
+	# The run the cartridge loads: the padded box, then `w * h` tiles behind it.
+	var run: int = BOX_TILES + height * height
+	var list: Array = record["frames"] as Array
+	for index: int in list.size():
+		var frame: PackedByteArray = list[index]
+		if not _r.check(frame.size() >= mask_bytes, "%s frame %d is shorter than its bitmask." % [
+			where, index
+		]):
+			continue
+		var bits: int = 0
+		for at: int in mask_bytes:
+			for bit: int in 8:
+				bits += (int(frame[at]) >> bit) & 1
+		_r.check(frame.size() == mask_bytes + bits, "%s frame %d names %d tiles for %d bits." % [
+			where, index, frame.size() - mask_bytes, bits
+		])
+		var reaches: bool = false
+		for at: int in range(mask_bytes, frame.size()):
+			var tile: int = RomLayout.pic_anim_box_tile(int(frame[at]), height)
+			_r.check(tile < run, "%s frame %d names tile %d, past the %d loaded." % [
+				where, index, tile, run
+			])
+			# `PokeAnim_SetVBank1`'s reason: the block's own 49 is `AppearUser`'s
+			# `$31` for the player's back pic, so an animated square has to be
+			# read off its own sheet or the two pictures share tile numbers.
+			reaches = reaches or tile >= Gen2BattleScreenMap.PLAYER_BASE_TILE
+		if reaches:
+			_collisions += 1
+
+	for mirrored: bool in [false, true]:
+		for kind: int in Gen2PicAnimation.SCENES:
+			_run_scene(record, kind, mirrored, run, where)
+	return list.size()
+
+
+## One whole scene, to the frame `PokeAnim_Finish` sets its own exit on. Every
+## box the animation leaves has to be drawable, which is the only thing the
+## renderer asks of it.
+func _run_scene(
+	record: Dictionary, kind: int, mirrored: bool, run: int, where: String
+) -> void:
+	var animation := Gen2PicAnimation.new(record, kind, mirrored)
+	var spent: int = 0
+	while not animation.finished() and spent < FRAME_CAP:
+		animation.advance()
+		spent += 1
+		for tile: int in animation.box:
+			if tile >= run:
+				_r.check(false, "%s scene %d draws tile %d, past the %d loaded." % [
+					where, kind, tile, run
+				])
+				return
+	_r.check(animation.finished(), "%s scene %d did not end within %d frames." % [
+		where, kind, FRAME_CAP
+	])

--- a/tools/checks/pic_anim.gd.uid
+++ b/tools/checks/pic_anim.gd.uid
@@ -1,0 +1,1 @@
+uid://bvmvcn86dnkql

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -22,7 +22,12 @@ extends SceneTree
 ## cartridge waits on a person there and nothing here can.
 ## `scene_off` clears the OPTION menu's battle-scene row first, which is what
 ## `CheckBattleScene` reads, and the capture should then show the field
-## untouched.
+## untouched. `with_intro` counts `<frames>` from the battle screen's own first
+## frame instead, so `BattleIntroSlidingPics` is inside the range rather than
+## spent before it; a cartridge trace is aligned to the slide's end, so use it
+## for a recording and not for a diff.
+##
+## Both flags may be given, in either order.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Enough frames for the scene to lay out before anything is driven, and enough
@@ -49,6 +54,7 @@ var _settle: int = 0
 var _held: int = 0
 var _last_trace: String = ""
 var _scene_off: bool = false
+var _with_intro: bool = false
 var _frames: int = 0
 
 
@@ -70,7 +76,16 @@ func _initialize() -> void:
 		_frames_in = _range_hi
 	else:
 		_frames_in = int(args[4])
-	_scene_off = args.size() > 5 and args[5] == "scene_off"
+	for flag: String in args.slice(5):
+		match flag:
+			"scene_off":
+				_scene_off = true
+			"with_intro":
+				_with_intro = true
+			_:
+				push_error("Unknown flag %s" % flag)
+				quit(1)
+				return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
@@ -136,8 +151,15 @@ func _shoot_range() -> bool:
 	if _settle > 0:
 		_settle -= 1
 		return false
-	if _cursor > _range_hi:
-		print("Wrote %d frames to %s_f*.png" % [_range_hi - _range_lo + 1, _prefix()])
+	# `DoBattle`'s first `BattleMenu` is the end of the opening, so a range that
+	# runs past it stops there rather than writing the menu over and over.
+	var done: bool = _cursor > _range_lo and not _screen.entrance_running() \
+		and not _screen.intro_running() and not _screen.frames_running() \
+		and not bool(_screen.battle_snapshot()["awaits_press"])
+	if _cursor > _range_hi or done:
+		print("Wrote %d frames to %s_f*.png" % [
+			mini(_cursor, _range_hi + 1) - _range_lo, _prefix()
+		])
 		quit(0)
 		return true
 	if _cursor >= _range_lo:
@@ -204,10 +226,16 @@ func _drive_entrance() -> bool:
 		_screen.show_trainer(1, 0)
 	else:
 		_screen.show_matchup(16, 155, 20, 20)
+	if _range_lo >= 0:
+		# `InitBattleDisplay` and `BattleIntroSlidingPics` are frames of the
+		# opening like any other; a diff against the cartridge trace wants them
+		# spent first, and a recording wants them in the picture.
+		if not _with_intro:
+			while _screen.intro_running():
+				_screen.advance_frame()
+		return true
 	while _screen.intro_running():
 		_screen.advance_frame()
-	if _range_lo >= 0:
-		return true
 	for _frame: int in _frames_in:
 		if not _screen.frames_running() and _screen.entrance_running():
 			_screen.finish()

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -124,6 +124,7 @@ func _process(_delta: float) -> bool:
 	if _frames < SETTLE_FRAMES + DRAW_FRAMES:
 		return false
 
+	RenderingServer.force_draw()
 	var image: Image = root.get_texture().get_image()
 	var error: Error = image.save_png(_output_path)
 	if error != OK:
@@ -163,6 +164,11 @@ func _shoot_range() -> bool:
 		quit(0)
 		return true
 	if _cursor >= _range_lo:
+		# The window is not guaranteed to have been composited between two of
+		# this driver's frames, and an uncomposited one hands back the last
+		# picture that was: a whole capture can come out as one frame repeated.
+		# Drawing on demand is what makes a run of this tool reproducible.
+		RenderingServer.force_draw()
 		var image: Image = root.get_texture().get_image()
 		var error: Error = image.save_png("%s_f%d.png" % [_prefix(), _cursor])
 		if error != OK:


### PR DESCRIPTION
The last routine of the battle entrance, and Crystal's alone: pokegold ships no `pic_animation.asm`, no `anim.asm`, no bitmasks and no frames, and both of its send-outs reach `PlayStereoCry` directly. On Crystal the enemy's cry is played *inside* the animation, which is why both callers `jr .skip_cry` past it. It is the enemy's alone on both cartridges; `SendOutPlayerMon` has no animation.

## What is imported

Cache format 71. Five tables, every address rgblink's own from a `pokecrystal11.gbc` byte identical to the dump. A frame's bitmask is resolved on the way in, since the bitmask table is pure deduplication, so a cached frame is its bitmask followed by its tiles. The tiles the frames name are the `w * h` behind the picture in the same decompressed run; they get a `front_anim` atlas rather than a wider pic cell, and `padded_pic` lays them in tile columns behind the 7x7 block, which is where `.GetTilemap`'s own `+24` puts them.

The egg tables are deliberately left out: `AnimateMon_CheckIfPokemon` refuses `EGG` before any of them is read.

## What runs it

`Gen2PicAnimation` is the per-frame interpreter, both nested state machines kept as the source has them: one scene command a frame, one script command over its own duration, and a repeat counter read while it runs. It answers a 7x7 box of tile numbers, which is what `PokeAnim_PlaceGraphic` writes and what the enemy's square is already stamped with.

## The bug this turned up

`PokeAnim_SetVBank1` is load bearing rather than decoration. The block's own 49 is `$31`, which is `AppearUser`'s first tile for the player's back pic, so **1,131 of Crystal's 1,133 animation frames name tiles the player's run already claims**. The cartridge answers that by reading the animated square out of VRAM bank 1, where `GetAnimatedEnemyFrontpic` puts the picture and its frames. The view now carries `bg_vbank1`, `wAttrmap` bit 3, and a pic layer skips a cell that is not its own sheet's. Without it the player's picture is drawn inside the enemy's square, which reads as a scrambled front pic rather than as a layering bug.

## Proof

| Artefact | Result |
|---|---|
| pret's own generated `anim.asm`, `anim_idle.asm`, `frames.asm`, `bitmask.asm` | 251 species and 26 Unown letters, every script and every frame identical from the pinned tables |
| the cache against a second reading of the dump | 277 records, 0 mismatches |
| `tools/checks/pic_anim.gd` (new topic, all three cartridges) | 276 records, 1,133 frames; every bitmask's set bits match its tile count and every tile is inside the loaded run, over both scripts, all seven `PokeAnims` scenes and both `wBoxAlignment` values |
| a real cartridge, on the Route 29 Rattata | every distinct box the cartridge drew, 3,136 of 3,136 pixels each |

GUT 3,279 over 152 scripts green, `validate.gd -- all` 55 topics green, `replay_world.gd` and the three-profile story walk green on all three cartridges, boot smoke clean. All three cartridges re-imported for the format bump.

## Not exact

How long the loop takes, and it is the loop's cost rather than the script's. `AnimateFrontpic`'s `.loop` has no `DelayFrame`: the frame comes from `HDMATransferTilemapToWRAMBank3`, whose `WaitDMATransfer` costs two frames when the transfer misses the vblank it was queued for. The transfers a command *adds* are modelled, since those are derivable from the source; the phase is not. On the Route 29 Rattata the cartridge spends 68 frames and this spends 64, and the long durations already agree exactly. Closing it needs a cycle clock this project does not have.