### PR TITLE
Slide the player in beside the opponent, and without colour

### DIFF
--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -15,8 +15,15 @@ extends RefCounted
 ## `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles it and [method
 ## finished] is that write.
 ##
-## `.subfunction3` slides the overworld's objects off before `HideSprites`; this
-## screen has no OAM, so there is nothing to walk.
+## The player is in two pieces while it runs, and reading `.subfunction3` as the
+## overworld's leftovers cost a session: the eighteen sprites it walks are
+## `CopyBackpic.LoadTrainerBackpicAsOAM`'s own, which is the top three tile rows
+## of the player's back pic drawn as OAM. The bottom of that pic is on the
+## background and comes in with the middle band, and the two track each other to
+## within the two pixels `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles.
+## Without the sprites the player has no head and no shoulders for the whole
+## slide. `HideSprites` is what takes them off, after which `PlaceGraphic` puts
+## the whole pic on the background at its own square.
 
 ## 32 tiles of 8, what an offset wraps at; past the screen's 160 is blank.
 const MAP_WIDTH: int = 256
@@ -44,6 +51,20 @@ const GOLD_MIDDLE_ROWS: int = 32
 ## `ld a, c` / `ldh [hSCX], a` / `call DelayFrame` puts the whole screen at the
 ## starting offset with no band written yet. Crystal delays nowhere.
 const GOLD_LEAD_FRAMES: int = 1
+
+## `.LoadTrainerBackpicAsOAM`: six columns of three, `ld e, (SCREEN_WIDTH + 1) *
+## TILE_WIDTH` for the first x and `ld d, 8 * TILE_WIDTH` for the first y, both
+## stepping one tile. The tile ids are the back pic's own, column major over its
+## six rows, so a column contributes its top three.
+const SPRITE_COLUMNS: int = 6
+const SPRITE_ROWS: int = 3
+const SPRITE_FIRST_X: int = (Gen2BattleAnimBackground.SCREEN_WIDTH + 1) * Gen2Tiles.TILE_WIDTH
+const SPRITE_FIRST_Y: int = 8 * Gen2Tiles.TILE_HEIGHT
+## `PLAYER_SIDE` rows to a column in `vTiles0`, which is where `CopyBackpic`
+## decompressed the pic before copying it into `vTiles2 tile $31`.
+const SPRITE_PIC_ROWS: int = Gen2BattleScreenMap.PLAYER_SIDE
+## `.subfunction3` runs on every frame but the last, `cp $1 / jr z, .skip1`.
+const SPRITE_STEP: int = 2
 
 var _crystal: bool = true
 var _frame: int = 0
@@ -74,6 +95,41 @@ func advance_frame() -> bool:
 		return false
 	_frame += 1
 	return true
+
+
+## `.LoadTrainerBackpicAsOAM` and `.subfunction3` together: the player's own
+## eighteen sprites where this frame leaves them, each { tile, x, y } with OAM's
+## own biased coordinates, which is what a renderer of one already takes.
+##
+## Gold and Silver walk the same eighteen: `CopyBackpic` is shared and their own
+## `.subfunction1` steps them by two beside its `rSCX` writes. Crystal's walk is
+## measured against a real cartridge, sprite by sprite, from x 158 to 16; Gold's
+## is read from the source alone and its lead frame leaves it one step short at
+## the end, which no dump here has been asked about.
+func sprites() -> Array:
+	var out: Array = []
+	if finished():
+		# `HideSprites` runs the moment the slide returns, and `PlaceGraphic`
+		# puts the whole pic on the background instead.
+		return out
+	var walked: int = _sprite_steps()
+	for column: int in SPRITE_COLUMNS:
+		for row: int in SPRITE_ROWS:
+			out.append({
+				"tile": column * SPRITE_PIC_ROWS + row,
+				"x": SPRITE_FIRST_X + column * Gen2Tiles.TILE_WIDTH - walked * SPRITE_STEP,
+				"y": SPRITE_FIRST_Y + row * Gen2Tiles.TILE_HEIGHT,
+			})
+	return out
+
+
+## How many times `.subfunction3` has run. It is skipped on the loop's last pass,
+## so the walk is one shorter than the scroll, which is why the sprites stop two
+## pixels before the background does and `PlaceGraphic` is what lines them up.
+func _sprite_steps() -> int:
+	if _crystal:
+		return _frame
+	return maxi(_frame - GOLD_LEAD_FRAMES, 0)
 
 
 ## Per scanline in hardware draw order; an offset looks *right* into the map.

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -157,6 +157,7 @@ func _draw_pics() -> void:
 	var map: PackedByteArray = _bg_map()
 	_ensure_pixels()
 	var raster: Array = _raster_key()
+	var gray: bool = bool(_view.get("grayscale", false))
 	# A packed array is passed by reference, so a key holding the screen's own
 	# map is a key that changes with it: every animation that edits nothing but
 	# the tilemap, which is most of them, would compare equal to what is on
@@ -171,14 +172,14 @@ func _draw_pics() -> void:
 	# when the square is holding a trainer, which it is until that trainer has
 	# sent something out.
 	var enemy_trainer: int = int(_view.get("enemy_trainer_pic", 0))
-	if enemy_trainer > 0:
+	if enemy_trainer > 0 and not bool(_view.get("grayscale", false)):
 		enemy_palette = _remap(
 			_data.trainer_palette(enemy_trainer),
 			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_ENEMY)
 		)
 	var vbank1: PackedByteArray = _vbank1()
 	var enemy_key: Array = [
-		map_key, enemy, _enemy_pixels_key, enemy_palette, raster, vbank1.duplicate(),
+		map_key, enemy, _enemy_pixels_key, enemy_palette, raster, vbank1.duplicate(), gray,
 	]
 	if enemy_key != _enemy_pic_key:
 		_enemy_pic_key = enemy_key
@@ -201,13 +202,14 @@ func _draw_pics() -> void:
 		# `GetPlayerOrMonPalettePointer`'s `and a / jp nz`: a zero species is the
 		# player standing there, and the palette is the player's own.
 		var backpic: String = String(_view.get("player_backpic", ""))
-		if not backpic.is_empty():
+		if not backpic.is_empty() and not bool(_view.get("grayscale", false)):
 			player_palette = _remap(
 				_data.player_palette(String(_view.get("player_backpic_palette", "chris"))),
 				_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_PLAYER)
 			)
 		var player_key: Array = [
-			map_key, player, _player_pixels_key, player_palette, raster, vbank1.duplicate(),
+			map_key, player, _player_pixels_key, player_palette, raster,
+			vbank1.duplicate(), gray,
 		]
 		if player_key != _player_pic_key:
 			_player_pic_key = player_key
@@ -500,7 +502,19 @@ static func _append_animation(
 ## A battler pic's own palette, permuted by whatever DMG byte the animation's
 ## last `BattleAnimRequestPals` left on that palette slot.
 func _battler_palette(species: int, slot: int) -> PackedColorArray:
+	var grayscale: PackedColorArray = _grayscale()
+	if not grayscale.is_empty():
+		return grayscale
 	return _remap(_data.palette(species), _palette_map("bg_palette_maps", slot))
+
+
+## `_CGB_BattleGrayscale`'s palette while the view says the battle is still in
+## it, which is every frame up to `GetSGBLayout SCGB_BATTLE_COLORS`. Empty once
+## the colours are loaded, which is what every other palette here answers to.
+func _grayscale() -> PackedColorArray:
+	if not bool(_view.get("grayscale", false)) or _data == null:
+		return PackedColorArray()
+	return _data.battle_grayscale_palette()
 
 
 ## `CopyPals`: colour [param index] of the result is colour
@@ -659,7 +673,10 @@ func _draw_hud_balls() -> void:
 ## transparent, which is what OAM's own colour 0 is.
 func _draw_sprites() -> void:
 	var sprites: Array = _view.get("anim_sprites", [])
-	if sprites.is_empty():
+	# `BattleIntroSlidingPics` walks the player's own eighteen, which are OAM
+	# like any other and go through the same blit.
+	var intro: Array = _view.get("intro_sprites", [])
+	if sprites.is_empty() and intro.is_empty():
 		_sprites.texture = null
 		return
 
@@ -669,6 +686,9 @@ func _draw_sprites() -> void:
 	for entry: Variant in sprites:
 		if entry is Dictionary:
 			_blit_sprite(image, entry as Dictionary)
+	for entry: Variant in intro:
+		if entry is Dictionary:
+			_blit_sprite(image, entry as Dictionary, true)
 	_sprites.texture = ImageTexture.create_from_image(image)
 	_sprites.size = image.get_size()
 	_sprites.position = Vector2.ZERO
@@ -676,15 +696,24 @@ func _draw_sprites() -> void:
 
 ## One OAM entry. The stored y and x are the hardware's, which subtracts sixteen
 ## and eight, so a zero in either is off screen rather than at the corner.
-func _blit_sprite(into: Image, sprite: Dictionary) -> void:
-	var pixels: PackedByteArray = _sprite_tile(int(sprite.get("tile", 0)))
+## [param backpic] names the player's back pic as the sprite sheet rather than
+## the animation window: `CopyBackpic` decompresses it into `vTiles0` and
+## `.LoadTrainerBackpicAsOAM` addresses it there, tile by tile, before it is ever
+## copied to `vTiles2 tile $31`.
+func _blit_sprite(into: Image, sprite: Dictionary, backpic: bool = false) -> void:
+	var index: int = int(sprite.get("tile", 0))
+	var pixels: PackedByteArray = _battler_tile(
+		Gen2BattleScreenMap.PLAYER_BASE_TILE + index
+	) if backpic else _sprite_tile(index)
 	if pixels.is_empty():
 		return
 	var attributes: int = int(sprite.get("attributes", 0))
-	var palette: PackedColorArray = _remap(
-		_object_palette(attributes & OAM_PALETTE),
-		_palette_map("ob_palette_maps", attributes & OAM_PALETTE)
-	)
+	var palette: PackedColorArray = _object_palette(attributes & OAM_PALETTE)
+	var grayscale: PackedColorArray = _grayscale()
+	if not grayscale.is_empty():
+		palette = grayscale
+	else:
+		palette = _remap(palette, _palette_map("ob_palette_maps", attributes & OAM_PALETTE))
 	var lookup: Image = Gen2PicImage.from_indices(pixels, TILE, TILE, palette, true)
 	if (attributes & OAM_XFLIP) != 0:
 		lookup.flip_x()

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1081,6 +1081,10 @@ func _init_battle_display() -> void:
 	)
 	_refresh_exp_bar()
 	_intro = Gen2BattleIntro.for_data(_data)
+	# `InitBattleDisplay` clears the top of the player's square before the slide
+	# and `PlaceGraphic` puts it back after, which is where [method
+	# advance_intro] restamps it.
+	Gen2BattleScreenMap.clear_intro_box(_bg_map)
 	_intro_message = ""
 	_entrance_stages = []
 	_slides = []
@@ -1127,8 +1131,10 @@ func advance_intro() -> bool:
 		return false
 	if _intro.finished():
 		# `InitBattleDisplay`'s own `xor a` / `ldh [hSCX], a` after the call, and
-		# then `BattleStartMessage`.
+		# then `hGraphicStartTile = $31` / `hlcoord 2, 6` / `PlaceGraphic`, which
+		# puts back the two tile rows its `ClearBox` took off before the slide.
 		_intro = null
+		Gen2BattleScreenMap.stamp(_bg_map, true)
 		_push_view()
 		_build_entrance()
 		_advance_entrance()
@@ -2038,7 +2044,7 @@ func show_message(text: String, prompt: bool = true) -> void:
 	## is the one a menu is drawn over and owes nothing.
 	_message_awaits_press = prompt and not text.is_empty()
 	if _box != null:
-		_box.show_text(text)
+		_box.show_text(text, prompt)
 
 
 ## What the animation layer is doing right now, for a scene test or a screenshot
@@ -4533,11 +4539,22 @@ func _push_view() -> void:
 		"player_hp": _drawn_hp(Gen2Battle.PLAYER), "player_max_hp": _player_max_hp,
 		"exp_pixels": _drawn_exp(),
 		## The background's own scroll, a value per scanline, empty when it is
-		## sitting still. `PlaceGraphic` puts the player's back pic up only after
-		## the slide has returned, so during it there is nothing to draw there.
+		## sitting still.
 		"raster_scx": _raster_offsets(),
 		"raster_scy": _raster_rows(),
-		"player_pic_visible": _intro == null,
+		## `CopyBackpic` puts the player's back pic on the tilemap before
+		## `InitBattleDisplay` ever reaches the slide, so it is there through it
+		## and comes in with the middle band. Its top three tile rows fall in the
+		## band the enemy scrolls, which is what the eighteen sprites below are
+		## for; `PlaceGraphic` afterwards is what settles the two pixels between
+		## them.
+		"player_pic_visible": true,
+		"intro_sprites": _intro.sprites() if _intro != null else [],
+		## `GetSGBLayout SCGB_BATTLE_GRAYSCALE` is called where the battle is
+		## entered and `SCGB_BATTLE_COLORS` only after `BattleIntroSlidingPics`,
+		## so a battle slides in with no colour at all and gains it on the frame
+		## the slide ends.
+		"grayscale": _intro != null,
 		## Which picture each square is holding and which panel is on the map.
 		## Both change several times while a battle is opening: see
 		## [method _build_entrance].

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -116,6 +116,33 @@ static func slide_step(map: PackedByteArray, player_side: bool) -> void:
 			map[y * COLUMNS + to] = map[y * COLUMNS + from]
 
 
+## `InitBattleDisplay`'s `hlcoord 1, 5 / lb bc, 3, 7 / ClearBox`, which runs
+## between `CopyBackpic` and the slide and takes the top two tile rows of the
+## player's back pic off the map.
+##
+## It is what makes the slide's eighteen sprites necessary rather than a second
+## copy of the same picture: those rows fall in the band the enemy's own scroll
+## owns, so the background cannot carry them and `.LoadTrainerBackpicAsOAM`
+## does. `PlaceGraphic` puts the whole pic back when the slide returns.
+const INTRO_CLEAR_AT: Vector2i = Vector2i(1, 5)
+const INTRO_CLEAR_COLUMNS: int = 7
+const INTRO_CLEAR_ROWS: int = 3
+
+
+static func clear_intro_box(map: PackedByteArray) -> void:
+	if map.size() != COLUMNS * ROWS:
+		return
+	for row: int in INTRO_CLEAR_ROWS:
+		var y: int = INTRO_CLEAR_AT.y + row
+		if y < 0 or y >= ROWS:
+			continue
+		for column: int in INTRO_CLEAR_COLUMNS:
+			var x: int = INTRO_CLEAR_AT.x + column
+			if x < 0 or x >= COLUMNS:
+				continue
+			map[y * COLUMNS + x] = BLANK_TILE
+
+
 ## `PlaceGraphic` over one battler's box: a tile is
 ## [code]base + column * side + row[/code], the column-major order `.BGSquares`
 ## indexes and `AppearUser` restores.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -50,6 +50,7 @@ var _foresight_matchups: Dictionary = {}
 var _atlases: Dictionary = {}
 var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
+var _battle_grayscale_palette: Array = []
 var _player_palettes: Dictionary = {}
 var _transition_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
@@ -134,6 +135,7 @@ static func open_directory(path: String) -> GameData:
 	data._atlases = manifest.get("atlases", {})
 	data._tiles = manifest.get("tiles", {})
 	data._bar_palettes = manifest.get("bar_palettes", {})
+	data._battle_grayscale_palette = manifest.get("battle_grayscale_palette", [])
 	data._player_palettes = manifest.get("player_palettes", {})
 	data._transition_palettes = manifest.get("transition_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
@@ -1994,6 +1996,19 @@ func player_palette(kind: String) -> PackedColorArray:
 		Gen2Palette.from_packed(int((stored as Array)[0])),
 		Gen2Palette.from_packed(int((stored as Array)[1])),
 	]))
+
+
+## `_CGB_BattleGrayscale`'s, which is `PredefPals`' `BLACKOUT`: white, two grays
+## and black. Every background and object palette holds it from `StartBattle`'s
+## own `GetSGBLayout` until `SCGB_BATTLE_COLORS` replaces it after
+## `BattleIntroSlidingPics`, which is why a battle slides in without colour.
+func battle_grayscale_palette() -> PackedColorArray:
+	if _battle_grayscale_palette.size() < RomLayout.PREDEF_PALETTE_COLORS:
+		return PackedColorArray()
+	var out := PackedColorArray()
+	for packed: Variant in _battle_grayscale_palette:
+		out.append(Gen2Palette.from_packed(int(packed)))
+	return out
 
 
 ## `StartTrainerBattle_LoadPokeBallGraphics`' own palette, which every

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -76,7 +76,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 71
+const FORMAT_VERSION: int = 72
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3926,6 +3926,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"player_palettes": _import_player_palettes(rom, layout),
 		"transition_palettes": _import_transition_palettes(rom, layout),
+		"battle_grayscale_palette": _import_battle_grayscale_palette(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
 		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
 		"pc_palette": _import_pc_palette(rom, layout),
@@ -4508,6 +4509,20 @@ func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 		out[RomLayout.BAR_PALETTE_NAMES[index]] = [
 			rom.u16le(entry), rom.u16le(entry + Gen2Palette.COLOR_BYTES),
 		]
+	return out
+
+
+## `_CGB_BattleGrayscale`'s own palette, which is `PredefPals`' `BLACKOUT` entry
+## and is what every background and object palette holds from the moment a battle
+## is entered until `GetSGBLayout SCGB_BATTLE_COLORS` runs, several hundred
+## frames later on the far side of `BattleIntroSlidingPics`.
+func _import_battle_grayscale_palette(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = RomLayout.predef_palette_offset(layout, RomLayout.PREDEFPAL_BLACKOUT)
+	if at < 0 or not rom.in_bounds(at, RomLayout.PREDEF_PALETTE_SIZE):
+		return []
+	var out: Array = []
+	for index: int in RomLayout.PREDEF_PALETTE_COLORS:
+		out.append(rom.u16le(at + index * Gen2Palette.COLOR_BYTES))
 	return out
 
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1121,6 +1121,25 @@ const GS_INTRO_WATER_FIRST_ROW: int = 15
 const GS_INTRO_MAGIKARP_PALETTES: int = 2
 const GS_INTRO_SHELLDER_LAPRAS_PALETTES: int = 3
 
+## `PREDEFPAL_BLACKOUT`, which is what `_CGB_BattleGrayscale` fills every
+## background and object palette with: `PalPacket_BattleGrayscale` is
+## `sgb_pal_set BLACKOUT, BLACKOUT, BLACKOUT, BLACKOUT` and `CopyPalettes` reads
+## each of those bytes as an index into `PredefPals` rather than as a colour.
+##
+## Despite the name it is not black: $7FFF, $1CE7, $0C62, $0000, the grayscale
+## ramp the whole battle is drawn in until `GetSGBLayout SCGB_BATTLE_COLORS`
+## runs, which is after `BattleIntroSlidingPics`. Identical in all three dumps.
+const PREDEFPAL_BLACKOUT: int = 0x1A
+const PREDEF_PALETTE_COLORS: int = 4
+const PREDEF_PALETTE_SIZE: int = PREDEF_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
+
+
+## The offset of one `PredefPals` entry, or -1 for a layout with no pin.
+static func predef_palette_offset(layout: Dictionary, index: int) -> int:
+	var base: int = int(layout.get("predef_pals", -1))
+	return -1 if base < 0 else base + index * PREDEF_PALETTE_SIZE
+
+
 ## `PredefPals` (gfx/sgb/predef.pal), eight bytes an entry. The three the movie
 ## reads are contiguous, so the run's own base is what locates them, and that
 ## base is already pinned: `game_freak_presents.object_palette` is
@@ -1606,6 +1625,9 @@ const GOLD_SILVER: Dictionary = {
 	"base_stats": 0x51B0B,
 	"pic_pointers": 0x48000,
 	"unown_pic_pointers": 0x7C000,
+	# `PredefPals`, which `CopyPalettes` expands a `sgb_pal_set` byte through.
+	# See [constant PREDEFPAL_BLACKOUT] for the one entry the battle reads.
+	"predef_pals": 0xA265,
 	# pokegold has no `pic_animation.asm`, no `anim.asm`, no bitmasks and no
 	# frames: both of its send-outs reach `PlayStereoCry` directly, which is
 	# Crystal's own `.cry_no_anim` branch. See [constant CRYSTAL].
@@ -2070,6 +2092,8 @@ const CRYSTAL: Dictionary = {
 	"base_stats": 0x51424,
 	"pic_pointers": 0x120000,
 	"unown_pic_pointers": 0x124000,
+	# The same table; Crystal has no Gold and Silver intro to pin it under.
+	"predef_pals": 0x9DF6,
 	# `AnimateFrontpic`'s five tables, Crystal's alone: pokegold ships no
 	# `pic_animation.asm`, no `anim.asm`, no bitmasks and no frames, and both of
 	# its send-outs reach `PlayStereoCry` directly. Every address here is

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -58,6 +58,9 @@ const TILE: int = Gen2Font.TILE
 ## Tiles per second while a page is revealing. The games run this off the frame
 ## counter; a rate is the same thing said in a way that does not assume 60 Hz.
 @export var reveal_speed: float = 30.0
+
+## Whether the last page loads the arrow; see [method show_text].
+var _blink_cursor: bool = true
 ## Whether A or B is being HELD, which is the whole of what a button does to a
 ## printing text. `PrintLetterDelay` reads `hJoyDown` and answers a held A or B
 ## with a single `DelayFrame`, whatever the speed setting says
@@ -174,8 +177,21 @@ func place_at_bottom() -> void:
 
 
 ## Lays [param text] out and starts revealing its first page.
-func show_text(text: String) -> void:
+##
+## [param blink_cursor] is whether the *last* page loads the arrow, and that is
+## not the same question as whether it waits. `WaitPressAorB_BlinkCursor`'s own
+## comment says it: "The cursor has to be shown before calling this function or
+## no cursor will be shown at all." Three routines show it, `Paragraph`,
+## `_ContText` and `PromptText`, so a page with another behind it always blinks;
+## the last page blinks only if the text ends in `prompt`.
+##
+## Two things therefore draw no arrow. A text ending in `done` reaches none of
+## the three, which is why `SendOutMonText` prints "Go! <MON>!" and runs on. And
+## a caller that waits with `JoyWaitAorB` instead loads no cursor whatever its
+## text ends in, which is every page of `ProfOaksPCBoot`.
+func show_text(text: String, blink_cursor: bool = true) -> void:
 	_pages = Gen2TextLayout.lay_out_pages(text, text_columns(), text_rows())
+	_blink_cursor = blink_cursor
 	_page = 0
 	_scroll_page = -1
 	_scroll_lines = []
@@ -430,12 +446,26 @@ func _draw_border(indices: PackedByteArray, width: int) -> void:
 
 ## The arrow, drawn only while the box is actually waiting: a page still
 ## revealing has not reached its `PromptButton` yet.
-func _draw_cursor(indices: PackedByteArray, width: int) -> void:
+## Whether `LoadBlinkingCursor` has the arrow up right now, which is the whole
+## rule for drawing it: a page still revealing has not reached its
+## `PromptButton`, a `scroll_nowait` page turns itself, a last page nothing
+## loaded the cursor for never shows one, and the blink is the other half of
+## `hVBlankCounter`.
+##
+## Public because it is a rule rather than a drawing step, and because a text
+## that owes no press is easy to draw an arrow over by accident.
+func cursor_visible() -> bool:
 	if _pages.is_empty() or is_revealing() or not _cursor_up():
-		return
+		return false
+	if not _blink_cursor and not has_pages_left():
+		return false
 	if _enter_of(_page + 1) == &"scroll_nowait":
-		return
-	if CURSOR_COLUMN >= columns or rows <= 0:
+		return false
+	return CURSOR_COLUMN < columns and rows > 0
+
+
+func _draw_cursor(indices: PackedByteArray, width: int) -> void:
+	if not cursor_visible():
 		return
 	font.draw_code(
 		CURSOR_CODE, indices, width, CURSOR_COLUMN * TILE, (rows - 1) * TILE

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2884,7 +2884,10 @@ func _show_prof_oaks_pc_page() -> void:
 		_close_prof_oaks_pc()
 		return
 	_apply_text_box_options()
-	_text_box.show_text(String(_oak_pc_pages[0]))
+	## `ProfOaksPCBoot` waits with `JoyWaitAorB`, which loads no cursor, so no
+	## page of the rating blinks an arrow however it ends. `_OakPCText2` ends in
+	## `prompt` and still shows none.
+	_text_box.show_text(String(_oak_pc_pages[0]), false)
 	_text_box.visible = true
 	## `ProfOaksPCBoot` plays the sound `Rate` chose after the rating is printed,
 	## not before it.
@@ -2917,7 +2920,8 @@ func _close_prof_oaks_pc() -> void:
 	if StringName(pending.get("type", &"")) == &"text" \
 		and _text_box != null and _text_box.font != null:
 		_apply_text_box_options()
-		_text_box.show_text(String(pending.get("text", "")))
+		# `OakPCText4` and its own `JoyWaitAorB`, the same as the pages above.
+		_text_box.show_text(String(pending.get("text", "")), false)
 		_text_box.visible = true
 		_script_prompt = "A: advance text"
 	else:
@@ -3708,12 +3712,18 @@ func _show_script_results(results: Array) -> void:
 				## Prof Oak's PC is the one special that draws on its own and
 				## whose script runs on past it, so its pages are shown first and
 				## this text waits behind them.
+				# `LoadBlinkingCursor` is `Paragraph`, `_ContText` and
+				# `PromptText`; a `writetext` whose text ends in `done` reaches
+				# none of them, so its last page carries no arrow and the script
+				# runs straight on.
+				_text_awaits_press = bool(event.get("prompt", true))
 				if _oak_pc_pages.is_empty():
 					_apply_text_box_options()
-					_text_box.show_text(String(event.get("text", "")))
+					_text_box.show_text(
+						String(event.get("text", "")), _text_awaits_press
+					)
 					_text_box.visible = true
 				_script_prompt = "A: advance text"
-				_text_awaits_press = bool(event.get("prompt", true))
 				continue_after_text = true
 			elif event_type == &"button":
 				if _text_box != null:

--- a/tests/integration/test_battle_animation_screen.gd
+++ b/tests/integration/test_battle_animation_screen.gd
@@ -159,10 +159,27 @@ func test_the_tilemap_is_the_battle_it_is_seeded_from() -> void:
 	assert_eq(map.size(), Gen2BattleScreenMap.COLUMNS * Gen2BattleScreenMap.ROWS)
 	# `GetEnemyFrontpicCoords` and `AppearUser`'s own `xor a` / `ld a, $31`.
 	assert_eq(int(map[Gen2BattleScreenMap.ENEMY_AT.x]), Gen2BattleScreenMap.ENEMY_BASE_TILE)
+	## `InitBattleDisplay`'s `hlcoord 1, 5 / lb bc, 3, 7 / ClearBox` runs between
+	## `CopyBackpic` and the slide, so the player's square is missing its top two
+	## tile rows for as long as the slide lasts and `PlaceGraphic` puts them back
+	## after. Checked against a real cartridge's own `wTilemap`, where the square
+	## holds `$33` to `$36` down each column while the pics are sliding and `$31`
+	## to `$36` once they have landed.
 	var player_at: int = Gen2BattleScreenMap.PLAYER_AT.y * Gen2BattleScreenMap.COLUMNS \
 		+ Gen2BattleScreenMap.PLAYER_AT.x
-	assert_eq(int(map[player_at]), Gen2BattleScreenMap.PLAYER_BASE_TILE)
+	assert_eq(int(map[player_at]), Gen2BattleScreenMap.BLANK_TILE)
+	var below: int = player_at + 2 * Gen2BattleScreenMap.COLUMNS
+	assert_eq(int(map[below]), Gen2BattleScreenMap.PLAYER_BASE_TILE + 2)
 	assert_eq(int(map[0]), Gen2BattleScreenMap.BLANK_TILE)
+
+	## And the slide is what is holding it: once it has run, the whole picture is
+	## on the map again.
+	while _screen.intro_running():
+		_screen.advance_frame()
+	assert_eq(
+		int(_screen._bg_map[player_at]), Gen2BattleScreenMap.PLAYER_BASE_TILE,
+		"`PlaceGraphic` puts the top rows back when the slide returns"
+	)
 
 
 func test_a_blanked_picture_stays_blank_until_something_stamps_it_back() -> void:

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -534,7 +534,19 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 	assert_eq(String(_battle_screen.battle_snapshot()["message"]), "", "the box is empty")
 
 	var view: Dictionary = _battle_screen._renderer._view
-	assert_false(bool(view["player_pic_visible"]), "the back pic is not placed yet")
+	## `CopyBackpic` puts the player's own picture on the map before
+	## `InitBattleDisplay` ever reaches the slide, and its eighteen sprites carry
+	## the rows `ClearBox` took off, so the player comes in from the right while
+	## the opponent comes in from the left. Both are drawn without colour:
+	## `SCGB_BATTLE_GRAYSCALE` is set where the battle is entered and
+	## `SCGB_BATTLE_COLORS` only after the slide returns.
+	assert_true(bool(view["player_pic_visible"]), "the back pic slides in too")
+	assert_true(bool(view["grayscale"]), "and the battle has no colour yet")
+	assert_eq(
+		(view["intro_sprites"] as Array).size(),
+		Gen2BattleIntro.SPRITE_COLUMNS * Gen2BattleIntro.SPRITE_ROWS,
+		"`.LoadTrainerBackpicAsOAM`'s own eighteen"
+	)
 	var offsets: PackedInt32Array = PackedInt32Array(view["raster_scx"])
 	assert_eq(offsets.size(), Gen2Screen.HEIGHT)
 	assert_ne(offsets[0], 0, "and the background is somewhere else entirely")
@@ -551,6 +563,8 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 	)
 	var settled: Dictionary = _battle_screen._renderer._view
 	assert_true(bool(settled["player_pic_visible"]))
+	assert_false(bool(settled["grayscale"]), "`SCGB_BATTLE_COLORS` runs after the slide")
+	assert_true((settled["intro_sprites"] as Array).is_empty(), "`HideSprites`")
 	assert_true(PackedInt32Array(settled["raster_scx"]).is_empty(), "and nothing is scrolled")
 
 

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -187,3 +187,35 @@ func test_a_no_pause_scroll_runs_itself() -> void:
 		box._process(FRAME)
 	assert_false(box.has_pages_left(), "the second page arrived without a press")
 	assert_false(box.is_revealing())
+
+
+## `LoadBlinkingCursor` is reached by `Paragraph`, `_ContText` and `PromptText`
+## and by nothing else, and `WaitPressAorB_BlinkCursor` says so itself: "The
+## cursor has to be shown before calling this function or no cursor will be shown
+## at all." So a text ending in `done` prints its last page with no arrow and the
+## caller runs on, which is `SendOutMonText`'s "Go! <MON>!"; and a caller waiting
+## with `JoyWaitAorB` shows none either way, which is every page of
+## `ProfOaksPCBoot` including the one ending in `prompt`.
+func test_a_text_nothing_loaded_a_cursor_for_draws_no_arrow() -> void:
+	var waiting: Gen2TextBox = _box()
+	waiting.show_text("hello there")
+	assert_false(waiting.is_revealing())
+	assert_true(waiting.cursor_visible(), "a prompt text blinks its arrow")
+
+	var running_on: Gen2TextBox = _box()
+	running_on.show_text("hello there", false)
+	assert_false(running_on.is_revealing())
+	assert_false(running_on.cursor_visible())
+
+
+## Only the *last* page is exempt: a page with another behind it is reached
+## through `Paragraph` or `_ContText`, both of which load the cursor whatever
+## ends the text.
+func test_a_page_break_blinks_even_when_the_text_runs_on() -> void:
+	var box: Gen2TextBox = _box()
+	box.show_text("first" + Gen2TextStream.PAGE_BREAK + "second", false)
+	assert_true(box.has_pages_left())
+	assert_true(box.cursor_visible(), "the page break waits like any other")
+	assert_true(box.advance())
+	assert_false(box.has_pages_left())
+	assert_false(box.cursor_visible(), "and the last page does not")

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -261,6 +261,62 @@ func _verify_the_transition(game_id: StringName, data: GameData) -> void:
 				]
 			)
 	print("%s: the four transitions run %s frames." % [game_id, lengths])
+	_verify_the_sliding_intro(game_id, data)
+
+
+## `BattleIntroSlidingPics`, which is the two bands and the eighteen sprites the
+## player's own back pic comes in as. Measured against a real cartridge: its OAM
+## holds six columns of three from x 158 down to 16 by two a frame, the top three
+## tile rows of each column of the pic, and `InitBattleDisplay`'s `ClearBox`
+## takes those same rows off the background for exactly as long.
+func _verify_the_sliding_intro(game_id: StringName, data: GameData) -> void:
+	var intro: Gen2BattleIntro = Gen2BattleIntro.for_data(data)
+	var first: Array = intro.sprites()
+	_r.check(
+		first.size() == Gen2BattleIntro.SPRITE_COLUMNS * Gen2BattleIntro.SPRITE_ROWS,
+		"%s: the slide starts with %d sprites, not eighteen." % [game_id, first.size()]
+	)
+	var xs: Array = []
+	var spent: int = 0
+	while not intro.finished() and spent < MAX_FRAMES:
+		intro.advance_frame()
+		spent += 1
+		var now: Array = intro.sprites()
+		if not now.is_empty():
+			xs.append(int((now[0] as Dictionary)["x"]))
+	_r.check(
+		intro.sprites().is_empty(),
+		"%s: the slide left its sprites up; `HideSprites` takes them off." % game_id
+	)
+	# Every step is `dec [hl]` twice, and the walk never turns back.
+	var steps: Dictionary = {}
+	for index: int in range(1, xs.size()):
+		steps[int(xs[index - 1]) - int(xs[index])] = true
+	_r.check(
+		steps.size() <= 1 and (steps.is_empty() or steps.has(Gen2BattleIntro.SPRITE_STEP)),
+		"%s: the sprite walk steps %s, not two a frame." % [game_id, steps.keys()]
+	)
+
+	# `ClearBox` and `PlaceGraphic`: the map is missing the pic's top two tile
+	# rows for the slide and holds all six after it.
+	var map: PackedByteArray = Gen2BattleScreenMap.seeded()
+	Gen2BattleScreenMap.clear_intro_box(map)
+	var at: int = Gen2BattleScreenMap.PLAYER_AT.y * Gen2BattleScreenMap.COLUMNS \
+		+ Gen2BattleScreenMap.PLAYER_AT.x
+	_r.check(
+		int(map[at]) == Gen2BattleScreenMap.BLANK_TILE
+			and int(map[at + 2 * Gen2BattleScreenMap.COLUMNS])
+				== Gen2BattleScreenMap.PLAYER_BASE_TILE + 2,
+		"%s: the slide's own map is not what a cartridge's `wTilemap` holds." % game_id
+	)
+	_r.check(
+		not data.battle_grayscale_palette().is_empty(),
+		"%s: `_CGB_BattleGrayscale`'s palette is not in the cache." % game_id
+	)
+	_r.note("the slide walks %d frames of sprites from x %d to %d" % [
+		xs.size(), int(xs[0]) if not xs.is_empty() else -1,
+		int(xs[xs.size() - 1]) if not xs.is_empty() else -1,
+	])
 
 
 ## `GetSubstitutePic`, on both sides and all three cartridges: the doll is four


### PR DESCRIPTION
Four defects in a battle's opening, reported by the owner frame by frame against an emulator. Each one a source reading.

## The player did not slide in

`BattleIntroSlidingPics.subfunction3` walks eighteen shadow-OAM entries. Reading them as the overworld's leftovers is what left the player out of the slide entirely: they are `CopyBackpic.LoadTrainerBackpicAsOAM`'s own — six columns of three carrying the **top three tile rows** of the back pic, from x 158 down to 16 by two a frame.

`InitBattleDisplay`'s `hlcoord 1, 5 / lb bc, 3, 7 / ClearBox` is why they exist. It runs between `CopyBackpic` and the slide and takes those rows off the background, because they fall in the band the *opponent's* scroll owns and the background cannot carry them. `PlaceGraphic` puts the whole pic back when the slide returns.

## The opening had colour and should have none

`StartBattle` calls `GetSGBLayout SCGB_BATTLE_GRAYSCALE`; `SCGB_BATTLE_COLORS` is only reached on the far side of the slide. So both pics come in through `PredefPals`' `BLACKOUT` ramp and gain their own palettes on the frame the slide ends. `DmgToCgbBGPals` does not load a palette — it reorders `wBGPals1` — so the ramp is pinned rather than assumed: `predef_pals` for all three dumps (Crystal `0x9DF6`, Gold and Silver `0xA265`), same entry in each. **Cache format 72.**

## The blinking arrow was drawn where nothing loads it

`WaitPressAorB_BlinkCursor` states the rule itself: *"The cursor has to be shown before calling this function or no cursor will be shown at all."* Only `Paragraph`, `_ContText` and `PromptText` show it. `SendOutMonText` ends in `done` and reaches none of them, so "Go! &lt;MON&gt;!" carries no arrow and runs straight on.

Looking for the class rather than the case found the same rule broken in the overworld: **whether a box blinks is not whether it waits.** Every page of `ProfOaksPCBoot` waits with `JoyWaitAorB`, which loads no cursor — including the one page whose text ends in `prompt`. `Gen2TextBox.show_text`'s second argument is that question and nothing else.

## Measured against a real cartridge

| Artefact | Result |
|---|---|
| shadow OAM through the slide | eighteen sprites at six columns x three rows, x 158 to 16 by two, none after `HideSprites` |
| `wTilemap` during vs after | `$33`-`$36` down each column of the player's square while sliding, `$31`-`$36` once landed |
| `wBGPals1` / `wOBPals1` | `$7FFF, $1CE7, $0C62, $0000` on every palette from frame 250 to 333, the battle's own colours from 336 |
| the player's box, ours vs the cartridge | same shape and shading frame for frame |

GUT 3,282 over 152 scripts green, `validate.gd -- all` 55 topics green (`battle_anims` grew a sliding-intro topic), `replay_world.gd` and the three-profile story walk green on all three cartridges, boot clean. All three cartridges re-imported for the format bump. Two tests asserted the old reading and now assert the cartridge's.

## Not exact

Crystal's sprite walk is measured against hardware. Gold's own routine has a lead frame this models one step short of, so its sprites stop two pixels early where Crystal's do not; no dump has been asked about it.