### PR TITLE
Let a mod's actor be talked to, and ask for a hidden item

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -36,7 +36,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -808,6 +808,26 @@ view. Three methods, refused by name at registration the way a renderer's are:
 | `advance_frame()` | Once per world frame, after the player's step advanced |
 | `sprites() -> Array` | What to draw now. A read: it is asked once a frame however many times the screen redraws |
 
+Two more are **optional** (`api_version` 7) and offered only to an actor that
+defines them, so every actor already written keeps working:
+
+| Method | Called when |
+|---|---|
+| `interact(cell: Vector2i, facing: int) -> bool` | A press of A that no cartridge object, background event or tile branch answered. `cell` is the player's faced cell and `facing` the player's own; the first actor answering true consumes the press |
+| `take_requests() -> Array` | The actor's one-shot outbox, drained once a world frame and emptied by the drain |
+
+`interact` is offered **only** after `Gen2WorldAPI.interact()` answered nothing at
+all, so a mod can never shadow a cartridge interaction. Only the actor's own pose
+changes, so no player event is spent, and a pose the press changed is on screen
+on the frame it was pressed.
+
+`take_requests` is where an **edge** goes; `sprites()` is where a **pose** goes.
+The one kind so far is `{"kind": &"cry", "species": n}`, played through the same
+player a script's `cry` command and the Pokedex CRY button use. A mod may not
+play a sound, so it asks and the host spends it, which is the bargain the shiny
+pulse already has; no dedup window is needed, since the mod asks once. Anything
+else in the outbox is dropped.
+
 Each entry of `sprites()` is a dictionary naming cartridge art and nothing else:
 
 | Key | Meaning |
@@ -816,6 +836,8 @@ Each entry of `sprites()` is a dictionary naming cartridge art and nothing else:
 | `sprite` | An `OverworldSprites` row instead, for an NPC or an object picture |
 | `facing` | `Gen2WorldSprite.FACING_*`. Right is the left picture mirrored, as on the cartridge |
 | `position_cells` | Where to draw it, in fractional walk cells, the unit `player_position_cells()` is in |
+| `colors` | Optional. Four colours to draw the sprite in instead of the map's own sprite palette. What a visible encounter wears, so a shiny one is a shiny one before the battle starts |
+| `emote` | Optional (`api_version` 7). `Gen2WorldActors.EMOTE_SHOCK` through `EMOTE_GRASS_RUSTLE`, drawn two rows above the sprite exactly as `SpawnEmote` puts one over a map object. State rather than an edge: it is up for as long as the entry keeps asking, so the mod owns the duration and the host owns the pixels, and a renderer reading `set_actors` gets it for free. An index outside the twelve is no emote rather than a wrong sheet |
 
 The host resolves the strip, the palette, the time of day and the icon's own
 two-frame animation (`.Frameset_PartyMon`'s rate), so a mod never composes
@@ -913,6 +935,43 @@ What the host does with a valid population:
 A world renderer that wants to draw the sparkle itself takes the optional
 `set_encounters(encounters: Gen2WorldEncounters)`; the population itself already
 arrives through `set_actors`.
+
+## Hidden items a mod can see, and ask for
+
+A mod that wants something of its own to pick a hidden item up, a follower
+walking over one or a detector drawing them, reads them and **asks** for one
+(`api_version` 7). It never takes one: taking one writes the bag, the event flag
+and the save, and runs `hiddenitem`'s own `verbosegiveitem` with its FOUND text,
+its fanfare and its pack-full branch, all of which is world state a mod must not
+write.
+
+`Gen2WorldAPI.hidden_items()` is the read: one entry per `BGEVENT_ITEM` on the
+current map, taken or not. Scene-free, like `visible_encounter_cells()` beside
+it, so a probe can walk a map and print them with no game running.
+
+| Key | Meaning |
+|---|---|
+| `cell` | Where the record sits |
+| `item` | The item it gives, with the gameplay catalog's patch already applied |
+| `flag` | Its own event flag, which is the site's completion |
+| `taken` | `event_flag_active(flag)`. The Itemfinder's own test |
+
+`Gen2ModHost.request_hidden_item(cell)` is the ask. The mod names a cell and
+reads nothing back: the host validates it against that same list and, on the
+next world frame nothing else owns, runs the map's **own** script through the
+ordinary path, so the text box, the fanfare and the pacing are the world
+screen's exactly as they are for a player walking onto the cell. It is the same
+bargain a visible-encounter provider has with a wild battle: the mod names the
+entry, the host runs it.
+
+- An ask for a cell with no record, or one whose flag is already set, does
+  nothing. `CheckBGEventFlag` is the host's test, not the mod's.
+- One is spent per frame, since the first one's script owns the world until its
+  box is pressed past; the rest wait in the queue in order.
+- An ask made inside a battle, a text box, a warp or an overlay is spent when the
+  world can spend it rather than dropped.
+
+Which cell to name is the mod's own business.
 
 ## Measured against the voxel mod
 

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -171,6 +171,9 @@ var _world_renderers: Dictionary = {}
 ## loaded, the way its entry object is: an actor carries the mod's own state
 ## between frames. See [method register_world_actor].
 var _world_actors: Dictionary = {}
+## Cells a mod asked the host to pick a hidden item up from. See
+## [method request_hidden_item].
+var _hidden_item_requests: Array[Vector2i] = []
 ## Mod id to the visible-encounter provider it registered, held the way an actor
 ## is. See [method register_visible_encounters].
 var _visible_encounters: Dictionary = {}
@@ -263,6 +266,12 @@ func create_world_renderer() -> Node:
 ## methods in [constant Gen2WorldActors.ACTOR_METHODS]; a registration missing
 ## one is refused here, where the mod's name is still in hand.
 ##
+## Two more are OPTIONAL and offered only to an actor that defines them, so every
+## actor already written keeps working: [constant
+## Gen2WorldActors.ACTOR_INTERACT_METHOD], offered a press of A no cartridge
+## branch answered, and [constant Gen2WorldActors.ACTOR_REQUESTS_METHOD], the
+## one-shot outbox the host drains once a world frame.
+##
 ## What an actor draws is presentation and takes part in nothing else. See
 ## [Gen2WorldActors] for the contract and `docs/MODS.md` for the entry shape.
 func register_world_actor(id: StringName, actor: Object) -> Dictionary:
@@ -283,6 +292,36 @@ func register_world_actor(id: StringName, actor: Object) -> Dictionary:
 		return {"ok": false, "reason": &"duplicate_actor", "detail": String(id)}
 	_world_actors[id] = actor
 	return {"ok": true, "id": id}
+
+
+## Asks the world screen to pick up the hidden item at [param cell] on the map
+## the player is on. A REQUEST and never the act: taking one writes the bag, the
+## event flag and the save, and runs `hiddenitem`'s own `verbosegiveitem` with
+## its FOUND text, its fanfare and its pack-full branch, none of which a mod may
+## do. So the mod names a cell, exactly as a visible-encounter provider names the
+## entry the host then starts a wild battle from.
+##
+## Queued rather than answered: the screen validates the cell against
+## [method Gen2WorldAPI.hidden_items] and runs the map's own script on the next
+## world frame it is idle for, so an ask inside a battle, a text box or a warp is
+## spent when the world can spend it. Which cell to name is the mod's business.
+func request_hidden_item(cell: Vector2i) -> void:
+	_hidden_item_requests.append(cell)
+
+
+## Drained by [Gen2WorldScreen], once, on the frame it spends them.
+func take_hidden_item_requests() -> Array[Vector2i]:
+	var out: Array[Vector2i] = _hidden_item_requests
+	_hidden_item_requests = []
+	return out
+
+
+## What a drain could not spend this frame, put back in front of anything asked
+## for since, so an ask is never lost by the frame it happened to land on.
+func requeue_hidden_items(cells: Array[Vector2i]) -> void:
+	if cells.is_empty():
+		return
+	_hidden_item_requests = cells + _hidden_item_requests
 
 
 func world_actor_ids() -> Array:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -20,7 +20,11 @@ const FILENAME: String = "mod.json"
 ## 5 added [member Gen2WorldAPI.rules], the run's own divergence flags.
 ## 6 added `occupied` to the visible-encounter context, which is the only way a
 ## provider can tell that a cell has an NPC or an item ball standing on it.
-const API_VERSION: int = 6
+## 7 gave a world actor an optional `interact` and an optional `take_requests`
+## outbox, an optional `emote` on a `sprites()` entry, and the host
+## [method Gen2ModHost.request_hidden_item] over
+## [method Gen2WorldAPI.hidden_items].
+const API_VERSION: int = 7
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -20,6 +20,34 @@ extends RefCounted
 
 ## Checked at registration, where the mod's name is still in hand.
 const ACTOR_METHODS: Array[String] = ["set_world", "advance_frame", "sprites"]
+## Optional, offered only to an actor that defines it. See [method interact].
+const ACTOR_INTERACT_METHOD: String = "interact"
+## Optional, drained once a world frame. See [method take_requests].
+const ACTOR_REQUESTS_METHOD: String = "take_requests"
+
+## constants/script_constants.asm's EMOTE_* order, which is
+## [constant RomLayout.EMOTE_NAMES]' too. Named here so a mod asking for one over
+## its own sprite names it rather than counting the array. The last four are the
+## engine's own overlays rather than `showemote` arguments, and a mod naming one
+## gets that sheet drawn where the bubble would be.
+const EMOTE_NONE: int = -1
+const EMOTE_SHOCK: int = 0
+const EMOTE_QUESTION: int = 1
+const EMOTE_HAPPY: int = 2
+const EMOTE_SAD: int = 3
+const EMOTE_HEART: int = 4
+const EMOTE_BOLT: int = 5
+const EMOTE_SLEEP: int = 6
+const EMOTE_FISH: int = 7
+const EMOTE_SHADOW: int = 8
+const EMOTE_ROD: int = 9
+const EMOTE_BOULDER_DUST: int = 10
+const EMOTE_GRASS_RUSTLE: int = 11
+
+## The kinds [method take_requests] passes on. Anything else a mod puts in its
+## outbox is dropped here rather than reaching the screen.
+const REQUEST_CRY: StringName = &"cry"
+const REQUEST_KINDS: Array[StringName] = [REQUEST_CRY]
 
 ## `.Frameset_PartyMon`: two OAM sets of eight, nine passes each because
 ## `GetSpriteAnimFrame` returns the entry on the pass that loads the duration
@@ -79,9 +107,69 @@ func advance_frame() -> bool:
 	return _changed(before, _sprites)
 
 
-## { sprite, facing, frame, position_cells, colors }, sorted by the row stood on
-## and then by registration order, the way the map's own objects are. `colors` is
-## empty for everything but a visible encounter.
+## A press of A that no cartridge object, background event or tile branch
+## answered, offered to the actors in registration order; the first answering
+## true consumes it. [param cell] is the player's faced cell and [param facing]
+## the player's own, so an actor tests its own pose and the host never has to
+## invent an occupancy notion for a sprite that occupies nothing.
+##
+## Offered ONLY after [method Gen2WorldAPI.interact] answered nothing, so no
+## cartridge interaction can ever be shadowed by a mod. An actor without the
+## method is offered nothing.
+func interact(cell: Vector2i, facing: int) -> bool:
+	for actor: Object in _actors:
+		if not actor.has_method(ACTOR_INTERACT_METHOD):
+			continue
+		if bool(actor.call(ACTOR_INTERACT_METHOD, cell, facing)):
+			## The press is spent, so what the actor changed about its own pose
+			## is on screen this frame rather than on the next advance.
+			_collect()
+			return true
+	return false
+
+
+## An actor's one-shot outbox, drained once a world frame and emptied by the
+## drain. A pose belongs in [method sprites], which is a read asked once a frame
+## however many times the screen redraws; an edge belongs here, asked for once
+## and spent once.
+##
+## Every entry is validated against [constant REQUEST_KINDS] here, so the screen
+## is handed requests it can spend rather than whatever a mod wrote.
+func take_requests() -> Array:
+	var out: Array = []
+	for actor: Object in _actors:
+		if not actor.has_method(ACTOR_REQUESTS_METHOD):
+			continue
+		var answered: Variant = actor.call(ACTOR_REQUESTS_METHOD)
+		if not answered is Array:
+			continue
+		for entry: Variant in answered as Array:
+			var request: Dictionary = _resolve_request(entry)
+			if not request.is_empty():
+				out.append(request)
+	return out
+
+
+func _resolve_request(entry: Variant) -> Dictionary:
+	if not entry is Dictionary:
+		return {}
+	var row: Dictionary = entry as Dictionary
+	var kind := StringName(row.get("kind", &""))
+	if not REQUEST_KINDS.has(kind):
+		return {}
+	if kind == REQUEST_CRY:
+		var species: int = int(row.get("species", 0))
+		# The record lookup is the real gate; this only keeps a zero out of it.
+		if species <= 0:
+			return {}
+		return {"kind": kind, "species": species}
+	return {}
+
+
+## { sprite, facing, frame, position_cells, colors, emote }, sorted by the row
+## stood on and then by registration order, the way the map's own objects are.
+## `colors` is empty for everything but a visible encounter, and `emote` is
+## [constant EMOTE_NONE] unless the entry asked for one.
 func sprites() -> Array:
 	return _sprites
 
@@ -136,7 +224,20 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 		# only way a shiny one is a shiny one before the battle starts. A view
 		# that does not read this draws the ordinary palette and is not wrong.
 		"colors": row.get("colors", PackedColorArray()),
+		# `SpawnEmote`'s bubble, two rows above the sprite. State rather than an
+		# edge: it is up for as long as the entry keeps asking, so the mod owns
+		# the duration and the host owns the pixels.
+		"emote": _resolve_emote(row),
 	}
+
+
+## An out-of-range index is no emote rather than a wrong sheet, the way art the
+## cache does not carry is dropped rather than drawn as a placeholder.
+func _resolve_emote(row: Dictionary) -> int:
+	var emote: int = int(row.get("emote", EMOTE_NONE))
+	if emote < 0 or emote >= RomLayout.EMOTE_NAMES.size():
+		return EMOTE_NONE
+	return emote
 
 
 ## A mon icon steps through its two at `.Frameset_PartyMon`'s rate; anything else
@@ -168,6 +269,7 @@ func _changed(before: Array, after: Array) -> bool:
 		if was["position_cells"] != now["position_cells"] \
 			or int(was["facing"]) != int(now["facing"]) \
 			or int(was["frame"]) != int(now["frame"]) \
+			or int(was["emote"]) != int(now["emote"]) \
 			or (was["sprite"] as Gen2WorldSprite).number \
 				!= (now["sprite"] as Gen2WorldSprite).number:
 			return true

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5667,21 +5667,77 @@ static func _escape_rope_failure(reason: StringName) -> Dictionary:
 ## `wXCoord + SCREEN_WIDTH / 4` and `wYCoord + SCREEN_HEIGHT / 4`, accepted while
 ## the difference stays below half a screen: four cells up and left of the
 ## player, four down and five right.
+## Every BGEVENT_ITEM on the current map, as `{cell, item, flag, taken}`, whether
+## or not it has been picked up: `taken` is [method event_flag_active] on its own
+## flag, which is the Itemfinder's own test. A read and scene-free, like
+## [method visible_encounter_cells], so a probe can walk a map and print them
+## with no game running.
+##
+## The map's own events and nothing past them; a connection's belong to the
+## connected map. An event whose three bytes do not decode is dropped rather than
+## offered with a zero item, the way [method _hidden_item_record] refuses one.
+func hidden_items() -> Array:
+	var out: Array = []
+	if current_map == null:
+		return out
+	var rows: Array = current_map.events.get("bg_events", [])
+	for index: int in rows.size():
+		var bg_event: Dictionary = (rows[index] as Dictionary).duplicate(true)
+		if int(bg_event.get("type", -1)) != BGEVENT_ITEM:
+			continue
+		## `event_index` the way [method events_at] stamps it: it is the only
+		## stable name a background event has, and [Gen2WorldCatalog] addresses a
+		## patched item under a tile by it. Without it every record on a map
+		## reads index 0 and a mod is told the wrong item.
+		bg_event["event_index"] = index
+		var record: Dictionary = _hidden_item_record(bg_event)
+		if not bool(record.get("ok", false)):
+			continue
+		out.append({
+			"cell": Vector2i(int(bg_event.get("x", 0)), int(bg_event.get("y", 0))),
+			"item": int(record["item"]),
+			"flag": int(record["flag"]),
+			"taken": event_flag_active(int(record["flag"])),
+		})
+	return out
+
+
+## The map's own hidden-item script at [param cell], queued and run through the
+## ordinary path, so the bag write, the event flag, the save, `verbosegiveitem`'s
+## FOUND text, its fanfare and its pack-full branch are all the host's exactly as
+## a player walking onto the cell would get them. Answers the script results the
+## way [method interact] does, and an empty array when the cell holds no hidden
+## item, when it has already been taken, or when a script is already running.
+func take_hidden_item(cell: Vector2i) -> Array:
+	if current_map == null or _active_script != null or not _script_queue.is_empty():
+		return []
+	## [method events_at] rather than the raw list: it is what stamps `kind` and
+	## `event_index`, both of which the request below is built from.
+	for event: Dictionary in events_at(cell):
+		if event.get("kind", &"") != &"bg_events" or int(event.get("type", -1)) != BGEVENT_ITEM:
+			continue
+		## The same gate `_active_events_at` applies to a background event, so a
+		## flag already set answers nothing rather than giving the item twice.
+		if not _bg_event_condition_active(event):
+			continue
+		var request: Dictionary = _hidden_item_request_for_event(event)
+		if request.is_empty():
+			continue
+		_enqueue_script(request)
+		return run_event_queue(false)
+	return []
+
+
 func hidden_item_nearby() -> bool:
 	if current_map == null:
 		return false
-	for event: Variant in current_map.events.get("bg_events", []):
-		var bg_event: Dictionary = event
-		if int(bg_event.get("type", -1)) != BGEVENT_ITEM:
+	for entry: Dictionary in hidden_items():
+		if bool(entry["taken"]):
 			continue
-		var offset: Vector2i = player_cell - Vector2i(
-			int(bg_event.get("x", 0)), int(bg_event.get("y", 0))
-		)
+		var offset: Vector2i = player_cell - (entry["cell"] as Vector2i)
 		if offset.x < -5 or offset.x > 4 or offset.y < -4 or offset.y > 4:
 			continue
-		var record: Dictionary = _hidden_item_record(bg_event)
-		if bool(record.get("ok", false)) and not event_flag_active(int(record["flag"])):
-			return true
+		return true
 	return false
 
 

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -424,9 +424,10 @@ func _draw() -> void:
 	var battlers_only: bool = _transition_sprites == Gen2BattleTransition.SPRITES_BATTLERS
 	## A mod's actors are drawn in the same pass and sorted into the same rows:
 	## a follower one cell below an NPC has to be drawn over it, and one cell
-	## above it under it. They carry no emote, no effect sprite and no grass of
-	## their own beyond the tuft the map draws over anything standing in it, and
-	## they are map objects here, so the respawn takes them with the rest.
+	## above it under it. They carry no effect sprite and no grass of their own
+	## beyond the tuft the map draws over anything standing in it, an emote only
+	## when the entry asked for one, and they are map objects here, so the
+	## respawn takes them with the rest.
 	var drawn: Array = []
 	for object: Gen2WorldObject in objects:
 		if battlers_only and object.index != _transition_opponent:
@@ -570,6 +571,12 @@ func _draw_actor(
 	draw_texture(texture, pixel)
 	if _in_grass(Vector2i(roundi(cell_position.x), roundi(cell_position.y))):
 		_draw_grass_over(pixel, page, palettes, tile_origin, tile_offset, window_size)
+	## The same bubble a map object's `showemote` puts up, over an actor that
+	## asked for one. Drawn after the grass, as an object's is: `SpawnEmote` is
+	## its own OAM and stands over the tuft rather than behind it.
+	var emote: int = int(sprite.get("emote", Gen2WorldActors.EMOTE_NONE))
+	if emote != Gen2WorldActors.EMOTE_NONE:
+		_draw_emote(emote, pixel)
 
 
 ## The object pass's own order, with a mod's actors sorted into it: the row a

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -529,6 +529,8 @@ func advance_frame() -> void:
 			_renderer.refresh()
 	if _actors != null and _actors.advance_frame() and _renderer != null:
 		_renderer.refresh()
+	_spend_actor_requests()
+	_spend_hidden_item_requests()
 	_advance_forced_movement()
 	_advance_held_direction()
 	if _objects_may_move() and _world.advance_object_steps_frame(_object_random) \
@@ -1283,7 +1285,12 @@ func interact() -> bool:
 		return false
 	var results: Array = _world.interact()
 	if results.is_empty():
-		return false
+		## Only here, after every cartridge branch `PlayerEvents` tries answered
+		## nothing: an actor can never shadow an object, a background event or a
+		## tile branch. Its own pose is all it changes, so no player event is
+		## spent and the sign timer stands.
+		return _actors != null \
+			and _actors.interact(_world.facing_cell(), _world.player_facing)
 	## `OWPlayerInput`, the last branch `PlayerEvents` tries, and a player event
 	## like the rest of them.
 	_zero_map_name_sign_timer()
@@ -1519,6 +1526,68 @@ class PreviewEncounters extends RefCounted:
 
 	func battle_finished(_id: StringName, _result: Variant) -> void:
 		pass
+
+
+## Public screenshot driver for the actor seam's optional half, which otherwise
+## needs a mod: a Pokemon one cell behind the player, pressed with A so it is
+## drawn wearing the heart the press put up. The press and the cry go through
+## the host's own path; only the actor is synthetic.
+func preview_pet_actor() -> void:
+	if _world == null or _actors == null or _renderer == null:
+		return
+	## Faced up so the bubble, which `MovementFunction_Emote` puts two rows above
+	## the sprite, is clear of the player rather than behind them.
+	_world.player_facing = Gen2WorldSprite.FACING_UP
+	_actors.set_actors([PreviewPet.new(_world)])
+	interact()
+	advance_frames(1)
+	_script_prompt = "Debug pet actor preview"
+	_renderer.refresh()
+	_refresh_labels()
+
+
+## What a mod's actor is, in the fewest lines that exercise the optional half.
+class PreviewPet extends RefCounted:
+	const CYNDAQUIL: int = 155
+
+	var _world: Gen2WorldAPI = null
+	var _petted: bool = false
+	var _cried: bool = false
+
+	func _init(world: Gen2WorldAPI) -> void:
+		_world = world
+
+	func set_world(world: Gen2WorldAPI) -> void:
+		_world = world
+
+	func advance_frame() -> void:
+		pass
+
+	func sprites() -> Array:
+		var entry: Dictionary = {
+			"icon": _world.data.mon_menu_icon(CYNDAQUIL),
+			"facing": _world.player_facing,
+			"position_cells": Vector2(_cell()),
+		}
+		if _petted:
+			entry["emote"] = Gen2WorldActors.EMOTE_HEART
+		return [entry]
+
+	func interact(cell: Vector2i, _facing: int) -> bool:
+		if cell != _cell():
+			return false
+		_petted = true
+		return true
+
+	func take_requests() -> Array:
+		if not _petted or _cried:
+			return []
+		_cried = true
+		return [{"kind": Gen2WorldActors.REQUEST_CRY, "species": CYNDAQUIL}]
+
+	## The faced cell, so a press with nothing in front of the player reaches it.
+	func _cell() -> Vector2i:
+		return _world.facing_cell()
 
 
 ## Public screenshot driver for `Script_pokepic`'s box. The scripts that run one
@@ -2840,15 +2909,10 @@ func _open_pokedex() -> void:
 	_refresh_labels()
 
 
-## The entry screen's CRY button. `PlayCry` is an effect, not music, so it goes
-## through the same player a script's `cry` command does.
+## The entry screen's CRY button, which is one caller of [method
+## _play_species_cry] rather than a path of its own.
 func _on_pokedex_cry_requested(species: int) -> void:
-	if _audio_player == null or _data == null:
-		return
-	var record: Dictionary = _data.species_cry(species)
-	if record.is_empty():
-		return
-	_audio_player.play_record(record, &"cry", _audio_assets())
+	_play_species_cry(species)
 
 
 func _on_pokedex_closed() -> void:
@@ -4149,6 +4213,61 @@ func _play_current_map_music() -> void:
 	if record.is_empty():
 		return
 	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
+## An actor's one-shot outbox, drained once a world frame. A mod may not play a
+## sound, so it asks for one and the host spends it: the same bargain the shiny
+## pulse already has, with no dedup window needed since the mod asks once.
+func _spend_actor_requests() -> void:
+	if _actors == null:
+		return
+	for request: Dictionary in _actors.take_requests():
+		if StringName(request["kind"]) == Gen2WorldActors.REQUEST_CRY:
+			_play_species_cry(int(request["species"]))
+
+
+## A mod's hidden-item asks, spent on the first world frame nothing else owns.
+## The map's own script runs through the ordinary path, so the box, the fanfare
+## and the pacing are the world screen's exactly as they are for a player walking
+## onto the cell; the mod named a cell and nothing else.
+##
+## Only one is spent per frame, since the first one's script owns the world until
+## its box is pressed past, and the rest wait in the host's queue.
+func _spend_hidden_item_requests() -> void:
+	if _world == null or not _world_idle_for_mod_request():
+		return
+	var requests: Array[Vector2i] = Gen2ModHost.instance().take_hidden_item_requests()
+	for index: int in requests.size():
+		var results: Array = _world.take_hidden_item(requests[index])
+		if results.is_empty():
+			continue
+		_zero_map_name_sign_timer()
+		_show_script_results(results)
+		## What is left goes back, in order, rather than being dropped on the
+		## floor by the drain that could only spend one of them.
+		Gen2ModHost.instance().requeue_hidden_items(requests.slice(index + 1))
+		return
+
+
+## Nothing of the world's own is running, which is the gate [method interact]
+## applies plus a box or a script still holding the screen: a request may not
+## open a text box over one that is already up.
+func _world_idle_for_mod_request() -> bool:
+	return not _overlay_open() and not _field_move_text \
+		and _oak_pc_pages.is_empty() and not _world.phone_ring_active() \
+		and not _world.fishing_busy() and not _world.script_busy() \
+		and (_text_box == null or not _text_box.visible)
+
+
+## `Script_cry`'s own path and the Pokedex CRY button's: `PlayCry` is an effect
+## and not music, so it goes through the player a script's `cry` command uses.
+func _play_species_cry(species: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	var record: Dictionary = _data.species_cry(species)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"cry", _audio_assets())
 
 
 func _play_ledge_hop_sfx() -> void:

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -37,6 +37,7 @@ func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
 	_add_an_item_and_its_shelf(host, manifest.id)
 	_add_a_control(host, manifest.id)
 	_populate_the_map(host, manifest.id)
+	_walk_something_behind_the_player(host, manifest.id)
 	_rebalance(host, manifest.id)
 	_watch(host, manifest.id)
 
@@ -202,6 +203,15 @@ func _populate_the_map(host: Gen2ModHost, id: StringName) -> void:
 	host.register_visible_encounters(id, Population.new())
 
 
+## One sprite in the world, petted and picking things up (`api_version` 7).
+##
+## An actor is PRESENTATION: it occupies no cell, blocks nothing and is in no
+## snapshot. The three methods below it are required; `interact`, `take_requests`
+## and a `sprites()` entry's `emote` are the optional three that make it a pet.
+func _walk_something_behind_the_player(host: Gen2ModHost, id: StringName) -> void:
+	host.register_world_actor(id, Pet.new())
+
+
 ## Rewriting how an event is PRESENTED, without changing what happened
 ## (`api_version` 4).
 ##
@@ -222,6 +232,74 @@ func _dress_world_event(result: Dictionary) -> Dictionary:
 		event["text"] = String(event.get("text", "")).replace("PIKACHU", "VOLTLING")
 		result["event"] = event
 	return result
+
+
+## A Pokemon walking one cell behind the player, which is what a follower mod is,
+## and every optional half of the actor contract in one object.
+class Pet:
+	extends RefCounted
+
+	## How long the heart stays up after a press, in world frames. The mod owns
+	## the duration because the emote is a pose the host draws while it is asked
+	## for, rather than an edge the host times.
+	const HEART_FRAMES: int = 60
+	const CYNDAQUIL: int = 155
+
+	var _world: Gen2WorldAPI = null
+	var _heart: int = 0
+	var _outbox: Array = []
+
+	func set_world(world: Gen2WorldAPI) -> void:
+		_world = world
+
+	func advance_frame() -> void:
+		_heart = maxi(0, _heart - 1)
+		_pick_up_what_it_walked_over()
+
+	func sprites() -> Array:
+		if _world == null:
+			return []
+		var entry: Dictionary = {
+			"icon": _world.data.mon_menu_icon(CYNDAQUIL),
+			"facing": _world.player_facing,
+			"position_cells": Vector2(_cell()),
+		}
+		if _heart > 0:
+			entry["emote"] = Gen2WorldActors.EMOTE_HEART
+		return [entry]
+
+	## Offered only a press no cartridge object, background event or tile branch
+	## answered, so this can never shadow one. Answering true consumes it.
+	func interact(cell: Vector2i, _facing: int) -> bool:
+		if _world == null or cell != _cell():
+			return false
+		_heart = HEART_FRAMES
+		## A mod may not play a sound, so it asks and the host spends it.
+		_outbox.append({"kind": Gen2WorldActors.REQUEST_CRY, "species": CYNDAQUIL})
+		return true
+
+	## The one-shot outbox, drained once a world frame and emptied by the drain.
+	func take_requests() -> Array:
+		var out: Array = _outbox
+		_outbox = []
+		return out
+
+	## And the other half a follower wants: a hidden item under the cell it is
+	## standing on. The mod reads the map and names the cell; taking one is the
+	## HOST's, because it writes the bag, the flag and the save.
+	func _pick_up_what_it_walked_over() -> void:
+		if _world == null:
+			return
+		for record: Dictionary in _world.hidden_items():
+			if bool(record["taken"]) or (record["cell"] as Vector2i) != _cell():
+				continue
+			Gen2ModHost.instance().request_hidden_item(record["cell"])
+			return
+
+	## One cell behind the player, which is where a follower walks: the faced
+	## cell reflected through the player, so no direction table is needed here.
+	func _cell() -> Vector2i:
+		return _world.player_cell - (_world.facing_cell() - _world.player_cell)
 
 
 ## The population itself. A separate object because a provider is a RefCounted

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 6,
+	"api_version": 7,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 6,
+	"api_version": 7,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -576,3 +576,137 @@ func test_the_grass_over_a_sprite_leaves_the_transition_s_own_cells_to_it() -> v
 		"a rectangle straddling the grid is split on it, not dropped whole"
 	)
 	renderer.free()
+
+
+## The optional half of the actor contract, through the production path: the
+## press only the actors are offered, the emote a renderer reads off the same
+## resolved list, and the cry the host plays because a mod may not.
+const PET_ACTOR_SOURCE: String = """extends RefCounted
+
+var world = null
+var petted: bool = false
+var pressed: Array = []
+var cries: Array = []
+
+func set_world(value) -> void:
+	world = value
+
+func advance_frame() -> void:
+	pass
+
+func sprites() -> Array:
+	var entry: Dictionary = {"icon": 1, "position_cells": Vector2(7, 7)}
+	if petted:
+		entry["emote"] = 4
+	return entry_list(entry)
+
+func entry_list(entry: Dictionary) -> Array:
+	return [entry]
+
+func interact(cell: Vector2i, facing: int) -> bool:
+	pressed.append(cell)
+	if cell != Vector2i(7, 7):
+		return false
+	petted = true
+	cries.append({"kind": &"cry", "species": 155})
+	return true
+
+func take_requests() -> Array:
+	var out: Array = cries
+	cries = []
+	return out
+"""
+
+
+func test_an_actor_is_offered_the_press_and_the_host_spends_its_cry() -> void:
+	var actor: Object = _script(PET_ACTOR_SOURCE).new()
+	assert_true(Gen2ModHost.instance().register_world_actor(&"pet", actor)["ok"])
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen.set_process(false)
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+	assert_true(_world_screen.interact(), "The faced cell is the actor's own.")
+	assert_eq(actor.get("pressed"), [Vector2i(7, 7)], "facing_cell(), not the player's")
+	assert_eq(
+		int(_world_screen._actors.sprites()[0]["emote"]), Gen2WorldActors.EMOTE_HEART,
+		"The pose the press changed is drawn on the frame it was pressed."
+	)
+	## The outbox is drained by the world frame, not by the press.
+	assert_eq((actor.get("cries") as Array).size(), 1)
+	_world_screen.advance_frames(1)
+	assert_eq((actor.get("cries") as Array).size(), 0, "One drain empties it.")
+
+
+## An actor may never shadow a cartridge interaction: the press reaches it only
+## when `Gen2WorldAPI.interact()` answered nothing at all.
+func test_an_actor_is_not_offered_a_press_a_cartridge_object_answered() -> void:
+	var actor: Object = _script(PET_ACTOR_SOURCE).new()
+	assert_true(Gen2ModHost.instance().register_world_actor(&"pet", actor)["ok"])
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen.set_process(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	var object: Gen2WorldObject = world.objects[0]
+	object.active = true
+	object.cell = Vector2i(7, 7)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+	assert_true(_world_screen.interact())
+	assert_eq(actor.get("pressed"), [], "The object answered, so nothing was offered.")
+
+
+## R27's bargain: the mod names a cell and the HOST runs the map's own script, so
+## the bag, the event flag, the text box and the fanfare stay the world's.
+func test_a_mods_hidden_item_request_runs_the_maps_own_script_when_the_world_is_idle() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts["48:6300"] = [40, 0, 3, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_data = GameData.open_directory(Fixture.directory())
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen.set_process(false)
+	var world: Gen2WorldAPI = _world_screen._world
+	world.current_map.events["bg_events"] = [
+		{"x": 2, "y": 3, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6300},
+	]
+
+	var listed: Array = world.hidden_items()
+	assert_eq(listed.size(), 1, JSON.stringify(listed))
+	assert_eq(listed[0]["cell"], Vector2i(2, 3))
+	assert_false(bool(listed[0]["taken"]))
+
+	## Nowhere near the player and never faced: naming the cell is the whole ask.
+	Gen2ModHost.instance().request_hidden_item(Vector2i(2, 3))
+	_world_screen.advance_frames(1)
+	assert_true(world.script_busy(), "The map's own script is running, in the world's own box.")
+	assert_true(_world_screen._text_box.visible)
+	assert_true(
+		("Found" in _world_screen._text_box.text_lines()[0]),
+		"`verbosegiveitem`'s own FOUND text, in the world's own box."
+	)
+	## What the script does from there is the world's, and is covered where the
+	## `hiddenitem` path is owned (`test_world_api.gd`). What is this layer's is
+	## that the ask was spent exactly once: the queue is empty, and the following
+	## frames do not run it again while its own box is still up.
+	assert_eq(Gen2ModHost.instance().take_hidden_item_requests(), [])
+	_world_screen.advance_frames(3)
+	assert_eq(world.state.items().get(3, 0), 0, "The receipt has not been pressed past.")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -7061,3 +7061,85 @@ func test_opening_a_world_carries_and_installs_its_rules() -> void:
 	assert_not_null(plain.rules, "a world opened without rules plays the installed set")
 	assert_false(Gen2Rules.hardware(&"belly_drum_boosts_below_half_hp"))
 	Gen2Rules.install(null)
+
+
+## The public read a mod plans a pickup from: every BGEVENT_ITEM on the map,
+## taken or not, and never the Itemfinder's one bool over its own window.
+func test_hidden_items_lists_every_record_on_the_map_with_its_flag() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6200"] = [30, 0, 3, Gen2WorldScript.END]
+	scripts["48:6208"] = [31, 0, 4, Gen2WorldScript.END]
+	# A third whose item byte is zero: it decodes to nothing and is dropped
+	# rather than offered with a zero item.
+	scripts["48:6210"] = [32, 0, 0, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+	world.current_map.events["bg_events"] = [
+		{"x": 8, "y": 6, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6200},
+		{"x": 2, "y": 2, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6208},
+		{"x": 3, "y": 3, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6210},
+		{"x": 4, "y": 4, "type": Gen2WorldAPI.BGEVENT_READ, "script": 0x6200},
+	]
+	world.set_event_flag(31)
+
+	var listed: Array = world.hidden_items()
+	assert_eq(listed.size(), 2, JSON.stringify(listed))
+	assert_eq(listed[0]["cell"], Vector2i(8, 6))
+	assert_eq(int(listed[0]["item"]), 3)
+	assert_eq(int(listed[0]["flag"]), 30)
+	assert_false(bool(listed[0]["taken"]))
+	assert_eq(listed[1]["cell"], Vector2i(2, 2))
+	assert_true(bool(listed[1]["taken"]), "A set flag is listed as taken, not dropped.")
+	# The Itemfinder is the same walk narrowed to its window and the untaken.
+	world.player_cell = Vector2i(8, 6)
+	assert_true(world.hidden_item_nearby())
+	world.set_event_flag(30)
+	assert_false(world.hidden_item_nearby())
+
+
+## The mod names a cell; the map's own script runs through the ordinary path, so
+## the box, the flag, the bag and the pack-full branch are all the host's.
+func test_take_hidden_item_runs_the_maps_own_script_from_a_named_cell() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6218"] = [33, 0, 3, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+	world.current_map.events["bg_events"] = [
+		{"x": 2, "y": 5, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6218},
+	]
+	# Nowhere near the player and not the cell being faced: naming it is the
+	# whole ask, which is what makes a follower's own cell reachable.
+	assert_true(world.interact().is_empty())
+	assert_true(world.take_hidden_item(Vector2i(4, 4)).is_empty(), "A cell with no record.")
+
+	var results: Array = world.take_hidden_item(Vector2i(2, 5))
+	assert_eq(results.size(), 1, JSON.stringify(results))
+	assert_eq(results[0]["source"]["kind"], &"hidden_item")
+	assert_eq(results[0]["event"]["text"], "Found\n%s!" % _item_name(3))
+	_receipt_sound(world, &"special_sound")
+	assert_eq(_receipt_notify(world, 3)[0]["status"], &"complete")
+	assert_eq(world.state.items().get(3, 0), 1)
+	assert_true(world.event_flag_active(33))
+	# And the flag it wrote closes it, the way a second A press on one is inert.
+	assert_true(world.take_hidden_item(Vector2i(2, 5)).is_empty())
+	assert_eq(world.state.items().get(3, 0), 1)
+
+
+## A request may not cut into a script that is already running.
+func test_take_hidden_item_refuses_while_a_script_is_running() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6220"] = [34, 0, 3, Gen2WorldScript.END]
+	scripts["48:6228"] = [35, 0, 4, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+	world.current_map.events["bg_events"] = [
+		{"x": 8, "y": 6, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6220},
+		{"x": 2, "y": 5, "type": Gen2WorldAPI.BGEVENT_ITEM, "script": 0x6228},
+	]
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_eq(world.interact().size(), 1, "The faced record is waiting on its box.")
+	assert_true(world.take_hidden_item(Vector2i(2, 5)).is_empty())
+	assert_false(world.event_flag_active(35))

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -355,3 +355,114 @@ func test_the_heal_machine_draws_nothing_for_an_empty_party() -> void:
 	var effects := Gen2WorldEffects.new()
 	effects.start_heal_machine(0, 0)
 	assert_false(effects.sprites_active())
+
+
+## The optional half of an actor's contract: an actor that defines neither is
+## offered neither, which is what keeps every actor already written working.
+class TestPetActor extends TestActor:
+	var pressed: Array = []
+	var answer: bool = true
+	var outbox: Array = []
+
+	func interact(cell: Vector2i, facing: int) -> bool:
+		pressed.append({"cell": cell, "facing": facing})
+		return answer
+
+	func take_requests() -> Array:
+		var taken: Array = outbox
+		outbox = []
+		return taken
+
+
+func test_an_actor_without_the_optional_methods_is_offered_neither() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([TestActor.new()])
+	actors.set_world(world)
+	assert_false(actors.interact(Vector2i(4, 3), Gen2WorldSprite.FACING_UP))
+	assert_eq(actors.take_requests(), [])
+	RomCache.clear(ActorFixture.directory())
+
+
+func test_the_first_actor_answering_a_press_consumes_it() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var first := TestPetActor.new()
+	first.answer = false
+	var second := TestPetActor.new()
+	var third := TestPetActor.new()
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([first, second, third])
+	actors.set_world(world)
+	assert_true(actors.interact(Vector2i(4, 3), Gen2WorldSprite.FACING_UP))
+	assert_eq(first.pressed.size(), 1, "Registration order, and the refusal moves on.")
+	assert_eq(second.pressed[0]["cell"], Vector2i(4, 3))
+	assert_eq(int(second.pressed[0]["facing"]), Gen2WorldSprite.FACING_UP)
+	assert_eq(third.pressed.size(), 0, "The first true consumes the press.")
+	RomCache.clear(ActorFixture.directory())
+
+
+## A pose the press changed is on screen on the frame it was pressed, rather
+## than waiting for the next advance.
+func test_a_consumed_press_recollects_the_sprites() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestPetActor.new()
+	actor.out = [{"icon": 1, "position_cells": Vector2(4, 4)}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_eq(int(actors.sprites()[0]["emote"]), Gen2WorldActors.EMOTE_NONE)
+	actor.out = [{
+		"icon": 1, "position_cells": Vector2(4, 4), "emote": Gen2WorldActors.EMOTE_HEART,
+	}]
+	actors.interact(Vector2i(4, 3), Gen2WorldSprite.FACING_UP)
+	assert_eq(int(actors.sprites()[0]["emote"]), Gen2WorldActors.EMOTE_HEART)
+	RomCache.clear(ActorFixture.directory())
+
+
+## An index outside `RomLayout.EMOTE_NAMES` is no emote rather than a wrong
+## sheet, the way art the cache does not carry is dropped.
+func test_an_out_of_range_emote_is_no_emote() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{"icon": 1, "position_cells": Vector2.ZERO, "emote": RomLayout.EMOTE_COUNT}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_eq(int(actors.sprites()[0]["emote"]), Gen2WorldActors.EMOTE_NONE)
+	RomCache.clear(ActorFixture.directory())
+
+
+## An emote is state, so putting one up is a change the screen redraws for.
+func test_raising_an_emote_is_a_change_the_frame_reports() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{"icon": 2, "position_cells": Vector2.ZERO}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	assert_false(actors.advance_frame(), "A standing sprite is not a change.")
+	actor.out = [{
+		"icon": 2, "position_cells": Vector2.ZERO, "emote": Gen2WorldActors.EMOTE_HEART,
+	}]
+	assert_true(actors.advance_frame())
+	RomCache.clear(ActorFixture.directory())
+
+
+func test_the_outbox_passes_a_cry_and_drops_everything_else() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestPetActor.new()
+	actor.outbox = [
+		{"kind": &"cry", "species": 155},
+		{"kind": &"cry", "species": 0},
+		{"kind": &"warp", "map": Vector2i(1, 1)},
+		"not a dictionary",
+	]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	var taken: Array = actors.take_requests()
+	assert_eq(taken.size(), 1, "A zero species, an unknown kind and a non-entry are dropped.")
+	assert_eq(StringName(taken[0]["kind"]), Gen2WorldActors.REQUEST_CRY)
+	assert_eq(int(taken[0]["species"]), 155)
+	assert_eq(actors.take_requests(), [], "The drain empties the outbox.")
+	RomCache.clear(ActorFixture.directory())

--- a/tools/checks/item_balls.gd
+++ b/tools/checks/item_balls.gd
@@ -90,6 +90,7 @@ func run(r: RefCounted) -> void:
 		_verify_hm07(data, game_id)
 		_verify_route_44(data, game_id)
 		_verify_hidden_items(data, game_id)
+		_sweep_the_public_read(data, game_id)
 
 
 ## The one that unblocks the route: picking HM07 up puts Waterfall in the bag,
@@ -248,6 +249,72 @@ func _verify_hidden_items(data: GameData, game_id: StringName) -> void:
 				and int(world.state.items().get(item, 0)) == 1,
 			"%s: the hidden item on %s can be picked up twice." % [game_id, cell]
 		)
+
+
+## `Gen2WorldAPI.hidden_items()` over EVERY map of the cartridge, which is the
+## only thing that can say the public read agrees with the dispatch the two
+## cases above drive one map at a time.
+##
+## What it proves, over every record rather than the two driven above: each one
+## decodes on a fresh state, none of them reads as already taken, and the read
+## and the ask agree on the item and the flag for every one of them.
+##
+## What it does NOT prove, and the reason is worth keeping so it is not chased
+## again: `_hidden_item_record` addresses the gameplay catalog's patch by
+## `event_index`, and on an unpatched cache `_catalogued_item` falls back to the
+## record's own byte, so a wrong index is inert over the whole corpus. It bites
+## only where a mod has moved what is in a hidden item, and the read is stamped
+## by `events_at()`'s own rule rather than by a second copy of it for that
+## reason. Maps carrying more than one record are counted below because that is
+## the population such a patch would be visible on.
+func _sweep_the_public_read(data: GameData, game_id: StringName) -> void:
+	var maps: int = 0
+	var records: int = 0
+	var multiples: int = 0
+	for map: Gen2WorldMap in data.world_maps():
+		var id := Vector2i(map.group, map.number)
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(
+			data, id.x, id.y, Vector2i.ZERO, Gen2WorldState.new()
+		)
+		if world == null or world.current_map == null:
+			continue
+		maps += 1
+		var listed: Array = world.hidden_items()
+		if listed.size() > 1:
+			multiples += 1
+		for record: Dictionary in listed:
+			records += 1
+			var cell: Vector2i = record["cell"]
+			if bool(record["taken"]):
+				_r.fail("%s: %s %s is taken on a fresh state." % [game_id, id, cell])
+				continue
+			## The ask and the press must decode the same record. `take_hidden_item`
+			## runs it, so a fresh world per record rather than one per map.
+			var asked: Gen2WorldAPI = Gen2WorldAPI.open(
+				data, id.x, id.y, Vector2i.ZERO, Gen2WorldState.new()
+			)
+			var results: Array = asked.take_hidden_item(cell)
+			if not _r.check(
+				results.size() == 1
+					and StringName(results[0].get("source", {}).get("kind", &"")) == &"hidden_item",
+				"%s: %s %s did not run as a hidden item when asked for." % [game_id, id, cell]
+			):
+				continue
+			var source: Dictionary = results[0].get("source", {})
+			_r.check(
+				int(source.get("item", -1)) == int(record["item"])
+					and int(source.get("flag", -1)) == int(record["flag"]),
+				"%s: %s %s reads item $%02x flag %d and runs item $%02x flag %d." % [
+					game_id, id, cell, int(record["item"]), int(record["flag"]),
+					int(source.get("item", -1)), int(source.get("flag", -1)),
+				]
+			)
+	_r.check(records > 0, "%s: no hidden item was listed on any map." % game_id)
+	## Without a map carrying two, the `event_index` invariant above is untested.
+	_r.check(multiples > 0, "%s: no map carries two hidden items." % game_id)
+	print("  %s hidden_items: %d maps, %d records, %d maps with more than one" % [
+		game_id, maps, records, multiples,
+	])
 
 
 func _open(data: GameData, id: Array, cell: Vector2i) -> Gen2WorldAPI:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -29,6 +29,8 @@ extends SceneTree
 ## (`BuyMenu`, talked open from the cell in front of a shop's counter, as
 ## `crystal 1 8 ... mart 3 3`), `pokepic`
 ## (`Script_pokepic`'s box over the map, holding Chikorita),
+## `pet_actor` (a mod's world actor one cell in front of the player, pressed with
+## A so it wears the heart `showemote` puts over a map object),
 ## `warp` (`MapSetupScript_Door` at its whitest: the player is walked up onto the
 ## warp tile named by the two numbers below it, and the picture is
 ## `FadeOutToWhite`'s last order, which is the frame the new map is loaded on:


### PR DESCRIPTION
Answers the mod repository's R26 and R27, both of which were entirely engine-blocked. `api_version` 7.

## R26, petting a world actor

Three gaps rather than one, and all three are host input, host art and host audio.

- An actor takes an optional `interact(cell, facing) -> bool`, offered in registration order and **only** after `Gen2WorldAPI.interact()` answered an empty array, so no cartridge object, background event or tile branch can be shadowed by a mod. The first actor answering true consumes the press; nothing else about it is spent, so the map name sign stands. An actor without the method is offered nothing.
- A `sprites()` entry takes an optional `emote`, one of the twelve named as `Gen2WorldActors.EMOTE_SHOCK` to `EMOTE_GRASS_RUSTLE`, drawn by the same `_draw_emote` a map object's `showemote` reaches. State rather than an edge: the mod owns the duration, the host owns the pixels, and a renderer reading `set_actors` gets it for free.
- An actor takes an optional `take_requests()` outbox, drained once a world frame, whose one kind is `{kind: &"cry", species: n}`. A mod may not play a sound, so it asks and the host spends it, which is the shiny pulse's own bargain.

A consumed press re-collects the sprites on the frame it was pressed rather than waiting for the next advance, which is what puts the heart up on the same frame as the cry.

## R27, hidden items a mod can see and ask for

- `Gen2WorldAPI.hidden_items()` is the public scene-free read: one `{cell, item, flag, taken}` per `BGEVENT_ITEM` on the map, taken or not, beside `visible_encounter_cells()`. `hidden_item_nearby()` is that walk narrowed to the Itemfinder's window rather than a second copy of it.
- `Gen2ModHost.request_hidden_item(cell)` is the ask, queued and spent by the world screen on the first frame nothing else owns. What runs is the map's **own** script through the ordinary path, so the bag, the event flag, the save, `verbosegiveitem`'s FOUND text, its fanfare and its pack-full branch are all the host's exactly as they are for a player walking onto the cell. One is spent per frame and the rest go back in the queue in order.

## Two bugs met on the way, fixed in the same commit

- `_hidden_item_record` addresses the gameplay catalog's patch by an event's place in its own `bg_events` list, and only `events_at()` stamps that index. Both new entry points go through the stamping rather than the raw array; without it the request could not be built at all, and a patched read would report the first record's item for every record on the map.
- The cry was written twice in `world_screen.gd`, the Pokedex CRY button and the new outbox. `_play_species_cry` is the one path both call.

## Proof

| Artefact | Result |
|---|---|
| GUT, both tiers | 3,294 tests over 152 scripts, green (3,282 before) |
| `validate.gd -- all` | exit 0, 55 topics |
| `replay_world.gd` | green on all three cartridges |
| three-profile story walk | green on all three, no errors and no failed step |
| boot smoke, with and without mods | clean |
| `item_balls` sweep | 259 records over 1,124 maps on all three: every one decodes, none reads as taken on a fresh state, and the read and the ask agree on the item and the flag |

`mods/examples/new_content` demonstrates all of it, since that example is the contract's documentation and `test_mod_registries.gd` fails a host bump that leaves it behind. `preview_world.gd -- <game> <group> <map> <png> live pet_actor <x> <y>` is the picture.