### PR TITLE
Redraw on the frame an actor consumes a press

### DIFF
--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1289,8 +1289,18 @@ func interact() -> bool:
 		## nothing: an actor can never shadow an object, a background event or a
 		## tile branch. Its own pose is all it changes, so no player event is
 		## spent and the sign timer stands.
-		return _actors != null \
-			and _actors.interact(_world.facing_cell(), _world.player_facing)
+		if _actors == null \
+			or not _actors.interact(_world.facing_cell(), _world.player_facing):
+			return false
+		## On the frame of the press, which is what the offer promises. The
+		## actor layer re-collects where the press is consumed, so nothing after
+		## this sees a change to redraw for: `advance_frame` would compare a list
+		## already carrying the new pose against itself and skip its own refresh,
+		## and the picture would wait for the next unrelated change, which for a
+		## mon icon is its two-frame flip nine frames later.
+		if _renderer != null:
+			_renderer.refresh()
+		return true
 	## `OWPlayerInput`, the last branch `PlayerEvents` tries, and a player event
 	## like the rest of them.
 	_zero_map_name_sign_timer()
@@ -1539,10 +1549,12 @@ func preview_pet_actor() -> void:
 	## the sprite, is clear of the player rather than behind them.
 	_world.player_facing = Gen2WorldSprite.FACING_UP
 	_actors.set_actors([PreviewPet.new(_world)])
+	## Deliberately NOT followed by a refresh of its own, unlike the other
+	## drivers here: the press is what has to reach the picture, and a driver
+	## redrawing after it would photograph a heart that never arrived on the
+	## frame it was pressed.
 	interact()
-	advance_frames(1)
 	_script_prompt = "Debug pet actor preview"
-	_renderer.refresh()
 	_refresh_labels()
 
 

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -710,3 +710,47 @@ func test_a_mods_hidden_item_request_runs_the_maps_own_script_when_the_world_is_
 	assert_eq(Gen2ModHost.instance().take_hidden_item_requests(), [])
 	_world_screen.advance_frames(3)
 	assert_eq(world.state.items().get(3, 0), 0, "The receipt has not been pressed past.")
+
+
+## A renderer that counts what it was asked to redraw, which is the only way to
+## say WHEN a change reached the picture rather than whether the pose is right.
+const COUNTING_SOURCE: String = """extends Node2D
+
+var refreshes: int = 0
+
+func set_world(_world, _animation = null) -> void:
+	pass
+
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+
+func refresh() -> void:
+	refreshes += 1
+
+func refresh_animation() -> void:
+	pass
+"""
+
+
+## A consumed press has to reach the picture ON THE FRAME OF THE PRESS. The actor
+## layer re-collects where it consumes one, so nothing after it sees a change to
+## redraw for: without this the emote waits for the next unrelated change, which
+## for a mon icon is its own two-frame flip nine frames later.
+func test_a_consumed_press_redraws_on_the_frame_it_was_pressed() -> void:
+	var actor: Object = _script(PET_ACTOR_SOURCE).new()
+	assert_true(Gen2ModHost.instance().register_world_actor(&"pet", actor)["ok"])
+	var renderer: Node = await _open_world(COUNTING_SOURCE)
+	_world_screen.set_process(false)
+	_world_screen._world.player_facing = Gen2WorldSprite.FACING_DOWN
+
+	var before: int = int(renderer.get("refreshes"))
+	assert_true(_world_screen.interact())
+	assert_gt(
+		int(renderer.get("refreshes")), before,
+		"the press drew nothing on its own frame"
+	)
+	## And the frames after it do not depend on an unrelated change to catch up:
+	## the emote is already on screen, so the icon's flip is all that is left.
+	assert_eq(
+		int(_world_screen._actors.sprites()[0]["emote"]), Gen2WorldActors.EMOTE_HEART
+	)


### PR DESCRIPTION
Answers the mod repository's R28, which is a real defect in R26 rather than a request.

## What was wrong

`Gen2WorldActors.interact()` re-collects where it consumes a press, so the new pose was current and nothing after it had a change to redraw for:

- `Gen2WorldScreen.interact()` returned the bool without touching the renderer, so nothing queued a redraw on the frame of the press;
- and the next `advance_frame()` compared a list that already carried the emote against itself, answered false, and skipped its own refresh as well.

So the emote waited for the next unrelated change, which for a mon icon is its own two-frame flip nine frames later. The mod repository measured it: the same capture command run three times drew the heart once, with the resolved entry carrying `emote 4` in all three.

The press refreshes the renderer now. That is the half that keeps the frame of the press the offer promises, rather than dropping the `_collect()` and letting the next frame catch it.

## What hid it, and now proves it

`preview_pet_actor` ended on a `_renderer.refresh()` of its own, which every other driver in that file does, so it photographed a picture the **driver** drew rather than the one the press did. It deliberately has none now, so the screenshot is a real acceptance check for this path.

| Proof | Result |
|---|---|
| `test_a_consumed_press_redraws_on_the_frame_it_was_pressed` | counts the renderer's own refreshes; fails on the old code with 0 |
| `preview_world.gd -- crystal 24 4 <png> live pet_actor 5 6`, three runs | byte-identical, heart present in each, with no driver refresh after the press |
| GUT, both tiers | 3,295 over 152 scripts, green |
| `validate.gd -- all` | exit 0, 55 topics |
| `replay_world.gd`, three-profile story walk, boot smoke with and without mods | green, no errors |

The mod repository's other finding, that petting is reachable only because a press in a new direction turns before it steps, needs no change here: that is `DoPlayerMovement`'s own branch, already built and cited at `world_api.gd`'s `player_input_move`, and it is the input path's alone.