### PR TITLE
Give Gold's battle slide its last sprite step, and three sounds their sources

### DIFF
--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -63,7 +63,7 @@ const SPRITE_FIRST_Y: int = 8 * Gen2Tiles.TILE_HEIGHT
 ## `PLAYER_SIDE` rows to a column in `vTiles0`, which is where `CopyBackpic`
 ## decompressed the pic before copying it into `vTiles2 tile $31`.
 const SPRITE_PIC_ROWS: int = Gen2BattleScreenMap.PLAYER_SIDE
-## `.subfunction3` runs on every frame but the last, `cp $1 / jr z, .skip1`.
+## `dec [hl]` twice per sprite.
 const SPRITE_STEP: int = 2
 
 var _crystal: bool = true
@@ -101,18 +101,22 @@ func advance_frame() -> bool:
 ## eighteen sprites where this frame leaves them, each { tile, x, y } with OAM's
 ## own biased coordinates, which is what a renderer of one already takes.
 ##
-## Gold and Silver walk the same eighteen: `CopyBackpic` is shared and their own
-## `.subfunction1` steps them by two beside its `rSCX` writes. Crystal's walk is
-## measured against a real cartridge, sprite by sprite, from x 158 to 16; Gold's
-## is read from the source alone and its lead frame leaves it one step short at
-## the end, which no dump here has been asked about.
+## Gold and Silver walk the same eighteen: `.LoadTrainerBackpicAsOAM` is
+## byte-identical in both disassemblies and their own `.subfunction1` steps them
+## by two beside its `rSCX` writes. Crystal's walk is measured against a real
+## cartridge, sprite by sprite, from x 158 to 16, and Gold's ends on the same 16:
+## its lead frame spends no step, but its loop skips none either.
 func sprites() -> Array:
 	var out: Array = []
 	if finished():
 		# `HideSprites` runs the moment the slide returns, and `PlaceGraphic`
 		# puts the whole pic on the background instead.
 		return out
-	var walked: int = _sprite_steps()
+	# Crystal's `.subfunction3` is skipped on the loop's last pass, `cp $1 /
+	# jr z, .skip1`, so 72 of its 73 frames step. Gold and Silver spend their
+	# lead frame before the loop and then step on all 72 of its passes, with no
+	# such test. Both walks are 72 steps long and the frame index is the count.
+	var walked: int = _frame
 	for column: int in SPRITE_COLUMNS:
 		for row: int in SPRITE_ROWS:
 			out.append({
@@ -121,15 +125,6 @@ func sprites() -> Array:
 				"y": SPRITE_FIRST_Y + row * Gen2Tiles.TILE_HEIGHT,
 			})
 	return out
-
-
-## How many times `.subfunction3` has run. It is skipped on the loop's last pass,
-## so the walk is one shorter than the scroll, which is why the sprites stop two
-## pixels before the background does and `PlaceGraphic` is what lines them up.
-func _sprite_steps() -> int:
-	if _crystal:
-		return _frame
-	return maxi(_frame - GOLD_LEAD_FRAMES, 0)
 
 
 ## Per scanline in hardware draw order; an offset looks *right* into the map.

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -469,9 +469,9 @@ static func _animation_columns(animation: Dictionary, side: int) -> int:
 static func _append_animation(
 	data: GameData, animation: Dictionary, out: PackedByteArray, strip: int, side: int
 ) -> void:
-	var name: String = String(animation.get("atlas", ""))
+	var atlas: String = String(animation.get("atlas", ""))
 	var cell: Dictionary = Gen2PicImage.atlas_cell(
-		data.atlas_indices(name), data.atlas(name), animation
+		data.atlas_indices(atlas), data.atlas(atlas), animation
 	)
 	if cell.is_empty():
 		return

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -24,6 +24,11 @@ signal closed
 ## player: the overworld's own answers it, the way it answers a script's cry.
 signal cry_requested(species: int)
 
+## `PlaySFX`, for the one sound this screen makes of its own:
+## `Pokedex_DisplayChangingModesMessage`'s. Answered by the overworld's player
+## the way [signal cry_requested] is.
+signal sfx_requested(index: int)
+
 enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA, UNOWN }
 
 ## The dex is drawn in hardware pixels and the start menu it opens over is
@@ -34,6 +39,12 @@ const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 ## `Pokedex_BlinkArrowCursor` counts its own frames and shows the arrow on the
 ## eight it is off `$8`, so the cursor is up for eight frames and down for eight.
 const CURSOR_BLINK_FRAMES: int = 8
+
+## `Pokedex_DisplayChangingModesMessage`'s two `ld c, 64` / `call DelayFrames`,
+## with `SFX_CHANGE_DEX_MODE` played between them.
+const CHANGING_MODES_FRAMES: int = 64
+## constants/sfx_constants.asm.
+const SFX_CHANGE_DEX_MODE: int = 0x5C
 
 ## `DexEntryScreen_ArrowCursorData`'s four positions, in its own order. PRNT
 ## wants a printer, which is deliberately out, so it is drawn and refuses.
@@ -53,6 +64,10 @@ var _option_cursor: int = 0
 ## `Pokedex_ReinitDexEntryScreen` puts back on PAGE for each new entry.
 var _entry_cursor: int = 0
 var _mode_rows: Array = []
+## Frames still owed to `Pokedex_DisplayChangingModesMessage`. The routine is a
+## pair of blocking `DelayFrames`, so nothing else on this screen runs while it
+## is above zero, the arrow's own blink included.
+var _changing_modes_frames: int = 0
 
 var _area: Gen2TownMapScreen = null
 
@@ -117,7 +132,7 @@ func current_mode() -> Mode:
 
 
 func handle_button(button: int) -> bool:
-	if _dex == null:
+	if _dex == null or _changing_modes_frames > 0:
 		return false
 	if _mode == Mode.AREA:
 		return _area.handle_button(button)
@@ -285,12 +300,15 @@ func _choose_mode() -> void:
 	if _dex.change_mode(int(row["mode"])):
 		_world.state.set_last_dex_mode(_dex.mode)
 		# `Pokedex_DisplayChangingModesMessage` puts its two lines in the option
-		# screen's own description box and spends 128 frames there. The message
-		# is drawn; the wait is not, since nothing here rebuilds an order slowly
-		# enough to need one.
+		# screen's own description box and holds there for 64 frames, the sound
+		# and 64 more. The listing opens when they are spent, which is
+		# `.skip_changing_mode` falling through to `Pokedex_BlackOutBG`.
 		_message = Gen2Pokedex.CHANGING_MODES_TEXT
+		_changing_modes_frames = CHANGING_MODES_FRAMES * 2
 		_refresh()
-		_message = ""
+		return
+	# `.skip_changing_mode`: the mode already in use shows no message and waits
+	# no frames.
 	_open_list_mode()
 
 
@@ -551,6 +569,13 @@ func _process(delta: float) -> void:
 
 
 func advance_frame() -> void:
+	if _changing_modes_frames > 0:
+		_changing_modes_frames -= 1
+		if _changing_modes_frames == CHANGING_MODES_FRAMES:
+			sfx_requested.emit(SFX_CHANGE_DEX_MODE)
+		elif _changing_modes_frames == 0:
+			_open_list_mode()
+		return
 	_blink = (_blink + 1) % (CURSOR_BLINK_FRAMES * 2)
 	if _blink == 0 or _blink == CURSOR_BLINK_FRAMES:
 		_refresh()

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -721,7 +721,6 @@ func _pack_cursor_on_cancel() -> bool:
 
 
 func _render_pack() -> void:
-	var pocket: Dictionary = _current_pocket()
 	_render_hardware()
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -177,11 +177,13 @@ var _replay_held_direction: int = Gen2Button.NONE
 ## Whether a frame is being spent right now, which is what tells a press
 ## delivered from inside the pump from one that arrived between two frames.
 var _spending_frame: bool = false
-## `HealMachineAnim`'s own sounds and the frame of its wait each is due on, taken
-## from the event the special emits and spent by [method advance_frame]. The
-## machine's two tiles are drawn alongside them by Gen2WorldEffects.
-var _heal_machine_sounds: Array = []
-var _heal_machine_frame: int = 0
+## A run of sounds the world owes the driver, spent one entry at a time by
+## [method advance_frame]: `HealMachineAnim`'s, whose entries are due on a frame
+## count of their own, and the ITEMFINDER's, whose are `WaitPlaySFX` and due when
+## the four effect channels are free. Nothing plays two at once, since the script
+## that started one is waiting on it.
+var _sound_schedule: Array = []
+var _sound_schedule_frame: int = 0
 var _screen_base_position: Vector2 = Vector2.ZERO
 
 @onready var _screen: Gen2Screen = %Screen
@@ -553,7 +555,7 @@ func advance_frame() -> void:
 		var wait_results: Array = _world.advance_script_wait_frame()
 		if not wait_results.is_empty():
 			_show_script_results(wait_results)
-	_advance_heal_machine_sounds()
+	_advance_sound_schedule()
 	## `_ContText`'s scroll ends on a frame rather than on a press, and the page
 	## it lands on may be the text's last, which is where the script runs on.
 	_continue_if_text_settled()
@@ -2916,6 +2918,7 @@ func _open_pokedex() -> void:
 	add_child(host)
 	host.closed.connect(_on_pokedex_closed)
 	host.cry_requested.connect(_on_pokedex_cry_requested)
+	host.sfx_requested.connect(_play_sfx)
 	_pokedex_host = host
 	_script_prompt = "Pokedex open"
 	_refresh_labels()
@@ -3088,6 +3091,11 @@ func _on_field_item_used(request: Dictionary) -> void:
 			select_fishing_rod(rods.find(StringName(request.get("rod", &""))))
 			start_fishing()
 		Gen2WorldPack.FIELD_EFFECT_ITEMFINDER:
+			## `.Script_FoundSomething` runs `.ItemfinderSound` before its line;
+			## `.Script_FoundNothing` plays nothing at all.
+			if bool(request.get("found", false)):
+				_start_sound_schedule(Gen2WorldScriptRunner.itemfinder_sounds())
+				_advance_sound_schedule()
 			_show_field_move_text(
 				_field_item_text(
 					"itemfinder_nearby",
@@ -3435,14 +3443,20 @@ func _run_heal_transfer(action: Dictionary) -> void:
 		_show_field_move_text("It won't have any effect.")
 		return
 	## `PARTYMENUTEXT_HEAL_HP`, which is the line every healing item shares.
-	_show_field_move_text("%s\nrecovered health!" % String(action.get("target_name", "")))
+	## `ItemActionText` is followed by `JoyWaitAorB`, which loads no cursor, so
+	## the line waits without an arrow the way `ProfOaksPCBoot`'s pages do.
+	_show_field_move_text(
+		"%s\nrecovered health!" % String(action.get("target_name", "")), false
+	)
 
 
-func _show_field_move_text(text: String) -> void:
+## [param blink_cursor] is whether the wait behind the line is one of the three
+## routines that call `LoadBlinkingCursor`, not whether it waits at all.
+func _show_field_move_text(text: String, blink_cursor: bool = true) -> void:
 	_field_move_text = true
 	if _text_box != null and _text_box.font != null:
 		_apply_text_box_options()
-		_text_box.show_text(text)
+		_text_box.show_text(text, blink_cursor)
 		_text_box.visible = true
 	_script_prompt = "A: continue"
 	_refresh_labels()
@@ -4295,32 +4309,46 @@ func _play_encounter_sounds() -> void:
 			_play_sfx(int((command["operands"] as Array)[1]))
 
 
-## The machine's sounds, started where the special asked for them. A schedule
-## already running is replaced rather than mixed: two heal machines cannot be
-## going at once, since the script that started the first is waiting for it.
+## The machine's sounds, started where the special asked for them.
 func _start_heal_machine_sounds(event: Dictionary) -> void:
-	_heal_machine_sounds = (event.get("sounds", []) as Array).duplicate(true)
-	_heal_machine_frame = 0
+	_start_sound_schedule((event.get("sounds", []) as Array).duplicate(true))
 	if _effects != null:
 		_effects.start_heal_machine(
 			int(event.get("machine_type", 0)), int(event.get("balls", 0))
 		)
-	_advance_heal_machine_sounds()
+	_advance_sound_schedule()
+
+
+func _start_sound_schedule(schedule: Array) -> void:
+	_sound_schedule = schedule
+	_sound_schedule_frame = 0
 
 
 ## One frame of that schedule, spent from the same pump the script's own wait is.
-func _advance_heal_machine_sounds() -> void:
-	if _heal_machine_sounds.is_empty():
-		return
-	while not _heal_machine_sounds.is_empty() \
-		and int(_heal_machine_sounds[0].get("frame", 0)) <= _heal_machine_frame:
-		var due: Dictionary = _heal_machine_sounds.pop_front()
+##
+## A `wait` entry is `WaitPlaySFX`, and it is a real wait only while the driver
+## is being serviced: a run with no audio device leaves the channels as the last
+## sound left them, so `effect_playing()` would answer true for the rest of the
+## run and the schedule would never drain. The rendered-frame count is what tells
+## the two apart, which is what the battle screen's own `ANIM_WAIT_SFX` does.
+func _advance_sound_schedule() -> void:
+	while not _sound_schedule.is_empty():
+		var due: Dictionary = _sound_schedule[0]
+		if bool(due.get("wait", false)):
+			if _audio_player != null and _audio_player.effect_playing():
+				var rendered: int = _audio_player.timeline_updates()
+				if int(due.get("rendered", -1)) != rendered:
+					due["rendered"] = rendered
+					break
+		elif int(due.get("frame", 0)) > _sound_schedule_frame:
+			break
+		_sound_schedule.pop_front()
 		var index: int = int(due.get("index", 0))
 		if StringName(due.get("kind", &"sound")) == &"music":
 			_play_music(index)
 		else:
-			_play_sfx(index)
-	_heal_machine_frame += 1
+			_play_sfx(index, bool(due.get("wait", false)))
+	_sound_schedule_frame += 1
 
 
 func _play_music(index: int) -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -126,6 +126,10 @@ const HEAL_MACHINE_FLASH_FRAMES: int = Gen2WorldEffects.HEAL_MACHINE_FLASHES \
 ## constants/sfx_constants.asm. The first is played once a ball by
 ## `.LoadBallsOntoMachine`; the other two are `.HOF_PlaySFX`'s pair.
 const SFX_SECOND_PART_OF_ITEMFINDER: int = 0x12
+## `ItemFinder.ItemfinderSound`'s other half, and `PlayTransactionSound`'s.
+const SFX_TRANSACTION: int = 0x22
+## `.ItemfinderSound`'s own `ld c, 4`.
+const ITEMFINDER_SFX_PASSES: int = 4
 const SFX_GAME_FREAK_LOGO_GS: int = 0xAA
 const SFX_BOOT_PC: int = 0x0D
 ## constants/music_constants.asm's MUSIC_HEAL, which `.PlayHealMusic` starts
@@ -2331,6 +2335,21 @@ static func heal_machine_sounds(machine_type: int, balls: int) -> Array:
 		})
 	else:
 		schedule.append({"frame": flashes_at, "kind": &"music", "index": MUSIC_HEAL})
+	return schedule
+
+
+## `ItemFinder.ItemfinderSound`, which its found branch runs as a `callasm`
+## before the line: four passes of `WaitPlaySFX SFX_SECOND_PART_OF_ITEMFINDER`
+## and `WaitPlaySFX SFX_TRANSACTION`. Each holds until the four effect channels
+## are free, so the eight are a run rather than eight sounds on one frame, and
+## `.Script_FoundNothing` has none of it.
+static func itemfinder_sounds() -> Array:
+	var schedule: Array = []
+	for _pass: int in ITEMFINDER_SFX_PASSES:
+		schedule.append({
+			"kind": &"sound", "wait": true, "index": SFX_SECOND_PART_OF_ITEMFINDER,
+		})
+		schedule.append({"kind": &"sound", "wait": true, "index": SFX_TRANSACTION})
 	return schedule
 
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -388,6 +388,29 @@ func test_a_field_item_closes_the_pack_and_answers_in_the_world() -> void:
 	assert_eq(_world_screen._world.state.item_quantity(ITEMFINDER), 1)
 
 
+## `ItemFinder.Script_FoundSomething` runs `.ItemfinderSound` in front of its
+## line and `.Script_FoundNothing` runs nothing, so the sounds are the branch's
+## rather than the item's. Driven through the screen's own handler, since the
+## schedule is spent by the world's pump as soon as it is started.
+func test_only_the_itemfinder_s_found_branch_owes_the_driver_its_sounds() -> void:
+	await _open_world()
+	_world_screen._on_field_item_used({
+		"effect": Gen2WorldPack.FIELD_EFFECT_ITEMFINDER, "item": ITEMFINDER,
+		"found": false,
+	})
+	assert_eq((_world_screen.get("_sound_schedule") as Array), [], "`.Script_FoundNothing`")
+
+	_world_screen._on_field_item_used({
+		"effect": Gen2WorldPack.FIELD_EFFECT_ITEMFINDER, "item": ITEMFINDER,
+		"found": true,
+	})
+	## With no audio device the driver is never busy, so `WaitPlaySFX` waits for
+	## nothing and the whole run is spent where it starts. What the test can see
+	## is that the run existed: the counter it was started with is back at one.
+	assert_eq(int(_world_screen.get("_sound_schedule_frame")), 1)
+	assert_eq((_world_screen.get("_sound_schedule") as Array), [], "all eight spent")
+
+
 ## `UseRod`: the rod the pack chose is the one `FishFunction` casts, and a cast
 ## it would refuse is `.FailFish`, which is `.Oak` with the pack still open.
 func test_a_rod_casts_from_the_pack_and_is_refused_away_from_water() -> void:
@@ -1295,6 +1318,44 @@ func test_unown_mode_is_offered_once_its_flag_is_set_and_returns_to_the_option_s
 		state.last_dex_mode(), RomLayout.DEXMODE_NEW,
 		"the listing keeps the mode it had"
 	)
+
+
+## `Pokedex_DisplayChangingModesMessage`: the OPTION screen holds its two lines
+## for 64 frames, plays `SFX_CHANGE_DEX_MODE`, holds 64 more and only then falls
+## through to the listing. `.skip_changing_mode` is the mode already in use,
+## which shows no message and waits nothing at all.
+func test_changing_the_dex_mode_holds_its_message_and_sounds_between_the_two_waits() -> void:
+	await _open_world()
+	_world_screen._world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX)
+	_world_screen._open_pokedex()
+	var dex: Gen2PokedexScreen = _world_screen._pokedex_host
+	var sounds: Array[int] = []
+	dex.sfx_requested.connect(func(index: int) -> void: sounds.append(index))
+
+	dex.handle_button(Gen2Button.SELECT)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.OPTION)
+	dex.handle_button(Gen2Button.DOWN)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.OPTION, "the message stands")
+	assert_eq(dex.get("_message"), Gen2Pokedex.CHANGING_MODES_TEXT)
+	assert_false(dex.handle_button(Gen2Button.B), "and nothing answers a press")
+
+	for _frame: int in Gen2PokedexScreen.CHANGING_MODES_FRAMES:
+		dex.advance_frame()
+	assert_eq(sounds, [Gen2PokedexScreen.SFX_CHANGE_DEX_MODE], "sounded halfway")
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.OPTION, "and still holding")
+	for _frame: int in Gen2PokedexScreen.CHANGING_MODES_FRAMES:
+		dex.advance_frame()
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.LIST)
+	assert_eq(dex.get("_message"), "", "the listing is drawn without it")
+
+	## The row the listing is already on is `.skip_changing_mode`.
+	var mode: int = _world_screen._world.state.last_dex_mode()
+	dex.handle_button(Gen2Button.SELECT)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.LIST, "no wait and no message")
+	assert_eq(sounds.size(), 1, "and no second sound")
+	assert_eq(_world_screen._world.state.last_dex_mode(), mode)
 
 
 ## `Pokedex_UpdateMainScreen`'s START reaches the search screen, and its CANCEL

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3230,6 +3230,23 @@ func test_heal_machine_sounds_follow_the_sequence_the_machine_type_selects() -> 
 	)
 
 
+## `ItemFinder.ItemfinderSound`: four passes of two `WaitPlaySFX`, so eight
+## entries that wait on the channels rather than on a frame count. The other
+## branch, `.Script_FoundNothing`, has no `callasm` at all.
+func test_the_itemfinder_sounds_are_eight_waited_effects_in_pairs() -> void:
+	var sounds: Array = Gen2WorldScriptRunner.itemfinder_sounds()
+	assert_eq(sounds.size(), Gen2WorldScriptRunner.ITEMFINDER_SFX_PASSES * 2)
+	for index: int in sounds.size():
+		var entry: Dictionary = sounds[index]
+		assert_true(bool(entry["wait"]), "every one of them is a `WaitPlaySFX`")
+		assert_false(entry.has("frame"), "and none is due on a count")
+		assert_eq(
+			int(entry["index"]),
+			Gen2WorldScriptRunner.SFX_TRANSACTION if index % 2 == 1 \
+				else Gen2WorldScriptRunner.SFX_SECOND_PART_OF_ITEMFINDER,
+		)
+
+
 func test_check_pokerus_special_reads_the_low_nibble_across_the_party_summary() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6360"] = [

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -296,6 +296,15 @@ func _verify_the_sliding_intro(game_id: StringName, data: GameData) -> void:
 		steps.size() <= 1 and (steps.is_empty() or steps.has(Gen2BattleIntro.SPRITE_STEP)),
 		"%s: the sprite walk steps %s, not two a frame." % [game_id, steps.keys()]
 	)
+	# Both games step 72 times: Crystal on 72 of its 73 frames (`.subfunction3`
+	# is skipped on the last) and Gold and Silver on all 72 passes of a loop
+	# their lead frame sits in front of. So the cartridge's own 158 down to 16.
+	# OAM's own x is eight to the right of the screen's.
+	var walk: Array = [] if xs.is_empty() else [int(xs[0]) - 8, int(xs[-1]) - 8]
+	_r.check(
+		walk == [158, 16],
+		"%s: the sprite walk runs %s, not 158 to 16." % [game_id, walk]
+	)
 
 	# `ClearBox` and `PlaceGraphic`: the map is missing the pic's top two tile
 	# rows for the slide and holds all six after it.


### PR DESCRIPTION
Four readings, each against the pinned disassemblies.

**Gold's battle slide.** `BattleIntroSlidingPics.subfunction1` has no
`cp $1 / jr z, .skip1` on pokegold; Crystal's `.subfunction3` is the one
skipped on its loop's last pass. Both that skip and Gold's lead frame were
being subtracted here, so the player's head and shoulders, which are the
eighteen OAM sprites `CopyBackpic.LoadTrainerBackpicAsOAM` writes, stopped
two pixels right of the body the background carries. The routine is
byte-identical in the two disassemblies, so the walks are 72 steps each and
both run the cartridge's own x 158 down to 16. `tools/checks/battle_anims.gd`
pins both ends on all three cartridges; before this it read 168 to 26 on
Gold and Silver and 166 to 24 on Crystal.

**The ITEMFINDER was silent.** `ItemFinder.Script_FoundSomething` runs
`.ItemfinderSound` in front of its line: four passes of `WaitPlaySFX
SFX_SECOND_PART_OF_ITEMFINDER` and `WaitPlaySFX SFX_TRANSACTION`.
`.Script_FoundNothing` runs none of it. The world screen's heal-machine
schedule is a general sound schedule now, so an entry may be due on a frame
count or on the four effect channels being free; the rendered-frame count is
what tells a serviced driver from an unserviced one, which is what the battle
screen's own `wait_sfx` already did.

**The Pokedex mode change showed nothing and sounded nothing.**
`Pokedex_DisplayChangingModesMessage` holds its two lines for 64 frames,
plays `SFX_CHANGE_DEX_MODE` and holds 64 more before `.skip_changing_mode`
falls through to the listing. The message was being drawn and overwritten
inside one call, so no frame of the game ever carried it. The mode already
in use still shows nothing and waits nothing.

**One more blinking arrow.** `Softboiled_MilkDrinkFunction` waits with
`JoyWaitAorB`, which loads no cursor, so its `PARTYMENUTEXT_HEAL_HP` line
should not blink one.

Green: 3,298 tests over 152 scripts, `validate.gd -- all` 54 topics passing,
`replay_world.gd` 11 routes 0 failures on all three, the three-profile story
walk clean, and the boot smoke test silent.