### PR TITLE
Say what the three bug modes are, and let each one be picked apart

### DIFF
--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -15,6 +15,15 @@ const PRINTER_LABELS: Array[String] = ["Lightest", "Lighter", "Normal", "Darker"
 ## [constant Gen2Rules.MODES], in its order. Written out rather than capitalized
 ## from the names, which would say "Qol".
 const RULE_MODES: Array[String] = ["Current", "Vanilla", "QoL"]
+## What each mode answers, said once. [constant Gen2Rules.MODE_CURRENT]'s row
+## counts the table rather than describing it, so a flag added later cannot leave
+## this sentence wrong.
+const RULE_MODE_TEXT: Dictionary = {
+	Gen2Rules.MODE_CURRENT: "what this port ships",
+	Gen2Rules.MODE_VANILLA: "every one of them reproduced, cartridge for cartridge",
+	Gen2Rules.MODE_QOL: "every one of them corrected",
+	Gen2Rules.MODE_CUSTOM: "your own picks",
+}
 
 var _theme: Gen2LauncherTheme = null
 var _options: Gen2Options = null
@@ -22,6 +31,10 @@ var _saved: Label = null
 ## Where a modal opens. The launcher root rather than this page, so a sheet
 ## covers the dock as well and is not clipped by the settings scroll.
 var _host: Control = null
+## The line under the Bugs row, which names the mode the flags actually describe.
+## Rewritten rather than rebuilt, because a mode press must not rebuild the row
+## the press came from.
+var _rules_summary: Label = null
 
 
 static func create(palette: Gen2LauncherTheme, host: Control = null) -> Gen2SettingsPage:
@@ -107,16 +120,25 @@ func _build() -> void:
 	var rules: VBoxContainer = _card(column, "Gameplay")
 	rules.add_child(Gen2LauncherUI.muted(
 		_theme,
-		"What the engine does where this port and the cartridge disagree. A run "
-		+ "keeps the rules it was created with, so changing these affects the next "
-		+ "new game rather than a save already in progress."
+		"Generation II shipped with bugs, and this port can play them either way. "
+		+ "A run keeps the rules it was created with, so changing these affects "
+		+ "the next new game rather than a save already in progress."
 	))
 	rules.add_child(Gen2LauncherUI.field(_theme, "Bugs", Gen2LauncherUI.segmented(
 		_theme, RULE_MODES, maxi(Gen2Rules.MODES.find(_options.rules.mode), 0),
 		func(index: int) -> void:
 			_options.rules.set_mode(Gen2Rules.MODES[index])
+			_refresh_rules()
 			_persist()
 	)))
+	_rules_summary = Gen2LauncherUI.muted(_theme, "")
+	rules.add_child(_rules_summary)
+	var listing: Gen2LauncherButton = Gen2LauncherButton.create(
+		_theme, "Which bugs...", Gen2LauncherButton.Variant.QUIET
+	)
+	listing.pressed.connect(_open_rules_sheet)
+	rules.add_child(listing)
+	_refresh_rules()
 	rules.add_child(Gen2LauncherUI.field(_theme, "Trainer AI", Gen2LauncherUI.segmented(
 		_theme, _titles(Gen2Rules.DIFFICULTIES),
 		maxi(Gen2Rules.DIFFICULTIES.find(_options.rules.difficulty), 0),
@@ -170,6 +192,78 @@ func _build() -> void:
 			_persist()
 	)))
 	column.add_child(Gen2LauncherUI.dock_safe_space())
+
+
+## Test and screen seam: what the Bugs row says and what the sheet lists, from
+## one place so the two cannot disagree. `mode` is what the flags describe rather
+## than what was last pressed, which is `custom` once one has been moved.
+func rules_snapshot() -> Dictionary:
+	var rules: Gen2Rules = _options.rules
+	var mode: StringName = rules.mode_of()
+	var flags: Array = []
+	var reproduced: int = 0
+	for flag: StringName in Gen2Rules.FLAGS:
+		var on: bool = rules.reproduces(flag)
+		reproduced += 1 if on else 0
+		var text: Dictionary = Gen2Rules.FLAG_TEXT.get(flag, {})
+		flags.append({
+			"flag": flag, "on": on,
+			"title": String(text.get("title", "")),
+			"detail": String(text.get("detail", "")),
+		})
+	return {
+		"mode": mode,
+		"summary": "%s: %s. %d of %d bugs reproduced." % [
+			String(mode).capitalize(), String(RULE_MODE_TEXT.get(mode, "")),
+			reproduced, flags.size(),
+		],
+		"flags": flags,
+	}
+
+
+func _refresh_rules() -> void:
+	if _rules_summary == null:
+		return
+	_rules_summary.text = String(rules_snapshot()["summary"])
+
+
+func _set_rule_flag(flag: StringName, reproduce_hardware: bool) -> void:
+	_options.rules.set_flag(flag, reproduce_hardware)
+	_refresh_rules()
+	_persist()
+
+
+## The five bugs themselves, each with what the cartridge does and a switch. The
+## model has carried per-flag overrides and a `custom` mode since it was written
+## and nothing reached them, so a player could pick an end of the table and not
+## see what was in it.
+func _open_rules_sheet() -> void:
+	var rules: Gen2Rules = _options.rules
+	var sheet: Gen2LauncherSheet = Gen2LauncherSheet.create(_theme, "Bugs and glitches")
+	sheet.body().add_child(Gen2LauncherUI.muted(
+		_theme, "On reproduces the cartridge. Off is this port's corrected answer."
+	))
+	for row: Dictionary in rules_snapshot()["flags"] as Array:
+		var flag := StringName(row["flag"])
+		var entry: VBoxContainer = Gen2LauncherUI.column(2)
+		sheet.body().add_child(entry)
+		var switch: Gen2LauncherToggle = _toggle(
+			bool(row["on"]), func(on: bool) -> void: _set_rule_flag(flag, on)
+		)
+		entry.add_child(Gen2LauncherUI.field(_theme, String(row["title"]), switch))
+		entry.add_child(Gen2LauncherUI.muted(_theme, String(row["detail"])))
+	var reset: Gen2LauncherButton = Gen2LauncherButton.create(
+		_theme, "Back to %s" % String(rules.mode).capitalize(),
+		Gen2LauncherButton.Variant.QUIET
+	)
+	reset.pressed.connect(func() -> void:
+		rules.clear_flags()
+		_refresh_rules()
+		_persist()
+		sheet.close()
+	)
+	sheet.add_action(reset)
+	sheet.open(_host if _host != null else self)
 
 
 func _open_touch_layout() -> void:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -427,6 +427,9 @@ func preview_sheet(view: StringName) -> void:
 		&"touch":
 			select_page(&"settings")
 			_settings._open_touch_layout()
+		&"bugs":
+			select_page(&"settings")
+			_settings._open_rules_sheet()
 		&"binding":
 			select_page(&"settings")
 			var sheet: Gen2BindingSheet = Gen2BindingSheet.for_button(

--- a/game/options/rules.gd
+++ b/game/options/rules.gd
@@ -37,6 +37,40 @@ const FLAGS: Dictionary = {
 	&"metal_powder_overflow": true,
 }
 
+## What each flag is, for a player choosing one. Keyed like [constant FLAGS] and
+## in its order: `title` names the bug and `detail` says what the CARTRIDGE does,
+## which is what the flag reproduces when it is on. Said without a source symbol,
+## because the symbols are beside the branches; this is the only wording a
+## settings screen has, so a second copy in the launcher would go stale.
+const FLAG_TEXT: Dictionary = {
+	&"belly_drum_boosts_below_half_hp": {
+		"title": "Belly Drum below half HP",
+		"detail": "Attack is raised by two stages before the HP is checked, so a"
+			+ " Belly Drum that fails for want of HP has already paid the boost.",
+	},
+	&"medium_slow_level_one_underflow": {
+		"title": "Medium Slow at level 1",
+		"detail": "The experience formula is run at level 1, where the medium slow"
+			+ " curve underflows and asks for about 16 million points.",
+	},
+	&"cautious_ai_abandons_remaining_moves": {
+		"title": "Cautious trainer AI",
+		"detail": "A trainer weighing its moves stops at the first one a roll"
+			+ " passes over, leaving the rest of them unscored.",
+	},
+	&"short_hp_bar_number_off_by_one": {
+		"title": "Short HP bar's number",
+		"detail": "The HP number printed while a short bar drains is rounded down"
+			+ " where the rest of the routine rounds up, so it reads one low."
+			+ " Never the bar itself.",
+	},
+	&"metal_powder_overflow": {
+		"title": "Metal Powder on Ditto",
+		"detail": "Boosting a Defense above 170 overflows, halves the attacker's"
+			+ " Attack instead and folds the defence back below where it started.",
+	},
+}
+
 ## `HANDOFF.md`'s mutual recoil faint row is deliberately NOT here: the award pass
 ## already refuses a fainted recipient, so clearing the participant as
 ## `UpdateFaintedPlayerMon` does changes no outcome that can be observed. It

--- a/tests/integration/test_controls_settings.gd
+++ b/tests/integration/test_controls_settings.gd
@@ -1,6 +1,7 @@
 extends GutTest
 
-## Seeing and changing the controls from the launcher.
+## Seeing and changing settings from the launcher: the controls, and the rules
+## the game is played under.
 
 var _theme: Gen2LauncherTheme = null
 var _options: Gen2Options = null
@@ -216,5 +217,51 @@ func test_the_layout_editor_previews_the_controller_it_is_arranging() -> void:
 	assert_true(pad.visible)
 	assert_same(pad.layout(), _options.touch_layout, "it edits the live layout")
 
+	sheet.close()
+	await get_tree().process_frame
+
+
+## The Gameplay card names three modes and nothing else said what was in them,
+## while the per-flag overrides the model has always carried were reachable from
+## no screen at all. Both halves are read off one snapshot, so the line under the
+## row and the sheet's own list cannot disagree.
+func test_the_bug_rules_are_named_and_each_one_can_be_moved_by_hand() -> void:
+	var page: Gen2SettingsPage = Gen2SettingsPage.create(_theme, _host)
+	_host.add_child(page)
+	var opened: Dictionary = page.rules_snapshot()
+	assert_eq(StringName(opened["mode"]), Gen2Rules.MODE_CURRENT)
+	assert_string_contains(String(opened["summary"]), "of %d bugs" % Gen2Rules.FLAGS.size())
+	# Wording is what a player has instead of the source, so a flag added without
+	# it fails here rather than showing as a bare symbol.
+	assert_eq((opened["flags"] as Array).size(), Gen2Rules.FLAGS.size())
+	for row: Dictionary in opened["flags"] as Array:
+		assert_false(String(row["title"]).is_empty(), String(row["flag"]))
+		assert_false(String(row["detail"]).is_empty(), String(row["flag"]))
+
+	page._open_rules_sheet()
+	await get_tree().process_frame
+	var sheet: Gen2LauncherSheet = null
+	for child: Node in _host.get_children():
+		if child is Gen2LauncherSheet:
+			sheet = child
+	assert_not_null(sheet)
+	var switches: Array[Gen2LauncherToggle] = []
+	for entry: Node in sheet.body().get_children():
+		for control: Node in entry.get_children():
+			for half: Node in control.get_children():
+				if half is Gen2LauncherToggle:
+					switches.append(half)
+	assert_eq(switches.size(), Gen2Rules.FLAGS.size(), "one switch per bug")
+
+	var first: Dictionary = (opened["flags"] as Array)[0]
+	switches[0].button_pressed = not bool(first["on"])
+	var moved: Dictionary = page.rules_snapshot()
+	assert_eq(StringName(moved["mode"]), Gen2Rules.MODE_CUSTOM)
+	assert_ne(bool((moved["flags"] as Array)[0]["on"]), bool(first["on"]))
+
+	# And the sheet's own way back, which is the mode the player last picked
+	# rather than a reset to the shipped one.
+	page._options.rules.clear_flags()
+	assert_eq(StringName(page.rules_snapshot()["mode"]), Gen2Rules.MODE_CURRENT)
 	sheet.close()
 	await get_tree().process_frame

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -7,7 +7,8 @@ extends SceneTree
 ##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] \
 ##       [scroll] [focus index] [fade step]
 ##
-## `view` is the mods page's own: `list`, `sources`, or `mod` with an id.
+## `view` opens a sheet (`manage`, `touch`, `binding`, `bugs`, `delete_mod`) or
+## picks the mods page's own: `list`, `sources`, or `mod` with an id.
 ## `fade` is which step of the screen transition to photograph, 0 for none and 1
 ## to 4 for one of `FadeOutToWhite`'s own rows: the launcher's leave-the-screen
 ## sheet is stepped rather than tweened, so a still is the only way to see that
@@ -82,7 +83,7 @@ func _process(_delta: float) -> bool:
 		if STATES.has(_state):
 			_launcher.preview_slot_states(STATES[_state])
 		_launcher.select_page(StringName(_page))
-		if _view in ["manage", "touch", "binding", "delete_mod"]:
+		if _view in ["manage", "touch", "binding", "delete_mod", "bugs"]:
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():
 			_launcher.preview_mods_view(StringName(_view), StringName(_mod))


### PR DESCRIPTION
The Gameplay card offered `Current`, `Vanilla` and `QoL` with nothing on screen saying what any of them meant or which bugs they covered. The setting was real — five flags, each with a live branch and a test, carried by the run and saved with it — but from the player's side it was three words and no table.

Two gaps closed:

- **Wording.** Each flag now carries a player-facing title and a sentence saying what the *cartridge* does, kept in `Gen2Rules` beside the flag list rather than in the launcher, so a flag added later cannot leave a settings screen describing four of five.
- **The overrides nothing reached.** `set_flag`, `mode_of` and `clear_flags` have existed and been tested since the rules object was written, and no screen called them. The Bugs row now shows the mode the flags actually describe (`Custom` once one is moved) with the count reproduced, and a sheet lists every bug with a switch and a way back to the mode last picked.

The row and the sheet both read `rules_snapshot()`, so the summary and the list cannot disagree, and the test asserts every flag has wording rather than rendering as a bare `StringName`.

`tools/preview_launcher.gd ... settings full bugs` photographs the sheet.

GUT 3,304/3,304 green over 152 scripts; `validate.gd -- all` passes; boot smoke clean.