### PR TITLE
Give an open sheet the arrows, and fit it inside the window

### DIFF
--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -14,6 +14,18 @@ extends Node
 ##
 ## Add one to a screen with [method attach] and call [method refresh] whenever
 ## what is on that screen changes.
+##
+## A modal over the screen takes the whole guard with it. Everything below is
+## still in the tree and still focusable, so without this the geometric search
+## joins a control in the modal to whatever happens to sit beside it on the page
+## behind, and one press walks out of the modal and scrolls the page. See
+## [constant MODAL_GROUP].
+
+## Nodes in this group are modal: while one is in the tree, it is the only part
+## of the screen the guard looks at. Named rather than typed so the guard owes
+## nothing to the launcher, and joined by whoever puts a layer over a screen
+## ([Gen2LauncherSheet] is the one that does today).
+const MODAL_GROUP: StringName = &"gen2_focus_modal"
 
 ## Where focus should land when there is somewhere better than the first control
 ## in tree order. A screen whose first control is a corner toggle would otherwise
@@ -71,11 +83,31 @@ func refresh() -> void:
 	if Gen2InputDevice.is_pointer(Gen2InputRuntime.instance().device()):
 		return
 	var viewport: Viewport = _root.get_viewport()
-	if viewport == null or viewport.gui_get_focus_owner() != null:
+	if viewport == null:
+		return
+	var focused: Control = viewport.gui_get_focus_owner()
+	var top: Control = _effective_root()
+	# Focus left behind on the page when a modal opened is focus outside the
+	# modal, so it is moved in rather than left where the arrows cannot see it.
+	if focused != null and (top == _root or top.is_ancestor_of(focused)):
 		return
 	var target: Control = _wanted()
 	if target != null:
 		target.grab_focus()
+
+
+## The part of the screen the guard is allowed to look at: the last modal added
+## under [member _root], or the whole screen when there is none. The last, so a
+## sheet opened over a sheet owns the arrows.
+func _effective_root() -> Control:
+	var top: Control = _root
+	for node: Node in _root.get_tree().get_nodes_in_group(MODAL_GROUP):
+		var control := node as Control
+		if control == null or not control.is_visible_in_tree():
+			continue
+		if control == _root or _root.is_ancestor_of(control):
+			top = control
+	return top
 
 
 func _wanted() -> Control:
@@ -87,7 +119,7 @@ func _wanted() -> Control:
 		and not _is_disabled(preferred)
 	):
 		return preferred
-	return first_focusable(_root)
+	return first_focusable(_effective_root())
 
 
 func _on_device_changed(_kind: StringName) -> void:
@@ -102,11 +134,12 @@ func move_focus(direction: Vector2) -> bool:
 	if _root == null or not _root.is_inside_tree() or direction == Vector2.ZERO:
 		return false
 	var viewport: Viewport = _root.get_viewport()
+	var top: Control = _effective_root()
 	var current: Control = viewport.gui_get_focus_owner()
-	if current == null or not _root.is_ancestor_of(current):
+	if current == null or not top.is_ancestor_of(current):
 		refresh()
 		return viewport.gui_get_focus_owner() != null
-	var best: Control = _neighbor(current, direction, focusable_controls(_root))
+	var best: Control = _neighbor(current, direction, focusable_controls(top))
 	if best == null:
 		return false
 	best.grab_focus()
@@ -119,7 +152,7 @@ func move_focus(direction: Vector2) -> bool:
 func _refresh_focus_neighbors() -> void:
 	if _root == null or not _root.is_inside_tree():
 		return
-	var controls: Array[Control] = focusable_controls(_root)
+	var controls: Array[Control] = focusable_controls(_effective_root())
 	for control: Control in controls:
 		_set_neighbor(control, &"left", _neighbor(control, Vector2.LEFT, controls))
 		_set_neighbor(control, &"right", _neighbor(control, Vector2.RIGHT, controls))

--- a/game/launcher/launcher_sheet.gd
+++ b/game/launcher/launcher_sheet.gd
@@ -6,13 +6,29 @@ extends Control
 ## Godot's own dialogs open a second window with its own decorations, which no
 ## amount of theming makes belong here and which mobile has no place to put. A
 ## sheet is drawn inside the launcher, so it is one look on every platform.
+##
+## It is sized against the window rather than against its own content: a
+## [CenterContainer] grants a card its minimum size whatever that is, so a sheet
+## with more rows than the window is tall used to hang its actions off the bottom
+## edge with no way to reach them. The body scrolls and the card is capped, so
+## the title, the actions and the close button are always on screen and the rows
+## between them are what gives.
 
 signal closed
+
+## The widest a sheet is drawn, and how much window is left around it when the
+## window is narrower or shorter than that.
+const MAX_WIDTH: float = 420.0
+const MARGIN: float = 24.0
 
 var _theme: Gen2LauncherTheme = null
 var _body: VBoxContainer = null
 var _actions: HBoxContainer = null
 var _card: Gen2LauncherCard = null
+var _scroll: Gen2LauncherScroll = null
+## The card's own chrome: the title row, the actions row and the padding, which
+## is what the body has to fit inside the window WITHOUT.
+var _column: VBoxContainer = null
 ## What had focus before the sheet opened, so closing puts it back rather than
 ## stranding a pad with nothing selected.
 var _restore_focus: Control = null
@@ -43,14 +59,13 @@ func _build(title: String) -> void:
 	add_child(centre)
 
 	_card = Gen2LauncherCard.floating(_theme, Gen2LauncherTheme.RADIUS_LG, 26, 34)
-	_card.custom_minimum_size = Vector2(420, 0)
 	centre.add_child(_card)
 
-	var column: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_LG)
-	_card.add_child(column)
+	_column = Gen2LauncherUI.column(Gen2LauncherUI.GAP_LG)
+	_card.add_child(_column)
 
 	var head: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
-	column.add_child(head)
+	_column.add_child(head)
 	var heading: Label = Gen2LauncherUI.title(_theme, title)
 	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	head.add_child(heading)
@@ -61,12 +76,38 @@ func _build(title: String) -> void:
 	dismiss.pressed.connect(close)
 	head.add_child(dismiss)
 
+	_scroll = Gen2LauncherScroll.create()
+	_column.add_child(_scroll)
 	_body = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
-	column.add_child(_body)
+	_body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_scroll.add_child(_body)
 
 	_actions = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
 	_actions.alignment = BoxContainer.ALIGNMENT_END
-	column.add_child(_actions)
+	_column.add_child(_actions)
+
+	## The window, and the rows themselves: a sheet is filled after it is built,
+	## so the fit is redone when the body grows rather than only when it opens.
+	add_to_group(Gen2FocusGuard.MODAL_GROUP)
+	resized.connect(_fit)
+	_body.minimum_size_changed.connect(_fit)
+	_fit()
+
+
+## Fits the card inside the window: the width first, then whatever height is
+## left for the rows once the title and the actions have taken theirs. The scroll
+## pane asks for exactly its content while that fits, so a sheet small enough to
+## fit is drawn exactly as it was before it could scroll.
+func _fit() -> void:
+	if _card == null or _scroll == null or size == Vector2.ZERO:
+		return
+	var width: float = minf(MAX_WIDTH, size.x - MARGIN * 2.0)
+	_card.custom_minimum_size.x = maxf(width, 0.0)
+	var chrome: float = _card.get_combined_minimum_size().y - _scroll.custom_minimum_size.y
+	var room: float = size.y - MARGIN * 2.0 - chrome
+	_scroll.custom_minimum_size.y = maxf(
+		minf(_body.get_combined_minimum_size().y, room), 0.0
+	)
 
 
 func body() -> VBoxContainer:

--- a/game/launcher/touch_layout_sheet.gd
+++ b/game/launcher/touch_layout_sheet.gd
@@ -33,6 +33,8 @@ static func create(palette: Gen2LauncherTheme, options: Gen2Options) -> Gen2Touc
 
 func _build() -> void:
 	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	## A modal, so the arrows belong to it rather than to the page under it.
+	add_to_group(Gen2FocusGuard.MODAL_GROUP)
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	theme = _theme.control_theme()
 

--- a/tests/integration/test_controls_settings.gd
+++ b/tests/integration/test_controls_settings.gd
@@ -230,7 +230,9 @@ func test_the_bug_rules_are_named_and_each_one_can_be_moved_by_hand() -> void:
 	_host.add_child(page)
 	var opened: Dictionary = page.rules_snapshot()
 	assert_eq(StringName(opened["mode"]), Gen2Rules.MODE_CURRENT)
-	assert_string_contains(String(opened["summary"]), "of %d bugs" % Gen2Rules.FLAGS.size())
+	assert_string_contains(
+		String(opened["summary"]), "of %d bugs" % Gen2Rules.FLAGS.size()
+	)
 	# Wording is what a player has instead of the source, so a flag added without
 	# it fails here rather than showing as a bare symbol.
 	assert_eq((opened["flags"] as Array).size(), Gen2Rules.FLAGS.size())
@@ -265,3 +267,72 @@ func test_the_bug_rules_are_named_and_each_one_can_be_moved_by_hand() -> void:
 	assert_eq(StringName(page.rules_snapshot()["mode"]), Gen2Rules.MODE_CURRENT)
 	sheet.close()
 	await get_tree().process_frame
+
+
+## A sheet is a modal, and everything under it is still in the tree and still
+## focusable: without the guard treating it as the only screen, one press down
+## walked out of the sheet and scrolled the page behind it.
+func test_arrows_stay_inside_an_open_sheet() -> void:
+	var behind: Gen2SettingsPage = Gen2SettingsPage.create(_theme, _host)
+	_host.add_child(behind)
+	var guard: Gen2FocusGuard = Gen2FocusGuard.attach(_host)
+	await get_tree().process_frame
+	behind._open_rules_sheet()
+	await get_tree().process_frame
+	var sheet: Gen2LauncherSheet = _launcher_sheet()
+	assert_not_null(sheet)
+
+	var inside: Array[Control] = Gen2FocusGuard.focusable_controls(sheet)
+	assert_true(inside.size() > 1, "the sheet has somewhere to move")
+	inside[0].grab_focus()
+	for step: int in 12:
+		guard.move_focus(Vector2.DOWN)
+		var owner: Control = _host.get_viewport().gui_get_focus_owner()
+		assert_true(
+			owner == sheet or sheet.is_ancestor_of(owner),
+			"down %d stayed in the sheet" % step
+		)
+	for step: int in 12:
+		guard.move_focus(Vector2.UP)
+		var owner: Control = _host.get_viewport().gui_get_focus_owner()
+		assert_true(
+			owner == sheet or sheet.is_ancestor_of(owner), "up %d" % step
+		)
+	sheet.close()
+	await get_tree().process_frame
+
+
+## A [CenterContainer] grants a card whatever minimum size it asks for, so a
+## sheet with more rows than the window is tall used to hang its actions off the
+## bottom edge with no way to reach them. The rows are what gives now.
+func test_a_sheet_taller_than_the_window_keeps_its_actions_on_screen() -> void:
+	_host.size = Vector2(900, 420)
+	var page: Gen2SettingsPage = Gen2SettingsPage.create(_theme, _host)
+	_host.add_child(page)
+	page._open_rules_sheet()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var sheet: Gen2LauncherSheet = _launcher_sheet()
+	assert_not_null(sheet)
+	var window := Rect2(Vector2.ZERO, _host.size)
+	assert_true(window.encloses(sheet._card.get_global_rect()), "the card fits")
+	# The rows are what scrolls; the title, the close button and the actions are
+	# the parts that must never leave, since one of them is the way out.
+	for control: Control in Gen2FocusGuard.focusable_controls(sheet._actions):
+		assert_true(
+			window.encloses(control.get_global_rect()), "an action is on screen"
+		)
+	assert_true(
+		window.encloses(Gen2FocusGuard.first_focusable(sheet._card).get_global_rect()),
+		"and the close button"
+	)
+	assert_true(sheet._scroll.get_v_scroll_bar().max_value > sheet._scroll.size.y)
+	sheet.close()
+	await get_tree().process_frame
+
+
+func _launcher_sheet() -> Gen2LauncherSheet:
+	for child: Node in _host.get_children():
+		if child is Gen2LauncherSheet:
+			return child
+	return null


### PR DESCRIPTION
Two defects the bugs sheet exposed, both fixed in `Gen2LauncherSheet` and `Gen2FocusGuard` rather than in the one screen that showed them.

**It did not fit.** A `CenterContainer` grants a card whatever minimum size it asks for, so a sheet taller than the window hung its actions off the bottom edge with no way to reach them. The body is in a scroll pane now and the card is measured against the window — width capped to the window less a margin, height to whatever is left once the title and the actions have taken theirs. A sheet that already fits asks for exactly its content, so the bindings, delete and manage sheets are drawn identically to before.

**The arrows walked out of it.** Everything under a modal is still in the tree and still focusable, so the guard's geometric neighbour search joined a control inside the sheet to whatever sat beside it on the page behind — one press left the sheet and scrolled the page. A modal now joins `Gen2FocusGuard.MODAL_GROUP`, and while one is in the tree it is the only part of the screen the guard looks at: the neighbour wiring, the directional search and where focus lands on open all follow it. Focus stranded on the page when a modal opens is pulled in rather than left where the arrows cannot see it.

Both `Gen2LauncherSheet` and `Gen2TouchLayoutSheet` are in the group, so this covers the binding editor, the delete confirmations, the replace-mod prompt and the on-screen-button arranger too.

Two tests, both failing on the old code: twelve presses down and twelve up stay inside an open sheet, and a sheet opened in a 900x420 window keeps its card, its close button and its actions on screen with the rows scrolling.

GUT 3,306/3,306 green over 152 scripts; `validate.gd -- all` passes; boot smoke and the editor panel clean.