### PR TITLE
Charge happiness where the cartridge charges it

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -567,6 +567,14 @@ var parties: Dictionary = {}
 ## every [method send_out], reset once experience is awarded.
 var _participants: Dictionary = {PLAYER: {}, ENEMY: {}}
 
+## Which of the player's Pokemon have already been charged
+## `UpdateFaintedPlayerMon`'s happiness, keyed by instance id. The cartridge runs
+## that routine once per faint, off its own turn loop; this engine reports a
+## faint from a dozen places and would otherwise charge one Pokemon several
+## times for going down once. A revive clears the entry, since a revived
+## Pokemon can faint again in the same fight.
+var _faint_charged: Dictionary = {}
+
 ## The last direct damage each side took this action pair, which Counter and
 ## Mirror Coat read after the faster side has acted. Cleared each pair: the
 ## cartridge's `wCurDamage` is move-local, not a history.
@@ -676,10 +684,10 @@ static func use_item(item: int) -> Dictionary:
 	return {"type": ACTION_ITEM, "item": item}
 
 
-## Fills [member enemy_items] from a trainer class's own attributes, the way
-## `LoadEnemyMon`'s caller copies `TRNATTR_ITEM1` and `TRNATTR_ITEM2` into the
-## two working slots. `NO_ITEM` is zero and is not carried.
-func load_trainer_items(trainer_class: int) -> void:
+## `InitEnemyTrainer`: the class's own `TRNATTR_ITEM1` and `TRNATTR_ITEM2` into
+## the two working slots, and then `IsGymLeader`'s own party walk. `NO_ITEM` is
+## zero and is not carried.
+func init_enemy_trainer(trainer_class: int) -> void:
 	enemy_items = []
 	if data == null or trainer_class <= 0:
 		return
@@ -688,6 +696,51 @@ func load_trainer_items(trainer_class: int) -> void:
 		var item: int = int(attributes.get(key, 0))
 		if item != 0:
 			enemy_items.append(item)
+	_gain_gym_battle_happiness(trainer_class)
+
+
+## `InitEnemyTrainer`'s `.partyloop`, which runs on the frame the trainer's pic
+## is placed rather than on the win: standing in front of a gym leader is what
+## pays, and a fainted member is skipped by `ld a, [hli] / or [hl] / jr z`.
+func _gain_gym_battle_happiness(trainer_class: int) -> void:
+	if not (KANTO_GYM_LEADERS.has(trainer_class) or JOHTO_GYM_LEADERS.has(trainer_class)):
+		return
+	for member: Gen2BattleMon in party(PLAYER).mons:
+		if member == null or member.is_fainted():
+			continue
+		member.happiness = Gen2WorldPartyHost.change_happiness(
+			data, member.happiness, HAPPINESS_GYMBATTLE
+		)
+
+
+## Reports one faint. Every site that knows a battler has gone down goes through
+## here rather than appending the event itself, because `UpdateFaintedPlayerMon`
+## hangs off the same moment and the cartridge reaches it once.
+func note_faint(side: int, events: Array, extra: Dictionary = {}) -> void:
+	var event: Dictionary = {"type": FAINTED, "side": side}
+	event.merge(extra, true)
+	events.append(event)
+	_charge_faint_happiness(side)
+
+
+## `UpdateFaintedPlayerMon`'s happiness half: HAPPINESS_BEATENBYSTRONGFOE when
+## the enemy stands at the fallen Pokemon's level plus thirty or above, and
+## HAPPINESS_FAINTED under it. The enemy's own faints reach no table.
+func _charge_faint_happiness(side: int) -> void:
+	if side != PLAYER:
+		return
+	var fallen: Gen2BattleMon = mon(PLAYER)
+	if fallen == null or not fallen.is_fainted():
+		return
+	var key: int = fallen.get_instance_id()
+	if _faint_charged.has(key):
+		return
+	_faint_charged[key] = true
+	var foe: Gen2BattleMon = mon(ENEMY)
+	var kind: int = HAPPINESS_FAINTED
+	if foe != null and foe.level >= fallen.level + 30:
+		kind = HAPPINESS_BEATENBYSTRONGFOE
+	fallen.happiness = Gen2WorldPartyHost.change_happiness(data, fallen.happiness, kind)
 
 
 func party(side: int) -> Gen2Party:
@@ -1334,7 +1387,7 @@ func _spikes_damage(side: int, events: Array) -> void:
 		"hp": entering.hp, "max_hp": entering.max_hp(),
 	})
 	if entering.is_fainted():
-		events.append({"type": FAINTED, "side": side})
+		note_faint(side, events)
 
 
 ## `UpdateUsedMoves`: remembered once, four kept, and a fifth drops the oldest
@@ -1508,7 +1561,7 @@ func _report_unannounced_action_faints(events: Array, since: int) -> void:
 				reported = true
 				break
 		if not reported:
-			events.append({"type": FAINTED, "side": side})
+			note_faint(side, events)
 
 
 ## `HandleFutureSight`, player then enemy: the count is decremented before it is
@@ -1684,7 +1737,7 @@ func _residual_status(side: int, events: Array) -> void:
 		"max_hp": current.max_hp(),
 	})
 	if current.is_fainted():
-		events.append({"type": FAINTED, "side": side})
+		note_faint(side, events)
 
 
 ## An eighth off the seeded Pokémon and onto the one opposite, capped by
@@ -1711,7 +1764,7 @@ func _residual_leech_seed(side: int, events: Array) -> void:
 		"to_max_hp": sapper.max_hp(),
 	})
 	if current.is_fainted():
-		events.append({"type": FAINTED, "side": side})
+		note_faint(side, events)
 
 
 ## Nothing here asks whether the sufferer is still asleep, because waking is what
@@ -1727,7 +1780,7 @@ func _residual_nightmare(side: int, events: Array) -> void:
 		"hp": current.hp, "max_hp": current.max_hp(),
 	})
 	if current.is_fainted():
-		events.append({"type": FAINTED, "side": side})
+		note_faint(side, events)
 
 
 func _residual_curse(side: int, events: Array) -> void:
@@ -1741,7 +1794,7 @@ func _residual_curse(side: int, events: Array) -> void:
 		"hp": current.hp, "max_hp": current.max_hp(),
 	})
 	if current.is_fainted():
-		events.append({"type": FAINTED, "side": side})
+		note_faint(side, events)
 
 
 ## `HandleWeather`: a turn off the count, its line, and a Sandstorm's eighth off
@@ -1779,7 +1832,7 @@ func _tick_weather(events: Array) -> void:
 			"max_hp": current.max_hp(),
 		})
 		if current.is_fainted():
-			events.append({"type": FAINTED, "side": side})
+			note_faint(side, events)
 
 
 ## `HandleWrap`: a turn off each bound Pokémon's counter and a sixteenth of its
@@ -1811,7 +1864,7 @@ func _tick_wrap(events: Array) -> void:
 			"max_hp": current.max_hp(),
 		})
 		if current.is_fainted():
-			events.append({"type": FAINTED, "side": side})
+			note_faint(side, events)
 
 
 ## `HandlePerishSong`: one off each count, said out loud, and whoever reaches zero
@@ -1834,7 +1887,7 @@ func _tick_perish(events: Array) -> void:
 
 		current.substatus &= ~Gen2Substatus.PERISH
 		current.hp = 0
-		events.append({"type": FAINTED, "side": side})
+		note_faint(side, events)
 
 
 ## `HandleBetweenTurnEffects`' leftovers block: `HandleLeftovers`,
@@ -2186,6 +2239,7 @@ func _apply_party_item(
 		if not target.is_fainted():
 			return {"ok": false, "reason": &"item_has_no_effect"}
 		target.hp = target.max_hp() if item == ITEM_MAX_REVIVE else maxi(target.max_hp() / 2, 1)
+		_faint_charged.erase(target.get_instance_id())
 		return {"ok": true, "revived": true, "healed": target.hp}
 	if target.is_fainted():
 		return {"ok": false, "reason": &"item_has_no_effect"}
@@ -2598,6 +2652,9 @@ const LANDMARK_NONE: int = -1
 ## takes it. Gold and Silver ship neither the second row nor the compare in
 ## front of it: their `.skip_active_mon_update` passes HAPPINESS_GAINLEVEL flat.
 const HAPPINESS_GAINLEVEL: int = 0x01
+const HAPPINESS_GYMBATTLE: int = 0x04
+const HAPPINESS_FAINTED: int = 0x06
+const HAPPINESS_BEATENBYSTRONGFOE: int = 0x08
 const HAPPINESS_GAINLEVELATHOME: int = 0x13
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -797,7 +797,7 @@ func show_trainer(
 	)
 	if _battle == null:
 		return
-	_battle.load_trainer_items(trainer_class)
+	_battle.init_enemy_trainer(trainer_class)
 
 	_init_battle_display()
 
@@ -896,7 +896,7 @@ func start_world_battle(
 	## `LevelUpHappinessMod` compares it against the winner's caught location.
 	_battle.landmark = _world_context.landmark if _world_context != null \
 		else Gen2Battle.LANDMARK_NONE
-	_battle.load_trainer_items(_enemy_trainer_class)
+	_battle.init_enemy_trainer(_enemy_trainer_class)
 	var player_party_ready: Gen2Party = prepared["player_party"]
 	var enemy_party_ready: Gen2Party = prepared["enemy_party"]
 	_player = player_party_ready.active_mon().species

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -1734,7 +1734,7 @@ static func _check_faint(turn: Gen2Turn) -> void:
 	_destiny_bond_takes_user(turn)
 	for side: int in [turn.target, turn.side]:
 		if turn.battle.mon(side).is_fainted():
-			turn.events.append({"type": Gen2Battle.FAINTED, "side": side})
+			turn.battle.note_faint(side, turn.events)
 	if turn.battle.mon(turn.target).is_fainted():
 		turn.end()
 
@@ -2786,7 +2786,7 @@ static func _curse_ghost(turn: Gen2Turn, user: Gen2BattleMon) -> void:
 	# `HasPlayerFainted` behind every move, and this engine has no such step, so
 	# whoever took the health reports it, as `_residual_damage` already does.
 	if user.is_fainted():
-		turn.emit(Gen2Battle.FAINTED)
+		turn.battle.note_faint(turn.side, turn.events)
 
 
 ## Field state [method Gen2Battle._spikes_damage] charges to whoever walks onto

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5002,7 +5002,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 		kind = &"water_move"
 	player_cell = destination
 	player_facing = _facing_for_direction(direction)
-	state.consume_repel_step()
+	state.count_step()
 	_advance_followers(-1, from_cell)
 	_start_player_step(direction, _step_frames_for_movement())
 	return {
@@ -5062,7 +5062,7 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	var from_cell: Vector2i = player_cell
 	player_cell = destination
 	player_facing = _facing_for_direction(direction)
-	state.consume_repel_step()
+	state.count_step()
 	_advance_followers(-1, from_cell)
 	_start_player_step(direction, STEP_FRAMES_WALK)
 	return {
@@ -5170,7 +5170,7 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	var from_cell: Vector2i = player_cell
 	player_cell = landing
 	player_facing = _facing_for_direction(direction)
-	state.consume_repel_step()
+	state.count_step()
 	_advance_followers(-1, from_cell)
 	_start_player_step(direction * 2, STEP_FRAMES_HOP, true)
 	return {

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -316,8 +316,7 @@ static func use_item(
 ## ForgetMove when its own scan finds no zero.
 ##
 ## An HM is not consumed: TeachTMHM returns straight after IsHM, so it skips both
-## ConsumeTM and the happiness change. The happiness change a TM does make is a
-## boundary, since no ChangeHappiness table is imported.
+## ConsumeTM and the happiness change.
 static func teach_tm_hm(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -407,8 +406,10 @@ static func teach_tm_hm(
 	}
 
 
-## `ChangeHappiness` over the imported table, without the egg and battle-mon
-## halves: an egg cannot reach a caller here, and no caller runs inside a battle.
+## `ChangeHappiness` over the imported table, taking the byte rather than the
+## Pokemon: `wCurPartyMon`'s egg guard and the `wBattleMonHappiness` mirror
+## behind it are the caller's, because a caller here holds either a
+## [Gen2SaveMon] or a [Gen2BattleMon] and never both.
 ##
 ## The three rows are picked by HAPPINESS_THRESHOLD_1 and _2, and the sign of a
 ## change is `cp $64`: a byte from 100 up is the subtracting branch, which is why
@@ -423,6 +424,29 @@ static func change_happiness(data: GameData, happiness: int, kind: int) -> int:
 	var row: int = 0 if happiness < HAPPINESS_THRESHOLD_1 \
 		else (1 if happiness < HAPPINESS_THRESHOLD_2 else 2)
 	return clampi(happiness + changes[row], 0, 255)
+
+
+## `StepHappiness`, spent [param times] over: one flat point to every party
+## member that is not an egg, saturating at 255 rather than wrapping, and
+## reaching no `HappinessChanges` row at all. The step counter that decides how
+## often is [method Gen2WorldState.count_step]'s.
+##
+## Answers the slots that moved, so a caller can persist only when the walk
+## actually changed something.
+static func apply_step_happiness(save: Gen2SaveData, times: int = 1) -> Array[int]:
+	var moved: Array[int] = []
+	if save == null or times <= 0:
+		return moved
+	for index: int in save.party.size():
+		var mon: Gen2SaveMon = save.party[index] as Gen2SaveMon
+		if mon == null or mon.is_egg:
+			continue
+		var raised: int = mini(255, mon.happiness + times)
+		if raised == mon.happiness:
+			continue
+		mon.happiness = raised
+		moved.append(index)
+	return moved
 
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1075,6 +1075,7 @@ func _complete_player_step(movement: Dictionary) -> bool:
 	## the step back onto land both reach one. `edge_warp` is
 	## `DoPlayerMovement.CheckWarp`'s own answer, which has already made the
 	## check `CheckWarpTile` refuses for a carpet.
+	_spend_step_happiness()
 	var kind: StringName = StringName(movement.get("kind", &""))
 	if kind == &"edge_warp" or (kind in [
 		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
@@ -1087,6 +1088,24 @@ func _complete_player_step(movement: Dictionary) -> bool:
 		_start_map_fade()
 		return true
 	return _after_map_settled()
+
+
+## `StepHappiness`, which `CountStep` reaches every 256 steps and which acts on
+## every second visit. [method Gen2WorldState.count_step] counts on the step
+## itself, wherever it was taken; the party lives on the save, which is here.
+## The cartridge raises happiness in WRAM and writes SRAM only when the player
+## saves, so this touches the loaded save and persists nothing of its own.
+func _spend_step_happiness() -> void:
+	if _world == null or _world.state == null:
+		return
+	var owed: int = _world.state.take_pending_step_happiness()
+	if owed <= 0:
+		return
+	var save: Gen2SaveData = active_save()
+	if save == null:
+		return
+	if not Gen2WorldPartyHost.apply_step_happiness(save, owed).is_empty():
+		_refresh_labels()
 
 
 ## `EnterMap`'s own tail, which a warp reaches once its setup script has run and

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -127,6 +127,18 @@ var _repel_steps: int = 0
 ## before it existed restores as zero, which is the value a walk reaches after
 ## its first four steps anyway.
 var _wild_encounter_cooldown: int = 0
+## `CountStep`'s own two bytes and `StepHappiness`'s, all three of them byte
+## counters that wrap. `wStepCount` wrapping to zero is what `jr nz` reads to
+## reach `StepHappiness`, and `wHappinessStepCount`'s `and 1` makes that act on
+## every second visit, so the party gains a point every 512 steps.
+## `wPoisonStepCount` has no reader here yet: field poison is not built, and the
+## byte is counted anyway so the reader that arrives needs no migration.
+var _step_count: int = 0
+var _poison_step_count: int = 0
+var _happiness_step_count: int = 0
+## How many `StepHappiness` passes the walk owes but no party owner has spent.
+## The state has no party; the screen that does drains this.
+var _pending_step_happiness: int = 0
 ## `wStatusFlags`' `STATUSFLAGS_NO_WILD_ENCOUNTERS_F`, which `wildoff` sets and
 ## `wildon` clears around a scripted sequence.
 var _wild_encounters_off: bool = false
@@ -276,6 +288,9 @@ func to_dict() -> Dictionary:
 		"just_battled": _just_battled,
 		"repel_steps": _repel_steps,
 		"wild_encounter_cooldown": _wild_encounter_cooldown,
+		"step_count": _step_count,
+		"poison_step_count": _poison_step_count,
+		"happiness_step_count": _happiness_step_count,
 		"wild_encounters_off": _wild_encounters_off,
 		"park_balls": _park_balls,
 		"bug_contest_started": _bug_contest_started.duplicate(),
@@ -360,6 +375,12 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 			restored.update_unown_dex(int(raw_form))
 	restored.set_registered_item(int(source.get("registered_item", 0)))
 	restored.set_wild_encounter_cooldown(int(source.get("wild_encounter_cooldown", 0)))
+	## Absent in a state written before the step counters existed, which restores
+	## as a fresh walk: zero is what a new game starts on and no reader of these
+	## can tell a migrated save from one that has taken no step.
+	restored._step_count = int(source.get("step_count", 0)) & 0xFF
+	restored._poison_step_count = int(source.get("poison_step_count", 0)) & 0xFF
+	restored._happiness_step_count = int(source.get("happiness_step_count", 0)) & 1
 	restored.set_wild_encounters_off(bool(source.get("wild_encounters_off", false)))
 	restored.set_park_balls(int(source.get("park_balls", 0)))
 	var started: Variant = source.get("bug_contest_started", {})
@@ -392,6 +413,10 @@ func restore_from_dict(raw: Variant) -> void:
 	_just_battled = restored._just_battled
 	_repel_steps = restored._repel_steps
 	_wild_encounter_cooldown = restored._wild_encounter_cooldown
+	_step_count = restored._step_count
+	_poison_step_count = restored._poison_step_count
+	_happiness_step_count = restored._happiness_step_count
+	_pending_step_happiness = 0
 	_wild_encounters_off = restored._wild_encounters_off
 	_park_balls = restored._park_balls
 	_bug_contest_started = restored._bug_contest_started.duplicate()
@@ -1010,11 +1035,35 @@ func picked_fruit_trees() -> Dictionary:
 	return _picked_fruit_trees.duplicate()
 
 
-func consume_repel_step() -> void:
-	if _repel_steps <= 0:
-		return
-	_repel_steps -= 1
+## `CountStep`: the two step counters, the Repel countdown, and `StepHappiness`
+## on the pass `wStepCount` wraps. One call per step the player finishes, from
+## wherever the step was taken.
+func count_step() -> void:
+	_poison_step_count = (_poison_step_count + 1) & 0xFF
+	_step_count = (_step_count + 1) & 0xFF
+	if _step_count == 0:
+		_happiness_step_count = (_happiness_step_count + 1) & 1
+		if _happiness_step_count == 0:
+			_pending_step_happiness += 1
+	if _repel_steps > 0:
+		_repel_steps -= 1
 	changed.emit()
+
+
+func step_count() -> int:
+	return _step_count
+
+
+func poison_step_count() -> int:
+	return _poison_step_count
+
+
+## Takes the owed `StepHappiness` passes and forgets them, so a caller that has
+## a party spends each one exactly once.
+func take_pending_step_happiness() -> int:
+	var owed: int = _pending_step_happiness
+	_pending_step_happiness = 0
+	return owed
 
 
 func swarm_map() -> Vector2i:

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3118,7 +3118,7 @@ func test_a_class_with_no_items_carries_none_into_the_battle() -> void:
 	var battle: Gen2Battle = _battle(
 		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	)
-	battle.load_trainer_items(0)
+	battle.init_enemy_trainer(0)
 	assert_eq(battle.enemy_items, [] as Array[int])
 
 
@@ -4348,3 +4348,95 @@ func test_region_check_keeps_the_fast_ship_and_victory_road_in_johto() -> void:
 	## Gold and Silver's table is one shorter from LANDMARK_BATTLE_TOWER on.
 	assert_true(Gen2Battle.region_is_kanto(Gen2WorldRadio.KANTO_LANDMARK - 1, false))
 	assert_false(Gen2Battle.region_is_kanto(Gen2WorldRadio.LANDMARK_FAST_SHIP - 1, false))
+
+
+## `InitEnemyTrainer`'s `.partyloop`: standing in front of a gym leader is what
+## pays, not beating one, and `ld a, [hli] / or [hl] / jr z` skips a member that
+## is already down. Class 1 is FALKNER, the first row of `GymLeaders`.
+func test_a_gym_leader_raises_the_whole_standing_party_at_the_start() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])]
+	)
+	var before: int = battle.party(Gen2Battle.PLAYER).at(0).happiness
+	_faint(battle.party(Gen2Battle.PLAYER).at(1))
+	battle.init_enemy_trainer(1)
+	assert_eq(
+		battle.party(Gen2Battle.PLAYER).at(0).happiness,
+		Gen2WorldPartyHost.change_happiness(_data, before, Gen2Battle.HAPPINESS_GYMBATTLE)
+	)
+	assert_eq(battle.party(Gen2Battle.PLAYER).at(1).happiness, before, "a fainted member is skipped")
+
+
+## `IsGymLeader` answers no for every other class, so an ordinary trainer moves
+## nothing. Class 9 is RIVAL1.
+func test_an_ordinary_trainer_moves_no_happiness() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])
+	)
+	var before: int = battle.player.happiness
+	battle.init_enemy_trainer(Gen2Battle.TRAINER_CLASS_RIVAL1)
+	assert_eq(battle.player.happiness, before)
+
+
+## `UpdateFaintedPlayerMon`: HAPPINESS_FAINTED under the enemy's level plus
+## thirty and HAPPINESS_BEATENBYSTRONGFOE at or above it, charged once no matter
+## how many places report the same faint. The enemy's own faints reach no row.
+func test_a_faint_costs_happiness_once_and_reads_the_enemy_level() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	var before: int = battle.player.happiness
+	_faint(battle.player)
+	var events: Array = []
+	battle.note_faint(Gen2Battle.PLAYER, events)
+	battle.note_faint(Gen2Battle.PLAYER, events)
+	assert_eq(events.size(), 2, "both reports still reach the caller")
+	assert_eq(
+		battle.player.happiness,
+		Gen2WorldPartyHost.change_happiness(_data, before, Gen2Battle.HAPPINESS_FAINTED),
+		"charged once for going down once"
+	)
+
+	var strong: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 35, [Fixture.TACKLE])
+	)
+	_faint(strong.player)
+	strong.note_faint(Gen2Battle.PLAYER, [])
+	assert_eq(
+		strong.player.happiness,
+		Gen2WorldPartyHost.change_happiness(
+			_data, before, Gen2Battle.HAPPINESS_BEATENBYSTRONGFOE
+		),
+		"level 35 is the fallen Pokemon's 5 plus 30"
+	)
+
+	var enemy_down: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])
+	)
+	var enemy_before: int = enemy_down.enemy.happiness
+	_faint(enemy_down.enemy)
+	enemy_down.note_faint(Gen2Battle.ENEMY, [])
+	assert_eq(enemy_down.enemy.happiness, enemy_before)
+
+
+## A faint reported through the ordinary turn loop reaches the same seam, which
+## is the point of routing every report through it.
+func test_a_faint_taken_in_a_turn_costs_happiness() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	battle.player.hp = 1
+	var before: int = battle.player.happiness
+	var events: Array = battle.take_turn(0, 0)
+	assert_true(battle.player.is_fainted(), JSON.stringify(events.size()))
+	assert_eq(
+		battle.player.happiness,
+		Gen2WorldPartyHost.change_happiness(_data, before, Gen2Battle.HAPPINESS_FAINTED)
+	)

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -694,3 +694,28 @@ func test_the_user_itself_a_fainted_member_and_a_full_one_are_all_refused() -> v
 		StringName(Gen2WorldPartyHost.transfer_health(_world, _save, 0, 1, false)["reason"]),
 		&"fainted_member"
 	)
+
+
+## `StepHappiness` reaches no `HappinessChanges` row: it is a flat `inc [hl]`
+## per party member, an egg is skipped by `cp EGG / jr z, .next`, and 255 stays
+## 255 because the wrap is caught by `ld [hl], $ff`.
+func test_step_happiness_raises_every_member_but_an_egg_and_saturates() -> void:
+	_save.party[0].happiness = 254
+	var second: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(
+		Gen2BattleMon.create(_data, 1, 5)
+	)
+	second.happiness = 10
+	second.is_egg = true
+	_save.party = [_save.party[0], second]
+
+	assert_eq(Gen2WorldPartyHost.apply_step_happiness(_save, 1), [0] as Array[int])
+	assert_eq(_save.party[0].happiness, 255)
+	assert_eq(_save.party[1].happiness, 10, "an egg reaches no point")
+
+	assert_true(Gen2WorldPartyHost.apply_step_happiness(_save, 1).is_empty(),
+		"nothing moved once the only eligible member is at 255")
+	_save.party[0].happiness = 100
+	assert_eq(Gen2WorldPartyHost.apply_step_happiness(_save, 3), [0] as Array[int])
+	assert_eq(_save.party[0].happiness, 103, "an owed run of passes is one add")
+	assert_true(Gen2WorldPartyHost.apply_step_happiness(null, 1).is_empty())
+	assert_true(Gen2WorldPartyHost.apply_step_happiness(_save, 0).is_empty())

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -473,3 +473,48 @@ func test_a_state_without_an_unown_dex_restores_empty() -> void:
 	var raw: Dictionary = state.to_dict()
 	raw.erase("unown_dex")
 	assert_true(Gen2WorldState.from_dict(raw).unown_dex().is_empty())
+
+
+## `CountStep` and `StepHappiness`: the party gains a point every 512 steps,
+## because `wStepCount` has to wrap for `StepHappiness` to be reached at all and
+## its own `and 1` acts on every second visit. `wPoisonStepCount` counts on the
+## same step and wraps on its own byte.
+func test_count_step_owes_step_happiness_every_five_hundred_and_twelve_steps() -> void:
+	var state := Gen2WorldState.new()
+	for _step: int in 511:
+		state.count_step()
+	assert_eq(state.step_count(), 511 & 0xFF)
+	assert_eq(state.take_pending_step_happiness(), 0, "the first wrap is the odd visit")
+	state.count_step()
+	assert_eq(state.step_count(), 0)
+	assert_eq(state.poison_step_count(), 0)
+	assert_eq(state.take_pending_step_happiness(), 1)
+	assert_eq(state.take_pending_step_happiness(), 0, "draining forgets what it took")
+	for _step: int in 512:
+		state.count_step()
+	assert_eq(state.take_pending_step_happiness(), 1)
+
+
+## The Repel countdown was the whole of this call before the counters joined it,
+## and it still spends one step at a time and stops at zero.
+func test_count_step_spends_a_repel_step_and_stops_at_zero() -> void:
+	var state := Gen2WorldState.new({}, {}, {}, {}, 0, {}, 2)
+	state.count_step()
+	assert_eq(state.repel_steps(), 1)
+	state.count_step()
+	state.count_step()
+	assert_eq(state.repel_steps(), 0)
+
+
+## The three counters are saved beside the Repel countdown. A state written
+## before they existed carries none of the keys and restores as a fresh walk.
+func test_step_counters_round_trip_and_default_to_a_fresh_walk() -> void:
+	var state := Gen2WorldState.new()
+	for _step: int in 300:
+		state.count_step()
+	var restored := Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.step_count(), 300 & 0xFF)
+	assert_eq(restored.poison_step_count(), 300 & 0xFF)
+	var legacy := Gen2WorldState.from_dict({"items": {}})
+	assert_eq(legacy.step_count(), 0)
+	assert_eq(legacy.poison_step_count(), 0)


### PR DESCRIPTION
Every `ChangeHappiness` caller whose own routine already exists in the tree now reaches it, and `CountStep`'s step counters are the world's.

- **A faint.** `Gen2Battle.note_faint` is now the one place a faint is reported from; the eleven sites that appended the event by hand go through it, so `UpdateFaintedPlayerMon`'s row is charged once per Pokemon that goes down rather than once per report. `HAPPINESS_BEATENBYSTRONGFOE` at the fallen Pokemon's level plus thirty, `HAPPINESS_FAINTED` under it. A revive clears the mark, since a revived Pokemon can go down again in the same fight.
- **A gym leader.** `load_trainer_items` was really `InitEnemyTrainer`, which is where `IsGymLeader`'s `.partyloop` sits, so it is named that and does both halves. Standing in front of a leader is what pays, not beating one, and a member already fainted is skipped.
- **Walking.** `Gen2WorldState.count_step` is `CountStep`: `wStepCount`, `wPoisonStepCount` and the Repel countdown on every step the player finishes, from all three `.DoStep` paths. `wStepCount` wrapping reaches `StepHappiness`, whose own `and 1` acts on every second visit, so the party gains a flat point every 512 steps, eggs skipped by `cp EGG` and 255 held by `ld [hl], $ff`. `wPoisonStepCount` is counted with them so the field-poison reader that arrives needs no migration.

The three counters save beside the Repel countdown and default to a fresh walk, so no save format moves.

GUT 3,314 over 152 scripts green, `validate.gd -- all` exit 0, `replay_world.gd` 11 routes 0 failures, the story walk clean on all three profiles.