### PR TITLE
Build the rest of InitClock

### DIFF
--- a/game/render/clock_set_page.gd
+++ b/game/render/clock_set_page.gd
@@ -3,8 +3,23 @@ extends RefCounted
 
 ## `InitClock` and `SetDayOfWeek` on the hardware tile grid. The two one-tile
 ## arrows stand where the source loads its temporary arrow graphics.
+##
+## The speech box is drawn here only for a caller that has no [Gen2TextBox] of
+## its own: `InitClock` reaches every one of its lines through `PrintText`, so
+## [Gen2ClockSetScreen] passes an empty prompt and puts a real box over this.
 
 const TILE: int = Gen2Font.TILE
+
+## `.loop`, `.HourIsSet` and `SetDayOfWeek.loop` each place their own `Textbox`,
+## its two arrows and its value, and differ in nothing else. Each row is the box
+## as (left, top, right, bottom), the column both arrows stand in, and where the
+## value is printed; both arrows sit on the box's own border rows.
+const DIALS: Dictionary = {
+	&"hour": {"box": Vector4i(3, 7, 19, 11), "arrow_x": 11, "value": Vector2i(4, 9)},
+	&"minutes": {"box": Vector4i(11, 7, 19, 11), "arrow_x": 15, "value": Vector2i(12, 9)},
+	&"day": {"box": Vector4i(9, 3, 19, 7), "arrow_x": 14, "value": Vector2i(10, 5)},
+}
+
 var font: Gen2Font = null
 var menu: Gen2MenuPage = null
 
@@ -16,31 +31,43 @@ static func from_data(data: GameData) -> Gen2ClockSetPage:
 	return out if out.font != null and out.menu != null else null
 
 
-func render(value: String, prompt: String, confirm_cursor: int, day: bool) -> Image:
+## [param kind] is which of [constant DIALS] is drawn, and empty draws none.
+## `InitClock`'s `.ClearScreen` runs before each `YesNoBox`, so a confirm has
+## no dial; `SetDayOfWeek` keeps its own up behind the question instead.
+func render(
+	value: String, prompt: String, confirm_cursor: int, kind: StringName,
+	palette: PackedColorArray = PackedColorArray()
+) -> Image:
 	var indices := PackedByteArray()
 	indices.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
-	var dial := Gen2MenuBox.from_coords(9 if day else 3, 3 if day else 7, 19, 7 if day else 11,
-		Gen2MenuBox.STATICMENU_NO_TOP_SPACING)
-	menu.draw(dial, [], -1, indices, Gen2Screen.WIDTH)
-	var value_at := Vector2i(10, 5) if day else Vector2i(4, 9)
-	font.draw_text(value, indices, Gen2Screen.WIDTH, value_at.x * TILE, value_at.y * TILE)
-	var arrow_x: int = 14 if day else (15 if value.contains("min.") else 11)
-	var arrow_top: int = 4 if day else 8
-	_draw_arrow(indices, arrow_x * TILE, arrow_top * TILE, false)
-	_draw_arrow(indices, arrow_x * TILE, (arrow_top + 3) * TILE, true)
-	var speech := Gen2MenuBox.from_coords(0, 12, 19, 17, 0)
-	menu.draw(speech, [], -1, indices, Gen2Screen.WIDTH)
-	var pages: Array = Gen2TextLayout.lay_out(prompt, 18, 2)
-	var lines: PackedStringArray = pages[0] if not pages.is_empty() else PackedStringArray()
-	for row: int in mini(2, lines.size()):
-		font.draw_text(String(lines[row]), indices, Gen2Screen.WIDTH,
-			TILE, (14 + row * 2) * TILE)
+	if DIALS.has(kind):
+		var dial: Dictionary = DIALS[kind]
+		var at: Vector4i = dial["box"]
+		var box := Gen2MenuBox.from_coords(at.x, at.y, at.z, at.w,
+			Gen2MenuBox.STATICMENU_NO_TOP_SPACING)
+		menu.draw(box, [], -1, indices, Gen2Screen.WIDTH)
+		var value_at: Vector2i = dial["value"]
+		font.draw_text(value, indices, Gen2Screen.WIDTH, value_at.x * TILE, value_at.y * TILE)
+		var arrow_x: int = int(dial["arrow_x"]) * TILE
+		_draw_arrow(indices, arrow_x, (at.y + 1) * TILE, false)
+		_draw_arrow(indices, arrow_x, at.w * TILE, true)
+	if not prompt.is_empty():
+		var speech := Gen2MenuBox.from_coords(0, 12, 19, 17, 0)
+		menu.draw(speech, [], -1, indices, Gen2Screen.WIDTH)
+		var pages: Array = Gen2TextLayout.lay_out(prompt, 18, 2)
+		var lines: PackedStringArray = pages[0] if not pages.is_empty() else PackedStringArray()
+		for row: int in mini(2, lines.size()):
+			font.draw_text(String(lines[row]), indices, Gen2Screen.WIDTH,
+				TILE, (14 + row * 2) * TILE)
 	if confirm_cursor >= 0:
+		# `YesNoBox`'s `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
+		# left 14, right 19, top 7, bottom 11.
 		var yes_no := Gen2MenuBox.from_coords(14, 7, 19, 11,
 			Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING)
 		menu.draw(yes_no, ["YES", "NO"], confirm_cursor, indices, Gen2Screen.WIDTH)
 	return Gen2PicImage.from_indices(indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])))
+		palette if palette.size() == 4 else Gen2Palette.pic_palette(
+			PackedColorArray([Color.WHITE, Color.BLACK])))
 
 
 func _draw_arrow(indices: PackedByteArray, x: int, y: int, down: bool) -> void:

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -5,10 +5,17 @@ extends Control
 ## routine ends on `OakText_ResponseToSetTime` after `.MinutesAreSet` and never
 ## calls `SetDayOfWeek`, which is Mom's own errand in `PlayersHouse1F.asm`. The
 ## weekday the save starts on is whatever the RTC holds, SUNDAY on a fresh one.
+##
+## Every line here is a `PrintText`, so the box is a [Gen2TextBox] and reveals at
+## the cartridge's own rate, and every wait is a `DelayFrames` operand spent
+## through a [Gen2IntroPresentation]. `RotateFourPalettesLeft` is the caller's,
+## over the screen `InitGender` left standing; see [Gen2IntroScreen].
 
 signal finished(day: int, hour: int, minute: int)
 
-enum Phase { HOUR, HOUR_CONFIRM, MINUTE, MINUTE_CONFIRM, DONE }
+enum Phase { WOKE_UP, HOUR, HOUR_CONFIRM, MINUTE, MINUTE_CONFIRM, RESPONSE, DONE }
+
+const TILE: int = Gen2Font.TILE
 
 ## `SetDayOfWeek`'s own `.WeekdayStrings`, padded the way the source pads them so
 ## the name is centred in its nine-wide box. Drawn by Mom's errand rather than
@@ -17,20 +24,55 @@ const DAYS: Array[String] = [
 	" SUNDAY", " MONDAY", " TUESDAY", "WEDNESDAY", "THURSDAY", " FRIDAY", "SATURDAY",
 ]
 
+## `_OakTimeWokeUpText`. `<……>` is `SixDotsCharText`, which is two ellipsis
+## tiles, so each of the first two lines is twelve.
+const WOKE_UP_TEXT: String = "%s\n%s%sZzz… Hm? Wha…?\nYou woke me up!%sWill you check the\nclock for me?"
+
+## `constants/misc_constants.asm`. `GetTimeOfDayString` tests MORN_HOUR, DAY_HOUR
+## and NITE_HOUR in that order and falls through to NITE, so 18 and up is NITE
+## again; `OakText_ResponseToSetTime` tests `DAY_HOUR + 1` instead, which is why
+## its three answers do not split the day where the MORN/DAY/NITE word does.
+const MORN_HOUR: int = 4
+const DAY_HOUR: int = 10
+const NITE_HOUR: int = 18
+const NOON_HOUR: int = 12
+
+## `.loop` and `.HourIsSet` both end on `ld c, 10 / call DelayFrames` before
+## their input loop, and `InterpretTwoOptionMenu` holds `ld c, $f` after an
+## answer, so neither a dial nor a YES/NO reads a button on the frame it is
+## drawn.
+const DIAL_DELAY_FRAMES: int = 10
+const YES_NO_DELAY_FRAMES: int = 15
+
 var _page: Gen2ClockSetPage = null
 var _view: TextureRect = null
-var _phase: int = Phase.HOUR
+var _text_box: Gen2TextBox = null
+var _presentation := Gen2IntroPresentation.new()
+var _after: Callable = Callable()
+var _accumulator: float = 0.0
+var _phase: int = Phase.WOKE_UP
 var _hour: int = 10
 var _minute: int = 0
 ## `InitTimeOfDay` leaves the RTC's own weekday alone, so a new save starts on
 ## SUNDAY and Mom's `SetDayOfWeek` is what changes it.
 var _day: int = 0
 var _confirm_cursor: int = 0
+## True while a queued `DelayFrames` run is being spent, which reads no button.
+var _waiting: bool = false
+## Whether the box was still printing when the screen behind it was last drawn.
+var _revealing: bool = false
 
 
 func open(data: GameData) -> bool:
 	_page = Gen2ClockSetPage.from_data(data)
-	return _page != null
+	if _page == null:
+		return false
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = _page.font
+	_text_box.frame_style = Gen2OptionsStore.current().textbox_frame
+	_text_box.position = Vector2(0, Gen2TextBox.STANDARD_TOP * TILE)
+	return true
 
 
 func _ready() -> void:
@@ -38,50 +80,91 @@ func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	_view = TextureRect.new()
 	_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_view.size = size
 	add_child(_view)
-	_render()
+	if _text_box != null:
+		add_child(_text_box)
+		# `RotateFourPalettesRight` comes back on a screen `ClearTilemap` and
+		# `.ClearScreen` left empty; the first `PrintText` is what puts a box on it.
+		_text_box.visible = false
+	_begin()
+
+
+func _process(delta: float) -> void:
+	if _text_box != null:
+		_text_box.accelerated = Gen2Button.text_accelerating()
+	_accumulator += delta * Gen2IntroPresentation.FRAME_RATE
+	var frames: int = int(_accumulator)
+	_accumulator -= float(frames)
+	advance_frames(frames)
+
+
+## Runs [param count] source frames of whatever the screen is standing in.
+## Public so a test or a preview tool can spend the cartridge's own
+## `DelayFrames` without a clock; [method _process] is the only other caller.
+func advance_frames(count: int) -> void:
+	for _frame: int in count:
+		if _text_box != null:
+			_text_box.advance_frame()
+		if not _waiting:
+			# The YES/NO box is `YesNoBox`, which runs after its question has
+			# finished printing, so the screen behind the box is redrawn on the
+			# frame the reveal ends.
+			if _text_box != null and _revealing != _text_box.is_revealing():
+				_render()
+			continue
+		_presentation.advance_frame()
+		_render()
+		# The last VBlank of a `DelayFrames` run is the frame the routine
+		# returns on, so no frame is spent at a call boundary.
+		if _presentation.finished():
+			_finish_queue()
+
+
+## How many source frames the screen owes before it will read a button: the
+## queued `DelayFrames`, or the rest of a text that is still printing.
+func animation_frames_left() -> int:
+	if _waiting:
+		return _presentation.remaining_frames()
+	return _text_box.frames_left() if _text_box != null else 0
 
 
 func handle_button(button: int) -> bool:
 	if _phase == Phase.DONE:
 		return true
-	if button in [Gen2Button.UP, Gen2Button.DOWN]:
-		if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM]:
-			_confirm_cursor = 1 - _confirm_cursor
-			_render()
-			return true
-		var step: int = 1 if button == Gen2Button.UP else -1
-		match _phase:
-			Phase.HOUR: _hour = wrapi(_hour + step, 0, 24)
-			Phase.MINUTE: _minute = wrapi(_minute + step, 0, 60)
-		_render()
+	if _waiting:
 		return true
-	if button == Gen2Button.B and _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM]:
-		_phase -= 1
-		_confirm_cursor = 0
+	if _text_box != null and _text_box.is_revealing():
+		return true
+	match _phase:
+		Phase.WOKE_UP:
+			if button != Gen2Button.A and button != Gen2Button.B:
+				return false
+			if _text_box.advance():
+				return true
+			_begin_hour()
+			return true
+		Phase.RESPONSE:
+			# `WaitPressAorB_BlinkCursor` takes either.
+			if button != Gen2Button.A and button != Gen2Button.B:
+				return false
+			_phase = Phase.DONE
+			finished.emit(_day, _hour, _minute)
+			return true
+	if _phase == Phase.HOUR_CONFIRM or _phase == Phase.MINUTE_CONFIRM:
+		return _handle_confirm(button)
+	if button in [Gen2Button.UP, Gen2Button.DOWN]:
+		var step: int = 1 if button == Gen2Button.UP else -1
+		if _phase == Phase.HOUR:
+			_hour = wrapi(_hour + step, 0, 24)
+		else:
+			_minute = wrapi(_minute + step, 0, 60)
 		_render()
 		return true
 	if button != Gen2Button.A:
 		return false
-	if _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM] \
-			and _confirm_cursor == 1:
-		_phase -= 1
-		_confirm_cursor = 0
-		_render()
-		return true
-	match _phase:
-		Phase.HOUR:
-			_phase = Phase.HOUR_CONFIRM
-			_confirm_cursor = 0
-		Phase.HOUR_CONFIRM: _phase = Phase.MINUTE
-		Phase.MINUTE:
-			_phase = Phase.MINUTE_CONFIRM
-			_confirm_cursor = 0
-		Phase.MINUTE_CONFIRM:
-			_phase = Phase.DONE
-			finished.emit(_day, _hour, _minute)
-	_render()
+	_begin_confirm()
 	return true
 
 
@@ -89,33 +172,165 @@ func value() -> Dictionary:
 	return {"day": _day, "hour": _hour, "minute": _minute}
 
 
+## `VerticalMenu` under `YesNoBox`: up and down move, A answers the row and B is
+## NO. `InterpretTwoOptionMenu` spends `ld c, $f` on either before the box is
+## closed, so the answer is not acted on until those frames have gone.
+func _handle_confirm(button: int) -> bool:
+	if button in [Gen2Button.UP, Gen2Button.DOWN]:
+		_confirm_cursor = 1 - _confirm_cursor
+		_render()
+		return true
+	if button != Gen2Button.A and button != Gen2Button.B:
+		return false
+	var yes: bool = button == Gen2Button.A and _confirm_cursor == 0
+	_presentation.clear()
+	_presentation.push_delay(YES_NO_DELAY_FRAMES)
+	_queue(_accept_confirm.bind(yes))
+	return true
+
+
+func _accept_confirm(yes: bool) -> void:
+	var hour_phase: bool = _phase == Phase.HOUR_CONFIRM
+	if not yes:
+		# `jr nc` failing takes the hour back to `.loop` and the minutes back to
+		# `.HourIsSet`, which is each dial's own entry.
+		if hour_phase:
+			_begin_hour()
+		else:
+			_begin_minute()
+		return
+	if hour_phase:
+		_begin_minute()
+		return
+	_begin_response()
+
+
+## `OakSpeech`'s `farcall InitClock` opens on `RotateFourPalettesRight`: the
+## caller faded to black over the gender screen, this screen is built behind it
+## and comes back in. `PrintText OakTimeWokeUpText` is what follows.
+func _begin() -> void:
+	_presentation.clear()
+	_presentation.push_rotate_four_right()
+	_queue(_show_woke_up)
+
+
+func _show_woke_up() -> void:
+	_phase = Phase.WOKE_UP
+	var dots: String = "…".repeat(12)
+	_text_box.visible = true
+	# Ends in `prompt`, which is the one text here that loads the arrow.
+	_text_box.show_text(WOKE_UP_TEXT % [
+		dots, dots, Gen2TextStream.PAGE_BREAK, Gen2TextStream.PAGE_BREAK
+	], true)
+	_render()
+
+
+## `.loop`: the question, the dial and its arrows, then `ld c, 10`.
+func _begin_hour() -> void:
+	_phase = Phase.HOUR
+	_show_line("What time is it?")
+	_hold(DIAL_DELAY_FRAMES)
+
+
+## `.HourIsSet`, which is the minutes' own entry and what a refused minute
+## returns to.
+func _begin_minute() -> void:
+	_phase = Phase.MINUTE
+	_show_line("How many minutes?")
+	_hold(DIAL_DELAY_FRAMES)
+
+
+## `.ClearScreen` takes the dial off before either question, so a YES/NO box
+## stands on an otherwise empty screen.
+func _begin_confirm() -> void:
+	_phase = Phase.HOUR_CONFIRM if _phase == Phase.HOUR else Phase.MINUTE_CONFIRM
+	_confirm_cursor = 0
+	_show_line("What?" if _phase == Phase.HOUR_CONFIRM else "Whoa!")
+
+
+## `.MinutesAreSet`: `OakText_ResponseToSetTime` prints the time it was given and
+## then one of three lines, all of which end in `done`, so `WaitPressAorB_
+## BlinkCursor` waits with no arrow shown.
+func _begin_response() -> void:
+	_phase = Phase.RESPONSE
+	_show_line("%s:%02d%s" % [_hour_text(), _minute, _response_line()], false)
+
+
+func _response_line() -> String:
+	if _hour < MORN_HOUR or _hour >= NITE_HOUR:
+		return "!\nNo wonder it's so%sdark!" % Gen2TextStream.SCROLL_BREAK
+	if _hour <= DAY_HOUR:
+		return "!\nI overslept!"
+	return "!\nYikes! I over-%sslept!" % Gen2TextStream.SCROLL_BREAK
+
+
+func _show_line(text: String, blink_cursor: bool = false) -> void:
+	_text_box.visible = true
+	_text_box.show_text(text, blink_cursor)
+	_render()
+
+
+func _hold(frames: int) -> void:
+	_presentation.clear()
+	_presentation.push_delay(frames)
+	_queue(Callable())
+
+
+func _queue(after: Callable) -> void:
+	_after = after
+	_waiting = true
+	_accumulator = 0.0
+	# The routine writes its first palette before the `DelayFrames` that holds
+	# it, so the frame this is queued on is already in that state.
+	_presentation.sync()
+	_render()
+
+
+func _finish_queue() -> void:
+	_presentation.clear()
+	_waiting = false
+	var next: Callable = _after
+	_after = Callable()
+	if next.is_valid():
+		next.call()
+
+
 func _render() -> void:
 	if _view == null or _page == null or _phase == Phase.DONE:
 		return
-	var confirm: bool = _phase in [Phase.HOUR_CONFIRM, Phase.MINUTE_CONFIRM]
-	var value_text: String
-	var prompt: String
-	if _phase in [Phase.MINUTE, Phase.MINUTE_CONFIRM]:
-		value_text = "%d min." % _minute
-		prompt = "Whoa! %d min.?" % _minute if confirm else "How many minutes?"
-	else:
+	var confirm: bool = (_phase == Phase.HOUR_CONFIRM or _phase == Phase.MINUTE_CONFIRM) \
+		and _text_box != null and not _text_box.is_revealing()
+	var kind: StringName = &""
+	var value_text: String = ""
+	if _phase == Phase.HOUR:
+		kind = &"hour"
 		value_text = "%s o'clock" % _hour_text()
-		prompt = "What? %s?" % value_text if confirm else "What time is it?"
+	elif _phase == Phase.MINUTE:
+		kind = &"minutes"
+		value_text = "%d min." % _minute
+	# Every BG palette on screen goes through the frame's own byte, which is what
+	# a hardware fade does to a screen carrying more than one palette.
+	var colors: PackedColorArray = Gen2IntroPresentation.apply_bgp(
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])),
+		_presentation.bgp()
+	)
 	_view.texture = ImageTexture.create_from_image(_page.render(
-		value_text, prompt, _confirm_cursor if confirm else -1, false
+		value_text, "", _confirm_cursor if confirm else -1, kind, colors
 	))
+	if _text_box != null:
+		_text_box.palette = colors
+		_revealing = _text_box.is_revealing()
 
 
 ## `PrintHour` prints `GetTimeOfDayString`'s own MORN/DAY/NITE ahead of the
-## hour, not AM/PM: `constants/misc_constants.asm`'s `MORN_HOUR`/`DAY_HOUR`/
-## `NITE_HOUR` are 4, 10 and 18, so midnight through 3 is still NITE.
+## hour, not AM/PM, and `AdjustHourForAMorPM` turns midnight into twelve.
 func _hour_text() -> String:
-	var shown: int = _hour % 12
+	var shown: int = _hour % NOON_HOUR
 	if shown == 0:
-		shown = 12
+		shown = NOON_HOUR
 	var word: String = "NITE"
-	if _hour >= 4 and _hour < 10:
+	if _hour >= MORN_HOUR and _hour < DAY_HOUR:
 		word = "MORN"
-	elif _hour >= 10 and _hour < 18:
+	elif _hour >= DAY_HOUR and _hour < NITE_HOUR:
 		word = "DAY"
 	return "%s %d" % [word, shown]

--- a/game/world/gender_screen.gd
+++ b/game/world/gender_screen.gd
@@ -19,6 +19,15 @@ var _page: Gen2GenderScreenPage = null
 var _question: String = ""
 var _background: TextureRect = null
 
+## The palette byte every colour on screen is remapped through
+## ([method Gen2IntroPresentation.apply_bgp]). `InitClock` opens with
+## `RotateFourPalettesLeft` over the screen `InitGender` left standing, so this
+## screen is what the next routine's fade-out fades.
+var bgp: int = Gen2IntroPresentation.BGP_NORMAL:
+	set(value):
+		bgp = value
+		_refresh()
+
 
 ## Answers false on a cartridge that has no gender screen, which is Gold and
 ## Silver: `pokegold` ships neither `init_gender.asm` nor its text, so the
@@ -97,5 +106,5 @@ func _refresh() -> void:
 func _palette() -> PackedColorArray:
 	var colors: PackedColorArray = _page.palette
 	if colors.size() < RomLayout.GENDER_SCREEN_PALETTE_COLORS:
-		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
-	return colors
+		colors = Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return Gen2IntroPresentation.apply_bgp(colors, bgp)

--- a/game/world/intro_presentation.gd
+++ b/game/world/intro_presentation.gd
@@ -117,6 +117,20 @@ func push_move_player_pic(right: bool) -> void:
 		push(KEEP, from + index * step, MOVE_STEP_FRAMES)
 
 
+## Applies the queued step's own palette byte and pic column without spending a
+## frame. A routine writes its first palette before the `DelayFrames` that holds
+## it, so a screen drawn between the push and the first VBlank is already in the
+## state the step names rather than one frame behind it.
+func sync() -> void:
+	if finished() or _step_frame != 0:
+		return
+	var step: Array = _steps[_step]
+	if int(step[0]) != KEEP:
+		_bgp = int(step[0])
+	if int(step[1]) != KEEP:
+		_column = int(step[1])
+
+
 ## Advances one source frame. False once the queue has run out, which is what
 ## tells a screen the routine it is standing in has returned.
 func advance_frame() -> bool:

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -23,6 +23,11 @@ signal failed(message: String)
 const WORLD_SCENE: String = "res://game/world/world_screen.tscn"
 const LAUNCHER_SCENE: String = "res://game/main/main.tscn"
 
+## `InitGender`'s trailing `ld c, 10` and `InitClock`'s opening `ld c, 8`, both
+## spent on the gender screen before its fade begins.
+const GENDER_TAIL_FRAMES: int = 10
+const CLOCK_HEAD_FRAMES: int = 8
+
 var _data: GameData = null
 var _slot: int = -1
 var _label: String = ""
@@ -37,6 +42,13 @@ var _clock: Dictionary = {"day": 0, "hour": 10, "minute": 0}
 ## Null when a driver builds this class directly rather than instancing the
 ## scene; the sub-screens are then plain children and draw at their own size.
 var _viewport: Gen2Screen = null
+## The fade between two sub-screens. The cartridge puts those in the caller: the
+## routine being left is still on screen while `RotateFourPalettesLeft` runs, so
+## the screen that hosts both is the one that can spend those frames.
+var _presentation := Gen2IntroPresentation.new()
+var _after: Callable = Callable()
+var _accumulator: float = 0.0
+var _fading: bool = false
 
 
 ## Runs the intro for [param slot] on [param data]. [param standalone] is false
@@ -68,6 +80,41 @@ func _ready() -> void:
 		_start()
 
 
+## Sub-screens that own frames of their own are driven from here, so the whole
+## intro runs on one clock.
+func _process(delta: float) -> void:
+	_accumulator += delta * Gen2IntroPresentation.FRAME_RATE
+	var frames: int = int(_accumulator)
+	_accumulator -= float(frames)
+	advance_frames(frames)
+
+
+## Spends [param count] source frames: the fade this screen is standing in, or
+## whatever the sub-screen under it is standing in. Public so a test or a
+## preview tool spends the cartridge's own `DelayFrames` without a clock.
+func advance_frames(count: int) -> void:
+	for _frame: int in count:
+		if not _fading:
+			var screen: Control = current()
+			if screen != null and screen.has_method(&"advance_frames"):
+				screen.call(&"advance_frames", 1)
+			continue
+		_presentation.advance_frame()
+		_apply_fade()
+		if _presentation.finished():
+			_finish_fade()
+
+
+## How many source frames the intro owes before it will read a button.
+func animation_frames_left() -> int:
+	if _fading:
+		return _presentation.remaining_frames()
+	var screen: Control = current()
+	if screen != null and screen.has_method(&"animation_frames_left"):
+		return int(screen.call(&"animation_frames_left"))
+	return 0
+
+
 ## The eight hardware buttons and nothing else, the way every other screen here
 ## reads input; see `docs/CONTRIBUTING.md`.
 func _unhandled_input(event: InputEvent) -> void:
@@ -84,11 +131,15 @@ func _unhandled_input(event: InputEvent) -> void:
 
 ## Sub-screens draw in the 160x144 space, so they go inside the hardware
 ## viewport when there is one.
+## A sub-screen's own `_process` is turned off once it is in the tree, since a
+## node with one has it enabled again when it is added: the intro owns the clock
+## and drives every screen under it, so nothing runs a second one.
 func _show_sub_screen(node: Control) -> void:
 	if _viewport != null:
 		_viewport.display(node)
-		return
-	add_child(node)
+	else:
+		add_child(node)
+	node.set_process(false)
 
 
 ## The launcher's staged slot, for the scene entered through a scene change.
@@ -115,6 +166,8 @@ func gender() -> int:
 
 
 func handle_button(button: int) -> bool:
+	if _fading:
+		return true
 	var screen: Control = current()
 	return screen.handle_button(button) if screen != null else false
 
@@ -162,11 +215,40 @@ func _start_profile_setup() -> void:
 	_show_sub_screen(_gender_screen)
 
 
+## `InitGender`'s own `ld c, 10 / call DelayFrames` after the choice, then
+## `InitClock`'s `ld c, 8` and its `RotateFourPalettesLeft`, all three of which
+## run with the gender screen still on screen. `_start_clock` is what the fade
+## ends on, so nothing else has to know the clock comes next.
 func _on_gender_chosen(chosen: int) -> void:
 	_gender = chosen
+	_presentation.clear()
+	_presentation.push_delay(GENDER_TAIL_FRAMES + CLOCK_HEAD_FRAMES)
+	_presentation.push_rotate_four_left()
+	_fading = true
+	_accumulator = 0.0
+	_after = _drop_gender_screen
+	_presentation.sync()
+	_apply_fade()
+
+
+func _drop_gender_screen() -> void:
 	Gen2Screen.drop(_gender_screen)
 	_gender_screen = null
 	_start_clock()
+
+
+func _apply_fade() -> void:
+	if _gender_screen != null:
+		_gender_screen.bgp = _presentation.bgp()
+
+
+func _finish_fade() -> void:
+	_presentation.clear()
+	_fading = false
+	var next: Callable = _after
+	_after = Callable()
+	if next.is_valid():
+		next.call()
 
 
 ## `OakSpeech` farcalls `InitClock` before its first `PrintText`, then

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -272,10 +272,10 @@ const WAIT_FRAMES: StringName = &"frames"
 ## delays six.
 const PAUSE_FRAMES_PER_UNIT: int = 2
 const WAIT_FRAMES_PER_UNIT: int = 6
-## `_SetDayOfWeek`'s own `.Days`, which are uppercase like every cartridge string.
-const WEEKDAY_NAMES: Array[StringName] = [
-	&"SUNDAY", &"MONDAY", &"TUESDAY", &"WEDNESDAY", &"THURSDAY", &"FRIDAY", &"SATURDAY",
-]
+## `SetDayOfWeek.WeekdayStrings`, padded the way the source pads them so the
+## name is centred in its nine-wide box. One list, in [Gen2ClockSetScreen],
+## because the dial that draws it is shared with `InitClock`.
+const WEEKDAY_NAMES: Array[String] = Gen2ClockSetScreen.DAYS
 
 ## Crystal event flags used by the player's room decoration callbacks. The
 ## importer keeps raw cartridge flag numbers, so these values match the
@@ -412,7 +412,10 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			var selected_day: int = posmod(choice, WEEKDAY_NAMES.size())
 			_pending = {
 				"type": &"text",
-				"text": "%s,\nis it?" % String(WEEKDAY_NAMES[selected_day]),
+				## `.ConfirmWeekdayText` places the weekday at `hlcoord 1, 14` and
+				## `_OakTimeIsItText` carries on from where `PlaceString` left
+				## off, so the two are one line.
+				"text": "%s, is it?" % WEEKDAY_NAMES[selected_day],
 				"special": &"set_day_of_week_confirmation",
 				"day": selected_day,
 				"source": _request.duplicate(true),

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -1374,7 +1374,7 @@ func _dial_image() -> Image:
 	var day: int = clampi(_cursor, 0, Gen2ClockSetScreen.DAYS.size() - 1)
 	var prompt: String = _summary if not _summary.is_empty() \
 		else "What day is it?"
-	return _clock_page.render(Gen2ClockSetScreen.DAYS[day], prompt, -1, true)
+	return _clock_page.render(Gen2ClockSetScreen.DAYS[day], prompt, -1, &"day")
 
 
 ## The `menu_coords` box this mode's own list sits in. `null` draws no box,

--- a/tests/integration/test_intro_screen.gd
+++ b/tests/integration/test_intro_screen.gd
@@ -29,6 +29,9 @@ func before_each() -> void:
 func after_each() -> void:
 	_clear_saves()
 	RomCache.clear(Fixture.directory())
+	# `Gen2Screen.drop` queues the sub-screen it replaced, and a test that never
+	# reaches a frame would leave every one of them standing as an orphan.
+	await get_tree().process_frame
 
 
 func _clear_saves() -> void:
@@ -59,21 +62,29 @@ func _settle_splash(limit: int = 800) -> void:
 		splash.advance_frames(1)
 
 
-## Spends whatever `DelayFrames` the speech is standing in. The intro's fades
-## and pic moves are real frame counts, so a test drives them rather than
-## skipping them; there is no clock in a GUT run.
+## Spends whatever `DelayFrames` the intro is standing in: its own fade between
+## two sub-screens, or the queue the screen under it is holding. The intro's
+## fades, pic moves and `DelayFrames` are real frame counts, so a test drives
+## them rather than skipping them; there is no clock in a GUT run.
 func _settle(limit: int = 40) -> void:
-	var speech: Gen2OakSpeechScreen = _screen.current() as Gen2OakSpeechScreen
 	for _pass: int in limit:
-		if speech == null or speech.animation_frames_left() == 0:
+		var owed: int = _screen.animation_frames_left()
+		if owed == 0:
 			return
-		speech.advance_frames(speech.animation_frames_left())
+		_screen.advance_frames(owed)
 
 
+## `InitClock` from the gender choice to Oak's speech: the fade in front of it,
+## Oak's woke-up text, both dials and both YES/NO boxes, and his answer.
 func _accept_clock() -> void:
+	_settle()
 	assert_true(_screen.current() is Gen2ClockSetScreen)
-	for _step: int in 6:
+	for _step: int in 12:
+		_settle()
+		if not (_screen.current() is Gen2ClockSetScreen):
+			return
 		_screen.handle_button(Gen2Button.A)
+	_settle()
 
 
 ## Presses A until [param stop] answers, so a test never has to know how many
@@ -135,6 +146,9 @@ func test_the_gender_question_comes_first() -> void:
 	_begin()
 	assert_true(_screen.current() is Gen2GenderScreen)
 	_screen.handle_button(Gen2Button.A)
+	assert_true(_screen.current() is Gen2GenderScreen,
+		"still standing under `RotateFourPalettesLeft`")
+	_settle()
 	assert_true(_screen.current() is Gen2ClockSetScreen, "then InitClock")
 	_accept_clock()
 	assert_true(_screen.current() is Gen2OakSpeechScreen, "then the speech")
@@ -146,16 +160,53 @@ func test_the_gender_question_comes_first() -> void:
 func test_clock_set_wraps_each_source_dial_and_reaches_the_speech() -> void:
 	_begin()
 	_screen.handle_button(Gen2Button.A)
+	_settle()
 	var clock: Gen2ClockSetScreen = _screen.current() as Gen2ClockSetScreen
 	assert_not_null(clock)
+	# `PrintText OakTimeWokeUpText`: three pages before the first dial is drawn.
+	for _page: int in 3:
+		_settle()
+		assert_true(_screen.current() is Gen2ClockSetScreen, "still in the text")
+		clock.handle_button(Gen2Button.A)
+	_settle()
 	clock.handle_button(Gen2Button.DOWN)
 	clock.handle_button(Gen2Button.A)
+	_settle()
+	# `YesNoBox` defaults to YES, and `InterpretTwoOptionMenu` holds `ld c, $f`
+	# before the answer is acted on.
 	clock.handle_button(Gen2Button.A)
+	assert_eq(clock.value()["minute"], 0, "the minutes dial has not been reached")
+	_settle()
 	clock.handle_button(Gen2Button.DOWN)
 	assert_eq(clock.value(), {"day": 0, "hour": 9, "minute": 59})
 	clock.handle_button(Gen2Button.A)
+	_settle()
+	clock.handle_button(Gen2Button.A)
+	_settle()
+	# `.MinutesAreSet`'s `OakText_ResponseToSetTime`, which waits with
+	# `WaitPressAorB_BlinkCursor` before the routine returns.
+	assert_true(_screen.current() is Gen2ClockSetScreen, "Oak answers the time")
 	clock.handle_button(Gen2Button.A)
 	assert_true(_screen.current() is Gen2OakSpeechScreen)
+
+
+## `.loop` and `.HourIsSet` end on `ld c, 10 / call DelayFrames`, and
+## `InterpretTwoOptionMenu` on `ld c, $f`, so neither a dial nor a YES/NO reads
+## a button on the frame it is drawn.
+func test_a_dial_reads_no_button_until_its_delay_frames_have_gone() -> void:
+	_begin()
+	_screen.handle_button(Gen2Button.A)
+	_settle()
+	var clock: Gen2ClockSetScreen = _screen.current() as Gen2ClockSetScreen
+	for _page: int in 3:
+		_settle()
+		clock.handle_button(Gen2Button.A)
+	assert_eq(clock.animation_frames_left(), Gen2ClockSetScreen.DIAL_DELAY_FRAMES)
+	clock.handle_button(Gen2Button.DOWN)
+	assert_eq(clock.value()["hour"], 10, "the dial is still held")
+	_settle()
+	clock.handle_button(Gen2Button.DOWN)
+	assert_eq(clock.value()["hour"], 9)
 
 
 ## `NewGame` reaches `InitializeWorld` only after both have returned, so nothing

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3334,13 +3334,15 @@ func test_set_day_of_week_follows_the_source_selection_and_confirmation_flow() -
 	## `SetDayOfWeek` shows one weekday between two arrows, not a seven-row list:
 	## seven rows at `_InitVerticalMenuCursor`'s two-row step do not fit a screen.
 	assert_eq(menu["event"]["menu_kind"], &"spinner")
+	## `.WeekdayStrings`' own padding, which is what centres the name in the
+	## nine-wide box `hlcoord 10, 5` places it in.
 	assert_eq(menu["event"]["options"], [
-		&"SUNDAY", &"MONDAY", &"TUESDAY", &"WEDNESDAY", &"THURSDAY", &"FRIDAY", &"SATURDAY",
+		" SUNDAY", " MONDAY", " TUESDAY", "WEDNESDAY", "THURSDAY", " FRIDAY", "SATURDAY",
 	])
 
 	var confirmation_text: Dictionary = runner.advance(true, 3)
 	assert_eq(confirmation_text["event"]["type"], &"text")
-	assert_eq(confirmation_text["event"]["text"], "WEDNESDAY,\nis it?")
+	assert_eq(confirmation_text["event"]["text"], "WEDNESDAY, is it?")
 	var confirmation: Dictionary = runner.advance(true)
 	assert_eq(confirmation["event"]["type"], &"choice")
 	assert_eq(confirmation["event"]["choices"], [&"yes", &"no"])

--- a/tools/preview_intro.gd
+++ b/tools/preview_intro.gd
@@ -133,9 +133,16 @@ func _drive(step: Vector2i) -> void:
 		_presses_run = step.x
 		return
 	if _what == "clock":
+		# `x` is A presses and `y` raw frames after them, so a fade or a
+		# `DelayFrames` run can be photographed partway as well as settled.
+		var clock: Gen2ClockSetScreen = _screen as Gen2ClockSetScreen
 		while _presses_run < step.x:
-			_screen.handle_button(Gen2Button.A)
+			_settle_frames(clock)
+			clock.handle_button(Gen2Button.A)
 			_presses_run += 1
+			_frames_run = 0
+		clock.advance_frames(maxi(step.y - _frames_run, 0))
+		_frames_run = maxi(step.y, _frames_run)
 		return
 	var speech: Gen2OakSpeechScreen = _screen as Gen2OakSpeechScreen
 	if _what == "speech":
@@ -144,7 +151,7 @@ func _drive(step: Vector2i) -> void:
 			_frames_run += 1
 		return
 	while _presses_run < step.x:
-		_settle(speech)
+		_settle_frames(speech)
 		speech.handle_button(Gen2Button.A)
 		_presses_run += 1
 		_frames_run = 0
@@ -154,11 +161,13 @@ func _drive(step: Vector2i) -> void:
 	_frames_run = maxi(step.y, _frames_run)
 
 
-func _settle(speech: Gen2OakSpeechScreen) -> void:
+## Spends whatever `DelayFrames` run or printing text a screen is standing in.
+func _settle_frames(screen: Node) -> void:
 	for _pass: int in 40:
-		if speech.animation_frames_left() == 0:
+		var owed: int = int(screen.call(&"animation_frames_left"))
+		if owed == 0:
 			return
-		speech.advance_frames(speech.animation_frames_left())
+		screen.call(&"advance_frames", owed)
 
 
 ## One capture per step, each after a fresh pair of rendered frames so the


### PR DESCRIPTION
The new game's clock screen implemented four of `InitClock`'s steps and invented the rest.

- **Both palette fades.** `RotateFourPalettesLeft` runs over the screen `InitGender` left standing, after that routine's own `ld c, 10` and `InitClock`'s `ld c, 8`, so the fade-out belongs to the caller. `Gen2IntroScreen` owns the frames between two sub-screens now and drives every screen under it, so the intro runs on one clock; `Gen2GenderScreen.bgp` is what it fades. `RotateFourPalettesRight` is the clock screen's own opening.
- **Oak's two speeches.** `OakTimeWokeUpText`, the three pages the routine opens on, and `OakText_ResponseToSetTime`, which prints the time it was given and one of three answers off `MORN_HOUR`, `DAY_HOUR + 1` and `NITE_HOUR`.
- **Both confirmations.** `_OakTimeWhatHoursText` is `text "What?@"` and nothing else, `_OakTimeWhoaMinutesText` is `"Whoa!"`, and `.ClearScreen` runs in front of each, so a `YesNoBox` stands on an empty screen rather than over the dial.
- **The minutes dial was drawn as the hour's.** `.HourIsSet` places `hlcoord 11, 7 / lb bc, 2, 7` with its value at `hlcoord 12, 9`, which is a seven-wide box on the right; `.loop`'s is fifteen wide from column 3. The three dials are one table in `Gen2ClockSetPage.DIALS` now, `SetDayOfWeek`'s included.
- **Every wait.** `.loop` and `.HourIsSet` end on `ld c, 10 / call DelayFrames` and `InterpretTwoOptionMenu` on `ld c, $f`, so neither a dial nor a YES/NO reads a button on the frame it is drawn.

Every line here is a `PrintText`, so the box is a `Gen2TextBox` and reveals at the cartridge's own rate rather than appearing whole.

Two more found on the way, both in the same routine's other half:

- `.ConfirmWeekdayText` is one line and not two: `_OakTimeIsItText` carries on from where `.PlaceWeekdayString` left off, and the string it placed is the padded `" SUNDAY"` rather than a bare name. There is one weekday list now.
- `Gen2IntroPresentation.sync` applies a queued step's palette without spending a frame, so a screen drawn between the push and the first VBlank is not one frame behind the routine it is standing in.

| Check | Result |
|---|---|
| GUT, whole tier | 3,315 tests over 152 scripts, green, no orphans |
| `validate.gd -- all` | 55 topics PASS, exit 0 |
| `replay_world.gd` | 11 routes, 0 failures on each of the three cartridges |
| Story walk, three profiles | no failure, no error line |
| Boot smoke, with and without mods | clean |