### PR TITLE
Register an evolution in the dex, and name what was not nicknamed

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -11,6 +11,9 @@ signal item_used(item: int, target: int)
 ## event rather than the battle result. The host owns the flag, since the battle
 ## engine is scene-free and holds no world state.
 signal enemy_seen(species: int)
+## `.proceed`'s `SetSeenAndCaughtMon` on the species a party member became. The
+## write is the world's, the way `enemy_seen`'s is.
+signal party_evolved(species: int)
 
 ## Owns the battle, the events and the text box; decides nothing about how they
 ## are drawn. A [Gen2Battle] resolves the turn and answers with events; this
@@ -3815,6 +3818,11 @@ func _apply_event_state(event: Dictionary) -> void:
 			# which answers correctly on its own even when the index that gained
 			# it is a benched participant rather than the one on screen.
 			_refresh_exp_bar()
+		Gen2Battle.EVOLVED:
+			# The dex write is all this screen owes the event: nothing here draws
+			# `EvolutionAnimation`, and the panel's own species follows the next
+			# `_push_view`.
+			party_evolved.emit(int(event["new_species"]))
 		Gen2Battle.GREW_LEVEL:
 			# The level number in the panel belongs to whoever is on screen, so it
 			# only moves when the index that grew is the one currently active: a

--- a/game/battle/evolution.gd
+++ b/game/battle/evolution.gd
@@ -77,7 +77,10 @@ static func nickname_after_evolution(
 ) -> String:
 	if data == null or old_species == new_species:
 		return nickname
-	if nickname != String(data.species(old_species).get("name", "")):
+	# A cartridge party row always holds a name, so an empty one here is this
+	# project's own way of saying un-nicknamed rather than a third case.
+	if not nickname.is_empty() \
+		and nickname != String(data.species(old_species).get("name", "")):
 		return nickname
 	return String(data.species(new_species).get("name", nickname))
 

--- a/game/battle/evolution.gd
+++ b/game/battle/evolution.gd
@@ -24,7 +24,8 @@ static func level_evolution(data: GameData, mon: Gen2BattleMon, time_of_day: int
 
 
 ## `.item`, which is the one branch of `EvolveAfterBattle` that never calls
-## `IsMonHoldingEverstone`: a stone used on an EVERSTONE holder evolves it.
+## `IsMonHoldingEverstone`. The refusal is one level up, in `EvoStoneEffect`'s
+## own `cp EVERSTONE`, so it belongs to whoever uses the item rather than here.
 static func item_evolution(data: GameData, mon: Gen2BattleMon, item: int) -> Dictionary:
 	if data == null or mon == null:
 		return {}
@@ -65,6 +66,20 @@ static func evolving_text(mon_name: String) -> String:
 
 static func evolved_text(mon_name: String, new_species_name: String) -> String:
 	return "Congratulations! Your %s evolved into %s!" % [mon_name, new_species_name]
+
+
+## `UpdateSpeciesNameIfNotNicknamed`, which runs before `GetBaseData` reloads
+## the new species: the comparison is against the OLD species' name, since
+## `wBaseDexNo` still holds it. A Pokemon carrying its own species name is not
+## nicknamed, so it takes the new one; anything else keeps what it was called.
+static func nickname_after_evolution(
+	data: GameData, nickname: String, old_species: int, new_species: int
+) -> String:
+	if data == null or old_species == new_species:
+		return nickname
+	if nickname != String(data.species(old_species).get("name", "")):
+		return nickname
+	return String(data.species(new_species).get("name", nickname))
 
 
 static func _eligible(row: Dictionary, mon: Gen2BattleMon, time_of_day: int) -> bool:

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -108,7 +108,13 @@ static func from_battle_party(
 			saved_mon.caught_gender = previous.caught_gender
 			saved_mon.caught_level = previous.caught_level
 			saved_mon.caught_location = previous.caught_location
-			saved_mon.nickname = previous.nickname
+			# `UpdateSpeciesNameIfNotNicknamed`: a party member that evolved
+			# during the battle takes the new species' name unless it was
+			# nicknamed, which is the one thing the old row does not decide.
+			saved_mon.nickname = Gen2Evolution.nickname_after_evolution(
+				party.mons[fought - 1].data, previous.nickname,
+				previous.species, saved_mon.species
+			)
 			saved_mon.original_trainer = previous.original_trainer
 		out.party.append(saved_mon)
 	return out

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1462,7 +1462,11 @@ func _use_summary(item: Dictionary, result: Dictionary) -> String:
 			item_name, int(result.get("repel_steps", 0)),
 		]
 	if StringName(result.get("effect", &"")) == &"evolution" and _data != null:
-		var nickname: String = _target_name(int(result.get("party_index", -1)))
+		## Both boxes read wStringBuffer2, which `GetNickname` filled before the
+		## species was replaced, so neither may be built from the party row: it
+		## already carries the new species and, for an un-nicknamed Pokemon, the
+		## new name.
+		var nickname: String = String(result.get("evolving_name", ""))
 		return "%s %s" % [
 			Gen2Evolution.evolving_text(nickname),
 			Gen2Evolution.evolved_text(nickname, String(

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -299,6 +299,7 @@ static func use_item(
 		"repel_steps": int(effect.get("repel_steps", -1)),
 		"old_species": int(effect.get("old_species", 0)),
 		"new_species": int(effect.get("new_species", 0)),
+		"evolving_name": String(effect.get("evolving_name", "")),
 		"move_offers": effect.get("move_offers", []).duplicate(),
 	}
 
@@ -917,6 +918,12 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 		if not battle_mon.learn_move(move):
 			move_offers.append(move)
 	var evolved_from: int = mon.species
+	# `GetNickname` / `CopyName1` fill wStringBuffer2 BEFORE the species is
+	# replaced, and both `EvolvingText` and `CongratulationsYourPokemonText` read
+	# it, so the two boxes name what the Pokemon was called on the way in. Held
+	# because the rename below is what the name would otherwise be read through.
+	var evolving_name: String = mon.nickname if not mon.nickname.is_empty() \
+		else String(data.species(evolved_from).get("name", ""))
 	mon.species = battle_mon.species
 	mon.nickname = Gen2Evolution.nickname_after_evolution(
 		data, mon.nickname, evolved_from, mon.species
@@ -940,6 +947,7 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 		"effect": &"evolution",
 		"old_species": int(result["old_species"]),
 		"new_species": int(result["new_species"]),
+		"evolving_name": evolving_name,
 		# `.proceed`'s `SetSeenAndCaughtMon`, and `UpdateUnownDex` behind it: the
 		# species a Pokemon became is caught, not only seen.
 		"register_caught": mon.species,

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -285,6 +285,10 @@ static func use_item(
 	)
 	if not bool(committed.get("ok", false)):
 		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	# `.proceed`'s dex writes, on the live state beside every other one: the
+	# caller has the snapshot a refused save rolls back to.
+	_register_caught(world, int(effect.get("register_caught", 0)))
+	_register_unown(world, int(effect.get("register_unown", 0)))
 	return {
 		"ok": true,
 		"item": item,
@@ -888,6 +892,12 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 	var row: Dictionary = {}
 	match method:
 		0, RomLayout.EVOLVE_ITEM:
+			# `EvoStoneEffect`'s own `cp EVERSTONE / jr z, .NoEffect`, which is
+			# where the stone path refuses one and `.item` does not: the check is
+			# the item effect's rather than the predicate's, so a link or field
+			# caller reaching `item_evolution` another way is not bound by it.
+			if battle_mon.item == Gen2Evolution.EVERSTONE:
+				return {}
 			row = Gen2Evolution.item_evolution(
 				data, battle_mon, int(declared.get("parameter", item))
 			)
@@ -906,7 +916,11 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 			continue
 		if not battle_mon.learn_move(move):
 			move_offers.append(move)
+	var evolved_from: int = mon.species
 	mon.species = battle_mon.species
+	mon.nickname = Gen2Evolution.nickname_after_evolution(
+		data, mon.nickname, evolved_from, mon.species
+	)
 	# `.trade`'s `xor a / ld [wTempMonItem], a`: a held requirement is spent by
 	# the evolution it caused.
 	if row.has("consumes_held_item"):
@@ -926,6 +940,12 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 		"effect": &"evolution",
 		"old_species": int(result["old_species"]),
 		"new_species": int(result["new_species"]),
+		# `.proceed`'s `SetSeenAndCaughtMon`, and `UpdateUnownDex` behind it: the
+		# species a Pokemon became is caught, not only seen.
+		"register_caught": mon.species,
+		"register_unown": _unown_form(
+			mon.species, mon.dvs, {"destination": &"party"}
+		),
 		"move_offers": move_offers,
 	}
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2435,6 +2435,7 @@ func _open_battle_host(request: Dictionary) -> void:
 	host.z_index = 10
 	host.mouse_filter = Control.MOUSE_FILTER_STOP
 	add_child(host)
+	host.party_evolved.connect(_on_party_evolved)
 	host.battle_finished.connect(_on_battle_finished)
 	host.enemy_seen.connect(_on_enemy_seen)
 	if not tutorial:
@@ -2479,6 +2480,12 @@ func _open_battle_host(request: Dictionary) -> void:
 func _on_enemy_seen(species: int) -> void:
 	if _world != null and _world.state != null:
 		_world.state.set_species_seen(species)
+
+
+## `.proceed`'s `SetSeenAndCaughtMon`, the write a level evolution owes the dex.
+func _on_party_evolved(species: int) -> void:
+	if _world != null and _world.state != null:
+		_world.state.set_species_caught(species)
 
 
 func _on_capture_requested(ball: int) -> void:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -522,11 +522,15 @@ func _write_stone_item() -> void:
 	for raw: Dictionary in species:
 		match int(raw.get("number", 0)):
 			155:
+				## Distinct names, since the fixture calls every filler species
+				## FILLER and the two boxes are about which name is used.
+				raw["name"] = "CHIKORITA"
 				raw["evolutions"] = [{
 					"method": RomLayout.EVOLVE_ITEM, "parameter": MOON_STONE,
 					"condition": 0, "target": EVOLVED_SPECIES,
 				}]
 			EVOLVED_SPECIES:
+				raw["name"] = "BAYLEEF"
 				raw["learnset"] = [{"level": 5, "move": OFFERED_MOVE}]
 	RomCache.write_json(RomCache.species_path(Fixture.directory()), species)
 	## Reopened the way before_each does: the rows above are read on open.
@@ -580,6 +584,30 @@ func test_a_field_stone_says_the_mon_is_evolving_and_what_it_became() -> void:
 	var result: String = String(host.get("_pack_result"))
 	assert_true(result.contains("%s is evolving!" % nickname), result)
 	assert_true(result.contains("evolved into"), result)
+
+
+## `GetNickname` / `CopyName1` run before the species is replaced, and BOTH
+## boxes read that buffer: an un-nicknamed Pokemon is named by what it WAS on the
+## way in, never by what it became. Reading it back off the party row said
+## "What? <NEW> is evolving!" instead.
+func test_the_evolving_line_names_what_the_mon_was_not_what_it_became() -> void:
+	_write_stone_item()
+	await _open_world()
+	var save: Gen2SaveData = _world_screen._injected_save
+	var before: String = String(_data.species(155).get("name", ""))
+	var after: String = String(_data.species(EVOLVED_SPECIES).get("name", ""))
+	assert_ne(before, after, "the two species are named differently")
+	## No nickname at all, which is the row `_party_targets` used to answer for.
+	save.party[0].nickname = ""
+	var host: Gen2StartMenuScreen = await _open_stone_pack()
+	await _use_stone_on_first_member(host)
+
+	var result: String = String(host.get("_pack_result"))
+	assert_true(result.contains("What? %s is evolving!" % before), result)
+	assert_true(result.contains("Your %s evolved into %s!" % [before, after]), result)
+	assert_false(result.contains("What? %s" % after), result)
+	## `UpdateSpeciesNameIfNotNicknamed` still runs, after both boxes.
+	assert_eq(save.party[0].nickname, after)
 
 
 ## `EvolveAfterBattle` calls `LearnMove` over the new learnset, so a move the new

--- a/tests/unit/test_evolution.gd
+++ b/tests/unit/test_evolution.gd
@@ -72,7 +72,8 @@ func _with_evolution_rows() -> GameData:
 
 
 ## `.item` never calls `IsMonHoldingEverstone`; only `.level`, `.happiness`,
-## `.trade` and `EVOLVE_STAT` do.
+## `.trade` and `EVOLVE_STAT` do. `EvoStoneEffect` is where the pack refuses one,
+## which is Gen2WorldPartyHost's own test, not this predicate's.
 func test_a_stone_evolves_an_everstone_holder_and_a_trade_does_not() -> void:
 	var data: GameData = _with_evolution_rows()
 	var mon := Gen2BattleMon.create(data, Fixture.BULBASAUR, 20, [])

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -257,6 +257,37 @@ func test_a_defined_item_naming_no_method_evolves_nothing() -> void:
 	assert_eq(_save.party[0].species, 2)
 
 
+## `EvoStoneEffect` reads MON_ITEM and refuses before `EvolvePokemon`, so the
+## pack answers "It won't have any effect." even though `.item` itself would
+## have evolved it.
+## `.proceed` runs `SetSeenAndCaughtMon` on the new species, and
+## `UpdateSpeciesNameIfNotNicknamed` before `GetBaseData`: an un-nicknamed
+## Pokemon takes the new name, a nicknamed one keeps its own.
+func test_an_evolution_registers_the_new_species_and_renames_only_the_unnamed() -> void:
+	var source: Gen2BattleMon = Gen2BattleMon.create(_data, 1, 5)
+	_save.party[0] = Gen2SaveBattleAdapter.from_battle_mon(source)
+	_save.party[0].nickname = String(_data.species(1).get("name", ""))
+	assert_false(_world.state.has_caught_species(2))
+
+	assert_true(Gen2WorldPartyHost.use_item(_world, _save, 0x08, 0, false)["ok"])
+
+	assert_true(_world.state.has_caught_species(2), "SetSeenAndCaughtMon")
+	assert_eq(_save.party[0].nickname, String(_data.species(2).get("name", "")))
+
+
+func test_a_stone_will_not_evolve_an_everstone_holder_from_the_pack() -> void:
+	var source: Gen2BattleMon = Gen2BattleMon.create(_data, 1, 5)
+	source.item = Gen2Evolution.EVERSTONE
+	_save.party[0] = Gen2SaveBattleAdapter.from_battle_mon(source)
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x08, 0, false)
+
+	assert_false(result["ok"])
+	assert_eq(StringName(result["reason"]), &"item_has_no_effect")
+	assert_eq(_save.party[0].species, 1)
+	assert_eq(_world.state.item_quantity(0x08), 1, "and the stone is not spent")
+
+
 func _add_party_evolution_metadata() -> void:
 	var species: Array = RomCache.read_json(RomCache.species_path(Fixture.directory()))
 	for raw: Dictionary in species:


### PR DESCRIPTION
Four findings from reading `EvolveAfterBattle` and `EvoStoneEffect` end to end after #319, one of them the mod repository's R32. The evolution gaps the owner asked to have recorded are in `HANDOFF.md`, not here.

| Defect | Source | What it looked like |
|---|---|---|
| Both boxes named what the Pokemon **became** | `GetNickname` / `CopyName1` fill wStringBuffer2 before the species is replaced, and `EvolvingText` **and** `CongratulationsYourPokemonText` both read it | R32, photographed in the mod repository: `What? ALAKAZAM is evolving!` on an un-nicknamed KADABRA, cartridge stones on the same path. `_use_summary` read `_target_name`, which answers off the live save after the commit. `use_item` returns `evolving_name`, held before the species is written. Only `EvolvedIntoText` names the new species, from wStringBuffer1 |
| The EVERSTONE refusal was in the predicate | `EvoStoneEffect`'s `cp EVERSTONE / jr z, .NoEffect` | `.item` never calls `IsMonHoldingEverstone`, but the item effect refuses before `EvolvePokemon` runs at all. #319 moved the check out of the predicate and did not put it back at the item, so a stone evolved an EVERSTONE holder from the pack |
| An evolution registered nothing in the Pokedex | `.proceed`'s `SetSeenAndCaughtMon`, `UpdateUnownDex` | Neither path registered the new species. The pack's answers `register_caught` and `register_unown` for `use_item` to spend the way every other transaction does; the battle's rides a `party_evolved` signal beside `enemy_seen`, which is also the first reader `Gen2Battle.EVOLVED` has ever had |
| An un-nicknamed Pokemon kept its old species' name | `UpdateSpeciesNameIfNotNicknamed` | It runs BEFORE `GetBaseData` reloads, so the comparison is against the OLD species' name, and after both boxes. `from_battle_party` had `saved_mon.nickname = previous.nickname` unconditionally, so a battle evolution was wrong there too |

`test_the_evolving_line_names_what_the_mon_was_not_what_it_became` fails on the old code with `What? BAYLEEF is evolving! Congratulations! Your BAYLEEF evolved into BAYLEEF!`.

## Proof

| Check | Result |
|---|---|
| GUT, `-gdir=res://tests -ginclude_subdirs` | 3,325 / 3,325 over 152 scripts, exit 0 |
| `tools/validate.gd -- all` | 56 topics PASS, 0 FAIL, exit 0 |
| `replay_world.gd` | exit 0, all four runs agree on every route |
| Story walk, gold / silver / crystal | exit 0, no failed step on any of the three |
| Screenshot | `preview_world.gd -- crystal 24 3 <png> live item_evolution_use` |