### PR TITLE
Evolve after the battle, with the animation and Pokerus

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -104,7 +104,6 @@ const STAT_EXP_GAINED: StringName = &"stat_exp_gained"
 ## [code]new_stats[/code] are both [Gen2BattleMon.stats], so a screen can show
 ## what moved without asking the Pokémon twice.
 const GREW_LEVEL: StringName = &"grew_level"
-const EVOLVED: StringName = &"evolved"
 ## A move learned into a slot that had nothing in it, no question asked because
 ## the cartridge does not ask one when there is nowhere for the answer to go.
 const MOVE_LEARNED: StringName = &"move_learned"
@@ -592,6 +591,12 @@ var _future_sight: Dictionary = {
 ## world completion boundary; the move command only scatters the coins.
 var pay_day_money: int = 0
 
+## `wEvolvableFlags`, cleared by `FindFirstAliveMonAndStartBattle` and set per
+## party member that gained a level. `ExitBattle` hands it to `EvolveAfterBattle`
+## on the overworld, so it is read at the completion boundary the way
+## [member pay_day_money] is.
+var _evolvable: Array[int] = []
+
 ## Moves waiting on [method learn_move] or [method decline_move], one queue per
 ## side, FIFO: a level that teaches two moves into a full six-move team asks
 ## about both, one at a time, in the order they were learned.
@@ -929,6 +934,13 @@ func winner() -> Variant:
 	if party(PLAYER).is_wiped() and party(ENEMY).is_wiped():
 		return null
 	return ENEMY if party(PLAYER).is_wiped() else PLAYER
+
+
+## `wEvolvableFlags` read back: the party indices that gained a level in this
+## battle, in party order. Battle-party indices, so a save carrying an egg maps
+## them through [method Gen2SaveBattleAdapter.save_party_index].
+func evolvable_indices() -> Array[int]:
+	return _evolvable.duplicate()
 
 
 ## Whether a side is waiting for somebody to be sent out: the Pokémon that was
@@ -2339,29 +2351,19 @@ func _give_experience_to(
 			"old_level": old_level, "new_level": learner.level,
 			"old_stats": old_stats, "new_stats": learner.stats.duplicate(),
 		})
-		var evolution: Dictionary = Gen2Evolution.level_evolution(
-			data, learner, time_of_day
-		)
-		if not evolution.is_empty():
-			var evolved: Dictionary = Gen2Evolution.evolve(
-				learner, int(evolution.get("target", 0))
-			)
-			if not evolved.is_empty():
-				events.append({
-					"type": EVOLVED, "side": PLAYER, "index": index,
-					"old_species": int(evolved["old_species"]),
-					"new_species": int(evolved["new_species"]),
-					"level": learner.level, "hp": learner.hp,
-					"max_hp": learner.max_hp(),
-				})
-		# `LearnLevelMoves` runs after the species has been replaced, so an
-		# evolved species gets its own move at the level that triggered it.
 		_offer_moves_learned_at(learner, index, learner.level, events)
 
 	## `LevelUpHappinessMod` sits after `.level_loop`, outside it: an award that
 	## crossed four levels raises happiness once, not four times.
 	if grew:
 		_gain_level_happiness(learner)
+		## The `SmallFarFlagAction SET_FLAG` at the end of the same block, which
+		## is what `EvolveAfterBattle` walks the party against once the battle is
+		## over and won. Nothing evolves in here: `ExitBattle` runs the pass on
+		## the overworld, so a Pokemon that levels up and then loses the fight
+		## does not evolve at all.
+		if not _evolvable.has(index):
+			_evolvable.append(index)
 
 
 ## `LevelUpHappinessMod`: HAPPINESS_GAINLEVELATHOME when the Pokémon is standing

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -11,9 +11,6 @@ signal item_used(item: int, target: int)
 ## event rather than the battle result. The host owns the flag, since the battle
 ## engine is scene-free and holds no world state.
 signal enemy_seen(species: int)
-## `.proceed`'s `SetSeenAndCaughtMon` on the species a party member became. The
-## write is the world's, the way `enemy_seen`'s is.
-signal party_evolved(species: int)
 
 ## Owns the battle, the events and the text box; decides nothing about how they
 ## are drawn. A [Gen2Battle] resolves the turn and answers with events; this
@@ -2926,8 +2923,13 @@ func _finish_world_battle() -> void:
 		"request": _world_battle_request.duplicate(true),
 		"save_written": _save_written,
 	}
-	if outcome == Gen2WorldBattleAdapter.OUTCOME_WON and _battle.pay_day_money > 0:
-		result["pay_day_money"] = _battle.pay_day_money
+	if outcome == Gen2WorldBattleAdapter.OUTCOME_WON:
+		if _battle.pay_day_money > 0:
+			result["pay_day_money"] = _battle.pay_day_money
+		## `ExitBattle`'s `and $f / ret nz`: `wEvolvableFlags` is only ever read
+		## after a battle that was WON, so a fight that was lost or run from
+		## carries nothing for the overworld's own `EvolveAfterBattle` to walk.
+		result["evolvable"] = _battle.evolvable_indices()
 	if outcome == Gen2WorldBattleAdapter.OUTCOME_LOST:
 		result["recovery"] = _world_battle_recovery.duplicate(true)
 	_world_battle_completion_sent = true
@@ -3818,11 +3820,6 @@ func _apply_event_state(event: Dictionary) -> void:
 			# which answers correctly on its own even when the index that gained
 			# it is a benched participant rather than the one on screen.
 			_refresh_exp_bar()
-		Gen2Battle.EVOLVED:
-			# The dex write is all this screen owes the event: nothing here draws
-			# `EvolutionAnimation`, and the panel's own species follows the next
-			# `_push_view`.
-			party_evolved.emit(int(event["new_species"]))
 		Gen2Battle.GREW_LEVEL:
 			# The level number in the panel belongs to whoever is on screen, so it
 			# only moves when the index that grew is the one currently active: a

--- a/game/battle/evolution.gd
+++ b/game/battle/evolution.gd
@@ -128,3 +128,75 @@ static func evolve(mon: Gen2BattleMon, target: int) -> Dictionary:
 	# `evolve.asm` adds the max-HP delta, preserving damage through evolution.
 	mon.hp = clampi(old_hp + mon.max_hp() - before_max_hp, 0, mon.max_hp())
 	return {"old_species": old_species, "new_species": target}
+
+
+## `StoppedEvolvingText`, printed by `CancelEvolution` before the master loop
+## moves on to the next party member.
+static func stopped_evolving_text(mon_name: String) -> String:
+	return "Huh? %s stopped evolving!" % mon_name
+
+
+## `EvolveAfterBattle`'s master loop, as a list of plans rather than a walk that
+## evolves as it goes: nothing here writes a party row, so a caller can show
+## `EvolutionAnimation` for each and apply only the ones that were not cancelled.
+##
+## [param evolvable] is `wEvolvableFlags` as [method Gen2Battle.evolvable_indices]
+## answers it: BATTLE-party indices, mapped here through the one rule that knows
+## an egg keeps its party slot without being a combatant. Only `.level`,
+## `.happiness` and `.stat` are reachable on this path: `wForceEvolution` is zero,
+## which is what `.item` demands, and `.trade` demands a `wLinkMode` this project
+## has none of.
+static func after_battle(
+	data: GameData, save: Gen2SaveData, evolvable: Array, time_of_day: int
+) -> Array:
+	var plans: Array = []
+	if data == null or save == null:
+		return plans
+	var flagged: Array[int] = []
+	for battle_index: int in evolvable:
+		var mapped: int = Gen2SaveBattleAdapter.save_party_index(save, int(battle_index))
+		if mapped >= 0:
+			flagged.append(mapped)
+	for index: int in save.party.size():
+		if not flagged.has(index):
+			continue
+		var mon: Gen2SaveMon = save.party[index]
+		if mon == null or mon.is_egg:
+			continue
+		var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, mon)
+		if battle_mon == null:
+			continue
+		var row: Dictionary = level_evolution(data, battle_mon, time_of_day)
+		if row.is_empty():
+			continue
+		var target: int = int(row.get("target", 0))
+		if target <= 0 or target == mon.species or data.species(target).is_empty():
+			continue
+		plans.append({
+			"index": index,
+			"old_species": mon.species,
+			"new_species": target,
+			"level": mon.level,
+			# `GetNickname` / `CopyName1` fill wStringBuffer2 before the species is
+			# replaced, and all four boxes read it, so every line of the sequence
+			# names what the Pokemon was called on the way in.
+			"evolving_name": mon.nickname if not mon.nickname.is_empty() \
+				else String(data.species(mon.species).get("name", "")),
+			# `.check_statused`'s `CheckFaintedFrzSlp`, which costs the cry and the
+			# closing `AnimateFrontpic` both.
+			"statused": is_statused(mon),
+			# `.pressed_b` reads `wForceEvolution`: a level evolution is not
+			# forced, so B cancels it, and an item's is and B does nothing.
+			"can_cancel": true,
+			"row": row.duplicate(true),
+		})
+	return plans
+
+
+## `CheckFaintedFrzSlp`, which `EvolutionAnimation.check_statused` asks about the
+## party row rather than about a battler: fainted, frozen or asleep.
+static func is_statused(mon: Gen2SaveMon) -> bool:
+	if mon == null:
+		return true
+	return mon.hp <= 0 or (mon.status & Gen2Status.FREEZE) != 0 \
+		or Gen2Status.is_asleep(mon.status)

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -137,3 +137,21 @@ static func to_battle_party(data: GameData, save: Gen2SaveData) -> Gen2Party:
 			return null
 		members.append(mon)
 	return Gen2Party.create(members)
+
+
+## Where battle-party slot [param battle_index] sits in [param save]'s party.
+## `CheckIfCurPartyMonIsFitToFight` refuses an EGG as a combatant but leaves it
+## in its party slot, so [method to_battle_party] skips it and the two lists
+## stop lining up the moment a party carries one. -1 when there is no such slot.
+static func save_party_index(save: Gen2SaveData, battle_index: int) -> int:
+	if save == null or battle_index < 0:
+		return -1
+	var seen: int = 0
+	for index: int in save.party.size():
+		var mon: Gen2SaveMon = save.party[index]
+		if mon != null and mon.is_egg:
+			continue
+		if seen == battle_index:
+			return index
+		seen += 1
+	return -1

--- a/game/world/evolution_screen.gd
+++ b/game/world/evolution_screen.gd
@@ -1,0 +1,467 @@
+class_name Gen2EvolutionScreen
+extends Control
+
+## `EvolveAfterBattle`'s `.proceed` and the `EvolutionAnimation` it farcalls,
+## for one plan at a time out of [method Gen2Evolution.after_battle].
+##
+## Presentation only: nothing here writes a party row. Each plan is announced
+## with [signal resolved] at the point `.proceed` writes the new species, so the
+## caller applies it in the source's own order and the next plan starts after it.
+##
+## Two pieces of `.PlayEvolvedSFX` are not drawn: the thirty-two balls of light
+## are sprite-anim objects and this project has no sprite-anim layer outside the
+## intro, so their frames are spent and the screen holds the new picture through
+## them. Everything else, including both cries, the flash loop's own rising and
+## falling counters and `AnimateFrontpic ANIM_MON_EVOLVE`, is the routine's.
+
+signal resolved(plan: Dictionary, canceled: bool)
+signal closed()
+## `PlayMonCry`, `PlaySFX` and `PlayMusic`, all through the overworld's own
+## driver the way the Hall of Fame's and the Pokedex's are.
+signal cry_requested(species: int)
+signal sfx_requested(index: int)
+signal music_requested(index: int)
+
+## constants/music_constants.asm.
+const MUSIC_NONE: int = 0
+const MUSIC_EVOLUTION: int = 0x22
+## constants/sfx_constants.asm.
+const SFX_EVOLVED: int = 0x4F
+const SFX_CAUGHT_MON: int = 0x2F
+
+const TILE: int = Gen2Font.TILE
+## `hlcoord 7, 2`, the 7x7 block both pics are placed in.
+const PIC_AT: Vector2i = Vector2i(7, 2)
+const BOX: int = Gen2PicImage.FRONTPIC_TILES
+
+## `.proceed`'s own `ld c, 50` after `EvolvingText`, and the `ld c, 40` after
+## `SFX_CAUGHT_MON` at the end of it.
+const EVOLVING_FRAMES: int = 50
+const CAUGHT_FRAMES: int = 40
+## `EvolutionAnimation`'s `ld c, 80` between `MUSIC_EVOLUTION` and the sequence.
+const MUSIC_FRAMES: int = 80
+## `.AnimationSequence`'s `lb bc, 1, 2 * 7`: b flashes rising by one and c frames
+## falling by two, so seven passes of 14, 12 ... 2 frames.
+const FLASH_START_WAIT: int = 2 * 7
+## Each `.ReplaceFrontpic` ends in `WaitBGMap`, so one half of a flash is one
+## frame and a flash is two.
+const REPLACE_FRAMES: int = 1
+## `.balls_of_light` spends a frame per jumptable step over its own 32, and
+## `.done` spends 32 more.
+const BALLS_FRAMES: int = 64
+
+enum Phase {
+	EVOLVING,
+	HOLD,
+	FLASH,
+	REPLACE,
+	BALLS,
+	ANIMATE,
+	CONGRATULATIONS,
+	CANCELED,
+	DONE,
+}
+
+var _data: GameData = null
+var _plans: Array = []
+var _index: int = 0
+var _phase: int = Phase.DONE
+var _frames: int = 0
+var _canceled: bool = false
+## Whether B arrived since the last frame; see [method advance_frame].
+var _b_held: bool = false
+var _showing_new: bool = false
+## The flash loop's own `b` and `c`, and how much of the current pass is left.
+var _flash_b: int = 1
+var _flash_c: int = FLASH_START_WAIT
+var _flash_left: int = 0
+var _flashes_left: int = 0
+var _animation: Gen2PicAnimation = null
+var _animation_pixels: PackedByteArray = PackedByteArray()
+
+var _backdrop: ColorRect = null
+var _pic: TextureRect = null
+var _text_box: Gen2TextBox = null
+
+
+## [param plans] is [method Gen2Evolution.after_battle]'s list. An empty one
+## closes on the frame it is opened, the way the Hall of Fame's does.
+func set_context(data: GameData, plans: Array) -> void:
+	_data = data
+	_plans = plans.duplicate()
+	_index = 0
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _plans.is_empty():
+		closed.emit()
+		return
+	_build()
+	_begin_plan()
+
+
+func remaining() -> int:
+	return maxi(_plans.size() - _index, 0)
+
+
+func current_plan() -> Dictionary:
+	if _index < 0 or _index >= _plans.size():
+		return {}
+	return _plans[_index]
+
+
+func phase() -> int:
+	return _phase
+
+
+## Whether the sequence is standing on a press: a page with another behind it,
+## which is `Paragraph`'s own `PromptButton`, or `StoppedEvolvingText`'s `prompt`.
+## Every other wait in the routine is a `DelayFrames` count.
+func awaiting_press() -> bool:
+	if _text_box == null or not _text_box.visible:
+		return false
+	return _text_box.has_pages_left() or _phase == Phase.CANCELED
+
+
+## Every line the box is holding, its pages in order. What the sequence says is
+## read through this rather than through the plan it was built from.
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+## `.WaitFrames_CheckPressedB` reads `hJoyDown`, which is the button being HELD
+## rather than a fresh press, and only inside the flash loop.
+func handle_button(button: int) -> bool:
+	if button == Gen2Button.B:
+		_b_held = true
+		return true
+	if button == Gen2Button.A and _text_box != null and _text_box.visible \
+		and (_text_box.is_revealing() or _text_box.has_pages_left()):
+		_text_box.advance()
+		return true
+	if button == Gen2Button.A and _phase == Phase.CANCELED:
+		_finish_plan()
+		return true
+	return false
+
+
+func _build() -> void:
+	_backdrop = ColorRect.new()
+	_backdrop.color = Color.WHITE
+	_backdrop.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_backdrop.visible = false
+	add_child(_backdrop)
+
+	_pic = TextureRect.new()
+	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_pic.visible = false
+	add_child(_pic)
+
+	_text_box = Gen2TextBox.new()
+	## The overworld owns the frame here too, so the reveal is spent from
+	## [method advance_frame] rather than from real time.
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	## The OPTION menu's own TEXT SPEED and frame, the way every other box in the
+	## overworld is drawn: this one is `PrintText` like the rest.
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+## `.proceed` up to its `ld c, 50`: the name is read before the species is
+## replaced, so the box is built from the plan rather than from the party.
+func _begin_plan() -> void:
+	var plan: Dictionary = current_plan()
+	if plan.is_empty():
+		_phase = Phase.DONE
+		closed.emit()
+		return
+	_canceled = false
+	_b_held = false
+	_showing_new = false
+	## `EvolvingText` is printed over the map, before the `ClearBox` that takes
+	## it down, so this phase draws no backdrop of its own.
+	_backdrop.visible = false
+	_pic.visible = false
+	_show_text(Gen2Evolution.evolving_text(String(plan.get("evolving_name", ""))))
+	_enter(Phase.EVOLVING, EVOLVING_FRAMES)
+
+
+func _enter(next: int, frames: int) -> void:
+	_phase = next
+	_frames = frames
+
+
+func _show_text(text: String) -> void:
+	if _text_box == null:
+		return
+	_text_box.visible = true
+	## Neither `EvolvingText` nor `EvolvedIntoText` ends in `prompt`, and
+	## `StoppedEvolvingText` does: the arrow follows the terminator, not the wait.
+	_text_box.show_text(text, _phase == Phase.CANCELED)
+
+
+## One hardware frame. Every wait in the routine is a `DelayFrames` count, so
+## the whole sequence is spent from the overworld's own pump.
+func advance_frame() -> void:
+	if _phase == Phase.DONE or _data == null:
+		return
+	if _text_box != null:
+		_text_box.advance_frame()
+		## A page still printing, or one with another behind it, is what the
+		## routine's own `PrintText` is waiting on before its `DelayFrames`.
+		if _text_box.visible and (_text_box.is_revealing() or _text_box.has_pages_left()):
+			return
+	## `hJoyDown` is the pad as it stands rather than a latch, and it is read on
+	## the wait frames alone, so a press is offered to this frame and dropped.
+	var pressed_b: bool = _b_held
+	_b_held = false
+	match _phase:
+		Phase.EVOLVING:
+			if _spend():
+				_open_animation()
+		Phase.HOLD:
+			if _spend():
+				_begin_flash()
+		Phase.FLASH:
+			_advance_flash(pressed_b)
+		Phase.REPLACE:
+			if _spend():
+				_begin_balls()
+		Phase.BALLS:
+			if _spend():
+				_open_frontpic_animation()
+		Phase.ANIMATE:
+			_advance_frontpic_animation()
+		Phase.CONGRATULATIONS:
+			if _spend():
+				_finish_plan()
+		Phase.CANCELED:
+			## `StoppedEvolvingText` ends in `prompt`, so this one waits on a
+			## press rather than on a count.
+			pass
+
+
+## True on the frame the countdown runs out.
+func _spend() -> bool:
+	_frames -= 1
+	return _frames <= 0
+
+
+## `EvolutionAnimation` up to its `ld c, 80`: the map is cleared, the OLD pic is
+## placed, the cry plays unless the Pokemon is statused, and the evolution track
+## takes over from whatever was playing.
+func _open_animation() -> void:
+	var plan: Dictionary = current_plan()
+	_text_box.visible = false
+	_backdrop.visible = true
+	_pic.visible = true
+	_draw_species(int(plan.get("old_species", 0)))
+	music_requested.emit(MUSIC_NONE)
+	if not bool(plan.get("statused", false)):
+		cry_requested.emit(int(plan.get("old_species", 0)))
+	music_requested.emit(MUSIC_EVOLUTION)
+	_enter(Phase.HOLD, MUSIC_FRAMES)
+
+
+func _begin_flash() -> void:
+	_flash_b = 1
+	_flash_c = FLASH_START_WAIT
+	_flash_left = _flash_c
+	_flashes_left = _flash_b * 2
+	_phase = Phase.FLASH
+
+
+## `.loop`: `c` frames of `.WaitFrames_CheckPressedB`, then `.Flash` b times,
+## then `inc b` and two `dec c`, until c reaches zero. B is read during the wait
+## alone, which is why a press landing inside a flash cancels nothing on the
+## cartridge either.
+func _advance_flash(pressed_b: bool) -> void:
+	if _flash_left > 0:
+		if pressed_b and bool(current_plan().get("can_cancel", true)):
+			_cancel()
+			return
+		_flash_left -= 1
+		return
+	if _flashes_left > 0:
+		## One `.ReplaceFrontpic` is one `WaitBGMap`, so a flash is two frames:
+		## the new stage on the first and the old one back on the second.
+		_flashes_left -= 1
+		_show_stage(not _showing_new)
+		if _flashes_left > 0:
+			return
+	_flash_c -= 2
+	if _flash_c <= 0:
+		_settle()
+		return
+	_flash_b += 1
+	_flash_left = _flash_c
+	_flashes_left = _flash_b * 2
+
+
+## The `ld a, -7 * 7 / .ReplaceFrontpic` after the sequence: the new stage is
+## left standing, `SFX_EVOLVED` plays and the balls of light run over it.
+func _settle() -> void:
+	_show_stage(true)
+	_enter(Phase.REPLACE, REPLACE_FRAMES)
+
+
+func _begin_balls() -> void:
+	sfx_requested.emit(SFX_EVOLVED)
+	_enter(Phase.BALLS, BALLS_FRAMES)
+
+
+## `.cancel_evo`: the old stage stays, `.PlayEvolvedSFX` returns without a sound
+## because `wEvolutionCanceled` is set, and a Pokemon that is not statused cries.
+func _cancel() -> void:
+	_canceled = true
+	_show_stage(false)
+	var plan: Dictionary = current_plan()
+	if not bool(plan.get("statused", false)):
+		cry_requested.emit(int(plan.get("old_species", 0)))
+	_phase = Phase.CANCELED
+	_backdrop.visible = true
+	_show_text(Gen2Evolution.stopped_evolving_text(
+		String(plan.get("evolving_name", ""))
+	))
+
+
+## `AnimateFrontpic ANIM_MON_EVOLVE`, skipped for a statused Pokemon along with
+## the cry, and absent from Gold and Silver, which have no pic animation at all.
+func _open_frontpic_animation() -> void:
+	var plan: Dictionary = current_plan()
+	var species: int = int(plan.get("new_species", 0))
+	var record: Dictionary = _data.pic_animation(species)
+	if bool(plan.get("statused", false)) or record.is_empty():
+		_open_congratulations()
+		return
+	_animation = Gen2PicAnimation.new(record, Gen2PicAnimation.ANIM_MON_EVOLVE)
+	_animation_pixels = Gen2BattleRenderer.padded_pic(
+		_data, _data.species_pic(species), BOX, true,
+		_data.species_pic_animation(species)
+	)
+	_phase = Phase.ANIMATE
+	_advance_frontpic_animation()
+
+
+func _advance_frontpic_animation() -> void:
+	if _animation == null:
+		_open_congratulations()
+		return
+	var cry: StringName = _animation.advance()
+	if cry != &"":
+		cry_requested.emit(int(current_plan().get("new_species", 0)))
+	_draw_animation_box()
+	if _animation.finished():
+		_animation = null
+		_animation_pixels = PackedByteArray()
+		_open_congratulations()
+
+
+## `CongratulationsYourPokemonText` and `EvolvedIntoText`, then `MUSIC_NONE`,
+## `SFX_CAUGHT_MON`, `WaitSFX` and `ld c, 40`.
+func _open_congratulations() -> void:
+	var plan: Dictionary = current_plan()
+	_show_stage(true)
+	_phase = Phase.CONGRATULATIONS
+	_show_text(Gen2Evolution.evolved_text(
+		String(plan.get("evolving_name", "")),
+		String(_data.species(int(plan.get("new_species", 0))).get("name", ""))
+	))
+	music_requested.emit(MUSIC_NONE)
+	sfx_requested.emit(SFX_CAUGHT_MON)
+	_frames = CAUGHT_FRAMES
+
+
+## `.proceed`'s write, or `CancelEvolution`'s `jp EvolveAfterBattle_MasterLoop`.
+func _finish_plan() -> void:
+	var plan: Dictionary = current_plan()
+	if not plan.is_empty():
+		resolved.emit(plan.duplicate(true), _canceled)
+	_index += 1
+	if _text_box != null:
+		_text_box.visible = false
+	if _index >= _plans.size():
+		_phase = Phase.DONE
+		closed.emit()
+		return
+	_begin_plan()
+
+
+func _show_stage(new_stage: bool) -> void:
+	_showing_new = new_stage
+	var plan: Dictionary = current_plan()
+	_draw_species(int(plan.get(
+		"new_species" if new_stage else "old_species", 0
+	)))
+
+
+func _draw_species(species: int) -> void:
+	if _pic == null or _data == null:
+		return
+	var pic: Dictionary = _data.species_pic(species)
+	if pic.is_empty():
+		_pic.texture = null
+		return
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.palette(species)
+	)
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = Vector2(image.get_size())
+	## `PadFrontpic` bottom-aligns a pic shorter than the block one column in,
+	## which is where `PlaceGraphic`'s tile numbers put it.
+	@warning_ignore("integer_division")
+	var columns: int = image.get_width() / TILE
+	@warning_ignore("integer_division")
+	var rows: int = image.get_height() / TILE
+	_pic.position = Vector2(
+		(PIC_AT.x + Gen2PicImage.frontpic_pad_columns(columns)) * TILE,
+		(PIC_AT.y + Gen2PicImage.frontpic_pad_rows(rows)) * TILE
+	)
+
+
+## The animation's own 7x7 box, drawn out of the same padded strip the battle
+## renderer reads: a cell is `column * 7 + row` into the box and its value is a
+## tile number down the strip's columns.
+func _draw_animation_box() -> void:
+	if _pic == null or _animation == null:
+		return
+	var square: int = BOX * BOX
+	if _animation.box.size() != square or _animation_pixels.is_empty():
+		return
+	var side: int = BOX * TILE
+	@warning_ignore("integer_division")
+	var strip: int = _animation_pixels.size() / side
+	var indices: PackedByteArray = PackedByteArray()
+	indices.resize(side * side)
+	for column: int in BOX:
+		for row: int in BOX:
+			var tile: int = int(_animation.box[column * BOX + row])
+			@warning_ignore("integer_division")
+			var source_x: int = (tile / BOX) * TILE
+			var source_y: int = (tile % BOX) * TILE
+			if source_x + TILE > strip:
+				continue
+			for line: int in TILE:
+				var from: int = (source_y + line) * strip + source_x
+				var to: int = (row * TILE + line) * side + column * TILE
+				for x: int in TILE:
+					indices[to + x] = _animation_pixels[from + x]
+	var image: Image = Gen2PicImage.from_indices(
+		indices, side, side,
+		_data.palette(int(current_plan().get("new_species", 0)))
+	)
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = Vector2(image.get_size())
+	_pic.position = Vector2(PIC_AT.x * TILE, PIC_AT.y * TILE)

--- a/game/world/evolution_screen.gd.uid
+++ b/game/world/evolution_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://b8n18gjhd7gwy

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -23,6 +23,11 @@ signal closed
 ## The payload is the resolved effect, because the screen hosting the world is
 ## the one that can cast a rod or draw a warp.
 signal field_item_used(request: Dictionary)
+
+## `EvoStoneEffect`'s own `EvolvePokemon`: the pack has already written the party
+## row, and the animation belongs to the screen the overworld hosts. [param after]
+## is this menu's own continuation, run when that screen closes.
+signal evolution_animation_requested(plan: Dictionary, after: Callable)
 ## `PlaySFX`, which this screen has no driver of its own for: the world that
 ## hosts it owns the player. `SFX_SAVE` is the only one it asks for.
 signal sfx_requested(sfx: int, waited: bool)
@@ -1418,9 +1423,18 @@ func _use_selected_item(party_index: int) -> void:
 	if StringName(result.get("effect", &"")) == &"evolution":
 		_forget_party_index = party_index
 		_evolution_offers.assign(result.get("move_offers", []))
-		_show_pack_result(
-			_use_summary(item, result), true, _offer_next_evolution_move
-		)
+		## `EvoStoneEffect` reaches `EvolvePokemon` with `wForceEvolution` set, so
+		## the same `EvolutionAnimation` runs and its B does nothing: the whole
+		## presentation is the screen the after-battle pass uses, and this path
+		## prints no box of its own.
+		evolution_animation_requested.emit({
+			"index": party_index,
+			"old_species": int(result.get("old_species", 0)),
+			"new_species": int(result.get("new_species", 0)),
+			"evolving_name": String(result.get("evolving_name", "")),
+			"statused": Gen2Evolution.is_statused(_pack_save.party[party_index]),
+			"can_cancel": false,
+		}, _offer_next_evolution_move)
 		return
 	_show_pack_result(_use_summary(item, result), true)
 
@@ -1460,18 +1474,6 @@ func _use_summary(item: Dictionary, result: Dictionary) -> String:
 	if int(result.get("repel_steps", -1)) >= 0:
 		return "%s will repel weak Pokemon for %d steps." % [
 			item_name, int(result.get("repel_steps", 0)),
-		]
-	if StringName(result.get("effect", &"")) == &"evolution" and _data != null:
-		## Both boxes read wStringBuffer2, which `GetNickname` filled before the
-		## species was replaced, so neither may be built from the party row: it
-		## already carries the new species and, for an un-nicknamed Pokemon, the
-		## new name.
-		var nickname: String = String(result.get("evolving_name", ""))
-		return "%s %s" % [
-			Gen2Evolution.evolving_text(nickname),
-			Gen2Evolution.evolved_text(nickname, String(
-				_data.species(int(result.get("new_species", 0))).get("name", "")
-			)),
 		]
 	var healed: int = int(result.get("healed", 0))
 	if healed > 0:

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -21,6 +21,10 @@ const ITEM_POKE_BALL: int = 0x05
 ## The Bug Contest's own ball. It is never in the bag: `wParkBallsRemaining` is
 ## what holds it and `BattleMenu_Pack`'s contest branch loads it by name.
 const ITEM_PARK_BALL: int = 0xB1
+## `ConvertBerriesToBerryJuice`'s own three constants.
+const ITEM_BERRY: int = 0xAD
+const ITEM_BERRY_JUICE: int = 0x8B
+const SHUCKLE: int = 0xD5
 
 ## HAPPINESS_THRESHOLD_1 and HAPPINESS_THRESHOLD_2
 ## (constants/pokemon_data_constants.asm), which pick a HappinessChanges column.
@@ -908,6 +912,21 @@ static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -
 			return {}
 	if row.is_empty():
 		return {}
+	return apply_evolution(data, mon, row)
+
+
+## `.proceed` and everything past it: the species is replaced, `CalcMonStats`
+## adds the max-HP delta, `UpdateSpeciesNameIfNotNicknamed` renames an
+## un-nicknamed row and `LearnLevelMoves` offers what the new species knows at
+## the level that triggered it. Shared, because the master loop reaches it from a
+## level evolution and `EvoStoneEffect` from an item, and only the predicate in
+## front of it differs.
+static func apply_evolution(data: GameData, mon: Gen2SaveMon, row: Dictionary) -> Dictionary:
+	if data == null or mon == null or row.is_empty():
+		return {}
+	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, mon)
+	if battle_mon == null:
+		return {}
 	var result: Dictionary = Gen2Evolution.evolve(battle_mon, int(row.get("target", 0)))
 	if result.is_empty():
 		return {}
@@ -1115,3 +1134,147 @@ static func _world_name(data: GameData, bank: int, address: int) -> String:
 
 static func _failure(reason: StringName, details: Dictionary) -> Dictionary:
 	return {"ok": false, "handled": false, "reason": reason, "details": details.duplicate(true)}
+
+
+## `GivePokerusAndConvertBerries`, the line `ExitBattle` runs one after
+## `EvolveAfterBattle`. Both halves are gated on
+## `STATUSFLAGS2_REACHED_GOLDENROD_F`, and both are pure party writes, so the
+## whole routine is one call the world boundary makes on a battle it won.
+##
+## Returns what changed, for a caller that wants to say so: an empty dictionary
+## when neither half did anything.
+static func give_pokerus_and_convert_berries(
+	data: GameData, save: Gen2SaveData, world: Gen2WorldAPI,
+	random: RandomNumberGenerator
+) -> Dictionary:
+	if save == null or random == null:
+		return {}
+	var reached: bool = world != null and world.state != null \
+		and world.state.reached_goldenrod(Gen2WorldState.is_crystal_profile(data))
+	var out: Dictionary = {}
+	var juice: int = _convert_berries_to_berry_juice(save, reached, random)
+	if juice >= 0:
+		out["berry_juice_index"] = juice
+	var infected: Dictionary = _give_pokerus(save, reached, random)
+	if not infected.is_empty():
+		out.merge(infected)
+	return out
+
+
+## `ConvertBerriesToBerryJuice`: a 1-in-16 roll, then the first SHUCKLE in the
+## party holding a BERRY. The party index it converted, or -1.
+static func _convert_berries_to_berry_juice(
+	save: Gen2SaveData, reached_goldenrod: bool, random: RandomNumberGenerator
+) -> int:
+	if not reached_goldenrod or _random_byte(random) >= 16:
+		return -1
+	for index: int in save.party.size():
+		var mon: Gen2SaveMon = save.party[index]
+		if mon == null or mon.species != SHUCKLE or mon.item != ITEM_BERRY:
+			continue
+		mon.item = ITEM_BERRY_JUICE
+		return index
+	return -1
+
+
+## The rest of `GivePokerusAndConvertBerries`: an active infection anywhere in
+## the party is sampled for a spread and nothing else can happen, which is why
+## no second Pokemon catches it de novo while one is still carrying it.
+static func _give_pokerus(
+	save: Gen2SaveData, reached_goldenrod: bool, random: RandomNumberGenerator
+) -> Dictionary:
+	var count: int = save.party.size()
+	for index: int in count:
+		var mon: Gen2SaveMon = save.party[index]
+		if mon != null and (mon.pokerus & 0x0F) != 0:
+			return _try_spread_pokerus(save, index, random)
+	if not reached_goldenrod:
+		return {}
+	## `Random` fills two bytes and both are read: 3 of 65,536.
+	if _random_byte(random) != 0 or _random_byte(random) >= 3:
+		return {}
+	var target: int = _random_byte(random) & 0x7
+	while target >= count:
+		target = _random_byte(random) & 0x7
+	var mon: Gen2SaveMon = save.party[target]
+	if mon == null or (mon.pokerus & 0xF0) != 0:
+		return {}
+	## `.randomPokerusLoop` samples the strain and the duration out of one byte,
+	## and rerolls a zero because that byte is the whole of both.
+	var roll: int = _random_byte(random)
+	while roll == 0:
+		roll = _random_byte(random)
+	mon.pokerus = pokerus_from_roll(roll)
+	return {"pokerus_index": target, "pokerus": mon.pokerus}
+
+
+## `.TrySpreadPokerus`: a 1-in-3 roll, then a walk away from the carrier in one
+## direction. A party member that has already recovered (`and $3` zero with a
+## strain still on it) stops the walk rather than being skipped.
+static func _try_spread_pokerus(
+	save: Gen2SaveData, carrier: int, random: RandomNumberGenerator
+) -> Dictionary:
+	if _random_byte(random) >= 85:
+		return {}
+	var count: int = save.party.size()
+	if count <= 1:
+		return {}
+	var strain_source: int = save.party[carrier].pokerus
+	## `ld a, b / cp 2 / jr c`: b is how many party members are left including
+	## the carrier, so a carrier in the last slot can only walk backwards.
+	var forwards: bool = carrier < count - 1 and _random_byte(random) >= 129
+	var step: int = 1 if forwards else -1
+	var index: int = carrier
+	while true:
+		index += step
+		if index < 0 or index >= count:
+			return {}
+		var mon: Gen2SaveMon = save.party[index]
+		if mon == null:
+			return {}
+		if mon.pokerus == 0:
+			mon.pokerus = pokerus_spread_from(strain_source)
+			return {"pokerus_index": index, "pokerus": mon.pokerus}
+		if (mon.pokerus & 0x3) == 0:
+			return {}
+		strain_source = mon.pokerus
+	return {}
+
+
+## `.load_pkrs`: one byte is the whole of both halves. A high nibble of zero is
+## strain zero, and the duration is read off the strain rather than off the byte,
+## which is what the shared `and $3 / inc a` after the `swap b` does.
+static func pokerus_from_roll(roll: int) -> int:
+	var strain: int = 0 if (roll & 0xF0) == 0 else (roll & 0x7) + 1
+	return ((strain << 4) & 0xF0) + (strain & 0x3) + 1
+
+
+## `.infectMon`: the carrier's strain is kept and the duration is derived from
+## that strain, so a spread never carries the carrier's remaining days.
+static func pokerus_spread_from(carrier: int) -> int:
+	return (carrier & 0xF0) + ((carrier >> 4) & 0x3) + 1
+
+
+## One `Random` byte. The cartridge's own generator is not modelled; what
+## matters at every call site above is the distribution and the number of draws.
+static func _random_byte(random: RandomNumberGenerator) -> int:
+	return random.randi_range(0, 0xFF)
+
+
+## `ApplyPokerusTick`, which `CheckPokerusTick` runs with the days elapsed since
+## the timer's start day: the low nibble is days remaining and floors at zero,
+## and the strain nibble is kept, which is what stops a recovered Pokemon from
+## catching it again. True when a byte moved.
+static func apply_pokerus_tick(save: Gen2SaveData, days: int) -> bool:
+	if save == null or days <= 0:
+		return false
+	var changed: bool = false
+	for mon: Gen2SaveMon in save.party:
+		if mon == null:
+			continue
+		var remaining: int = mon.pokerus & 0x0F
+		if remaining == 0:
+			continue
+		mon.pokerus = (mon.pokerus & 0xF0) + maxi(remaining - days, 0)
+		changed = true
+	return changed

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -119,6 +119,15 @@ var _start_menu_host: Gen2StartMenuScreen = null
 var _party_host: Gen2PartyScreen = null
 var _hall_of_fame_host: Gen2HallOfFameScreen = null
 var _credits_host: Gen2CreditsScreen = null
+## `EvolveAfterBattle`'s own screen, opened on the overworld after a battle that
+## was won and by an evolution stone from the pack.
+var _evolution_host: Gen2EvolutionScreen = null
+## What the evolution pass has to run when its screen closes: the pack's own
+## continuation, or nothing for the after-battle pass.
+var _evolution_after: Callable = Callable()
+## The party the open pass applies to, which is the fought save rather than
+## whatever is selected while the screen is up.
+var _evolution_save: Gen2SaveData = null
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
@@ -592,6 +601,10 @@ func advance_frame() -> void:
 	## place on the same frame.
 	if _battle_host != null:
 		_battle_host.advance_hardware_frame()
+	## `EvolveAfterBattle` runs inside the map's own loop the same way, so its
+	## `DelayFrames` counts are spent from this pump.
+	if _evolution_host != null:
+		_evolution_host.advance_frame()
 	_spending_frame = false
 
 
@@ -664,6 +677,7 @@ func _advance_day_cycle(delta: float) -> void:
 		return
 	var ticks: Array = _clock.advance(delta, _world)
 	_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
+	_apply_pokerus_days(ticks)
 	if ticks.is_empty():
 		return
 	_update_time_of_day()
@@ -732,7 +746,8 @@ func _overlay_open() -> bool:
 		or _battle_host != null or _service_host != null \
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
-		or _pokedex_host != null or _credits_host != null
+		or _pokedex_host != null or _credits_host != null \
+		or _evolution_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -820,6 +835,12 @@ func _handle_button(button: int) -> bool:
 		return true
 	if not _map_fade.is_empty() or not _trainer_approach.is_empty() \
 		or _world.phone_ring_active():
+		return true
+	## In front of every other overlay: `EvolveAfterBattle` runs with the map
+	## loop suspended, and the pack path reaches it with the pack still open
+	## behind it, so its B is the animation's cancel rather than the pack's back.
+	if _evolution_host != null:
+		_evolution_host.handle_button(button)
 		return true
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -1414,10 +1435,26 @@ func advance_world_time(seconds: float) -> Array:
 		return []
 	var ticks: Array = _clock.advance(seconds, _world)
 	_world.set_world_clock(_clock.day, _clock.hour, _clock.minute)
+	_apply_pokerus_days(ticks)
 	if not ticks.is_empty():
 		_update_time_of_day()
 		_refresh_labels()
 	return ticks
+
+
+## `CheckPokerusTick`, which `UpdateTime` reaches with the days elapsed since the
+## timer's start day. The clock here runs a minute at a time rather than being
+## read off a hardware RTC, so the count is the midnights the ticks crossed.
+func _apply_pokerus_days(ticks: Array) -> void:
+	var days: int = 0
+	for tick: Dictionary in ticks:
+		if int(tick.get("hour", -1)) == 0 and int(tick.get("minute", -1)) == 0:
+			days += 1
+	if days <= 0:
+		return
+	Gen2WorldPartyHost.apply_pokerus_tick(
+		_injected_save if _injected_save != null else _selected_runtime_save(), days
+	)
 
 
 ## Public host boundary for a time/radio tick. The imported roaming graph is
@@ -1863,6 +1900,57 @@ func _first_stone_evolution() -> Dictionary:
 		for row: Dictionary in _data.evolutions(species):
 			if int(row.get("method", 0)) == RomLayout.EVOLVE_ITEM:
 				return {"species": species, "item": int(row.get("parameter", 0))}
+	return {}
+
+
+## Public screenshot driver and scene-test entry for `EvolveAfterBattle`'s own
+## presentation: it stands the first party member on the first LEVEL evolution
+## the cache holds and opens the screen on it, which is the one path a stone
+## cannot reach, since `.pressed_b` lets B cancel this one and not that one.
+##
+## The party row is left alone. [method _on_evolution_resolved] applies it, the
+## same way the after-battle pass does, so the preview is that pass rather than
+## a picture of it.
+func preview_level_evolution() -> void:
+	if _world == null or _data == null:
+		return
+	if _evolution_host != null:
+		return
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Evolution preview needs a party"
+		_refresh_labels()
+		return
+	_injected_save = save
+	var plans: Array = Gen2Evolution.after_battle(
+		_data, save, [0], _world.object_time_of_day
+	)
+	if plans.is_empty():
+		## Only when the party's own lead has nothing due: a caller that has
+		## already staged one is photographing that one.
+		var row: Dictionary = _first_level_evolution()
+		if row.is_empty():
+			_script_prompt = "Evolution preview: this cache has no level evolution"
+			_refresh_labels()
+			return
+		var mon: Gen2SaveMon = save.party[0]
+		mon.species = int(row["species"])
+		mon.level = maxi(mon.level, int(row["row"].get("parameter", mon.level)))
+		mon.nickname = String(_data.species(mon.species).get("name", ""))
+		mon.hp = maxi(mon.hp, 1)
+		mon.status = Gen2Status.NONE
+		plans = Gen2Evolution.after_battle(
+			_data, save, [0], _world.object_time_of_day
+		)
+	_open_evolution(plans, save, Callable())
+
+
+func _first_level_evolution() -> Dictionary:
+	for species: int in range(1, _data.species_count() + 1):
+		for row: Dictionary in _data.evolutions(species):
+			if int(row.get("method", 0)) == RomLayout.EVOLVE_LEVEL:
+				return {"species": species, "row": row}
 	return {}
 
 
@@ -2435,7 +2523,6 @@ func _open_battle_host(request: Dictionary) -> void:
 	host.z_index = 10
 	host.mouse_filter = Control.MOUSE_FILTER_STOP
 	add_child(host)
-	host.party_evolved.connect(_on_party_evolved)
 	host.battle_finished.connect(_on_battle_finished)
 	host.enemy_seen.connect(_on_enemy_seen)
 	if not tutorial:
@@ -2480,12 +2567,6 @@ func _open_battle_host(request: Dictionary) -> void:
 func _on_enemy_seen(species: int) -> void:
 	if _world != null and _world.state != null:
 		_world.state.set_species_seen(species)
-
-
-## `.proceed`'s `SetSeenAndCaughtMon`, the write a level evolution owes the dex.
-func _on_party_evolved(species: int) -> void:
-	if _world != null and _world.state != null:
-		_world.state.set_species_caught(species)
 
 
 func _on_capture_requested(ball: int) -> void:
@@ -2549,6 +2630,40 @@ func _on_battle_finished(result: Dictionary) -> void:
 		_world.state.apply_changes({}, {}, {"money": {
 			0: mini(_world.state.money(0) + pay_day_money, Gen2WorldInventory.MAX_MONEY),
 		}})
+	## `ExitBattle`'s own tail, in its order: `CheckPayDay`, then
+	## `EvolveAfterBattle`, then `GivePokerusAndConvertBerries`, and only then
+	## does the map come back. The evolution owns frames, so the rest of the exit
+	## is what its screen resumes into rather than something that runs behind it.
+	var fought_save: Gen2SaveData = _active_battle_save
+	var plans: Array = _after_battle_evolution_plans(result, fought_save)
+	if not plans.is_empty():
+		_open_evolution(plans, fought_save, func() -> void:
+			_finish_battle_exit(result, fought_save)
+		)
+		return
+	_finish_battle_exit(result, fought_save)
+
+
+## `EvolveAfterBattle`'s `wEvolvableFlags`, read only on a battle that was won.
+func _after_battle_evolution_plans(result: Dictionary, save: Gen2SaveData) -> Array:
+	if _data == null or save == null or _world == null:
+		return []
+	if StringName(result.get("outcome", &"")) != Gen2WorldBattleAdapter.OUTCOME_WON:
+		return []
+	return Gen2Evolution.after_battle(
+		_data, save, result.get("evolvable", []), _world.object_time_of_day
+	)
+
+
+## Everything `ExitBattle` does once `EvolveAfterBattle` has returned.
+func _finish_battle_exit(result: Dictionary, fought_save: Gen2SaveData) -> void:
+	if _world == null:
+		return
+	if StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON:
+		Gen2WorldPartyHost.give_pokerus_and_convert_berries(
+			_data, fought_save, _world, _encounter_random
+		)
+		_persist_after_battle(fought_save)
 	var resumed: Array = _world.complete_runtime_request(result)
 	if resumed.is_empty():
 		## `WildBattleScript` is `randomwildmon`, `startbattle`,
@@ -2588,6 +2703,113 @@ func _on_battle_finished(result: Dictionary) -> void:
 	## map's own track back over the one `PlayBattleMusic` started.
 	_play_current_map_music()
 	_refresh_labels()
+
+
+## `EvoStoneEffect`'s evolution, which the pack has already applied: only the
+## animation is left, and it is the after-battle pass's own screen so both ways
+## in draw the same thing.
+func _on_pack_evolution(plan: Dictionary, after: Callable) -> void:
+	## No [member _evolution_save]: the row is already written, so [method
+	## _on_evolution_resolved] has nothing to apply and the dex write was the
+	## pack transaction's.
+	_open_evolution([plan], null, after)
+
+
+## `EvolveAfterBattle`'s screen. [param plans] is
+## [method Gen2Evolution.after_battle]'s list, [param save] the party they are
+## applied to, and [param after] whatever the caller was doing when the pass
+## interrupted it, run once the last plan has been answered.
+func _open_evolution(plans: Array, save: Gen2SaveData, after: Callable) -> void:
+	if _evolution_host != null or _data == null or plans.is_empty():
+		if after.is_valid():
+			after.call()
+		return
+	var host := Gen2EvolutionScreen.new()
+	host.set_context(_data, plans)
+	_evolution_save = save
+	_evolution_after = after
+	host.resolved.connect(_on_evolution_resolved)
+	host.closed.connect(_on_evolution_closed)
+	host.cry_requested.connect(_play_species_cry)
+	host.sfx_requested.connect(_play_sfx)
+	host.music_requested.connect(_play_evolution_music)
+	## Into the 160x144 viewport rather than over the whole window: the first box
+	## is printed over the map, so it has to be composited with it the way the
+	## world's own text box is.
+	host.z_index = 30
+	## Held before the node enters the tree: `_ready()` runs inside
+	## [method Gen2Screen.display], and a screen that closes there has to find
+	## itself here to be taken off again.
+	_evolution_host = host
+	_screen.display(host)
+	if _evolution_host == null:
+		return
+	_script_prompt = "Evolving"
+	_refresh_labels()
+
+
+## `.proceed`'s own write, or `CancelEvolution` doing nothing but printing.
+## `SetSeenAndCaughtMon` and `UpdateUnownDex` are here rather than in the screen:
+## the screen draws, the world owns the dex and the party.
+func _on_evolution_resolved(plan: Dictionary, canceled: bool) -> void:
+	if canceled or _evolution_save == null or _data == null:
+		return
+	var index: int = int(plan.get("index", -1))
+	if index < 0 or index >= _evolution_save.party.size():
+		return
+	var applied: Dictionary = Gen2WorldPartyHost.apply_evolution(
+		_data, _evolution_save.party[index], plan.get("row", {})
+	)
+	if applied.is_empty() or _world == null or _world.state == null:
+		return
+	_world.state.set_species_caught(int(applied["register_caught"]))
+	var form: int = int(applied.get("register_unown", 0))
+	if form > 0:
+		_world.state.update_unown_dex(form)
+	## `LearnLevelMoves` teaches whatever fits an empty slot, which
+	## [method Gen2WorldPartyHost.apply_evolution] has already done. A move that
+	## needs `ForgetMove` is declined here: that menu lives inside the start menu
+	## screen's own mode machine and this pass has no way into it, and declining
+	## is one of the two answers the cartridge takes.
+	_script_prompt = "%s evolved" % String(plan.get("evolving_name", ""))
+
+
+func _on_evolution_closed() -> void:
+	var host: Gen2EvolutionScreen = _evolution_host
+	_evolution_host = null
+	_evolution_save = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	var after: Callable = _evolution_after
+	_evolution_after = Callable()
+	if after.is_valid():
+		after.call()
+
+
+## `PlayMusic` from inside the animation: MUSIC_NONE stops what the map or the
+## battle left playing, and MUSIC_EVOLUTION is its own track.
+func _play_evolution_music(music: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	if music == Gen2EvolutionScreen.MUSIC_NONE:
+		_audio_player.stop_all()
+		return
+	var record: Dictionary = _data.world_audio(&"music", music)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
+## The save write `ExitBattle` owes once the evolution pass and Pokerus have
+## both run over the party the battle already wrote.
+func _persist_after_battle(save: Gen2SaveData) -> void:
+	if save == null or not _active_battle_persist or _data == null:
+		return
+	var written: Dictionary = Gen2SaveStore.save(save, _data)
+	if not bool(written.get("ok", false)):
+		push_error("Could not save the battle exit: %s" % String(written.get("message", "")))
 
 
 func _advance_script_input() -> void:
@@ -2933,6 +3155,7 @@ func _open_start_menu_host(entry: Callable) -> void:
 	host.action_chosen.connect(_on_start_menu_action)
 	host.closed.connect(_on_start_menu_closed)
 	host.field_item_used.connect(_on_field_item_used)
+	host.evolution_animation_requested.connect(_on_pack_evolution)
 	host.sfx_requested.connect(_play_sfx)
 	_start_menu_host = host
 	_script_prompt = "Start menu open"

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -899,6 +899,9 @@ func consume_wild_encounter_cooldown() -> bool:
 ## `wStatusFlags2`' own bit, so it sits past `ENGINE_MOBILE_SYSTEM` and shifts on
 ## Gold and Silver like every other flag there.
 const ENGINE_BUG_CONTEST_TIMER: int = 17
+## Five entries further down the same run (data/events/engine_flags.asm), so it
+## shifts on Gold and Silver the way every flag past ENGINE_MOBILE_SYSTEM does.
+const ENGINE_REACHED_GOLDENROD: int = 22
 ## `ENGINE_DAILY_BUG_CONTEST`, the once-a-day flag the officer checks.
 const ENGINE_DAILY_BUG_CONTEST: int = 81
 ## `BugCatchingContestantEventFlagTable`, whose ten entries are the same numbers
@@ -910,6 +913,13 @@ const EVENT_BUG_CATCHING_CONTESTANT_FIRST: int = 1814
 ## holds no GameData of its own, so the caller resolves the profile.
 func bug_contest_active(crystal: bool = true) -> bool:
 	return is_engine_flag_active(engine_flag(ENGINE_BUG_CONTEST_TIMER, crystal))
+
+
+## `STATUSFLAGS2_REACHED_GOLDENROD_F`, the fifth entry of the same `wStatusFlags2`
+## run: `GivePokerusAndConvertBerries` gates both of its halves on it, so neither
+## Pokerus nor BERRY JUICE exists before Goldenrod has been walked into once.
+func reached_goldenrod(crystal: bool = true) -> bool:
+	return is_engine_flag_active(engine_flag(ENGINE_REACHED_GOLDENROD, crystal))
 
 
 func park_balls() -> int:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -569,9 +569,10 @@ func _use_stone_on_first_member(host: Gen2StartMenuScreen) -> void:
 	await get_tree().process_frame
 
 
-## `EvolvingText` and `CongratulationsYourPokemonText`, which the field stone had
-## none of: it ended at "MOON STONE was used." and never said what happened.
-func test_a_field_stone_says_the_mon_is_evolving_and_what_it_became() -> void:
+## `EvoStoneEffect` reaches `EvolvePokemon`, so a field stone runs the same
+## `EvolutionAnimation` the after-battle pass does: the pack prints no box of its
+## own, and every line of the sequence belongs to that screen.
+func test_a_field_stone_opens_the_evolution_screen_over_the_pack() -> void:
 	_write_stone_item()
 	await _open_world()
 	var host: Gen2StartMenuScreen = await _open_stone_pack()
@@ -579,17 +580,20 @@ func test_a_field_stone_says_the_mon_is_evolving_and_what_it_became() -> void:
 	var nickname: String = save.party[0].nickname
 	await _use_stone_on_first_member(host)
 
-	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
+	assert_not_null(screen, "the animation screen is open")
 	assert_eq(save.party[0].species, EVOLVED_SPECIES)
-	var result: String = String(host.get("_pack_result"))
-	assert_true(result.contains("%s is evolving!" % nickname), result)
-	assert_true(result.contains("evolved into"), result)
+	assert_eq(screen.remaining(), 1)
+	## `.pressed_b` reads `wForceEvolution`, which `EvoStoneEffect` set: B cannot
+	## cancel a stone's evolution.
+	assert_false(bool(screen.current_plan().get("can_cancel", true)))
+	assert_true(_lines_of(screen).contains("%s is evolving!" % nickname), "the first box")
+	_settle_evolution()
 
 
 ## `GetNickname` / `CopyName1` run before the species is replaced, and BOTH
 ## boxes read that buffer: an un-nicknamed Pokemon is named by what it WAS on the
-## way in, never by what it became. Reading it back off the party row said
-## "What? <NEW> is evolving!" instead.
+## way in, never by what it became.
 func test_the_evolving_line_names_what_the_mon_was_not_what_it_became() -> void:
 	_write_stone_item()
 	await _open_world()
@@ -602,12 +606,37 @@ func test_the_evolving_line_names_what_the_mon_was_not_what_it_became() -> void:
 	var host: Gen2StartMenuScreen = await _open_stone_pack()
 	await _use_stone_on_first_member(host)
 
-	var result: String = String(host.get("_pack_result"))
-	assert_true(result.contains("What? %s is evolving!" % before), result)
-	assert_true(result.contains("Your %s evolved into %s!" % [before, after]), result)
-	assert_false(result.contains("What? %s" % after), result)
+	var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
+	assert_not_null(screen)
+	var opening: String = _lines_of(screen)
+	assert_true(opening.contains("What? %s is evolving!" % before), opening)
+	assert_false(opening.contains("What? %s" % after), opening)
 	## `UpdateSpeciesNameIfNotNicknamed` still runs, after both boxes.
 	assert_eq(save.party[0].nickname, after)
+	_settle_evolution()
+
+
+## Runs the open evolution screen to its end, pressing A for every page it waits
+## on, the way the overworld's own pump and funnel do.
+func _settle_evolution() -> void:
+	for _frame: int in 4000:
+		if _world_screen.get("_evolution_host") == null:
+			return
+		_world_screen.advance_frame()
+		var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
+		## The frame that closed it has already run whatever was waiting behind
+		## it, so a press here would answer that instead of the box.
+		if screen == null:
+			return
+		if screen.awaiting_press():
+			_world_screen.press_button(Gen2Button.A)
+	fail_test("the evolution screen never closed")
+
+
+## The whole box as one string, so a test asserts what it says rather than how
+## the lines were wrapped.
+func _lines_of(screen: Gen2EvolutionScreen) -> String:
+	return " ".join(screen.text_lines())
 
 
 ## `EvolveAfterBattle` calls `LearnMove` over the new learnset, so a move the new
@@ -619,11 +648,10 @@ func test_an_evolution_offers_its_new_move_and_a_full_moveset_opens_forget() -> 
 	var host: Gen2StartMenuScreen = await _open_stone_pack()
 	await _use_stone_on_first_member(host)
 
-	## The evolution's own box is pressed past first, page by page, the way
-	## PrintText waits; the offer follows its last page instead of the pack.
-	while host.get("_mode") == Gen2StartMenuScreen.Mode.PACK_RESULT:
-		host.handle_button(Gen2Button.A)
-		await get_tree().process_frame
+	## The animation runs to its end first: the offer is `LearnLevelMoves`, which
+	## the source reaches after `EvolutionAnimation` has returned.
+	_settle_evolution()
+	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
 	assert_true(String(host.call("box_text")).contains("EMBER"), String(host.call("box_text")))
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1154,3 +1154,86 @@ func test_a_battle_runs_its_transition_before_the_overlay_exists() -> void:
 	assert_true(seen, "the outro blacks the map out on the way")
 	assert_gt(frames, Gen2BattleTransition.LEAD_FRAMES, "the flash and an outro")
 	assert_not_null(_battle_child(), "and the battle behind it once it lands")
+
+
+## `ExitBattle`'s `predef EvolveAfterBattle`, which is the pass this screen runs
+## on the overworld: the level evolution the fight paid for is presented, and
+## the party row is only written when the animation has finished.
+const EVOLVING_SPECIES: int = 155
+const EVOLVED_SPECIES: int = 156
+const EVOLVE_LEVEL: int = 5
+
+
+func _write_level_evolution() -> void:
+	var species: Array = RomCache.read_json(RomCache.species_path(Fixture.directory()))
+	for raw: Dictionary in species:
+		match int(raw.get("number", 0)):
+			EVOLVING_SPECIES:
+				raw["name"] = "CHIKORITA"
+				raw["evolutions"] = [{
+					"method": RomLayout.EVOLVE_LEVEL, "parameter": EVOLVE_LEVEL,
+					"condition": 0, "target": EVOLVED_SPECIES,
+				}]
+			EVOLVED_SPECIES:
+				raw["name"] = "BAYLEEF"
+	RomCache.write_json(RomCache.species_path(Fixture.directory()), species)
+	_data = GameData.open_directory(Fixture.directory())
+
+
+## Runs the open evolution screen to its end, pressing A for every page it waits
+## on, the way the overworld's own pump and funnel do.
+func _settle_evolution(cancel: bool = false) -> void:
+	for _frame: int in 4000:
+		if _world_screen.get("_evolution_host") == null:
+			return
+		_world_screen.advance_frame()
+		var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
+		if screen == null:
+			return
+		if cancel and screen.phase() == Gen2EvolutionScreen.Phase.FLASH:
+			_world_screen.press_button(Gen2Button.B)
+		elif screen.awaiting_press():
+			_world_screen.press_button(Gen2Button.A)
+	fail_test("the evolution screen never closed")
+
+
+func test_a_level_evolution_is_presented_after_the_battle_and_then_applied() -> void:
+	_write_level_evolution()
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	save.party[0].species = EVOLVING_SPECIES
+	save.party[0].nickname = "CHIKORITA"
+	save.party[0].level = EVOLVE_LEVEL
+
+	_world_screen.preview_level_evolution()
+	var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
+	assert_not_null(screen, "the pass opened its screen")
+	assert_eq(screen.remaining(), 1)
+	assert_eq(save.party[0].species, EVOLVING_SPECIES, "nothing is written before the animation")
+
+	_settle_evolution()
+	assert_null(_world_screen.get("_evolution_host"), "and it closes on its own")
+	assert_eq(save.party[0].species, EVOLVED_SPECIES)
+	assert_eq(save.party[0].nickname, "BAYLEEF", "UpdateSpeciesNameIfNotNicknamed")
+	assert_true(_world_screen._world.state.has_caught_species(EVOLVED_SPECIES),
+		"SetSeenAndCaughtMon")
+
+
+## `.WaitFrames_CheckPressedB` sets `wEvolutionCanceled` and `.proceed`'s
+## `jp c, CancelEvolution` prints `StoppedEvolvingText` instead of writing the
+## new species. The flash loop is the only place B is read, which is why the
+## press waits for that phase rather than landing on the first frame.
+func test_b_during_the_flash_cancels_the_evolution_and_says_so() -> void:
+	_write_level_evolution()
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	save.party[0].species = EVOLVING_SPECIES
+	save.party[0].nickname = "CHIKORITA"
+	save.party[0].level = EVOLVE_LEVEL
+
+	_world_screen.preview_level_evolution()
+	_settle_evolution(true)
+
+	assert_eq(save.party[0].species, EVOLVING_SPECIES, "the species is unchanged")
+	assert_eq(save.party[0].nickname, "CHIKORITA")
+	assert_false(_world_screen._world.state.has_caught_species(EVOLVED_SPECIES))

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1496,6 +1496,26 @@ func test_levelling_up_learns_a_move_into_an_empty_slot_without_asking() -> void
 	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
 
 
+## `wEvolvableFlags`: the `SmallFarFlagAction SET_FLAG` at the end of the same
+## block as `.level_loop`, so the flag is set once per party member that gained a
+## level rather than once per level. Nothing evolves in here at all:
+## `ExitBattle` runs `EvolveAfterBattle` on the overworld, after the battle.
+func test_a_level_gained_sets_the_evolvable_flag_and_evolves_nothing() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.BULBASAUR, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])
+	)
+	battle.player.hp = battle.player.max_hp() * 10
+	battle.enemy.hp = 1
+	assert_true(battle.evolvable_indices().is_empty(), "cleared at the start")
+
+	var events: Array = battle.take_turn(0, 0)
+
+	assert_gt(_of_type(events, Gen2Battle.GREW_LEVEL).size(), 1, "more than one level")
+	assert_eq(battle.evolvable_indices(), [0] as Array[int], "one flag, not one per level")
+	assert_eq(battle.player.species, Fixture.BULBASAUR, "and it did not evolve here")
+
+
 ## `LevelUpHappinessMod`: once per award that levelled, not once per level, and
 ## HAPPINESS_GAINLEVELATHOME only where the Pokemon was caught. The table's own
 ## rows are signed, so the numbers come out of the cache rather than out of here.

--- a/tests/unit/test_evolution.gd
+++ b/tests/unit/test_evolution.gd
@@ -96,3 +96,61 @@ func test_a_trade_evolution_honours_its_held_item_parameter() -> void:
 	var row: Dictionary = Gen2Evolution.trade_evolution(data, held)
 	assert_eq(int(row.get("target", 0)), TRADE_TARGET)
 	assert_eq(int(row.get("consumes_held_item", 0)), TRADE_HELD_ITEM)
+
+
+## `EvolveAfterBattle_MasterLoop`: the walk is over `wEvolvableFlags`, which is
+## per party member and not per level gained, and it evolves nobody it was not
+## handed a flag for.
+func test_the_after_battle_walk_reads_the_evolvable_flags_and_nothing_else() -> void:
+	var save: Gen2SaveData = _save_with([Fixture.BULBASAUR, Fixture.BULBASAUR], 16)
+
+	assert_true(Gen2Evolution.after_battle(
+		_data, save, [], Gen2WorldPalette.TIME_DAY
+	).is_empty(), "no flag, no plan")
+
+	var plans: Array = Gen2Evolution.after_battle(
+		_data, save, [1], Gen2WorldPalette.TIME_DAY
+	)
+	assert_eq(plans.size(), 1)
+	assert_eq(int(plans[0]["index"]), 1)
+	assert_eq(int(plans[0]["old_species"]), Fixture.BULBASAUR)
+	assert_eq(int(plans[0]["new_species"]), 2)
+	assert_true(bool(plans[0]["can_cancel"]), "wForceEvolution is zero after a battle")
+	assert_eq(save.party[1].species, Fixture.BULBASAUR, "and nothing is written yet")
+
+
+## `CheckFaintedFrzSlp`, which costs the cry and the closing animation both.
+func test_a_statused_party_member_is_planned_without_its_cry() -> void:
+	var save: Gen2SaveData = _save_with([Fixture.BULBASAUR], 16)
+	save.party[0].status = Gen2Status.FREEZE
+	assert_true(bool(Gen2Evolution.after_battle(
+		_data, save, [0], Gen2WorldPalette.TIME_DAY
+	)[0]["statused"]))
+
+	save.party[0].status = Gen2Status.NONE
+	assert_false(bool(Gen2Evolution.after_battle(
+		_data, save, [0], Gen2WorldPalette.TIME_DAY
+	)[0]["statused"]))
+
+
+## An EGG keeps its party slot without being a combatant, so the flag the battle
+## set for battle slot 0 belongs to party slot 1 when an egg is in front of it.
+func test_an_egg_shifts_the_flag_off_the_battle_party_indices() -> void:
+	var save: Gen2SaveData = _save_with([Fixture.BULBASAUR, Fixture.BULBASAUR], 16)
+	save.party[0].is_egg = true
+
+	assert_eq(Gen2SaveBattleAdapter.save_party_index(save, 0), 1)
+	var plans: Array = Gen2Evolution.after_battle(
+		_data, save, [0], Gen2WorldPalette.TIME_DAY
+	)
+	assert_eq(plans.size(), 1)
+	assert_eq(int(plans[0]["index"]), 1)
+
+
+func _save_with(species: Array, level: int) -> Gen2SaveData:
+	var save := Gen2SaveData.new()
+	for number: int in species:
+		save.party.append(Gen2SaveBattleAdapter.from_battle_mon(
+			Gen2BattleMon.create(_data, number, level, [])
+		))
+	return save

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -288,6 +288,85 @@ func test_a_stone_will_not_evolve_an_everstone_holder_from_the_pack() -> void:
 	assert_eq(_world.state.item_quantity(0x08), 1, "and the stone is not spent")
 
 
+## `ConvertBerriesToBerryJuice`'s Goldenrod gate. Swept over every seed rather
+## than one, since the branch behind the gate is a roll: before the city, no
+## draw converts anything.
+func test_a_shuckle_holding_a_berry_makes_juice_only_past_goldenrod() -> void:
+	var flag: int = _world.state.engine_flag(
+		Gen2WorldState.ENGINE_REACHED_GOLDENROD, true
+	)
+	assert_false(_world.state.is_engine_flag_active(flag), "the fixture starts short of it")
+	var converted_before: int = 0
+	var converted_after: int = 0
+	for seed_value: int in 64:
+		converted_before += 1 if _juice_run(seed_value) else 0
+	_world.state.set_engine_flag(flag, true)
+	for seed_value: int in 64:
+		converted_after += 1 if _juice_run(seed_value) else 0
+	assert_eq(converted_before, 0, "nothing converts before Goldenrod")
+	assert_gt(converted_after, 0, "and the 1-in-16 roll lands inside 64 seeds")
+
+
+## One run of the routine over a SHUCKLE holding a BERRY, answering whether it
+## became BERRY JUICE.
+func _juice_run(seed_value: int) -> bool:
+	_save.party[0] = Gen2SaveBattleAdapter.from_battle_mon(
+		Gen2BattleMon.create(_data, 1, 5)
+	)
+	_save.party[0].species = Gen2WorldPartyHost.SHUCKLE
+	_save.party[0].item = Gen2WorldPartyHost.ITEM_BERRY
+	var random := RandomNumberGenerator.new()
+	random.seed = seed_value
+	Gen2WorldPartyHost.give_pokerus_and_convert_berries(_data, _save, _world, random)
+	return _save.party[0].item == Gen2WorldPartyHost.ITEM_BERRY_JUICE
+
+
+## `.loopMons`: an active infection anywhere in the party is sampled for a
+## spread, and nothing is infected de novo while one is standing, so the strain
+## every seed can produce is the carrier's own rather than a fresh roll.
+func test_a_carrier_spreads_its_own_strain_and_blocks_a_new_infection() -> void:
+	_world.state.set_engine_flag(_world.state.engine_flag(
+		Gen2WorldState.ENGINE_REACHED_GOLDENROD, true
+	), true)
+	var spread: int = 0
+	for seed_value: int in 64:
+		_save.party[0].pokerus = 0x31
+		_save.party[1].pokerus = 0
+		var random := RandomNumberGenerator.new()
+		random.seed = seed_value
+		Gen2WorldPartyHost.give_pokerus_and_convert_berries(_data, _save, _world, random)
+		assert_eq(_save.party[0].pokerus, 0x31, "the carrier is never rewritten")
+		if _save.party[1].pokerus != 0:
+			spread += 1
+			assert_eq(_save.party[1].pokerus, 0x34, ".infectMon keeps the strain")
+	assert_gt(spread, 0, "the 1-in-3 roll lands inside 64 seeds")
+
+
+## `ApplyPokerusTick`: the days floor at zero and the STRAIN nibble survives,
+## which is what stops a recovered Pokemon from catching it a second time.
+func test_the_pokerus_tick_floors_the_days_and_keeps_the_strain() -> void:
+	_save.party[0].pokerus = 0x33
+	_save.party[1].pokerus = 0x00
+
+	assert_true(Gen2WorldPartyHost.apply_pokerus_tick(_save, 2))
+	assert_eq(_save.party[0].pokerus, 0x31)
+
+	assert_true(Gen2WorldPartyHost.apply_pokerus_tick(_save, 9))
+	assert_eq(_save.party[0].pokerus, 0x30, "cured, and still carrying its strain")
+	assert_eq(_save.party[1].pokerus, 0x00, "an uninfected member is left alone")
+	assert_false(Gen2WorldPartyHost.apply_pokerus_tick(_save, 1), "nothing left to spend")
+
+
+## `.randomPokerusLoop` and `.infectMon`, the two pieces of arithmetic a reading
+## gets wrong: both durations come off the STRAIN nibble, not off the byte.
+func test_the_two_pokerus_bytes_are_the_source_arithmetic() -> void:
+	assert_eq(Gen2WorldPartyHost.pokerus_from_roll(0x0F), 0x01, "a zero strain is one day")
+	assert_eq(Gen2WorldPartyHost.pokerus_from_roll(0x13), 0x41, "(3 & 7) + 1 = 4")
+	assert_eq(Gen2WorldPartyHost.pokerus_from_roll(0xF7), 0x81, "strain 8, and 8 & 3 is 0")
+	assert_eq(Gen2WorldPartyHost.pokerus_spread_from(0x31), 0x34)
+	assert_eq(Gen2WorldPartyHost.pokerus_spread_from(0x44), 0x41, "4 & 3 is 0")
+
+
 func _add_party_evolution_metadata() -> void:
 	var species: Array = RomCache.read_json(RomCache.species_path(Fixture.directory()))
 	for raw: Dictionary in species:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -193,7 +193,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	## cell, so the player is left where the map puts them.
 	if _kind_cell.x >= 0:
 		_screen.start_cell = _kind_cell
-	elif cell.x >= 0 and _kind != &"battle_transition":
+	elif cell.x >= 0 and _kind not in [&"battle_transition", &"level_evolution"]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
 	## screen resolves is what a wandering NPC's own generator is built from.
@@ -235,6 +235,20 @@ func _process(_delta: float) -> bool:
 			## a different picture; the second is 1 for a trainer's, which is the
 			## branch that draws the Poke Ball and floods the map.
 			_screen.preview_battle_transition(_cell.x, _cell.y != 0)
+		elif _kind == &"level_evolution":
+			## `EvolveAfterBattle`'s own screen, which is a few hundred frames of
+			## picture. The first number is how far into it to photograph rather
+			## than a cell, the way `battle_transition`'s is; the box is pressed
+			## past on the frames it is waiting on, since neither `PrintText` nor
+			## `DelayFrames` shortens for a screenshot.
+			_screen.preview_level_evolution()
+			for _frame: int in maxi(_cell.x, 0):
+				_screen.advance_frame()
+				var evolving: Gen2EvolutionScreen = _screen.get("_evolution_host")
+				if evolving == null:
+					break
+				if evolving.awaiting_press():
+					_screen.press_button(Gen2Button.A)
 		elif _kind == &"yes_no":
 			## `Script_yesorno`'s own box: the NPC beside the player is talked
 			## to and each page answered until the choice the script ends on is
@@ -324,7 +338,7 @@ func _process(_delta: float) -> bool:
 			_screen.preview_effect_sprites(_kind)
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
-			&"battle_transition",
+			&"battle_transition", &"level_evolution",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -9249,7 +9249,8 @@ func _party_species(save: Gen2SaveData) -> Array:
 ## offered into a full moveset is left in the engine's queue, which is the same
 ## answer as declining it.
 func _award_battle_experience(
-	world: Gen2WorldAPI, save: Gen2SaveData, battle: Gen2Battle, player_party: Gen2Party
+	data: GameData, world: Gen2WorldAPI, save: Gen2SaveData, battle: Gen2Battle,
+	player_party: Gen2Party
 ) -> Dictionary:
 	if battle == null or player_party == null or save == null:
 		return {"ok": true, "awarded": 0, "grew": []}
@@ -9267,11 +9268,23 @@ func _award_battle_experience(
 					"species": int(event.get("species", 0)),
 					"level": int(event.get("new_level", 0)),
 				})
-			Gen2Battle.EVOLVED:
-				grew.append({
-					"species": int(event.get("new_species", 0)),
-					"from": int(event.get("old_species", 0)),
-				})
+	## `ExitBattle`'s own order: the party is written back first, and the evolution
+	## pass then walks it on the overworld. Nothing here can press B, so every plan
+	## proceeds, which is what the cartridge does when nobody touches the pad.
+	for plan: Dictionary in Gen2Evolution.after_battle(
+		data, save, battle.evolvable_indices(), world.object_time_of_day
+	):
+		var applied: Dictionary = Gen2WorldPartyHost.apply_evolution(
+			data, save.party[int(plan["index"])], plan["row"]
+		)
+		if applied.is_empty():
+			continue
+		world.state.set_species_caught(int(applied["new_species"]))
+		grew.append({
+			"species": int(applied["new_species"]),
+			"from": int(applied["old_species"]),
+		})
+		_mirror_party(world, save)
 	return {"ok": true, "awarded": awarded, "grew": grew}
 
 
@@ -9586,7 +9599,7 @@ func _drain_story(
 					break
 				var enemy_party: Gen2Party = prepared.get("enemy_party", null)
 				var levelled: Dictionary = _award_battle_experience(
-					world, save, prepared.get("battle", null), player_party
+					data, world, save, prepared.get("battle", null), player_party
 				)
 				if not bool(levelled.get("ok", true)):
 					last_reason = String(levelled.get("reason", "experience write-back failed"))


### PR DESCRIPTION
## What this fixes

A level evolution used to happen inside the fight, silently. The cartridge does it after: `ExitBattle` checks that the battle was won, then runs `EvolveAfterBattle` on the overworld with a screen of its own. So a Pokemon that levelled up and then lost the battle evolved here and does not on hardware, and nobody ever saw "What? ... is evolving!".

## What changed

**The flag, not the level.** The battle now keeps `wEvolvableFlags`: one flag per party member that gained a level, not one per level, cleared when the battle starts. The result carries it only for a win. An egg keeps its party slot without being a combatant, so battle-party indices are mapped back through one rule.

**The animation.** `Gen2EvolutionScreen` is `EvolutionAnimation`, run from the overworld's own frame pump: the first box printed over the map, the old picture, the cry unless the Pokemon is fainted, frozen or asleep, the evolution music, the flash loop with its rising and falling counters, the closing pic animation and the congratulations box.

**B cancels.** The source reads the pad on the wait frames of the flash loop alone, and refuses the cancel when the evolution was forced. So a level evolution takes the press and an evolution stone's does not. The pack now shows the same screen instead of printing its own text.

**Pokerus.** `GivePokerusAndConvertBerries` runs where the source runs it. Both halves are behind the Goldenrod flag: the 1-in-16 Shuckle berry conversion, the spread from a party member that already has it, the 3-in-65,536 new infection, and the daily tick on the midnights the world clock crosses.

## Not drawn

The thirty-two balls of light are sprite objects and there is no sprite layer outside the intro, so their frames are spent with the new picture standing. A move the new species learns into a full moveset is declined after a battle rather than opening the forget menu, which is one of the two answers the cartridge takes.

## Checks

- GUT: 3,335 tests over 152 scripts, green
- `validate.gd -- all`: 56 topics, no failures
- `replay_world.gd`: 11 routes, 0 failures
- The story walk on Crystal, Gold and Silver
- Screenshots of every phase against the real Crystal cache, with `preview_world.gd ... live level_evolution <frame> 0`