### PR TITLE
Check the imported map corpus against the pinned sources

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2654,9 +2654,13 @@ const LANDMARK_NONE: int = -1
 ## takes it. Gold and Silver ship neither the second row nor the compare in
 ## front of it: their `.skip_active_mon_update` passes HAPPINESS_GAINLEVEL flat.
 const HAPPINESS_GAINLEVEL: int = 0x01
+const HAPPINESS_USEDITEM: int = 0x02
 const HAPPINESS_GYMBATTLE: int = 0x04
 const HAPPINESS_FAINTED: int = 0x06
 const HAPPINESS_BEATENBYSTRONGFOE: int = 0x08
+const HAPPINESS_BITTERPOWDER: int = 0x0F
+const HAPPINESS_ENERGYROOT: int = 0x10
+const HAPPINESS_REVIVALHERB: int = 0x11
 const HAPPINESS_GAINLEVELATHOME: int = 0x13
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -76,7 +76,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 72
+const FORMAT_VERSION: int = 73
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1966,7 +1966,9 @@ const GOLD_SILVER: Dictionary = {
 	"map_group_pointers": 0x940ED,
 	"map_group_counts": [14, 7, 82, 9, 10, 8, 17, 7, 6, 17, 22, 13, 6, 8, 12, 8, 13, 14, 4, 4, 26, 9, 13, 13, 15, 11],
 	"tilesets": 0x156BE,
-	"tileset_block_counts": [128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64],
+	## Each tileset's `*Meta` run, whose length is only the distance to the next
+	## label: `TilesetForest` is 40 blocks on both cartridges, not 64.
+	"tileset_block_counts": [128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 40],
 	"tileset_palette_bank": 0x02,
 	"world_palette_offset": 0xB75E,
 	"overworld_sprites": 0x147DE,
@@ -2394,6 +2396,7 @@ const CRYSTAL: Dictionary = {
 	"map_group_pointers": 0x94000,
 	"map_group_counts": [14, 7, 91, 9, 10, 8, 17, 7, 6, 17, 24, 13, 6, 8, 12, 8, 13, 14, 4, 6, 26, 16, 13, 13, 15, 11],
 	"tilesets": 0x4D596,
+	## See GOLD_SILVER: `TilesetForest`, here number 31, is the short one.
 	"tileset_block_counts": [128, 128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 40, 64, 64, 64, 64, 64],
 	"tileset_palette_bank": 0x13,
 	"world_palette_offset": 0xB319,

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -11,6 +11,7 @@ extends RefCounted
 const ITEM_POTION: int = 0x12
 const ITEM_REVIVE: int = 0x27
 const ITEM_MAX_REVIVE: int = 0x28
+const ITEM_REVIVAL_HERB: int = 0x7C
 const ITEM_REPEL: int = 0x14
 const ITEM_SUPER_REPEL: int = 0x2A
 const ITEM_MAX_REPEL: int = 0x2B
@@ -22,6 +23,27 @@ const ITEM_POKE_BALL: int = 0x05
 ## what holds it and `BattleMenu_Pack`'s contest branch loads it by name.
 const ITEM_PARK_BALL: int = 0xB1
 ## `ConvertBerriesToBerryJuice`'s own three constants.
+## `StatExpItemPointerOffsets`: the five vitamins and the stat experience each
+## one raises. `MON_HP_EXP` and its four neighbours are words and the offsets
+## name the high byte, so `VitaminEffect` reads and writes that byte alone: it
+## refuses at 100 and adds 10 there, which is 25,600 and 2,560 of the flat value
+## kept here.
+const VITAMINS: Dictionary = {
+	0x1A: "hp", 0x1B: "attack", 0x1C: "defense", 0x1D: "speed", 0x1F: "special",
+}
+const VITAMIN_CAP: int = 100 << 8
+const VITAMIN_STEP: int = 10 << 8
+
+## The four items whose own routine is an ordinary effect plus a happiness
+## penalty and `LooksBitterMessage`. `EnergypowderEffect` and `EnergyRootEffect`
+## share one body and differ only in the row they charge.
+const BITTER_ITEMS: Dictionary = {
+	0x79: Gen2Battle.HAPPINESS_BITTERPOWDER,
+	0x7A: Gen2Battle.HAPPINESS_ENERGYROOT,
+	0x7B: Gen2Battle.HAPPINESS_BITTERPOWDER,
+	ITEM_REVIVAL_HERB: Gen2Battle.HAPPINESS_REVIVALHERB,
+}
+
 const ITEM_BERRY: int = 0xAD
 const ITEM_BERRY_JUICE: int = 0x8B
 const SHUCKLE: int = 0xD5
@@ -305,6 +327,8 @@ static func use_item(
 		"new_species": int(effect.get("new_species", 0)),
 		"evolving_name": String(effect.get("evolving_name", "")),
 		"move_offers": effect.get("move_offers", []).duplicate(),
+		"bitter": bool(effect.get("bitter", false)),
+		"stat": String(effect.get("stat", "")),
 	}
 
 
@@ -826,12 +850,19 @@ static func _apply_item_effect(
 	var evolution: Dictionary = _apply_item_evolution(data, mon, item)
 	if not evolution.is_empty():
 		return evolution
+	var vitamin: Dictionary = _apply_vitamin(data, mon, item)
+	if not vitamin.is_empty():
+		return vitamin
 	var max_hp: int = _max_hp(data, mon)
-	if item in [ITEM_REVIVE, ITEM_MAX_REVIVE]:
+	# `RevivePokemon`'s own `cp REVIVE / jr z, .revive_half_hp`: REVIVE is the
+	# only half, so MAX_REVIVE and REVIVAL_HERB both reach `ReviveFullHP`.
+	if item in [ITEM_REVIVE, ITEM_MAX_REVIVE, ITEM_REVIVAL_HERB]:
 		if mon.hp > 0:
 			return {"ok": false, "reason": &"item_has_no_effect"}
-		mon.hp = max_hp if item == ITEM_MAX_REVIVE else maxi(max_hp / 2, 1)
-		return {"ok": true, "effect": &"revive", "healed": mon.hp}
+		mon.hp = maxi(max_hp / 2, 1) if item == ITEM_REVIVE else max_hp
+		return _with_bitterness(
+			data, mon, item, {"ok": true, "effect": &"revive", "healed": mon.hp}
+		)
 
 	var status_mask: int = int(definition.get("status_mask", 0))
 	var heal_amount: int = int(definition.get("heal_amount", 0))
@@ -847,10 +878,44 @@ static func _apply_item_effect(
 		mon.status &= ~status_mask
 	if healed <= 0 and cleared == 0:
 		return {"ok": false, "reason": &"item_has_no_effect"}
-	return {
+	return _with_bitterness(data, mon, item, {
 		"ok": true, "effect": &"party_item", "healed": healed,
 		"status_cleared": cleared,
+	})
+
+
+## `VitaminEffect`. The cap is a refusal rather than a clamp.
+## `UpdateStatsAfterItem` is `CalcMonStats` writing `MON_MAXHP` and the five
+## stats below it and nothing else, so an HP UP raises the maximum and heals
+## nothing; here every one of those is derived from the stat experience, which
+## leaves the raise and the happiness row as the whole effect.
+static func _apply_vitamin(data: GameData, mon: Gen2SaveMon, item: int) -> Dictionary:
+	if not VITAMINS.has(item):
+		return {}
+	var stat: String = VITAMINS[item]
+	var raised: int = int(mon.stat_exp.get(stat, 0))
+	if raised >= VITAMIN_CAP:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	mon.stat_exp[stat] = raised + VITAMIN_STEP
+	mon.happiness = change_happiness(data, mon.happiness, Gen2Battle.HAPPINESS_USEDITEM)
+	return {
+		"ok": true, "effect": &"vitamin", "stat": stat,
+		"stat_exp": int(mon.stat_exp[stat]), "happiness": mon.happiness,
 	}
+
+
+## The happiness half of `HealPowderEffect`, `EnergypowderEnergyRootCommon` and
+## `RevivalHerbEffect`, which each run it only once their shared effect reports
+## the item was used. Every other field item charges nothing.
+static func _with_bitterness(
+	data: GameData, mon: Gen2SaveMon, item: int, effect: Dictionary
+) -> Dictionary:
+	if not BITTER_ITEMS.has(item):
+		return effect
+	mon.happiness = change_happiness(data, mon.happiness, int(BITTER_ITEMS[item]))
+	effect["bitter"] = true
+	effect["happiness"] = mon.happiness
+	return effect
 
 
 ## `_SacredAsh`: `CheckAnyFaintedMon` first, which skips eggs and stops at the

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -184,6 +184,83 @@ func test_sacred_ash_is_refused_and_kept_while_nothing_has_fainted() -> void:
 	assert_eq(_world.state.item_quantity(0x9C), 1)
 
 
+## `VitaminEffect`: ten added to the high byte of one stat experience word,
+## which is 2,560 flat, and HAPPINESS_USEDITEM. `UpdateStatsAfterItem` writes
+## MON_MAXHP and the stats, never MON_HP, so the maximum rises and the member is
+## no healthier than it was.
+func test_a_vitamin_raises_one_stat_experience_and_the_maximum_it_pays_for() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x1A: 2, 0x1B: 1}})
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.happiness = 100
+	mon.hp = 1
+	var before_max: int = Gen2SaveBattleAdapter.to_battle_mon(_data, mon).max_hp()
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x1A, 0, false)
+
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(result["effect"], &"vitamin")
+	assert_eq(int(_save.party[0].stat_exp["hp"]), 10 << 8)
+	assert_gt(_save.party[0].happiness, 100)
+	assert_gt(Gen2SaveBattleAdapter.to_battle_mon(_data, _save.party[0]).max_hp(), before_max)
+	assert_eq(_save.party[0].hp, 1)
+	assert_eq(_world.state.item_quantity(0x1A), 1)
+
+	var other: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x1B, 0, false)
+	assert_true(other["ok"], JSON.stringify(other))
+	assert_eq(int(_save.party[0].stat_exp["attack"]), 10 << 8)
+	assert_eq(int(_save.party[0].stat_exp["hp"]), 10 << 8)
+
+
+## `cp 100 / jr nc, NoEffectMessage` is a refusal, not a clamp, and it reads the
+## high byte alone.
+func test_a_vitamin_is_refused_and_kept_once_its_stat_reaches_the_cap() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x1A: 1}})
+	_save.party[0].stat_exp["hp"] = 100 << 8
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x1A, 0, false)
+
+	assert_false(result["ok"])
+	assert_eq(StringName(result["reason"]), &"item_has_no_effect")
+	assert_eq(int(_save.party[0].stat_exp["hp"]), 100 << 8)
+	assert_eq(_world.state.item_quantity(0x1A), 1)
+
+
+## `RevivalHerbEffect` reaches `RevivePokemon`, whose `cp REVIVE` leaves it on
+## `ReviveFullHP`, and then charges HAPPINESS_REVIVALHERB.
+func test_a_revival_herb_revives_to_full_health_and_costs_happiness() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x7C: 1}})
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.hp = 0
+	mon.happiness = 100
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x7C, 0, false)
+
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_true(result["bitter"])
+	assert_eq(_save.party[0].hp, Gen2SaveBattleAdapter.to_battle_mon(_data, mon).max_hp())
+	assert_eq(_save.party[0].happiness, 85)
+	assert_eq(_world.state.item_quantity(0x7C), 0)
+
+
+## `EnergypowderEnergyRootCommon` charges its row only once `ItemRestoreHP`
+## reports the item was used, and every item outside those four charges nothing.
+func test_an_energy_root_costs_happiness_where_a_potion_costs_none() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x7A: 1}})
+	_save.party[0].hp = 1
+	_save.party[0].happiness = 100
+
+	var bitter: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x7A, 0, false)
+	assert_true(bitter["ok"], JSON.stringify(bitter))
+	assert_true(bitter["bitter"])
+	assert_eq(_save.party[0].happiness, 90)
+
+	_save.party[0].hp = 1
+	var plain: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x12, 0, false)
+	assert_true(plain["ok"], JSON.stringify(plain))
+	assert_false(plain["bitter"])
+	assert_eq(_save.party[0].happiness, 90)
+
+
 func test_moon_stone_evolves_a_party_member_and_consumes_the_item() -> void:
 	var source: Gen2BattleMon = Gen2BattleMon.create(_data, 1, 5)
 	source.hp = maxi(source.max_hp() - 3, 1)
@@ -781,6 +858,8 @@ func _add_party_item_metadata() -> void:
 			raw["heal_amount"] = 20
 		if number == 0x09:
 			raw["status_mask"] = Gen2Status.POISON
+		if number == 0x7A:
+			raw["heal_amount"] = 200
 		if number == 0x14:
 			raw["field_menu"] = RomLayout.ITEMMENU_CURRENT
 		if number == 0x05:

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -1,0 +1,439 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## The imported map corpus against the pins' own copies of the same bytes.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- map_data
+##
+## pret assembles to a bit-identical ROM, so `maps/*.blk`,
+## `data/tilesets/*_metatiles.bin`, `data/tilesets/*_collision.asm` and
+## `gfx/tilesets/*_palette_map.asm` are the cartridge's own bytes read a second
+## way. Agreement proves the importer's addressing, stride and fold, which is
+## where an offset or a stride read one row out hides; it proves nothing about
+## what the bytes mean. `drawn_blocks` and `side_walls` are the semantic half.
+##
+## Gold and Silver both run against `pokegold`, and every identity here comes
+## from the pin's own tables rather than from a number: a map is found by
+## walking `constants/map_constants.asm` in order, and a tileset's files by
+## following `TilesetXMeta` through `gfx/tilesets.asm`, because `Tileset0` and
+## `TilesetJohto` are the same record under two labels.
+##
+## The checkouts are local-only, so a missing one skips rather than fails.
+
+const PINS: Dictionary = {
+	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",
+}
+
+## `constants/tileset_constants.asm`'s `PAL_BG_*` order.
+const BG_PALETTES: Array[String] = [
+	"GRAY", "RED", "GREEN", "WATER", "YELLOW", "BROWN", "ROOF", "TEXT",
+]
+
+## `constants/hardware.inc`: `OAM_BANK1 equ 1 << B_OAM_BANK1`.
+const OAM_BANK1: int = 1 << 3
+
+var _pins: Dictionary = {}
+var _root: String = ""
+var _failures: int = 0
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_root = _reference_root()
+	_r.each_game(_check_game)
+	if _failures > 0:
+		_r.fail("%d layers disagreed with the pinned sources." % _failures)
+
+
+func _check_game() -> void:
+	var pin: String = _root.path_join(String(PINS[_r.game_id]))
+	if not DirAccess.dir_exists_absolute(pin):
+		_r.note("%s is not checked out, so nothing was compared." % pin.get_file())
+		return
+	_check_blocks(pin)
+	_check_tilesets(pin)
+
+
+# --- Map block arrays -------------------------------------------------------
+
+
+func _check_blocks(pin: String) -> void:
+	var attributes: Dictionary = _attributes(pin)
+	var blockdata: Dictionary = _blockdata(pin)
+	var compared: int = 0
+	var highest: int = -1
+	for entry: Dictionary in _map_ids(pin):
+		var id: String = entry["id"]
+		var map: Gen2WorldMap = _r.data.world_map(entry["group"], entry["number"])
+		if map == null:
+			_report("map %d/%d (%s) is not in the cache." % [entry["group"], entry["number"], id])
+			continue
+		if map.width_blocks != entry["width"] or map.height_blocks != entry["height"]:
+			_report("%s is %dx%d blocks, the pin says %dx%d." % [
+				id, map.width_blocks, map.height_blocks, entry["width"], entry["height"]
+			])
+			continue
+		var attribute: Dictionary = attributes.get(id, {})
+		if attribute.is_empty():
+			_report("%s has no `map_attributes` row in the pin." % id)
+			continue
+		if map.border_block != attribute["border"]:
+			_report("%s border block is $%02X, the pin says $%02X." % [
+				id, map.border_block, attribute["border"]
+			])
+		var relative: String = blockdata.get("%s_Blocks" % attribute["label"], "")
+		var pinned: PackedByteArray = _bytes(pin.path_join(relative))
+		if pinned.is_empty():
+			# Every map on both pins has a `.blk` of its own, so a map that
+			# reaches none is a broken identity rather than shared blockdata.
+			_report("%s reaches no blockdata file in the pin." % id)
+			continue
+		compared += 1
+		_compare(
+			"%s blocks" % id, map.blocks, pinned,
+			map.width_blocks * map.height_blocks
+		)
+		highest = maxi(highest, _check_block_reach(id, map))
+	_r.note("blocks: %d maps compared against their own `.blk`, highest block named %d" % [
+		compared, highest
+	])
+	if compared == 0:
+		_report("no map's blocks were compared, so the layer proved nothing.")
+
+
+## The highest block [param map] names, and a failure when that is past its
+## tileset's own table. A metatile run's length is only the distance to the next
+## label, so `RomLayout.tileset_block_counts` is the one number here the pins
+## state nowhere: this is what says the imported length covers the corpus, and
+## `TilesetForest`'s 40 is why it is checked rather than assumed.
+func _check_block_reach(id: String, map: Gen2WorldMap) -> int:
+	var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+	if tileset == null:
+		_report("%s runs on tileset %d, which is not in the cache." % [id, map.tileset])
+		return -1
+	var highest: int = -1
+	for block: int in map.blocks:
+		highest = maxi(highest, block)
+	if highest >= tileset.block_count:
+		_report("%s names block %d of tileset %d, which holds %d." % [
+			id, highest, map.tileset, tileset.block_count
+		])
+	return highest
+
+
+# --- Metatiles, collision and palette maps ----------------------------------
+
+
+func _check_tilesets(pin: String) -> void:
+	var collisions: Dictionary = _collision_values(pin)
+	var paths: Dictionary = _label_paths(pin, "gfx/tilesets.asm")
+	paths.merge(_label_paths(pin, "gfx/tileset_palette_maps.asm"))
+	var names: PackedStringArray = _tileset_labels(pin)
+	if names.is_empty():
+		_report("no tileset rows were read from the pin's `Tilesets::`.")
+		return
+	var compared: int = 0
+	var overread: int = 0
+	for number: int in names.size():
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(number)
+		if tileset == null:
+			# Crystal's table is longer than Gold's; a number the cache does not
+			# carry is one the importer skipped, and the count line below says so.
+			continue
+		var label: String = names[number]
+		compared += 1
+		var meta: PackedByteArray = _bytes(pin.path_join(paths.get("%sMeta" % label, "")))
+		if meta.is_empty():
+			_report("tileset %d (%s) has no metatile file in the pin." % [number, label])
+		else:
+			_compare("tileset %d meta" % number, tileset.meta, meta, tileset.meta.size())
+		var collision: PackedByteArray = _collision_bytes(
+			pin.path_join(paths.get("%sColl" % label, "")), collisions
+		)
+		if collision.is_empty():
+			_report("tileset %d (%s) has no collision file in the pin." % [number, label])
+		else:
+			_compare(
+				"tileset %d collision" % number, tileset.collision, collision,
+				tileset.collision.size()
+			)
+		# `_LoadOverworldAttrmapPals` indexes `wTilesetPalettes` with the raw tile
+		# number and nothing bounds the read, so a palette map is only as long as
+		# the distance to the next one: Crystal's is 112 bytes, the two graphics
+		# blocks with the sixteen `$ff` the unusable $60..$7F range costs between
+		# them, and Gold and Silver's is 48, the first block alone. The importer
+		# reads RomLayout.WORLD_PALETTE_MAP_BYTES for both, which is the overread
+		# the cartridge performs, so the pin's length is the comparable span and
+		# `_check_palette_reach` is what says the rest is reachable.
+		var palettes: PackedByteArray = _palette_map_bytes(
+			pin.path_join(paths.get("%sPalMap" % label, ""))
+		)
+		if palettes.is_empty():
+			_report("tileset %d (%s) has no palette map in the pin." % [number, label])
+		else:
+			_compare(
+				"tileset %d palette map" % number, tileset.palette_map, palettes,
+				palettes.size()
+			)
+			overread += tileset.palette_map.size() - palettes.size()
+		_check_palette_reach(number, tileset)
+	_r.note("tilesets: %d of the pin's %d compared over three layers, %d palette bytes read past the pinned record" % [
+		compared, names.size(), overread
+	])
+	if compared == 0:
+		_report("no tileset was compared, so three layers proved nothing.")
+
+
+## Every tile a live block names has to fall inside the imported palette map,
+## because a tile past it draws with palette 0 here and with the next record's
+## byte on the cartridge. The pinned records stop short of the tile numbers the
+## metatiles reach, so this is the half of the palette layer the pin cannot
+## answer and the importer's own read length has to.
+func _check_palette_reach(number: int, tileset: Gen2WorldTileset) -> void:
+	var highest: int = -1
+	for block: int in tileset.block_count:
+		for tile: int in RomLayout.MAP_BLOCK_TILE_WIDTH * RomLayout.MAP_BLOCK_TILE_WIDTH:
+			var at: int = block * RomLayout.TILESET_META_BYTES_PER_BLOCK + tile
+			var index: int = tileset.meta[at] if at < tileset.meta.size() else 0
+			if index < tileset.tile_count:
+				highest = maxi(highest, index)
+	if highest >= 0 and (highest >> 1) >= tileset.palette_map.size():
+		_report("tileset %d names tile %d, past its %d-byte palette map." % [
+			number, highest, tileset.palette_map.size()
+		])
+
+
+# --- Comparison -------------------------------------------------------------
+
+
+## Reports the first differing byte of [param ours] against [param pinned] over
+## [param length] bytes, and a length disagreement as its own failure.
+func _compare(
+	subject: String, ours: PackedByteArray, pinned: PackedByteArray, length: int
+) -> void:
+	if ours.size() < length or pinned.size() < length:
+		_report("%s: %d bytes here and %d in the pin, %d expected." % [
+			subject, ours.size(), pinned.size(), length
+		])
+		return
+	for at: int in length:
+		if ours[at] == pinned[at]:
+			continue
+		_report("%s: byte %d is $%02X, the pin says $%02X." % [
+			subject, at, ours[at], pinned[at]
+		])
+		return
+
+
+func _report(message: String) -> void:
+	_failures += 1
+	printerr("%-8s %s" % [_r.game_id, message])
+
+
+# --- The pinned sources -----------------------------------------------------
+
+
+## `constants/map_constants.asm` in order: `newgroup` opens a group and each
+## `map_const` is the next map in it, so this is the same walk that gives
+## `MapGroupPointers` its indices.
+func _map_ids(pin: String) -> Array:
+	return _parsed(pin, &"map_ids", func() -> Array:
+		var out: Array = []
+		var group: int = 0
+		var number: int = 0
+		for line: String in _lines(pin.path_join("constants/map_constants.asm")):
+			if line.begins_with("newgroup"):
+				group += 1
+				number = 0
+			elif line.begins_with("map_const"):
+				number += 1
+				var fields: PackedStringArray = _fields(line)
+				if fields.size() < 3:
+					continue
+				out.append({
+					"group": group, "number": number, "id": fields[0],
+					"width": int(fields[1]), "height": int(fields[2]),
+				})
+		return out
+	)
+
+
+## `map_attributes Label, MAP_ID, $border`.
+func _attributes(pin: String) -> Dictionary:
+	return _parsed(pin, &"attributes", func() -> Dictionary:
+		var out: Dictionary = {}
+		for line: String in _lines(pin.path_join("data/maps/attributes.asm")):
+			if not line.begins_with("map_attributes"):
+				continue
+			var fields: PackedStringArray = _fields(line)
+			if fields.size() < 3:
+				continue
+			out[fields[1]] = {"label": fields[0], "border": _number(fields[2])}
+		return out
+	)
+
+
+## `<Label>_Blocks:` to the `.blk` it includes. Several labels can stand over
+## one `INCBIN`, which is how two maps share blockdata.
+func _blockdata(pin: String) -> Dictionary:
+	return _parsed(pin, &"blockdata", func() -> Dictionary:
+		return _includes(pin.path_join("data/maps/blocks.asm"))
+	)
+
+
+## The `Tilesets::` table in order, so the row index is the `TILESET_*` value.
+func _tileset_labels(pin: String) -> PackedStringArray:
+	return _parsed(pin, &"tilesets", func() -> PackedStringArray:
+		var out: PackedStringArray = []
+		var open: bool = false
+		for line: String in _lines(pin.path_join("data/tilesets.asm")):
+			if line.begins_with("Tilesets:"):
+				open = true
+			elif open and line.begins_with("tileset "):
+				out.append(line.substr("tileset ".length()).strip_edges())
+		return out
+	)
+
+
+func _label_paths(pin: String, relative: String) -> Dictionary:
+	return _parsed(pin, StringName(relative), func() -> Dictionary:
+		return _includes(pin.path_join(relative))
+	)
+
+
+## `DEF COLL_WALL EQU $07`.
+func _collision_values(pin: String) -> Dictionary:
+	return _parsed(pin, &"collision_values", func() -> Dictionary:
+		var out: Dictionary = {}
+		for line: String in _lines(pin.path_join("constants/collision_constants.asm")):
+			if not line.begins_with("DEF COLL_"):
+				continue
+			var parts: PackedStringArray = line.split(" ", false)
+			if parts.size() < 4 or parts[2] != "EQU":
+				continue
+			out[parts[1].substr("COLL_".length())] = _number(parts[3])
+		return out
+	)
+
+
+## `tilecoll A, B, C, D` is four permission bytes, one per 2x2 cell.
+func _collision_bytes(path: String, values: Dictionary) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	for line: String in _lines(path):
+		if not line.begins_with("tilecoll"):
+			continue
+		for field: String in _fields(line):
+			out.append(int(values.get(field, -1)) & 0xFF)
+	return out
+
+
+## `tilepal <bank>, <pal>...` packs two assignments per byte, the first in the
+## low nibble: the macro's own `dn (x | PAL_BG_\3), (x | PAL_BG_\2)`. The
+## `rept 16 / db $ff` between the two banks is the gap tiles $60..$7F leave and
+## is part of the record, so it is assembled here rather than skipped.
+func _palette_map_bytes(path: String) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	var repeat: int = 1
+	var block: PackedByteArray = PackedByteArray()
+	for line: String in _lines(path):
+		if line.begins_with("rept "):
+			repeat = int(line.substr("rept ".length()))
+			block = PackedByteArray()
+		elif line.begins_with("endr"):
+			for _pass: int in repeat:
+				out.append_array(block)
+			repeat = 1
+			block = PackedByteArray()
+		elif line.begins_with("db "):
+			block.append(_number(line.substr("db ".length()).strip_edges()) & 0xFF)
+		elif line.begins_with("tilepal"):
+			var fields: PackedStringArray = _fields(line)
+			var bank: int = OAM_BANK1 if int(fields[0]) == 1 else 0
+			var at: int = 1
+			while at + 1 < fields.size():
+				out.append(
+					((bank | BG_PALETTES.find(fields[at + 1])) << 4)
+					| (bank | BG_PALETTES.find(fields[at]))
+				)
+				at += 2
+	return out
+
+
+## Every `<Label>:` standing over an `INCBIN`/`INCLUDE`, mapped to its path. A
+## `SECTION` ends a run of labels that reached no include.
+func _includes(path: String) -> Dictionary:
+	var out: Dictionary = {}
+	var pending: PackedStringArray = []
+	for line: String in _lines(path):
+		if line.begins_with("SECTION"):
+			pending.clear()
+		elif line.begins_with("INCBIN") or line.begins_with("INCLUDE"):
+			var quoted: PackedStringArray = line.split("\"")
+			if quoted.size() >= 2:
+				for label: String in pending:
+					out[label] = quoted[1]
+			pending.clear()
+		elif line.ends_with(":") or line.ends_with("::"):
+			pending.append(line.trim_suffix(":").trim_suffix(":"))
+	return out
+
+
+# --- Files ------------------------------------------------------------------
+
+
+## One pin's parse of [param key], computed once per run. Every table here is
+## read for all three cartridges and two of them share a checkout.
+func _parsed(pin: String, key: StringName, body: Callable) -> Variant:
+	var cache: Dictionary = _pins.get_or_add(pin, {})
+	if not cache.has(key):
+		cache[key] = body.call()
+	return cache[key]
+
+
+## A source file with its comments and indentation gone, so a caller matches on
+## the directive alone.
+func _lines(path: String) -> PackedStringArray:
+	var out: PackedStringArray = []
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return out
+	while not file.eof_reached():
+		var line: String = file.get_line()
+		var comment: int = line.find(";")
+		if comment >= 0:
+			line = line.substr(0, comment)
+		line = line.strip_edges()
+		if line != "":
+			out.append(line)
+	return out
+
+
+func _bytes(path: String) -> PackedByteArray:
+	if path == "" or not FileAccess.file_exists(path):
+		return PackedByteArray()
+	return FileAccess.get_file_as_bytes(path)
+
+
+## The operands of a one-directive line, trimmed.
+func _fields(line: String) -> PackedStringArray:
+	var space: int = line.find(" ")
+	var out: PackedStringArray = []
+	if space < 0:
+		return out
+	for field: String in line.substr(space).split(","):
+		out.append(field.strip_edges())
+	return out
+
+
+func _number(text: String) -> int:
+	return text.substr(1).hex_to_int() if text.begins_with("$") else int(text)
+
+
+## `.references/` by default, the same root `tools/fetch_reference_sources.sh`
+## and `docs/REFERENCES.md` use.
+func _reference_root() -> String:
+	var override: String = OS.get_environment("GEN2_REFERENCE_ROOT")
+	if override != "":
+		return override
+	return ProjectSettings.globalize_path("res://").path_join(".references")

--- a/tools/checks/map_data.gd.uid
+++ b/tools/checks/map_data.gd.uid
@@ -1,0 +1,1 @@
+uid://b6ljqypqo5x6q

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -22,7 +22,9 @@ const GROUPS: Dictionary = {
 		&"cut", &"surf", &"whirlpool", &"strength", &"headbutt", &"rock_smash",
 		&"field_move_prompts",
 	],
-	&"terrain": [&"ledge_hops", &"side_walls", &"drawn_blocks", &"story_map_ids"],
+	&"terrain": [
+		&"ledge_hops", &"side_walls", &"drawn_blocks", &"story_map_ids", &"map_data",
+	],
 	&"johto": [
 		&"radio_tower", &"rising_badge", &"command_queues", &"item_balls",
 		&"route_27", &"magnet_train", &"scripted_scenes",


### PR DESCRIPTION
The disassemblies ship a complete second copy of every layer the map importer reads out of the cartridge. Nothing here had ever been compared against it.

`tools/checks/map_data.gd` sweeps all four layers on all three cartridges, whole corpus, no sampling:

| Layer | Crystal | Gold and Silver |
|---|---|---|
| Map blocks, dimensions and border block | 388 maps | 368 |
| Block to 4x4 tiles | 37 tilesets | 29 |
| Permission per quarter | 37 | 29 |
| Palette and bank per tile | 37 | 29 |

Every identity comes from the sources' own tables rather than from a number, because `Tileset0` and `TilesetJohto` are one record under two labels.

## What it found

A metatile run's length is only the distance to the next label, so the block count per tileset is a table kept by hand here. Gold and Silver said 64 blocks for `TilesetForest` where the real run is 40. Both imported 384 bytes of the following record as forest metatiles and 96 as its collision. Crystal already had the exception; Gold did not. Cache format 73 carries the fix.

The check now proves that table from the other side too: no map on any cartridge names a block past its tileset, the highest named being 127.

## What only looks like a defect

A palette map is the same kind of run, and the two cartridges disagree. Crystal's is 112 bytes, the two graphics blocks with the sixteen `$ff` the unusable `$60..$7F` range costs between them. Gold and Silver's is 48, the first block alone. `_LoadOverworldAttrmapPals` bounds nothing, so reading 112 on both is the same overread the hardware performs, and the pinned length is the comparable span. Every tile a live block names still falls inside what is read.

## Four field item effects

Separate, and they were missing.

- `VitaminEffect` adds ten to the high byte of one stat experience word, which is 2,560 flat. It refuses at 100 rather than clamping. `UpdateStatsAfterItem` writes the maximum and the five stats and never the current HP, so an HP UP raises the maximum and heals nothing.
- Heal Powder, Energypowder, Energy Root and the Revival Herb are each an ordinary effect plus a happiness row, charged only where the shared effect reports the item was used.
- The Revival Herb reaches `ReviveFullHP` rather than the healing path. It used to do nothing at all on a fainted member.

## Checks

- `validate.gd -- all`: 57 topics, exit 0
- GUT, both tiers: 3,339 tests over 152 scripts, green
- `replay_world.gd` on all three: 11 routes, 0 failures each
- the three-profile story walk: clean
- boot smoke test with and without mods: no error line