### PR TITLE
Let a mod carry its own icon and thumbnail

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -27,6 +27,8 @@ drops the id, so reinstalling later does not find it silently off.
 user://mods/<id>/
   mod.json
   mod.gd
+  icon.png        optional
+  thumbnail.webp  optional
 ```
 
 `mod.json`:
@@ -40,8 +42,14 @@ user://mods/<id>/
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
+| `icon` | Optional path to the icon, when it is not one of the conventional names |
+| `thumbnail` | Optional path to the thumbnail, same |
 | `dependencies` | Optional object from required mod ids to SemVer ranges |
 | `games` | Optional list of cartridge ids the mod is for |
+
+Neither art field is an `api_version` change: a host that has never heard of
+one ignores it, so a mod shipping art still installs on an older launcher and
+simply has no face there.
 
 `version` is a strict `major.minor.patch` number. Dependency ranges accept an
 exact version, `*`, component wildcards such as `1.x` or `1.4.*`, comparison
@@ -142,6 +150,35 @@ app's `Documents/mods` on iOS (reachable in the Files app, since the export sets
 `UIFileSharingEnabled`), and internal app storage on Android, where the system
 file picker is how an archive gets in.
 
+## An icon and a thumbnail
+
+Both are optional, and a mod that wants either declares nothing: dropping the
+file at the mod root is the whole of it.
+
+| | File tried, in order | Size | Drawn by |
+|---|---|---|---|
+| Icon | `icon.png`, `icon.webp`, `icon.jpg` | 32x32, square | The launcher's list row and mod page |
+| Thumbnail | `thumbnail.webp`, `thumb.webp`, `thumbnail.png`, `thumb.png` | 1280x720 | Nothing in the game; a listing site |
+
+A manifest may name another path with `icon` or `thumbnail`, which is what a mod
+keeping its art in a subdirectory needs. The path stays inside the mod folder on
+the same rule as `entry`, and one that climbs out is refused as
+`art_escapes_mod`.
+
+32x32 is the party-icon grid the cartridge itself draws on, and the launcher
+draws an icon at a whole multiple of it with nearest filtering, so the pixels
+stay square. Anything up to `Gen2ModArt.MAX_ICON_SIDE` on a side is accepted and
+never stretched to fill its box; past that, or past a megabyte, or not a PNG,
+WebP or JPEG by its own magic, it is ignored and the row keeps the generic
+glyph. A mod's art comes out of a stranger's archive, so every one of those is
+an ordinary answer rather than an error.
+
+An index row may carry `icon` and `thumbnail` as https URLs. That is how a mod
+has a face while it is still only listed: the launcher fetches each one once, on
+its own request so an icon never delays a download or a feed, and keeps it under
+`user://mod_icon_cache/` so a listing browsed offline still has faces. An
+installed copy's own file always wins over the URL.
+
 ## Publishing a source
 
 A source is a JSON feed listing mods that stay in their authors' own
@@ -158,7 +195,9 @@ adds it, because following a source is trusting whoever publishes it.
       "name": "Voxel Preview",
       "version": "1.0.0",
       "description": "Draws the map as geometry.",
-      "download": "https://example.com/voxel_preview-1.0.0.zip"
+      "download": "https://example.com/voxel_preview-1.0.0.zip",
+      "icon": "https://example.com/voxel_preview/icon.png",
+      "thumbnail": "https://example.com/voxel_preview/thumbnail.webp"
     }
   ]
 }
@@ -168,7 +207,9 @@ adds it, because following a source is trusting whoever publishes it.
 format may reuse a field name for something else. Feeds and downloads are https
 only: over plain http anyone on the path could rewrite where a download points.
 A row with no `id`, no usable `download`, or an id that is not a legal mod id is
-dropped, and the rest of the listing still works.
+dropped, and the rest of the listing still works. `icon` and `thumbnail` are
+optional and held to the same https rule; one that is not is dropped on its own
+rather than costing the row.
 
 Pasting `owner/repo`, the repository page, a site root or the feed file all
 resolve to the same feed, `https://<owner>.github.io/<repo>/index.json` for a

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -9,6 +9,9 @@ const GAP_XS: int = 4
 const GAP_SM: int = 8
 const GAP_MD: int = 14
 const GAP_LG: int = 22
+## The side a mod's icon is drawn at: a whole multiple of its native 32, so the
+## cartridge's own pixels stay square.
+const MOD_ICON_SIDE: float = 64.0
 ## Empty scroll tail that lets the final control rise clear of the floating dock.
 const DOCK_SAFE_BOTTOM: float = 132.0
 
@@ -282,6 +285,46 @@ static func file_picker(
 	dialog.use_native_dialog = true
 	dialog.theme = theme.control_theme()
 	return dialog
+
+
+## The square a mod's icon is drawn in, on a list row and on its own page.
+##
+## Always the same node whether or not there is a picture, because the alternative
+## is a list whose names start at two different places depending on whose mod it
+## is. A mod with no icon gets the generic glyph, greyed, in the same square.
+##
+## Nearest filtering, and never stretched: an icon is 32x32 pixel art drawn at
+## about 40, so smoothing it would blur exactly the edges it is made of, and
+## letting it fill a square it is not square for would distort it.
+static func mod_icon(
+	theme: Gen2LauncherTheme, texture: Texture2D, side: float = MOD_ICON_SIDE
+) -> Control:
+	if texture == null:
+		var glyph: Gen2LauncherIcon = Gen2LauncherIcon.create(&"mods", side * 0.62, theme.faint)
+		glyph.custom_minimum_size = Vector2(side, side)
+		glyph.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+		return glyph
+	var art := TextureRect.new()
+	art.texture = texture
+	art.custom_minimum_size = Vector2(side, side)
+	art.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	art.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	art.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	art.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	art.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	return art
+
+
+## Swaps the picture into a square [method mod_icon] already drew, for an icon
+## that arrived from the network after its row was built. A square holding the
+## fallback glyph answers false and is replaced by its owner instead:
+## [Gen2LauncherIcon] is a [TextureRect] too, so filling one would leave a node
+## that draws a mod's art while still believing it is a tinted glyph.
+static func set_mod_icon(square: Control, texture: Texture2D) -> bool:
+	if square is Gen2LauncherIcon or square is not TextureRect or texture == null:
+		return false
+	(square as TextureRect).texture = texture
+	return true
 
 
 static func _label(text: String, size: int, colour: Color) -> Label:

--- a/game/launcher/mod_detail_page.gd
+++ b/game/launcher/mod_detail_page.gd
@@ -17,6 +17,8 @@ var _theme: Gen2LauncherTheme = null
 var _title: Label = null
 var _subtitle: Label = null
 var _body: VBoxContainer = null
+var _head: HBoxContainer = null
+var _icon: Control = null
 var _status: Label = null
 var _row: Dictionary = {}
 
@@ -42,6 +44,9 @@ func _build() -> void:
 	back.tooltip_text = "Back to the mod list"
 	back.pressed.connect(func() -> void: closed.emit())
 	head.add_child(back)
+	_head = head
+	_icon = Gen2LauncherUI.mod_icon(_theme, null)
+	head.add_child(_icon)
 	var text: VBoxContainer = Gen2LauncherUI.column(2)
 	text.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	head.add_child(text)
@@ -72,6 +77,7 @@ func set_row(row: Dictionary) -> void:
 	if row.is_empty():
 		return
 	_row = row.duplicate(true)
+	_draw_icon(row)
 	_title.text = String(row["name"])
 	_subtitle.text = "%s  %s" % [row["id"], row["source_label"]]
 	Gen2LauncherUI.clear(_body)
@@ -154,6 +160,25 @@ func _summary(row: Dictionary) -> Control:
 		remove.pressed.connect(func() -> void: remove_requested.emit(_row))
 		actions.add_child(remove)
 	return panel
+
+
+## The mod's own icon beside its name, from the installed copy or from whatever
+## the list already fetched for it. This page never asks the network: it is
+## reached by pressing a row that has drawn the same picture already.
+func _draw_icon(row: Dictionary) -> void:
+	var texture: Texture2D = Gen2ModArt.icon_texture(String(row.get("icon", "")))
+	if texture == null:
+		var url: String = String(row.get("icon_url", ""))
+		if not url.is_empty():
+			texture = Gen2ModArt.cached_icon(url)
+	if Gen2LauncherUI.set_mod_icon(_icon, texture):
+		return
+	var art: Control = Gen2LauncherUI.mod_icon(_theme, texture)
+	_head.add_child(art)
+	_head.move_child(art, _icon.get_index())
+	_head.remove_child(_icon)
+	_icon.queue_free()
+	_icon = art
 
 
 ## A field's right-hand side. Wrapping is off, because a label given the room

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -43,6 +43,15 @@ var _pending: Dictionary = {}
 var _busy: bool = false
 var _check_queue: Array[String] = []
 var _check_updates_button: Gen2LauncherButton = null
+## Its own request, because the page's other one is serialised behind `_busy`
+## and an icon must never make a player wait for a download or a feed.
+var _icons: HTTPRequest = null
+## Icon URLs still to fetch, and the squares waiting for them. A square is a
+## node in the list, so a rebuild drops both rather than filling a freed one.
+var _icon_queue: Array[String] = []
+var _icon_targets: Dictionary = {}
+var _icon_busy: bool = false
+var _icon_pending: String = ""
 
 
 static func create(palette: Gen2LauncherTheme, host: Control = null) -> Gen2ModsPage:
@@ -60,6 +69,11 @@ func _build() -> void:
 	_http.use_threads = true
 	_http.body_size_limit = MAX_DOWNLOAD_BYTES
 	add_child(_http)
+	_icons = HTTPRequest.new()
+	_icons.use_threads = true
+	_icons.body_size_limit = Gen2ModArt.MAX_ICON_BYTES
+	_icons.request_completed.connect(_on_icon_arrived)
+	add_child(_icons)
 
 	_views = Control.new()
 	_views.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -128,6 +142,8 @@ func refresh() -> void:
 
 
 func _relist() -> void:
+	_icon_queue.clear()
+	_icon_targets.clear()
 	Gen2LauncherUI.clear(_list)
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	var groups: Array = Gen2ModCatalogue.groups(
@@ -149,6 +165,7 @@ func _relist() -> void:
 		for failure: Dictionary in failures:
 			_list.add_child(_refusal(failure))
 	_list.add_child(Gen2LauncherUI.dock_safe_space())
+	_fetch_next_icon()
 
 
 func _empty_state() -> Control:
@@ -173,9 +190,11 @@ func _card(row: Dictionary) -> Control:
 	var panel: Gen2LauncherCard = Gen2LauncherCard.create(_theme, Gen2LauncherTheme.RADIUS_MD, 18)
 	var line: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
 	panel.add_child(line)
+	line.add_child(_icon_square(row))
 
 	var text: VBoxContainer = Gen2LauncherUI.column(1)
 	text.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	text.alignment = BoxContainer.ALIGNMENT_CENTER
 	line.add_child(text)
 	text.add_child(Gen2LauncherUI.body(_theme, String(row["name"])))
 	text.add_child(Gen2LauncherUI.muted(_theme, _version_line(row)))
@@ -561,6 +580,72 @@ func _request(url: String, handler: Callable) -> bool:
 		_status("Could not reach %s." % url, _theme.error)
 		return false
 	return true
+
+
+## The square for one row, and the one place that decides where its picture
+## comes from: the installed copy's own file first, then whatever the source
+## already handed over, and the network only for a listing whose icon is not on
+## disk yet.
+func _icon_square(row: Dictionary) -> Control:
+	var texture: Texture2D = Gen2ModArt.icon_texture(String(row.get("icon", "")))
+	var url: String = String(row.get("icon_url", ""))
+	if texture == null and not url.is_empty():
+		texture = Gen2ModArt.cached_icon(url)
+	var square: Control = Gen2LauncherUI.mod_icon(_theme, texture)
+	if texture == null and Gen2ModArt.wants_fetch(url) and not _icon_targets.has(url):
+		# Only a TextureRect can be filled in later, and a square with no picture
+		# is the fallback glyph. It is replaced through its parent instead.
+		_icon_targets[url] = square
+		_icon_queue.append(url)
+	return square
+
+
+func _fetch_next_icon() -> void:
+	if _icon_busy or _icon_queue.is_empty() or _icons == null:
+		return
+	var url: String = _icon_queue.pop_front()
+	_icon_busy = true
+	if _icons.request(url) != OK:
+		_icon_busy = false
+		_icon_targets.erase(url)
+		_fetch_next_icon()
+		return
+	_icon_pending = url
+
+
+func _on_icon_arrived(
+	result: int, code: int, _headers: PackedStringArray, body: PackedByteArray
+) -> void:
+	var url: String = _icon_pending
+	_icon_pending = ""
+	_icon_busy = false
+	# A missing icon is not a failure worth telling anyone about: the row keeps
+	# its glyph and nothing is retried until the list is built again.
+	if result == HTTPRequest.RESULT_SUCCESS and code == 200:
+		var texture: Texture2D = Gen2ModArt.icon_texture_from_bytes(body)
+		if texture != null:
+			Gen2ModArt.cache_icon(url, body)
+			_place_icon(url, texture)
+	_icon_targets.erase(url)
+	_fetch_next_icon()
+
+
+## Puts an arrived picture in the square that was drawn for it, replacing the
+## fallback glyph in place so the row does not move.
+func _place_icon(url: String, texture: Texture2D) -> void:
+	var square: Variant = _icon_targets.get(url, null)
+	if square is not Control or not (square as Control).is_inside_tree():
+		return
+	var control: Control = square as Control
+	if Gen2LauncherUI.set_mod_icon(control, texture):
+		return
+	var parent: Node = control.get_parent()
+	var art: Control = Gen2LauncherUI.mod_icon(_theme, texture)
+	parent.add_child(art)
+	parent.move_child(art, control.get_index())
+	parent.remove_child(control)
+	control.queue_free()
+	_icon_targets[url] = art
 
 
 func _status(message: String, colour: Color) -> void:

--- a/game/mods/mod_art.gd
+++ b/game/mods/mod_art.gd
@@ -1,0 +1,162 @@
+class_name Gen2ModArt
+extends RefCounted
+
+## A mod's own pictures: the icon the launcher draws beside its name, and the
+## thumbnail a listing site shows for it.
+##
+## Both are optional and neither is declared for the usual mod: dropping
+## `icon.png` beside `mod.json` is the whole of it, because a convention an
+## author has to read a document to obey is one most will not. A manifest may
+## still name another path, which is what a mod keeping its art in a
+## subdirectory or inside a pack needs.
+##
+## The game never draws a thumbnail. It is resolved here anyway so one rule
+## covers both files and a packaging script has one place to ask.
+
+## Tried in order, and the first that exists wins. PNG leads because an icon is
+## 32x32 pixel art off the cartridge, where lossy compression only costs.
+const ICON_NAMES: Array = ["icon.png", "icon.webp", "icon.jpg", "icon.jpeg"]
+## The website's picture, 1280x720. `thumb` is here because half of everyone
+## types it.
+const THUMBNAIL_NAMES: Array = [
+	"thumbnail.webp", "thumb.webp", "thumbnail.png", "thumb.png", "thumbnail.jpg",
+]
+
+## What an icon is drawn from: the party-icon grid the cartridge itself uses, so
+## a mod's icon sits beside the game's own art without resampling.
+const ICON_SIDE: int = 32
+## An icon is a few hundred bytes of pixel art. Anything larger is a photograph
+## someone renamed, and refusing it here is cheaper than decoding it.
+const MAX_ICON_BYTES: int = 1024 * 1024
+## Room for an author who drew at 8x and never scaled down, and a stop well
+## before a decoded image costs real memory on a phone.
+const MAX_ICON_SIDE: int = 512
+## Icons fetched from a followed index, one file per URL. Kept beside the feed
+## cache and for the same reason: a listing browsed offline still has faces.
+const CACHE_DIRECTORY: String = "user://mod_icon_cache"
+
+## Icon bytes to the texture decoded from them, because the launcher rebuilds
+## its whole list on any change and would otherwise decode every icon again.
+## Keyed by content rather than by path: an icon file is a kilobyte, so reading
+## it back is nothing beside decoding it, and a reinstalled mod cannot be drawn
+## with the picture the version before it had. Modification time is not enough
+## for that, since a replace inside the same second keeps it.
+static var _textures: Dictionary = {}
+
+
+## The icon file for [param manifest], or an empty string for a mod without one.
+static func icon_path(manifest: Gen2ModManifest) -> String:
+	if manifest == null:
+		return ""
+	return locate(manifest.directory, ICON_NAMES, manifest.icon)
+
+
+## The thumbnail file for [param manifest], or an empty string. See the class
+## note: nothing in the game reads this, and a packaging script does.
+static func thumbnail_path(manifest: Gen2ModManifest) -> String:
+	if manifest == null:
+		return ""
+	return locate(manifest.directory, THUMBNAIL_NAMES, manifest.thumbnail)
+
+
+## The first of [param names] that exists in [param folder], or [param declared]
+## when the manifest named one. Pure enough to test with a temporary directory
+## and no mod around it.
+static func locate(folder: String, names: Array, declared: String = "") -> String:
+	if folder.is_empty():
+		return ""
+	if not declared.is_empty():
+		var named: String = "%s/%s" % [folder, declared]
+		return named if FileAccess.file_exists(named) else ""
+	for candidate: String in names:
+		var path: String = "%s/%s" % [folder, candidate]
+		if FileAccess.file_exists(path):
+			return path
+	return ""
+
+
+## Reads [param path] as an icon, or null for a file that is missing, too big,
+## or not an image. A mod's icon comes from a stranger's archive, so every
+## failure here is an ordinary answer rather than an error worth printing.
+static func icon_texture(path: String) -> Texture2D:
+	if path.is_empty() or not FileAccess.file_exists(path):
+		return null
+	var bytes: PackedByteArray = FileAccess.get_file_as_bytes(path)
+	var key: String = _digest(bytes)
+	if _textures.has(key):
+		return _textures[key]
+	var texture: Texture2D = _decode(bytes)
+	if texture != null:
+		_textures[key] = texture
+	return texture
+
+
+## The same for bytes that never became a file, which is what a fetched icon is
+## before it is cached.
+static func icon_texture_from_bytes(bytes: PackedByteArray) -> Texture2D:
+	return _decode(bytes)
+
+
+## Where a fetched icon is kept. Named by hash of its URL, the way
+## [method Gen2ModIndex.cache_path] names a feed, because a URL is not a
+## filename.
+static func cache_path(url: String, directory: String = CACHE_DIRECTORY) -> String:
+	return "%s/%s" % [directory, url.sha256_text().substr(0, 32)]
+
+
+## Keeps [param bytes] as the icon for [param url]. Only bytes that decoded are
+## worth keeping, so the caller checks first and a broken server cannot fill the
+## cache with rubbish that is retried from disk forever.
+static func cache_icon(url: String, bytes: PackedByteArray, directory: String = CACHE_DIRECTORY) -> bool:
+	if bytes.size() > MAX_ICON_BYTES:
+		return false
+	DirAccess.make_dir_recursive_absolute(directory)
+	var file: FileAccess = FileAccess.open(cache_path(url, directory), FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_buffer(bytes)
+	file.close()
+	return true
+
+
+## The cached icon for [param url], or null when it was never fetched.
+static func cached_icon(url: String, directory: String = CACHE_DIRECTORY) -> Texture2D:
+	return icon_texture(cache_path(url, directory))
+
+
+## True when [param url] is worth fetching an icon from: https, like every other
+## address this project reads, and not already on disk.
+static func wants_fetch(url: String, directory: String = CACHE_DIRECTORY) -> bool:
+	if not Gen2ModIndex.is_downloadable(url):
+		return false
+	return not FileAccess.file_exists(cache_path(url, directory))
+
+
+## Content hash, since [PackedByteArray] has no digest of its own and a path
+## with a modification time is not one: a mod replaced inside the same second
+## keeps both.
+static func _digest(bytes: PackedByteArray) -> String:
+	var context := HashingContext.new()
+	context.start(HashingContext.HASH_SHA256)
+	context.update(bytes)
+	return context.finish().hex_encode()
+
+
+static func _decode(bytes: PackedByteArray) -> Texture2D:
+	if bytes.is_empty() or bytes.size() > MAX_ICON_BYTES:
+		return null
+	var image := Image.new()
+	# Format by magic rather than by extension, because a fetched icon has no
+	# name and a file's name is the author's guess at its own contents.
+	var loaded: int = FAILED
+	if bytes.slice(0, 8) == PackedByteArray([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]):
+		loaded = image.load_png_from_buffer(bytes)
+	elif bytes.slice(0, 4) == PackedByteArray([0x52, 0x49, 0x46, 0x46]):
+		loaded = image.load_webp_from_buffer(bytes)
+	elif bytes.slice(0, 3) == PackedByteArray([0xFF, 0xD8, 0xFF]):
+		loaded = image.load_jpg_from_buffer(bytes)
+	if loaded != OK or image.is_empty():
+		return null
+	if image.get_width() > MAX_ICON_SIDE or image.get_height() > MAX_ICON_SIDE:
+		return null
+	return ImageTexture.create_from_image(image)

--- a/game/mods/mod_art.gd.uid
+++ b/game/mods/mod_art.gd.uid
@@ -1,0 +1,1 @@
+uid://jqagwvs8skha

--- a/game/mods/mod_catalogue.gd
+++ b/game/mods/mod_catalogue.gd
@@ -74,6 +74,10 @@ static func _row(
 		"listed_version": listed_version,
 		"description": String(entry.get("description", "")),
 		"download": String(entry.get("download", "")),
+		# The installed copy's own file when there is one, and the listing's URL
+		# otherwise, so a mod has a face while it is still only being browsed.
+		"icon": Gen2ModArt.icon_path(manifest),
+		"icon_url": String(entry.get("icon", "")),
 		"feed": feed,
 		"source_label": label,
 		"installed": manifest != null,

--- a/game/mods/mod_index.gd
+++ b/game/mods/mod_index.gd
@@ -78,9 +78,10 @@ static func resolve_source(input: String) -> Dictionary:
 ## Reads a fetched feed into rows the launcher can list.
 ##
 ## Returns { ok, name, entries } where each entry has id, name, version,
-## description and download. An entry missing an id or a usable download is
-## dropped rather than failing the whole feed, because one bad row in someone
-## else's file should not cost the player the rest of the list.
+## description, download, and the optional icon and thumbnail URLs. An entry
+## missing an id or a usable download is dropped rather than failing the whole
+## feed, because one bad row in someone else's file should not cost the player
+## the rest of the list.
 static func parse_feed(text: String) -> Dictionary:
 	if text.length() > MAX_FEED_BYTES:
 		return {"ok": false, "reason": &"index_too_large"}
@@ -263,7 +264,16 @@ static func _entry_from(raw: Dictionary) -> Dictionary:
 		"version": String(raw.get("version", "")),
 		"description": String(raw.get("description", "")),
 		"download": download,
+		# Optional art. Held to the same https rule as the download, and dropped
+		# rather than refused: a listing without a picture is still a listing.
+		"icon": _art_url(raw.get("icon", "")),
+		"thumbnail": _art_url(raw.get("thumbnail", "")),
 	}
+
+
+static func _art_url(raw: Variant) -> String:
+	var url: String = String(raw).strip_edges()
+	return url if is_downloadable(url) else ""
 
 
 static func _github_slug(url: String) -> Dictionary:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -26,6 +26,10 @@ const FILENAME: String = "mod.json"
 ## [method Gen2WorldAPI.hidden_items].
 ## 8 added [method Gen2ModHost.register_stats_page], a page of a Pokémon's stats
 ## screen past the cartridge's own three.
+##
+## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
+## host that has never heard of either ignores the field, so a mod that ships
+## art still installs on an older launcher and simply has no face there.
 const API_VERSION: int = 9
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
@@ -43,6 +47,12 @@ var entry: String = ""
 ## [member entry] is a path inside that root rather than inside the directory.
 var pack: String = ""
 var description: String = ""
+## An optional icon beside the manifest, for the launcher's list. Empty means
+## the conventional names are tried instead; see [Gen2ModArt].
+var icon: String = ""
+## An optional 16:9 thumbnail beside the manifest, for a listing site. Nothing
+## in the game draws one; see [Gen2ModArt].
+var thumbnail: String = ""
 ## Required mod ids to accepted semantic-version ranges.
 var dependencies: Dictionary = {}
 ## Which cartridges the mod is for, as [RomRegistry] ids. Empty means every game
@@ -87,6 +97,8 @@ static func from_dictionary(source: Dictionary, folder: String) -> Dictionary:
 	manifest.entry = String(source.get("entry", ""))
 	manifest.pack = String(source.get("pack", ""))
 	manifest.description = String(source.get("description", ""))
+	manifest.icon = String(source.get("icon", ""))
+	manifest.thumbnail = String(source.get("thumbnail", ""))
 	var raw_dependencies: Variant = source.get("dependencies", {})
 	if not raw_dependencies is Dictionary:
 		return _refuse(&"invalid_dependencies", String(manifest.id))
@@ -142,6 +154,13 @@ static func from_dictionary(source: Dictionary, folder: String) -> Dictionary:
 			return _refuse(&"pack_escapes_mod", manifest.pack)
 		if not (manifest.pack.ends_with(".pck") or manifest.pack.ends_with(".zip")):
 			return _refuse(&"pack_not_a_resource_pack", manifest.pack)
+	# Art is read from the mod directory rather than mounted or run, so the
+	# only rule is the entry's: a path that stays inside the mod's own folder.
+	for art: String in [manifest.icon, manifest.thumbnail]:
+		if art.is_empty():
+			continue
+		if art.begins_with("/") or art.contains("..") or art.contains(":"):
+			return _refuse(&"art_escapes_mod", art)
 	return {"ok": true, "manifest": manifest}
 
 
@@ -195,6 +214,8 @@ func summary() -> Dictionary:
 		"pack": pack,
 		"dependencies": dependencies.duplicate(),
 		"games": games.duplicate(),
+		"icon": Gen2ModArt.icon_path(self),
+		"thumbnail": Gen2ModArt.thumbnail_path(self),
 	}
 
 

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -41,6 +41,7 @@ const WORDING: Dictionary = {
 	&"entry_not_gdscript": "A mod's entry script has to be GDScript (%s).",
 	&"entry_escapes_mod": "The entry script points outside the mod folder (%s).",
 	&"pack_escapes_mod": "The mod's resource pack has to be a file beside its mod.json (%s).",
+	&"art_escapes_mod": "The mod's icon or thumbnail points outside the mod folder (%s).",
 	&"pack_not_a_resource_pack": "A mod's pack has to be a .pck or .zip (%s).",
 
 	# Writing it into place.

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -190,6 +190,38 @@ func test_mod_update_controls_stay_icon_sized_for_mobile() -> void:
 		action.free()
 
 
+func test_a_mod_icon_keeps_its_square_whether_or_not_the_mod_has_a_picture() -> void:
+	var image: Image = Image.create_empty(
+		Gen2ModArt.ICON_SIDE, Gen2ModArt.ICON_SIDE, false, Image.FORMAT_RGBA8
+	)
+	image.fill(Color.REBECCA_PURPLE)
+	var texture: ImageTexture = ImageTexture.create_from_image(image)
+
+	var blank: Control = Gen2LauncherUI.mod_icon(_light, null)
+	var drawn: Control = Gen2LauncherUI.mod_icon(_light, texture)
+	var side: float = Gen2LauncherUI.MOD_ICON_SIDE
+	for square: Control in [blank, drawn]:
+		assert_eq(
+			square.custom_minimum_size, Vector2(side, side),
+			"a name starts at the same place with or without an icon"
+		)
+	assert_eq(
+		(drawn as TextureRect).stretch_mode, TextureRect.STRETCH_KEEP_ASPECT_CENTERED,
+		"an icon that is not square for its box is never stretched to fit"
+	)
+	assert_eq(
+		(drawn as TextureRect).texture_filter, CanvasItem.TEXTURE_FILTER_NEAREST,
+		"32x32 cartridge art is not smoothed on the way up"
+	)
+	assert_true(Gen2LauncherUI.set_mod_icon(drawn, texture), "a drawn square takes a later picture")
+	assert_false(
+		Gen2LauncherUI.set_mod_icon(blank, texture),
+		"and the fallback glyph is replaced by its owner rather than filled"
+	)
+	blank.free()
+	drawn.free()
+
+
 func test_launcher_buttons_always_draw_a_coloured_focus_ring() -> void:
 	for variant: Gen2LauncherButton.Variant in Gen2LauncherButton.Variant.values():
 		var button: Gen2LauncherButton = Gen2LauncherButton.create(_light, "Focus", variant)

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1603,3 +1603,117 @@ func test_a_chosen_view_survives_a_reload_and_falls_back_when_its_mod_is_gone() 
 		reloaded.selected_world_renderer(), &"voxel3d",
 		"and is picked up again when the mod loads"
 	)
+
+
+## A tiny square PNG on disk, which is what a mod's icon is.
+func _write_icon(path: String, side: int = Gen2ModArt.ICON_SIDE) -> void:
+	var image: Image = Image.create_empty(side, side, false, Image.FORMAT_RGBA8)
+	image.fill(Color.REBECCA_PURPLE)
+	image.save_png(path)
+
+
+func test_a_mod_gets_its_icon_and_thumbnail_by_dropping_them_beside_the_manifest() -> void:
+	_write_manifest(_valid_manifest())
+	_write_icon("%s/icon.png" % _directory)
+	_write_icon("%s/thumbnail.webp" % _directory)
+	var read: Dictionary = Gen2ModManifest.read(_directory)
+	assert_true(read["ok"], "a mod carrying art is an ordinary mod")
+	var manifest: Gen2ModManifest = read["manifest"]
+	assert_eq(Gen2ModArt.icon_path(manifest), "%s/icon.png" % _directory)
+	assert_eq(Gen2ModArt.thumbnail_path(manifest), "%s/thumbnail.webp" % _directory)
+	assert_not_null(Gen2ModArt.icon_texture(Gen2ModArt.icon_path(manifest)))
+
+
+func test_a_mod_with_no_art_answers_with_nothing_rather_than_a_missing_path() -> void:
+	_write_manifest(_valid_manifest())
+	var manifest: Gen2ModManifest = Gen2ModManifest.read(_directory)["manifest"]
+	assert_eq(Gen2ModArt.icon_path(manifest), "")
+	assert_eq(Gen2ModArt.thumbnail_path(manifest), "")
+	assert_null(Gen2ModArt.icon_texture(""))
+
+
+func test_a_declared_icon_wins_and_one_that_leaves_the_mod_directory_is_refused() -> void:
+	DirAccess.make_dir_recursive_absolute("%s/art" % _directory)
+	_write_icon("%s/art/face.png" % _directory)
+	# The conventional name is present too, so this proves the declaration is
+	# read rather than the discovery happening to find the same file.
+	_write_icon("%s/icon.png" % _directory)
+	var source: Dictionary = _valid_manifest()
+	source["icon"] = "art/face.png"
+	_write_manifest(source)
+	var manifest: Gen2ModManifest = Gen2ModManifest.read(_directory)["manifest"]
+	assert_eq(Gen2ModArt.icon_path(manifest), "%s/art/face.png" % _directory)
+
+	source["icon"] = "../../elsewhere/icon.png"
+	_write_manifest(source)
+	var escaped: Dictionary = Gen2ModManifest.read(_directory)
+	assert_false(escaped["ok"])
+	assert_eq(escaped["reason"], &"art_escapes_mod")
+
+
+func test_art_that_is_not_an_image_or_is_far_too_large_is_not_drawn() -> void:
+	_write("%s/icon.png" % _directory, "this is not a png")
+	assert_null(Gen2ModArt.icon_texture("%s/icon.png" % _directory), "rubbish decodes to nothing")
+	_write_icon("%s/big.png" % _directory, Gen2ModArt.MAX_ICON_SIDE + 8)
+	assert_null(
+		Gen2ModArt.icon_texture("%s/big.png" % _directory),
+		"an icon past the side cap is refused rather than decoded"
+	)
+
+
+func test_a_listing_keeps_only_art_it_could_actually_fetch() -> void:
+	var parsed: Dictionary = Gen2ModIndex.parse_feed(JSON.stringify({
+		"schema_version": Gen2ModIndex.SCHEMA_VERSION,
+		"mods": [{
+			"id": "voxel", "name": "Voxel", "version": "1.0.0",
+			"download": "https://example.test/voxel.zip",
+			"icon": "https://example.test/voxel/icon.png",
+			"thumbnail": "http://example.test/voxel/thumbnail.webp",
+		}],
+	}))
+	assert_true(parsed["ok"])
+	var entry: Dictionary = (parsed["entries"] as Array)[0]
+	assert_eq(entry["icon"], "https://example.test/voxel/icon.png")
+	assert_eq(entry["thumbnail"], "", "plain http is dropped, the way a download would be")
+
+
+func test_a_row_carries_the_installed_icon_and_the_listing_falls_back_to_its_url() -> void:
+	_write_manifest(_valid_manifest())
+	_write_icon("%s/icon.png" % _directory)
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	var listing: Dictionary = {
+		"voxel": [{
+			"id": &"voxel", "name": "Voxel", "version": "1.0.0",
+			"download": "https://example.test/voxel.zip",
+			"icon": "https://example.test/voxel/icon.png",
+		}, {
+			"id": &"absent", "name": "Absent", "version": "1.0.0",
+			"download": "https://example.test/absent.zip",
+			"icon": "https://example.test/absent/icon.png",
+		}],
+	}
+	var groups: Array = Gen2ModCatalogue.groups(
+		host.manifests(), [{"feed": "voxel", "label": "Test source"}], listing
+	)
+	var rows: Dictionary = {}
+	for row: Dictionary in groups[0]["rows"] as Array:
+		rows[String(row["id"])] = row
+	assert_eq(rows["voxel"]["icon"], "%s/icon.png" % _directory, "installed art wins")
+	assert_eq(rows["absent"]["icon"], "", "a mod that is only listed has no file")
+	assert_eq(rows["absent"]["icon_url"], "https://example.test/absent/icon.png")
+
+
+func test_a_fetched_icon_is_cached_and_read_back_without_the_network() -> void:
+	var directory: String = "%s/icon_cache" % ROOT
+	var url: String = "https://example.test/voxel/icon.png"
+	assert_true(Gen2ModArt.wants_fetch(url, directory), "nothing cached yet")
+	assert_false(
+		Gen2ModArt.wants_fetch("http://example.test/icon.png", directory),
+		"plain http is never fetched"
+	)
+	_write_icon("%s/source.png" % _directory)
+	var bytes: PackedByteArray = FileAccess.get_file_as_bytes("%s/source.png" % _directory)
+	assert_true(Gen2ModArt.cache_icon(url, bytes, directory))
+	assert_false(Gen2ModArt.wants_fetch(url, directory), "and not fetched twice")
+	assert_not_null(Gen2ModArt.cached_icon(url, directory))


### PR DESCRIPTION
A mod can now have a face, and a mod that wants one declares nothing.

- `icon.png` beside `mod.json` is drawn in the launcher's list row and on the mod's own page.
- `thumbnail.webp` is resolved on the same rule and drawn by nothing in the game. It is for a listing site.

`icon.webp`, `icon.jpg`, `thumb.webp` and a few more names are tried too, and a manifest may name another path with `"icon"` or `"thumbnail"`. That path stays inside the mod folder on the same rule as `entry`; one that climbs out is refused as `art_escapes_mod`.

`Gen2ModArt` is the whole rule. An icon is capped at a megabyte and 512 on a side, and has to be a PNG, WebP or JPEG by its own magic rather than by its filename. Art comes out of a stranger's archive, so each of those is an ordinary answer rather than an error: the row keeps the generic glyph and nothing is printed.

32x32 is the party-icon grid the cartridge draws on. The launcher draws an icon at a whole multiple of it with nearest filtering, so the pixels stay square, and never stretches one to fill its box.

An index row may carry `icon` and `thumbnail` as https URLs, which is how a mod has a face while it is still only being browsed. The mods page fetches those on a second `HTTPRequest` of its own, because the existing one is serialised behind `_busy` and an icon must never make a player wait for a download or a feed. Fetched icons are cached under `user://mod_icon_cache/`, beside the feed cache and for the same reason. An installed copy's own file always wins over the URL.

This is deliberately not an `api_version` change. A host that has never heard of either field ignores it, so a mod shipping art still installs on an older launcher and simply has no face there.

## Proving it

| | |
|---|---|
| GUT, full tier | 3,347 tests over 152 scripts, green |
| `validate.gd -- all` | exit 0 |
| Boot smoke | exit 0 |
| Screenshots | mods list, scrolled list and a mod page, from `preview_launcher.gd` |

Seven new cases: art found by convention, a declared path winning and an escaping one refused, rubbish and oversized art ignored, a listing keeping only art it could fetch, a row preferring the installed file, and the fetch cache. Plus one on the icon square holding its size with or without a picture.

Screenshots below are the six mods in [pokerecomp-decrypt-mods#37](https://github.com/Decryptu/pokerecomp-decrypt-mods/pull/37), which adds art to all six. `voxel_preview` at the bottom of the list has none and shows the fallback: same square, so every name still starts at the same place.