### PR TITLE
Fly the title bird on the cartridge's own frames

### DIFF
--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -147,11 +147,19 @@ const BIRD_SETS_SILVER: Array[Vector2i] = [
 	Vector2i(1, 0x60), Vector2i(0, 0x00),
 ]
 
-## `.OAMData_GSTitleTrail`: one 8x16 object a tile up and left of the struct's
-## own coordinate, drawn through object palette 1. `SPRITE_ANIM_OAMSET_GS_TITLE_TRAIL_1`
-## and `_2` are the same picture at vtile $f8 and $fa, and `TitleScreen` copies
-## the trail into `vTiles1 tile $78`, which is where those two land.
-const TRAIL_AT := Vector3i(-8, -8, 0x00)
+## `.OAMData_GSTitleTrail`, which is not the same picture on the two cartridges.
+## Gold's is one 8x16 object at `dbsprite -1, -1, 4, 4`, so its four pixels of
+## offset take it half a tile up and left of the struct rather than a whole one;
+## Silver's is two objects side by side at `-1, -1` and `0, -1` with no pixel
+## offset, and its own tiles rather than a vtile base. Both are drawn through
+## object palette 1.
+const TRAIL_OAM_GOLD: Array[Vector3i] = [Vector3i(-4, -4, 0x00)]
+const TRAIL_OAM_SILVER: Array[Vector3i] = [
+	Vector3i(-8, -8, 0x00), Vector3i(0, -8, 0x02),
+]
+## `SPRITE_ANIM_OAMSET_GS_TITLE_TRAIL_1` and `_2` are Gold's one picture at vtile
+## $f8 and $fa, which is what its frameset alternates. Silver's frameset reaches
+## only `_1`, so nothing steps this there.
 const TRAIL_TILES: Array[int] = [0x00, 0x02]
 ## `TitleScreen` copies the trail into `vTiles1 tile $78`, which the object
 ## layer addresses as tile $78 of the second sheet.
@@ -435,11 +443,14 @@ func _oam_set(kind: StringName, frame: int) -> Array[Vector3i]:
 		Gen2TitleScene.SPRITE_CRYSTAL:
 			return [Vector3i(0, 0, 0)] as Array[Vector3i]
 		Gen2TitleScene.SPRITE_TRAIL:
-			# The frameset's own two sets, which are one picture each.
-			return [Vector3i(
-				TRAIL_AT.x, TRAIL_AT.y,
-				TRAIL_TILES[clampi(frame, 0, TRAIL_TILES.size() - 1)]
-			)] as Array[Vector3i]
+			if _profile == RomRegistry.SILVER:
+				return TRAIL_OAM_SILVER
+			# Gold's frameset alternates the two vtile bases over one picture.
+			var step: int = TRAIL_TILES[clampi(frame, 0, TRAIL_TILES.size() - 1)]
+			var trail: Array[Vector3i] = []
+			for part: Vector3i in TRAIL_OAM_GOLD:
+				trail.append(Vector3i(part.x, part.y, part.z + step))
+			return trail
 		_:
 			var sets: Array[Vector2i] = (
 				BIRD_SETS_GOLD if _profile == RomRegistry.GOLD else BIRD_SETS_SILVER

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -89,16 +89,17 @@ const BIRD_AT := Vector2i(11 * Gen2Tiles.TILE_WIDTH, 12 * Gen2Tiles.TILE_HEIGHT)
 const BIRD_SINE_GOLD: int = 2
 const BIRD_SINE_SILVER: int = 8
 
-## `.Frameset_GSIntroHoOhLugia` as [code](oam set, frames)[/code] pairs per
-## profile. `oamframe X, n` lasts n + 1 and `oamrestart` loops rather than ending.
+## `.Frameset_GSIntroHoOhLugia` as (OAM set, duration) pairs per profile, the
+## same shape as [constant TRAIL_FRAMESET_GOLD]: a frame lasts its duration plus
+## one, and `oamrestart` loops rather than ending.
 const BIRD_FRAMESET_GOLD: Array[Vector2i] = [
-	Vector2i(0, 11), Vector2i(1, 10), Vector2i(2, 11),
-	Vector2i(3, 11), Vector2i(2, 10), Vector2i(4, 11),
+	Vector2i(0, 10), Vector2i(1, 9), Vector2i(2, 10),
+	Vector2i(3, 10), Vector2i(2, 9), Vector2i(4, 10),
 ]
 const BIRD_FRAMESET_SILVER: Array[Vector2i] = [
-	Vector2i(1, 4), Vector2i(0, 8), Vector2i(1, 8), Vector2i(2, 8),
-	Vector2i(2, 8), Vector2i(3, 8), Vector2i(3, 8), Vector2i(2, 8),
-	Vector2i(1, 4),
+	Vector2i(1, 3), Vector2i(0, 7), Vector2i(1, 7), Vector2i(2, 7),
+	Vector2i(2, 7), Vector2i(3, 7), Vector2i(3, 7), Vector2i(2, 7),
+	Vector2i(1, 3),
 ]
 
 ## `UpdateTitleTrailSprite`, a trail every fourth frame of the timer. Gold picks
@@ -169,7 +170,19 @@ var _suicune_counter: int = 0
 ## by the page: the counter is read before it is raised, so the write lands late.
 var _suicune_base: int = SUICUNE_FIRST_BASE
 var _bird_var: int = 0
+## `SPRITEANIMSTRUCT_FRAME` and `..._DURATION` for the bird's own struct, and
+## the frame counter opens at 0 rather than `_InitSpriteAnimStruct`'s -1.
+## `_TitleScreen` copies the spawned struct into `wSpriteAnim10` with
+## `ld bc, NUM_SPRITE_ANIM_STRUCTS`, which is ten bytes where the struct is
+## sixteen, so the six fields from `..._FRAME` up are never copied. They are the
+## zeroes `ClearSpriteAnims` left, that routine having wiped the whole of
+## `wSpriteAnimData` at the top of `_TitleScreen`, so the values are the
+## cartridge's on every entry rather than boot-time WRAM. The one visible
+## consequence is `GetSpriteAnimFrame`'s `inc [hl]`: entry 0 is skipped on the
+## first pass, and `oamrestart` writes -1, so every later cycle plays it.
 var _bird_frame: int = 0
+var _bird_duration: int = 0
+var _bird_set: int = 0
 var _selected: int = -1
 var _sine: Gen2BattleAnimData = null
 ## Live particles as `{ at, var1, yoffset, fresh }`, capped the way
@@ -301,7 +314,13 @@ func _advance_animation() -> void:
 	# The struct's own VAR1, counted the way each profile counts it. A byte, so
 	# Silver's countdown wraps rather than going negative.
 	_bird_var = (_bird_var + (1 if _profile == RomRegistry.GOLD else -1)) & 0xFF
-	_bird_frame += 1
+	var bird: Dictionary = {
+		"frame": _bird_frame, "duration": _bird_duration, "set": _bird_set,
+	}
+	_advance_frameset(bird, _bird_frameset(), true)
+	_bird_frame = int(bird["frame"])
+	_bird_duration = int(bird["duration"])
+	_bird_set = int(bird["set"])
 	_advance_trails()
 
 
@@ -320,6 +339,10 @@ func _advance_clouds() -> void:
 func _advance_trails() -> void:
 	var alive: Array[Dictionary] = []
 	for trail: Dictionary in _trails:
+		if bool(trail["dead"]):
+			# `DeinitializeSprite` cleared the index on the pass before this one,
+			# so `.loop`'s `and a` skips the struct and nothing draws it again.
+			continue
 		if bool(trail["fresh"]):
 			trail["fresh"] = false
 			if _profile == RomRegistry.GOLD:
@@ -338,6 +361,13 @@ func _advance_trails() -> void:
 			)
 		var at: Vector2i = trail["at"]
 		if at.x >= TRAIL_X_END:
+			# `DoNextFrameForAllSprites` calls `UpdateAnimFrame` whatever the
+			# animation did, so `.delete`'s `DeinitializeSprite` does not take the
+			# sprite off this frame: the struct is drawn once more where it
+			# stands, and the frameset it is drawn through steps as usual.
+			trail["dead"] = true
+			_advance_trail_frameset(trail)
+			alive.append(trail)
 			continue
 		at.x += TRAIL_X_STEP
 		if _profile == RomRegistry.GOLD:
@@ -348,7 +378,13 @@ func _advance_trails() -> void:
 		_advance_trail_frameset(trail)
 		alive.append(trail)
 	_trails = alive
-	if (_timer & TRAIL_SPAWN_MASK) != 0 or _trails.size() >= MAX_TRAILS:
+	# A struct deleted on this pass has already released its slot, so it is not
+	# one of the ten `_InitSpriteAnimStruct` walks even though it is still drawn.
+	var live: int = 0
+	for trail: Dictionary in _trails:
+		if not bool(trail["dead"]):
+			live += 1
+	if (_timer & TRAIL_SPAWN_MASK) != 0 or live >= MAX_TRAILS:
 		return
 	var spawn: Vector2i = TRAIL_AT_SILVER
 	if _profile == RomRegistry.GOLD:
@@ -362,26 +398,36 @@ func _advance_trails() -> void:
 	if _anim_count == 0:
 		_anim_count = 1
 	_trails.append({
-		"at": spawn, "var1": 0, "yoffset": 0, "fresh": true, "index": _anim_count,
-		"set": 0, "frame": -1, "duration": 0,
+		"at": spawn, "var1": 0, "yoffset": 0, "fresh": true, "dead": false,
+		"index": _anim_count, "set": 0, "frame": -1, "duration": 0,
 	})
 
 
-## `GetSpriteAnimFrame` for one trail. The counter starts at -1 and the duration
-## loads on the pass that reads an entry, so `oamframe X, n` is drawn n + 1
-## times; Gold `oamrestart`s and Silver `oamend`s, repeating the last.
-func _advance_trail_frameset(trail: Dictionary) -> void:
-	var frames: Array[Vector2i] = TRAIL_FRAMESET_GOLD if _profile == RomRegistry.GOLD \
-		else TRAIL_FRAMESET_SILVER
-	if int(trail["duration"]) > 0:
-		trail["duration"] = int(trail["duration"]) - 1
+## `GetSpriteAnimFrame` for one struct, [param state] carrying its `frame`,
+## `duration` and `set`. The duration loads on the pass that reads an entry, so
+## `oamframe X, n` is drawn n + 1 times; [param restarts] is `oamrestart` and
+## the other end is `oamend`, whose `.repeat_last` holds the last entry.
+func _advance_frameset(
+	state: Dictionary, frames: Array[Vector2i], restarts: bool
+) -> void:
+	if int(state["duration"]) > 0:
+		state["duration"] = int(state["duration"]) - 1
 		return
-	var at: int = int(trail["frame"]) + 1
+	var at: int = int(state["frame"]) + 1
 	if at >= frames.size():
-		at = 0 if _profile == RomRegistry.GOLD else frames.size() - 1
-	trail["frame"] = at
-	trail["set"] = frames[at].x
-	trail["duration"] = frames[at].y
+		at = 0 if restarts else frames.size() - 1
+	state["frame"] = at
+	state["set"] = frames[at].x
+	state["duration"] = frames[at].y
+
+
+## The trails' own frameset, which Gold `oamrestart`s and Silver `oamend`s.
+func _advance_trail_frameset(trail: Dictionary) -> void:
+	_advance_frameset(
+		trail,
+		TRAIL_FRAMESET_GOLD if _profile == RomRegistry.GOLD else TRAIL_FRAMESET_SILVER,
+		_profile == RomRegistry.GOLD
+	)
 
 
 ## `AnimSeqs_Sine` over `BattleAnimSineWave`, as the byte `UpdateAnimFrame` adds
@@ -519,24 +565,13 @@ func _bird_sprites() -> Array[Dictionary]:
 func bird_frame() -> int:
 	if _profile == RomRegistry.CRYSTAL:
 		return -1
-	return int(_bird_frameset()[_bird_entry()].x)
+	return _bird_set
 
 
 ## `SPRITEANIMSTRUCT_FRAME` is the frameset entry, not the OAM set it names:
 ## Gold's list reaches set 2 twice and `.TitleTrailCoords` indexes the entry.
 func _bird_entry() -> int:
-	var frameset: Array[Vector2i] = _bird_frameset()
-	var total: int = 0
-	for entry: Vector2i in frameset:
-		total += entry.y
-	if total <= 0:
-		return 0
-	var at: int = _bird_frame % total
-	for index: int in frameset.size():
-		if at < frameset[index].y:
-			return index
-		at -= frameset[index].y
-	return 0
+	return _bird_frame
 
 
 func _bird_frameset() -> Array[Vector2i]:

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -217,14 +217,30 @@ func test_the_crystal_falls_to_its_own_stop() -> void:
 ## whose `oamrestart` takes it back to the top.
 func test_the_birds_frameset_loops() -> void:
 	var scene: Gen2TitleScene = _scene(RomRegistry.GOLD)
-	assert_eq(scene.bird_frame(), 0)
-	_spend(scene, 11)
-	assert_eq(scene.bird_frame(), 1, "the first entry lasts its own eleven frames")
+	## `_TitleScreen` copies ten bytes of a sixteen-byte struct into
+	## `wSpriteAnim10`, so the bird's `SPRITEANIMSTRUCT_FRAME` keeps the zero
+	## `ClearSpriteAnims` left rather than `_InitSpriteAnimStruct`'s -1, and
+	## `GetSpriteAnimFrame`'s `inc [hl]` skips entry 0 on the first pass alone.
+	_spend(scene, 1)
+	assert_eq(scene.bird_frame(), 1, "the screen opens on the second entry")
+	_spend(scene, 9)
+	assert_eq(scene.bird_frame(), 1, "which lasts its own duration plus one")
+	_spend(scene, 1)
+	assert_eq(scene.bird_frame(), 2)
+
+	## `oamrestart` writes -1, so every cycle after the first plays entry 0. The
+	## first cycle is the whole frameset less that entry, and the screen is
+	## eleven frames into it here.
 	var total: int = 0
 	for entry: Vector2i in Gen2TitleScene.BIRD_FRAMESET_GOLD:
-		total += entry.y
-	_spend(scene, total - 11)
+		total += entry.y + 1
+	var first_cycle: int = total - (Gen2TitleScene.BIRD_FRAMESET_GOLD[0].y + 1)
+	_spend(scene, first_cycle - 11 + 1)
 	assert_eq(scene.bird_frame(), 0, "and the sequence restarts")
+	_spend(scene, Gen2TitleScene.BIRD_FRAMESET_GOLD[0].y)
+	assert_eq(scene.bird_frame(), 0, "for the entry's own duration plus one")
+	_spend(scene, 1)
+	assert_eq(scene.bird_frame(), 1)
 
 
 ## `UpdateTitleTrailSprite` spawns on every fourth frame of the timer, and
@@ -366,6 +382,35 @@ func test_golds_trails_open_on_their_own_phase() -> void:
 		if path.size() == 11 and not shapes.has(path):
 			shapes.append(path)
 	assert_gt(shapes.size(), 1, "consecutive spawns ride the sine from different places")
+
+
+## `DoNextFrameForAllSprites` calls `UpdateAnimFrame` whatever the animation
+## did, so `AnimSeq_GSTitleTrail`'s `.delete` clears the struct's index and the
+## sprite is still written to shadow OAM on that same pass, unmoved. The pass
+## after it is the one `.loop`'s `and a` skips.
+func test_a_trail_is_drawn_once_more_on_the_frame_it_is_deleted() -> void:
+	var scene := Gen2TitleScene.create(RomRegistry.GOLD, _sine())
+	var last: Vector2i = Vector2i(-1, -1)
+	var held: int = 0
+	for _frame: int in 200:
+		scene.advance_frame()
+		for at: Vector2i in _trails(scene):
+			if at.x < Gen2TitleScene.TRAIL_X_END - Gen2TitleScene.TRAIL_X_STEP:
+				continue
+			if at == last:
+				held += 1
+			last = at
+	assert_gt(held, 0, "the struct is drawn a second time where it stands")
+
+	## And it is gone the pass after, rather than riding on past $a4.
+	var beyond: Array[Vector2i] = []
+	var walk := Gen2TitleScene.create(RomRegistry.GOLD, _sine())
+	for _frame: int in 200:
+		walk.advance_frame()
+		for at: Vector2i in _trails(walk):
+			if at.x > Gen2TitleScene.TRAIL_X_END:
+				beyond.append(at)
+	assert_eq(beyond, [] as Array[Vector2i], "and never past the edge")
 
 
 func _distinct(values: Array[int]) -> int:


### PR DESCRIPTION
Gold and Silver's title screen now puts the same sprites in the same places as a real cartridge, frame for frame.

## The bird

`TitleScreen` spawns the bird, then copies its struct into `wSpriteAnim10` with `ld bc, NUM_SPRITE_ANIM_STRUCTS`. That is ten bytes. The struct is sixteen. The six fields from `SPRITEANIMSTRUCT_FRAME` up are never copied.

They are not leftovers from an earlier screen. `_TitleScreen` runs `ClearSpriteAnims` over the whole of `wSpriteAnimData` before the spawn, so all ten structs are zero and the six uncopied fields are zero on every entry to the title screen.

Zero is the initialised value of five of them. It is not `FRAME`'s. `_InitSpriteAnimStruct` writes `FRAME` as -1, and `GetSpriteAnimFrame` increments it before it reads it. So the bird's first pass plays frameset entry 1, not entry 0, and `oamrestart` writes -1 again, so every cycle after the first plays entry 0 as normal.

The frameset is now walked with the struct's own `FRAME` and `DURATION`, the way the trails already were, instead of a running frame count. Both tables hold the source's own durations, and a frame lasts its duration plus one in one place rather than two.

## Two more, found in the same diff

`.OAMData_GSTitleTrail` is a different picture on each cartridge. Gold's is one object at `dbsprite -1, -1, 4, 4`, which is half a tile up and left of the struct rather than a whole one. Silver's is two objects at `-1, -1` and `0, -1`, carrying their own tile numbers instead of a vtile base.

A struct whose sequence deletes itself is drawn one last time where it stands. `DoNextFrameForAllSprites` calls `UpdateAnimFrame` whether or not `DoSpriteAnimFrame` called `DeinitializeSprite`. The splash and the Gold/Silver intro already did this. The title screen dropped its trail a frame early. The slot the delete frees is available to the same pass's spawn.

## Measurements

Against a real dump, 900 frames of the title screen, distinct states in order:

| | Bird | Trail |
|---|---|---|
| Gold | 197/197 | 897/897 |
| Silver | 416/416 | 762/762 |

Per frame the Gold run is exact for 672 frames, which is where the cartridge first repeats a buffer after a loop that overran VBlank.

Full test tier green: 3,348 tests over 152 scripts. `validate.gd -- all` exits 0. `replay_world.gd` and the three-profile story walk are clean on all three cartridges.