### PR TITLE
Hatch the egg the story hands out

### DIFF
--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -31,8 +31,11 @@ Save format version 6 stores:
   cartridge's own bugs are reproduced, and the trainer-AI difficulty);
 - `is_egg` for received eggs. An egg keeps its party slot and is skipped when
   the battle party is built, matching the cartridge refusing it as a combatant
-  rather than removing it; the writeback puts it back in the same slot. Hatch
-  behavior does not exist yet.
+  rather than removing it; the writeback puts it back in the same slot. Its
+  `happiness` byte is its hatch counter, which is what `GiveEgg` writes and what
+  `DoEggStep` drains: the walk takes one cycle off every egg in the party every
+  256 steps, and the first to reach zero hatches where it stands. Breeding and
+  the Day-Care do not exist, so the only egg the game hands out is a script's.
 
 Derived battle stats are recalculated on load. Volatile state, including stages,
 confusion, recharge, Disable, Encore, trapping, Fly, Dig, Rollout and rampage,

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -2498,8 +2498,19 @@ func _overlaid(kind: StringName, number: int, base: Dictionary) -> Dictionary:
 ## walk is the whole script corpus and nothing about it changes while a cache is
 ## open. See [Gen2WorldCatalog].
 func catalog() -> Gen2WorldCatalog:
-	if _catalog == null:
-		_catalog = Gen2WorldCatalog.build(self)
+	if _catalog != null:
+		return _catalog
+	## The scan costs about thirteen seconds and its answer is a function of the
+	## cache alone, so it is read from the sidecar the import wrote. A cache from
+	## a build before the sidecar existed, or one whose sidecar is stale, pays
+	## the scan once and then has one.
+	_catalog = Gen2WorldCatalog.from_dict(
+		self, RomCache.read_json(RomCache.world_catalog_path(directory))
+	)
+	if _catalog != null:
+		return _catalog
+	_catalog = Gen2WorldCatalog.build(self)
+	RomCache.write_json(RomCache.world_catalog_path(directory), _catalog.to_dict())
 	return _catalog
 
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -48,6 +48,8 @@ var _trainers: Array = []
 var _matchups: Dictionary = {}
 var _foresight_matchups: Dictionary = {}
 var _atlases: Dictionary = {}
+## `EggPic` and `PokemonPalettes` entry EGG, which no species record owns.
+var _egg_pic: Dictionary = {}
 var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
 var _battle_grayscale_palette: Array = []
@@ -133,6 +135,7 @@ static func open_directory(path: String) -> GameData:
 	data.id = StringName(manifest.get("game_id", ""))
 	data.sha1 = String(manifest.get("sha1", ""))
 	data._atlases = manifest.get("atlases", {})
+	data._egg_pic = manifest.get("egg_pic", {})
 	data._tiles = manifest.get("tiles", {})
 	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._battle_grayscale_palette = manifest.get("battle_grayscale_palette", [])
@@ -2126,6 +2129,29 @@ func species_pic(number: int, back: bool = false) -> Dictionary:
 		"width": int(tiles[0]) * Gen2Tiles.TILE_WIDTH,
 		"height": int(tiles[1]) * Gen2Tiles.TILE_HEIGHT,
 	}
+
+
+## `GetEggFrontpic`'s picture, in [method species_pic]'s shape. Empty on a cache
+## written before eggs had one.
+func egg_pic() -> Dictionary:
+	if _egg_pic.is_empty() or atlas("egg_front").is_empty():
+		return {}
+	var name: String = "egg_front"
+	var side: int = int(_egg_pic.get("tiles", 0)) * Gen2Tiles.TILE_WIDTH
+	return {"atlas": name, "slot": 0, "width": side, "height": side}
+
+
+## `Hatch_LoadFrontpicPal`'s palette for the egg itself.
+func egg_palette(shiny: bool = false) -> PackedColorArray:
+	var stored: Variant = (_egg_pic.get("palette", {}) as Dictionary).get(
+		"shiny" if shiny else "normal", null
+	)
+	if not stored is Array or (stored as Array).size() < 2:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return Gen2Palette.pic_palette(PackedColorArray([
+		Gen2Palette.from_packed(int((stored as Array)[0])),
+		Gen2Palette.from_packed(int((stored as Array)[1])),
+	]))
 
 
 ## A mod's own picture for a numbered row, in [method species_pic]'s shape but

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -16,6 +16,13 @@ extends RefCounted
 ## records. That is why there is no cache-format bump behind it and why a fresh
 ## cartridge needs no re-import.
 ##
+## The scan is not cheap: it decodes every command of every imported script,
+## about thirteen seconds for Crystal, and it answered 547 rows for that. So it
+## is written beside the cache as a sidecar and read back ([method to_dict]).
+## The sidecar is derived, not imported: an absent, stale or unreadable one is
+## rebuilt and written, so no cache format covers it and a cache from an older
+## build needs no re-import.
+##
 ## A patch changes a FIELD of a row. It never replaces a script, a completion
 ## flag, a dialogue, an inventory transaction or a battle flow: the site still
 ## runs the cartridge's own code, and only the number it hands over is the mod's.
@@ -68,6 +75,17 @@ const MAX_SCRIPT_COMMANDS: int = 4096
 ## past anything real and is what keeps this a second rather than eight.
 const MAX_ROUTINES: int = 16
 
+## The sidecar's own shape. Bumped when a row, a link or a kind changes meaning,
+## which rebuilds every cache's sidecar without touching the cache format.
+const FORMAT_VERSION: int = 1
+
+## The row and link fields whose value is a StringName rather than a String:
+## `kind` on every row, and `role` on a link. See [method _restore_value].
+const STRING_NAME_FIELDS: Array[String] = ["kind", "role"]
+## The one field whose value is a Vector2i, the map a site stands on. JSON has
+## no vector, so it goes out as a two-element array.
+const VECTOR_FIELDS: Array[String] = ["map"]
+
 var _data: GameData = null
 ## id to row.
 var _rows: Dictionary = {}
@@ -96,6 +114,110 @@ static func build(data: GameData) -> Gen2WorldCatalog:
 	out._scan_scripts()
 	out._scan_map_events()
 	out._attribute_maps()
+	return out
+
+
+## The scan's result, for the sidecar. Ids are dictionary keys, so they go out
+## as decimal strings and come back as ints; every one is well under the 2^53
+## a JSON number carries exactly.
+##
+## The lazy answers ([member _item_sources], [member _field_hms]) are not here:
+## both are derived from these rows in a millisecond and would only be a second
+## copy to keep in step.
+func to_dict() -> Dictionary:
+	var rows: Dictionary = {}
+	for id: int in _rows:
+		rows[str(id)] = _stored_value(_rows[id])
+	var links: Dictionary = {}
+	for at: int in _links:
+		links[str(at)] = _stored_value(_links[at])
+	var kinds: Dictionary = {}
+	for kind: StringName in _by_kind:
+		kinds[String(kind)] = (_by_kind[kind] as Array).duplicate()
+	return {"version": FORMAT_VERSION, "rows": rows, "links": links, "kinds": kinds}
+
+
+## The counterpart, bound to [param data] so [method check] can still fold a mod
+## patch in. Answers null for anything that is not this version's own shape, so
+## a stale or truncated sidecar is rebuilt rather than half read.
+static func from_dict(data: GameData, source: Variant) -> Gen2WorldCatalog:
+	if not source is Dictionary:
+		return null
+	var raw: Dictionary = source as Dictionary
+	if int(raw.get("version", -1)) != FORMAT_VERSION:
+		return null
+	for key: String in ["rows", "links", "kinds"]:
+		if not raw.get(key, null) is Dictionary:
+			return null
+	var out := Gen2WorldCatalog.new()
+	out._data = data
+	for id: String in raw["rows"] as Dictionary:
+		var row: Variant = (raw["rows"] as Dictionary)[id]
+		if not row is Dictionary:
+			return null
+		out._rows[id.to_int()] = _restore_value(row)
+	for at: String in raw["links"] as Dictionary:
+		var link: Variant = (raw["links"] as Dictionary)[at]
+		if not link is Dictionary:
+			return null
+		out._links[at.to_int()] = _restore_value(link)
+	for kind: String in raw["kinds"] as Dictionary:
+		var ids: Variant = (raw["kinds"] as Dictionary)[kind]
+		if not ids is Array:
+			return null
+		var packed: Array = []
+		for id: Variant in ids as Array:
+			packed.append(int(id))
+		out._by_kind[StringName(kind)] = packed
+	return out
+
+
+## JSON has one number type and no StringName, so a row that went out as ints
+## and a `kind` comes back as floats and a String. A reader compares these with
+## `==` against typed literals, so the shapes have to be restored rather than
+## coerced at every site.
+##
+## Whole floats become ints: every number a row carries is an id, a bank, an
+## address, an item, a quantity or a price, and none of them is fractional. The
+## two String fields that are StringNames name themselves.
+static func _stored_value(value: Variant) -> Variant:
+	if value is Array:
+		var list: Array = []
+		for entry: Variant in value as Array:
+			list.append(_stored_value(entry))
+		return list
+	if not value is Dictionary:
+		return value
+	var out: Dictionary = {}
+	for key: Variant in value as Dictionary:
+		var stored: Variant = (value as Dictionary)[key]
+		if String(key) in VECTOR_FIELDS and stored is Vector2i:
+			out[key] = [(stored as Vector2i).x, (stored as Vector2i).y]
+			continue
+		out[key] = _stored_value(stored)
+	return out
+
+
+static func _restore_value(value: Variant) -> Variant:
+	if value is float:
+		var number: float = value as float
+		return int(number) if is_equal_approx(number, floor(number)) else number
+	if value is Array:
+		var list: Array = []
+		for entry: Variant in value as Array:
+			list.append(_restore_value(entry))
+		return list
+	if not value is Dictionary:
+		return value
+	var out: Dictionary = {}
+	for key: Variant in value as Dictionary:
+		var restored: Variant = _restore_value((value as Dictionary)[key])
+		if String(key) in STRING_NAME_FIELDS and restored is String:
+			restored = StringName(restored as String)
+		elif String(key) in VECTOR_FIELDS and restored is Array \
+			and (restored as Array).size() == 2:
+			restored = Vector2i(int((restored as Array)[0]), int((restored as Array)[1]))
+		out[key] = restored
 	return out
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -33,6 +33,10 @@ const PICS_DIR: String = "pics"
 const TILES_DIR: String = "tiles"
 const WORLD_MAPS: String = "world_maps.json"
 const WORLD_SCRIPTS: String = "world_scripts.json"
+## [Gen2WorldCatalog]'s scan of those scripts. Derived rather than imported, so
+## it is a sidecar the cache heals rather than a section the format version
+## covers: an absent or unreadable one is rebuilt and written back.
+const WORLD_CATALOG: String = "world_catalog.json"
 const WORLD_STANDARD_SCRIPTS: String = "world_standard_scripts.json"
 const WORLD_TEXT: String = "world_text.json"
 const WORLD_MOVEMENTS: String = "world_movements.json"
@@ -169,6 +173,10 @@ static func blob_path(json_path: String) -> String:
 
 static func world_scripts_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_SCRIPTS]
+
+
+static func world_catalog_path(directory: String) -> String:
+	return "%s/%s" % [directory, WORLD_CATALOG]
 
 
 static func world_standard_scripts_path(directory: String) -> String:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -76,7 +76,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 73
+const FORMAT_VERSION: int = 74
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3964,6 +3964,17 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		result["message"] = "Could not write manifest."
 		return result
 
+	## [Gen2WorldCatalog]'s sidecar, written here so a player never pays its
+	## scan: it decodes every command of every script this import just wrote,
+	## and the first mod-enabled map entry is where it would otherwise land.
+	## After the manifest, because the scan opens the cache it describes.
+	var catalogued: GameData = GameData.open_directory(directory)
+	if catalogued != null:
+		RomCache.write_json(
+			RomCache.world_catalog_path(directory),
+			Gen2WorldCatalog.build(catalogued).to_dict()
+		)
+
 	result["ok"] = true
 	result["species"] = species.size()
 	result["moves"] = moves.size()

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3949,6 +3949,14 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
 		"battle_object_palettes": _import_battle_object_palettes(rom, layout),
 		"atlases": pics,
+		## `PokemonPalettes` entry EGG, which `Hatch_LoadFrontpicPal` reaches
+		## through `GetBaseData`. It is a species-shaped record with no species
+		## behind it, so it is stored beside the atlases rather than in the
+		## species table every other palette lives in.
+		"egg_pic": {
+			"tiles": RomLayout.EGG_PIC_TILES,
+			"palette": _read_egg_palette(rom, layout),
+		},
 		"tiles": tiles,
 		"complete": true,
 	}
@@ -5644,6 +5652,15 @@ static func _rows_from_columns(
 	return out
 
 
+## `PokemonPalettes` entry EGG, in the same two-pair shape a species carries.
+func _read_egg_palette(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = RomLayout.palette_offset(layout, RomLayout.EGG_SPECIES)
+	return {
+		"normal": [rom.u16le(at), rom.u16le(at + 2)],
+		"shiny": [rom.u16le(at + 4), rom.u16le(at + 6)],
+	}
+
+
 func _import_pics(
 	rom: RomFile, layout: Dictionary, species: Array, on_progress: Callable
 ) -> Dictionary:
@@ -5660,6 +5677,27 @@ func _import_pics(
 		RomLayout.FRONTPIC_MAX_TILES, RomLayout.UNOWN_FORMS
 	)
 	var unown_back: Dictionary = _new_atlas(RomLayout.BACKPIC_TILES, RomLayout.UNOWN_FORMS)
+	# `EggPic` is entry EGG of `PokemonPicPointers`, past the 251 species and the
+	# unused slot between them, and `GetEggFrontpic` loads it the way any other
+	# front pic is loaded. It gets an atlas of its own because there is no
+	# species record to hang it on: EGG is a party species, not a Pokemon.
+	var egg_front: Dictionary = _new_atlas(RomLayout.FRONTPIC_MAX_TILES, 1)
+	var egg_side: int = RomLayout.EGG_PIC_TILES
+	## Gold and Silver's table stops at NUM_POKEMON, so `_GetFrontpic` answers
+	## EGG with `ld hl, EggPic` and the pic is at an address like a back pic.
+	## Their picture is a different one.
+	##
+	## Crystal's run carries two animation frames that nothing reads:
+	## `GetEggFrontpic` is `GetMonFrontpic`, not `GetAnimatedFrontpic`, and
+	## `AnimateMon_CheckIfPokemon` refuses EGG before any script is read.
+	var egg_at: int = int(layout.get("egg_pic", -1))
+	if egg_at >= 0:
+		_decode_lz_into(rom, egg_at, egg_side, egg_side, egg_front, 0)
+	else:
+		_decode_into(
+			rom, layout, RomLayout.pic_pointer_offset(layout, RomLayout.EGG_SPECIES, false),
+			egg_side, egg_side, egg_front, 0
+		)
 	var trainer_classes: int = RomLayout.trainer_class_count(layout)
 	var trainers: Dictionary = _new_atlas(RomLayout.TRAINER_PIC_TILES, trainer_classes)
 	# `GetTrainerBackpic`'s three, which are the player standing on the field
@@ -5749,7 +5787,7 @@ func _import_pics(
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var atlases: Dictionary = {
 		"front": front, "back": back, "unown_front": unown_front, "unown_back": unown_back,
-		"trainers": trainers, "player_back": player_back,
+		"trainers": trainers, "player_back": player_back, "egg_front": egg_front,
 	}
 	# `AnimateFrontpic` is Crystal's alone, so the two atlases behind the front
 	# pics are written only where something reads them.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1501,6 +1501,14 @@ const BACKPIC_TILES: int = 6
 ## The battle screen's frontpic window, and so the atlas cell size.
 const FRONTPIC_MAX_TILES: int = 7
 
+## `EGG` is a party species rather than a Pokemon: `PokemonPicPointers` and
+## `PokemonPalettes` both carry an entry for it past the 251, and nothing else
+## in either table does.
+const EGG_SPECIES: int = 0xFD
+## `gfx/pokemon/egg/front.animated.2bpp`, five tiles square like the smallest
+## front pics.
+const EGG_PIC_TILES: int = 5
+
 ## Byte positions within a 32-byte base stats entry.
 const STAT_HP: int = 1
 const STAT_ATTACK: int = 2
@@ -1731,6 +1739,13 @@ const GOLD_SILVER: Dictionary = {
 	# `GetTrainerBackpic`'s pics, LZ at the address rather than behind a
 	# pointer. Gold and Silver have one player character, so there is no Kris.
 	"player_backpic": {"chris": 0x3F9CB, "kris": -1, "dude": 0x3FB5B},
+	# `EggPic`, LZ at the address the way the back pics are: Gold and Silver's
+	# `PokemonPicPointers` stops at NUM_POKEMON and `_GetFrontpic` reaches the
+	# egg through its own `cp EGG / ld hl, EggPic` instead. The picture is not
+	# Crystal's and carries no animation frames. Located by decompressing at
+	# every offset and keeping the run that reproduces pokegold's own
+	# `gfx/pokemon/egg/egg.png`; the hit is unique and the same in both dumps.
+	"egg_pic": 0x53A83,
 	# Trainer card. Located by converting the pinned gfx/trainer_card PNGs and
 	# matching the bytes in the cartridge; the run is contiguous and
 	# self-consistent, status running straight into the two leader copies and
@@ -2202,6 +2217,9 @@ const CRYSTAL: Dictionary = {
 		"tiles": 0x8C2F4, "palette": 0x8C6A1, "dark_palette": 0x8C6A9,
 	},
 	"player_backpic": {"chris": 0x2BA1A, "kris": 0x88ED6, "dude": 0x2BBAA},
+	# Crystal's `PokemonPicPointers` carries an EGG entry and `_GetFrontpic`
+	# reads the egg through it like any other pic, so there is no address to pin.
+	"egg_pic": -1,
 	# Trainer card; see the Gold and Silver block above for how these were
 	# located. Crystal splits the card pic in two by gender and stores both
 	# column-major, and adds the one-tile right corner Gold and Silver lack.

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -600,8 +600,18 @@ func _icon_square(row: Dictionary) -> Control:
 	return square
 
 
+## `HTTPRequest.request` refuses, loudly, from a node that is not in the tree,
+## and [method create] builds the whole page before the launcher adds it: the
+## queue is left standing until the page is on screen, and every icon it holds
+## is asked for then. Nothing else here starts a request on its own.
+func _ready() -> void:
+	_fetch_next_icon()
+
+
 func _fetch_next_icon() -> void:
 	if _icon_busy or _icon_queue.is_empty() or _icons == null:
+		return
+	if not is_inside_tree():
 		return
 	var url: String = _icon_queue.pop_front()
 	_icon_busy = true

--- a/game/render/naming_screen_page.gd
+++ b/game/render/naming_screen_page.gd
@@ -186,10 +186,14 @@ func _clear(map: PackedInt32Array, x: int, y: int, rows: int, columns: int) -> v
 			_put(map, Vector2i(x + column, y + row), BLANK_TILE)
 
 
+## A prompt is one `PlaceString` per row, and `.Pokemon`'s two are `hlcoord 5, 2`
+## and `hlcoord 5, 4`: the rows the screen prints on are two apart.
 func _string(map: PackedInt32Array, text: String, at: Vector2i) -> void:
-	var codes: PackedByteArray = Gen2Text.encode(text)
-	for index: int in codes.size():
-		_put(map, at + Vector2i(index, 0), codes[index])
+	var lines: PackedStringArray = text.split("\n")
+	for line: int in lines.size():
+		var codes: PackedByteArray = Gen2Text.encode(lines[line])
+		for index: int in codes.size():
+			_put(map, at + Vector2i(index, line * 2), codes[index])
 
 
 func _put(map: PackedInt32Array, at: Vector2i, tile: int) -> void:

--- a/game/save/move_screen.gd
+++ b/game/save/move_screen.gd
@@ -17,7 +17,7 @@ signal closed
 signal sfx_requested(index: int, waited: bool)
 
 ## `constants/sfx_constants.asm`.
-const SFX_READ_TEXT_2: int = 0x02
+const SFX_READ_TEXT_2: int = 0x08
 const SFX_SWITCH_POKEMON: int = Gen2PartyScreen.SFX_SWITCH_POKEMON
 
 var _data: GameData = null

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -772,12 +772,16 @@ func _blend_stats_pic(image: Image, snapshot: Dictionary) -> void:
 	var species: int = int(snapshot.get("species", 0))
 	if species <= 0:
 		return
-	var pic: Dictionary = _data.species_pic(species)
+	## `EggStatsScreen` draws the egg rather than what is inside it, which is
+	## `GetEggFrontpic`'s own picture and its own palette entry.
+	var egg: bool = bool(snapshot.get("egg", false))
+	var pic: Dictionary = _data.egg_pic() if egg else _data.species_pic(species)
 	if pic.is_empty():
 		return
 	var art: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(species, bool(snapshot.get("shiny", false)))
+		_data.egg_palette() if egg \
+			else _data.palette(species, bool(snapshot.get("shiny", false)))
 	)
 	if art == null:
 		return

--- a/game/world/egg_hatch_screen.gd
+++ b/game/world/egg_hatch_screen.gd
@@ -1,0 +1,514 @@
+class_name Gen2EggHatchScreen
+extends Control
+
+## `HatchEggs` and the `EggHatch_AnimationSequence` its `.Text_HatchEgg` runs,
+## for one party egg at a time.
+##
+## Presentation only: [method Gen2WorldPartyHost.hatch_egg] has already written
+## the party row, which is the source's own order, so the picture the sequence
+## ends on is the Pokemon the row now holds. What this screen owns after that is
+## the nickname: [signal named] carries the answer and the caller writes it.
+##
+## `Hatch_InitShellFragments`' ten shell pieces are sprite-anim objects and this
+## project has no sprite-anim layer outside the intro, the same reason
+## `.PlayEvolvedSFX`'s balls of light are absent from [Gen2EvolutionScreen].
+## Their 130 frames are spent with the hatchling standing.
+
+## The nickname the player settled on for the hatched party slot.
+signal named(party_index: int, nickname: String)
+signal closed()
+signal cry_requested(species: int)
+signal sfx_requested(index: int)
+signal music_requested(index: int)
+
+## constants/music_constants.asm.
+const MUSIC_NONE: int = 0
+const MUSIC_EVOLUTION: int = 0x22
+## constants/sfx_constants.asm.
+const SFX_CAUGHT_MON: int = 0x02
+const SFX_EGG_CRACK: int = 0x9E
+const SFX_EGG_HATCH: int = 0xA6
+
+const TILE: int = Gen2Font.TILE
+const BOX: int = Gen2PicImage.FRONTPIC_TILES
+## `hlcoord 7, 4` for the egg and `hlcoord 6, 3` for the hatchling. The egg is
+## five tiles square and sits in the middle of the block the hatchling fills.
+const EGG_AT: Vector2i = Vector2i(7, 4)
+const HATCHLING_AT: Vector2i = Vector2i(6, 3)
+
+## `ld c, 80` between `MUSIC_EVOLUTION` and the wobble.
+const OPENING_FRAMES: int = 80
+## `.outerloop` runs while the counter before the `inc` is under 8, so its
+## passes are e = 1 to 8.
+const WOBBLE_PASSES: int = 8
+## Each half of a wobble is `EggHatch_DoAnimFrame`'s own `DelayFrame` plus
+## `ld c, 2`, and a wobble is both halves.
+const WOBBLE_HALF_FRAMES: int = 3
+## `ld c, 16` at the end of every pass.
+const PASS_TAIL_FRAMES: int = 16
+## `hSCX` is written 2 and then -2, which scrolls the background the other way.
+const WOBBLE_SHIFT: int = 2
+## `Hatch_InitShellFragments`' own closing `EggHatch_DoAnimFrame` and
+## `Hatch_ShellFragmentLoop`'s `ld c, 129`.
+const FRAGMENT_FRAMES: int = 1 + 129
+
+enum Phase {
+	HUH,
+	OPENING,
+	WOBBLE,
+	FRAGMENTS,
+	ANIMATE,
+	HATCHED,
+	ASK_NICKNAME,
+	NAMING,
+	DONE,
+}
+
+var _data: GameData = null
+## [method Gen2WorldPartyHost.hatch_egg]'s summaries, in party order.
+var _hatches: Array = []
+var _index: int = 0
+var _phase: int = Phase.DONE
+var _frames: int = 0
+## `wFrameCounter`, and where the current pass stands inside its own wobble.
+var _counter: int = 0
+var _halves_left: int = 0
+var _half_frames: int = 0
+var _shift: int = 0
+## Which block the picture is standing in, so the wobble can move it without
+## knowing whether it is drawing the egg or the hatchling.
+var _pic_origin: Vector2i = EGG_AT
+var _nickname_yes: bool = true
+var _animation: Gen2PicAnimation = null
+var _animation_pixels: PackedByteArray = PackedByteArray()
+
+var _backdrop: ColorRect = null
+var _pic: TextureRect = null
+var _text_box: Gen2TextBox = null
+var _menu_page: Gen2MenuPage = null
+var _menu: TextureRect = null
+var _naming: Gen2NamingScreenScreen = null
+
+
+## [param hatches] is one [method Gen2WorldPartyHost.hatch_egg] summary per egg,
+## in the order `HatchEggs` walks the party. An empty list closes at once.
+func set_context(data: GameData, hatches: Array) -> void:
+	_data = data
+	_hatches = hatches.duplicate(true)
+	_index = 0
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _hatches.is_empty():
+		closed.emit()
+		return
+	_build()
+	_begin_hatch()
+
+
+func remaining() -> int:
+	return maxi(_hatches.size() - _index, 0)
+
+
+func current_hatch() -> Dictionary:
+	if _index < 0 or _index >= _hatches.size():
+		return {}
+	return _hatches[_index]
+
+
+func phase() -> int:
+	return _phase
+
+
+## Whether the sequence is standing on a press rather than on a count:
+## `Text_BreedHuh`'s `para`, `_BreedEggHatchText`'s `text_promptbutton` and the
+## `YesNoBox` after it.
+func awaiting_press() -> bool:
+	if _phase in [Phase.ASK_NICKNAME, Phase.NAMING]:
+		return true
+	if _text_box == null or not _text_box.visible:
+		return false
+	return _text_box.has_pages_left() or _phase == Phase.HATCHED
+
+
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+## The YES/NO cursor, so a driver can read it without a redraw. -1 when the box
+## is not up.
+func nickname_cursor() -> int:
+	return (0 if _nickname_yes else 1) if _phase == Phase.ASK_NICKNAME else -1
+
+
+func naming_screen() -> Gen2NamingScreenScreen:
+	return _naming
+
+
+func handle_button(button: int) -> bool:
+	if _phase == Phase.NAMING and _naming != null:
+		return _naming.handle_button(button)
+	if _phase == Phase.ASK_NICKNAME:
+		match button:
+			Gen2Button.UP, Gen2Button.DOWN:
+				_nickname_yes = not _nickname_yes
+				_draw_yes_no()
+				return true
+			Gen2Button.A:
+				_answer_nickname(_nickname_yes)
+				return true
+			Gen2Button.B:
+				## `YesNoBox` answers B as NO, which is `.nonickname`.
+				_answer_nickname(false)
+				return true
+		return false
+	if button == Gen2Button.A and _text_box != null and _text_box.visible \
+		and (_text_box.is_revealing() or _text_box.has_pages_left()):
+		_text_box.advance()
+		return true
+	if button == Gen2Button.A and _phase == Phase.HATCHED:
+		_open_nickname_question()
+		return true
+	return false
+
+
+func _build() -> void:
+	_backdrop = ColorRect.new()
+	_backdrop.color = Color.WHITE
+	_backdrop.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_backdrop.visible = false
+	add_child(_backdrop)
+
+	_pic = TextureRect.new()
+	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_pic.visible = false
+	add_child(_pic)
+
+	_menu = TextureRect.new()
+	_menu.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_menu.visible = false
+	add_child(_menu)
+
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+## `Text_BreedHuh`, printed over the map before anything is cleared.
+func _begin_hatch() -> void:
+	if current_hatch().is_empty():
+		_phase = Phase.DONE
+		closed.emit()
+		return
+	_backdrop.visible = false
+	_pic.visible = false
+	_menu.visible = false
+	_phase = Phase.HUH
+	_show_text(Gen2WorldPartyHost.HUH_TEXT)
+
+
+func _show_text(text: String, prompt: bool = false) -> void:
+	if _text_box == null:
+		return
+	_text_box.visible = true
+	_text_box.show_text(text, prompt)
+
+
+func advance_frame() -> void:
+	if _phase == Phase.DONE or _data == null:
+		return
+	if _phase == Phase.NAMING:
+		return
+	if _text_box != null and _text_box.visible:
+		_text_box.advance_frame()
+		if _text_box.is_revealing() or _text_box.has_pages_left():
+			return
+	match _phase:
+		Phase.HUH:
+			## Reached on the frame the empty `para` page has been pressed past,
+			## since a page with another behind it is what `awaiting_press`
+			## answers and the funnel presses it.
+			_open_sequence()
+		Phase.OPENING:
+			if _spend():
+				_begin_wobble()
+		Phase.WOBBLE:
+			_advance_wobble()
+		Phase.FRAGMENTS:
+			if _spend():
+				_open_frontpic_animation()
+		Phase.ANIMATE:
+			_advance_frontpic_animation()
+
+
+func _spend() -> bool:
+	_frames -= 1
+	return _frames <= 0
+
+
+## `EggHatch_AnimationSequence` up to its `ld c, 80`: the music stops, the
+## screen is blanked and the egg is placed, and the evolution track starts
+## before the wait rather than after it.
+func _open_sequence() -> void:
+	_text_box.visible = false
+	_backdrop.visible = true
+	_pic.visible = true
+	_shift = 0
+	music_requested.emit(MUSIC_NONE)
+	_draw_egg()
+	music_requested.emit(MUSIC_EVOLUTION)
+	_phase = Phase.OPENING
+	_frames = OPENING_FRAMES
+
+
+func _begin_wobble() -> void:
+	_counter = 0
+	_phase = Phase.WOBBLE
+	_start_pass()
+
+
+## `.outerloop`: the counter is read, incremented and compared against 8, and
+## the pass wobbles as many times as the incremented value.
+func _start_pass() -> void:
+	if _counter >= WOBBLE_PASSES:
+		_finish_wobble()
+		return
+	_counter += 1
+	_halves_left = _counter * 2
+	_half_frames = WOBBLE_HALF_FRAMES
+	_shift = -WOBBLE_SHIFT
+	_place_pic()
+
+
+func _advance_wobble() -> void:
+	if _halves_left > 0:
+		_half_frames -= 1
+		if _half_frames > 0:
+			return
+		_halves_left -= 1
+		_half_frames = WOBBLE_HALF_FRAMES
+		_shift = -_shift
+		_place_pic()
+		if _halves_left > 0:
+			return
+		## `ld c, 16` closes the pass with the scroll still where the last half
+		## left it; `.done` is what puts it back.
+		_frames = PASS_TAIL_FRAMES
+		return
+	if _spend():
+		_crack_shell()
+		_start_pass()
+
+
+## `EggHatch_CrackShell`: the counter's own `dec a / and $7`, which returns
+## without a sound on the eighth pass and on every even step of the other
+## seven, so three of the eight passes crack.
+func _crack_shell() -> void:
+	var step: int = (_counter - 1) & 0x7
+	if step == 0x7 or (step & 1) == 0:
+		return
+	sfx_requested.emit(SFX_EGG_CRACK)
+
+
+## `.done`: the scroll is put back, the shell fragments are thrown and the
+## hatchling takes the block the egg was standing in.
+func _finish_wobble() -> void:
+	_shift = 0
+	sfx_requested.emit(SFX_EGG_HATCH)
+	_draw_species(int(current_hatch().get("species", 0)))
+	_phase = Phase.FRAGMENTS
+	_frames = FRAGMENT_FRAMES
+
+
+## `AnimateFrontpic ANIM_MON_HATCH`, which is Crystal's alone: Gold and Silver
+## have no pic animation and the sequence ends on the standing picture.
+func _open_frontpic_animation() -> void:
+	var species: int = int(current_hatch().get("species", 0))
+	var record: Dictionary = _data.pic_animation(species)
+	if record.is_empty():
+		_open_hatched_text()
+		return
+	_animation = Gen2PicAnimation.new(record, Gen2PicAnimation.ANIM_MON_HATCH)
+	_animation_pixels = Gen2BattleRenderer.padded_pic(
+		_data, _data.species_pic(species), BOX, true,
+		_data.species_pic_animation(species)
+	)
+	_phase = Phase.ANIMATE
+	_advance_frontpic_animation()
+
+
+func _advance_frontpic_animation() -> void:
+	if _animation == null:
+		_open_hatched_text()
+		return
+	var cry: StringName = _animation.advance()
+	if cry != &"":
+		cry_requested.emit(int(current_hatch().get("species", 0)))
+	_draw_animation_box()
+	if _animation.finished():
+		_animation = null
+		_animation_pixels = PackedByteArray()
+		_open_hatched_text()
+
+
+## `.BreedClearboxText` and then `_BreedEggHatchText`, which carries
+## `sound_caught_mon` and ends in `text_promptbutton`.
+func _open_hatched_text() -> void:
+	_draw_species(int(current_hatch().get("species", 0)))
+	_phase = Phase.HATCHED
+	_show_text(
+		Gen2WorldPartyHost.hatch_text(String(current_hatch().get("nickname", ""))), true
+	)
+	sfx_requested.emit(SFX_CAUGHT_MON)
+
+
+func _open_nickname_question() -> void:
+	_phase = Phase.ASK_NICKNAME
+	_nickname_yes = true
+	_show_text(
+		Gen2WorldPartyHost.nickname_question(String(current_hatch().get("nickname", "")))
+	)
+	_draw_yes_no()
+
+
+## `.nonickname` keeps `wStringBuffer1`, which is the species name the row was
+## already given; YES opens `NamingScreen` under NAME_MON.
+func _answer_nickname(yes: bool) -> void:
+	_menu.visible = false
+	if not yes:
+		_finish_hatch(String(current_hatch().get("nickname", "")))
+		return
+	_naming = Gen2NamingScreenScreen.new()
+	if not _naming.open(
+		_data, Gen2WorldPartyHost.nickname_prompt(
+			String(current_hatch().get("nickname", ""))
+		),
+		Gen2NamingScreenScreen.KIND_MON
+	):
+		_naming = null
+		_finish_hatch(String(current_hatch().get("nickname", "")))
+		return
+	_text_box.visible = false
+	_backdrop.visible = false
+	_pic.visible = false
+	_naming.closed.connect(_on_named)
+	add_child(_naming)
+	_phase = Phase.NAMING
+
+
+## `InitName`, which keeps the species name when the entry came back empty.
+func _on_named(entered: String) -> void:
+	var chosen: String = entered.strip_edges()
+	Gen2Screen.drop(_naming)
+	_naming = null
+	_finish_hatch(
+		chosen if not chosen.is_empty()
+		else String(current_hatch().get("nickname", ""))
+	)
+
+
+func _finish_hatch(nickname: String) -> void:
+	var hatch: Dictionary = current_hatch()
+	if not hatch.is_empty():
+		named.emit(int(hatch.get("party_index", -1)), nickname)
+	_index += 1
+	if _text_box != null:
+		_text_box.visible = false
+	if _index >= _hatches.size():
+		_phase = Phase.DONE
+		closed.emit()
+		return
+	_begin_hatch()
+
+
+func _draw_yes_no() -> void:
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
+	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _nickname_yes else 1)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true
+
+
+## `GetEggFrontpic`, which is the egg's own picture and its own palette entry
+## rather than the species the row is carrying.
+func _draw_egg() -> void:
+	var pic: Dictionary = _data.egg_pic()
+	if pic.is_empty():
+		_pic.texture = null
+		return
+	_blit(pic, _data.egg_palette(), EGG_AT)
+
+
+func _draw_species(species: int) -> void:
+	var pic: Dictionary = _data.species_pic(species)
+	if pic.is_empty():
+		_pic.texture = null
+		return
+	_blit(pic, _data.palette(species), HATCHLING_AT)
+
+
+func _blit(pic: Dictionary, colours: PackedColorArray, at: Vector2i) -> void:
+	var image: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, colours
+	)
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = Vector2(image.get_size())
+	_pic_origin = at
+	_place_pic()
+
+
+## `hSCX` scrolls the whole background, so the picture moves the other way.
+func _place_pic() -> void:
+	if _pic == null:
+		return
+	_pic.position = Vector2(_pic_origin.x * TILE - _shift, _pic_origin.y * TILE)
+
+
+func _draw_animation_box() -> void:
+	if _pic == null or _animation == null:
+		return
+	var square: int = BOX * BOX
+	if _animation.box.size() != square or _animation_pixels.is_empty():
+		return
+	var side: int = BOX * TILE
+	@warning_ignore("integer_division")
+	var strip: int = _animation_pixels.size() / side
+	var indices: PackedByteArray = PackedByteArray()
+	indices.resize(side * side)
+	for column: int in BOX:
+		for row: int in BOX:
+			var tile: int = int(_animation.box[column * BOX + row])
+			@warning_ignore("integer_division")
+			var source_x: int = (tile / BOX) * TILE
+			var source_y: int = (tile % BOX) * TILE
+			if source_x + TILE > strip:
+				continue
+			for line: int in TILE:
+				var from: int = (source_y + line) * strip + source_x
+				var to: int = (row * TILE + line) * side + column * TILE
+				for x: int in TILE:
+					indices[to + x] = _animation_pixels[from + x]
+	var image: Image = Gen2PicImage.from_indices(
+		indices, side, side, _data.palette(int(current_hatch().get("species", 0)))
+	)
+	_pic.texture = ImageTexture.create_from_image(image)
+	_pic.size = Vector2(image.get_size())
+	_pic_origin = HATCHLING_AT
+	_place_pic()

--- a/game/world/egg_hatch_screen.gd.uid
+++ b/game/world/egg_hatch_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dnkrak5twlf7w

--- a/game/world/evolution_screen.gd
+++ b/game/world/evolution_screen.gd
@@ -26,8 +26,8 @@ signal music_requested(index: int)
 const MUSIC_NONE: int = 0
 const MUSIC_EVOLUTION: int = 0x22
 ## constants/sfx_constants.asm.
-const SFX_EVOLVED: int = 0x4F
-const SFX_CAUGHT_MON: int = 0x2F
+const SFX_EVOLVED: int = 0xA4
+const SFX_CAUGHT_MON: int = 0x02
 
 const TILE: int = Gen2Font.TILE
 ## `hlcoord 7, 2`, the 7x7 block both pics are placed in.

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -38,16 +38,16 @@ const MAP_ROWS: int = RomLayout.INTRO_MAP_ROWS
 const SCREEN_HEIGHT_PX: int = 144
 
 ## The sound effects the movie asks for, as their `SFX_*` numbers.
-const SFX_INTRO_UNOWN_1: int = 0xB6
-const SFX_INTRO_UNOWN_2: int = 0xB8
-const SFX_INTRO_UNOWN_3: int = 0xB9
-const SFX_INTRO_SUICUNE_2: int = 0xB7
-const SFX_INTRO_SUICUNE_3: int = 0xBA
-const SFX_INTRO_SUICUNE_4: int = 0xBB
-const SFX_INTRO_WHOOSH: int = 0xBC
-const SFX_INTRO_PICHU: int = 0xBD
+const SFX_INTRO_UNOWN_1: int = 0xBE
+const SFX_INTRO_UNOWN_2: int = 0xBF
+const SFX_INTRO_UNOWN_3: int = 0xC0
+const SFX_INTRO_SUICUNE_2: int = 0xC5
+const SFX_INTRO_SUICUNE_3: int = 0xC6
+const SFX_INTRO_SUICUNE_4: int = 0xC8
+const SFX_INTRO_WHOOSH: int = 0xCB
+const SFX_INTRO_PICHU: int = 0xC4
 ## `MUSIC_CRYSTAL_OPENING`, started by `IntroScene13` rather than at the top.
-const MUSIC_CRYSTAL_OPENING: int = 0x25
+const MUSIC_CRYSTAL_OPENING: int = 0x62
 
 ## The six `SpriteAnimObjects` rows the movie spawns, as (frameset, function).
 const OBJ_INTRO_SUICUNE: StringName = &"suicune"

--- a/game/world/intro_presentation.gd
+++ b/game/world/intro_presentation.gd
@@ -68,9 +68,9 @@ func clear() -> void:
 	_step_frame = 0
 
 
-func push(bgp: int, column: int, frames: int) -> void:
+func push(palette_byte: int, pic_column: int, frames: int) -> void:
 	if frames > 0:
-		_steps.append([bgp, column, frames])
+		_steps.append([palette_byte, pic_column, frames])
 
 
 func push_delay(frames: int) -> void:
@@ -98,8 +98,8 @@ func push_rotate_three_left() -> void:
 
 
 func push_rotate_left_frontpic() -> void:
-	for bgp: int in FRONTPIC_FADE:
-		push(bgp, KEEP, FRONTPIC_FADE_STEP_FRAMES)
+	for palette_byte: int in FRONTPIC_FADE:
+		push(palette_byte, KEEP, FRONTPIC_FADE_STEP_FRAMES)
 
 
 func push_wipe_in_frontpic() -> void:
@@ -173,13 +173,13 @@ func remaining_frames() -> int:
 ## `CopyPals`: displayed colour `i` is the loaded colour the byte's `i`th pair
 ## names, low pair first. Anything that is not a four-colour row is handed back,
 ## since there is no palette for the byte to index.
-static func apply_bgp(row: PackedColorArray, bgp: int) -> PackedColorArray:
+static func apply_bgp(row: PackedColorArray, palette_byte: int) -> PackedColorArray:
 	if row.size() != 4:
 		return row
 	var out := PackedColorArray()
 	out.resize(4)
 	for index: int in 4:
-		out[index] = row[(bgp >> (2 * index)) & 3]
+		out[index] = row[(palette_byte >> (2 * index)) & 3]
 	return out
 
 

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -36,6 +36,15 @@ var column_spacing: int = 0
 var row_step: int = ROW_STEP
 
 
+
+## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
+## the five-wide, four-tall box at (14, 7). Every YES/NO in the game is this one.
+static func yes_no() -> Gen2MenuBox:
+	return from_coords(
+		14, 7, 19, 11, STATICMENU_CURSOR | STATICMENU_NO_TOP_SPACING
+	)
+
+
 static func from_coords(x1: int, y1: int, x2: int, y2: int, menu_flags: int) -> Gen2MenuBox:
 	var box := Gen2MenuBox.new()
 	box.left = x1

--- a/game/world/naming_screen.gd
+++ b/game/world/naming_screen.gd
@@ -46,6 +46,9 @@ const RESULT_FULL: StringName = &"full"
 const PLAYER_MAX_LENGTH: int = Gen2SaveData.MAX_PLAYER_NAME
 ## `BOX_NAME_LENGTH - 1`.
 const BOX_MAX_LENGTH: int = 8
+## `MON_NAME_LENGTH - 1`, which `.StoreMonIconParams` writes. A nickname uses
+## the player's keyboard and entry row and differs only in how long it may be.
+const MON_MAX_LENGTH: int = 10
 
 ## The cursor's own columns, which is every second byte of a row.
 const COLUMNS: int = RomLayout.NAME_INPUT_COLUMNS
@@ -82,6 +85,10 @@ static func for_player(data: GameData) -> Gen2NamingScreen:
 
 static func for_box(data: GameData) -> Gen2NamingScreen:
 	return _build(data, true, BOX_MAX_LENGTH)
+
+
+static func for_mon(data: GameData) -> Gen2NamingScreen:
+	return _build(data, false, MON_MAX_LENGTH)
 
 
 static func _build(data: GameData, box: bool, limit: int) -> Gen2NamingScreen:

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -12,6 +12,11 @@ extends Control
 ## nothing else, so a caller that never sees this signal has no name to take.
 signal closed(name: String)
 
+## `wNamingScreenType`'s two that a screen here opens. Both are the player's
+## keyboard; NAME_MON differs only in `MON_NAME_LENGTH - 1` behind it.
+const KIND_PLAYER: StringName = &"player"
+const KIND_MON: StringName = &"mon"
+
 var _screen: Gen2NamingScreen = null
 var _page: Gen2NamingScreenPage = null
 var _prompt: String = ""
@@ -31,17 +36,23 @@ var palette: PackedColorArray = PackedColorArray():
 ## names a Pokemon, the rival and Mom under its own prompt. Answers false when
 ## the cache carried no keyboards, which the caller reports rather than opening
 ## a screen with nothing on it.
-func open(data: GameData, prompt: String, box: bool = false) -> bool:
+func open(data: GameData, prompt: String, kind: StringName = KIND_PLAYER) -> bool:
 	_prompt = prompt
 	_page = Gen2NamingScreenPage.from_data(data)
 	if _page == null or not _page.ready():
 		return false
-	_screen = Gen2NamingScreen.for_box(data) if box else Gen2NamingScreen.for_player(data)
+	_screen = _model(data, kind)
 	if _screen.rows().is_empty():
 		return false
 	if is_inside_tree():
 		_refresh()
 	return true
+
+
+static func _model(data: GameData, kind: StringName) -> Gen2NamingScreen:
+	if kind == KIND_MON:
+		return Gen2NamingScreen.for_mon(data)
+	return Gen2NamingScreen.for_player(data)
 
 
 func _ready() -> void:

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -44,7 +44,7 @@ const CURSOR_BLINK_FRAMES: int = 8
 ## with `SFX_CHANGE_DEX_MODE` played between them.
 const CHANGING_MODES_FRAMES: int = 64
 ## constants/sfx_constants.asm.
-const SFX_CHANGE_DEX_MODE: int = 0x5C
+const SFX_CHANGE_DEX_MODE: int = 0x15
 
 ## `DexEntryScreen_ArrowCursorData`'s four positions, in its own order. PRNT
 ## wants a printer, which is deliberately out, so it is drawn and refuses.

--- a/game/world/radio_show.gd
+++ b/game/world/radio_show.gd
@@ -259,8 +259,8 @@ const BOX_TEXT_COLUMN: int = 1
 ## `MUSIC_POKEMON_TALK`, `MUSIC_POKEMON_MARCH` and `MUSIC_POKEMON_LULLABY`
 ## (`constants/music_constants.asm`), the three tracks a segment restarts.
 const MUSIC_POKEMON_TALK: int = 29
-const MUSIC_POKEMON_MARCH: int = 30
-const MUSIC_POKEMON_LULLABY: int = 31
+const MUSIC_POKEMON_MARCH: int = 0x51
+const MUSIC_POKEMON_LULLABY: int = 0x50
 
 var _data: GameData = null
 var _random: RandomNumberGenerator = null

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1380,8 +1380,8 @@ static func _give_pokerus(
 ) -> Dictionary:
 	var count: int = save.party.size()
 	for index: int in count:
-		var mon: Gen2SaveMon = save.party[index]
-		if mon != null and (mon.pokerus & 0x0F) != 0:
+		var carrier: Gen2SaveMon = save.party[index]
+		if carrier != null and (carrier.pokerus & 0x0F) != 0:
 			return _try_spread_pokerus(save, index, random)
 	if not reached_goldenrod:
 		return {}

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -8,6 +8,17 @@ extends RefCounted
 ## the candidate after both sides have succeeded. The six-party limit is
 ## deliberate until the save model has a real PC-box owner.
 
+## `CAUGHT_EGG_LEVEL`: a hatchling's caught level is 1 whatever level it hatches
+## at, so the stats page shows the egg rather than the hatch.
+const CAUGHT_EGG_LEVEL: int = 1
+## `HatchEggs`' own `ld [hl], $78`, the happiness a hatchling starts on.
+const HATCHED_HAPPINESS: int = 0x78
+## `LANDMARK_GIFT`, the landmark `SetGiftMonCaughtData` writes instead of a map.
+const LANDMARK_GIFT: int = 0x7E
+## `HatchEggs`' own `cp TOGEPI`, the one species whose hatch sets an event flag.
+const SPECIES_TOGEPI: int = 0xAF
+const EVENT_TOGEPI_HATCHED: int = 84
+
 const ITEM_POTION: int = 0x12
 const ITEM_REVIVE: int = 0x27
 const ITEM_MAX_REVIVE: int = 0x28
@@ -541,6 +552,51 @@ static func apply_step_happiness(save: Gen2SaveData, times: int = 1) -> Array[in
 
 
 
+## `Text_BreedHuh`: "Huh?" and then a `para` whose page is empty, because the
+## `text_asm` behind it is the animation rather than a line. The empty page is
+## what the sequence opens on, so the box waits for a press like any other
+## paragraph break.
+const HUH_TEXT: String = "Huh?" + Gen2TextStream.PAGE_BREAK
+
+
+## `_BreedEggHatchText`, whose `wStringBuffer1` is the name the row now carries.
+static func hatch_text(nickname: String) -> String:
+	return "%s came\nout of its EGG!" % nickname
+
+
+## `_BreedAskNicknameText`, the `YesNoBox` after the hatch.
+static func nickname_question(nickname: String) -> String:
+	return "Give a nickname to\n%s?" % nickname
+
+
+## `NamingScreenJumptable`'s `.Pokemon`: the name, `'S` beside it and
+## `NICKNAME?` on the row two below.
+static func nickname_prompt(nickname: String) -> String:
+	return "%s'S\nNICKNAME?" % nickname
+
+
+## `DoEggStep`, spent [param times] over. Each pass walks the party from the
+## front taking one hatch cycle off every egg, and stops on the first egg whose
+## counter reaches zero, so an egg behind that one keeps its cycle for that
+## step. Answers the party index of the egg that is ready to hatch, or -1.
+##
+## The counter lives in the happiness byte, which is what `GiveEgg` wrote and
+## what `HatchEggs` reads; [method apply_step_happiness] skips eggs for the same
+## reason.
+static func apply_egg_steps(save: Gen2SaveData, times: int = 1) -> int:
+	if save == null or times <= 0:
+		return -1
+	for _pass: int in times:
+		for index: int in save.party.size():
+			var mon: Gen2SaveMon = save.party[index] as Gen2SaveMon
+			if mon == null or not mon.is_egg:
+				continue
+			mon.happiness = (mon.happiness - 1) & 0xFF
+			if mon.happiness == 0:
+				return index
+	return -1
+
+
 ## Attempts to catch one wild battle mon and consumes the ball on either result.
 ## The battle screen owns the animation; this host owns the cartridge outcome and
 ## the save/world writeback. A caught mon enters the party when there is room and
@@ -579,11 +635,17 @@ static func capture_wild(
 	var candidate: Gen2SaveData = opened["candidate"]
 	var destination: Dictionary = {}
 	if bool(outcome.get("caught", false)):
-		var captured: Gen2SaveMon = _captured_mon(
-			world.data, save, wild, generator, caught_location
-		)
+		var captured: Gen2SaveMon = _captured_mon(world.data, save, wild, generator)
 		if captured == null:
 			return _failure(&"could_not_create_captured_pokemon", outcome)
+		## `SetCaughtData` runs on the caught Pokemon itself. [param
+		## caught_location] is the caller's override, for a catch whose landmark
+		## is not the map the player is standing on; every one that has none
+		## passes 0 and takes the map's.
+		set_caught_data(
+			captured, wild.level, world.object_time_of_day, world.player_female(),
+			caught_location if caught_location > 0 else world.landmark()
+		)
 		destination = candidate.add_party_or_box(captured)
 		if not bool(destination.get("ok", false)):
 			return _failure(StringName(destination.get("reason", &"storage_full")), {
@@ -644,6 +706,12 @@ static func _apply_party_request(
 		)
 		if mon == null:
 			return {"ok": false, "reason": &"could_not_create_pokemon"}
+		## `AddPartyMon`'s three caught-data branches. An egg's is overwritten by
+		## `SetEggMonCaughtData` when it hatches; a plain `givepoke` takes
+		## `SetCaughtData`, the map the player is standing on.
+		set_caught_data(
+			mon, level, world.object_time_of_day, world.player_female(), world.landmark()
+		)
 		if not is_egg:
 			var source: Dictionary = request.get("source", {})
 			var bank: int = int(source.get("bank", -1))
@@ -657,6 +725,10 @@ static func _apply_party_request(
 				mon.nickname = nickname
 			if not ot_name.is_empty():
 				mon.original_trainer = ot_name
+				## `SetGiftPartyMonCaughtData`: a `givepoke` that names an OT is
+				## somebody's present, so its level byte is zero and its
+				## landmark is LANDMARK_GIFT rather than this map.
+				set_caught_data(mon, 0, -1, world.player_female(), LANDMARK_GIFT)
 		return _append_mon(candidate, mon, 2 if is_egg else 1, {
 			"kind": &"egg" if is_egg else &"gift",
 			"species": species, "level": level, "item": held_item,
@@ -799,6 +871,10 @@ static func _new_mon(
 	if is_egg:
 		out.nickname = "EGG"
 		out.hp = 0
+		# `GiveEgg`'s `ld a, [wBaseEggSteps] / ld [hl], a`: an egg's happiness
+		# byte is its hatch counter, and `DoEggStep` spends one of it per 256
+		# steps. The debug branch above it writes 1 and is not reachable here.
+		out.happiness = int(data.species(species).get("hatch_cycles", 0))
 	return out
 
 
@@ -1162,8 +1238,7 @@ static func _captured_mon(
 	data: GameData,
 	save: Gen2SaveData,
 	wild: Gen2BattleMon,
-	random: RandomNumberGenerator,
-	caught_location: int
+	random: RandomNumberGenerator
 ) -> Gen2SaveMon:
 	var out: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(wild)
 	if out == null:
@@ -1174,11 +1249,66 @@ static func _captured_mon(
 	out.original_trainer = save.player_name
 	out.ot_id = random.randi_range(0, 0xFFFF)
 	out.happiness = 70
-	out.caught_level = wild.level
-	out.caught_gender = 1 if wild.gender() == Gen2BattleMon.GENDER_FEMALE else 0
-	out.caught_location = clampi(caught_location, 0, 127)
 	out.is_egg = false
 	return out
+
+
+## `SetBoxmonOrEggmonCaughtData`, the three bytes every caught or hatched
+## Pokemon carries. All three are the trainer's rather than the Pokemon's: the
+## gender bit is `wPlayerGender` and not the caught mon's, which is what the
+## "caught by" line reads back, and the level is CAUGHT_EGG_LEVEL for a hatch.
+static func set_caught_data(
+	mon: Gen2SaveMon, level: int, time_of_day: int, player_female: bool, landmark: int
+) -> void:
+	if mon == null:
+		return
+	mon.caught_level = clampi(level, 0, 63)
+	# `ld a, [wTimeOfDay] / inc a`: the field holds MORN as 1, so the -1 a gift
+	# passes is the cartridge's own `xor a` over both halves of the byte.
+	mon.caught_time = clampi(time_of_day + 1, 0, 3)
+	mon.caught_gender = 1 if player_female else 0
+	mon.caught_location = clampi(landmark, 0, 127)
+
+
+## `HatchEggs` for one party slot: the egg becomes the Pokemon it was carrying.
+## Everything here is the source's own order, and every one of the seven writes
+## has a reader in this project, which is why none is left out.
+##
+## Answers the summary the screen shows, or an empty dictionary when the slot is
+## not an egg that is ready.
+static func hatch_egg(
+	world: Gen2WorldAPI, save: Gen2SaveData, index: int
+) -> Dictionary:
+	if world == null or world.data == null or save == null:
+		return {}
+	if index < 0 or index >= save.party.size():
+		return {}
+	var mon: Gen2SaveMon = save.party[index] as Gen2SaveMon
+	if mon == null or not mon.is_egg or mon.happiness != 0:
+		return {}
+	set_caught_data(
+		mon, CAUGHT_EGG_LEVEL, world.object_time_of_day,
+		world.player_female(), world.landmark()
+	)
+	mon.is_egg = false
+	# `ld [hl], $78`: the counter the walk drained becomes the hatchling's own
+	# base happiness, which is why the write happens before anything reads it.
+	mon.happiness = HATCHED_HAPPINESS
+	mon.status = Gen2Status.NONE
+	mon.hp = _max_hp(world.data, mon)
+	mon.ot_id = save.player_id
+	mon.original_trainer = save.player_name
+	mon.nickname = String(world.data.species(mon.species).get("name", ""))
+	## `SetSeenAndCaughtMon`, which `GiveEgg` was careful to undo when the egg
+	## arrived: the dex learns the species here and nowhere earlier.
+	if world.state != null:
+		world.state.set_species_caught(mon.species)
+		if mon.species == SPECIES_TOGEPI:
+			world.state.set_event_flag(EVENT_TOGEPI_HATCHED)
+	return {
+		"kind": &"hatch", "party_index": index, "species": mon.species,
+		"level": mon.level, "nickname": mon.nickname,
+	}
 
 
 static func _max_hp(data: GameData, mon: Gen2SaveMon) -> int:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -23,7 +23,7 @@ const SFX_JUMP_OVER_LEDGE: int = 0x16
 ## constants/sfx_constants.asm's SFX_PLACE_PUZZLE_PIECE_DOWN, played by
 ## OWCutAnimation before its sprite animation. The animation itself is not
 ## rendered here; the sound is.
-const SFX_CUT: int = 0x1E
+const SFX_CUT: int = 0x38
 ## constants/sfx_constants.asm's SFX_SURF, which is what PlayWhirlpoolSound plays
 ## (engine/events/field_moves.asm); there is no whirlpool-specific effect.
 const SFX_WHIRLPOOL: int = 0x53
@@ -128,6 +128,9 @@ var _evolution_after: Callable = Callable()
 ## The party the open pass applies to, which is the fought save rather than
 ## whatever is selected while the screen is up.
 var _evolution_save: Gen2SaveData = null
+## `OverworldHatchEgg`'s screen and the save whose party it has already written.
+var _hatch_host: Gen2EggHatchScreen = null
+var _hatch_save: Gen2SaveData = null
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
@@ -605,6 +608,8 @@ func advance_frame() -> void:
 	## `DelayFrames` counts are spent from this pump.
 	if _evolution_host != null:
 		_evolution_host.advance_frame()
+	if _hatch_host != null:
+		_hatch_host.advance_frame()
 	_spending_frame = false
 
 
@@ -747,7 +752,7 @@ func _overlay_open() -> bool:
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
 		or _pokedex_host != null or _credits_host != null \
-		or _evolution_host != null
+		or _evolution_host != null or _hatch_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -841,6 +846,11 @@ func _handle_button(button: int) -> bool:
 	## behind it, so its B is the animation's cancel rather than the pack's back.
 	if _evolution_host != null:
 		_evolution_host.handle_button(button)
+		return true
+	## The same rule for `OverworldHatchEgg`, which `PlayerEvents` runs with the
+	## map loop suspended in exactly the same place.
+	if _hatch_host != null:
+		_hatch_host.handle_button(button)
 		return true
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -1097,6 +1107,7 @@ func _complete_player_step(movement: Dictionary) -> bool:
 	## `DoPlayerMovement.CheckWarp`'s own answer, which has already made the
 	## check `CheckWarpTile` refuses for a carpet.
 	_spend_step_happiness()
+	_spend_egg_steps()
 	var kind: StringName = StringName(movement.get("kind", &""))
 	if kind == &"edge_warp" or (kind in [
 		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
@@ -1127,6 +1138,77 @@ func _spend_step_happiness() -> void:
 		return
 	if not Gen2WorldPartyHost.apply_step_happiness(save, owed).is_empty():
 		_refresh_labels()
+
+
+## `DoEggStep` and the `PLAYEREVENT_HATCH` it raises. The party lives on the
+## save, so the walk counts the step and this spends it, the way
+## [method _spend_step_happiness] does for `StepHappiness`.
+##
+## `HatchEggs` walks the whole party, so every egg the pass left on zero hatches
+## in one screen rather than one per step.
+func _spend_egg_steps() -> void:
+	if _world == null or _world.state == null or _hatch_host != null:
+		return
+	var owed: int = _world.state.take_pending_egg_steps()
+	if owed <= 0:
+		return
+	var save: Gen2SaveData = active_save()
+	if save == null:
+		return
+	if Gen2WorldPartyHost.apply_egg_steps(save, owed) < 0:
+		return
+	var hatches: Array = []
+	for index: int in save.party.size():
+		var summary: Dictionary = Gen2WorldPartyHost.hatch_egg(_world, save, index)
+		if not summary.is_empty():
+			hatches.append(summary)
+	if hatches.is_empty():
+		return
+	_open_hatch(hatches, save)
+
+
+## `OverworldHatchEgg`. The rows are already written; the screen owns the
+## sequence and the nickname alone.
+func _open_hatch(hatches: Array, save: Gen2SaveData) -> void:
+	var host := Gen2EggHatchScreen.new()
+	host.set_context(_data, hatches)
+	_hatch_save = save
+	host.named.connect(_on_hatch_named)
+	host.closed.connect(_on_hatch_closed)
+	host.cry_requested.connect(_play_species_cry)
+	host.sfx_requested.connect(_play_sfx)
+	host.music_requested.connect(_play_evolution_music)
+	host.z_index = 30
+	_hatch_host = host
+	_screen.display(host)
+	if _hatch_host == null:
+		return
+	_script_prompt = "Hatching"
+	_refresh_labels()
+
+
+## `InitName`, which writes whatever the naming screen left into the row's
+## nickname. `.nonickname` reaches this too, with the species name.
+func _on_hatch_named(party_index: int, nickname: String) -> void:
+	if _hatch_save == null or party_index < 0 \
+		or party_index >= _hatch_save.party.size():
+		return
+	var mon: Gen2SaveMon = _hatch_save.party[party_index] as Gen2SaveMon
+	if mon == null:
+		return
+	mon.nickname = nickname
+	_script_prompt = "%s hatched" % nickname
+
+
+func _on_hatch_closed() -> void:
+	var host: Gen2EggHatchScreen = _hatch_host
+	_hatch_host = null
+	_hatch_save = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	_refresh_labels()
 
 
 ## `EnterMap`'s own tail, which a warp reaches once its setup script has run and
@@ -1891,6 +1973,36 @@ func preview_item_evolution_use() -> void:
 		if int((rows[index] as Dictionary).get("item", 0)) == int(stone["item"]):
 			_start_menu_host.set("_pack_cursor", index)
 			break
+
+
+## Public screenshot driver and scene-test entry for `OverworldHatchEgg`: it
+## stands an egg with one cycle left in the first party slot of an injected
+## save, spends the egg step, and opens the sequence on whatever hatched.
+##
+## [param species] is what is inside the egg; 0 takes the first species the
+## cache holds, so the driver works on all three without a table.
+func preview_egg_hatch(species: int = 0) -> void:
+	if _world == null or _data == null or _hatch_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Hatch preview needs a party"
+		_refresh_labels()
+		return
+	var mon: Gen2SaveMon = save.party[0]
+	mon.species = species if species > 0 else 1
+	mon.is_egg = true
+	mon.hp = 0
+	mon.nickname = "EGG"
+	## One cycle left, so the pass this drains is the one that hatches it.
+	mon.happiness = 1
+	_injected_save = save
+	if Gen2WorldPartyHost.apply_egg_steps(save, 1) < 0:
+		return
+	var summary: Dictionary = Gen2WorldPartyHost.hatch_egg(_world, save, 0)
+	if summary.is_empty():
+		return
+	_open_hatch([summary], save)
 
 
 ## The first `EVOLVE_ITEM` row this cache carries, as `{species, item}`. Walked

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -615,7 +615,7 @@ func _render_mart() -> void:
 		if _mart_menu_page == null:
 			_mart_menu_page = Gen2MenuPage.from_data(_data)
 		if _mart_menu_page != null:
-			var box: Gen2MenuBox = _mart_yes_no_box()
+			var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 			var menu: Image = _mart_menu_page.render(
 				box, ["YES", "NO"], _mart_confirm
 			)
@@ -624,15 +624,6 @@ func _render_mart() -> void:
 				box.border_position() * Gen2Font.TILE
 			)
 	_mart_view.texture = ImageTexture.create_from_image(image)
-
-
-## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
-## the five-wide, four-tall box at (14,7).
-func _mart_yes_no_box() -> Gen2MenuBox:
-	return Gen2MenuBox.from_coords(
-		14, 7, 19, 11,
-		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
-	)
 
 
 ## `UpdateItemDescription`, which prints nothing for the CANCEL row.

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -18,6 +18,10 @@ const MUSIC_NONE: int = 0
 ## `wUndergroundSwitchPositions`, the phone rematch counters), so they are
 ## kept as an address-keyed byte map rather than a WRAM image.
 const SCRIPT_MEMORY_CAPACITY: int = 64
+
+## `CountStep`'s `cp $80`: the step count `DoEggStep` runs on, half a wrap away
+## from the `StepHappiness` pass at zero.
+const EGG_STEP_PHASE: int = 0x80
 const PHONE_RECEIVE_DELAYS: Array[int] = [20, 10, 5, 3]
 const TEMPORARY_MAP_RELOAD_FLAGS: Array[int] = [0, 1, 2, 3, 4, 5, 6, 7]
 ## Crystal maps STATUSFLAGS_HALL_OF_FAME_F through the source engine flag
@@ -139,6 +143,10 @@ var _happiness_step_count: int = 0
 ## How many `StepHappiness` passes the walk owes but no party owner has spent.
 ## The state has no party; the screen that does drains this.
 var _pending_step_happiness: int = 0
+## The same for `DoEggStep`, which `CountStep` reaches on the pass `wStepCount`
+## is `$80`, so an egg loses one hatch cycle every 256 steps offset 128 from the
+## happiness pass.
+var _pending_egg_steps: int = 0
 ## `wStatusFlags`' `STATUSFLAGS_NO_WILD_ENCOUNTERS_F`, which `wildoff` sets and
 ## `wildon` clears around a scripted sequence.
 var _wild_encounters_off: bool = false
@@ -417,6 +425,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_poison_step_count = restored._poison_step_count
 	_happiness_step_count = restored._happiness_step_count
 	_pending_step_happiness = 0
+	_pending_egg_steps = 0
 	_wild_encounters_off = restored._wild_encounters_off
 	_park_balls = restored._park_balls
 	_bug_contest_started = restored._bug_contest_started.duplicate()
@@ -1055,6 +1064,8 @@ func count_step() -> void:
 		_happiness_step_count = (_happiness_step_count + 1) & 1
 		if _happiness_step_count == 0:
 			_pending_step_happiness += 1
+	if _step_count == EGG_STEP_PHASE:
+		_pending_egg_steps += 1
 	if _repel_steps > 0:
 		_repel_steps -= 1
 	changed.emit()
@@ -1073,6 +1084,13 @@ func poison_step_count() -> int:
 func take_pending_step_happiness() -> int:
 	var owed: int = _pending_step_happiness
 	_pending_step_happiness = 0
+	return owed
+
+
+## The same for the owed `DoEggStep` passes.
+func take_pending_egg_steps() -> int:
+	var owed: int = _pending_egg_steps
+	_pending_egg_steps = 0
 	return owed
 
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -588,7 +588,7 @@ func test_a_field_stone_opens_the_evolution_screen_over_the_pack() -> void:
 	## cancel a stone's evolution.
 	assert_false(bool(screen.current_plan().get("can_cancel", true)))
 	assert_true(_lines_of(screen).contains("%s is evolving!" % nickname), "the first box")
-	_settle_evolution()
+	await _settle_evolution()
 
 
 ## `GetNickname` / `CopyName1` run before the species is replaced, and BOTH
@@ -613,7 +613,7 @@ func test_the_evolving_line_names_what_the_mon_was_not_what_it_became() -> void:
 	assert_false(opening.contains("What? %s" % after), opening)
 	## `UpdateSpeciesNameIfNotNicknamed` still runs, after both boxes.
 	assert_eq(save.party[0].nickname, after)
-	_settle_evolution()
+	await _settle_evolution()
 
 
 ## Runs the open evolution screen to its end, pressing A for every page it waits
@@ -621,12 +621,16 @@ func test_the_evolving_line_names_what_the_mon_was_not_what_it_became() -> void:
 func _settle_evolution() -> void:
 	for _frame: int in 4000:
 		if _world_screen.get("_evolution_host") == null:
+			## `queue_free` lands at the end of the frame, so the screen is only
+			## gone once one has passed; without this the run reports it orphaned.
+			await get_tree().process_frame
 			return
 		_world_screen.advance_frame()
 		var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
 		## The frame that closed it has already run whatever was waiting behind
 		## it, so a press here would answer that instead of the box.
 		if screen == null:
+			await get_tree().process_frame
 			return
 		if screen.awaiting_press():
 			_world_screen.press_button(Gen2Button.A)
@@ -650,7 +654,7 @@ func test_an_evolution_offers_its_new_move_and_a_full_moveset_opens_forget() -> 
 
 	## The animation runs to its end first: the offer is `LearnLevelMoves`, which
 	## the source reaches after `EvolutionAnimation` has returned.
-	_settle_evolution()
+	await _settle_evolution()
 	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
 	assert_true(String(host.call("box_text")).contains("EMBER"), String(host.call("box_text")))

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1185,10 +1185,14 @@ func _write_level_evolution() -> void:
 func _settle_evolution(cancel: bool = false) -> void:
 	for _frame: int in 4000:
 		if _world_screen.get("_evolution_host") == null:
+			## `queue_free` lands at the end of the frame, so the screen is only
+			## gone once one has passed; without this the run reports it orphaned.
+			await get_tree().process_frame
 			return
 		_world_screen.advance_frame()
 		var screen: Gen2EvolutionScreen = _world_screen.get("_evolution_host")
 		if screen == null:
+			await get_tree().process_frame
 			return
 		if cancel and screen.phase() == Gen2EvolutionScreen.Phase.FLASH:
 			_world_screen.press_button(Gen2Button.B)
@@ -1211,7 +1215,7 @@ func test_a_level_evolution_is_presented_after_the_battle_and_then_applied() -> 
 	assert_eq(screen.remaining(), 1)
 	assert_eq(save.party[0].species, EVOLVING_SPECIES, "nothing is written before the animation")
 
-	_settle_evolution()
+	await _settle_evolution()
 	assert_null(_world_screen.get("_evolution_host"), "and it closes on its own")
 	assert_eq(save.party[0].species, EVOLVED_SPECIES)
 	assert_eq(save.party[0].nickname, "BAYLEEF", "UpdateSpeciesNameIfNotNicknamed")
@@ -1232,8 +1236,106 @@ func test_b_during_the_flash_cancels_the_evolution_and_says_so() -> void:
 	save.party[0].level = EVOLVE_LEVEL
 
 	_world_screen.preview_level_evolution()
-	_settle_evolution(true)
+	await _settle_evolution(true)
 
 	assert_eq(save.party[0].species, EVOLVING_SPECIES, "the species is unchanged")
 	assert_eq(save.party[0].nickname, "CHIKORITA")
 	assert_false(_world_screen._world.state.has_caught_species(EVOLVED_SPECIES))
+
+
+## Runs the open hatch screen to its end, pressing A for every page and box it
+## waits on, the way the overworld's own pump and funnel do.
+func _settle_hatch(nickname: bool = false) -> void:
+	for _frame: int in 4000:
+		var screen: Gen2EggHatchScreen = _world_screen.get("_hatch_host")
+		if screen == null:
+			await get_tree().process_frame
+			return
+		_world_screen.advance_frame()
+		screen = _world_screen.get("_hatch_host")
+		if screen == null:
+			await get_tree().process_frame
+			return
+		if screen.phase() == Gen2EggHatchScreen.Phase.NAMING:
+			var model: Gen2NamingScreen = screen.naming_screen().model()
+			if model.length == 0:
+				_world_screen.press_button(Gen2Button.A)
+			else:
+				## END, which is `NamingScreen_StoreEntry`.
+				model.column = Gen2NamingScreen.LAST_COLUMN
+				model.row = model.command_row()
+				_world_screen.press_button(Gen2Button.A)
+			continue
+		if screen.phase() == Gen2EggHatchScreen.Phase.ASK_NICKNAME and not nickname:
+			_world_screen.press_button(Gen2Button.B)
+			continue
+		if screen.awaiting_press():
+			_world_screen.press_button(Gen2Button.A)
+	fail_test("the hatch screen never closed")
+
+
+## `HatchEggs` has already written the row when the sequence opens, so the
+## screen is presentation and the nickname alone. `.nonickname` keeps the
+## species name `GetPokemonName` put there.
+func test_an_egg_hatches_into_the_species_it_was_carrying() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	_world_screen.preview_egg_hatch()
+	save = _world_screen._injected_save
+	var screen: Gen2EggHatchScreen = _world_screen.get("_hatch_host")
+	assert_not_null(screen, "the pass opened its screen")
+	assert_false(save.party[0].is_egg, "the row is written before the sequence")
+	assert_true(save.party[0].hp > 0)
+	assert_eq(" ".join(screen.text_lines()).strip_edges(), "Huh?",
+		"`Text_BreedHuh` is printed over the map before anything is cleared")
+	assert_true(screen.awaiting_press(), "its `para` waits for a press")
+	var species_name: String = String(
+		_data.species(save.party[0].species).get("name", "")
+	)
+	for _frame: int in 4000:
+		if screen.phase() == Gen2EggHatchScreen.Phase.HATCHED:
+			break
+		_world_screen.advance_frame()
+		if screen.awaiting_press():
+			_world_screen.press_button(Gen2Button.A)
+	assert_eq(
+		" ".join(screen.text_lines()),
+		Gen2WorldPartyHost.hatch_text(species_name).replace("\n", " ")
+	)
+
+	await _settle_hatch()
+	assert_null(_world_screen.get("_hatch_host"), "and it closes on its own")
+	assert_eq(
+		save.party[0].nickname,
+		String(_data.species(save.party[0].species).get("name", "")),
+		"NO keeps the species name"
+	)
+	assert_true(_world_screen._world.state.has_caught_species(save.party[0].species))
+
+
+## YES reaches `NamingScreen` under NAME_MON, and what it stores is the row's
+## nickname. An empty entry keeps the species name, which is `InitName`.
+func test_yes_opens_the_naming_screen_and_its_entry_becomes_the_nickname() -> void:
+	await _open_world(true)
+	_world_screen.preview_egg_hatch()
+	var save: Gen2SaveData = _world_screen._injected_save
+	var screen: Gen2EggHatchScreen = _world_screen.get("_hatch_host")
+	for _frame: int in 4000:
+		if screen.phase() == Gen2EggHatchScreen.Phase.ASK_NICKNAME:
+			break
+		_world_screen.advance_frame()
+		if screen.awaiting_press():
+			_world_screen.press_button(Gen2Button.A)
+	assert_eq(screen.nickname_cursor(), 0, "YesNoBox opens on YES")
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(screen.phase(), Gen2EggHatchScreen.Phase.NAMING)
+	var model: Gen2NamingScreen = screen.naming_screen().model()
+	assert_eq(model.max_length, Gen2NamingScreen.MON_MAX_LENGTH)
+	model.press_a()
+	model.column = Gen2NamingScreen.LAST_COLUMN
+	model.row = model.command_row()
+	_world_screen.press_button(Gen2Button.A)
+
+	await _settle_hatch()
+	assert_null(_world_screen.get("_hatch_host"))
+	assert_eq(save.party[0].nickname.length(), 1, "the one letter that was entered")

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -964,3 +964,77 @@ func test_step_happiness_raises_every_member_but_an_egg_and_saturates() -> void:
 	assert_eq(_save.party[0].happiness, 103, "an owed run of passes is one add")
 	assert_true(Gen2WorldPartyHost.apply_step_happiness(null, 1).is_empty())
 	assert_true(Gen2WorldPartyHost.apply_step_happiness(_save, 0).is_empty())
+
+
+func _egg(species: int, cycles: int) -> Gen2SaveMon:
+	var egg: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(
+		Gen2BattleMon.create(_data, species, 5)
+	)
+	egg.is_egg = true
+	egg.hp = 0
+	egg.happiness = cycles
+	egg.nickname = "EGG"
+	return egg
+
+
+## `DoEggStep` walks the party taking one cycle off every egg and stops on the
+## first that reaches zero, so an egg behind that one keeps the cycle.
+func test_an_egg_step_drains_every_egg_and_stops_on_the_first_ready_one() -> void:
+	_save.party = [_save.party[0], _egg(1, 1), _egg(1, 3)]
+	assert_eq(Gen2WorldPartyHost.apply_egg_steps(_save, 1), 1)
+	assert_eq(_save.party[1].happiness, 0)
+	assert_eq(_save.party[2].happiness, 3, "the walk stopped before the second egg")
+	assert_eq(_save.party[0].happiness, Gen2SaveStore.create_development_save(
+		_data, 0
+	).party[0].happiness, "a Pokemon is not an egg and loses nothing")
+
+
+func test_an_egg_step_answers_minus_one_until_a_counter_runs_out() -> void:
+	_save.party = [_egg(1, 3)]
+	assert_eq(Gen2WorldPartyHost.apply_egg_steps(_save, 2), -1)
+	assert_eq(_save.party[0].happiness, 1)
+	assert_eq(Gen2WorldPartyHost.apply_egg_steps(_save, 1), 0)
+	assert_eq(Gen2WorldPartyHost.apply_egg_steps(null, 1), -1)
+	assert_eq(Gen2WorldPartyHost.apply_egg_steps(_save, 0), -1)
+
+
+## `HatchEggs`: the row becomes the Pokemon it was carrying, at full health, on
+## `$78` happiness, with the player's own ID and name and CAUGHT_EGG_LEVEL.
+func test_hatching_writes_the_row_the_source_writes() -> void:
+	_save.player_id = 0x1234
+	_save.player_name = "KRIS"
+	_save.party = [_egg(1, 1)]
+	assert_true(Gen2WorldPartyHost.hatch_egg(_world, _save, 0).is_empty(),
+		"an egg with cycles left does not hatch")
+	assert_eq(Gen2WorldPartyHost.apply_egg_steps(_save, 1), 0)
+
+	var summary: Dictionary = Gen2WorldPartyHost.hatch_egg(_world, _save, 0)
+	assert_eq(int(summary.get("party_index", -1)), 0)
+	assert_eq(int(summary.get("species", 0)), 1)
+	var mon: Gen2SaveMon = _save.party[0]
+	assert_false(mon.is_egg)
+	assert_eq(mon.happiness, Gen2WorldPartyHost.HATCHED_HAPPINESS)
+	assert_eq(mon.status, Gen2Status.NONE)
+	assert_true(mon.hp > 0, "the hatchling stands at its own maximum")
+	assert_eq(mon.ot_id, 0x1234)
+	assert_eq(mon.original_trainer, "KRIS")
+	assert_eq(mon.caught_level, Gen2WorldPartyHost.CAUGHT_EGG_LEVEL)
+	assert_eq(mon.caught_location, _world.landmark())
+	assert_true(_world.state.has_caught_species(1), "SetSeenAndCaughtMon runs here")
+	assert_true(Gen2WorldPartyHost.hatch_egg(_world, _save, 0).is_empty(),
+		"a hatched row is not an egg any more")
+
+
+## `SetBoxmonOrEggmonCaughtData` writes the trainer's gender, not the caught
+## Pokemon's, and the time of day plus one.
+func test_caught_data_is_the_trainers_rather_than_the_pokemons() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	Gen2WorldPartyHost.set_caught_data(mon, 12, Gen2WorldPalette.TIME_NIGHT, true, 9)
+	assert_eq(mon.caught_level, 12)
+	assert_eq(mon.caught_time, Gen2WorldPalette.TIME_NIGHT + 1)
+	assert_eq(mon.caught_gender, 1)
+	assert_eq(mon.caught_location, 9)
+	Gen2WorldPartyHost.set_caught_data(mon, 0, -1, false, Gen2WorldPartyHost.LANDMARK_GIFT)
+	assert_eq(mon.caught_time, 0, "a gift's whole level byte is zeroed")
+	assert_eq(mon.caught_gender, 0)
+	assert_eq(mon.caught_location, Gen2WorldPartyHost.LANDMARK_GIFT)

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -495,6 +495,23 @@ func test_count_step_owes_step_happiness_every_five_hundred_and_twelve_steps() -
 	assert_eq(state.take_pending_step_happiness(), 1)
 
 
+## `CountStep`'s `cp $80`: `DoEggStep` is owed every 256 steps, half a wrap away
+## from the `StepHappiness` pass at zero.
+func test_count_step_owes_an_egg_step_every_two_hundred_and_fifty_six_steps() -> void:
+	var state := Gen2WorldState.new()
+	for _step: int in Gen2WorldState.EGG_STEP_PHASE - 1:
+		state.count_step()
+	assert_eq(state.take_pending_egg_steps(), 0)
+	state.count_step()
+	assert_eq(state.step_count(), Gen2WorldState.EGG_STEP_PHASE)
+	assert_eq(state.take_pending_egg_steps(), 1)
+	assert_eq(state.take_pending_egg_steps(), 0, "draining forgets what it took")
+	assert_eq(state.take_pending_step_happiness(), 0, "the two passes never share a step")
+	for _step: int in 256:
+		state.count_step()
+	assert_eq(state.take_pending_egg_steps(), 1)
+
+
 ## The Repel countdown was the whole of this call before the counters joined it,
 ## and it still spends one step at a time and stops at zero.
 func test_count_step_spends_a_repel_step_and_stops_at_zero() -> void:

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -74,7 +74,40 @@ func run(r: RefCounted) -> void:
 		_verify_patching(catalog)
 		_verify_links(catalog)
 		_verify_progression(catalog)
+		_verify_sidecar(catalog)
 	)
+
+
+## The sidecar is what a player actually reads: the scan costs thirteen seconds
+## and runs at import, and every check above this one ran against whatever
+## [method GameData.catalog] handed back. So this asks the other question, that
+## a restored catalog and a freshly scanned one are the same catalog, every row,
+## every link and every kind's order.
+func _verify_sidecar(catalog: Gen2WorldCatalog) -> void:
+	var written: Variant = RomCache.read_json(
+		RomCache.world_catalog_path(_r.data.directory)
+	)
+	if not _r.check(written is Dictionary, "the import wrote no catalog sidecar."):
+		return
+	var restored: Gen2WorldCatalog = Gen2WorldCatalog.from_dict(_r.data, written)
+	if not _r.check(restored != null, "the catalog sidecar does not restore."):
+		return
+	var scanned: Gen2WorldCatalog = Gen2WorldCatalog.build(_r.data)
+	_r.check(
+		restored.to_dict() == scanned.to_dict(),
+		"the sidecar and a fresh scan disagree."
+	)
+	## And the one thing `to_dict` cannot say: that what the runtime asks for
+	## comes back the same, patches folded in and all.
+	for kind: StringName in Gen2WorldCatalog.KINDS:
+		_r.check(
+			restored.ids(kind) == scanned.ids(kind),
+			"%s ids differ between the sidecar and a fresh scan." % kind
+		)
+		for id: int in scanned.ids(kind):
+			if restored.check(id) != scanned.check(id):
+				_r.check(false, "row %d differs between the sidecar and a scan." % id)
+				return
 
 
 func _verify_census(catalog: Gen2WorldCatalog) -> void:

--- a/tools/checks/pokepic.gd
+++ b/tools/checks/pokepic.gd
@@ -32,6 +32,7 @@ func run(r: RefCounted) -> void:
 
 
 func _check_game() -> void:
+	_check_egg_pic()
 	var map: Gen2WorldMap = _r.data.world_map(MAP_GROUP, MAP_NUMBER)
 	if not _r.check(map != null, "map %d/%d is missing." % [MAP_GROUP, MAP_NUMBER]):
 		return
@@ -59,6 +60,33 @@ func _check_game() -> void:
 	_r.note("pokepic %d of %d species, sizes %s" % [
 		drawn, LAST_SPECIES - FIRST_SPECIES + 1, sizes
 	])
+
+
+## `GetEggFrontpic`'s own picture, which no species record owns: Crystal reaches
+## it through `PokemonPicPointers`' EGG entry and Gold and Silver through
+## `_GetFrontpic`'s `ld hl, EggPic`, so the two are different pictures at
+## different addresses and both are checked here.
+func _check_egg_pic() -> void:
+	var pic: Dictionary = _r.data.egg_pic()
+	if not _r.check(not pic.is_empty(), "the cache carries no egg pic."):
+		return
+	var side: int = RomLayout.EGG_PIC_TILES * Gen2Font.TILE
+	_r.check(
+		int(pic["width"]) == side and int(pic["height"]) == side,
+		"the egg pic is %dx%d rather than %d square." % [
+			int(pic["width"]), int(pic["height"]), side,
+		]
+	)
+	var image: Image = Gen2PicImage.from_atlas(
+		_r.data.atlas_indices(String(pic["atlas"])), _r.data.atlas(String(pic["atlas"])),
+		pic, _r.data.egg_palette()
+	)
+	if not _r.check(image != null, "the egg pic does not decode."):
+		return
+	_r.check(
+		_ink(image, Rect2i(Vector2i.ZERO, image.get_size()), image.get_pixel(0, 0)),
+		"the egg pic decoded to a blank square."
+	)
 
 
 ## Where `PadFrontpic` says the pic is, and where it says it is not: the ink runs

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -193,7 +193,9 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	## cell, so the player is left where the map puts them.
 	if _kind_cell.x >= 0:
 		_screen.start_cell = _kind_cell
-	elif cell.x >= 0 and _kind not in [&"battle_transition", &"level_evolution"]:
+	elif cell.x >= 0 and _kind not in [
+		&"battle_transition", &"level_evolution", &"egg_hatch",
+	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
 	## screen resolves is what a wandering NPC's own generator is built from.
@@ -248,6 +250,19 @@ func _process(_delta: float) -> bool:
 				if evolving == null:
 					break
 				if evolving.awaiting_press():
+					_screen.press_button(Gen2Button.A)
+		elif _kind == &"egg_hatch":
+			## `OverworldHatchEgg`, driven the same way and for the same reason:
+			## the sequence is five hundred frames of picture, so the first
+			## number is how far into it to photograph and the second is the
+			## species inside the egg, 0 for the first the cache holds.
+			_screen.preview_egg_hatch(maxi(_cell.y, 0))
+			for _frame: int in maxi(_cell.x, 0):
+				_screen.advance_frame()
+				var hatching: Gen2EggHatchScreen = _screen.get("_hatch_host")
+				if hatching == null:
+					break
+				if hatching.awaiting_press():
 					_screen.press_button(Gen2Button.A)
 		elif _kind == &"yes_no":
 			## `Script_yesorno`'s own box: the NPC beside the player is talked
@@ -338,7 +353,7 @@ func _process(_delta: float) -> bool:
 			_screen.preview_effect_sprites(_kind)
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
-			&"battle_transition", &"level_evolution",
+			&"battle_transition", &"level_evolution", &"egg_hatch",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.


### PR DESCRIPTION
`giveegg TOGEPI` at Violet Pokecenter 1F is a required story step, and the egg it gives could never become anything. Four routines were missing. All four are here.

## The egg

- **`GiveEgg`'s `ld a, [wBaseEggSteps]`.** An egg's happiness byte is its hatch counter. Nothing was writing it, so every egg started on zero.
- **`DoEggStep`.** Owed on the pass `wStepCount` is `$80`, so one cycle comes off every egg in the party every 256 steps. The world state counts the step; the screen that owns the party spends it, the way `StepHappiness` already worked.
- **`HatchEggs`.** Writes the row before anything is drawn: species name, full HP, `$78` happiness, the player's ID and name, `SetEggMonCaughtData`, `SetSeenAndCaughtMon` and the TOGEPI event flag.
- **`EggHatch_AnimationSequence`**, as `Gen2EggHatchScreen`, on the overworld's own pump. The wobble, the three shell cracks, `AnimateFrontpic ANIM_MON_HATCH`, and the YES/NO that opens the naming screen under `NAME_MON`.

The ten shell fragments are sprite-anim objects and there is no sprite-anim layer outside the intro, so their 130 frames are spent with the hatchling standing. The evolution screen already does that with the balls of light.

`EggPic` is imported for all three cartridges, cache format 74. Crystal reads it through `PokemonPicPointers`' EGG entry. Gold and Silver's table stops at `NUM_POKEMON`, so `_GetFrontpic` answers EGG with `ld hl, EggPic` and their picture is a different one, at its own address. It is also the picture an egg's stats page had been drawing nothing in place of.

Photograph any frame with:

```
tools/preview_world.gd -- <game> <group> <map> <png> live egg_hatch <frame> <species>
```

## Three defects found on the way

**Twelve sound constants named the wrong sound.** Every `SFX_*` and `MUSIC_*` constant in `game/` was checked against the tables. `SFX_CAUGHT_MON` was `SFX_KINESIS`. `SFX_EVOLVED` was `SFX_LEER`. `SFX_CHANGE_DEX_MODE` was `SFX_SING`. `SFX_CUT` was `SFX_PLACE_PUZZLE_PIECE_DOWN`. `SFX_READ_TEXT_2` was `SFX_CAUGHT_MON`. The two radio tracks were swapped for other songs, and the eight intro-movie effects plus `MUSIC_CRYSTAL_OPENING` were all wrong. Both sources agree on every shared name, so one constant serves all three cartridges.

**The launcher's mods page drove an `HTTPRequest` before it was in the tree.** `Gen2ModsPage.create` lists the page before the shell adds it, and `_fetch_next_icon` then walked the whole icon queue from there. `request()` refused once per queued icon, and the launcher rebuilds its tree on every palette change, so the errors piled up. The queue waits for `_ready` now.

**A caught Pokemon's caught-data bytes were wrong or absent.** `SetBoxmonOrEggmonCaughtData` writes the trainer's gender, the time of day plus one, and the map's landmark. The capture wrote the caught mon's gender, no time at all, and a landmark of 0, so `LevelUpHappinessMod`'s `HAPPINESS_GAINLEVELATHOME` could never fire. One `set_caught_data` is the only writer now, and `givepoke`'s gift branch reaches `LANDMARK_GIFT` through it.

## The thirteen-second freeze on starting a game

Starting a game with mods on froze for about ten seconds before the map drew. `Gen2WorldCatalog` decodes every command of every imported script, 13.5 s on Crystal for 547 rows, and `GameData.catalog()` built it lazily. Its only runtime caller is `Gen2WorldScriptRunner._catalogued`, which runs only when a mod overlay exists, so the scan landed inside the first map-entry callback of a modded session with the window frozen and nothing drawn.

It is a sidecar in the cache directory now, written at import and read back in 2 ms. Measured on the same launch path, mods on:

| Step | Before | After |
|---|---|---|
| `add_child` on the world screen | 13,023 ms | 79 ms |

The sidecar is derived rather than imported, so it is `world_catalog.json` beside the cache rather than a section of it: an absent, stale or unreadable one is rebuilt and written back, and a cache from an older build needs no re-import. The cost moves rather than disappears, and an import is about 4.6 s longer.

`tools/checks/catalog.gd` proves the sidecar and a fresh scan are the same catalog, row by row and link by link. That is what caught JSON handing back floats for ints, Strings for StringNames and `"(12, 4)"` for a `Vector2i`.

## Editor warnings

Five of the panel's GDScript entries were this repository's and are gone: four `SHADOWED_VARIABLE` in `intro_presentation.gd`, where `push`'s two parameters, a `for` iterator and `apply_bgp`'s parameter were all named after the `bgp()` and `column()` methods beside them, and one `CONFUSABLE_LOCAL_DECLARATION` where `_give_pokerus` declared `mon` in its loop and again below it.

The six left are under `user://mods`. Four of them are a stale copy of this repository's own example mod: the installed `voxel_preview` declares `api_version` 1 against a host at 9, from before those shadowings were fixed, and `mods/examples/voxel_preview/renderer.gd` has none of them. Reinstalling it from the repository clears those four.

## Checks

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3,355 passing over 152 scripts |
| Launch with mods, world screen `_ready` | 13,023 ms before, 79 ms after |
| `validate.gd -- all` | 57 topics pass, exit 0 |
| Import, all three cartridges | `layout: Layout verified.` on each |
| `replay_world.gd` | 11 routes, 0 failures, on all three |
| Story walk, three profiles | no failure, no missing map |
| Boot smoke, with and without mods | no error or warning line |
