### PR TITLE
Draw the stats and move screens in the cartridge's palettes

### DIFF
--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -604,7 +604,7 @@ func _draw_panels() -> void:
 		var gained: PackedByteArray = _new_buffer()
 		if player_hud:
 			_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, exp_pixels)
-		_show_layer(_exp_bar, gained, _data.bar_palette("exp"))
+		_show_layer(_exp_bar, gained, _data.bar_palette(GameData.EXP_BAR_PALETTE))
 
 	_draw_hud_balls()
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -53,6 +53,8 @@ var _egg_pic: Dictionary = {}
 var _tiles: Dictionary = {}
 var _bar_palettes: Dictionary = {}
 var _battle_grayscale_palette: Array = []
+var _move_screen_palette: Array = []
+var _stats_screen_palettes: Dictionary = {}
 var _player_palettes: Dictionary = {}
 var _transition_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
@@ -139,6 +141,8 @@ static func open_directory(path: String) -> GameData:
 	data._tiles = manifest.get("tiles", {})
 	data._bar_palettes = manifest.get("bar_palettes", {})
 	data._battle_grayscale_palette = manifest.get("battle_grayscale_palette", [])
+	data._move_screen_palette = manifest.get("move_screen_palette", [])
+	data._stats_screen_palettes = manifest.get("stats_screen_palettes", {})
 	data._player_palettes = manifest.get("player_palettes", {})
 	data._transition_palettes = manifest.get("transition_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
@@ -1863,8 +1867,10 @@ func footprint_tiles(number: int) -> PackedInt32Array:
 	])
 
 
-## The three bar palettes in `GetHPPal`'s own order.
+## The three bar palettes in `GetHPPal`'s own order, and `ExpBarPalette`'s key
+## beside them, both as [method bar_palette] takes them.
 const HP_BAR_PALETTE_NAMES: Array[String] = ["hp_green", "hp_yellow", "hp_red"]
+const EXP_BAR_PALETTE: String = "exp"
 
 
 ## Which HP bar palette a bar of [param lit] pixels is drawn in. The colour
@@ -2010,6 +2016,50 @@ func battle_grayscale_palette() -> PackedColorArray:
 		return PackedColorArray()
 	var out := PackedColorArray()
 	for packed: Variant in _battle_grayscale_palette:
+		out.append(Gen2Palette.from_packed(int(packed)))
+	return out
+
+
+## `_CGB_MoveList`'s background palette, `PredefPals`' `GOLDENROD`. White and
+## black on a cartridge with no pin for it, which is what the screen was drawn
+## in before it was imported.
+func move_screen_palette() -> PackedColorArray:
+	return _predef_colors(_move_screen_palette)
+
+
+## One of `StatsScreenPagePals`, the whole four-colour palette a page indicator
+## block wears. Pages past the cartridge's three are this project's own
+## ([method Gen2StatsScreenPage.page_count]), so they cycle the three.
+func stats_page_palette(page: int) -> PackedColorArray:
+	var pages: Variant = _stats_screen_palettes.get("pages", [])
+	if not pages is Array or (pages as Array).is_empty():
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return _predef_colors((pages as Array)[_stats_page_index(page, (pages as Array).size())])
+
+
+## One of `StatsScreenPals`, the colour `LoadStatsScreenPals` writes over colour
+## 0 of the HP and exp palettes, so the open page tints the lower screen. White
+## for a cartridge with no pin, which draws the page the way it was drawn before.
+func stats_page_tint(page: int) -> Color:
+	var tints: Variant = _stats_screen_palettes.get("tints", [])
+	if not tints is Array or (tints as Array).is_empty():
+		return Color.WHITE
+	return Gen2Palette.from_packed(
+		int((tints as Array)[_stats_page_index(page, (tints as Array).size())])
+	)
+
+
+## `LoadStatsScreenPals`' own `dec c`: the pink page is 1 and the table starts
+## at 0.
+func _stats_page_index(page: int, count: int) -> int:
+	return posmod(page - Gen2StatsScreenPage.PINK_PAGE, count)
+
+
+func _predef_colors(stored: Variant) -> PackedColorArray:
+	if not stored is Array or (stored as Array).size() < RomLayout.PREDEF_PALETTE_COLORS:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	var out := PackedColorArray()
+	for packed: Variant in stored as Array:
 		out.append(Gen2Palette.from_packed(int(packed)))
 	return out
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -80,7 +80,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 74
+const FORMAT_VERSION: int = 75
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -3113,7 +3113,9 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## The battle HUD's graphics, checked by the one thing they do that nothing else
-## in the section does: they count.
+## in the section does: they count. The pinned palette values every bar and page
+## is drawn with are checked here too, the stats screen's included: they are the
+## same bars and the same kind of check.
 ##
 ## A bar's fill levels are consecutive tiles each lighting one more column, so
 ## the ink climbs by exactly two pixels a step, which a wrong offset does not
@@ -3136,6 +3138,30 @@ static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictiona
 						RomLayout.BAR_PALETTE_NAMES[index], colour, wanted[colour], read,
 					],
 				}
+
+	# `StatsScreenPagePals` and `StatsScreenPals`, one run and one check: the
+	# three tints are the three page palettes' own colour 1, so a run that reads
+	# right in both halves cannot be the wrong run.
+	for index: int in RomLayout.STATS_PAGE_PALETTES:
+		var page: int = RomLayout.stats_page_palette_offset(layout, index)
+		var wanted_page: Array = RomLayout.STATS_SCREEN_PAGE_PALETTES[index]
+		for colour: int in wanted_page.size():
+			var read_page: int = rom.u16le(page + colour * Gen2Palette.COLOR_BYTES)
+			if read_page != int(wanted_page[colour]):
+				return {
+					"ok": false,
+					"message": "Stats page palette %d colour %d: expected $%04X, read $%04X." % [
+						index, colour, wanted_page[colour], read_page,
+					],
+				}
+		var tint: int = rom.u16le(RomLayout.stats_page_tint_offset(layout, index))
+		if tint != int(RomLayout.STATS_SCREEN_PAGE_TINTS[index]):
+			return {
+				"ok": false,
+				"message": "Stats page tint %d: expected $%04X, read $%04X." % [
+					index, RomLayout.STATS_SCREEN_PAGE_TINTS[index], tint,
+				],
+			}
 
 	# `BattleObjectPals`, checked the same way and for the same reason: a palette
 	# table one table out still decodes into colours.
@@ -3927,6 +3953,8 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"player_palettes": _import_player_palettes(rom, layout),
 		"transition_palettes": _import_transition_palettes(rom, layout),
 		"battle_grayscale_palette": _import_battle_grayscale_palette(rom, layout),
+		"move_screen_palette": _import_move_screen_palette(rom, layout),
+		"stats_screen_palettes": _import_stats_screen_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
 		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
 		"pc_palette": _import_pc_palette(rom, layout),
@@ -4536,13 +4564,44 @@ func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## is entered until `GetSGBLayout SCGB_BATTLE_COLORS` runs, several hundred
 ## frames later on the far side of `BattleIntroSlidingPics`.
 func _import_battle_grayscale_palette(rom: RomFile, layout: Dictionary) -> Array:
-	var at: int = RomLayout.predef_palette_offset(layout, RomLayout.PREDEFPAL_BLACKOUT)
+	return _import_predef_palette(rom, layout, RomLayout.PREDEFPAL_BLACKOUT)
+
+
+## `_CGB_MoveList`'s background palette, `PREDEFPAL_GOLDENROD`, which is the one
+## colour on the move screen that is not a bar or a mon icon.
+func _import_move_screen_palette(rom: RomFile, layout: Dictionary) -> Array:
+	return _import_predef_palette(rom, layout, RomLayout.PREDEFPAL_GOLDENROD)
+
+
+## One whole `PredefPals` entry. Empty for a layout with no pin, which is what a
+## caller that draws white and black falls back on.
+func _import_predef_palette(rom: RomFile, layout: Dictionary, index: int) -> Array:
+	var at: int = RomLayout.predef_palette_offset(layout, index)
 	if at < 0 or not rom.in_bounds(at, RomLayout.PREDEF_PALETTE_SIZE):
 		return []
 	var out: Array = []
-	for index: int in RomLayout.PREDEF_PALETTE_COLORS:
-		out.append(rom.u16le(at + index * Gen2Palette.COLOR_BYTES))
+	for colour: int in RomLayout.PREDEF_PALETTE_COLORS:
+		out.append(rom.u16le(at + colour * Gen2Palette.COLOR_BYTES))
 	return out
+
+
+## `StatsScreenPagePals` and `StatsScreenPals`: the three page indicators' whole
+## palettes, and the three colours `LoadStatsScreenPals` tints the open page's
+## background with.
+func _import_stats_screen_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var pages: Array = []
+	var tints: Array = []
+	for index: int in RomLayout.STATS_PAGE_PALETTES:
+		var page: int = RomLayout.stats_page_palette_offset(layout, index)
+		var tint: int = RomLayout.stats_page_tint_offset(layout, index)
+		if page < 0 or not rom.in_bounds(tint, Gen2Palette.COLOR_BYTES):
+			return {}
+		var colors: Array = []
+		for colour: int in RomLayout.STATS_PAGE_PALETTE_COLORS:
+			colors.append(rom.u16le(page + colour * Gen2Palette.COLOR_BYTES))
+		pages.append(colors)
+		tints.append(rom.u16le(tint))
+	return {"pages": pages, "tints": tints}
 
 
 ## The six `BattleObjectPals` an animation object is drawn with, four colours

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1129,6 +1129,9 @@ const GS_INTRO_SHELLDER_LAPRAS_PALETTES: int = 3
 ## Despite the name it is not black: $7FFF, $1CE7, $0C62, $0000, the grayscale
 ## ramp the whole battle is drawn in until `GetSGBLayout SCGB_BATTLE_COLORS`
 ## runs, which is after `BattleIntroSlidingPics`. Identical in all three dumps.
+## `_CGB_MoveList`'s own background palette, which is why the move screen is
+## the same warm gold as Goldenrod City rather than white.
+const PREDEFPAL_GOLDENROD: int = 0x10
 const PREDEFPAL_BLACKOUT: int = 0x1A
 const PREDEF_PALETTE_COLORS: int = 4
 const PREDEF_PALETTE_SIZE: int = PREDEF_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
@@ -1366,6 +1369,44 @@ const BAR_PALETTE_NAMES: Array = ["hp_green", "hp_yellow", "hp_red", "exp"]
 const BAR_PALETTES: Array = [
 	[0x3F5E, 0x02E0], [0x3F5E, 0x02BF], [0x3F5E, 0x001F], [0x3F5E, 0x7E24],
 ]
+
+## `StatsScreenPagePals` (gfx/stats/pages.pal) and `StatsScreenPals`
+## (gfx/stats/stats.pal), one contiguous run: three whole four-colour palettes
+## the stats screen's three page indicators wear, then the three single colours
+## `LoadStatsScreenPals` writes over colour 0 of `wBGPals1` palettes 0 and 2, so
+## the open page tints the whole lower screen and the exp bar's trough.
+##
+## The two labels are read as one record because the second follows the first
+## with nothing between it, which is what locates both from one pin.
+const STATS_PAGE_PALETTES: int = 3
+const STATS_PAGE_PALETTE_COLORS: int = 4
+const STATS_PAGE_TINTS_OFFSET: int = (
+	STATS_PAGE_PALETTES * STATS_PAGE_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
+)
+
+## What that run holds, the way [constant BAR_PALETTES] pins the bars': pink,
+## green and blue, identical in all three dumps.
+const STATS_SCREEN_PAGE_PALETTES: Array = [
+	[0x7FFF, 0x7E7F, 0x7DFF, 0x0000],
+	[0x7FFF, 0x3BF5, 0x03F1, 0x0000],
+	[0x7FFF, 0x7FF1, 0x7FF1, 0x0000],
+]
+const STATS_SCREEN_PAGE_TINTS: Array = [0x7E7F, 0x3BF5, 0x7FF1]
+
+
+## The offset of one `StatsScreenPagePals` entry, or -1 for a layout with no pin.
+static func stats_page_palette_offset(layout: Dictionary, index: int) -> int:
+	var base: int = int(layout.get("stats_screen_palettes", -1))
+	return -1 if base < 0 else base \
+		+ index * STATS_PAGE_PALETTE_COLORS * Gen2Palette.COLOR_BYTES
+
+
+## The offset of one `StatsScreenPals` colour, or -1 for a layout with no pin.
+static func stats_page_tint_offset(layout: Dictionary, index: int) -> int:
+	var base: int = int(layout.get("stats_screen_palettes", -1))
+	return -1 if base < 0 else base + STATS_PAGE_TINTS_OFFSET \
+		+ index * Gen2Palette.COLOR_BYTES
+
 
 ## An HP bar is green down to half and yellow down to a fifth, measured in lit
 ## pixels rather than in hit points: what colours the bar is what is drawn.
@@ -1718,6 +1759,7 @@ const GOLD_SILVER: Dictionary = {
 	"font": 0xF82F2,
 	"frames": 0xF88F2,
 	"bar_palettes": 0xAD2D,
+	"stats_screen_palettes": 0x94D3,
 	"battle_font": 0xF86F2,
 	# `FontsExtra_SolidBlackAndUpArrowGFX`' second tile, which is 1bpp here and
 	# a 2bpp sheet of its own on Crystal. Both are unique in their dump.
@@ -2200,6 +2242,7 @@ const CRYSTAL: Dictionary = {
 	"font": 0xF8200,
 	"frames": 0xF8800,
 	"bar_palettes": 0xA8BE,
+	"stats_screen_palettes": 0x8F52,
 	"battle_font": 0xF8600,
 	# `FontsExtra2_UpArrowGFX`, its own 2bpp tile here.
 	"up_arrow": {"offset": 0xF9424, "bits": 2},

--- a/game/render/move_screen_page.gd
+++ b/game/render/move_screen_page.gd
@@ -134,10 +134,7 @@ func advance() -> void:
 ## The page as pixels with the icon composed on top: it is an object, so colour
 ## 0 is transparent and it is blended rather than written into the buffer.
 func render(page: Dictionary, data: GameData) -> Image:
-	var image: Image = Gen2PicImage.from_indices(
-		draw(page), COLUMNS * TILE, ROWS * TILE,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
-	)
+	var image: Image = _background(page, data)
 	if data == null or _frame < 0:
 		return image
 	var colors: PackedColorArray = data.party_menu_icon_palette()
@@ -151,6 +148,34 @@ func render(page: Dictionary, data: GameData) -> Image:
 			ICON_AT + Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
 		)
 	return image
+
+
+## `_CGB_MoveList`: `PREDEFPAL_GOLDENROD` over the whole screen, and one
+## `FillBoxCGB` putting the Pokémon's own HP palette on the nine cells beside the
+## nickname. Its `SetHPPal` reads `wPlayerHPPal`, so the colour follows how much
+## of the HP bar the party menu behind it was lighting.
+const HP_ATTRIBUTE: Array = [11, 1, 9, 2, 1]
+
+
+static func attributes() -> PackedInt32Array:
+	return Gen2PicImage.attribute_boxes([HP_ATTRIBUTE], COLUMNS, ROWS)
+
+
+func _background(page: Dictionary, data: GameData) -> Image:
+	var indices: PackedByteArray = draw(page)
+	if data == null:
+		return Gen2PicImage.from_indices(
+			indices, COLUMNS * TILE, ROWS * TILE,
+			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		)
+	var lit: int = Gen2BattleHud.bar_pixels(
+		int(page.get("hp", 0)), int(page.get("max_hp", 0)),
+		Gen2BattleHud.HP_BAR_TILES * TILE
+	)
+	return Gen2PicImage.from_attributes(
+		indices, COLUMNS * TILE, ROWS * TILE, attributes(), COLUMNS,
+		[data.move_screen_palette(), data.bar_palette(GameData.hp_bar_palette_name(lit))]
+	)
 
 
 ## The whole 160x144 screen as palette indices. [param page] is

--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -317,16 +317,7 @@ func draw_move_list(map: PackedInt32Array, names: Array, cursor: int) -> void:
 
 ## `_CGB_PackPals`' attrmap, as one palette index per cell.
 static func attributes() -> PackedInt32Array:
-	var out := PackedInt32Array()
-	out.resize(COLUMNS * ROWS)
-	for box: Array in ATTRIBUTES:
-		for row: int in int(box[3]):
-			for column: int in int(box[2]):
-				var x: int = int(box[0]) + column
-				var y: int = int(box[1]) + row
-				if x < COLUMNS and y < ROWS:
-					out[y * COLUMNS + x] = int(box[4])
-	return out
+	return Gen2PicImage.attribute_boxes(ATTRIBUTES, COLUMNS, ROWS)
 
 
 ## The whole screen as pixels. [param female] is Kris's pack and her own
@@ -339,23 +330,13 @@ func image(
 	var palettes: Array = []
 	for slot: int in RomLayout.PACK_PALETTES:
 		var colors: PackedColorArray = data.pack_palette(slot, female)
-		palettes.append(colors if not colors.is_empty() else data.pack_palette(slot))
-	var out := Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
-	for row: int in ROWS:
-		for column: int in COLUMNS:
-			var palette: PackedColorArray = palettes[
-				clampi(slots[row * COLUMNS + column], 0, palettes.size() - 1)
-			]
-			if palette.is_empty():
-				continue
-			for y: int in TILE:
-				for x: int in TILE:
-					var at_x: int = column * TILE + x
-					var at_y: int = row * TILE + y
-					out.set_pixel(at_x, at_y, palette[
-						clampi(indices[at_y * Gen2Screen.WIDTH + at_x], 0, palette.size() - 1)
-					])
-	return out
+		if colors.is_empty():
+			colors = data.pack_palette(slot)
+		palettes.append(colors if not colors.is_empty() \
+			else Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])))
+	return Gen2PicImage.from_attributes(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, slots, COLUMNS, palettes
+	)
 
 
 ## Resolves every tile number to pixels: the menu sheet, the pocket's own

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -46,6 +46,71 @@ static func from_indices(
 	return Image.create_from_data(width, height, false, Image.FORMAT_RGBA8, pixels)
 
 
+## An image from a row-major index buffer plus `wAttrmap`: one palette index per
+## tile, so a screen the hardware draws in several palettes is one buffer here
+## too rather than a layer per colour. [param slots] is [param columns] wide and
+## row-major, and a slot naming no palette falls back on the first.
+##
+## `FillBoxCGB` and `ByteFill` over an attrmap `WipeAttrmap` cleared are what
+## every `_CGB_*` layout writes, so a caller's own `attributes()` is that list of
+## boxes flattened once.
+static func from_attributes(
+	indices: PackedByteArray,
+	width: int,
+	height: int,
+	slots: PackedInt32Array,
+	columns: int,
+	palettes: Array
+) -> Image:
+	if palettes.is_empty():
+		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
+	if width <= 0 or height <= 0 or indices.size() < width * height:
+		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
+
+	var lookups: Array[PackedByteArray] = []
+	for palette: Variant in palettes:
+		lookups.append(_lookup(palette as PackedColorArray, false))
+
+	var tile: int = Gen2Font.TILE
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(width * height * CHANNELS)
+	for y: int in height:
+		@warning_ignore("integer_division")
+		var row: int = (y / tile) * columns
+		for x: int in width:
+			@warning_ignore("integer_division")
+			var slot: int = row + x / tile
+			var lookup: PackedByteArray = lookups[
+				clampi(slots[slot] if slot < slots.size() else 0, 0, lookups.size() - 1)
+			]
+			var at: int = int(indices[y * width + x]) * CHANNELS
+			var to: int = (y * width + x) * CHANNELS
+			pixels[to] = lookup[at]
+			pixels[to + 1] = lookup[at + 1]
+			pixels[to + 2] = lookup[at + 2]
+			pixels[to + 3] = lookup[at + 3]
+
+	return Image.create_from_data(width, height, false, Image.FORMAT_RGBA8, pixels)
+
+
+## An attrmap from a list of `FillBoxCGB` boxes, each (x, y, width, height,
+## palette) over the zeroes `WipeAttrmap` leaves.
+static func attribute_boxes(
+	boxes: Array, columns: int, rows: int
+) -> PackedInt32Array:
+	var out := PackedInt32Array()
+	out.resize(columns * rows)
+	for box: Variant in boxes:
+		var cells: Array = box as Array
+		for row: int in int(cells[3]):
+			for column: int in int(cells[2]):
+				var x: int = int(cells[0]) + column
+				var y: int = int(cells[1]) + row
+				if x >= 0 and x < columns and y >= 0 and y < rows:
+					out[y * columns + x] = int(cells[4])
+	return out
+
+
 ## One cell out of a pic atlas, cropped to the pic's real size.
 ## [param pic] is [method GameData.species_pic]'s answer: which atlas, which slot
 ## and how much of the cell is filled. A cell is the size of the largest pic of

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -277,33 +277,81 @@ func draw(page: Dictionary) -> PackedByteArray:
 	return indices
 
 
-## The page as pixels, with the HP bar blended over it in its own colour: the
-## hardware gives every tile a palette and one index buffer carries one, which
-## is how [Gen2PartyMenuPage] draws the same bar.
+## `_CGB_StatsScreenHPPals`' attrmap, as (x, y, width, height, palette) boxes
+## over the zeroes `WipeAttrmap` leaves: the upper half on the mon's own palette,
+## the exp bar's ten cells on the exp palette, and one palette per 2x2 page
+## indicator from slot [constant FIRST_PAGE_SLOT] on. The source's three blocks
+## are three `FillBoxCGB` calls at fixed columns; here they follow
+## [method page_indicators], so a registered page's block is coloured like the
+## cartridge's are.
+const MON_ROWS: int = 8
+const EXP_ATTR_AT: Vector2i = Vector2i(10, 16)
+const EXP_ATTR_WIDTH: int = 10
+const MON_SLOT: int = 1
+const EXP_SLOT: int = 2
+const FIRST_PAGE_SLOT: int = 3
+
+
+static func attributes(count: int = NUM_PAGES) -> PackedInt32Array:
+	var boxes: Array = [
+		[0, 0, COLUMNS, MON_ROWS, MON_SLOT],
+		[EXP_ATTR_AT.x, EXP_ATTR_AT.y, EXP_ATTR_WIDTH, 1, EXP_SLOT],
+	]
+	var indicators: Array[Vector2i] = page_indicators(count)
+	for index: int in indicators.size():
+		boxes.append([
+			indicators[index].x, indicators[index].y, PAGE_INDICATOR_STEP,
+			PAGE_INDICATOR_STEP, FIRST_PAGE_SLOT + index,
+		])
+	return Gen2PicImage.attribute_boxes(boxes, COLUMNS, ROWS)
+
+
+## The page as pixels. The hardware gives every tile a palette and one index
+## buffer carries one, so the HP bar, the exp bar, the front pic's own square and
+## the three page indicators are the attrmap rather than four blended layers.
+## Slot 0 is the HP palette, which is what `WipeAttrmap` leaves every other cell on.
+##
+## `LoadStatsScreenPals` writes the open page's colour over colour 0 of the HP
+## and exp palettes, which is what tints the lower screen pink, green or blue.
+## An egg never reaches it: `EggStatsInit` jumps past `StatsScreen_LoadPage`, so
+## its screen keeps the white both palettes came in with.
 func render(page: Dictionary, data: GameData) -> Image:
-	var image: Image = Gen2PicImage.from_indices(
-		draw(page), COLUMNS * TILE, ROWS * TILE,
-		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
-	)
-	if data == null or bool(page.get("egg", false)) \
-		or int(page.get("page", PINK_PAGE)) != PINK_PAGE:
-		return image
+	var indices: PackedByteArray = draw(page)
 	var width: int = COLUMNS * TILE
-	var buffer := PackedByteArray()
-	buffer.resize(width * ROWS * TILE)
+	if data == null:
+		return Gen2PicImage.from_indices(
+			indices, width, ROWS * TILE,
+			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		)
+
+	var egg: bool = bool(page.get("egg", false))
+	var number: int = int(page.get("page", PINK_PAGE))
 	var hp: int = int(page.get("hp", 0))
-	var max_hp: int = int(page.get("max_hp", 0))
-	hud.draw_hp_bar(buffer, width, HP_BAR, hp, max_hp)
-	var lit: int = Gen2BattleHud.bar_pixels(hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE)
-	var fill: Image = Gen2PicImage.from_indices(
-		buffer, width, ROWS * TILE,
-		data.bar_palette(GameData.hp_bar_palette_name(lit)), true
+	var lit: int = Gen2BattleHud.bar_pixels(
+		hp, int(page.get("max_hp", 0)), Gen2BattleHud.HP_BAR_TILES * TILE
 	)
-	var at := Vector2i((HP_BAR.x + 2) * TILE, HP_BAR.y * TILE)
-	image.blend_rect(
-		fill, Rect2i(at, Vector2i(Gen2BattleHud.HP_BAR_TILES * TILE, TILE)), at
+	var tint: Color = Color.WHITE if egg else data.stats_page_tint(number)
+	var palettes: Array = [
+		_tinted(data.bar_palette(GameData.hp_bar_palette_name(lit)), tint),
+		data.egg_palette() if egg \
+			else data.palette(int(page.get("species", 0)), bool(page.get("shiny", false))),
+		_tinted(data.bar_palette(GameData.EXP_BAR_PALETTE), tint),
+	]
+	var count: int = page_count()
+	for index: int in count:
+		palettes.append(data.stats_page_palette(PINK_PAGE + index))
+	return Gen2PicImage.from_attributes(
+		indices, width, ROWS * TILE, attributes(count), COLUMNS, palettes
 	)
-	return image
+
+
+## `LoadStatsScreenPals`' two writes, which replace colour 0 and nothing else.
+func _tinted(palette: PackedColorArray, colour: Color) -> PackedColorArray:
+	if palette.is_empty():
+		return palette
+	var out: PackedColorArray = palette.duplicate()
+	out[0] = colour
+	return out
 
 
 ## `PrintTempMonStats`: the five names down one column and the five numbers down

--- a/game/save/move_screen.gd
+++ b/game/save/move_screen.gd
@@ -171,8 +171,14 @@ func snapshot() -> Dictionary:
 			"type_name": _data.type_name(int(record.get("type", 0))),
 			"description": String(record.get("description", "")),
 		})
+	## `SetUpMoveScreenBG`'s `SetHPPal` colours the box beside the nickname, and
+	## the pixel count it reads is `wPlayerHPPal`'s last writer rather than a
+	## fresh one, which in play is this Pokémon's own bar in the party list.
+	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
 	return {
 		"species": mon.species,
+		"hp": mon.hp,
+		"max_hp": battle_mon.max_hp() if battle_mon != null else 0,
 		"nickname": mon.nickname if not mon.nickname.is_empty() \
 			else String(_data.species(mon.species).get("name", "")),
 		"level": mon.level,

--- a/tests/unit/test_pic_image.gd
+++ b/tests/unit/test_pic_image.gd
@@ -299,3 +299,40 @@ func test_a_pic_layer_claims_only_its_own_sheets_cells() -> void:
 	)
 	assert_false(Gen2BattleRenderer.claims_tile(banked, true, true, square, banked))
 	assert_false(Gen2BattleRenderer.claims_tile(-1, false, false, square, banked))
+
+
+## `WipeAttrmap` then `FillBoxCGB`: a box is (x, y, width, height, palette) and
+## anything it does not reach stays on palette 0. A box running off the screen is
+## clipped rather than wrapping, which is what `FillBoxCGB`'s own row step does.
+func test_an_attrmap_is_its_boxes_over_the_zeroes_wipeattrmap_leaves() -> void:
+	var slots: PackedInt32Array = Gen2PicImage.attribute_boxes(
+		[[1, 0, 2, 2, 3], [3, 1, 4, 1, 5]], 4, 3
+	)
+	assert_eq(Array(slots), [0, 3, 3, 0, 0, 3, 3, 5, 0, 0, 0, 0])
+
+
+## One index buffer, one palette per tile: the hardware's own shape, and what
+## keeps the stats screen's bars, front pic and page indicators out of layers of
+## their own.
+func test_a_tile_is_drawn_in_the_palette_its_attrmap_slot_names() -> void:
+	var tile: int = Gen2Font.TILE
+	var indices := PackedByteArray()
+	indices.resize(tile * 2 * tile)
+	for x: int in tile * 2:
+		indices[x] = 1
+	var image: Image = Gen2PicImage.from_attributes(
+		indices, tile * 2, tile, Gen2PicImage.attribute_boxes([[1, 0, 1, 1, 1]], 2, 1), 2,
+		[
+			PackedColorArray([Color.WHITE, Color.RED, Color.BLACK, Color.BLACK]),
+			PackedColorArray([Color.WHITE, Color.BLUE, Color.BLACK, Color.BLACK]),
+		]
+	)
+	assert_eq(image.get_pixel(0, 0), Color.RED)
+	assert_eq(image.get_pixel(tile, 0), Color.BLUE)
+	# A slot naming a palette that is not there falls back on the first rather
+	# than reading past the list.
+	var clamped: Image = Gen2PicImage.from_attributes(
+		indices, tile * 2, tile, Gen2PicImage.attribute_boxes([[1, 0, 1, 1, 9]], 2, 1), 2,
+		[PackedColorArray([Color.WHITE, Color.RED, Color.BLACK, Color.BLACK])]
+	)
+	assert_eq(clamped.get_pixel(tile, 0), Color.RED)

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -700,6 +700,7 @@ func _battle_dump() -> PackedByteArray:
 	_write_hud(data, int(_layout["player_hud"]), RomLayout.PLAYER_HUD_TILES)
 	_write_bar_palettes(data)
 	_write_battle_object_palettes(data)
+	_write_stats_screen_palettes(data)
 	_write_stats_tiles(data)
 	return data
 
@@ -725,6 +726,19 @@ func _write_bar_palettes(data: PackedByteArray) -> void:
 	for index: int in RomLayout.BAR_PALETTE_NAMES.size():
 		var at: int = RomLayout.bar_palette_offset(_layout, index)
 		_write_palette(data, at, RomLayout.BAR_PALETTES[index])
+
+
+## `StatsScreenPagePals` and the `StatsScreenPals` tints behind it, one run.
+func _write_stats_screen_palettes(data: PackedByteArray) -> void:
+	for index: int in RomLayout.STATS_PAGE_PALETTES:
+		_write_palette(
+			data, RomLayout.stats_page_palette_offset(_layout, index),
+			RomLayout.STATS_SCREEN_PAGE_PALETTES[index]
+		)
+		_write_palette(
+			data, RomLayout.stats_page_tint_offset(_layout, index),
+			[RomLayout.STATS_SCREEN_PAGE_TINTS[index]]
+		)
 
 
 ## The six `BattleObjectPals`, checked the same way and for the same reason.
@@ -780,6 +794,17 @@ func _write_hud(data: PackedByteArray, at: int, tiles: int) -> void:
 func test_battle_graphics_that_count_up_verify() -> void:
 	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(_battle_dump()), _layout)
 	assert_true(result["ok"], result["message"])
+
+
+## The stats screen's own run, checked the same way: its tints are the page
+## palettes' colour 1, so a run right in one half and wrong in the other is not
+## the run.
+func test_a_stats_page_palette_that_is_not_the_pinned_one_fails() -> void:
+	var data: PackedByteArray = _battle_dump()
+	data[RomLayout.stats_page_tint_offset(_layout, 1)] = 0x00
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(String(result["message"]), "Stats page tint 1")
 
 
 ## A palette table one table out still decodes into colours, so the check is the

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -475,6 +475,37 @@ func test_the_snapshot_carries_the_dvs_and_stat_experience_a_page_cannot_reach()
 	assert_eq(int(mon.stat_exp["attack"]), 25600)
 
 
+## `_CGB_StatsScreenHPPals`' attrmap: the upper eight rows on the mon's own
+## palette, the exp bar's ten cells on the exp palette, one slot per page
+## indicator, and everything else on the HP palette `WipeAttrmap` leaves. The
+## source's three blocks are fixed columns; a registered page moves the run, so
+## the attrmap follows `page_indicators` rather than repeating them.
+func test_the_stats_screen_attrmap_colours_the_upper_half_the_bars_and_the_pages() -> void:
+	var columns: int = Gen2StatsScreenPage.COLUMNS
+	var slots: PackedInt32Array = Gen2StatsScreenPage.attributes()
+	assert_eq(slots[7 * columns + 19], Gen2StatsScreenPage.MON_SLOT, "the divider row")
+	assert_eq(slots[8 * columns], 0, "the row under it is the HP palette's")
+	assert_eq(slots[16 * columns + 10], Gen2StatsScreenPage.EXP_SLOT)
+	assert_eq(slots[16 * columns + 9], 0, "the cell before the exp bar's cap")
+	for index: int in Gen2StatsScreenPage.NUM_PAGES:
+		var at: Vector2i = Gen2StatsScreenPage.page_indicators(
+			Gen2StatsScreenPage.NUM_PAGES
+		)[index]
+		assert_eq(
+			slots[at.y * columns + at.x], Gen2StatsScreenPage.FIRST_PAGE_SLOT + index
+		)
+	var four: PackedInt32Array = Gen2StatsScreenPage.attributes(
+		Gen2StatsScreenPage.NUM_PAGES + 1
+	)
+	var moved: Vector2i = Gen2StatsScreenPage.page_indicators(
+		Gen2StatsScreenPage.NUM_PAGES + 1
+	)[0]
+	assert_eq(
+		four[moved.y * columns + moved.x], Gen2StatsScreenPage.FIRST_PAGE_SLOT,
+		"a fourth page moves the run left and takes the first slot with it"
+	)
+
+
 ## `.d_up` and `.d_down` neither wrap nor reach past the party, and each reload
 ## is a `PlayMonCry2`. The first member is poisoned rather than asleep or frozen,
 ## so `CheckFaintedFrzSlp` lets both cries through.

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -364,11 +364,13 @@ func _verify_screen(game_id: StringName, data: GameData) -> void:
 			0, "Restores HP.", name_cells
 		)
 		var image: Image = page.image(data, map, pocket)
-		_r.check(
+		if not _r.check(
 			image != null and image.get_width() == Gen2Screen.WIDTH
 				and image.get_height() == Gen2Screen.HEIGHT,
 			"%s: pocket %d did not compose a screen." % [game_id, pocket]
-		)
+		):
+			continue
+		_check_pack_palettes(game_id, data, image, pocket)
 	_r.check(
 		names.size() == RomLayout.PACK_POCKETS,
 		"%s: the four pocket names are %d distinct pieces." % [game_id, names.size()]
@@ -383,6 +385,57 @@ func _verify_screen(game_id: StringName, data: GameData) -> void:
 	print("%s: four pockets drawn, %d palettes, female pack %s." % [
 		game_id, RomLayout.PACK_PALETTES, "yes" if female else "no",
 	])
+
+
+## `_CGB_PackPals`' five `FillBoxCGB` calls, transcribed from the source rather
+## than read off [Gen2PackPage]: a colour a cell is drawn in has to come from the
+## palette its own slot names. A size assertion passes on a screen composed in
+## one palette, which is what the pack looked like before the attrmap was drawn
+## through.
+const SOURCE_PACK_BOXES: Array = [
+	[0, 0, 10, 1, 1],
+	[10, 0, 10, 1, 2],
+	[7, 2, 1, 9, 3],
+	[0, 7, 5, 3, 4],
+	[0, 3, 5, 3, 5],
+]
+
+
+func _check_pack_palettes(
+	game_id: StringName, data: GameData, image: Image, pocket: int
+) -> void:
+	var columns: int = Gen2PackPage.COLUMNS
+	var slots: PackedInt32Array = Gen2PicImage.attribute_boxes(
+		SOURCE_PACK_BOXES, columns, Gen2PackPage.ROWS
+	)
+	if not _r.check(
+		Array(Gen2PackPage.attributes()) == Array(slots),
+		"%s: the pack's attrmap is not `_CGB_PackPals`'." % game_id
+	):
+		return
+	var palettes: Array = []
+	for slot: int in RomLayout.PACK_PALETTES:
+		var colours := PackedColorArray()
+		for colour: Color in data.pack_palette(slot):
+			colours.append(Color8(
+				int(roundf(colour.r * 255.0)), int(roundf(colour.g * 255.0)),
+				int(roundf(colour.b * 255.0)), int(roundf(colour.a * 255.0))
+			))
+		palettes.append(colours)
+	for row: int in Gen2PackPage.ROWS:
+		for column: int in columns:
+			var allowed: PackedColorArray = palettes[slots[row * columns + column]]
+			for y: int in Gen2Font.TILE:
+				for x: int in Gen2Font.TILE:
+					var at := Vector2i(
+						column * Gen2Font.TILE + x, row * Gen2Font.TILE + y
+					)
+					if allowed.has(image.get_pixel(at.x, at.y)):
+						continue
+					_r.check(false, "%s: pocket %d cell %d,%d is off its own palette." % [
+						game_id, pocket, column, row,
+					])
+					return
 
 
 ## `PrintItemDescription` and `PrintMoveDescription`: every row the pack can

--- a/tools/checks/screen_palettes.gd
+++ b/tools/checks/screen_palettes.gd
@@ -1,0 +1,256 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies `_CGB_StatsScreenHPPals` and `_CGB_MoveList` against freshly imported
+## real caches: every species, every page, on all three cartridges.
+##
+## What a sampled case cannot say: the two screens are drawn in six palettes at
+## once and every one of them is a different table. A page drawn in one palette
+## is right about the text and wrong about everything else, and a slot one out
+## still produces a legible screen, so what is checked here is CONTAINMENT: the
+## colours a region is drawn in have to come from the palette its attrmap slot
+## names and from no other. The regions differ per species (the mon palette),
+## per page (the tint) and per hit points (the HP palette), which is why the
+## sweep is the corpus rather than one Pokémon.
+##
+## `LoadStatsScreenPals` writes the open page's colour over colour 0 of the HP
+## and exp palettes alone, so the tint is checked as an identity as well: the
+## lower half's background IS `StatsScreenPals`' own entry for that page.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- screen_palettes
+
+## `data/pokemon/base_stats/`'s own range.
+const FIRST_SPECIES: int = 1
+const LAST_SPECIES: int = 251
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = Gen2StatsScreenPage.COLUMNS
+const ROWS: int = Gen2StatsScreenPage.ROWS
+
+## `_CGB_StatsScreenHPPals`' own `hlcoord` and `lb bc` operands, transcribed
+## here rather than taken from the page: a check that reads the implementation's
+## own attrmap agrees with it however wrong it is. `FillBoxCGB` takes (rows,
+## columns) and `ByteFill` a length, so the exp bar's ten cells are one row.
+const SOURCE_BOXES: Array = [
+	[0, 0, 20, 8, 1],
+	[10, 16, 10, 1, 2],
+	[13, 5, 2, 2, 3],
+	[15, 5, 2, 2, 4],
+	[17, 5, 2, 2, 5],
+]
+
+## `_CGB_MoveList`'s one `FillBoxCGB`, the same way.
+const SOURCE_MOVE_BOXES: Array = [[11, 1, 9, 2, 1]]
+
+## Hit points to draw each page with, so all three `GetHPPal` bands are swept:
+## full is green, `HP_YELLOW_PIXELS` of the bar is yellow and one is red.
+const HP_FRACTIONS: Array[float] = [1.0, 0.3, 0.05]
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var page: Gen2StatsScreenPage = Gen2StatsScreenPage.from_data(_r.data)
+	if not _r.check(page != null, "the stats screen page will not build."):
+		return
+	var pages: int = Gen2StatsScreenPage.page_count()
+	if not _r.check(
+		pages == Gen2StatsScreenPage.NUM_PAGES,
+		"a mod is registering stats pages, so the source's attrmap is not the one drawn."
+	):
+		return
+	if not _r.check(
+		Array(Gen2StatsScreenPage.attributes(pages)) == Array(_source_slots()),
+		"the stats screen's attrmap is not `_CGB_StatsScreenHPPals`'."
+	):
+		return
+	var drawn: int = 0
+	for species: int in range(FIRST_SPECIES, LAST_SPECIES + 1):
+		for number: int in range(
+			Gen2StatsScreenPage.PINK_PAGE, Gen2StatsScreenPage.PINK_PAGE + pages
+		):
+			var hp: float = HP_FRACTIONS[(species + number) % HP_FRACTIONS.size()]
+			if not _check_page(page, species, number, hp, pages):
+				return
+			drawn += 1
+	_check_egg(page)
+	_check_move_screen()
+	_r.note("screen_palettes %d stats pages over %d species and %d pages" % [
+		drawn, LAST_SPECIES - FIRST_SPECIES + 1, pages,
+	])
+
+
+## One page, region by region. Returns false on the first failure so a broken
+## rule reports once rather than 753 times.
+func _check_page(
+	page: Gen2StatsScreenPage, species: int, number: int, hp_fraction: float, pages: int
+) -> bool:
+	var max_hp: int = 100
+	var hp: int = maxi(int(round(max_hp * hp_fraction)), 1)
+	var snapshot: Dictionary = {
+		"egg": false, "page": number, "species": species, "dex_number": species,
+		"species_name": "X", "nickname": "X", "level": 5, "hp": hp, "max_hp": max_hp,
+		"moves": [], "types": ["NORMAL"], "item_name": "---",
+	}
+	var image: Image = page.render(snapshot, _r.data)
+	if not _r.check(image != null, "species %d page %d draws nothing." % [species, number]):
+		return false
+
+	var tint: Color = _r.data.stats_page_tint(number)
+	var palettes: Array = _palettes(species, hp, max_hp, tint, pages)
+	var slots: PackedInt32Array = _source_slots()
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var slot: int = slots[row * COLUMNS + column]
+			var allowed: PackedColorArray = palettes[slot]
+			for y: int in TILE:
+				for x: int in TILE:
+					var colour: Color = image.get_pixel(column * TILE + x, row * TILE + y)
+					if allowed.has(colour):
+						continue
+					_r.check(false, (
+						"species %d page %d cell %d,%d is %s, "
+						+ "which palette %d does not hold."
+					) % [species, number, column, row, colour, slot])
+					return false
+
+	## The identity `LoadStatsScreenPals` writes: colour 0 of the HP palette, and
+	## so the background of every cell the attrmap left on slot 0.
+	if not _r.check(
+		image.get_pixel(0, (Gen2StatsScreenPage.MON_ROWS + 1) * TILE) == _quantised(
+			PackedColorArray([tint]))[0],
+		"species %d page %d does not tint the lower half." % [species, number]
+	):
+		return false
+	return true
+
+
+## The palette per attrmap slot, built here off [GameData] rather than taken from
+## the page, so a page that names the wrong table has nothing to agree with.
+func _palettes(
+	species: int, hp: int, max_hp: int, tint: Color, pages: int
+) -> Array:
+	var lit: int = Gen2BattleHud.bar_pixels(hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE)
+	var out: Array = [
+		_tinted(_r.data.bar_palette(GameData.hp_bar_palette_name(lit)), tint),
+		_quantised(_r.data.palette(species) if species > 0 else _r.data.egg_palette()),
+		_tinted(_r.data.bar_palette(GameData.EXP_BAR_PALETTE), tint),
+	]
+	for index: int in pages:
+		out.append(_quantised(
+			_r.data.stats_page_palette(Gen2StatsScreenPage.PINK_PAGE + index)
+		))
+	return out
+
+
+func _tinted(palette: PackedColorArray, colour: Color) -> PackedColorArray:
+	var out: PackedColorArray = palette.duplicate()
+	if not out.is_empty():
+		out[0] = colour
+	return _quantised(out)
+
+
+## The source's own boxes, flattened the way `WipeAttrmap` plus `FillBoxCGB`
+## leaves them.
+func _source_slots() -> PackedInt32Array:
+	return Gen2PicImage.attribute_boxes(SOURCE_BOXES, COLUMNS, ROWS)
+
+
+## A 15-bit colour is stored as a float and read back through an eight-bit
+## image, so the comparison is made where the picture is: `Color8`'s own
+## rounding, which is what [method Gen2PicImage.from_attributes] wrote.
+func _quantised(palette: PackedColorArray) -> PackedColorArray:
+	var out := PackedColorArray()
+	for colour: Color in palette:
+		out.append(Color8(
+			int(roundf(colour.r * 255.0)), int(roundf(colour.g * 255.0)),
+			int(roundf(colour.b * 255.0)), int(roundf(colour.a * 255.0))
+		))
+	return out
+
+
+## `EggStatsInit` jumps past `StatsScreen_LoadPage`, so an egg reaches
+## `LoadStatsScreenPals` on no cartridge and its screen keeps the white both
+## palettes were loaded with. The picture is the egg's own palette, not a
+## species'.
+func _check_egg(page: Gen2StatsScreenPage) -> void:
+	var image: Image = page.render(
+		{"egg": true, "page": Gen2StatsScreenPage.PINK_PAGE, "species": 0, "egg_message": "X"},
+		_r.data
+	)
+	if not _r.check(image != null, "the egg stats screen draws nothing."):
+		return
+	_r.check(
+		image.get_pixel(0, (Gen2StatsScreenPage.MON_ROWS + 1) * TILE) == Color.WHITE,
+		"an egg's stats screen is tinted, and no cartridge tints one."
+	)
+	var slots: PackedInt32Array = _source_slots()
+	var egg: PackedColorArray = _quantised(_r.data.egg_palette())
+	for row: int in Gen2StatsScreenPage.MON_ROWS:
+		for column: int in COLUMNS:
+			if slots[row * COLUMNS + column] != Gen2StatsScreenPage.MON_SLOT:
+				continue
+			for y: int in TILE:
+				for x: int in TILE:
+					if egg.has(image.get_pixel(column * TILE + x, row * TILE + y)):
+						continue
+					_r.check(false, "the egg screen's cell %d,%d is not the egg's own colour." % [
+						column, row,
+					])
+					return
+
+
+## `_CGB_MoveList`: `PREDEFPAL_GOLDENROD` everywhere and the Pokémon's own HP
+## palette on the nine cells beside the nickname.
+func _check_move_screen() -> void:
+	var page: Gen2MoveScreenPage = Gen2MoveScreenPage.from_data(_r.data)
+	if not _r.check(page != null, "the move screen page will not build."):
+		return
+	var goldenrod: PackedColorArray = _quantised(_r.data.move_screen_palette())
+	_r.check(
+		goldenrod.size() == RomLayout.PREDEF_PALETTE_COLORS,
+		"the move screen's palette is %d colours, not %d." % [
+			goldenrod.size(), RomLayout.PREDEF_PALETTE_COLORS,
+		]
+	)
+	var image: Image = page.render(
+		{
+			"species": FIRST_SPECIES, "nickname": "X", "level": 5, "hp": 1, "max_hp": 100,
+			"moves": [], "cursor": 0, "held": -1,
+		},
+		_r.data
+	)
+	if not _r.check(image != null, "the move screen draws nothing."):
+		return
+	if not _r.check(
+		Array(Gen2MoveScreenPage.attributes()) == Array(
+			Gen2PicImage.attribute_boxes(SOURCE_MOVE_BOXES, COLUMNS, ROWS)
+		),
+		"the move screen's attrmap is not `_CGB_MoveList`'."
+	):
+		return
+	var slots: PackedInt32Array = Gen2PicImage.attribute_boxes(
+		SOURCE_MOVE_BOXES, COLUMNS, ROWS
+	)
+	var hp: PackedColorArray = _quantised(_r.data.bar_palette(
+		GameData.hp_bar_palette_name(Gen2BattleHud.bar_pixels(
+			1, 100, Gen2BattleHud.HP_BAR_TILES * TILE
+		))
+	))
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var allowed: PackedColorArray = hp \
+				if slots[row * COLUMNS + column] == 1 else goldenrod
+			for y: int in TILE:
+				for x: int in TILE:
+					var colour: Color = image.get_pixel(column * TILE + x, row * TILE + y)
+					if allowed.has(colour):
+						continue
+					_r.check(false, "move screen cell %d,%d is %s, off its own palette." % [
+						column, row, colour,
+					])
+					return

--- a/tools/checks/screen_palettes.gd.uid
+++ b/tools/checks/screen_palettes.gd.uid
@@ -1,0 +1,1 @@
+uid://b363c27doy2du

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -21,6 +21,8 @@ extends SceneTree
 
 const FRAMES_BEFORE_CAPTURE: int = 6
 
+const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
+
 ## Item numbers from `constants/item_constants.asm`, the three rows the pack's
 ## own submenu split is worth photographing.
 const ITEM_POTION: int = 0x12
@@ -37,6 +39,10 @@ var _what: String = "party"
 var _programs: Array[String] = [""]
 var _at: int = 0
 var _screen: Control = null
+## The hardware screen the start menu draws into, handed over once both it and
+## the menu are in the tree.
+var _hardware: Gen2Screen = null
+var _menu: Gen2StartMenuScreen = null
 var _elapsed: int = 0
 
 
@@ -73,8 +79,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	root.add_child(_screen)
-	# Both are window-resolution panels rather than hardware-tile screens, so
-	# they are given the whole window the way a scene root would be.
+	# The party and box views are window-resolution panels, so they are given the
+	# whole window the way a scene root would be; the start menu is a hardware
+	# screen inside one and takes its own layer once both are in the tree.
 	_screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	current_scene = _screen
 
@@ -92,7 +99,7 @@ func _build(data: GameData) -> Control:
 		boxes.set_context(data, save, false, true)
 		return boxes
 	if _what == "pack" or _what == "select":
-		return _build_pack(data, save)
+		return _wrap(_build_pack(data, save))
 	## The stats screen's mod seam has no player until a mod is installed, so the
 	## shipped example's own page is registered here: this is the one place the
 	## fourth page and its relaid-out indicators can be looked at.
@@ -134,17 +141,39 @@ func _build_pack(data: GameData, save: Gen2SaveData) -> Control:
 	return menu
 
 
+## `Gen2StartMenuScreen` draws into a [Gen2Screen] the host hands over and into
+## nothing else, so a driver that adds it to a tree and hands it none photographs
+## an empty window. The world screen owns one; here it is built beside the menu.
+func _wrap(menu: Control) -> Control:
+	if menu == null:
+		return null
+	var host := Control.new()
+	_menu = menu as Gen2StartMenuScreen
+	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
+	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.add_child(screen)
+	host.add_child(menu)
+	_hardware = screen
+	return host
+
+
 func _drive(program: String) -> void:
 	for key: String in program.split(",", false):
 		var button: Variant = BUTTONS.get(key.strip_edges().to_lower(), null)
 		if button == null:
 			push_error("Unknown button %s" % key)
 			continue
-		_screen.handle_button(int(button))
+		var target: Object = _menu if _menu != null else _screen
+		target.call("handle_button", int(button))
 
 
 func _process(_delta: float) -> bool:
 	_elapsed += 1
+	## `Gen2Screen`'s own layers are `@onready`, so the menu is handed the screen
+	## on the first frame rather than while the tree is still being built.
+	if _menu != null and _hardware != null:
+		_menu.set_screen(_hardware)
+		_hardware = null
 	if _elapsed < FRAMES_BEFORE_CAPTURE:
 		return false
 	if _at >= _programs.size():

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -36,6 +36,7 @@ const GROUPS: Dictionary = {
 	&"art": [
 		&"intro_movie", &"gs_intro", &"credits", &"town_map", &"battle_anims",
 		&"overworld_effects", &"party_icons", &"pokepic", &"map_name_sign",
+		&"screen_palettes",
 	],
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",


### PR DESCRIPTION
The stats screen and the move screen were drawn in one palette, black on white, with the HP bar blended over the top as a second image. The hardware gives every tile a palette and these two screens use six.

`_CGB_StatsScreenHPPals` writes the six and an attrmap. The upper eight rows take the Pokemon's own palette. The exp bar's ten cells take the exp palette. Each 2x2 page indicator takes one of `StatsScreenPagePals`. `LoadStatsScreenPals` then writes the open page's colour over colour 0 of the HP and exp palettes, and that is what tints the whole lower screen pink, green or blue.

`_CGB_MoveList` is `PREDEFPAL_GOLDENROD` plus the HP palette on the nine cells beside the nickname. Its colour 0 is white, so that screen looks the same and is now drawn off the table instead of a hardcoded pair.

An egg keeps white. `EggStatsInit` jumps straight to `EggStatsScreen` and never reaches `StatsScreen_LoadPage`, so `LoadStatsScreenPals` runs on no cartridge for one.

## The shared part

`Gen2PicImage.from_attributes` and `attribute_boxes` are one shape for any screen drawn in several palettes: one index buffer, one palette index per tile, boxes over the zeroes `WipeAttrmap` leaves. `Gen2PackPage` had its own copy of that rule and goes through the shared one now, which also drops its per-pixel loop. The stats screen's HP bar is no longer a blended second image, because palette 0 is the HP palette.

## Import

Cache format 75 carries `StatsScreenPagePals`, `StatsScreenPals` and `PredefPals`' GOLDENROD entry. One pin per profile covers a run the two labels share. The values are the check for the offset, and the three tints are the three page palettes' own colour 1, so a run right in one half cannot be wrong in the other. All three cartridges re-import and report `layout: Layout verified.`

## Checks

`tools/checks/screen_palettes.gd` sweeps 753 stats pages per cartridge: every species against every page, across all three HP colour bands. It asserts that a colour a cell is drawn in comes from the palette its attrmap slot names. The attrmap it checks against is transcribed from the source in the check file, not read off the page, which is what makes it fail when the page is wrong.

`tools/checks/pack.gd` asserted only that its screen came out 160x144. It asserts the same containment now.

## Two defects met on the way

`preview_party.gd`'s `pack` and `select` modes photographed an empty window. `Gen2StartMenuScreen` draws into a `Gen2Screen` the host hands over and into nothing else, and the driver handed it none. Both modes were documented and had never drawn anything.

The exp bar's palette was named by a string literal in two places. `GameData.EXP_BAR_PALETTE` is the one name now.

## Numbers

| Check | Result |
|---|---|
| GUT unit tier | 2,937 tests, green |
| GUT full tier | 3,359 tests over 152 scripts, green |
| `validate.gd -- all` | 58 topics, exit 0 |
| `screen_palettes` | 753 stats pages per cartridge, 251 species, 3 pages |
| Story walk, three profiles | exit 0 |
| `replay_world.gd` | exit 0 |
| Boot smoke, with and without mods | exit 0 |