### PR TITLE
Draw a battle animation object one last time when it deletes itself

### DIFF
--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -487,14 +487,20 @@ func _execute_bg_effects() -> void:
 
 ## `BattleAnim_UpdateOAM_All`: every live object stepped and drawn, in slot
 ## order, stopping at the first one whose sprites would not fit.
+##
+## The slot's index byte is tested once, at the top of the loop, so an object
+## whose own callback calls `DeinitBattleAnimation` still reaches
+## `BattleAnimOAMUpdate` and is **drawn one last time where it stands**;
+## `DeinitBattleAnimation` clears the index and nothing else, so the frameset
+## steps normally on that pass. Measured against a real cartridge: TACKLE's
+## `anim_incobj 1` frees the target's two rows on the frame it runs and OAM
+## still holds their fourteen sprites for that frame.
 func _update_oam() -> void:
 	_sprites = []
 	for object: Gen2BattleAnimObject in _objects:
 		if object == null or not object.active():
 			continue
 		_do_battle_anim_frame(object)
-		if not object.active():
-			continue
 		var update: Dictionary = object.oam_update(_data, _enemy_turn, _anim_index)
 		var new_sprites: Array = update["sprites"]
 		if _sprites.size() + new_sprites.size() > MAX_SPRITES:

--- a/tests/unit/test_battle_anim_player.gd
+++ b/tests/unit/test_battle_anim_player.gd
@@ -173,6 +173,28 @@ func test_incobj_retires_an_object_with_the_null_callback() -> void:
 	)
 
 
+## `BattleAnim_UpdateOAM_All` tests the slot's index once, at the top of its
+## loop, so the object whose own callback has just deinitialised itself still
+## reaches `BattleAnimOAMUpdate` and is drawn one last time. Measured on a real
+## cartridge: TACKLE's `anim_incobj 1` frees the target's two rows on the frame
+## it runs and OAM still holds their sprites for that frame.
+func test_an_object_that_deletes_itself_is_drawn_one_last_time() -> void:
+	var player: Gen2BattleAnimPlayer = _player(
+		SPAWN + [0x01] + [0xD6, 0x01] + [0x01] + RET
+	)
+	player.advance_frame()
+	player.advance_frame()
+	var before: int = player.sprites().size()
+	player.advance_frame()
+	assert_eq(player.objects().size(), 0, "the null callback deinitialised it")
+	assert_eq(
+		player.sprites().size(), before,
+		"the freed slot is still drawn on the frame it was freed"
+	)
+	player.advance_frame()
+	assert_eq(player.sprites().size(), 0, "and on no frame after it")
+
+
 ## `anim_setobj` writes the index rather than stepping it, and an index no object
 ## carries finds nothing rather than writing over slot zero.
 func test_setobj_writes_the_index_and_an_unknown_one_finds_nothing() -> void:

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -116,6 +116,7 @@ func run(r: RefCounted) -> void:
 		_verify_substitute_pic(game_id, data)
 		_run_every_animation(game_id, data)
 		_play_every_animation(game_id, data)
+		_verify_tackle_frames(game_id, data)
 		_verify_the_entrance(game_id, data)
 		_verify_the_transition(game_id, data)
 
@@ -129,6 +130,74 @@ const SEND_OUT_EFFECTS: Dictionary = {0: [0x0B], 1: [0x01, 0x06]}
 ## And how long each takes: the two `anim_wait`s of `.Normal` and the ten of
 ## `.Shiny`, plus the frame each batch of commands between them spends.
 const SEND_OUT_FRAMES: Dictionary = {0: 39, 1: 69}
+
+
+## TACKLE, frame by frame, against a real cartridge: `.claude/oracle/battle`'s
+## `trace_move_anim.py` reads the shadow OAM and `wBattleAnimDelay` of a live
+## fight, and these are the three runs of sprite counts it recorded.
+##
+## Fourteen is the target's two rows, lifted off the tilemap by
+## `anim_battlergfx_1row`; thirty adds `BATTLE_ANIM_OBJ_HIT_BIG_YFIX`, whose
+## frameset is `oamframe 0, 6` and so lasts seven frames.
+##
+## The last run is the one number a reading gets wrong. `anim_incobj 1` frees the
+## target's rows through `BattleAnimFunc_Null`, and `BattleAnim_UpdateOAM_All`
+## has already passed the index test for that slot, so the freed object is drawn
+## one last time: eleven frames, not ten. The cartridge's own frames are 26 to
+## 56, one of them a repeat of the frame before it, which is a loop that overran
+## VBlank rather than a state of its own.
+## Crystal's row is the measured one. Gold and Silver run
+## `BattleAnim_TargetObj_1Row` where Crystal runs `..._2Row`, which is the
+## profile split [constant TACKLE_BG_EFFECTS] already pins, so their target is
+## seven sprites rather than fourteen and every run length is the same.
+## Both sides are measured. On the enemy's turn the target is the player, whose
+## picture is six columns rather than seven, so the two runs differ by the two
+## rows and nothing else.
+const TACKLE_SPRITE_RUNS: Dictionary = {
+	&"crystal": [
+		[[14, 12], [30, 7], [14, 11], [0, 2]],
+		[[12, 12], [28, 7], [12, 11], [0, 2]],
+	],
+	&"gold": [
+		[[7, 12], [23, 7], [7, 11], [0, 2]],
+		[[6, 12], [22, 7], [6, 11], [0, 2]],
+	],
+	&"silver": [
+		[[7, 12], [23, 7], [7, 11], [0, 2]],
+		[[6, 12], [22, 7], [6, 11], [0, 2]],
+	],
+}
+
+
+func _verify_tackle_frames(game_id: StringName, data: GameData) -> void:
+	var anims: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(data)
+	if not _r.check(anims != null, "%s: no battle animation data in the cache." % game_id):
+		return
+	for enemy_turn: bool in [false, true]:
+		var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create(
+			anims, TACKLE_INDEX, enemy_turn
+		)
+		if not _r.check(player != null, "%s: TACKLE would not start." % game_id):
+			continue
+		var runs: Array = []
+		var frames: int = 0
+		while player.advance_frame() and frames < MAX_FRAMES:
+			frames += 1
+			var count: int = player.sprites().size()
+			if runs.is_empty() or int((runs[-1] as Array)[0]) != count:
+				runs.append([count, 1])
+			else:
+				(runs[-1] as Array)[1] = int((runs[-1] as Array)[1]) + 1
+		var expected: Array = (TACKLE_SPRITE_RUNS[game_id] as Array)[1 if enemy_turn else 0]
+		_r.check(
+			runs == expected,
+			"%s: TACKLE draws %s sprites on the %s side, not the cartridge's %s." % [
+				game_id, runs, "enemy" if enemy_turn else "player", expected,
+			]
+		)
+		print("%s: TACKLE draws %s over %d frames on the %s side." % [
+			game_id, runs, frames, "enemy" if enemy_turn else "player",
+		])
 
 
 ## `ANIM_SEND_OUT_MON`, which every entrance plays and which nothing else in the


### PR DESCRIPTION
A battle animation object that its own callback deletes is still drawn on the frame it was deleted.

`BattleAnim_UpdateOAM_All` tests the slot's index once, at the top of its loop. `DoBattleAnimFrame` runs next and may call `DeinitBattleAnimation`, and `BattleAnimOAMUpdate` is called either way. `DeinitBattleAnimation` clears the index byte and nothing else, so the frameset steps normally and the sprites are written where the object stands. This code re-tested the slot between the two calls and lost that frame.

It was wrong for 238 of the 278 animations on each side of all three cartridges: 714 of 1,668 runs change.

The numbers come from a real cartridge, Route 29's TACKLE, on both sides. Frames on which the animation's own counters repeat are a game loop that overran VBlank, not a state, and are dropped. What is left agrees frame for frame:

| Run | Cartridge | Here |
|---|---|---|
| the target's lifted rows | 12 | 12 |
| plus the hit object | 7 | 7 |
| the rows again, `anim_incobj 1`'s own frame included | 11 | 11 |

`tools/checks/battle_anims.gd` pins all six runs, three cartridges by two sides. Gold and Silver differ only by `BattleAnim_TargetObj_1Row` against Crystal's `..._2Row`, which the same file already pinned.

GUT 2,938 tests green, `validate.gd -- all` 58 topics green, `replay_world.gd` 33 routes with no failures, the story walk clean on all three profiles.