### PR TITLE
Build the Name Rater and the move deleter on one party list

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -77,6 +77,8 @@ var _intro_movie: Dictionary = {}
 var _gs_intro: Dictionary = {}
 var _menu_text: Dictionary = {}
 var _mart_text: Dictionary = {}
+var _name_rater_text: Dictionary = {}
+var _move_deleter_text: Dictionary = {}
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 var _world_maps: Array = []
@@ -187,6 +189,10 @@ static func open_directory(path: String) -> GameData:
 	data._menu_text = raw_menu_text if raw_menu_text is Dictionary else {}
 	var raw_mart_text: Variant = manifest.get("mart_text", {})
 	data._mart_text = raw_mart_text if raw_mart_text is Dictionary else {}
+	var raw_name_rater_text: Variant = manifest.get("name_rater_text", {})
+	data._name_rater_text = raw_name_rater_text if raw_name_rater_text is Dictionary else {}
+	var raw_move_deleter_text: Variant = manifest.get("move_deleter_text", {})
+	data._move_deleter_text = raw_move_deleter_text if raw_move_deleter_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
@@ -1450,6 +1456,22 @@ func menu_text(key: String) -> String:
 ## imported before them.
 func mart_text(name: String) -> String:
 	return String(_mart_text.get(name, ""))
+
+
+## One of `engine/events/name_rater.asm`'s own boxes, by the name
+## `RomLayout.NAME_RATER_TEXT_ORDER` gives its stub, still carrying
+## [Gen2TextStream]'s marker for the nickname. Empty on a cache imported before
+## them.
+func name_rater_text(name: String) -> String:
+	return String(_name_rater_text.get(name, ""))
+
+
+## One of `engine/events/move_deleter.asm`'s own boxes, by the name
+## `RomLayout.MOVE_DELETER_TEXT_ORDER` gives its stub, still carrying
+## [Gen2TextStream]'s marker for the move name. Empty on a cache imported before
+## them.
+func move_deleter_text(name: String) -> String:
+	return String(_move_deleter_text.get(name, ""))
 
 
 ## `.MenuDesc`'s line for one start-menu item, by the item's own kind. Empty for

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -80,7 +80,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 75
+const FORMAT_VERSION: int = 76
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -354,6 +354,14 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not mart_text["ok"]:
 		return mart_text
 
+	var name_rater_text: Dictionary = verify_name_rater_text(rom, layout)
+	if not name_rater_text["ok"]:
+		return name_rater_text
+
+	var move_deleter_text: Dictionary = verify_move_deleter_text(rom, layout)
+	if not move_deleter_text["ok"]:
+		return move_deleter_text
+
 	var map_entry_sign: Dictionary = verify_map_entry_sign(rom, layout)
 	if not map_entry_sign["ok"]:
 		return map_entry_sign
@@ -1118,6 +1126,47 @@ static func verify_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"message": "The mart's welcome text is \"%s\", not the shop's own." % welcome,
 		}
 	return {"ok": true, "message": "The mart's texts verified."}
+
+
+## `engine/events/name_rater.asm`'s ten `text_far` stubs, identified by content
+## the way the mart's are: all ten have to decode and the routine's opening line
+## has to be the one he introduces himself with.
+static func verify_name_rater_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	for name: String in RomLayout.NAME_RATER_TEXT_ORDER:
+		if read_oak_text(rom, layout, RomLayout.name_rater_text_offset(layout, name)).is_empty():
+			return {
+				"ok": false, "message": "The Name Rater's %s text did not decode." % name,
+			}
+	var hello: String = read_oak_text(
+		rom, layout, RomLayout.name_rater_text_offset(layout, "hello")
+	)
+	if not hello.begins_with("Hello, hello!"):
+		return {
+			"ok": false,
+			"message": "The Name Rater's hello text is \"%s\", not his own." % hello,
+		}
+	return {"ok": true, "message": "The Name Rater's texts verified."}
+
+
+## `engine/events/move_deleter.asm`'s eight `text_far` stubs, identified by
+## content the same way.
+static func verify_move_deleter_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	for name: String in RomLayout.MOVE_DELETER_TEXT_ORDER:
+		if read_oak_text(
+			rom, layout, RomLayout.move_deleter_text_offset(layout, name)
+		).is_empty():
+			return {
+				"ok": false, "message": "The move deleter's %s text did not decode." % name,
+			}
+	var intro: String = read_oak_text(
+		rom, layout, RomLayout.move_deleter_text_offset(layout, "intro")
+	)
+	if not intro.contains("MOVE DELETER"):
+		return {
+			"ok": false,
+			"message": "The move deleter's intro is \"%s\", not his own." % intro,
+		}
+	return {"ok": true, "message": "The move deleter's texts verified."}
 
 
 ## `UnownWords`, twenty-six words in form order, A first. Empty on any failure,
@@ -3961,6 +4010,8 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"gender_screen_palette": _import_gender_screen_palette(rom, layout),
 		"menu_text": _import_menu_text(rom, layout),
 		"mart_text": _import_mart_text(rom, layout),
+		"name_rater_text": _import_name_rater_text(rom, layout),
+		"move_deleter_text": _import_move_deleter_text(rom, layout),
 		"copyright_string": _import_copyright_string(rom, layout),
 		"copyright_palette": _import_copyright_palette(rom, layout),
 		"presents_palettes": _import_presents_palettes(rom, layout),
@@ -4737,6 +4788,28 @@ func _import_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var out: Dictionary = {}
 	for name: String in RomLayout.MART_TEXT_AT:
 		out[name] = read_oak_text(rom, layout, RomLayout.mart_text_offset(layout, name))
+	return out
+
+
+## The Name Rater's own boxes, by the name `RomLayout.NAME_RATER_TEXT_ORDER`
+## gives each stub.
+func _import_name_rater_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in RomLayout.NAME_RATER_TEXT_ORDER:
+		out[name] = read_oak_text(
+			rom, layout, RomLayout.name_rater_text_offset(layout, name)
+		)
+	return out
+
+
+## The move deleter's own boxes, by the name
+## `RomLayout.MOVE_DELETER_TEXT_ORDER` gives each stub.
+func _import_move_deleter_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in RomLayout.MOVE_DELETER_TEXT_ORDER:
+		out[name] = read_oak_text(
+			rom, layout, RomLayout.move_deleter_text_offset(layout, name)
+		)
 	return out
 
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1264,6 +1264,28 @@ const MART_TEXT_AT: Dictionary = {
 	"ask_more": 0x1AB,
 }
 
+## A `text_far` stub is `TX_FAR`, a two-byte address, a bank byte and a
+## `text_end`, so a run of them declared together is walked at this stride. The
+## two runs below are each one contiguous block, which is what makes one pinned
+## address per dump enough for either.
+const TEXT_FAR_STUB_BYTES: int = 5
+
+## `engine/events/name_rater.asm`'s ten stubs, in the file's own order, which is
+## `_NameRater` reaching them with `.egg` ahead of `.samename`. Byte identical on
+## all three cartridges.
+const NAME_RATER_TEXT_ORDER: Array[String] = [
+	"hello", "which_mon", "better_name", "what_name", "finished",
+	"come_again", "perfect_name", "egg", "same_name", "named",
+]
+
+## `engine/events/move_deleter.asm`'s eight, in the file's own order rather than
+## the routine's: `MoveDeletion` lays them out between `.onlyonemove` and
+## `.DeleteMove`. Byte identical on all three cartridges as well.
+const MOVE_DELETER_TEXT_ORDER: Array[String] = [
+	"knows_one", "ask_delete", "forgot", "egg", "come_again", "which_move",
+	"intro", "which_mon",
+]
+
 ## `Landmarks` (data/maps/landmarks.asm): `db x + 8, y + 16` then a name pointer,
 ## so the stored bytes are already shadow-OAM coordinates and the raw x,y are
 ## screen pixels. Gold and Silver ship no `BATTLE TOWER`, so every landmark from
@@ -2051,6 +2073,10 @@ const GOLD_SILVER: Dictionary = {
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
 	"mart_text": 0x16063,
+	## `NameRaterHelloText`, bank $3e:$7919 in both dumps.
+	"name_rater_text": 0xFB919,
+	## `MoveDeletion.MoveKnowsOneText`, bank $0b:$43dc in both dumps.
+	"move_deleter_text": 0x2C3DC,
 	"fruit_trees": 0x44091,
 	## `SpawnPoints` and `Flypoints`, each located by the byte column that is the
 	## same on all three dumps: the spawn coordinates at a stride of four, and
@@ -2483,6 +2509,10 @@ const CRYSTAL: Dictionary = {
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,
 	"mart_text": 0x15E0E,
+	## `NameRaterHelloText`, bank $3e:$780f.
+	"name_rater_text": 0xFB80F,
+	## `MoveDeletion.MoveKnowsOneText`, bank $0b:$45d1.
+	"move_deleter_text": 0x2C5D1,
 	"fruit_trees": 0x44097,
 	"spawn_points": 0x152AB,
 	"flypoints": 0x91C5E,
@@ -3023,6 +3053,24 @@ static func pokecenter_pc_text_offset(layout: Dictionary, name: String) -> int:
 	if at < 0 or not POKECENTER_PC_TEXT_AT.has(name):
 		return -1
 	return at + int(POKECENTER_PC_TEXT_AT[name])
+
+
+## Where the move deleter's `text_far` stub [param name] names sits.
+static func move_deleter_text_offset(layout: Dictionary, name: String) -> int:
+	var at: int = int(layout.get("move_deleter_text", -1))
+	var index: int = MOVE_DELETER_TEXT_ORDER.find(name)
+	if at < 0 or index < 0:
+		return -1
+	return at + index * TEXT_FAR_STUB_BYTES
+
+
+## Where the Name Rater's `text_far` stub [param name] names sits.
+static func name_rater_text_offset(layout: Dictionary, name: String) -> int:
+	var at: int = int(layout.get("name_rater_text", -1))
+	var index: int = NAME_RATER_TEXT_ORDER.find(name)
+	if at < 0 or index < 0:
+		return -1
+	return at + index * TEXT_FAR_STUB_BYTES
 
 
 ## Where the mart's `text_far` stub [param name] names sits.

--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -289,6 +289,19 @@ static func fill_marker(text: String, prefix: String, value: String) -> String:
 	return text.substr(0, at) + value + text.substr(end + 1)
 
 
+## Every marker of [param prefix], not just the first. `_NameRaterPerfectNameText`
+## names `wStringBuffer1` twice, and a text with one marker is unchanged by the
+## second pass.
+static func fill_all_markers(text: String, prefix: String, value: String) -> String:
+	var out: String = text
+	while out.find(prefix) >= 0:
+		var filled: String = fill_marker(out, prefix, value)
+		if filled == out:
+			break
+		out = filled
+	return out
+
+
 static func _ram_string(context: Dictionary, address: int) -> String:
 	var ram: Variant = context.get("ram", {})
 	if ram is Dictionary and (ram as Dictionary).has(address):

--- a/game/render/move_screen_page.gd
+++ b/game/render/move_screen_page.gd
@@ -4,7 +4,8 @@ extends RefCounted
 ## The move screen (`MoveScreenLoop` in `engine/pokemon/mon_menu.asm`), on the
 ## tile grid the hardware uses.
 ##
-## `SetUpMoveScreenBG` draws the two boxes, the nickname and the two arrows once;
+## `SetUpMoveScreenBG` draws the two boxes and the nickname once and
+## `MoveScreenLoop` adds the two arrows, which `ChooseMoveToDelete` does not;
 ## `SetUpMoveList` fills the list; `PlaceMoveData` fills the bottom box with
 ## whichever row the cursor is on. Swapping replaces that box with `Where?`
 ## instead, which is `.moving_move`.

--- a/game/save/move_screen.gd
+++ b/game/save/move_screen.gd
@@ -15,6 +15,10 @@ signal closed
 ## `PlayClickSFX` on every press this screen answers, and `SFX_SWITCH_POKEMON`
 ## twice once two moves have traded places.
 signal sfx_requested(index: int, waited: bool)
+## `ChooseMoveToDelete`'s own answer, when the screen was opened as the move
+## deleter's list rather than as `ManagePokemonMoves`: the row A landed on, or
+## -1 for the carry `.b_button` sets.
+signal selection_made(move_index: int)
 
 ## `constants/sfx_constants.asm`.
 const SFX_READ_TEXT_2: int = 0x08
@@ -27,6 +31,10 @@ var _cursor: int = 0
 var _row: int = 0
 ## `wSwappingMove` less one: the row being moved, or -1 when nothing is held.
 var _held: int = -1
+## `ChooseMoveToDelete`'s own list. `DeleteMoveScreen2DMenuData` accepts
+## `PAD_UP | PAD_DOWN | PAD_A | PAD_B` and nothing else, so there is no cycling
+## between members and no move to hold: A answers the caller and B is its carry.
+var _deleting: bool = false
 
 
 static func create(data: GameData, party: Array, start_cursor: int = 0) -> Gen2MoveScreen:
@@ -47,11 +55,25 @@ func cursor() -> int:
 	return _cursor
 
 
+## `ChooseMoveToDelete`: the same screen with the swap and the cycle taken off
+## its accepted buttons.
+func open_deletion() -> void:
+	_deleting = true
+	_held = -1
+	_row = 0
+
+
 ## `MoveScreenLoop`'s joypad block, which `ScrollingMenuJoypad` has already
 ## narrowed to the control pad, A and B. Returns whether the button was used.
 func handle_button(button: int) -> bool:
 	match button:
 		Gen2Button.B:
+			## `.ChooseMoveToDelete`'s own `.a_button` and `.b_button` reach
+			## neither `PlayClickSFX` nor `WaitSFX`, where `MoveScreenLoop`'s
+			## both do, so the deleter's list answers silently.
+			if _deleting:
+				selection_made.emit(-1)
+				return true
 			sfx_requested.emit(SFX_READ_TEXT_2, false)
 			## `.b_button`: a held move is put back where it came from and the
 			## screen stays up; nothing held is the way out.
@@ -62,6 +84,9 @@ func handle_button(button: int) -> bool:
 			closed.emit()
 			return true
 		Gen2Button.A:
+			if _deleting:
+				selection_made.emit(_row)
+				return true
 			sfx_requested.emit(SFX_READ_TEXT_2, false)
 			if _held < 0:
 				_held = _row
@@ -94,7 +119,7 @@ func _move_row(delta: int) -> bool:
 ## egg both turn round, so the screen never lands on a member it cannot list.
 ## `.d_left` and `.d_right` refuse outright while a move is held.
 func _cycle(delta: int) -> bool:
-	if _held >= 0:
+	if _held >= 0 or _deleting:
 		return false
 	var found: int = _next_listable(delta)
 	if found < 0 or found == _cursor:
@@ -185,6 +210,9 @@ func snapshot() -> Dictionary:
 		"moves": moves,
 		"cursor": clampi(_row, 0, maxi(moves.size() - 1, 0)),
 		"held": _held,
-		"previous": has_neighbour(-1),
-		"next": has_neighbour(1),
+		## `PlaceMoveScreenArrows` is `MoveScreenLoop`'s own call and not
+		## `SetUpMoveScreenBG`'s, so the deleter's list carries neither arrow:
+		## `.ChooseMoveToDelete` never reaches it.
+		"previous": not _deleting and has_neighbour(-1),
+		"next": not _deleting and has_neighbour(1),
 	}

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -28,6 +28,13 @@ signal sfx_requested(index: int, waited: bool)
 ## `PlayMonCry2`, which the stats screen this menu opens plays on every mon it
 ## loads. Emitted for the same reason [signal sfx_requested] is.
 signal cry_requested(species: int)
+## `PartyMenuSelect`'s own answer, when the list was opened as
+## `SelectMonFromParty` rather than as `StartMenu_Pokemon`: the chosen party
+## index, or -1 for the carry a CANCEL row or a B press returns. Every caller of
+## `SelectMonFromParty` (the Name Rater, the move deleter, the seer, the haircut
+## brothers) is one of these, so the selection is the list's answer rather than a
+## per-caller mode.
+signal selection_made(party_index: int)
 
 const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
@@ -128,6 +135,11 @@ var _heal_move: int = 0
 ## `wSwitchMon` less one: which member SWITCH is holding, or -1 when the list is
 ## not `InitPartyMenuNoCancel`'s.
 var _switch_from: int = -1
+## `SelectMonFromParty`'s own list: A answers the caller rather than opening
+## `PokemonActionSubmenu`, and the prompt is whichever `PartyMenuStrings` row
+## the caller wrote into `wPartyMenuActionText`.
+var _selecting: bool = false
+var _select_prompt: String = PROMPT_CHOOSE
 
 ## The embedded view's own hardware screen and the two pages drawn into it.
 var _hardware: Gen2Screen = null
@@ -179,6 +191,27 @@ func set_context(data: GameData, save: Gen2SaveData, embedded: bool = false) -> 
 	_stats = null
 	_moves = null
 	if is_inside_tree() and _cards != null:
+		_refresh()
+
+
+## `SelectMonFromParty`: the same `InitPartyMenuWithCancel` list with
+## `wPartyMenuActionText` set by the caller, whose A opens no submenu and
+## answers [signal selection_made] instead. [param prompt] is the
+## `PartyMenuStrings` row that caller writes; the default is the
+## PARTYMENUACTION_CHOOSE_POKEMON `SelectMonFromParty` writes with its own
+## `xor a`.
+func open_selection(prompt: String = PROMPT_CHOOSE) -> void:
+	_selecting = true
+	_select_prompt = prompt
+	_member_cursor = 0
+	_submenu_open = false
+	_item_menu_open = false
+	_submenu_items = []
+	_switch_from = -1
+	_heal_user = -1
+	_heal_move = 0
+	_message = ""
+	if is_inside_tree():
 		_refresh()
 
 
@@ -298,7 +331,7 @@ func handle_button(button: int) -> bool:
 		return false
 	if _party_size() == 0:
 		if button == Gen2Button.B:
-			close_embedded()
+			_cancel()
 			return true
 		return false
 	match button:
@@ -349,6 +382,11 @@ func _confirm() -> void:
 	## the row and the button are one path.
 	if _on_cancel_row() and not _submenu_open:
 		_cancel()
+		return
+	## `SelectMonFromParty` returns the moment `PartyMenuSelect` does: there is
+	## no submenu behind this list.
+	if _selecting:
+		selection_made.emit(_member_cursor)
 		return
 	if _switch_from >= 0:
 		_finish_switch()
@@ -460,6 +498,10 @@ func _close_stats() -> void:
 
 
 func _cancel() -> void:
+	## `PartyMenuSelect`'s carry, which is the same answer the CANCEL row gives.
+	if _selecting:
+		selection_made.emit(-1)
+		return
 	## `SwitchPartyMons`' `bit B_PAD_B` reaches `.DontSwitch`, which is
 	## `CancelPokemonAction`: the move is given up and the plain list comes back.
 	if _switch_from >= 0:
@@ -703,6 +745,8 @@ func _rows() -> Array:
 func _prompt() -> String:
 	if not _message.is_empty():
 		return _message
+	if _selecting:
+		return _select_prompt
 	if _switch_from >= 0:
 		return PROMPT_MOVE_TO_WHERE
 	return PROMPT_USE_ON_WHICH if _heal_user >= 0 else PROMPT_CHOOSE

--- a/game/world/move_deleter.gd
+++ b/game/world/move_deleter.gd
@@ -1,0 +1,55 @@
+class_name Gen2MoveDeleter
+extends RefCounted
+
+## `MoveDeletion` (`engine/events/move_deleter.asm`), the rules half.
+##
+## Same shape as [Gen2NameRater], one house further on: an introduction and a
+## `YesNoBox`, the party list `SelectMonFromParty` opens, two endings that need
+## no move, `ChooseMoveToDelete`'s own list, a second `YesNoBox` and
+## `.DeleteMove`. [Gen2MoveDeleterScreen] is the routine; this holds nothing.
+
+## The endings `PrintText` closes on, by the stub each branch loads into hl.
+const ENDING_EGG: StringName = &"egg"
+const ENDING_ONLY_ONE_MOVE: StringName = &"knows_one"
+const ENDING_DECLINED: StringName = &"come_again"
+const ENDING_FORGOT: StringName = &"forgot"
+
+## `constants/sfx_constants.asm`'s SFX_MOVE_DELETED, played between two
+## `WaitSFX`es once the slot has been cleared.
+const SFX_MOVE_DELETED: int = 0x97
+
+
+## Which ending [param mon] reaches once it has been chosen, or `&""` for the
+## one member the routine carries on with.
+##
+## `.onlyonemove` reads `wPartyMon1Moves + 1`, which is the *second* slot rather
+## than a move count, so a member whose second slot is empty is refused whatever
+## stands behind it.
+static func ending_for(mon: Gen2SaveMon) -> StringName:
+	if mon == null:
+		return ENDING_DECLINED
+	if mon.is_egg:
+		return ENDING_EGG
+	if mon.moves.size() < 2 or int(mon.moves[1]) == 0:
+		return ENDING_ONLY_ONE_MOVE
+	return &""
+
+
+## `.DeleteMove`: the slots above the deleted one come down and the last is
+## zeroed, moves and PP in the same shape. Answers whether anything was written.
+static func delete_move(mon: Gen2SaveMon, slot: int) -> bool:
+	if mon == null or slot < 0 or slot >= mon.moves.size():
+		return false
+	if int(mon.moves[slot]) == 0:
+		return false
+	_shift(mon.moves, slot)
+	_shift(mon.pp, slot)
+	return true
+
+
+static func _shift(slots: Array, slot: int) -> void:
+	if slot >= slots.size():
+		return
+	for index: int in range(slot, slots.size() - 1):
+		slots[index] = slots[index + 1]
+	slots[slots.size() - 1] = 0

--- a/game/world/move_deleter.gd.uid
+++ b/game/world/move_deleter.gd.uid
@@ -1,0 +1,1 @@
+uid://dbf74r84lacv6

--- a/game/world/move_deleter_screen.gd
+++ b/game/world/move_deleter_screen.gd
@@ -1,0 +1,319 @@
+class_name Gen2MoveDeleterScreen
+extends Control
+
+## `MoveDeletion` (`engine/events/move_deleter.asm`) on the overworld's own pump.
+##
+## The same shape as [Gen2NameRaterScreen] and for the same reason: the routine
+## owns its boxes, its two `YesNoBox`es and the two screens it opens, and the
+## map script's own `waitbutton` is what dismisses the text `PrintText` left
+## standing, so the ending is handed back rather than pressed here.
+##
+## `ChooseMoveToDelete` is `MoveScreenLoop`'s own screen with
+## `DeleteMoveScreen2DMenuData` in front of it, so the list is [Gen2MoveScreen]
+## in its deletion mode and the picture is [Gen2MoveScreenPage].
+
+signal finished(party_index: int, move_index: int, ending_text: String)
+signal closed()
+signal sfx_requested(index: int, waited: bool)
+
+const TILE: int = Gen2Font.TILE
+
+const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
+
+enum Phase {
+	INTRO,
+	INTRO_ASK,
+	WHICH_MON,
+	SELECT_MON,
+	WHICH_MOVE,
+	SELECT_MOVE,
+	DELETE_ASK,
+	DONE,
+}
+
+var _data: GameData = null
+var _save: Gen2SaveData = null
+## Every stub `RomLayout.MOVE_DELETER_TEXT_ORDER` names, by that name.
+var _texts: Dictionary = {}
+
+var _phase: int = Phase.DONE
+var _yes: bool = true
+var _party_index: int = -1
+var _move_index: int = -1
+var _move_name: String = ""
+
+var _text_box: Gen2TextBox = null
+var _menu_page: Gen2MenuPage = null
+var _menu: TextureRect = null
+var _party: Gen2PartyScreen = null
+var _move_view: TextureRect = null
+var _move_model: Gen2MoveScreen = null
+var _move_page: Gen2MoveScreenPage = null
+
+
+func set_context(data: GameData, save: Gen2SaveData, texts: Dictionary) -> void:
+	_data = data
+	_save = save
+	_texts = texts.duplicate(true)
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _save == null or _text("intro").is_empty():
+		_phase = Phase.DONE
+		finished.emit(-1, -1, "")
+		closed.emit()
+		return
+	_build()
+	_phase = Phase.INTRO
+	_show_text(_text("intro"))
+
+
+func phase() -> int:
+	return _phase
+
+
+func question_cursor() -> int:
+	return (0 if _yes else 1) if _phase in [Phase.INTRO_ASK, Phase.DELETE_ASK] else -1
+
+
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+func party_screen() -> Gen2PartyScreen:
+	return _party
+
+
+func move_screen() -> Gen2MoveScreen:
+	return _move_model
+
+
+func handle_button(button: int) -> bool:
+	if _phase == Phase.SELECT_MON and _party != null:
+		return _party.handle_button(button)
+	if _phase == Phase.SELECT_MOVE and _move_model != null:
+		var used: bool = _move_model.handle_button(button)
+		if _move_model != null:
+			_draw_move_list()
+		return used
+	if _phase in [Phase.INTRO_ASK, Phase.DELETE_ASK]:
+		match button:
+			Gen2Button.UP, Gen2Button.DOWN:
+				_yes = not _yes
+				_draw_yes_no()
+				return true
+			Gen2Button.A:
+				_answer(_yes)
+				return true
+			Gen2Button.B:
+				_answer(false)
+				return true
+		return false
+	if button != Gen2Button.A or _text_box == null or not _text_box.visible:
+		return false
+	if _text_box.is_revealing() or _text_box.has_pages_left():
+		_text_box.advance()
+		return true
+	match _phase:
+		Phase.WHICH_MON:
+			_open_party()
+		Phase.WHICH_MOVE:
+			_open_move_list()
+		_:
+			return false
+	return true
+
+
+func advance_frame() -> void:
+	## `_2DMENU_ENABLE_SPRITE_ANIMS_F` is set for the deleter's list too, so its
+	## `LoadMenuMonIcon` icon steps on the same clock the move screen's does.
+	if _phase == Phase.SELECT_MOVE:
+		if _move_page != null:
+			_move_page.advance()
+			_draw_move_list()
+		return
+	if _text_box != null and _text_box.visible:
+		_text_box.advance_frame()
+		if _text_box.is_revealing() or _text_box.has_pages_left():
+			return
+	## Both questions are a `YesNoBox` over a text ending in `done`, which
+	## `PrintText` returns from without a press.
+	if _phase == Phase.INTRO:
+		_open_question(Phase.INTRO_ASK)
+	elif _phase == Phase.DELETE_ASK and (_menu == null or not _menu.visible):
+		_draw_yes_no()
+
+
+func _text(name: String) -> String:
+	return String(_texts.get(name, ""))
+
+
+func _build() -> void:
+	_move_view = TextureRect.new()
+	_move_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_move_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_move_view.visible = false
+	add_child(_move_view)
+
+	_menu = TextureRect.new()
+	_menu.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_menu.visible = false
+	add_child(_menu)
+
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+func _show_text(text: String, prompt: bool = false) -> void:
+	if _text_box == null:
+		return
+	_menu.visible = false
+	_text_box.visible = true
+	_text_box.show_text(text, prompt)
+
+
+func _open_question(phase: int) -> void:
+	_phase = phase
+	_yes = true
+	_draw_yes_no()
+
+
+func _answer(yes: bool) -> void:
+	_menu.visible = false
+	if not yes:
+		_end(Gen2MoveDeleter.ENDING_DECLINED)
+		return
+	if _phase == Phase.INTRO_ASK:
+		_phase = Phase.WHICH_MON
+		_show_text(_text("which_mon"), true)
+		return
+	_delete_move()
+
+
+## `SelectMonFromParty`, the same list the Name Rater's own question opens.
+func _open_party() -> void:
+	var host: Gen2PartyScreen = PARTY_SCENE.instantiate() as Gen2PartyScreen
+	if host == null:
+		_end(Gen2MoveDeleter.ENDING_DECLINED)
+		return
+	host.set_context(_data, _save, true)
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	host.selection_made.connect(_on_member_selected)
+	add_child(host)
+	host.open_selection()
+	_party = host
+	_text_box.visible = false
+	_phase = Phase.SELECT_MON
+
+
+func _on_member_selected(party_index: int) -> void:
+	Gen2Screen.drop(_party)
+	_party = null
+	if party_index < 0 or party_index >= _save.party.size():
+		_end(Gen2MoveDeleter.ENDING_DECLINED)
+		return
+	_party_index = party_index
+	var ending: StringName = Gen2MoveDeleter.ending_for(
+		_save.party[party_index] as Gen2SaveMon
+	)
+	if ending != &"":
+		_end(ending)
+		return
+	_phase = Phase.WHICH_MOVE
+	_show_text(_text("which_move"), true)
+
+
+func _open_move_list() -> void:
+	_move_model = Gen2MoveScreen.create(_data, _save.party, _party_index)
+	## No `sfx_requested` connection: `.ChooseMoveToDelete` plays nothing, so the
+	## list is silent and the only sound this routine owes is
+	## `SFX_MOVE_DELETED`.
+	_move_model.open_deletion()
+	_move_model.selection_made.connect(_on_move_selected)
+	_text_box.visible = false
+	_phase = Phase.SELECT_MOVE
+	_draw_move_list()
+
+
+func _on_move_selected(move_index: int) -> void:
+	var mon: Gen2SaveMon = _save.party[_party_index] as Gen2SaveMon
+	_move_model = null
+	if _move_view != null:
+		_move_view.visible = false
+	if move_index < 0 or mon == null or move_index >= mon.moves.size():
+		_end(Gen2MoveDeleter.ENDING_DECLINED)
+		return
+	_move_index = move_index
+	## `GetMoveName` off the row the cursor landed on, which is what the
+	## question names.
+	_move_name = String(_data.move(int(mon.moves[move_index])).get("name", ""))
+	_phase = Phase.DELETE_ASK
+	_yes = true
+	_show_text(Gen2TextStream.fill_all_markers(
+		_text("ask_delete"), Gen2TextStream.RAM_MARKER, _move_name
+	))
+
+
+## `.DeleteMove` and the `WaitSFX` on either side of `SFX_MOVE_DELETED`.
+func _delete_move() -> void:
+	var mon: Gen2SaveMon = _save.party[_party_index] as Gen2SaveMon
+	if not Gen2MoveDeleter.delete_move(mon, _move_index):
+		_end(Gen2MoveDeleter.ENDING_DECLINED)
+		return
+	sfx_requested.emit(Gen2MoveDeleter.SFX_MOVE_DELETED, true)
+	_end(Gen2MoveDeleter.ENDING_FORGOT)
+
+
+func _end(ending: StringName) -> void:
+	## `.DeleteMove` is the one branch that wrote anything.
+	if ending != Gen2MoveDeleter.ENDING_FORGOT:
+		_party_index = -1
+		_move_index = -1
+	_phase = Phase.DONE
+	if _text_box != null:
+		_text_box.visible = false
+	if _menu != null:
+		_menu.visible = false
+	if _move_view != null:
+		_move_view.visible = false
+	finished.emit(_party_index, _move_index, _text(String(ending)))
+	closed.emit()
+
+
+func _draw_move_list() -> void:
+	if _move_model == null or _move_view == null:
+		return
+	if _move_page == null:
+		_move_page = Gen2MoveScreenPage.from_data(_data)
+	if _move_page == null:
+		return
+	var image: Image = _move_page.render(_move_model.snapshot(), _data)
+	if image == null:
+		return
+	_move_view.texture = ImageTexture.create_from_image(image)
+	_move_view.visible = true
+
+
+func _draw_yes_no() -> void:
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
+	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true

--- a/game/world/move_deleter_screen.gd.uid
+++ b/game/world/move_deleter_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cw6t40uj2iqnf

--- a/game/world/name_rater.gd
+++ b/game/world/name_rater.gd
@@ -1,0 +1,72 @@
+class_name Gen2NameRater
+extends RefCounted
+
+## `engine/events/name_rater.asm`, the rules half.
+##
+## `_NameRater` is a straight line of text, question, party selection, text and
+## naming screen; what needs a reading rather than a screen is which of its five
+## endings a chosen party member reaches, and the three routines beside it that
+## decide the last one. [Gen2NameRaterScreen] is the routine itself, on the
+## overworld's own pump; this holds nothing and answers questions.
+##
+## Every string is the cartridge's, read through [method GameData.name_rater_text]
+## off the ten `text_far` stubs `RomLayout.NAME_RATER_TEXT_ORDER` pins.
+
+## `MON_NAME_LENGTH - 1`: how many characters a nickname holds before its `@`.
+const NICKNAME_LENGTH: int = 10
+
+## The five endings `.done` prints, by the stub each one loads into hl.
+const ENDING_EGG: StringName = &"egg"
+const ENDING_TRADED: StringName = &"perfect_name"
+const ENDING_CANCEL: StringName = &"come_again"
+const ENDING_FINISHED: StringName = &"finished"
+const ENDING_SAME_NAME: StringName = &"same_name"
+
+
+## `CheckIfMonIsYourOT`, which returns carry when the member was *not* caught by
+## this trainer. Both halves are compared: the OT name and the two bytes of the
+## trainer ID, so a traded member carrying the player's own name is still refused
+## on its ID.
+static func is_your_ot(mon: Gen2SaveMon, player_name: String, player_id: int) -> bool:
+	if mon == null:
+		return false
+	return mon.original_trainer == player_name and mon.ot_id == player_id
+
+
+## `IsNewNameEmpty`: an entry of nothing but spaces, or one that begins with the
+## terminator, is treated as unchanged. The walk stops after
+## [constant NICKNAME_LENGTH] characters, which is what the naming screen holds.
+static func is_new_name_empty(entered: String) -> bool:
+	for index: int in mini(entered.length(), NICKNAME_LENGTH):
+		if entered[index] != " ":
+			return false
+	return true
+
+
+## `CompareNewToOld`, which returns carry when the two names are the same.
+## `GetNicknamenameLength` stops at [constant NICKNAME_LENGTH], so two names that
+## differ only past that length compare equal here as they do on the cartridge.
+static func is_same_name(entered: String, current: String) -> bool:
+	return entered.substr(0, NICKNAME_LENGTH) == current.substr(0, NICKNAME_LENGTH)
+
+
+## Which of `_NameRater`'s endings [param mon] reaches once it has been chosen,
+## and whether the routine carries on to the naming screen. `&""` is the answer
+## for a member that does, which is the only branch with anything left to do.
+static func ending_for(mon: Gen2SaveMon, player_name: String, player_id: int) -> StringName:
+	if mon == null:
+		return ENDING_CANCEL
+	if mon.is_egg:
+		return ENDING_EGG
+	if not is_your_ot(mon, player_name, player_id):
+		return ENDING_TRADED
+	return &""
+
+
+## The ending a settled naming screen reaches, and the nickname to write with it.
+## `.samename` covers both refusals and keeps the row's own name.
+static func ending_for_entry(entered: String, current: String) -> Dictionary:
+	var trimmed: String = entered.substr(0, NICKNAME_LENGTH)
+	if is_new_name_empty(trimmed) or is_same_name(trimmed, current):
+		return {"ending": ENDING_SAME_NAME, "nickname": current}
+	return {"ending": ENDING_FINISHED, "nickname": trimmed}

--- a/game/world/name_rater.gd.uid
+++ b/game/world/name_rater.gd.uid
@@ -1,0 +1,1 @@
+uid://bet5xuqbb0j0i

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -1,0 +1,329 @@
+class_name Gen2NameRaterScreen
+extends Control
+
+## `_NameRater` (`engine/events/name_rater.asm`) on the overworld's own pump.
+##
+## The routine is a straight line: an introduction and a `YesNoBox`, the party
+## list `SelectMonFromParty` opens, three endings that need no new name, a second
+## `YesNoBox`, `_NamingScreen`, and `.done`'s own text. [Gen2NameRater] answers
+## which ending a member reaches; this owns the boxes, the presses and the two
+## screens it opens over itself.
+##
+## The last text is deliberately not pressed here. `special NameRater` returns
+## the moment `PrintText` has drawn it and the map script's own `waitbutton` is
+## what dismisses it, so the ending text is handed to the caller through
+## [signal finished] and stands in the world's speech box for that one press.
+
+## The chosen nickname, if the routine wrote one, and the text `.done` ends on.
+## [param party_index] is -1 for every ending that renames nothing.
+signal finished(party_index: int, nickname: String, ending_text: String)
+signal closed()
+
+const TILE: int = Gen2Font.TILE
+
+const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
+
+enum Phase {
+	HELLO,
+	HELLO_ASK,
+	WHICH_MON,
+	SELECT,
+	BETTER_NAME,
+	BETTER_ASK,
+	WHAT_NAME,
+	NAMING,
+	NAMED,
+	DONE,
+}
+
+var _data: GameData = null
+var _save: Gen2SaveData = null
+var _player_name: String = ""
+var _player_id: int = 0
+## Every stub `RomLayout.NAME_RATER_TEXT_ORDER` names, by that name.
+var _texts: Dictionary = {}
+
+var _phase: int = Phase.DONE
+var _yes: bool = true
+## Which member `PartyMenuSelect` answered with, and the nickname the routine
+## settled on for it.
+var _party_index: int = -1
+var _nickname: String = ""
+var _ending: StringName = Gen2NameRater.ENDING_CANCEL
+
+var _text_box: Gen2TextBox = null
+var _menu_page: Gen2MenuPage = null
+var _menu: TextureRect = null
+var _party: Gen2PartyScreen = null
+var _naming: Gen2NamingScreenScreen = null
+
+
+## [param texts] is `GameData.name_rater_text` for each of the ten stubs, which
+## the host has already read; an empty one closes at once rather than inventing
+## a line.
+func set_context(
+	data: GameData,
+	save: Gen2SaveData,
+	texts: Dictionary,
+	player_name: String,
+	player_id: int
+) -> void:
+	_data = data
+	_save = save
+	_texts = texts.duplicate(true)
+	_player_name = player_name
+	_player_id = player_id
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _save == null or _text("hello").is_empty():
+		_phase = Phase.DONE
+		finished.emit(-1, "", "")
+		closed.emit()
+		return
+	_build()
+	_phase = Phase.HELLO
+	_show_text(_text("hello"))
+
+
+func phase() -> int:
+	return _phase
+
+
+## The YES/NO cursor, so a driver can read it without a redraw. -1 when no box
+## is up.
+func question_cursor() -> int:
+	return (0 if _yes else 1) if _phase in [Phase.HELLO_ASK, Phase.BETTER_ASK] else -1
+
+
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+func party_screen() -> Gen2PartyScreen:
+	return _party
+
+
+func naming_screen() -> Gen2NamingScreenScreen:
+	return _naming
+
+
+func handle_button(button: int) -> bool:
+	if _phase == Phase.SELECT and _party != null:
+		return _party.handle_button(button)
+	if _phase == Phase.NAMING and _naming != null:
+		return _naming.handle_button(button)
+	if _phase in [Phase.HELLO_ASK, Phase.BETTER_ASK]:
+		match button:
+			Gen2Button.UP, Gen2Button.DOWN:
+				_yes = not _yes
+				_draw_yes_no()
+				return true
+			Gen2Button.A:
+				_answer(_yes)
+				return true
+			Gen2Button.B:
+				## `YesNoBox` answers B with the carry `jp c, .cancel` takes.
+				_answer(false)
+				return true
+		return false
+	if button != Gen2Button.A or _text_box == null or not _text_box.visible:
+		return false
+	if _text_box.is_revealing() or _text_box.has_pages_left():
+		_text_box.advance()
+		return true
+	## The press `prompt` waits for. `PrintText` returns on it and the routine
+	## carries on to whatever follows the text.
+	match _phase:
+		Phase.WHICH_MON:
+			_open_party()
+		Phase.WHAT_NAME:
+			_open_naming()
+		Phase.NAMED:
+			_end(_ending)
+		_:
+			return false
+	return true
+
+
+func advance_frame() -> void:
+	if _text_box != null and _text_box.visible:
+		_text_box.advance_frame()
+		if _text_box.is_revealing() or _text_box.has_pages_left():
+			return
+	## `PrintText` on a text ending in `done` returns without a press, and both
+	## of the routine's questions are a `YesNoBox` over one.
+	if _phase == Phase.HELLO:
+		_open_question(Phase.HELLO_ASK)
+	elif _phase == Phase.BETTER_NAME:
+		_open_question(Phase.BETTER_ASK)
+
+
+func _text(name: String) -> String:
+	return String(_texts.get(name, ""))
+
+
+## Every one of the routine's texts that names `wStringBuffer1` is filled with
+## `GetCurNickname`'s own answer, which is the chosen member's nickname before
+## the copy and its new one after.
+func _filled(name: String, nickname: String) -> String:
+	return Gen2TextStream.fill_all_markers(
+		_text(name), Gen2TextStream.RAM_MARKER, nickname
+	)
+
+
+func _build() -> void:
+	_menu = TextureRect.new()
+	_menu.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_menu.visible = false
+	add_child(_menu)
+
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+func _show_text(text: String, prompt: bool = false) -> void:
+	if _text_box == null:
+		return
+	_menu.visible = false
+	_text_box.visible = true
+	_text_box.show_text(text, prompt)
+
+
+func _open_question(phase: int) -> void:
+	_phase = phase
+	_yes = true
+	_draw_yes_no()
+
+
+func _answer(yes: bool) -> void:
+	_menu.visible = false
+	if not yes:
+		_end(Gen2NameRater.ENDING_CANCEL)
+		return
+	if _phase == Phase.HELLO_ASK:
+		_phase = Phase.WHICH_MON
+		_show_text(_text("which_mon"), true)
+		return
+	_phase = Phase.WHAT_NAME
+	_show_text(_text("what_name"), true)
+
+
+## `SelectMonFromParty`, which is `InitPartyMenuWithCancel` with
+## PARTYMENUACTION_CHOOSE_POKEMON in `wPartyMenuActionText`.
+func _open_party() -> void:
+	var host: Gen2PartyScreen = PARTY_SCENE.instantiate() as Gen2PartyScreen
+	if host == null:
+		_end(Gen2NameRater.ENDING_CANCEL)
+		return
+	host.set_context(_data, _save, true)
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	host.selection_made.connect(_on_selected)
+	add_child(host)
+	host.open_selection()
+	_party = host
+	_text_box.visible = false
+	_phase = Phase.SELECT
+
+
+func _on_selected(party_index: int) -> void:
+	Gen2Screen.drop(_party)
+	_party = null
+	if party_index < 0 or party_index >= _save.party.size():
+		_end(Gen2NameRater.ENDING_CANCEL)
+		return
+	_party_index = party_index
+	var mon: Gen2SaveMon = _save.party[party_index] as Gen2SaveMon
+	_nickname = _display_name(mon)
+	var ending: StringName = Gen2NameRater.ending_for(mon, _player_name, _player_id)
+	if ending != &"":
+		_end(ending)
+		return
+	_phase = Phase.BETTER_NAME
+	_show_text(_filled("better_name", _nickname))
+
+
+## `_NamingScreen` under NAME_MON, whose header is the *species* name out of
+## `wNamedObjectIndex` rather than the nickname the row is carrying.
+func _open_naming() -> void:
+	var mon: Gen2SaveMon = _save.party[_party_index] as Gen2SaveMon
+	var species: String = String(_data.species(mon.species).get("name", ""))
+	_naming = Gen2NamingScreenScreen.new()
+	if not _naming.open(
+		_data, Gen2WorldPartyHost.nickname_prompt(species),
+		Gen2NamingScreenScreen.KIND_MON
+	):
+		## No keyboard is no new name, which is `IsNewNameEmpty`'s own answer.
+		_naming = null
+		_ending = Gen2NameRater.ENDING_SAME_NAME
+		_end_named(_nickname)
+		return
+	_text_box.visible = false
+	_naming.closed.connect(_on_named)
+	add_child(_naming)
+	_phase = Phase.NAMING
+
+
+func _on_named(entered: String) -> void:
+	Gen2Screen.drop(_naming)
+	_naming = null
+	var settled: Dictionary = Gen2NameRater.ending_for_entry(entered, _nickname)
+	_ending = StringName(settled["ending"])
+	_end_named(String(settled["nickname"]))
+
+
+## `.samename`, which the copy falls through into: `GetCurNickname` is read again
+## and `NameRaterNamedText` prints before whichever of the two endings loaded hl.
+func _end_named(nickname: String) -> void:
+	_nickname = nickname
+	_phase = Phase.NAMED
+	_show_text(_filled("named", nickname), true)
+
+
+func _end(ending: StringName) -> void:
+	## Only `NameRaterFinishedText` is reached past the `CopyBytes`; every other
+	## ending leaves the row's nickname where it was.
+	if ending != Gen2NameRater.ENDING_FINISHED:
+		_party_index = -1
+	_phase = Phase.DONE
+	if _text_box != null:
+		_text_box.visible = false
+	if _menu != null:
+		_menu.visible = false
+	finished.emit(
+		_party_index, _nickname, _filled(String(ending), _nickname)
+	)
+	closed.emit()
+
+
+func _display_name(mon: Gen2SaveMon) -> String:
+	if mon == null:
+		return ""
+	if not mon.nickname.is_empty():
+		return mon.nickname
+	return String(_data.species(mon.species).get("name", ""))
+
+
+func _draw_yes_no() -> void:
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
+	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true

--- a/game/world/name_rater_screen.gd.uid
+++ b/game/world/name_rater_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cfx6hyy5l25fk

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -117,6 +117,33 @@ static func resolve_runtime_request(
 	}
 
 
+## `_NameRater`'s own ten boxes, by the name each stub is pinned under. Empty on
+## a cache imported before format 76 carried them, which is a refusal rather than
+## a reason to invent his lines. Public because the screenshot driver opens the
+## routine with no script behind it and needs the same answer.
+static func name_rater_texts(data: GameData) -> Dictionary:
+	return _stub_run(data, RomLayout.NAME_RATER_TEXT_ORDER, "name_rater_text")
+
+
+## `MoveDeletion`'s own eight, read and refused the same way.
+static func move_deleter_texts(data: GameData) -> Dictionary:
+	return _stub_run(data, RomLayout.MOVE_DELETER_TEXT_ORDER, "move_deleter_text")
+
+
+## One whole run of `text_far` stubs off [GameData], or nothing: a run missing a
+## box is a cache too old for the routine that reads it, not a box to work round.
+static func _stub_run(data: GameData, order: Array[String], accessor: String) -> Dictionary:
+	if data == null:
+		return {}
+	var out: Dictionary = {}
+	for name: String in order:
+		var line: String = String(data.call(accessor, name))
+		if line.is_empty():
+			return {}
+		out[name] = line
+	return out
+
+
 static func choose_script_input(world: Gen2WorldAPI, choice: int) -> Array:
 	if world == null:
 		return [{"ok": false, "status": &"failed", "reason": &"missing_world"}]
@@ -146,6 +173,10 @@ static func _reason_for(kind: StringName) -> StringName:
 			return &"town_map_host_unavailable"
 		&"apricorn_selection_requested":
 			return &"apricorn_data_unavailable"
+		&"name_rater_requested":
+			return &"name_rater_data_unavailable"
+		&"move_deleter_requested":
+			return &"move_deleter_data_unavailable"
 		&"pc_requested":
 			return &"pc_host_unavailable"
 	return &"runtime_host_unavailable"
@@ -180,6 +211,16 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 				"ok": true,
 				"data": {"mart": mart, "mart_id": mart_id, "dialog": dialog_id},
 			}
+		&"name_rater_requested":
+			var lines: Dictionary = name_rater_texts(world.data)
+			if lines.is_empty():
+				return {"ok": false, "reason": &"name_rater_text_unavailable"}
+			return {"ok": true, "data": {"name_rater_text": lines}}
+		&"move_deleter_requested":
+			var boxes: Dictionary = move_deleter_texts(world.data)
+			if boxes.is_empty():
+				return {"ok": false, "reason": &"move_deleter_text_unavailable"}
+			return {"ok": true, "data": {"move_deleter_text": boxes}}
 		&"apricorn_selection_requested":
 			## `FindApricornsInBag` is the whole of the request's data: an empty
 			## bag is the source's own refusal, not a missing host.

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1270,6 +1270,26 @@ static func set_caught_data(
 	mon.caught_location = clampi(landmark, 0, 127)
 
 
+## `_NameRater`'s own `CopyBytes` into `wPartyMonNicknames`, which is the one
+## write the routine makes. Kept here rather than in the screen that asks for it:
+## every caller of `_NamingScreen` over a party row lands on this same copy.
+static func rename_party_mon(
+	save: Gen2SaveData, party_index: int, nickname: String
+) -> Dictionary:
+	if save == null:
+		return {"ok": false, "reason": &"missing_save"}
+	if party_index < 0 or party_index >= save.party.size():
+		return {"ok": false, "reason": &"invalid_party_index"}
+	var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
+	if mon == null:
+		return {"ok": false, "reason": &"invalid_party_index"}
+	var settled: String = nickname.substr(0, Gen2NameRater.NICKNAME_LENGTH)
+	if settled.is_empty():
+		return {"ok": false, "reason": &"empty_nickname"}
+	mon.nickname = settled
+	return {"ok": true, "party_index": party_index, "nickname": settled}
+
+
 ## `HatchEggs` for one party slot: the egg becomes the Pokemon it was carrying.
 ## Everything here is the source's own order, and every one of the seven writes
 ## has a reader in this project, which is why none is left out.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -131,6 +131,12 @@ var _evolution_save: Gen2SaveData = null
 ## `OverworldHatchEgg`'s screen and the save whose party it has already written.
 var _hatch_host: Gen2EggHatchScreen = null
 var _hatch_save: Gen2SaveData = null
+## `special NameRater`'s screen and the save whose party row it may rename.
+var _name_rater_host: Gen2NameRaterScreen = null
+var _name_rater_save: Gen2SaveData = null
+## `special MoveDeletion`'s screen. It needs no save of its own beside it: the
+## moves and their PP belong to the save it was handed and it writes them itself.
+var _move_deleter_host: Gen2MoveDeleterScreen = null
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
@@ -610,6 +616,10 @@ func advance_frame() -> void:
 		_evolution_host.advance_frame()
 	if _hatch_host != null:
 		_hatch_host.advance_frame()
+	if _name_rater_host != null:
+		_name_rater_host.advance_frame()
+	if _move_deleter_host != null:
+		_move_deleter_host.advance_frame()
 	_spending_frame = false
 
 
@@ -752,7 +762,8 @@ func _overlay_open() -> bool:
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
 		or _pokedex_host != null or _credits_host != null \
-		or _evolution_host != null or _hatch_host != null
+		or _evolution_host != null or _hatch_host != null \
+		or _name_rater_host != null or _move_deleter_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -851,6 +862,15 @@ func _handle_button(button: int) -> bool:
 	## map loop suspended in exactly the same place.
 	if _hatch_host != null:
 		_hatch_host.handle_button(button)
+		return true
+	## `special NameRater` runs inside `opentext`, so the map loop is suspended
+	## behind it the same way and its own two screens are reached through it.
+	if _name_rater_host != null:
+		_name_rater_host.handle_button(button)
+		return true
+	## `special MoveDeletion` is the same shape one house further on.
+	if _move_deleter_host != null:
+		_move_deleter_host.handle_button(button)
 		return true
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -1209,6 +1229,127 @@ func _on_hatch_closed() -> void:
 	if _renderer != null:
 		_renderer.refresh()
 	_refresh_labels()
+
+
+## `special NameRater`. `_NameRater` owns its own boxes and both of the screens
+## it opens, so the whole routine is one host and the script stays suspended
+## behind it, which is what `opentext` left it doing.
+func _open_name_rater() -> bool:
+	if _name_rater_host != null or _world == null or _data == null:
+		return false
+	var texts: Dictionary = Gen2WorldHost.name_rater_texts(_data)
+	if texts.is_empty():
+		_script_prompt = "Name Rater unavailable: name_rater_text_unavailable"
+		return false
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null:
+		_script_prompt = "The Name Rater needs a validated save"
+		return false
+	var host := Gen2NameRaterScreen.new()
+	host.set_context(_data, save, texts, _world.player_name(), _world.player_id())
+	host.finished.connect(_on_name_rater_finished)
+	host.closed.connect(_on_name_rater_closed)
+	host.z_index = 30
+	_name_rater_save = save
+	_name_rater_host = host
+	_screen.display(host)
+	_script_prompt = "Name Rater"
+	_refresh_labels()
+	return true
+
+
+## The `CopyBytes` and the text `.done` ends on. The text is put in the world's
+## own speech box rather than pressed here: `special NameRater` returns as soon
+## as `PrintText` has drawn it and the script's `waitbutton` is that press.
+func _on_name_rater_finished(
+	party_index: int, nickname: String, ending_text: String
+) -> void:
+	if party_index >= 0 and _name_rater_save != null:
+		Gen2WorldPartyHost.rename_party_mon(_name_rater_save, party_index, nickname)
+	if not ending_text.is_empty() and _text_box != null and _text_box.font != null:
+		_apply_text_box_options()
+		_text_awaits_press = false
+		_text_box.show_text(ending_text, false)
+		_text_box.visible = true
+
+
+func _on_name_rater_closed() -> void:
+	var host: Gen2NameRaterScreen = _name_rater_host
+	_name_rater_host = null
+	_name_rater_save = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	if _world != null:
+		_show_script_results(_world.complete_runtime_request({"ok": true}))
+	_refresh_labels()
+
+
+## `special MoveDeletion`, hosted exactly as `special NameRater` is.
+func _open_move_deleter() -> bool:
+	if _move_deleter_host != null or _world == null or _data == null:
+		return false
+	var texts: Dictionary = Gen2WorldHost.move_deleter_texts(_data)
+	if texts.is_empty():
+		_script_prompt = "Move deleter unavailable: move_deleter_text_unavailable"
+		return false
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null:
+		_script_prompt = "The move deleter needs a validated save"
+		return false
+	var host := Gen2MoveDeleterScreen.new()
+	host.set_context(_data, save, texts)
+	host.finished.connect(_on_move_deleter_finished)
+	host.closed.connect(_on_move_deleter_closed)
+	host.sfx_requested.connect(_play_sfx)
+	host.z_index = 30
+	_move_deleter_host = host
+	_screen.display(host)
+	_script_prompt = "Move deleter"
+	_refresh_labels()
+	return true
+
+
+## The screen has already written the row, since the moves and their PP belong
+## to the save it was handed. What is left is the text `.done` ends on, which
+## the script's own `waitbutton` presses.
+func _on_move_deleter_finished(
+	_party_index: int, _move_index: int, ending_text: String
+) -> void:
+	if ending_text.is_empty() or _text_box == null or _text_box.font == null:
+		return
+	_apply_text_box_options()
+	_text_awaits_press = false
+	_text_box.show_text(ending_text, false)
+	_text_box.visible = true
+
+
+func _on_move_deleter_closed() -> void:
+	var host: Gen2MoveDeleterScreen = _move_deleter_host
+	_move_deleter_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	if _world != null:
+		_show_script_results(_world.complete_runtime_request({"ok": true}))
+	_refresh_labels()
+
+
+## Public screenshot driver for `special MoveDeletion`, the same way
+## [method preview_name_rater] is: no fixture cell reaches it.
+func preview_move_deleter() -> void:
+	if _world == null or _data == null or _move_deleter_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Move deleter preview needs a party"
+		_refresh_labels()
+		return
+	save.party[0].is_egg = false
+	_injected_save = save
+	_open_move_deleter()
 
 
 ## `EnterMap`'s own tail, which a warp reaches once its setup script has run and
@@ -1973,6 +2114,27 @@ func preview_item_evolution_use() -> void:
 		if int((rows[index] as Dictionary).get("item", 0)) == int(stone["item"]):
 			_start_menu_host.set("_pack_cursor", index)
 			break
+
+
+## Public screenshot driver for `special NameRater`, which no cell of the
+## fixture maps reaches: it stands a member the player caught in the first party
+## slot and opens the routine on it, so every box, both questions and the party
+## list can be photographed on any map.
+func preview_name_rater() -> void:
+	if _world == null or _data == null or _name_rater_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Name Rater preview needs a party"
+		_refresh_labels()
+		return
+	var mon: Gen2SaveMon = save.party[0]
+	mon.is_egg = false
+	mon.original_trainer = save.player_name
+	mon.ot_id = save.player_id
+	_injected_save = save
+	_world.set_player_id(save.player_id)
+	_open_name_rater()
 
 
 ## Public screenshot driver and scene-test entry for `OverworldHatchEgg`: it
@@ -4260,6 +4422,14 @@ func _show_script_results(results: Array) -> void:
 					_script_prompt = _bug_contest_placings_text(judged)
 					_show_script_results(judged_results)
 					return
+				if StringName(request.get("kind", &"")) == &"name_rater_requested":
+					if _open_name_rater():
+						break
+					continue
+				if StringName(request.get("kind", &"")) == &"move_deleter_requested":
+					if _open_move_deleter():
+						break
+					continue
 				if StringName(request.get("kind", &"")) == &"swarm_requested":
 					var values: Dictionary = request.get("values", {})
 					var swarm_results: Array = _world.complete_runtime_request({

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -156,6 +156,16 @@ const SNORLAX_PROXIMITY_CELLS: Array[Vector2i] = [
 ## special_index() already normalizes. maps/KurtsHouse.asm's `.AskApricorn`
 ## branches on wScriptVar afterwards, one label per apricorn.
 const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
+## MoveDeletion, 33 in both profiles: it sits below the first index the two
+## tables disagree on, so `special_index()` leaves it alone. `MoveDeletion` owns
+## the same shape `NameRater` does, one house further on, so it is one host
+## request as well.
+const SPECIAL_MOVE_DELETION: int = 33
+## NameRater, 87 in Crystal and 86 in Gold/Silver, which special_index()
+## already normalizes. `_NameRater` owns its own texts, its two `YesNoBox`es and
+## the party list `SelectMonFromParty` opens, so the whole routine is one host
+## request; the map script's own `waitbutton` follows it.
+const SPECIAL_NAME_RATER: int = 87
 ## DisplayUnownWords, which is Crystal's alone: pokegold's table stops well
 ## before it, so no Gold or Silver script can reach this index and neither dump
 ## ships the words. The four wall patterns are Crystal bg events, two per
@@ -770,6 +780,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## `BugContestJudging` answers with the placing, which the results script
 		## reads out of wScriptVar exactly as the marts and the PC do.
 		&"bug_contest_judging_requested",
+		## Neither routine writes anything a script reads: each returns and the
+		## map's own `waitbutton` presses the text it left standing.
+		&"name_rater_requested", &"move_deleter_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -2491,6 +2504,14 @@ func _execute_special(special: int) -> Dictionary:
 			_emit_runtime_event(&"roaming_mons_initialized", {
 				"special": special,
 				"count": state.roaming_mons().size() if state != null else 0,
+			})
+		SPECIAL_NAME_RATER:
+			return _stage_runtime_request(&"name_rater_requested", {
+				"special": special,
+			})
+		SPECIAL_MOVE_DELETION:
+			return _stage_runtime_request(&"move_deleter_requested", {
+				"special": special,
 			})
 		SPECIAL_SELECT_APRICORN_FOR_KURT:
 			## Both of the special's boxes are the host's; it answers with the

--- a/tests/integration/test_world_mon_specials.gd
+++ b/tests/integration/test_world_mon_specials.gd
@@ -1,0 +1,361 @@
+extends GutTest
+
+## Scene integration for the two specials that open `SelectMonFromParty`:
+## `NameRater` and `MoveDeletion`. Each is its own line through the overworld,
+## two `YesNoBox`es, the party list, and an ending text.
+##
+## Both maps are `opentext / special / waitbutton / closetext / end`, so the last
+## text either special prints is dismissed by the script's own `waitbutton` and
+## not by the special. That ordering is what this covers; [Gen2NameRater]'s and
+## [Gen2MoveDeleter]'s own branches are unit tested beside the party host.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const PLAYER_CELL: Vector2i = Vector2i(2, 2)
+const TALK_CELL: Vector2i = Vector2i(4, 5)
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_write_name_rater_script()
+	_data = GameData.open_directory(Fixture.directory())
+	Gen2OptionsStore.use_test_path()
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
+
+
+func after_each() -> void:
+	## The routine drops its party list and its naming screen with `queue_free`,
+	## which the tree runs on the next frame and this test never spends: the
+	## presses above are hardware frames, not process ones.
+	await get_tree().process_frame
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+func _write_name_rater_script(
+	special: int = Gen2WorldScriptRunner.SPECIAL_NAME_RATER
+) -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		Gen2WorldScript.SPECIAL, special, 0x00,
+		Gen2WorldScript.WAITBUTTON,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+
+
+func _open_world() -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = PLAYER_CELL
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, Gen2WorldState.new()
+	)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	save.world = world.snapshot()
+	world.set_player_id(save.player_id)
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	## The box reveals on hardware frames and this test counts presses, so the
+	## frames it spends have to be the ones it asks for.
+	_world_screen.set_process(false)
+	var mon: Gen2SaveMon = save.party[0]
+	mon.is_egg = false
+	mon.nickname = "SPARKY"
+	mon.original_trainer = save.player_name
+	mon.ot_id = save.player_id
+
+
+func _run_script() -> void:
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(TALK_CELL)
+	)
+
+
+func _host() -> Gen2NameRaterScreen:
+	return _world_screen._name_rater_host
+
+
+## Spends whatever the routine's box still owes, which is what a player waits
+## through, plus the frame `advance_frame` reads it on: `PrintText` returning is
+## what opens a `YesNoBox`, and no press can shorten the printing.
+func _settle() -> void:
+	var guard: int = 600
+	while guard > 0:
+		var host: Gen2NameRaterScreen = _host()
+		if host == null or host._text_box == null or not host._text_box.is_revealing():
+			break
+		_world_screen.advance_frame()
+		guard -= 1
+	_world_screen.advance_frame()
+
+
+func _press(button: int) -> void:
+	_settle()
+	_world_screen.press_button(button)
+
+
+## Walks to the party list: hello, YES, which_mon, the press `prompt` waits for.
+func _reach_party() -> void:
+	_run_script()
+	_press(Gen2Button.A)
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.WHICH_MON)
+	_press(Gen2Button.A)
+
+
+func test_the_special_opens_the_routine_and_holds_the_world() -> void:
+	await _open_world()
+	_run_script()
+	assert_not_null(_host())
+	assert_false(_world_screen.move_player(Vector2i.RIGHT))
+	assert_false(_world_screen.interact())
+	_settle()
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.HELLO_ASK)
+	assert_eq(_host().question_cursor(), 0)
+
+
+## `jp c, .cancel`: NO on the first question is `NameRaterComeAgainText`, and
+## nothing after it runs.
+func test_no_on_the_introduction_ends_on_come_again() -> void:
+	await _open_world()
+	_run_script()
+	_settle()
+	_world_screen.press_button(Gen2Button.DOWN)
+	_world_screen.press_button(Gen2Button.A)
+	assert_null(_host())
+	assert_true(_world_screen._text_box.visible)
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.name_rater_text("come_again").split("\n"))
+	)
+
+
+## The ending text is the script's, not the special's: `special NameRater`
+## returns with it standing and the map's own `waitbutton` is the press.
+func test_the_ending_text_waits_on_the_scripts_own_waitbutton() -> void:
+	await _open_world()
+	_run_script()
+	_settle()
+	_world_screen.press_button(Gen2Button.B)
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"button"
+	)
+
+
+func test_the_party_list_is_select_mon_from_party() -> void:
+	await _open_world()
+	await _reach_party()
+	var party: Gen2PartyScreen = _host().party_screen()
+	assert_not_null(party)
+	assert_eq(party._prompt(), Gen2PartyScreen.PROMPT_CHOOSE)
+	## A on a member answers the caller rather than opening `MonSubmenu`.
+	party.handle_button(Gen2Button.A)
+	assert_null(_host().party_screen())
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.BETTER_NAME)
+
+
+## `PartyMenuSelect`'s carry: B over the list is the same `.cancel` a NO is.
+func test_cancelling_the_party_list_ends_on_come_again() -> void:
+	await _open_world()
+	await _reach_party()
+	_host().party_screen().handle_button(Gen2Button.B)
+	assert_null(_host())
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.name_rater_text("come_again").split("\n"))
+	)
+
+
+## `.traded`: `CheckIfMonIsYourOT` is read before either question about the
+## name, so a traded member never reaches the naming screen.
+func test_a_traded_member_ends_on_perfect_name_with_its_nickname_filled() -> void:
+	await _open_world()
+	_world_screen.active_save().party[0].ot_id += 1
+	await _reach_party()
+	_host().party_screen().handle_button(Gen2Button.A)
+	assert_null(_host())
+	var shown: String = " ".join(_world_screen._text_box.text_lines())
+	assert_true(shown.contains("SPARKY"), shown)
+	assert_false(shown.contains(Gen2TextStream.RAM_MARKER), shown)
+
+
+## `.egg`: the EGG test runs before `GetCurNickname`, so an egg is refused
+## whoever caught it.
+func test_an_egg_ends_on_the_egg_text() -> void:
+	await _open_world()
+	_world_screen.active_save().party[0].is_egg = true
+	await _reach_party()
+	_host().party_screen().handle_button(Gen2Button.A)
+	assert_null(_host())
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.name_rater_text("egg").split("\n"))
+	)
+
+
+## The whole line through, ending in the `CopyBytes` into the party row.
+func test_a_new_name_is_written_to_the_party_row() -> void:
+	await _open_world()
+	await _reach_party()
+	_host().party_screen().handle_button(Gen2Button.A)
+	_settle()
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.BETTER_ASK)
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.WHAT_NAME)
+	_press(Gen2Button.A)
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.NAMING)
+
+	var naming: Gen2NamingScreenScreen = _host().naming_screen()
+	assert_not_null(naming)
+	naming.closed.emit("BOLT")
+	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.NAMED)
+	_press(Gen2Button.A)
+	assert_null(_host())
+	assert_eq(_world_screen.active_save().party[0].nickname, "BOLT")
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.name_rater_text("finished").split("\n"))
+	)
+
+
+## `IsNewNameEmpty` reaching `.samename`: `NameRaterSameNameText` prints and the
+## row keeps the name it had.
+func test_an_empty_entry_leaves_the_row_alone() -> void:
+	await _open_world()
+	await _reach_party()
+	_host().party_screen().handle_button(Gen2Button.A)
+	_settle()
+	_world_screen.press_button(Gen2Button.A)
+	_press(Gen2Button.A)
+	_host().naming_screen().closed.emit("")
+	_press(Gen2Button.A)
+	assert_null(_host())
+	assert_eq(_world_screen.active_save().party[0].nickname, "SPARKY")
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.name_rater_text("same_name").split("\n"))
+	)
+
+
+## The move deleter from here down. Same harness, one special further on: the
+## script is rewritten before the world is opened, so `_host()` below is the
+## other routine's.
+func _open_deleter_world() -> void:
+	_write_name_rater_script(Gen2WorldScriptRunner.SPECIAL_MOVE_DELETION)
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world()
+	var mon: Gen2SaveMon = _world_screen.active_save().party[0]
+	mon.moves = [1, 2, 0, 0]
+	mon.pp = [10, 20, 0, 0]
+
+
+func _deleter() -> Gen2MoveDeleterScreen:
+	return _world_screen._move_deleter_host
+
+
+func _settle_deleter() -> void:
+	var guard: int = 600
+	while guard > 0:
+		var host: Gen2MoveDeleterScreen = _deleter()
+		if host == null or host._text_box == null or not host._text_box.is_revealing():
+			break
+		_world_screen.advance_frame()
+		guard -= 1
+	_world_screen.advance_frame()
+
+
+## Walks to the move list: intro, YES, which_mon, the party list, the member,
+## which_move, the press `prompt` waits for.
+func _reach_move_list() -> void:
+	_run_script()
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.A)
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.A)
+	_deleter().party_screen().handle_button(Gen2Button.A)
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.A)
+
+
+func test_the_deleter_special_opens_its_own_routine() -> void:
+	await _open_deleter_world()
+	_run_script()
+	assert_not_null(_deleter())
+	assert_null(_world_screen._name_rater_host)
+	_settle_deleter()
+	assert_eq(_deleter().phase(), Gen2MoveDeleterScreen.Phase.INTRO_ASK)
+
+
+## `.onlyonemove` is read off the second slot, before the move list is ever
+## drawn.
+func test_a_member_with_one_move_is_refused_before_the_list() -> void:
+	await _open_deleter_world()
+	_world_screen.active_save().party[0].moves = [1, 0, 0, 0]
+	_run_script()
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.A)
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.A)
+	_deleter().party_screen().handle_button(Gen2Button.A)
+	assert_null(_deleter())
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.move_deleter_text("knows_one").split("\n"))
+	)
+
+
+## `DeleteMoveScreen2DMenuData` accepts up, down, A and B and nothing else, so
+## the list neither cycles between members nor holds a move.
+func test_the_move_list_neither_cycles_nor_swaps() -> void:
+	await _open_deleter_world()
+	await _reach_move_list()
+	var moves: Gen2MoveScreen = _deleter().move_screen()
+	assert_not_null(moves)
+	assert_false(moves.handle_button(Gen2Button.RIGHT))
+	assert_false(moves.handle_button(Gen2Button.LEFT))
+	assert_eq(moves.snapshot()["held"], -1)
+
+
+## The whole line through: the move and its PP leave together and the ending
+## text is the script's.
+func test_a_deleted_move_takes_its_pp_with_it() -> void:
+	await _open_deleter_world()
+	await _reach_move_list()
+	_deleter().move_screen().handle_button(Gen2Button.DOWN)
+	_deleter().move_screen().handle_button(Gen2Button.A)
+	assert_eq(_deleter().phase(), Gen2MoveDeleterScreen.Phase.DELETE_ASK)
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.A)
+	assert_null(_deleter())
+	var mon: Gen2SaveMon = _world_screen.active_save().party[0]
+	assert_eq(mon.moves, [1, 0, 0, 0])
+	assert_eq(mon.pp, [10, 0, 0, 0])
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.move_deleter_text("forgot").split("\n"))
+	)
+
+
+## NO on the second question is `.declined`, and nothing is written.
+func test_no_on_the_confirmation_leaves_the_moves_alone() -> void:
+	await _open_deleter_world()
+	await _reach_move_list()
+	_deleter().move_screen().handle_button(Gen2Button.A)
+	_settle_deleter()
+	_world_screen.press_button(Gen2Button.B)
+	assert_null(_deleter())
+	assert_eq(_world_screen.active_save().party[0].moves, [1, 2, 0, 0])
+	assert_eq(
+		" ".join(_world_screen._text_box.text_lines()),
+		" ".join(_data.move_deleter_text("come_again").split("\n"))
+	)

--- a/tests/integration/test_world_mon_specials.gd.uid
+++ b/tests/integration/test_world_mon_specials.gd.uid
@@ -1,0 +1,1 @@
+uid://7l1dxkajdsnl

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -92,6 +92,8 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_battle_graphics(directory, manifest)
 	_write_splash_graphics(directory, manifest, game_id == RomRegistry.CRYSTAL)
 	_write_menu_text(manifest)
+	_write_name_rater_text(manifest)
+	_write_move_deleter_text(manifest)
 	_write_pokecenter_pc(manifest)
 	_write_unown_words(manifest)
 	_write_credits(directory, manifest, crystal_commands)
@@ -378,6 +380,40 @@ static func _write_overworld_graphics(directory: String) -> void:
 	icon.resize(8 * Gen2Tiles.TILE_PIXELS)
 	icon.fill(1)
 	RomCache.write_indices(RomCache.overworld_icon_path(directory, 1), icon)
+
+
+## `engine/events/name_rater.asm`'s ten boxes, shortened but keeping the two
+## things the routine reads: which ending each is, and the `wStringBuffer1`
+## markers `_NameRaterPerfectNameText` carries twice.
+static func _write_name_rater_text(manifest: Dictionary) -> void:
+	manifest["name_rater_text"] = {
+		"hello": "Hello, hello!",
+		"which_mon": "Which POKéMON?",
+		"better_name": "Hm… <RAM_D073>…\nA decent name.",
+		"what_name": "What name, then?",
+		"finished": "That's a better\nname than before!",
+		"come_again": "OK, then. Come\nagain sometime.",
+		"perfect_name": "Hm… <RAM_D073>?\nTreat <RAM_D073>\nwith loving care.",
+		"egg": "Whoa… That's just\nan EGG.",
+		"same_name": "But this new name\nis much better!",
+		"named": "This POKéMON is\nnow named <RAM_D073>.",
+	}
+
+
+## `engine/events/move_deleter.asm`'s eight, shortened the same way: which
+## ending each is, and the one `wStringBuffer1` marker `_AskDeleteMoveText`
+## carries.
+static func _write_move_deleter_text(manifest: Dictionary) -> void:
+	manifest["move_deleter_text"] = {
+		"knows_one": "That POKéMON knows\nonly one move.",
+		"ask_delete": "Oh, make it forget\n<RAM_D073>?",
+		"forgot": "Done! Your POKéMON\nforgot the move.",
+		"egg": "An EGG doesn't\nknow any moves!",
+		"come_again": "No? Come visit me\nagain.",
+		"which_move": "Which move should\nit forget, then?",
+		"intro": "Um… I'm the MOVE\nDELETER.",
+		"which_mon": "Which POKéMON?",
+	}
 
 
 ## The start menu's nine descriptions and the pack's five texts, as the cartridge

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -35,6 +35,99 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory())
 
 
+## `.onlyonemove` reads `wPartyMon1Moves + 1`, the second slot rather than a
+## count, so a hole in the list is read as one move whatever stands behind it.
+func test_move_deleter_reads_the_second_slot_not_a_move_count() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.is_egg = false
+	mon.moves = [1, 0, 5, 0]
+	assert_eq(Gen2MoveDeleter.ending_for(mon), Gen2MoveDeleter.ENDING_ONLY_ONE_MOVE)
+	mon.moves = [1, 2, 0, 0]
+	assert_eq(Gen2MoveDeleter.ending_for(mon), &"")
+	mon.is_egg = true
+	assert_eq(Gen2MoveDeleter.ending_for(mon), Gen2MoveDeleter.ENDING_EGG)
+
+
+## `.DeleteMove`: the slots above come down and the last is zeroed, moves and PP
+## in the same shape, so the two lists never fall out of step.
+func test_deleting_a_move_shifts_its_pp_with_it() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.is_egg = false
+	mon.moves = [10, 20, 30, 40]
+	mon.pp = [11, 22, 33, 44]
+	assert_true(Gen2MoveDeleter.delete_move(mon, 1))
+	assert_eq(mon.moves, [10, 30, 40, 0])
+	assert_eq(mon.pp, [11, 33, 44, 0])
+	assert_true(Gen2MoveDeleter.delete_move(mon, 2))
+	assert_eq(mon.moves, [10, 30, 0, 0])
+	assert_eq(mon.pp, [11, 33, 0, 0])
+	assert_false(Gen2MoveDeleter.delete_move(mon, 2), "an empty slot is not a move")
+
+
+## `CheckIfMonIsYourOT` compares both halves: a member carrying the player's own
+## name but a different ID is still a traded one, which is `.traded`.
+func test_name_rater_refuses_a_traded_member_on_either_half() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.is_egg = false
+	mon.original_trainer = "GOLD"
+	mon.ot_id = 1234
+	assert_true(Gen2NameRater.is_your_ot(mon, "GOLD", 1234))
+	assert_false(Gen2NameRater.is_your_ot(mon, "GOLD", 4321))
+	assert_false(Gen2NameRater.is_your_ot(mon, "KRIS", 1234))
+	assert_eq(Gen2NameRater.ending_for(mon, "KRIS", 1234), Gen2NameRater.ENDING_TRADED)
+	assert_eq(Gen2NameRater.ending_for(mon, "GOLD", 1234), &"")
+
+
+## `AnimateMon_CheckIfPokemon`'s own refusal one routine further on: the egg
+## check runs before `GetCurNickname`, so an egg never reaches the OT test.
+func test_name_rater_refuses_an_egg_before_the_ot_test() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.is_egg = true
+	mon.original_trainer = "SOMEONE"
+	mon.ot_id = 9
+	assert_eq(Gen2NameRater.ending_for(mon, "GOLD", 1234), Gen2NameRater.ENDING_EGG)
+
+
+## `IsNewNameEmpty` and `CompareNewToOld`, the two refusals that reach
+## `.samename` and leave the row's own nickname where it was.
+func test_name_rater_treats_an_empty_or_unchanged_entry_as_unchanged() -> void:
+	assert_true(Gen2NameRater.is_new_name_empty(""))
+	assert_true(Gen2NameRater.is_new_name_empty("     "))
+	assert_false(Gen2NameRater.is_new_name_empty(" A "))
+	for entered: String in ["", "   ", "SPARKY"]:
+		var settled: Dictionary = Gen2NameRater.ending_for_entry(entered, "SPARKY")
+		assert_eq(settled["ending"], Gen2NameRater.ENDING_SAME_NAME, entered)
+		assert_eq(settled["nickname"], "SPARKY", entered)
+	var renamed: Dictionary = Gen2NameRater.ending_for_entry("BOLT", "SPARKY")
+	assert_eq(renamed["ending"], Gen2NameRater.ENDING_FINISHED)
+	assert_eq(renamed["nickname"], "BOLT")
+
+
+## `GetNicknamenameLength` stops at MON_NAME_LENGTH - 1, so two entries that
+## differ only past ten characters are the same name on the cartridge, and the
+## `CopyBytes` that follows moves ten bytes.
+func test_name_rater_compares_and_writes_ten_characters() -> void:
+	var settled: Dictionary = Gen2NameRater.ending_for_entry(
+		"ABCDEFGHIJKL", "ABCDEFGHIJ"
+	)
+	assert_eq(settled["ending"], Gen2NameRater.ENDING_SAME_NAME)
+	var written: Dictionary = Gen2WorldPartyHost.rename_party_mon(
+		_save, 0, "ABCDEFGHIJKL"
+	)
+	assert_true(written["ok"])
+	assert_eq(_save.party[0].nickname, "ABCDEFGHIJ")
+
+
+func test_rename_refuses_a_slot_no_party_row_stands_in() -> void:
+	assert_false(Gen2WorldPartyHost.rename_party_mon(_save, -1, "BOLT")["ok"])
+	assert_false(
+		Gen2WorldPartyHost.rename_party_mon(_save, _save.party.size(), "BOLT")["ok"]
+	)
+	assert_eq(
+		Gen2WorldPartyHost.rename_party_mon(_save, 0, "")["reason"], &"empty_nickname"
+	)
+
+
 func test_givepoke_appends_a_real_save_mon_and_resumes_the_script() -> void:
 	_set_script(0x6200)
 	var waiting: Array = _world.dispatch_script_events(Vector2i(2, 2))

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -326,6 +326,122 @@ func test_menu_input_can_be_cancelled_without_selecting_an_option() -> void:
 	) == false)
 
 
+## `special NameRater`, the same shape Kurt's own special is staged with.
+func _set_name_rater_script() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6300)] = [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_NAME_RATER, 0x00,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	var maps: Array = RomCache.read_json(RomCache.world_maps_path(Fixture.directory()))
+	for raw: Dictionary in maps:
+		if int(raw.get("group", -1)) != Fixture.MAP_GROUP \
+		or int(raw.get("number", -1)) != Fixture.MAP_NUMBER:
+			continue
+		var events: Dictionary = raw.get("events", {})
+		events["coord_events"] = [{"x": 7, "y": 6, "script": 0x6300}]
+		raw["events"] = events
+	RomCache.write_json(RomCache.world_maps_path(Fixture.directory()), maps)
+	_data = GameData.open_directory(Fixture.directory())
+	_world = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6),
+		Gen2WorldState.new({}, {}, {})
+	)
+	_save = Gen2SaveStore.create_development_save(_data, 0)
+	_save.world = _world.snapshot()
+
+
+func test_name_rater_special_stages_a_request_carrying_all_ten_boxes() -> void:
+	_set_name_rater_script()
+	var waiting: Array = _world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+	assert_eq(_world.pending_runtime_request()["kind"], &"name_rater_requested")
+
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_true(resolved["ok"], JSON.stringify(resolved))
+	var lines: Dictionary = resolved["data"]["name_rater_text"]
+	assert_eq(lines.size(), RomLayout.NAME_RATER_TEXT_ORDER.size())
+	for name: String in RomLayout.NAME_RATER_TEXT_ORDER:
+		assert_false(String(lines[name]).is_empty(), name)
+
+
+## A cache imported before format 76 carries none of the boxes, and inventing
+## his lines would be worse than saying the host cannot run.
+func test_name_rater_refuses_a_cache_without_his_boxes() -> void:
+	var manifest: Dictionary = RomCache.read_manifest(Fixture.directory())
+	manifest.erase("name_rater_text")
+	RomCache.write_json(RomCache.manifest_path(Fixture.directory()), manifest)
+	_set_name_rater_script()
+	assert_eq(_world.dispatch_script_events(Vector2i(7, 6))[0]["status"], &"waiting")
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_false(resolved["ok"])
+	assert_eq(resolved["reason"], &"name_rater_text_unavailable")
+
+
+## `_NameRaterPerfectNameText` names `wStringBuffer1` twice, so filling the
+## first marker alone leaves the second on screen.
+func test_every_nickname_marker_in_a_box_is_filled() -> void:
+	var filled: String = Gen2TextStream.fill_all_markers(
+		_data.name_rater_text("perfect_name"), Gen2TextStream.RAM_MARKER, "SPARKY"
+	)
+	assert_false(filled.contains(Gen2TextStream.RAM_MARKER))
+	assert_eq(filled.count("SPARKY"), 2)
+
+
+## `special MoveDeletion`, staged the same way.
+func _set_move_deleter_script() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6300)] = [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_MOVE_DELETION, 0x00,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	var maps: Array = RomCache.read_json(RomCache.world_maps_path(Fixture.directory()))
+	for raw: Dictionary in maps:
+		if int(raw.get("group", -1)) != Fixture.MAP_GROUP \
+		or int(raw.get("number", -1)) != Fixture.MAP_NUMBER:
+			continue
+		var events: Dictionary = raw.get("events", {})
+		events["coord_events"] = [{"x": 7, "y": 6, "script": 0x6300}]
+		raw["events"] = events
+	RomCache.write_json(RomCache.world_maps_path(Fixture.directory()), maps)
+	_data = GameData.open_directory(Fixture.directory())
+	_world = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6),
+		Gen2WorldState.new({}, {}, {})
+	)
+	_save = Gen2SaveStore.create_development_save(_data, 0)
+	_save.world = _world.snapshot()
+
+
+func test_move_deleter_special_stages_a_request_carrying_all_eight_boxes() -> void:
+	_set_move_deleter_script()
+	var waiting: Array = _world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+	assert_eq(_world.pending_runtime_request()["kind"], &"move_deleter_requested")
+
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_true(resolved["ok"], JSON.stringify(resolved))
+	var lines: Dictionary = resolved["data"]["move_deleter_text"]
+	assert_eq(lines.size(), RomLayout.MOVE_DELETER_TEXT_ORDER.size())
+	for name: String in RomLayout.MOVE_DELETER_TEXT_ORDER:
+		assert_false(String(lines[name]).is_empty(), name)
+
+
+func test_move_deleter_refuses_a_cache_without_his_boxes() -> void:
+	var manifest: Dictionary = RomCache.read_manifest(Fixture.directory())
+	manifest.erase("move_deleter_text")
+	RomCache.write_json(RomCache.manifest_path(Fixture.directory()), manifest)
+	_set_move_deleter_script()
+	assert_eq(_world.dispatch_script_events(Vector2i(7, 6))[0]["status"], &"waiting")
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_false(resolved["ok"])
+	assert_eq(resolved["reason"], &"move_deleter_text_unavailable")
+
+
 func _write_services() -> void:
 	_write_services_at(Fixture.directory())
 

--- a/tools/checks/mon_specials.gd
+++ b/tools/checks/mon_specials.gd
@@ -1,0 +1,247 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the two specials that open `SelectMonFromParty` against freshly
+## imported real caches: the boxes each prints, the markers they carry, and every
+## map script in the corpus that reaches either, rather than a sampled one.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## `engine/events/name_rater.asm` and `engine/events/move_deleter.asm`,
+## `data/text/common_2.asm`'s ten `_NameRater*` texts and `common_3.asm`'s eight
+## `_Deleter*` ones, `data/events/special_pointers.asm`, and the two
+## `*NameRater.asm` maps beside `MoveDeletersHouse.asm`.
+##
+## One pinned address per cartridge finds every text, so what says the address is
+## right is the content, the way the mart's own topic reads its stubs. The corpus
+## half is the script sweep: the Name Rater's index differs by one between the two
+## command profiles where the deleter's does not, so a wrong normalization shows
+## up as a map reaching a different routine, and the surrounding `opentext`/`waitbutton`/`closetext` is
+## what says the ending text is pressed once rather than twice.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- mon_specials
+
+## Enough of each of the Name Rater's boxes to say which stub decoded. His two
+## questions and the three endings that need no new name are the branches a
+## reading gets wrong.
+const EXPECTED_TEXT_OPENINGS: Dictionary = {
+	"hello": "Hello, hello! I'm",
+	"which_mon": "Which POKéMON's",
+	"better_name": "Hm… ",
+	"what_name": "All right. What",
+	"finished": "That's a better",
+	"come_again": "OK, then. Come",
+	"perfect_name": "Hm… ",
+	"egg": "Whoa… That's just",
+	"same_name": "It might look the",
+	"named": "All right. This",
+}
+
+## How many `text_ram wStringBuffer1` each of his boxes carries. `_NameRaterPerfectNameText`
+## is the one with two, which is why the screen fills every marker rather than
+## the first.
+const EXPECTED_MARKERS: Dictionary = {
+	"hello": 0,
+	"which_mon": 0,
+	"better_name": 1,
+	"what_name": 0,
+	"finished": 0,
+	"come_again": 0,
+	"perfect_name": 2,
+	"egg": 0,
+	"same_name": 0,
+	"named": 1,
+}
+
+## `maps/GoldenrodNameRater.asm` and `maps/LavenderNameRater.asm` for one,
+## `maps/MoveDeletersHouse.asm` for the other. Both counts are the same on every
+## cartridge.
+const EXPECTED_SITES: Dictionary = {"name_rater": 2, "move_deleter": 1}
+
+## The move deleter's own eight, read the same way.
+const EXPECTED_DELETER_OPENINGS: Dictionary = {
+	"knows_one": "That POKéMON knows",
+	"ask_delete": "Oh, make it forget",
+	"forgot": "Done! Your POKéMON",
+	"egg": "An EGG doesn't",
+	"come_again": "No? Come visit me",
+	"which_move": "Which move should",
+	"intro": "Um… Oh, yes, I'm",
+	"which_mon": "Which POKéMON?",
+}
+
+## `_AskDeleteMoveText` is the one of the eight that names `wStringBuffer1`.
+const EXPECTED_DELETER_MARKERS: Dictionary = {
+	"knows_one": 0, "ask_delete": 1, "forgot": 0, "egg": 0,
+	"come_again": 0, "which_move": 0, "intro": 0, "which_mon": 0,
+}
+
+## The commands each site wraps the special in, in order. `waitbutton` is what
+## presses the ending text `PrintText` left standing.
+const EXPECTED_SHAPE: Array[String] = ["special", "waitbutton", "closetext"]
+
+## The Crystal-canonical index each routine's special is numbered with.
+const INDEX_OF: Dictionary = {
+	"name_rater": Gen2WorldScriptRunner.SPECIAL_NAME_RATER,
+	"move_deleter": Gen2WorldScriptRunner.SPECIAL_MOVE_DELETION,
+}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		_verify_texts(data)
+		_verify_deleter_texts(data)
+		_verify_sites(data, game_id == &"crystal")
+	_r.game_id = &""
+
+
+func _verify_texts(data: GameData) -> void:
+	var decoded: int = 0
+	for name: String in RomLayout.NAME_RATER_TEXT_ORDER:
+		if not data.name_rater_text(name).is_empty():
+			decoded += 1
+	_r.check(
+		decoded == RomLayout.NAME_RATER_TEXT_ORDER.size(),
+		"%d of %d Name Rater texts decoded" % [
+			decoded, RomLayout.NAME_RATER_TEXT_ORDER.size(),
+		]
+	)
+	for name: String in EXPECTED_TEXT_OPENINGS:
+		var text: String = data.name_rater_text(name)
+		_r.check(
+			text.begins_with(String(EXPECTED_TEXT_OPENINGS[name])),
+			"text %s opens \"%s\", not \"%s\"" % [
+				name, text.substr(0, 24), EXPECTED_TEXT_OPENINGS[name],
+			]
+		)
+	for name: String in EXPECTED_MARKERS:
+		var markers: int = data.name_rater_text(name).count(Gen2TextStream.RAM_MARKER)
+		_r.check(
+			markers == int(EXPECTED_MARKERS[name]),
+			"text %s carries %d nickname markers, not %d" % [
+				name, markers, EXPECTED_MARKERS[name],
+			]
+		)
+		## Every one of them has to be fillable, or the player is shown the
+		## marker itself.
+		var filled: String = Gen2TextStream.fill_all_markers(
+			data.name_rater_text(name), Gen2TextStream.RAM_MARKER, "NICKNAME"
+		)
+		_r.check(
+			not filled.contains(Gen2TextStream.RAM_MARKER),
+			"text %s still carries a marker once filled" % name
+		)
+
+
+func _verify_deleter_texts(data: GameData) -> void:
+	var decoded: int = 0
+	for name: String in RomLayout.MOVE_DELETER_TEXT_ORDER:
+		if not data.move_deleter_text(name).is_empty():
+			decoded += 1
+	_r.check(
+		decoded == RomLayout.MOVE_DELETER_TEXT_ORDER.size(),
+		"%d of %d move deleter texts decoded" % [
+			decoded, RomLayout.MOVE_DELETER_TEXT_ORDER.size(),
+		]
+	)
+	for name: String in EXPECTED_DELETER_OPENINGS:
+		var text: String = data.move_deleter_text(name)
+		_r.check(
+			text.begins_with(String(EXPECTED_DELETER_OPENINGS[name])),
+			"deleter text %s opens \"%s\", not \"%s\"" % [
+				name, text.substr(0, 24), EXPECTED_DELETER_OPENINGS[name],
+			]
+		)
+	for name: String in EXPECTED_DELETER_MARKERS:
+		var markers: int = data.move_deleter_text(name).count(Gen2TextStream.RAM_MARKER)
+		_r.check(
+			markers == int(EXPECTED_DELETER_MARKERS[name]),
+			"deleter text %s carries %d move-name markers, not %d" % [
+				name, markers, EXPECTED_DELETER_MARKERS[name],
+			]
+		)
+
+
+## Every cached script on the cartridge, walked for the two specials this topic
+## owns.
+func _verify_sites(data: GameData, crystal_commands: bool) -> void:
+	var scripts: Variant = RomCache.read_json(RomCache.world_scripts_path(data.directory))
+	if not scripts is Dictionary:
+		_r.fail("the script table is missing")
+		return
+	var sites: Dictionary = {"name_rater": 0, "move_deleter": 0}
+	var shaped: int = 0
+	var total: int = 0
+	for raw_key: Variant in (scripts as Dictionary):
+		var parts: PackedStringArray = String(raw_key).split(":")
+		if parts.size() != 2:
+			continue
+		var bytes: PackedByteArray = data.world_script(
+			int(parts[0]), ("0x%s" % parts[1]).hex_to_int()
+		)
+		var names: PackedStringArray = _commands_from(bytes, crystal_commands)
+		for routine: String in sites:
+			var at: int = _special_at(bytes, crystal_commands, INDEX_OF[routine])
+			if at < 0:
+				continue
+			sites[routine] = int(sites[routine]) + 1
+			total += 1
+			if names.slice(at, at + EXPECTED_SHAPE.size()) \
+				== PackedStringArray(EXPECTED_SHAPE):
+				shaped += 1
+	for routine: String in EXPECTED_SITES:
+		_r.check(
+			int(sites[routine]) == int(EXPECTED_SITES[routine]),
+			"%d scripts reach the %s special, not %d" % [
+				sites[routine], routine, EXPECTED_SITES[routine],
+			]
+		)
+	_r.check(
+		shaped == total,
+		"%d of %d scripts are opentext/special/waitbutton/closetext" % [shaped, total]
+	)
+
+
+## The command names one script's bytes decode to, stopping where the walk does.
+func _commands_from(bytes: PackedByteArray, crystal_commands: bool) -> PackedStringArray:
+	var out: PackedStringArray = PackedStringArray()
+	var offset: int = 0
+	var steps: int = 0
+	while offset < bytes.size() and steps < Gen2WorldScript.MAX_COMMANDS:
+		var command: Dictionary = Gen2WorldScript.command_at(bytes, offset, crystal_commands)
+		if not bool(command.get("ok", false)):
+			break
+		out.append(String(command.get("name", "")))
+		steps += 1
+		offset += int(command["width"])
+		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal_commands):
+			break
+	return out
+
+
+## Which command index [param special] sits at, or -1. The operand is normalized
+## before it is compared, so Gold and Silver's Name Rater at 86 and Crystal's at
+## 87 are the same site.
+func _special_at(bytes: PackedByteArray, crystal_commands: bool, special: int) -> int:
+	var offset: int = 0
+	var index: int = 0
+	while offset < bytes.size() and index < Gen2WorldScript.MAX_COMMANDS:
+		var command: Dictionary = Gen2WorldScript.command_at(bytes, offset, crystal_commands)
+		if not bool(command.get("ok", false)):
+			return -1
+		if String(command.get("name", "")) == "special" \
+			and Gen2WorldScript.special_index(
+				int(command.get("value", -1)), crystal_commands
+			) == special:
+			return index
+		index += 1
+		offset += int(command["width"])
+		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal_commands):
+			return -1
+	return -1

--- a/tools/checks/mon_specials.gd.uid
+++ b/tools/checks/mon_specials.gd.uid
@@ -1,0 +1,1 @@
+uid://d0mxgmif1yke5

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -45,6 +45,10 @@ extends SceneTree
 ## New Bark Town into Route 29),
 ## `yes_no` (`Script_yesorno`'s box, over the map's first script run to the
 ## choice it ends on: `crystal 26 3 ... yes_no 31 6` is Cherrygrove's guide),
+## `name_rater` and `move_deleter` (`special NameRater` and `special
+## MoveDeletion`, which no fixture cell reaches: the first number is how many
+## presses into the routine to photograph, so 0 is the introduction, 2 its last
+## page with the YES/NO up, and 4 the party list),
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
@@ -65,6 +69,11 @@ var _window: Vector2i = WINDOW_SIZE
 ## Longer than a step onto a warp tile and the fade behind it, for the `warp`
 ## kind, which drives to a frame rather than spending a count.
 const WARP_FRAME_CAP: int = 120
+## How long one of the two routines' boxes may take to finish printing, which is
+## a text speed rather than a count this file knows.
+const MON_SPECIAL_FRAME_CAP: int = 600
+
+
 ## `UpdateJumpPosition`'s highest `.y_offsets` entry, which is where the `ledge`
 ## kind photographs the hop.
 const LEDGE_ARC_TOP: float = 12.0
@@ -194,7 +203,8 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	if _kind_cell.x >= 0:
 		_screen.start_cell = _kind_cell
 	elif cell.x >= 0 and _kind not in [
-		&"battle_transition", &"level_evolution", &"egg_hatch",
+		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
+		&"move_deleter",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -208,6 +218,20 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	## time. It owns none of them here: the staged frames below are spent by
 	## hand.
 	_screen.set_process(false)
+
+
+## Spends whatever one of the two routines' boxes still owes, plus the frame
+## `advance_frame` reads it on: `PrintText` returning is what opens a `YesNoBox`.
+func _settle_mon_special(host_property: String) -> void:
+	for _frame: int in MON_SPECIAL_FRAME_CAP:
+		var routine: Control = _screen.get(host_property)
+		if routine == null:
+			return
+		var box: Gen2TextBox = routine.get("_text_box")
+		if box == null or not box.is_revealing():
+			break
+		_screen.advance_frame()
+	_screen.advance_frame()
 
 
 func _process(_delta: float) -> bool:
@@ -264,6 +288,25 @@ func _process(_delta: float) -> bool:
 					break
 				if hatching.awaiting_press():
 					_screen.press_button(Gen2Button.A)
+		elif _kind in [&"name_rater", &"move_deleter"]:
+			## `special NameRater` and `special MoveDeletion`, neither of which
+			## any fixture cell reaches. The first number is how many presses
+			## into the routine to photograph: 2 is the introduction's last page
+			## with its YES/NO up, 4 the party list, and so on. Presses are spent
+			## only once the box owes no frames, since nothing shortens a
+			## printing text.
+			if _kind == &"name_rater":
+				_screen.preview_name_rater()
+			else:
+				_screen.preview_move_deleter()
+			var host_property: String = "_name_rater_host" \
+				if _kind == &"name_rater" else "_move_deleter_host"
+			_settle_mon_special(host_property)
+			for _press: int in maxi(_cell.x, 0):
+				if _screen.get(host_property) == null:
+					break
+				_screen.press_button(Gen2Button.A)
+				_settle_mon_special(host_property)
 		elif _kind == &"yes_no":
 			## `Script_yesorno`'s own box: the NPC beside the player is talked
 			## to and each page answered until the choice the script ends on is
@@ -353,7 +396,8 @@ func _process(_delta: float) -> bool:
 			_screen.preview_effect_sprites(_kind)
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
-			&"battle_transition", &"level_evolution", &"egg_hatch",
+			&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
+			&"move_deleter",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -41,6 +41,7 @@ const GROUPS: Dictionary = {
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
+		&"mon_specials",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
Two NPCs in the game reached a `special` with no handler. Talking to either stopped the script and left an empty box standing on the map. Both routines are built now, whole, against their own disassembly.

## The party list is one path

`SelectMonFromParty` is what both open, and it is the party menu the start menu already draws. It has a selection mode now: A answers the caller instead of opening the mon submenu, B and the CANCEL row answer its carry, and the prompt is whichever `PartyMenuStrings` row the caller writes. Seven more routines call `SelectMonFromParty` on the cartridge. Each of them is this same call when its own routine is built.

## What the two routines are

The Name Rater is an introduction and a yes/no, the party list, three endings that need no new name, a second yes/no, the naming screen, and one closing line. Which ending a chosen party member reaches is `Gen2NameRater`. A traded member is refused on both halves of `CheckIfMonIsYourOT`: the trainer name and the two bytes of the ID, so a member carrying the player's own name but a different ID is still traded.

The move deleter is the same shape one house further on. `ChooseMoveToDelete` is the move screen with the swap and the cycle taken off, which is what `DeleteMoveScreen2DMenuData`'s accepted buttons say, and it draws no left or right arrow: `PlaceMoveScreenArrows` belongs to `MoveScreenLoop` and the deleter never reaches it. `.DeleteMove` brings the slots above the deleted one down and zeroes the last, moves and PP in the same shape.

## Where the lines come from

Every line either routine says is read from the cartridge. Cache format 76 carries the ten `text_far` stubs of one and the eight of the other. Each run is one contiguous block, so one pinned address per dump finds all of them, and what says the address is right is the content.

## Four things worth naming

- **The last text belongs to the script.** Both maps are `opentext / special / waitbutton / closetext`, and the special returns as soon as `PrintText` has drawn its last box. Pressing that box inside the routine would cost the player a second press on an empty one. Both hosts hand the text back and the map's own box holds it.
- **`SFX_MOVE_DELETED` is 151, not 97.** The comment in `constants/sfx_constants.asm` is hexadecimal. Read as decimal it is a different effect that plays and sounds wrong.
- **`.onlyonemove` reads a slot, not a count.** `wPartyMon1Moves + 1` is the second slot, so a member holding a move in slot 3 with slot 2 empty is refused as knowing one move.
- **One box names the nickname twice.** `_NameRaterPerfectNameText` does, so filling the first marker alone leaves the second on screen. `Gen2TextStream.fill_all_markers` fills every one.

## Proof

| Check | Result |
|---|---|
| Import, all three cartridges | 3/3, `layout: Layout verified.` on each |
| `tools/checks/mon_specials.gd` | Both text runs and all three map sites, on all three cartridges |
| GUT, full tier | 3,386 tests over 153 scripts, green |
| `tools/validate.gd -- all` | exit 0, 59 topics, no failures |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk | Crystal, Gold and Silver, no failures |

Screenshots of both routines are in the review thread.