### PR TITLE
Answer or name every script special the corpus reaches

### DIFF
--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -282,7 +282,7 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 				return {"ok": false, "reason": &"unsupported_pc_mode"}
 			return {"ok": true, "data": {"pc": {"mode": pc_mode}}}
 		&"audio_requested":
-			var audio: Dictionary = _audio_for_request(world, request)
+			var audio: Dictionary = audio_for_request(world, request)
 			var audio_kind: StringName = StringName(request.get("values", {}).get("kind", &""))
 			if audio.is_empty() and audio_kind != &"sound_wait":
 				return {"ok": false, "reason": &"audio_data_unavailable"}
@@ -290,7 +290,9 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 	return {}
 
 
-static func _audio_for_request(world: Gen2WorldAPI, request: Dictionary) -> Dictionary:
+## The record one `audio_requested` resolves to, which is also what says a
+## `PlaySlowCry` and a `cry` are one request with one field between them.
+static func audio_for_request(world: Gen2WorldAPI, request: Dictionary) -> Dictionary:
 	var values: Dictionary = request.get("values", {})
 	var audio_kind: StringName = StringName(values.get("kind", &""))
 	var data: GameData = world.data
@@ -315,7 +317,18 @@ static func _audio_for_request(world: Gen2WorldAPI, request: Dictionary) -> Dict
 			# `PlayMonCry`, whose own `GetCryIndex` is the species less one into
 			# `PokemonCries`. Only the low byte of the two the command carries is
 			# kept, the way the source pushes the first and discards the second.
-			return data.species_cry(int(values.get("species", -1)) & 0xFF)
+			var cry: Dictionary = data.species_cry(
+				int(values.get("species", -1)) & 0xFF
+			)
+			if cry.is_empty() or not bool(values.get("slow", false)):
+				return cry
+			# `PlaySlowCry` edits the record `LoadCry` just loaded rather than
+			# playing a second one: `wCryPitch` less `$140` and `wCryLength`
+			# plus `$60`, both sixteen bit and both wrapping there.
+			cry = cry.duplicate(true)
+			cry["cry_pitch"] = (int(cry.get("cry_pitch", 0)) - 0x140) & 0xFFFF
+			cry["cry_length"] = (int(cry.get("cry_length", 0)) + 0x60) & 0xFFFF
+			return cry
 		&"warp_sound":
 			var collision: int = int(values.get("collision", -1))
 			var warp_sfx: int = 0x23

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -120,8 +120,15 @@ const FADE_IDENTITY: int = 0xE4
 ## `ConvertTimePalsDecHL` walks the same four back.
 const FADE_OUT_ORDERS: Array[int] = [0xE4, 0x90, 0x40, 0x00]
 const FADE_IN_ORDERS: Array[int] = [0x00, 0x40, 0x90, 0xE4]
+## `FadeOutToBlack` is `ld c, $9` walked backwards and `FadeInFromBlack`
+## `ld c, $0` walked forwards, which is the other half of the same seven rows.
+## Neither runs `FillWhiteBGColor`, so colour 0 stays the map's on the way out.
+const FADE_TO_BLACK_ORDERS: Array[int] = [0xE4, 0xF9, 0xFE, 0xFF]
+const FADE_FROM_BLACK_ORDERS: Array[int] = [0xFF, 0xFE, 0xF9, 0xE4]
 ## `DelayFrames`' own `ld c, 2` inside either loop.
 const FADE_STEP_FRAMES: int = 2
+## `BattleTowerFade` is `FadeOutToWhite`'s four rows with `ld c, 7` instead.
+const BATTLE_TOWER_FADE_STEP_FRAMES: int = 7
 
 
 ## One step of a palette fade: `CopyPals`' rule, which every `DmgToCgb*Pals`

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -88,6 +88,13 @@ var _pending_step_events: Dictionary = {}
 ## empty on every other frame. The map swaps between the two stages, which is
 ## where the setup script's own list sits.
 var _map_fade: Dictionary = {}
+## The fade one of the five fade specials is inside, `{ orders, white_fill,
+## step_frames, step, frames }`, and the row it left behind once it is done. A
+## `FadeOutToWhite` holds the screen white until its own `FadeInFromWhite` runs,
+## so the last row of a finished fade stays applied rather than snapping back.
+var _script_fade: Dictionary = {}
+var _script_fade_order: int = Gen2WorldPalette.FADE_IDENTITY
+var _script_fade_white: bool = false
 ## `DoBattleTransition` and the battle it is in front of: the encounter is
 ## resolved when the transition starts, and the battle screen is not built until
 ## it has finished.
@@ -514,6 +521,7 @@ func advance_frame() -> void:
 	## Before everything the map draws: the fade owns the frame the map swaps on,
 	## and nothing else runs while `RunMapSetupScript` is spending its own.
 	_advance_map_fade()
+	_advance_script_fade()
 	## `DoBattleTransition`'s own `.loop`, which owns every frame between the
 	## encounter and the battle screen.
 	_advance_battle_transition()
@@ -1418,6 +1426,11 @@ func map_fade() -> Dictionary:
 	return _map_fade.duplicate()
 
 
+## The same for one of the five fade specials, empty on every other frame.
+func script_fade() -> Dictionary:
+	return _script_fade.duplicate()
+
+
 ## `WarpToNewMapScript`. `GetWarpSFX` reads the tile the step landed on, and
 ## `MapSetupScript_Door`'s `FadeOutToWhite` is the first thing the setup script
 ## spends: four palette orders, two frames each, before anything is loaded.
@@ -1473,8 +1486,10 @@ func _apply_map_fade_step() -> void:
 	if _renderer == null or not _renderer.has_method(Gen2ModHost.RENDERER_FADE_METHOD):
 		return
 	if _map_fade.is_empty():
+		## The warp's fade is over; whatever a script fade left standing is what
+		## the screen is drawn with, which is the identity unless one is held.
 		_renderer.call(
-			Gen2ModHost.RENDERER_FADE_METHOD, Gen2WorldPalette.FADE_IDENTITY, false
+			Gen2ModHost.RENDERER_FADE_METHOD, _script_fade_order, _script_fade_white
 		)
 		return
 	var out: bool = StringName(_map_fade["stage"]) == &"out"
@@ -1485,6 +1500,61 @@ func _apply_map_fade_step() -> void:
 	)
 
 
+## `FadeOutToWhite` and its four siblings, opened by the special and stepped from
+## here. The script is already holding for the frames the fade costs, since the
+## runner staged that wait; this is the row the renderer draws with on each of
+## them.
+func _start_script_fade(event: Dictionary) -> void:
+	var orders: Array = event.get("orders", [])
+	if orders.is_empty():
+		return
+	_script_fade = {
+		"orders": orders.duplicate(),
+		"white_fill": bool(event.get("white_fill", false)),
+		"step_frames": maxi(1, int(event.get("step_frames", 1))),
+		"step": 0,
+	}
+	_script_fade["frames"] = int(_script_fade["step_frames"])
+	_apply_script_fade_step()
+
+
+## One frame of it, and the row the last step leaves behind.
+func _advance_script_fade() -> void:
+	if _script_fade.is_empty():
+		return
+	_script_fade["frames"] = int(_script_fade["frames"]) - 1
+	if int(_script_fade["frames"]) > 0:
+		return
+	var step: int = int(_script_fade["step"]) + 1
+	if step >= (_script_fade["orders"] as Array).size():
+		_script_fade = {}
+		return
+	_script_fade["step"] = step
+	_script_fade["frames"] = int(_script_fade["step_frames"])
+	_apply_script_fade_step()
+
+
+func _apply_script_fade_step() -> void:
+	var orders: Array = _script_fade.get("orders", [])
+	var step: int = int(_script_fade.get("step", 0))
+	if step >= orders.size():
+		return
+	_script_fade_order = int(orders[step])
+	_script_fade_white = bool(_script_fade.get("white_fill", false))
+	## The warp's own fade owns the renderer while it runs, so a script fade
+	## under one is held rather than drawn twice.
+	if _map_fade.is_empty():
+		_apply_map_fade_step()
+
+
+## `MapSetupScript_Door`'s own fade in ends with the map's palettes restored, so
+## a row a script fade was holding is dropped where the map is.
+func _clear_script_fade() -> void:
+	_script_fade = {}
+	_script_fade_order = Gen2WorldPalette.FADE_IDENTITY
+	_script_fade_white = false
+
+
 ## The middle of `MapSetupScript_Door`: the map the warp names is loaded with the
 ## screen at its whitest, and `FadeToMapMusic` is the eight-step fade the new
 ## map's track arrives behind rather than a restart.
@@ -1492,6 +1562,7 @@ func _swap_warped_map() -> void:
 	var transition: Dictionary = _world.try_warp()
 	if not bool(transition.get("ok", false)):
 		return
+	_clear_script_fade()
 	_animation.configure(_world, time_of_day)
 	_set_renderer_world()
 	_fade_to_map_music()
@@ -2143,6 +2214,21 @@ func preview_name_rater() -> void:
 ##
 ## [param species] is what is inside the egg; 0 takes the first species the
 ## cache holds, so the driver works on all three without a table.
+## One of the five fade specials on the map that is already open, for a
+## screenshot. The frames it spends are the script's on the real path, so this
+## opens the fade and the caller advances into it.
+func preview_script_fade(special: int) -> void:
+	if not Gen2WorldScriptRunner.FADE_ORDERS_OF.has(special):
+		return
+	_start_script_fade({
+		"orders": Gen2WorldScriptRunner.FADE_ORDERS_OF[special],
+		"white_fill": special in Gen2WorldScriptRunner.FADE_WHITE_FILL_SPECIALS,
+		"step_frames": Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES \
+			if special == Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_FADE \
+			else Gen2WorldPalette.FADE_STEP_FRAMES,
+	})
+
+
 func preview_egg_hatch(species: int = 0) -> void:
 	if _world == null or _data == null or _hatch_host != null:
 		return
@@ -4301,6 +4387,9 @@ func _show_script_results(results: Array) -> void:
 			elif result_event.get("type", &"") == &"presentation_special_applied" \
 				and StringName(result_event.get("kind", &"")) == &"heal_machine_anim":
 				_start_heal_machine_sounds(result_event)
+			elif result_event.get("type", &"") == &"presentation_special_applied" \
+				and StringName(result_event.get("kind", &"")) == &"palette_fade":
+				_start_script_fade(result_event)
 			elif result_event.get("type", &"") == &"hall_of_fame_requested":
 				## An event, not a runtime request: `halloffame` commits its flag
 				## and runs on, and the source's own `end` is the next command,
@@ -4990,11 +5079,15 @@ func _refresh_party_summary() -> void:
 	var names: Array = []
 	var eggs: Array = []
 	var fainted: Array = []
+	var happiness: Array = []
+	var own_ot: Array = []
 	for member: Variant in save.party:
 		if member is Gen2SaveMon:
 			var mon: Gen2SaveMon = member as Gen2SaveMon
 			if (int(mon.pokerus) & 0x0F) != 0:
 				has_pokerus = true
+			happiness.append(int(mon.happiness))
+			own_ot.append(_is_own_mon(save, mon))
 			species.append(int(mon.species))
 			# CheckPartyMove walks every slot's four move slots; zeroes are empty
 			# slots, not moves, so they are dropped rather than searched.
@@ -5021,9 +5114,48 @@ func _refresh_party_summary() -> void:
 			## `VAR_BOXSPACE`, which Route 29's catching tutorial reads before it
 			## offers to hand a POKé BALL over.
 			"box_free_space": save.box_free_space(),
+			## Per slot, for the two specials that read a happiness byte or an
+			## OT: `GetFirstPokemonHappiness` and
+			## `FindPartyMonThatSpeciesYourTrainerID`.
+			"happiness": happiness,
+			"own_ot": own_ot,
+			## `CheckOwnMonAnywhere`'s answer for every species at once: a mon in
+			## the party or in any box carrying the player's own ID and OT name.
+			"owned_species": _owned_species(save),
 		},
 		fainted
 	)
+
+
+## `CheckOwnMon`'s three tests: the species is the caller's question, and what is
+## left is the player's own ID and OT name.
+func _is_own_mon(save: Gen2SaveData, mon: Gen2SaveMon) -> bool:
+	return int(mon.ot_id) == int(save.player_id) \
+		and mon.original_trainer == save.player_name
+
+
+## `CheckOwnMonAnywhere` for every species in one walk. Its own `ret z` on an
+## empty party is why an empty party owns nothing even when a box does not, and
+## the Day-Care is deliberately not walked: `docs/bugs_and_glitches.md` records
+## that omission as the cartridge's.
+func _owned_species(save: Gen2SaveData) -> Array:
+	var owned: Array = []
+	if save.party.is_empty():
+		return owned
+	var seen: Dictionary = {}
+	for member: Variant in save.party:
+		if member is Gen2SaveMon and _is_own_mon(save, member as Gen2SaveMon):
+			seen[int((member as Gen2SaveMon).species)] = true
+	for box: Variant in save.boxes:
+		if not box is Gen2SaveBox:
+			continue
+		for slot: Variant in (box as Gen2SaveBox).slots:
+			if slot is Gen2SaveMon and _is_own_mon(save, slot as Gen2SaveMon):
+				seen[int((slot as Gen2SaveMon).species)] = true
+	for key: Variant in seen:
+		owned.append(int(key))
+	owned.sort()
+	return owned
 
 
 ## GetPartyNickname's answer for one slot, following the party screen's own rule:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -180,6 +180,32 @@ const SPECIAL_INITIAL_SET_DST_FLAG: int = 166
 const SPECIAL_INITIAL_CLEAR_DST_FLAG: int = 167
 const SPECIAL_FADE_OUT_MUSIC: int = 106
 const SPECIAL_INIT_ROAM_MONS: int = 105
+## The five map fades. `BattleTowerFade` is Crystal's own insertion at 47, which
+## is why the four either side of it need no profile split.
+const SPECIAL_FADE_OUT_TO_WHITE: int = 46
+const SPECIAL_BATTLE_TOWER_FADE: int = 47
+const SPECIAL_FADE_OUT_TO_BLACK: int = 48
+const SPECIAL_FADE_IN_FROM_WHITE: int = 49
+const SPECIAL_FADE_IN_FROM_BLACK: int = 50
+## Which four rows of `.cgbfade` each of them walks, and in which direction.
+const FADE_ORDERS_OF: Dictionary = {
+	SPECIAL_FADE_OUT_TO_WHITE: Gen2WorldPalette.FADE_OUT_ORDERS,
+	SPECIAL_BATTLE_TOWER_FADE: Gen2WorldPalette.FADE_OUT_ORDERS,
+	SPECIAL_FADE_IN_FROM_WHITE: Gen2WorldPalette.FADE_IN_ORDERS,
+	SPECIAL_FADE_OUT_TO_BLACK: Gen2WorldPalette.FADE_TO_BLACK_ORDERS,
+	SPECIAL_FADE_IN_FROM_BLACK: Gen2WorldPalette.FADE_FROM_BLACK_ORDERS,
+}
+## `FillWhiteBGColor` runs in front of the two fades that end white and nowhere
+## else, so the way to black flattens onto the map's own colour 0.
+const FADE_WHITE_FILL_SPECIALS: Array[int] = [
+	SPECIAL_FADE_OUT_TO_WHITE, SPECIAL_BATTLE_TOWER_FADE,
+]
+## `GameboyCheck`'s three answers (`constants/misc_constants.asm`). Every screen
+## here is drawn in the CGB palettes, so `hCGB` is set and the other two are
+## unreachable.
+const GBCHECK_CGB: int = 2
+## `BeastsCheck`'s three, in the order it asks about them.
+const BEAST_SPECIES: Array[int] = [243, 244, 245]
 ## StrengthBoulderScript's index in StdScripts (engine/events/std_scripts.asm),
 ## the same 14 in both pins despite the tables being 52 and 46 long. Every
 ## boulder object in every map reaches Strength through `jumpstd` on it.
@@ -2188,6 +2214,24 @@ func _stage_trainer_approach() -> void:
 	})
 
 
+## `FindThatSpecies`, and `CheckOwnMon`'s ID and OT test on top of it when
+## [param own_only]. The walk is `wPartySpecies`, so an EGG's slot carries EGG
+## rather than what is inside it and cannot match a species.
+func _party_slot_of_species(party: Dictionary, species: int, own_only: bool) -> int:
+	var listed: Array = party.get("species", [])
+	var eggs: Array = party.get("eggs", [])
+	var own_ot: Array = party.get("own_ot", [])
+	for slot: int in listed.size():
+		if slot < eggs.size() and bool(eggs[slot]):
+			continue
+		if int(listed[slot]) != species:
+			continue
+		if own_only and (slot >= own_ot.size() or not bool(own_ot[slot])):
+			return -1
+		return slot
+	return -1
+
+
 ## `wXCoord`/`wYCoord`, mirrored onto the request the way the party count is.
 func _player_cell() -> Vector2i:
 	var standing: Variant = _request.get("player_cell", Vector2i(-1, -1))
@@ -2477,22 +2521,126 @@ func _execute_special(special: int) -> Dictionary:
 			_script_value = 1 if state != null \
 				and state.map_music() == Gen2WorldRadio.MUSIC_POKE_FLUTE_CHANNEL \
 				and cell in SNORLAX_PROXIMITY_CELLS else 0
-		46, 48, 49, 50, 51, 52, 53, 94, 95, 157, 158:
-			## Fade, sprite reload and the dummied trainer-ranking bookkeeping
-			## affect presentation or source-only counters, not scene-free state.
+		SPECIAL_FADE_OUT_TO_WHITE, SPECIAL_BATTLE_TOWER_FADE, SPECIAL_FADE_OUT_TO_BLACK, \
+		SPECIAL_FADE_IN_FROM_WHITE, SPECIAL_FADE_IN_FROM_BLACK:
 			## `FadeOutToWhite` is 46 in both pins, since Crystal's inserted
 			## `BattleTowerFade` sits at 47, so it needs no profile split;
 			## `FadeInFromWhite` is 49 here and 48 in Gold/Silver, which
 			## special_index() already normalizes (maps/OlivineLighthouse6F.asm's
-			## Amphy cure runs 46 then 49); `LoadUsedSpritesGFX` (94) and
+			## Amphy cure runs 46 then 49).
+			##
+			## Each of the five is `GetTimePalFade` and then four rows of the
+			## fade table, and none of them is free: `ConvertTimePals*HL` spends
+			## `ld c, 2` on every row and `BattleTowerFade`'s own loop `ld c, 7`,
+			## so the script holds for the whole walk the way it does on the
+			## cartridge. `FillWhiteBGColor` is the two white fades' alone.
+			var orders: Array[int] = FADE_ORDERS_OF[special]
+			var step_frames: int = Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES \
+				if special == SPECIAL_BATTLE_TOWER_FADE \
+				else Gen2WorldPalette.FADE_STEP_FRAMES
+			_emit_runtime_event(&"presentation_special_applied", {
+				"special": special, "kind": &"palette_fade",
+				"orders": orders.duplicate(),
+				"step_frames": step_frames,
+				"white_fill": special in FADE_WHITE_FILL_SPECIALS,
+			})
+			return _stage_frame_wait(orders.size() * step_frames, {
+				"special": special, "kind": &"palette_fade",
+			})
+		51, 52, 53, 55, 56, 94, 152, 157, 158, 164:
+			## Sprite reload, palette reload and the dummied trainer-ranking
+			## bookkeeping affect presentation or source-only counters, not
+			## scene-free state. `LoadUsedSpritesGFX` (94), `UpdateSprites` (55),
+			## `UpdatePlayerSprite` (56), `ReloadSpritesNoPalettes` (51) and
 			## `RefreshSprites` (158) reload the sprite set a `variablesprite`
-			## just changed. `PlaySlowCry` (95) is the cry player with its pitch
-			## and tempo lowered, so it plays audio and reads nothing.
-			## `ClearBGPalettes` (52) and `UpdateTimePals` (53) are the palette
-			## pair `BugContestResultsWarpScript` and the day/night scripts open
-			## with; the renderer takes its palettes from the map and the clock,
-			## so both are presentation here too.
+			## just changed. `ClearBGPalettes` (52), `UpdateTimePals` (53),
+			## `SetPlayerPalette` (152) and `LoadMapPalettes` (164) are the
+			## palette pair `BugContestResultsWarpScript` and the day/night
+			## scripts open with; the renderer takes its palettes from the map
+			## and the clock, so all four are presentation here too.
 			_emit_runtime_event(&"presentation_special_applied", {"special": special})
+		95, 100:
+			## `PlaySlowCry` (95) is `LoadCry` with the record's own pitch
+			## lowered by `$140` and its length raised by `$60`, and
+			## `PlayCurMonCry` (100) is `PlayMonCry` straight. Both take their
+			## species from wScriptVar (the second through `wCurPartySpecies`,
+			## which the `loadvar` in front of it has already set) and write
+			## nothing back, so what they owe is the sound and the `WaitSFX`
+			## each ends on. `Script_cry`'s own request is the same one.
+			return _stage_audio_request(&"cry", {
+				"special": special,
+				"species": _script_value,
+				"slow": special == 95,
+			})
+		59:
+			## `SpecialWaitSFX` is `WaitSFX`: it holds until the four effect
+			## channels are free rather than spending a counted number of
+			## frames, which is `Script_waitsfx`'s own request.
+			return _stage_audio_request(&"sound_wait", {"special": special})
+		66, 67:
+			## `FindPartyMonThatSpecies` and its ID-checking twin. Both answer
+			## TRUE/FALSE in wScriptVar off the species wScriptVar was loaded
+			## with; the second adds `CheckOwnMon`'s ID and OT test on the slot
+			## the first one found.
+			var party: Dictionary = _request.get("party", {})
+			if party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			_script_value = 1 if _party_slot_of_species(
+				party, _script_value, special == 67
+			) >= 0 else 0
+		89:
+			## `GetFirstPokemonHappiness` walks past every EGG in the list and
+			## answers the first hatched member's happiness byte, naming that
+			## member in the buffer its two boxes print.
+			var happy_party: Dictionary = _request.get("party", {})
+			if happy_party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			var eggs: Array = happy_party.get("eggs", [])
+			var happiness: Array = happy_party.get("happiness", [])
+			var names: Array = happy_party.get("names", [])
+			var slot: int = 0
+			while slot < eggs.size() and bool(eggs[slot]):
+				slot += 1
+			_script_value = int(happiness[slot]) if slot < happiness.size() else 0
+			if slot < names.size():
+				_set_text_buffer(3, String(names[slot]), &"first_party_mon", {
+					"special": special, "slot": slot,
+				})
+		90:
+			## `CheckFirstMonIsEgg` reads slot zero alone, and names it whether
+			## or not it is an egg: `GetPokemonName` runs on both branches.
+			var first_party: Dictionary = _request.get("party", {})
+			if first_party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			var first_eggs: Array = first_party.get("eggs", [])
+			var first_names: Array = first_party.get("names", [])
+			_script_value = 1 if not first_eggs.is_empty() and bool(first_eggs[0]) else 0
+			if not first_names.is_empty():
+				_set_text_buffer(3, String(first_names[0]), &"first_party_mon", {
+					"special": special, "slot": 0,
+				})
+		102:
+			## `GameboyCheck` reports which console the game booted on. This one
+			## is a Game Boy Color every time, since every screen here is drawn
+			## in the CGB palettes `hCGB` selects.
+			_script_value = GBCHECK_CGB
+		150, 151:
+			## `MonCheck` answers whether the player owns the species in
+			## wScriptVar and `BeastsCheck` runs the same test on all three
+			## beasts, leaving the last species it asked about behind in
+			## wScriptVar when one is missing.
+			var owner_party: Dictionary = _request.get("party", {})
+			if owner_party.is_empty():
+				return {"ok": false, "reason": &"missing_party_summary", "special": special}
+			var owned: Array = owner_party.get("owned_species", [])
+			if special == 151:
+				_script_value = 1 if owned.has(_script_value) else 0
+			else:
+				_script_value = 1
+				for beast: int in BEAST_SPECIES:
+					if not owned.has(beast):
+						_script_value = beast
+						break
 		SPECIAL_INIT_ROAM_MONS:
 			## InitRoamMons seeds the roam structs with Raikou and Entei at
 			## level 40 on their starting maps. Gen2WorldAPI.open() already

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1468,12 +1468,179 @@ func test_fade_out_to_white_is_presentation_on_both_profiles() -> void:
 		"kind": &"test", "bank": 48, "script": 0x6A00,
 	})
 	var result: Dictionary = runner.advance()
-	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	## `ConvertTimePals*HL` spends `ld c, 2` on each of its four rows, so the
+	## script holds for eight frames rather than running straight on.
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(int(result["event"]["frames"]), 8, JSON.stringify(result))
 	assert_eq(
 		int(_event_value(result["events"], &"presentation_special_applied", "special")),
 		46,
 		JSON.stringify(result),
 	)
+	assert_eq(
+		_event_value(result["events"], &"presentation_special_applied", "orders"),
+		Gen2WorldPalette.FADE_OUT_ORDERS,
+		JSON.stringify(result),
+	)
+
+
+## `BattleTowerFade` is `FadeOutToWhite`'s four rows with `ld c, 7` instead of
+## `ld c, 2`, and it is Crystal's own insertion at 47, which is why the four
+## either side of it need no profile mapping.
+func test_battle_tower_fade_walks_the_white_rows_at_seven_frames_each() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6A40"] = [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_FADE, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6A40,
+	})
+	var result: Dictionary = runner.advance()
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(int(result["event"]["frames"]), 28, JSON.stringify(result))
+	assert_eq(
+		int(_event_value(result["events"], &"presentation_special_applied", "step_frames")),
+		Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES,
+		JSON.stringify(result),
+	)
+
+
+## `FadeOutToBlack` and `FadeInFromBlack` walk the other half of `.cgbfade`, and
+## neither runs `FillWhiteBGColor`, so colour 0 stays the map's own.
+func test_the_two_black_fades_walk_the_dark_rows_without_the_white_fill() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6A60"] = [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_FADE_OUT_TO_BLACK, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6A60,
+	})
+	var result: Dictionary = runner.advance()
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(
+		_event_value(result["events"], &"presentation_special_applied", "orders"),
+		Gen2WorldPalette.FADE_TO_BLACK_ORDERS,
+		JSON.stringify(result),
+	)
+	assert_false(
+		bool(_event_value(result["events"], &"presentation_special_applied", "white_fill")),
+		JSON.stringify(result),
+	)
+	## `FadeOutToWhite` is the one that does, which is what says the flag is read
+	## rather than always false.
+	assert_true(
+		Gen2WorldScriptRunner.SPECIAL_FADE_OUT_TO_WHITE
+			in Gen2WorldScriptRunner.FADE_WHITE_FILL_SPECIALS
+	)
+
+
+## `CheckFirstMonIsEgg` reads slot zero alone and names it on both branches,
+## since `GetPokemonName` runs before either `ld [wScriptVar]` is reached.
+func test_check_first_mon_is_egg_reads_slot_zero_and_names_it() -> void:
+	for is_egg: bool in [true, false]:
+		var result: Array = _events_answering_special(
+			90, 1 if is_egg else 0, 0x6A80,
+			[172] as Array[int], [is_egg], [true], [70], [172], ["PICHU"]
+		)
+		assert_true(_flag_31_set(result), "egg %s" % is_egg)
+		assert_eq(
+			_event_value(result[0]["events"], &"text_buffer_changed", "value"),
+			"PICHU", "GetPokemonName runs on both branches",
+		)
+
+
+## `GetFirstPokemonHappiness` walks past every EGG in the list rather than
+## reading slot zero, which is the one step a reading of it drops.
+func test_first_pokemon_happiness_skips_the_eggs_in_front_of_it() -> void:
+	var result: Array = _events_answering_special(
+		89, 200, 0x6AA0,
+		[172, 25] as Array[int], [true, false], [true, true], [10, 200], [25],
+		["PICHU", "PIKACHU"]
+	)
+	assert_true(_flag_31_set(result))
+	## The box it fills names the member it answered for, not slot zero.
+	assert_eq(
+		_event_value(result[0]["events"], &"text_buffer_changed", "value"), "PIKACHU"
+	)
+
+
+## `CheckOwnMon` is three tests, not one: the species, the player's ID and the
+## OT name. A traded mon of the right species owns nothing.
+func test_mon_check_refuses_a_party_member_with_another_trainers_ot() -> void:
+	for owned: Array in [[25], []]:
+		var result: Array = _events_answering_special(
+			151, 1 if not owned.is_empty() else 0, 0x6AC0,
+			[25] as Array[int], [false], [not owned.is_empty()], [70], owned,
+			["PIKACHU"], 25
+		)
+		assert_true(_flag_31_set(result), JSON.stringify(owned))
+
+
+## `BeastsCheck` leaves the species it stopped on in wScriptVar, which is what
+## `.notexist`'s own `xor a` does not do: the caller branches on which beast is
+## missing rather than on a plain FALSE.
+func test_beasts_check_answers_the_first_beast_the_player_does_not_own() -> void:
+	var cases: Array = [[[], 243], [[243], 244], [[243, 244], 245], [[243, 244, 245], 1]]
+	for case: Array in cases:
+		var result: Array = _events_answering_special(
+			150, int(case[1]), 0x6AE0,
+			[25] as Array[int], [false], [true], [70], case[0], ["PIKACHU"]
+		)
+		assert_true(_flag_31_set(result), JSON.stringify(case))
+
+
+## One script that runs [param special] with [param value] loaded and sets event
+## 31 only when it answers [param expected], which is how a wScriptVar the API
+## does not expose is read: the branch the cartridge's own caller takes.
+func _events_answering_special(
+	special: int, expected: int, address: int,
+	species: Array[int], eggs: Array, own_ot: Array, happiness: Array,
+	owned_species: Array, names: Array, value: int = -1
+) -> Array:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	var refused: int = address + 0x10
+	var body: Array = []
+	if value >= 0:
+		body.append_array([Gen2WorldScript.SETVAL, value])
+	body.append_array([
+		Gen2WorldScript.SPECIAL, special, 0,
+		Gen2WorldScript.IFNOTEQUAL, expected, refused & 0xFF, (refused >> 8) & 0xFF,
+		Gen2WorldScript.SETEVENT, 31, 0,
+		Gen2WorldScript.END,
+	])
+	scripts["48:%04X" % address] = body
+	scripts["48:%04X" % refused] = [Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var moves: Array = []
+	for _slot: int in species.size():
+		moves.append([])
+	world.set_party_summary(
+		species.size(), false, species, moves, names, eggs,
+		{"own_ot": own_ot, "happiness": happiness, "owned_species": owned_species},
+		[]
+	)
+	world.current_map.events["coord_events"] = [{
+		"scene": 0, "x": 7, "y": 6, "script": address,
+	}]
+	var result: Array = world.dispatch_script_events(Vector2i(7, 6))
+	result.append(world)
+	return result
+
+
+## Whether the branch was taken, read off the world the helper appended.
+func _flag_31_set(result: Array) -> bool:
+	var world: Gen2WorldAPI = result.back() as Gen2WorldAPI
+	return world != null and world.state.is_event_flag_active(31)
 
 
 func test_fade_in_from_white_is_presentation_on_both_profiles() -> void:
@@ -1490,10 +1657,18 @@ func test_fade_in_from_white_is_presentation_on_both_profiles() -> void:
 		"kind": &"test", "bank": 48, "script": 0x6A20,
 	})
 	var result: Dictionary = runner.advance()
-	assert_eq(result["status"], &"complete", JSON.stringify(result))
+	## `ConvertTimePals*HL` spends `ld c, 2` on each of its four rows, so the
+	## script holds for eight frames rather than running straight on.
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(int(result["event"]["frames"]), 8, JSON.stringify(result))
 	assert_eq(
 		int(_event_value(result["events"], &"presentation_special_applied", "special")),
 		49,
+		JSON.stringify(result),
+	)
+	assert_eq(
+		_event_value(result["events"], &"presentation_special_applied", "orders"),
+		Gen2WorldPalette.FADE_IN_ORDERS,
 		JSON.stringify(result),
 	)
 

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -1,0 +1,293 @@
+extends RefCounted
+
+## Sweeps every cached map script on all three cartridges for the `special`
+## command and asserts that each index it reaches is one this project answers,
+## or one of the named routines it deliberately does not.
+##
+## The class this exists to stop is a dispatch gap rather than a wrong reading:
+## `Gen2WorldScriptRunner._execute_special` fails an index it does not name, and
+## `_run_command`'s own `_fail` then stops the script where it stands, so one
+## missing entry is a wall in front of every NPC that reaches it. Nothing else
+## in the suite sees that, because a test reaches the specials it was written
+## for and a story walk reaches the maps it was written for.
+##
+## `data/events/special_pointers.asm` is the corpus and the runner's own match
+## is the claim, so the difference is derived rather than kept by hand:
+## `EXPECTED_DEFERRED` names what is left, and a routine leaving that list is a
+## line deleted here rather than a number edited.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- specials
+
+## Every index the corpus reaches that this project answers with nothing, and
+## the feature each belongs to. `Gen2WorldScriptRunner` is checked against this
+## in both directions: an index here that the runner now handles fails, so the
+## row is deleted with the work rather than left behind.
+const EXPECTED_DEFERRED: Dictionary = {
+	## HANDOFF's "Deliberately deferred": link play, the Mobile Adapter GB,
+	## Mystery Gift and the Battle Tower. None of the four has a path to a
+	## modern platform or a save section this project reads.
+	1: "SetBitsForLinkTradeRequest", 2: "WaitForLinkedFriend",
+	3: "CheckLinkTimeout_Receptionist", 4: "TryQuickSave",
+	5: "CheckBothSelectedSameRoom", 6: "FailedLinkToPast", 7: "CloseLink",
+	8: "WaitForOtherPlayerToExit", 9: "SetBitsForBattleRequest",
+	10: "SetBitsForTimeCapsuleRequest", 11: "CheckTimeCapsuleCompatibility",
+	12: "EnterTimeCapsule", 13: "TradeCenter", 14: "Colosseum", 15: "TimeCapsule",
+	16: "CableClubCheckWhichChris", 17: "CheckMysteryGift",
+	18: "GetMysteryGiftItem", 19: "UnlockMysteryGift", 88: "DisplayLinkRecord",
+	116: "BattleTowerRoomMenu", 119: "BattleTowerBattle",
+	122: "LoadOpponentTrainerAndPokemonWithOTSprite",
+	124: "CheckForBattleTowerRules", 125: "GiveOddEgg",
+	127: "Function1011f1", 128: "Function101220", 129: "Function101225",
+	130: "Function101231", 134: "BattleTowerAction",
+	136: "Menu_ChallengeExplanationCancel", 139: "BattleTowerMobileError",
+	140: "AskMobileOrCable", 154: "Mobile_SelectThreeMons",
+	155: "Function1037eb", 156: "Function10383c", 159: "Function1037c2",
+	160: "CheckMobileAdapterStatusSpecial", 161: "Function103780",
+	162: "Function10387b", 163: "AskRememberPassword",
+
+	## Screens and facilities with no routine here yet. Each is its own piece of
+	## work, not a dispatch entry: it opens a screen, spends a transaction, or
+	## reads a save field nothing writes.
+	25: "CheckMagikarpLength", 26: "MagikarpHouseSign",
+	30: "DayCareMan", 31: "DayCareLady", 32: "DayCareManOutside",
+	34: "BankOfMom", 39: "UnownPrinter", 40: "MapRadio", 41: "UnownPuzzle",
+	42: "SlotMachine", 43: "CardFlip", 57: "GameCornerPrizeMonCheckDex",
+	75: "GiveShuckle", 76: "ReturnShuckie", 77: "BillsGrandfather",
+	79: "DisplayCoinCaseBalance", 80: "DisplayMoneyAndCoinBalance",
+	81: "PlaceMoneyTopRight", 82: "CheckForLuckyNumberWinners",
+	83: "CheckLuckyNumberShowFlag", 84: "ResetLuckyNumberShowFlag",
+	85: "PrintTodaysLuckyNumber", 97: "OlderHaircutBrother",
+	98: "YoungerHaircutBrother", 99: "DaisysGrooming", 103: "TrainerHouse",
+	104: "PhotoStudio", 107: "Diploma", 108: "PrintDiploma",
+	126: "Reset", 131: "MoveTutor", 132: "OmanyteChamber",
+	141: "HoOhChamber", 143: "CelebiShrineEvent", 144: "CheckCaughtCelebi",
+	145: "PokeSeer", 146: "BuenasPassword", 147: "BuenaPrize",
+	148: "GiveDratini", 149: "SampleKenjiBreakCountdown",
+
+	## Reached by one script row each and by nothing the player can talk to.
+	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table, and
+	## the Day-Care's two mon readers belong with the three Day-Care routines
+	## above them.
+	0: "WarpToSpawnPoint", 64: "FindPartyMonAboveLevel",
+	69: "DayCareMon1", 70: "DayCareMon2",
+}
+
+## Script rows whose linear walk runs past a `jumptext` pointer table and decodes
+## its addresses as commands, so the `special` it reports names no routine at
+## all. Pinned rather than filtered: `Gen2WorldScript.is_terminal` stops at
+## `end` and `endcallback` alone, and until the commands that never return stop
+## it too, this is what that costs measured at one place.
+const EXPECTED_OUT_OF_TABLE: Dictionary = {&"crystal": 23, &"gold": 25, &"silver": 25}
+
+## The five fades and what each of them costs, from `ConvertTimePals*HL`'s own
+## `ld c` and `BattleTowerFade`'s. A fade that spends no frame is what this
+## number is here to stop.
+const EXPECTED_FADE_FRAMES: Dictionary = {46: 8, 47: 28, 48: 8, 49: 8, 50: 8}
+
+## `data/events/special_pointers.asm`'s own length, the same in both pins.
+const SPECIALS_POINTERS_SIZE: int = 169
+
+## A linear walk has to stop where control leaves the script, or it decodes the
+## pointer table a `jumptext` list is followed by as commands. These are the
+## decoder's own names for the commands that never come back;
+## `scall`/`farscall`/`callstd` do and are not here.
+const WALK_ENDS: Array[String] = [
+	"end", "endcallback", "reloadend", "endall", "stopandsjump",
+	"sjump", "farsjump", "memjump", "jumpstd",
+	"jumptext", "farjumptext", "jumptextfaceplayer",
+]
+
+var _r: RefCounted = null
+## Which indices the runner answers, derived from the runner rather than kept
+## beside it: a second copy of the match would go stale the first time one is
+## built, which is the whole failure this topic exists to catch.
+var _handled: Dictionary = {}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_probe_handled()
+	_verify_fade_table()
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		_verify_corpus(data, game_id == &"crystal")
+		_verify_slow_cry(data)
+	_r.game_id = &""
+	_verify_deferred_list_is_current()
+
+
+## `_execute_special` asked about every index in `SpecialsPointers`. An index it
+## answers with `unsupported_phone_special` is one no script can reach; every
+## other reason (a missing party mirror, an absent record) is a handler that ran.
+func _probe_handled() -> void:
+	for special: int in SPECIALS_POINTERS_SIZE:
+		var runner := Gen2WorldScriptRunner.new()
+		var result: Variant = runner.call(&"_execute_special", special)
+		if result is Dictionary and StringName((result as Dictionary).get(
+			"reason", &""
+		)) == &"unsupported_phone_special":
+			continue
+		_handled[special] = true
+	_r.check(
+		not _handled.is_empty(), "the runner answers no special at all"
+	)
+
+
+## Each fade's four rows and the frames it holds each of them for, against the
+## runner's own tables rather than against a repeated literal.
+func _verify_fade_table() -> void:
+	for raw_special: Variant in EXPECTED_FADE_FRAMES:
+		var special: int = int(raw_special)
+		var orders: Array = Gen2WorldScriptRunner.FADE_ORDERS_OF.get(special, [])
+		_r.check(
+			orders.size() == 4,
+			"special %d walks %d fade rows, not 4" % [special, orders.size()]
+		)
+		var step_frames: int = Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES \
+			if special == Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_FADE \
+			else Gen2WorldPalette.FADE_STEP_FRAMES
+		_r.check(
+			orders.size() * step_frames == int(EXPECTED_FADE_FRAMES[special]),
+			"special %d spends %d frames, not %d" % [
+				special, orders.size() * step_frames, EXPECTED_FADE_FRAMES[special],
+			]
+		)
+		## Both ends of the walk are rows of `.cgbfade`, and the one it starts or
+		## ends on is the identity, which is what says the direction is right.
+		_r.check(
+			Gen2WorldPalette.FADE_IDENTITY in [int(orders[0]), int(orders[3])],
+			"special %d's fade touches neither end of the identity row" % special
+		)
+		for order: Variant in orders:
+			_r.check(
+				Gen2WorldPalette.FADE_ORDERS.has(int(order)),
+				"special %d walks row %d, which is not one of .cgbfade's" % [
+					special, int(order),
+				]
+			)
+
+
+## `PlaySlowCry` edits the record `LoadCry` just loaded rather than playing a
+## second one: `wCryPitch` less `$140` and `wCryLength` plus `$60`, both sixteen
+## bit. Swept over every species rather than one, since a record whose pitch is
+## already below `$140` is where the wrap shows.
+func _verify_slow_cry(data: GameData) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(0, 0))
+	if world == null:
+		_r.fail("the first map is unavailable")
+		return
+	var checked: int = 0
+	for species: int in range(1, 252):
+		var plain: Dictionary = Gen2WorldHost.audio_for_request(world, {
+			"values": {"kind": &"cry", "species": species},
+		})
+		if plain.is_empty():
+			continue
+		var slow: Dictionary = Gen2WorldHost.audio_for_request(world, {
+			"values": {"kind": &"cry", "species": species, "slow": true},
+		})
+		checked += 1
+		if int(slow.get("cry_pitch", 0)) != (int(plain["cry_pitch"]) - 0x140) & 0xFFFF \
+			or int(slow.get("cry_length", 0)) != (int(plain["cry_length"]) + 0x60) & 0xFFFF:
+			_r.fail("species %d's slow cry is not the record moved" % species)
+			return
+		## The plain request has to be left alone, or `Script_cry` plays the
+		## slow one after a `PlaySlowCry` has run once.
+		if int(Gen2WorldHost.audio_for_request(world, {
+			"values": {"kind": &"cry", "species": species},
+		}).get("cry_pitch", -1)) != int(plain["cry_pitch"]):
+			_r.fail("species %d's own record was edited in place" % species)
+			return
+	_r.check(checked >= 250, "%d species cries read, not 251" % checked)
+
+
+## Every cached script on one cartridge, walked for `special` and tallied.
+func _verify_corpus(data: GameData, crystal_commands: bool) -> void:
+	var scripts: Variant = RomCache.read_json(RomCache.world_scripts_path(data.directory))
+	if not scripts is Dictionary:
+		_r.fail("the script table is missing")
+		return
+	var reached: Dictionary = {}
+	for raw_key: Variant in (scripts as Dictionary):
+		var parts: PackedStringArray = String(raw_key).split(":")
+		if parts.size() != 2:
+			continue
+		var bytes: PackedByteArray = data.world_script(
+			int(parts[0]), ("0x%s" % parts[1]).hex_to_int()
+		)
+		for special: int in _specials_in(bytes, crystal_commands):
+			reached[special] = int(reached.get(special, 0)) + 1
+	var unnamed: PackedStringArray = PackedStringArray()
+	var sites: int = 0
+	var out_of_table: int = 0
+	for raw_special: Variant in reached:
+		var special: int = int(raw_special)
+		if special < 0 or special >= SPECIALS_POINTERS_SIZE:
+			out_of_table += int(reached[raw_special])
+			continue
+		if _handled.has(special) or EXPECTED_DEFERRED.has(special):
+			continue
+		unnamed.append("%d (%d sites)" % [special, int(reached[raw_special])])
+		sites += int(reached[raw_special])
+	_r.check(
+		out_of_table == int(EXPECTED_OUT_OF_TABLE.get(data.id, -1)),
+		"%d decoded specials fall outside SpecialsPointers, not %d" % [
+			out_of_table, EXPECTED_OUT_OF_TABLE.get(data.id, -1),
+		]
+	)
+	_r.check(
+		unnamed.is_empty(),
+		"%d script sites reach a special this project neither answers nor names: %s" % [
+			sites, ", ".join(unnamed),
+		]
+	)
+	## The other direction: a routine that is built has to leave the list, or
+	## the list stops describing what is missing.
+	for raw_special: Variant in EXPECTED_DEFERRED:
+		_r.check(
+			not _handled.has(int(raw_special)),
+			"special %d (%s) is built and still listed as deferred" % [
+				int(raw_special), EXPECTED_DEFERRED[raw_special],
+			]
+		)
+
+
+## Every special index one script's bytes reach, stopping where control leaves
+## the script rather than at its last byte.
+func _specials_in(bytes: PackedByteArray, crystal_commands: bool) -> Array[int]:
+	var out: Array[int] = []
+	var offset: int = 0
+	var steps: int = 0
+	while offset < bytes.size() and steps < Gen2WorldScript.MAX_COMMANDS:
+		var command: Dictionary = Gen2WorldScript.command_at(bytes, offset, crystal_commands)
+		if not bool(command.get("ok", false)):
+			break
+		var name: String = String(command.get("name", ""))
+		if name == "special":
+			out.append(Gen2WorldScript.special_index(
+				int(command.get("value", -1)), crystal_commands
+			))
+		steps += 1
+		offset += int(command["width"])
+		if name in WALK_ENDS:
+			break
+	return out
+
+
+## The list names routines, so a typo in one is a row that can never be deleted.
+## `SpecialsPointers` is `SPECIALS_POINTERS_SIZE` entries long in both pins.
+func _verify_deferred_list_is_current() -> void:
+	for raw_special: Variant in EXPECTED_DEFERRED:
+		var special: int = int(raw_special)
+		_r.check(
+			special >= 0 and special < SPECIALS_POINTERS_SIZE,
+			"deferred special %d is outside SpecialsPointers" % special
+		)
+		_r.check(
+			not String(EXPECTED_DEFERRED[raw_special]).is_empty(),
+			"deferred special %d is unnamed" % special
+		)

--- a/tools/checks/specials.gd.uid
+++ b/tools/checks/specials.gd.uid
@@ -1,0 +1,1 @@
+uid://chp1gxxmh5lhs

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -35,6 +35,9 @@ extends SceneTree
 ## warp tile named by the two numbers below it, and the picture is
 ## `FadeOutToWhite`'s last order, which is the frame the new map is loaded on:
 ## `crystal 24 7 ... warp 7 1` is the bedroom staircase),
+## `script_fade` (one of the five fade specials over the map, as
+## `crystal 24 4 ... script_fade 46 6`: the first number is the special and the
+## second how many of its frames to spend before the picture),
 ## `door` (`.CheckWarp`'s carpet: the player is walked down onto an interior
 ## door's mat and photographed standing on it, which the step itself no longer
 ## warps: `crystal 24 6 ... door 6 5` is the front door of the player's house),
@@ -261,6 +264,15 @@ func _process(_delta: float) -> bool:
 			## a different picture; the second is 1 for a trainer's, which is the
 			## branch that draws the Poke Ball and floods the map.
 			_screen.preview_battle_transition(_cell.x, _cell.y != 0)
+		elif _kind == &"script_fade":
+			## One of the five fade specials over the map it runs on. The first
+			## number is the special (46 `FadeOutToWhite`, 47 `BattleTowerFade`,
+			## 48 `FadeOutToBlack`, 49 `FadeInFromWhite`, 50 `FadeInFromBlack`)
+			## and the second how many of its frames to spend before the
+			## picture, since each of the four rows is a different screen.
+			_screen.preview_script_fade(maxi(_cell.x, 0))
+			for _frame: int in maxi(_cell.y, 0):
+				_screen.advance_frame()
 		elif _kind == &"level_evolution":
 			## `EvolveAfterBattle`'s own screen, which is a few hundred frames of
 			## picture. The first number is how far into it to photograph rather

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -41,7 +41,7 @@ const GROUPS: Dictionary = {
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
-		&"mon_specials",
+		&"mon_specials", &"specials",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
A `special` index the world script runner does not name fails, and the command dispatch then stops the script where it stands. So one missing entry is a wall in front of every NPC that reaches it. Nothing in the suite could see this: a test reaches the specials it was written for, and a story walk reaches the maps it was written for.

Swept over every cached script on all three cartridges, 430 Crystal script sites reached an index with no handler.

## What is built

Fourteen routines, each read against its own source: `BattleTowerFade`, `UpdateSprites`, `UpdatePlayerSprite`, `SetPlayerPalette`, `LoadMapPalettes`, `SpecialWaitSFX`, `PlayCurMonCry`, `FindPartyMonThatSpecies`, `FindPartyMonThatSpeciesYourTrainerID`, `GetFirstPokemonHappiness`, `CheckFirstMonIsEgg`, `GameboyCheck`, `MonCheck` and `BeastsCheck`.

The rest are named in `tools/checks/specials.gd`, with the feature each belongs to: link play, the Mobile Adapter, Mystery Gift, the Battle Tower, and the screens and facilities that are their own piece of work.

## Four readings

| Trap | What it cost |
|---|---|
| A fade special is not free | `ConvertTimePalsIncHL` and `ConvertTimePalsDecHL` spend two frames on each of four rows, and `BattleTowerFade`'s own loop seven. All five were reported as presentation and spent no frame, so a script ran straight through its own fade. |
| `set_fade` had no caller | The renderer seam was built and nothing drove it, so a fade special changed no pixel. The warp's fade owns the renderer while it runs; a script fade's last row is held after it, because `FadeOutToWhite` leaves the screen white until its own `FadeInFromWhite` runs. |
| `FillWhiteBGColor` belongs to two of the five | Only `FadeOutToWhite` and `BattleTowerFade` run it. `FadeOutToBlack` flattens onto colour 3 of whatever palette the cell was drawn in, which is the overworld's own `RGB 7,7,7`. |
| `GetFirstPokemonHappiness` walks past the eggs | It skips every EGG in the party list and answers the first hatched member, naming that member rather than slot zero. `CheckFirstMonIsEgg` beside it reads slot zero alone and names it on both branches. |

`PlaySlowCry` is not a second cry: it edits the record `LoadCry` just loaded, pitch less `$140` and length plus `$60`. It goes through the existing cry request with one field set.

## What proves it

`tools/checks/specials.gd` derives both sides rather than keeping either. The runner is asked about all 169 indices of `SpecialsPointers`, the corpus is walked for what it reaches, and a routine that gets built has to leave the deferred list or the topic fails. It also sweeps the slow cry over all 251 species and proves the plain record is left alone, since the cache hands its dictionary back by reference.

- 60 check topics pass, exit 0.
- GUT 3,392 tests over 153 scripts, green.
- `replay_world.gd`: 33 routes, 0 failures.
- The story walk runs on all three profiles with no failed script.

Photograph any row of any of the five fades with `preview_world.gd ... live script_fade <special> <frames>`.