### PR TITLE
Stop a script walk where control leaves the script

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -249,9 +249,37 @@ func world_maps() -> Array:
 
 ## Every imported script's `bank:address` key, sorted, for a caller that has to
 ## walk the whole corpus rather than follow one pointer. See [Gen2WorldCatalog].
+##
+## The keys an item ball, a hidden item or a conditional background event points
+## at are NOT here. Their bytes live in the map-scripts bank and are cached with
+## the scripts because every runtime reader asks [method world_script] for them,
+## but they are `db item, quantity`, `dwb event, item` and a `conditional_event`
+## record rather than commands, and a corpus walk that decoded them read item
+## counts as opcodes.
 func world_script_keys() -> Array:
-	var out: Array = _scripts().keys()
+	var data_only: Dictionary = _script_data_pointers()
+	var out: Array = []
+	for key: Variant in _scripts():
+		if not data_only.has(String(key)):
+			out.append(key)
 	out.sort()
+	return out
+
+
+## The pointer keys [method world_script_keys] leaves out, derived from the maps
+## rather than stored, so the importer and this side cannot drift apart.
+func _script_data_pointers() -> Dictionary:
+	var out: Dictionary = {}
+	for map: Gen2WorldMap in _maps():
+		var bank: int = int(map.events.get("bank", 0))
+		for source: String in ["bg_events", "objects"]:
+			for raw: Variant in map.events.get(source, []):
+				if not raw is Dictionary:
+					continue
+				var event: Dictionary = raw
+				if Gen2WorldImporter.event_pointer_is_script(source, event):
+					continue
+				out[Gen2WorldScript.pointer_key(bank, int(event.get("script", 0)))] = true
 	return out
 
 

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -125,16 +125,16 @@ static func build(data: GameData) -> Gen2WorldCatalog:
 ## both are derived from these rows in a millisecond and would only be a second
 ## copy to keep in step.
 func to_dict() -> Dictionary:
-	var rows: Dictionary = {}
+	var stored_rows: Dictionary = {}
 	for id: int in _rows:
-		rows[str(id)] = _stored_value(_rows[id])
+		stored_rows[str(id)] = _stored_value(_rows[id])
 	var links: Dictionary = {}
 	for at: int in _links:
 		links[str(at)] = _stored_value(_links[at])
 	var kinds: Dictionary = {}
 	for kind: StringName in _by_kind:
 		kinds[String(kind)] = (_by_kind[kind] as Array).duplicate()
-	return {"version": FORMAT_VERSION, "rows": rows, "links": links, "kinds": kinds}
+	return {"version": FORMAT_VERSION, "rows": stored_rows, "links": links, "kinds": kinds}
 
 
 ## The counterpart, bound to [param data] so [method check] can still fold a mod
@@ -162,11 +162,11 @@ static func from_dict(data: GameData, source: Variant) -> Gen2WorldCatalog:
 			return null
 		out._links[at.to_int()] = _restore_value(link)
 	for kind: String in raw["kinds"] as Dictionary:
-		var ids: Variant = (raw["kinds"] as Dictionary)[kind]
-		if not ids is Array:
+		var kind_ids: Variant = (raw["kinds"] as Dictionary)[kind]
+		if not kind_ids is Array:
 			return null
 		var packed: Array = []
-		for id: Variant in ids as Array:
+		for id: Variant in kind_ids as Array:
 			packed.append(int(id))
 		out._by_kind[StringName(kind)] = packed
 	return out
@@ -201,7 +201,9 @@ static func _stored_value(value: Variant) -> Variant:
 static func _restore_value(value: Variant) -> Variant:
 	if value is float:
 		var number: float = value as float
-		return int(number) if is_equal_approx(number, floor(number)) else number
+		if is_equal_approx(number, floor(number)):
+			return int(number)
+		return number
 	if value is Array:
 		var list: Array = []
 		for entry: Variant in value as Array:

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -386,6 +386,8 @@ func _scan_one_script(
 	## The walk does NOT stop at the first `end` or `sjump`. A bounded blob holds
 	## a routine and the branch bodies behind it, and the Game Corner's three
 	## prizes are exactly that: one `.loop` and three labels after its jump.
+	## The bound counts `end`s, not every command that never returns: a `sjump`
+	## into a label below it is one routine, not two.
 	##
 	## It DOES stop at the first byte no command owns. Everything decoded before
 	## that came from a real entry point at a real offset; everything after would
@@ -554,8 +556,7 @@ static func _branch_bounds(commands: Array, at: int, crystal: bool) -> Array:
 	var end: int = 0x10000
 	for command: Dictionary in commands:
 		var offset: int = int(command["offset"])
-		if not Gen2WorldScript.is_terminal(int(command["opcode"]), crystal) \
-			and StringName(command["name"]) not in [&"sjump", &"farsjump", &"jumpstd"]:
+		if Gen2WorldScript.continues_after(int(command["opcode"]), crystal):
 			continue
 		if offset < at:
 			start = offset + int(command["width"])
@@ -795,8 +796,7 @@ func _requirements(commands: Array, at: int, crystal: bool) -> Array:
 		## last `end` or `sjump` guards one of the earlier ones. Reading the whole
 		## blob put thirteen conditions on a starter, two of them badges the
 		## cartridge plainly does not ask a starter for.
-		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal) \
-			or StringName(command["name"]) in [&"sjump", &"farsjump", &"jumpstd"]:
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal):
 			out.clear()
 			seen.clear()
 			continue

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -80,7 +80,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 76
+const FORMAT_VERSION: int = 77
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -1,12 +1,20 @@
 class_name Gen2WorldImporter
 extends RefCounted
 
+const OBJECTTYPE_SCRIPT: int = 0
 const OBJECTTYPE_TRAINER: int = 2
 const TRAINER_RECORD_SIZE: int = 12
 ## The two background-event types whose pointer addresses a conditional_event
 ## record rather than a script (constants/script_constants.asm).
 const BGEVENT_IFSET: int = 5
 const BGEVENT_IFNOTSET: int = 6
+
+## The background-event types whose pointer is the script `BGEventJumptable`
+## calls (engine/overworld/events.asm): `.read` and the four `.checkdir`
+## entries. `.itemifset` and `.copy` copy their two bytes into
+## `wHiddenItemData`, and `.ifset`/`.ifnotset` read a conditional_event first,
+## which is [method _collect_conditional_bg_script]'s job.
+const BGEVENT_SCRIPT_TYPES: Array[int] = [0, 1, 2, 3, 4]
 
 ## Imports the map table, map attributes, map events, tileset tables, overworld
 ## object graphics and addressable overworld tile strips for a verified
@@ -982,7 +990,8 @@ static func _read_map(
 				continue
 			_collect_script(
 				rom, scripts_bank, int(event.get("script", 0)),
-				script_data, text_data, movement_data
+				script_data, text_data, movement_data,
+				event_pointer_is_script(source, event)
 			)
 			if source == "bg_events":
 				_collect_conditional_bg_script(
@@ -1279,6 +1288,25 @@ static func _read_map_scripts(
 	return {"ok": true, "scenes": scenes, "callbacks": callbacks}
 
 
+## Whether an event record's own pointer addresses commands.
+##
+## Only `ObjectEventTypeArray`'s `.script` and `BGEventJumptable`'s five reading
+## entries reach `CallScript` with it. An item ball's word is the `itemball`
+## macro's `db item, quantity`, a hidden item's is `hiddenitem`'s
+## `dwb event, item`, a conditional background event's is a `conditional_event`
+## record, and `OBJECTTYPE_3` through `OBJECTTYPE_6` are dummy events that run
+## nothing. Decoding those as commands and following what they named is where 50
+## Crystal and 20 Gold `loadmenu` records came from, and the `special` operands
+## that name no `SpecialsPointers` entry with them.
+static func event_pointer_is_script(source: String, event: Dictionary) -> bool:
+	match source:
+		"objects":
+			return int(event.get("object_type", -1)) == OBJECTTYPE_SCRIPT
+		"bg_events":
+			return int(event.get("type", -1)) in BGEVENT_SCRIPT_TYPES
+	return true
+
+
 ## A `BGEVENT_IFSET` or `BGEVENT_IFNOTSET` background event does not point at a
 ## script. It points at the four-byte `conditional_event` record
 ## (`macros/scripts/maps.asm`), an event flag then a near script pointer, and the
@@ -1306,6 +1334,10 @@ static func _collect_conditional_bg_script(
 	)
 
 
+## [param follow_references] is false for a pointer whose bytes are data rather
+## than commands. The slice is still cached, because every runtime reader of an
+## item ball, a hidden item and a conditional background event asks
+## `Gen2GameData.world_script` for it, but nothing decodes it as a script.
 static func _collect_script(
 	rom: RomFile,
 	bank: int,
@@ -1313,6 +1345,7 @@ static func _collect_script(
 	script_data: Dictionary,
 	text_data: Dictionary,
 	movement_data: Dictionary,
+	follow_references: bool = true,
 ) -> void:
 	if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
 		return
@@ -1327,6 +1360,8 @@ static func _collect_script(
 	if bytes.is_empty():
 		return
 	script_data[key] = Array(bytes)
+	if not follow_references:
+		return
 	var references: Dictionary = Gen2WorldScript.scan_references(
 		bytes, bank, address, rom.id == &"crystal"
 	)

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -759,7 +759,7 @@ static func _scan_menu_references(
 			if not uses.has(use):
 				uses.append(use)
 		at += int(command["width"])
-		if Gen2WorldScript.is_terminal(opcode, crystal_commands):
+		if not Gen2WorldScript.continues_after(opcode, crystal_commands):
 			break
 
 

--- a/game/world/move_deleter_screen.gd
+++ b/game/world/move_deleter_screen.gd
@@ -148,8 +148,8 @@ func advance_frame() -> void:
 		_draw_yes_no()
 
 
-func _text(name: String) -> String:
-	return String(_texts.get(name, ""))
+func _text(key: String) -> String:
+	return String(_texts.get(key, ""))
 
 
 func _build() -> void:
@@ -184,8 +184,8 @@ func _show_text(text: String, prompt: bool = false) -> void:
 	_text_box.show_text(text, prompt)
 
 
-func _open_question(phase: int) -> void:
-	_phase = phase
+func _open_question(next_phase: int) -> void:
+	_phase = next_phase
 	_yes = true
 	_draw_yes_no()
 

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -163,16 +163,16 @@ func advance_frame() -> void:
 		_open_question(Phase.BETTER_ASK)
 
 
-func _text(name: String) -> String:
-	return String(_texts.get(name, ""))
+func _text(key: String) -> String:
+	return String(_texts.get(key, ""))
 
 
 ## Every one of the routine's texts that names `wStringBuffer1` is filled with
 ## `GetCurNickname`'s own answer, which is the chosen member's nickname before
 ## the copy and its new one after.
-func _filled(name: String, nickname: String) -> String:
+func _filled(key: String, nickname: String) -> String:
 	return Gen2TextStream.fill_all_markers(
-		_text(name), Gen2TextStream.RAM_MARKER, nickname
+		_text(key), Gen2TextStream.RAM_MARKER, nickname
 	)
 
 
@@ -202,8 +202,8 @@ func _show_text(text: String, prompt: bool = false) -> void:
 	_text_box.show_text(text, prompt)
 
 
-func _open_question(phase: int) -> void:
-	_phase = phase
+func _open_question(next_phase: int) -> void:
+	_phase = next_phase
 	_yes = true
 	_draw_yes_no()
 

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -595,6 +595,36 @@ static func is_terminal(opcode: int, crystal_commands: bool = true) -> bool:
 	return is_end(opcode, crystal_commands) or is_endcallback(opcode, crystal_commands)
 
 
+## pokegold-numbered opcodes whose handler reaches ScriptJump, Script_end or
+## Script_endall unconditionally, so the bytes after the command are never read
+## as one. Two near misses are deliberately absent: `endifjustbattled`'s
+## `jp Script_end` sits behind a `ret z`, and `reloadmapafterbattle` jumps only
+## on LOSE and otherwise falls into `Script_reloadmap`, whose `StopScript`
+## leaves the script pointer where it stands (Route30.asm resumes on the
+## `loadmem` after it).
+const NON_RETURNING_SOURCE_OPCODES: Array[int] = [
+	0x03, 0x04, 0x05,  ## sjump, farsjump, memjump
+	0x0C,  ## jumpstd
+	0x51,  ## jumptextfaceplayer
+	0x64,  ## scripttalkafter
+	0x8E, 0x8F, 0x90, 0x91, 0x92,  ## stopandsjump, endcallback, end, reloadend, endall
+	0x99, 0x9A,  ## describedecoration, fruittree
+	0x9F, 0xA0,  ## halloffame, credits
+]
+
+
+## Whether the command at [param opcode] is followed by another command.
+##
+## A linear walk over a script stops here, not at [method is_terminal]: a script
+## that ends in `jumptext` is followed by the text it named, and a `jumpstd`
+## table by its pointers. Only the live runner, which dispatches one command at
+## a time and is told where to go next, uses `is_terminal`.
+static func continues_after(opcode: int, crystal_commands: bool = true) -> bool:
+	if is_text_jump(opcode, crystal_commands):
+		return false
+	return source_opcode(opcode, crystal_commands) not in NON_RETURNING_SOURCE_OPCODES
+
+
 static func is_waitbutton(opcode: int, crystal_commands: bool = true) -> bool:
 	return opcode == WAITBUTTON if crystal_commands else opcode == 0x53
 
@@ -918,7 +948,7 @@ static func scan_references(
 				command_queues.append({"bank": bank, "address": int(command["address"])})
 		at += int(command["width"])
 		command_count += 1
-		if is_terminal(opcode, crystal_commands):
+		if not continues_after(opcode, crystal_commands):
 			break
 	return {
 		"scripts": scripts, "texts": texts, "movements": movements,

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -376,3 +376,37 @@ func test_reference_scan_reports_command_queue_pointers() -> void:
 	assert_eq(queues.size(), 1)
 	assert_eq(queues[0], {"bank": 48, "address": 0x572B})
 	assert_true(references["scripts"].is_empty())
+
+
+## The commands that never come back, on both profiles. A walker bounded on
+## `is_terminal` alone read the pointer table behind a `jumptext` as commands.
+func test_commands_that_never_return_end_a_linear_walk() -> void:
+	## Crystal: sjump, jumpstd, jumptextfaceplayer, farjumptext, jumptext,
+	## stopandsjump, end, endall, fruittree, credits.
+	for opcode: int in [0x03, 0x0C, 0x51, 0x52, 0x53, 0x8F, 0x91, 0x93, 0x9B, 0xA2]:
+		assert_false(
+			Gen2WorldScript.continues_after(opcode, true),
+			"crystal %02X continues" % opcode
+		)
+	## Gold and Silver, one lower from jumptext on and two from halloffame on.
+	for opcode: int in [0x03, 0x0C, 0x51, 0x52, 0x8E, 0x90, 0x92, 0x9A, 0xA0]:
+		assert_false(
+			Gen2WorldScript.continues_after(opcode, false),
+			"gold %02X continues" % opcode
+		)
+
+
+## `endifjustbattled`'s `jp Script_end` sits behind a `ret z` and
+## `reloadmapafterbattle` jumps only on LOSE, so the stream carries on after
+## both; Route30.asm's rematch counter is the `loadmem` after one.
+func test_conditional_enders_do_not_stop_a_linear_walk() -> void:
+	for opcode: int in [Gen2WorldScript.SCALL, 0x60, 0x66, 0x3C, 0x8A]:
+		assert_true(
+			Gen2WorldScript.continues_after(opcode, true),
+			"crystal %02X stops" % opcode
+		)
+	for opcode: int in [Gen2WorldScript.SCALL, 0x5F, 0x65, 0x3C, 0x89]:
+		assert_true(
+			Gen2WorldScript.continues_after(opcode, false),
+			"gold %02X stops" % opcode
+		)

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -34,9 +34,9 @@ const RED_GYARADOS: int = 130
 ## Per game: total rows, and the count under each kind in
 ## [constant Gen2WorldCatalog.KINDS]' own order.
 const EXPECTED_CENSUS: Dictionary = {
-	&"gold": [482, 3, 9, 15, 9, 9, 360, 18, 59],
-	&"silver": [482, 3, 9, 15, 9, 9, 360, 18, 59],
-	&"crystal": [547, 3, 11, 15, 13, 6, 427, 16, 56],
+	&"gold": [465, 3, 9, 15, 8, 9, 352, 16, 53],
+	&"silver": [465, 3, 9, 15, 8, 9, 352, 16, 53],
+	&"crystal": [532, 3, 11, 14, 9, 6, 419, 16, 54],
 }
 
 ## The legendaries and set pieces every profile has to place, and at what level.
@@ -46,9 +46,7 @@ const EXPECTED_STATICS: Dictionary = {
 	&"silver": {LUGIA: [70, 40], HO_OH: [40, 70], SNORLAX: [50], SUDOWOODO: [20]},
 	&"crystal": {
 		LUGIA: [60], HO_OH: [60], CELEBI: [30], SUICUNE: [40],
-		## Crystal reaches its Sudowoodo from two `loadwildmon` sites, one per
-		## branch of the Squirtbottle script; Gold and Silver from one.
-		SNORLAX: [50], SUDOWOODO: [20, 20], RED_GYARADOS: [30],
+		SNORLAX: [50], SUDOWOODO: [20], RED_GYARADOS: [30],
 	},
 }
 

--- a/tools/checks/mon_specials.gd
+++ b/tools/checks/mon_specials.gd
@@ -220,7 +220,7 @@ func _commands_from(bytes: PackedByteArray, crystal_commands: bool) -> PackedStr
 		out.append(String(command.get("name", "")))
 		steps += 1
 		offset += int(command["width"])
-		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal_commands):
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal_commands):
 			break
 	return out
 
@@ -242,6 +242,6 @@ func _special_at(bytes: PackedByteArray, crystal_commands: bool, special: int) -
 			return index
 		index += 1
 		offset += int(command["width"])
-		if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal_commands):
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal_commands):
 			return -1
 	return -1

--- a/tools/checks/opening_lane.gd
+++ b/tools/checks/opening_lane.gd
@@ -142,7 +142,7 @@ func _audit_scripts(data: GameData, crystal: bool) -> Dictionary:
 				unknown_commands += 1
 				break
 			at += int(command.get("width", 1))
-			if Gen2WorldScript.is_terminal(int(command.get("opcode", 0)), crystal):
+			if not Gen2WorldScript.continues_after(int(command.get("opcode", 0)), crystal):
 				break
 	return {
 		"failures": failures,

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -72,12 +72,17 @@ const EXPECTED_DEFERRED: Dictionary = {
 	69: "DayCareMon1", 70: "DayCareMon2",
 }
 
-## Script rows whose linear walk runs past a `jumptext` pointer table and decodes
-## its addresses as commands, so the `special` it reports names no routine at
-## all. Pinned rather than filtered: `Gen2WorldScript.is_terminal` stops at
-## `end` and `endcallback` alone, and until the commands that never return stop
-## it too, this is what that costs measured at one place.
-const EXPECTED_OUT_OF_TABLE: Dictionary = {&"crystal": 23, &"gold": 25, &"silver": 25}
+## Decoded `special` operands that name no `SpecialsPointers` entry. Pinned
+## rather than filtered, so a walker that starts overrunning a script again is
+## caught here: every one of these comes from a cached script pointer, and a
+## pointer only exists because some walk collected it.
+##
+## Crystal's one is the cartridge's own. BattleTowerElevator.asm's receptionist
+## is an `OBJECTTYPE_SCRIPT` object whose script word is
+## `MovementData_BattleTowerElevatorReceptionistWalksIn`, so the bytes behind it
+## are movement rather than commands; the object stands in a room the scene
+## script drives and is never talked to.
+const EXPECTED_OUT_OF_TABLE: Dictionary = {&"crystal": 1, &"gold": 0, &"silver": 0}
 
 ## The five fades and what each of them costs, from `ConvertTimePals*HL`'s own
 ## `ld c` and `BattleTowerFade`'s. A fade that spends no frame is what this
@@ -86,16 +91,6 @@ const EXPECTED_FADE_FRAMES: Dictionary = {46: 8, 47: 28, 48: 8, 49: 8, 50: 8}
 
 ## `data/events/special_pointers.asm`'s own length, the same in both pins.
 const SPECIALS_POINTERS_SIZE: int = 169
-
-## A linear walk has to stop where control leaves the script, or it decodes the
-## pointer table a `jumptext` list is followed by as commands. These are the
-## decoder's own names for the commands that never come back;
-## `scall`/`farscall`/`callstd` do and are not here.
-const WALK_ENDS: Array[String] = [
-	"end", "endcallback", "reloadend", "endall", "stopandsjump",
-	"sjump", "farsjump", "memjump", "jumpstd",
-	"jumptext", "farjumptext", "jumptextfaceplayer",
-]
 
 var _r: RefCounted = null
 ## Which indices the runner answers, derived from the runner rather than kept
@@ -207,12 +202,12 @@ func _verify_slow_cry(data: GameData) -> void:
 
 ## Every cached script on one cartridge, walked for `special` and tallied.
 func _verify_corpus(data: GameData, crystal_commands: bool) -> void:
-	var scripts: Variant = RomCache.read_json(RomCache.world_scripts_path(data.directory))
-	if not scripts is Dictionary:
+	var scripts: Array = data.world_script_keys()
+	if scripts.is_empty():
 		_r.fail("the script table is missing")
 		return
 	var reached: Dictionary = {}
-	for raw_key: Variant in (scripts as Dictionary):
+	for raw_key: Variant in scripts:
 		var parts: PackedStringArray = String(raw_key).split(":")
 		if parts.size() != 2:
 			continue
@@ -273,7 +268,7 @@ func _specials_in(bytes: PackedByteArray, crystal_commands: bool) -> Array[int]:
 			))
 		steps += 1
 		offset += int(command["width"])
-		if name in WALK_ENDS:
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal_commands):
 			break
 	return out
 

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -44,7 +44,7 @@ func _validate(game_id: StringName) -> bool:
 	var crystal_commands: bool = game_id == &"crystal"
 	var script_count: int = 0
 	var command_count: int = 0
-	var terminal_count: int = 0
+	var walk_end_count: int = 0
 	var parse_failures: int = 0
 	var failure_reasons: Dictionary = {}
 	var failure_opcodes: Dictionary = {}
@@ -75,8 +75,8 @@ func _validate(game_id: StringName) -> bool:
 			command_count += 1
 			steps += 1
 			offset += int(command["width"])
-			if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal_commands):
-				terminal_count += 1
+			if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal_commands):
+				walk_end_count += 1
 				break
 
 	var invalid_text: int = 0
@@ -99,8 +99,8 @@ func _validate(game_id: StringName) -> bool:
 		number_markers += text.count(Gen2TextStream.NUMBER_MARKER)
 		_tally_raw_bytes(text, String(raw_key), raw_bytes)
 
-	print("%s: scripts=%d commands=%d terminal=%d parse_failures=%d texts=%d invalid_text=%d" % [
-		game_id, script_count, command_count, terminal_count, parse_failures,
+	print("%s: scripts=%d commands=%d walk_ends=%d parse_failures=%d texts=%d invalid_text=%d" % [
+		game_id, script_count, command_count, walk_end_count, parse_failures,
 		(text_value as Dictionary).size(), invalid_text,
 	])
 	print("  movements=%d" % (movement_value as Dictionary).size() \

--- a/tools/trace_world_story.gd
+++ b/tools/trace_world_story.gd
@@ -98,7 +98,7 @@ func _trace_pointer(bank: int, address: int, label: String) -> void:
 		print("  @%d %s" % [offset, JSON.stringify(display)])
 		_print_text_pointer(bank, command)
 		offset += int(command["width"])
-		if Gen2WorldScript.is_terminal(int(command["opcode"]), _data.id == &"crystal"):
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), _data.id == &"crystal"):
 			break
 		if offset >= raw.size():
 			break


### PR DESCRIPTION
A linear walk over an overworld script stopped at `end` and `endcallback` alone. Every command that jumps away and never comes back was walked straight through, so the decoder read the pointer table behind a `jumptext` list as if it were more commands.

`Gen2WorldScript.continues_after` is the rule now. `sjump`, `farsjump`, `memjump`, `jumpstd`, `jumptext`, `farjumptext`, `jumptextfaceplayer`, `stopandsjump`, `end`, `endcallback`, `reloadend`, `endall`, `describedecoration`, `fruittree`, `scripttalkafter`, `halloffame` and `credits` all reach `ScriptJump`, `Script_end` or `Script_endall` with no test in front of them. Two commands that look like they belong are left out. `endifjustbattled` jumps behind a `ret z`. `reloadmapafterbattle` jumps only when the battle was lost and otherwise falls through, which the rematch counter after it on Route 30 depends on.

The second half is bigger. Not every event pointer addresses commands at all. The engine calls a script for `OBJECTTYPE_SCRIPT` objects and for the five background events that read. An item ball's word is `db item, quantity`. A hidden item's is `dwb event, item`. A conditional background event's is a four-byte record. Object types 3 to 6 run nothing. The importer decoded all of these as scripts and then followed whatever their bytes happened to name.

Those slices are still cached, because the item ball, hidden item and conditional readers all ask for them at runtime. What changed is that nothing decodes them, and a corpus walk no longer sees them.

Cache format 77, so all three cartridges need importing again.

| Measure | Before | After |
|---|---|---|
| `loadmenu` records imported, Crystal / Gold | 66 / 29 | 16 / 9 |
| `special` operands naming no table entry | 23 / 25 / 25 | 1 / 0 / 0 |
| Catalog rows, Crystal / Gold | 547 / 482 | 532 / 465 |

The one `special` left is the cartridge's own. The Battle Tower elevator receptionist is an `OBJECTTYPE_SCRIPT` object whose script word points at movement data. Nobody can talk to it.

Two pinned numbers turned out to be artefacts of the bug. Crystal has one `loadwildmon SUDOWOODO`, not two. And the census counted rows decoded out of item data: Crystal's item kind is 419 now, against the sources' own 178 item balls, 85 hidden items and 157 give sites.

All checks pass, 3,392 tests pass, and the replay and story walks are unchanged.