### PR TITLE
Run the overworld at the cartridge's own pass rate

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1050,10 +1050,13 @@ fractional cell, from one cell behind the committed cell down to zero. The
 logical cell commits at the start of the step; the fraction is presentation only
 and never reaches collision, events or the snapshot. `applymovement` applies its
 whole stream at once, so a scripted path commits together and the offset trails
-by as many cells as are left to draw; `advance_scripted_steps_frame()` drains
-that trail, 16 frames a step for the slow commands, 8 for plain, 4 for bike
-speed. `Gen2WorldObject.frame` is the cartridge's `Facings` index, 0 to 3,
-changing every four frames the way `SetFacingStepAction` does.
+by as many cells as are left to draw; `advance_scripted_steps_pass()` drains
+that trail, 16 overworld passes a step for the slow commands, 8 for plain, 4 for
+bike speed. A pass is two hardware frames
+(`Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS`, `MaxOverworldDelay`), so a plain step
+covers its cell in sixteen of them. `Gen2WorldObject.frame` is the cartridge's
+`Facings` index, 0 to 3, changing every four passes the way
+`SetFacingStepAction` does.
 `mods/examples/voxel_preview/` reads all of it.
 
 A hop is the one step with a second axis.

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -29,29 +29,29 @@ const TRAINER_SHOCK_FRAMES: int = 60
 ## StepVectors' normal-speed row: 2 pixels per frame for 8 frames, the source
 ## duration for ordinary player walking (engine/overworld/map_objects.asm). The
 ## trainer approach shares it: see advance_trainer_approach_step().
-const STEP_FRAMES_WALK: int = 8
+const STEP_PASSES_WALK: int = 8
 ## A ledge hop is two chained STEP_WALK-duration cells back to back
 ## (engine/overworld/map_objects.asm's StepFunction_PlayerJump: .initjump/
 ## .stepjump then .initland/.stepland, each timed by the same InitStep call
 ## the ordinary walk uses). OBJECT_JUMP_HEIGHT/UpdateJumpPosition supplies the
 ## vertical arc exposed by player_jump_offset() and drawn by the world renderer.
-const STEP_FRAMES_HOP: int = STEP_FRAMES_WALK * 2
+const STEP_PASSES_HOP: int = STEP_PASSES_WALK * 2
 ## StepVectors' slow row: 1 pixel per frame for 16 frames. _RandomWalkContinue
 ## calls InitStep with a direction of 0 to 3, which indexes that first row, so
 ## a wandering object steps at half the player's walking speed.
-const STEP_FRAMES_NPC_WALK: int = 16
+const STEP_PASSES_NPC_WALK: int = 16
 ## MovementFunction_Strength calls InitStep with `direction | 0`, so a pushed
 ## boulder indexes that same slow row and slides at a wandering NPC's speed.
-const STEP_FRAMES_BOULDER_PUSH: int = STEP_FRAMES_NPC_WALK
+const STEP_PASSES_BOULDER_PUSH: int = STEP_PASSES_NPC_WALK
 ## `Movement_tree_shake`'s own `ld a, 24`, spent as a STEP_TYPE_SLEEP.
 const TREE_SHAKE_FRAMES: int = 24
 ## StepVectors' fast row: 4 pixels per frame for 4 frames, which the bike-speed
 ## movement commands reach through `STEP_BIKE`.
-const STEP_FRAMES_FAST: int = 4
+const STEP_PASSES_FAST: int = 4
 ## `StepFunction_Turn` (engine/overworld/map_objects.asm): two frames standing,
 ## then the new facing is written and two more, so a turn on the spot costs
 ## four frames and no cell.
-const STEP_FRAMES_TURN: int = 4
+const STEP_PASSES_TURN: int = 4
 ## How long each scripted step command takes, from the `STEP_*` speed it passes
 ## to `InitStep` (engine/overworld/movement.asm) and that row of `StepVectors`.
 ##
@@ -69,21 +69,21 @@ const STEP_FRAMES_TURN: int = 4
 ## `turn_step` is the one command that is not here: `TurnStep` sets
 ## STEP_TYPE_TURN, never calls `InitStep`, and `StepFunction_Turn` is two frames
 ## of standing and two of the new facing. It is filed with `turn_head` below.
-const SCRIPTED_STEP_FRAMES: Dictionary = {
-	&"slow_step": STEP_FRAMES_NPC_WALK,
-	&"step": STEP_FRAMES_WALK,
-	&"big_step": STEP_FRAMES_FAST,
-	&"slow_slide_step": STEP_FRAMES_NPC_WALK,
-	&"slide_step": STEP_FRAMES_WALK,
-	&"fast_slide_step": STEP_FRAMES_FAST,
-	&"slow_jump_step": STEP_FRAMES_NPC_WALK,
-	&"jump_step": STEP_FRAMES_WALK,
-	&"fast_jump_step": STEP_FRAMES_FAST,
-	&"turn_away": STEP_FRAMES_NPC_WALK,
-	&"turn_in": STEP_FRAMES_WALK,
-	&"turn_waterfall": STEP_FRAMES_FAST,
+const SCRIPTED_STEP_PASSES: Dictionary = {
+	&"slow_step": STEP_PASSES_NPC_WALK,
+	&"step": STEP_PASSES_WALK,
+	&"big_step": STEP_PASSES_FAST,
+	&"slow_slide_step": STEP_PASSES_NPC_WALK,
+	&"slide_step": STEP_PASSES_WALK,
+	&"fast_slide_step": STEP_PASSES_FAST,
+	&"slow_jump_step": STEP_PASSES_NPC_WALK,
+	&"jump_step": STEP_PASSES_WALK,
+	&"fast_jump_step": STEP_PASSES_FAST,
+	&"turn_away": STEP_PASSES_NPC_WALK,
+	&"turn_in": STEP_PASSES_WALK,
+	&"turn_waterfall": STEP_PASSES_FAST,
 }
-## The three rows of SCRIPTED_STEP_FRAMES that are a hop: two cells, twice the
+## The three rows of SCRIPTED_STEP_PASSES that are a hop: two cells, twice the
 ## frames, and the arc `UpdateJumpPosition` draws over them.
 const JUMP_STEP_KINDS: Array[StringName] = [
 	&"slow_jump_step", &"jump_step", &"fast_jump_step",
@@ -110,6 +110,24 @@ const BGEVENT_IFNOTSET: int = 6
 const BGEVENT_ITEM: int = 7
 const BGEVENT_COPY: int = 8
 
+## `HandleMap` spends `NextOverworldFrame` in the middle of every pass and
+## `MaxOverworldDelay` is 2 (engine/overworld/events.asm), so the whole
+## overworld runs one pass per two hardware frames: every map object's step,
+## every landmark sign countdown and every joypad read is a pass's, never a
+## screen frame's. Measured on a real cartridge with
+## `.claude/oracle/overworld/trace_walk.py`: an ordinary walk step is eight
+## passes of two pixels and sixteen frames. Every `PASSES` count below is in
+## that unit, and [Gen2WorldScreen] is what spends the two frames.
+const FRAMES_PER_OVERWORLD_PASS: int = 2
+
+
+## Hardware frames for a count of overworld passes. Anything spending frames
+## against a duration read off the source, a driver or a preview, goes through
+## this rather than multiplying by hand.
+static func passes_in_frames(passes: int) -> int:
+	return passes * FRAMES_PER_OVERWORLD_PASS
+
+
 ## `InitMapNameSign`. `wCurLandmark` is -1 on a map that has no name to show,
 ## and the five landmarks `.CheckSpecialMap` names get no sign either, alongside
 ## `LANDMARK_SPECIAL` itself. Crystal indices, since the sign is Crystal's own
@@ -117,7 +135,9 @@ const BGEVENT_COPY: int = 8
 ## maps 15 and 17, which `.CheckNationalParkGate` names because their
 ## environment is not `GATE`.
 const MAP_NAME_SIGN_NO_LANDMARK: int = -1
-const MAP_NAME_SIGN_FRAMES: int = 60
+## `wLandmarkSignTimer`, decremented once per `PlaceMapNameSign` and so once
+## per overworld pass, which is two hardware frames.
+const MAP_NAME_SIGN_PASSES: int = 60
 const NATIONAL_PARK_GATE_GROUP: int = 10
 const NATIONAL_PARK_GATE_MAPS: Array[int] = [15, 17]
 const MAP_NAME_SIGN_SILENT_LANDMARKS: Array[int] = [
@@ -274,8 +294,8 @@ var _phone_ring_request: Dictionary = {}
 ## a renderer draws the sprite. Never read by collision, events or the
 ## snapshot.
 var _player_step_direction: Vector2i = Vector2i.ZERO
-var _player_step_frames_total: int = 0
-var _player_step_frames_remaining: int = 0
+var _player_step_passes_total: int = 0
+var _player_step_passes_remaining: int = 0
 ## Gen2WorldObject.step_began for the player.
 var _player_step_began: bool = false
 ## Whether the step in flight is a ledge hop, which is the only one the source
@@ -650,7 +670,7 @@ func player_pixel_position() -> Vector2i:
 
 
 func player_step_in_progress() -> bool:
-	return _player_step_frames_remaining > 0
+	return _player_step_passes_remaining > 0
 
 
 ## `UpdateJumpPosition`'s `.y_offsets`: the pixel a jumping sprite is drawn above
@@ -666,10 +686,10 @@ const JUMP_OFFSETS: Array[int] = [
 ## is in flight. Presentation only: `player_cell` committed to the landing cell
 ## when the hop started.
 func player_jump_offset() -> int:
-	if not _player_jumping or _player_step_frames_total <= 0:
+	if not _player_jumping or _player_step_passes_total <= 0:
 		return 0
-	var spent: int = _player_step_frames_total - _player_step_frames_remaining
-	return jump_offset_at(spent, _player_step_frames_total)
+	var spent: int = _player_step_passes_total - _player_step_passes_remaining
+	return jump_offset_at(spent, _player_step_passes_total)
 
 
 ## The table entry a jump of [param total] frames is on after [param spent] of
@@ -705,9 +725,9 @@ func player_step_offset_cells() -> Vector2:
 	var behind := Vector2.ZERO
 	for entry: Dictionary in _player_queued_steps:
 		behind -= Vector2(entry["direction"] as Vector2i)
-	if _player_step_frames_remaining > 0 and _player_step_frames_total > 0:
+	if _player_step_passes_remaining > 0 and _player_step_passes_total > 0:
 		behind -= Vector2(_player_step_direction) \
-			* (float(_player_step_frames_remaining) / float(_player_step_frames_total))
+			* (float(_player_step_passes_remaining) / float(_player_step_passes_total))
 	return behind
 
 
@@ -717,7 +737,7 @@ func player_walk_frame() -> int:
 	## StepFunction_Turn writes OBJECT_WALKING = STANDING for the whole four
 	## frames. Once an ordinary step ends, SetFacingStanding selects the standing
 	## drawing even though OBJECT_STEP_FRAME itself retains its counter.
-	if _player_step_frames_remaining <= 0 or _player_step_direction == Vector2i.ZERO:
+	if _player_step_passes_remaining <= 0 or _player_step_direction == Vector2i.ZERO:
 		return 0
 	return (_player_step_frame >> 2) & 3
 
@@ -740,7 +760,7 @@ func _queue_player_step(
 	direction: Vector2i, frames: int, jumping: bool = false,
 	facing: Vector2i = Vector2i.ZERO
 ) -> void:
-	if _player_step_frames_remaining > 0 or not _player_queued_steps.is_empty():
+	if _player_step_passes_remaining > 0 or not _player_queued_steps.is_empty():
 		_player_scripted_steps = true
 		_player_queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
@@ -783,8 +803,8 @@ func _begin_player_step(
 	## it. `_try_ledge_hop` and a `jump_step` raise the flag again.
 	_player_jumping = jumping
 	_player_step_direction = direction
-	_player_step_frames_total = maxi(0, frames)
-	_player_step_frames_remaining = _player_step_frames_total
+	_player_step_passes_total = maxi(0, frames)
+	_player_step_passes_remaining = _player_step_passes_total
 	_player_step_began = direction != Vector2i.ZERO
 
 
@@ -792,8 +812,8 @@ func _clear_player_step() -> void:
 	_player_step_began = false
 	_player_jumping = false
 	_player_step_direction = Vector2i.ZERO
-	_player_step_frames_total = 0
-	_player_step_frames_remaining = 0
+	_player_step_passes_total = 0
+	_player_step_passes_remaining = 0
 	_player_queued_steps.clear()
 	_player_scripted_steps = false
 	_player_step_frame = 0
@@ -804,12 +824,12 @@ func _clear_player_step() -> void:
 ## This only shrinks a presentation offset that starts and ends at player_cell;
 ## it never changes player_cell, collision or event results, and a caller that
 ## never starts a step sees no difference.
-func advance_player_step_frame() -> bool:
-	if _player_step_frames_remaining <= 0:
+func advance_player_step_pass() -> bool:
+	if _player_step_passes_remaining <= 0:
 		return false
 	_player_step_frame = (_player_step_frame + 1) & 0x0F
-	_player_step_frames_remaining -= 1
-	if _player_step_frames_remaining <= 0:
+	_player_step_passes_remaining -= 1
+	if _player_step_passes_remaining <= 0:
 		_start_next_player_step()
 	return true
 
@@ -1115,7 +1135,7 @@ func complete_surf() -> Dictionary:
 	movement_mode = MOVEMENT_SURF
 	player_sprite_number = int(request["sprite"])
 	player_cell = request["cell"]
-	_start_player_step(request["direction"], STEP_FRAMES_NPC_WALK)
+	_start_player_step(request["direction"], STEP_PASSES_NPC_WALK)
 	return {
 		"ok": true,
 		"kind": &"surf_applied",
@@ -2372,7 +2392,7 @@ func take_grass_rustles() -> Array:
 			out.append({
 				"object_index": -1,
 				"cell": player_cell,
-				"frames": maxi(0, _player_step_frames_total - 1),
+				"frames": maxi(0, _player_step_passes_total - 1),
 			})
 	for object: Gen2WorldObject in objects:
 		if not object.step_began:
@@ -2385,7 +2405,7 @@ func take_grass_rustles() -> Array:
 		out.append({
 			"object_index": object.index,
 			"cell": object.cell,
-			"frames": maxi(0, object.step_frames_total - 1),
+			"frames": maxi(0, object.step_passes_total - 1),
 		})
 	return out
 
@@ -2428,7 +2448,7 @@ func start_trainer_approach(
 	object.set_emote(TRAINER_SHOCK_EMOTE, true, TRAINER_SHOCK_FRAMES)
 	plan["emote_id"] = TRAINER_SHOCK_EMOTE
 	plan["emote_frames"] = TRAINER_SHOCK_FRAMES
-	plan["step_frames"] = STEP_FRAMES_WALK
+	plan["step_passes"] = STEP_PASSES_WALK
 	return plan
 
 
@@ -2470,7 +2490,7 @@ func trainer_approach_plan(
 ## calls CanObjectMoveInDirection. That is what walks Cerulean Gym's swimmers
 ## over their own pool.
 ##
-## STEP_FRAMES_WALK, not the slow row: TrainerWalkToPlayer passes 1 in d and
+## STEP_PASSES_WALK, not the slow row: TrainerWalkToPlayer passes 1 in d and
 ## `.GetPathToPlayer`'s `push de`/`pop af` hands it to
 ## ComputePathToWalkToPlayer, whose `ld b, a` selects `.MovementData`'s `step`
 ## row (engine/overworld/player_object.asm, home/movement.asm).
@@ -2486,7 +2506,7 @@ func advance_trainer_approach_step(object_index: int, direction: Vector2i) -> Di
 			"object_index": object_index, "cell": destination,
 		}
 	object.cell = destination
-	object.start_step(direction, STEP_FRAMES_WALK)
+	object.start_step(direction, STEP_PASSES_WALK)
 	var key: String = _object_key(current_map.group, current_map.number, object_index)
 	_object_position_overrides[key] = object.cell
 	_object_facing_overrides[key] = object.facing
@@ -3979,7 +3999,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 			object.queue_step(Vector2i.ZERO, 0, false, turn)
 			final_facing = _facing_for_direction(turn)
 			continue
-		if SCRIPTED_STEP_FRAMES.has(kind):
+		if SCRIPTED_STEP_PASSES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			var jumping: bool = kind in JUMP_STEP_KINDS
 			var cells: int = 2 if jumping else 1
@@ -3991,9 +4011,9 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				# The cell commits here, as it does for every other step in this
 				# runtime; only the drawing trails. A stream applies in one call,
 				# so the whole path is queued and drawn a step at a time by
-				# advance_scripted_steps_frame().
+				# advance_scripted_steps_pass().
 				object.queue_step(
-					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping,
+					direction * cells, int(SCRIPTED_STEP_PASSES[kind]) * cells, jumping,
 					direction,
 				)
 				_advance_followers(object_index, vacated)
@@ -4105,7 +4125,7 @@ func _apply_player_movement(event: Dictionary) -> Array:
 				_movement_direction(int(command.get("direction", 0))),
 			)
 			continue
-		if SCRIPTED_STEP_FRAMES.has(kind):
+		if SCRIPTED_STEP_PASSES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			var jumping: bool = kind in JUMP_STEP_KINDS
 			var cells: int = 2 if jumping else 1
@@ -4114,7 +4134,7 @@ func _apply_player_movement(event: Dictionary) -> Array:
 				var vacated: Vector2i = player_cell
 				player_cell = destination
 				_queue_player_step(
-					direction * cells, int(SCRIPTED_STEP_FRAMES[kind]) * cells, jumping,
+					direction * cells, int(SCRIPTED_STEP_PASSES[kind]) * cells, jumping,
 					direction,
 				)
 				_advance_followers(-1, vacated)
@@ -4619,7 +4639,7 @@ func _object_landing_cells(
 ## advance after each successful player step.
 ##
 ## One movement decision per eligible object per call. A caller wanting the
-## source's pacing uses advance_object_steps_frame(), which spends the step and
+## source's pacing uses advance_object_steps_pass(), which spends the step and
 ## idle durations this records.
 func advance_objects(random: RandomNumberGenerator) -> int:
 	var moved: int = 0
@@ -4659,7 +4679,7 @@ func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenera
 		return false
 	object.cell = destination
 	object.apply_direction(direction)
-	object.start_step(direction, STEP_FRAMES_NPC_WALK)
+	object.start_step(direction, STEP_PASSES_NPC_WALK)
 	return true
 
 
@@ -4670,14 +4690,14 @@ func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenera
 ## STEP_TYPE_SLEEP and STEP_TYPE_FROM_MOVEMENT cycle. The cell commits when the
 ## step starts, matching InitStep and the player path, and only the presentation
 ## offset trails. Returns true when something a renderer draws changed.
-func advance_object_steps_frame(random: RandomNumberGenerator) -> bool:
+func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 	if random == null or objects.is_empty():
 		return false
 	var changed: bool = false
 	for object: Gen2WorldObject in objects:
 		if not object.active or object.deleted:
 			continue
-		# A scripted trail belongs to advance_scripted_steps_frame(), which runs
+		# A scripted trail belongs to advance_scripted_steps_pass(), which runs
 		# while a script does. Draining it here as well would walk it at twice
 		# the speed on every frame both drivers run.
 		if object.scripted_steps:
@@ -4714,12 +4734,12 @@ func advance_object_steps_frame(random: RandomNumberGenerator) -> bool:
 ## Drains the presentation trail an `applymovement` left on the objects it moved,
 ## and nothing else.
 ##
-## Separate from [method advance_object_steps_frame] because that one decides
+## Separate from [method advance_object_steps_pass] because that one decides
 ## movement and a caller stops calling it while a script runs, which is exactly
 ## when a scripted stream needs drawing. This decides nothing, rolls nothing and
 ## writes no cell: every cell the stream names committed when it was applied.
 ## Returns true when something a renderer draws moved.
-func advance_scripted_steps_frame() -> bool:
+func advance_scripted_steps_pass() -> bool:
 	var changed: bool = false
 	for object: Gen2WorldObject in objects:
 		if object.scripted_steps and not object.deleted and object.tick_step():
@@ -4733,7 +4753,7 @@ func advance_scripted_steps_frame() -> bool:
 ## The two waits are `ScriptEvents`'s own: SCRIPT_WAIT_MOVEMENT, which ends when
 ## the stream an `applymovement` started has been drawn, and the counted delay
 ## `pause`, `wait`, `deactivatefacing` and `showemote` spend. A host calls this
-## once per frame beside [method advance_scripted_steps_frame], which is what
+## once per frame beside [method advance_scripted_steps_pass], which is what
 ## draws the movement the first one waits for.
 func advance_script_wait_frame() -> Array:
 	var wait: Dictionary = pending_script_wait()
@@ -4779,8 +4799,8 @@ func _complete_script_wait() -> Array:
 ## no render loop of its own: the trails and then the wait that is watching them.
 ## A screen calls the three parts itself, in the order it already draws them.
 func advance_script_presentation_frame() -> Array:
-	advance_player_step_frame()
-	advance_scripted_steps_frame()
+	advance_player_step_pass()
+	advance_scripted_steps_pass()
 	return advance_script_wait_frame()
 
 
@@ -4880,11 +4900,11 @@ func _step_follower(follower_index: int, target_cell: Vector2i, exact: bool) -> 
 	if follower == null:
 		player_cell = destination
 		player_facing = _facing_for_direction(direction)
-		_queue_player_step(direction, STEP_FRAMES_WALK)
+		_queue_player_step(direction, STEP_PASSES_WALK)
 		return
 	follower.cell = destination
 	follower.apply_direction(direction)
-	follower.queue_step(direction, STEP_FRAMES_WALK)
+	follower.queue_step(direction, STEP_PASSES_WALK)
 	var override_key: String = _object_key(
 		current_map.group, current_map.number, follower_index
 	)
@@ -4920,7 +4940,7 @@ func player_input_move(direction: Vector2i) -> Dictionary:
 		var pressed_facing: int = _facing_for_direction(direction)
 		if pressed_facing != player_facing:
 			player_facing = pressed_facing
-			_start_player_step(Vector2i.ZERO, STEP_FRAMES_TURN)
+			_start_player_step(Vector2i.ZERO, STEP_PASSES_TURN)
 			return {
 				"ok": true, "kind": &"turn", "facing": player_facing, "cell": player_cell,
 			}
@@ -5064,7 +5084,7 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	player_facing = _facing_for_direction(direction)
 	state.count_step()
 	_advance_followers(-1, from_cell)
-	_start_player_step(direction, STEP_FRAMES_WALK)
+	_start_player_step(direction, STEP_PASSES_WALK)
 	return {
 		"ok": true,
 		"kind": &"forced_move",
@@ -5121,7 +5141,7 @@ func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary
 	var fall: Dictionary = stone_queue_script(boulder)
 	# FIXED_FACING is set on the boulder's movement data, so InitStep skips the
 	# OBJECT_DIRECTION write and the sprite keeps facing down while it slides.
-	boulder.start_step(direction, STEP_FRAMES_BOULDER_PUSH)
+	boulder.start_step(direction, STEP_PASSES_BOULDER_PUSH)
 	_remember_object_position(boulder)
 	var pushed: Dictionary = {
 		"index": boulder.index,
@@ -5172,7 +5192,7 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	player_facing = _facing_for_direction(direction)
 	state.count_step()
 	_advance_followers(-1, from_cell)
-	_start_player_step(direction * 2, STEP_FRAMES_HOP, true)
+	_start_player_step(direction * 2, STEP_PASSES_HOP, true)
 	return {
 		"ok": true,
 		"kind": &"ledge_hop",
@@ -5576,7 +5596,7 @@ func dig_request() -> Dictionary:
 ## `.BikeCheck`'s downhill branch is not modelled: `BIKEFLAGS_DOWNHILL_F` is set
 ## by nothing in either pin, so no map can ask for the slower non-down step.
 func _step_frames_for_movement() -> int:
-	return STEP_FRAMES_FAST if movement_mode == MOVEMENT_BIKE else STEP_FRAMES_WALK
+	return STEP_PASSES_FAST if movement_mode == MOVEMENT_BIKE else STEP_PASSES_WALK
 
 
 ## `BikeFunction`'s `.TryBike`: `.CheckEnvironment` first, then the state the

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -201,14 +201,14 @@ func start_cut(
 ## `SpawnShadow`, under a jumping object for twice the jump it was spawned in.
 ## Tracks whoever is jumping, and sits below them because the jump is an offset
 ## on the sprite alone.
-func start_jump_shadow(object_index: int, cell: Vector2i, direction: Vector2i, step_frames: int) -> void:
+func start_jump_shadow(object_index: int, cell: Vector2i, direction: Vector2i, step_passes: int) -> void:
 	_sprites.append({
 		"kind": SPRITE_SHADOW,
 		"cell": cell,
 		"object_index": object_index,
 		"palette": PAL_OW_EMOTE,
 		"frame": 0,
-		"duration": (int(float(maxi(0, step_frames)) / 2.0) + 1) * 2,
+		"duration": (int(float(maxi(0, step_passes)) / 2.0) + 1) * 2,
 		"direction": _direction_index(direction),
 	})
 
@@ -231,14 +231,14 @@ func start_grass_rustle(object_index: int, cell: Vector2i, frames: int) -> void:
 ## `SpawnStrengthBoulderDust`, spawned where the boulder starts sliding.
 ## `MovementFunction_BoulderDust` spends `(step duration + 1) * 2` frames, so the
 ## dust outlives the push.
-func start_boulder_dust(object_index: int, cell: Vector2i, direction: Vector2i, step_frames: int) -> void:
+func start_boulder_dust(object_index: int, cell: Vector2i, direction: Vector2i, step_passes: int) -> void:
 	_sprites.append({
 		"kind": SPRITE_BOULDER_DUST,
 		"cell": cell,
 		"object_index": object_index,
 		"palette": PAL_OW_EMOTE,
 		"frame": 0,
-		"duration": (maxi(0, step_frames) + 1) * 2,
+		"duration": (maxi(0, step_passes) + 1) * 2,
 		"direction": _direction_index(direction),
 	})
 
@@ -267,15 +267,20 @@ func start_heal_machine(machine_type: int, balls: int) -> void:
 	})
 
 
-func advance_frame() -> bool:
-	var moved: bool = false
-	var running: Array = []
-	for sprite: Dictionary in _sprites:
-		sprite["frame"] = int(sprite["frame"]) + 1
-		if int(sprite["frame"]) < int(sprite["duration"]):
-			running.append(sprite)
-		moved = true
-	_sprites = running
+## The three sprites that are temporary map objects on the cartridge, so their
+## countdowns are `HandleMap`'s passes rather than screen frames
+## (Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS). The other four are a routine's own
+## `DelayFrame` loop: `ShakeHeadbuttTree`, `OWCutAnimation` and `HealMachineAnim`
+## each spin on one while the script waits, so they keep the screen's rate.
+const PASS_PACED_SPRITES: Array[StringName] = [
+	SPRITE_SHADOW, SPRITE_GRASS_RUSTLE, SPRITE_BOULDER_DUST,
+]
+
+
+## One `HandleMap` pass: the tracking sprites, and `step_shake`'s own screen
+## shake, which is a movement and so is spent with the object that runs it.
+func advance_pass() -> bool:
+	var moved: bool = _spend_sprites(true)
 	if not active():
 		return moved
 	_frame += 1
@@ -283,6 +288,27 @@ func advance_frame() -> bool:
 		_kind = &"none"
 		_source = {}
 	return true
+
+
+## One hardware frame: the four sprites whose source routine spins on
+## `DelayFrame` rather than being stepped by `HandleObjectStep`.
+func advance_frame() -> bool:
+	return _spend_sprites(false)
+
+
+func _spend_sprites(pass_paced: bool) -> bool:
+	var moved: bool = false
+	var running: Array = []
+	for sprite: Dictionary in _sprites:
+		if PASS_PACED_SPRITES.has(StringName(sprite["kind"])) != pass_paced:
+			running.append(sprite)
+			continue
+		sprite["frame"] = int(sprite["frame"]) + 1
+		if int(sprite["frame"]) < int(sprite["duration"]):
+			running.append(sprite)
+		moved = true
+	_sprites = running
+	return moved
 
 
 func active() -> bool:

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -85,8 +85,8 @@ var emote_remaining: int = 0
 ## Sub-cell presentation offset toward a cell already committed to: the logical
 ## cell changes at the start of a step, and this only draws the approach.
 var step_direction: Vector2i = Vector2i.ZERO
-var step_frames_total: int = 0
-var step_frames_remaining: int = 0
+var step_passes_total: int = 0
+var step_passes_remaining: int = 0
 ## Whether the in-flight step is a `jump_step`, which is the only kind drawn
 ## above its own cell. See height_offset_pixels().
 var step_jumping: bool = false
@@ -103,13 +103,13 @@ var weird_tree: bool = false
 var queued_steps: Array = []
 ## True while the trail above belongs to a script rather than to the movement
 ## templates, which is what tells the two drivers apart:
-## Gen2WorldAPI.advance_object_steps_frame() decides movement and is refused while a
-## script runs, advance_scripted_steps_frame() only draws and is not.
+## Gen2WorldAPI.advance_object_steps_pass() decides movement and is refused while a
+## script runs, advance_scripted_steps_pass() only draws and is not.
 var scripted_steps: bool = false
 ## Frames this object waits before its movement template decides again. The
 ## source keeps this in OBJECT_STEP_DURATION while the object sits in
 ## STEP_TYPE_SLEEP (engine/overworld/map_objects.asm, StepFunction_Sleep).
-var idle_frames_remaining: int = 0
+var idle_passes_remaining: int = 0
 
 
 static func from_event(
@@ -153,14 +153,14 @@ func carry_presentation_from(previous: Gen2WorldObject) -> void:
 	emote_visible = previous.emote_visible
 	emote_remaining = previous.emote_remaining
 	step_direction = previous.step_direction
-	step_frames_total = previous.step_frames_total
-	step_frames_remaining = previous.step_frames_remaining
+	step_passes_total = previous.step_passes_total
+	step_passes_remaining = previous.step_passes_remaining
 	step_jumping = previous.step_jumping
 	queued_steps = previous.queued_steps.duplicate(true)
 	scripted_steps = previous.scripted_steps
 	step_frame = previous.step_frame
 	frame = previous.frame
-	idle_frames_remaining = previous.idle_frames_remaining
+	idle_passes_remaining = previous.idle_passes_remaining
 	deleted = previous.deleted
 
 
@@ -354,7 +354,7 @@ func queue_step(
 	direction: Vector2i, frames: int, jumping: bool = false,
 	new_facing: Vector2i = Vector2i.ZERO
 ) -> void:
-	if step_frames_remaining > 0 or not queued_steps.is_empty():
+	if step_passes_remaining > 0 or not queued_steps.is_empty():
 		scripted_steps = true
 		queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
@@ -397,8 +397,8 @@ func _begin_step(direction: Vector2i, frames: int, jumping: bool = false) -> voi
 	# and every step begun after it replaces the type, so the arc ends here.
 	step_jumping = jumping
 	step_direction = direction
-	step_frames_total = maxi(0, frames)
-	step_frames_remaining = step_frames_total
+	step_passes_total = maxi(0, frames)
+	step_passes_remaining = step_passes_total
 	# `NormalStep` calls `ShakeGrass` where it starts the step, and a queued
 	# stream starts its later steps here, so the flag is raised here and read
 	# once by Gen2WorldAPI.take_grass_rustles().
@@ -408,12 +408,12 @@ func _begin_step(direction: Vector2i, frames: int, jumping: bool = false) -> voi
 ## One frame of an in-flight step; false once it has finished, so a caller pacing
 ## by call count can tell "still stepping" from "done".
 func tick_step() -> bool:
-	if step_frames_remaining <= 0:
+	if step_passes_remaining <= 0:
 		return false
 	if step_direction != Vector2i.ZERO or weird_tree:
 		advance_walk_frame()
-	step_frames_remaining -= 1
-	if step_frames_remaining <= 0:
+	step_passes_remaining -= 1
+	if step_passes_remaining <= 0:
 		if weird_tree:
 			# The 24 frames are not a multiple of the four-frame cycle, so
 			# unlike a step this one has to be stood back up by hand.
@@ -440,7 +440,7 @@ func _start_next_queued_step() -> void:
 
 
 func is_stepping() -> bool:
-	return step_frames_remaining > 0
+	return step_passes_remaining > 0
 
 
 ## One hardware frame of `SetFacingStepAction`. The counter is never cleared
@@ -459,24 +459,24 @@ func walk_frame() -> int:
 ## rolls this duration itself; the caller supplies the rolled value so this
 ## class stays free of the generator.
 func start_idle(frames: int) -> void:
-	idle_frames_remaining = maxi(0, frames)
+	idle_passes_remaining = maxi(0, frames)
 
 
 ## Consumes one frame of that wait. Returns true when a frame was consumed,
 ## matching tick_step() so one caller can pace both.
 func tick_idle() -> bool:
-	if idle_frames_remaining <= 0:
+	if idle_passes_remaining <= 0:
 		return false
-	idle_frames_remaining -= 1
+	idle_passes_remaining -= 1
 	return true
 
 
 func is_idle() -> bool:
-	return idle_frames_remaining > 0
+	return idle_passes_remaining > 0
 
 
 ## Pixel offset from the committed cell back toward where the step began,
-## shrinking to zero as step_frames_remaining reaches zero.
+## shrinking to zero as step_passes_remaining reaches zero.
 func step_offset(cell_pixels: int) -> Vector2i:
 	var offset: Vector2 = step_offset_cells() * float(cell_pixels)
 	return Vector2i(int(round(offset.x)), int(round(offset.y)))
@@ -487,10 +487,10 @@ func step_offset(cell_pixels: int) -> Vector2i:
 ## `jump_step` is in flight; presentation only, the cell having committed to the
 ## landing cell when the jump started.
 func height_offset_pixels() -> float:
-	if not step_jumping or step_frames_total <= 0:
+	if not step_jumping or step_passes_total <= 0:
 		return 0.0
 	return float(-Gen2WorldAPI.jump_offset_at(
-		step_frames_total - step_frames_remaining, step_frames_total
+		step_passes_total - step_passes_remaining, step_passes_total
 	))
 
 
@@ -502,7 +502,7 @@ func step_offset_cells() -> Vector2:
 	var behind := Vector2.ZERO
 	for entry: Dictionary in queued_steps:
 		behind -= Vector2(entry["direction"] as Vector2i)
-	if step_frames_remaining > 0 and step_frames_total > 0:
+	if step_passes_remaining > 0 and step_passes_total > 0:
 		behind -= Vector2(step_direction) \
-			* (float(step_frames_remaining) / float(step_frames_total))
+			* (float(step_passes_remaining) / float(step_passes_total))
 	return behind

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -102,9 +102,12 @@ var _battle_transition: Gen2BattleTransition = null
 var _battle_transition_request: Dictionary = {}
 ## `wLandmarkSignTimer` and the window the sign is drawn in. The map load decides
 ## whether there is a sign (`Gen2WorldAPI.map_name_sign_pending`); the sixty
-## frames it stands for are spent here, like every other overworld countdown.
+## passes it stands for are spent here, like every other overworld countdown.
 var _map_name_sign: TextureRect = null
-var _map_name_sign_frames: int = 0
+var _map_name_sign_passes: int = 0
+## `wOverworldDelay`, counted down a hardware frame at a time so `HandleMap`
+## runs once per [member Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS] of them.
+var _overworld_delay: int = 0
 var _text_box: Gen2TextBox = null
 var _text_box_rect: Rect2i = Rect2i()
 var _text_box_rect_pushed: bool = false
@@ -514,8 +517,22 @@ func advance_frames(count: int) -> void:
 ##
 ## Every countdown below is spent exactly once here, so each is a function of
 ## [member Gen2WorldAPI.frame_number] and not of banked real time.
+##
+## Half of what follows is `HandleMap`'s own pass and runs once per two frames:
+## see [member Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS] and `map_pass` below. The
+## other half is what the source spends its own `DelayFrames` on from inside a
+## command, which the pass does not gate: a text box, either fade, the battle
+## transition, `GameTimer` and `AnimateTileset` are all VBlank's or a routine's
+## own and are spent on every frame.
 func advance_frame() -> void:
 	_spending_frame = true
+	## `ResetOverworldDelay` and `NextOverworldFrame`: the pass reloads the delay
+	## and then spends it, so the first frame of a world is a pass and every
+	## FRAMES_PER_OVERWORLD_PASS-th frame after it is the next one.
+	_overworld_delay -= 1
+	var map_pass: bool = _overworld_delay <= 0
+	if map_pass:
+		_overworld_delay = Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
 	if _text_box != null:
 		_text_box.accelerated = Gen2Button.text_accelerating()
 		_text_box.advance_frame()
@@ -534,23 +551,33 @@ func advance_frame() -> void:
 	## `RefreshMapSprites` runs inside the setup script and `PlaceMapNameSign`
 	## with the rest of the map's background, so a sign raised by the load this
 	## frame carried is spent from the next one.
-	_advance_map_name_sign()
+	if map_pass:
+		_advance_map_name_sign_pass()
 	_raise_map_name_sign()
 	if _effects != null:
-		if _effects.advance_frame() and _renderer != null:
+		var effects_moved: bool = _effects.advance_frame()
+		if map_pass:
+			effects_moved = _effects.advance_pass() or effects_moved
+		if effects_moved and _renderer != null:
 			_renderer.refresh()
 		_apply_world_effect_offset()
+	## `AnimateTileset` is VBlank's, not the pass's, so the water and the flowers
+	## animate on every frame while the objects standing on them move on passes.
 	if _animation != null and _animation.advance_frame() and _renderer != null:
 		_renderer.refresh_animation()
-	if _world != null and _world.advance_player_step_frame() and _renderer != null:
+	if map_pass and _world != null and _world.advance_player_step_pass() \
+		and _renderer != null:
 		_renderer.refresh()
 	## `_HandlePlayerStep` runs before `PlayerEvents` in `HandleMap`, so the step
 	## that finishes on this frame is the one whose events this frame runs.
-	if not _pending_step_events.is_empty() and _world != null \
+	if map_pass and not _pending_step_events.is_empty() and _world != null \
 		and not _world.player_step_in_progress():
 		var landed: Dictionary = _pending_step_events
 		_pending_step_events = {}
 		_complete_player_step(landed)
+	## Not the pass's: an emote's own countdown stands in for the `pause` between
+	## `ShowEmoteScript`'s two movements, and a script's `DelayFrames` is spent
+	## from inside the command rather than by `NextOverworldFrame`.
 	if _world != null and _world.advance_emotes_frame() and _renderer != null:
 		_renderer.refresh()
 	## After the player's own step, so an actor reading
@@ -565,18 +592,24 @@ func advance_frame() -> void:
 		_renderer.refresh()
 	_spend_actor_requests()
 	_spend_hidden_item_requests()
-	_advance_forced_movement()
-	_advance_held_direction()
-	if _objects_may_move() and _world.advance_object_steps_frame(_object_random) \
+	## `GetJoypad` and `PlayerEvents` are both inside the pass, so a held
+	## direction starts a step on a pass and never between two.
+	if map_pass:
+		_advance_forced_movement()
+		_advance_held_direction()
+	if map_pass and _objects_may_move() \
+		and _world.advance_object_steps_pass(_object_random) \
 		and _renderer != null:
 		_renderer.refresh()
 	# Not gated on _objects_may_move(): an applymovement is drawn while the
 	# script that ran it is still going, which is when a script runs one.
-	if _world != null and _world.advance_scripted_steps_frame() and _renderer != null:
+	if map_pass and _world != null and _world.advance_scripted_steps_pass() \
+		and _renderer != null:
 		_renderer.refresh()
 	# After both trails: `ShakeGrass` is called where the step starts, so a
 	# rustle taken now belongs to a step begun on this frame.
-	_spawn_grass_rustles()
+	if map_pass:
+		_spawn_grass_rustles()
 	if not _pending_headbutt_finish.is_empty() and (_effects == null or not _effects.sprites_active()):
 		var headbutt: Dictionary = _pending_headbutt_finish
 		_pending_headbutt_finish = {}
@@ -592,7 +625,7 @@ func advance_frame() -> void:
 	## it lands on may be the text's last, which is where the script runs on.
 	_continue_if_text_settled()
 	if not _trainer_approach.is_empty():
-		_advance_trainer_approach()
+		_advance_trainer_approach(map_pass)
 	if _world != null and _world.phone_ring_active():
 		var ring_results: Array = _world.advance_phone_ring_frame()
 		if not ring_results.is_empty():
@@ -1069,7 +1102,7 @@ func move_player(direction: Vector2i) -> bool:
 				## starts the slide, and the dust tracks the boulder from there.
 				_effects.start_boulder_dust(
 					int(pushed["index"]), pushed["to_cell"], pushed["direction"],
-					Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH,
+					Gen2WorldAPI.STEP_PASSES_BOULDER_PUSH,
 				)
 			if _renderer != null:
 				_renderer.refresh()
@@ -1104,7 +1137,7 @@ func _after_player_move(movement: Dictionary) -> bool:
 			## the player over both cells of it.
 			_effects.start_jump_shadow(
 				-1, _world.player_cell, _world.facing_direction(),
-				Gen2WorldAPI.STEP_FRAMES_HOP,
+				Gen2WorldAPI.STEP_PASSES_HOP,
 			)
 	## .ExitWater calls PlayMapMusic before the step, which is what drops the
 	## surfing track once the player is walking again.
@@ -1797,7 +1830,7 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 			_effects.start_cut(_world.facing_cell(), 1, _world.facing_direction(), _world.player_cell)
 			_effects.start_jump_shadow(
 				-1, _world.player_cell, _world.facing_direction(),
-				Gen2WorldAPI.STEP_FRAMES_HOP,
+				Gen2WorldAPI.STEP_PASSES_HOP,
 			)
 		_script_prompt = "Debug cut animation preview"
 		_renderer.refresh()
@@ -1820,10 +1853,10 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 	if _effects != null:
 		_effects.start_headbutt_tree(_world.player_cell + Vector2i(1, 0))
 		_effects.start_boulder_dust(
-			-1, _world.player_cell, Vector2i.DOWN, Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH
+			-1, _world.player_cell, Vector2i.DOWN, Gen2WorldAPI.STEP_PASSES_BOULDER_PUSH
 		)
 		_effects.start_grass_rustle(
-			-1, _world.player_cell, Gen2WorldAPI.STEP_FRAMES_WALK - 1
+			-1, _world.player_cell, Gen2WorldAPI.STEP_PASSES_WALK - 1
 		)
 	## The nearest object rather than the first, so the emote lands inside the
 	## view a capture photographs.
@@ -3261,10 +3294,13 @@ func _start_trainer_approach(request: Dictionary) -> void:
 
 ## One hardware frame of `SeenByTrainerScript`'s presentation: the shock emote's
 ## own count, the movement delay, then one planned cell at a time. The object's
-## step_frames_remaining (set by
+## step_passes_remaining (set by
 ## [method Gen2WorldAPI.advance_trainer_approach_step]) is spent by the same
 ## frame, while step_offset() still gives the renderer 16-frame interpolation.
-func _advance_trainer_approach() -> void:
+## [param map_pass] is whether this hardware frame runs `HandleMap`'s own pass.
+## The two countdowns in front of the walk are the script's `DelayFrames` and are
+## spent on every frame; the walk itself is `HandleObjectStep`'s and is not.
+func _advance_trainer_approach(map_pass: bool) -> void:
 	if _world == null:
 		_trainer_approach = {}
 		return
@@ -3277,6 +3313,8 @@ func _advance_trainer_approach() -> void:
 	var movement_delay: int = int(_trainer_approach.get("movement_delay", 0))
 	if movement_delay > 0:
 		_trainer_approach["movement_delay"] = movement_delay - 1
+		return
+	if not map_pass:
 		return
 	var object_index: int = int(_trainer_approach.get("object_index", -1))
 	var stepping_object: Gen2WorldObject = _world.objects[object_index] \
@@ -4837,8 +4875,8 @@ func _show_story_picture(species: int) -> void:
 
 ## How many of `wLandmarkSignTimer`'s sixty frames the sign has left, and zero
 ## when there is none up. What a test or a screenshot tool waits on.
-func map_name_sign_frames() -> int:
-	return _map_name_sign_frames
+func map_name_sign_passes() -> int:
+	return _map_name_sign_passes
 
 
 ## `InitMapNameSign`'s own decision, raised where the map load leaves it: the
@@ -4858,7 +4896,7 @@ func _raise_map_name_sign() -> void:
 	## The timer is the setup script's, not the sheet's: a cache with no
 	## `MapEntryFrameGFX` spends the same sixty frames with nothing drawn in
 	## them rather than skipping them.
-	_map_name_sign_frames = Gen2WorldAPI.MAP_NAME_SIGN_FRAMES
+	_map_name_sign_passes = Gen2WorldAPI.MAP_NAME_SIGN_PASSES
 	var image: Image = Gen2MapNameSignPage.render(
 		_data,
 		_data.landmark_name(landmark),
@@ -4882,11 +4920,11 @@ func _raise_map_name_sign() -> void:
 
 ## `PlaceMapNameSign`, which counts `wLandmarkSignTimer` down a frame at a time
 ## and takes the window away on the frame it runs out.
-func _advance_map_name_sign() -> void:
-	if _map_name_sign_frames <= 0:
+func _advance_map_name_sign_pass() -> void:
+	if _map_name_sign_passes <= 0:
 		return
-	_map_name_sign_frames -= 1
-	if _map_name_sign_frames <= 0:
+	_map_name_sign_passes -= 1
+	if _map_name_sign_passes <= 0:
 		_hide_map_name_sign()
 		return
 	if _map_name_sign != null:
@@ -4921,7 +4959,7 @@ func _zero_map_name_sign_for(results: Array) -> void:
 
 
 func _hide_map_name_sign() -> void:
-	_map_name_sign_frames = 0
+	_map_name_sign_passes = 0
 	if _map_name_sign == null:
 		return
 	Gen2Screen.drop(_map_name_sign)

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -424,8 +424,8 @@ func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() ->
 	## Mid-step it is DRAWN across two cells, and a wild standing in either of
 	## them stands inside it, so `step_offset_cells()` puts both in the list.
 	trainer.step_direction = Vector2i(1, 0)
-	trainer.step_frames_total = 8
-	trainer.step_frames_remaining = 4
+	trainer.step_passes_total = 8
+	trainer.step_passes_remaining = 4
 	_world_screen._encounters.advance_frame()
 	var walking: PackedVector2Array = provider.get("context")["occupied"]
 	assert_true(walking.has(Vector2(6, 3)), "the cell it is committed to")

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -1,10 +1,18 @@
 extends GutTest
 
 ## `StepVectors`' normal row (`engine/overworld/map_objects.asm`): two pixels a
-## frame for eight frames, which is one cell.
+## pass for eight passes, which is one cell.
+##
+## A pass is not a frame. `HandleMap` ends every iteration in
+## `NextOverworldFrame`, whose `MaxOverworldDelay` is 2, so the whole overworld
+## runs once per two hardware frames and an ordinary walk step takes sixteen.
+## Measured on a real cartridge, `.claude/oracle/overworld/trace_walk.py` on
+## Route 29: `wPlayerStepDuration` counts 7 down to 0 over frames 19 to 34 while
+## `wPlayerSpriteX` walks 208 to 224 two pixels at a time, and a hook on
+## `HandleMapObjects` fires on every other frame and no other.
 ##
 ## The constant on its own is not the question; the pacing around it is. A step
-## that costs nine frames because the frame the last one ended on is spent
+## that costs nine passes because the pass the last one ended on is spent
 ## starting the next reads as sluggish, and no constant would be wrong. In the
 ## source it costs eight: `HandleObjectStep`'s `.one` calls
 ## `StepFunction_FromMovement`, and when that starts a step the step type is no
@@ -39,55 +47,106 @@ func after_each() -> void:
 
 
 func _walk_frames() -> int:
-	return Gen2WorldAPI.STEP_FRAMES_WALK
+	return Gen2WorldAPI.STEP_PASSES_WALK
+
+
+## The screen's own frames for a count of overworld passes. `HandleMap` runs one
+## pass per `NextOverworldFrame`, and `MaxOverworldDelay` is 2, so a duration
+## read off `InitStep` or off `wLandmarkSignTimer` costs twice its number of
+## frames. Measured on a real cartridge with
+## `.claude/oracle/overworld/trace_walk.py`.
+func _screen_frames(passes: int) -> int:
+	return passes * Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
+
+
+func _walk_screen_frames() -> int:
+	return _screen_frames(Gen2WorldAPI.STEP_PASSES_WALK)
+
+
+func _turn_screen_frames() -> int:
+	return _screen_frames(Gen2WorldAPI.STEP_PASSES_TURN)
+
+
+## `MaxOverworldDelay`, which is what makes every row below a pass rather than a
+## frame.
+func test_the_overworld_runs_one_pass_per_two_hardware_frames() -> void:
+	assert_eq(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS, 2)
+
+
+## The cartridge's own sixteen, measured between two landings so the count does
+## not depend on which frame the press arrived on: a direction held through the
+## pump walks a cell every FRAMES_PER_OVERWORLD_PASS * STEP_PASSES_WALK frames.
+## This is the case the pinned trace is for, and the one that fails on a port
+## that spends a pass per frame.
+func test_a_held_walk_covers_a_cell_every_sixteen_hardware_frames() -> void:
+	## Three cells clear of any warp or wall, walked west across the fixture.
+	_screen = await _screen_at(Fixture.WARP_CELL + Vector2i.DOWN)
+	var landings: Array[int] = []
+	var cell: Vector2i = _screen._world.player_cell
+	for frame: int in _walk_screen_frames() * 4:
+		## `move_player` refuses while a step is in flight, so pressing every
+		## frame is the held direction `_advance_held_direction` polls.
+		_screen.move_left()
+		_screen.advance_frame()
+		if _screen._world.player_cell != cell:
+			cell = _screen._world.player_cell
+			landings.append(frame)
+		if landings.size() >= 3:
+			break
+	assert_eq(landings.size(), 3, "three cells walked")
+	assert_eq(
+		landings[1] - landings[0], _walk_screen_frames(),
+		"one cell per sixteen hardware frames"
+	)
+	assert_eq(landings[2] - landings[1], _walk_screen_frames())
 
 
 ## `StepVectors`' own three rows, which is where every duration in
 ## [Gen2WorldAPI] comes from.
 func test_the_step_durations_are_the_source_rows() -> void:
-	assert_eq(Gen2WorldAPI.STEP_FRAMES_NPC_WALK, 16, "the slow row")
-	assert_eq(Gen2WorldAPI.STEP_FRAMES_WALK, 8, "the normal row")
-	assert_eq(Gen2WorldAPI.STEP_FRAMES_FAST, 4, "the fast row")
+	assert_eq(Gen2WorldAPI.STEP_PASSES_NPC_WALK, 16, "the slow row")
+	assert_eq(Gen2WorldAPI.STEP_PASSES_WALK, 8, "the normal row")
+	assert_eq(Gen2WorldAPI.STEP_PASSES_FAST, 4, "the fast row")
 	# `StepFunction_Turn` is two frames standing and two on the new facing.
-	assert_eq(Gen2WorldAPI.STEP_FRAMES_TURN, 4)
+	assert_eq(Gen2WorldAPI.STEP_PASSES_TURN, 4)
 
 
-## Eight frames, no more: the eighth is the one that ends it.
-func test_a_walk_step_costs_exactly_eight_frames() -> void:
+## Eight passes, no more: the eighth is the one that ends it.
+func test_a_walk_step_costs_exactly_eight_passes() -> void:
 	_world._start_player_step(Vector2i(1, 0), _walk_frames())
 	for _frame: int in _walk_frames() - 1:
-		_world.advance_player_step_frame()
+		_world.advance_player_step_pass()
 		assert_true(_world.player_step_in_progress(), "still walking")
-	_world.advance_player_step_frame()
-	assert_false(_world.player_step_in_progress(), "the eighth frame ends it")
+	_world.advance_player_step_pass()
+	assert_false(_world.player_step_in_progress(), "the eighth pass ends it")
 
 
-## A step queued behind the one running takes over on the frame the first ends,
-## so a walk of several cells is eight frames a cell rather than nine.
+## A step queued behind the one running takes over on the pass the first ends,
+## so a walk of several cells is eight passes a cell rather than nine.
 func test_a_queued_step_starts_on_the_frame_the_last_one_ends() -> void:
 	_world._start_player_step(Vector2i(1, 0), _walk_frames())
 	_world._queue_player_step(Vector2i(1, 0), _walk_frames())
 	for _frame: int in _walk_frames():
-		_world.advance_player_step_frame()
+		_world.advance_player_step_pass()
 	assert_true(_world.player_step_in_progress(), "the second step took over")
 	for _frame: int in _walk_frames() - 1:
-		_world.advance_player_step_frame()
+		_world.advance_player_step_pass()
 		assert_true(_world.player_step_in_progress())
-	_world.advance_player_step_frame()
+	_world.advance_player_step_pass()
 	assert_false(_world.player_step_in_progress(), "and cost the same eight")
 
 
 ## The offset the renderer draws the player at closes over the step's own eight
-## frames, which is `StepVectors`' two pixels a frame reaching sixteen.
+## passes, which is `StepVectors`' two pixels a pass reaching sixteen.
 func test_the_offset_covers_one_cell() -> void:
 	_world._start_player_step(Vector2i(1, 0), _walk_frames())
 	for _frame: int in _walk_frames() - 1:
-		_world.advance_player_step_frame()
+		_world.advance_player_step_pass()
 	assert_ne(
 		_world.player_step_offset_cells(), Vector2.ZERO,
 		"the pic is still short of the cell"
 	)
-	_world.advance_player_step_frame()
+	_world.advance_player_step_pass()
 	assert_eq(_world.player_step_offset_cells(), Vector2.ZERO, "and lands on it")
 
 
@@ -108,11 +167,15 @@ func _walk_onto_the_door() -> Gen2WorldScreen:
 
 
 func _screen_below_the_door() -> Gen2WorldScreen:
+	return await _screen_at(Fixture.WARP_CELL + Vector2i.DOWN)
+
+
+func _screen_at(start: Vector2i) -> Gen2WorldScreen:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
 	screen.map_group = Fixture.MAP_GROUP
 	screen.map_number = Fixture.MAP_NUMBER
-	screen.start_cell = Fixture.WARP_CELL + Vector2i.DOWN
+	screen.start_cell = start
 	screen.encounter_seed = 1
 	screen.set_data(_data)
 	add_child(screen)
@@ -129,19 +192,24 @@ func _screen_below_the_door() -> Gen2WorldScreen:
 func test_a_warp_waits_for_the_step_onto_its_tile_to_land() -> void:
 	_screen = await _screen_below_the_door()
 	_screen.move_up()   # `.CheckTurning`: the first press only turns.
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_TURN:
+	for _frame: int in _turn_screen_frames():
 		_screen.advance_frame()
 	_screen.move_up()
 	assert_true(_screen._world.player_step_in_progress(), "the step onto the door started")
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK - 1:
-		_screen.advance_frame()
+	## Driven to the landing rather than counted: which of the two frames of a
+	## pass the press arrived on decides whether the step's first pass is this
+	## frame or the next, and neither is the thing under test.
+	var frames: int = 0
+	while _screen._world.player_step_in_progress() and frames < WALK_FRAME_CAP:
 		assert_true(
 			_screen.map_fade().is_empty(),
 			"no warp while the player is still between the two cells",
 		)
-	assert_true(_screen._world.player_step_in_progress(), "the last frame of the step")
-	_screen.advance_frame()
-	assert_false(_screen._world.player_step_in_progress(), "which lands it")
+		_screen.advance_frame()
+		frames += 1
+	assert_false(_screen._world.player_step_in_progress(), "the step landed")
+	assert_gt(frames, _walk_screen_frames() - Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS,
+		"and cost a pass short of sixteen frames at worst")
 	assert_false(_screen.map_fade().is_empty(), "and the warp is taken on that frame")
 
 
@@ -197,23 +265,23 @@ func test_no_input_is_taken_while_the_warp_fade_runs() -> void:
 
 ## `InitMapNameSign` sits inside the same setup script: the warp crosses from the
 ## map's own landmark into the house's, so a sign is raised, and
-## `PlaceMapNameSign` counts `wLandmarkSignTimer`'s sixty frames down behind it.
+## `PlaceMapNameSign` counts `wLandmarkSignTimer`'s sixty passes down behind it.
 func test_a_warp_into_another_landmark_raises_the_map_name_sign() -> void:
 	_screen = await _walk_onto_the_door()
-	assert_eq(_screen.map_name_sign_frames(), 0, "nothing is up while the fade runs")
+	assert_eq(_screen.map_name_sign_passes(), 0, "nothing is up while the fade runs")
 	for _frame: int in WALK_FRAME_CAP:
 		_screen.advance_frame()
-		if _screen.map_name_sign_frames() > 0:
+		if _screen.map_name_sign_passes() > 0:
 			break
 	assert_eq(
-		_screen.map_name_sign_frames(), Gen2WorldAPI.MAP_NAME_SIGN_FRAMES,
-		"the sign is raised once the map is loaded, with all sixty frames to spend"
+		_screen.map_name_sign_passes(), Gen2WorldAPI.MAP_NAME_SIGN_PASSES,
+		"the sign is raised once the map is loaded, with all sixty passes to spend"
 	)
-	for _frame: int in Gen2WorldAPI.MAP_NAME_SIGN_FRAMES - 1:
+	for _frame: int in _screen_frames(Gen2WorldAPI.MAP_NAME_SIGN_PASSES) - 1:
 		_screen.advance_frame()
-	assert_eq(_screen.map_name_sign_frames(), 1, "still up on its last frame")
+	assert_eq(_screen.map_name_sign_passes(), 1, "still up on its last pass")
 	_screen.advance_frame()
-	assert_eq(_screen.map_name_sign_frames(), 0, "and gone on the sixtieth")
+	assert_eq(_screen.map_name_sign_passes(), 0, "and gone on the sixtieth")
 
 
 ## `PlayerEvents` zeroes `wLandmarkSignTimer` behind `DoPlayerEvent`, so only a
@@ -225,18 +293,19 @@ func test_a_queued_map_callback_does_not_take_the_sign_down() -> void:
 	_screen = await _walk_onto_the_door()
 	for _frame: int in WALK_FRAME_CAP:
 		_screen.advance_frame()
-		if _screen.map_name_sign_frames() > 0:
+		if _screen.map_name_sign_passes() > 0:
 			break
-	assert_eq(_screen.map_name_sign_frames(), Gen2WorldAPI.MAP_NAME_SIGN_FRAMES)
+	assert_eq(_screen.map_name_sign_passes(), Gen2WorldAPI.MAP_NAME_SIGN_PASSES)
 	## The fixture's house has no callback of its own, so one stands on the
 	## queue directly: what is under test is that a waiting script is not what
 	## takes the sign down, whatever put it there.
 	_screen._world._script_queue.append({})
 	assert_true(_screen._world.script_busy(), "a callback is waiting to run")
-	_screen.advance_frame()
+	for _frame: int in Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS:
+		_screen.advance_frame()
 	assert_eq(
-		_screen.map_name_sign_frames(), Gen2WorldAPI.MAP_NAME_SIGN_FRAMES - 1,
-		"and the sign spent that frame rather than being taken down"
+		_screen.map_name_sign_passes(), Gen2WorldAPI.MAP_NAME_SIGN_PASSES - 1,
+		"and the sign spent that pass rather than being taken down"
 	)
 
 
@@ -249,19 +318,19 @@ func test_only_a_player_event_result_takes_the_sign_down() -> void:
 	_screen = await _walk_onto_the_door()
 	for _frame: int in WALK_FRAME_CAP:
 		_screen.advance_frame()
-		if _screen.map_name_sign_frames() > 0:
+		if _screen.map_name_sign_passes() > 0:
 			break
-	var raised: int = _screen.map_name_sign_frames()
-	assert_eq(raised, Gen2WorldAPI.MAP_NAME_SIGN_FRAMES)
+	var raised: int = _screen.map_name_sign_passes()
+	assert_eq(raised, Gen2WorldAPI.MAP_NAME_SIGN_PASSES)
 
 	_screen._zero_map_name_sign_for([{"source": {"kind": &"callback"}}])
-	assert_eq(_screen.map_name_sign_frames(), raised, "a map callback raises no event")
+	assert_eq(_screen.map_name_sign_passes(), raised, "a map callback raises no event")
 
 	_screen._zero_map_name_sign_for([{"source": {"kind": &"scene"}, "deferred": false}])
-	assert_eq(_screen.map_name_sign_frames(), raised, "and nor does a scene of bare ends")
+	assert_eq(_screen.map_name_sign_passes(), raised, "and nor does a scene of bare ends")
 
 	_screen._zero_map_name_sign_for([{"source": {"kind": &"scene"}, "deferred": true}])
-	assert_eq(_screen.map_name_sign_frames(), 0, "an `sdefer` is the carry that does")
+	assert_eq(_screen.map_name_sign_passes(), 0, "an `sdefer` is the carry that does")
 
 
 ## `.CheckMovingWithinLandmark`: the map the world opens on is `wPrevLandmark`,

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -328,7 +328,7 @@ func test_choosing_cut_shows_the_message_and_defers_the_block_change() -> void:
 	## the one faced, so the walk is the press after it.
 	_world_screen.move_player(Vector2i.DOWN)
 	while world.player_step_in_progress():
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 	if world.player_cell != TREE_CELL:
 		assert_true(_world_screen.move_player(Vector2i.DOWN))
 	assert_eq(world.player_cell, TREE_CELL)
@@ -411,12 +411,12 @@ func test_stepping_back_onto_land_stops_surfing_through_the_screen() -> void:
 	# The entry step is a slow_step, so the presentation offset has to run out
 	# before the screen accepts input again.
 	while world.player_step_in_progress():
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 	## `.CheckTurning` turns on the spot first when the pressed direction is not
 	## the one faced, so the walk is the press after it.
 	_world_screen.move_player(Vector2i.UP)
 	while world.player_step_in_progress():
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 	if world.player_cell != SHORE_CELL:
 		assert_true(_world_screen.move_player(Vector2i.UP))
 	assert_eq(world.player_cell, SHORE_CELL)

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -104,7 +104,7 @@ func test_a_renderer_never_receives_a_movement_or_interaction_button() -> void:
 	## spawns facing down; the walk is the press after it.
 	_world_screen._unhandled_input(_press(KEY_RIGHT))
 	while _world_screen._world.player_step_in_progress():
-		_world_screen._world.advance_player_step_frame()
+		_world_screen._world.advance_player_step_pass()
 	_world_screen._unhandled_input(_press(KEY_RIGHT))
 	_world_screen._unhandled_input(_press(KEY_SPACE))
 	# The screen claimed both: the player moved, and neither key was offered on.

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -271,8 +271,8 @@ func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 	assert_true(saw_step)
 	# tick_step() spends one hardware frame, the same one the emote and
 	# movement-delay counters are spent by; the offset eases down to one
-	# STEP_FRAMES_WALK-th of a cell on the frame before the step formally ends.
-	assert_eq(lowest_magnitude, Gen2WorldAPI.CELL_PIXELS / Gen2WorldAPI.STEP_FRAMES_WALK)
+	# STEP_PASSES_WALK-th of a cell on the frame before the step formally ends.
+	assert_eq(lowest_magnitude, Gen2WorldAPI.CELL_PIXELS / Gen2WorldAPI.STEP_PASSES_WALK)
 
 
 func test_victory_displays_imported_text_reloads_objects_and_keeps_player_cell() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -867,7 +867,7 @@ func test_ledge_hop_crosses_two_cells_after_an_ordinary_step_is_blocked() -> voi
 	assert_eq(world.repel_steps(), 1)
 
 	# The presentation offset starts two cells behind and eases to zero over
-	# STEP_FRAMES_HOP frames, the same generic step system a one-cell walk
+	# STEP_PASSES_HOP frames, the same generic step system a one-cell walk
 	# uses with a magnitude-2 direction.
 	assert_true(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2(0, -2))
@@ -884,9 +884,9 @@ func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
 	assert_eq(world.player_jump_offset(), 0, "standing still is on the ground")
 	assert_eq(world.move_result(Vector2i.DOWN)["kind"], &"ledge_hop")
 	var arc: Array = []
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_HOP:
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_HOP:
 		arc.append(world.player_jump_offset())
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 	assert_eq(arc, Gen2WorldAPI.JUMP_OFFSETS)
 	assert_eq(world.player_jump_offset(), 0, "and the arc ends with the step")
 
@@ -896,10 +896,10 @@ func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
 	assert_eq(lifted.move_result(Vector2i.DOWN)["kind"], &"ledge_hop")
 	var cell: Vector2i = lifted.player_cell
 	var highest: float = 0.0
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_HOP:
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_HOP:
 		highest = maxf(highest, lifted.player_height_offset_pixels())
 		assert_eq(lifted.player_cell, cell, "the cell is the landing cell throughout")
-		lifted.advance_player_step_frame()
+		lifted.advance_player_step_pass()
 	assert_eq(highest, 12.0, "the top of .y_offsets, above the ground")
 	assert_eq(lifted.player_height_offset_pixels(), 0.0, "and back down on landing")
 
@@ -911,9 +911,9 @@ func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
 	## UpdateJumpPosition, so the step after the hop is on the ground for the
 	## whole of it however the hop left the flag.
 	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)), "a walk off the ledge")
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
 		assert_eq(world.player_jump_offset(), 0, "the walk after a hop has no arc")
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 
 
 func test_ledge_hop_refuses_a_direction_the_code_does_not_allow() -> void:
@@ -1019,12 +1019,12 @@ func test_strength_push_slides_the_boulder_over_the_slow_step_duration() -> void
 	var boulder: Gen2WorldObject = _boulder_at(world, BOULDER_LANDING)
 	assert_not_null(boulder)
 	assert_true(boulder.is_stepping())
-	assert_eq(boulder.step_frames_total, Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH)
+	assert_eq(boulder.step_passes_total, Gen2WorldAPI.STEP_PASSES_BOULDER_PUSH)
 
 	var random := RandomNumberGenerator.new()
 	random.seed = 7
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_BOULDER_PUSH:
-		world.advance_object_steps_frame(random)
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_BOULDER_PUSH:
+		world.advance_object_steps_pass(random)
 	assert_false(boulder.is_stepping())
 	assert_false(boulder.is_idle())
 	assert_eq(boulder.cell, BOULDER_LANDING)
@@ -2187,7 +2187,7 @@ func test_the_interpolated_camera_origin_does_not_pan_a_step_early() -> void:
 	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(4.0, 2.0))
 
-	assert_true(world.advance_player_step_frame())
+	assert_true(world.advance_player_step_pass())
 	assert_eq(world.player_position_cells(), Vector2(7.875, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(3.875, 2.0))
 
@@ -2214,22 +2214,22 @@ func test_advance_player_step_spends_exactly_one_frame_per_call() -> void:
 	assert_true(world.move(Vector2i.LEFT))
 	assert_eq(world.player_cell, Vector2i(7, 6))
 
-	assert_true(world.advance_player_step_frame())
+	assert_true(world.advance_player_step_pass())
 	assert_eq(world.player_step_offset_cells(), Vector2(0.875, 0.0))
 
-	# STEP_FRAMES_WALK is 8, one of which is spent above.
+	# STEP_PASSES_WALK is 8, one of which is spent above.
 	for _frame: int in 4:
-		assert_true(world.advance_player_step_frame())
+		assert_true(world.advance_player_step_pass())
 	assert_eq(world.player_step_offset_cells(), Vector2(3.0 / 8.0, 0.0))
 	assert_eq(world.player_cell, Vector2i(7, 6))
 
 	for _frame: int in 3:
-		assert_true(world.advance_player_step_frame())
+		assert_true(world.advance_player_step_pass())
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(world.player_cell, Vector2i(7, 6))
 	assert_eq(world.player_walk_frame(), 0, "SetFacingStanding restores the resting cel")
-	assert_false(world.advance_player_step_frame())
+	assert_false(world.advance_player_step_pass())
 
 
 func test_player_step_does_not_affect_cell_collision_or_events() -> void:
@@ -2268,8 +2268,8 @@ func test_connection_transition_spends_a_step() -> void:
 	assert_eq(world.map_id(), Vector2i(1, 2))
 	assert_true(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2(-1, 0))
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_player_step_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_player_step_pass()
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 
@@ -2327,7 +2327,7 @@ func _advance_object_frames(
 	world: Gen2WorldAPI, frames: int, random: RandomNumberGenerator
 ) -> void:
 	for _frame: int in frames:
-		world.advance_object_steps_frame(random)
+		world.advance_object_steps_pass(random)
 
 
 ## Spends the frames the player's step still owes. Bounded rather than a while
@@ -2337,7 +2337,7 @@ func _finish_player_step(world: Gen2WorldAPI) -> void:
 	for _frame: int in 64:
 		if not world.player_step_in_progress():
 			return
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 
 
 func test_wander_object_commits_its_cell_and_eases_over_the_slow_step() -> void:
@@ -2348,10 +2348,10 @@ func test_wander_object_commits_its_cell_and_eases_over_the_slow_step() -> void:
 	var start: Vector2i = object.cell
 
 	# The first frame is the object's turn at the movement function.
-	assert_true(world.advance_object_steps_frame(random))
+	assert_true(world.advance_object_steps_pass(random))
 	assert_true(object.is_stepping())
 	# StepVectors' slow row is 16 frames, half the player's walking speed.
-	assert_eq(object.step_frames_total, Gen2WorldAPI.STEP_FRAMES_NPC_WALK)
+	assert_eq(object.step_passes_total, Gen2WorldAPI.STEP_PASSES_NPC_WALK)
 	# The cell commits when the step starts, exactly as InitStep and the
 	# player's own walk do; only the drawn offset trails behind it.
 	assert_ne(object.cell, start)
@@ -2360,7 +2360,7 @@ func test_wander_object_commits_its_cell_and_eases_over_the_slow_step() -> void:
 	# The deciding frame starts the step without spending one of its frames,
 	# the way the source runs the movement function and the step function on
 	# separate frames, so the full duration follows it.
-	_advance_object_frames(world, Gen2WorldAPI.STEP_FRAMES_NPC_WALK, random)
+	_advance_object_frames(world, Gen2WorldAPI.STEP_PASSES_NPC_WALK, random)
 	assert_false(object.is_stepping())
 	assert_eq(object.step_offset_cells(), Vector2.ZERO)
 	assert_eq(abs(object.cell.x - start.x) + abs(object.cell.y - start.y), 1)
@@ -2422,7 +2422,7 @@ func test_a_swim_wander_object_moves_across_its_pond_within_its_radius() -> void
 
 	var visited: Dictionary = {object.cell: true}
 	for _frame: int in 1024:
-		world.advance_object_steps_frame(random)
+		world.advance_object_steps_pass(random)
 		visited[object.cell] = true
 	assert_eq(
 		visited.keys().size(), 2,
@@ -2438,16 +2438,16 @@ func test_wander_object_waits_its_rolled_idle_before_deciding_again() -> void:
 	var random := RandomNumberGenerator.new()
 	random.seed = 4242
 
-	_advance_object_frames(world, 1 + Gen2WorldAPI.STEP_FRAMES_NPC_WALK, random)
+	_advance_object_frames(world, 1 + Gen2WorldAPI.STEP_PASSES_NPC_WALK, random)
 	assert_false(object.is_stepping())
 	# The step's final frame rolls the next wait, exactly as
 	# StepFunction_ContinueWalk jumps to RandomStepDuration_Slow. That mask is
 	# $7F, so the wait never exceeds 127 frames.
 	assert_true(object.is_idle())
-	assert_true(object.idle_frames_remaining <= Gen2WorldAPI.IDLE_MASK_SLOW)
+	assert_true(object.idle_passes_remaining <= Gen2WorldAPI.IDLE_MASK_SLOW)
 
 	var resting_cell: Vector2i = object.cell
-	var idle_frames: int = object.idle_frames_remaining
+	var idle_frames: int = object.idle_passes_remaining
 	_advance_object_frames(world, idle_frames, random)
 	assert_eq(object.cell, resting_cell)
 	assert_false(object.is_idle())
@@ -2462,7 +2462,7 @@ func test_blocked_wander_object_keeps_its_cell_and_waits() -> void:
 	random.seed = 77
 	var start: Vector2i = object.cell
 
-	assert_false(world.advance_object_steps_frame(random))
+	assert_false(world.advance_object_steps_pass(random))
 	assert_eq(object.cell, start)
 	assert_false(object.is_stepping())
 	# _RandomWalkContinue's .new_duration branch waits again rather than
@@ -2483,7 +2483,7 @@ func test_wander_object_never_leaves_its_source_radius() -> void:
 	var strayed: Vector2i = Vector2i.MAX
 	var visited: Dictionary = {}
 	for _frame: int in 2000:
-		world.advance_object_steps_frame(random)
+		world.advance_object_steps_pass(random)
 		visited[object.cell] = true
 		if abs(object.cell.x - origin.x) > 1 or abs(object.cell.y - origin.y) > 1:
 			strayed = object.cell
@@ -2511,7 +2511,7 @@ func test_spin_templates_turn_without_starting_a_step() -> void:
 		assert_false(object.is_stepping())
 		var mask: int = Gen2WorldAPI.IDLE_MASK_SLOW \
 			if movement == Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW else Gen2WorldAPI.IDLE_MASK_FAST
-		assert_true(object.idle_frames_remaining <= mask)
+		assert_true(object.idle_passes_remaining <= mask)
 
 
 func test_standing_objects_are_never_moved_by_the_driver() -> void:
@@ -2523,7 +2523,7 @@ func test_standing_objects_are_never_moved_by_the_driver() -> void:
 	var facing: int = object.facing
 
 	for _frame: int in 300:
-		assert_false(world.advance_object_steps_frame(random))
+		assert_false(world.advance_object_steps_pass(random))
 	assert_eq(object.cell, start)
 	assert_eq(object.facing, facing)
 
@@ -2538,12 +2538,12 @@ func test_object_driver_spends_exactly_one_frame_per_call() -> void:
 	random.seed = 90210
 
 	# The deciding frame starts the step without spending one of its frames.
-	assert_true(world.advance_object_steps_frame(random))
-	assert_eq(object.step_frames_remaining, Gen2WorldAPI.STEP_FRAMES_NPC_WALK)
+	assert_true(world.advance_object_steps_pass(random))
+	assert_eq(object.step_passes_remaining, Gen2WorldAPI.STEP_PASSES_NPC_WALK)
 	for _frame: int in 4:
-		assert_true(world.advance_object_steps_frame(random))
+		assert_true(world.advance_object_steps_pass(random))
 	assert_eq(
-		object.step_frames_remaining, Gen2WorldAPI.STEP_FRAMES_NPC_WALK - 4
+		object.step_passes_remaining, Gen2WorldAPI.STEP_PASSES_NPC_WALK - 4
 	)
 
 
@@ -2559,7 +2559,7 @@ func test_object_steps_do_not_survive_a_map_transition() -> void:
 	for _frame: int in 600:
 		if object.is_stepping():
 			break
-		world.advance_object_steps_frame(random)
+		world.advance_object_steps_pass(random)
 	assert_true(object.is_stepping())
 
 	var result: Dictionary = world.try_warp()
@@ -2597,7 +2597,7 @@ func test_object_driver_ignores_a_missing_generator() -> void:
 	var world: Gen2WorldAPI = _wandering_world()
 	var object: Gen2WorldObject = world.objects[0]
 	var start: Vector2i = object.cell
-	assert_false(world.advance_object_steps_frame(null))
+	assert_false(world.advance_object_steps_pass(null))
 	assert_eq(object.cell, start)
 	assert_false(object.is_stepping())
 
@@ -2629,7 +2629,7 @@ func test_follower_carries_the_player_walk_step_offset() -> void:
 	assert_eq(follower.cell, Vector2i(6, 6))
 	# A follower keeps the player's pace, not the slower wandering one.
 	assert_true(follower.is_stepping())
-	assert_eq(follower.step_frames_total, Gen2WorldAPI.STEP_FRAMES_WALK)
+	assert_eq(follower.step_passes_total, Gen2WorldAPI.STEP_PASSES_WALK)
 	# The follower moved right, into the cell the player left, so it is drawn
 	# one cell to the left of its committed cell as the step begins.
 	assert_eq(follower.step_offset_cells(), Vector2(-1.0, 0.0))
@@ -2978,11 +2978,11 @@ func test_a_step_into_grass_takes_one_rustle_per_step() -> void:
 	assert_eq(rustles.size(), 1)
 	assert_eq(rustles[0]["object_index"], -1, "the player is index -1")
 	assert_eq(rustles[0]["cell"], Vector2i(5, 10))
-	assert_eq(rustles[0]["frames"], Gen2WorldAPI.STEP_FRAMES_WALK - 1)
+	assert_eq(rustles[0]["frames"], Gen2WorldAPI.STEP_PASSES_WALK - 1)
 	assert_true(world.take_grass_rustles().is_empty(), "the flag is taken once")
 
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_player_step_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_player_step_pass()
 	assert_true(bool(world.move_result(Vector2i.UP).get("ok", false)))
 	assert_true(world.take_grass_rustles().is_empty(), "the cell left behind is not grass")
 
@@ -3925,7 +3925,7 @@ func test_a_press_in_a_new_direction_turns_on_the_spot_before_it_walks() -> void
 	assert_eq(world.player_walk_frame(), 0, "StepFunction_Turn stays standing")
 
 	while world.player_step_in_progress():
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 	assert_eq(world.player_walk_frame(), 0, "the completed turn stays standing")
 	var walk: Dictionary = world.player_input_move(Vector2i.RIGHT)
 	assert_true(walk["ok"])
@@ -4065,8 +4065,8 @@ func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> v
 	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
 	# One cell of trail, at turn_in's own STEP_WALK duration.
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 1.0))
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_player_step_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_player_step_pass()
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(_final_status(_run_script(world, dispatched)), &"complete")
 
@@ -4090,8 +4090,8 @@ func test_a_scripted_jump_step_covers_two_cells_and_arcs_over_them() -> void:
 	assert_eq(object.cell, start + Vector2i(2, 0), "two cells, committed at once")
 
 	var highest: float = 0.0
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK * 2:
-		assert_true(world.advance_scripted_steps_frame())
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK * 2:
+		assert_true(world.advance_scripted_steps_pass())
 		highest = maxf(highest, object.height_offset_pixels())
 	assert_eq(highest, 12.0, "the top of .y_offsets")
 	assert_eq(object.step_offset_cells(), Vector2.ZERO, "and the whole hop is drawn")
@@ -4115,16 +4115,16 @@ func test_script_movement_leaves_a_trail_the_renderer_walks_a_step_at_a_time() -
 	assert_eq(object.cell, start + Vector2i(2, 0), "both cells commit at once")
 	assert_eq(object.step_offset_cells(), Vector2(-2.0, 0.0), "and the drawing is behind both")
 
-	# Each of the two cells costs STEP_FRAMES_WALK frames.
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		assert_true(world.advance_scripted_steps_frame())
+	# Each of the two cells costs STEP_PASSES_WALK frames.
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		assert_true(world.advance_scripted_steps_pass())
 	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0), "one step drawn, one to go")
 	assert_eq(object.cell, start + Vector2i(2, 0), "and no cell moved with it")
 
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_scripted_steps_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_scripted_steps_pass()
 	assert_eq(object.step_offset_cells(), Vector2.ZERO)
-	assert_false(world.advance_scripted_steps_frame())
+	assert_false(world.advance_scripted_steps_pass())
 
 
 ## `NormalStep` writes OBJECT_FACING where it starts each step, so a stream whose
@@ -4147,14 +4147,14 @@ func test_a_turning_stream_is_drawn_facing_each_leg_in_turn() -> void:
 	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
 
 	assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN, "the first leg")
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_scripted_steps_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_scripted_steps_pass()
 	assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN, "still the second")
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_scripted_steps_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_scripted_steps_pass()
 	assert_eq(object.facing, Gen2WorldSprite.FACING_RIGHT, "and the last one turns")
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_scripted_steps_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_scripted_steps_pass()
 	assert_eq(object.step_offset_cells(), Vector2.ZERO)
 
 
@@ -4184,7 +4184,7 @@ func test_applymovement_holds_the_script_until_the_trail_has_been_drawn() -> voi
 	assert_true(world.pending_runtime_request().is_empty(), "no host answers a wait")
 
 	# Two `step` commands, so the wait outlasts the first one's frames.
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
 		assert_true(
 			world.advance_script_presentation_frame().is_empty()
 		)
@@ -4305,7 +4305,7 @@ func _types_of(result: Dictionary) -> Array[StringName]:
 	return types
 
 
-## The two drivers own different objects. advance_object_steps_frame() decides
+## The two drivers own different objects. advance_object_steps_pass() decides
 ## movement and a screen stops calling it while a script runs, which is exactly
 ## when a scripted trail has to keep being drawn, so draining it there as well
 ## would walk it at twice the speed.
@@ -4325,14 +4325,14 @@ func test_the_movement_driver_leaves_a_scripted_trail_to_its_own_driver() -> voi
 
 	var random := RandomNumberGenerator.new()
 	random.seed = 7
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_object_steps_frame(random)
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_object_steps_pass(random)
 	assert_eq(object.step_offset_cells(), Vector2(-1.0, 0.0), "untouched by the other driver")
 
 	@warning_ignore("integer_division")
-	var half: int = Gen2WorldAPI.STEP_FRAMES_WALK / 2
+	var half: int = Gen2WorldAPI.STEP_PASSES_WALK / 2
 	for _frame: int in half:
-		assert_true(world.advance_scripted_steps_frame())
+		assert_true(world.advance_scripted_steps_pass())
 	assert_eq(object.step_offset_cells(), Vector2(-0.5, 0.0))
 
 
@@ -4355,14 +4355,14 @@ func test_a_scripted_player_stream_trails_and_advances_the_walk_frame() -> void:
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 2.0))
 	assert_eq(world.player_walk_frame(), 0)
 
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		assert_true(world.advance_player_step_frame())
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		assert_true(world.advance_player_step_pass())
 	assert_eq(world.player_step_offset_cells(), Vector2(0.0, 1.0), "one step drawn")
 	# Eight frames in, the counter is on its third drawing: stand, walk, stand.
 	assert_eq(world.player_walk_frame(), 2)
 
-	for _frame: int in Gen2WorldAPI.STEP_FRAMES_WALK:
-		world.advance_player_step_frame()
+	for _frame: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		world.advance_player_step_pass()
 	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
 	assert_eq(world.player_cell, Vector2i(7, 4))
 	assert_eq(world.player_walk_frame(), 0, "EndSpriteMovement leaves the player standing")
@@ -5217,7 +5217,7 @@ func test_trainer_approach_crosses_water_a_wandering_object_could_not() -> void:
 	assert_eq(trainer.cell, Vector2i(8, 7))
 	# TrainerWalkToPlayer passes 1 to ComputePathToWalkToPlayer, which selects
 	# `step` rather than `slow_step`: StepVectors' normal row, 8 frames.
-	assert_eq(trainer.step_frames_total, Gen2WorldAPI.STEP_FRAMES_WALK)
+	assert_eq(trainer.step_passes_total, Gen2WorldAPI.STEP_PASSES_WALK)
 	assert_true(world.advance_trainer_approach_step(0, Vector2i.UP)["ok"])
 	assert_eq(trainer.cell, Vector2i(8, 6))
 

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -10,11 +10,11 @@ func test_source_packed_screen_shake_uses_duration_and_amplitude_bits() -> void:
 	assert_eq(started["offset"], Vector2(-2, 0))
 
 	for _frame: int in 19:
-		assert_true(effects.advance_frame())
+		assert_true(effects.advance_pass())
 	assert_true(effects.active())
-	assert_true(effects.advance_frame())
+	assert_true(effects.advance_pass())
 	assert_false(effects.active())
-	assert_false(effects.advance_frame(), "a spent effect costs no more frames")
+	assert_false(effects.advance_pass(), "a spent effect costs no more frames")
 	assert_eq(effects.offset(), Vector2.ZERO)
 
 
@@ -55,13 +55,13 @@ func test_a_grass_rustle_swaps_its_two_facings_every_four_frames() -> void:
 	assert_eq((first[0] as Dictionary)["offset"], Vector2i(0, 8))
 	assert_true(bool((first[1] as Dictionary)["flip_x"]), "FacingGrass1 mirrors its right tile")
 	for _frame: int in 4:
-		effects.advance_frame()
+		effects.advance_pass()
 	assert_eq(
 		((effects.sprites()[0] as Dictionary)["tiles"][0] as Dictionary)["offset"],
 		Vector2i(-1, 9),
 	)
 	for _frame: int in 3:
-		effects.advance_frame()
+		effects.advance_pass()
 	assert_false(effects.sprites_active(), "a rustle is one frame shorter than its step")
 
 
@@ -73,15 +73,15 @@ func test_boulder_dust_takes_its_offset_from_the_push_direction() -> void:
 	assert_eq((sprite["tiles"][0] as Dictionary)["offset"], Vector2i(6, 2))
 	assert_eq(sprite["tiles"].size(), 4, "one tile drawn four times in a 16x16 square")
 	## `SetFacingBoulderDust` swaps the two tiles on bit 1 of the frame counter.
-	effects.advance_frame()
+	effects.advance_pass()
 	assert_eq(int((effects.sprites()[0] as Dictionary)["tiles"][0]["tile"]), 0)
-	effects.advance_frame()
+	effects.advance_pass()
 	assert_eq(int((effects.sprites()[0] as Dictionary)["tiles"][0]["tile"]), 1)
 	## (step duration + 1) * 2 frames, so the dust outlives the push.
 	for _frame: int in 31:
-		effects.advance_frame()
+		effects.advance_pass()
 	assert_true(effects.sprites_active())
-	effects.advance_frame()
+	effects.advance_pass()
 	assert_false(effects.sprites_active())
 
 
@@ -137,16 +137,16 @@ func test_cut_leaves_spawn_four_deep_and_spiral() -> void:
 ## for twice the half-hop it was spawned in.
 func test_a_jump_shadow_is_two_mirrored_tiles_under_the_jumper() -> void:
 	var effects := Gen2WorldEffects.new()
-	effects.start_jump_shadow(-1, Vector2i(4, 4), Vector2i.DOWN, Gen2WorldAPI.STEP_FRAMES_HOP)
+	effects.start_jump_shadow(-1, Vector2i(4, 4), Vector2i.DOWN, Gen2WorldAPI.STEP_PASSES_HOP)
 	var sprite: Dictionary = effects.sprites()[0]
 	assert_eq(sprite["kind"], Gen2WorldEffects.SPRITE_SHADOW)
 	assert_eq(sprite["tiles"].size(), 2)
 	assert_eq((sprite["tiles"][0] as Dictionary)["offset"], Vector2i(0, 14))
 	assert_true(bool((sprite["tiles"][1] as Dictionary)["flip_x"]))
 	for _frame: int in 17:
-		effects.advance_frame()
+		effects.advance_pass()
 	assert_true(effects.sprites_active(), "(8 + 1) * 2 frames, so it outlasts the hop")
-	effects.advance_frame()
+	effects.advance_pass()
 	assert_false(effects.sprites_active())
 
 

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1557,7 +1557,7 @@ func test_a_step_on_the_bike_spends_half_the_frames() -> void:
 func _drain_player_step(world: Gen2WorldAPI) -> int:
 	var frames: int = 0
 	while world.player_step_in_progress():
-		world.advance_player_step_frame()
+		world.advance_player_step_pass()
 		frames += 1
 	return frames
 

--- a/tools/checks/cerulean.gd
+++ b/tools/checks/cerulean.gd
@@ -392,9 +392,9 @@ func _verify_swimmer_approach(data: GameData, game_id: StringName, swimmer: Arra
 		):
 			return
 		_r.check(
-			swimmer_object.step_frames_total == Gen2WorldAPI.STEP_FRAMES_WALK,
+			swimmer_object.step_passes_total == Gen2WorldAPI.STEP_PASSES_WALK,
 			"%s: swimmer %d steps over %d frames, not %d." % [
-				game_id, index, swimmer_object.step_frames_total, Gen2WorldAPI.STEP_FRAMES_WALK,
+				game_id, index, swimmer_object.step_passes_total, Gen2WorldAPI.STEP_PASSES_WALK,
 			]
 		)
 	_r.check(

--- a/tools/checks/surf.gd
+++ b/tools/checks/surf.gd
@@ -327,7 +327,7 @@ func _verify_swimming_objects(game_id: StringName, data: GameData, crystal: bool
 	random.seed = 17
 	var visited: Dictionary = {lapras.cell: true}
 	for _frame: int in LAPRAS_STEP_FRAME_BUDGET:
-		world.advance_object_steps_frame(random)
+		world.advance_object_steps_pass(random)
 		visited[lapras.cell] = true
 	var reached: Array = visited.keys()
 	var expected: Array = allowed.keys()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -367,7 +367,9 @@ func _process(_delta: float) -> bool:
 				):
 					## player_cell commits when the step starts, so the frames
 					## the player is still walking are spent before the picture.
-					_screen.advance_frames(Gen2WorldAPI.STEP_FRAMES_WALK)
+					_screen.advance_frames(
+						Gen2WorldAPI.passes_in_frames(Gen2WorldAPI.STEP_PASSES_WALK)
+					)
 					break
 		elif _kind == &"ledge":
 			## `StepFunction_PlayerJump` at the top of its arc: the player is
@@ -388,8 +390,8 @@ func _process(_delta: float) -> bool:
 			for _frame: int in WARP_FRAME_CAP:
 				_screen.move_left()
 				_screen.advance_frame()
-				if _screen.map_name_sign_frames() > 0 \
-					and _screen.map_name_sign_frames() < Gen2WorldAPI.MAP_NAME_SIGN_FRAMES:
+				if _screen.map_name_sign_passes() > 0 \
+					and _screen.map_name_sign_passes() < Gen2WorldAPI.MAP_NAME_SIGN_PASSES:
 					break
 		elif _kind == &"pokepic":
 			_screen.preview_pokepic(POKEPIC_SPECIES)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -169,7 +169,7 @@ const BLACKTHORN_GYM_PUSHES: Array = [
 const DRAGON_SHRINE_ANSWERS: Array[int] = [0, 0, 1, 0, 1]
 
 ## How many hardware frames one pushed boulder may spend sliding before the walk
-## calls it stuck. The slide is STEP_FRAMES_BOULDER_PUSH, well inside this.
+## calls it stuck. The slide is STEP_PASSES_BOULDER_PUSH, well inside this.
 const OBJECT_STEP_FRAME_BUDGET: int = 64
 
 ## Route 44's Ice Path door and then every warp cell the cave is crossed by, in
@@ -8260,7 +8260,7 @@ func _push_boulder_run(
 
 
 ## Spends hardware frames until no object is mid-step. A pushed boulder slides
-## for STEP_FRAMES_BOULDER_PUSH frames and refuses a second push until it stands
+## for STEP_PASSES_BOULDER_PUSH frames and refuses a second push until it stands
 ## again, so this has to spend the frames rather than ask for them at once.
 func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) -> void:
 	for _frame: int in OBJECT_STEP_FRAME_BUDGET:
@@ -8271,7 +8271,7 @@ func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) ->
 				break
 		if not stepping:
 			return
-		world.advance_object_steps_frame(random)
+		world.advance_object_steps_pass(random)
 
 
 ## Mahogany Town east to Blackthorn City, on the same world, state and save.

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -422,10 +422,13 @@ func _drive(screen: Gen2WorldScreen, frames: int) -> int:
 		else:
 			in_battle = false
 			## Two cells, alternating, so every step lands on grass and the roll
-			## keeps being offered. A step is STEP_FRAMES_WALK long, and a
-			## direction held across it is one step.
+			## keeps being offered. A step is STEP_PASSES_WALK passes long and
+			## this loop spends hardware frames, so the direction is held for
+			## `passes_in_frames` of them: half that flips it mid-step and the
+			## player turns back before landing on anything.
 			@warning_ignore("integer_division")
-			var step: int = screen._world.frame_number / Gen2WorldAPI.STEP_FRAMES_WALK
+			var step: int = screen._world.frame_number \
+				/ Gen2WorldAPI.passes_in_frames(Gen2WorldAPI.STEP_PASSES_WALK)
 			screen.press_button(
 				Gen2Button.DOWN if step % 2 == 0 else Gen2Button.UP
 			)
@@ -457,6 +460,12 @@ func _program(seed_value: int, frames: int, errand: bool = false) -> Array:
 	return log
 
 
+## One walk step in the hardware frames this tool spends, which is the pass
+## duration doubled (Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS).
+func _walk_frames() -> int:
+	return Gen2WorldAPI.passes_in_frames(Gen2WorldAPI.STEP_PASSES_WALK)
+
+
 ## The scripted errand: walk the door column up to the counter, turn into the
 ## clerk, and then press A on a cadence for the rest of the run. That one button
 ## carries the whole leg, because every step of it answers a press: the clerk's
@@ -468,19 +477,19 @@ func _program(seed_value: int, frames: int, errand: bool = false) -> Array:
 ## move on.
 func _errand_program(frames: int) -> Array:
 	var log: Array = []
-	var walk: int = mini(frames, (MART_DOOR.y - MART_COUNTER.y) * Gen2WorldAPI.STEP_FRAMES_WALK)
+	var walk: int = mini(frames, (MART_DOOR.y - MART_COUNTER.y) * _walk_frames())
 	for frame: int in range(1, walk + 1):
 		log.append({"frame": frame, "kind": "hold", "button": Gen2Button.UP})
 	## Clear of the walk rather than up against it: `move_player` refuses a press
 	## while the last step is still in flight, and a turn that is refused leaves
 	## the player facing the wall behind the counter instead of the clerk.
-	if walk + Gen2WorldAPI.STEP_FRAMES_WALK * 3 <= frames:
+	if walk + _walk_frames() * 3 <= frames:
 		log.append({
-			"frame": walk + Gen2WorldAPI.STEP_FRAMES_WALK * 3,
+			"frame": walk + _walk_frames() * 3,
 			"kind": "press",
 			"button": Gen2Button.LEFT,
 		})
-	var frame: int = walk + Gen2WorldAPI.STEP_FRAMES_WALK * 5
+	var frame: int = walk + _walk_frames() * 5
 	while frame <= frames:
 		log.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
 		frame += 8


### PR DESCRIPTION
`HandleMap` ends each iteration in `NextOverworldFrame`, and `MaxOverworldDelay`
is 2. So the whole map layer runs once per two hardware frames: the objects, the
map events, the background and the joypad read. Every duration in the overworld
is counted in those passes, not in screen frames.

This port spent one of each on every frame. The overworld ran at twice the
cartridge's speed. A walk step cost eight frames instead of sixteen, a turn four
instead of eight, an NPC's wander half its wait, and the map name sign one
second instead of two.

`Gen2WorldScreen.advance_frame` now reloads and spends `wOverworldDelay` where
the source does. The unit is in the names: `STEP_PASSES_*`,
`MAP_NAME_SIGN_PASSES`, `step_passes_*`, `idle_passes_remaining`, and the API's
`advance_*_pass` drivers. `Gen2WorldAPI.passes_in_frames()` is the one
conversion for a tool that spends hardware frames against a source duration.
Three drivers were doing that multiplication by hand, and each of them flipped a
held direction mid-step.

The other half of the frame keeps the screen's rate. A routine that spins on its
own `DelayFrame` is not the pass: a text box, both map fades, the battle
transition, `OWCutAnimation`, `ShakeHeadbuttTree`, `HealMachineAnim`, an emote's
countdown, and VBlank's `GameTimer` and `AnimateTileset`. `Gen2WorldEffects`
holds both kinds and is split down `PASS_PACED_SPRITES`. The trainer approach
takes the flag for the same reason: its emote delay is the script's, its walk is
the objects'.

Measured against a real Crystal dump on Route 29:

| Measure | Cartridge | Before | After |
|---|---|---|---|
| `HandleMapObjects` calls | every other frame | every frame | every other frame |
| A walk step | 16 frames | 8 | 16 |
| `wPlayerSpriteX` per step | 2 px a pass, 208 to 224 | 2 px a frame | 2 px a pass |
| A turn on the spot | 8 frames | 4 | 8 |
| `wLandmarkSignTimer` | 60 passes | 60 frames | 60 passes |

Green: 3,404 GUT tests over 153 scripts, all 60 check topics, 33 replay routes,
and the story walk to 16 badges on all three cartridges.