### PR TITLE
Build the Day-Care and the breeding behind it

### DIFF
--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -34,8 +34,8 @@ Save format version 6 stores:
   rather than removing it; the writeback puts it back in the same slot. Its
   `happiness` byte is its hatch counter, which is what `GiveEgg` writes and what
   `DoEggStep` drains: the walk takes one cycle off every egg in the party every
-  256 steps, and the first to reach zero hatches where it stands. Breeding and
-  the Day-Care do not exist, so the only egg the game hands out is a script's.
+  256 steps, and the first to reach zero hatches where it stands. A script's
+  `giveegg` and the Day-Care both hand one out.
 
 Derived battle stats are recalculated on load. Volatile state, including stages,
 confusion, recharge, Disable, Encore, trapping, Fly, Dig, Rollout and rampage,

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -79,6 +79,7 @@ var _menu_text: Dictionary = {}
 var _mart_text: Dictionary = {}
 var _name_rater_text: Dictionary = {}
 var _move_deleter_text: Dictionary = {}
+var _day_care_text: Dictionary = {}
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 var _world_maps: Array = []
@@ -193,6 +194,8 @@ static func open_directory(path: String) -> GameData:
 	data._name_rater_text = raw_name_rater_text if raw_name_rater_text is Dictionary else {}
 	var raw_move_deleter_text: Variant = manifest.get("move_deleter_text", {})
 	data._move_deleter_text = raw_move_deleter_text if raw_move_deleter_text is Dictionary else {}
+	var raw_day_care_text: Variant = manifest.get("day_care_text", {})
+	data._day_care_text = raw_day_care_text if raw_day_care_text is Dictionary else {}
 	data._species = data._read_array(RomCache.species_path(path))
 	data._moves = data._read_array(RomCache.moves_path(path))
 	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
@@ -1041,9 +1044,9 @@ func evolutions(number: int) -> Array:
 ## species that named none.
 ##
 ## Move numbers alone: an egg move has no level, unlike a [method learnset] row.
-## Which of them a hatched Pokémon actually knows is the breeding rule, not this
-## table, and no breeding exists here yet; the data is what a mod, a dex screen or
-## a randomizer asks for.
+## Which of them a hatched Pokémon actually knows is the breeding rule rather
+## than this table: [method Gen2WorldDayCare.inherits_move] is that rule, and this
+## is one of the three ways in it reads.
 func egg_moves(number: int) -> Array[int]:
 	var out: Array[int] = []
 	for move_id: Variant in species(number).get("egg_moves", []):
@@ -1500,6 +1503,14 @@ func name_rater_text(name: String) -> String:
 ## them.
 func move_deleter_text(name: String) -> String:
 	return String(_move_deleter_text.get(name, ""))
+
+
+## One of the Day-Care's own boxes, by the name
+## `RomLayout.DAY_CARE_TEXT_RUNS` gives its stub, still carrying
+## [Gen2TextStream]'s markers for the nickname and money it prints. Empty on a
+## cache imported before them.
+func day_care_text(name: String) -> String:
+	return String(_day_care_text.get(name, ""))
 
 
 ## `.MenuDesc`'s line for one start-menu item, by the item's own kind. Empty for

--- a/game/data/learnset.gd
+++ b/game/data/learnset.gd
@@ -33,19 +33,42 @@ const MOVE_SLOTS: int = 4
 ## slots pushes the oldest out, so the answer is the last four learnable moves.
 static func moves_at_level(learnset: Array, level: int) -> Array:
 	var out: Array = []
-
-	for entry: Dictionary in learnset:
-		if int(entry["level"]) > level:
-			break
-
-		var move: int = int(entry["move"])
-		if out.has(move):
-			continue
-		if out.size() == MOVE_SLOTS:
-			out.remove_at(0)
-		out.append(move)
-
+	fill_moves(learnset, out, level)
 	return out
+
+
+## `FillMoves` itself, which is what [method moves_at_level] is one call of.
+##
+## [param known] is filled in place and may already hold moves: a slot is taken
+## when one is empty, and the four are shifted down when none is. [param above]
+## is `wPrevPartyLevel`, and passing anything above zero is the
+## `wSkipMovesBeforeLevelUp` branch, which offers only the levels *between* the
+## two. `known` grows to at most [constant MOVE_SLOTS] entries and is padded with
+## zeroes only if it arrived that way, so a party row's four-slot array stays
+## four slots.
+static func fill_moves(
+	learnset: Array, known: Array, level: int, above: int = 0
+) -> void:
+	var padded: bool = known.size() == MOVE_SLOTS
+	for entry: Dictionary in learnset:
+		var at: int = int(entry["level"])
+		if at > level:
+			break
+		if above > 0 and at <= above:
+			continue
+		var move: int = int(entry["move"])
+		if known.has(move):
+			continue
+		var slot: int = known.find(0) if padded else -1
+		if slot >= 0:
+			known[slot] = move
+			continue
+		if known.size() == MOVE_SLOTS:
+			for index: int in MOVE_SLOTS - 1:
+				known[index] = known[index + 1]
+			known[MOVE_SLOTS - 1] = move
+			continue
+		known.append(move)
 
 
 ## The moves offered on reaching exactly [param level], in the order the list

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -80,7 +80,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 77
+const FORMAT_VERSION: int = 78
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -362,6 +362,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not move_deleter_text["ok"]:
 		return move_deleter_text
 
+	var day_care_text: Dictionary = verify_day_care_text(rom, layout)
+	if not day_care_text["ok"]:
+		return day_care_text
+
 	var map_entry_sign: Dictionary = verify_map_entry_sign(rom, layout)
 	if not map_entry_sign["ok"]:
 		return map_entry_sign
@@ -1167,6 +1171,37 @@ static func verify_move_deleter_text(rom: RomFile, layout: Dictionary) -> Dictio
 			"message": "The move deleter's intro is \"%s\", not his own." % intro,
 		}
 	return {"ok": true, "message": "The move deleter's texts verified."}
+
+
+## The Day-Care's thirty-two `text_far` stubs across its four runs, identified
+## by content the same way: every stub has to decode and the man's opening line
+## has to be his own, which is what says the four pins are the four runs.
+static func verify_day_care_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	for name: String in day_care_text_names():
+		if read_oak_text(
+			rom, layout, RomLayout.day_care_text_offset(layout, name)
+		).is_empty():
+			return {
+				"ok": false, "message": "The Day-Care's %s text did not decode." % name,
+			}
+	var intro: String = read_oak_text(
+		rom, layout, RomLayout.day_care_text_offset(layout, "man_intro")
+	)
+	if not intro.begins_with("I'm the DAY-CARE"):
+		return {
+			"ok": false,
+			"message": "The Day-Care man's intro is \"%s\", not his own." % intro,
+		}
+	return {"ok": true, "message": "The Day-Care's texts verified."}
+
+
+## Every stub name across the four runs, in run order.
+static func day_care_text_names() -> Array[String]:
+	var out: Array[String] = []
+	for run: Array in RomLayout.DAY_CARE_TEXT_RUNS:
+		for name: Variant in run[1] as Array:
+			out.append(String(name))
+	return out
 
 
 ## `UnownWords`, twenty-six words in form order, A first. Empty on any failure,
@@ -4012,6 +4047,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"mart_text": _import_mart_text(rom, layout),
 		"name_rater_text": _import_name_rater_text(rom, layout),
 		"move_deleter_text": _import_move_deleter_text(rom, layout),
+		"day_care_text": _import_day_care_text(rom, layout),
 		"copyright_string": _import_copyright_string(rom, layout),
 		"copyright_palette": _import_copyright_palette(rom, layout),
 		"presents_palettes": _import_presents_palettes(rom, layout),
@@ -4798,6 +4834,17 @@ func _import_name_rater_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for name: String in RomLayout.NAME_RATER_TEXT_ORDER:
 		out[name] = read_oak_text(
 			rom, layout, RomLayout.name_rater_text_offset(layout, name)
+		)
+	return out
+
+
+## The Day-Care's own boxes, by the name
+## `RomImporter.day_care_text_names` gives each stub.
+func _import_day_care_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in day_care_text_names():
+		out[name] = read_oak_text(
+			rom, layout, RomLayout.day_care_text_offset(layout, name)
 		)
 	return out
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -160,10 +160,9 @@ const ICON_POINTER_SIZE: int = 2
 const ICON_EGG: int = 28
 
 ## `HeldItemIcons` is `gfx/stats/mail.2bpp` and `gfx/stats/item.2bpp`, the two
-## tiles `GetIconGFX` loads behind every icon's eight. The mail one is drawn by
-## no party menu here: nothing imports `data/items/mail_items.asm`, so
-## `ItemIsMail` is never true and `SPRITE_ANIM_FRAMESET_PARTY_MON_WITH_MAIL` is
-## unreachable.
+## tiles `GetIconGFX` loads behind every icon's eight. `ItemIsMail` is
+## [method Gen2HeldItem.is_mail]; the mail icon is still drawn by no party menu
+## here, and `SPRITE_ANIM_FRAMESET_PARTY_MON_WITH_MAIL` is unreachable.
 const HELD_ITEM_ICON_TILES: int = 2
 const HELD_ITEM_ICON_MAIL: int = 0
 const HELD_ITEM_ICON_ITEM: int = 1
@@ -1286,6 +1285,40 @@ const MOVE_DELETER_TEXT_ORDER: Array[String] = [
 	"intro", "which_mon",
 ]
 
+## The Day-Care's four stub runs. `PrintDayCareText.TextTable` is a pointer
+## table, but its twenty stubs are laid out in the file's own order behind it, so
+## one pin walks them the way the two runs above are walked; the order below is
+## that file order and not the table's. `.NotYetText` sits alone inside
+## `DayCareManOutside` and needs a pin of its own. All four runs are byte
+## identical on all three cartridges.
+const DAY_CARE_TEXT_ORDER: Array[String] = [
+	"man_intro", "man_intro_egg", "lady_intro", "lady_intro_egg", "which_one",
+	"only_one_mon", "cant_accept_egg", "remove_mail", "last_healthy_mon",
+	"ill_raise", "come_back_later", "are_we_geniuses", "has_grown",
+	"perfect_heres_your_mon", "got_back", "back_already", "have_no_room",
+	"not_enough_money", "oh_fine_then", "come_again",
+]
+## `DayCareManOutside`'s own five, after `.AskGiveEgg`.
+const DAY_CARE_EGG_TEXT_ORDER: Array[String] = [
+	"found_an_egg", "received_egg", "take_good_care", "ill_keep_it",
+	"no_room_for_egg",
+]
+## `engine/pokemon/breeding.asm`'s two, the lady's ahead of the man's.
+const DAY_CARE_LEFT_WITH_TEXT_ORDER: Array[String] = ["left_with_lady", "left_with_man"]
+## `DayCareMonCompatibilityText`'s five, in the order the routine tests them.
+const DAY_CARE_COMPATIBILITY_TEXT_ORDER: Array[String] = [
+	"brimming_with_energy", "no_interest", "appears_to_care", "friendly",
+	"shows_interest",
+]
+## Which pin each name is walked from, and at what index into it.
+const DAY_CARE_TEXT_RUNS: Array = [
+	["day_care_text", DAY_CARE_TEXT_ORDER],
+	["day_care_not_yet_text", ["not_yet"]],
+	["day_care_egg_text", DAY_CARE_EGG_TEXT_ORDER],
+	["day_care_left_with_text", DAY_CARE_LEFT_WITH_TEXT_ORDER],
+	["day_care_compatibility_text", DAY_CARE_COMPATIBILITY_TEXT_ORDER],
+]
+
 ## `Landmarks` (data/maps/landmarks.asm): `db x + 8, y + 16` then a name pointer,
 ## so the stored bytes are already shadow-OAM coordinates and the raw x,y are
 ## screen pixels. Gold and Silver ship no `BATTLE TOWER`, so every landmark from
@@ -2073,6 +2106,15 @@ const GOLD_SILVER: Dictionary = {
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
 	"mart_text": 0x16063,
+	## The Day-Care's four stub runs, each located by the text its first stub
+	## points at rather than by a symbol: `PrintDayCareText.TextTable`'s twenty
+	## behind `_DayCareManIntroText`, `.NotYetText` alone, `DayCareManOutside`'s
+	## five and `engine/pokemon/breeding.asm`'s two plus five.
+	"day_care_text": 0x16B28,
+	"day_care_not_yet_text": 0x16B9A,
+	"day_care_egg_text": 0x16BE9,
+	"day_care_left_with_text": 0x177E6,
+	"day_care_compatibility_text": 0x17820,
 	## `NameRaterHelloText`, bank $3e:$7919 in both dumps.
 	"name_rater_text": 0xFB919,
 	## `MoveDeletion.MoveKnowsOneText`, bank $0b:$43dc in both dumps.
@@ -2509,6 +2551,13 @@ const CRYSTAL: Dictionary = {
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,
 	"mart_text": 0x15E0E,
+	## The Day-Care's four stub runs; see the Gold and Silver block for how each
+	## is located.
+	"day_care_text": 0x168D2,
+	"day_care_not_yet_text": 0x16944,
+	"day_care_egg_text": 0x16993,
+	"day_care_left_with_text": 0x17462,
+	"day_care_compatibility_text": 0x1749C,
 	## `NameRaterHelloText`, bank $3e:$780f.
 	"name_rater_text": 0xFB80F,
 	## `MoveDeletion.MoveKnowsOneText`, bank $0b:$45d1.
@@ -3071,6 +3120,18 @@ static func name_rater_text_offset(layout: Dictionary, name: String) -> int:
 	if at < 0 or index < 0:
 		return -1
 	return at + index * TEXT_FAR_STUB_BYTES
+
+
+## Where the Day-Care's `text_far` stub [param name] names sits, whichever of
+## its four runs holds it.
+static func day_care_text_offset(layout: Dictionary, name: String) -> int:
+	for run: Array in DAY_CARE_TEXT_RUNS:
+		var index: int = (run[1] as Array).find(name)
+		if index < 0:
+			continue
+		var at: int = int(layout.get(run[0], -1))
+		return -1 if at < 0 else at + index * TEXT_FAR_STUB_BYTES
+	return -1
 
 
 ## Where the mart's `text_far` stub [param name] names sits.

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -198,6 +198,16 @@ func show_text(text: String, blink_cursor: bool = true) -> void:
 	_start_page()
 
 
+## `WaitPressAorB_BlinkCursor` reached with a box already standing, which is what
+## `DayCareMonCursor` and `PromptButton` are: the arrow appears on a text that
+## ended in `done` because the caller waited rather than because the text did.
+func set_blink_cursor(blink: bool) -> void:
+	if _blink_cursor == blink:
+		return
+	_blink_cursor = blink
+	_redraw()
+
+
 ## How many hardware frames the box still owes before it reaches its
 ## `PromptButton`: the rest of the page, or the rest of a `TextScroll`. Zero
 ## while it is waiting on a press, which is what it is waiting on there.

--- a/game/world/day_care_screen.gd
+++ b/game/world/day_care_screen.gd
@@ -1,0 +1,543 @@
+class_name Gen2DayCareScreen
+extends Control
+
+## `DayCareMan`, `DayCareLady`, `DayCareManOutside`, `DayCareMon1` and
+## `DayCareMon2` on the overworld's own pump.
+##
+## All five are straight lines of boxes, questions, a party list and two sounds,
+## so they are one screen with a queue rather than five: [Gen2WorldDayCare]
+## answers every question that needs a source reading and this owns the presses.
+##
+## Which of the five is running decides how it ends. The two counters and the man
+## outside are called from a script that follows them with `waitbutton`, so their
+## last box is handed to the caller through [signal finished] and stands in the
+## world's speech box for that one press; the two signs are called with no
+## `waitbutton` at all, because `DayCareMonCursor` and the compatibility text's
+## own `prompt` are the press.
+
+## [param script_value] is -1 for the four routines that write no wScriptVar.
+signal finished(script_value: int, ending_text: String)
+signal closed()
+signal cry_requested(species: int)
+signal sfx_requested(sfx: int)
+
+const TILE: int = Gen2Font.TILE
+
+const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
+
+## `SFX_GET_EGG`, the one sound `DayCareManOutside` plays, and the 120 frames of
+## `ld c, 120 / call DelayFrames` behind it.
+const SFX_GET_EGG: int = 0xAC
+const EGG_SOUND_FRAMES: int = 120
+
+## Every box the five routines print that ends in `prompt` rather than `done`,
+## which is the whole of the difference between a box that waits for a press and
+## one the next thing draws over.
+const PROMPT_TEXTS: Array[String] = [
+	Gen2WorldDayCare.TEXT_WHICH_ONE, Gen2WorldDayCare.TEXT_LAST_MON,
+	Gen2WorldDayCare.TEXT_CANT_BREED_EGG, Gen2WorldDayCare.TEXT_REMOVE_MAIL,
+	Gen2WorldDayCare.TEXT_LAST_ALIVE_MON, Gen2WorldDayCare.TEXT_DEPOSIT,
+	Gen2WorldDayCare.TEXT_WITHDRAW, Gen2WorldDayCare.TEXT_GOT_BACK,
+	Gen2WorldDayCare.TEXT_PARTY_FULL, Gen2WorldDayCare.TEXT_NOT_ENOUGH_MONEY,
+	Gen2WorldDayCare.TEXT_OH_FINE,
+	Gen2WorldDayCare.COMPATIBILITY_BRIMMING, Gen2WorldDayCare.COMPATIBILITY_NONE,
+	Gen2WorldDayCare.COMPATIBILITY_CARES, Gen2WorldDayCare.COMPATIBILITY_FRIENDLY,
+	Gen2WorldDayCare.COMPATIBILITY_INTEREST,
+]
+
+## `constants/script_constants.asm`'s YOUR_MONEY.
+const ACCOUNT_YOUR_MONEY: int = 0
+
+enum Phase { TEXT, ASK, PARTY, WAIT, DONE }
+
+var _data: GameData = null
+var _save: Gen2SaveData = null
+var _state: Gen2WorldState = null
+var _role: StringName = &"man"
+var _player_name: String = ""
+var _player_id: int = 0
+var _random: RandomNumberGenerator = null
+## Every stub `RomLayout.DAY_CARE_TEXT_RUNS` names, by that name.
+var _texts: Dictionary = {}
+
+var _phase: int = Phase.DONE
+var _queue: Array = []
+var _yes: bool = true
+var _question: StringName = &""
+var _wait_frames: int = 0
+## Whether the box now up is one the routine waits on, and the text it is
+## holding. `Gen2TextBox` keeps neither: whether a box blinks is not whether it
+## waits, and the two are decided here off the source's own terminators.
+var _text_waits: bool = false
+var _text_source: String = ""
+var _script_value: int = -1
+var _ending_text: String = ""
+## Which slot the running routine acts on, and what it costs to get it back.
+var _slot: int = Gen2WorldDayCare.SLOT_MAN
+var _price: int = 0
+var _growth: int = 0
+
+var _text_box: Gen2TextBox = null
+var _menu_page: Gen2MenuPage = null
+var _menu: TextureRect = null
+var _party: Gen2PartyScreen = null
+
+
+func set_context(
+	data: GameData,
+	save: Gen2SaveData,
+	state: Gen2WorldState,
+	role: StringName,
+	texts: Dictionary,
+	player_name: String,
+	player_id: int,
+	random: RandomNumberGenerator
+) -> void:
+	_data = data
+	_save = save
+	_state = state
+	_role = role
+	_texts = texts.duplicate(true)
+	_player_name = player_name
+	_player_id = player_id
+	_random = random
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _save == null or _state == null \
+		or _text(Gen2WorldDayCare.TEXT_MAN_INTRO).is_empty():
+		_finish()
+		return
+	_build()
+	match _role:
+		&"lady":
+			_slot = Gen2WorldDayCare.SLOT_LADY
+			_open_counter()
+		&"outside":
+			_open_outside()
+		&"mon1":
+			_open_sign(Gen2WorldDayCare.SLOT_MAN)
+		&"mon2":
+			_open_sign(Gen2WorldDayCare.SLOT_LADY)
+		_:
+			_open_counter()
+	_step()
+
+
+func phase() -> int:
+	return _phase
+
+
+## The YES/NO cursor, so a driver can read it without a redraw. -1 when no box is
+## up.
+func question_cursor() -> int:
+	return (0 if _yes else 1) if _phase == Phase.ASK else -1
+
+
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+func party_screen() -> Gen2PartyScreen:
+	return _party
+
+
+func handle_button(button: int) -> bool:
+	if _phase == Phase.PARTY and _party != null:
+		return _party.handle_button(button)
+	if _phase == Phase.ASK:
+		match button:
+			Gen2Button.UP, Gen2Button.DOWN:
+				_yes = not _yes
+				_draw_yes_no()
+				return true
+			Gen2Button.A:
+				_answer(_yes)
+				return true
+			Gen2Button.B:
+				## `YesNoBox` answers B with the carry each caller takes as NO.
+				_answer(false)
+				return true
+		return false
+	if _phase != Phase.TEXT or button != Gen2Button.A \
+		or _text_box == null or not _text_box.visible:
+		return false
+	if _text_box.is_revealing() or _text_box.has_pages_left():
+		_text_box.advance()
+		return true
+	_step()
+	return true
+
+
+func advance_frame() -> void:
+	if _phase == Phase.WAIT:
+		_wait_frames -= 1
+		if _wait_frames <= 0:
+			_step()
+		return
+	if _text_box == null or not _text_box.visible:
+		return
+	_text_box.advance_frame()
+	if _text_box.is_revealing() or _text_box.has_pages_left():
+		return
+	## `PrintText` on a text ending in `done` returns without a press, so the
+	## queue carries on the frame the last character lands.
+	if _phase == Phase.TEXT and not _text_waits:
+		_step()
+
+
+## `DayCareMan` and `DayCareLady`, which differ only in the slot and in which
+## intro the first visit prints.
+func _open_counter() -> void:
+	if _state.day_care_has_mon(_slot):
+		_queue_withdraw()
+		return
+	_queue.append({"text": _intro_key()})
+	_queue.append({"ask": &"deposit"})
+
+
+## `DayCareManIntroText` sets the man's ACTIVE bit and always prints his short
+## line; `DayCareLadyIntroText` prints the *egg* variant on the visit that sets
+## hers, which is why only the lady ever explains what an egg is.
+func _intro_key() -> String:
+	if _slot == Gen2WorldDayCare.SLOT_MAN:
+		_state.set_day_care_man_flags(
+			_state.day_care_man_flags() | Gen2WorldDayCare.MAN_ACTIVE
+		)
+		return Gen2WorldDayCare.TEXT_MAN_INTRO
+	if _state.day_care_lady_flags() & Gen2WorldDayCare.LADY_ACTIVE != 0:
+		return Gen2WorldDayCare.TEXT_LADY_INTRO
+	_state.set_day_care_lady_flags(
+		_state.day_care_lady_flags() | Gen2WorldDayCare.LADY_ACTIVE
+	)
+	return Gen2WorldDayCare.TEXT_LADY_INTRO_EGG
+
+
+## `.AskWithdrawMon`: the level growth and the price are read before the first
+## box, since both of them are printed inside it.
+func _queue_withdraw() -> void:
+	var mon: Gen2SaveMon = _state.day_care_mon(_slot)
+	_growth = Gen2WorldDayCare.level_growth(_data, mon)
+	_price = Gen2WorldDayCare.price_to_retrieve(_growth)
+	if _growth == 0:
+		_queue.append({"text": Gen2WorldDayCare.TEXT_TOO_SOON})
+		_queue.append({"ask": &"withdraw_soon"})
+		return
+	_queue.append({"text": Gen2WorldDayCare.TEXT_GENIUSES})
+	_queue.append({"ask": &"withdraw_see"})
+
+
+## `DayCareManOutside`.
+func _open_outside() -> void:
+	if _state.day_care_man_flags() & Gen2WorldDayCare.MAN_HAS_EGG == 0:
+		## `.NotYetText` returns without writing wScriptVar at all.
+		_queue.append({"text": "not_yet"})
+		return
+	_queue.append({"text": "found_an_egg"})
+	_queue.append({"ask": &"take_egg"})
+
+
+## `DayCareMon1` and `DayCareMon2`.
+func _open_sign(slot: int) -> void:
+	var mine: Gen2SaveMon = _state.day_care_mon(slot)
+	var other_slot: int = 1 - slot
+	var key: String = "left_with_man" if slot == Gen2WorldDayCare.SLOT_MAN \
+		else "left_with_lady"
+	_queue.append({"text": key, "ram": _nickname(mine)})
+	_queue.append({"cry": 0 if mine == null else mine.species})
+	if not _state.day_care_has_mon(other_slot):
+		## `DayCareMonCursor` is `WaitPressAorB_BlinkCursor`, which is the box
+		## already standing plus a press.
+		_queue.append({"press": true})
+		return
+	## `PromptButton`, and then the compatibility line, which names the *other*
+	## slot in `wStringBuffer1`.
+	_queue.append({"press": true})
+	var other: Gen2SaveMon = _state.day_care_mon(other_slot)
+	var value: int = Gen2WorldDayCare.compatibility(_data, mine, other)
+	_queue.append({
+		"text": Gen2WorldDayCare.compatibility_text_key(value),
+		"ram": _nickname(other),
+	})
+
+
+func _answer(yes: bool) -> void:
+	if _menu != null:
+		_menu.visible = false
+	var question: StringName = _question
+	_question = &""
+	match question:
+		&"deposit":
+			if not yes:
+				_queue_cancel()
+			else:
+				_queue_deposit_selection()
+		&"withdraw_soon":
+			if not yes:
+				_queue_refusal(Gen2WorldDayCare.TEXT_OH_FINE)
+			else:
+				_queue_pay()
+		&"withdraw_see":
+			if not yes:
+				_queue_refusal(Gen2WorldDayCare.TEXT_OH_FINE)
+			else:
+				_queue.append({"text": Gen2WorldDayCare.TEXT_ASK_WITHDRAW})
+				_queue.append({"ask": &"withdraw_take"})
+		&"withdraw_take":
+			if not yes:
+				_queue_refusal(Gen2WorldDayCare.TEXT_OH_FINE)
+			else:
+				_queue_pay()
+		&"take_egg":
+			if not yes:
+				_script_value = 0
+				_queue.append({"text": "ill_keep_it"})
+			elif _save.party.size() >= Gen2SaveData.MAX_PARTY:
+				_script_value = 1
+				_queue.append({"text": "no_room_for_egg"})
+			else:
+				_give_egg()
+	_step()
+
+
+## `DayCareAskDepositPokemon`'s own first test, which is the party count and not
+## the selection: one Pokemon never reaches the list at all.
+func _queue_deposit_selection() -> void:
+	if _save.party.size() < 2:
+		_queue_refusal(Gen2WorldDayCare.TEXT_LAST_MON)
+		return
+	_queue.append({"text": Gen2WorldDayCare.TEXT_WHICH_ONE})
+	_queue.append({"party": true})
+
+
+## `.print_text` then `.cancel`: a refusal prints its own box and then
+## `ComeAgainText`.
+func _queue_refusal(key: String) -> void:
+	_queue.append({"text": key})
+	_queue_cancel()
+
+
+func _queue_cancel() -> void:
+	_queue.append({"text": Gen2WorldDayCare.TEXT_COME_AGAIN})
+
+
+## `.check_money` and `DayCare_GetBackMonForMoney`.
+func _queue_pay() -> void:
+	if _state.money(ACCOUNT_YOUR_MONEY) < _price:
+		_queue_refusal(Gen2WorldDayCare.TEXT_NOT_ENOUGH_MONEY)
+		return
+	if _save.party.size() >= Gen2SaveData.MAX_PARTY:
+		_queue_refusal(Gen2WorldDayCare.TEXT_PARTY_FULL)
+		return
+	var mon: Gen2SaveMon = _state.day_care_mon(_slot)
+	var nickname: String = _nickname(mon)
+	var retrieved: Dictionary = Gen2WorldDayCare.retrieve(_state, _save, _data, _slot)
+	if retrieved.is_empty():
+		_queue_cancel()
+		return
+	_state.apply_changes({}, {}, {
+		"money": {ACCOUNT_YOUR_MONEY: _state.money(ACCOUNT_YOUR_MONEY) - _price},
+	})
+	## Withdrawing from either slot clears the man's compatibility bit, since it
+	## is the *pair* that is no longer breeding.
+	_state.set_day_care_man_flags(
+		_state.day_care_man_flags() & ~Gen2WorldDayCare.MAN_MONS_COMPATIBLE
+	)
+	_queue.append({"text": Gen2WorldDayCare.TEXT_WITHDRAW})
+	_queue.append({"cry": int(retrieved.get("species", 0))})
+	_queue.append({"text": Gen2WorldDayCare.TEXT_GOT_BACK, "ram": nickname})
+	_queue_cancel()
+
+
+## `DayCare_GiveEgg`, `DayCare_InitBreeding` behind it and the three boxes.
+func _give_egg() -> void:
+	var given: Dictionary = Gen2WorldDayCare.give_egg(_state, _save)
+	if given.is_empty():
+		_script_value = 1
+		_queue.append({"text": "no_room_for_egg"})
+		return
+	Gen2WorldDayCare.init_breeding(
+		_state, _data, _player_name, _player_id, _random
+	)
+	_script_value = 0
+	_queue.append({"text": "received_egg"})
+	_queue.append({"sfx": SFX_GET_EGG, "frames": EGG_SOUND_FRAMES})
+	_queue.append({"text": "take_good_care"})
+
+
+func _step() -> void:
+	if _queue.is_empty():
+		_finish()
+		return
+	var action: Dictionary = _queue.pop_front()
+	if action.has("text"):
+		_phase = Phase.TEXT
+		_show_text(action)
+		return
+	if action.has("ask"):
+		_phase = Phase.ASK
+		_question = StringName(action["ask"])
+		_yes = true
+		_draw_yes_no()
+		return
+	if action.has("party"):
+		_open_party()
+		return
+	if action.has("cry"):
+		if int(action["cry"]) > 0:
+			cry_requested.emit(int(action["cry"]))
+		_step()
+		return
+	if action.has("sfx"):
+		sfx_requested.emit(int(action["sfx"]))
+		_phase = Phase.WAIT
+		_wait_frames = int(action.get("frames", 0))
+		if _wait_frames <= 0:
+			_step()
+		return
+	if action.has("press"):
+		## A box already standing plus the press `PromptButton` and
+		## `DayCareMonCursor` wait for, arrow included.
+		_phase = Phase.TEXT
+		_text_waits = true
+		if _text_box != null:
+			_text_box.set_blink_cursor(true)
+		return
+	_step()
+
+
+
+
+
+func _show_text(action: Dictionary) -> void:
+	var key: String = String(action["text"])
+	var text: String = _text(key)
+	if action.has("ram"):
+		text = Gen2TextStream.fill_all_markers(
+			text, Gen2TextStream.RAM_MARKER, String(action["ram"])
+		)
+	if key == Gen2WorldDayCare.TEXT_ASK_WITHDRAW:
+		## `_YourMonHasGrownText`'s two `text_decimal`s, in the order it prints
+		## them: the levels gained and then the price.
+		text = Gen2TextStream.fill_marker(
+			text, Gen2TextStream.NUMBER_MARKER, "%3d" % _growth
+		)
+		text = Gen2TextStream.fill_marker(
+			text, Gen2TextStream.NUMBER_MARKER, "%4d" % _price
+		)
+	text = Gen2TextStream.fill_all_markers(text, "<PLAYER", _player_name)
+	if _menu != null:
+		_menu.visible = false
+	if _text_box == null:
+		return
+	_text_waits = key in PROMPT_TEXTS
+	_text_source = text
+	_text_box.visible = true
+	_text_box.show_text(text, _text_waits)
+
+
+## `SelectTradeOrDayCareMon`, which is the party list under
+## PARTYMENUACTION_GIVE_MON.
+func _open_party() -> void:
+	var host: Gen2PartyScreen = PARTY_SCENE.instantiate() as Gen2PartyScreen
+	if host == null:
+		_queue_refusal(Gen2WorldDayCare.TEXT_OH_FINE)
+		_step()
+		return
+	host.set_context(_data, _save, true)
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	host.selection_made.connect(_on_selected)
+	add_child(host)
+	host.open_selection()
+	_party = host
+	_text_box.visible = false
+	_phase = Phase.PARTY
+
+
+func _on_selected(party_index: int) -> void:
+	Gen2Screen.drop(_party)
+	_party = null
+	if party_index < 0 or party_index >= _save.party.size():
+		## `.Declined`, which is the same `OhFineThenText` a refused question
+		## prints.
+		_queue_refusal(Gen2WorldDayCare.TEXT_OH_FINE)
+		_step()
+		return
+	var refusal: String = Gen2WorldDayCare.deposit_refusal(_save, party_index)
+	if not refusal.is_empty():
+		_queue_refusal(refusal)
+		_step()
+		return
+	var mon: Gen2SaveMon = _save.party[party_index] as Gen2SaveMon
+	var nickname: String = _nickname(mon)
+	var species: int = mon.species
+	Gen2WorldDayCare.deposit(_state, _save, _slot, party_index)
+	Gen2WorldDayCare.init_breeding(_state, _data, _player_name, _player_id, _random)
+	## `DayCare_DepositPokemonText`, and then the `ret` that leaves
+	## `ComeAgainText` unprinted: a deposit is the one path that does not end on
+	## it.
+	_queue.append({"text": Gen2WorldDayCare.TEXT_DEPOSIT, "ram": nickname})
+	_queue.append({"cry": species})
+	_queue.append({"text": Gen2WorldDayCare.TEXT_COME_BACK_LATER})
+	_step()
+
+
+func _finish() -> void:
+	_phase = Phase.DONE
+	if _menu != null:
+		_menu.visible = false
+	## The two signs press their own last box; the three routines a script
+	## follows with `waitbutton` hand theirs over instead.
+	if _role not in [&"mon1", &"mon2"] and _text_box != null and _text_box.visible:
+		_ending_text = _text_source
+	if _text_box != null:
+		_text_box.visible = false
+	finished.emit(_script_value, _ending_text)
+	closed.emit()
+
+
+func _text(key: String) -> String:
+	return String(_texts.get(key, ""))
+
+
+func _nickname(mon: Gen2SaveMon) -> String:
+	if mon == null:
+		return ""
+	if not mon.nickname.is_empty():
+		return mon.nickname
+	return String(_data.species(mon.species).get("name", ""))
+
+
+func _build() -> void:
+	_menu = TextureRect.new()
+	_menu.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_menu.visible = false
+	add_child(_menu)
+
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+func _draw_yes_no() -> void:
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
+	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true

--- a/game/world/day_care_screen.gd.uid
+++ b/game/world/day_care_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dvqwowdsvbcu4

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -268,6 +268,10 @@ var object_random: RandomNumberGenerator = null
 ## reason they are apart from each other: reading the radio must not move a
 ## wild encounter or an NPC.
 var radio_random: RandomNumberGenerator = null
+## Supplies `DayCareStep`'s two rolls and `DayCare_InitBreeding`'s counter. Apart
+## from the other four for the same reason: a step spent breeding must not move
+## the wild encounter that step could also have rolled.
+var breed_random: RandomNumberGenerator = null
 ## The programme the open radio card is reading, built by tune_radio() and
 ## dropped when the card closes or the dial finds dead air.
 var _radio_show: Gen2RadioShow = null

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -60,8 +60,9 @@ static func toss(
 ## a Pokemon already holding something is refused with nothing written, which is
 ## where the source stops to ask.
 ##
-## `ItemIsMail` has no counterpart here, so `.please_remove_mail` and
-## `ComposeMailMessage` are unreachable and no item is refused for being mail.
+## `ItemIsMail` is [method Gen2HeldItem.is_mail], but nothing here composes a
+## message, so `.please_remove_mail` and `ComposeMailMessage` are unreachable and
+## no item is refused for being mail.
 static func give_to_party(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -1,0 +1,597 @@
+class_name Gen2WorldDayCare
+extends RefCounted
+
+## `engine/events/daycare.asm` and `engine/pokemon/breeding.asm`, the rules half.
+##
+## The two Day-Care slots are world state rather than party members: the
+## cartridge keeps them in `wBreedMon1` and `wBreedMon2`, which are boxmon
+## structs beside the flag byte that says whether each is occupied. This answers
+## what the three routines ask of that state and nothing else; the boxes,
+## presses and party list are [Gen2DayCareScreen]'s.
+##
+## Every duration and every roll here is the source's own. What a reading gets
+## wrong is which parent a field comes from: `wBreedMotherOrNonDitto` is set once
+## in `DayCare_InitBreeding` and then read by four routines that each pick a
+## *different* side of it, so it is computed once here as
+## [method mother_or_non_ditto] and passed down.
+
+## `wDayCareMan`'s four bits (constants/ram_constants.asm).
+const MAN_HAS_MON: int = 1 << 0
+const MAN_MONS_COMPATIBLE: int = 1 << 5
+const MAN_HAS_EGG: int = 1 << 6
+const MAN_ACTIVE: int = 1 << 7
+## `wDayCareLady`'s two. `MONS_COMPATIBLE` and `HAS_EGG` live on the man's byte
+## for both slots, which is why withdrawing from the lady clears a man's bit.
+const LADY_HAS_MON: int = 1 << 0
+const LADY_ACTIVE: int = 1 << 7
+
+## Which slot a routine is acting on. `SLOT_MAN` is `wBreedMon1`.
+const SLOT_MAN: int = 0
+const SLOT_LADY: int = 1
+
+const SPECIES_DITTO: int = 132
+const SPECIES_NIDORAN_F: int = 29
+const SPECIES_NIDORAN_M: int = 32
+## `EGG_NONE`, the fifteenth egg group. `CheckBreedingGroupCompatibility`
+## compares the whole byte against `EGG_NONE * $11`, so a species is refused only
+## when *both* of its nibbles are this.
+const EGG_GROUP_NONE: int = 15
+## `EGG_LEVEL`, the level every egg hatches at.
+const EGG_LEVEL: int = 5
+## `MAX_LEVEL`, above which a deposited Pokemon stops gaining experience.
+const MAX_LEVEL: int = 100
+## `MAX_DAY_CARE_EXP`. The routine clamps the experience's *high byte* alone, on
+## the pass a carry reaches it, which is why the cap is a plain 3-byte value here
+## and not a mask.
+const MAX_DAY_CARE_EXP: int = 0x500000
+
+## `GetPriceToRetrieveBreedmon`: a hundred coins a level gained, plus a hundred
+## for the stay itself.
+const RETRIEVE_BASE_PRICE: int = 100
+const RETRIEVE_PRICE_PER_LEVEL: int = 100
+
+## `DayCare_InitBreeding`'s own `cp 150`: the first counter is a random byte of
+## at least this, so the earliest possible egg is 150 step cycles away.
+const FIRST_EGG_STEPS_MINIMUM: int = 150
+
+## `DayCareStep`'s four bands, as [compatibility floor, chance out of 256]. The
+## chances are the source's `percent` macro, which is `x * $ff / 100` with
+## integer division: `31 percent + 1` is 80, `16 percent` 40, `12 percent` 30 and
+## `4 percent` 10. Walked in order, the first floor a value reaches winning.
+const EGG_CHANCE_BANDS: Array = [[230, 80], [170, 40], [110, 30], [0, 10]]
+
+## `DayCareMonCompatibilityText`'s five answers, by the stub each loads. The
+## walk is the routine's own order and its first match wins, so 255 is answered
+## before the zero test that would otherwise never be reached for it.
+const COMPATIBILITY_BRIMMING: String = "brimming_with_energy"
+const COMPATIBILITY_NONE: String = "no_interest"
+const COMPATIBILITY_CARES: String = "appears_to_care"
+const COMPATIBILITY_FRIENDLY: String = "friendly"
+const COMPATIBILITY_INTEREST: String = "shows_interest"
+
+## `PrintDayCareText`'s own indices, by the stub name `RomLayout` pins.
+const TEXT_MAN_INTRO: String = "man_intro"
+const TEXT_MAN_INTRO_EGG: String = "man_intro_egg"
+const TEXT_LADY_INTRO: String = "lady_intro"
+const TEXT_LADY_INTRO_EGG: String = "lady_intro_egg"
+const TEXT_WHICH_ONE: String = "which_one"
+const TEXT_DEPOSIT: String = "ill_raise"
+const TEXT_CANT_BREED_EGG: String = "cant_accept_egg"
+const TEXT_LAST_MON: String = "only_one_mon"
+const TEXT_LAST_ALIVE_MON: String = "last_healthy_mon"
+const TEXT_COME_BACK_LATER: String = "come_back_later"
+const TEXT_REMOVE_MAIL: String = "remove_mail"
+const TEXT_GENIUSES: String = "are_we_geniuses"
+const TEXT_ASK_WITHDRAW: String = "has_grown"
+const TEXT_WITHDRAW: String = "perfect_heres_your_mon"
+const TEXT_GOT_BACK: String = "got_back"
+const TEXT_TOO_SOON: String = "back_already"
+const TEXT_PARTY_FULL: String = "have_no_room"
+const TEXT_NOT_ENOUGH_MONEY: String = "not_enough_money"
+const TEXT_OH_FINE: String = "oh_fine_then"
+const TEXT_COME_AGAIN: String = "come_again"
+
+
+## `GetGender` on a Day-Care slot, which runs under `wMonType` TEMPMON with the
+## slot's own species and DVs loaded. Returns one of [Gen2BattleMon]'s three.
+static func gender_of(data: GameData, mon: Gen2SaveMon) -> StringName:
+	if data == null or mon == null:
+		return Gen2BattleMon.GENDER_NONE
+	return Gen2BattleMon.gender_for(data, mon.species, mon.dvs)
+
+
+## `CheckBreedingGroupCompatibility`. Ditto is compatible with everything that is
+## not in the No Eggs group, including a second Ditto: the pair test that stops
+## two Dittos is `.genderless`'s, one caller up.
+static func groups_compatible(data: GameData, mon1: Gen2SaveMon, mon2: Gen2SaveMon) -> bool:
+	if data == null or mon1 == null or mon2 == null:
+		return false
+	if _breeds_no_eggs(data, mon2.species) or _breeds_no_eggs(data, mon1.species):
+		return false
+	if mon2.species == SPECIES_DITTO or mon1.species == SPECIES_DITTO:
+		return true
+	var groups1: Array = _egg_groups(data, mon1.species)
+	var groups2: Array = _egg_groups(data, mon2.species)
+	return groups1[0] in groups2 or groups1[1] in groups2
+
+
+## `CheckBreedmonCompatibility`'s own byte. 0 refuses, 255 is the matching-DV
+## refusal that still reads as "brimming with energy", and everything else is a
+## live pair whose value decides how often an egg is offered.
+static func compatibility(data: GameData, mon1: Gen2SaveMon, mon2: Gen2SaveMon) -> int:
+	if not groups_compatible(data, mon1, mon2):
+		return 0
+	var gender1: StringName = gender_of(data, mon1)
+	var gender2: StringName = gender_of(data, mon2)
+	var opposite: bool = gender1 != Gen2BattleMon.GENDER_NONE \
+		and gender2 != Gen2BattleMon.GENDER_NONE and gender1 != gender2
+	if not opposite:
+		## `.genderless`, reached by a genderless parent and by two of the same
+		## gender alike: exactly one of the two has to be a Ditto.
+		var ditto1: bool = mon1.species == SPECIES_DITTO
+		var ditto2: bool = mon2.species == SPECIES_DITTO
+		if ditto1 == ditto2:
+			return 0
+	if _dvs_match(mon1, mon2):
+		return 255
+	var value: int = 254 if mon1.species == mon2.species else 128
+	## `.compare_ids`: a shared trainer ID is what lowers it, not a shared
+	## species, and the subtraction happens on both branches above.
+	if mon1.ot_id == mon2.ot_id:
+		value -= 77
+	return value
+
+
+## Which of `DayCareMonCompatibilityText`'s five stubs [param value] reaches.
+static func compatibility_text_key(value: int) -> String:
+	if value == 255:
+		return COMPATIBILITY_BRIMMING
+	if value == 0:
+		return COMPATIBILITY_NONE
+	if value >= 230:
+		return COMPATIBILITY_CARES
+	if value >= 70:
+		return COMPATIBILITY_FRIENDLY
+	return COMPATIBILITY_INTEREST
+
+
+## `wBreedMotherOrNonDitto`: 0 when `wBreedMon1` is the mother or the non-Ditto,
+## 1 when `wBreedMon2` is. A Ditto in either slot decides it before any gender is
+## read, which is why a Ditto pairing never asks about gender at all.
+static func mother_or_non_ditto(data: GameData, mon1: Gen2SaveMon, mon2: Gen2SaveMon) -> int:
+	if mon1 == null or mon2 == null:
+		return SLOT_MAN
+	if mon1.species == SPECIES_DITTO:
+		return SLOT_LADY
+	if mon2.species == SPECIES_DITTO:
+		return SLOT_MAN
+	return SLOT_MAN if gender_of(data, mon1) == Gen2BattleMon.GENDER_FEMALE else SLOT_LADY
+
+
+## `GetPreEvolution`: the lowest-numbered species that evolves into
+## [param species], or [param species] itself when nothing does. The walk is by
+## species number and stops at the first match, so a species reached by two
+## evolutions takes the smaller number.
+static func pre_evolution(data: GameData, species: int) -> int:
+	if data == null:
+		return species
+	for candidate: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		for row: Dictionary in data.evolutions(candidate):
+			if int(row.get("target", 0)) == species:
+				return candidate
+	return species
+
+
+## `DayCare_InitBreeding`'s two `callfar GetPreEvolution` and the Nidoran split
+## behind them. Nidoran F is the one mother whose egg can be either sign, and the
+## roll is `cp 50 percent + 1`, which is 128.
+static func egg_species(data: GameData, mother_species: int, random: RandomNumberGenerator) -> int:
+	var species: int = pre_evolution(data, pre_evolution(data, mother_species))
+	if species != SPECIES_NIDORAN_F:
+		return species
+	return SPECIES_NIDORAN_F if _random_byte(random) < 128 else SPECIES_NIDORAN_M
+
+
+## `GetHeritableMoves`: whose four moves the egg may inherit. The answer is the
+## father in an ordinary pairing and the *non-Ditto* parent in a Ditto one, which
+## is not the same side [method breedmon_move_source] takes.
+static func heritable_move_source(
+	data: GameData, mon1: Gen2SaveMon, mon2: Gen2SaveMon
+) -> Gen2SaveMon:
+	if mon1.species == SPECIES_DITTO:
+		return mon1 if gender_of(data, mon2) == Gen2BattleMon.GENDER_FEMALE else mon2
+	if mon2.species == SPECIES_DITTO:
+		return mon2 if gender_of(data, mon1) == Gen2BattleMon.GENDER_FEMALE else mon1
+	return mon2 if mother_or_non_ditto(data, mon1, mon2) == SLOT_MAN else mon1
+
+
+## `GetBreedmonMovePointer`: the mother's four moves, or the Ditto's. `GetEggMove`
+## reads these to decide whether a move the father knows is one the pair could
+## have passed on at all.
+static func breedmon_move_source(
+	data: GameData, mon1: Gen2SaveMon, mon2: Gen2SaveMon
+) -> Gen2SaveMon:
+	if mon1.species == SPECIES_DITTO:
+		return mon1
+	if mon2.species == SPECIES_DITTO:
+		return mon2
+	return mon1 if mother_or_non_ditto(data, mon1, mon2) == SLOT_MAN else mon2
+
+
+## `GetEggMove`, which answers whether one move the father knows reaches the egg.
+## Three ways in, in the routine's own order: the egg species' own egg-move list,
+## a move the mother knows that the egg species learns by level, and a TM or HM
+## the egg species can be taught.
+static func inherits_move(
+	data: GameData, egg: int, move: int, mother: Gen2SaveMon
+) -> bool:
+	if data == null or move <= 0:
+		return false
+	if data.egg_moves(egg).has(move):
+		return true
+	if mother != null and mother.moves.has(move):
+		for row: Dictionary in data.learnset(egg):
+			if int(row.get("move", 0)) == move:
+				return true
+	var number: int = data.tmhm_number_for_move(move)
+	return number > 0 and _can_learn_tm_hm(data, egg, number)
+
+
+## `LoadEggMove`: the first empty slot, or the last one after the four have been
+## shifted down. `FillPP` follows it, which is why the pp array is written here
+## rather than by the caller.
+static func load_egg_move(data: GameData, moves: Array, pp: Array, move: int) -> void:
+	var slot: int = moves.find(0)
+	if slot < 0:
+		for index: int in Gen2SaveMon.MAX_MOVES - 1:
+			moves[index] = moves[index + 1]
+		slot = Gen2SaveMon.MAX_MOVES - 1
+	moves[slot] = move
+	for index: int in Gen2SaveMon.MAX_MOVES:
+		var known: int = int(moves[index])
+		pp[index] = int(data.move(known).get("pp", 0)) if known > 0 else 0
+
+
+## `GetBreedMon1LevelGrowth`: how many levels the slot's experience has bought
+## since it was deposited. `CalcLevel` reads the experience and the stored level
+## is what it is compared against, so a slot at MAX_LEVEL still reports zero.
+static func level_growth(data: GameData, mon: Gen2SaveMon) -> int:
+	if data == null or mon == null:
+		return 0
+	return maxi(0, grown_level(data, mon) - mon.level)
+
+
+## `CalcLevel`'s own answer for a slot, which is the level it will come out at.
+static func grown_level(data: GameData, mon: Gen2SaveMon) -> int:
+	if data == null or mon == null:
+		return 0
+	return Gen2Experience.level_for_exp(
+		int(data.species(mon.species).get("growth_rate", 0)), mon.exp
+	)
+
+
+## `GetPriceToRetrieveBreedmon`.
+static func price_to_retrieve(growth: int) -> int:
+	return RETRIEVE_BASE_PRICE + RETRIEVE_PRICE_PER_LEVEL * maxi(0, growth)
+
+
+## `DayCareStep`, the whole of it: a point of experience for each occupied slot
+## and, once the pair is compatible, the counter that offers an egg.
+##
+## Returns true when this step set `DAYCAREMAN_HAS_EGG_F`, which is the one thing
+## outside the state a caller can observe.
+static func step(state: Gen2WorldState, data: GameData, random: RandomNumberGenerator) -> bool:
+	if state == null or data == null:
+		return false
+	for slot: int in [SLOT_MAN, SLOT_LADY]:
+		if not state.day_care_has_mon(slot):
+			continue
+		var mon: Gen2SaveMon = state.day_care_mon(slot)
+		if mon == null or mon.level >= MAX_LEVEL:
+			continue
+		mon.exp = _day_care_exp_after(mon.exp)
+		state.set_day_care_mon(slot, mon)
+	if state.day_care_man_flags() & MAN_MONS_COMPATIBLE == 0:
+		return false
+	state.set_steps_to_egg(state.steps_to_egg() - 1)
+	if state.steps_to_egg() > 0:
+		return false
+	## `call Random / ld [hl], a`: the counter is reloaded with a raw byte here
+	## rather than with the `cp 150` roll `DayCare_InitBreeding` uses.
+	state.set_steps_to_egg(_random_byte(random))
+	var value: int = compatibility(
+		data, state.day_care_mon(SLOT_MAN), state.day_care_mon(SLOT_LADY)
+	)
+	var chance: int = 10
+	for band: Array in EGG_CHANCE_BANDS:
+		if value >= int(band[0]):
+			chance = int(band[1])
+			break
+	if _random_byte(random) >= chance:
+		return false
+	state.set_day_care_man_flags(
+		(state.day_care_man_flags() & ~MAN_MONS_COMPATIBLE) | MAN_HAS_EGG
+	)
+	return true
+
+
+## `DayCare_InitBreeding`, run after every deposit and after the egg is handed
+## over. An incompatible pair leaves the counter and the egg alone; a compatible
+## one builds the egg now and holds it until the counter runs out, which is what
+## the cartridge does and why a pair swapped mid-count changes nothing.
+static func init_breeding(
+	state: Gen2WorldState,
+	data: GameData,
+	player_name: String,
+	player_id: int,
+	random: RandomNumberGenerator
+) -> bool:
+	if state == null or data == null:
+		return false
+	if not state.day_care_has_mon(SLOT_MAN) or not state.day_care_has_mon(SLOT_LADY):
+		return false
+	var mon1: Gen2SaveMon = state.day_care_mon(SLOT_MAN)
+	var mon2: Gen2SaveMon = state.day_care_mon(SLOT_LADY)
+	var value: int = compatibility(data, mon1, mon2)
+	if value == 0 or value == 255:
+		return false
+	state.set_day_care_man_flags(state.day_care_man_flags() | MAN_MONS_COMPATIBLE)
+	## `.loop`: a random byte re-rolled until it is at least 150.
+	var steps: int = _random_byte(random)
+	while steps < FIRST_EGG_STEPS_MINIMUM:
+		steps = _random_byte(random)
+	state.set_steps_to_egg(steps)
+	state.set_day_care_egg(make_egg(data, mon1, mon2, player_name, player_id, random))
+	return true
+
+
+## `.UselessJump` onward: the egg itself. Built in the source's own order, which
+## matters twice over. The level-up moves are filled before the inherited ones,
+## so an inherited move pushes the oldest level-up move out; and the DVs are
+## rolled after both, so the gender that decides which parent the Defense DV
+## comes from is the *egg's* own, read off the freshly rolled bytes.
+static func make_egg(
+	data: GameData,
+	mon1: Gen2SaveMon,
+	mon2: Gen2SaveMon,
+	player_name: String,
+	player_id: int,
+	random: RandomNumberGenerator
+) -> Gen2SaveMon:
+	if data == null or mon1 == null or mon2 == null:
+		return null
+	var mother_slot: int = mother_or_non_ditto(data, mon1, mon2)
+	var mother: Gen2SaveMon = mon1 if mother_slot == SLOT_MAN else mon2
+	var species: int = egg_species(data, mother.species, random)
+	var egg: Gen2SaveMon = Gen2SaveMon.new()
+	egg.species = species
+	egg.is_egg = true
+	egg.nickname = "EGG"
+	egg.original_trainer = player_name
+	egg.ot_id = player_id
+	egg.item = 0
+	egg.level = EGG_LEVEL
+	egg.caught_level = 0
+	egg.moves = [0, 0, 0, 0]
+	egg.pp = [0, 0, 0, 0]
+	for move: Variant in Gen2Learnset.moves_at_level(data.learnset(species), EGG_LEVEL):
+		load_egg_move(data, egg.moves, egg.pp, int(move))
+	## `InitEggMoves`, which walks the father's four in order and stops at the
+	## first empty slot rather than skipping it.
+	var father: Gen2SaveMon = heritable_move_source(data, mon1, mon2)
+	var move_source: Gen2SaveMon = breedmon_move_source(data, mon1, mon2)
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		var move: int = int(father.moves[slot])
+		if move == 0:
+			break
+		if egg.moves.has(move):
+			continue
+		if inherits_move(data, species, move, move_source):
+			load_egg_move(data, egg.moves, egg.pp, move)
+	egg.exp = Gen2Experience.total_exp_at(
+		int(data.species(species).get("growth_rate", 0)), EGG_LEVEL
+	)
+	for key: Variant in Gen2SaveMon.STAT_EXP_KEYS:
+		egg.stat_exp[key] = 0
+	egg.dvs = inherited_dvs(
+		data, species, _random_byte(random) << 8 | _random_byte(random), mon1, mon2
+	)
+	## `FillPP` again, now that the DVs are settled: the moves have not changed,
+	## so this is the same answer, and it is here because the source runs it here.
+	for index: int in Gen2SaveMon.MAX_MOVES:
+		var known: int = int(egg.moves[index])
+		egg.pp[index] = int(data.move(known).get("pp", 0)) if known > 0 else 0
+	## `ld a, [wBaseEggSteps]`: an egg's happiness byte is its hatch counter,
+	## which is what `DoEggStep` drains.
+	egg.happiness = int(data.species(species).get("hatch_cycles", 0))
+	egg.hp = 0
+	return egg
+
+
+## `.GotDVs` and the two parent checks in front of it. [param rolled] is the two
+## random bytes the routine has just written; a genderless egg keeps both of them
+## whole, and any other egg replaces its Defense DV and the low three bits of its
+## Special DV with the chosen parent's.
+static func inherited_dvs(
+	data: GameData, species: int, rolled: int, mon1: Gen2SaveMon, mon2: Gen2SaveMon
+) -> int:
+	var source: Gen2SaveMon = null
+	if mon1.species == SPECIES_DITTO:
+		source = mon1
+	elif mon2.species == SPECIES_DITTO:
+		source = mon2
+	else:
+		var egg_gender: StringName = Gen2BattleMon.gender_for(data, species, rolled)
+		if egg_gender == Gen2BattleMon.GENDER_NONE:
+			return rolled
+		var mother_slot: int = mother_or_non_ditto(data, mon1, mon2)
+		if egg_gender == Gen2BattleMon.GENDER_FEMALE:
+			## `.ParentCheck2`, which takes the slot the mother is *not* in.
+			source = mon1 if mother_slot == SLOT_LADY else mon2
+		else:
+			source = mon1 if mother_slot == SLOT_MAN else mon2
+	## The egg keeps its own Attack and Speed DVs and the Special DV's top bit;
+	## the Defense DV and the Special DV's low three bits come from the parent.
+	return (rolled & 0xF0F8) | (source.dvs & 0x0F00) | _low_bits(source.dvs)
+
+
+## `DayCareAskDepositPokemon`'s refusals, in the routine's own order. Answers the
+## `PrintDayCareText` stub the refusal prints, or `&""` when the member may go in.
+static func deposit_refusal(save: Gen2SaveData, party_index: int) -> String:
+	if save == null or save.party.size() < 2:
+		return TEXT_LAST_MON
+	if party_index < 0 or party_index >= save.party.size():
+		return TEXT_OH_FINE
+	var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
+	if mon == null:
+		return TEXT_OH_FINE
+	if mon.is_egg:
+		return TEXT_CANT_BREED_EGG
+	## `CheckCurPartyMonFainted`, which refuses the *last* healthy member rather
+	## than a fainted one: a fainted member may be deposited if another can walk.
+	if _last_healthy(save, party_index):
+		return TEXT_LAST_ALIVE_MON
+	if Gen2HeldItem.is_mail(mon.item):
+		return TEXT_REMOVE_MAIL
+	return ""
+
+
+## `DepositMonWithDayCareMan` and `RemoveMonFromPartyOrBox` behind it. The member
+## leaves the party whole: the slot holds what the party held, so nothing is
+## recomputed until it comes back out.
+static func deposit(
+	state: Gen2WorldState, save: Gen2SaveData, slot: int, party_index: int
+) -> bool:
+	if state == null or save == null \
+		or party_index < 0 or party_index >= save.party.size():
+		return false
+	var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
+	if mon == null:
+		return false
+	state.set_day_care_mon(slot, mon)
+	save.party.remove_at(party_index)
+	state.set_day_care_has_mon(slot, true)
+	return true
+
+
+## `RetrieveBreedmon`. The level comes from the experience, `HealPartyMon` fills
+## HP, status and PP, and `FillMoves` teaches whatever the levels between the two
+## carry.
+##
+## The last write is `CalcExpAtLevel`, which puts the experience *back* to the
+## bottom of the level it just reached: that is
+## `docs/bugs_and_glitches.md`'s "Pokemon deposited in the Day-Care might lose
+## experience", and it is reproduced rather than corrected.
+static func retrieve(
+	state: Gen2WorldState, save: Gen2SaveData, data: GameData, slot: int
+) -> Dictionary:
+	if state == null or save == null or data == null:
+		return {}
+	var mon: Gen2SaveMon = state.day_care_mon(slot)
+	if mon == null or save.party.size() >= Gen2SaveData.MAX_PARTY:
+		return {}
+	var previous_level: int = mon.level
+	mon.level = clampi(grown_level(data, mon), previous_level, MAX_LEVEL)
+	Gen2Learnset.fill_moves(
+		data.learnset(mon.species), mon.moves, mon.level, previous_level
+	)
+	var growth_rate: int = int(data.species(mon.species).get("growth_rate", 0))
+	mon.exp = Gen2Experience.total_exp_at(growth_rate, mon.level)
+	mon.status = Gen2Status.NONE
+	mon.hp = Gen2Stats.calculate(
+		int((data.species(mon.species).get("stats", {}) as Dictionary).get("hp", 0)),
+		Gen2Stats.hp_dv(mon.dvs), int(mon.stat_exp.get("hp", 0)), mon.level, true
+	)
+	for index: int in Gen2SaveMon.MAX_MOVES:
+		var move: int = int(mon.moves[index])
+		mon.pp[index] = int(data.move(move).get("pp", 0)) if move > 0 else 0
+	save.party.append(mon)
+	state.set_day_care_mon(slot, null)
+	state.set_day_care_has_mon(slot, false)
+	return {
+		"party_index": save.party.size() - 1,
+		"species": mon.species,
+		"level": mon.level,
+		"previous_level": previous_level,
+	}
+
+
+## `DayCare_GiveEgg`. The egg the pair built when the counter started is the one
+## handed over, which is why nothing is rolled here.
+static func give_egg(state: Gen2WorldState, save: Gen2SaveData) -> Dictionary:
+	if state == null or save == null or save.party.size() >= Gen2SaveData.MAX_PARTY:
+		return {}
+	var egg: Gen2SaveMon = state.day_care_egg()
+	if egg == null:
+		return {}
+	save.party.append(egg)
+	state.set_day_care_egg(null)
+	state.set_day_care_man_flags(state.day_care_man_flags() & ~MAN_HAS_EGG)
+	return {
+		"party_index": save.party.size() - 1,
+		"species": egg.species,
+		"nickname": egg.nickname,
+	}
+
+
+static func _egg_groups(data: GameData, species: int) -> Array:
+	var groups: Variant = data.species(species).get("egg_groups", [])
+	if not groups is Array or (groups as Array).size() < 2:
+		return [EGG_GROUP_NONE, EGG_GROUP_NONE]
+	return [int((groups as Array)[0]), int((groups as Array)[1])]
+
+
+static func _breeds_no_eggs(data: GameData, species: int) -> bool:
+	var groups: Array = _egg_groups(data, species)
+	return groups[0] == EGG_GROUP_NONE and groups[1] == EGG_GROUP_NONE
+
+
+## `.CheckDVs`: the Defense DV and the low three bits of the Special DV. A pair
+## matching on both is refused, which is the "brimming with energy" quirk.
+static func _dvs_match(mon1: Gen2SaveMon, mon2: Gen2SaveMon) -> bool:
+	return Gen2Stats.defense_dv(mon1.dvs) == Gen2Stats.defense_dv(mon2.dvs) \
+		and _low_bits(mon1.dvs) == _low_bits(mon2.dvs)
+
+
+## The low three bits of a DV word's second byte, which is the Special DV's own
+## low three: the byte is the Speed DV over the Special DV.
+static func _low_bits(dvs: int) -> int:
+	return dvs & 0x07
+
+
+static func _can_learn_tm_hm(data: GameData, species: int, number: int) -> bool:
+	var flags: Variant = data.species(species).get("tmhm", [])
+	if not flags is Array:
+		return false
+	var bit: int = number - 1
+	var index: int = bit >> 3
+	if index >= (flags as Array).size():
+		return false
+	return int((flags as Array)[index]) & (1 << (bit & 7)) != 0
+
+
+## `CheckCurPartyMonFainted`, which is `.OutOfUsableMons` when no *other* member
+## can still walk.
+static func _last_healthy(save: Gen2SaveData, party_index: int) -> bool:
+	for index: int in save.party.size():
+		if index == party_index:
+			continue
+		var other: Gen2SaveMon = save.party[index] as Gen2SaveMon
+		if other != null and not other.is_egg and other.hp > 0:
+			return false
+	return true
+
+
+## `.day_care_lady`'s three `inc [hl]`: one point of experience, with the high
+## byte held at `MAX_DAY_CARE_EXP`'s own on the pass a carry reaches it.
+static func _day_care_exp_after(exp: int) -> int:
+	var raised: int = (exp + 1) & 0xFFFFFF
+	if raised & 0xFFFF == 0 and raised >> 16 >= MAX_DAY_CARE_EXP >> 16:
+		return MAX_DAY_CARE_EXP
+	return raised
+
+
+static func _random_byte(random: RandomNumberGenerator) -> int:
+	if random == null:
+		return 0
+	return random.randi_range(0, 255)

--- a/game/world/world_day_care.gd.uid
+++ b/game/world/world_day_care.gd.uid
@@ -1,0 +1,1 @@
+uid://dm620cg7rg1sh

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -129,6 +129,16 @@ static func name_rater_texts(data: GameData) -> Dictionary:
 static func move_deleter_texts(data: GameData) -> Dictionary:
 	return _stub_run(data, RomLayout.MOVE_DELETER_TEXT_ORDER, "move_deleter_text")
 
+## The Day-Care's own thirty-two, across its four runs, read and refused the same
+## way. Public for the same reason: the screenshot driver opens the routine with
+## no script behind it.
+static func day_care_texts(data: GameData) -> Dictionary:
+	var order: Array[String] = []
+	for run: Array in RomLayout.DAY_CARE_TEXT_RUNS:
+		for name: Variant in run[1] as Array:
+			order.append(String(name))
+	return _stub_run(data, order, "day_care_text")
+
 
 ## One whole run of `text_far` stubs off [GameData], or nothing: a run missing a
 ## box is a cache too old for the routine that reads it, not a box to work round.
@@ -177,6 +187,8 @@ static func _reason_for(kind: StringName) -> StringName:
 			return &"name_rater_data_unavailable"
 		&"move_deleter_requested":
 			return &"move_deleter_data_unavailable"
+		&"day_care_requested":
+			return &"day_care_data_unavailable"
 		&"pc_requested":
 			return &"pc_host_unavailable"
 	return &"runtime_host_unavailable"
@@ -221,6 +233,11 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 			if boxes.is_empty():
 				return {"ok": false, "reason": &"move_deleter_text_unavailable"}
 			return {"ok": true, "data": {"move_deleter_text": boxes}}
+		&"day_care_requested":
+			var day_care: Dictionary = day_care_texts(world.data)
+			if day_care.is_empty():
+				return {"ok": false, "reason": &"day_care_text_unavailable"}
+			return {"ok": true, "data": {"day_care_text": day_care}}
 		&"apricorn_selection_requested":
 			## `FindApricornsInBag` is the whole of the request's data: an empty
 			## bag is the source's own refusal, not a missing host.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -153,6 +153,13 @@ var _name_rater_save: Gen2SaveData = null
 ## `special MoveDeletion`'s screen. It needs no save of its own beside it: the
 ## moves and their PP belong to the save it was handed and it writes them itself.
 var _move_deleter_host: Gen2MoveDeleterScreen = null
+## The Day-Care's five routines, all one screen. It edits the save's party and
+## the world state directly, which is what `DepositBreedmon` and `RetrieveBreedmon`
+## do, so the save it was handed is kept beside it only to write nothing else.
+var _day_care_host: Gen2DayCareScreen = null
+## What `DayCareManOutside` left in wScriptVar, held between the screen finishing
+## and the request completing. -1 while no routine has written one.
+var _day_care_script_value: int = -1
 ## Whether a field-move message is on screen waiting for its acknowledge. The
 ## world is idle while it is, the same way a script text pause holds it.
 var _field_move_text: bool = false
@@ -193,6 +200,8 @@ var _encounter_random := RandomNumberGenerator.new()
 ## NPC movement rolls from its own generator, so a seeded route keeps the same
 ## encounters and script results however long the player stands watching.
 var _object_random := RandomNumberGenerator.new()
+## The Day-Care's rolls, from a stream of their own for the same reason.
+var _breed_random := RandomNumberGenerator.new()
 var _selected_rod: StringName = Gen2WorldEncounter.METHOD_OLD_ROD
 ## Real time banked toward the next hardware frame. The overworld's one clock:
 ## see [method _process].
@@ -315,11 +324,13 @@ func _build_world() -> void:
 	## One seed, two streams: the second is offset so the object generator is not
 	## a replay of the encounter one.
 	_object_random.seed = run_seed + 1
+	_breed_random.seed = run_seed + 2
 	_world.random_seed = run_seed
 
 	_world.schedule_random = _encounter_random
 	_world.script_random = _encounter_random
 	_world.object_random = _object_random
+	_world.breed_random = _breed_random
 	_clock = Gen2WorldClock.new(initial_hour, initial_minute, initial_day)
 	time_of_day = _clock.time_of_day()
 	_animation = Gen2WorldAnimation.new()
@@ -667,6 +678,8 @@ func advance_frame() -> void:
 		_name_rater_host.advance_frame()
 	if _move_deleter_host != null:
 		_move_deleter_host.advance_frame()
+	if _day_care_host != null:
+		_day_care_host.advance_frame()
 	_spending_frame = false
 
 
@@ -810,7 +823,8 @@ func _overlay_open() -> bool:
 		or _hall_of_fame_host != null or _trainer_card_host != null \
 		or _pokedex_host != null or _credits_host != null \
 		or _evolution_host != null or _hatch_host != null \
-		or _name_rater_host != null or _move_deleter_host != null
+		or _name_rater_host != null or _move_deleter_host != null \
+		or _day_care_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -918,6 +932,10 @@ func _handle_button(button: int) -> bool:
 	## `special MoveDeletion` is the same shape one house further on.
 	if _move_deleter_host != null:
 		_move_deleter_host.handle_button(button)
+		return true
+	## The Day-Care's five, one screen with the same shape again.
+	if _day_care_host != null:
+		_day_care_host.handle_button(button)
 		return true
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -1175,6 +1193,7 @@ func _complete_player_step(movement: Dictionary) -> bool:
 	## check `CheckWarpTile` refuses for a carpet.
 	_spend_step_happiness()
 	_spend_egg_steps()
+	_spend_day_care_steps()
 	var kind: StringName = StringName(movement.get("kind", &""))
 	if kind == &"edge_warp" or (kind in [
 		&"move", &"ledge_hop", &"water_move", &"exit_water", &"forced_move",
@@ -1232,6 +1251,23 @@ func _spend_egg_steps() -> void:
 	if hatches.is_empty():
 		return
 	_open_hatch(hatches, save)
+
+
+## `DayCareStep`, which `CountStep` reaches on every step that did not hatch an
+## egg: `jr nz, .hatch` jumps over the `farcall`, and the hatch screen standing
+## is what says this step was one of those.
+##
+## The two slots live in the world state rather than on the save, so nothing here
+## is a save transaction; what it can produce is `DAYCAREMAN_HAS_EGG_F`, which
+## the man outside the Day-Care reads.
+func _spend_day_care_steps() -> void:
+	if _world == null or _world.state == null or _data == null:
+		return
+	var owed: int = _world.state.take_pending_day_care_steps()
+	if owed <= 0 or _hatch_host != null:
+		return
+	for _pass: int in owed:
+		Gen2WorldDayCare.step(_world.state, _data, _breed_random)
 
 
 ## `OverworldHatchEgg`. The rows are already written; the screen owns the
@@ -1330,6 +1366,66 @@ func _on_name_rater_closed() -> void:
 		_renderer.refresh()
 	if _world != null:
 		_show_script_results(_world.complete_runtime_request({"ok": true}))
+	_refresh_labels()
+
+
+## The Day-Care's five specials, hosted exactly as `special NameRater` is. The
+## routine writes the party, the two slots and the money itself, so nothing is
+## staged: the cartridge's own routines write WRAM straight and the save is only
+## committed when the player saves.
+func _open_day_care(request: Dictionary) -> bool:
+	if _day_care_host != null or _world == null or _data == null:
+		return false
+	var texts: Dictionary = Gen2WorldHost.day_care_texts(_data)
+	if texts.is_empty():
+		_script_prompt = "Day-Care unavailable: day_care_text_unavailable"
+		return false
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null:
+		_script_prompt = "The Day-Care needs a validated save"
+		return false
+	var host := Gen2DayCareScreen.new()
+	host.set_context(
+		_data, save, _world.state,
+		StringName((request.get("values", {}) as Dictionary).get("role", &"man")),
+		texts, _world.player_name(), _world.player_id(), _breed_random
+	)
+	host.finished.connect(_on_day_care_finished)
+	host.closed.connect(_on_day_care_closed)
+	host.cry_requested.connect(_play_species_cry)
+	host.sfx_requested.connect(_play_sfx)
+	host.z_index = 30
+	_day_care_host = host
+	_screen.display(host)
+	_script_prompt = "Day-Care"
+	_refresh_labels()
+	return true
+
+
+## `DayCareManOutside`'s own wScriptVar, and the box the map script's
+## `waitbutton` presses. -1 is the four routines that write no variable.
+func _on_day_care_finished(script_value: int, ending_text: String) -> void:
+	_day_care_script_value = script_value
+	if not ending_text.is_empty() and _text_box != null and _text_box.font != null:
+		_apply_text_box_options()
+		_text_awaits_press = false
+		_text_box.show_text(ending_text, false)
+		_text_box.visible = true
+
+
+func _on_day_care_closed() -> void:
+	var host: Gen2DayCareScreen = _day_care_host
+	_day_care_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	if _world != null:
+		var completion: Dictionary = {"ok": true}
+		if _day_care_script_value >= 0:
+			completion["script_value"] = _day_care_script_value
+		_day_care_script_value = -1
+		_show_script_results(_world.complete_runtime_request(completion))
 	_refresh_labels()
 
 
@@ -2245,6 +2341,35 @@ func preview_name_rater() -> void:
 	_injected_save = save
 	_world.set_player_id(save.player_id)
 	_open_name_rater()
+
+
+## Public screenshot driver for the Day-Care's five specials, which no cell of
+## the fixture maps reaches either. [param role] picks the routine; the two signs
+## and the man outside need state behind them, so a slot is filled and the egg
+## flag set before the screen opens.
+func preview_day_care(role: StringName) -> void:
+	if _world == null or _data == null or _day_care_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.size() < 2:
+		_script_prompt = "The Day-Care preview needs two party members"
+		_refresh_labels()
+		return
+	_injected_save = save
+	_world.set_player_id(save.player_id)
+	var state: Gen2WorldState = _world.state
+	if role in [&"mon1", &"mon2"]:
+		for slot: int in [
+			Gen2WorldDayCare.SLOT_MAN, Gen2WorldDayCare.SLOT_LADY
+		]:
+			state.set_day_care_mon(slot, save.party[slot] as Gen2SaveMon)
+			state.set_day_care_has_mon(slot, true)
+	elif role == &"outside":
+		state.set_day_care_man_flags(
+			state.day_care_man_flags() | Gen2WorldDayCare.MAN_HAS_EGG
+		)
+		state.set_day_care_egg(save.party[0] as Gen2SaveMon)
+	_open_day_care({"values": {"role": role}})
 
 
 ## Public screenshot driver and scene-test entry for `OverworldHatchEgg`: it
@@ -4571,6 +4696,10 @@ func _show_script_results(results: Array) -> void:
 					continue
 				if StringName(request.get("kind", &"")) == &"move_deleter_requested":
 					if _open_move_deleter():
+						break
+					continue
+				if StringName(request.get("kind", &"")) == &"day_care_requested":
+					if _open_day_care(request):
 						break
 					continue
 				if StringName(request.get("kind", &"")) == &"swarm_requested":

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -168,6 +168,26 @@ const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
 ## the same shape `NameRater` does, one house further on, so it is one host
 ## request as well.
 const SPECIAL_MOVE_DELETION: int = 33
+## The Day-Care's five, all below the first index the two tables disagree on, so
+## `special_index()` leaves them alone. `DayCareMan` and `DayCareLady` are the
+## deposit and withdrawal counters; `DayCareManOutside` is the man who brings the
+## egg out and the only one of the five that writes wScriptVar, which its map
+## script branches on; `DayCareMon1` and `DayCareMon2` are the two signs inside,
+## each a line, a cry and the pair's compatibility.
+const SPECIAL_DAY_CARE_MAN: int = 30
+const SPECIAL_DAY_CARE_LADY: int = 31
+const SPECIAL_DAY_CARE_MAN_OUTSIDE: int = 32
+const SPECIAL_DAY_CARE_MON_1: int = 69
+const SPECIAL_DAY_CARE_MON_2: int = 70
+## Which routine each index opens, in the request the host answers.
+const DAY_CARE_ROLE_OF: Dictionary = {
+	SPECIAL_DAY_CARE_MAN: &"man",
+	SPECIAL_DAY_CARE_LADY: &"lady",
+	SPECIAL_DAY_CARE_MAN_OUTSIDE: &"outside",
+	SPECIAL_DAY_CARE_MON_1: &"mon1",
+	SPECIAL_DAY_CARE_MON_2: &"mon2",
+}
+
 ## NameRater, 87 in Crystal and 86 in Gold/Silver, which special_index()
 ## already normalizes. `_NameRater` owns its own texts, its two `YesNoBox`es and
 ## the party list `SelectMonFromParty` opens, so the whole routine is one host
@@ -842,6 +862,24 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 			)
 		_events.append({
 			"type": &"trainer_approach_completed",
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
+		return advance()
+	if kind == &"day_care_requested":
+		## Four of the five write nothing a script reads, so wScriptVar is left
+		## where it stood unless the result carries one: `DayCareManOutside` is
+		## the only routine of the five with an `ld [wScriptVar], a` in it.
+		if not bool(result.get("ok", false)):
+			return _fail(
+				StringName(result.get("reason", &"runtime_request_failed")), result
+			)
+		if result.has("script_value"):
+			_script_value = int(result["script_value"])
+		_events.append({
+			"type": &"runtime_request_completed",
+			"kind": kind,
 			"request": request.duplicate(true),
 			"result": result.duplicate(true),
 		})
@@ -2740,6 +2778,15 @@ func _execute_special(special: int) -> Dictionary:
 				"kind": _money_window,
 				"money": _money_balance(ACCOUNT_YOUR_MONEY),
 				"coins": _coins_value(),
+			})
+		SPECIAL_DAY_CARE_MAN, SPECIAL_DAY_CARE_LADY, SPECIAL_DAY_CARE_MAN_OUTSIDE, \
+		SPECIAL_DAY_CARE_MON_1, SPECIAL_DAY_CARE_MON_2:
+			## Each of the five owns its own boxes, and the two counters own the
+			## party list and both `YesNoBox`es as well, so the whole routine is
+			## one host request the way `NameRater` is.
+			return _stage_runtime_request(&"day_care_requested", {
+				"special": special,
+				"role": DAY_CARE_ROLE_OF[special],
 			})
 		SPECIAL_NAME_RATER:
 			return _stage_runtime_request(&"name_rater_requested", {

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -147,6 +147,18 @@ var _pending_step_happiness: int = 0
 ## is `$80`, so an egg loses one hatch cycle every 256 steps offset 128 from the
 ## happiness pass.
 var _pending_egg_steps: int = 0
+## `wDayCareMan` and `wDayCareLady`, their two boxmon slots, `wStepsToEgg` and
+## the `wEggMon` the pair built. The slots are [Gen2SaveMon] rather than party
+## members: a deposited Pokemon leaves the party whole and comes back recomputed,
+## which is what `DepositBreedmon` and `RetrieveBreedmon` do.
+var _day_care_man: int = 0
+var _day_care_lady: int = 0
+var _day_care_mons: Array = [null, null]
+var _steps_to_egg: int = 0
+var _day_care_egg: Gen2SaveMon = null
+## `DayCareStep` runs on every step, not on a phase of the counter, so this is
+## the whole step rather than a 256-step remainder.
+var _pending_day_care_steps: int = 0
 ## `wStatusFlags`' `STATUSFLAGS_NO_WILD_ENCOUNTERS_F`, which `wildoff` sets and
 ## `wildon` clears around a scripted sequence.
 var _wild_encounters_off: bool = false
@@ -322,6 +334,11 @@ func to_dict() -> Dictionary:
 		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
 		"picked_fruit_trees": _picked_fruit_trees.duplicate(),
 		"registered_item": _registered_item,
+		"day_care_man": _day_care_man,
+		"day_care_lady": _day_care_lady,
+		"day_care_mons": _day_care_mons_dict(),
+		"steps_to_egg": _steps_to_egg,
+		"day_care_egg": {} if _day_care_egg == null else _day_care_egg.to_dict(),
 	}
 
 
@@ -400,6 +417,17 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored.set_contest_second_party_species(
 		int(source.get("contest_second_party_species", 0))
 	)
+	## Absent in a state written before the Day-Care existed, which restores as
+	## two empty slots: nothing is deposited, so no flag, counter or egg has
+	## anything to be wrong about.
+	restored._day_care_man = int(source.get("day_care_man", 0)) & 0xFF
+	restored._day_care_lady = int(source.get("day_care_lady", 0)) & 0xFF
+	restored._steps_to_egg = int(source.get("steps_to_egg", 0)) & 0xFF
+	var stored_mons: Variant = source.get("day_care_mons", [])
+	if stored_mons is Array:
+		for slot: int in mini((stored_mons as Array).size(), 2):
+			restored._day_care_mons[slot] = _mon_from_value((stored_mons as Array)[slot])
+	restored._day_care_egg = _mon_from_value(source.get("day_care_egg", {}))
 	return restored
 
 
@@ -449,6 +477,12 @@ func restore_from_dict(raw: Variant) -> void:
 	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
 	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
 	_registered_item = restored._registered_item
+	_day_care_man = restored._day_care_man
+	_day_care_lady = restored._day_care_lady
+	_day_care_mons = restored._day_care_mons.duplicate()
+	_steps_to_egg = restored._steps_to_egg
+	_day_care_egg = restored._day_care_egg
+	_pending_day_care_steps = 0
 	changed.emit()
 
 
@@ -1066,6 +1100,10 @@ func count_step() -> void:
 			_pending_step_happiness += 1
 	if _step_count == EGG_STEP_PHASE:
 		_pending_egg_steps += 1
+	## `farcall DayCareStep` sits after the egg branch and runs on every other
+	## step; a step that hatches jumps over it, which the spender settles because
+	## only it knows whether an egg came out.
+	_pending_day_care_steps += 1
 	if _repel_steps > 0:
 		_repel_steps -= 1
 	changed.emit()
@@ -1092,6 +1130,117 @@ func take_pending_egg_steps() -> int:
 	var owed: int = _pending_egg_steps
 	_pending_egg_steps = 0
 	return owed
+
+
+## The same for the owed `DayCareStep` passes. `CountStep` reaches it on every
+## step and skips it on the one a `DoEggStep` hatch takes, which is
+## `jr nz, .hatch` jumping over the `farcall`.
+func take_pending_day_care_steps() -> int:
+	var owed: int = _pending_day_care_steps
+	_pending_day_care_steps = 0
+	return owed
+
+
+func day_care_man_flags() -> int:
+	return _day_care_man
+
+
+func set_day_care_man_flags(flags: int) -> void:
+	var next_flags: int = flags & 0xFF
+	if _day_care_man == next_flags:
+		return
+	_day_care_man = next_flags
+	changed.emit()
+
+
+func day_care_lady_flags() -> int:
+	return _day_care_lady
+
+
+func set_day_care_lady_flags(flags: int) -> void:
+	var next_flags: int = flags & 0xFF
+	if _day_care_lady == next_flags:
+		return
+	_day_care_lady = next_flags
+	changed.emit()
+
+
+## Whether the slot holds a Pokemon. The bit is on the man's byte for slot 0 and
+## the lady's for slot 1, and both are bit 0.
+func day_care_has_mon(slot: int) -> bool:
+	if slot == Gen2WorldDayCare.SLOT_MAN:
+		return _day_care_man & Gen2WorldDayCare.MAN_HAS_MON != 0
+	return _day_care_lady & Gen2WorldDayCare.LADY_HAS_MON != 0
+
+
+func set_day_care_has_mon(slot: int, held: bool) -> void:
+	if slot == Gen2WorldDayCare.SLOT_MAN:
+		set_day_care_man_flags(
+			(_day_care_man | Gen2WorldDayCare.MAN_HAS_MON) if held
+			else (_day_care_man & ~Gen2WorldDayCare.MAN_HAS_MON)
+		)
+		return
+	set_day_care_lady_flags(
+		(_day_care_lady | Gen2WorldDayCare.LADY_HAS_MON) if held
+		else (_day_care_lady & ~Gen2WorldDayCare.LADY_HAS_MON)
+	)
+
+
+## A copy of the slot's own record, so a caller that raises its experience has to
+## put it back through [method set_day_care_mon] and cannot edit the state by
+## reference.
+func day_care_mon(slot: int) -> Gen2SaveMon:
+	if slot < 0 or slot >= _day_care_mons.size():
+		return null
+	return _copy_mon(_day_care_mons[slot])
+
+
+func set_day_care_mon(slot: int, mon: Gen2SaveMon) -> void:
+	if slot < 0 or slot >= _day_care_mons.size():
+		return
+	_day_care_mons[slot] = _copy_mon(mon)
+	changed.emit()
+
+
+func steps_to_egg() -> int:
+	return _steps_to_egg
+
+
+func set_steps_to_egg(steps: int) -> void:
+	var next_steps: int = steps & 0xFF
+	if _steps_to_egg == next_steps:
+		return
+	_steps_to_egg = next_steps
+	changed.emit()
+
+
+## `wEggMon`, built when the counter starts and handed over when it runs out.
+func day_care_egg() -> Gen2SaveMon:
+	return _copy_mon(_day_care_egg)
+
+
+func set_day_care_egg(mon: Gen2SaveMon) -> void:
+	_day_care_egg = _copy_mon(mon)
+	changed.emit()
+
+
+func _day_care_mons_dict() -> Array:
+	var out: Array = []
+	for mon: Variant in _day_care_mons:
+		out.append({} if mon == null else (mon as Gen2SaveMon).to_dict())
+	return out
+
+
+static func _copy_mon(mon: Gen2SaveMon) -> Gen2SaveMon:
+	return null if mon == null else Gen2SaveMon.from_dict(mon.to_dict())
+
+
+static func _mon_from_value(raw: Variant) -> Gen2SaveMon:
+	if not raw is Dictionary or (raw as Dictionary).is_empty():
+		return null
+	if int((raw as Dictionary).get("species", 0)) <= 0:
+		return null
+	return Gen2SaveMon.from_dict(raw)
 
 
 func swarm_map() -> Vector2i:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -94,6 +94,7 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_menu_text(manifest)
 	_write_name_rater_text(manifest)
 	_write_move_deleter_text(manifest)
+	_write_day_care_text(manifest)
 	_write_pokecenter_pc(manifest)
 	_write_unown_words(manifest)
 	_write_credits(directory, manifest, crystal_commands)
@@ -414,6 +415,80 @@ static func _write_move_deleter_text(manifest: Dictionary) -> void:
 		"intro": "Um… I'm the MOVE\nDELETER.",
 		"which_mon": "Which POKéMON?",
 	}
+
+
+## The Day-Care's thirty-three, shortened to the two things the routines read:
+## which of them waits for a press, and the markers `_IllRaiseYourMonText`,
+## `_YourMonHasGrownText` and `_GotBackMonText` carry.
+static func _write_day_care_text(manifest: Dictionary) -> void:
+	var texts: Dictionary = {
+		"man_intro": "I'm the DAY-CARE
+MAN.",
+		"man_intro_egg": "Do you know about
+EGGS?",
+		"lady_intro": "I'm the DAY-CARE
+LADY.",
+		"lady_intro_egg": "Do you know about
+EGGS?",
+		"which_one": "What should I
+raise for you?",
+		"only_one_mon": "But you have just
+one POKéMON.",
+		"cant_accept_egg": "I can't accept an
+EGG.",
+		"remove_mail": "Remove MAIL before
+you come see me.",
+		"last_healthy_mon": "What will you
+battle with?",
+		"ill_raise": "OK. I'll raise
+your <RAM_D073>.",
+		"come_back_later": "Come back for it
+later.",
+		"are_we_geniuses": "Want to see your
+<RAM_D073>?",
+		"has_grown": "Grown by <NUM_D074>.
+It costs ¥<NUM_D075>.",
+		"perfect_heres_your_mon": "Perfect! Here's
+your POKéMON.",
+		"got_back": "<PLAYER> got back
+<RAM_D073>.",
+		"back_already": "Back already? It
+needs more time.",
+		"have_no_room": "You have no room
+for it.",
+		"not_enough_money": "You don't have
+enough money.",
+		"oh_fine_then": "Oh, fine then.",
+		"come_again": "Come again.",
+		"not_yet": "Not yet…",
+		"found_an_egg": "Your POKéMON had
+an EGG! You want it?",
+		"received_egg": "<PLAYER> received
+the EGG!",
+		"take_good_care": "Take good care of
+it.",
+		"ill_keep_it": "Well then, I'll
+keep it. Thanks!",
+		"no_room_for_egg": "You have no room
+in your party.",
+		"left_with_lady": "It's <RAM_DEF6> that
+was left with the
+DAY-CARE LADY.",
+		"left_with_man": "It's <RAM_DEF6> that
+was left with the
+DAY-CARE MAN.",
+		"brimming_with_energy": "It's brimming with
+energy.",
+		"no_interest": "It has no interest
+in <RAM_D073>.",
+		"appears_to_care": "It appears to care
+for <RAM_D073>.",
+		"friendly": "It's friendly with
+<RAM_D073>.",
+		"shows_interest": "It shows interest
+in <RAM_D073>.",
+	}
+	manifest["day_care_text"] = texts
 
 
 ## The start menu's nine descriptions and the pack's five texts, as the cartridge

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -36,6 +36,18 @@ const HOOTHOOT: int = 163
 ## The highest species number this table fills.
 const MAX_SPECIES: int = MAGCARGO
 
+## `constants/pokemon_data_constants.asm`'s egg groups, the four the fixture uses.
+const EGG_MONSTER: int = 1
+const EGG_FIELD: int = 5
+const EGG_PLANT: int = 7
+const EGG_DITTO: int = 13
+const EGG_NONE: int = 15
+## `wBaseEggSteps`, the hatch counter every fixture species starts an egg on.
+const HATCH_CYCLES: int = 20
+## Eight `TMHMMoves` bytes with the first TM's bit set and nothing else, which is
+## the one flag [method Gen2WorldDayCare.inherits_move] asks about.
+const TMHM_FLAGS: Array = [1, 0, 0, 0, 0, 0, 0, 0]
+
 const TACKLE: int = 33
 const EMBER: int = 52
 const THUNDERBOLT: int = 85
@@ -209,6 +221,9 @@ const DREAM_EATER_MOVE: int = 263
 
 ## The four fixed-damage effects sharing one command.
 const LEVEL_DAMAGE_MOVE: int = 264
+## `TMHMMoves`' only entry here, which is the one move the fixture's TM flag byte
+## says a species can be taught.
+const TM01_MOVE: int = LEVEL_DAMAGE_MOVE
 const STATIC_DAMAGE_MOVE: int = 265
 const SUPER_FANG_MOVE: int = 266
 const PSYWAVE_MOVE: int = 267
@@ -418,6 +433,9 @@ static func build(directory: String, id: String = "testgame") -> GameData:
 	RomCache.write_json(RomCache.matchups_path(directory), _matchups())
 	RomCache.write_json(RomCache.trainers_path(directory), [])
 	RomCache.write_json(RomCache.happiness_changes_path(directory), HAPPINESS_CHANGES)
+	## `TMHMMoves` with one entry, which is what the fixture's TM flag byte
+	## names: enough for `CanLearnTMHMMove` to have a table to answer from.
+	RomCache.write_json(RomCache.tmhm_moves_path(directory), [TM01_MOVE])
 	RomCache.write_json(RomCache.manifest_path(directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": id,
@@ -481,6 +499,17 @@ static func _species() -> Array:
 		],
 	}
 
+	## The breeding half of a base-stats record, which nothing in a battle reads
+	## and everything in the Day-Care does. Ditto is in its own group, Marowak is
+	## the fixture's No Eggs species, and the rest share EGG_FIELD so an ordinary
+	## pair breeds. `hatch_cycles` and the TM flags are the same for all of them:
+	## the routines read them, and no case here turns on which value.
+	var egg_groups: Dictionary = {
+		DITTO: [EGG_DITTO, EGG_DITTO],
+		MAROWAK: [EGG_NONE, EGG_NONE],
+		BULBASAUR: [EGG_MONSTER, EGG_PLANT],
+	}
+
 	var out: Array = []
 	for number: int in range(1, MAX_SPECIES + 1):
 		var entry: Array = known.get(number, [
@@ -504,6 +533,10 @@ static func _species() -> Array:
 				"condition": 0, "target": 2,
 			}] if number == BULBASAUR else [],
 			"gender_ratio": entry[6],
+			"egg_groups": egg_groups.get(number, [EGG_FIELD, EGG_FIELD]),
+			"hatch_cycles": HATCH_CYCLES,
+			"tmhm": TMHM_FLAGS.duplicate(),
+			"egg_moves": [] if number != HOOTHOOT else [MIST_MOVE],
 			"front_tiles": [7, 7],
 			"dex": {
 				"category": "%s MON" % entry[0],

--- a/tests/unit/test_learnset.gd
+++ b/tests/unit/test_learnset.gd
@@ -122,3 +122,26 @@ func test_four_slots_is_what_a_battler_carries() -> void:
 	# The two constants are the same number seen from either side of the line, and
 	# a Pokémon that knew five would be trimmed silently on its way into a battle.
 	assert_eq(Gen2Learnset.MOVE_SLOTS, Gen2BattleMon.MAX_MOVES)
+
+
+func test_the_skip_branch_teaches_only_the_levels_between_the_two() -> void:
+	# `wSkipMovesBeforeLevelUp`, which is what a Day-Care retrieval fills with:
+	# a Golbat deposited at 12 and taken back at 19 is offered Confuse Ray and
+	# nothing it already knew.
+	var known: Array = [SCREECH, LEECH_LIFE, SUPERSONIC, BITE]
+	Gen2Learnset.fill_moves(_golbat(), known, 19, 12)
+	assert_eq(known, [LEECH_LIFE, SUPERSONIC, BITE, CONFUSE_RAY])
+
+
+func test_the_skip_branch_fills_an_empty_slot_before_it_shifts() -> void:
+	var known: Array = [SCREECH, 0, 0, 0]
+	Gen2Learnset.fill_moves(_golbat(), known, 19, 12)
+	assert_eq(known, [SCREECH, CONFUSE_RAY, 0, 0])
+
+
+func test_a_move_learned_at_the_level_deposited_at_is_not_offered_again() -> void:
+	# `cp b / jr nc, .GetMove` skips the level itself, so a Golbat put in at 19
+	# and taken out at 19 learns nothing.
+	var known: Array = [SCREECH, 0, 0, 0]
+	Gen2Learnset.fill_moves(_golbat(), known, 19, 19)
+	assert_eq(known, [SCREECH, 0, 0, 0])

--- a/tests/unit/test_world_day_care.gd
+++ b/tests/unit/test_world_day_care.gd
@@ -1,0 +1,433 @@
+extends GutTest
+
+## `engine/events/daycare.asm` and `engine/pokemon/breeding.asm`, the rules half.
+##
+## Everything here is scene-free: the two slots are world state and
+## [Gen2WorldDayCare] is static, so a case builds two Pokemon and reads an
+## answer. The corpus sweep on real cartridges is `tools/checks/day_care.gd`; the
+## point of these is the branches a corpus cannot single out, which is every one
+## that turns on gender, on Ditto, or on the order two writes happen in.
+
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
+## The fixture's own species. Cubone and Hoothoot share EGG_FIELD, Bulbasaur is
+## in two other groups, Marowak is the No Eggs species and Ditto is alone in its.
+const CUBONE: int = Fixture.CUBONE
+const MAROWAK: int = Fixture.MAROWAK
+const HOOTHOOT: int = Fixture.HOOTHOOT
+const BULBASAUR: int = Fixture.BULBASAUR
+const IVYSAUR: int = 2
+const DITTO: int = Fixture.DITTO
+
+## Two DV words giving opposite genders at GENDER_F50, whose Defense DVs and
+## Special low bits differ so `.CheckDVs` does not refuse the pair. The Attack
+## and Speed nibbles are what `GetGender` reads: `$0` is male at a 127 ratio and
+## `$F` is female.
+const MALE_DVS: int = 0x0A05
+const FEMALE_DVS: int = 0xF3FE
+
+const CACHE_ID: StringName = &"daycaretest"
+const CACHE_SHA1: String = "0123456789abcdef"
+
+var _data: GameData = null
+
+
+func before_each() -> void:
+	_data = Fixture.build(RomCache.directory_for(CACHE_ID, CACHE_SHA1))
+
+
+func _mon(species: int, dvs: int = MALE_DVS, ot_id: int = 100) -> Gen2SaveMon:
+	var mon: Gen2SaveMon = Gen2SaveMon.new()
+	mon.species = species
+	mon.dvs = dvs
+	mon.ot_id = ot_id
+	mon.level = 10
+	mon.hp = 20
+	mon.exp = Gen2Experience.total_exp_at(
+		int(_data.species(species).get("growth_rate", 0)), 10
+	)
+	mon.nickname = String(_data.species(species).get("name", ""))
+	return mon
+
+
+func _state() -> Gen2WorldState:
+	return Gen2WorldState.new()
+
+
+func _seeded(value: int) -> RandomNumberGenerator:
+	var random := RandomNumberGenerator.new()
+	random.seed = value
+	return random
+
+
+func test_a_no_eggs_species_is_refused_whatever_it_is_paired_with() -> void:
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(MAROWAK, MALE_DVS), _mon(CUBONE, FEMALE_DVS)
+		), 0
+	)
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(MAROWAK, MALE_DVS), _mon(DITTO, FEMALE_DVS)
+		), 0
+	)
+
+
+func test_two_dittos_never_breed() -> void:
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(DITTO, MALE_DVS), _mon(DITTO, FEMALE_DVS)
+		), 0
+	)
+
+
+func test_ditto_breeds_with_a_genderless_species_no_other_pair_could() -> void:
+	# `.genderless` is reached by the genderless parent and answered by the one
+	# Ditto, which is the whole of why a Ditto pairing needs no gender at all.
+	assert_gt(
+		Gen2WorldDayCare.compatibility(_data, _mon(DITTO, MALE_DVS), _mon(CUBONE, FEMALE_DVS)),
+		0
+	)
+
+
+func test_two_of_the_same_gender_are_refused() -> void:
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(CUBONE, MALE_DVS, 100), _mon(HOOTHOOT, MALE_DVS + 0x0100, 200)
+		), 0
+	)
+
+
+func test_matching_defence_and_special_dvs_are_the_255_refusal() -> void:
+	# `.CheckDVs`, which answers 255 rather than 0: the pair reads as brimming
+	# with energy and still never produces an egg.
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(CUBONE, 0x0F05, 100), _mon(HOOTHOOT, 0xFF05, 200)
+		), 255
+	)
+	assert_eq(Gen2WorldDayCare.compatibility_text_key(255), "brimming_with_energy")
+
+
+func test_the_same_species_from_different_trainers_is_the_best_pair() -> void:
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(CUBONE, MALE_DVS, 100), _mon(CUBONE, FEMALE_DVS, 200)
+		), 254
+	)
+
+
+func test_a_shared_trainer_id_costs_seventy_seven() -> void:
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(CUBONE, MALE_DVS, 100), _mon(CUBONE, FEMALE_DVS, 100)
+		), 177
+	)
+	assert_eq(
+		Gen2WorldDayCare.compatibility(
+			_data, _mon(CUBONE, MALE_DVS, 100), _mon(HOOTHOOT, FEMALE_DVS, 100)
+		), 51
+	)
+
+
+func test_the_five_compatibility_lines_are_the_routines_own_order() -> void:
+	assert_eq(Gen2WorldDayCare.compatibility_text_key(0), "no_interest")
+	assert_eq(Gen2WorldDayCare.compatibility_text_key(254), "appears_to_care")
+	assert_eq(Gen2WorldDayCare.compatibility_text_key(177), "friendly")
+	assert_eq(Gen2WorldDayCare.compatibility_text_key(51), "shows_interest")
+
+
+func test_the_mother_is_the_female_and_the_non_ditto() -> void:
+	assert_eq(
+		Gen2WorldDayCare.mother_or_non_ditto(
+			_data, _mon(CUBONE, FEMALE_DVS), _mon(HOOTHOOT, MALE_DVS)
+		), Gen2WorldDayCare.SLOT_MAN
+	)
+	assert_eq(
+		Gen2WorldDayCare.mother_or_non_ditto(
+			_data, _mon(CUBONE, MALE_DVS), _mon(HOOTHOOT, FEMALE_DVS)
+		), Gen2WorldDayCare.SLOT_LADY
+	)
+	# A Ditto decides it before any gender is read, in either slot.
+	assert_eq(
+		Gen2WorldDayCare.mother_or_non_ditto(
+			_data, _mon(DITTO, FEMALE_DVS), _mon(CUBONE, FEMALE_DVS)
+		), Gen2WorldDayCare.SLOT_LADY
+	)
+
+
+func test_the_egg_is_the_mothers_base_form() -> void:
+	# Bulbasaur is the fixture's only evolution, so Ivysaur is the one species
+	# with a pre-evolution to find.
+	assert_eq(Gen2WorldDayCare.pre_evolution(_data, IVYSAUR), BULBASAUR)
+	assert_eq(Gen2WorldDayCare.pre_evolution(_data, BULBASAUR), BULBASAUR)
+	assert_eq(
+		Gen2WorldDayCare.egg_species(_data, IVYSAUR, _seeded(1)), BULBASAUR
+	)
+
+
+func test_a_deposit_takes_the_member_out_of_the_party_whole() -> void:
+	var state: Gen2WorldState = _state()
+	var save: Gen2SaveData = Gen2SaveData.new()
+	save.party = [_mon(CUBONE), _mon(HOOTHOOT)]
+	assert_true(Gen2WorldDayCare.deposit(state, save, Gen2WorldDayCare.SLOT_MAN, 0))
+	assert_eq(save.party.size(), 1)
+	assert_true(state.day_care_has_mon(Gen2WorldDayCare.SLOT_MAN))
+	assert_eq(state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).species, CUBONE)
+
+
+func test_a_slot_gains_one_point_of_experience_a_step() -> void:
+	var state: Gen2WorldState = _state()
+	var save: Gen2SaveData = Gen2SaveData.new()
+	save.party = [_mon(CUBONE), _mon(HOOTHOOT)]
+	Gen2WorldDayCare.deposit(state, save, Gen2WorldDayCare.SLOT_MAN, 0)
+	var before: int = state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp
+	Gen2WorldDayCare.step(state, _data, _seeded(3))
+	assert_eq(state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp, before + 1)
+
+
+func test_a_slot_at_the_level_cap_gains_nothing() -> void:
+	var state: Gen2WorldState = _state()
+	var mon: Gen2SaveMon = _mon(CUBONE)
+	mon.level = Gen2WorldDayCare.MAX_LEVEL
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, mon)
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	var before: int = state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp
+	Gen2WorldDayCare.step(state, _data, _seeded(3))
+	assert_eq(state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp, before)
+
+
+func test_a_retrieval_costs_a_hundred_a_level_plus_a_hundred() -> void:
+	assert_eq(Gen2WorldDayCare.price_to_retrieve(0), 100)
+	assert_eq(Gen2WorldDayCare.price_to_retrieve(7), 800)
+
+
+func test_a_retrieved_member_comes_back_at_the_level_its_experience_bought() -> void:
+	var state: Gen2WorldState = _state()
+	var save: Gen2SaveData = Gen2SaveData.new()
+	save.party = [_mon(CUBONE), _mon(HOOTHOOT)]
+	Gen2WorldDayCare.deposit(state, save, Gen2WorldDayCare.SLOT_MAN, 0)
+	var grown: Gen2SaveMon = state.day_care_mon(Gen2WorldDayCare.SLOT_MAN)
+	var growth_rate: int = int(_data.species(CUBONE).get("growth_rate", 0))
+	grown.exp = Gen2Experience.total_exp_at(growth_rate, 14) + 500
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, grown)
+	assert_eq(Gen2WorldDayCare.level_growth(_data, grown), 4)
+	var out: Dictionary = Gen2WorldDayCare.retrieve(
+		state, save, _data, Gen2WorldDayCare.SLOT_MAN
+	)
+	assert_eq(int(out["level"]), 14)
+	assert_false(state.day_care_has_mon(Gen2WorldDayCare.SLOT_MAN))
+	var back: Gen2SaveMon = save.party[int(out["party_index"])]
+	# `CalcExpAtLevel` writes the experience back to the bottom of the level it
+	# just reached, which is the source's own documented loss.
+	assert_eq(back.exp, Gen2Experience.total_exp_at(growth_rate, 14))
+	assert_eq(back.status, Gen2Status.NONE)
+	assert_gt(back.hp, 0)
+
+
+func test_a_full_party_cannot_take_a_member_back() -> void:
+	var state: Gen2WorldState = _state()
+	var save: Gen2SaveData = Gen2SaveData.new()
+	for _slot: int in Gen2SaveData.MAX_PARTY:
+		save.party.append(_mon(HOOTHOOT))
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, _mon(CUBONE))
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	assert_true(
+		Gen2WorldDayCare.retrieve(state, save, _data, Gen2WorldDayCare.SLOT_MAN).is_empty()
+	)
+
+
+func test_one_member_never_reaches_the_party_list() -> void:
+	var save: Gen2SaveData = Gen2SaveData.new()
+	save.party = [_mon(CUBONE)]
+	assert_eq(
+		Gen2WorldDayCare.deposit_refusal(save, 0), Gen2WorldDayCare.TEXT_LAST_MON
+	)
+
+
+func test_an_egg_and_the_last_healthy_member_are_each_refused() -> void:
+	var save: Gen2SaveData = Gen2SaveData.new()
+	var egg: Gen2SaveMon = _mon(CUBONE)
+	egg.is_egg = true
+	save.party = [egg, _mon(HOOTHOOT)]
+	assert_eq(
+		Gen2WorldDayCare.deposit_refusal(save, 0),
+		Gen2WorldDayCare.TEXT_CANT_BREED_EGG
+	)
+	# The egg cannot battle, so giving away the Hoothoot leaves nothing that can.
+	assert_eq(
+		Gen2WorldDayCare.deposit_refusal(save, 1),
+		Gen2WorldDayCare.TEXT_LAST_ALIVE_MON
+	)
+
+
+func test_a_fainted_member_may_be_deposited_while_another_can_walk() -> void:
+	var save: Gen2SaveData = Gen2SaveData.new()
+	var fainted: Gen2SaveMon = _mon(CUBONE)
+	fainted.hp = 0
+	save.party = [fainted, _mon(HOOTHOOT)]
+	assert_eq(Gen2WorldDayCare.deposit_refusal(save, 0), "")
+
+
+func test_a_held_mail_is_refused() -> void:
+	var save: Gen2SaveData = Gen2SaveData.new()
+	var mailed: Gen2SaveMon = _mon(CUBONE)
+	mailed.item = Gen2HeldItem.MAIL_ITEMS[0]
+	save.party = [mailed, _mon(HOOTHOOT)]
+	assert_eq(
+		Gen2WorldDayCare.deposit_refusal(save, 0), Gen2WorldDayCare.TEXT_REMOVE_MAIL
+	)
+
+
+func _breeding_pair(state: Gen2WorldState) -> void:
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, _mon(CUBONE, MALE_DVS, 100))
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_LADY, _mon(CUBONE, FEMALE_DVS, 200))
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_LADY, true)
+
+
+func test_a_compatible_pair_starts_a_counter_of_at_least_a_hundred_and_fifty() -> void:
+	var state: Gen2WorldState = _state()
+	_breeding_pair(state)
+	assert_true(Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9)))
+	assert_true(
+		state.day_care_man_flags() & Gen2WorldDayCare.MAN_MONS_COMPATIBLE != 0
+	)
+	assert_gte(state.steps_to_egg(), Gen2WorldDayCare.FIRST_EGG_STEPS_MINIMUM)
+	# The egg is built when the counter starts, not when it runs out.
+	assert_not_null(state.day_care_egg())
+	assert_true(state.day_care_egg().is_egg)
+	assert_eq(state.day_care_egg().level, Gen2WorldDayCare.EGG_LEVEL)
+	assert_eq(state.day_care_egg().original_trainer, "RED")
+
+
+func test_only_one_slot_filled_starts_nothing() -> void:
+	var state: Gen2WorldState = _state()
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, _mon(CUBONE))
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	assert_false(Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9)))
+	assert_eq(state.steps_to_egg(), 0)
+
+
+func test_an_egg_hatch_counter_is_the_species_own() -> void:
+	var state: Gen2WorldState = _state()
+	_breeding_pair(state)
+	Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9))
+	assert_eq(
+		state.day_care_egg().happiness,
+		int(_data.species(CUBONE).get("hatch_cycles", 0))
+	)
+
+
+func test_the_egg_takes_the_parents_defence_dv() -> void:
+	var state: Gen2WorldState = _state()
+	_breeding_pair(state)
+	Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9))
+	var egg: Gen2SaveMon = state.day_care_egg()
+	var mother: int = Gen2Stats.defense_dv(FEMALE_DVS)
+	var father: int = Gen2Stats.defense_dv(MALE_DVS)
+	assert_true(
+		Gen2Stats.defense_dv(egg.dvs) in [mother, father],
+		"the Defense DV comes from one of the two parents"
+	)
+
+
+func test_the_counter_runs_down_a_step_at_a_time_and_offers_an_egg() -> void:
+	var state: Gen2WorldState = _state()
+	_breeding_pair(state)
+	Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9))
+	var random: RandomNumberGenerator = _seeded(4)
+	var steps: int = state.steps_to_egg()
+	for _pass: int in steps - 1:
+		assert_false(Gen2WorldDayCare.step(state, _data, random))
+	assert_eq(state.steps_to_egg(), 1)
+	# The pass that empties the counter re-rolls it and rolls for the egg; it may
+	# refuse, so the walk runs until one is offered rather than asserting on one.
+	var offered: bool = false
+	for _pass: int in 4000:
+		if Gen2WorldDayCare.step(state, _data, random):
+			offered = true
+			break
+	assert_true(offered, "a compatible pair eventually offers an egg")
+	assert_true(state.day_care_man_flags() & Gen2WorldDayCare.MAN_HAS_EGG != 0)
+	assert_true(
+		state.day_care_man_flags() & Gen2WorldDayCare.MAN_MONS_COMPATIBLE == 0,
+		"the pair stops counting while the egg is waiting outside"
+	)
+
+
+func test_the_egg_waiting_is_the_one_handed_over() -> void:
+	var state: Gen2WorldState = _state()
+	var save: Gen2SaveData = Gen2SaveData.new()
+	_breeding_pair(state)
+	Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9))
+	state.set_day_care_man_flags(
+		state.day_care_man_flags() | Gen2WorldDayCare.MAN_HAS_EGG
+	)
+	var waiting: Gen2SaveMon = state.day_care_egg()
+	var given: Dictionary = Gen2WorldDayCare.give_egg(state, save)
+	assert_eq(int(given["species"]), waiting.species)
+	assert_eq(save.party.size(), 1)
+	assert_true((save.party[0] as Gen2SaveMon).is_egg)
+	assert_null(state.day_care_egg())
+	assert_true(state.day_care_man_flags() & Gen2WorldDayCare.MAN_HAS_EGG == 0)
+
+
+func test_the_day_care_survives_a_save_round_trip() -> void:
+	var state: Gen2WorldState = _state()
+	_breeding_pair(state)
+	Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9))
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.day_care_man_flags(), state.day_care_man_flags())
+	assert_eq(restored.steps_to_egg(), state.steps_to_egg())
+	assert_eq(
+		restored.day_care_mon(Gen2WorldDayCare.SLOT_LADY).dvs,
+		state.day_care_mon(Gen2WorldDayCare.SLOT_LADY).dvs
+	)
+	assert_eq(restored.day_care_egg().species, state.day_care_egg().species)
+
+
+func test_a_state_written_before_the_day_care_restores_as_two_empty_slots() -> void:
+	var restored: Gen2WorldState = Gen2WorldState.from_dict({"coins": 3})
+	assert_false(restored.day_care_has_mon(Gen2WorldDayCare.SLOT_MAN))
+	assert_false(restored.day_care_has_mon(Gen2WorldDayCare.SLOT_LADY))
+	assert_null(restored.day_care_egg())
+	assert_eq(restored.steps_to_egg(), 0)
+
+
+func test_a_step_is_owed_by_the_walk_and_spent_by_the_screen() -> void:
+	var state: Gen2WorldState = _state()
+	state.count_step()
+	state.count_step()
+	assert_eq(state.take_pending_day_care_steps(), 2)
+	assert_eq(state.take_pending_day_care_steps(), 0)
+
+
+func test_an_egg_move_the_father_knows_reaches_the_egg() -> void:
+	# Hoothoot's own egg-move list is the fixture's, and `GetEggMove`'s first
+	# test is that list.
+	assert_true(
+		Gen2WorldDayCare.inherits_move(_data, HOOTHOOT, Fixture.MIST_MOVE, null)
+	)
+	assert_false(
+		Gen2WorldDayCare.inherits_move(_data, CUBONE, Fixture.MIST_MOVE, null)
+	)
+
+
+func test_a_tm_move_the_egg_species_can_learn_is_inherited() -> void:
+	assert_true(
+		Gen2WorldDayCare.inherits_move(_data, CUBONE, Fixture.TM01_MOVE, null)
+	)
+
+
+func test_a_move_the_mother_knows_and_the_egg_learns_by_level_is_inherited() -> void:
+	# `.found_eggmove`: the move has to be one of the mother's four AND one the
+	# egg species learns on its own, and neither half is enough.
+	var mother: Gen2SaveMon = _mon(Fixture.GEODUDE)
+	mother.moves = [Fixture.SLASH, 0, 0, 0]
+	assert_true(
+		Gen2WorldDayCare.inherits_move(_data, Fixture.GEODUDE, Fixture.SLASH, mother)
+	)
+	assert_false(
+		Gen2WorldDayCare.inherits_move(_data, Fixture.GEODUDE, Fixture.SLASH, null)
+	)

--- a/tests/unit/test_world_day_care.gd.uid
+++ b/tests/unit/test_world_day_care.gd.uid
@@ -1,0 +1,1 @@
+uid://dewiave774xi2

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -328,10 +328,16 @@ func test_menu_input_can_be_cancelled_without_selecting_an_option() -> void:
 
 ## `special NameRater`, the same shape Kurt's own special is staged with.
 func _set_name_rater_script() -> void:
+	_set_special_script(Gen2WorldScriptRunner.SPECIAL_NAME_RATER)
+
+
+## One `special` on the cell the world opens standing on, and a world rebuilt
+## around it.
+func _set_special_script(special: int) -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6300)] = [
 		Gen2WorldScript.SPECIAL,
-		Gen2WorldScriptRunner.SPECIAL_NAME_RATER, 0x00,
+		special, 0x00,
 		Gen2WorldScript.END,
 	]
 	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
@@ -351,6 +357,42 @@ func _set_name_rater_script() -> void:
 	)
 	_save = Gen2SaveStore.create_development_save(_data, 0)
 	_save.world = _world.snapshot()
+
+
+## The five Day-Care specials, staged the same way and answered from the same
+## run of stubs. The role is what tells the one screen which routine it is.
+func test_the_five_day_care_specials_each_stage_their_own_role() -> void:
+	var roles: Dictionary = {
+		Gen2WorldScriptRunner.SPECIAL_DAY_CARE_MAN: &"man",
+		Gen2WorldScriptRunner.SPECIAL_DAY_CARE_LADY: &"lady",
+		Gen2WorldScriptRunner.SPECIAL_DAY_CARE_MAN_OUTSIDE: &"outside",
+		Gen2WorldScriptRunner.SPECIAL_DAY_CARE_MON_1: &"mon1",
+		Gen2WorldScriptRunner.SPECIAL_DAY_CARE_MON_2: &"mon2",
+	}
+	for special: int in roles:
+		_set_special_script(special)
+		var waiting: Array = _world.dispatch_script_events(Vector2i(7, 6))
+		assert_eq(waiting[0]["status"], &"waiting", JSON.stringify(waiting))
+		var request: Dictionary = _world.pending_runtime_request()
+		assert_eq(request["kind"], &"day_care_requested")
+		assert_eq(StringName(request["values"]["role"]), StringName(roles[special]))
+
+		var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+		assert_true(resolved["ok"], JSON.stringify(resolved))
+		assert_eq(
+			(resolved["data"]["day_care_text"] as Dictionary).size(),
+			Gen2WorldHost.day_care_texts(_data).size()
+		)
+
+
+## Four of the five write no wScriptVar at all, so a completion with no value in
+## it must leave whatever the script had put there.
+func test_a_day_care_completion_without_a_value_leaves_the_script_variable() -> void:
+	_set_special_script(Gen2WorldScriptRunner.SPECIAL_DAY_CARE_MON_1)
+	_world.dispatch_script_events(Vector2i(7, 6))
+	var results: Array = _world.complete_runtime_request({"ok": true})
+	assert_false(results.is_empty())
+	assert_true(bool(results[0].get("ok", false)), JSON.stringify(results))
 
 
 func test_name_rater_special_stages_a_request_carrying_all_ten_boxes() -> void:

--- a/tools/checks/day_care.gd
+++ b/tools/checks/day_care.gd
@@ -1,0 +1,212 @@
+extends RefCounted
+
+## Sweeps the Day-Care and the breeding rules behind it on freshly imported real
+## caches, all three cartridges, whole corpus.
+##
+## What this exists to catch is a rule that is right for the pair a test was
+## written for and wrong for the corpus: `GetPreEvolution` is a search over every
+## species, `CheckBreedmonCompatibility` reads two records at once, and
+## `FillMoves` is the same routine the retrieval and the egg both go through. A
+## sampled pair answers none of those.
+##
+## The real-cartridge counterpart to tests/unit/test_world_day_care.gd.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- day_care
+
+## `PrintDayCareText.TextTable`'s twenty, `.NotYetText`, `DayCareManOutside`'s
+## five and `engine/pokemon/breeding.asm`'s two plus five.
+const EXPECTED_TEXTS: int = 33
+## One stub per run, by the words that identify the run rather than the address.
+const TEXT_ANCHORS: Dictionary = {
+	"man_intro": "I'm the DAY-CARE",
+	"not_yet": "Not yet",
+	"found_an_egg": "it's you!",
+	"left_with_man": "DAY-CARE MAN",
+	"brimming_with_energy": "brimming with",
+}
+
+## `DITTO`, the one species compatible with everything that breeds at all.
+const SPECIES_DITTO: int = 132
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		_verify_texts(game_id, data)
+		_verify_pre_evolutions(game_id, data)
+		_verify_compatibility(game_id, data)
+		_verify_egg_moves(game_id, data)
+		_verify_fill_moves(game_id, data)
+	_r.game_id = &""
+
+
+## Every stub of the four runs decodes, and one per run carries the words that
+## say the pin is that run and not its neighbour.
+func _verify_texts(game_id: StringName, data: GameData) -> void:
+	var found: int = 0
+	for run: Array in RomLayout.DAY_CARE_TEXT_RUNS:
+		for raw_name: Variant in run[1] as Array:
+			var name: String = String(raw_name)
+			var text: String = data.day_care_text(name)
+			if _r.check(
+				not text.is_empty(), "%s: the Day-Care's %s text is empty." % [game_id, name]
+			):
+				found += 1
+	_r.check(
+		found == EXPECTED_TEXTS,
+		"%s: %d of %d Day-Care texts decoded." % [game_id, found, EXPECTED_TEXTS]
+	)
+	for name: String in TEXT_ANCHORS:
+		_r.check(
+			data.day_care_text(name).contains(String(TEXT_ANCHORS[name])),
+			"%s: the Day-Care's %s text is \"%s\"." % [
+				game_id, name, data.day_care_text(name)
+			]
+		)
+
+
+## `DayCare_InitBreeding` calls `GetPreEvolution` exactly twice, so two passes
+## have to reach a base form for every species on the cartridge: a third pass
+## finding anything would mean a three-deep line whose egg is the middle stage.
+func _verify_pre_evolutions(game_id: StringName, data: GameData) -> void:
+	var deepest: int = 0
+	for species: int in range(1, data.species_count() + 1):
+		var once: int = Gen2WorldDayCare.pre_evolution(data, species)
+		var twice: int = Gen2WorldDayCare.pre_evolution(data, once)
+		var thrice: int = Gen2WorldDayCare.pre_evolution(data, twice)
+		if once != species:
+			deepest = maxi(deepest, 2 if twice != once else 1)
+		if not _r.check(
+			thrice == twice,
+			"%s: species %d is still evolving from %d after two passes." % [
+				game_id, species, thrice
+			]
+		):
+			continue
+		## Every species an egg can be has a hatch counter, since the counter is
+		## what `DoEggStep` drains and a zero one hatches on the first step.
+		_r.check(
+			int(data.species(twice).get("hatch_cycles", 0)) > 0,
+			"%s: base species %d has no hatch cycles." % [game_id, twice]
+		)
+	_r.check(deepest == 2, "%s: no species is two evolutions deep." % game_id)
+
+
+## `CheckBreedmonCompatibility` over the whole species square. Two things are
+## swept: the answer does not depend on which slot a species is in, and every
+## answer is one of the values `DayCareMonCompatibilityText` and
+## `DayCare_InitBreeding` between them account for.
+func _verify_compatibility(game_id: StringName, data: GameData) -> void:
+	var count: int = data.species_count()
+	var breeders: int = 0
+	var asymmetric: int = 0
+	var out_of_range: int = 0
+	for first: int in range(1, count + 1):
+		var mon1: Gen2SaveMon = _mon(first, 0x1234, 111)
+		for second: int in range(first, count + 1):
+			var mon2: Gen2SaveMon = _mon(second, 0x5678, 222)
+			var forward: int = Gen2WorldDayCare.compatibility(data, mon1, mon2)
+			var backward: int = Gen2WorldDayCare.compatibility(data, mon2, mon1)
+			if forward != backward:
+				asymmetric += 1
+			if forward not in [0, 51, 128, 177, 254, 255]:
+				out_of_range += 1
+			if forward != 0 and forward != 255:
+				breeders += 1
+	_r.check(
+		asymmetric == 0,
+		"%s: %d species pairs answer differently by slot." % [game_id, asymmetric]
+	)
+	_r.check(
+		out_of_range == 0,
+		"%s: %d species pairs answer a value no branch reads." % [game_id, out_of_range]
+	)
+	_r.check(breeders > 0, "%s: no species pair breeds at all." % game_id)
+	## Ditto's own row, which is the one species the group test lets through
+	## whatever it is paired with.
+	var ditto: Gen2SaveMon = _mon(SPECIES_DITTO, 0x1234, 111)
+	for species: int in range(1, count + 1):
+		var partner: Gen2SaveMon = _mon(species, 0x5678, 222)
+		var breeds: bool = Gen2WorldDayCare.compatibility(data, ditto, partner) != 0
+		_r.check(
+			breeds == (species != SPECIES_DITTO
+				and Gen2WorldDayCare.groups_compatible(data, ditto, partner)),
+			"%s: DITTO and species %d disagree with their egg groups." % [game_id, species]
+		)
+
+
+## Every egg move names a move this cache has, and every one of them is one the
+## egg species can actually receive: `GetEggMove`'s first test is the list
+## itself, so a list entry that fails [method Gen2WorldDayCare.inherits_move]
+## would mean the two readings of the same table disagree.
+func _verify_egg_moves(game_id: StringName, data: GameData) -> void:
+	var rows: int = 0
+	for species: int in range(1, data.species_count() + 1):
+		for move: int in data.egg_moves(species):
+			rows += 1
+			if not _r.check(
+				move > 0 and move <= data.move_count(),
+				"%s: species %d inherits move %d." % [game_id, species, move]
+			):
+				continue
+			_r.check(
+				Gen2WorldDayCare.inherits_move(data, species, move, null),
+				"%s: species %d's own egg move %d is refused." % [game_id, species, move]
+			)
+	_r.check(rows > 0, "%s: no egg moves imported." % game_id)
+
+
+## `FillMoves` over every species at every level, both branches. Four slots, no
+## repeats and nothing above the level asked for is the whole of the routine's
+## contract, and the skip branch may only ever be a subset of the plain one.
+func _verify_fill_moves(game_id: StringName, data: GameData) -> void:
+	for species: int in range(1, data.species_count() + 1):
+		var learnset: Array = data.learnset(species)
+		for level: int in range(1, Gen2Experience.MAX_LEVEL + 1):
+			var known: Array = Gen2Learnset.moves_at_level(learnset, level)
+			if not _r.check(
+				known.size() <= Gen2Learnset.MOVE_SLOTS,
+				"%s: species %d knows %d moves at level %d." % [
+					game_id, species, known.size(), level
+				]
+			):
+				return
+			var seen: Dictionary = {}
+			for move: Variant in known:
+				if not _r.check(
+					not seen.has(move),
+					"%s: species %d knows move %d twice at level %d." % [
+						game_id, species, int(move), level
+					]
+				):
+					return
+				seen[move] = true
+			## The retrieval branch: filling from the level below teaches at most
+			## what the whole walk would, and never a move it would not.
+			var grown: Array = Gen2Learnset.moves_at_level(learnset, maxi(1, level - 1))
+			Gen2Learnset.fill_moves(learnset, grown, level, maxi(1, level - 1))
+			if not _r.check(
+				grown.size() <= Gen2Learnset.MOVE_SLOTS,
+				"%s: species %d grows into %d moves at level %d." % [
+					game_id, species, grown.size(), level
+				]
+			):
+				return
+
+
+## A Day-Care slot with the DVs and trainer ID a sweep needs to be able to vary,
+## since both of them are read by `CheckBreedmonCompatibility`.
+func _mon(species: int, dvs: int, ot_id: int) -> Gen2SaveMon:
+	var mon: Gen2SaveMon = Gen2SaveMon.new()
+	mon.species = species
+	mon.dvs = dvs
+	mon.ot_id = ot_id
+	mon.level = 20
+	return mon

--- a/tools/checks/day_care.gd.uid
+++ b/tools/checks/day_care.gd.uid
@@ -1,0 +1,1 @@
+uid://236liq4w0eep

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -49,7 +49,6 @@ const EXPECTED_DEFERRED: Dictionary = {
 	## work, not a dispatch entry: it opens a screen, spends a transaction, or
 	## reads a save field nothing writes.
 	25: "CheckMagikarpLength", 26: "MagikarpHouseSign",
-	30: "DayCareMan", 31: "DayCareLady", 32: "DayCareManOutside",
 	34: "BankOfMom", 39: "UnownPrinter", 40: "MapRadio", 41: "UnownPuzzle",
 	42: "SlotMachine", 43: "CardFlip", 57: "GameCornerPrizeMonCheckDex",
 	75: "GiveShuckle", 76: "ReturnShuckie",
@@ -63,11 +62,8 @@ const EXPECTED_DEFERRED: Dictionary = {
 	148: "GiveDratini", 149: "SampleKenjiBreakCountdown",
 
 	## Reached by one script row each and by nothing the player can talk to.
-	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table, and
-	## the Day-Care's two mon readers belong with the three Day-Care routines
-	## above them.
+	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table.
 	0: "WarpToSpawnPoint", 64: "FindPartyMonAboveLevel",
-	69: "DayCareMon1", 70: "DayCareMon2",
 }
 
 ## Decoded `special` operands that name no `SpecialsPointers` entry. Pinned

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -52,6 +52,9 @@ extends SceneTree
 ## MoveDeletion`, which no fixture cell reaches: the first number is how many
 ## presses into the routine to photograph, so 0 is the introduction, 2 its last
 ## page with the YES/NO up, and 4 the party list),
+## `day_care` (the Day-Care's five specials, driven the same way: the first
+## number is how many presses in and the second which routine, 0 the man,
+## 1 the lady, 2 the man outside, 3 and 4 the two signs),
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
@@ -75,6 +78,10 @@ const WARP_FRAME_CAP: int = 120
 ## How long one of the two routines' boxes may take to finish printing, which is
 ## a text speed rather than a count this file knows.
 const MON_SPECIAL_FRAME_CAP: int = 600
+## The Day-Care's five routines, in the order the second number picks them.
+const DAY_CARE_ROLES: Array[StringName] = [
+	&"man", &"lady", &"outside", &"mon1", &"mon2",
+]
 
 
 ## `UpdateJumpPosition`'s highest `.y_offsets` entry, which is where the `ledge`
@@ -207,7 +214,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 		_screen.start_cell = _kind_cell
 	elif cell.x >= 0 and _kind not in [
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-		&"move_deleter",
+		&"move_deleter", &"day_care",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -300,6 +307,20 @@ func _process(_delta: float) -> bool:
 					break
 				if hatching.awaiting_press():
 					_screen.press_button(Gen2Button.A)
+		elif _kind == &"day_care":
+			## The Day-Care's five, driven the way the two above are. The first
+			## number is how many presses into the routine to photograph and the
+			## second is which routine: 0 the man, 1 the lady, 2 the man outside,
+			## 3 and 4 the two signs.
+			_screen.preview_day_care(DAY_CARE_ROLES[clampi(
+				_cell.y, 0, DAY_CARE_ROLES.size() - 1
+			)])
+			_settle_mon_special("_day_care_host")
+			for _press: int in maxi(_cell.x, 0):
+				if _screen.get("_day_care_host") == null:
+					break
+				_screen.press_button(Gen2Button.A)
+				_settle_mon_special("_day_care_host")
 		elif _kind in [&"name_rater", &"move_deleter"]:
 			## `special NameRater` and `special MoveDeletion`, neither of which
 			## any fixture cell reaches. The first number is how many presses
@@ -411,7 +432,7 @@ func _process(_delta: float) -> bool:
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
 			&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-			&"move_deleter",
+			&"move_deleter", &"day_care",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -41,7 +41,7 @@ const GROUPS: Dictionary = {
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
-		&"mon_specials", &"specials",
+		&"mon_specials", &"specials", &"day_care",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
The five Day-Care specials were a wall in front of every NPC that ran them. All five are built now, on one screen and one rules module.

`Gen2WorldDayCare` is `engine/events/daycare.asm` and `engine/pokemon/breeding.asm`: compatibility, the egg the pair builds when the counter starts, that egg's moves and DVs, `DayCareStep`'s point of experience a step, and the price of taking a Pokemon back. `Gen2DayCareScreen` is the boxes, the two questions and the party list, as one queue rather than five state machines. The two slots, the counter and the waiting egg live in the world state, where `wBreedMon1` and `wBreedMon2` live on the cartridge.

Four readings a shorter one gets wrong:

- `wBreedMotherOrNonDitto` is written once and read by four routines that each take a different side of it. It is computed once and each side is asked for by name.
- The Day-Care man never prints his egg introduction. The lady prints hers on the visit that sets her active bit.
- A pair whose Defense DVs and low Special bits match answers 255, which reads as "brimming with energy" and never lays an egg.
- `RetrieveBreedmon` ends on `CalcExpAtLevel`, so a withdrawn Pokemon loses the experience above its own level. Reproduced.

`FillMoves` is one routine in `Gen2Learnset` now rather than two. The retrieval's `wSkipMovesBeforeLevelUp` branch is the same walk with a floor, and `moves_at_level` is one call of it.

Cache format 78 carries the Day-Care's four `text_far` stub runs, thirty-three boxes. Each run is located by the text its first stub points at. All three cartridges re-imported, each reporting `layout: Layout verified.`

| Check | Result |
|---|---|
| `tools/validate.gd -- all` | 61 topics, pass |
| `tools/checks/day_care.gd` (new) | 33 texts, 251 species, the full compatibility square, every egg move and every level of `FillMoves`, on all three |
| `tools/checks/specials.gd` | five rows deleted from `EXPECTED_DEFERRED` |
| GUT, full tier | 3,441 tests over 154 scripts, green |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 0 failures |

Photograph any of the five with `tools/preview_world.gd -- <game> <group> <map> <png> live day_care <presses> <routine>`.