### PR TITLE
Give the camera the pass it lags the player by

### DIFF
--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -31,6 +31,11 @@ var _timer: int = 0
 var _water_color: int = -1
 var _cave_color: int = -1
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
+## The world's own flag store, read live by the four forest tree commands the
+## way `ForestTreeLeftAnimation` reads `wCelebiEvent` on every tick.
+var _state: Gen2WorldState = null
+## Which engine flag table `_state` is keyed by. See Gen2WorldState.engine_flag().
+var _crystal_flags: bool = true
 var _changed: bool = false
 ## Which tiles a run of commands rewrote, and whether a palette row moved. A
 ## renderer that keeps a texture only has to redo these tiles: the sequence
@@ -44,6 +49,8 @@ func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MOR
 	data = world.data if world != null else null
 	map = world.current_map if world != null else null
 	tileset = world.current_tileset if world != null else null
+	_state = world.state if world != null else null
+	_crystal_flags = Gen2WorldState.is_crystal_profile(data)
 	_time_of_day = clampi(time_of_day, 0, 3)
 	_command_index = 0
 	_timer = 0
@@ -222,13 +229,13 @@ func tick() -> bool:
 				"fountain", 0, TIMER_FOUNTAIN_FRAMES[_timer & 7], int(command.get("tile", -1))
 			)
 		"forest_left":
-			_copy_asset_tile("forest", 0, 0, 0x0C)
+			_copy_asset_tile("forest", 0, _forest_tree_frame(false), 0x0C)
 		"forest_right":
-			_copy_asset_tile("forest", 0, 0, 0x0F, 32)
+			_copy_asset_tile("forest", 0, _forest_tree_frame(false), 0x0F, 32)
 		"forest_left_2":
-			_copy_asset_tile("forest", 0, 0, 0x0C)
+			_copy_asset_tile("forest", 0, _forest_tree_frame(true), 0x0C)
 		"forest_right_2":
-			_copy_asset_tile("forest", 0, 0, 0x0F, 32)
+			_copy_asset_tile("forest", 0, _forest_tree_frame(true), 0x0F, 32)
 		"lava_1":
 			_copy_asset_tile("lava", 0, (((_timer & 6) >> 1) + 2) & 3, 0x5B)
 		"lava_2":
@@ -266,6 +273,19 @@ func tick() -> bool:
 					_palette_changed = true
 				_cave_color = cave_color
 	return true
+
+
+## `GetForestTreeFrame`: the parity of `wTileAnimationTimer`, which the two
+## `...Animation2` routines then flip with their own `xor %10`. Outside the
+## Celebi event all four routines take the `jr nz` branch to the first frame, so
+## an ordinary visit to Ilex Forest sees the trees standing still.
+func _forest_tree_frame(offset: bool) -> int:
+	if _state == null or not _state.is_engine_flag_active(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_FOREST_IS_RESTLESS, _crystal_flags)
+	):
+		return 0
+	var frame: int = _timer & 1
+	return 1 - frame if offset else frame
 
 
 func _copy_asset_tile(

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -314,6 +314,10 @@ var _player_queued_steps: Array = []
 var _player_scripted_steps: bool = false
 ## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
 var _player_step_frame: int = 0
+## How far the player has moved that hSCX/hSCY have not been given yet: one
+## pass's step vector, since `ScrollScreen` runs after `NextOverworldFrame`.
+## See visible_origin_cells().
+var _camera_lag_cells: Vector2 = Vector2.ZERO
 ## Frames left of the counted wait a script is standing in, -1 while it is not
 ## standing in one or has not started counting.
 var _script_wait_frames: int = -1
@@ -662,11 +666,14 @@ func player_position_cells() -> Vector2:
 func visible_origin_cells() -> Vector2:
 	if current_map == null:
 		return Vector2.ZERO
-	return player_position_cells() - Vector2(PLAYER_VIEW_CELL)
+	return player_position_cells() - _camera_lag_cells - Vector2(PLAYER_VIEW_CELL)
 
 
-## The player's screen pixel after applying the same fine scroll as the map.
-## The hardware keeps this at PLAYER_VIEW_CELL while hSCX/hSCY move the world.
+## The player's screen pixel, which is PLAYER_VIEW_CELL plus whatever hSCX/hSCY
+## have not caught up with: `ScrollScreen` sits after `NextOverworldFrame` in
+## `HandleMapBackground`, so the scroll a pass computed is written two frames
+## after the sprite moved and a walking player is drawn two pixels ahead of its
+## resting cell for the whole walk.
 func player_pixel_position() -> Vector2i:
 	return Vector2i(
 		(player_position_cells() - visible_origin_cells()) * float(CELL_PIXELS)
@@ -813,6 +820,7 @@ func _begin_player_step(
 
 
 func _clear_player_step() -> void:
+	_camera_lag_cells = Vector2.ZERO
 	_player_step_began = false
 	_player_jumping = false
 	_player_step_direction = Vector2i.ZERO
@@ -830,11 +838,16 @@ func _clear_player_step() -> void:
 ## never starts a step sees no difference.
 func advance_player_step_pass() -> bool:
 	if _player_step_passes_remaining <= 0:
+		_camera_lag_cells = Vector2.ZERO
 		return false
+	var before: Vector2 = player_position_cells()
 	_player_step_frame = (_player_step_frame + 1) & 0x0F
 	_player_step_passes_remaining -= 1
 	if _player_step_passes_remaining <= 0:
 		_start_next_player_step()
+	## What `ScrollScreen` will add to hSCX/hSCY, which it does not do until
+	## after this pass's own two frames have been spent.
+	_camera_lag_cells = player_position_cells() - before
 	return true
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -576,11 +576,20 @@ func advance_frame() -> void:
 	## animate on every frame while the objects standing on them move on passes.
 	if _animation != null and _animation.advance_frame() and _renderer != null:
 		_renderer.refresh_animation()
+	## `GetJoypad` and `PlayerEvents` are both inside the pass, so a held
+	## direction starts a step on a pass and never between two. Before the step
+	## below, which is `HandleMap`'s own order: `MapEvents` starts the step and
+	## `HandleMapObjects` moves it in the same pass, so a walk begun from
+	## standing covers its first two pixels on the pass the press landed on.
+	if map_pass:
+		_advance_forced_movement()
+		_advance_held_direction()
 	if map_pass and _world != null and _world.advance_player_step_pass() \
 		and _renderer != null:
 		_renderer.refresh()
-	## `_HandlePlayerStep` runs before `PlayerEvents` in `HandleMap`, so the step
-	## that finishes on this frame is the one whose events this frame runs.
+	## `CheckPlayerState` reads the step flags at the end of `HandleMap`, after
+	## `HandleMapObjects`, so the step that finishes on this frame is the one
+	## whose events this frame runs.
 	if map_pass and not _pending_step_events.is_empty() and _world != null \
 		and not _world.player_step_in_progress():
 		var landed: Dictionary = _pending_step_events
@@ -603,11 +612,6 @@ func advance_frame() -> void:
 		_renderer.refresh()
 	_spend_actor_requests()
 	_spend_hidden_item_requests()
-	## `GetJoypad` and `PlayerEvents` are both inside the pass, so a held
-	## direction starts a step on a pass and never between two.
-	if map_pass:
-		_advance_forced_movement()
-		_advance_held_direction()
 	if map_pass and _objects_may_move() \
 		and _world.advance_object_steps_pass(_object_random) \
 		and _renderer != null:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -55,6 +55,11 @@ const ENGINE_ROCKETS_IN_RADIO_TOWER: int = 19
 const ENGINE_ROCKETS_IN_RADIO_TOWER_GOLD_SILVER: int = 18
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED: int = 86
 const ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER: int = 85
+## `CELEBIEVENT_FOREST_IS_RESTLESS_F`, which `ForestTreeLeftAnimation` and its
+## three neighbours read every tick: while it is set, Ilex Forest's two tree
+## tiles cycle instead of standing on their first frame. Crystal only, the Gold
+## and Silver `TilesetForestAnim` carrying no tree frame at all.
+const ENGINE_FOREST_IS_RESTLESS: int = 100
 ## The first entry in the same `wDailyFlags1` byte. `KurtsHouse.asm` sets it
 ## when the apricorns are handed over and reads it to decide whether the ball is
 ## ready, so the day boundary is the whole of the errand's wait.

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -55,11 +55,40 @@ func _write_cache() -> void:
 			{"operation": "water", "tile": 0},
 			{"operation": "done"},
 		],
+	}, {
+		# `TilesetForestAnim`'s own four tree commands, in its order: the pair
+		# and then the pair the source offsets by a frame, with the timer bump
+		# after both so all four see the same `wTileAnimationTimer`.
+		"number": 2,
+		"block_count": 1,
+		"tile_count": RomLayout.TILESET_TILE_COUNT,
+		"meta": meta,
+		"collision": [],
+		"palette_map": [0],
+		"animation_commands": [
+			{"operation": "forest_left"},
+			{"operation": "forest_right"},
+			{"operation": "forest_left_2"},
+			{"operation": "forest_right_2"},
+			{"operation": "timer_8"},
+			{"operation": "done"},
+		],
 	}])
 	RomCache.write_json(RomCache.world_maps_path(_directory), [{
 		"group": 1,
 		"number": 1,
 		"tileset": 0,
+		"environment": 0,
+		"width_blocks": 1,
+		"height_blocks": 1,
+		"blocks": [0],
+		"collision": [0, 0, 0, 0],
+		"collision_width": 2,
+		"collision_height": 2,
+	}, {
+		"group": 1,
+		"number": 3,
+		"tileset": 2,
 		"environment": 0,
 		"width_blocks": 1,
 		"height_blocks": 1,
@@ -83,6 +112,7 @@ func _write_cache() -> void:
 	pixels.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
 	RomCache.write_indices(RomCache.world_tile_path(_directory, 0), pixels)
 	RomCache.write_indices(RomCache.world_tile_path(_directory, 1), pixels)
+	RomCache.write_indices(RomCache.world_tile_path(_directory, 2), pixels)
 
 	var palettes: Array = []
 	for _group: int in RomLayout.WORLD_PALETTE_GROUP_COUNT:
@@ -100,7 +130,20 @@ func _write_cache() -> void:
 	for frame: int in range(1, 4):
 		for y: int in frame:
 			water[frame * 16 + y * 2] = 0xFF
-	RomCache.write_json(RomCache.world_animation_assets_path(_directory), {"water": water})
+	# `ForestTreeLeftFrames` and `ForestTreeRightFrames`, four tiles in a row,
+	# each filled with its own index so a written tile names the frame it came
+	# from: 1 and 2 are the left tree's, 3 and 4 the right tree's.
+	var forest: Array = []
+	forest.resize(64)
+	for index: int in forest.size():
+		forest[index] = 0
+	for tile: int in 4:
+		for y: int in 8:
+			forest[tile * 16 + y * 2] = 0xFF if (tile & 1) == 0 else 0
+			forest[tile * 16 + y * 2 + 1] = 0xFF if (tile & 1) == 1 else 0
+	RomCache.write_json(
+		RomCache.world_animation_assets_path(_directory), {"water": water, "forest": forest}
+	)
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "testanimation",
@@ -208,3 +251,55 @@ func test_reload_tileset_keeps_the_place_a_connection_crossing_left() -> void:
 	# A warp is the other setup script and does reset it.
 	animation.configure(neighbour)
 	assert_eq(animation.command_index(), 0)
+
+
+## The four tree commands read `wCelebiEvent` on every tick, so an ordinary visit
+## to Ilex Forest draws both trees on their first frame and the restless one
+## alternates, with `...Animation2`'s `xor %10` a frame ahead of its pair.
+func test_the_forest_trees_stand_still_until_the_celebi_event_is_set() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 3, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world)
+
+	# Two whole cycles of the six commands, which leaves wTileAnimationTimer at
+	# 2 and both trees on the frame the `jr nz` branch never leaves.
+	for _command: int in 12:
+		animation.tick()
+	assert_eq(_tree_frame(animation, 0x0C), 0)
+	assert_eq(_tree_frame(animation, 0x0F), 0)
+
+	world.state.set_engine_flag(Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_FOREST_IS_RESTLESS, Gen2WorldState.is_crystal_profile(data)
+	))
+	# An even timer is `GetForestTreeFrame`'s own zero, so the pair draws the
+	# first frame and the `xor %10` pair the second.
+	_tick_pair(animation)
+	assert_eq(_tree_frame(animation, 0x0C), 0)
+	assert_eq(_tree_frame(animation, 0x0F), 0)
+	_tick_pair(animation)
+	assert_eq(_tree_frame(animation, 0x0C), 1)
+	assert_eq(_tree_frame(animation, 0x0F), 1)
+
+	# The bump and the rewind, and then the odd timer answers the other way round.
+	_tick_pair(animation)
+	_tick_pair(animation)
+	assert_eq(_tree_frame(animation, 0x0C), 1)
+	assert_eq(_tree_frame(animation, 0x0F), 1)
+	_tick_pair(animation)
+	assert_eq(_tree_frame(animation, 0x0C), 0)
+	assert_eq(_tree_frame(animation, 0x0F), 0)
+
+
+func _tick_pair(animation: Gen2WorldAnimation) -> void:
+	animation.tick()
+	animation.tick()
+
+
+## Which of the two frames a tree tile is holding, read off the fixture asset's
+## own marking: frame 0 lights the first plane and frame 1 the second, so the
+## palette index of a lit pixel is 1 or 2. The strip is one row of tiles, so a
+## tile's first pixel is its own column of row zero rather than a tile-sized
+## stride into the array.
+func _tree_frame(animation: Gen2WorldAnimation, tile: int) -> int:
+	return 0 if animation.current_indices()[tile * Gen2Tiles.TILE_WIDTH] == 1 else 1

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2173,7 +2173,7 @@ func test_player_walk_step_starts_a_cell_behind_and_never_moves_the_committed_ce
 	assert_eq(world.player_pixel_position(), Gen2WorldAPI.PLAYER_VIEW_CELL * 16)
 
 
-func test_the_interpolated_camera_origin_does_not_pan_a_step_early() -> void:
+func test_the_camera_origin_follows_the_player_one_pass_behind() -> void:
 	var world: Gen2WorldAPI = _world()
 	# Standing still, the hardware page origin and the camera agree.
 	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
@@ -2187,15 +2187,24 @@ func test_the_interpolated_camera_origin_does_not_pan_a_step_early() -> void:
 	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(4.0, 2.0))
 
+	# `ScrollScreen` runs after `NextOverworldFrame`, so the scroll a pass
+	# computed is written two frames after the sprite moved: the camera stands
+	# still on the pass the walk starts and the player is drawn two pixels ahead
+	# of it, which is `sprite_x - scx` of 62 on the cartridge.
 	assert_true(world.advance_player_step_pass())
 	assert_eq(world.player_position_cells(), Vector2(7.875, 6.0))
-	assert_eq(world.visible_origin_cells(), Vector2(3.875, 2.0))
+	assert_eq(world.visible_origin_cells(), Vector2(4.0, 2.0))
+	assert_eq(world.player_pixel_position(), Vector2i(62, 64))
 
-	# The step lands on the committed cell, where the two agree again.
+	# The step lands on the committed cell with the camera still one pass behind,
+	# and the pass after it, which moves nothing, is where the two agree again.
 	_finish_player_step(world)
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_position_cells(), Vector2(7.0, 6.0))
+	assert_eq(world.visible_origin_cells(), Vector2(3.125, 2.0))
+	assert_false(world.advance_player_step_pass())
 	assert_eq(world.visible_origin_cells(), Vector2(world.visible_screen_origin_cell()))
+	assert_eq(world.player_pixel_position(), Gen2WorldAPI.PLAYER_VIEW_CELL * 16)
 
 
 func test_the_interpolated_camera_origin_runs_off_the_map_like_the_page_does() -> void:

--- a/tools/trace_world_walk.gd
+++ b/tools/trace_world_walk.gd
@@ -1,0 +1,102 @@
+extends SceneTree
+
+## Every hardware frame of a walk on the real world screen: where the map is
+## scrolled to, where the player is drawn, and which of `Facings` is up.
+##
+##   Godot --headless --path . -s res://tools/trace_world_walk.gd -- \
+##       <game> <group> <map> <x> <y> <direction> <frames> <out.txt>
+##
+## The port half of `.claude/oracle/overworld/trace_walk.py`, which prints the
+## same artefact off a real cartridge. The line is
+## `frame cam_x cam_y x y screen_x screen_y facing walk_frame`, where `cam_x`
+## and `cam_y` are hSCX/hSCY in map pixels rather than modulo the BG map and
+## `screen_x`/`screen_y` are `sprite_x - scx` on that side: the camera lags the
+## player by one pass (`ScrollScreen` runs after `NextOverworldFrame`), so a
+## walking player is drawn two pixels ahead of its resting cell and the pair is
+## what says so.
+##
+## Ten standing frames come first, the way the cartridge trace opens, so a diff
+## aligns on the frame the direction starts being held rather than on the file.
+
+const STANDING_FRAMES: int = 10
+
+
+func _initialize() -> void:
+	_run.call_deferred()
+
+
+func _run() -> void:
+	await process_frame
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 8:
+		push_error("usage: <game> <group> <map> <x> <y> <direction> <frames> <out.txt>")
+		quit(2)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("no imported cache for %s" % args[0])
+		quit(2)
+		return
+	var direction: int = _button_for(args[5])
+	if direction == Gen2Button.NONE:
+		push_error("direction is one of up, down, left, right")
+		quit(2)
+		return
+	var frames: int = maxi(1, int(args[6]))
+
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	screen.set_data(data)
+	screen.map_group = int(args[1])
+	screen.map_number = int(args[2])
+	screen.start_cell = Vector2i(int(args[3]), int(args[4]))
+	screen.process_mode = Node.PROCESS_MODE_DISABLED
+	root.add_child(screen)
+	await process_frame
+	if screen._world == null:
+		push_error("the world did not open: %s" % screen._caption.text)
+		quit(2)
+		return
+	screen.set_process(false)
+
+	## Held from the eleventh frame on, which is where the cartridge trace
+	## presses, and released once the run has spent its frames.
+	var log: Array = []
+	for frame: int in range(STANDING_FRAMES, frames):
+		log.append({"frame": frame, "kind": "hold", "button": direction})
+	screen.replay_input(log)
+
+	var lines: PackedStringArray = PackedStringArray([
+		"# frame cam_x cam_y x y screen_x screen_y facing walk_frame"
+	])
+	for frame: int in frames:
+		screen.advance_frame()
+		lines.append(_sample(screen._world, frame))
+	var out: String = args[7]
+	FileAccess.open(out, FileAccess.WRITE).store_string("\n".join(lines) + "\n")
+	print("wrote %d frames to %s" % [frames, out])
+	root.remove_child(screen)
+	screen.free()
+	quit(0)
+
+
+## Read after the frame is spent, which is where the emulator samples: a line is
+## the state the frame it names left behind.
+func _sample(world: Gen2WorldAPI, frame: int) -> String:
+	var camera: Vector2 = world.visible_origin_cells() * float(Gen2WorldAPI.CELL_PIXELS)
+	var screen_pixel: Vector2i = world.player_pixel_position()
+	return "%d %d %d %d %d %d %d %d %d" % [
+		frame, roundi(camera.x), roundi(camera.y),
+		world.player_cell.x, world.player_cell.y,
+		screen_pixel.x, screen_pixel.y,
+		world.player_facing, world.player_walk_frame(),
+	]
+
+
+func _button_for(name: String) -> int:
+	match name.to_lower():
+		"up": return Gen2Button.UP
+		"down": return Gen2Button.DOWN
+		"left": return Gen2Button.LEFT
+		"right": return Gen2Button.RIGHT
+	return Gen2Button.NONE

--- a/tools/trace_world_walk.gd.uid
+++ b/tools/trace_world_walk.gd.uid
@@ -1,0 +1,1 @@
+uid://btjyqfubputhw


### PR DESCRIPTION
The overworld camera and the player moved as one number here. On a real
cartridge they do not.

`HandleMap` runs `MapEvents` before `HandleMapObjects`, so `DoPlayerMovement`
starts a step and the object moves its first two pixels in the same pass. The
world screen read the joypad after spending the step, so every walk begun from
standing lost a pass at its front.

`HandleMapBackground` then runs `ScrollScreen` after `NextOverworldFrame`, so
hSCX and hSCY are given the step vector two frames after the sprite took it. The
cartridge draws a walking player two pixels ahead of its resting cell for the
whole walk. This port drew it dead centre.

`Gen2WorldAPI._camera_lag_cells` is that vector, and `visible_origin_cells()`
subtracts it. That is the one number the map, every object and the player are
all placed from, so one change covers everything drawn.

A held walk now draws the standing frame for one pass out of every eight. That
is not a flicker: `SetFacingStanding` runs when a step ends and the next one
does not start until the following `MapEvents`.

`tools/trace_world_walk.gd` is the port half of the cartridge walk trace. It
prints the same line per frame, so the two diff directly instead of a frame
count measured from the port itself.

Measured on Route 29, walking west:

| Measure | Cartridge | Before | After |
|---|---|---|---|
| `sprite_x - scx` while walking | 62 | 64 | 62 |
| `sprite_x - scx` standing | 64 | 64 | 64 |
| The pass a step spends its first two pixels on | the press's own | the next one | the press's own |
| Passes drawn standing between two held steps | 1 | 0 | 1 |

Beside it, the four forest tree animation commands were one behaviour where the
source has two. All four read `wCelebiEvent` on every tick, and this port wrote
the first frame whatever the flag said, so the two `...Animation2` routines were
copies of the pair they exist to offset by a frame. The frame is now
`GetForestTreeFrame`'s parity of `wTileAnimationTimer`, flipped by the `xor %10`
for the offset pair, read live from the engine flag. Crystal only: Gold and
Silver ship no tree frame.

Proof: 3,442 GUT tests green across both tiers, `validate.gd -- all` exit 0,
`replay_world.gd` 33 routes 0 failures, and the story walk green on all three
cartridges.