### PR TITLE
Build the Unown puzzle the Ruins of Alph chambers open

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -74,6 +74,7 @@ var _unown_words: PackedStringArray = PackedStringArray()
 var _unown_walls: PackedStringArray = PackedStringArray()
 var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
+var _unown_puzzle: Dictionary = {}
 var _gs_intro: Dictionary = {}
 var _menu_text: Dictionary = {}
 var _mart_text: Dictionary = {}
@@ -184,6 +185,8 @@ static func open_directory(path: String) -> GameData:
 	data._credits = credits if credits is Dictionary else {}
 	var intro_movie: Variant = manifest.get("intro_movie", {})
 	data._intro_movie = intro_movie if intro_movie is Dictionary else {}
+	var unown_puzzle: Variant = manifest.get("unown_puzzle", {})
+	data._unown_puzzle = unown_puzzle if unown_puzzle is Dictionary else {}
 	var gs_intro: Variant = manifest.get("gs_intro", {})
 	data._gs_intro = gs_intro if gs_intro is Dictionary else {}
 	var raw_menu_text: Variant = manifest.get("menu_text", {})
@@ -1711,6 +1714,28 @@ func intro_palette(name: String) -> PackedColorArray:
 	if not stored is Array:
 		return colors
 	for packed: Variant in stored as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## Whether the cache carries `_UnownPuzzle`'s art, which is the whole of what
+## the screen needs: a cartridge with no pin answers false and the special
+## refuses rather than opening an empty board.
+func has_unown_puzzle() -> bool:
+	return not (_unown_puzzle.get("palette", []) as Array).is_empty()
+
+
+## One of `_UnownPuzzle`'s tile strips, by the name
+## `RomLayout.UNOWN_PUZZLE_SECTION` gives it plus `tile_borders`.
+func unown_puzzle_indices(name: String) -> PackedByteArray:
+	return tile_indices("unown_puzzle_%s" % name)
+
+
+## PREDEFPAL_UNOWN_PUZZLE, the one palette `_CGB_UnownPuzzle` gives all four
+## background slots and object palette 0.
+func unown_puzzle_palette() -> PackedColorArray:
+	var colors := PackedColorArray()
+	for packed: Variant in _unown_puzzle.get("palette", []) as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -80,7 +80,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 78
+const FORMAT_VERSION: int = 79
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -342,6 +342,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not gs_intro["ok"]:
 		return gs_intro
 
+	var unown_puzzle: Dictionary = verify_unown_puzzle(rom, layout)
+	if not unown_puzzle["ok"]:
+		return unown_puzzle
+
 	var credits: Dictionary = verify_credits(rom, layout)
 	if not credits["ok"]:
 		return credits
@@ -1521,6 +1525,35 @@ static func verify_intro_movie(rom: RomFile, layout: Dictionary) -> Dictionary:
 			}
 	return {"ok": true, "message": "Intro movie verified."}
 
+
+## `_UnownPuzzle`'s art. The walk is most of the check: seven records whose
+## lengths are the sizes the routine copies into VRAM, each address the previous
+## entry's own consumed length, so one wrong pin fails the next entry.
+##
+## What the walk cannot see is that a puzzle picture is square: the four are
+## six by six tiles because `ConvertLoadedPuzzlePieces` doubles them into the
+## twelve-by-twelve grid the sixteen three-by-three pieces are cut from.
+static func verify_unown_puzzle(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("unown_puzzle", {})
+	if entry.is_empty() or int(entry.get("section", -1)) < 0:
+		return {"ok": true, "message": "No Unown puzzle on this cartridge."}
+
+	var section: Dictionary = read_unown_puzzle_section(rom, layout)
+	if section.is_empty():
+		return {"ok": false, "message": "The Unown puzzle section does not walk."}
+
+	var side: int = RomLayout.UNOWN_PUZZLE_PICTURE_TILES
+	for name: String in RomLayout.UNOWN_PUZZLE_PICTURES:
+		var tiles: int = int(section[name].size()) / Gen2Tiles.TILE_BYTES
+		if tiles != side * side:
+			return {
+				"ok": false,
+				"message": "The %s puzzle is not %d by %d tiles." % [name, side, side],
+			}
+
+	if RomLayout.predef_palette_offset(layout, RomLayout.PREDEFPAL_UNOWN_PUZZLE) < 0:
+		return {"ok": false, "message": "No PredefPals pin for the Unown puzzle palette."}
+	return {"ok": true, "message": "Unown puzzle verified."}
 
 ## `GoldSilverIntro`. The section walk is most of the check; what is left is the
 ## three palette runs outside it and the two metatile maps, which name their own
@@ -4058,6 +4091,7 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		"gs_intro": _import_gs_intro(rom, layout),
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
+		"unown_puzzle": _import_unown_puzzle(rom, layout),
 		"unown_words": Array(read_unown_words(rom, layout)),
 		"unown_walls": Array(read_unown_walls(rom, layout)),
 		"credits": _import_credits(rom, layout),
@@ -5411,6 +5445,90 @@ func _strip_sheet_entry(tiles: int) -> Dictionary:
 	}
 
 
+## `_UnownPuzzle`'s art section. `PuzzlePieceBorderData.TileBordersGFX` is pinned
+## on its own because thirty-four bytes of code sit between it and the run;
+## everything from `UnownPuzzleCursorGFX` on is one walk, each address the
+## previous entry's consumed length, with no alignment between them.
+##
+## Returns {name: PackedByteArray} in `UNOWN_PUZZLE_SECTION` order plus
+## `tile_borders`, or an empty Dictionary if any entry does not decompress to
+## its own size.
+static func read_unown_puzzle_section(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("unown_puzzle", {})
+	var borders: int = int(entry.get("tile_borders", -1))
+	var at: int = int(entry.get("section", -1))
+	if borders < 0 or at < 0:
+		return {}
+	var border_bytes: int = RomLayout.UNOWN_PUZZLE_BORDER_TILES * Gen2Tiles.TILE_BYTES
+	if not rom.in_bounds(borders, border_bytes):
+		return {}
+	var lz := Gen2Lz.new()
+	var out: Dictionary = {"tile_borders": rom.slice(borders, border_bytes)}
+	for row: Array in RomLayout.UNOWN_PUZZLE_SECTION:
+		var name: String = String(row[0])
+		var wanted: int = int(row[2]) * Gen2Tiles.TILE_BYTES
+		var raw: PackedByteArray = PackedByteArray()
+		var consumed: int = 0
+		if String(row[1]) == "raw":
+			if not rom.in_bounds(at, wanted):
+				return {}
+			raw = rom.slice(at, wanted)
+			consumed = wanted
+		else:
+			raw = lz.decompress(rom.bytes(), at)
+			consumed = lz.consumed
+			if lz.failed or raw.size() != wanted:
+				return {}
+		out[name] = raw
+		at += consumed
+		## The four pictures' own `.lz` files are zero-padded past the `$ff` the
+		## decompressor stops on: four bytes after Ho-Oh's stream, fifteen after
+		## Aerodactyl's, ten after Kabuto's, none after START>CANCEL's. A `$00`
+		## after a terminator cannot be a command, so the fill is skipped rather
+		## than modelled as an alignment, which no power of two fits. The walk
+		## still checks itself: every entry behind the fill has to decompress to
+		## exactly its own size.
+		while rom.in_bounds(at) and rom.u8(at) == 0:
+			at += 1
+	return out
+
+
+## The seven strips above, written the way the intro's are, plus the one palette
+## `_CGB_UnownPuzzle` draws the whole screen in.
+func _import_unown_puzzle_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_unown_puzzle_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var out: Dictionary = {}
+	var rows: Array = [
+		["tile_borders", "raw", RomLayout.UNOWN_PUZZLE_BORDER_TILES]
+	]
+	rows.append_array(RomLayout.UNOWN_PUZZLE_SECTION)
+	for row: Array in rows:
+		var name: String = String(row[0])
+		var tiles: int = int(row[2])
+		var path: String = RomCache.tile_path(directory, "unown_puzzle_%s" % name)
+		if not RomCache.write_indices(
+			path, Gen2Tiles.decode_2bpp_strip(section[name], 0, tiles)
+		):
+			return {}
+		out["unown_puzzle_%s" % name] = _strip_sheet_entry(tiles)
+	return out
+
+
+## `_CGB_UnownPuzzle`: `PalPacket_UnownPuzzle` names PREDEFPAL_UNOWN_PUZZLE for
+## all four background palettes, and object palette 0 is the same entry with its
+## first colour overwritten red, which is the colour the cursor is drawn in.
+func _import_unown_puzzle(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var palette: Array = _import_predef_palette(
+		rom, layout, RomLayout.PREDEFPAL_UNOWN_PUZZLE
+	)
+	if palette.is_empty():
+		return {}
+	return {"palette": palette}
+
+
 ## `GameFreakDittoGFX`, the one LZ run in the splash. `GameFreakPresentsInit`
 ## splits it over `vTiles0` and `vTiles1` as 128 tiles each, and the OAM sets
 ## index the result with a stride of $10, so it is kept as one strip of 256 and
@@ -5779,6 +5897,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_pc_sheets(rom, layout), true)
 	written.merge(_import_intro_sheets(rom, layout), true)
 	written.merge(_import_gs_intro_sheets(rom, layout), true)
+	written.merge(_import_unown_puzzle_sheets(rom, layout), true)
 	var done: int = 0
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1130,6 +1130,44 @@ const GS_INTRO_SHELLDER_LAPRAS_PALETTES: int = 3
 ## runs, which is after `BattleIntroSlidingPics`. Identical in all three dumps.
 ## `_CGB_MoveList`'s own background palette, which is why the move screen is
 ## the same warm gold as Goldenrod City rather than white.
+## `_UnownPuzzle`'s art (engine/games/unown_puzzle.asm), as (cache name, kind,
+## tiles). `raw` is an uncompressed strip, everything else an LZ one of that many
+## tiles. The order is the routine's own INCBIN order and is what the walk
+## depends on: `UnownPuzzleCursorGFX` pins the six behind it, each address the
+## previous entry's own consumed length, and all six reproduce pret's build byte
+## for byte on all three cartridges.
+##
+## `tile_borders` is pinned separately because it is not in that run:
+## `LoadUnownPuzzlePiecesGFX` and its pointer table sit between the borders and
+## the cursor, which is thirty-four bytes of code inside the data.
+##
+## A puzzle picture is six by six tiles and `ConvertLoadedPuzzlePieces` doubles
+## it to twelve by twelve, so the sixteen three-by-three pieces come out of one
+## 36-tile strip.
+const UNOWN_PUZZLE_SECTION: Array[Array] = [
+	["cursor", "raw", 4],
+	["start_cancel", "lz", 19],
+	["hooh", "lz", 36],
+	["aerodactyl", "lz", 36],
+	["kabuto", "lz", 36],
+	["omanyte", "lz", 36],
+]
+## `LoadUnownPuzzlePiecesGFX.LZPointers` in `UNOWNPUZZLE_*` order, which is what
+## the map's own `setval` in front of the special names. `maskbits
+## NUM_UNOWN_PUZZLES` is what bounds it, so the operand is taken modulo four.
+const UNOWN_PUZZLE_PICTURES: Array[String] = [
+	"kabuto", "omanyte", "aerodactyl", "hooh",
+]
+## A puzzle picture's side in tiles before `ConvertLoadedPuzzlePieces` doubles it.
+const UNOWN_PUZZLE_PICTURE_TILES: int = 6
+## `PuzzlePieceBorderData.TileBordersGFX`, the eight tiles
+## `UnownPuzzle_AddPuzzlePieceBorders` ORs onto every piece's outer eight.
+const UNOWN_PUZZLE_BORDER_TILES: int = 8
+## `PREDEFPAL_UNOWN_PUZZLE`, which `_CGB_UnownPuzzle` writes to all four
+## background palettes and to object palette 0.
+const PREDEFPAL_UNOWN_PUZZLE: int = 0x4C
+
+
 const PREDEFPAL_GOLDENROD: int = 0x10
 const PREDEFPAL_BLACKOUT: int = 0x1A
 const PREDEF_PALETTE_COLORS: int = 4
@@ -1975,6 +2013,9 @@ const GOLD_SILVER: Dictionary = {
 	},
 	# `CrystalIntro` is Crystal's; Gold and Silver run `GoldSilverIntro` below.
 	"intro_movie": {"section": -1, "fade": -1, "unown_pals": -1},
+	# `_UnownPuzzle`'s art, the same two pins as Crystal's at Gold and Silver's
+	# own addresses. Both cartridges carry it at the same offsets.
+	"unown_puzzle": {"tile_borders": 0xE1F30, "section": 0xE1FD2},
 	# `GoldSilverIntro`'s art section. `Intro_WaterGFX1` is the only pinned
 	# address in it: the section is contiguous and sixteen-byte aligned, so the
 	# walk in `GS_INTRO_SECTION` reaches the other ten, and all eleven reproduce
@@ -2437,6 +2478,10 @@ const CRYSTAL: Dictionary = {
 	# inside the code rather than in that section; both are unique byte runs, and
 	# `unown_1.pal` pins `unown_2.pal` directly behind it.
 	"intro_movie": {"section": 0xE555D, "fade": 0xE519C, "unown_pals": 0xE538D},
+	# `_UnownPuzzle`'s art. `PuzzlePieceBorderData.TileBordersGFX` and
+	# `UnownPuzzleCursorGFX` are the two pinned addresses; the walk in
+	# `UNOWN_PUZZLE_SECTION` reaches the five behind the cursor.
+	"unown_puzzle": {"tile_borders": 0xE1723, "section": 0xE17C5},
 	# Crystal ships no `GoldSilverIntro`. Nested the way trainer_card is, so the
 	# -1s stay out of the flat offset checks.
 	"gs_intro": {

--- a/game/render/unown_puzzle_page.gd
+++ b/game/render/unown_puzzle_page.gd
@@ -1,0 +1,357 @@
+class_name Gen2UnownPuzzlePage
+extends RefCounted
+
+## `_UnownPuzzle`'s screen: the board tilemap and the two object sets over it.
+##
+## Node-free, so the whole board can be read back headless. The tile bank is
+## built once per opened puzzle and the render is one index buffer.
+##
+## Four things the source states and a reading gets wrong:
+##
+## - **A puzzle picture is doubled, not drawn.** `ConvertLoadedPuzzlePieces`
+##   enlarges the 6x6 strip into a 12x12 one by taking each nibble through
+##   `.EnlargedTiles`, which is a two-times nearest scale of the whole picture:
+##   destination tile `(2r + h, 2c + w)` is source tile `(r, c)`'s own quarter.
+##   The sixteen three-by-three pieces are cut from that grid, so piece n's
+##   corner tile is `((n - 1) / 4) * 36 + ((n - 1) % 4) * 3`, which is
+##   `GetCurrentPuzzlePieceVTileCorner.Corners`.
+## - **The borders are ORed onto the pieces, in bitplanes.**
+##   `UnownPuzzle_AddPuzzlePieceBorders` runs `or [hl]` over the 2bpp bytes,
+##   which is a bitwise OR of the colour index per pixel, and it reaches the
+##   eight tiles around each piece's own centre rather than the picture's edge.
+## - **The board is drawn in vTiles0 and so from tile $00.** `ld a, %10010011`
+##   into `rLCDC` is the unsigned tile base, which is why a piece tile number is
+##   a small one and START>CANCEL sits at the top of the bank.
+## - **The cursor is red because of a palette write, not a tile.**
+##   `_CGB_UnownPuzzle` copies PREDEFPAL_UNOWN_PUZZLE everywhere and then
+##   overwrites object colour 0 with `palred 31`; `DmgToCgbObjPal0 $24` maps
+##   colour 3 onto colour 0, so the cursor's own ink draws in it.
+
+const TILE: int = Gen2Tiles.TILE_WIDTH
+const TILE_PIXELS: int = Gen2Tiles.TILE_PIXELS
+## `SCREEN_WIDTH` and `SCREEN_HEIGHT`.
+const SCREEN_COLUMNS: int = 20
+const SCREEN_ROWS: int = 18
+const WIDTH: int = SCREEN_COLUMNS * TILE
+const HEIGHT: int = SCREEN_ROWS * TILE
+## The whole vTiles0 bank the board indexes into.
+const BANK_TILES: int = 256
+
+## `PUZZLE_BORDER` and `PUZZLE_VOID`, the two tiles a vacant cell is filled with.
+const PUZZLE_BORDER: int = 0xEE
+const PUZZLE_VOID: int = 0xEF
+## `UnownPuzzleStartCancelLZ` goes to `vTiles0 tile $ed`, so the strip's own tile
+## 0 is $ed and PUZZLE_BORDER and PUZZLE_VOID are its next two.
+const START_CANCEL_FIRST_TILE: int = 0xED
+## `UnownPuzzleCursorGFX` goes to `vTiles0 tile $e0`.
+const CURSOR_FIRST_TILE: int = 0xE0
+
+## The doubled picture: twelve tiles across, which is the stride a piece's own
+## three-by-three block steps by.
+const PICTURE_TILES: int = 12
+## `.Corners`' own arithmetic.
+const PIECE_TILES: int = 3
+const PIECE_ROW_STRIDE: int = PICTURE_TILES * PIECE_TILES
+
+## `PuzzlePieceBorderData`: which tile of a piece each of the eight border tiles
+## is ORed onto, in the table's own order. The centre takes none.
+const BORDER_PIECE_TILES: Array[int] = [0, 1, 2, 12, 14, 24, 25, 26]
+
+## `UnownPuzzleCoordData`, one row per cell: the OAM point the cursor is centred
+## on and the tilemap corner the three-by-three block is drawn at. The vacant
+## tile is the ring's `PUZZLE_BORDER` or the inner square's `PUZZLE_VOID`, which
+## is derivable from the cell and so is not carried.
+const CELL_OAM_ORIGIN: Vector2i = Vector2i(3 * TILE + 4, 3 * TILE + 4)
+const CELL_OAM_STEP: int = 3 * TILE
+const CELL_MAP_ORIGIN: Vector2i = Vector2i(1, 0)
+const CELL_MAP_STEP: int = 3
+
+## `PlaceStartCancelBoxBorder`'s own tiles and corner, and the ten
+## `PlaceStartCancelBox` writes into the row between them.
+const BOX_CORNER: Vector2i = Vector2i(4, 15)
+const BOX_INNER_COLUMNS: int = 10
+const BOX_TOP_LEFT: int = 0xF0
+const BOX_TOP: int = 0xF1
+const BOX_TOP_RIGHT: int = 0xF2
+const BOX_SIDE: int = 0xF3
+const BOX_BOTTOM_LEFT: int = 0xF4
+const BOX_BOTTOM_RIGHT: int = 0xF5
+const BOX_TEXT_FIRST: int = 0xF6
+
+## `.OAM_NotHoldingPiece` and `.OAM_HoldingPiece`, as
+## (offset from the cell's point, tile, x flip, y flip). Both are three by three
+## objects around the point; the empty cursor is four tiles mirrored into nine
+## and the held piece is the piece's own nine.
+const CURSOR_OBJECTS: Array[Array] = [
+	[Vector2i(-12, -12), 0x00, false, false],
+	[Vector2i(-4, -12), 0x01, false, false],
+	[Vector2i(4, -12), 0x00, true, false],
+	[Vector2i(-12, -4), 0x02, false, false],
+	[Vector2i(-4, -4), 0x03, false, false],
+	[Vector2i(4, -4), 0x02, true, false],
+	[Vector2i(-12, 4), 0x00, false, true],
+	[Vector2i(-4, 4), 0x01, false, true],
+	[Vector2i(4, 4), 0x00, true, true],
+]
+const HELD_OBJECTS: Array[Array] = [
+	[Vector2i(-12, -12), 0x00],
+	[Vector2i(-4, -12), 0x01],
+	[Vector2i(4, -12), 0x02],
+	[Vector2i(-12, -4), 0x0C],
+	[Vector2i(-4, -4), 0x0D],
+	[Vector2i(4, -4), 0x0E],
+	[Vector2i(-12, 4), 0x18],
+	[Vector2i(-4, 4), 0x19],
+	[Vector2i(4, 4), 0x1A],
+]
+## The hardware's own OAM offsets, which a shadow-OAM value carries.
+const OAM_ORIGIN: Vector2i = Vector2i(8, 16)
+
+## `DmgToCgbBGPals $e4` and `DmgToCgbObjPal0 $24`, the two `CopyPals` orders the
+## screen is drawn through.
+const BG_ORDER: int = 0xE4
+const OBJECT_ORDER: int = 0x24
+## `palred 31 + palgreen 0 + palblue 0`, written over object colour 0.
+const CURSOR_COLOR: Color = Color(1.0, 0.0, 0.0, 1.0)
+
+var _tiles: PackedByteArray = PackedByteArray()
+var _background: PackedColorArray = PackedColorArray()
+var _objects: PackedColorArray = PackedColorArray()
+
+
+## The bank for one puzzle, [param puzzle] a `UNOWNPUZZLE_*` index.
+## `maskbits NUM_UNOWN_PUZZLES` is what bounds it on the cartridge, so an
+## operand outside the four wraps rather than failing.
+static func from_data(data: GameData, puzzle: int) -> Gen2UnownPuzzlePage:
+	if data == null or not data.has_unown_puzzle():
+		return null
+	var page := Gen2UnownPuzzlePage.new()
+	var names: Array[String] = RomLayout.UNOWN_PUZZLE_PICTURES
+	var picture: PackedByteArray = data.unown_puzzle_indices(
+		names[posmod(puzzle, names.size())]
+	)
+	var borders: PackedByteArray = data.unown_puzzle_indices("tile_borders")
+	var cursor: PackedByteArray = data.unown_puzzle_indices("cursor")
+	var box: PackedByteArray = data.unown_puzzle_indices("start_cancel")
+	var side: int = RomLayout.UNOWN_PUZZLE_PICTURE_TILES
+	if picture.size() < side * side * TILE_PIXELS or borders.is_empty() \
+		or cursor.is_empty() or box.is_empty():
+		return null
+
+	page._tiles.resize(BANK_TILES * TILE_PIXELS)
+	page._load_picture(picture, side)
+	page._add_piece_borders(borders)
+	page._load_strip(cursor, CURSOR_FIRST_TILE)
+	page._load_strip(box, START_CANCEL_FIRST_TILE)
+
+	var palette: PackedColorArray = data.unown_puzzle_palette()
+	if palette.size() < 4:
+		return null
+	page._background = Gen2WorldPalette.fade_palette(palette, BG_ORDER)
+	var objects: PackedColorArray = palette.duplicate()
+	objects[0] = CURSOR_COLOR
+	page._objects = Gen2WorldPalette.fade_palette(objects, OBJECT_ORDER)
+	return page
+
+
+func ready() -> bool:
+	return not _tiles.is_empty()
+
+
+func background_palette() -> PackedColorArray:
+	return _background
+
+
+func object_palette() -> PackedColorArray:
+	return _objects
+
+
+## The bank, as one index strip [constant BANK_TILES] tiles wide. Kept for the
+## check topic, which compares the doubling and the borders against the strips
+## the cache holds.
+func tile_indices(tile: int) -> PackedByteArray:
+	if tile < 0 or tile >= BANK_TILES:
+		return PackedByteArray()
+	return _tiles.slice(tile * TILE_PIXELS, (tile + 1) * TILE_PIXELS)
+
+
+## The whole screen for [param board]. [param frame] is `hVBlankCounter`, which
+## is what the empty cursor blinks off; a board that has been solved has lost the
+## START>CANCEL row and draws no objects at all, which is `PlaceStartCancelBoxBorder`
+## and `ClearSprites` on the way out.
+func render(board: Gen2UnownPuzzle, frame: int = Gen2UnownPuzzle.BLINK_MASK) -> Image:
+	var map: PackedByteArray = tilemap(board)
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(WIDTH * HEIGHT)
+	for row: int in SCREEN_ROWS:
+		for column: int in SCREEN_COLUMNS:
+			_blit(pixels, WIDTH, int(map[row * SCREEN_COLUMNS + column]),
+				Vector2i(column * TILE, row * TILE))
+	var image: Image = Gen2PicImage.from_indices(pixels, WIDTH, HEIGHT, _background)
+	if board == null or not board.cursor_visible(frame):
+		return image
+
+	var sprites: PackedByteArray = PackedByteArray()
+	sprites.resize(WIDTH * HEIGHT)
+	var point: Vector2i = cell_point(board.cursor())
+	if board.holding():
+		var corner: int = piece_corner_tile(board.held_piece())
+		for object: Array in HELD_OBJECTS:
+			_blit(sprites, WIDTH, corner + int(object[1]), point + (object[0] as Vector2i))
+	else:
+		for object: Array in CURSOR_OBJECTS:
+			_blit(
+				sprites, WIDTH, CURSOR_FIRST_TILE + int(object[1]),
+				point + (object[0] as Vector2i), bool(object[2]), bool(object[3])
+			)
+	image.blend_rect(
+		Gen2PicImage.from_indices(sprites, WIDTH, HEIGHT, _objects, true),
+		Rect2i(0, 0, WIDTH, HEIGHT), Vector2i.ZERO
+	)
+	return image
+
+
+## `UnownPuzzle_UpdateTilemap` over a screen `ByteFill`ed with PUZZLE_BORDER and
+## a twelve-by-twelve of PUZZLE_VOID, with `PlaceStartCancelBox` over the bottom.
+func tilemap(board: Gen2UnownPuzzle) -> PackedByteArray:
+	var map: PackedByteArray = PackedByteArray()
+	map.resize(SCREEN_COLUMNS * SCREEN_ROWS)
+	map.fill(PUZZLE_BORDER)
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		var piece: int = board.piece_at(cell) if board != null else 0
+		var at: Vector2i = cell_corner(cell)
+		var corner: int = piece_corner_tile(piece) if piece > 0 else -1
+		for row: int in PIECE_TILES:
+			for column: int in PIECE_TILES:
+				var tile: int = vacant_tile(cell)
+				if corner >= 0:
+					tile = corner + row * PICTURE_TILES + column
+				var to: Vector2i = at + Vector2i(column, row)
+				map[to.y * SCREEN_COLUMNS + to.x] = tile
+	_place_box(map, board == null or board.box_text_visible())
+	return map
+
+
+## `PlaceStartCancelBoxBorder`, and `PlaceStartCancelBox`'s ten text tiles when
+## the puzzle is still open. Solving it redraws the border alone, which leaves
+## the row PUZZLE_VOID.
+func _place_box(map: PackedByteArray, text: bool) -> void:
+	var right: int = BOX_CORNER.x + BOX_INNER_COLUMNS + 1
+	_write(map, Vector2i(BOX_CORNER.x, BOX_CORNER.y), BOX_TOP_LEFT)
+	_write(map, Vector2i(right, BOX_CORNER.y), BOX_TOP_RIGHT)
+	_write(map, Vector2i(BOX_CORNER.x, BOX_CORNER.y + 1), BOX_SIDE)
+	_write(map, Vector2i(right, BOX_CORNER.y + 1), BOX_SIDE)
+	_write(map, Vector2i(BOX_CORNER.x, BOX_CORNER.y + 2), BOX_BOTTOM_LEFT)
+	_write(map, Vector2i(right, BOX_CORNER.y + 2), BOX_BOTTOM_RIGHT)
+	for column: int in BOX_INNER_COLUMNS:
+		var x: int = BOX_CORNER.x + 1 + column
+		_write(map, Vector2i(x, BOX_CORNER.y), BOX_TOP)
+		_write(map, Vector2i(x, BOX_CORNER.y + 1),
+			BOX_TEXT_FIRST + column if text else PUZZLE_VOID)
+		_write(map, Vector2i(x, BOX_CORNER.y + 2), BOX_TOP)
+
+
+func _write(map: PackedByteArray, at: Vector2i, tile: int) -> void:
+	map[at.y * SCREEN_COLUMNS + at.x] = tile
+
+
+## `GetUnownPuzzleCoordData`'s filler column: the inner four by four is
+## PUZZLE_VOID and the ring around it PUZZLE_BORDER.
+static func vacant_tile(cell: int) -> int:
+	var row: int = cell / Gen2UnownPuzzle.COLUMNS
+	var column: int = cell % Gen2UnownPuzzle.COLUMNS
+	var inner: bool = row >= 1 and row <= Gen2UnownPuzzle.PIECE_COLUMNS \
+		and column >= 1 and column <= Gen2UnownPuzzle.PIECE_COLUMNS
+	return PUZZLE_VOID if inner else PUZZLE_BORDER
+
+
+## The cell's tilemap corner, `dwcoord`'s own column of `UnownPuzzleCoordData`.
+static func cell_corner(cell: int) -> Vector2i:
+	return CELL_MAP_ORIGIN + Vector2i(
+		(cell % Gen2UnownPuzzle.COLUMNS) * CELL_MAP_STEP,
+		(cell / Gen2UnownPuzzle.COLUMNS) * CELL_MAP_STEP
+	)
+
+
+## The cell's OAM point in screen pixels, `dbpixel`'s own column with the
+## hardware's offsets taken back off.
+static func cell_point(cell: int) -> Vector2i:
+	return CELL_OAM_ORIGIN - OAM_ORIGIN + Vector2i(
+		(cell % Gen2UnownPuzzle.COLUMNS) * CELL_OAM_STEP,
+		(cell / Gen2UnownPuzzle.COLUMNS) * CELL_OAM_STEP
+	)
+
+
+## `GetCurrentPuzzlePieceVTileCorner.Corners` as the arithmetic it is.
+static func piece_corner_tile(piece: int) -> int:
+	if piece < 1 or piece > Gen2UnownPuzzle.PIECES:
+		return CURSOR_FIRST_TILE
+	var index: int = piece - 1
+	return (index / Gen2UnownPuzzle.PIECE_COLUMNS) * PIECE_ROW_STRIDE \
+		+ (index % Gen2UnownPuzzle.PIECE_COLUMNS) * PIECE_TILES
+
+
+## `ConvertLoadedPuzzlePieces`, which is a two-times nearest scale of the
+## picture into the twelve-by-twelve grid the pieces are cut from.
+## The cache holds a picture as a strip of `side * side` tiles side by side and
+## eight rows tall, not as a square, so a source pixel is found through its own
+## tile rather than through a row of 48.
+func _load_picture(picture: PackedByteArray, side: int) -> void:
+	var stride: int = side * side * TILE
+	var pixels: int = side * TILE
+	for y: int in pixels * 2:
+		for x: int in pixels * 2:
+			var from_x: int = x >> 1
+			var from_y: int = y >> 1
+			var from: int = (from_y % TILE) * stride \
+				+ ((from_y / TILE) * side + from_x / TILE) * TILE + from_x % TILE
+			var tile: int = (y / TILE) * PICTURE_TILES + x / TILE
+			_tiles[tile * TILE_PIXELS + (y % TILE) * TILE + x % TILE] = int(picture[from])
+
+
+## `UnownPuzzle_AddPuzzlePieceBorders`: eight tiles ORed onto the eight around
+## every piece's own centre, `or [hl]` on the bitplanes being a bitwise OR of the
+## colour index.
+func _add_piece_borders(borders: PackedByteArray) -> void:
+	var count: int = borders.size() / (TILE * TILE)
+	for index: int in mini(count, BORDER_PIECE_TILES.size()):
+		for piece: int in range(1, Gen2UnownPuzzle.PIECES + 1):
+			var tile: int = piece_corner_tile(piece) + BORDER_PIECE_TILES[index]
+			for y: int in TILE:
+				for x: int in TILE:
+					var at: int = tile * TILE_PIXELS + y * TILE + x
+					_tiles[at] = int(_tiles[at]) | int(borders[y * count * TILE + index * TILE + x])
+
+
+## One decoded strip into the bank from [param first], which is the
+## `ld de, vTiles0 tile $xx` each `Decompress` or `CopyBytes` is handed.
+func _load_strip(strip: PackedByteArray, first: int) -> void:
+	var count: int = strip.size() / (TILE * TILE)
+	for tile: int in count:
+		if first + tile >= BANK_TILES:
+			break
+		for y: int in TILE:
+			for x: int in TILE:
+				_tiles[(first + tile) * TILE_PIXELS + y * TILE + x] = \
+					strip[y * count * TILE + tile * TILE + x]
+
+
+## One tile into an index buffer, with the two OAM flips a cursor object carries.
+func _blit(
+	buffer: PackedByteArray, width: int, tile: int, at: Vector2i,
+	flip_x: bool = false, flip_y: bool = false
+) -> void:
+	if tile < 0 or tile >= BANK_TILES:
+		return
+	var base: int = tile * TILE_PIXELS
+	for y: int in TILE:
+		var to_y: int = at.y + y
+		if to_y < 0 or to_y >= HEIGHT:
+			continue
+		var from_y: int = TILE - 1 - y if flip_y else y
+		for x: int in TILE:
+			var to_x: int = at.x + x
+			if to_x < 0 or to_x >= width:
+				continue
+			var from_x: int = TILE - 1 - x if flip_x else x
+			buffer[to_y * width + to_x] = _tiles[base + from_y * TILE + from_x]

--- a/game/render/unown_puzzle_page.gd.uid
+++ b/game/render/unown_puzzle_page.gd.uid
@@ -1,0 +1,1 @@
+uid://cud7qrewrkj8k

--- a/game/world/unown_puzzle.gd
+++ b/game/world/unown_puzzle.gd
@@ -1,0 +1,284 @@
+class_name Gen2UnownPuzzle
+extends RefCounted
+
+## `_UnownPuzzle` (engine/games/unown_puzzle.asm), the sliding-piece puzzle the
+## four Ruins of Alph chambers open.
+##
+## The board is `wPuzzlePieces`, six by six cells holding a piece number 1 to 16
+## or zero. Only the inner four by four is the picture; the ring around it is
+## where the sixteen pieces are scattered, less the four cells the START>CANCEL
+## box stands on, which is why `.PuzzlePieceInitialPositions` is sixteen entries
+## for sixteen pieces and the scatter is a permutation rather than a placement.
+##
+## Node-free and scene-free: the screen owns the frames and the sound, this owns
+## the rules, and the generator is injected so a run replays.
+##
+## Three things a reading gets wrong:
+##
+## - **The cursor walks cells, not tiles, and its edges are hand-listed.** The
+##   bottom border row is reachable at its two ends alone: `.d_right`'s own
+##   `.right_overflow` jumps cell 30 straight to 35 over the four the box
+##   covers, and `.d_left` jumps back. Nothing steps down out of the bottom
+##   inner row either, which is the four `ret z` in front of `.d_down`'s bound.
+## - **A press is refused rather than ignored.** Lifting from an empty cell and
+##   placing onto a full one both reach `UnownPuzzle_InvalidAction`, which plays
+##   `SFX_WRONG` and waits it out, so the frame is spent either way.
+## - **Holding a piece stops the cursor blinking.** `_UnownPuzzle.loop` reads
+##   `hVBlankCounter and $10` only when `wHoldingUnownPuzzlePiece` is clear, so
+##   the empty cursor is up sixteen frames in thirty-two and a held piece is up
+##   on every one of them.
+
+## `wPuzzlePieces` is six by six and `puzcoord` is `row * 6 + column`.
+const COLUMNS: int = 6
+const ROWS: int = 6
+const CELLS: int = COLUMNS * ROWS
+## The sixteen pieces, which is also the inner four by four.
+const PIECES: int = 16
+const PIECE_COLUMNS: int = 4
+
+## `.PuzzlePieceInitialPositions`: the whole top row and then the two end columns
+## of the five below it, which is every ring cell the START>CANCEL box does not
+## stand on.
+const START_CELLS: Array[int] = [
+	0, 1, 2, 3, 4, 5,
+	6, 11,
+	12, 17,
+	18, 23,
+	24, 29,
+	30, 35,
+]
+
+## The two cells `.right_overflow` and `.left_overflow` jump between, which is
+## how the cursor crosses the START>CANCEL box without entering it.
+const BOX_LEFT_CELL: int = 30
+const BOX_RIGHT_CELL: int = 35
+
+## `.d_down`'s four `ret z`: the bottom inner row steps nowhere.
+const NO_STEP_DOWN: Array[int] = [25, 26, 27, 28]
+
+## `JoyTextDelay`'s own repeat, which is what makes a held direction walk. The
+## frame a button is newly pressed reloads `wTextDelayFrames` with fifteen and
+## acts; after that `.restartframedelay` acts only on the frames the counter has
+## reached zero and reloads it with five.
+const REPEAT_DELAY_FRAMES: int = 15
+const REPEAT_RATE_FRAMES: int = 5
+
+## `hVBlankCounter and $10`: the empty cursor is drawn on the frames bit 4 is
+## set and cleared off the screen on the rest.
+const BLINK_MASK: int = 0x10
+
+## The six sounds, as constants/sfx_constants.asm's own indices. The comments
+## there are hexadecimal and the run has no gaps, so each is its position in the
+## enum. `SFX_PLACE_PUZZLE_PIECE_DOWN` is shared with `OWCutAnimation`.
+const SFX_MOVE_CURSOR: int = 0x31
+const SFX_MOVE_HELD_PIECE: int = 0x32
+const SFX_LIFT_PIECE: int = 0x3E
+const SFX_PLACE_PIECE: int = 0x1E
+const SFX_REFUSED: int = 0x19
+const SFX_SOLVED: int = 0x99
+
+var _pieces: PackedByteArray = PackedByteArray()
+var _cursor: int = 0
+var _holding: bool = false
+var _held: int = 0
+var _solved: bool = false
+var _finished: bool = false
+## `wTextDelayFrames`, which the VBlank handler decrements and `JoyTextDelay`
+## reloads. Carried here because the repeat is part of how the board is walked.
+var _delay: int = 0
+## Whether the board is waiting out `SimpleWaitPressAorB` after the last piece
+## went down, which is the one press the puzzle takes after it is solved.
+var _awaiting_solved_press: bool = false
+
+
+## `InitUnownPuzzlePiecePositions`, which walks 1 to 16 and drops each on a
+## random free start cell, rerolling on a taken one. Rerolling is a permutation
+## whatever the generator answers, so the shuffle is drawn as one rather than
+## looped: the roll order is the same set of outcomes and costs no unbounded
+## loop, and no caller can see the difference.
+static func create(rng: RandomNumberGenerator) -> Gen2UnownPuzzle:
+	var puzzle := Gen2UnownPuzzle.new()
+	puzzle._pieces.resize(CELLS)
+	var free: Array[int] = START_CELLS.duplicate()
+	for piece: int in range(1, PIECES + 1):
+		var at: int = 0
+		if rng != null and free.size() > 1:
+			at = rng.randi_range(0, free.size() - 1)
+		puzzle._pieces[free[at]] = piece
+		free.remove_at(at)
+	return puzzle
+
+
+func pieces() -> PackedByteArray:
+	return _pieces.duplicate()
+
+
+func piece_at(cell: int) -> int:
+	return int(_pieces[cell]) if cell >= 0 and cell < CELLS else 0
+
+
+func cursor() -> int:
+	return _cursor
+
+
+func holding() -> bool:
+	return _holding
+
+
+func held_piece() -> int:
+	return _held
+
+
+func solved() -> bool:
+	return _solved
+
+
+## `JUMPTABLE_EXIT_F`, which START sets and the solved board sets after its own
+## press.
+func finished() -> bool:
+	return _finished
+
+
+## Whether the cursor is drawn this frame. A held piece is always up; an empty
+## cursor blinks off `hVBlankCounter`. The solved tail's own `ClearSprites` runs
+## in front of `SimpleWaitPressAorB`, so nothing is drawn from the frame the last
+## piece went down.
+func cursor_visible(frame: int) -> bool:
+	if _awaiting_solved_press or _solved:
+		return false
+	return _holding or (frame & BLINK_MASK) != 0
+
+
+## Whether the START>CANCEL row is still written. The solved tail redraws
+## `PlaceStartCancelBoxBorder` alone, which leaves that row PUZZLE_VOID, and it
+## does so before the press rather than after it.
+func box_text_visible() -> bool:
+	return not (_awaiting_solved_press or _solved)
+
+
+## One pass of `_UnownPuzzle.loop`, [param pressed] the buttons that went down
+## this frame (`hJoyPressed`) and [param held] the ones still down
+## (`hJoyDown`, which is what `hJoyLast` carries with `hInMenu` set).
+##
+## Answers the sounds `PlaySFX` was handed, in order, plus whether the pass
+## solved the board. A caller spends the frame either way: `UnownPuzzle_A` and
+## `UnownPuzzle_InvalidAction` both end on `WaitSFX`.
+func advance(pressed: Array = [], held: Array = []) -> Dictionary:
+	var sounds: Array[int] = []
+	if _finished:
+		return {"sounds": sounds, "solved": _solved, "wait_sfx": false}
+
+	if _awaiting_solved_press:
+		## `SimpleWaitPressAorB`, the one press between the solved fanfare and
+		## the exit. No other button reaches it.
+		if Gen2Button.A in pressed or Gen2Button.B in pressed:
+			_awaiting_solved_press = false
+			_solved = true
+			_finished = true
+		return {"sounds": sounds, "solved": _solved, "wait_sfx": false}
+
+	var repeating: bool = _joy_text_delay(not pressed.is_empty())
+
+	if Gen2Button.START in pressed:
+		_finished = true
+		return {"sounds": sounds, "solved": false, "wait_sfx": false}
+
+	if Gen2Button.A in pressed:
+		return _press_a()
+
+	if repeating:
+		var step: int = _step_for(pressed + held)
+		if step != _cursor:
+			_cursor = step
+			sounds.append(SFX_MOVE_HELD_PIECE if _holding else SFX_MOVE_CURSOR)
+	return {"sounds": sounds, "solved": false, "wait_sfx": false}
+
+
+## `JoyTextDelay` with `hInMenu` set, which is what `_UnownPuzzle` sets on the
+## way in: `hJoyLast` is the held buttons on the frame a press starts and on
+## every fifth frame after fifteen, and zero on the rest. The counter is
+## decremented by the VBlank the loop's own `DelayFrame` waits for, which is
+## after the pass rather than before it.
+func _joy_text_delay(newly_pressed: bool) -> bool:
+	var acts: bool = true
+	if newly_pressed:
+		_delay = REPEAT_DELAY_FRAMES
+	elif _delay > 0:
+		acts = false
+	else:
+		_delay = REPEAT_RATE_FRAMES
+	_delay = maxi(_delay - 1, 0)
+	return acts
+
+
+## `UnownPuzzle_A`: lift the piece under the cursor, or put the held one down.
+## Both halves refuse rather than doing nothing, and the placement that fills the
+## board runs `CheckSolvedUnownPuzzle`.
+func _press_a() -> Dictionary:
+	var sounds: Array[int] = []
+	var occupant: int = int(_pieces[_cursor])
+	if not _holding:
+		if occupant == 0:
+			sounds.append(SFX_REFUSED)
+			return {"sounds": sounds, "solved": false, "wait_sfx": true}
+		sounds.append(SFX_LIFT_PIECE)
+		_pieces[_cursor] = 0
+		_held = occupant
+		_holding = true
+		return {"sounds": sounds, "solved": false, "wait_sfx": true}
+
+	if occupant != 0:
+		sounds.append(SFX_REFUSED)
+		return {"sounds": sounds, "solved": false, "wait_sfx": true}
+	sounds.append(SFX_PLACE_PIECE)
+	_pieces[_cursor] = _held
+	_held = 0
+	_holding = false
+	if not _is_solved():
+		return {"sounds": sounds, "solved": false, "wait_sfx": true}
+
+	## The solved tail: the box loses its START>CANCEL row, the cursor goes off
+	## the screen and the fanfare is waited out before the one press that leaves.
+	sounds.append(SFX_SOLVED)
+	_awaiting_solved_press = true
+	return {"sounds": sounds, "solved": true, "wait_sfx": true}
+
+
+## `CheckSolvedUnownPuzzle`: piece n sits at inner row `(n - 1) / 4` and column
+## `(n - 1) % 4`, and every ring cell is empty.
+func _is_solved() -> bool:
+	for cell: int in CELLS:
+		if int(_pieces[cell]) != solved_piece_at(cell):
+			return false
+	return true
+
+
+## `.SolvedPuzzleConfiguration`'s own byte for [param cell].
+static func solved_piece_at(cell: int) -> int:
+	var row: int = cell / COLUMNS
+	var column: int = cell % COLUMNS
+	if row < 1 or row > PIECE_COLUMNS or column < 1 or column > PIECE_COLUMNS:
+		return 0
+	return (row - 1) * PIECE_COLUMNS + column
+
+
+## Where the cursor lands for the direction in [param buttons], or where it
+## already is when the step is refused. `.Function` tests up, down, left and
+## right in that order and takes the first, so a diagonal is one direction.
+func _step_for(buttons: Array) -> int:
+	var column: int = _cursor % COLUMNS
+	if Gen2Button.UP in buttons:
+		return _cursor - COLUMNS if _cursor >= COLUMNS else _cursor
+	if Gen2Button.DOWN in buttons:
+		if _cursor in NO_STEP_DOWN or _cursor >= BOX_LEFT_CELL:
+			return _cursor
+		return _cursor + COLUMNS
+	if Gen2Button.LEFT in buttons:
+		if _cursor == BOX_RIGHT_CELL:
+			return BOX_LEFT_CELL
+		return _cursor if column == 0 else _cursor - 1
+	if Gen2Button.RIGHT in buttons:
+		if _cursor == BOX_LEFT_CELL:
+			return BOX_RIGHT_CELL
+		return _cursor if column == COLUMNS - 1 else _cursor + 1
+	return _cursor

--- a/game/world/unown_puzzle.gd.uid
+++ b/game/world/unown_puzzle.gd.uid
@@ -1,0 +1,1 @@
+uid://bt5sshsekvfyu

--- a/game/world/unown_puzzle_screen.gd
+++ b/game/world/unown_puzzle_screen.gd
@@ -1,0 +1,145 @@
+class_name Gen2UnownPuzzleScreen
+extends Control
+
+## `_UnownPuzzle`'s own loop, on the overworld's pump.
+##
+## [Gen2UnownPuzzle] owns the rules and [Gen2UnownPuzzlePage] the picture; this
+## is `.loop`: one pass a frame, `JoyTextDelay`'s repeat carried by the board,
+## and the exit `JUMPTABLE_EXIT_F` sets.
+##
+## Two things the loop states that a screen would otherwise get wrong:
+##
+## - **A press is answered where it lands as well as on the frame.** The host is
+##   press-only, so a tap between two frames would be lost; the pass runs on the
+##   press and the frame's own pass is skipped, which keeps one pass a frame.
+## - **`UnownPuzzle_A` ends on `WaitSFX` and nothing is read until it returns.**
+##   The wait is the driver's, not a frame count, so the screen holds while the
+##   player it was handed reports an effect. A screen with no player waits
+##   nothing, which is what a headless driver and every test see.
+
+signal closed(solved: bool)
+signal sfx_requested(index: int, waited: bool)
+
+var _board: Gen2UnownPuzzle = null
+var _page: Gen2UnownPuzzlePage = null
+var _view: TextureRect = null
+var _audio: Gen2AudioPlayer = null
+## `hVBlankCounter`, which the empty cursor blinks off.
+var _frame: int = 0
+## Whether this frame's pass has already run, which a press does.
+var _acted: bool = false
+## Whether `WaitSFX` is still holding.
+var _waiting: bool = false
+## `hJoyDown`, which the host can only say by pairing presses with releases. A
+## direction walks the board while it is held, so this is what the repeat reads.
+var _held: Array[int] = []
+var _open: bool = false
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## [param puzzle] is the `UNOWNPUZZLE_*` index the map's own `setval` left in
+## wScriptVar, [param rng] the generator the scatter is drawn from.
+##
+## Answers false on a cache with no puzzle art, which is what a caller refuses
+## the special on rather than opening an empty board.
+func open(data: GameData, puzzle: int, rng: RandomNumberGenerator) -> bool:
+	_page = Gen2UnownPuzzlePage.from_data(data, puzzle)
+	if _page == null or not _page.ready():
+		visible = false
+		return false
+	_board = Gen2UnownPuzzle.create(rng)
+	_open = true
+	visible = true
+	_refresh()
+	return true
+
+
+func set_audio_player(player: Gen2AudioPlayer) -> void:
+	_audio = player
+
+
+func board() -> Gen2UnownPuzzle:
+	return _board
+
+
+func page() -> Gen2UnownPuzzlePage:
+	return _page
+
+
+func frame_number() -> int:
+	return _frame
+
+
+## Whether `WaitSFX` is holding the loop this frame.
+func waiting_for_sfx() -> bool:
+	return _waiting
+
+
+func handle_button(button: int) -> bool:
+	if not _open or _board == null:
+		return false
+	if not _held.has(button):
+		_held.append(button)
+	if _waiting:
+		return true
+	_pass([button], _held)
+	_acted = true
+	_refresh()
+	return true
+
+
+## The other half of `hJoyDown`. A direction released stops walking; a press the
+## host never releases would otherwise repeat for ever.
+func release_button(button: int) -> void:
+	_held.erase(button)
+
+
+func advance_frame() -> void:
+	if not _open or _board == null:
+		return
+	_frame += 1
+	if _waiting:
+		## `WaitSFX`. Held by the driver rather than by a count, so a screen with
+		## no audio player is never held and a test drives straight through.
+		if _audio != null and _audio.effect_playing():
+			_refresh()
+			return
+		_waiting = false
+	if not _acted:
+		_pass([], _held)
+	_acted = false
+	_refresh()
+
+
+## One pass of `.loop`, and the exit it may reach.
+func _pass(pressed: Array, held: Array) -> void:
+	var result: Dictionary = _board.advance(pressed, held)
+	for index: int in result.get("sounds", []) as Array:
+		sfx_requested.emit(index, false)
+	if bool(result.get("wait_sfx", false)):
+		_waiting = true
+	if _board.finished():
+		close()
+
+
+func close() -> void:
+	if not _open:
+		return
+	_open = false
+	visible = false
+	closed.emit(_board != null and _board.solved())
+
+
+func _refresh() -> void:
+	if _page == null or _board == null:
+		return
+	if _view == null:
+		_view = TextureRect.new()
+		_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		add_child(_view)
+	_view.texture = ImageTexture.create_from_image(_page.render(_board, _frame))

--- a/game/world/unown_puzzle_screen.gd.uid
+++ b/game/world/unown_puzzle_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://bcx8q55vk575f

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -22,8 +22,9 @@ const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
 const SFX_JUMP_OVER_LEDGE: int = 0x16
 ## constants/sfx_constants.asm's SFX_PLACE_PUZZLE_PIECE_DOWN, played by
 ## OWCutAnimation before its sprite animation. The animation itself is not
-## rendered here; the sound is.
-const SFX_CUT: int = 0x38
+## rendered here; the sound is. Not SFX_CUT, which is $38 and is the battle
+## move's own effect: the field animation shares the Unown puzzle's sound.
+const SFX_CUT: int = Gen2UnownPuzzle.SFX_PLACE_PIECE
 ## constants/sfx_constants.asm's SFX_SURF, which is what PlayWhirlpoolSound plays
 ## (engine/events/field_moves.asm); there is no whirlpool-specific effect.
 const SFX_WHIRLPOOL: int = 0x53
@@ -157,6 +158,7 @@ var _move_deleter_host: Gen2MoveDeleterScreen = null
 ## the world state directly, which is what `DepositBreedmon` and `RetrieveBreedmon`
 ## do, so the save it was handed is kept beside it only to write nothing else.
 var _day_care_host: Gen2DayCareScreen = null
+var _unown_puzzle_host: Gen2UnownPuzzleScreen = null
 ## What `DayCareManOutside` left in wScriptVar, held between the screen finishing
 ## and the request completing. -1 while no routine has written one.
 var _day_care_script_value: int = -1
@@ -684,6 +686,8 @@ func advance_frame() -> void:
 		_move_deleter_host.advance_frame()
 	if _day_care_host != null:
 		_day_care_host.advance_frame()
+	if _unown_puzzle_host != null:
+		_unown_puzzle_host.advance_frame()
 	_spending_frame = false
 
 
@@ -828,7 +832,7 @@ func _overlay_open() -> bool:
 		or _pokedex_host != null or _credits_host != null \
 		or _evolution_host != null or _hatch_host != null \
 		or _name_rater_host != null or _move_deleter_host != null \
-		or _day_care_host != null
+		or _day_care_host != null or _unown_puzzle_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world. A
@@ -854,10 +858,14 @@ func _unhandled_input(event: InputEvent) -> void:
 		if press_button(button):
 			accept_event()
 		return
-	## The dex area's SELECT and the credits' A and B are held states rather than
-	## presses, and those two overlays are the only ones with anything to do with
-	## a release.
+	## The dex area's SELECT, the credits' A and B and the Unown puzzle's
+	## directions are held states rather than presses, and those three overlays
+	## are the only ones with anything to do with a release.
 	var released: int = Gen2Button.released_in(event)
+	if released != Gen2Button.NONE and _unown_puzzle_host != null:
+		_unown_puzzle_host.release_button(released)
+		accept_event()
+		return
 	if released != Gen2Button.NONE and _pokedex_host != null:
 		_pokedex_host.release_button(released)
 		accept_event()
@@ -940,6 +948,11 @@ func _handle_button(button: int) -> bool:
 	## The Day-Care's five, one screen with the same shape again.
 	if _day_care_host != null:
 		_day_care_host.handle_button(button)
+		return true
+	## `special UnownPuzzle`, which owns the whole screen until START or the
+	## last piece.
+	if _unown_puzzle_host != null:
+		_unown_puzzle_host.handle_button(button)
 		return true
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -1377,6 +1390,46 @@ func _on_name_rater_closed() -> void:
 ## routine writes the party, the two slots and the money itself, so nothing is
 ## staged: the cartridge's own routines write WRAM straight and the save is only
 ## committed when the player saves.
+## `special UnownPuzzle`. `FadeToMenu` in front of it and `ExitAllMenus` behind
+## it are what the host's own overlay already is: the board covers the map and
+## the map is redrawn when it closes.
+func _open_unown_puzzle(request: Dictionary) -> bool:
+	if _unown_puzzle_host != null or _world == null or _data == null:
+		return false
+	var host := Gen2UnownPuzzleScreen.new()
+	## The board is scattered from the world's own generator, so the run's seed
+	## reproduces it the way it reproduces an encounter.
+	if not host.open(
+		_data, int((request.get("values", {}) as Dictionary).get("puzzle", 0)),
+		_encounter_random
+	):
+		host.free()
+		_script_prompt = "Unown puzzle unavailable: unown_puzzle_art_unavailable"
+		return false
+	host.set_audio_player(_audio_player)
+	host.closed.connect(_on_unown_puzzle_closed)
+	host.sfx_requested.connect(_play_sfx)
+	host.z_index = 30
+	_unown_puzzle_host = host
+	_screen.display(host)
+	_script_prompt = "Unown puzzle"
+	_refresh_labels()
+	return true
+
+
+## `ld a, [wSolvedUnownPuzzle] / ld [wScriptVar], a`, which the chamber's own
+## `iftrue` after the `closetext` branches on.
+func _on_unown_puzzle_closed(solved: bool) -> void:
+	var host: Gen2UnownPuzzleScreen = _unown_puzzle_host
+	_unown_puzzle_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	_script_prompt = ""
+	_show_script_results(_world.complete_runtime_request({
+		"ok": true, "script_value": 1 if solved else 0,
+	}))
+
+
 func _open_day_care(request: Dictionary) -> bool:
 	if _day_care_host != null or _world == null or _data == null:
 		return false
@@ -2374,6 +2427,87 @@ func preview_day_care(role: StringName) -> void:
 		)
 		state.set_day_care_egg(save.party[0] as Gen2SaveMon)
 	_open_day_care({"values": {"role": role}})
+
+
+## Public screenshot driver and scene-test entry for `special UnownPuzzle`,
+## which only the four Ruins of Alph chambers reach and no fixture cell does.
+## [param puzzle] is the `UNOWNPUZZLE_*` index the chamber's own `setval` names.
+## Long enough for any of the puzzle's own effects to finish under the driver.
+const PUZZLE_WAIT_FRAME_CAP: int = 240
+
+
+## [param solve] walks the board into `.SolvedPuzzleConfiguration` through the
+## screen's own presses, which is the only way to photograph the assembled
+## picture: nothing else puts a piece anywhere.
+func preview_unown_puzzle(puzzle: int, solve: bool = false) -> void:
+	if _world == null or _data == null or _unown_puzzle_host != null:
+		return
+	_open_unown_puzzle({"values": {"puzzle": puzzle}})
+	if not solve or _unown_puzzle_host == null:
+		return
+	var board: Gen2UnownPuzzle = _unown_puzzle_host.board()
+	for piece: int in range(1, Gen2UnownPuzzle.PIECES + 1):
+		_walk_puzzle_cursor(_puzzle_cell_of(board, piece))
+		_press_puzzle_a()
+		_walk_puzzle_cursor(_puzzle_cell_of(board, piece, true))
+		_press_puzzle_a()
+
+
+## `UnownPuzzle_A` ends on `WaitSFX` and the loop reads nothing until it
+## returns, so a driver spending no frames would have its next press swallowed.
+func _press_puzzle_a() -> void:
+	var host: Gen2UnownPuzzleScreen = _unown_puzzle_host
+	if host == null:
+		return
+	host.handle_button(Gen2Button.A)
+	host.release_button(Gen2Button.A)
+	## The wait is the driver's, and a screenshot spends no wall clock for it to
+	## finish in, so the effect is cut rather than waited out: `SFXChannelsOff`
+	## is what the cartridge itself does to a sound it will not wait for.
+	if _audio_player != null:
+		_audio_player.stop_effects()
+	var guard: int = PUZZLE_WAIT_FRAME_CAP
+	while guard > 0 and host.waiting_for_sfx():
+		host.advance_frame()
+		guard -= 1
+
+
+## Which cell holds [param piece], or where the solved board wants it.
+func _puzzle_cell_of(
+	board: Gen2UnownPuzzle, piece: int, solved: bool = false
+) -> int:
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		var holds: int = Gen2UnownPuzzle.solved_piece_at(cell) if solved \
+			else board.piece_at(cell)
+		if holds == piece:
+			return cell
+	return 0
+
+
+## Up and left both refuse at the edge, so pressing each a row's worth parks the
+## cursor on cell 0, and the board is walked from there.
+func _walk_puzzle_cursor(cell: int) -> void:
+	var host: Gen2UnownPuzzleScreen = _unown_puzzle_host
+	if host == null:
+		return
+	## Each press is released before the next: `hJoyLast` carries every held
+	## button and `.Function` takes the first direction it finds, so a driver
+	## that never lets go would walk up for ever.
+	for _step: int in Gen2UnownPuzzle.ROWS:
+		_tap_puzzle(Gen2Button.LEFT)
+		_tap_puzzle(Gen2Button.UP)
+	for _step: int in cell / Gen2UnownPuzzle.COLUMNS:
+		_tap_puzzle(Gen2Button.DOWN)
+	for _step: int in cell % Gen2UnownPuzzle.COLUMNS:
+		_tap_puzzle(Gen2Button.RIGHT)
+
+
+func _tap_puzzle(button: int) -> void:
+	var host: Gen2UnownPuzzleScreen = _unown_puzzle_host
+	if host == null:
+		return
+	host.handle_button(button)
+	host.release_button(button)
 
 
 ## Public screenshot driver and scene-test entry for `OverworldHatchEgg`: it
@@ -4706,6 +4840,16 @@ func _show_script_results(results: Array) -> void:
 					if _open_day_care(request):
 						break
 					continue
+				if StringName(request.get("kind", &"")) == &"unown_puzzle_requested":
+					if _open_unown_puzzle(request):
+						break
+					## A cartridge whose cache has no puzzle art answers the
+					## script an unsolved board rather than stopping it, which is
+					## the `iftrue` the map takes either way.
+					_show_script_results(_world.complete_runtime_request({
+						"ok": true, "script_value": 0,
+					}))
+					return
 				if StringName(request.get("kind", &"")) == &"swarm_requested":
 					var values: Dictionary = request.get("values", {})
 					var swarm_results: Array = _world.complete_runtime_request({

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -233,6 +233,11 @@ const MONEY_WINDOW_KIND_OF: Dictionary = {
 ## chamber, where Gold and Silver's cells carry only the puzzle sign. A preceding
 ## `setval` puts the `UNOWNWORDS_*` index in wScriptVar. Not to be read as 41,
 ## which is `UnownPuzzle` on both and is the sliding puzzle itself.
+## `UnownPuzzle`, the sliding puzzle each of the four Ruins of Alph chambers
+## opens. The map's own `setval` in front of it names which picture; the special
+## answers `wSolvedUnownPuzzle` in wScriptVar, which the `iftrue` after the
+## `closetext` reads. 41 on both profiles, being under `special_index`'s split.
+const SPECIAL_UNOWN_PUZZLE: int = 41
 const SPECIAL_DISPLAY_UNOWN_WORDS: int = 135
 const SPECIAL_RANDOM_UNSEEN_WILD_MON: int = 91
 const SPECIAL_RANDOM_PHONE_WILD_MON: int = 92
@@ -894,6 +899,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## Neither routine writes anything a script reads: each returns and the
 		## map's own `waitbutton` presses the text it left standing.
 		&"name_rater_requested", &"move_deleter_requested",
+		## `UnownPuzzle` answers `wSolvedUnownPuzzle`, which is zero for a board
+		## left on START and one for a solved one.
+		&"unown_puzzle_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -2867,6 +2875,13 @@ func _execute_special(special: int) -> Dictionary:
 				"special": special,
 				"kind": &"toggle_decorations_visibility",
 				"defaults": true,
+			})
+		SPECIAL_UNOWN_PUZZLE:
+			return _stage_runtime_request(&"unown_puzzle_requested", {
+				"special": special,
+				## `maskbits NUM_UNOWN_PUZZLES` is what bounds the operand, so a
+				## value outside the four wraps rather than failing.
+				"puzzle": _script_value & 0x3,
 			})
 		SPECIAL_DISPLAY_UNOWN_WORDS:
 			## The word the wall spells, staged as the text `JoyWaitAorB` holds

--- a/tests/integration/test_world_unown_puzzle.gd
+++ b/tests/integration/test_world_unown_puzzle.gd
@@ -1,0 +1,140 @@
+extends GutTest
+
+## Scene integration for `special UnownPuzzle`, which is the whole line from the
+## chamber's script to the `iftrue` it branches on.
+##
+## `UnownPuzzle` is `FadeToMenu`, the board, and then
+## `ld a, [wSolvedUnownPuzzle] / ld [wScriptVar], a`, so the two things a unit
+## test cannot see are covered here: the board owns the screen while it is up,
+## and what it answers reaches the script. [Gen2UnownPuzzle]'s own rules are
+## `tests/unit/test_unown_puzzle.gd` and the art is
+## `tools/checks/unown_puzzle.gd`.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+
+const PLAYER_CELL: Vector2i = Vector2i(2, 2)
+const TALK_CELL: Vector2i = Vector2i(4, 5)
+
+## `UNOWNPUZZLE_AERODACTYL`, so the picture is not the first the table holds.
+const PUZZLE: int = 2
+
+var _data: GameData = null
+var _world_screen: Gen2WorldScreen = null
+
+
+func before_each() -> void:
+	Fixture.build()
+	_write_puzzle_script()
+	_data = GameData.open_directory(Fixture.directory())
+	Gen2OptionsStore.use_test_path()
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
+
+
+func after_each() -> void:
+	await get_tree().process_frame
+	if is_instance_valid(_world_screen):
+		_world_screen.free()
+		_world_screen = null
+	RomCache.clear(Fixture.directory())
+
+
+## `RuinsOfAlphKabutoChamberPuzzle`'s own shape: `setval`, the special, and an
+## `iftrue` whose branch is the only thing that says what the board answered.
+## The branch sets an event, which is what the chamber does with it.
+const SOLVED_SCRIPT: int = 0x6190
+const SOLVED_EVENT: int = 0x123
+
+
+func _write_puzzle_script() -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		Gen2WorldScript.SETVAL, PUZZLE,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_UNOWN_PUZZLE, 0x00,
+		Gen2WorldScript.IFTRUE, SOLVED_SCRIPT & 0xFF, SOLVED_SCRIPT >> 8,
+		Gen2WorldScript.END,
+	]
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, SOLVED_SCRIPT)] = [
+		Gen2WorldScript.SETEVENT, SOLVED_EVENT & 0xFF, SOLVED_EVENT >> 8,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+
+
+func _open_world() -> void:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = PLAYER_CELL
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, Gen2WorldState.new()
+	)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	save.world = world.snapshot()
+	_world_screen.set_data(_data)
+	_world_screen.set_save(save)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	## The board counts hardware frames, so the ones this test spends have to be
+	## the ones it asks for.
+	_world_screen.set_process(false)
+
+
+func _run_script() -> void:
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(TALK_CELL)
+	)
+
+
+func _host() -> Gen2UnownPuzzleScreen:
+	return _world_screen._unown_puzzle_host
+
+
+func test_the_special_opens_the_board_and_holds_the_world() -> void:
+	await _open_world()
+	_run_script()
+	assert_not_null(_host(), "the special must open the board")
+	assert_true(_host().visible)
+	assert_false(_world_screen.move_player(Vector2i.RIGHT))
+	assert_false(_world_screen.interact())
+
+
+## The `setval` in front of the special is which picture, and nothing else picks
+## one: a board opened for Aerodactyl draws Aerodactyl's own tiles.
+func test_the_setval_in_front_of_it_picks_the_picture() -> void:
+	await _open_world()
+	_run_script()
+	var page: Gen2UnownPuzzlePage = _host().page()
+	assert_not_null(page)
+	var wanted: PackedByteArray = _data.unown_puzzle_indices(
+		RomLayout.UNOWN_PUZZLE_PICTURES[PUZZLE]
+	)
+	## The fixture fills each picture with its own index, so the doubled bank's
+	## first pixel says which strip it was built from. The border is ORed onto
+	## that tile, so the centre of a piece is what carries the strip alone.
+	var centre: PackedByteArray = page.tile_indices(
+		Gen2UnownPuzzlePage.piece_corner_tile(1) + 0x0D
+	)
+	assert_eq(int(centre[0]), int(wanted[0]))
+
+
+## START is `UnownPuzzle_Quit`, which leaves `wSolvedUnownPuzzle` at the zero
+## `_UnownPuzzle` cleared it to, so the script's own `iftrue` does not branch.
+func test_start_closes_the_board_and_answers_the_script_zero() -> void:
+	await _open_world()
+	_run_script()
+	_world_screen.press_button(Gen2Button.START)
+	assert_null(_host(), "START must close the board")
+	assert_false(
+		_world_screen._world.state.is_event_flag_active(SOLVED_EVENT),
+		"an unsolved board must not take the `iftrue`"
+	)
+
+
+## The world takes its own presses back once the board has gone.
+func test_the_world_moves_again_once_the_board_closes() -> void:
+	await _open_world()
+	_run_script()
+	_world_screen.press_button(Gen2Button.START)
+	assert_true(_world_screen.move_player(Vector2i.RIGHT))

--- a/tests/integration/test_world_unown_puzzle.gd.uid
+++ b/tests/integration/test_world_unown_puzzle.gd.uid
@@ -1,0 +1,1 @@
+uid://codhtr4x3n8mh

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -97,6 +97,7 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_day_care_text(manifest)
 	_write_pokecenter_pc(manifest)
 	_write_unown_words(manifest)
+	_write_unown_puzzle(directory, manifest)
 	_write_credits(directory, manifest, crystal_commands)
 	_write_name_input_chars(directory)
 	_write_intro_text(directory, crystal_commands)
@@ -524,6 +525,40 @@ static func _write_unown_words(manifest: Dictionary) -> void:
 	for form: int in RomLayout.UNOWN_FORMS:
 		words.append("%sWORD" % char("A".unicode_at(0) + form))
 	manifest["unown_words"] = words
+
+
+## `_UnownPuzzle`'s seven strips and its one palette. Nothing here is the
+## cartridge's picture: what the screen needs from the cache is a strip of the
+## right length per name, since the doubling and the borders are arithmetic over
+## whatever is in them. Each strip is filled with a different index so a tile
+## drawn from the wrong one is visible rather than merely different.
+static func _write_unown_puzzle(directory: String, manifest: Dictionary) -> void:
+	var sheets: Dictionary = manifest.get("tiles", {})
+	var rows: Array = [["tile_borders", RomLayout.UNOWN_PUZZLE_BORDER_TILES]]
+	rows.append(["cursor", 4])
+	rows.append(["start_cancel", 19])
+	var side: int = RomLayout.UNOWN_PUZZLE_PICTURE_TILES
+	for name: String in RomLayout.UNOWN_PUZZLE_PICTURES:
+		rows.append([name, side * side])
+	var fill: int = 0
+	for row: Array in rows:
+		var key: String = "unown_puzzle_%s" % String(row[0])
+		var tile_count: int = int(row[1])
+		var indices: PackedByteArray = PackedByteArray()
+		indices.resize(tile_count * Gen2Tiles.TILE_PIXELS)
+		indices.fill(fill % 4)
+		fill += 1
+		RomCache.write_indices(RomCache.tile_path(directory, key), indices)
+		sheets[key] = {
+			"width": tile_count * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": tile_count,
+			"first_code": 0,
+			"bits": 2,
+		}
+	manifest["tiles"] = sheets
+	## PREDEFPAL_UNOWN_PUZZLE as the cartridge stores it.
+	manifest["unown_puzzle"] = {"palette": [0x7FFF, 0x2E98, 0x2DB2, 0x0000]}
 
 
 static func _write_pokecenter_pc(manifest: Dictionary) -> void:

--- a/tests/unit/test_unown_puzzle.gd
+++ b/tests/unit/test_unown_puzzle.gd
@@ -1,0 +1,208 @@
+extends GutTest
+
+## `engine/games/unown_puzzle.asm`, the rules half.
+##
+## Scene-free: [Gen2UnownPuzzle] is the board and its generator is injected, so a
+## case is a scatter, a walk and a press. The corpus sweep on real cartridges is
+## `tools/checks/unown_puzzle.gd`, which owns the art, the doubling and the
+## thirty-six cells against four directions; the point of these is the branches
+## a sweep cannot single out, which is every one that turns on what the cursor is
+## carrying or on the order two presses happen in.
+
+const UP: int = Gen2Button.UP
+const DOWN: int = Gen2Button.DOWN
+const LEFT: int = Gen2Button.LEFT
+const RIGHT: int = Gen2Button.RIGHT
+const A: int = Gen2Button.A
+const START: int = Gen2Button.START
+
+
+func _press(puzzle: Gen2UnownPuzzle, button: int) -> Dictionary:
+	return puzzle.advance([button], [button])
+
+
+## Walk the cursor to [param cell] from wherever it stands. Up and left both
+## refuse at the edge, so pressing each six times parks it on cell 0, and the
+## board is walked from there down the first column and along the row.
+func _walk_to(puzzle: Gen2UnownPuzzle, cell: int) -> void:
+	for _step: int in Gen2UnownPuzzle.ROWS:
+		_press(puzzle, LEFT)
+		_press(puzzle, UP)
+	for _step: int in cell / Gen2UnownPuzzle.COLUMNS:
+		_press(puzzle, DOWN)
+	for _step: int in cell % Gen2UnownPuzzle.COLUMNS:
+		_press(puzzle, RIGHT)
+	assert_eq(puzzle.cursor(), cell, "the cursor did not reach cell %d" % cell)
+
+
+func test_scatter_is_a_permutation_of_the_sixteen_start_cells() -> void:
+	## `InitUnownPuzzlePiecePositions` rerolls a taken cell, so sixteen pieces
+	## land on sixteen of the twenty ring cells and never on the four the
+	## START>CANCEL box stands on.
+	for seed_value: int in 8:
+		var rng := RandomNumberGenerator.new()
+		rng.seed = seed_value
+		var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(rng)
+		var seen: Array[int] = []
+		for cell: int in Gen2UnownPuzzle.CELLS:
+			var piece: int = puzzle.piece_at(cell)
+			if piece == 0:
+				continue
+			assert_true(
+				cell in Gen2UnownPuzzle.START_CELLS,
+				"seed %d put a piece on cell %d" % [seed_value, cell]
+			)
+			assert_false(seen.has(piece), "seed %d placed piece %d twice" % [seed_value, piece])
+			seen.append(piece)
+		assert_eq(seen.size(), Gen2UnownPuzzle.PIECES)
+
+
+func test_the_same_seed_scatters_the_same_board() -> void:
+	var first := RandomNumberGenerator.new()
+	var second := RandomNumberGenerator.new()
+	first.seed = 12345
+	second.seed = 12345
+	assert_eq(
+		Gen2UnownPuzzle.create(first).pieces(),
+		Gen2UnownPuzzle.create(second).pieces(),
+		"a replayed run must scatter the board it recorded"
+	)
+
+
+func test_the_cursor_crosses_the_start_cancel_box_at_its_two_ends() -> void:
+	## `.right_overflow` and `.left_overflow`: cell 30 steps straight to 35 over
+	## the four cells the box covers, and back.
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	_walk_to(puzzle, Gen2UnownPuzzle.BOX_LEFT_CELL)
+	_press(puzzle, RIGHT)
+	assert_eq(puzzle.cursor(), Gen2UnownPuzzle.BOX_RIGHT_CELL)
+	_press(puzzle, LEFT)
+	assert_eq(puzzle.cursor(), Gen2UnownPuzzle.BOX_LEFT_CELL)
+
+
+func test_the_bottom_inner_row_steps_nowhere_down() -> void:
+	## `.d_down`'s four `ret z`, which is what stops the cursor walking into the
+	## box from above.
+	for cell: int in Gen2UnownPuzzle.NO_STEP_DOWN:
+		var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+		_walk_to(puzzle, cell)
+		_press(puzzle, DOWN)
+		assert_eq(puzzle.cursor(), cell, "cell %d stepped down" % cell)
+
+
+func test_a_held_direction_repeats_after_fifteen_frames_then_every_fifth() -> void:
+	## `JoyTextDelay`: the press acts, then `wTextDelayFrames` holds for fifteen
+	## frames and `.restartframedelay` acts every fifth after that.
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	puzzle.advance([RIGHT], [RIGHT])
+	assert_eq(puzzle.cursor(), 1, "the press itself must step")
+	var steps: Array[int] = []
+	for frame: int in 30:
+		var before: int = puzzle.cursor()
+		puzzle.advance([], [RIGHT])
+		if puzzle.cursor() != before:
+			steps.append(frame)
+	assert_eq(
+		steps, [14, 19, 24, 29] as Array[int],
+		"the repeat is fifteen frames and then one in five"
+	)
+
+
+func test_a_released_direction_stops_repeating() -> void:
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	puzzle.advance([RIGHT], [RIGHT])
+	for _frame: int in 40:
+		puzzle.advance([], [])
+	assert_eq(puzzle.cursor(), 1, "a board with nothing held must not walk")
+
+
+func test_lifting_an_empty_cell_is_refused_with_a_sound() -> void:
+	## `UnownPuzzle_InvalidAction`, which plays SFX_WRONG and waits it out rather
+	## than doing nothing.
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	_walk_to(puzzle, 7)
+	var result: Dictionary = _press(puzzle, A)
+	assert_eq(result["sounds"], [Gen2UnownPuzzle.SFX_REFUSED] as Array[int])
+	assert_true(bool(result["wait_sfx"]), "the refusal spends its own frame")
+	assert_false(puzzle.holding())
+
+
+func test_a_piece_is_lifted_and_put_down_on_an_empty_cell() -> void:
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	var piece: int = puzzle.piece_at(0)
+	assert_gt(piece, 0, "cell 0 is a start cell")
+	var lifted: Dictionary = _press(puzzle, A)
+	assert_eq(lifted["sounds"], [Gen2UnownPuzzle.SFX_LIFT_PIECE] as Array[int])
+	assert_true(puzzle.holding())
+	assert_eq(puzzle.held_piece(), piece)
+	assert_eq(puzzle.piece_at(0), 0, "the cell the piece came off is empty")
+
+	## A held piece moves with the cursor and answers a different sound doing it.
+	_press(puzzle, DOWN)
+	var moved: Dictionary = _press(puzzle, RIGHT)
+	assert_eq(moved["sounds"], [Gen2UnownPuzzle.SFX_MOVE_HELD_PIECE] as Array[int])
+	var placed: Dictionary = _press(puzzle, A)
+	assert_eq(placed["sounds"], [Gen2UnownPuzzle.SFX_PLACE_PIECE] as Array[int])
+	assert_false(puzzle.holding())
+	assert_eq(puzzle.piece_at(7), piece)
+
+
+func test_placing_onto_an_occupied_cell_is_refused_and_keeps_the_piece() -> void:
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	var piece: int = puzzle.piece_at(0)
+	_press(puzzle, A)
+	_press(puzzle, RIGHT)
+	var refused: Dictionary = _press(puzzle, A)
+	assert_eq(refused["sounds"], [Gen2UnownPuzzle.SFX_REFUSED] as Array[int])
+	assert_true(puzzle.holding(), "the refusal must not drop the piece")
+	assert_eq(puzzle.held_piece(), piece)
+
+
+func test_start_leaves_the_board_unsolved() -> void:
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	_press(puzzle, START)
+	assert_true(puzzle.finished())
+	assert_false(puzzle.solved())
+
+
+func test_solving_the_board_takes_one_more_press_before_it_leaves() -> void:
+	## `CheckSolvedUnownPuzzle` returning carry runs the fanfare and then
+	## `SimpleWaitPressAorB`, so the last piece going down does not leave.
+	var puzzle: Gen2UnownPuzzle = Gen2UnownPuzzle.create(null)
+	var solved_sounds: Array = _solve(puzzle)
+	assert_eq(
+		solved_sounds,
+		[Gen2UnownPuzzle.SFX_PLACE_PIECE, Gen2UnownPuzzle.SFX_SOLVED] as Array[int]
+	)
+	assert_false(puzzle.finished(), "the solved board waits for a press")
+	assert_false(
+		puzzle.box_text_visible(),
+		"`PlaceStartCancelBoxBorder` runs before the press, not after it"
+	)
+	assert_false(puzzle.cursor_visible(Gen2UnownPuzzle.BLINK_MASK), "`ClearSprites` too")
+	_press(puzzle, A)
+	assert_true(puzzle.finished())
+	assert_true(puzzle.solved())
+
+
+## Moves every piece into `.SolvedPuzzleConfiguration`'s own cell and answers the
+## sounds the last placement made.
+func _solve(puzzle: Gen2UnownPuzzle) -> Array:
+	var sounds: Array = []
+	for piece: int in range(1, Gen2UnownPuzzle.PIECES + 1):
+		var from: int = -1
+		for cell: int in Gen2UnownPuzzle.CELLS:
+			if puzzle.piece_at(cell) == piece:
+				from = cell
+				break
+		assert_gt(from, -1, "piece %d is on the board" % piece)
+		_walk_to(puzzle, from)
+		_press(puzzle, A)
+		var to: int = -1
+		for cell: int in Gen2UnownPuzzle.CELLS:
+			if Gen2UnownPuzzle.solved_piece_at(cell) == piece:
+				to = cell
+				break
+		_walk_to(puzzle, to)
+		sounds = _press(puzzle, A)["sounds"]
+	return sounds

--- a/tests/unit/test_unown_puzzle.gd.uid
+++ b/tests/unit/test_unown_puzzle.gd.uid
@@ -1,0 +1,1 @@
+uid://d21mshhafm56b

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -49,7 +49,7 @@ const EXPECTED_DEFERRED: Dictionary = {
 	## work, not a dispatch entry: it opens a screen, spends a transaction, or
 	## reads a save field nothing writes.
 	25: "CheckMagikarpLength", 26: "MagikarpHouseSign",
-	34: "BankOfMom", 39: "UnownPrinter", 40: "MapRadio", 41: "UnownPuzzle",
+	34: "BankOfMom", 39: "UnownPrinter", 40: "MapRadio",
 	42: "SlotMachine", 43: "CardFlip", 57: "GameCornerPrizeMonCheckDex",
 	75: "GiveShuckle", 76: "ReturnShuckie",
 	82: "CheckForLuckyNumberWinners",

--- a/tools/checks/unown_puzzle.gd
+++ b/tools/checks/unown_puzzle.gd
@@ -1,0 +1,393 @@
+extends RefCounted
+
+## Sweeps `_UnownPuzzle` on freshly imported real caches, all three cartridges,
+## all four pictures, all thirty-six cells and all sixteen pieces.
+##
+## Every expectation below is transcribed from pokecrystal's own
+## engine/games/unown_puzzle.asm rather than read back out of the
+## implementation, which is the only way the topic can go red: the corners, the
+## solved configuration, the two OAM sets and the cursor's own hand-listed edges
+## are the source's tables, and the art is re-read out of the dump beside the
+## cache rather than compared with itself.
+##
+## The class of bug it exists to catch is the doubling. `ConvertLoadedPuzzlePieces`
+## and `UnownPuzzle_AddPuzzlePieceBorders` are two passes over one strip, and a
+## picture that is off by a nibble, a half-tile or a bitplane still draws
+## something. So the check asserts the pixel identity per piece rather than a
+## checksum: 144 tiles a picture, four pictures, three cartridges.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- unown_puzzle
+
+const TILE: int = Gen2Tiles.TILE_WIDTH
+
+## `.Corners`, the sixteen `GetCurrentPuzzlePieceVTileCorner` answers for pieces
+## 1 to 16, and its own `$e0` for none.
+const CORNERS: Array[int] = [
+	0x00, 0x03, 0x06, 0x09,
+	0x24, 0x27, 0x2A, 0x2D,
+	0x48, 0x4B, 0x4E, 0x51,
+	0x6C, 0x6F, 0x72, 0x75,
+]
+const NO_PIECE_CORNER: int = 0xE0
+
+## `.SolvedPuzzleConfiguration`, byte for byte.
+const SOLVED: Array[int] = [
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x00,
+	0x00, 0x05, 0x06, 0x07, 0x08, 0x00,
+	0x00, 0x09, 0x0A, 0x0B, 0x0C, 0x00,
+	0x00, 0x0D, 0x0E, 0x0F, 0x10, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]
+
+## `PuzzlePieceBorderData`'s destinations, and the one tile of a piece it leaves
+## alone.
+const BORDERED: Array[int] = [0x00, 0x01, 0x02, 0x0C, 0x0E, 0x18, 0x19, 0x1A]
+const UNBORDERED_CENTRE: int = 0x0D
+
+## `UnownPuzzleCoordData`'s tilemap column, `dwcoord x, y` per cell.
+const MAP_COORDS: Array[Array] = [
+	[1, 0], [4, 0], [7, 0], [10, 0], [13, 0], [16, 0],
+	[1, 3], [4, 3], [7, 3], [10, 3], [13, 3], [16, 3],
+	[1, 6], [4, 6], [7, 6], [10, 6], [13, 6], [16, 6],
+	[1, 9], [4, 9], [7, 9], [10, 9], [13, 9], [16, 9],
+	[1, 12], [4, 12], [7, 12], [10, 12], [13, 12], [16, 12],
+	[1, 15], [4, 15], [7, 15], [10, 15], [13, 15], [16, 15],
+]
+## Its `dbpixel x, y, 4, 4` column, as the OAM bytes the macro emits.
+const OAM_COORDS: Array[Array] = [
+	[28, 28], [52, 28], [76, 28], [100, 28], [124, 28], [148, 28],
+	[28, 52], [52, 52], [76, 52], [100, 52], [124, 52], [148, 52],
+	[28, 76], [52, 76], [76, 76], [100, 76], [124, 76], [148, 76],
+	[28, 100], [52, 100], [76, 100], [100, 100], [124, 100], [148, 100],
+	[28, 124], [52, 124], [76, 124], [100, 124], [124, 124], [148, 124],
+	[28, 148], [52, 148], [76, 148], [100, 148], [124, 148], [148, 148],
+]
+## Its own filler column: PUZZLE_BORDER for the ring, PUZZLE_VOID for the square.
+const VACANT: Array[int] = [
+	0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE,
+	0xEE, 0xEF, 0xEF, 0xEF, 0xEF, 0xEE,
+	0xEE, 0xEF, 0xEF, 0xEF, 0xEF, 0xEE,
+	0xEE, 0xEF, 0xEF, 0xEF, 0xEF, 0xEE,
+	0xEE, 0xEF, 0xEF, 0xEF, 0xEF, 0xEE,
+	0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE,
+]
+
+## The strips the section carries and the tile count each is copied into VRAM as.
+const STRIPS: Dictionary = {
+	"tile_borders": 8, "cursor": 4, "start_cancel": 19,
+	"hooh": 36, "aerodactyl": 36, "kabuto": 36, "omanyte": 36,
+}
+
+## `.d_up`, `.d_down`, `.d_left` and `.d_right` restated as the cells each
+## refuses. Everything else steps by six or by one, less the two overflows.
+const NO_STEP_UP: Array[int] = [0, 1, 2, 3, 4, 5]
+const NO_STEP_DOWN: Array[int] = [25, 26, 27, 28, 30, 31, 32, 33, 34, 35]
+const NO_STEP_LEFT: Array[int] = [0, 6, 12, 18, 24, 30]
+const NO_STEP_RIGHT: Array[int] = [5, 11, 17, 23, 29, 35]
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		if not _r.check(
+			data.has_unown_puzzle(), "%s: no Unown puzzle art in the cache." % game_id
+		):
+			continue
+		_verify_section(game_id, data)
+		_verify_palette(game_id, data)
+		for puzzle: int in RomLayout.UNOWN_PUZZLE_PICTURES.size():
+			_verify_bank(game_id, data, puzzle)
+			_verify_board(game_id, data, puzzle)
+	_r.game_id = &""
+	_verify_rules()
+
+
+## The cache against a second reading of the dump, which is what says the walk
+## found the records rather than seven runs that happen to decompress.
+func _verify_section(game_id: StringName, data: GameData) -> void:
+	var rom: RomFile = RomFile.open_verified("res://roms/%s.gbc" % game_id)
+	if not _r.check(rom != null, "%s: roms/%s.gbc is unreadable." % [game_id, game_id]):
+		return
+	var section: Dictionary = RomImporter.read_unown_puzzle_section(
+		rom, RomLayout.for_id(rom.id)
+	)
+	if not _r.check(
+		section.size() == STRIPS.size(),
+		"%s: the puzzle section walked %d records, not %d." % [
+			game_id, section.size(), STRIPS.size()
+		]
+	):
+		return
+	for name: String in STRIPS:
+		var tiles: int = int(STRIPS[name])
+		_r.check(
+			int(section[name].size()) == tiles * Gen2Tiles.TILE_BYTES,
+			"%s: %s is %d bytes, not %d tiles." % [
+				game_id, name, section[name].size(), tiles
+			]
+		)
+		_r.check(
+			data.unown_puzzle_indices(name) == Gen2Tiles.decode_2bpp_strip(
+				section[name], 0, tiles
+			),
+			"%s: the cached %s strip is not the dump's." % [game_id, name]
+		)
+	_r.note("%s: %d puzzle records, %d tiles." % [
+		game_id, STRIPS.size(), _total_tiles()
+	])
+
+
+## `_CGB_UnownPuzzle`: one predef palette everywhere, and object colour 0 red.
+func _verify_palette(game_id: StringName, data: GameData) -> void:
+	var palette: PackedColorArray = data.unown_puzzle_palette()
+	if not _r.check(
+		palette.size() == RomLayout.PREDEF_PALETTE_COLORS,
+		"%s: the puzzle palette has %d colours." % [game_id, palette.size()]
+	):
+		return
+	var page: Gen2UnownPuzzlePage = Gen2UnownPuzzlePage.from_data(data, 0)
+	if not _r.check(page != null, "%s: the puzzle page will not build." % game_id):
+		return
+	## `DmgToCgbBGPals $e4` is the identity, so the background is the entry as
+	## imported.
+	_r.check(
+		page.background_palette() == palette,
+		"%s: the background palette is not PREDEFPAL_UNOWN_PUZZLE." % game_id
+	)
+	var objects: PackedColorArray = page.object_palette()
+	_r.check(
+		objects.size() == 4 and objects[0] == Gen2UnownPuzzlePage.CURSOR_COLOR
+			and objects[3] == Gen2UnownPuzzlePage.CURSOR_COLOR
+			and objects[1] == palette[1] and objects[2] == palette[2],
+		"%s: `DmgToCgbObjPal0 $24` over the red colour 0 is not what the cursor draws in." % game_id
+	)
+
+
+## `ConvertLoadedPuzzlePieces` and `UnownPuzzle_AddPuzzlePieceBorders`, per
+## pixel, against the strip the cache holds rather than against the bank.
+func _verify_bank(game_id: StringName, data: GameData, puzzle: int) -> void:
+	var name: String = RomLayout.UNOWN_PUZZLE_PICTURES[puzzle]
+	var page: Gen2UnownPuzzlePage = Gen2UnownPuzzlePage.from_data(data, puzzle)
+	if not _r.check(page != null, "%s: %s will not build a bank." % [game_id, name]):
+		return
+	var picture: PackedByteArray = data.unown_puzzle_indices(name)
+	var borders: PackedByteArray = data.unown_puzzle_indices("tile_borders")
+	var side: int = RomLayout.UNOWN_PUZZLE_PICTURE_TILES
+	var wrong_pixels: int = 0
+	var wrong_borders: int = 0
+	for piece: int in Gen2UnownPuzzle.PIECES:
+		var corner: int = CORNERS[piece]
+		for local: int in Gen2UnownPuzzlePage.PIECE_TILES * Gen2UnownPuzzlePage.PICTURE_TILES:
+			var row: int = local / Gen2UnownPuzzlePage.PICTURE_TILES
+			var column: int = local % Gen2UnownPuzzlePage.PICTURE_TILES
+			if row >= Gen2UnownPuzzlePage.PIECE_TILES \
+				or column >= Gen2UnownPuzzlePage.PIECE_TILES:
+				continue
+			var offset: int = row * Gen2UnownPuzzlePage.PICTURE_TILES + column
+			var tile: PackedByteArray = page.tile_indices(corner + offset)
+			## Where this tile sits in the doubled twelve-by-twelve grid.
+			var grid: int = corner + offset
+			var grid_row: int = grid / Gen2UnownPuzzlePage.PICTURE_TILES
+			var grid_column: int = grid % Gen2UnownPuzzlePage.PICTURE_TILES
+			var border: int = _border_for(offset)
+			for y: int in TILE:
+				for x: int in TILE:
+					## The source pixel this one is a quarter of.
+					var from_x: int = (grid_column * TILE + x) / 2
+					var from_y: int = (grid_row * TILE + y) / 2
+					var wanted: int = int(picture[_strip_at(from_x, from_y, side)])
+					if border >= 0:
+						wanted |= int(borders[y * STRIPS["tile_borders"] * TILE
+							+ border * TILE + x])
+					if int(tile[y * TILE + x]) != wanted:
+						if border >= 0:
+							wrong_borders += 1
+						else:
+							wrong_pixels += 1
+	_r.check(
+		wrong_pixels == 0,
+		"%s: %s doubles %d pixels wrong." % [game_id, name, wrong_pixels]
+	)
+	_r.check(
+		wrong_borders == 0,
+		"%s: %s borders %d pixels wrong." % [game_id, name, wrong_borders]
+	)
+	## The centre tile takes no border, which is what says the eight destinations
+	## are the eight and not the whole block.
+	var centre: PackedByteArray = page.tile_indices(CORNERS[0] + UNBORDERED_CENTRE)
+	var plain: bool = true
+	for y: int in TILE:
+		for x: int in TILE:
+			if int(centre[y * TILE + x]) != int(picture[_strip_at(
+				(UNBORDERED_CENTRE % Gen2UnownPuzzlePage.PICTURE_TILES) * TILE / 2 + x / 2,
+				(UNBORDERED_CENTRE / Gen2UnownPuzzlePage.PICTURE_TILES) * TILE / 2 + y / 2,
+				side
+			)]):
+				plain = false
+	_r.check(plain, "%s: %s ORs a border onto a piece's centre tile." % [game_id, name])
+
+
+## A pixel of the source picture, which the cache holds as one strip of
+## `side * side` tiles.
+func _strip_at(x: int, y: int, side: int) -> int:
+	var tile: int = (y / TILE) * side + x / TILE
+	return (y % TILE) * side * side * TILE + tile * TILE + x % TILE
+
+
+## Which border tile, if any, a piece-local tile takes.
+func _border_for(local: int) -> int:
+	return BORDERED.find(local)
+
+
+## `UnownPuzzle_UpdateTilemap` and `PlaceStartCancelBox` over a whole board, in
+## both the scattered and the solved configuration.
+func _verify_board(game_id: StringName, data: GameData, puzzle: int) -> void:
+	var name: String = RomLayout.UNOWN_PUZZLE_PICTURES[puzzle]
+	var page: Gen2UnownPuzzlePage = Gen2UnownPuzzlePage.from_data(data, puzzle)
+	if page == null:
+		return
+	var rng := RandomNumberGenerator.new()
+	rng.seed = puzzle + 1
+	var board: Gen2UnownPuzzle = Gen2UnownPuzzle.create(rng)
+	var placed: Array[int] = []
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		var piece: int = board.piece_at(cell)
+		if piece == 0:
+			continue
+		placed.append(piece)
+		_r.check(
+			cell in Gen2UnownPuzzle.START_CELLS,
+			"%s: %s scattered a piece onto cell %d." % [game_id, name, cell]
+		)
+	placed.sort()
+	_r.check(
+		placed.size() == Gen2UnownPuzzle.PIECES
+			and placed[0] == 1 and placed[-1] == Gen2UnownPuzzle.PIECES,
+		"%s: %s scattered %d pieces." % [game_id, name, placed.size()]
+	)
+
+	var map: PackedByteArray = page.tilemap(board)
+	var outside: int = 0
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		var at: Array = MAP_COORDS[cell]
+		var piece: int = board.piece_at(cell)
+		for row: int in Gen2UnownPuzzlePage.PIECE_TILES:
+			for column: int in Gen2UnownPuzzlePage.PIECE_TILES:
+				var x: int = int(at[0]) + column
+				var y: int = int(at[1]) + row
+				if y >= 15:
+					## The START>CANCEL box is placed over the bottom row after
+					## the cells are, so those tiles are the box's own.
+					continue
+				var wanted: int = VACANT[cell] if piece == 0 else CORNERS[piece - 1] \
+					+ row * Gen2UnownPuzzlePage.PICTURE_TILES + column
+				if int(map[y * Gen2UnownPuzzlePage.SCREEN_COLUMNS + x]) != wanted:
+					outside += 1
+	_r.check(
+		outside == 0,
+		"%s: %s draws %d board tiles wrong." % [game_id, name, outside]
+	)
+	var unloaded: int = 0
+	for tile: int in map:
+		if tile > 0x8F and tile < 0xED:
+			unloaded += 1
+	_r.check(
+		unloaded == 0,
+		"%s: %s names %d tiles no strip loaded." % [game_id, name, unloaded]
+	)
+	## The cell each cursor object is centred on, which is the one number the
+	## OAM sets are placed by.
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		var point: Vector2i = Gen2UnownPuzzlePage.cell_point(cell)
+		_r.check(
+			point == Vector2i(int(OAM_COORDS[cell][0]), int(OAM_COORDS[cell][1]))
+				- Gen2UnownPuzzlePage.OAM_ORIGIN,
+			"%s: cell %d's OAM point is %s." % [game_id, cell, point]
+		)
+
+
+## The rules, which are cartridge-independent: the corners, the solved
+## configuration and the cursor's own edges.
+func _verify_rules() -> void:
+	for piece: int in Gen2UnownPuzzle.PIECES:
+		_r.check(
+			Gen2UnownPuzzlePage.piece_corner_tile(piece + 1) == CORNERS[piece],
+			"Piece %d's corner tile is not $%02X." % [piece + 1, CORNERS[piece]]
+		)
+	_r.check(
+		Gen2UnownPuzzlePage.piece_corner_tile(0) == NO_PIECE_CORNER,
+		"No piece selected is not $%02X." % NO_PIECE_CORNER
+	)
+	var solved_wrong: int = 0
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		if Gen2UnownPuzzle.solved_piece_at(cell) != SOLVED[cell]:
+			solved_wrong += 1
+		if Gen2UnownPuzzlePage.vacant_tile(cell) != VACANT[cell]:
+			solved_wrong += 1
+	_r.check(
+		solved_wrong == 0,
+		"The solved configuration or the filler column differs in %d cells." % solved_wrong
+	)
+	_verify_walk()
+
+
+## Every cell against every direction, which is the whole of `.Function`'s
+## hand-listed edges rather than the four a screenshot would show.
+func _verify_walk() -> void:
+	var wrong: int = 0
+	for cell: int in Gen2UnownPuzzle.CELLS:
+		for direction: int in [
+			Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT
+		]:
+			var puzzle := Gen2UnownPuzzle.create(null)
+			## The board is walked from cell 0, one step a press, so the cursor
+			## is put where the case wants it by pressing there first.
+			while puzzle.cursor() != cell:
+				var towards: int = Gen2Button.DOWN \
+					if puzzle.cursor() / Gen2UnownPuzzle.COLUMNS < cell / Gen2UnownPuzzle.COLUMNS \
+					else Gen2Button.RIGHT
+				var before: int = puzzle.cursor()
+				puzzle.advance([towards], [towards])
+				if puzzle.cursor() == before:
+					break
+			if puzzle.cursor() != cell:
+				continue
+			var from: int = puzzle.cursor()
+			puzzle.advance([direction], [direction])
+			if puzzle.cursor() != _wanted_step(from, direction):
+				wrong += 1
+	_r.check(wrong == 0, "The cursor walks %d of its cases wrong." % wrong)
+	_r.note("Cursor: %d cells against four directions." % Gen2UnownPuzzle.CELLS)
+
+
+## `.d_up`, `.d_down`, `.d_left` and `.d_right`, restated.
+func _wanted_step(cell: int, direction: int) -> int:
+	match direction:
+		Gen2Button.UP:
+			return cell if cell in NO_STEP_UP else cell - 6
+		Gen2Button.DOWN:
+			return cell if cell in NO_STEP_DOWN else cell + 6
+		Gen2Button.LEFT:
+			if cell == 35:
+				return 30
+			return cell if cell in NO_STEP_LEFT else cell - 1
+		Gen2Button.RIGHT:
+			if cell == 30:
+				return 35
+			return cell if cell in NO_STEP_RIGHT else cell + 1
+	return cell
+
+
+func _total_tiles() -> int:
+	var total: int = 0
+	for name: String in STRIPS:
+		total += int(STRIPS[name])
+	return total

--- a/tools/checks/unown_puzzle.gd.uid
+++ b/tools/checks/unown_puzzle.gd.uid
@@ -1,0 +1,1 @@
+uid://b0ct8bd8y3n5g

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -55,6 +55,11 @@ extends SceneTree
 ## `day_care` (the Day-Care's five specials, driven the same way: the first
 ## number is how many presses in and the second which routine, 0 the man,
 ## 1 the lady, 2 the man outside, 3 and 4 the two signs),
+## `unown_puzzle` (`special UnownPuzzle`'s board, which no fixture cell reaches:
+## the first number is how many frames in to photograph and the second which
+## picture, 0 Kabuto, 1 Omanyte, 2 Aerodactyl and 3 Ho-Oh, or 4 to 7 for the
+## same four solved; the empty cursor blinks off `hVBlankCounter`, so a frame
+## with bit 4 clear has none on it),
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
@@ -214,7 +219,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 		_screen.start_cell = _kind_cell
 	elif cell.x >= 0 and _kind not in [
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-		&"move_deleter", &"day_care",
+		&"move_deleter", &"day_care", &"unown_puzzle",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -307,6 +312,23 @@ func _process(_delta: float) -> bool:
 					break
 				if hatching.awaiting_press():
 					_screen.press_button(Gen2Button.A)
+		elif _kind == &"unown_puzzle":
+			## `special UnownPuzzle`, which no fixture cell reaches. The first
+			## number is how many frames into the board to photograph and the
+			## second which picture: 0 Kabuto, 1 Omanyte, 2 Aerodactyl, 3 Ho-Oh.
+			## The empty cursor blinks off `hVBlankCounter`, so a frame with bit
+			## 4 clear photographs a board with no cursor on it.
+			## 4 to 7 are the same four pictures with the board walked into
+			## `.SolvedPuzzleConfiguration` through the screen's own presses,
+			## which is the only way to photograph the assembled picture.
+			_screen.preview_unown_puzzle(
+				maxi(_cell.y, 0) % RomLayout.UNOWN_PUZZLE_PICTURES.size(),
+				maxi(_cell.y, 0) >= RomLayout.UNOWN_PUZZLE_PICTURES.size()
+			)
+			for _frame: int in maxi(_cell.x, 0):
+				if _screen.get("_unown_puzzle_host") == null:
+					break
+				_screen.advance_frame()
 		elif _kind == &"day_care":
 			## The Day-Care's five, driven the way the two above are. The first
 			## number is how many presses into the routine to photograph and the

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -41,7 +41,7 @@ const GROUPS: Dictionary = {
 	&"tables": [
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
-		&"mon_specials", &"specials", &"day_care",
+		&"mon_specials", &"specials", &"day_care", &"unown_puzzle",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
`special UnownPuzzle` returned unsupported, so the four Ruins of Alph chambers walled a playthrough. It is built now.

`engine/games/unown_puzzle.asm` is ported as its own three pieces. `Gen2UnownPuzzle` is the board and its rules. `Gen2UnownPuzzlePage` is the tile bank and the screen. `Gen2UnownPuzzleScreen` is the per-frame loop. The generator is injected, so a run's seed scatters the same board twice.

## The art

Seven records live together in bank $38. Two addresses are pinned per cartridge and the walk reaches the rest. The four compressed runs are zero-padded past the terminator the decompressor stops on, by four, fifteen and ten bytes and none. No power of two fits that, so the walk skips the fill and checks itself on the next entry's own size. Cache format is 79 and all three cartridges are re-imported.

## What a reading costs

A puzzle picture is doubled, not drawn. `ConvertLoadedPuzzlePieces` enlarges a six by six strip into the twelve by twelve grid the sixteen three-by-three pieces are cut from. That is a two-times nearest scale of the whole picture. `UnownPuzzle_AddPuzzlePieceBorders` then ORs eight tiles onto the eight around each piece's own centre, in bitplanes.

Two more the source states outright. The cursor is red because `_CGB_UnownPuzzle` overwrites object colour 0 with red and the DMG mapping puts colour 3 on it. A held direction walks the board on the text delay's own repeat, fifteen frames and then one in five.

## Proof

| Artefact | Result |
|---|---|
| `tools/checks/unown_puzzle.gd` | 7 records and 175 tiles a cartridge, 144 tiles a picture asserted per pixel, four pictures, three cartridges |
| The same topic's rules half | the corners, the solved configuration, the coordinate table, and 36 cells against four directions |
| pret's own `kabuto.png` | all 1,024 pixels of the eight unbordered centre tiles are a two-times scale of it; the 1,936 that differ over the whole square are the border ink |
| GUT | 3,457 tests over 156 scripts, green |
| `tools/validate.gd -- all` | 62 topics, green |
| `replay_world.gd` | 33 routes, 0 failures |
| The three-profile story walk | clean on all three |

## One bug met on the way

`OWCutAnimation` plays `SFX_PLACE_PUZZLE_PIECE_DOWN`, which is $1e. The constant here held $38, which is the battle move's own effect. Cut has been playing the wrong sound. Fixed in the same commit.

## Pictures

Photograph any frame with `tools/preview_world.gd -- <game> <group> <map> <png> live unown_puzzle <frame> <picture>`. Pictures 4 to 7 are the same four solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)