### PR TITLE
Fix the overworld tile animation's timer, scroll and flicker

### DIFF
--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -37,6 +37,11 @@ var _state: Gen2WorldState = null
 ## Which engine flag table `_state` is keyed by. See Gen2WorldState.engine_flag().
 var _crystal_flags: bool = true
 var _changed: bool = false
+## `hVBlankCounter`, which VBlank increments before it reaches `AnimateTileset`
+## and which no map load resets. `FlickeringCaveEntrancePalette` reads it rather
+## than `wTileAnimationTimer`, so it is not the sequence's own timer and
+## [method configure] deliberately leaves it alone.
+var _vblank: int = 0
 ## Which tiles a run of commands rewrote, and whether a palette row moved. A
 ## renderer that keeps a texture only has to redo these tiles: the sequence
 ## touches one or two tiles per frame, and a palette change is the only thing
@@ -46,10 +51,28 @@ var _palette_changed: bool = false
 
 
 func configure(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MORNING) -> void:
-	data = world.data if world != null else null
+	configure_tileset(
+		world.data if world != null else null,
+		world.current_tileset if world != null else null,
+		time_of_day,
+		world.state if world != null else null,
+	)
 	map = world.current_map if world != null else null
-	tileset = world.current_tileset if world != null else null
-	_state = world.state if world != null else null
+
+
+## The tileset half of [method configure], for a caller holding a tileset and no
+## map: `wTilesetAnim` is the whole of what the sequence reads, so a sweep over
+## the corpus and [method tile_frames]' own walk both open one this way.
+func configure_tileset(
+	source: GameData,
+	from_tileset: Gen2WorldTileset,
+	time_of_day: int = Gen2WorldPalette.TIME_MORNING,
+	state: Gen2WorldState = null,
+) -> void:
+	data = source
+	map = null
+	tileset = from_tileset
+	_state = state
 	_crystal_flags = Gen2WorldState.is_crystal_profile(data)
 	_time_of_day = clampi(time_of_day, 0, 3)
 	_command_index = 0
@@ -90,6 +113,7 @@ func reload_tileset(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIM
 func advance_frame() -> bool:
 	if _commands.is_empty() or tileset == null:
 		return false
+	_vblank = (_vblank + 1) & 0xFF
 	_changed_tiles = {}
 	_palette_changed = false
 	_changed = false
@@ -119,6 +143,11 @@ func command_index() -> int:
 	return _command_index
 
 
+## `wTileAnimationTimer`, which most commands read and three of them tick.
+func timer() -> int:
+	return _timer
+
+
 func current_indices() -> PackedByteArray:
 	return _indices
 
@@ -137,13 +166,7 @@ func tile_frames(tile: int) -> Array[PackedByteArray]:
 	if _commands.is_empty() or tileset == null or tile < 0 or tile >= tileset.tile_count:
 		return out
 	var walk: Gen2WorldAnimation = Gen2WorldAnimation.new()
-	walk.data = data
-	walk.map = map
-	walk.tileset = tileset
-	walk._time_of_day = _time_of_day
-	walk._commands = _commands
-	walk._indices = data.world_tileset_indices(tileset.number).duplicate()
-	walk._buffer.resize(TILE_BYTES)
+	walk.configure_tileset(data, tileset, _time_of_day, _state)
 	var base: PackedByteArray = walk._tile_indices(tile)
 	# Every timer mask in the command table is &7 or narrower and a pass bumps
 	# the timer at most once, so eight passes of the list is a whole cycle of
@@ -256,6 +279,12 @@ func tick() -> bool:
 		"write_buffer":
 			_set_tile_bytes(int(command.get("tile", -1)), _buffer)
 		"scroll_horizontal":
+			# `ScrollTileRightLeft` ticks `wTileAnimationTimer` itself and then
+			# reads bit 2 of it, which is the only tick the cave, dark cave and
+			# ice path lists have: none of the three carries a
+			# `StandingTileFrame8`, so the water palette, the flicker and this
+			# tile's own direction all hang off this one increment.
+			_timer = (_timer + 1) & 7
 			_scroll_horizontal()
 		"scroll_vertical":
 			_scroll_vertical()
@@ -267,7 +296,7 @@ func tick() -> bool:
 			_water_color = water_color
 		"cave_palette":
 			if _time_of_day == Gen2WorldPalette.TIME_DARK:
-				var cave_color: int = (_timer >> 1) & 1
+				var cave_color: int = 1 if (_vblank & 2) != 0 else 0
 				if cave_color != _cave_color:
 					_changed = true
 					_palette_changed = true
@@ -350,10 +379,10 @@ func _set_tile_bytes(tile: int, bytes: PackedByteArray) -> void:
 
 
 func _scroll_horizontal() -> void:
+	var direction_right: bool = (_timer & 4) == 0  # `and %100 / jr nz` is left
 	for y: int in Gen2Tiles.TILE_HEIGHT:
 		var low: int = int(_buffer[y * 2])
 		var high: int = int(_buffer[y * 2 + 1])
-		var direction_right: bool = (_timer & 4) == 0
 		if direction_right:
 			low = ((low >> 1) | ((low & 1) << 7)) & 0xFF
 			high = ((high >> 1) | ((high & 1) << 7)) & 0xFF
@@ -364,10 +393,11 @@ func _scroll_horizontal() -> void:
 		_buffer[y * 2 + 1] = high
 
 
+## `ScrollTileDown`. `ScrollTileUpDown` is unreferenced, so no list on any
+## cartridge ever scrolls a tile the other way and there is no timer in this one.
 func _scroll_vertical() -> void:
 	var copy: PackedByteArray = _buffer.duplicate()
-	var direction_down: bool = (_timer & 4) != 0
 	for y: int in Gen2Tiles.TILE_HEIGHT:
-		var source_y: int = ((y - 1) & 7) if direction_down else ((y + 1) & 7)
+		var source_y: int = (y - 1) & 7
 		_buffer[y * 2] = copy[source_y * 2]
 		_buffer[y * 2 + 1] = copy[source_y * 2 + 1]

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -356,7 +356,7 @@ func _build_world() -> void:
 	var rods: Array[StringName] = _world.available_fishing_rods()
 	if not rods.is_empty() and not rods.has(_selected_rod):
 		_selected_rod = rods[0]
-	_animation.configure(_world, time_of_day)
+	_animation.configure(_world, _render_time_of_day())
 	_build_renderer()
 	_screen_base_position = _screen.position
 	_audio_player = AUDIO_PLAYER_SCRIPT.new()
@@ -1203,7 +1203,7 @@ func _after_player_move(movement: Dictionary) -> bool:
 			## boundary into the same track is one continuous piece. It carries
 			## no `LoadMapGraphics` either, so the tile animation is re-pointed
 			## at the new tileset where it stands rather than restarted.
-			_animation.reload_tileset(_world, time_of_day)
+			_animation.reload_tileset(_world, _render_time_of_day())
 			_set_renderer_world()
 			_fade_to_map_music()
 		else:
@@ -1858,7 +1858,7 @@ func _swap_warped_map() -> void:
 	if not bool(transition.get("ok", false)):
 		return
 	_clear_script_fade()
-	_animation.configure(_world, time_of_day)
+	_animation.configure(_world, _render_time_of_day())
 	_set_renderer_world()
 	_fade_to_map_music()
 
@@ -2065,7 +2065,7 @@ func _update_time_of_day() -> void:
 	time_of_day = next_time_of_day
 	_world.set_object_time(_clock.hour, time_of_day)
 	if _animation != null:
-		_animation.configure(_world, time_of_day)
+		_animation.configure(_world, _render_time_of_day())
 	if _renderer != null:
 		_renderer.set_time_of_day(_render_time_of_day())
 
@@ -5112,7 +5112,7 @@ func _show_script_results(results: Array) -> void:
 			## left standing goes with it the way `closetext`'s redraw takes it.
 			_hide_money_window()
 			_world.reload_current_map()
-			_animation.configure(_world, time_of_day)
+			_animation.configure(_world, _render_time_of_day())
 			_set_renderer_world()
 			_renderer.set_time_of_day(_render_time_of_day())
 			_play_current_map_music()
@@ -5132,7 +5132,7 @@ func _show_script_results(results: Array) -> void:
 func _refresh_after_escape() -> void:
 	if _world == null:
 		return
-	_animation.configure(_world, time_of_day)
+	_animation.configure(_world, _render_time_of_day())
 	_set_renderer_world()
 	if _renderer != null:
 		_renderer.set_time_of_day(_render_time_of_day())

--- a/tests/integration/test_world_mon_specials.gd
+++ b/tests/integration/test_world_mon_specials.gd
@@ -412,6 +412,11 @@ func test_grooming_raises_happiness_and_leaves_the_chosen_species_standing() -> 
 	await _run_haircut(Gen2WorldScriptRunner.SPECIAL_DAISYS_GROOMING)
 	var mon: Gen2SaveMon = _world_screen.active_save().party[0]
 	mon.happiness = 100
+	## One roll in 256 walks off the end of the table and changes nothing, which
+	## is `HAPPINESS_TABLE_OVERRUN_OPCODE`'s own case and is covered where the
+	## walk lives. Pin the roll so this case is the row and not the overrun.
+	var script: Gen2WorldScriptRunner = _world_screen._world._active_script
+	script._random.seed = 1
 	_selection_list().handle_button(Gen2Button.A)
 	var runner: Gen2WorldScriptRunner = _world_screen._world._active_script
 	assert_gt(mon.happiness, 100, "HAPPINESS_GROOMING is a rise at every threshold")

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -73,6 +73,37 @@ func _write_cache() -> void:
 			{"operation": "timer_8"},
 			{"operation": "done"},
 		],
+	}, {
+		# `TilesetCaveAnim` with tiles 0 and 1 standing in for $14 and $40. Its
+		# only tick is `ScrollTileRightLeft`'s own, which is what the water
+		# palette, the flicker and both scrolls hang off.
+		"number": 3,
+		"block_count": 1,
+		"tile_count": RomLayout.TILESET_TILE_COUNT,
+		"meta": meta,
+		"collision": [],
+		"palette_map": [0],
+		"animation_commands": [
+			{"operation": "read_buffer", "tile": 0},
+			{"operation": "cave_palette"},
+			{"operation": "scroll_horizontal", "tile": -1},
+			{"operation": "cave_palette"},
+			{"operation": "write_buffer", "tile": 0},
+			{"operation": "cave_palette"},
+			{"operation": "water_palette"},
+			{"operation": "cave_palette"},
+			{"operation": "read_buffer", "tile": 1},
+			{"operation": "cave_palette"},
+			{"operation": "scroll_vertical", "tile": -1},
+			{"operation": "cave_palette"},
+			{"operation": "scroll_vertical", "tile": -1},
+			{"operation": "cave_palette"},
+			{"operation": "scroll_vertical", "tile": -1},
+			{"operation": "cave_palette"},
+			{"operation": "write_buffer", "tile": 1},
+			{"operation": "cave_palette"},
+			{"operation": "done"},
+		],
 	}])
 	RomCache.write_json(RomCache.world_maps_path(_directory), [{
 		"group": 1,
@@ -98,6 +129,17 @@ func _write_cache() -> void:
 		"collision_height": 2,
 	}, {
 		"group": 1,
+		"number": 4,
+		"tileset": 3,
+		"environment": 0,
+		"width_blocks": 1,
+		"height_blocks": 1,
+		"blocks": [0],
+		"collision": [0, 0, 0, 0],
+		"collision_width": 2,
+		"collision_height": 2,
+	}, {
+		"group": 1,
 		"number": 2,
 		"tileset": 1,
 		"environment": 0,
@@ -113,6 +155,12 @@ func _write_cache() -> void:
 	RomCache.write_indices(RomCache.world_tile_path(_directory, 0), pixels)
 	RomCache.write_indices(RomCache.world_tile_path(_directory, 1), pixels)
 	RomCache.write_indices(RomCache.world_tile_path(_directory, 2), pixels)
+	# One lit pixel in the top-left corner of tiles 0 and 1, so where the two
+	# scrolls put it is the whole reading of their direction.
+	var scrolled: PackedByteArray = pixels.duplicate()
+	scrolled[0] = 1
+	scrolled[Gen2Tiles.TILE_WIDTH] = 1
+	RomCache.write_indices(RomCache.world_tile_path(_directory, 3), scrolled)
 
 	var palettes: Array = []
 	for _group: int in RomLayout.WORLD_PALETTE_GROUP_COUNT:
@@ -303,3 +351,56 @@ func _tick_pair(animation: Gen2WorldAnimation) -> void:
 ## stride into the array.
 func _tree_frame(animation: Gen2WorldAnimation, tile: int) -> int:
 	return 0 if animation.current_indices()[tile * Gen2Tiles.TILE_WIDTH] == 1 else 1
+
+
+## `ScrollTileRightLeft` is the cave, dark cave and ice path lists' only tick:
+## none of the three carries a `StandingTileFrame8`, so a reading that leaves
+## the timer to something else stops the water palette, the flicker and this
+## tile's own reversal all at once. `ScrollTileDown` is the referenced vertical
+## routine and `ScrollTileUpDown` is not, so the second tile only ever goes down.
+func test_the_cave_list_ticks_its_timer_from_the_horizontal_scroll_alone() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 4, Vector2i.ZERO)
+	var animation := Gen2WorldAnimation.new()
+	animation.configure(world, Gen2WorldPalette.TIME_DARK)
+	var commands: int = data.world_tileset(3).animation_commands.size()
+
+	var across: Array[int] = []
+	var down: Array[int] = []
+	var timers: Array[int] = []
+	var flicker: Array[int] = []
+	for pass_index: int in 8:
+		for _step: int in commands:
+			animation.advance_frame()
+			flicker.append(animation.cave_palette_color())
+		timers.append(animation.timer())
+		across.append(_lit_column(animation, 0))
+		down.append(_lit_row(animation, 1))
+
+	assert_eq(timers, [1, 2, 3, 4, 5, 6, 7, 0] as Array[int])
+	# The tick is in front of the test, so the branch reads 1, 2, 3, 4 ... and
+	# `and %100` sends the four passes at 4 to 7 the other way.
+	assert_eq(across, [1, 2, 3, 2, 1, 0, 7, 0] as Array[int])
+	# Three `ScrollTileDown` a pass and no direction to choose.
+	assert_eq(down, [3, 6, 1, 4, 7, 2, 5, 0] as Array[int])
+	# `hVBlankCounter and %10`, which is two frames of each and is not the
+	# sequence's own timer: the timer moves once per nineteen frames here. The
+	# opening -1 is the frame before the list's first `cave_palette`.
+	assert_eq(flicker.slice(0, 8), [-1, 1, 1, 0, 0, 1, 1, 0] as Array[int])
+
+
+## Which column of tile [param tile]'s top row is lit, and which row of its
+## first column is, for the two scrolls above.
+func _lit_column(animation: Gen2WorldAnimation, tile: int) -> int:
+	for x: int in Gen2Tiles.TILE_WIDTH:
+		if animation.current_indices()[tile * Gen2Tiles.TILE_WIDTH + x] != 0:
+			return x
+	return -1
+
+
+func _lit_row(animation: Gen2WorldAnimation, tile: int) -> int:
+	var width: int = RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_WIDTH
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		if animation.current_indices()[y * width + tile * Gen2Tiles.TILE_WIDTH] != 0:
+			return y
+	return -1

--- a/tools/checks/tile_anims.gd
+++ b/tools/checks/tile_anims.gd
@@ -1,0 +1,197 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Every tileset's `wTilesetAnim` command list, on all three cartridges, run for
+## a whole cycle.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- tile_anims
+##
+## The list is `data/tileset_anims.asm` and the commands are
+## `engine/tilesets/tileset_anims.asm`, both byte identical between the pins
+## apart from the addresses `RomLayout`'s `world_animation_functions` names. What
+## a reading of them costs is which command ticks `wTileAnimationTimer`:
+## `StandingTileFrame8` and `StandingTileFrame` do, and so does
+## `ScrollTileRightLeft`, which is the **only** tick the cave, dark cave and ice
+## path lists have. A timer that never moves leaves those three maps with a still
+## water palette, a still cave flicker and a tile scrolling one way for ever.
+##
+## `.claude/oracle/overworld/trace_tiles.py` and `tools/trace_world_tiles.gd` are
+## the frame-by-frame half of this, against a real cartridge.
+
+## The whole set `Gen2WorldAnimation.tick` implements, which is every label
+## `_AnimateTileset` can `jp hl` to. An operation outside it is an unread
+## function pointer rather than a new command.
+const OPERATIONS: Array[String] = [
+	"done", "wait", "timer_8", "timer", "water", "flower", "fountain",
+	"forest_left", "forest_right", "forest_left_2", "forest_right_2",
+	"lava_1", "lava_2", "tower", "whirlpool",
+	"read_buffer", "write_buffer", "scroll_horizontal", "scroll_vertical",
+	"water_palette", "cave_palette",
+]
+
+## The three that write `wTileAnimationTimer`: `StandingTileFrame8`,
+## `StandingTileFrame` and `ScrollTileRightLeft`'s own `inc a / and %111`.
+const TICKING: Array[String] = ["timer_8", "timer", "scroll_horizontal"]
+
+## The commands that read it. A list holding one of these and no [constant
+## TICKING] draws the same frame for ever, which is what the cave, the dark cave
+## and the ice path did while `scroll_horizontal` was read as a plain rotate.
+const READING: Array[String] = [
+	"water", "flower", "fountain", "forest_left", "forest_right",
+	"forest_left_2", "forest_right_2", "lava_1", "lava_2", "tower", "whirlpool",
+	"scroll_horizontal", "water_palette",
+]
+
+## `ScrollTileRightLeft` and `ScrollTileDown` are handed `wTileAnimBuffer`, which
+## is WRAM and not a tile, so the importer's own VRAM decode answers -1 for them.
+const BUFFER_OPERAND: Array[String] = ["scroll_horizontal", "scroll_vertical"]
+
+## `wTileAnimationTimer` is masked to three bits by every writer, so eight passes
+## of any list is one whole cycle of everything it can draw.
+const TIMER_VALUES: int = 8
+
+## Census per cartridge, pinned so a cache or a table change is loud:
+## tilesets, distinct command lists, lists that draw nothing but `done`,
+## commands in all, and distinct tiles animated across the corpus.
+const EXPECTED: Dictionary = {
+	&"gold": [29, 8, 0, 246, 21],
+	&"silver": [29, 8, 0, 246, 21],
+	&"crystal": [37, 10, 0, 287, 21],
+}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(_check_game)
+
+
+func _check_game() -> void:
+	var lists: Dictionary = {}
+	var commands: int = 0
+	var still: int = 0
+	var tiles: Dictionary = {}
+	for number: int in _r.data.world_tileset_count():
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(number)
+		if tileset == null:
+			_r.fail("tileset %d is missing from the cache." % number)
+			continue
+		var list: Array = tileset.animation_commands
+		commands += list.size()
+		lists[_signature(list)] = true
+		if list.size() <= 1:
+			still += 1
+		_check_list(number, list, tileset.tile_count)
+		for tile: int in _check_cycle(tileset):
+			tiles[tile] = true
+	var census: Array = [
+		_r.data.world_tileset_count(), lists.size(), still, commands, tiles.size(),
+	]
+	_r.note("tilesets %d, lists %d, still %d, commands %d, tiles animated %d" % census)
+	var expected: Array = EXPECTED.get(_r.game_id, [])
+	_r.check(
+		expected.is_empty() or census == expected,
+		"census is %s, pinned %s." % [census, expected],
+	)
+
+
+## The list's own shape, which is what `_AnimateTileset` walks: one terminator,
+## at the end, every operation read, every tile inside the strip, and a tick
+## somewhere, since a list with none freezes every timer-driven command in it.
+func _check_list(number: int, list: Array, tiles_in_strip: int) -> void:
+	if not _r.check(not list.is_empty(), "tileset %d has no command list." % number):
+		return
+	var ticks: int = 0
+	var reads: int = 0
+	for index: int in list.size():
+		var command: Dictionary = list[index]
+		var operation: String = String(command.get("operation", ""))
+		_r.check(
+			OPERATIONS.has(operation),
+			"tileset %d command %d is %s, which nothing implements." % [
+				number, index, operation,
+			],
+		)
+		_r.check(
+			(operation == "done") == (index == list.size() - 1),
+			"tileset %d command %d is %s, so the list does not end on its own." % [
+				number, index, operation,
+			],
+		)
+		if TICKING.has(operation):
+			ticks += 1
+		if command.has("tile"):
+			var tile: int = int(command["tile"])
+			if BUFFER_OPERAND.has(operation):
+				_r.check(
+					tile == -1,
+					"tileset %d command %d scrolls tile %d rather than the buffer." % [
+						number, index, tile,
+					],
+				)
+			else:
+				_r.check(
+					tile >= 0 and tile < tiles_in_strip,
+					"tileset %d command %d names tile %d, outside the strip." % [
+						number, index, tile,
+					],
+				)
+		if READING.has(operation):
+			reads += 1
+	_r.check(
+		reads == 0 or ticks > 0,
+		"tileset %d reads the timer %d times and never ticks it." % [number, reads],
+	)
+
+
+## Eight passes of the list, which is one whole cycle of `wTileAnimationTimer`.
+## Answers the tiles it rewrote. Two things are proved by running it rather than
+## reading it: a list that draws at all visits every timer value, and the strip
+## it leaves behind is the one it started from, since every scroll is a rotation
+## and every other command writes a frame out of a cycle.
+func _check_cycle(tileset: Gen2WorldTileset) -> PackedInt32Array:
+	var animation := Gen2WorldAnimation.new()
+	animation.configure_tileset(_r.data, tileset)
+	var seen: Dictionary = {}
+	var tiles: Dictionary = {}
+	var opening := PackedByteArray()
+	# Two cycles, and the first is a warm-up: a tileset's own tile stands until
+	# the command that owns it writes for the first time, so the strip a list
+	# returns to is the one after a whole cycle rather than the one on the map
+	# load.
+	for cycle: int in 2:
+		if cycle == 1:
+			opening = animation.current_indices().duplicate()
+		for _pass: int in TIMER_VALUES:
+			for _step: int in tileset.animation_commands.size():
+				animation.advance_frame()
+				seen[animation.timer() & 0x7] = true
+				for tile: int in animation.changed_tiles():
+					tiles[tile] = true
+	if not tiles.is_empty():
+		_r.check(
+			seen.size() == TIMER_VALUES,
+			"tileset %d drew %d tiles but its timer only reached %s." % [
+				tileset.number, tiles.size(), seen.keys(),
+			],
+		)
+		_r.check(
+			animation.current_indices() == opening,
+			"tileset %d does not return to its own strip after a whole cycle." % (
+				tileset.number
+			),
+		)
+	var out := PackedInt32Array()
+	for tile: int in tiles:
+		out.append(tile)
+	return out
+
+
+## A list as its operations, so two tilesets sharing one table count once.
+func _signature(list: Array) -> String:
+	var parts: PackedStringArray = []
+	for command: Dictionary in list:
+		parts.append("%s:%d" % [
+			String(command.get("operation", "")), int(command.get("tile", -1)),
+		])
+	return ",".join(parts)

--- a/tools/checks/tile_anims.gd.uid
+++ b/tools/checks/tile_anims.gd.uid
@@ -1,0 +1,1 @@
+uid://ceerhixy6phdb

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -58,6 +58,10 @@ extends SceneTree
 ## `slot_machine` (`special SlotMachine`, which no fixture cell reaches: the
 ## first number is how many frames into the game to photograph and the second
 ## the bet, 1 to 3, plus 4 for the lucky machine),
+## `tile_anim` (the map after the first number's worth of `AnimateTileset`
+## frames, which is how the water, the flowers, the lava and the cave scroll are
+## photographed at a chosen point in their cycle: `crystal 3 37 ... tile_anim 60`
+## is Union Cave a second in),
 ## `card_flip` (`special CardFlip`, which no fixture cell reaches: the first
 ## number is how many frames into the game to photograph and the second the
 ## balance in hundreds of coins),
@@ -226,7 +230,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	elif cell.x >= 0 and _kind not in [
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
 		&"move_deleter", &"day_care", &"unown_puzzle", &"slot_machine",
-		&"card_flip",
+		&"card_flip", &"tile_anim",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -345,6 +349,13 @@ func _process(_delta: float) -> bool:
 			_screen.preview_slot_machine(
 				100, maxi(_cell.y, 0) >= 4, maxi(slots_bet, 1), maxi(_cell.x, 0)
 			)
+		elif _kind == &"tile_anim":
+			## `AnimateTileset` runs once a hardware frame, so any frame of a
+			## map's own water, flowers, lava or cave scroll is reachable by
+			## spending them: the first number is how many, and the cell goes in
+			## `tile_anim@x,y` as usual.
+			for _spent: int in maxi(_cell.x, 0):
+				_screen.advance_frame()
 		elif _kind == &"card_flip":
 			## `special CardFlip`, which no fixture cell reaches either. The
 			## first number is how many frames into the game to photograph and

--- a/tools/trace_world_tiles.gd
+++ b/tools/trace_world_tiles.gd
@@ -1,0 +1,68 @@
+extends SceneTree
+
+## Every hardware frame of a map's tileset animation: which of the tileset's
+## tiles `_AnimateTileset` rewrote, where the command list stands, and what the
+## two palette commands are holding.
+##
+##   Godot --headless --path . -s res://tools/trace_world_tiles.gd -- \
+##       <game> <group> <map> <frames> <out.txt> [time_of_day]
+##
+## The port half of `.claude/oracle/overworld/trace_tiles.py`, which prints the
+## same artefact off a real cartridge by reading vTiles2 once a frame. The line
+## is `frame anim_frame timer water cave tiles`, and `anim_frame` is read after
+## the frame is spent, which is where `hTileAnimFrame` stands on that side.
+
+func _initialize() -> void:
+	_run.call_deferred()
+
+
+func _run() -> void:
+	await process_frame
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 5:
+		push_error("usage: <game> <group> <map> <frames> <out.txt> [time_of_day]")
+		quit(2)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("no imported cache for %s" % args[0])
+		quit(2)
+		return
+	var frames: int = maxi(1, int(args[3]))
+
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	screen.set_data(data)
+	screen.map_group = int(args[1])
+	screen.map_number = int(args[2])
+	if args.size() > 5:
+		screen.time_of_day = int(args[5])
+	screen.process_mode = Node.PROCESS_MODE_DISABLED
+	root.add_child(screen)
+	await process_frame
+	if screen._world == null:
+		push_error("the world did not open")
+		quit(2)
+		return
+	screen.set_process(false)
+
+	var animation: Gen2WorldAnimation = screen._animation
+	var lines: PackedStringArray = PackedStringArray([
+		"# frame anim_frame timer water cave tiles"
+	])
+	for frame: int in frames:
+		screen.advance_frame()
+		var changed: PackedInt32Array = animation.changed_tiles()
+		var names: PackedStringArray = PackedStringArray()
+		for tile: int in changed:
+			names.append("%02X" % tile)
+		lines.append("%d %d %d %d %d %s" % [
+			frame, animation.command_index(), animation.timer(),
+			animation.water_palette_color(), animation.cave_palette_color(),
+			",".join(names) if names.size() > 0 else "-",
+		])
+	FileAccess.open(args[4], FileAccess.WRITE).store_string("\n".join(lines) + "\n")
+	print("wrote %d frames to %s" % [frames, args[4]])
+	root.remove_child(screen)
+	screen.free()
+	quit(0)

--- a/tools/trace_world_tiles.gd.uid
+++ b/tools/trace_world_tiles.gd.uid
@@ -1,0 +1,1 @@
+uid://do8afgpirf8gh


### PR DESCRIPTION
The cave, dark cave and ice path tile animations were frozen. Their command
lists carry no `StandingTileFrame8`, so the only thing that ticks
`wTileAnimationTimer` on those maps is `ScrollTileRightLeft`, which does it
itself. Reading that command as a plain rotate left the timer where it started
for ever: the water palette stopped moving, the cave-entrance flicker stopped,
and the scrolled tile went one way and never came back.

Three more in the same routine, each one reading:

- `ScrollTileDown` is the vertical routine the lists name. `ScrollTileUpDown` is
  unreferenced, so there is no direction to pick, and the cave waterfall was
  running backwards.
- `FlickeringCaveEntrancePalette` reads the VBlank frame counter, not the
  sequence's timer. That counter is bumped before the animation runs and no map
  load resets it, so the animation keeps one of its own.
- The animation was being told the clock's time of day. The routine's own gate
  is a dark map with Flash unused, which the clock never reports, so the flicker
  could not run anywhere. All six call sites pass the map's answer now.

## How it is checked

Frame by frame against a real cartridge, on which tiles the game rewrote on
which frame:

| List | States | Result |
|---|---|---|
| `TilesetJohtoAnim` (Route 29) | 104 | 104/104 identical |
| `TilesetCaveAnim` (Dark Cave Violet Entrance) | 152 | 152/152 identical |

`tools/trace_world_tiles.gd` prints this side of that.

`tools/checks/tile_anims.gd` sweeps the whole corpus on all three cartridges:
every tileset's command list, and two full timer cycles of each one run rather
than read. A list that draws anything has to visit all eight timer values and
end a cycle on the strip it started it with. Putting the first bug back turns it
red on six tilesets.

`preview_world.gd` grows a `tile_anim` kind, so any frame of any map's animation
can be photographed.

Unrelated, in the same branch: the grooming integration test pins its roll. One
roll in 256 walks off the end of the grooming table and changes no happiness,
which is covered where that walk lives, and it made the test fail now and then.

## Runs

| Run | Result |
|---|---|
| unit tier | 3033 tests, all passing |
| full tier | 3489 tests, all passing |
| `validate.gd -- all` | 65 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| story walk, all three games | no failed step |
| boot smoke | clean |