### PR TITLE
Turn NPCs toward the player where the source turns them

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3968,6 +3968,7 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 					var object: Gen2WorldObject = objects[object_index]
 					var facing: int = _facing_toward(object.cell, player_cell)
 					_object_facing_overrides[key] = facing
+				reload_objects = true
 			&"object_face_object":
 				var target_index: int = int(event.get("target_index", -1))
 				if map_group == current_map.group and map_number == current_map.number \

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -49,6 +49,14 @@ var _last_item: int = 0
 var _staged_warp: Dictionary = {}
 var _script_value: int = 0
 var _command_count: int = 0
+## `RunScriptCommand`'s own artefact: every command executed, with the
+## `bank:address` the cartridge would have in wScriptBank:wScriptPos when it
+## ran. Collected only while `trace_commands` is on, which
+## `tools/trace_world_script.gd` turns on for every runner a world builds so a
+## walked conversation can be diffed against `.claude/oracle/overworld/
+## trace_script.py`'s reading of the same one.
+static var trace_commands: bool = false
+var command_trace: Array[Dictionary] = []
 ## `Script_sdefer`'s own `RUN_DEFERRED_SCRIPT`, which is the only thing that
 ## makes `RunSceneScript` answer `PlayerEvents` with carry: a scene script that
 ## does not set it has run and raised no player event
@@ -735,6 +743,13 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		)
 		if not bool(command.get("ok", false)):
 			return _fail(StringName(command.get("reason", &"invalid_command")), command)
+		if trace_commands:
+			command_trace.append({
+				"bank": int(frame["bank"]),
+				"address": int(frame["address"]) + int(frame["offset"]),
+				"opcode": int(command["opcode"]),
+				"name": String(command["name"]),
+			})
 		frame["offset"] = int(frame["offset"]) + int(command["width"])
 		_frames[_frames.size() - 1] = frame
 		_command_count += 1
@@ -1463,6 +1478,12 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		Gen2WorldScript.FARWRITETEXT:
 			return _show_text(int(command["bank"]), int(command["address"]), false)
 		Gen2WorldScript.JUMPTEXTFACEPLAYER:
+			## `Script_jumptextfaceplayer` jumps to JumpTextFacePlayerScript,
+			## whose first command is `faceplayer`; `jumptext` and `farjumptext`
+			## enter the same script one command later, at JumpTextScript. The
+			## four commands after it are `opentext`, `repeattext -1, -1`,
+			## `waitbutton` and `closetext`, which is what _show_text spends.
+			_face_player()
 			return _show_text(bank, int(command["address"]), true)
 		Gen2WorldScript.REPEATTEXT:
 			if int(command["value"]) == 0xFF and int(command["value_2"]) == 0xFF:
@@ -2030,10 +2051,7 @@ func _execute_object_command(source_opcode: int, command: Dictionary) -> Diction
 			})
 			return _stage_movement_wait({"object_index": _last_talked_object_index})
 		0x6A:
-			if _last_talked_object_index >= 0:
-				_emit_object_event(&"object_face_player", {
-					"object_index": _last_talked_object_index,
-				})
+			_face_player()
 		0x6B:
 			var first_object_id: int = int(command.get("object_id", 0))
 			var first_object: int = _object_index_from_id(first_object_id)
@@ -2353,6 +2371,16 @@ func _stage_trainer_approach() -> void:
 		"distance": int(_request.get("distance", 0)),
 		"direction": _request.get("direction", Vector2i.ZERO),
 	})
+
+
+## `Script_faceplayer`, which turns the object the player is standing in front
+## of. Shared with `jumptextfaceplayer`, whose own script runs one before the
+## text.
+func _face_player() -> void:
+	if _last_talked_object_index >= 0:
+		_emit_object_event(&"object_face_player", {
+			"object_index": _last_talked_object_index,
+		})
 
 
 ## `FindThatSpecies`, and `CheckOwnMon`'s ID and OT test on top of it when

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2945,6 +2945,50 @@ func test_facing_interaction_commits_map_and_engine_flags_after_text() -> void:
 	assert_eq(restored.visible_objects().size(), 0)
 
 
+## `Script_faceplayer` turns the object the talk is with, and the turn has to
+## reach what is drawn on the frame it runs: the override alone leaves the
+## object standing the way its event placed it until some later reload.
+func test_faceplayer_turns_the_talked_object_toward_the_player() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6190"] = [Gen2WorldScript.FACEPLAYER, Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(6, 6))
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	var object: Gen2WorldObject = world.objects[0]
+	object.facing = Gen2WorldSprite.FACING_DOWN
+	world.current_map.events["objects"][0]["script"] = 0x6190
+	object.event_script = 0x6190
+
+	world.interact()
+	assert_eq(
+		(world.objects[0] as Gen2WorldObject).facing, Gen2WorldSprite.FACING_RIGHT,
+		"the object faces the player it was talked to by"
+	)
+
+
+## `Script_jumptextfaceplayer` jumps to JumpTextFacePlayerScript, whose first
+## command is `faceplayer`; `jumptext` and `farjumptext` enter the same script
+## one command later and turn nothing. Most NPCs in either pin are the first.
+func test_jumptextfaceplayer_turns_the_object_and_jumptext_does_not() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:61A0"] = [Gen2WorldScript.JUMPTEXTFACEPLAYER, 0x00, 0x70]
+	scripts["48:61B0"] = [Gen2WorldScript.JUMPTEXT, 0x00, 0x70]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	for row: Array in [[0x61A0, Gen2WorldSprite.FACING_RIGHT], [0x61B0, Gen2WorldSprite.FACING_DOWN]]:
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(6, 6))
+		world.player_facing = Gen2WorldSprite.FACING_LEFT
+		var object: Gen2WorldObject = world.objects[0]
+		object.facing = Gen2WorldSprite.FACING_DOWN
+		world.current_map.events["objects"][0]["script"] = int(row[0])
+		object.event_script = int(row[0])
+
+		var waiting: Array = world.interact()
+		assert_eq(waiting[0]["event"]["text"], "AB")
+		assert_eq((world.objects[0] as Gen2WorldObject).facing, int(row[1]))
+
+
 func test_background_events_honor_source_direction_and_conditional_pointer_records() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6170"] = [Gen2WorldScript.SETEVENT, 11, 0, Gen2WorldScript.END]

--- a/tools/trace_world_script.gd
+++ b/tools/trace_world_script.gd
@@ -1,0 +1,193 @@
+extends SceneTree
+
+## Every script command a walked conversation runs on the real world screen, in
+## the order it ran and with the `bank:address` the cartridge would hold in
+## wScriptBank:wScriptPos for it.
+##
+##   Godot --headless --path . -s res://tools/trace_world_script.gd -- \
+##       <game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>
+##
+## The port half of `.claude/oracle/overworld/trace_script.py`, which prints the
+## same artefact off a real cartridge. The line is `frame bank:addr opcode name`,
+## so the two command orders diff directly and a branch taken on the wrong side
+## of a flag shows up as the first differing address rather than as a wrong box
+## on a screenshot.
+##
+## The walk list is the steps taken before A is pressed, so a run reaches the
+## object it is about to talk to. A count of zero is a turn on the spot, which
+## is what a press into the object being talked to does. A is then pressed every
+## fourteenth frame, the cadence the cartridge trace mashes at, until the one
+## conversation it started has ended.
+
+## The cartridge trace's own pace: slow enough that a box waiting for a press is
+## not pressed twice.
+const PRESS_EVERY: int = 14
+## A scratch root, so a run cannot reach the owner's own saves: the world is
+## given a save because half the script commands read one, VAR_BOXSPACE and
+## VAR_PARTYCOUNT among them, and a world with none fails the command rather
+## than inventing an empty party.
+const SAVE_ROOT: String = "user://trace_world_script_slots"
+## Frames with no script running before a run is called finished.
+const IDLE_FRAMES: int = 90
+
+
+## The runner being drained, held across the frame it finishes on.
+var _runner: Gen2WorldScriptRunner = null
+var _seen: int = 0
+## Set once a conversation has run and ended. One talk is the artefact, and a
+## press into the object it was with starts the same one over.
+var _finished: bool = false
+
+
+func _initialize() -> void:
+	_run.call_deferred()
+
+
+func _run() -> void:
+	await process_frame
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 8:
+		push_error("usage: <game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>")
+		quit(2)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("no imported cache for %s" % args[0])
+		quit(2)
+		return
+
+	DirAccess.make_dir_recursive_absolute(SAVE_ROOT)
+	Gen2SaveStore.use_root(SAVE_ROOT)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if save == null:
+		push_error("no development save")
+		quit(2)
+		return
+	save.world = null
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	screen.set_data(data)
+	screen.set_save(save)
+	screen.map_group = int(args[1])
+	screen.map_number = int(args[2])
+	screen.start_cell = Vector2i(int(args[3]), int(args[4]))
+	screen.process_mode = Node.PROCESS_MODE_DISABLED
+	root.add_child(screen)
+	await process_frame
+	if screen._world == null:
+		push_error("the world did not open: %s" % screen._caption.text)
+		quit(2)
+		return
+	screen.set_process(false)
+
+	Gen2WorldScriptRunner.trace_commands = true
+	var lines: PackedStringArray = PackedStringArray(["# frame bank:addr opcode name"])
+	var frame: int = 0
+
+	for step: String in args[5].split(",", false):
+		var parts: PackedStringArray = step.split(":")
+		var button: int = _button_for(parts[0])
+		if button == Gen2Button.NONE:
+			push_error("a walk step is <up|down|left|right>:<count>")
+			quit(2)
+			return
+		var cells: int = int(parts[1]) if parts.size() > 1 else 1
+		if cells == 0:
+			var turns: int = 0
+			while turns < 16 and screen._world.player_facing != _facing_for(button):
+				screen.press_button(button)
+				screen.advance_frame()
+				_collect(screen, lines, frame)
+				frame += 1
+				turns += 1
+			continue
+		for cell: int in cells:
+			var before: Vector2i = screen._world.player_cell
+			var spent: int = 0
+			while spent < 48 and screen._world.player_cell == before:
+				screen.press_button(button)
+				screen.advance_frame()
+				_collect(screen, lines, frame)
+				frame += 1
+				spent += 1
+			## The step is still being drawn when the cell commits, and a button
+			## that arrives inside one is refused, so the next step or the turn
+			## after it would be dropped.
+			while screen._world.player_step_in_progress():
+				screen.advance_frame()
+				_collect(screen, lines, frame)
+				frame += 1
+
+	print("talking from %s facing %d" % [screen._world.player_cell, screen._world.player_facing])
+	var idle: int = 0
+	var limit: int = maxi(1, int(args[6]))
+	while frame < limit:
+		if frame % PRESS_EVERY == 0:
+			screen.press_button(Gen2Button.A)
+		screen.advance_frame()
+		_collect(screen, lines, frame)
+		frame += 1
+		if _finished:
+			break
+		if screen._world._active_script == null:
+			idle += 1
+			if idle > IDLE_FRAMES:
+				break
+		else:
+			idle = 0
+
+	Gen2WorldScriptRunner.trace_commands = false
+	FileAccess.open(args[7], FileAccess.WRITE).store_string("\n".join(lines) + "\n")
+	print("wrote %d commands to %s" % [lines.size() - 1, args[7]])
+	root.remove_child(screen)
+	screen.free()
+	quit(0)
+
+
+## Drains whatever the runner has executed since the last frame, and drains a
+## runner that finished inside the frame before letting go of it: the commands
+## after the last wait all run on one frame, and a sample that only ever looks
+## at the live runner loses every one of them.
+func _collect(screen: Gen2WorldScreen, lines: PackedStringArray, frame: int) -> void:
+	var runner: Gen2WorldScriptRunner = screen._world._active_script
+	if runner != _runner:
+		_drain(lines, frame)
+		if _runner != null:
+			_finished = true
+			return
+		_runner = runner
+		_seen = 0
+	_drain(lines, frame)
+
+
+func _drain(lines: PackedStringArray, frame: int) -> void:
+	if _runner == null:
+		return
+	var trace: Array[Dictionary] = _runner.command_trace
+	for index: int in range(_seen, trace.size()):
+		var command: Dictionary = trace[index]
+		lines.append("%d %02x:%04x %02x %s" % [
+			frame, int(command["bank"]), int(command["address"]),
+			int(command["opcode"]), String(command["name"]),
+		])
+	_seen = trace.size()
+
+
+## The facing a held direction settles on, which is what says a turn on the spot
+## has been taken.
+func _facing_for(button: int) -> int:
+	match button:
+		Gen2Button.UP: return Gen2WorldSprite.FACING_UP
+		Gen2Button.DOWN: return Gen2WorldSprite.FACING_DOWN
+		Gen2Button.LEFT: return Gen2WorldSprite.FACING_LEFT
+		Gen2Button.RIGHT: return Gen2WorldSprite.FACING_RIGHT
+	return Gen2WorldSprite.FACING_DOWN
+
+
+func _button_for(name: String) -> int:
+	match name.to_lower():
+		"up": return Gen2Button.UP
+		"down": return Gen2Button.DOWN
+		"left": return Gen2Button.LEFT
+		"right": return Gen2Button.RIGHT
+	return Gen2Button.NONE

--- a/tools/trace_world_script.gd.uid
+++ b/tools/trace_world_script.gd.uid
@@ -1,0 +1,1 @@
+uid://2yr3gvdb4c2y


### PR DESCRIPTION
Two defects in how a script turns the object the player is talking to. Both were
found by diffing the script commands one conversation runs against the same
conversation on a real cartridge, and both are classes rather than single cases.

`Script_jumptextfaceplayer` jumps to `JumpTextFacePlayerScript`. Its first
command is `faceplayer`. `jumptext` and `farjumptext` enter the same script one
command later, at `JumpTextScript`, and turn nothing. All three were spent here
as the text alone. So every object written as a bare `jumptextfaceplayer`, which
is 367 of them in the Crystal corpus, kept facing the way its event placed it.

`object_face_player` wrote the facing override but did not ask for the object
reload that reads it back. Its two siblings, `object_facing` and
`object_face_object`, both do. So an explicit `faceplayer` only reached the
screen if something else happened to reload the objects afterwards. That is the
other 370 sites.

`tools/trace_world_script.gd` is new: it prints `frame bank:addr opcode name` for
every command a walked conversation runs, read off the frame stack the script
runner already keeps. Two conversations match the cartridge command for command
now, Cherrygrove's whole guide-gent tour at 65 of 65 and Route 29's catching
tutorial at 12 of 12.

Unit tier 3035 passing, `validate.gd -- all` green, `replay_world.gd` 33 routes
0 failures, the three-profile story walk clean.