### PR TITLE
Run a move's effect list the way DoMove reads it

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -579,6 +579,14 @@ var _faint_charged: Dictionary = {}
 ## cartridge's `wCurDamage` is move-local, not a history.
 var _last_damage_taken: Dictionary = {PLAYER: {}, ENEMY: {}}
 
+## `DoMove`'s own artefact: every effect command executed, in the order the read
+## cycle reached it, skips and loop passes included. Collected only while
+## `trace_commands` is on, which `tools/trace_battle_commands.gd` turns on so a
+## fought turn can be diffed against `.claude/oracle/battle/trace_move_commands.py`'s
+## reading of the same one.
+static var trace_commands: bool = false
+var command_trace: Array[StringName] = []
+
 ## `wPlayerFutureSightCount/Damage` and the enemy pair. Keyed by the side that
 ## foresaw the attack, so switching either active Pokémon leaves it intact and
 ## the eventual target is whoever is opposite when the count reaches one.
@@ -814,6 +822,18 @@ func schedule_future_sight(side: int, damage: int) -> bool:
 		return false
 	_future_sight[side] = {"count": 4, "damage": clampi(damage, 0, 0xFFFF)}
 	return true
+
+
+## `BattleCommand_CheckFutureSight`'s own read: the count still standing, and on
+## the turn it is one, the stored word taken and the count cleared.
+func future_sight_count(side: int) -> int:
+	return int((_future_sight.get(side, {}) as Dictionary).get("count", 0))
+
+
+func take_future_sight_damage(side: int) -> int:
+	var pending: Dictionary = _future_sight[side]
+	pending["count"] = 0
+	return int(pending.get("damage", 0))
 
 
 ## A battle is lost when a whole party is down, not when the Pokémon that is out
@@ -1577,7 +1597,9 @@ func _report_unannounced_action_faints(events: Array, since: int) -> void:
 
 
 ## `HandleFutureSight`, player then enemy: the count is decremented before it is
-## tested, and the stored base damage takes its spread on impact.
+## tested, and the move is then run through `DoMove` like any other, so the
+## stored word takes its spread, its hit roll and its faint check inside the
+## effect list rather than beside it. `checkfuturesight` is what loads it.
 func _tick_future_sight(events: Array) -> void:
 	for side: int in [PLAYER, ENEMY]:
 		var pending: Dictionary = _future_sight[side]
@@ -1588,23 +1610,13 @@ func _tick_future_sight(events: Array) -> void:
 		pending["count"] = count
 		if count != 1:
 			continue
-		pending["count"] = 0
 		if mon(side).is_fainted() or mon(opponent_of(side)).is_fainted():
+			pending["count"] = 0
 			continue
 		events.append({"type": FUTURE_SIGHT_HIT, "side": side, "target": opponent_of(side)})
-		var move: Dictionary = data.move(Gen2MoveEffect.FUTURE_SIGHT_MOVE)
-		var turn: Gen2Turn = Gen2Turn.create(
-			self, side, -1, Gen2MoveEffect.FUTURE_SIGHT_MOVE, move, events
-		)
-		turn.damage = int(pending.get("damage", 0))
-		for command: StringName in [
-			Gen2EffectCommands.DAMAGE_VARIATION, Gen2EffectCommands.CHECK_HIT,
-			Gen2EffectCommands.MOVE_ANIM_NO_SUB, Gen2EffectCommands.APPLY_DAMAGE,
-			Gen2EffectCommands.CHECK_FAINT,
-		]:
-			if turn.ended:
-				break
-			Gen2EffectCommands.run(command, turn)
+		var number: int = Gen2MoveEffect.FUTURE_SIGHT_MOVE
+		var turn: Gen2Turn = Gen2Turn.create(self, side, -1, number, data.move(number), events)
+		run_move_effect(turn)
 
 
 ## `wPlayerIsSwitching` and `wEnemyIsSwitching`, zeroed each turn the way
@@ -2567,18 +2579,45 @@ func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 	# which is the cartridge's arrangement: every move goes through it, so no
 	# sequence has to remember to include it.
 	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
-	_run_move_effect(turn)
+	run_move_effect(turn)
 
 
+## The command interpreter: `DoMove`'s own read cycle over the list an effect
+## byte picks, with `SkipToBattleCommand` and `endloop`'s rewind to `critical`.
+##
 ## `ResetTurn`, used by Metronome, Mirror Move and Sleep Talk: the called move
 ## replaces the working one and starts its list from the beginning, without the
 ## once-per-action status gate. A fresh [Gen2Turn] is that clean move-struct copy,
 ## keeping the acting side and the one event stream.
-func _run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
-	for command: StringName in Gen2MoveEffect.sequence_for(turn.effect()):
+func run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
+	var sequence: Array = Gen2MoveEffect.sequence_for(turn.effect())
+	var counter: int = 0
+	while counter < sequence.size():
 		if turn.ended:
 			return
+		var command: StringName = sequence[counter]
+		counter += 1
+		# `SkipToBattleCommand` walks the pointer past the byte it matched, so
+		# the command it was sent to find is not run either.
+		if turn.skip_to != &"":
+			if command == turn.skip_to:
+				turn.skip_to = &""
+			continue
+		if trace_commands:
+			command_trace.append(command)
 		Gen2EffectCommands.run(command, turn)
+		if turn.ended:
+			return
+		if turn.loop_back:
+			# `.loop_back_to_critical` scans down for `critical` and resumes on
+			# it, not behind it.
+			turn.loop_back = false
+			var back: int = sequence.rfind(Gen2EffectCommands.CRITICAL, counter - 1)
+			if back < 0:
+				push_error("a looping effect has no critical to return to")
+				return
+			counter = back
+			continue
 		if turn.called_move_number == 0:
 			continue
 		if depth >= 16:
@@ -2597,7 +2636,7 @@ func _run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
 			self, turn.side, -1, number, called_move, turn.events
 		)
 		called_turn.called = true
-		_run_move_effect(called_turn, depth + 1)
+		run_move_effect(called_turn, depth + 1)
 		return
 
 

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -214,13 +214,6 @@ const CONFUSE_TARGET: StringName = &"confusetarget"
 ## Dream Eater behind its own rule inside [constant CHECK_HIT].
 const DRAIN_TARGET: StringName = &"draintarget"
 
-## Two to five hits for [constant Gen2MoveEffect.MULTI_HIT], exactly two for
-## [constant Gen2MoveEffect.DOUBLE_HIT] and [constant Gen2MoveEffect.TWINEEDLE]:
-## one command repeating the roll and the hit rather than a runner-repeated
-## sequence, as [constant ALL_STATS_UP] repeats a stage change five times in one
-## command.
-const MULTI_HIT: StringName = &"multihit"
-
 ## Overwrites what [constant DAMAGE_CALC] worked out with the number
 ## [constant Gen2MoveEffect.SUPER_FANG], [constant Gen2MoveEffect.STATIC_DAMAGE],
 ## [constant Gen2MoveEffect.LEVEL_DAMAGE] and [constant Gen2MoveEffect.PSYWAVE]
@@ -236,18 +229,42 @@ const OHKO: StringName = &"ohko"
 ## list rather than anything a target-facing command touches.
 const RECHARGE: StringName = &"recharge"
 
-## A two-turn move's charge. First run: lock the user in, announce, end the move.
-## Second: clear the lock and let the list run as an ordinary attack, which
-## [method Gen2Battle.move_for] makes the user's only option.
+## `BattleCommand_CheckCharge`, the first command of every two-turn list: on the
+## release turn it clears the lock and skips over [constant CHARGE], so the rest
+## of the list runs as an ordinary attack, which [method Gen2Battle.move_for]
+## makes the user's only option. On the charging turn it does nothing and the
+## list falls into `doturn` and [constant CHARGE].
 const CHARGE_MOVE: StringName = &"chargemove"
+
+## `BattleCommand_Charge`: the charging turn's own line, and the end of the move.
+## It stands behind `doturn` and in front of `usedmovetext`, so a charging turn
+## announces "made a whirlwind!" and never "used RAZOR WIND!"; Skull Bash is the
+## one that carries on, skipping to [constant END_TURN] for the Defense raise
+## behind it.
+const CHARGE: StringName = &"charge"
+
+## `endturn_command`, which ends the read cycle the way [constant END_MOVE] does.
+## Only Skull Bash's list carries one, as the marker `charge` skips forward to.
+const END_TURN: StringName = &"endturn"
+
+## `BattleCommand_StartLoop` and `BattleCommand_EndLoop`: a multi-hit move is the
+## commands between them run again, `endloop` deciding the count on its first
+## pass and rewinding to [constant CRITICAL] until it runs out.
+const START_LOOP: StringName = &"startloop"
+const END_LOOP: StringName = &"endloop"
 
 ## Rollout checks for a live chain, applies its power and advances the hit count;
 ## the first command resets a finished chain before PP and damage.
 const ROLLOUT_CHECK: StringName = &"rolloutcheck"
 const ROLLOUT_POWER: StringName = &"rolloutpower"
 
-## Starts or advances Thrash, Petal Dance and Outrage, and marks Defense Curl's
-## persistent substatus for Rollout.
+## `BattleCommand_CheckRampage`, the first command of Thrash, Petal Dance and
+## Outrage: it counts a live rampage down and, on the turn it runs out, clears
+## the lock and confuses the user unless its own Safeguard refuses.
+const CHECK_RAMPAGE: StringName = &"checkrampage"
+
+## Starts Thrash, Petal Dance and Outrage, and marks Defense Curl's persistent
+## substatus for Rollout.
 const RAMPAGE: StringName = &"rampage"
 const CURL: StringName = &"curl"
 
@@ -359,9 +376,10 @@ const THIEF: StringName = &"thief"
 ## Pursuit, which doubles the finished figure against a side that is leaving.
 const PURSUIT: StringName = &"pursuit"
 
-## Beat Up, whose own body is the `startloop`/`endloop` pair around one hit per
-## party member, as [constant MULTI_HIT]'s is around one hit per roll.
+## Beat Up: one pass of its loop, and the line behind the loop that says nothing
+## unless every member was refused.
 const BEAT_UP: StringName = &"beatup"
+const BEAT_UP_FAIL_TEXT: StringName = &"beatupfailtext"
 
 ## `BattleCommand_CheckSafeguard`, Safeguard's loud half: the four status moves
 ## carrying it end on `SafeguardProtectText`, while the six secondary effects
@@ -417,10 +435,13 @@ const CHARGE_EFFECTS: Array[int] = [
 const STAT_UP_ANIM: StringName = &"statupanim"
 const STAT_DOWN_ANIM: StringName = &"statdownanim"
 
-## The five effects `BattleCommand_MoveAnimNoSub` alternates `wBattleAnimParam`
-## for rather than clearing it. Conversion and Triple Kick are unwritten.
+## The four effects `BattleCommand_MoveAnimNoSub` alternates `wBattleAnimParam`
+## for rather than clearing it. Triple Kick is the fifth and is not one of them:
+## its `.triplekick` label is jumped to over the clear, so a kick keeps the param
+## `kickcounter` left and every kick carries the damage flash.
 const ALTERNATING_ANIM_EFFECTS: Array[int] = [
 	Gen2MoveEffect.MULTI_HIT, Gen2MoveEffect.DOUBLE_HIT, Gen2MoveEffect.TWINEEDLE,
+	Gen2MoveEffect.CONVERSION,
 ]
 
 ## Raises and lowers a stat by one stage or two, named as the cartridge names
@@ -681,8 +702,6 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_confuse_target(turn)
 		DRAIN_TARGET:
 			_drain_target(turn)
-		MULTI_HIT:
-			_multi_hit(turn)
 		FIXED_DAMAGE:
 			_fixed_damage(turn)
 		OHKO:
@@ -690,11 +709,21 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 		RECHARGE:
 			_recharge(turn)
 		CHARGE_MOVE:
-			_charge_move(turn)
+			_check_charge(turn)
+		CHARGE:
+			_charge(turn)
+		END_TURN:
+			turn.end()
+		START_LOOP:
+			turn.attacker().rollout_count = 0
+		END_LOOP:
+			_end_loop(turn)
 		ROLLOUT_CHECK:
 			_rollout_check(turn)
 		ROLLOUT_POWER:
 			_rollout_power(turn)
+		CHECK_RAMPAGE:
+			_check_rampage(turn)
 		RAMPAGE:
 			_rampage(turn)
 		CURL:
@@ -769,6 +798,8 @@ static func run(command: StringName, turn: Gen2Turn) -> void:
 			_pursuit(turn)
 		BEAT_UP:
 			_beat_up(turn)
+		BEAT_UP_FAIL_TEXT:
+			_beat_up_fail_text(turn)
 		CHECK_SAFEGUARD:
 			_check_safeguard(turn)
 		HEAL:
@@ -888,22 +919,42 @@ static func _rage_damage(turn: Gen2Turn) -> void:
 	turn.damage = mini(base * (turn.attacker().rage_count + 1), 0xFFFF)
 
 
-## Ordinary damage builds Rage in `_apply_damage`, where every damaging effect
-## passes. This command remains in source-shaped lists as that shared seam.
-static func _build_opponent_rage(_turn: Gen2Turn) -> void:
-	pass
+## `BattleCommand_BuildOpponentRage`: one count on the target's Rage per hit it
+## takes, and the line that says so. It stands behind `checkfaint`, which ends
+## the move when the target has fallen, so a Rage that faints does not build; a
+## substitute is not a gate, the doll spending the hit still counting.
+##
+## `inc a / ret z` is the saturation: 255 increments to 0 and is not stored.
+static func _build_opponent_rage(turn: Gen2Turn) -> void:
+	if turn.missed:
+		return
+	var defender: Gen2BattleMon = turn.defender()
+	if not Gen2Substatus.has(defender.substatus, Gen2Substatus.RAGE):
+		return
+	if defender.rage_count >= 0xFF:
+		return
+	defender.rage_count += 1
+	turn.emit(Gen2Battle.RAGE_BUILDING, {"target": turn.target})
 
 
 static func _check_future_sight(turn: Gen2Turn) -> void:
-	if turn.battle.future_sight_pending(turn.side):
-		turn.emit(Gen2Battle.MOVE_FAILED)
-		turn.end()
+	if turn.battle.future_sight_count(turn.side) != 1:
+		return
+	# The stored word is the damage, and the skip lands past `futuresight`, so
+	# the announcement, the PP and the formula are all skipped and only the
+	# spread, the roll and the hit are spent.
+	turn.damage = turn.battle.take_future_sight_damage(turn.side)
+	turn.skip_to = FUTURE_SIGHT
 
 
 ## Stores damage after DamageCalc and before DamageVariation, exactly where the
-## source copies `wCurDamage` into the side's delayed word.
+## source copies `wCurDamage` into the side's delayed word, and ends the move.
+##
+## `.failed` is a count still running: the move announces and then fails, which is
+## what a second Future Sight does.
 static func _future_sight(turn: Gen2Turn) -> void:
 	if not turn.battle.schedule_future_sight(turn.side, turn.damage):
+		turn.damage = 0
 		turn.emit(Gen2Battle.MOVE_FAILED)
 	else:
 		turn.emit(Gen2Battle.FUTURE_SIGHT_SET, {"target": turn.target})
@@ -1574,7 +1625,9 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		return
 
 	turn.dealt = defender.take_damage(turn.damage)
-	turn.emit(Gen2Battle.HIT, {
+	# `wCriticalHit` at 2 is the one-hit line rather than the critical one, which
+	# is the only thing that tells an OHKO's own hit apart from any other.
+	turn.emit(Gen2Battle.OHKO if turn.one_hit_ko else Gen2Battle.HIT, {
 		"target": turn.target,
 		"amount": turn.dealt,
 		"critical": turn.critical,
@@ -1582,11 +1635,6 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		"hp": defender.hp,
 		"max_hp": defender.max_hp(),
 	})
-	if not defender.is_fainted() \
-			and Gen2Substatus.has(defender.substatus, Gen2Substatus.RAGE) \
-			and defender.rage_count < 0xFF:
-		defender.rage_count += 1
-		turn.emit(Gen2Battle.RAGE_BUILDING, {"target": turn.target})
 	if braced:
 		turn.emit(Gen2Battle.ENDURED_HIT, {"target": turn.target})
 	if endured:
@@ -1729,7 +1777,7 @@ static func _recoil(turn: Gen2Turn) -> void:
 ## it is skipped; the attacker going down to recoil ends nothing, the cartridge
 ## testing only the opponent's HP. The commands behind it keep their own
 ## fainted-target check, since a list with no faint step can still reach one
-## through [constant MULTI_HIT].
+## through [constant BEAT_UP].
 static func _check_faint(turn: Gen2Turn) -> void:
 	_destiny_bond_takes_user(turn)
 	for side: int in [turn.target, turn.side]:
@@ -2116,64 +2164,6 @@ static func _drain_target(turn: Gen2Turn) -> void:
 	})
 
 
-## Two to five hits for [constant Gen2MoveEffect.MULTI_HIT], exactly two for
-## [constant Gen2MoveEffect.DOUBLE_HIT] and [constant Gen2MoveEffect.TWINEEDLE].
-## [constant CHECK_HIT] has already rolled the move's one accuracy check; the
-## first hit reuses [constant DAMAGE_CALC]'s numbers and every later one rerolls
-## the critical and the spread, as the cartridge's loop does. A faint ends the
-## move, which is why the "hit N times" summary needs every planned hit.
-static func _multi_hit(turn: Gen2Turn) -> void:
-	var attacker: Gen2BattleMon = turn.attacker()
-	var defender: Gen2BattleMon = turn.defender()
-	var hits: int = 2 if FIXED_TWO_HIT_EFFECTS.has(turn.effect()) else _roll_multi_hit_count(turn.rng())
-
-	var focus_energy: bool = Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY)
-	for hit: int in hits:
-		if hit > 0:
-			var result: Dictionary = Gen2Damage.calculate(
-				attacker, defender, turn.effective_move(), turn.rng(), focus_energy,
-				false, turn.battle.weather, turn.battle.screens[turn.target],
-				Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
-			)
-			turn.damage = int(result["damage"])
-			turn.critical = bool(result["critical"])
-			turn.effectiveness = int(result["effectiveness"])
-
-		# `lowersub` opens the source loop and `moveanimnosub` sits inside it,
-		# before `applydamage`, so every hit drops the doll and animates and only
-		# the last carries the flash. `endloop`'s `raisesub` is this command's tail.
-		_lower_sub(turn)
-		_multi_hit_anim(turn, hit == hits - 1)
-
-		# `applydamage` is inside the loop too, so each hit goes through all of it,
-		# Focus Band and Substitute included, which is why `DoSubstituteDamage`
-		# exempts this effect from stamping `EFFECT_NORMAL_HIT`.
-		_apply_damage(turn)
-
-		if defender.is_fainted():
-			_check_faint(turn)
-			turn.end()
-			return
-
-	# `BattleCommand_EndLoop` says how many hits landed, and the `raisesub`
-	# behind `endloop` follows that line rather than leading it.
-	turn.emit(Gen2Battle.HIT_TIMES, {"target": turn.target, "times": hits})
-	_raise_sub(turn)
-
-
-const FIXED_TWO_HIT_EFFECTS: Array = [Gen2MoveEffect.DOUBLE_HIT, Gen2MoveEffect.TWINEEDLE]
-
-
-## How many times a generic multi-hit move connects, by the cartridge's two-roll
-## algorithm: a first roll out of four keeps 0 or 1, or rolls again for 2 or 3, so
-## two and three hits come up three times as often as four and five.
-static func _roll_multi_hit_count(rng: RandomNumberGenerator) -> int:
-	var first: int = rng.randi_range(0, 3)
-	if first < 2:
-		return first + 2
-	return rng.randi_range(0, 3) + 2
-
-
 ## `BattleCommand_ConstantDamage`: the whole hit without the ordinary formula.
 ## [constant Gen2MoveEffect.LEVEL_DAMAGE] is the user's level,
 ## [constant Gen2MoveEffect.PSYWAVE] a roll of it,
@@ -2243,17 +2233,11 @@ static func _ohko(turn: Gen2Turn) -> void:
 		turn.end()
 		return
 
-	# `OHKOHit` is `ohko, moveanim, failuretext, applydamage`: this command owns
-	# the roll and the damage both, so the animation sits between them here.
-	_move_anim(turn)
-	turn.battle.record_damage_taken(
-		turn.target, turn.side, turn.move_number, turn.effect(), 0xFFFF
-	)
-	var dealt: int = defender.take_damage(defender.hp)
-	turn.emit(Gen2Battle.OHKO, {
-		"target": turn.target, "amount": dealt, "hp": defender.hp, "max_hp": defender.max_hp(),
-	})
-	_check_faint(turn)
+	# `ld a, $ff / ld [hli], a / ld [hl], a` over `wCurDamage`, and `wCriticalHit`
+	# marked 2, which is what `criticaltext` reads as the one-hit line. The
+	# animation, the damage and the faint are the list's own commands behind this.
+	turn.damage = 0xFFFF
+	turn.one_hit_ko = true
 
 
 ## Locks the user out of its next turn. The tail of Hyper Beam's own list,
@@ -2262,31 +2246,110 @@ static func _recharge(turn: Gen2Turn) -> void:
 	turn.attacker().substatus |= Gen2Substatus.RECHARGING
 
 
-## A two-turn move's charge, a list that ends early the first time: lock the user
-## in, announce, stop before damage. The release turn clears the lock and runs on
-## as an ordinary attack, [method Gen2Battle.move_for] forcing the charged move.
-static func _charge_move(turn: Gen2Turn) -> void:
+## `BattleCommand_CheckCharge`: the release turn clears the lock and skips over
+## [constant CHARGE], so the rest of the list is an ordinary attack. On the
+## charging turn it answers nothing and the list runs on into `doturn`.
+static func _check_charge(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
-	if Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING):
-		mon.substatus &= ~Gen2Substatus.CHARGING
-		mon.substatus &= ~(Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
-		mon.charged_move = 0
+	if not Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING):
 		return
+	mon.substatus &= ~Gen2Substatus.CHARGING
+	mon.substatus &= ~(Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
+	mon.charged_move = 0
+	turn.skip_to = CHARGE
 
-	if turn.skip_charge:
+
+## `BattleCommand_Charge`: the charging turn. It locks the user in, says its own
+## line and ends the move; Skull Bash carries on at [constant END_TURN], which is
+## where its Defense raise sits.
+##
+## A user that is asleep gets `PrintButItFailed` instead, which is Sleep Talk
+## reaching a two-turn move: the source spends `movedelay` and `raisesub` before
+## the line.
+static func _charge(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	if Gen2Status.is_asleep(mon.status):
+		_raise_sub(turn)
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		turn.end()
 		return
 
 	mon.substatus |= Gen2Substatus.CHARGING
 	mon.charged_move = turn.move_number
-	if turn.effect() == Gen2MoveEffect.FLY_OR_DIG:
-		if turn.move_number == Gen2MoveEffect.FLY_MOVE:
-			mon.substatus |= Gen2Substatus.FLYING
-		elif turn.move_number == Gen2MoveEffect.DIG_MOVE:
-			mon.substatus |= Gen2Substatus.UNDERGROUND
+	if turn.move_number == Gen2MoveEffect.FLY_MOVE:
+		mon.substatus |= Gen2Substatus.FLYING
+	elif turn.move_number == Gen2MoveEffect.DIG_MOVE:
+		mon.substatus |= Gen2Substatus.UNDERGROUND
 	## `.UsedText` picks its line by move number rather than by effect, so the
 	## move travels with the event and the screen owns the wording.
 	turn.emit(Gen2Battle.CHARGING_UP, {"move": turn.move_number})
+	if turn.effect() == Gen2MoveEffect.SKULL_BASH:
+		turn.skip_to = END_TURN
+		return
 	turn.end()
+
+
+## `BattleCommand_EndLoop`. Its first pass decides how many times the commands
+## behind it run and rewinds to `critical`; every later one counts down. The
+## count lives in the same byte Rollout's does, which is why `startloop` zeroes
+## it and why a Double Kick ends a Rollout chain.
+static func _end_loop(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.IN_LOOP):
+		mon.rollout_count -= 1
+		if mon.rollout_count > 0:
+			turn.loop_back = true
+			return
+		_finish_loop(turn)
+		return
+
+	mon.substatus |= Gen2Substatus.IN_LOOP
+	var remaining: int = 0
+	match turn.effect():
+		Gen2MoveEffect.TWINEEDLE, Gen2MoveEffect.DOUBLE_HIT:
+			remaining = 1
+		Gen2MoveEffect.BEAT_UP:
+			# `.check_ot_beat_up`: a wild Pokémon has no party at all, and one
+			# member is `.only_one_beatup`, which clears the flag, says the fail
+			# line and ends the move outright, so `kingsrock` never runs.
+			# `docs/bugs_and_glitches.md`'s entry, mirrored rather than fixed.
+			var size: int = 0
+			if turn.side == Gen2Battle.PLAYER or turn.battle.is_trainer_battle:
+				size = turn.battle.party(turn.side).size()
+			if size < 2:
+				mon.substatus &= ~Gen2Substatus.IN_LOOP
+				_beat_up_fail_text(turn)
+				turn.end()
+				return
+			remaining = size - 1
+		Gen2MoveEffect.TRIPLE_KICK:
+			# `and $3` resampled until it is not zero, then decremented: one kick
+			# twice as often as two or three.
+			var roll: int = 0
+			while roll == 0:
+				roll = turn.rng().randi_range(0, 3)
+			remaining = roll - 1
+			if remaining == 0:
+				turn.loop_hits = 1
+				_finish_loop(turn)
+				return
+		_:
+			# Two rolls of four, the second only when the first is 2 or 3, so two
+			# and three hits come up three times as often as four and five.
+			var first: int = turn.rng().randi_range(0, 3)
+			remaining = (first if first < 2 else turn.rng().randi_range(0, 3)) + 1
+	mon.rollout_count = remaining
+	turn.loop_hits = remaining + 1
+	turn.loop_back = true
+
+
+## `.done_loop`: the flag off, the count said, and the counter cleared. Beat Up
+## says nothing, its own list having spoken once per member.
+static func _finish_loop(turn: Gen2Turn) -> void:
+	turn.attacker().substatus &= ~Gen2Substatus.IN_LOOP
+	if turn.effect() != Gen2MoveEffect.BEAT_UP:
+		turn.emit(Gen2Battle.HIT_TIMES, {"target": turn.target, "times": turn.loop_hits})
+	turn.loop_hits = 0
 
 
 ## A new Rollout starts a fresh count. A continuation leaves the count alone so
@@ -2342,21 +2405,33 @@ const ROLLOUT_MAX_COUNT: int = 5
 ## Thrash, Petal Dance and Outrage share the rampage flag: the first turn rolls
 ## one or two more, each continuation spends one, and the user is confused after
 ## the last of them still lands.
+static func _check_rampage(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+	if not Gen2Substatus.has(mon.substatus, Gen2Substatus.RAMPAGING):
+		return
+	# `.continue_rampage` is reached whichever way this goes, and it skips past
+	# `rampage`: the lock and its count are set on the first turn only.
+	turn.skip_to = RAMPAGE
+	mon.rampage_turns -= 1
+	if mon.rampage_turns > 0:
+		return
+	mon.substatus &= ~Gen2Substatus.RAMPAGING
+	mon.rampage_move = 0
+	# The routine switches turn around its own `SafeCheckSafeguard` and back, so
+	# the Safeguard that matters is the rampaging Pokemon's own: it is the one
+	# about to be confused.
+	if _safeguard_refuses(turn, turn.side):
+		return
+	mon.confusion_turns = Gen2Substatus.roll_rampage_confusion(turn.rng())
+	mon.substatus |= Gen2Substatus.CONFUSED
+
+
+## `BattleCommand_Rampage`: the lock and its one or two more turns. A user that
+## is asleep sets nothing, which is Sleep Talk reaching Thrash.
 static func _rampage(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
-	if Gen2Substatus.has(mon.substatus, Gen2Substatus.RAMPAGING):
-		mon.rampage_turns -= 1
-		if mon.rampage_turns <= 0:
-			mon.substatus &= ~Gen2Substatus.RAMPAGING
-			mon.rampage_move = 0
-			# `BattleCommand_Rampage` switches turn around its own
-			# `SafeCheckSafeguard` and back, so the Safeguard that matters is the
-			# rampaging Pokémon's own: it is the one about to be confused.
-			if not _safeguard_refuses(turn, turn.side):
-				mon.confusion_turns = Gen2Substatus.roll_rampage_confusion(turn.rng())
-				mon.substatus |= Gen2Substatus.CONFUSED
+	if Gen2Status.is_asleep(mon.status):
 		return
-
 	mon.substatus |= Gen2Substatus.RAMPAGING
 	mon.rampage_move = turn.move_number
 	mon.rampage_turns = Gen2Substatus.roll_rampage_turns(turn.rng())
@@ -3191,22 +3266,18 @@ static func _pursuit(turn: Gen2Turn) -> void:
 	turn.damage = mini(turn.damage * 2, 0xFFFF)
 
 
-## `BattleCommand_BeatUp` with `startloop` and `endloop` around it: one hit per
-## party member, in order, each off that member's species base Attack and level.
-## The loop is inside this command as [method _multi_hit]'s is, `endloop` jumping
-## back to `critical` rather than the top of the list, so `checkhit` rolls once.
+## `BattleCommand_BeatUp`: one pass of the loop, which picks the party member
+## this hit is worked out from and loads the formula's two numbers off its base
+## stats. `damagecalc` never sees `damagestats`, so no item, screen, stage or
+## truncation touches either figure, and there is no `stab`, so the modifier
+## stays `EFFECTIVE` and no effectiveness is announced.
 ##
-## `damagecalc` is handed base stats and never sees `damagestats`, so no item,
-## screen, stage or truncation touches either figure, and there is no `stab`, so
-## no same-type bonus, weather or matchup: the modifier stays `EFFECTIVE` and
-## `supereffectivetext` says nothing.
-##
-## `.beatup_fail` skips a member with no health or any status and lets the loop
-## carry on, and `endloop` prints no "hit N times" line here (`.beat_up_2`).
+## A member with no health or any status takes `.beatup_fail`, which skips
+## forward to `buildopponentrage`: the hit is not spent and the loop carries on.
 static func _beat_up(turn: Gen2Turn) -> void:
+	turn.damage = 0
 	var battle: Gen2Battle = turn.battle
-	var party: Gen2Party = battle.party(turn.side)
-	var defender: Gen2BattleMon = turn.defender()
+	var mon: Gen2BattleMon = turn.attacker()
 
 	# `.wild`, which has no party to walk: `EnemyAttackDamage` gives the wild
 	# Pokémon one ordinary hit off its own real stats, and `endloop`'s
@@ -3214,64 +3285,40 @@ static func _beat_up(turn: Gen2Turn) -> void:
 	# ever set `wBeatUpHitAtLeastOnce`, so the hit lands and "But it failed!" is
 	# printed behind it anyway.
 	if turn.side == Gen2Battle.ENEMY and not battle.is_trainer_battle:
-		turn.emit(Gen2Battle.BEAT_UP_ATTACK, {"index": -1, "species": turn.attacker().species})
+		turn.emit(Gen2Battle.BEAT_UP_ATTACK, {"index": -1, "species": mon.species})
 		_damage_stats(turn)
-		_beat_up_hit(turn)
-		if defender.is_fainted():
-			_check_faint(turn)
-		else:
-			turn.emit(Gen2Battle.MOVE_FAILED)
-		turn.end()
 		return
 
-	var struck: bool = false
-	for index: int in party.size():
-		var member: Gen2BattleMon = party.at(index)
-		if not member.is_fainted() and member.status == Gen2Status.NONE:
-			struck = true
-			turn.emit(Gen2Battle.BEAT_UP_ATTACK, {
-				"index": index, "species": member.species,
-			})
-			turn.attack_stat = _base_stat(turn, member.species, "attack")
-			turn.defense_stat = _base_stat(turn, defender.species, "defense")
-			turn.level_override = member.level
-			turn.power_override = int(turn.move.get("power", 0))
-			_beat_up_hit(turn)
-			if defender.is_fainted():
-				_check_faint(turn)
-				turn.end()
-				return
+	var party: Gen2Party = battle.party(turn.side)
+	# `.next_mon` counts down from the party's own size, so the first pass is the
+	# member in slot 0 and the last is the member the count has reached 1 on.
+	var index: int = 0
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.IN_LOOP):
+		index = party.size() - mon.rollout_count
+	if index < 0 or index >= party.size():
+		turn.skip_to = BUILD_OPPONENT_RAGE
+		return
+	var member: Gen2BattleMon = party.at(index)
+	if member.is_fainted() or member.status != Gen2Status.NONE:
+		turn.skip_to = BUILD_OPPONENT_RAGE
+		return
 
-		# `.only_one_beatup`, reached on `cp 1`: the loop flag is cleared and the
-		# move ends outright, so `kingsrock` never runs.
-		# `docs/bugs_and_glitches.md`'s entry, mirrored rather than fixed.
-		if party.size() == 1:
-			if not struck:
-				turn.emit(Gen2Battle.MOVE_FAILED)
-			turn.end()
-			return
-
-	# `beatupfailtext`, which says nothing when any member landed a hit, and the
-	# `raisesub` the list puts behind it.
-	if not struck:
-		turn.emit(Gen2Battle.MOVE_FAILED)
-	_raise_sub(turn)
+	turn.beat_up_hit = true
+	turn.emit(Gen2Battle.BEAT_UP_ATTACK, {"index": index, "species": member.species})
+	turn.attack_stat = _base_stat(turn, member.species, "attack")
+	turn.defense_stat = _base_stat(turn, turn.defender().species, "defense")
+	turn.level_override = member.level
+	turn.power_override = int(turn.move.get("power", 0))
 
 
-## One pass of the loop: `critical`, `beatup`'s own numbers, `damagecalc`,
-## `damagevariation`, `moveanimnosub` and `applydamage`.
-##
-## `clearmissdamage` is structural, since the one `checkhit` sits outside the loop
-## and has already ended the move on a miss.
-static func _beat_up_hit(turn: Gen2Turn) -> void:
-	# `lowersub` is the first command of the loop body, so every member's hit
-	# drops the user's doll again.
-	_lower_sub(turn)
-	_critical(turn)
-	_damage_calc(turn)
-	_damage_variation(turn)
-	_move_anim(turn)
-	_apply_damage(turn)
+## `BattleCommand_BeatUpFailText`, which says nothing when any member landed a
+## hit. It stands behind `endloop` and in front of `kingsrock`, which is why a
+## failed Beat Up can still trigger a King's Rock flinch
+## (`docs/bugs_and_glitches.md`).
+static func _beat_up_fail_text(turn: Gen2Turn) -> void:
+	if turn.beat_up_hit:
+		return
+	turn.emit(Gen2Battle.MOVE_FAILED)
 
 
 ## A species' own base Attack or base Defense, which is what `GetBaseData` leaves
@@ -3393,7 +3440,7 @@ static func _thunder_accuracy(turn: Gen2Turn) -> void:
 ## branch first, so this answers only for the turn a charge would start.
 static func _skip_sun_charge(turn: Gen2Turn) -> void:
 	if turn.battle.weather == Gen2Weather.SUN:
-		turn.skip_charge = true
+		turn.skip_to = CHARGE
 
 
 ## `PlayFXAnimID`. Nothing is drawn here: the animation is written down as an
@@ -3441,11 +3488,24 @@ static func _play_opponent_battle_anim(turn: Gen2Turn, index: int) -> void:
 static func _move_anim(turn: Gen2Turn) -> void:
 	if turn.missed:
 		return
-	turn.battle.battle_anim_param = 0
-	_play_fx_anim(
-		turn, turn.move_number, _damage_after_anim(turn),
-		turn.move_number in [Gen2MoveEffect.FLY_MOVE, Gen2MoveEffect.DIG_MOVE]
-	)
+	var reappears: bool = turn.move_number in [Gen2MoveEffect.FLY_MOVE, Gen2MoveEffect.DIG_MOVE]
+	var effect: int = turn.effect()
+	if ALTERNATING_ANIM_EFFECTS.has(effect):
+		# `.alternate_anim`: the picture flips side per hit, and only the pass
+		# with one loop left carries the damage flash.
+		turn.battle.battle_anim_param = (turn.battle.battle_anim_param & 1) ^ 1
+		var last: bool = turn.attacker().rollout_count == 1
+		_play_fx_anim(
+			turn, turn.move_number,
+			_damage_after_anim(turn) if last else Gen2BattleAnimPlayer.AFTER_ANIM_NONE,
+			reappears
+		)
+		return
+	# `.triplekick` is jumped to over the clear, so a kick keeps the param
+	# `kickcounter` left and every kick flashes.
+	if effect != Gen2MoveEffect.TRIPLE_KICK:
+		turn.battle.battle_anim_param = 0
+	_play_fx_anim(turn, turn.move_number, _damage_after_anim(turn), reappears)
 
 
 ## `BattleCommand_LowerSub`: the user's doll dropped out of the way of whatever
@@ -3497,17 +3557,6 @@ static func _raise_sub(turn: Gen2Turn) -> void:
 		return
 	turn.battle.battle_anim_param = SUBSTITUTE_ANIM_RAISE
 	_play_fx_anim(turn, SUBSTITUTE_MOVE, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
-
-
-## `.alternate_anim`, taken by the five multi-hit effects instead of clearing the
-## param: the low bit flips and the damage flash is kept only for the hit the
-## rollout count says is the last, so a multi-hit flashes once.
-static func _multi_hit_anim(turn: Gen2Turn, last_hit: bool) -> void:
-	turn.battle.battle_anim_param = (turn.battle.battle_anim_param & 1) ^ 1
-	_play_fx_anim(
-		turn, turn.move_number,
-		_damage_after_anim(turn) if last_hit else Gen2BattleAnimPlayer.AFTER_ANIM_NONE
-	)
 
 
 ## `ANIM_ENEMY_DAMAGE` on the player's turn, `ANIM_PLAYER_DAMAGE` on the

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -71,12 +71,10 @@ const SKETCH_MOVE: int = 166
 const CONVERSION_2_MOVE: int = 176
 const SLEEP_TALK_MOVE: int = 214
 
-## Two to five hits, the cartridge's own weighted roll
-## ([method Gen2EffectCommands._roll_multi_hit_count]); and exactly two, always,
-## for [constant DOUBLE_HIT]. Both point at the one command,
-## [constant Gen2EffectCommands.MULTI_HIT], which tells the two apart by
-## reading the effect byte back off the turn the same way the cartridge's own
-## loop does, rather than needing two commands that differ only in a number.
+## Two to five hits, the cartridge's own weighted roll; and exactly two, always,
+## for [constant DOUBLE_HIT]. Both run one list,
+## [constant MULTI_HIT_SEQUENCE], and `endloop` tells them apart by reading the
+## effect byte back off the turn.
 const MULTI_HIT: int = 29
 const DOUBLE_HIT: int = 44
 ## Twineedle: the same two hits as [constant DOUBLE_HIT], with a chance of
@@ -371,6 +369,7 @@ const NORMAL_HIT: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -380,8 +379,8 @@ const NORMAL_HIT: Array = [
 ## two-or-three-turn lock.
 const BIDE_SEQUENCE: Array = [
 	Gen2EffectCommands.STORE_ENERGY,
-	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.UNLEASH_ENERGY,
 	Gen2EffectCommands.RESET_TYPE_MATCHUP,
 	Gen2EffectCommands.CHECK_HIT,
@@ -400,6 +399,7 @@ const RAGE_SEQUENCE: Array = [
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.RAGE_DAMAGE,
 	Gen2EffectCommands.DAMAGE_VARIATION,
@@ -408,6 +408,7 @@ const RAGE_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
 	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -418,6 +419,12 @@ const FUTURE_SIGHT_SEQUENCE: Array = [
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.FUTURE_SIGHT,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -457,6 +464,7 @@ const COUNTER_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -468,6 +476,7 @@ const MIRROR_COAT_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -488,6 +497,7 @@ const SELFDESTRUCT_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -509,6 +519,7 @@ const RECOIL_HIT_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.RECOIL,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -590,8 +601,9 @@ const RECHARGE_HIT_SEQUENCE: Array = [
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
-	Gen2EffectCommands.CHECK_FAINT,
 	Gen2EffectCommands.RECHARGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -601,9 +613,10 @@ const RECHARGE_HIT_SEQUENCE: Array = [
 ## the second time, it clears the lock and everything after it is
 ## [constant NORMAL_HIT] again.
 const CHARGE_SEQUENCE: Array = [
-	Gen2EffectCommands.USED_MOVE_TEXT,
-	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
@@ -614,27 +627,55 @@ const CHARGE_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
+## Fly and Dig: [constant CHARGE_SEQUENCE] with the doll put back between the
+## animation and the damage, which is where `AppearUserLowerSub` brings the user
+## back down.
+const FLY_SEQUENCE: Array = [
+	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE,
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.CRITICAL,
+	Gen2EffectCommands.DAMAGE_STATS,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
+	Gen2EffectCommands.RAISE_SUB,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.KINGS_ROCK,
+	Gen2EffectCommands.END_MOVE,
+]
+
 
 ## Thrash, Petal Dance and Outrage use one shared rampage state. The first turn
 ## starts the state; later turns are forced through [method Gen2Battle.move_for]
 ## and this command counts them down. The cartridge does not clear the state on
 ## a miss, so the hit check is allowed to finish before the next turn's choice.
 const RAMPAGE_SEQUENCE: Array = [
-	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.CHECK_RAMPAGE,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.RAMPAGE,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.STAB,
 	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -644,18 +685,20 @@ const RAMPAGE_SEQUENCE: Array = [
 ## counts successful hits so the next call can select the right multiplier.
 const ROLLOUT_SEQUENCE: Array = [
 	Gen2EffectCommands.ROLLOUT_CHECK,
-	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.ROLLOUT_POWER,
 	Gen2EffectCommands.DAMAGE_VARIATION,
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -682,9 +725,10 @@ const DEFENSE_CURL_SEQUENCE: Array = [
 ## the same as no flinch at all, and nothing here should assume that stays true
 ## forever.
 const SKY_ATTACK_SEQUENCE: Array = [
-	Gen2EffectCommands.USED_MOVE_TEXT,
-	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
@@ -696,6 +740,7 @@ const SKY_ATTACK_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.FLINCH_TARGET,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
@@ -705,9 +750,10 @@ const SKY_ATTACK_SEQUENCE: Array = [
 ## behind the hit landing, which is the one thing that sets it apart from
 ## [constant CHARGE_SEQUENCE].
 const SKULL_BASH_SEQUENCE: Array = [
-	Gen2EffectCommands.USED_MOVE_TEXT,
-	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CHARGE,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
@@ -718,9 +764,11 @@ const SKULL_BASH_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.KINGS_ROCK,
+	Gen2EffectCommands.END_TURN,
 	Gen2EffectCommands.DEFENSE_UP,
 	Gen2EffectCommands.STAT_UP_MESSAGE,
-	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -807,6 +855,7 @@ const TRAP_TARGET_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.TRAP_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -942,6 +991,7 @@ const RAPID_SPIN_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CLEAR_HAZARDS,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1034,6 +1084,7 @@ const THIEF_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.THIEF,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1054,14 +1105,14 @@ const PURSUIT_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
-## Beat Up. The `startloop`/`endloop` pair is inside
-## [constant Gen2EffectCommands.BEAT_UP], as [constant Gen2EffectCommands.MULTI_HIT]
-## already holds its own, and `endloop` jumps back to `critical` rather than to
-## the top, so `checkhit` is outside the loop and rolls once for the whole move.
+## Beat Up: one pass of the loop per party member, `endloop` jumping back to
+## `critical` rather than to the top, so `checkhit` is outside the loop and rolls
+## once for the whole move.
 ##
 ## No `damagestats` and no `stab`: the command loads the formula's two stats
 ## itself, from base stats rather than from either Pokémon's real ones, and
@@ -1070,8 +1121,20 @@ const PURSUIT_SEQUENCE: Array = [
 const BEAT_UP_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.START_LOOP,
+	Gen2EffectCommands.LOWER_SUB,
 	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.BEAT_UP,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.END_LOOP,
+	Gen2EffectCommands.BEAT_UP_FAIL_TEXT,
+	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1094,6 +1157,7 @@ const THUNDER_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.PARALYZE_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1101,10 +1165,11 @@ const THUNDER_SEQUENCE: Array = [
 ## Solarbeam: [constant CHARGE_SEQUENCE] with the sun's own way out in front of
 ## the charge, exactly where `skipsuncharge` sits in front of `charge`.
 const SOLARBEAM_SEQUENCE: Array = [
-	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.CHARGE_MOVE,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.SKIP_SUN_CHARGE,
-	Gen2EffectCommands.CHARGE_MOVE,
+	Gen2EffectCommands.CHARGE,
+	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
@@ -1115,6 +1180,7 @@ const SOLARBEAM_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1129,41 +1195,56 @@ const MEAN_LOOK_SEQUENCE: Array = [
 	Gen2EffectCommands.END_MOVE,
 ]
 
-## [constant MULTI_HIT] and [constant DOUBLE_HIT]: the accuracy roll happens
-## once, the way the cartridge's own script checks it before the loop that
-## repeats the hit even starts, and everything from the critical roll onward
-## is [constant Gen2EffectCommands.MULTI_HIT]'s own job, hit by hit.
+## [constant MULTI_HIT] and [constant DOUBLE_HIT]. `startloop` and `endloop`
+## bracket the hit and `endloop` rewinds to `critical`, so the accuracy roll and
+## the doll are outside the loop and the damage is worked out again per hit.
+##
+## The count is rolled by `endloop` on its first pass, which is *behind* the
+## first hit's own spread: rolling it in front would take the same seed to a
+## different battle.
 const MULTI_HIT_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.START_LOOP,
+	Gen2EffectCommands.LOWER_SUB,
+	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.STAB,
 	Gen2EffectCommands.DAMAGE_VARIATION,
 	Gen2EffectCommands.CHECK_IMMUNE,
-	Gen2EffectCommands.CHECK_HIT,
-	Gen2EffectCommands.MULTI_HIT,
+	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.END_LOOP,
+	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
-## Twineedle: the same two hits, with the poison roll taken once right after
-## the accuracy check, in the same slot [method Gen2MoveEffect._secondary]
-## already puts a secondary effect's roll, and applied once at the very end,
-## after both hits, rather than after either one on its own.
+## Twineedle: the same loop with the poison roll taken once, in front of the
+## first hit, and the poison itself applied once behind both.
 const TWINEEDLE_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.START_LOOP,
+	Gen2EffectCommands.LOWER_SUB,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.EFFECT_CHANCE,
 	Gen2EffectCommands.CRITICAL,
 	Gen2EffectCommands.DAMAGE_STATS,
 	Gen2EffectCommands.DAMAGE_CALC,
 	Gen2EffectCommands.STAB,
 	Gen2EffectCommands.DAMAGE_VARIATION,
 	Gen2EffectCommands.CHECK_IMMUNE,
-	Gen2EffectCommands.CHECK_HIT,
-	Gen2EffectCommands.EFFECT_CHANCE,
-	Gen2EffectCommands.MULTI_HIT,
+	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.END_LOOP,
+	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.POISON_TARGET,
 	Gen2EffectCommands.END_MOVE,
@@ -1187,6 +1268,7 @@ const DRAIN_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.DRAIN_TARGET,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1208,6 +1290,7 @@ const DREAM_EATER_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.DRAIN_TARGET,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1229,6 +1312,7 @@ const FIXED_DAMAGE_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1240,8 +1324,11 @@ const OHKO_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
 	Gen2EffectCommands.STAB,
-	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.OHKO,
+	Gen2EffectCommands.MOVE_ANIM,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.END_MOVE,
 ]
 
@@ -1264,6 +1351,7 @@ const RETURN_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1282,6 +1370,7 @@ const FRUSTRATION_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1304,6 +1393,7 @@ const MAGNITUDE_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1324,6 +1414,7 @@ const HIDDEN_POWER_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1343,6 +1434,7 @@ const PRESENT_SEQUENCE: Array = [
 	Gen2EffectCommands.DAMAGE_VARIATION,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1359,6 +1451,7 @@ const REVERSAL_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1379,19 +1472,19 @@ const FURY_CUTTER_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
 
-## Triple Kick, which is a loop like the multi-hit moves and unlike them in
-## rolling its own accuracy per kick and multiplying each kick by which one it
-## is. [constant Gen2EffectCommands.TRIPLE_KICK] does the multiply and
-## [constant Gen2EffectCommands.KICK_COUNTER] walks the count on.
+## Triple Kick: the multi-hit loop with the power multiplied by which kick it is.
+## [constant Gen2EffectCommands.TRIPLE_KICK] does the multiply,
+## [constant Gen2EffectCommands.KICK_COUNTER] walks the count on inside the loop,
+## and `endloop` rolls one, two or three kicks rather than two to five.
 const TRIPLE_KICK_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
-	# `lowersub` opens the source's loop body and its `raisesub` sits behind
-	# `endloop`, which is where both land in a list run once per kick.
+	Gen2EffectCommands.START_LOOP,
 	Gen2EffectCommands.LOWER_SUB,
 	Gen2EffectCommands.CHECK_HIT,
 	Gen2EffectCommands.CRITICAL,
@@ -1400,10 +1493,13 @@ const TRIPLE_KICK_SEQUENCE: Array = [
 	Gen2EffectCommands.TRIPLE_KICK,
 	Gen2EffectCommands.STAB,
 	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.CHECK_IMMUNE,
 	Gen2EffectCommands.MOVE_ANIM_NO_SUB,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KICK_COUNTER,
+	Gen2EffectCommands.END_LOOP,
 	Gen2EffectCommands.RAISE_SUB,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
@@ -1425,6 +1521,7 @@ const FALSE_SWIPE_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1517,6 +1614,7 @@ const SNORE_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.FLINCH_TARGET,
 	Gen2EffectCommands.KINGS_ROCK,
 	Gen2EffectCommands.END_MOVE,
@@ -1538,7 +1636,7 @@ const TRI_ATTACK_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
-	Gen2EffectCommands.EFFECT_CHANCE,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.TRI_STATUS_CHANCE,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1560,12 +1658,13 @@ const FLAME_WHEEL_SEQUENCE: Array = [
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.DEFROST,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.BURN_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
 
-## Gust and Earthquake: [constant NORMAL_HIT] with the doubling behind the spread
-## and no King's Rock, which the two lists really do leave out.
+## Gust: [constant NORMAL_HIT] with the doubling behind the spread and no King's
+## Rock, which the list really does leave out.
 const DOUBLE_DAMAGE_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,
@@ -1580,8 +1679,32 @@ const DOUBLE_DAMAGE_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.END_MOVE,
 ]
+## Earthquake: Gust's list with an `effectchance` and nothing behind it. It rolls
+## against a chance byte of zero and can only fail, so the whole of what it does
+## is spend one number out of the generator, which is why the two lists are not
+## one here.
+const EARTHQUAKE_SEQUENCE: Array = [
+	Gen2EffectCommands.USED_MOVE_TEXT,
+	Gen2EffectCommands.DO_TURN,
+	Gen2EffectCommands.CRITICAL,
+	Gen2EffectCommands.DAMAGE_STATS,
+	Gen2EffectCommands.DAMAGE_CALC,
+	Gen2EffectCommands.STAB,
+	Gen2EffectCommands.DAMAGE_VARIATION,
+	Gen2EffectCommands.DOUBLE_DAMAGE,
+	Gen2EffectCommands.CHECK_IMMUNE,
+	Gen2EffectCommands.CHECK_HIT,
+	Gen2EffectCommands.EFFECT_CHANCE,
+	Gen2EffectCommands.MOVE_ANIM,
+	Gen2EffectCommands.APPLY_DAMAGE,
+	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+	Gen2EffectCommands.END_MOVE,
+]
+
 
 ## Twister and Stomp: the same list with the flinch chance both carry.
 const DOUBLE_DAMAGE_FLINCH_SEQUENCE: Array = [
@@ -1599,6 +1722,7 @@ const DOUBLE_DAMAGE_FLINCH_SEQUENCE: Array = [
 	Gen2EffectCommands.MOVE_ANIM,
 	Gen2EffectCommands.APPLY_DAMAGE,
 	Gen2EffectCommands.CHECK_FAINT,
+	Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	Gen2EffectCommands.FLINCH_TARGET,
 	Gen2EffectCommands.END_MOVE,
 ]
@@ -1645,6 +1769,7 @@ static func _secondary(trailing: Array) -> Array:
 		Gen2EffectCommands.MOVE_ANIM,
 		Gen2EffectCommands.APPLY_DAMAGE,
 		Gen2EffectCommands.CHECK_FAINT,
+		Gen2EffectCommands.BUILD_OPPONENT_RAGE,
 	] + trailing + [Gen2EffectCommands.END_MOVE]
 
 
@@ -1826,7 +1951,7 @@ static func _sequences() -> Dictionary:
 		RECHARGE_HIT: RECHARGE_HIT_SEQUENCE,
 		RAZOR_WIND: CHARGE_SEQUENCE,
 		SOLARBEAM: SOLARBEAM_SEQUENCE,
-		FLY_OR_DIG: CHARGE_SEQUENCE,
+		FLY_OR_DIG: FLY_SEQUENCE,
 		SKY_ATTACK: SKY_ATTACK_SEQUENCE,
 		SKULL_BASH: SKULL_BASH_SEQUENCE,
 		RAMPAGE: RAMPAGE_SEQUENCE,
@@ -1918,7 +2043,7 @@ static func _sequences() -> Dictionary:
 		FLAME_WHEEL: FLAME_WHEEL_SEQUENCE,
 		SACRED_FIRE: FLAME_WHEEL_SEQUENCE,
 		GUST: DOUBLE_DAMAGE_SEQUENCE,
-		EARTHQUAKE: DOUBLE_DAMAGE_SEQUENCE,
+		EARTHQUAKE: EARTHQUAKE_SEQUENCE,
 		TWISTER: DOUBLE_DAMAGE_FLINCH_SEQUENCE,
 		STOMP: DOUBLE_DAMAGE_FLINCH_SEQUENCE,
 		SWAGGER: SWAGGER_SEQUENCE,

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -68,6 +68,11 @@ const LOCK_ON: int = 1 << 25
 const BIDE: int = 1 << 26
 const RAGE: int = 1 << 27
 const TRANSFORMED: int = 1 << 28
+## `SUBSTATUS_IN_LOOP`, set by `endloop` on the pass that decides how many hits a
+## multi-hit move gets and cleared on the pass that runs out. A target that
+## faints mid-loop ends the move with it still set, which is the cartridge's own
+## arrangement and what `supereffectivelooptext` reads.
+const IN_LOOP: int = 1 << 29
 
 const NONE: int = 0
 

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -72,9 +72,6 @@ var bide_release: bool = false
 ## [method Gen2EffectCommands._thunder_accuracy] sets it.
 var accuracy: int = -1
 
-## Solarbeam in sun: [method Gen2EffectCommands._charge_move] locks nothing in.
-var skip_charge: bool = false
-
 ## A secondary effect's roll came up short. Not [member ended]: the damage
 ## stands and only what was behind the roll is skipped.
 var failed_chance: bool = false
@@ -92,6 +89,28 @@ var someone_is_rampaging: bool = false
 ## A drop blocked by Mist, which the fail-text step says differently from an
 ## "already at the bottom" one.
 var stat_mist_blocked: bool = false
+
+## `SkipToBattleCommand`: the command the runner walks forward to without running
+## anything, the named one included. Empty for the ordinary next step.
+var skip_to: StringName = &""
+
+## `BattleCommand_EndLoop`'s `.loop_back_to_critical`, which rewinds the script
+## pointer to the `critical` behind it. Consumed by [Gen2Battle] as soon as the
+## command returns.
+var loop_back: bool = false
+
+## `wCriticalHit` at 2, which `BattleCommand_OHKO` writes and `criticaltext`
+## reads: the hit says "It's a one-hit KO!" instead of "A critical hit!".
+var one_hit_ko: bool = false
+
+## `wBeatUpHitAtLeastOnce`, which is what `beatupfailtext` reads: a Beat Up whose
+## every member was fainted or statused says "But it failed!" and one that landed
+## anything says nothing.
+var beat_up_hit: bool = false
+
+## How many hits a multi-hit move has landed, which is the number its "hit N
+## times!" line prints. `wPlayerDamageTaken` holds it on the cartridge.
+var loop_hits: int = 0
 
 
 static func create(

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1183,16 +1183,19 @@ func test_a_two_turn_move_ignores_the_slot_it_is_asked_for_on_release() -> void:
 	assert_eq(int(_first(second_turn, Gen2Battle.USED_MOVE)["move"]), Fixture.SOLARBEAM)
 
 
-func test_skull_bashs_charge_raises_defense_only_once_it_lands() -> void:
+func test_skull_bashs_charge_raises_defense_on_the_turn_it_lowers_its_head() -> void:
+	# `BattleCommand_Charge` skips to `endturn` for Skull Bash alone, and the two
+	# commands behind that marker are `defenseup, statupmessage`. The release
+	# turn's `checkcharge` skips over `charge`, so it never reaches them.
 	var battle: Gen2Battle = _battle(
 		_mon(Fixture.PIKACHU, 50, [Fixture.SKULL_BASH]),
 		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	)
 	battle.take_turn(0, 0)
-	assert_eq(battle.player.stage("defense"), 0, "nothing moves on the charge turn")
+	assert_eq(battle.player.stage("defense"), 1, "the charge turn is what raises it")
 
 	battle.take_turn(0, 0)
-	assert_eq(battle.player.stage("defense"), 1)
+	assert_eq(battle.player.stage("defense"), 1, "and the landing turn does not raise it again")
 
 
 func test_toxic_takes_more_each_turn_than_an_ordinary_poison_would() -> void:

--- a/tests/unit/test_battle_animation_commands.gd
+++ b/tests/unit/test_battle_animation_commands.gd
@@ -55,10 +55,7 @@ func _run_move(battle: Gen2Battle, move_number: int, side: int = Gen2Battle.PLAY
 		battle, side, 0, move_number, _data.move(move_number), events
 	)
 	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
-	for command: StringName in Gen2MoveEffect.sequence_for(turn.effect()):
-		if turn.ended:
-			break
-		Gen2EffectCommands.run(command, turn)
+	battle.run_move_effect(turn)
 	return events
 
 

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -76,10 +76,7 @@ func _run_move(
 	)
 	turn.locked = locked
 	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
-	for command: StringName in Gen2MoveEffect.sequence_for(turn.effect()):
-		if turn.ended:
-			break
-		Gen2EffectCommands.run(command, turn)
+	battle.run_move_effect(turn)
 	return turn
 
 
@@ -90,10 +87,7 @@ func _run_enemy_move(battle: Gen2Battle, move_number: int) -> Gen2Turn:
 		battle, Gen2Battle.ENEMY, 0, move_number, _data.move(move_number), []
 	)
 	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
-	for command: StringName in Gen2MoveEffect.sequence_for(turn.effect()):
-		if turn.ended:
-			break
-		Gen2EffectCommands.run(command, turn)
+	battle.run_move_effect(turn)
 	return turn
 
 
@@ -566,7 +560,7 @@ func test_a_charge_move_ends_the_turn_before_the_damage_step() -> void:
 
 func test_charge_move_locks_the_user_in_and_says_so() -> void:
 	var turn: Gen2Turn = _turn(_battle(), Fixture.SOLARBEAM)
-	Gen2EffectCommands.run(Gen2EffectCommands.CHARGE_MOVE, turn)
+	Gen2EffectCommands.run(Gen2EffectCommands.CHARGE, turn)
 	var mon: Gen2BattleMon = turn.attacker()
 	assert_true(Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING))
 	assert_eq(mon.charged_move, Fixture.SOLARBEAM)
@@ -587,6 +581,7 @@ func test_charge_move_releases_on_the_second_call_and_lets_the_rest_run() -> voi
 	assert_false(turn.ended)
 	assert_false(Gen2Substatus.has(mon.substatus, Gen2Substatus.CHARGING))
 	assert_eq(mon.charged_move, 0)
+	assert_eq(turn.skip_to, Gen2EffectCommands.CHARGE, "the release turn skips the charge")
 
 
 func test_rollout_rampage_and_defense_curl_use_their_effect_sequences() -> void:
@@ -902,21 +897,19 @@ func test_psych_up_fails_when_the_target_has_nothing_to_copy() -> void:
 	assert_eq(turn.events.size(), 0)
 
 
-func test_multi_hit_and_double_hit_share_one_command() -> void:
+func test_multi_hit_and_double_hit_share_one_list() -> void:
 	var multi: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.MULTI_HIT)
 	var double_hit: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.DOUBLE_HIT)
 	assert_eq(multi, double_hit)
-	assert_true(multi.has(Gen2EffectCommands.MULTI_HIT))
-	assert_eq(
-		multi.find(Gen2EffectCommands.CHECK_HIT) + 1, multi.find(Gen2EffectCommands.MULTI_HIT),
-		"the accuracy roll happens once, right before the hits it covers"
+	assert_lt(
+		multi.find(Gen2EffectCommands.CHECK_HIT), multi.find(Gen2EffectCommands.CRITICAL),
+		"the accuracy roll is outside the loop `endloop` rewinds to `critical`"
 	)
 
 
 func test_double_hit_always_hits_exactly_twice() -> void:
-	var turn: Gen2Turn = _turn(_battle(), Fixture.DOUBLE_HIT_MOVE)
-	_run_damage_steps(turn)
-	Gen2EffectCommands.run(Gen2EffectCommands.MULTI_HIT, turn)
+	var battle: Gen2Battle = _battle()
+	var turn: Gen2Turn = _run_move(battle, Fixture.DOUBLE_HIT_MOVE)
 	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 2)
 	assert_eq(int(_first(turn.events, Gen2Battle.HIT_TIMES)["times"]), 2)
 
@@ -926,22 +919,18 @@ func test_multi_hit_lands_between_two_and_five_times() -> void:
 	# whatever one seed happens to land on.
 	for seed_value: int in range(1, 21):
 		_rng.seed = seed_value
-		var turn: Gen2Turn = _turn(_battle(), Fixture.MULTI_HIT_MOVE)
-		_run_damage_steps(turn)
-		Gen2EffectCommands.run(Gen2EffectCommands.MULTI_HIT, turn)
+		var turn: Gen2Turn = _run_move(_battle(), Fixture.MULTI_HIT_MOVE)
 		var hits: int = _of_type(turn.events, Gen2Battle.HIT).size()
 		assert_between(hits, 2, 5, "seed %d" % seed_value)
 		assert_eq(int(_first(turn.events, Gen2Battle.HIT_TIMES)["times"]), hits)
 
 
 func test_multi_hit_stops_and_says_nothing_once_the_target_is_down() -> void:
-	# The cartridge's own loop jumps straight past the "hit N times" line the
-	# moment a hit brings the target down, so no summary is the whole point.
+	# `checkfaint` ends the move inside the loop, so `endloop` never reaches the
+	# "hit N times" line: no summary is the whole point.
 	var battle: Gen2Battle = _battle()
 	battle.enemy.hp = 1
-	var turn: Gen2Turn = _turn(battle, Fixture.MULTI_HIT_MOVE)
-	_run_damage_steps(turn)
-	Gen2EffectCommands.run(Gen2EffectCommands.MULTI_HIT, turn)
+	var turn: Gen2Turn = _run_move(battle, Fixture.MULTI_HIT_MOVE)
 	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 1, "the one hit that finished it")
 	assert_eq(_first(turn.events, Gen2Battle.HIT_TIMES), {})
 	assert_true(turn.ended)
@@ -949,12 +938,7 @@ func test_multi_hit_stops_and_says_nothing_once_the_target_is_down() -> void:
 
 
 func test_twineedle_hits_twice_then_rolls_poison_once_for_both() -> void:
-	var turn: Gen2Turn = _turn(_battle(), Fixture.TWINEEDLE_MOVE)
-	_run_damage_steps(turn)
-	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_HIT, turn)
-	Gen2EffectCommands.run(Gen2EffectCommands.EFFECT_CHANCE, turn)
-	Gen2EffectCommands.run(Gen2EffectCommands.MULTI_HIT, turn)
-	Gen2EffectCommands.run(Gen2EffectCommands.POISON_TARGET, turn)
+	var turn: Gen2Turn = _run_move(_battle(), Fixture.TWINEEDLE_MOVE)
 	assert_eq(_of_type(turn.events, Gen2Battle.HIT).size(), 2)
 	assert_true(
 		Gen2Status.has(turn.defender().status, Gen2Status.POISON), "the 256-chance never fails"
@@ -1089,11 +1073,15 @@ func test_psywave_stays_inside_its_own_range() -> void:
 		assert_between(turn.damage, 1, upper - 1, "seed %d" % seed_value)
 
 
-func test_ohko_has_no_ordinary_hit_or_damage_steps() -> void:
+func test_ohko_rolls_its_own_accuracy_and_leaves_the_damage_to_applydamage() -> void:
+	# `OHKOHit` carries no `checkhit`: the command calls it itself, so the three
+	# moves are the one place a locked-on flying target is still out of reach.
+	# It carries no `damagestats` or `damagecalc` either, the damage being $FFFF.
 	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.OHKO)
 	assert_true(sequence.has(Gen2EffectCommands.OHKO))
 	assert_false(sequence.has(Gen2EffectCommands.CHECK_HIT))
-	assert_false(sequence.has(Gen2EffectCommands.APPLY_DAMAGE))
+	assert_false(sequence.has(Gen2EffectCommands.DAMAGE_CALC))
+	assert_true(sequence.has(Gen2EffectCommands.APPLY_DAMAGE))
 
 
 func test_ohko_fails_outright_against_a_higher_level_target() -> void:
@@ -1123,8 +1111,7 @@ func test_ohko_faints_the_target_outright_when_it_connects() -> void:
 	var battle: Gen2Battle = _battle()
 	battle.player.level = 100
 	battle.enemy.level = 5
-	var turn: Gen2Turn = _turn(battle, Fixture.OHKO_MOVE)
-	Gen2EffectCommands.run(Gen2EffectCommands.OHKO, turn)
+	var turn: Gen2Turn = _run_move(battle, Fixture.OHKO_MOVE)
 	assert_eq(battle.enemy.hp, 0)
 	assert_eq(int(_first(turn.events, Gen2Battle.OHKO)["amount"]), battle.enemy.max_hp())
 	assert_eq(_first(turn.events, Gen2Battle.FAINTED)["side"], Gen2Battle.ENEMY)
@@ -2261,6 +2248,67 @@ func test_triple_kick_is_three_kicks_each_worth_one_more() -> void:
 		assert_eq(turn.damage, one_kick * (kick + 1), "kick %d" % (kick + 1))
 		Gen2EffectCommands.run(Gen2EffectCommands.KICK_COUNTER, turn)
 	assert_eq(turn.battle.battle_anim_param, 3, "and the counter walked all three")
+
+
+func test_triple_kick_lands_one_two_or_three_times() -> void:
+	# `endloop` resamples `and $3` until it is not zero and decrements, so one
+	# kick comes up as often as two and three together.
+	var seen: Dictionary = {}
+	for seed_value: int in range(1, 41):
+		_rng.seed = seed_value
+		var battle: Gen2Battle = _battle()
+		battle.enemy.hp = 30000
+		var turn: Gen2Turn = _run_move(battle, Fixture.TRIPLE_KICK, false, {"accuracy": 255})
+		var kicks: int = _of_type(turn.events, Gen2Battle.HIT).size()
+		assert_between(kicks, 1, 3, "seed %d" % seed_value)
+		assert_eq(int(_first(turn.events, Gen2Battle.HIT_TIMES)["times"]), kicks)
+		seen[kicks] = true
+	assert_gt(seen.size(), 1, "forty seeds should not all give the same count")
+
+
+## `BattleCommand_Stab` is what writes the immunity and `checkimmune` is that
+## write split out, so it can never stand in front of the `stab` it reads. And a
+## list whose `stab` comes first has to check before `checkhit` does, since that
+## step reads the same flag: the other order says "it doesn't affect" twice.
+func test_every_list_checks_immunity_behind_the_stab_that_decides_it() -> void:
+	for effect: int in range(0, 157):
+		var sequence: Array = Gen2MoveEffect.sequence_for(effect)
+		var immune: int = sequence.find(Gen2EffectCommands.CHECK_IMMUNE)
+		if immune < 0:
+			continue
+		var stab: int = sequence.find(Gen2EffectCommands.STAB)
+		var hit: int = sequence.find(Gen2EffectCommands.CHECK_HIT)
+		assert_true(stab >= 0 and stab < immune, "effect %d checks immunity before stab" % effect)
+		assert_false(
+			hit >= 0 and stab < hit and hit < immune,
+			"effect %d rolls between stab and the immunity it wrote" % effect
+		)
+
+
+func test_a_charging_turn_says_its_own_line_and_not_the_ordinary_one() -> void:
+	# `charge` stands between `doturn` and `usedmovetext`, so a charging turn
+	# never reaches "used SOLARBEAM!"; the release turn skips `charge` and does.
+	var battle: Gen2Battle = _battle()
+	var charging: Gen2Turn = _run_move(battle, Fixture.SOLARBEAM)
+	assert_eq(_first(charging.events, Gen2Battle.USED_MOVE), {})
+	assert_eq(int(_first(charging.events, Gen2Battle.CHARGING_UP)["move"]), Fixture.SOLARBEAM)
+
+	var landing: Gen2Turn = _run_move(battle, Fixture.SOLARBEAM, true)
+	assert_eq(int(_first(landing.events, Gen2Battle.USED_MOVE)["move"]), Fixture.SOLARBEAM)
+	assert_eq(_first(landing.events, Gen2Battle.CHARGING_UP), {})
+
+
+func test_a_rampage_rolls_its_length_once_and_not_again_each_turn() -> void:
+	# `checkrampage`'s `.continue_rampage` skips past `rampage`, so the counter
+	# is set on the first turn alone and counts down from there.
+	var battle: Gen2Battle = _battle()
+	battle.enemy.hp = 30000
+	battle.player.moves = [Fixture.THRASH]
+	battle.player.pp = [20]
+	_run_move(battle, Fixture.THRASH, false, {"accuracy": 255})
+	var length: int = battle.player.rampage_turns
+	_run_move(battle, Fixture.THRASH, true, {"accuracy": 255})
+	assert_eq(battle.player.rampage_turns, length - 1)
 
 
 func test_false_swipe_leaves_the_target_standing_on_one() -> void:
@@ -4407,14 +4455,12 @@ func _commands_run(battle: Gen2Battle, move_number: int) -> Array:
 	var turn: Gen2Turn = Gen2Turn.create(
 		battle, Gen2Battle.PLAYER, 0, move_number, _data.move(move_number), []
 	)
-	var ran: Array = []
 	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
-	for command: StringName in Gen2MoveEffect.sequence_for(turn.effect()):
-		if turn.ended:
-			break
-		ran.append(command)
-		Gen2EffectCommands.run(command, turn)
-	return ran
+	Gen2Battle.trace_commands = true
+	battle.command_trace.clear()
+	battle.run_move_effect(turn)
+	Gen2Battle.trace_commands = false
+	return battle.command_trace.duplicate()
 
 
 func test_damage_taken_accumulates_and_saturates_like_the_shared_source_word() -> void:
@@ -4464,6 +4510,7 @@ func test_rage_builds_when_hit_and_multiplies_its_next_attack() -> void:
 	)
 	incoming.damage = 5
 	Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, incoming)
+	Gen2EffectCommands.run(Gen2EffectCommands.BUILD_OPPONENT_RAGE, incoming)
 	assert_eq(battle.player.rage_count, 1)
 	var scaled: Gen2Turn = _turn(battle, Fixture.RAGE)
 	scaled.damage = 7

--- a/tools/checks/move_effects.gd
+++ b/tools/checks/move_effects.gd
@@ -1,0 +1,241 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Every effect byte's command list against the pins' own `data/moves/effects.asm`.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- move_effects
+##
+## A move is a short program and [Gen2MoveEffect] is the whole table of them
+## transcribed by hand, so the comparable artefact is the command list itself:
+## the pin's `MoveEffectsPointers` in order, each label's commands resolved
+## through its fallthrough, against [method Gen2MoveEffect.sequence_for]. That
+## catches a step in the wrong place, which no unit test of one move can, and it
+## is the static half of the battle-command trace
+## `.claude/oracle/battle/trace_move_commands.py` runs against a real cartridge.
+##
+## `pokecrystal` and `pokegold` ship the same two files byte for byte, so the
+## corpus is one table read against all three caches.
+##
+## The checkouts are local-only, so a missing one skips rather than fails.
+
+const PINS: Dictionary = {
+	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",
+}
+
+## Cartridge commands this port spends inside another step, and the one it runs
+## in front of the list. A row here is a claim that the step still happens, only
+## not as a command of its own; anything not in it and not a name we use is an
+## unread step and fails.
+const FOLDED: Dictionary = {
+	# `CheckTurn` is called before `DoMove` and `checkobedience` is the first
+	# command of every list; both are the once-per-action gate `Gen2Battle._act`
+	# runs as `checkstatus` in front of the sequence.
+	&"checkturn": "",
+	&"checkobedience": "",
+	# Text and pacing. Every one of these prints what the step in front of it
+	# decided, and here that step emits its own event.
+	&"failuretext": "",
+	&"criticaltext": "",
+	&"supereffectivetext": "",
+	&"supereffectivelooptext": "",
+	# `checkhit` ends a missed move here, so the line `bidefailtext` would print
+	# is the one that step already emitted.
+	&"bidefailtext": "",
+	&"cleartext": "",
+	&"movedelay": "",
+	# `wCurDamage` is not carried across a miss here: a missed turn ends before
+	# anything reads it, so there is nothing to clear.
+	&"clearmissdamage": "",
+	# Renames, where the same step is named for what it does rather than for the
+	# register it writes.
+	&"constantdamage": "fixeddamage",
+	&"eatdream": "draintarget",
+	&"resetstats": "haze",
+	&"rechargenextturn": "recharge",
+	&"checkrollout": "rolloutcheck",
+	&"checkcharge": "chargemove",
+	&"poison": "poisontarget",
+	&"paralyze": "paralyzetarget",
+	&"confuse": "confusetarget",
+	&"raisesubnoanim": "raisesub",
+	&"healmorn": "timedheal",
+	&"healday": "timedheal",
+	&"healnite": "timedheal",
+	&"doubleflyingdamage": "doubledamage",
+	&"doubleundergrounddamage": "doubledamage",
+	&"doubleminimizedamage": "doubledamage",
+}
+
+## `toxictarget` is the second half of `BattleCommand_Poison`, which reads the
+## effect byte back to decide between a flat poison and a ramping one; the two
+## readings are two commands here and one there.
+##
+## `checkimmune` is this port's own, and the one command with no cartridge name:
+## `BattleCommand_Stab` writes `wAttackMissed` when the matchup is zero and the
+## later steps read it back, so the immunity is split out of `stab` here rather
+## than carried in a register. It is dropped from our side before the lists are
+## compared.
+const OURS_ONLY: Array[String] = ["checkimmune"]
+
+## Ours named for what it does where the pin names the register it writes.
+const RENAMED: Dictionary = {&"toxictarget": "poisontarget"}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	var root: String = _reference_root()
+	var compared: int = 0
+	for game_id: StringName in _r.GAME_IDS:
+		var pin: String = root.path_join(String(PINS[game_id]))
+		if not DirAccess.dir_exists_absolute(pin):
+			print("%s is not checked out, so nothing was compared." % pin.get_file())
+			continue
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		compared += _compare(pin, data)
+		_r.game_id = &""
+	if compared == 0:
+		print("no pin was checked out; move_effects compared nothing.")
+
+
+func _compare(pin: String, data: GameData) -> int:
+	var lists: Array = _lists(pin)
+	if lists.is_empty():
+		_r.fail("%s carries no move effect table." % pin.get_file())
+		return 0
+	var carried: Dictionary = _effects_in_use(data)
+	var mismatched: int = 0
+	## Effect bytes with a list of their own that no move in the table carries,
+	## so nothing in the game can run one. Named rather than counted: the pair is
+	## `DefrostOpponent` and `FakeOut`, and a third appearing means a move lost
+	## its effect byte on import.
+	var unused: PackedStringArray = []
+	for effect: int in lists.size():
+		var row: Dictionary = lists[effect]
+		var want: PackedStringArray = row["commands"]
+		var have: PackedStringArray = PackedStringArray()
+		for command: StringName in Gen2MoveEffect.sequence_for(effect):
+			if OURS_ONLY.has(String(command)):
+				continue
+			have.append(String(RENAMED.get(command, command)))
+		if want == have:
+			continue
+		if not carried.has(effect):
+			unused.append("%d (%s)" % [effect, row["label"]])
+			continue
+		mismatched += 1
+		_r.fail("effect %d (%s)\n      pin: %s\n      ours: %s" % [
+			effect, row["label"], " ".join(want), " ".join(have),
+		])
+	_r.check(
+		unused.size() == 2,
+		"%d effect lists are carried by no move, not 2: %s" % [unused.size(), " ".join(unused)]
+	)
+	_r.note("%d effect lists, %d differ; %s are carried by no move." % [
+		lists.size(), mismatched, " ".join(unused),
+	])
+	return lists.size()
+
+
+## Every effect byte at least one move in the cache carries. An effect no move
+## names cannot be reached in play, so a list that differs there is a gap rather
+## than a defect and is counted instead of failed.
+func _effects_in_use(data: GameData) -> Dictionary:
+	var out: Dictionary = {}
+	for number: int in range(1, 252):
+		var move: Dictionary = data.move(number)
+		if move.is_empty():
+			continue
+		out[int(move.get("effect", 0))] = true
+	return out
+
+
+## `MoveEffectsPointers` in order, each label's commands resolved through the
+## fallthrough a list without an `endmove` of its own takes.
+func _lists(pin: String) -> Array:
+	var commands: Dictionary = _command_names(pin)
+	if commands.is_empty():
+		return []
+	var order: PackedStringArray = []
+	var bodies: Dictionary = {}
+	var label: String = ""
+	for line: String in _lines(pin.path_join("data/moves/effects.asm")):
+		if line.ends_with(":"):
+			label = line.trim_suffix(":")
+			order.append(label)
+			bodies[label] = PackedStringArray()
+			continue
+		var word: String = line.split(" ")[0]
+		if commands.has(word) and label != "":
+			bodies[label].append(word)
+	# A label with no `endmove` of its own runs on into the next one, and an
+	# empty label is that list under a second name.
+	for index: int in range(order.size() - 1, -1, -1):
+		var body: PackedStringArray = bodies[order[index]]
+		if body.is_empty() or body[body.size() - 1] != "endmove":
+			if index + 1 < order.size():
+				body.append_array(bodies[order[index + 1]])
+				bodies[order[index]] = body
+	var out: Array = []
+	for line: String in _lines(pin.path_join("data/moves/effects_pointers.asm")):
+		if not line.begins_with("dw "):
+			continue
+		var target: String = line.substr(3).strip_edges()
+		if not bodies.has(target):
+			_r.fail("effects_pointers names %s, which effects.asm does not define." % target)
+			return []
+		out.append({"label": target, "commands": _normalise(bodies[target])})
+	return out
+
+
+## The pin's list as the names this port uses, with the steps it spends inside
+## another one dropped.
+func _normalise(body: PackedStringArray) -> PackedStringArray:
+	var out: PackedStringArray = []
+	for word: String in body:
+		var name: String = word
+		if FOLDED.has(StringName(word)):
+			name = String(FOLDED[StringName(word)])
+		if name == "":
+			continue
+		out.append(name)
+	return out
+
+
+## `macros/scripts/battle_commands.asm`, which is what tells a command apart from
+## a label or a directive in the effect table.
+func _command_names(pin: String) -> Dictionary:
+	var out: Dictionary = {}
+	for line: String in _lines(pin.path_join("macros/scripts/battle_commands.asm")):
+		if line.begins_with("command "):
+			out[line.substr(8).strip_edges()] = true
+	return out
+
+
+func _lines(path: String) -> PackedStringArray:
+	var out: PackedStringArray = []
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return out
+	while not file.eof_reached():
+		var line: String = file.get_line()
+		var comment: int = line.find(";")
+		if comment >= 0:
+			line = line.substr(0, comment)
+		line = line.strip_edges()
+		if line != "":
+			out.append(line)
+	return out
+
+
+## `.references/` by default, the same root `tools/fetch_reference_sources.sh`
+## and `docs/REFERENCES.md` use.
+func _reference_root() -> String:
+	var override: String = OS.get_environment("GEN2_REFERENCE_ROOT")
+	if override != "":
+		return override
+	return ProjectSettings.globalize_path("res://").path_join(".references")

--- a/tools/checks/move_effects.gd.uid
+++ b/tools/checks/move_effects.gd.uid
@@ -1,0 +1,1 @@
+uid://dds2wu8qvlcte

--- a/tools/trace_battle_commands.gd
+++ b/tools/trace_battle_commands.gd
@@ -1,0 +1,69 @@
+extends SceneTree
+
+## Every effect command one turn of a battle runs here, in the same shape
+## `.claude/oracle/battle/trace_move_commands.py` prints off a real cartridge.
+##
+##   Godot --headless --path . -s res://tools/trace_battle_commands.gd -- \
+##       <game> <out.txt> <player_move> <enemy_move>
+##
+## It fights until one side is down, so the artefact is a whole wild battle
+## rather than one turn.
+##
+## `DoMove`'s read cycle is [method Gen2Battle.run_move_effect] and its artefact
+## is [member Gen2Battle.command_trace], so the two files diff line for line and
+## a step in the wrong place is the first difference rather than a wrong number
+## on a screenshot. The opcode is the pin's own
+## `macros/scripts/battle_commands.asm` index, which this side does not carry, so
+## it is printed as `--` and the name is what a diff reads.
+
+## The matchup `.claude/oracle/battle/states/in_wild` stands in: a level five
+## Cyndaquil against the level two Rattata that state walked into. The DVs and
+## the generator are this side's own, so the two fights are the same shape and
+## not the same numbers.
+const PLAYER_SPECIES: int = 155
+const PLAYER_LEVEL: int = 5
+const ENEMY_SPECIES: int = 19
+const ENEMY_LEVEL: int = 2
+
+## A runaway guard: no wild battle between two level-five Pokemon lasts anywhere
+## near this, and a driver that never reaches a faint should say so.
+const MAX_TURNS: int = 64
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 4:
+		push_error(
+			"Usage: trace_battle_commands.gd -- <game> <out.txt> <player_move> <enemy_move>"
+		)
+		quit(1)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 1
+	var battle: Gen2Battle = Gen2Battle.create(
+		data,
+		Gen2BattleMon.create(data, PLAYER_SPECIES, PLAYER_LEVEL, [int(args[2])]),
+		Gen2BattleMon.create(data, ENEMY_SPECIES, ENEMY_LEVEL, [int(args[3])]),
+		rng
+	)
+
+	Gen2Battle.trace_commands = true
+	battle.command_trace.clear()
+	for _turn: int in MAX_TURNS:
+		if battle.player.is_fainted() or battle.enemy.is_fainted():
+			break
+		battle.take_turn(0, 0)
+	Gen2Battle.trace_commands = false
+
+	var lines: PackedStringArray = ["# n opcode name"]
+	for index: int in battle.command_trace.size():
+		lines.append("%d -- %s" % [index, battle.command_trace[index]])
+	FileAccess.open(args[1], FileAccess.WRITE).store_string("\n".join(lines) + "\n")
+	print("wrote %d commands to %s" % [battle.command_trace.size(), args[1]])
+	quit(0)

--- a/tools/trace_battle_commands.gd.uid
+++ b/tools/trace_battle_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://cmxnvd2hgtcvo

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -42,7 +42,7 @@ const GROUPS: Dictionary = {
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
-		&"card_flip",
+		&"card_flip", &"move_effects",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
A move is a short program. The effect table is that list of programs, transcribed by hand, so the list itself is the thing to check.

`tools/checks/move_effects.gd` reads `MoveEffectsPointers` out of the disassembly in order, resolves each label's fallthrough, and diffs all 157 lists against `Gen2MoveEffect` on all three cartridges. Seventy of them differed.

The runner is now `DoMove`'s own read cycle: a pointer into the list, `SkipToBattleCommand`, and `endloop`'s rewind to `critical`. That closes the two classes of defect.

`buildopponentrage` was being spent inside `applydamage` on all fifty lists that carry one. `checkfaint` stands between the two and ends the move, so a Rage that was knocked out still built a count, and a substitute taking the hit stopped a count it should not have.

The five loop effects had no loop. Multi Hit, Double Hit, Twineedle, Triple Kick and Beat Up were folded into two commands. The fold rolled the hit count in front of the first hit, where `endloop` rolls it behind, so the same seed took a different battle. Triple Kick never kicked more than once. Beat Up built no Rage.

Fourteen more, each a single command in the wrong place:

- A charging turn printed "used FLY!". `charge` stands between `doturn` and `usedmovetext`, so the cartridge prints its own line and no other.
- Skull Bash raised its Defense on the landing turn. `charge` skips to `endturn` for that move alone, and the raise belongs to the turn it lowers its head.
- Future Sight's hit ran a hand-built list beside the interpreter. `HandleFutureSight` calls `DoMove` on the move itself.
- `rampage` re-rolled its length every turn, and set the lock through Sleep Talk.
- `ohko` applied its own damage instead of leaving it to `applydamage`.
- Earthquake spends a roll of the generator that Gust does not.
- Bide, Rollout, Rampage, Hyper Beam, Rage, Tri Attack and Fly each had a step in the wrong slot.

All 157 lists now agree on all three cartridges.

Beside the sweep, `tools/trace_battle_commands.gd` prints every command a turn runs, in the same shape a real cartridge's own trace prints. A whole wild battle, first move to faint, agrees command for command.

Unit tier 3,035 tests green, scene tier 3,495, `validate.gd -- all` 66 topics, `replay_world.gd` 33 routes, and the three-profile story walk clean.